### PR TITLE
ci: add GitHub Actions for tests, lint, and migration checks

### DIFF
--- a/.github/workflows/check_migrations.yml
+++ b/.github/workflows/check_migrations.yml
@@ -1,0 +1,134 @@
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+name: Check Migrations
+
+on:
+  pull_request:
+    paths:
+      - 'db/migrations/**'
+
+jobs:
+  check-migrations:
+    name: Check Migrations
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Fetch base branch
+        run: |
+          BASE_REF="${{ github.base_ref || 'main' }}"
+          git fetch origin ${BASE_REF}:refs/remotes/origin/${BASE_REF}
+          echo "BASE_REF=${BASE_REF}" >> $GITHUB_ENV
+
+      - name: Check migration format and ordering
+        run: |
+          set -o pipefail
+
+          CHANGED_MIGRATIONS=$(git diff --diff-filter=A --name-only origin/${BASE_REF}...HEAD -- db/migrations/*.sql | sort)
+
+          if [ -z "$CHANGED_MIGRATIONS" ]; then
+            echo "No new migration files in this PR"
+            exit 0
+          fi
+
+          echo "New migration files:"
+          echo "$CHANGED_MIGRATIONS"
+
+          # Check 1: Filename format (sequential 4-digit prefix)
+          echo ""
+          echo "Checking filename format..."
+          FORMAT_VALID=true
+          for file in $CHANGED_MIGRATIONS; do
+            FILENAME=$(basename "$file")
+            if ! echo "$FILENAME" | grep -qE '^[0-9]{4}_.*\.(up|down)\.sql$'; then
+              echo "::error::Invalid migration filename: $file"
+              echo "  Expected format: NNNN_description.{up|down}.sql"
+              echo "  Example: 0003_add_feature.up.sql"
+              FORMAT_VALID=false
+            fi
+          done
+          if [ "$FORMAT_VALID" = false ]; then
+            exit 1
+          fi
+          echo "  All filenames match NNNN_description.{up|down}.sql"
+
+          # Check 2: Up/down pairs
+          echo ""
+          echo "Checking for up/down pairs..."
+          PREFIXES=$(echo "$CHANGED_MIGRATIONS" | sed -E 's/\.(up|down)\.sql$//' | sort -u)
+          for prefix in $PREFIXES; do
+            if ! echo "$CHANGED_MIGRATIONS" | grep -qF "${prefix}.up.sql"; then
+              echo "::error::Missing .up.sql for: ${prefix}"
+              exit 1
+            fi
+            if ! echo "$CHANGED_MIGRATIONS" | grep -qF "${prefix}.down.sql"; then
+              echo "::error::Missing .down.sql for: ${prefix}"
+              exit 1
+            fi
+          done
+          echo "  All migrations have both .up.sql and .down.sql"
+
+          # Check 3: Single migration per PR
+          echo ""
+          echo "Checking for single migration..."
+          UNIQUE_NUMBERS=$(echo "$CHANGED_MIGRATIONS" | xargs -n1 basename | grep -oE '^[0-9]{4}' | sort -u)
+          NUM_COUNT=$(echo "$UNIQUE_NUMBERS" | wc -l | tr -d ' ')
+          if [ "$NUM_COUNT" -gt 1 ]; then
+            echo "::error::Multiple migrations found ($NUM_COUNT different sequence numbers)"
+            echo "  Only one new migration per PR. Numbers found:"
+            echo "$UNIQUE_NUMBERS"
+            exit 1
+          fi
+          echo "  Single migration check passed"
+
+          # Check 4: New migration has the highest sequence number
+          echo ""
+          echo "Checking sequence ordering..."
+          NEW_NUM=$(echo "$UNIQUE_NUMBERS" | head -1)
+          ALL_MIGRATIONS=$(ls db/migrations/*.sql 2>/dev/null | sort || true)
+          FAILED=false
+          for file in $ALL_MIGRATIONS; do
+            if echo "$CHANGED_MIGRATIONS" | grep -q "$file"; then
+              continue
+            fi
+            EXISTING_NUM=$(basename "$file" | grep -oE '^[0-9]{4}' || true)
+            if [ -n "$EXISTING_NUM" ] && [ "$EXISTING_NUM" -ge "$NEW_NUM" ]; then
+              echo "::error::Existing migration has same or higher number:"
+              echo "  Existing: $file ($EXISTING_NUM)"
+              echo "  New:      $NEW_NUM"
+              FAILED=true
+            fi
+          done
+          if [ "$FAILED" = true ]; then
+            exit 1
+          fi
+          echo "  New migration ($NEW_NUM) has the highest sequence number"
+
+          # Check 5: Transaction wrapping (BEGIN/COMMIT)
+          echo ""
+          echo "Checking transaction wrapping..."
+          TX_VALID=true
+          for file in $CHANGED_MIGRATIONS; do
+            FILTERED=$(grep -v '^[[:space:]]*$' "$file" | grep -v '^[[:space:]]*--' || true)
+            FIRST_LINE=$(echo "$FILTERED" | head -n 1 | sed 's/--.*$//' | tr -d '[:space:]' | tr '[:lower:]' '[:upper:]')
+            LAST_LINE=$(echo "$FILTERED" | tail -n 1 | sed 's/--.*$//' | tr -d '[:space:]' | tr '[:lower:]' '[:upper:]')
+
+            if [ "$FIRST_LINE" != "BEGIN;" ]; then
+              echo "::error::Migration missing BEGIN; at start: $file"
+              TX_VALID=false
+            fi
+            if [ "$LAST_LINE" != "COMMIT;" ]; then
+              echo "::error::Migration missing COMMIT; at end: $file"
+              TX_VALID=false
+            fi
+          done
+          if [ "$TX_VALID" = false ]; then
+            exit 1
+          fi
+          echo "  All migrations wrapped in BEGIN/COMMIT"
+
+          echo ""
+          echo "All migration checks passed."

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,104 @@
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+name: Test
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:15-alpine
+        env:
+          POSTGRES_USER: router
+          POSTGRES_PASSWORD: router
+          POSTGRES_DB: router
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U router -d router"
+          --health-interval 1s
+          --health-timeout 3s
+          --health-retries 30
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache-dependency-path: go.sum
+
+      - name: Install golang-migrate
+        run: |
+          curl -L https://github.com/golang-migrate/migrate/releases/download/v4.17.1/migrate.linux-amd64.tar.gz \
+            | tar xvz
+          sudo mv migrate /usr/local/bin/migrate
+
+      - name: Install sqlc
+        run: |
+          curl -L https://downloads.sqlc.dev/sqlc_1.30.0_linux_amd64.tar.gz | tar xvz
+          sudo mv sqlc /usr/local/bin/sqlc
+
+      # The docker-compose stack pre-creates the router schema via an init
+      # script mounted into postgres. CI's service container has no such
+      # init hook, so we recreate that step explicitly here.
+      - name: Pre-create router schema
+        env:
+          PGPASSWORD: router
+        run: |
+          psql -h localhost -p 5432 -U router -d router \
+            -c "CREATE SCHEMA IF NOT EXISTS router;"
+
+      - name: Apply migrations
+        run: |
+          migrate -path ./db/migrations \
+            -database 'postgres://router:router@localhost:5432/router?sslmode=disable&search_path=router' \
+            up
+
+      # Round-trip catches reversible-migration regressions: a broken
+      # down.sql would silently rot until someone tries to roll back.
+      - name: Roll migrations down then back up
+        run: |
+          migrate -path ./db/migrations \
+            -database 'postgres://router:router@localhost:5432/router?sslmode=disable&search_path=router' \
+            down -all
+          migrate -path ./db/migrations \
+            -database 'postgres://router:router@localhost:5432/router?sslmode=disable&search_path=router' \
+            up
+
+      # Detects schema/query drift: if migrations or queries change
+      # without regenerating internal/sqlc/, this fails the build.
+      - name: Check sqlc generation is up to date
+        working-directory: db
+        run: |
+          sqlc generate
+          if ! git diff --quiet ../internal/sqlc/; then
+            echo "::error::sqlc generation is out of date. Run 'make generate' and commit."
+            git diff ../internal/sqlc/
+            exit 1
+          fi
+
+      - name: Check formatting
+        run: |
+          UNFORMATTED=$(gofmt -l .)
+          if [ -n "$UNFORMATTED" ]; then
+            echo "::error::Go files are not formatted. Run 'gofmt -w .' on:"
+            echo "$UNFORMATTED"
+            exit 1
+          fi
+
+      - name: Vet
+        run: go vet ./...
+
+      - name: Typecheck
+        run: go build -o /dev/null ./...
+
+      - name: Run tests
+        run: go test -count=1 ./...

--- a/cmd/router/main.go
+++ b/cmd/router/main.go
@@ -471,5 +471,3 @@ func envVarForProvider(provider string) string {
 		return "<unknown provider " + provider + ">"
 	}
 }
-
-

--- a/internal/auth/installation.go
+++ b/internal/auth/installation.go
@@ -8,13 +8,13 @@ import (
 )
 
 type Installation struct {
-	ID         string
-	ExternalID string
-	Name       string
-	CreatedAt  time.Time
-	UpdatedAt  time.Time
-	DeletedAt  *time.Time
-	CreatedBy  *string
+	ID                string
+	ExternalID        string
+	Name              string
+	CreatedAt         time.Time
+	UpdatedAt         time.Time
+	DeletedAt         *time.Time
+	CreatedBy         *string
 	IsEvalAllowlisted bool
 }
 

--- a/internal/observability/otel/buffer.go
+++ b/internal/observability/otel/buffer.go
@@ -76,4 +76,3 @@ func Flush(ctx context.Context) {
 		buf.Flush()
 	}
 }
-

--- a/internal/observability/otel/buffer_test.go
+++ b/internal/observability/otel/buffer_test.go
@@ -166,4 +166,3 @@ func TestBuffer_FlushDrainsSpans(t *testing.T) {
 	assert.Len(t, names, 3)
 	assert.ElementsMatch(t, []string{"first", "second", "third"}, names)
 }
-

--- a/internal/observability/otel/emitter.go
+++ b/internal/observability/otel/emitter.go
@@ -12,8 +12,8 @@ import (
 
 	"google.golang.org/protobuf/proto"
 
-	commonv1 "go.opentelemetry.io/proto/otlp/common/v1"
 	coltracepb "go.opentelemetry.io/proto/otlp/collector/trace/v1"
+	commonv1 "go.opentelemetry.io/proto/otlp/common/v1"
 	resourcev1 "go.opentelemetry.io/proto/otlp/resource/v1"
 	tracev1 "go.opentelemetry.io/proto/otlp/trace/v1"
 )

--- a/internal/observability/otel/pricing.go
+++ b/internal/observability/otel/pricing.go
@@ -43,9 +43,9 @@ var pricingTable = map[string]Pricing{
 	"gpt-4o-mini":  {InputUSDPer1M: 0.15, OutputUSDPer1M: 0.60},
 
 	// Google Gemini 3.x
-	"gemini-3-pro-preview":        {InputUSDPer1M: 2.00, OutputUSDPer1M: 8.00},
-	"gemini-3.1-pro-preview":      {InputUSDPer1M: 2.00, OutputUSDPer1M: 8.00},
-	"gemini-3-flash-preview":      {InputUSDPer1M: 0.50, OutputUSDPer1M: 2.00},
+	"gemini-3-pro-preview":          {InputUSDPer1M: 2.00, OutputUSDPer1M: 8.00},
+	"gemini-3.1-pro-preview":        {InputUSDPer1M: 2.00, OutputUSDPer1M: 8.00},
+	"gemini-3-flash-preview":        {InputUSDPer1M: 0.50, OutputUSDPer1M: 2.00},
 	"gemini-3.1-flash-lite-preview": {InputUSDPer1M: 0.10, OutputUSDPer1M: 0.40},
 
 	// Google Gemini 2.x (legacy)

--- a/internal/observability/otel/spans.go
+++ b/internal/observability/otel/spans.go
@@ -38,13 +38,13 @@ func generateSpanID() [8]byte {
 func spanToProto(s Span, traceID [16]byte) *tracev1.Span {
 	spanID := generateSpanID()
 	return &tracev1.Span{
-		TraceId:            traceID[:],
-		SpanId:             spanID[:],
-		Name:               s.Name,
-		StartTimeUnixNano:  uint64(s.Start.UnixNano()),
-		EndTimeUnixNano:    uint64(s.End.UnixNano()),
-		Attributes:         attrsToKeyValues(s.Attrs),
-		Kind:               tracev1.Span_SPAN_KIND_INTERNAL,
+		TraceId:           traceID[:],
+		SpanId:            spanID[:],
+		Name:              s.Name,
+		StartTimeUnixNano: uint64(s.Start.UnixNano()),
+		EndTimeUnixNano:   uint64(s.End.UnixNano()),
+		Attributes:        attrsToKeyValues(s.Attrs),
+		Kind:              tracev1.Span_SPAN_KIND_INTERNAL,
 	}
 }
 

--- a/internal/providers/anthropic/client_test.go
+++ b/internal/providers/anthropic/client_test.go
@@ -185,4 +185,3 @@ func TestProxy_StampsTimingOnError(t *testing.T) {
 	assert.NotZero(t, tm.UpstreamFirstByteNanos.Load(), "must stamp UpstreamFirstByteNanos on error body read")
 	assert.NotZero(t, tm.UpstreamEOFNanos.Load(), "must stamp UpstreamEOFNanos after error body is drained")
 }
-

--- a/internal/providers/openai/client_test.go
+++ b/internal/providers/openai/client_test.go
@@ -132,7 +132,6 @@ func TestProxy_StampsTimingMilestones(t *testing.T) {
 	assert.LessOrEqual(t, tm.UpstreamFirstByteNanos.Load(), tm.UpstreamEOFNanos.Load())
 }
 
-
 func TestPassthrough_ForwardsPathAndAuth(t *testing.T) {
 	var (
 		gotPath string

--- a/internal/proxy/decision_log.go
+++ b/internal/proxy/decision_log.go
@@ -27,11 +27,11 @@ type DecisionLog struct {
 // transcript JSONL) — the join key that lets a consumer correlate the
 // two streams.
 type DecisionLogEntry struct {
-	Timestamp       string `json:"ts"`
-	RequestID       string `json:"request_id"`
-	RequestedModel  string `json:"requested_model"`
-	DecisionModel   string `json:"decision_model"`
-	DecisionReason  string `json:"decision_reason"`
+	Timestamp        string `json:"ts"`
+	RequestID        string `json:"request_id"`
+	RequestedModel   string `json:"requested_model"`
+	DecisionModel    string `json:"decision_model"`
+	DecisionReason   string `json:"decision_reason"`
 	DecisionProvider string `json:"decision_provider"`
 }
 

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -268,7 +268,7 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 
 	in, out := extractor.Tokens()
 	upstreamAttrs := map[string]any{
-		"request_id":                 requestID,
+		"request_id":                requestID,
 		"external_id":               externalID,
 		"usage.input_tokens":        in,
 		"usage.output_tokens":       out,
@@ -458,7 +458,7 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 
 	in, out := extractor.Tokens()
 	openaiUpstreamAttrs := map[string]any{
-		"request_id":                 requestID,
+		"request_id":                requestID,
 		"external_id":               externalID,
 		"usage.input_tokens":        in,
 		"usage.output_tokens":       out,

--- a/internal/router/cluster/scorer.go
+++ b/internal/router/cluster/scorer.go
@@ -32,15 +32,15 @@ func DefaultConfig() Config {
 // Scorer is the cluster router for one frozen artifact version. Errors
 // delegate to the fallback router so the request stays serviceable.
 type Scorer struct {
-	version   string
-	cfg       Config
-	embed     Embedder
-	centroids *Centroids
-	rankings  Rankings
-	registry  *ModelRegistry
+	version    string
+	cfg        Config
+	embed      Embedder
+	centroids  *Centroids
+	rankings   Rankings
+	registry   *ModelRegistry
 	candidates []DeployedEntry
 	models     []string
-	fallback router.Router
+	fallback   router.Router
 }
 
 // Version returns the artifact version (e.g. "v0.2") for logging and

--- a/internal/router/model.go
+++ b/internal/router/model.go
@@ -140,11 +140,11 @@ var registry = map[string]ModelSpec{
 	// `-preview` suffix is the canonical model ID Google's OpenAI-compat
 	// endpoint accepts. Gemini 3 Pro Preview is itself deprecated
 	// 2026-03-09 in favor of gemini-3.1-pro-preview.
-	"gemini-3-pro-preview":           googleBase,
-	"gemini-3.1-pro-preview":         googleBase,
-	"gemini-3-flash-preview":         googleBase,
-	"gemini-3.1-flash-lite-preview":  googleBase,
-	"gemini-3.1-flash-live-preview":  googleBase,
+	"gemini-3-pro-preview":          googleBase,
+	"gemini-3.1-pro-preview":        googleBase,
+	"gemini-3-flash-preview":        googleBase,
+	"gemini-3.1-flash-lite-preview": googleBase,
+	"gemini-3.1-flash-live-preview": googleBase,
 
 	// ── Google: Gemini 2.x families (still routable; bench-trained) ──
 	"gemini-2.5-pro":        googleBase,

--- a/internal/translate/envelope.go
+++ b/internal/translate/envelope.go
@@ -29,7 +29,7 @@ var ErrNotJSONObject = errors.New("request body must be a JSON object")
 type Format int
 
 const (
-	FormatOpenAI    Format = iota
+	FormatOpenAI Format = iota
 	FormatAnthropic
 )
 
@@ -400,15 +400,15 @@ var modelMaxOutputTokens = map[string]int{
 	"gpt-5.4-mini": 128000, "gpt-5.4-nano": 128000,
 	"gpt-5.5": 128000, "gpt-5.5-pro": 128000, "gpt-5.5-mini": 128000,
 	"gpt-5.5-nano": 128000,
-	"o1": 100000, "o1-pro": 100000, "o1-mini": 65536,
+	"o1":           100000, "o1-pro": 100000, "o1-mini": 65536,
 	"o3": 100000, "o3-pro": 100000, "o3-mini": 100000,
-	"o4-mini": 100000,
+	"o4-mini":              100000,
 	"gemini-3-pro-preview": 65536, "gemini-3.1-pro-preview": 65536,
 	"gemini-3-flash-preview": 65536, "gemini-3.1-flash-lite-preview": 65536,
 	"gemini-3.1-flash-live-preview": 65536,
-	"gemini-2.5-pro": 65536, "gemini-2.5-flash": 65536,
+	"gemini-2.5-pro":                65536, "gemini-2.5-flash": 65536,
 	"gemini-2.5-flash-lite": 65536,
-	"gemini-2.0-flash": 8192, "gemini-2.0-flash-lite": 8192,
+	"gemini-2.0-flash":      8192, "gemini-2.0-flash-lite": 8192,
 }
 
 const defaultMaxOutputTokenCap = 8192
@@ -433,4 +433,3 @@ func clampOutputTokens(doc map[string]any, model string) {
 		}
 	}
 }
-


### PR DESCRIPTION
## Summary

- **test.yml**: Full Go CI pipeline on push to `main` and PRs. Spins up Postgres 15 service container, applies migrations (with round-trip down/up to catch broken rollbacks), verifies `sqlc generate` is current, checks `gofmt`/`go vet`, typechecks, and runs all tests with `-count=1`.
- **check_migrations.yml**: PR-only check triggered on `db/migrations/` changes. Validates filename format (4-digit sequential prefix), up/down pairs, single migration per PR, monotonic ordering, and `BEGIN`/`COMMIT` wrapping.

Mirrors patterns from the Workweave monorepo `test_router.yml` and `check_postgres_migration_timestamps.yml`, adapted for this standalone repo (free `ubuntu-latest` runners, no skip-if-no-changes orchestration, sequential 4-digit migration numbering instead of 14-digit timestamps).
