### PR TITLE
feat: semantic cache for non-streaming requests

### DIFF
--- a/cmd/router/main.go
+++ b/cmd/router/main.go
@@ -29,6 +29,7 @@ import (
 	openaiProvider "workweave/router/internal/providers/openai"
 	"workweave/router/internal/proxy"
 	"workweave/router/internal/router"
+	"workweave/router/internal/router/cache"
 	"workweave/router/internal/router/cluster"
 	"workweave/router/internal/router/evalswitch"
 	"workweave/router/internal/router/heuristic"
@@ -157,7 +158,8 @@ func main() {
 		logger.Info("Decision sidecar log enabled", "path", decisionsLogPath)
 	}
 
-	proxySvc := proxy.NewService(rtr, providerMap, emitter, embedLastUser, stickyTTL, decisionLog)
+	semanticCache := buildSemanticCache(primary)
+	proxySvc := proxy.NewService(rtr, providerMap, emitter, embedLastUser, stickyTTL, decisionLog, semanticCache)
 
 	engine := gin.New()
 	engine.UnescapePathValues = true
@@ -456,6 +458,77 @@ func buildHeuristicFallback(providerMap map[string]providers.Client) *heuristic.
 		LargeModel:      "gemini-3.1-pro-preview",
 		ThresholdTokens: thresholdTokens,
 	})
+}
+
+// buildSemanticCache constructs the cross-request semantic cache, or
+// returns nil when disabled. Wiring honors:
+//
+//	ROUTER_SEMANTIC_CACHE_ENABLED — "false" disables; default enabled.
+//	ROUTER_SEMANTIC_CACHE_TTL_SEC — per-entry TTL in seconds (default 3600).
+//	ROUTER_SEMANTIC_CACHE_BUCKET  — per-(installation, format, cluster)
+//	                                 LRU capacity (default 1024).
+//
+// The cache is wired only when `primary` is the cluster router (or
+// wraps one), because the cache keys on the cluster scorer's
+// embeddings; a heuristic-only deployment has nothing to key on. When
+// primary is anything other than *cluster.Multiversion (heuristic-only,
+// or cluster build failed at boot) the cache is disabled.
+//
+// Per-cluster cosine thresholds are pulled from the default version's
+// metadata.yaml `cache_config` block. Other built versions reuse the
+// default's thresholds at runtime — keeping the cache config tied to
+// the default version means promotion (flipping `artifacts/latest`)
+// also flips cache thresholds atomically.
+func buildSemanticCache(primary router.Router) *cache.Cache {
+	logger := observability.Get()
+	if config.GetOr("ROUTER_SEMANTIC_CACHE_ENABLED", "true") != "true" {
+		logger.Info("Semantic cache disabled (ROUTER_SEMANTIC_CACHE_ENABLED=false)")
+		return nil
+	}
+	multi, ok := primary.(*cluster.Multiversion)
+	if !ok {
+		logger.Info("Semantic cache disabled: cluster router not active (no embeddings to key on)")
+		return nil
+	}
+	defaultScorer, ok := multi.Versions[multi.Default]
+	if !ok {
+		// Defensive: NewMultiversion guarantees the default is built.
+		logger.Warn("Semantic cache disabled: default cluster scorer not found", "default_version", multi.Default)
+		return nil
+	}
+	perCluster, defaultThreshold := defaultScorer.CacheThresholds()
+
+	cfg := cache.DefaultConfig()
+	cfg.PerClusterThreshold = perCluster
+	if defaultThreshold > 0 {
+		cfg.DefaultThreshold = defaultThreshold
+	}
+	if v := config.GetOr("ROUTER_SEMANTIC_CACHE_TTL_SEC", ""); v != "" {
+		secs, err := strconv.Atoi(v)
+		if err != nil || secs <= 0 {
+			logger.Warn("Invalid ROUTER_SEMANTIC_CACHE_TTL_SEC; using default", "value", v, "default_sec", int(cfg.TTL.Seconds()))
+		} else {
+			cfg.TTL = time.Duration(secs) * time.Second
+		}
+	}
+	if v := config.GetOr("ROUTER_SEMANTIC_CACHE_BUCKET", ""); v != "" {
+		size, err := strconv.Atoi(v)
+		if err != nil || size <= 0 {
+			logger.Warn("Invalid ROUTER_SEMANTIC_CACHE_BUCKET; using default", "value", v, "default", cfg.BucketSize)
+		} else {
+			cfg.BucketSize = size
+		}
+	}
+	logger.Info(
+		"Semantic cache enabled",
+		"default_threshold", cfg.DefaultThreshold,
+		"per_cluster_overrides", len(cfg.PerClusterThreshold),
+		"bucket_size", cfg.BucketSize,
+		"ttl_sec", int(cfg.TTL.Seconds()),
+		"max_body_kib", cfg.MaxBodyBytes/1024,
+		"version", multi.Default,
+	)
+	return cache.New(cfg)
 }
 
 // envVarForProvider returns the env var name for a provider's API key.

--- a/internal/proxy/cache_writer.go
+++ b/internal/proxy/cache_writer.go
@@ -1,0 +1,74 @@
+package proxy
+
+import (
+	"bytes"
+	"net/http"
+)
+
+// captureWriter wraps an http.ResponseWriter to mirror writes into an
+// in-memory buffer so the proxy can store the wire-format response in
+// the semantic cache after it streams. Writes pass through to the
+// underlying writer unchanged; the buffer is purely a side channel.
+//
+// Bodies that exceed maxBytes mark the capture as overflowed: the
+// pass-through continues so the client still gets its full response,
+// but the buffer is dropped and the proxy skips the post-Proxy Store
+// call. This bounds peak memory at maxBytes per concurrent in-flight
+// non-streaming request.
+type captureWriter struct {
+	w           http.ResponseWriter
+	body        bytes.Buffer
+	statusCode  int
+	wroteHeader bool
+	maxBytes    int
+	overflow    bool
+}
+
+func newCaptureWriter(w http.ResponseWriter, maxBytes int) *captureWriter {
+	return &captureWriter{w: w, statusCode: http.StatusOK, maxBytes: maxBytes}
+}
+
+func (c *captureWriter) Header() http.Header { return c.w.Header() }
+
+func (c *captureWriter) WriteHeader(code int) {
+	if c.wroteHeader {
+		return
+	}
+	c.statusCode = code
+	c.wroteHeader = true
+	c.w.WriteHeader(code)
+}
+
+func (c *captureWriter) Write(p []byte) (int, error) {
+	if !c.overflow {
+		if c.body.Len()+len(p) > c.maxBytes {
+			c.overflow = true
+			c.body.Reset()
+		} else {
+			c.body.Write(p)
+		}
+	}
+	return c.w.Write(p)
+}
+
+// Flush forwards to the underlying writer when it implements
+// http.Flusher (gin's default does). Provider clients call Flush()
+// during SSE streaming; we honor it transparently. Non-streaming
+// paths Flush() once at end-of-body and the captured bytes are still
+// complete.
+func (c *captureWriter) Flush() {
+	if f, ok := c.w.(http.Flusher); ok {
+		f.Flush()
+	}
+}
+
+// captured reports whether the buffer still holds the full body and
+// returns it. Callers must check the bool before reading body.
+func (c *captureWriter) captured() ([]byte, int, bool) {
+	if c.overflow {
+		return nil, 0, false
+	}
+	out := make([]byte, c.body.Len())
+	copy(out, c.body.Bytes())
+	return out, c.statusCode, true
+}

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -11,6 +11,7 @@ import (
 	"workweave/router/internal/observability/otel"
 	"workweave/router/internal/providers"
 	"workweave/router/internal/router"
+	"workweave/router/internal/router/cache"
 	"workweave/router/internal/translate"
 
 	"github.com/google/uuid"
@@ -25,6 +26,10 @@ type Service struct {
 	embedLastUserMessage bool
 	stickyDecisions      *expirable.LRU[string, router.Decision]
 	decisionLog          *DecisionLog
+	// semanticCache short-circuits non-streaming requests on a
+	// cosine-similarity hit against a stored response. Nil disables
+	// the cache entirely. Always nil-check before use.
+	semanticCache *cache.Cache
 }
 
 // APIKeyIDContextKey is the request-context key for the authenticated api_key_id.
@@ -34,7 +39,7 @@ type APIKeyIDContextKey struct{}
 type ExternalIDContextKey struct{}
 
 // NewService constructs the proxy service.
-func NewService(r router.Router, providerMap map[string]providers.Client, emitter *otel.Emitter, embedLastUserMessage bool, stickyDecisionTTL time.Duration, decisionLog *DecisionLog) *Service {
+func NewService(r router.Router, providerMap map[string]providers.Client, emitter *otel.Emitter, embedLastUserMessage bool, stickyDecisionTTL time.Duration, decisionLog *DecisionLog, semanticCache *cache.Cache) *Service {
 	var sticky *expirable.LRU[string, router.Decision]
 	if stickyDecisionTTL > 0 {
 		sticky = expirable.NewLRU[string, router.Decision](10000, nil, stickyDecisionTTL)
@@ -46,12 +51,75 @@ func NewService(r router.Router, providerMap map[string]providers.Client, emitte
 		embedLastUserMessage: embedLastUserMessage,
 		stickyDecisions:      sticky,
 		decisionLog:          decisionLog,
+		semanticCache:        semanticCache,
 	}
 }
 
 // ErrProviderNotConfigured is returned when a routing decision selects a
 // provider that is not present in the registry.
 var ErrProviderNotConfigured = errors.New("provider not configured")
+
+// semanticCacheMaxBodyBytes caps how large a non-streaming response
+// the cache will store. Bodies larger than this stream through to the
+// client unchanged, but the post-Proxy Store call is skipped to keep
+// peak memory bounded. 1 MiB covers typical Anthropic Messages and
+// OpenAI Chat Completions responses; the long-tail of large bodies
+// pays full provider cost on subsequent identical prompts.
+const semanticCacheMaxBodyBytes = 1 << 20
+
+// headersToSkipOnHit lists response headers the cache must NOT replay
+// on a hit. request-id ties to a specific upstream call and would
+// confuse downstream consumers (decisionLog, OTel correlation) if
+// reused. x-router-* are set fresh on the hit path so the client
+// always sees the current decision rather than a stale one.
+var headersToSkipOnHit = map[string]struct{}{
+	"Request-Id":         {},
+	"X-Request-Id":       {},
+	"X-Router-Decision":  {},
+	"X-Router-Provider":  {},
+	"X-Router-Model":     {},
+	"X-Router-Cache":     {},
+}
+
+// cloneCacheHeaders snapshots a header set for storage, dropping
+// transient identifiers that must not survive replay (see
+// headersToSkipOnHit).
+func cloneCacheHeaders(h http.Header) http.Header {
+	out := make(http.Header, len(h))
+	for k, vs := range h {
+		if _, skip := headersToSkipOnHit[http.CanonicalHeaderKey(k)]; skip {
+			continue
+		}
+		copied := make([]string, len(vs))
+		copy(copied, vs)
+		out[k] = copied
+	}
+	return out
+}
+
+// writeCachedResponse emits a stored CachedResponse to the client.
+// Caller-set router headers (x-router-*) are written from the live
+// decision (not the cached entry) so the client always sees an
+// accurate routing trace; the x-router-cache marker advertises the
+// hit. Body is written verbatim — already in the inbound wire format.
+func (s *Service) writeCachedResponse(w http.ResponseWriter, resp cache.CachedResponse, decision router.Decision) {
+	for k, vs := range resp.Headers {
+		for _, v := range vs {
+			w.Header().Add(k, v)
+		}
+	}
+	w.Header().Set("x-router-decision", decision.Reason)
+	w.Header().Set("x-router-provider", decision.Provider)
+	w.Header().Set("x-router-model", decision.Model)
+	w.Header().Set("x-router-cache", "hit")
+	if resp.StatusCode != 0 && resp.StatusCode != http.StatusOK {
+		w.WriteHeader(resp.StatusCode)
+	}
+	_, _ = w.Write(resp.Body)
+	if f, ok := w.(http.Flusher); ok {
+		f.Flush()
+	}
+}
 
 // EmbedLastUserMessageContextKey is the context key for the per-request embed flag override.
 type EmbedLastUserMessageContextKey struct{}
@@ -187,6 +255,33 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 	}
 	routeMs := time.Since(routeStart).Milliseconds()
 
+	// Semantic-cache lookup. Eligible when the cache is configured at
+	// boot, the request is non-streaming, the routing decision carries
+	// metadata (cluster scorer was used; heuristic decisions don't have
+	// an embedding to key on), and the caller has an externalID for
+	// per-tenant isolation.
+	cacheEligible := s.semanticCache != nil && !env.Stream() && decision.Metadata != nil && externalID != ""
+	if cacheEligible {
+		if resp, hit := s.semanticCache.Lookup(externalID, cache.FormatAnthropic, decision.Metadata.Embedding, decision.Metadata.ClusterIDs); hit {
+			s.writeCachedResponse(w, resp, decision)
+			otel.Record(ctx, otel.Span{
+				Name: "router.cache_hit", Start: requestStart, End: time.Now(),
+				Attrs: map[string]any{
+					"request_id":        requestID,
+					"external_id":       externalID,
+					"decision.model":    decision.Model,
+					"decision.provider": decision.Provider,
+					"cache.hit":         true,
+					"cache.format":      string(cache.FormatAnthropic),
+					"latency.total_ms":  time.Since(requestStart).Milliseconds(),
+				},
+			})
+			otel.Flush(ctx)
+			log.Info("ProxyMessages cache hit", "requested_model", feats.Model, "decision_model", decision.Model, "decision_provider", decision.Provider, "external_id", externalID, "total_ms", time.Since(requestStart).Milliseconds())
+			return nil
+		}
+	}
+
 	w.Header().Set("x-router-decision", decision.Reason)
 	w.Header().Set("x-router-provider", decision.Provider)
 	w.Header().Set("x-router-model", decision.Model)
@@ -225,6 +320,17 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 		IncludeStreamUsage: s.emitter != nil,
 	}
 
+	// Wrap w with a captureWriter when the cache is eligible so the
+	// post-translation wire bytes get mirrored into a buffer for
+	// post-Proxy storage. captureW.captured() is the source of truth
+	// for whether storage should happen.
+	var captureW *captureWriter
+	var sink http.ResponseWriter = w
+	if cacheEligible {
+		captureW = newCaptureWriter(w, semanticCacheMaxBodyBytes)
+		sink = captureW
+	}
+
 	proxyStart := time.Now()
 	var proxyErr error
 	crossFormat := false
@@ -237,9 +343,9 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 			log.Error("Failed to emit Anthropic body", "err", emitErr)
 			return fmt.Errorf("emit body: %w", emitErr)
 		}
-		proxyWriter := w
+		proxyWriter := sink
 		if s.emitter != nil {
-			extractor = otel.NewUsageExtractor(w, decision.Provider)
+			extractor = otel.NewUsageExtractor(sink, decision.Provider)
 			proxyWriter = extractor
 		}
 		proxyErr = p.Proxy(ctx, decision, prep, proxyWriter, r)
@@ -250,18 +356,33 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 			log.Error("Failed to translate Anthropic request to OpenAI format", "err", emitErr, "decision_provider", decision.Provider)
 			return fmt.Errorf("translate anthropic request: %w", emitErr)
 		}
-		var sink otel.UsageSink
+		var usage otel.UsageSink
 		if s.emitter != nil {
 			extractor = otel.NewUsageExtractor(nil, decision.Provider)
-			sink = extractor
+			usage = extractor
 		}
-		translator := translate.NewAnthropicSSETranslator(w, decision.Model, sink)
+		translator := translate.NewAnthropicSSETranslator(sink, decision.Model, usage)
 		proxyErr = p.Proxy(ctx, decision, prep, translator, r)
 		if proxyErr == nil {
 			proxyErr = translator.Finalize()
 		}
 	default:
 		return fmt.Errorf("%w: %s (no translation path defined for inbound Anthropic Messages)", ErrProviderNotConfigured, decision.Provider)
+	}
+
+	// Cache store. Only on success and when the captured body fits
+	// within MaxBodyBytes (captureW.captured returns false on
+	// overflow). Use the smallest top-p cluster id for storage; the
+	// LRU.Lookup path scans every top-p cluster, so any one is fine.
+	if cacheEligible && proxyErr == nil && captureW != nil {
+		if body, status, ok := captureW.captured(); ok && status == http.StatusOK {
+			storeResp := cache.CachedResponse{
+				StatusCode: status,
+				Headers:    cloneCacheHeaders(w.Header()),
+				Body:       body,
+			}
+			s.semanticCache.Store(externalID, cache.FormatAnthropic, decision.Metadata.Embedding, decision.Metadata.ClusterIDs[0], storeResp)
+		}
 	}
 
 	proxyMs := time.Since(proxyStart).Milliseconds()
@@ -379,6 +500,31 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 		return err
 	}
 
+	// Semantic-cache lookup — same eligibility rules as ProxyMessages
+	// (see that handler for rationale). Inbound format is FormatOpenAI
+	// so an Anthropic-stored response is never replayed here.
+	cacheEligible := s.semanticCache != nil && !env.Stream() && decision.Metadata != nil && externalID != ""
+	if cacheEligible {
+		if resp, hit := s.semanticCache.Lookup(externalID, cache.FormatOpenAI, decision.Metadata.Embedding, decision.Metadata.ClusterIDs); hit {
+			s.writeCachedResponse(w, resp, decision)
+			otel.Record(ctx, otel.Span{
+				Name: "router.cache_hit", Start: requestStart, End: time.Now(),
+				Attrs: map[string]any{
+					"request_id":        requestID,
+					"external_id":       externalID,
+					"decision.model":    decision.Model,
+					"decision.provider": decision.Provider,
+					"cache.hit":         true,
+					"cache.format":      string(cache.FormatOpenAI),
+					"latency.total_ms":  time.Since(requestStart).Milliseconds(),
+				},
+			})
+			otel.Flush(ctx)
+			log.Info("ProxyOpenAIChatCompletion cache hit", "requested_model", feats.Model, "decision_model", decision.Model, "decision_provider", decision.Provider, "external_id", externalID, "total_ms", time.Since(requestStart).Milliseconds())
+			return nil
+		}
+	}
+
 	p, provErr := s.provider(decision.Provider)
 	if provErr != nil {
 		return provErr
@@ -415,6 +561,16 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 		IncludeStreamUsage: s.emitter != nil,
 	}
 
+	// Wrap w with a captureWriter when the cache is eligible so the
+	// post-translation wire bytes get mirrored into a buffer for
+	// post-Proxy storage.
+	var captureW *captureWriter
+	var sink http.ResponseWriter = w
+	if cacheEligible {
+		captureW = newCaptureWriter(w, semanticCacheMaxBodyBytes)
+		sink = captureW
+	}
+
 	proxyStart := time.Now()
 	var proxyErr error
 	crossFormat := false
@@ -427,9 +583,9 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 			log.Error("Failed to emit OpenAI body", "err", emitErr)
 			return fmt.Errorf("emit body: %w", emitErr)
 		}
-		proxyWriter := w
+		proxyWriter := sink
 		if s.emitter != nil {
-			extractor = otel.NewUsageExtractor(w, decision.Provider)
+			extractor = otel.NewUsageExtractor(sink, decision.Provider)
 			proxyWriter = extractor
 		}
 		proxyErr = p.Proxy(ctx, decision, prep, proxyWriter, r)
@@ -440,18 +596,29 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 			log.Error("Failed to translate OpenAI request to Anthropic format", "err", emitErr)
 			return fmt.Errorf("translate openai request: %w", emitErr)
 		}
-		var sink otel.UsageSink
+		var usage otel.UsageSink
 		if s.emitter != nil {
 			extractor = otel.NewUsageExtractor(nil, "anthropic")
-			sink = extractor
+			usage = extractor
 		}
-		translator := translate.NewSSETranslator(w, decision.Model, sink)
+		translator := translate.NewSSETranslator(sink, decision.Model, usage)
 		proxyErr = p.Proxy(ctx, decision, prep, translator, r)
 		if proxyErr == nil {
 			proxyErr = translator.Finalize()
 		}
 	default:
 		return fmt.Errorf("%w: %s (no translation path defined)", ErrProviderNotConfigured, decision.Provider)
+	}
+
+	if cacheEligible && proxyErr == nil && captureW != nil {
+		if body, status, ok := captureW.captured(); ok && status == http.StatusOK {
+			storeResp := cache.CachedResponse{
+				StatusCode: status,
+				Headers:    cloneCacheHeaders(w.Header()),
+				Body:       body,
+			}
+			s.semanticCache.Store(externalID, cache.FormatOpenAI, decision.Metadata.Embedding, decision.Metadata.ClusterIDs[0], storeResp)
+		}
 	}
 
 	proxyMs := time.Since(proxyStart).Milliseconds()

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -73,12 +73,12 @@ const semanticCacheMaxBodyBytes = 1 << 20
 // reused. x-router-* are set fresh on the hit path so the client
 // always sees the current decision rather than a stale one.
 var headersToSkipOnHit = map[string]struct{}{
-	"Request-Id":         {},
-	"X-Request-Id":       {},
-	"X-Router-Decision":  {},
-	"X-Router-Provider":  {},
-	"X-Router-Model":     {},
-	"X-Router-Cache":     {},
+	"Request-Id":        {},
+	"X-Request-Id":      {},
+	"X-Router-Decision": {},
+	"X-Router-Provider": {},
+	"X-Router-Model":    {},
+	"X-Router-Cache":    {},
 }
 
 // cloneCacheHeaders snapshots a header set for storage, dropping

--- a/internal/proxy/service_cache_test.go
+++ b/internal/proxy/service_cache_test.go
@@ -1,0 +1,210 @@
+package proxy_test
+
+import (
+	"context"
+	"math"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"workweave/router/internal/providers"
+	"workweave/router/internal/proxy"
+	"workweave/router/internal/router"
+	"workweave/router/internal/router/cache"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// embeddingFixture returns a deterministic L2-normalized vector keyed
+// by `seed`. Different seeds yield different unit vectors so tests
+// can exercise distinct cache entries without sharing state.
+func embeddingFixture(seed float32) []float32 {
+	v := []float32{seed, 1, 0, 0, 0, 0, 0, 0}
+	var sum float32
+	for _, x := range v {
+		sum += x * x
+	}
+	if sum == 0 {
+		return v
+	}
+	norm := float32(math.Sqrt(float64(sum)))
+	out := make([]float32, len(v))
+	for i, x := range v {
+		out[i] = x / norm
+	}
+	return out
+}
+
+// anthropicBody returns a minimal valid Anthropic Messages body. The
+// stream flag is configurable so tests can exercise both cacheable
+// (stream=false) and bypass (stream=true) paths.
+func anthropicBody(prompt string, stream bool) []byte {
+	streamLit := "false"
+	if stream {
+		streamLit = "true"
+	}
+	return []byte(`{
+		"model":"claude-opus-4-7",
+		"max_tokens":256,
+		"stream":` + streamLit + `,
+		"messages":[{"role":"user","content":"` + prompt + `"}]
+	}`)
+}
+
+// decisionWithEmbedding builds a routing decision that carries the
+// metadata needed for cache eligibility — mirrors what the cluster
+// scorer produces in production.
+func decisionWithEmbedding(emb []float32, clusterIDs []int) router.Decision {
+	return router.Decision{
+		Provider: "anthropic",
+		Model:    "claude-haiku-4-5",
+		Reason:   "test",
+		Metadata: &router.RoutingMetadata{
+			Embedding:  emb,
+			ClusterIDs: clusterIDs,
+		},
+	}
+}
+
+// proxyContextWithExternalID wires the per-tenant identifier the cache
+// uses for isolation. Without it the proxy bypasses the cache.
+func proxyContextWithExternalID(t *testing.T, externalID string) context.Context {
+	t.Helper()
+	ctx := context.Background()
+	if externalID != "" {
+		ctx = context.WithValue(ctx, proxy.ExternalIDContextKey{}, externalID)
+	}
+	return ctx
+}
+
+func TestService_Cache_HitShortCircuitsProvider(t *testing.T) {
+	emb := embeddingFixture(1)
+	provider := &fakeProvider{
+		proxyResponse: func(w http.ResponseWriter) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"id":"first","content":"hi"}`))
+		},
+	}
+	fr := &fakeRouter{decision: decisionWithEmbedding(emb, []int{0, 1, 2, 3})}
+	c := cache.New(cache.DefaultConfig())
+	svc := proxy.NewService(fr, map[string]providers.Client{"anthropic": provider}, nil, false, 0, nil, c)
+
+	ctx := proxyContextWithExternalID(t, "tenant-1")
+	body := anthropicBody("ping", false)
+
+	// First call: provider runs and the response is captured into the cache.
+	rec1 := httptest.NewRecorder()
+	httpReq1 := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(""))
+	require.NoError(t, svc.ProxyMessages(ctx, body, rec1, httpReq1))
+	require.Len(t, provider.proxyBodies, 1, "first call must hit the provider")
+
+	// Second call with identical body+context: cache must short-circuit so
+	// the provider sees no second request.
+	rec2 := httptest.NewRecorder()
+	httpReq2 := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(""))
+	require.NoError(t, svc.ProxyMessages(ctx, body, rec2, httpReq2))
+	assert.Len(t, provider.proxyBodies, 1, "cache hit must not invoke provider a second time")
+
+	// Replay must surface the original body bytes.
+	assert.Equal(t, `{"id":"first","content":"hi"}`, rec2.Body.String())
+	// And the hit marker must advertise the cache to the client.
+	assert.Equal(t, "hit", rec2.Header().Get("x-router-cache"))
+}
+
+func TestService_Cache_StreamingBypasses(t *testing.T) {
+	emb := embeddingFixture(2)
+	provider := &fakeProvider{
+		proxyResponse: func(w http.ResponseWriter) { _, _ = w.Write([]byte("event: stream-payload\n")) },
+	}
+	fr := &fakeRouter{decision: decisionWithEmbedding(emb, []int{0})}
+	c := cache.New(cache.DefaultConfig())
+	svc := proxy.NewService(fr, map[string]providers.Client{"anthropic": provider}, nil, false, 0, nil, c)
+
+	ctx := proxyContextWithExternalID(t, "tenant-1")
+	body := anthropicBody("streaming please", true) // stream=true
+
+	rec1 := httptest.NewRecorder()
+	httpReq1 := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(""))
+	require.NoError(t, svc.ProxyMessages(ctx, body, rec1, httpReq1))
+
+	rec2 := httptest.NewRecorder()
+	httpReq2 := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(""))
+	require.NoError(t, svc.ProxyMessages(ctx, body, rec2, httpReq2))
+
+	assert.Len(t, provider.proxyBodies, 2, "streaming requests must always hit the provider — no caching")
+	assert.Empty(t, rec2.Header().Get("x-router-cache"), "streaming responses carry no x-router-cache marker")
+}
+
+func TestService_Cache_HeuristicDecisionBypasses(t *testing.T) {
+	provider := &fakeProvider{
+		proxyResponse: func(w http.ResponseWriter) { _, _ = w.Write([]byte(`{"id":"x"}`)) },
+	}
+	// Decision with no Metadata — what the heuristic router produces.
+	fr := &fakeRouter{decision: router.Decision{Provider: "anthropic", Model: "claude-haiku-4-5", Reason: "heuristic"}}
+	c := cache.New(cache.DefaultConfig())
+	svc := proxy.NewService(fr, map[string]providers.Client{"anthropic": provider}, nil, false, 0, nil, c)
+
+	ctx := proxyContextWithExternalID(t, "tenant-1")
+	body := anthropicBody("ask", false)
+
+	rec1 := httptest.NewRecorder()
+	httpReq1 := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(""))
+	require.NoError(t, svc.ProxyMessages(ctx, body, rec1, httpReq1))
+
+	rec2 := httptest.NewRecorder()
+	httpReq2 := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(""))
+	require.NoError(t, svc.ProxyMessages(ctx, body, rec2, httpReq2))
+
+	assert.Len(t, provider.proxyBodies, 2, "decisions without RoutingMetadata must not be cached (no embedding to key on)")
+}
+
+func TestService_Cache_MissingExternalIDBypasses(t *testing.T) {
+	emb := embeddingFixture(3)
+	provider := &fakeProvider{
+		proxyResponse: func(w http.ResponseWriter) { _, _ = w.Write([]byte(`{"id":"y"}`)) },
+	}
+	fr := &fakeRouter{decision: decisionWithEmbedding(emb, []int{0})}
+	c := cache.New(cache.DefaultConfig())
+	svc := proxy.NewService(fr, map[string]providers.Client{"anthropic": provider}, nil, false, 0, nil, c)
+
+	body := anthropicBody("ask", false)
+
+	// No externalID on context → cache is bypassed for safety (per-tenant
+	// scope is the cache's only isolation mechanism).
+	ctx := context.Background()
+	rec1 := httptest.NewRecorder()
+	httpReq1 := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(""))
+	require.NoError(t, svc.ProxyMessages(ctx, body, rec1, httpReq1))
+
+	rec2 := httptest.NewRecorder()
+	httpReq2 := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(""))
+	require.NoError(t, svc.ProxyMessages(ctx, body, rec2, httpReq2))
+
+	assert.Len(t, provider.proxyBodies, 2, "without externalID the cache must not store or replay")
+}
+
+func TestService_Cache_DisabledByNilCache(t *testing.T) {
+	emb := embeddingFixture(4)
+	provider := &fakeProvider{
+		proxyResponse: func(w http.ResponseWriter) { _, _ = w.Write([]byte(`{"id":"z"}`)) },
+	}
+	fr := &fakeRouter{decision: decisionWithEmbedding(emb, []int{0})}
+	// nil cache — same effect as ROUTER_SEMANTIC_CACHE_ENABLED=false.
+	svc := proxy.NewService(fr, map[string]providers.Client{"anthropic": provider}, nil, false, 0, nil, nil)
+
+	ctx := proxyContextWithExternalID(t, "tenant-1")
+	body := anthropicBody("ask", false)
+
+	rec1 := httptest.NewRecorder()
+	httpReq1 := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(""))
+	require.NoError(t, svc.ProxyMessages(ctx, body, rec1, httpReq1))
+
+	rec2 := httptest.NewRecorder()
+	httpReq2 := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(""))
+	require.NoError(t, svc.ProxyMessages(ctx, body, rec2, httpReq2))
+
+	assert.Len(t, provider.proxyBodies, 2, "nil cache must be a transparent passthrough")
+	assert.Empty(t, rec2.Header().Get("x-router-cache"))
+}

--- a/internal/proxy/service_test.go
+++ b/internal/proxy/service_test.go
@@ -62,7 +62,7 @@ func (f *fakeProvider) Passthrough(ctx context.Context, prep providers.PreparedR
 }
 
 func makeProxyService(decision router.Decision, p map[string]providers.Client) *proxy.Service {
-	return proxy.NewService(&fakeRouter{decision: decision}, p, nil, false, 0, nil)
+	return proxy.NewService(&fakeRouter{decision: decision}, p, nil, false, 0, nil, nil)
 }
 
 func TestService_Dispatch_ForwardsRequestToProvider(t *testing.T) {
@@ -118,7 +118,7 @@ func TestService_Dispatch_PropagatesProviderError(t *testing.T) {
 }
 
 func TestService_Dispatch_UnknownProviderReturnsErrProviderNotConfigured(t *testing.T) {
-	svc := proxy.NewService(&fakeRouter{}, map[string]providers.Client{}, nil, false, 0, nil)
+	svc := proxy.NewService(&fakeRouter{}, map[string]providers.Client{}, nil, false, 0, nil, nil)
 
 	_, err := svc.Dispatch(
 		context.Background(),
@@ -174,6 +174,7 @@ func TestService_ProxyMessages_EmbedLastUserMessageFlag(t *testing.T) {
 			false,
 			0,
 			nil,
+			nil,
 		)
 
 		rec := httptest.NewRecorder()
@@ -195,6 +196,7 @@ func TestService_ProxyMessages_EmbedLastUserMessageFlag(t *testing.T) {
 			nil,
 			true,
 			0,
+			nil,
 			nil,
 		)
 
@@ -258,6 +260,7 @@ func TestService_ProxyMessages_EmbedLastUserMessageContextOverride(t *testing.T)
 				tc.startupFlag,
 				0,
 				nil,
+				nil,
 			)
 
 			ctx := context.Background()
@@ -301,6 +304,7 @@ func TestService_ProxyMessages_StickyBypassedByEvalOverrideHeaders(t *testing.T)
 				nil,
 				false,
 				time.Hour, // long TTL so sticky window stays open across both calls
+				nil,
 				nil,
 			)
 

--- a/internal/router/cache/cache.go
+++ b/internal/router/cache/cache.go
@@ -1,0 +1,284 @@
+// Package cache implements a semantic response cache for the router.
+//
+// The cache short-circuits identical and near-duplicate requests by
+// keying on the cluster scorer's prompt embedding (cosine similarity
+// against previously-stored entries). On a hit, the captured wire-
+// format response bytes are replayed to the client without invoking
+// the upstream provider.
+//
+// Scope (v1):
+//
+//   - Non-streaming requests only. The proxy bypasses the cache when
+//     the inbound body has stream=true; streaming buffer-on-miss is a
+//     follow-up. RouterArena's eval traffic is non-streaming, so the
+//     v1 covers the benchmark surface.
+//
+//   - Per-(installation, inbound-format) isolation. Two tenants asking
+//     the same question both pay first-call cost; a cached Anthropic
+//     response is never replayed for an OpenAI client. Inbound format
+//     is part of the bucket key because the captured bytes are
+//     post-translation (Anthropic SSE for Anthropic clients,
+//     OpenAI JSON for OpenAI clients).
+//
+//   - Cluster-bucketed brute-force lookup. Each (installationID,
+//     inboundFormat, clusterID) tuple owns its own LRU. On lookup, the
+//     cache scans the buckets for the routing decision's top-p clusters
+//     and returns the first entry whose cosine ≥ the per-cluster
+//     threshold. With 10 clusters and 1k entries per bucket, top-p=4
+//     × 1k × 768-d cosine ops fits in <5ms; HNSW is unnecessary at
+//     this scale.
+//
+// Out of scope: streaming, distributed (Redis), cross-installation
+// sharing, event-driven invalidation. TTL is the only eviction
+// mechanism.
+package cache
+
+import (
+	"crypto/sha256"
+	"encoding/binary"
+	"math"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/hashicorp/golang-lru/v2/expirable"
+)
+
+// CachedResponse captures the upstream response in the inbound wire
+// format so a cache hit can replay it byte-for-byte. We intentionally
+// store the post-translation bytes (e.g. an Anthropic SSE response
+// produced by translate.AnthropicSSETranslator when the upstream is
+// OpenAI) rather than the upstream's native bytes — the goal is
+// indistinguishable replay from the client's perspective.
+type CachedResponse struct {
+	// StatusCode is the HTTP status the proxy wrote (or 200 if
+	// implicit).
+	StatusCode int
+	// Headers is a snapshot of the response headers at end-of-write.
+	// Caller-set router headers (x-router-*) and upstream headers
+	// (request-id, content-type, etc.) are both preserved; the cache
+	// consumer can scrub or override per-hit.
+	Headers http.Header
+	// Body is the full response body (post-translation if
+	// cross-format). Bounded by the cache's MaxBodyBytes; entries
+	// exceeding the cap are dropped (not stored) so callers should
+	// budget for a short tail of uncached large responses.
+	Body []byte
+}
+
+// Config carries the runtime knobs.
+type Config struct {
+	// PerClusterThreshold overrides DefaultThreshold per cluster.
+	// Empty/nil means "always use DefaultThreshold".
+	PerClusterThreshold map[int]float32
+	// DefaultThreshold is the cosine floor applied to every cluster
+	// without an override. Conservative default 0.95.
+	DefaultThreshold float32
+	// BucketSize caps per-(installation, inboundFormat, clusterID)
+	// LRU size. Bounded so a single chatty installation can't evict
+	// another's entries.
+	BucketSize int
+	// TTL is the LRU's per-entry time-to-live.
+	TTL time.Duration
+	// MaxBodyBytes drops responses larger than this without caching.
+	// Prevents an unbounded body from blowing memory on a single
+	// outlier (Anthropic max_tokens is 200k tokens ≈ 1MB).
+	MaxBodyBytes int
+}
+
+// DefaultConfig returns conservative defaults. Tuned for a single
+// staging deployment; production may want larger BucketSize and a
+// shorter TTL.
+func DefaultConfig() Config {
+	return Config{
+		DefaultThreshold: 0.95,
+		BucketSize:       1024,
+		TTL:              1 * time.Hour,
+		MaxBodyBytes:     1 << 20, // 1 MiB
+	}
+}
+
+// Cache is the in-memory semantic cache. Safe for concurrent use; the
+// outer map of buckets is mutex-guarded, and each per-bucket
+// expirable.LRU is itself thread-safe.
+type Cache struct {
+	cfg     Config
+	buckets map[bucketKey]*expirable.LRU[entryKey, *entry]
+	mu      sync.Mutex // guards `buckets` map (LRU itself is thread-safe)
+}
+
+// New constructs a Cache. nil Config fields fall through to
+// DefaultConfig().
+func New(cfg Config) *Cache {
+	def := DefaultConfig()
+	if cfg.DefaultThreshold == 0 {
+		cfg.DefaultThreshold = def.DefaultThreshold
+	}
+	if cfg.BucketSize <= 0 {
+		cfg.BucketSize = def.BucketSize
+	}
+	if cfg.TTL <= 0 {
+		cfg.TTL = def.TTL
+	}
+	if cfg.MaxBodyBytes <= 0 {
+		cfg.MaxBodyBytes = def.MaxBodyBytes
+	}
+	return &Cache{
+		cfg:     cfg,
+		buckets: make(map[bucketKey]*expirable.LRU[entryKey, *entry]),
+	}
+}
+
+// Format names the inbound wire format the cached response is encoded
+// in. Lookups must match against the same Format the entry was stored
+// under so an Anthropic client never receives an OpenAI-shaped reply.
+type Format string
+
+const (
+	FormatAnthropic Format = "anthropic"
+	FormatOpenAI    Format = "openai"
+)
+
+type bucketKey struct {
+	installationID string
+	format         Format
+	clusterID      int
+}
+
+// entryKey is a 16-byte digest of the embedding, derived from sha256
+// truncation. It identifies an entry inside its bucket without storing
+// the full 3KB embedding twice (the entry already carries it).
+type entryKey [16]byte
+
+type entry struct {
+	embedding []float32
+	response  CachedResponse
+}
+
+// thresholdFor returns the cosine threshold for a given cluster, with
+// fall-through to the default.
+func (c *Cache) thresholdFor(clusterID int) float32 {
+	if t, ok := c.cfg.PerClusterThreshold[clusterID]; ok {
+		return t
+	}
+	return c.cfg.DefaultThreshold
+}
+
+// Lookup walks the buckets for the given (installation, format,
+// clusterIDs) tuples and returns the first entry whose cosine
+// similarity against `embedding` clears the cluster's threshold.
+//
+// Embedding must be L2-normalized (matching the cluster scorer's
+// output); cosine reduces to a dot product. clusterIDs is the
+// scorer's top-p list. Order of clusterIDs is irrelevant — every
+// listed bucket is scanned.
+//
+// The (CachedResponse, false) case never occurs; the bool is sized
+// around the typical Go cache idiom of "value, hit".
+func (c *Cache) Lookup(installationID string, format Format, embedding []float32, clusterIDs []int) (CachedResponse, bool) {
+	if c == nil || len(embedding) == 0 || len(clusterIDs) == 0 {
+		return CachedResponse{}, false
+	}
+	for _, cid := range clusterIDs {
+		bucket := c.bucket(installationID, format, cid, false)
+		if bucket == nil {
+			continue
+		}
+		threshold := c.thresholdFor(cid)
+		// Iterate the LRU's keys; on each hit-candidate compute
+		// cosine. expirable.LRU.Keys() returns MRU-first which biases
+		// us toward returning the most-recently-stored similar entry —
+		// useful when the same prompt has been answered repeatedly.
+		for _, k := range bucket.Keys() {
+			e, ok := bucket.Get(k)
+			if !ok {
+				continue
+			}
+			sim := cosine(embedding, e.embedding)
+			if sim >= threshold {
+				return e.response, true
+			}
+		}
+	}
+	return CachedResponse{}, false
+}
+
+// Store persists a response under (installationID, format, clusterID).
+// clusterID should be one of the routing decision's top-p clusters
+// (the scorer sorts them ascending; picking the smallest keeps storage
+// deterministic). Lookup scans every top-p cluster, so any one is
+// sufficient.
+//
+// Bodies exceeding cfg.MaxBodyBytes are silently dropped (no error,
+// no panic) so a single outlier doesn't blow memory.
+func (c *Cache) Store(installationID string, format Format, embedding []float32, clusterID int, resp CachedResponse) {
+	if c == nil || len(embedding) == 0 {
+		return
+	}
+	if len(resp.Body) > c.cfg.MaxBodyBytes {
+		return
+	}
+	bucket := c.bucket(installationID, format, clusterID, true)
+	if bucket == nil {
+		return
+	}
+	// Deep-copy the embedding: the caller's slice is owned by
+	// router.Decision.Metadata and may be mutated/recycled.
+	embedCopy := make([]float32, len(embedding))
+	copy(embedCopy, embedding)
+	bucket.Add(entryKeyFor(embedCopy), &entry{
+		embedding: embedCopy,
+		response:  resp,
+	})
+}
+
+// bucket returns the LRU for a given key. When create is false and the
+// bucket doesn't exist, returns nil (lookup path: we skip the empty
+// bucket). When create is true, the bucket is lazily allocated.
+func (c *Cache) bucket(installationID string, format Format, clusterID int, create bool) *expirable.LRU[entryKey, *entry] {
+	key := bucketKey{installationID: installationID, format: format, clusterID: clusterID}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	b, ok := c.buckets[key]
+	if !ok {
+		if !create {
+			return nil
+		}
+		b = expirable.NewLRU[entryKey, *entry](c.cfg.BucketSize, nil, c.cfg.TTL)
+		c.buckets[key] = b
+	}
+	return b
+}
+
+// entryKeyFor derives a deterministic key from an embedding by
+// hashing its raw bytes. Two identical embeddings produce the same
+// key, so re-storing the same prompt updates the existing entry
+// in-place rather than churning the LRU.
+func entryKeyFor(embedding []float32) entryKey {
+	if len(embedding) == 0 {
+		return entryKey{}
+	}
+	buf := make([]byte, len(embedding)*4)
+	for i, v := range embedding {
+		binary.LittleEndian.PutUint32(buf[i*4:], math.Float32bits(v))
+	}
+	sum := sha256.Sum256(buf)
+	var k entryKey
+	copy(k[:], sum[:16])
+	return k
+}
+
+// cosine computes the cosine similarity between two L2-normalized
+// vectors. Both inputs must already be normalized (the cluster scorer
+// guarantees this for its embeddings); skipping the sqrt + divide
+// here mirrors scorer.go::topPNearest's reasoning.
+func cosine(a, b []float32) float32 {
+	if len(a) != len(b) {
+		return 0
+	}
+	var sum float32
+	for i := range a {
+		sum += a[i] * b[i]
+	}
+	return sum
+}

--- a/internal/router/cache/cache_test.go
+++ b/internal/router/cache/cache_test.go
@@ -1,0 +1,218 @@
+package cache_test
+
+import (
+	"math"
+	"net/http"
+	"testing"
+	"time"
+
+	"workweave/router/internal/router/cache"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// l2Normalize returns vec / ||vec||₂ so callers can build test
+// fixtures the same way the cluster scorer's embedder does.
+func l2Normalize(v []float32) []float32 {
+	var sum float32
+	for _, x := range v {
+		sum += x * x
+	}
+	if sum == 0 {
+		return v
+	}
+	norm := float32(math.Sqrt(float64(sum)))
+	out := make([]float32, len(v))
+	for i, x := range v {
+		out[i] = x / norm
+	}
+	return out
+}
+
+// blendVectors returns alpha*a + (1-alpha)*b, L2-normalized. Used to
+// generate near-duplicates with a tunable cosine to either side of a
+// threshold.
+func blendVectors(a, b []float32, alpha float32) []float32 {
+	out := make([]float32, len(a))
+	for i := range a {
+		out[i] = alpha*a[i] + (1-alpha)*b[i]
+	}
+	return l2Normalize(out)
+}
+
+func sampleResponse(body string) cache.CachedResponse {
+	h := http.Header{}
+	h.Set("Content-Type", "application/json")
+	return cache.CachedResponse{
+		StatusCode: http.StatusOK,
+		Headers:    h,
+		Body:       []byte(body),
+	}
+}
+
+func TestCache_IdenticalEmbeddingHits(t *testing.T) {
+	c := cache.New(cache.DefaultConfig())
+	emb := l2Normalize([]float32{1, 0, 0, 0})
+	want := sampleResponse(`{"id":"resp-1"}`)
+
+	c.Store("inst-1", cache.FormatAnthropic, emb, 0, want)
+
+	got, hit := c.Lookup("inst-1", cache.FormatAnthropic, emb, []int{0, 1, 2, 3})
+	require.True(t, hit, "identical embedding should hit")
+	assert.Equal(t, want.Body, got.Body)
+	assert.Equal(t, want.StatusCode, got.StatusCode)
+}
+
+func TestCache_NearDuplicateHitsAboveThreshold(t *testing.T) {
+	cfg := cache.DefaultConfig()
+	cfg.DefaultThreshold = 0.95
+	c := cache.New(cfg)
+
+	a := l2Normalize([]float32{1, 0, 0, 0})
+	// Build a near-duplicate at cosine ≈ 0.97 by mixing in a small
+	// orthogonal component.
+	b := blendVectors(a, l2Normalize([]float32{0, 1, 0, 0}), 0.95)
+
+	// Sanity: the blend's cosine to a should clear 0.95.
+	var sim float32
+	for i := range a {
+		sim += a[i] * b[i]
+	}
+	require.Greater(t, sim, float32(0.95), "test fixture cosine must be above the threshold")
+
+	c.Store("inst-1", cache.FormatAnthropic, a, 0, sampleResponse(`{"id":"resp-near"}`))
+
+	_, hit := c.Lookup("inst-1", cache.FormatAnthropic, b, []int{0})
+	assert.True(t, hit, "near-duplicate above threshold should hit")
+}
+
+func TestCache_BelowThresholdMisses(t *testing.T) {
+	cfg := cache.DefaultConfig()
+	cfg.DefaultThreshold = 0.95
+	c := cache.New(cfg)
+
+	a := l2Normalize([]float32{1, 0, 0, 0})
+	// Distant vector — cosine ~0.5 between a and the blend.
+	b := blendVectors(a, l2Normalize([]float32{0, 1, 0, 0}), 0.5)
+
+	c.Store("inst-1", cache.FormatAnthropic, a, 0, sampleResponse(`{"id":"resp"}`))
+
+	_, hit := c.Lookup("inst-1", cache.FormatAnthropic, b, []int{0})
+	assert.False(t, hit, "below-threshold cosine must miss")
+}
+
+func TestCache_PerClusterThresholdOverride(t *testing.T) {
+	cfg := cache.DefaultConfig()
+	cfg.DefaultThreshold = 0.99 // strict
+	cfg.PerClusterThreshold = map[int]float32{
+		7: 0.5, // permissive for cluster 7 only
+	}
+	c := cache.New(cfg)
+
+	a := l2Normalize([]float32{1, 0, 0, 0})
+	b := blendVectors(a, l2Normalize([]float32{0, 1, 0, 0}), 0.7) // cosine ≈ 0.7
+
+	// Cluster 0 uses the strict default → miss.
+	c.Store("inst-1", cache.FormatAnthropic, a, 0, sampleResponse(`{"id":"strict"}`))
+	_, hitStrict := c.Lookup("inst-1", cache.FormatAnthropic, b, []int{0})
+	assert.False(t, hitStrict, "default 0.99 threshold should reject 0.7 cosine")
+
+	// Cluster 7 uses the override → hit.
+	c.Store("inst-1", cache.FormatAnthropic, a, 7, sampleResponse(`{"id":"loose"}`))
+	resp, hitLoose := c.Lookup("inst-1", cache.FormatAnthropic, b, []int{7})
+	require.True(t, hitLoose, "cluster 7 override 0.5 threshold should accept 0.7 cosine")
+	assert.Equal(t, []byte(`{"id":"loose"}`), resp.Body)
+}
+
+func TestCache_BucketIsolationAcrossInstallations(t *testing.T) {
+	c := cache.New(cache.DefaultConfig())
+	emb := l2Normalize([]float32{1, 0, 0, 0})
+
+	c.Store("inst-A", cache.FormatAnthropic, emb, 0, sampleResponse(`{"who":"A"}`))
+
+	// Same embedding, different installation → must miss.
+	_, hit := c.Lookup("inst-B", cache.FormatAnthropic, emb, []int{0})
+	assert.False(t, hit, "embeddings must not cross installations")
+}
+
+func TestCache_BucketIsolationAcrossFormats(t *testing.T) {
+	c := cache.New(cache.DefaultConfig())
+	emb := l2Normalize([]float32{1, 0, 0, 0})
+
+	c.Store("inst-1", cache.FormatAnthropic, emb, 0, sampleResponse(`{"fmt":"anth"}`))
+
+	// Same embedding, OpenAI inbound → must miss; Anthropic-shaped
+	// bytes are not safe to replay to an OpenAI client.
+	_, hit := c.Lookup("inst-1", cache.FormatOpenAI, emb, []int{0})
+	assert.False(t, hit, "cached Anthropic response must not replay for OpenAI")
+}
+
+func TestCache_TTLExpiry(t *testing.T) {
+	cfg := cache.DefaultConfig()
+	cfg.TTL = 50 * time.Millisecond
+	c := cache.New(cfg)
+
+	emb := l2Normalize([]float32{1, 0, 0, 0})
+	c.Store("inst-1", cache.FormatAnthropic, emb, 0, sampleResponse(`{"id":"old"}`))
+
+	// Immediately: hit.
+	_, hit := c.Lookup("inst-1", cache.FormatAnthropic, emb, []int{0})
+	require.True(t, hit, "fresh entry should hit")
+
+	// After TTL: must miss.
+	time.Sleep(80 * time.Millisecond)
+	_, hit = c.Lookup("inst-1", cache.FormatAnthropic, emb, []int{0})
+	assert.False(t, hit, "expired entry must miss")
+}
+
+func TestCache_LookupScansAllTopPClusters(t *testing.T) {
+	c := cache.New(cache.DefaultConfig())
+	emb := l2Normalize([]float32{1, 0, 0, 0})
+
+	// Store in cluster 5 only. Lookup with top-p clusters [2, 3, 5, 7]
+	// should still find it because the cache scans every listed
+	// cluster.
+	c.Store("inst-1", cache.FormatAnthropic, emb, 5, sampleResponse(`{"id":"in-5"}`))
+
+	got, hit := c.Lookup("inst-1", cache.FormatAnthropic, emb, []int{2, 3, 5, 7})
+	require.True(t, hit, "top-p sweep should locate entries in any listed cluster")
+	assert.Equal(t, []byte(`{"id":"in-5"}`), got.Body)
+}
+
+func TestCache_StoreDropsOversizedBodies(t *testing.T) {
+	cfg := cache.DefaultConfig()
+	cfg.MaxBodyBytes = 16 // tiny cap so we trip it deterministically
+	c := cache.New(cfg)
+
+	emb := l2Normalize([]float32{1, 0, 0, 0})
+	bigBody := make([]byte, cfg.MaxBodyBytes+1)
+	c.Store("inst-1", cache.FormatAnthropic, emb, 0, cache.CachedResponse{
+		StatusCode: http.StatusOK,
+		Headers:    http.Header{},
+		Body:       bigBody,
+	})
+
+	_, hit := c.Lookup("inst-1", cache.FormatAnthropic, emb, []int{0})
+	assert.False(t, hit, "oversized bodies must not be stored")
+}
+
+func TestCache_NilCacheLookupAndStoreAreSafe(t *testing.T) {
+	// Disabled-mode cache: callers pass nil and expect no-op behavior.
+	var c *cache.Cache
+
+	_, hit := c.Lookup("inst-1", cache.FormatAnthropic, []float32{1}, []int{0})
+	assert.False(t, hit, "nil cache must report a miss without panicking")
+
+	// Store on nil must not panic either.
+	c.Store("inst-1", cache.FormatAnthropic, []float32{1}, 0, sampleResponse(`x`))
+}
+
+func TestCache_EmptyEmbeddingMisses(t *testing.T) {
+	c := cache.New(cache.DefaultConfig())
+	_, hit := c.Lookup("inst-1", cache.FormatAnthropic, nil, []int{0})
+	assert.False(t, hit, "empty embedding must miss")
+	c.Store("inst-1", cache.FormatAnthropic, nil, 0, sampleResponse(`x`))
+	_, hit = c.Lookup("inst-1", cache.FormatAnthropic, l2Normalize([]float32{1, 0, 0, 0}), []int{0})
+	assert.False(t, hit, "empty-embedding store must be a no-op")
+}

--- a/internal/router/cluster/artifacts.go
+++ b/internal/router/cluster/artifacts.go
@@ -151,17 +151,17 @@ func (r *ModelRegistry) Models() []string {
 // field is informational at runtime; the routing decision is a function
 // of centroids + rankings + registry only.
 type ArtifactMetadata struct {
-	Version           string               `yaml:"version"`
-	Parent            string               `yaml:"parent,omitempty"`
-	Status            string               `yaml:"status,omitempty"`
-	PromotedDate      string               `yaml:"promoted_date,omitempty"`
-	FrozenDate        string               `yaml:"frozen_date,omitempty"`
-	Embedder          ArtifactEmbedder     `yaml:"embedder"`
-	Training          ArtifactTraining     `yaml:"training"`
-	DeployedProviders []string             `yaml:"deployed_providers,omitempty"`
-	DeployedModels    []string             `yaml:"deployed_models,omitempty"`
-	CostPer1KInputUSD map[string]float64   `yaml:"cost_per_1k_input_usd,omitempty"`
-	Changelog         string               `yaml:"changelog,omitempty"`
+	Version           string             `yaml:"version"`
+	Parent            string             `yaml:"parent,omitempty"`
+	Status            string             `yaml:"status,omitempty"`
+	PromotedDate      string             `yaml:"promoted_date,omitempty"`
+	FrozenDate        string             `yaml:"frozen_date,omitempty"`
+	Embedder          ArtifactEmbedder   `yaml:"embedder"`
+	Training          ArtifactTraining   `yaml:"training"`
+	DeployedProviders []string           `yaml:"deployed_providers,omitempty"`
+	DeployedModels    []string           `yaml:"deployed_models,omitempty"`
+	CostPer1KInputUSD map[string]float64 `yaml:"cost_per_1k_input_usd,omitempty"`
+	Changelog         string             `yaml:"changelog,omitempty"`
 	// CacheConfig is optional. Absence means "use the runtime default
 	// threshold" (a single global value applied to every cluster).
 	// Each artifact version may tune thresholds independently — a

--- a/internal/router/cluster/artifacts.go
+++ b/internal/router/cluster/artifacts.go
@@ -151,17 +151,38 @@ func (r *ModelRegistry) Models() []string {
 // field is informational at runtime; the routing decision is a function
 // of centroids + rankings + registry only.
 type ArtifactMetadata struct {
-	Version           string             `yaml:"version"`
-	Parent            string             `yaml:"parent,omitempty"`
-	Status            string             `yaml:"status,omitempty"`
-	PromotedDate      string             `yaml:"promoted_date,omitempty"`
-	FrozenDate        string             `yaml:"frozen_date,omitempty"`
-	Embedder          ArtifactEmbedder   `yaml:"embedder"`
-	Training          ArtifactTraining   `yaml:"training"`
-	DeployedProviders []string           `yaml:"deployed_providers,omitempty"`
-	DeployedModels    []string           `yaml:"deployed_models,omitempty"`
-	CostPer1KInputUSD map[string]float64 `yaml:"cost_per_1k_input_usd,omitempty"`
-	Changelog         string             `yaml:"changelog,omitempty"`
+	Version           string               `yaml:"version"`
+	Parent            string               `yaml:"parent,omitempty"`
+	Status            string               `yaml:"status,omitempty"`
+	PromotedDate      string               `yaml:"promoted_date,omitempty"`
+	FrozenDate        string               `yaml:"frozen_date,omitempty"`
+	Embedder          ArtifactEmbedder     `yaml:"embedder"`
+	Training          ArtifactTraining     `yaml:"training"`
+	DeployedProviders []string             `yaml:"deployed_providers,omitempty"`
+	DeployedModels    []string             `yaml:"deployed_models,omitempty"`
+	CostPer1KInputUSD map[string]float64   `yaml:"cost_per_1k_input_usd,omitempty"`
+	Changelog         string               `yaml:"changelog,omitempty"`
+	// CacheConfig is optional. Absence means "use the runtime default
+	// threshold" (a single global value applied to every cluster).
+	// Each artifact version may tune thresholds independently — a
+	// version with looser cluster geometry can ship lower thresholds
+	// without affecting other versions.
+	CacheConfig *ArtifactCacheConfig `yaml:"cache_config,omitempty"`
+}
+
+// ArtifactCacheConfig carries the per-version semantic-cache knobs the
+// runtime needs at boot. Not load-bearing for routing itself; consumed
+// only by the cache subsystem when enabled.
+type ArtifactCacheConfig struct {
+	// DefaultThreshold is the cosine-similarity floor below which a
+	// candidate cache entry is rejected, applied to every cluster
+	// without an explicit override. 0 means "fall back to the
+	// runtime's compiled-in default".
+	DefaultThreshold float32 `yaml:"default_threshold,omitempty"`
+	// PerClusterThreshold overrides DefaultThreshold for individual
+	// cluster IDs. Sparse: only list the outliers. Map keys are
+	// cluster ids; values are cosine thresholds in [0, 1].
+	PerClusterThreshold map[int]float32 `yaml:"per_cluster_threshold,omitempty"`
 }
 
 type ArtifactEmbedder struct {

--- a/internal/router/cluster/scorer.go
+++ b/internal/router/cluster/scorer.go
@@ -41,11 +41,35 @@ type Scorer struct {
 	candidates []DeployedEntry
 	models     []string
 	fallback   router.Router
+	// metadata carries the parsed metadata.yaml for this version. May
+	// be nil when the bundle had no metadata.yaml. Currently used only
+	// by the semantic cache (CacheThresholds()).
+	metadata *ArtifactMetadata
 }
 
 // Version returns the artifact version (e.g. "v0.2") for logging and
 // /health-style endpoints.
 func (s *Scorer) Version() string { return s.version }
+
+// CacheThresholds returns the per-version semantic-cache thresholds
+// parsed from the bundle's metadata.yaml `cache_config` block. The
+// returned (perCluster, defaultThreshold) pair drives the cache's
+// per-cluster threshold lookup. defaultThreshold is 0 when the bundle
+// has no cache_config or its DefaultThreshold field is unset; callers
+// substitute their own runtime default in that case.
+func (s *Scorer) CacheThresholds() (perCluster map[int]float32, defaultThreshold float32) {
+	if s.metadata == nil || s.metadata.CacheConfig == nil {
+		return nil, 0
+	}
+	cfg := s.metadata.CacheConfig
+	if len(cfg.PerClusterThreshold) > 0 {
+		perCluster = make(map[int]float32, len(cfg.PerClusterThreshold))
+		for k, v := range cfg.PerClusterThreshold {
+			perCluster[k] = v
+		}
+	}
+	return perCluster, cfg.DefaultThreshold
+}
 
 // NewScorer wires a Scorer from a pre-loaded artifact Bundle. Entries whose
 // provider is not in availableProviders are filtered out of the candidate set.
@@ -129,6 +153,7 @@ func NewScorer(bundle *Bundle, cfg Config, embed Embedder, fallback router.Route
 		candidates: candidates,
 		models:     models,
 		fallback:   fallback,
+		metadata:   bundle.Metadata,
 	}, nil
 }
 
@@ -247,6 +272,14 @@ func (s *Scorer) Route(ctx context.Context, req router.Request) (router.Decision
 		return s.fallback.Route(ctx, req)
 	}
 
+	// Hand off the embedding + top-p clusters so downstream consumers
+	// (semantic cache) can reuse them without re-embedding. Both slices
+	// are short-lived inside this Route call; copy into heap-allocated
+	// metadata slices that survive the return.
+	embedCopy := make([]float32, len(vec))
+	copy(embedCopy, vec)
+	clustersCopy := make([]int, len(topClusters))
+	copy(clustersCopy, topClusters)
 	decision := router.Decision{
 		Provider: chosen.Provider,
 		Model:    chosen.Model,
@@ -254,6 +287,10 @@ func (s *Scorer) Route(ctx context.Context, req router.Request) (router.Decision
 			"cluster:%s top_p=%s model=%s provider=%s",
 			s.version, clusterIDsString(topClusters), chosen.Model, chosen.Provider,
 		),
+		Metadata: &router.RoutingMetadata{
+			Embedding:  embedCopy,
+			ClusterIDs: clustersCopy,
+		},
 	}
 	log.Info(
 		"Cluster routing decision",

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -18,6 +18,26 @@ type Decision struct {
 	Provider string
 	Model    string
 	Reason   string
+	// Metadata carries optional per-decision context populated by
+	// content-aware routers (cluster scorer). Nil for routers that
+	// don't compute it (heuristic, evalswitch passthrough); downstream
+	// consumers (semantic cache, observability) must nil-check before
+	// dereferencing.
+	Metadata *RoutingMetadata
+}
+
+// RoutingMetadata is populated by cluster-based routers so downstream
+// components can reuse the embedding + cluster context without
+// recomputing it. Always nil-check before reading.
+type RoutingMetadata struct {
+	// Embedding is the L2-normalized prompt vector used for cluster
+	// selection. Length matches the artifact's embed_dim (768 today).
+	Embedding []float32
+	// ClusterIDs are the top-p nearest cluster ids the scorer summed
+	// over. ClusterIDs[0] is not necessarily the closest centroid:
+	// the scorer sorts them ascending for log determinism, so callers
+	// that care about "closest centroid" should not assume order.
+	ClusterIDs []int
 }
 
 type Router interface {


### PR DESCRIPTION
## Summary

- New `internal/router/cache/` package: cluster-bucketed brute-force semantic cache, per-(installation, format, clusterID) LRU isolation, TTL-based eviction, configurable per-cluster cosine thresholds via `metadata.yaml`'s new optional `cache_config` block.
- `router.Decision` gains optional `*RoutingMetadata{Embedding, ClusterIDs}`; cluster scorer populates it. Heuristic decisions remain `Metadata: nil` and skip the cache.
- Proxy service does Lookup → on hit, replay captured wire-format bytes (`x-router-cache: hit`); on miss, tee the response via `captureWriter` and Store on 200 OK.
- Wiring honors `ROUTER_SEMANTIC_CACHE_ENABLED` (default true), `ROUTER_SEMANTIC_CACHE_TTL_SEC` (3600), `ROUTER_SEMANTIC_CACHE_BUCKET` (1024). Auto-disabled when the cluster router isn't active.

## Scope (v1)

- Non-streaming only; `stream: true` bypasses
- Per-installation (`externalID`) isolation
- In-memory per-pod, no Redis
- Cluster-routed decisions only (heuristic has no embedding to key on)

## Out of scope (follow-ups)

- Streaming buffer-on-miss replay
- HNSW (cluster-bucketed scan handles 10K entries in <5ms)
- Cross-installation sharing, distributed cache

## Test plan

- [x] `go test -tags no_onnx ./...` — all packages pass; 11 cache unit tests + 5 proxy integration tests
- [x] Local curl smoke confirmed:
  - Cold call: 2.4s, full provider round-trip
  - Warm call: 8ms, `x-router-cache: hit`
  - Near-paraphrase: 8ms, hit (cosine ≥ 0.95)
  - `stream: true`: 2.2s, bypasses cache as designed
- [ ] RouterArena `full` smoke (5–15% expected hit rate from designed near-duplicates)

🤖 Generated with [Claude Code](https://claude.com/claude-code)