### PR TITLE
feat: capture client identity in OTEL spans and decision log

### DIFF
--- a/internal/api/anthropic/messages.go
+++ b/internal/api/anthropic/messages.go
@@ -4,6 +4,7 @@
 package anthropic
 
 import (
+	"context"
 	"errors"
 	"io"
 	"net/http"
@@ -16,6 +17,7 @@ import (
 	"workweave/router/internal/translate"
 
 	"github.com/gin-gonic/gin"
+	"github.com/tidwall/gjson"
 )
 
 var writerTraceEnabled = os.Getenv("ROUTER_DEBUG_WRITER_TRACE") == "true"
@@ -62,6 +64,9 @@ func MessagesHandler(svc *proxy.Service) gin.HandlerFunc {
 			return
 		}
 
+		ctx := stashClientIdentity(c.Request.Context(), c.Request.Header, body)
+		c.Request = c.Request.WithContext(ctx)
+
 		var w http.ResponseWriter = c.Writer
 		if writerTraceEnabled {
 			w = &tracingWriter{ResponseWriter: c.Writer}
@@ -92,6 +97,25 @@ func MessagesHandler(svc *proxy.Service) gin.HandlerFunc {
 			return
 		}
 	}
+}
+
+// stashClientIdentity extracts user identification signals from HTTP headers
+// and the Anthropic metadata.user_id body field, then stashes them on the
+// context for downstream OTEL spans and the decision sidecar log.
+func stashClientIdentity(ctx context.Context, h http.Header, body []byte) context.Context {
+	metaRaw := gjson.GetBytes(body, "metadata.user_id").String()
+	deviceID, accountID, sessionID := proxy.ParseClaudeCodeMetadata(metaRaw)
+	if sessionID == "" {
+		sessionID = h.Get("X-Claude-Code-Session-Id")
+	}
+	id := proxy.ClientIdentity{
+		DeviceID:  deviceID,
+		AccountID: accountID,
+		SessionID: sessionID,
+		UserAgent: h.Get("User-Agent"),
+		ClientApp: h.Get("X-App"),
+	}
+	return context.WithValue(ctx, proxy.ClientIdentityContextKey{}, id)
 }
 
 func writeAnthropicError(c *gin.Context, status int, errType, message string) {

--- a/internal/api/openai/completions.go
+++ b/internal/api/openai/completions.go
@@ -2,6 +2,7 @@
 package openai
 
 import (
+	"context"
 	"errors"
 	"io"
 	"net/http"
@@ -31,6 +32,9 @@ func ChatCompletionHandler(svc *proxy.Service) gin.HandlerFunc {
 			writeOpenAIError(c, http.StatusRequestEntityTooLarge, "invalid_request_error", "request body too large")
 			return
 		}
+
+		ctx := stashClientIdentity(c.Request.Context(), c.Request.Header)
+		c.Request = c.Request.WithContext(ctx)
 
 		if err := svc.ProxyOpenAIChatCompletion(c.Request.Context(), body, c.Writer, c.Request); err != nil {
 			var statusErr *providers.UpstreamStatusError
@@ -62,6 +66,18 @@ func ChatCompletionHandler(svc *proxy.Service) gin.HandlerFunc {
 			return
 		}
 	}
+}
+
+// stashClientIdentity extracts user identification signals from HTTP headers
+// and stashes them on the context. OpenAI-format requests don't carry the
+// Anthropic metadata.user_id body field, so only headers are inspected.
+func stashClientIdentity(ctx context.Context, h http.Header) context.Context {
+	id := proxy.ClientIdentity{
+		SessionID: h.Get("X-Claude-Code-Session-Id"),
+		UserAgent: h.Get("User-Agent"),
+		ClientApp: h.Get("X-App"),
+	}
+	return context.WithValue(ctx, proxy.ClientIdentityContextKey{}, id)
 }
 
 func writeOpenAIError(c *gin.Context, status int, errType, message string) {

--- a/internal/proxy/client_identity.go
+++ b/internal/proxy/client_identity.go
@@ -1,0 +1,51 @@
+package proxy
+
+import (
+	"context"
+	"encoding/json"
+)
+
+// ClientIdentity holds per-request user identification signals extracted from
+// inbound headers and the Anthropic metadata.user_id body field. Claude Code
+// populates all three IDs; other clients may populate a subset.
+type ClientIdentity struct {
+	DeviceID  string
+	AccountID string
+	SessionID string
+	UserAgent string
+	ClientApp string
+}
+
+// ClientIdentityContextKey is the request-context key for client identity.
+// The handler layer writes it; the proxy service reads it for OTEL spans
+// and the decision sidecar log.
+type ClientIdentityContextKey struct{}
+
+// ClientIdentityFrom reads the ClientIdentity stashed on ctx by the handler.
+// Returns a zero-value identity when absent.
+func ClientIdentityFrom(ctx context.Context) ClientIdentity {
+	id, _ := ctx.Value(ClientIdentityContextKey{}).(ClientIdentity)
+	return id
+}
+
+// claudeCodeMetadata mirrors the JSON structure Claude Code encodes into the
+// Anthropic metadata.user_id string field.
+type claudeCodeMetadata struct {
+	DeviceID  string `json:"device_id"`
+	AccountID string `json:"account_uuid"`
+	SessionID string `json:"session_id"`
+}
+
+// ParseClaudeCodeMetadata extracts device_id, account_uuid, and session_id
+// from the JSON string Claude Code packs into metadata.user_id. Returns
+// zero-value fields on any parse failure (best-effort, not request-blocking).
+func ParseClaudeCodeMetadata(raw string) (deviceID, accountID, sessionID string) {
+	if raw == "" {
+		return "", "", ""
+	}
+	var meta claudeCodeMetadata
+	if err := json.Unmarshal([]byte(raw), &meta); err != nil {
+		return "", "", ""
+	}
+	return meta.DeviceID, meta.AccountID, meta.SessionID
+}

--- a/internal/proxy/decision_log.go
+++ b/internal/proxy/decision_log.go
@@ -33,6 +33,8 @@ type DecisionLogEntry struct {
 	DecisionModel    string `json:"decision_model"`
 	DecisionReason   string `json:"decision_reason"`
 	DecisionProvider string `json:"decision_provider"`
+	DeviceID         string `json:"device_id,omitempty"`
+	SessionID        string `json:"session_id,omitempty"`
 }
 
 // NewDecisionLog returns a *DecisionLog when path is non-empty (and the

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -225,6 +225,7 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 
 	apiKeyID, _ := ctx.Value(APIKeyIDContextKey{}).(string)
 	externalID, _ := ctx.Value(ExternalIDContextKey{}).(string)
+	clientID := ClientIdentityFrom(ctx)
 	bypassSticky := hasEvalOverrideHeader(r)
 	var (
 		decision   router.Decision
@@ -298,6 +299,11 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 		Attrs: map[string]any{
 			"request_id":                      requestID,
 			"external_id":                     externalID,
+			"client.device_id":                clientID.DeviceID,
+			"client.account_id":               clientID.AccountID,
+			"client.session_id":               clientID.SessionID,
+			"client.user_agent":               clientID.UserAgent,
+			"client.app":                      clientID.ClientApp,
 			"requested.model":                 feats.Model,
 			"decision.model":                  decision.Model,
 			"decision.provider":               decision.Provider,
@@ -391,6 +397,11 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 	upstreamAttrs := map[string]any{
 		"request_id":                requestID,
 		"external_id":               externalID,
+		"client.device_id":          clientID.DeviceID,
+		"client.account_id":         clientID.AccountID,
+		"client.session_id":         clientID.SessionID,
+		"client.user_agent":         clientID.UserAgent,
+		"client.app":                clientID.ClientApp,
 		"usage.input_tokens":        in,
 		"usage.output_tokens":       out,
 		"cost.requested_input_usd":  float64(in) / 1_000_000 * reqPricing.InputUSDPer1M,
@@ -418,6 +429,8 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 			DecisionModel:    decision.Model,
 			DecisionReason:   decision.Reason,
 			DecisionProvider: decision.Provider,
+			DeviceID:         clientID.DeviceID,
+			SessionID:        clientID.SessionID,
 		})
 	}
 
@@ -479,6 +492,7 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 	ctx = buf.WithContext(ctx)
 
 	externalID, _ := ctx.Value(ExternalIDContextKey{}).(string)
+	clientID := ClientIdentityFrom(ctx)
 
 	env, parseErr := translate.ParseOpenAI(body)
 	if parseErr != nil {
@@ -541,6 +555,11 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 		Attrs: map[string]any{
 			"request_id":                      requestID,
 			"external_id":                     externalID,
+			"client.device_id":                clientID.DeviceID,
+			"client.account_id":               clientID.AccountID,
+			"client.session_id":               clientID.SessionID,
+			"client.user_agent":               clientID.UserAgent,
+			"client.app":                      clientID.ClientApp,
 			"requested.model":                 feats.Model,
 			"decision.model":                  decision.Model,
 			"decision.provider":               decision.Provider,
@@ -627,6 +646,11 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 	openaiUpstreamAttrs := map[string]any{
 		"request_id":                requestID,
 		"external_id":               externalID,
+		"client.device_id":          clientID.DeviceID,
+		"client.account_id":         clientID.AccountID,
+		"client.session_id":         clientID.SessionID,
+		"client.user_agent":         clientID.UserAgent,
+		"client.app":                clientID.ClientApp,
 		"usage.input_tokens":        in,
 		"usage.output_tokens":       out,
 		"cost.requested_input_usd":  float64(in) / 1_000_000 * reqPricing.InputUSDPer1M,

--- a/internal/translate/envelope.go
+++ b/internal/translate/envelope.go
@@ -110,6 +110,13 @@ func (e *RequestEnvelope) Model() string {
 	return gjson.GetBytes(e.body, "model").String()
 }
 
+// MetadataUserID returns the raw metadata.user_id string from the request body.
+// Claude Code packs a JSON-encoded object here containing device_id,
+// account_uuid, and session_id. Returns "" when the field is absent.
+func (e *RequestEnvelope) MetadataUserID() string {
+	return gjson.GetBytes(e.body, "metadata.user_id").String()
+}
+
 // HasTools reports whether the request contains a non-empty tools array.
 func (e *RequestEnvelope) HasTools() bool {
 	r := gjson.GetBytes(e.body, "tools.#")


### PR DESCRIPTION
## Summary

- Extract client identity signals (device_id, account_id, session_id, user_agent, app) from inbound request headers and Anthropic metadata.user_id body field
- Propagate client identity into all OTEL span attributes (router.decision and router.upstream) for both Anthropic and OpenAI proxy paths
- Add device_id and session_id to the decision sidecar log for downstream correlation
- Add MetadataUserID() accessor to RequestEnvelope for future consumers

Port of monorepo commit 71b72355b8.

## Test plan

- [x] `go build -tags no_onnx ./...` — compiles clean
- [x] `go vet -tags no_onnx ./...` — no issues
- [x] `go test -tags no_onnx ./internal/proxy/... ./internal/translate/... ./internal/api/...` — all pass

Made with [Cursor](https://cursor.com)