### PR TITLE
fix: bump cluster EmbedTimeout default 200ms → 1500ms

### DIFF
--- a/internal/router/cluster/scorer.go
+++ b/internal/router/cluster/scorer.go
@@ -25,7 +25,7 @@ func DefaultConfig() Config {
 		TopP:           4,
 		MinPromptChars: 20,
 		MaxPromptChars: 1024,
-		EmbedTimeout:   200 * time.Millisecond,
+		EmbedTimeout:   1500 * time.Millisecond,
 	}
 }
 


### PR DESCRIPTION
## Summary
- The 200ms default `EmbedTimeout` was tight enough that fresh local-dev bootstraps (`make full-setup PLATFORM=cc` on a Mac running ONNX through Docker's linux/arm64 VM) hit it on every request, so the cluster scorer fell open to the heuristic on every prompt and routed long ones to Opus.
- `EmbedTimeout` is a fail-open guardrail, not a latency budget. Bumping the default to 1500ms gives slow local environments enough headroom to actually serve the cluster decision; ops who want it tighter still set `ROUTER_CLUSTER_EMBED_TIMEOUT_MS`.

## Test plan
- [ ] `make full-setup PLATFORM=cc` on a Mac, send a >1k-char prompt, and verify logs show `Cluster routing decision` (not `Cluster scorer: embed failed`).
- [ ] Confirm `ROUTER_CLUSTER_EMBED_TIMEOUT_MS=200` still overrides back to the old behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)