### PR TITLE
fix: use grep -oE in full-setup for BSD/GNU portability

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,7 +96,7 @@ full-setup: ## Bootstrap router: docker compose + seed + optional Claude Code wi
 		done; \
 		echo "==> Seeding a Weave Router key for your installation..."; \
 		SEED_OUTPUT=$$(docker compose run --rm seed 2>&1); \
-		WEAVE_KEY=$$(echo "$$SEED_OUTPUT" | grep -oP "^  rk_[a-zA-Z0-9_-]+$$" | head -1 | xargs); \
+		WEAVE_KEY=$$(echo "$$SEED_OUTPUT" | grep -oE "^  rk_[a-zA-Z0-9_-]+$$" | head -1 | xargs); \
 		if [ -z "$$WEAVE_KEY" ]; then \
 			echo "error: failed to extract router key from seed output."; \
 			echo "$$SEED_OUTPUT"; \


### PR DESCRIPTION
## Summary
- `make full-setup` was failing on macOS with `grep: invalid option -- P` right after a successful seed, because `grep -oP` (Perl regex) is GNU-only — BSD grep on macOS rejects it.
- The pattern `^  rk_[a-zA-Z0-9_-]+$` has no Perl-only features, so `-oE` (POSIX ERE) works on both BSD and GNU grep.

## Repro before fix
On macOS:
```
make full-setup PLATFORM=cc
...
==> Seeding a Weave Router key for your installation...
grep: invalid option -- P
error: failed to extract router key from seed output.
```

## Test plan
- [x] `grep -oE "^  rk_[a-zA-Z0-9_-]+$" <<< "  rk_abcDEF_-123"` returns the key on macOS BSD grep.
- [ ] `make full-setup PLATFORM=cc` runs end-to-end on macOS without the parse failure.
- [ ] Same target still works on Linux (GNU grep handles `-oE` identically).

🤖 Generated with [Claude Code](https://claude.com/claude-code)