### PR TITLE
feat: implement R4 flat OTel attribute builder

### DIFF
--- a/internal/observability/otel/buffer_test.go
+++ b/internal/observability/otel/buffer_test.go
@@ -87,6 +87,7 @@ func makeSpan(name string) otel.Span {
 		Name:  name,
 		Start: now,
 		End:   now.Add(10 * time.Millisecond),
+		Attrs: nil,
 	}
 }
 

--- a/internal/observability/otel/spans.go
+++ b/internal/observability/otel/spans.go
@@ -2,7 +2,6 @@ package otel
 
 import (
 	"crypto/rand"
-	"fmt"
 	"time"
 
 	commonv1 "go.opentelemetry.io/proto/otlp/common/v1"
@@ -16,7 +15,7 @@ type Span struct {
 	Name  string
 	Start time.Time
 	End   time.Time
-	Attrs map[string]any
+	Attrs []*commonv1.KeyValue
 }
 
 func generateTraceID() [16]byte {
@@ -35,6 +34,59 @@ func generateSpanID() [8]byte {
 	return id
 }
 
+// AttrBuilder constructs OTLP KeyValue attributes directly without
+// intermediate map allocations. Not safe for concurrent use.
+type AttrBuilder struct {
+	attrs []*commonv1.KeyValue
+}
+
+// NewAttrBuilder returns a builder pre-sized for cap attributes.
+func NewAttrBuilder(cap int) *AttrBuilder {
+	return &AttrBuilder{attrs: make([]*commonv1.KeyValue, 0, cap)}
+}
+
+// String appends a string attribute.
+func (b *AttrBuilder) String(key, val string) *AttrBuilder {
+	b.attrs = append(b.attrs, &commonv1.KeyValue{
+		Key:   key,
+		Value: &commonv1.AnyValue{Value: &commonv1.AnyValue_StringValue{StringValue: val}},
+	})
+	return b
+}
+
+// Int64 appends an int64 attribute.
+func (b *AttrBuilder) Int64(key string, val int64) *AttrBuilder {
+	b.attrs = append(b.attrs, &commonv1.KeyValue{
+		Key:   key,
+		Value: &commonv1.AnyValue{Value: &commonv1.AnyValue_IntValue{IntValue: val}},
+	})
+	return b
+}
+
+// Float64 appends a float64 attribute.
+func (b *AttrBuilder) Float64(key string, val float64) *AttrBuilder {
+	b.attrs = append(b.attrs, &commonv1.KeyValue{
+		Key:   key,
+		Value: &commonv1.AnyValue{Value: &commonv1.AnyValue_DoubleValue{DoubleValue: val}},
+	})
+	return b
+}
+
+// Bool appends a bool attribute.
+func (b *AttrBuilder) Bool(key string, val bool) *AttrBuilder {
+	b.attrs = append(b.attrs, &commonv1.KeyValue{
+		Key:   key,
+		Value: &commonv1.AnyValue{Value: &commonv1.AnyValue_BoolValue{BoolValue: val}},
+	})
+	return b
+}
+
+// Build returns the accumulated KeyValue slice. The slice is valid until
+// the next method call on the builder.
+func (b *AttrBuilder) Build() []*commonv1.KeyValue {
+	return b.attrs
+}
+
 func spanToProto(s Span, traceID [16]byte) *tracev1.Span {
 	spanID := generateSpanID()
 	return &tracev1.Span{
@@ -43,39 +95,8 @@ func spanToProto(s Span, traceID [16]byte) *tracev1.Span {
 		Name:              s.Name,
 		StartTimeUnixNano: uint64(s.Start.UnixNano()),
 		EndTimeUnixNano:   uint64(s.End.UnixNano()),
-		Attributes:        attrsToKeyValues(s.Attrs),
+		Attributes:        s.Attrs,
 		Kind:              tracev1.Span_SPAN_KIND_INTERNAL,
-	}
-}
-
-func attrsToKeyValues(attrs map[string]any) []*commonv1.KeyValue {
-	if len(attrs) == 0 {
-		return nil
-	}
-	kvs := make([]*commonv1.KeyValue, 0, len(attrs))
-	for k, v := range attrs {
-		kvs = append(kvs, &commonv1.KeyValue{
-			Key:   k,
-			Value: anyToValue(v),
-		})
-	}
-	return kvs
-}
-
-func anyToValue(v any) *commonv1.AnyValue {
-	switch val := v.(type) {
-	case string:
-		return &commonv1.AnyValue{Value: &commonv1.AnyValue_StringValue{StringValue: val}}
-	case int:
-		return &commonv1.AnyValue{Value: &commonv1.AnyValue_IntValue{IntValue: int64(val)}}
-	case int64:
-		return &commonv1.AnyValue{Value: &commonv1.AnyValue_IntValue{IntValue: val}}
-	case float64:
-		return &commonv1.AnyValue{Value: &commonv1.AnyValue_DoubleValue{DoubleValue: val}}
-	case bool:
-		return &commonv1.AnyValue{Value: &commonv1.AnyValue_BoolValue{BoolValue: val}}
-	default:
-		return &commonv1.AnyValue{Value: &commonv1.AnyValue_StringValue{StringValue: fmt.Sprintf("%v", v)}}
 	}
 }
 

--- a/internal/observability/otel/spans_test.go
+++ b/internal/observability/otel/spans_test.go
@@ -1,0 +1,86 @@
+package otel_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	commonv1 "go.opentelemetry.io/proto/otlp/common/v1"
+
+	"workweave/router/internal/observability/otel"
+)
+
+func TestAttrBuilder_BuildsCorrectKeyValues(t *testing.T) {
+	b := otel.NewAttrBuilder(5)
+	attrs := b.
+		String("str_key", "value").
+		Int64("int_key", 42).
+		Float64("float_key", 3.14).
+		Bool("bool_key", true).
+		String("str_key2", "").
+		Build()
+
+	assert.Len(t, attrs, 5)
+
+	assert.Equal(t, "str_key", attrs[0].Key)
+	assert.Equal(t, "value", attrs[0].Value.GetStringValue())
+
+	assert.Equal(t, "int_key", attrs[1].Key)
+	assert.Equal(t, int64(42), attrs[1].Value.GetIntValue())
+
+	assert.Equal(t, "float_key", attrs[2].Key)
+	assert.Equal(t, 3.14, attrs[2].Value.GetDoubleValue())
+
+	assert.Equal(t, "bool_key", attrs[3].Key)
+	assert.True(t, attrs[3].Value.GetBoolValue())
+
+	assert.Equal(t, "str_key2", attrs[4].Key)
+	assert.Equal(t, "", attrs[4].Value.GetStringValue())
+}
+
+func TestAttrBuilder_PreSizedCapacity(t *testing.T) {
+	b := otel.NewAttrBuilder(2)
+	attrs := b.String("a", "1").String("b", "2").Build()
+	assert.Len(t, attrs, 2)
+}
+
+func TestAttrBuilder_ChainableAPI(t *testing.T) {
+	b := otel.NewAttrBuilder(3)
+	result := b.String("a", "1").Int64("b", 2).Bool("c", false)
+	assert.IsType(t, &otel.AttrBuilder{}, result)
+
+	attrs := result.Build()
+	assert.Len(t, attrs, 3)
+}
+
+func TestAttrBuilder_EmptyBuildReturnsEmptySlice(t *testing.T) {
+	b := otel.NewAttrBuilder(0)
+	attrs := b.Build()
+	assert.NotNil(t, attrs)
+	assert.Len(t, attrs, 0)
+}
+
+func TestAttrBuilder_TypedValuesMatchProtobuf(t *testing.T) {
+	b := otel.NewAttrBuilder(4)
+	attrs := b.
+		String("s", "test").
+		Int64("i", -100).
+		Float64("f", -2.5).
+		Bool("b", false).
+		Build()
+
+	stringVal := attrs[0].Value
+	assert.Equal(t, "test", stringVal.GetStringValue())
+	assert.IsType(t, &commonv1.AnyValue_StringValue{}, stringVal.Value)
+
+	intVal := attrs[1].Value
+	assert.Equal(t, int64(-100), intVal.GetIntValue())
+	assert.IsType(t, &commonv1.AnyValue_IntValue{}, intVal.Value)
+
+	floatVal := attrs[2].Value
+	assert.Equal(t, -2.5, floatVal.GetDoubleValue())
+	assert.IsType(t, &commonv1.AnyValue_DoubleValue{}, floatVal.Value)
+
+	boolVal := attrs[3].Value
+	assert.False(t, boolVal.GetBoolValue())
+	assert.IsType(t, &commonv1.AnyValue_BoolValue{}, boolVal.Value)
+}

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -266,16 +266,18 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 		if resp, hit := s.semanticCache.Lookup(externalID, cache.FormatAnthropic, decision.Metadata.Embedding, decision.Metadata.ClusterIDs); hit {
 			s.writeCachedResponse(w, resp, decision)
 			otel.Record(ctx, otel.Span{
-				Name: "router.cache_hit", Start: requestStart, End: time.Now(),
-				Attrs: map[string]any{
-					"request_id":        requestID,
-					"external_id":       externalID,
-					"decision.model":    decision.Model,
-					"decision.provider": decision.Provider,
-					"cache.hit":         true,
-					"cache.format":      string(cache.FormatAnthropic),
-					"latency.total_ms":  time.Since(requestStart).Milliseconds(),
-				},
+				Name:  "router.cache_hit",
+				Start: requestStart,
+				End:   time.Now(),
+				Attrs: otel.NewAttrBuilder(7).
+					String("request_id", requestID).
+					String("external_id", externalID).
+					String("decision.model", decision.Model).
+					String("decision.provider", decision.Provider).
+					Bool("cache.hit", true).
+					String("cache.format", string(cache.FormatAnthropic)).
+					Int64("latency.total_ms", time.Since(requestStart).Milliseconds()).
+					Build(),
 			})
 			otel.Flush(ctx)
 			log.Info("ProxyMessages cache hit", "requested_model", feats.Model, "decision_model", decision.Model, "decision_provider", decision.Provider, "external_id", externalID, "total_ms", time.Since(requestStart).Milliseconds())
@@ -295,28 +297,30 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 	reqPricing := otel.Lookup(feats.Model)
 	actPricing := otel.Lookup(decision.Model)
 	otel.Record(ctx, otel.Span{
-		Name: "router.decision", Start: requestStart, End: time.Now(),
-		Attrs: map[string]any{
-			"request_id":                      requestID,
-			"external_id":                     externalID,
-			"client.device_id":                clientID.DeviceID,
-			"client.account_id":               clientID.AccountID,
-			"client.session_id":               clientID.SessionID,
-			"client.user_agent":               clientID.UserAgent,
-			"client.app":                      clientID.ClientApp,
-			"requested.model":                 feats.Model,
-			"decision.model":                  decision.Model,
-			"decision.provider":               decision.Provider,
-			"decision.reason":                 decision.Reason,
-			"routing.sticky_hit":              stickyHit,
-			"routing.embed_input":             embedInput,
-			"routing.estimated_input_tokens":  feats.Tokens,
-			"pricing.requested_input_per_1m":  reqPricing.InputUSDPer1M,
-			"pricing.requested_output_per_1m": reqPricing.OutputUSDPer1M,
-			"pricing.actual_input_per_1m":     actPricing.InputUSDPer1M,
-			"pricing.actual_output_per_1m":    actPricing.OutputUSDPer1M,
-			"latency.route_ms":                routeMs,
-		},
+		Name:  "router.decision",
+		Start: requestStart,
+		End:   time.Now(),
+		Attrs: otel.NewAttrBuilder(19).
+			String("request_id", requestID).
+			String("external_id", externalID).
+			String("client.device_id", clientID.DeviceID).
+			String("client.account_id", clientID.AccountID).
+			String("client.session_id", clientID.SessionID).
+			String("client.user_agent", clientID.UserAgent).
+			String("client.app", clientID.ClientApp).
+			String("requested.model", feats.Model).
+			String("decision.model", decision.Model).
+			String("decision.provider", decision.Provider).
+			String("decision.reason", decision.Reason).
+			Bool("routing.sticky_hit", stickyHit).
+			String("routing.embed_input", embedInput).
+			Int64("routing.estimated_input_tokens", int64(feats.Tokens)).
+			Float64("pricing.requested_input_per_1m", reqPricing.InputUSDPer1M).
+			Float64("pricing.requested_output_per_1m", reqPricing.OutputUSDPer1M).
+			Float64("pricing.actual_input_per_1m", actPricing.InputUSDPer1M).
+			Float64("pricing.actual_output_per_1m", actPricing.OutputUSDPer1M).
+			Int64("latency.route_ms", routeMs).
+			Build(),
 	})
 	otel.Flush(ctx)
 
@@ -394,31 +398,30 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 	proxyMs := time.Since(proxyStart).Milliseconds()
 
 	in, out := extractor.Tokens()
-	upstreamAttrs := map[string]any{
-		"request_id":                requestID,
-		"external_id":               externalID,
-		"client.device_id":          clientID.DeviceID,
-		"client.account_id":         clientID.AccountID,
-		"client.session_id":         clientID.SessionID,
-		"client.user_agent":         clientID.UserAgent,
-		"client.app":                clientID.ClientApp,
-		"usage.input_tokens":        in,
-		"usage.output_tokens":       out,
-		"cost.requested_input_usd":  float64(in) / 1_000_000 * reqPricing.InputUSDPer1M,
-		"cost.requested_output_usd": float64(out) / 1_000_000 * reqPricing.OutputUSDPer1M,
-		"cost.actual_input_usd":     float64(in) / 1_000_000 * actPricing.InputUSDPer1M,
-		"cost.actual_output_usd":    float64(out) / 1_000_000 * actPricing.OutputUSDPer1M,
-		"latency.upstream_ms":       proxyMs,
-		"latency.total_ms":          time.Since(requestStart).Milliseconds(),
-		"upstream.status_code":      upstreamStatus(proxyErr),
-		"routing.cross_format":      crossFormat,
-	}
-	for k, v := range timingAttrs(ctx) {
-		upstreamAttrs[k] = v
-	}
+	upstreamBuilder := otel.NewAttrBuilder(24).
+		String("request_id", requestID).
+		String("external_id", externalID).
+		String("client.device_id", clientID.DeviceID).
+		String("client.account_id", clientID.AccountID).
+		String("client.session_id", clientID.SessionID).
+		String("client.user_agent", clientID.UserAgent).
+		String("client.app", clientID.ClientApp).
+		Int64("usage.input_tokens", int64(in)).
+		Int64("usage.output_tokens", int64(out)).
+		Float64("cost.requested_input_usd", float64(in)/1_000_000*reqPricing.InputUSDPer1M).
+		Float64("cost.requested_output_usd", float64(out)/1_000_000*reqPricing.OutputUSDPer1M).
+		Float64("cost.actual_input_usd", float64(in)/1_000_000*actPricing.InputUSDPer1M).
+		Float64("cost.actual_output_usd", float64(out)/1_000_000*actPricing.OutputUSDPer1M).
+		Int64("latency.upstream_ms", proxyMs).
+		Int64("latency.total_ms", time.Since(requestStart).Milliseconds()).
+		Int64("upstream.status_code", int64(upstreamStatus(proxyErr))).
+		Bool("routing.cross_format", crossFormat)
+	addTimingAttrs(ctx, upstreamBuilder)
 	otel.Record(ctx, otel.Span{
-		Name: "router.upstream", Start: proxyStart, End: time.Now(),
-		Attrs: upstreamAttrs,
+		Name:  "router.upstream",
+		Start: proxyStart,
+		End:   time.Now(),
+		Attrs: upstreamBuilder.Build(),
 	})
 	otel.Flush(ctx)
 
@@ -448,11 +451,13 @@ func hasEvalOverrideHeader(r *http.Request) bool {
 		r.Header.Get("x-weave-embed-last-user-message") != ""
 }
 
-// timingAttrs returns derived latency attributes from the request Timing, or nil if absent.
-func timingAttrs(ctx context.Context) map[string]any {
+// addTimingAttrs appends derived latency attributes from the request Timing
+// to the builder. No-op when no Timing is attached (middleware not wired or
+// OTel disabled).
+func addTimingAttrs(ctx context.Context, b *otel.AttrBuilder) {
 	t := otel.TimingFrom(ctx)
 	if t == nil {
-		return nil
+		return
 	}
 	upstreamTotal := t.Ms(&t.UpstreamRequestNanos, &t.UpstreamEOFNanos)
 	fullE2E := t.MsSince(&t.EntryNanos)
@@ -462,15 +467,13 @@ func timingAttrs(ctx context.Context) map[string]any {
 		overhead = fullE2E - upstreamTotal
 	}
 
-	return map[string]any{
-		"latency.full_e2e_ms":            fullE2E,
-		"latency.preupstream_ms":         t.Ms(&t.EntryNanos, &t.UpstreamRequestNanos),
-		"latency.upstream_headers_ms":    t.Ms(&t.UpstreamRequestNanos, &t.UpstreamHeadersNanos),
-		"latency.upstream_first_byte_ms": t.Ms(&t.UpstreamRequestNanos, &t.UpstreamFirstByteNanos),
-		"latency.upstream_total_ms":      upstreamTotal,
-		"latency.postupstream_ms":        t.MsSince(&t.UpstreamEOFNanos),
-		"latency.router_overhead_ms":     overhead,
-	}
+	b.Int64("latency.full_e2e_ms", fullE2E).
+		Int64("latency.preupstream_ms", t.Ms(&t.EntryNanos, &t.UpstreamRequestNanos)).
+		Int64("latency.upstream_headers_ms", t.Ms(&t.UpstreamRequestNanos, &t.UpstreamHeadersNanos)).
+		Int64("latency.upstream_first_byte_ms", t.Ms(&t.UpstreamRequestNanos, &t.UpstreamFirstByteNanos)).
+		Int64("latency.upstream_total_ms", upstreamTotal).
+		Int64("latency.postupstream_ms", t.MsSince(&t.UpstreamEOFNanos)).
+		Int64("latency.router_overhead_ms", overhead)
 }
 
 // upstreamStatus extracts the HTTP status from an UpstreamStatusError, or 0.
@@ -522,16 +525,18 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 		if resp, hit := s.semanticCache.Lookup(externalID, cache.FormatOpenAI, decision.Metadata.Embedding, decision.Metadata.ClusterIDs); hit {
 			s.writeCachedResponse(w, resp, decision)
 			otel.Record(ctx, otel.Span{
-				Name: "router.cache_hit", Start: requestStart, End: time.Now(),
-				Attrs: map[string]any{
-					"request_id":        requestID,
-					"external_id":       externalID,
-					"decision.model":    decision.Model,
-					"decision.provider": decision.Provider,
-					"cache.hit":         true,
-					"cache.format":      string(cache.FormatOpenAI),
-					"latency.total_ms":  time.Since(requestStart).Milliseconds(),
-				},
+				Name:  "router.cache_hit",
+				Start: requestStart,
+				End:   time.Now(),
+				Attrs: otel.NewAttrBuilder(7).
+					String("request_id", requestID).
+					String("external_id", externalID).
+					String("decision.model", decision.Model).
+					String("decision.provider", decision.Provider).
+					Bool("cache.hit", true).
+					String("cache.format", string(cache.FormatOpenAI)).
+					Int64("latency.total_ms", time.Since(requestStart).Milliseconds()).
+					Build(),
 			})
 			otel.Flush(ctx)
 			log.Info("ProxyOpenAIChatCompletion cache hit", "requested_model", feats.Model, "decision_model", decision.Model, "decision_provider", decision.Provider, "external_id", externalID, "total_ms", time.Since(requestStart).Milliseconds())
@@ -551,26 +556,28 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 	reqPricing := otel.Lookup(feats.Model)
 	actPricing := otel.Lookup(decision.Model)
 	otel.Record(ctx, otel.Span{
-		Name: "router.decision", Start: requestStart, End: time.Now(),
-		Attrs: map[string]any{
-			"request_id":                      requestID,
-			"external_id":                     externalID,
-			"client.device_id":                clientID.DeviceID,
-			"client.account_id":               clientID.AccountID,
-			"client.session_id":               clientID.SessionID,
-			"client.user_agent":               clientID.UserAgent,
-			"client.app":                      clientID.ClientApp,
-			"requested.model":                 feats.Model,
-			"decision.model":                  decision.Model,
-			"decision.provider":               decision.Provider,
-			"decision.reason":                 decision.Reason,
-			"routing.estimated_input_tokens":  feats.Tokens,
-			"pricing.requested_input_per_1m":  reqPricing.InputUSDPer1M,
-			"pricing.requested_output_per_1m": reqPricing.OutputUSDPer1M,
-			"pricing.actual_input_per_1m":     actPricing.InputUSDPer1M,
-			"pricing.actual_output_per_1m":    actPricing.OutputUSDPer1M,
-			"latency.route_ms":                routeMs,
-		},
+		Name:  "router.decision",
+		Start: requestStart,
+		End:   time.Now(),
+		Attrs: otel.NewAttrBuilder(17).
+			String("request_id", requestID).
+			String("external_id", externalID).
+			String("client.device_id", clientID.DeviceID).
+			String("client.account_id", clientID.AccountID).
+			String("client.session_id", clientID.SessionID).
+			String("client.user_agent", clientID.UserAgent).
+			String("client.app", clientID.ClientApp).
+			String("requested.model", feats.Model).
+			String("decision.model", decision.Model).
+			String("decision.provider", decision.Provider).
+			String("decision.reason", decision.Reason).
+			Int64("routing.estimated_input_tokens", int64(feats.Tokens)).
+			Float64("pricing.requested_input_per_1m", reqPricing.InputUSDPer1M).
+			Float64("pricing.requested_output_per_1m", reqPricing.OutputUSDPer1M).
+			Float64("pricing.actual_input_per_1m", actPricing.InputUSDPer1M).
+			Float64("pricing.actual_output_per_1m", actPricing.OutputUSDPer1M).
+			Int64("latency.route_ms", routeMs).
+			Build(),
 	})
 	otel.Flush(ctx)
 
@@ -643,31 +650,30 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 	proxyMs := time.Since(proxyStart).Milliseconds()
 
 	in, out := extractor.Tokens()
-	openaiUpstreamAttrs := map[string]any{
-		"request_id":                requestID,
-		"external_id":               externalID,
-		"client.device_id":          clientID.DeviceID,
-		"client.account_id":         clientID.AccountID,
-		"client.session_id":         clientID.SessionID,
-		"client.user_agent":         clientID.UserAgent,
-		"client.app":                clientID.ClientApp,
-		"usage.input_tokens":        in,
-		"usage.output_tokens":       out,
-		"cost.requested_input_usd":  float64(in) / 1_000_000 * reqPricing.InputUSDPer1M,
-		"cost.requested_output_usd": float64(out) / 1_000_000 * reqPricing.OutputUSDPer1M,
-		"cost.actual_input_usd":     float64(in) / 1_000_000 * actPricing.InputUSDPer1M,
-		"cost.actual_output_usd":    float64(out) / 1_000_000 * actPricing.OutputUSDPer1M,
-		"latency.upstream_ms":       proxyMs,
-		"latency.total_ms":          time.Since(requestStart).Milliseconds(),
-		"upstream.status_code":      upstreamStatus(proxyErr),
-		"routing.cross_format":      crossFormat,
-	}
-	for k, v := range timingAttrs(ctx) {
-		openaiUpstreamAttrs[k] = v
-	}
+	openaiUpstreamBuilder := otel.NewAttrBuilder(24).
+		String("request_id", requestID).
+		String("external_id", externalID).
+		String("client.device_id", clientID.DeviceID).
+		String("client.account_id", clientID.AccountID).
+		String("client.session_id", clientID.SessionID).
+		String("client.user_agent", clientID.UserAgent).
+		String("client.app", clientID.ClientApp).
+		Int64("usage.input_tokens", int64(in)).
+		Int64("usage.output_tokens", int64(out)).
+		Float64("cost.requested_input_usd", float64(in)/1_000_000*reqPricing.InputUSDPer1M).
+		Float64("cost.requested_output_usd", float64(out)/1_000_000*reqPricing.OutputUSDPer1M).
+		Float64("cost.actual_input_usd", float64(in)/1_000_000*actPricing.InputUSDPer1M).
+		Float64("cost.actual_output_usd", float64(out)/1_000_000*actPricing.OutputUSDPer1M).
+		Int64("latency.upstream_ms", proxyMs).
+		Int64("latency.total_ms", time.Since(requestStart).Milliseconds()).
+		Int64("upstream.status_code", int64(upstreamStatus(proxyErr))).
+		Bool("routing.cross_format", crossFormat)
+	addTimingAttrs(ctx, openaiUpstreamBuilder)
 	otel.Record(ctx, otel.Span{
-		Name: "router.upstream", Start: proxyStart, End: time.Now(),
-		Attrs: openaiUpstreamAttrs,
+		Name:  "router.upstream",
+		Start: proxyStart,
+		End:   time.Now(),
+		Attrs: openaiUpstreamBuilder.Build(),
 	})
 	otel.Flush(ctx)
 


### PR DESCRIPTION
## Summary

Implement R4 from the zero-alloc Pareto plan: replace `map[string]any` span
attributes with a flat `AttrBuilder` that constructs protobuf `KeyValue`s
directly, eliminating intermediate map allocations and the double conversion
(map → KeyValue slice → protobuf) on the request path.

## Changes

- `Span.Attrs`: `map[string]any` → `[]*commonv1.KeyValue`
- New `AttrBuilder` with chainable `String` / `Int64` / `Float64` / `Bool` /
  `Build` API in `internal/observability/otel/spans.go`
- Convert all six span sites in `proxy.Service` to use the builder:
  `router.decision`, `router.upstream`, and `router.cache_hit` for both
  `ProxyMessages` and `ProxyOpenAIChatCompletion`
- Replace `timingAttrs()` (returns map) with `addTimingAttrs()` (appends to
  builder) so timing attrs join the per-span builder without an extra map
- Drop the now-unused `attrsToKeyValues` and `anyToValue` conversion helpers

## Performance impact

Eliminates per-request (worst case, OpenAI/Anthropic upstream span path):

- 2 map allocations (decision + upstream spans)
- ~40+ boxed `interface{}` values — values are now type-specialized at the
  call site
- One full pass of `map → []*KeyValue` conversion at flush time

## Test plan

- [x] `go build ./...` — compiles clean
- [x] `go vet ./...` — no issues
- [x] `go test -count=1 ./internal/observability/otel/... ./internal/proxy/...` — all pass
- [x] New `spans_test.go` covers the builder API end-to-end (chainable
  return type, typed protobuf values, pre-sized capacity, empty build)


Made with [Cursor](https://cursor.com)