### PR TITLE
ci: bump router pin via direct gitlink write

### DIFF
--- a/.github/workflows/bump-workweave-pin.yml
+++ b/.github/workflows/bump-workweave-pin.yml
@@ -36,7 +36,6 @@ jobs:
         with:
           repository: workweave/WorkWeave
           token: ${{ secrets.WORKWEAVE_PIN_BUMP_PAT }}
-          submodules: recursive
           fetch-depth: 0
           path: WorkWeave
 
@@ -46,23 +45,20 @@ jobs:
           git config user.name "workweave-bot"
           git config user.email "bot@workweave.ai"
 
-      - name: Bump router submodule
+      - name: Bump router gitlink
         id: bump
         working-directory: WorkWeave
         env:
           NEW_SHA: ${{ github.event.pull_request.merge_commit_sha }}
         run: |
           set -euo pipefail
-          git -C router-internal/router fetch origin "$NEW_SHA"
-          git -C router-internal/router checkout "$NEW_SHA"
-
           SHORT_SHA="${NEW_SHA:0:7}"
           BRANCH="bump-router-${SHORT_SHA}"
           echo "branch=${BRANCH}" >> "$GITHUB_OUTPUT"
           echo "short_sha=${SHORT_SHA}" >> "$GITHUB_OUTPUT"
 
           git checkout -b "$BRANCH"
-          git add router-internal/router
+          git update-index --add --cacheinfo 160000,"$NEW_SHA",router-internal/router
           git commit \
             -m "Bump router pin to ${SHORT_SHA}" \
             -m "Source: ${{ github.event.pull_request.title }}" \


### PR DESCRIPTION
The pin-bump workflow was checking out WorkWeave with `submodules: recursive` and then running `git -C router-internal/router fetch / checkout` before `git add`-ing the gitlink. That made the PAT depend on read access into the submodule's source repo even though the job only ever writes a new gitlink in WorkWeave's index — it never reads or modifies any file inside `router-internal/router/`.

Drop `submodules: recursive` and stage the gitlink directly with `git update-index --add --cacheinfo 160000,<sha>,router-internal/router`. This removes the cross-repo permission dependency and skips a slow clone of the submodule on every run.