### PR TITLE
feat: per-request provider gating in cluster scorer

### DIFF
--- a/internal/api/anthropic/messages.go
+++ b/internal/api/anthropic/messages.go
@@ -93,6 +93,11 @@ func MessagesHandler(svc *proxy.Service) gin.HandlerFunc {
 				writeAnthropicError(c, http.StatusBadRequest, "invalid_request_error", "request body must be a JSON object")
 				return
 			}
+			if errors.Is(err, cluster.ErrNoEligibleProvider) {
+				log.Warn("No eligible provider for request", "err", err)
+				writeAnthropicError(c, http.StatusBadRequest, "invalid_request_error", "no provider keys available for any deployed model: register a BYOK key or supply a provider Authorization header")
+				return
+			}
 			if errors.Is(err, cluster.ErrClusterUnavailable) {
 				log.Error("Cluster routing unavailable", "err", err)
 				c.Header("Retry-After", "1")

--- a/internal/api/openai/completions.go
+++ b/internal/api/openai/completions.go
@@ -62,6 +62,11 @@ func ChatCompletionHandler(svc *proxy.Service) gin.HandlerFunc {
 				writeOpenAIError(c, http.StatusBadRequest, "invalid_request_error", "request body must be a JSON object")
 				return
 			}
+			if errors.Is(err, cluster.ErrNoEligibleProvider) {
+				log.Warn("No eligible provider for request", "err", err)
+				writeOpenAIError(c, http.StatusBadRequest, "invalid_request_error", "no provider keys available for any deployed model: register a BYOK key or supply a provider Authorization header")
+				return
+			}
 			if errors.Is(err, cluster.ErrClusterUnavailable) {
 				log.Error("Cluster routing unavailable", "err", err)
 				c.Header("Retry-After", "1")

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -261,6 +261,7 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 			EstimatedInputTokens: feats.Tokens,
 			HasTools:             feats.HasTools,
 			PromptText:           promptText,
+			EnabledProviders:     s.enabledProvidersForRequest(ctx, r.Header),
 		})
 		if err != nil {
 			log.Error("Routing failed", "err", err, "route_ms", time.Since(routeStart).Milliseconds(), "requested_model", feats.Model, "estimated_input_tokens", feats.Tokens)
@@ -484,6 +485,32 @@ func externalKeysFromContext(ctx context.Context) []*auth.ExternalAPIKey {
 	return keys
 }
 
+// enabledProvidersForRequest returns the set of provider names whose
+// credentials are resolvable for this request: any provider the router
+// has a boot-time env key for, any provider with a BYOK key on the
+// installation, and any provider whose client-supplied header carries a
+// non-router bearer/x-api-key. The cluster scorer intersects this set
+// with its boot-time candidates so argmax never picks a model the
+// upstream call would 401 on.
+func (s *Service) enabledProvidersForRequest(ctx context.Context, headers http.Header) map[string]struct{} {
+	out := make(map[string]struct{}, len(s.providers))
+	for p := range s.providers {
+		out[p] = struct{}{}
+	}
+	for _, k := range externalKeysFromContext(ctx) {
+		out[k.Provider] = struct{}{}
+	}
+	for _, p := range []string{"anthropic", "openai", "google", "openrouter"} {
+		if _, already := out[p]; already {
+			continue
+		}
+		if ExtractClientCredentials(p, headers) != nil {
+			out[p] = struct{}{}
+		}
+	}
+	return out
+}
+
 // resolveAndInjectCredentials builds a BYOK credentials map from the external
 // keys on ctx, resolves the best credentials for provider, and returns a
 // context with the credentials stashed under CredentialsContextKey. When no
@@ -556,6 +583,7 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 		EstimatedInputTokens: feats.Tokens,
 		HasTools:             feats.HasTools,
 		PromptText:           feats.PromptText,
+		EnabledProviders:     s.enabledProvidersForRequest(ctx, r.Header),
 	})
 	routeMs := time.Since(routeStart).Milliseconds()
 	if err != nil {

--- a/internal/router/cluster/scorer.go
+++ b/internal/router/cluster/scorer.go
@@ -20,6 +20,14 @@ import (
 // regressions in eval and lets quality silently degrade in prod.
 var ErrClusterUnavailable = errors.New("cluster: routing unavailable")
 
+// ErrNoEligibleProvider is returned by Scorer.Route when the per-request
+// EnabledProviders set has no overlap with the scorer's boot-time
+// candidates. Callers map this to HTTP 4xx: the customer's request can't
+// be served because no provider keys are resolvable for any deployed
+// model, and silently routing to an unavailable provider would 401 at
+// the upstream call.
+var ErrNoEligibleProvider = errors.New("cluster: no eligible provider for request")
+
 // Config carries the scorer's runtime knobs.
 type Config struct {
 	TopP           int
@@ -245,16 +253,40 @@ func (s *Scorer) Route(ctx context.Context, req router.Request) (router.Decision
 		return router.Decision{}, fmt.Errorf("embedding dim %d != expected %d: %w", len(vec), s.centroids.Dim, ErrClusterUnavailable)
 	}
 
+	// Per-request provider gating: when the caller has resolved which
+	// providers they have credentials for, restrict argmax to that
+	// subset. This is the runtime complement to NewScorer's boot-time
+	// filterByProviders — boot gating excludes providers the deployment
+	// has no env key for, request gating excludes providers this
+	// installation has no BYOK / client key for.
+	eligibleModels := s.models
+	if req.EnabledProviders != nil {
+		eligibleModels = eligibleModels[:0:0]
+		for _, c := range s.candidates {
+			if _, ok := req.EnabledProviders[c.Provider]; ok {
+				eligibleModels = append(eligibleModels, c.Model)
+			}
+		}
+		if len(eligibleModels) == 0 {
+			log.Warn(
+				"Cluster scorer: no eligible provider for request; returning ErrNoEligibleProvider",
+				"enabled_providers", sortedKeys(req.EnabledProviders),
+				"requested_model", req.RequestedModel,
+			)
+			return router.Decision{}, fmt.Errorf("enabled providers %v have no overlap with deployed candidates: %w", sortedKeys(req.EnabledProviders), ErrNoEligibleProvider)
+		}
+	}
+
 	scoreStart := time.Now()
 	topClusters := topPNearest(vec, s.centroids, s.cfg.TopP)
-	scores := make(map[string]float32, len(s.models))
+	scores := make(map[string]float32, len(eligibleModels))
 	for _, k := range topClusters {
 		row := s.rankings[k]
-		for _, m := range s.models {
+		for _, m := range eligibleModels {
 			scores[m] += row[m]
 		}
 	}
-	chosenModel, chosenScore := argmax(scores, s.models)
+	chosenModel, chosenScore := argmax(scores, eligibleModels)
 	scoreUs := time.Since(scoreStart).Microseconds()
 
 	if chosenModel == "" {

--- a/internal/router/cluster/scorer_test.go
+++ b/internal/router/cluster/scorer_test.go
@@ -465,3 +465,93 @@ func TestArgmax_TiebreakUsesOrderSlice(t *testing.T) {
 	assert.Equal(t, "A", gotA)
 	assert.Equal(t, "B", gotB)
 }
+
+// twoProviderArtifacts builds a 2-cluster fixture with one candidate per
+// provider (anthropic / openai), where the openai model would otherwise
+// outscore the anthropic model on the cluster the prompt aligns to. Used
+// to exercise per-request EnabledProviders gating.
+func twoProviderArtifacts(t *testing.T) (centroidsBlob, rankingsBlob, registryBlob []byte) {
+	t.Helper()
+	dim := EmbedDim
+	c0 := make([]float32, dim)
+	c0[0] = 1
+	c1 := make([]float32, dim)
+	c1[1] = 1
+	full := append(append([]float32{}, c0...), c1...)
+	centroidsBlob = buildCentroidsBlob(t, 2, dim, full)
+
+	rankingsBlob = []byte(`{
+		"rankings": {
+			"0": {"claude-opus-4-7": 0.5, "gpt-5": 0.9},
+			"1": {"claude-opus-4-7": 0.1, "gpt-5": 0.05}
+		}
+	}`)
+	registryBlob = []byte(`{
+		"deployed_models": [
+			{"model": "claude-opus-4-7", "provider": "anthropic", "bench_column": "gpt-5", "proxy": true},
+			{"model": "gpt-5", "provider": "openai", "bench_column": "gpt-5"}
+		]
+	}`)
+	return
+}
+
+func newTwoProviderScorer(t *testing.T, emb Embedder) *Scorer {
+	t.Helper()
+	cb, rb, regb := twoProviderArtifacts(t)
+	bundle := bundleFromBlobs(t, "v-test-2p", cb, rb, regb)
+	available := map[string]struct{}{"anthropic": {}, "openai": {}}
+	s, err := NewScorer(bundle, cfgForTest(), emb, available)
+	require.NoError(t, err)
+	return s
+}
+
+// TestScorer_NilEnabledProvidersPreservesBootBehavior is the regression
+// guard for the gating opt-in: when the proxy passes no per-request
+// provider set, argmax runs unrestricted over the boot-time candidates.
+func TestScorer_NilEnabledProvidersPreservesBootBehavior(t *testing.T) {
+	emb := &fakeEmbedder{vec: makeOpusVec()}
+	s := newTwoProviderScorer(t, emb)
+
+	got, err := s.Route(context.Background(), router.Request{
+		PromptText: strings.Repeat("x", 100),
+	})
+	require.NoError(t, err)
+	// Cluster 0 ranks gpt-5 above opus; without gating, gpt-5 wins.
+	assert.Equal(t, "gpt-5", got.Model)
+	assert.Equal(t, "openai", got.Provider)
+}
+
+// TestScorer_EnabledProvidersGatesArgmax is the load-bearing assertion:
+// even when the unrestricted argmax would pick openai, restricting
+// EnabledProviders to {anthropic} forces argmax onto anthropic candidates.
+func TestScorer_EnabledProvidersGatesArgmax(t *testing.T) {
+	emb := &fakeEmbedder{vec: makeOpusVec()}
+	s := newTwoProviderScorer(t, emb)
+
+	got, err := s.Route(context.Background(), router.Request{
+		PromptText:       strings.Repeat("x", 100),
+		EnabledProviders: map[string]struct{}{"anthropic": {}},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "claude-opus-4-7", got.Model)
+	assert.Equal(t, "anthropic", got.Provider)
+}
+
+// TestScorer_EmptyEnabledProvidersReturnsErrNoEligibleProvider asserts
+// the typed error: an installation with no resolvable provider keys
+// must surface a 4xx-mappable error rather than picking a model the
+// upstream call would 401 on.
+func TestScorer_EmptyEnabledProvidersReturnsErrNoEligibleProvider(t *testing.T) {
+	emb := &fakeEmbedder{vec: makeOpusVec()}
+	s := newTwoProviderScorer(t, emb)
+
+	_, err := s.Route(context.Background(), router.Request{
+		PromptText:       strings.Repeat("x", 100),
+		EnabledProviders: map[string]struct{}{"google": {}},
+	})
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrNoEligibleProvider))
+	// Must NOT also surface as ErrClusterUnavailable; the API layer
+	// maps these two sentinels to different status codes (400 vs 503).
+	assert.False(t, errors.Is(err, ErrClusterUnavailable))
+}

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -12,6 +12,13 @@ type Request struct {
 	// used by content-aware routers (e.g. RouteLLM). Empty for routers
 	// that key only on token count or other features.
 	PromptText string
+	// EnabledProviders is the set of provider names whose credentials are
+	// resolvable for this request — boot-time env keys, BYOK keys on the
+	// installation, or per-request client headers. When non-nil, routers
+	// must restrict argmax to providers in this set so we never return a
+	// decision the upstream call would 401 on. Nil means "no per-request
+	// gating; use whatever the router was constructed with."
+	EnabledProviders map[string]struct{}
 }
 
 type Decision struct {


### PR DESCRIPTION
## Summary

Adds an `EnabledProviders` set to `router.Request` that the cluster scorer intersects with its boot-time candidates before argmax. This is the runtime complement to `NewScorer`'s `filterByProviders`:

- **Boot gating** (existing): excludes providers the deployment has no env key for.
- **Request gating** (this PR): excludes providers this installation has no BYOK / client key for, so the scorer never picks a model the upstream call would 401 on.

## What changed

- `router.Request.EnabledProviders` — nil preserves existing unrestricted behavior; non-nil intersects with candidate providers.
- `cluster.Scorer.Route` applies the intersection just before argmax. Empty intersection returns the new `ErrNoEligibleProvider` sentinel (distinct from `ErrClusterUnavailable`).
- `proxy.Service.enabledProvidersForRequest` builds the set from the union of: boot-registered providers + BYOK external keys + client-supplied `Authorization` / `x-api-key` headers. Threaded into both Route call sites in `ProxyMessages` and `ProxyOpenAIChatCompletion`.
- `/v1/messages` and `/v1/chat/completions` handlers map `ErrNoEligibleProvider` → 400 (vs `ErrClusterUnavailable` → 503) so misconfigured installations get an actionable error rather than an upstream 401.

## Tests

Three new cases in `scorer_test.go`:
- `TestScorer_NilEnabledProvidersPreservesBootBehavior` — nil set preserves unrestricted argmax.
- `TestScorer_EnabledProvidersGatesArgmax` — `{anthropic}` restriction overrides an otherwise-winning openai argmax.
- `TestScorer_EmptyEnabledProvidersReturnsErrNoEligibleProvider` — empty intersection surfaces the typed error and *not* `ErrClusterUnavailable` (the API layer maps them to different status codes).

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./...` green
- [ ] Smoke: `wv mr` boots with subset of provider env keys; request with BYOK installation that only has a subset returns decisions limited to that subset
- [ ] Smoke: request with zero resolvable providers returns 400, not an upstream 401