### PR TITLE
feat(router): turn-type detection + §3.4 compaction/Explore hard pins

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -301,6 +301,14 @@ code comment before creating it.
 
 ### Go style
 
+- **No magic strings for provider names or model names.** Use the named
+  constants from `internal/providers` (`providers.ProviderAnthropic`,
+  `providers.ProviderOpenAI`, `providers.ProviderGoogle`,
+  `providers.ProviderOpenRouter`) everywhere provider names appear as
+  values — map keys, switch cases, `router.Decision.Provider` literals,
+  log fields, test fixtures. For new model name constants, add them to the
+  appropriate package before using them. Bare string literals for these
+  values are a review-blocking issue.
 - Keep files small. Split distinct logic into separate files, especially
   when shared between multiple places.
 - Avoid unnecessary nesting — flatten conditionals with early returns and

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -301,6 +301,14 @@ code comment before creating it.
 
 ### Go style
 
+- **No magic strings for provider names or model names.** Use the named
+  constants from `internal/providers` (`providers.ProviderAnthropic`,
+  `providers.ProviderOpenAI`, `providers.ProviderGoogle`,
+  `providers.ProviderOpenRouter`) everywhere provider names appear as
+  values — map keys, switch cases, `router.Decision.Provider` literals,
+  log fields, test fixtures. For new model name constants, add them to the
+  appropriate package before using them. Bare string literals for these
+  values are a review-blocking issue.
 - Keep files small. Split distinct logic into separate files, especially
   when shared between multiple places.
 - Avoid unnecessary nesting — flatten conditionals with early returns and

--- a/cmd/router/main.go
+++ b/cmd/router/main.go
@@ -191,7 +191,12 @@ func main() {
 		logger.Info("Session pin store enabled (sliding 1h TTL, hourly sweep)")
 	}
 
-	proxySvc := proxy.NewService(rtr, providerMap, emitter, embedLastUser, stickyTTL, decisionLog, semanticCache, pinStore)
+	hardPinExplore := config.GetOr("ROUTER_HARD_PIN_EXPLORE", "false") == "true"
+	if hardPinExplore {
+		logger.Info("Explore sub-agent hard-pin enabled (claude-haiku-4-5)")
+	}
+
+	proxySvc := proxy.NewService(rtr, providerMap, emitter, embedLastUser, stickyTTL, decisionLog, semanticCache, pinStore, hardPinExplore)
 
 	engine := gin.New()
 	engine.UnescapePathValues = true

--- a/cmd/router/main.go
+++ b/cmd/router/main.go
@@ -109,7 +109,7 @@ func main() {
 	// its own key; without it, the client's auth headers (OAuth / x-api-key)
 	// are passed through to api.anthropic.com directly.
 	anthropicKey := config.GetOr("ANTHROPIC_API_KEY", "")
-	providerMap["anthropic"] = anthropic.NewClient(anthropicKey, anthropic.DefaultBaseURL)
+	providerMap[providers.ProviderAnthropic] = anthropic.NewClient(anthropicKey, anthropic.DefaultBaseURL)
 	if anthropicKey != "" {
 		logger.Info("Anthropic provider enabled (router key)", "base_url", anthropic.DefaultBaseURL)
 	} else {
@@ -118,19 +118,19 @@ func main() {
 
 	if openaiKey := config.GetOr("OPENAI_PROVIDER_API_KEY", ""); openaiKey != "" {
 		openaiBaseURL := config.GetOr("OPENAI_PROVIDER_BASE_URL", openaiProvider.DefaultBaseURL)
-		providerMap["openai"] = openaiProvider.NewClient(openaiKey, openaiBaseURL)
+		providerMap[providers.ProviderOpenAI] = openaiProvider.NewClient(openaiKey, openaiBaseURL)
 		logger.Info("OpenAI provider enabled", "base_url", openaiBaseURL)
 	}
 
 	if openRouterKey := config.GetOr("OPENROUTER_API_KEY", ""); openRouterKey != "" {
 		openRouterBaseURL := config.GetOr("OPENROUTER_BASE_URL", openaiCompatProvider.DefaultBaseURL)
-		providerMap["openrouter"] = openaiCompatProvider.NewClient(openRouterKey, openRouterBaseURL)
+		providerMap[providers.ProviderOpenRouter] = openaiCompatProvider.NewClient(openRouterKey, openRouterBaseURL)
 		logger.Info("OpenRouter provider enabled", "base_url", openRouterBaseURL)
 	}
 
 	if googleKey := config.GetOr("GOOGLE_PROVIDER_API_KEY", ""); googleKey != "" {
 		googleBaseURL := config.GetOr("GOOGLE_PROVIDER_BASE_URL", googleProvider.DefaultBaseURL)
-		providerMap["google"] = googleProvider.NewClient(googleKey, googleBaseURL)
+		providerMap[providers.ProviderGoogle] = googleProvider.NewClient(googleKey, googleBaseURL)
 		logger.Info("Google (Gemini) provider enabled", "base_url", googleBaseURL)
 	}
 
@@ -560,34 +560,38 @@ func runSessionPinSweep(ctx context.Context, store sessionpin.Store) {
 	}
 }
 
+// defaultHardPinProvider and defaultHardPinModel are the fallback (provider,
+// model) used by resolveHardPinModel when the cluster bundle can't be loaded.
+const (
+	defaultHardPinProvider = providers.ProviderAnthropic
+	defaultHardPinModel    = "claude-haiku-4-5"
+)
+
 // resolveHardPinModel returns the (provider, model) to use for compaction and
 // Explore hard-pins. Operator override wins; otherwise the cheapest model in
 // the default artifact bundle among available providers is selected.
-// Falls back to ("anthropic", "claude-haiku-4-5") when no bundle is loadable.
+// Falls back to (defaultHardPinProvider, defaultHardPinModel) when no bundle is loadable.
 func resolveHardPinModel(available map[string]struct{}, logger *slog.Logger) (provider, model string) {
-	const defaultProvider = "anthropic"
-	const defaultModel = "claude-haiku-4-5"
-
 	if m := config.GetOr("ROUTER_HARD_PIN_MODEL", ""); m != "" {
-		p := config.GetOr("ROUTER_HARD_PIN_PROVIDER", defaultProvider)
+		p := config.GetOr("ROUTER_HARD_PIN_PROVIDER", defaultHardPinProvider)
 		return p, m
 	}
 
 	reqVersion := config.GetOr("ROUTER_CLUSTER_VERSION", cluster.LatestVersion)
 	defaultVersion, err := cluster.ResolveVersion(reqVersion)
 	if err != nil {
-		logger.Warn("Hard-pin model: could not resolve cluster version; using default", "err", err, "default_model", defaultModel)
-		return defaultProvider, defaultModel
+		logger.Warn("Hard-pin model: could not resolve cluster version; using default", "err", err, "default_model", defaultHardPinModel)
+		return defaultHardPinProvider, defaultHardPinModel
 	}
 	bundle, err := cluster.LoadBundle(defaultVersion)
 	if err != nil {
-		logger.Warn("Hard-pin model: could not load bundle; using default", "err", err, "default_model", defaultModel)
-		return defaultProvider, defaultModel
+		logger.Warn("Hard-pin model: could not load bundle; using default", "err", err, "default_model", defaultHardPinModel)
+		return defaultHardPinProvider, defaultHardPinModel
 	}
 	p, m, ok := cluster.CheapestModel(bundle.Metadata, bundle.Registry, available)
 	if !ok {
-		logger.Warn("Hard-pin model: no cost-annotated model found for available providers; using default", "default_model", defaultModel)
-		return defaultProvider, defaultModel
+		logger.Warn("Hard-pin model: no cost-annotated model found for available providers; using default", "default_model", defaultHardPinModel)
+		return defaultHardPinProvider, defaultHardPinModel
 	}
 	return p, m
 }
@@ -595,13 +599,13 @@ func resolveHardPinModel(available map[string]struct{}, logger *slog.Logger) (pr
 // envVarForProvider returns the env var name for a provider's API key.
 func envVarForProvider(provider string) string {
 	switch provider {
-	case "anthropic":
+	case providers.ProviderAnthropic:
 		return "ANTHROPIC_API_KEY"
-	case "openai":
+	case providers.ProviderOpenAI:
 		return "OPENAI_PROVIDER_API_KEY"
-	case "openrouter":
+	case providers.ProviderOpenRouter:
 		return "OPENROUTER_API_KEY"
-	case "google":
+	case providers.ProviderGoogle:
 		return "GOOGLE_PROVIDER_API_KEY"
 	default:
 		return "<unknown provider " + provider + ">"

--- a/cmd/router/main.go
+++ b/cmd/router/main.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"net/url"
 	"os"
@@ -192,11 +193,13 @@ func main() {
 	}
 
 	hardPinExplore := config.GetOr("ROUTER_HARD_PIN_EXPLORE", "false") == "true"
+	hardPinProvider, hardPinModel := resolveHardPinModel(availableProviders, logger)
 	if hardPinExplore {
-		logger.Info("Explore sub-agent hard-pin enabled (claude-haiku-4-5)")
+		logger.Info("Explore sub-agent hard-pin enabled", "provider", hardPinProvider, "model", hardPinModel)
 	}
+	logger.Info("Hard-pin model resolved", "provider", hardPinProvider, "model", hardPinModel)
 
-	proxySvc := proxy.NewService(rtr, providerMap, emitter, embedLastUser, stickyTTL, decisionLog, semanticCache, pinStore, hardPinExplore)
+	proxySvc := proxy.NewService(rtr, providerMap, emitter, embedLastUser, stickyTTL, decisionLog, semanticCache, pinStore, hardPinExplore, hardPinProvider, hardPinModel)
 
 	engine := gin.New()
 	engine.UnescapePathValues = true
@@ -555,6 +558,38 @@ func runSessionPinSweep(ctx context.Context, store sessionpin.Store) {
 			cancel()
 		}
 	}
+}
+
+// resolveHardPinModel returns the (provider, model) to use for compaction and
+// Explore hard-pins. Operator override wins; otherwise the cheapest model in
+// the default artifact bundle among available providers is selected.
+// Falls back to ("anthropic", "claude-haiku-4-5") when no bundle is loadable.
+func resolveHardPinModel(available map[string]struct{}, logger *slog.Logger) (provider, model string) {
+	const defaultProvider = "anthropic"
+	const defaultModel = "claude-haiku-4-5"
+
+	if m := config.GetOr("ROUTER_HARD_PIN_MODEL", ""); m != "" {
+		p := config.GetOr("ROUTER_HARD_PIN_PROVIDER", defaultProvider)
+		return p, m
+	}
+
+	reqVersion := config.GetOr("ROUTER_CLUSTER_VERSION", cluster.LatestVersion)
+	defaultVersion, err := cluster.ResolveVersion(reqVersion)
+	if err != nil {
+		logger.Warn("Hard-pin model: could not resolve cluster version; using default", "err", err, "default_model", defaultModel)
+		return defaultProvider, defaultModel
+	}
+	bundle, err := cluster.LoadBundle(defaultVersion)
+	if err != nil {
+		logger.Warn("Hard-pin model: could not load bundle; using default", "err", err, "default_model", defaultModel)
+		return defaultProvider, defaultModel
+	}
+	p, m, ok := cluster.CheapestModel(bundle.Metadata, bundle.Registry, available)
+	if !ok {
+		logger.Warn("Hard-pin model: no cost-annotated model found for available providers; using default", "default_model", defaultModel)
+		return defaultProvider, defaultModel
+	}
+	return p, m
 }
 
 // envVarForProvider returns the env var name for a provider's API key.

--- a/internal/observability/otel/usage.go
+++ b/internal/observability/otel/usage.go
@@ -9,6 +9,16 @@ import (
 	"workweave/router/internal/sse"
 )
 
+// providerAnthropic / providerOpenAI / providerGoogle are local mirrors of the
+// providers.Provider* constants. This package is a leaf utility (must not
+// import internal/providers), so we duplicate the short strings rather than
+// introduce a circular import. Keep in sync with internal/providers/provider.go.
+const (
+	providerAnthropic = "anthropic"
+	providerOpenAI    = "openai"
+	providerGoogle    = "google"
+)
+
 // UsageSink receives extracted token usage. Translators call RecordUsage
 // when they encounter usage data in already-parsed events, eliminating
 // the need for a separate parse pass.
@@ -120,9 +130,9 @@ func (u *UsageExtractor) scanBuffer() {
 
 func (u *UsageExtractor) extractFromSSEEvent(eventType []byte, data []byte) {
 	switch u.provider {
-	case "anthropic":
+	case providerAnthropic:
 		u.extractAnthropicSSE(eventType, data)
-	case "openai", "google":
+	case providerOpenAI, providerGoogle:
 		u.extractOpenAISSE(data)
 	}
 }
@@ -133,7 +143,7 @@ func (u *UsageExtractor) extractAnthropicSSE(eventType []byte, data []byte) {
 		return
 	}
 
-	input, output, found := extractUsageGJSON(data, "anthropic")
+	input, output, found := extractUsageGJSON(data, providerAnthropic)
 	if !found {
 		return
 	}
@@ -184,7 +194,7 @@ func (u *UsageExtractor) tryExtractFromJSON() {
 // json.Unmarshal and map[string]any allocations entirely.
 func extractUsageGJSON(data []byte, provider string) (input, output int, found bool) {
 	usage := gjson.GetBytes(data, "usage")
-	if !usage.Exists() && provider == "anthropic" {
+	if !usage.Exists() && provider == providerAnthropic {
 		usage = gjson.GetBytes(data, "message.usage")
 	}
 	if !usage.Exists() {
@@ -192,10 +202,10 @@ func extractUsageGJSON(data []byte, provider string) (input, output int, found b
 	}
 
 	switch provider {
-	case "anthropic":
+	case providerAnthropic:
 		input = int(usage.Get("input_tokens").Int())
 		output = int(usage.Get("output_tokens").Int())
-	case "openai", "google":
+	case providerOpenAI, providerGoogle:
 		input = int(usage.Get("prompt_tokens").Int())
 		output = int(usage.Get("completion_tokens").Int())
 	default:

--- a/internal/providers/provider.go
+++ b/internal/providers/provider.go
@@ -12,6 +12,16 @@ import (
 	"workweave/router/internal/router"
 )
 
+// Provider name constants are the canonical keys used in
+// map[string]providers.Client registries and router.Decision.Provider.
+// Always use these instead of raw string literals.
+const (
+	ProviderAnthropic  = "anthropic"
+	ProviderOpenAI     = "openai"
+	ProviderGoogle     = "google"
+	ProviderOpenRouter = "openrouter"
+)
+
 // HopByHopHeaders are stripped from upstream responses per RFC 7230.
 // Connection-specific headers must not be forwarded by a proxy.
 var HopByHopHeaders = map[string]struct{}{

--- a/internal/proxy/credentials.go
+++ b/internal/proxy/credentials.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"workweave/router/internal/auth"
+	"workweave/router/internal/providers"
 )
 
 // Credentials holds the API key to use for an upstream request.
@@ -47,11 +48,11 @@ func BuildCredentialsMap(keys []*auth.ExternalAPIKey) map[string]*Credentials {
 // HasAPIKeyPrefix guard and leak upstream.
 func ExtractClientCredentials(provider string, headers http.Header) *Credentials {
 	switch provider {
-	case "anthropic":
+	case providers.ProviderAnthropic:
 		if key := strings.TrimSpace(headers.Get("x-api-key")); key != "" && !auth.HasAPIKeyPrefix(key) {
 			return &Credentials{APIKey: []byte(key), Source: "client"}
 		}
-	case "openai", "google":
+	case providers.ProviderOpenAI, providers.ProviderGoogle:
 		authHeader := headers.Get("Authorization")
 		if raw, found := strings.CutPrefix(authHeader, "Bearer "); found {
 			key := strings.TrimSpace(raw)

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -219,7 +219,7 @@ func (s *Service) Route(ctx context.Context, req router.Request) (router.Decisio
 // provider ("anthropic") for backward compatibility with existing Anthropic
 // metadata endpoints (count_tokens, models).
 func (s *Service) PassthroughToProvider(ctx context.Context, body []byte, w http.ResponseWriter, r *http.Request) error {
-	return s.PassthroughToNamedProvider(ctx, "anthropic", body, w, r)
+	return s.PassthroughToNamedProvider(ctx, providers.ProviderAnthropic, body, w, r)
 }
 
 // PassthroughToNamedProvider forwards a non-routing-path request to a specific
@@ -234,7 +234,7 @@ func (s *Service) PassthroughToNamedProvider(ctx context.Context, providerName s
 	}
 
 	var prep providers.PreparedRequest
-	if providerName == "anthropic" && len(body) > 0 {
+	if providerName == providers.ProviderAnthropic && len(body) > 0 {
 		env, parseErr := translate.ParseAnthropic(body)
 		if parseErr == nil {
 			prep, err = env.PrepareAnthropicPassthrough(r.Header)
@@ -244,7 +244,7 @@ func (s *Service) PassthroughToNamedProvider(ctx context.Context, providerName s
 		} else {
 			prep = providers.PreparedRequest{Body: body, Headers: translate.AnthropicPassthroughHeaders(r.Header)}
 		}
-	} else if providerName == "anthropic" {
+	} else if providerName == providers.ProviderAnthropic {
 		prep = providers.PreparedRequest{Body: body, Headers: translate.AnthropicPassthroughHeaders(r.Header)}
 	} else {
 		prep = providers.PreparedRequest{Body: body, Headers: make(http.Header)}
@@ -533,7 +533,7 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 	var extractor *otel.UsageExtractor
 
 	switch decision.Provider {
-	case "anthropic":
+	case providers.ProviderAnthropic:
 		prep, emitErr := env.PrepareAnthropic(r.Header, opts)
 		if emitErr != nil {
 			log.Error("Failed to emit Anthropic body", "err", emitErr)
@@ -545,7 +545,7 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 			proxyWriter = extractor
 		}
 		proxyErr = p.Proxy(ctx, decision, prep, proxyWriter, r)
-	case "openai", "google":
+	case providers.ProviderOpenAI, providers.ProviderGoogle:
 		crossFormat = true
 		prep, emitErr := env.PrepareOpenAI(r.Header, opts)
 		if emitErr != nil {
@@ -696,7 +696,7 @@ func (s *Service) enabledProvidersForRequest(ctx context.Context, headers http.H
 	for _, k := range externalKeysFromContext(ctx) {
 		out[k.Provider] = struct{}{}
 	}
-	for _, p := range []string{"anthropic", "openai", "google", "openrouter"} {
+	for _, p := range []string{providers.ProviderAnthropic, providers.ProviderOpenAI, providers.ProviderGoogle, providers.ProviderOpenRouter} {
 		if _, already := out[p]; already {
 			continue
 		}
@@ -878,7 +878,7 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 	var extractor *otel.UsageExtractor
 
 	switch decision.Provider {
-	case "openai", "google":
+	case providers.ProviderOpenAI, providers.ProviderGoogle:
 		prep, emitErr := env.PrepareOpenAI(r.Header, opts)
 		if emitErr != nil {
 			log.Error("Failed to emit OpenAI body", "err", emitErr)
@@ -890,7 +890,7 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 			proxyWriter = extractor
 		}
 		proxyErr = p.Proxy(ctx, decision, prep, proxyWriter, r)
-	case "anthropic":
+	case providers.ProviderAnthropic:
 		crossFormat = true
 		prep, emitErr := env.PrepareAnthropic(r.Header, opts)
 		if emitErr != nil {
@@ -899,7 +899,7 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 		}
 		var usage otel.UsageSink
 		if s.emitter != nil {
-			extractor = otel.NewUsageExtractor(nil, "anthropic")
+			extractor = otel.NewUsageExtractor(nil, providers.ProviderAnthropic)
 			usage = extractor
 		}
 		translator := translate.NewSSETranslator(sink, decision.Model, usage)

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -51,10 +51,16 @@ type Service struct {
 	// fresh route on the next turn rather than accumulating goroutines
 	// under slow/unavailable Postgres.
 	pinWriteSem chan struct{}
-	// hardPinExplore gates the §3.4 Explore sub-agent hard-pin to Haiku.
+	// hardPinExplore gates the §3.4 Explore sub-agent hard-pin.
 	// Off by default; enable via ROUTER_HARD_PIN_EXPLORE=true after one
 	// week of shadow validation (see docs/plans/AGENTIC_CODING.md §3.4).
 	hardPinExplore bool
+	// hardPinProvider and hardPinModel are the (provider, model) routed to
+	// for compaction and (when hardPinExplore is on) Explore sub-agent turns.
+	// Derived at boot from the cheapest available model in the cluster bundle;
+	// overridable via ROUTER_HARD_PIN_PROVIDER / ROUTER_HARD_PIN_MODEL.
+	hardPinProvider string
+	hardPinModel    string
 }
 
 // pinSessionTTL is the sliding TTL written into pinned_until on every
@@ -92,7 +98,7 @@ type InstallationIDContextKey struct{}
 // NewService constructs the proxy service. pinStore may be nil when the
 // session-pin feature flag is off; the tiered lookup transparently
 // short-circuits past tiers 1–2 in that case.
-func NewService(r router.Router, providerMap map[string]providers.Client, emitter *otel.Emitter, embedLastUserMessage bool, stickyDecisionTTL time.Duration, decisionLog *DecisionLog, semanticCache *cache.Cache, pinStore sessionpin.Store, hardPinExplore bool) *Service {
+func NewService(r router.Router, providerMap map[string]providers.Client, emitter *otel.Emitter, embedLastUserMessage bool, stickyDecisionTTL time.Duration, decisionLog *DecisionLog, semanticCache *cache.Cache, pinStore sessionpin.Store, hardPinExplore bool, hardPinProvider, hardPinModel string) *Service {
 	var sticky *expirable.LRU[string, router.Decision]
 	if stickyDecisionTTL > 0 {
 		sticky = expirable.NewLRU[string, router.Decision](10000, nil, stickyDecisionTTL)
@@ -115,6 +121,8 @@ func NewService(r router.Router, providerMap map[string]providers.Client, emitte
 		pinCache:             pinCache,
 		pinWriteSem:          pinWriteSem,
 		hardPinExplore:       hardPinExplore,
+		hardPinProvider:      hardPinProvider,
+		hardPinModel:         hardPinModel,
 	}
 }
 
@@ -303,8 +311,8 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 	)
 	if tt == turntype.Compaction || (tt == turntype.SubAgentDispatch && s.hardPinExplore) {
 		decision = router.Decision{
-			Provider: "anthropic",
-			Model:    "claude-haiku-4-5",
+			Provider: s.hardPinProvider,
+			Model:    s.hardPinModel,
 			Reason:   string(tt) + "_hard_pin",
 		}
 		stickyHit = true

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -15,6 +15,7 @@ import (
 	"workweave/router/internal/router"
 	"workweave/router/internal/router/cache"
 	"workweave/router/internal/router/sessionpin"
+	"workweave/router/internal/router/turntype"
 	"workweave/router/internal/translate"
 
 	"github.com/google/uuid"
@@ -50,6 +51,10 @@ type Service struct {
 	// fresh route on the next turn rather than accumulating goroutines
 	// under slow/unavailable Postgres.
 	pinWriteSem chan struct{}
+	// hardPinExplore gates the §3.4 Explore sub-agent hard-pin to Haiku.
+	// Off by default; enable via ROUTER_HARD_PIN_EXPLORE=true after one
+	// week of shadow validation (see docs/plans/AGENTIC_CODING.md §3.4).
+	hardPinExplore bool
 }
 
 // pinSessionTTL is the sliding TTL written into pinned_until on every
@@ -87,7 +92,7 @@ type InstallationIDContextKey struct{}
 // NewService constructs the proxy service. pinStore may be nil when the
 // session-pin feature flag is off; the tiered lookup transparently
 // short-circuits past tiers 1–2 in that case.
-func NewService(r router.Router, providerMap map[string]providers.Client, emitter *otel.Emitter, embedLastUserMessage bool, stickyDecisionTTL time.Duration, decisionLog *DecisionLog, semanticCache *cache.Cache, pinStore sessionpin.Store) *Service {
+func NewService(r router.Router, providerMap map[string]providers.Client, emitter *otel.Emitter, embedLastUserMessage bool, stickyDecisionTTL time.Duration, decisionLog *DecisionLog, semanticCache *cache.Cache, pinStore sessionpin.Store, hardPinExplore bool) *Service {
 	var sticky *expirable.LRU[string, router.Decision]
 	if stickyDecisionTTL > 0 {
 		sticky = expirable.NewLRU[string, router.Decision](10000, nil, stickyDecisionTTL)
@@ -109,6 +114,7 @@ func NewService(r router.Router, providerMap map[string]providers.Client, emitte
 		pinStore:             pinStore,
 		pinCache:             pinCache,
 		pinWriteSem:          pinWriteSem,
+		hardPinExplore:       hardPinExplore,
 	}
 }
 
@@ -259,6 +265,8 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 		return fmt.Errorf("parse request: %w", parseErr)
 	}
 
+	tt := turntype.Detect(body)
+
 	embedFlag := s.embedLastUserMessage
 	if v, ok := embedLastUserMessageOverride(ctx); ok {
 		embedFlag = v
@@ -278,15 +286,12 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 	bypassEval := hasEvalOverrideHeader(r)
 	bypassSticky := bypassEval
 
-	// Tiered routing-decision lookup (see docs/plans/SESSION_PIN.md §5).
-	//   Tier 1 — pinCache (in-proc, 30s):   absorbs same-instance burst.
-	//   Tier 2 — pinStore (Postgres, 1h):   survives Cloud Run restarts.
-	//   Tier 3 — stickyDecisions (legacy):  apiKeyID-keyed LRU; kept
-	//                                        during rollout, removed in
-	//                                        a follow-up.
-	// Tier 3 is only consulted on a tier-2 *miss*, never on a tier-2
-	// *error* — papering over store errors with the legacy cache would
-	// mask the migrate-to-Memorystore trigger criteria.
+	// §3.4: hard pins for turn types whose optimal model is known a priori.
+	// These bypass all session-pin tiers and the cluster scorer, and must NOT
+	// write a pin upsert (they must not overwrite the session's main-loop model).
+	//   Compaction — always Haiku (short-out-of-long-in cost profile).
+	//   SubAgentDispatch — Haiku when ROUTER_HARD_PIN_EXPLORE is set; gated
+	//     until one week of shadow validation confirms no quality regression.
 	var (
 		decision    router.Decision
 		stickyHit   bool
@@ -296,7 +301,28 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 		pinCacheKey string
 		routeStart  = time.Now()
 	)
-	pinEligible := s.pinStore != nil && !bypassSticky
+	if tt == turntype.Compaction || (tt == turntype.SubAgentDispatch && s.hardPinExplore) {
+		decision = router.Decision{
+			Provider: "anthropic",
+			Model:    "claude-haiku-4-5",
+			Reason:   string(tt) + "_hard_pin",
+		}
+		stickyHit = true
+		pinTier = string(tt) + "_hard_pin"
+	}
+
+	// Tiered routing-decision lookup (see docs/plans/SESSION_PIN.md §5).
+	//   Tier 1 — pinCache (in-proc, 30s):   absorbs same-instance burst.
+	//   Tier 2 — pinStore (Postgres, 1h):   survives Cloud Run restarts.
+	//   Tier 3 — stickyDecisions (legacy):  apiKeyID-keyed LRU; kept
+	//                                        during rollout, removed in
+	//                                        a follow-up.
+	// Tier 3 is only consulted on a tier-2 *miss*, never on a tier-2
+	// *error* — papering over store errors with the legacy cache would
+	// mask the migrate-to-Memorystore trigger criteria.
+	// pinEligible is false for hard-pinned turns (stickyHit already set above),
+	// which also suppresses the async pin upsert for those turns.
+	pinEligible := s.pinStore != nil && !bypassSticky && !stickyHit
 	if pinEligible {
 		sessionKey = DeriveSessionKey(env, apiKeyID)
 		pinCacheKey = sessionPinCacheKey(sessionKey, sessionpin.DefaultRole)
@@ -351,6 +377,13 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 		if s.stickyDecisions != nil && apiKeyID != "" && !bypassSticky {
 			s.stickyDecisions.Add(apiKeyID, decision)
 		}
+	}
+
+	// §3.3: annotate pin tier when a tool-result turn short-circuits to an
+	// existing session pin, so the routing.session_pin_tier OTel attribute
+	// reflects the bypass in dashboards.
+	if stickyHit && tt == turntype.ToolResult {
+		pinTier += "_tool_result_sc"
 	}
 
 	// Async upsert on every routed request — refreshes the sliding TTL
@@ -436,7 +469,7 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 		Name:  "router.decision",
 		Start: requestStart,
 		End:   time.Now(),
-		Attrs: otel.NewAttrBuilder(23).
+		Attrs: otel.NewAttrBuilder(24).
 			String("request_id", requestID).
 			String("external_id", externalID).
 			String("client.device_id", clientID.DeviceID).
@@ -452,6 +485,7 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 			Bool("routing.session_pin_hit", pinTier == "in_proc" || pinTier == "postgres").
 			String("routing.session_pin_tier", pinTier).
 			Int64("routing.session_pin_age_s", pinAgeSec).
+			String("routing.turn_type", string(tt)).
 			String("routing.embed_input", embedInput).
 			Int64("routing.estimated_input_tokens", int64(feats.Tokens)).
 			Float64("pricing.requested_input_per_1m", reqPricing.InputUSDPer1M).

--- a/internal/proxy/service_cache_test.go
+++ b/internal/proxy/service_cache_test.go
@@ -89,7 +89,7 @@ func TestService_Cache_HitShortCircuitsProvider(t *testing.T) {
 	}
 	fr := &fakeRouter{decision: decisionWithEmbedding(emb, []int{0, 1, 2, 3})}
 	c := cache.New(cache.DefaultConfig())
-	svc := proxy.NewService(fr, map[string]providers.Client{"anthropic": provider}, nil, false, 0, nil, c, nil, false, "anthropic", "claude-haiku-4-5")
+	svc := proxy.NewService(fr, map[string]providers.Client{providers.ProviderAnthropic: provider}, nil, false, 0, nil, c, nil, false, providers.ProviderAnthropic, "claude-haiku-4-5")
 
 	ctx := proxyContextWithExternalID(t, "tenant-1")
 	body := anthropicBody("ping", false)
@@ -120,7 +120,7 @@ func TestService_Cache_StreamingBypasses(t *testing.T) {
 	}
 	fr := &fakeRouter{decision: decisionWithEmbedding(emb, []int{0})}
 	c := cache.New(cache.DefaultConfig())
-	svc := proxy.NewService(fr, map[string]providers.Client{"anthropic": provider}, nil, false, 0, nil, c, nil, false, "anthropic", "claude-haiku-4-5")
+	svc := proxy.NewService(fr, map[string]providers.Client{providers.ProviderAnthropic: provider}, nil, false, 0, nil, c, nil, false, providers.ProviderAnthropic, "claude-haiku-4-5")
 
 	ctx := proxyContextWithExternalID(t, "tenant-1")
 	body := anthropicBody("streaming please", true) // stream=true
@@ -144,7 +144,7 @@ func TestService_Cache_HeuristicDecisionBypasses(t *testing.T) {
 	// Decision with no Metadata — what the heuristic router produces.
 	fr := &fakeRouter{decision: router.Decision{Provider: "anthropic", Model: "claude-haiku-4-5", Reason: "heuristic"}}
 	c := cache.New(cache.DefaultConfig())
-	svc := proxy.NewService(fr, map[string]providers.Client{"anthropic": provider}, nil, false, 0, nil, c, nil, false, "anthropic", "claude-haiku-4-5")
+	svc := proxy.NewService(fr, map[string]providers.Client{providers.ProviderAnthropic: provider}, nil, false, 0, nil, c, nil, false, providers.ProviderAnthropic, "claude-haiku-4-5")
 
 	ctx := proxyContextWithExternalID(t, "tenant-1")
 	body := anthropicBody("ask", false)
@@ -167,7 +167,7 @@ func TestService_Cache_MissingExternalIDBypasses(t *testing.T) {
 	}
 	fr := &fakeRouter{decision: decisionWithEmbedding(emb, []int{0})}
 	c := cache.New(cache.DefaultConfig())
-	svc := proxy.NewService(fr, map[string]providers.Client{"anthropic": provider}, nil, false, 0, nil, c, nil, false, "anthropic", "claude-haiku-4-5")
+	svc := proxy.NewService(fr, map[string]providers.Client{providers.ProviderAnthropic: provider}, nil, false, 0, nil, c, nil, false, providers.ProviderAnthropic, "claude-haiku-4-5")
 
 	body := anthropicBody("ask", false)
 
@@ -192,7 +192,7 @@ func TestService_Cache_DisabledByNilCache(t *testing.T) {
 	}
 	fr := &fakeRouter{decision: decisionWithEmbedding(emb, []int{0})}
 	// nil cache — same effect as ROUTER_SEMANTIC_CACHE_ENABLED=false.
-	svc := proxy.NewService(fr, map[string]providers.Client{"anthropic": provider}, nil, false, 0, nil, nil, nil, false, "anthropic", "claude-haiku-4-5")
+	svc := proxy.NewService(fr, map[string]providers.Client{providers.ProviderAnthropic: provider}, nil, false, 0, nil, nil, nil, false, providers.ProviderAnthropic, "claude-haiku-4-5")
 
 	ctx := proxyContextWithExternalID(t, "tenant-1")
 	body := anthropicBody("ask", false)

--- a/internal/proxy/service_cache_test.go
+++ b/internal/proxy/service_cache_test.go
@@ -89,7 +89,7 @@ func TestService_Cache_HitShortCircuitsProvider(t *testing.T) {
 	}
 	fr := &fakeRouter{decision: decisionWithEmbedding(emb, []int{0, 1, 2, 3})}
 	c := cache.New(cache.DefaultConfig())
-	svc := proxy.NewService(fr, map[string]providers.Client{"anthropic": provider}, nil, false, 0, nil, c, nil, false)
+	svc := proxy.NewService(fr, map[string]providers.Client{"anthropic": provider}, nil, false, 0, nil, c, nil, false, "anthropic", "claude-haiku-4-5")
 
 	ctx := proxyContextWithExternalID(t, "tenant-1")
 	body := anthropicBody("ping", false)
@@ -120,7 +120,7 @@ func TestService_Cache_StreamingBypasses(t *testing.T) {
 	}
 	fr := &fakeRouter{decision: decisionWithEmbedding(emb, []int{0})}
 	c := cache.New(cache.DefaultConfig())
-	svc := proxy.NewService(fr, map[string]providers.Client{"anthropic": provider}, nil, false, 0, nil, c, nil, false)
+	svc := proxy.NewService(fr, map[string]providers.Client{"anthropic": provider}, nil, false, 0, nil, c, nil, false, "anthropic", "claude-haiku-4-5")
 
 	ctx := proxyContextWithExternalID(t, "tenant-1")
 	body := anthropicBody("streaming please", true) // stream=true
@@ -144,7 +144,7 @@ func TestService_Cache_HeuristicDecisionBypasses(t *testing.T) {
 	// Decision with no Metadata — what the heuristic router produces.
 	fr := &fakeRouter{decision: router.Decision{Provider: "anthropic", Model: "claude-haiku-4-5", Reason: "heuristic"}}
 	c := cache.New(cache.DefaultConfig())
-	svc := proxy.NewService(fr, map[string]providers.Client{"anthropic": provider}, nil, false, 0, nil, c, nil, false)
+	svc := proxy.NewService(fr, map[string]providers.Client{"anthropic": provider}, nil, false, 0, nil, c, nil, false, "anthropic", "claude-haiku-4-5")
 
 	ctx := proxyContextWithExternalID(t, "tenant-1")
 	body := anthropicBody("ask", false)
@@ -167,7 +167,7 @@ func TestService_Cache_MissingExternalIDBypasses(t *testing.T) {
 	}
 	fr := &fakeRouter{decision: decisionWithEmbedding(emb, []int{0})}
 	c := cache.New(cache.DefaultConfig())
-	svc := proxy.NewService(fr, map[string]providers.Client{"anthropic": provider}, nil, false, 0, nil, c, nil, false)
+	svc := proxy.NewService(fr, map[string]providers.Client{"anthropic": provider}, nil, false, 0, nil, c, nil, false, "anthropic", "claude-haiku-4-5")
 
 	body := anthropicBody("ask", false)
 
@@ -192,7 +192,7 @@ func TestService_Cache_DisabledByNilCache(t *testing.T) {
 	}
 	fr := &fakeRouter{decision: decisionWithEmbedding(emb, []int{0})}
 	// nil cache — same effect as ROUTER_SEMANTIC_CACHE_ENABLED=false.
-	svc := proxy.NewService(fr, map[string]providers.Client{"anthropic": provider}, nil, false, 0, nil, nil, nil, false)
+	svc := proxy.NewService(fr, map[string]providers.Client{"anthropic": provider}, nil, false, 0, nil, nil, nil, false, "anthropic", "claude-haiku-4-5")
 
 	ctx := proxyContextWithExternalID(t, "tenant-1")
 	body := anthropicBody("ask", false)

--- a/internal/proxy/service_cache_test.go
+++ b/internal/proxy/service_cache_test.go
@@ -89,7 +89,7 @@ func TestService_Cache_HitShortCircuitsProvider(t *testing.T) {
 	}
 	fr := &fakeRouter{decision: decisionWithEmbedding(emb, []int{0, 1, 2, 3})}
 	c := cache.New(cache.DefaultConfig())
-	svc := proxy.NewService(fr, map[string]providers.Client{"anthropic": provider}, nil, false, 0, nil, c, nil)
+	svc := proxy.NewService(fr, map[string]providers.Client{"anthropic": provider}, nil, false, 0, nil, c, nil, false)
 
 	ctx := proxyContextWithExternalID(t, "tenant-1")
 	body := anthropicBody("ping", false)
@@ -120,7 +120,7 @@ func TestService_Cache_StreamingBypasses(t *testing.T) {
 	}
 	fr := &fakeRouter{decision: decisionWithEmbedding(emb, []int{0})}
 	c := cache.New(cache.DefaultConfig())
-	svc := proxy.NewService(fr, map[string]providers.Client{"anthropic": provider}, nil, false, 0, nil, c, nil)
+	svc := proxy.NewService(fr, map[string]providers.Client{"anthropic": provider}, nil, false, 0, nil, c, nil, false)
 
 	ctx := proxyContextWithExternalID(t, "tenant-1")
 	body := anthropicBody("streaming please", true) // stream=true
@@ -144,7 +144,7 @@ func TestService_Cache_HeuristicDecisionBypasses(t *testing.T) {
 	// Decision with no Metadata — what the heuristic router produces.
 	fr := &fakeRouter{decision: router.Decision{Provider: "anthropic", Model: "claude-haiku-4-5", Reason: "heuristic"}}
 	c := cache.New(cache.DefaultConfig())
-	svc := proxy.NewService(fr, map[string]providers.Client{"anthropic": provider}, nil, false, 0, nil, c, nil)
+	svc := proxy.NewService(fr, map[string]providers.Client{"anthropic": provider}, nil, false, 0, nil, c, nil, false)
 
 	ctx := proxyContextWithExternalID(t, "tenant-1")
 	body := anthropicBody("ask", false)
@@ -167,7 +167,7 @@ func TestService_Cache_MissingExternalIDBypasses(t *testing.T) {
 	}
 	fr := &fakeRouter{decision: decisionWithEmbedding(emb, []int{0})}
 	c := cache.New(cache.DefaultConfig())
-	svc := proxy.NewService(fr, map[string]providers.Client{"anthropic": provider}, nil, false, 0, nil, c, nil)
+	svc := proxy.NewService(fr, map[string]providers.Client{"anthropic": provider}, nil, false, 0, nil, c, nil, false)
 
 	body := anthropicBody("ask", false)
 
@@ -192,7 +192,7 @@ func TestService_Cache_DisabledByNilCache(t *testing.T) {
 	}
 	fr := &fakeRouter{decision: decisionWithEmbedding(emb, []int{0})}
 	// nil cache — same effect as ROUTER_SEMANTIC_CACHE_ENABLED=false.
-	svc := proxy.NewService(fr, map[string]providers.Client{"anthropic": provider}, nil, false, 0, nil, nil, nil)
+	svc := proxy.NewService(fr, map[string]providers.Client{"anthropic": provider}, nil, false, 0, nil, nil, nil, false)
 
 	ctx := proxyContextWithExternalID(t, "tenant-1")
 	body := anthropicBody("ask", false)

--- a/internal/proxy/service_session_pin_test.go
+++ b/internal/proxy/service_session_pin_test.go
@@ -76,11 +76,11 @@ func newPinSvc(fr *fakeRouter, store *fakePinStore) *proxy.Service {
 	return proxy.NewService(
 		fr,
 		map[string]providers.Client{providers.ProviderAnthropic: &fakeProvider{}},
-		nil,                         // emitter
-		false,                       // embedLastUserMessage
-		0,                           // stickyDecisionTTL — disable legacy LRU for clarity
-		nil,                         // decisionLog
-		nil,                         // semanticCache
+		nil,   // emitter
+		false, // embedLastUserMessage
+		0,     // stickyDecisionTTL — disable legacy LRU for clarity
+		nil,   // decisionLog
+		nil,   // semanticCache
 		store,
 		false,                       // hardPinExplore
 		providers.ProviderAnthropic, // hardPinProvider

--- a/internal/proxy/service_session_pin_test.go
+++ b/internal/proxy/service_session_pin_test.go
@@ -75,16 +75,16 @@ func waitForUpsert(t *testing.T, store *fakePinStore) {
 func newPinSvc(fr *fakeRouter, store *fakePinStore) *proxy.Service {
 	return proxy.NewService(
 		fr,
-		map[string]providers.Client{"anthropic": &fakeProvider{}},
-		nil,              // emitter
-		false,            // embedLastUserMessage
-		0,                // stickyDecisionTTL — disable legacy LRU for clarity
-		nil,              // decisionLog
-		nil,              // semanticCache
+		map[string]providers.Client{providers.ProviderAnthropic: &fakeProvider{}},
+		nil,                         // emitter
+		false,                       // embedLastUserMessage
+		0,                           // stickyDecisionTTL — disable legacy LRU for clarity
+		nil,                         // decisionLog
+		nil,                         // semanticCache
 		store,
-		false,            // hardPinExplore
-		"anthropic",      // hardPinProvider
-		"claude-haiku-4-5", // hardPinModel
+		false,                       // hardPinExplore
+		providers.ProviderAnthropic, // hardPinProvider
+		"claude-haiku-4-5",          // hardPinModel
 	)
 }
 
@@ -247,16 +247,16 @@ func TestService_HardPin_ExploreRoutesToHaikuWhenFlagOn(t *testing.T) {
 	fr := &fakeRouter{decision: router.Decision{Provider: "anthropic", Model: "claude-opus-4-7", Reason: "cluster"}}
 	svc := proxy.NewService(
 		fr,
-		map[string]providers.Client{"anthropic": &fakeProvider{}},
+		map[string]providers.Client{providers.ProviderAnthropic: &fakeProvider{}},
 		nil,
 		false,
 		0,
 		nil,
 		nil,
 		store,
-		true,              // hardPinExplore = on
-		"anthropic",       // hardPinProvider
-		"claude-haiku-4-5", // hardPinModel
+		true,                        // hardPinExplore = on
+		providers.ProviderAnthropic, // hardPinProvider
+		"claude-haiku-4-5",          // hardPinModel
 	)
 
 	ctx := authedCtx(uuid.New().String())

--- a/internal/proxy/service_session_pin_test.go
+++ b/internal/proxy/service_session_pin_test.go
@@ -82,6 +82,7 @@ func newPinSvc(fr *fakeRouter, store *fakePinStore) *proxy.Service {
 		nil,   // decisionLog
 		nil,   // semanticCache
 		store,
+		false, // hardPinExplore
 	)
 }
 
@@ -196,4 +197,94 @@ func TestService_SessionPin_EvalOverrideHeaderBypassesAllTiers(t *testing.T) {
 		"eval-override header must bypass the pin tiers so the harness can compare router strategies on the same prompt")
 	assert.Equal(t, 0, store.getCalls,
 		"the pin store must not even be consulted when bypass is active")
+}
+
+// compactionBody is a minimal Anthropic request whose system prompt triggers
+// the compaction detector (§3.4).
+const compactionBody = `{
+	"model":"claude-opus-4-7",
+	"system":"Your task is to create a detailed summary of the conversation so far.",
+	"messages":[{"role":"user","content":"go"}]
+}`
+
+// exploreBody is a minimal Anthropic request whose metadata marks it as an
+// Explore sub-agent dispatch (§3.4).
+const exploreBody = `{
+	"model":"claude-opus-4-7",
+	"metadata":{"user_id":"subagent:Explore"},
+	"messages":[{"role":"user","content":"list go files"}]
+}`
+
+func TestService_HardPin_CompactionAlwaysRoutesToHaiku(t *testing.T) {
+	store := newFakePinStore()
+	fr := &fakeRouter{decision: router.Decision{Provider: "anthropic", Model: "claude-opus-4-7", Reason: "cluster"}}
+	svc := newPinSvc(fr, store)
+
+	ctx := authedCtx(uuid.New().String())
+	rec := httptest.NewRecorder()
+	httpReq := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(""))
+	require.NoError(t, svc.ProxyMessages(ctx, []byte(compactionBody), rec, httpReq))
+
+	assert.Equal(t, 0, fr.routeCalls,
+		"compaction turns must bypass the cluster scorer entirely")
+	assert.Equal(t, "claude-haiku-4-5", rec.Header().Get("x-router-model"),
+		"compaction must hard-pin to Haiku")
+	assert.Equal(t, 0, store.getCalls,
+		"compaction turns must not consult the pin store")
+
+	// Give any async goroutine a moment to fire (there should be none).
+	select {
+	case <-store.upsertCh:
+		t.Fatal("compaction turn must not write a session pin (would overwrite main-loop model)")
+	case <-time.After(100 * time.Millisecond):
+	}
+}
+
+func TestService_HardPin_ExploreRoutesToHaikuWhenFlagOn(t *testing.T) {
+	store := newFakePinStore()
+	fr := &fakeRouter{decision: router.Decision{Provider: "anthropic", Model: "claude-opus-4-7", Reason: "cluster"}}
+	svc := proxy.NewService(
+		fr,
+		map[string]providers.Client{"anthropic": &fakeProvider{}},
+		nil,
+		false,
+		0,
+		nil,
+		nil,
+		store,
+		true, // hardPinExplore = on
+	)
+
+	ctx := authedCtx(uuid.New().String())
+	rec := httptest.NewRecorder()
+	httpReq := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(""))
+	require.NoError(t, svc.ProxyMessages(ctx, []byte(exploreBody), rec, httpReq))
+
+	assert.Equal(t, 0, fr.routeCalls,
+		"Explore sub-agent turns must bypass the cluster scorer when hardPinExplore is on")
+	assert.Equal(t, "claude-haiku-4-5", rec.Header().Get("x-router-model"),
+		"Explore hard-pin must select Haiku")
+
+	select {
+	case <-store.upsertCh:
+		t.Fatal("Explore hard-pin turn must not write a session pin")
+	case <-time.After(100 * time.Millisecond):
+	}
+}
+
+func TestService_HardPin_ExploreFallsThroughWhenFlagOff(t *testing.T) {
+	store := newFakePinStore()
+	fr := &fakeRouter{decision: router.Decision{Provider: "anthropic", Model: "claude-opus-4-7", Reason: "cluster"}}
+	// hardPinExplore = false (default via newPinSvc)
+	svc := newPinSvc(fr, store)
+
+	ctx := authedCtx(uuid.New().String())
+	rec := httptest.NewRecorder()
+	httpReq := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(""))
+	require.NoError(t, svc.ProxyMessages(ctx, []byte(exploreBody), rec, httpReq))
+
+	assert.Equal(t, 1, fr.routeCalls,
+		"Explore sub-agent must fall through to the cluster scorer when hardPinExplore is off")
+	assert.Equal(t, "claude-opus-4-7", rec.Header().Get("x-router-model"),
+		"cluster scorer decision must be used when hardPinExplore is off")
 }

--- a/internal/proxy/service_session_pin_test.go
+++ b/internal/proxy/service_session_pin_test.go
@@ -76,13 +76,15 @@ func newPinSvc(fr *fakeRouter, store *fakePinStore) *proxy.Service {
 	return proxy.NewService(
 		fr,
 		map[string]providers.Client{"anthropic": &fakeProvider{}},
-		nil,   // emitter
-		false, // embedLastUserMessage
-		0,     // stickyDecisionTTL — disable legacy LRU for clarity
-		nil,   // decisionLog
-		nil,   // semanticCache
+		nil,              // emitter
+		false,            // embedLastUserMessage
+		0,                // stickyDecisionTTL — disable legacy LRU for clarity
+		nil,              // decisionLog
+		nil,              // semanticCache
 		store,
-		false, // hardPinExplore
+		false,            // hardPinExplore
+		"anthropic",      // hardPinProvider
+		"claude-haiku-4-5", // hardPinModel
 	)
 }
 
@@ -252,7 +254,9 @@ func TestService_HardPin_ExploreRoutesToHaikuWhenFlagOn(t *testing.T) {
 		nil,
 		nil,
 		store,
-		true, // hardPinExplore = on
+		true,              // hardPinExplore = on
+		"anthropic",       // hardPinProvider
+		"claude-haiku-4-5", // hardPinModel
 	)
 
 	ctx := authedCtx(uuid.New().String())

--- a/internal/proxy/service_test.go
+++ b/internal/proxy/service_test.go
@@ -53,7 +53,7 @@ func (f *fakeProvider) Passthrough(ctx context.Context, prep providers.PreparedR
 }
 
 func makeProxyService(decision router.Decision, p map[string]providers.Client) *proxy.Service {
-	return proxy.NewService(&fakeRouter{decision: decision}, p, nil, false, 0, nil, nil, nil, false)
+	return proxy.NewService(&fakeRouter{decision: decision}, p, nil, false, 0, nil, nil, nil, false, "anthropic", "claude-haiku-4-5")
 }
 
 func TestService_ProxyMessages_PropagatesUpstreamStatusError(t *testing.T) {
@@ -104,6 +104,7 @@ func TestService_ProxyMessages_EmbedLastUserMessageFlag(t *testing.T) {
 			nil,
 			nil,
 			false,
+			"anthropic", "claude-haiku-4-5",
 		)
 
 		rec := httptest.NewRecorder()
@@ -129,6 +130,7 @@ func TestService_ProxyMessages_EmbedLastUserMessageFlag(t *testing.T) {
 			nil,
 			nil,
 			false,
+			"anthropic", "claude-haiku-4-5",
 		)
 
 		rec := httptest.NewRecorder()
@@ -194,6 +196,7 @@ func TestService_ProxyMessages_EmbedLastUserMessageContextOverride(t *testing.T)
 				nil,
 				nil,
 				false,
+				"anthropic", "claude-haiku-4-5",
 			)
 
 			ctx := context.Background()
@@ -240,6 +243,7 @@ func TestService_ProxyMessages_StickyBypassedByEvalOverrideHeaders(t *testing.T)
 				nil,
 				nil,
 				false,
+				"anthropic", "claude-haiku-4-5",
 			)
 
 			ctx := context.WithValue(context.Background(), proxy.APIKeyIDContextKey{}, "key-1")

--- a/internal/proxy/service_test.go
+++ b/internal/proxy/service_test.go
@@ -53,7 +53,7 @@ func (f *fakeProvider) Passthrough(ctx context.Context, prep providers.PreparedR
 }
 
 func makeProxyService(decision router.Decision, p map[string]providers.Client) *proxy.Service {
-	return proxy.NewService(&fakeRouter{decision: decision}, p, nil, false, 0, nil, nil, nil)
+	return proxy.NewService(&fakeRouter{decision: decision}, p, nil, false, 0, nil, nil, nil, false)
 }
 
 func TestService_ProxyMessages_PropagatesUpstreamStatusError(t *testing.T) {
@@ -103,6 +103,7 @@ func TestService_ProxyMessages_EmbedLastUserMessageFlag(t *testing.T) {
 			nil,
 			nil,
 			nil,
+			false,
 		)
 
 		rec := httptest.NewRecorder()
@@ -127,6 +128,7 @@ func TestService_ProxyMessages_EmbedLastUserMessageFlag(t *testing.T) {
 			nil,
 			nil,
 			nil,
+			false,
 		)
 
 		rec := httptest.NewRecorder()
@@ -191,6 +193,7 @@ func TestService_ProxyMessages_EmbedLastUserMessageContextOverride(t *testing.T)
 				nil,
 				nil,
 				nil,
+				false,
 			)
 
 			ctx := context.Background()
@@ -236,6 +239,7 @@ func TestService_ProxyMessages_StickyBypassedByEvalOverrideHeaders(t *testing.T)
 				nil,
 				nil,
 				nil,
+				false,
 			)
 
 			ctx := context.WithValue(context.Background(), proxy.APIKeyIDContextKey{}, "key-1")

--- a/internal/proxy/service_test.go
+++ b/internal/proxy/service_test.go
@@ -53,7 +53,7 @@ func (f *fakeProvider) Passthrough(ctx context.Context, prep providers.PreparedR
 }
 
 func makeProxyService(decision router.Decision, p map[string]providers.Client) *proxy.Service {
-	return proxy.NewService(&fakeRouter{decision: decision}, p, nil, false, 0, nil, nil, nil, false, "anthropic", "claude-haiku-4-5")
+	return proxy.NewService(&fakeRouter{decision: decision}, p, nil, false, 0, nil, nil, nil, false, providers.ProviderAnthropic, "claude-haiku-4-5")
 }
 
 func TestService_ProxyMessages_PropagatesUpstreamStatusError(t *testing.T) {
@@ -96,7 +96,7 @@ func TestService_ProxyMessages_EmbedLastUserMessageFlag(t *testing.T) {
 	t.Run("flag off uses concatenated stream", func(t *testing.T) {
 		fr := &fakeRouter{decision: router.Decision{Provider: "anthropic", Model: "claude-haiku-4-5"}}
 		svc := proxy.NewService(fr,
-			map[string]providers.Client{"anthropic": &fakeProvider{}},
+			map[string]providers.Client{providers.ProviderAnthropic: &fakeProvider{}},
 			nil,
 			false,
 			0,
@@ -104,7 +104,7 @@ func TestService_ProxyMessages_EmbedLastUserMessageFlag(t *testing.T) {
 			nil,
 			nil,
 			false,
-			"anthropic", "claude-haiku-4-5",
+			providers.ProviderAnthropic, "claude-haiku-4-5",
 		)
 
 		rec := httptest.NewRecorder()
@@ -122,7 +122,7 @@ func TestService_ProxyMessages_EmbedLastUserMessageFlag(t *testing.T) {
 	t.Run("flag on uses last user message only", func(t *testing.T) {
 		fr := &fakeRouter{decision: router.Decision{Provider: "anthropic", Model: "claude-haiku-4-5"}}
 		svc := proxy.NewService(fr,
-			map[string]providers.Client{"anthropic": &fakeProvider{}},
+			map[string]providers.Client{providers.ProviderAnthropic: &fakeProvider{}},
 			nil,
 			true,
 			0,
@@ -130,7 +130,7 @@ func TestService_ProxyMessages_EmbedLastUserMessageFlag(t *testing.T) {
 			nil,
 			nil,
 			false,
-			"anthropic", "claude-haiku-4-5",
+			providers.ProviderAnthropic, "claude-haiku-4-5",
 		)
 
 		rec := httptest.NewRecorder()
@@ -235,7 +235,7 @@ func TestService_ProxyMessages_StickyBypassedByEvalOverrideHeaders(t *testing.T)
 		t.Run(tc.name, func(t *testing.T) {
 			fr := &fakeRouter{decision: router.Decision{Provider: "anthropic", Model: "claude-haiku-4-5"}}
 			svc := proxy.NewService(fr,
-				map[string]providers.Client{"anthropic": &fakeProvider{}},
+				map[string]providers.Client{providers.ProviderAnthropic: &fakeProvider{}},
 				nil,
 				false,
 				time.Hour, // long TTL so sticky window stays open across both calls
@@ -243,7 +243,7 @@ func TestService_ProxyMessages_StickyBypassedByEvalOverrideHeaders(t *testing.T)
 				nil,
 				nil,
 				false,
-				"anthropic", "claude-haiku-4-5",
+				providers.ProviderAnthropic, "claude-haiku-4-5",
 			)
 
 			ctx := context.WithValue(context.Background(), proxy.APIKeyIDContextKey{}, "key-1")

--- a/internal/router/cluster/artifacts.go
+++ b/internal/router/cluster/artifacts.go
@@ -370,6 +370,30 @@ func loadRankings(raw []byte) (Rankings, error) {
 	return out, nil
 }
 
+// CheapestModel returns the provider and model whose cost-per-1k-input is
+// lowest among all entries in registry whose provider appears in available.
+// The cost lookup uses meta.CostPer1KInputUSD. Entries missing a cost entry
+// are skipped. Returns ("", "", false) if no matching entry is found.
+func CheapestModel(meta *ArtifactMetadata, registry *ModelRegistry, available map[string]struct{}) (provider, model string, ok bool) {
+	var bestCost float64 = -1
+	for _, e := range registry.DeployedModels {
+		if _, inSet := available[e.Provider]; !inSet {
+			continue
+		}
+		cost, hasCost := meta.CostPer1KInputUSD[e.Model]
+		if !hasCost {
+			continue
+		}
+		if bestCost < 0 || cost < bestCost {
+			bestCost = cost
+			provider = e.Provider
+			model = e.Model
+			ok = true
+		}
+	}
+	return
+}
+
 // loadRegistry validates that every entry carries a non-empty (model,
 // provider, bench_column) triple. Empty fields are loud errors at boot
 // rather than silent "decision routes to nothing" at request time.

--- a/internal/router/cluster/artifacts_test.go
+++ b/internal/router/cluster/artifacts_test.go
@@ -203,3 +203,53 @@ func TestResolveVersion_UnknownErrors(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "v99.99")
 }
+
+func TestCheapestModel(t *testing.T) {
+	meta := &ArtifactMetadata{
+		CostPer1KInputUSD: map[string]float64{
+			"model-a": 3.00,
+			"model-b": 0.50,
+			"model-c": 0.10,
+		},
+	}
+	registry := &ModelRegistry{
+		DeployedModels: []DeployedEntry{
+			{Model: "model-a", Provider: "anthropic", BenchColumn: "col-a"},
+			{Model: "model-b", Provider: "google", BenchColumn: "col-b"},
+			{Model: "model-c", Provider: "google", BenchColumn: "col-c"},
+		},
+	}
+
+	t.Run("picks cheapest across providers", func(t *testing.T) {
+		available := map[string]struct{}{"anthropic": {}, "google": {}}
+		p, m, ok := CheapestModel(meta, registry, available)
+		require.True(t, ok)
+		assert.Equal(t, "google", p)
+		assert.Equal(t, "model-c", m)
+	})
+
+	t.Run("filters by available providers", func(t *testing.T) {
+		available := map[string]struct{}{"anthropic": {}}
+		p, m, ok := CheapestModel(meta, registry, available)
+		require.True(t, ok)
+		assert.Equal(t, "anthropic", p)
+		assert.Equal(t, "model-a", m)
+	})
+
+	t.Run("returns false when no provider matches", func(t *testing.T) {
+		available := map[string]struct{}{"openai": {}}
+		_, _, ok := CheapestModel(meta, registry, available)
+		assert.False(t, ok)
+	})
+
+	t.Run("skips entries with no cost annotation", func(t *testing.T) {
+		metaNoCost := &ArtifactMetadata{
+			CostPer1KInputUSD: map[string]float64{"model-a": 1.00},
+		}
+		available := map[string]struct{}{"anthropic": {}, "google": {}}
+		p, m, ok := CheapestModel(metaNoCost, registry, available)
+		require.True(t, ok)
+		assert.Equal(t, "anthropic", p)
+		assert.Equal(t, "model-a", m)
+	})
+}

--- a/internal/router/turntype/detect.go
+++ b/internal/router/turntype/detect.go
@@ -1,0 +1,122 @@
+// Package turntype classifies inbound Anthropic-format request bodies by
+// conversation role. It is a pure, I/O-free helper used by the proxy service
+// to enable role-conditioned routing (§3.3–§3.4 of docs/plans/AGENTIC_CODING.md).
+package turntype
+
+import (
+	"strings"
+
+	"github.com/tidwall/gjson"
+)
+
+// TurnType classifies an inbound conversation turn.
+type TurnType string
+
+const (
+	// MainLoop is the default — a regular user prompt scored by the cluster scorer.
+	MainLoop TurnType = "main_loop"
+	// ToolResult indicates the last user message consists entirely of
+	// tool_result blocks with no text. The cluster scorer embedding is mostly
+	// noise on these turns; they short-circuit to the session pin when one exists.
+	ToolResult TurnType = "tool_result"
+	// SubAgentDispatch indicates the request originates from a read-only
+	// sub-agent (e.g. Claude Code's Explore agent). Routed to Haiku under §3.4
+	// when ROUTER_HARD_PIN_EXPLORE is enabled.
+	SubAgentDispatch TurnType = "sub_agent_dispatch"
+	// Compaction indicates a Claude Code context-compaction turn. Always routed
+	// to Haiku under §3.4 (short-out-of-long-in cost profile).
+	Compaction TurnType = "compaction"
+)
+
+// Detect classifies the inbound Anthropic-format request body.
+// Conservative: false negatives (returning MainLoop) are safe — the cluster
+// scorer runs normally. False positives are the real risk; each heuristic is
+// intentionally tight.
+func Detect(body []byte) TurnType {
+	if isCompaction(body) {
+		return Compaction
+	}
+	if isSubAgentDispatch(body) {
+		return SubAgentDispatch
+	}
+	if isToolResult(body) {
+		return ToolResult
+	}
+	return MainLoop
+}
+
+// isCompaction returns true when the system prompt contains Claude Code's
+// context-compaction instruction markers.
+func isCompaction(body []byte) bool {
+	text := systemText(body)
+	lower := strings.ToLower(text)
+	return strings.Contains(lower, "your task is to create a detailed summary") ||
+		(strings.Contains(lower, "compact") && strings.Contains(lower, "conversation"))
+}
+
+// isSubAgentDispatch returns true when the request originates from a Claude
+// Code sub-agent. Claude Code encodes sub-agent identity in metadata.user_id
+// as "subagent:<type>", or marks it in the system prompt.
+func isSubAgentDispatch(body []byte) bool {
+	if strings.HasPrefix(gjson.GetBytes(body, "metadata.user_id").String(), "subagent:") {
+		return true
+	}
+	lower := strings.ToLower(systemText(body))
+	return strings.Contains(lower, "subagent_type") || strings.Contains(lower, "sub-agent")
+}
+
+// isToolResult returns true when the last user message contains only
+// tool_result blocks and no text blocks.
+func isToolResult(body []byte) bool {
+	msgs := gjson.GetBytes(body, "messages")
+	if !msgs.IsArray() {
+		return false
+	}
+	var lastMsg gjson.Result
+	msgs.ForEach(func(_, msg gjson.Result) bool {
+		lastMsg = msg
+		return true
+	})
+	if !lastMsg.Exists() || lastMsg.Get("role").String() != "user" {
+		return false
+	}
+	content := lastMsg.Get("content")
+	if !content.IsArray() {
+		return false
+	}
+	hasToolResult := false
+	hasText := false
+	content.ForEach(func(_, block gjson.Result) bool {
+		switch block.Get("type").String() {
+		case "tool_result":
+			hasToolResult = true
+		case "text":
+			hasText = true
+		}
+		return true
+	})
+	return hasToolResult && !hasText
+}
+
+// systemText extracts plain text from the system field, which may be a string
+// or an array of content blocks.
+func systemText(body []byte) string {
+	sys := gjson.GetBytes(body, "system")
+	if sys.Type == gjson.String {
+		return sys.String()
+	}
+	if !sys.IsArray() {
+		return ""
+	}
+	var b strings.Builder
+	sys.ForEach(func(_, block gjson.Result) bool {
+		if block.Get("type").String() == "text" {
+			if b.Len() > 0 {
+				b.WriteByte('\n')
+			}
+			b.WriteString(block.Get("text").String())
+		}
+		return true
+	})
+	return b.String()
+}

--- a/internal/router/turntype/detect_test.go
+++ b/internal/router/turntype/detect_test.go
@@ -1,0 +1,116 @@
+package turntype_test
+
+import (
+	"testing"
+
+	"workweave/router/internal/router/turntype"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDetect(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+		want turntype.TurnType
+	}{
+		{
+			name: "regular user prompt is main_loop",
+			body: `{"model":"claude-sonnet-4-5","messages":[{"role":"user","content":"explain recursion"}]}`,
+			want: turntype.MainLoop,
+		},
+		{
+			name: "tool_result only last message",
+			body: `{"model":"claude-sonnet-4-5","messages":[
+				{"role":"user","content":"run the grep"},
+				{"role":"assistant","content":[{"type":"tool_use","id":"t1","name":"Bash","input":{}}]},
+				{"role":"user","content":[{"type":"tool_result","tool_use_id":"t1","content":"file.go:12: foo"}]}
+			]}`,
+			want: turntype.ToolResult,
+		},
+		{
+			name: "tool_result with text block is main_loop",
+			body: `{"model":"claude-sonnet-4-5","messages":[
+				{"role":"user","content":[
+					{"type":"tool_result","tool_use_id":"t1","content":"output"},
+					{"type":"text","text":"did you see this?"}
+				]}
+			]}`,
+			want: turntype.MainLoop,
+		},
+		{
+			name: "last message is assistant — main_loop",
+			body: `{"model":"claude-sonnet-4-5","messages":[
+				{"role":"user","content":"hi"},
+				{"role":"assistant","content":[{"type":"text","text":"hello"}]}
+			]}`,
+			want: turntype.MainLoop,
+		},
+		{
+			name: "last message string content (not array) is main_loop",
+			body: `{"model":"claude-sonnet-4-5","messages":[{"role":"user","content":"hello"}]}`,
+			want: turntype.MainLoop,
+		},
+		{
+			name: "compaction via task summary phrase",
+			body: `{"model":"claude-sonnet-4-5","system":"Your task is to create a detailed summary of the conversation so far.","messages":[{"role":"user","content":"go"}]}`,
+			want: turntype.Compaction,
+		},
+		{
+			name: "compaction via compact+conversation keywords",
+			body: `{"model":"claude-sonnet-4-5","system":"Please compact the conversation history into a concise summary.","messages":[{"role":"user","content":"ok"}]}`,
+			want: turntype.Compaction,
+		},
+		{
+			name: "compaction with array system prompt",
+			body: `{"model":"claude-sonnet-4-5","system":[{"type":"text","text":"Your task is to create a detailed summary of the conversation above."}],"messages":[{"role":"user","content":"go"}]}`,
+			want: turntype.Compaction,
+		},
+		{
+			name: "sub-agent via metadata user_id prefix",
+			body: `{"model":"claude-haiku-4-5","metadata":{"user_id":"subagent:Explore"},"messages":[{"role":"user","content":"find all go files"}]}`,
+			want: turntype.SubAgentDispatch,
+		},
+		{
+			name: "sub-agent via system prompt sub-agent marker",
+			body: `{"model":"claude-haiku-4-5","system":"You are a sub-agent for the Explore task.","messages":[{"role":"user","content":"list files"}]}`,
+			want: turntype.SubAgentDispatch,
+		},
+		{
+			name: "sub-agent via system prompt subagent_type marker",
+			body: `{"model":"claude-haiku-4-5","system":"subagent_type: Explore","messages":[{"role":"user","content":"grep"}]}`,
+			want: turntype.SubAgentDispatch,
+		},
+		{
+			name: "empty body is main_loop",
+			body: `{}`,
+			want: turntype.MainLoop,
+		},
+		{
+			name: "empty messages array is main_loop",
+			body: `{"model":"claude-sonnet-4-5","messages":[]}`,
+			want: turntype.MainLoop,
+		},
+		{
+			name: "compaction takes priority over tool_result",
+			body: `{"model":"claude-sonnet-4-5","system":"compact the conversation","messages":[
+				{"role":"user","content":[{"type":"tool_result","tool_use_id":"t1","content":"output"}]}
+			]}`,
+			want: turntype.Compaction,
+		},
+		{
+			name: "sub-agent takes priority over tool_result",
+			body: `{"model":"claude-haiku-4-5","metadata":{"user_id":"subagent:Explore"},"messages":[
+				{"role":"user","content":[{"type":"tool_result","tool_use_id":"t1","content":"output"}]}
+			]}`,
+			want: turntype.SubAgentDispatch,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := turntype.Detect([]byte(tc.body))
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}


### PR DESCRIPTION
Implements §3.3 and §3.4 from docs/plans/AGENTIC_CODING.md.

**§3.3 — Turn-type detector (`internal/router/turntype/`)**
- New pure-Go package classifying inbound Anthropic requests as `main_loop`, `tool_result`, `sub_agent_dispatch`, or `compaction`
- Conservative heuristics: false negatives (→ `main_loop`) are safe; false positives are the real risk
- Tool-result turns that hit the session pin have their `routing.session_pin_tier` annotated with `_tool_result_sc` for observability
- `routing.turn_type` added to the OTel `router.decision` span

**§3.4 — Hard pins for compaction and Explore sub-agent**
- Compaction turns (system prompt contains compaction markers) always route to the cheapest available model (see below); bypass all session-pin tiers, the cluster scorer, and pin upsert
- Explore sub-agent turns (`metadata.user_id` prefix `subagent:` or system prompt marker) route to the cheapest available model when `ROUTER_HARD_PIN_EXPLORE=true` (off by default; enable after one week of shadow validation)
- Hard-pinned turns skip pin upsert so they cannot overwrite the session's main-loop model

**Dynamic cheapest-model resolution**
Rather than hardcoding `claude-haiku-4-5`, the hard-pin target is derived at boot from the cluster artifact bundle's `cost_per_1k_input_usd` map, filtered to providers registered at boot. A deployment that registers Google will automatically pin to `gemini-3.1-flash-lite-preview` ($0.10/1k) instead of Haiku ($0.80/1k). Override with `ROUTER_HARD_PIN_MODEL` + `ROUTER_HARD_PIN_PROVIDER` env vars if needed. Falls back to `("anthropic", "claude-haiku-4-5")` if the bundle can't be loaded.

**Wiring**
- `proxy.NewService` gains `hardPinExplore bool`, `hardPinProvider string`, `hardPinModel string` parameters
- `cmd/router/main.go` reads `ROUTER_HARD_PIN_EXPLORE`, `ROUTER_HARD_PIN_MODEL`, `ROUTER_HARD_PIN_PROVIDER` env vars; derives cheapest model from default bundle

**Tests**
- `internal/router/turntype/detect_test.go`: 15 table-driven cases
- 3 new proxy integration tests: compaction hard-pin, Explore hard-pin (flag on), Explore fallthrough (flag off); each asserts zero cluster-scorer calls and zero pin upserts for hard-pinned turns
- `TestCheapestModel`: 4 cases covering cross-provider selection, provider filtering, no-match, and missing cost annotations

---

<details>
<summary>Plan: §3.3 + §3.4 from AGENTIC_CODING.md</summary>

## Context

Session-sticky routing (§3.1) landed in `29d1f8d`. The session-pin schema is already role-keyed but always emits `role="default"` — the comment in `sessionpin/store.go` explicitly says "role-conditioned pinning waits on the §3.3 turn-type detector."

§3.3 adds a pure-Go turn-type detector so tool-result turns short-circuit to the session pin without calling the cluster scorer. §3.4 hard-pins two specific turn types (compaction → cheapest available, Explore sub-agent → cheapest available) regardless of session state. Together these are the highest-leverage Stage 1 items after §3.1.

### New package: `internal/router/turntype/`

Detection logic (in priority order):

1. **Compaction** — system prompt contains `"your task is to create a detailed summary"` OR (`"compact"` AND `"conversation"`).
2. **SubAgentDispatch** — `metadata.user_id` begins with `"subagent:"`, OR system text contains `"sub-agent"` / `"subagent_type"`.
3. **ToolResult** — last message role is `"user"` and content array has at least one `tool_result` block and zero `text` blocks.
4. **MainLoop** — everything else.

### §3.4 Hard pins

- Compaction: always route to cheapest available model (bypasses cluster scorer, session pins, and pin upsert).
- Explore sub-agent: route to cheapest available model when `ROUTER_HARD_PIN_EXPLORE=true`.
- Cheapest model resolved at boot from `cluster.CheapestModel(bundle.Metadata, bundle.Registry, availableProviders)`.
</details>