### PR TITLE
fix(proxy): wire OpenRouter into Anthropic→OpenAI translation path

### DIFF
--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -545,7 +545,7 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 			proxyWriter = extractor
 		}
 		proxyErr = p.Proxy(ctx, decision, prep, proxyWriter, r)
-	case providers.ProviderOpenAI, providers.ProviderGoogle:
+	case providers.ProviderOpenAI, providers.ProviderGoogle, providers.ProviderOpenRouter:
 		crossFormat = true
 		prep, emitErr := env.PrepareOpenAI(r.Header, opts)
 		if emitErr != nil {


### PR DESCRIPTION
OpenRouter uses the OpenAI-compat wire format but was missing from the `ProviderOpenAI, ProviderGoogle` case in `ProxyMessages`. Any cluster routing decision that landed on an OSS model (Qwen, Llama, DeepSeek via OpenRouter) hit the `default` branch and returned `ErrProviderNotConfigured`.

One-line fix: add `ProviderOpenRouter` to the existing OpenAI-compat case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)