### PR TITLE
feat(providers/google): native Gemini adapter for thought_signature round-trip

### DIFF
--- a/cmd/router/main.go
+++ b/cmd/router/main.go
@@ -129,9 +129,13 @@ func main() {
 	}
 
 	if googleKey := config.GetOr("GOOGLE_PROVIDER_API_KEY", ""); googleKey != "" {
-		googleBaseURL := config.GetOr("GOOGLE_PROVIDER_BASE_URL", googleProvider.DefaultBaseURL)
-		providerMap[providers.ProviderGoogle] = googleProvider.NewClient(googleKey, googleBaseURL)
-		logger.Info("Google (Gemini) provider enabled", "base_url", googleBaseURL)
+		// Native Generative Language REST surface — required for multi-turn
+		// tool use against Gemini 3.x preview models, whose opaque
+		// thought_signature field is not exposed by the OpenAI-compat
+		// surface. See router/internal/providers/google/native_client.go.
+		googleBaseURL := config.GetOr("GOOGLE_PROVIDER_BASE_URL", googleProvider.NativeBaseURL)
+		providerMap[providers.ProviderGoogle] = googleProvider.NewNativeClient(googleKey, googleBaseURL)
+		logger.Info("Google (Gemini) native provider enabled", "base_url", googleBaseURL)
 	}
 
 	availableProviders := make(map[string]struct{}, len(providerMap))

--- a/internal/providers/google/native_client.go
+++ b/internal/providers/google/native_client.go
@@ -1,0 +1,154 @@
+package google
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"workweave/router/internal/observability/otel"
+	"workweave/router/internal/providers"
+	"workweave/router/internal/providers/httputil"
+	"workweave/router/internal/proxy"
+	"workweave/router/internal/router"
+	"workweave/router/internal/translate"
+)
+
+// NativeBaseURL is Google's native Generative Language base URL. Native
+// endpoints sit under /v1beta/models/{model}:generateContent — distinct from
+// the OpenAI-compat surface (which lives under /v1beta/openai). NativeClient
+// composes the per-request URL.
+const NativeBaseURL = "https://generativelanguage.googleapis.com"
+
+// NativeClient is the providers.Client adapter for Google Gemini's native
+// REST surface. The native API both returns and accepts the opaque
+// thought_signature field that multi-turn tool use against Gemini 3.x preview
+// models requires; the OpenAI-compat surface (see Client) does not.
+//
+// Auth is via the x-goog-api-key request header. BYOK credentials on the
+// request context take precedence over the deployment-level key.
+type NativeClient struct {
+	apiKey  string
+	baseURL string
+	http    *http.Client
+}
+
+// NewNativeClient is pooled for sustained traffic to a single host. baseURL
+// defaults to NativeBaseURL when empty.
+func NewNativeClient(apiKey, baseURL string) *NativeClient {
+	if baseURL == "" {
+		baseURL = NativeBaseURL
+	}
+	return &NativeClient{
+		apiKey:  apiKey,
+		baseURL: baseURL,
+		http:    &http.Client{Transport: httputil.NewTransport(5*time.Second, 5*time.Second)},
+	}
+}
+
+// Proxy posts the prepared Gemini-native body to :generateContent (or
+// :streamGenerateContent?alt=sse when the inbound request was streaming) and
+// streams the response back via the provided ResponseWriter.
+//
+// The streaming/non-streaming choice is communicated by the caller: the
+// translate.GeminiToOpenAISSETranslator wrapping w expects Gemini SSE only
+// when the upstream Content-Type advertises text/event-stream. Callers select
+// streaming by setting "X-Stream" on prep.Headers; we strip that synthetic
+// header before forwarding.
+func (c *NativeClient) Proxy(ctx context.Context, decision router.Decision, prep providers.PreparedRequest, w http.ResponseWriter, r *http.Request) error {
+	stream := prep.Headers.Get(translate.GeminiStreamHintHeader) == "true"
+	prep.Headers.Del(translate.GeminiStreamHintHeader)
+
+	method := ":generateContent"
+	query := ""
+	if stream {
+		method = ":streamGenerateContent"
+		query = "?alt=sse"
+	}
+	url := c.baseURL + "/v1beta/models/" + decision.Model + method + query
+
+	upstream, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(prep.Body))
+	if err != nil {
+		return fmt.Errorf("build upstream request: %w", err)
+	}
+	upstream.Header.Set("Content-Type", "application/json")
+	c.applyAPIKey(ctx, upstream)
+	for k, vs := range prep.Headers {
+		upstream.Header[http.CanonicalHeaderKey(k)] = vs
+	}
+	if stream {
+		upstream.Header.Set("Accept", "text/event-stream")
+	}
+
+	t := otel.TimingFrom(ctx)
+	t.StampUpstreamRequest()
+	resp, err := c.http.Do(upstream)
+	if err != nil {
+		return fmt.Errorf("upstream call: %w", err)
+	}
+	defer resp.Body.Close()
+	t.StampUpstreamHeaders()
+
+	providers.CopyUpstreamHeaders(w, resp)
+	w.WriteHeader(resp.StatusCode)
+	return httputil.StreamBody(resp.Body, resp.StatusCode, w, t)
+}
+
+// Passthrough forwards an inbound non-routing request (e.g. /v1/models) to the
+// native surface unchanged. The native API exposes /v1beta/models for model
+// discovery; the inbound /v1/... prefix is rewritten to /v1beta/.
+func (c *NativeClient) Passthrough(ctx context.Context, prep providers.PreparedRequest, w http.ResponseWriter, r *http.Request) error {
+	suffix := r.URL.Path
+	if rest, ok := strings.CutPrefix(suffix, "/v1/"); ok {
+		suffix = "/v1beta/" + rest
+	} else if !strings.HasPrefix(suffix, "/v1beta") {
+		suffix = "/v1beta" + suffix
+	}
+	url := c.baseURL + suffix
+	if r.URL.RawQuery != "" {
+		url += "?" + r.URL.RawQuery
+	}
+
+	upstream, err := http.NewRequestWithContext(ctx, r.Method, url, bytes.NewReader(prep.Body))
+	if err != nil {
+		return fmt.Errorf("build upstream passthrough request: %w", err)
+	}
+	if ct := r.Header.Get("Content-Type"); ct != "" {
+		upstream.Header.Set("Content-Type", ct)
+	}
+	c.applyAPIKey(ctx, upstream)
+	for k, vs := range prep.Headers {
+		upstream.Header[http.CanonicalHeaderKey(k)] = vs
+	}
+	if v := r.Header.Get("Accept"); v != "" {
+		upstream.Header.Set("Accept", v)
+	}
+
+	resp, err := c.http.Do(upstream)
+	if err != nil {
+		return fmt.Errorf("upstream passthrough call: %w", err)
+	}
+	defer resp.Body.Close()
+
+	providers.CopyUpstreamHeaders(w, resp)
+	w.WriteHeader(resp.StatusCode)
+	_, err = io.Copy(w, resp.Body)
+	return err
+}
+
+// applyAPIKey sets x-goog-api-key from BYOK credentials when present, falling
+// back to the deployment-level key. Mirrors Client.Proxy's resolution order.
+func (c *NativeClient) applyAPIKey(ctx context.Context, req *http.Request) {
+	if creds := proxy.CredentialsFromContext(ctx); creds != nil && len(creds.APIKey) > 0 {
+		req.Header.Set("x-goog-api-key", string(creds.APIKey))
+		return
+	}
+	if c.apiKey != "" {
+		req.Header.Set("x-goog-api-key", c.apiKey)
+	}
+}
+
+var _ providers.Client = (*NativeClient)(nil)

--- a/internal/providers/google/native_client_test.go
+++ b/internal/providers/google/native_client_test.go
@@ -1,0 +1,127 @@
+package google_test
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"workweave/router/internal/providers"
+	"workweave/router/internal/providers/google"
+	"workweave/router/internal/proxy"
+	"workweave/router/internal/router"
+	"workweave/router/internal/translate"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNativeClient_GenerateContentURLAndAuth(t *testing.T) {
+	var (
+		gotPath  string
+		gotKey   string
+		gotBody  []byte
+		gotQuery string
+	)
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotKey = r.Header.Get("x-goog-api-key")
+		gotQuery = r.URL.RawQuery
+		gotBody, _ = io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"candidates":[{"content":{"parts":[{"text":"ok"}]}}]}`))
+	}))
+	defer upstream.Close()
+
+	c := google.NewNativeClient("test-key", upstream.URL)
+	rec := httptest.NewRecorder()
+	clientReq := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(""))
+
+	prep := providers.PreparedRequest{
+		Body:    []byte(`{"contents":[{"role":"user","parts":[{"text":"hi"}]}]}`),
+		Headers: make(http.Header),
+	}
+	err := c.Proxy(context.Background(), router.Decision{Model: "gemini-3.1-flash-lite-preview"}, prep, rec, clientReq)
+	require.NoError(t, err)
+
+	assert.Equal(t, "/v1beta/models/gemini-3.1-flash-lite-preview:generateContent", gotPath)
+	assert.Equal(t, "test-key", gotKey)
+	assert.Empty(t, gotQuery, "non-streaming requests must not carry alt=sse")
+	var bodyMap map[string]any
+	require.NoError(t, json.Unmarshal(gotBody, &bodyMap))
+	assert.NotNil(t, bodyMap["contents"])
+	assert.Equal(t, http.StatusOK, rec.Code)
+}
+
+func TestNativeClient_StreamingHintFlipsToStreamGenerateContent(t *testing.T) {
+	var gotPath, gotQuery string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotQuery = r.URL.RawQuery
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`data: {"candidates":[{"content":{"parts":[{"text":"x"}]}}]}` + "\n\n"))
+	}))
+	defer upstream.Close()
+
+	c := google.NewNativeClient("k", upstream.URL)
+	rec := httptest.NewRecorder()
+	prep := providers.PreparedRequest{Body: []byte(`{"contents":[]}`), Headers: make(http.Header)}
+	prep.Headers.Set(translate.GeminiStreamHintHeader, "true")
+	err := c.Proxy(context.Background(), router.Decision{Model: "gemini-x"},
+		prep, rec, httptest.NewRequest(http.MethodPost, "/v1/x", strings.NewReader("")))
+	require.NoError(t, err)
+
+	assert.Equal(t, "/v1beta/models/gemini-x:streamGenerateContent", gotPath)
+	assert.Equal(t, "alt=sse", gotQuery)
+}
+
+func TestNativeClient_StreamHintHeaderStrippedFromUpstream(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// The synthetic hint header is an internal coordination signal; it must
+		// never be forwarded to Gemini.
+		assert.Empty(t, r.Header.Get(translate.GeminiStreamHintHeader))
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	c := google.NewNativeClient("k", upstream.URL)
+	rec := httptest.NewRecorder()
+	prep := providers.PreparedRequest{Body: []byte(`{}`), Headers: make(http.Header)}
+	prep.Headers.Set(translate.GeminiStreamHintHeader, "true")
+	_ = c.Proxy(context.Background(), router.Decision{Model: "g"}, prep, rec,
+		httptest.NewRequest(http.MethodPost, "/v1/x", strings.NewReader("")))
+}
+
+func TestNativeClient_BYOKCredentialsOverrideDeploymentKey(t *testing.T) {
+	var gotKey string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotKey = r.Header.Get("x-goog-api-key")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	c := google.NewNativeClient("deployment-key", upstream.URL)
+	ctx := context.WithValue(context.Background(),
+		proxy.CredentialsContextKey{},
+		&proxy.Credentials{APIKey: []byte("byok-key")})
+
+	rec := httptest.NewRecorder()
+	prep := providers.PreparedRequest{Body: []byte(`{}`), Headers: make(http.Header)}
+	_ = c.Proxy(ctx, router.Decision{Model: "g"}, prep, rec,
+		httptest.NewRequest(http.MethodPost, "/v1/x", strings.NewReader("")))
+	assert.Equal(t, "byok-key", gotKey,
+		"BYOK credentials on context must take precedence over the deployment-level key")
+}
+
+func TestNativeClient_DefaultBaseURL(t *testing.T) {
+	c := google.NewNativeClient("k", "")
+	// We can't easily test the URL without making a real call, but we can
+	// verify the constant is what we expect.
+	assert.Equal(t, "https://generativelanguage.googleapis.com", google.NativeBaseURL)
+	_ = c
+}

--- a/internal/providers/google/native_integration_test.go
+++ b/internal/providers/google/native_integration_test.go
@@ -1,0 +1,187 @@
+//go:build google_integration
+// +build google_integration
+
+package google_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+
+	"workweave/router/internal/providers"
+	"workweave/router/internal/providers/google"
+	"workweave/router/internal/router"
+	"workweave/router/internal/translate"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestNative_TwoTurnToolUseRoundTripsThoughtSignature is the load-bearing
+// integration test for the native adapter. Run with:
+//
+//	GOOGLE_PROVIDER_API_KEY=... go test -tags=google_integration \
+//	  -run TestNative ./internal/providers/google/
+//
+// Asserts a complete tool-use loop succeeds against the real Gemini native
+// API: the model emits a functionCall with a thoughtSignature; we round-trip
+// that signature on the next turn alongside a functionResponse; the model
+// produces a final text answer without 400-ing on the missing signature.
+func TestNative_TwoTurnToolUseRoundTripsThoughtSignature(t *testing.T) {
+	key := os.Getenv("GOOGLE_PROVIDER_API_KEY")
+	if key == "" {
+		t.Skip("GOOGLE_PROVIDER_API_KEY not set")
+	}
+
+	const model = "gemini-2.5-flash"
+	c := google.NewNativeClient(key, "")
+
+	// Turn 1: ask the model to use a tool.
+	turn1 := map[string]any{
+		"contents": []any{
+			map[string]any{"role": "user", "parts": []any{map[string]any{"text": "What is the weather in San Francisco? Use the get_weather tool."}}},
+		},
+		"tools": []any{
+			map[string]any{"functionDeclarations": []any{
+				map[string]any{
+					"name":        "get_weather",
+					"description": "Get current weather for a location",
+					"parameters": map[string]any{
+						"type": "object",
+						"properties": map[string]any{
+							"location": map[string]any{"type": "string"},
+						},
+						"required": []any{"location"},
+					},
+				},
+			}},
+		},
+		"toolConfig": map[string]any{"functionCallingConfig": map[string]any{"mode": "ANY"}},
+	}
+	body1, err := json.Marshal(turn1)
+	require.NoError(t, err)
+
+	rec1 := httptest.NewRecorder()
+	prep1 := providers.PreparedRequest{Body: body1, Headers: make(http.Header)}
+	require.NoError(t, c.Proxy(context.Background(),
+		router.Decision{Model: model}, prep1, rec1,
+		httptest.NewRequest(http.MethodPost, "/v1/x", strings.NewReader(""))))
+
+	require.Equal(t, http.StatusOK, rec1.Code, "turn 1 must succeed; got body: %s", rec1.Body.String())
+
+	var resp1 map[string]any
+	require.NoError(t, json.Unmarshal(rec1.Body.Bytes(), &resp1))
+	candidates, _ := resp1["candidates"].([]any)
+	require.NotEmpty(t, candidates, "turn 1 must return a candidate; got: %s", rec1.Body.String())
+	parts := candidates[0].(map[string]any)["content"].(map[string]any)["parts"].([]any)
+
+	var fcPart map[string]any
+	for _, p := range parts {
+		if pm, ok := p.(map[string]any); ok {
+			if _, hasFC := pm["functionCall"]; hasFC {
+				fcPart = pm
+				break
+			}
+		}
+	}
+	require.NotNil(t, fcPart, "turn 1 must produce a functionCall part; parts=%v", parts)
+
+	sig, _ := fcPart["thoughtSignature"].(string)
+	t.Logf("turn 1 thoughtSignature length: %d", len(sig))
+	// Gemini 3.x requires the signature; for Gemini 2.5 it may or may not be
+	// present. The test still verifies the round-trip succeeds either way.
+
+	// Turn 2: round-trip the assistant turn (with thoughtSignature) and
+	// supply a functionResponse.
+	assistantPart := map[string]any{
+		"functionCall": fcPart["functionCall"],
+	}
+	if sig != "" {
+		assistantPart["thoughtSignature"] = sig
+	}
+	turn2 := map[string]any{
+		"contents": []any{
+			turn1["contents"].([]any)[0],
+			map[string]any{"role": "model", "parts": []any{assistantPart}},
+			map[string]any{"role": "user", "parts": []any{
+				map[string]any{"functionResponse": map[string]any{
+					"name":     fcPart["functionCall"].(map[string]any)["name"],
+					"response": map[string]any{"result": "62°F and sunny"},
+				}},
+			}},
+		},
+		"tools":      turn1["tools"],
+		"toolConfig": map[string]any{"functionCallingConfig": map[string]any{"mode": "AUTO"}},
+	}
+	body2, err := json.Marshal(turn2)
+	require.NoError(t, err)
+
+	rec2 := httptest.NewRecorder()
+	prep2 := providers.PreparedRequest{Body: body2, Headers: make(http.Header)}
+	require.NoError(t, c.Proxy(context.Background(),
+		router.Decision{Model: model}, prep2, rec2,
+		httptest.NewRequest(http.MethodPost, "/v1/x", strings.NewReader(""))))
+
+	require.Equal(t, http.StatusOK, rec2.Code,
+		"turn 2 must succeed (no thought_signature 400); body: %s", rec2.Body.String())
+
+	var resp2 map[string]any
+	require.NoError(t, json.Unmarshal(rec2.Body.Bytes(), &resp2))
+	t.Logf("turn 2 response: %s", rec2.Body.String())
+
+	// Sanity: turn 2 produced something — either a text answer or another
+	// functionCall (model's choice). The assertion that matters is the
+	// HTTP 200 above.
+	cands2 := resp2["candidates"].([]any)
+	require.NotEmpty(t, cands2)
+}
+
+func TestNative_GenerateContentTextOnly(t *testing.T) {
+	key := os.Getenv("GOOGLE_PROVIDER_API_KEY")
+	if key == "" {
+		t.Skip("GOOGLE_PROVIDER_API_KEY not set")
+	}
+	c := google.NewNativeClient(key, "")
+	body, _ := json.Marshal(map[string]any{
+		"contents": []any{
+			map[string]any{"role": "user", "parts": []any{map[string]any{"text": "Reply with a single word: hello"}}},
+		},
+	})
+	rec := httptest.NewRecorder()
+	prep := providers.PreparedRequest{Body: body, Headers: make(http.Header)}
+	err := c.Proxy(context.Background(),
+		router.Decision{Model: "gemini-2.5-flash"}, prep, rec,
+		httptest.NewRequest(http.MethodPost, "/v1/x", strings.NewReader("")))
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, rec.Code, "body: %s", rec.Body.String())
+}
+
+// TestNative_StreamGenerateContent verifies the streaming hint flips the URL
+// to :streamGenerateContent?alt=sse and the response is text/event-stream.
+func TestNative_StreamGenerateContent(t *testing.T) {
+	key := os.Getenv("GOOGLE_PROVIDER_API_KEY")
+	if key == "" {
+		t.Skip("GOOGLE_PROVIDER_API_KEY not set")
+	}
+	c := google.NewNativeClient(key, "")
+	body, _ := json.Marshal(map[string]any{
+		"contents": []any{
+			map[string]any{"role": "user", "parts": []any{map[string]any{"text": "Count to three."}}},
+		},
+	})
+	rec := httptest.NewRecorder()
+	prep := providers.PreparedRequest{Body: body, Headers: make(http.Header)}
+	prep.Headers.Set(translate.GeminiStreamHintHeader, "true")
+	err := c.Proxy(context.Background(),
+		router.Decision{Model: "gemini-2.5-flash"}, prep, rec,
+		httptest.NewRequest(http.MethodPost, "/v1/x", strings.NewReader("")))
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, rec.Code, "body: %s", rec.Body.String())
+	assert.Contains(t, rec.Header().Get("Content-Type"), "text/event-stream",
+		"streaming response must advertise SSE content-type")
+	assert.Contains(t, rec.Body.String(), "data:")
+}

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -545,7 +545,7 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 			proxyWriter = extractor
 		}
 		proxyErr = p.Proxy(ctx, decision, prep, proxyWriter, r)
-	case providers.ProviderOpenAI, providers.ProviderGoogle, providers.ProviderOpenRouter:
+	case providers.ProviderOpenAI, providers.ProviderOpenRouter:
 		crossFormat = true
 		prep, emitErr := env.PrepareOpenAI(r.Header, opts)
 		if emitErr != nil {
@@ -561,6 +561,28 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 		proxyErr = p.Proxy(ctx, decision, prep, translator, r)
 		if proxyErr == nil {
 			proxyErr = translator.Finalize()
+		}
+	case providers.ProviderGoogle:
+		crossFormat = true
+		prep, emitErr := env.PrepareGemini(r.Header, opts)
+		if emitErr != nil {
+			log.Error("Failed to translate Anthropic request to Gemini format", "err", emitErr)
+			return fmt.Errorf("translate anthropic request to gemini: %w", emitErr)
+		}
+		var usage otel.UsageSink
+		if s.emitter != nil {
+			extractor = otel.NewUsageExtractor(nil, decision.Provider)
+			usage = extractor
+		}
+		// Chain: Gemini SSE → OpenAI SSE → Anthropic SSE.
+		anthropicTr := translate.NewAnthropicSSETranslator(sink, decision.Model, usage)
+		geminiTr := translate.NewGeminiToOpenAISSETranslator(anthropicTr, decision.Model, nil)
+		proxyErr = p.Proxy(ctx, decision, prep, geminiTr, r)
+		if proxyErr == nil {
+			proxyErr = geminiTr.Finalize()
+		}
+		if proxyErr == nil {
+			proxyErr = anthropicTr.Finalize()
 		}
 	default:
 		return fmt.Errorf("%w: %s (no translation path defined for inbound Anthropic Messages)", ErrProviderNotConfigured, decision.Provider)
@@ -878,7 +900,7 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 	var extractor *otel.UsageExtractor
 
 	switch decision.Provider {
-	case providers.ProviderOpenAI, providers.ProviderGoogle, providers.ProviderOpenRouter:
+	case providers.ProviderOpenAI, providers.ProviderOpenRouter:
 		prep, emitErr := env.PrepareOpenAI(r.Header, opts)
 		if emitErr != nil {
 			log.Error("Failed to emit OpenAI body", "err", emitErr)
@@ -890,6 +912,23 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 			proxyWriter = extractor
 		}
 		proxyErr = p.Proxy(ctx, decision, prep, proxyWriter, r)
+	case providers.ProviderGoogle:
+		crossFormat = true
+		prep, emitErr := env.PrepareGemini(r.Header, opts)
+		if emitErr != nil {
+			log.Error("Failed to translate OpenAI request to Gemini format", "err", emitErr)
+			return fmt.Errorf("translate openai request to gemini: %w", emitErr)
+		}
+		var usage otel.UsageSink
+		if s.emitter != nil {
+			extractor = otel.NewUsageExtractor(nil, decision.Provider)
+			usage = extractor
+		}
+		translator := translate.NewGeminiToOpenAISSETranslator(sink, decision.Model, usage)
+		proxyErr = p.Proxy(ctx, decision, prep, translator, r)
+		if proxyErr == nil {
+			proxyErr = translator.Finalize()
+		}
 	case providers.ProviderAnthropic:
 		crossFormat = true
 		prep, emitErr := env.PrepareAnthropic(r.Header, opts)

--- a/internal/translate/emit_gemini.go
+++ b/internal/translate/emit_gemini.go
@@ -1,0 +1,701 @@
+package translate
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"workweave/router/internal/providers"
+
+	"github.com/tidwall/gjson"
+)
+
+// PrepareGemini builds a fully-prepared request body for Google Gemini's native
+// REST surface (POST /v1beta/models/{model}:generateContent). Required for
+// multi-turn tool use against Gemini 3.x preview models, which need the opaque
+// thought_signature field round-tripped — Gemini's OpenAI-compat surface does
+// not return that field.
+//
+// Source format may be OpenAI (Chat Completions wire) or Anthropic Messages.
+// In both cases we walk the parsed body map (e.ensureSrc) and write a fresh
+// Gemini native body.
+func (e *RequestEnvelope) PrepareGemini(_ http.Header, opts EmitOptions) (providers.PreparedRequest, error) {
+	src, err := e.ensureSrc()
+	if err != nil {
+		return providers.PreparedRequest{}, err
+	}
+
+	out := make(map[string]any)
+
+	switch e.format {
+	case FormatOpenAI:
+		if err := pullOpenAISystemAndContents(src, out); err != nil {
+			return providers.PreparedRequest{}, err
+		}
+		if err := pullOpenAIToolsToGemini(src, out); err != nil {
+			return providers.PreparedRequest{}, err
+		}
+		pullOpenAIToolChoiceToGemini(e.body, out)
+		pullOpenAIGenerationConfig(e.body, out, opts.TargetModel)
+	case FormatAnthropic:
+		pullAnthropicSystemToGemini(src, out)
+		if err := pullAnthropicContentsToGemini(src, out); err != nil {
+			return providers.PreparedRequest{}, err
+		}
+		if err := pullAnthropicToolsToGemini(src, out); err != nil {
+			return providers.PreparedRequest{}, err
+		}
+		pullAnthropicToolChoiceToGemini(e.body, out)
+		pullAnthropicGenerationConfig(e.body, out, opts.TargetModel)
+	default:
+		return providers.PreparedRequest{}, fmt.Errorf("unsupported source format for Gemini emit: %d", e.format)
+	}
+
+	body, err := json.Marshal(out)
+	if err != nil {
+		return providers.PreparedRequest{}, fmt.Errorf("marshal gemini body: %w", err)
+	}
+	// Hint to the native client whether to hit :streamGenerateContent vs
+	// :generateContent. Carried as a synthetic header on PreparedRequest so
+	// the proxy.Service stays ignorant of provider-specific URL composition.
+	headers := make(http.Header)
+	if e.Stream() {
+		headers.Set(GeminiStreamHintHeader, "true")
+	}
+	return providers.PreparedRequest{Body: body, Headers: headers}, nil
+}
+
+// GeminiStreamHintHeader is the synthetic header PrepareGemini sets when the
+// inbound request asked for streaming. The google native client consumes it
+// to choose between :generateContent and :streamGenerateContent and strips
+// it before forwarding upstream.
+const GeminiStreamHintHeader = "X-Router-Gemini-Stream"
+
+// ----- OpenAI → Gemini -----
+
+// pullOpenAISystemAndContents walks OpenAI messages, concatenating role:system
+// messages into systemInstruction and converting the rest into Gemini contents.
+func pullOpenAISystemAndContents(src map[string]any, out map[string]any) error {
+	msgs, _ := src["messages"].([]any)
+	if len(msgs) == 0 {
+		return nil
+	}
+
+	// First pass: build a map of tool_call_id → function name so role:tool
+	// messages can recover the function name for functionResponse.
+	toolNames := openAICollectToolCallNames(msgs)
+
+	var sysParts []string
+	var contents []any
+	for _, raw := range msgs {
+		msg, _ := raw.(map[string]any)
+		if msg == nil {
+			continue
+		}
+		role, _ := msg["role"].(string)
+		switch role {
+		case "system":
+			if s := openAITextContent(msg["content"]); s != "" {
+				sysParts = append(sysParts, s)
+			}
+		case "user":
+			parts := openAIUserToGeminiParts(msg["content"])
+			if len(parts) > 0 {
+				contents = append(contents, map[string]any{"role": "user", "parts": parts})
+			}
+		case "assistant":
+			parts, err := openAIAssistantToGeminiParts(msg)
+			if err != nil {
+				return err
+			}
+			if len(parts) > 0 {
+				contents = append(contents, map[string]any{"role": "model", "parts": parts})
+			}
+		case "tool":
+			tcID, _ := msg["tool_call_id"].(string)
+			name := toolNames[tcID]
+			result := openAITextContent(msg["content"])
+			contents = append(contents, map[string]any{
+				"role":  "user",
+				"parts": []any{map[string]any{"functionResponse": map[string]any{"name": name, "response": map[string]any{"result": result}}}},
+			})
+		}
+	}
+
+	if len(sysParts) > 0 {
+		out["systemInstruction"] = map[string]any{
+			"parts": []any{map[string]any{"text": strings.Join(sysParts, "\n")}},
+		}
+	}
+	if len(contents) > 0 {
+		out["contents"] = contents
+	}
+	return nil
+}
+
+func openAICollectToolCallNames(msgs []any) map[string]string {
+	out := map[string]string{}
+	for _, raw := range msgs {
+		msg, _ := raw.(map[string]any)
+		if msg == nil {
+			continue
+		}
+		if r, _ := msg["role"].(string); r != "assistant" {
+			continue
+		}
+		tcs, _ := msg["tool_calls"].([]any)
+		for _, t := range tcs {
+			tc, _ := t.(map[string]any)
+			if tc == nil {
+				continue
+			}
+			id, _ := tc["id"].(string)
+			fn, _ := tc["function"].(map[string]any)
+			name, _ := fn["name"].(string)
+			if id != "" {
+				out[id] = name
+			}
+		}
+	}
+	return out
+}
+
+// openAITextContent returns the textual content from an OpenAI message.content
+// field, accepting both the bare-string and the array-of-parts shapes.
+func openAITextContent(content any) string {
+	switch c := content.(type) {
+	case string:
+		return c
+	case []any:
+		var parts []string
+		for _, p := range c {
+			pm, _ := p.(map[string]any)
+			if pm == nil {
+				continue
+			}
+			if t, _ := pm["type"].(string); t == "text" {
+				if s, _ := pm["text"].(string); s != "" {
+					parts = append(parts, s)
+				}
+			}
+		}
+		return strings.Join(parts, "\n")
+	default:
+		return ""
+	}
+}
+
+// openAIUserToGeminiParts turns OpenAI user content into Gemini Parts (text +
+// inlineData). data: URLs are decoded to inline base64 with the embedded
+// mime type.
+func openAIUserToGeminiParts(content any) []any {
+	switch c := content.(type) {
+	case string:
+		if c == "" {
+			return nil
+		}
+		return []any{map[string]any{"text": c}}
+	case []any:
+		var parts []any
+		for _, p := range c {
+			pm, _ := p.(map[string]any)
+			if pm == nil {
+				continue
+			}
+			switch t, _ := pm["type"].(string); t {
+			case "text":
+				if s, _ := pm["text"].(string); s != "" {
+					parts = append(parts, map[string]any{"text": s})
+				}
+			case "image_url":
+				img, _ := pm["image_url"].(map[string]any)
+				url, _ := img["url"].(string)
+				if part := dataURLToInlinePart(url); part != nil {
+					parts = append(parts, part)
+				}
+			}
+		}
+		return parts
+	}
+	return nil
+}
+
+// dataURLToInlinePart parses a "data:<mime>;base64,<payload>" URL into a
+// Gemini inlineData part. Plain http(s):// URLs are unsupported on the native
+// surface; they are dropped (Gemini supports fileData with a Files API URI,
+// not arbitrary public URLs).
+func dataURLToInlinePart(url string) map[string]any {
+	if !strings.HasPrefix(url, "data:") {
+		return nil
+	}
+	rest := strings.TrimPrefix(url, "data:")
+	mime, payload, ok := strings.Cut(rest, ";base64,")
+	if !ok {
+		return nil
+	}
+	if mime == "" {
+		mime = "image/jpeg"
+	}
+	// Validate base64 once so the upstream rejects don't surface as opaque
+	// 400s; we re-emit as base64 verbatim because Gemini wants the raw
+	// base64 string in inlineData.data, not bytes.
+	if _, err := base64.StdEncoding.DecodeString(payload); err != nil {
+		return nil
+	}
+	return map[string]any{
+		"inlineData": map[string]any{"mimeType": mime, "data": payload},
+	}
+}
+
+// openAIAssistantToGeminiParts converts an OpenAI assistant message to Gemini
+// model-role Parts. Text content becomes a text part; each tool_call becomes
+// a functionCall part. thought_signature smuggled on tool_calls is preserved
+// as thoughtSignature on the corresponding part — the load-bearing round-trip
+// for Gemini 3.x multi-turn tool use.
+func openAIAssistantToGeminiParts(msg map[string]any) ([]any, error) {
+	var parts []any
+	if s := openAITextContent(msg["content"]); s != "" {
+		parts = append(parts, map[string]any{"text": s})
+	}
+	tcs, _ := msg["tool_calls"].([]any)
+	for _, t := range tcs {
+		tc, _ := t.(map[string]any)
+		if tc == nil {
+			continue
+		}
+		fn, _ := tc["function"].(map[string]any)
+		name, _ := fn["name"].(string)
+		argsStr, _ := fn["arguments"].(string)
+		var args any = map[string]any{}
+		if argsStr != "" {
+			if err := json.Unmarshal([]byte(argsStr), &args); err != nil {
+				return nil, fmt.Errorf("parse tool_call arguments: %w", err)
+			}
+		}
+		part := map[string]any{
+			"functionCall": map[string]any{"name": name, "args": args},
+		}
+		// thought_signature may live either on the tool_call itself or on
+		// the function object; round-trip whichever shape we receive.
+		if sig, _ := tc["thought_signature"].(string); sig != "" {
+			part["thoughtSignature"] = sig
+		} else if sig, _ := fn["thought_signature"].(string); sig != "" {
+			part["thoughtSignature"] = sig
+		}
+		parts = append(parts, part)
+	}
+	return parts, nil
+}
+
+// ----- OpenAI tools / tool_choice / generationConfig → Gemini -----
+
+func pullOpenAIToolsToGemini(src map[string]any, out map[string]any) error {
+	tools, _ := src["tools"].([]any)
+	if len(tools) == 0 {
+		return nil
+	}
+	var decls []any
+	for _, t := range tools {
+		tool, _ := t.(map[string]any)
+		fn, _ := tool["function"].(map[string]any)
+		if fn == nil {
+			continue
+		}
+		decl := map[string]any{"name": fn["name"]}
+		if d, ok := fn["description"]; ok {
+			decl["description"] = d
+		}
+		if p, ok := fn["parameters"]; ok && p != nil {
+			decl["parameters"] = p
+		}
+		decls = append(decls, decl)
+	}
+	if len(decls) == 0 {
+		return nil
+	}
+	out["tools"] = []any{map[string]any{"functionDeclarations": decls}}
+	return nil
+}
+
+func pullOpenAIToolChoiceToGemini(body []byte, out map[string]any) {
+	r := gjson.GetBytes(body, "tool_choice")
+	if !r.Exists() {
+		return
+	}
+	if r.Type == gjson.String {
+		switch r.String() {
+		case "auto":
+			out["toolConfig"] = map[string]any{"functionCallingConfig": map[string]any{"mode": "AUTO"}}
+		case "none":
+			out["toolConfig"] = map[string]any{"functionCallingConfig": map[string]any{"mode": "NONE"}}
+		case "required":
+			out["toolConfig"] = map[string]any{"functionCallingConfig": map[string]any{"mode": "ANY"}}
+		}
+		return
+	}
+	if r.IsObject() && r.Get("type").String() == "function" {
+		name := r.Get("function.name").String()
+		if name == "" {
+			return
+		}
+		out["toolConfig"] = map[string]any{
+			"functionCallingConfig": map[string]any{
+				"mode":                 "ANY",
+				"allowedFunctionNames": []any{name},
+			},
+		}
+	}
+}
+
+func pullOpenAIGenerationConfig(body []byte, out map[string]any, model string) {
+	gc := make(map[string]any)
+	if r := gjson.GetBytes(body, "temperature"); r.Exists() && r.Type == gjson.Number {
+		gc["temperature"] = r.Num
+	}
+	if r := gjson.GetBytes(body, "top_p"); r.Exists() && r.Type == gjson.Number {
+		gc["topP"] = r.Num
+	}
+	if r := gjson.GetBytes(body, "max_tokens"); r.Exists() && r.Type == gjson.Number {
+		gc["maxOutputTokens"] = clampToModelOutputCap(int64(r.Num), model)
+	}
+	if r := gjson.GetBytes(body, "max_completion_tokens"); r.Exists() && r.Type == gjson.Number {
+		gc["maxOutputTokens"] = clampToModelOutputCap(int64(r.Num), model)
+	}
+	if r := gjson.GetBytes(body, "stop"); r.Exists() {
+		gc["stopSequences"] = stopToArray(r)
+	}
+	if r := gjson.GetBytes(body, "response_format"); r.Exists() && r.IsObject() {
+		if r.Get("type").String() == "json_object" {
+			gc["responseMimeType"] = "application/json"
+		}
+	}
+	if r := gjson.GetBytes(body, "reasoning_effort"); r.Exists() && r.Type == gjson.String {
+		if tc, ok := mapReasoningEffortToThinkingConfig(r.String()); ok {
+			gc["thinkingConfig"] = tc
+		}
+	}
+	if len(gc) > 0 {
+		out["generationConfig"] = gc
+	}
+}
+
+func clampToModelOutputCap(v int64, model string) int64 {
+	cap := modelMaxOutputTokens[model]
+	if cap == 0 {
+		cap = defaultMaxOutputTokenCap
+	}
+	if v > int64(cap) {
+		return int64(cap)
+	}
+	return v
+}
+
+func stopToArray(r gjson.Result) []any {
+	if r.IsArray() {
+		var out []any
+		r.ForEach(func(_, v gjson.Result) bool {
+			out = append(out, v.String())
+			return true
+		})
+		return out
+	}
+	if r.Type == gjson.String {
+		return []any{r.String()}
+	}
+	return nil
+}
+
+// mapReasoningEffortToThinkingConfig mirrors the table Google publishes for
+// their OpenAI-compat surface. "none" passes through with thinkingBudget=0;
+// Gemini 3.x rejects it but we let the upstream surface its own error rather
+// than masking it here.
+func mapReasoningEffortToThinkingConfig(effort string) (map[string]any, bool) {
+	switch effort {
+	case "none":
+		return map[string]any{"thinkingBudget": 0}, true
+	case "low":
+		return map[string]any{"thinkingBudget": 1024}, true
+	case "medium":
+		return map[string]any{"thinkingBudget": 8192}, true
+	case "high":
+		return map[string]any{"thinkingBudget": 24576}, true
+	}
+	return nil, false
+}
+
+// ----- Anthropic → Gemini -----
+
+func pullAnthropicSystemToGemini(src map[string]any, out map[string]any) {
+	system := src["system"]
+	var parts []string
+	switch s := system.(type) {
+	case string:
+		if s != "" {
+			parts = append(parts, s)
+		}
+	case []any:
+		for _, b := range s {
+			block, _ := b.(map[string]any)
+			if block == nil {
+				continue
+			}
+			if t, _ := block["type"].(string); t == "text" {
+				if text, _ := block["text"].(string); text != "" {
+					parts = append(parts, text)
+				}
+			}
+		}
+	}
+	if len(parts) == 0 {
+		return
+	}
+	out["systemInstruction"] = map[string]any{
+		"parts": []any{map[string]any{"text": strings.Join(parts, "\n")}},
+	}
+}
+
+// pullAnthropicContentsToGemini converts Anthropic messages into Gemini
+// contents. tool_use blocks on assistant messages become functionCall parts
+// (round-tripping thought_signature); tool_result blocks on user messages
+// become functionResponse parts. Tracks tool_use_id → function name so a
+// later tool_result block can recover the name Gemini requires.
+func pullAnthropicContentsToGemini(src map[string]any, out map[string]any) error {
+	msgs, _ := src["messages"].([]any)
+	if len(msgs) == 0 {
+		return nil
+	}
+	toolNames := anthropicCollectToolUseNames(msgs)
+
+	var contents []any
+	for _, raw := range msgs {
+		msg, _ := raw.(map[string]any)
+		if msg == nil {
+			continue
+		}
+		role, _ := msg["role"].(string)
+		switch role {
+		case "user":
+			parts, err := anthropicUserToGeminiParts(msg["content"], toolNames)
+			if err != nil {
+				return err
+			}
+			if len(parts) > 0 {
+				contents = append(contents, map[string]any{"role": "user", "parts": parts})
+			}
+		case "assistant":
+			parts, err := anthropicAssistantToGeminiParts(msg["content"])
+			if err != nil {
+				return err
+			}
+			if len(parts) > 0 {
+				contents = append(contents, map[string]any{"role": "model", "parts": parts})
+			}
+		}
+	}
+	if len(contents) > 0 {
+		out["contents"] = contents
+	}
+	return nil
+}
+
+func anthropicCollectToolUseNames(msgs []any) map[string]string {
+	out := map[string]string{}
+	for _, raw := range msgs {
+		msg, _ := raw.(map[string]any)
+		if msg == nil {
+			continue
+		}
+		if r, _ := msg["role"].(string); r != "assistant" {
+			continue
+		}
+		blocks, _ := msg["content"].([]any)
+		for _, b := range blocks {
+			block, _ := b.(map[string]any)
+			if block == nil {
+				continue
+			}
+			if t, _ := block["type"].(string); t != "tool_use" {
+				continue
+			}
+			id, _ := block["id"].(string)
+			name, _ := block["name"].(string)
+			if id != "" {
+				out[id] = name
+			}
+		}
+	}
+	return out
+}
+
+func anthropicUserToGeminiParts(content any, toolNames map[string]string) ([]any, error) {
+	switch c := content.(type) {
+	case string:
+		if c == "" {
+			return nil, nil
+		}
+		return []any{map[string]any{"text": c}}, nil
+	case []any:
+		var parts []any
+		for _, b := range c {
+			block, _ := b.(map[string]any)
+			if block == nil {
+				continue
+			}
+			switch t, _ := block["type"].(string); t {
+			case "text":
+				if text, _ := block["text"].(string); text != "" {
+					parts = append(parts, map[string]any{"text": text})
+				}
+			case "image":
+				if part := anthropicImageToInlinePart(block); part != nil {
+					parts = append(parts, part)
+				}
+			case "tool_result":
+				id, _ := block["tool_use_id"].(string)
+				name := toolNames[id]
+				result := toolResultContent(block["content"])
+				parts = append(parts, map[string]any{
+					"functionResponse": map[string]any{"name": name, "response": map[string]any{"result": result}},
+				})
+			}
+		}
+		return parts, nil
+	}
+	return nil, nil
+}
+
+func anthropicImageToInlinePart(block map[string]any) map[string]any {
+	src, _ := block["source"].(map[string]any)
+	if src == nil {
+		return nil
+	}
+	if t, _ := src["type"].(string); t != "base64" {
+		return nil
+	}
+	data, _ := src["data"].(string)
+	mime, _ := src["media_type"].(string)
+	if data == "" {
+		return nil
+	}
+	if mime == "" {
+		mime = "image/jpeg"
+	}
+	return map[string]any{"inlineData": map[string]any{"mimeType": mime, "data": data}}
+}
+
+func anthropicAssistantToGeminiParts(content any) ([]any, error) {
+	switch c := content.(type) {
+	case string:
+		if c == "" {
+			return nil, nil
+		}
+		return []any{map[string]any{"text": c}}, nil
+	case []any:
+		var parts []any
+		for _, b := range c {
+			block, _ := b.(map[string]any)
+			if block == nil {
+				continue
+			}
+			switch t, _ := block["type"].(string); t {
+			case "text":
+				if text, _ := block["text"].(string); text != "" {
+					parts = append(parts, map[string]any{"text": text})
+				}
+			case "tool_use":
+				name, _ := block["name"].(string)
+				input := block["input"]
+				if input == nil {
+					input = map[string]any{}
+				}
+				part := map[string]any{
+					"functionCall": map[string]any{"name": name, "args": input},
+				}
+				if sig, _ := block["thought_signature"].(string); sig != "" {
+					part["thoughtSignature"] = sig
+				}
+				parts = append(parts, part)
+			}
+		}
+		return parts, nil
+	}
+	return nil, nil
+}
+
+func pullAnthropicToolsToGemini(src map[string]any, out map[string]any) error {
+	tools, _ := src["tools"].([]any)
+	if len(tools) == 0 {
+		return nil
+	}
+	var decls []any
+	for _, t := range tools {
+		tool, _ := t.(map[string]any)
+		if tool == nil {
+			continue
+		}
+		name, _ := tool["name"].(string)
+		if name == "" {
+			continue
+		}
+		decl := map[string]any{"name": name}
+		if d, ok := tool["description"]; ok {
+			decl["description"] = d
+		}
+		if p, ok := tool["input_schema"]; ok && p != nil {
+			decl["parameters"] = p
+		}
+		decls = append(decls, decl)
+	}
+	if len(decls) == 0 {
+		return nil
+	}
+	out["tools"] = []any{map[string]any{"functionDeclarations": decls}}
+	return nil
+}
+
+func pullAnthropicToolChoiceToGemini(body []byte, out map[string]any) {
+	r := gjson.GetBytes(body, "tool_choice")
+	if !r.Exists() || !r.IsObject() {
+		return
+	}
+	switch r.Get("type").String() {
+	case "auto":
+		out["toolConfig"] = map[string]any{"functionCallingConfig": map[string]any{"mode": "AUTO"}}
+	case "any":
+		out["toolConfig"] = map[string]any{"functionCallingConfig": map[string]any{"mode": "ANY"}}
+	case "none":
+		out["toolConfig"] = map[string]any{"functionCallingConfig": map[string]any{"mode": "NONE"}}
+	case "tool":
+		name := r.Get("name").String()
+		if name == "" {
+			return
+		}
+		out["toolConfig"] = map[string]any{
+			"functionCallingConfig": map[string]any{
+				"mode":                 "ANY",
+				"allowedFunctionNames": []any{name},
+			},
+		}
+	}
+}
+
+func pullAnthropicGenerationConfig(body []byte, out map[string]any, model string) {
+	gc := make(map[string]any)
+	if r := gjson.GetBytes(body, "temperature"); r.Exists() && r.Type == gjson.Number {
+		gc["temperature"] = r.Num
+	}
+	if r := gjson.GetBytes(body, "top_p"); r.Exists() && r.Type == gjson.Number {
+		gc["topP"] = r.Num
+	}
+	if r := gjson.GetBytes(body, "max_tokens"); r.Exists() && r.Type == gjson.Number {
+		gc["maxOutputTokens"] = clampToModelOutputCap(int64(r.Num), model)
+	}
+	if r := gjson.GetBytes(body, "stop_sequences"); r.Exists() {
+		gc["stopSequences"] = stopToArray(r)
+	}
+	if len(gc) > 0 {
+		out["generationConfig"] = gc
+	}
+}

--- a/internal/translate/gemini_response.go
+++ b/internal/translate/gemini_response.go
@@ -1,0 +1,389 @@
+package translate
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// GeminiToOpenAIResponse converts a non-streaming Gemini :generateContent
+// response to an OpenAI Chat Completion response. requestModel is the model
+// the client originally asked for; used as the response.model field (Gemini's
+// native body does not echo the requested model).
+func GeminiToOpenAIResponse(body []byte, requestModel string) ([]byte, error) {
+	var resp map[string]any
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return nil, fmt.Errorf("unmarshal gemini response: %w", err)
+	}
+
+	candidates, _ := resp["candidates"].([]any)
+	var first map[string]any
+	if len(candidates) > 0 {
+		first, _ = candidates[0].(map[string]any)
+	}
+
+	textContent, toolCalls, leadingSig := extractGeminiParts(first)
+	finishReason := mapGeminiFinishReason(stringField(first, "finishReason"), len(toolCalls) > 0)
+
+	message := map[string]any{"role": "assistant"}
+	if textContent != "" {
+		message["content"] = textContent
+	} else {
+		message["content"] = nil
+	}
+	if len(toolCalls) > 0 {
+		message["tool_calls"] = toolCalls
+	} else if leadingSig != "" {
+		// Off-spec extra field for thoughtSignature on a text-only response.
+		// litellm/openai-go pass through unknown fields.
+		message["thought_signature"] = leadingSig
+	}
+
+	out := map[string]any{
+		"id":      generateChatCmplID(),
+		"object":  "chat.completion",
+		"created": time.Now().Unix(),
+		"model":   requestModel,
+		"choices": []any{map[string]any{
+			"index":         0,
+			"message":       message,
+			"finish_reason": finishReason,
+		}},
+		"usage": geminiUsageToOpenAI(resp["usageMetadata"]),
+	}
+	return json.Marshal(out)
+}
+
+// GeminiToAnthropicResponse converts a non-streaming Gemini response to an
+// Anthropic Messages response. requestModel is echoed as response.model.
+func GeminiToAnthropicResponse(body []byte, requestModel string) ([]byte, error) {
+	var resp map[string]any
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return nil, fmt.Errorf("unmarshal gemini response: %w", err)
+	}
+
+	candidates, _ := resp["candidates"].([]any)
+	var first map[string]any
+	if len(candidates) > 0 {
+		first, _ = candidates[0].(map[string]any)
+	}
+
+	blocks := buildAnthropicBlocksFromGemini(first)
+	stopReason := mapGeminiFinishReasonToAnthropic(stringField(first, "finishReason"), blocksContainToolUse(blocks))
+
+	out := map[string]any{
+		"id":            generateAnthropicMsgID(),
+		"type":          "message",
+		"role":          "assistant",
+		"model":         requestModel,
+		"content":       blocks,
+		"stop_reason":   stopReason,
+		"stop_sequence": nil,
+		"usage":         geminiUsageToAnthropic(resp["usageMetadata"]),
+	}
+	return json.Marshal(out)
+}
+
+// GeminiToOpenAIError re-wraps a Gemini error envelope as an OpenAI error.
+// Gemini's error shape is { "error": { "code": int, "message": string,
+// "status": string } }. Returns the input unchanged when the body doesn't
+// parse as that shape.
+func GeminiToOpenAIError(body []byte) []byte {
+	var g struct {
+		Error struct {
+			Code    int    `json:"code"`
+			Message string `json:"message"`
+			Status  string `json:"status"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal(body, &g); err != nil {
+		return body
+	}
+	if g.Error.Message == "" && g.Error.Status == "" {
+		return body
+	}
+	out, err := json.Marshal(map[string]any{
+		"error": map[string]any{
+			"message": g.Error.Message,
+			"type":    strings.ToLower(g.Error.Status),
+			"param":   nil,
+			"code":    g.Error.Code,
+		},
+	})
+	if err != nil {
+		return body
+	}
+	return out
+}
+
+// GeminiToAnthropicError re-wraps a Gemini error envelope as an Anthropic error.
+func GeminiToAnthropicError(body []byte) []byte {
+	var g struct {
+		Error struct {
+			Message string `json:"message"`
+			Status  string `json:"status"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal(body, &g); err != nil {
+		return body
+	}
+	if g.Error.Message == "" && g.Error.Status == "" {
+		return body
+	}
+	out, err := json.Marshal(map[string]any{
+		"type": "error",
+		"error": map[string]any{
+			"type":    strings.ToLower(g.Error.Status),
+			"message": g.Error.Message,
+		},
+	})
+	if err != nil {
+		return body
+	}
+	return out
+}
+
+// extractGeminiParts walks candidate.content.parts and produces the OpenAI
+// view: a concatenated text content, one tool_call per functionCall part
+// (with thoughtSignature smuggled through as function.thought_signature),
+// and a leadingSig from the first text part if no functionCalls are present.
+func extractGeminiParts(candidate map[string]any) (textContent string, toolCalls []any, leadingSig string) {
+	if candidate == nil {
+		return "", nil, ""
+	}
+	content, _ := candidate["content"].(map[string]any)
+	parts, _ := content["parts"].([]any)
+
+	var texts []string
+	var firstTextSig string
+	for _, p := range parts {
+		part, _ := p.(map[string]any)
+		if part == nil {
+			continue
+		}
+		if fc, ok := part["functionCall"].(map[string]any); ok {
+			tc := geminiFunctionCallToToolCall(fc, stringField(part, "thoughtSignature"))
+			toolCalls = append(toolCalls, tc)
+			continue
+		}
+		if t, ok := part["text"].(string); ok && t != "" {
+			texts = append(texts, t)
+			if firstTextSig == "" {
+				if sig, _ := part["thoughtSignature"].(string); sig != "" {
+					firstTextSig = sig
+				}
+			}
+		}
+	}
+	textContent = strings.Join(texts, "")
+	if len(toolCalls) == 0 {
+		leadingSig = firstTextSig
+	}
+	return textContent, toolCalls, leadingSig
+}
+
+func geminiFunctionCallToToolCall(fc map[string]any, signature string) map[string]any {
+	name, _ := fc["name"].(string)
+	args := fc["args"]
+	var argStr string
+	if args == nil {
+		argStr = "{}"
+	} else {
+		b, err := json.Marshal(args)
+		if err != nil {
+			argStr = "{}"
+		} else {
+			argStr = string(b)
+		}
+	}
+	fn := map[string]any{
+		"name":      name,
+		"arguments": argStr,
+	}
+	tc := map[string]any{
+		"id":       generateToolCallID(),
+		"type":     "function",
+		"function": fn,
+	}
+	if signature != "" {
+		// Off-spec extra field; openai/litellm clients pass it through and
+		// our own translators read it back on the next turn.
+		fn["thought_signature"] = signature
+		tc["thought_signature"] = signature
+	}
+	return tc
+}
+
+// buildAnthropicBlocksFromGemini produces Anthropic content blocks from a
+// Gemini candidate. text parts become {type:text}; functionCall parts become
+// {type:tool_use} preserving thought_signature as a top-level field.
+func buildAnthropicBlocksFromGemini(candidate map[string]any) []any {
+	if candidate == nil {
+		return []any{}
+	}
+	content, _ := candidate["content"].(map[string]any)
+	parts, _ := content["parts"].([]any)
+
+	var blocks []any
+	for _, p := range parts {
+		part, _ := p.(map[string]any)
+		if part == nil {
+			continue
+		}
+		if fc, ok := part["functionCall"].(map[string]any); ok {
+			block := map[string]any{
+				"type":  "tool_use",
+				"id":    generateToolUseID(),
+				"name":  fc["name"],
+				"input": fc["args"],
+			}
+			if block["input"] == nil {
+				block["input"] = map[string]any{}
+			}
+			if sig, _ := part["thoughtSignature"].(string); sig != "" {
+				block["thought_signature"] = sig
+			}
+			blocks = append(blocks, block)
+			continue
+		}
+		if t, ok := part["text"].(string); ok && t != "" {
+			block := map[string]any{"type": "text", "text": t}
+			if sig, _ := part["thoughtSignature"].(string); sig != "" {
+				block["thought_signature"] = sig
+			}
+			blocks = append(blocks, block)
+		}
+	}
+	if blocks == nil {
+		return []any{}
+	}
+	return blocks
+}
+
+func blocksContainToolUse(blocks []any) bool {
+	for _, b := range blocks {
+		bm, _ := b.(map[string]any)
+		if t, _ := bm["type"].(string); t == "tool_use" {
+			return true
+		}
+	}
+	return false
+}
+
+// mapGeminiFinishReason converts Gemini finishReason to OpenAI finish_reason.
+// Unknown values fall through to "stop"; logging is the caller's job (the
+// SSE/non-streaming wrappers see the raw value).
+func mapGeminiFinishReason(reason string, hasToolCalls bool) string {
+	switch reason {
+	case "STOP":
+		if hasToolCalls {
+			return "tool_calls"
+		}
+		return "stop"
+	case "MAX_TOKENS":
+		return "length"
+	case "SAFETY", "RECITATION", "OTHER", "BLOCKLIST", "PROHIBITED_CONTENT", "SPII":
+		return "content_filter"
+	case "":
+		return "stop"
+	default:
+		return "stop"
+	}
+}
+
+func mapGeminiFinishReasonToAnthropic(reason string, hasToolUse bool) string {
+	switch reason {
+	case "STOP":
+		if hasToolUse {
+			return "tool_use"
+		}
+		return "end_turn"
+	case "MAX_TOKENS":
+		return "max_tokens"
+	case "SAFETY", "RECITATION", "OTHER", "BLOCKLIST", "PROHIBITED_CONTENT", "SPII":
+		return "stop_sequence"
+	default:
+		return "end_turn"
+	}
+}
+
+func geminiUsageToOpenAI(meta any) map[string]any {
+	m, _ := meta.(map[string]any)
+	if m == nil {
+		return map[string]any{"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0}
+	}
+	prompt := numField(m, "promptTokenCount")
+	completion := numField(m, "candidatesTokenCount")
+	total := numField(m, "totalTokenCount")
+	if total == 0 {
+		total = prompt + completion
+	}
+	return map[string]any{
+		"prompt_tokens":     prompt,
+		"completion_tokens": completion,
+		"total_tokens":      total,
+	}
+}
+
+func geminiUsageToAnthropic(meta any) map[string]any {
+	m, _ := meta.(map[string]any)
+	if m == nil {
+		return map[string]any{"input_tokens": 0, "output_tokens": 0}
+	}
+	return map[string]any{
+		"input_tokens":  numField(m, "promptTokenCount"),
+		"output_tokens": numField(m, "candidatesTokenCount"),
+	}
+}
+
+func numField(m map[string]any, k string) int {
+	v, ok := m[k]
+	if !ok {
+		return 0
+	}
+	if f, ok := v.(float64); ok {
+		return int(f)
+	}
+	return 0
+}
+
+func stringField(m map[string]any, k string) string {
+	if m == nil {
+		return ""
+	}
+	s, _ := m[k].(string)
+	return s
+}
+
+// generateChatCmplID returns "chatcmpl-" + 16 random hex chars per OpenAI's
+// id format.
+func generateChatCmplID() string {
+	return "chatcmpl-" + randomHex(8)
+}
+
+// generateToolCallID returns "call_" + 8 random hex chars per OpenAI's
+// tool_call id convention.
+func generateToolCallID() string {
+	return "call_" + randomHex(4)
+}
+
+// generateAnthropicMsgID returns "msg_" + 16 random hex chars.
+func generateAnthropicMsgID() string {
+	return "msg_" + randomHex(8)
+}
+
+// generateToolUseID returns "toolu_" + 16 random hex chars.
+func generateToolUseID() string {
+	return "toolu_" + randomHex(8)
+}
+
+func randomHex(n int) string {
+	buf := make([]byte, n)
+	if _, err := rand.Read(buf); err != nil {
+		return strings.Repeat("0", n*2)
+	}
+	return hex.EncodeToString(buf)
+}

--- a/internal/translate/gemini_stream.go
+++ b/internal/translate/gemini_stream.go
@@ -1,0 +1,350 @@
+package translate
+
+import (
+	"bufio"
+	"bytes"
+	"net/http"
+	"strings"
+	"time"
+
+	"workweave/router/internal/observability/otel"
+	"workweave/router/internal/sse"
+
+	"github.com/tidwall/gjson"
+)
+
+// GeminiToOpenAISSETranslator wraps an http.ResponseWriter and translates
+// Gemini :streamGenerateContent SSE chunks into OpenAI Chat Completion
+// chat.completion.chunk SSE on the fly. Non-streaming responses (non-2xx
+// errors or buffered JSON) are flushed by Finalize.
+//
+// Used as the leaf translator for OpenAI-inbound → Google routing. For
+// Anthropic-inbound → Google, this is chained: the inner sink is an
+// AnthropicSSETranslator that re-encodes the OpenAI chunks we emit.
+type GeminiToOpenAISSETranslator struct {
+	inner   http.ResponseWriter
+	flusher http.Flusher
+	bw      *bufio.Writer
+
+	streaming  bool
+	statusCode int
+	buf        bytes.Buffer
+
+	model    string
+	chatID   string
+	created  int64
+	started  bool
+	closed   bool
+	toolIdx  int
+	finished bool
+
+	usageSink otel.UsageSink
+}
+
+// NewGeminiToOpenAISSETranslator wraps w. Call Finalize after upstream returns
+// to flush non-streaming bodies and emit the trailing [DONE] for streams that
+// ended without a finishReason.
+func NewGeminiToOpenAISSETranslator(w http.ResponseWriter, model string, sink otel.UsageSink) *GeminiToOpenAISSETranslator {
+	flusher, _ := w.(http.Flusher)
+	return &GeminiToOpenAISSETranslator{
+		inner:     w,
+		flusher:   flusher,
+		bw:        bufio.NewWriterSize(w, 8192),
+		model:     model,
+		chatID:    generateChatCmplID(),
+		created:   time.Now().Unix(),
+		usageSink: sink,
+	}
+}
+
+func (t *GeminiToOpenAISSETranslator) Header() http.Header {
+	return t.inner.Header()
+}
+
+// WriteHeader detects whether the upstream response is streaming SSE based
+// on Content-Type. Errors and non-streaming JSON defer to Finalize.
+func (t *GeminiToOpenAISSETranslator) WriteHeader(code int) {
+	t.statusCode = code
+	ct := t.inner.Header().Get("Content-Type")
+	t.streaming = strings.Contains(ct, "text/event-stream") && code < 400
+
+	t.inner.Header().Del("Content-Length")
+	t.inner.Header().Del("Content-Encoding")
+
+	if t.streaming {
+		t.inner.Header().Set("Content-Type", "text/event-stream")
+		t.inner.WriteHeader(code)
+	}
+}
+
+func (t *GeminiToOpenAISSETranslator) Write(data []byte) (int, error) {
+	n := len(data)
+	t.buf.Write(data)
+	if !t.streaming {
+		return n, nil
+	}
+	return n, t.processSSEBuffer()
+}
+
+func (t *GeminiToOpenAISSETranslator) Flush() {
+	if !t.streaming {
+		return
+	}
+	if t.flusher != nil {
+		t.flusher.Flush()
+	}
+}
+
+// Finalize translates and flushes the buffered body for non-streaming
+// responses, or emits a trailing [DONE] for streams that ended without a
+// finishReason in the last chunk (defensive — Gemini sometimes sends usage
+// in its own chunk).
+func (t *GeminiToOpenAISSETranslator) Finalize() error {
+	if t.streaming {
+		if t.closed {
+			return nil
+		}
+		if !t.finished {
+			if err := t.emitFinalChunk("stop", nil); err != nil {
+				return err
+			}
+		}
+		return t.emitDone()
+	}
+
+	body := t.buf.Bytes()
+	if t.statusCode >= 400 {
+		t.inner.Header().Set("Content-Type", "application/json")
+		t.inner.WriteHeader(t.statusCode)
+		_, err := t.inner.Write(GeminiToOpenAIError(body))
+		return err
+	}
+
+	if t.usageSink != nil {
+		usage := gjson.GetBytes(body, "usageMetadata")
+		if usage.Exists() {
+			t.usageSink.RecordUsage(
+				int(usage.Get("promptTokenCount").Int()),
+				int(usage.Get("candidatesTokenCount").Int()),
+			)
+		}
+	}
+
+	translated, err := GeminiToOpenAIResponse(body, t.model)
+	if err != nil {
+		t.inner.Header().Set("Content-Type", "application/json")
+		t.inner.WriteHeader(http.StatusBadGateway)
+		_, _ = t.inner.Write([]byte(`{"error":{"message":"translation failed","type":"api_error"}}`))
+		return err
+	}
+	t.inner.Header().Set("Content-Type", "application/json")
+	t.inner.WriteHeader(t.statusCode)
+	_, err = t.inner.Write(translated)
+	return err
+}
+
+func (t *GeminiToOpenAISSETranslator) processSSEBuffer() error {
+	for {
+		event, n := sse.SplitNext(t.buf.Bytes())
+		if n == 0 {
+			return nil
+		}
+		err := t.translateEvent(event)
+		t.buf.Next(n)
+		if err != nil {
+			return err
+		}
+	}
+}
+
+func (t *GeminiToOpenAISSETranslator) translateEvent(raw []byte) error {
+	_, data := sse.ParseEvent(raw)
+	if len(data) == 0 {
+		return nil
+	}
+
+	if !t.started {
+		if err := t.emitFirstChunk(); err != nil {
+			return err
+		}
+		t.started = true
+	}
+
+	candidate := gjson.GetBytes(data, "candidates.0")
+	parts := candidate.Get("content.parts")
+	if parts.IsArray() {
+		var emitErr error
+		parts.ForEach(func(_, part gjson.Result) bool {
+			if fc := part.Get("functionCall"); fc.Exists() {
+				name := fc.Get("name").String()
+				argsRaw := fc.Get("args").Raw
+				if argsRaw == "" {
+					argsRaw = "{}"
+				}
+				sig := part.Get("thoughtSignature").String()
+				if err := t.emitToolCallChunk(t.toolIdx, name, argsRaw, sig); err != nil {
+					emitErr = err
+					return false
+				}
+				t.toolIdx++
+				return true
+			}
+			if text := part.Get("text"); text.Exists() && text.String() != "" {
+				if err := t.emitTextDelta(text.String()); err != nil {
+					emitErr = err
+					return false
+				}
+			}
+			return true
+		})
+		if emitErr != nil {
+			return emitErr
+		}
+	}
+
+	usage := geminiUsageFromBytes(data)
+	finishReason := candidate.Get("finishReason").String()
+	if finishReason != "" {
+		mapped := mapGeminiFinishReason(finishReason, t.toolIdx > 0)
+		if err := t.emitFinalChunk(mapped, usage); err != nil {
+			return err
+		}
+		t.finished = true
+		return t.emitDone()
+	}
+	if usage != nil {
+		// Gemini sometimes sends usage in a trailing chunk without a
+		// finishReason. Emit a usage-only chunk so downstream consumers
+		// (e.g. AnthropicSSETranslator) see it before [DONE].
+		if err := t.emitUsageOnlyChunk(usage); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func geminiUsageFromBytes(data []byte) map[string]int {
+	r := gjson.GetBytes(data, "usageMetadata")
+	if !r.Exists() {
+		return nil
+	}
+	prompt := int(r.Get("promptTokenCount").Int())
+	completion := int(r.Get("candidatesTokenCount").Int())
+	total := int(r.Get("totalTokenCount").Int())
+	if total == 0 {
+		total = prompt + completion
+	}
+	return map[string]int{
+		"prompt_tokens":     prompt,
+		"completion_tokens": completion,
+		"total_tokens":      total,
+	}
+}
+
+func (t *GeminiToOpenAISSETranslator) emitFirstChunk() error {
+	t.writeChunkHeader()
+	t.bw.WriteString(`"choices":[{"index":0,"delta":{"role":"assistant","content":""},"finish_reason":null}]}`)
+	t.bw.WriteString("\n\n")
+	return t.flushEvent()
+}
+
+func (t *GeminiToOpenAISSETranslator) emitTextDelta(text string) error {
+	t.writeChunkHeader()
+	t.bw.WriteString(`"choices":[{"index":0,"delta":{"content":`)
+	sse.WriteJSONString(t.bw, text)
+	t.bw.WriteString(`},"finish_reason":null}]}`)
+	t.bw.WriteString("\n\n")
+	return t.flushEvent()
+}
+
+// emitToolCallChunk emits a single OpenAI tool_calls delta carrying name and
+// the full arguments JSON in one chunk. Gemini does not split functionCall
+// args across chunks on this surface, so we don't accumulate a partial.
+// thoughtSignature is smuggled as function.thought_signature (off-spec but
+// preserved by passthrough clients) so the next request can round-trip it.
+func (t *GeminiToOpenAISSETranslator) emitToolCallChunk(idx int, name, argsRaw, sig string) error {
+	id := generateToolCallID()
+	t.writeChunkHeader()
+	t.bw.WriteString(`"choices":[{"index":0,"delta":{"tool_calls":[{"index":`)
+	sse.WriteJSONInt(t.bw, int64(idx))
+	t.bw.WriteString(`,"id":`)
+	sse.WriteJSONString(t.bw, id)
+	t.bw.WriteString(`,"type":"function","function":{"name":`)
+	sse.WriteJSONString(t.bw, name)
+	t.bw.WriteString(`,"arguments":`)
+	// arguments must be a string in OpenAI's wire format; encode the raw
+	// JSON args object as a JSON string.
+	sse.WriteJSONString(t.bw, argsRaw)
+	if sig != "" {
+		t.bw.WriteString(`,"thought_signature":`)
+		sse.WriteJSONString(t.bw, sig)
+	}
+	t.bw.WriteString(`}}]},"finish_reason":null}]}`)
+	t.bw.WriteString("\n\n")
+	return t.flushEvent()
+}
+
+func (t *GeminiToOpenAISSETranslator) emitFinalChunk(finishReason string, usage map[string]int) error {
+	t.writeChunkHeader()
+	t.bw.WriteString(`"choices":[{"index":0,"delta":{},"finish_reason":`)
+	sse.WriteJSONString(t.bw, finishReason)
+	t.bw.WriteString(`}]`)
+	if usage != nil {
+		t.bw.WriteString(`,"usage":{"prompt_tokens":`)
+		sse.WriteJSONInt(t.bw, int64(usage["prompt_tokens"]))
+		t.bw.WriteString(`,"completion_tokens":`)
+		sse.WriteJSONInt(t.bw, int64(usage["completion_tokens"]))
+		t.bw.WriteString(`,"total_tokens":`)
+		sse.WriteJSONInt(t.bw, int64(usage["total_tokens"]))
+		t.bw.WriteByte('}')
+		if t.usageSink != nil {
+			t.usageSink.RecordUsage(usage["prompt_tokens"], usage["completion_tokens"])
+		}
+	}
+	t.bw.WriteString("}\n\n")
+	return t.flushEvent()
+}
+
+func (t *GeminiToOpenAISSETranslator) emitUsageOnlyChunk(usage map[string]int) error {
+	t.writeChunkHeader()
+	t.bw.WriteString(`"choices":[],"usage":{"prompt_tokens":`)
+	sse.WriteJSONInt(t.bw, int64(usage["prompt_tokens"]))
+	t.bw.WriteString(`,"completion_tokens":`)
+	sse.WriteJSONInt(t.bw, int64(usage["completion_tokens"]))
+	t.bw.WriteString(`,"total_tokens":`)
+	sse.WriteJSONInt(t.bw, int64(usage["total_tokens"]))
+	t.bw.WriteString("}}\n\n")
+	if t.usageSink != nil {
+		t.usageSink.RecordUsage(usage["prompt_tokens"], usage["completion_tokens"])
+	}
+	return t.flushEvent()
+}
+
+func (t *GeminiToOpenAISSETranslator) emitDone() error {
+	t.bw.WriteString("data: [DONE]\n\n")
+	t.closed = true
+	return t.flushEvent()
+}
+
+func (t *GeminiToOpenAISSETranslator) writeChunkHeader() {
+	t.bw.WriteString(`data: {"id":`)
+	sse.WriteJSONString(t.bw, t.chatID)
+	t.bw.WriteString(`,"object":"chat.completion.chunk","created":`)
+	sse.WriteJSONInt(t.bw, t.created)
+	t.bw.WriteString(`,"model":`)
+	sse.WriteJSONString(t.bw, t.model)
+	t.bw.WriteByte(',')
+}
+
+func (t *GeminiToOpenAISSETranslator) flushEvent() error {
+	if err := t.bw.Flush(); err != nil {
+		return err
+	}
+	if t.flusher != nil {
+		t.flusher.Flush()
+	}
+	return nil
+}
+
+var _ http.ResponseWriter = (*GeminiToOpenAISSETranslator)(nil)
+var _ http.Flusher = (*GeminiToOpenAISSETranslator)(nil)

--- a/internal/translate/gemini_test.go
+++ b/internal/translate/gemini_test.go
@@ -130,9 +130,9 @@ func TestPrepareGemini_ToolsMappedToFunctionDeclarations(t *testing.T) {
 
 func TestPrepareGemini_ToolChoiceVariants(t *testing.T) {
 	cases := map[string]string{
-		`"tool_choice":"auto"`:                                        "AUTO",
-		`"tool_choice":"none"`:                                        "NONE",
-		`"tool_choice":"required"`:                                    "ANY",
+		`"tool_choice":"auto"`:     "AUTO",
+		`"tool_choice":"none"`:     "NONE",
+		`"tool_choice":"required"`: "ANY",
 		`"tool_choice":{"type":"function","function":{"name":"bash"}}`: "ANY",
 	}
 	for tc, mode := range cases {

--- a/internal/translate/gemini_test.go
+++ b/internal/translate/gemini_test.go
@@ -1,0 +1,379 @@
+package translate_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"workweave/router/internal/router"
+	"workweave/router/internal/translate"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ----- OpenAI → Gemini request -----
+
+func TestPrepareGemini_FromOpenAI_SimpleText(t *testing.T) {
+	body := []byte(`{
+		"model": "gemini-3.1-flash-lite-preview",
+		"messages": [
+			{"role": "system", "content": "You are helpful."},
+			{"role": "user", "content": "list /tmp"}
+		]
+	}`)
+	env, err := translate.ParseOpenAI(body)
+	require.NoError(t, err)
+	prep, err := env.PrepareGemini(http.Header{}, translate.EmitOptions{TargetModel: "gemini-3.1-flash-lite-preview"})
+	require.NoError(t, err)
+
+	out := mustUnmarshal(t, prep.Body)
+	sys := must(t, out, "systemInstruction")
+	assert.Equal(t, "You are helpful.", sys.(map[string]any)["parts"].([]any)[0].(map[string]any)["text"])
+
+	contents := must(t, out, "contents").([]any)
+	require.Len(t, contents, 1)
+	first := contents[0].(map[string]any)
+	assert.Equal(t, "user", first["role"])
+	parts := first["parts"].([]any)
+	assert.Equal(t, "list /tmp", parts[0].(map[string]any)["text"])
+}
+
+func TestPrepareGemini_MultipleSystemMessagesConcatenated(t *testing.T) {
+	body := []byte(`{
+		"messages": [
+			{"role": "system", "content": "rule one"},
+			{"role": "system", "content": "rule two"},
+			{"role": "user", "content": "go"}
+		]
+	}`)
+	env, _ := translate.ParseOpenAI(body)
+	prep, err := env.PrepareGemini(http.Header{}, translate.EmitOptions{})
+	require.NoError(t, err)
+
+	out := mustUnmarshal(t, prep.Body)
+	sys := out["systemInstruction"].(map[string]any)
+	text := sys["parts"].([]any)[0].(map[string]any)["text"].(string)
+	assert.Equal(t, "rule one\nrule two", text)
+}
+
+func TestPrepareGemini_AssistantToolCallsRoundTripsThoughtSignature(t *testing.T) {
+	// Load-bearing test: thought_signature on a prior assistant tool_call must
+	// land as thoughtSignature on the Gemini functionCall part. This is the
+	// whole reason the native adapter exists.
+	body := []byte(`{
+		"messages": [
+			{"role": "user", "content": "list /tmp"},
+			{"role": "assistant", "content": null, "tool_calls": [
+				{"id": "c1", "type": "function",
+				 "function": {"name": "bash", "arguments": "{\"command\":\"ls /tmp\"}",
+				              "thought_signature": "OPAQUE_SIG_BYTES"}}
+			]},
+			{"role": "tool", "tool_call_id": "c1", "content": "f1\nf2"}
+		]
+	}`)
+	env, _ := translate.ParseOpenAI(body)
+	prep, err := env.PrepareGemini(http.Header{}, translate.EmitOptions{})
+	require.NoError(t, err)
+
+	out := mustUnmarshal(t, prep.Body)
+	contents := out["contents"].([]any)
+	require.Len(t, contents, 3)
+
+	// model turn carries functionCall + thoughtSignature.
+	model := contents[1].(map[string]any)
+	assert.Equal(t, "model", model["role"])
+	parts := model["parts"].([]any)
+	require.Len(t, parts, 1)
+	p := parts[0].(map[string]any)
+	fc := p["functionCall"].(map[string]any)
+	assert.Equal(t, "bash", fc["name"])
+	args := fc["args"].(map[string]any)
+	assert.Equal(t, "ls /tmp", args["command"])
+	assert.Equal(t, "OPAQUE_SIG_BYTES", p["thoughtSignature"])
+
+	// tool turn must surface as user-role functionResponse with the same name.
+	toolTurn := contents[2].(map[string]any)
+	assert.Equal(t, "user", toolTurn["role"])
+	tps := toolTurn["parts"].([]any)
+	fr := tps[0].(map[string]any)["functionResponse"].(map[string]any)
+	assert.Equal(t, "bash", fr["name"])
+	assert.Equal(t, "f1\nf2", fr["response"].(map[string]any)["result"])
+}
+
+func TestPrepareGemini_ToolsMappedToFunctionDeclarations(t *testing.T) {
+	body := []byte(`{
+		"messages": [{"role":"user","content":"hi"}],
+		"tools": [
+			{"type":"function","function":{
+				"name":"bash","description":"Run bash",
+				"parameters":{"type":"object","properties":{"command":{"type":"string"}},"required":["command"]}
+			}}
+		]
+	}`)
+	env, _ := translate.ParseOpenAI(body)
+	prep, err := env.PrepareGemini(http.Header{}, translate.EmitOptions{})
+	require.NoError(t, err)
+
+	out := mustUnmarshal(t, prep.Body)
+	tools := out["tools"].([]any)
+	require.Len(t, tools, 1)
+	decls := tools[0].(map[string]any)["functionDeclarations"].([]any)
+	require.Len(t, decls, 1)
+	d := decls[0].(map[string]any)
+	assert.Equal(t, "bash", d["name"])
+	assert.Equal(t, "Run bash", d["description"])
+	assert.NotNil(t, d["parameters"])
+}
+
+func TestPrepareGemini_ToolChoiceVariants(t *testing.T) {
+	cases := map[string]string{
+		`"tool_choice":"auto"`:                                        "AUTO",
+		`"tool_choice":"none"`:                                        "NONE",
+		`"tool_choice":"required"`:                                    "ANY",
+		`"tool_choice":{"type":"function","function":{"name":"bash"}}`: "ANY",
+	}
+	for tc, mode := range cases {
+		body := []byte(`{"messages":[{"role":"user","content":"x"}],` + tc + `}`)
+		env, _ := translate.ParseOpenAI(body)
+		prep, err := env.PrepareGemini(http.Header{}, translate.EmitOptions{})
+		require.NoError(t, err, tc)
+		out := mustUnmarshal(t, prep.Body)
+		got := out["toolConfig"].(map[string]any)["functionCallingConfig"].(map[string]any)["mode"]
+		assert.Equal(t, mode, got, tc)
+	}
+}
+
+func TestPrepareGemini_ReasoningEffortMapsToThinkingBudget(t *testing.T) {
+	cases := map[string]int{"low": 1024, "medium": 8192, "high": 24576, "none": 0}
+	for effort, budget := range cases {
+		body := []byte(`{"messages":[{"role":"user","content":"x"}],"reasoning_effort":"` + effort + `"}`)
+		env, _ := translate.ParseOpenAI(body)
+		prep, err := env.PrepareGemini(http.Header{}, translate.EmitOptions{})
+		require.NoError(t, err, effort)
+		out := mustUnmarshal(t, prep.Body)
+		gc := out["generationConfig"].(map[string]any)
+		tc := gc["thinkingConfig"].(map[string]any)
+		assert.EqualValues(t, budget, tc["thinkingBudget"], effort)
+	}
+}
+
+func TestPrepareGemini_StreamHintHeaderSet(t *testing.T) {
+	body := []byte(`{"messages":[{"role":"user","content":"x"}],"stream":true}`)
+	env, _ := translate.ParseOpenAI(body)
+	prep, err := env.PrepareGemini(http.Header{}, translate.EmitOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, "true", prep.Headers.Get(translate.GeminiStreamHintHeader))
+}
+
+func TestPrepareGemini_NoStreamHintWhenNonStreaming(t *testing.T) {
+	body := []byte(`{"messages":[{"role":"user","content":"x"}]}`)
+	env, _ := translate.ParseOpenAI(body)
+	prep, err := env.PrepareGemini(http.Header{}, translate.EmitOptions{})
+	require.NoError(t, err)
+	assert.Empty(t, prep.Headers.Get(translate.GeminiStreamHintHeader))
+}
+
+// ----- Anthropic → Gemini request -----
+
+func TestPrepareGemini_FromAnthropic_SystemAndToolUseRoundTripsSignature(t *testing.T) {
+	body := []byte(`{
+		"system": "be helpful",
+		"messages": [
+			{"role":"user","content":[{"type":"text","text":"list"}]},
+			{"role":"assistant","content":[
+				{"type":"tool_use","id":"toolu_x","name":"bash",
+				 "input":{"command":"ls"},
+				 "thought_signature":"ANTHROPIC_SIG"}
+			]},
+			{"role":"user","content":[
+				{"type":"tool_result","tool_use_id":"toolu_x","content":"f1"}
+			]}
+		],
+		"tools": [{"name":"bash","description":"b","input_schema":{"type":"object"}}]
+	}`)
+	env, _ := translate.ParseAnthropic(body)
+	prep, err := env.PrepareGemini(http.Header{}, translate.EmitOptions{Capabilities: router.ModelSpec{}})
+	require.NoError(t, err)
+
+	out := mustUnmarshal(t, prep.Body)
+	assert.NotNil(t, out["systemInstruction"])
+
+	contents := out["contents"].([]any)
+	require.Len(t, contents, 3)
+
+	model := contents[1].(map[string]any)
+	parts := model["parts"].([]any)
+	p := parts[0].(map[string]any)
+	assert.Equal(t, "ANTHROPIC_SIG", p["thoughtSignature"])
+	fc := p["functionCall"].(map[string]any)
+	assert.Equal(t, "bash", fc["name"])
+
+	tr := contents[2].(map[string]any)
+	frPart := tr["parts"].([]any)[0].(map[string]any)
+	fr := frPart["functionResponse"].(map[string]any)
+	assert.Equal(t, "bash", fr["name"])
+}
+
+// ----- Gemini → OpenAI response -----
+
+func TestGeminiToOpenAIResponse_TextOnly(t *testing.T) {
+	body := []byte(`{
+		"candidates":[{"content":{"role":"model","parts":[{"text":"hi"}]},"finishReason":"STOP","index":0}],
+		"usageMetadata":{"promptTokenCount":3,"candidatesTokenCount":1,"totalTokenCount":4}
+	}`)
+	out, err := translate.GeminiToOpenAIResponse(body, "gemini-3.1-flash-lite-preview")
+	require.NoError(t, err)
+	resp := mustUnmarshal(t, out)
+	assert.Equal(t, "chat.completion", resp["object"])
+	assert.Equal(t, "gemini-3.1-flash-lite-preview", resp["model"])
+	choice := resp["choices"].([]any)[0].(map[string]any)
+	msg := choice["message"].(map[string]any)
+	assert.Equal(t, "hi", msg["content"])
+	assert.Equal(t, "stop", choice["finish_reason"])
+	usage := resp["usage"].(map[string]any)
+	assert.EqualValues(t, 3, usage["prompt_tokens"])
+	assert.EqualValues(t, 1, usage["completion_tokens"])
+	assert.EqualValues(t, 4, usage["total_tokens"])
+	id := resp["id"].(string)
+	assert.True(t, strings.HasPrefix(id, "chatcmpl-"))
+	assert.Len(t, id, len("chatcmpl-")+16)
+}
+
+func TestGeminiToOpenAIResponse_ToolCallPreservesThoughtSignature(t *testing.T) {
+	// Load-bearing: response-side signature surfaces on tool_call.function.
+	body := []byte(`{
+		"candidates":[{"content":{"role":"model","parts":[
+			{"functionCall":{"name":"bash","args":{"command":"ls /tmp"}},
+			 "thoughtSignature":"GEMINI_SIG"}
+		]},"finishReason":"STOP","index":0}]
+	}`)
+	out, err := translate.GeminiToOpenAIResponse(body, "gemini-3.1-flash-lite-preview")
+	require.NoError(t, err)
+	resp := mustUnmarshal(t, out)
+	choice := resp["choices"].([]any)[0].(map[string]any)
+	assert.Equal(t, "tool_calls", choice["finish_reason"])
+	tc := choice["message"].(map[string]any)["tool_calls"].([]any)[0].(map[string]any)
+	fn := tc["function"].(map[string]any)
+	assert.Equal(t, "bash", fn["name"])
+	assert.Equal(t, `{"command":"ls /tmp"}`, fn["arguments"])
+	assert.Equal(t, "GEMINI_SIG", fn["thought_signature"])
+	assert.Equal(t, "GEMINI_SIG", tc["thought_signature"])
+}
+
+func TestGeminiToOpenAIResponse_FinishReasonMapping(t *testing.T) {
+	cases := map[string]string{
+		"STOP":       "stop",
+		"MAX_TOKENS": "length",
+		"SAFETY":     "content_filter",
+		"RECITATION": "content_filter",
+		"":           "stop",
+	}
+	for fr, want := range cases {
+		body := []byte(`{"candidates":[{"content":{"parts":[{"text":"x"}]},"finishReason":"` + fr + `"}]}`)
+		out, _ := translate.GeminiToOpenAIResponse(body, "m")
+		resp := mustUnmarshal(t, out)
+		got := resp["choices"].([]any)[0].(map[string]any)["finish_reason"]
+		assert.Equal(t, want, got, fr)
+	}
+}
+
+// ----- Gemini → Anthropic response -----
+
+func TestGeminiToAnthropicResponse_ToolUsePreservesThoughtSignature(t *testing.T) {
+	body := []byte(`{
+		"candidates":[{"content":{"role":"model","parts":[
+			{"functionCall":{"name":"bash","args":{"command":"ls"}},
+			 "thoughtSignature":"GS"}
+		]},"finishReason":"STOP"}]
+	}`)
+	out, err := translate.GeminiToAnthropicResponse(body, "gemini-x")
+	require.NoError(t, err)
+	resp := mustUnmarshal(t, out)
+	assert.Equal(t, "tool_use", resp["stop_reason"])
+	blocks := resp["content"].([]any)
+	tu := blocks[0].(map[string]any)
+	assert.Equal(t, "tool_use", tu["type"])
+	assert.Equal(t, "GS", tu["thought_signature"])
+	assert.Equal(t, "bash", tu["name"])
+}
+
+// ----- Streaming -----
+
+func TestGeminiStream_TextDeltas(t *testing.T) {
+	rec := httptest.NewRecorder()
+	tr := translate.NewGeminiToOpenAISSETranslator(rec, "gemini-x", nil)
+	tr.Header().Set("Content-Type", "text/event-stream")
+	tr.WriteHeader(http.StatusOK)
+
+	chunks := []string{
+		`data: {"candidates":[{"content":{"parts":[{"text":"hi "}]}}]}` + "\n\n",
+		`data: {"candidates":[{"content":{"parts":[{"text":"world"}]}}]}` + "\n\n",
+		`data: {"candidates":[{"content":{"parts":[]},"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":3,"candidatesTokenCount":2,"totalTokenCount":5}}` + "\n\n",
+	}
+	for _, c := range chunks {
+		_, err := tr.Write([]byte(c))
+		require.NoError(t, err)
+	}
+	require.NoError(t, tr.Finalize())
+
+	body := rec.Body.String()
+	assert.Contains(t, body, `"role":"assistant"`)
+	assert.Contains(t, body, `"content":"hi "`)
+	assert.Contains(t, body, `"content":"world"`)
+	assert.Contains(t, body, `"finish_reason":"stop"`)
+	assert.Contains(t, body, `"prompt_tokens":3`)
+	assert.Contains(t, body, "data: [DONE]")
+}
+
+func TestGeminiStream_FunctionCallChunkPreservesThoughtSignature(t *testing.T) {
+	rec := httptest.NewRecorder()
+	tr := translate.NewGeminiToOpenAISSETranslator(rec, "gemini-x", nil)
+	tr.Header().Set("Content-Type", "text/event-stream")
+	tr.WriteHeader(http.StatusOK)
+
+	chunk := `data: {"candidates":[{"content":{"parts":[{"functionCall":{"name":"bash","args":{"command":"ls"}},"thoughtSignature":"SIG"}]},"finishReason":"STOP"}]}` + "\n\n"
+	_, err := tr.Write([]byte(chunk))
+	require.NoError(t, err)
+	require.NoError(t, tr.Finalize())
+
+	body := rec.Body.String()
+	assert.Contains(t, body, `"tool_calls"`)
+	assert.Contains(t, body, `"name":"bash"`)
+	assert.Contains(t, body, `"thought_signature":"SIG"`)
+	assert.Contains(t, body, `"finish_reason":"tool_calls"`)
+	assert.Contains(t, body, "data: [DONE]")
+}
+
+func TestGeminiStream_NonStreamingErrorTranslated(t *testing.T) {
+	rec := httptest.NewRecorder()
+	tr := translate.NewGeminiToOpenAISSETranslator(rec, "gemini-x", nil)
+	tr.Header().Set("Content-Type", "application/json")
+	tr.WriteHeader(http.StatusBadRequest)
+	_, err := tr.Write([]byte(`{"error":{"code":400,"message":"bad","status":"INVALID_ARGUMENT"}}`))
+	require.NoError(t, err)
+	require.NoError(t, tr.Finalize())
+
+	resp := mustUnmarshal(t, rec.Body.Bytes())
+	e := resp["error"].(map[string]any)
+	assert.Equal(t, "bad", e["message"])
+	assert.Equal(t, "invalid_argument", e["type"])
+}
+
+// ----- helpers -----
+
+func mustUnmarshal(t *testing.T, b []byte) map[string]any {
+	t.Helper()
+	var out map[string]any
+	require.NoError(t, json.Unmarshal(b, &out))
+	return out
+}
+
+func must(t *testing.T, m map[string]any, k string) any {
+	t.Helper()
+	v, ok := m[k]
+	require.True(t, ok, "missing key %s", k)
+	return v
+}


### PR DESCRIPTION
## Summary

- Adds `providers/google.NativeClient` hitting `/v1beta/models/{model}:generateContent` (+ `:streamGenerateContent?alt=sse`) so Gemini 3.x preview models' opaque `thought_signature` round-trips across multi-turn tool use. The OpenAI-compat surface drops it, which 400s turn 2 of any tool-use loop.
- Adds OpenAI/Anthropic ↔ Gemini wire-format translators in `internal/translate/` (envelope-based, matching the existing `emit_openai.go` / `emit_anthropic.go` pattern).
- `proxy.Service` splits `ProviderGoogle` off from the OpenAI/OpenRouter cases in both `ProxyMessages` and `ProxyOpenAIChatCompletion`. For Anthropic-inbound, the response chain is Gemini SSE → OpenAI SSE → Anthropic SSE.
- `cmd/router/main.go` wholesale-swaps to `NewNativeClient`; the OpenAI-compat `Client` stays in the package as the revert path (bump the gitlink in WorkWeave).

Why now: empirically verified turn-2 400s on the OpenAI-compat path; see `eval/SWEBENCH_AGENTIC_STATUS.md` in WorkWeave.

## Files

Created (7):
- `internal/translate/emit_gemini.go` — `RequestEnvelope.PrepareGemini` (OpenAI- or Anthropic-source) + `GeminiStreamHintHeader`.
- `internal/translate/gemini_response.go` — non-streaming Gemini → OpenAI / Anthropic / error.
- `internal/translate/gemini_stream.go` — `GeminiToOpenAISSETranslator`.
- `internal/translate/gemini_test.go` — load-bearing tests (thought_signature round-trip both directions, system→systemInstruction, tool_choice, reasoning_effort, finish_reason, streaming text + tool_call + error).
- `internal/providers/google/native_client.go` — HTTP adapter; `x-goog-api-key` auth with BYOK precedence; mirrors `httputil.NewTransport` / `StreamBody`.
- `internal/providers/google/native_client_test.go` — fake-server tests for URL composition, stream toggling, hint-header stripping, BYOK override.
- `internal/providers/google/native_integration_test.go` — `//go:build google_integration`; 2-turn tool-use round-trip + text-only + streaming against the real API.

Modified (2):
- `internal/proxy/service.go`
- `cmd/router/main.go`

## Test results

`go build ./...` clean. `go vet ./...` clean. `go test ./... -tags=no_onnx -count=1` — all 16 packages green, including 16 new gemini-specific tests.

Integration test against the real Gemini API (`GOOGLE_PROVIDER_API_KEY=... go test -tags=google_integration -run TestNative ./internal/providers/google/`):

```
=== RUN   TestNative_TwoTurnToolUseRoundTripsThoughtSignature
    native_integration_test.go:94: turn 1 thoughtSignature length: 376
    native_integration_test.go:134: turn 2 response: ... "The weather in San Francisco is 62°F and sunny." ... finishReason: STOP
--- PASS: TestNative_TwoTurnToolUseRoundTripsThoughtSignature (1.73s)
=== RUN   TestNative_GenerateContentTextOnly
--- PASS (0.95s)
=== RUN   TestNative_StreamGenerateContent
--- PASS (0.77s)
PASS
```

The 376-byte `thoughtSignature` from turn 1 is the load-bearing piece — turn 2 returns 200 with a synthesized text answer instead of the prior 400.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./... -tags=no_onnx -count=1`
- [x] `go test -tags=google_integration -run TestNative ./internal/providers/google/`
- [ ] Bump WorkWeave gitlink and run `eval.run_swebench_agentic` against staging — confirms no `thought_signature` 400s in the run log.

## Revert plan

Revert the gitlink bump in WorkWeave; the OpenAI-compat `google.Client` is still in the package and `main.go`'s switch is the only call site to swap back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)