### PR TITLE
fix(proxy): keep session-key pinning active under eval-override headers

### DIFF
--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -292,7 +292,16 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 	installationID, _ := ctx.Value(InstallationIDContextKey{}).(string)
 	clientID := ClientIdentityFrom(ctx)
 	bypassEval := hasEvalOverrideHeader(r)
-	bypassSticky := bypassEval
+	// Tier-1/2 (session-key-based) pinning stays enabled for eval traffic. The
+	// session_key is derived from the system text + first user message, so each
+	// eval prompt produces a unique key; pinning per-session is exactly what an
+	// agentic harness needs to keep multi-turn tool-use on a single provider
+	// (mid-conversation provider switches break Gemini, which rejects function
+	// calls without thoughtSignature emitted by other providers). Tier-3 (the
+	// legacy apiKeyID LRU) stays bypassed because the eval harness shares one
+	// apiKeyID across all 500 instances — without that bypass, the first
+	// decision would stick across unrelated instances.
+	bypassLegacySticky := bypassEval
 
 	// §3.4: hard pins for turn types whose optimal model is known a priori.
 	// These bypass all session-pin tiers and the cluster scorer, and must NOT
@@ -330,7 +339,7 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 	// mask the migrate-to-Memorystore trigger criteria.
 	// pinEligible is false for hard-pinned turns (stickyHit already set above),
 	// which also suppresses the async pin upsert for those turns.
-	pinEligible := s.pinStore != nil && !bypassSticky && !stickyHit
+	pinEligible := s.pinStore != nil && !stickyHit
 	if pinEligible {
 		sessionKey = DeriveSessionKey(env, apiKeyID)
 		pinCacheKey = sessionPinCacheKey(sessionKey, sessionpin.DefaultRole)
@@ -361,7 +370,7 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 
 	// Tier 3: legacy apiKeyID LRU. Consulted only on tier-2 miss (or
 	// when pinStore is nil).
-	if !stickyHit && s.stickyDecisions != nil && apiKeyID != "" && !bypassSticky {
+	if !stickyHit && s.stickyDecisions != nil && apiKeyID != "" && !bypassLegacySticky {
 		if d, ok := s.stickyDecisions.Get(apiKeyID); ok {
 			decision = d
 			stickyHit = true
@@ -382,7 +391,7 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 			log.Error("Routing failed", "err", err, "route_ms", time.Since(routeStart).Milliseconds(), "requested_model", feats.Model, "estimated_input_tokens", feats.Tokens)
 			return err
 		}
-		if s.stickyDecisions != nil && apiKeyID != "" && !bypassSticky {
+		if s.stickyDecisions != nil && apiKeyID != "" && !bypassLegacySticky {
 			s.stickyDecisions.Add(apiKeyID, decision)
 		}
 	}

--- a/internal/proxy/service_session_pin_test.go
+++ b/internal/proxy/service_session_pin_test.go
@@ -182,10 +182,17 @@ func TestService_SessionPin_ExpiredPinIsIgnored(t *testing.T) {
 	assert.Equal(t, "claude-opus-4-7", rec.Header().Get("x-router-model"))
 }
 
-func TestService_SessionPin_EvalOverrideHeaderBypassesAllTiers(t *testing.T) {
+func TestService_SessionPin_EvalOverrideHeaderKeepsSessionKeyPinning(t *testing.T) {
+	// Tier-1/2 (session-key-based) session pinning must stay active under
+	// eval-harness traffic. The session_key is derived from system text +
+	// first user message, so each eval prompt produces a unique key — pinning
+	// per-session is exactly what an agentic harness needs to keep multi-turn
+	// tool-use on a single provider. Without this, mid-conversation provider
+	// switches break Gemini, which rejects function calls without
+	// thoughtSignature emitted by other providers.
 	store := newFakePinStore()
 	store.hasPin = true
-	store.pin = sessionpin.Pin{Provider: "anthropic", Model: "claude-haiku-4-5", PinnedUntil: time.Now().Add(time.Hour)}
+	store.pin = sessionpin.Pin{Provider: "anthropic", Model: "claude-haiku-4-5", PinnedUntil: time.Now().Add(time.Hour), Reason: "pinned"}
 	fr := &fakeRouter{decision: router.Decision{Provider: "anthropic", Model: "claude-opus-4-7", Reason: "fresh"}}
 	svc := newPinSvc(fr, store)
 
@@ -195,10 +202,12 @@ func TestService_SessionPin_EvalOverrideHeaderBypassesAllTiers(t *testing.T) {
 	httpReq.Header.Set("x-weave-cluster-version", "v0.2")
 	require.NoError(t, svc.ProxyMessages(ctx, []byte(pinTestBody), rec, httpReq))
 
-	assert.Equal(t, 1, fr.routeCalls,
-		"eval-override header must bypass the pin tiers so the harness can compare router strategies on the same prompt")
-	assert.Equal(t, 0, store.getCalls,
-		"the pin store must not even be consulted when bypass is active")
+	assert.Equal(t, 0, fr.routeCalls,
+		"eval-override header must NOT bypass session-key-based pinning; the pin must short-circuit the cluster scorer")
+	assert.Equal(t, 1, store.getCalls,
+		"the pin store must be consulted even when eval-override headers are present")
+	assert.Equal(t, "claude-haiku-4-5", rec.Header().Get("x-router-model"),
+		"the pinned model must win over the cluster-scorer's fresh decision")
 }
 
 // compactionBody is a minimal Anthropic request whose system prompt triggers


### PR DESCRIPTION
## Summary

- Eval-override headers (`x-weave-cluster-version`, `x-weave-embed-last-user-message`) used to disable **both** the session_key-based pin tiers (1+2) and the legacy apiKeyID LRU (tier 3). That made multi-turn agentic eval unsafe: cluster scorer re-ran fresh on every turn → free provider switches mid-conversation → first non-Gemini tool_call permanently breaks any subsequent Gemini route (no thoughtSignature → 400).
- Split `bypassEval` from `bypassLegacySticky`. Tier 1/2 (session_key keyed; each eval prompt has a unique system+user pair → unique key) stays active. Tier 3 (apiKeyID LRU; the eval shares one key across 500 instances) stays bypassed.

## Why now

PR #32 (native Gemini adapter) is correct, but the agentic SWE-bench 500-run still 400'd after a few instances. Trajectory inspection: turns 1–8 routed to OpenRouter (deepseek + qwen), turn 9 routed to Gemini-3.x → 400 `Function call is missing a thought_signature in functionCall parts. Additional data, function call \`default_api:bash\`, position 2`. Cross-provider conversation, not an adapter bug.

## Tests

- Updated `TestService_SessionPin_EvalOverrideHeaderBypassesAllTiers` → `…KeepsSessionKeyPinning`. New assertions: with eval-override header set, pin store IS consulted, pinned model wins over the cluster scorer's fresh decision.
- Existing `TestService_ProxyMessages_StickyBypassedByEvalOverrideHeaders` still asserts tier-3 bypass behavior unchanged.

`go build ./... && go test ./... -tags=no_onnx -count=1` clean.

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/proxy/... -count=1`
- [x] `go test ./... -tags=no_onnx -count=1`
- [ ] Bump WorkWeave gitlink, deploy staging, re-run `eval/run_swebench_agentic --workers 2 --limit 500`. Expect zero `thought_signature` 400s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)