### PR TITLE
feat(auth): make EXTERNAL_KEY_ENCRYPTION_KEY optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -514,6 +514,14 @@ Set `DATABASE_URL` directly, or compose it from the individual vars:
 | `ROUTER_DECISIONS_LOG_PATH`    | `~/.weave-router/decisions.jsonl`    | Path for the JSON-lines decision sidecar log (one line per routed request). Set to `off` to disable.                                        |
 
 
+#### BYOK encryption
+
+
+| Variable                       | Default    | Purpose                                                                                                                                                                                                                                                                          |
+| ------------------------------ | ---------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `EXTERNAL_KEY_ENCRYPTION_KEY`  | *(unset)*  | Tink AES-256-GCM keyset (JSON) used to encrypt customer-supplied upstream provider keys (BYOK secrets) at rest. **If unset, the router boots with a no-op encryptor and stores BYOK secrets unencrypted** — the router logs a `WARN` at startup. Set this in any deployment that handles real customer BYOK secrets. A *malformed* keyset still fails closed (the router refuses to boot); only a genuinely absent value triggers the bypass. Generate with `tinkey create-keyset --key-template AES256_GCM --out-format json`. |
+
+
 #### Telemetry (OpenTelemetry)
 
 The router can export per-request trace spans to any OTLP-compatible

--- a/cmd/router/main.go
+++ b/cmd/router/main.go
@@ -78,20 +78,19 @@ func main() {
 	}
 	defer pool.Close()
 
-	// Load Tink keyset for external API key encryption. Fail-closed: a missing
-	// keyset is only acceptable under ROUTER_DEV_MODE=true, which the bundled
-	// docker-compose stack sets explicitly. Without this guard a deploy/config
-	// mistake would silently store customer BYOK secrets unencrypted.
 	devMode := config.GetOr("ROUTER_DEV_MODE", "false") == "true"
+
+	// Load Tink keyset for external API key encryption. The keyset is optional:
+	// if EXTERNAL_KEY_ENCRYPTION_KEY is unset the router boots with the no-op
+	// encryptor and stores BYOK secrets unencrypted at rest. This is convenient
+	// for self-hosters and local dev; for production deployments handling
+	// customer BYOK secrets, set the keyset so ciphertext is at-rest encrypted.
+	// A malformed keyset is still fail-closed — we only bypass when the var is
+	// genuinely absent, never when it's set-but-broken.
 	keysetJSON := config.GetOr("EXTERNAL_KEY_ENCRYPTION_KEY", "")
 	var encryptor auth.Encryptor
 	if keysetJSON == "" {
-		if !devMode {
-			err := errors.New("EXTERNAL_KEY_ENCRYPTION_KEY not set; refusing to boot without BYOK encryption (set ROUTER_DEV_MODE=true to allow the no-op encryptor in local dev)")
-			logger.Error("Refusing to boot without BYOK encryption key", "err", err)
-			panic(err)
-		}
-		logger.Warn("EXTERNAL_KEY_ENCRYPTION_KEY not set, using no-op encryptor (ROUTER_DEV_MODE=true)")
+		logger.Warn("EXTERNAL_KEY_ENCRYPTION_KEY not set; BYOK secrets will be stored unencrypted at rest. Set EXTERNAL_KEY_ENCRYPTION_KEY to a Tink AES-256-GCM keyset to enable encryption.")
 		encryptor = auth.NoOpEncryptor{}
 	} else {
 		encryptor, err = auth.NewTinkEncryptor(keysetJSON)


### PR DESCRIPTION
## Summary

- Missing `EXTERNAL_KEY_ENCRYPTION_KEY` no longer panics at boot. The router falls back to `auth.NoOpEncryptor{}` and logs a `WARN` explaining that BYOK secrets will be stored unencrypted at rest.
- A *malformed* keyset still fail-closes (`os.Exit(1)`). Only a genuinely absent value triggers the bypass — we don't silently swallow a broken-but-set key.
- README gets a new **BYOK encryption** subsection under Configuration → Environment variables documenting the var, its default, the unencrypted fallback, the fail-closed-on-malformed exception, and how to generate a keyset with `tinkey`.

## Why

Self-hosters and fresh local deploys had to either set a real Tink keyset or flip `ROUTER_DEV_MODE=true` (which also bypasses bearer auth — coupling two unrelated concerns). For deployments that don't store customer BYOK secrets, encryption-at-rest of upstream provider keys isn't a hard requirement, so making it opt-in is the right default.

## Test plan

- [ ] Boot router with `EXTERNAL_KEY_ENCRYPTION_KEY` unset and `ROUTER_DEV_MODE=false` → starts, emits the WARN, requests succeed.
- [ ] Boot with a malformed `EXTERNAL_KEY_ENCRYPTION_KEY` → exits with the existing "Failed to create Tink encryptor from keyset" error.
- [ ] Boot with a valid keyset → encryption path unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)