### PR TITLE
refactor(translate,turntype): envelope-driven turn-type detection

### DIFF
--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -273,13 +273,14 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 		return fmt.Errorf("parse request: %w", parseErr)
 	}
 
-	tt := turntype.Detect(body)
-
 	embedFlag := s.embedLastUserMessage
 	if v, ok := embedLastUserMessageOverride(ctx); ok {
 		embedFlag = v
 	}
 	feats := env.RoutingFeatures(embedFlag)
+	// Anthropic clients pack sub-agent identity into metadata.user_id;
+	// the x-weave-subagent-type header is for non-Anthropic ingress.
+	tt := turntype.DetectFromEnvelope(env, feats, "")
 	promptText := feats.PromptText
 	embedInput := "concatenated_stream"
 	if embedFlag && feats.LastUserMessageText != "" {

--- a/internal/router/turntype/detect.go
+++ b/internal/router/turntype/detect.go
@@ -1,12 +1,13 @@
-// Package turntype classifies inbound Anthropic-format request bodies by
-// conversation role. It is a pure, I/O-free helper used by the proxy service
-// to enable role-conditioned routing (§3.3–§3.4 of docs/plans/AGENTIC_CODING.md).
+// Package turntype classifies inbound conversation requests by role,
+// independent of wire format. It is a pure, I/O-free helper used by
+// the proxy service to enable role-conditioned routing (§3.3–§3.4 of
+// docs/plans/AGENTIC_CODING.md).
 package turntype
 
 import (
 	"strings"
 
-	"github.com/tidwall/gjson"
+	"workweave/router/internal/translate"
 )
 
 // TurnType classifies an inbound conversation turn.
@@ -15,7 +16,7 @@ type TurnType string
 const (
 	// MainLoop is the default — a regular user prompt scored by the cluster scorer.
 	MainLoop TurnType = "main_loop"
-	// ToolResult indicates the last user message consists entirely of
+	// ToolResult indicates the last user-side input consists entirely of
 	// tool_result blocks with no text. The cluster scorer embedding is mostly
 	// noise on these turns; they short-circuit to the session pin when one exists.
 	ToolResult TurnType = "tool_result"
@@ -28,18 +29,28 @@ const (
 	Compaction TurnType = "compaction"
 )
 
-// Detect classifies the inbound Anthropic-format request body.
-// Conservative: false negatives (returning MainLoop) are safe — the cluster
-// scorer runs normally. False positives are the real risk; each heuristic is
-// intentionally tight.
-func Detect(body []byte) TurnType {
-	if isCompaction(body) {
+// DetectFromEnvelope classifies an inbound request using a parsed
+// envelope and its already-computed routing features. subAgentHint is
+// the optional `x-weave-subagent-type` header value: clients that
+// can't pack subagent identity into Anthropic's metadata.user_id (e.g.
+// OpenAI / Gemini ingress) use the header instead. Empty hint is
+// ignored.
+//
+// Conservative: false negatives (returning MainLoop) are safe — the
+// cluster scorer runs normally. False positives are the real risk; each
+// heuristic is intentionally tight.
+func DetectFromEnvelope(env *translate.RequestEnvelope, feats translate.RoutingFeatures, subAgentHint string) TurnType {
+	if env == nil {
+		return MainLoop
+	}
+	systemText := env.SystemText()
+	if isCompaction(systemText) {
 		return Compaction
 	}
-	if isSubAgentDispatch(body) {
+	if isSubAgentDispatch(env.MetadataUserID(), systemText, subAgentHint) {
 		return SubAgentDispatch
 	}
-	if isToolResult(body) {
+	if feats.LastKind == "tool_result" {
 		return ToolResult
 	}
 	return MainLoop
@@ -47,76 +58,24 @@ func Detect(body []byte) TurnType {
 
 // isCompaction returns true when the system prompt contains Claude Code's
 // context-compaction instruction markers.
-func isCompaction(body []byte) bool {
-	text := systemText(body)
-	lower := strings.ToLower(text)
+func isCompaction(systemText string) bool {
+	lower := strings.ToLower(systemText)
 	return strings.Contains(lower, "your task is to create a detailed summary") ||
 		(strings.Contains(lower, "compact") && strings.Contains(lower, "conversation"))
 }
 
-// isSubAgentDispatch returns true when the request originates from a Claude
-// Code sub-agent. Claude Code encodes sub-agent identity in metadata.user_id
-// as "subagent:<type>", or marks it in the system prompt.
-func isSubAgentDispatch(body []byte) bool {
-	if strings.HasPrefix(gjson.GetBytes(body, "metadata.user_id").String(), "subagent:") {
+// isSubAgentDispatch returns true when the request originates from a
+// sub-agent dispatch. Claude Code packs sub-agent identity into
+// metadata.user_id as "subagent:<type>"; non-Anthropic clients pass it
+// via the x-weave-subagent-type header (subAgentHint). The system
+// prompt also carries marker phrases as a third fallback.
+func isSubAgentDispatch(metadataUserID, systemText, subAgentHint string) bool {
+	if subAgentHint != "" {
 		return true
 	}
-	lower := strings.ToLower(systemText(body))
+	if strings.HasPrefix(metadataUserID, "subagent:") {
+		return true
+	}
+	lower := strings.ToLower(systemText)
 	return strings.Contains(lower, "subagent_type") || strings.Contains(lower, "sub-agent")
-}
-
-// isToolResult returns true when the last user message contains only
-// tool_result blocks and no text blocks.
-func isToolResult(body []byte) bool {
-	msgs := gjson.GetBytes(body, "messages")
-	if !msgs.IsArray() {
-		return false
-	}
-	var lastMsg gjson.Result
-	msgs.ForEach(func(_, msg gjson.Result) bool {
-		lastMsg = msg
-		return true
-	})
-	if !lastMsg.Exists() || lastMsg.Get("role").String() != "user" {
-		return false
-	}
-	content := lastMsg.Get("content")
-	if !content.IsArray() {
-		return false
-	}
-	hasToolResult := false
-	hasText := false
-	content.ForEach(func(_, block gjson.Result) bool {
-		switch block.Get("type").String() {
-		case "tool_result":
-			hasToolResult = true
-		case "text":
-			hasText = true
-		}
-		return true
-	})
-	return hasToolResult && !hasText
-}
-
-// systemText extracts plain text from the system field, which may be a string
-// or an array of content blocks.
-func systemText(body []byte) string {
-	sys := gjson.GetBytes(body, "system")
-	if sys.Type == gjson.String {
-		return sys.String()
-	}
-	if !sys.IsArray() {
-		return ""
-	}
-	var b strings.Builder
-	sys.ForEach(func(_, block gjson.Result) bool {
-		if block.Get("type").String() == "text" {
-			if b.Len() > 0 {
-				b.WriteByte('\n')
-			}
-			b.WriteString(block.Get("text").String())
-		}
-		return true
-	})
-	return b.String()
 }

--- a/internal/router/turntype/detect_test.go
+++ b/internal/router/turntype/detect_test.go
@@ -4,14 +4,17 @@ import (
 	"testing"
 
 	"workweave/router/internal/router/turntype"
+	"workweave/router/internal/translate"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
-func TestDetect(t *testing.T) {
+func TestDetectFromEnvelope_Anthropic(t *testing.T) {
 	tests := []struct {
 		name string
 		body string
+		hint string
 		want turntype.TurnType
 	}{
 		{
@@ -82,6 +85,12 @@ func TestDetect(t *testing.T) {
 			want: turntype.SubAgentDispatch,
 		},
 		{
+			name: "sub-agent via x-weave-subagent-type header hint",
+			body: `{"model":"claude-haiku-4-5","messages":[{"role":"user","content":"grep"}]}`,
+			hint: "Explore",
+			want: turntype.SubAgentDispatch,
+		},
+		{
 			name: "empty body is main_loop",
 			body: `{}`,
 			want: turntype.MainLoop,
@@ -109,8 +118,89 @@ func TestDetect(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			got := turntype.Detect([]byte(tc.body))
+			env, err := translate.ParseAnthropic([]byte(tc.body))
+			require.NoError(t, err)
+			feats := env.RoutingFeatures(false)
+			got := turntype.DetectFromEnvelope(env, feats, tc.hint)
 			assert.Equal(t, tc.want, got)
 		})
 	}
+}
+
+func TestDetectFromEnvelope_OpenAI(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+		hint string
+		want turntype.TurnType
+	}{
+		{
+			name: "regular user prompt is main_loop",
+			body: `{"model":"gpt-4o","messages":[{"role":"user","content":"explain recursion"}]}`,
+			want: turntype.MainLoop,
+		},
+		{
+			name: "trailing tool message is tool_result",
+			body: `{"model":"gpt-4o","messages":[
+				{"role":"user","content":"run the grep"},
+				{"role":"assistant","content":null,"tool_calls":[{"id":"t1","type":"function","function":{"name":"Bash","arguments":"{}"}}]},
+				{"role":"tool","tool_call_id":"t1","content":"file.go:12: foo"}
+			]}`,
+			want: turntype.ToolResult,
+		},
+		{
+			name: "tool followed by user message is main_loop",
+			body: `{"model":"gpt-4o","messages":[
+				{"role":"assistant","content":null,"tool_calls":[{"id":"t1","type":"function","function":{"name":"Bash","arguments":"{}"}}]},
+				{"role":"tool","tool_call_id":"t1","content":"out"},
+				{"role":"user","content":"keep going"}
+			]}`,
+			want: turntype.MainLoop,
+		},
+		{
+			name: "compaction via system message",
+			body: `{"model":"gpt-4o","messages":[
+				{"role":"system","content":"Your task is to create a detailed summary of the conversation so far."},
+				{"role":"user","content":"go"}
+			]}`,
+			want: turntype.Compaction,
+		},
+		{
+			name: "sub-agent via header hint",
+			body: `{"model":"gpt-4o","messages":[{"role":"user","content":"grep"}]}`,
+			hint: "Explore",
+			want: turntype.SubAgentDispatch,
+		},
+		{
+			name: "sub-agent via system message marker",
+			body: `{"model":"gpt-4o","messages":[
+				{"role":"system","content":"You are a sub-agent for the Explore task."},
+				{"role":"user","content":"list files"}
+			]}`,
+			want: turntype.SubAgentDispatch,
+		},
+		{
+			name: "last message assistant is main_loop",
+			body: `{"model":"gpt-4o","messages":[
+				{"role":"user","content":"hi"},
+				{"role":"assistant","content":"hello"}
+			]}`,
+			want: turntype.MainLoop,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			env, err := translate.ParseOpenAI([]byte(tc.body))
+			require.NoError(t, err)
+			feats := env.RoutingFeatures(false)
+			got := turntype.DetectFromEnvelope(env, feats, tc.hint)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestDetectFromEnvelope_NilEnv(t *testing.T) {
+	got := turntype.DetectFromEnvelope(nil, translate.RoutingFeatures{}, "")
+	assert.Equal(t, turntype.MainLoop, got)
 }

--- a/internal/translate/envelope.go
+++ b/internal/translate/envelope.go
@@ -117,16 +117,50 @@ func (e *RequestEnvelope) MetadataUserID() string {
 	return gjson.GetBytes(e.body, "metadata.user_id").String()
 }
 
-// SystemText returns the concatenated system-prompt text (Anthropic
-// format only). Empty for OpenAI-format requests, which carry the
-// system prompt as messages[0]. Used by session-pin keying as one of
-// the two stable inputs that don't change across turns of the same
-// session.
+// SystemText returns the concatenated system-prompt text in a
+// format-neutral way. For Anthropic, reads the top-level `system`
+// field. For OpenAI, walks `messages[]` collecting every `system`-role
+// message's text content (OpenAI carries the system prompt as a
+// message rather than a separate field, and may have multiple). Used
+// by session-pin keying and turn-type detection (compaction markers).
 func (e *RequestEnvelope) SystemText() string {
-	if e.format != FormatAnthropic {
+	switch e.format {
+	case FormatAnthropic:
+		return systemTextGJSON(gjson.GetBytes(e.body, "system"))
+	case FormatOpenAI:
+		return openAISystemText(e.body)
+	default:
 		return ""
 	}
-	return systemTextGJSON(gjson.GetBytes(e.body, "system"))
+}
+
+// LastUserMessageInfo summarizes the trailing user-side input on a
+// request. HasText is true when the last user-side input contains any
+// human-authored text; HasToolResult is true when it contains tool
+// results (tool_result blocks for Anthropic, role=="tool" messages for
+// OpenAI). Both flags can be true at once (mixed turn). Text holds the
+// extracted human text (empty when HasText is false). ToolResultCount
+// counts the contributing tool-result blocks/messages.
+type LastUserMessageInfo struct {
+	HasText         bool
+	HasToolResult   bool
+	ToolResultCount int
+	Text            string
+}
+
+// LastUserMessage returns format-neutral information about the last
+// user-side input. Used by turn-type detection to classify tool-result
+// short-circuit turns and by future per-format helpers. Returns the
+// zero value when messages is absent or empty.
+func (e *RequestEnvelope) LastUserMessage() LastUserMessageInfo {
+	switch e.format {
+	case FormatAnthropic:
+		return anthropicLastUserMessage(e.body)
+	case FormatOpenAI:
+		return openAILastUserMessage(e.body)
+	default:
+		return LastUserMessageInfo{}
+	}
 }
 
 // FirstUserMessageText returns the text of messages[0] when role is

--- a/internal/translate/envelope_extras_test.go
+++ b/internal/translate/envelope_extras_test.go
@@ -1,0 +1,237 @@
+package translate_test
+
+import (
+	"testing"
+
+	"workweave/router/internal/translate"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRequestEnvelope_SystemText_Anthropic(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+		want string
+	}{
+		{
+			name: "string system",
+			body: `{"system":"You are helpful.","messages":[{"role":"user","content":"hi"}]}`,
+			want: "You are helpful.",
+		},
+		{
+			name: "array system blocks",
+			body: `{"system":[{"type":"text","text":"alpha"},{"type":"text","text":"beta"}],"messages":[{"role":"user","content":"hi"}]}`,
+			want: "alpha\nbeta",
+		},
+		{
+			name: "missing system",
+			body: `{"messages":[{"role":"user","content":"hi"}]}`,
+			want: "",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			env, err := translate.ParseAnthropic([]byte(tc.body))
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, env.SystemText())
+		})
+	}
+}
+
+func TestRequestEnvelope_SystemText_OpenAI(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+		want string
+	}{
+		{
+			name: "single system message string content",
+			body: `{"messages":[{"role":"system","content":"You are helpful."},{"role":"user","content":"hi"}]}`,
+			want: "You are helpful.",
+		},
+		{
+			name: "multiple system messages concatenate",
+			body: `{"messages":[{"role":"system","content":"first"},{"role":"system","content":"second"},{"role":"user","content":"hi"}]}`,
+			want: "first\nsecond",
+		},
+		{
+			name: "system message array content",
+			body: `{"messages":[{"role":"system","content":[{"type":"text","text":"alpha"},{"type":"text","text":"beta"}]},{"role":"user","content":"hi"}]}`,
+			want: "alpha\nbeta",
+		},
+		{
+			name: "no system message",
+			body: `{"messages":[{"role":"user","content":"hi"}]}`,
+			want: "",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			env, err := translate.ParseOpenAI([]byte(tc.body))
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, env.SystemText())
+		})
+	}
+}
+
+func TestRequestEnvelope_LastUserMessage_Anthropic(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+		want translate.LastUserMessageInfo
+	}{
+		{
+			name: "string content",
+			body: `{"messages":[{"role":"user","content":"hello"}]}`,
+			want: translate.LastUserMessageInfo{HasText: true, Text: "hello"},
+		},
+		{
+			name: "tool_result only",
+			body: `{"messages":[
+				{"role":"user","content":[{"type":"tool_result","tool_use_id":"t1","content":"out"}]}
+			]}`,
+			want: translate.LastUserMessageInfo{HasToolResult: true, ToolResultCount: 1},
+		},
+		{
+			name: "mixed text + tool_result",
+			body: `{"messages":[
+				{"role":"user","content":[
+					{"type":"tool_result","tool_use_id":"t1","content":"out"},
+					{"type":"text","text":"more please"}
+				]}
+			]}`,
+			want: translate.LastUserMessageInfo{
+				HasText: true, Text: "more please", HasToolResult: true, ToolResultCount: 1,
+			},
+		},
+		{
+			name: "two tool_results",
+			body: `{"messages":[
+				{"role":"user","content":[
+					{"type":"tool_result","tool_use_id":"t1","content":"a"},
+					{"type":"tool_result","tool_use_id":"t2","content":"b"}
+				]}
+			]}`,
+			want: translate.LastUserMessageInfo{HasToolResult: true, ToolResultCount: 2},
+		},
+		{
+			name: "no user message",
+			body: `{"messages":[{"role":"assistant","content":"hi"}]}`,
+			want: translate.LastUserMessageInfo{},
+		},
+		{
+			name: "earlier user with assistant after",
+			body: `{"messages":[
+				{"role":"user","content":"first"},
+				{"role":"assistant","content":"reply"}
+			]}`,
+			want: translate.LastUserMessageInfo{HasText: true, Text: "first"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			env, err := translate.ParseAnthropic([]byte(tc.body))
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, env.LastUserMessage())
+		})
+	}
+}
+
+func TestRequestEnvelope_LastUserMessage_OpenAI(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+		want translate.LastUserMessageInfo
+	}{
+		{
+			name: "trailing user message",
+			body: `{"messages":[{"role":"user","content":"hello"}]}`,
+			want: translate.LastUserMessageInfo{HasText: true, Text: "hello"},
+		},
+		{
+			name: "trailing tool message",
+			body: `{"messages":[
+				{"role":"user","content":"go"},
+				{"role":"assistant","content":null,"tool_calls":[{"id":"t1","type":"function","function":{"name":"Bash","arguments":"{}"}}]},
+				{"role":"tool","tool_call_id":"t1","content":"out"}
+			]}`,
+			want: translate.LastUserMessageInfo{HasToolResult: true, ToolResultCount: 1},
+		},
+		{
+			name: "two trailing tool messages",
+			body: `{"messages":[
+				{"role":"assistant","content":null,"tool_calls":[{"id":"t1","type":"function","function":{"name":"Bash","arguments":"{}"}}]},
+				{"role":"tool","tool_call_id":"t1","content":"a"},
+				{"role":"tool","tool_call_id":"t2","content":"b"}
+			]}`,
+			want: translate.LastUserMessageInfo{HasToolResult: true, ToolResultCount: 2},
+		},
+		{
+			name: "tool then user",
+			body: `{"messages":[
+				{"role":"tool","tool_call_id":"t1","content":"a"},
+				{"role":"user","content":"continue"}
+			]}`,
+			want: translate.LastUserMessageInfo{HasText: true, Text: "continue"},
+		},
+		{
+			name: "trailing assistant",
+			body: `{"messages":[
+				{"role":"user","content":"hi"},
+				{"role":"assistant","content":"hello"}
+			]}`,
+			want: translate.LastUserMessageInfo{},
+		},
+		{
+			name: "empty messages",
+			body: `{"messages":[]}`,
+			want: translate.LastUserMessageInfo{},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			env, err := translate.ParseOpenAI([]byte(tc.body))
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, env.LastUserMessage())
+		})
+	}
+}
+
+func TestRequestEnvelope_RoutingFeatures_OpenAI_LastKind(t *testing.T) {
+	cases := []struct {
+		name        string
+		body        string
+		wantKind    string
+		wantPreview string
+	}{
+		{
+			name:        "user role",
+			body:        `{"messages":[{"role":"user","content":"hi there"}]}`,
+			wantKind:    "user_prompt",
+			wantPreview: "hi there",
+		},
+		{
+			name:     "tool role",
+			body:     `{"messages":[{"role":"user","content":"go"},{"role":"tool","tool_call_id":"t1","content":"output"}]}`,
+			wantKind: "tool_result",
+		},
+		{
+			name:     "assistant role",
+			body:     `{"messages":[{"role":"user","content":"hi"},{"role":"assistant","content":"hello"}]}`,
+			wantKind: "assistant",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			env, err := translate.ParseOpenAI([]byte(tc.body))
+			require.NoError(t, err)
+			feats := env.RoutingFeatures(false)
+			assert.Equal(t, tc.wantKind, feats.LastKind)
+			if tc.wantPreview != "" {
+				assert.Equal(t, tc.wantPreview, feats.LastPreview)
+			}
+		})
+	}
+}

--- a/internal/translate/features.go
+++ b/internal/translate/features.go
@@ -83,21 +83,176 @@ func (e *RequestEnvelope) openAIRoutingFeatures() RoutingFeatures {
 	msgs := gjson.GetBytes(e.body, "messages")
 
 	var b strings.Builder
-	msgCount := 0
+	var (
+		msgCount int
+		lastMsg  gjson.Result
+	)
 	msgs.ForEach(func(_, msg gjson.Result) bool {
 		msgCount++
 		appendText(&b, openAIContentTextGJSON(msg.Get("content")))
+		lastMsg = msg
 		return true
 	})
 	text := b.String()
 
-	return RoutingFeatures{
+	feats := RoutingFeatures{
 		Tokens:       len(text) / 4,
 		Model:        e.Model(),
 		HasTools:     e.HasTools(),
 		PromptText:   text,
 		MessageCount: msgCount,
 	}
+
+	if msgCount > 0 {
+		feats.LastKind = classifyLastMessageOpenAI(lastMsg.Get("role").String())
+		feats.LastPreview = previewText(openAIContentTextGJSON(lastMsg.Get("content")))
+	}
+
+	return feats
+}
+
+// classifyLastMessageOpenAI maps an OpenAI message role onto the
+// shared three-value LastKind enum. OpenAI uses dedicated `tool` and
+// `assistant` roles, so unlike Anthropic there is no need to inspect
+// content blocks.
+func classifyLastMessageOpenAI(role string) string {
+	switch role {
+	case "assistant":
+		return "assistant"
+	case "tool":
+		return "tool_result"
+	default:
+		return "user_prompt"
+	}
+}
+
+// previewText returns the first previewMaxChars of text with newlines
+// collapsed to single spaces. Shared by Anthropic and OpenAI feature
+// extraction so LastPreview has identical semantics across formats.
+func previewText(text string) string {
+	if text == "" {
+		return ""
+	}
+	text = strings.Join(strings.Fields(text), " ")
+	runes := []rune(text)
+	if len(runes) <= previewMaxChars {
+		return text
+	}
+	return string(runes[:previewMaxChars]) + "…"
+}
+
+// anthropicLastUserMessage walks messages backwards for the last role
+// "user" entry and reports whether it contains text and/or tool_result
+// blocks. The bare-string content shape counts as text.
+func anthropicLastUserMessage(body []byte) LastUserMessageInfo {
+	msgs := gjson.GetBytes(body, "messages")
+	if !msgs.IsArray() {
+		return LastUserMessageInfo{}
+	}
+	var lastUser gjson.Result
+	msgs.ForEach(func(_, msg gjson.Result) bool {
+		if msg.Get("role").String() == "user" {
+			lastUser = msg
+		}
+		return true
+	})
+	if !lastUser.Exists() {
+		return LastUserMessageInfo{}
+	}
+	content := lastUser.Get("content")
+	if content.Type == gjson.String {
+		s := content.String()
+		return LastUserMessageInfo{HasText: s != "", Text: s}
+	}
+	if !content.IsArray() {
+		return LastUserMessageInfo{}
+	}
+	info := LastUserMessageInfo{}
+	var b strings.Builder
+	content.ForEach(func(_, block gjson.Result) bool {
+		switch block.Get("type").String() {
+		case "tool_result":
+			info.HasToolResult = true
+			info.ToolResultCount++
+		case "text":
+			text := block.Get("text").String()
+			if text == "" {
+				return true
+			}
+			info.HasText = true
+			if b.Len() > 0 {
+				b.WriteByte('\n')
+			}
+			b.WriteString(text)
+		}
+		return true
+	})
+	if info.HasText {
+		info.Text = b.String()
+	}
+	return info
+}
+
+// openAILastUserMessage scans the trailing run of role=="tool"
+// messages and the most recent role=="user" message. OpenAI splits
+// tool returns into separate messages, so a tool-result-only turn is
+// one or more trailing role=="tool" messages with no role=="user"
+// after them.
+func openAILastUserMessage(body []byte) LastUserMessageInfo {
+	msgs := gjson.GetBytes(body, "messages")
+	if !msgs.IsArray() {
+		return LastUserMessageInfo{}
+	}
+	all := msgs.Array()
+	if len(all) == 0 {
+		return LastUserMessageInfo{}
+	}
+	info := LastUserMessageInfo{}
+	for i := len(all) - 1; i >= 0; i-- {
+		role := all[i].Get("role").String()
+		switch role {
+		case "tool":
+			info.HasToolResult = true
+			info.ToolResultCount++
+			continue
+		case "user":
+			text := openAIContentTextGJSON(all[i].Get("content"))
+			if text != "" {
+				info.HasText = true
+				info.Text = text
+			}
+		}
+		// Stop at the first non-tool message regardless of role.
+		break
+	}
+	return info
+}
+
+// openAISystemText concatenates every role=="system" message's text
+// content. OpenAI carries the system prompt inline rather than in a
+// separate field, and may have multiple system messages (e.g. one
+// from the framework, one from the developer).
+func openAISystemText(body []byte) string {
+	msgs := gjson.GetBytes(body, "messages")
+	if !msgs.IsArray() {
+		return ""
+	}
+	var b strings.Builder
+	msgs.ForEach(func(_, msg gjson.Result) bool {
+		if msg.Get("role").String() != "system" {
+			return true
+		}
+		text := openAIContentTextGJSON(msg.Get("content"))
+		if text == "" {
+			return true
+		}
+		if b.Len() > 0 {
+			b.WriteByte('\n')
+		}
+		b.WriteString(text)
+		return true
+	})
+	return b.String()
 }
 
 // --- gjson-based content text helpers (zero allocation from e.body) ---
@@ -162,16 +317,7 @@ func classifyLastMessageGJSON(role string, content gjson.Result) string {
 }
 
 func previewGJSON(content gjson.Result) string {
-	text := contentTextGJSON(content)
-	if text == "" {
-		return ""
-	}
-	text = strings.Join(strings.Fields(text), " ")
-	runes := []rune(text)
-	if len(runes) <= previewMaxChars {
-		return text
-	}
-	return string(runes[:previewMaxChars]) + "…"
+	return previewText(contentTextGJSON(content))
 }
 
 func userPromptTextGJSON(content gjson.Result) string {


### PR DESCRIPTION
## Summary

Step 1 of unifying session-aware routing across all ingress formats (see [AGENTIC_CODING.md](docs/plans/AGENTIC_CODING.md)). Foundational refactor with **no behavior change** on the Anthropic ingress; sets up the upcoming \`routeWithSession\` helper and OpenAI/Gemini ingresses to share one detection path.

## Changes

- \`translate.RequestEnvelope.SystemText()\` is now format-neutral. OpenAI walks \`messages[]\` for \`role==\"system\"\` entries (was \`\"\"\` before).
- New \`translate.RequestEnvelope.LastUserMessage()\` reports \`HasText\` / \`HasToolResult\` / \`Text\` / \`ToolResultCount\` format-neutrally.
- OpenAI \`RoutingFeatures\` now populates \`LastKind\` and \`LastPreview\`, so the upcoming OpenAI \`ToolResult\` classification works without re-walking the body.
- \`turntype.Detect(body []byte)\` replaced by \`DetectFromEnvelope(env, feats, subAgentHint)\`. \`subAgentHint\` is the optional \`x-weave-subagent-type\` header for non-Anthropic clients that can't pack identity into \`metadata.user_id\`.

## Why this is the right seam

After this PR, all turn-type detection is fed by parsed-envelope methods that the proxy already computes. PR 2 (\`routeWithSession\`) can wire both Anthropic and OpenAI ingress through one helper because they now share the detection contract. PR 3 (native Gemini ingress) only needs to add a third \`switch e.format\` arm — no new turn-type code.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go vet ./...\` clean
- [x] \`go test ./...\` green
- [x] Existing turntype/anthropic test cases ported verbatim to the new signature
- [x] New OpenAI fixtures added for all four turn types (\`MainLoop\`, \`ToolResult\`, \`Compaction\`, \`SubAgentDispatch\`)
- [x] New translate tests cover \`SystemText\` (Anthropic + OpenAI) and \`LastUserMessage\` (Anthropic + OpenAI) shapes
- [ ] Manual smoke against staging (deferred to PR 4 SWE-Bench validation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)