### PR TITLE
refactor(proxy): unify session-aware routing across all ingress

### DIFF
--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -15,7 +15,6 @@ import (
 	"workweave/router/internal/router"
 	"workweave/router/internal/router/cache"
 	"workweave/router/internal/router/sessionpin"
-	"workweave/router/internal/router/turntype"
 	"workweave/router/internal/translate"
 
 	"github.com/google/uuid"
@@ -278,9 +277,6 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 		embedFlag = v
 	}
 	feats := env.RoutingFeatures(embedFlag)
-	// Anthropic clients pack sub-agent identity into metadata.user_id;
-	// the x-weave-subagent-type header is for non-Anthropic ingress.
-	tt := turntype.DetectFromEnvelope(env, feats, "")
 	promptText := feats.PromptText
 	embedInput := "concatenated_stream"
 	if embedFlag && feats.LastUserMessageText != "" {
@@ -290,7 +286,7 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 
 	apiKeyID, _ := ctx.Value(APIKeyIDContextKey{}).(string)
 	externalID, _ := ctx.Value(ExternalIDContextKey{}).(string)
-	installationID, _ := ctx.Value(InstallationIDContextKey{}).(string)
+	installationID := installationIDFromContext(ctx)
 	clientID := ClientIdentityFrom(ctx)
 	bypassEval := hasEvalOverrideHeader(r)
 	// Tier-1/2 (session-key-based) pinning stays enabled for eval traffic. The
@@ -304,141 +300,26 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 	// decision would stick across unrelated instances.
 	bypassLegacySticky := bypassEval
 
-	// §3.4: hard pins for turn types whose optimal model is known a priori.
-	// These bypass all session-pin tiers and the cluster scorer, and must NOT
-	// write a pin upsert (they must not overwrite the session's main-loop model).
-	//   Compaction — always Haiku (short-out-of-long-in cost profile).
-	//   SubAgentDispatch — Haiku when ROUTER_HARD_PIN_EXPLORE is set; gated
-	//     until one week of shadow validation confirms no quality regression.
-	var (
-		decision    router.Decision
-		stickyHit   bool
-		pinTier     = "miss"
-		pinAgeSec   int64
-		sessionKey  [sessionpin.SessionKeyLen]byte
-		pinCacheKey string
-		routeStart  = time.Now()
-	)
-	if tt == turntype.Compaction || (tt == turntype.SubAgentDispatch && s.hardPinExplore) {
-		decision = router.Decision{
-			Provider: s.hardPinProvider,
-			Model:    s.hardPinModel,
-			Reason:   string(tt) + "_hard_pin",
-		}
-		stickyHit = true
-		pinTier = string(tt) + "_hard_pin"
+	// Anthropic clients pack sub-agent identity into metadata.user_id; the
+	// x-weave-subagent-type header is for non-Anthropic ingress, so this
+	// call passes "".
+	routeStart := time.Now()
+	routeRes, routeErr := s.routeWithSession(ctx, env, feats, apiKeyID, installationID, "", bypassLegacySticky, router.Request{
+		RequestedModel:       feats.Model,
+		EstimatedInputTokens: feats.Tokens,
+		HasTools:             feats.HasTools,
+		PromptText:           promptText,
+		EnabledProviders:     s.enabledProvidersForRequest(ctx, r.Header),
+	})
+	if routeErr != nil {
+		log.Error("Routing failed", "err", routeErr, "route_ms", time.Since(routeStart).Milliseconds(), "requested_model", feats.Model, "estimated_input_tokens", feats.Tokens)
+		return routeErr
 	}
-
-	// Tiered routing-decision lookup (see docs/plans/SESSION_PIN.md §5).
-	//   Tier 1 — pinCache (in-proc, 30s):   absorbs same-instance burst.
-	//   Tier 2 — pinStore (Postgres, 1h):   survives Cloud Run restarts.
-	//   Tier 3 — stickyDecisions (legacy):  apiKeyID-keyed LRU; kept
-	//                                        during rollout, removed in
-	//                                        a follow-up.
-	// Tier 3 is only consulted on a tier-2 *miss*, never on a tier-2
-	// *error* — papering over store errors with the legacy cache would
-	// mask the migrate-to-Memorystore trigger criteria.
-	// pinEligible is false for hard-pinned turns (stickyHit already set above),
-	// which also suppresses the async pin upsert for those turns.
-	pinEligible := s.pinStore != nil && !stickyHit
-	if pinEligible {
-		sessionKey = DeriveSessionKey(env, apiKeyID)
-		pinCacheKey = sessionPinCacheKey(sessionKey, sessionpin.DefaultRole)
-
-		if s.pinCache != nil {
-			if pin, ok := s.pinCache.Get(pinCacheKey); ok {
-				decision = pinDecision(pin)
-				stickyHit = true
-				pinTier = "in_proc"
-				pinAgeSec = pinAge(pin)
-			}
-		}
-		if !stickyHit {
-			pin, found, err := s.pinStore.Get(ctx, sessionKey, sessionpin.DefaultRole)
-			if err != nil {
-				log.Error("session pin store unavailable; falling through to cluster scorer", "err", err)
-			} else if found && pin.PinnedUntil.After(time.Now()) {
-				decision = pinDecision(pin)
-				stickyHit = true
-				pinTier = "postgres"
-				pinAgeSec = pinAge(pin)
-				if s.pinCache != nil {
-					s.pinCache.Add(pinCacheKey, pin)
-				}
-			}
-		}
-	}
-
-	// Tier 3: legacy apiKeyID LRU. Consulted only on tier-2 miss (or
-	// when pinStore is nil).
-	if !stickyHit && s.stickyDecisions != nil && apiKeyID != "" && !bypassLegacySticky {
-		if d, ok := s.stickyDecisions.Get(apiKeyID); ok {
-			decision = d
-			stickyHit = true
-			pinTier = "legacy_apikey"
-		}
-	}
-
-	if !stickyHit {
-		var err error
-		decision, err = s.router.Route(ctx, router.Request{
-			RequestedModel:       feats.Model,
-			EstimatedInputTokens: feats.Tokens,
-			HasTools:             feats.HasTools,
-			PromptText:           promptText,
-			EnabledProviders:     s.enabledProvidersForRequest(ctx, r.Header),
-		})
-		if err != nil {
-			log.Error("Routing failed", "err", err, "route_ms", time.Since(routeStart).Milliseconds(), "requested_model", feats.Model, "estimated_input_tokens", feats.Tokens)
-			return err
-		}
-		if s.stickyDecisions != nil && apiKeyID != "" && !bypassLegacySticky {
-			s.stickyDecisions.Add(apiKeyID, decision)
-		}
-	}
-
-	// §3.3: annotate pin tier when a tool-result turn short-circuits to an
-	// existing session pin, so the routing.session_pin_tier OTel attribute
-	// reflects the bypass in dashboards.
-	if stickyHit && tt == turntype.ToolResult {
-		pinTier += "_tool_result_sc"
-	}
-
-	// Async upsert on every routed request — refreshes the sliding TTL
-	// for sticky hits, records new pins for fresh routes. Uses
-	// context.Background() per repo convention so a request cancel
-	// never drops the pin write (would force re-route on the next turn
-	// and break cache continuity).
-	if pinEligible && installationID != "" {
-		instUUID, parseErr := uuid.Parse(installationID)
-		if parseErr == nil {
-			pin := sessionpin.Pin{
-				SessionKey:     sessionKey,
-				Role:           sessionpin.DefaultRole,
-				InstallationID: instUUID,
-				Provider:       decision.Provider,
-				Model:          decision.Model,
-				Reason:         decision.Reason,
-				TurnCount:      1, // ON CONFLICT increments; only meaningful on first insert
-				PinnedUntil:    time.Now().Add(pinSessionTTL),
-			}
-			select {
-			case s.pinWriteSem <- struct{}{}:
-				go func(p sessionpin.Pin) {
-					defer func() { <-s.pinWriteSem }()
-					if err := s.pinStore.Upsert(context.Background(), p); err != nil {
-						observability.Get().Error("session pin upsert failed", "err", err)
-					}
-				}(pin)
-			default:
-				observability.Get().Debug("session pin upsert dropped: semaphore full")
-			}
-			if s.pinCache != nil {
-				s.pinCache.Add(pinCacheKey, pin)
-			}
-		}
-	}
-
+	decision := routeRes.Decision
+	tt := routeRes.TurnType
+	stickyHit := routeRes.StickyHit
+	pinTier := routeRes.PinTier
+	pinAgeSec := routeRes.PinAgeSec
 	routeMs := time.Since(routeStart).Milliseconds()
 
 	// Semantic-cache lookup. Eligible when the cache is configured at
@@ -795,7 +676,9 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 	buf := otel.NewBuffer(s.emitter)
 	ctx = buf.WithContext(ctx)
 
+	apiKeyID, _ := ctx.Value(APIKeyIDContextKey{}).(string)
 	externalID, _ := ctx.Value(ExternalIDContextKey{}).(string)
+	installationID := installationIDFromContext(ctx)
 	clientID := ClientIdentityFrom(ctx)
 
 	env, parseErr := translate.ParseOpenAI(body)
@@ -805,8 +688,15 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 	}
 	feats := env.RoutingFeatures(false)
 
+	bypassEval := hasEvalOverrideHeader(r)
+	bypassLegacySticky := bypassEval
+
+	// OpenAI clients can't pack subagent identity into metadata.user_id;
+	// they signal it via the x-weave-subagent-type header instead.
+	subAgentHint := r.Header.Get("x-weave-subagent-type")
+
 	routeStart := time.Now()
-	decision, err := s.router.Route(ctx, router.Request{
+	routeRes, err := s.routeWithSession(ctx, env, feats, apiKeyID, installationID, subAgentHint, bypassLegacySticky, router.Request{
 		RequestedModel:       feats.Model,
 		EstimatedInputTokens: feats.Tokens,
 		HasTools:             feats.HasTools,
@@ -818,12 +708,16 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 		log.Error("Routing failed for OpenAI request", "err", err, "route_ms", routeMs, "requested_model", feats.Model, "estimated_input_tokens", feats.Tokens)
 		return err
 	}
+	decision := routeRes.Decision
+	tt := routeRes.TurnType
+	stickyHit := routeRes.StickyHit
+	pinTier := routeRes.PinTier
+	pinAgeSec := routeRes.PinAgeSec
 
 	// Semantic-cache lookup — same eligibility rules as ProxyMessages
 	// (see that handler for rationale). Inbound format is FormatOpenAI
 	// so an Anthropic-stored response is never replayed here. Eval-
 	// harness traffic bypasses the cache; see ProxyMessages.
-	bypassEval := hasEvalOverrideHeader(r)
 	cacheEligible := s.semanticCache != nil && !env.Stream() && decision.Metadata != nil && externalID != "" && !bypassEval
 	if cacheEligible {
 		if resp, hit := s.semanticCache.Lookup(externalID, cache.FormatOpenAI, decision.Metadata.Embedding, decision.Metadata.ClusterIDs); hit {
@@ -863,7 +757,7 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 		Name:  "router.decision",
 		Start: requestStart,
 		End:   time.Now(),
-		Attrs: otel.NewAttrBuilder(17).
+		Attrs: otel.NewAttrBuilder(22).
 			String("request_id", requestID).
 			String("external_id", externalID).
 			String("client.device_id", clientID.DeviceID).
@@ -875,6 +769,11 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 			String("decision.model", decision.Model).
 			String("decision.provider", decision.Provider).
 			String("decision.reason", decision.Reason).
+			Bool("routing.sticky_hit", stickyHit).
+			Bool("routing.session_pin_hit", pinTier == "in_proc" || pinTier == "postgres").
+			String("routing.session_pin_tier", pinTier).
+			Int64("routing.session_pin_age_s", pinAgeSec).
+			String("routing.turn_type", string(tt)).
 			Int64("routing.estimated_input_tokens", int64(feats.Tokens)).
 			Float64("pricing.requested_input_per_1m", reqPricing.InputUSDPer1M).
 			Float64("pricing.requested_output_per_1m", reqPricing.OutputUSDPer1M).
@@ -1001,6 +900,6 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 	})
 	otel.Flush(ctx)
 
-	log.Info("ProxyOpenAIChatCompletion complete", "requested_model", feats.Model, "decision_model", decision.Model, "decision_reason", decision.Reason, "estimated_input_tokens", feats.Tokens, "has_tools", feats.HasTools, "cross_format", crossFormat, "route_ms", routeMs, "proxy_ms", proxyMs, "proxy_err", proxyErr, "upstream_status", upstreamStatus(proxyErr))
+	log.Info("ProxyOpenAIChatCompletion complete", "requested_model", feats.Model, "decision_model", decision.Model, "decision_provider", decision.Provider, "decision_reason", decision.Reason, "estimated_input_tokens", feats.Tokens, "has_tools", feats.HasTools, "cross_format", crossFormat, "sticky_hit", stickyHit, "pin_tier", pinTier, "turn_type", string(tt), "route_ms", routeMs, "proxy_ms", proxyMs, "proxy_err", proxyErr, "upstream_status", upstreamStatus(proxyErr))
 	return proxyErr
 }

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -273,13 +273,14 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 		return fmt.Errorf("parse request: %w", parseErr)
 	}
 
-	tt := turntype.Detect(body)
-
 	embedFlag := s.embedLastUserMessage
 	if v, ok := embedLastUserMessageOverride(ctx); ok {
 		embedFlag = v
 	}
 	feats := env.RoutingFeatures(embedFlag)
+	// Anthropic clients pack sub-agent identity into metadata.user_id;
+	// the x-weave-subagent-type header is for non-Anthropic ingress.
+	tt := turntype.DetectFromEnvelope(env, feats, "")
 	promptText := feats.PromptText
 	embedInput := "concatenated_stream"
 	if embedFlag && feats.LastUserMessageText != "" {

--- a/internal/proxy/service_session_pin_test.go
+++ b/internal/proxy/service_session_pin_test.go
@@ -301,3 +301,177 @@ func TestService_HardPin_ExploreFallsThroughWhenFlagOff(t *testing.T) {
 	assert.Equal(t, "claude-opus-4-7", rec.Header().Get("x-router-model"),
 		"cluster scorer decision must be used when hardPinExplore is off")
 }
+
+// --- OpenAI ingress: same Stage 1 path as Anthropic, exercised through
+// ProxyOpenAIChatCompletion. Before the routeWithSession unification,
+// this handler ran the cluster scorer on every turn with no session
+// memory; the assertions below codify the unblock.
+
+const openAIPinTestBody = `{
+	"model":"gpt-4o",
+	"messages":[
+		{"role":"system","content":"You are helpful."},
+		{"role":"user","content":"original prompt"}
+	]
+}`
+
+func newOpenAIPinSvc(fr *fakeRouter, store *fakePinStore) *proxy.Service {
+	// Register fakeProvider under both Anthropic (default decision target
+	// for cross-format paths) and OpenAI (matches the test decisions).
+	return proxy.NewService(
+		fr,
+		map[string]providers.Client{
+			providers.ProviderAnthropic: &fakeProvider{},
+			providers.ProviderOpenAI:    &fakeProvider{},
+		},
+		nil, false, 0, nil, nil,
+		store,
+		false, providers.ProviderAnthropic, "claude-haiku-4-5",
+	)
+}
+
+func TestService_SessionPin_OpenAI_PostgresHitShortCircuitsRoute(t *testing.T) {
+	store := newFakePinStore()
+	store.hasPin = true
+	store.pin = sessionpin.Pin{
+		Provider:      providers.ProviderOpenAI,
+		Model:         "gpt-5",
+		Reason:        "cluster:v0.2",
+		PinnedUntil:   time.Now().Add(30 * time.Minute),
+		FirstPinnedAt: time.Now().Add(-5 * time.Minute),
+	}
+	fr := &fakeRouter{decision: router.Decision{Provider: providers.ProviderOpenAI, Model: "gpt-4o", Reason: "cluster:v0.2"}}
+	svc := newOpenAIPinSvc(fr, store)
+
+	ctx := authedCtx(uuid.New().String())
+	rec := httptest.NewRecorder()
+	httpReq := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(""))
+	require.NoError(t, svc.ProxyOpenAIChatCompletion(ctx, []byte(openAIPinTestBody), rec, httpReq))
+
+	assert.Equal(t, 0, fr.routeCalls,
+		"OpenAI ingress: tier-2 hit must short-circuit the cluster scorer "+
+			"(this is the SWE-Bench unblock — without it every turn re-runs "+
+			"the cluster scorer cold)")
+	assert.Equal(t, "gpt-5", rec.Header().Get("x-router-model"),
+		"the response must reflect the pinned model, not the fresh-route model")
+	waitForUpsert(t, store)
+}
+
+func TestService_SessionPin_OpenAI_FreshRouteCreatesPin(t *testing.T) {
+	store := newFakePinStore()
+	fr := &fakeRouter{decision: router.Decision{Provider: providers.ProviderOpenAI, Model: "gpt-4o", Reason: "fresh"}}
+	svc := newOpenAIPinSvc(fr, store)
+
+	ctx := authedCtx(uuid.New().String())
+	rec := httptest.NewRecorder()
+	httpReq := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(""))
+	require.NoError(t, svc.ProxyOpenAIChatCompletion(ctx, []byte(openAIPinTestBody), rec, httpReq))
+
+	assert.Equal(t, 1, fr.routeCalls, "first turn must route fresh")
+	waitForUpsert(t, store)
+	require.Len(t, store.upserts, 1)
+	assert.Equal(t, providers.ProviderOpenAI, store.upserts[0].Provider)
+	assert.Equal(t, "gpt-4o", store.upserts[0].Model)
+}
+
+func TestService_SessionPin_OpenAI_ToolResultShortCircuit(t *testing.T) {
+	// Trailing role=="tool" message — turntype.ToolResult on the OpenAI
+	// path. With a pin present, this must short-circuit the cluster
+	// scorer (the embedding for a tool-result-only turn is mostly noise
+	// and would otherwise flip the decision mid-session).
+	const toolResultBody = `{
+		"model":"gpt-4o",
+		"messages":[
+			{"role":"system","content":"You are helpful."},
+			{"role":"user","content":"original prompt"},
+			{"role":"assistant","content":null,"tool_calls":[{"id":"t1","type":"function","function":{"name":"Bash","arguments":"{}"}}]},
+			{"role":"tool","tool_call_id":"t1","content":"ls output"}
+		]
+	}`
+	store := newFakePinStore()
+	store.hasPin = true
+	store.pin = sessionpin.Pin{
+		Provider:    providers.ProviderOpenAI,
+		Model:       "gpt-5",
+		Reason:      "cluster:v0.2",
+		PinnedUntil: time.Now().Add(30 * time.Minute),
+	}
+	fr := &fakeRouter{decision: router.Decision{Provider: providers.ProviderOpenAI, Model: "gpt-4o", Reason: "fresh"}}
+	svc := newOpenAIPinSvc(fr, store)
+
+	ctx := authedCtx(uuid.New().String())
+	rec := httptest.NewRecorder()
+	httpReq := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(""))
+	require.NoError(t, svc.ProxyOpenAIChatCompletion(ctx, []byte(toolResultBody), rec, httpReq))
+
+	assert.Equal(t, 0, fr.routeCalls,
+		"tool-result turn with an existing pin must not re-run the cluster scorer")
+	assert.Equal(t, "gpt-5", rec.Header().Get("x-router-model"),
+		"the pinned model must serve the tool-result turn")
+}
+
+// newOpenAIHardPinSvc configures a service whose hard-pin target is on
+// the OpenAI provider, so the OpenAI ingress hard-pin path stays
+// same-format and doesn't exercise the cross-format Anthropic
+// translator (which would need a real upstream response body to
+// finalize). The test scope is the routing decision; the cross-format
+// path has its own coverage in service_test.go.
+func newOpenAIHardPinSvc(fr *fakeRouter, store *fakePinStore, hardPinExplore bool) *proxy.Service {
+	return proxy.NewService(
+		fr,
+		map[string]providers.Client{
+			providers.ProviderAnthropic: &fakeProvider{},
+			providers.ProviderOpenAI:    &fakeProvider{},
+		},
+		nil, false, 0, nil, nil,
+		store,
+		hardPinExplore,
+		providers.ProviderOpenAI,
+		"gpt-4o-mini",
+	)
+}
+
+func TestService_HardPin_OpenAI_CompactionRoutesToHardPin(t *testing.T) {
+	const compactionOpenAIBody = `{
+		"model":"gpt-4o",
+		"messages":[
+			{"role":"system","content":"Your task is to create a detailed summary of the conversation so far."},
+			{"role":"user","content":"go"}
+		]
+	}`
+	store := newFakePinStore()
+	fr := &fakeRouter{decision: router.Decision{Provider: providers.ProviderOpenAI, Model: "gpt-4o", Reason: "cluster"}}
+	svc := newOpenAIHardPinSvc(fr, store, false)
+
+	ctx := authedCtx(uuid.New().String())
+	rec := httptest.NewRecorder()
+	httpReq := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(""))
+	require.NoError(t, svc.ProxyOpenAIChatCompletion(ctx, []byte(compactionOpenAIBody), rec, httpReq))
+
+	assert.Equal(t, 0, fr.routeCalls,
+		"OpenAI compaction turns must bypass the cluster scorer entirely")
+	assert.Equal(t, "gpt-4o-mini", rec.Header().Get("x-router-model"),
+		"compaction must hard-pin to the configured hard-pin model regardless of inbound format")
+
+	select {
+	case <-store.upsertCh:
+		t.Fatal("compaction turn must not write a session pin")
+	case <-time.After(100 * time.Millisecond):
+	}
+}
+
+func TestService_HardPin_OpenAI_SubAgentHeaderHintRoutesToHardPin(t *testing.T) {
+	store := newFakePinStore()
+	fr := &fakeRouter{decision: router.Decision{Provider: providers.ProviderOpenAI, Model: "gpt-4o", Reason: "cluster"}}
+	svc := newOpenAIHardPinSvc(fr, store, true)
+
+	ctx := authedCtx(uuid.New().String())
+	rec := httptest.NewRecorder()
+	httpReq := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(""))
+	httpReq.Header.Set("x-weave-subagent-type", "Explore")
+	require.NoError(t, svc.ProxyOpenAIChatCompletion(ctx, []byte(openAIPinTestBody), rec, httpReq))
+
+	assert.Equal(t, 0, fr.routeCalls,
+		"x-weave-subagent-type header must trigger Explore hard-pin on OpenAI ingress")
+	assert.Equal(t, "gpt-4o-mini", rec.Header().Get("x-router-model"))
+}

--- a/internal/proxy/session_route.go
+++ b/internal/proxy/session_route.go
@@ -1,0 +1,185 @@
+package proxy
+
+import (
+	"context"
+	"time"
+
+	"workweave/router/internal/observability"
+	"workweave/router/internal/router"
+	"workweave/router/internal/router/sessionpin"
+	"workweave/router/internal/router/turntype"
+	"workweave/router/internal/translate"
+
+	"github.com/google/uuid"
+)
+
+// installationIDFromContext reads the installation ID stashed by the
+// auth middleware and parses it. Returns uuid.Nil for unauthenticated
+// callers or when the value isn't a valid UUID; both cases mean "no
+// async pin upsert" downstream.
+func installationIDFromContext(ctx context.Context) uuid.UUID {
+	raw, _ := ctx.Value(InstallationIDContextKey{}).(string)
+	if raw == "" {
+		return uuid.Nil
+	}
+	id, err := uuid.Parse(raw)
+	if err != nil {
+		return uuid.Nil
+	}
+	return id
+}
+
+// sessionRouteResult bundles the routing decision and the pin-state
+// fields handlers attach to OTel spans and log lines. PinTier is the
+// tier-string the dashboards group on; PinAgeSec is seconds since
+// first pinning (zero on a fresh decision or a hard-pin path).
+type sessionRouteResult struct {
+	Decision   router.Decision
+	SessionKey [sessionpin.SessionKeyLen]byte
+	TurnType   turntype.TurnType
+	StickyHit  bool
+	HardPinned bool
+	PinTier    string
+	PinAgeSec  int64
+}
+
+// routeWithSession is the format-agnostic routing orchestrator: turn-type
+// detection, hard-pin short-circuit, tiered session-pin lookup, cluster
+// scorer fallback, and async pin upsert. ProxyMessages and
+// ProxyOpenAIChatCompletion (and any future ingress) call it and apply
+// the returned decision through the existing provider dispatch switch.
+//
+// installationID is uuid.Nil for unauthenticated / non-installation
+// callers; in that case the async upsert is skipped (pin rows require an
+// installation_id). subAgentHint is the optional x-weave-subagent-type
+// header value — empty for ingresses that don't read it.
+//
+// bypassLegacySticky disables the Tier-3 (apiKeyID-keyed LRU) lookup;
+// Tier 1/2 stay active because the session_key derivation is per-prompt,
+// not per-apiKey.
+func (s *Service) routeWithSession(
+	ctx context.Context,
+	env *translate.RequestEnvelope,
+	feats translate.RoutingFeatures,
+	apiKeyID string,
+	installationID uuid.UUID,
+	subAgentHint string,
+	bypassLegacySticky bool,
+	req router.Request,
+) (sessionRouteResult, error) {
+	log := observability.Get()
+	res := sessionRouteResult{
+		TurnType: turntype.DetectFromEnvelope(env, feats, subAgentHint),
+		PinTier:  "miss",
+	}
+
+	// §3.4: hard pins for turn types whose optimal model is known a priori.
+	// These bypass all pin tiers and the cluster scorer, and must NOT write
+	// a pin upsert (would overwrite the session's main-loop model).
+	if res.TurnType == turntype.Compaction ||
+		(res.TurnType == turntype.SubAgentDispatch && s.hardPinExplore) {
+		res.Decision = router.Decision{
+			Provider: s.hardPinProvider,
+			Model:    s.hardPinModel,
+			Reason:   string(res.TurnType) + "_hard_pin",
+		}
+		res.StickyHit = true
+		res.HardPinned = true
+		res.PinTier = string(res.TurnType) + "_hard_pin"
+		return res, nil
+	}
+
+	// Tier 1 (in-proc LRU) → Tier 2 (Postgres) → Tier 3 (legacy apiKeyID
+	// LRU). See docs/plans/SESSION_PIN.md §5. Tier 3 stays bypassed under
+	// eval-override headers because the eval harness shares a single
+	// apiKeyID across unrelated prompts.
+	pinEligible := s.pinStore != nil
+	var pinCacheKey string
+	if pinEligible {
+		res.SessionKey = DeriveSessionKey(env, apiKeyID)
+		pinCacheKey = sessionPinCacheKey(res.SessionKey, sessionpin.DefaultRole)
+
+		if s.pinCache != nil {
+			if pin, ok := s.pinCache.Get(pinCacheKey); ok {
+				res.Decision = pinDecision(pin)
+				res.StickyHit = true
+				res.PinTier = "in_proc"
+				res.PinAgeSec = pinAge(pin)
+			}
+		}
+		if !res.StickyHit {
+			pin, found, err := s.pinStore.Get(ctx, res.SessionKey, sessionpin.DefaultRole)
+			if err != nil {
+				log.Error("session pin store unavailable; falling through to cluster scorer", "err", err)
+			} else if found && pin.PinnedUntil.After(time.Now()) {
+				res.Decision = pinDecision(pin)
+				res.StickyHit = true
+				res.PinTier = "postgres"
+				res.PinAgeSec = pinAge(pin)
+				if s.pinCache != nil {
+					s.pinCache.Add(pinCacheKey, pin)
+				}
+			}
+		}
+	}
+
+	// Tier 3: legacy apiKeyID LRU. Consulted only on Tier-2 miss (or when
+	// pinStore is nil) and never under eval-override headers.
+	if !res.StickyHit && s.stickyDecisions != nil && apiKeyID != "" && !bypassLegacySticky {
+		if d, ok := s.stickyDecisions.Get(apiKeyID); ok {
+			res.Decision = d
+			res.StickyHit = true
+			res.PinTier = "legacy_apikey"
+		}
+	}
+
+	if !res.StickyHit {
+		decision, err := s.router.Route(ctx, req)
+		if err != nil {
+			return res, err
+		}
+		res.Decision = decision
+		if s.stickyDecisions != nil && apiKeyID != "" && !bypassLegacySticky {
+			s.stickyDecisions.Add(apiKeyID, decision)
+		}
+	}
+
+	// §3.3: annotate pin tier when a tool-result turn short-circuits to an
+	// existing session pin.
+	if res.StickyHit && res.TurnType == turntype.ToolResult {
+		res.PinTier += "_tool_result_sc"
+	}
+
+	// Async upsert refreshes the sliding TTL on sticky hits and records
+	// new pins on fresh routes. context.Background() is mandatory: a
+	// request cancel would otherwise drop the write and force re-routing
+	// next turn (breaking provider/cache continuity).
+	if pinEligible && installationID != uuid.Nil {
+		pin := sessionpin.Pin{
+			SessionKey:     res.SessionKey,
+			Role:           sessionpin.DefaultRole,
+			InstallationID: installationID,
+			Provider:       res.Decision.Provider,
+			Model:          res.Decision.Model,
+			Reason:         res.Decision.Reason,
+			TurnCount:      1, // ON CONFLICT increments; only meaningful on first insert
+			PinnedUntil:    time.Now().Add(pinSessionTTL),
+		}
+		select {
+		case s.pinWriteSem <- struct{}{}:
+			go func(p sessionpin.Pin) {
+				defer func() { <-s.pinWriteSem }()
+				if err := s.pinStore.Upsert(context.Background(), p); err != nil {
+					observability.Get().Error("session pin upsert failed", "err", err)
+				}
+			}(pin)
+		default:
+			observability.Get().Debug("session pin upsert dropped: semaphore full")
+		}
+		if s.pinCache != nil {
+			s.pinCache.Add(pinCacheKey, pin)
+		}
+	}
+
+	return res, nil
+}

--- a/internal/router/turntype/detect.go
+++ b/internal/router/turntype/detect.go
@@ -1,12 +1,13 @@
-// Package turntype classifies inbound Anthropic-format request bodies by
-// conversation role. It is a pure, I/O-free helper used by the proxy service
-// to enable role-conditioned routing (§3.3–§3.4 of docs/plans/AGENTIC_CODING.md).
+// Package turntype classifies inbound conversation requests by role,
+// independent of wire format. It is a pure, I/O-free helper used by
+// the proxy service to enable role-conditioned routing (§3.3–§3.4 of
+// docs/plans/AGENTIC_CODING.md).
 package turntype
 
 import (
 	"strings"
 
-	"github.com/tidwall/gjson"
+	"workweave/router/internal/translate"
 )
 
 // TurnType classifies an inbound conversation turn.
@@ -15,7 +16,7 @@ type TurnType string
 const (
 	// MainLoop is the default — a regular user prompt scored by the cluster scorer.
 	MainLoop TurnType = "main_loop"
-	// ToolResult indicates the last user message consists entirely of
+	// ToolResult indicates the last user-side input consists entirely of
 	// tool_result blocks with no text. The cluster scorer embedding is mostly
 	// noise on these turns; they short-circuit to the session pin when one exists.
 	ToolResult TurnType = "tool_result"
@@ -28,18 +29,28 @@ const (
 	Compaction TurnType = "compaction"
 )
 
-// Detect classifies the inbound Anthropic-format request body.
-// Conservative: false negatives (returning MainLoop) are safe — the cluster
-// scorer runs normally. False positives are the real risk; each heuristic is
-// intentionally tight.
-func Detect(body []byte) TurnType {
-	if isCompaction(body) {
+// DetectFromEnvelope classifies an inbound request using a parsed
+// envelope and its already-computed routing features. subAgentHint is
+// the optional `x-weave-subagent-type` header value: clients that
+// can't pack subagent identity into Anthropic's metadata.user_id (e.g.
+// OpenAI / Gemini ingress) use the header instead. Empty hint is
+// ignored.
+//
+// Conservative: false negatives (returning MainLoop) are safe — the
+// cluster scorer runs normally. False positives are the real risk; each
+// heuristic is intentionally tight.
+func DetectFromEnvelope(env *translate.RequestEnvelope, feats translate.RoutingFeatures, subAgentHint string) TurnType {
+	if env == nil {
+		return MainLoop
+	}
+	systemText := env.SystemText()
+	if isCompaction(systemText) {
 		return Compaction
 	}
-	if isSubAgentDispatch(body) {
+	if isSubAgentDispatch(env.MetadataUserID(), systemText, subAgentHint) {
 		return SubAgentDispatch
 	}
-	if isToolResult(body) {
+	if feats.LastKind == "tool_result" {
 		return ToolResult
 	}
 	return MainLoop
@@ -47,76 +58,24 @@ func Detect(body []byte) TurnType {
 
 // isCompaction returns true when the system prompt contains Claude Code's
 // context-compaction instruction markers.
-func isCompaction(body []byte) bool {
-	text := systemText(body)
-	lower := strings.ToLower(text)
+func isCompaction(systemText string) bool {
+	lower := strings.ToLower(systemText)
 	return strings.Contains(lower, "your task is to create a detailed summary") ||
 		(strings.Contains(lower, "compact") && strings.Contains(lower, "conversation"))
 }
 
-// isSubAgentDispatch returns true when the request originates from a Claude
-// Code sub-agent. Claude Code encodes sub-agent identity in metadata.user_id
-// as "subagent:<type>", or marks it in the system prompt.
-func isSubAgentDispatch(body []byte) bool {
-	if strings.HasPrefix(gjson.GetBytes(body, "metadata.user_id").String(), "subagent:") {
+// isSubAgentDispatch returns true when the request originates from a
+// sub-agent dispatch. Claude Code packs sub-agent identity into
+// metadata.user_id as "subagent:<type>"; non-Anthropic clients pass it
+// via the x-weave-subagent-type header (subAgentHint). The system
+// prompt also carries marker phrases as a third fallback.
+func isSubAgentDispatch(metadataUserID, systemText, subAgentHint string) bool {
+	if subAgentHint != "" {
 		return true
 	}
-	lower := strings.ToLower(systemText(body))
+	if strings.HasPrefix(metadataUserID, "subagent:") {
+		return true
+	}
+	lower := strings.ToLower(systemText)
 	return strings.Contains(lower, "subagent_type") || strings.Contains(lower, "sub-agent")
-}
-
-// isToolResult returns true when the last user message contains only
-// tool_result blocks and no text blocks.
-func isToolResult(body []byte) bool {
-	msgs := gjson.GetBytes(body, "messages")
-	if !msgs.IsArray() {
-		return false
-	}
-	var lastMsg gjson.Result
-	msgs.ForEach(func(_, msg gjson.Result) bool {
-		lastMsg = msg
-		return true
-	})
-	if !lastMsg.Exists() || lastMsg.Get("role").String() != "user" {
-		return false
-	}
-	content := lastMsg.Get("content")
-	if !content.IsArray() {
-		return false
-	}
-	hasToolResult := false
-	hasText := false
-	content.ForEach(func(_, block gjson.Result) bool {
-		switch block.Get("type").String() {
-		case "tool_result":
-			hasToolResult = true
-		case "text":
-			hasText = true
-		}
-		return true
-	})
-	return hasToolResult && !hasText
-}
-
-// systemText extracts plain text from the system field, which may be a string
-// or an array of content blocks.
-func systemText(body []byte) string {
-	sys := gjson.GetBytes(body, "system")
-	if sys.Type == gjson.String {
-		return sys.String()
-	}
-	if !sys.IsArray() {
-		return ""
-	}
-	var b strings.Builder
-	sys.ForEach(func(_, block gjson.Result) bool {
-		if block.Get("type").String() == "text" {
-			if b.Len() > 0 {
-				b.WriteByte('\n')
-			}
-			b.WriteString(block.Get("text").String())
-		}
-		return true
-	})
-	return b.String()
 }

--- a/internal/router/turntype/detect_test.go
+++ b/internal/router/turntype/detect_test.go
@@ -4,14 +4,17 @@ import (
 	"testing"
 
 	"workweave/router/internal/router/turntype"
+	"workweave/router/internal/translate"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
-func TestDetect(t *testing.T) {
+func TestDetectFromEnvelope_Anthropic(t *testing.T) {
 	tests := []struct {
 		name string
 		body string
+		hint string
 		want turntype.TurnType
 	}{
 		{
@@ -82,6 +85,12 @@ func TestDetect(t *testing.T) {
 			want: turntype.SubAgentDispatch,
 		},
 		{
+			name: "sub-agent via x-weave-subagent-type header hint",
+			body: `{"model":"claude-haiku-4-5","messages":[{"role":"user","content":"grep"}]}`,
+			hint: "Explore",
+			want: turntype.SubAgentDispatch,
+		},
+		{
 			name: "empty body is main_loop",
 			body: `{}`,
 			want: turntype.MainLoop,
@@ -109,8 +118,89 @@ func TestDetect(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			got := turntype.Detect([]byte(tc.body))
+			env, err := translate.ParseAnthropic([]byte(tc.body))
+			require.NoError(t, err)
+			feats := env.RoutingFeatures(false)
+			got := turntype.DetectFromEnvelope(env, feats, tc.hint)
 			assert.Equal(t, tc.want, got)
 		})
 	}
+}
+
+func TestDetectFromEnvelope_OpenAI(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+		hint string
+		want turntype.TurnType
+	}{
+		{
+			name: "regular user prompt is main_loop",
+			body: `{"model":"gpt-4o","messages":[{"role":"user","content":"explain recursion"}]}`,
+			want: turntype.MainLoop,
+		},
+		{
+			name: "trailing tool message is tool_result",
+			body: `{"model":"gpt-4o","messages":[
+				{"role":"user","content":"run the grep"},
+				{"role":"assistant","content":null,"tool_calls":[{"id":"t1","type":"function","function":{"name":"Bash","arguments":"{}"}}]},
+				{"role":"tool","tool_call_id":"t1","content":"file.go:12: foo"}
+			]}`,
+			want: turntype.ToolResult,
+		},
+		{
+			name: "tool followed by user message is main_loop",
+			body: `{"model":"gpt-4o","messages":[
+				{"role":"assistant","content":null,"tool_calls":[{"id":"t1","type":"function","function":{"name":"Bash","arguments":"{}"}}]},
+				{"role":"tool","tool_call_id":"t1","content":"out"},
+				{"role":"user","content":"keep going"}
+			]}`,
+			want: turntype.MainLoop,
+		},
+		{
+			name: "compaction via system message",
+			body: `{"model":"gpt-4o","messages":[
+				{"role":"system","content":"Your task is to create a detailed summary of the conversation so far."},
+				{"role":"user","content":"go"}
+			]}`,
+			want: turntype.Compaction,
+		},
+		{
+			name: "sub-agent via header hint",
+			body: `{"model":"gpt-4o","messages":[{"role":"user","content":"grep"}]}`,
+			hint: "Explore",
+			want: turntype.SubAgentDispatch,
+		},
+		{
+			name: "sub-agent via system message marker",
+			body: `{"model":"gpt-4o","messages":[
+				{"role":"system","content":"You are a sub-agent for the Explore task."},
+				{"role":"user","content":"list files"}
+			]}`,
+			want: turntype.SubAgentDispatch,
+		},
+		{
+			name: "last message assistant is main_loop",
+			body: `{"model":"gpt-4o","messages":[
+				{"role":"user","content":"hi"},
+				{"role":"assistant","content":"hello"}
+			]}`,
+			want: turntype.MainLoop,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			env, err := translate.ParseOpenAI([]byte(tc.body))
+			require.NoError(t, err)
+			feats := env.RoutingFeatures(false)
+			got := turntype.DetectFromEnvelope(env, feats, tc.hint)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestDetectFromEnvelope_NilEnv(t *testing.T) {
+	got := turntype.DetectFromEnvelope(nil, translate.RoutingFeatures{}, "")
+	assert.Equal(t, turntype.MainLoop, got)
 }

--- a/internal/translate/envelope.go
+++ b/internal/translate/envelope.go
@@ -117,16 +117,50 @@ func (e *RequestEnvelope) MetadataUserID() string {
 	return gjson.GetBytes(e.body, "metadata.user_id").String()
 }
 
-// SystemText returns the concatenated system-prompt text (Anthropic
-// format only). Empty for OpenAI-format requests, which carry the
-// system prompt as messages[0]. Used by session-pin keying as one of
-// the two stable inputs that don't change across turns of the same
-// session.
+// SystemText returns the concatenated system-prompt text in a
+// format-neutral way. For Anthropic, reads the top-level `system`
+// field. For OpenAI, walks `messages[]` collecting every `system`-role
+// message's text content (OpenAI carries the system prompt as a
+// message rather than a separate field, and may have multiple). Used
+// by session-pin keying and turn-type detection (compaction markers).
 func (e *RequestEnvelope) SystemText() string {
-	if e.format != FormatAnthropic {
+	switch e.format {
+	case FormatAnthropic:
+		return systemTextGJSON(gjson.GetBytes(e.body, "system"))
+	case FormatOpenAI:
+		return openAISystemText(e.body)
+	default:
 		return ""
 	}
-	return systemTextGJSON(gjson.GetBytes(e.body, "system"))
+}
+
+// LastUserMessageInfo summarizes the trailing user-side input on a
+// request. HasText is true when the last user-side input contains any
+// human-authored text; HasToolResult is true when it contains tool
+// results (tool_result blocks for Anthropic, role=="tool" messages for
+// OpenAI). Both flags can be true at once (mixed turn). Text holds the
+// extracted human text (empty when HasText is false). ToolResultCount
+// counts the contributing tool-result blocks/messages.
+type LastUserMessageInfo struct {
+	HasText         bool
+	HasToolResult   bool
+	ToolResultCount int
+	Text            string
+}
+
+// LastUserMessage returns format-neutral information about the last
+// user-side input. Used by turn-type detection to classify tool-result
+// short-circuit turns and by future per-format helpers. Returns the
+// zero value when messages is absent or empty.
+func (e *RequestEnvelope) LastUserMessage() LastUserMessageInfo {
+	switch e.format {
+	case FormatAnthropic:
+		return anthropicLastUserMessage(e.body)
+	case FormatOpenAI:
+		return openAILastUserMessage(e.body)
+	default:
+		return LastUserMessageInfo{}
+	}
 }
 
 // FirstUserMessageText returns the text of messages[0] when role is

--- a/internal/translate/envelope_extras_test.go
+++ b/internal/translate/envelope_extras_test.go
@@ -1,0 +1,237 @@
+package translate_test
+
+import (
+	"testing"
+
+	"workweave/router/internal/translate"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRequestEnvelope_SystemText_Anthropic(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+		want string
+	}{
+		{
+			name: "string system",
+			body: `{"system":"You are helpful.","messages":[{"role":"user","content":"hi"}]}`,
+			want: "You are helpful.",
+		},
+		{
+			name: "array system blocks",
+			body: `{"system":[{"type":"text","text":"alpha"},{"type":"text","text":"beta"}],"messages":[{"role":"user","content":"hi"}]}`,
+			want: "alpha\nbeta",
+		},
+		{
+			name: "missing system",
+			body: `{"messages":[{"role":"user","content":"hi"}]}`,
+			want: "",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			env, err := translate.ParseAnthropic([]byte(tc.body))
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, env.SystemText())
+		})
+	}
+}
+
+func TestRequestEnvelope_SystemText_OpenAI(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+		want string
+	}{
+		{
+			name: "single system message string content",
+			body: `{"messages":[{"role":"system","content":"You are helpful."},{"role":"user","content":"hi"}]}`,
+			want: "You are helpful.",
+		},
+		{
+			name: "multiple system messages concatenate",
+			body: `{"messages":[{"role":"system","content":"first"},{"role":"system","content":"second"},{"role":"user","content":"hi"}]}`,
+			want: "first\nsecond",
+		},
+		{
+			name: "system message array content",
+			body: `{"messages":[{"role":"system","content":[{"type":"text","text":"alpha"},{"type":"text","text":"beta"}]},{"role":"user","content":"hi"}]}`,
+			want: "alpha\nbeta",
+		},
+		{
+			name: "no system message",
+			body: `{"messages":[{"role":"user","content":"hi"}]}`,
+			want: "",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			env, err := translate.ParseOpenAI([]byte(tc.body))
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, env.SystemText())
+		})
+	}
+}
+
+func TestRequestEnvelope_LastUserMessage_Anthropic(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+		want translate.LastUserMessageInfo
+	}{
+		{
+			name: "string content",
+			body: `{"messages":[{"role":"user","content":"hello"}]}`,
+			want: translate.LastUserMessageInfo{HasText: true, Text: "hello"},
+		},
+		{
+			name: "tool_result only",
+			body: `{"messages":[
+				{"role":"user","content":[{"type":"tool_result","tool_use_id":"t1","content":"out"}]}
+			]}`,
+			want: translate.LastUserMessageInfo{HasToolResult: true, ToolResultCount: 1},
+		},
+		{
+			name: "mixed text + tool_result",
+			body: `{"messages":[
+				{"role":"user","content":[
+					{"type":"tool_result","tool_use_id":"t1","content":"out"},
+					{"type":"text","text":"more please"}
+				]}
+			]}`,
+			want: translate.LastUserMessageInfo{
+				HasText: true, Text: "more please", HasToolResult: true, ToolResultCount: 1,
+			},
+		},
+		{
+			name: "two tool_results",
+			body: `{"messages":[
+				{"role":"user","content":[
+					{"type":"tool_result","tool_use_id":"t1","content":"a"},
+					{"type":"tool_result","tool_use_id":"t2","content":"b"}
+				]}
+			]}`,
+			want: translate.LastUserMessageInfo{HasToolResult: true, ToolResultCount: 2},
+		},
+		{
+			name: "no user message",
+			body: `{"messages":[{"role":"assistant","content":"hi"}]}`,
+			want: translate.LastUserMessageInfo{},
+		},
+		{
+			name: "earlier user with assistant after",
+			body: `{"messages":[
+				{"role":"user","content":"first"},
+				{"role":"assistant","content":"reply"}
+			]}`,
+			want: translate.LastUserMessageInfo{HasText: true, Text: "first"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			env, err := translate.ParseAnthropic([]byte(tc.body))
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, env.LastUserMessage())
+		})
+	}
+}
+
+func TestRequestEnvelope_LastUserMessage_OpenAI(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+		want translate.LastUserMessageInfo
+	}{
+		{
+			name: "trailing user message",
+			body: `{"messages":[{"role":"user","content":"hello"}]}`,
+			want: translate.LastUserMessageInfo{HasText: true, Text: "hello"},
+		},
+		{
+			name: "trailing tool message",
+			body: `{"messages":[
+				{"role":"user","content":"go"},
+				{"role":"assistant","content":null,"tool_calls":[{"id":"t1","type":"function","function":{"name":"Bash","arguments":"{}"}}]},
+				{"role":"tool","tool_call_id":"t1","content":"out"}
+			]}`,
+			want: translate.LastUserMessageInfo{HasToolResult: true, ToolResultCount: 1},
+		},
+		{
+			name: "two trailing tool messages",
+			body: `{"messages":[
+				{"role":"assistant","content":null,"tool_calls":[{"id":"t1","type":"function","function":{"name":"Bash","arguments":"{}"}}]},
+				{"role":"tool","tool_call_id":"t1","content":"a"},
+				{"role":"tool","tool_call_id":"t2","content":"b"}
+			]}`,
+			want: translate.LastUserMessageInfo{HasToolResult: true, ToolResultCount: 2},
+		},
+		{
+			name: "tool then user",
+			body: `{"messages":[
+				{"role":"tool","tool_call_id":"t1","content":"a"},
+				{"role":"user","content":"continue"}
+			]}`,
+			want: translate.LastUserMessageInfo{HasText: true, Text: "continue"},
+		},
+		{
+			name: "trailing assistant",
+			body: `{"messages":[
+				{"role":"user","content":"hi"},
+				{"role":"assistant","content":"hello"}
+			]}`,
+			want: translate.LastUserMessageInfo{},
+		},
+		{
+			name: "empty messages",
+			body: `{"messages":[]}`,
+			want: translate.LastUserMessageInfo{},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			env, err := translate.ParseOpenAI([]byte(tc.body))
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, env.LastUserMessage())
+		})
+	}
+}
+
+func TestRequestEnvelope_RoutingFeatures_OpenAI_LastKind(t *testing.T) {
+	cases := []struct {
+		name        string
+		body        string
+		wantKind    string
+		wantPreview string
+	}{
+		{
+			name:        "user role",
+			body:        `{"messages":[{"role":"user","content":"hi there"}]}`,
+			wantKind:    "user_prompt",
+			wantPreview: "hi there",
+		},
+		{
+			name:     "tool role",
+			body:     `{"messages":[{"role":"user","content":"go"},{"role":"tool","tool_call_id":"t1","content":"output"}]}`,
+			wantKind: "tool_result",
+		},
+		{
+			name:     "assistant role",
+			body:     `{"messages":[{"role":"user","content":"hi"},{"role":"assistant","content":"hello"}]}`,
+			wantKind: "assistant",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			env, err := translate.ParseOpenAI([]byte(tc.body))
+			require.NoError(t, err)
+			feats := env.RoutingFeatures(false)
+			assert.Equal(t, tc.wantKind, feats.LastKind)
+			if tc.wantPreview != "" {
+				assert.Equal(t, tc.wantPreview, feats.LastPreview)
+			}
+		})
+	}
+}

--- a/internal/translate/features.go
+++ b/internal/translate/features.go
@@ -83,21 +83,176 @@ func (e *RequestEnvelope) openAIRoutingFeatures() RoutingFeatures {
 	msgs := gjson.GetBytes(e.body, "messages")
 
 	var b strings.Builder
-	msgCount := 0
+	var (
+		msgCount int
+		lastMsg  gjson.Result
+	)
 	msgs.ForEach(func(_, msg gjson.Result) bool {
 		msgCount++
 		appendText(&b, openAIContentTextGJSON(msg.Get("content")))
+		lastMsg = msg
 		return true
 	})
 	text := b.String()
 
-	return RoutingFeatures{
+	feats := RoutingFeatures{
 		Tokens:       len(text) / 4,
 		Model:        e.Model(),
 		HasTools:     e.HasTools(),
 		PromptText:   text,
 		MessageCount: msgCount,
 	}
+
+	if msgCount > 0 {
+		feats.LastKind = classifyLastMessageOpenAI(lastMsg.Get("role").String())
+		feats.LastPreview = previewText(openAIContentTextGJSON(lastMsg.Get("content")))
+	}
+
+	return feats
+}
+
+// classifyLastMessageOpenAI maps an OpenAI message role onto the
+// shared three-value LastKind enum. OpenAI uses dedicated `tool` and
+// `assistant` roles, so unlike Anthropic there is no need to inspect
+// content blocks.
+func classifyLastMessageOpenAI(role string) string {
+	switch role {
+	case "assistant":
+		return "assistant"
+	case "tool":
+		return "tool_result"
+	default:
+		return "user_prompt"
+	}
+}
+
+// previewText returns the first previewMaxChars of text with newlines
+// collapsed to single spaces. Shared by Anthropic and OpenAI feature
+// extraction so LastPreview has identical semantics across formats.
+func previewText(text string) string {
+	if text == "" {
+		return ""
+	}
+	text = strings.Join(strings.Fields(text), " ")
+	runes := []rune(text)
+	if len(runes) <= previewMaxChars {
+		return text
+	}
+	return string(runes[:previewMaxChars]) + "…"
+}
+
+// anthropicLastUserMessage walks messages backwards for the last role
+// "user" entry and reports whether it contains text and/or tool_result
+// blocks. The bare-string content shape counts as text.
+func anthropicLastUserMessage(body []byte) LastUserMessageInfo {
+	msgs := gjson.GetBytes(body, "messages")
+	if !msgs.IsArray() {
+		return LastUserMessageInfo{}
+	}
+	var lastUser gjson.Result
+	msgs.ForEach(func(_, msg gjson.Result) bool {
+		if msg.Get("role").String() == "user" {
+			lastUser = msg
+		}
+		return true
+	})
+	if !lastUser.Exists() {
+		return LastUserMessageInfo{}
+	}
+	content := lastUser.Get("content")
+	if content.Type == gjson.String {
+		s := content.String()
+		return LastUserMessageInfo{HasText: s != "", Text: s}
+	}
+	if !content.IsArray() {
+		return LastUserMessageInfo{}
+	}
+	info := LastUserMessageInfo{}
+	var b strings.Builder
+	content.ForEach(func(_, block gjson.Result) bool {
+		switch block.Get("type").String() {
+		case "tool_result":
+			info.HasToolResult = true
+			info.ToolResultCount++
+		case "text":
+			text := block.Get("text").String()
+			if text == "" {
+				return true
+			}
+			info.HasText = true
+			if b.Len() > 0 {
+				b.WriteByte('\n')
+			}
+			b.WriteString(text)
+		}
+		return true
+	})
+	if info.HasText {
+		info.Text = b.String()
+	}
+	return info
+}
+
+// openAILastUserMessage scans the trailing run of role=="tool"
+// messages and the most recent role=="user" message. OpenAI splits
+// tool returns into separate messages, so a tool-result-only turn is
+// one or more trailing role=="tool" messages with no role=="user"
+// after them.
+func openAILastUserMessage(body []byte) LastUserMessageInfo {
+	msgs := gjson.GetBytes(body, "messages")
+	if !msgs.IsArray() {
+		return LastUserMessageInfo{}
+	}
+	all := msgs.Array()
+	if len(all) == 0 {
+		return LastUserMessageInfo{}
+	}
+	info := LastUserMessageInfo{}
+	for i := len(all) - 1; i >= 0; i-- {
+		role := all[i].Get("role").String()
+		switch role {
+		case "tool":
+			info.HasToolResult = true
+			info.ToolResultCount++
+			continue
+		case "user":
+			text := openAIContentTextGJSON(all[i].Get("content"))
+			if text != "" {
+				info.HasText = true
+				info.Text = text
+			}
+		}
+		// Stop at the first non-tool message regardless of role.
+		break
+	}
+	return info
+}
+
+// openAISystemText concatenates every role=="system" message's text
+// content. OpenAI carries the system prompt inline rather than in a
+// separate field, and may have multiple system messages (e.g. one
+// from the framework, one from the developer).
+func openAISystemText(body []byte) string {
+	msgs := gjson.GetBytes(body, "messages")
+	if !msgs.IsArray() {
+		return ""
+	}
+	var b strings.Builder
+	msgs.ForEach(func(_, msg gjson.Result) bool {
+		if msg.Get("role").String() != "system" {
+			return true
+		}
+		text := openAIContentTextGJSON(msg.Get("content"))
+		if text == "" {
+			return true
+		}
+		if b.Len() > 0 {
+			b.WriteByte('\n')
+		}
+		b.WriteString(text)
+		return true
+	})
+	return b.String()
 }
 
 // --- gjson-based content text helpers (zero allocation from e.body) ---
@@ -162,16 +317,7 @@ func classifyLastMessageGJSON(role string, content gjson.Result) string {
 }
 
 func previewGJSON(content gjson.Result) string {
-	text := contentTextGJSON(content)
-	if text == "" {
-		return ""
-	}
-	text = strings.Join(strings.Fields(text), " ")
-	runes := []rune(text)
-	if len(runes) <= previewMaxChars {
-		return text
-	}
-	return string(runes[:previewMaxChars]) + "…"
+	return previewText(contentTextGJSON(content))
 }
 
 func userPromptTextGJSON(content gjson.Result) string {


### PR DESCRIPTION
**Stacked on #35.** Review #35 first; this PR's diff is meaningful only after the envelope refactor lands.

## Summary

Steps 3-4 of unifying session-aware routing (see [AGENTIC_CODING.md](docs/plans/AGENTIC_CODING.md)). Extracts the Stage-1 orchestration out of \`ProxyMessages\` into a single helper and wires the OpenAI handler through it.

## Why this is the SWE-Bench unblock

\`ProxyOpenAIChatCompletion\` was calling \`s.router.Route()\` directly. No session-pin lookup, no hard-pins, no tool-result short-circuit. Every turn of an OpenAI-format conversation (e.g. mini-swe-agent over litellm) re-ran the cluster scorer cold and could flip models mid-session, invalidating the prompt cache and breaking \`thought_signature\` continuity for Gemini-routed sessions.

After this PR, both Anthropic and OpenAI ingresses call \`routeWithSession\`. The cluster scorer runs once per session, not once per turn.

## Changes

- New \`internal/proxy/session_route.go\` containing \`(*Service).routeWithSession\` and the \`installationIDFromContext\` helper.
- \`ProxyMessages\` collapses ~150 lines of inline orchestration into one call.
- \`ProxyOpenAIChatCompletion\` now reads \`apiKeyID\` and \`installationID\` from context, reads \`x-weave-subagent-type\` from headers, and routes through the helper.
- OpenAI handler's OTel decision span gains the same \`routing.sticky_hit\` / \`routing.session_pin_tier\` / \`routing.session_pin_age_s\` / \`routing.turn_type\` attributes the Anthropic span has, so dashboards work.
- Async pin upsert uses \`context.Background()\` per the deferred-write rule.

## Provider dispatch unchanged

The provider switch in each handler (Anthropic / OpenAI / Google / OpenRouter) is untouched. \`routeWithSession\` returns a \`router.Decision\`; cross-format emit still happens in the existing \`PrepareAnthropic\` / \`PrepareOpenAI\` / \`PrepareGemini\` paths.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go vet ./...\` clean
- [x] All existing tests still pass (Anthropic coverage unchanged)
- [x] New OpenAI-ingress tests:
  - Postgres pin hit short-circuits the cluster scorer
  - Fresh route writes a pin with the OpenAI provider/model
  - Tool-result turn (\`role==\"tool\"\`) with an existing pin short-circuits
  - System-message compaction marker triggers hard-pin
  - \`x-weave-subagent-type\` header triggers Explore hard-pin
- [ ] Manual curl + staging SWE-Bench 5-instance smoke (deferred to PR 4 — that's where we'll verify \`session_pins\` row count ≈ 5, not 5 × 30)

🤖 Generated with [Claude Code](https://claude.com/claude-code)