### PR TITLE
fix(main): default ROUTER_SESSION_PIN_ENABLED to true

### DIFF
--- a/cmd/router/main.go
+++ b/cmd/router/main.go
@@ -188,8 +188,18 @@ func main() {
 
 	semanticCache := buildSemanticCache(rtr)
 
+	// Default-on: the cluster scorer's α-blend is baked at training time on
+	// per-prompt cost numbers that don't account for prompt-cache continuity.
+	// Without session pinning, mid-conversation provider switches discard the
+	// cache prefix (Anthropic's cache is keyed per-model) and pay the cache-
+	// write penalty on the new model — over a 30-turn agentic trajectory that
+	// dominates routing-decision savings. Until cost models reflect cache-warm
+	// economics, leaving pinning off makes the router optimize a number that
+	// doesn't match production.
+	//
+	// Set ROUTER_SESSION_PIN_ENABLED=false to opt out (kill switch).
 	var pinStore sessionpin.Store
-	if config.GetOr("ROUTER_SESSION_PIN_ENABLED", "false") == "true" {
+	if config.GetOr("ROUTER_SESSION_PIN_ENABLED", "true") == "true" {
 		pinStore = postgres.NewSessionPinRepo(pool)
 		go runSessionPinSweep(context.Background(), pinStore)
 		logger.Info("Session pin store enabled (sliding 1h TTL, hourly sweep)")


### PR DESCRIPTION
## Summary

Flip the default for `ROUTER_SESSION_PIN_ENABLED` from `"false"` to `"true"` in `cmd/router/main.go`. Kill switch via the env var is preserved.

## Why

The cluster scorer's α-blend is baked at training time on per-prompt cost values that don't model prompt-cache continuity. Without session pinning, the scorer freely switches providers mid-conversation. Each switch:

- Discards the warm cache prefix on the old model (Anthropic's cache is keyed per-model)
- Pays the 1.25× cache-write penalty on the new model

Over a 30-turn agentic trajectory that dominates whatever per-prompt savings the router claims it's getting. Until cost models reflect cache-warm economics, leaving pinning off makes the router optimize a number that doesn't match production.

## Empirical evidence

5-instance SWE-bench agentic smoke against current staging (which has `ROUTER_SESSION_PIN_ENABLED` unset, so `pinStore` is `nil` per `main.go:191`). One representative trajectory:

```
exit: LimitsExceeded   (mini-swe-agent step cap, no API errors)
msgs: 56
models: {'deepseek/deepseek-v4-pro-20260423': 5, 'qwen/qwen3.5-flash-20260224': 18}
```

Single conversation, 23 assistant turns, two different upstream models. That's exactly the thrash pattern session pinning exists to prevent — and exactly what made multi-turn tool use against Gemini-3.x impossible before PR #32 / #33.

## Risk

Small. The pin store's `Get` already fails open to the cluster scorer on Postgres errors (per D5), so a database hiccup degrades to today's behavior rather than blocking. The in-proc 30s LRU absorbs the steady state, so PG load stays bounded (a 50-turn session hits PG ~5–10 times). If anything regresses, set `ROUTER_SESSION_PIN_ENABLED=false`.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .` clean
- [ ] Bump WorkWeave gitlink, redeploy staging, re-run `eval/run_swebench_agentic --workers 2 --limit 5`. Expect each trajectory pinned to one provider/model from turn 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)