### PR TITLE
feat(auth): one active key per installation (W-1299)

### DIFF
--- a/cmd/seed/main.go
+++ b/cmd/seed/main.go
@@ -84,6 +84,20 @@ func main() {
 		os.Exit(1)
 	}
 
+	// One active key per installation (migration 0007). Soft-delete any
+	// existing key so re-running `make seed` rotates the local-dev token
+	// instead of erroring on the partial unique index.
+	if _, err := tx.Exec(ctx, `
+		UPDATE model_router_api_keys
+		SET deleted_at = CURRENT_TIMESTAMP
+		WHERE installation_id = @installation_id::uuid
+		  AND deleted_at IS NULL`,
+		pgx.NamedArgs{"installation_id": installationID},
+	); err != nil {
+		fmt.Fprintf(os.Stderr, "error: cannot soft-delete existing api keys: %v\n", err)
+		os.Exit(1)
+	}
+
 	var apiKeyID string
 	err = tx.QueryRow(ctx, `
 		INSERT INTO model_router_api_keys

--- a/db/migrations/0007_single_active_key_per_installation.down.sql
+++ b/db/migrations/0007_single_active_key_per_installation.down.sql
@@ -1,0 +1,9 @@
+BEGIN;
+
+DROP INDEX router.model_router_api_keys_installation_active_unique;
+
+-- The dedupe in the up migration is irreversible: we can't tell which
+-- keys were "really" duplicates vs. legitimate per-user keys. Customers
+-- who relied on the multi-key pattern must reissue keys after a rollback.
+
+COMMIT;

--- a/db/migrations/0007_single_active_key_per_installation.up.sql
+++ b/db/migrations/0007_single_active_key_per_installation.up.sql
@@ -1,0 +1,31 @@
+BEGIN;
+
+-- Closes the per-user-API-key pattern: keys are now an installation-scoped
+-- secret; identity moves into router.model_router_users (migration 0006).
+--
+-- For any installation that holds more than one active key, keep the
+-- most-recently-used row (or the most recently created if no key has
+-- ever been used) and soft-delete the rest. The newest key wins on the
+-- assumption that customers rotate forward when they want a new key.
+WITH ranked AS (
+  SELECT
+    id,
+    ROW_NUMBER() OVER (
+      PARTITION BY installation_id
+      ORDER BY COALESCE(last_used_at, created_at) DESC, created_at DESC, id DESC
+    ) AS rn
+  FROM router.model_router_api_keys
+  WHERE deleted_at IS NULL
+)
+UPDATE router.model_router_api_keys
+SET deleted_at = CURRENT_TIMESTAMP
+WHERE id IN (SELECT id FROM ranked WHERE rn > 1);
+
+CREATE UNIQUE INDEX model_router_api_keys_installation_active_unique
+  ON router.model_router_api_keys(installation_id)
+  WHERE deleted_at IS NULL;
+
+COMMENT ON INDEX router.model_router_api_keys_installation_active_unique IS
+  'One active key per installation. Identity is carried by router.model_router_users; a key is an installation-scoped secret, not a per-user credential.';
+
+COMMIT;

--- a/internal/auth/errors.go
+++ b/internal/auth/errors.go
@@ -8,4 +8,10 @@ import "errors"
 var (
 	ErrInvalidPrefix = errors.New("invalid bearer key prefix")
 	ErrInvalidToken  = errors.New("invalid bearer key")
+
+	// ErrActiveKeyExists is returned by APIKeyRepository.Create when the
+	// installation already has an active (non-soft-deleted) key. Callers
+	// should rotate (soft-delete the old key, then create a new one) rather
+	// than create a second.
+	ErrActiveKeyExists = errors.New("installation already has an active api key")
 )

--- a/internal/postgres/repository.go
+++ b/internal/postgres/repository.go
@@ -4,12 +4,22 @@ package postgres
 
 import (
 	"context"
+	"errors"
 
 	"workweave/router/internal/auth"
 	"workweave/router/internal/sqlc"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgconn"
 )
+
+// activeKeyUniqueIndex matches the partial unique index added in
+// migration 0007 (one active key per installation).
+const activeKeyUniqueIndex = "model_router_api_keys_installation_active_unique"
+
+// uniqueViolation is the SQLSTATE 23505 returned by Postgres when a
+// unique constraint or partial unique index is violated.
+const uniqueViolation = "23505"
 
 // Repository aggregates all auth repositories backed by the same DBTX.
 type Repository struct {
@@ -108,6 +118,10 @@ func (r *apiKeyRepo) Create(ctx context.Context, params auth.CreateAPIKeyParams)
 		CreatedBy:      params.CreatedBy,
 	})
 	if err != nil {
+		var pgErr *pgconn.PgError
+		if errors.As(err, &pgErr) && pgErr.Code == uniqueViolation && pgErr.ConstraintName == activeKeyUniqueIndex {
+			return nil, auth.ErrActiveKeyExists
+		}
 		return nil, err
 	}
 	return toAuthAPIKey(row), nil


### PR DESCRIPTION
**Stacks on #41 → #40.** Phase 2 of the per-user-API-key collapse plan.

## Summary

- Migration 0007 deduplicates any installation with multiple active keys (keeps the most-recently-used row, soft-deletes the rest), then adds a partial unique index \`(installation_id) WHERE deleted_at IS NULL\`.
- New \`auth.ErrActiveKeyExists\` sentinel returned by \`apiKeyRepo.Create\` on SQLSTATE 23505 against the new index, so the Weave backend (next PR) can surface a friendly error before customers see a 500.
- \`make seed\` now soft-deletes the prior key in the same tx as inserting the new one — \"seed = rotate\" semantics.

The \"one key per installation\" invariant is now enforced at the database level. Identity moves entirely to \`router.model_router_users\` (#40).

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go test ./...\` green
- [ ] Local: \`make migrate-up\`, then verify \`SELECT installation_id, COUNT(*) FROM router.model_router_api_keys WHERE deleted_at IS NULL GROUP BY 1 HAVING COUNT(*) > 1;\` returns no rows.
- [ ] \`make seed && make seed\` succeeds twice in a row (proving rotate semantics).

## Production check

Before deploying, run against prod via \`mcp__db-tools\`:
\`\`\`sql
SELECT installation_id, COUNT(*) AS active_keys
FROM router.model_router_api_keys
WHERE deleted_at IS NULL
GROUP BY 1
HAVING COUNT(*) > 1;
\`\`\`
The dedupe is irreversible; if any installation owns multiple keys, notify those customers before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)