### PR TITLE
feat(otel): emit cluster IDs on router.decision span

### DIFF
--- a/internal/observability/otel/spans.go
+++ b/internal/observability/otel/spans.go
@@ -81,6 +81,22 @@ func (b *AttrBuilder) Bool(key string, val bool) *AttrBuilder {
 	return b
 }
 
+// IntSlice appends an int slice as an OTLP array of int64 values.
+// A nil or empty slice still emits the attribute with an empty array, so
+// downstream consumers can distinguish "field present, no clusters" from
+// "field absent" (e.g. pinned-route turns where Metadata is nil).
+func (b *AttrBuilder) IntSlice(key string, vals []int) *AttrBuilder {
+	values := make([]*commonv1.AnyValue, len(vals))
+	for i, v := range vals {
+		values[i] = &commonv1.AnyValue{Value: &commonv1.AnyValue_IntValue{IntValue: int64(v)}}
+	}
+	b.attrs = append(b.attrs, &commonv1.KeyValue{
+		Key:   key,
+		Value: &commonv1.AnyValue{Value: &commonv1.AnyValue_ArrayValue{ArrayValue: &commonv1.ArrayValue{Values: values}}},
+	})
+	return b
+}
+
 // Build returns the accumulated KeyValue slice. The slice is valid until
 // the next method call on the builder.
 func (b *AttrBuilder) Build() []*commonv1.KeyValue {

--- a/internal/observability/otel/spans_test.go
+++ b/internal/observability/otel/spans_test.go
@@ -84,3 +84,35 @@ func TestAttrBuilder_TypedValuesMatchProtobuf(t *testing.T) {
 	assert.False(t, boolVal.GetBoolValue())
 	assert.IsType(t, &commonv1.AnyValue_BoolValue{}, boolVal.Value)
 }
+
+func TestAttrBuilder_IntSliceEmitsArrayOfInts(t *testing.T) {
+	attrs := otel.NewAttrBuilder(1).
+		IntSlice("routing.cluster_ids", []int{7, 0, 42}).
+		Build()
+
+	assert.Len(t, attrs, 1)
+	assert.Equal(t, "routing.cluster_ids", attrs[0].Key)
+	assert.IsType(t, &commonv1.AnyValue_ArrayValue{}, attrs[0].Value.Value)
+
+	arr := attrs[0].Value.GetArrayValue()
+	assert.NotNil(t, arr)
+	assert.Len(t, arr.Values, 3)
+	assert.Equal(t, int64(7), arr.Values[0].GetIntValue())
+	assert.Equal(t, int64(0), arr.Values[1].GetIntValue())
+	assert.Equal(t, int64(42), arr.Values[2].GetIntValue())
+	for _, v := range arr.Values {
+		assert.IsType(t, &commonv1.AnyValue_IntValue{}, v.Value)
+	}
+}
+
+func TestAttrBuilder_IntSliceNilEmitsEmptyArray(t *testing.T) {
+	attrs := otel.NewAttrBuilder(1).
+		IntSlice("routing.cluster_ids", nil).
+		Build()
+
+	assert.Len(t, attrs, 1)
+	assert.Equal(t, "routing.cluster_ids", attrs[0].Key)
+	arr := attrs[0].Value.GetArrayValue()
+	assert.NotNil(t, arr)
+	assert.Len(t, arr.Values, 0)
+}

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -368,7 +368,7 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 		Name:  "router.decision",
 		Start: requestStart,
 		End:   time.Now(),
-		Attrs: otel.NewAttrBuilder(24).
+		Attrs: otel.NewAttrBuilder(25).
 			String("request_id", requestID).
 			String("external_id", externalID).
 			String("client.device_id", clientID.DeviceID).
@@ -387,6 +387,7 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 			String("routing.turn_type", string(tt)).
 			String("routing.embed_input", embedInput).
 			Int64("routing.estimated_input_tokens", int64(feats.Tokens)).
+			IntSlice("routing.cluster_ids", clusterIDsFromDecision(decision)).
 			Float64("pricing.requested_input_per_1m", reqPricing.InputUSDPer1M).
 			Float64("pricing.requested_output_per_1m", reqPricing.OutputUSDPer1M).
 			Float64("pricing.actual_input_per_1m", actPricing.InputUSDPer1M).
@@ -559,6 +560,16 @@ func pinDecision(p sessionpin.Pin) router.Decision {
 		Model:    p.Model,
 		Reason:   p.Reason,
 	}
+}
+
+// clusterIDsFromDecision returns the cluster ids stamped on a routing
+// decision, or nil for decisions without metadata (pinned-route turns,
+// heuristic fallback).
+func clusterIDsFromDecision(d router.Decision) []int {
+	if d.Metadata == nil {
+		return nil
+	}
+	return d.Metadata.ClusterIDs
 }
 
 // pinAge returns seconds since first_pinned_at; zero if the timestamp
@@ -757,7 +768,7 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 		Name:  "router.decision",
 		Start: requestStart,
 		End:   time.Now(),
-		Attrs: otel.NewAttrBuilder(22).
+		Attrs: otel.NewAttrBuilder(23).
 			String("request_id", requestID).
 			String("external_id", externalID).
 			String("client.device_id", clientID.DeviceID).
@@ -775,6 +786,7 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 			Int64("routing.session_pin_age_s", pinAgeSec).
 			String("routing.turn_type", string(tt)).
 			Int64("routing.estimated_input_tokens", int64(feats.Tokens)).
+			IntSlice("routing.cluster_ids", clusterIDsFromDecision(decision)).
 			Float64("pricing.requested_input_per_1m", reqPricing.InputUSDPer1M).
 			Float64("pricing.requested_output_per_1m", reqPricing.OutputUSDPer1M).
 			Float64("pricing.actual_input_per_1m", actPricing.InputUSDPer1M).


### PR DESCRIPTION
## Summary
- Adds `AttrBuilder.IntSlice` so OTLP attributes can carry int arrays
- Emits `routing.cluster_ids` on both Anthropic and OpenAI `router.decision` spans, sourced from `decision.Metadata.ClusterIDs`
- Nil-safe: pinned-route turns and any future router without `Metadata` emit an empty array (field present, no clusters)

Refs [W-1307](https://linear.app/workweave/issue/W-1307/add-clusterids-as-otel-routing-decision-span-attributes).

## Test plan
- [x] `go test ./internal/observability/otel/ ./internal/proxy/`
- [x] `go build ./...`
- [ ] After merge + gitlink bump, confirm OTLP export in staging contains `routing.cluster_ids` on cluster-routed turns

🤖 Generated with [Claude Code](https://claude.com/claude-code)