### PR TITLE
feat(byok): allow openrouter as external api key provider

### DIFF
--- a/db/migrations/0008_add_openrouter_to_external_api_keys.down.sql
+++ b/db/migrations/0008_add_openrouter_to_external_api_keys.down.sql
@@ -1,0 +1,10 @@
+BEGIN;
+
+ALTER TABLE router.model_router_external_api_keys
+  DROP CONSTRAINT model_router_external_api_keys_provider_check;
+
+ALTER TABLE router.model_router_external_api_keys
+  ADD CONSTRAINT model_router_external_api_keys_provider_check
+  CHECK (provider IN ('anthropic','openai','google'));
+
+COMMIT;

--- a/db/migrations/0008_add_openrouter_to_external_api_keys.up.sql
+++ b/db/migrations/0008_add_openrouter_to_external_api_keys.up.sql
@@ -1,0 +1,10 @@
+BEGIN;
+
+ALTER TABLE router.model_router_external_api_keys
+  DROP CONSTRAINT model_router_external_api_keys_provider_check;
+
+ALTER TABLE router.model_router_external_api_keys
+  ADD CONSTRAINT model_router_external_api_keys_provider_check
+  CHECK (provider IN ('anthropic','openai','google','openrouter'));
+
+COMMIT;


### PR DESCRIPTION
## Summary
- Relax the `model_router_external_api_keys.provider` CHECK constraint to allow `'openrouter'` alongside `anthropic`, `openai`, and `google`.
- Unblocks per-customer BYOK for OpenRouter on the WorkWeave side (provider client + env-var registration are already wired in `cmd/router/main.go`).

## Test plan
- [ ] `wv db run-migrations -r` applies cleanly
- [ ] Down migration rolls back cleanly
- [ ] Existing BYOK rows for anthropic/openai/google still satisfy the new constraint

🤖 Generated with [Claude Code](https://claude.com/claude-code)