### PR TITLE
feat(install): add --dir flag, interactive scope prompt, and uninstall --dir support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,11 +60,17 @@ full-setup: generate-statusline ## Bootstrap router: docker compose + seed + opt
 	##   make full-setup                                  # boot compose, seed, print instructions
 	##   make full-setup PLATFORM=cc                      # boot + seed + auto-wire Claude Code
 	##   make full-setup PLATFORM=cc KEY=rk_... BASE_URL=http://...  # wire existing router to Claude Code
+	##   make full-setup PLATFORM=cc KEY=rk_... BASE_URL=http://... DIR=/tmp/test  # isolated throwaway install
+	##   make full-setup PLATFORM=cc KEY=rk_... BASE_URL=http://... SCOPE=project NON_INTERACTIVE=1  # CI-friendly
 	##   make full-setup KEY=rk_... BASE_URL=http://...  # print instructions for existing router
 	@if [ -n "$(KEY)" ] && [ -n "$(BASE_URL)" ]; then \
 		if [ "$(PLATFORM)" = "cc" ]; then \
-			echo "==> Wiring Claude Code → $(BASE_URL) with provided key..."; \
-			WEAVE_ROUTER_KEY="$(KEY)" ./install/install.sh --base-url "$(BASE_URL)"; \
+			INSTALL_CMD='WEAVE_ROUTER_KEY="$(KEY)" ./install/install.sh --base-url "$(BASE_URL)"'; \
+			[ -n "$(SCOPE)" ] && INSTALL_CMD="$$INSTALL_CMD --scope $(SCOPE)"; \
+			[ -n "$(DIR)" ] && INSTALL_CMD="$$INSTALL_CMD --dir $(DIR)"; \
+			[ "$(NON_INTERACTIVE)" = "1" ] && INSTALL_CMD="$$INSTALL_CMD --non-interactive"; \
+			echo "==> Wiring Claude Code → $(BASE_URL)..."; \
+			eval "$$INSTALL_CMD"; \
 		else \
 			echo "Weave Router key:"; \
 			echo "  $(KEY)"; \

--- a/install/README.md
+++ b/install/README.md
@@ -19,11 +19,17 @@ curl -fsSL https://weave.ai/cc/install.sh | sh -s -- --scope project
 Or from a clone of this repo:
 
 ```bash
-./router/install/install.sh                  # user scope (default)
-./router/install/install.sh --scope project  # project scope
+./router/install/install.sh                  # prompts: user or project
+./router/install/install.sh --scope user     # skip prompt — user scope
+./router/install/install.sh --scope project  # skip prompt — project scope
 ```
 
-The installer prompts for your API key (or reads `$WEAVE_ROUTER_KEY` for
+When run interactively without `--scope`, the installer asks whether to install
+at **user** scope (everywhere) or **project** scope (this repo only) and
+defaults to `user` on Enter. Pass `--scope` explicitly (or `--non-interactive`)
+to skip the prompt — useful for CI and `curl | sh` pipelines.
+
+The installer also prompts for your API key (or reads `$WEAVE_ROUTER_KEY` for
 non-interactive installs).
 
 ### Self-hosted via `docker compose` (zero-config)
@@ -100,7 +106,7 @@ The `install.sh --scope project` step only needs to run once per checkout
 
 | Flag                       | Default                       | Meaning                                                                |
 | -------------------------- | ----------------------------- | ---------------------------------------------------------------------- |
-| `--scope user\|project`    | `user`                        | User-level install (everywhere) vs project-level (this repo only).      |
+| `--scope user\|project`    | interactive prompt (default `user`) | User-level install (everywhere) vs project-level (this repo only). If omitted on a TTY, the installer asks; defaults to `user` non-interactively. |
 | `--local`                  | off                           | Shortcut for the bundled docker-compose router (`localhost:8082`, dev mode). |
 | `--base-url <url>`         | `https://router.weave.ai`     | Override the router endpoint. Use for self-hosted / custom port.        |
 | `--dev-mode`               | off                           | Router has `ROUTER_DEV_MODE=true`; skip the API key prompt entirely.    |

--- a/install/install.sh
+++ b/install/install.sh
@@ -11,9 +11,13 @@
 #   - user (default):  ~/.claude/settings.json  + ~/.weave/cc-statusline.sh
 #   - project:         <repo>/.claude/settings.json + <repo>/.claude/cc-statusline.sh
 #
+# Or pass --dir to install into any directory:
+#   - dir:              <dir>/.claude/settings.json + <dir>/.claude/cc-statusline.sh
+#
 # Usage:
 #   ./install.sh                                  # hosted router, user scope
 #   ./install.sh --scope project                  # commit-with-team install
+#   ./install.sh --dir /tmp/my-sandbox            # isolated throwaway install
 #   ./install.sh --local                          # docker-compose router on localhost:8082, dev-mode
 #   ./install.sh --base-url http://localhost:8082 # self-hosted, custom port / non-dev-mode
 #   ./install.sh --non-interactive                # require WEAVE_ROUTER_KEY env var
@@ -33,6 +37,8 @@ DEFAULT_BASE_URL="${WEAVE_ROUTER_URL:-https://router.weave.ai}"
 STATUSLINE_RAW_URL="${WEAVE_STATUSLINE_RAW_URL:-https://raw.githubusercontent.com/weave-ai/workweave/main/router/install/cc-statusline.sh}"
 
 scope="user"
+scope_explicit="false"
+install_dir=""
 base_url=""
 non_interactive="false"
 dev_mode="false"
@@ -81,6 +87,7 @@ while [ $# -gt 0 ]; do
     --scope)
       scope="${2:-}"; shift 2
       [ "$scope" = "user" ] || [ "$scope" = "project" ] || { err "--scope must be 'user' or 'project'"; exit 2; }
+      scope_explicit="true"
       ;;
     --base-url)
       base_url="${2:-}"; shift 2
@@ -99,6 +106,10 @@ while [ $# -gt 0 ]; do
     --non-interactive)
       non_interactive="true"; shift
       ;;
+    --dir)
+      install_dir="${2:-}"; shift 2
+      [ -n "$install_dir" ] || { err "--dir requires a path"; exit 2; }
+      ;;
     -h|--help)
       usage 0
       ;;
@@ -114,6 +125,24 @@ fi
 # trim trailing slash for cleanliness
 base_url="${base_url%/}"
 
+# ---------- interactive scope prompt ----------
+
+# If the user didn't pass --scope and we have a controlling terminal, ask which
+# scope to install into. Non-interactive runs (CI, `curl | sh --non-interactive`)
+# silently use the "user" default.
+if [ -z "$install_dir" ] && [ "$scope_explicit" = "false" ] && [ "$non_interactive" = "false" ] && [ -r /dev/tty ]; then
+  printf "Install scope:\n"
+  printf "  1) user     — write to ~/.claude/ (applies everywhere you run claude)\n"
+  printf "  2) project  — write to <repo>/.claude/ (applies only inside this repo)\n"
+  printf "Choose [1/2] (default 1): "
+  read -r scope_choice </dev/tty || scope_choice=""
+  case "${scope_choice:-1}" in
+    1|""|user|u|U)    scope="user" ;;
+    2|project|p|P)    scope="project" ;;
+    *) err "invalid choice: $scope_choice"; exit 2 ;;
+  esac
+fi
+
 # ---------- pre-flight ----------
 
 info "Weave Router installer (scope=$scope, base_url=$base_url)"
@@ -126,37 +155,58 @@ if ! command -v claude >/dev/null 2>&1; then
   warn "Continuing — settings.json will be written and will take effect once Claude Code is installed."
 fi
 
-# Resolve target paths based on scope.
 script_dir="$(cd "$(dirname "$0")" 2>/dev/null && pwd || true)"
 local_statusline="$script_dir/cc-statusline.sh"
 
+# Resolve the base directory. User scope always uses $HOME. Project scope uses
+# --dir if given, otherwise the CWD's git root. --dir alone (no --scope) is a
+# throwaway user-style install.
+if [ -n "$install_dir" ]; then
+  install_dir="$(cd "$install_dir" 2>/dev/null && pwd || echo "$install_dir")"
+  settings_base="$install_dir"
+else
+  case "$scope" in
+    user)
+      settings_base="$HOME"
+      ;;
+    project)
+      if ! git_root="$(git rev-parse --show-toplevel 2>/dev/null)"; then
+        err "--scope project must be run inside a git repo, or pass --dir <path>. cd into your project first, or use --dir."
+        exit 1
+      fi
+      settings_base="$git_root"
+      ;;
+  esac
+fi
+
 case "$scope" in
   user)
-    settings_dir="$HOME/.claude"
+    settings_dir="$settings_base/.claude"
     settings_file="$settings_dir/settings.json"
     local_settings_file=""
-    statusline_dir="$HOME/.weave"
+    statusline_dir="${settings_base}/.weave"
     statusline_file="$statusline_dir/cc-statusline.sh"
     statusline_path_for_settings="$statusline_file"
     ;;
   project)
-    if ! git_root="$(git rev-parse --show-toplevel 2>/dev/null)"; then
-      err "--scope project must be run inside a git repo. cd into your project first."
-      exit 1
-    fi
-    settings_dir="$git_root/.claude"
+    settings_dir="$settings_base/.claude"
     settings_file="$settings_dir/settings.json"
     local_settings_file="$settings_dir/settings.local.json"
-    statusline_dir="$git_root/.claude"
+    statusline_dir="$settings_base/.claude"
     statusline_file="$statusline_dir/cc-statusline.sh"
-    # Use a path that's portable across teammates' machines (relative to repo root).
-    statusline_path_for_settings="\${CLAUDE_PROJECT_DIR}/.claude/cc-statusline.sh"
+    # Portable relative path for real repos (teammates can clone anywhere).
+    # Absolute path when --dir overrides (no meaningful $CLAUDE_PROJECT_DIR).
+    if [ -z "$install_dir" ]; then
+      statusline_path_for_settings="\${CLAUDE_PROJECT_DIR}/.claude/cc-statusline.sh"
+    else
+      statusline_path_for_settings="$statusline_file"
+    fi
     ;;
 esac
 
-# Symlink containment: refuse if any target path (or its parent dir for project
-# scope) is a symlink. User-scope paths under $HOME are trusted; project-scope
-# paths come from a git repo that may be hostile, so we check those.
+# Symlink containment: refuse if any target path is a symlink. User-scope paths
+# under $HOME are trusted; project-scope and --dir paths come from a git repo or
+# user-supplied directory that may be hostile, so we check those.
 if [ "$scope" = "project" ]; then
   refuse_if_symlink "$settings_dir"
   refuse_if_symlink "$settings_file"
@@ -218,25 +268,23 @@ ok "Statusline installed at $statusline_file"
 # Build the merge patch. Claude Code keeps its own Anthropic auth in
 # Authorization/x-api-key; the router key rides in ANTHROPIC_CUSTOM_HEADERS.
 # Project scope writes the key to settings.local.json (gitignored).
+# --dir and user scope write the key directly into settings.json.
 tmp_patch="$(mktemp)"
 trap 'rm -f "$tmp_patch"' EXIT
 
-if [ "$scope" = "user" ]; then
-  if [ "$dev_mode" = "true" ]; then
-    jq -n --arg url "$base_url" --arg sl "$statusline_path_for_settings" '{
-      env: { ANTHROPIC_BASE_URL: $url },
-      statusLine: { type: "command", command: $sl }
-    }' >"$tmp_patch"
-  else
-    jq -n --arg url "$base_url" --arg header "$router_key_header: $api_key" --arg sl "$statusline_path_for_settings" '{
-      env: { ANTHROPIC_BASE_URL: $url, ANTHROPIC_CUSTOM_HEADERS: $header },
-      statusLine: { type: "command", command: $sl }
-    }' >"$tmp_patch"
-  fi
-else
-  # project scope
+if [ "$scope" = "project" ]; then
   jq -n --arg url "$base_url" --arg sl "$statusline_path_for_settings" '{
     env: { ANTHROPIC_BASE_URL: $url },
+    statusLine: { type: "command", command: $sl }
+  }' >"$tmp_patch"
+elif [ "$dev_mode" = "true" ]; then
+  jq -n --arg url "$base_url" --arg sl "$statusline_path_for_settings" '{
+    env: { ANTHROPIC_BASE_URL: $url },
+    statusLine: { type: "command", command: $sl }
+  }' >"$tmp_patch"
+else
+  jq -n --arg url "$base_url" --arg header "$router_key_header: $api_key" --arg sl "$statusline_path_for_settings" '{
+    env: { ANTHROPIC_BASE_URL: $url, ANTHROPIC_CUSTOM_HEADERS: $header },
     statusLine: { type: "command", command: $sl }
   }' >"$tmp_patch"
 fi
@@ -281,7 +329,7 @@ fi
 
 # ---------- gitignore for project scope ----------
 
-if [ "$scope" = "project" ]; then
+if [ "$scope" = "project" ] && [ -z "$install_dir" ]; then
   gitignore="$git_root/.gitignore"
   # Same symlink containment as the .claude/ paths above: a hostile repo could
   # commit .gitignore as a symlink so the >> below writes outside the repo.
@@ -325,11 +373,12 @@ fi
 
 printf "\n"
 ok "Weave Router installed for Claude Code."
-case "$scope" in
-  user)
-    echo "  Run 'claude' anywhere — the status line will show the routed model + savings."
-    ;;
-  project)
+if [ "$scope" = "project" ]; then
+  if [ -n "$install_dir" ]; then
+    echo "  Installed into $install_dir/.claude/ (project scope)."
+    echo "  Run 'cd $install_dir && claude' to use the router."
+    echo "  Uninstall with: $script_dir/uninstall.sh --scope project --dir $install_dir"
+  else
     echo "  Commit .claude/settings.json + the .gitignore changes."
     echo "  Local helpers/settings are gitignored — each teammate runs"
     echo "  './router/install/install.sh --scope project' once after cloning."
@@ -337,6 +386,13 @@ case "$scope" in
       echo "  Each teammate also adds this to their shell rc:"
       echo "    export WEAVE_ROUTER_KEY=rk_..."
     fi
-    ;;
-esac
-echo "  Uninstall with: $script_dir/uninstall.sh${scope:+ --scope $scope}"
+    echo "  Uninstall with: $script_dir/uninstall.sh --scope project"
+  fi
+elif [ -n "$install_dir" ]; then
+  echo "  Run 'claude' from $install_dir — the status line will show the routed model + savings."
+  echo "  'cd $install_dir && claude' to use the router; run 'claude' elsewhere to skip it."
+  echo "  Uninstall with: $script_dir/uninstall.sh --dir $install_dir"
+else
+  echo "  Run 'claude' anywhere — the status line will show the routed model + savings."
+  echo "  Uninstall with: $script_dir/uninstall.sh --scope user"
+fi

--- a/install/install.sh
+++ b/install/install.sh
@@ -207,7 +207,7 @@ esac
 # Symlink containment: refuse if any target path is a symlink. User-scope paths
 # under $HOME are trusted; project-scope and --dir paths come from a git repo or
 # user-supplied directory that may be hostile, so we check those.
-if [ "$scope" = "project" ]; then
+if [ "$scope" = "project" ] || [ -n "$install_dir" ]; then
   refuse_if_symlink "$settings_dir"
   refuse_if_symlink "$settings_file"
   refuse_if_symlink "$local_settings_file"
@@ -267,12 +267,13 @@ ok "Statusline installed at $statusline_file"
 
 # Build the merge patch. Claude Code keeps its own Anthropic auth in
 # Authorization/x-api-key; the router key rides in ANTHROPIC_CUSTOM_HEADERS.
-# Project scope writes the key to settings.local.json (gitignored).
-# --dir and user scope write the key directly into settings.json.
+# Project scope (no --dir) writes the key to settings.local.json (gitignored)
+# so teammates can share settings.json. --dir and user scope inline the key
+# directly into settings.json since there's no team to coordinate with.
 tmp_patch="$(mktemp)"
 trap 'rm -f "$tmp_patch"' EXIT
 
-if [ "$scope" = "project" ]; then
+if [ "$scope" = "project" ] && [ -z "$install_dir" ]; then
   jq -n --arg url "$base_url" --arg sl "$statusline_path_for_settings" '{
     env: { ANTHROPIC_BASE_URL: $url },
     statusLine: { type: "command", command: $sl }
@@ -308,7 +309,7 @@ else
 fi
 ok "Settings written to $settings_file"
 
-if [ "$scope" = "project" ] && [ "$dev_mode" != "true" ]; then
+if [ "$scope" = "project" ] && [ -z "$install_dir" ] && [ "$dev_mode" != "true" ]; then
   jq -n --arg header "$router_key_header: $api_key" '{
     env: { ANTHROPIC_CUSTOM_HEADERS: $header }
   }' >"$tmp_patch"

--- a/install/uninstall.sh
+++ b/install/uninstall.sh
@@ -8,10 +8,12 @@
 # Usage:
 #   ./uninstall.sh                  # user scope
 #   ./uninstall.sh --scope project  # run inside the repo
+#   ./uninstall.sh --dir /tmp/test  # remove from arbitrary directory
 
 set -euo pipefail
 
 scope="user"
+install_dir=""
 
 err()  { printf "\033[31merror:\033[0m %s\n" "$*" >&2; }
 info() { printf "\033[36m==>\033[0m %s\n" "$*"; }
@@ -35,6 +37,10 @@ while [ $# -gt 0 ]; do
       scope="${2:-}"; shift 2
       [ "$scope" = "user" ] || [ "$scope" = "project" ] || { err "--scope must be 'user' or 'project'"; exit 2; }
       ;;
+    --dir)
+      install_dir="${2:-}"; shift 2
+      [ -n "$install_dir" ] || { err "--dir requires a path"; exit 2; }
+      ;;
     -h|--help)
       # awk avoids GNU `head -n -<N>` (rejected by BSD head on macOS).
       awk 'NR<2 { next } /^set -euo/ { exit } { sub(/^# ?/, ""); print }' "$0"
@@ -51,29 +57,33 @@ if ! command -v jq >/dev/null 2>&1; then
   exit 1
 fi
 
-case "$scope" in
-  user)
-    settings_file="$HOME/.claude/settings.json"
-    local_settings_file=""
-    statusline_file="$HOME/.weave/cc-statusline.sh"
-    ;;
-  project)
-    if ! git_root="$(git rev-parse --show-toplevel 2>/dev/null)"; then
-      err "--scope project must be run inside a git repo."
-      exit 1
-    fi
-    settings_file="$git_root/.claude/settings.json"
-    local_settings_file="$git_root/.claude/settings.local.json"
-    statusline_file="$git_root/.claude/cc-statusline.sh"
-    # Symlink containment: paths come from a git repo that may be hostile. The
-    # later `>` redirect on settings_file and `rm -f` on the scripts would
-    # otherwise follow links out of the repo.
-    refuse_if_symlink "$git_root/.claude"
-    refuse_if_symlink "$settings_file"
-    refuse_if_symlink "$local_settings_file"
-    refuse_if_symlink "$statusline_file"
-    ;;
-esac
+# Resolve the base directory. When --dir is given, use it directly.
+if [ -n "$install_dir" ]; then
+  install_dir="$(cd "$install_dir" 2>/dev/null && pwd || echo "$install_dir")"
+  settings_file="$install_dir/.claude/settings.json"
+  local_settings_file=""
+  statusline_file="$install_dir/.claude/cc-statusline.sh"
+elif [ "$scope" = "user" ]; then
+  settings_file="$HOME/.claude/settings.json"
+  local_settings_file=""
+  statusline_file="$HOME/.weave/cc-statusline.sh"
+else
+  # project
+  if ! git_root="$(git rev-parse --show-toplevel 2>/dev/null)"; then
+    err "--scope project must be run inside a git repo, or use --dir <path>."
+    exit 1
+  fi
+  settings_file="$git_root/.claude/settings.json"
+  local_settings_file="$git_root/.claude/settings.local.json"
+  statusline_file="$git_root/.claude/cc-statusline.sh"
+  # Symlink containment: paths come from a git repo that may be hostile. The
+  # later `>` redirect on settings_file and `rm -f` on the scripts would
+  # otherwise follow links out of the repo.
+  refuse_if_symlink "$git_root/.claude"
+  refuse_if_symlink "$settings_file"
+  refuse_if_symlink "$local_settings_file"
+  refuse_if_symlink "$statusline_file"
+fi
 
 if [ -f "$settings_file" ]; then
   # Only remove keys we actually installed: scrub our two env vars, and only
@@ -115,4 +125,8 @@ for f in "$statusline_file"; do
   fi
 done
 
-ok "Weave Router uninstalled (scope=$scope)."
+if [ -n "$install_dir" ]; then
+  ok "Weave Router uninstalled from $install_dir."
+else
+  ok "Weave Router uninstalled (scope=$scope)."
+fi

--- a/install/uninstall.sh
+++ b/install/uninstall.sh
@@ -6,9 +6,10 @@
 # Leaves the rest of settings.json untouched.
 #
 # Usage:
-#   ./uninstall.sh                  # user scope
-#   ./uninstall.sh --scope project  # run inside the repo
-#   ./uninstall.sh --dir /tmp/test  # remove from arbitrary directory
+#   ./uninstall.sh                            # user scope
+#   ./uninstall.sh --scope project            # run inside the repo
+#   ./uninstall.sh --dir /tmp/test            # --dir alone (user scope, .weave/)
+#   ./uninstall.sh --scope project --dir /tmp # --dir + project scope (.claude/)
 
 set -euo pipefail
 
@@ -62,7 +63,13 @@ if [ -n "$install_dir" ]; then
   install_dir="$(cd "$install_dir" 2>/dev/null && pwd || echo "$install_dir")"
   settings_file="$install_dir/.claude/settings.json"
   local_settings_file=""
-  statusline_file="$install_dir/.claude/cc-statusline.sh"
+  # --dir alone (scope defaults to "user") uses .weave/; --dir --scope project
+  # uses .claude/. Match the installer's scope-dependent statusline placement.
+  if [ "$scope" = "project" ]; then
+    statusline_file="$install_dir/.claude/cc-statusline.sh"
+  else
+    statusline_file="$install_dir/.weave/cc-statusline.sh"
+  fi
   # Symlink containment: --dir paths come from a user-supplied directory that may
   # be hostile. The later `>` redirect on settings_file and `rm -f` on the
   # statusline script would otherwise follow links out of the directory.

--- a/install/uninstall.sh
+++ b/install/uninstall.sh
@@ -63,6 +63,12 @@ if [ -n "$install_dir" ]; then
   settings_file="$install_dir/.claude/settings.json"
   local_settings_file=""
   statusline_file="$install_dir/.claude/cc-statusline.sh"
+  # Symlink containment: --dir paths come from a user-supplied directory that may
+  # be hostile. The later `>` redirect on settings_file and `rm -f` on the
+  # statusline script would otherwise follow links out of the directory.
+  refuse_if_symlink "$install_dir/.claude"
+  refuse_if_symlink "$settings_file"
+  refuse_if_symlink "$statusline_file"
 elif [ "$scope" = "user" ]; then
   settings_file="$HOME/.claude/settings.json"
   local_settings_file=""


### PR DESCRIPTION
## Summary
- `install.sh`: added `--dir <path>` for isolated throwaway installs into any directory (no git repo needed)
- `install.sh`: interactive 1/2 scope prompt when `--scope` is omitted (skipped when `--dir` or `--non-interactive`)
- `install.sh`: `--scope project --dir <path>` for project-style install at a specific directory
- `uninstall.sh`: added `--dir <path>` — surgical jq cleanup (no `rm -rf .claude/`)
- `Makefile full-setup`: accepts `DIR=`, `SCOPE=`, `NON_INTERACTIVE=1` vars
- `README.md`: updated flags table, quick start examples, and interactive prompt docs

## Test plan
- [x] `./install.sh --dir /tmp/test-sandbox` installs into isolated dir, doesn't touch `~/.claude/`
- [x] `./install.sh --scope project --dir /path/to/repo` installs project-style without `cd`
- [x] `./install.sh` (no flags, TTY) shows interactive prompt, Enter defaults to user
- [x] `./install.sh --scope project` skips prompt
- [x] `./uninstall.sh --dir /tmp/test-sandbox` surgically removes only router keys
- [x] `make full-setup PLATFORM=cc KEY=... BASE_URL=... DIR=/tmp/test` works end-to-end
- [x] Both scripts pass `bash -n` syntax check

🤖 Generated with [Claude Code](https://claude.com/claude-code)