### PR TITLE
chore: add Elastic License v2 and README badge

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,5 @@
+Copyright 2025 Workweave, Inc.
+
 Elastic License 2.0
 
 URL: https://www.elastic.co/licensing/elastic-license

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,88 @@
+Elastic License 2.0
+
+URL: https://www.elastic.co/licensing/elastic-license
+
+## Acceptance
+
+By using the software, you agree to all of the terms and conditions below.
+
+## Copyright License
+
+The licensor grants you a non-exclusive, royalty-free, worldwide,
+non-sublicensable, non-transferable license to use, copy, distribute, make
+available, and prepare derivative works of the software, in each case subject to
+the limitations and conditions below.
+
+## Limitations
+
+You may not provide the software to third parties as a hosted or managed
+service, where the service provides users with access to any substantial set of
+the features or functionality of the software.
+
+You may not move, change, disable, or circumvent the license key functionality
+in the software, and you may not remove or obscure any functionality in the
+software that is protected by the license key.
+
+You may not alter, remove, or obscure any licensing, copyright, or other notices
+of the licensor in the software. Any use of the licensor's trademarks is subject
+to applicable law.
+
+## Patents
+
+The licensor grants you a license, under any patent claims the licensor can
+license, or becomes able to license, to make, have made, use, practice,
+sell, offer for sale, import or transfer any part of the software. This license
+does not cover any patent claims that you cause to be infringed by modifications
+or additions to the software. If you or your company make any written claim that
+the software infringes or contributes to infringement of any patent, your patent
+license for the software granted under these terms ends immediately.
+
+## Notices
+
+You must ensure that anyone who gets a copy of any part of the software from you
+also gets a copy of these terms.
+
+If you modify the software, you must include in any modified copies of the
+software prominent notices stating that you have modified the software.
+
+## No Other Rights
+
+These terms do not imply any licenses other than those expressly granted in
+these terms.
+
+## Termination
+
+If you use the software in violation of these terms, such use is not licensed,
+and your licenses will automatically terminate. If the licensor provides you
+with a notice of your violation, and you cease all violation of this license no
+later than 30 days after you receive that notice, your licenses will
+automatically be reinstated unless the licensor notifies you otherwise. If you
+violate these terms after reinstatement, any additional violation will
+automatically and permanently terminate your licenses.
+
+## No Liability
+
+*As far as the law allows, the software comes as is, without any warranty or
+condition, and the licensor will not be liable to you for any damages arising
+out of these terms or the use or nature of the software, under any kind of
+legal claim.*
+
+## Definitions
+
+The **licensor** is the entity offering these terms, and the **software** is the
+software the licensor makes available under these terms, including any portion
+of it.
+
+**you** refers to the individual or entity agreeing to these terms.
+
+**your company** is any legal entity, sole proprietorship, or other kind of
+organization that you work for, plus all organizations that have more than 25%
+ownership in the relationship with you.
+
+**your licenses** are all the licenses granted to you for the software under
+these terms.
+
+**use** includes anything you do with the software requiring one of your
+licenses.
+
+**trademark** includes logos, service marks, and other designations.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Go Version](https://img.shields.io/badge/Go-1.25%2B-00ADD8?logo=go)](go.mod)
 [![Tests](https://github.com/workweave/router/actions/workflows/test.yml/badge.svg)](https://github.com/workweave/router/actions/workflows/test.yml)
+[![License: ELv2](https://img.shields.io/badge/License-ELv2-00BFB3.svg)](https://www.elastic.co/licensing/elastic-license)
 
 A standalone Go service for authenticating and routing LLM completions
 to the most appropriate provider. The router proxies Anthropic Messages


### PR DESCRIPTION
## Summary
- Adds `LICENSE` file with the full Elastic License 2.0 text
- Adds ELv2 badge to README alongside the existing Go version and CI badges

## Test plan
- [ ] Verify LICENSE file renders correctly on GitHub
- [ ] Verify badge displays in README preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)