### PR TITLE
feat(observability): extract cache_creation/read_input_tokens (W-1309)

### DIFF
--- a/internal/observability/otel/usage.go
+++ b/internal/observability/otel/usage.go
@@ -19,11 +19,12 @@ const (
 	providerGoogle    = "google"
 )
 
-// UsageSink receives extracted token usage. Translators call RecordUsage
-// when they encounter usage data in already-parsed events, eliminating
-// the need for a separate parse pass.
+// UsageSink receives extracted token usage. Translators call RecordUsage /
+// RecordCacheUsage when they encounter usage data in already-parsed events,
+// eliminating the need for a separate parse pass.
 type UsageSink interface {
 	RecordUsage(inputTokens, outputTokens int)
+	RecordCacheUsage(cacheCreationTokens, cacheReadTokens int)
 }
 
 var (
@@ -40,8 +41,10 @@ type UsageExtractor struct {
 	inner    http.ResponseWriter
 	provider string
 
-	input  int
-	output int
+	input         int
+	output        int
+	cacheCreation int
+	cacheRead     int
 
 	leftover []byte
 }
@@ -93,6 +96,20 @@ func (u *UsageExtractor) RecordUsage(inputTokens, outputTokens int) {
 	}
 }
 
+// RecordCacheUsage sets cache token counts directly. Sibling to RecordUsage
+// for translators that already parsed cache usage (Anthropic
+// cache_creation_input_tokens / cache_read_input_tokens; OpenAI
+// prompt_tokens_details.cached_tokens — passed as cacheReadTokens with
+// cacheCreationTokens=0 since OpenAI has no creation concept).
+func (u *UsageExtractor) RecordCacheUsage(cacheCreationTokens, cacheReadTokens int) {
+	if cacheCreationTokens > 0 {
+		u.cacheCreation = cacheCreationTokens
+	}
+	if cacheReadTokens > 0 {
+		u.cacheRead = cacheReadTokens
+	}
+}
+
 // Tokens returns the extracted input and output token counts. Nil receiver
 // returns (0, 0) so callers can skip the extractor when OTel is disabled.
 func (u *UsageExtractor) Tokens() (input, output int) {
@@ -100,6 +117,16 @@ func (u *UsageExtractor) Tokens() (input, output int) {
 		return 0, 0
 	}
 	return u.input, u.output
+}
+
+// CacheTokens returns the extracted cache creation and cache read token
+// counts. Nil receiver returns (0, 0); zero values indicate the provider
+// does not emit cache tokens (Google) or the response had no cache hits.
+func (u *UsageExtractor) CacheTokens() (creation, read int) {
+	if u == nil {
+		return 0, 0
+	}
+	return u.cacheCreation, u.cacheRead
 }
 
 // scanBuffer splits buffered data on SSE event boundaries and extracts
@@ -137,19 +164,27 @@ func (u *UsageExtractor) extractFromSSEEvent(eventType []byte, data []byte) {
 	}
 }
 
-// message_start carries input_tokens; message_delta carries output_tokens.
+// message_start carries input_tokens + cache tokens; message_delta carries output_tokens.
 func (u *UsageExtractor) extractAnthropicSSE(eventType []byte, data []byte) {
 	if !bytes.Equal(eventType, []byte("message_start")) && !bytes.Equal(eventType, []byte("message_delta")) {
 		return
 	}
 
-	input, output, found := extractUsageGJSON(data, providerAnthropic)
+	input, output, cacheCreation, cacheRead, found := extractUsageGJSON(data, providerAnthropic)
 	if !found {
 		return
 	}
 
-	if bytes.Equal(eventType, []byte("message_start")) && input > 0 {
-		u.input = input
+	if bytes.Equal(eventType, []byte("message_start")) {
+		if input > 0 {
+			u.input = input
+		}
+		if cacheCreation > 0 {
+			u.cacheCreation = cacheCreation
+		}
+		if cacheRead > 0 {
+			u.cacheRead = cacheRead
+		}
 	}
 	if bytes.Equal(eventType, []byte("message_delta")) && output > 0 {
 		u.output = output
@@ -163,13 +198,19 @@ func (u *UsageExtractor) extractOpenAISSE(data []byte) {
 		return
 	}
 
-	input, output, found := extractUsageGJSON(trimmed, u.provider)
+	input, output, cacheCreation, cacheRead, found := extractUsageGJSON(trimmed, u.provider)
 	if !found {
 		return
 	}
 
 	u.input = input
 	u.output = output
+	if cacheCreation > 0 {
+		u.cacheCreation = cacheCreation
+	}
+	if cacheRead > 0 {
+		u.cacheRead = cacheRead
+	}
 }
 
 func (u *UsageExtractor) tryExtractFromJSON() {
@@ -177,7 +218,7 @@ func (u *UsageExtractor) tryExtractFromJSON() {
 		return
 	}
 
-	input, output, found := extractUsageGJSON(u.leftover, u.provider)
+	input, output, cacheCreation, cacheRead, found := extractUsageGJSON(u.leftover, u.provider)
 	if !found {
 		return
 	}
@@ -188,29 +229,40 @@ func (u *UsageExtractor) tryExtractFromJSON() {
 	if output > 0 {
 		u.output = output
 	}
+	if cacheCreation > 0 {
+		u.cacheCreation = cacheCreation
+	}
+	if cacheRead > 0 {
+		u.cacheRead = cacheRead
+	}
 }
 
 // extractUsageGJSON probes for token usage fields using gjson, avoiding
-// json.Unmarshal and map[string]any allocations entirely.
-func extractUsageGJSON(data []byte, provider string) (input, output int, found bool) {
+// json.Unmarshal and map[string]any allocations entirely. OpenAI has no
+// cache-creation concept; cacheRead maps to prompt_tokens_details.cached_tokens.
+// Google emits neither and returns zeros for both cache values.
+func extractUsageGJSON(data []byte, provider string) (input, output, cacheCreation, cacheRead int, found bool) {
 	usage := gjson.GetBytes(data, "usage")
 	if !usage.Exists() && provider == providerAnthropic {
 		usage = gjson.GetBytes(data, "message.usage")
 	}
 	if !usage.Exists() {
-		return 0, 0, false
+		return 0, 0, 0, 0, false
 	}
 
 	switch provider {
 	case providerAnthropic:
 		input = int(usage.Get("input_tokens").Int())
 		output = int(usage.Get("output_tokens").Int())
+		cacheCreation = int(usage.Get("cache_creation_input_tokens").Int())
+		cacheRead = int(usage.Get("cache_read_input_tokens").Int())
 	case providerOpenAI, providerGoogle:
 		input = int(usage.Get("prompt_tokens").Int())
 		output = int(usage.Get("completion_tokens").Int())
+		cacheRead = int(usage.Get("prompt_tokens_details.cached_tokens").Int())
 	default:
-		return 0, 0, false
+		return 0, 0, 0, 0, false
 	}
 
-	return input, output, true
+	return input, output, cacheCreation, cacheRead, true
 }

--- a/internal/observability/otel/usage_test.go
+++ b/internal/observability/otel/usage_test.go
@@ -107,4 +107,101 @@ func TestUsageExtractor_NoUsageReturnsZero(t *testing.T) {
 	in, out := ext.Tokens()
 	assert.Equal(t, 0, in)
 	assert.Equal(t, 0, out)
+
+	cacheCreation, cacheRead := ext.CacheTokens()
+	assert.Equal(t, 0, cacheCreation)
+	assert.Equal(t, 0, cacheRead)
+}
+
+func TestUsageExtractor_AnthropicCacheTokens_NonStreaming(t *testing.T) {
+	rec := httptest.NewRecorder()
+	ext := otel.NewUsageExtractor(rec, "anthropic")
+
+	body := `{"id":"msg_456","type":"message","role":"assistant","content":[{"type":"text","text":"OK"}],"model":"claude-sonnet-4-5","stop_reason":"end_turn","usage":{"input_tokens":42,"output_tokens":17,"cache_creation_input_tokens":256,"cache_read_input_tokens":1024}}`
+	_, err := ext.Write([]byte(body))
+	require.NoError(t, err)
+
+	in, out := ext.Tokens()
+	assert.Equal(t, 42, in)
+	assert.Equal(t, 17, out)
+
+	cacheCreation, cacheRead := ext.CacheTokens()
+	assert.Equal(t, 256, cacheCreation)
+	assert.Equal(t, 1024, cacheRead)
+}
+
+func TestUsageExtractor_AnthropicCacheTokens_Streaming(t *testing.T) {
+	rec := httptest.NewRecorder()
+	ext := otel.NewUsageExtractor(rec, "anthropic")
+
+	// cache tokens arrive in message_start; subsequent message_delta carries
+	// only output_tokens and must not clobber the cache values.
+	events := []string{
+		"event: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_1\",\"type\":\"message\",\"role\":\"assistant\",\"model\":\"claude-sonnet-4-5\",\"usage\":{\"input_tokens\":100,\"output_tokens\":0,\"cache_creation_input_tokens\":300,\"cache_read_input_tokens\":900}}}\n\n",
+		"event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"Hi\"}}\n\n",
+		"event: message_delta\ndata: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\"},\"usage\":{\"output_tokens\":25}}\n\n",
+	}
+
+	for _, e := range events {
+		_, err := ext.Write([]byte(e))
+		require.NoError(t, err)
+	}
+
+	in, out := ext.Tokens()
+	assert.Equal(t, 100, in)
+	assert.Equal(t, 25, out)
+
+	cacheCreation, cacheRead := ext.CacheTokens()
+	assert.Equal(t, 300, cacheCreation)
+	assert.Equal(t, 900, cacheRead)
+}
+
+func TestUsageExtractor_OpenAICacheTokens_NonStreaming(t *testing.T) {
+	rec := httptest.NewRecorder()
+	ext := otel.NewUsageExtractor(rec, "openai")
+
+	// OpenAI exposes cached prompt tokens via prompt_tokens_details.cached_tokens.
+	// There is no creation analogue, so cache_creation stays at 0.
+	body := `{"id":"chatcmpl-2","object":"chat.completion","choices":[{"message":{"role":"assistant","content":"Hi"},"finish_reason":"stop"}],"usage":{"prompt_tokens":15,"completion_tokens":8,"total_tokens":23,"prompt_tokens_details":{"cached_tokens":42}}}`
+	_, err := ext.Write([]byte(body))
+	require.NoError(t, err)
+
+	in, out := ext.Tokens()
+	assert.Equal(t, 15, in)
+	assert.Equal(t, 8, out)
+
+	cacheCreation, cacheRead := ext.CacheTokens()
+	assert.Equal(t, 0, cacheCreation)
+	assert.Equal(t, 42, cacheRead)
+}
+
+func TestUsageExtractor_OpenAICacheTokens_Streaming(t *testing.T) {
+	rec := httptest.NewRecorder()
+	ext := otel.NewUsageExtractor(rec, "openai")
+
+	events := []string{
+		"data: {\"id\":\"chatcmpl-2\",\"object\":\"chat.completion.chunk\",\"choices\":[{\"delta\":{\"content\":\"Hi\"}}]}\n\n",
+		"data: {\"id\":\"chatcmpl-2\",\"object\":\"chat.completion.chunk\",\"choices\":[],\"usage\":{\"prompt_tokens\":20,\"completion_tokens\":12,\"prompt_tokens_details\":{\"cached_tokens\":7}}}\n\n",
+		"data: [DONE]\n\n",
+	}
+
+	for _, e := range events {
+		_, err := ext.Write([]byte(e))
+		require.NoError(t, err)
+	}
+
+	in, out := ext.Tokens()
+	assert.Equal(t, 20, in)
+	assert.Equal(t, 12, out)
+
+	cacheCreation, cacheRead := ext.CacheTokens()
+	assert.Equal(t, 0, cacheCreation)
+	assert.Equal(t, 7, cacheRead)
+}
+
+func TestUsageExtractor_RecordCacheUsage_NilReceiver(t *testing.T) {
+	var ext *otel.UsageExtractor
+	creation, read := ext.CacheTokens()
+	assert.Equal(t, 0, creation)
+	assert.Equal(t, 0, read)
 }

--- a/internal/proxy/gemini.go
+++ b/internal/proxy/gemini.go
@@ -150,7 +150,8 @@ func (s *Service) ProxyGeminiGenerateContent(ctx context.Context, body []byte, w
 	proxyMs := time.Since(proxyStart).Milliseconds()
 
 	in, out := extractor.Tokens()
-	geminiUpstreamBuilder := otel.NewAttrBuilder(20).
+	cacheCreation, cacheRead := extractor.CacheTokens()
+	geminiUpstreamBuilder := otel.NewAttrBuilder(22).
 		String("request_id", requestID).
 		String("external_id", externalID).
 		String("client.device_id", clientID.DeviceID).
@@ -160,6 +161,8 @@ func (s *Service) ProxyGeminiGenerateContent(ctx context.Context, body []byte, w
 		String("client.app", clientID.ClientApp).
 		Int64("usage.input_tokens", int64(in)).
 		Int64("usage.output_tokens", int64(out)).
+		Int64("usage.cache_creation_input_tokens", int64(cacheCreation)).
+		Int64("usage.cache_read_input_tokens", int64(cacheRead)).
 		Float64("cost.requested_input_usd", float64(in)/1_000_000*reqPricing.InputUSDPer1M).
 		Float64("cost.requested_output_usd", float64(out)/1_000_000*reqPricing.OutputUSDPer1M).
 		Float64("cost.actual_input_usd", float64(in)/1_000_000*actPricing.InputUSDPer1M).

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -550,7 +550,8 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 	proxyMs := time.Since(proxyStart).Milliseconds()
 
 	in, out := extractor.Tokens()
-	upstreamBuilder := otel.NewAttrBuilder(25).
+	cacheCreation, cacheRead := extractor.CacheTokens()
+	upstreamBuilder := otel.NewAttrBuilder(27).
 		String("request_id", requestID).
 		String("external_id", externalID).
 		String("router_user_id", auth.UserIDFrom(ctx)).
@@ -561,6 +562,8 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 		String("client.app", clientID.ClientApp).
 		Int64("usage.input_tokens", int64(in)).
 		Int64("usage.output_tokens", int64(out)).
+		Int64("usage.cache_creation_input_tokens", int64(cacheCreation)).
+		Int64("usage.cache_read_input_tokens", int64(cacheRead)).
 		Float64("cost.requested_input_usd", float64(in)/1_000_000*reqPricing.InputUSDPer1M).
 		Float64("cost.requested_output_usd", float64(out)/1_000_000*reqPricing.OutputUSDPer1M).
 		Float64("cost.actual_input_usd", float64(in)/1_000_000*actPricing.InputUSDPer1M).
@@ -982,7 +985,8 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 	proxyMs := time.Since(proxyStart).Milliseconds()
 
 	in, out := extractor.Tokens()
-	openaiUpstreamBuilder := otel.NewAttrBuilder(25).
+	cacheCreation, cacheRead := extractor.CacheTokens()
+	openaiUpstreamBuilder := otel.NewAttrBuilder(27).
 		String("request_id", requestID).
 		String("external_id", externalID).
 		String("router_user_id", auth.UserIDFrom(ctx)).
@@ -993,6 +997,8 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 		String("client.app", clientID.ClientApp).
 		Int64("usage.input_tokens", int64(in)).
 		Int64("usage.output_tokens", int64(out)).
+		Int64("usage.cache_creation_input_tokens", int64(cacheCreation)).
+		Int64("usage.cache_read_input_tokens", int64(cacheRead)).
 		Float64("cost.requested_input_usd", float64(in)/1_000_000*reqPricing.InputUSDPer1M).
 		Float64("cost.requested_output_usd", float64(out)/1_000_000*reqPricing.OutputUSDPer1M).
 		Float64("cost.actual_input_usd", float64(in)/1_000_000*actPricing.InputUSDPer1M).

--- a/internal/translate/cache_usage_test.go
+++ b/internal/translate/cache_usage_test.go
@@ -1,0 +1,81 @@
+package translate_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"workweave/router/internal/translate"
+)
+
+// fakeUsageSink records the last RecordUsage / RecordCacheUsage calls.
+// Translators forward parsed token counts to whichever sink the proxy
+// installed (in prod: *otel.UsageExtractor); these tests verify the
+// translator passes the right JSON-extracted values to the sink without
+// constructing a real extractor.
+type fakeUsageSink struct {
+	input         int
+	output        int
+	cacheCreation int
+	cacheRead     int
+}
+
+func (f *fakeUsageSink) RecordUsage(input, output int) {
+	f.input = input
+	f.output = output
+}
+
+func (f *fakeUsageSink) RecordCacheUsage(creation, read int) {
+	f.cacheCreation = creation
+	f.cacheRead = read
+}
+
+// SSETranslator forwards Anthropic message_start cache tokens to the sink
+// (cache_creation_input_tokens, cache_read_input_tokens). Catches typos in
+// either JSON path.
+func TestSSETranslator_ForwardsAnthropicCacheTokens(t *testing.T) {
+	rec := httptest.NewRecorder()
+	sink := &fakeUsageSink{}
+	translator := translate.NewSSETranslator(rec, "claude-sonnet-4-5", sink)
+
+	translator.Header().Set("Content-Type", "text/event-stream")
+	translator.WriteHeader(http.StatusOK)
+
+	event := "event: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_1\",\"type\":\"message\",\"role\":\"assistant\",\"model\":\"claude-sonnet-4-5\",\"usage\":{\"input_tokens\":150,\"output_tokens\":0,\"cache_creation_input_tokens\":512,\"cache_read_input_tokens\":2048}}}\n\n"
+	_, err := translator.Write([]byte(event))
+	require.NoError(t, err)
+
+	assert.Equal(t, 150, sink.input)
+	assert.Equal(t, 512, sink.cacheCreation)
+	assert.Equal(t, 2048, sink.cacheRead)
+}
+
+// AnthropicSSETranslator forwards OpenAI prompt_tokens_details.cached_tokens
+// to the sink as cacheRead (no cache_creation on OpenAI). Catches typos in
+// the nested JSON path that gjson would otherwise silently return 0 for.
+func TestAnthropicSSETranslator_ForwardsOpenAICachedTokens(t *testing.T) {
+	rec := httptest.NewRecorder()
+	sink := &fakeUsageSink{}
+	translator := translate.NewAnthropicSSETranslator(rec, "gpt-4o", sink)
+
+	translator.Header().Set("Content-Type", "text/event-stream")
+	translator.WriteHeader(http.StatusOK)
+
+	events := []string{
+		"data: {\"id\":\"chatcmpl-1\",\"object\":\"chat.completion.chunk\",\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\",\"content\":\"hi\"},\"finish_reason\":null}]}\n\n",
+		"data: {\"id\":\"chatcmpl-1\",\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"stop\"}],\"usage\":{\"prompt_tokens\":80,\"completion_tokens\":12,\"prompt_tokens_details\":{\"cached_tokens\":64}}}\n\n",
+		"data: [DONE]\n\n",
+	}
+	for _, e := range events {
+		_, err := translator.Write([]byte(e))
+		require.NoError(t, err)
+	}
+
+	assert.Equal(t, 80, sink.input)
+	assert.Equal(t, 12, sink.output)
+	assert.Equal(t, 0, sink.cacheCreation)
+	assert.Equal(t, 64, sink.cacheRead)
+}

--- a/internal/translate/stream.go
+++ b/internal/translate/stream.go
@@ -116,6 +116,10 @@ func (t *SSETranslator) Finalize() error {
 				int(usage.Get("input_tokens").Int()),
 				int(usage.Get("output_tokens").Int()),
 			)
+			t.usageSink.RecordCacheUsage(
+				int(usage.Get("cache_creation_input_tokens").Int()),
+				int(usage.Get("cache_read_input_tokens").Int()),
+			)
 		}
 	}
 
@@ -195,6 +199,10 @@ func (t *SSETranslator) handleMessageStart(data []byte) error {
 		t.bw.WriteByte('}')
 		if t.usageSink != nil {
 			t.usageSink.RecordUsage(int(inputTokens), 0)
+			t.usageSink.RecordCacheUsage(
+				int(usageResult.Get("cache_creation_input_tokens").Int()),
+				int(usageResult.Get("cache_read_input_tokens").Int()),
+			)
 		}
 	}
 
@@ -453,6 +461,10 @@ func (t *AnthropicSSETranslator) Finalize() error {
 				int(usage.Get("prompt_tokens").Int()),
 				int(usage.Get("completion_tokens").Int()),
 			)
+			t.usageSink.RecordCacheUsage(
+				0,
+				int(usage.Get("prompt_tokens_details.cached_tokens").Int()),
+			)
 		}
 	}
 
@@ -540,11 +552,13 @@ func (t *AnthropicSSETranslator) extractAndForwardUsage(data []byte) {
 	}
 	prompt := usage.Get("prompt_tokens").Int()
 	completion := usage.Get("completion_tokens").Int()
+	cachedRead := usage.Get("prompt_tokens_details.cached_tokens").Int()
 	t.usageInputTokens = int(prompt)
 	t.usageOutputTokens = int(completion)
 	t.hasUsage = true
 	if t.usageSink != nil {
 		t.usageSink.RecordUsage(int(prompt), int(completion))
+		t.usageSink.RecordCacheUsage(0, int(cachedRead))
 	}
 }
 


### PR DESCRIPTION
## Summary

- Extract Anthropic `cache_creation_input_tokens` / `cache_read_input_tokens` and OpenAI `prompt_tokens_details.cached_tokens` in the OTel `UsageExtractor`. Sibling to existing input/output extraction.
- Plumb through `UsageSink` (new `RecordCacheUsage` method) so cross-format translators (Anthropic→OpenAI, OpenAI→Anthropic) forward parsed cache tokens to the same extractor that emits OTel attrs.
- Emit two new attributes on the `router.upstream` span across all three proxy paths (Anthropic, OpenAI, Gemini): `usage.cache_creation_input_tokens` and `usage.cache_read_input_tokens`.

OpenAI has no creation concept (only cache reads), so its `cacheCreation` stays at 0. Gemini emits neither and both stay at 0. Existing `RecordUsage` / `Tokens()` callsites are unchanged — the new methods (`RecordCacheUsage`, `CacheTokens`) are additive.

Required for cache-aware cost accounting and W-1310 (cached-input cost dimension in the α-blend, blocked by this).

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` (full repo) — all packages pass
- [x] New tests:
  - `TestUsageExtractor_AnthropicCacheTokens_NonStreaming` — JSON body cache extraction
  - `TestUsageExtractor_AnthropicCacheTokens_Streaming` — SSE `message_start` cache extraction, verifies subsequent `message_delta` does not clobber
  - `TestUsageExtractor_OpenAICacheTokens_NonStreaming` — `prompt_tokens_details.cached_tokens`
  - `TestUsageExtractor_OpenAICacheTokens_Streaming` — SSE final-chunk path
  - `TestUsageExtractor_RecordCacheUsage_NilReceiver` — nil-safety mirror of `Tokens()`
  - `TestSSETranslator_ForwardsAnthropicCacheTokens` — guards JSON paths in Anthropic→OpenAI translator wiring
  - `TestAnthropicSSETranslator_ForwardsOpenAICachedTokens` — guards nested `prompt_tokens_details.cached_tokens` path in OpenAI→Anthropic translator wiring
- [x] `TestUsageExtractor_NoUsageReturnsZero` extended to assert `CacheTokens()` returns `(0, 0)` as well

## Scope / out-of-scope

In scope: extraction + plumb + OTel span attrs.

Out of scope (W-1310 will follow up):
- α-blend cost math using the new cache values
- Per-model cached-input price table
- DB columns on `router.model_router_request_telemetry` for cache tokens (not added until a consumer exists)

Linear: [W-1309](https://linear.app/workweave/issue/W-1309/extract-cache-creationread-input-tokens-in-usage-extractor)

🤖 Generated with [Claude Code](https://claude.com/claude-code)