### PR TITLE
fix(install): restore awk \n + || true safety net, round generated prices

### DIFF
--- a/cmd/genprices/main.go
+++ b/cmd/genprices/main.go
@@ -6,6 +6,7 @@ package main
 
 import (
 	"fmt"
+	"math"
 	"os"
 	"sort"
 	"strconv"
@@ -109,8 +110,18 @@ func maxLen(models []string) int {
 	return n
 }
 
-// fmtPrice formats a USD/1k price with enough precision for the jq math in
-// cc-statusline.sh. Uses the shortest decimal representation that round-trips.
+// fmtPrice formats a USD/1k price for the jq math in cc-statusline.sh.
+// Rounds to 6 significant figures before formatting so the generated block
+// doesn't carry IEEE 754 representation artifacts (e.g. 0.071/1000 would
+// otherwise render as 0.00007099999999999999). 6 sig figs gives ~10×
+// headroom over the smallest input we ever serialize (~6.5e-5 USD/k) and
+// stays well within the precision the downstream jq calculation needs.
 func fmtPrice(v float64) string {
-	return strconv.FormatFloat(v, 'f', -1, 64)
+	if v == 0 {
+		return "0"
+	}
+	const sigFigs = 6
+	scale := math.Pow10(sigFigs - 1 - int(math.Floor(math.Log10(math.Abs(v)))))
+	rounded := math.Round(v*scale) / scale
+	return strconv.FormatFloat(rounded, 'f', -1, 64)
 }

--- a/cmd/genprices/main_test.go
+++ b/cmd/genprices/main_test.go
@@ -1,0 +1,52 @@
+package main
+
+import "testing"
+
+// TestFmtPriceRoundsAwayFloat64Artifacts pins fmtPrice to a clean decimal form
+// for prices that round-trip through 0.<value>/1000 in float64. The naive
+// FormatFloat(-1) representation leaks IEEE 754 noise (e.g. 0.071/1000
+// renders as 0.00007099999999999999) into the generated install.sh /
+// cc-statusline.sh prices block, which is checked into the repo and copied
+// into WorkWeave verbatim by the bump-workweave-pin workflow.
+//
+// Inputs are taken from float64 variables so the test mirrors the runtime
+// path genprices walks (struct field / 1000), not Go's untyped-constant
+// arithmetic which silently uses higher-than-float64 precision.
+func TestFmtPriceRoundsAwayFloat64Artifacts(t *testing.T) {
+	cases := []struct {
+		name           string
+		inputUSDPer1M  float64
+		want           string
+	}{
+		// USD/1M values that, divided by 1000 at runtime, leak IEEE 754 noise.
+		{"qwen3-235b input", 0.071, "0.000071"},
+		{"qwen3-coder-next input", 0.070, "0.00007"},
+		{"qwen3-next-80b input", 0.090, "0.00009"},
+		{"qwen3.5-flash input", 0.065, "0.000065"},
+		{"deepseek-v4-flash input", 0.140, "0.00014"},
+		{"qwen3-235b output", 0.463, "0.000463"},
+		{"deepseek-v4-flash output", 0.280, "0.00028"},
+		{"qwen3.5-flash output", 0.260, "0.00026"},
+
+		// Values that were already clean must stay clean.
+		{"claude-opus input", 15.00, "0.015"},
+		{"claude-haiku input", 0.80, "0.0008"},
+		{"gemini-2.0-flash-lite input", 0.075, "0.000075"},
+		{"gpt-5.5-pro input", 30.00, "0.03"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := fmtPrice(tc.inputUSDPer1M / 1000)
+			if got != tc.want {
+				t.Fatalf("fmtPrice(%g/1000) = %q; want %q", tc.inputUSDPer1M, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestFmtPriceZero(t *testing.T) {
+	if got := fmtPrice(0); got != "0" {
+		t.Fatalf("fmtPrice(0) = %q; want %q", got, "0")
+	}
+}

--- a/cmd/genprices/main_test.go
+++ b/cmd/genprices/main_test.go
@@ -14,9 +14,9 @@ import "testing"
 // arithmetic which silently uses higher-than-float64 precision.
 func TestFmtPriceRoundsAwayFloat64Artifacts(t *testing.T) {
 	cases := []struct {
-		name           string
-		inputUSDPer1M  float64
-		want           string
+		name          string
+		inputUSDPer1M float64
+		want          string
 	}{
 		// USD/1M values that, divided by 1000 at runtime, leak IEEE 754 noise.
 		{"qwen3-235b input", 0.071, "0.000071"},

--- a/install/cc-statusline.sh
+++ b/install/cc-statusline.sh
@@ -45,7 +45,7 @@ prices='{
     "claude-haiku-4-5":                 0.0008,
     "claude-opus-4-7":                  0.015,
     "claude-sonnet-4-5":                0.003,
-    "deepseek/deepseek-v4-flash":       0.00014000000000000001,
+    "deepseek/deepseek-v4-flash":       0.00014,
     "deepseek/deepseek-v4-pro":         0.000435,
     "gemini-2.0-flash":                 0.0001,
     "gemini-2.0-flash-lite":            0.000075,
@@ -75,18 +75,18 @@ prices='{
     "gpt-5.5-pro":                      0.03,
     "mistralai/mistral-small-2603":     0.00015,
     "moonshotai/kimi-k2.5":             0.00044,
-    "qwen/qwen3-235b-a22b-2507":        0.00007099999999999999,
+    "qwen/qwen3-235b-a22b-2507":        0.000071,
     "qwen/qwen3-30b-a3b-instruct-2507": 0.00008,
     "qwen/qwen3-coder":                 0.00022,
-    "qwen/qwen3-coder-next":            0.00007000000000000001,
-    "qwen/qwen3-next-80b-a3b-instruct": 0.00008999999999999999,
-    "qwen/qwen3.5-flash-02-23":         0.00006500000000000001
+    "qwen/qwen3-coder-next":            0.00007,
+    "qwen/qwen3-next-80b-a3b-instruct": 0.00009,
+    "qwen/qwen3.5-flash-02-23":         0.000065
   },
   "output": {
     "claude-haiku-4-5":                 0.004,
     "claude-opus-4-7":                  0.075,
     "claude-sonnet-4-5":                0.015,
-    "deepseek/deepseek-v4-flash":       0.00028000000000000003,
+    "deepseek/deepseek-v4-flash":       0.00028,
     "deepseek/deepseek-v4-pro":         0.00087,
     "gemini-2.0-flash":                 0.0004,
     "gemini-2.0-flash-lite":            0.0003,
@@ -116,12 +116,12 @@ prices='{
     "gpt-5.5-pro":                      0.12,
     "mistralai/mistral-small-2603":     0.0006,
     "moonshotai/kimi-k2.5":             0.002,
-    "qwen/qwen3-235b-a22b-2507":        0.00046300000000000003,
+    "qwen/qwen3-235b-a22b-2507":        0.000463,
     "qwen/qwen3-30b-a3b-instruct-2507": 0.00033,
     "qwen/qwen3-coder":                 0.0018,
     "qwen/qwen3-coder-next":            0.0003,
     "qwen/qwen3-next-80b-a3b-instruct": 0.0011,
-    "qwen/qwen3.5-flash-02-23":         0.00026000000000000003
+    "qwen/qwen3.5-flash-02-23":         0.00026
   }
 }'
 # END_GENERATED_PRICES
@@ -202,7 +202,7 @@ if [[ -n "$transcript_path" && -f "$transcript_path" ]]; then
       end
     ' "$transcript_path" 2>/dev/null \
     | awk 'BEGIN{tot=0; last=0} {tot+=$1; last=$1} END{printf "%.4f %.4f\n", last, tot}'
-  )
+  ) || true
 fi
 
 # Brand color (#FF6C47) on terminals that grok 24-bit truecolor — that's

--- a/install/install.sh
+++ b/install/install.sh
@@ -296,7 +296,7 @@ prices='{
     "claude-haiku-4-5":                 0.0008,
     "claude-opus-4-7":                  0.015,
     "claude-sonnet-4-5":                0.003,
-    "deepseek/deepseek-v4-flash":       0.00014000000000000001,
+    "deepseek/deepseek-v4-flash":       0.00014,
     "deepseek/deepseek-v4-pro":         0.000435,
     "gemini-2.0-flash":                 0.0001,
     "gemini-2.0-flash-lite":            0.000075,
@@ -326,18 +326,18 @@ prices='{
     "gpt-5.5-pro":                      0.03,
     "mistralai/mistral-small-2603":     0.00015,
     "moonshotai/kimi-k2.5":             0.00044,
-    "qwen/qwen3-235b-a22b-2507":        0.00007099999999999999,
+    "qwen/qwen3-235b-a22b-2507":        0.000071,
     "qwen/qwen3-30b-a3b-instruct-2507": 0.00008,
     "qwen/qwen3-coder":                 0.00022,
-    "qwen/qwen3-coder-next":            0.00007000000000000001,
-    "qwen/qwen3-next-80b-a3b-instruct": 0.00008999999999999999,
-    "qwen/qwen3.5-flash-02-23":         0.00006500000000000001
+    "qwen/qwen3-coder-next":            0.00007,
+    "qwen/qwen3-next-80b-a3b-instruct": 0.00009,
+    "qwen/qwen3.5-flash-02-23":         0.000065
   },
   "output": {
     "claude-haiku-4-5":                 0.004,
     "claude-opus-4-7":                  0.075,
     "claude-sonnet-4-5":                0.015,
-    "deepseek/deepseek-v4-flash":       0.00028000000000000003,
+    "deepseek/deepseek-v4-flash":       0.00028,
     "deepseek/deepseek-v4-pro":         0.00087,
     "gemini-2.0-flash":                 0.0004,
     "gemini-2.0-flash-lite":            0.0003,
@@ -367,12 +367,12 @@ prices='{
     "gpt-5.5-pro":                      0.12,
     "mistralai/mistral-small-2603":     0.0006,
     "moonshotai/kimi-k2.5":             0.002,
-    "qwen/qwen3-235b-a22b-2507":        0.00046300000000000003,
+    "qwen/qwen3-235b-a22b-2507":        0.000463,
     "qwen/qwen3-30b-a3b-instruct-2507": 0.00033,
     "qwen/qwen3-coder":                 0.0018,
     "qwen/qwen3-coder-next":            0.0003,
     "qwen/qwen3-next-80b-a3b-instruct": 0.0011,
-    "qwen/qwen3.5-flash-02-23":         0.00026000000000000003
+    "qwen/qwen3.5-flash-02-23":         0.00026
   }
 }'
 # END_GENERATED_PRICES
@@ -452,9 +452,8 @@ if [[ -n "$transcript_path" && -f "$transcript_path" ]]; then
         end
       end
     ' "$transcript_path" 2>/dev/null \
-    | awk 'BEGIN{tot=0; last=0} {tot+=$1; last=$1} END{printf "%.4f %.4f
-", last, tot}'
-  )
+    | awk 'BEGIN{tot=0; last=0} {tot+=$1; last=$1} END{printf "%.4f %.4f\n", last, tot}'
+  ) || true
 fi
 
 # Brand color (#FF6C47) on terminals that grok 24-bit truecolor — that's


### PR DESCRIPTION
Addresses bot comments on WorkWeave PR #7298 (the auto-generated router-pin bump). `install/install.sh` is copied verbatim into `backend/internal/app/syncrouterinstall/install_template.sh` by the `bump-workweave-pin` workflow, so fixing it here propagates downstream on the next bump.

- **install.sh awk printf** — the `\n` escape was rendered as a literal newline when PR #47 inlined `cc-statusline.sh` as a heredoc; restored the escape so the format string compiles on stricter POSIX awks (BSD awk on macOS).
- **`|| true` safety guard** — restored on both `install.sh` and `cc-statusline.sh` after the savings `read -r ... < <(jq | awk)`; without it, `set -euo pipefail` aborts the installer on a malformed transcript.
- **Generated prices block** — rewrote `cmd/genprices/fmtPrice` to round to 6 significant figures before `strconv.FormatFloat`, eliminating IEEE 754 noise like `0.00007099999999999999`; regenerated both files clean and added a unit test (using float64 variables, not untyped constants, so it reproduces the runtime division path).

## Test plan

- `go test ./cmd/genprices/...` — fmtPrice rounding pinned (14/14).
- `go test ./internal/observability/otel/...` — drift guard still passes (86/86).
- `bash -n install/install.sh && bash -n install/cc-statusline.sh` — syntax valid.