### PR TITLE
feat(translate): inject default max_tokens when source omits it (W-1327)

### DIFF
--- a/internal/translate/default_max_tokens_test.go
+++ b/internal/translate/default_max_tokens_test.go
@@ -1,0 +1,172 @@
+package translate_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"workweave/router/internal/router"
+	"workweave/router/internal/translate"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Anthropic Messages requires max_tokens; we inject a per-model default when
+// the source request omits it. defaultMaxOutputTokenCap is 8192; per-model
+// caps in modelMaxOutputTokens floor below that (e.g. gpt-4-turbo at 4096).
+
+func TestAnthropicSameFormat_DefaultMaxTokensInjectedWhenAbsent(t *testing.T) {
+	body := []byte(`{"model":"claude-sonnet-4-20250514","messages":[{"role":"user","content":"hi"}]}`)
+	opts := translate.EmitOptions{
+		TargetModel:  "claude-opus-4-7",
+		Capabilities: router.Lookup("claude-opus-4-7"),
+	}
+	out := parseAndEmit(t, body, "anthropic", opts)
+	assert.Equal(t, float64(8192), out["max_tokens"])
+}
+
+func TestAnthropicSameFormat_ExistingMaxTokensUnchanged(t *testing.T) {
+	body := []byte(`{"model":"claude-sonnet-4-20250514","messages":[{"role":"user","content":"hi"}],"max_tokens":1024}`)
+	opts := translate.EmitOptions{
+		TargetModel:  "claude-opus-4-7",
+		Capabilities: router.Lookup("claude-opus-4-7"),
+	}
+	out := parseAndEmit(t, body, "anthropic", opts)
+	assert.Equal(t, float64(1024), out["max_tokens"])
+}
+
+func TestOpenAISameFormat_DefaultMaxTokensInjectedForNonReasoningTarget(t *testing.T) {
+	body := []byte(`{"model":"gpt-4o","messages":[{"role":"user","content":"hi"}]}`)
+	opts := translate.EmitOptions{
+		TargetModel:  "gpt-4o",
+		Capabilities: router.Lookup("gpt-4o"),
+	}
+	out := parseAndEmit(t, body, "openai", opts)
+	assert.Equal(t, float64(8192), out["max_tokens"])
+	assert.NotContains(t, out, "max_completion_tokens")
+}
+
+func TestOpenAISameFormat_DefaultMaxCompletionTokensInjectedForReasoningTarget(t *testing.T) {
+	body := []byte(`{"model":"gpt-4o","messages":[{"role":"user","content":"hi"}]}`)
+	opts := translate.EmitOptions{
+		TargetModel:  "o3",
+		Capabilities: router.Lookup("o3"),
+	}
+	out := parseAndEmit(t, body, "openai", opts)
+	assert.Equal(t, float64(8192), out["max_completion_tokens"])
+	assert.NotContains(t, out, "max_tokens")
+}
+
+// gpt-4-turbo's cap (4096) is below defaultMaxOutputTokenCap (8192); the
+// default must floor to the model cap so we never inject a value the model
+// will reject.
+func TestOpenAISameFormat_DefaultRespectsLowerPerModelCap(t *testing.T) {
+	body := []byte(`{"model":"gpt-4o","messages":[{"role":"user","content":"hi"}]}`)
+	opts := translate.EmitOptions{
+		TargetModel:  "gpt-4-turbo",
+		Capabilities: router.Lookup("gpt-4-turbo"),
+	}
+	out := parseAndEmit(t, body, "openai", opts)
+	assert.Equal(t, float64(4096), out["max_tokens"])
+}
+
+// gpt-4.1 caps at 32768 which is well above defaultMaxOutputTokenCap (8192);
+// the global cap is the binding floor for the default, not the per-model cap.
+func TestOpenAISameFormat_DefaultCappedByGlobalCap(t *testing.T) {
+	body := []byte(`{"model":"gpt-4o","messages":[{"role":"user","content":"hi"}]}`)
+	opts := translate.EmitOptions{
+		TargetModel:  "gpt-4.1",
+		Capabilities: router.Lookup("gpt-4.1"),
+	}
+	out := parseAndEmit(t, body, "openai", opts)
+	assert.Equal(t, float64(8192), out["max_tokens"])
+}
+
+func TestOpenAISameFormat_DefaultNotInjectedWhenMaxTokensPresent(t *testing.T) {
+	body := []byte(`{"model":"gpt-4o","messages":[{"role":"user","content":"hi"}],"max_tokens":512}`)
+	opts := translate.EmitOptions{
+		TargetModel:  "gpt-4o",
+		Capabilities: router.Lookup("gpt-4o"),
+	}
+	out := parseAndEmit(t, body, "openai", opts)
+	assert.Equal(t, float64(512), out["max_tokens"])
+}
+
+func TestOpenAISameFormat_DefaultNotInjectedWhenMaxCompletionTokensPresent(t *testing.T) {
+	body := []byte(`{"model":"gpt-4o","messages":[{"role":"user","content":"hi"}],"max_completion_tokens":512}`)
+	opts := translate.EmitOptions{
+		TargetModel:  "o3",
+		Capabilities: router.Lookup("o3"),
+	}
+	out := parseAndEmit(t, body, "openai", opts)
+	assert.Equal(t, float64(512), out["max_completion_tokens"])
+	assert.NotContains(t, out, "max_tokens")
+}
+
+// Cross-format Anthropic ← OpenAI: pullMaxTokens already injected a hardcoded
+// 4096 default before this ticket; verify the per-model default replaces it.
+func TestCrossFormat_OpenAIToAnthropic_DefaultMaxTokensInjectedWhenAbsent(t *testing.T) {
+	body := []byte(`{"model":"gpt-4o","messages":[{"role":"user","content":"hi"}]}`)
+	env, err := translate.ParseOpenAI(body)
+	require.NoError(t, err)
+	prep, err := env.PrepareAnthropic(http.Header{}, translate.EmitOptions{
+		TargetModel:  "claude-opus-4-7",
+		Capabilities: router.Lookup("claude-opus-4-7"),
+	})
+	require.NoError(t, err)
+	var out map[string]any
+	require.NoError(t, json.Unmarshal(prep.Body, &out))
+	assert.Equal(t, float64(8192), out["max_tokens"])
+}
+
+// Cross-format Anthropic → OpenAI: source omits max_tokens and target is
+// non-reasoning; injection populates max_tokens before the (no-op) rename.
+func TestCrossFormat_AnthropicToOpenAI_DefaultMaxTokensInjectedWhenAbsent(t *testing.T) {
+	body := []byte(`{"model":"claude-sonnet-4-20250514","messages":[{"role":"user","content":"hi"}]}`)
+	env, err := translate.ParseAnthropic(body)
+	require.NoError(t, err)
+	prep, err := env.PrepareOpenAI(http.Header{}, translate.EmitOptions{
+		TargetModel:  "gpt-4o",
+		Capabilities: router.Lookup("gpt-4o"),
+	})
+	require.NoError(t, err)
+	var out map[string]any
+	require.NoError(t, json.Unmarshal(prep.Body, &out))
+	assert.Equal(t, float64(8192), out["max_tokens"])
+}
+
+// Cross-format Anthropic → OpenAI with reasoning target: injection populates
+// max_tokens, and the existing rename converts it to max_completion_tokens.
+func TestCrossFormat_AnthropicToOpenAI_DefaultMaxCompletionTokensForReasoning(t *testing.T) {
+	body := []byte(`{"model":"claude-sonnet-4-20250514","messages":[{"role":"user","content":"hi"}]}`)
+	env, err := translate.ParseAnthropic(body)
+	require.NoError(t, err)
+	prep, err := env.PrepareOpenAI(http.Header{}, translate.EmitOptions{
+		TargetModel:  "o3",
+		Capabilities: router.Lookup("o3"),
+	})
+	require.NoError(t, err)
+	var out map[string]any
+	require.NoError(t, json.Unmarshal(prep.Body, &out))
+	assert.Equal(t, float64(8192), out["max_completion_tokens"])
+	assert.NotContains(t, out, "max_tokens")
+}
+
+// The default-injection path must not mutate the source body bytes
+// (same invariant as the existing clamp/rename paths).
+func TestAnthropicSameFormat_DefaultInjectionPreservesSourceBytes(t *testing.T) {
+	body := []byte(`{"model":"claude-sonnet-4-20250514","messages":[{"role":"user","content":"hi"}]}`)
+	original := make([]byte, len(body))
+	copy(original, body)
+
+	env, err := translate.ParseAnthropic(body)
+	require.NoError(t, err)
+	_, err = env.PrepareAnthropic(http.Header{}, translate.EmitOptions{
+		TargetModel:  "claude-opus-4-7",
+		Capabilities: router.Lookup("claude-opus-4-7"),
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, original, body)
+}

--- a/internal/translate/emit_anthropic.go
+++ b/internal/translate/emit_anthropic.go
@@ -12,8 +12,6 @@ import (
 	"github.com/tidwall/gjson"
 )
 
-const defaultMaxTokens = 4096
-
 // PrepareAnthropic builds a fully-prepared Anthropic Messages request.
 // Same-format requests use byte-level overrides; cross-format requests
 // pull fields from the parsed map.
@@ -101,7 +99,7 @@ func (e *RequestEnvelope) buildAnthropicFromOpenAI(opts EmitOptions) (map[string
 	if err := e.pullOpenAIMessages(out); err != nil {
 		return nil, err
 	}
-	pullMaxTokens(e.body, out)
+	pullMaxTokens(e.body, out, opts.TargetModel)
 	pullStopSequences(e.body, out)
 	if err := e.pullOpenAITools(out); err != nil {
 		return nil, err
@@ -131,7 +129,7 @@ func (e *RequestEnvelope) pullOpenAIMessages(out map[string]any) error {
 	return nil
 }
 
-func pullMaxTokens(body []byte, out map[string]any) {
+func pullMaxTokens(body []byte, out map[string]any, targetModel string) {
 	if r := gjson.GetBytes(body, "max_tokens"); r.Exists() {
 		out["max_tokens"] = r.Value()
 		return
@@ -140,7 +138,7 @@ func pullMaxTokens(body []byte, out map[string]any) {
 		out["max_tokens"] = r.Value()
 		return
 	}
-	out["max_tokens"] = defaultMaxTokens
+	out["max_tokens"] = defaultOutputTokens(targetModel)
 }
 
 func pullStopSequences(body []byte, out map[string]any) {

--- a/internal/translate/emit_openai.go
+++ b/internal/translate/emit_openai.go
@@ -63,6 +63,8 @@ func (e *RequestEnvelope) buildOpenAIFromAnthropic(opts EmitOptions) ([]byte, er
 	}
 	if r := gjson.GetBytes(e.body, "max_tokens"); r.Exists() {
 		out["max_tokens"] = r.Value()
+	} else {
+		out["max_tokens"] = defaultOutputTokens(opts.TargetModel)
 	}
 
 	if mt, ok := out["max_tokens"]; ok && opts.Capabilities.Supports(router.CapReasoning) {

--- a/internal/translate/envelope.go
+++ b/internal/translate/envelope.go
@@ -228,6 +228,13 @@ type EmitOverrides struct {
 	ClampMaxTokensValue     int64
 	ClampMaxCompTokensValue int64 // applied after SetMaxCompletionTokens
 
+	// DefaultMaxTokensKey / DefaultMaxTokensValue inject the named field only
+	// when it is absent in the source body. Anthropic Messages requires
+	// max_tokens; downstream routing/cost accounting also benefits from a
+	// deterministic value being present.
+	DefaultMaxTokensKey   string
+	DefaultMaxTokensValue int64
+
 	InjectStreamUsage   bool // set stream_options.include_usage = true
 	StripThinkingBlocks bool // filter thinking/redacted_thinking from messages[*].content[*]
 }
@@ -267,6 +274,15 @@ func applyOverrides(body []byte, ov EmitOverrides) ([]byte, error) {
 	}
 	if ov.ClampMaxCompTokensValue > 0 {
 		out = clampFieldBytes(out, "max_completion_tokens", ov.ClampMaxCompTokensValue)
+	}
+
+	if ov.DefaultMaxTokensKey != "" && ov.DefaultMaxTokensValue > 0 {
+		if !gjson.GetBytes(out, ov.DefaultMaxTokensKey).Exists() {
+			out, err = sjson.SetBytes(out, ov.DefaultMaxTokensKey, ov.DefaultMaxTokensValue)
+			if err != nil {
+				return nil, fmt.Errorf("set default %s: %w", ov.DefaultMaxTokensKey, err)
+			}
+		}
 	}
 
 	if ov.InjectStreamUsage {
@@ -395,8 +411,12 @@ func resolveOpenAIOverrides(body []byte, opts EmitOptions) EmitOverrides {
 		ov.DeleteKeys = append(ov.DeleteKeys, "reasoning_effort")
 	}
 
-	if gjson.GetBytes(body, "max_tokens").Exists() && opts.Capabilities.Supports(router.CapReasoning) {
-		if !gjson.GetBytes(body, "max_completion_tokens").Exists() {
+	hasMaxTokens := gjson.GetBytes(body, "max_tokens").Exists()
+	hasMaxComp := gjson.GetBytes(body, "max_completion_tokens").Exists()
+	supportsReasoning := opts.Capabilities.Supports(router.CapReasoning)
+
+	if hasMaxTokens && supportsReasoning {
+		if !hasMaxComp {
 			val := gjson.GetBytes(body, "max_tokens").Int()
 			ov.SetMaxCompletionTokens = &val
 		}
@@ -407,13 +427,22 @@ func resolveOpenAIOverrides(body []byte, opts EmitOptions) EmitOverrides {
 	if cap == 0 {
 		cap = defaultMaxOutputTokenCap
 	}
-	maxTokensDeleted := gjson.GetBytes(body, "max_tokens").Exists() && opts.Capabilities.Supports(router.CapReasoning)
-	if gjson.GetBytes(body, "max_tokens").Exists() && !maxTokensDeleted {
+	maxTokensDeleted := hasMaxTokens && supportsReasoning
+	if hasMaxTokens && !maxTokensDeleted {
 		ov.ClampMaxTokensKey = "max_tokens"
 		ov.ClampMaxTokensValue = int64(cap)
 	}
-	if gjson.GetBytes(body, "max_completion_tokens").Exists() || ov.SetMaxCompletionTokens != nil {
+	if hasMaxComp || ov.SetMaxCompletionTokens != nil {
 		ov.ClampMaxCompTokensValue = int64(cap)
+	}
+
+	if !hasMaxTokens && !hasMaxComp {
+		if supportsReasoning {
+			ov.DefaultMaxTokensKey = "max_completion_tokens"
+		} else {
+			ov.DefaultMaxTokensKey = "max_tokens"
+		}
+		ov.DefaultMaxTokensValue = defaultOutputTokens(opts.TargetModel)
 	}
 
 	if opts.IncludeStreamUsage {
@@ -456,6 +485,11 @@ func resolveAnthropicOverrides(body []byte, opts EmitOptions) EmitOverrides {
 
 	if !opts.Capabilities.Supports(router.CapAdaptiveThinking) && !opts.Capabilities.Supports(router.CapExtendedThinking) {
 		ov.StripThinkingBlocks = true
+	}
+
+	if !gjson.GetBytes(body, "max_tokens").Exists() {
+		ov.DefaultMaxTokensKey = "max_tokens"
+		ov.DefaultMaxTokensValue = defaultOutputTokens(opts.TargetModel)
 	}
 
 	return ov
@@ -511,6 +545,17 @@ var modelMaxOutputTokens = map[string]int{
 }
 
 const defaultMaxOutputTokenCap = 8192
+
+// defaultOutputTokens returns the default max output tokens for a model,
+// floored by the model's own cap and globally at defaultMaxOutputTokenCap.
+// Returns defaultMaxOutputTokenCap for models not in modelMaxOutputTokens.
+// Used to inject a value when the source request omits max_tokens entirely.
+func defaultOutputTokens(model string) int64 {
+	if cap, ok := modelMaxOutputTokens[model]; ok && cap < defaultMaxOutputTokenCap {
+		return int64(cap)
+	}
+	return defaultMaxOutputTokenCap
+}
 
 // clampOutputTokens caps max_tokens/max_completion_tokens in a map. Cross-format only.
 func clampOutputTokens(doc map[string]any, model string) {


### PR DESCRIPTION
## Summary

- Anthropic Messages requires `max_tokens`; previously only the cross-format OpenAI→Anthropic path injected a hardcoded 4096 fallback, so an Anthropic same-format request without `max_tokens` would 400 upstream.
- Same-format OpenAI requests without `max_tokens` / `max_completion_tokens` also left nothing for downstream routing / cost accounting to read.
- This PR introduces a single `defaultOutputTokens(model)` helper — `min(per-model cap, defaultMaxOutputTokenCap=8192)` — and wires it through all four emit paths:
  - Anthropic same-format (`resolveAnthropicOverrides`)
  - OpenAI same-format (`resolveOpenAIOverrides`) — picks `max_completion_tokens` for reasoning targets, `max_tokens` otherwise
  - OpenAI→Anthropic cross-format (`pullMaxTokens` — replaces the hardcoded 4096)
  - Anthropic→OpenAI cross-format (`buildOpenAIFromAnthropic`)
- Adds `EmitOverrides.DefaultMaxTokensKey` / `DefaultMaxTokensValue` for the same-format paths (set-if-absent semantics, mirroring the existing clamp pair).

Required prerequisite for [W-1330](https://linear.app/workweave/issue/W-1330/r2-router-length-conditioned-scoring) (R2-Router length-conditioned scoring), which needs a deterministic `max_tokens` value present on every routed request.

Linear: [W-1327](https://linear.app/workweave/issue/W-1327/inject-default-max-tokens-when-missing)

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `gofmt -l internal/translate/` clean
- [x] `go test ./internal/translate/...` — new tests in `default_max_tokens_test.go` cover:
  - Anthropic same-format: absent → 8192 injected; present → unchanged; source body bytes unchanged after emit
  - OpenAI same-format: absent + non-reasoning target → `max_tokens` injected; absent + reasoning target → `max_completion_tokens` injected; present → unchanged
  - Per-model cap floor: target `gpt-4-turbo` (cap 4096) → default = 4096, not 8192
  - Global cap floor: target `gpt-4.1` (cap 32768) → default = 8192
  - Cross-format both directions: `OpenAI→Anthropic` and `Anthropic→OpenAI` (incl. reasoning rename)
- [x] `go test ./...` (whole repo) green

🤖 Generated with [Claude Code](https://claude.com/claude-code)