### PR TITLE
fix(byok): managed deployments must not fall back to deployment-level keys

### DIFF
--- a/cmd/router/main.go
+++ b/cmd/router/main.go
@@ -117,40 +117,72 @@ func main() {
 
 	providerMap := make(map[string]providers.Client)
 
-	// Anthropic is always registered. With ANTHROPIC_API_KEY the router uses
-	// its own key; without it, the client's auth headers (OAuth / x-api-key)
-	// are passed through to api.anthropic.com directly.
-	anthropicKey := config.GetOr("ANTHROPIC_API_KEY", "")
+	// In managed mode every provider is registered unconditionally with no
+	// deployment-level API key. The proxy service is also flipped into
+	// BYOK-only mode below, so a request without BYOK or client-supplied
+	// credentials for the chosen provider 400s at the scorer rather than
+	// silently spending the platform's API budget on customer traffic.
+	// Self-hosted mode keeps the historical per-env-key gating: an operator
+	// who sets ANTHROPIC_API_KEY/etc. on their own deployment expects those
+	// keys to serve traffic without per-installation BYOK plumbing.
+	byokOnly := deploymentMode == server.DeploymentModeManaged
+
+	// Anthropic is always registered. With ANTHROPIC_API_KEY (selfhosted only)
+	// the router uses its own key; otherwise the client's auth headers
+	// (OAuth / x-api-key) are passed through to api.anthropic.com directly.
+	anthropicKey := ""
+	if !byokOnly {
+		anthropicKey = config.GetOr("ANTHROPIC_API_KEY", "")
+	}
 	providerMap[providers.ProviderAnthropic] = anthropic.NewClient(anthropicKey, anthropic.DefaultBaseURL)
-	if anthropicKey != "" {
+	switch {
+	case byokOnly:
+		logger.Info("Anthropic provider enabled (BYOK only)", "base_url", anthropic.DefaultBaseURL)
+	case anthropicKey != "":
 		logger.Info("Anthropic provider enabled (router key)", "base_url", anthropic.DefaultBaseURL)
-	} else {
+	default:
 		logger.Info("Anthropic provider enabled (client auth passthrough)", "base_url", anthropic.DefaultBaseURL)
 	}
 
-	if openaiKey := config.GetOr("OPENAI_PROVIDER_API_KEY", ""); openaiKey != "" {
+	if byokOnly {
+		openaiBaseURL := config.GetOr("OPENAI_PROVIDER_BASE_URL", openaiProvider.DefaultBaseURL)
+		providerMap[providers.ProviderOpenAI] = openaiProvider.NewClient("", openaiBaseURL)
+		logger.Info("OpenAI provider enabled (BYOK only)", "base_url", openaiBaseURL)
+	} else if openaiKey := config.GetOr("OPENAI_PROVIDER_API_KEY", ""); openaiKey != "" {
 		openaiBaseURL := config.GetOr("OPENAI_PROVIDER_BASE_URL", openaiProvider.DefaultBaseURL)
 		providerMap[providers.ProviderOpenAI] = openaiProvider.NewClient(openaiKey, openaiBaseURL)
 		logger.Info("OpenAI provider enabled", "base_url", openaiBaseURL)
 	}
 
-	if openRouterKey := config.GetOr("OPENROUTER_API_KEY", ""); openRouterKey != "" {
+	if byokOnly {
+		openRouterBaseURL := config.GetOr("OPENROUTER_BASE_URL", openaiCompatProvider.DefaultBaseURL)
+		providerMap[providers.ProviderOpenRouter] = openaiCompatProvider.NewClient("", openRouterBaseURL)
+		logger.Info("OpenRouter provider enabled (BYOK only)", "base_url", openRouterBaseURL)
+	} else if openRouterKey := config.GetOr("OPENROUTER_API_KEY", ""); openRouterKey != "" {
 		openRouterBaseURL := config.GetOr("OPENROUTER_BASE_URL", openaiCompatProvider.DefaultBaseURL)
 		providerMap[providers.ProviderOpenRouter] = openaiCompatProvider.NewClient(openRouterKey, openRouterBaseURL)
 		logger.Info("OpenRouter provider enabled", "base_url", openRouterBaseURL)
 	}
 
-	if fireworksKey := config.GetOr("FIREWORKS_API_KEY", ""); fireworksKey != "" {
+	if byokOnly {
+		fireworksBaseURL := config.GetOr("FIREWORKS_BASE_URL", openaiCompatProvider.FireworksBaseURL)
+		providerMap[providers.ProviderFireworks] = openaiCompatProvider.NewClient("", fireworksBaseURL)
+		logger.Info("Fireworks provider enabled (BYOK only)", "base_url", fireworksBaseURL)
+	} else if fireworksKey := config.GetOr("FIREWORKS_API_KEY", ""); fireworksKey != "" {
 		fireworksBaseURL := config.GetOr("FIREWORKS_BASE_URL", openaiCompatProvider.FireworksBaseURL)
 		providerMap[providers.ProviderFireworks] = openaiCompatProvider.NewClient(fireworksKey, fireworksBaseURL)
 		logger.Info("Fireworks provider enabled", "base_url", fireworksBaseURL)
 	}
 
-	if googleKey := config.GetOr("GOOGLE_PROVIDER_API_KEY", ""); googleKey != "" {
+	if byokOnly {
 		// Native Generative Language REST surface — required for multi-turn
 		// tool use against Gemini 3.x preview models, whose opaque
 		// thought_signature field is not exposed by the OpenAI-compat
 		// surface. See router/internal/providers/google/native_client.go.
+		googleBaseURL := config.GetOr("GOOGLE_PROVIDER_BASE_URL", googleProvider.NativeBaseURL)
+		providerMap[providers.ProviderGoogle] = googleProvider.NewNativeClient("", googleBaseURL)
+		logger.Info("Google (Gemini) native provider enabled (BYOK only)", "base_url", googleBaseURL)
+	} else if googleKey := config.GetOr("GOOGLE_PROVIDER_API_KEY", ""); googleKey != "" {
 		googleBaseURL := config.GetOr("GOOGLE_PROVIDER_BASE_URL", googleProvider.NativeBaseURL)
 		providerMap[providers.ProviderGoogle] = googleProvider.NewNativeClient(googleKey, googleBaseURL)
 		logger.Info("Google (Gemini) native provider enabled", "base_url", googleBaseURL)
@@ -237,7 +269,7 @@ func main() {
 	}
 	logger.Info("Hard-pin model resolved", "provider", hardPinProvider, "model", hardPinModel)
 
-	proxySvc := proxy.NewService(rtr, providerMap, emitter, embedLastUser, stickyTTL, semanticCache, pinStore, hardPinExplore, hardPinProvider, hardPinModel, repo.Telemetry)
+	proxySvc := proxy.NewService(rtr, providerMap, emitter, embedLastUser, stickyTTL, semanticCache, pinStore, hardPinExplore, hardPinProvider, hardPinModel, repo.Telemetry).WithByokOnly(byokOnly)
 
 	engine := gin.New()
 	engine.UnescapePathValues = true

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -62,6 +62,13 @@ type Service struct {
 	// telemetry is an optional repository for persisting per-request telemetry.
 	// Nil disables persistence (e.g. no DB in some test environments).
 	telemetry TelemetryRepository
+	// byokOnly disables the deployment-level credential fallback. When true,
+	// a provider is only eligible for a request if BYOK credentials or
+	// client-supplied (Bearer/x-api-key) credentials are present. Set on
+	// Weave-managed deployments via WithByokOnly so customer requests never
+	// silently consume the platform's API key budget; self-hosted
+	// deployments leave it false so operator-set env keys serve traffic.
+	byokOnly bool
 }
 
 // pinSessionTTL is the sliding TTL written into pinned_until on every
@@ -120,6 +127,15 @@ func NewService(r router.Router, providerMap map[string]providers.Client, emitte
 		hardPinModel:         hardPinModel,
 		telemetry:            telemetry,
 	}
+}
+
+// WithByokOnly enables BYOK-only credential resolution. When on, the proxy
+// service refuses to route a request to any provider for which the caller has
+// not supplied credentials (BYOK or client-supplied Bearer/x-api-key) — the
+// deployment-level env key is ignored even if registered.
+func (s *Service) WithByokOnly(byokOnly bool) *Service {
+	s.byokOnly = byokOnly
+	return s
 }
 
 // MetricsSummary returns aggregated cost/token totals for the given installation and time window.
@@ -699,13 +715,20 @@ func externalKeysFromContext(ctx context.Context) []*auth.ExternalAPIKey {
 // upstream call would 401 on.
 func (s *Service) enabledProvidersForRequest(ctx context.Context, headers http.Header) map[string]struct{} {
 	out := make(map[string]struct{}, len(s.providers))
-	for p := range s.providers {
-		out[p] = struct{}{}
+	// In BYOK-only mode the deployment-level env key never serves customer
+	// traffic, so a registered provider with no per-request creds must not
+	// be eligible — otherwise argmax happily picks it and the upstream call
+	// 401/402s with the platform's exhausted key. Without that mode the
+	// historical baseline stands: every registered provider is eligible.
+	if !s.byokOnly {
+		for p := range s.providers {
+			out[p] = struct{}{}
+		}
 	}
 	for _, k := range externalKeysFromContext(ctx) {
 		out[k.Provider] = struct{}{}
 	}
-	for _, p := range []string{providers.ProviderAnthropic, providers.ProviderOpenAI, providers.ProviderGoogle, providers.ProviderOpenRouter} {
+	for _, p := range []string{providers.ProviderAnthropic, providers.ProviderOpenAI, providers.ProviderGoogle, providers.ProviderOpenRouter, providers.ProviderFireworks} {
 		if _, already := out[p]; already {
 			continue
 		}

--- a/internal/proxy/service_test.go
+++ b/internal/proxy/service_test.go
@@ -390,3 +390,66 @@ func TestService_ProxyOpenAIChatCompletion_NativeOpenRouter(t *testing.T) {
 	assert.Contains(t, rec.Body.String(), `"chat.completion"`,
 		"OpenRouter response is already OpenAI-format and must pass through verbatim")
 }
+
+// TestService_WithByokOnly_FiltersUnauthedProvidersFromScorer asserts the
+// managed-deployment guard: when WithByokOnly(true) is set, a registered
+// provider must NOT appear in req.EnabledProviders unless the caller
+// supplied BYOK credentials or a client-supplied Bearer/x-api-key for that
+// provider. Without this guard, the cluster scorer happily picks
+// e.g. OpenRouter for an installation with no OpenRouter key and the
+// upstream call 402s on the platform's exhausted deployment key —
+// exactly the regression this flag fixes.
+func TestService_WithByokOnly_FiltersUnauthedProvidersFromScorer(t *testing.T) {
+	body := []byte(`{"model":"claude-opus-4-7","messages":[{"role":"user","content":"hi"}]}`)
+	providerMap := map[string]providers.Client{
+		providers.ProviderAnthropic:  &fakeProvider{},
+		providers.ProviderOpenRouter: &fakeProvider{},
+	}
+
+	t.Run("byok-off keeps every registered provider eligible (selfhost baseline)", func(t *testing.T) {
+		fr := &fakeRouter{decision: router.Decision{Provider: providers.ProviderAnthropic, Model: "claude-haiku-4-5"}}
+		svc := proxy.NewService(fr, providerMap, nil, false, 0, nil, nil, false, providers.ProviderAnthropic, "claude-haiku-4-5", nil)
+
+		rec := httptest.NewRecorder()
+		httpReq := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(""))
+		require.NoError(t, svc.ProxyMessages(context.Background(), body, rec, httpReq))
+
+		require.NotNil(t, fr.capturedReq)
+		assert.Contains(t, fr.capturedReq.EnabledProviders, providers.ProviderAnthropic)
+		assert.Contains(t, fr.capturedReq.EnabledProviders, providers.ProviderOpenRouter,
+			"selfhost default: registered providers are eligible without per-request BYOK")
+	})
+
+	t.Run("byok-on with no creds yields empty eligible set", func(t *testing.T) {
+		fr := &fakeRouter{decision: router.Decision{Provider: providers.ProviderAnthropic, Model: "claude-haiku-4-5"}}
+		svc := proxy.NewService(fr, providerMap, nil, false, 0, nil, nil, false, providers.ProviderAnthropic, "claude-haiku-4-5", nil).
+			WithByokOnly(true)
+
+		rec := httptest.NewRecorder()
+		httpReq := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(""))
+		require.NoError(t, svc.ProxyMessages(context.Background(), body, rec, httpReq))
+
+		require.NotNil(t, fr.capturedReq)
+		assert.Empty(t, fr.capturedReq.EnabledProviders,
+			"managed/BYOK-only: a registered provider must not be eligible without BYOK or client-supplied creds")
+	})
+
+	t.Run("byok-on with client-supplied Bearer enables only that provider", func(t *testing.T) {
+		// Anthropic decision so the proxy completes; this subtest only asserts
+		// on req.EnabledProviders captured at Route() time.
+		fr := &fakeRouter{decision: router.Decision{Provider: providers.ProviderAnthropic, Model: "claude-haiku-4-5"}}
+		svc := proxy.NewService(fr, providerMap, nil, false, 0, nil, nil, false, providers.ProviderAnthropic, "claude-haiku-4-5", nil).
+			WithByokOnly(true)
+
+		rec := httptest.NewRecorder()
+		httpReq := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(""))
+		httpReq.Header.Set("Authorization", "Bearer sk-or-v1-customer-key")
+		_ = svc.ProxyMessages(context.Background(), body, rec, httpReq)
+
+		require.NotNil(t, fr.capturedReq)
+		assert.NotContains(t, fr.capturedReq.EnabledProviders, providers.ProviderAnthropic,
+			"managed/BYOK-only: Anthropic must not be eligible without anthropic-specific creds")
+		assert.Contains(t, fr.capturedReq.EnabledProviders, providers.ProviderOpenRouter,
+			"managed/BYOK-only: a client-supplied Bearer for OpenRouter must make it eligible")
+	})
+}


### PR DESCRIPTION
## Summary
- Adds `proxy.Service.WithByokOnly(true)`, set on `ROUTER_DEPLOYMENT_MODE=managed`. When on, `enabledProvidersForRequest` no longer baselines the cluster scorer with the registered-providers set, so a provider is only eligible if the caller supplies a BYOK row OR a client-supplied Bearer/x-api-key for it.
- `cmd/router/main.go` registers all 5 providers unconditionally in managed mode (with empty `apiKey`, since that path is now unreachable). Self-hosted mode keeps the historical per-env-key gating: operator-set keys still serve traffic.
- New `TestService_WithByokOnly_FiltersUnauthedProvidersFromScorer` asserts both states: byok-off keeps registered providers eligible (selfhost baseline); byok-on yields an empty eligible set with no creds, and only the BYOK-matching provider with client-supplied Bearer.

## Why
Production saw 402s like:
```
ProxyMessages complete decision_model=deepseek/deepseek-v4-pro decision_provider=openrouter proxy_err="upstream returned status 402" upstream_status=402
```
The customer org had no OpenRouter BYOK key, but the router still picked OpenRouter (because the platform's `OPENROUTER_API_KEY` was registered) and OpenRouter rejected it on the platform key's exhausted balance. The customer never had a way to fix this — the credential they could provide wasn't being used.

With `WithByokOnly(true)` the scorer doesn't pick OpenRouter for that org; instead, the request 400s at the cluster layer with the existing `cluster.ErrNoEligibleProvider` → "no provider keys available for any deployed model: register a BYOK key or supply a provider Authorization header".

## Test plan
- [x] `go test ./internal/proxy/... -tags=no_onnx` passes (new + existing)
- [x] `go test ./internal/api/... ./internal/server/... ./cmd/... -tags=no_onnx` passes
- [x] `go build ./...` clean
- [ ] After merge: bump WorkWeave gitlink and verify managed prod sees `ErrNoEligibleProvider` instead of upstream 402 for an org with no BYOK

🤖 Generated with [Claude Code](https://claude.com/claude-code)