### PR TITLE
feat(providers): log upstream 4xx body preview for Google native + OpenAI-compat

### DIFF
--- a/internal/providers/google/native_client.go
+++ b/internal/providers/google/native_client.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"workweave/router/internal/observability"
 	"workweave/router/internal/observability/otel"
 	"workweave/router/internal/providers"
 	"workweave/router/internal/providers/httputil"
@@ -94,6 +95,35 @@ func (c *NativeClient) Proxy(ctx context.Context, decision router.Decision, prep
 
 	providers.CopyUpstreamHeaders(w, resp)
 	w.WriteHeader(resp.StatusCode)
+
+	if resp.StatusCode >= 400 {
+		var snip [1024]byte
+		n, _ := io.ReadFull(resp.Body, snip[:])
+		if n > 0 {
+			t.StampUpstreamFirstByte()
+		}
+		_, snipWriteErr := w.Write(snip[:n])
+		rest, copyErr := io.Copy(w, resp.Body)
+		if copyErr == nil {
+			t.StampUpstreamEOF()
+		}
+		logUpstreamStatus(
+			"Upstream Google returned error status",
+			resp.StatusCode,
+			"routed_model", decision.Model,
+			"streaming", stream,
+			"body_preview", string(snip[:n]),
+			"body_total_bytes", int64(n)+rest,
+		)
+		if snipWriteErr != nil {
+			return snipWriteErr
+		}
+		if copyErr != nil {
+			return copyErr
+		}
+		return &providers.UpstreamStatusError{Status: resp.StatusCode}
+	}
+
 	return httputil.StreamBody(resp.Body, resp.StatusCode, w, t)
 }
 
@@ -135,8 +165,41 @@ func (c *NativeClient) Passthrough(ctx context.Context, prep providers.PreparedR
 
 	providers.CopyUpstreamHeaders(w, resp)
 	w.WriteHeader(resp.StatusCode)
+	if resp.StatusCode >= 400 {
+		var snip [1024]byte
+		n, _ := io.ReadFull(resp.Body, snip[:])
+		_, snipWriteErr := w.Write(snip[:n])
+		rest, copyErr := io.Copy(w, resp.Body)
+		logUpstreamStatus(
+			"Upstream Google returned error status (passthrough)",
+			resp.StatusCode,
+			"path", r.URL.Path,
+			"body_preview", string(snip[:n]),
+			"body_total_bytes", int64(n)+rest,
+		)
+		if snipWriteErr != nil {
+			return snipWriteErr
+		}
+		if copyErr != nil {
+			return copyErr
+		}
+		return &providers.UpstreamStatusError{Status: resp.StatusCode}
+	}
 	_, err = io.Copy(w, resp.Body)
 	return err
+}
+
+// logUpstreamStatus emits an Error log for upstream 4xx/5xx, Warn for 429s.
+// Mirrors the Anthropic adapter's helper so non-2xx upstream responses are
+// surfaced to ops with a body preview rather than blackholing into a generic
+// "upstream call failed" string at the client.
+func logUpstreamStatus(msg string, status int, attrs ...any) {
+	merged := append([]any{"status", status}, attrs...)
+	if status >= 500 || (status >= 400 && status != http.StatusTooManyRequests) {
+		observability.Get().Error(msg, merged...)
+		return
+	}
+	observability.Get().Warn(msg, merged...)
 }
 
 // applyAPIKey sets x-goog-api-key from BYOK credentials when present, falling

--- a/internal/providers/openaicompat/client.go
+++ b/internal/providers/openaicompat/client.go
@@ -16,6 +16,7 @@ import (
 	"strings"
 	"time"
 
+	"workweave/router/internal/observability"
 	"workweave/router/internal/observability/otel"
 	"workweave/router/internal/providers"
 	"workweave/router/internal/providers/httputil"
@@ -85,6 +86,35 @@ func (c *Client) Proxy(ctx context.Context, decision router.Decision, prep provi
 
 	providers.CopyUpstreamHeaders(w, resp)
 	w.WriteHeader(resp.StatusCode)
+
+	if resp.StatusCode >= 400 {
+		var snip [1024]byte
+		n, _ := io.ReadFull(resp.Body, snip[:])
+		if n > 0 {
+			t.StampUpstreamFirstByte()
+		}
+		_, snipWriteErr := w.Write(snip[:n])
+		rest, copyErr := io.Copy(w, resp.Body)
+		if copyErr == nil {
+			t.StampUpstreamEOF()
+		}
+		logUpstreamStatus(
+			"Upstream OpenAI-compatible provider returned error status",
+			resp.StatusCode,
+			"base_url", c.baseURL,
+			"routed_model", decision.Model,
+			"body_preview", string(snip[:n]),
+			"body_total_bytes", int64(n)+rest,
+		)
+		if snipWriteErr != nil {
+			return snipWriteErr
+		}
+		if copyErr != nil {
+			return copyErr
+		}
+		return &providers.UpstreamStatusError{Status: resp.StatusCode}
+	}
+
 	return httputil.StreamBody(resp.Body, resp.StatusCode, w, t)
 }
 
@@ -122,8 +152,42 @@ func (c *Client) Passthrough(ctx context.Context, prep providers.PreparedRequest
 
 	providers.CopyUpstreamHeaders(w, resp)
 	w.WriteHeader(resp.StatusCode)
+	if resp.StatusCode >= 400 {
+		var snip [1024]byte
+		n, _ := io.ReadFull(resp.Body, snip[:])
+		_, snipWriteErr := w.Write(snip[:n])
+		rest, copyErr := io.Copy(w, resp.Body)
+		logUpstreamStatus(
+			"Upstream OpenAI-compatible provider returned error status (passthrough)",
+			resp.StatusCode,
+			"base_url", c.baseURL,
+			"path", r.URL.Path,
+			"body_preview", string(snip[:n]),
+			"body_total_bytes", int64(n)+rest,
+		)
+		if snipWriteErr != nil {
+			return snipWriteErr
+		}
+		if copyErr != nil {
+			return copyErr
+		}
+		return &providers.UpstreamStatusError{Status: resp.StatusCode}
+	}
 	_, err = io.Copy(w, resp.Body)
 	return err
+}
+
+// logUpstreamStatus emits an Error log for upstream 4xx/5xx, Warn for 429s.
+// Mirrors the Anthropic adapter's helper so non-2xx upstream responses are
+// surfaced to ops with a body preview rather than blackholing into a generic
+// "upstream call failed" string at the client.
+func logUpstreamStatus(msg string, status int, attrs ...any) {
+	merged := append([]any{"status", status}, attrs...)
+	if status >= 500 || (status >= 400 && status != http.StatusTooManyRequests) {
+		observability.Get().Error(msg, merged...)
+		return
+	}
+	observability.Get().Warn(msg, merged...)
 }
 
 var _ providers.Client = (*Client)(nil)


### PR DESCRIPTION
## Summary
- Adds the Anthropic adapter's 4xx body-preview logging pattern to `internal/providers/google/native_client.go` and `internal/providers/openaicompat/client.go` (covers Google native, OpenRouter, Fireworks, and any custom OpenAI-compat host).
- Reads up to 1KB of the upstream response body, logs `status / routed_model / base_url / body_preview / body_total_bytes`, tees the body through to the client unchanged, and returns the typed `UpstreamStatusError`. 429 stays at Warn; everything else 4xx/5xx logs at Error.

## Why
Prod hit a `proxy_err="upstream returned status 400"` on a translated Anthropic→Google request:
```
ProxyMessages complete decision_model=gemini-3.1-pro-preview decision_provider=google proxy_err="upstream returned status 400" upstream_status=400 has_tools=true estimated_input_tokens=23942
```
The Claude CLI shows only "API Error: 400 upstream call failed", so the actual Google rejection message — which is the only signal that tells us whether it's a tool-schema bug, a token-limit issue, an unsupported field, etc. — was invisible on both ends. The Anthropic adapter already logs a body preview on 4xx; this just gives Google and the OpenAI-compat surface the same affordance.

## Test plan
- [x] `go test ./internal/providers/... -tags=no_onnx` passes
- [x] `go build ./...` clean
- [ ] After merge + gitlink bump: reproduce the 400 in prod, confirm the body preview shows up in GCP logs, identify the translation issue from the Google error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)