### PR TITLE
feat(auth): attribute users by claude_account_uuid when email is missing

### DIFF
--- a/db/migrations/0011_users_account_uuid_attribution.down.sql
+++ b/db/migrations/0011_users_account_uuid_attribution.down.sql
@@ -1,0 +1,19 @@
+BEGIN;
+
+DROP INDEX IF EXISTS router.model_router_users_installation_account_unique;
+
+ALTER TABLE router.model_router_users
+  DROP CONSTRAINT IF EXISTS model_router_users_identity_present;
+
+-- Email-NULL rows would violate NOT NULL on rollback; delete them. They were
+-- only created by the new account_uuid-only path, so dropping them is safe —
+-- the workflow that created them no longer exists post-rollback.
+DELETE FROM router.model_router_users WHERE email IS NULL;
+
+ALTER TABLE router.model_router_users
+  ALTER COLUMN email SET NOT NULL;
+
+COMMENT ON COLUMN router.model_router_users.email IS
+  'Lowercased, trimmed user email (typically git user.email). Application-normalized; column is plain TEXT.';
+
+COMMIT;

--- a/db/migrations/0011_users_account_uuid_attribution.up.sql
+++ b/db/migrations/0011_users_account_uuid_attribution.up.sql
@@ -1,0 +1,37 @@
+BEGIN;
+
+-- Allow attribution by Claude Code account_uuid when the inbound request
+-- carries no email. Claude CLI v2.1.x packs only {device_id, account_uuid,
+-- session_id} into metadata.user_id — there is no email field — so the
+-- previous email-required design silently dropped attribution for every
+-- request from those clients. account_uuid is stable per Claude account and
+-- is enough to identify a seat for dashboard / cost-attribution purposes.
+
+ALTER TABLE router.model_router_users
+  ALTER COLUMN email DROP NOT NULL;
+
+-- Backstop: a row with no identity signal is useless. The application
+-- guarantees this (ResolveAndStashUser early-returns on both-empty input)
+-- but the CHECK constraint keeps the invariant honest against any future
+-- writer.
+ALTER TABLE router.model_router_users
+  ADD CONSTRAINT model_router_users_identity_present
+  CHECK (email IS NOT NULL OR claude_account_uuid IS NOT NULL);
+
+-- The pre-existing partial unique on (installation_id, email)
+-- WHERE deleted_at IS NULL still applies. Postgres treats NULL as distinct
+-- in unique indexes, so multiple email-NULL rows can coexist; the new
+-- partial unique below scopes account-only rows so we don't accumulate
+-- duplicates for the same Claude account on the same installation.
+CREATE UNIQUE INDEX model_router_users_installation_account_unique
+  ON router.model_router_users(installation_id, claude_account_uuid)
+  WHERE email IS NULL
+    AND claude_account_uuid IS NOT NULL
+    AND deleted_at IS NULL;
+
+COMMENT ON COLUMN router.model_router_users.email IS
+  'Lowercased, trimmed user email (typically git user.email). Nullable: '
+  'Claude CLI versions that send only account_uuid in metadata.user_id '
+  'produce email-NULL rows keyed on (installation_id, claude_account_uuid).';
+
+COMMIT;

--- a/db/queries/model_router_users.sql
+++ b/db/queries/model_router_users.sql
@@ -1,8 +1,9 @@
--- Upserts an end-user identity for an installation, refreshing last_seen_at on every
--- hit. claude_account_uuid is overwritten only when the new value is non-NULL so a
--- request from a non-Claude-Code client can't blank out the field. Returns the row
--- so the caller can stash user_id on the request context.
--- name: UpsertModelRouterUser :one
+-- Upserts an end-user identity keyed on (installation_id, email), refreshing
+-- last_seen_at on every hit. claude_account_uuid is overwritten only when
+-- the new value is non-NULL so a request from a non-Claude-Code client
+-- can't blank out the field. Returns the row so the caller can stash
+-- user_id on the request context.
+-- name: UpsertModelRouterUserByEmail :one
 INSERT INTO router.model_router_users (
     installation_id,
     email,
@@ -16,6 +17,29 @@ VALUES (
 ON CONFLICT (installation_id, email) WHERE deleted_at IS NULL DO UPDATE SET
     last_seen_at        = CURRENT_TIMESTAMP,
     claude_account_uuid = COALESCE(EXCLUDED.claude_account_uuid, router.model_router_users.claude_account_uuid)
+RETURNING *;
+
+-- Upserts an end-user identity keyed on (installation_id, claude_account_uuid)
+-- for inbound requests that carry no email. Claude CLI v2.1.x ships only
+-- {device_id, account_uuid, session_id} in metadata.user_id, so the
+-- email-keyed upsert above would silently drop attribution for every such
+-- request. The CONFLICT target matches the partial unique index
+-- model_router_users_installation_account_unique
+-- (WHERE email IS NULL AND claude_account_uuid IS NOT NULL).
+-- name: UpsertModelRouterUserByAccountUUID :one
+INSERT INTO router.model_router_users (
+    installation_id,
+    email,
+    claude_account_uuid
+)
+VALUES (
+    @installation_id::uuid,
+    NULL,
+    @claude_account_uuid::uuid
+)
+ON CONFLICT (installation_id, claude_account_uuid)
+  WHERE email IS NULL AND claude_account_uuid IS NOT NULL AND deleted_at IS NULL
+DO UPDATE SET last_seen_at = CURRENT_TIMESTAMP
 RETURNING *;
 
 -- Single-row read by id; returns sql.ErrNoRows when missing or soft-deleted.

--- a/internal/auth/service.go
+++ b/internal/auth/service.go
@@ -227,10 +227,17 @@ func (s *Service) VerifyAPIKey(ctx context.Context, rawToken string) (*Installat
 	return installation, apiKey, externalKeys, nil
 }
 
-// ResolveAndStashUser upserts a router user keyed on (installationID, email)
-// and stashes the resolved user ID on ctx via UserIDContextKey. Returns the
-// original ctx unchanged when email is empty or the upsert fails — user
-// resolution is best-effort and must never fail an authenticated request.
+// ResolveAndStashUser upserts a router user and stashes the resolved user ID
+// on ctx via UserIDContextKey. Email takes precedence when present:
+// (installationID, email) keys the row and account_uuid enriches it. When
+// email is empty but claudeAccountUUID is present (Claude CLI v2.1.x packs
+// only account_uuid + device_id + session_id into metadata.user_id), the
+// row is keyed on (installationID, claude_account_uuid) with NULL email so
+// per-seat attribution still works.
+//
+// Returns the original ctx unchanged when no identifying signal is present
+// or the upsert fails — user resolution is best-effort and must never fail
+// an authenticated request.
 //
 // Reads through s.userCache: hits skip the DB upsert entirely. The trade-off
 // is that last_seen_at lags by up to the cache TTL, which is fine for a
@@ -239,21 +246,36 @@ func (s *Service) VerifyAPIKey(ctx context.Context, rawToken string) (*Installat
 // Callers normalize email (lower-case, trim) before calling. claudeAccountUUID
 // is optional; pass "" when the client isn't Claude Code.
 func (s *Service) ResolveAndStashUser(ctx context.Context, installationID, email, claudeAccountUUID string) context.Context {
-	if s.users == nil || installationID == "" || email == "" {
+	if s.users == nil || installationID == "" {
 		return ctx
 	}
-	if cached, ok := s.userCache.Get(installationID, email); ok {
+	if email == "" && claudeAccountUUID == "" {
+		return ctx
+	}
+
+	identityKey := userIdentityKey(email, claudeAccountUUID)
+	if cached, ok := s.userCache.Get(installationID, identityKey); ok {
 		return context.WithValue(ctx, UserIDContextKey{}, cached)
 	}
-	var accountPtr *string
-	if claudeAccountUUID != "" {
-		accountPtr = &claudeAccountUUID
+
+	var user *User
+	var err error
+	if email != "" {
+		var accountPtr *string
+		if claudeAccountUUID != "" {
+			accountPtr = &claudeAccountUUID
+		}
+		user, err = s.users.UpsertByEmail(ctx, UpsertUserParams{
+			InstallationID:    installationID,
+			Email:             email,
+			ClaudeAccountUUID: accountPtr,
+		})
+	} else {
+		user, err = s.users.UpsertByAccountUUID(ctx, UpsertUserByAccountUUIDParams{
+			InstallationID:    installationID,
+			ClaudeAccountUUID: claudeAccountUUID,
+		})
 	}
-	user, err := s.users.Upsert(ctx, UpsertUserParams{
-		InstallationID:    installationID,
-		Email:             email,
-		ClaudeAccountUUID: accountPtr,
-	})
 	if err != nil {
 		observability.Get().Warn(
 			"Failed to resolve router user",
@@ -262,8 +284,19 @@ func (s *Service) ResolveAndStashUser(ctx context.Context, installationID, email
 		)
 		return ctx
 	}
-	s.userCache.Set(installationID, email, user.ID)
+	s.userCache.Set(installationID, identityKey, user.ID)
 	return context.WithValue(ctx, UserIDContextKey{}, user.ID)
+}
+
+// userIdentityKey produces a stable cache key for a (email, account_uuid) pair.
+// Email-bearing rows and account-only rows live in disjoint key spaces so a
+// future request from the same seat that finally carries email doesn't
+// false-hit the account-only cache entry.
+func userIdentityKey(email, claudeAccountUUID string) string {
+	if email != "" {
+		return "email:" + email
+	}
+	return "account:" + claudeAccountUUID
 }
 
 // fireMarkUsed runs the last_used_at update off the request path. We use

--- a/internal/auth/user.go
+++ b/internal/auth/user.go
@@ -22,32 +22,48 @@ func UserIDFrom(ctx context.Context) string {
 // authenticates the installation, and User identifies which seat made the request
 // (typically derived from git user.email carried in metadata.user_id or the
 // X-Weave-User-Email header).
+//
+// Email may be empty: Claude CLI versions that pack only account_uuid into
+// metadata.user_id produce email-empty rows attributed by ClaudeAccountUUID.
 type User struct {
 	ID                string
 	InstallationID    string
-	Email             string
+	Email             string // "" when the row is account_uuid-only
 	ClaudeAccountUUID *string
 	FirstSeenAt       time.Time
 	LastSeenAt        time.Time
 	DeletedAt         *time.Time
 }
 
-// UpsertUserParams is the input to UserRepository.Upsert. Email must already be
-// normalized (lowercased + trimmed) by the caller — the unique index is
-// case-sensitive at the database layer.
+// UpsertUserParams is the input to UserRepository.UpsertByEmail. Email must
+// already be normalized (lowercased + trimmed) by the caller — the unique
+// index is case-sensitive at the database layer.
 type UpsertUserParams struct {
 	InstallationID    string
 	Email             string
 	ClaudeAccountUUID *string
 }
 
+// UpsertUserByAccountUUIDParams is the input to UserRepository.UpsertByAccountUUID.
+// Used when the inbound request carries a Claude account_uuid but no email
+// (Claude CLI v2.1.x and similar).
+type UpsertUserByAccountUUIDParams struct {
+	InstallationID    string
+	ClaudeAccountUUID string
+}
+
 // UserRepository is the data-access port for end-user identities. The auth
 // Service writes through this on every authenticated request that carries an
-// email; the dashboard reads through it for listing.
+// identifying signal; the dashboard reads through it for listing.
 type UserRepository interface {
-	// Upsert finds-or-creates a row keyed on (installation_id, email), refreshing
-	// last_seen_at and merging a non-empty claude_account_uuid. Idempotent.
-	Upsert(ctx context.Context, params UpsertUserParams) (*User, error)
+	// UpsertByEmail finds-or-creates a row keyed on (installation_id, email),
+	// refreshing last_seen_at and merging a non-empty claude_account_uuid.
+	// Idempotent.
+	UpsertByEmail(ctx context.Context, params UpsertUserParams) (*User, error)
+	// UpsertByAccountUUID finds-or-creates an email-NULL row keyed on
+	// (installation_id, claude_account_uuid), refreshing last_seen_at.
+	// Idempotent. Used when the inbound request has no email signal.
+	UpsertByAccountUUID(ctx context.Context, params UpsertUserByAccountUUIDParams) (*User, error)
 	Get(ctx context.Context, id string) (*User, error)
 	ListForInstallation(ctx context.Context, installationID string) ([]*User, error)
 }

--- a/internal/auth/user_cache.go
+++ b/internal/auth/user_cache.go
@@ -8,13 +8,18 @@ import (
 	"github.com/hashicorp/golang-lru/v2/expirable"
 )
 
-// UserCache memoizes resolved router user IDs keyed on (installation_id, email)
-// so the hot request path doesn't UPSERT on every call. Cache hits skip the DB
-// entirely; the trade-off is that last_seen_at lags by up to the cache TTL,
-// which is acceptable for a dashboard timestamp.
+// UserCache memoizes resolved router user IDs keyed on
+// (installation_id, identityKey) so the hot request path doesn't UPSERT on
+// every call. identityKey is "email:<addr>" or "account:<uuid>" depending on
+// which signal Claude Code (or another client) supplied — the two key spaces
+// are disjoint so an account-only request never false-hits an email-bearing
+// row, and vice versa.
+//
+// Cache hits skip the DB entirely; the trade-off is that last_seen_at lags
+// by up to the cache TTL, which is acceptable for a dashboard timestamp.
 type UserCache interface {
-	Get(installationID, email string) (string, bool)
-	Set(installationID, email, userID string)
+	Get(installationID, identityKey string) (string, bool)
+	Set(installationID, identityKey, userID string)
 }
 
 // NoOpUserCache is the Null Object — every Get misses, every Set is dropped.
@@ -23,9 +28,10 @@ type NoOpUserCache struct{}
 func (NoOpUserCache) Get(string, string) (string, bool) { return "", false }
 func (NoOpUserCache) Set(string, string, string)        {}
 
-// LRUUserCache wraps an expirable LRU. Keys are sha256(installation_id || email)
-// hex-encoded so the in-memory map doesn't pin user emails as plain strings any
-// longer than necessary.
+// LRUUserCache wraps an expirable LRU. Keys are
+// sha256(installation_id || identityKey) hex-encoded so the in-memory map
+// doesn't pin user emails or account UUIDs as plain strings any longer than
+// necessary.
 type LRUUserCache struct {
 	store *expirable.LRU[string, string]
 }
@@ -36,18 +42,18 @@ func NewLRUUserCache(size int, ttl time.Duration) *LRUUserCache {
 	}
 }
 
-func (c *LRUUserCache) Get(installationID, email string) (string, bool) {
-	return c.store.Get(userCacheKey(installationID, email))
+func (c *LRUUserCache) Get(installationID, identityKey string) (string, bool) {
+	return c.store.Get(userCacheKey(installationID, identityKey))
 }
 
-func (c *LRUUserCache) Set(installationID, email, userID string) {
-	c.store.Add(userCacheKey(installationID, email), userID)
+func (c *LRUUserCache) Set(installationID, identityKey, userID string) {
+	c.store.Add(userCacheKey(installationID, identityKey), userID)
 }
 
-func userCacheKey(installationID, email string) string {
+func userCacheKey(installationID, identityKey string) string {
 	h := sha256.New()
 	h.Write([]byte(installationID))
 	h.Write([]byte{0x00})
-	h.Write([]byte(email))
+	h.Write([]byte(identityKey))
 	return hex.EncodeToString(h.Sum(nil))
 }

--- a/internal/auth/user_test.go
+++ b/internal/auth/user_test.go
@@ -14,16 +14,27 @@ import (
 )
 
 type fakeUserRepo struct {
-	mu      sync.Mutex
-	upserts []auth.UpsertUserParams
-	user    *auth.User
-	err     error
+	mu              sync.Mutex
+	upserts         []auth.UpsertUserParams
+	accountUpserts  []auth.UpsertUserByAccountUUIDParams
+	user            *auth.User
+	err             error
 }
 
-func (f *fakeUserRepo) Upsert(ctx context.Context, params auth.UpsertUserParams) (*auth.User, error) {
+func (f *fakeUserRepo) UpsertByEmail(ctx context.Context, params auth.UpsertUserParams) (*auth.User, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.upserts = append(f.upserts, params)
+	if f.err != nil {
+		return nil, f.err
+	}
+	return f.user, nil
+}
+
+func (f *fakeUserRepo) UpsertByAccountUUID(ctx context.Context, params auth.UpsertUserByAccountUUIDParams) (*auth.User, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.accountUpserts = append(f.accountUpserts, params)
 	if f.err != nil {
 		return nil, f.err
 	}
@@ -65,14 +76,46 @@ func TestResolveAndStashUser_UpsertsAndStashesID(t *testing.T) {
 	assert.Equal(t, "user-42", auth.UserIDFrom(ctx))
 }
 
-func TestResolveAndStashUser_NoEmailIsNoOp(t *testing.T) {
+func TestResolveAndStashUser_NoIdentitySignalIsNoOp(t *testing.T) {
 	repo := &fakeUserRepo{}
 	svc := makeServiceWithUsers(t, repo)
 
 	ctx := svc.ResolveAndStashUser(context.Background(), "inst-1", "", "")
 
 	assert.Empty(t, repo.upserts)
+	assert.Empty(t, repo.accountUpserts)
 	assert.Equal(t, "", auth.UserIDFrom(ctx))
+}
+
+func TestResolveAndStashUser_AccountUUIDOnlyUsesAccountUpsert(t *testing.T) {
+	// Claude CLI v2.1.x packs only {device_id, account_uuid, session_id}
+	// into metadata.user_id — no email. Per-seat attribution must still
+	// work via the account_uuid-keyed upsert path.
+	repo := &fakeUserRepo{user: &auth.User{ID: "user-9", InstallationID: "inst-1"}}
+	svc := makeServiceWithUsers(t, repo)
+
+	ctx := svc.ResolveAndStashUser(context.Background(), "inst-1", "", "2c2aace8-82e9-4cb1-8d1f-2f822da43177")
+
+	assert.Empty(t, repo.upserts, "email-empty input must NOT call UpsertByEmail")
+	require.Len(t, repo.accountUpserts, 1)
+	assert.Equal(t, "inst-1", repo.accountUpserts[0].InstallationID)
+	assert.Equal(t, "2c2aace8-82e9-4cb1-8d1f-2f822da43177", repo.accountUpserts[0].ClaudeAccountUUID)
+	assert.Equal(t, "user-9", auth.UserIDFrom(ctx))
+}
+
+func TestResolveAndStashUser_EmailPathBeatsAccountUUIDPath(t *testing.T) {
+	// When both signals are present, email is the canonical key and the
+	// account_uuid rides along as enrichment on the email-keyed row.
+	// Using UpsertByAccountUUID here would create a duplicate seat.
+	repo := &fakeUserRepo{user: &auth.User{ID: "user-3"}}
+	svc := makeServiceWithUsers(t, repo)
+
+	svc.ResolveAndStashUser(context.Background(), "inst-1", "alice@example.com", "2c2aace8-82e9-4cb1-8d1f-2f822da43177")
+
+	require.Len(t, repo.upserts, 1)
+	assert.Empty(t, repo.accountUpserts, "email-present input must NOT call UpsertByAccountUUID")
+	require.NotNil(t, repo.upserts[0].ClaudeAccountUUID)
+	assert.Equal(t, "2c2aace8-82e9-4cb1-8d1f-2f822da43177", *repo.upserts[0].ClaudeAccountUUID)
 }
 
 func TestResolveAndStashUser_NoInstallationIsNoOp(t *testing.T) {

--- a/internal/auth/user_test.go
+++ b/internal/auth/user_test.go
@@ -14,11 +14,11 @@ import (
 )
 
 type fakeUserRepo struct {
-	mu              sync.Mutex
-	upserts         []auth.UpsertUserParams
-	accountUpserts  []auth.UpsertUserByAccountUUIDParams
-	user            *auth.User
-	err             error
+	mu             sync.Mutex
+	upserts        []auth.UpsertUserParams
+	accountUpserts []auth.UpsertUserByAccountUUIDParams
+	user           *auth.User
+	err            error
 }
 
 func (f *fakeUserRepo) UpsertByEmail(ctx context.Context, params auth.UpsertUserParams) (*auth.User, error) {

--- a/internal/postgres/user_repo.go
+++ b/internal/postgres/user_repo.go
@@ -19,16 +19,36 @@ func NewUserRepository(tx sqlc.DBTX) auth.UserRepository {
 	return &userRepo{tx: tx}
 }
 
-func (r *userRepo) Upsert(ctx context.Context, params auth.UpsertUserParams) (*auth.User, error) {
+func (r *userRepo) UpsertByEmail(ctx context.Context, params auth.UpsertUserParams) (*auth.User, error) {
 	installationID, err := uuid.Parse(params.InstallationID)
 	if err != nil {
 		return nil, err
 	}
 	q := sqlc.New(r.tx)
-	row, err := q.UpsertModelRouterUser(ctx, sqlc.UpsertModelRouterUserParams{
+	row, err := q.UpsertModelRouterUserByEmail(ctx, sqlc.UpsertModelRouterUserByEmailParams{
 		InstallationID:    installationID,
 		Email:             params.Email,
 		ClaudeAccountUUID: claudeAccountUUIDArg(params.ClaudeAccountUUID),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return toAuthUser(row), nil
+}
+
+func (r *userRepo) UpsertByAccountUUID(ctx context.Context, params auth.UpsertUserByAccountUUIDParams) (*auth.User, error) {
+	installationID, err := uuid.Parse(params.InstallationID)
+	if err != nil {
+		return nil, err
+	}
+	accountUUID, err := uuid.Parse(params.ClaudeAccountUUID)
+	if err != nil {
+		return nil, err
+	}
+	q := sqlc.New(r.tx)
+	row, err := q.UpsertModelRouterUserByAccountUUID(ctx, sqlc.UpsertModelRouterUserByAccountUUIDParams{
+		InstallationID:    installationID,
+		ClaudeAccountUUID: accountUUID,
 	})
 	if err != nil {
 		return nil, err
@@ -70,10 +90,12 @@ func toAuthUser(row sqlc.RouterModelRouterUser) *auth.User {
 	user := &auth.User{
 		ID:             row.ID.String(),
 		InstallationID: row.InstallationID.String(),
-		Email:          row.Email,
 		FirstSeenAt:    timestampOrZero(row.FirstSeenAt),
 		LastSeenAt:     timestampOrZero(row.LastSeenAt),
 		DeletedAt:      timestampPtr(row.DeletedAt),
+	}
+	if row.Email != nil {
+		user.Email = *row.Email
 	}
 	if row.ClaudeAccountUUID.Valid {
 		s := uuid.UUID(row.ClaudeAccountUUID.Bytes).String()

--- a/internal/proxy/client_identity.go
+++ b/internal/proxy/client_identity.go
@@ -35,7 +35,8 @@ func ClientIdentityFrom(ctx context.Context) ClientIdentity {
 }
 
 // ResolveUserFromContext is the glue every inbound handler runs after
-// stashing ClientIdentity: pull the email out of ctx, hand it to
+// stashing ClientIdentity: pull whatever identity signal the request
+// carried (email and/or Claude account_uuid) out of ctx, hand it to
 // auth.Service.ResolveAndStashUser, return the (possibly enriched) ctx.
 //
 // Lives here rather than in each handler subpackage so the resolution
@@ -43,14 +44,18 @@ func ClientIdentityFrom(ctx context.Context) ClientIdentity {
 // copies between Anthropic / OpenAI / Gemini handlers would silently
 // break per-protocol attribution.
 //
-// No-op when authSvc, installation, or the email on the existing
-// ClientIdentity is missing; in those cases ctx is returned unchanged.
+// No-op when authSvc / installation are missing, or when the client
+// supplied neither an email nor a Claude account_uuid — there's nothing
+// to attribute a row to in that case. Claude CLI v2.1.x packs only
+// account_uuid (no email), so guarding on email alone here would defeat
+// the entire account_uuid attribution path; Service.ResolveAndStashUser
+// is responsible for picking the right upsert based on what's set.
 func ResolveUserFromContext(ctx context.Context, authSvc *auth.Service, installation *auth.Installation) context.Context {
 	if authSvc == nil || installation == nil {
 		return ctx
 	}
 	id := ClientIdentityFrom(ctx)
-	if id.Email == "" {
+	if id.Email == "" && id.AccountID == "" {
 		return ctx
 	}
 	return authSvc.ResolveAndStashUser(ctx, installation.ID, id.Email, id.AccountID)

--- a/internal/proxy/client_identity_test.go
+++ b/internal/proxy/client_identity_test.go
@@ -1,14 +1,47 @@
 package proxy_test
 
 import (
+	"context"
+	"errors"
 	"strings"
 	"testing"
 
+	"workweave/router/internal/auth"
 	"workweave/router/internal/proxy"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// captureUserRepo is the minimal auth.UserRepository needed to verify that
+// ResolveUserFromContext reaches Service.ResolveAndStashUser. Only the two
+// Upsert methods are exercised by the request path; Get/List are unused.
+type captureUserRepo struct {
+	emailUpserts   []auth.UpsertUserParams
+	accountUpserts []auth.UpsertUserByAccountUUIDParams
+}
+
+func (r *captureUserRepo) UpsertByEmail(ctx context.Context, p auth.UpsertUserParams) (*auth.User, error) {
+	r.emailUpserts = append(r.emailUpserts, p)
+	return &auth.User{ID: "user-from-email"}, nil
+}
+func (r *captureUserRepo) UpsertByAccountUUID(ctx context.Context, p auth.UpsertUserByAccountUUIDParams) (*auth.User, error) {
+	r.accountUpserts = append(r.accountUpserts, p)
+	return &auth.User{ID: "user-from-account"}, nil
+}
+func (r *captureUserRepo) Get(ctx context.Context, id string) (*auth.User, error) {
+	return nil, errors.New("not used")
+}
+func (r *captureUserRepo) ListForInstallation(ctx context.Context, _ string) ([]*auth.User, error) {
+	return nil, errors.New("not used")
+}
+
+// newTestAuthSvc wires a Service with only what ResolveAndStashUser touches
+// (users repo + the no-op user cache). The other interface params aren't
+// exercised by the resolver path so nil is safe.
+func newTestAuthSvc(users auth.UserRepository) *auth.Service {
+	return auth.NewService(nil, nil, nil, users, nil, auth.NoOpUserCache{}, nil)
+}
 
 func TestParseClaudeCodeMetadata_PullsEmail(t *testing.T) {
 	raw := `{"device_id":"dev-1","account_uuid":"acct-1","session_id":"sess-1","email":"User@Example.com"}`
@@ -88,4 +121,56 @@ func TestNormalizeClientIdentifier_RejectsOverLength(t *testing.T) {
 	overCap := strings.Repeat("a", proxy.MaxClientIdentifierLen+1)
 	require.Greater(t, len(overCap), proxy.MaxClientIdentifierLen)
 	assert.Equal(t, "", proxy.NormalizeClientIdentifier(overCap))
+}
+
+func TestResolveUserFromContext_AccountUUIDOnlyReachesUpsert(t *testing.T) {
+	// Regression: an earlier version of this guard returned early on
+	// id.Email == "", which made the new account_uuid-only upsert path
+	// (added for Claude CLI v2.1.x, which packs only account_uuid in
+	// metadata.user_id) completely unreachable from any inbound handler.
+	repo := &captureUserRepo{}
+	svc := newTestAuthSvc(repo)
+	inst := &auth.Installation{ID: "inst-1"}
+
+	ctx := context.WithValue(context.Background(), proxy.ClientIdentityContextKey{}, proxy.ClientIdentity{
+		AccountID: "2c2aace8-82e9-4cb1-8d1f-2f822da43177",
+	})
+	ctx = proxy.ResolveUserFromContext(ctx, svc, inst)
+
+	assert.Empty(t, repo.emailUpserts, "no email signal: must not hit the email-keyed upsert")
+	require.Len(t, repo.accountUpserts, 1, "account_uuid alone must still reach UpsertByAccountUUID")
+	assert.Equal(t, "2c2aace8-82e9-4cb1-8d1f-2f822da43177", repo.accountUpserts[0].ClaudeAccountUUID)
+	assert.Equal(t, "user-from-account", auth.UserIDFrom(ctx))
+}
+
+func TestResolveUserFromContext_EmailOnlyReachesEmailUpsert(t *testing.T) {
+	repo := &captureUserRepo{}
+	svc := newTestAuthSvc(repo)
+	inst := &auth.Installation{ID: "inst-1"}
+
+	ctx := context.WithValue(context.Background(), proxy.ClientIdentityContextKey{}, proxy.ClientIdentity{
+		Email: "alice@example.com",
+	})
+	ctx = proxy.ResolveUserFromContext(ctx, svc, inst)
+
+	require.Len(t, repo.emailUpserts, 1)
+	assert.Empty(t, repo.accountUpserts)
+	assert.Equal(t, "alice@example.com", repo.emailUpserts[0].Email)
+	assert.Equal(t, "user-from-email", auth.UserIDFrom(ctx))
+}
+
+func TestResolveUserFromContext_BothMissingIsNoOp(t *testing.T) {
+	repo := &captureUserRepo{}
+	svc := newTestAuthSvc(repo)
+	inst := &auth.Installation{ID: "inst-1"}
+
+	// ClientIdentity stashed but both Email and AccountID empty: nothing
+	// to attribute, so neither upsert path should fire and the ctx must
+	// flow through with no UserID set.
+	ctx := context.WithValue(context.Background(), proxy.ClientIdentityContextKey{}, proxy.ClientIdentity{})
+	ctx = proxy.ResolveUserFromContext(ctx, svc, inst)
+
+	assert.Empty(t, repo.emailUpserts)
+	assert.Empty(t, repo.accountUpserts)
+	assert.Equal(t, "", auth.UserIDFrom(ctx))
 }

--- a/internal/sqlc/model_router_users.sql.go
+++ b/internal/sqlc/model_router_users.sql.go
@@ -83,7 +83,66 @@ func (q *Queries) ListModelRouterUsersForInstallation(ctx context.Context, insta
 	return items, nil
 }
 
-const upsertModelRouterUser = `-- name: UpsertModelRouterUser :one
+const upsertModelRouterUserByAccountUUID = `-- name: UpsertModelRouterUserByAccountUUID :one
+INSERT INTO router.model_router_users (
+    installation_id,
+    email,
+    claude_account_uuid
+)
+VALUES (
+    $1::uuid,
+    NULL,
+    $2::uuid
+)
+ON CONFLICT (installation_id, claude_account_uuid)
+  WHERE email IS NULL AND claude_account_uuid IS NOT NULL AND deleted_at IS NULL
+DO UPDATE SET last_seen_at = CURRENT_TIMESTAMP
+RETURNING id, installation_id, email, claude_account_uuid, first_seen_at, last_seen_at, deleted_at
+`
+
+type UpsertModelRouterUserByAccountUUIDParams struct {
+	InstallationID    uuid.UUID
+	ClaudeAccountUUID uuid.UUID
+}
+
+// Upserts an end-user identity keyed on (installation_id, claude_account_uuid)
+// for inbound requests that carry no email. Claude CLI v2.1.x ships only
+// {device_id, account_uuid, session_id} in metadata.user_id, so the
+// email-keyed upsert above would silently drop attribution for every such
+// request. The CONFLICT target matches the partial unique index
+// model_router_users_installation_account_unique
+// (WHERE email IS NULL AND claude_account_uuid IS NOT NULL).
+//
+//	INSERT INTO router.model_router_users (
+//	    installation_id,
+//	    email,
+//	    claude_account_uuid
+//	)
+//	VALUES (
+//	    $1::uuid,
+//	    NULL,
+//	    $2::uuid
+//	)
+//	ON CONFLICT (installation_id, claude_account_uuid)
+//	  WHERE email IS NULL AND claude_account_uuid IS NOT NULL AND deleted_at IS NULL
+//	DO UPDATE SET last_seen_at = CURRENT_TIMESTAMP
+//	RETURNING id, installation_id, email, claude_account_uuid, first_seen_at, last_seen_at, deleted_at
+func (q *Queries) UpsertModelRouterUserByAccountUUID(ctx context.Context, arg UpsertModelRouterUserByAccountUUIDParams) (RouterModelRouterUser, error) {
+	row := q.db.QueryRow(ctx, upsertModelRouterUserByAccountUUID, arg.InstallationID, arg.ClaudeAccountUUID)
+	var i RouterModelRouterUser
+	err := row.Scan(
+		&i.ID,
+		&i.InstallationID,
+		&i.Email,
+		&i.ClaudeAccountUUID,
+		&i.FirstSeenAt,
+		&i.LastSeenAt,
+		&i.DeletedAt,
+	)
+	return i, err
+}
+
+const upsertModelRouterUserByEmail = `-- name: UpsertModelRouterUserByEmail :one
 INSERT INTO router.model_router_users (
     installation_id,
     email,
@@ -100,16 +159,17 @@ ON CONFLICT (installation_id, email) WHERE deleted_at IS NULL DO UPDATE SET
 RETURNING id, installation_id, email, claude_account_uuid, first_seen_at, last_seen_at, deleted_at
 `
 
-type UpsertModelRouterUserParams struct {
+type UpsertModelRouterUserByEmailParams struct {
 	InstallationID    uuid.UUID
 	Email             string
 	ClaudeAccountUUID pgtype.UUID
 }
 
-// Upserts an end-user identity for an installation, refreshing last_seen_at on every
-// hit. claude_account_uuid is overwritten only when the new value is non-NULL so a
-// request from a non-Claude-Code client can't blank out the field. Returns the row
-// so the caller can stash user_id on the request context.
+// Upserts an end-user identity keyed on (installation_id, email), refreshing
+// last_seen_at on every hit. claude_account_uuid is overwritten only when
+// the new value is non-NULL so a request from a non-Claude-Code client
+// can't blank out the field. Returns the row so the caller can stash
+// user_id on the request context.
 //
 //	INSERT INTO router.model_router_users (
 //	    installation_id,
@@ -125,8 +185,8 @@ type UpsertModelRouterUserParams struct {
 //	    last_seen_at        = CURRENT_TIMESTAMP,
 //	    claude_account_uuid = COALESCE(EXCLUDED.claude_account_uuid, router.model_router_users.claude_account_uuid)
 //	RETURNING id, installation_id, email, claude_account_uuid, first_seen_at, last_seen_at, deleted_at
-func (q *Queries) UpsertModelRouterUser(ctx context.Context, arg UpsertModelRouterUserParams) (RouterModelRouterUser, error) {
-	row := q.db.QueryRow(ctx, upsertModelRouterUser, arg.InstallationID, arg.Email, arg.ClaudeAccountUUID)
+func (q *Queries) UpsertModelRouterUserByEmail(ctx context.Context, arg UpsertModelRouterUserByEmailParams) (RouterModelRouterUser, error) {
+	row := q.db.QueryRow(ctx, upsertModelRouterUserByEmail, arg.InstallationID, arg.Email, arg.ClaudeAccountUUID)
 	var i RouterModelRouterUser
 	err := row.Scan(
 		&i.ID,

--- a/internal/sqlc/models.go
+++ b/internal/sqlc/models.go
@@ -99,8 +99,8 @@ type RouterModelRouterRequestTelemetry struct {
 type RouterModelRouterUser struct {
 	ID             uuid.UUID
 	InstallationID uuid.UUID
-	// Lowercased, trimmed user email (typically git user.email). Application-normalized; column is plain TEXT.
-	Email string
+	// Lowercased, trimmed user email (typically git user.email). Nullable: Claude CLI versions that send only account_uuid in metadata.user_id produce email-NULL rows keyed on (installation_id, claude_account_uuid).
+	Email *string
 	// Optional Claude Code account_uuid carried in metadata.user_id; informational only.
 	ClaudeAccountUUID pgtype.UUID
 	FirstSeenAt       pgtype.Timestamp


### PR DESCRIPTION
## Summary
Claude CLI v2.1.x packs only `{device_id, account_uuid, session_id}` into `metadata.user_id` — no `email` field — so the existing email-required design silently drops per-seat attribution. `router.model_router_users` stayed empty for active installations, `router_user_id` was always `""` on OTel spans, and the dashboard's per-seat views had nothing to show.

Confirmed by capturing the raw inbound body via a local relay:
```
[metadata.user_id parsed] keys: ['account_uuid', 'device_id', 'session_id']
  - email: <missing>
  - account_uuid: '2c2aace8-…'
```

## Schema (migration 0011)
- `email` becomes nullable on `router.model_router_users`
- `CHECK (email IS NOT NULL OR claude_account_uuid IS NOT NULL)` keeps zero-identity rows from ever being inserted
- New partial unique on `(installation_id, claude_account_uuid) WHERE email IS NULL AND claude_account_uuid IS NOT NULL AND deleted_at IS NULL` — dedups account-only rows
- Existing email partial unique is unchanged; Postgres treats NULL as distinct so the two key spaces don't collide

## Queries
- `UpsertModelRouterUser` → `UpsertModelRouterUserByEmail` (renamed; same semantics)
- New `UpsertModelRouterUserByAccountUUID` for the email-NULL path

## Go
- `UserRepository` grows `UpsertByAccountUUID`
- `ResolveAndStashUser` branches on which signal is present:
  - Email present → email-keyed upsert; account_uuid rides along as enrichment
  - Email empty + account_uuid present → new account-keyed upsert
  - Both empty → no-op (unchanged)
- `UserCache` key space is now `"email:<addr>"` vs `"account:<uuid>"` so an account-only request never false-hits an email-bearing cache entry and vice versa

## Test plan
- [x] `go test -tags=no_onnx ./internal/auth/... ./internal/postgres/... -count=1` passes
- [x] `go test -tags=no_onnx ./...` clean except pre-existing v0.28/v0.29/v0.30 artifact-dim failures
- [x] `go build ./...` clean
- [x] `make generate` produced expected SQLC diff (committed)
- [ ] After merge: verify a row appears in `router.model_router_users` for installation `b56c5517...` after the first request post-deploy (currently zero rows for any Claude CLI v2.1.x user)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
