### PR TITLE
chore(diag): info-level breadcrumbs on user-resolution path

### DIFF
--- a/internal/auth/service.go
+++ b/internal/auth/service.go
@@ -246,18 +246,23 @@ func (s *Service) VerifyAPIKey(ctx context.Context, rawToken string) (*Installat
 // Callers normalize email (lower-case, trim) before calling. claudeAccountUUID
 // is optional; pass "" when the client isn't Claude Code.
 func (s *Service) ResolveAndStashUser(ctx context.Context, installationID, email, claudeAccountUUID string) context.Context {
+	log := observability.Get()
 	if s.users == nil || installationID == "" {
+		log.Info("ResolveAndStashUser bailout", "reason", "nil_users_or_empty_inst", "users_nil", s.users == nil, "inst_empty", installationID == "")
 		return ctx
 	}
 	if email == "" && claudeAccountUUID == "" {
+		log.Info("ResolveAndStashUser bailout", "reason", "no_identity_signal", "installation_id", installationID)
 		return ctx
 	}
 
 	identityKey := userIdentityKey(email, claudeAccountUUID)
 	if cached, ok := s.userCache.Get(installationID, identityKey); ok {
+		log.Info("ResolveAndStashUser cache hit", "installation_id", installationID, "user_id", cached)
 		return context.WithValue(ctx, UserIDContextKey{}, cached)
 	}
 
+	log.Info("ResolveAndStashUser upsert", "installation_id", installationID, "email_present", email != "", "account_present", claudeAccountUUID != "")
 	var user *User
 	var err error
 	if email != "" {
@@ -285,6 +290,7 @@ func (s *Service) ResolveAndStashUser(ctx context.Context, installationID, email
 		return ctx
 	}
 	s.userCache.Set(installationID, identityKey, user.ID)
+	log.Info("ResolveAndStashUser upsert ok", "installation_id", installationID, "user_id", user.ID)
 	return context.WithValue(ctx, UserIDContextKey{}, user.ID)
 }
 

--- a/internal/proxy/client_identity.go
+++ b/internal/proxy/client_identity.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"workweave/router/internal/auth"
+	"workweave/router/internal/observability"
 )
 
 // ClientIdentity holds per-request user identification signals extracted from
@@ -51,13 +52,28 @@ func ClientIdentityFrom(ctx context.Context) ClientIdentity {
 // the entire account_uuid attribution path; Service.ResolveAndStashUser
 // is responsible for picking the right upsert based on what's set.
 func ResolveUserFromContext(ctx context.Context, authSvc *auth.Service, installation *auth.Installation) context.Context {
+	log := observability.Get()
 	if authSvc == nil || installation == nil {
+		log.Info("ResolveUserFromContext bailout",
+			"reason", "nil_dep",
+			"authsvc_nil", authSvc == nil,
+			"installation_nil", installation == nil,
+		)
 		return ctx
 	}
 	id := ClientIdentityFrom(ctx)
 	if id.Email == "" && id.AccountID == "" {
+		log.Info("ResolveUserFromContext bailout",
+			"reason", "no_identity_signal",
+			"installation_id", installation.ID,
+		)
 		return ctx
 	}
+	log.Info("ResolveUserFromContext dispatch",
+		"installation_id", installation.ID,
+		"email_present", id.Email != "",
+		"account_present", id.AccountID != "",
+	)
 	return authSvc.ResolveAndStashUser(ctx, installation.ID, id.Email, id.AccountID)
 }
 


### PR DESCRIPTION
## Why
\`router.model_router_users\` is empty for installation \`b56c5517...\` despite:
- Migration 0011 applied (email nullable, partial unique indexes in place)
- Deployed router commit includes PR #61 (account_uuid path + guard fix)
- Local relay confirms Claude CLI packs \`account_uuid\` into \`metadata.user_id\` on every request
- Requests reach \`ProxyMessages\` (\`http request status=200\` for \"hello there\")
- Zero \`Failed to resolve router user\` warnings in logs

Manual \`INSERT\` directly via the prod DB succeeded → schema/index/SQL are fine. So the Go path either short-circuits before the upsert or upserts silently with no row.

## What
Info-level logs at every fork on the path:
- \`ResolveUserFromContext bailout\` (reason: nil_dep | no_identity_signal)
- \`ResolveUserFromContext dispatch\`
- \`ResolveAndStashUser bailout\` (reason: nil_users_or_empty_inst | no_identity_signal)
- \`ResolveAndStashUser cache hit\`
- \`ResolveAndStashUser upsert\` (entry) / \`upsert ok\` (after success)

After deploy + one request we can read the breadcrumb trail and know exactly which branch is firing.

## Revert plan
Drop the Info lines (or demote to Debug) in a follow-up once the root cause is identified — Info on every request is too noisy for steady state.