### PR TITLE
chore(diag): log metadata.user_id parse in anthropic handler

### DIFF
--- a/internal/api/anthropic/messages.go
+++ b/internal/api/anthropic/messages.go
@@ -138,7 +138,25 @@ func stashClientIdentity(ctx context.Context, h http.Header, body []byte) contex
 		UserAgent: h.Get("User-Agent"),
 		ClientApp: h.Get("X-App"),
 	}
+	observability.Get().Info("anthropic stashClientIdentity",
+		"meta_raw_len", len(metaRaw),
+		"meta_raw_preview", truncate(metaRaw, 200),
+		"parsed_email_present", meta.Email != "",
+		"parsed_account_present", meta.AccountID != "",
+		"parsed_device_present", meta.DeviceID != "",
+		"parsed_account_len", len(meta.AccountID),
+		"final_email_present", id.Email != "",
+		"final_account_present", id.AccountID != "",
+		"header_email_present", h.Get("X-Weave-User-Email") != "",
+	)
 	return context.WithValue(ctx, proxy.ClientIdentityContextKey{}, id)
+}
+
+func truncate(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n]
 }
 
 func writeAnthropicError(c *gin.Context, status int, errType, message string) {


### PR DESCRIPTION
## Why
After PR #63 deployed, prod logs show `ResolveUserFromContext bailout reason=no_identity_signal` for every request — meaning `ClientIdentity.Email` and `ClientIdentity.AccountID` are both empty going into ctx, even though Claude CLI v2.1.x packs `account_uuid` into `metadata.user_id`.

The bailout fires *after* `stashClientIdentity` has already populated the struct, so the signal is being lost in parse/normalize. This patch logs:
- raw `metadata.user_id` length + 200-byte preview
- whether the parsed `meta.AccountID` / `meta.Email` / `meta.DeviceID` were present
- final `id.Email` / `id.AccountID` after normalization

One request after deploy and the logs will name the exact step that drops the signal. Rip this out in a follow-up once the root cause is fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)