### PR TITLE
fix(translate): strip exclusiveMinimum and numeric enums from Gemini tool schemas

### DIFF
--- a/internal/translate/emit_gemini.go
+++ b/internal/translate/emit_gemini.go
@@ -716,6 +716,9 @@ var geminiUnsupportedSchemaKeys = map[string]struct{}{
 	"writeOnly":             {},
 	"examples":              {},
 	"deprecated":            {},
+	"exclusiveMinimum":      {},
+	"exclusiveMaximum":      {},
+	"multipleOf":            {},
 }
 
 // sanitizeSchemaForGemini returns a deep copy of v with JSON Schema fields
@@ -735,6 +738,9 @@ func sanitizeSchemaForGemini(v any) any {
 			if _, drop := geminiUnsupportedSchemaKeys[k]; drop {
 				continue
 			}
+			if k == "enum" && !enumAllStrings(child) {
+				continue
+			}
 			out[k] = sanitizeSchemaForGemini(child)
 		}
 		return out
@@ -747,6 +753,23 @@ func sanitizeSchemaForGemini(v any) any {
 	default:
 		return v
 	}
+}
+
+// enumAllStrings reports whether the enum value is a slice whose entries are
+// all strings. Google's function-calling API requires enum entries to be
+// TYPE_STRING; numeric or mixed enums are rejected with a 400. When this
+// returns false, the enum field is dropped from the sanitized schema.
+func enumAllStrings(v any) bool {
+	arr, ok := v.([]any)
+	if !ok {
+		return false
+	}
+	for _, item := range arr {
+		if _, ok := item.(string); !ok {
+			return false
+		}
+	}
+	return true
 }
 
 func pullAnthropicToolChoiceToGemini(body []byte, out map[string]any) {


### PR DESCRIPTION
## Summary
Two new Gemini 400 failure modes uncovered in prod after PR #62 landed:

```
Unknown name \"exclusiveMinimum\" at 'tools[0].function_declarations[12]...'
Invalid value at '...enum[0]' (TYPE_STRING), 7
```

## What
- Add `exclusiveMinimum` / `exclusiveMaximum` / `multipleOf` to `geminiUnsupportedSchemaKeys` (JSON-Schema-only numeric constraints, not in Google's OpenAPI 3.0 subset).
- Drop `enum` entirely when any entry isn't a string — Google's function-calling API forces enum values to `TYPE_STRING` and rejects numeric/mixed enums with a 400.

## Test plan
- [x] `go build ./...` passes
- [x] `go test -tags=no_onnx ./internal/translate/...` passes
- [ ] After merge + deploy: confirm a Claude Code tools-bearing request to a Gemini decision returns 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)