### PR TITLE
fix: remove ROUTER_DEV_MODE, simplify onboarding, fix port to 8080

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -50,13 +50,9 @@ PORT=8080
 # `managed` skips both (for SaaS deployments with a separate admin frontend).
 ROUTER_DEPLOYMENT_MODE=selfhosted
 
-# REQUIRED in selfhosted mode unless ROUTER_DEV_MODE=true (which defaults
-# to the password "admin" — local dev only).
+# Admin dashboard password. Defaults to "admin" when unset (logs a warning).
+# Set this in any deployment exposed to the internet.
 # ROUTER_ADMIN_PASSWORD=change-me
-
-# Bypass bearer auth on /v1/* and default the admin password to "admin".
-# Local development only.
-ROUTER_DEV_MODE=false
 
 # Cookie security flag for the admin dashboard. Set to `true` only when
 # serving the dashboard over plain HTTP (e.g. local dev without TLS).

--- a/Makefile
+++ b/Makefile
@@ -93,7 +93,7 @@ full-setup: generate-statusline ## Bootstrap router: docker compose + seed + opt
 		docker compose up --build -d; \
 		echo "==> Waiting for the router to become healthy..."; \
 		for i in $$(seq 1 60); do \
-			if curl -fsS --max-time 2 http://localhost:8082/health >/dev/null 2>&1; then \
+			if curl -fsS --max-time 2 http://localhost:8080/health >/dev/null 2>&1; then \
 				echo "    healthy after $${i}s"; \
 				break; \
 			fi; \
@@ -118,16 +118,16 @@ full-setup: generate-statusline ## Bootstrap router: docker compose + seed + opt
 		echo ""; \
 		if [ "$(PLATFORM)" = "cc" ]; then \
 			echo "==> Wiring Claude Code → router..."; \
-			WEAVE_ROUTER_KEY="$$WEAVE_KEY" ./install/install.sh --base-url http://localhost:8082 --scope project --non-interactive; \
+			WEAVE_ROUTER_KEY="$$WEAVE_KEY" ./install/install.sh --base-url http://localhost:8080 --scope project --non-interactive; \
 			echo ""; \
 			echo "Done. Your local setup:"; \
-			echo "  • Router runs on http://localhost:8082"; \
+			echo "  • Router runs on http://localhost:8080"; \
 			echo "  • Weave Router key saved in .weave-router-key (gitignored)"; \
 			echo "  • Claude Code is wired (.claude/settings.json + .claude/settings.local.json)"; \
 			echo ""; \
 			echo "Share with teammates (replace BASE_URL with a host they can reach,"; \
 			echo "e.g. an ngrok tunnel or a deployed router — localhost only works on this machine):"; \
-			echo "  make full-setup PLATFORM=cc KEY=$$WEAVE_KEY BASE_URL=http://localhost:8082"; \
+			echo "  make full-setup PLATFORM=cc KEY=$$WEAVE_KEY BASE_URL=http://localhost:8080"; \
 			echo ""; \
 			echo "Useful follow-ups:"; \
 			echo "  make logs    # tail server logs"; \
@@ -136,16 +136,16 @@ full-setup: generate-statusline ## Bootstrap router: docker compose + seed + opt
 			echo "Your local Weave Router is ready. Set up Claude Code or Cursor:"; \
 			echo ""; \
 			echo "=== Claude Code ==="; \
-			echo "  make full-setup PLATFORM=cc KEY=$$WEAVE_KEY BASE_URL=http://localhost:8082"; \
+			echo "  make full-setup PLATFORM=cc KEY=$$WEAVE_KEY BASE_URL=http://localhost:8080"; \
 			echo ""; \
 			echo "=== Cursor ==="; \
 			echo "  1. Open Cursor Settings > Models > Override OpenAI Base URL"; \
-			echo "     Set to: http://localhost:8082/v1"; \
+			echo "     Set to: http://localhost:8080/v1"; \
 			echo "  2. Add API key: $$WEAVE_KEY"; \
 			echo ""; \
 			echo "Share with teammates (replace BASE_URL with a host they can reach,"; \
 			echo "e.g. an ngrok tunnel or a deployed router — localhost only works on this machine):"; \
-			echo "  make full-setup PLATFORM=cc KEY=$$WEAVE_KEY BASE_URL=http://localhost:8082"; \
+			echo "  make full-setup PLATFORM=cc KEY=$$WEAVE_KEY BASE_URL=http://localhost:8080"; \
 			echo ""; \
 			echo "Useful follow-ups:"; \
 			echo "  make logs    # tail server logs"; \

--- a/README.md
+++ b/README.md
@@ -13,38 +13,36 @@ Together, Fireworks, etc.).
 
 ## Quick start
 
-There are two local-dev paths:
-
-- **[Headless](#headless-quick-start)** — boot the proxy in Docker, hit
-  `/v1/messages` from `curl` or any LLM client. No browser involved.
-- **[With UI](#ui-quick-start)** — same boot, plus the self-hoster
-  admin dashboard at `http://localhost:8082/ui/` for managing API keys,
-  viewing routing decisions, and configuring BYOK provider credentials.
-
-Both paths use Docker Compose (Postgres + router) and `.env.local` for
-secrets. Pick whichever fits.
-
-### Headless quick start
-
 ```bash
-# 1. (Recommended) Add an OpenRouter key — this unlocks the OSS-model
-#    pool the cluster scorer is trained against. See "Configuring API
-#    keys" below for the full set of supported providers.
-echo "OPENROUTER_API_KEY=sk-or-v1-..." >> .env.local
-
-# 2. Boot the stack and seed a router API key (rk_...).
+# Boot Postgres + the router, run migrations, and seed a router API key.
 make full-setup
 ```
 
-`make full-setup` boots Postgres + the router on `http://localhost:8082`,
-runs migrations, seeds one installation, and prints the `rk_...` key on
-stdout. Use that key as a `Bearer` token from any client:
+`make full-setup` starts the stack on `http://localhost:8080`, seeds one
+installation, and prints the `rk_...` key.
+
+**Provider keys — two ways to add them:**
+
+- **Via `.env.local` (no browser needed):** add keys before or after booting and
+  restart the stack. OpenRouter is the recommended baseline — it unlocks the full
+  OSS-model pool the cluster scorer is trained against:
+  ```bash
+  echo "OPENROUTER_API_KEY=sk-or-v1-..." >> .env.local
+  docker compose restart server   # pick up the new key
+  ```
+  See [Configuring API keys](#configuring-api-keys) for all supported providers.
+
+- **Via the dashboard:** open <http://localhost:8080/ui/> (default password:
+  `admin`), navigate to **Provider keys**, and paste in your keys. No restart
+  needed — BYOK keys are stored in Postgres and resolved per-request.
+
+Once you have at least one provider key in place, you can call the router:
 
 ```bash
 ROUTER_KEY=rk_...
 
 # Anthropic Messages format
-curl -sS http://localhost:8082/v1/messages \
+curl -sS http://localhost:8080/v1/messages \
   -H "Authorization: Bearer $ROUTER_KEY" \
   -H "Content-Type: application/json" \
   -d '{
@@ -54,7 +52,7 @@ curl -sS http://localhost:8082/v1/messages \
   }'
 
 # OpenAI Chat Completions format
-curl -sS http://localhost:8082/v1/chat/completions \
+curl -sS http://localhost:8080/v1/chat/completions \
   -H "Authorization: Bearer $ROUTER_KEY" \
   -H "Content-Type: application/json" \
   -d '{
@@ -63,7 +61,7 @@ curl -sS http://localhost:8082/v1/chat/completions \
   }'
 
 # Get the routing decision without proxying upstream
-curl -sS http://localhost:8082/v1/route \
+curl -sS http://localhost:8080/v1/route \
   -H "Authorization: Bearer $ROUTER_KEY" \
   -H "Content-Type: application/json" \
   -d '{"model": "claude-sonnet-4-5", "messages": [{"role":"user","content":"Hello"}]}'
@@ -76,37 +74,10 @@ make logs   # tail server logs (per-request access lines at INFO)
 make down   # stop the stack (keeps the postgres volume)
 ```
 
-### UI quick start
-
-The router ships with a Next.js admin dashboard mounted at `/ui/*` when
-running in self-hosted mode (the default). It needs an admin password to
-boot.
-
-```bash
-# 1. Provider key (same as headless).
-echo "OPENROUTER_API_KEY=sk-or-v1-..." >> .env.local
-
-# 2. Set an admin password for the dashboard.
-echo "ROUTER_ADMIN_PASSWORD=your-strong-password" >> .env.local
-
-# 3. Boot.
-make full-setup
-```
-
-Then open <http://localhost:8082/ui/> and log in with the password you set.
-
-The dashboard covers:
-
-- API-key issuance and rotation (replaces `make seed` for ongoing use).
-- BYOK provider credentials (per-installation upstream keys, encrypted
-  at rest when `EXTERNAL_KEY_ENCRYPTION_KEY` is set — see [BYOK encryption](#byok-encryption)).
-- Live routing-decision feed and aggregate stats.
-- Server config inspection (read-only view of effective env config).
-
-> **Skipping `ROUTER_ADMIN_PASSWORD` in local dev.** Set
-> `ROUTER_DEV_MODE=true` in `.env.local` and the router will boot with
-> the default password `admin`. Don't do this outside local dev — it's a
-> known-default and the router logs a warning at startup.
+> **Dashboard password.** Defaults to `admin` when `ROUTER_ADMIN_PASSWORD`
+> is not set (the router logs a warning). Set it in `.env.local` for any
+> deployment you care about securing:
+> `echo "ROUTER_ADMIN_PASSWORD=your-strong-password" >> .env.local`
 >
 > **Disabling the dashboard entirely.** Set
 > `ROUTER_DEPLOYMENT_MODE=managed` to skip mounting `/ui/*` and the
@@ -115,9 +86,8 @@ The dashboard covers:
 
 ### Wiring Claude Code or Cursor
 
-The headless and UI quick starts both leave you with a router on
-`localhost:8082` and an `rk_...` key. To point Claude Code or Cursor at
-it:
+`make full-setup` leaves you with a router on `localhost:8080` and an
+`rk_...` key. To point Claude Code or Cursor at it:
 
 ```bash
 make full-setup PLATFORM=cc        # auto-wires ~/.claude/settings.json
@@ -128,7 +98,7 @@ Or manually:
 **Claude Code:**
 
 ```bash
-export ANTHROPIC_BASE_URL=http://localhost:8082
+export ANTHROPIC_BASE_URL=http://localhost:8080
 export ANTHROPIC_CUSTOM_HEADERS="X-Weave-Router-Key: rk_..."
 claude
 ```
@@ -136,7 +106,7 @@ claude
 **Cursor:**
 
 1. Open Cursor Settings → Models → Override OpenAI Base URL.
-   Set to `http://localhost:8082/v1`.
+   Set to `http://localhost:8080/v1`.
 2. Add an API key: paste the `rk_...` value.
 
 To wire an already-running router (e.g. a shared/staging deployment)
@@ -193,15 +163,11 @@ only matters for the `make dev` flow.
 | `/validate`                 | GET    | bearer        | Bearer-key validity check. Returns the matched installation on success.             |
 | `/v1/messages`              | POST   | bearer or dev | Anthropic Messages proxy. Routes to a model, dispatches to the upstream provider.   |
 | `/v1/chat/completions`      | POST   | bearer or dev | OpenAI Chat Completions proxy. Same routing logic as `/v1/messages`.                |
-| `/v1/messages/count_tokens` | POST   | bearer or dev | Anthropic passthrough — forwarded as-is.                                            |
-| `/v1/models`                | GET    | bearer or dev | Anthropic passthrough — model availability list.                                    |
-| `/v1/models/:model`         | GET    | bearer or dev | Anthropic passthrough — single-model lookup.                                        |
-| `/v1/route`                 | POST   | bearer or dev | Returns the routing decision (model, provider, reason) without proxying upstream.   |
-| `/v1beta/models/:modelAction` | POST | bearer or dev | Google Gemini native format (`generateContent` / `streamGenerateContent`). Same routing logic as `/v1/messages`. |
-
-"bearer or dev" means auth is required unless `ROUTER_DEV_MODE=true`,
-which bypasses bearer auth on `/v1/*` for local development. `/validate`
-stays protected regardless.
+| `/v1/messages/count_tokens` | POST   | bearer | Anthropic passthrough — forwarded as-is.                                            |
+| `/v1/models`                | GET    | bearer | Anthropic passthrough — model availability list.                                    |
+| `/v1/models/:model`         | GET    | bearer | Anthropic passthrough — single-model lookup.                                        |
+| `/v1/route`                 | POST   | bearer | Returns the routing decision (model, provider, reason) without proxying upstream.   |
+| `/v1beta/models/:modelAction` | POST | bearer | Google Gemini native format (`generateContent` / `streamGenerateContent`). Same routing logic as `/v1/messages`. |
 
 ## Configuring API keys
 
@@ -254,12 +220,11 @@ Set `DATABASE_URL` directly, or compose it from the individual vars:
 
 ### Server
 
-| Variable                    | Default                           | Purpose                                                                                                          |
-| --------------------------- | --------------------------------- | ---------------------------------------------------------------------------------------------------------------- |
-| `PORT`                      | `8080`                            | HTTP listen port.                                                                                                |
-| `ROUTER_DEPLOYMENT_MODE`    | `selfhosted`                      | `selfhosted` mounts `/ui/*` and `/admin/v1/*`. `managed` skips both (for SaaS deployments with a separate admin UI). |
-| `ROUTER_ADMIN_PASSWORD`     | *(required in `selfhosted` mode)* | Password for the admin dashboard. The router refuses to boot without it unless `ROUTER_DEV_MODE=true`.           |
-| `ROUTER_DEV_MODE`           | `false`                           | Bypass bearer auth on `/v1/*` and default the admin password to `admin`. Local dev only.                         |
+| Variable                    | Default      | Purpose                                                                                                          |
+| --------------------------- | ------------ | ---------------------------------------------------------------------------------------------------------------- |
+| `PORT`                      | `8080`       | HTTP listen port.                                                                                                |
+| `ROUTER_DEPLOYMENT_MODE`    | `selfhosted` | `selfhosted` mounts `/ui/*` and `/admin/v1/*`. `managed` skips both (for SaaS deployments with a separate admin UI). |
+| `ROUTER_ADMIN_PASSWORD`     | `admin`      | Password for the admin dashboard. Defaults to `admin` with a warning when unset — set this for any internet-facing deployment. |
 
 ### Routing
 

--- a/cmd/router/main.go
+++ b/cmd/router/main.go
@@ -77,8 +77,6 @@ func main() {
 	}
 	defer pool.Close()
 
-	devMode := config.GetOr("ROUTER_DEV_MODE", "false") == "true"
-
 	// Deployment mode gates the self-hoster dashboard + /admin/v1/* API.
 	// Default is selfhosted so docker-compose / bare-binary deployments
 	// "just work"; Weave-managed Cloud Run services explicitly set
@@ -205,21 +203,15 @@ func main() {
 	userCache := auth.NewLRUUserCache(50000, 10*time.Minute)
 	authSvc := auth.NewService(repo.Installations, repo.APIKeys, repo.ExternalAPIKeys, repo.Users, cache, userCache, time.Now).WithEncryptor(encryptor)
 
-	// Admin dashboard password. Required outside dev mode so a self-hoster
-	// who simply runs the binary cannot end up with an unauthenticated
-	// dashboard exposed to the internet. In dev mode we fall back to a
-	// well-known default and warn loudly. In managed mode the dashboard
-	// is not mounted at all, so the password is irrelevant.
+	// Admin dashboard password. In managed mode the dashboard is not mounted
+	// at all so the password is irrelevant. In selfhosted mode, fall back to
+	// "admin" when unset and warn — operators that care about securing the
+	// dashboard should always set ROUTER_ADMIN_PASSWORD explicitly.
 	if deploymentMode == server.DeploymentModeSelfHosted {
 		adminPassword := config.GetOr("ROUTER_ADMIN_PASSWORD", "")
 		if adminPassword == "" {
-			if !devMode {
-				err := errors.New("ROUTER_ADMIN_PASSWORD not set; refusing to boot without admin dashboard credentials (set ROUTER_DEV_MODE=true to use the default 'admin' password in local dev, or ROUTER_DEPLOYMENT_MODE=managed to disable the dashboard)")
-				logger.Error("Refusing to boot without admin password", "err", err)
-				panic(err)
-			}
 			adminPassword = "admin"
-			logger.Warn("ROUTER_ADMIN_PASSWORD not set; using default 'admin' (ROUTER_DEV_MODE=true)")
+			logger.Warn("ROUTER_ADMIN_PASSWORD not set; using default 'admin'. Set ROUTER_ADMIN_PASSWORD to secure the dashboard.")
 		}
 		authSvc.WithAdminPassword(adminPassword)
 	}
@@ -280,10 +272,7 @@ func main() {
 		gin.Recovery(),
 	)
 
-	if devMode {
-		logger.Info("ROUTER_DEV_MODE=true; bypassing bearer auth on /v1/* (DO NOT use in production)")
-	}
-	server.Register(engine, authSvc, proxySvc, devMode, deploymentMode)
+	server.Register(engine, authSvc, proxySvc, deploymentMode)
 
 	srv := &http.Server{
 		Addr:    ":" + config.GetOr("PORT", "8080"),

--- a/cmd/seed/main.go
+++ b/cmd/seed/main.go
@@ -25,7 +25,7 @@ const (
 	defaultOrgID = "local-dev"
 	defaultName  = "local-dev-seed"
 	createdBy    = "make seed"
-	baseURL      = "http://localhost:8082"
+	baseURL      = "http://localhost:8080"
 )
 
 func main() {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,8 +6,8 @@
 #   docker compose up --build
 #
 # Health checks:
-#   curl http://localhost:8082/health
-#   curl -H 'Authorization: Bearer rk_invalid' http://localhost:8082/validate  # 401
+#   curl http://localhost:8080/health
+#   curl -H 'Authorization: Bearer rk_invalid' http://localhost:8080/validate  # 401
 #
 # To seed an installation + API key for testing:
 #   docker compose run --rm seed
@@ -84,12 +84,6 @@ services:
       DATABASE_URL: postgres://router:router@postgres:5432/router?sslmode=disable
       PORT: "8080"
       LOG_LEVEL: info
-      # Local docker-compose is for dev only — bypass router-side bearer auth
-      # on /v1/* so `install.sh --local` and ad-hoc curl just work without
-      # seeding a key. install.sh's --local flag assumes this. Override by
-      # setting ROUTER_DEV_MODE=false in .env.local (then run
-      # `docker compose run --rm seed` and use the printed rk_ token).
-      ROUTER_DEV_MODE: "true"
       # .env.development sets ROUTER_ONNX_ASSETS_DIR to a repo-relative path
       # that's correct for `make dev` outside Docker but wrong inside the
       # container, where the Dockerfile populates /opt/router/assets/. The
@@ -102,10 +96,8 @@ services:
       # that doesn't exist inside the container. The Dockerfile copies
       # libonnxruntime.so to /usr/lib which is on the default linker path.
       ROUTER_ONNX_LIBRARY_DIR: /usr/lib
-    # Host port 8082 matches the .env.development default for local non-docker
-    # runs, so the same curl commands work against either.
     ports:
-      - "8082:8080"
+      - "8080:8080"
     restart: unless-stopped
 
   # One-shot seed runner. Creates a local-dev installation + API key and

--- a/install/README.md
+++ b/install/README.md
@@ -35,19 +35,18 @@ non-interactive installs).
 ### Self-hosted via `docker compose` (zero-config)
 
 If you're running the router locally with the bundled `docker-compose.yml`
-(`ROUTER_DEV_MODE=true` on `localhost:8082`), use the shortcut:
+(`localhost:8080`), use the shortcut:
 
 ```bash
 cd router
-docker compose up -d            # start the router
+make full-setup                 # boot the stack and seed a router key
 make install-cc                 # → ./install/install.sh --local
 claude                          # routes through your local router
 ```
 
-`make install-cc` is just a wrapper around `./install/install.sh --local`,
-which is itself shorthand for
-`--base-url http://localhost:8082 --dev-mode`. Use the long form if you want
-to mix-and-match flags (e.g. project scope on a local router):
+`make install-cc` is a wrapper around `./install/install.sh --local`,
+which is shorthand for `--base-url http://localhost:8080`. Use the long
+form if you want to mix-and-match flags (e.g. project scope on a local router):
 
 ```bash
 ./router/install/install.sh --local --scope project
@@ -107,9 +106,8 @@ The `install.sh --scope project` step only needs to run once per checkout
 | Flag                       | Default                       | Meaning                                                                |
 | -------------------------- | ----------------------------- | ---------------------------------------------------------------------- |
 | `--scope user\|project`    | interactive prompt (default `user`) | User-level install (everywhere) vs project-level (this repo only). If omitted on a TTY, the installer asks; defaults to `user` non-interactively. |
-| `--local`                  | off                           | Shortcut for the bundled docker-compose router (`localhost:8082`, dev mode). |
+| `--local`                  | off                           | Shortcut for the bundled docker-compose router (`localhost:8080`).      |
 | `--base-url <url>`         | `https://router.weave.ai`     | Override the router endpoint. Use for self-hosted / custom port.        |
-| `--dev-mode`               | off                           | Router has `ROUTER_DEV_MODE=true`; skip the API key prompt entirely.    |
 | `--non-interactive`        | off                           | Fail if `$WEAVE_ROUTER_KEY` isn't set instead of prompting. CI-friendly. |
 
 Override the default base URL globally by setting `$WEAVE_ROUTER_URL` before

--- a/install/install.sh
+++ b/install/install.sh
@@ -18,8 +18,8 @@
 #   ./install.sh                                  # hosted router, user scope
 #   ./install.sh --scope project                  # commit-with-team install
 #   ./install.sh --dir /tmp/my-sandbox            # isolated throwaway install
-#   ./install.sh --local                          # local router on localhost:8080, dev-mode
-#   ./install.sh --base-url http://localhost:8080 # self-hosted, custom port / non-dev-mode
+#   ./install.sh --local                          # local router on localhost:8080
+#   ./install.sh --base-url http://localhost:8080 # self-hosted, custom port
 #   ./install.sh --non-interactive                # require WEAVE_ROUTER_KEY env var
 #
 #   curl -fsSL https://weave.ai/cc/install.sh | sh
@@ -38,7 +38,6 @@ scope_explicit="false"
 install_dir=""
 base_url=""
 non_interactive="false"
-dev_mode="false"
 router_key_header="X-Weave-Router-Key"
 
 # ---------- helpers ----------
@@ -90,14 +89,9 @@ while [ $# -gt 0 ]; do
       base_url="${2:-}"; shift 2
       [ -n "$base_url" ] || { err "--base-url requires a value"; exit 2; }
       ;;
-    --dev-mode)
-      dev_mode="true"; shift
-      ;;
     --local)
-      # Shorthand for local dev: ROUTER_DEV_MODE=true on localhost:8080
-      # (matches `wv mr` / `make dev` default PORT). No key required.
+      # Shorthand for local dev: localhost:8080 (matches `wv mr` / `make dev` default PORT).
       base_url="http://localhost:8080"
-      dev_mode="true"
       shift
       ;;
     --non-interactive)
@@ -215,10 +209,7 @@ mkdir -p "$settings_dir" "$statusline_dir"
 # ---------- token handling ----------
 
 api_key=""
-if [ "$dev_mode" = "true" ]; then
-  info "Dev mode — skipping API key (router has ROUTER_DEV_MODE=true)."
-else
-  if [ -n "${WEAVE_ROUTER_KEY:-}" ]; then
+if [ -n "${WEAVE_ROUTER_KEY:-}" ]; then
     api_key="$WEAVE_ROUTER_KEY"
     info "Using WEAVE_ROUTER_KEY from environment."
   elif [ "$non_interactive" = "true" ]; then
@@ -244,7 +235,6 @@ else
     printf "\n"
     [ -n "$api_key" ] || { err "no key provided"; exit 1; }
   fi
-fi
 
 # ---------- write the statusline script ----------
 
@@ -511,11 +501,6 @@ if [ "$scope" = "project" ] && [ -z "$install_dir" ]; then
     env: { ANTHROPIC_BASE_URL: $url },
     statusLine: { type: "command", command: $sl }
   }' >"$tmp_patch"
-elif [ "$dev_mode" = "true" ]; then
-  jq -n --arg url "$base_url" --arg sl "$statusline_path_for_settings" '{
-    env: { ANTHROPIC_BASE_URL: $url },
-    statusLine: { type: "command", command: $sl }
-  }' >"$tmp_patch"
 else
   jq -n --arg url "$base_url" --arg header "$router_key_header: $api_key" --arg sl "$statusline_path_for_settings" '{
     env: { ANTHROPIC_BASE_URL: $url, ANTHROPIC_CUSTOM_HEADERS: $header },
@@ -542,7 +527,7 @@ else
 fi
 ok "Settings written to $settings_file"
 
-if [ "$scope" = "project" ] && [ -z "$install_dir" ] && [ "$dev_mode" != "true" ]; then
+if [ "$scope" = "project" ] && [ -z "$install_dir" ]; then
   jq -n --arg header "$router_key_header: $api_key" '{
     env: { ANTHROPIC_CUSTOM_HEADERS: $header }
   }' >"$tmp_patch"
@@ -591,7 +576,7 @@ else
   warn "Could not reach $base_url/health within 5s. Settings are written; verify the router is running."
 fi
 
-if [ "$dev_mode" != "true" ] && [ -n "$api_key" ]; then
+if [ -n "$api_key" ]; then
   # Pass the router key via stdin (`@-`) instead of a -H argument so the key
   # never appears in the process arg list (visible via `ps` / /proc to other
   # local users on shared machines).
@@ -599,7 +584,7 @@ if [ "$dev_mode" != "true" ] && [ -n "$api_key" ]; then
       | curl -fsS --max-time 5 --header @- "$base_url/validate" >/dev/null 2>&1; then
     ok "API key validated."
   else
-    warn "Router rejected the API key (check it matches the dashboard, or pass --dev-mode for a local ROUTER_DEV_MODE server)."
+    warn "Router rejected the API key (check it matches the dashboard at $base_url/ui/)."
   fi
 fi
 
@@ -616,10 +601,7 @@ if [ "$scope" = "project" ]; then
     echo "  Commit .claude/settings.json + the .gitignore changes."
     echo "  Local helpers/settings are gitignored — each teammate runs"
     echo "  './router/install/install.sh --scope project' once after cloning."
-    if [ "$dev_mode" != "true" ]; then
-      echo "  Each teammate also adds this to their shell rc:"
-      echo "    export WEAVE_ROUTER_KEY=rk_..."
-    fi
+    echo "  Each teammate also sets WEAVE_ROUTER_KEY=rk_... or pastes it when prompted."
     echo "  Uninstall with: $script_dir/uninstall.sh --scope project"
   fi
 elif [ -n "$install_dir" ]; then

--- a/internal/api/admin/config.go
+++ b/internal/api/admin/config.go
@@ -14,7 +14,6 @@ type configResponse struct {
 	EmbedLastUserMsg     bool   `json:"embed_last_user_message"`
 	StickyDecisionTTL    string `json:"sticky_decision_ttl_ms"`
 	OtelEnabled          bool   `json:"otel_enabled"`
-	DevMode              bool   `json:"dev_mode"`
 	SemanticCacheEnabled bool   `json:"semantic_cache_enabled"`
 }
 
@@ -30,7 +29,6 @@ func ConfigHandler(c *gin.Context) {
 		EmbedLastUserMsg:     config.GetOr("ROUTER_EMBED_LAST_USER_MESSAGE", "false") == "true",
 		StickyDecisionTTL:    config.GetOr("ROUTER_STICKY_DECISION_TTL_MS", "0"),
 		OtelEnabled:          config.GetOr("OTEL_EXPORTER_OTLP_ENDPOINT", "") != "",
-		DevMode:              config.GetOr("ROUTER_DEV_MODE", "false") == "true",
 		SemanticCacheEnabled: config.GetOr("ROUTER_SEMANTIC_CACHE_ENABLED", "true") == "true",
 	})
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -40,10 +40,9 @@ const (
 	DeploymentModeManaged DeploymentMode = "managed"
 )
 
-// Register wires routes onto the engine. devModeNoAuth skips bearer-auth on
-// /v1/* for local development. In managed mode the dashboard + /admin/v1/*
-// routes are not registered at all.
-func Register(engine *gin.Engine, authSvc *auth.Service, proxySvc *proxy.Service, devModeNoAuth bool, mode DeploymentMode) {
+// Register wires routes onto the engine. In managed mode the dashboard +
+// /admin/v1/* routes are not registered at all.
+func Register(engine *gin.Engine, authSvc *auth.Service, proxySvc *proxy.Service, mode DeploymentMode) {
 	engine.GET("/health", middleware.WithTimeout(healthTimeout), admin.HealthHandler)
 
 	// /validate is a token-validity probe used by clients (not the dashboard), so it stays mounted in both modes.
@@ -79,47 +78,39 @@ func Register(engine *gin.Engine, authSvc *auth.Service, proxySvc *proxy.Service
 		mgmt.GET("/config", admin.ConfigHandler)
 	}
 
-	messagesAuth := []gin.HandlerFunc{middleware.WithTimingEntry(), middleware.WithTimeout(messagesTimeout)}
-	if !devModeNoAuth {
-		messagesAuth = append(messagesAuth, middleware.WithAuth(authSvc))
-	}
-	messagesAuth = append(messagesAuth,
+	messagesGroup := engine.Group("",
+		middleware.WithTimingEntry(),
+		middleware.WithTimeout(messagesTimeout),
+		middleware.WithAuth(authSvc),
 		middleware.WithEmbedLastUserMessageOverride(),
 		middleware.WithClusterVersionOverride(),
 	)
-	messagesGroup := engine.Group("", messagesAuth...)
 	messagesGroup.POST("/v1/messages", anthropicapi.MessagesHandler(proxySvc, authSvc))
 
-	chatCompletionAuth := []gin.HandlerFunc{middleware.WithTimingEntry(), middleware.WithTimeout(chatCompletionTimeout)}
-	if !devModeNoAuth {
-		chatCompletionAuth = append(chatCompletionAuth, middleware.WithAuth(authSvc))
-	}
-	chatCompletionAuth = append(chatCompletionAuth,
+	chatCompletionGroup := engine.Group("",
+		middleware.WithTimingEntry(),
+		middleware.WithTimeout(chatCompletionTimeout),
+		middleware.WithAuth(authSvc),
 		middleware.WithEmbedLastUserMessageOverride(),
 		middleware.WithClusterVersionOverride(),
 	)
-	chatCompletionGroup := engine.Group("", chatCompletionAuth...)
 	chatCompletionGroup.POST("/v1/chat/completions", openaiapi.ChatCompletionHandler(proxySvc, authSvc))
 	// Action suffix (:generateContent or :streamGenerateContent) lives inside modelAction because Gin treats `:` outside the leading position as a literal.
 	chatCompletionGroup.POST("/v1beta/models/:modelAction", geminiapi.GenerateContentHandler(proxySvc, authSvc))
 
-	passthroughAuth := []gin.HandlerFunc{middleware.WithTimeout(passthroughTimeout)}
-	if !devModeNoAuth {
-		passthroughAuth = append(passthroughAuth, middleware.WithAuth(authSvc))
-	}
-	passthroughGroup := engine.Group("", passthroughAuth...)
+	passthroughGroup := engine.Group("",
+		middleware.WithTimeout(passthroughTimeout),
+		middleware.WithAuth(authSvc),
+	)
 	passthroughGroup.POST("/v1/messages/count_tokens", anthropicapi.PassthroughHandler(proxySvc))
 	passthroughGroup.GET("/v1/models", anthropicapi.PassthroughHandler(proxySvc))
 	passthroughGroup.GET("/v1/models/:model", anthropicapi.PassthroughHandler(proxySvc))
 
-	routeAuth := []gin.HandlerFunc{middleware.WithTimeout(routeTimeout)}
-	if !devModeNoAuth {
-		routeAuth = append(routeAuth, middleware.WithAuth(authSvc))
-	}
-	routeAuth = append(routeAuth,
+	routeGroup := engine.Group("",
+		middleware.WithTimeout(routeTimeout),
+		middleware.WithAuth(authSvc),
 		middleware.WithEmbedLastUserMessageOverride(),
 		middleware.WithClusterVersionOverride(),
 	)
-	routeGroup := engine.Group("", routeAuth...)
 	routeGroup.POST("/v1/route", anthropicapi.RouteHandler(proxySvc))
 }

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -55,7 +55,7 @@ func TestRegister_DeploymentMode(t *testing.T) {
 	t.Run("selfhosted mounts dashboard and product routes", func(t *testing.T) {
 		engine := gin.New()
 		// Nil services are fine: engine.Routes() inspection never invokes the closure-captured handlers.
-		server.Register(engine, nil, nil, false, server.DeploymentModeSelfHosted)
+		server.Register(engine, nil, nil, server.DeploymentModeSelfHosted)
 		got := routeSet(engine)
 		for _, want := range productRoutes {
 			assert.Contains(t, got, want, "product route missing in selfhosted mode")
@@ -67,7 +67,7 @@ func TestRegister_DeploymentMode(t *testing.T) {
 
 	t.Run("managed skips dashboard but keeps product routes", func(t *testing.T) {
 		engine := gin.New()
-		server.Register(engine, nil, nil, false, server.DeploymentModeManaged)
+		server.Register(engine, nil, nil, server.DeploymentModeManaged)
 		got := routeSet(engine)
 		for _, want := range productRoutes {
 			assert.Contains(t, got, want, "product route missing in managed mode")


### PR DESCRIPTION
## Summary

- **Remove `ROUTER_DEV_MODE`**: bearer auth is now always enforced on `/v1/*`; the admin dashboard password defaults to `"admin"` with a startup warning instead of panicking when unset. Removes the `devModeNoAuth bool` parameter from `server.Register` and cleans up all dead conditional auth blocks.
- **Fix port**: docker-compose maps `8080:8080` (was `8082:8080`); all curl examples, seed output, install instructions, and `install.sh --local` updated to match.
- **Simplify README quick start**: collapsed two paths (headless + UI) into one. `make full-setup` → open dashboard → add keys. Also documents the `.env.local` path for CLI-only users who don't want to open a browser.
- **Remove `--dev-mode` from `install.sh`**: the flag assumed a ROUTER_DEV_MODE server that no longer exists; cleaned up related dead code throughout.

## Test plan

- [ ] `go build -tags no_onnx ./...` passes
- [ ] `go test -tags no_onnx ./...` passes
- [ ] `make full-setup` boots, seeds an `rk_` key, and dashboard is accessible at `http://localhost:8080/ui/`
- [ ] `install.sh --local` no longer prompts for dev-mode behavior; requires a valid `rk_` key

🤖 Generated with [Claude Code](https://claude.com/claude-code)