### PR TITLE
fix: remove redundant .weave-router-key file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,9 +63,6 @@ node_modules/
 .next/
 tsconfig.tsbuildinfo
 
-# Dashboard router admin key (issued by `wv mr seed-key`, never commit)
-.weave-router-key
-
 # Eval results (stored in GCS, not git)
 eval/results/
 scripts/results/

--- a/Makefile
+++ b/Makefile
@@ -112,9 +112,6 @@ full-setup: generate-statusline ## Bootstrap router: docker compose + seed + opt
 			exit 1; \
 		fi; \
 		echo "    key: $$WEAVE_KEY"; \
-		echo "$$WEAVE_KEY" > .weave-router-key; \
-		chmod 600 .weave-router-key; \
-		echo "    saved to .weave-router-key"; \
 		echo ""; \
 		if [ "$(PLATFORM)" = "cc" ]; then \
 			echo "==> Wiring Claude Code → router..."; \
@@ -122,7 +119,6 @@ full-setup: generate-statusline ## Bootstrap router: docker compose + seed + opt
 			echo ""; \
 			echo "Done. Your local setup:"; \
 			echo "  • Router runs on http://localhost:8080"; \
-			echo "  • Weave Router key saved in .weave-router-key (gitignored)"; \
 			echo "  • Claude Code is wired (.claude/settings.json + .claude/settings.local.json)"; \
 			echo ""; \
 			echo "Share with teammates (replace BASE_URL with a host they can reach,"; \


### PR DESCRIPTION
## Summary

- `make full-setup` was writing the seeded `rk_` key to `.weave-router-key` as an intermediate file, but it was never read back — the key goes straight into `.claude/settings.local.json` via `install.sh`
- Removes the write, the `chmod`, and the gitignore entry for the file

🤖 Generated with [Claude Code](https://claude.com/claude-code)