### PR TITLE
Strip Claude Code injected tag blocks from embed input

### DIFF
--- a/internal/translate/features.go
+++ b/internal/translate/features.go
@@ -329,6 +329,9 @@ func userPromptTextGJSON(content gjson.Result) string {
 		if text == "" {
 			return true
 		}
+		if isClaudeCodeInjectedBlock(text) {
+			return true
+		}
 		if b.Len() > 0 {
 			b.WriteByte('\n')
 		}
@@ -336,6 +339,31 @@ func userPromptTextGJSON(content gjson.Result) string {
 		return true
 	})
 	return b.String()
+}
+
+// claudeCodeInjectedBlockPrefixes are wrapper tags Claude Code injects into
+// user-message content arrays (system reminders, slash-command echoes, local
+// command output). They carry no routing signal and dwarf the user's typed
+// text, so we skip them when building the embed input. The full untouched
+// request body is still proxied to the upstream model.
+var claudeCodeInjectedBlockPrefixes = []string{
+	"<system-reminder>",
+	"<command-name>",
+	"<command-message>",
+	"<command-args>",
+	"<local-command-stdout>",
+	"<local-command-stderr>",
+	"<local-command-caveat>",
+}
+
+func isClaudeCodeInjectedBlock(text string) bool {
+	trimmed := strings.TrimLeft(text, " \t\r\n")
+	for _, prefix := range claudeCodeInjectedBlockPrefixes {
+		if strings.HasPrefix(trimmed, prefix) {
+			return true
+		}
+	}
+	return false
 }
 
 func openAIContentTextGJSON(v gjson.Result) string {


### PR DESCRIPTION
## Summary
- The cluster scorer's `embed_last_user_message` path concatenated every text block in the trailing user message. Claude Code injects its own `<system-reminder>`, `<command-name>`, and `<local-command-*>` blocks as separate text entries before the user's typed prompt — with MCP enabled those reminders run 10–50 KB and dominate the embedding.
- Result: a turn whose actual user text is "hello there" was embedding as 17k tokens of MCP/system-reminder content and biasing every routing decision toward the agentic-tools cluster.
- Filter the known CC wrapper tags out of `userPromptTextGJSON` so the embed input reflects what the user actually typed. The full request body is still proxied unchanged to the upstream model — this only affects routing-signal text.

## Test plan
- [x] `go test ./internal/translate/...` passes locally
- [x] `go build ./...` clean
- [ ] Verify in `make dev-log`: with `ROUTER_EMBED_LAST_USER_MESSAGE=true` + `ROUTER_SESSION_PIN_ENABLED=false`, sending "hello there" via Claude Code logs `prompt_chars` ≈ 15 (was 1024 truncated) and routes based on the actual user text rather than the injected reminders
- [ ] Existing tool-result / multi-turn flows unaffected (the filter only skips top-of-block wrapped tags, real user text passes through)

🤖 Generated with [Claude Code](https://claude.com/claude-code)