### PR TITLE
Make cluster MinPromptChars configurable via env

### DIFF
--- a/cmd/router/main.go
+++ b/cmd/router/main.go
@@ -373,6 +373,15 @@ func buildClusterScorer(availableProviders map[string]struct{}) (router.Router, 
 			logger.Info("Cluster embed timeout overridden", "embed_timeout_ms", ms.Milliseconds())
 		}
 	}
+	if v := config.GetOr("ROUTER_CLUSTER_MIN_PROMPT_CHARS", ""); v != "" {
+		n, parseErr := strconv.Atoi(v)
+		if parseErr != nil || n < 0 {
+			logger.Warn("Invalid ROUTER_CLUSTER_MIN_PROMPT_CHARS; using default", "value", v, "default", cfg.MinPromptChars)
+		} else {
+			cfg.MinPromptChars = n
+			logger.Info("Cluster min prompt chars overridden", "min_prompt_chars", n)
+		}
+	}
 
 	scorers := make(map[string]*cluster.Scorer, len(versions))
 	for _, v := range versions {


### PR DESCRIPTION
## Summary
- The cluster scorer rejects prompts shorter than 20 chars with `ErrClusterUnavailable` → HTTP 503, which is sensible for production but makes "hello"-style turns unroutable in dev/demos.
- Add `ROUTER_CLUSTER_MIN_PROMPT_CHARS` to override the default. Mirrors the existing `ROUTER_CLUSTER_EMBED_TIMEOUT_MS` override pattern (same file, same shape).
- Default behavior unchanged: production deployments that don't set the var keep the 20-char floor.

## Test plan
- [x] `go build ./...` clean
- [ ] With `ROUTER_CLUSTER_MIN_PROMPT_CHARS=1` in `.env.local`, send a "hi" turn through Claude Code and confirm the cluster scorer routes instead of 503-ing
- [ ] Unset the var and verify the 20-char default still kicks in (existing 503 behavior preserved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)