### PR TITLE
fix(proxy): make session pin per-session, not per-user

### DIFF
--- a/internal/proxy/session_key.go
+++ b/internal/proxy/session_key.go
@@ -8,25 +8,27 @@ import (
 )
 
 // DeriveSessionKey produces the 16-byte digest used to look up a session
-// pin. Three tiers tried in order:
+// pin. Two tiers tried in order:
 //
-//  1. routerUserID (stable across devices for the same human),
-//  2. metadata.user_id (per-device, no email needed),
-//  3. system prompt + first user message (matches Anthropic prompt-cache shape).
+//  1. metadata.user_id (Claude Code packs device_id + account_uuid +
+//     session_id here, so this is session-distinct),
+//  2. system prompt + first user message (matches Anthropic prompt-cache
+//     shape; session-distinct for clients that don't set metadata.user_id).
 //
 // apiKeyID is mixed into all tiers so callers under different keys can't
-// collide on a shared pin. Pure function; empty apiKeyID/routerUserID just
-// fall back to the next tier.
-func DeriveSessionKey(env *translate.RequestEnvelope, apiKeyID, routerUserID string) [sessionpin.SessionKeyLen]byte {
+// collide on a shared pin. Pure function; empty apiKeyID just falls back to
+// the next tier.
+//
+// Routing the same human across separate sessions to the same pin would be a
+// user pin, not a session pin — so the resolved router user ID is
+// deliberately not consulted here.
+func DeriveSessionKey(env *translate.RequestEnvelope, apiKeyID string) [sessionpin.SessionKeyLen]byte {
 	h := sha256.New()
 	h.Write([]byte(apiKeyID))
 	// Domain separator: prevents cross-tier collisions from caller-controlled strings.
 	h.Write([]byte{0x00})
 
 	switch {
-	case routerUserID != "":
-		h.Write([]byte("router_user_id:"))
-		h.Write([]byte(routerUserID))
 	case env != nil && env.MetadataUserID() != "":
 		h.Write([]byte("user_id:"))
 		h.Write([]byte(env.MetadataUserID()))

--- a/internal/proxy/session_key_test.go
+++ b/internal/proxy/session_key_test.go
@@ -36,8 +36,8 @@ func TestDeriveSessionKey_StableAcrossTurns(t *testing.T) {
 		]
 	}`)
 
-	k1 := proxy.DeriveSessionKey(turn1, "api-key-A", "")
-	k2 := proxy.DeriveSessionKey(turn2, "api-key-A", "")
+	k1 := proxy.DeriveSessionKey(turn1, "api-key-A")
+	k2 := proxy.DeriveSessionKey(turn2, "api-key-A")
 
 	assert.Equal(t, k1, k2, "key stable across turns: system + first user message don't change")
 	assert.Len(t, k1, sessionpin.SessionKeyLen)
@@ -49,8 +49,8 @@ func TestDeriveSessionKey_DiffersAcrossAPIKeys(t *testing.T) {
 		"messages": [{"role": "user", "content": "hello"}]
 	}`)
 
-	k1 := proxy.DeriveSessionKey(env, "api-key-A", "")
-	k2 := proxy.DeriveSessionKey(env, "api-key-B", "")
+	k1 := proxy.DeriveSessionKey(env, "api-key-A")
+	k2 := proxy.DeriveSessionKey(env, "api-key-B")
 
 	assert.NotEqual(t, k1, k2, "distinct callers must not collide on identical prompts")
 }
@@ -65,8 +65,8 @@ func TestDeriveSessionKey_DiffersAcrossSystemPrompts(t *testing.T) {
 		"messages": [{"role": "user", "content": "go"}]
 	}`)
 
-	kA := proxy.DeriveSessionKey(envA, "api-key", "")
-	kB := proxy.DeriveSessionKey(envB, "api-key", "")
+	kA := proxy.DeriveSessionKey(envA, "api-key")
+	kB := proxy.DeriveSessionKey(envB, "api-key")
 
 	assert.NotEqual(t, kA, kB)
 }
@@ -84,13 +84,16 @@ func TestDeriveSessionKey_PrefersMetadataUserID(t *testing.T) {
 		"messages": [{"role": "user", "content": "third turn"}]
 	}`)
 
-	k1 := proxy.DeriveSessionKey(env1, "api-key", "")
-	k2 := proxy.DeriveSessionKey(env2, "api-key", "")
+	k1 := proxy.DeriveSessionKey(env1, "api-key")
+	k2 := proxy.DeriveSessionKey(env2, "api-key")
 
 	assert.Equal(t, k1, k2, "metadata.user_id takes precedence over prompt-prefix fallback")
 }
 
 func TestDeriveSessionKey_DistinctMetadataUserIDsDoNotCollide(t *testing.T) {
+	// Claude Code packs {device_id, account_uuid, session_id} into
+	// metadata.user_id, so different sessions for the same human produce
+	// different keys — that's the whole point of a *session* pin.
 	envA := anthropicEnv(t, `{
 		"metadata": {"user_id": "device=abc;session=1"},
 		"messages": [{"role": "user", "content": "x"}]
@@ -100,8 +103,8 @@ func TestDeriveSessionKey_DistinctMetadataUserIDsDoNotCollide(t *testing.T) {
 		"messages": [{"role": "user", "content": "x"}]
 	}`)
 
-	kA := proxy.DeriveSessionKey(envA, "api-key", "")
-	kB := proxy.DeriveSessionKey(envB, "api-key", "")
+	kA := proxy.DeriveSessionKey(envA, "api-key")
+	kB := proxy.DeriveSessionKey(envB, "api-key")
 
 	assert.NotEqual(t, kA, kB)
 }
@@ -118,48 +121,15 @@ func TestDeriveSessionKey_MetadataTierDoesNotCollideWithPromptTier(t *testing.T)
 		"messages": [{"role": "user", "content": ""}]
 	}`)
 
-	kMeta := proxy.DeriveSessionKey(envWithMeta, "api-key", "")
-	kNoMeta := proxy.DeriveSessionKey(envNoMeta, "api-key", "")
+	kMeta := proxy.DeriveSessionKey(envWithMeta, "api-key")
+	kNoMeta := proxy.DeriveSessionKey(envNoMeta, "api-key")
 
 	assert.NotEqual(t, kMeta, kNoMeta)
 }
 
-func TestDeriveSessionKey_PrefersRouterUserIDOverMetadata(t *testing.T) {
-	// routerUserID wins over metadata.user_id: same human across devices shares a pin.
-	envDev1 := anthropicEnv(t, `{
-		"metadata": {"user_id": "device=DEV1;session=42"},
-		"messages": [{"role": "user", "content": "hi"}]
-	}`)
-	envDev2 := anthropicEnv(t, `{
-		"metadata": {"user_id": "device=DEV2;session=99"},
-		"messages": [{"role": "user", "content": "different prompt"}]
-	}`)
-
-	k1 := proxy.DeriveSessionKey(envDev1, "api-key", "user-uuid")
-	k2 := proxy.DeriveSessionKey(envDev2, "api-key", "user-uuid")
-
-	assert.Equal(t, k1, k2)
-}
-
-func TestDeriveSessionKey_RouterUserIDTierIsDomainSeparated(t *testing.T) {
-	// routerUserID and metadata.user_id tiers must be domain-separated.
-	envWithMeta := anthropicEnv(t, `{
-		"metadata": {"user_id": "shared-string"},
-		"messages": [{"role": "user", "content": "x"}]
-	}`)
-	envNoMeta := anthropicEnv(t, `{
-		"messages": [{"role": "user", "content": "x"}]
-	}`)
-
-	kMetaTier := proxy.DeriveSessionKey(envWithMeta, "api-key", "")
-	kUserIDTier := proxy.DeriveSessionKey(envNoMeta, "api-key", "shared-string")
-
-	assert.NotEqual(t, kMetaTier, kUserIDTier)
-}
-
 func TestDeriveSessionKey_NilEnvelopeStillKeyedByAPIKey(t *testing.T) {
 	// Defensive: parsing failure must not leak across callers via a shared pin.
-	kA := proxy.DeriveSessionKey(nil, "api-key-A", "")
-	kB := proxy.DeriveSessionKey(nil, "api-key-B", "")
+	kA := proxy.DeriveSessionKey(nil, "api-key-A")
+	kB := proxy.DeriveSessionKey(nil, "api-key-B")
 	assert.NotEqual(t, kA, kB)
 }

--- a/internal/proxy/session_route.go
+++ b/internal/proxy/session_route.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"time"
 
-	"workweave/router/internal/auth"
 	"workweave/router/internal/observability"
 	"workweave/router/internal/router"
 	"workweave/router/internal/router/sessionpin"
@@ -87,7 +86,7 @@ func (s *Service) routeWithSession(
 	pinEligible := s.pinStore != nil
 	var pinCacheKey string
 	if pinEligible {
-		res.SessionKey = DeriveSessionKey(env, apiKeyID, auth.UserIDFrom(ctx))
+		res.SessionKey = DeriveSessionKey(env, apiKeyID)
 		pinCacheKey = sessionPinCacheKey(res.SessionKey, sessionpin.DefaultRole)
 
 		if s.pinCache != nil {


### PR DESCRIPTION
## Summary

- `DeriveSessionKey`'s top tier was `routerUserID` — the resolved `(installationID, email|account_uuid)` row, which is stable per human across devices and sessions. Once a user's first turn pinned a model, every later session they started collapsed onto the same pin and was rerouted to that model regardless of what the cluster scorer would have chosen. That's a user pin, not a session pin.
- Drop the `routerUserID` tier. `metadata.user_id` becomes the primary key (Claude Code packs `device_id` + `account_uuid` + `session_id` there, so it's session-distinct), with the prompt-prefix hash as the fallback for clients that don't set it. Both remaining tiers are session-distinct.
- Removed the two tests that locked in the user-pin behavior (`PrefersRouterUserIDOverMetadata`, `RouterUserIDTierIsDomainSeparated`); updated remaining tests to the new two-arg signature.

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/proxy/...`
- [ ] Verify in staging that two concurrent Claude Code sessions from the same human produce distinct session_pin rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)