### PR TITLE
fix(proxy): pass upstream non-2xx body through cross-format translator

### DIFF
--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -466,9 +466,7 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 		}
 		translator := translate.NewAnthropicSSETranslator(sink, decision.Model, usage)
 		proxyErr = p.Proxy(ctx, decision, prep, translator, r)
-		if proxyErr == nil {
-			proxyErr = translator.Finalize()
-		}
+		proxyErr = finalizeAfterProxy(proxyErr, translator.Finalize)
 	case providers.ProviderGoogle:
 		crossFormat = true
 		prep, emitErr := env.PrepareGemini(r.Header, opts)
@@ -485,12 +483,8 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 		anthropicTr := translate.NewAnthropicSSETranslator(sink, decision.Model, usage)
 		geminiTr := translate.NewGeminiToOpenAISSETranslator(anthropicTr, decision.Model, nil)
 		proxyErr = p.Proxy(ctx, decision, prep, geminiTr, r)
-		if proxyErr == nil {
-			proxyErr = geminiTr.Finalize()
-		}
-		if proxyErr == nil {
-			proxyErr = anthropicTr.Finalize()
-		}
+		proxyErr = finalizeAfterProxy(proxyErr, geminiTr.Finalize)
+		proxyErr = finalizeAfterProxy(proxyErr, anthropicTr.Finalize)
 	default:
 		return fmt.Errorf("%w: %s (no translation path defined for inbound Anthropic Messages)", ErrProviderNotConfigured, decision.Provider)
 	}
@@ -750,6 +744,26 @@ func upstreamStatus(err error) int {
 	return 0
 }
 
+// finalizeAfterProxy runs a translator's Finalize step when the upstream call
+// either succeeded or returned a typed UpstreamStatusError. Cross-format
+// translators buffer the upstream body for non-streaming responses and only
+// flush it inside Finalize; skipping that on a 4xx/5xx drops the upstream
+// error envelope (e.g. an OpenRouter 402 "out of credits" message) before it
+// can reach the client. UpstreamStatusError takes precedence over a Finalize
+// error so telemetry preserves the upstream status code.
+func finalizeAfterProxy(proxyErr error, fn func() error) error {
+	var statusErr *providers.UpstreamStatusError
+	isStatus := errors.As(proxyErr, &statusErr)
+	if proxyErr != nil && !isStatus {
+		return proxyErr
+	}
+	finErr := fn()
+	if isStatus {
+		return proxyErr
+	}
+	return finErr
+}
+
 // ProxyOpenAIChatCompletion routes an OpenAI Chat Completion request,
 // translating cross-format when the decision picks a non-OpenAI provider.
 func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w http.ResponseWriter, r *http.Request) error {
@@ -914,9 +928,7 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 		}
 		translator := translate.NewGeminiToOpenAISSETranslator(sink, decision.Model, usage)
 		proxyErr = p.Proxy(ctx, decision, prep, translator, r)
-		if proxyErr == nil {
-			proxyErr = translator.Finalize()
-		}
+		proxyErr = finalizeAfterProxy(proxyErr, translator.Finalize)
 	case providers.ProviderAnthropic:
 		crossFormat = true
 		prep, emitErr := env.PrepareAnthropic(r.Header, opts)
@@ -931,9 +943,7 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 		}
 		translator := translate.NewSSETranslator(sink, decision.Model, usage)
 		proxyErr = p.Proxy(ctx, decision, prep, translator, r)
-		if proxyErr == nil {
-			proxyErr = translator.Finalize()
-		}
+		proxyErr = finalizeAfterProxy(proxyErr, translator.Finalize)
 	default:
 		return fmt.Errorf("%w: %s (no translation path defined)", ErrProviderNotConfigured, decision.Provider)
 	}

--- a/internal/proxy/service_test.go
+++ b/internal/proxy/service_test.go
@@ -75,6 +75,46 @@ func TestService_ProxyMessages_PropagatesUpstreamStatusError(t *testing.T) {
 	assert.Equal(t, 400, got.Status)
 }
 
+// TestService_ProxyMessages_CrossFormatUpstreamErrorBodyReachesClient guards
+// against the regression where a cross-format upstream non-2xx (e.g. OpenRouter
+// 402 "out of credits") buffered the upstream body inside the
+// AnthropicSSETranslator but never flushed it, because Finalize was skipped on
+// any non-nil proxyErr. Claude Code would then see only the generic
+// "upstream call failed" envelope written by the handler. The translated body
+// must reach the client and the typed UpstreamStatusError must still surface
+// to the handler so telemetry records the upstream status.
+func TestService_ProxyMessages_CrossFormatUpstreamErrorBodyReachesClient(t *testing.T) {
+	const upstreamBody = `{"error":{"message":"OpenRouter: insufficient credits","code":402,"type":"invalid_request_error"}}`
+	provider := &fakeProvider{
+		proxyResponse: func(w http.ResponseWriter) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusPaymentRequired)
+			_, _ = io.WriteString(w, upstreamBody)
+		},
+		proxyErr: &providers.UpstreamStatusError{Status: http.StatusPaymentRequired},
+	}
+	svc := makeProxyService(
+		router.Decision{Provider: providers.ProviderOpenRouter, Model: "deepseek/deepseek-chat"},
+		map[string]providers.Client{providers.ProviderOpenRouter: provider},
+	)
+
+	rec := httptest.NewRecorder()
+	httpReq := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(""))
+	body := []byte(`{"model":"claude-opus-4-7","messages":[{"role":"user","content":"hi"}]}`)
+
+	err := svc.ProxyMessages(context.Background(), body, rec, httpReq)
+
+	var got *providers.UpstreamStatusError
+	require.ErrorAs(t, err, &got, "UpstreamStatusError must still propagate for telemetry")
+	assert.Equal(t, http.StatusPaymentRequired, got.Status)
+
+	assert.Equal(t, http.StatusPaymentRequired, rec.Code, "upstream status must reach the client")
+	respBody := rec.Body.String()
+	require.NotEmpty(t, respBody, "translated upstream error body must reach the client")
+	assert.Contains(t, respBody, "insufficient credits", "upstream error message must survive translation")
+	assert.Contains(t, respBody, `"type":"error"`, "body must be in Anthropic error envelope shape")
+}
+
 func TestService_ProxyMessages_EmbedLastUserMessageFlag(t *testing.T) {
 	const userPrompt = "Walk every Go file under router/internal/ and produce a one-paragraph summary of each."
 	// CC-shaped body: system preamble + earlier user prompt + long tool_result.


### PR DESCRIPTION
## Summary

- When an Anthropic-Messages request routed to a cross-format upstream (OpenAI / OpenRouter / Fireworks / Google) and the upstream returned a non-2xx (e.g. OpenRouter 402 "out of credits"), the upstream error body was dropped before reaching the client.
- The provider client writes the error body into the `AnthropicSSETranslator`; the translator buffers it and only flushes the Anthropic-shaped error envelope inside `Finalize` (`internal/translate/stream.go:449`). `proxy.Service` only called `Finalize` when `proxyErr == nil`, so any `UpstreamStatusError` skipped the flush and Claude Code saw the handler's generic `"upstream call failed"` envelope.
- Fix: run `Finalize` on `UpstreamStatusError` too, while preserving the typed error for telemetry. Same fix applied to the OpenAI Chat Completion path (`SSETranslator` + `GeminiToOpenAISSETranslator`).

## Test plan

- [x] `go test ./internal/proxy/... ./internal/translate/... ./internal/providers/... -count=1`
- [x] New `TestService_ProxyMessages_CrossFormatUpstreamErrorBodyReachesClient` asserts that a fake OpenRouter 402 with body `{"error":{"message":"OpenRouter: insufficient credits"...}}` reaches the client as an Anthropic-shaped error envelope, and that `UpstreamStatusError(402)` still surfaces to the handler.
- [ ] Manual: hit `/v1/messages` against a routing decision that maps to OpenRouter with an exhausted key; confirm Claude Code logs include the upstream message instead of a generic failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)