### PR TITLE
Route on user-role text only by default

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -617,11 +617,11 @@ runs as a Modal app (`modal_app.py`); see [`eval/README.md`](eval/README.md).
   `cluster.VersionFromContext` and dispatches to the matching `Scorer`.
   Customer traffic (no header) always serves the deployment's default
   version (`ROUTER_CLUSTER_VERSION` → `artifacts/latest`).
-- `internal/server/middleware.WithEmbedLastUserMessageOverride` honors
-  the `x-weave-embed-last-user-message: true` header, flipping the
-  proxy to embed the last-user-typed message instead of the concatenated
-  stream. Used for orthogonal feature-extraction A/Bs against the
-  artifact-version axis.
+- `internal/server/middleware.WithEmbedOnlyUserMessageOverride` honors
+  the `x-weave-embed-only-user-message: true|false` header, flipping
+  the proxy between embedding user-role text only (default) and the
+  concatenated turn stream. Used for orthogonal feature-extraction
+  A/Bs against the artifact-version axis.
 - The eval harness names cluster routers as `vX.Y-cluster` — any
   committed artifact directory under
   `internal/router/cluster/artifacts/` is reachable by name, no Python

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -617,11 +617,11 @@ runs as a Modal app (`modal_app.py`); see [`eval/README.md`](eval/README.md).
   `cluster.VersionFromContext` and dispatches to the matching `Scorer`.
   Customer traffic (no header) always serves the deployment's default
   version (`ROUTER_CLUSTER_VERSION` → `artifacts/latest`).
-- `internal/server/middleware.WithEmbedLastUserMessageOverride` honors
-  the `x-weave-embed-last-user-message: true` header, flipping the
-  proxy to embed the last-user-typed message instead of the concatenated
-  stream. Used for orthogonal feature-extraction A/Bs against the
-  artifact-version axis.
+- `internal/server/middleware.WithEmbedOnlyUserMessageOverride` honors
+  the `x-weave-embed-only-user-message: true|false` header, flipping
+  the proxy between embedding user-role text only (default) and the
+  concatenated turn stream. Used for orthogonal feature-extraction
+  A/Bs against the artifact-version axis.
 - The eval harness names cluster routers as `vX.Y-cluster` — any
   committed artifact directory under
   `internal/router/cluster/artifacts/` is reachable by name, no Python

--- a/README.md
+++ b/README.md
@@ -246,7 +246,7 @@ Set `DATABASE_URL` directly, or compose it from the individual vars:
 | --------------------------------- | ---------------------------- | -------------------------------------------------------------------------------------- |
 | `ROUTER_CLUSTER_VERSION`          | *(reads `artifacts/latest`)* | Pin a specific cluster artifact version (e.g. `v0.27`).                                |
 | `ROUTER_CLUSTER_EMBED_TIMEOUT_MS` | `200`                        | Per-request ONNX embed timeout. Increase for slower hosts.                             |
-| `ROUTER_EMBED_LAST_USER_MESSAGE`  | `false`                      | Feed the last user message to the embedder instead of the concatenated turn context.   |
+| `ROUTER_EMBED_ONLY_USER_MESSAGE`  | `true`                       | Feed only user-role text (no system, assistant, or tool_result) to the embedder. Set `false` to fall back to the concatenated turn context. |
 | `ROUTER_STICKY_DECISION_TTL_MS`   | `0` (disabled)               | Reuse a routing decision per API key for this many ms.                                 |
 | `ROUTER_SESSION_PIN_ENABLED`      | `true`                       | Pin a session to its first-routed model so multi-turn conversations stay coherent.     |
 | `ROUTER_HARD_PIN_MODEL`           | *(none)*                     | Force every request to a specific model, bypassing the cluster scorer. Debugging only. |

--- a/cmd/router/main.go
+++ b/cmd/router/main.go
@@ -263,9 +263,11 @@ func main() {
 		}
 		authSvc.WithAdminPassword(adminPassword)
 	}
-	embedLastUser := config.GetOr("ROUTER_EMBED_LAST_USER_MESSAGE", "false") == "true"
-	if embedLastUser {
-		logger.Info("Cluster scorer embedding the last user message (ROUTER_EMBED_LAST_USER_MESSAGE=true)")
+	embedOnlyUser := config.GetOr("ROUTER_EMBED_ONLY_USER_MESSAGE", "true") == "true"
+	if embedOnlyUser {
+		logger.Info("Cluster scorer embedding user-role text only (ROUTER_EMBED_ONLY_USER_MESSAGE=true)")
+	} else {
+		logger.Info("Cluster scorer embedding concatenated stream (ROUTER_EMBED_ONLY_USER_MESSAGE=false)")
 	}
 	var stickyTTL time.Duration
 	if v := config.GetOr("ROUTER_STICKY_DECISION_TTL_MS", "0"); v != "0" && v != "" {
@@ -329,7 +331,7 @@ func main() {
 		deploymentEligible[providers.ProviderAnthropic] = struct{}{}
 	}
 
-	proxySvc := proxy.NewService(rtr, providerMap, emitter, embedLastUser, stickyTTL, semanticCache, pinStore, hardPinExplore, hardPinProvider, hardPinModel, repo.Telemetry).
+	proxySvc := proxy.NewService(rtr, providerMap, emitter, embedOnlyUser, stickyTTL, semanticCache, pinStore, hardPinExplore, hardPinProvider, hardPinModel, repo.Telemetry).
 		WithByokOnly(byokOnly).
 		WithDeploymentKeyedProviders(deploymentEligible)
 

--- a/frontend/src/app/(app)/settings/page.tsx
+++ b/frontend/src/app/(app)/settings/page.tsx
@@ -591,9 +591,9 @@ function buildRows(cfg: RouterConfig): ConfigRow[] {
       description: "Active routing artifact bundle served by default",
     },
     {
-      label: "Embed last user message",
-      value: cfg.embed_last_user_message ? "Enabled" : "Disabled",
-      description: "Whether the router embeds only the last user turn for cluster routing",
+      label: "Embed only user message",
+      value: cfg.embed_only_user_message ? "Enabled" : "Disabled",
+      description: "Whether the router embeds user-role text only (no system, assistant, or tool_result content) for cluster routing",
     },
     {
       label: "Sticky decision TTL",

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -100,7 +100,7 @@ export interface ExternalKey {
 
 export interface RouterConfig {
   cluster_version: string;
-  embed_last_user_message: boolean;
+  embed_only_user_message: boolean;
   sticky_decision_ttl_ms: string;
   otel_enabled: boolean;
   dev_mode: boolean;

--- a/internal/api/admin/config.go
+++ b/internal/api/admin/config.go
@@ -12,7 +12,7 @@ import (
 
 type configResponse struct {
 	ClusterVersion       string `json:"cluster_version"`
-	EmbedLastUserMsg     bool   `json:"embed_last_user_message"`
+	EmbedOnlyUserMsg     bool   `json:"embed_only_user_message"`
 	StickyDecisionTTL    string `json:"sticky_decision_ttl_ms"`
 	OtelEnabled          bool   `json:"otel_enabled"`
 	SemanticCacheEnabled bool   `json:"semantic_cache_enabled"`
@@ -48,7 +48,7 @@ func ConfigHandler(c *gin.Context) {
 	}
 	c.JSON(http.StatusOK, configResponse{
 		ClusterVersion:       config.GetOr("ROUTER_CLUSTER_VERSION", "artifacts/latest"),
-		EmbedLastUserMsg:     config.GetOr("ROUTER_EMBED_LAST_USER_MESSAGE", "false") == "true",
+		EmbedOnlyUserMsg:     config.GetOr("ROUTER_EMBED_ONLY_USER_MESSAGE", "true") == "true",
 		StickyDecisionTTL:    config.GetOr("ROUTER_STICKY_DECISION_TTL_MS", "0"),
 		OtelEnabled:          config.GetOr("OTEL_EXPORTER_OTLP_ENDPOINT", "") != "",
 		SemanticCacheEnabled: config.GetOr("ROUTER_SEMANTIC_CACHE_ENABLED", "true") == "true",

--- a/internal/api/anthropic/route.go
+++ b/internal/api/anthropic/route.go
@@ -34,12 +34,18 @@ func RouteHandler(svc *proxy.Service) gin.HandlerFunc {
 			return
 		}
 
-		feats := env.RoutingFeatures(false)
-		decision, routeErr := svc.Route(c.Request.Context(), router.Request{
+		ctx := c.Request.Context()
+		embedFlag := svc.ResolveEmbedOnlyUserMessage(ctx)
+		feats := env.RoutingFeatures(embedFlag)
+		promptText := feats.PromptText
+		if embedFlag && feats.OnlyUserMessageText != "" {
+			promptText = feats.OnlyUserMessageText
+		}
+		decision, routeErr := svc.Route(ctx, router.Request{
 			RequestedModel:       feats.Model,
 			EstimatedInputTokens: feats.Tokens,
 			HasTools:             feats.HasTools,
-			PromptText:           feats.PromptText,
+			PromptText:           promptText,
 		})
 		if routeErr != nil {
 			log.Error("Routing failed", "err", routeErr)

--- a/internal/proxy/gemini.go
+++ b/internal/proxy/gemini.go
@@ -51,8 +51,10 @@ func (s *Service) ProxyGeminiGenerateContent(ctx context.Context, body []byte, w
 	}
 	feats := env.RoutingFeatures(embedFlag)
 	promptText := feats.PromptText
+	embedInput := "concatenated_stream"
 	if embedFlag && feats.OnlyUserMessageText != "" {
 		promptText = feats.OnlyUserMessageText
+		embedInput = "only_user_message"
 	}
 
 	bypassEval := hasEvalOverrideHeader(r)
@@ -94,7 +96,7 @@ func (s *Service) ProxyGeminiGenerateContent(ctx context.Context, body []byte, w
 		Name:  "router.decision",
 		Start: requestStart,
 		End:   time.Now(),
-		Attrs: otel.NewAttrBuilder(22).
+		Attrs: otel.NewAttrBuilder(23).
 			String("request_id", requestID).
 			String("external_id", externalID).
 			String("client.device_id", clientID.DeviceID).
@@ -111,6 +113,7 @@ func (s *Service) ProxyGeminiGenerateContent(ctx context.Context, body []byte, w
 			String("routing.session_pin_tier", pinTier).
 			Int64("routing.session_pin_age_s", pinAgeSec).
 			String("routing.turn_type", string(tt)).
+			String("routing.embed_input", embedInput).
 			Int64("routing.estimated_input_tokens", int64(feats.Tokens)).
 			Float64("pricing.requested_input_per_1m", reqPricing.InputUSDPer1M).
 			Float64("pricing.requested_output_per_1m", reqPricing.OutputUSDPer1M).
@@ -180,6 +183,6 @@ func (s *Service) ProxyGeminiGenerateContent(ctx context.Context, body []byte, w
 	})
 	otel.Flush(ctx)
 
-	log.Info("ProxyGeminiGenerateContent complete", "requested_model", feats.Model, "decision_model", decision.Model, "decision_provider", decision.Provider, "decision_reason", decision.Reason, "estimated_input_tokens", feats.Tokens, "has_tools", feats.HasTools, "sticky_hit", stickyHit, "pin_tier", pinTier, "turn_type", string(tt), "route_ms", routeMs, "proxy_ms", proxyMs, "proxy_err", proxyErr, "upstream_status", upstreamStatus(proxyErr))
+	log.Info("ProxyGeminiGenerateContent complete", "requested_model", feats.Model, "decision_model", decision.Model, "decision_provider", decision.Provider, "decision_reason", decision.Reason, "estimated_input_tokens", feats.Tokens, "has_tools", feats.HasTools, "embed_input", embedInput, "sticky_hit", stickyHit, "pin_tier", pinTier, "turn_type", string(tt), "route_ms", routeMs, "proxy_ms", proxyMs, "proxy_err", proxyErr, "upstream_status", upstreamStatus(proxyErr))
 	return proxyErr
 }

--- a/internal/proxy/gemini.go
+++ b/internal/proxy/gemini.go
@@ -45,7 +45,15 @@ func (s *Service) ProxyGeminiGenerateContent(ctx context.Context, body []byte, w
 		log.Error("Failed to parse Gemini request", "err", parseErr)
 		return fmt.Errorf("parse request: %w", parseErr)
 	}
-	feats := env.RoutingFeatures(false)
+	embedFlag := s.embedOnlyUserMessage
+	if v, ok := embedOnlyUserMessageOverride(ctx); ok {
+		embedFlag = v
+	}
+	feats := env.RoutingFeatures(embedFlag)
+	promptText := feats.PromptText
+	if embedFlag && feats.OnlyUserMessageText != "" {
+		promptText = feats.OnlyUserMessageText
+	}
 
 	bypassEval := hasEvalOverrideHeader(r)
 	bypassLegacySticky := bypassEval
@@ -57,7 +65,7 @@ func (s *Service) ProxyGeminiGenerateContent(ctx context.Context, body []byte, w
 		RequestedModel:       feats.Model,
 		EstimatedInputTokens: feats.Tokens,
 		HasTools:             feats.HasTools,
-		PromptText:           feats.PromptText,
+		PromptText:           promptText,
 		EnabledProviders:     s.enabledProvidersForRequest(ctx, r.Header),
 	})
 	routeMs := time.Since(routeStart).Milliseconds()

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -26,7 +26,7 @@ type Service struct {
 	router               router.Router
 	providers            map[string]providers.Client
 	emitter              *otel.Emitter
-	embedLastUserMessage bool
+	embedOnlyUserMessage bool
 	stickyDecisions      *expirable.LRU[string, router.Decision]
 	// semanticCache short-circuits non-streaming requests on a cosine-similarity hit.
 	semanticCache *cache.Cache
@@ -88,7 +88,7 @@ func CredentialsFromContext(ctx context.Context) *Credentials {
 
 // NewService constructs the proxy service. pinStore may be nil when the
 // session-pin feature flag is off.
-func NewService(r router.Router, providerMap map[string]providers.Client, emitter *otel.Emitter, embedLastUserMessage bool, stickyDecisionTTL time.Duration, semanticCache *cache.Cache, pinStore sessionpin.Store, hardPinExplore bool, hardPinProvider, hardPinModel string, telemetry TelemetryRepository) *Service {
+func NewService(r router.Router, providerMap map[string]providers.Client, emitter *otel.Emitter, embedOnlyUserMessage bool, stickyDecisionTTL time.Duration, semanticCache *cache.Cache, pinStore sessionpin.Store, hardPinExplore bool, hardPinProvider, hardPinModel string, telemetry TelemetryRepository) *Service {
 	var sticky *expirable.LRU[string, router.Decision]
 	if stickyDecisionTTL > 0 {
 		sticky = expirable.NewLRU[string, router.Decision](10000, nil, stickyDecisionTTL)
@@ -103,7 +103,7 @@ func NewService(r router.Router, providerMap map[string]providers.Client, emitte
 		router:               r,
 		providers:            providerMap,
 		emitter:              emitter,
-		embedLastUserMessage: embedLastUserMessage,
+		embedOnlyUserMessage: embedOnlyUserMessage,
 		stickyDecisions:      sticky,
 		semanticCache:        semanticCache,
 		pinStore:             pinStore,
@@ -260,12 +260,12 @@ func (s *Service) writeCachedResponse(w http.ResponseWriter, resp cache.CachedRe
 	}
 }
 
-// EmbedLastUserMessageContextKey is the context key for the per-request embed flag override.
-type EmbedLastUserMessageContextKey struct{}
+// EmbedOnlyUserMessageContextKey is the context key for the per-request embed flag override.
+type EmbedOnlyUserMessageContextKey struct{}
 
-// embedLastUserMessageOverride reads the per-request embed flag from ctx.
-func embedLastUserMessageOverride(ctx context.Context) (bool, bool) {
-	v, ok := ctx.Value(EmbedLastUserMessageContextKey{}).(bool)
+// embedOnlyUserMessageOverride reads the per-request embed flag from ctx.
+func embedOnlyUserMessageOverride(ctx context.Context) (bool, bool) {
+	v, ok := ctx.Value(EmbedOnlyUserMessageContextKey{}).(bool)
 	return v, ok
 }
 
@@ -338,16 +338,16 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 		return fmt.Errorf("parse request: %w", parseErr)
 	}
 
-	embedFlag := s.embedLastUserMessage
-	if v, ok := embedLastUserMessageOverride(ctx); ok {
+	embedFlag := s.embedOnlyUserMessage
+	if v, ok := embedOnlyUserMessageOverride(ctx); ok {
 		embedFlag = v
 	}
 	feats := env.RoutingFeatures(embedFlag)
 	promptText := feats.PromptText
 	embedInput := "concatenated_stream"
-	if embedFlag && feats.LastUserMessageText != "" {
-		promptText = feats.LastUserMessageText
-		embedInput = "last_user_message"
+	if embedFlag && feats.OnlyUserMessageText != "" {
+		promptText = feats.OnlyUserMessageText
+		embedInput = "only_user_message"
 	}
 
 	apiKeyID, _ := ctx.Value(APIKeyIDContextKey{}).(string)
@@ -663,7 +663,7 @@ func hasEvalOverrideHeader(r *http.Request) bool {
 		return false
 	}
 	return r.Header.Get("x-weave-cluster-version") != "" ||
-		r.Header.Get("x-weave-embed-last-user-message") != ""
+		r.Header.Get("x-weave-embed-only-user-message") != ""
 }
 
 // externalKeysFromContext reads external API keys stashed by auth middleware.
@@ -830,7 +830,15 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 		log.Error("Failed to parse OpenAI request", "err", parseErr)
 		return fmt.Errorf("parse request: %w", parseErr)
 	}
-	feats := env.RoutingFeatures(false)
+	embedFlag := s.embedOnlyUserMessage
+	if v, ok := embedOnlyUserMessageOverride(ctx); ok {
+		embedFlag = v
+	}
+	feats := env.RoutingFeatures(embedFlag)
+	promptText := feats.PromptText
+	if embedFlag && feats.OnlyUserMessageText != "" {
+		promptText = feats.OnlyUserMessageText
+	}
 
 	bypassEval := hasEvalOverrideHeader(r)
 	bypassLegacySticky := bypassEval
@@ -843,7 +851,7 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 		RequestedModel:       feats.Model,
 		EstimatedInputTokens: feats.Tokens,
 		HasTools:             feats.HasTools,
-		PromptText:           feats.PromptText,
+		PromptText:           promptText,
 		EnabledProviders:     s.enabledProvidersForRequest(ctx, r.Header),
 	})
 	routeMs := time.Since(routeStart).Milliseconds()

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -269,6 +269,19 @@ func embedOnlyUserMessageOverride(ctx context.Context) (bool, bool) {
 	return v, ok
 }
 
+// ResolveEmbedOnlyUserMessage reports the effective embed-only-user flag for
+// ctx, applying the per-request override (if set) on top of the service
+// default. Exposed so handlers outside this package (e.g. /v1/route) can use
+// the same resolution as ProxyMessages and stay in sync with customer-visible
+// routing behavior.
+func (s *Service) ResolveEmbedOnlyUserMessage(ctx context.Context) bool {
+	flag := s.embedOnlyUserMessage
+	if v, ok := embedOnlyUserMessageOverride(ctx); ok {
+		flag = v
+	}
+	return flag
+}
+
 func (s *Service) provider(name string) (providers.Client, error) {
 	p, ok := s.providers[name]
 	if !ok {
@@ -836,8 +849,10 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 	}
 	feats := env.RoutingFeatures(embedFlag)
 	promptText := feats.PromptText
+	embedInput := "concatenated_stream"
 	if embedFlag && feats.OnlyUserMessageText != "" {
 		promptText = feats.OnlyUserMessageText
+		embedInput = "only_user_message"
 	}
 
 	bypassEval := hasEvalOverrideHeader(r)
@@ -906,7 +921,7 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 		Name:  "router.decision",
 		Start: requestStart,
 		End:   time.Now(),
-		Attrs: otel.NewAttrBuilder(24).
+		Attrs: otel.NewAttrBuilder(25).
 			String("request_id", requestID).
 			String("external_id", externalID).
 			String("router_user_id", auth.UserIDFrom(ctx)).
@@ -924,6 +939,7 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 			String("routing.session_pin_tier", pinTier).
 			Int64("routing.session_pin_age_s", pinAgeSec).
 			String("routing.turn_type", string(tt)).
+			String("routing.embed_input", embedInput).
 			Int64("routing.estimated_input_tokens", int64(feats.Tokens)).
 			IntSlice("routing.cluster_ids", clusterIDsFromDecision(decision)).
 			Float64("pricing.requested_input_per_1m", reqPricing.InputUSDPer1M).
@@ -1067,6 +1083,7 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 			DecisionReason:         decision.Reason,
 			EstimatedInputTokens:   int32(feats.Tokens),
 			StickyHit:              stickyHit,
+			EmbedInput:             embedInput,
 			InputTokens:            int32(in),
 			OutputTokens:           int32(out),
 			RequestedInputCostUSD:  float64(in) / 1_000_000 * reqPricing.InputUSDPer1M,
@@ -1088,6 +1105,6 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 		})
 	}
 
-	log.Info("ProxyOpenAIChatCompletion complete", "requested_model", feats.Model, "decision_model", decision.Model, "decision_provider", decision.Provider, "decision_reason", decision.Reason, "estimated_input_tokens", feats.Tokens, "has_tools", feats.HasTools, "cross_format", crossFormat, "sticky_hit", stickyHit, "pin_tier", pinTier, "turn_type", string(tt), "route_ms", routeMs, "proxy_ms", proxyMs, "proxy_err", proxyErr, "upstream_status", upstreamStatus(proxyErr))
+	log.Info("ProxyOpenAIChatCompletion complete", "requested_model", feats.Model, "decision_model", decision.Model, "decision_provider", decision.Provider, "decision_reason", decision.Reason, "estimated_input_tokens", feats.Tokens, "has_tools", feats.HasTools, "embed_input", embedInput, "cross_format", crossFormat, "sticky_hit", stickyHit, "pin_tier", pinTier, "turn_type", string(tt), "route_ms", routeMs, "proxy_ms", proxyMs, "proxy_err", proxyErr, "upstream_status", upstreamStatus(proxyErr))
 	return proxyErr
 }

--- a/internal/proxy/service_test.go
+++ b/internal/proxy/service_test.go
@@ -115,17 +115,21 @@ func TestService_ProxyMessages_CrossFormatUpstreamErrorBodyReachesClient(t *test
 	assert.Contains(t, respBody, `"type":"error"`, "body must be in Anthropic error envelope shape")
 }
 
-func TestService_ProxyMessages_EmbedLastUserMessageFlag(t *testing.T) {
-	const userPrompt = "Walk every Go file under router/internal/ and produce a one-paragraph summary of each."
-	// CC-shaped body: system preamble + earlier user prompt + long tool_result.
-	// Most recent user-authored text is the original prompt, several messages back.
+func TestService_ProxyMessages_EmbedOnlyUserMessageFlag(t *testing.T) {
+	const firstUserPrompt = "Walk every Go file under router/internal/ and produce a one-paragraph summary of each."
+	const secondUserPrompt = "Now narrow it to handlers under internal/api/."
+	// CC-shaped body: system preamble + two user prompts separated by an
+	// assistant turn + trailing tool_result. embedOnlyUserMessage must keep
+	// both user prompts and drop the system text, the assistant tool_use, and
+	// the tool_result blocks.
 	body := []byte(`{
 		"model":"claude-opus-4-7",
 		"system":"You are Claude Code. CLAUDE.md says: do not use emojis...",
 		"messages":[
-			{"role":"user","content":"` + userPrompt + `"},
+			{"role":"user","content":"` + firstUserPrompt + `"},
 			{"role":"assistant","content":[{"type":"tool_use","id":"toolu_1","name":"Read","input":{"path":"go.mod"}}]},
-			{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_1","content":"module workweave/router\n\ngo 1.23\n\nrequire (\n\tgithub.com/gin-gonic/gin v1.10.0\n)"}]}
+			{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_1","content":"module workweave/router\n\ngo 1.23\n\nrequire (\n\tgithub.com/gin-gonic/gin v1.10.0\n)"}]},
+			{"role":"user","content":"` + secondUserPrompt + `"}
 		]
 	}`)
 
@@ -150,10 +154,10 @@ func TestService_ProxyMessages_EmbedLastUserMessageFlag(t *testing.T) {
 		require.NotNil(t, fr.capturedReq)
 		got := fr.capturedReq.PromptText
 		assert.Contains(t, got, "You are Claude Code", "flag=off keeps system prompt")
-		assert.Contains(t, got, userPrompt, "flag=off keeps user message text")
+		assert.Contains(t, got, firstUserPrompt, "flag=off keeps first user message text")
 	})
 
-	t.Run("flag on uses last user message only", func(t *testing.T) {
+	t.Run("flag on concatenates user-role text and drops everything else", func(t *testing.T) {
 		fr := &fakeRouter{decision: router.Decision{Provider: "anthropic", Model: "claude-haiku-4-5"}}
 		svc := proxy.NewService(fr,
 			map[string]providers.Client{providers.ProviderAnthropic: &fakeProvider{}},
@@ -173,11 +177,12 @@ func TestService_ProxyMessages_EmbedLastUserMessageFlag(t *testing.T) {
 
 		require.NotNil(t, fr.capturedReq)
 		got := fr.capturedReq.PromptText
-		assert.Equal(t, userPrompt, got, "flag=on uses last user message verbatim, no preamble")
+		assert.Equal(t, firstUserPrompt+"\n"+secondUserPrompt, got,
+			"flag=on emits user-role text only (no system, no assistant tool_use, no tool_result)")
 	})
 }
 
-func TestService_ProxyMessages_EmbedLastUserMessageContextOverride(t *testing.T) {
+func TestService_ProxyMessages_EmbedOnlyUserMessageContextOverride(t *testing.T) {
 	const userPrompt = "Find the race condition in main.go"
 	body := []byte(`{
 		"model":"claude-opus-4-7",
@@ -233,7 +238,7 @@ func TestService_ProxyMessages_EmbedLastUserMessageContextOverride(t *testing.T)
 
 			ctx := context.Background()
 			if tc.ctxOverride != nil {
-				ctx = context.WithValue(ctx, proxy.EmbedLastUserMessageContextKey{}, *tc.ctxOverride)
+				ctx = context.WithValue(ctx, proxy.EmbedOnlyUserMessageContextKey{}, *tc.ctxOverride)
 			}
 
 			rec := httptest.NewRecorder()
@@ -260,7 +265,7 @@ func TestService_ProxyMessages_StickyBypassedByEvalOverrideHeaders(t *testing.T)
 	cases := []runConfig{
 		{name: "no override → second call hits sticky cache", header: "", wantRouteCalls: 1},
 		{name: "x-weave-cluster-version bypasses sticky", header: "x-weave-cluster-version", wantRouteCalls: 2},
-		{name: "x-weave-embed-last-user-message bypasses sticky", header: "x-weave-embed-last-user-message", wantRouteCalls: 2},
+		{name: "x-weave-embed-only-user-message bypasses sticky", header: "x-weave-embed-only-user-message", wantRouteCalls: 2},
 	}
 
 	for _, tc := range cases {

--- a/internal/server/middleware/embed_override.go
+++ b/internal/server/middleware/embed_override.go
@@ -10,13 +10,13 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
-// EmbedLastUserMessageOverrideHeader flips the cluster scorer's PromptText source per-request.
-const EmbedLastUserMessageOverrideHeader = "x-weave-embed-last-user-message"
+// EmbedOnlyUserMessageOverrideHeader flips the cluster scorer's PromptText source per-request.
+const EmbedOnlyUserMessageOverrideHeader = "x-weave-embed-only-user-message"
 
-// WithEmbedLastUserMessageOverride attaches a bool override to the request context when the header is "true" or "false".
-func WithEmbedLastUserMessageOverride() gin.HandlerFunc {
+// WithEmbedOnlyUserMessageOverride attaches a bool override to the request context when the header is "true" or "false".
+func WithEmbedOnlyUserMessageOverride() gin.HandlerFunc {
 	return func(c *gin.Context) {
-		raw := strings.TrimSpace(c.GetHeader(EmbedLastUserMessageOverrideHeader))
+		raw := strings.TrimSpace(c.GetHeader(EmbedOnlyUserMessageOverrideHeader))
 		if raw == "" {
 			c.Next()
 			return
@@ -37,10 +37,10 @@ func WithEmbedLastUserMessageOverride() gin.HandlerFunc {
 			c.Next()
 			return
 		}
-		ctx := context.WithValue(c.Request.Context(), proxy.EmbedLastUserMessageContextKey{}, override)
+		ctx := context.WithValue(c.Request.Context(), proxy.EmbedOnlyUserMessageContextKey{}, override)
 		c.Request = c.Request.WithContext(ctx)
 		observability.FromGin(c).Info(
-			"Embed-last-user-message override applied",
+			"Embed-only-user-message override applied",
 			"installation_id", installation.ID,
 			"value", override,
 		)

--- a/internal/server/middleware/embed_override_test.go
+++ b/internal/server/middleware/embed_override_test.go
@@ -24,12 +24,12 @@ func runEmbedOverride(t *testing.T, installation *auth.Installation, header stri
 		}
 		c.Next()
 	})
-	engine.Use(middleware.WithEmbedLastUserMessageOverride())
+	engine.Use(middleware.WithEmbedOnlyUserMessageOverride())
 
 	var observedSet bool
 	var observedValue bool
 	engine.GET("/probe", func(c *gin.Context) {
-		v, ok := c.Request.Context().Value(proxy.EmbedLastUserMessageContextKey{}).(bool)
+		v, ok := c.Request.Context().Value(proxy.EmbedOnlyUserMessageContextKey{}).(bool)
 		observedSet = ok
 		observedValue = v
 		c.Status(http.StatusOK)
@@ -37,7 +37,7 @@ func runEmbedOverride(t *testing.T, installation *auth.Installation, header stri
 
 	req := httptest.NewRequest(http.MethodGet, "/probe", nil)
 	if header != "" {
-		req.Header.Set(middleware.EmbedLastUserMessageOverrideHeader, header)
+		req.Header.Set(middleware.EmbedOnlyUserMessageOverrideHeader, header)
 	}
 	rr := httptest.NewRecorder()
 	engine.ServeHTTP(rr, req)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -85,7 +85,7 @@ func Register(engine *gin.Engine, authSvc *auth.Service, proxySvc *proxy.Service
 		middleware.WithTimingEntry(),
 		middleware.WithTimeout(messagesTimeout),
 		middleware.WithAuth(authSvc),
-		middleware.WithEmbedLastUserMessageOverride(),
+		middleware.WithEmbedOnlyUserMessageOverride(),
 		middleware.WithClusterVersionOverride(),
 	)
 	messagesGroup.POST("/v1/messages", anthropicapi.MessagesHandler(proxySvc, authSvc))
@@ -94,7 +94,7 @@ func Register(engine *gin.Engine, authSvc *auth.Service, proxySvc *proxy.Service
 		middleware.WithTimingEntry(),
 		middleware.WithTimeout(chatCompletionTimeout),
 		middleware.WithAuth(authSvc),
-		middleware.WithEmbedLastUserMessageOverride(),
+		middleware.WithEmbedOnlyUserMessageOverride(),
 		middleware.WithClusterVersionOverride(),
 	)
 	chatCompletionGroup.POST("/v1/chat/completions", openaiapi.ChatCompletionHandler(proxySvc, authSvc))
@@ -112,7 +112,7 @@ func Register(engine *gin.Engine, authSvc *auth.Service, proxySvc *proxy.Service
 	routeGroup := engine.Group("",
 		middleware.WithTimeout(routeTimeout),
 		middleware.WithAuth(authSvc),
-		middleware.WithEmbedLastUserMessageOverride(),
+		middleware.WithEmbedOnlyUserMessageOverride(),
 		middleware.WithClusterVersionOverride(),
 	)
 	routeGroup.POST("/v1/route", anthropicapi.RouteHandler(proxySvc))

--- a/internal/translate/features.go
+++ b/internal/translate/features.go
@@ -19,41 +19,45 @@ type RoutingFeatures struct {
 	LastKind string
 	// LastPreview: first previewMaxChars of the last message's text, newlines collapsed.
 	LastPreview string
-	// LastUserMessageText: most recent user-authored prompt text (skipping tool_result blocks).
-	LastUserMessageText string
+	// OnlyUserMessageText: concatenated text from every role=="user" message in
+	// order, with system prompt, assistant turns, and tool_result blocks
+	// excluded. Populated when the caller passes extractOnlyUser=true.
+	OnlyUserMessageText string
 }
 
-// RoutingFeatures extracts routing inputs from the envelope.
-func (e *RequestEnvelope) RoutingFeatures(extractLastUser bool) RoutingFeatures {
+// RoutingFeatures extracts routing inputs from the envelope. When
+// extractOnlyUser is true, OnlyUserMessageText is populated so the caller can
+// route on user-typed text only.
+func (e *RequestEnvelope) RoutingFeatures(extractOnlyUser bool) RoutingFeatures {
 	switch e.format {
 	case FormatAnthropic:
-		return e.anthropicRoutingFeatures(extractLastUser)
+		return e.anthropicRoutingFeatures(extractOnlyUser)
 	case FormatOpenAI:
-		return e.openAIRoutingFeatures()
+		return e.openAIRoutingFeatures(extractOnlyUser)
 	case FormatGemini:
-		return e.geminiRoutingFeatures()
+		return e.geminiRoutingFeatures(extractOnlyUser)
 	default:
 		return RoutingFeatures{}
 	}
 }
 
-func (e *RequestEnvelope) anthropicRoutingFeatures(extractLastUser bool) RoutingFeatures {
+func (e *RequestEnvelope) anthropicRoutingFeatures(extractOnlyUser bool) RoutingFeatures {
 	var b strings.Builder
 	appendText(&b, systemTextGJSON(gjson.GetBytes(e.body, "system")))
 
 	msgs := gjson.GetBytes(e.body, "messages")
 	var (
-		msgCount     int
-		lastMsg      gjson.Result
-		lastUserText string
+		msgCount  int
+		lastMsg   gjson.Result
+		onlyUserB strings.Builder
 	)
 	msgs.ForEach(func(_, msg gjson.Result) bool {
 		msgCount++
 		appendText(&b, contentTextGJSON(msg.Get("content")))
 		lastMsg = msg
-		if extractLastUser && msg.Get("role").String() == "user" {
+		if extractOnlyUser && msg.Get("role").String() == "user" {
 			if text := userPromptTextGJSON(msg.Get("content")); text != "" {
-				lastUserText = text
+				appendText(&onlyUserB, text)
 			}
 		}
 		return true
@@ -73,25 +77,31 @@ func (e *RequestEnvelope) anthropicRoutingFeatures(extractLastUser bool) Routing
 		feats.LastPreview = previewGJSON(lastMsg.Get("content"))
 	}
 
-	if lastUserText != "" {
-		feats.LastUserMessageText = lastUserText
+	if onlyUserB.Len() > 0 {
+		feats.OnlyUserMessageText = onlyUserB.String()
 	}
 
 	return feats
 }
 
-func (e *RequestEnvelope) openAIRoutingFeatures() RoutingFeatures {
+func (e *RequestEnvelope) openAIRoutingFeatures(extractOnlyUser bool) RoutingFeatures {
 	msgs := gjson.GetBytes(e.body, "messages")
 
 	var b strings.Builder
 	var (
-		msgCount int
-		lastMsg  gjson.Result
+		msgCount  int
+		lastMsg   gjson.Result
+		onlyUserB strings.Builder
 	)
 	msgs.ForEach(func(_, msg gjson.Result) bool {
 		msgCount++
 		appendText(&b, openAIContentTextGJSON(msg.Get("content")))
 		lastMsg = msg
+		if extractOnlyUser && msg.Get("role").String() == "user" {
+			if text := openAIContentTextGJSON(msg.Get("content")); text != "" {
+				appendText(&onlyUserB, text)
+			}
+		}
 		return true
 	})
 	text := b.String()
@@ -107,6 +117,10 @@ func (e *RequestEnvelope) openAIRoutingFeatures() RoutingFeatures {
 	if msgCount > 0 {
 		feats.LastKind = classifyLastMessageOpenAI(lastMsg.Get("role").String())
 		feats.LastPreview = previewText(openAIContentTextGJSON(lastMsg.Get("content")))
+	}
+
+	if onlyUserB.Len() > 0 {
+		feats.OnlyUserMessageText = onlyUserB.String()
 	}
 
 	return feats

--- a/internal/translate/features_gemini.go
+++ b/internal/translate/features_gemini.go
@@ -12,20 +12,26 @@ import (
 //   - tools / generationConfig: top-level
 // Streaming choice is encoded in the URL path, not the body.
 
-func (e *RequestEnvelope) geminiRoutingFeatures() RoutingFeatures {
+func (e *RequestEnvelope) geminiRoutingFeatures(extractOnlyUser bool) RoutingFeatures {
 	contents := gjson.GetBytes(e.body, "contents")
 
 	var b strings.Builder
 	appendText(&b, geminiSystemText(e.body))
 
 	var (
-		msgCount int
-		lastMsg  gjson.Result
+		msgCount  int
+		lastMsg   gjson.Result
+		onlyUserB strings.Builder
 	)
 	contents.ForEach(func(_, msg gjson.Result) bool {
 		msgCount++
 		appendText(&b, geminiPartsText(msg.Get("parts")))
 		lastMsg = msg
+		if extractOnlyUser && msg.Get("role").String() == "user" {
+			if text := geminiPartsText(msg.Get("parts")); text != "" {
+				appendText(&onlyUserB, text)
+			}
+		}
 		return true
 	})
 	text := b.String()
@@ -41,6 +47,10 @@ func (e *RequestEnvelope) geminiRoutingFeatures() RoutingFeatures {
 	if msgCount > 0 {
 		feats.LastKind = classifyLastMessageGemini(lastMsg)
 		feats.LastPreview = previewText(geminiPartsText(lastMsg.Get("parts")))
+	}
+
+	if onlyUserB.Len() > 0 {
+		feats.OnlyUserMessageText = onlyUserB.String()
 	}
 
 	return feats


### PR DESCRIPTION
## Summary
- Rename `embedLastUserMessage` -> `embedOnlyUserMessage` and redefine: when on, route on the concatenated text of every `role=="user"` message; system prompt, assistant turns, and tool_result blocks are excluded.
- Flip the default to **true**. Customer traffic now routes on user-typed text only.
- Plumb the flag through all three ingress paths: `ProxyMessages` (Anthropic), `ProxyOpenAIChatCompletion`, and `ProxyGeminiGenerateContent`. OpenAI and Gemini previously hardcoded the concatenated stream and ignored the flag.
- Keep the per-request override (renamed `x-weave-embed-only-user-message`) so eval can A/B back to the concatenated mode without a redeploy. `hasEvalOverrideHeader` updated to match.
- Env var: `ROUTER_EMBED_LAST_USER_MESSAGE` -> `ROUTER_EMBED_ONLY_USER_MESSAGE` (default `"true"`). Admin `/config` JSON field renamed `embed_only_user_message`, dashboard label updated.

## Why
Previously the routing embedder saw system preambles, assistant tool_use turns, and tool_result blocks alongside the user prompt. For Claude-Code-shaped conversations the user-typed text was a small fraction of the embedded input, biasing routing toward whatever the surrounding context looked like. Routing on user-role text only matches what the model is actually being asked.

## Test plan
- [x] `go build -tags no_onnx ./...`
- [x] `go test -tags no_onnx ./...` — all packages pass
- [x] `gofmt -l internal/ cmd/` clean
- [x] `go vet -tags no_onnx ./...` clean
- [x] Updated `TestService_ProxyMessages_EmbedOnlyUserMessageFlag` covers multi-user-message concatenation and tool_result/assistant exclusion
- [x] Context-override and middleware tests renamed; both pass
- [ ] Manual: hit `/v1/messages`, `/v1/chat/completions`, `/v1beta/models/:modelAction` with multi-turn conversations and confirm `routing.embed_input=only_user_message` in OTel spans
- [ ] Manual: set `x-weave-embed-only-user-message: false` and confirm the route bypasses the per-API-key sticky cache

🤖 Generated with [Claude Code](https://claude.com/claude-code)