### PR TITLE
fix(translate): repair Anthropic→Gemini tool schemas (array items, empty enums)

### DIFF
--- a/internal/translate/emit_gemini.go
+++ b/internal/translate/emit_gemini.go
@@ -707,10 +707,24 @@ func sanitizeSchemaForGemini(v any) any {
 			if _, drop := geminiUnsupportedSchemaKeys[k]; drop {
 				continue
 			}
-			if k == "enum" && !enumAllStrings(child) {
+			if k == "enum" {
+				cleaned := filterStringEnum(child)
+				if len(cleaned) == 0 {
+					continue
+				}
+				out[k] = cleaned
 				continue
 			}
 			out[k] = sanitizeSchemaForGemini(child)
+		}
+		// Anthropic permits `{"type":"array"}` with no `items`; Gemini's strict
+		// function-calling validator rejects it ("missing field"). Inject a
+		// permissive default so the tool definition survives translation. Real
+		// items schemas from the source were preserved by the loop above.
+		if t, ok := out["type"].(string); ok && t == "array" {
+			if existing, has := out["items"]; !has || existing == nil {
+				out["items"] = map[string]any{"type": "string"}
+			}
 		}
 		return out
 	case []any:
@@ -724,19 +738,24 @@ func sanitizeSchemaForGemini(v any) any {
 	}
 }
 
-// enumAllStrings reports whether enum entries are all strings. Google requires
-// TYPE_STRING enums; numeric/mixed are rejected with a 400, so we drop them.
-func enumAllStrings(v any) bool {
+// filterStringEnum returns enum entries that are non-empty strings. Google's
+// function-calling surface requires TYPE_STRING enums and rejects empty-string
+// entries ("enum[i]: cannot be empty"); both filter out here. Returns an empty
+// slice when nothing survives so the caller can drop the field entirely.
+func filterStringEnum(v any) []any {
 	arr, ok := v.([]any)
 	if !ok {
-		return false
+		return nil
 	}
+	out := make([]any, 0, len(arr))
 	for _, item := range arr {
-		if _, ok := item.(string); !ok {
-			return false
+		s, ok := item.(string)
+		if !ok || s == "" {
+			continue
 		}
+		out = append(out, s)
 	}
-	return true
+	return out
 }
 
 func pullAnthropicToolChoiceToGemini(body []byte, out map[string]any) {

--- a/internal/translate/gemini_test.go
+++ b/internal/translate/gemini_test.go
@@ -471,3 +471,85 @@ func TestSanitizeSchemaForGemini_PreservesSupportedFields(t *testing.T) {
 	assert.Equal(t, true, props["line"].(map[string]any)["nullable"], "nullable must survive")
 	assert.Equal(t, []any{"path", "mode"}, params["required"], "required must survive")
 }
+
+func TestPrepareGemini_RepairsArrayMissingItems(t *testing.T) {
+	// Regression: production Claude Code traffic includes MCP tools whose schemas
+	// declare `{"type":"array"}` with no `items` field (valid JSON Schema, invalid
+	// Gemini function-call schema). Gemini rejected the whole request with
+	// "GenerateContentRequest.tools[0].function_declarations[N].parameters.
+	// properties[X].items: missing field". Inject a permissive default instead.
+	body := []byte(`{
+		"messages": [{"role":"user","content":"hi"}],
+		"tools": [{
+			"name":"odd-tool",
+			"input_schema":{
+				"type":"object",
+				"properties":{
+					"tools":{"type":"array","description":"a list of tools"},
+					"nested":{
+						"type":"object",
+						"properties":{
+							"items":{"type":"array"}
+						}
+					}
+				}
+			}
+		}]
+	}`)
+	env, err := translate.ParseAnthropic(body)
+	require.NoError(t, err)
+	prep, err := env.PrepareGemini(http.Header{}, translate.EmitOptions{})
+	require.NoError(t, err)
+
+	out := mustUnmarshal(t, prep.Body)
+	params := out["tools"].([]any)[0].(map[string]any)["functionDeclarations"].([]any)[0].(map[string]any)["parameters"].(map[string]any)
+	props := params["properties"].(map[string]any)
+
+	toolsField := props["tools"].(map[string]any)
+	assert.Equal(t, "array", toolsField["type"])
+	require.Contains(t, toolsField, "items", "top-level array missing items must get a default injected")
+	assert.Equal(t, map[string]any{"type": "string"}, toolsField["items"])
+
+	nestedItems := props["nested"].(map[string]any)["properties"].(map[string]any)["items"].(map[string]any)
+	assert.Equal(t, "array", nestedItems["type"])
+	require.Contains(t, nestedItems, "items", "nested array missing items must get a default injected too")
+	assert.Equal(t, map[string]any{"type": "string"}, nestedItems["items"])
+}
+
+func TestPrepareGemini_DropsEmptyStringEnumEntries(t *testing.T) {
+	// Regression: MCP tool schemas occasionally include `""` as an enum value
+	// (e.g. an "operator" field that allows "no filter"). Gemini rejects with
+	// "function_declarations[N].parameters.properties[X].enum[0]: cannot be
+	// empty". Drop empty strings; drop the enum entirely when nothing remains.
+	body := []byte(`{
+		"messages": [{"role":"user","content":"hi"}],
+		"tools": [{
+			"name":"odd-tool",
+			"input_schema":{
+				"type":"object",
+				"properties":{
+					"operator":{"type":"string","enum":["","eq","neq","gt"]},
+					"all_empty":{"type":"string","enum":["",""]},
+					"normal":{"type":"string","enum":["a","b"]}
+				}
+			}
+		}]
+	}`)
+	env, err := translate.ParseAnthropic(body)
+	require.NoError(t, err)
+	prep, err := env.PrepareGemini(http.Header{}, translate.EmitOptions{})
+	require.NoError(t, err)
+
+	out := mustUnmarshal(t, prep.Body)
+	params := out["tools"].([]any)[0].(map[string]any)["functionDeclarations"].([]any)[0].(map[string]any)["parameters"].(map[string]any)
+	props := params["properties"].(map[string]any)
+
+	operator := props["operator"].(map[string]any)
+	assert.Equal(t, []any{"eq", "neq", "gt"}, operator["enum"], "empty string must be filtered out")
+
+	allEmpty := props["all_empty"].(map[string]any)
+	assert.NotContains(t, allEmpty, "enum", "enum with only empty strings must be dropped entirely")
+
+	normal := props["normal"].(map[string]any)
+	assert.Equal(t, []any{"a", "b"}, normal["enum"], "well-formed enums must pass through unchanged")
+}


### PR DESCRIPTION
## Summary
`sanitizeSchemaForGemini` was leaving two patterns intact that Gemini's strict function-calling validator rejects with HTTP 400:

- **Arrays without `items`.** Anthropic permits `{"type":"array"}` with no `items`; Gemini errors with `properties[X].items: missing field`. Inject `items: {"type": "string"}` as a permissive default when an array node has no items (or `items: null`). Real item schemas from the source are preserved by the existing recursion.
- **Empty-string entries in enums.** `enumAllStrings` reported `true` for arrays like `["", "eq", "neq"]` (empty string is a string), so the enum survived and Gemini errored with `enum[0]: cannot be empty`. Replaced with `filterStringEnum` that drops empty/non-string entries and drops the whole enum field when nothing remains.

## Why
Hit production when a Claude Code session's cache-aware planner switched into `gemini-3.1-flash-lite-preview` (PR #82's planner). The cluster decision was sound but the upstream call 400'd on three of the user's MCP tool definitions (`function_declarations[299]`, `[320]`, `[323]`):

```
GenerateContentRequest.tools[0].function_declarations[299].parameters.properties[tools].items: missing field
GenerateContentRequest.tools[0].function_declarations[320].parameters.properties[filters].items.properties[operator].enum[0]: cannot be empty
GenerateContentRequest.tools[0].function_declarations[320].parameters.properties[filters].items.properties[value].items: missing field
GenerateContentRequest.tools[0].function_declarations[323].parameters.properties[filters].items.properties[operator].enum[0]: cannot be empty
GenerateContentRequest.tools[0].function_declarations[323].parameters.properties[filters].items.properties[value].items: missing field
```

The downstream effect was that any planner-driven switch into Gemini failed the turn instead of falling back, so this is load-bearing for cache-aware routing shipping with Gemini as a real switch target.

## Test plan
- [x] `go build -tags no_onnx ./...` clean
- [x] `go vet -tags no_onnx ./...` clean
- [x] `gofmt -l internal/translate/` clean
- [x] `go test -tags no_onnx ./internal/translate/ -count=1` — all green
- [x] Two new regression tests mirror both production error shapes:
  - `TestPrepareGemini_RepairsArrayMissingItems` — top-level + nested arrays with missing `items`
  - `TestPrepareGemini_DropsEmptyStringEnumEntries` — empty strings filtered, all-empty enums dropped entirely, well-formed enums pass through unchanged
- [ ] Manual end-to-end: with PR #82 branch checked out and planner enabled, run a multi-turn Claude Code session that triggers an EV-positive switch into a Gemini target. Confirm `upstream_status=200` rather than `upstream_status=400` on the switch turn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)