### PR TITLE
feat(proxy): inject routing marker as first content block in cross-format streams

### DIFF
--- a/internal/proxy/marker_internal_test.go
+++ b/internal/proxy/marker_internal_test.go
@@ -1,0 +1,258 @@
+package proxy
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"workweave/router/internal/router"
+	"workweave/router/internal/router/planner"
+	"workweave/router/internal/translate"
+)
+
+// TestRoutingMarkerFor_PlannerPaths covers the planner outcomes a reader
+// of the assistant pane is most likely to see, plus the no-planner
+// fallbacks. The upfront marker reports brand + model + reason only;
+// savings live on the closing marker (see TestClosingMarkerFor_*).
+func TestRoutingMarkerFor_PlannerPaths(t *testing.T) {
+	decision := router.Decision{Model: "deepseek/deepseek-v4-pro", Provider: "openrouter"}
+
+	cases := []struct {
+		name           string
+		res            turnLoopResult
+		wantContains   []string
+		wantNotContain []string
+	}{
+		{
+			name: "ev_positive: planner switched",
+			res: turnLoopResult{
+				Decision:        decision,
+				PlannerDecision: planner.Decision{Reason: planner.ReasonEVPositive},
+			},
+			wantContains: []string{
+				"✦ **Weave Router** → deepseek/deepseek-v4-pro (openrouter)",
+				"reason: switched to save on cache reads",
+			},
+			wantNotContain: []string{
+				"ev_positive",
+				"est. save",
+				"saved $",
+			},
+		},
+		{
+			name: "ev_negative: planner stayed",
+			res: turnLoopResult{
+				Decision:        decision,
+				PlannerDecision: planner.Decision{Reason: planner.ReasonEVNegative},
+			},
+			wantContains: []string{
+				"reason: stayed: cache reuse beats the switch",
+			},
+			wantNotContain: []string{
+				"ev_negative",
+				"est. save",
+			},
+		},
+		{
+			name: "same_model: planner ran with trivial outcome",
+			res: turnLoopResult{
+				Decision:        decision,
+				PlannerDecision: planner.Decision{Reason: planner.ReasonSameModel},
+			},
+			wantContains: []string{
+				"reason: scorer matches the pin",
+			},
+			wantNotContain: []string{
+				"est. save",
+				"same_model",
+			},
+		},
+		{
+			name: "no planner ran, fresh decision: first-turn fallback reason",
+			res: turnLoopResult{
+				Decision: decision,
+				// PlannerDecision zero-valued (Reason == "").
+			},
+			wantContains: []string{
+				"reason: first turn",
+			},
+			wantNotContain: []string{
+				"est. save",
+			},
+		},
+		{
+			name: "hard-pin path: planner didn't run, mark it accordingly",
+			res: turnLoopResult{
+				Decision:   decision,
+				HardPinned: true,
+			},
+			wantContains: []string{
+				"reason: hard pin (compaction / sub-agent)",
+			},
+			wantNotContain: []string{
+				"est. save",
+			},
+		},
+		{
+			name: "tool-result short-circuit: pinned model reused, no planner",
+			res: turnLoopResult{
+				Decision:  decision,
+				StickyHit: true,
+			},
+			wantContains: []string{
+				"reason: tool-result follow-up",
+			},
+			wantNotContain: []string{
+				"est. save",
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := routingMarkerFor(tc.res)
+			for _, want := range tc.wantContains {
+				assert.Contains(t, got, want)
+			}
+			for _, nope := range tc.wantNotContain {
+				assert.NotContains(t, got, nope)
+			}
+			assert.True(t, len(got) >= 2 && got[len(got)-2:] == "\n\n",
+				"marker must terminate with a blank line so the upstream response starts on its own paragraph")
+		})
+	}
+}
+
+func TestRoutingMarkerFor_EmptyDecisionEmitsNothing(t *testing.T) {
+	// Defensive: a routing path that produced no Decision.Model shouldn't
+	// inject an empty / malformed marker into the response.
+	got := routingMarkerFor(turnLoopResult{Decision: router.Decision{}})
+	assert.Empty(t, got)
+}
+
+func TestRoutingMarkerFor_OmitsProviderParensWhenProviderMissing(t *testing.T) {
+	// Some upstream paths populate Model but not Provider. Marker must
+	// still be well-formed (no trailing empty parens).
+	got := routingMarkerFor(turnLoopResult{
+		Decision: router.Decision{Model: "claude-haiku-4-5"},
+		PlannerDecision: planner.Decision{
+			Reason: planner.ReasonNoPin,
+		},
+	})
+	assert.Contains(t, got, "✦ **Weave Router** → claude-haiku-4-5 ·")
+	assert.NotContains(t, got, "()")
+	assert.Contains(t, got, "reason: first turn")
+}
+
+// TestHumanReasonFromPlanner_UnknownCodePassesThrough verifies the
+// fail-loud behavior: a new planner reason code that hasn't been added
+// to the human-readable map surfaces in the marker as its raw label,
+// not as silently dropped text.
+func TestHumanReasonFromPlanner_UnknownCodePassesThrough(t *testing.T) {
+	got := humanReasonFromPlanner("brand_new_reason_v9")
+	assert.Equal(t, "brand_new_reason_v9", got)
+}
+
+// TestClosingMarkerFor_EmitsSavingsWhenRoutedIsCheaper exercises the
+// happy path: routed to a cheap model, request was for an expensive
+// one, savings > $0.0001 → marker fires with the correct dollar amount
+// and "vs <requested>" framing.
+func TestClosingMarkerFor_EmitsSavingsWhenRoutedIsCheaper(t *testing.T) {
+	// claude-opus-4-7: $15 input / $75 output / 0.10 cache mult
+	// deepseek/deepseek-v4-pro: $0.435 input / $0.870 output / 0.10 cache mult
+	// Usage: 10k non-cached input, 5k cache-read, 1k output.
+	//   routed input    = 10000*0.435 + 5000*0.435*0.10 = 4350 + 217.5 = 4567.5
+	//   routed output   = 1000*0.870 = 870
+	//   routed total    = 5437.5 / 1e6 = $0.0054375
+	//   requested input = 10000*15 + 5000*15*0.10 = 150000 + 7500 = 157500
+	//   requested out   = 1000*75 = 75000
+	//   requested total = 232500 / 1e6 = $0.2325
+	//   savings         = 0.2325 - 0.0054375 = $0.2270625
+	fn := closingMarkerFor(
+		router.Decision{Model: "deepseek/deepseek-v4-pro", Provider: "openrouter"},
+		"claude-opus-4-7",
+	)
+	got := fn(translate.Usage{InputTokens: 15000, OutputTokens: 1000, CacheReadTokens: 5000})
+	assert.Equal(t, "✦ saved $0.2271 vs claude-opus-4-7 (15k in / 1k out)", got)
+}
+
+// TestClosingMarkerFor_FormatsTokenCounts pins the order-of-magnitude
+// short-form rendering so the marker stays legible across sub-1k,
+// thousands, and million-token turns. Demos rely on this readability:
+// "127k in" is what makes the savings number believable.
+func TestClosingMarkerFor_FormatsTokenCounts(t *testing.T) {
+	fn := closingMarkerFor(
+		router.Decision{Model: "deepseek/deepseek-v4-pro", Provider: "openrouter"},
+		"claude-opus-4-7",
+	)
+	cases := []struct {
+		name string
+		u    translate.Usage
+		want string
+	}{
+		{
+			name: "thousands input, sub-thousand output",
+			u:    translate.Usage{InputTokens: 127053, OutputTokens: 50},
+			want: "(127k in / 50 out)",
+		},
+		{
+			name: "sub-thousand both",
+			u:    translate.Usage{InputTokens: 850, OutputTokens: 42},
+			want: "(850 in / 42 out)",
+		},
+		{
+			name: "million-plus input",
+			u:    translate.Usage{InputTokens: 1_500_000, OutputTokens: 2000},
+			want: "(1.5M in / 2k out)",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := fn(tc.u)
+			assert.Contains(t, got, tc.want)
+		})
+	}
+}
+
+func TestClosingMarkerFor_NoEmissionWhenRoutedEqualsRequested(t *testing.T) {
+	// Identity case: nothing to compare against → no marker.
+	fn := closingMarkerFor(
+		router.Decision{Model: "claude-opus-4-7", Provider: "anthropic"},
+		"claude-opus-4-7",
+	)
+	got := fn(translate.Usage{InputTokens: 10000, OutputTokens: 500})
+	assert.Empty(t, got)
+}
+
+func TestClosingMarkerFor_NoEmissionWhenSavingsAreNonPositive(t *testing.T) {
+	// Routed to the EXPENSIVE side relative to what the client asked
+	// for — the marker mustn't advertise a loss. Inverse of the happy
+	// path above.
+	fn := closingMarkerFor(
+		router.Decision{Model: "claude-opus-4-7", Provider: "anthropic"},
+		"deepseek/deepseek-v4-pro",
+	)
+	got := fn(translate.Usage{InputTokens: 15000, OutputTokens: 1000, CacheReadTokens: 5000})
+	assert.Empty(t, got)
+}
+
+func TestClosingMarkerFor_NoEmissionWhenPricingMissing(t *testing.T) {
+	// Routed model unknown to the pricing table → can't compute → skip.
+	fn := closingMarkerFor(
+		router.Decision{Model: "imaginary-model-v0", Provider: "openrouter"},
+		"claude-opus-4-7",
+	)
+	got := fn(translate.Usage{InputTokens: 10000, OutputTokens: 1000})
+	assert.Empty(t, got)
+}
+
+func TestClosingMarkerFor_NoEmissionWhenSavingsBelowEpsilon(t *testing.T) {
+	// Tiny token counts → savings fall below $0.0001 floor → skip so
+	// the marker doesn't flicker for trivial turns.
+	fn := closingMarkerFor(
+		router.Decision{Model: "deepseek/deepseek-v4-pro", Provider: "openrouter"},
+		"claude-opus-4-7",
+	)
+	got := fn(translate.Usage{InputTokens: 1, OutputTokens: 1})
+	assert.Empty(t, got)
+}

--- a/internal/proxy/marker_internal_test.go
+++ b/internal/proxy/marker_internal_test.go
@@ -10,10 +10,6 @@ import (
 	"workweave/router/internal/translate"
 )
 
-// TestRoutingMarkerFor_PlannerPaths covers the planner outcomes a reader
-// of the assistant pane is most likely to see, plus the no-planner
-// fallbacks. The upfront marker reports brand + model + reason only;
-// savings live on the closing marker (see TestClosingMarkerFor_*).
 func TestRoutingMarkerFor_PlannerPaths(t *testing.T) {
 	decision := router.Decision{Model: "deepseek/deepseek-v4-pro", Provider: "openrouter"}
 
@@ -71,7 +67,6 @@ func TestRoutingMarkerFor_PlannerPaths(t *testing.T) {
 			name: "no planner ran, fresh decision: first-turn fallback reason",
 			res: turnLoopResult{
 				Decision: decision,
-				// PlannerDecision zero-valued (Reason == "").
 			},
 			wantContains: []string{
 				"reason: first turn",
@@ -118,21 +113,17 @@ func TestRoutingMarkerFor_PlannerPaths(t *testing.T) {
 				assert.NotContains(t, got, nope)
 			}
 			assert.True(t, len(got) >= 2 && got[len(got)-2:] == "\n\n",
-				"marker must terminate with a blank line so the upstream response starts on its own paragraph")
+				"marker must terminate with a blank line")
 		})
 	}
 }
 
 func TestRoutingMarkerFor_EmptyDecisionEmitsNothing(t *testing.T) {
-	// Defensive: a routing path that produced no Decision.Model shouldn't
-	// inject an empty / malformed marker into the response.
 	got := routingMarkerFor(turnLoopResult{Decision: router.Decision{}})
 	assert.Empty(t, got)
 }
 
 func TestRoutingMarkerFor_OmitsProviderParensWhenProviderMissing(t *testing.T) {
-	// Some upstream paths populate Model but not Provider. Marker must
-	// still be well-formed (no trailing empty parens).
 	got := routingMarkerFor(turnLoopResult{
 		Decision: router.Decision{Model: "claude-haiku-4-5"},
 		PlannerDecision: planner.Decision{
@@ -144,30 +135,14 @@ func TestRoutingMarkerFor_OmitsProviderParensWhenProviderMissing(t *testing.T) {
 	assert.Contains(t, got, "reason: first turn")
 }
 
-// TestHumanReasonFromPlanner_UnknownCodePassesThrough verifies the
-// fail-loud behavior: a new planner reason code that hasn't been added
-// to the human-readable map surfaces in the marker as its raw label,
-// not as silently dropped text.
 func TestHumanReasonFromPlanner_UnknownCodePassesThrough(t *testing.T) {
 	got := humanReasonFromPlanner("brand_new_reason_v9")
 	assert.Equal(t, "brand_new_reason_v9", got)
 }
 
-// TestClosingMarkerFor_EmitsSavingsWhenRoutedIsCheaper exercises the
-// happy path: routed to a cheap model, request was for an expensive
-// one, savings > $0.0001 → marker fires with the correct dollar amount
-// and "vs <requested>" framing.
 func TestClosingMarkerFor_EmitsSavingsWhenRoutedIsCheaper(t *testing.T) {
-	// claude-opus-4-7: $15 input / $75 output / 0.10 cache mult
-	// deepseek/deepseek-v4-pro: $0.435 input / $0.870 output / 0.10 cache mult
-	// Usage: 10k non-cached input, 5k cache-read, 1k output.
-	//   routed input    = 10000*0.435 + 5000*0.435*0.10 = 4350 + 217.5 = 4567.5
-	//   routed output   = 1000*0.870 = 870
-	//   routed total    = 5437.5 / 1e6 = $0.0054375
-	//   requested input = 10000*15 + 5000*15*0.10 = 150000 + 7500 = 157500
-	//   requested out   = 1000*75 = 75000
-	//   requested total = 232500 / 1e6 = $0.2325
-	//   savings         = 0.2325 - 0.0054375 = $0.2270625
+	// opus 4.7 ($15/$75) vs deepseek-v4-pro ($0.435/$0.870), 0.10 cache mult,
+	// 10k non-cached + 5k cache-read in / 1k out → savings = $0.2271.
 	fn := closingMarkerFor(
 		router.Decision{Model: "deepseek/deepseek-v4-pro", Provider: "openrouter"},
 		"claude-opus-4-7",
@@ -176,10 +151,6 @@ func TestClosingMarkerFor_EmitsSavingsWhenRoutedIsCheaper(t *testing.T) {
 	assert.Equal(t, "✦ saved $0.2271 vs claude-opus-4-7 (15k in / 1k out)", got)
 }
 
-// TestClosingMarkerFor_FormatsTokenCounts pins the order-of-magnitude
-// short-form rendering so the marker stays legible across sub-1k,
-// thousands, and million-token turns. Demos rely on this readability:
-// "127k in" is what makes the savings number believable.
 func TestClosingMarkerFor_FormatsTokenCounts(t *testing.T) {
 	fn := closingMarkerFor(
 		router.Decision{Model: "deepseek/deepseek-v4-pro", Provider: "openrouter"},
@@ -215,7 +186,6 @@ func TestClosingMarkerFor_FormatsTokenCounts(t *testing.T) {
 }
 
 func TestClosingMarkerFor_NoEmissionWhenRoutedEqualsRequested(t *testing.T) {
-	// Identity case: nothing to compare against → no marker.
 	fn := closingMarkerFor(
 		router.Decision{Model: "claude-opus-4-7", Provider: "anthropic"},
 		"claude-opus-4-7",
@@ -225,9 +195,7 @@ func TestClosingMarkerFor_NoEmissionWhenRoutedEqualsRequested(t *testing.T) {
 }
 
 func TestClosingMarkerFor_NoEmissionWhenSavingsAreNonPositive(t *testing.T) {
-	// Routed to the EXPENSIVE side relative to what the client asked
-	// for — the marker mustn't advertise a loss. Inverse of the happy
-	// path above.
+	// Routed to the more expensive side — marker mustn't advertise a loss.
 	fn := closingMarkerFor(
 		router.Decision{Model: "claude-opus-4-7", Provider: "anthropic"},
 		"deepseek/deepseek-v4-pro",
@@ -237,7 +205,6 @@ func TestClosingMarkerFor_NoEmissionWhenSavingsAreNonPositive(t *testing.T) {
 }
 
 func TestClosingMarkerFor_NoEmissionWhenPricingMissing(t *testing.T) {
-	// Routed model unknown to the pricing table → can't compute → skip.
 	fn := closingMarkerFor(
 		router.Decision{Model: "imaginary-model-v0", Provider: "openrouter"},
 		"claude-opus-4-7",
@@ -247,8 +214,7 @@ func TestClosingMarkerFor_NoEmissionWhenPricingMissing(t *testing.T) {
 }
 
 func TestClosingMarkerFor_NoEmissionWhenSavingsBelowEpsilon(t *testing.T) {
-	// Tiny token counts → savings fall below $0.0001 floor → skip so
-	// the marker doesn't flicker for trivial turns.
+	// Savings below $0.0001 → skip so the marker doesn't flicker.
 	fn := closingMarkerFor(
 		router.Decision{Model: "deepseek/deepseek-v4-pro", Provider: "openrouter"},
 		"claude-opus-4-7",

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -109,22 +109,14 @@ type InstallationExcludedModelsContextKey struct{}
 
 // installationExcludedModelsFromContext returns the per-installation exclusion
 // list stashed on ctx by the auth middleware, or nil when none is present.
-// routingMarkerFor returns the upfront text snippet — brand, routed
-// model + provider, and routing reason — emitted as a standalone
-// Anthropic content block at the start of every cross-format streamed
-// response. The actual-cost savings line is emitted separately by
-// closingMarkerFor after the response completes, so it can use
-// observed usage numbers instead of an a priori EV estimate. Returns
-// "" (no emission) when the decision carries no model name.
+
+// routingMarkerFor builds the upfront "brand → model · reason" snippet emitted
+// at the start of every cross-format streamed response.
 func routingMarkerFor(res turnLoopResult) string {
 	decision := res.Decision
 	if decision.Model == "" {
 		return ""
 	}
-	// "Weave Router" wrapped in markdown bold so the brand stands out in
-	// the agent pane. Claude Code renders Markdown but not raw ANSI inside
-	// assistant content, so we can't paint the brand color (#FF6C47) the
-	// statusline uses — bold is the closest portable affordance.
 	parts := []string{"✦ **Weave Router** → " + decision.Model}
 	if decision.Provider != "" {
 		parts[0] += " (" + decision.Provider + ")"
@@ -135,23 +127,9 @@ func routingMarkerFor(res turnLoopResult) string {
 	return strings.Join(parts, " · ") + "\n\n"
 }
 
-// closingMarkerFor returns the callback the SSE translator invokes
-// after the response stream completes. The returned function receives
-// the upstream-observed usage and emits a single-line "saved $X vs Y"
-// summary using actual input + output token counts × per-model pricing
-// (input + cache-read multiplier + output). Returns "" (no closing
-// marker) when:
-//
-//   - the routed model is the same as what the client requested (no
-//     comparison to draw),
-//   - pricing data is missing for either side (can't compute),
-//   - or the computed savings are non-positive (we'd be advertising a
-//     loss; demo affordance — also keeps the marker from cluttering
-//     legitimately equal-cost turns).
-//
-// Tracks the requested model the client originally asked for (from
-// feats.Model) and the routed decision so it can format
-// "saved $X vs <requested>".
+// closingMarkerFor returns a callback that formats a "saved $X vs <requested>"
+// line from observed usage. Returns "" when routed == requested, pricing is
+// missing, or savings are non-positive / below the flicker floor.
 func closingMarkerFor(decision router.Decision, requestedModel string) func(translate.Usage) string {
 	return func(u translate.Usage) string {
 		if decision.Model == "" || requestedModel == "" {
@@ -166,8 +144,6 @@ func closingMarkerFor(decision router.Decision, requestedModel string) func(tran
 			return ""
 		}
 		savings := closingMarkerSavingsUSD(u, routed, requested)
-		// Skip sub-tenth-of-a-cent diffs so floating-point noise on
-		// zero-traffic turns doesn't flicker a "saved $0.0001" line.
 		if savings < 0.0001 {
 			return ""
 		}
@@ -177,12 +153,7 @@ func closingMarkerFor(decision router.Decision, requestedModel string) func(tran
 	}
 }
 
-// formatTokenCount renders a token count for the closing marker in the
-// most legible short form: raw for sub-1k counts, "%dk" for thousands,
-// "%.1fM" once a turn breaks a million tokens. The marker is
-// audience-facing, not a billing source of truth — readability over
-// precision is the right tradeoff. The DB telemetry table still
-// carries exact integer counts for accounting.
+// formatTokenCount renders a token count as raw / "Nk" / "N.NM".
 func formatTokenCount(n int) string {
 	switch {
 	case n < 1000:
@@ -194,13 +165,8 @@ func formatTokenCount(n int) string {
 	}
 }
 
-// closingMarkerSavingsUSD computes (alternative cost on requested model)
-// minus (actual cost on routed model) using the post-stream usage
-// breakdown. Both sides are priced under the same usage shape — input
-// tokens at full price minus the cached portion at the model's
-// cache-read multiplier — so the delta isolates the price difference
-// between the two models for the same workload. Output tokens are
-// always priced at the model's full output rate.
+// closingMarkerSavingsUSD = requested-model cost − routed-model cost for the
+// same usage shape.
 func closingMarkerSavingsUSD(u translate.Usage, routed, requested pricing.Pricing) float64 {
 	nonCached := u.InputTokens - u.CacheReadTokens
 	if nonCached < 0 {
@@ -211,11 +177,7 @@ func closingMarkerSavingsUSD(u translate.Usage, routed, requested pricing.Pricin
 	return requestedCost - routedCost
 }
 
-// costForUsage returns the dollar cost of (nonCached, cacheRead, output)
-// tokens billed against the given Pricing entry. Cache-creation tokens
-// are folded into nonCached at full price — OpenAI-style upstreams
-// don't bill writes separately, and the demo marker is an
-// approximation, not the source of truth (the telemetry table is).
+// costForUsage prices (nonCached, cacheRead, output) tokens against p.
 func costForUsage(nonCachedInput, cacheReadInput, output int, p pricing.Pricing) float64 {
 	cacheMult := p.EffectiveCacheReadMultiplier()
 	inputCost := float64(nonCachedInput)*p.InputUSDPer1M +
@@ -224,12 +186,8 @@ func costForUsage(nonCachedInput, cacheReadInput, output int, p pricing.Pricing)
 	return (inputCost + outputCost) / 1e6
 }
 
-// routingReasonShort returns a short, demo-readable phrase for why this
-// turn landed on the chosen model. Translates the planner's snake_case
-// reason codes (machine-friendly, kept verbatim in logs / spans) into
-// the verb-led human-readable form that goes in the in-pane marker.
-// Falls back to a coarse description of the orchestrator path when the
-// planner didn't run so the marker is never reasonless.
+// routingReasonShort returns a human-readable reason for the marker, falling
+// back to the orchestrator path when the planner didn't run.
 func routingReasonShort(res turnLoopResult) string {
 	if res.PlannerDecision.Reason != "" {
 		return humanReasonFromPlanner(res.PlannerDecision.Reason)
@@ -243,12 +201,8 @@ func routingReasonShort(res turnLoopResult) string {
 	return "first turn"
 }
 
-// humanReasonFromPlanner maps planner.Reason* codes to the short
-// human-readable phrases rendered in the marker. Unknown codes pass
-// through verbatim — new planner reasons will surface in the marker
-// as their raw label until this map is updated, which is the right
-// fail-loud behavior (the marker complains visibly instead of silently
-// dropping the reason).
+// humanReasonFromPlanner maps planner.Reason* codes to marker prose. Unknown
+// codes pass through verbatim so new reasons surface visibly.
 func humanReasonFromPlanner(code string) string {
 	switch code {
 	case planner.ReasonEVPositive:

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"net/http"
 	"sort"
+	"strconv"
+	"strings"
 	"time"
 
 	"workweave/router/internal/auth"
@@ -17,6 +19,7 @@ import (
 	"workweave/router/internal/router/cache"
 	"workweave/router/internal/router/handover"
 	"workweave/router/internal/router/planner"
+	"workweave/router/internal/router/pricing"
 	"workweave/router/internal/router/sessionpin"
 	"workweave/router/internal/translate"
 
@@ -106,6 +109,167 @@ type InstallationExcludedModelsContextKey struct{}
 
 // installationExcludedModelsFromContext returns the per-installation exclusion
 // list stashed on ctx by the auth middleware, or nil when none is present.
+// routingMarkerFor returns the upfront text snippet — brand, routed
+// model + provider, and routing reason — emitted as a standalone
+// Anthropic content block at the start of every cross-format streamed
+// response. The actual-cost savings line is emitted separately by
+// closingMarkerFor after the response completes, so it can use
+// observed usage numbers instead of an a priori EV estimate. Returns
+// "" (no emission) when the decision carries no model name.
+func routingMarkerFor(res turnLoopResult) string {
+	decision := res.Decision
+	if decision.Model == "" {
+		return ""
+	}
+	// "Weave Router" wrapped in markdown bold so the brand stands out in
+	// the agent pane. Claude Code renders Markdown but not raw ANSI inside
+	// assistant content, so we can't paint the brand color (#FF6C47) the
+	// statusline uses — bold is the closest portable affordance.
+	parts := []string{"✦ **Weave Router** → " + decision.Model}
+	if decision.Provider != "" {
+		parts[0] += " (" + decision.Provider + ")"
+	}
+	if reason := routingReasonShort(res); reason != "" {
+		parts = append(parts, "reason: "+reason)
+	}
+	return strings.Join(parts, " · ") + "\n\n"
+}
+
+// closingMarkerFor returns the callback the SSE translator invokes
+// after the response stream completes. The returned function receives
+// the upstream-observed usage and emits a single-line "saved $X vs Y"
+// summary using actual input + output token counts × per-model pricing
+// (input + cache-read multiplier + output). Returns "" (no closing
+// marker) when:
+//
+//   - the routed model is the same as what the client requested (no
+//     comparison to draw),
+//   - pricing data is missing for either side (can't compute),
+//   - or the computed savings are non-positive (we'd be advertising a
+//     loss; demo affordance — also keeps the marker from cluttering
+//     legitimately equal-cost turns).
+//
+// Tracks the requested model the client originally asked for (from
+// feats.Model) and the routed decision so it can format
+// "saved $X vs <requested>".
+func closingMarkerFor(decision router.Decision, requestedModel string) func(translate.Usage) string {
+	return func(u translate.Usage) string {
+		if decision.Model == "" || requestedModel == "" {
+			return ""
+		}
+		if decision.Model == requestedModel {
+			return ""
+		}
+		routed, ok1 := pricing.For(decision.Model)
+		requested, ok2 := pricing.For(requestedModel)
+		if !ok1 || !ok2 {
+			return ""
+		}
+		savings := closingMarkerSavingsUSD(u, routed, requested)
+		// Skip sub-tenth-of-a-cent diffs so floating-point noise on
+		// zero-traffic turns doesn't flicker a "saved $0.0001" line.
+		if savings < 0.0001 {
+			return ""
+		}
+		return fmt.Sprintf("✦ saved $%.4f vs %s (%s in / %s out)",
+			savings, requestedModel,
+			formatTokenCount(u.InputTokens), formatTokenCount(u.OutputTokens))
+	}
+}
+
+// formatTokenCount renders a token count for the closing marker in the
+// most legible short form: raw for sub-1k counts, "%dk" for thousands,
+// "%.1fM" once a turn breaks a million tokens. The marker is
+// audience-facing, not a billing source of truth — readability over
+// precision is the right tradeoff. The DB telemetry table still
+// carries exact integer counts for accounting.
+func formatTokenCount(n int) string {
+	switch {
+	case n < 1000:
+		return strconv.Itoa(n)
+	case n < 1_000_000:
+		return strconv.Itoa(n/1000) + "k"
+	default:
+		return fmt.Sprintf("%.1fM", float64(n)/1_000_000)
+	}
+}
+
+// closingMarkerSavingsUSD computes (alternative cost on requested model)
+// minus (actual cost on routed model) using the post-stream usage
+// breakdown. Both sides are priced under the same usage shape — input
+// tokens at full price minus the cached portion at the model's
+// cache-read multiplier — so the delta isolates the price difference
+// between the two models for the same workload. Output tokens are
+// always priced at the model's full output rate.
+func closingMarkerSavingsUSD(u translate.Usage, routed, requested pricing.Pricing) float64 {
+	nonCached := u.InputTokens - u.CacheReadTokens
+	if nonCached < 0 {
+		nonCached = 0
+	}
+	routedCost := costForUsage(nonCached, u.CacheReadTokens, u.OutputTokens, routed)
+	requestedCost := costForUsage(nonCached, u.CacheReadTokens, u.OutputTokens, requested)
+	return requestedCost - routedCost
+}
+
+// costForUsage returns the dollar cost of (nonCached, cacheRead, output)
+// tokens billed against the given Pricing entry. Cache-creation tokens
+// are folded into nonCached at full price — OpenAI-style upstreams
+// don't bill writes separately, and the demo marker is an
+// approximation, not the source of truth (the telemetry table is).
+func costForUsage(nonCachedInput, cacheReadInput, output int, p pricing.Pricing) float64 {
+	cacheMult := p.EffectiveCacheReadMultiplier()
+	inputCost := float64(nonCachedInput)*p.InputUSDPer1M +
+		float64(cacheReadInput)*p.InputUSDPer1M*cacheMult
+	outputCost := float64(output) * p.OutputUSDPer1M
+	return (inputCost + outputCost) / 1e6
+}
+
+// routingReasonShort returns a short, demo-readable phrase for why this
+// turn landed on the chosen model. Translates the planner's snake_case
+// reason codes (machine-friendly, kept verbatim in logs / spans) into
+// the verb-led human-readable form that goes in the in-pane marker.
+// Falls back to a coarse description of the orchestrator path when the
+// planner didn't run so the marker is never reasonless.
+func routingReasonShort(res turnLoopResult) string {
+	if res.PlannerDecision.Reason != "" {
+		return humanReasonFromPlanner(res.PlannerDecision.Reason)
+	}
+	if res.HardPinned {
+		return "hard pin (compaction / sub-agent)"
+	}
+	if res.StickyHit {
+		return "tool-result follow-up"
+	}
+	return "first turn"
+}
+
+// humanReasonFromPlanner maps planner.Reason* codes to the short
+// human-readable phrases rendered in the marker. Unknown codes pass
+// through verbatim — new planner reasons will surface in the marker
+// as their raw label until this map is updated, which is the right
+// fail-loud behavior (the marker complains visibly instead of silently
+// dropping the reason).
+func humanReasonFromPlanner(code string) string {
+	switch code {
+	case planner.ReasonEVPositive:
+		return "switched to save on cache reads"
+	case planner.ReasonEVNegative:
+		return "stayed: cache reuse beats the switch"
+	case planner.ReasonSameModel:
+		return "scorer matches the pin"
+	case planner.ReasonNoPin:
+		return "first turn"
+	case planner.ReasonNoPriorUsage:
+		return "no cache stats yet"
+	case planner.ReasonPinModelMissing:
+		return "pin model no longer available"
+	case planner.ReasonPricingMissing:
+		return "missing pricing for a candidate"
+	default:
+		return code
+	}
+}
+
 func installationExcludedModelsFromContext(ctx context.Context) []string {
 	v := ctx.Value(InstallationExcludedModelsContextKey{})
 	if v == nil {
@@ -671,7 +835,9 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 			extractor = otel.NewUsageExtractor(nil, decision.Provider)
 			usage = extractor
 		}
-		translator := translate.NewAnthropicSSETranslator(sink, decision.Model, usage)
+		translator := translate.NewAnthropicSSETranslator(sink, decision.Model, usage).
+			WithRoutingMarker(routingMarkerFor(routeRes)).
+			WithClosingMarker(closingMarkerFor(decision, feats.Model))
 		proxyErr = p.Proxy(ctx, decision, prep, translator, r)
 		proxyErr = finalizeAfterProxy(proxyErr, translator.Finalize)
 	case providers.ProviderGoogle:
@@ -687,7 +853,9 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 			usage = extractor
 		}
 		// SSE chain: Gemini → OpenAI → Anthropic.
-		anthropicTr := translate.NewAnthropicSSETranslator(sink, decision.Model, usage)
+		anthropicTr := translate.NewAnthropicSSETranslator(sink, decision.Model, usage).
+			WithRoutingMarker(routingMarkerFor(routeRes)).
+			WithClosingMarker(closingMarkerFor(decision, feats.Model))
 		geminiTr := translate.NewGeminiToOpenAISSETranslator(anthropicTr, decision.Model, nil)
 		proxyErr = p.Proxy(ctx, decision, prep, geminiTr, r)
 		proxyErr = finalizeAfterProxy(proxyErr, geminiTr.Finalize)

--- a/internal/translate/stream.go
+++ b/internal/translate/stream.go
@@ -362,6 +362,45 @@ type AnthropicSSETranslator struct {
 	modelFromUpstream string
 
 	usageSink otel.UsageSink
+
+	// usageCacheReadTokens is the OpenAI-side prompt-cache hit count we
+	// extracted from the upstream's usage event. Stored on the translator
+	// (in addition to forwarded to usageSink) so the closing-marker
+	// callback can compute actual-cost savings without depending on the
+	// sink's internal shape.
+	usageCacheReadTokens int
+
+	// routingMarker, if non-empty, is emitted as a standalone text content
+	// block at index 0 immediately after message_start and before any
+	// upstream content. Lets Claude Code render "routed to X" the instant
+	// streaming begins instead of waiting for the upstream's first token.
+	// markerEmitted guards single emission per response.
+	routingMarker string
+	markerEmitted bool
+
+	// closingMarkerFn, if non-nil, is invoked from finishStream after all
+	// upstream content blocks have closed but before message_delta /
+	// message_stop. Its return value (if non-empty) is emitted as a final
+	// standalone text content block so the client renders a turn-final
+	// summary (typically the actual-cost-savings line) using observed
+	// usage numbers instead of a priori estimates.
+	closingMarkerFn      func(Usage) string
+	closingMarkerEmitted bool
+}
+
+// Usage is the upstream-observed token breakdown the closing-marker
+// callback uses to compute its text. Field semantics match Anthropic's
+// usage shape after cross-format translation: InputTokens is the
+// non-cached prompt portion, CacheReadTokens is the portion served from
+// the prompt cache (priced at the model's cache-read multiplier), and
+// CacheCreationTokens is the portion written into the cache on this
+// turn. OpenAI-style upstreams don't bill for cache writes separately,
+// so CacheCreationTokens may be zero even when caching is active.
+type Usage struct {
+	InputTokens         int
+	OutputTokens        int
+	CacheReadTokens     int
+	CacheCreationTokens int
 }
 
 // NewAnthropicSSETranslator wraps w. Call Finalize after upstream returns.
@@ -374,6 +413,45 @@ func NewAnthropicSSETranslator(w http.ResponseWriter, requestModel string, sink 
 		requestModel: requestModel,
 		toolBlocks:   make(map[int]int),
 		usageSink:    sink,
+	}
+}
+
+// WithRoutingMarker installs a text snippet that the translator emits as a
+// standalone Anthropic content block at index 0 right after message_start,
+// before any upstream content arrives. Designed for the live demo / debug
+// case: lets the client (Claude Code) render the routed model name as soon
+// as streaming begins, without waiting for the upstream model's first token.
+// Empty string disables emission. Returns the receiver for fluent wiring.
+func (t *AnthropicSSETranslator) WithRoutingMarker(marker string) *AnthropicSSETranslator {
+	t.routingMarker = marker
+	return t
+}
+
+// WithClosingMarker installs a callback that the translator invokes from
+// finishStream after the last upstream content block closes and before
+// message_delta. The callback receives observed usage (input / output /
+// cache-read / cache-creation token counts) so it can compute a final
+// actual-cost summary using real numbers instead of a priori estimates.
+// A non-empty return value is emitted as a standalone text content block
+// at the next available index; an empty return value (or a nil callback)
+// is a no-op. Returns the receiver for fluent wiring.
+func (t *AnthropicSSETranslator) WithClosingMarker(fn func(Usage) string) *AnthropicSSETranslator {
+	t.closingMarkerFn = fn
+	return t
+}
+
+// usage returns the upstream-observed token breakdown as a Usage value.
+// Internal helper for the closing-marker callback so it doesn't have to
+// know the translator's field shape.
+func (t *AnthropicSSETranslator) usage() Usage {
+	return Usage{
+		InputTokens:     t.usageInputTokens,
+		OutputTokens:    t.usageOutputTokens,
+		CacheReadTokens: t.usageCacheReadTokens,
+		// CacheCreationTokens stays zero for OpenAI-style upstreams;
+		// Anthropic-format streams that do carry cache_creation will
+		// populate it here when the Anthropic passthrough path grows
+		// its own closing-marker support (separate follow-up).
 	}
 }
 
@@ -528,6 +606,9 @@ func (t *AnthropicSSETranslator) translateOpenAIEvent(raw []byte) error {
 			return err
 		}
 		t.started = true
+		if err := t.emitRoutingMarkerIfConfigured(); err != nil {
+			return err
+		}
 	}
 
 	delta := firstChoice.Get("delta")
@@ -554,6 +635,7 @@ func (t *AnthropicSSETranslator) extractAndForwardUsage(data []byte) {
 	cachedRead := usage.Get("prompt_tokens_details.cached_tokens").Int()
 	t.usageInputTokens = int(prompt)
 	t.usageOutputTokens = int(completion)
+	t.usageCacheReadTokens = int(cachedRead)
 	t.hasUsage = true
 	if t.usageSink != nil {
 		t.usageSink.RecordUsage(int(prompt), int(completion))
@@ -611,12 +693,71 @@ func (t *AnthropicSSETranslator) emitDelta(delta gjson.Result) error {
 	return emitErr
 }
 
+// emitRoutingMarkerIfConfigured writes a standalone text content block
+// (start + delta + stop) at the current block index if WithRoutingMarker
+// installed a non-empty marker and we haven't emitted it yet. Safe to
+// invoke from any post-message_start codepath; guarded against double
+// emission so finishStream can also call it for empty-upstream paths.
+func (t *AnthropicSSETranslator) emitRoutingMarkerIfConfigured() error {
+	if t.markerEmitted || t.routingMarker == "" {
+		return nil
+	}
+	idx := t.blockIdx
+	if err := t.emitContentBlockStartText(idx); err != nil {
+		return err
+	}
+	if err := t.emitContentBlockDeltaText(idx, t.routingMarker); err != nil {
+		return err
+	}
+	if err := t.emitContentBlockStop(idx); err != nil {
+		return err
+	}
+	t.blockIdx++
+	t.markerEmitted = true
+	return nil
+}
+
+// emitClosingMarkerIfConfigured asks the configured callback (if any) for
+// a final text block to render after the upstream's content but before
+// message_delta. Empty return values are treated as "no marker"; the
+// callback can therefore decline to emit (missing pricing, same routed
+// and requested model, zero or negative savings) without forcing the
+// caller to special-case. Single-emission-guarded so the empty-upstream
+// path in finishStream doesn't double-emit when the request also went
+// through translateOpenAIEvent.
+func (t *AnthropicSSETranslator) emitClosingMarkerIfConfigured() error {
+	if t.closingMarkerEmitted || t.closingMarkerFn == nil {
+		return nil
+	}
+	text := t.closingMarkerFn(t.usage())
+	if text == "" {
+		t.closingMarkerEmitted = true
+		return nil
+	}
+	idx := t.blockIdx
+	if err := t.emitContentBlockStartText(idx); err != nil {
+		return err
+	}
+	if err := t.emitContentBlockDeltaText(idx, text); err != nil {
+		return err
+	}
+	if err := t.emitContentBlockStop(idx); err != nil {
+		return err
+	}
+	t.blockIdx++
+	t.closingMarkerEmitted = true
+	return nil
+}
+
 func (t *AnthropicSSETranslator) finishStream() error {
 	if !t.started {
 		if err := t.emitMessageStart(); err != nil {
 			return err
 		}
 		t.started = true
+		if err := t.emitRoutingMarkerIfConfigured(); err != nil {
+			return err
+		}
 	}
 	if t.textOpen {
 		if err := t.emitContentBlockStop(t.blockIdx - 1); err != nil {
@@ -630,6 +771,15 @@ func (t *AnthropicSSETranslator) finishStream() error {
 		}
 	}
 	t.toolBlocks = map[int]int{}
+
+	// Closing marker (e.g. actual-cost savings summary) fires after every
+	// upstream content block has closed but before message_delta /
+	// message_stop, so it lands as the final visible content in the
+	// rendered assistant message. Usage numbers passed to the callback
+	// are the upstream-observed totals captured by extractAndForwardUsage.
+	if err := t.emitClosingMarkerIfConfigured(); err != nil {
+		return err
+	}
 
 	if err := t.emitMessageDelta(); err != nil {
 		return err

--- a/internal/translate/stream.go
+++ b/internal/translate/stream.go
@@ -363,39 +363,24 @@ type AnthropicSSETranslator struct {
 
 	usageSink otel.UsageSink
 
-	// usageCacheReadTokens is the OpenAI-side prompt-cache hit count we
-	// extracted from the upstream's usage event. Stored on the translator
-	// (in addition to forwarded to usageSink) so the closing-marker
-	// callback can compute actual-cost savings without depending on the
-	// sink's internal shape.
+	// usageCacheReadTokens is the prompt-cache hit count; kept on the
+	// translator so the closing-marker callback can compute savings.
 	usageCacheReadTokens int
 
-	// routingMarker, if non-empty, is emitted as a standalone text content
-	// block at index 0 immediately after message_start and before any
-	// upstream content. Lets Claude Code render "routed to X" the instant
-	// streaming begins instead of waiting for the upstream's first token.
-	// markerEmitted guards single emission per response.
+	// routingMarker, when non-empty, is emitted as a standalone text block
+	// at index 0 right after message_start. markerEmitted guards single emission.
 	routingMarker string
 	markerEmitted bool
 
-	// closingMarkerFn, if non-nil, is invoked from finishStream after all
-	// upstream content blocks have closed but before message_delta /
-	// message_stop. Its return value (if non-empty) is emitted as a final
-	// standalone text content block so the client renders a turn-final
-	// summary (typically the actual-cost-savings line) using observed
-	// usage numbers instead of a priori estimates.
+	// closingMarkerFn, when non-nil, is invoked from finishStream after the
+	// last upstream block closes; a non-empty return is emitted as a final
+	// text block before message_delta.
 	closingMarkerFn      func(Usage) string
 	closingMarkerEmitted bool
 }
 
-// Usage is the upstream-observed token breakdown the closing-marker
-// callback uses to compute its text. Field semantics match Anthropic's
-// usage shape after cross-format translation: InputTokens is the
-// non-cached prompt portion, CacheReadTokens is the portion served from
-// the prompt cache (priced at the model's cache-read multiplier), and
-// CacheCreationTokens is the portion written into the cache on this
-// turn. OpenAI-style upstreams don't bill for cache writes separately,
-// so CacheCreationTokens may be zero even when caching is active.
+// Usage is the upstream-observed token breakdown passed to the closing-marker
+// callback. CacheCreationTokens is zero for OpenAI-style upstreams.
 type Usage struct {
 	InputTokens         int
 	OutputTokens        int
@@ -416,42 +401,26 @@ func NewAnthropicSSETranslator(w http.ResponseWriter, requestModel string, sink 
 	}
 }
 
-// WithRoutingMarker installs a text snippet that the translator emits as a
-// standalone Anthropic content block at index 0 right after message_start,
-// before any upstream content arrives. Designed for the live demo / debug
-// case: lets the client (Claude Code) render the routed model name as soon
-// as streaming begins, without waiting for the upstream model's first token.
-// Empty string disables emission. Returns the receiver for fluent wiring.
+// WithRoutingMarker installs a text snippet emitted as a standalone content
+// block at index 0 immediately after message_start. Empty string disables it.
 func (t *AnthropicSSETranslator) WithRoutingMarker(marker string) *AnthropicSSETranslator {
 	t.routingMarker = marker
 	return t
 }
 
-// WithClosingMarker installs a callback that the translator invokes from
-// finishStream after the last upstream content block closes and before
-// message_delta. The callback receives observed usage (input / output /
-// cache-read / cache-creation token counts) so it can compute a final
-// actual-cost summary using real numbers instead of a priori estimates.
-// A non-empty return value is emitted as a standalone text content block
-// at the next available index; an empty return value (or a nil callback)
-// is a no-op. Returns the receiver for fluent wiring.
+// WithClosingMarker installs a callback invoked from finishStream after the
+// last upstream block closes; a non-empty return is emitted as a final text
+// block before message_delta.
 func (t *AnthropicSSETranslator) WithClosingMarker(fn func(Usage) string) *AnthropicSSETranslator {
 	t.closingMarkerFn = fn
 	return t
 }
 
-// usage returns the upstream-observed token breakdown as a Usage value.
-// Internal helper for the closing-marker callback so it doesn't have to
-// know the translator's field shape.
 func (t *AnthropicSSETranslator) usage() Usage {
 	return Usage{
 		InputTokens:     t.usageInputTokens,
 		OutputTokens:    t.usageOutputTokens,
 		CacheReadTokens: t.usageCacheReadTokens,
-		// CacheCreationTokens stays zero for OpenAI-style upstreams;
-		// Anthropic-format streams that do carry cache_creation will
-		// populate it here when the Anthropic passthrough path grows
-		// its own closing-marker support (separate follow-up).
 	}
 }
 
@@ -693,11 +662,8 @@ func (t *AnthropicSSETranslator) emitDelta(delta gjson.Result) error {
 	return emitErr
 }
 
-// emitRoutingMarkerIfConfigured writes a standalone text content block
-// (start + delta + stop) at the current block index if WithRoutingMarker
-// installed a non-empty marker and we haven't emitted it yet. Safe to
-// invoke from any post-message_start codepath; guarded against double
-// emission so finishStream can also call it for empty-upstream paths.
+// emitRoutingMarkerIfConfigured emits the routing marker as a standalone text
+// block at the current index, once per response.
 func (t *AnthropicSSETranslator) emitRoutingMarkerIfConfigured() error {
 	if t.markerEmitted || t.routingMarker == "" {
 		return nil
@@ -717,14 +683,8 @@ func (t *AnthropicSSETranslator) emitRoutingMarkerIfConfigured() error {
 	return nil
 }
 
-// emitClosingMarkerIfConfigured asks the configured callback (if any) for
-// a final text block to render after the upstream's content but before
-// message_delta. Empty return values are treated as "no marker"; the
-// callback can therefore decline to emit (missing pricing, same routed
-// and requested model, zero or negative savings) without forcing the
-// caller to special-case. Single-emission-guarded so the empty-upstream
-// path in finishStream doesn't double-emit when the request also went
-// through translateOpenAIEvent.
+// emitClosingMarkerIfConfigured invokes the callback (if any) and emits a
+// final text block when it returns non-empty. Empty returns are a no-op.
 func (t *AnthropicSSETranslator) emitClosingMarkerIfConfigured() error {
 	if t.closingMarkerEmitted || t.closingMarkerFn == nil {
 		return nil
@@ -772,11 +732,6 @@ func (t *AnthropicSSETranslator) finishStream() error {
 	}
 	t.toolBlocks = map[int]int{}
 
-	// Closing marker (e.g. actual-cost savings summary) fires after every
-	// upstream content block has closed but before message_delta /
-	// message_stop, so it lands as the final visible content in the
-	// rendered assistant message. Usage numbers passed to the callback
-	// are the upstream-observed totals captured by extractAndForwardUsage.
 	if err := t.emitClosingMarkerIfConfigured(); err != nil {
 		return err
 	}

--- a/internal/translate/translate_test.go
+++ b/internal/translate/translate_test.go
@@ -544,6 +544,187 @@ func TestAnthropicSSETranslator_EmptyStreamEmitsSyntheticMessage(t *testing.T) {
 	assert.Contains(t, body, "event: message_stop")
 }
 
+func TestAnthropicSSETranslator_RoutingMarkerEmittedBeforeUpstreamContent(t *testing.T) {
+	// The marker must land as a standalone text block immediately after
+	// message_start and before the upstream's first content delta. That
+	// ordering is what lets Claude Code render "routed to X" the instant
+	// streaming begins instead of waiting for the upstream model's first
+	// token.
+	rec := httptest.NewRecorder()
+	marker := "✦ **Weave Router** → deepseek/deepseek-v4-pro (openrouter) · reason: switched to save on cache reads\n\n"
+	translator := translate.NewAnthropicSSETranslator(rec, "gpt-4o", nil).
+		WithRoutingMarker(marker)
+
+	translator.Header().Set("Content-Type", "text/event-stream")
+	translator.WriteHeader(http.StatusOK)
+
+	events := []string{
+		"data: {\"id\":\"chatcmpl-1\",\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\",\"content\":\"\"},\"finish_reason\":null}]}\n\n",
+		"data: {\"id\":\"chatcmpl-1\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"Hello\"},\"finish_reason\":null}]}\n\n",
+		"data: {\"id\":\"chatcmpl-1\",\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"stop\"}]}\n\n",
+		"data: [DONE]\n\n",
+	}
+	for _, e := range events {
+		_, err := translator.Write([]byte(e))
+		require.NoError(t, err)
+	}
+	require.NoError(t, translator.Finalize())
+
+	body := rec.Body.String()
+	// strings.Index returns >=0 when found (0 is a valid match at the start
+	// of the buffer), -1 when missing. The marker's trailing newlines get
+	// JSON-escaped inside the SSE data field, so match against the visible
+	// prose portion instead of the raw trailing newlines.
+	markerProse := "✦ **Weave Router** → deepseek/deepseek-v4-pro (openrouter) · reason: switched to save on cache reads"
+	startIdx := strings.Index(body, "event: message_start")
+	markerIdx := strings.Index(body, markerProse)
+	helloIdx := strings.Index(body, `"text":"Hello"`)
+	require.GreaterOrEqual(t, startIdx, 0, "message_start must be emitted")
+	require.GreaterOrEqual(t, markerIdx, 0, "marker text must appear in the stream")
+	require.GreaterOrEqual(t, helloIdx, 0, "upstream content must appear in the stream")
+	assert.Less(t, startIdx, markerIdx, "marker must follow message_start")
+	assert.Less(t, markerIdx, helloIdx, "marker must precede the upstream's first text delta")
+
+	// Marker occupies a standalone text content block at index 0 (its own
+	// start + delta + stop) so the upstream's first text block lands at
+	// index 1 and Claude Code's content-block assembly doesn't conflate
+	// them.
+	idx0Start := strings.Index(body, `"index":0,"content_block":{"type":"text"`)
+	idx1Start := strings.Index(body, `"index":1,"content_block":{"type":"text"`)
+	require.GreaterOrEqual(t, idx0Start, 0, "marker should open content_block at index 0")
+	require.GreaterOrEqual(t, idx1Start, 0, "upstream content should open content_block at index 1")
+	assert.Less(t, idx0Start, idx1Start)
+}
+
+func TestAnthropicSSETranslator_RoutingMarkerEmittedOnEmptyUpstream(t *testing.T) {
+	// Even when the upstream emits no choices (error, immediate [DONE]),
+	// the marker still lands so the client sees the routed-model attribution.
+	// finishStream's emitMessageStart fallback covers this codepath.
+	rec := httptest.NewRecorder()
+	marker := "✦ **Weave Router** → gpt-5-mini (openai) · reason: first turn\n\n"
+	markerProse := "✦ **Weave Router** → gpt-5-mini (openai) · reason: first turn"
+	translator := translate.NewAnthropicSSETranslator(rec, "claude-opus-4-7", nil).
+		WithRoutingMarker(marker)
+
+	translator.Header().Set("Content-Type", "text/event-stream")
+	translator.WriteHeader(http.StatusOK)
+
+	_, err := translator.Write([]byte("data: [DONE]\n\n"))
+	require.NoError(t, err)
+	require.NoError(t, translator.Finalize())
+
+	body := rec.Body.String()
+	assert.Contains(t, body, "event: message_start")
+	assert.Contains(t, body, markerProse,
+		"marker prose must fire even when upstream emits no content")
+	assert.Contains(t, body, "event: message_stop")
+}
+
+func TestAnthropicSSETranslator_NoMarkerWhenNotConfigured(t *testing.T) {
+	// Sanity: when WithRoutingMarker isn't called, the stream is identical
+	// to the legacy behavior — no synthetic content block is injected.
+	rec := httptest.NewRecorder()
+	translator := translate.NewAnthropicSSETranslator(rec, "gpt-4o", nil)
+
+	translator.Header().Set("Content-Type", "text/event-stream")
+	translator.WriteHeader(http.StatusOK)
+
+	events := []string{
+		"data: {\"id\":\"chatcmpl-3\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"hi\"},\"finish_reason\":null}]}\n\n",
+		"data: {\"id\":\"chatcmpl-3\",\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"stop\"}]}\n\n",
+		"data: [DONE]\n\n",
+	}
+	for _, e := range events {
+		_, err := translator.Write([]byte(e))
+		require.NoError(t, err)
+	}
+	require.NoError(t, translator.Finalize())
+
+	body := rec.Body.String()
+	assert.NotContains(t, body, "Weave Router",
+		"no marker should appear when WithRoutingMarker was not invoked")
+	assert.Contains(t, body, `"text":"hi"`)
+	// Upstream's first text block must occupy index 0 (the marker-reserved
+	// index) when no marker is configured.
+	assert.Contains(t, body, `"index":0,"content_block":{"type":"text"`)
+}
+
+func TestAnthropicSSETranslator_ClosingMarkerEmittedAfterContent(t *testing.T) {
+	// The closing marker fires from finishStream AFTER every upstream
+	// content block has closed and BEFORE message_delta / message_stop.
+	// The callback receives observed usage so it can format a real-cost
+	// summary using post-stream numbers, not a priori estimates.
+	rec := httptest.NewRecorder()
+	closingProse := "✦ saved $0.0234 vs claude-opus-4-7"
+	closingFn := func(u translate.Usage) string {
+		// Defensive: the callback should see the usage values the
+		// upstream reported, not the zero value.
+		require.Equal(t, 100, u.InputTokens)
+		require.Equal(t, 20, u.OutputTokens)
+		require.Equal(t, 50, u.CacheReadTokens)
+		return closingProse
+	}
+	translator := translate.NewAnthropicSSETranslator(rec, "gpt-4o", nil).
+		WithClosingMarker(closingFn)
+
+	translator.Header().Set("Content-Type", "text/event-stream")
+	translator.WriteHeader(http.StatusOK)
+
+	events := []string{
+		"data: {\"id\":\"chatcmpl-c1\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"answer body\"},\"finish_reason\":null}]}\n\n",
+		"data: {\"id\":\"chatcmpl-c1\",\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"stop\"}],\"usage\":{\"prompt_tokens\":100,\"completion_tokens\":20,\"prompt_tokens_details\":{\"cached_tokens\":50}}}\n\n",
+		"data: [DONE]\n\n",
+	}
+	for _, e := range events {
+		_, err := translator.Write([]byte(e))
+		require.NoError(t, err)
+	}
+	require.NoError(t, translator.Finalize())
+
+	body := rec.Body.String()
+	answerIdx := strings.Index(body, `"text":"answer body"`)
+	closingIdx := strings.Index(body, closingProse)
+	deltaIdx := strings.Index(body, "event: message_delta")
+	require.GreaterOrEqual(t, answerIdx, 0, "upstream content must appear")
+	require.GreaterOrEqual(t, closingIdx, 0, "closing marker text must appear in the stream")
+	require.GreaterOrEqual(t, deltaIdx, 0, "message_delta must follow the content")
+	assert.Less(t, answerIdx, closingIdx, "closing marker must follow the upstream content")
+	assert.Less(t, closingIdx, deltaIdx, "closing marker must precede message_delta")
+}
+
+func TestAnthropicSSETranslator_ClosingMarkerSkippedWhenCallbackReturnsEmpty(t *testing.T) {
+	// Callbacks that can't compute (no pricing, equal models, negative
+	// savings) return "" — translator must skip injection rather than
+	// emit an empty content block, and message_delta / message_stop must
+	// still close the stream cleanly.
+	rec := httptest.NewRecorder()
+	translator := translate.NewAnthropicSSETranslator(rec, "gpt-4o", nil).
+		WithClosingMarker(func(translate.Usage) string { return "" })
+
+	translator.Header().Set("Content-Type", "text/event-stream")
+	translator.WriteHeader(http.StatusOK)
+
+	events := []string{
+		"data: {\"id\":\"chatcmpl-c2\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"hi\"},\"finish_reason\":null}]}\n\n",
+		"data: {\"id\":\"chatcmpl-c2\",\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"stop\"}],\"usage\":{\"prompt_tokens\":1,\"completion_tokens\":1}}\n\n",
+		"data: [DONE]\n\n",
+	}
+	for _, e := range events {
+		_, err := translator.Write([]byte(e))
+		require.NoError(t, err)
+	}
+	require.NoError(t, translator.Finalize())
+
+	body := rec.Body.String()
+	assert.Contains(t, body, "event: message_delta",
+		"stream must still close cleanly when closing marker returns empty")
+	assert.Contains(t, body, "event: message_stop")
+	// Upstream content holds index 0; no closing-marker block means
+	// nothing was opened at index 1 (the next available slot).
+	assert.NotContains(t, body, `"index":1`,
+		"empty closing-marker text must not open a content block")
+}
+
 func TestPrepareAnthropic_ToolResultStringContent(t *testing.T) {
 	openAIReq := `{
 		"model": "gpt-4o",

--- a/internal/translate/translate_test.go
+++ b/internal/translate/translate_test.go
@@ -545,11 +545,6 @@ func TestAnthropicSSETranslator_EmptyStreamEmitsSyntheticMessage(t *testing.T) {
 }
 
 func TestAnthropicSSETranslator_RoutingMarkerEmittedBeforeUpstreamContent(t *testing.T) {
-	// The marker must land as a standalone text block immediately after
-	// message_start and before the upstream's first content delta. That
-	// ordering is what lets Claude Code render "routed to X" the instant
-	// streaming begins instead of waiting for the upstream model's first
-	// token.
 	rec := httptest.NewRecorder()
 	marker := "✦ **Weave Router** → deepseek/deepseek-v4-pro (openrouter) · reason: switched to save on cache reads\n\n"
 	translator := translate.NewAnthropicSSETranslator(rec, "gpt-4o", nil).
@@ -571,10 +566,8 @@ func TestAnthropicSSETranslator_RoutingMarkerEmittedBeforeUpstreamContent(t *tes
 	require.NoError(t, translator.Finalize())
 
 	body := rec.Body.String()
-	// strings.Index returns >=0 when found (0 is a valid match at the start
-	// of the buffer), -1 when missing. The marker's trailing newlines get
-	// JSON-escaped inside the SSE data field, so match against the visible
-	// prose portion instead of the raw trailing newlines.
+	// Marker's trailing newlines get JSON-escaped in the SSE data field;
+	// match the prose only.
 	markerProse := "✦ **Weave Router** → deepseek/deepseek-v4-pro (openrouter) · reason: switched to save on cache reads"
 	startIdx := strings.Index(body, "event: message_start")
 	markerIdx := strings.Index(body, markerProse)
@@ -585,10 +578,7 @@ func TestAnthropicSSETranslator_RoutingMarkerEmittedBeforeUpstreamContent(t *tes
 	assert.Less(t, startIdx, markerIdx, "marker must follow message_start")
 	assert.Less(t, markerIdx, helloIdx, "marker must precede the upstream's first text delta")
 
-	// Marker occupies a standalone text content block at index 0 (its own
-	// start + delta + stop) so the upstream's first text block lands at
-	// index 1 and Claude Code's content-block assembly doesn't conflate
-	// them.
+	// Marker takes index 0; upstream content shifts to index 1.
 	idx0Start := strings.Index(body, `"index":0,"content_block":{"type":"text"`)
 	idx1Start := strings.Index(body, `"index":1,"content_block":{"type":"text"`)
 	require.GreaterOrEqual(t, idx0Start, 0, "marker should open content_block at index 0")
@@ -597,9 +587,6 @@ func TestAnthropicSSETranslator_RoutingMarkerEmittedBeforeUpstreamContent(t *tes
 }
 
 func TestAnthropicSSETranslator_RoutingMarkerEmittedOnEmptyUpstream(t *testing.T) {
-	// Even when the upstream emits no choices (error, immediate [DONE]),
-	// the marker still lands so the client sees the routed-model attribution.
-	// finishStream's emitMessageStart fallback covers this codepath.
 	rec := httptest.NewRecorder()
 	marker := "✦ **Weave Router** → gpt-5-mini (openai) · reason: first turn\n\n"
 	markerProse := "✦ **Weave Router** → gpt-5-mini (openai) · reason: first turn"
@@ -615,14 +602,11 @@ func TestAnthropicSSETranslator_RoutingMarkerEmittedOnEmptyUpstream(t *testing.T
 
 	body := rec.Body.String()
 	assert.Contains(t, body, "event: message_start")
-	assert.Contains(t, body, markerProse,
-		"marker prose must fire even when upstream emits no content")
+	assert.Contains(t, body, markerProse)
 	assert.Contains(t, body, "event: message_stop")
 }
 
 func TestAnthropicSSETranslator_NoMarkerWhenNotConfigured(t *testing.T) {
-	// Sanity: when WithRoutingMarker isn't called, the stream is identical
-	// to the legacy behavior — no synthetic content block is injected.
 	rec := httptest.NewRecorder()
 	translator := translate.NewAnthropicSSETranslator(rec, "gpt-4o", nil)
 
@@ -641,24 +625,16 @@ func TestAnthropicSSETranslator_NoMarkerWhenNotConfigured(t *testing.T) {
 	require.NoError(t, translator.Finalize())
 
 	body := rec.Body.String()
-	assert.NotContains(t, body, "Weave Router",
-		"no marker should appear when WithRoutingMarker was not invoked")
+	assert.NotContains(t, body, "Weave Router")
 	assert.Contains(t, body, `"text":"hi"`)
-	// Upstream's first text block must occupy index 0 (the marker-reserved
-	// index) when no marker is configured.
+	// Upstream's first block takes index 0 when no marker is configured.
 	assert.Contains(t, body, `"index":0,"content_block":{"type":"text"`)
 }
 
 func TestAnthropicSSETranslator_ClosingMarkerEmittedAfterContent(t *testing.T) {
-	// The closing marker fires from finishStream AFTER every upstream
-	// content block has closed and BEFORE message_delta / message_stop.
-	// The callback receives observed usage so it can format a real-cost
-	// summary using post-stream numbers, not a priori estimates.
 	rec := httptest.NewRecorder()
 	closingProse := "✦ saved $0.0234 vs claude-opus-4-7"
 	closingFn := func(u translate.Usage) string {
-		// Defensive: the callback should see the usage values the
-		// upstream reported, not the zero value.
 		require.Equal(t, 100, u.InputTokens)
 		require.Equal(t, 20, u.OutputTokens)
 		require.Equal(t, 50, u.CacheReadTokens)
@@ -685,18 +661,14 @@ func TestAnthropicSSETranslator_ClosingMarkerEmittedAfterContent(t *testing.T) {
 	answerIdx := strings.Index(body, `"text":"answer body"`)
 	closingIdx := strings.Index(body, closingProse)
 	deltaIdx := strings.Index(body, "event: message_delta")
-	require.GreaterOrEqual(t, answerIdx, 0, "upstream content must appear")
-	require.GreaterOrEqual(t, closingIdx, 0, "closing marker text must appear in the stream")
-	require.GreaterOrEqual(t, deltaIdx, 0, "message_delta must follow the content")
-	assert.Less(t, answerIdx, closingIdx, "closing marker must follow the upstream content")
-	assert.Less(t, closingIdx, deltaIdx, "closing marker must precede message_delta")
+	require.GreaterOrEqual(t, answerIdx, 0)
+	require.GreaterOrEqual(t, closingIdx, 0)
+	require.GreaterOrEqual(t, deltaIdx, 0)
+	assert.Less(t, answerIdx, closingIdx, "closing marker follows upstream content")
+	assert.Less(t, closingIdx, deltaIdx, "closing marker precedes message_delta")
 }
 
 func TestAnthropicSSETranslator_ClosingMarkerSkippedWhenCallbackReturnsEmpty(t *testing.T) {
-	// Callbacks that can't compute (no pricing, equal models, negative
-	// savings) return "" — translator must skip injection rather than
-	// emit an empty content block, and message_delta / message_stop must
-	// still close the stream cleanly.
 	rec := httptest.NewRecorder()
 	translator := translate.NewAnthropicSSETranslator(rec, "gpt-4o", nil).
 		WithClosingMarker(func(translate.Usage) string { return "" })
@@ -716,13 +688,10 @@ func TestAnthropicSSETranslator_ClosingMarkerSkippedWhenCallbackReturnsEmpty(t *
 	require.NoError(t, translator.Finalize())
 
 	body := rec.Body.String()
-	assert.Contains(t, body, "event: message_delta",
-		"stream must still close cleanly when closing marker returns empty")
+	assert.Contains(t, body, "event: message_delta")
 	assert.Contains(t, body, "event: message_stop")
-	// Upstream content holds index 0; no closing-marker block means
-	// nothing was opened at index 1 (the next available slot).
-	assert.NotContains(t, body, `"index":1`,
-		"empty closing-marker text must not open a content block")
+	// No closing-marker emission means index 1 stays unopened.
+	assert.NotContains(t, body, `"index":1`)
 }
 
 func TestPrepareAnthropic_ToolResultStringContent(t *testing.T) {


### PR DESCRIPTION
## Summary
Prepend a single-line marker naming the routed model, the routing reason, and (when the planner's EV math ran) the magnitude of the savings driving the decision. Emitted as a standalone Anthropic text content block right after `message_start` and before any upstream content arrives, so the client renders the routing attribution the *instant* streaming begins instead of waiting for the upstream model's first token. On long-thinking models that wait is 10–30 seconds, which made routing look slow during demos even though it actually completed in ~100ms.

Example:

```
✦ Weave → deepseek/deepseek-v4-pro (openrouter) · reason: switched to save on cache reads · est. save: $0.1770
```

## Why
The Claude Code statusline (and any client that reads `message.model` from the transcript) only sees the routed model *after* the full assistant turn finishes streaming, because the transcript is only written at end-of-turn. There's no way to drive a mid-stream statusline refresh from outside Claude Code — verified against the official docs: the statusline is event-driven, re-renders only at turn boundaries, and `refreshInterval` doesn't fire during a response. The only surface that updates live during streaming is the content of the assistant pane itself. Injecting a content block at the start of the stream is the cleanest way to surface the routing decision in real time.

## Format
```
✦ Weave → <model> (<provider>) · reason: <human-readable reason> · est. save: $X.XXXX
```

**Reason** is the human-readable translation of the planner's snake_case codes (kept verbatim in logs / OTel spans for grep-ability). Mapping:

| Planner code | Marker text |
|---|---|
| `ev_positive` | switched to save on cache reads |
| `ev_negative` | stayed: cache reuse beats the switch |
| `same_model` | scorer matches the pin |
| `no_pin` | first turn |
| `no_prior_usage` | no cache stats yet |
| `pin_model_missing` | pin model no longer available |
| `pricing_missing` | missing pricing for a candidate |

When the planner didn't run, the marker falls back to a coarse description of the orchestrator path:

| Path | Marker text |
|---|---|
| Hard-pin (compaction / sub-agent) | hard pin (compaction / sub-agent) |
| Tool-result short-circuit | tool-result follow-up |
| No-pin-store / planner-disabled / first decision | first turn |

Unknown planner codes pass through verbatim — new reasons surface as their raw label until the human-readable map is updated, which is the right fail-loud behavior.

**est. save** renders only for `ev_positive` / `ev_negative` (the two outcomes that actually ran the EV math). It's the magnitude of `expectedSavings − evictionCost` — positive whether we switched to capture it or stayed to avoid it.

## What changed
- **`internal/translate/stream.go`** — `AnthropicSSETranslator` gains `routingMarker` / `markerEmitted` state plus a `WithRoutingMarker(string)` fluent setter. `emitRoutingMarkerIfConfigured` fires from `translateOpenAIEvent` (right after `emitMessageStart` sets `started=true`) and from `finishStream` so empty / errored upstreams still carry the marker. Single-emission guard prevents duplicates across the two codepaths.
- **`internal/proxy/service.go`** — Adds `routingMarkerFor(turnLoopResult)` plus the `routingReasonShort`, `humanReasonFromPlanner`, and `routingEstimatedSaveUSD` helpers (each with its own logic comment). Wires `WithRoutingMarker(routingMarkerFor(routeRes))` into both cross-format construction sites: the OpenAI/OpenRouter/Fireworks branch, and the Google Gemini → OpenAI → Anthropic chain.
- **Tests** — Three SSE-translator tests for the marker plumbing + five internal `routingMarkerFor` tests pinning all reason shapes (planner happy paths, hard-pin fallback, tool-result fallback, first-turn fallback) plus the unknown-code pass-through.

## Index handling
The marker reserves content_block index 0 (its own `start` + `delta` + `stop`) so the upstream's first text block lands at index 1. Mixed text/tool_use responses are unchanged structurally — the upstream's tool_use blocks just shift one index up.

## Out of scope
- **Pure Anthropic passthrough** (Anthropic ingress + Anthropic upstream) — the upstream stream is already in client format and goes through a different writer chain. Adding the marker there requires a separate SSE rewriter that watches for `message_start` and renumbers indices on subsequent events. Easy follow-up if needed.
- **Gating** — marker is always-on per product call. Output-token accounting is unaffected (the marker is emitted at translator-level, not upstream-counted).

## Test plan
- [x] `go build -tags no_onnx ./...` clean
- [x] `go vet -tags no_onnx ./...` clean
- [x] `gofmt -l internal/translate/ internal/proxy/` clean
- [x] `go test -tags no_onnx ./... -count=1` — all green
- [x] `TestAnthropicSSETranslator_RoutingMarkerEmittedBeforeUpstreamContent` pins the ordering (message_start → marker → upstream content) and the index-0/index-1 invariant.
- [x] `TestAnthropicSSETranslator_RoutingMarkerEmittedOnEmptyUpstream` covers the empty-upstream `finishStream` path so an error mid-flight still surfaces the routing attribution.
- [x] `TestAnthropicSSETranslator_NoMarkerWhenNotConfigured` guards the zero-configuration baseline.
- [x] `TestRoutingMarkerFor_PlannerPaths` covers all six reason shapes — ev_positive / ev_negative / same_model / first-turn / hard-pin / tool-result follow-up — pinning the contract demos rely on.
- [x] `TestRoutingMarkerFor_EmptyDecisionEmitsNothing` covers the defensive empty-model case.
- [x] `TestRoutingMarkerFor_OmitsProviderParensWhenProviderMissing` keeps the string well-formed when only Model is populated.
- [x] `TestHumanReasonFromPlanner_UnknownCodePassesThrough` verifies the fail-loud behavior for new planner codes.
- [ ] Manual end-to-end through Claude Code against the local docker-compose router: prompt routes cross-format → the marker renders at the top of the assistant message the instant streaming starts, well before the upstream model produces its own first token.

🤖 Generated with [Claude Code](https://claude.com/claude-code)