### PR TITLE
feat(planner): add capability-tier upgrade guard

### DIFF
--- a/cmd/router/main.go
+++ b/cmd/router/main.go
@@ -365,11 +365,8 @@ func main() {
 		WithAvailableModels(availableModels)
 	logger.Info("Planner configured", "enabled", plannerEnabled, "threshold_usd", plannerCfg.ThresholdUSD, "expected_remaining_turns", plannerCfg.ExpectedRemainingTurns, "tier_upgrade_enabled", plannerCfg.TierUpgradeEnabled, "available_models_count", len(availableModels))
 
-	// Tier-guard depends on a complete capability.TierFor table: any
-	// deployed model missing from it would silently bypass the upgrade
-	// check (TierUnknown disables the guard for that pair). Fail loud
-	// at boot when enabled so a newly-added model can't ship without a
-	// tier assignment.
+	// Fail loud if a deployed model is missing from the tier table;
+	// TierUnknown would silently disable the guard for that pair.
 	if plannerCfg.TierUpgradeEnabled && len(availableModels) > 0 {
 		deployed := make([]string, 0, len(availableModels))
 		for m := range availableModels {
@@ -676,8 +673,7 @@ func parseEnvFloat(key string, fallback float64) float64 {
 	return v
 }
 
-// boolDefault returns the "true"/"false" string a bool default maps to,
-// for use with config.GetOr on boolean env vars.
+// boolDefault renders a bool default for config.GetOr on bool envs.
 func boolDefault(b bool) string {
 	if b {
 		return "true"

--- a/cmd/router/main.go
+++ b/cmd/router/main.go
@@ -31,6 +31,7 @@ import (
 	"workweave/router/internal/proxy"
 	"workweave/router/internal/router"
 	"workweave/router/internal/router/cache"
+	"workweave/router/internal/router/capability"
 	"workweave/router/internal/router/cluster"
 	"workweave/router/internal/router/handover"
 	"workweave/router/internal/router/planner"
@@ -332,6 +333,7 @@ func main() {
 	plannerCfg := planner.EVConfig{
 		ThresholdUSD:           parseEnvFloat("ROUTER_SWITCH_EV_THRESHOLD_USD", proxy.DefaultPlannerThresholdUSD),
 		ExpectedRemainingTurns: parseEnvInt("ROUTER_SWITCH_EXPECTED_REMAINING_TURNS", proxy.DefaultPlannerExpectedRemainingTurns),
+		TierUpgradeEnabled:     config.GetOr("ROUTER_SWITCH_TIER_UPGRADE_ENABLED", boolDefault(proxy.DefaultPlannerTierUpgradeEnabled)) == "true",
 	}
 	handoverProviderName := config.GetOr("ROUTER_HANDOVER_PROVIDER", providers.ProviderAnthropic)
 	handoverModel := config.GetOr("ROUTER_HANDOVER_MODEL", proxy.DefaultHandoverModel)
@@ -361,7 +363,23 @@ func main() {
 		WithPlanner(plannerCfg).
 		WithSummarizer(summarizer).
 		WithAvailableModels(availableModels)
-	logger.Info("Planner configured", "enabled", plannerEnabled, "threshold_usd", plannerCfg.ThresholdUSD, "expected_remaining_turns", plannerCfg.ExpectedRemainingTurns, "available_models_count", len(availableModels))
+	logger.Info("Planner configured", "enabled", plannerEnabled, "threshold_usd", plannerCfg.ThresholdUSD, "expected_remaining_turns", plannerCfg.ExpectedRemainingTurns, "tier_upgrade_enabled", plannerCfg.TierUpgradeEnabled, "available_models_count", len(availableModels))
+
+	// Tier-guard depends on a complete capability.TierFor table: any
+	// deployed model missing from it would silently bypass the upgrade
+	// check (TierUnknown disables the guard for that pair). Fail loud
+	// at boot when enabled so a newly-added model can't ship without a
+	// tier assignment.
+	if plannerCfg.TierUpgradeEnabled && len(availableModels) > 0 {
+		deployed := make([]string, 0, len(availableModels))
+		for m := range availableModels {
+			deployed = append(deployed, m)
+		}
+		if err := capability.Validate(deployed); err != nil {
+			logger.Error("Capability tier table incomplete; refusing to start with tier guard enabled", "err", err)
+			panic(err)
+		}
+	}
 
 	// ROUTER_EXCLUDED_MODELS pins a deployment-wide model exclusion list,
 	// overriding per-installation DB state. Empty / unset → DB takes over.
@@ -656,6 +674,15 @@ func parseEnvFloat(key string, fallback float64) float64 {
 		return fallback
 	}
 	return v
+}
+
+// boolDefault returns the "true"/"false" string a bool default maps to,
+// for use with config.GetOr on boolean env vars.
+func boolDefault(b bool) string {
+	if b {
+		return "true"
+	}
+	return "false"
 }
 
 // parseEnvDurationMs reads an env var as a millisecond integer and returns

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -154,6 +154,13 @@ const DefaultPlannerThresholdUSD = 0.001
 // per-turn savings. Matches observed agentic-loop tail length.
 const DefaultPlannerExpectedRemainingTurns = 3
 
+// DefaultPlannerTierUpgradeEnabled turns on the capability-tier guard
+// by default. The guard overturns an EV "stay" when the fresh scorer
+// recommendation is in a strictly higher tier than the pin so a small
+// first turn cannot pin a Low-tier model for the rest of the session.
+// See internal/router/capability for the tier table.
+const DefaultPlannerTierUpgradeEnabled = true
+
 // session-pin feature flag is off. The planner runs by default with the
 // conservative EVConfig above; callers tune it via WithPlanner /
 // WithPlannerEnabled / WithSummarizer / WithAvailableModels.
@@ -183,6 +190,7 @@ func NewService(r router.Router, providerMap map[string]providers.Client, emitte
 		planner: planner.EVConfig{
 			ThresholdUSD:           DefaultPlannerThresholdUSD,
 			ExpectedRemainingTurns: DefaultPlannerExpectedRemainingTurns,
+			TierUpgradeEnabled:     DefaultPlannerTierUpgradeEnabled,
 		},
 		plannerEnabled: true,
 	}
@@ -200,6 +208,7 @@ func (s *Service) WithPlanner(cfg planner.EVConfig) *Service {
 	if cfg.ExpectedRemainingTurns > 0 {
 		s.planner.ExpectedRemainingTurns = cfg.ExpectedRemainingTurns
 	}
+	s.planner.TierUpgradeEnabled = cfg.TierUpgradeEnabled
 	return s
 }
 

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -154,11 +154,9 @@ const DefaultPlannerThresholdUSD = 0.001
 // per-turn savings. Matches observed agentic-loop tail length.
 const DefaultPlannerExpectedRemainingTurns = 3
 
-// DefaultPlannerTierUpgradeEnabled turns on the capability-tier guard
-// by default. The guard overturns an EV "stay" when the fresh scorer
-// recommendation is in a strictly higher tier than the pin so a small
-// first turn cannot pin a Low-tier model for the rest of the session.
-// See internal/router/capability for the tier table.
+// DefaultPlannerTierUpgradeEnabled turns on the tier guard so a trivial
+// first turn can't pin a Low-tier model for the rest of the session.
+// See internal/router/capability.
 const DefaultPlannerTierUpgradeEnabled = true
 
 // session-pin feature flag is off. The planner runs by default with the

--- a/internal/router/capability/tier.go
+++ b/internal/router/capability/tier.go
@@ -1,0 +1,126 @@
+// Package capability assigns a coarse "tier" to each deployed model so
+// the planner can overturn a cost-driven "stay" verdict when the scorer
+// recommends a strictly stronger model than the session pin.
+//
+// The tier ladder is intentionally short (Low / Mid / High) and
+// hand-maintained. We deliberately do NOT derive tiers from
+// pricing.OutputUSDPer1M: output price tracks vendor pricing strategy
+// more than capability (OSS models on OpenRouter are systematically
+// cheap for their strength), and pricing churn would silently move
+// models between tiers without any human review of whether the move
+// is correct. A small explicit table is easier to reason about and
+// keeps tier moves a deliberate decision.
+//
+// Adding a new deployed model means adding it here too. The boot-time
+// Validate call against the cluster scorer's deployed set ensures a
+// new model can never silently bypass the tier guard.
+package capability
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// Tier is the coarse capability bucket for a model. Higher is stronger.
+// Comparisons use the standard integer ordering: a > b means a is in a
+// strictly stronger bucket than b.
+type Tier int
+
+const (
+	// TierUnknown is the zero value, returned when a model is not in the
+	// tier table. Callers should treat it as "do not apply the tier
+	// guard" (fail-soft per request); Validate is what makes a missing
+	// entry fail loud at boot.
+	TierUnknown Tier = iota
+	// TierLow is small / fast / cheap models suitable for greetings,
+	// short Q&A, and trivial code edits.
+	TierLow
+	// TierMid is capable generalists — coding, summarization, mid-depth
+	// reasoning, most agentic workloads.
+	TierMid
+	// TierHigh is frontier models — hard design questions, long-horizon
+	// reasoning, complex agentic loops.
+	TierHigh
+)
+
+// String returns a snake_case label suitable for logs and OTel attrs.
+func (t Tier) String() string {
+	switch t {
+	case TierLow:
+		return "low"
+	case TierMid:
+		return "mid"
+	case TierHigh:
+		return "high"
+	default:
+		return "unknown"
+	}
+}
+
+// tiers is the source of truth. Keys must match the deployed model
+// names in internal/router/cluster/artifacts/<version>/model_registry.json
+// verbatim; Validate enforces this at boot.
+var tiers = map[string]Tier{
+	// --- Low ---
+	"claude-haiku-4-5":                 TierLow,
+	"gemini-3.1-flash-lite-preview":    TierLow,
+	"gemini-2.5-flash":                 TierLow,
+	"gpt-4.1-nano":                     TierLow,
+	"gpt-4.1-mini":                     TierLow,
+	"qwen/qwen3-30b-a3b-instruct-2507": TierLow,
+	"qwen/qwen3.5-flash-02-23":         TierLow,
+	"deepseek/deepseek-v4-flash":       TierLow,
+	"mistralai/mistral-small-2603":     TierLow,
+
+	// --- Mid ---
+	"claude-sonnet-4-5":                TierMid,
+	"gemini-3-flash-preview":           TierMid,
+	"gpt-4.1":                          TierMid,
+	"gpt-5.5-nano":                     TierMid,
+	"gpt-5.5-mini":                     TierMid,
+	"gpt-5.4-nano":                     TierMid,
+	"gpt-5.4-mini":                     TierMid,
+	"qwen/qwen3-235b-a22b-2507":        TierMid,
+	"qwen/qwen3-coder":                 TierMid,
+	"qwen/qwen3-coder-next":            TierMid,
+	"qwen/qwen3-next-80b-a3b-instruct": TierMid,
+
+	// --- High ---
+	"claude-opus-4-7":           TierHigh,
+	"gemini-3-pro-preview":      TierHigh,
+	"gemini-3.1-pro-preview":    TierHigh,
+	"gpt-5":                     TierHigh,
+	"gpt-5.4":                   TierHigh,
+	"gpt-5.5":                   TierHigh,
+	"gpt-5.4-pro":               TierHigh,
+	"gpt-5.5-pro":               TierHigh,
+	"moonshotai/kimi-k2.5":      TierHigh,
+	"deepseek/deepseek-v4-pro":  TierHigh,
+}
+
+// TierFor returns the capability tier for a model, or TierUnknown when
+// the model is not in the table. TierUnknown disables the planner's
+// tier guard for that decision (it never compares greater than any
+// known tier).
+func TierFor(model string) Tier {
+	return tiers[model]
+}
+
+// Validate returns a non-nil error listing any model in deployed that
+// is absent from the tier table. Intended to be called once at boot
+// against the cluster scorer's deployed-models set so a newly-added
+// model cannot silently bypass the tier guard.
+func Validate(deployed []string) error {
+	var missing []string
+	for _, m := range deployed {
+		if _, ok := tiers[m]; !ok {
+			missing = append(missing, m)
+		}
+	}
+	if len(missing) == 0 {
+		return nil
+	}
+	sort.Strings(missing)
+	return fmt.Errorf("capability: deployed models missing from tier table — add them to internal/router/capability/tier.go: %s", strings.Join(missing, ", "))
+}

--- a/internal/router/capability/tier.go
+++ b/internal/router/capability/tier.go
@@ -1,19 +1,8 @@
-// Package capability assigns a coarse "tier" to each deployed model so
-// the planner can overturn a cost-driven "stay" verdict when the scorer
-// recommends a strictly stronger model than the session pin.
-//
-// The tier ladder is intentionally short (Low / Mid / High) and
-// hand-maintained. We deliberately do NOT derive tiers from
-// pricing.OutputUSDPer1M: output price tracks vendor pricing strategy
-// more than capability (OSS models on OpenRouter are systematically
-// cheap for their strength), and pricing churn would silently move
-// models between tiers without any human review of whether the move
-// is correct. A small explicit table is easier to reason about and
-// keeps tier moves a deliberate decision.
-//
-// Adding a new deployed model means adding it here too. The boot-time
-// Validate call against the cluster scorer's deployed set ensures a
-// new model can never silently bypass the tier guard.
+// Package capability assigns a coarse Low/Mid/High tier to each
+// deployed model so the planner can overturn a cost-driven "stay" when
+// the scorer recommends a strictly stronger model. Hand-maintained on
+// purpose — deriving tiers from price would silently move models on
+// every pricing change.
 package capability
 
 import (
@@ -22,29 +11,21 @@ import (
 	"strings"
 )
 
-// Tier is the coarse capability bucket for a model. Higher is stronger.
-// Comparisons use the standard integer ordering: a > b means a is in a
-// strictly stronger bucket than b.
+// Tier is the coarse capability bucket. Higher is stronger; integer
+// ordering is load-bearing (planner compares freshTier > pinTier).
 type Tier int
 
 const (
-	// TierUnknown is the zero value, returned when a model is not in the
-	// tier table. Callers should treat it as "do not apply the tier
-	// guard" (fail-soft per request); Validate is what makes a missing
-	// entry fail loud at boot.
+	// TierUnknown is the zero value for models absent from the table.
+	// Per-request it disables the tier guard; Validate fails loud at
+	// boot so a missing entry can't silently bypass it.
 	TierUnknown Tier = iota
-	// TierLow is small / fast / cheap models suitable for greetings,
-	// short Q&A, and trivial code edits.
 	TierLow
-	// TierMid is capable generalists — coding, summarization, mid-depth
-	// reasoning, most agentic workloads.
 	TierMid
-	// TierHigh is frontier models — hard design questions, long-horizon
-	// reasoning, complex agentic loops.
 	TierHigh
 )
 
-// String returns a snake_case label suitable for logs and OTel attrs.
+// String returns a snake_case label for logs and OTel attrs.
 func (t Tier) String() string {
 	switch t {
 	case TierLow:
@@ -58,8 +39,8 @@ func (t Tier) String() string {
 	}
 }
 
-// tiers is the source of truth. Keys must match the deployed model
-// names in internal/router/cluster/artifacts/<version>/model_registry.json
+// tiers keys must match deployed model names in
+// internal/router/cluster/artifacts/<version>/model_registry.json
 // verbatim; Validate enforces this at boot.
 var tiers = map[string]Tier{
 	// --- Low ---
@@ -99,18 +80,13 @@ var tiers = map[string]Tier{
 	"deepseek/deepseek-v4-pro":  TierHigh,
 }
 
-// TierFor returns the capability tier for a model, or TierUnknown when
-// the model is not in the table. TierUnknown disables the planner's
-// tier guard for that decision (it never compares greater than any
-// known tier).
+// TierFor returns the model's tier, or TierUnknown if absent.
 func TierFor(model string) Tier {
 	return tiers[model]
 }
 
-// Validate returns a non-nil error listing any model in deployed that
-// is absent from the tier table. Intended to be called once at boot
-// against the cluster scorer's deployed-models set so a newly-added
-// model cannot silently bypass the tier guard.
+// Validate returns an error naming any deployed model missing from the
+// tier table. Called once at boot against the scorer's deployed set.
 func Validate(deployed []string) error {
 	var missing []string
 	for _, m := range deployed {

--- a/internal/router/capability/tier.go
+++ b/internal/router/capability/tier.go
@@ -68,16 +68,16 @@ var tiers = map[string]Tier{
 	"qwen/qwen3-next-80b-a3b-instruct": TierMid,
 
 	// --- High ---
-	"claude-opus-4-7":           TierHigh,
-	"gemini-3-pro-preview":      TierHigh,
-	"gemini-3.1-pro-preview":    TierHigh,
-	"gpt-5":                     TierHigh,
-	"gpt-5.4":                   TierHigh,
-	"gpt-5.5":                   TierHigh,
-	"gpt-5.4-pro":               TierHigh,
-	"gpt-5.5-pro":               TierHigh,
-	"moonshotai/kimi-k2.5":      TierHigh,
-	"deepseek/deepseek-v4-pro":  TierHigh,
+	"claude-opus-4-7":          TierHigh,
+	"gemini-3-pro-preview":     TierHigh,
+	"gemini-3.1-pro-preview":   TierHigh,
+	"gpt-5":                    TierHigh,
+	"gpt-5.4":                  TierHigh,
+	"gpt-5.5":                  TierHigh,
+	"gpt-5.4-pro":              TierHigh,
+	"gpt-5.5-pro":              TierHigh,
+	"moonshotai/kimi-k2.5":     TierHigh,
+	"deepseek/deepseek-v4-pro": TierHigh,
 }
 
 // TierFor returns the model's tier, or TierUnknown if absent.

--- a/internal/router/capability/tier_test.go
+++ b/internal/router/capability/tier_test.go
@@ -1,0 +1,90 @@
+package capability_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"workweave/router/internal/router/capability"
+)
+
+func TestTierFor(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		model string
+		want  capability.Tier
+	}{
+		{"claude-haiku-4-5", capability.TierLow},
+		{"gemini-3.1-flash-lite-preview", capability.TierLow},
+		{"claude-sonnet-4-5", capability.TierMid},
+		{"qwen/qwen3-coder", capability.TierMid},
+		{"claude-opus-4-7", capability.TierHigh},
+		{"gpt-5.5", capability.TierHigh},
+		{"moonshotai/kimi-k2.5", capability.TierHigh},
+		{"deepseek/deepseek-v4-pro", capability.TierHigh},
+		{"fictional-foo-1.0", capability.TierUnknown},
+	}
+	for _, tc := range cases {
+		t.Run(tc.model, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.want, capability.TierFor(tc.model))
+		})
+	}
+}
+
+// TestTierOrdering pins the integer ordering the planner relies on:
+// Unknown < Low < Mid < High. If anyone reorders the iota, this fails.
+func TestTierOrdering(t *testing.T) {
+	t.Parallel()
+	assert.Less(t, capability.TierUnknown, capability.TierLow)
+	assert.Less(t, capability.TierLow, capability.TierMid)
+	assert.Less(t, capability.TierMid, capability.TierHigh)
+}
+
+func TestValidate(t *testing.T) {
+	t.Parallel()
+
+	t.Run("all deployed models have tiers", func(t *testing.T) {
+		t.Parallel()
+		// Mirror the v0.27 deployed_models set — the production-bound
+		// bundle. Adding a model to that registry without adding it to
+		// the tier table should be caught here too.
+		deployed := []string{
+			"claude-haiku-4-5",
+			"claude-sonnet-4-5",
+			"claude-opus-4-7",
+			"gemini-3.1-flash-lite-preview",
+			"gemini-3.1-pro-preview",
+			"gemini-3-flash-preview",
+			"gpt-4.1",
+			"gpt-5.4-mini",
+			"gpt-5.5",
+			"gemini-2.5-flash",
+			"qwen/qwen3-235b-a22b-2507",
+			"qwen/qwen3-30b-a3b-instruct-2507",
+			"qwen/qwen3-coder-next",
+			"qwen/qwen3-next-80b-a3b-instruct",
+			"qwen/qwen3.5-flash-02-23",
+			"qwen/qwen3-coder",
+			"deepseek/deepseek-v4-flash",
+			"deepseek/deepseek-v4-pro",
+			"moonshotai/kimi-k2.5",
+			"mistralai/mistral-small-2603",
+		}
+		require.NoError(t, capability.Validate(deployed))
+	})
+
+	t.Run("missing model surfaces in error", func(t *testing.T) {
+		t.Parallel()
+		err := capability.Validate([]string{"claude-opus-4-7", "fictional-foo-1.0"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "fictional-foo-1.0")
+		assert.NotContains(t, err.Error(), "claude-opus-4-7")
+	})
+
+	t.Run("empty deployed list is valid", func(t *testing.T) {
+		t.Parallel()
+		assert.NoError(t, capability.Validate(nil))
+	})
+}

--- a/internal/router/planner/policy.go
+++ b/internal/router/planner/policy.go
@@ -12,8 +12,13 @@
 // where pinMult / freshMult are each model's per-provider cache-read
 // multiplier (Anthropic 0.10, OpenAI 0.50, Gemini 0.25, ...) read via
 // pricing.Pricing.EffectiveCacheReadMultiplier. The planner switches
-// only when (expected savings - eviction cost) exceeds a configurable
-// threshold. The cache-read multiplier on the savings term reflects
+// when (expected savings - eviction cost) exceeds a configurable
+// threshold OR when the optional tier-upgrade guard fires — that is,
+// when the fresh scorer recommendation is in a strictly higher
+// capability tier than the pin (see internal/router/capability). The
+// tier guard exists because a small first turn ("hi") can pin a Low
+// model, and the pure EV math will then keep all subsequent harder
+// prompts on the cheap pin since switching evicts the warm cache. The cache-read multiplier on the savings term reflects
 // that once a pin is warm, ~(1 - mult) of input tokens come from cache
 // on both the pinned and (post-eviction) fresh model, so only the
 // cache-read portion of the per-turn delta accrues over the horizon.
@@ -25,6 +30,7 @@ package planner
 
 import (
 	"workweave/router/internal/router"
+	"workweave/router/internal/router/capability"
 	"workweave/router/internal/router/pricing"
 	"workweave/router/internal/router/sessionpin"
 )
@@ -64,6 +70,16 @@ type EVConfig struct {
 	// Default 3 reflects observed session length distributions; tuned
 	// per deployment via env.
 	ExpectedRemainingTurns int
+	// TierUpgradeEnabled overturns an EV "stay" verdict when the fresh
+	// scorer recommendation is in a strictly higher capability tier
+	// than the pin. Tiers live in internal/router/capability and are a
+	// short hand-maintained ladder (low / mid / high). The guard is
+	// asymmetric on purpose: only upgrades fire, never sideways or
+	// downward moves — those are already governed correctly by the EV
+	// math (cheap fresh model → expectedSavings > evictionCost → switch).
+	// Defaults to false so existing callers (tests, BYOK paths) get
+	// unchanged behavior; production wires it on via env.
+	TierUpgradeEnabled bool
 }
 
 // Inputs is the full per-turn input to Decide. Kept as a struct (not
@@ -85,6 +101,7 @@ const (
 	ReasonPricingMissing  = "pricing_missing"
 	ReasonEVPositive      = "ev_positive"
 	ReasonEVNegative      = "ev_negative"
+	ReasonTierUpgrade     = "tier_upgrade"
 )
 
 // Decide returns the planner verdict for this turn. See package doc for
@@ -142,12 +159,35 @@ func Decide(in Inputs, cfg EVConfig) Decision {
 		EvictionCostUSD:    evictionCost,
 		ThresholdUSD:       cfg.ThresholdUSD,
 	}
-	if expectedSavings-evictionCost > cfg.ThresholdUSD {
+	switch {
+	case expectedSavings-evictionCost > cfg.ThresholdUSD:
 		d.Outcome = OutcomeSwitch
 		d.Reason = ReasonEVPositive
-	} else {
+	case cfg.TierUpgradeEnabled && tierUpgrade(in.Pin.Model, in.Fresh.Model):
+		// EV said stay, but the scorer wants a strictly stronger model.
+		// Pay the eviction cost — the per-turn capability gain on a hard
+		// prompt is worth more than the cache we'd preserve. Only fires
+		// when both models are in the tier table; unknown-tier models
+		// fall through to the EV verdict so a missing entry never
+		// silently forces a switch.
+		d.Outcome = OutcomeSwitch
+		d.Reason = ReasonTierUpgrade
+	default:
 		d.Outcome = OutcomeStay
 		d.Reason = ReasonEVNegative
 	}
 	return d
+}
+
+// tierUpgrade reports whether fresh is in a strictly higher capability
+// tier than pin. Both models must be in the tier table; an unknown
+// tier on either side disables the guard for that decision, so a model
+// missing from the table can never silently force a switch.
+func tierUpgrade(pin, fresh string) bool {
+	pinTier := capability.TierFor(pin)
+	freshTier := capability.TierFor(fresh)
+	if pinTier == capability.TierUnknown || freshTier == capability.TierUnknown {
+		return false
+	}
+	return freshTier > pinTier
 }

--- a/internal/router/planner/policy.go
+++ b/internal/router/planner/policy.go
@@ -13,12 +13,11 @@
 // multiplier (Anthropic 0.10, OpenAI 0.50, Gemini 0.25, ...) read via
 // pricing.Pricing.EffectiveCacheReadMultiplier. The planner switches
 // when (expected savings - eviction cost) exceeds a configurable
-// threshold OR when the optional tier-upgrade guard fires — that is,
-// when the fresh scorer recommendation is in a strictly higher
-// capability tier than the pin (see internal/router/capability). The
-// tier guard exists because a small first turn ("hi") can pin a Low
-// model, and the pure EV math will then keep all subsequent harder
-// prompts on the cheap pin since switching evicts the warm cache. The cache-read multiplier on the savings term reflects
+// threshold OR when the tier-upgrade guard fires (fresh is in a
+// strictly higher capability tier than pin; see
+// internal/router/capability). The guard exists because a trivial
+// first turn can pin a Low model and the pure EV math will then keep
+// every harder prompt on the cheap pin. The cache-read multiplier on the savings term reflects
 // that once a pin is warm, ~(1 - mult) of input tokens come from cache
 // on both the pinned and (post-eviction) fresh model, so only the
 // cache-read portion of the per-turn delta accrues over the horizon.
@@ -70,15 +69,10 @@ type EVConfig struct {
 	// Default 3 reflects observed session length distributions; tuned
 	// per deployment via env.
 	ExpectedRemainingTurns int
-	// TierUpgradeEnabled overturns an EV "stay" verdict when the fresh
-	// scorer recommendation is in a strictly higher capability tier
-	// than the pin. Tiers live in internal/router/capability and are a
-	// short hand-maintained ladder (low / mid / high). The guard is
-	// asymmetric on purpose: only upgrades fire, never sideways or
-	// downward moves — those are already governed correctly by the EV
-	// math (cheap fresh model → expectedSavings > evictionCost → switch).
-	// Defaults to false so existing callers (tests, BYOK paths) get
-	// unchanged behavior; production wires it on via env.
+	// TierUpgradeEnabled overturns an EV "stay" when fresh is strictly
+	// higher tier than pin (see internal/router/capability). Upgrade-
+	// only by design — downgrades and sideways moves stay under the EV
+	// verdict, which already routes cheap-fresh to switch.
 	TierUpgradeEnabled bool
 }
 
@@ -164,12 +158,7 @@ func Decide(in Inputs, cfg EVConfig) Decision {
 		d.Outcome = OutcomeSwitch
 		d.Reason = ReasonEVPositive
 	case cfg.TierUpgradeEnabled && tierUpgrade(in.Pin.Model, in.Fresh.Model):
-		// EV said stay, but the scorer wants a strictly stronger model.
-		// Pay the eviction cost — the per-turn capability gain on a hard
-		// prompt is worth more than the cache we'd preserve. Only fires
-		// when both models are in the tier table; unknown-tier models
-		// fall through to the EV verdict so a missing entry never
-		// silently forces a switch.
+		// EV said stay; pay the eviction cost for a stronger model.
 		d.Outcome = OutcomeSwitch
 		d.Reason = ReasonTierUpgrade
 	default:
@@ -179,10 +168,9 @@ func Decide(in Inputs, cfg EVConfig) Decision {
 	return d
 }
 
-// tierUpgrade reports whether fresh is in a strictly higher capability
-// tier than pin. Both models must be in the tier table; an unknown
-// tier on either side disables the guard for that decision, so a model
-// missing from the table can never silently force a switch.
+// tierUpgrade reports whether fresh is strictly higher tier than pin.
+// Unknown on either side disables the guard so a missing entry never
+// silently forces a switch.
 func tierUpgrade(pin, fresh string) bool {
 	pinTier := capability.TierFor(pin)
 	freshTier := capability.TierFor(fresh)

--- a/internal/router/planner/policy_test.go
+++ b/internal/router/planner/policy_test.go
@@ -36,6 +36,15 @@ var availableAll = map[string]struct{}{
 	modelGPT5:   {},
 }
 
+// tierUpgradeCfg mirrors defaultCfg with the tier guard turned on. Used
+// by the tier-upgrade tests so the EV-only cases stay independent of the
+// new knob.
+var tierUpgradeCfg = planner.EVConfig{
+	ThresholdUSD:           0.001,
+	ExpectedRemainingTurns: 3,
+	TierUpgradeEnabled:     true,
+}
+
 // pinWithUsage returns a populated pin that has completed at least one
 // turn, so the planner's LastTurnEndedAt-zero guard does not fire.
 func pinWithUsage(model string) sessionpin.Pin {
@@ -239,6 +248,66 @@ func TestDecide(t *testing.T) {
 			expectEVMath:           true,
 			wantExpectedSavingsUSD: 0.0375,
 			wantEvictionCostUSD:    0.0625,
+		},
+		{
+			// Tier guard off: haiku -> opus would normally stay (huge net
+			// loss on EV). Same case as "ev_negative" above — kept here as
+			// a regression that the tier knob is the only thing that
+			// flips the outcome.
+			name: "tier_upgrade_disabled: low -> high still stays",
+			in: planner.Inputs{
+				Pin:                  pinWithUsage(modelHaiku),
+				Fresh:                router.Decision{Model: modelOpus},
+				EstimatedInputTokens: 50_000,
+				AvailableModels:      availableAll,
+			},
+			cfg:                    defaultCfg, // TierUpgradeEnabled = false
+			want:                   planner.Decision{Outcome: planner.OutcomeStay, Reason: planner.ReasonEVNegative},
+			expectEVMath:           true,
+			wantExpectedSavingsUSD: -0.213,
+			wantEvictionCostUSD:    0.675,
+		},
+		{
+			// Tier guard on: same haiku -> opus EV-loss case as above
+			// now flips because opus is strictly higher tier than haiku.
+			// EV math still runs and the USD fields are populated; only
+			// the verdict differs.
+			name: "tier_upgrade: low -> high flips stay into switch",
+			in: planner.Inputs{
+				Pin:                  pinWithUsage(modelHaiku),
+				Fresh:                router.Decision{Model: modelOpus},
+				EstimatedInputTokens: 50_000,
+				AvailableModels:      availableAll,
+			},
+			cfg:                    tierUpgradeCfg,
+			want:                   planner.Decision{Outcome: planner.OutcomeSwitch, Reason: planner.ReasonTierUpgrade},
+			expectEVMath:           true,
+			wantExpectedSavingsUSD: -0.213,
+			wantEvictionCostUSD:    0.675,
+		},
+		{
+			// Tier guard on but pin and fresh are in the same tier
+			// (sonnet is Mid; haiku is Low — different tiers but this
+			// is a DOWNgrade, not an upgrade). Tier guard must not fire
+			// on downgrades; EV math governs (here EV is also negative
+			// → stay).
+			name: "tier_upgrade: downgrade does not trigger guard",
+			in: planner.Inputs{
+				// per-token net = (3 * 0.1 * (3.00 - 0.80) - 0.9 * 0.80) / 1e6
+				//               = (0.66 - 0.72) / 1e6 = -0.06 / 1e6  → tiny net loss per turn.
+				Pin:                  pinWithUsage(modelSonnet),
+				Fresh:                router.Decision{Model: modelHaiku},
+				EstimatedInputTokens: 1000,
+				AvailableModels:      availableAll,
+			},
+			cfg:          tierUpgradeCfg,
+			want:         planner.Decision{Outcome: planner.OutcomeStay, Reason: planner.ReasonEVNegative},
+			expectEVMath: true,
+			// savingsPerTurn = (3.00 - 0.80) * 0.1 * 1000 / 1e6 = $0.00022
+			// expectedSavings = 0.00022 * 3 = $0.00066
+			// evictionCost   = 0.80 * 1000 * 0.9 / 1e6 = $0.00072
+			wantExpectedSavingsUSD: 0.00066,
+			wantEvictionCostUSD:    0.00072,
 		},
 	}
 

--- a/internal/router/planner/policy_test.go
+++ b/internal/router/planner/policy_test.go
@@ -36,9 +36,7 @@ var availableAll = map[string]struct{}{
 	modelGPT5:   {},
 }
 
-// tierUpgradeCfg mirrors defaultCfg with the tier guard turned on. Used
-// by the tier-upgrade tests so the EV-only cases stay independent of the
-// new knob.
+// tierUpgradeCfg mirrors defaultCfg with the tier guard on.
 var tierUpgradeCfg = planner.EVConfig{
 	ThresholdUSD:           0.001,
 	ExpectedRemainingTurns: 3,
@@ -250,10 +248,8 @@ func TestDecide(t *testing.T) {
 			wantEvictionCostUSD:    0.0625,
 		},
 		{
-			// Tier guard off: haiku -> opus would normally stay (huge net
-			// loss on EV). Same case as "ev_negative" above — kept here as
-			// a regression that the tier knob is the only thing that
-			// flips the outcome.
+			// Mirror of ev_negative; pinned here so the next case can show
+			// the tier knob is what flips the verdict.
 			name: "tier_upgrade_disabled: low -> high still stays",
 			in: planner.Inputs{
 				Pin:                  pinWithUsage(modelHaiku),
@@ -268,10 +264,8 @@ func TestDecide(t *testing.T) {
 			wantEvictionCostUSD:    0.675,
 		},
 		{
-			// Tier guard on: same haiku -> opus EV-loss case as above
-			// now flips because opus is strictly higher tier than haiku.
-			// EV math still runs and the USD fields are populated; only
-			// the verdict differs.
+			// Same EV-loss as above; guard on flips it because opus is
+			// strictly higher tier than haiku. USD fields still populated.
 			name: "tier_upgrade: low -> high flips stay into switch",
 			in: planner.Inputs{
 				Pin:                  pinWithUsage(modelHaiku),
@@ -286,15 +280,10 @@ func TestDecide(t *testing.T) {
 			wantEvictionCostUSD:    0.675,
 		},
 		{
-			// Tier guard on but pin and fresh are in the same tier
-			// (sonnet is Mid; haiku is Low — different tiers but this
-			// is a DOWNgrade, not an upgrade). Tier guard must not fire
-			// on downgrades; EV math governs (here EV is also negative
-			// → stay).
+			// Sonnet (Mid) -> haiku (Low) is a downgrade; guard must
+			// not fire, EV math governs.
 			name: "tier_upgrade: downgrade does not trigger guard",
 			in: planner.Inputs{
-				// per-token net = (3 * 0.1 * (3.00 - 0.80) - 0.9 * 0.80) / 1e6
-				//               = (0.66 - 0.72) / 1e6 = -0.06 / 1e6  → tiny net loss per turn.
 				Pin:                  pinWithUsage(modelSonnet),
 				Fresh:                router.Decision{Model: modelHaiku},
 				EstimatedInputTokens: 1000,


### PR DESCRIPTION
## Summary

- New \`internal/router/capability\` package with a small hand-maintained tier table (Low / Mid / High).
- New \`EVConfig.TierUpgradeEnabled\` knob (default on, env \`ROUTER_SWITCH_TIER_UPGRADE_ENABLED\`). When the EV math would say *stay* but the scorer's fresh recommendation is in a strictly higher tier than the pin, the planner overturns to switch with reason \`tier_upgrade\`. Downgrades and sideways moves fall through to the existing EV verdict.
- Boot-time \`capability.Validate\` against the cluster scorer's deployed set panics if any deployed model is missing from the tier table — a new model can never silently bypass the guard via \`TierUnknown\`.

## Why

The current planner is purely economic: it compares (expected cache savings) vs (eviction cost) and stays whenever the math is non-positive. A trivial first turn (\`hi\`) pins a Low-tier model like \`gemini-3.1-flash-lite-preview\`, and every subsequent harder prompt then stays on the cheap pin because evicting the warm Gemini cache beats the input-price delta — even when the scorer's fresh recommendation is opus or gemini-pro. The tier guard fixes exactly that case.

Why explicit tiers instead of \`OutputUSDPer1M\` ratio:

- Output price tracks vendor pricing strategy as much as capability (OSS models on OpenRouter are systematically cheap for their strength).
- Pricing churn would silently move models between tiers with no human review.
- A short hand-maintained table is easier to reason about; every tier move is a deliberate decision in the diff.

## Tiers

\`\`\`
Low : claude-haiku-4-5, gemini-3.1-flash-lite-preview, gemini-2.5-flash,
      gpt-4.1-nano/mini, qwen3-30b/qwen3.5-flash, deepseek-v4-flash,
      mistral-small-2603
Mid : claude-sonnet-4-5, gemini-3-flash-preview, gpt-4.1, gpt-5.x-mini/nano,
      qwen3-235b/qwen3-coder/qwen3-coder-next/qwen3-next-80b
High: claude-opus-4-7, gemini-3-pro-preview, gemini-3.1-pro-preview,
      gpt-5, gpt-5.4, gpt-5.5, gpt-5.4-pro, gpt-5.5-pro,
      moonshotai/kimi-k2.5, deepseek/deepseek-v4-pro
\`\`\`

## Test plan

- [x] \`go test ./internal/router/capability/... ./internal/router/planner/... ./internal/proxy/...\` passes locally
- [x] \`go build ./...\` and \`go vet ./...\` clean
- [x] \`capability.Validate\` exercised against the v0.27 deployed_models set
- [x] New planner cases: tier-guard-off downgrade still stays, tier-guard-on upgrade flips stay→switch, downgrade with guard on still stays

🤖 Generated with [Claude Code](https://claude.com/claude-code)