### PR TITLE
proxy: classify max_tokens<=4 as Probe + drop min-prompt-chars floor

### DIFF
--- a/cmd/router/main.go
+++ b/cmd/router/main.go
@@ -506,16 +506,6 @@ func buildClusterScorer(availableProviders map[string]struct{}) (router.Router, 
 			logger.Info("Cluster embed timeout overridden", "embed_timeout_ms", ms.Milliseconds())
 		}
 	}
-	if v := config.GetOr("ROUTER_CLUSTER_MIN_PROMPT_CHARS", ""); v != "" {
-		n, parseErr := strconv.Atoi(v)
-		if parseErr != nil || n < 0 {
-			logger.Warn("Invalid ROUTER_CLUSTER_MIN_PROMPT_CHARS; using default", "value", v, "default", cfg.MinPromptChars)
-		} else {
-			cfg.MinPromptChars = n
-			logger.Info("Cluster min prompt chars overridden", "min_prompt_chars", n)
-		}
-	}
-
 	scorers := make(map[string]*cluster.Scorer, len(versions))
 	for _, v := range versions {
 		bundle, err := cluster.LoadBundle(v)

--- a/internal/proxy/turnloop.go
+++ b/internal/proxy/turnloop.go
@@ -92,10 +92,14 @@ func (s *Service) runTurnLoop(
 	}
 
 	// Hard pins for turn types whose optimal model is known a priori
-	// (compaction, Explore sub-agent dispatch). Bypass pin lookup, pin
-	// write, planner and scorer entirely so the pin row keeps tracking
-	// the main-loop model.
+	// (compaction, Explore sub-agent dispatch, SDK quota probes). Bypass
+	// pin lookup, pin write, planner and scorer entirely so the pin row
+	// keeps tracking the main-loop model. Probes specifically MUST NOT
+	// create a session pin — the Anthropic SDK fires one on init before
+	// the first real user turn, and if it anchored the pin every
+	// subsequent turn would inherit the probe's cheap-model decision.
 	if res.TurnType == turntype.Compaction ||
+		res.TurnType == turntype.Probe ||
 		(res.TurnType == turntype.SubAgentDispatch && s.hardPinExplore) {
 		res.Decision = router.Decision{
 			Provider: s.hardPinProvider,

--- a/internal/router/cluster/scorer.go
+++ b/internal/router/cluster/scorer.go
@@ -25,7 +25,6 @@ var ErrNoEligibleProvider = errors.New("cluster: no eligible provider for reques
 // Config carries the scorer's runtime knobs.
 type Config struct {
 	TopP           int
-	MinPromptChars int
 	MaxPromptChars int
 	EmbedTimeout   time.Duration
 }
@@ -34,7 +33,6 @@ type Config struct {
 func DefaultConfig() Config {
 	return Config{
 		TopP:           4,
-		MinPromptChars: 20,
 		MaxPromptChars: 1024,
 		EmbedTimeout:   1500 * time.Millisecond,
 	}
@@ -189,16 +187,6 @@ func sortedKeys(m map[string]struct{}) []string {
 func (s *Scorer) Route(ctx context.Context, req router.Request) (router.Decision, error) {
 	start := time.Now()
 	log := observability.Get()
-
-	if len(req.PromptText) < s.cfg.MinPromptChars {
-		log.Warn(
-			"Cluster scorer: prompt too short; returning ErrClusterUnavailable",
-			"prompt_chars", len(req.PromptText),
-			"min_prompt_chars", s.cfg.MinPromptChars,
-			"requested_model", req.RequestedModel,
-		)
-		return router.Decision{}, fmt.Errorf("prompt has %d chars, minimum is %d: %w", len(req.PromptText), s.cfg.MinPromptChars, ErrClusterUnavailable)
-	}
 
 	text := tailTruncate(req.PromptText, s.cfg.MaxPromptChars)
 	truncated := len(req.PromptText) > s.cfg.MaxPromptChars

--- a/internal/router/cluster/scorer_test.go
+++ b/internal/router/cluster/scorer_test.go
@@ -177,18 +177,6 @@ func TestScorer_PicksOtherClusterWhenAligned(t *testing.T) {
 	assert.Equal(t, "claude-haiku-4-5", got.Model)
 }
 
-// Fail loud rather than silently degrade — silent fallback masked real
-// regressions in eval.
-func TestScorer_ReturnsErrOnShortPrompt(t *testing.T) {
-	emb := &fakeEmbedder{vec: makeOpusVec()}
-	s := newScorerForTest(t, emb, cfgForTest())
-
-	_, err := s.Route(context.Background(), router.Request{PromptText: "hi"})
-	require.Error(t, err)
-	assert.True(t, errors.Is(err, ErrClusterUnavailable))
-	assert.Equal(t, 0, emb.calls, "embedder should not be called for short prompts")
-}
-
 func TestScorer_ReturnsErrOnEmbedderError(t *testing.T) {
 	emb := &fakeEmbedder{err: errors.New("ort exploded")}
 	s := newScorerForTest(t, emb, cfgForTest())

--- a/internal/router/turntype/detect.go
+++ b/internal/router/turntype/detect.go
@@ -25,7 +25,19 @@ const (
 	// Compaction: Claude Code context-compaction turn. Always routed to
 	// Haiku (short-out-of-long-in cost profile).
 	Compaction TurnType = "compaction"
+	// Probe: a quota / liveness check the caller issued before any real
+	// conversation (Anthropic SDK + Claude Code do this on init with
+	// max_tokens=1). Always hard-pinned to the cheap model AND skips
+	// session-pin creation so a probe never anchors subsequent routing.
+	Probe TurnType = "probe"
 )
+
+// probeMaxTokensThreshold is the inclusive upper bound on max_tokens for
+// classifying a request as a probe. The Anthropic SDK quota check uses
+// max_tokens=1; allow up to 4 to absorb minor variations across SDK
+// versions without false-positiving real "give me a short answer" calls
+// (which start around 64+).
+const probeMaxTokensThreshold = 4
 
 // DetectFromEnvelope classifies an inbound request. subAgentHint is the
 // optional x-weave-subagent-type header value; empty is ignored.
@@ -36,6 +48,13 @@ const (
 func DetectFromEnvelope(env *translate.RequestEnvelope, feats translate.RoutingFeatures, subAgentHint string) TurnType {
 	if env == nil {
 		return MainLoop
+	}
+	// Probe is checked first: it's the most specific signal (a numeric
+	// cap on the caller's request, not a heuristic over text) and the
+	// consequence is biggest — a probe that anchors a session pin
+	// poisons every subsequent turn in that session.
+	if isProbe(feats) {
+		return Probe
 	}
 	systemText := env.SystemText()
 	if isCompaction(systemText) {
@@ -48,6 +67,15 @@ func DetectFromEnvelope(env *translate.RequestEnvelope, feats translate.RoutingF
 		return ToolResult
 	}
 	return MainLoop
+}
+
+// isProbe reports whether a request is a liveness/quota check that should
+// be hard-pinned and excluded from session-pin creation. The Anthropic
+// SDK's `client.messages.create(..., max_tokens=1)` quota probe is the
+// canonical case; OpenAI's `max_completion_tokens` and Gemini's
+// `generationConfig.maxOutputTokens` produce the same RoutingFeatures.
+func isProbe(feats translate.RoutingFeatures) bool {
+	return feats.MaxTokens > 0 && feats.MaxTokens <= probeMaxTokensThreshold
 }
 
 // isCompaction reports whether the system prompt contains Claude Code's

--- a/internal/router/turntype/detect_test.go
+++ b/internal/router/turntype/detect_test.go
@@ -101,6 +101,31 @@ func TestDetectFromEnvelope_Anthropic(t *testing.T) {
 			want: turntype.MainLoop,
 		},
 		{
+			name: "max_tokens=1 quota probe is probe",
+			body: `{"model":"claude-haiku-4-5","max_tokens":1,"messages":[{"role":"user","content":"quota"}]}`,
+			want: turntype.Probe,
+		},
+		{
+			name: "max_tokens=4 still probe (SDK variation buffer)",
+			body: `{"model":"claude-haiku-4-5","max_tokens":4,"messages":[{"role":"user","content":"hi"}]}`,
+			want: turntype.Probe,
+		},
+		{
+			name: "max_tokens=5 is not a probe",
+			body: `{"model":"claude-haiku-4-5","max_tokens":5,"messages":[{"role":"user","content":"hello"}]}`,
+			want: turntype.MainLoop,
+		},
+		{
+			name: "no max_tokens is not a probe",
+			body: `{"model":"claude-haiku-4-5","messages":[{"role":"user","content":"hello there"}]}`,
+			want: turntype.MainLoop,
+		},
+		{
+			name: "probe takes priority over compaction system prompt",
+			body: `{"model":"claude-sonnet-4-5","max_tokens":1,"system":"Your task is to create a detailed summary","messages":[{"role":"user","content":"quota"}]}`,
+			want: turntype.Probe,
+		},
+		{
 			name: "compaction takes priority over tool_result",
 			body: `{"model":"claude-sonnet-4-5","system":"compact the conversation","messages":[
 				{"role":"user","content":[{"type":"tool_result","tool_use_id":"t1","content":"output"}]}
@@ -187,6 +212,16 @@ func TestDetectFromEnvelope_OpenAI(t *testing.T) {
 			]}`,
 			want: turntype.MainLoop,
 		},
+		{
+			name: "max_completion_tokens=1 is probe (modern OpenAI SDK)",
+			body: `{"model":"gpt-4o","max_completion_tokens":1,"messages":[{"role":"user","content":"quota"}]}`,
+			want: turntype.Probe,
+		},
+		{
+			name: "max_tokens=1 is probe (legacy OpenAI SDK)",
+			body: `{"model":"gpt-4o","max_tokens":1,"messages":[{"role":"user","content":"quota"}]}`,
+			want: turntype.Probe,
+		},
 	}
 
 	for _, tc := range tests {
@@ -250,6 +285,11 @@ func TestDetectFromEnvelope_Gemini(t *testing.T) {
 				{"role":"model","parts":[{"text":"hello"}]}
 			]}`,
 			want: turntype.MainLoop,
+		},
+		{
+			name: "generationConfig.maxOutputTokens=1 is probe",
+			body: `{"generationConfig":{"maxOutputTokens":1},"contents":[{"role":"user","parts":[{"text":"quota"}]}]}`,
+			want: turntype.Probe,
 		},
 	}
 

--- a/internal/translate/features.go
+++ b/internal/translate/features.go
@@ -15,6 +15,11 @@ type RoutingFeatures struct {
 	HasTools     bool
 	PromptText   string
 	MessageCount int
+	// MaxTokens is the caller's requested output cap (max_tokens for
+	// Anthropic/OpenAI, generationConfig.maxOutputTokens for Gemini). 0
+	// means unset/unknown. Probe detection in router/turntype keys off
+	// this — Anthropic SDK quota probes set max_tokens=1.
+	MaxTokens int
 	// LastKind: "user_prompt", "tool_result", or "assistant". Empty when messages is empty.
 	LastKind string
 	// LastPreview: first previewMaxChars of the last message's text, newlines collapsed.
@@ -70,6 +75,7 @@ func (e *RequestEnvelope) anthropicRoutingFeatures(extractOnlyUser bool) Routing
 		HasTools:     e.HasTools(),
 		PromptText:   text,
 		MessageCount: msgCount,
+		MaxTokens:    intGJSON(gjson.GetBytes(e.body, "max_tokens")),
 	}
 
 	if msgCount > 0 {
@@ -112,6 +118,7 @@ func (e *RequestEnvelope) openAIRoutingFeatures(extractOnlyUser bool) RoutingFea
 		HasTools:     e.HasTools(),
 		PromptText:   text,
 		MessageCount: msgCount,
+		MaxTokens:    openAIMaxTokens(e.body),
 	}
 
 	if msgCount > 0 {
@@ -124,6 +131,31 @@ func (e *RequestEnvelope) openAIRoutingFeatures(extractOnlyUser bool) RoutingFea
 	}
 
 	return feats
+}
+
+// intGJSON returns the integer value of a JSON number, or 0 when the
+// result is absent / non-numeric / fractional. Probe detection only cares
+// about whole-number caps (max_tokens=1); float values aren't valid here
+// and should be treated as unset rather than rounded silently.
+func intGJSON(v gjson.Result) int {
+	if !v.Exists() || v.Type != gjson.Number {
+		return 0
+	}
+	n := v.Int()
+	if n < 0 {
+		return 0
+	}
+	return int(n)
+}
+
+// openAIMaxTokens reads the output token cap from an OpenAI-format body.
+// Recent OpenAI SDKs send `max_completion_tokens`; older ones send
+// `max_tokens`. Either signals the caller's intent for a probe.
+func openAIMaxTokens(body []byte) int {
+	if n := intGJSON(gjson.GetBytes(body, "max_completion_tokens")); n > 0 {
+		return n
+	}
+	return intGJSON(gjson.GetBytes(body, "max_tokens"))
 }
 
 // classifyLastMessageOpenAI maps an OpenAI message role onto the shared

--- a/internal/translate/features_gemini.go
+++ b/internal/translate/features_gemini.go
@@ -42,6 +42,7 @@ func (e *RequestEnvelope) geminiRoutingFeatures(extractOnlyUser bool) RoutingFea
 		HasTools:     e.HasTools(),
 		PromptText:   text,
 		MessageCount: msgCount,
+		MaxTokens:    intGJSON(gjson.GetBytes(e.body, "generationConfig.maxOutputTokens")),
 	}
 
 	if msgCount > 0 {


### PR DESCRIPTION
## Summary
- New `turntype.Probe` classification for SDK liveness/quota checks (Anthropic SDK fires `messages.create(..., max_tokens=1)` on init). Probes are hard-pinned to the deployment's cheap model and **do not create a session pin** — previously a probe landing on init would anchor every subsequent turn to whatever the cluster scorer picked for its 5-char `"quota"` body, masking the scorer's real output for the user's first real message.
- Removes `ROUTER_CLUSTER_MIN_PROMPT_CHARS` env knob and the `< 20 chars` check in the scorer. The floor was only load-bearing because probes weren't filtered upstream; now that they are, real short user messages flow through the embedder.

## Why
Observed in local logs: a Claude Code session that opened with a quota probe (`prompt_chars=5`, body literally `"quota"`) anchored a session pin to gemini-3.1-flash-lite. The cluster scorer's actual recommendation for the user's first real prompt (`"hello there gangster"`, 20 chars) was deepseek-v4-pro, but the planner correctly stayed on the pin because cache reuse beat the switch. Net effect: routing decisions for a whole session were determined by an SDK init probe, not the user's actual content.

## What changed
- `translate/features.go` / `features_gemini.go` — `RoutingFeatures.MaxTokens` populated for Anthropic (`max_tokens`), OpenAI (`max_completion_tokens` || `max_tokens`), and Gemini (`generationConfig.maxOutputTokens`).
- `router/turntype/detect.go` — new `Probe` constant; `isProbe(feats)` returns true when `0 < MaxTokens <= 4`. Checked first in `DetectFromEnvelope` since it's the most specific signal.
- `proxy/turnloop.go` — Probe joins Compaction in the existing hard-pin branch (reuses `hardPinProvider/hardPinModel`); skips both pin lookup and pin write.
- `router/cluster/scorer.go` — drops `MinPromptChars` from `Config`, `DefaultConfig()`, and the `< MinPromptChars` check in `Route()`. `TestScorer_ReturnsErrOnShortPrompt` deleted with it.
- `cmd/router/main.go` — drops the `ROUTER_CLUSTER_MIN_PROMPT_CHARS` env override block.

## Test plan
- [x] `go test ./...` — full router suite green
- [x] New turntype cases cover all three wire formats: Anthropic `max_tokens` 1/4/5/unset, OpenAI `max_completion_tokens` (modern SDK) + `max_tokens` (legacy), Gemini `generationConfig.maxOutputTokens`, and probe-vs-compaction priority.
- [ ] Manual: rebuild container, send Claude Code session, verify first real-message decision is fresh (no probe-anchored pin in logs)