### PR TITLE
proxy: humanize tier_upgrade routing reason

### DIFF
--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -219,6 +219,8 @@ func humanReasonFromPlanner(code string) string {
 		return "pin model no longer available"
 	case planner.ReasonPricingMissing:
 		return "missing pricing for a candidate"
+	case planner.ReasonTierUpgrade:
+		return "model tier upgrade"
 	default:
 		return code
 	}


### PR DESCRIPTION
## Summary

The Claude Code statusline was rendering the planner reason verbatim as `tier_upgrade` because `humanReasonFromPlanner` had no case for `planner.ReasonTierUpgrade` and fell through to the default passthrough.

Adds the mapping so the marker now reads:

```
✦ Weave Router → deepseek/deepseek-v4-pro (openrouter) · reason: model tier upgrade
```

## Test plan

- [ ] Trigger a tier-upgrade routing decision and confirm the marker prose reads "model tier upgrade"