### PR TITLE
translate: preserve thought_signature on streaming Anthropic tool_use blocks

### DIFF
--- a/internal/translate/stream.go
+++ b/internal/translate/stream.go
@@ -645,10 +645,14 @@ func (t *AnthropicSSETranslator) emitDelta(delta gjson.Result) error {
 			}
 			id := tc.Get("id").Str
 			name := tc.Get("function.name").Str
+			sig := tc.Get("function.thought_signature").Str
+			if sig == "" {
+				sig = tc.Get("thought_signature").Str
+			}
 			blockIdx = t.blockIdx
 			t.toolBlocks[idx] = blockIdx
 			t.blockIdx++
-			if emitErr = t.emitContentBlockStartTool(blockIdx, id, name); emitErr != nil {
+			if emitErr = t.emitContentBlockStartTool(blockIdx, id, name, sig); emitErr != nil {
 				return false
 			}
 		}
@@ -776,7 +780,12 @@ func (t *AnthropicSSETranslator) emitContentBlockStartText(index int) error {
 	return t.flushEvent()
 }
 
-func (t *AnthropicSSETranslator) emitContentBlockStartTool(index int, id, name string) error {
+// emitContentBlockStartTool emits an Anthropic content_block_start for a
+// tool_use block. sig, when non-empty, is the opaque thought_signature that
+// Gemini 3.x requires round-tripped on the next turn's functionCall part —
+// smuggled here as a non-standard field on the tool_use block so clients
+// that pass through unknown fields preserve it.
+func (t *AnthropicSSETranslator) emitContentBlockStartTool(index int, id, name, sig string) error {
 	if sseTraceEnabled {
 		observability.Get().Debug("AnthropicSSE emit", "event", "content_block_start", "type", "tool_use", "name", name)
 	}
@@ -786,6 +795,10 @@ func (t *AnthropicSSETranslator) emitContentBlockStartTool(index int, id, name s
 	sse.WriteJSONString(t.bw, id)
 	t.bw.WriteString(",\"name\":")
 	sse.WriteJSONString(t.bw, name)
+	if sig != "" {
+		t.bw.WriteString(",\"thought_signature\":")
+		sse.WriteJSONString(t.bw, sig)
+	}
 	t.bw.WriteString(",\"input\":{}}}\n\n")
 	return t.flushEvent()
 }

--- a/internal/translate/translate_test.go
+++ b/internal/translate/translate_test.go
@@ -501,6 +501,34 @@ func TestAnthropicSSETranslator_StreamingToolUse(t *testing.T) {
 	assert.Contains(t, body, "event: message_stop")
 }
 
+// Load-bearing: Gemini 3.x requires the opaque thought_signature round-tripped
+// on the next turn's functionCall part. The Gemini→OpenAI translator smuggles
+// it as function.thought_signature on the tool_call chunk; AnthropicSSE must
+// surface it on the tool_use content_block_start so passthrough clients echo
+// it back on the next request.
+func TestAnthropicSSETranslator_StreamingToolUsePreservesThoughtSignature(t *testing.T) {
+	rec := httptest.NewRecorder()
+	translator := translate.NewAnthropicSSETranslator(rec, "gemini-x", nil)
+
+	translator.Header().Set("Content-Type", "text/event-stream")
+	translator.WriteHeader(http.StatusOK)
+
+	events := []string{
+		"data: {\"id\":\"chatcmpl-3\",\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\",\"content\":null,\"tool_calls\":[{\"index\":0,\"id\":\"call_x\",\"type\":\"function\",\"function\":{\"name\":\"bash\",\"arguments\":\"{}\",\"thought_signature\":\"OPAQUE_SIG\"}}]},\"finish_reason\":null}]}\n\n",
+		"data: {\"id\":\"chatcmpl-3\",\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"tool_calls\"}]}\n\n",
+		"data: [DONE]\n\n",
+	}
+	for _, event := range events {
+		_, err := translator.Write([]byte(event))
+		require.NoError(t, err)
+	}
+	require.NoError(t, translator.Finalize())
+
+	body := rec.Body.String()
+	assert.Contains(t, body, `"type":"tool_use"`)
+	assert.Contains(t, body, `"thought_signature":"OPAQUE_SIG"`)
+}
+
 func TestAnthropicSSETranslator_NonStreamingResponse(t *testing.T) {
 	rec := httptest.NewRecorder()
 	translator := translate.NewAnthropicSSETranslator(rec, "gpt-4o", nil)


### PR DESCRIPTION
## Summary

Gemini 3.x rejects multi-turn tool use when a prior `functionCall` part comes back without its `thought_signature`. The Gemini→OpenAI streaming translator already smuggles the signature as `function.thought_signature` on each tool_call chunk, and the non-streaming Gemini→Anthropic path preserves it on `tool_use` blocks — but `AnthropicSSETranslator` was dropping it, so passthrough Anthropic clients (Claude Code) had nothing to echo back on the next turn.

- `AnthropicSSETranslator.emitDelta` now reads `function.thought_signature` from the tool_call chunk.
- `emitContentBlockStartTool` surfaces it as a non-standard field on the `tool_use` content_block_start.
- Added `TestAnthropicSSETranslator_StreamingToolUsePreservesThoughtSignature` covering the previously-untested Gemini→OpenAI→Anthropic streaming leg.

Repro path: Claude Code → router (Anthropic surface) → Gemini 3 native client; assistant emits a tool call (e.g. `EnterPlanMode`), next turn fails with `Function call is missing a thought_signature in functionCall parts`.

## Test plan

- [x] `go test ./internal/translate/`
- [ ] Manual: rerun the Claude Code repro against a router pinned to this commit and confirm the second turn no longer 400s