### PR TITLE
cmd: only build the served cluster version by default

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -66,6 +66,12 @@ ROUTER_DEPLOYMENT_MODE=selfhosted
 # the version named in internal/router/cluster/artifacts/latest.
 # ROUTER_CLUSTER_VERSION=
 
+# Build a Scorer for every committed bundle so callers can A/B versions
+# per-request via the `x-weave-cluster-version` header. Default false:
+# prod loads only the served default version. Set true on staging/eval
+# deployments where the eval harness flips between versions.
+# ROUTER_CLUSTER_BUILD_ALL_VERSIONS=false
+
 # Per-request ONNX embed timeout. Increase on slower hosts.
 ROUTER_CLUSTER_EMBED_TIMEOUT_MS=200
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -465,14 +465,17 @@ the rules-for-AI subset.
   e.g. `v0.2`) names the version the runtime serves by default; the
   `ROUTER_CLUSTER_VERSION` env var overrides it. Promotion is a
   one-line edit to `latest` plus a redeploy.
-- The Go runtime builds **one Scorer per committed bundle** at boot
-  (`cluster.NewMultiversion` in `cmd/router/main.go`); customer traffic
-  hits the default version; any caller can pin per-request to a sibling
-  version with `x-weave-cluster-version: v0.X` via
+- The Go runtime builds **only the served default version** by default
+  (`cmd/router/main.go`'s `buildClusterScorer`). Setting
+  `ROUTER_CLUSTER_BUILD_ALL_VERSIONS=true` switches to building **one
+  Scorer per committed bundle** so callers can pin per-request to a
+  sibling version with `x-weave-cluster-version: v0.X` via
   `middleware.WithClusterVersionOverride`. This is the
-  "compare-against-each-other" mechanism — a single staging deployment
-  carries every committed bundle and the eval harness flips between
-  them per-request.
+  "compare-against-each-other" mechanism — staging/eval deployments set
+  the flag so a single deploy carries every committed bundle and the
+  eval harness flips between them per-request. Prod leaves the flag
+  off: only the default bundle is loaded into memory and the header
+  override is a no-op.
 - **Centroids/rankings are write-once.** `train_cluster_router.py`
   always writes to `artifacts/v<X.Y>/` and never overwrites a previous
   version (auto-bumps from `latest` when `--version` is omitted). Pass

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -465,14 +465,17 @@ the rules-for-AI subset.
   e.g. `v0.2`) names the version the runtime serves by default; the
   `ROUTER_CLUSTER_VERSION` env var overrides it. Promotion is a
   one-line edit to `latest` plus a redeploy.
-- The Go runtime builds **one Scorer per committed bundle** at boot
-  (`cluster.NewMultiversion` in `cmd/router/main.go`); customer traffic
-  hits the default version; any caller can pin per-request to a sibling
-  version with `x-weave-cluster-version: v0.X` via
+- The Go runtime builds **only the served default version** by default
+  (`cmd/router/main.go`'s `buildClusterScorer`). Setting
+  `ROUTER_CLUSTER_BUILD_ALL_VERSIONS=true` switches to building **one
+  Scorer per committed bundle** so callers can pin per-request to a
+  sibling version with `x-weave-cluster-version: v0.X` via
   `middleware.WithClusterVersionOverride`. This is the
-  "compare-against-each-other" mechanism — a single staging deployment
-  carries every committed bundle and the eval harness flips between
-  them per-request.
+  "compare-against-each-other" mechanism — staging/eval deployments set
+  the flag so a single deploy carries every committed bundle and the
+  eval harness flips between them per-request. Prod leaves the flag
+  off: only the default bundle is loaded into memory and the header
+  override is a no-op.
 - **Centroids/rankings are write-once.** `train_cluster_router.py`
   always writes to `artifacts/v<X.Y>/` and never overwrites a previous
   version (auto-bumps from `latest` when `--version` is omitted). Pass

--- a/cmd/router/main.go
+++ b/cmd/router/main.go
@@ -486,9 +486,21 @@ func buildClusterScorer(availableProviders map[string]struct{}) (router.Router, 
 		return nil, fmt.Errorf("resolve cluster version %q: %w", requestedVersion, err)
 	}
 
-	versions, err := cluster.ListVersions()
-	if err != nil {
-		return nil, fmt.Errorf("list cluster versions: %w", err)
+	// Default to building only the served version. Staging/eval deployments
+	// opt in to building every committed bundle by setting
+	// ROUTER_CLUSTER_BUILD_ALL_VERSIONS=true; that powers the eval harness's
+	// per-request x-weave-cluster-version header A/B. Prod doesn't need the
+	// other bundles in memory and exposing them via header override is a
+	// foot-gun.
+	buildAll := strings.EqualFold(config.GetOr("ROUTER_CLUSTER_BUILD_ALL_VERSIONS", "false"), "true")
+	var versions []string
+	if buildAll {
+		versions, err = cluster.ListVersions()
+		if err != nil {
+			return nil, fmt.Errorf("list cluster versions: %w", err)
+		}
+	} else {
+		versions = []string{defaultVersion}
 	}
 
 	embedder, err := cluster.NewEmbedder()
@@ -554,6 +566,7 @@ func buildClusterScorer(availableProviders map[string]struct{}) (router.Router, 
 		"default_version", defaultVersion,
 		"built_versions", multi.Built(),
 		"requested_version", requestedVersion,
+		"build_all_versions", buildAll,
 	)
 
 	// Warmup: burn the lazy ONNX graph-optimization cost at boot.


### PR DESCRIPTION
## Summary
- `buildClusterScorer` was loading every committed `artifacts/v*` bundle into memory at boot and registering them with the multiversion router. That's load-bearing for the eval harness (per-request `x-weave-cluster-version` header A/B), but wasteful in prod and exposes every historical version through the override header.
- Default to building only the resolved default version. Staging/eval deployments opt in to the full set with `ROUTER_CLUSTER_BUILD_ALL_VERSIONS=true`.
- Docs (`CLAUDE.md`, `AGENTS.md`, `.env.example`) updated.

## Test plan
- [x] `go build -tags=no_onnx ./...`
- [ ] Boot locally with the flag unset → log line shows `build_all_versions=false`, `built_versions=[<default>]`
- [ ] Boot locally with `ROUTER_CLUSTER_BUILD_ALL_VERSIONS=true` → `built_versions` lists every committed bundle (current behavior)
- [ ] Staging: set the flag in the staging Cloud Run env so the eval harness keeps working
- [ ] Prod: leave flag unset; confirm header override is a no-op against current default

🤖 Generated with [Claude Code](https://claude.com/claude-code)