### PR TITLE
proxy: default cost baseline when requested model has no pricing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -78,6 +78,12 @@ ROUTER_CLUSTER_EMBED_TIMEOUT_MS=200
 # Feed the last user message to the embedder instead of concatenated context.
 ROUTER_EMBED_LAST_USER_MESSAGE=false
 
+# Cost-comparison baseline for inbound model names that have no pricing
+# entry (e.g. custom IDE model names like "weave-router"). Savings markers
+# and dashboard cost math fall back to this model's pricing. Set to empty
+# to disable substitution (savings show $0 for unknown requested models).
+ROUTER_DEFAULT_BASELINE_MODEL=claude-sonnet-4-5
+
 # Pin a session to its first-routed model so multi-turn conversations stay
 # coherent. Disable only if you want every turn re-routed independently.
 ROUTER_SESSION_PIN_ENABLED=true

--- a/cmd/router/baseline_test.go
+++ b/cmd/router/baseline_test.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestResolveDefaultBaselineModel(t *testing.T) {
+	t.Run("unset returns default", func(t *testing.T) {
+		orig, hadOrig := os.LookupEnv("ROUTER_DEFAULT_BASELINE_MODEL")
+		require := func() {
+			if hadOrig {
+				os.Setenv("ROUTER_DEFAULT_BASELINE_MODEL", orig)
+			} else {
+				os.Unsetenv("ROUTER_DEFAULT_BASELINE_MODEL")
+			}
+		}
+		os.Unsetenv("ROUTER_DEFAULT_BASELINE_MODEL")
+		t.Cleanup(require)
+		assert.Equal(t, "claude-sonnet-4-5", resolveDefaultBaselineModel())
+	})
+
+	t.Run("explicit empty disables substitution", func(t *testing.T) {
+		t.Setenv("ROUTER_DEFAULT_BASELINE_MODEL", "")
+		assert.Equal(t, "", resolveDefaultBaselineModel())
+	})
+
+	t.Run("explicit value wins", func(t *testing.T) {
+		t.Setenv("ROUTER_DEFAULT_BASELINE_MODEL", "claude-opus-4-7")
+		assert.Equal(t, "claude-opus-4-7", resolveDefaultBaselineModel())
+	})
+
+	t.Run("whitespace trimmed", func(t *testing.T) {
+		t.Setenv("ROUTER_DEFAULT_BASELINE_MODEL", "  claude-haiku-4-5  ")
+		assert.Equal(t, "claude-haiku-4-5", resolveDefaultBaselineModel())
+	})
+}

--- a/cmd/router/main.go
+++ b/cmd/router/main.go
@@ -363,7 +363,7 @@ func main() {
 		WithPlanner(plannerCfg).
 		WithSummarizer(summarizer).
 		WithAvailableModels(availableModels).
-		WithDefaultBaselineModel(strings.TrimSpace(config.GetOr("ROUTER_DEFAULT_BASELINE_MODEL", "claude-sonnet-4-5")))
+		WithDefaultBaselineModel(resolveDefaultBaselineModel())
 	logger.Info("Planner configured", "enabled", plannerEnabled, "threshold_usd", plannerCfg.ThresholdUSD, "expected_remaining_turns", plannerCfg.ExpectedRemainingTurns, "tier_upgrade_enabled", plannerCfg.TierUpgradeEnabled, "available_models_count", len(availableModels))
 
 	// Fail loud if a deployed model is missing from the tier table;
@@ -798,6 +798,19 @@ const (
 	defaultHardPinProvider = providers.ProviderAnthropic
 	defaultHardPinModel    = "claude-haiku-4-5"
 )
+
+// resolveDefaultBaselineModel returns the cost-comparison baseline used when
+// the inbound RequestedModel has no pricing entry. Unset → default
+// claude-sonnet-4-5; set to empty → no substitution. config.GetOr collapses
+// the empty-set and unset cases, so we use os.LookupEnv directly to preserve
+// the "" → disable contract documented in .env.example.
+func resolveDefaultBaselineModel() string {
+	v, ok := os.LookupEnv("ROUTER_DEFAULT_BASELINE_MODEL")
+	if !ok {
+		return "claude-sonnet-4-5"
+	}
+	return strings.TrimSpace(v)
+}
 
 // resolveHardPinModel returns the (provider, model) to use for compaction and
 // Explore hard-pins. Operator override wins; otherwise the cheapest model in

--- a/cmd/router/main.go
+++ b/cmd/router/main.go
@@ -362,7 +362,8 @@ func main() {
 		WithPlannerEnabled(plannerEnabled).
 		WithPlanner(plannerCfg).
 		WithSummarizer(summarizer).
-		WithAvailableModels(availableModels)
+		WithAvailableModels(availableModels).
+		WithDefaultBaselineModel(strings.TrimSpace(config.GetOr("ROUTER_DEFAULT_BASELINE_MODEL", "claude-sonnet-4-5")))
 	logger.Info("Planner configured", "enabled", plannerEnabled, "threshold_usd", plannerCfg.ThresholdUSD, "expected_remaining_turns", plannerCfg.ExpectedRemainingTurns, "tier_upgrade_enabled", plannerCfg.TierUpgradeEnabled, "available_models_count", len(availableModels))
 
 	// Fail loud if a deployed model is missing from the tier table;

--- a/internal/proxy/baseline_internal_test.go
+++ b/internal/proxy/baseline_internal_test.go
@@ -1,0 +1,35 @@
+package proxy
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBaselineFor(t *testing.T) {
+	t.Run("known model returns itself", func(t *testing.T) {
+		s := &Service{defaultBaselineModel: "claude-sonnet-4-5"}
+		assert.Equal(t, "claude-opus-4-7", s.baselineFor("claude-opus-4-7"))
+	})
+
+	t.Run("unknown model returns baseline", func(t *testing.T) {
+		s := &Service{defaultBaselineModel: "claude-sonnet-4-5"}
+		assert.Equal(t, "claude-sonnet-4-5", s.baselineFor("weave-router"))
+	})
+
+	t.Run("empty model returns baseline", func(t *testing.T) {
+		s := &Service{defaultBaselineModel: "claude-sonnet-4-5"}
+		assert.Equal(t, "claude-sonnet-4-5", s.baselineFor(""))
+	})
+
+	t.Run("unknown model with no baseline returns empty", func(t *testing.T) {
+		s := &Service{}
+		assert.Equal(t, "", s.baselineFor("weave-router"))
+	})
+}
+
+func TestWithDefaultBaselineModel(t *testing.T) {
+	s := &Service{}
+	s.WithDefaultBaselineModel("claude-sonnet-4-5")
+	assert.Equal(t, "claude-sonnet-4-5", s.defaultBaselineModel)
+}

--- a/internal/proxy/gemini.go
+++ b/internal/proxy/gemini.go
@@ -89,7 +89,7 @@ func (s *Service) ProxyGeminiGenerateContent(ctx context.Context, body []byte, w
 	w.Header().Set("x-router-provider", decision.Provider)
 	w.Header().Set("x-router-model", decision.Model)
 
-	reqPricing := otel.Lookup(feats.Model)
+	reqPricing := otel.Lookup(s.baselineFor(feats.Model))
 	actPricing := otel.Lookup(decision.Model)
 	geminiDecisionBuilder := otel.NewAttrBuilder(40).
 		String("request_id", requestID).
@@ -188,6 +188,6 @@ func (s *Service) ProxyGeminiGenerateContent(ctx context.Context, body []byte, w
 	// has cache-hit evidence. Off the request path; drops on saturation.
 	s.recordTurnUsage(routeRes, in, out, cacheCreation, cacheRead)
 
-	log.Info("ProxyGeminiGenerateContent complete", "requested_model", feats.Model, "decision_model", decision.Model, "decision_provider", decision.Provider, "decision_reason", decision.Reason, "estimated_input_tokens", feats.Tokens, "has_tools", feats.HasTools, "embed_input", embedInput, "sticky_hit", stickyHit, "pin_tier", pinTier, "turn_type", string(tt), "route_ms", routeMs, "proxy_ms", proxyMs, "proxy_err", proxyErr, "upstream_status", upstreamStatus(proxyErr))
+	log.Info("ProxyGeminiGenerateContent complete", "requested_model", feats.Model, "baseline_model", s.baselineFor(feats.Model), "decision_model", decision.Model, "decision_provider", decision.Provider, "decision_reason", decision.Reason, "estimated_input_tokens", feats.Tokens, "has_tools", feats.HasTools, "embed_input", embedInput, "sticky_hit", stickyHit, "pin_tier", pinTier, "turn_type", string(tt), "route_ms", routeMs, "proxy_ms", proxyMs, "proxy_err", proxyErr, "upstream_status", upstreamStatus(proxyErr))
 	return proxyErr
 }

--- a/internal/proxy/marker_internal_test.go
+++ b/internal/proxy/marker_internal_test.go
@@ -146,14 +146,29 @@ func TestClosingMarkerFor_EmitsSavingsWhenRoutedIsCheaper(t *testing.T) {
 	fn := closingMarkerFor(
 		router.Decision{Model: "deepseek/deepseek-v4-pro", Provider: "openrouter"},
 		"claude-opus-4-7",
+		"claude-opus-4-7",
 	)
 	got := fn(translate.Usage{InputTokens: 15000, OutputTokens: 1000, CacheReadTokens: 5000})
 	assert.Equal(t, "✦ saved $0.2271 vs claude-opus-4-7 (15k in / 1k out)", got)
 }
 
+func TestClosingMarkerFor_LabelsConfiguredBaselineWhenSubstituted(t *testing.T) {
+	// requested_model has no pricing entry, baseline kicked in. Marker must
+	// flag the comparison as the configured baseline so users see it's an
+	// attribution, not a literal "vs the model you asked for".
+	fn := closingMarkerFor(
+		router.Decision{Model: "deepseek/deepseek-v4-pro", Provider: "openrouter"},
+		"weave-router",
+		"claude-opus-4-7",
+	)
+	got := fn(translate.Usage{InputTokens: 15000, OutputTokens: 1000, CacheReadTokens: 5000})
+	assert.Equal(t, "✦ saved $0.2271 vs claude-opus-4-7 (configured baseline) (15k in / 1k out)", got)
+}
+
 func TestClosingMarkerFor_FormatsTokenCounts(t *testing.T) {
 	fn := closingMarkerFor(
 		router.Decision{Model: "deepseek/deepseek-v4-pro", Provider: "openrouter"},
+		"claude-opus-4-7",
 		"claude-opus-4-7",
 	)
 	cases := []struct {
@@ -189,6 +204,7 @@ func TestClosingMarkerFor_NoEmissionWhenRoutedEqualsRequested(t *testing.T) {
 	fn := closingMarkerFor(
 		router.Decision{Model: "claude-opus-4-7", Provider: "anthropic"},
 		"claude-opus-4-7",
+		"claude-opus-4-7",
 	)
 	got := fn(translate.Usage{InputTokens: 10000, OutputTokens: 500})
 	assert.Empty(t, got)
@@ -199,6 +215,7 @@ func TestClosingMarkerFor_NoEmissionWhenSavingsAreNonPositive(t *testing.T) {
 	fn := closingMarkerFor(
 		router.Decision{Model: "claude-opus-4-7", Provider: "anthropic"},
 		"deepseek/deepseek-v4-pro",
+		"deepseek/deepseek-v4-pro",
 	)
 	got := fn(translate.Usage{InputTokens: 15000, OutputTokens: 1000, CacheReadTokens: 5000})
 	assert.Empty(t, got)
@@ -207,6 +224,7 @@ func TestClosingMarkerFor_NoEmissionWhenSavingsAreNonPositive(t *testing.T) {
 func TestClosingMarkerFor_NoEmissionWhenPricingMissing(t *testing.T) {
 	fn := closingMarkerFor(
 		router.Decision{Model: "imaginary-model-v0", Provider: "openrouter"},
+		"claude-opus-4-7",
 		"claude-opus-4-7",
 	)
 	got := fn(translate.Usage{InputTokens: 10000, OutputTokens: 1000})
@@ -217,6 +235,7 @@ func TestClosingMarkerFor_NoEmissionWhenSavingsBelowEpsilon(t *testing.T) {
 	// Savings below $0.0001 → skip so the marker doesn't flicker.
 	fn := closingMarkerFor(
 		router.Decision{Model: "deepseek/deepseek-v4-pro", Provider: "openrouter"},
+		"claude-opus-4-7",
 		"claude-opus-4-7",
 	)
 	got := fn(translate.Usage{InputTokens: 1, OutputTokens: 1})

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -133,28 +133,37 @@ func routingMarkerFor(res turnLoopResult) string {
 	return strings.Join(parts, " · ") + "\n\n"
 }
 
-// closingMarkerFor returns a callback that formats a "saved $X vs <requested>"
-// line from observed usage. Returns "" when routed == requested, pricing is
+// closingMarkerFor returns a callback that formats a "saved $X vs <baseline>"
+// line from observed usage. Returns "" when routed == baseline, pricing is
 // missing, or savings are non-positive / below the flicker floor.
-func closingMarkerFor(decision router.Decision, requestedModel string) func(translate.Usage) string {
+//
+// When requestedModel and baselineModel differ, the inbound model name had
+// no pricing entry and the baseline was substituted in; the marker labels
+// the comparison "(configured baseline)" so users see the savings are an
+// attribution rather than against a literal model they requested.
+func closingMarkerFor(decision router.Decision, requestedModel, baselineModel string) func(translate.Usage) string {
 	return func(u translate.Usage) string {
-		if decision.Model == "" || requestedModel == "" {
+		if decision.Model == "" || baselineModel == "" {
 			return ""
 		}
-		if decision.Model == requestedModel {
+		if decision.Model == baselineModel {
 			return ""
 		}
 		routed, ok1 := pricing.For(decision.Model)
-		requested, ok2 := pricing.For(requestedModel)
+		baseline, ok2 := pricing.For(baselineModel)
 		if !ok1 || !ok2 {
 			return ""
 		}
-		savings := closingMarkerSavingsUSD(u, routed, requested)
+		savings := closingMarkerSavingsUSD(u, routed, baseline)
 		if savings < 0.0001 {
 			return ""
 		}
+		label := baselineModel
+		if requestedModel != baselineModel {
+			label = baselineModel + " (configured baseline)"
+		}
 		return fmt.Sprintf("✦ saved $%.4f vs %s (%s in / %s out)",
-			savings, requestedModel,
+			savings, label,
 			formatTokenCount(u.InputTokens), formatTokenCount(u.OutputTokens))
 	}
 }
@@ -827,7 +836,7 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 		}
 		translator := translate.NewAnthropicSSETranslator(sink, decision.Model, usage).
 			WithRoutingMarker(routingMarkerFor(routeRes)).
-			WithClosingMarker(closingMarkerFor(decision, s.baselineFor(feats.Model)))
+			WithClosingMarker(closingMarkerFor(decision, feats.Model, s.baselineFor(feats.Model)))
 		proxyErr = p.Proxy(ctx, decision, prep, translator, r)
 		proxyErr = finalizeAfterProxy(proxyErr, translator.Finalize)
 	case providers.ProviderGoogle:
@@ -845,7 +854,7 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 		// SSE chain: Gemini → OpenAI → Anthropic.
 		anthropicTr := translate.NewAnthropicSSETranslator(sink, decision.Model, usage).
 			WithRoutingMarker(routingMarkerFor(routeRes)).
-			WithClosingMarker(closingMarkerFor(decision, s.baselineFor(feats.Model)))
+			WithClosingMarker(closingMarkerFor(decision, feats.Model, s.baselineFor(feats.Model)))
 		geminiTr := translate.NewGeminiToOpenAISSETranslator(anthropicTr, decision.Model, nil)
 		proxyErr = p.Proxy(ctx, decision, prep, geminiTr, r)
 		proxyErr = finalizeAfterProxy(proxyErr, geminiTr.Finalize)

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -86,6 +86,12 @@ type Service struct {
 	// are registered. Read by the planner to decide whether a pin's model
 	// is still routable; if not, switch regardless of EV.
 	availableModels map[string]struct{}
+	// defaultBaselineModel is the cost-comparison baseline used when the
+	// inbound RequestedModel has no pricing entry (typical of generic
+	// "weave-router"-style custom names IDE clients send). Empty means no
+	// substitution — savings markers and pricing fields stay empty for
+	// unknown models, preserving prior behavior.
+	defaultBaselineModel string
 }
 
 // pinSessionTTL is the sliding TTL on pinned_until. Mirrors Anthropic's
@@ -361,6 +367,27 @@ func (s *Service) WithAvailableModels(models map[string]struct{}) *Service {
 	}
 	s.availableModels = copied
 	return s
+}
+
+// WithDefaultBaselineModel installs the cost-comparison fallback used
+// when the inbound RequestedModel has no pricing entry. Empty disables
+// substitution. See [Service.defaultBaselineModel] for rationale.
+func (s *Service) WithDefaultBaselineModel(model string) *Service {
+	s.defaultBaselineModel = model
+	return s
+}
+
+// baselineFor returns requested if it has a pricing entry; otherwise the
+// configured defaultBaselineModel (which may itself be ""). Used by every
+// cost/savings lookup so unknown client model names (e.g. "weave-router")
+// still attribute savings to a real baseline.
+func (s *Service) baselineFor(requested string) string {
+	if requested != "" {
+		if _, ok := pricing.For(requested); ok {
+			return requested
+		}
+	}
+	return s.defaultBaselineModel
 }
 
 // WithByokOnly enables BYOK-only credential resolution: providers without
@@ -700,7 +727,7 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 					Build(),
 			})
 			otel.Flush(ctx)
-			log.Info("ProxyMessages cache hit", "requested_model", feats.Model, "decision_model", decision.Model, "decision_provider", decision.Provider, "external_id", externalID, "total_ms", time.Since(requestStart).Milliseconds())
+			log.Info("ProxyMessages cache hit", "requested_model", feats.Model, "baseline_model", s.baselineFor(feats.Model), "decision_model", decision.Model, "decision_provider", decision.Provider, "external_id", externalID, "total_ms", time.Since(requestStart).Milliseconds())
 			return nil
 		}
 	}
@@ -714,7 +741,7 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 		return provErr
 	}
 
-	reqPricing := otel.Lookup(feats.Model)
+	reqPricing := otel.Lookup(s.baselineFor(feats.Model))
 	actPricing := otel.Lookup(decision.Model)
 	decisionBuilder := otel.NewAttrBuilder(40).
 		String("request_id", requestID).
@@ -800,7 +827,7 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 		}
 		translator := translate.NewAnthropicSSETranslator(sink, decision.Model, usage).
 			WithRoutingMarker(routingMarkerFor(routeRes)).
-			WithClosingMarker(closingMarkerFor(decision, feats.Model))
+			WithClosingMarker(closingMarkerFor(decision, s.baselineFor(feats.Model)))
 		proxyErr = p.Proxy(ctx, decision, prep, translator, r)
 		proxyErr = finalizeAfterProxy(proxyErr, translator.Finalize)
 	case providers.ProviderGoogle:
@@ -818,7 +845,7 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 		// SSE chain: Gemini → OpenAI → Anthropic.
 		anthropicTr := translate.NewAnthropicSSETranslator(sink, decision.Model, usage).
 			WithRoutingMarker(routingMarkerFor(routeRes)).
-			WithClosingMarker(closingMarkerFor(decision, feats.Model))
+			WithClosingMarker(closingMarkerFor(decision, s.baselineFor(feats.Model)))
 		geminiTr := translate.NewGeminiToOpenAISSETranslator(anthropicTr, decision.Model, nil)
 		proxyErr = p.Proxy(ctx, decision, prep, geminiTr, r)
 		proxyErr = finalizeAfterProxy(proxyErr, geminiTr.Finalize)
@@ -919,7 +946,7 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 		})
 	}
 
-	log.Info("ProxyMessages complete", "requested_model", feats.Model, "decision_model", decision.Model, "decision_provider", decision.Provider, "decision_reason", decision.Reason, "estimated_input_tokens", feats.Tokens, "has_tools", feats.HasTools, "message_count", feats.MessageCount, "last_kind", feats.LastKind, "last_preview", feats.LastPreview, "embed_input", embedInput, "cross_format", crossFormat, "sticky_hit", stickyHit, "route_ms", routeMs, "proxy_ms", proxyMs, "proxy_err", proxyErr, "upstream_status", upstreamStatus(proxyErr))
+	log.Info("ProxyMessages complete", "requested_model", feats.Model, "baseline_model", s.baselineFor(feats.Model), "decision_model", decision.Model, "decision_provider", decision.Provider, "decision_reason", decision.Reason, "estimated_input_tokens", feats.Tokens, "has_tools", feats.HasTools, "message_count", feats.MessageCount, "last_kind", feats.LastKind, "last_preview", feats.LastPreview, "embed_input", embedInput, "cross_format", crossFormat, "sticky_hit", stickyHit, "route_ms", routeMs, "proxy_ms", proxyMs, "proxy_err", proxyErr, "upstream_status", upstreamStatus(proxyErr))
 	return proxyErr
 }
 
@@ -1352,7 +1379,7 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 					Build(),
 			})
 			otel.Flush(ctx)
-			log.Info("ProxyOpenAIChatCompletion cache hit", "requested_model", feats.Model, "decision_model", decision.Model, "decision_provider", decision.Provider, "external_id", externalID, "total_ms", time.Since(requestStart).Milliseconds())
+			log.Info("ProxyOpenAIChatCompletion cache hit", "requested_model", feats.Model, "baseline_model", s.baselineFor(feats.Model), "decision_model", decision.Model, "decision_provider", decision.Provider, "external_id", externalID, "total_ms", time.Since(requestStart).Milliseconds())
 			return nil
 		}
 	}
@@ -1366,7 +1393,7 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 	w.Header().Set("x-router-provider", decision.Provider)
 	w.Header().Set("x-router-model", decision.Model)
 
-	reqPricing := otel.Lookup(feats.Model)
+	reqPricing := otel.Lookup(s.baselineFor(feats.Model))
 	actPricing := otel.Lookup(decision.Model)
 	openaiDecisionBuilder := otel.NewAttrBuilder(40).
 		String("request_id", requestID).
@@ -1562,6 +1589,6 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 		})
 	}
 
-	log.Info("ProxyOpenAIChatCompletion complete", "requested_model", feats.Model, "decision_model", decision.Model, "decision_provider", decision.Provider, "decision_reason", decision.Reason, "estimated_input_tokens", feats.Tokens, "has_tools", feats.HasTools, "embed_input", embedInput, "cross_format", crossFormat, "sticky_hit", stickyHit, "pin_tier", pinTier, "turn_type", string(tt), "route_ms", routeMs, "proxy_ms", proxyMs, "proxy_err", proxyErr, "upstream_status", upstreamStatus(proxyErr))
+	log.Info("ProxyOpenAIChatCompletion complete", "requested_model", feats.Model, "baseline_model", s.baselineFor(feats.Model), "decision_model", decision.Model, "decision_provider", decision.Provider, "decision_reason", decision.Reason, "estimated_input_tokens", feats.Tokens, "has_tools", feats.HasTools, "embed_input", embedInput, "cross_format", crossFormat, "sticky_hit", stickyHit, "pin_tier", pinTier, "turn_type", string(tt), "route_ms", routeMs, "proxy_ms", proxyMs, "proxy_err", proxyErr, "upstream_status", upstreamStatus(proxyErr))
 	return proxyErr
 }


### PR DESCRIPTION
## Summary
- Inbound requests with a custom `model` name (e.g. Cursor → "Override OpenAI Base URL" + a custom model named `weave-router`) miss the pricing table, so the savings closing-marker silently disappears and dashboard cost math goes to $0.
- Add `ROUTER_DEFAULT_BASELINE_MODEL` (default `claude-sonnet-4-5`). When `pricing.For(requested_model)` misses, fall back to the baseline for cost comparisons only.
- `requested_model` is still recorded as-sent (routing decisions, telemetry, logs); a new `baseline_model` log field shows what was substituted.

## Test plan
- [x] `proxy.TestBaselineFor` covers known / unknown / empty / no-baseline cases
- [x] `go build -tags=no_onnx ./...` clean
- [x] `go test -tags=no_onnx ./internal/proxy/...` passes
- [ ] Local Cursor → ngrok → router flow with custom model `weave-router`: confirm `ProxyOpenAIChatCompletion complete` log shows `baseline_model=claude-sonnet-4-5` and the closing marker shows `saved $X vs claude-sonnet-4-5`
- [ ] Existing flows with a real model (e.g. `claude-opus-4-7` from Claude Code) unaffected: `baseline_model` equals `requested_model`

## Caveat
The "saved $X" number when baseline substitution kicks in is an attribution, not an observation — the client never actually requested the baseline model. Worth labeling in dashboard UI down the line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)