### PR TITLE
auth+router: per-installation routing alpha (quality vs cost knob)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -509,10 +509,15 @@ the rules-for-AI subset.
 
 **What to NOT do:**
 
-- **Don't add per-request cost lookup or a runtime α knob.** α is
-  baked at training time; changing it requires retraining. Per-request
-  override (`x-weave-routing-alpha`) is P1, not P0 — wait for a
-  customer to ask before shipping it.
+- **Don't add per-request cost lookup.** Pricing is baked into rankings
+  at training time and not consulted on the hot path.
+- **α is per-installation, not per-request.** Each installation row
+  carries a `routing_alpha` smallint (0..10, where 5 = α=0.5). The
+  cluster Multiversion router maps that value to a pre-baked
+  `v<stem>-a<NN>` artifact bundle, so α tuning is a bundle-selection
+  problem, not a runtime blend. Per-request override
+  (`x-weave-routing-alpha`) remains P1; ship it only when a customer
+  asks. Retraining the α sweep is one command (`scripts/train_alpha_sweep.sh`).
 - **Don't loosen the `MaxPromptChars = 1024` cap** without re-running
   the latency test. BERT inference is O(n²) attention; the cap is
   load-bearing.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -509,10 +509,15 @@ the rules-for-AI subset.
 
 **What to NOT do:**
 
-- **Don't add per-request cost lookup or a runtime α knob.** α is
-  baked at training time; changing it requires retraining. Per-request
-  override (`x-weave-routing-alpha`) is P1, not P0 — wait for a
-  customer to ask before shipping it.
+- **Don't add per-request cost lookup.** Pricing is baked into rankings
+  at training time and not consulted on the hot path.
+- **α is per-installation, not per-request.** Each installation row
+  carries a `routing_alpha` smallint (0..10, where 5 = α=0.5). The
+  cluster Multiversion router maps that value to a pre-baked
+  `v<stem>-a<NN>` artifact bundle, so α tuning is a bundle-selection
+  problem, not a runtime blend. Per-request override
+  (`x-weave-routing-alpha`) remains P1; ship it only when a customer
+  asks. Retraining the α sweep is one command (`scripts/train_alpha_sweep.sh`).
 - **Don't loosen the `MaxPromptChars = 1024` cap** without re-running
   the latency test. BERT inference is O(n²) attention; the cap is
   load-bearing.

--- a/db/migrations/0004_installation_routing_alpha.down.sql
+++ b/db/migrations/0004_installation_routing_alpha.down.sql
@@ -1,0 +1,6 @@
+BEGIN;
+
+ALTER TABLE router.model_router_installations
+  DROP COLUMN routing_alpha;
+
+COMMIT;

--- a/db/migrations/0004_installation_routing_alpha.up.sql
+++ b/db/migrations/0004_installation_routing_alpha.up.sql
@@ -1,0 +1,12 @@
+BEGIN;
+
+-- Per-installation quality-vs-cost knob. Stored as SMALLINT 0..10 (representing
+-- alpha values 0.0..1.0 in 0.1 steps) so the runtime can do exact-equality
+-- bundle lookups without float-precision concerns. 5 = 0.5, matching the
+-- shipped global default close enough that pre-existing installations don't
+-- silently shift toward either pole when the column is backfilled.
+ALTER TABLE router.model_router_installations
+  ADD COLUMN routing_alpha SMALLINT NOT NULL DEFAULT 5
+  CHECK (routing_alpha BETWEEN 0 AND 10);
+
+COMMIT;

--- a/db/queries/model_router_installations.sql
+++ b/db/queries/model_router_installations.sql
@@ -44,3 +44,14 @@ SET excluded_models = @excluded_models::text[],
 WHERE id = @id::uuid
   AND external_id = @external_id::varchar
   AND deleted_at IS NULL;
+
+-- Replaces the per-installation routing alpha (0..10, representing 0.0..1.0 in
+-- 0.1 steps). Scoped to an external_id to prevent cross-tenant updates. Bumps
+-- updated_at so dashboards see the change.
+-- name: UpdateModelRouterInstallationRoutingAlpha :exec
+UPDATE router.model_router_installations
+SET routing_alpha = @routing_alpha::smallint,
+    updated_at = NOW()
+WHERE id = @id::uuid
+  AND external_id = @external_id::varchar
+  AND deleted_at IS NULL;

--- a/frontend/src/app/(app)/settings/page.tsx
+++ b/frontend/src/app/(app)/settings/page.tsx
@@ -16,7 +16,7 @@ import {
   type ExternalKey,
   type RouterConfig,
 } from "@/lib/api";
-import { ChevronDown, Copy, Filter, KeyRound, Plug, RotateCw, Settings as SettingsIcon, Trash2 } from "lucide-react";
+import { ChevronDown, Copy, Filter, KeyRound, Plug, RotateCw, Scale, Settings as SettingsIcon, Trash2 } from "lucide-react";
 import { useEffect, useState } from "react";
 
 export default function SettingsPage() {
@@ -69,6 +69,24 @@ export default function SettingsPage() {
             Bring your own keys for Anthropic, OpenAI, Google, OpenRouter.
           </Text>
           <ProviderKeysPanel />
+        </Page.Section>
+
+        <Page.Section
+          className="py-3"
+          header={
+            <Page.SectionHeader>
+              <Scale className="size-4" />
+              <Text variant="h4" as="h3">
+                Quality vs cost
+              </Text>
+            </Page.SectionHeader>
+          }
+        >
+          <Text className="text-xs text-muted-foreground">
+            Bias routing toward cheaper models or higher-scoring models in
+            0.1 steps. Changes take effect on the next request.
+          </Text>
+          <RoutingAlphaPanel />
         </Page.Section>
 
         <Page.Section
@@ -818,6 +836,108 @@ function ModelSelectionPanel() {
             {saving ? "Saving…" : "Save"}
           </Button>
         </Card.Footer>
+      </Card>
+    </>
+  );
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Routing alpha panel
+// ──────────────────────────────────────────────────────────────────────────
+
+function formatAlpha(value: number, max: number): string {
+  // Range is 0..max (default 10) representing α=0.0..1.0. Render the float
+  // form so users see the canonical alpha; we never persist or display the
+  // raw integer to keep the UI consistent with the paper notation.
+  return (value / max).toFixed(1);
+}
+
+function RoutingAlphaPanel() {
+  const [bounds, setBounds] = useState<{ min: number; max: number } | null>(null);
+  const [value, setValue] = useState<number | null>(null);
+  const [savedValue, setSavedValue] = useState<number | null>(null);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    api.routingAlpha
+      .get()
+      .then(res => {
+        setBounds({ min: res.min, max: res.max });
+        setValue(res.alpha);
+        setSavedValue(res.alpha);
+      })
+      .catch((err: unknown) =>
+        setError(err instanceof Error ? err.message : "Failed to load routing alpha"),
+      );
+  }, []);
+
+  async function commit(next: number) {
+    if (savedValue === next) return;
+    setSaving(true);
+    setError(null);
+    try {
+      const res = await api.routingAlpha.update(next);
+      setValue(res.alpha);
+      setSavedValue(res.alpha);
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err.message : "Failed to save routing alpha");
+      // Roll back the optimistic slider position on failure so the UI
+      // doesn't lie about persisted state.
+      setValue(savedValue);
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  if (bounds == null || value == null) {
+    return (
+      <Card className="p-0">
+        <Card.Content>
+          <div className="px-5 py-8 text-center text-2xs text-muted-foreground">
+            {error != null ? "Failed to load" : "Loading…"}
+          </div>
+        </Card.Content>
+      </Card>
+    );
+  }
+
+  return (
+    <>
+      {error && <ErrorBanner>{error}</ErrorBanner>}
+      <Card>
+        <Card.Content>
+          <div className="flex flex-col gap-3">
+            <div className="flex items-baseline justify-between">
+              <Text className="text-2xs uppercase tracking-wide text-muted-foreground">
+                Alpha
+              </Text>
+              <span className="font-mono text-sm text-foreground">
+                α = {formatAlpha(value, bounds.max)}
+                {saving && <span className="ml-2 text-2xs text-muted-foreground">saving…</span>}
+              </span>
+            </div>
+            <input
+              type="range"
+              min={bounds.min}
+              max={bounds.max}
+              step={1}
+              value={value}
+              onChange={e => setValue(Number(e.target.value))}
+              onMouseUp={e => commit(Number((e.target as HTMLInputElement).value))}
+              onTouchEnd={e => commit(Number((e.target as HTMLInputElement).value))}
+              onKeyUp={e => commit(Number((e.target as HTMLInputElement).value))}
+              disabled={saving}
+              className="w-full accent-brand"
+              aria-label="Routing alpha"
+            />
+            <div className="flex justify-between text-2xs text-muted-foreground">
+              <span>Lowest cost</span>
+              <span>Default (0.5)</span>
+              <span>Highest quality</span>
+            </div>
+          </div>
+        </Card.Content>
       </Card>
     </>
   );

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -124,6 +124,12 @@ export interface ExcludedModelsResponse {
   env_override_active: boolean;
 }
 
+export interface RoutingAlphaResponse {
+  alpha: number;
+  min: number;
+  max: number;
+}
+
 // --- API calls ---
 
 export const api = {
@@ -187,6 +193,14 @@ export const api = {
       request<ExcludedModelsResponse>("/excluded-models", {
         method: "PUT",
         body: JSON.stringify({ excluded }),
+      }),
+  },
+  routingAlpha: {
+    get: () => request<RoutingAlphaResponse>("/routing-alpha"),
+    update: (alpha: number) =>
+      request<RoutingAlphaResponse>("/routing-alpha", {
+        method: "PUT",
+        body: JSON.stringify({ alpha }),
       }),
   },
 };

--- a/internal/api/admin/routing_alpha.go
+++ b/internal/api/admin/routing_alpha.go
@@ -1,0 +1,75 @@
+package admin
+
+import (
+	"errors"
+	"net/http"
+
+	"workweave/router/internal/auth"
+	"workweave/router/internal/observability"
+
+	"github.com/gin-gonic/gin"
+)
+
+type routingAlphaResponse struct {
+	Alpha int `json:"alpha"`
+	Min   int `json:"min"`
+	Max   int `json:"max"`
+}
+
+type updateRoutingAlphaRequest struct {
+	Alpha int `json:"alpha"`
+}
+
+// GetRoutingAlphaHandler returns the caller installation's current routing
+// alpha plus the valid range so the UI can render a slider without hardcoding
+// the bounds.
+func GetRoutingAlphaHandler(authSvc *auth.Service) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		installation, ok := resolveInstallation(c, authSvc)
+		if !ok {
+			return
+		}
+		c.JSON(http.StatusOK, routingAlphaResponse{
+			Alpha: installation.RoutingAlpha,
+			Min:   auth.MinRoutingAlpha,
+			Max:   auth.MaxRoutingAlpha,
+		})
+	}
+}
+
+// UpdateRoutingAlphaHandler replaces the installation's routing alpha. Out of
+// range values return 400; the new value is visible to the request path
+// within the APIKey cache TTL (same write-through-by-TTL pattern as excluded
+// models).
+func UpdateRoutingAlphaHandler(authSvc *auth.Service) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		log := observability.FromGin(c)
+		installation, ok := resolveInstallation(c, authSvc)
+		if !ok {
+			return
+		}
+
+		var req updateRoutingAlphaRequest
+		if err := c.ShouldBindJSON(&req); err != nil {
+			c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": "invalid request body"})
+			return
+		}
+
+		if err := authSvc.SetInstallationRoutingAlpha(c.Request.Context(), installation.ExternalID, installation.ID, req.Alpha); err != nil {
+			if errors.Is(err, auth.ErrAlphaOutOfRange) {
+				c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+				return
+			}
+			log.Error("Failed to update routing alpha", "err", err, "installation_id", installation.ID, "alpha", req.Alpha)
+			c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"error": "failed to update routing alpha"})
+			return
+		}
+
+		log.Info("Routing alpha updated", "installation_id", installation.ID, "alpha", req.Alpha)
+		c.JSON(http.StatusOK, routingAlphaResponse{
+			Alpha: req.Alpha,
+			Min:   auth.MinRoutingAlpha,
+			Max:   auth.MaxRoutingAlpha,
+		})
+	}
+}

--- a/internal/auth/installation.go
+++ b/internal/auth/installation.go
@@ -18,6 +18,11 @@ type Installation struct {
 	// ExcludedModels is the per-installation model exclusion list applied
 	// at request time by the cluster scorer. Empty slice means no exclusion.
 	ExcludedModels []string
+	// RoutingAlpha is the quality-vs-cost knob in 0.1 steps, stored as the
+	// integer 0..10 (so 5 = α=0.5). 0 biases purely toward cost, 10 purely
+	// toward quality. The cluster Multiversion router maps this to a
+	// pre-baked artifact bundle at request time.
+	RoutingAlpha int
 }
 
 type CreateInstallationParams struct {
@@ -37,4 +42,9 @@ type InstallationRepository interface {
 	// scoped to externalID to prevent cross-tenant updates. An empty (or
 	// nil) slice clears the list.
 	UpdateExcludedModels(ctx context.Context, externalID, id string, models []string) error
+	// UpdateRoutingAlpha replaces the per-installation routing alpha (0..10),
+	// scoped to externalID to prevent cross-tenant updates. Caller validates
+	// the range; the repo persists whatever it receives so SQLSTATE 23514
+	// would surface a malformed write loudly rather than silently clipping.
+	UpdateRoutingAlpha(ctx context.Context, externalID, id string, alpha int) error
 }

--- a/internal/auth/service.go
+++ b/internal/auth/service.go
@@ -17,6 +17,18 @@ import (
 // requested model ID is not in the allowed set the caller passed in.
 var ErrUnknownModel = errors.New("auth: unknown model id")
 
+// MinRoutingAlpha and MaxRoutingAlpha bound the per-installation alpha knob.
+// Stored as an integer 0..10 representing α=0.0..1.0 in 0.1 steps so the
+// cluster Multiversion router can do exact-equality bundle lookups.
+const (
+	MinRoutingAlpha = 0
+	MaxRoutingAlpha = 10
+)
+
+// ErrAlphaOutOfRange is returned by SetInstallationRoutingAlpha when alpha is
+// outside [MinRoutingAlpha, MaxRoutingAlpha].
+var ErrAlphaOutOfRange = errors.New("auth: routing alpha out of range")
+
 type Clock func() time.Time
 
 // Service authenticates incoming bearer tokens. Identity only; routing/dispatch lives in proxy.Service.
@@ -194,6 +206,22 @@ func (s *Service) SetInstallationExcludedModels(ctx context.Context, externalID,
 		return nil, err
 	}
 	return out, nil
+}
+
+// SetInstallationRoutingAlpha replaces the per-installation routing alpha
+// (0..10), scoped to externalID. Returns ErrAlphaOutOfRange when the input
+// falls outside the bounds — the DB CHECK constraint would catch this too,
+// but a clean error at the service boundary keeps the HTTP layer's 400 path
+// uncoupled from SQLSTATE inspection.
+//
+// New alpha is visible to the request path within the APIKey cache TTL
+// (default 5 min); explicit invalidation is intentionally not wired so the
+// in-process cache stays write-through-by-TTL like excluded models.
+func (s *Service) SetInstallationRoutingAlpha(ctx context.Context, externalID, installationID string, alpha int) error {
+	if alpha < MinRoutingAlpha || alpha > MaxRoutingAlpha {
+		return fmt.Errorf("%w: %d (want %d..%d)", ErrAlphaOutOfRange, alpha, MinRoutingAlpha, MaxRoutingAlpha)
+	}
+	return s.installations.UpdateRoutingAlpha(ctx, externalID, installationID, alpha)
 }
 
 // VerifyAPIKey authenticates a raw bearer token.

--- a/internal/auth/service_test.go
+++ b/internal/auth/service_test.go
@@ -96,6 +96,8 @@ func (f *fakeExternalAPIKeyRepo) MarkUsed(ctx context.Context, id string) error 
 type fakeInstallationRepository struct {
 	excludedModelsByID         map[string][]string
 	excludedModelsExternalByID map[string]string
+	routingAlphaByID           map[string]int
+	routingAlphaExternalByID   map[string]string
 }
 
 func (fakeInstallationRepository) Create(ctx context.Context, params auth.CreateInstallationParams) (*auth.Installation, error) {
@@ -119,6 +121,17 @@ func (f *fakeInstallationRepository) UpdateExcludedModels(ctx context.Context, e
 	}
 	f.excludedModelsByID[id] = append([]string{}, models...)
 	f.excludedModelsExternalByID[id] = externalID
+	return nil
+}
+func (f *fakeInstallationRepository) UpdateRoutingAlpha(ctx context.Context, externalID, id string, alpha int) error {
+	if f.routingAlphaByID == nil {
+		f.routingAlphaByID = map[string]int{}
+	}
+	if f.routingAlphaExternalByID == nil {
+		f.routingAlphaExternalByID = map[string]string{}
+	}
+	f.routingAlphaByID[id] = alpha
+	f.routingAlphaExternalByID[id] = externalID
 	return nil
 }
 
@@ -584,5 +597,36 @@ func TestService_SetInstallationExcludedModels(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, []string{}, out)
 		assert.Equal(t, []string{}, installRepo.excludedModelsByID["inst-3"])
+	})
+}
+
+func TestService_SetInstallationRoutingAlpha(t *testing.T) {
+	installRepo := &fakeInstallationRepository{}
+	svc := auth.NewService(installRepo, &fakeAPIKeyRepository{byHash: map[string]fakeKeyRow{}}, nil, nil, auth.NoOpAPIKeyCache{}, nil, frozenClock())
+
+	t.Run("persists in range alpha scoped by external_id", func(t *testing.T) {
+		require.NoError(t, svc.SetInstallationRoutingAlpha(context.Background(), "ext-1", "inst-1", 7))
+		assert.Equal(t, 7, installRepo.routingAlphaByID["inst-1"])
+		assert.Equal(t, "ext-1", installRepo.routingAlphaExternalByID["inst-1"],
+			"external_id must be propagated for cross-tenant scoping")
+	})
+
+	t.Run("accepts boundary values", func(t *testing.T) {
+		require.NoError(t, svc.SetInstallationRoutingAlpha(context.Background(), "ext-1", "inst-1", auth.MinRoutingAlpha))
+		assert.Equal(t, auth.MinRoutingAlpha, installRepo.routingAlphaByID["inst-1"])
+		require.NoError(t, svc.SetInstallationRoutingAlpha(context.Background(), "ext-1", "inst-1", auth.MaxRoutingAlpha))
+		assert.Equal(t, auth.MaxRoutingAlpha, installRepo.routingAlphaByID["inst-1"])
+	})
+
+	t.Run("rejects below minimum with ErrAlphaOutOfRange", func(t *testing.T) {
+		err := svc.SetInstallationRoutingAlpha(context.Background(), "ext-1", "inst-1", -1)
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, auth.ErrAlphaOutOfRange))
+	})
+
+	t.Run("rejects above maximum with ErrAlphaOutOfRange", func(t *testing.T) {
+		err := svc.SetInstallationRoutingAlpha(context.Background(), "ext-1", "inst-1", auth.MaxRoutingAlpha+1)
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, auth.ErrAlphaOutOfRange))
 	})
 }

--- a/internal/postgres/converters.go
+++ b/internal/postgres/converters.go
@@ -23,6 +23,7 @@ func toAuthInstallation(row sqlc.RouterModelRouterInstallation) *auth.Installati
 		DeletedAt:      timestampPtr(row.DeletedAt),
 		CreatedBy:      row.CreatedBy,
 		ExcludedModels: excluded,
+		RoutingAlpha:   int(row.RoutingAlpha),
 	}
 }
 

--- a/internal/postgres/repository.go
+++ b/internal/postgres/repository.go
@@ -112,6 +112,19 @@ func (r *installationRepo) UpdateExcludedModels(ctx context.Context, externalID,
 	})
 }
 
+func (r *installationRepo) UpdateRoutingAlpha(ctx context.Context, externalID, id string, alpha int) error {
+	parsed, err := uuid.Parse(id)
+	if err != nil {
+		return err
+	}
+	q := sqlc.New(r.tx)
+	return q.UpdateModelRouterInstallationRoutingAlpha(ctx, sqlc.UpdateModelRouterInstallationRoutingAlphaParams{
+		ID:           parsed,
+		ExternalID:   externalID,
+		RoutingAlpha: int16(alpha),
+	})
+}
+
 type apiKeyRepo struct {
 	tx sqlc.DBTX
 }

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -113,6 +113,12 @@ type CredentialsContextKey struct{}
 // proxy can build the request-time filter without re-reading the DB.
 type InstallationExcludedModelsContextKey struct{}
 
+// InstallationRoutingAlphaContextKey is the request-context key for the
+// authed installation's routing alpha (int 0..10). Stashed by WithAuth so
+// the cluster Multiversion router can map it to the matching pre-baked
+// bundle without re-reading the DB on every request.
+type InstallationRoutingAlphaContextKey struct{}
+
 // installationExcludedModelsFromContext returns the per-installation exclusion
 // list stashed on ctx by the auth middleware, or nil when none is present.
 
@@ -248,6 +254,23 @@ func installationExcludedModelsFromContext(ctx context.Context) []string {
 	}
 	out, _ := v.([]string)
 	return out
+}
+
+// installationRoutingAlphaFromContext returns the per-installation routing
+// alpha stashed on ctx by WithAuth. ok is false when no value is present
+// (unauthenticated test paths, or callers that bypass WithAuth) so the
+// caller can leave router.Request.AlphaSet at false and let the scorer use
+// its default bundle.
+func installationRoutingAlphaFromContext(ctx context.Context) (int, bool) {
+	v := ctx.Value(InstallationRoutingAlphaContextKey{})
+	if v == nil {
+		return 0, false
+	}
+	alpha, ok := v.(int)
+	if !ok {
+		return 0, false
+	}
+	return alpha, true
 }
 
 // excludedModelsForRequest returns the model exclusion set to apply for this
@@ -690,6 +713,7 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 	installationID := installationIDFromContext(ctx)
 	clientID := ClientIdentityFrom(ctx)
 	bypassEval := hasEvalOverrideHeader(r)
+	installationAlpha, installationAlphaSet := installationRoutingAlphaFromContext(ctx)
 
 	// Anthropic packs sub-agent identity into metadata.user_id; the
 	// x-weave-subagent-type header is for non-Anthropic ingress only.
@@ -701,6 +725,8 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 		PromptText:           promptText,
 		EnabledProviders:     s.enabledProvidersForRequest(ctx, r.Header),
 		ExcludedModels:       s.excludedModelsForRequest(ctx),
+		Alpha:                installationAlpha,
+		AlphaSet:             installationAlphaSet,
 	})
 	if routeErr != nil {
 		log.Error("Routing failed", "err", routeErr, "route_ms", time.Since(routeStart).Milliseconds(), "requested_model", feats.Model, "estimated_input_tokens", feats.Tokens)
@@ -1342,6 +1368,7 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 	}
 
 	bypassEval := hasEvalOverrideHeader(r)
+	installationAlpha, installationAlphaSet := installationRoutingAlphaFromContext(ctx)
 
 	// OpenAI signals sub-agent identity via x-weave-subagent-type (no metadata.user_id).
 	subAgentHint := r.Header.Get("x-weave-subagent-type")
@@ -1354,6 +1381,8 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 		PromptText:           promptText,
 		EnabledProviders:     s.enabledProvidersForRequest(ctx, r.Header),
 		ExcludedModels:       s.excludedModelsForRequest(ctx),
+		Alpha:                installationAlpha,
+		AlphaSet:             installationAlphaSet,
 	})
 	routeMs := time.Since(routeStart).Milliseconds()
 	if err != nil {

--- a/internal/router/cluster/multiversion.go
+++ b/internal/router/cluster/multiversion.go
@@ -3,7 +3,9 @@ package cluster
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"sort"
+	"strconv"
 
 	"workweave/router/internal/observability"
 	"workweave/router/internal/router"
@@ -25,11 +27,36 @@ func VersionFromContext(ctx context.Context) string {
 	return v
 }
 
+// alphaSuffixPattern captures the trailing -a<NN> form used to mark
+// alpha-blend variants of the same training stem (e.g. v0.38-a05 → stem
+// "v0.38", alpha 5). Two-digit zero-padded so lexicographic listing matches
+// numeric order.
+var alphaSuffixPattern = regexp.MustCompile(`^(.*)-a(\d{2})$`)
+
+// parseAlphaSuffix returns (stem, alphaValue, true) when name has a valid
+// -a<NN> suffix with NN in 0..10. Anything else returns ok=false.
+func parseAlphaSuffix(name string) (stem string, alpha int, ok bool) {
+	matches := alphaSuffixPattern.FindStringSubmatch(name)
+	if matches == nil {
+		return "", 0, false
+	}
+	alpha, err := strconv.Atoi(matches[2])
+	if err != nil || alpha < 0 || alpha > 10 {
+		return "", 0, false
+	}
+	return matches[1], alpha, true
+}
+
 // Multiversion holds one Scorer per artifact version and dispatches
-// per-request based on a context override.
+// per-request based on a context override or an installation's routing alpha.
 type Multiversion struct {
 	Default  string
 	Versions map[string]*Scorer
+	// alphaToVersion maps an integer alpha (0..10) to the bundle name that
+	// corresponds to it within the default version's stem. Empty when the
+	// default version is a legacy bundle without an -a<NN> suffix, in which
+	// case routing-alpha overrides degrade gracefully to the default scorer.
+	alphaToVersion map[int]string
 }
 
 // NewMultiversion requires defaultVersion to be a key in versions.
@@ -45,9 +72,20 @@ func NewMultiversion(defaultVersion string, versions map[string]*Scorer) (*Multi
 		sort.Strings(built)
 		return nil, fmt.Errorf("cluster multiversion: default %q not in built versions %v", defaultVersion, built)
 	}
+	alphaToVersion := map[int]string{}
+	if stem, _, ok := parseAlphaSuffix(defaultVersion); ok {
+		for name := range versions {
+			candidateStem, alpha, ok := parseAlphaSuffix(name)
+			if !ok || candidateStem != stem {
+				continue
+			}
+			alphaToVersion[alpha] = name
+		}
+	}
 	return &Multiversion{
-		Default:  defaultVersion,
-		Versions: versions,
+		Default:        defaultVersion,
+		Versions:       versions,
+		alphaToVersion: alphaToVersion,
 	}, nil
 }
 
@@ -72,11 +110,15 @@ func (m *Multiversion) DefaultDeployedModels() []DeployedEntry {
 	return s.DeployedModels()
 }
 
-// Route dispatches to the per-request version override if built, otherwise Default.
+// Route dispatches based on (in priority order): the per-request version
+// header override; the per-installation routing alpha (when alpha bundles for
+// the default's stem are built); otherwise the default version. Missing
+// overrides degrade silently to the default so a misconfigured installation
+// never errors a request — the cluster scorer's "fail loud" sentinels are
+// reserved for unavailability, not for routing-preference fallbacks.
 func (m *Multiversion) Route(ctx context.Context, req router.Request) (router.Decision, error) {
-	requested := VersionFromContext(ctx)
 	chosen := m.Default
-	if requested != "" {
+	if requested := VersionFromContext(ctx); requested != "" {
 		if _, ok := m.Versions[requested]; ok {
 			chosen = requested
 		} else {
@@ -85,6 +127,19 @@ func (m *Multiversion) Route(ctx context.Context, req router.Request) (router.De
 				"requested_version", requested,
 				"default_version", m.Default,
 				"built_versions", m.Built(),
+			)
+		}
+	} else if req.AlphaSet {
+		if alphaVersion, ok := m.alphaToVersion[req.Alpha]; ok {
+			chosen = alphaVersion
+		} else {
+			// Bundle for this alpha isn't built (legacy default, or alpha
+			// outside the built sweep). Log Debug rather than Warn so the
+			// expected legacy case doesn't flood production logs.
+			observability.Get().Debug(
+				"Cluster scorer: routing alpha bundle not built; serving default",
+				"alpha", req.Alpha,
+				"default_version", m.Default,
 			)
 		}
 	}

--- a/internal/router/cluster/multiversion_test.go
+++ b/internal/router/cluster/multiversion_test.go
@@ -87,3 +87,128 @@ func TestWithVersion_EmptyStringIsNoOp(t *testing.T) {
 	ctx := WithVersion(context.Background(), "")
 	assert.Empty(t, VersionFromContext(ctx))
 }
+
+func TestParseAlphaSuffix(t *testing.T) {
+	cases := []struct {
+		in     string
+		stem   string
+		alpha  int
+		wantOk bool
+	}{
+		{"v0.38-a00", "v0.38", 0, true},
+		{"v0.38-a05", "v0.38", 5, true},
+		{"v0.38-a10", "v0.38", 10, true},
+		{"v0.38", "", 0, false},        // no suffix → not an alpha bundle
+		{"v0.38-a11", "", 0, false},    // out of 0..10 range
+		{"v0.38-a5", "", 0, false},     // not two-digit
+		{"v0.38-aXY", "", 0, false},    // non-numeric
+		{"plain", "", 0, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.in, func(t *testing.T) {
+			stem, alpha, ok := parseAlphaSuffix(tc.in)
+			assert.Equal(t, tc.wantOk, ok)
+			if tc.wantOk {
+				assert.Equal(t, tc.stem, stem)
+				assert.Equal(t, tc.alpha, alpha)
+			}
+		})
+	}
+}
+
+func TestMultiversion_AlphaDispatchPicksMatchingBundle(t *testing.T) {
+	emb := &fakeEmbedder{vec: makeOpusVec()}
+	a00 := scorerForVersion(t, "v0.38-a00", emb)
+	a05 := scorerForVersion(t, "v0.38-a05", emb)
+	a10 := scorerForVersion(t, "v0.38-a10", emb)
+
+	multi, err := NewMultiversion("v0.38-a05", map[string]*Scorer{
+		"v0.38-a00": a00,
+		"v0.38-a05": a05,
+		"v0.38-a10": a10,
+	})
+	require.NoError(t, err)
+
+	tests := []struct {
+		name        string
+		alpha       int
+		alphaSet    bool
+		wantVersion string
+	}{
+		{"unset alpha serves default", 0, false, "v0.38-a05"},
+		{"alpha=0 picks a00", 0, true, "v0.38-a00"},
+		{"alpha=10 picks a10", 10, true, "v0.38-a10"},
+		{"alpha=5 picks a05", 5, true, "v0.38-a05"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := multi.Route(context.Background(), router.Request{
+				PromptText: strings.Repeat("x", 100),
+				Alpha:      tc.alpha,
+				AlphaSet:   tc.alphaSet,
+			})
+			require.NoError(t, err)
+			assert.Contains(t, got.Reason, "cluster:"+tc.wantVersion)
+		})
+	}
+}
+
+// Installations whose alpha doesn't have a built bundle must serve the
+// default scorer, not error. Missing-bundle is a deployment-time degradation
+// (rolled out config before retraining) and shouldn't 503 every request.
+func TestMultiversion_AlphaUnknownFallsBackToDefault(t *testing.T) {
+	emb := &fakeEmbedder{vec: makeOpusVec()}
+	a05 := scorerForVersion(t, "v0.38-a05", emb)
+
+	multi, err := NewMultiversion("v0.38-a05", map[string]*Scorer{"v0.38-a05": a05})
+	require.NoError(t, err)
+
+	got, err := multi.Route(context.Background(), router.Request{
+		PromptText: strings.Repeat("x", 100),
+		Alpha:      8,
+		AlphaSet:   true,
+	})
+	require.NoError(t, err)
+	assert.Contains(t, got.Reason, "cluster:v0.38-a05")
+}
+
+// Header override beats per-installation alpha so the eval harness can pin
+// a specific bundle regardless of what an installation has saved.
+func TestMultiversion_VersionHeaderBeatsAlpha(t *testing.T) {
+	emb := &fakeEmbedder{vec: makeOpusVec()}
+	a00 := scorerForVersion(t, "v0.38-a00", emb)
+	a05 := scorerForVersion(t, "v0.38-a05", emb)
+
+	multi, err := NewMultiversion("v0.38-a05", map[string]*Scorer{
+		"v0.38-a00": a00,
+		"v0.38-a05": a05,
+	})
+	require.NoError(t, err)
+
+	ctx := WithVersion(context.Background(), "v0.38-a00")
+	got, err := multi.Route(ctx, router.Request{
+		PromptText: strings.Repeat("x", 100),
+		Alpha:      10, // would pick a10 if it were built, but header wins
+		AlphaSet:   true,
+	})
+	require.NoError(t, err)
+	assert.Contains(t, got.Reason, "cluster:v0.38-a00")
+}
+
+// Legacy bundles (no -aNN suffix on the default) get no alpha-aware lookup;
+// any alpha override is silently ignored and the default serves.
+func TestMultiversion_LegacyDefaultIgnoresAlpha(t *testing.T) {
+	emb := &fakeEmbedder{vec: makeOpusVec()}
+	legacy := scorerForVersion(t, "v0.37", emb)
+
+	multi, err := NewMultiversion("v0.37", map[string]*Scorer{"v0.37": legacy})
+	require.NoError(t, err)
+
+	got, err := multi.Route(context.Background(), router.Request{
+		PromptText: strings.Repeat("x", 100),
+		Alpha:      0,
+		AlphaSet:   true,
+	})
+	require.NoError(t, err)
+	assert.Contains(t, got.Reason, "cluster:v0.37")
+}

--- a/internal/router/cluster/multiversion_test.go
+++ b/internal/router/cluster/multiversion_test.go
@@ -98,10 +98,10 @@ func TestParseAlphaSuffix(t *testing.T) {
 		{"v0.38-a00", "v0.38", 0, true},
 		{"v0.38-a05", "v0.38", 5, true},
 		{"v0.38-a10", "v0.38", 10, true},
-		{"v0.38", "", 0, false},        // no suffix → not an alpha bundle
-		{"v0.38-a11", "", 0, false},    // out of 0..10 range
-		{"v0.38-a5", "", 0, false},     // not two-digit
-		{"v0.38-aXY", "", 0, false},    // non-numeric
+		{"v0.38", "", 0, false},     // no suffix → not an alpha bundle
+		{"v0.38-a11", "", 0, false}, // out of 0..10 range
+		{"v0.38-a5", "", 0, false},  // not two-digit
+		{"v0.38-aXY", "", 0, false}, // non-numeric
 		{"plain", "", 0, false},
 	}
 	for _, tc := range cases {

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -17,6 +17,14 @@ type Request struct {
 	// Nil or empty means no exclusion. If filtering empties the eligible
 	// set, the scorer returns ErrNoEligibleProvider rather than falling back.
 	ExcludedModels map[string]struct{}
+	// Alpha is the quality-vs-cost knob in integer steps (0..10, where 5 =
+	// α=0.5). The cluster Multiversion router maps this to a pre-baked
+	// artifact bundle. Zero is a valid value (pure cost), so callers signal
+	// "use the default" by leaving AlphaSet false rather than zeroing Alpha.
+	Alpha int
+	// AlphaSet differentiates "explicit α=0" from "no preference". Set true
+	// only when the caller has a per-installation value to apply.
+	AlphaSet bool
 }
 
 type Decision struct {

--- a/internal/server/middleware/auth.go
+++ b/internal/server/middleware/auth.go
@@ -85,6 +85,7 @@ func withAPIKey(svc *auth.Service) gin.HandlerFunc {
 			if len(installation.ExcludedModels) > 0 {
 				ctx = context.WithValue(ctx, proxy.InstallationExcludedModelsContextKey{}, installation.ExcludedModels)
 			}
+			ctx = context.WithValue(ctx, proxy.InstallationRoutingAlphaContextKey{}, installation.RoutingAlpha)
 		}
 		if externalKeys != nil {
 			ctx = context.WithValue(ctx, proxy.ExternalAPIKeysContextKey{}, externalKeys)

--- a/internal/server/middleware/auth_test.go
+++ b/internal/server/middleware/auth_test.go
@@ -78,6 +78,10 @@ func (fakeInstallationRepository) UpdateExcludedModels(ctx context.Context, exte
 	return errors.New("not used")
 }
 
+func (fakeInstallationRepository) UpdateRoutingAlpha(ctx context.Context, externalID, id string, alpha int) error {
+	return errors.New("not used")
+}
+
 func TestWithAuthPrefersRouterKeyHeader(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	const routerToken = "rk_router"

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -87,6 +87,8 @@ func Register(engine *gin.Engine, authSvc *auth.Service, proxySvc *proxy.Service
 			mgmt.GET("/excluded-models", admin.GetExcludedModelsHandler(authSvc, deployedModels, proxySvc))
 			mgmt.PUT("/excluded-models", admin.UpdateExcludedModelsHandler(authSvc, deployedModels, proxySvc))
 		}
+		mgmt.GET("/routing-alpha", admin.GetRoutingAlphaHandler(authSvc))
+		mgmt.PUT("/routing-alpha", admin.UpdateRoutingAlphaHandler(authSvc))
 	}
 
 	messagesGroup := engine.Group("",

--- a/internal/sqlc/model_router_api_keys.sql.go
+++ b/internal/sqlc/model_router_api_keys.sql.go
@@ -92,7 +92,7 @@ func (q *Queries) CreateModelRouterAPIKey(ctx context.Context, arg CreateModelRo
 }
 
 const getActiveModelRouterAPIKeyWithInstallationByHash = `-- name: GetActiveModelRouterAPIKeyWithInstallationByHash :one
-SELECT k.id, k.installation_id, k.external_id, k.name, k.key_prefix, k.key_hash, k.key_suffix, k.last_used_at, k.created_at, k.deleted_at, k.created_by, i.id, i.external_id, i.name, i.created_at, i.updated_at, i.deleted_at, i.created_by, i.excluded_models
+SELECT k.id, k.installation_id, k.external_id, k.name, k.key_prefix, k.key_hash, k.key_suffix, k.last_used_at, k.created_at, k.deleted_at, k.created_by, i.id, i.external_id, i.name, i.created_at, i.updated_at, i.deleted_at, i.created_by, i.excluded_models, i.routing_alpha
 FROM router.model_router_api_keys k
 INNER JOIN router.model_router_installations i ON i.id = k.installation_id
 WHERE k.key_hash = $1::varchar
@@ -111,7 +111,7 @@ type GetActiveModelRouterAPIKeyWithInstallationByHashRow struct {
 // both sides so a soft-deleted installation invalidates all its keys without per-key
 // updates.
 //
-//	SELECT k.id, k.installation_id, k.external_id, k.name, k.key_prefix, k.key_hash, k.key_suffix, k.last_used_at, k.created_at, k.deleted_at, k.created_by, i.id, i.external_id, i.name, i.created_at, i.updated_at, i.deleted_at, i.created_by, i.excluded_models
+//	SELECT k.id, k.installation_id, k.external_id, k.name, k.key_prefix, k.key_hash, k.key_suffix, k.last_used_at, k.created_at, k.deleted_at, k.created_by, i.id, i.external_id, i.name, i.created_at, i.updated_at, i.deleted_at, i.created_by, i.excluded_models, i.routing_alpha
 //	FROM router.model_router_api_keys k
 //	INNER JOIN router.model_router_installations i ON i.id = k.installation_id
 //	WHERE k.key_hash = $1::varchar
@@ -140,6 +140,7 @@ func (q *Queries) GetActiveModelRouterAPIKeyWithInstallationByHash(ctx context.C
 		&i.RouterModelRouterInstallation.DeletedAt,
 		&i.RouterModelRouterInstallation.CreatedBy,
 		&i.RouterModelRouterInstallation.ExcludedModels,
+		&i.RouterModelRouterInstallation.RoutingAlpha,
 	)
 	return i, err
 }

--- a/internal/sqlc/model_router_installations.sql.go
+++ b/internal/sqlc/model_router_installations.sql.go
@@ -22,7 +22,7 @@ VALUES (
     $2::varchar,
     $3
 )
-RETURNING id, external_id, name, created_at, updated_at, deleted_at, created_by, excluded_models
+RETURNING id, external_id, name, created_at, updated_at, deleted_at, created_by, excluded_models, routing_alpha
 `
 
 type CreateModelRouterInstallationParams struct {
@@ -43,7 +43,7 @@ type CreateModelRouterInstallationParams struct {
 //	    $2::varchar,
 //	    $3
 //	)
-//	RETURNING id, external_id, name, created_at, updated_at, deleted_at, created_by, excluded_models
+//	RETURNING id, external_id, name, created_at, updated_at, deleted_at, created_by, excluded_models, routing_alpha
 func (q *Queries) CreateModelRouterInstallation(ctx context.Context, arg CreateModelRouterInstallationParams) (RouterModelRouterInstallation, error) {
 	row := q.db.QueryRow(ctx, createModelRouterInstallation, arg.ExternalID, arg.Name, arg.CreatedBy)
 	var i RouterModelRouterInstallation
@@ -56,12 +56,13 @@ func (q *Queries) CreateModelRouterInstallation(ctx context.Context, arg CreateM
 		&i.DeletedAt,
 		&i.CreatedBy,
 		&i.ExcludedModels,
+		&i.RoutingAlpha,
 	)
 	return i, err
 }
 
 const getModelRouterInstallation = `-- name: GetModelRouterInstallation :one
-SELECT id, external_id, name, created_at, updated_at, deleted_at, created_by, excluded_models
+SELECT id, external_id, name, created_at, updated_at, deleted_at, created_by, excluded_models, routing_alpha
 FROM router.model_router_installations
 WHERE id = $1::uuid
   AND external_id = $2::varchar
@@ -75,7 +76,7 @@ type GetModelRouterInstallationParams struct {
 
 // Gets an installation by id, scoped to an external_id to prevent cross-tenant access.
 //
-//	SELECT id, external_id, name, created_at, updated_at, deleted_at, created_by, excluded_models
+//	SELECT id, external_id, name, created_at, updated_at, deleted_at, created_by, excluded_models, routing_alpha
 //	FROM router.model_router_installations
 //	WHERE id = $1::uuid
 //	  AND external_id = $2::varchar
@@ -92,12 +93,13 @@ func (q *Queries) GetModelRouterInstallation(ctx context.Context, arg GetModelRo
 		&i.DeletedAt,
 		&i.CreatedBy,
 		&i.ExcludedModels,
+		&i.RoutingAlpha,
 	)
 	return i, err
 }
 
 const listModelRouterInstallationsForExternalID = `-- name: ListModelRouterInstallationsForExternalID :many
-SELECT id, external_id, name, created_at, updated_at, deleted_at, created_by, excluded_models
+SELECT id, external_id, name, created_at, updated_at, deleted_at, created_by, excluded_models, routing_alpha
 FROM router.model_router_installations
 WHERE external_id = $1::varchar
   AND deleted_at IS NULL
@@ -106,7 +108,7 @@ ORDER BY created_at DESC
 
 // ListModelRouterInstallationsForExternalID
 //
-//	SELECT id, external_id, name, created_at, updated_at, deleted_at, created_by, excluded_models
+//	SELECT id, external_id, name, created_at, updated_at, deleted_at, created_by, excluded_models, routing_alpha
 //	FROM router.model_router_installations
 //	WHERE external_id = $1::varchar
 //	  AND deleted_at IS NULL
@@ -129,6 +131,7 @@ func (q *Queries) ListModelRouterInstallationsForExternalID(ctx context.Context,
 			&i.DeletedAt,
 			&i.CreatedBy,
 			&i.ExcludedModels,
+			&i.RoutingAlpha,
 		); err != nil {
 			return nil, err
 		}
@@ -192,5 +195,35 @@ type UpdateModelRouterInstallationExcludedModelsParams struct {
 //	  AND deleted_at IS NULL
 func (q *Queries) UpdateModelRouterInstallationExcludedModels(ctx context.Context, arg UpdateModelRouterInstallationExcludedModelsParams) error {
 	_, err := q.db.Exec(ctx, updateModelRouterInstallationExcludedModels, arg.ExcludedModels, arg.ID, arg.ExternalID)
+	return err
+}
+
+const updateModelRouterInstallationRoutingAlpha = `-- name: UpdateModelRouterInstallationRoutingAlpha :exec
+UPDATE router.model_router_installations
+SET routing_alpha = $1::smallint,
+    updated_at = NOW()
+WHERE id = $2::uuid
+  AND external_id = $3::varchar
+  AND deleted_at IS NULL
+`
+
+type UpdateModelRouterInstallationRoutingAlphaParams struct {
+	RoutingAlpha int16
+	ID           uuid.UUID
+	ExternalID   string
+}
+
+// Replaces the per-installation routing alpha (0..10, representing 0.0..1.0 in
+// 0.1 steps). Scoped to an external_id to prevent cross-tenant updates. Bumps
+// updated_at so dashboards see the change.
+//
+//	UPDATE router.model_router_installations
+//	SET routing_alpha = $1::smallint,
+//	    updated_at = NOW()
+//	WHERE id = $2::uuid
+//	  AND external_id = $3::varchar
+//	  AND deleted_at IS NULL
+func (q *Queries) UpdateModelRouterInstallationRoutingAlpha(ctx context.Context, arg UpdateModelRouterInstallationRoutingAlphaParams) error {
+	_, err := q.db.Exec(ctx, updateModelRouterInstallationRoutingAlpha, arg.RoutingAlpha, arg.ID, arg.ExternalID)
 	return err
 }

--- a/internal/sqlc/models.go
+++ b/internal/sqlc/models.go
@@ -56,6 +56,7 @@ type RouterModelRouterInstallation struct {
 	DeletedAt      pgtype.Timestamp
 	CreatedBy      *string
 	ExcludedModels []string
+	RoutingAlpha   int16
 }
 
 type RouterModelRouterRequestTelemetry struct {


### PR DESCRIPTION
## Summary

Lets each installation pick its own quality-vs-cost tradeoff for the cluster router in 0.1 steps via the self-hosted dashboard.

- New `routing_alpha SMALLINT 0..10` on `model_router_installations` (5 = α=0.5, matches today's shipped global default). Hot-path API-key join returns it inline.
- `cluster.Multiversion` parses an `-a<NN>` suffix on the default version, builds an α→bundle map at boot, and dispatches: header override > installation α > default. Missing α bundles fall back silently with a Debug log; legacy bundles (no `-aNN` suffix) ignore α entirely.
- `auth.Service.SetInstallationRoutingAlpha` validates the range (`ErrAlphaOutOfRange`); persistence rides the same write-through-by-TTL contract as excluded models.
- `/admin/v1/routing-alpha` GET/PUT under the admin-cookie mgmt group.
- `/ui/settings` gains a **Quality vs cost** section with a native range slider, labeled `Lowest cost / Default (0.5) / Highest quality`, displaying the canonical α float.
- `scripts/train_alpha_sweep.sh` (in the WorkWeave outer repo, not this submodule) drives 11 alpha bundles per stem; only the `-a05` bundle is promoted to `latest`.
- `CLAUDE.md` / `AGENTS.md` updated — the old "Don't add a runtime α knob" rule is replaced with the per-installation contract; per-request `x-weave-routing-alpha` header remains P1.

## Why α can be tunable without retraining N models

α is a scalar in the blend `score = α·p̃ + (1−α)·(1−q̃)` over **pre-computed** per-cluster price (`p̃`) and quality (`q̃`) tables. Today it's pre-blended at training time and only the result is shipped in `rankings.json`. Producing 11 alpha variants is 11 reruns of the existing training script with the same upstream embeddings — no model training. The runtime selects the matching bundle at request time.

## Test plan

- [x] `go build ./...`, `go vet ./...` clean
- [x] `go test ./...` all green; new tests cover:
  - [x] `parseAlphaSuffix` edge cases (no suffix, out-of-range, non-numeric, single-digit)
  - [x] `Multiversion` α dispatch: default-on-unset, exact picks at 0/5/10, header beats α, missing bundle falls back, legacy default ignores α
  - [x] `auth.Service.SetInstallationRoutingAlpha`: persistence with `external_id` scoping, boundary values, `ErrAlphaOutOfRange` below/above range
- [ ] Migration applied locally (`wv db run-migrations -r`) — verify default `5` backfills, then `wv db undo-migration -r`
- [ ] Local `wv mr` with `ROUTER_CLUSTER_BUILD_ALL_VERSIONS=true` after the α sweep lands; seed two API keys with different α values and confirm the routing decision flips for the same prompt
- [ ] Eval harness pinned to `-a02` vs `-a08` shows quality/cost numbers move in the expected direction
- [ ] Dashboard slider persists across reload and survives commit on `mouseup` / `touchend` / `keyup` without spamming the PUT endpoint

## Out of scope (follow-ups)

- The α sweep artifact bundles themselves (`v<X.Y>-a00 … -a10`). Land this PR first; ship bundles in a follow-up so reviewers don't have to wade through ~11× the artifact diff. Until they land, the runtime serves the legacy `v0.37` default and treats α as a no-op (the test suite covers that legacy fallback).
- Per-request `x-weave-routing-alpha` header override (P1 — defer until a customer asks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)