### PR TITLE
translate: smuggle Gemini thought_signature in tool_use.id

### DIFF
--- a/internal/translate/emit_gemini.go
+++ b/internal/translate/emit_gemini.go
@@ -283,12 +283,18 @@ func openAIAssistantToGeminiParts(msg map[string]any) ([]any, error) {
 		part := map[string]any{
 			"functionCall": map[string]any{"name": name, "args": args},
 		}
-		// thought_signature may live on the tool_call or the function object;
-		// round-trip whichever shape we receive.
+		// thought_signature may live on the tool_call, the function object,
+		// or smuggled into tc.id; round-trip whichever shape we receive.
+		// OpenAI Chat Completions clients pass tool_call.id verbatim, so the
+		// id channel survives typed-SDK field stripping.
 		if sig, _ := tc["thought_signature"].(string); sig != "" {
 			part["thoughtSignature"] = sig
 		} else if sig, _ := fn["thought_signature"].(string); sig != "" {
 			part["thoughtSignature"] = sig
+		} else if id, _ := tc["id"].(string); id != "" {
+			if _, sig := extractSignatureFromID(id); sig != "" {
+				part["thoughtSignature"] = sig
+			}
 		}
 		parts = append(parts, part)
 	}
@@ -616,7 +622,16 @@ func anthropicAssistantToGeminiParts(content any) ([]any, error) {
 				part := map[string]any{
 					"functionCall": map[string]any{"name": name, "args": input},
 				}
-				if sig, _ := block["thought_signature"].(string); sig != "" {
+				// Prefer an explicit thought_signature field, but fall back to
+				// one smuggled into block.id — Claude Code and other typed
+				// Anthropic SDKs drop the off-spec field on the way back.
+				sig, _ := block["thought_signature"].(string)
+				if sig == "" {
+					if id, _ := block["id"].(string); id != "" {
+						_, sig = extractSignatureFromID(id)
+					}
+				}
+				if sig != "" {
 					part["thoughtSignature"] = sig
 				}
 				parts = append(parts, part)

--- a/internal/translate/gemini_response.go
+++ b/internal/translate/gemini_response.go
@@ -199,13 +199,14 @@ func geminiFunctionCallToToolCall(fc map[string]any, signature string) map[strin
 		"arguments": argStr,
 	}
 	tc := map[string]any{
-		"id":       generateToolCallID(),
+		"id":       embedSignatureInID(generateToolCallID(), signature),
 		"type":     "function",
 		"function": fn,
 	}
 	if signature != "" {
-		// Off-spec; clients pass it through and our translators read it back
-		// on the next turn.
+		// Off-spec; clients that preserve unknown fields pass it through.
+		// The signature is also smuggled into tc.id above for typed SDKs
+		// (Claude Code, Anthropic TS SDK) that drop unknown fields.
 		fn["thought_signature"] = signature
 		tc["thought_signature"] = signature
 	}
@@ -226,16 +227,17 @@ func buildAnthropicBlocksFromGemini(candidate map[string]any) []any {
 			continue
 		}
 		if fc, ok := part["functionCall"].(map[string]any); ok {
+			sig, _ := part["thoughtSignature"].(string)
 			block := map[string]any{
 				"type":  "tool_use",
-				"id":    generateToolUseID(),
+				"id":    embedSignatureInID(generateToolUseID(), sig),
 				"name":  fc["name"],
 				"input": fc["args"],
 			}
 			if block["input"] == nil {
 				block["input"] = map[string]any{}
 			}
-			if sig, _ := part["thoughtSignature"].(string); sig != "" {
+			if sig != "" {
 				block["thought_signature"] = sig
 			}
 			blocks = append(blocks, block)

--- a/internal/translate/gemini_stream.go
+++ b/internal/translate/gemini_stream.go
@@ -256,7 +256,7 @@ func (t *GeminiToOpenAISSETranslator) emitTextDelta(text string) error {
 // function.thought_signature (off-spec but preserved by passthrough clients)
 // so the next request can round-trip it.
 func (t *GeminiToOpenAISSETranslator) emitToolCallChunk(idx int, name, argsRaw, sig string) error {
-	id := generateToolCallID()
+	id := embedSignatureInID(generateToolCallID(), sig)
 	t.writeChunkHeader()
 	t.bw.WriteString(`"choices":[{"index":0,"delta":{"tool_calls":[{"index":`)
 	sse.WriteJSONInt(t.bw, int64(idx))

--- a/internal/translate/gemini_test.go
+++ b/internal/translate/gemini_test.go
@@ -298,6 +298,114 @@ func TestGeminiToAnthropicResponse_ToolUsePreservesThoughtSignature(t *testing.T
 	assert.Equal(t, "tool_use", tu["type"])
 	assert.Equal(t, "GS", tu["thought_signature"])
 	assert.Equal(t, "bash", tu["name"])
+	// The id must also carry the signature so typed-SDK clients (Claude Code)
+	// that drop unknown content-block fields still round-trip it.
+	assert.Contains(t, tu["id"].(string), "__thought__")
+}
+
+// TestPrepareGemini_FromAnthropic_ToolUseSignatureSurvivesUnknownFieldStripping
+// is the load-bearing regression test for Gemini 3.x multi-turn tool use
+// when the client (Claude Code) drops the off-spec thought_signature field
+// from a tool_use content block on deserialization. The signature must still
+// be smuggled back to Gemini via the id channel.
+func TestPrepareGemini_FromAnthropic_ToolUseSignatureSurvivesUnknownFieldStripping(t *testing.T) {
+	// Turn 1: Gemini → Anthropic response embeds the signature into the
+	// synthesized tool_use.id.
+	geminiResp := []byte(`{
+		"candidates":[{"content":{"role":"model","parts":[
+			{"functionCall":{"name":"bash","args":{"command":"ls"}},
+			 "thoughtSignature":"OPAQUE_GEMINI_SIG"}
+		]},"finishReason":"STOP"}]
+	}`)
+	anthropicOut, err := translate.GeminiToAnthropicResponse(geminiResp, "gemini-3.1-pro-preview")
+	require.NoError(t, err)
+	resp := mustUnmarshal(t, anthropicOut)
+	tu := resp["content"].([]any)[0].(map[string]any)
+	smuggledID := tu["id"].(string)
+	require.Contains(t, smuggledID, "__thought__")
+
+	// Simulate Claude Code stripping the off-spec field on deserialization.
+	delete(tu, "thought_signature")
+
+	// Turn 3: client sends history back. Router translates Anthropic → Gemini.
+	req := map[string]any{
+		"model": "claude-opus-4-7",
+		"messages": []any{
+			map[string]any{"role": "user", "content": "list files"},
+			map[string]any{"role": "assistant", "content": []any{tu}},
+			map[string]any{"role": "user", "content": []any{
+				map[string]any{"type": "tool_result", "tool_use_id": smuggledID, "content": "f1\nf2"},
+			}},
+		},
+	}
+	reqBody, err := json.Marshal(req)
+	require.NoError(t, err)
+	env, err := translate.ParseAnthropic(reqBody)
+	require.NoError(t, err)
+	prep, err := env.PrepareGemini(http.Header{}, translate.EmitOptions{TargetModel: "gemini-3.1-pro-preview"})
+	require.NoError(t, err)
+
+	out := mustUnmarshal(t, prep.Body)
+	contents := out["contents"].([]any)
+	require.Len(t, contents, 3)
+	model := contents[1].(map[string]any)
+	parts := model["parts"].([]any)
+	p := parts[0].(map[string]any)
+	// The signature is what Gemini 3.x rejects requests for when missing.
+	assert.Equal(t, "OPAQUE_GEMINI_SIG", p["thoughtSignature"])
+	fc := p["functionCall"].(map[string]any)
+	assert.Equal(t, "bash", fc["name"])
+	// And the functionResponse must still resolve the name from the smuggled id.
+	tr := contents[2].(map[string]any)
+	frPart := tr["parts"].([]any)[0].(map[string]any)
+	fr := frPart["functionResponse"].(map[string]any)
+	assert.Equal(t, "bash", fr["name"])
+}
+
+// Same as above but via OpenAI Chat Completions wire format; tool_call.id is
+// the round-trip channel and is preserved by every Chat Completions client.
+func TestPrepareGemini_FromOpenAI_ToolCallSignatureSurvivesUnknownFieldStripping(t *testing.T) {
+	geminiResp := []byte(`{
+		"candidates":[{"content":{"role":"model","parts":[
+			{"functionCall":{"name":"bash","args":{"command":"ls"}},
+			 "thoughtSignature":"OPAQUE_SIG_2"}
+		]},"finishReason":"STOP"}]
+	}`)
+	openaiOut, err := translate.GeminiToOpenAIResponse(geminiResp, "gemini-3.1-pro-preview")
+	require.NoError(t, err)
+	resp := mustUnmarshal(t, openaiOut)
+	choice := resp["choices"].([]any)[0].(map[string]any)
+	tc := choice["message"].(map[string]any)["tool_calls"].([]any)[0].(map[string]any)
+	smuggledID := tc["id"].(string)
+	require.Contains(t, smuggledID, "__thought__")
+
+	// Strip the explicit signature fields on both the tool_call and the
+	// nested function — simulating a client that only preserves spec fields.
+	delete(tc, "thought_signature")
+	fn := tc["function"].(map[string]any)
+	delete(fn, "thought_signature")
+
+	req := map[string]any{
+		"model": "gpt-x",
+		"messages": []any{
+			map[string]any{"role": "user", "content": "list files"},
+			map[string]any{"role": "assistant", "content": nil, "tool_calls": []any{tc}},
+			map[string]any{"role": "tool", "tool_call_id": smuggledID, "content": "f1\nf2"},
+		},
+	}
+	reqBody, err := json.Marshal(req)
+	require.NoError(t, err)
+	env, err := translate.ParseOpenAI(reqBody)
+	require.NoError(t, err)
+	prep, err := env.PrepareGemini(http.Header{}, translate.EmitOptions{TargetModel: "gemini-3.1-pro-preview"})
+	require.NoError(t, err)
+	out := mustUnmarshal(t, prep.Body)
+	contents := out["contents"].([]any)
+	require.GreaterOrEqual(t, len(contents), 2)
+	model := contents[1].(map[string]any)
+	parts := model["parts"].([]any)
+	p := parts[0].(map[string]any)
+	assert.Equal(t, "OPAQUE_SIG_2", p["thoughtSignature"])
 }
 
 // ----- Streaming -----

--- a/internal/translate/thought_signature_id.go
+++ b/internal/translate/thought_signature_id.go
@@ -1,0 +1,43 @@
+package translate
+
+import (
+	"encoding/base64"
+	"strings"
+)
+
+// thoughtSignatureIDDelimiter separates a synthesized tool-use id from a
+// base64-encoded Gemini thoughtSignature smuggled inside it. The id field is
+// structurally preserved by every Anthropic and OpenAI client (it's a typed
+// string used to correlate tool_use ↔ tool_result), so this is a stateless
+// round-trip channel that works even when a client's typed SDK drops unknown
+// fields like the off-spec thought_signature field on a tool_use block.
+//
+// Prior art: BerriAI/litellm PR #16895 uses the same approach on OpenAI
+// tool_call.id.
+const thoughtSignatureIDDelimiter = "__thought__"
+
+// embedSignatureInID returns id with sig encoded and appended via the
+// delimiter. Returns id unchanged when sig is empty.
+func embedSignatureInID(id, sig string) string {
+	if sig == "" {
+		return id
+	}
+	return id + thoughtSignatureIDDelimiter + base64.RawURLEncoding.EncodeToString([]byte(sig))
+}
+
+// extractSignatureFromID is the inverse of embedSignatureInID. If id contains
+// the delimiter and the suffix decodes as base64, it returns the leading
+// portion and the decoded signature. Otherwise it returns id unchanged and an
+// empty signature.
+func extractSignatureFromID(id string) (cleanID, signature string) {
+	i := strings.Index(id, thoughtSignatureIDDelimiter)
+	if i < 0 {
+		return id, ""
+	}
+	encoded := id[i+len(thoughtSignatureIDDelimiter):]
+	decoded, err := base64.RawURLEncoding.DecodeString(encoded)
+	if err != nil {
+		return id, ""
+	}
+	return id[:i], string(decoded)
+}


### PR DESCRIPTION
## Summary

- Fixes Gemini 3.x 400 \`Function call is missing a thought_signature in functionCall parts\` errors hit by Claude Code in multi-turn tool-use conversations.
- Roots cause: the router was passing thought_signature back to clients as an off-spec field on the Anthropic \`tool_use\` content block / OpenAI \`tool_call\`, but Claude Code uses Anthropic's typed TS SDK, which drops unknown fields on deserialization. By turn 3 the signature was gone and Gemini rejected the request.
- Fix: smuggle the signature into the synthesized tool id with a \`__thought__<base64>\` suffix. \`tool_use.id\` / \`tool_call.id\` are structurally preserved by every Anthropic / OpenAI client because they correlate tool_use ↔ tool_result, so the round-trip survives typed-SDK field stripping. The existing off-spec field is kept as a primary channel for clients that do preserve unknown fields.
- Stateless — no server-side cache, survives router restarts and load-balancing across replicas. Mirrors [BerriAI/litellm PR #16895](https://github.com/BerriAI/litellm/pull/16895), the same approach LiteLLM landed for the same bug class.

## Test plan

- [x] \`go test -tags no_onnx ./...\` — all green
- [x] New regression test \`TestPrepareGemini_FromAnthropic_ToolUseSignatureSurvivesUnknownFieldStripping\` — simulates Claude Code dropping the off-spec field on a tool_use block across a 3-turn conversation and asserts the router still emits \`thoughtSignature\` on the outbound Gemini functionCall.
- [x] OpenAI-side mirror test \`TestPrepareGemini_FromOpenAI_ToolCallSignatureSurvivesUnknownFieldStripping\`.
- [x] Existing \`TestGeminiToAnthropicResponse_ToolUsePreservesThoughtSignature\` strengthened to assert the smuggled id format.
- [ ] Manual: end-to-end against \`gemini-3.1-pro-preview\` from Claude Code after the WorkWeave gitlink bump

🤖 Generated with [Claude Code](https://claude.com/claude-code)