### PR TITLE
proxy: stop routing to OpenRouter without credentials in managed/BYOK mode

### DIFF
--- a/cmd/router/main.go
+++ b/cmd/router/main.go
@@ -303,15 +303,41 @@ func main() {
 	// runs on every installation, including ones without their own BYOK.
 	// Anthropic-passthrough is excluded for the same reason: an inbound
 	// request that doesn't carry Anthropic client headers would 401.
-	hardPinAvailable := envKeyedProviders
-	if byokOnly {
-		hardPinAvailable = availableProviders
-	}
-	hardPinProvider, hardPinModel := resolveHardPinModel(hardPinAvailable, logger)
+	// In selfhosted mode the boot-time hard-pin is computed over providers
+	// with deployment-level env keys — those are the only ones a hard-pin
+	// can rely on across every installation. In managed/byokOnly mode there
+	// is no provider with deployment auth, so any boot-time hard-pin would
+	// 401 for installations that didn't BYOK that exact provider; we resolve
+	// hard-pin per-request from the cluster bundle below instead.
+	hardPinProvider, hardPinModel := resolveHardPinModel(envKeyedProviders, logger)
 	if hardPinExplore {
 		logger.Info("Explore sub-agent hard-pin enabled", "provider", hardPinProvider, "model", hardPinModel)
 	}
-	logger.Info("Hard-pin model resolved", "provider", hardPinProvider, "model", hardPinModel)
+	logger.Info("Hard-pin model resolved", "provider", hardPinProvider, "model", hardPinModel, "byok_only", byokOnly)
+
+	// Per-request hard-pin resolver for byokOnly deployments. Loads the
+	// default cluster bundle once and closes over its metadata/registry; the
+	// resolver is then called from the proxy with the request's enabled-
+	// providers set so compaction lands on the cheapest model the request
+	// can actually authenticate to. Selfhosted mode leaves the resolver nil
+	// — its boot-time hardPin{Provider,Model} is already correct.
+	var hardPinResolver func(map[string]struct{}) (string, string, bool)
+	if byokOnly {
+		reqVersion := config.GetOr("ROUTER_CLUSTER_VERSION", cluster.LatestVersion)
+		if version, vErr := cluster.ResolveVersion(reqVersion); vErr == nil {
+			if bundle, bErr := cluster.LoadBundle(version); bErr == nil {
+				meta, registry := bundle.Metadata, bundle.Registry
+				hardPinResolver = func(enabled map[string]struct{}) (string, string, bool) {
+					return cluster.CheapestModel(meta, registry, enabled)
+				}
+				logger.Info("Hard-pin resolver wired for byokOnly mode (per-request cheapest model from cluster bundle)", "version", version)
+			} else {
+				logger.Warn("Hard-pin resolver disabled: cluster bundle failed to load; byokOnly hard-pin will fall back to boot-time defaults", "err", bErr, "version", version)
+			}
+		} else {
+			logger.Warn("Hard-pin resolver disabled: could not resolve cluster version; byokOnly hard-pin will fall back to boot-time defaults", "err", vErr)
+		}
+	}
 
 	// Default-eligible set for proxy.Service: env-keyed providers + the
 	// Anthropic passthrough path. BYOK and client-supplied credentials add
@@ -359,6 +385,7 @@ func main() {
 	proxySvc := proxy.NewService(rtr, providerMap, emitter, embedOnlyUser, semanticCache, pinStore, hardPinExplore, hardPinProvider, hardPinModel, repo.Telemetry).
 		WithByokOnly(byokOnly).
 		WithDeploymentKeyedProviders(deploymentEligible).
+		WithHardPinResolver(hardPinResolver).
 		WithPlannerEnabled(plannerEnabled).
 		WithPlanner(plannerCfg).
 		WithSummarizer(summarizer).

--- a/internal/proxy/gemini.go
+++ b/internal/proxy/gemini.go
@@ -65,7 +65,7 @@ func (s *Service) ProxyGeminiGenerateContent(ctx context.Context, body []byte, w
 		EstimatedInputTokens: feats.Tokens,
 		HasTools:             feats.HasTools,
 		PromptText:           promptText,
-		EnabledProviders:     s.enabledProvidersForRequest(ctx, r.Header),
+		EnabledProviders:     s.enabledProvidersForRequest(ctx, providers.ProviderGoogle, r.Header),
 		ExcludedModels:       s.excludedModelsForRequest(ctx),
 	})
 	routeMs := time.Since(routeStart).Milliseconds()

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -55,6 +55,16 @@ type Service struct {
 	// model; overridable via ROUTER_HARD_PIN_PROVIDER / ROUTER_HARD_PIN_MODEL.
 	hardPinProvider string
 	hardPinModel    string
+	// hardPinResolver, when set, overrides the boot-time hardPin{Provider,Model}
+	// per-request. Used in byokOnly (managed) deployments where the cheapest
+	// model among ALL registered providers is the wrong choice — the
+	// installation may only BYOK a subset, and a hard-pin to a provider they
+	// can't authenticate to would 401 at dispatch. The resolver is given the
+	// request's enabled-providers set (BYOK + client-creds intersection) and
+	// returns (provider, model, ok). ok=false signals no eligible provider for
+	// this request — the orchestrator surfaces ErrClusterUnavailable rather
+	// than silently falling back.
+	hardPinResolver func(enabled map[string]struct{}) (provider, model string, ok bool)
 	// telemetry is an optional repository for persisting per-request telemetry.
 	telemetry TelemetryRepository
 	// byokOnly disables deployment-level credential fallback. When true, a
@@ -375,6 +385,18 @@ func (s *Service) WithAvailableModels(models map[string]struct{}) *Service {
 		copied[m] = struct{}{}
 	}
 	s.availableModels = copied
+	return s
+}
+
+// WithHardPinResolver installs a per-request hard-pin resolver. The
+// resolver is consulted on compaction/probe/Explore turns when set; nil
+// preserves the boot-time hardPin{Provider,Model} for every request
+// (the selfhosted default). The resolver receives the request's enabled
+// providers set; ok=false signals the request has no eligible provider
+// and the turnloop should surface ErrClusterUnavailable rather than
+// dispatching to a provider the request can't authenticate to.
+func (s *Service) WithHardPinResolver(resolver func(enabled map[string]struct{}) (provider, model string, ok bool)) *Service {
+	s.hardPinResolver = resolver
 	return s
 }
 
@@ -699,7 +721,7 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 		EstimatedInputTokens: feats.Tokens,
 		HasTools:             feats.HasTools,
 		PromptText:           promptText,
-		EnabledProviders:     s.enabledProvidersForRequest(ctx, r.Header),
+		EnabledProviders:     s.enabledProvidersForRequest(ctx, providers.ProviderAnthropic, r.Header),
 		ExcludedModels:       s.excludedModelsForRequest(ctx),
 	})
 	if routeErr != nil {
@@ -1179,7 +1201,16 @@ func (s *Service) requestUsesNonDeploymentCreds(ctx context.Context, headers htt
 // resolvable for this request (boot-time env key, BYOK, or client-supplied
 // header). The cluster scorer intersects this set with its boot-time
 // candidates so argmax never picks a model the upstream call would 401 on.
-func (s *Service) enabledProvidersForRequest(ctx context.Context, headers http.Header) map[string]struct{} {
+//
+// surfaceProvider is the inbound wire-format's natural provider (anthropic
+// for /v1/messages, openai for /v1/chat/completions, google for the Gemini
+// surface). A client-supplied bearer/x-api-key header is treated as creds
+// for that surface only — never as a licence to enable other OpenAI-compat
+// upstreams that happen to read the same Authorization header. This matches
+// the guard already in resolveAndInjectCredentials: a router-key-authed
+// request must rely on BYOK; a header on such a request is for the inbound
+// surface only and must not enable cross-provider routing.
+func (s *Service) enabledProvidersForRequest(ctx context.Context, surfaceProvider string, headers http.Header) map[string]struct{} {
 	out := make(map[string]struct{}, len(s.providers))
 	// In BYOK-only mode the deployment-level env key must not make a provider
 	// eligible — otherwise argmax could pick it and 401 with the platform key.
@@ -1206,12 +1237,16 @@ func (s *Service) enabledProvidersForRequest(ctx context.Context, headers http.H
 		}
 		out[k.Provider] = struct{}{}
 	}
-	for _, p := range []string{providers.ProviderAnthropic, providers.ProviderOpenAI, providers.ProviderGoogle, providers.ProviderOpenRouter, providers.ProviderFireworks} {
-		if _, already := out[p]; already {
-			continue
-		}
-		if ExtractClientCredentials(p, headers) != nil {
-			out[p] = struct{}{}
+	// Client-supplied headers are only consulted when the request is NOT
+	// authed via a router key. A router-key-authed request that happens to
+	// carry an inbound bearer (e.g. Claude Code's Anthropic OAuth token
+	// passing through) must not enable OpenAI-compat upstreams just because
+	// they share the Authorization: Bearer header format.
+	if installationIDFromContext(ctx) == (uuid.UUID{}) && surfaceProvider != "" {
+		if _, already := out[surfaceProvider]; !already {
+			if ExtractClientCredentials(surfaceProvider, headers) != nil {
+				out[surfaceProvider] = struct{}{}
+			}
 		}
 	}
 	return out
@@ -1352,7 +1387,7 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 		EstimatedInputTokens: feats.Tokens,
 		HasTools:             feats.HasTools,
 		PromptText:           promptText,
-		EnabledProviders:     s.enabledProvidersForRequest(ctx, r.Header),
+		EnabledProviders:     s.enabledProvidersForRequest(ctx, providers.ProviderOpenAI, r.Header),
 		ExcludedModels:       s.excludedModelsForRequest(ctx),
 	})
 	routeMs := time.Since(routeStart).Milliseconds()

--- a/internal/proxy/service_session_pin_test.go
+++ b/internal/proxy/service_session_pin_test.go
@@ -10,9 +10,11 @@ import (
 	"testing"
 	"time"
 
+	"workweave/router/internal/auth"
 	"workweave/router/internal/providers"
 	"workweave/router/internal/proxy"
 	"workweave/router/internal/router"
+	"workweave/router/internal/router/cluster"
 	"workweave/router/internal/router/sessionpin"
 
 	"github.com/google/uuid"
@@ -106,6 +108,19 @@ func newPinSvc(fr *fakeRouter, store *fakePinStore) *proxy.Service {
 func authedCtx(installationID string) context.Context {
 	ctx := context.WithValue(context.Background(), proxy.APIKeyIDContextKey{}, "key-1")
 	return context.WithValue(ctx, proxy.InstallationIDContextKey{}, installationID)
+}
+
+// authedCtxWithExternalKey mirrors authedCtx and additionally stashes one
+// BYOK ExternalAPIKey on the context, the way the auth middleware does at
+// runtime.
+func authedCtxWithExternalKey(installationID, provider string, plaintext []byte) context.Context {
+	ctx := authedCtx(installationID)
+	keys := []*auth.ExternalAPIKey{{
+		InstallationID: installationID,
+		Provider:       provider,
+		Plaintext:      plaintext,
+	}}
+	return context.WithValue(ctx, proxy.ExternalAPIKeysContextKey{}, keys)
 }
 
 const pinTestBody = `{
@@ -242,6 +257,78 @@ const exploreBody = `{
 	"metadata":{"user_id":"subagent:Explore"},
 	"messages":[{"role":"user","content":"list go files"}]
 }`
+
+// In byokOnly mode the per-request hard-pin resolver overrides the
+// boot-time hardPin{Provider,Model} so compaction lands on a model the
+// request can authenticate to. Resolver receives the request's
+// enabled-providers set; here we BYOK only Anthropic and assert the
+// hard-pin lands on Anthropic regardless of the boot-time default.
+func TestService_HardPin_Compaction_ByokOnly_UsesRequestResolver(t *testing.T) {
+	store := newFakePinStore()
+	fr := &fakeRouter{decision: router.Decision{Provider: "anthropic", Model: "claude-opus-4-7", Reason: "cluster"}}
+
+	resolver := func(enabled map[string]struct{}) (string, string, bool) {
+		if _, ok := enabled[providers.ProviderAnthropic]; ok {
+			return providers.ProviderAnthropic, "claude-haiku-anthropic-byok", true
+		}
+		if _, ok := enabled[providers.ProviderOpenRouter]; ok {
+			return providers.ProviderOpenRouter, "deepseek/cheap", true
+		}
+		return "", "", false
+	}
+
+	providerMap := map[string]providers.Client{
+		providers.ProviderAnthropic:  &fakeProvider{},
+		providers.ProviderOpenRouter: &fakeProvider{},
+	}
+	// Boot-time hard-pin points at OpenRouter (mimics the buggy managed-mode
+	// boot path); the per-request resolver must override it to Anthropic
+	// because the installation only BYOKs Anthropic.
+	svc := proxy.NewService(
+		fr, providerMap, nil, false, nil, store, false,
+		providers.ProviderOpenRouter, "deepseek/cheap",
+		nil,
+	).WithByokOnly(true).WithHardPinResolver(resolver)
+
+	ctx := authedCtxWithExternalKey(uuid.New().String(), providers.ProviderAnthropic, []byte("sk-ant-test"))
+	rec := httptest.NewRecorder()
+	httpReq := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(""))
+	require.NoError(t, svc.ProxyMessages(ctx, []byte(compactionBody), rec, httpReq))
+
+	assert.Equal(t, 0, fr.routeCalls, "compaction must bypass the cluster scorer")
+	assert.Equal(t, "claude-haiku-anthropic-byok", rec.Header().Get("x-router-model"),
+		"per-request resolver must land hard-pin on the installation's BYOK provider, not the boot-time default")
+}
+
+// With no BYOK and no client creds in byokOnly mode the resolver returns
+// ok=false; the hard-pin branch must surface ErrClusterUnavailable rather
+// than dispatching to the boot-time default that the request can't auth to.
+func TestService_HardPin_Compaction_ByokOnly_NoEligibleProviderErrors(t *testing.T) {
+	store := newFakePinStore()
+	fr := &fakeRouter{decision: router.Decision{Provider: "anthropic", Model: "claude-opus-4-7", Reason: "cluster"}}
+
+	resolver := func(enabled map[string]struct{}) (string, string, bool) {
+		if _, ok := enabled[providers.ProviderAnthropic]; ok {
+			return providers.ProviderAnthropic, "claude-haiku", true
+		}
+		return "", "", false
+	}
+
+	providerMap := map[string]providers.Client{providers.ProviderAnthropic: &fakeProvider{}}
+	svc := proxy.NewService(
+		fr, providerMap, nil, false, nil, store, false,
+		providers.ProviderOpenRouter, "deepseek/cheap",
+		nil,
+	).WithByokOnly(true).WithHardPinResolver(resolver)
+
+	ctx := authedCtx(uuid.New().String()) // no external keys
+	rec := httptest.NewRecorder()
+	httpReq := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(""))
+	err := svc.ProxyMessages(ctx, []byte(compactionBody), rec, httpReq)
+	require.Error(t, err, "hard-pin with no eligible provider must surface an error, not silently dispatch")
+	assert.ErrorIs(t, err, cluster.ErrClusterUnavailable,
+		"error must be ErrClusterUnavailable so handlers map it to HTTP 503")
+}
 
 func TestService_HardPin_CompactionAlwaysRoutesToHaiku(t *testing.T) {
 	store := newFakePinStore()

--- a/internal/proxy/service_test.go
+++ b/internal/proxy/service_test.go
@@ -433,21 +433,51 @@ func TestService_WithByokOnly_FiltersUnauthedProvidersFromScorer(t *testing.T) {
 		assert.Empty(t, fr.capturedReq.EnabledProviders, "BYOK-only: registered providers ineligible without creds")
 	})
 
-	t.Run("byok-on with client-supplied Bearer enables only that provider", func(t *testing.T) {
-		// Anthropic decision lets proxy complete; assertion targets EnabledProviders.
+	t.Run("byok-on Anthropic surface with x-api-key enables Anthropic only", func(t *testing.T) {
+		// On the Anthropic surface, a client x-api-key is the legitimate
+		// passthrough credential and enables Anthropic. It must NOT enable
+		// OpenRouter or any other OpenAI-compat upstream — those use a
+		// different inbound surface and reading the same header would be a
+		// cross-provider credential leak.
 		fr := &fakeRouter{decision: router.Decision{Provider: providers.ProviderAnthropic, Model: "claude-haiku-4-5"}}
 		svc := proxy.NewService(fr, providerMap, nil, false, nil, nil, false, providers.ProviderAnthropic, "claude-haiku-4-5", nil).
 			WithByokOnly(true)
 
 		rec := httptest.NewRecorder()
 		httpReq := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(""))
-		httpReq.Header.Set("Authorization", "Bearer sk-or-v1-customer-key")
+		httpReq.Header.Set("x-api-key", "sk-ant-customer-key")
 		_ = svc.ProxyMessages(context.Background(), body, rec, httpReq)
 
 		require.NotNil(t, fr.capturedReq)
-		assert.NotContains(t, fr.capturedReq.EnabledProviders, providers.ProviderAnthropic)
-		assert.Contains(t, fr.capturedReq.EnabledProviders, providers.ProviderOpenRouter,
-			"client-supplied Bearer enables the matching provider")
+		assert.Contains(t, fr.capturedReq.EnabledProviders, providers.ProviderAnthropic,
+			"client-supplied x-api-key on the Anthropic surface enables Anthropic")
+		assert.NotContains(t, fr.capturedReq.EnabledProviders, providers.ProviderOpenRouter,
+			"client header on the Anthropic surface must not leak credentials into OpenAI-compat upstreams")
+	})
+
+	t.Run("byok-on Anthropic surface with inbound Bearer (e.g. Claude Code OAuth) enables nothing", func(t *testing.T) {
+		// Regression for the 2026-05-13 prod incident: Claude Code passes an
+		// Anthropic OAuth bearer (Authorization: Bearer sk-ant-oat-…) on every
+		// request. The old code treated that header as creds for every
+		// OpenAI-compat provider (OpenRouter/Fireworks/OpenAI/Google),
+		// enabling argmax to pick OpenRouter and 401'ing at dispatch when no
+		// OpenRouter key was attached. On the Anthropic surface a bearer is
+		// never legitimate client creds (Anthropic uses x-api-key), so the
+		// enabled set must remain empty.
+		fr := &fakeRouter{decision: router.Decision{Provider: providers.ProviderAnthropic, Model: "claude-haiku-4-5"}}
+		svc := proxy.NewService(fr, providerMap, nil, false, nil, nil, false, providers.ProviderAnthropic, "claude-haiku-4-5", nil).
+			WithByokOnly(true)
+
+		rec := httptest.NewRecorder()
+		httpReq := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(""))
+		httpReq.Header.Set("Authorization", "Bearer sk-ant-oat-claude-code-token")
+		_ = svc.ProxyMessages(context.Background(), body, rec, httpReq)
+
+		require.NotNil(t, fr.capturedReq)
+		assert.NotContains(t, fr.capturedReq.EnabledProviders, providers.ProviderOpenRouter,
+			"inbound Bearer on the Anthropic surface must never enable OpenRouter")
+		assert.NotContains(t, fr.capturedReq.EnabledProviders, providers.ProviderAnthropic,
+			"a Bearer is not Anthropic auth — surface uses x-api-key")
 	})
 }
 

--- a/internal/proxy/turnloop.go
+++ b/internal/proxy/turnloop.go
@@ -2,11 +2,14 @@ package proxy
 
 import (
 	"context"
+	"fmt"
 	"net/http"
+	"sort"
 	"time"
 
 	"workweave/router/internal/observability"
 	"workweave/router/internal/router"
+	"workweave/router/internal/router/cluster"
 	"workweave/router/internal/router/handover"
 	"workweave/router/internal/router/planner"
 	"workweave/router/internal/router/sessionpin"
@@ -101,9 +104,27 @@ func (s *Service) runTurnLoop(
 	if res.TurnType == turntype.Compaction ||
 		res.TurnType == turntype.Probe ||
 		(res.TurnType == turntype.SubAgentDispatch && s.hardPinExplore) {
+		provider, model := s.hardPinProvider, s.hardPinModel
+		// In byokOnly mode the boot-time hard-pin is unsafe: it was
+		// computed over every registered provider, but the request may
+		// only have BYOK credentials for a subset. Resolve per-request
+		// against the request's enabled-providers set so compaction
+		// stays on a provider the request can authenticate to.
+		if s.hardPinResolver != nil {
+			p, m, ok := s.hardPinResolver(req.EnabledProviders)
+			if !ok {
+				log.Warn(
+					"Hard-pin: no eligible provider for request; returning ErrClusterUnavailable",
+					"turn_type", string(res.TurnType),
+					"enabled_providers", sortedEnabledKeys(req.EnabledProviders),
+				)
+				return res, fmt.Errorf("hard-pin: no eligible provider for %s: %w", res.TurnType, cluster.ErrClusterUnavailable)
+			}
+			provider, model = p, m
+		}
 		res.Decision = router.Decision{
-			Provider: s.hardPinProvider,
-			Model:    s.hardPinModel,
+			Provider: provider,
+			Model:    model,
 			Reason:   string(res.TurnType) + "_hard_pin",
 		}
 		res.StickyHit = true
@@ -369,4 +390,18 @@ func estimateSummaryTokens(s string) int {
 		return 0
 	}
 	return len(s) / 4
+}
+
+// sortedEnabledKeys returns a deterministic slice of the keys in m for
+// log-line attribution. nil/empty map yields an empty slice.
+func sortedEnabledKeys(m map[string]struct{}) []string {
+	if len(m) == 0 {
+		return []string{}
+	}
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
 }


### PR DESCRIPTION
## Summary

In managed (`byokOnly`) deployments the router was selecting OpenRouter (and other OpenAI-compat) models and dispatching upstream with no auth, getting 401'd. Concretely from a 2026-05-13 prod log: Claude Code on `/v1/messages`, router-key authed, no OpenRouter BYOK — decision lands on `openrouter/deepseek-v4-pro`, upstream returns `401 "No cookie auth credentials found"`.

Two distinct paths fed the bug. Both are fixed here.

### 1. Bearer leak in `enabledProvidersForRequest`

`ExtractClientCredentials` returns the same `Authorization: Bearer …` header for every OpenAI-compat provider (openai/google/openrouter/fireworks) — the function has no way to tell from headers alone which one the caller intended. The old `enabledProvidersForRequest` looped over all five providers and added anything non-nil, so Claude Code's Anthropic OAuth bearer (`sk-ant-oat-…`) on every `/v1/messages` request silently enabled OpenRouter+Fireworks+Google+OpenAI at routing time. Scorer happily picks OpenRouter; at dispatch the bearer is correctly dropped (router-key authed) and the upstream call goes naked.

Fix: `enabledProvidersForRequest` takes the inbound `surfaceProvider` and only consults the client header for that provider, and only when no router key is in play (mirrors the guard already in `resolveAndInjectCredentials`). `ProxyMessages` → `anthropic`, `ProxyOpenAIChatCompletion` → `openai`, gemini handler → `google`.

### 2. Boot-time hard-pin over wrong provider set

`cmd/router/main.go` used to resolve hard-pin (compaction/probe/Explore) over `availableProviders` (every registered provider) when `byokOnly`. With no env keys in managed mode, `CheapestModel` picks the cluster bundle's globally cheapest — typically an OpenRouter model. Compaction/probe traffic for every installation hard-pins to that model, bypassing `enabledProvidersForRequest` entirely, and 401s upstream.

Fix: selfhosted resolution is unchanged (`envKeyedProviders` only). Managed mode loads the cluster bundle once at boot and closes it into `Service.WithHardPinResolver`, which runs `CheapestModel` per request against `req.EnabledProviders`. No eligible provider → `cluster.ErrClusterUnavailable` (HTTP 503) — no silent dispatch to an unauthenticated upstream.

## Test plan

- [x] `go test ./...` and `go vet ./...` clean.
- [x] Updated `TestService_WithByokOnly_FiltersUnauthedProvidersFromScorer` — the previous case asserted the bug (Bearer on `/v1/messages` enables OpenRouter). New cases assert the regression: Claude Code OAuth bearer must not enable OpenRouter; x-api-key on Anthropic surface enables only Anthropic.
- [x] New `TestService_HardPin_Compaction_ByokOnly_UsesRequestResolver` — installation BYOK = Anthropic only, boot-time hard-pin set to OpenRouter; resolver overrides to the BYOK provider.
- [x] New `TestService_HardPin_Compaction_ByokOnly_NoEligibleProviderErrors` — no BYOK + no client creds returns `cluster.ErrClusterUnavailable`.
- [ ] Smoke against managed staging once deployed: confirm Claude Code traffic on /v1/messages no longer produces OpenRouter 401s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)