### PR TITLE
proxy: rename 'first turn' routing reason to 'top scorer'

### DIFF
--- a/internal/proxy/marker_internal_test.go
+++ b/internal/proxy/marker_internal_test.go
@@ -64,12 +64,12 @@ func TestRoutingMarkerFor_PlannerPaths(t *testing.T) {
 			},
 		},
 		{
-			name: "no planner ran, fresh decision: first-turn fallback reason",
+			name: "no planner ran, fresh decision: top-scorer fallback reason",
 			res: turnLoopResult{
 				Decision: decision,
 			},
 			wantContains: []string{
-				"reason: first turn",
+				"reason: top scorer",
 			},
 			wantNotContain: []string{
 				"est. save",
@@ -132,7 +132,7 @@ func TestRoutingMarkerFor_OmitsProviderParensWhenProviderMissing(t *testing.T) {
 	})
 	assert.Contains(t, got, "✦ **Weave Router** → claude-haiku-4-5 ·")
 	assert.NotContains(t, got, "()")
-	assert.Contains(t, got, "reason: first turn")
+	assert.Contains(t, got, "reason: top scorer")
 }
 
 func TestHumanReasonFromPlanner_UnknownCodePassesThrough(t *testing.T) {

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -223,7 +223,7 @@ func routingReasonShort(res turnLoopResult) string {
 	if res.StickyHit {
 		return "tool-result follow-up"
 	}
-	return "first turn"
+	return "top scorer"
 }
 
 // humanReasonFromPlanner maps planner.Reason* codes to marker prose. Unknown
@@ -237,7 +237,7 @@ func humanReasonFromPlanner(code string) string {
 	case planner.ReasonSameModel:
 		return "scorer matches the pin"
 	case planner.ReasonNoPin:
-		return "first turn"
+		return "top scorer"
 	case planner.ReasonNoPriorUsage:
 		return "no cache stats yet"
 	case planner.ReasonPinModelMissing:

--- a/internal/translate/translate_test.go
+++ b/internal/translate/translate_test.go
@@ -616,8 +616,8 @@ func TestAnthropicSSETranslator_RoutingMarkerEmittedBeforeUpstreamContent(t *tes
 
 func TestAnthropicSSETranslator_RoutingMarkerEmittedOnEmptyUpstream(t *testing.T) {
 	rec := httptest.NewRecorder()
-	marker := "✦ **Weave Router** → gpt-5-mini (openai) · reason: first turn\n\n"
-	markerProse := "✦ **Weave Router** → gpt-5-mini (openai) · reason: first turn"
+	marker := "✦ **Weave Router** → gpt-5-mini (openai) · reason: top scorer\n\n"
+	markerProse := "✦ **Weave Router** → gpt-5-mini (openai) · reason: top scorer"
 	translator := translate.NewAnthropicSSETranslator(rec, "claude-opus-4-7", nil).
 		WithRoutingMarker(marker)
 


### PR DESCRIPTION
## Summary

- The marker reason `first turn` named the *trigger* (no prior pin) rather than the actual decision logic.
- The cluster scorer always picks the highest-scoring model — independent of turn number — so `top scorer` is a more accurate description of what the router did.
- Applies to both the `routingReasonShort` fallback and the `planner.ReasonNoPin` case in `humanReasonFromPlanner`.

## Test plan

- [x] `go test ./internal/proxy/... ./internal/translate/...` passes
- [ ] Spot-check marker output in a staging request shows `reason: top scorer`

🤖 Generated with [Claude Code](https://claude.com/claude-code)