### PR TITLE
router: default ROUTER_HARD_PIN_EXPLORE to true

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -94,7 +94,7 @@ ROUTER_STICKY_DECISION_TTL_MS=0
 # Hard pins — bypass the cluster scorer entirely. Debugging only.
 # ROUTER_HARD_PIN_MODEL=
 # ROUTER_HARD_PIN_PROVIDER=
-# ROUTER_HARD_PIN_EXPLORE=
+# ROUTER_HARD_PIN_EXPLORE=true  # default true — set false to let Explore sub-agents go through the scorer
 
 # Semantic cache for routing decisions (optional).
 # ROUTER_SEMANTIC_CACHE_ENABLED=false

--- a/cmd/router/main.go
+++ b/cmd/router/main.go
@@ -297,7 +297,7 @@ func main() {
 		logger.Info("Session pin store enabled (sliding 1h TTL, hourly sweep)")
 	}
 
-	hardPinExplore := config.GetOr("ROUTER_HARD_PIN_EXPLORE", "false") == "true"
+	hardPinExplore := config.GetOr("ROUTER_HARD_PIN_EXPLORE", "true") == "true"
 	// Pin to a model whose provider has actual deployment-level auth — a
 	// BYOK-only registered provider would 401 here since hard-pin compaction
 	// runs on every installation, including ones without their own BYOK.


### PR DESCRIPTION
## Summary
- Flip the default of `ROUTER_HARD_PIN_EXPLORE` from `false` to `true` in `cmd/router/main.go`.
- Update the `.env.example` comment so the new default is discoverable.

## Why
Explore sub-agent dispatches (`turntype.SubAgentDispatch`) previously bypassed the hard-pin path and re-ran the cluster scorer every turn. Because each dispatch has a fresh prompt embedding, the same Explore agent in a single session could land on kimi, then gemini, then something else — visible in the UI as `agent (explore)` decisions that keep shifting model while the main session is pinned.

That jitter:
- Wrecks eval signal stability (same workload scores against different models per dispatch).
- Is confusing UX (users see the pin "broken" mid-session even though it isn't).
- Defeats the purpose of having a cheap handover model resolved at boot.

With the new default, `SubAgentDispatch` goes through the same `Compaction`/`Probe` hard-pin branch in `internal/proxy/turnloop.go`, landing on the boot-resolved hard-pin model. Operators who want to let Explore go through the scorer can set `ROUTER_HARD_PIN_EXPLORE=false`.

## Test plan
- [x] `go build ./...`
- [x] `go test ./cmd/router/... ./internal/proxy/...`
- [ ] Verify locally that Explore dispatches show `agent_explore_hard_pin` reason instead of `agent (explore)` scorer reasons