### PR TITLE
router: stop classifying main-loop as SubAgentDispatch

### DIFF
--- a/internal/router/turntype/detect.go
+++ b/internal/router/turntype/detect.go
@@ -60,7 +60,7 @@ func DetectFromEnvelope(env *translate.RequestEnvelope, feats translate.RoutingF
 	if isCompaction(systemText) {
 		return Compaction
 	}
-	if isSubAgentDispatch(env.MetadataUserID(), systemText, subAgentHint) {
+	if isSubAgentDispatch(env.MetadataUserID(), subAgentHint) {
 		return SubAgentDispatch
 	}
 	if feats.LastKind == "tool_result" {
@@ -89,15 +89,19 @@ func isCompaction(systemText string) bool {
 // isSubAgentDispatch reports whether the request originates from a
 // sub-agent dispatch. Claude Code packs sub-agent identity into
 // metadata.user_id as "subagent:<type>"; non-Anthropic clients pass it
-// via the x-weave-subagent-type header. System-prompt marker phrases
-// are a third fallback.
-func isSubAgentDispatch(metadataUserID, systemText, subAgentHint string) bool {
+// via the x-weave-subagent-type header.
+//
+// A system-prompt string-match fallback used to live here ("subagent_type"
+// / "sub-agent") but was removed: Claude Code's main-loop system prompt
+// includes the Agent tool description, which contains the literal
+// "subagent_type" parameter name. That false-positive misclassified every
+// main-loop turn as a sub-agent and, with ROUTER_HARD_PIN_EXPLORE=true,
+// hard-pinned them all to the cheap model. Per this file's invariant,
+// false negatives (returning MainLoop) are safe — the cluster scorer
+// runs normally — so we keep detection to the two authoritative signals.
+func isSubAgentDispatch(metadataUserID, subAgentHint string) bool {
 	if subAgentHint != "" {
 		return true
 	}
-	if strings.HasPrefix(metadataUserID, "subagent:") {
-		return true
-	}
-	lower := strings.ToLower(systemText)
-	return strings.Contains(lower, "subagent_type") || strings.Contains(lower, "sub-agent")
+	return strings.HasPrefix(metadataUserID, "subagent:")
 }

--- a/internal/router/turntype/detect_test.go
+++ b/internal/router/turntype/detect_test.go
@@ -75,14 +75,14 @@ func TestDetectFromEnvelope_Anthropic(t *testing.T) {
 			want: turntype.SubAgentDispatch,
 		},
 		{
-			name: "sub-agent via system prompt sub-agent marker",
-			body: `{"model":"claude-haiku-4-5","system":"You are a sub-agent for the Explore task.","messages":[{"role":"user","content":"list files"}]}`,
-			want: turntype.SubAgentDispatch,
-		},
-		{
-			name: "sub-agent via system prompt subagent_type marker",
-			body: `{"model":"claude-haiku-4-5","system":"subagent_type: Explore","messages":[{"role":"user","content":"grep"}]}`,
-			want: turntype.SubAgentDispatch,
+			// Regression guard: Claude Code's main-loop system prompt embeds
+			// the Agent tool description, which contains "subagent_type" as
+			// a parameter name. That used to trigger SubAgentDispatch and
+			// hard-pin every turn to the cheap model. Detection now requires
+			// the metadata.user_id or x-weave-subagent-type signal.
+			name: "main_loop with Agent tool description mentioning subagent_type stays main_loop",
+			body: `{"model":"claude-opus-4-7","system":"Use the Agent tool with a subagent_type parameter to dispatch sub-agents.","messages":[{"role":"user","content":"hi"}]}`,
+			want: turntype.MainLoop,
 		},
 		{
 			name: "sub-agent via x-weave-subagent-type header hint",
@@ -197,12 +197,13 @@ func TestDetectFromEnvelope_OpenAI(t *testing.T) {
 			want: turntype.SubAgentDispatch,
 		},
 		{
-			name: "sub-agent via system message marker",
+			// Regression guard — see TestDetectFromEnvelope_Anthropic.
+			name: "system message mentioning subagent_type stays main_loop",
 			body: `{"model":"gpt-4o","messages":[
-				{"role":"system","content":"You are a sub-agent for the Explore task."},
+				{"role":"system","content":"Use the Agent tool with a subagent_type parameter."},
 				{"role":"user","content":"list files"}
 			]}`,
-			want: turntype.SubAgentDispatch,
+			want: turntype.MainLoop,
 		},
 		{
 			name: "last message assistant is main_loop",
@@ -271,12 +272,13 @@ func TestDetectFromEnvelope_Gemini(t *testing.T) {
 			want: turntype.SubAgentDispatch,
 		},
 		{
-			name: "sub-agent via systemInstruction marker",
+			// Regression guard — see TestDetectFromEnvelope_Anthropic.
+			name: "systemInstruction mentioning subagent_type stays main_loop",
 			body: `{
-				"systemInstruction":{"parts":[{"text":"You are a sub-agent for the Explore task."}]},
+				"systemInstruction":{"parts":[{"text":"Use the Agent tool with a subagent_type parameter."}]},
 				"contents":[{"role":"user","parts":[{"text":"list files"}]}]
 			}`,
-			want: turntype.SubAgentDispatch,
+			want: turntype.MainLoop,
 		},
 		{
 			name: "trailing model message is main_loop",


### PR DESCRIPTION
## Summary
Tighten `isSubAgentDispatch` to rely only on the `x-weave-subagent-type` header and `metadata.user_id="subagent:<type>"` prefix. Drop the system-prompt string fallback (`"subagent_type"` / `"sub-agent"`).

## Why this matters
Claude Code's main-loop system prompt embeds the Agent tool description, which contains the literal `subagent_type` parameter name. The old fallback matched on that string, so **every** Claude Code request that exposes the Agent tool was misclassified as `SubAgentDispatch`.

Combined with #98 (which defaulted `ROUTER_HARD_PIN_EXPLORE=true`), this hard-pinned every turn — main conversation, tool-result follow-ups, everything — to the cheap model instead of letting the cluster scorer and session pin run. Symptom in the wild: every Claude Code UI chip read "Weave Router → qwen/qwen3.5-flash-02-23 · reason: hard pin (compaction / sub-agent)".

## Fix
- `isSubAgentDispatch` now only checks the header + metadata signals. Those are what Claude Code and the Anthropic SDK actually emit for real sub-agent dispatches.
- File's own invariant covers this: false negatives (returning `MainLoop`) are safe; the scorer routes normally.

## Tests
- New regression guards: system text containing `subagent_type` must classify as `MainLoop`.
- Dropped the now-obsolete positive cases that exercised the string fallback (Anthropic, OpenAI, Gemini detectors all updated).
- `go test ./internal/router/turntype/... ./internal/proxy/... ./cmd/router/...` passes.

## Test plan
- [x] `go build ./...`
- [x] Unit tests pass with regression guards
- [ ] Verify in docker that main-loop opus turns show `decision_reason="cluster:v0.37 ..."` not `sub_agent_dispatch_hard_pin`
- [ ] Verify real Explore dispatches (Claude Code's `Agent({...subagent_type: "Explore"...})`) still classify as `SubAgentDispatch` (they carry `metadata.user_id="subagent:Explore"`)

## Relation to #98
This is the urgent follow-up. #98 turned the hard-pin path on by default, which exposed the detection bug. Both PRs need to land for the new default to be safe; this one can land first.