### PR TITLE
router: enforce requested-model tier ceiling on routing decisions

### DIFF
--- a/cmd/router/main.go
+++ b/cmd/router/main.go
@@ -345,15 +345,15 @@ func main() {
 	// whose provider is in the request's enabled set. Nil when the bundle
 	// can't load — the proxy then leaves all decisions un-clamped (preserves
 	// pre-tier-ceiling behavior).
-	var tierClampResolver func(map[string]struct{}, capability.Tier) (string, string, bool)
+	var tierClampResolver func(map[string]struct{}, map[string]struct{}, capability.Tier) (string, string, bool)
 	{
 		reqVersion := config.GetOr("ROUTER_CLUSTER_VERSION", cluster.LatestVersion)
 		if version, vErr := cluster.ResolveVersion(reqVersion); vErr == nil {
 			if bundle, bErr := cluster.LoadBundle(version); bErr == nil {
 				meta, registry := bundle.Metadata, bundle.Registry
-				tierClampResolver = func(enabled map[string]struct{}, ceiling capability.Tier) (string, string, bool) {
+				tierClampResolver = func(enabled, excluded map[string]struct{}, ceiling capability.Tier) (string, string, bool) {
 					allowed := capability.AllowedAtOrBelow(ceiling)
-					return cluster.CheapestModelInSet(meta, registry, enabled, allowed)
+					return cluster.CheapestModelInSet(meta, registry, enabled, excluded, allowed)
 				}
 				logger.Info("Tier-clamp resolver wired", "version", version)
 			} else {

--- a/cmd/router/main.go
+++ b/cmd/router/main.go
@@ -339,6 +339,31 @@ func main() {
 		}
 	}
 
+	// Tier-clamp resolver enforces the requested-model ceiling. Loads the
+	// default cluster bundle once and, on each call, returns the cheapest
+	// deployed model whose capability tier is at or below the ceiling and
+	// whose provider is in the request's enabled set. Nil when the bundle
+	// can't load — the proxy then leaves all decisions un-clamped (preserves
+	// pre-tier-ceiling behavior).
+	var tierClampResolver func(map[string]struct{}, capability.Tier) (string, string, bool)
+	{
+		reqVersion := config.GetOr("ROUTER_CLUSTER_VERSION", cluster.LatestVersion)
+		if version, vErr := cluster.ResolveVersion(reqVersion); vErr == nil {
+			if bundle, bErr := cluster.LoadBundle(version); bErr == nil {
+				meta, registry := bundle.Metadata, bundle.Registry
+				tierClampResolver = func(enabled map[string]struct{}, ceiling capability.Tier) (string, string, bool) {
+					allowed := capability.AllowedAtOrBelow(ceiling)
+					return cluster.CheapestModelInSet(meta, registry, enabled, allowed)
+				}
+				logger.Info("Tier-clamp resolver wired", "version", version)
+			} else {
+				logger.Warn("Tier-clamp resolver disabled: cluster bundle failed to load", "err", bErr, "version", version)
+			}
+		} else {
+			logger.Warn("Tier-clamp resolver disabled: could not resolve cluster version", "err", vErr)
+		}
+	}
+
 	// Default-eligible set for proxy.Service: env-keyed providers + the
 	// Anthropic passthrough path. BYOK and client-supplied credentials add
 	// to this set per-request inside enabledProvidersForRequest.
@@ -386,6 +411,7 @@ func main() {
 		WithByokOnly(byokOnly).
 		WithDeploymentKeyedProviders(deploymentEligible).
 		WithHardPinResolver(hardPinResolver).
+		WithTierClampResolver(tierClampResolver).
 		WithPlannerEnabled(plannerEnabled).
 		WithPlanner(plannerCfg).
 		WithSummarizer(summarizer).

--- a/internal/proxy/marker_internal_test.go
+++ b/internal/proxy/marker_internal_test.go
@@ -6,9 +6,52 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"workweave/router/internal/router"
+	"workweave/router/internal/router/capability"
 	"workweave/router/internal/router/planner"
 	"workweave/router/internal/translate"
 )
+
+func TestRoutingMarkerFor_TierClampNote(t *testing.T) {
+	t.Parallel()
+
+	t.Run("haiku-ceiling clamp suggests sonnet upsell", func(t *testing.T) {
+		res := turnLoopResult{
+			Decision:      router.Decision{Model: "claude-haiku-4-5", Provider: "anthropic"},
+			TierClamped:   true,
+			PreClampModel: "deepseek/deepseek-v4-pro",
+			RequestedTier: capability.TierLow,
+		}
+		got := routingMarkerFor(res)
+		assert.Contains(t, got, "second-choice pick")
+		assert.Contains(t, got, "deepseek/deepseek-v4-pro")
+		assert.Contains(t, got, "low tier")
+		assert.Contains(t, got, "claude-sonnet-4-5")
+	})
+
+	t.Run("sonnet-ceiling clamp suggests opus upsell", func(t *testing.T) {
+		res := turnLoopResult{
+			Decision:      router.Decision{Model: "claude-sonnet-4-5", Provider: "anthropic"},
+			TierClamped:   true,
+			PreClampModel: "claude-opus-4-7",
+			RequestedTier: capability.TierMid,
+		}
+		got := routingMarkerFor(res)
+		assert.Contains(t, got, "claude-opus-4-7")
+		assert.Contains(t, got, "mid tier")
+		assert.Contains(t, got, "claude-opus-4-7 to unlock")
+	})
+
+	t.Run("no clamp emits no note", func(t *testing.T) {
+		res := turnLoopResult{
+			Decision:      router.Decision{Model: "claude-opus-4-7", Provider: "anthropic"},
+			TierClamped:   false,
+			RequestedTier: capability.TierHigh,
+		}
+		got := routingMarkerFor(res)
+		assert.NotContains(t, got, "second-choice")
+		assert.NotContains(t, got, "would have used")
+	})
+}
 
 func TestRoutingMarkerFor_PlannerPaths(t *testing.T) {
 	decision := router.Decision{Model: "deepseek/deepseek-v4-pro", Provider: "openrouter"}

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -17,6 +17,7 @@ import (
 	"workweave/router/internal/providers"
 	"workweave/router/internal/router"
 	"workweave/router/internal/router/cache"
+	"workweave/router/internal/router/capability"
 	"workweave/router/internal/router/handover"
 	"workweave/router/internal/router/planner"
 	"workweave/router/internal/router/pricing"
@@ -65,6 +66,12 @@ type Service struct {
 	// this request — the orchestrator surfaces ErrClusterUnavailable rather
 	// than silently falling back.
 	hardPinResolver func(enabled map[string]struct{}) (provider, model string, ok bool)
+	// tierClampResolver enforces the requested-model tier ceiling: returns
+	// the cheapest deployed model whose tier ≤ ceiling and whose provider
+	// is in the request's enabled set. Nil disables the clamp. See
+	// WithTierClampResolver and turnloop.go's clampToCeiling for the call
+	// sites.
+	tierClampResolver func(enabled map[string]struct{}, ceiling capability.Tier) (provider, model string, ok bool)
 	// telemetry is an optional repository for persisting per-request telemetry.
 	telemetry TelemetryRepository
 	// byokOnly disables deployment-level credential fallback. When true, a
@@ -405,6 +412,18 @@ func (s *Service) WithHardPinResolver(resolver func(enabled map[string]struct{})
 // substitution. See [Service.defaultBaselineModel] for rationale.
 func (s *Service) WithDefaultBaselineModel(model string) *Service {
 	s.defaultBaselineModel = model
+	return s
+}
+
+// WithTierClampResolver installs the resolver used by the tier-ceiling
+// guard. Given a request's enabled-providers set and a tier ceiling, it
+// returns the cheapest registry-deployed model whose tier is ≤ ceiling
+// and whose provider is enabled. ok=false means no in-ceiling model is
+// routable for this request — the orchestrator preserves the original
+// (unclamped) decision rather than failing the turn. Nil resolver
+// disables clamping (preserves pre-tier-ceiling behavior).
+func (s *Service) WithTierClampResolver(resolver func(enabled map[string]struct{}, ceiling capability.Tier) (provider, model string, ok bool)) *Service {
+	s.tierClampResolver = resolver
 	return s
 }
 
@@ -977,7 +996,7 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 		})
 	}
 
-	log.Info("ProxyMessages complete", "requested_model", feats.Model, "baseline_model", s.baselineFor(feats.Model), "decision_model", decision.Model, "decision_provider", decision.Provider, "decision_reason", decision.Reason, "estimated_input_tokens", feats.Tokens, "has_tools", feats.HasTools, "message_count", feats.MessageCount, "last_kind", feats.LastKind, "last_preview", feats.LastPreview, "embed_input", embedInput, "cross_format", crossFormat, "sticky_hit", stickyHit, "route_ms", routeMs, "proxy_ms", proxyMs, "proxy_err", proxyErr, "upstream_status", upstreamStatus(proxyErr))
+	log.Info("ProxyMessages complete", "requested_model", feats.Model, "baseline_model", s.baselineFor(feats.Model), "decision_model", decision.Model, "decision_provider", decision.Provider, "decision_reason", decision.Reason, "requested_tier", routeRes.RequestedTier.String(), "decision_tier", capability.TierFor(decision.Model).String(), "tier_clamped", routeRes.TierClamped, "pre_clamp_model", routeRes.PreClampModel, "estimated_input_tokens", feats.Tokens, "has_tools", feats.HasTools, "message_count", feats.MessageCount, "last_kind", feats.LastKind, "last_preview", feats.LastPreview, "embed_input", embedInput, "cross_format", crossFormat, "sticky_hit", stickyHit, "route_ms", routeMs, "proxy_ms", proxyMs, "proxy_err", proxyErr, "upstream_status", upstreamStatus(proxyErr))
 	return proxyErr
 }
 
@@ -1086,6 +1105,10 @@ func (s *Service) recordTurnUsage(res turnLoopResult, in, out, cacheCreation, ca
 		EndedAt:           time.Now(),
 	}
 	key := res.SessionKey
+	role := res.PinRole
+	if role == "" {
+		role = sessionpin.DefaultRole
+	}
 
 	// Keep the in-proc LRU coherent with the DB writeback. Without this,
 	// loadPin's Tier-1 hit serves a stale pin with zero usage and the
@@ -1093,7 +1116,7 @@ func (s *Service) recordTurnUsage(res turnLoopResult, in, out, cacheCreation, ca
 	// resetting under typical agentic turn cadence), which silently
 	// disables EV-based switching for all active sessions.
 	if s.pinCache != nil {
-		pinCacheKey := sessionPinCacheKey(key, sessionpin.DefaultRole)
+		pinCacheKey := sessionPinCacheKey(key, role)
 		if pin, ok := s.pinCache.Get(pinCacheKey); ok {
 			pin.LastInputTokens = usage.InputTokens
 			pin.LastCachedReadTokens = usage.CachedReadTokens
@@ -1108,7 +1131,7 @@ func (s *Service) recordTurnUsage(res turnLoopResult, in, out, cacheCreation, ca
 	case s.usageWriteSem <- struct{}{}:
 		go func() {
 			defer func() { <-s.usageWriteSem }()
-			if err := s.pinStore.UpdateUsage(context.Background(), key, sessionpin.DefaultRole, usage); err != nil {
+			if err := s.pinStore.UpdateUsage(context.Background(), key, role, usage); err != nil {
 				observability.Get().Debug("session pin usage writeback failed", "err", err)
 			}
 		}()
@@ -1633,6 +1656,6 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 		})
 	}
 
-	log.Info("ProxyOpenAIChatCompletion complete", "requested_model", feats.Model, "baseline_model", s.baselineFor(feats.Model), "decision_model", decision.Model, "decision_provider", decision.Provider, "decision_reason", decision.Reason, "estimated_input_tokens", feats.Tokens, "has_tools", feats.HasTools, "embed_input", embedInput, "cross_format", crossFormat, "sticky_hit", stickyHit, "pin_tier", pinTier, "turn_type", string(tt), "route_ms", routeMs, "proxy_ms", proxyMs, "proxy_err", proxyErr, "upstream_status", upstreamStatus(proxyErr))
+	log.Info("ProxyOpenAIChatCompletion complete", "requested_model", feats.Model, "baseline_model", s.baselineFor(feats.Model), "decision_model", decision.Model, "decision_provider", decision.Provider, "decision_reason", decision.Reason, "requested_tier", routeRes.RequestedTier.String(), "decision_tier", capability.TierFor(decision.Model).String(), "tier_clamped", routeRes.TierClamped, "pre_clamp_model", routeRes.PreClampModel, "estimated_input_tokens", feats.Tokens, "has_tools", feats.HasTools, "embed_input", embedInput, "cross_format", crossFormat, "sticky_hit", stickyHit, "pin_tier", pinTier, "turn_type", string(tt), "route_ms", routeMs, "proxy_ms", proxyMs, "proxy_err", proxyErr, "upstream_status", upstreamStatus(proxyErr))
 	return proxyErr
 }

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -67,11 +67,12 @@ type Service struct {
 	// than silently falling back.
 	hardPinResolver func(enabled map[string]struct{}) (provider, model string, ok bool)
 	// tierClampResolver enforces the requested-model tier ceiling: returns
-	// the cheapest deployed model whose tier ≤ ceiling and whose provider
-	// is in the request's enabled set. Nil disables the clamp. See
+	// the cheapest deployed model whose tier ≤ ceiling, whose provider is
+	// in the request's enabled set, and which is NOT in the request's
+	// excluded-models denylist. Nil disables the clamp. See
 	// WithTierClampResolver and turnloop.go's clampToCeiling for the call
 	// sites.
-	tierClampResolver func(enabled map[string]struct{}, ceiling capability.Tier) (provider, model string, ok bool)
+	tierClampResolver func(enabled, excluded map[string]struct{}, ceiling capability.Tier) (provider, model string, ok bool)
 	// telemetry is an optional repository for persisting per-request telemetry.
 	telemetry TelemetryRepository
 	// byokOnly disables deployment-level credential fallback. When true, a
@@ -454,7 +455,7 @@ func (s *Service) WithDefaultBaselineModel(model string) *Service {
 // routable for this request — the orchestrator preserves the original
 // (unclamped) decision rather than failing the turn. Nil resolver
 // disables clamping (preserves pre-tier-ceiling behavior).
-func (s *Service) WithTierClampResolver(resolver func(enabled map[string]struct{}, ceiling capability.Tier) (provider, model string, ok bool)) *Service {
+func (s *Service) WithTierClampResolver(resolver func(enabled, excluded map[string]struct{}, ceiling capability.Tier) (provider, model string, ok bool)) *Service {
 	s.tierClampResolver = resolver
 	return s
 }

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -147,7 +147,39 @@ func routingMarkerFor(res turnLoopResult) string {
 	if reason := routingReasonShort(res); reason != "" {
 		parts = append(parts, "reason: "+reason)
 	}
+	if note := clampNote(res); note != "" {
+		parts = append(parts, note)
+	}
 	return strings.Join(parts, " · ") + "\n\n"
+}
+
+// clampNote surfaces the tier-ceiling clamp to the caller when it fired:
+// names the runner-up model the scorer actually preferred and points at
+// the action that would unlock it (request a higher-tier model). Empty
+// string when no clamp occurred.
+func clampNote(res turnLoopResult) string {
+	if !res.TierClamped || res.PreClampModel == "" {
+		return ""
+	}
+	upsell := upsellModelFor(res.RequestedTier)
+	if upsell == "" {
+		return fmt.Sprintf("second-choice pick (would have used %s — capped to your requested %s tier)", res.PreClampModel, res.RequestedTier.String())
+	}
+	return fmt.Sprintf("second-choice pick (would have used %s — capped to your requested %s tier; request %s to unlock higher-tier picks)", res.PreClampModel, res.RequestedTier.String(), upsell)
+}
+
+// upsellModelFor returns the conventional next-tier-up model name to
+// suggest in the clamp note. High tier has no upsell. Unknown returns
+// empty so the marker falls back to the no-upsell wording.
+func upsellModelFor(t capability.Tier) string {
+	switch t {
+	case capability.TierLow:
+		return "claude-sonnet-4-5"
+	case capability.TierMid:
+		return "claude-opus-4-7"
+	default:
+		return ""
+	}
 }
 
 // closingMarkerFor returns a callback that formats a "saved $X vs <baseline>"

--- a/internal/proxy/service_session_pin_test.go
+++ b/internal/proxy/service_session_pin_test.go
@@ -14,6 +14,7 @@ import (
 	"workweave/router/internal/providers"
 	"workweave/router/internal/proxy"
 	"workweave/router/internal/router"
+	"workweave/router/internal/router/capability"
 	"workweave/router/internal/router/cluster"
 	"workweave/router/internal/router/sessionpin"
 
@@ -553,4 +554,88 @@ func TestService_HardPin_OpenAI_SubAgentHeaderHintRoutesToHardPin(t *testing.T) 
 
 	assert.Equal(t, 0, fr.routeCalls, "x-weave-subagent-type must trigger Explore hard-pin")
 	assert.Equal(t, "gpt-4o-mini", rec.Header().Get("x-router-model"))
+}
+
+// haikuClampBody requests a Low-tier model (haiku); the scorer is
+// stubbed to return an Opus (High) pick, which violates the ceiling and
+// must be clamped down to a Low-tier alternative.
+const haikuClampBody = `{
+	"model":"claude-haiku-4-5",
+	"system":"sys",
+	"messages":[{"role":"user","content":"summarize this"}]
+}`
+
+// TestService_TierClamp_HaikuRequestedClampsHighScore covers the
+// haiku-tier leak that motivated this change: a background haiku call
+// whose scorer recommended an Opus/DeepSeek-pro/Gemini-pro pick must be
+// clamped to a Low-tier alternative.
+func TestService_TierClamp_HaikuRequestedClampsHighScore(t *testing.T) {
+	store := newFakePinStore()
+	// Scorer returns High-tier model: must be rewritten.
+	fr := &fakeRouter{decision: router.Decision{Provider: "anthropic", Model: "claude-opus-4-7", Reason: "cluster:v0.37"}}
+
+	svc := newPinSvc(fr, store).WithTierClampResolver(func(_ map[string]struct{}, ceiling capability.Tier) (string, string, bool) {
+		require.Equal(t, capability.TierLow, ceiling, "haiku requested → Low ceiling")
+		return providers.ProviderAnthropic, "claude-haiku-4-5", true
+	})
+
+	ctx := authedCtx(uuid.New().String())
+	rec := httptest.NewRecorder()
+	httpReq := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(""))
+	require.NoError(t, svc.ProxyMessages(ctx, []byte(haikuClampBody), rec, httpReq))
+
+	assert.Equal(t, "claude-haiku-4-5", rec.Header().Get("x-router-model"), "decision must be clamped to in-ceiling model")
+}
+
+// TestService_TierClamp_OpusRequestedNoClamp confirms High-tier
+// requests (opus) leave any decision unchanged — there's no ceiling
+// to enforce above High.
+func TestService_TierClamp_OpusRequestedNoClamp(t *testing.T) {
+	store := newFakePinStore()
+	// Scorer returns a High model; opus ceiling allows it.
+	fr := &fakeRouter{decision: router.Decision{Provider: providers.ProviderAnthropic, Model: "claude-opus-4-7", Reason: "cluster:v0.37"}}
+
+	resolverCalls := 0
+	svc := newPinSvc(fr, store).WithTierClampResolver(func(_ map[string]struct{}, _ capability.Tier) (string, string, bool) {
+		resolverCalls++
+		return "", "", false
+	})
+
+	ctx := authedCtx(uuid.New().String())
+	rec := httptest.NewRecorder()
+	httpReq := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(""))
+	require.NoError(t, svc.ProxyMessages(ctx, []byte(pinTestBody), rec, httpReq))
+
+	assert.Equal(t, "claude-opus-4-7", rec.Header().Get("x-router-model"), "opus ceiling allows High picks unchanged")
+	assert.Equal(t, 0, resolverCalls, "resolver must not be called when decision is at or below ceiling")
+}
+
+// TestService_TierClamp_PinAboveCeilingIsClamped covers the original
+// leak directly: a session pin from a previous opus turn points at
+// deepseek-v4-pro (High); the next turn requests haiku (Low ceiling) —
+// the pin's stored model must be clamped on read, not blindly served.
+// (Pin keying by tier role prevents this in practice; this test guards
+// the defense-in-depth clamp on the pin-hit path in case roles collide.)
+func TestService_TierClamp_PinAboveCeilingIsClamped(t *testing.T) {
+	store := newFakePinStore()
+	store.hasPin = true
+	store.pin = sessionpin.Pin{
+		Provider:      providers.ProviderAnthropic,
+		Model:         "claude-opus-4-7",
+		Reason:        "cluster:v0.37",
+		PinnedUntil:   time.Now().Add(30 * time.Minute),
+		FirstPinnedAt: time.Now().Add(-5 * time.Minute),
+	}
+	fr := &fakeRouter{decision: router.Decision{Provider: providers.ProviderAnthropic, Model: "claude-opus-4-7", Reason: "cluster:v0.37"}}
+
+	svc := newPinSvc(fr, store).WithTierClampResolver(func(_ map[string]struct{}, _ capability.Tier) (string, string, bool) {
+		return providers.ProviderAnthropic, "claude-haiku-4-5", true
+	})
+
+	ctx := authedCtx(uuid.New().String())
+	rec := httptest.NewRecorder()
+	httpReq := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(""))
+	require.NoError(t, svc.ProxyMessages(ctx, []byte(haikuClampBody), rec, httpReq))
+
+	assert.Equal(t, "claude-haiku-4-5", rec.Header().Get("x-router-model"))
 }

--- a/internal/proxy/service_session_pin_test.go
+++ b/internal/proxy/service_session_pin_test.go
@@ -639,3 +639,50 @@ func TestService_TierClamp_PinAboveCeilingIsClamped(t *testing.T) {
 
 	assert.Equal(t, "claude-haiku-4-5", rec.Header().Get("x-router-model"))
 }
+
+// TestService_TierClamp_StaleFlagClearedOnUnclampedFinal regression-
+// guards the case Cursor flagged on PR #100: when the orchestrator
+// clamps an early-stage decision (e.g. the fresh scorer output) and a
+// later stage picks an in-ceiling pin without needing to clamp, the
+// TierClamped/PreClampModel fields must reflect the *final* decision —
+// otherwise the structured log falsely reports a clamp that didn't
+// actually affect the served model.
+func TestService_TierClamp_StaleFlagClearedOnUnclampedFinal(t *testing.T) {
+	store := newFakePinStore()
+	// Pin is in-ceiling for an opus request (TierHigh) — no clamp at the
+	// pin-hit step.
+	store.hasPin = true
+	store.pin = sessionpin.Pin{
+		Provider:      providers.ProviderAnthropic,
+		Model:         "claude-opus-4-7",
+		Reason:        "cluster:v0.37",
+		PinnedUntil:   time.Now().Add(30 * time.Minute),
+		FirstPinnedAt: time.Now().Add(-5 * time.Minute),
+		// Prior-turn usage so the planner has eviction-cost evidence to
+		// weigh against the fresh decision; with this set the planner
+		// returns OutcomeStay (cache-warm beats switch).
+		LastInputTokens: 50000,
+	}
+	// Fresh scorer returns a violating model (haiku ceiling would have
+	// clamped); irrelevant here because we go through the High path.
+	fr := &fakeRouter{decision: router.Decision{Provider: providers.ProviderAnthropic, Model: "claude-opus-4-7", Reason: "cluster:v0.37"}}
+
+	clampCalls := 0
+	svc := newPinSvc(fr, store).WithTierClampResolver(func(_ map[string]struct{}, _ capability.Tier) (string, string, bool) {
+		clampCalls++
+		// Resolver should never need to fire because all decisions are
+		// at or below the High ceiling.
+		return providers.ProviderAnthropic, "claude-haiku-4-5", true
+	})
+
+	ctx := authedCtx(uuid.New().String())
+	rec := httptest.NewRecorder()
+	httpReq := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(""))
+	require.NoError(t, svc.ProxyMessages(ctx, []byte(pinTestBody), rec, httpReq))
+
+	assert.Equal(t, "claude-opus-4-7", rec.Header().Get("x-router-model"))
+	assert.Equal(t, 0, clampCalls, "no clamp should fire under a High ceiling with in-ceiling models")
+	// Implicit: by passing through without clamp, the log would record
+	// tier_clamped=false / pre_clamp_model="" — the regression would
+	// have left a stale true here from a prior-stage clamp.
+}

--- a/internal/proxy/service_session_pin_test.go
+++ b/internal/proxy/service_session_pin_test.go
@@ -556,6 +556,45 @@ func TestService_HardPin_OpenAI_SubAgentHeaderHintRoutesToHardPin(t *testing.T) 
 	assert.Equal(t, "gpt-4o-mini", rec.Header().Get("x-router-model"))
 }
 
+// TestService_HardPin_BypassesTierCeiling regression-guards the PR #100
+// finding: ROUTER_HARD_PIN_MODEL is an explicit operator opt-in that
+// MUST win over the requested-model tier ceiling. Before the fix, the
+// orchestrator clamped the hard-pin decision and silently rewrote the
+// operator's chosen model to the cheapest in-ceiling alternative when
+// the operator pinned an over-ceiling (or unknown-tier) model.
+func TestService_HardPin_BypassesTierCeiling(t *testing.T) {
+	store := newFakePinStore()
+	fr := &fakeRouter{decision: router.Decision{Provider: providers.ProviderAnthropic, Model: "claude-opus-4-7", Reason: "cluster:v0.37"}}
+
+	// Hard-pin set to opus (High); inbound model haiku → ceiling Low.
+	// Pre-fix, clampToCeiling would rewrite opus → the resolver's pick.
+	svc := proxy.NewService(
+		fr,
+		map[string]providers.Client{providers.ProviderAnthropic: &fakeProvider{}},
+		nil,
+		false,
+		nil,
+		store,
+		false,
+		providers.ProviderAnthropic,
+		"claude-opus-4-7",
+		nil,
+	).WithTierClampResolver(func(_, _ map[string]struct{}, _ capability.Tier) (string, string, bool) {
+		// If this fires for a hard-pin decision, the bypass is broken.
+		return providers.ProviderAnthropic, "claude-haiku-4-5", true
+	})
+
+	ctx := authedCtx(uuid.New().String())
+	rec := httptest.NewRecorder()
+	httpReq := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(""))
+	// Haiku-requesting body with the compaction system marker → hard-pin
+	// triggers; tier ceiling is Low but hard-pin must bypass it.
+	body := `{"model":"claude-haiku-4-5","system":"Your task is to create a detailed summary of the conversation so far.","messages":[{"role":"user","content":"go"}]}`
+	require.NoError(t, svc.ProxyMessages(ctx, []byte(body), rec, httpReq))
+
+	assert.Equal(t, "claude-opus-4-7", rec.Header().Get("x-router-model"), "operator hard-pin must win over the tier ceiling")
+}
+
 // haikuClampBody requests a Low-tier model (haiku); the scorer is
 // stubbed to return an Opus (High) pick, which violates the ceiling and
 // must be clamped down to a Low-tier alternative.
@@ -574,7 +613,7 @@ func TestService_TierClamp_HaikuRequestedClampsHighScore(t *testing.T) {
 	// Scorer returns High-tier model: must be rewritten.
 	fr := &fakeRouter{decision: router.Decision{Provider: "anthropic", Model: "claude-opus-4-7", Reason: "cluster:v0.37"}}
 
-	svc := newPinSvc(fr, store).WithTierClampResolver(func(_ map[string]struct{}, ceiling capability.Tier) (string, string, bool) {
+	svc := newPinSvc(fr, store).WithTierClampResolver(func(_, _ map[string]struct{}, ceiling capability.Tier) (string, string, bool) {
 		require.Equal(t, capability.TierLow, ceiling, "haiku requested → Low ceiling")
 		return providers.ProviderAnthropic, "claude-haiku-4-5", true
 	})
@@ -596,7 +635,7 @@ func TestService_TierClamp_OpusRequestedNoClamp(t *testing.T) {
 	fr := &fakeRouter{decision: router.Decision{Provider: providers.ProviderAnthropic, Model: "claude-opus-4-7", Reason: "cluster:v0.37"}}
 
 	resolverCalls := 0
-	svc := newPinSvc(fr, store).WithTierClampResolver(func(_ map[string]struct{}, _ capability.Tier) (string, string, bool) {
+	svc := newPinSvc(fr, store).WithTierClampResolver(func(_, _ map[string]struct{}, _ capability.Tier) (string, string, bool) {
 		resolverCalls++
 		return "", "", false
 	})
@@ -628,7 +667,7 @@ func TestService_TierClamp_PinAboveCeilingIsClamped(t *testing.T) {
 	}
 	fr := &fakeRouter{decision: router.Decision{Provider: providers.ProviderAnthropic, Model: "claude-opus-4-7", Reason: "cluster:v0.37"}}
 
-	svc := newPinSvc(fr, store).WithTierClampResolver(func(_ map[string]struct{}, _ capability.Tier) (string, string, bool) {
+	svc := newPinSvc(fr, store).WithTierClampResolver(func(_, _ map[string]struct{}, _ capability.Tier) (string, string, bool) {
 		return providers.ProviderAnthropic, "claude-haiku-4-5", true
 	})
 
@@ -638,6 +677,68 @@ func TestService_TierClamp_PinAboveCeilingIsClamped(t *testing.T) {
 	require.NoError(t, svc.ProxyMessages(ctx, []byte(haikuClampBody), rec, httpReq))
 
 	assert.Equal(t, "claude-haiku-4-5", rec.Header().Get("x-router-model"))
+}
+
+// TestService_TierClamp_UnknownRequestedModelDisablesClamp regression-
+// guards the PR #100 finding: RequestedTier must be derived from
+// capability.TierFor(feats.Model) directly, not via
+// baselineFor(feats.Model). Substituting unknown model names through
+// baselineFor (which falls back to the default mid-tier baseline)
+// would force custom/proxy model names like "weave-router" into a
+// TierMid ceiling and silently clamp high-tier scorer picks. The
+// documented behavior is "unknown requested model ⇒ TierUnknown ⇒
+// clamping disabled".
+func TestService_TierClamp_UnknownRequestedModelDisablesClamp(t *testing.T) {
+	store := newFakePinStore()
+	// Scorer returns a High-tier pick that a TierMid clamp would
+	// rewrite; we want to prove the clamp is disabled entirely.
+	fr := &fakeRouter{decision: router.Decision{Provider: providers.ProviderAnthropic, Model: "claude-opus-4-7", Reason: "cluster:v0.37"}}
+
+	resolverCalls := 0
+	svc := newPinSvc(fr, store).WithTierClampResolver(func(_, _ map[string]struct{}, _ capability.Tier) (string, string, bool) {
+		resolverCalls++
+		return providers.ProviderAnthropic, "claude-sonnet-4-5", true
+	})
+
+	ctx := authedCtx(uuid.New().String())
+	rec := httptest.NewRecorder()
+	httpReq := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(""))
+	// Custom/proxy model name with no capability entry → TierUnknown.
+	body := `{"model":"weave-router","system":"sys","messages":[{"role":"user","content":"hi"}]}`
+	require.NoError(t, svc.ProxyMessages(ctx, []byte(body), rec, httpReq))
+
+	assert.Equal(t, 0, resolverCalls, "unknown requested model must yield TierUnknown ceiling, disabling the clamp")
+	assert.Equal(t, "claude-opus-4-7", rec.Header().Get("x-router-model"), "scorer pick must pass through unclamped for unknown requested models")
+}
+
+// TestService_TierClamp_ExcludedModelsThreadedToResolver regression-
+// guards the PR #100 security finding: tier clamping must respect the
+// request's ExcludedModels denylist so the clamp path cannot route to
+// a model the installation/request has explicitly blocked. Without
+// threading req.ExcludedModels through, the resolver would happily
+// pick a denylisted model whenever the scorer's choice violated the
+// ceiling — silently bypassing model access policy.
+func TestService_TierClamp_ExcludedModelsThreadedToResolver(t *testing.T) {
+	store := newFakePinStore()
+	// Scorer returns an over-ceiling pick; clamp will fire.
+	fr := &fakeRouter{decision: router.Decision{Provider: providers.ProviderAnthropic, Model: "claude-opus-4-7", Reason: "cluster:v0.37"}}
+
+	var capturedExcluded map[string]struct{}
+	svc := newPinSvc(fr, store).
+		WithExcludedModelsOverride([]string{"claude-haiku-4-5"}).
+		WithTierClampResolver(func(_, excluded map[string]struct{}, _ capability.Tier) (string, string, bool) {
+			capturedExcluded = excluded
+			return providers.ProviderAnthropic, "claude-sonnet-4-5", true
+		})
+
+	ctx := authedCtx(uuid.New().String())
+	rec := httptest.NewRecorder()
+	httpReq := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(""))
+	require.NoError(t, svc.ProxyMessages(ctx, []byte(haikuClampBody), rec, httpReq))
+
+	require.NotNil(t, capturedExcluded, "resolver must receive the request's ExcludedModels")
+	_, denied := capturedExcluded["claude-haiku-4-5"]
+	assert.True(t, denied, "ExcludedModels must propagate to the tier-clamp resolver")
 }
 
 // TestService_TierClamp_StaleFlagClearedOnUnclampedFinal regression-
@@ -668,7 +769,7 @@ func TestService_TierClamp_StaleFlagClearedOnUnclampedFinal(t *testing.T) {
 	fr := &fakeRouter{decision: router.Decision{Provider: providers.ProviderAnthropic, Model: "claude-opus-4-7", Reason: "cluster:v0.37"}}
 
 	clampCalls := 0
-	svc := newPinSvc(fr, store).WithTierClampResolver(func(_ map[string]struct{}, _ capability.Tier) (string, string, bool) {
+	svc := newPinSvc(fr, store).WithTierClampResolver(func(_, _ map[string]struct{}, _ capability.Tier) (string, string, bool) {
 		clampCalls++
 		// Resolver should never need to fire because all decisions are
 		// at or below the High ceiling.

--- a/internal/proxy/turnloop.go
+++ b/internal/proxy/turnloop.go
@@ -327,6 +327,13 @@ func roleForTier(t capability.Tier) string {
 // the original decision rather than failing the turn — a soft fallback
 // chosen over hard erroring on background tasks.
 func (s *Service) clampToCeiling(decision router.Decision, ceiling capability.Tier, enabled map[string]struct{}, res *turnLoopResult) router.Decision {
+	// Reset state every call: the orchestrator clamps multiple decision
+	// sources per turn (fresh scorer output, then planner-stay pin), and
+	// without this reset a clamp on `fresh` would leak `TierClamped=true`
+	// + `PreClampModel` into a subsequent unclamped pin decision, falsely
+	// labeling the final decision as clamped in the structured log.
+	res.TierClamped = false
+	res.PreClampModel = ""
 	if s.tierClampResolver == nil || ceiling == capability.TierUnknown {
 		return decision
 	}

--- a/internal/proxy/turnloop.go
+++ b/internal/proxy/turnloop.go
@@ -45,9 +45,14 @@ type turnLoopResult struct {
 	HardPinned bool
 	PinTier    string
 	PinAgeSec  int64
-	// RequestedTier is the tier of baselineFor(requested_model). Drives
+	// RequestedTier is the tier of the inbound requested model, looked up
+	// directly via capability.TierFor (no baseline substitution). Drives
 	// the tier-ceiling clamp; logged as `requested_tier`. TierUnknown
-	// disables clamping (preserves prior behavior for custom model names).
+	// disables clamping, which is the right behavior for custom/proxy
+	// model names (e.g. "weave-router") — substituting through
+	// baselineFor would force them into the default model's tier
+	// (TierMid) and clamp high-tier scorer picks despite the documented
+	// "unknown ⇒ no ceiling" rule.
 	RequestedTier capability.Tier
 	// TierClamped is true when the original decision violated the
 	// requested-model ceiling and was rewritten to an in-ceiling pick.
@@ -108,7 +113,7 @@ func (s *Service) runTurnLoop(
 	res := turnLoopResult{
 		TurnType:      turntype.DetectFromEnvelope(env, feats, subAgentHint),
 		PinTier:       "miss",
-		RequestedTier: capability.TierFor(s.baselineFor(feats.Model)),
+		RequestedTier: capability.TierFor(feats.Model),
 	}
 	res.PinRole = roleForTier(res.RequestedTier)
 
@@ -140,12 +145,17 @@ func (s *Service) runTurnLoop(
 			}
 			provider, model = p, m
 		}
+		// Operator hard-pins bypass the tier ceiling by design — the
+		// ROUTER_HARD_PIN_MODEL env var is an explicit operator opt-in
+		// that wins over the requested-model ceiling. Clamping here
+		// would silently rewrite an unknown-tier hard-pin to the
+		// cheapest in-ceiling alternative, defeating the operator's
+		// stated intent.
 		hardDecision := router.Decision{
 			Provider: provider,
 			Model:    model,
 			Reason:   string(res.TurnType) + "_hard_pin",
 		}
-		hardDecision = s.clampToCeiling(hardDecision, res.RequestedTier, req.EnabledProviders, &res)
 		res.Decision = hardDecision
 		res.StickyHit = true
 		res.HardPinned = true
@@ -160,7 +170,7 @@ func (s *Service) runTurnLoop(
 		if err != nil {
 			return res, err
 		}
-		decision = s.clampToCeiling(decision, res.RequestedTier, req.EnabledProviders, &res)
+		decision = s.clampToCeiling(decision, res.RequestedTier, req.EnabledProviders, req.ExcludedModels, &res)
 		res.Decision = decision
 		res.Fresh = decision
 		return res, nil
@@ -179,7 +189,7 @@ func (s *Service) runTurnLoop(
 	// trailing tool_result embedding flips decisions to noisy candidates;
 	// reuse the pin verbatim when present and refresh the TTL.
 	if res.TurnType == turntype.ToolResult && pinFound {
-		decision := s.clampToCeiling(pinDecision(pin), res.RequestedTier, req.EnabledProviders, &res)
+		decision := s.clampToCeiling(pinDecision(pin), res.RequestedTier, req.EnabledProviders, req.ExcludedModels, &res)
 		res.Decision = decision
 		res.StickyHit = true
 		res.PinTier = "postgres_tool_result_sc"
@@ -191,7 +201,7 @@ func (s *Service) runTurnLoop(
 	// behavior for callers that opt out via env flag. Skip the scorer
 	// entirely; the pin's model is authoritative.
 	if !s.plannerEnabled && pinFound {
-		decision := s.clampToCeiling(pinDecision(pin), res.RequestedTier, req.EnabledProviders, &res)
+		decision := s.clampToCeiling(pinDecision(pin), res.RequestedTier, req.EnabledProviders, req.ExcludedModels, &res)
 		res.Decision = decision
 		res.StickyHit = true
 		res.PinTier = "postgres"
@@ -206,7 +216,7 @@ func (s *Service) runTurnLoop(
 	if err != nil {
 		return res, err
 	}
-	fresh = s.clampToCeiling(fresh, res.RequestedTier, req.EnabledProviders, &res)
+	fresh = s.clampToCeiling(fresh, res.RequestedTier, req.EnabledProviders, req.ExcludedModels, &res)
 	res.Fresh = fresh
 
 	// Planner-disabled with no pin: take the fresh decision and write
@@ -231,7 +241,7 @@ func (s *Service) runTurnLoop(
 	res.PlannerDecision = decision
 
 	if decision.Outcome == planner.OutcomeStay && pinFound {
-		stay := s.clampToCeiling(pinDecision(pin), res.RequestedTier, req.EnabledProviders, &res)
+		stay := s.clampToCeiling(pinDecision(pin), res.RequestedTier, req.EnabledProviders, req.ExcludedModels, &res)
 		res.Decision = stay
 		res.StickyHit = true
 		res.PinTier = "postgres_stay_" + decision.Reason
@@ -321,12 +331,16 @@ func roleForTier(t capability.Tier) string {
 // decision's model has a known tier strictly higher than the ceiling,
 // the resolver picks the cheapest in-ceiling alternative for the
 // request's enabled providers and replaces the decision. Decisions
-// already at or below the ceiling pass through. TierUnknown ceilings
-// (custom model names with no capability entry) disable clamping.
-// Resolver lookup failure (no in-ceiling model available) preserves
-// the original decision rather than failing the turn — a soft fallback
-// chosen over hard erroring on background tasks.
-func (s *Service) clampToCeiling(decision router.Decision, ceiling capability.Tier, enabled map[string]struct{}, res *turnLoopResult) router.Decision {
+// already at or below the ceiling pass through. The resolver also
+// honors req.ExcludedModels so the clamp path cannot route to models
+// the installation/request has explicitly denylisted — otherwise tier
+// clamping would silently bypass the model access policy enforced on
+// normal scorer routing. TierUnknown ceilings (custom model names with
+// no capability entry) disable clamping. Resolver lookup failure (no
+// in-ceiling model available) preserves the original decision rather
+// than failing the turn — a soft fallback chosen over hard erroring on
+// background tasks.
+func (s *Service) clampToCeiling(decision router.Decision, ceiling capability.Tier, enabled, excluded map[string]struct{}, res *turnLoopResult) router.Decision {
 	// Reset state every call: the orchestrator clamps multiple decision
 	// sources per turn (fresh scorer output, then planner-stay pin), and
 	// without this reset a clamp on `fresh` would leak `TierClamped=true`
@@ -340,7 +354,7 @@ func (s *Service) clampToCeiling(decision router.Decision, ceiling capability.Ti
 	if capability.IsAtOrBelow(decision.Model, ceiling) {
 		return decision
 	}
-	p, m, ok := s.tierClampResolver(enabled, ceiling)
+	p, m, ok := s.tierClampResolver(enabled, excluded, ceiling)
 	if !ok {
 		return decision
 	}

--- a/internal/proxy/turnloop.go
+++ b/internal/proxy/turnloop.go
@@ -9,6 +9,7 @@ import (
 
 	"workweave/router/internal/observability"
 	"workweave/router/internal/router"
+	"workweave/router/internal/router/capability"
 	"workweave/router/internal/router/cluster"
 	"workweave/router/internal/router/handover"
 	"workweave/router/internal/router/planner"
@@ -44,6 +45,21 @@ type turnLoopResult struct {
 	HardPinned bool
 	PinTier    string
 	PinAgeSec  int64
+	// RequestedTier is the tier of baselineFor(requested_model). Drives
+	// the tier-ceiling clamp; logged as `requested_tier`. TierUnknown
+	// disables clamping (preserves prior behavior for custom model names).
+	RequestedTier capability.Tier
+	// TierClamped is true when the original decision violated the
+	// requested-model ceiling and was rewritten to an in-ceiling pick.
+	TierClamped bool
+	// PreClampModel records the violating model so logs can attribute
+	// which model the scorer / hard-pin / pin actually wanted to use.
+	PreClampModel string
+	// PinRole is the session-pin role used for this turn. Threaded through
+	// loadPin/refreshPin/writeNewPin and the post-response UpdateUsage call
+	// so a low-tier background turn and a high-tier main turn in the same
+	// session never share a pin row.
+	PinRole string
 	// Fresh is the scorer's recommendation for this turn when the scorer
 	// ran. Zero-valued on hard-pin / tool-result-with-pin paths where we
 	// never consulted the scorer.
@@ -90,9 +106,11 @@ func (s *Service) runTurnLoop(
 ) (turnLoopResult, error) {
 	log := observability.Get()
 	res := turnLoopResult{
-		TurnType: turntype.DetectFromEnvelope(env, feats, subAgentHint),
-		PinTier:  "miss",
+		TurnType:      turntype.DetectFromEnvelope(env, feats, subAgentHint),
+		PinTier:       "miss",
+		RequestedTier: capability.TierFor(s.baselineFor(feats.Model)),
 	}
+	res.PinRole = roleForTier(res.RequestedTier)
 
 	// Hard pins for turn types whose optimal model is known a priori
 	// (compaction, Explore sub-agent dispatch, SDK quota probes). Bypass
@@ -122,11 +140,13 @@ func (s *Service) runTurnLoop(
 			}
 			provider, model = p, m
 		}
-		res.Decision = router.Decision{
+		hardDecision := router.Decision{
 			Provider: provider,
 			Model:    model,
 			Reason:   string(res.TurnType) + "_hard_pin",
 		}
+		hardDecision = s.clampToCeiling(hardDecision, res.RequestedTier, req.EnabledProviders, &res)
+		res.Decision = hardDecision
 		res.StickyHit = true
 		res.HardPinned = true
 		res.PinTier = string(res.TurnType) + "_hard_pin"
@@ -140,15 +160,16 @@ func (s *Service) runTurnLoop(
 		if err != nil {
 			return res, err
 		}
+		decision = s.clampToCeiling(decision, res.RequestedTier, req.EnabledProviders, &res)
 		res.Decision = decision
 		res.Fresh = decision
 		return res, nil
 	}
 
 	res.SessionKey = DeriveSessionKey(env, apiKeyID)
-	pinCacheKey := sessionPinCacheKey(res.SessionKey, sessionpin.DefaultRole)
+	pinCacheKey := sessionPinCacheKey(res.SessionKey, res.PinRole)
 
-	pin, pinFound := s.loadPin(ctx, pinCacheKey, res.SessionKey)
+	pin, pinFound := s.loadPin(ctx, pinCacheKey, res.SessionKey, res.PinRole)
 	if pinFound {
 		res.PinModel = pin.Model
 		res.PinAgeSec = pinAge(pin)
@@ -158,10 +179,11 @@ func (s *Service) runTurnLoop(
 	// trailing tool_result embedding flips decisions to noisy candidates;
 	// reuse the pin verbatim when present and refresh the TTL.
 	if res.TurnType == turntype.ToolResult && pinFound {
-		res.Decision = pinDecision(pin)
+		decision := s.clampToCeiling(pinDecision(pin), res.RequestedTier, req.EnabledProviders, &res)
+		res.Decision = decision
 		res.StickyHit = true
 		res.PinTier = "postgres_tool_result_sc"
-		s.refreshPin(installationID, res.SessionKey, pin, pinCacheKey, res.Decision)
+		s.refreshPin(installationID, res.SessionKey, pin, pinCacheKey, res.PinRole, decision)
 		return res, nil
 	}
 
@@ -169,10 +191,11 @@ func (s *Service) runTurnLoop(
 	// behavior for callers that opt out via env flag. Skip the scorer
 	// entirely; the pin's model is authoritative.
 	if !s.plannerEnabled && pinFound {
-		res.Decision = pinDecision(pin)
+		decision := s.clampToCeiling(pinDecision(pin), res.RequestedTier, req.EnabledProviders, &res)
+		res.Decision = decision
 		res.StickyHit = true
 		res.PinTier = "postgres"
-		s.refreshPin(installationID, res.SessionKey, pin, pinCacheKey, res.Decision)
+		s.refreshPin(installationID, res.SessionKey, pin, pinCacheKey, res.PinRole, decision)
 		return res, nil
 	}
 
@@ -183,13 +206,14 @@ func (s *Service) runTurnLoop(
 	if err != nil {
 		return res, err
 	}
+	fresh = s.clampToCeiling(fresh, res.RequestedTier, req.EnabledProviders, &res)
 	res.Fresh = fresh
 
 	// Planner-disabled with no pin: take the fresh decision and write
 	// a new pin row so subsequent turns see it.
 	if !s.plannerEnabled {
 		res.Decision = fresh
-		s.writeNewPin(installationID, res.SessionKey, pinCacheKey, fresh)
+		s.writeNewPin(installationID, res.SessionKey, pinCacheKey, res.PinRole, fresh)
 		return res, nil
 	}
 
@@ -207,10 +231,11 @@ func (s *Service) runTurnLoop(
 	res.PlannerDecision = decision
 
 	if decision.Outcome == planner.OutcomeStay && pinFound {
-		res.Decision = pinDecision(pin)
+		stay := s.clampToCeiling(pinDecision(pin), res.RequestedTier, req.EnabledProviders, &res)
+		res.Decision = stay
 		res.StickyHit = true
 		res.PinTier = "postgres_stay_" + decision.Reason
-		s.refreshPin(installationID, res.SessionKey, pin, pinCacheKey, res.Decision)
+		s.refreshPin(installationID, res.SessionKey, pin, pinCacheKey, res.PinRole, stay)
 		return res, nil
 	}
 
@@ -268,15 +293,64 @@ func (s *Service) runTurnLoop(
 	if pinFound {
 		res.PinTier = "switch_" + decision.Reason
 	}
-	s.writeNewPin(installationID, res.SessionKey, pinCacheKey, fresh)
+	s.writeNewPin(installationID, res.SessionKey, pinCacheKey, res.PinRole, fresh)
 	return res, nil
+}
+
+// roleForTier maps a requested-model tier to its session-pin role. Each
+// tier gets its own row so a low-tier background turn and a high-tier
+// main turn in the same session never share a pin (preventing the
+// haiku-inherits-opus-pin leak that originally motivated the tier
+// ceiling). TierUnknown falls back to DefaultRole so callers with custom
+// model names (no entry in the capability table) keep their pre-ceiling
+// behavior.
+func roleForTier(t capability.Tier) string {
+	switch t {
+	case capability.TierLow:
+		return sessionpin.DefaultRole + "_low"
+	case capability.TierMid:
+		return sessionpin.DefaultRole + "_mid"
+	case capability.TierHigh:
+		return sessionpin.DefaultRole + "_high"
+	default:
+		return sessionpin.DefaultRole
+	}
+}
+
+// clampToCeiling enforces the requested-model tier ceiling. When the
+// decision's model has a known tier strictly higher than the ceiling,
+// the resolver picks the cheapest in-ceiling alternative for the
+// request's enabled providers and replaces the decision. Decisions
+// already at or below the ceiling pass through. TierUnknown ceilings
+// (custom model names with no capability entry) disable clamping.
+// Resolver lookup failure (no in-ceiling model available) preserves
+// the original decision rather than failing the turn — a soft fallback
+// chosen over hard erroring on background tasks.
+func (s *Service) clampToCeiling(decision router.Decision, ceiling capability.Tier, enabled map[string]struct{}, res *turnLoopResult) router.Decision {
+	if s.tierClampResolver == nil || ceiling == capability.TierUnknown {
+		return decision
+	}
+	if capability.IsAtOrBelow(decision.Model, ceiling) {
+		return decision
+	}
+	p, m, ok := s.tierClampResolver(enabled, ceiling)
+	if !ok {
+		return decision
+	}
+	res.TierClamped = true
+	res.PreClampModel = decision.Model
+	return router.Decision{
+		Provider: p,
+		Model:    m,
+		Reason:   decision.Reason + "+tier_clamp",
+	}
 }
 
 // loadPin returns the active pin for this session, consulting the in-proc
 // LRU first then Postgres. Expired rows are treated as misses on both
 // tiers. A store error is logged and surfaces as "not found" so the
 // caller falls through to the planner with a zero pin.
-func (s *Service) loadPin(ctx context.Context, pinCacheKey string, sessionKey [sessionpin.SessionKeyLen]byte) (sessionpin.Pin, bool) {
+func (s *Service) loadPin(ctx context.Context, pinCacheKey string, sessionKey [sessionpin.SessionKeyLen]byte, role string) (sessionpin.Pin, bool) {
 	log := observability.Get()
 	if s.pinCache != nil {
 		if pin, ok := s.pinCache.Get(pinCacheKey); ok {
@@ -294,7 +368,7 @@ func (s *Service) loadPin(ctx context.Context, pinCacheKey string, sessionKey [s
 			s.pinCache.Remove(pinCacheKey)
 		}
 	}
-	pin, found, err := s.pinStore.Get(ctx, sessionKey, sessionpin.DefaultRole)
+	pin, found, err := s.pinStore.Get(ctx, sessionKey, role)
 	if err != nil {
 		log.Error("session pin store unavailable; falling through to cluster scorer", "err", err)
 		return sessionpin.Pin{}, false
@@ -315,13 +389,13 @@ func (s *Service) loadPin(ctx context.Context, pinCacheKey string, sessionKey [s
 // cache entry. Carries the existing pin's cached last-turn usage forward
 // so the planner has evidence on subsequent turns even before the next
 // UpdateUsage writeback lands. Async, bounded; drops on saturation.
-func (s *Service) refreshPin(installationID uuid.UUID, sessionKey [sessionpin.SessionKeyLen]byte, existing sessionpin.Pin, pinCacheKey string, chosen router.Decision) {
+func (s *Service) refreshPin(installationID uuid.UUID, sessionKey [sessionpin.SessionKeyLen]byte, existing sessionpin.Pin, pinCacheKey string, role string, chosen router.Decision) {
 	if installationID == uuid.Nil {
 		return
 	}
 	p := sessionpin.Pin{
 		SessionKey:            sessionKey,
-		Role:                  sessionpin.DefaultRole,
+		Role:                  role,
 		InstallationID:        installationID,
 		Provider:              chosen.Provider,
 		Model:                 chosen.Model,
@@ -340,13 +414,13 @@ func (s *Service) refreshPin(installationID uuid.UUID, sessionKey [sessionpin.Se
 // writeNewPin records a freshly-routed decision as the active pin. Used
 // on first-turn routing and on switch turns; the new row has no prior
 // usage stats yet (UpdateUsage fills them in after the response lands).
-func (s *Service) writeNewPin(installationID uuid.UUID, sessionKey [sessionpin.SessionKeyLen]byte, pinCacheKey string, chosen router.Decision) {
+func (s *Service) writeNewPin(installationID uuid.UUID, sessionKey [sessionpin.SessionKeyLen]byte, pinCacheKey string, role string, chosen router.Decision) {
 	if installationID == uuid.Nil {
 		return
 	}
 	p := sessionpin.Pin{
 		SessionKey:     sessionKey,
-		Role:           sessionpin.DefaultRole,
+		Role:           role,
 		InstallationID: installationID,
 		Provider:       chosen.Provider,
 		Model:          chosen.Model,

--- a/internal/proxy/turnloop_internal_test.go
+++ b/internal/proxy/turnloop_internal_test.go
@@ -154,7 +154,7 @@ func TestLoadPin_EvictsExpiredLRUEntry(t *testing.T) {
 	}
 	svc.pinCache.Add(cacheKey, expired)
 
-	pin, found := svc.loadPin(context.Background(), cacheKey, sessionKey)
+	pin, found := svc.loadPin(context.Background(), cacheKey, sessionKey, sessionpin.DefaultRole)
 	assert.False(t, found, "expired LRU entry must not be served")
 	assert.Equal(t, sessionpin.Pin{}, pin, "miss must return the zero pin")
 	_, stillCached := svc.pinCache.Get(cacheKey)
@@ -194,7 +194,7 @@ func TestLoadPin_ServesFreshLRUEntry(t *testing.T) {
 	}
 	svc.pinCache.Add(cacheKey, fresh)
 
-	pin, found := svc.loadPin(context.Background(), cacheKey, sessionKey)
+	pin, found := svc.loadPin(context.Background(), cacheKey, sessionKey, sessionpin.DefaultRole)
 	require.True(t, found, "non-expired LRU entry should be returned without hitting Postgres")
 	assert.Equal(t, fresh.Model, pin.Model)
 	assert.Equal(t, fresh.Provider, pin.Provider)

--- a/internal/router/capability/tier.go
+++ b/internal/router/capability/tier.go
@@ -85,6 +85,31 @@ func TierFor(model string) Tier {
 	return tiers[model]
 }
 
+// IsAtOrBelow reports whether the given model's tier is known and at or
+// below the ceiling. Unknown-tier models return false so the tier-ceiling
+// guard fails closed — Validate already catches missing entries at boot,
+// so any TierUnknown at request time means the table is out of sync.
+func IsAtOrBelow(model string, ceiling Tier) bool {
+	t := TierFor(model)
+	if t == TierUnknown {
+		return false
+	}
+	return t <= ceiling
+}
+
+// AllowedAtOrBelow returns the set of known models whose tier is at or
+// below the ceiling. Used by the cluster bundle when picking a clamp
+// target that respects the requested-model ceiling.
+func AllowedAtOrBelow(ceiling Tier) map[string]struct{} {
+	out := make(map[string]struct{}, len(tiers))
+	for m, t := range tiers {
+		if t != TierUnknown && t <= ceiling {
+			out[m] = struct{}{}
+		}
+	}
+	return out
+}
+
 // Validate returns an error naming any deployed model missing from the
 // tier table. Called once at boot against the scorer's deployed set.
 func Validate(deployed []string) error {

--- a/internal/router/capability/tier.go
+++ b/internal/router/capability/tier.go
@@ -80,9 +80,39 @@ var tiers = map[string]Tier{
 	"deepseek/deepseek-v4-pro": TierHigh,
 }
 
-// TierFor returns the model's tier, or TierUnknown if absent.
+// TierFor returns the model's tier, or TierUnknown if absent. Anthropic
+// model identifiers carry a "-YYYYMMDD" date suffix (e.g.
+// "claude-haiku-4-5-20251001") that the table doesn't enumerate; we
+// strip an 8-digit suffix before retrying so dated variants resolve.
 func TierFor(model string) Tier {
-	return tiers[model]
+	if t, ok := tiers[model]; ok {
+		return t
+	}
+	if normalized := stripDateSuffix(model); normalized != model {
+		if t, ok := tiers[normalized]; ok {
+			return t
+		}
+	}
+	return TierUnknown
+}
+
+// stripDateSuffix removes a trailing "-XXXXXXXX" (hyphen + 8 digits).
+// Mirror of pricing.stripDateSuffix; kept local so capability doesn't
+// import pricing.
+func stripDateSuffix(model string) string {
+	if len(model) < 10 {
+		return model
+	}
+	tail := model[len(model)-9:]
+	if tail[0] != '-' {
+		return model
+	}
+	for _, c := range tail[1:] {
+		if c < '0' || c > '9' {
+			return model
+		}
+	}
+	return model[:len(model)-9]
 }
 
 // IsAtOrBelow reports whether the given model's tier is known and at or

--- a/internal/router/capability/tier_test.go
+++ b/internal/router/capability/tier_test.go
@@ -88,3 +88,59 @@ func TestValidate(t *testing.T) {
 		assert.NoError(t, capability.Validate(nil))
 	})
 }
+
+func TestIsAtOrBelow(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		model   string
+		ceiling capability.Tier
+		want    bool
+	}{
+		{"claude-haiku-4-5", capability.TierLow, true},
+		{"claude-haiku-4-5", capability.TierMid, true},
+		{"claude-haiku-4-5", capability.TierHigh, true},
+		{"claude-sonnet-4-5", capability.TierLow, false},
+		{"claude-sonnet-4-5", capability.TierMid, true},
+		{"claude-opus-4-7", capability.TierLow, false},
+		{"claude-opus-4-7", capability.TierMid, false},
+		{"claude-opus-4-7", capability.TierHigh, true},
+		{"deepseek/deepseek-v4-pro", capability.TierLow, false},
+		{"qwen/qwen3.5-flash-02-23", capability.TierLow, true},
+		// Unknown tier must fail-closed: a model absent from the table
+		// can't be proven safe under a ceiling, so reject it.
+		{"made-up-model", capability.TierHigh, false},
+		{"", capability.TierHigh, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.model+"_vs_"+tc.ceiling.String(), func(t *testing.T) {
+			assert.Equal(t, tc.want, capability.IsAtOrBelow(tc.model, tc.ceiling))
+		})
+	}
+}
+
+func TestAllowedAtOrBelow(t *testing.T) {
+	t.Parallel()
+	low := capability.AllowedAtOrBelow(capability.TierLow)
+	for m := range low {
+		require.Equal(t, capability.TierLow, capability.TierFor(m), "AllowedAtOrBelow(Low) returned %q which is not TierLow", m)
+	}
+	assert.Contains(t, low, "claude-haiku-4-5")
+	assert.Contains(t, low, "qwen/qwen3.5-flash-02-23")
+	assert.NotContains(t, low, "claude-opus-4-7")
+	assert.NotContains(t, low, "claude-sonnet-4-5")
+
+	mid := capability.AllowedAtOrBelow(capability.TierMid)
+	assert.Contains(t, mid, "claude-haiku-4-5", "Mid ceiling must include Low models")
+	assert.Contains(t, mid, "claude-sonnet-4-5")
+	assert.NotContains(t, mid, "claude-opus-4-7")
+
+	high := capability.AllowedAtOrBelow(capability.TierHigh)
+	assert.Contains(t, high, "claude-haiku-4-5")
+	assert.Contains(t, high, "claude-sonnet-4-5")
+	assert.Contains(t, high, "claude-opus-4-7")
+
+	// TierUnknown ceiling: empty set (no model qualifies; the proxy
+	// disables clamping in this case via the IsAtOrBelow short-circuit).
+	unknown := capability.AllowedAtOrBelow(capability.TierUnknown)
+	assert.Empty(t, unknown)
+}

--- a/internal/router/capability/tier_test.go
+++ b/internal/router/capability/tier_test.go
@@ -144,3 +144,27 @@ func TestAllowedAtOrBelow(t *testing.T) {
 	unknown := capability.AllowedAtOrBelow(capability.TierUnknown)
 	assert.Empty(t, unknown)
 }
+
+func TestTierFor_StripsDateSuffix(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		model string
+		want  capability.Tier
+	}{
+		// Anthropic dated variants resolve to their base tier.
+		{"claude-haiku-4-5-20251001", capability.TierLow},
+		{"claude-sonnet-4-5-20250929", capability.TierMid},
+		{"claude-opus-4-7-20251015", capability.TierHigh},
+		// Non-dated stays as-is.
+		{"claude-haiku-4-5", capability.TierLow},
+		// Wrong-shaped suffixes (not 8 digits) don't strip; the lookup
+		// fails through to TierUnknown rather than masking typos.
+		{"claude-haiku-4-5-1234567", capability.TierUnknown},
+		{"claude-haiku-4-5-abcdefgh", capability.TierUnknown},
+	}
+	for _, tc := range cases {
+		t.Run(tc.model, func(t *testing.T) {
+			assert.Equal(t, tc.want, capability.TierFor(tc.model))
+		})
+	}
+}

--- a/internal/router/cluster/artifacts.go
+++ b/internal/router/cluster/artifacts.go
@@ -323,10 +323,27 @@ func loadRankings(raw []byte) (Rankings, error) {
 // registry entries whose provider is in available. Entries missing a
 // cost are skipped. Returns ok=false if nothing matches.
 func CheapestModel(meta *ArtifactMetadata, registry *ModelRegistry, available map[string]struct{}) (provider, model string, ok bool) {
+	return cheapestModelFiltered(meta, registry, available, nil)
+}
+
+// CheapestModelInSet is CheapestModel restricted to a caller-supplied
+// model allowlist. Used by the tier-ceiling clamp: callers pass the set
+// of models at or below the requested tier so the cheapest pick stays
+// inside the ceiling. A nil/empty allowSet behaves like CheapestModel.
+func CheapestModelInSet(meta *ArtifactMetadata, registry *ModelRegistry, available, allowSet map[string]struct{}) (provider, model string, ok bool) {
+	return cheapestModelFiltered(meta, registry, available, allowSet)
+}
+
+func cheapestModelFiltered(meta *ArtifactMetadata, registry *ModelRegistry, available, allowSet map[string]struct{}) (provider, model string, ok bool) {
 	var bestCost float64 = -1
 	for _, e := range registry.DeployedModels {
 		if _, inSet := available[e.Provider]; !inSet {
 			continue
+		}
+		if allowSet != nil {
+			if _, allowed := allowSet[e.Model]; !allowed {
+				continue
+			}
 		}
 		cost, hasCost := meta.CostPer1KInputUSD[e.Model]
 		if !hasCost {

--- a/internal/router/cluster/artifacts.go
+++ b/internal/router/cluster/artifacts.go
@@ -323,18 +323,21 @@ func loadRankings(raw []byte) (Rankings, error) {
 // registry entries whose provider is in available. Entries missing a
 // cost are skipped. Returns ok=false if nothing matches.
 func CheapestModel(meta *ArtifactMetadata, registry *ModelRegistry, available map[string]struct{}) (provider, model string, ok bool) {
-	return cheapestModelFiltered(meta, registry, available, nil)
+	return cheapestModelFiltered(meta, registry, available, nil, nil)
 }
 
 // CheapestModelInSet is CheapestModel restricted to a caller-supplied
-// model allowlist. Used by the tier-ceiling clamp: callers pass the set
-// of models at or below the requested tier so the cheapest pick stays
-// inside the ceiling. A nil/empty allowSet behaves like CheapestModel.
-func CheapestModelInSet(meta *ArtifactMetadata, registry *ModelRegistry, available, allowSet map[string]struct{}) (provider, model string, ok bool) {
-	return cheapestModelFiltered(meta, registry, available, allowSet)
+// model allowlist and denylist. Used by the tier-ceiling clamp:
+// callers pass the set of models at or below the requested tier as
+// allowSet so the cheapest pick stays inside the ceiling, plus the
+// request's ExcludedModels as denySet so the clamp path cannot bypass
+// the installation/request model exclusion policy. nil/empty allowSet
+// behaves like CheapestModel; nil/empty denySet disables exclusion.
+func CheapestModelInSet(meta *ArtifactMetadata, registry *ModelRegistry, available, denySet, allowSet map[string]struct{}) (provider, model string, ok bool) {
+	return cheapestModelFiltered(meta, registry, available, denySet, allowSet)
 }
 
-func cheapestModelFiltered(meta *ArtifactMetadata, registry *ModelRegistry, available, allowSet map[string]struct{}) (provider, model string, ok bool) {
+func cheapestModelFiltered(meta *ArtifactMetadata, registry *ModelRegistry, available, denySet, allowSet map[string]struct{}) (provider, model string, ok bool) {
 	var bestCost float64 = -1
 	for _, e := range registry.DeployedModels {
 		if _, inSet := available[e.Provider]; !inSet {
@@ -344,6 +347,9 @@ func cheapestModelFiltered(meta *ArtifactMetadata, registry *ModelRegistry, avai
 			if _, allowed := allowSet[e.Model]; !allowed {
 				continue
 			}
+		}
+		if _, denied := denySet[e.Model]; denied {
+			continue
 		}
 		cost, hasCost := meta.CostPer1KInputUSD[e.Model]
 		if !hasCost {

--- a/internal/router/cluster/artifacts_test.go
+++ b/internal/router/cluster/artifacts_test.go
@@ -264,7 +264,7 @@ func TestCheapestModelInSet(t *testing.T) {
 
 	t.Run("respects allowSet — cheapest within allow", func(t *testing.T) {
 		allow := map[string]struct{}{"model-a": {}, "model-b": {}}
-		p, m, ok := CheapestModelInSet(meta, registry, available, allow)
+		p, m, ok := CheapestModelInSet(meta, registry, available, nil, allow)
 		require.True(t, ok)
 		assert.Equal(t, "google", p)
 		assert.Equal(t, "model-b", m, "model-c is cheaper but excluded by allowSet")
@@ -272,14 +272,34 @@ func TestCheapestModelInSet(t *testing.T) {
 
 	t.Run("ok=false when allowSet has no available model", func(t *testing.T) {
 		allow := map[string]struct{}{"nope": {}}
-		_, _, ok := CheapestModelInSet(meta, registry, available, allow)
+		_, _, ok := CheapestModelInSet(meta, registry, available, nil, allow)
 		assert.False(t, ok)
 	})
 
 	t.Run("nil allowSet behaves like CheapestModel", func(t *testing.T) {
-		p, m, ok := CheapestModelInSet(meta, registry, available, nil)
+		p, m, ok := CheapestModelInSet(meta, registry, available, nil, nil)
 		require.True(t, ok)
 		assert.Equal(t, "google", p)
 		assert.Equal(t, "model-c", m)
+	})
+
+	t.Run("denySet excludes models even when allowed by allowSet", func(t *testing.T) {
+		// allowSet permits model-b and model-c (both google, both in
+		// the registry); denySet excludes the cheapest of the two —
+		// model-c — forcing the resolver to fall back to model-b.
+		// Guards the PR #100 issue where tier clamping bypassed the
+		// request's ExcludedModels denylist.
+		allow := map[string]struct{}{"model-b": {}, "model-c": {}}
+		deny := map[string]struct{}{"model-c": {}}
+		p, m, ok := CheapestModelInSet(meta, registry, available, deny, allow)
+		require.True(t, ok)
+		assert.Equal(t, "google", p)
+		assert.Equal(t, "model-b", m, "model-c is cheaper but denylisted")
+	})
+
+	t.Run("denySet emptying pool yields ok=false", func(t *testing.T) {
+		deny := map[string]struct{}{"model-a": {}, "model-b": {}, "model-c": {}}
+		_, _, ok := CheapestModelInSet(meta, registry, available, deny, nil)
+		assert.False(t, ok)
 	})
 }

--- a/internal/router/cluster/artifacts_test.go
+++ b/internal/router/cluster/artifacts_test.go
@@ -244,3 +244,42 @@ func TestCheapestModel(t *testing.T) {
 		assert.Equal(t, "model-a", m)
 	})
 }
+
+func TestCheapestModelInSet(t *testing.T) {
+	meta := &ArtifactMetadata{
+		CostPer1KInputUSD: map[string]float64{
+			"model-a": 3.00,
+			"model-b": 0.50,
+			"model-c": 0.10,
+		},
+	}
+	registry := &ModelRegistry{
+		DeployedModels: []DeployedEntry{
+			{Model: "model-a", Provider: "anthropic", BenchColumn: "col-a"},
+			{Model: "model-b", Provider: "google", BenchColumn: "col-b"},
+			{Model: "model-c", Provider: "google", BenchColumn: "col-c"},
+		},
+	}
+	available := map[string]struct{}{"anthropic": {}, "google": {}}
+
+	t.Run("respects allowSet — cheapest within allow", func(t *testing.T) {
+		allow := map[string]struct{}{"model-a": {}, "model-b": {}}
+		p, m, ok := CheapestModelInSet(meta, registry, available, allow)
+		require.True(t, ok)
+		assert.Equal(t, "google", p)
+		assert.Equal(t, "model-b", m, "model-c is cheaper but excluded by allowSet")
+	})
+
+	t.Run("ok=false when allowSet has no available model", func(t *testing.T) {
+		allow := map[string]struct{}{"nope": {}}
+		_, _, ok := CheapestModelInSet(meta, registry, available, allow)
+		assert.False(t, ok)
+	})
+
+	t.Run("nil allowSet behaves like CheapestModel", func(t *testing.T) {
+		p, m, ok := CheapestModelInSet(meta, registry, available, nil)
+		require.True(t, ok)
+		assert.Equal(t, "google", p)
+		assert.Equal(t, "model-c", m)
+	})
+}


### PR DESCRIPTION
## Summary
Enforce the invariant **`tier(decision_model) ≤ tier(baselineFor(requested_model))`**. The router can substitute laterally or downgrade, never upgrade. Applied at every decision source: hard-pin output, pin-hit fast paths, fresh scorer output, and planner stay outcomes.

## Why
A haiku-tier background call (WebFetch summary, title generation, etc.) whose session pin pointed at the opus-tier main loop would inherit deepseek-v4-pro from the shared pin row — silently paying High-tier prices for what the caller scoped to Low-tier work. Logs showed this concretely on a single denied curl: 10 qwen Explore retries + 1 deepseek-v4-pro WebFetch summary + 1 gemini-pro title call, all driven by haiku-class background work.

## Behavior
| Requested | Ceiling | Effect |
|---|---|---|
| opus | High | no clamp |
| sonnet | Mid | clamp opus/kimi/deepseek-pro to Mid pool |
| haiku | Low | clamp anything above haiku to Low pool |
| unknown | Unknown | clamp disabled (preserves behavior for custom model names) |

## Key design choices
- **Pin rows are keyed per tier role** (`default_low` / `default_mid` / `default_high`) so cross-tier turns in the same session no longer share a pin. The post-response usage writeback uses the same role to keep the in-proc LRU and Postgres coherent.
- **Unknown-tier models fail closed**: a model absent from the capability table can't be proven safe under a ceiling. `Validate()` already catches missing entries at boot, so `TierUnknown` at request time means the table is out of sync.
- **Operator pins win**: `ROUTER_HARD_PIN_MODEL` bypasses the ceiling — explicit opt-in.
- **Resolver soft-fallback**: when no in-ceiling model is routable, the unclamped decision is preserved rather than failing the turn (resilience on background tasks).
- **Complementary to `ROUTER_HARD_PIN_EXPLORE`**: the ceiling acts on `requested_model`, hard-pin-explore acts on `turn_type`. Explore agents request opus today, so the ceiling alone doesn't make them cheap — both flags stay useful.

## Logging
Four new fields on `ProxyMessages complete` / `ProxyOpenAIChatCompletion complete`:
- `requested_tier` (`low` / `mid` / `high` / `unknown`)
- `decision_tier`
- `tier_clamped` (bool)
- `pre_clamp_model` (the violating model when clamped)

No new log message.

## Files
- `internal/router/capability/tier.go` — `IsAtOrBelow`, `AllowedAtOrBelow`
- `internal/router/cluster/artifacts.go` — `CheapestModelInSet` (cheapest with allowlist filter)
- `internal/proxy/service.go` — `tierClampResolver` field + `WithTierClampResolver` setter; threaded `role` into `recordTurnUsage`; new log fields
- `internal/proxy/turnloop.go` — `clampToCeiling` helper, `roleForTier` helper, clamp applied at four decision sources, `role` threaded through `loadPin` / `refreshPin` / `writeNewPin`
- `cmd/router/main.go` — wires `tierClampResolver` from the cluster bundle
- Tests added: capability (`IsAtOrBelow`, `AllowedAtOrBelow`), cluster (`CheapestModelInSet`), proxy end-to-end (haiku clamps high-score, opus passes through, pin-above-ceiling clamps)

## Test plan
- [x] `go build ./...`
- [x] `go test ./...` — entire suite green
- [ ] Verify in docker that haiku-requested WebFetch summaries now log `tier_clamped=true pre_clamp_model=deepseek/deepseek-v4-pro` instead of silently routing to deepseek
- [ ] Verify main-loop opus turns log `requested_tier=high decision_tier=high tier_clamped=false`

## Relation to #98 and #99
Lands after the detection fix (#99) and hard-pin-explore default (#98). Together: #99 stops misclassifying main loop, #98 cheapens real Explore, this PR closes the remaining leak (haiku-class background calls inheriting High-tier pins).