### PR TITLE
router: detect Claude Code sub-agent dispatch via <transcript> envelope

### DIFF
--- a/internal/router/turntype/detect.go
+++ b/internal/router/turntype/detect.go
@@ -60,7 +60,7 @@ func DetectFromEnvelope(env *translate.RequestEnvelope, feats translate.RoutingF
 	if isCompaction(systemText) {
 		return Compaction
 	}
-	if isSubAgentDispatch(env.MetadataUserID(), subAgentHint) {
+	if isSubAgentDispatch(env.MetadataUserID(), env.FirstUserMessageText(), subAgentHint) {
 		return SubAgentDispatch
 	}
 	if feats.LastKind == "tool_result" {
@@ -87,21 +87,46 @@ func isCompaction(systemText string) bool {
 }
 
 // isSubAgentDispatch reports whether the request originates from a
-// sub-agent dispatch. Claude Code packs sub-agent identity into
-// metadata.user_id as "subagent:<type>"; non-Anthropic clients pass it
-// via the x-weave-subagent-type header.
+// sub-agent dispatch. Three independent signals:
 //
-// A system-prompt string-match fallback used to live here ("subagent_type"
-// / "sub-agent") but was removed: Claude Code's main-loop system prompt
-// includes the Agent tool description, which contains the literal
-// "subagent_type" parameter name. That false-positive misclassified every
-// main-loop turn as a sub-agent and, with ROUTER_HARD_PIN_EXPLORE=true,
-// hard-pinned them all to the cheap model. Per this file's invariant,
-// false negatives (returning MainLoop) are safe — the cluster scorer
-// runs normally — so we keep detection to the two authoritative signals.
-func isSubAgentDispatch(metadataUserID, subAgentHint string) bool {
+//  1. x-weave-subagent-type header — set by non-Anthropic clients or
+//     middleware that knows it dispatched a sub-agent.
+//  2. metadata.user_id starting with "subagent:" — older Anthropic SDK
+//     convention.
+//  3. First user message wrapped in Claude Code's "<transcript>...</transcript>"
+//     envelope — what Claude Code's Agent tool actually emits today for
+//     dispatches like Explore. metadata.user_id is unset in this case
+//     (Claude Code reuses the parent session_id), so without this signal
+//     real Explore agents would never classify as SubAgentDispatch.
+//
+// "<transcript>" lives in the user-message body, not the system prompt.
+// That's deliberate: an earlier attempt matched "subagent_type" in the
+// system text and false-positived on every main-loop turn that exposed
+// the Agent tool description (since the tool description contains that
+// parameter name verbatim). The "<transcript>" envelope is specific to
+// dispatched sub-agent prompts and does not appear in main-loop traffic.
+//
+// Per this file's invariant, false negatives (returning MainLoop) are
+// safe — the cluster scorer runs normally; only false positives are
+// dangerous.
+func isSubAgentDispatch(metadataUserID, firstUserText, subAgentHint string) bool {
 	if subAgentHint != "" {
 		return true
 	}
-	return strings.HasPrefix(metadataUserID, "subagent:")
+	if strings.HasPrefix(metadataUserID, "subagent:") {
+		return true
+	}
+	// Claude Code's Agent tool wraps the dispatched prompt as:
+	//   <transcript>
+	//   User: <body>
+	//   </transcript>
+	// Look at a bounded prefix so a stray "<transcript>" string embedded
+	// deep in user content can't trigger SubAgentDispatch on a long
+	// main-loop turn.
+	const sniffLen = 64
+	prefix := firstUserText
+	if len(prefix) > sniffLen {
+		prefix = prefix[:sniffLen]
+	}
+	return strings.Contains(prefix, "<transcript>")
 }

--- a/internal/router/turntype/detect_test.go
+++ b/internal/router/turntype/detect_test.go
@@ -91,6 +91,23 @@ func TestDetectFromEnvelope_Anthropic(t *testing.T) {
 			want: turntype.SubAgentDispatch,
 		},
 		{
+			// Claude Code's Agent tool wraps the dispatched prompt in a
+			// <transcript> envelope. metadata.user_id is unset (Claude
+			// Code reuses the parent session_id), so the transcript
+			// marker is the only signal we get.
+			name: "sub-agent via <transcript> envelope in user message",
+			body: `{"model":"claude-opus-4-7","messages":[{"role":"user","content":"<transcript>\nUser: Find all router cost references\n</transcript>"}]}`,
+			want: turntype.SubAgentDispatch,
+		},
+		{
+			// Regression guard: a long main-loop user prompt that
+			// happens to contain "<transcript>" deep in its body must
+			// not trip the heuristic. Detection sniffs a 64-byte prefix.
+			name: "long main_loop with embedded <transcript> deep in body stays main_loop",
+			body: `{"model":"claude-opus-4-7","messages":[{"role":"user","content":"please review this code and tell me what you think about its overall structure and design including a <transcript> tag we discussed earlier"}]}`,
+			want: turntype.MainLoop,
+		},
+		{
 			name: "empty body is main_loop",
 			body: `{}`,
 			want: turntype.MainLoop,


### PR DESCRIPTION
## Summary
Re-add a third SubAgentDispatch detection signal: Claude Code's `<transcript>` envelope in the first user message body. Scoped tightly (64-byte prefix sniff) so it can't false-positive on main-loop prompts that happen to mention the substring.

## Why
#99 removed the system-prompt string fallback because it matched `"subagent_type"` — a substring that appears in Claude Code's Agent tool description on every main-loop turn. That cleanup left only two signals: the `x-weave-subagent-type` header and `metadata.user_id` with the `"subagent:"` prefix. **Claude Code emits neither for its Agent tool.**

Confirmed in docker logs from a real session: two parallel Explore agents both classified as `MainLoop` and went through the cluster scorer instead of hard-pinning. One landed on `kimi-k2.5`, the other on `deepseek-v4-pro` — exactly the runaway sub-agent cost `ROUTER_HARD_PIN_EXPLORE=true` (defaulted-on in #98) was supposed to prevent.

The actual signal Claude Code does send is in the user-message body. Every sub-agent dispatch is wrapped:

```
<transcript>
User: <body>
</transcript>
```

## Why this won't reintroduce the #99 bug
The original false-positive was in the **system prompt** (Agent tool description, present on every main-loop turn). `<transcript>` lives in the **user-message body** (only present on dispatched sub-agent prompts). Plus the sniff is bounded to a 64-byte prefix, so a long main-loop prompt that mentions `<transcript>` deep in its content doesn't trip.

## Tests
- Positive: `<transcript>\nUser: ...` first user message → `SubAgentDispatch`
- Regression guard: long main-loop user prompt with `<transcript>` substring buried after byte 64 → `MainLoop`
- All existing detection tests still pass; full repo test suite green

## Effect after merge
| Before | After |
|---|---|
| Real Explore agents → MainLoop → cluster scorer → kimi/deepseek-pro (TierHigh, expensive) | Real Explore agents → SubAgentDispatch → hard-pin → cheap pool model |

Closes the regression introduced by #99 against Claude Code traffic.

## Test plan
- [x] `go build ./...`
- [x] `go test ./...` — full suite green
- [ ] Verify in docker: an Explore-style request (`<transcript>` envelope) logs `decision_reason=sub_agent_dispatch_hard_pin` instead of falling through to the cluster scorer