### PR TITLE
translate: strip x- vendor extensions and $-prefixed keys from Gemini tool schemas

### DIFF
--- a/internal/translate/emit_gemini.go
+++ b/internal/translate/emit_gemini.go
@@ -722,6 +722,14 @@ func sanitizeSchemaForGemini(v any) any {
 			if _, drop := geminiUnsupportedSchemaKeys[k]; drop {
 				continue
 			}
+			// Drop vendor extensions ("x-*", e.g. x-google-enum-descriptions from
+			// Google-API-derived MCP tool schemas) and JSON Schema metadata
+			// ("$*", e.g. $schema/$id/$ref). Gemini's proto-based validator
+			// rejects any unknown field name with 400, so we strip by prefix
+			// rather than maintaining a moving allowlist.
+			if strings.HasPrefix(k, "x-") || strings.HasPrefix(k, "$") {
+				continue
+			}
 			if k == "enum" {
 				cleaned := filterStringEnum(child)
 				if len(cleaned) == 0 {

--- a/internal/translate/gemini_test.go
+++ b/internal/translate/gemini_test.go
@@ -545,6 +545,61 @@ func TestPrepareGemini_StripsJSONSchemaFieldsGoogleRejects(t *testing.T) {
 	assert.Equal(t, "URL to fetch", url["description"])
 }
 
+func TestPrepareGemini_StripsVendorExtensionAndDollarPrefixedKeys(t *testing.T) {
+	// Regression: MCP tool schemas derived from Google APIs (and friends)
+	// embed vendor extensions like `x-google-enum-descriptions` at every
+	// nesting level. Gemini's proto validator rejects any unknown field
+	// with 400 "Cannot find field". Strip anything with an "x-" or "$"
+	// prefix instead of maintaining a moving allowlist.
+	body := []byte(`{
+		"messages": [{"role":"user","content":"hi"}],
+		"tools": [{
+			"name":"sheets_get",
+			"input_schema":{
+				"$schema":"http://json-schema.org/draft-07/schema#",
+				"$id":"urn:weave:test",
+				"type":"object",
+				"x-google-resource":"sheet",
+				"properties":{
+					"range":{
+						"type":"string",
+						"x-google-enum-descriptions":["A","B"],
+						"enum":["A1","B2"]
+					},
+					"nested":{
+						"type":"object",
+						"x-google-foo":"bar",
+						"properties":{
+							"leaf":{"type":"string","x-vendor-thing":"y"}
+						}
+					}
+				}
+			}
+		}]
+	}`)
+	env, err := translate.ParseAnthropic(body)
+	require.NoError(t, err)
+	prep, err := env.PrepareGemini(http.Header{}, translate.EmitOptions{})
+	require.NoError(t, err)
+
+	params := mustUnmarshal(t, prep.Body)["tools"].([]any)[0].(map[string]any)["functionDeclarations"].([]any)[0].(map[string]any)["parameters"].(map[string]any)
+
+	assert.NotContains(t, params, "x-google-resource", "top-level x- extension must be stripped")
+	assert.NotContains(t, params, "$schema", "top-level $-prefixed key must be stripped")
+	assert.NotContains(t, params, "$id", "top-level $-prefixed key must be stripped")
+
+	props := params["properties"].(map[string]any)
+	rangeField := props["range"].(map[string]any)
+	assert.NotContains(t, rangeField, "x-google-enum-descriptions", "nested x- extension must be stripped")
+	assert.Equal(t, []any{"A1", "B2"}, rangeField["enum"], "real enum must survive")
+
+	nested := props["nested"].(map[string]any)
+	assert.NotContains(t, nested, "x-google-foo", "nested x- extension must be stripped at every level")
+	leaf := nested["properties"].(map[string]any)["leaf"].(map[string]any)
+	assert.NotContains(t, leaf, "x-vendor-thing", "leaf x- extension must be stripped")
+	assert.Equal(t, "string", leaf["type"], "real type must survive")
+}
+
 func TestSanitizeSchemaForGemini_PreservesSupportedFields(t *testing.T) {
 	// Defense-in-depth: exhaustively confirms which keys survive sanitization.
 	body := []byte(`{


### PR DESCRIPTION
## Summary

Production 400s from Gemini Flash Lite when Claude Code sessions with Google-API-derived MCPs (QuickBooks, Sheets, Fireflies, etc.) get routed there:

```
Invalid JSON payload received. Unknown name "x-google-enum-descriptions" at
'tools[0].function_declarations[71].parameters.properties[0].value':
Cannot find field.
```

The Anthropic→Gemini tool-schema sanitizer (`internal/translate/emit_gemini.go`) maintained a static allowlist of JSON Schema keys to drop. It missed `x-google-enum-descriptions` (and any other `x-*` extension MCP authors embed in their schemas). Gemini's proto-based function-call validator rejects any unknown field name, so the whole tools-bearing request fails.

This PR switches to **prefix-based stripping** for `x-*` (OpenAPI vendor extensions) and `$*` (JSON Schema metadata) on top of the existing allowlist. That handles arbitrary vendor extensions without us chasing each one.

## Why other users hit this and not all of us

Same cluster decision (`v0.32`, short prompts + tools → Gemini). What differs is the *tool definitions* Claude Code sends — 220+ tools loaded from heavy MCP suites carry `x-google-*` extensions; lighter sessions don't. Production logs show `function_declarations[71], [80], [81], [85], [87], [220]` all dying on the same field.

## Followup (not in this PR)

The same 400 also names `Unknown name "type" ... Proto field is …` (log truncated). Likely a JSON-Schema `"type": ["string","null"]` array form that Gemini's validator can't parse. Worth a separate PR once we have a clean repro.

## Test plan

- [x] `go test ./internal/translate/ -run "Gemini|sanitize"` — new regression test `TestPrepareGemini_StripsVendorExtensionAndDollarPrefixedKeys` covers top-level, nested-object, and leaf-property positions
- [x] Existing Gemini sanitizer tests still pass (allowlist still applies; `$schema` stripping is now covered by both paths)
- [ ] Stage canary against an affected install

🤖 Generated with [Claude Code](https://claude.com/claude-code)