### PR TITLE
ci(bump-workweave-pin): point sync_router_pricing at new pricing package

### DIFF
--- a/.github/workflows/bump-workweave-pin.yml
+++ b/.github/workflows/bump-workweave-pin.yml
@@ -44,7 +44,7 @@ jobs:
           path: router
           sparse-checkout: |
             install
-            internal/observability/otel
+            internal/router/pricing
           sparse-checkout-cone-mode: true
 
       - name: Checkout WorkWeave
@@ -88,7 +88,7 @@ jobs:
           # Regenerate eval/pricing.py from the updated pricing.go so the two
           # files never drift. Router is already sparse-checked-out above.
           python3 scripts/sync_router_pricing.py \
-            --pricing-go ../router/internal/observability/otel/pricing.go
+            --pricing-go ../router/internal/router/pricing/pricing.go
           git add router-internal/eval/pricing.py
 
           git commit \


### PR DESCRIPTION
## Summary

The pricing table moved out of \`internal/observability/otel/pricing.go\` (now a thin re-export of \`internal/router/pricing\`) into \`internal/router/pricing/pricing.go\`. The bump-workweave-pin workflow's sparse-checkout + \`--pricing-go\` arg still pointed at the old path, so every router → WorkWeave bump PR was failing with:

\`\`\`
ERROR: pricingTable not found in ../router/internal/observability/otel/pricing.go
\`\`\`

This points both at \`internal/router/pricing/pricing.go\`.

The matching WorkWeave-side script update (regex now matches \`var table\` and tolerates the new \`CacheReadMultiplier\` field) is in workweave/WorkWeave#7423; the script is also forward/backward-compatible — if anyone re-runs it with the legacy path, it auto-resolves to the inner-ring source.

## Test plan
- [ ] Merge this PR and confirm the bump-workweave-pin job creates a clean WorkWeave bump PR