### PR TITLE
fix(ci): drop --delete-branch from pin-bump auto-merge

### DIFF
--- a/.github/workflows/bump-workweave-pin.yml
+++ b/.github/workflows/bump-workweave-pin.yml
@@ -129,5 +129,4 @@ jobs:
           gh pr merge "$BRANCH" \
             --repo workweave/WorkWeave \
             --auto \
-            --squash \
-            --delete-branch
+            --squash


### PR DESCRIPTION
## Summary
- `gh pr merge` in the pin-bump workflow was failing with `Cannot use -d or --delete-branch when merge queue enabled` because WorkWeave's `main` is gated by a merge queue.
- Drop `--delete-branch`; the merge queue handles branch cleanup itself.

## Test plan
- [ ] Next router→WorkWeave pin-bump workflow run completes the "Enable auto-merge" step without erroring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)