### PR TITLE
proxy: suppress routing marker on tool-result follow-ups

### DIFF
--- a/internal/proxy/marker_internal_test.go
+++ b/internal/proxy/marker_internal_test.go
@@ -60,6 +60,7 @@ func TestRoutingMarkerFor_PlannerPaths(t *testing.T) {
 		res            turnLoopResult
 		wantContains   []string
 		wantNotContain []string
+		wantEmpty      bool
 	}{
 		{
 			name: "ev_positive: planner switched",
@@ -131,23 +132,25 @@ func TestRoutingMarkerFor_PlannerPaths(t *testing.T) {
 			},
 		},
 		{
-			name: "tool-result short-circuit: pinned model reused, no planner",
+			// Tool-result follow-ups are suppressed entirely — every
+			// post-tool turn would otherwise re-emit "Weave Router → …"
+			// mid-stream without conveying new routing info.
+			name: "tool-result short-circuit: marker suppressed",
 			res: turnLoopResult{
 				Decision:  decision,
 				StickyHit: true,
 			},
-			wantContains: []string{
-				"reason: tool-result follow-up",
-			},
-			wantNotContain: []string{
-				"est. save",
-			},
+			wantEmpty: true,
 		},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			got := routingMarkerFor(tc.res)
+			if tc.wantEmpty {
+				assert.Empty(t, got)
+				return
+			}
 			for _, want := range tc.wantContains {
 				assert.Contains(t, got, want)
 			}

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -140,6 +140,14 @@ func routingMarkerFor(res turnLoopResult) string {
 	if decision.Model == "" {
 		return ""
 	}
+	// Suppress the marker on tool-result follow-ups: every turn after a
+	// tool call would otherwise emit a duplicate "Weave Router → …" line
+	// mid-stream, which clutters the transcript without conveying new
+	// routing information. The planner / hard-pin / clamp branches still
+	// emit so genuine routing events stay visible.
+	if res.PlannerDecision.Reason == "" && !res.HardPinned && !res.TierClamped && res.StickyHit {
+		return ""
+	}
 	parts := []string{"✦ **Weave Router** → " + decision.Model}
 	if decision.Provider != "" {
 		parts[0] += " (" + decision.Provider + ")"


### PR DESCRIPTION
## Summary
- Suppress the inline `✦ **Weave Router** → … · reason: tool-result follow-up` marker on tool-result follow-up turns. Every post-tool turn in an agentic loop was re-emitting the marker mid-stream, cluttering transcripts without conveying new routing info.
- Markers still emit for genuine routing events: planner switches/stays, hard pins, tier clamps, and the first-turn top-scorer pick.

## Test plan
- [x] `go test ./internal/proxy/ -run TestRoutingMarker`