### PR TITLE
Makefile: drop PLATFORM=cc, always wire Claude Code interactively

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,8 +76,14 @@ full-setup: generate-statusline ## Bootstrap router: docker compose + seed + int
 			echo "error: KEY and BASE_URL must both be provided together."; \
 			exit 1; \
 		fi; \
+		COMPOSE_LOG="$$(mktemp -t full-setup-compose.XXXXXX.log)"; \
 		echo "==> Building and starting docker compose stack (postgres, migrate, server)..."; \
-		docker compose up --build -d; \
+		echo "    (build log: $$COMPOSE_LOG)"; \
+		if ! docker compose up --build -d >"$$COMPOSE_LOG" 2>&1; then \
+			echo "error: docker compose failed. Output:"; \
+			cat "$$COMPOSE_LOG"; \
+			exit 1; \
+		fi; \
 		echo "==> Waiting for the router to become healthy..."; \
 		for i in $$(seq 1 60); do \
 			if curl -fsS --max-time 2 http://localhost:8080/health >/dev/null 2>&1; then \
@@ -101,21 +107,9 @@ full-setup: generate-statusline ## Bootstrap router: docker compose + seed + int
 		echo "    key: $$WEAVE_KEY"; \
 		echo ""; \
 		echo "==> Wiring Claude Code → router (you'll be prompted for scope: user or project)..."; \
-		WEAVE_ROUTER_KEY="$$WEAVE_KEY" ./install/install.sh --base-url http://localhost:8080; \
+		WEAVE_ROUTER_KEY="$$WEAVE_KEY" ./install/install.sh --base-url http://localhost:8080 --quiet; \
 		echo ""; \
-		echo "Done. Router runs on http://localhost:8080."; \
-		echo ""; \
-		echo "Share with teammates (replace BASE_URL with a host they can reach,"; \
-		echo "e.g. an ngrok tunnel or a deployed router — localhost only works on this machine):"; \
-		echo "  make full-setup KEY=$$WEAVE_KEY BASE_URL=http://localhost:8080"; \
-		echo ""; \
-		echo "Cursor users: wire manually (see README \"Wiring Claude Code or Cursor\")."; \
-		echo "  Base URL: http://localhost:8080/v1"; \
-		echo "  API key:  $$WEAVE_KEY"; \
-		echo ""; \
-		echo "Useful follow-ups:"; \
-		echo "  make logs    # tail server logs"; \
-		echo "  make down    # stop the stack"; \
+		echo "Done. Router on http://localhost:8080. Share with teammates: make full-setup KEY=$$WEAVE_KEY BASE_URL=<reachable-url>"; \
 	fi
 
 db: ## Start the compose Postgres only (port 5433)

--- a/Makefile
+++ b/Makefile
@@ -55,35 +55,22 @@ seed: ## Create a local dev installation + API key and print usage instructions
 
 setup: migrate-up seed ## Bootstrap (host DB): init DB, run migrations, seed an API key
 
-full-setup: generate-statusline ## Bootstrap router: docker compose + seed + optional Claude Code wiring (see below)
+full-setup: generate-statusline ## Bootstrap router: docker compose + seed + interactively wire Claude Code
 	## Usage:
-	##   make full-setup                                  # boot compose, seed, print instructions
-	##   make full-setup PLATFORM=cc                      # boot + seed + auto-wire Claude Code
-	##   make full-setup PLATFORM=cc KEY=rk_... BASE_URL=http://...  # wire existing router to Claude Code
-	##   make full-setup PLATFORM=cc KEY=rk_... BASE_URL=http://... DIR=/tmp/test  # isolated throwaway install
-	##   make full-setup PLATFORM=cc KEY=rk_... BASE_URL=http://... SCOPE=project NON_INTERACTIVE=1  # CI-friendly
-	##   make full-setup KEY=rk_... BASE_URL=http://...  # print instructions for existing router
+	##   make full-setup                                  # boot compose, seed, wire Claude Code (interactive scope prompt)
+	##   make full-setup KEY=rk_... BASE_URL=http://...   # wire an already-running router to Claude Code
+	##   make full-setup KEY=rk_... BASE_URL=http://... DIR=/tmp/test         # isolated throwaway install
+	##   make full-setup KEY=rk_... BASE_URL=http://... SCOPE=user            # skip the interactive scope prompt
+	##   make full-setup KEY=rk_... BASE_URL=http://... SCOPE=user NON_INTERACTIVE=1  # CI-friendly
+	##
+	## Cursor wiring is manual — see README "Wiring Claude Code or Cursor".
 	@if [ -n "$(KEY)" ] && [ -n "$(BASE_URL)" ]; then \
-		if [ "$(PLATFORM)" = "cc" ]; then \
-			INSTALL_CMD='WEAVE_ROUTER_KEY="$(KEY)" ./install/install.sh --base-url "$(BASE_URL)"'; \
-			[ -n "$(SCOPE)" ] && INSTALL_CMD="$$INSTALL_CMD --scope $(SCOPE)"; \
-			[ -n "$(DIR)" ] && INSTALL_CMD="$$INSTALL_CMD --dir $(DIR)"; \
-			[ "$(NON_INTERACTIVE)" = "1" ] && INSTALL_CMD="$$INSTALL_CMD --non-interactive"; \
-			echo "==> Wiring Claude Code → $(BASE_URL)..."; \
-			eval "$$INSTALL_CMD"; \
-		else \
-			echo "Weave Router key:"; \
-			echo "  $(KEY)"; \
-			echo ""; \
-			echo "=== Claude Code ==="; \
-			echo "  export WEAVE_ROUTER_KEY=$(KEY)"; \
-			echo "  ./install/install.sh --base-url $(BASE_URL)"; \
-			echo ""; \
-			echo "=== Cursor ==="; \
-			echo "  1. Open Cursor Settings > Models > Override OpenAI Base URL"; \
-			echo "     Set to: $(BASE_URL)/v1"; \
-			echo "  2. Add API key: $(KEY)"; \
-		fi; \
+		INSTALL_CMD='WEAVE_ROUTER_KEY="$(KEY)" ./install/install.sh --base-url "$(BASE_URL)"'; \
+		[ -n "$(SCOPE)" ] && INSTALL_CMD="$$INSTALL_CMD --scope $(SCOPE)"; \
+		[ -n "$(DIR)" ] && INSTALL_CMD="$$INSTALL_CMD --dir $(DIR)"; \
+		[ "$(NON_INTERACTIVE)" = "1" ] && INSTALL_CMD="$$INSTALL_CMD --non-interactive"; \
+		echo "==> Wiring Claude Code → $(BASE_URL)..."; \
+		eval "$$INSTALL_CMD"; \
 	else \
 		if [ -n "$(KEY)" ] || [ -n "$(BASE_URL)" ]; then \
 			echo "error: KEY and BASE_URL must both be provided together."; \
@@ -113,40 +100,22 @@ full-setup: generate-statusline ## Bootstrap router: docker compose + seed + opt
 		fi; \
 		echo "    key: $$WEAVE_KEY"; \
 		echo ""; \
-		if [ "$(PLATFORM)" = "cc" ]; then \
-			echo "==> Wiring Claude Code → router..."; \
-			WEAVE_ROUTER_KEY="$$WEAVE_KEY" ./install/install.sh --base-url http://localhost:8080 --scope project --non-interactive; \
-			echo ""; \
-			echo "Done. Your local setup:"; \
-			echo "  • Router runs on http://localhost:8080"; \
-			echo "  • Claude Code is wired (.claude/settings.json + .claude/settings.local.json)"; \
-			echo ""; \
-			echo "Share with teammates (replace BASE_URL with a host they can reach,"; \
-			echo "e.g. an ngrok tunnel or a deployed router — localhost only works on this machine):"; \
-			echo "  make full-setup PLATFORM=cc KEY=$$WEAVE_KEY BASE_URL=http://localhost:8080"; \
-			echo ""; \
-			echo "Useful follow-ups:"; \
-			echo "  make logs    # tail server logs"; \
-			echo "  make down    # stop the stack"; \
-		else \
-			echo "Your local Weave Router is ready. Set up Claude Code or Cursor:"; \
-			echo ""; \
-			echo "=== Claude Code ==="; \
-			echo "  make full-setup PLATFORM=cc KEY=$$WEAVE_KEY BASE_URL=http://localhost:8080"; \
-			echo ""; \
-			echo "=== Cursor ==="; \
-			echo "  1. Open Cursor Settings > Models > Override OpenAI Base URL"; \
-			echo "     Set to: http://localhost:8080/v1"; \
-			echo "  2. Add API key: $$WEAVE_KEY"; \
-			echo ""; \
-			echo "Share with teammates (replace BASE_URL with a host they can reach,"; \
-			echo "e.g. an ngrok tunnel or a deployed router — localhost only works on this machine):"; \
-			echo "  make full-setup PLATFORM=cc KEY=$$WEAVE_KEY BASE_URL=http://localhost:8080"; \
-			echo ""; \
-			echo "Useful follow-ups:"; \
-			echo "  make logs    # tail server logs"; \
-			echo "  make down    # stop the stack"; \
-		fi; \
+		echo "==> Wiring Claude Code → router (you'll be prompted for scope: user or project)..."; \
+		WEAVE_ROUTER_KEY="$$WEAVE_KEY" ./install/install.sh --base-url http://localhost:8080; \
+		echo ""; \
+		echo "Done. Router runs on http://localhost:8080."; \
+		echo ""; \
+		echo "Share with teammates (replace BASE_URL with a host they can reach,"; \
+		echo "e.g. an ngrok tunnel or a deployed router — localhost only works on this machine):"; \
+		echo "  make full-setup KEY=$$WEAVE_KEY BASE_URL=http://localhost:8080"; \
+		echo ""; \
+		echo "Cursor users: wire manually (see README \"Wiring Claude Code or Cursor\")."; \
+		echo "  Base URL: http://localhost:8080/v1"; \
+		echo "  API key:  $$WEAVE_KEY"; \
+		echo ""; \
+		echo "Useful follow-ups:"; \
+		echo "  make logs    # tail server logs"; \
+		echo "  make down    # stop the stack"; \
 	fi
 
 db: ## Start the compose Postgres only (port 5433)

--- a/README.md
+++ b/README.md
@@ -100,12 +100,9 @@ make down   # stop the stack (keeps the postgres volume)
 
 ### Wiring Claude Code or Cursor
 
-`make full-setup` leaves you with a router on `localhost:8080` and an
-`rk_...` key. To point Claude Code or Cursor at it:
-
-```bash
-make full-setup PLATFORM=cc        # auto-wires ~/.claude/settings.json
-```
+`make full-setup` boots the router on `localhost:8080`, seeds an
+`rk_...` key, and runs the Claude Code installer interactively (it
+prompts whether to wire user scope or a project directory).
 
 Or manually:
 
@@ -127,7 +124,7 @@ To wire an already-running router (e.g. a shared/staging deployment)
 instead of booting locally:
 
 ```bash
-make full-setup PLATFORM=cc KEY=rk_... BASE_URL=https://router.example.com
+make full-setup KEY=rk_... BASE_URL=https://router.example.com
 ```
 
 > **Two different keys, do not confuse them.**

--- a/install/install.sh
+++ b/install/install.sh
@@ -21,6 +21,7 @@
 #   ./install.sh --local                          # local router on localhost:8080
 #   ./install.sh --base-url http://localhost:8080 # self-hosted, custom port
 #   ./install.sh --non-interactive                # require WEAVE_ROUTER_KEY env var
+#   ./install.sh --quiet                          # suppress banner, ping check, and trailing tips
 #
 #   curl -fsSL https://weave.ai/cc/install.sh | sh
 #   curl -fsSL https://weave.ai/cc/install.sh | sh -s -- --scope project
@@ -38,6 +39,7 @@ scope_explicit="false"
 install_dir=""
 base_url=""
 non_interactive="false"
+quiet="false"
 router_key_header="X-Weave-Router-Key"
 
 # ---------- helpers ----------
@@ -96,6 +98,9 @@ while [ $# -gt 0 ]; do
       ;;
     --non-interactive)
       non_interactive="true"; shift
+      ;;
+    --quiet)
+      quiet="true"; shift
       ;;
     --dir)
       install_dir="${2:-}"; shift 2
@@ -156,7 +161,7 @@ fi
 
 # ---------- pre-flight ----------
 
-info "Weave Router installer (scope=$scope, base_url=$base_url)"
+[ "$quiet" = "true" ] || info "Weave Router installer (scope=$scope, base_url=$base_url)"
 
 require_cmd jq    "macOS: 'brew install jq' · Debian/Ubuntu: 'sudo apt install jq'"
 require_cmd curl  "macOS/Linux: usually preinstalled — check your package manager"
@@ -597,11 +602,13 @@ fi
 
 # ---------- post-install verification ----------
 
-info "Pinging router at $base_url ..."
-if curl -fsS --max-time 5 "$base_url/health" >/dev/null 2>&1; then
-  ok "Router is reachable."
-else
-  warn "Could not reach $base_url/health within 5s. Settings are written; verify the router is running."
+if [ "$quiet" != "true" ]; then
+  info "Pinging router at $base_url ..."
+  if curl -fsS --max-time 5 "$base_url/health" >/dev/null 2>&1; then
+    ok "Router is reachable."
+  else
+    warn "Could not reach $base_url/health within 5s. Settings are written; verify the router is running."
+  fi
 fi
 
 if [ -n "$api_key" ]; then
@@ -620,7 +627,9 @@ fi
 
 printf "\n"
 ok "Weave Router installed for Claude Code."
-if [ "$scope" = "project" ]; then
+if [ "$quiet" = "true" ]; then
+  : # caller (e.g. make full-setup) prints its own next-steps block
+elif [ "$scope" = "project" ]; then
   if [ -n "$install_dir" ]; then
     echo "  Installed into $install_dir/.claude/ (project scope)."
     echo "  Run 'cd $install_dir && claude' to use the router."


### PR DESCRIPTION
## Summary

`make full-setup PLATFORM=cc` was hardcoded to `--scope project --non-interactive`, so the Claude Code installer always landed in the router checkout (CWD) with no prompt. That's not what you want when bootstrapping a local dev box.

- Drop the `PLATFORM` switch entirely. Cursor wiring is manual anyway, so the branching was dead weight.
- Local bootstrap path (no `KEY`/`BASE_URL`) now runs `install.sh --base-url http://localhost:8080` with no `--scope`/`--non-interactive`, so the installer's interactive scope prompt (user vs. project vs. dir) actually runs.
- `KEY`+`BASE_URL` path still honors optional `SCOPE`/`DIR`/`NON_INTERACTIVE` env knobs for CI use.
- README updated to drop `PLATFORM=cc` references and to call out the interactive prompt.

## Test plan

- [ ] `make full-setup` on a fresh box → confirm the installer prompts for scope and writes to the chosen location (not the router checkout).
- [ ] `make full-setup KEY=rk_... BASE_URL=http://localhost:8080` → confirm it still runs the installer non-interactively-ish (TTY-driven), respects `SCOPE`/`DIR`/`NON_INTERACTIVE`.
- [ ] `make -n full-setup` still parses cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)