### PR TITLE
proxy: strip routing marker from inbound message history

### DIFF
--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -672,6 +672,16 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 	buf := otel.NewBuffer(s.emitter)
 	ctx = buf.WithContext(ctx)
 
+	// Strip the routing marker that prior cross-format responses injected as
+	// standalone assistant text blocks. Without this, the marker round-trips
+	// through clients that preserve content verbatim and ends up in upstream
+	// context on every subsequent turn.
+	body, stripErr := translate.StripRoutingMarkerFromMessages(body)
+	if stripErr != nil {
+		log.Error("Failed to strip routing marker from inbound messages", "err", stripErr)
+		return fmt.Errorf("strip routing marker: %w", stripErr)
+	}
+
 	env, parseErr := translate.ParseAnthropic(body)
 	if parseErr != nil {
 		log.Error("Failed to parse Anthropic request", "err", parseErr)

--- a/internal/proxy/service_test.go
+++ b/internal/proxy/service_test.go
@@ -114,6 +114,45 @@ func TestService_ProxyMessages_CrossFormatUpstreamErrorBodyReachesClient(t *test
 	assert.Contains(t, respBody, `"type":"error"`, "body must be in Anthropic error envelope shape")
 }
 
+// TestService_ProxyMessages_StripsRoutingMarkerFromInboundHistory guards the
+// hygiene fix at internal/proxy/service.go: the routing-marker text injected
+// on prior cross-format responses (✦ **Weave Router** → ...) must not survive
+// into the upstream body. Without the strip, the marker round-trips through
+// clients that preserve assistant content verbatim and pollutes context on
+// every subsequent turn.
+func TestService_ProxyMessages_StripsRoutingMarkerFromInboundHistory(t *testing.T) {
+	const markerSentinel = "Weave Router"
+	body := []byte(`{
+		"model":"claude-opus-4-7",
+		"messages":[
+			{"role":"user","content":"first prompt"},
+			{"role":"assistant","content":[
+				{"type":"text","text":"✦ **Weave Router** → deepseek/deepseek-v4-pro (openrouter) · reason: top scorer\n\n"},
+				{"type":"text","text":"real assistant reply"}
+			]},
+			{"role":"user","content":[
+				{"type":"text","text":"</summary>\n<result>✦ **Weave Router** → claude-haiku-4-5 (anthropic) · reason: tool-result follow-up\n\n</result>"}
+			]}
+		]
+	}`)
+
+	provider := &fakeProvider{}
+	svc := makeProxyService(
+		router.Decision{Provider: providers.ProviderAnthropic, Model: "claude-haiku-4-5"},
+		map[string]providers.Client{providers.ProviderAnthropic: provider},
+	)
+
+	rec := httptest.NewRecorder()
+	httpReq := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(""))
+	require.NoError(t, svc.ProxyMessages(context.Background(), body, rec, httpReq))
+
+	require.Len(t, provider.proxyBodies, 1)
+	upstream := string(provider.proxyBodies[0])
+	assert.NotContains(t, upstream, markerSentinel, "routing marker must not reach upstream")
+	assert.Contains(t, upstream, "real assistant reply", "non-marker assistant content must survive")
+	assert.Contains(t, upstream, "</result>", "wrapper text around an embedded marker must survive")
+}
+
 func TestService_ProxyMessages_EmbedOnlyUserMessageFlag(t *testing.T) {
 	const firstUserPrompt = "Walk every Go file under router/internal/ and produce a one-paragraph summary of each."
 	const secondUserPrompt = "Now narrow it to handlers under internal/api/."

--- a/internal/translate/envelope.go
+++ b/internal/translate/envelope.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"regexp"
 	"strings"
 
 	"workweave/router/internal/router"
@@ -385,6 +386,113 @@ func stripThinkingBlocksBytes(body []byte) ([]byte, error) {
 			return false
 		}
 		msgRaws = append(msgRaws, newMsg)
+		return true
+	})
+
+	if walkErr != nil {
+		return nil, walkErr
+	}
+	if !anyChanged {
+		return body, nil
+	}
+
+	newMessagesArray := "[" + strings.Join(msgRaws, ",") + "]"
+	return sjson.SetRawBytes(body, "messages", []byte(newMessagesArray))
+}
+
+// encodeJSONStringNoHTMLEscape returns the JSON encoding of s without
+// HTML-escaping `<`, `>`, or `&`. Preserves whatever escaping the client
+// originally chose so that re-emitted message text matches the input byte
+// pattern as closely as possible (relevant for upstream prompt-cache keys).
+func encodeJSONStringNoHTMLEscape(s string) ([]byte, error) {
+	var buf strings.Builder
+	enc := json.NewEncoder(&buf)
+	enc.SetEscapeHTML(false)
+	if err := enc.Encode(s); err != nil {
+		return nil, err
+	}
+	out := buf.String()
+	// json.Encoder appends a trailing newline; strip it for sjson.
+	return []byte(strings.TrimSuffix(out, "\n")), nil
+}
+
+// routingMarkerPattern matches the upfront "✦ **Weave Router** → ..." snippet
+// that AnthropicSSETranslator emits as a standalone text block on cross-format
+// responses. Single-line, terminated by the literal "\n\n" appended in
+// routingMarkerFor; the body between prefix and terminator is opaque (varies
+// with model, provider, planner reason, and clamp note).
+var routingMarkerPattern = regexp.MustCompile(`✦ \*\*Weave Router\*\* → [^\n]*\n\n`)
+
+// StripRoutingMarkerFromMessages removes the routing-marker snippet from every
+// text block in messages[*].content[*]. The marker is injected on outbound
+// cross-format responses (see internal/translate/stream.go) and round-trips
+// through clients that preserve assistant content verbatim; stripping on
+// ingress keeps it out of upstream context and stabilizes the assistant
+// prefix for prompt-cache reuse. Mirrors stripThinkingBlocksBytes' two-phase
+// O(B) reconstruction.
+func StripRoutingMarkerFromMessages(body []byte) ([]byte, error) {
+	messages := gjson.GetBytes(body, "messages")
+	if !messages.Exists() || !messages.IsArray() {
+		return body, nil
+	}
+
+	anyChanged := false
+	var msgRaws []string
+	var walkErr error
+
+	messages.ForEach(func(_, msg gjson.Result) bool {
+		content := msg.Get("content")
+		if !content.Exists() || !content.IsArray() {
+			msgRaws = append(msgRaws, msg.Raw)
+			return true
+		}
+
+		var newBlocks []string
+		msgChanged := false
+		content.ForEach(func(_, block gjson.Result) bool {
+			if block.Get("type").String() != "text" {
+				newBlocks = append(newBlocks, block.Raw)
+				return true
+			}
+			text := block.Get("text").String()
+			if !routingMarkerPattern.MatchString(text) {
+				newBlocks = append(newBlocks, block.Raw)
+				return true
+			}
+			stripped := routingMarkerPattern.ReplaceAllString(text, "")
+			msgChanged = true
+			if strings.TrimSpace(stripped) == "" {
+				return true
+			}
+			encoded, err := encodeJSONStringNoHTMLEscape(stripped)
+			if err != nil {
+				walkErr = fmt.Errorf("marshal stripped text: %w", err)
+				return false
+			}
+			newBlock, err := sjson.SetRawBytes([]byte(block.Raw), "text", encoded)
+			if err != nil {
+				walkErr = fmt.Errorf("replace text in block: %w", err)
+				return false
+			}
+			newBlocks = append(newBlocks, string(newBlock))
+			return true
+		})
+		if walkErr != nil {
+			return false
+		}
+		if !msgChanged {
+			msgRaws = append(msgRaws, msg.Raw)
+			return true
+		}
+
+		anyChanged = true
+		newContent := "[" + strings.Join(newBlocks, ",") + "]"
+		newMsg, err := sjson.SetRawBytes([]byte(msg.Raw), "content", []byte(newContent))
+		if err != nil {
+			walkErr = fmt.Errorf("replace content in message: %w", err)
+			return false
+		}
+		msgRaws = append(msgRaws, string(newMsg))
 		return true
 	})
 

--- a/internal/translate/strip_marker_test.go
+++ b/internal/translate/strip_marker_test.go
@@ -1,0 +1,198 @@
+package translate_test
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"workweave/router/internal/translate"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+)
+
+const markerSentinel = "✦ **Weave Router**"
+
+// Sample markers covering every humanReasonFromPlanner output and the
+// no-planner fallbacks ("hard pin", "tool-result follow-up", "top scorer")
+// plus the clamp note tail. Keep in sync with internal/proxy/service.go.
+var sampleMarkers = []string{
+	"✦ **Weave Router** → claude-haiku-4-5 (anthropic) · reason: top scorer\n\n",
+	"✦ **Weave Router** → deepseek/deepseek-v4-pro (openrouter) · reason: scorer matches the pin\n\n",
+	"✦ **Weave Router** → deepseek/deepseek-v4-pro (openrouter) · reason: tool-result follow-up\n\n",
+	"✦ **Weave Router** → deepseek/deepseek-v4-pro (openrouter) · reason: switched to save on cache reads\n\n",
+	"✦ **Weave Router** → deepseek/deepseek-v4-pro (openrouter) · reason: stayed: cache reuse beats the switch\n\n",
+	"✦ **Weave Router** → claude-sonnet-4-5 (anthropic) · reason: model tier upgrade\n\n",
+	"✦ **Weave Router** → gemini-3.1-flash-lite-preview (google) · reason: hard pin (compaction / sub-agent)\n\n",
+	"✦ **Weave Router** → claude-opus-4-7 · reason: top scorer · second-choice pick (would have used claude-sonnet-4-5 — capped to your requested mid tier; request claude-opus-4-7 to unlock higher-tier picks)\n\n",
+}
+
+func TestStripRoutingMarker_AssistantBlockExactMatch(t *testing.T) {
+	marker := sampleMarkers[1]
+	body := buildBody(t, []map[string]any{
+		{"role": "user", "content": []any{textBlock("hi")}},
+		{"role": "assistant", "content": []any{textBlock(marker), textBlock("real response")}},
+	})
+
+	out, err := translate.StripRoutingMarkerFromMessages(body)
+	require.NoError(t, err)
+	assert.NotContains(t, string(out), markerSentinel)
+
+	content := gjson.GetBytes(out, "messages.1.content")
+	require.True(t, content.IsArray())
+	assert.Equal(t, 1, len(content.Array()), "marker-only block dropped, real text retained")
+	assert.Equal(t, "real response", content.Get("0.text").String())
+}
+
+func TestStripRoutingMarker_OnlyMarkerBlockDropsToEmptyContent(t *testing.T) {
+	body := buildBody(t, []map[string]any{
+		{"role": "assistant", "content": []any{textBlock(sampleMarkers[0])}},
+	})
+
+	out, err := translate.StripRoutingMarkerFromMessages(body)
+	require.NoError(t, err)
+	assert.NotContains(t, string(out), markerSentinel)
+
+	content := gjson.GetBytes(out, "messages.0.content")
+	require.True(t, content.IsArray())
+	assert.Equal(t, 0, len(content.Array()), "sole marker block dropped, leaving empty content")
+}
+
+func TestStripRoutingMarker_EmbeddedInUserBlockStripsSubstringOnly(t *testing.T) {
+	// Mirrors the sub-agent quoted-result case observed in production: marker
+	// sits inside a wrapping <task-notification>/<result> envelope, the rest
+	// of the text must survive verbatim.
+	embedded := "</summary>\n<result>" + sampleMarkers[2] + "</result>\n<usage><total_tokens>0</total_tokens></usage>"
+	body := buildBody(t, []map[string]any{
+		{"role": "user", "content": []any{textBlock(embedded)}},
+	})
+
+	out, err := translate.StripRoutingMarkerFromMessages(body)
+	require.NoError(t, err)
+	assert.NotContains(t, string(out), markerSentinel)
+
+	text := gjson.GetBytes(out, "messages.0.content.0.text").String()
+	assert.True(t, strings.HasPrefix(text, "</summary>\n<result>"))
+	assert.True(t, strings.HasSuffix(text, "</usage>"))
+}
+
+func TestStripRoutingMarker_MultipleOccurrencesInOneBlock(t *testing.T) {
+	text := sampleMarkers[0] + "some prose " + sampleMarkers[1] + "more prose " + sampleMarkers[2]
+	body := buildBody(t, []map[string]any{
+		{"role": "assistant", "content": []any{textBlock(text)}},
+	})
+
+	out, err := translate.StripRoutingMarkerFromMessages(body)
+	require.NoError(t, err)
+	assert.NotContains(t, string(out), markerSentinel)
+	stripped := gjson.GetBytes(out, "messages.0.content.0.text").String()
+	assert.Equal(t, "some prose more prose ", stripped)
+}
+
+func TestStripRoutingMarker_NoMarkerReturnsIdenticalSlice(t *testing.T) {
+	body := buildBody(t, []map[string]any{
+		{"role": "user", "content": []any{textBlock("plain prompt")}},
+		{"role": "assistant", "content": []any{textBlock("plain response")}},
+	})
+
+	out, err := translate.StripRoutingMarkerFromMessages(body)
+	require.NoError(t, err)
+	require.Equal(t, len(body), len(out))
+	// Identity check: when nothing changes we hand back the exact input slice.
+	assert.True(t, &body[0] == &out[0], "expected the same backing array when no marker present")
+}
+
+func TestStripRoutingMarker_AllPlannerReasonShapes(t *testing.T) {
+	for _, marker := range sampleMarkers {
+		t.Run(marker[:min(60, len(marker))], func(t *testing.T) {
+			body := buildBody(t, []map[string]any{
+				{"role": "assistant", "content": []any{textBlock(marker + "trailing model text")}},
+			})
+			out, err := translate.StripRoutingMarkerFromMessages(body)
+			require.NoError(t, err)
+			assert.NotContains(t, string(out), markerSentinel)
+			assert.Equal(t, "trailing model text", gjson.GetBytes(out, "messages.0.content.0.text").String())
+		})
+	}
+}
+
+func TestStripRoutingMarker_NonTextBlocksUntouched(t *testing.T) {
+	toolUse := map[string]any{
+		"type":  "tool_use",
+		"id":    "toolu_abc",
+		"name":  "Bash",
+		"input": map[string]any{"command": "ls"},
+	}
+	body := buildBody(t, []map[string]any{
+		{"role": "assistant", "content": []any{textBlock(sampleMarkers[1]), toolUse}},
+	})
+
+	out, err := translate.StripRoutingMarkerFromMessages(body)
+	require.NoError(t, err)
+	content := gjson.GetBytes(out, "messages.0.content")
+	require.Equal(t, 1, len(content.Array()))
+	assert.Equal(t, "tool_use", content.Get("0.type").String())
+	assert.Equal(t, "Bash", content.Get("0.name").String())
+}
+
+func TestStripRoutingMarker_EmptyAndMissingMessages(t *testing.T) {
+	cases := [][]byte{
+		[]byte(`{"model":"x","messages":[]}`),
+		[]byte(`{"model":"x"}`),
+		[]byte(`{"model":"x","messages":[{"role":"user","content":"plain string"}]}`),
+	}
+	for _, body := range cases {
+		out, err := translate.StripRoutingMarkerFromMessages(body)
+		require.NoError(t, err)
+		assert.Equal(t, body, out)
+	}
+}
+
+func TestStripRoutingMarker_StringContentNoOp(t *testing.T) {
+	// Some clients send messages[].content as a plain string. The marker is
+	// only injected inside content arrays, so string-content messages must be
+	// returned unchanged.
+	body := []byte(`{"messages":[{"role":"user","content":"hello"}]}`)
+	out, err := translate.StripRoutingMarkerFromMessages(body)
+	require.NoError(t, err)
+	assert.Equal(t, body, out)
+}
+
+func TestStripRoutingMarker_PreservesAdjacentFields(t *testing.T) {
+	marker := sampleMarkers[1]
+	body := buildBody(t, []map[string]any{
+		{"role": "assistant", "content": []any{textBlock(marker + "kept")}},
+	})
+	withExtras, err := json.Marshal(map[string]any{
+		"model":       "claude-opus-4-7",
+		"max_tokens":  64000,
+		"system":      "you are helpful",
+		"temperature": 0.7,
+		"messages":    json.RawMessage(gjson.GetBytes(body, "messages").Raw),
+	})
+	require.NoError(t, err)
+
+	out, err := translate.StripRoutingMarkerFromMessages(withExtras)
+	require.NoError(t, err)
+	assert.Equal(t, "claude-opus-4-7", gjson.GetBytes(out, "model").String())
+	assert.Equal(t, int64(64000), gjson.GetBytes(out, "max_tokens").Int())
+	assert.Equal(t, "you are helpful", gjson.GetBytes(out, "system").String())
+	assert.InDelta(t, 0.7, gjson.GetBytes(out, "temperature").Float(), 1e-9)
+	assert.Equal(t, "kept", gjson.GetBytes(out, "messages.0.content.0.text").String())
+}
+
+func textBlock(text string) map[string]any {
+	return map[string]any{"type": "text", "text": text}
+}
+
+func buildBody(t *testing.T, messages []map[string]any) []byte {
+	t.Helper()
+	body, err := json.Marshal(map[string]any{
+		"model":    "claude-opus-4-7",
+		"messages": messages,
+	})
+	require.NoError(t, err)
+	return body
+}
+

--- a/internal/translate/strip_marker_test.go
+++ b/internal/translate/strip_marker_test.go
@@ -195,4 +195,3 @@ func buildBody(t *testing.T, messages []map[string]any) []byte {
 	require.NoError(t, err)
 	return body
 }
-


### PR DESCRIPTION
## Summary

- The router emits a `✦ **Weave Router** → <model> · reason: ...` text block at the start of every cross-format streamed response (`AnthropicSSETranslator.WithRoutingMarker`). Because it's a real text content block — not an SSE event — clients like Claude Code preserve it in their transcript and re-send it on every subsequent turn.
- Production logs confirm the marker appears as `block 0` of every prior assistant turn in a multi-turn `/v1/messages` body, plus once embedded inside a sub-agent `<result>...</result>` envelope on a user turn.
- Token cost is small (~0.5%), but the marker varies turn-to-turn (model + reason change), destabilizing the assistant prefix and defeating upstream prompt-cache reuse on OpenRouter / Google. It also lets the model read its own routing prose.

## What changes

- New `translate.StripRoutingMarkerFromMessages` mirrors `stripThinkingBlocksBytes`' two-phase O(B) walk over `messages[*].content[*]`. For each text block: regex-strip every `✦ \*\*Weave Router\*\* → [^\n]*\n\n` occurrence; drop the block if the resulting text is empty; otherwise replace in-place without HTML-escaping so unrelated bytes (`<`, `>`, `&`) don't shift and disturb upstream cache keys.
- Wired into `proxy.Service.ProxyMessages` right before `ParseAnthropic`. Scope is `ProxyMessages` only — OpenAI/Gemini ingress and the Anthropic passthrough handler don't carry marker contamination today.
- When nothing changes, the function returns the input slice unchanged (identity preserved).

## Test plan

- [x] `go test ./internal/translate/ -run TestStripRoutingMarker` — 10 unit cases (exact match, embedded substring, multi-occurrence, no-op, missing/empty messages, string-content, every planner-reason variant, non-text blocks, adjacent-field preservation, identity slice).
- [x] `go test ./internal/proxy/ -run TestService_ProxyMessages_StripsRoutingMarker` — end-to-end ProxyMessages round-trip asserting the captured upstream body contains no `Weave Router` substring while non-marker content (including `</result>` wrapper) survives.
- [x] `go test ./...` — full router suite green.
- [x] `go vet ./...` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)