### PR TITLE
fix(translate): preserve thoughtSignature on text parts for Gemini 3.x round-trip

### DIFF
--- a/internal/translate/emit_gemini.go
+++ b/internal/translate/emit_gemini.go
@@ -611,7 +611,15 @@ func anthropicAssistantToGeminiParts(content any) ([]any, error) {
 			switch t, _ := block["type"].(string); t {
 			case "text":
 				if text, _ := block["text"].(string); text != "" {
-					parts = append(parts, map[string]any{"text": text})
+					part := map[string]any{"text": text}
+					// Gemini 3.x attaches thoughtSignature to the leading
+					// text/thinking part, not the subsequent functionCalls;
+					// dropping it here causes the next turn to 400 on
+					// missing signature for the functionCall parts.
+					if sig, _ := block["thought_signature"].(string); sig != "" {
+						part["thoughtSignature"] = sig
+					}
+					parts = append(parts, part)
 				}
 			case "tool_use":
 				name, _ := block["name"].(string)

--- a/internal/translate/gemini_stream.go
+++ b/internal/translate/gemini_stream.go
@@ -35,6 +35,11 @@ type GeminiToOpenAISSETranslator struct {
 	closed   bool
 	toolIdx  int
 	finished bool
+	// pendingSig is a thoughtSignature observed on a leading text part with
+	// no functionCall sibling to carry it. Gemini 3.x requires the next turn
+	// to round-trip the signature; we smuggle it onto the first tool_call
+	// chunk so the downstream Anthropic translator lands it on tool_use.
+	pendingSig string
 
 	usageSink otel.UsageSink
 }
@@ -175,6 +180,10 @@ func (t *GeminiToOpenAISSETranslator) translateEvent(raw []byte) error {
 					argsRaw = "{}"
 				}
 				sig := part.Get("thoughtSignature").String()
+				if sig == "" && t.pendingSig != "" {
+					sig = t.pendingSig
+				}
+				t.pendingSig = ""
 				if err := t.emitToolCallChunk(t.toolIdx, name, argsRaw, sig); err != nil {
 					emitErr = err
 					return false
@@ -183,6 +192,9 @@ func (t *GeminiToOpenAISSETranslator) translateEvent(raw []byte) error {
 				return true
 			}
 			if text := part.Get("text"); text.Exists() && text.String() != "" {
+				if sig := part.Get("thoughtSignature").String(); sig != "" && t.pendingSig == "" {
+					t.pendingSig = sig
+				}
 				if err := t.emitTextDelta(text.String()); err != nil {
 					emitErr = err
 					return false


### PR DESCRIPTION
## Summary

- Gemini 3.x preview models (e.g. `gemini-3.1-flash-lite-preview`) 400 on multi-turn tool use with `Function call is missing a thought_signature in functionCall parts` when the prior model turn placed the opaque `thoughtSignature` on a leading `text`/thinking part rather than on the `functionCall` itself. The translator was dropping that sig.
- `anthropicAssistantToGeminiParts` now reads `block["thought_signature"]` on `text` blocks and emits `thoughtSignature` on the Gemini text part, matching the existing `tool_use` arm.
- `GeminiToOpenAISSETranslator` captures a leading text part's `thoughtSignature` into `pendingSig` and forwards it on the first subsequent tool_call chunk's `function.thought_signature` when the call itself has no sig. The downstream Anthropic SSE translator already lands `function.thought_signature` on the `tool_use` block, so the round-trip survives Gemini → OpenAI → Anthropic.

The non-streaming Anthropic path (`buildAnthropicBlocksFromGemini`) already attaches sig to text blocks, so no change there. The OpenAI non-streaming path (`GeminiToOpenAIResponse` `leadingSig`) still drops sig when tool_calls are present — out of scope for this fix; happy to follow up.

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/translate/...`
- [ ] Manual: Claude Code → router → `gemini-3.1-flash-lite-preview` multi-turn with parallel Bash calls (the original repro)