### PR TITLE
proxy: persist cache_creation/cache_read tokens to telemetry rows

### DIFF
--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -1024,6 +1024,8 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 			ChosenScore:            obs.ChosenScore,
 			ClusterRouterVersion:   obs.ClusterRouterVersion,
 			TTFTMs:                 obs.TTFTMs,
+			CacheCreationTokens:    cacheTokenPtr(cacheCreation),
+			CacheReadTokens:        cacheTokenPtr(cacheRead),
 			DeviceID:               clientID.DeviceID,
 			SessionID:              clientID.SessionID,
 		})
@@ -1358,6 +1360,16 @@ func addTimingAttrs(ctx context.Context, b *otel.AttrBuilder) {
 		Int64("latency.router_overhead_ms", overhead)
 }
 
+// cacheTokenPtr returns nil for zero so the DB column stays NULL when the
+// upstream did not report cache usage, distinguishing "no cache" from "0 hits".
+func cacheTokenPtr(n int) *int32 {
+	if n <= 0 {
+		return nil
+	}
+	v := int32(n)
+	return &v
+}
+
 // fireTelemetry persists a telemetry row asynchronously. Telemetry loss is acceptable.
 func (s *Service) fireTelemetry(p InsertTelemetryParams) {
 	if s.telemetry == nil {
@@ -1684,6 +1696,8 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 			ChosenScore:            openaiObs.ChosenScore,
 			ClusterRouterVersion:   openaiObs.ClusterRouterVersion,
 			TTFTMs:                 openaiObs.TTFTMs,
+			CacheCreationTokens:    cacheTokenPtr(cacheCreation),
+			CacheReadTokens:        cacheTokenPtr(cacheRead),
 			DeviceID:               clientID.DeviceID,
 			SessionID:              clientID.SessionID,
 		})

--- a/internal/proxy/service_observation_test.go
+++ b/internal/proxy/service_observation_test.go
@@ -121,10 +121,51 @@ func TestProxyMessages_RecordsClusterObservation(t *testing.T) {
 	require.NotNil(t, row.ChosenScore)
 	assert.InDelta(t, 0.85, *row.ChosenScore, 1e-6)
 	assert.Equal(t, "v-test", row.ClusterRouterVersion)
-	// AlphaBreakdown / Cache* are W-1335 / W-1309 forward-compat slots; nil here.
+	// AlphaBreakdown is a W-1335 forward-compat slot; nil here.
+	// Cache* are nil because the fake provider returns no body, so the
+	// usage extractor reports 0 and cacheTokenPtr returns nil.
 	assert.Nil(t, row.AlphaBreakdown)
 	assert.Nil(t, row.CacheCreationTokens)
 	assert.Nil(t, row.CacheReadTokens)
+}
+
+// TestProxyMessages_PersistsCacheTokens covers the inverse of the above:
+// when the upstream actually reports cache_creation_input_tokens and
+// cache_read_input_tokens, those values must land on the telemetry row.
+// Regression guard against the W-1309 fields being declared but never wired.
+func TestProxyMessages_PersistsCacheTokens(t *testing.T) {
+	const installID = "44444444-4444-4444-4444-444444444444"
+	decision := router.Decision{
+		Provider: providers.ProviderAnthropic,
+		Model:    "claude-haiku-4-5",
+		Reason:   "pin",
+	}
+	telem := newCaptureTelemetry()
+	provider := &fakeProvider{
+		proxyResponse: func(w http.ResponseWriter) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"id":"msg_1","type":"message","role":"assistant","content":[{"type":"text","text":"ok"}],"model":"claude-haiku-4-5","stop_reason":"end_turn","usage":{"input_tokens":120,"output_tokens":7,"cache_creation_input_tokens":512,"cache_read_input_tokens":2048}}`))
+		},
+	}
+	svc := proxy.NewService(
+		&fakeRouter{decision: decision},
+		map[string]providers.Client{providers.ProviderAnthropic: provider},
+		nil, false, nil, nil, false,
+		providers.ProviderAnthropic, "claude-haiku-4-5",
+		telem,
+	)
+
+	ctx := context.WithValue(context.Background(), proxy.InstallationIDContextKey{}, installID)
+	rec := httptest.NewRecorder()
+	body := []byte(`{"model":"claude-opus-4-7","messages":[{"role":"user","content":"hello"}]}`)
+	httpReq := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(""))
+	require.NoError(t, svc.ProxyMessages(ctx, body, rec, httpReq))
+
+	row := telem.firstRow(t)
+	require.NotNil(t, row.CacheCreationTokens, "cache_creation_input_tokens must persist as *int32, not be dropped")
+	assert.Equal(t, int32(512), *row.CacheCreationTokens)
+	require.NotNil(t, row.CacheReadTokens, "cache_read_input_tokens must persist as *int32, not be dropped")
+	assert.Equal(t, int32(2048), *row.CacheReadTokens)
 }
 
 // TestProxyMessages_ChosenScoreZeroIsPersisted pins the *float64 semantics:

--- a/internal/proxy/telemetry.go
+++ b/internal/proxy/telemetry.go
@@ -54,8 +54,8 @@ type InsertTelemetryParams struct {
 	AlphaBreakdown       []byte // pre-marshaled JSON for W-1335; nil until then
 	ClusterRouterVersion string
 	TTFTMs               *int64
-	CacheCreationTokens  *int32 // W-1309 forward-compat; nil until populated
-	CacheReadTokens      *int32 // W-1309 forward-compat; nil until populated
+	CacheCreationTokens  *int32 // nil when the upstream reported no cache usage
+	CacheReadTokens      *int32 // nil when the upstream reported no cache usage
 	DeviceID             string
 	SessionID            string
 }


### PR DESCRIPTION
## Summary

The `model_router_request_telemetry` table has `cache_creation_tokens` and `cache_read_tokens` columns and the Postgres adapter already forwards them, but the proxy never populated the `InsertTelemetryParams` fields — they were declared in `internal/proxy/telemetry.go` with the comment *"W-1309 forward-compat; nil until populated"* and left at nil at both `fireTelemetry` call sites.

Result: every row in the telemetry table had NULL cache columns even when the upstream returned cache token counts. Meanwhile `session_pins.last_cached_read_tokens` was being written from the same `extractor.CacheTokens()` source, so the data existed in one place and was silently dropped in the other. The dashboards drilling into telemetry consequently underreported caching to zero.

## Changes

- Add `cacheTokenPtr(int) *int32` helper in `internal/proxy/service.go` that returns nil for zero (preserves NULL when the upstream reports no cache usage, so "no cache" stays distinguishable from a real 0 in future analytics).
- Wire `CacheCreationTokens` / `CacheReadTokens` on both `fireTelemetry` calls — the Anthropic path at `service.go:998` and the OpenAI path at `service.go:1658`.
- Update the stale `// W-1309 forward-compat` comments on the struct fields.
- Add `TestProxyMessages_PersistsCacheTokens` to assert the round-trip from a fake upstream returning `cache_creation_input_tokens: 512, cache_read_input_tokens: 2048` lands on the captured telemetry row. Pairs with the existing observation tests that assert nil when the upstream reports nothing.

## Test plan

- [x] `go test ./internal/proxy/ -count=1` — passes
- [x] `go build ./...` — clean
- [ ] After deploy, query `model_router_request_telemetry` for the next hour and confirm rows now have non-NULL `cache_read_tokens` where `session_pins` shows hits

## Out of scope

- The `internal/proxy/gemini.go` path (`ProxyGeminiGenerateContent`) does not call `fireTelemetry` at all today; adding that is a separate change.
- Cross-format `cache_control` forwarding (so OpenRouter / Gemini targets are *asked* to cache) is a follow-up — this PR just makes the existing implicit-caching signal visible.