### PR TITLE
translate,otel: extract Gemini cachedContentTokenCount end-to-end

### DIFF
--- a/internal/observability/otel/usage.go
+++ b/internal/observability/otel/usage.go
@@ -235,9 +235,19 @@ func (u *UsageExtractor) tryExtractFromJSON() {
 
 // extractUsageGJSON probes for token usage fields using gjson, avoiding
 // json.Unmarshal and map[string]any allocations entirely. OpenAI has no
-// cache-creation concept (cacheRead maps to prompt_tokens_details.cached_tokens);
-// Google emits neither cache field.
+// cache-creation concept (cacheRead maps to prompt_tokens_details.cached_tokens).
+// Google's native :generateContent surface uses usageMetadata with
+// cachedContentTokenCount; the OpenAI-compat surface uses the OpenAI shape.
 func extractUsageGJSON(data []byte, provider string) (input, output, cacheCreation, cacheRead int, found bool) {
+	if provider == providerGoogle {
+		if meta := gjson.GetBytes(data, "usageMetadata"); meta.Exists() {
+			input = int(meta.Get("promptTokenCount").Int())
+			output = int(meta.Get("candidatesTokenCount").Int())
+			cacheRead = int(meta.Get("cachedContentTokenCount").Int())
+			return input, output, 0, cacheRead, true
+		}
+	}
+
 	usage := gjson.GetBytes(data, "usage")
 	if !usage.Exists() && provider == providerAnthropic {
 		usage = gjson.GetBytes(data, "message.usage")

--- a/internal/observability/otel/usage_test.go
+++ b/internal/observability/otel/usage_test.go
@@ -199,6 +199,26 @@ func TestUsageExtractor_OpenAICacheTokens_Streaming(t *testing.T) {
 	assert.Equal(t, 7, cacheRead)
 }
 
+func TestUsageExtractor_GoogleNativeCacheTokens_NonStreaming(t *testing.T) {
+	rec := httptest.NewRecorder()
+	ext := otel.NewUsageExtractor(rec, "google")
+
+	// Native Gemini :generateContent body — no "usage" field, only "usageMetadata"
+	// with cachedContentTokenCount. Without the native-shape branch the
+	// extractor returned all zeros and Gemini caching was invisible end-to-end.
+	body := `{"candidates":[{"content":{"parts":[{"text":"ok"}]},"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":1200,"candidatesTokenCount":4,"totalTokenCount":1204,"cachedContentTokenCount":1024}}`
+	_, err := ext.Write([]byte(body))
+	require.NoError(t, err)
+
+	in, out := ext.Tokens()
+	assert.Equal(t, 1200, in)
+	assert.Equal(t, 4, out)
+
+	cacheCreation, cacheRead := ext.CacheTokens()
+	assert.Equal(t, 0, cacheCreation)
+	assert.Equal(t, 1024, cacheRead)
+}
+
 func TestUsageExtractor_RecordCacheUsage_NilReceiver(t *testing.T) {
 	var ext *otel.UsageExtractor
 	creation, read := ext.CacheTokens()

--- a/internal/translate/cache_usage_test.go
+++ b/internal/translate/cache_usage_test.go
@@ -104,3 +104,57 @@ func TestAnthropicSSETranslator_MessageStartCarriesEstimatedInputTokens(t *testi
 	startSegment := body[startIdx:deltaIdx]
 	assert.Contains(t, startSegment, `"usage":{"input_tokens":1234,"output_tokens":0}`)
 }
+
+// Catches the Gemini cachedContentTokenCount field being dropped on its way
+// to the usage sink. Gemini implicit caching is the only signal we have that
+// caching is working at all on the Gemini path, so this number must reach
+// recordTurnUsage → session_pins / telemetry.
+func TestGeminiSSETranslator_ForwardsCachedContentTokenCount(t *testing.T) {
+	rec := httptest.NewRecorder()
+	sink := &fakeUsageSink{}
+	translator := translate.NewGeminiToOpenAISSETranslator(rec, "gemini-3.1-flash-lite-preview", sink)
+
+	translator.Header().Set("Content-Type", "text/event-stream")
+	translator.WriteHeader(http.StatusOK)
+
+	chunks := []string{
+		`data: {"candidates":[{"content":{"parts":[{"text":"ok"}]}}]}` + "\n\n",
+		`data: {"candidates":[{"content":{"parts":[]},"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":2048,"candidatesTokenCount":4,"totalTokenCount":2052,"cachedContentTokenCount":1900}}` + "\n\n",
+	}
+	for _, c := range chunks {
+		_, err := translator.Write([]byte(c))
+		require.NoError(t, err)
+	}
+	require.NoError(t, translator.Finalize())
+
+	assert.Equal(t, 2048, sink.input)
+	assert.Equal(t, 4, sink.output)
+	assert.Equal(t, 0, sink.cacheCreation, "Gemini reports only cache reads, not creation")
+	assert.Equal(t, 1900, sink.cacheRead)
+
+	// The serialized OpenAI chunk must carry prompt_tokens_details.cached_tokens
+	// so the downstream AnthropicSSETranslator picks it up via gjson at the
+	// path it already reads (stream.go:604).
+	body := rec.Body.String()
+	assert.Contains(t, body, `"prompt_tokens_details":{"cached_tokens":1900}`)
+}
+
+// Same field, non-streaming path (Gemini :generateContent returned as a single
+// JSON body rather than SSE). Same propagation requirement.
+func TestGeminiSSETranslator_NonStreamingForwardsCachedContentTokenCount(t *testing.T) {
+	rec := httptest.NewRecorder()
+	sink := &fakeUsageSink{}
+	translator := translate.NewGeminiToOpenAISSETranslator(rec, "gemini-3.1-flash-lite-preview", sink)
+
+	translator.Header().Set("Content-Type", "application/json")
+	translator.WriteHeader(http.StatusOK)
+
+	body := `{"candidates":[{"content":{"parts":[{"text":"ok"}]},"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":1500,"candidatesTokenCount":3,"totalTokenCount":1503,"cachedContentTokenCount":1200}}`
+	_, err := translator.Write([]byte(body))
+	require.NoError(t, err)
+	require.NoError(t, translator.Finalize())
+
+	assert.Equal(t, 1500, sink.input)
+	assert.Equal(t, 3, sink.output)
+	assert.Equal(t, 1200, sink.cacheRead)
+}

--- a/internal/translate/gemini_stream.go
+++ b/internal/translate/gemini_stream.go
@@ -125,6 +125,9 @@ func (t *GeminiToOpenAISSETranslator) Finalize() error {
 				int(usage.Get("promptTokenCount").Int()),
 				int(usage.Get("candidatesTokenCount").Int()),
 			)
+			if cached := int(usage.Get("cachedContentTokenCount").Int()); cached > 0 {
+				t.usageSink.RecordCacheUsage(0, cached)
+			}
 		}
 	}
 
@@ -236,6 +239,7 @@ func geminiUsageFromBytes(data []byte) map[string]int {
 	prompt := int(r.Get("promptTokenCount").Int())
 	completion := int(r.Get("candidatesTokenCount").Int())
 	total := int(r.Get("totalTokenCount").Int())
+	cached := int(r.Get("cachedContentTokenCount").Int())
 	if total == 0 {
 		total = prompt + completion
 	}
@@ -243,6 +247,7 @@ func geminiUsageFromBytes(data []byte) map[string]int {
 		"prompt_tokens":     prompt,
 		"completion_tokens": completion,
 		"total_tokens":      total,
+		"cached_tokens":     cached,
 	}
 }
 
@@ -294,16 +299,8 @@ func (t *GeminiToOpenAISSETranslator) emitFinalChunk(finishReason string, usage 
 	sse.WriteJSONString(t.bw, finishReason)
 	t.bw.WriteString(`}]`)
 	if usage != nil {
-		t.bw.WriteString(`,"usage":{"prompt_tokens":`)
-		sse.WriteJSONInt(t.bw, int64(usage["prompt_tokens"]))
-		t.bw.WriteString(`,"completion_tokens":`)
-		sse.WriteJSONInt(t.bw, int64(usage["completion_tokens"]))
-		t.bw.WriteString(`,"total_tokens":`)
-		sse.WriteJSONInt(t.bw, int64(usage["total_tokens"]))
-		t.bw.WriteByte('}')
-		if t.usageSink != nil {
-			t.usageSink.RecordUsage(usage["prompt_tokens"], usage["completion_tokens"])
-		}
+		t.writeUsageJSON(usage)
+		t.recordUsageOnSink(usage)
 	}
 	t.bw.WriteString("}\n\n")
 	return t.flushEvent()
@@ -311,17 +308,40 @@ func (t *GeminiToOpenAISSETranslator) emitFinalChunk(finishReason string, usage 
 
 func (t *GeminiToOpenAISSETranslator) emitUsageOnlyChunk(usage map[string]int) error {
 	t.writeChunkHeader()
-	t.bw.WriteString(`"choices":[],"usage":{"prompt_tokens":`)
+	t.bw.WriteString(`"choices":[]`)
+	t.writeUsageJSON(usage)
+	t.bw.WriteString("}\n\n")
+	t.recordUsageOnSink(usage)
+	return t.flushEvent()
+}
+
+// writeUsageJSON serializes an OpenAI-shape usage object onto t.bw, including
+// prompt_tokens_details.cached_tokens when Gemini reported a cached prefix.
+// The nested shape matches what AnthropicSSETranslator.extractAndForwardUsage
+// reads via gjson, so cache numbers propagate through the chain.
+func (t *GeminiToOpenAISSETranslator) writeUsageJSON(usage map[string]int) {
+	t.bw.WriteString(`,"usage":{"prompt_tokens":`)
 	sse.WriteJSONInt(t.bw, int64(usage["prompt_tokens"]))
 	t.bw.WriteString(`,"completion_tokens":`)
 	sse.WriteJSONInt(t.bw, int64(usage["completion_tokens"]))
 	t.bw.WriteString(`,"total_tokens":`)
 	sse.WriteJSONInt(t.bw, int64(usage["total_tokens"]))
-	t.bw.WriteString("}}\n\n")
-	if t.usageSink != nil {
-		t.usageSink.RecordUsage(usage["prompt_tokens"], usage["completion_tokens"])
+	if cached := usage["cached_tokens"]; cached > 0 {
+		t.bw.WriteString(`,"prompt_tokens_details":{"cached_tokens":`)
+		sse.WriteJSONInt(t.bw, int64(cached))
+		t.bw.WriteByte('}')
 	}
-	return t.flushEvent()
+	t.bw.WriteByte('}')
+}
+
+func (t *GeminiToOpenAISSETranslator) recordUsageOnSink(usage map[string]int) {
+	if t.usageSink == nil {
+		return
+	}
+	t.usageSink.RecordUsage(usage["prompt_tokens"], usage["completion_tokens"])
+	if cached := usage["cached_tokens"]; cached > 0 {
+		t.usageSink.RecordCacheUsage(0, cached)
+	}
 }
 
 func (t *GeminiToOpenAISSETranslator) emitDone() error {


### PR DESCRIPTION
## Summary

Companion to #123 (merged). With #123 the telemetry table starts receiving whatever the proxy extracts — this PR fixes the extractor for Gemini, which today drops the only cache signal Gemini provides.

Per-model telemetry over the last 12h:

| Model | Sessions | Turns | Last-turn cache % | Sessions w/ any hit |
|---|---|---|---|---|
| deepseek/deepseek-v4-pro | 4 | 319 | 69% | 3/4 |
| gemini-3.1-flash-lite-preview | 4 | 159 | **0%** | **0/4** |
| moonshotai/kimi-k2.5 | 1 | 4 | 0% | 0/1 |

Gemini was 0/4 sessions, 0/159 turns despite 511K input tokens across sessions whose prefixes were all well above the 1024-token cache threshold. Root cause: `usageMetadata.cachedContentTokenCount` is the only field Gemini populates for implicit cache hits, and nothing in the router reads it.

## Where the read was missing

The Anthropic-format → Gemini path in `proxy.Service.ProxyMessages` builds this chain:

```
Gemini upstream → GeminiToOpenAISSETranslator → AnthropicSSETranslator → recordTurnUsage → session_pins
```

- `geminiUsageFromBytes` parsed `promptTokenCount` and `candidatesTokenCount` but ignored `cachedContentTokenCount`.
- `emitFinalChunk` / `emitUsageOnlyChunk` serialized an OpenAI-shape `usage` object without `prompt_tokens_details.cached_tokens`, so the downstream `AnthropicSSETranslator.extractAndForwardUsage` (which already reads that exact field) saw zero.
- `Finalize`'s non-SSE branch called `RecordUsage` but not `RecordCacheUsage`.

Separately, the OTel `UsageExtractor` used for the native `ProxyGeminiGenerateContent` path looked for a top-level `usage` field that Gemini's native endpoint never emits, so it returned all zeros regardless of cache state.

## Changes

- `internal/translate/gemini_stream.go`:
  - `geminiUsageFromBytes` now extracts `cachedContentTokenCount` into a `cached_tokens` key on the returned map.
  - Hoisted the usage JSON serialization and sink recording into `writeUsageJSON` / `recordUsageOnSink` so the streaming/usage-only/non-streaming paths all emit `prompt_tokens_details.cached_tokens` and call `RecordCacheUsage(0, cached)` consistently.
- `internal/observability/otel/usage.go`: `extractUsageGJSON` learns Gemini's native shape — when provider is `google` and the body has `usageMetadata`, read `promptTokenCount` / `candidatesTokenCount` / `cachedContentTokenCount`. OpenAI-compat path is unchanged.
- Tests in `internal/translate/cache_usage_test.go` and `internal/observability/otel/usage_test.go` assert both the sink and the serialized OpenAI chunk receive the cached count. Existing non-cached tests still pass (the `cached_tokens` field is only emitted when > 0).

## Out of scope

- Body-level translation to the client (`openAIUsageToAnthropicResponse`, `geminiUsageToAnthropic`) still drops `cache_read_input_tokens` from the Anthropic response payload. Affects client-facing display in Claude Code but not router-side observability. Follow-up.
- Kimi via OpenRouter is 0% because OpenRouter requires explicit `cache_control` markers for Moonshot models, unlike DeepSeek's server-side auto-cache. Forwarding `cache_control` through `AnthropicToOpenAIRequest` is separate.

## Test plan

- [x] \`go test ./... -count=1\` — all green
- [x] \`go build ./...\` — clean
- [ ] After deploy: query \`model_router_request_telemetry\` filtered to \`decision_model = 'gemini-3.1-flash-lite-preview'\` for the next hour and confirm \`cache_read_tokens\` is non-NULL on long-prefix sessions
- [ ] Confirm \`session_pins.last_cached_read_tokens\` starts populating for Gemini sessions