### PR TITLE
feat(translate): disable reasoning for deepseek/* on OpenRouter

### DIFF
--- a/internal/translate/emit_openai.go
+++ b/internal/translate/emit_openai.go
@@ -43,6 +43,12 @@ func (e *RequestEnvelope) buildOpenAIFromOpenAI(opts EmitOptions) ([]byte, error
 			return nil, fmt.Errorf("set openrouter provider hint: %w", err)
 		}
 	}
+	if reasoning := openRouterReasoningHint(opts.TargetModel); reasoning != nil {
+		body, err = sjson.SetBytes(body, "reasoning", reasoning)
+		if err != nil {
+			return nil, fmt.Errorf("set openrouter reasoning hint: %w", err)
+		}
+	}
 	return body, nil
 }
 
@@ -88,6 +94,9 @@ func (e *RequestEnvelope) buildOpenAIFromAnthropic(opts EmitOptions) ([]byte, er
 
 	if hint := openRouterProviderHint(opts.TargetModel); hint != nil {
 		out["provider"] = hint
+	}
+	if reasoning := openRouterReasoningHint(opts.TargetModel); reasoning != nil {
+		out["reasoning"] = reasoning
 	}
 
 	return json.Marshal(out)

--- a/internal/translate/provider_hint.go
+++ b/internal/translate/provider_hint.go
@@ -31,3 +31,20 @@ func openRouterProviderHint(model string) map[string]any {
 	}
 	return nil
 }
+
+// openRouterReasoningHint returns the OpenRouter `reasoning` request-body
+// field for models whose default reasoning behavior burns the entire
+// max_tokens budget on hidden thinking, leaving zero visible content for
+// the caller. Returns nil for models that don't need the override.
+//
+// Native DeepSeek serving deepseek/* defaults to reasoning-on, and at
+// agentic max_tokens budgets (1-2K) reliably emits 2000 reasoning tokens
+// and 0 visible tokens — the user waits a minute and gets nothing. Only
+// `reasoning.enabled=false` actually disables it; `effort=minimal` and
+// `max_tokens=0` are ignored by the upstream.
+func openRouterReasoningHint(model string) map[string]any {
+	if strings.HasPrefix(model, "deepseek/") {
+		return map[string]any{"enabled": false}
+	}
+	return nil
+}

--- a/internal/translate/provider_hint_test.go
+++ b/internal/translate/provider_hint_test.go
@@ -89,6 +89,62 @@ func TestPrepareOpenAI_NoHintForUnrecognizedModel(t *testing.T) {
 		"first-party OpenAI/Fireworks targets must not get a provider hint")
 }
 
+// reasoningField extracts the `reasoning` field from an emitted OpenAI body.
+func reasoningField(t *testing.T, body []byte) map[string]any {
+	t.Helper()
+	var doc map[string]any
+	require.NoError(t, json.Unmarshal(body, &doc))
+	r, _ := doc["reasoning"].(map[string]any)
+	return r
+}
+
+func TestPrepareOpenAI_AnthropicSource_DisablesReasoningForDeepSeek(t *testing.T) {
+	src := []byte(`{"model":"claude-opus-4-7","messages":[{"role":"user","content":"hi"}],"max_tokens":256}`)
+	env, err := translate.ParseAnthropic(src)
+	require.NoError(t, err)
+
+	out, err := env.PrepareOpenAI(nil, translate.EmitOptions{
+		TargetModel: "deepseek/deepseek-v4-pro",
+	})
+	require.NoError(t, err)
+
+	r := reasoningField(t, out.Body)
+	require.NotNil(t, r, "deepseek/* must get a reasoning override")
+	assert.Equal(t, false, r["enabled"])
+}
+
+func TestPrepareOpenAI_OpenAISource_DisablesReasoningForDeepSeek(t *testing.T) {
+	src := []byte(`{"model":"x","messages":[{"role":"user","content":"hi"}],"max_tokens":256}`)
+	env, err := translate.ParseOpenAI(src)
+	require.NoError(t, err)
+
+	out, err := env.PrepareOpenAI(nil, translate.EmitOptions{
+		TargetModel: "deepseek/deepseek-v4-pro",
+	})
+	require.NoError(t, err)
+
+	r := reasoningField(t, out.Body)
+	require.NotNil(t, r)
+	assert.Equal(t, false, r["enabled"])
+}
+
+func TestPrepareOpenAI_NoReasoningOverrideForNonDeepSeek(t *testing.T) {
+	cases := []string{"moonshotai/kimi-k2.5", "qwen/qwen3-max", "google/gemini-2.5-pro", "gpt-5"}
+	for _, model := range cases {
+		t.Run(model, func(t *testing.T) {
+			src := []byte(`{"model":"claude-opus-4-7","messages":[{"role":"user","content":"hi"}],"max_tokens":256}`)
+			env, err := translate.ParseAnthropic(src)
+			require.NoError(t, err)
+
+			out, err := env.PrepareOpenAI(nil, translate.EmitOptions{TargetModel: model})
+			require.NoError(t, err)
+
+			assert.Nil(t, reasoningField(t, out.Body),
+				"non-deepseek targets must not get a reasoning override")
+		})
+	}
+}
+
 func TestPrepareOpenAI_QwenAndGoogleGetSortHint(t *testing.T) {
 	cases := []string{"qwen/qwen3-max", "google/gemini-2.5-pro"}
 	for _, model := range cases {


### PR DESCRIPTION
## Summary

Inject `reasoning: {enabled: false}` into every OpenRouter request body for `deepseek/*` targets. Native DeepSeek's default reasoning-on behavior burns the entire `max_tokens` budget on hidden thinking at agentic budgets (1–2K tokens), returning **zero visible content** after 60+ seconds.

## Why

Probe results against `deepseek/deepseek-v4-pro` (native DeepSeek pin, 2K max_tokens, ~1.2K-token system prompt):

| Config | Visible tok | Reasoning tok | TTFT | Visible TPS |
|---|---|---|---|---|
| Baseline (no override) | **0** | 2000 | n/a | **0** |
| `reasoning.enabled=false` | **2000** | **0** | **1.07s** | **36.5** |
| `reasoning.effort=minimal` | 0 | 2000 | n/a | 0 |
| `reasoning.max_tokens=0` | 0 | 2000 | n/a | 0 |
| `reasoning.exclude=true` | 0 | 2000 | n/a | 0 |

Only `enabled: false` actually disables reasoning on the upstream. The other knobs are silently ignored. Cache hit rate stays at 93–96% — the existing native-DeepSeek pin is unaffected.

## Changes

- `internal/translate/provider_hint.go` — new `openRouterReasoningHint(model)` helper, returning `{"enabled": false}` for `deepseek/*`.
- `internal/translate/emit_openai.go` — inject the reasoning hint in both `buildOpenAIFromOpenAI` (via sjson) and `buildOpenAIFromAnthropic` (via map), next to the existing provider hint.
- `internal/translate/provider_hint_test.go` — three new tests: Anthropic-source path, OpenAI-source path, and a negative case covering moonshot/qwen/google/gpt-5.

## Tradeoffs

Disabling reasoning will hurt quality on genuinely hard turns (architectural decisions, subtle debugging). Expectation based on V3-class non-reasoner gaps: 5–15 percentage points on coding/math benchmarks. For agentic coding specifically the gap is usually smaller because most turns are easy (read a file, run a command). The current state — `deepseek/*` routes return nothing — is unusable, so even a quality-reduced visible answer is a strict improvement.

Re-running the eval harness with the override is recommended before promoting to broader traffic.

## Test plan

- [ ] `go test ./internal/translate/...` passes locally (verified)
- [ ] Hit a deepseek/* slug through the router, confirm `reasoning_tokens` is 0 and the response contains visible content
- [ ] Confirm cache hit rate on warm turns is unchanged (~93–96%)
- [ ] Re-run cluster eval against `deepseek-v4-pro@deepseek` with the override and compare to the previous rankings

🤖 Generated with [Claude Code](https://claude.com/claude-code)