### PR TITLE
turntype: add Classifier turn type, hard-pin Claude Code security monitor

### DIFF
--- a/internal/proxy/service_cache_test.go
+++ b/internal/proxy/service_cache_test.go
@@ -35,7 +35,10 @@ func embeddingFixture(seed float32) []float32 {
 	return out
 }
 
-// anthropicBody returns a minimal valid Anthropic Messages body.
+// anthropicBody returns a minimal valid Anthropic Messages body. Includes a
+// stub tool so the request stays classified as MainLoop — without it the
+// turntype detector would fingerprint it as Classifier (small max_tokens,
+// no tools, short message list) and hard-pin past the semantic cache.
 func anthropicBody(prompt string, stream bool) []byte {
 	streamLit := "false"
 	if stream {
@@ -45,6 +48,7 @@ func anthropicBody(prompt string, stream bool) []byte {
 		"model":"claude-opus-4-7",
 		"max_tokens":256,
 		"stream":` + streamLit + `,
+		"tools":[{"name":"noop","description":"placeholder","input_schema":{"type":"object"}}],
 		"messages":[{"role":"user","content":"` + prompt + `"}]
 	}`)
 }

--- a/internal/proxy/turnloop.go
+++ b/internal/proxy/turnloop.go
@@ -130,6 +130,7 @@ func (s *Service) runTurnLoop(
 	if res.TurnType == turntype.Compaction ||
 		res.TurnType == turntype.Probe ||
 		res.TurnType == turntype.TitleGen ||
+		res.TurnType == turntype.Classifier ||
 		(res.TurnType == turntype.SubAgentDispatch && s.hardPinExplore) {
 		provider, model := s.hardPinProvider, s.hardPinModel
 		// In byokOnly mode the boot-time hard-pin is unsafe: it was

--- a/internal/router/turntype/detect.go
+++ b/internal/router/turntype/detect.go
@@ -40,6 +40,15 @@ const (
 	// pin written here would anchor the real-conv turn that lands ~25ms
 	// later (same session key) before its own scorer even runs.
 	TitleGen TurnType = "title_gen"
+	// Classifier: a short-form classification call — no tools, small
+	// max_tokens, short message list. Anthropic's Claude Code security
+	// monitor (allow/block-with-reason on the agent's latest action) is
+	// the canonical case, but the pattern is general: any caller asking
+	// the model to emit a tiny verdict from a fixed-shape context. Same
+	// routing treatment as Probe and TitleGen — hard-pinned to the cheap
+	// model and skips session-pin creation so the real-conv pin doesn't
+	// inherit a classifier's decision.
+	Classifier TurnType = "classifier"
 )
 
 // probeMaxTokensThreshold is the inclusive upper bound on max_tokens for
@@ -48,6 +57,17 @@ const (
 // versions without false-positiving real "give me a short answer" calls
 // (which start around 64+).
 const probeMaxTokensThreshold = 4
+
+// classifier{Max,Msg}Threshold bound the Classifier turn type to short-form
+// classification calls. Claude Code's security monitor uses max_tokens=64
+// and message_count=2 (system + a single transcript-bundled user turn);
+// the bounds give headroom for similar yes/no/verdict classifiers without
+// catching real "short reply" main-loop turns (which start at ~512 output
+// tokens and carry the full 128-tool Claude Code registry).
+const (
+	classifierMaxTokensThreshold = 256
+	classifierMaxMessageCount    = 3
+)
 
 // DetectFromEnvelope classifies an inbound request. subAgentHint is the
 // optional x-weave-subagent-type header value; empty is ignored.
@@ -76,6 +96,9 @@ func DetectFromEnvelope(env *translate.RequestEnvelope, feats translate.RoutingF
 	if isSubAgentDispatch(env.MetadataUserID(), env.FirstUserMessageText(), subAgentHint) {
 		return SubAgentDispatch
 	}
+	if isClassifier(feats) {
+		return Classifier
+	}
 	if feats.LastKind == "tool_result" {
 		return ToolResult
 	}
@@ -89,6 +112,37 @@ func DetectFromEnvelope(env *translate.RequestEnvelope, feats translate.RoutingF
 // `generationConfig.maxOutputTokens` produce the same RoutingFeatures.
 func isProbe(feats translate.RoutingFeatures) bool {
 	return feats.MaxTokens > 0 && feats.MaxTokens <= probeMaxTokensThreshold
+}
+
+// isClassifier reports whether a request is a short-form classifier call
+// (Anthropic's security monitor, or any similar caller asking for a tiny
+// verdict from a fixed-shape context). Three structural signals, all
+// required:
+//
+//  1. No tools — a real Claude Code main-loop turn always carries the
+//     full 128-tool registry, even when the user asks for a short reply.
+//  2. max_tokens within classifierMaxTokensThreshold — classifier outputs
+//     are tiny (security monitor uses 64; title-gen and friends similar).
+//  3. message_count within classifierMaxMessageCount — classifiers are
+//     stateless and bundle their context into a single user turn; real
+//     conversations grow the message list past 3 quickly.
+//
+// Probe (max_tokens<=4) is checked first and wins; TitleGen and Compaction
+// have more specific fingerprints and also win when they match. This is a
+// general fallback for the broader classifier shape. False negatives
+// (returning MainLoop) are safe; false positives would route a real
+// conversation to the cheap hard-pin, hence the tight conjunction.
+func isClassifier(feats translate.RoutingFeatures) bool {
+	if feats.HasTools {
+		return false
+	}
+	if feats.MaxTokens <= 0 || feats.MaxTokens > classifierMaxTokensThreshold {
+		return false
+	}
+	if feats.MessageCount <= 0 || feats.MessageCount > classifierMaxMessageCount {
+		return false
+	}
+	return true
 }
 
 // isTitleGen reports whether a request is Claude Code's sidebar-title

--- a/internal/router/turntype/detect_test.go
+++ b/internal/router/turntype/detect_test.go
@@ -128,8 +128,22 @@ func TestDetectFromEnvelope_Anthropic(t *testing.T) {
 			want: turntype.Probe,
 		},
 		{
-			name: "max_tokens=5 is not a probe",
+			// max_tokens=5 is above the Probe threshold (which is the
+			// canonical SDK quota-check shape at max_tokens=1). With no
+			// tools and a short message list it falls into the broader
+			// Classifier shape — see the security-monitor case below for
+			// the canonical example.
+			name: "max_tokens=5 with no tools is classifier (above probe threshold)",
 			body: `{"model":"claude-haiku-4-5","max_tokens":5,"messages":[{"role":"user","content":"hello"}]}`,
+			want: turntype.Classifier,
+		},
+		{
+			// Belt for the test above: max_tokens=5 with the full tool
+			// registry stays MainLoop. Probe vs Classifier boundaries
+			// must never catch a real conversation that requested a
+			// terse reply.
+			name: "max_tokens=5 with tools stays main_loop",
+			body: `{"model":"claude-haiku-4-5","max_tokens":5,"tools":[{"name":"Bash","input_schema":{"type":"object"}}],"messages":[{"role":"user","content":"hello"}]}`,
 			want: turntype.MainLoop,
 		},
 		{
@@ -195,6 +209,74 @@ func TestDetectFromEnvelope_Anthropic(t *testing.T) {
 			body: `{"model":"claude-haiku-4-5","metadata":{"user_id":"subagent:Explore"},"messages":[
 				{"role":"user","content":[{"type":"tool_result","tool_use_id":"t1","content":"output"}]}
 			]}`,
+			want: turntype.SubAgentDispatch,
+		},
+		{
+			// Anthropic Claude Code security monitor — the canonical
+			// classifier shape: small max_tokens, no tools, short message
+			// list. Must hard-pin to the cheap model so the main-loop
+			// session pin isn't poisoned with a classifier verdict.
+			name: "anthropic security monitor classifier",
+			body: `{"model":"claude-opus-4-7","max_tokens":64,"messages":[{"role":"user","content":"is this safe?"}],"system":"You are a security monitor for autonomous AI coding agents."}`,
+			want: turntype.Classifier,
+		},
+		{
+			name: "classifier with two messages still classifier",
+			body: `{"model":"claude-opus-4-7","max_tokens":64,"messages":[
+				{"role":"user","content":"transcript"},
+				{"role":"assistant","content":"verdict?"}
+			]}`,
+			want: turntype.Classifier,
+		},
+		{
+			// Regression guard: a real Claude Code main-loop turn always
+			// ships the full tool registry, even when the user requests a
+			// terse reply. tools=[non-empty] must keep it MainLoop.
+			name: "short reply with tools stays main_loop",
+			body: `{"model":"claude-opus-4-7","max_tokens":64,"tools":[{"name":"Bash","input_schema":{"type":"object"}}],"messages":[{"role":"user","content":"yes or no?"}]}`,
+			want: turntype.MainLoop,
+		},
+		{
+			// Regression guard: max_tokens above the classifier threshold
+			// must keep the turn on the cluster scorer. 4096 is a typical
+			// real-conversation cap.
+			name: "max_tokens 4096 with no tools is not classifier",
+			body: `{"model":"claude-opus-4-7","max_tokens":4096,"messages":[{"role":"user","content":"explain this"}]}`,
+			want: turntype.MainLoop,
+		},
+		{
+			// Regression guard: a long classifier session (message_count
+			// exceeding classifierMaxMessageCount) is no longer the
+			// classifier shape — likely a stateful conversation. Drop
+			// to MainLoop so the cluster scorer handles it.
+			name: "small max_tokens but message_count 4 is main_loop",
+			body: `{"model":"claude-opus-4-7","max_tokens":64,"messages":[
+				{"role":"user","content":"a"},
+				{"role":"assistant","content":"b"},
+				{"role":"user","content":"c"},
+				{"role":"assistant","content":"d"}
+			]}`,
+			want: turntype.MainLoop,
+		},
+		{
+			name: "probe takes priority over classifier",
+			body: `{"model":"claude-opus-4-7","max_tokens":1,"messages":[{"role":"user","content":"ping"}]}`,
+			want: turntype.Probe,
+		},
+		{
+			// Regression guard: classifier must not pre-empt the more
+			// specific compaction match (its system-prompt fingerprint
+			// is unambiguous even when max_tokens is small).
+			name: "compaction takes priority over classifier",
+			body: `{"model":"claude-opus-4-7","max_tokens":64,"system":"Your task is to create a detailed summary","messages":[{"role":"user","content":"go"}]}`,
+			want: turntype.Compaction,
+		},
+		{
+			// Regression guard: a short sub-agent dispatch must remain
+			// SubAgentDispatch (its hard-pin is gated on the Explore
+			// feature flag; classifier's is unconditional).
+			name: "subagent dispatch takes priority over classifier",
+			body: `{"model":"claude-opus-4-7","max_tokens":64,"metadata":{"user_id":"subagent:Explore"},"messages":[{"role":"user","content":"grep"}]}`,
 			want: turntype.SubAgentDispatch,
 		},
 	}


### PR DESCRIPTION
## Summary

Anthropic's Claude Code ships a **security monitor** classifier that fires on every autonomous-agent turn to evaluate whether the agent's latest action should be blocked (HARD/SOFT BLOCK rules around prompt injection, scope creep, accidental damage). The system prompt opens with *"You are a security monitor for autonomous AI coding agents."* Wire shape:

- `max_tokens=64` (output is a brief allow/block verdict)
- `tools=[]` (pure classification, no tool use)
- `message_count ≤ 2` (stateless; transcript bundled into one user turn)
- ~28k input tokens (system + bundled transcript)

The existing `Probe` detector (`max_tokens ≤ 4`) was calibrated for the Anthropic SDK's `max_tokens=1` quota ping and doesn't catch this. Without a match, the request falls through to `MainLoop`, gets cluster-scored as high-tier work (because the prompt is long), and inherits the main-loop's session pin — routing **every** classifier turn to whichever high-tier model the user's main conversation is pinned to (we observed `deepseek-v4-pro`). Wasteful on both cost and latency for a yes/no classifier that runs once per real user turn.

## What this PR does

Adds a `Classifier` turn type with a tight conjunctive signal:

\`\`\`
tools = ∅  ∧  max_tokens ≤ 256  ∧  message_count ≤ 3
\`\`\`

Same hard-pin treatment as `Probe` and `TitleGen`: route to the cheap model (`qwen3.5-flash-02-23` on the default config), skip cluster scoring, **skip session-pin write** so a classifier verdict can't anchor the main-loop pin to the cheap model.

Priority cascade is preserved:
- `Probe` (max_tokens ≤ 4) still wins — SDK-probe semantics intact
- `TitleGen` (JSON-schema title fingerprint) still wins
- `Compaction` (system-prompt fingerprint) still wins
- `SubAgentDispatch` (transcript envelope / metadata signal) still wins
- `Classifier` is the broader fallback for short-form classification calls
- `MainLoop` (default) only when nothing else matches

## Estimated impact

For Claude Code users in autonomous mode, every "real" user turn fires ~1 security-monitor classifier call at ~28k input tokens. Moving those from v4-pro to qwen-flash:

- **Cost**: ~10x cheaper per classifier call
- **Latency**: 2–4x faster (low-tier OpenRouter route)
- **Quality**: no regression — qwen-flash is plenty capable of yes/no classification

## Test plan

- [x] `go test ./internal/router/turntype/...` — new `Classifier` cases + regression guards for boundaries (max_tokens, message_count, tools-present, priority over MainLoop, priority *under* Probe/Compaction/SubAgentDispatch)
- [x] `go test ./internal/...` — full suite green; `anthropicBody` fixture updated to include a stub tool so cache tests don't trip the new boundary
- [ ] Live: rebuild local container, drive a real autonomous Claude Code session, expect the security-monitor traffic (~114KB requests, max_tokens=64) to log `decision_reason=classifier_hard_pin` and `decision_model=qwen/qwen3.5-flash-02-23`

🤖 Generated with [Claude Code](https://claude.com/claude-code)