### PR TITLE
fix(install): default base URL to router.workweave.ai

### DIFF
--- a/install/README.md
+++ b/install/README.md
@@ -107,7 +107,7 @@ The `install.sh --scope project` step only needs to run once per checkout
 | -------------------------- | ----------------------------- | ---------------------------------------------------------------------- |
 | `--scope user\|project`    | interactive prompt (default `user`) | User-level install (everywhere) vs project-level (this repo only). If omitted on a TTY, the installer asks; defaults to `user` non-interactively. |
 | `--local`                  | off                           | Shortcut for the bundled docker-compose router (`localhost:8080`).      |
-| `--base-url <url>`         | `https://router.weave.ai`     | Override the router endpoint. Use for self-hosted / custom port.        |
+| `--base-url <url>`         | `https://router.workweave.ai` | Override the router endpoint. Use for self-hosted / custom port.        |
 | `--non-interactive`        | off                           | Fail if `$WEAVE_ROUTER_KEY` isn't set instead of prompting. CI-friendly. |
 
 Override the default base URL globally by setting `$WEAVE_ROUTER_URL` before

--- a/install/install.sh
+++ b/install/install.sh
@@ -31,7 +31,7 @@ set -euo pipefail
 # ---------- defaults ----------
 
 # The hosted Weave Router URL. Override with --base-url for self-hosted.
-DEFAULT_BASE_URL="${WEAVE_ROUTER_URL:-https://router.weave.ai}"
+DEFAULT_BASE_URL="${WEAVE_ROUTER_URL:-https://router.workweave.ai}"
 
 
 scope="user"


### PR DESCRIPTION
## Summary

- \`router.weave.ai\` DNS doesn't resolve, so the curl-piped installer from \`app.workweave.ai/api/weave_router/install.sh\` writes settings but then fails both the \`/health\` ping and the \`/validate\` key check.
- Switch \`DEFAULT_BASE_URL\` to \`https://router.workweave.ai\` (the actual prod host, returns 200 on \`/health\`).
- \`WEAVE_ROUTER_URL\` env var and \`--base-url\` flag still override.

## Test plan

- [ ] \`curl -fsS https://router.workweave.ai/health\` returns 200 (verified)
- [ ] Re-run the installer against a fresh dir and confirm \`/health\` + \`/validate\` succeed without flags