### PR TITLE
router: trim verbose comments across packages

### DIFF
--- a/internal/auth/admin.go
+++ b/internal/auth/admin.go
@@ -15,10 +15,10 @@ import (
 	"github.com/hashicorp/golang-lru/v2/expirable"
 )
 
-// AdminSessionCookieName is the HttpOnly cookie name carrying signed admin sessions. Stable across versions.
+// AdminSessionCookieName is the HttpOnly cookie name for admin sessions.
 const AdminSessionCookieName = "router_admin_session"
 
-// DefaultAdminSessionTTL is the admin session validity. Rotate the env password to invalidate cookies sooner.
+// DefaultAdminSessionTTL is the admin session validity.
 const DefaultAdminSessionTTL = 7 * 24 * time.Hour
 
 // ErrAdminSessionInvalid is returned when a session token fails to verify or the password is wrong.
@@ -27,8 +27,7 @@ var ErrAdminSessionInvalid = errors.New("admin session invalid")
 // ErrAdminPasswordNotConfigured is returned when admin auth is attempted but no ROUTER_ADMIN_PASSWORD is set.
 var ErrAdminPasswordNotConfigured = errors.New("admin password not configured")
 
-// ErrAdminLoginRateLimited is returned when per-IP failures exceed the threshold. Handlers map it to HTTP 429
-// so a brute-force attempt against ROUTER_ADMIN_PASSWORD pays a real cost between guesses.
+// ErrAdminLoginRateLimited is returned when per-IP failures exceed the threshold.
 var ErrAdminLoginRateLimited = errors.New("admin login rate limited")
 
 // Per-IP brute-force lockout: 5 failures inside 5 minutes triggers the limiter; entries self-expire off the LRU.
@@ -41,28 +40,28 @@ const (
 // with a different signing context (e.g. future CSRF tokens or webhook signatures).
 const adminSessionLabel = "router-admin-session-v1"
 
-// AdminInstallationExternalID is the well-known externalID for the dashboard-admin-owned installation.
-// rk_ keys issued from the dashboard belong to this installation; the admin handlers create it on first use.
+// AdminInstallationExternalID is the external ID for the admin-owned installation.
 const AdminInstallationExternalID = "__router_admin__"
 
 // AdminInstallationName is the display name for the auto-created admin installation.
 const AdminInstallationName = "Dashboard"
 
-// adminClaims is the payload inside a signed session token. Minimal: proves "knew admin password at issue-time and not expired".
+// adminClaims is the signed session-token payload.
 type adminClaims struct {
 	Subject   string `json:"sub"`
 	IssuedAt  int64  `json:"iat"`
 	ExpiresAt int64  `json:"exp"`
 }
 
-// AdminPrincipal is what VerifyAdminSession returns. Deliberately no installation details — admin
-// sessions are operator-of-this-router identities, not customer identities.
+// AdminPrincipal is returned by VerifyAdminSession. Carries no installation details —
+// admin sessions are operator identities, not customer identities.
 type AdminPrincipal struct {
 	Subject   string
 	ExpiresAt time.Time
 }
 
-// WithAdminPassword installs the operator password used to mint and verify admin session cookies. Empty disables admin login.
+// WithAdminPassword installs the operator password for minting and verifying admin sessions.
+// Empty string disables admin login.
 func (s *Service) WithAdminPassword(password string) *Service {
 	s.adminPassword = password
 	if password == "" {
@@ -81,14 +80,12 @@ func (s *Service) WithAdminPassword(password string) *Service {
 	return s
 }
 
-// AdminLoginEnabled reports whether the service has an admin password configured. Handlers use this
-// to surface a clean 503 instead of a misleading 401 when self-hosters forgot to set the env var.
+// AdminLoginEnabled reports whether an admin password is configured.
 func (s *Service) AdminLoginEnabled() bool {
 	return s.adminPassword != "" && len(s.adminSessionKey) == sha256.Size
 }
 
-// VerifyAdminPassword returns nil iff password matches. Constant-time compare to avoid timing oracles.
-// HTTP callers should prefer VerifyAdminPasswordFromIP, which also throttles brute-force attempts.
+// VerifyAdminPassword uses constant-time comparison to avoid timing oracles.
 func (s *Service) VerifyAdminPassword(password string) error {
 	if !s.AdminLoginEnabled() {
 		return ErrAdminPasswordNotConfigured
@@ -99,10 +96,7 @@ func (s *Service) VerifyAdminPassword(password string) error {
 	return ErrAdminSessionInvalid
 }
 
-// VerifyAdminPasswordFromIP wraps VerifyAdminPassword with a per-IP failure counter. After
-// adminLoginMaxFailures unsuccessful attempts inside adminLoginFailureTTL, further attempts from
-// that IP return ErrAdminLoginRateLimited until the entry expires. A successful login clears the
-// counter so a legitimate user who mistyped is not punished indefinitely. Pass c.ClientIP().
+// VerifyAdminPasswordFromIP wraps VerifyAdminPassword with per-IP brute-force throttling.
 func (s *Service) VerifyAdminPasswordFromIP(remoteIP, password string) error {
 	if !s.AdminLoginEnabled() {
 		return ErrAdminPasswordNotConfigured
@@ -125,8 +119,8 @@ func (s *Service) VerifyAdminPasswordFromIP(remoteIP, password string) error {
 	return nil
 }
 
-// IssueAdminSession returns a signed session token plus expiry. Format `<base64url(payload)>.<base64url(hmac)>`
-// — no JWT dep, no session row. Rotating ROUTER_ADMIN_PASSWORD changes the signing key and invalidates all cookies.
+// IssueAdminSession returns a signed session token. Format: `<payload>.<hmac>`.
+// Rotating ROUTER_ADMIN_PASSWORD changes the signing key and invalidates all cookies.
 func (s *Service) IssueAdminSession() (token string, expiresAt time.Time, err error) {
 	if !s.AdminLoginEnabled() {
 		return "", time.Time{}, ErrAdminPasswordNotConfigured
@@ -149,11 +143,8 @@ func (s *Service) IssueAdminSession() (token string, expiresAt time.Time, err er
 	return encodedPayload + "." + encodedSig, expiresAt, nil
 }
 
-// EnsureAdminInstallation returns the singleton admin-owned installation, creating it on first call.
-//
-// Concurrent first-hit requests race: both see no row, both try Create; one wins, the other hits the
-// unique constraint on (name, external_id). On Create failure we re-list so the loser returns the
-// winner's row instead of bubbling a 500.
+// EnsureAdminInstallation returns the singleton admin installation, creating it on first call.
+// On concurrent first-hit, the loser re-lists and returns the winner's row.
 func (s *Service) EnsureAdminInstallation(ctx context.Context) (*Installation, error) {
 	if inst, ok, err := s.findAdminInstallation(ctx); err != nil {
 		return nil, err
@@ -167,7 +158,7 @@ func (s *Service) EnsureAdminInstallation(ctx context.Context) (*Installation, e
 	if createErr == nil {
 		return created, nil
 	}
-	// Lost a concurrent race — the row exists now. Re-list and return it.
+	// Lost a concurrent race.
 	if inst, ok, err := s.findAdminInstallation(ctx); err == nil && ok {
 		return inst, nil
 	}
@@ -187,8 +178,7 @@ func (s *Service) findAdminInstallation(ctx context.Context) (*Installation, boo
 	return nil, false, nil
 }
 
-// VerifyAdminSession parses and authenticates a session cookie. Returns ErrAdminSessionInvalid for
-// anything malformed, badly signed, or expired so middleware can map cleanly to 401.
+// VerifyAdminSession parses and authenticates a session cookie token.
 func (s *Service) VerifyAdminSession(token string) (*AdminPrincipal, error) {
 	if !s.AdminLoginEnabled() {
 		return nil, ErrAdminPasswordNotConfigured

--- a/internal/auth/api_key.go
+++ b/internal/auth/api_key.go
@@ -33,8 +33,6 @@ type APIKeyRepository interface {
 	Create(ctx context.Context, params CreateAPIKeyParams) (*APIKey, error)
 	GetActiveByHashWithInstallation(ctx context.Context, keyHash string) (*APIKey, *Installation, error)
 	ListForInstallation(ctx context.Context, installationID string) ([]*APIKey, error)
-	// MarkUsed records that a key was used. Called fire-and-forget after auth;
-	// implementations should be idempotent on retry.
 	MarkUsed(ctx context.Context, id string) error
 	SoftDelete(ctx context.Context, id string) error
 }

--- a/internal/auth/apikey_cache.go
+++ b/internal/auth/apikey_cache.go
@@ -7,7 +7,7 @@ import (
 	"github.com/hashicorp/golang-lru/v2/expirable"
 )
 
-// CachedKey is the value stored in APIKeyCache. Negative=true marks a known-bad token; APIKey/Installation are nil then.
+// CachedKey is the value stored in APIKeyCache. Negative marks a known-bad token.
 type CachedKey struct {
 	APIKey       *APIKey
 	Installation *Installation
@@ -15,42 +15,33 @@ type CachedKey struct {
 	Negative     bool
 }
 
-// APIKeyCache is an in-process read-through cache for the auth lookup. Must be safe for concurrent use.
-// Positive entries can be invalidated by installation ID via InvalidateInstallation so settings changes
-// (excluded models, BYOK keys) are visible on the next request; the TTL is a safety net for replicas
-// that miss the invalidation signal.
+// APIKeyCache is an in-process read-through cache for the auth lookup.
+// Positive entries can be invalidated by installation ID.
 type APIKeyCache interface {
 	Get(keyHash string) (CachedKey, bool)
 	Set(keyHash string, entry CachedKey)
 	InvalidateInstallation(installationID string)
 }
 
-// NoOpAPIKeyCache is the Null Object: every Get misses, every Set is dropped.
+// NoOpAPIKeyCache is the Null Object: every Get misses.
 type NoOpAPIKeyCache struct{}
 
 func (NoOpAPIKeyCache) Get(string) (CachedKey, bool)  { return CachedKey{}, false }
 func (NoOpAPIKeyCache) Set(string, CachedKey)         {}
 func (NoOpAPIKeyCache) InvalidateInstallation(string) {}
 
-// LRUAPIKeyCache uses two LRUs so positive/negative entries have independent sizes and TTLs.
-// Negative gets a shorter TTL so a freshly-created key isn't 401'd longer than necessary.
-//
-// byInstallation is a secondary index over the positive LRU; it lets writers evict every
-// cached key for an installation in O(keys-per-installation) when settings change. Eviction
-// callbacks (LRU capacity churn or TTL expiry) keep the index in sync so it never accumulates
-// dangling hashes. Negative entries are not indexed: they're keyed by hash and have no
-// installation_id binding.
+// LRUAPIKeyCache uses two LRUs for positive/negative entries with independent sizes and TTLs.
+// Negative TTL is shorter so a freshly-created key isn't 401'd longer than necessary.
+// byInstallation is a secondary index for O(keys-per-installation) eviction on settings changes.
+// eviction callbacks keep the index in sync. Negative entries are not indexed.
 type LRUAPIKeyCache struct {
 	mu             sync.Mutex
 	positive       *expirable.LRU[string, CachedKey]
 	negative       *expirable.LRU[string, CachedKey]
 	byInstallation map[string]map[string]struct{}
-	// invalidationGen counts InvalidateInstallation calls per installation
-	// so Set can detect an invalidation that slipped between its index
-	// update and the LRU insert and clean up the orphaned entry. We can't
-	// simply hold mu across positive.Add because the LRU's eviction
-	// callback (onPositiveEvict) also acquires mu, which would deadlock
-	// when Add triggers a capacity eviction.
+	// invalidationGen detects invalidation races between index update and LRU insert.
+	// We cannot hold mu across positive.Add because the LRU eviction callback acquires mu,
+	// which would deadlock when Add triggers a capacity eviction.
 	invalidationGen map[string]uint64
 }
 
@@ -119,10 +110,8 @@ func (c *LRUAPIKeyCache) Set(keyHash string, entry CachedKey) {
 	c.mu.Unlock()
 }
 
-// InvalidateInstallation drops every positive entry tied to installationID so the next request
-// for any of its API keys re-reads the row (with refreshed ExcludedModels / ExternalKeys) from
-// Postgres. Negative entries are untouched: they're per-token and unaffected by installation
-// settings.
+// InvalidateInstallation drops every positive entry for installationID so the next auth
+// re-reads from Postgres. Negative entries (per-token) are untouched.
 func (c *LRUAPIKeyCache) InvalidateInstallation(installationID string) {
 	if installationID == "" {
 		return
@@ -137,9 +126,8 @@ func (c *LRUAPIKeyCache) InvalidateInstallation(installationID string) {
 	}
 }
 
-// onPositiveEvict keeps byInstallation consistent with the LRU. Fires for both capacity-driven
-// evictions and TTL expiries, including the synchronous Remove calls made by InvalidateInstallation
-// (which is why we must not hold c.mu when calling Remove).
+// onPositiveEvict keeps byInstallation in sync with the LRU on eviction or TTL expiry.
+// Must not hold c.mu when calling Remove (would deadlock with Add's capacity eviction).
 func (c *LRUAPIKeyCache) onPositiveEvict(keyHash string, entry CachedKey) {
 	if entry.Installation == nil || entry.Installation.ID == "" {
 		return

--- a/internal/auth/crypto.go
+++ b/internal/auth/crypto.go
@@ -10,8 +10,8 @@ import (
 	"github.com/tink-crypto/tink-go/v2/tink"
 )
 
-// Encryptor handles AES-256-GCM encryption/decryption via Google Tink.
-// AAD binds each ciphertext to (externalID, provider) so a stolen row can't be decrypted under a different identity.
+// Encryptor encrypts/decrypts external API keys via AES-256-GCM.
+// AAD binds each ciphertext to (externalID, provider).
 type Encryptor interface {
 	Encrypt(plaintext []byte, externalID, provider string) (ciphertext []byte, err error)
 	Decrypt(ciphertext []byte, externalID, provider string) (plaintext []byte, err error)
@@ -22,7 +22,6 @@ type tinkEncryptor struct {
 }
 
 // NewTinkEncryptor creates an Encryptor from a Tink keyset JSON.
-// Generate with: tinkey create-keyset --key-template AES256_GCM --out-format json
 func NewTinkEncryptor(keysetJSON string) (Encryptor, error) {
 	reader := keyset.NewJSONReader(bytes.NewBufferString(keysetJSON))
 	handle, err := insecurecleartextkeyset.Read(reader)
@@ -45,13 +44,12 @@ func (e *tinkEncryptor) Decrypt(ciphertext []byte, externalID, provider string) 
 }
 
 // aadFor MUST stay byte-identical with the Weave-side helper at
-// backend/internal/app/weaverouter/crypto.go. Drift bricks BYOK decrypt with
-// tag mismatch; crypto_test.go on both sides pins the format.
+// backend/internal/app/weaverouter/crypto.go.
 func aadFor(externalID, provider string) []byte {
 	return []byte(externalID + "\x00" + provider)
 }
 
-// NoOpEncryptor is a passthrough for local development without encryption.
+// NoOpEncryptor is a pass-through for development without encryption.
 type NoOpEncryptor struct{}
 
 func (NoOpEncryptor) Encrypt(plaintext []byte, _, _ string) ([]byte, error) {

--- a/internal/auth/errors.go
+++ b/internal/auth/errors.go
@@ -2,16 +2,12 @@ package auth
 
 import "errors"
 
-// ErrInvalidPrefix and ErrInvalidToken are kept distinct for internal telemetry;
-// HTTP handlers must collapse both to the same opaque 401 to avoid leaking which
-// check failed.
+// ErrInvalidPrefix and ErrInvalidToken are distinct for internal telemetry.
+// HTTP handlers collapse both to the same opaque 401.
 var (
 	ErrInvalidPrefix = errors.New("invalid bearer key prefix")
 	ErrInvalidToken  = errors.New("invalid bearer key")
 
-	// ErrActiveKeyExists is returned by APIKeyRepository.Create when the
-	// installation already has an active (non-soft-deleted) key. Callers
-	// should rotate (soft-delete the old key, then create a new one) rather
-	// than create a second.
+	// ErrActiveKeyExists is returned when the installation already has an active key.
 	ErrActiveKeyExists = errors.New("installation already has an active api key")
 )

--- a/internal/auth/external_api_key.go
+++ b/internal/auth/external_api_key.go
@@ -34,12 +34,10 @@ type CreateExternalAPIKeyParams struct {
 
 // ExternalAPIKeyRepository manages external API keys in storage.
 type ExternalAPIKeyRepository interface {
-	// Create inserts a new external API key. Callers must soft-delete any existing key for the same (installation, provider) first.
 	Create(ctx context.Context, params CreateExternalAPIKeyParams) (*ExternalAPIKey, error)
-	// GetForInstallation returns all active keys with Plaintext populated after decryption.
+	// GetForInstallation returns all active keys with Plaintext populated.
 	GetForInstallation(ctx context.Context, installationID string) ([]*ExternalAPIKey, error)
 	SoftDeleteByProvider(ctx context.Context, installationID, provider string) error
 	SoftDelete(ctx context.Context, installationID, id string) error
-	// MarkUsed updates last_used_at. Fire-and-forget, non-blocking.
 	MarkUsed(ctx context.Context, id string) error
 }

--- a/internal/auth/installation.go
+++ b/internal/auth/installation.go
@@ -1,4 +1,4 @@
-// Package auth holds installation/api-key types, repository interfaces, and the
+// Package auth provides installation/api-key types, repository interfaces, and a
 // Service that authenticates incoming bearer tokens.
 package auth
 
@@ -15,8 +15,8 @@ type Installation struct {
 	UpdatedAt  time.Time
 	DeletedAt  *time.Time
 	CreatedBy  *string
-	// ExcludedModels is the per-installation model exclusion list applied
-	// at request time by the cluster scorer. Empty slice means no exclusion.
+	// ExcludedModels is the per-installation model exclusion list.
+	// Empty means no exclusion.
 	ExcludedModels []string
 }
 
@@ -28,13 +28,10 @@ type CreateInstallationParams struct {
 
 type InstallationRepository interface {
 	Create(ctx context.Context, params CreateInstallationParams) (*Installation, error)
-	// Get is scoped to externalID to prevent cross-tenant access.
 	Get(ctx context.Context, externalID, id string) (*Installation, error)
 	ListForExternalID(ctx context.Context, externalID string) ([]*Installation, error)
-	// SoftDelete is scoped to externalID to prevent cross-tenant deletes.
 	SoftDelete(ctx context.Context, externalID, id string) error
-	// UpdateExcludedModels replaces the per-installation exclusion list,
-	// scoped to externalID to prevent cross-tenant updates. An empty (or
-	// nil) slice clears the list.
+	// UpdateExcludedModels replaces the per-installation exclusion list.
+	// An empty (or nil) slice clears the list.
 	UpdateExcludedModels(ctx context.Context, externalID, id string, models []string) error
 }

--- a/internal/auth/service.go
+++ b/internal/auth/service.go
@@ -13,21 +13,18 @@ import (
 	"github.com/hashicorp/golang-lru/v2/expirable"
 )
 
-// ErrUnknownModel is returned by SetInstallationExcludedModels when a
-// requested model ID is not in the allowed set the caller passed in.
+// ErrUnknownModel is returned when a requested model ID is not in the caller-supplied allowed set.
 var ErrUnknownModel = errors.New("auth: unknown model id")
 
 type Clock func() time.Time
 
-// InstallationChangeNotifier publishes per-installation invalidation events so
-// peer replicas can drop their cached entries. Fire-and-forget: implementations
-// should not block the caller; transport errors are logged, not returned.
+// InstallationChangeNotifier fans out installation-change events to peer replicas.
+// Fire-and-forget: implementations must not block the caller.
 type InstallationChangeNotifier interface {
 	NotifyInstallationChanged(installationID string)
 }
 
-// NoOpInstallationChangeNotifier is the Null Object used when no cross-replica
-// fanout is configured (e.g. local dev, single-replica deployments).
+// NoOpInstallationChangeNotifier is the Null Object when no cross-replica fanout is configured.
 type NoOpInstallationChangeNotifier struct{}
 
 // NotifyInstallationChanged is a no-op.
@@ -45,11 +42,11 @@ type Service struct {
 	now           Clock
 	encryptor     Encryptor
 
-	// Admin dashboard auth: shared password (ROUTER_ADMIN_PASSWORD) plus derived HMAC key for session cookies. Empty when admin login is disabled.
+	// adminPassword and adminSessionKey are empty when admin login is disabled.
 	adminPassword   string
 	adminSessionKey []byte
 
-	// adminLoginFailures throttles per-IP brute-force attempts; lazy-init in WithAdminPassword guarded by adminLoginMu.
+	// adminLoginFailures throttles per-IP brute-force login attempts.
 	adminLoginFailures *expirable.LRU[string, int]
 	adminLoginMu       sync.Mutex
 }
@@ -79,14 +76,12 @@ func NewService(
 	}
 }
 
-// WithEncryptor sets the encryptor used when creating external API keys.
 func (s *Service) WithEncryptor(e Encryptor) *Service {
 	s.encryptor = e
 	return s
 }
 
-// WithInstallationChangeNotifier wires a cross-replica fanout so cached entries
-// on peer replicas are dropped when settings change. Pass nil to disable.
+// WithInstallationChangeNotifier wires a cross-replica fanout. Pass nil to disable.
 func (s *Service) WithInstallationChangeNotifier(n InstallationChangeNotifier) *Service {
 	if n == nil {
 		s.notifier = NoOpInstallationChangeNotifier{}
@@ -106,7 +101,7 @@ func (s *Service) invalidateInstallation(installationID string) {
 	s.notifier.NotifyInstallationChanged(installationID)
 }
 
-// IssueAPIKey creates a new router API key and returns the raw token (only visible here; not stored in plaintext).
+// IssueAPIKey creates a new router API key and returns the raw token.
 func (s *Service) IssueAPIKey(ctx context.Context, installationID string, name *string, createdBy *string) (*APIKey, string, error) {
 	rawToken := GenerateID(APIKeyPrefix)
 	keyHash, keyPrefix, keySuffix := APITokenFingerprint(rawToken)
@@ -131,11 +126,9 @@ func (s *Service) ListAPIKeys(ctx context.Context, installationID string) ([]*AP
 	return s.apiKeys.ListForInstallation(ctx, installationID)
 }
 
-// RotateAPIKey soft-deletes the active key and issues a new one, carrying forward its name.
-//
-// Not wrapped in a tx: the brief "no active key" window is acceptable because (a) the partial unique
-// index on (installation_id) WHERE deleted_at IS NULL prevents collision, and (b) rotation's purpose
-// is to invalidate the old token, so a concurrent auth failure against it is expected.
+// RotateAPIKey soft-deletes all active keys and issues a new one, carrying forward the name.
+// Not wrapped in a tx: a brief "no active key" window is acceptable because rotation's purpose
+// is to invalidate the old token anyway.
 func (s *Service) RotateAPIKey(ctx context.Context, installationID string, createdBy *string) (*APIKey, string, error) {
 	existing, err := s.apiKeys.ListForInstallation(ctx, installationID)
 	if err != nil {
@@ -158,7 +151,7 @@ func (s *Service) RotateAPIKey(ctx context.Context, installationID string, creat
 	return key, raw, nil
 }
 
-// DeleteAPIKey soft-deletes an API key. The LRU entry TTL-expires; in-flight requests within the TTL window still succeed, acceptable for this rare path.
+// DeleteAPIKey soft-deletes an API key.
 func (s *Service) DeleteAPIKey(ctx context.Context, id string) error {
 	return s.apiKeys.SoftDelete(ctx, id)
 }
@@ -168,9 +161,9 @@ func (s *Service) ListExternalAPIKeys(ctx context.Context, installationID string
 	return s.externalKeys.GetForInstallation(ctx, installationID)
 }
 
-// UpsertExternalAPIKey replaces any existing key for the provider and inserts a new one. Raw key is encrypted before storage.
+// UpsertExternalAPIKey replaces any existing key for the provider and inserts a new one.
 func (s *Service) UpsertExternalAPIKey(ctx context.Context, installationID, provider, rawKey string, name *string, createdBy *string) (*ExternalAPIKey, error) {
-	// Generate external ID first so it binds into the ciphertext as AAD; decrypt re-derives AAD from (external_id, provider) on every read.
+	// Generate external ID first so it binds into the ciphertext as AAD.
 	externalID := GenerateID("ekid")
 	ciphertext, err := s.encryptor.Encrypt([]byte(rawKey), externalID, provider)
 	if err != nil {
@@ -207,16 +200,8 @@ func (s *Service) DeleteExternalAPIKey(ctx context.Context, installationID, id s
 	return nil
 }
 
-// SetInstallationExcludedModels replaces the per-installation model exclusion
-// list, scoped to externalID to prevent cross-tenant updates. allowed is the
-// universe of valid model IDs the caller is willing to accept (typically
-// every deployed model); passing nil skips validation. Returns
-// ErrUnknownModel when an entry in models is not in allowed.
-//
-// The new list is visible on the next authenticated request: the API-key
-// cache is explicitly invalidated for this installation on commit, with the
-// TTL acting as the safety net across replicas that miss the invalidation
-// signal.
+// SetInstallationExcludedModels replaces the per-installation model exclusion list.
+// allowed is the set of valid model IDs; passing nil skips validation.
 func (s *Service) SetInstallationExcludedModels(ctx context.Context, externalID, installationID string, models []string, allowed map[string]struct{}) ([]string, error) {
 	if models == nil {
 		models = []string{}
@@ -245,12 +230,9 @@ func (s *Service) SetInstallationExcludedModels(ctx context.Context, externalID,
 	return out, nil
 }
 
-// VerifyAPIKey authenticates a raw bearer token.
-//
-// Returns ErrInvalidPrefix/ErrInvalidToken for unauthenticated cases; repo transport errors propagate
-// as-is so they aren't masked as 401s. Reads through s.cache: ErrNoRows populates a negative entry
-// (defends against credential-stuffing); transport errors are not cached so the next request can retry.
-// Returned ExternalAPIKey slice has Plaintext populated; nil when none exist or s.externalKeys is nil.
+// VerifyAPIKey authenticates a raw bearer token against the API key cache then Postgres.
+// Returns ErrInvalidPrefix/ErrInvalidToken for unauthenticated cases.
+// Returned ExternalAPIKey slice has Plaintext populated; nil when none exist.
 func (s *Service) VerifyAPIKey(ctx context.Context, rawToken string) (*Installation, *APIKey, []*ExternalAPIKey, error) {
 	if !HasAPIKeyPrefix(rawToken) {
 		return nil, nil, nil, ErrInvalidPrefix
@@ -292,16 +274,10 @@ func (s *Service) VerifyAPIKey(ctx context.Context, rawToken string) (*Installat
 	return installation, apiKey, externalKeys, nil
 }
 
-// ResolveAndStashUser upserts a router user and stashes the resolved ID on ctx via UserIDContextKey.
-//
-// Email takes precedence: (installationID, email) keys the row and account_uuid enriches it.
-// When email is empty but claudeAccountUUID is present (Claude CLI v2.1.x packs only
-// account_uuid+device_id+session_id into metadata.user_id), the row is keyed on
-// (installationID, claude_account_uuid) with NULL email so per-seat attribution still works.
-//
-// Best-effort: returns the original ctx unchanged on no signal or upsert failure — must never fail an authenticated request.
-// Reads through s.userCache; last_seen_at lags by up to the cache TTL.
-// Callers must normalize email (lowercase, trim). claudeAccountUUID is optional.
+// ResolveAndStashUser upserts a router user and stashes the ID on ctx.
+// Email takes precedence as the lookup key. When only claudeAccountUUID is present,
+// the row is keyed on account_uuid with NULL email.
+// Best-effort: returns ctx unchanged on failure — must never fail an authenticated request.
 func (s *Service) ResolveAndStashUser(ctx context.Context, installationID, email, claudeAccountUUID string) context.Context {
 	log := observability.Get()
 	if s.users == nil || installationID == "" {
@@ -351,8 +327,6 @@ func (s *Service) ResolveAndStashUser(ctx context.Context, installationID, email
 	return context.WithValue(ctx, UserIDContextKey{}, user.ID)
 }
 
-// userIdentityKey produces a stable cache key. Email-bearing and account-only rows live in disjoint
-// key spaces so a later request that finally carries email doesn't false-hit the account-only entry.
 func userIdentityKey(email, claudeAccountUUID string) string {
 	if email != "" {
 		return "email:" + email

--- a/internal/auth/user.go
+++ b/internal/auth/user.go
@@ -14,21 +14,19 @@ func UserIDFrom(ctx context.Context) string {
 	return s
 }
 
-// User is an end-user identity scoped to an installation. The API key authenticates the installation;
-// User identifies which seat made the request (from git user.email in metadata.user_id or X-Weave-User-Email).
-// Email may be empty when only account_uuid is available (Claude CLI versions that pack only account_uuid).
+// User is an end-user identity scoped to an installation.
 type User struct {
 	ID                string
 	InstallationID    string
-	Email             string // "" when the row is account_uuid-only
+	Email             string // empty when account-uuid-only
 	ClaudeAccountUUID *string
 	FirstSeenAt       time.Time
 	LastSeenAt        time.Time
 	DeletedAt         *time.Time
 }
 
-// UpsertUserParams is the input to UserRepository.UpsertByEmail. Email must be normalized
-// (lowercased+trimmed) by the caller — the DB unique index is case-sensitive.
+// UpsertUserParams is the input to UserRepository.UpsertByEmail.
+// Email must be lowercased and trimmed by the caller.
 type UpsertUserParams struct {
 	InstallationID    string
 	Email             string
@@ -36,7 +34,6 @@ type UpsertUserParams struct {
 }
 
 // UpsertUserByAccountUUIDParams is the input to UserRepository.UpsertByAccountUUID.
-// Used when the inbound request carries a Claude account_uuid but no email.
 type UpsertUserByAccountUUIDParams struct {
 	InstallationID    string
 	ClaudeAccountUUID string
@@ -44,11 +41,9 @@ type UpsertUserByAccountUUIDParams struct {
 
 // UserRepository is the data-access port for end-user identities.
 type UserRepository interface {
-	// UpsertByEmail finds-or-creates a row keyed on (installation_id, email), refreshing last_seen_at
-	// and merging a non-empty claude_account_uuid. Idempotent.
+	// UpsertByEmail finds-or-creates a row keyed on (installation_id, email).
 	UpsertByEmail(ctx context.Context, params UpsertUserParams) (*User, error)
 	// UpsertByAccountUUID finds-or-creates an email-NULL row keyed on (installation_id, claude_account_uuid).
-	// Idempotent. Used when the inbound request has no email signal.
 	UpsertByAccountUUID(ctx context.Context, params UpsertUserByAccountUUIDParams) (*User, error)
 	Get(ctx context.Context, id string) (*User, error)
 	ListForInstallation(ctx context.Context, installationID string) ([]*User, error)

--- a/internal/auth/user_cache.go
+++ b/internal/auth/user_cache.go
@@ -8,16 +8,13 @@ import (
 	"github.com/hashicorp/golang-lru/v2/expirable"
 )
 
-// UserCache memoizes resolved router user IDs keyed on (installation_id, identityKey) to skip the
-// UPSERT on the hot path. identityKey is "email:<addr>" or "account:<uuid>" — the two key spaces are
-// disjoint so an account-only request never false-hits an email-bearing row.
-// Cache hits skip the DB; last_seen_at lags by up to the cache TTL.
+// UserCache memoizes resolved user IDs to skip the DB upsert on the hot path.
 type UserCache interface {
 	Get(installationID, identityKey string) (string, bool)
 	Set(installationID, identityKey, userID string)
 }
 
-// NoOpUserCache is the Null Object: every Get misses, every Set is dropped.
+// NoOpUserCache is the Null Object: every Get misses.
 type NoOpUserCache struct{}
 
 func (NoOpUserCache) Get(string, string) (string, bool) { return "", false }

--- a/internal/providers/anthropic/client.go
+++ b/internal/providers/anthropic/client.go
@@ -36,10 +36,7 @@ func NewClient(apiKey, baseURL string) *Client {
 	}
 }
 
-// setAuth applies authentication to the upstream request. Precedence:
-// (1) per-request BYOK credentials in ctx; (2) deployment-level API key;
-// (3) passthrough of the client's own Anthropic auth headers (OAuth bearer or
-// x-api-key). Router-only credentials are deliberately not forwarded.
+// setAuth resolves credentials in precedence order: BYOK, deployment key, then client-sent auth headers.
 func (c *Client) setAuth(ctx context.Context, upstream *http.Request, inbound *http.Request) {
 	if creds := proxy.CredentialsFromContext(ctx); creds != nil {
 		upstream.Header.Set("x-api-key", string(creds.APIKey))

--- a/internal/providers/google/client.go
+++ b/internal/providers/google/client.go
@@ -1,7 +1,4 @@
-// Package google is the providers.Client adapter for Google Gemini's
-// OpenAI-compatible Chat Completions endpoint. Kept separate from the openai
-// adapter so the composition root can register them under distinct provider
-// names with their own auth header and base URL.
+// Package google is the providers.Client adapter for Gemini's OpenAI-compatible endpoint.
 package google
 
 import (
@@ -20,8 +17,7 @@ import (
 	"workweave/router/internal/router"
 )
 
-// DefaultBaseURL is the public OpenAI-compatible endpoint for Gemini. Override
-// via GOOGLE_BASE_URL for a regional endpoint or Vertex AI proxy.
+// DefaultBaseURL is the public OpenAI-compatible endpoint for Gemini.
 const DefaultBaseURL = "https://generativelanguage.googleapis.com/v1beta/openai"
 
 type Client struct {
@@ -47,7 +43,6 @@ func (c *Client) Proxy(ctx context.Context, decision router.Decision, prep provi
 		return fmt.Errorf("build upstream request: %w", err)
 	}
 	upstream.Header.Set("Content-Type", "application/json")
-	// BYOK credentials take precedence over the deployment-level API key.
 	if creds := proxy.CredentialsFromContext(ctx); creds != nil {
 		upstream.Header.Set("Authorization", "Bearer "+string(creds.APIKey))
 	} else if c.apiKey != "" {
@@ -74,10 +69,7 @@ func (c *Client) Proxy(ctx context.Context, decision router.Decision, prep provi
 	return httputil.StreamBody(resp.Body, resp.StatusCode, w, t)
 }
 
-// Passthrough forwards to the same path on Gemini's OpenAI-compat surface.
-// DefaultBaseURL already carries Gemini's /v1beta/openai prefix, so the
-// inbound /v1 must be stripped or the upstream URL would double-prefix to
-// /v1beta/openai/v1/models and 404.
+// Passthrough strips the inbound /v1 prefix to avoid double-prefixing with DefaultBaseURL.
 func (c *Client) Passthrough(ctx context.Context, prep providers.PreparedRequest, w http.ResponseWriter, r *http.Request) error {
 	suffix := strings.TrimPrefix(r.URL.Path, "/v1")
 	url := c.baseURL + suffix
@@ -92,7 +84,6 @@ func (c *Client) Passthrough(ctx context.Context, prep providers.PreparedRequest
 	if ct := r.Header.Get("Content-Type"); ct != "" {
 		upstream.Header.Set("Content-Type", ct)
 	}
-	// BYOK credentials take precedence over the deployment-level API key.
 	if creds := proxy.CredentialsFromContext(ctx); creds != nil {
 		upstream.Header.Set("Authorization", "Bearer "+string(creds.APIKey))
 	} else if c.apiKey != "" {

--- a/internal/providers/google/native_client.go
+++ b/internal/providers/google/native_client.go
@@ -18,22 +18,18 @@ import (
 	"workweave/router/internal/translate"
 )
 
-// NativeBaseURL is Google's native Generative Language base URL. Endpoints sit
-// under /v1beta/models/{model}:generateContent — distinct from the OpenAI-compat
-// surface under /v1beta/openai.
+// NativeBaseURL is Google's native Generative Language base URL.
 const NativeBaseURL = "https://generativelanguage.googleapis.com"
 
 // NativeClient is the providers.Client adapter for Gemini's native REST surface.
-// The native API returns and accepts the opaque thought_signature field that
-// multi-turn tool use against Gemini 3.x preview models requires; the
-// OpenAI-compat surface does not. Auth is via x-goog-api-key.
+// The native API preserves thought_signature for multi-turn tool use with Gemini 3.x preview models.
 type NativeClient struct {
 	apiKey  string
 	baseURL string
 	http    *http.Client
 }
 
-// NewNativeClient returns a NativeClient; baseURL defaults to NativeBaseURL when empty.
+// NewNativeClient returns a NativeClient using NativeBaseURL when baseURL is empty.
 func NewNativeClient(apiKey, baseURL string) *NativeClient {
 	if baseURL == "" {
 		baseURL = NativeBaseURL
@@ -45,9 +41,7 @@ func NewNativeClient(apiKey, baseURL string) *NativeClient {
 	}
 }
 
-// Proxy posts the prepared body to :generateContent, or
-// :streamGenerateContent?alt=sse when prep.Headers[GeminiStreamHintHeader] is
-// "true". The synthetic hint header is stripped before forwarding upstream.
+// Proxy posts to :generateContent or :streamGenerateContent?alt=sse depending on the Gemini stream hint header.
 func (c *NativeClient) Proxy(ctx context.Context, decision router.Decision, prep providers.PreparedRequest, w http.ResponseWriter, r *http.Request) error {
 	stream := prep.Headers.Get(translate.GeminiStreamHintHeader) == "true"
 	prep.Headers.Del(translate.GeminiStreamHintHeader)
@@ -116,8 +110,7 @@ func (c *NativeClient) Proxy(ctx context.Context, decision router.Decision, prep
 	return httputil.StreamBody(resp.Body, resp.StatusCode, w, t)
 }
 
-// Passthrough forwards to the native surface, rewriting the inbound /v1/
-// prefix to /v1beta/ since the native API exposes /v1beta/models for discovery.
+// Passthrough rewrites inbound /v1/ paths to /v1beta/ for the native API surface.
 func (c *NativeClient) Passthrough(ctx context.Context, prep providers.PreparedRequest, w http.ResponseWriter, r *http.Request) error {
 	suffix := r.URL.Path
 	if rest, ok := strings.CutPrefix(suffix, "/v1/"); ok {
@@ -177,9 +170,7 @@ func (c *NativeClient) Passthrough(ctx context.Context, prep providers.PreparedR
 	return err
 }
 
-// logUpstreamStatus emits Error for 4xx/5xx and Warn for 429s, surfacing a
-// body preview so non-2xx upstream responses don't blackhole into a generic
-// "upstream call failed" string at the client.
+// logUpstreamStatus logs non-2xx upstream responses with a body preview.
 func logUpstreamStatus(msg string, status int, attrs ...any) {
 	merged := append([]any{"status", status}, attrs...)
 	if status >= 500 || (status >= 400 && status != http.StatusTooManyRequests) {

--- a/internal/providers/openai/client.go
+++ b/internal/providers/openai/client.go
@@ -43,7 +43,6 @@ func (c *Client) Proxy(ctx context.Context, decision router.Decision, prep provi
 		return fmt.Errorf("build upstream request: %w", err)
 	}
 	upstream.Header.Set("Content-Type", "application/json")
-	// BYOK credentials take precedence over the deployment-level API key.
 	if creds := proxy.CredentialsFromContext(ctx); creds != nil {
 		upstream.Header.Set("Authorization", "Bearer "+string(creds.APIKey))
 	} else if c.apiKey != "" {
@@ -78,9 +77,7 @@ func (c *Client) Proxy(ctx context.Context, decision router.Decision, prep provi
 	w.WriteHeader(resp.StatusCode)
 	status := resp.StatusCode
 
-	// Per-chunk diagnostics (first-byte preview, EOF, write/read errors) require
-	// a manual streaming loop instead of httputil.StreamBody. Skip it when debug
-	// is off so info-level deployments keep the fast path.
+	// Manual stream loop for per-chunk diagnostics; non-debug takes the fast path.
 	if !log.Enabled(ctx, slog.LevelDebug) {
 		return httputil.StreamBody(resp.Body, status, w, t)
 	}
@@ -142,7 +139,6 @@ func (c *Client) Passthrough(ctx context.Context, prep providers.PreparedRequest
 	if ct := r.Header.Get("Content-Type"); ct != "" {
 		upstream.Header.Set("Content-Type", ct)
 	}
-	// BYOK credentials take precedence over the deployment-level API key.
 	if creds := proxy.CredentialsFromContext(ctx); creds != nil {
 		upstream.Header.Set("Authorization", "Bearer "+string(creds.APIKey))
 	} else if c.apiKey != "" {

--- a/internal/providers/openaicompat/client.go
+++ b/internal/providers/openaicompat/client.go
@@ -1,8 +1,4 @@
-// Package openaicompat is a generic providers.Client adapter for upstreams
-// that expose the OpenAI Chat Completions wire shape (OpenRouter, vLLM,
-// Together, Fireworks, DeepInfra, customer-hosted endpoints). Kept separate
-// from the first-party OpenAI adapter so the composition root can register
-// these pools under their own provider names and API keys.
+// Package openaicompat is a generic providers.Client adapter for upstreams that speak OpenAI Chat Completions.
 package openaicompat
 
 import (
@@ -44,8 +40,7 @@ func NewClient(apiKey, baseURL string) *Client {
 	}
 }
 
-// setAuth applies authentication: BYOK credentials in ctx take precedence
-// over the deployment-level API key.
+// setAuth sets the Authorization header, preferring BYOK credentials over the deployment-level key.
 func (c *Client) setAuth(ctx context.Context, upstream *http.Request) {
 	if creds := proxy.CredentialsFromContext(ctx); creds != nil {
 		upstream.Header.Set("Authorization", "Bearer "+string(creds.APIKey))
@@ -65,9 +60,6 @@ func (c *Client) Proxy(ctx context.Context, decision router.Decision, prep provi
 	for k, vs := range prep.Headers {
 		upstream.Header[http.CanonicalHeaderKey(k)] = vs
 	}
-	// setAuth is applied after prep.Headers so the resolved credential
-	// always wins — prep.Headers must never clobber the Authorization
-	// header set here (currently empty, but belt-and-suspenders).
 	c.setAuth(ctx, upstream)
 	if v := r.Header.Get("Accept"); v != "" {
 		upstream.Header.Set("Accept", v)
@@ -116,10 +108,7 @@ func (c *Client) Proxy(ctx context.Context, decision router.Decision, prep provi
 	return httputil.StreamBody(resp.Body, resp.StatusCode, w, t)
 }
 
-// Passthrough forwards to the same resource suffix on the upstream. The
-// configured baseURL already includes the provider's version prefix (e.g.
-// /api/v1), so the inbound /v1 must be stripped before joining or the upstream
-// URL would double-prefix.
+// Passthrough strips the inbound /v1 prefix to avoid double-prefixing with the configured baseURL.
 func (c *Client) Passthrough(ctx context.Context, prep providers.PreparedRequest, w http.ResponseWriter, r *http.Request) error {
 	suffix := strings.TrimPrefix(r.URL.Path, "/v1")
 	url := c.baseURL + suffix
@@ -137,8 +126,6 @@ func (c *Client) Passthrough(ctx context.Context, prep providers.PreparedRequest
 	for k, vs := range prep.Headers {
 		upstream.Header[http.CanonicalHeaderKey(k)] = vs
 	}
-	// setAuth is applied after prep.Headers so the resolved credential
-	// always wins.
 	c.setAuth(ctx, upstream)
 	if v := r.Header.Get("Accept"); v != "" {
 		upstream.Header.Set("Accept", v)
@@ -177,9 +164,7 @@ func (c *Client) Passthrough(ctx context.Context, prep providers.PreparedRequest
 	return err
 }
 
-// logUpstreamStatus emits Error for 4xx/5xx and Warn for 429s, surfacing a
-// body preview so non-2xx upstream responses don't blackhole into a generic
-// "upstream call failed" string at the client.
+// logUpstreamStatus logs non-2xx upstream responses with a body preview.
 func logUpstreamStatus(msg string, status int, attrs ...any) {
 	merged := append([]any{"status", status}, attrs...)
 	if status >= 500 || (status >= 400 && status != http.StatusTooManyRequests) {

--- a/internal/providers/provider.go
+++ b/internal/providers/provider.go
@@ -1,4 +1,4 @@
-// Package providers defines the upstream LLM client interface and shared types.
+// Package providers defines the upstream LLM client interface, sentinel errors, and shared wire helpers.
 package providers
 
 import (
@@ -11,7 +11,6 @@ import (
 	"workweave/router/internal/router"
 )
 
-// Canonical provider keys used in client registries and router.Decision.Provider.
 const (
 	ProviderAnthropic  = "anthropic"
 	ProviderOpenAI     = "openai"
@@ -20,10 +19,7 @@ const (
 	ProviderFireworks  = "fireworks"
 )
 
-// APIKeyEnvVars maps a canonical provider name to the env var that supplies
-// the deployment-level upstream API key. Single source of truth: the boot
-// wiring in cmd/router/main.go and the /admin/v1/config handler both read
-// it so the dashboard's env-keyed view can't drift from the actual wiring.
+// APIKeyEnvVars maps provider name to the env var providing its deployment-level upstream API key.
 var APIKeyEnvVars = map[string]string{
 	ProviderAnthropic:  "ANTHROPIC_API_KEY",
 	ProviderOpenAI:     "OPENAI_API_KEY",
@@ -38,7 +34,7 @@ func APIKeyEnvVar(provider string) string {
 	return APIKeyEnvVars[provider]
 }
 
-// HopByHopHeaders are stripped from upstream responses per RFC 7230.
+// HopByHopHeaders are stripped from upstream responses per RFC 7230 §6.1.
 var HopByHopHeaders = map[string]struct{}{
 	"Connection":          {},
 	"Keep-Alive":          {},
@@ -50,9 +46,7 @@ var HopByHopHeaders = map[string]struct{}{
 	"Upgrade":             {},
 }
 
-// CopyUpstreamHeaders copies non-hop-by-hop headers from resp into w. Per
-// RFC 7230 §6.1, headers named in the upstream Connection header are also
-// treated as hop-by-hop and stripped.
+// CopyUpstreamHeaders copies non-hop-by-hop headers from resp into w.
 func CopyUpstreamHeaders(w http.ResponseWriter, resp *http.Response) {
 	dynamicHop := make(map[string]struct{})
 	for _, v := range resp.Header.Values("Connection") {
@@ -81,11 +75,8 @@ func CopyUpstreamHeaders(w http.ResponseWriter, resp *http.Response) {
 var ErrNotImplemented = errors.New("provider: not implemented")
 
 // UpstreamStatusError is returned by Client.Proxy and Client.Passthrough after
-// the upstream non-2xx response envelope has already been written through to
-// the client. The body is committed before this error is returned, so handlers
-// detecting c.Writer.Written() must NOT also write their own JSON envelope.
-// Exists so callers can surface upstream rejections that would otherwise hide
-// behind a successful proxy of an error response.
+// the upstream non-2xx response body has already been written to the client.
+// Handlers detecting c.Writer.Written() must NOT write their own JSON envelope.
 type UpstreamStatusError struct {
 	Status int
 }
@@ -94,22 +85,16 @@ func (e *UpstreamStatusError) Error() string {
 	return fmt.Sprintf("upstream returned status %d", e.Status)
 }
 
-// PreparedRequest is the output of translate.RequestEnvelope.Prepare*. Body is
-// the fully-encoded target-format request body; Headers carries format-specific
-// header overrides (e.g. filtered anthropic-beta) the adapter applies alongside
-// its own auth headers.
+// PreparedRequest holds the encoded target-format request body and format-specific header overrides.
 type PreparedRequest struct {
 	Body    []byte
 	Headers http.Header
 }
 
 type Client interface {
-	// Proxy forwards prep.Body verbatim to the upstream and streams the response
-	// into w. Implementations must not decode/re-encode the body.
+	// Proxy forwards prep.Body verbatim to the upstream and streams the response into w.
 	Proxy(ctx context.Context, decision router.Decision, prep PreparedRequest, w http.ResponseWriter, r *http.Request) error
 
-	// Passthrough forwards an inbound request to the same path on the upstream
-	// with no model rewriting and no routing decision applied. Used for
-	// ancillary endpoints (model availability, token counting).
+	// Passthrough forwards an inbound request to the same path on the upstream with no model rewriting.
 	Passthrough(ctx context.Context, prep PreparedRequest, w http.ResponseWriter, r *http.Request) error
 }

--- a/internal/proxy/cache_writer.go
+++ b/internal/proxy/cache_writer.go
@@ -5,11 +5,9 @@ import (
 	"net/http"
 )
 
-// captureWriter mirrors writes into an in-memory buffer so the proxy can
-// store the wire-format response in the semantic cache after it streams.
-// Bodies exceeding maxBytes mark the capture as overflowed: pass-through
-// continues but the buffer is dropped, bounding peak memory at maxBytes
-// per concurrent in-flight non-streaming request.
+// captureWriter mirrors writes into a buffer for post-response cache storage.
+// Bodies exceeding maxBytes mark the capture as overflowed: streaming continues
+// but the buffer is dropped.
 type captureWriter struct {
 	w           http.ResponseWriter
 	body        bytes.Buffer
@@ -46,14 +44,13 @@ func (c *captureWriter) Write(p []byte) (int, error) {
 	return c.w.Write(p)
 }
 
-// Flush forwards to the underlying writer when it implements http.Flusher.
 func (c *captureWriter) Flush() {
 	if f, ok := c.w.(http.Flusher); ok {
 		f.Flush()
 	}
 }
 
-// captured reports whether the buffer still holds the full body and returns it.
+// captured reports whether the buffer holds the full body and returns it.
 func (c *captureWriter) captured() ([]byte, int, bool) {
 	if c.overflow {
 		return nil, 0, false

--- a/internal/proxy/client_identity.go
+++ b/internal/proxy/client_identity.go
@@ -10,8 +10,7 @@ import (
 )
 
 // ClientIdentity holds per-request user identification signals. Email is the
-// cross-protocol identity persisted as router.model_router_users.email and
-// the only signal reliable enough to link to a Weave account.
+// cross-protocol identity persisted to router.model_router_users.email.
 type ClientIdentity struct {
 	DeviceID  string
 	AccountID string
@@ -24,20 +23,16 @@ type ClientIdentity struct {
 // ClientIdentityContextKey is the request-context key for client identity.
 type ClientIdentityContextKey struct{}
 
-// ClientIdentityFrom reads the ClientIdentity stashed on ctx, or a zero value when absent.
+// ClientIdentityFrom reads the ClientIdentity stashed on ctx.
 func ClientIdentityFrom(ctx context.Context) ClientIdentity {
 	id, _ := ctx.Value(ClientIdentityContextKey{}).(ClientIdentity)
 	return id
 }
 
-// ResolveUserFromContext pulls identity signals (email and/or Claude
-// account_uuid) from ctx and hands them to auth.Service.ResolveAndStashUser,
-// returning the (possibly enriched) ctx. Centralized here so resolution rules
-// don't diverge across protocol handlers.
-//
-// No-op when deps are missing, or when neither email nor account_uuid is set.
-// Claude CLI v2.1.x packs only account_uuid (no email), so guarding on email
-// alone would defeat the account_uuid attribution path.
+// ResolveUserFromContext pulls identity signals from ctx and hands them to
+// auth.Service.ResolveAndStashUser. No-op when deps are missing or both
+// email and account_uuid are empty. Claude CLI v2.1.x packs only
+// account_uuid (no email), so guarding on email alone would defeat that path.
 func ResolveUserFromContext(ctx context.Context, authSvc *auth.Service, installation *auth.Installation) context.Context {
 	log := observability.Get()
 	if authSvc == nil || installation == nil {
@@ -64,9 +59,8 @@ func ResolveUserFromContext(ctx context.Context, authSvc *auth.Service, installa
 	return authSvc.ResolveAndStashUser(ctx, installation.ID, id.Email, id.AccountID)
 }
 
-// ClaudeCodeMetadata mirrors the JSON Claude Code encodes into the Anthropic
-// metadata.user_id field. Email is promoted into router.model_router_users;
-// the others stay request-scoped.
+// ClaudeCodeMetadata mirrors the JSON Claude Code encodes into
+// metadata.user_id. Email is promoted to router.model_router_users.
 type ClaudeCodeMetadata struct {
 	DeviceID  string `json:"device_id"`
 	AccountID string `json:"account_uuid"`
@@ -74,8 +68,8 @@ type ClaudeCodeMetadata struct {
 	Email     string `json:"email"`
 }
 
-// ParseClaudeCodeMetadata extracts identity fields from the JSON Claude Code
-// packs into metadata.user_id. Best-effort: returns a zero value on parse failure.
+// ParseClaudeCodeMetadata extracts identity fields from the JSON in
+// metadata.user_id. Best-effort: returns zero on parse failure.
 func ParseClaudeCodeMetadata(raw string) ClaudeCodeMetadata {
 	if raw == "" {
 		return ClaudeCodeMetadata{}
@@ -87,18 +81,16 @@ func ParseClaudeCodeMetadata(raw string) ClaudeCodeMetadata {
 	return meta
 }
 
-// MaxEmailLen caps email length per RFC 5321 §4.5.3.1.3 (256 bytes); we use
-// 254 to bound row growth from caller-controlled inputs flooding the table.
+// MaxEmailLen caps email length per RFC 5321 §4.5.3.1.3 (256 bytes).
 const MaxEmailLen = 254
 
-// MaxClientIdentifierLen bounds caller-controlled opaque identifiers
-// (device_id, session_id). Claude Code emits ~36-char UUIDs; 128 is overhead.
-// Flood-protection floor against high-cardinality spam into telemetry storage.
+// MaxClientIdentifierLen bounds caller-controlled opaque identifiers.
+// Claude Code emits ~36-char UUIDs; 128 is overhead with flood-protection.
 const MaxClientIdentifierLen = 128
 
-// NormalizeClientIdentifier returns the input unchanged when it fits inside
-// MaxClientIdentifierLen, else "". Rejection (not truncation) keeps the shape
-// honest: a truncated identifier looks valid but no longer correlates.
+// NormalizeClientIdentifier returns input unchanged when within bounds, else "".
+// Rejection (not truncation) keeps shape honest: a truncated identifier looks
+// valid but no longer correlates.
 func NormalizeClientIdentifier(s string) string {
 	if len(s) > MaxClientIdentifierLen {
 		return ""
@@ -106,12 +98,11 @@ func NormalizeClientIdentifier(s string) string {
 	return s
 }
 
-// NormalizeEmail trims whitespace, lower-cases, and structurally validates an
-// email so it matches the case-sensitive unique index on (installation_id,
-// email). Returns "" when empty, oversized, or shaped wrong (missing or
-// duplicate '@', empty local-part or domain). Callers treat "" as "no email
-// signal" and skip the upsert. Deliverability is not checked: email here is
-// an opaque identifier, and the shape check is a flood-protection floor.
+// NormalizeEmail trims, lower-cases, and structurally validates an email
+// to match the case-sensitive unique index on (installation_id, email).
+// Returns "" when empty, oversized, or malformed. Deliverability is not
+// checked: email is an opaque identifier, and the shape check is
+// flood-protection.
 func NormalizeEmail(s string) string {
 	s = strings.ToLower(strings.TrimSpace(s))
 	if s == "" || len(s) > MaxEmailLen {

--- a/internal/proxy/handover.go
+++ b/internal/proxy/handover.go
@@ -22,33 +22,27 @@ import (
 )
 
 // DefaultHandoverModel is the Anthropic model used to summarize prior
-// conversation context before a mid-session model switch. Haiku-class
-// is intentional: summarization is one of the cheapest workloads
-// available and the 3s timeout is comfortable on a 1k-token output.
+// conversation before a mid-session model switch. Haiku-class is intentional:
+// summarization is one of the cheapest workloads available.
 const DefaultHandoverModel = "claude-haiku-4-5"
 
 // DefaultHandoverTimeout bounds the summarizer call so a slow upstream
-// cannot block the request path. On timeout, the orchestrator falls
-// back to TrimLastN.
+// cannot block the request path.
 const DefaultHandoverTimeout = 3 * time.Second
 
-// DefaultHandoverMaxTokens caps the synthesized summary length so it
-// can never blow up input cost on the switched-to model.
+// DefaultHandoverMaxTokens caps the synthesized summary length.
 const DefaultHandoverMaxTokens = 800
 
 // handoverInstruction is appended as a final user message to elicit the
-// summary. Kept explicit about what must be preserved so a routing
-// switch does not lose decisions, file paths, or the user's latest
-// intent.
+// summary. Kept explicit about what must be preserved so a routing switch
+// does not lose decisions, file paths, or the user's latest intent.
 const handoverInstruction = "Summarize the conversation so far in <= 800 tokens. " +
 	"Preserve all decisions, file paths, code snippets, and the user's latest intent. " +
 	"Output only the summary text — no preamble, no closing remark."
 
-// ProviderSummarizer is the default handover.Summarizer adapter. It
-// builds a small Anthropic Messages request from the inbound envelope's
-// prior conversation and invokes a providers.Client (typically the
-// Anthropic Haiku client) with a bounded timeout, returning the assistant
-// text as the summary.
+// ProviderSummarizer adapts a providers.Client to the handover.Summarizer
+// interface by building a small Anthropic Messages request from the inbound
+// envelope's prior conversation.
 type ProviderSummarizer struct {
 	client    providers.Client
 	model     string
@@ -56,9 +50,8 @@ type ProviderSummarizer struct {
 	maxTokens int
 }
 
-// NewProviderSummarizer constructs a summarizer adapter. Empty/zero
-// args fall back to DefaultHandoverModel / DefaultHandoverTimeout /
-// DefaultHandoverMaxTokens respectively.
+// NewProviderSummarizer constructs a summarizer adapter. Empty/zero args
+// fall back to defaults.
 func NewProviderSummarizer(client providers.Client, model string, timeout time.Duration) *ProviderSummarizer {
 	if model == "" {
 		model = DefaultHandoverModel
@@ -84,18 +77,12 @@ func (s *ProviderSummarizer) WithMaxTokens(n int) *ProviderSummarizer {
 }
 
 // ErrEmptySummary is returned when the upstream call succeeded but no
-// assistant text was extractable from the response (truncated, refused,
-// or unrecognized response shape).
+// assistant text was extractable.
 var ErrEmptySummary = errors.New("handover: upstream returned no summary text")
 
-// Summarize implements handover.Summarizer. It builds an Anthropic
-// Messages call from env's prior conversation, dispatches it through
-// the configured providers.Client under a hard timeout, and returns
-// the assistant text.
-//
-// Failure cases (timeout, network error, upstream non-2xx, empty
-// response) return ("", err) so the caller can fall back to
-// handover.TrimLastN.
+// Summarize implements handover.Summarizer. Builds an Anthropic Messages call,
+// dispatches through the configured client under a hard timeout. On failure
+// returns ("", err) so the caller can fall back to handover.TrimLastN.
 func (s *ProviderSummarizer) Summarize(ctx context.Context, env *translate.RequestEnvelope) (string, error) {
 	log := observability.Get()
 	if env == nil {
@@ -116,7 +103,6 @@ func (s *ProviderSummarizer) Summarize(ctx context.Context, env *translate.Reque
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodPost, "/v1/messages", bytes.NewReader(body))
 	req.Header.Set("content-type", "application/json")
-	// Force non-streaming response by NOT setting accept: text/event-stream.
 
 	prep := providers.PreparedRequest{
 		Body:    body,
@@ -158,12 +144,8 @@ func (s *ProviderSummarizer) Summarize(ctx context.Context, env *translate.Reque
 }
 
 // buildHandoverRequestBody constructs a non-streaming Anthropic Messages
-// request body from the inbound envelope's prior conversation plus a
-// final user instruction asking for a summary. Format-aware: for
-// Anthropic ingress we reuse messages/system as-is; for OpenAI/Gemini
-// ingress we go through translate's existing cross-format builder by
-// preparing an Anthropic body and then injecting our instruction +
-// override model/max_tokens/stream.
+// request from the inbound envelope's prior conversation, injecting a
+// summary instruction and overriding model/max_tokens/stream.
 func buildHandoverRequestBody(env *translate.RequestEnvelope, model string, maxTokens int) ([]byte, error) {
 	prep, err := env.PrepareAnthropic(nil, translate.EmitOptions{TargetModel: model})
 	if err != nil {
@@ -189,8 +171,6 @@ func buildHandoverRequestBody(env *translate.RequestEnvelope, model string, maxT
 		return nil, fmt.Errorf("append instruction: %w", err)
 	}
 
-	// Drop fields that would only complicate the summary call. Tools and
-	// thinking are not relevant for a summarize-and-return workload.
 	for _, key := range []string{"tools", "tool_choice", "thinking", "context_management", "effort", "output_config", "metadata"} {
 		body, _ = sjson.DeleteBytes(body, key)
 	}
@@ -198,8 +178,7 @@ func buildHandoverRequestBody(env *translate.RequestEnvelope, model string, maxT
 	return body, nil
 }
 
-// appendUserInstruction appends a role=user text message to the
-// messages array. Returns the new body.
+// appendUserInstruction appends a role=user text message to the messages array.
 func appendUserInstruction(body []byte, text string) ([]byte, error) {
 	msg := map[string]any{
 		"role": "user",
@@ -214,12 +193,8 @@ func appendUserInstruction(body []byte, text string) ([]byte, error) {
 	return sjson.SetRawBytes(body, "messages.-1", raw)
 }
 
-// extractAnthropicAssistantText pulls the concatenated text from an
-// Anthropic Messages non-streaming response. The shape is:
-//
-//	{ "content": [ {"type":"text", "text": "..."}, ... ], ... }
-//
-// All text blocks are joined with newlines.
+// extractAnthropicAssistantText pulls concatenated text from an Anthropic
+// Messages non-streaming response. All text blocks are joined with newlines.
 func extractAnthropicAssistantText(body []byte) string {
 	if !gjson.ValidBytes(body) {
 		return ""
@@ -246,5 +221,4 @@ func extractAnthropicAssistantText(body []byte) string {
 	return out.String()
 }
 
-// Compile-time check: ProviderSummarizer satisfies handover.Summarizer.
 var _ handover.Summarizer = (*ProviderSummarizer)(nil)

--- a/internal/proxy/marker_internal_test.go
+++ b/internal/proxy/marker_internal_test.go
@@ -132,9 +132,6 @@ func TestRoutingMarkerFor_PlannerPaths(t *testing.T) {
 			},
 		},
 		{
-			// Tool-result follow-ups are suppressed entirely — every
-			// post-tool turn would otherwise re-emit "Weave Router → …"
-			// mid-stream without conveying new routing info.
 			name: "tool-result short-circuit: marker suppressed",
 			res: turnLoopResult{
 				Decision:  decision,

--- a/internal/proxy/observation.go
+++ b/internal/proxy/observation.go
@@ -8,20 +8,19 @@ import (
 )
 
 // observationContext bundles per-request routing values shared by the OTel
-// span and the telemetry row. Zero values for non-cluster decisions; the
-// telemetry adapter maps them to NULL columns.
+// span and telemetry row.
 type observationContext struct {
 	// ClusterIDs is the top-p cluster set, widened to int32 for SQLC's INT[].
 	ClusterIDs []int32
 	// CandidateModels mirrors the scorer's eligible argmax set.
 	CandidateModels []string
-	// ChosenScore is the argmax score. Pointer so a literal 0.0 stays distinct
-	// from "not a cluster decision".
+	// ChosenScore is the argmax score. Pointer so 0.0 stays distinct from
+	// "not a cluster decision".
 	ChosenScore *float64
 	// ClusterRouterVersion is the artifact version that produced this decision.
 	ClusterRouterVersion string
-	// TTFTMs is the upstream-request → first-byte delta in ms. Pointer because
-	// zero is a legitimate sub-millisecond measurement, not "unmeasured".
+	// TTFTMs is the upstream-request-to-first-byte delta in ms. Pointer because
+	// zero is a legitimate sub-millisecond measurement.
 	TTFTMs *int64
 }
 
@@ -40,8 +39,8 @@ func buildObservationContext(ctx context.Context, decision router.Decision) obse
 		if len(md.CandidateModels) > 0 {
 			obs.CandidateModels = append([]string(nil), md.CandidateModels...)
 		}
-		// Unconditional inside md != nil: a `!= 0` guard would silently drop
-		// legitimate zero scores.
+		// ChosenScore is unconditional inside md != nil: a != 0 guard
+		// would silently drop legitimate zero scores.
 		score := float64(md.ChosenScore)
 		obs.ChosenScore = &score
 		obs.ClusterRouterVersion = md.ClusterRouterVersion
@@ -54,8 +53,7 @@ func buildObservationContext(ctx context.Context, decision router.Decision) obse
 	return obs
 }
 
-// applySpanAttrs records routing fields on an OTel AttrBuilder using the same
-// gating as the telemetry row, keeping the span and DB row symmetric.
+// applySpanAttrs records routing fields on an OTel AttrBuilder.
 func (o observationContext) applySpanAttrs(b *otel.AttrBuilder) {
 	if len(o.ClusterIDs) > 0 {
 		// Widen int32 → int for AttrBuilder.IntSlice.

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -34,87 +34,64 @@ type Service struct {
 	providers            map[string]providers.Client
 	emitter              *otel.Emitter
 	embedOnlyUserMessage bool
-	// semanticCache short-circuits non-streaming requests on a cosine-similarity hit.
-	semanticCache *cache.Cache
-	// pinStore persists session-sticky routing decisions across instance restarts.
-	// Nil when the feature flag is off; the orchestrator then runs the scorer
-	// every turn and persists nothing.
+	semanticCache        *cache.Cache
+	// pinStore persists session-sticky routing decisions. Nil when the feature
+	// flag is off; the orchestrator then runs the scorer every turn.
 	pinStore sessionpin.Store
 	// pinCache absorbs the hot path; 30s TTL is short enough that pinned_until
 	// in the pin store remains source of truth for validity.
 	pinCache *expirable.LRU[string, sessionpin.Pin]
-	// pinWriteSem bounds concurrent async pin-upsert goroutines. Writes drop
-	// (non-blocking) when full so a slow Postgres can't accumulate goroutines.
+	// pinWriteSem bounds concurrent async pin-upsert goroutines with drop-on-full semantics.
 	pinWriteSem chan struct{}
-	// usageWriteSem bounds concurrent async last-turn-usage writeback
-	// goroutines, with the same drop-on-full semantics as pinWriteSem.
+	// usageWriteSem bounds concurrent async last-turn-usage writeback goroutines,
+	// with the same drop-on-full semantics as pinWriteSem.
 	usageWriteSem chan struct{}
 	// hardPinExplore gates the Explore sub-agent hard-pin.
 	hardPinExplore bool
 	// hardPinProvider/hardPinModel route compaction (and, when hardPinExplore is
-	// on, Explore sub-agent turns). Derived at boot from the cheapest available
+	// on, Explore sub-agent turns). Derived at boot from the cheapest registered
 	// model; overridable via ROUTER_HARD_PIN_PROVIDER / ROUTER_HARD_PIN_MODEL.
 	hardPinProvider string
 	hardPinModel    string
-	// hardPinResolver, when set, overrides the boot-time hardPin{Provider,Model}
-	// per-request. Used in byokOnly (managed) deployments where the cheapest
-	// model among ALL registered providers is the wrong choice — the
-	// installation may only BYOK a subset, and a hard-pin to a provider they
-	// can't authenticate to would 401 at dispatch. The resolver is given the
-	// request's enabled-providers set (BYOK + client-creds intersection) and
-	// returns (provider, model, ok). ok=false signals no eligible provider for
-	// this request — the orchestrator surfaces ErrClusterUnavailable rather
-	// than silently falling back.
+	// hardPinResolver, when set, overrides boot-time hardPin{Provider,Model}
+	// per-request. Used in byokOnly deployments where the registered cheapest
+	// model is unsafe — the installation may only BYOK a subset of providers.
+	// Returns (provider, model, ok); ok=false signals no eligible provider.
 	hardPinResolver func(enabled map[string]struct{}) (provider, model string, ok bool)
-	// tierClampResolver enforces the requested-model tier ceiling: returns
-	// the cheapest deployed model whose tier ≤ ceiling, whose provider is
-	// in the request's enabled set, and which is NOT in the request's
-	// excluded-models denylist. Nil disables the clamp. See
-	// WithTierClampResolver and turnloop.go's clampToCeiling for the call
-	// sites.
+	// tierClampResolver enforces the requested-model tier ceiling. Nil disables
+	// the clamp.
 	tierClampResolver func(enabled, excluded map[string]struct{}, ceiling capability.Tier) (provider, model string, ok bool)
 	// telemetry is an optional repository for persisting per-request telemetry.
 	telemetry TelemetryRepository
-	// byokOnly disables deployment-level credential fallback. When true, a
-	// provider is only eligible if BYOK or client-supplied credentials are
-	// present. Set on Weave-managed deployments so customer requests never
-	// silently consume the platform's API key budget.
+	// byokOnly disables deployment-level credential fallback so customer
+	// requests never silently consume the platform's API key budget.
 	byokOnly bool
 	// excludedModelsOverride, when non-nil, replaces the per-installation
-	// exclusion list on every request. Set from ROUTER_EXCLUDED_MODELS at
-	// boot so headless self-hosters can pin the list in their manifest.
+	// exclusion list on every request. Set from ROUTER_EXCLUDED_MODELS at boot.
 	excludedModelsOverride map[string]struct{}
 	// deploymentKeyedProviders is the subset of registered providers whose
-	// upstream API key is actually configured at the deployment level (env
-	// var). It's the "default eligible" set used by enabledProvidersForRequest
-	// in non-BYOK-only mode. When nil, all registered providers are treated
-	// as deployment-keyed (legacy behavior preserved for tests).
+	// upstream API key is configured at the deployment level. When nil, all
+	// registered providers are treated as deployment-keyed (legacy behavior).
 	deploymentKeyedProviders map[string]struct{}
-	// planner parameterizes the Prism-style EV policy that decides
-	// stay-vs-switch per turn. Constructed once at boot from env.
+	// planner parameterizes the Prism-style EV policy for stay-vs-switch.
 	planner planner.EVConfig
-	// plannerEnabled is the kill switch (ROUTER_PLANNER_ENABLED). When
-	// false, the orchestrator falls back to first-decision-wins behavior.
+	// plannerEnabled is the kill switch. When false, the orchestrator falls
+	// back to first-decision-wins behavior.
 	plannerEnabled bool
-	// summarizer produces a bounded-cost handover summary on switch
-	// turns. May be nil — the orchestrator then falls straight to
-	// handover.TrimLastN on switch.
+	// summarizer produces a bounded-cost handover summary on switch turns.
+	// nil falls straight to handover.TrimLastN.
 	summarizer handover.Summarizer
-	// availableModels is the boot-time set of model names whose providers
-	// are registered. Read by the planner to decide whether a pin's model
-	// is still routable; if not, switch regardless of EV.
+	// availableModels is the boot-time set of model names whose providers are
+	// registered. Read by the planner to decide whether a pin's model is still
+	// routable.
 	availableModels map[string]struct{}
-	// defaultBaselineModel is the cost-comparison baseline used when the
-	// inbound RequestedModel has no pricing entry (typical of generic
-	// "weave-router"-style custom names IDE clients send). Empty means no
-	// substitution — savings markers and pricing fields stay empty for
-	// unknown models, preserving prior behavior.
+	// defaultBaselineModel is the cost-comparison baseline used when the inbound
+	// RequestedModel has no pricing entry. Empty means no substitution.
 	defaultBaselineModel string
 }
 
-// pinSessionTTL is the sliding TTL on pinned_until. Mirrors Anthropic's
-// prompt-cache TTL on Sonnet/Haiku/Opus 4.5+ so the pin lifecycle tracks
-// the cache it's keeping warm.
+// pinSessionTTL mirrors Anthropic's prompt-cache TTL on Sonnet/Haiku/Opus 4.5+
+// so the pin lifecycle tracks the cache it's keeping warm.
 const pinSessionTTL = time.Hour
 
 // APIKeyIDContextKey is the request-context key for the authenticated api_key_id.
@@ -126,26 +103,22 @@ type ExternalIDContextKey struct{}
 // CredentialsContextKey is the request-context key for resolved per-request credentials.
 type CredentialsContextKey struct{}
 
-// InstallationExcludedModelsContextKey is the request-context key for the
-// authed installation's model exclusion list. Carried as []string so the
-// proxy can build the request-time filter without re-reading the DB.
+// InstallationExcludedModelsContextKey is the context key for the authed
+// installation's model exclusion list. Carried as []string.
 type InstallationExcludedModelsContextKey struct{}
 
 // installationExcludedModelsFromContext returns the per-installation exclusion
 // list stashed on ctx by the auth middleware, or nil when none is present.
 
-// routingMarkerFor builds the upfront "brand → model · reason" snippet emitted
+// routingMarkerFor builds the "brand -> model . reason" snippet emitted
 // at the start of every cross-format streamed response.
 func routingMarkerFor(res turnLoopResult) string {
 	decision := res.Decision
 	if decision.Model == "" {
 		return ""
 	}
-	// Suppress the marker on tool-result follow-ups: every turn after a
-	// tool call would otherwise emit a duplicate "Weave Router → …" line
-	// mid-stream, which clutters the transcript without conveying new
-	// routing information. The planner / hard-pin / clamp branches still
-	// emit so genuine routing events stay visible.
+	// Suppress the marker on tool-result follow-ups: every post-tool turn would
+	// otherwise re-emit a duplicate mid-stream.
 	if res.PlannerDecision.Reason == "" && !res.HardPinned && !res.TierClamped && res.StickyHit {
 		return ""
 	}
@@ -162,10 +135,7 @@ func routingMarkerFor(res turnLoopResult) string {
 	return strings.Join(parts, " · ") + "\n\n"
 }
 
-// clampNote surfaces the tier-ceiling clamp to the caller when it fired:
-// names the runner-up model the scorer actually preferred and points at
-// the action that would unlock it (request a higher-tier model). Empty
-// string when no clamp occurred.
+// clampNote surfaces the tier-ceiling clamp; empty when no clamp occurred.
 func clampNote(res turnLoopResult) string {
 	if !res.TierClamped || res.PreClampModel == "" {
 		return ""
@@ -177,9 +147,8 @@ func clampNote(res turnLoopResult) string {
 	return fmt.Sprintf("second-choice pick (would have used %s — capped to your requested %s tier; request %s to unlock higher-tier picks)", res.PreClampModel, res.RequestedTier.String(), upsell)
 }
 
-// upsellModelFor returns the conventional next-tier-up model name to
-// suggest in the clamp note. High tier has no upsell. Unknown returns
-// empty so the marker falls back to the no-upsell wording.
+// upsellModelFor returns the conventional next-tier-up model name for the
+// clamp note. High tier has no upsell.
 func upsellModelFor(t capability.Tier) string {
 	switch t {
 	case capability.TierLow:
@@ -191,8 +160,7 @@ func upsellModelFor(t capability.Tier) string {
 	}
 }
 
-// routingReasonShort returns a human-readable reason for the marker, falling
-// back to the orchestrator path when the planner didn't run.
+// routingReasonShort returns a human-readable reason for the marker.
 func routingReasonShort(res turnLoopResult) string {
 	if res.PlannerDecision.Reason != "" {
 		return humanReasonFromPlanner(res.PlannerDecision.Reason)
@@ -206,8 +174,7 @@ func routingReasonShort(res turnLoopResult) string {
 	return "top scorer"
 }
 
-// humanReasonFromPlanner maps planner.Reason* codes to marker prose. Unknown
-// codes pass through verbatim so new reasons surface visibly.
+// humanReasonFromPlanner maps planner reason codes to marker prose.
 func humanReasonFromPlanner(code string) string {
 	switch code {
 	case planner.ReasonEVPositive:
@@ -240,9 +207,8 @@ func installationExcludedModelsFromContext(ctx context.Context) []string {
 	return out
 }
 
-// excludedModelsForRequest returns the model exclusion set to apply for this
-// request. The env-driven override wins; otherwise the installation list (if
-// any) is converted to a set. Returns nil when neither is configured.
+// excludedModelsForRequest returns the request's model exclusion set.
+// Env override wins; otherwise the installation list is converted to a set.
 func (s *Service) excludedModelsForRequest(ctx context.Context) map[string]struct{} {
 	if s.excludedModelsOverride != nil {
 		return s.excludedModelsOverride
@@ -258,8 +224,7 @@ func (s *Service) excludedModelsForRequest(ctx context.Context) map[string]struc
 	return out
 }
 
-// CredentialsFromContext returns the resolved credentials stashed on ctx,
-// or nil when none are present (plan-based auth path).
+// CredentialsFromContext returns the resolved credentials stashed on ctx.
 func CredentialsFromContext(ctx context.Context) *Credentials {
 	v := ctx.Value(CredentialsContextKey{})
 	if v == nil {
@@ -269,24 +234,19 @@ func CredentialsFromContext(ctx context.Context) *Credentials {
 	return creds
 }
 
-// DefaultPlannerThresholdUSD is the minimum positive EV (over the
-// remaining-turn horizon) required to switch off a pinned model. Small
-// enough that genuine arbitrage triggers a switch; large enough that
-// near-tie noise doesn't flap decisions.
+// DefaultPlannerThresholdUSD is the minimum positive EV over remaining-turn
+// horizon to switch off a pinned model. Small enough for arbitrage; large
+// enough to avoid near-tie noise.
 const DefaultPlannerThresholdUSD = 0.001
 
-// DefaultPlannerExpectedRemainingTurns is the horizon used to amortize
-// per-turn savings. Matches observed agentic-loop tail length.
+// DefaultPlannerExpectedRemainingTurns is the horizon for amortizing per-turn
+// savings. Matches observed agentic-loop tail length.
 const DefaultPlannerExpectedRemainingTurns = 3
 
-// DefaultPlannerTierUpgradeEnabled turns on the tier guard so a trivial
-// first turn can't pin a Low-tier model for the rest of the session.
-// See internal/router/capability.
+// DefaultPlannerTierUpgradeEnabled turns on the tier guard so a trivial first
+// turn can't pin a Low-tier model for the session.
 const DefaultPlannerTierUpgradeEnabled = true
 
-// session-pin feature flag is off. The planner runs by default with the
-// conservative EVConfig above; callers tune it via WithPlanner /
-// WithPlannerEnabled / WithSummarizer / WithAvailableModels.
 func NewService(r router.Router, providerMap map[string]providers.Client, emitter *otel.Emitter, embedOnlyUserMessage bool, semanticCache *cache.Cache, pinStore sessionpin.Store, hardPinExplore bool, hardPinProvider, hardPinModel string, telemetry TelemetryRepository) *Service {
 	var pinCache *expirable.LRU[string, sessionpin.Pin]
 	var pinWriteSem chan struct{}
@@ -319,13 +279,9 @@ func NewService(r router.Router, providerMap map[string]providers.Client, emitte
 	}
 }
 
-// WithPlanner overrides the EV-policy configuration. ThresholdUSD is
-// assigned verbatim — zero and negative values are legitimate operator-
-// chosen settings (the planner switches when expectedSavings -
-// evictionCost > threshold; the test plan documents -1 as the force-
-// switch knob). ExpectedRemainingTurns falls back to the default on
-// non-positive values because amortizing savings over <= 0 turns has no
-// meaningful interpretation.
+// WithPlanner overrides the EV-policy configuration. ThresholdUSD is assigned
+// verbatim (zero and negative are legitimate). ExpectedRemainingTurns falls
+// back to the default on non-positive values.
 func (s *Service) WithPlanner(cfg planner.EVConfig) *Service {
 	s.planner.ThresholdUSD = cfg.ThresholdUSD
 	if cfg.ExpectedRemainingTurns > 0 {
@@ -335,26 +291,23 @@ func (s *Service) WithPlanner(cfg planner.EVConfig) *Service {
 	return s
 }
 
-// WithPlannerEnabled is the kill switch (ROUTER_PLANNER_ENABLED). When
-// false, the orchestrator preserves the "first decision wins" behavior
-// (Tier-1/2 pin lookup, scorer fallback, no EV math).
+// WithPlannerEnabled is the kill switch. When false, the orchestrator
+// preserves first-decision-wins behavior.
 func (s *Service) WithPlannerEnabled(enabled bool) *Service {
 	s.plannerEnabled = enabled
 	return s
 }
 
-// WithSummarizer installs the cheap-model summarizer used to bound
-// handover cost on switch turns. nil disables the synchronous summary
-// step; the orchestrator then trims-last-N on every switch.
+// WithSummarizer installs the cheap-model summarizer for handover on switch
+// turns. nil disables the summary step; TrimLastN is used instead.
 func (s *Service) WithSummarizer(sz handover.Summarizer) *Service {
 	s.summarizer = sz
 	return s
 }
 
-// WithAvailableModels installs the boot-time set of model names whose
-// providers are registered. The planner consults this set so a pin
-// whose model is no longer routable forces a switch regardless of EV.
-// Passing nil clears the set (every model is considered available).
+// WithAvailableModels installs the boot-time set of routable model names.
+// The planner consults this set so a pin whose model is no longer
+// available forces a switch. nil treats every model as available.
 func (s *Service) WithAvailableModels(models map[string]struct{}) *Service {
 	if models == nil {
 		s.availableModels = nil
@@ -368,42 +321,29 @@ func (s *Service) WithAvailableModels(models map[string]struct{}) *Service {
 	return s
 }
 
-// WithHardPinResolver installs a per-request hard-pin resolver. The
-// resolver is consulted on compaction/probe/Explore turns when set; nil
-// preserves the boot-time hardPin{Provider,Model} for every request
-// (the selfhosted default). The resolver receives the request's enabled
-// providers set; ok=false signals the request has no eligible provider
-// and the turnloop should surface ErrClusterUnavailable rather than
-// dispatching to a provider the request can't authenticate to.
+// WithHardPinResolver installs a per-request hard-pin resolver. nil
+// preserves the boot-time hardPin{Provider,Model} for every request.
+// ok=false signals no eligible provider, surfacing ErrClusterUnavailable.
 func (s *Service) WithHardPinResolver(resolver func(enabled map[string]struct{}) (provider, model string, ok bool)) *Service {
 	s.hardPinResolver = resolver
 	return s
 }
 
-// WithDefaultBaselineModel installs the cost-comparison fallback used
-// when the inbound RequestedModel has no pricing entry. Empty disables
-// substitution. See [Service.defaultBaselineModel] for rationale.
+// WithDefaultBaselineModel installs the cost-comparison fallback for when
+// the inbound RequestedModel has no pricing entry. Empty disables.
 func (s *Service) WithDefaultBaselineModel(model string) *Service {
 	s.defaultBaselineModel = model
 	return s
 }
 
-// WithTierClampResolver installs the resolver used by the tier-ceiling
-// guard. Given a request's enabled-providers set and a tier ceiling, it
-// returns the cheapest registry-deployed model whose tier is ≤ ceiling
-// and whose provider is enabled. ok=false means no in-ceiling model is
-// routable for this request — the orchestrator preserves the original
-// (unclamped) decision rather than failing the turn. Nil resolver
-// disables clamping (preserves pre-tier-ceiling behavior).
+// WithTierClampResolver installs the tier-ceiling clamp resolver. Nil disables.
 func (s *Service) WithTierClampResolver(resolver func(enabled, excluded map[string]struct{}, ceiling capability.Tier) (provider, model string, ok bool)) *Service {
 	s.tierClampResolver = resolver
 	return s
 }
 
-// baselineFor returns requested if it has a pricing entry; otherwise the
-// configured defaultBaselineModel (which may itself be ""). Used by every
-// cost/savings lookup so unknown client model names (e.g. "weave-router")
-// still attribute savings to a real baseline.
+// baselineFor returns requested if it has a pricing entry, otherwise the
+// configured defaultBaselineModel (which may be "").
 func (s *Service) baselineFor(requested string) string {
 	if requested != "" {
 		if _, ok := pricing.For(requested); ok {
@@ -414,17 +354,14 @@ func (s *Service) baselineFor(requested string) string {
 }
 
 // WithByokOnly enables BYOK-only credential resolution: providers without
-// caller-supplied credentials are ineligible, even if a deployment-level env
-// key is registered.
+// caller-supplied credentials are ineligible.
 func (s *Service) WithByokOnly(byokOnly bool) *Service {
 	s.byokOnly = byokOnly
 	return s
 }
 
 // WithExcludedModelsOverride pins the per-request model exclusion list to a
-// deployment-wide set, ignoring per-installation DB state. Pass nil or an
-// empty slice to clear the override (per-installation DB state then takes
-// over). Used for headless self-hosted deployments that pin config in env.
+// deployment-wide set. Pass nil or empty slice to clear the override.
 func (s *Service) WithExcludedModelsOverride(models []string) *Service {
 	if len(models) == 0 {
 		s.excludedModelsOverride = nil
@@ -438,16 +375,12 @@ func (s *Service) WithExcludedModelsOverride(models []string) *Service {
 	return s
 }
 
-// HasExcludedModelsOverride reports whether ROUTER_EXCLUDED_MODELS (or an
-// equivalent override) is in effect. Admin handlers use this to render the
-// UI read-only and to reject mutating PUTs.
+// HasExcludedModelsOverride reports whether an excluded-models override is active.
 func (s *Service) HasExcludedModelsOverride() bool {
 	return s.excludedModelsOverride != nil
 }
 
-// ExcludedModelsOverride returns a sorted copy of the override list, or nil
-// when no override is active. Surfaced via the admin GET endpoint so the UI
-// can show the operator which models the env var pins off.
+// ExcludedModelsOverride returns a sorted copy of the override list.
 func (s *Service) ExcludedModelsOverride() []string {
 	if s.excludedModelsOverride == nil {
 		return nil
@@ -461,24 +394,14 @@ func (s *Service) ExcludedModelsOverride() []string {
 }
 
 // usageRequired reports whether per-request token usage must be captured.
-// Both OTel export and DB telemetry persistence need it; without either, we
-// can skip the SSE include_usage flag + extractor wiring.
-//
-// This used to be gated on s.emitter alone, which meant local deployments
-// without OTEL_EXPORTER_OTLP_ENDPOINT silently persisted every telemetry
-// row with input/output_tokens = 0 (and therefore $0 cost). Telemetry
-// persistence is the source of truth for the dashboard's cost panel — it
-// can't depend on OTel being configured.
+// Both OTel export and DB telemetry persistence need it.
 func (s *Service) usageRequired() bool {
 	return s.emitter != nil || s.telemetry != nil
 }
 
-// WithDeploymentKeyedProviders restricts the "default eligible" set for
-// non-BYOK-only requests to providers whose deployment env key is actually
-// set. Without this, every registered provider is eligible by default —
-// which is wrong when we register a provider with an empty key purely so
-// BYOK keys can route to it. Passing nil restores the legacy "all
-// registered providers eligible" behavior.
+// WithDeploymentKeyedProviders restricts the default eligible set to
+// providers whose deployment env key is set. nil restores legacy behavior
+// (all registered providers eligible).
 func (s *Service) WithDeploymentKeyedProviders(set map[string]struct{}) *Service {
 	if set == nil {
 		s.deploymentKeyedProviders = nil
@@ -756,8 +679,7 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 	s.logPlannerOutcome(routeRes)
 
 	// Semantic-cache eligibility: configured, non-streaming, decision has
-	// metadata, externalID present, not eval traffic (eval bypasses to keep
-	// per-prompt accuracy attribution clean).
+	// metadata, externalID present, not eval traffic.
 	cacheEligible := s.semanticCache != nil && !env.Stream() && decision.Metadata != nil && externalID != "" && !bypassEval
 	if cacheEligible {
 		if resp, hit := s.semanticCache.Lookup(externalID, cache.FormatAnthropic, decision.Metadata.Embedding, decision.Metadata.ClusterIDs); hit {
@@ -834,10 +756,8 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 		IncludeStreamUsage: s.usageRequired(),
 	}
 
-	// BYOK takes precedence; inbound headers supply fallback credentials.
 	ctx = resolveAndInjectCredentials(ctx, decision.Provider, r.Header)
 
-	// Mirror post-translation wire bytes into a buffer for post-Proxy storage.
 	var captureW *captureWriter
 	var sink http.ResponseWriter = w
 	if cacheEligible {
@@ -948,7 +868,6 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 	applyPlannerAttrs(upstreamBuilder, routeRes)
 	addTimingAttrs(ctx, upstreamBuilder)
 
-	// Span attrs and telemetry row share the same source; bundle keeps them symmetric.
 	obs := buildObservationContext(ctx, decision)
 	obs.applySpanAttrs(upstreamBuilder)
 
@@ -960,8 +879,6 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 	})
 	otel.Flush(ctx)
 
-	// Persist last-turn usage to the pin row so the next turn's planner
-	// has cache-hit evidence. Off the request path; drops on saturation.
 	s.recordTurnUsage(routeRes, in, out, cacheCreation, cacheRead)
 
 	if installationID != uuid.Nil {
@@ -1006,17 +923,13 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 }
 
 // sessionPinCacheKey produces the in-proc LRU key for a (session_key, role)
-// pair. Hex-encoded for the string-keyed LRU; role suffix preserves the
-// schema's role dimension for non-default roles.
+// pair. Hex-encoded for the string-keyed LRU.
 func sessionPinCacheKey(key [sessionpin.SessionKeyLen]byte, role string) string {
 	return hex.EncodeToString(key[:]) + ":" + role
 }
 
 // applyPlannerAttrs stamps planner and handover attributes onto a span
-// attribute builder. Safe to call when the planner didn't run; uses
-// "skipped" for the outcome and zero values for the EV fields so the
-// schema stays uniform across hard-pin / tool-result / planner-disabled
-// paths.
+// attribute builder. Safe when the planner didn't run (uses "skipped" outcome).
 func applyPlannerAttrs(b *otel.AttrBuilder, res turnLoopResult) *otel.AttrBuilder {
 	outcome := plannerOutcomeAttr(res)
 	b.String("planner.outcome", outcome).
@@ -1034,10 +947,7 @@ func applyPlannerAttrs(b *otel.AttrBuilder, res turnLoopResult) *otel.AttrBuilde
 	return b
 }
 
-// plannerOutcomeAttr maps the planner's typed outcome to the string used
-// in OTel attrs. "skipped" covers every path where Decide was not
-// invoked (hard-pin, tool-result short-circuit, planner-disabled,
-// pin-store-disabled).
+// plannerOutcomeAttr maps the planner's typed outcome to an OTel string.
 func plannerOutcomeAttr(res turnLoopResult) string {
 	if res.PlannerDecision.Reason == "" {
 		return "skipped"
@@ -1052,9 +962,8 @@ func plannerOutcomeAttr(res turnLoopResult) string {
 	}
 }
 
-// logPlannerOutcome emits a single structured log line summarizing the
-// planner's verdict. Switch turns are Info (rare, decision-affecting);
-// stay turns are Debug so the steady-state hot path stays quiet.
+// logPlannerOutcome emits a structured log line for the planner's verdict.
+// Switch turns are Info; stay turns are Debug.
 func (s *Service) logPlannerOutcome(res turnLoopResult) {
 	if res.PlannerDecision.Reason == "" {
 		return
@@ -1083,23 +992,14 @@ func (s *Service) logPlannerOutcome(res turnLoopResult) {
 	)
 }
 
-// recordTurnUsage writes the upstream's observed input/output/cache
-// tokens back to the session pin row. The planner reads these on the
-// next turn to weigh switch EV against eviction cost.
-//
-// Bounded async; drops on saturation. Guarded against hard-pin turns
-// (no pin row to update) and missing session keys (e.g. pin store
-// disabled). Uses context.Background() — per CLAUDE.md, deferred DB
-// writes must outlive the request ctx.
-// effectiveInputCost returns the true USD input cost after applying cache pricing.
-// Fresh input tokens are priced at base rate; cache-creation tokens at 1.25×;
-// cache-read tokens at the model's effective cache-read multiplier (default 0.5×).
-// Matches the formula in install/cc-statusline.sh.
-//
-// upstreamProvider distinguishes wire-format semantics: Anthropic's
-// input_tokens is fresh-only (cache counters are non-overlapping); OpenAI's
-// prompt_tokens is the total including cached_tokens. Without this signal we'd
-// over-subtract on the Anthropic path and clamp fresh to 0.
+// recordTurnUsage writes upstream token usage back to the session pin row
+// for the planner's next-turn EV math. Bounded async; drops on saturation.
+// Uses context.Background() so the DB write outlives the request ctx.
+
+// effectiveInputCost returns the true USD input cost after applying cache
+// pricing. Fresh tokens at base rate; cache-creation at 1.25x; cache-read at
+// the model's effective multiplier. upstreamProvider distinguishes Anthropic
+// (input_tokens is fresh-only) from OpenAI (prompt_tokens includes cached).
 func effectiveInputCost(inputTokens, cacheCreation, cacheRead int, pricePer1M float64, pinfo pricing.Pricing, upstreamProvider string) float64 {
 	fresh := inputTokens
 	if upstreamProvider != providers.ProviderAnthropic {
@@ -1167,9 +1067,8 @@ func (s *Service) recordTurnUsage(res turnLoopResult, in, out, cacheCreation, ca
 	}
 }
 
-// pinDecision rehydrates a router.Decision from a stored pin. Metadata is
-// nil intentionally — the embedding isn't persisted, so semantic-cache won't
-// fire on a pinned turn (acceptable: the pin already short-circuits routing).
+// pinDecision rehydrates a router.Decision from a stored pin. Metadata is nil
+// (embedding isn't persisted, acceptable since the pin short-circuits routing).
 func pinDecision(p sessionpin.Pin) router.Decision {
 	return router.Decision{
 		Provider: p.Provider,
@@ -1178,8 +1077,7 @@ func pinDecision(p sessionpin.Pin) router.Decision {
 	}
 }
 
-// clusterIDsFromDecision returns the cluster ids on a decision, or nil for
-// decisions without metadata.
+// clusterIDsFromDecision returns cluster ids from a decision's metadata.
 func clusterIDsFromDecision(d router.Decision) []int {
 	if d.Metadata == nil {
 		return nil
@@ -1187,7 +1085,7 @@ func clusterIDsFromDecision(d router.Decision) []int {
 	return d.Metadata.ClusterIDs
 }
 
-// pinAge returns seconds since first_pinned_at, or zero for fresh pins.
+// pinAge returns seconds since first_pinned_at.
 func pinAge(p sessionpin.Pin) int64 {
 	if p.FirstPinnedAt.IsZero() {
 		return 0
@@ -1218,14 +1116,12 @@ func externalKeysFromContext(ctx context.Context) []*auth.ExternalAPIKey {
 	return keys
 }
 
-// requestUsesNonDeploymentCreds reports whether the inbound request's
-// provider credentials are NOT the platform's deployment-level env keys.
-// The handover summarizer is wired at boot with deployment-level
-// credentials; calling it on a request whose upstream call would use
-// BYOK or client-supplied creds would route prior conversation context
-// (preserved by the summarizer's handover instruction) through the
-// platform account, violating tenant data boundaries. The orchestrator
-// uses this to skip the summarizer and fall through to TrimLastN.
+// requestUsesNonDeploymentCreds reports whether the request would use BYOK
+// or client-supplied creds for upstream calls. The summarizer is wired with
+// deployment-level creds; calling it on a BYOK request would route prior
+// conversation context through the platform account, violating tenant data
+// boundaries. The orchestrator uses this to skip the summarizer and fall
+// through to TrimLastN.
 func (s *Service) requestUsesNonDeploymentCreds(ctx context.Context, headers http.Header) bool {
 	if s.byokOnly {
 		return true
@@ -1247,27 +1143,16 @@ func (s *Service) requestUsesNonDeploymentCreds(ctx context.Context, headers htt
 	return false
 }
 
-// enabledProvidersForRequest returns providers whose credentials are
-// resolvable for this request (boot-time env key, BYOK, or client-supplied
-// header). The cluster scorer intersects this set with its boot-time
-// candidates so argmax never picks a model the upstream call would 401 on.
-//
-// surfaceProvider is the inbound wire-format's natural provider (anthropic
-// for /v1/messages, openai for /v1/chat/completions, google for the Gemini
-// surface). A client-supplied bearer/x-api-key header is treated as creds
-// for that surface only — never as a licence to enable other OpenAI-compat
-// upstreams that happen to read the same Authorization header. This matches
-// the guard already in resolveAndInjectCredentials: a router-key-authed
-// request must rely on BYOK; a header on such a request is for the inbound
-// surface only and must not enable cross-provider routing.
+// enabledProvidersForRequest returns providers with resolvable credentials
+// for this request (deployment key, BYOK, or client-supplied header).
+// surfaceProvider is the inbound wire-format's natural provider. A
+// client-supplied bearer header is treated as creds for that surface only —
+// never as a licence to enable other OpenAI-compat upstreams that share the
+// same Authorization header format. A router-key-authed request must rely on
+// BYOK; a header on such a request is for the inbound surface only.
 func (s *Service) enabledProvidersForRequest(ctx context.Context, surfaceProvider string, headers http.Header) map[string]struct{} {
 	out := make(map[string]struct{}, len(s.providers))
-	// In BYOK-only mode the deployment-level env key must not make a provider
-	// eligible — otherwise argmax could pick it and 401 with the platform key.
 	if !s.byokOnly {
-		// Prefer the explicit env-keyed set when configured (selfhosted mode
-		// with BYOK-routable providers registered but unkeyed). Fall back to
-		// "every registered provider" for legacy callers that don't set it.
 		if s.deploymentKeyedProviders != nil {
 			for p := range s.deploymentKeyedProviders {
 				out[p] = struct{}{}
@@ -1279,19 +1164,17 @@ func (s *Service) enabledProvidersForRequest(ctx context.Context, surfaceProvide
 		}
 	}
 	for _, k := range externalKeysFromContext(ctx) {
-		// Empty plaintext (decryption produced no bytes, or a stale row was
-		// written without a value) must not enroll the provider — argmax
-		// would pick it and the upstream call would 401 with no auth header.
+		// Empty plaintext must not enroll the provider — argmax would pick
+		// it and the upstream call would 401 with no auth header.
 		if len(k.Plaintext) == 0 {
 			continue
 		}
 		out[k.Provider] = struct{}{}
 	}
-	// Client-supplied headers are only consulted when the request is NOT
-	// authed via a router key. A router-key-authed request that happens to
-	// carry an inbound bearer (e.g. Claude Code's Anthropic OAuth token
-	// passing through) must not enable OpenAI-compat upstreams just because
-	// they share the Authorization: Bearer header format.
+	// Client-supplied headers are only consulted when NOT authed via a
+	// router key. A router-key-authed request carrying an inbound bearer
+	// must not enable OpenAI-compat upstreams that share the Authorization
+	// header format.
 	if installationIDFromContext(ctx) == (uuid.UUID{}) && surfaceProvider != "" {
 		if _, already := out[surfaceProvider]; !already {
 			if ExtractClientCredentials(surfaceProvider, headers) != nil {
@@ -1303,14 +1186,10 @@ func (s *Service) enabledProvidersForRequest(ctx context.Context, surfaceProvide
 }
 
 // resolveAndInjectCredentials resolves credentials for provider and stashes
-// them on ctx. Returns ctx unchanged when none are available.
-//
-// When the request was authenticated via a router key (installation ID present
-// on ctx), client-header extraction is skipped. This prevents the client's
-// inbound Anthropic key (Authorization: Bearer sk-ant-...) from being
-// mistakenly forwarded as credentials to a different upstream provider
-// (OpenRouter, Fireworks, etc.). In that case the deployment-level env key
-// on the provider client is the correct fallback.
+// them on ctx. When authed via a router key, client-header extraction is
+// skipped — prevents the client's inbound Anthropic key from being
+// forwarded to a different upstream provider. Deployment-level env key on
+// the provider client is the correct fallback in that case.
 func resolveAndInjectCredentials(ctx context.Context, provider string, headers http.Header) context.Context {
 	byok := BuildCredentialsMap(externalKeysFromContext(ctx))
 	var creds *Credentials
@@ -1318,8 +1197,6 @@ func resolveAndInjectCredentials(ctx context.Context, provider string, headers h
 		creds = byok[provider]
 	}
 	if creds == nil && installationIDFromContext(ctx) == (uuid.UUID{}) {
-		// No router-key auth — allow client-supplied bearer as provider creds
-		// (plan-based / dev-mode passthrough scenario).
 		creds = ExtractClientCredentials(provider, headers)
 	}
 	if creds != nil {
@@ -1329,7 +1206,6 @@ func resolveAndInjectCredentials(ctx context.Context, provider string, headers h
 }
 
 // addTimingAttrs appends derived latency attributes from the request Timing.
-// No-op when no Timing is attached.
 func addTimingAttrs(ctx context.Context, b *otel.AttrBuilder) {
 	t := otel.TimingFrom(ctx)
 	if t == nil {
@@ -1353,7 +1229,7 @@ func addTimingAttrs(ctx context.Context, b *otel.AttrBuilder) {
 }
 
 // cacheTokenPtr returns nil for zero so the DB column stays NULL when the
-// upstream did not report cache usage, distinguishing "no cache" from "0 hits".
+// upstream didn't report cache usage (distinguishing "no cache" from "0 hits").
 func cacheTokenPtr(n int) *int32 {
 	if n <= 0 {
 		return nil
@@ -1385,12 +1261,10 @@ func upstreamStatus(err error) int {
 	return 0
 }
 
-// finalizeAfterProxy runs a translator's Finalize step when the upstream call
-// either succeeded or returned a typed UpstreamStatusError. Cross-format
-// translators buffer the upstream body for non-streaming responses and only
-// flush it inside Finalize; skipping that on a 4xx/5xx drops the upstream
-// error envelope (e.g. an OpenRouter 402 "out of credits" message) before it
-// can reach the client. UpstreamStatusError takes precedence over a Finalize
+// finalizeAfterProxy runs a translator's Finalize step. Cross-format
+// translators buffer upstream body for non-streaming responses and flush only
+// inside Finalize; skipping on 4xx/5xx drops the upstream error envelope before
+// the client can see it. UpstreamStatusError takes precedence over Finalize
 // error so telemetry preserves the upstream status code.
 func finalizeAfterProxy(proxyErr error, fn func() error) error {
 	var statusErr *providers.UpstreamStatusError
@@ -1462,8 +1336,6 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 	pinAgeSec := routeRes.PinAgeSec
 	s.logPlannerOutcome(routeRes)
 
-	// Same eligibility rules as ProxyMessages. FormatOpenAI keeps replays
-	// scoped: an Anthropic-stored response is never served here.
 	cacheEligible := s.semanticCache != nil && !env.Stream() && decision.Metadata != nil && externalID != "" && !bypassEval
 	if cacheEligible {
 		if resp, hit := s.semanticCache.Lookup(externalID, cache.FormatOpenAI, decision.Metadata.Embedding, decision.Metadata.ClusterIDs); hit {
@@ -1542,7 +1414,6 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 
 	ctx = resolveAndInjectCredentials(ctx, decision.Provider, r.Header)
 
-	// Mirror post-translation wire bytes into a buffer for post-Proxy storage.
 	var captureW *captureWriter
 	var sink http.ResponseWriter = w
 	if cacheEligible {
@@ -1641,7 +1512,6 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 	applyPlannerAttrs(openaiUpstreamBuilder, routeRes)
 	addTimingAttrs(ctx, openaiUpstreamBuilder)
 
-	// Shared bundle keeps the OpenAI path in lockstep with ProxyMessages.
 	openaiObs := buildObservationContext(ctx, decision)
 	openaiObs.applySpanAttrs(openaiUpstreamBuilder)
 
@@ -1653,8 +1523,6 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 	})
 	otel.Flush(ctx)
 
-	// Persist last-turn usage to the pin row so the next turn's planner
-	// has cache-hit evidence. Off the request path; drops on saturation.
 	s.recordTurnUsage(routeRes, in, out, cacheCreation, cacheRead)
 
 	installationIDOAI, _ := ctx.Value(InstallationIDContextKey{}).(string)

--- a/internal/proxy/session_key.go
+++ b/internal/proxy/session_key.go
@@ -7,25 +7,14 @@ import (
 	"workweave/router/internal/translate"
 )
 
-// DeriveSessionKey produces the 16-byte digest used to look up a session
-// pin. Two tiers tried in order:
-//
-//  1. metadata.user_id (Claude Code packs device_id + account_uuid +
-//     session_id here, so this is session-distinct),
-//  2. system prompt + first user message (matches Anthropic prompt-cache
-//     shape; session-distinct for clients that don't set metadata.user_id).
-//
-// apiKeyID is mixed into all tiers so callers under different keys can't
-// collide on a shared pin. Pure function; empty apiKeyID just falls back to
-// the next tier.
-//
-// Routing the same human across separate sessions to the same pin would be a
-// user pin, not a session pin — so the resolved router user ID is
-// deliberately not consulted here.
+// DeriveSessionKey produces a 16-byte session digest. Tries metadata.user_id
+// (session-distinct from Claude Code's device+account+session bundle), then
+// system prompt + first user message (prompt-cache shape fallback). apiKeyID
+// is mixed into every tier to prevent cross-key collisions.
 func DeriveSessionKey(env *translate.RequestEnvelope, apiKeyID string) [sessionpin.SessionKeyLen]byte {
 	h := sha256.New()
 	h.Write([]byte(apiKeyID))
-	// Domain separator: prevents cross-tier collisions from caller-controlled strings.
+	// Domain separator prevents cross-tier collisions from caller-controlled strings.
 	h.Write([]byte{0x00})
 
 	switch {
@@ -33,7 +22,6 @@ func DeriveSessionKey(env *translate.RequestEnvelope, apiKeyID string) [sessionp
 		h.Write([]byte("user_id:"))
 		h.Write([]byte(env.MetadataUserID()))
 	case env != nil:
-		// Stable across turns: matches Anthropic's prompt-cache key shape.
 		h.Write([]byte("prompt_prefix:"))
 		h.Write([]byte(env.SystemText()))
 		h.Write([]byte{0x00})

--- a/internal/proxy/telemetry.go
+++ b/internal/proxy/telemetry.go
@@ -19,9 +19,7 @@ type TelemetryRepository interface {
 	GetTelemetryRowsAll(ctx context.Context, from, to time.Time, limit int32) ([]TelemetryRow, error)
 }
 
-// InsertTelemetryParams mirrors one router.upstream span row. Fields after
-// UpstreamStatusCode are nullable; pinned-route and heuristic paths leave
-// them zero and the adapter translates that to NULL columns.
+// InsertTelemetryParams mirrors one router.upstream span row.
 type InsertTelemetryParams struct {
 	InstallationID         string
 	RequestID              string
@@ -47,15 +45,14 @@ type InsertTelemetryParams struct {
 	CrossFormat            bool
 	UpstreamStatusCode     int32
 
-	// Routing observability fields. Populated for cluster-routed requests.
 	ClusterIDs           []int32
 	CandidateModels      []string
 	ChosenScore          *float64
 	AlphaBreakdown       []byte // pre-marshaled JSON for W-1335; nil until then
 	ClusterRouterVersion string
 	TTFTMs               *int64
-	CacheCreationTokens  *int32 // nil when the upstream reported no cache usage
-	CacheReadTokens      *int32 // nil when the upstream reported no cache usage
+	CacheCreationTokens  *int32
+	CacheReadTokens      *int32
 	DeviceID             string
 	SessionID            string
 }
@@ -87,8 +84,8 @@ type TelemetryRow struct {
 	StickyHit           bool
 	InputTokens         int32
 	OutputTokens        int32
-	CacheCreationTokens *int32 // nil when the upstream reported no cache usage
-	CacheReadTokens     *int32 // nil when the upstream reported no cache usage
+	CacheCreationTokens *int32
+	CacheReadTokens     *int32
 	RequestedCostUSD    float64
 	ActualCostUSD       float64
 	TotalLatencyMs      int64

--- a/internal/proxy/turnloop.go
+++ b/internal/proxy/turnloop.go
@@ -35,8 +35,7 @@ func installationIDFromContext(ctx context.Context) uuid.UUID {
 	return id
 }
 
-// turnLoopResult bundles the routing decision and pin/planner state for
-// OTel spans and structured log lines.
+// turnLoopResult bundles the routing decision and pin/planner state.
 type turnLoopResult struct {
 	Decision   router.Decision
 	SessionKey [sessionpin.SessionKeyLen]byte
@@ -45,41 +44,25 @@ type turnLoopResult struct {
 	HardPinned bool
 	PinTier    string
 	PinAgeSec  int64
-	// RequestedTier is the tier of the inbound requested model, looked up
-	// directly via capability.TierFor (no baseline substitution). Drives
-	// the tier-ceiling clamp; logged as `requested_tier`. TierUnknown
-	// disables clamping, which is the right behavior for custom/proxy
-	// model names (e.g. "weave-router") — substituting through
-	// baselineFor would force them into the default model's tier
-	// (TierMid) and clamp high-tier scorer picks despite the documented
-	// "unknown ⇒ no ceiling" rule.
+	// RequestedTier is the tier of the inbound requested model. Drives the
+	// tier-ceiling clamp. TierUnknown disables clamping — the right behavior
+	// for custom model names that have no known tier.
 	RequestedTier capability.Tier
 	// TierClamped is true when the original decision violated the
-	// requested-model ceiling and was rewritten to an in-ceiling pick.
-	TierClamped bool
-	// PreClampModel records the violating model so logs can attribute
-	// which model the scorer / hard-pin / pin actually wanted to use.
-	PreClampModel string
-	// PinRole is the session-pin role used for this turn. Threaded through
-	// loadPin/refreshPin/writeNewPin and the post-response UpdateUsage call
-	// so a low-tier background turn and a high-tier main turn in the same
-	// session never share a pin row.
+	// requested-model ceiling and was rewritten.
+	TierClamped    bool
+	PreClampModel  string
+	// PinRole is the session-pin role used for this turn, preventing a
+	// low-tier background turn and a high-tier main turn from sharing a pin.
 	PinRole string
-	// Fresh is the scorer's recommendation for this turn when the scorer
-	// ran. Zero-valued on hard-pin / tool-result-with-pin paths where we
-	// never consulted the scorer.
+	// Fresh is the scorer's recommendation for this turn when the scorer ran.
 	Fresh router.Decision
-	// PlannerDecision holds the planner's verdict and EV math when the
-	// planner ran. Zero-valued on hard-pin / tool-result / planner-
-	// disabled / no-pin-store paths.
+	// PlannerDecision holds the planner's verdict and EV math when the planner ran.
 	PlannerDecision planner.Decision
-	// PinModel is the model on the loaded pin, when one existed. Stamped
-	// independently of PlannerDecision so log lines can describe the
-	// from-model even on stay outcomes.
+	// PinModel is the model on the loaded pin (stamped independently of
+	// PlannerDecision so log lines can name the from-model even on stay outcomes).
 	PinModel string
-	// Handover captures what happened in the cache-eviction path. Invoked
-	// is true only when the planner switched off an existing pin and the
-	// orchestrator attempted a summarize-or-trim step.
+	// Handover captures the summarize-or-trim step when the planner switched.
 	Handover handoverOutcome
 }
 
@@ -91,14 +74,12 @@ type handoverOutcome struct {
 	FallbackToTrim bool
 }
 
-// runTurnLoop is the format-agnostic Prism-style routing orchestrator.
-// See the package-level docs (and the routing plan) for the flow; in
-// brief: detect turn type, short-circuit hard pins, load any existing
-// pin, run the scorer for MainLoop turns, hand the result to the
-// planner, and on switch attempt bounded-cost handover.
+// runTurnLoop is the format-agnostic routing orchestrator: detect turn type,
+// short-circuit hard pins, load pin, run scorer, hand to planner, and on
+// switch attempt bounded-cost handover.
 //
-// installationID == uuid.Nil skips the async pin upsert (pin rows
-// require an installation_id); the rest of the path runs normally.
+// installationID == uuid.Nil skips async pin upsert (pin rows need an
+// installation_id); the rest of the path runs normally.
 func (s *Service) runTurnLoop(
 	ctx context.Context,
 	env *translate.RequestEnvelope,
@@ -117,16 +98,12 @@ func (s *Service) runTurnLoop(
 	}
 	res.PinRole = roleForTier(res.RequestedTier)
 
-	// Hard pins for turn types whose optimal model is known a priori
-	// (compaction, Explore sub-agent dispatch, SDK quota probes, Claude
-	// Code title generation). Bypass pin lookup, pin write, planner and
-	// scorer entirely so the pin row keeps tracking the main-loop model.
-	// Probes and title-gen specifically MUST NOT create a session pin —
-	// the Anthropic SDK fires probes on init before the first real user
-	// turn, and Claude Code fires a title-gen call ~25ms before the
-	// real-conv call on every user turn. In both cases an anchored pin
-	// would inherit the cheap-model decision into the immediately-
-	// following real conversation that should have routed on its own.
+	// Hard pins bypass pin lookup, pin write, planner, and scorer entirely.
+	// Probes and title-gen MUST NOT create a session pin — the Anthropic SDK
+	// fires probes on init before the first real user turn, and Claude Code
+	// fires title-gen ~25ms before the real-conv call. An anchored pin would
+	// inherit the cheap-model decision into the immediately-following real
+	// conversation that should have routed on its own.
 	if res.TurnType == turntype.Compaction ||
 		res.TurnType == turntype.Probe ||
 		res.TurnType == turntype.TitleGen ||
@@ -168,8 +145,7 @@ func (s *Service) runTurnLoop(
 		return res, nil
 	}
 
-	// Without a pin store there is no pin lifecycle to manage; degrade to
-	// "run the scorer, return its decision, persist nothing".
+	// Without a pin store, run the scorer and return its decision.
 	if s.pinStore == nil {
 		decision, err := s.router.Route(ctx, req)
 		if err != nil {
@@ -202,9 +178,7 @@ func (s *Service) runTurnLoop(
 		return res, nil
 	}
 
-	// Planner-disabled + pin found: preserve "first decision wins"
-	// behavior for callers that opt out via env flag. Skip the scorer
-	// entirely; the pin's model is authoritative.
+	// Planner-disabled + pin found: preserve first-decision-wins behavior.
 	if !s.plannerEnabled && pinFound {
 		decision := s.clampToCeiling(pinDecision(pin), res.RequestedTier, req.EnabledProviders, req.ExcludedModels, &res)
 		res.Decision = decision
@@ -214,9 +188,7 @@ func (s *Service) runTurnLoop(
 		return res, nil
 	}
 
-	// MainLoop (or ToolResult without an existing pin, or planner-
-	// disabled without a pin): always run the scorer. The scorer's
-	// error path surfaces to HTTP 503 in the presentation layer.
+	// Always run the scorer when no pin, or on MainLoop with a pin.
 	fresh, err := s.router.Route(ctx, req)
 	if err != nil {
 		return res, err
@@ -224,15 +196,12 @@ func (s *Service) runTurnLoop(
 	fresh = s.clampToCeiling(fresh, res.RequestedTier, req.EnabledProviders, req.ExcludedModels, &res)
 	res.Fresh = fresh
 
-	// Planner-disabled with no pin: take the fresh decision and write
-	// a new pin row so subsequent turns see it.
 	if !s.plannerEnabled {
 		res.Decision = fresh
 		s.writeNewPin(installationID, res.SessionKey, pinCacheKey, res.PinRole, fresh)
 		return res, nil
 	}
 
-	// Planner path: weigh pin vs. fresh under the EV policy.
 	plannerIn := planner.Inputs{
 		Pin:                  pin,
 		Fresh:                fresh,
@@ -254,23 +223,15 @@ func (s *Service) runTurnLoop(
 		return res, nil
 	}
 
-	// Switch path: either explicit outcome=switch, or (defensively)
-	// outcome=stay with no pin to actually stay on. When switching off an
-	// existing warm cache, attempt bounded-cost handover: synchronously
-	// summarize prior context with the cheap-model summarizer; on error
-	// fall back to TrimLastN so the switch turn still succeeds. When the
-	// summarizer is not wired (self-hoster with no Anthropic key) or the
-	// request carries BYOK/client credentials, skip summarization and
-	// trim instead — either way the switch turn must NOT forward the
-	// full prior conversation to the new model (defeats the cost-bounding
-	// goal of handover).
+	// Switch path: when switching off a warm cache, attempt bounded-cost
+	// handover. On summarizer error fall back to TrimLastN. When the
+	// summarizer is not wired or the request carries BYOK/client credentials,
+	// skip summarization and trim instead — the switch turn must NOT forward
+	// the full prior conversation to the new model.
 	//
-	// Privacy guard: the summarizer is wired at boot with deployment-level
-	// provider credentials. Calling it on a request whose upstream call
-	// would otherwise use BYOK or client-supplied credentials would route
-	// prior conversation context (carried verbatim into the summarizer
-	// prompt) through the platform account, violating tenant data
-	// boundaries.
+	// Privacy guard: the summarizer is wired with deployment-level creds.
+	// Calling it on a BYOK/client-creds request would route prior conversation
+	// through the platform account, violating tenant data boundaries.
 	if pinFound {
 		switch {
 		case s.summarizer == nil:
@@ -312,13 +273,9 @@ func (s *Service) runTurnLoop(
 	return res, nil
 }
 
-// roleForTier maps a requested-model tier to its session-pin role. Each
-// tier gets its own row so a low-tier background turn and a high-tier
-// main turn in the same session never share a pin (preventing the
-// haiku-inherits-opus-pin leak that originally motivated the tier
-// ceiling). TierUnknown falls back to DefaultRole so callers with custom
-// model names (no entry in the capability table) keep their pre-ceiling
-// behavior.
+// roleForTier maps a requested-model tier to its session-pin role. Each tier
+// gets its own row so separate-tier turns never share a pin. TierUnknown
+// falls back to DefaultRole.
 func roleForTier(t capability.Tier) string {
 	switch t {
 	case capability.TierLow:
@@ -333,24 +290,14 @@ func roleForTier(t capability.Tier) string {
 }
 
 // clampToCeiling enforces the requested-model tier ceiling. When the
-// decision's model has a known tier strictly higher than the ceiling,
-// the resolver picks the cheapest in-ceiling alternative for the
-// request's enabled providers and replaces the decision. Decisions
-// already at or below the ceiling pass through. The resolver also
-// honors req.ExcludedModels so the clamp path cannot route to models
-// the installation/request has explicitly denylisted — otherwise tier
-// clamping would silently bypass the model access policy enforced on
-// normal scorer routing. TierUnknown ceilings (custom model names with
-// no capability entry) disable clamping. Resolver lookup failure (no
-// in-ceiling model available) preserves the original decision rather
-// than failing the turn — a soft fallback chosen over hard erroring on
-// background tasks.
+// decision's tier exceeds the ceiling, the resolver picks the cheapest
+// in-ceiling alternative. Decisions at/below ceiling pass through.
+// TierUnknown disables clamping. Resolver failure preserves the original
+// decision as a soft fallback.
 func (s *Service) clampToCeiling(decision router.Decision, ceiling capability.Tier, enabled, excluded map[string]struct{}, res *turnLoopResult) router.Decision {
 	// Reset state every call: the orchestrator clamps multiple decision
-	// sources per turn (fresh scorer output, then planner-stay pin), and
-	// without this reset a clamp on `fresh` would leak `TierClamped=true`
-	// + `PreClampModel` into a subsequent unclamped pin decision, falsely
-	// labeling the final decision as clamped in the structured log.
+	// sources per turn, and without this reset a clamp on `fresh` would leak
+	// TierClamped=true + PreClampModel into a subsequent unclamped pin decision.
 	res.TierClamped = false
 	res.PreClampModel = ""
 	if s.tierClampResolver == nil || ceiling == capability.TierUnknown {
@@ -373,22 +320,16 @@ func (s *Service) clampToCeiling(decision router.Decision, ceiling capability.Ti
 }
 
 // loadPin returns the active pin for this session, consulting the in-proc
-// LRU first then Postgres. Expired rows are treated as misses on both
-// tiers. A store error is logged and surfaces as "not found" so the
-// caller falls through to the planner with a zero pin.
+// LRU first then Postgres. Expired rows are treated as misses.
 func (s *Service) loadPin(ctx context.Context, pinCacheKey string, sessionKey [sessionpin.SessionKeyLen]byte, role string) (sessionpin.Pin, bool) {
 	log := observability.Get()
 	log.Debug("loadPin called", "role", role, "session_key_hex", fmt.Sprintf("%x", sessionKey))
 	if s.pinCache != nil {
 		if pin, ok := s.pinCache.Get(pinCacheKey); ok {
-			// Mirror the Postgres-tier expiry check below: an LRU entry
-			// whose PinnedUntil has lapsed must not be served. The 30s
-			// LRU TTL is short relative to the 1h pin TTL, so this is
-			// mostly defense-in-depth — but recordTurnUsage re-adds
-			// entries on every turn (resetting the LRU clock), so under
-			// the worst-case ordering (refreshPin's enqueue dropped on
-			// semaphore saturation while recordTurnUsage keeps landing)
-			// an expired entry could otherwise outlive its PinnedUntil.
+			// Check expiry: recordTurnUsage refreshes LRU entries on every
+			// turn (resetting the 30s eviction clock), so without this guard
+			// an expired entry whose refreshPin write was dropped could keep
+			// being served past its PinnedUntil.
 			if pin.PinnedUntil.After(time.Now()) {
 				return pin, true
 			}
@@ -412,10 +353,9 @@ func (s *Service) loadPin(ctx context.Context, pinCacheKey string, sessionKey [s
 	return pin, true
 }
 
-// refreshPin extends the TTL on an existing pin and refreshes the in-proc
-// cache entry. Carries the existing pin's cached last-turn usage forward
-// so the planner has evidence on subsequent turns even before the next
-// UpdateUsage writeback lands. Async, bounded; drops on saturation.
+// refreshPin extends the TTL on an existing pin. Carries the existing pin's
+// usage forward so the planner has evidence before the next UpdateUsage
+// writeback lands. Async, bounded; drops on saturation.
 func (s *Service) refreshPin(installationID uuid.UUID, sessionKey [sessionpin.SessionKeyLen]byte, existing sessionpin.Pin, pinCacheKey string, role string, chosen router.Decision) {
 	if installationID == uuid.Nil {
 		return
@@ -438,9 +378,8 @@ func (s *Service) refreshPin(installationID uuid.UUID, sessionKey [sessionpin.Se
 	s.enqueuePinUpsert(p, pinCacheKey)
 }
 
-// writeNewPin records a freshly-routed decision as the active pin. Used
-// on first-turn routing and on switch turns; the new row has no prior
-// usage stats yet (UpdateUsage fills them in after the response lands).
+// writeNewPin records a freshly-routed decision as the active pin. Used on
+// first-turn routing and switch turns. UpdateUsage fills in usage stats later.
 func (s *Service) writeNewPin(installationID uuid.UUID, sessionKey [sessionpin.SessionKeyLen]byte, pinCacheKey string, role string, chosen router.Decision) {
 	observability.Get().Debug("writeNewPin called", "installation_id", installationID.String(), "role", role, "model", chosen.Model, "session_key_hex", fmt.Sprintf("%x", sessionKey))
 	if installationID == uuid.Nil {
@@ -461,9 +400,7 @@ func (s *Service) writeNewPin(installationID uuid.UUID, sessionKey [sessionpin.S
 }
 
 // enqueuePinUpsert pushes a pin write onto the bounded async worker pool.
-// Drops on saturation (a slow Postgres must not accumulate goroutines on
-// the request path). Also primes the in-proc LRU so the next turn on
-// this session avoids Postgres.
+// Drops on saturation. Primes the in-proc LRU so the next turn avoids Postgres.
 func (s *Service) enqueuePinUpsert(p sessionpin.Pin, pinCacheKey string) {
 	log := observability.Get()
 	select {

--- a/internal/proxy/turnloop.go
+++ b/internal/proxy/turnloop.go
@@ -50,8 +50,8 @@ type turnLoopResult struct {
 	RequestedTier capability.Tier
 	// TierClamped is true when the original decision violated the
 	// requested-model ceiling and was rewritten.
-	TierClamped    bool
-	PreClampModel  string
+	TierClamped   bool
+	PreClampModel string
 	// PinRole is the session-pin role used for this turn, preventing a
 	// low-tier background turn and a high-tier main turn from sharing a pin.
 	PinRole string

--- a/internal/proxy/turnloop_internal_test.go
+++ b/internal/proxy/turnloop_internal_test.go
@@ -13,9 +13,7 @@ import (
 	"workweave/router/internal/router/sessionpin"
 )
 
-// stubPinStore is the minimum sessionpin.Store needed to exercise the
-// recordTurnUsage LRU-coherence path without pulling in the external
-// fake from service_session_pin_test.go (different test package).
+// stubPinStore is a minimal sessionpin.Store for testing recordTurnUsage.
 type stubPinStore struct {
 	mu          sync.Mutex
 	lastUsage   sessionpin.Usage
@@ -45,19 +43,13 @@ func (s *stubPinStore) UpdateUsage(_ context.Context, _ [sessionpin.SessionKeyLe
 
 func (s *stubPinStore) SweepExpired(context.Context) error { return nil }
 
-// TestRecordTurnUsage_UpdatesInProcCache guards the LRU-coherence
-// invariant: when recordTurnUsage persists usage, the in-proc pin cache
-// entry for the same session must reflect the new Last* fields. Without
-// this, loadPin's Tier-1 hit serves a stale zero-usage pin and the
-// planner returns ReasonNoPriorUsage forever (the 30s LRU TTL keeps
-// resetting under typical agentic turn cadence), silently disabling
-// EV-based switching for all active sessions.
+// TestRecordTurnUsage_UpdatesInProcCache guards the LRU-coherence invariant:
+// when recordTurnUsage persists usage, the in-proc pin cache entry must
+// reflect the new Last* fields. Without this, loadPin's Tier-1 hit serves a
+// stale zero-usage pin and the planner returns ReasonNoPriorUsage forever.
 func TestRecordTurnUsage_UpdatesInProcCache(t *testing.T) {
 	store := newStubPinStore()
-	// NewService wires a real expirable LRU when pinSessionTTL/etc. are
-	// in play; constructing through the public ctor keeps that wiring
-	// honest. We don't need a router/provider for this test — only the
-	// usage path.
+	// NewService wires a real expirable LRU when pinStore is set.
 	svc := NewService(
 		nil,
 		nil,
@@ -77,8 +69,7 @@ func TestRecordTurnUsage_UpdatesInProcCache(t *testing.T) {
 	}
 	cacheKey := sessionPinCacheKey(sessionKey, sessionpin.DefaultRole)
 
-	// Pre-warm the cache the same way writeNewPin/refreshPin would: a
-	// freshly-routed pin with zero usage stats.
+	// Pre-warm the cache as writeNewPin/refreshPin would.
 	initial := sessionpin.Pin{
 		SessionKey:  sessionKey,
 		Role:        sessionpin.DefaultRole,
@@ -112,12 +103,9 @@ func TestRecordTurnUsage_UpdatesInProcCache(t *testing.T) {
 }
 
 // TestLoadPin_EvictsExpiredLRUEntry guards the LRU tier's expiry check.
-// recordTurnUsage refreshes LRU entries on every turn, so the 30s eviction
-// clock keeps resetting under typical agentic cadence. Without checking
-// PinnedUntil on the LRU hit path, an entry whose pin has lapsed could
-// keep being served well past its intended expiry — particularly when
-// refreshPin's bounded enqueue drops on semaphore saturation while
-// recordTurnUsage keeps landing.
+// recordTurnUsage refreshes LRU entries on every turn, so expired entries
+// could keep being served if expiry isn't checked — particularly when
+// refreshPin's bounded enqueue drops but recordTurnUsage keeps landing.
 func TestLoadPin_EvictsExpiredLRUEntry(t *testing.T) {
 	store := newStubPinStore()
 	svc := NewService(
@@ -139,10 +127,9 @@ func TestLoadPin_EvictsExpiredLRUEntry(t *testing.T) {
 	}
 	cacheKey := sessionPinCacheKey(sessionKey, sessionpin.DefaultRole)
 
-	// Pre-warm the LRU with a pin whose PinnedUntil is already in the past.
-	// The stub pin store returns no rows on Get, so any non-expired LRU
-	// entry would be the only source of a "found" result. Confirming a
-	// miss here proves the expiry check fires before the LRU is served.
+	// Pre-warm the LRU with an expired pin. The stub store returns no rows
+	// on Get, so any non-expired LRU entry would be the only source of a
+	// "found" result.
 	expired := sessionpin.Pin{
 		SessionKey:  sessionKey,
 		Role:        sessionpin.DefaultRole,
@@ -161,8 +148,8 @@ func TestLoadPin_EvictsExpiredLRUEntry(t *testing.T) {
 	assert.False(t, stillCached, "expired LRU entry must be evicted on lookup so subsequent turns hit Postgres")
 }
 
-// TestLoadPin_ServesFreshLRUEntry is the companion happy-path test: a
-// non-expired LRU entry hits Tier 1 without touching Postgres.
+// TestLoadPin_ServesFreshLRUEntry is the companion test: a non-expired LRU
+// entry hits Tier 1 without touching Postgres.
 func TestLoadPin_ServesFreshLRUEntry(t *testing.T) {
 	store := newStubPinStore()
 	svc := NewService(

--- a/internal/router/cache/cache.go
+++ b/internal/router/cache/cache.go
@@ -1,21 +1,7 @@
-// Package cache implements a semantic response cache for the router.
-//
-// Short-circuits near-duplicate requests by cosine similarity on the
-// cluster scorer's prompt embedding; on hit, captured wire-format bytes
-// are replayed without invoking the upstream provider.
-//
-// Scope (v1):
-//   - Non-streaming only. Proxy bypasses cache when stream=true.
-//   - Per-(installation, inbound-format) isolation. Bucket key includes
-//     inbound format because captured bytes are post-translation, so a
-//     cached Anthropic response must never replay for an OpenAI client.
-//   - Cluster-bucketed brute-force lookup. Each (installation, format,
-//     clusterID) owns an LRU; lookup scans the routing decision's top-p
-//     clusters. At ~10 clusters × 1k entries × 768-d, fits in <5ms;
-//     HNSW is unnecessary.
-//
-// Out of scope: streaming, distributed (Redis), cross-installation
-// sharing, event-driven invalidation. TTL is the only eviction.
+// Package cache implements a semantic response cache. Short-circuits
+// near-duplicate non-streaming requests by cosine similarity on prompt
+// embedding; per-(installation, inbound-format) isolation. TTL is the only
+// eviction.
 package cache
 
 import (
@@ -29,26 +15,20 @@ import (
 	"github.com/hashicorp/golang-lru/v2/expirable"
 )
 
-// CachedResponse captures the upstream response in the inbound wire
-// format. Stores post-translation bytes so replay is indistinguishable
-// from the client's perspective.
+// CachedResponse captures the upstream response in the inbound wire format.
 type CachedResponse struct {
 	StatusCode int
 	Headers    http.Header
-	// Body is bounded by MaxBodyBytes; oversized entries are dropped.
-	Body []byte
+	Body       []byte // Bounded by MaxBodyBytes; oversized entries are dropped.
 }
 
 // Config carries the runtime knobs.
 type Config struct {
 	PerClusterThreshold map[int]float32
 	DefaultThreshold    float32
-	// BucketSize caps per-(installation, format, clusterID) LRU size so
-	// one chatty installation can't evict another's entries.
-	BucketSize int
-	TTL        time.Duration
-	// MaxBodyBytes drops responses larger than this without caching
-	// (Anthropic max_tokens is 200k ≈ 1MB).
+	// BucketSize caps per-(installation, format, clusterID) LRU size.
+	BucketSize   int
+	TTL          time.Duration
 	MaxBodyBytes int
 }
 
@@ -58,7 +38,7 @@ func DefaultConfig() Config {
 		DefaultThreshold: 0.95,
 		BucketSize:       1024,
 		TTL:              1 * time.Hour,
-		MaxBodyBytes:     1 << 20, // 1 MiB
+		MaxBodyBytes:     1 << 20,
 	}
 }
 
@@ -66,7 +46,7 @@ func DefaultConfig() Config {
 type Cache struct {
 	cfg     Config
 	buckets map[bucketKey]*expirable.LRU[entryKey, *entry]
-	mu      sync.Mutex // guards `buckets`; LRU itself is thread-safe
+	mu      sync.Mutex
 }
 
 // New constructs a Cache; zero Config fields fall through to DefaultConfig.
@@ -124,7 +104,7 @@ func (c *Cache) thresholdFor(clusterID int) float32 {
 }
 
 // Lookup walks buckets for (installation, format, clusterIDs) and
-// returns the first entry whose cosine clears the cluster's threshold.
+// returns the first entry whose cosine clears the threshold.
 // embedding must be L2-normalized; clusterIDs order is irrelevant.
 func (c *Cache) Lookup(installationID string, format Format, embedding []float32, clusterIDs []int) (CachedResponse, bool) {
 	if c == nil || len(embedding) == 0 || len(clusterIDs) == 0 {
@@ -136,8 +116,7 @@ func (c *Cache) Lookup(installationID string, format Format, embedding []float32
 			continue
 		}
 		threshold := c.thresholdFor(cid)
-		// LRU.Keys() returns MRU-first, biasing toward the most-recently
-		// stored similar entry.
+		// Keys() returns MRU-first, biasing toward most recently stored entry.
 		for _, k := range bucket.Keys() {
 			e, ok := bucket.Get(k)
 			if !ok {
@@ -153,8 +132,7 @@ func (c *Cache) Lookup(installationID string, format Format, embedding []float32
 }
 
 // Store persists a response. clusterID should be one of the routing
-// decision's top-p clusters; Lookup scans every top-p cluster so any
-// one suffices. Oversized bodies are silently dropped.
+// decision's top-p clusters. Oversized bodies are silently dropped.
 func (c *Cache) Store(installationID string, format Format, embedding []float32, clusterID int, resp CachedResponse) {
 	if c == nil || len(embedding) == 0 {
 		return
@@ -166,8 +144,7 @@ func (c *Cache) Store(installationID string, format Format, embedding []float32,
 	if bucket == nil {
 		return
 	}
-	// Deep-copy: caller's slice is owned by router.Decision.Metadata
-	// and may be mutated/recycled.
+	// Deep-copy: caller's slice may be mutated/recycled.
 	embedCopy := make([]float32, len(embedding))
 	copy(embedCopy, embedding)
 	bucket.Add(entryKeyFor(embedCopy), &entry{
@@ -176,8 +153,8 @@ func (c *Cache) Store(installationID string, format Format, embedding []float32,
 	})
 }
 
-// bucket returns the LRU for a key. create=false returns nil for
-// missing buckets (lookup path); create=true allocates lazily.
+// bucket returns the LRU for a key. create=false returns nil for missing
+// buckets (lookup path); create=true allocates lazily.
 func (c *Cache) bucket(installationID string, format Format, clusterID int, create bool) *expirable.LRU[entryKey, *entry] {
 	key := bucketKey{installationID: installationID, format: format, clusterID: clusterID}
 	c.mu.Lock()
@@ -193,8 +170,8 @@ func (c *Cache) bucket(installationID string, format Format, clusterID int, crea
 	return b
 }
 
-// entryKeyFor hashes embedding bytes so identical embeddings produce
-// the same key and re-stores update in-place rather than churning the LRU.
+// entryKeyFor hashes embedding bytes so re-stores update in-place rather
+// than churning the LRU.
 func entryKeyFor(embedding []float32) entryKey {
 	if len(embedding) == 0 {
 		return entryKey{}
@@ -209,9 +186,8 @@ func entryKeyFor(embedding []float32) entryKey {
 	return k
 }
 
-// cosine computes cosine similarity. Both inputs must be L2-normalized
-// (cluster scorer guarantees this); skip sqrt+divide to mirror
-// scorer.go::topPNearest.
+// cosine computes cosine similarity. Both inputs must be L2-normalized;
+// skip sqrt+divide to mirror scorer.go::topPNearest.
 func cosine(a, b []float32) float32 {
 	if len(a) != len(b) {
 		return 0

--- a/internal/router/capability/tier.go
+++ b/internal/router/capability/tier.go
@@ -1,8 +1,7 @@
-// Package capability assigns a coarse Low/Mid/High tier to each
-// deployed model so the planner can overturn a cost-driven "stay" when
-// the scorer recommends a strictly stronger model. Hand-maintained on
-// purpose — deriving tiers from price would silently move models on
-// every pricing change.
+// Package capability assigns Low/Mid/High tiers to deployed models so the
+// planner can overturn cost-driven stays when the scorer recommends a
+// strictly stronger model. Hand-maintained — deriving from price would
+// silently move models on every pricing change.
 package capability
 
 import (
@@ -16,10 +15,7 @@ import (
 type Tier int
 
 const (
-	// TierUnknown is the zero value for models absent from the table.
-	// Per-request it disables the tier guard; Validate fails loud at
-	// boot so a missing entry can't silently bypass it.
-	TierUnknown Tier = iota
+	TierUnknown Tier = iota // Zero value; absent from table. Validate catches at boot.
 	TierLow
 	TierMid
 	TierHigh
@@ -39,9 +35,7 @@ func (t Tier) String() string {
 	}
 }
 
-// tiers keys must match deployed model names in
-// internal/router/cluster/artifacts/<version>/model_registry.json
-// verbatim; Validate enforces this at boot.
+// tiers must match model_registry.json verbatim; Validate enforces at boot.
 var tiers = map[string]Tier{
 	// --- Low ---
 	"claude-haiku-4-5":                 TierLow,
@@ -80,10 +74,8 @@ var tiers = map[string]Tier{
 	"deepseek/deepseek-v4-pro": TierHigh,
 }
 
-// TierFor returns the model's tier, or TierUnknown if absent. Anthropic
-// model identifiers carry a "-YYYYMMDD" date suffix (e.g.
-// "claude-haiku-4-5-20251001") that the table doesn't enumerate; we
-// strip an 8-digit suffix before retrying so dated variants resolve.
+// TierFor returns the model's tier, or TierUnknown if absent. Strips an
+// 8-digit date suffix before retrying so dated variants resolve.
 func TierFor(model string) Tier {
 	if t, ok := tiers[model]; ok {
 		return t
@@ -97,8 +89,6 @@ func TierFor(model string) Tier {
 }
 
 // stripDateSuffix removes a trailing "-XXXXXXXX" (hyphen + 8 digits).
-// Mirror of pricing.stripDateSuffix; kept local so capability doesn't
-// import pricing.
 func stripDateSuffix(model string) string {
 	if len(model) < 10 {
 		return model
@@ -115,10 +105,9 @@ func stripDateSuffix(model string) string {
 	return model[:len(model)-9]
 }
 
-// IsAtOrBelow reports whether the given model's tier is known and at or
-// below the ceiling. Unknown-tier models return false so the tier-ceiling
-// guard fails closed — Validate already catches missing entries at boot,
-// so any TierUnknown at request time means the table is out of sync.
+// IsAtOrBelow reports whether the model's tier is known and at or below
+// the ceiling. Unknown-tier models return false — Validate catches missing
+// entries at boot.
 func IsAtOrBelow(model string, ceiling Tier) bool {
 	t := TierFor(model)
 	if t == TierUnknown {

--- a/internal/router/cluster/artifacts.go
+++ b/internal/router/cluster/artifacts.go
@@ -16,40 +16,34 @@ import (
 
 // centroids.bin file format (little-endian):
 //
-//	magic     [4]byte  = "CRT1"
-//	version   uint32   = 1
-//	k         uint32   number of centroids
-//	dim       uint32   embedding dimension (must equal EmbedDim)
-//	data      [k][dim]float32  L2-normalized centroids, row-major
-//
-// Magic + version header catches malformed/truncated files at load time
-// rather than producing silently-wrong routing.
+//	magic   [4]byte  = "CRT1"
+//	version uint32   = 1
+//	k       uint32   number of centroids
+//	dim     uint32   embedding dimension (must equal EmbedDim)
+//	data    [k][dim]float32  L2-normalized centroids, row-major
 const (
 	centroidsMagic   = "CRT1"
 	centroidsVersion = uint32(1)
 )
 
 // LatestPointer names the file inside artifacts/ pinning the default
-// served version. Promoting a trained version is a one-line edit.
+// served version.
 const LatestPointer = "latest"
 
 // LatestVersion is the sentinel ROUTER_CLUSTER_VERSION accepts to mean
-// "read artifacts/latest". Treat identically to empty string.
+// "read artifacts/latest".
 const LatestVersion = "latest"
 
-// embeddedArtifacts is the entire artifacts/ tree compiled into the
-// binary; each subdir is one frozen, comparable bundle.
+// embeddedArtifacts is the entire artifacts/ tree compiled into the binary.
 //
 //go:embed all:artifacts
 var embeddedArtifacts embed.FS
 
-// Centroids are L2-normalized at training time so the runtime can use
-// dot product as a cosine-distance signal.
+// Centroids are L2-normalized at training time so runtime can use dot product.
 type Centroids struct {
 	K   int
 	Dim int
-	// Data is row-major: centroid k at Data[k*Dim : (k+1)*Dim]. Single
-	// contiguous allocation keeps the distance loop cache-friendly.
+	// Data is row-major: centroid k at Data[k*Dim : (k+1)*Dim].
 	Data []float32
 }
 
@@ -59,9 +53,8 @@ func (c *Centroids) Row(k int) []float32 {
 }
 
 // Rankings is the per-(cluster, model) α-blended score table.
-// Values are min-max-normalized per cluster and α-blended at training
-// time (paper §3): xⱼⁱ = α · p̃ⱼⁱ + (1 − α) · (1 − q̃ⱼⁱ).
-// Runtime scorer just sums + argmaxes.
+// Values are min-max-normalized per cluster and α-blended at training time
+// (paper §3). Runtime scorer sums + argmaxes.
 type Rankings map[int]map[string]float32
 
 // rankingsFile is the on-disk JSON form; cluster ids parsed back to int.
@@ -81,8 +74,7 @@ type rankingsFile struct {
 }
 
 // DeployedEntry is one routable target. Direct columns are 1:1
-// (Model == BenchColumn); proxy entries reuse another column's scores
-// until enough D3 traffic accumulates to rank directly.
+// (Model == BenchColumn); proxy entries reuse another column's scores.
 type DeployedEntry struct {
 	Model       string `json:"model"`
 	Provider    string `json:"provider"`
@@ -97,8 +89,6 @@ type ModelRegistry struct {
 }
 
 // Models returns the deduplicated model-name set in DeployedModels order.
-// Order is meaningful: it pins tie-breaking when providers share a
-// bench column score.
 func (r *ModelRegistry) Models() []string {
 	seen := make(map[string]struct{}, len(r.DeployedModels))
 	out := make([]string, 0, len(r.DeployedModels))
@@ -112,8 +102,8 @@ func (r *ModelRegistry) Models() []string {
 	return out
 }
 
-// ArtifactMetadata is the parsed metadata.yaml. Informational at
-// runtime; routing decisions depend only on centroids + rankings + registry.
+// ArtifactMetadata is the parsed metadata.yaml. Informational at runtime;
+// routing decisions depend only on centroids + rankings + registry.
 type ArtifactMetadata struct {
 	Version           string             `yaml:"version"`
 	Parent            string             `yaml:"parent,omitempty"`
@@ -126,18 +116,14 @@ type ArtifactMetadata struct {
 	DeployedModels    []string           `yaml:"deployed_models,omitempty"`
 	CostPer1KInputUSD map[string]float64 `yaml:"cost_per_1k_input_usd,omitempty"`
 	Changelog         string             `yaml:"changelog,omitempty"`
-	// CacheConfig is optional. Each version may tune thresholds
-	// independently — looser geometry can ship lower thresholds.
+	// CacheConfig carries per-version semantic-cache knobs.
 	CacheConfig *ArtifactCacheConfig `yaml:"cache_config,omitempty"`
 }
 
 // ArtifactCacheConfig carries per-version semantic-cache knobs.
 type ArtifactCacheConfig struct {
-	// DefaultThreshold is the cosine floor applied to clusters without
-	// override; 0 means fall back to the runtime's compiled-in default.
-	DefaultThreshold float32 `yaml:"default_threshold,omitempty"`
-	// PerClusterThreshold is sparse; only list outliers. Values in [0, 1].
-	PerClusterThreshold map[int]float32 `yaml:"per_cluster_threshold,omitempty"`
+	DefaultThreshold    float32           `yaml:"default_threshold,omitempty"`
+	PerClusterThreshold map[int]float32   `yaml:"per_cluster_threshold,omitempty"`
 }
 
 type ArtifactEmbedder struct {
@@ -166,8 +152,6 @@ type Bundle struct {
 }
 
 // ListVersions returns sorted version directories under artifacts/.
-// Order is lexicographic — keep names monotonic and zero-padded past
-// 9 minor versions. The "latest" pointer file is not returned.
 func ListVersions() ([]string, error) {
 	entries, err := fs.ReadDir(embeddedArtifacts, "artifacts")
 	if err != nil {
@@ -320,19 +304,13 @@ func loadRankings(raw []byte) (Rankings, error) {
 }
 
 // CheapestModel returns the lowest cost-per-1k-input entry among
-// registry entries whose provider is in available. Entries missing a
-// cost are skipped. Returns ok=false if nothing matches.
+// registry entries whose provider is in available. Returns ok=false if
+// nothing matches.
 func CheapestModel(meta *ArtifactMetadata, registry *ModelRegistry, available map[string]struct{}) (provider, model string, ok bool) {
 	return cheapestModelFiltered(meta, registry, available, nil, nil)
 }
 
-// CheapestModelInSet is CheapestModel restricted to a caller-supplied
-// model allowlist and denylist. Used by the tier-ceiling clamp:
-// callers pass the set of models at or below the requested tier as
-// allowSet so the cheapest pick stays inside the ceiling, plus the
-// request's ExcludedModels as denySet so the clamp path cannot bypass
-// the installation/request model exclusion policy. nil/empty allowSet
-// behaves like CheapestModel; nil/empty denySet disables exclusion.
+// CheapestModelInSet is CheapestModel restricted to an allowlist and denylist.
 func CheapestModelInSet(meta *ArtifactMetadata, registry *ModelRegistry, available, denySet, allowSet map[string]struct{}) (provider, model string, ok bool) {
 	return cheapestModelFiltered(meta, registry, available, denySet, allowSet)
 }
@@ -365,8 +343,8 @@ func cheapestModelFiltered(meta *ArtifactMetadata, registry *ModelRegistry, avai
 	return
 }
 
-// loadRegistry validates every entry has a non-empty (model, provider,
-// bench_column) triple — loud at boot beats silent "routes to nothing".
+// loadRegistry validates every entry has non-empty (model, provider,
+// bench_column).
 func loadRegistry(raw []byte) (*ModelRegistry, error) {
 	if len(raw) == 0 {
 		return nil, fmt.Errorf("model_registry.json is empty")

--- a/internal/router/cluster/artifacts.go
+++ b/internal/router/cluster/artifacts.go
@@ -122,8 +122,8 @@ type ArtifactMetadata struct {
 
 // ArtifactCacheConfig carries per-version semantic-cache knobs.
 type ArtifactCacheConfig struct {
-	DefaultThreshold    float32           `yaml:"default_threshold,omitempty"`
-	PerClusterThreshold map[int]float32   `yaml:"per_cluster_threshold,omitempty"`
+	DefaultThreshold    float32         `yaml:"default_threshold,omitempty"`
+	PerClusterThreshold map[int]float32 `yaml:"per_cluster_threshold,omitempty"`
 }
 
 type ArtifactEmbedder struct {

--- a/internal/router/cluster/embedder.go
+++ b/internal/router/cluster/embedder.go
@@ -1,21 +1,16 @@
 // Package cluster implements a content-aware Router based on AvengersPro
-// (arxiv 2508.12631, DAI 2025): embed the prompt with Jina v2 base-code
-// (768-dim, INT8-quantized ONNX), find top-p nearest centroids, and sum
-// α-blended per-(cluster, model) scores to pick a deployed model.
+// (arxiv 2508.12631, DAI 2025): embed the prompt, find top-p nearest
+// centroids, and argmax α-blended per-(cluster, model) scores.
 //
-// Runtime path is fully in-process. See docs/plans/archive/CLUSTER_ROUTING_PLAN.md.
+// Runtime path is fully in-process.
 package cluster
 
 import "context"
 
-// EmbedDim is the Jina v2 base-code output dimensionality. Pinned as a
-// sanity check against shipping a centroids.bin or model.onnx with a
-// disagreeing dimension.
+// EmbedDim is the Jina v2 base-code output dimensionality.
 const EmbedDim = 768
 
 // Embedder produces an L2-normalized [EmbedDim]float32 for prompt text.
-// Production impl wraps a hugot pipeline over an INT8-quantized ONNX
-// export of jinaai/jina-embeddings-v2-base-code.
 type Embedder interface {
 	Embed(ctx context.Context, text string) ([]float32, error)
 }

--- a/internal/router/cluster/embedder_onnx.go
+++ b/internal/router/cluster/embedder_onnx.go
@@ -14,25 +14,19 @@ import (
 	"github.com/knights-analytics/hugot/pipelines"
 )
 
-// model.onnx and tokenizer.json are paired (tokenizer must match the
-// model it was trained against); versioned together on HF Hub.
+// model.onnx and tokenizer.json are versioned together on HF Hub.
 // Override with ROUTER_ONNX_ASSETS_DIR for local dev.
 const defaultAssetsDir = "/opt/router/assets"
 
-// minModelSizeBytes is a sanity floor catching an unpopulated HF
-// download or placeholder. Real INT8-quantized jina-v2-base-code is
-// ~160 MB; failing loudly at boot beats silently miscalibrating.
-const minModelSizeBytes = 1 << 20 // 1 MiB
+// minModelSizeBytes catches unpopulated HF downloads or placeholders.
+// Real INT8-quantized jina-v2-base-code is ~160 MB.
+const minModelSizeBytes = 1 << 20
 
 // onnxEmbedder is the production Embedder. Owns one hugot session and
-// pipeline; both goroutine-safe so one instance is shared across all
-// requests. hugot handles tokenization, ONNX inference, mean pooling,
-// and L2 normalization.
+// pipeline; both goroutine-safe so one instance serves all requests.
 type onnxEmbedder struct {
-	session  *hugot.Session
-	pipeline *pipelines.FeatureExtractionPipeline
-
-	// closeOnce guards against double-close from tests/shutdown hooks.
+	session   *hugot.Session
+	pipeline  *pipelines.FeatureExtractionPipeline
 	closeOnce sync.Once
 }
 
@@ -45,8 +39,7 @@ func resolveAssetsDir() string {
 }
 
 // NewEmbedder reads model.onnx and tokenizer.json from disk and
-// constructs the shared session + pipeline. Callers must Close on
-// shutdown to release the ORT session.
+// constructs the shared session + pipeline.
 func NewEmbedder() (*onnxEmbedder, error) {
 	assetsDir := resolveAssetsDir()
 	modelPath := filepath.Join(assetsDir, "model.onnx")
@@ -63,10 +56,8 @@ func NewEmbedder() (*onnxEmbedder, error) {
 		return nil, fmt.Errorf("cluster: stat tokenizer.json at %s: %w", tokenizerPath, err)
 	}
 
-	// hugot defaults to /usr/lib (Linux) / /usr/local/lib (macOS).
-	// macOS brew installs to /opt/homebrew/lib — not the default — so
-	// ROUTER_ONNX_LIBRARY_DIR is the dev escape hatch (hugot v0.7.0
-	// takes a *directory*, not a file).
+	// hugot defaults to /usr/lib (Linux) / /usr/local/lib (macOS);
+	// ROUTER_ONNX_LIBRARY_DIR overrides (macOS brew → /opt/homebrew/lib).
 	var sessOpts []options.WithOption
 	if dir := os.Getenv("ROUTER_ONNX_LIBRARY_DIR"); dir != "" {
 		sessOpts = append(sessOpts, options.WithOnnxLibraryPath(dir))
@@ -80,11 +71,7 @@ func NewEmbedder() (*onnxEmbedder, error) {
 		ModelPath:    assetsDir,
 		Name:         "weave-router-jina-v2",
 		OnnxFilename: "model.onnx",
-		Options: []hugot.FeatureExtractionOption{
-			// jina-embeddings-v2-base-code is trained with mean pooling +
-			// L2 normalization; hard-pin to match.
-			pipelines.WithNormalization(),
-		},
+		Options:      []hugot.FeatureExtractionOption{pipelines.WithNormalization()},
 	}
 	pipeline, err := hugot.NewPipeline(session, pipelineCfg)
 	if err != nil {
@@ -98,7 +85,7 @@ func NewEmbedder() (*onnxEmbedder, error) {
 	}, nil
 }
 
-// Embed runs the pipeline on a single text. ctx is ignored — hugot
+// Embed runs the pipeline on a single text. ctx is ignored because hugot
 // v0.7.0's RunPipeline doesn't accept one; scorer.Route races this call
 // against context.WithTimeout in a goroutine instead.
 func (e *onnxEmbedder) Embed(_ context.Context, text string) ([]float32, error) {

--- a/internal/router/cluster/multiversion.go
+++ b/internal/router/cluster/multiversion.go
@@ -61,9 +61,7 @@ func (m *Multiversion) Built() []string {
 	return out
 }
 
-// DefaultDeployedModels returns the deployed candidates from the default
-// version's Scorer. The admin model-selection UI uses this as the universe
-// of valid model IDs; per-version differences are intentionally hidden.
+// DefaultDeployedModels returns the deployed candidates from the default version's Scorer.
 func (m *Multiversion) DefaultDeployedModels() []DeployedEntry {
 	s, ok := m.Versions[m.Default]
 	if !ok {
@@ -90,13 +88,10 @@ func (m *Multiversion) Route(ctx context.Context, req router.Request) (router.De
 	}
 	scorer, ok := m.Versions[chosen]
 	if !ok {
-		// Defensive: NewMultiversion enforces Default ∈ Versions. Surface
-		// the bug as ErrClusterUnavailable rather than silently degrading.
-		observability.Get().Error(
-			"Cluster scorer: chosen version missing; returning ErrClusterUnavailable",
-			"chosen_version", chosen,
-		)
+		// NewMultiversion enforces Default ∈ Versions — should be unreachable.
 		return router.Decision{}, fmt.Errorf("cluster multiversion: chosen version %q not built: %w", chosen, ErrClusterUnavailable)
 	}
 	return scorer.Route(ctx, req)
 }
+
+var _ router.Router = (*Multiversion)(nil)

--- a/internal/router/cluster/multiversion.go
+++ b/internal/router/cluster/multiversion.go
@@ -89,6 +89,10 @@ func (m *Multiversion) Route(ctx context.Context, req router.Request) (router.De
 	scorer, ok := m.Versions[chosen]
 	if !ok {
 		// NewMultiversion enforces Default ∈ Versions — should be unreachable.
+		observability.Get().Error(
+			"Cluster scorer: chosen version missing; returning ErrClusterUnavailable",
+			"chosen_version", chosen,
+		)
 		return router.Decision{}, fmt.Errorf("cluster multiversion: chosen version %q not built: %w", chosen, ErrClusterUnavailable)
 	}
 	return scorer.Route(ctx, req)

--- a/internal/router/cluster/scorer.go
+++ b/internal/router/cluster/scorer.go
@@ -12,14 +12,12 @@ import (
 	"workweave/router/internal/router"
 )
 
-// ErrClusterUnavailable is returned when the cluster scorer cannot
-// produce a routing decision. Callers map to HTTP 503: silent fallback
-// masks real regressions in eval and lets quality silently degrade.
+// ErrClusterUnavailable is returned when the cluster scorer cannot produce
+// a routing decision. Callers map to HTTP 503.
 var ErrClusterUnavailable = errors.New("cluster: routing unavailable")
 
 // ErrNoEligibleProvider is returned when req.EnabledProviders has no
-// overlap with boot-time candidates. Callers map to HTTP 4xx; silently
-// routing to an unavailable provider would 401 upstream.
+// overlap with boot-time candidates. Callers map to HTTP 4xx.
 var ErrNoEligibleProvider = errors.New("cluster: no eligible provider for request")
 
 // Config carries the scorer's runtime knobs.
@@ -39,8 +37,6 @@ func DefaultConfig() Config {
 }
 
 // Scorer is the cluster router for one frozen artifact version.
-// Failure modes return ErrClusterUnavailable rather than silently
-// falling back to a default model.
 type Scorer struct {
 	version    string
 	cfg        Config
@@ -50,19 +46,13 @@ type Scorer struct {
 	registry   *ModelRegistry
 	candidates []DeployedEntry
 	models     []string
-	// metadata is the parsed metadata.yaml; nil if absent. Used only by
-	// the semantic cache (CacheThresholds).
-	metadata *ArtifactMetadata
+	metadata   *ArtifactMetadata // nil if absent; cache threshold source.
 }
 
 // Version returns the artifact version (e.g. "v0.2").
 func (s *Scorer) Version() string { return s.version }
 
-// DeployedModels returns the static, provider-filtered candidate list this
-// Scorer was built with. The slice is a copy; mutating it does not affect
-// routing. Used by the admin API to render the model-selection checklist
-// (we surface the universe of choices, not just the currently-eligible
-// subset for a given installation).
+// DeployedModels returns a copy of the provider-filtered candidate list.
 func (s *Scorer) DeployedModels() []DeployedEntry {
 	out := make([]DeployedEntry, len(s.candidates))
 	copy(out, s.candidates)
@@ -70,8 +60,8 @@ func (s *Scorer) DeployedModels() []DeployedEntry {
 }
 
 // CacheThresholds returns per-version semantic-cache thresholds from the
-// bundle's metadata.yaml cache_config block. defaultThreshold is 0 when
-// unset; callers substitute their own runtime default.
+// bundle's metadata.yaml. defaultThreshold is 0 when unset; callers
+// substitute their own runtime default.
 func (s *Scorer) CacheThresholds() (perCluster map[int]float32, defaultThreshold float32) {
 	if s.metadata == nil || s.metadata.CacheConfig == nil {
 		return nil, 0
@@ -106,7 +96,6 @@ func NewScorer(bundle *Bundle, cfg Config, embed Embedder, availableProviders ma
 	}
 
 	if bundle.Centroids.K < cfg.TopP {
-		// TopP > K collapses top-p to "all clusters", defeating routing.
 		return nil, fmt.Errorf("cluster %s: K=%d < TopP=%d", bundle.Version, bundle.Centroids.K, cfg.TopP)
 	}
 
@@ -137,8 +126,8 @@ func NewScorer(bundle *Bundle, cfg Config, embed Embedder, availableProviders ma
 		models[i] = c.Model
 	}
 
-	// Iterate [0, K) (not rankings keys) so a missing cluster fails fast:
-	// it could win top-p at request time and silently contribute zero.
+	// Validate every cluster in [0, K) has a ranking row so a missing
+	// cluster can't win top-p at request time and silently contribute zero.
 	for k := 0; k < bundle.Centroids.K; k++ {
 		row, ok := bundle.Rankings[k]
 		if !ok {
@@ -235,9 +224,7 @@ func (s *Scorer) Route(ctx context.Context, req router.Request) (router.Decision
 		return router.Decision{}, fmt.Errorf("embedding dim %d != expected %d: %w", len(vec), s.centroids.Dim, ErrClusterUnavailable)
 	}
 
-	// Per-request gating complements boot-time filterByProviders: boot
-	// excludes providers without env keys; request excludes providers
-	// without BYOK / client keys for this installation.
+	// Per-request gating complements boot-time filterByProviders.
 	eligibleModels := s.models
 	if req.EnabledProviders != nil {
 		eligibleModels = eligibleModels[:0:0]
@@ -256,10 +243,7 @@ func (s *Scorer) Route(ctx context.Context, req router.Request) (router.Decision
 		}
 	}
 
-	// Per-installation (or env-var-driven) model exclusion. Applied after
-	// EnabledProviders so the two filters compose: provider-eligible AND
-	// not-excluded. Empties → ErrNoEligibleProvider (no silent fallback;
-	// the operator deliberately narrowed the pool).
+	// Model exclusion composes with provider gating.
 	if len(req.ExcludedModels) > 0 {
 		filtered := eligibleModels[:0:0]
 		for _, m := range eligibleModels {
@@ -301,7 +285,6 @@ func (s *Scorer) Route(ctx context.Context, req router.Request) (router.Decision
 	chosen := s.lookupCandidate(chosenModel)
 	if chosen == nil {
 		// Unreachable: argmax picks from s.models, built from s.candidates.
-		// Guard for future refactor that decouples them.
 		log.Error(
 			"Cluster scorer: argmax model not found in candidates; returning ErrClusterUnavailable",
 			"chosen_model", chosenModel,
@@ -309,9 +292,7 @@ func (s *Scorer) Route(ctx context.Context, req router.Request) (router.Decision
 		return router.Decision{}, fmt.Errorf("argmax model %q not found in candidates: %w", chosenModel, ErrClusterUnavailable)
 	}
 
-	// Copy slices so downstream consumers (semantic cache) can reuse the
-	// embedding + top-p clusters without re-embedding; originals are
-	// short-lived within this call.
+	// Copy slices for downstream (semantic cache) reuse.
 	embedCopy := make([]float32, len(vec))
 	copy(embedCopy, vec)
 	clustersCopy := make([]int, len(topClusters))
@@ -354,7 +335,6 @@ func (s *Scorer) Route(ctx context.Context, req router.Request) (router.Decision
 	return decision, nil
 }
 
-// lookupCandidate returns nil when no candidate matches.
 func (s *Scorer) lookupCandidate(model string) *DeployedEntry {
 	for i := range s.candidates {
 		if s.candidates[i].Model == model {

--- a/internal/router/handover/summarizer.go
+++ b/internal/router/handover/summarizer.go
@@ -1,14 +1,12 @@
 // Package handover defines the contract for bounded-cost context handover
-// when the planner switches models mid-session. The adapter that calls a
-// real provider lives in internal/proxy; this package only declares the
-// interface and the envelope-rewrite helpers so inner-ring code can
-// describe the operation without taking an I/O dependency.
+// when the planner switches models mid-session. The provider-backed
+// implementation lives in internal/proxy; this package only declares the
+// interface and envelope-rewrite helpers so inner-ring code can describe
+// the operation without an I/O dependency.
 //
-// Why this exists: switching models mid-session forces the new model to
-// take a one-time prompt-cache miss on the whole prior context. By
-// summarizing the conversation and replacing the message history with
-// [synthesizedSummary, latestUser], the switch turn's input cost is
-// bounded regardless of how long the session has been running.
+// Why: switching mid-session forces a prompt-cache miss on the full prior
+// context. Summarizing and replacing history with [summary, latestUser]
+// bounds switch-turn input cost regardless of session length.
 package handover
 
 import (
@@ -17,29 +15,20 @@ import (
 	"workweave/router/internal/translate"
 )
 
-// Summarizer produces a short prose summary of the prior conversation
-// suitable to seed a new model's context after a router switch. Adapters
-// implement this against a real LLM (default: claude-haiku-4-5).
+// Summarizer produces a prose summary of the prior conversation for
+// seeding a new model's context after a router switch.
 //
-// The summarizer SHOULD respect the context's deadline. On timeout or
-// any error, callers fall back to TrimLastN — implementations return an
-// error rather than blocking past the deadline.
+// Implementations SHOULD respect the context deadline. On timeout or
+// error, callers fall back to TrimLastN.
 type Summarizer interface {
 	Summarize(ctx context.Context, env *translate.RequestEnvelope) (summary string, err error)
 }
 
-// RewriteEnvelope mutates env in-place: keeps the system block(s) and
-// replaces all messages with [assistantSummary, latestUser]. The summary
-// is wrapped with translate.HandoverSummaryTag so a reader can tell
-// synthesized context from real assistant output.
+// RewriteEnvelope mutates env in-place: keeps system blocks, replaces
+// messages with [assistantSummary, latestUser]. Returns the number of
+// original messages elided.
 //
-// Returns the number of original messages that were elided so the
-// caller can log it. The synthesized summary entry is not counted as
-// elided.
-//
-// Pure: no I/O. Returns 0 and does nothing when env is nil, when the
-// envelope's message array is missing, or when the message array is
-// empty.
+// Pure: no I/O. Returns 0 when env is nil or the message array is missing/empty.
 func RewriteEnvelope(env *translate.RequestEnvelope, summary string) int {
 	if env == nil {
 		return 0
@@ -47,10 +36,9 @@ func RewriteEnvelope(env *translate.RequestEnvelope, summary string) int {
 	return env.RewriteForHandover(summary)
 }
 
-// TrimLastN is the graceful-degradation path used when summarization
-// fails or times out. Keeps the most recent n non-system messages plus
-// the system block(s); n <= 0 is treated as 3. Returns the number of
-// messages elided.
+// TrimLastN is the graceful-degradation path when summarization fails or
+// times out. Keeps the most recent n non-system messages plus system
+// blocks; n <= 0 is treated as 3. Returns the number of messages elided.
 //
 // Pure: no I/O. Returns 0 when env is nil.
 func TrimLastN(env *translate.RequestEnvelope, n int) int {

--- a/internal/router/model.go
+++ b/internal/router/model.go
@@ -34,8 +34,8 @@ func NewSpec(caps ...ModelCapability) ModelSpec {
 // dateSuffix matches Anthropic (-20251001) and OpenAI (-2024-08-06) trailing date stamps.
 var dateSuffix = regexp.MustCompile(`-\d{4}-?\d{2}-?\d{2}$`)
 
-// Lookup returns the spec for a known model ID. Dated variants fall back
-// to the base model. Unknown models get a zero-value ModelSpec.
+// Lookup returns the spec for a known model ID. Dated variants (e.g.
+// "-20251001") fall back to the base model; unknown models get zero-value.
 func Lookup(model string) ModelSpec {
 	if s, ok := registry[model]; ok {
 		return s
@@ -65,38 +65,31 @@ var googleBase = NewSpec()
 var openAICompatBase = NewSpec()
 
 var registry = map[string]ModelSpec{
-	// Anthropic: adaptive + extended
 	"claude-opus-4-7":   anthropicFull,
 	"claude-sonnet-4-6": anthropicFull,
 	"claude-opus-4-6":   anthropicFull,
 
-	// Anthropic: extended only.
-	// Empirical (2026-04-30): claude-haiku-4-5 returns 400
-	// "adaptive thinking is not supported on this model" when a Claude
-	// Code body with thinking.type=adaptive is forwarded through the
-	// router after a downgrade from claude-opus-4-7.
+	// claude-haiku-4-5 returns 400 "adaptive thinking is not supported on
+	// this model" when a Claude Code body with thinking.type=adaptive is
+	// forwarded through the router after a downgrade from opus.
 	"claude-haiku-4-5": anthropicExtended,
 	"claude-opus-4-5":  anthropicExtended,
 	"claude-opus-4-1":  anthropicExtended,
 	"claude-opus-4-0":  anthropicExtended,
 
-	// Anthropic: no thinking
 	"claude-sonnet-4-5": NewSpec(),
 	"claude-sonnet-4-0": NewSpec(),
 
-	// OpenAI: GPT-5.5
 	"gpt-5.5":      openaiReasoning,
 	"gpt-5.5-pro":  openaiReasoning,
 	"gpt-5.5-mini": openaiReasoning,
 	"gpt-5.5-nano": openaiReasoning,
 
-	// OpenAI: GPT-5.4
 	"gpt-5.4":      openaiReasoning,
 	"gpt-5.4-pro":  openaiReasoning,
 	"gpt-5.4-mini": openaiReasoning,
 	"gpt-5.4-nano": openaiReasoning,
 
-	// OpenAI: GPT-5.x earlier
 	"gpt-5.3":     openaiReasoning,
 	"gpt-5.2":     openaiReasoning,
 	"gpt-5.2-pro": openaiReasoning,
@@ -107,7 +100,6 @@ var registry = map[string]ModelSpec{
 	"gpt-5-mini":  openaiReasoning,
 	"gpt-5-nano":  openaiReasoning,
 
-	// OpenAI: o-series
 	"o3":      openaiReasoning,
 	"o3-pro":  openaiReasoning,
 	"o3-mini": openaiReasoning,
@@ -116,7 +108,6 @@ var registry = map[string]ModelSpec{
 	"o1-pro":  openaiReasoning,
 	"o1-mini": openaiReasoning,
 
-	// OpenAI: GPT-4.x and older
 	"gpt-4.1":      openaiBase,
 	"gpt-4.1-mini": openaiBase,
 	"gpt-4.1-nano": openaiBase,
@@ -125,23 +116,20 @@ var registry = map[string]ModelSpec{
 	"gpt-4-turbo":  openaiBase,
 	"gpt-4":        openaiBase,
 
-	// Google: Gemini 3.x frontier. Preview-only as of 2026-04-30; the
-	// `-preview` suffix is the canonical model ID. gemini-3-pro-preview
-	// is deprecated 2026-03-09 in favor of gemini-3.1-pro-preview.
+	// Gemini 3.x preview models use `-preview` suffix as canonical ID.
+	// gemini-3-pro-preview is deprecated 2026-03-09 in favor of 3.1.
 	"gemini-3-pro-preview":          googleBase,
 	"gemini-3.1-pro-preview":        googleBase,
 	"gemini-3-flash-preview":        googleBase,
 	"gemini-3.1-flash-lite-preview": googleBase,
 	"gemini-3.1-flash-live-preview": googleBase,
 
-	// Google: Gemini 2.x
 	"gemini-2.5-pro":        googleBase,
 	"gemini-2.5-flash":      googleBase,
 	"gemini-2.5-flash-lite": googleBase,
 	"gemini-2.0-flash":      googleBase,
 	"gemini-2.0-flash-lite": googleBase,
 
-	// OpenRouter / OpenAI-compatible OSS pool
 	"qwen/qwen3-235b-a22b-2507":        openAICompatBase,
 	"qwen/qwen3-30b-a3b-instruct-2507": openAICompatBase,
 	"qwen/qwen3-coder-next":            openAICompatBase,

--- a/internal/router/planner/policy.go
+++ b/internal/router/planner/policy.go
@@ -1,30 +1,17 @@
 // Package planner decides, per turn, whether to stay on a session's
 // pinned model (preserving the upstream prompt cache) or switch to the
-// scorer's fresh recommendation. The verdict is a pure function of the
-// pin row, the fresh decision, an estimated input-token count, and the
-// currently-available model set; no I/O happens here.
+// scorer's fresh recommendation. Pure function of (pin, fresh decision,
+// estimated tokens, available models); no I/O.
 //
-// The EV math compares:
+// EV math:
 //
-//	expected savings = (pin $/M-tok × pinMult − fresh $/M-tok × freshMult) × tokens × remaining-turn horizon
-//	eviction cost    = fresh $/M-tok × tokens × (1 − freshMult)
+//	savings_per_turn = (pin $/M-tok × pinMult − fresh $/M-tok × freshMult) × tokens
+//	eviction_cost    = fresh $/M-tok × tokens × (1 − freshMult)
 //
-// where pinMult / freshMult are each model's per-provider cache-read
-// multiplier (Anthropic 0.10, OpenAI 0.50, Gemini 0.25, ...) read via
-// pricing.Pricing.EffectiveCacheReadMultiplier. The planner switches
-// when (expected savings - eviction cost) exceeds a configurable
-// threshold OR when the tier-upgrade guard fires (fresh is in a
-// strictly higher capability tier than pin; see
-// internal/router/capability). The guard exists because a trivial
-// first turn can pin a Low model and the pure EV math will then keep
-// every harder prompt on the cheap pin. The cache-read multiplier on the savings term reflects
-// that once a pin is warm, ~(1 - mult) of input tokens come from cache
-// on both the pinned and (post-eviction) fresh model, so only the
-// cache-read portion of the per-turn delta accrues over the horizon.
-// Per-model multipliers (vs a single global) keep cross-provider
-// switches (e.g. opus → gpt-5) economically correct. The full spec
-// lives in the Prism-style cache-aware routing plan; this file is the
-// executable form.
+// where pinMult/freshMult are per-model cache-read multipliers from
+// pricing.Pricing.EffectiveCacheReadMultiplier. Switches when
+// (expected_savings − eviction_cost) > threshold, or when tier-upgrade
+// guard fires (fresh is strictly higher tier than pin).
 package planner
 
 import (
@@ -38,18 +25,11 @@ import (
 type Outcome int
 
 const (
-	// OutcomeStay keeps the request on the session's pinned model so the
-	// upstream prompt cache stays warm.
-	OutcomeStay Outcome = iota
-	// OutcomeSwitch routes the turn to the fresh scorer recommendation,
-	// accepting the one-time cache eviction cost.
-	OutcomeSwitch
+	OutcomeStay   Outcome = iota // Keep on pinned model.
+	OutcomeSwitch                // Route to fresh scorer recommendation.
 )
 
-// Decision is the planner's output. Reason is a short snake_case label
-// suitable for log/OTel attributes. The three USD fields are populated
-// whenever the EV math ran (zero values are fine when it did not) so
-// the orchestrator can stamp them as span attributes uniformly.
+// Decision is the planner's output. Reason is a short snake_case label.
 type Decision struct {
 	Outcome            Outcome
 	Reason             string
@@ -60,24 +40,18 @@ type Decision struct {
 
 // EVConfig parameterizes the policy. Constructed once at boot from env.
 type EVConfig struct {
-	// ThresholdUSD is the minimum positive EV (over the remaining-turn
-	// horizon) required to switch off the pinned model. Default $0.001
-	// keeps noise from flipping decisions while letting any non-trivial
-	// arbitrage trigger a switch.
+	// ThresholdUSD is the minimum positive EV over the horizon to switch.
+	// Default $0.001 keeps noise from flipping decisions.
 	ThresholdUSD float64
 	// ExpectedRemainingTurns amortizes per-turn savings into a horizon.
-	// Default 3 reflects observed session length distributions; tuned
-	// per deployment via env.
+	// Default 3 reflects observed session lengths.
 	ExpectedRemainingTurns int
-	// TierUpgradeEnabled overturns an EV "stay" when fresh is strictly
-	// higher tier than pin (see internal/router/capability). Upgrade-
-	// only by design — downgrades and sideways moves stay under the EV
-	// verdict, which already routes cheap-fresh to switch.
+	// TierUpgradeEnabled overturns an EV stay when fresh is strictly higher
+	// tier than pin. Upgrade-only by design.
 	TierUpgradeEnabled bool
 }
 
-// Inputs is the full per-turn input to Decide. Kept as a struct (not
-// positional args) because the call site grows over time.
+// Inputs is the full per-turn input to Decide.
 type Inputs struct {
 	Pin                  sessionpin.Pin
 	Fresh                router.Decision
@@ -85,8 +59,6 @@ type Inputs struct {
 	AvailableModels      map[string]struct{}
 }
 
-// Reason constants for Decision.Reason. Kept as exported strings so the
-// orchestrator and tests reference the same labels without retyping.
 const (
 	ReasonNoPin           = "no_pin"
 	ReasonSameModel       = "same_model"
@@ -98,31 +70,25 @@ const (
 	ReasonTierUpgrade     = "tier_upgrade"
 )
 
-// Decide returns the planner verdict for this turn. See package doc for
-// the rule the implementation follows.
+// Decide returns the planner verdict for this turn.
 func Decide(in Inputs, cfg EVConfig) Decision {
-	// No active pin → nothing to preserve, take the fresh recommendation.
 	if in.Pin.Model == "" {
 		return Decision{Outcome: OutcomeSwitch, Reason: ReasonNoPin}
 	}
 
-	// Fresh recommendation already matches the pin: trivial stay.
 	if in.Fresh.Model == in.Pin.Model {
 		return Decision{Outcome: OutcomeStay, Reason: ReasonSameModel}
 	}
 
-	// Pin's model is no longer routable (provider key removed, model
-	// retired): we have to switch regardless of EV. nil AvailableModels
-	// means "no filter configured" — preserve the pin in that case.
+	// Pin's model no longer routable: switch regardless of EV.
+	// nil AvailableModels means "no filter" — preserve pin.
 	if in.AvailableModels != nil {
 		if _, ok := in.AvailableModels[in.Pin.Model]; !ok {
 			return Decision{Outcome: OutcomeSwitch, Reason: ReasonPinModelMissing}
 		}
 	}
 
-	// We have a pin but it has never completed a turn, so we have no
-	// evidence the upstream cache is warm. Stay conservatively rather
-	// than paying an eviction cost against a cold cache.
+	// No completed turn yet: no evidence upstream cache is warm.
 	if in.Pin.LastTurnEndedAt.IsZero() {
 		return Decision{Outcome: OutcomeStay, Reason: ReasonNoPriorUsage}
 	}
@@ -134,14 +100,8 @@ func Decide(in Inputs, cfg EVConfig) Decision {
 	}
 
 	tokens := float64(in.EstimatedInputTokens)
-	// Per-model cache-read multipliers scale the per-turn delta because,
-	// in steady state on either model, ~(1 - multiplier) of input tokens
-	// are served from the prompt cache. Switching only avoids cost on the
-	// cache-read portion of subsequent turns; pricing the savings off full
-	// input price systematically overstates the switch benefit. Reading
-	// the multiplier per-model (vs a single global) is what makes
-	// cross-provider switches (e.g. opus → gpt-5, where Anthropic's 0.10
-	// and OpenAI's 0.50 differ by 5×) economically correct.
+	// Per-model cache-read multipliers scale savings: only the cache-read
+	// portion of per-turn delta accrues over the horizon.
 	pinMult := pinPrice.EffectiveCacheReadMultiplier()
 	freshMult := freshPrice.EffectiveCacheReadMultiplier()
 	savingsPerTurn := (pinPrice.InputUSDPer1M*pinMult - freshPrice.InputUSDPer1M*freshMult) * tokens / 1e6
@@ -158,7 +118,6 @@ func Decide(in Inputs, cfg EVConfig) Decision {
 		d.Outcome = OutcomeSwitch
 		d.Reason = ReasonEVPositive
 	case cfg.TierUpgradeEnabled && tierUpgrade(in.Pin.Model, in.Fresh.Model):
-		// EV said stay; pay the eviction cost for a stronger model.
 		d.Outcome = OutcomeSwitch
 		d.Reason = ReasonTierUpgrade
 	default:
@@ -169,8 +128,7 @@ func Decide(in Inputs, cfg EVConfig) Decision {
 }
 
 // tierUpgrade reports whether fresh is strictly higher tier than pin.
-// Unknown on either side disables the guard so a missing entry never
-// silently forces a switch.
+// Unknown on either side disables the guard.
 func tierUpgrade(pin, fresh string) bool {
 	pinTier := capability.TierFor(pin)
 	freshTier := capability.TierFor(fresh)

--- a/internal/router/pricing/pricing.go
+++ b/internal/router/pricing/pricing.go
@@ -1,6 +1,6 @@
 // Package pricing exposes per-model input/output USD pricing for inner-ring
-// consumers (e.g. the planner's EV math). Pure data + lookup helpers; no I/O.
-// Source of truth for prices the OTel layer also emits as attributes.
+// consumers (planner's EV math, OTel attributes). Pure data + lookup
+// helpers; no I/O.
 package pricing
 
 import "maps"
@@ -10,38 +10,24 @@ type Pricing struct {
 	InputUSDPer1M  float64
 	OutputUSDPer1M float64
 	// CacheReadMultiplier is the per-model cost of a cache hit relative to
-	// the base input price (e.g. 0.10 means cache reads cost 10% of base).
-	// Zero means "unspecified — use DefaultCacheReadMultiplier"; the planner
-	// always reads this via EffectiveCacheReadMultiplier so a zero never
-	// reaches the EV math directly. Published values:
-	//   Anthropic     : 0.10  (docs.anthropic.com/prompt-caching)
-	//   OpenAI        : 0.50  (cached_input_tokens, GPT-4.1 / 4o / 5.x)
-	//   Google Gemini : 0.25  (implicit caching, 2.x / 3.x preview)
-	//   DeepSeek      : 0.10  (cache-hit pricing)
+	// base input price (e.g. 0.10 for Anthropic, 0.50 for OpenAI).
+	// Zero means "unspecified — use DefaultCacheReadMultiplier".
 	CacheReadMultiplier float64
 }
 
-// DefaultCacheReadMultiplier is the fallback multiplier for models whose
-// Pricing.CacheReadMultiplier is zero (no per-model data). 0.5 is the
-// OpenAI rate and a conservative middle of the published range: high
-// enough that the planner doesn't treat unknown providers as having free
-// caching (which would zero out eviction cost and make every switch look
-// free) but low enough to not block switches outright.
+// DefaultCacheReadMultiplier is the fallback multiplier for models without
+// published cache pricing. 0.5 is conservative: high enough to not treat
+// unknown providers as free caching, low enough to not block switches.
 const DefaultCacheReadMultiplier = 0.5
 
 // EffectiveCacheReadMultiplier returns CacheReadMultiplier if set, else
-// DefaultCacheReadMultiplier. Always use this in EV math so a zero
-// multiplier never reaches downstream arithmetic.
+// DefaultCacheReadMultiplier.
 func (p Pricing) EffectiveCacheReadMultiplier() float64 {
 	if p.CacheReadMultiplier > 0 {
 		return p.CacheReadMultiplier
 	}
 	return DefaultCacheReadMultiplier
 }
-
-// TODO: Unify all model configuration that is indexed by model name
-// (this pricing table, model_registry.json, heuristic config, etc.)
-// into a single shared model registry so additions/removals stay in sync.
 
 // All returns a copy of the full pricing table keyed by model name.
 func All() map[string]Pricing {
@@ -50,11 +36,6 @@ func All() map[string]Pricing {
 	return out
 }
 
-// Values from provider pricing pages. Output costs are typically 4-5× input.
-// CacheReadMultiplier reflects published per-provider cached-input pricing
-// (see Pricing.CacheReadMultiplier doc); models without published cache
-// pricing leave it zero so EffectiveCacheReadMultiplier falls back to the
-// package default.
 var table = map[string]Pricing{
 	// Anthropic (cache reads at 10% of base)
 	"claude-opus-4-7":   {InputUSDPer1M: 15.00, OutputUSDPer1M: 75.00, CacheReadMultiplier: 0.10},
@@ -99,15 +80,13 @@ var table = map[string]Pricing{
 	"gemini-2.0-flash":      {InputUSDPer1M: 0.10, OutputUSDPer1M: 0.40, CacheReadMultiplier: 0.25},
 	"gemini-2.0-flash-lite": {InputUSDPer1M: 0.075, OutputUSDPer1M: 0.30, CacheReadMultiplier: 0.25},
 
-	// OpenRouter OSS pool: Qwen3 R2-Router clone candidates
-	// (No published prompt-cache pricing — falls back to DefaultCacheReadMultiplier.)
+	// OpenRouter OSS pool
 	"qwen/qwen3-235b-a22b-2507":        {InputUSDPer1M: 0.071, OutputUSDPer1M: 0.463},
 	"qwen/qwen3-30b-a3b-instruct-2507": {InputUSDPer1M: 0.080, OutputUSDPer1M: 0.330},
 	"qwen/qwen3-coder-next":            {InputUSDPer1M: 0.070, OutputUSDPer1M: 0.300},
 	"qwen/qwen3-next-80b-a3b-instruct": {InputUSDPer1M: 0.090, OutputUSDPer1M: 1.100},
 
-	// OpenRouter OSS pool: v0.25 expansion. DeepSeek has documented cache-hit
-	// pricing at ~10% of base; the rest fall back to the default.
+	// OpenRouter OSS pool: v0.25 expansion
 	"qwen/qwen3.5-flash-02-23":     {InputUSDPer1M: 0.065, OutputUSDPer1M: 0.260},
 	"qwen/qwen3-coder":             {InputUSDPer1M: 0.220, OutputUSDPer1M: 1.800},
 	"deepseek/deepseek-v4-flash":   {InputUSDPer1M: 0.140, OutputUSDPer1M: 0.280, CacheReadMultiplier: 0.10},
@@ -116,10 +95,8 @@ var table = map[string]Pricing{
 	"mistralai/mistral-small-2603": {InputUSDPer1M: 0.150, OutputUSDPer1M: 0.600},
 }
 
-// For returns pricing for the given model and a boolean indicating whether the
-// model was found. If the exact name is not present, it retries after stripping
-// a trailing 8-digit suffix (e.g. "-20251001") so dated model variants resolve
-// to their canonical pricing.
+// For returns pricing for the given model. If the exact name isn't found,
+// retries after stripping an 8-digit date suffix (e.g. "-20251001").
 func For(model string) (Pricing, bool) {
 	if p, ok := table[model]; ok {
 		return p, true
@@ -132,8 +109,7 @@ func For(model string) (Pricing, bool) {
 	return Pricing{}, false
 }
 
-// stripDateSuffix removes a trailing "-XXXXXXXX" (hyphen + exactly 8 digits)
-// from model names. Returns the input unchanged if the pattern doesn't match.
+// stripDateSuffix removes a trailing "-XXXXXXXX" (hyphen + exactly 8 digits).
 func stripDateSuffix(model string) string {
 	if len(model) < 10 {
 		return model

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -7,15 +7,11 @@ type Request struct {
 	RequestedModel       string
 	EstimatedInputTokens int
 	HasTools             bool
-	// PromptText is the concatenated user/system text, used by content-aware routers.
-	PromptText string
-	// EnabledProviders restricts argmax so we never return a decision the
-	// upstream call would 401 on. Nil means no per-request gating.
+	PromptText           string
+	// Per-request provider gating — nil means unrestricted.
 	EnabledProviders map[string]struct{}
-	// ExcludedModels drops the named models from argmax. Per-installation
-	// or env-var-driven; sibling to EnabledProviders but at model granularity.
-	// Nil or empty means no exclusion. If filtering empties the eligible
-	// set, the scorer returns ErrNoEligibleProvider rather than falling back.
+	// Per-request model exclusion — nil or empty means no exclusion.
+	// If filtering empties eligible set, scorer returns ErrNoEligibleProvider.
 	ExcludedModels map[string]struct{}
 }
 
@@ -23,23 +19,16 @@ type Decision struct {
 	Provider string
 	Model    string
 	Reason   string
-	// Metadata is populated by content-aware routers; nil for others.
-	// Downstream consumers must nil-check before dereferencing.
+	// Nil for non-content-aware routers; nil-check before dereferencing.
 	Metadata *RoutingMetadata
 }
 
-// RoutingMetadata lets downstream components reuse the embedding + cluster
-// context without recomputing. Always nil-check before reading.
+// RoutingMetadata lets downstream components reuse the embedding and
+// cluster context without recomputing.
 type RoutingMetadata struct {
-	Embedding []float32
-	// ClusterIDs are sorted ascending for log determinism; ClusterIDs[0]
-	// is NOT necessarily the closest centroid.
-	ClusterIDs []int
-	// CandidateModels is the eligible-model set argmax ran over; captured
-	// so observations record what was on the table, not just what was picked.
-	CandidateModels []string
-	// ChosenScore is the sum of rankings across top-p clusters; used for
-	// margin-of-victory analytics.
+	Embedding            []float32
+	ClusterIDs           []int // Sorted ascending; [0] is NOT necessarily closest.
+	CandidateModels      []string
 	ChosenScore          float32
 	ClusterRouterVersion string
 }

--- a/internal/router/sessionpin/store.go
+++ b/internal/router/sessionpin/store.go
@@ -1,9 +1,6 @@
 // Package sessionpin defines the inner-ring contract for session-sticky
-// routing pins. Pure types + interface; adapters live in
-// internal/postgres so the proxy service can be tested without a DB.
-//
-// Stage 1 ships the schema as role-keyed but always emits role="default";
-// role-conditioned pinning waits on the turn-type detector.
+// routing pins. Pure types + interface; the Postgres adapter lives in
+// internal/postgres.
 package sessionpin
 
 import (
@@ -13,9 +10,8 @@ import (
 	"github.com/google/uuid"
 )
 
-// SessionKeyLen is the sha256-truncated session key length. 16 bytes
-// makes collisions astronomically rare at per-(api-key, session)
-// granularity and mirrors routing_observations.prompt_prefix_hash.
+// SessionKeyLen is the sha256-truncated session key length. 16 bytes makes
+// collisions astronomically rare at per-(api-key, session) granularity.
 const SessionKeyLen = 16
 
 // DefaultRole is the only role emitted in Stage 1; column exists so the
@@ -25,13 +21,10 @@ const DefaultRole = "default"
 // Pin is one row in the session-pin table. Mirrors a routing decision
 // so a hit can rehydrate router.Decision without re-running the scorer.
 //
-// The Last*Tokens / LastTurnEndedAt fields record the previous turn's
-// upstream token usage; the Prism-style planner reads them to compute
-// the expected-value math for switching providers vs. retaining the
-// existing prompt cache. They are written by Store.UpdateUsage after a
-// turn completes and are deliberately left untouched by Upsert so the
-// at-start-of-turn refresh cannot clobber them with zeros.
-// LastTurnEndedAt's zero value means "no turn has completed yet".
+// Last*Tokens / LastTurnEndedAt record the previous turn's upstream usage
+// and are written by Store.UpdateUsage after a turn completes. They are
+// deliberately left untouched by Upsert so an at-start-of-turn refresh
+// cannot clobber them with zeros.
 type Pin struct {
 	SessionKey            [SessionKeyLen]byte
 	Role                  string
@@ -50,9 +43,7 @@ type Pin struct {
 	LastTurnEndedAt       time.Time
 }
 
-// Usage captures the previous turn's upstream token accounting. It is
-// the input to Store.UpdateUsage; the planner reads it back through
-// Store.Get on the next turn to weigh switch EV against eviction cost.
+// Usage captures the previous turn's upstream token accounting.
 type Usage struct {
 	InputTokens       int
 	CachedReadTokens  int
@@ -61,10 +52,9 @@ type Usage struct {
 	EndedAt           time.Time
 }
 
-// Store is the I/O surface for session pins. Get returns (zero, false,
-// nil) when no row exists (no error). UpdateUsage is a no-op (returns
-// nil) when the pin has been evicted or never existed; callers fire it
-// off the request path so a missing row must not surface as an error.
+// Store is the I/O surface for session pins. Get returns (zero, false, nil)
+// when no row exists. UpdateUsage is a no-op when the pin has been evicted
+// or never existed.
 type Store interface {
 	Get(ctx context.Context, sessionKey [SessionKeyLen]byte, role string) (Pin, bool, error)
 	Upsert(ctx context.Context, p Pin) error

--- a/internal/router/turntype/detect.go
+++ b/internal/router/turntype/detect.go
@@ -13,64 +13,34 @@ import (
 type TurnType string
 
 const (
-	MainLoop TurnType = "main_loop"
-	// ToolResult: last user-side input is all tool_result blocks with no
-	// text. Embedding is mostly noise on these turns; short-circuits to
-	// the session pin when one exists.
-	ToolResult TurnType = "tool_result"
-	// SubAgentDispatch: request originates from a read-only sub-agent
-	// (e.g. Claude Code's Explore agent). Routed to Haiku when
-	// ROUTER_HARD_PIN_EXPLORE is enabled.
+	MainLoop         TurnType = "main_loop"
+	ToolResult       TurnType = "tool_result"
 	SubAgentDispatch TurnType = "sub_agent_dispatch"
-	// Compaction: Claude Code context-compaction turn. Always routed to
-	// Haiku (short-out-of-long-in cost profile).
+	// Compaction: Claude Code context-compaction turn. Always Haiku.
 	Compaction TurnType = "compaction"
-	// Probe: a quota / liveness check the caller issued before any real
-	// conversation (Anthropic SDK + Claude Code do this on init with
-	// max_tokens=1). Always hard-pinned to the cheap model AND skips
-	// session-pin creation so a probe never anchors subsequent routing.
+	// Probe: quota/liveness check (max_tokens=1..4). Hard-pinned to cheap
+	// model AND skips session-pin creation.
 	Probe TurnType = "probe"
-	// TitleGen: Claude Code's sidebar-title generation call. Fires once
-	// per user turn alongside the real conversation request, carries no
-	// tools and a JSON-schema response format, and always asks for the
-	// same fixed-shape output ({"title": "..."}). Hard-pinned to the
-	// cheap model AND skips session-pin creation: routing the real
-	// conversation through the cluster scorer is the whole point of the
-	// router, but the title-gen call has no signal worth scoring and a
-	// pin written here would anchor the real-conv turn that lands ~25ms
-	// later (same session key) before its own scorer even runs.
+	// TitleGen: Claude Code sidebar-title generation. Hard-pinned AND
+	// skips session-pin creation.
 	TitleGen TurnType = "title_gen"
-	// Classifier: a short-form classification call — no tools, small
-	// max_tokens, short message list. Anthropic's Claude Code security
-	// monitor (allow/block-with-reason on the agent's latest action) is
-	// the canonical case, but the pattern is general: any caller asking
-	// the model to emit a tiny verdict from a fixed-shape context. Same
-	// routing treatment as Probe and TitleGen — hard-pinned to the cheap
-	// model and skips session-pin creation so the real-conv pin doesn't
-	// inherit a classifier's decision.
+	// Classifier: short-form classification call (security monitor, etc.).
+	// Hard-pinned AND skips session-pin creation.
 	Classifier TurnType = "classifier"
 )
 
-// probeMaxTokensThreshold is the inclusive upper bound on max_tokens for
-// classifying a request as a probe. The Anthropic SDK quota check uses
-// max_tokens=1; allow up to 4 to absorb minor variations across SDK
-// versions without false-positiving real "give me a short answer" calls
-// (which start around 64+).
 const probeMaxTokensThreshold = 4
 
-// classifier{Max,Msg}Threshold bound the Classifier turn type to short-form
-// classification calls. Claude Code's security monitor uses max_tokens=64
-// and message_count=2 (system + a single transcript-bundled user turn);
-// the bounds give headroom for similar yes/no/verdict classifiers without
-// catching real "short reply" main-loop turns (which start at ~512 output
-// tokens and carry the full 128-tool Claude Code registry).
+// classifier thresholds bound the Classifier type to short-form calls.
+// Claude Code's security monitor uses max_tokens=64, message_count=2;
+// headroom for similar classifiers without catching real main-loop turns.
 const (
 	classifierMaxTokensThreshold = 256
 	classifierMaxMessageCount    = 3
 )
 
 // DetectFromEnvelope classifies an inbound request. subAgentHint is the
-// optional x-weave-subagent-type header value; empty is ignored.
+// optional x-weave-subagent-type header value.
 //
 // Conservative: false negatives (returning MainLoop) are safe — the
 // cluster scorer runs normally. False positives are the real risk; each
@@ -79,10 +49,7 @@ func DetectFromEnvelope(env *translate.RequestEnvelope, feats translate.RoutingF
 	if env == nil {
 		return MainLoop
 	}
-	// Probe is checked first: it's the most specific signal (a numeric
-	// cap on the caller's request, not a heuristic over text) and the
-	// consequence is biggest — a probe that anchors a session pin
-	// poisons every subsequent turn in that session.
+	// Probe first: most specific signal with biggest consequence.
 	if isProbe(feats) {
 		return Probe
 	}
@@ -105,33 +72,18 @@ func DetectFromEnvelope(env *translate.RequestEnvelope, feats translate.RoutingF
 	return MainLoop
 }
 
-// isProbe reports whether a request is a liveness/quota check that should
-// be hard-pinned and excluded from session-pin creation. The Anthropic
-// SDK's `client.messages.create(..., max_tokens=1)` quota probe is the
-// canonical case; OpenAI's `max_completion_tokens` and Gemini's
-// `generationConfig.maxOutputTokens` produce the same RoutingFeatures.
 func isProbe(feats translate.RoutingFeatures) bool {
 	return feats.MaxTokens > 0 && feats.MaxTokens <= probeMaxTokensThreshold
 }
 
-// isClassifier reports whether a request is a short-form classifier call
-// (Anthropic's security monitor, or any similar caller asking for a tiny
-// verdict from a fixed-shape context). Three structural signals, all
-// required:
+// isClassifier reports whether a request is a short-form classifier call.
+// Three structural signals, all required:
+//  1. No tools — real Claude Code turns always carry the tool registry.
+//  2. max_tokens within classifierMaxTokensThreshold.
+//  3. message_count within classifierMaxMessageCount.
 //
-//  1. No tools — a real Claude Code main-loop turn always carries the
-//     full 128-tool registry, even when the user asks for a short reply.
-//  2. max_tokens within classifierMaxTokensThreshold — classifier outputs
-//     are tiny (security monitor uses 64; title-gen and friends similar).
-//  3. message_count within classifierMaxMessageCount — classifiers are
-//     stateless and bundle their context into a single user turn; real
-//     conversations grow the message list past 3 quickly.
-//
-// Probe (max_tokens<=4) is checked first and wins; TitleGen and Compaction
-// have more specific fingerprints and also win when they match. This is a
-// general fallback for the broader classifier shape. False negatives
-// (returning MainLoop) are safe; false positives would route a real
-// conversation to the cheap hard-pin, hence the tight conjunction.
+// Probe (max_tokens<=4) is checked first and wins. False negatives are
+// safe; false positives would hard-pin a real conversation — hence tight.
 func isClassifier(feats translate.RoutingFeatures) bool {
 	if feats.HasTools {
 		return false
@@ -146,22 +98,11 @@ func isClassifier(feats translate.RoutingFeatures) bool {
 }
 
 // isTitleGen reports whether a request is Claude Code's sidebar-title
-// generation call. Detection uses two structural signals (per the
-// project's classifier-must-not-string-match-content rule), both
-// required:
-//
-//  1. The request declares a JSON-schema response format whose top-level
-//     schema has a string "title" property — i.e. it is asking the model
-//     to emit `{"title": "..."}` and nothing else. This is the structural
-//     fingerprint of Claude Code's title generator; a general-purpose
-//     structured-output call with a different schema does not match.
-//  2. tools is empty. A real conversation that wants a title-shaped
-//     structured output still carries the full Claude Code tool
-//     registry, so this guard prevents hard-pinning conversations.
-//
-// Per this file's invariant, false negatives (returning MainLoop) are
-// safe — the cluster scorer runs normally; only false positives are
-// dangerous.
+// generation call. Two structural signals:
+//  1. Declares a JSON-schema response format with top-level "title" string
+//     property — asking the model to emit {"title": "..."}.
+//  2. tools is empty — a real conversation with structured output still
+//     carries the tool registry.
 func isTitleGen(env *translate.RequestEnvelope, hasTools bool) bool {
 	if hasTools {
 		return false
@@ -178,28 +119,18 @@ func isCompaction(systemText string) bool {
 }
 
 // isSubAgentDispatch reports whether the request originates from a
-// sub-agent dispatch. Three independent signals:
+// sub-agent. Three independent signals:
+//  1. x-weave-subagent-type header.
+//  2. metadata.user_id starting with "subagent:".
+//  3. First user message wrapped in "<transcript>...</transcript>"
+//     (Claude Code's Agent tool convention).
 //
-//  1. x-weave-subagent-type header — set by non-Anthropic clients or
-//     middleware that knows it dispatched a sub-agent.
-//  2. metadata.user_id starting with "subagent:" — older Anthropic SDK
-//     convention.
-//  3. First user message wrapped in Claude Code's "<transcript>...</transcript>"
-//     envelope — what Claude Code's Agent tool actually emits today for
-//     dispatches like Explore. metadata.user_id is unset in this case
-//     (Claude Code reuses the parent session_id), so without this signal
-//     real Explore agents would never classify as SubAgentDispatch.
+// "<transcript>" lives in the user-message body, not the system prompt —
+// earlier attempt matching "subagent_type" in system text false-positived
+// on every main-loop turn exposing the Agent tool description.
 //
-// "<transcript>" lives in the user-message body, not the system prompt.
-// That's deliberate: an earlier attempt matched "subagent_type" in the
-// system text and false-positived on every main-loop turn that exposed
-// the Agent tool description (since the tool description contains that
-// parameter name verbatim). The "<transcript>" envelope is specific to
-// dispatched sub-agent prompts and does not appear in main-loop traffic.
-//
-// Per this file's invariant, false negatives (returning MainLoop) are
-// safe — the cluster scorer runs normally; only false positives are
-// dangerous.
+// Sniff bounded prefix so a stray "<transcript>" deep in content can't
+// trigger on long main-loop turns.
 func isSubAgentDispatch(metadataUserID, firstUserText, subAgentHint string) bool {
 	if subAgentHint != "" {
 		return true
@@ -207,13 +138,6 @@ func isSubAgentDispatch(metadataUserID, firstUserText, subAgentHint string) bool
 	if strings.HasPrefix(metadataUserID, "subagent:") {
 		return true
 	}
-	// Claude Code's Agent tool wraps the dispatched prompt as:
-	//   <transcript>
-	//   User: <body>
-	//   </transcript>
-	// Look at a bounded prefix so a stray "<transcript>" string embedded
-	// deep in user content can't trigger SubAgentDispatch on a long
-	// main-loop turn.
 	const sniffLen = 64
 	prefix := firstUserText
 	if len(prefix) > sniffLen {

--- a/internal/translate/billing_header.go
+++ b/internal/translate/billing_header.go
@@ -2,23 +2,10 @@ package translate
 
 import "regexp"
 
-// anthropicBillingHeaderPrefix matches the "x-anthropic-billing-header: <line>"
-// prelude Claude Code injects into the leading system text block. Carries a
-// per-request `cch=<hex>` nonce plus a per-session `cc_version` suffix;
-// forwarding it to non-Anthropic upstreams (OpenRouter / DeepSeek / Gemini
-// OpenAI-compat) busts their automatic prompt-prefix cache because bytes
-// 14–118 of the body change every single turn. Anthropic strips this
-// server-side before computing the cache key; foreign upstreams cannot.
-//
-// Trailing newline is optional: Claude Code emits the header as a STANDALONE
-// system text block with no terminator, then the rest of the system prompt
-// follows in a SEPARATE text block. The flatten step joins them with "\n",
-// which is where the newline observed downstream comes from.
+// anthropicBillingHeaderPrefix matches the Claude Code billing-header line that
+// breaks prompt-prefix caching on non-Anthropic upstreams.
 var anthropicBillingHeaderPrefix = regexp.MustCompile(`\Ax-anthropic-billing-header:[^\n]*\n?`)
 
-// stripAnthropicBillingHeader removes the leading Claude Code billing-header
-// line from a system text block, if present. Idempotent. Returns the input
-// unchanged when no header is found.
 func stripAnthropicBillingHeader(s string) string {
 	return anthropicBillingHeaderPrefix.ReplaceAllString(s, "")
 }

--- a/internal/translate/emit_anthropic.go
+++ b/internal/translate/emit_anthropic.go
@@ -12,7 +12,7 @@ import (
 	"github.com/tidwall/gjson"
 )
 
-// PrepareAnthropic builds a fully-prepared Anthropic Messages request.
+// PrepareAnthropic builds an Anthropic Messages request body.
 func (e *RequestEnvelope) PrepareAnthropic(in http.Header, opts EmitOptions) (providers.PreparedRequest, error) {
 	var body []byte
 	var err error
@@ -282,8 +282,7 @@ func appendToolResult(anthropic *[]any, msg map[string]any) {
 	})
 }
 
-// toolResultContent flattens OpenAI tool message content (string or array-of-parts)
-// to a single string, since OpenAI tool messages only accept strings.
+// toolResultContent flattens OpenAI tool message content to a single string.
 func toolResultContent(raw any) string {
 	switch c := raw.(type) {
 	case string:
@@ -307,8 +306,8 @@ func toolResultContent(raw any) string {
 	}
 }
 
-// openAIToolContentToAnthropic converts OpenAI tool message content into
-// Anthropic-compatible tool_result content (text + image blocks).
+// openAIToolContentToAnthropic converts OpenAI tool message content to
+// Anthropic-compatible tool_result content.
 func openAIToolContentToAnthropic(raw any) any {
 	switch c := raw.(type) {
 	case string:

--- a/internal/translate/emit_gemini.go
+++ b/internal/translate/emit_gemini.go
@@ -13,13 +13,11 @@ import (
 	"github.com/tidwall/sjson"
 )
 
-// PrepareGemini builds a fully-prepared request body for Gemini's native REST
-// surface. Required for multi-turn tool use against Gemini 3.x preview models,
-// which need the opaque thought_signature round-tripped — Gemini's
-// OpenAI-compat surface does not return that field.
+// PrepareGemini builds a Gemini native REST request body. The native surface is
+// required for multi-turn tool use against Gemini 3.x preview models because
+// OpenAI-compat does not return the opaque thought_signature field.
 func (e *RequestEnvelope) PrepareGemini(_ http.Header, opts EmitOptions) (providers.PreparedRequest, error) {
-	// Strip the synthetic top-level "model" and "stream" fields injected by the
-	// Gemini handler; neither belongs in the upstream generateContent body.
+	// Strip synthetic top-level "model" and "stream" — belonging to routing, not Gemini.
 	if e.format == FormatGemini {
 		body := e.body
 		var err error
@@ -198,8 +196,7 @@ func openAITextContent(content any) string {
 }
 
 // openAIUserToGeminiParts converts OpenAI user content into Gemini Parts.
-// data: URLs become inlineData; http(s) URLs are unsupported on the native
-// surface and dropped.
+// http(s) image URLs are unsupported on the native surface and dropped.
 func openAIUserToGeminiParts(content any) []any {
 	switch c := content.(type) {
 	case string:
@@ -232,8 +229,7 @@ func openAIUserToGeminiParts(content any) []any {
 	return nil
 }
 
-// dataURLToInlinePart parses "data:<mime>;base64,<payload>" into a Gemini
-// inlineData part.
+// dataURLToInlinePart parses data: URLs into Gemini inlineData parts.
 func dataURLToInlinePart(url string) map[string]any {
 	if !strings.HasPrefix(url, "data:") {
 		return nil
@@ -246,8 +242,7 @@ func dataURLToInlinePart(url string) map[string]any {
 	if mime == "" {
 		mime = "image/jpeg"
 	}
-	// Validate base64 so upstream rejects don't surface as opaque 400s;
-	// Gemini wants the raw base64 string, not bytes.
+	// Validate base64 so upstream rejects surface as client-visible errors.
 	if _, err := base64.StdEncoding.DecodeString(payload); err != nil {
 		return nil
 	}
@@ -257,9 +252,7 @@ func dataURLToInlinePart(url string) map[string]any {
 }
 
 // openAIAssistantToGeminiParts converts an OpenAI assistant message to Gemini
-// model-role Parts. thought_signature smuggled on tool_calls is preserved as
-// thoughtSignature — the load-bearing round-trip for Gemini 3.x multi-turn
-// tool use.
+// model-role Parts. thought_signature is preserved for Gemini 3.x multi-turn tool use.
 func openAIAssistantToGeminiParts(msg map[string]any) ([]any, error) {
 	var parts []any
 	if s := openAITextContent(msg["content"]); s != "" {
@@ -285,8 +278,6 @@ func openAIAssistantToGeminiParts(msg map[string]any) ([]any, error) {
 		}
 		// thought_signature may live on the tool_call, the function object,
 		// or smuggled into tc.id; round-trip whichever shape we receive.
-		// OpenAI Chat Completions clients pass tool_call.id verbatim, so the
-		// id channel survives typed-SDK field stripping.
 		if sig, _ := tc["thought_signature"].(string); sig != "" {
 			part["thoughtSignature"] = sig
 		} else if sig, _ := fn["thought_signature"].(string); sig != "" {
@@ -419,9 +410,8 @@ func stopToArray(r gjson.Result) []any {
 	return nil
 }
 
-// mapReasoningEffortToThinkingConfig mirrors Google's published table for the
-// OpenAI-compat surface. "none" passes through with thinkingBudget=0; Gemini
-// 3.x rejects it but we surface the upstream error rather than mask it.
+// mapReasoningEffortToThinkingConfig maps OpenAI reasoning_effort values to
+// Gemini thinkingConfig. "none" sets thinkingBudget=0.
 func mapReasoningEffortToThinkingConfig(effort string) (map[string]any, bool) {
 	switch effort {
 	case "none":
@@ -469,9 +459,8 @@ func pullAnthropicSystemToGemini(src map[string]any, out map[string]any) {
 	}
 }
 
-// pullAnthropicContentsToGemini converts Anthropic messages into Gemini
-// contents. Tracks tool_use_id → function name so a later tool_result block
-// can recover the name Gemini requires.
+// pullAnthropicContentsToGemini converts Anthropic messages into Gemini contents.
+// Tracks tool_use_id to function name for tool_result recovery.
 func pullAnthropicContentsToGemini(src map[string]any, out map[string]any) error {
 	msgs, _ := src["messages"].([]any)
 	if len(msgs) == 0 {
@@ -614,10 +603,6 @@ func anthropicAssistantToGeminiParts(content any) ([]any, error) {
 			case "text":
 				if text, _ := block["text"].(string); text != "" {
 					part := map[string]any{"text": text}
-					// Gemini 3.x attaches thoughtSignature to the leading
-					// text/thinking part, not the subsequent functionCalls;
-					// dropping it here causes the next turn to 400 on
-					// missing signature for the functionCall parts.
 					if sig, _ := block["thought_signature"].(string); sig != "" {
 						part["thoughtSignature"] = sig
 					}
@@ -632,9 +617,8 @@ func anthropicAssistantToGeminiParts(content any) ([]any, error) {
 				part := map[string]any{
 					"functionCall": map[string]any{"name": name, "args": input},
 				}
-				// Prefer an explicit thought_signature field, but fall back to
-				// one smuggled into block.id — Claude Code and other typed
-				// Anthropic SDKs drop the off-spec field on the way back.
+				// typed Anthropic SDKs drop off-spec fields on tool_use, so fall
+				// back to a signature smuggled inside block.id.
 				sig, _ := block["thought_signature"].(string)
 				if sig == "" {
 					if id, _ := block["id"].(string); id != "" {
@@ -683,11 +667,8 @@ func pullAnthropicToolsToGemini(src map[string]any, out map[string]any) error {
 	return nil
 }
 
-// geminiUnsupportedSchemaKeys lists JSON Schema keywords that Google's
-// function-calling API rejects with 400 "Cannot find field". Claude Code tool
-// definitions routinely include these, so they must be stripped before
-// sending upstream. Keep the list conservative — fields like description /
-// nullable / enum / format are valid and must pass through.
+// geminiUnsupportedSchemaKeys lists JSON Schema keywords Google's function-calling
+// API rejects with 400. Claude Code tool definitions routinely include these.
 var geminiUnsupportedSchemaKeys = map[string]struct{}{
 	"$schema":               {},
 	"$id":                   {},
@@ -720,10 +701,8 @@ var geminiUnsupportedSchemaKeys = map[string]struct{}{
 	"multipleOf":            {},
 }
 
-// sanitizeSchemaForGemini returns a deep copy of v with JSON Schema fields
-// Google's function-calling surface rejects removed. Always returns a copy so
-// the caller can mutate without touching the original input_schema (other
-// emitters DO accept full JSON Schema).
+// sanitizeSchemaForGemini returns a deep copy of v with fields Google's
+// function-calling surface rejects removed.
 func sanitizeSchemaForGemini(v any) any {
 	switch node := v.(type) {
 	case map[string]any:
@@ -732,11 +711,8 @@ func sanitizeSchemaForGemini(v any) any {
 			if _, drop := geminiUnsupportedSchemaKeys[k]; drop {
 				continue
 			}
-			// Drop vendor extensions ("x-*", e.g. x-google-enum-descriptions from
-			// Google-API-derived MCP tool schemas) and JSON Schema metadata
-			// ("$*", e.g. $schema/$id/$ref). Gemini's proto-based validator
-			// rejects any unknown field name with 400, so we strip by prefix
-			// rather than maintaining a moving allowlist.
+			// Drop vendor extensions and JSON Schema metadata; Gemini's
+			// proto-based validator rejects unknown field names.
 			if strings.HasPrefix(k, "x-") || strings.HasPrefix(k, "$") {
 				continue
 			}
@@ -750,16 +726,9 @@ func sanitizeSchemaForGemini(v any) any {
 			}
 			out[k] = sanitizeSchemaForGemini(child)
 		}
-		// JSON Schema allows "type" to be an array (e.g. ["array", "null"]),
-		// but Gemini's proto Schema expects a single Type enum value and a
-		// separate "nullable" boolean. Collapse array types: pick the first
-		// non-"null" entry as the type and set nullable=true when "null"
-		// appears alongside.
+		// JSON Schema allows "type": ["array", "null"]; Gemini wants single Type + nullable bool.
 		out = collapseTypeArray(out)
-		// Anthropic permits `{"type":"array"}` with no `items`; Gemini's strict
-		// function-calling validator rejects it ("missing field"). Inject a
-		// permissive default so the tool definition survives translation. Real
-		// items schemas from the source were preserved by the loop above.
+		// Gemini rejects {"type":"array"} with no "items" — inject a default.
 		if t, ok := out["type"].(string); ok && t == "array" {
 			if existing, has := out["items"]; !has || existing == nil {
 				out["items"] = map[string]any{"type": "string"}
@@ -777,9 +746,8 @@ func sanitizeSchemaForGemini(v any) any {
 	}
 }
 
-// collapseTypeArray collapses JSON Schema array-typed "type" (e.g. ["array", "null"])
-// into Gemini's single-Type-plus-nullable convention. Returns the map unchanged
-// when "type" is already a string or absent.
+// collapseTypeArray collapses JSON Schema ["array", "null"] into Gemini's
+// single Type + nullable convention. Drops "type" entirely if only "null".
 func collapseTypeArray(out map[string]any) map[string]any {
 	types, ok := out["type"].([]any)
 	if !ok {
@@ -799,7 +767,6 @@ func collapseTypeArray(out map[string]any) map[string]any {
 		}
 	}
 	if primary == "" {
-		// Only "null" or empty — invalid, remove the type field.
 		delete(out, "type")
 		return out
 	}
@@ -810,10 +777,8 @@ func collapseTypeArray(out map[string]any) map[string]any {
 	return out
 }
 
-// filterStringEnum returns enum entries that are non-empty strings. Google's
-// function-calling surface requires TYPE_STRING enums and rejects empty-string
-// entries ("enum[i]: cannot be empty"); both filter out here. Returns an empty
-// slice when nothing survives so the caller can drop the field entirely.
+// filterStringEnum returns non-empty string entries from an enum array.
+// Google's function-calling surface rejects empty-string entries.
 func filterStringEnum(v any) []any {
 	arr, ok := v.([]any)
 	if !ok {

--- a/internal/translate/emit_openai.go
+++ b/internal/translate/emit_openai.go
@@ -13,7 +13,7 @@ import (
 	"github.com/tidwall/sjson"
 )
 
-// PrepareOpenAI builds a fully-prepared OpenAI Chat Completions request.
+// PrepareOpenAI builds an OpenAI Chat Completions request body.
 func (e *RequestEnvelope) PrepareOpenAI(in http.Header, opts EmitOptions) (providers.PreparedRequest, error) {
 	var body []byte
 	var err error

--- a/internal/translate/envelope.go
+++ b/internal/translate/envelope.go
@@ -203,16 +203,16 @@ func (e *RequestEnvelope) RequestsTitleSchema() bool {
 // EmitOverrides describes byte-level mutations for same-format serialization.
 // Zero-valued fields are no-ops.
 type EmitOverrides struct {
-	Model         string
-	DeleteKeys    []string
-	SetMaxCompletionTokens *int64
+	Model                   string
+	DeleteKeys              []string
+	SetMaxCompletionTokens  *int64
 	ClampMaxTokensKey       string
 	ClampMaxTokensValue     int64
 	ClampMaxCompTokensValue int64
-	DefaultMaxTokensKey   string
-	DefaultMaxTokensValue int64
-	InjectStreamUsage   bool
-	StripThinkingBlocks bool
+	DefaultMaxTokensKey     string
+	DefaultMaxTokensValue   int64
+	InjectStreamUsage       bool
+	StripThinkingBlocks     bool
 }
 
 func (e *RequestEnvelope) emitSameFormat(ov EmitOverrides) ([]byte, error) {

--- a/internal/translate/envelope.go
+++ b/internal/translate/envelope.go
@@ -14,14 +14,9 @@ import (
 )
 
 // INVARIANTS:
-//   - e.body is immutable — set once at parse, never modified. Callers must
-//     not mutate it; the slice is shared across all same-format emit calls.
-//   - Same-format emit uses byte-level gjson/sjson overrides on e.body — no
-//     cloning or json.Marshal.
-//   - Cross-format emit pulls fields from e.ensureSrc() into a new map; the
-//     Unmarshal is deferred until the first cross-format call.
-//   - Field accessors and RoutingFeatures use gjson directly on e.body —
-//     zero allocations, no Unmarshal required.
+//   - e.body is immutable after parse. Same-format emit uses gjson/sjson overrides
+//     on e.body with no cloning. Cross-format emit unmarshals into e.src once.
+//   - Field accessors use gjson directly on e.body.
 
 // ErrNotJSONObject is returned when the request body is not a valid JSON object.
 var ErrNotJSONObject = errors.New("request body must be a JSON object")
@@ -42,10 +37,9 @@ type EmitOptions struct {
 }
 
 // RequestEnvelope wraps a parsed request body regardless of wire format.
-// Use Prepare* to emit target-format bytes; accessors and RoutingFeatures
-// read fields.
+// Use Prepare* to emit target-format bytes; accessors read fields.
 type RequestEnvelope struct {
-	body   []byte         // immutable raw request bytes
+	body   []byte
 	src    map[string]any // lazily populated for cross-format emit
 	format Format
 }
@@ -86,9 +80,7 @@ func validateJSONObject(body []byte) error {
 	return nil
 }
 
-// ensureSrc lazily unmarshals e.body into e.src on first call. Returns an
-// error when encoding/json rejects input that gjson accepted (e.g. nesting
-// beyond encoding/json's 500-level limit).
+// ensureSrc lazily unmarshals e.body into e.src on first call.
 func (e *RequestEnvelope) ensureSrc() (map[string]any, error) {
 	if e.src == nil {
 		if err := json.Unmarshal(e.body, &e.src); err != nil {
@@ -100,11 +92,8 @@ func (e *RequestEnvelope) ensureSrc() (map[string]any, error) {
 
 func (e *RequestEnvelope) SourceFormat() Format { return e.format }
 
-// Stream reports whether the request has "stream": true. Accepts JSON booleans
-// and string values but rejects numeric coercion. For Gemini ingress the
-// streaming choice lives in the URL path (:generateContent vs
-// :streamGenerateContent); the Gemini handler injects a synthetic top-level
-// "stream": true into the body before parsing.
+// Stream reports whether the request has "stream": true. Rejects numeric coercion.
+// For Gemini ingress, the handler injects a synthetic "stream": true.
 func (e *RequestEnvelope) Stream() bool {
 	r := gjson.GetBytes(e.body, "stream")
 	if r.Type == gjson.Number {
@@ -118,14 +107,12 @@ func (e *RequestEnvelope) Model() string {
 	return gjson.GetBytes(e.body, "model").String()
 }
 
-// MetadataUserID returns the raw metadata.user_id string. Claude Code packs a
-// JSON-encoded object here containing device_id, account_uuid, and session_id.
+// MetadataUserID returns the raw metadata.user_id string.
 func (e *RequestEnvelope) MetadataUserID() string {
 	return gjson.GetBytes(e.body, "metadata.user_id").String()
 }
 
 // SystemText returns the concatenated system-prompt text format-neutrally.
-// OpenAI may carry multiple system-role messages; all are concatenated.
 func (e *RequestEnvelope) SystemText() string {
 	switch e.format {
 	case FormatAnthropic:
@@ -139,8 +126,7 @@ func (e *RequestEnvelope) SystemText() string {
 	}
 }
 
-// LastUserMessageInfo summarizes the trailing user-side input. Both flags can
-// be true at once (mixed turn).
+// LastUserMessageInfo summarizes the trailing user-side input.
 type LastUserMessageInfo struct {
 	HasText         bool
 	HasToolResult   bool
@@ -148,8 +134,7 @@ type LastUserMessageInfo struct {
 	Text            string
 }
 
-// LastUserMessage returns format-neutral information about the last user-side
-// input. Used by turn-type detection.
+// LastUserMessage returns format-neutral information about the last user input.
 func (e *RequestEnvelope) LastUserMessage() LastUserMessageInfo {
 	switch e.format {
 	case FormatAnthropic:
@@ -193,24 +178,9 @@ func (e *RequestEnvelope) HasTools() bool {
 	return r.Int() > 0
 }
 
-// RequestsTitleSchema reports whether the request asks the model to
-// emit a JSON-schema-shaped response with a top-level string "title"
-// property. Structural signal used by turn-type classification to
-// identify Claude Code's sidebar-title generation call without content
-// matching on the system prompt.
-//
-// Anthropic: output_config.format.{type:"json_schema", schema:{...}}
-// OpenAI:    response_format.{type:"json_schema",
-//
-//	json_schema:{schema:{...}}}
-//
-// Gemini:    no structured-title equivalent today — returns false.
-//
-// Detection requires both (a) the JSON-schema format declaration and
-// (b) a schema declaring `properties.title.type == "string"`. The
-// combined shape is specific to a fixed-output title generator; a
-// general-purpose structured-output call with a different schema does
-// not match.
+// RequestsTitleSchema reports whether the request asks for a JSON-schema response
+// with a top-level string "title" property. Used to identify Claude Code's
+// sidebar-title generation call without content-matching the system prompt.
 func (e *RequestEnvelope) RequestsTitleSchema() bool {
 	switch e.format {
 	case FormatAnthropic:
@@ -233,22 +203,14 @@ func (e *RequestEnvelope) RequestsTitleSchema() bool {
 // EmitOverrides describes byte-level mutations for same-format serialization.
 // Zero-valued fields are no-ops.
 type EmitOverrides struct {
-	Model string
-
-	DeleteKeys []string
-
+	Model         string
+	DeleteKeys    []string
 	SetMaxCompletionTokens *int64
-
 	ClampMaxTokensKey       string
 	ClampMaxTokensValue     int64
 	ClampMaxCompTokensValue int64
-
-	// DefaultMaxTokensKey / DefaultMaxTokensValue inject the named field only
-	// when absent. Anthropic Messages requires max_tokens; downstream
-	// routing/cost accounting also benefits from a deterministic value.
 	DefaultMaxTokensKey   string
 	DefaultMaxTokensValue int64
-
 	InjectStreamUsage   bool
 	StripThinkingBlocks bool
 }
@@ -333,9 +295,7 @@ func clampFieldBytes(body []byte, key string, maxVal int64) []byte {
 }
 
 // stripThinkingBlocksBytes removes thinking/redacted_thinking blocks from
-// messages[*].content[*]. Uses two-phase reconstruction to guarantee O(B)
-// total work — a per-block sjson.DeleteBytes approach would be O(N*B) and
-// a DoS vector when N is large (~300K blocks in 10 MB).
+// messages[*].content[*]. Uses two-phase reconstruction for O(B) work.
 func stripThinkingBlocksBytes(body []byte) ([]byte, error) {
 	messages := gjson.GetBytes(body, "messages")
 	if !messages.Exists() || !messages.IsArray() {
@@ -400,10 +360,8 @@ func stripThinkingBlocksBytes(body []byte) ([]byte, error) {
 	return sjson.SetRawBytes(body, "messages", []byte(newMessagesArray))
 }
 
-// encodeJSONStringNoHTMLEscape returns the JSON encoding of s without
-// HTML-escaping `<`, `>`, or `&`. Preserves whatever escaping the client
-// originally chose so that re-emitted message text matches the input byte
-// pattern as closely as possible (relevant for upstream prompt-cache keys).
+// encodeJSONStringNoHTMLEscape marshals s without HTML-escaping <, >, or &.
+// Preserves the client's original escaping for upstream prompt-cache keys.
 func encodeJSONStringNoHTMLEscape(s string) ([]byte, error) {
 	var buf strings.Builder
 	enc := json.NewEncoder(&buf)
@@ -416,20 +374,13 @@ func encodeJSONStringNoHTMLEscape(s string) ([]byte, error) {
 	return []byte(strings.TrimSuffix(out, "\n")), nil
 }
 
-// routingMarkerPattern matches the upfront "✦ **Weave Router** → ..." snippet
-// that AnthropicSSETranslator emits as a standalone text block on cross-format
-// responses. Single-line, terminated by the literal "\n\n" appended in
-// routingMarkerFor; the body between prefix and terminator is opaque (varies
-// with model, provider, planner reason, and clamp note).
+// routingMarkerPattern matches the "✦ **Weave Router** → ..." snippet
+// injected in cross-format responses.
 var routingMarkerPattern = regexp.MustCompile(`✦ \*\*Weave Router\*\* → [^\n]*\n\n`)
 
 // StripRoutingMarkerFromMessages removes the routing-marker snippet from every
-// text block in messages[*].content[*]. The marker is injected on outbound
-// cross-format responses (see internal/translate/stream.go) and round-trips
-// through clients that preserve assistant content verbatim; stripping on
-// ingress keeps it out of upstream context and stabilizes the assistant
-// prefix for prompt-cache reuse. Mirrors stripThinkingBlocksBytes' two-phase
-// O(B) reconstruction.
+// text block in messages[*].content[*]. Stripping on ingress keeps it out of
+// upstream context and stabilizes assistant prefixes for prompt-cache reuse.
 func StripRoutingMarkerFromMessages(body []byte) ([]byte, error) {
 	messages := gjson.GetBytes(body, "messages")
 	if !messages.Exists() || !messages.IsArray() {

--- a/internal/translate/features.go
+++ b/internal/translate/features.go
@@ -15,24 +15,19 @@ type RoutingFeatures struct {
 	HasTools     bool
 	PromptText   string
 	MessageCount int
-	// MaxTokens is the caller's requested output cap (max_tokens for
-	// Anthropic/OpenAI, generationConfig.maxOutputTokens for Gemini). 0
-	// means unset/unknown. Probe detection in router/turntype keys off
-	// this — Anthropic SDK quota probes set max_tokens=1.
+	// MaxTokens is the caller's requested output cap. 0 means unset.
+	// Probe detection keys off this — Anthropic SDK quota probes set max_tokens=1.
 	MaxTokens int
-	// LastKind: "user_prompt", "tool_result", or "assistant". Empty when messages is empty.
+	// LastKind: "user_prompt", "tool_result", or "assistant".
 	LastKind string
-	// LastPreview: first previewMaxChars of the last message's text, newlines collapsed.
+	// LastPreview: first previewMaxChars of the last message's text.
 	LastPreview string
-	// OnlyUserMessageText: concatenated text from every role=="user" message in
-	// order, with system prompt, assistant turns, and tool_result blocks
-	// excluded. Populated when the caller passes extractOnlyUser=true.
+	// OnlyUserMessageText: user-message text with system/assistant/tool_result excluded.
 	OnlyUserMessageText string
 }
 
 // RoutingFeatures extracts routing inputs from the envelope. When
-// extractOnlyUser is true, OnlyUserMessageText is populated so the caller can
-// route on user-typed text only.
+// extractOnlyUser is true, OnlyUserMessageText is populated.
 func (e *RequestEnvelope) RoutingFeatures(extractOnlyUser bool) RoutingFeatures {
 	switch e.format {
 	case FormatAnthropic:
@@ -133,10 +128,8 @@ func (e *RequestEnvelope) openAIRoutingFeatures(extractOnlyUser bool) RoutingFea
 	return feats
 }
 
-// intGJSON returns the integer value of a JSON number, or 0 when the
-// result is absent / non-numeric / fractional. Probe detection only cares
-// about whole-number caps (max_tokens=1); float values aren't valid here
-// and should be treated as unset rather than rounded silently.
+// intGJSON returns the integer value of a JSON number, or 0 when absent/non-numeric.
+// Fractional values (invalid for token caps) are treated as unset.
 func intGJSON(v gjson.Result) int {
 	if !v.Exists() || v.Type != gjson.Number {
 		return 0
@@ -148,9 +141,8 @@ func intGJSON(v gjson.Result) int {
 	return int(n)
 }
 
-// openAIMaxTokens reads the output token cap from an OpenAI-format body.
-// Recent OpenAI SDKs send `max_completion_tokens`; older ones send
-// `max_tokens`. Either signals the caller's intent for a probe.
+// openAIMaxTokens reads the output token cap from an OpenAI body.
+// Reads max_completion_tokens first, falling back to max_tokens.
 func openAIMaxTokens(body []byte) int {
 	if n := intGJSON(gjson.GetBytes(body, "max_completion_tokens")); n > 0 {
 		return n
@@ -158,8 +150,7 @@ func openAIMaxTokens(body []byte) int {
 	return intGJSON(gjson.GetBytes(body, "max_tokens"))
 }
 
-// classifyLastMessageOpenAI maps an OpenAI message role onto the shared
-// three-value LastKind enum.
+// classifyLastMessageOpenAI maps an OpenAI message role to the shared LastKind enum.
 func classifyLastMessageOpenAI(role string) string {
 	switch role {
 	case "assistant":
@@ -171,8 +162,7 @@ func classifyLastMessageOpenAI(role string) string {
 	}
 }
 
-// previewText returns the first previewMaxChars of text with newlines
-// collapsed to spaces.
+// previewText returns the first previewMaxChars with newlines collapsed to spaces.
 func previewText(text string) string {
 	if text == "" {
 		return ""
@@ -186,7 +176,6 @@ func previewText(text string) string {
 }
 
 // anthropicLastUserMessage walks messages backwards for the last user entry.
-// The bare-string content shape counts as text.
 func anthropicLastUserMessage(body []byte) LastUserMessageInfo {
 	msgs := gjson.GetBytes(body, "messages")
 	if !msgs.IsArray() {
@@ -236,10 +225,8 @@ func anthropicLastUserMessage(body []byte) LastUserMessageInfo {
 	return info
 }
 
-// openAILastUserMessage scans the trailing run of role=="tool" messages and
-// the most recent role=="user" message. OpenAI splits tool returns into
-// separate messages, so a tool-result-only turn is trailing role=="tool"
-// messages with no role=="user" after them.
+// openAILastUserMessage scans the trailing run of role=="tool" messages and the
+// most recent role=="user" message.
 func openAILastUserMessage(body []byte) LastUserMessageInfo {
 	msgs := gjson.GetBytes(body, "messages")
 	if !msgs.IsArray() {
@@ -388,10 +375,8 @@ func userPromptTextGJSON(content gjson.Result) string {
 }
 
 // claudeCodeInjectedBlockPrefixes are wrapper tags Claude Code injects into
-// user-message content arrays (system reminders, slash-command echoes, local
-// command output). They carry no routing signal and dwarf the user's typed
-// text, so we skip them when building the embed input. The full untouched
-// request body is still proxied to the upstream model.
+// user-message content arrays. They carry no routing signal and dwarf the
+// user's typed text, so we skip them when building the embed input.
 var claudeCodeInjectedBlockPrefixes = []string{
 	"<system-reminder>",
 	"<command-name>",

--- a/internal/translate/features_gemini.go
+++ b/internal/translate/features_gemini.go
@@ -7,8 +7,8 @@ import (
 )
 
 // Gemini wire format reference:
-//   - systemInstruction: { parts: [ {text: ...}, ... ] }
-//   - contents: [ { role: "user"|"model", parts: [ {text|functionCall|functionResponse|inlineData|thoughtSignature: ...} ] }, ... ]
+//   - systemInstruction: { parts: [ {text: ...} ] }
+//   - contents: [ { role: "user"|"model", parts: [...] } ]
 //   - tools / generationConfig: top-level
 // Streaming choice is encoded in the URL path, not the body.
 
@@ -57,8 +57,7 @@ func (e *RequestEnvelope) geminiRoutingFeatures(extractOnlyUser bool) RoutingFea
 	return feats
 }
 
-// classifyLastMessageGemini maps a Gemini contents[] entry onto the shared
-// three-value LastKind enum.
+// classifyLastMessageGemini maps a Gemini contents[] entry to the shared LastKind enum.
 func classifyLastMessageGemini(msg gjson.Result) string {
 	if msg.Get("role").String() == "model" {
 		return "assistant"
@@ -109,8 +108,7 @@ func geminiSystemText(body []byte) string {
 	return b.String()
 }
 
-// geminiPartsText concatenates every text-bearing part. Tool-call/response and
-// thoughtSignature parts contribute no text.
+// geminiPartsText concatenates every text-bearing part.
 func geminiPartsText(parts gjson.Result) string {
 	if !parts.IsArray() {
 		return ""
@@ -175,7 +173,7 @@ func geminiLastUserMessage(body []byte) LastUserMessageInfo {
 	return info
 }
 
-// geminiFirstUserMessageText returns the text of the first role=="user" contents[] entry.
+// geminiFirstUserMessageText returns the text of the first role=="user" contents entry.
 func geminiFirstUserMessageText(body []byte) string {
 	contents := gjson.GetBytes(body, "contents")
 	if !contents.IsArray() {

--- a/internal/translate/gemini_response.go
+++ b/internal/translate/gemini_response.go
@@ -9,9 +9,7 @@ import (
 	"time"
 )
 
-// GeminiToOpenAIResponse converts a non-streaming Gemini :generateContent
-// response to an OpenAI Chat Completion response. Gemini's native body does
-// not echo the requested model, so requestModel is used.
+// GeminiToOpenAIResponse converts a non-streaming Gemini response to OpenAI format.
 func GeminiToOpenAIResponse(body []byte, requestModel string) ([]byte, error) {
 	var resp map[string]any
 	if err := json.Unmarshal(body, &resp); err != nil {
@@ -36,7 +34,7 @@ func GeminiToOpenAIResponse(body []byte, requestModel string) ([]byte, error) {
 	if len(toolCalls) > 0 {
 		message["tool_calls"] = toolCalls
 	} else if leadingSig != "" {
-		// Off-spec extra field; litellm/openai-go pass through unknown fields.
+		// Off-spec; litellm/openai-go pass through unknown fields.
 		message["thought_signature"] = leadingSig
 	}
 
@@ -55,8 +53,8 @@ func GeminiToOpenAIResponse(body []byte, requestModel string) ([]byte, error) {
 	return json.Marshal(out)
 }
 
-// GeminiToAnthropicResponse converts a non-streaming Gemini response to an
-// Anthropic Messages response.
+// GeminiToAnthropicResponse converts a non-streaming Gemini response to
+// Anthropic Messages format.
 func GeminiToAnthropicResponse(body []byte, requestModel string) ([]byte, error) {
 	var resp map[string]any
 	if err := json.Unmarshal(body, &resp); err != nil {
@@ -86,7 +84,6 @@ func GeminiToAnthropicResponse(body []byte, requestModel string) ([]byte, error)
 }
 
 // GeminiToOpenAIError re-wraps a Gemini error envelope as an OpenAI error.
-// Returns the input unchanged when the body doesn't parse as a Gemini error.
 func GeminiToOpenAIError(body []byte) []byte {
 	var g struct {
 		Error struct {
@@ -142,9 +139,9 @@ func GeminiToAnthropicError(body []byte) []byte {
 	return out
 }
 
-// extractGeminiParts walks candidate.content.parts and produces the OpenAI
-// view. thoughtSignature is smuggled as function.thought_signature; leadingSig
-// is set from the first text part when no functionCalls are present.
+// extractGeminiParts walks candidate.content.parts and produces the OpenAI view.
+// thoughtSignature is smuggled on function.thought_signature; leadingSig is
+// set from the first text part when no functionCalls are present.
 func extractGeminiParts(candidate map[string]any) (textContent string, toolCalls []any, leadingSig string) {
 	if candidate == nil {
 		return "", nil, ""
@@ -204,9 +201,7 @@ func geminiFunctionCallToToolCall(fc map[string]any, signature string) map[strin
 		"function": fn,
 	}
 	if signature != "" {
-		// Off-spec; clients that preserve unknown fields pass it through.
-		// The signature is also smuggled into tc.id above for typed SDKs
-		// (Claude Code, Anthropic TS SDK) that drop unknown fields.
+		// Also smuggled in tc.id for typed SDKs that drop unknown fields.
 		fn["thought_signature"] = signature
 		tc["thought_signature"] = signature
 	}
@@ -268,7 +263,6 @@ func blocksContainToolUse(blocks []any) bool {
 }
 
 // mapGeminiFinishReason converts Gemini finishReason to OpenAI finish_reason.
-// Unknown values fall through to "stop".
 func mapGeminiFinishReason(reason string, hasToolCalls bool) string {
 	switch reason {
 	case "STOP":

--- a/internal/translate/gemini_stream.go
+++ b/internal/translate/gemini_stream.go
@@ -13,12 +13,9 @@ import (
 	"github.com/tidwall/gjson"
 )
 
-// GeminiToOpenAISSETranslator translates Gemini :streamGenerateContent SSE
-// into OpenAI chat.completion.chunk SSE on the fly. Non-streaming responses
-// flush via Finalize.
-//
-// For Anthropic-inbound → Google, this is chained: the inner sink is an
-// AnthropicSSETranslator that re-encodes the OpenAI chunks we emit.
+// GeminiToOpenAISSETranslator translates Gemini :streamGenerateContent SSE into
+// OpenAI chat.completion.chunk on the fly. For Anthropic-inbound, it chains with
+// an inner AnthropicSSETranslator.
 type GeminiToOpenAISSETranslator struct {
 	inner   http.ResponseWriter
 	flusher http.Flusher
@@ -35,10 +32,8 @@ type GeminiToOpenAISSETranslator struct {
 	closed   bool
 	toolIdx  int
 	finished bool
-	// pendingSig is a thoughtSignature observed on a leading text part with
-	// no functionCall sibling to carry it. Gemini 3.x requires the next turn
-	// to round-trip the signature; we smuggle it onto the first tool_call
-	// chunk so the downstream Anthropic translator lands it on tool_use.
+	// pendingSig is a thoughtSignature from a text part with no functionCall
+	// sibling, held for the next tool_call chunk.
 	pendingSig string
 
 	usageSink otel.UsageSink
@@ -94,9 +89,7 @@ func (t *GeminiToOpenAISSETranslator) Flush() {
 	}
 }
 
-// Finalize flushes the buffered body for non-streaming responses, or emits
-// a trailing [DONE] for streams that ended without a finishReason (defensive
-// — Gemini sometimes sends usage in its own chunk).
+// Finalize flushes non-streaming responses or emits trailing [DONE] for streams.
 func (t *GeminiToOpenAISSETranslator) Finalize() error {
 	if t.streaming {
 		if t.closed {
@@ -267,11 +260,9 @@ func (t *GeminiToOpenAISSETranslator) emitTextDelta(text string) error {
 	return t.flushEvent()
 }
 
-// emitToolCallChunk emits a single OpenAI tool_calls delta carrying name and
-// the full arguments JSON in one chunk; Gemini does not split functionCall
-// args across chunks. thoughtSignature is smuggled as
-// function.thought_signature (off-spec but preserved by passthrough clients)
-// so the next request can round-trip it.
+// emitToolCallChunk emits an OpenAI tool_calls delta with a full arguments JSON
+// in one chunk. thoughtSignature is smuggled as function.thought_signature so the
+// next request can round-trip it.
 func (t *GeminiToOpenAISSETranslator) emitToolCallChunk(idx int, name, argsRaw, sig string) error {
 	id := embedSignatureInID(generateToolCallID(), sig)
 	t.writeChunkHeader()
@@ -316,9 +307,8 @@ func (t *GeminiToOpenAISSETranslator) emitUsageOnlyChunk(usage map[string]int) e
 }
 
 // writeUsageJSON serializes an OpenAI-shape usage object onto t.bw, including
-// prompt_tokens_details.cached_tokens when Gemini reported a cached prefix.
-// The nested shape matches what AnthropicSSETranslator.extractAndForwardUsage
-// reads via gjson, so cache numbers propagate through the chain.
+// cached_tokens when present. The nested shape matches what AnthropicSSETranslator
+// reads, so cache numbers propagate through the chain.
 func (t *GeminiToOpenAISSETranslator) writeUsageJSON(usage map[string]int) {
 	t.bw.WriteString(`,"usage":{"prompt_tokens":`)
 	sse.WriteJSONInt(t.bw, int64(usage["prompt_tokens"]))

--- a/internal/translate/handover.go
+++ b/internal/translate/handover.go
@@ -13,18 +13,9 @@ import (
 // apart from real assistant output.
 const HandoverSummaryTag = "[handover summary] "
 
-// RewriteForHandover mutates the envelope body in place: it keeps the
-// system block(s) (Anthropic top-level field, OpenAI role="system"
-// messages, Gemini systemInstruction) and replaces all other messages
-// with [assistantSummary, latestUserMessage]. The summary is prefixed
-// with HandoverSummaryTag.
-//
-// Returns the number of non-system messages that were elided so the
-// caller can log it. No-ops (and returns 0) when the envelope has no
-// messages or the body cannot be parsed.
-//
-// Used by handover.RewriteEnvelope to bound the input-token cost of a
-// mid-session model switch. Pure: no I/O.
+// RewriteForHandover replaces all non-system messages with [assistantSummary, latestUserMessage].
+// Returns the count of elided messages. No-ops when the envelope has no messages.
+// Used to bound input-token cost on mid-session model switches.
 func (e *RequestEnvelope) RewriteForHandover(summary string) int {
 	if e == nil {
 		return 0
@@ -41,10 +32,8 @@ func (e *RequestEnvelope) RewriteForHandover(summary string) int {
 	}
 }
 
-// TrimLastNMessages keeps the most recent n non-system messages
-// (defaulting to 3 when n <= 0) plus the system block(s), discarding
-// older messages. Used as the graceful-degradation path when
-// summarization fails. Returns the number of messages elided.
+// TrimLastNMessages keeps the most recent n non-system messages plus system
+// blocks. Falls back to n=3 when n <= 0. Returns the number elided.
 func (e *RequestEnvelope) TrimLastNMessages(n int) int {
 	if e == nil {
 		return 0
@@ -64,8 +53,7 @@ func (e *RequestEnvelope) TrimLastNMessages(n int) int {
 	}
 }
 
-// rewriteAnthropicForHandover rewrites the "messages" array. Anthropic
-// keeps system on a separate top-level field, so it is untouched.
+// rewriteAnthropicForHandover rewrites the "messages" array for Anthropic format.
 func (e *RequestEnvelope) rewriteAnthropicForHandover(summary string) int {
 	msgs := gjson.GetBytes(e.body, "messages")
 	if !msgs.IsArray() {
@@ -76,8 +64,7 @@ func (e *RequestEnvelope) rewriteAnthropicForHandover(summary string) int {
 		return 0
 	}
 
-	// Find the last user message (walking from the end). Anthropic's
-	// "user" role carries either a string content or a content[] array.
+	// Find the last user message (walking from the end).
 	var latestUser gjson.Result
 	for i := len(all) - 1; i >= 0; i-- {
 		if all[i].Get("role").String() == "user" {
@@ -108,10 +95,8 @@ func (e *RequestEnvelope) rewriteAnthropicForHandover(summary string) int {
 	return elided
 }
 
-// anthropicAssistantSummaryBlock builds the synthesized assistant entry.
-// Content is a single text block so the wire shape matches what
-// downstream emitters expect (PrepareAnthropic / PrepareOpenAI both
-// walk content[]).
+// anthropicAssistantSummaryBlock builds a synthesized assistant entry with a
+// single text block containing the tagged summary.
 func anthropicAssistantSummaryBlock(summary string) string {
 	tagged := HandoverSummaryTag + summary
 	msg := map[string]any{
@@ -122,9 +107,8 @@ func anthropicAssistantSummaryBlock(summary string) string {
 	}
 	raw, err := json.Marshal(msg)
 	if err != nil {
-		// json.Marshal can fail only on unsupported values; both keys
-		// here are strings, so falling through to a minimal hand-crafted
-		// shape is defensive.
+		// json.Marshal can only fail on unsupported values; both keys
+		// are strings, so this is defensive.
 		escaped, _ := json.Marshal(tagged)
 		return `{"role":"assistant","content":[{"type":"text","text":` + string(escaped) + `}]}`
 	}
@@ -155,10 +139,8 @@ func (e *RequestEnvelope) trimAnthropicLastN(n int) int {
 	return len(all) - len(keep)
 }
 
-// rewriteOpenAIForHandover preserves the leading run of role=="system"
-// messages, replaces every other message with [assistantSummary,
-// latestUser]. OpenAI carries system inside messages, so we have to
-// split the array into system vs non-system.
+// rewriteOpenAIForHandover preserves role=="system" messages and replaces
+// every other message with [assistantSummary, latestUser].
 func (e *RequestEnvelope) rewriteOpenAIForHandover(summary string) int {
 	msgs := gjson.GetBytes(e.body, "messages")
 	if !msgs.IsArray() {
@@ -216,9 +198,8 @@ func (e *RequestEnvelope) rewriteOpenAIForHandover(summary string) int {
 	return elided
 }
 
-// openAIAssistantSummaryMessage builds an OpenAI-shaped assistant message
-// with the tagged summary as a single string content (OpenAI's most
-// widely-supported content shape on assistant messages).
+// openAIAssistantSummaryMessage builds an OpenAI assistant message with the
+// tagged summary as a single string content.
 func openAIAssistantSummaryMessage(summary string) string {
 	tagged := HandoverSummaryTag + summary
 	msg := map[string]any{
@@ -269,8 +250,7 @@ func (e *RequestEnvelope) trimOpenAILastN(n int) int {
 }
 
 // rewriteGeminiForHandover mirrors the Anthropic path against Gemini's
-// `contents` array. systemInstruction is a separate top-level field;
-// untouched.
+// `contents` array. systemInstruction is untouched.
 func (e *RequestEnvelope) rewriteGeminiForHandover(summary string) int {
 	contents := gjson.GetBytes(e.body, "contents")
 	if !contents.IsArray() {

--- a/internal/translate/provider_hint.go
+++ b/internal/translate/provider_hint.go
@@ -2,18 +2,10 @@ package translate
 
 import "strings"
 
-// openRouterProviderHint returns the OpenRouter `provider` request-body field
-// for OSS model slugs that need pinning to caching-capable backends. Returns
-// nil when the target model doesn't need a hint (first-party Anthropic /
-// OpenAI / Google, Fireworks, or any unrecognized slug).
-//
-// Without a hint OpenRouter load-balances by price across every provider
-// serving the model. For deepseek/* and moonshotai/* that routinely picks
-// third-party hosts (Parasail, Baidu, etc.) which don't implement prefix
-// caching — fatal for agentic workloads where every turn re-sends a
-// 25-30K-token transcript. Pinning to the model's native provider re-enables
-// automatic prefix caching and lets OpenRouter's sticky-routing keep the
-// cache warm across turns.
+// openRouterProviderHint returns the OpenRouter `provider` field for model slugs
+// that need pinning to caching-capable backends. Without a hint, OpenRouter
+// load-balances by price and picks hosts without prefix caching, which breaks
+// agentic workloads re-sending large transcripts each turn.
 func openRouterProviderHint(model string) map[string]any {
 	switch {
 	case strings.HasPrefix(model, "deepseek/"):
@@ -32,16 +24,9 @@ func openRouterProviderHint(model string) map[string]any {
 	return nil
 }
 
-// openRouterReasoningHint returns the OpenRouter `reasoning` request-body
-// field for models whose default reasoning behavior burns the entire
-// max_tokens budget on hidden thinking, leaving zero visible content for
-// the caller. Returns nil for models that don't need the override.
-//
-// Native DeepSeek serving deepseek/* defaults to reasoning-on, and at
-// agentic max_tokens budgets (1-2K) reliably emits 2000 reasoning tokens
-// and 0 visible tokens — the user waits a minute and gets nothing. Only
-// `reasoning.enabled=false` actually disables it; `effort=minimal` and
-// `max_tokens=0` are ignored by the upstream.
+// openRouterReasoningHint returns the OpenRouter `reasoning` field to disable
+// reasoning on models that burn the entire max_tokens budget on hidden thinking.
+// Native DeepSeek serving defaults to reasoning-on and ignores effort=minimal.
 func openRouterReasoningHint(model string) map[string]any {
 	if strings.HasPrefix(model, "deepseek/") {
 		return map[string]any{"enabled": false}

--- a/internal/translate/stream.go
+++ b/internal/translate/stream.go
@@ -339,7 +339,7 @@ type AnthropicSSETranslator struct {
 	// closed guards against double-emission after [DONE] triggers finishStream.
 	closed   bool
 	blockIdx int
-		// textOpen avoids empty text blocks for tool-only responses.
+	// textOpen avoids empty text blocks for tool-only responses.
 	textOpen   bool
 	toolBlocks map[int]int
 

--- a/internal/translate/stream.go
+++ b/internal/translate/stream.go
@@ -14,8 +14,8 @@ import (
 	"github.com/tidwall/gjson"
 )
 
-// SSETranslator translates Anthropic streaming SSE to OpenAI
-// chat.completion.chunk on the fly. Non-streaming responses buffer for Finalize.
+// SSETranslator translates Anthropic streaming SSE to OpenAI chat.completion.chunk
+// on the fly. Non-streaming responses buffer for Finalize.
 type SSETranslator struct {
 	inner   http.ResponseWriter
 	flusher http.Flusher
@@ -28,8 +28,7 @@ type SSETranslator struct {
 	msgID   string
 	model   string
 	created int64
-	// toolIdx advances on content_block_stop for tool_use blocks so the start
-	// chunk and all input_json_deltas share the same index.
+	// toolIdx advances on content_block_stop for tool_use blocks.
 	toolIdx       int
 	currentIsTool bool
 
@@ -53,14 +52,13 @@ func (t *SSETranslator) Header() http.Header {
 	return t.inner.Header()
 }
 
-// WriteHeader routes streaming success responses through SSE; errors and
-// non-streaming defer to Finalize.
+// WriteHeader routes streaming success responses through SSE.
 func (t *SSETranslator) WriteHeader(code int) {
 	t.statusCode = code
 	ct := t.inner.Header().Get("Content-Type")
 	t.streaming = strings.Contains(ct, "text/event-stream") && code < 400
 
-	// Stale once we re-encode the body to a different size.
+	// Content-Length and Content-Encoding are stale once we re-encode.
 	t.inner.Header().Del("Content-Length")
 	t.inner.Header().Del("Content-Encoding")
 
@@ -79,8 +77,7 @@ func (t *SSETranslator) Write(data []byte) (int, error) {
 	return n, t.processSSEBuffer()
 }
 
-// Flush only forwards once committed to streaming; flushing during buffered
-// non-streaming would prematurely commit gin's default 200 status.
+// Flush only forwards once streaming is committed.
 func (t *SSETranslator) Flush() {
 	if !t.streaming {
 		return
@@ -90,8 +87,7 @@ func (t *SSETranslator) Flush() {
 	}
 }
 
-// Finalize writes the buffered body for non-streaming responses. Streaming
-// is a no-op — [DONE] was already emitted on message_stop.
+// Finalize writes the buffered body for non-streaming responses.
 func (t *SSETranslator) Finalize() error {
 	if t.streaming {
 		return nil
@@ -340,12 +336,10 @@ type AnthropicSSETranslator struct {
 	requestModel string
 
 	started bool
-	// closed guards against double-emission: [DONE] triggers finishStream
-	// mid-stream, and Finalize runs again after Proxy returns.
+	// closed guards against double-emission after [DONE] triggers finishStream.
 	closed   bool
 	blockIdx int
-	// textOpen is lazily set on first content delta to avoid empty blocks for
-	// tool-only responses.
+		// textOpen avoids empty text blocks for tool-only responses.
 	textOpen   bool
 	toolBlocks map[int]int
 
@@ -360,15 +354,12 @@ type AnthropicSSETranslator struct {
 
 	usageSink otel.UsageSink
 
-	// estimatedInputTokens is the proxy's pre-inference input-token estimate.
-	// It populates message_start.usage.input_tokens so clients that key off
-	// that event (Claude Code's subagent token counter, etc.) see a non-zero
-	// value even on cross-format paths where the real upstream usage doesn't
-	// arrive until message_delta.
+	// estimatedInputTokens is the pre-inference estimate, used to populate
+	// message_start.usage.input_tokens for cross-format paths where upstream
+	// usage doesn't arrive until message_delta.
 	estimatedInputTokens int
 
-	// routingMarker, when non-empty, is emitted as a standalone text block
-	// at index 0 right after message_start. markerEmitted guards single emission.
+	// routingMarker is emitted as a standalone text block at index 0.
 	routingMarker string
 	markerEmitted bool
 }
@@ -387,16 +378,14 @@ func NewAnthropicSSETranslator(w http.ResponseWriter, requestModel string, sink 
 }
 
 // WithRoutingMarker installs a text snippet emitted as a standalone content
-// block at index 0 immediately after message_start. Empty string disables it.
+// block at index 0 after message_start. Empty string disables it.
 func (t *AnthropicSSETranslator) WithRoutingMarker(marker string) *AnthropicSSETranslator {
 	t.routingMarker = marker
 	return t
 }
 
-// WithEstimatedInputTokens seeds message_start.usage.input_tokens with the
-// proxy's pre-inference estimate. Cross-format paths (OpenAI, Gemini) don't
-// learn the real input_tokens until message_delta, but some clients only read
-// input_tokens off message_start — without this hint they see zero.
+// WithEstimatedInputTokens seeds message_start.usage.input_tokens for cross-format
+// paths where upstream usage arrives after message_start.
 func (t *AnthropicSSETranslator) WithEstimatedInputTokens(n int) *AnthropicSSETranslator {
 	if n > 0 {
 		t.estimatedInputTokens = n
@@ -408,8 +397,7 @@ func (t *AnthropicSSETranslator) Header() http.Header {
 	return t.inner.Header()
 }
 
-// WriteHeader routes streaming success responses through SSE; errors and
-// non-streaming defer to Finalize.
+// WriteHeader routes streaming success responses through SSE.
 func (t *AnthropicSSETranslator) WriteHeader(code int) {
 	t.statusCode = code
 	ct := t.inner.Header().Get("Content-Type")
@@ -447,8 +435,8 @@ func (t *AnthropicSSETranslator) Flush() {
 	}
 }
 
-// Finalize writes the buffered body for non-streaming responses; for streaming,
-// emits trailing message_delta/message_stop if not already closed.
+// Finalize writes the buffered body for non-streaming responses, or emits
+// trailing message_delta/message_stop for streaming.
 func (t *AnthropicSSETranslator) Finalize() error {
 	observability.Get().Debug("AnthropicSSE Finalize entry",
 		"streaming", t.streaming,
@@ -707,11 +695,6 @@ func (t *AnthropicSSETranslator) emitMessageStart() error {
 		id = "msg_translated"
 	}
 	observability.Get().Debug("AnthropicSSE emit", "event", "message_start")
-	// estimatedInputTokens is the proxy's pre-inference estimate, used so clients
-	// that key off message_start.usage.input_tokens (e.g. Claude Code's subagent
-	// token counter) see a non-zero value for cross-format paths where the real
-	// upstream usage doesn't arrive until the final chunk. message_delta
-	// overwrites it with the actual upstream-reported value.
 	t.bw.WriteString("event: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"id\":")
 	sse.WriteJSONString(t.bw, id)
 	t.bw.WriteString(",\"type\":\"message\",\"role\":\"assistant\",\"content\":[],\"model\":")
@@ -730,11 +713,9 @@ func (t *AnthropicSSETranslator) emitContentBlockStartText(index int) error {
 	return t.flushEvent()
 }
 
-// emitContentBlockStartTool emits an Anthropic content_block_start for a
-// tool_use block. sig, when non-empty, is the opaque thought_signature that
-// Gemini 3.x requires round-tripped on the next turn's functionCall part —
-// smuggled here as a non-standard field on the tool_use block so clients
-// that pass through unknown fields preserve it.
+// emitContentBlockStartTool emits a tool_use content_block_start. sig, when
+// non-empty, is an opaque thought_signature for Gemini 3.x round-trips,
+// smuggled as a non-standard field so passthrough clients preserve it.
 func (t *AnthropicSSETranslator) emitContentBlockStartTool(index int, id, name, sig string) error {
 	observability.Get().Debug("AnthropicSSE emit", "event", "content_block_start", "type", "tool_use", "name", name)
 	t.bw.WriteString("event: content_block_start\ndata: {\"type\":\"content_block_start\",\"index\":")
@@ -786,10 +767,8 @@ func (t *AnthropicSSETranslator) emitMessageDelta() error {
 	sse.WriteJSONString(t.bw, stopReason)
 	t.bw.WriteString(",\"stop_sequence\":null},\"usage\":{")
 	if t.hasUsage {
-		// Anthropic's input_tokens is fresh-only; OpenAI's prompt_tokens (the
-		// source) is the total including cached tokens. Subtract cache so the
-		// statusline formula (input + 1.25*cwrt + multiplier*crd) doesn't
-		// double-count cache tokens.
+		// Anthropic's input_tokens is fresh-only; subtract cache so the
+		// statusline formula doesn't double-count.
 		freshInput := max(0, t.usageInputTokens-t.usageCacheCreationTokens-t.usageCacheReadTokens)
 		t.bw.WriteString("\"input_tokens\":")
 		sse.WriteJSONInt(t.bw, int64(freshInput))

--- a/internal/translate/thought_signature_id.go
+++ b/internal/translate/thought_signature_id.go
@@ -5,19 +5,16 @@ import (
 	"strings"
 )
 
-// thoughtSignatureIDDelimiter separates a synthesized tool-use id from a
-// base64-encoded Gemini thoughtSignature smuggled inside it. The id field is
-// structurally preserved by every Anthropic and OpenAI client (it's a typed
-// string used to correlate tool_use ↔ tool_result), so this is a stateless
-// round-trip channel that works even when a client's typed SDK drops unknown
-// fields like the off-spec thought_signature field on a tool_use block.
+// thoughtSignatureIDDelimiter separates the tool-use id from a base64-encoded
+// Gemini thoughtSignature smuggled inside it. The id field survives all
+// Anthropic/OpenAI client SDKs (typed string, tool_use/tool_result correlation),
+// making it a stateless round-trip channel for opaque signatures that typed SDKs
+// would otherwise drop as unknown fields.
 //
-// Prior art: BerriAI/litellm PR #16895 uses the same approach on OpenAI
-// tool_call.id.
+// Prior art: BerriAI/litellm PR #16895.
 const thoughtSignatureIDDelimiter = "__thought__"
 
-// embedSignatureInID returns id with sig encoded and appended via the
-// delimiter. Returns id unchanged when sig is empty.
+// embedSignatureInID returns id with sig base64-encoded and appended.
 func embedSignatureInID(id, sig string) string {
 	if sig == "" {
 		return id
@@ -25,10 +22,7 @@ func embedSignatureInID(id, sig string) string {
 	return id + thoughtSignatureIDDelimiter + base64.RawURLEncoding.EncodeToString([]byte(sig))
 }
 
-// extractSignatureFromID is the inverse of embedSignatureInID. If id contains
-// the delimiter and the suffix decodes as base64, it returns the leading
-// portion and the decoded signature. Otherwise it returns id unchanged and an
-// empty signature.
+// extractSignatureFromID is the inverse of embedSignatureInID.
 func extractSignatureFromID(id string) (cleanID, signature string) {
 	i := strings.Index(id, thoughtSignatureIDDelimiter)
 	if i < 0 {

--- a/internal/translate/translate.go
+++ b/internal/translate/translate.go
@@ -1,7 +1,6 @@
-// Package translate converts request and response bodies between the OpenAI
-// Chat Completions and Anthropic Messages wire formats. Request-side
-// translation lives in RequestEnvelope (envelope.go, emit_*.go); this file
-// retains response-side helpers.
+// Package translate converts request and response bodies between OpenAI and
+// Anthropic wire formats. Request translation uses RequestEnvelope; this file
+// handles non-streaming response helpers.
 package translate
 
 import (
@@ -11,9 +10,7 @@ import (
 	"time"
 )
 
-// AnthropicToOpenAIResponse converts a non-streaming Anthropic Messages response
-// to an OpenAI Chat Completion response. requestModel is the fallback when the
-// upstream body omits a model field.
+// AnthropicToOpenAIResponse converts a non-streaming Anthropic response to OpenAI format.
 func AnthropicToOpenAIResponse(body []byte, requestModel string) ([]byte, error) {
 	var resp map[string]any
 	if err := json.Unmarshal(body, &resp); err != nil {
@@ -110,8 +107,7 @@ func mapStopReason(reason any) string {
 	}
 }
 
-// AnthropicToOpenAIError re-wraps an Anthropic error as OpenAI format. Returns
-// the input unchanged when it isn't a valid Anthropic error envelope.
+// AnthropicToOpenAIError re-wraps an Anthropic error as OpenAI format.
 func AnthropicToOpenAIError(body []byte) []byte {
 	var anthropic struct {
 		Error struct {
@@ -153,9 +149,8 @@ func translateUsage(usage any) map[string]any {
 	}
 }
 
-// OpenAIToAnthropicResponse converts a non-streaming OpenAI Chat Completion
-// response to an Anthropic Messages response. requestModel is the fallback when
-// the upstream body omits a model field.
+// OpenAIToAnthropicResponse converts a non-streaming OpenAI response to
+// Anthropic Messages format.
 func OpenAIToAnthropicResponse(body []byte, requestModel string) ([]byte, error) {
 	var resp map[string]any
 	if err := json.Unmarshal(body, &resp); err != nil {
@@ -231,8 +226,7 @@ func buildAnthropicContent(message map[string]any) []any {
 	return blocks
 }
 
-// openAIFinishToAnthropicResponse is the non-streaming variant; it takes an
-// `any` directly out of the JSON map.
+// openAIFinishToAnthropicResponse is the non-streaming variant.
 func openAIFinishToAnthropicResponse(reason any) string {
 	s, _ := reason.(string)
 	switch s {
@@ -259,9 +253,7 @@ func openAIUsageToAnthropicResponse(usage any) map[string]any {
 		cacheRead, _ = details["cached_tokens"].(float64)
 		cacheCreation, _ = details["cache_creation_tokens"].(float64)
 	}
-	// Anthropic's input_tokens is fresh-only; OpenAI's prompt_tokens is the
-	// total including cached tokens. Subtract cache so the field matches
-	// Anthropic semantics (mirrors AnthropicSSETranslator.emitMessageDelta).
+	// Anthropic's input_tokens is fresh-only; subtract cached tokens.
 	freshInput := prompt - cacheCreation - cacheRead
 	if freshInput < 0 {
 		freshInput = 0
@@ -279,8 +271,7 @@ func openAIUsageToAnthropicResponse(usage any) map[string]any {
 	return out
 }
 
-// OpenAIToAnthropicError re-wraps an OpenAI error as Anthropic format. Returns
-// the input unchanged when it isn't a valid OpenAI error envelope.
+// OpenAIToAnthropicError re-wraps an OpenAI error as Anthropic format.
 func OpenAIToAnthropicError(body []byte) []byte {
 	var openai struct {
 		Error struct {


### PR DESCRIPTION
## Summary
- Comment-only pass across auth, providers, proxy, router, and translate packages
- Net: 722 insertions / 1595 deletions — purely shortening verbose multi-paragraph comments
- No semantic changes; `go build ./...` clean

## Test plan
- [ ] CI passes (this is comment-only)