### PR TITLE
translate: inject Edit-tool fidelity reminder into DeepSeek system prompt

### DIFF
--- a/internal/translate/emit_openai.go
+++ b/internal/translate/emit_openai.go
@@ -49,6 +49,12 @@ func (e *RequestEnvelope) buildOpenAIFromOpenAI(opts EmitOptions) ([]byte, error
 			return nil, fmt.Errorf("set openrouter reasoning hint: %w", err)
 		}
 	}
+	if reminder := openRouterSystemReminder(opts.TargetModel); reminder != "" && gjson.GetBytes(body, "tools").Exists() {
+		body, err = applySystemReminderToBody(body, reminder)
+		if err != nil {
+			return nil, fmt.Errorf("set system reminder: %w", err)
+		}
+	}
 	return body, nil
 }
 
@@ -97,6 +103,12 @@ func (e *RequestEnvelope) buildOpenAIFromAnthropic(opts EmitOptions) ([]byte, er
 	}
 	if reasoning := openRouterReasoningHint(opts.TargetModel); reasoning != nil {
 		out["reasoning"] = reasoning
+	}
+	if reminder := openRouterSystemReminder(opts.TargetModel); reminder != "" {
+		if _, hasTools := out["tools"]; hasTools {
+			msgs, _ := out["messages"].([]any)
+			out["messages"] = injectSystemReminder(msgs, reminder)
+		}
 	}
 
 	return json.Marshal(out)

--- a/internal/translate/system_reminder.go
+++ b/internal/translate/system_reminder.go
@@ -1,0 +1,81 @@
+package translate
+
+import (
+	"encoding/json"
+	"strings"
+
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
+)
+
+// openRouterSystemReminder returns a system-message addendum for upstreams whose
+// models mishandle agentic tool use, or "" when no reminder is needed.
+//
+// DeepSeek (V3/V4 family) routinely emits `old_string` values that differ from
+// the file by tabs vs spaces, em-dash vs hyphen, or trailing whitespace, then
+// falls back to sed/python and corrupts files. Aider pins these models to its
+// diff edit format with a sys-level "EXACTLY MATCH" reminder
+// (aider/coders/editblock_prompts.py); this is the router equivalent for
+// Anthropic-style Edit calls reaching DeepSeek via OpenRouter.
+func openRouterSystemReminder(model string) string {
+	if strings.HasPrefix(model, "deepseek/") {
+		return deepseekToolUseReminder
+	}
+	return ""
+}
+
+const deepseekToolUseReminder = "When using file-edit tools, copy `old_string` byte-for-byte from the most recent file read — preserve tabs, leading and trailing whitespace, and unicode characters (em-dash —, smart quotes, non-breaking spaces) exactly. If an Edit call fails, re-read the file before retrying. Never fall back to shell commands (sed, awk, python) to modify files."
+
+// injectSystemReminder appends `reminder` to an existing system message in
+// `messages`, or prepends a new system message when none exists. Returns the
+// (possibly new) slice.
+func injectSystemReminder(messages []any, reminder string) []any {
+	if reminder == "" {
+		return messages
+	}
+	for i, raw := range messages {
+		msg, _ := raw.(map[string]any)
+		if msg == nil {
+			continue
+		}
+		role, _ := msg["role"].(string)
+		if role != "system" {
+			continue
+		}
+		switch content := msg["content"].(type) {
+		case string:
+			msg["content"] = content + "\n\n" + reminder
+		case []any:
+			msg["content"] = append(content, map[string]any{
+				"type": "text",
+				"text": reminder,
+			})
+		default:
+			msg["content"] = reminder
+		}
+		messages[i] = msg
+		return messages
+	}
+	return append([]any{map[string]any{"role": "system", "content": reminder}}, messages...)
+}
+
+// applySystemReminderToBody injects the reminder into a serialized OpenAI body's
+// `messages` array. Best-effort: returns the input unchanged on parse failure
+// rather than failing the request.
+func applySystemReminderToBody(body []byte, reminder string) ([]byte, error) {
+	if reminder == "" {
+		return body, nil
+	}
+	msgsResult := gjson.GetBytes(body, "messages")
+	if !msgsResult.IsArray() {
+		return sjson.SetBytes(body, "messages", []any{
+			map[string]any{"role": "system", "content": reminder},
+		})
+	}
+	var msgs []any
+	if err := json.Unmarshal([]byte(msgsResult.Raw), &msgs); err != nil {
+		return body, nil
+	}
+	msgs = injectSystemReminder(msgs, reminder)
+	return sjson.SetBytes(body, "messages", msgs)
+}

--- a/internal/translate/system_reminder_test.go
+++ b/internal/translate/system_reminder_test.go
@@ -1,0 +1,174 @@
+package translate_test
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"workweave/router/internal/translate"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// emittedMessages returns the `messages` array from an emitted OpenAI body.
+func emittedMessages(t *testing.T, body []byte) []map[string]any {
+	t.Helper()
+	var doc map[string]any
+	require.NoError(t, json.Unmarshal(body, &doc))
+	raw, _ := doc["messages"].([]any)
+	out := make([]map[string]any, 0, len(raw))
+	for _, m := range raw {
+		msg, _ := m.(map[string]any)
+		if msg != nil {
+			out = append(out, msg)
+		}
+	}
+	return out
+}
+
+// systemContent returns the concatenated text content of the first system
+// message, or "" when none is present.
+func systemContent(msgs []map[string]any) string {
+	for _, msg := range msgs {
+		if role, _ := msg["role"].(string); role != "system" {
+			continue
+		}
+		switch c := msg["content"].(type) {
+		case string:
+			return c
+		case []any:
+			var parts []string
+			for _, b := range c {
+				block, _ := b.(map[string]any)
+				if block == nil {
+					continue
+				}
+				if text, _ := block["text"].(string); text != "" {
+					parts = append(parts, text)
+				}
+			}
+			return strings.Join(parts, "\n")
+		}
+	}
+	return ""
+}
+
+const reminderSnippet = "byte-for-byte"
+
+func TestSystemReminder_AnthropicSource_AppendsForDeepSeekWithTools(t *testing.T) {
+	src := []byte(`{
+		"model":"claude-opus-4-7",
+		"system":"You are a helpful coding assistant.",
+		"messages":[{"role":"user","content":"hi"}],
+		"tools":[{"name":"Edit","description":"edit","input_schema":{"type":"object"}}],
+		"max_tokens":256
+	}`)
+	env, err := translate.ParseAnthropic(src)
+	require.NoError(t, err)
+
+	out, err := env.PrepareOpenAI(nil, translate.EmitOptions{TargetModel: "deepseek/deepseek-v4-pro"})
+	require.NoError(t, err)
+
+	got := systemContent(emittedMessages(t, out.Body))
+	assert.Contains(t, got, "You are a helpful coding assistant.", "original system text must be preserved")
+	assert.Contains(t, got, reminderSnippet, "deepseek/* with tools must get the reminder")
+}
+
+func TestSystemReminder_AnthropicSource_SkipsWithoutTools(t *testing.T) {
+	src := []byte(`{
+		"model":"claude-opus-4-7",
+		"system":"You are a helpful coding assistant.",
+		"messages":[{"role":"user","content":"hi"}],
+		"max_tokens":256
+	}`)
+	env, err := translate.ParseAnthropic(src)
+	require.NoError(t, err)
+
+	out, err := env.PrepareOpenAI(nil, translate.EmitOptions{TargetModel: "deepseek/deepseek-v4-pro"})
+	require.NoError(t, err)
+
+	assert.NotContains(t, systemContent(emittedMessages(t, out.Body)), reminderSnippet,
+		"requests without tools must not get the reminder")
+}
+
+func TestSystemReminder_AnthropicSource_NoSystemMessagePrepended(t *testing.T) {
+	src := []byte(`{
+		"model":"claude-opus-4-7",
+		"messages":[{"role":"user","content":"hi"}],
+		"tools":[{"name":"Edit","description":"edit","input_schema":{"type":"object"}}],
+		"max_tokens":256
+	}`)
+	env, err := translate.ParseAnthropic(src)
+	require.NoError(t, err)
+
+	out, err := env.PrepareOpenAI(nil, translate.EmitOptions{TargetModel: "deepseek/deepseek-v4-pro"})
+	require.NoError(t, err)
+
+	msgs := emittedMessages(t, out.Body)
+	require.NotEmpty(t, msgs)
+	assert.Equal(t, "system", msgs[0]["role"], "reminder must be prepended as a new system message")
+	assert.Contains(t, msgs[0]["content"], reminderSnippet)
+}
+
+func TestSystemReminder_AnthropicSource_NoReminderForNonDeepSeek(t *testing.T) {
+	cases := []string{"gpt-5", "moonshotai/kimi-k2.5", "qwen/qwen3-max", "google/gemini-2.5-pro"}
+	for _, model := range cases {
+		t.Run(model, func(t *testing.T) {
+			src := []byte(`{
+				"model":"claude-opus-4-7",
+				"system":"sys",
+				"messages":[{"role":"user","content":"hi"}],
+				"tools":[{"name":"Edit","description":"edit","input_schema":{"type":"object"}}],
+				"max_tokens":256
+			}`)
+			env, err := translate.ParseAnthropic(src)
+			require.NoError(t, err)
+
+			out, err := env.PrepareOpenAI(nil, translate.EmitOptions{TargetModel: model})
+			require.NoError(t, err)
+
+			assert.NotContains(t, systemContent(emittedMessages(t, out.Body)), reminderSnippet,
+				"non-deepseek targets must not receive the reminder")
+		})
+	}
+}
+
+func TestSystemReminder_OpenAISource_AppendsForDeepSeekWithTools(t *testing.T) {
+	src := []byte(`{
+		"model":"x",
+		"messages":[
+			{"role":"system","content":"be concise"},
+			{"role":"user","content":"hi"}
+		],
+		"tools":[{"type":"function","function":{"name":"Edit","parameters":{"type":"object"}}}],
+		"max_tokens":256
+	}`)
+	env, err := translate.ParseOpenAI(src)
+	require.NoError(t, err)
+
+	out, err := env.PrepareOpenAI(nil, translate.EmitOptions{TargetModel: "deepseek/deepseek-v4-pro"})
+	require.NoError(t, err)
+
+	got := systemContent(emittedMessages(t, out.Body))
+	assert.Contains(t, got, "be concise", "original system content preserved")
+	assert.Contains(t, got, reminderSnippet, "OpenAI→OpenAI path must inject reminder for deepseek/* with tools")
+}
+
+func TestSystemReminder_OpenAISource_SkipsWithoutTools(t *testing.T) {
+	src := []byte(`{
+		"model":"x",
+		"messages":[
+			{"role":"system","content":"be concise"},
+			{"role":"user","content":"hi"}
+		],
+		"max_tokens":256
+	}`)
+	env, err := translate.ParseOpenAI(src)
+	require.NoError(t, err)
+
+	out, err := env.PrepareOpenAI(nil, translate.EmitOptions{TargetModel: "deepseek/deepseek-v4-pro"})
+	require.NoError(t, err)
+
+	assert.NotContains(t, systemContent(emittedMessages(t, out.Body)), reminderSnippet)
+}


### PR DESCRIPTION
## Summary
- Append a DeepSeek-specific tool-fidelity reminder to the system message when emitting to `deepseek/*` with tools present
- Mirrors Aider's `reminder="sys"` pattern (`aider/coders/editblock_prompts.py`), which they ship specifically for DeepSeek models in `model-settings.yml`
- Gated on `tools` presence so non-agentic DeepSeek calls are unaffected

## Why
DeepSeek V3/V4 routes (which is where a lot of our agentic traffic lands) regularly fail Anthropic-style Edit tools by emitting `old_string` values that differ from the file by:
- tabs vs spaces
- em-dash (—) vs hyphen
- trailing whitespace

When the byte-exact match fails, the model falls back to `sed` / `python` and corrupts files (see recent Claude Code transcripts). Aider hits the same family and ships the same reminder upstream. This is the router-side equivalent — both `Anthropic→OpenAI` and `OpenAI→OpenAI` emit paths covered.

## Out of scope (deferred)
- **Tool-call leak detection** (V3.2 `<｜tool▁call▁begin｜>` markers in `content`) — defer until we have logs showing the exact format the upstream emits
- **Escape normalization** of `old_string` — would corrupt legitimate code containing literal `\n`/`\t`; OpenCode only does this with file content in hand
- **Strict mode / temperature=0** for DeepSeek — needs eval validation across OpenRouter providers; its own PR

## Test plan
- [x] `go test ./internal/translate/...` passes (6 new tests cover both source formats, with/without tools, with/without existing system message, non-DeepSeek targets)
- [x] `go build ./...` clean