### PR TITLE
docs: split CLAUDE.md/AGENTS.md by package

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,8 +1,8 @@
 # router — AGENTS
 
-> **Mirror notice.** Verbatim sync with [CLAUDE.md](CLAUDE.md). Cursor + generic agents read `AGENTS.md`; Claude Code reads `CLAUDE.md`. **Update both together** — divergence = bug.
+> **Mirror notice.** Verbatim sync with [CLAUDE.md](CLAUDE.md). Claude Code reads `CLAUDE.md`; Cursor + generic agents read `AGENTS.md`. **Update both together** — divergence = bug.
 
-Instructs AI agents in `router/` subproject. Covers router-specific layering + design conventions. First read for any task: [README](README.md), then this file.
+Root guide for AI agents in the `router/` subproject. Covers cross-cutting design + the layer model. **First read for any task:** [README](README.md), then this file. Then read the `CLAUDE.md` inside the package you're editing — each subpackage has its own with focused recipes + invariants.
 
 ## Engineering principles
 
@@ -88,90 +88,33 @@ Three concentric layers. Imports flow inward only.
 - **Small utility third-party libs allowed at every layer.** Layering = about *where I/O and behavior live*, not banning go.mod entries. Reach for vetted small lib (`golang-lru`, `uuid`, error helpers) before rolling own. Reject heavyweight frameworks (DI containers, ORMs, metaprogramming kits).
 - **Inner-ring packages are I/O-free.** `internal/router`, `internal/providers`, `internal/translate`, `internal/sse`, `internal/router/{cache,capability,handover,planner,pricing,sessionpin,turntype}`, `internal/proxy/usage` define interfaces, value types, pure functions only. Adding I/O method (HTTP, DB, queue, FS) = layering violation; put on `auth.Service` / `proxy.Service` or adapter subpackage. Pure-Go utility libs fine.
 - **Adapters depend only on inner ring.** `internal/postgres` may also import `internal/sqlc`. Adapters never import each other — `internal/postgres` doesn't know `internal/api/admin` etc. Note: provider adapters (`internal/providers/<name>/`) import `internal/proxy` for `OnUpstreamMeta` callback so streaming responses record usage/headers back to proxy — one of few inward-pointing adapter→inner-ring imports, intentional.
-- **`internal/api/*` and `internal/server`** depend on `internal/auth` (Service handle + middleware-context types) and `internal/proxy` (routing/dispatch service handle). May import `internal/observability` for logging, `internal/providers` for shared sentinel errors, `internal/router/cluster` for `ErrClusterUnavailable` sentinel + `DeployedModelsSource` interface (API handlers map sentinel → HTTP 503). Must not import `internal/postgres`, any concrete `internal/providers/*` adapter, or `internal/translate` directly. Concrete instances reach presentation only via constructor params from composition root. (`internal/router/heuristic` and `internal/router/evalswitch` previously lived here; both removed when heuristic fallback retired in favor of `cluster.ErrClusterUnavailable` → HTTP 503.)
+- **`internal/api/*` and `internal/server`** depend on `internal/auth` (Service handle + middleware-context types) and `internal/proxy` (routing/dispatch service handle). May import `internal/observability` for logging, `internal/providers` for shared sentinel errors, `internal/router/cluster` for `ErrClusterUnavailable` sentinel + `DeployedModelsSource` interface (API handlers map sentinel → HTTP 503). Must not import `internal/postgres`, any concrete `internal/providers/*` adapter, or `internal/translate` directly. Concrete instances reach presentation only via constructor params from composition root.
 - **`internal/config` and `internal/observability` are leaf utilities** — must not import any other package under `internal/`. Third-party utility deps fine; today pull only stdlib + gin (request-scoped logger middleware). `internal/observability/otel` subpackage *is* an adapter (builds real OTLP exporter) and can import other internal packages; parent `internal/observability` stays a leaf.
-- **Composition happens in `cmd/router/main.go`.** Only file that constructs concrete adapters + injects them. No other place wires things. Keep `main.go` focused on wiring; helpers today: `buildClusterScorer` (per-version Scorer assembly + embedder warmup), `buildSemanticCache` (response-cache assembly), `buildOtelEmitter` (OTel span exporter), `runSessionPinSweep` (TTL sweep loop), `resolveHardPinModel` / `resolveDefaultBaselineModel` / `resolveAvailableModels` (boot-time model resolution), small env parsers. No more heuristic-fallback router — if cluster routing fails to boot, `main.go` panics.
+- **Composition happens in `cmd/router/main.go`.** Only file that constructs concrete adapters + injects them. No other place wires things. See [`cmd/CLAUDE.md`](cmd/CLAUDE.md).
 
 If wanting to import something that violates these rules, design is wrong — surface as interface in appropriate inner-ring package and implement in adapter subpackage.
 
-## Adding code — step-by-step recipes
+## Where to put new code
 
-### Adding an HTTP endpoint
+Pick by responsibility, then read that package's `CLAUDE.md`:
 
-1. **Decide timeout budget.** Cheap auth-only ops use `validateTimeout` / `healthTimeout` (1 s). Provider calls get own constant in [`server.go`](internal/server/server.go) — pick budget + justify in comment.
-2. **Decide auth.** Routes needing valid `rk_` bearer go through `middleware.WithAuth(authSvc)`. Admin endpoints use `WithAdminOrAuth` (admin cookie OR bearer) or `WithAdminOnly` (admin cookie only). Unauthed routes (e.g. `/health`) attach no auth middleware.
-3. **Decide if self-hoster dashboard surface.** `/ui/*` static dashboard, `/admin/v1/auth/*`, `/admin/v1` mgmt group (metrics, keys, provider-keys, config, excluded-models) mount only when `mode == server.DeploymentModeSelfHosted`. New endpoints whose only consumer is self-hosted dashboard go inside that block; product-surface endpoints (`/v1/*`, `/v1beta/*`, `/health`, `/validate`) stay outside so available in `managed` mode too. **Do not** add new `/admin/v1/*` route outside selfhosted block — would re-expose redundant control plane on Weave-managed deploys.
-4. **Pick (or create) right `internal/api/<group>/` subpackage.** Operational endpoints → `internal/api/admin/`; Anthropic Messages surface → `internal/api/anthropic/` (also hosts `/v1/route` for routing introspection + passthrough endpoints); OpenAI Chat Completions → `internal/api/openai/`; Gemini native `:generateContent` / `:streamGenerateContent` → `internal/api/gemini/`. New surfaces get own subpackage.
-5. **Use `observability.FromGin(c)` for request-scoped logger.** If need authed installation: `middleware.InstallationFrom(c)` (nil if `WithAuth` not applied — handler should be on authed group). For BYOK secrets attached to request: `middleware.ExternalAPIKeysFrom(c)`.
-6. **Pick right service.** Identity-only ops → `*auth.Service`. Routing/dispatch/translate → `*proxy.Service`. Don't touch repositories, router, providers, planner/handover/cache packages from handler. Handler adapts HTTP ↔ service; service does the work.
-7. **Test with in-memory fakes + gin testing harness** (`httptest.NewRequest`/`ResponseRecorder`). No real DB for handler tests — use fakes from [`internal/auth/service_test.go`](internal/auth/service_test.go) and [`internal/proxy/service_test.go`](internal/proxy/service_test.go) as model.
+| Responsibility | Package | Guide |
+|---|---|---|
+| HTTP endpoint (handler + route) | `internal/api/<group>/` | [internal/api/CLAUDE.md](internal/api/CLAUDE.md) |
+| Identity / API-key logic | `internal/auth` (method on `*Service`) | [internal/auth/CLAUDE.md](internal/auth/CLAUDE.md) |
+| Routing / dispatch / per-turn orchestration | `internal/proxy` (method on `*Service`) | [internal/proxy/CLAUDE.md](internal/proxy/CLAUDE.md) |
+| Cross-format wire conversion (no I/O) | `internal/translate` | [internal/translate/CLAUDE.md](internal/translate/CLAUDE.md) |
+| New upstream provider | `internal/providers/<name>/` | [internal/providers/CLAUDE.md](internal/providers/CLAUDE.md) |
+| New `Router` implementation | `internal/router/<name>/` | [internal/router/CLAUDE.md](internal/router/CLAUDE.md) |
+| Cluster scorer / artifacts | `internal/router/cluster/` | [internal/router/cluster/CLAUDE.md](internal/router/cluster/CLAUDE.md) |
+| Cache-aware turn routing internals | `internal/router/{planner,handover,cache,sessionpin,pricing,capability,turntype}/` | each has its own CLAUDE.md |
+| Anthropic usage-bypass gate | `internal/proxy/usage` | [internal/proxy/usage/CLAUDE.md](internal/proxy/usage/CLAUDE.md) |
+| New column / SQL query | `db/queries/` + `internal/postgres/` | [db/CLAUDE.md](db/CLAUDE.md), [internal/postgres/CLAUDE.md](internal/postgres/CLAUDE.md) |
+| Doc under `docs/` | `docs/` | [docs/CLAUDE.md](docs/CLAUDE.md) |
 
-### Adding a method to a Service
+**Default rule:** put logic in the package that uses it. Only promote to a shared home (`auth`, `proxy`, `translate`, `config`, `observability`, `sse`) when 3+ packages need the same logic.
 
-Pick service first:
-
-- **Identity / API-key** → `*auth.Service` in [`internal/auth/service.go`](internal/auth/service.go).
-- **Routing / dispatch / cross-format proxying / planner integration** → `*proxy.Service` in [`internal/proxy/service.go`](internal/proxy/service.go).
-
-Then:
-
-1. **Define method on chosen `*Service`.** No I/O directly here — push into repo or provider adapter. Inner-ring imports (`router`, `providers`, `translate`, `observability`, `internal/router/*` helper packages, `internal/proxy/usage`) + small utility libs fine.
-2. **If need new repo methods, add to interfaces in [`installation.go`](internal/auth/installation.go) / [`api_key.go`](internal/auth/api_key.go) / sibling files.** Interface = contract; adapter must satisfy. `sessionpin.Store` interface in [`internal/router/sessionpin/store.go`](internal/router/sessionpin/store.go), implemented by `postgres.SessionPinRepository`.
-3. **Implement new repo method in [`internal/postgres/repository.go`](internal/postgres/repository.go)** (or sibling in `internal/postgres/`), adding SQLC query in `db/queries/`. Run `make generate` to regenerate `internal/sqlc/`.
-4. **Update matching `service_test.go` fakes** to satisfy expanded interface. Tests for new Service method use fakes; assert on real return values, not just that mocks were called.
-
-### Adding a wire-format pair (translation)
-
-When new inbound format needs to talk to existing upstream provider with different wire format:
-
-1. **Add conversion functions to [`internal/translate/`](internal/translate).** Pure functions only — no I/O, no provider knowledge, no domain types. Package covers all three directions: Anthropic ⇄ OpenAI and Gemini ⇄ {Anthropic, OpenAI} via `RequestEnvelope` intermediate + per-target `emit_*.go` files.
-2. **If response streaming, adapt [`stream.go`](internal/translate/stream.go) / [`gemini_stream.go`](internal/translate/gemini_stream.go)** or add sibling decorator. Decorators wrap `http.ResponseWriter` and translate on the fly so we never buffer entire responses. Use [`internal/sse`](internal/sse) for zero-alloc SSE framing.
-3. **Compose new translation in `proxy.Service.Proxy*`.** Proxy service is only caller of `translate`. Keep providers (`internal/providers/<name>/`) ignorant of cross-format concerns.
-
-### Adding a new `providers.Client` adapter
-
-1. **Create `internal/providers/<name>/client.go`** with `Client` struct + `NewClient(...)` constructor taking credentials (typically API key string + base URL). For OpenAI-compatible upstreams (vLLM, Together, DeepInfra, customer endpoints), prefer adding sibling `*BaseURL` constant in [`internal/providers/openaicompat`](internal/providers/openaicompat) over new adapter — openaicompat client already covers OpenRouter + Fireworks under own provider keys.
-2. **Implement `Proxy` and `Passthrough`.** Adapter translates prepared request body to provider's wire format, sends with pooled `http.Client` (use `httputil.NewTransport` and `httputil.StreamBody` from `internal/providers/httputil/`), streams response back. Adapters call into `proxy.OnUpstreamMeta` when they observe usage/header data to record. Do not leak provider-specific types across package boundary.
-3. **Add compile-time check:** `var _ providers.Client = (*Client)(nil)`
-4. **Add canonical name constant** to [`internal/providers/provider.go`](internal/providers/provider.go) (the `Provider*` block) + register matching env-var name in `APIKeyEnvVars`. Today's wired keys: `"anthropic"`, `"openai"`, `"google"`, `"openrouter"`, `"fireworks"`. Composition root reads `APIKeyEnvVars` so admin `/config` view can't drift from actual wiring.
-5. **Wire in `cmd/router/main.go`.** Only place that imports provider package directly. Provider must be added to `providerMap` regardless of mode; `envKeyedProviders` (parallel set) tracks which providers have deployment-level key configured so hard-pin resolver knows what's safe to pin to. Managed-mode deploys register every provider with empty key + rely exclusively on BYOK / client-supplied auth.
-
-### Adding a new `router.Router` implementation
-
-1. **Create sibling subpackage to `internal/router/cluster/`.** Today `cluster/` (AvengersPro, with `Multiversion` wrapper for per-request bundle selection) is only `Router` impl in prod. New ones might be e.g. `internal/router/shadow/` wrapping two others.
-2. **Implement `Route(ctx, router.Request) (router.Decision, error)`.**
-3. **Add compile-time check:** `var _ router.Router = (*X)(nil)`.
-4. **Wire in `cmd/router/main.go`** (replacing or wrapping cluster scorer as needed).
-5. **If impl needs CGO or external libs**, follow build-tag pattern in `cluster/embedder_onnx.go` + `embedder_stub.go` so contributors without library can still `go test` locally.
-6. **Failure modes return errors, not silent fallbacks.** Cluster scorer's `ErrClusterUnavailable` → HTTP 503 pattern is the model: silent fallback to default model masks regressions + lets quality silently degrade in eval + prod.
-
-### Adding a column or query
-
-1. **Migration first.** Add `db/migrations/NNNN_<name>.up.sql` + `.down.sql` in sequential numbering. Wrap in `BEGIN`/`COMMIT`. Down migration must be precise rollback — no `IF EXISTS` guards.
-2. **Add query** to appropriate `db/queries/<table>.sql`. Use named params with type casts (`@param::varchar`). Use `sqlc.embed(t)` for JOINs.
-3. **Run `make generate`** to regenerate `internal/sqlc/`. Commit generated code alongside changes.
-4. **Update [`internal/postgres/repository.go`](internal/postgres/repository.go)** (and [`converters.go`](internal/postgres/converters.go) if new column needs domain mapping). Domain types (`auth.Installation`, `auth.APIKey`, `sessionpin.Pin`) must not leak `pgtype` / `uuid` concerns — convert at adapter boundary.
-
-### Adding a doc under `docs/`
-
-Every Markdown doc under `router/docs/` (active or archived) indexed in [`docs/README.md`](docs/README.md). When adding new doc, same change must update index — drift between doc tree and index = bug.
-
-1. **Top of new file:** include standard two-line header before H1:
-
-   ```
-   Created: YYYY-MM-DD
-   Last edited: YYYY-MM-DD
-   ```
-
-   `Created` date is load-bearing — `docs/README.md` orders TOC by it. Don't backdate; if doc takes multiple days, leave `Created` on day it first landed and bump `Last edited` as it changes.
-
-2. **Append row to [`docs/README.md`](docs/README.md)** in correct section (Active or Archived), keeping each table sorted by `Created` ascending. Write one- or two-sentence summary covering what doc is for and (for archived) why archived plus link to active replacement.
-
-3. **If archiving active doc:** move row from active table to archived with short reason, mirror entry in [`docs/plans/archive/README.md`](docs/plans/archive/README.md). Move file with `git mv` so history follows.
-
-4. **Renaming or deleting doc:** update both this rule's index and inbound links. `grep -rn 'old/path' router/` before merging.
-
-### Adding a new helper
+## Adding a new helper
 
 Don't, unless same logic needed in 3+ places and no plausible existing home. Canonical homes:
 
@@ -204,19 +147,6 @@ If new helper doesn't fit, justify new package in code comment before creating.
 - In-memory fakes for repos/routers/provider clients are cheap + far better than mocks for unit testing Service.
 - No DB-backed integration tests in `internal/`. If need real Postgres, `docker compose` stack is runtime fixture; write scripts under `scripts/` rather than `*_test.go`.
 
-### SQL and migrations
-
-- Always named params (`@param::varchar`), never numbered (`$1`).
-- Always include type casts so SQLC inference unambiguous.
-- Query names use consistent prefixes: `Insert*`, `Upsert*`, `Get*`, `Update*`, `Delete*`.
-- Every query gets explanatory comment (SQLC turns into godoc on generated function).
-- No-rows single-row queries return error — check `errors.Is(err, sql.ErrNoRows)`.
-- Always wrap migrations in `BEGIN; ... COMMIT;`.
-- Never create migration files manually — use `make migrate-create NAME=<name>`.
-- Down migrations must be precise rollbacks. No `IF EXISTS` guards. Don't separately drop indexes when dropping tables.
-- `organization_id` + `created_by` = opaque external identifiers — never add foreign keys to tables outside router's own schema.
-- Soft-delete via `deleted_at TIMESTAMP` on tables needing lifecycle. Hot-path queries filter `WHERE deleted_at IS NULL`.
-
 ### Logging
 
 - Log message explains in plain English what happened. Include `err` + relevant context (IDs, counts, status codes).
@@ -237,102 +167,6 @@ If new helper doesn't fit, justify new package in code comment before creating.
 - **Never log secrets, raw API keys, or full request bodies.** First 8 + last 4 chars on `auth.APIKey` are safe form. BYOK secrets at rest go through `auth.Encryptor` (Tink AES-256-GCM); plaintext only in memory for request lifetime.
 - **Never edit generated files** under `internal/sqlc/`. Regenerate with `make generate`. SQLC's "DO NOT EDIT" header is load-bearing.
 
-## Cluster routing (P0)
-
-`internal/router/cluster` = AvengersPro-derived primary router (arxiv 2508.12631, DAI 2025). Full design in [`docs/plans/archive/CLUSTER_ROUTING_PLAN.md`](docs/plans/archive/CLUSTER_ROUTING_PLAN.md); this section is rules-for-AI subset.
-
-**What's load-bearing:**
-
-- Package compiles in **two layered modes via build tags**:
-  - `embedder_onnx.go` vs `embedder_stub.go` — gated by `no_onnx`. Default builds compile real hugot-backed embedder; `-tags=no_onnx` swaps in stub `NewEmbedder` that always errors. Used by contributors without `libonnxruntime`.
-  - `-tags ORT` — required by **hugot v0.7+** to enable ONNX Runtime backend. Without it, `hugot.NewORTSession` returns "to enable ORT, run `go build -tags ORT`" and `cluster.NewEmbedder` fails. Dockerfile builds with `-tags ORT`. **Do not drop this tag from any production-bound build.**
-  - To run parity integration test, combine: `-tags "onnx_integration ORT"`.
-- Local-dev build env (Apple Silicon):
-  - `libtokenizers` static lib must be on linker path. Pre-built releases at https://github.com/daulet/tokenizers/releases/. Extract `libtokenizers.darwin-arm64.tar.gz` somewhere user-writable + set `CGO_LDFLAGS=-L/path/to/dir`.
-  - `libonnxruntime` shared lib via `brew install onnxruntime`. brew installs to `/opt/homebrew/lib`, hugot defaults to `/usr/local/lib` lookup. Set `ROUTER_ONNX_LIBRARY_DIR=/opt/homebrew/lib` to override. (Linux containers using Dockerfile don't need this — `/usr/lib/libonnxruntime.so` is default, populated by runtime stage.)
-- **Versioned artifacts.** Every committed bundle lives at `internal/router/cluster/artifacts/v<X.Y>/` with four files: `centroids.bin`, `rankings.json`, `model_registry.json`, `metadata.yaml`. `artifacts/latest` pointer file (single line, e.g. `v0.37`) names version runtime serves by default; `ROUTER_CLUSTER_VERSION` env overrides. Promotion = one-line edit to `latest` + redeploy. Committed history spans v0.21 through current `latest` — earlier pruned once they fell out of eval comparison.
-- Go runtime builds **only served default version** by default (`cmd/router/main.go`'s `buildClusterScorer`). Setting `ROUTER_CLUSTER_BUILD_ALL_VERSIONS=true` switches to building **one Scorer per committed bundle** so callers can pin per-request to sibling version with `x-weave-cluster-version: v0.X` via `middleware.WithClusterVersionOverride`. "Compare-against-each-other" mechanism — staging/eval deploys set flag so single deploy carries every committed bundle + eval harness flips between them per-request. Prod leaves flag off: only default bundle loaded into memory, header override is no-op.
-- **Centroids/rankings are write-once.** `train_cluster_router.py` always writes to `artifacts/v<X.Y>/` and never overwrites previous version (auto-bumps from `latest` when `--version` omitted). Pass `--from v0.36` to clone previous version's `model_registry.json` before training new one. **Never edit `centroids.bin` / `rankings.json` by hand.** `model_registry.json` is only hand-editable file in a bundle (training script reads it).
-- `metadata.yaml` is informational at runtime — carries version changelog, training params, deployed models, α-blend cost values. Go runtime parses for `/health`-style provenance; eval harness reads offline. Keep accurate but does not affect routing decisions.
-- `assets/model.onnx` is **NOT in git.** Use Jina's own INT8 export at `jinaai/jina-embeddings-v2-base-code`, file path `onnx/model_quantized.onnx`. Dockerfile pulls anonymously during build (Jina repo public — self-hosters don't need creds); local dev pulls via `scripts/download_from_hf.py`. `HF_TOKEN` build secret is *optional* (raises rate limits in CI) + `required=false` in Dockerfile. Go embedder reads from `/opt/router/assets/model.onnx` (override via `ROUTER_ONNX_ASSETS_DIR`). If missing or <1 MiB, `cluster.NewEmbedder` errors at boot + `main.go` panics — router refuses to start rather than silently degrading. `HF_MODEL_REVISION` pinned to Jina SHA by default; bump deliberately to pick up new upstream export.
-- **Cost values** used in α-blend live in `train_cluster_router.py`'s `DEFAULT_COST_PER_1K_INPUT`. Baked into `rankings.json` at training time, not looked up at request time (paper §3 — runtime scoring is single argmax). When Anthropic changes prices, update dict + rerun training.
-
-**What to NOT do:**
-
-- **Don't add per-request cost lookup or runtime α knob.** α baked at training time; changing requires retraining. Per-request override (`x-weave-routing-alpha`) is P1, not P0 — wait for customer ask before shipping.
-- **Don't loosen `MaxPromptChars = 1024` cap** without re-running latency test. BERT inference is O(n²) attention; cap is load-bearing.
-- **Don't add fail-open fallbacks.** Cluster scorer returns `ErrClusterUnavailable` on every failure path (embed timeout, embed error, dim mismatch, prompt too short, empty argmax). API handlers map to HTTP 503. Previous `heuristic` fallback removed because it silently degraded routing — every request that should have hit cluster scorer instead got `claude-haiku-4-5`, masking real regressions in eval + prod. New failure modes return sentinel; no default-model shortcut "for safety".
-- **Don't change centroid format without bumping magic string.** `loadCentroids` uses magic + version header to refuse mismatched binaries; if layout changes, bump `centroidsMagic` from `CRT1` to `CRT2` so next deploy refuses old binary instead of silently misrouting.
-- **Don't overwrite previously committed artifact version.** Versions frozen for comparison — once `v0.37` committed, train to `v0.38` rather than re-running `train_cluster_router.py` against `v0.37`. Training script auto-bumps; only override with `--version v0.X` for in-place fixes intended to land as separate commit.
-- **Don't bypass version pointer.** `artifacts/latest` is single source of truth for default served version. Don't hardcode version in `cmd/router/main.go`; let `cluster.ResolveVersion` read pointer.
-
-
-## Multi-provider routing (Anthropic / OpenAI / Google / OpenRouter / Fireworks)
-
-Router serves five vendor pools from one composition root. Single routing decision picks `(Provider, Model)` + proxy dispatches accordingly. Cross-format translation lives in `internal/translate` so handlers never juggle wire formats.
-
-**Architecture:**
-
-- `cmd/router/main.go` registers each provider client. In **selfhosted** mode each provider's deployment-level key read from env var (`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `GOOGLE_API_KEY`, `OPENROUTER_API_KEY`, `FIREWORKS_API_KEY`); missing key keeps provider registered for BYOK / client-passthrough but excludes from `envKeyedProviders` (set hard-pin resolver may pin to). In **managed** mode (`ROUTER_DEPLOYMENT_MODE=managed`) every provider registered unconditionally with empty key + proxy service flipped into BYOK-only mode — request without BYOK or client-supplied creds for chosen provider 400s at scorer rather than silently spending platform budget on customer traffic. Single source of truth for provider→env-var mapping = `providers.APIKeyEnvVars` in [`internal/providers/provider.go`](internal/providers/provider.go).
-- `cluster.NewScorer` filters `model_registry.json`'s `deployed_models` list to entries whose `provider` is in `availableProviders`. argmax runs over filtered list, so deploy without OpenRouter key cannot accidentally emit `deepseek-*` decision.
-- `model_registry.json` = flat list of `{model, provider, bench_column, proxy?, proxy_note?}` entries. Direct columns are 1:1 with OpenRouterBench; proxy entries (`proxy: true`) reuse another column's score until direct ranking data available. Training script copies bench-column scores onto every deployed entry referencing that column rather than averaging columns — that's how scorer can rank `gpt-5` and proxy `claude-opus-4-7` distinctly.
-- `internal/translate` has all three directions (Anthropic ⇄ OpenAI ⇄ Gemini) routed through `RequestEnvelope` intermediate. Streaming decorators in `stream.go` / `gemini_stream.go` translate SSE events on fly. `proxy.Service` is only caller of `translate`.
-- **`internal/providers/google` ships native Generative Language REST client** (`NativeClient` against `https://generativelanguage.googleapis.com/v1beta/models/{model}:generateContent`). OpenAI-compat surface at `/v1beta/openai` does **not** preserve opaque `thought_signature` field that multi-turn tool use against Gemini 3.x preview models requires, so native client is mandatory for those flows. Auth via `x-goog-api-key` header. Old OpenAI-compat path remains in file but no longer wired into `main.go`.
-- `internal/providers/openaicompat` = generic OpenAI Chat Completions adapter, used today for OpenRouter (`https://openrouter.ai/api/v1`) + Fireworks (`https://api.fireworks.ai/inference/v1`). New OpenAI-compatible upstreams (vLLM, Together, DeepInfra, customer-hosted) should plug in here under new provider-name constant rather than getting own adapter package.
-- `internal/providers/noop` = placeholder client returning `providers.ErrNotImplemented`. Use when wiring new `availableProviders` key whose adapter hasn't landed yet so cluster scorer can already filter against it.
-
-**What is load-bearing:**
-
-- **Training script is only writer of `rankings.json`.** Hand-editing breaks cluster geometry guarantee (`scorer.go`'s sorted-candidate ordering must match what training produced). Re-run `train_cluster_router.py` after touching `model_registry.json` + commit regenerated artifact.
-- **Cluster scorer is availability-aware at boot, not request time.** Filter happens in `NewScorer`; runtime argmax unchanged. Empty filtered set = hard boot error so misconfigured deploys fail loud.
-- **Anthropic-only fields (`thinking`, `cache_control`, `metadata`, Anthropic beta headers) stripped at translation time + again defensively in OpenAI / openaicompat adapters.** Keep both checks — belt-and-suspenders intentional because field set drifts as Anthropic adds beta features.
-
-**What to NOT do:**
-
-- **Don't bypass provider filter.** If need to route to provider whose key isn't registered (and not reachable via BYOK or client passthrough), register provider — don't add special-case path that ignores `availableProviders`.
-- **Don't add bench-column averaging back to training script.** 1:1 mapping is the point. Two entries that share column copy same score; they don't average across columns.
-- **Don't route Gemini 3.x preview tool-use through OpenAI-compat surface.** Loses `thought_signature` and second turn 400s. Use `google.NewNativeClient` (already wired default).
-- **Don't add per-installation provider preference yet.** Deploy-time env config + cluster scorer's per-prompt argmax cover v1 use cases; per-installation routing = follow-up PR with DB migration on `model_router_installations`.
-
-## Cache-aware turn routing (planner / handover / session pin / cache)
-
-Proxy's per-turn flow is more than "scorer → dispatch". Pinned session, planner verdict, optional handover summary, semantic response cache all sit between inbound request and upstream provider. Packages intentionally small + single-purpose so each unit-testable without others.
-
-**Packages:**
-
-- [`internal/router/sessionpin`](internal/router/sessionpin) — `Pin` type + `Store` interface for sticky per-session routing. Keyed by `(api_key_id, session_key, role)` where `session_key` = 16-byte sha256 truncation derived from inbound request (see [`internal/proxy/session_key.go`](internal/proxy/session_key.go)). Stage 1 emits `role="default"` only; column exists so turn-type detector can land role-conditioned pinning without schema change. Postgres adapter in `internal/postgres/`; `runSessionPinSweep` in `main.go` runs TTL sweep loop.
-- [`internal/router/turntype`](internal/router/turntype) — classifies inbound requests into `MainLoop`, `ToolResult`, `SubAgentDispatch`, `Compaction`, `Probe`. Used by proxy to short-circuit to session pin on tool-result turns (whose embeddings are mostly noise), force Haiku on compaction turns, bypass routing entirely on probe turns. Pure, no I/O.
-- [`internal/router/capability`](internal/router/capability) — hand-maintained `Tier` table (Low / Mid / High) for each deployed model. Used by planner to overturn cost-driven "stay" when fresh decision is in strictly higher capability tier than pin. `Validate()` called at boot so any deployed model missing tier entry fails build loudly rather than silently bypassing guard.
-- [`internal/router/pricing`](internal/router/pricing) — per-model USD pricing + per-model cache-read multipliers (Anthropic 0.10, OpenAI 0.50, Gemini 0.25, DeepSeek 0.10; `DefaultCacheReadMultiplier = 0.5` for unspecified). Pure data + lookup helpers; OTel layer also reads this so cost attributes on spans can't drift from what planner used.
-- [`internal/router/planner`](internal/router/planner) — Prism-style cache-aware EV policy. Per turn, decides STAY (preserve pinned model's upstream prompt cache) vs SWITCH (take cluster scorer's fresh decision + eat one-time cache miss). Math compares expected per-turn savings over remaining horizon against eviction cost of warming new cache; tier-upgrade guard fires when STAY would clearly under-serve prompt. Pure function of `(pin, fresh decision, estimated tokens, available models)`; no I/O.
-- [`internal/router/handover`](internal/router/handover) — `Summarizer` interface + envelope-rewrite helpers. When planner decides SWITCH, proxy asks small model to summarize prior conversation + rewrites message history to `[synthesizedSummary, latestUser]` before dispatching to new model. Bounds switch turn's input cost regardless of session length. Provider-backed implementation in `internal/proxy/handover.go`; inner-ring package only defines contract. On summarizer timeout or error, proxy falls back to `handover.TrimLastN`.
-- [`internal/router/cache`](internal/router/cache) — cross-request semantic response cache. Short-circuits near-duplicate non-streaming requests by cosine similarity on cluster scorer's prompt embedding; captured wire-format bytes replayed without invoking upstream. Per-(installation, inbound-format) isolation, since captured bytes are post-translation. Streaming bypasses cache entirely. `buildSemanticCache` in `main.go` constructs singleton.
-
-**What's load-bearing:**
-
-- **Planner is pure function.** Inputs = pin row, fresh `router.Decision`, estimated token count, available-model set resolved at boot. No DB lookups, no provider calls. Tests cover EV math without spinning anything up.
-- **Capability tiers hand-maintained.** Deriving from price rejected because would silently move models on every pricing change. Every deployed model must have entry in `capability.Table`; `Validate()` enforces at boot.
-- **Cache-read multipliers per-provider, not global.** Single global multiplier makes cross-provider switches (opus → gpt-5) economically wrong. Read multipliers via `pricing.Pricing.EffectiveCacheReadMultiplier`, never bare struct field.
-- **Session-pin store interface in inner ring; impl in `internal/postgres`.** Proxy service unit-tested with in-memory fake (`internal/proxy/service_test.go`); Postgres adapter exercised end-to-end via docker-compose stack.
-- **`OnUpstreamMeta` callbacks** let provider adapters report streaming usage back to proxy without coupling provider packages to proxy internals. Pricing / planner stack depends on per-turn token counts being recorded promptly; don't add provider that forgets to call callback.
-
-**What to NOT do:**
-
-- **Don't move provider-call logic into planner.** Planner must remain pure so we can prove correctness of EV math. Anything needing network call goes in `proxy.Service`.
-- **Don't add handover path that doesn't time out.** Summarizer contract says implementations MUST respect context deadline. Falling back to `TrimLastN` on timeout is correct, not a bug; do not "fix" by waiting longer.
-- **Don't cache streaming responses.** Streaming bypasses cache on purpose — captured bytes would be post-translation SSE frames + lookup latency budget is hostile to first-token-time. If you think we should change, write a doc first.
-- **Don't put pricing data in two places.** `pricing.Pricing` is single source of truth. OTel emitter + planner both read same map.
-
-## Anthropic usage-bypass gate
-
-[`internal/proxy/usage`](internal/proxy/usage) tracks most recent Anthropic unified rate-limit utilization (same data `claude /usage` CLI reads off `anthropic-ratelimit-unified-{5h,weekly}-*` response headers).
-
-When `ROUTER_USAGE_BYPASS_ENABLED=true`, requests whose recorded 5h + weekly utilization are both below `ROUTER_USAGE_BYPASS_THRESHOLD` (default `0.95`) pass straight through to Anthropic with requested model — no cluster routing, no planner verdict. Once either window crosses threshold, gate disengages for that credential + cluster scorer takes over. Observations expire after `ROUTER_USAGE_OBSERVATION_TTL` (default 10 minutes); torn-down key or long idle period falls back to "cold start = bypass" rather than pinning gate open on stale near-100% reading.
-
-Observer is pure in-memory state with no persistence; entries keyed by `usage.CredentialKey` (salted hash of upstream API key bytes) so logs + metrics never see raw token. Periodic sweep bounds memory by evicting expired entries.
-
-Gate exists because Anthropic-plan customers (Claude Code's logged-in flow) want unused quota spent on Anthropic, not silently redirected to cheaper substitute, until actually approaching cap.
-
 ## Deployment modes
 
 `ROUTER_DEPLOYMENT_MODE` read at boot in `cmd/router/main.go`:
@@ -342,30 +176,22 @@ Gate exists because Anthropic-plan customers (Claude Code's logged-in flow) want
 
 When adding new endpoint, put inside `selfhosted` block in `server.Register` unless part of product surface (`/v1/*`, `/v1beta/*`, `/health`, `/validate`). Do not re-expose admin surface in managed mode.
 
-## Eval harness (router/eval/)
+## Eval harness (sibling `router-internal/eval/`)
 
-Phase 1a's go/no-go gate. Sibling Poetry package to `router/scripts/`, runs as Modal app (`modal_app.py`); see [`eval/README.md`](eval/README.md).
+The eval harness is a sibling Poetry package, **not in this repo** — lives at `router-internal/eval/` in the WorkWeave monorepo and runs as a Modal app. It exercises the router via staging headers; see that package's README.
 
-**Per-request router selection:**
+**Per-request router selection (server side):**
 
-- `internal/server/middleware.WithClusterVersionOverride` reads `x-weave-cluster-version: v0.X` header + stashes version on request context. `cluster.Multiversion.Route` reads via `cluster.VersionFromContext` + dispatches to matching `Scorer`. Customer traffic (no header) always serves deployment's default version (`ROUTER_CLUSTER_VERSION` → `artifacts/latest`).
-- `internal/server/middleware.WithEmbedOnlyUserMessageOverride` honors `x-weave-embed-only-user-message: true|false` header, flipping proxy between embedding user-role text only (default) + concatenated turn stream. Used for orthogonal feature-extraction A/Bs against artifact-version axis.
-- Eval harness names cluster routers as `vX.Y-cluster` — any committed artifact directory under `internal/router/cluster/artifacts/` reachable by name, no Python Literal updates needed. `eval/types.py::CLUSTER_ROUTER_PATTERN` is regex; `parse_cluster_router` returns `(version, last_user_flag)` + `routing.py` translates into two staging headers.
+- [`internal/server/middleware`](internal/server/middleware).`WithClusterVersionOverride` reads `x-weave-cluster-version: v0.X` header + stashes version on request context. `cluster.Multiversion.Route` reads via `cluster.VersionFromContext` + dispatches to matching `Scorer`. Customer traffic (no header) always serves deployment's default version (`ROUTER_CLUSTER_VERSION` → `artifacts/latest`).
+- `WithEmbedOnlyUserMessageOverride` honors `x-weave-embed-only-user-message: true|false` header, flipping proxy between embedding user-role text only (default) + concatenated turn stream.
 
 **What to NOT do:**
 
 - **Do NOT re-introduce heuristic-vs-cluster A/B switch.** Heuristic retired because silent-fallback behavior masked cluster regressions. If need to compare strategies, ship alternate strategy as another `internal/router/X` package + promote on own merits, not as runtime fallback.
-- **Do NOT add runtime override that picks specific model directly.** Whole point is comparing *router strategies*, not per-request model overrides — different feature (P1, see `docs/plans/archive/CLUSTER_ROUTING_PLAN.md` open questions).
+- **Do NOT add runtime override that picks specific model directly.** Whole point is comparing *router strategies*, not per-request model overrides.
 
-## Quick reference for common questions
+## Quick reference
 
-- **"Where does feature X go?"** Pick by responsibility:
-  - Identity / API-key → method on `*auth.Service`.
-  - Routing / dispatch / cross-format proxying / per-turn orchestration → method on `*proxy.Service`.
-  - Wire-format conversion (no I/O) → function in `internal/translate/`.
-  - Pure routing-policy math (EV, tier, pricing) → new helper in matching `internal/router/<name>/` inner-ring subpackage, never proxy service.
-  Add new repo interface method (if touches DB) + adapter impl. Handler just adapts HTTP.
-- **"Should this be in `auth`/`proxy`/`translate`/`config`/`observability` or in package that uses it?"** In package that uses it, unless 3+ packages need same logic. Shared homes not catch-alls.
-- **"How do I add new OpenAI-compatible upstream?"** Add `*BaseURL` constant to `internal/providers/openaicompat`, provider-name constant + env-var entry to `internal/providers/provider.go`, registration block in `cmd/router/main.go`. No new adapter package.
 - **"Should I commit `internal/sqlc/`?"** Yes. Dockerfile + CI builds depend on generated code being present. Run `make generate` before committing migration or query changes.
 - **"How do I run one-off query against local DB?"** `docker compose exec postgres psql -U router -d router`. Migrate step has already applied schema. (Router lives in `router` schema; pool's `AfterConnect` hook pins `search_path` so accidental writes to `public.*` are impossible.)
+- **"How do I add new OpenAI-compatible upstream?"** Add `*BaseURL` constant to `internal/providers/openaicompat`, provider-name constant + env-var entry to `internal/providers/provider.go`, registration block in `cmd/router/main.go`. No new adapter package. See [internal/providers/CLAUDE.md](internal/providers/CLAUDE.md).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 > **Mirror notice.** Verbatim sync with [AGENTS.md](AGENTS.md). Claude Code reads `CLAUDE.md`; Cursor + generic agents read `AGENTS.md`. **Update both together** — divergence = bug.
 
-Instructs AI agents in `router/` subproject. Covers router-specific layering + design conventions. First read for any task: [README](README.md), then this file.
+Root guide for AI agents in the `router/` subproject. Covers cross-cutting design + the layer model. **First read for any task:** [README](README.md), then this file. Then read the `CLAUDE.md` inside the package you're editing — each subpackage has its own with focused recipes + invariants.
 
 ## Engineering principles
 
@@ -88,90 +88,33 @@ Three concentric layers. Imports flow inward only.
 - **Small utility third-party libs allowed at every layer.** Layering = about *where I/O and behavior live*, not banning go.mod entries. Reach for vetted small lib (`golang-lru`, `uuid`, error helpers) before rolling own. Reject heavyweight frameworks (DI containers, ORMs, metaprogramming kits).
 - **Inner-ring packages are I/O-free.** `internal/router`, `internal/providers`, `internal/translate`, `internal/sse`, `internal/router/{cache,capability,handover,planner,pricing,sessionpin,turntype}`, `internal/proxy/usage` define interfaces, value types, pure functions only. Adding I/O method (HTTP, DB, queue, FS) = layering violation; put on `auth.Service` / `proxy.Service` or adapter subpackage. Pure-Go utility libs fine.
 - **Adapters depend only on inner ring.** `internal/postgres` may also import `internal/sqlc`. Adapters never import each other — `internal/postgres` doesn't know `internal/api/admin` etc. Note: provider adapters (`internal/providers/<name>/`) import `internal/proxy` for `OnUpstreamMeta` callback so streaming responses record usage/headers back to proxy — one of few inward-pointing adapter→inner-ring imports, intentional.
-- **`internal/api/*` and `internal/server`** depend on `internal/auth` (Service handle + middleware-context types) and `internal/proxy` (routing/dispatch service handle). May import `internal/observability` for logging, `internal/providers` for shared sentinel errors, `internal/router/cluster` for `ErrClusterUnavailable` sentinel + `DeployedModelsSource` interface (API handlers map sentinel → HTTP 503). Must not import `internal/postgres`, any concrete `internal/providers/*` adapter, or `internal/translate` directly. Concrete instances reach presentation only via constructor params from composition root. (`internal/router/heuristic` and `internal/router/evalswitch` previously lived here; both removed when heuristic fallback retired in favor of `cluster.ErrClusterUnavailable` → HTTP 503.)
+- **`internal/api/*` and `internal/server`** depend on `internal/auth` (Service handle + middleware-context types) and `internal/proxy` (routing/dispatch service handle). May import `internal/observability` for logging, `internal/providers` for shared sentinel errors, `internal/router/cluster` for `ErrClusterUnavailable` sentinel + `DeployedModelsSource` interface (API handlers map sentinel → HTTP 503). Must not import `internal/postgres`, any concrete `internal/providers/*` adapter, or `internal/translate` directly. Concrete instances reach presentation only via constructor params from composition root.
 - **`internal/config` and `internal/observability` are leaf utilities** — must not import any other package under `internal/`. Third-party utility deps fine; today pull only stdlib + gin (request-scoped logger middleware). `internal/observability/otel` subpackage *is* an adapter (builds real OTLP exporter) and can import other internal packages; parent `internal/observability` stays a leaf.
-- **Composition happens in `cmd/router/main.go`.** Only file that constructs concrete adapters + injects them. No other place wires things. Keep `main.go` focused on wiring; helpers today: `buildClusterScorer` (per-version Scorer assembly + embedder warmup), `buildSemanticCache` (response-cache assembly), `buildOtelEmitter` (OTel span exporter), `runSessionPinSweep` (TTL sweep loop), `resolveHardPinModel` / `resolveDefaultBaselineModel` / `resolveAvailableModels` (boot-time model resolution), small env parsers. No more heuristic-fallback router — if cluster routing fails to boot, `main.go` panics.
+- **Composition happens in `cmd/router/main.go`.** Only file that constructs concrete adapters + injects them. No other place wires things. See [`cmd/CLAUDE.md`](cmd/CLAUDE.md).
 
 If wanting to import something that violates these rules, design is wrong — surface as interface in appropriate inner-ring package and implement in adapter subpackage.
 
-## Adding code — step-by-step recipes
+## Where to put new code
 
-### Adding an HTTP endpoint
+Pick by responsibility, then read that package's `CLAUDE.md`:
 
-1. **Decide timeout budget.** Cheap auth-only ops use `validateTimeout` / `healthTimeout` (1 s). Provider calls get own constant in [`server.go`](internal/server/server.go) — pick budget + justify in comment.
-2. **Decide auth.** Routes needing valid `rk_` bearer go through `middleware.WithAuth(authSvc)`. Admin endpoints use `WithAdminOrAuth` (admin cookie OR bearer) or `WithAdminOnly` (admin cookie only). Unauthed routes (e.g. `/health`) attach no auth middleware.
-3. **Decide if self-hoster dashboard surface.** `/ui/*` static dashboard, `/admin/v1/auth/*`, `/admin/v1` mgmt group (metrics, keys, provider-keys, config, excluded-models) mount only when `mode == server.DeploymentModeSelfHosted`. New endpoints whose only consumer is self-hosted dashboard go inside that block; product-surface endpoints (`/v1/*`, `/v1beta/*`, `/health`, `/validate`) stay outside so available in `managed` mode too. **Do not** add new `/admin/v1/*` route outside selfhosted block — would re-expose redundant control plane on Weave-managed deploys.
-4. **Pick (or create) right `internal/api/<group>/` subpackage.** Operational endpoints → `internal/api/admin/`; Anthropic Messages surface → `internal/api/anthropic/` (also hosts `/v1/route` for routing introspection + passthrough endpoints); OpenAI Chat Completions → `internal/api/openai/`; Gemini native `:generateContent` / `:streamGenerateContent` → `internal/api/gemini/`. New surfaces get own subpackage.
-5. **Use `observability.FromGin(c)` for request-scoped logger.** If need authed installation: `middleware.InstallationFrom(c)` (nil if `WithAuth` not applied — handler should be on authed group). For BYOK secrets attached to request: `middleware.ExternalAPIKeysFrom(c)`.
-6. **Pick right service.** Identity-only ops → `*auth.Service`. Routing/dispatch/translate → `*proxy.Service`. Don't touch repositories, router, providers, planner/handover/cache packages from handler. Handler adapts HTTP ↔ service; service does the work.
-7. **Test with in-memory fakes + gin testing harness** (`httptest.NewRequest`/`ResponseRecorder`). No real DB for handler tests — use fakes from [`internal/auth/service_test.go`](internal/auth/service_test.go) and [`internal/proxy/service_test.go`](internal/proxy/service_test.go) as model.
+| Responsibility | Package | Guide |
+|---|---|---|
+| HTTP endpoint (handler + route) | `internal/api/<group>/` | [internal/api/CLAUDE.md](internal/api/CLAUDE.md) |
+| Identity / API-key logic | `internal/auth` (method on `*Service`) | [internal/auth/CLAUDE.md](internal/auth/CLAUDE.md) |
+| Routing / dispatch / per-turn orchestration | `internal/proxy` (method on `*Service`) | [internal/proxy/CLAUDE.md](internal/proxy/CLAUDE.md) |
+| Cross-format wire conversion (no I/O) | `internal/translate` | [internal/translate/CLAUDE.md](internal/translate/CLAUDE.md) |
+| New upstream provider | `internal/providers/<name>/` | [internal/providers/CLAUDE.md](internal/providers/CLAUDE.md) |
+| New `Router` implementation | `internal/router/<name>/` | [internal/router/CLAUDE.md](internal/router/CLAUDE.md) |
+| Cluster scorer / artifacts | `internal/router/cluster/` | [internal/router/cluster/CLAUDE.md](internal/router/cluster/CLAUDE.md) |
+| Cache-aware turn routing internals | `internal/router/{planner,handover,cache,sessionpin,pricing,capability,turntype}/` | each has its own CLAUDE.md |
+| Anthropic usage-bypass gate | `internal/proxy/usage` | [internal/proxy/usage/CLAUDE.md](internal/proxy/usage/CLAUDE.md) |
+| New column / SQL query | `db/queries/` + `internal/postgres/` | [db/CLAUDE.md](db/CLAUDE.md), [internal/postgres/CLAUDE.md](internal/postgres/CLAUDE.md) |
+| Doc under `docs/` | `docs/` | [docs/CLAUDE.md](docs/CLAUDE.md) |
 
-### Adding a method to a Service
+**Default rule:** put logic in the package that uses it. Only promote to a shared home (`auth`, `proxy`, `translate`, `config`, `observability`, `sse`) when 3+ packages need the same logic.
 
-Pick service first:
-
-- **Identity / API-key** → `*auth.Service` in [`internal/auth/service.go`](internal/auth/service.go).
-- **Routing / dispatch / cross-format proxying / planner integration** → `*proxy.Service` in [`internal/proxy/service.go`](internal/proxy/service.go).
-
-Then:
-
-1. **Define method on chosen `*Service`.** No I/O directly here — push into repo or provider adapter. Inner-ring imports (`router`, `providers`, `translate`, `observability`, `internal/router/*` helper packages, `internal/proxy/usage`) + small utility libs fine.
-2. **If need new repo methods, add to interfaces in [`installation.go`](internal/auth/installation.go) / [`api_key.go`](internal/auth/api_key.go) / sibling files.** Interface = contract; adapter must satisfy. `sessionpin.Store` interface in [`internal/router/sessionpin/store.go`](internal/router/sessionpin/store.go), implemented by `postgres.SessionPinRepository`.
-3. **Implement new repo method in [`internal/postgres/repository.go`](internal/postgres/repository.go)** (or sibling in `internal/postgres/`), adding SQLC query in `db/queries/`. Run `make generate` to regenerate `internal/sqlc/`.
-4. **Update matching `service_test.go` fakes** to satisfy expanded interface. Tests for new Service method use fakes; assert on real return values, not just that mocks were called.
-
-### Adding a wire-format pair (translation)
-
-When new inbound format needs to talk to existing upstream provider with different wire format:
-
-1. **Add conversion functions to [`internal/translate/`](internal/translate).** Pure functions only — no I/O, no provider knowledge, no domain types. Package covers all three directions: Anthropic ⇄ OpenAI and Gemini ⇄ {Anthropic, OpenAI} via `RequestEnvelope` intermediate + per-target `emit_*.go` files.
-2. **If response streaming, adapt [`stream.go`](internal/translate/stream.go) / [`gemini_stream.go`](internal/translate/gemini_stream.go)** or add sibling decorator. Decorators wrap `http.ResponseWriter` and translate on the fly so we never buffer entire responses. Use [`internal/sse`](internal/sse) for zero-alloc SSE framing.
-3. **Compose new translation in `proxy.Service.Proxy*`.** Proxy service is only caller of `translate`. Keep providers (`internal/providers/<name>/`) ignorant of cross-format concerns.
-
-### Adding a new `providers.Client` adapter
-
-1. **Create `internal/providers/<name>/client.go`** with `Client` struct + `NewClient(...)` constructor taking credentials (typically API key string + base URL). For OpenAI-compatible upstreams (vLLM, Together, DeepInfra, customer endpoints), prefer adding sibling `*BaseURL` constant in [`internal/providers/openaicompat`](internal/providers/openaicompat) over new adapter — openaicompat client already covers OpenRouter + Fireworks under own provider keys.
-2. **Implement `Proxy` and `Passthrough`.** Adapter translates prepared request body to provider's wire format, sends with pooled `http.Client` (use `httputil.NewTransport` and `httputil.StreamBody` from `internal/providers/httputil/`), streams response back. Adapters call into `proxy.OnUpstreamMeta` when they observe usage/header data to record. Do not leak provider-specific types across package boundary.
-3. **Add compile-time check:** `var _ providers.Client = (*Client)(nil)`
-4. **Add canonical name constant** to [`internal/providers/provider.go`](internal/providers/provider.go) (the `Provider*` block) + register matching env-var name in `APIKeyEnvVars`. Today's wired keys: `"anthropic"`, `"openai"`, `"google"`, `"openrouter"`, `"fireworks"`. Composition root reads `APIKeyEnvVars` so admin `/config` view can't drift from actual wiring.
-5. **Wire in `cmd/router/main.go`.** Only place that imports provider package directly. Provider must be added to `providerMap` regardless of mode; `envKeyedProviders` (parallel set) tracks which providers have deployment-level key configured so hard-pin resolver knows what's safe to pin to. Managed-mode deploys register every provider with empty key + rely exclusively on BYOK / client-supplied auth.
-
-### Adding a new `router.Router` implementation
-
-1. **Create sibling subpackage to `internal/router/cluster/`.** Today `cluster/` (AvengersPro, with `Multiversion` wrapper for per-request bundle selection) is only `Router` impl in prod. New ones might be e.g. `internal/router/shadow/` wrapping two others.
-2. **Implement `Route(ctx, router.Request) (router.Decision, error)`.**
-3. **Add compile-time check:** `var _ router.Router = (*X)(nil)`.
-4. **Wire in `cmd/router/main.go`** (replacing or wrapping cluster scorer as needed).
-5. **If impl needs CGO or external libs**, follow build-tag pattern in `cluster/embedder_onnx.go` + `embedder_stub.go` so contributors without library can still `go test` locally.
-6. **Failure modes return errors, not silent fallbacks.** Cluster scorer's `ErrClusterUnavailable` → HTTP 503 pattern is the model: silent fallback to default model masks regressions + lets quality silently degrade in eval + prod.
-
-### Adding a column or query
-
-1. **Migration first.** Add `db/migrations/NNNN_<name>.up.sql` + `.down.sql` in sequential numbering. Wrap in `BEGIN`/`COMMIT`. Down migration must be precise rollback — no `IF EXISTS` guards.
-2. **Add query** to appropriate `db/queries/<table>.sql`. Use named params with type casts (`@param::varchar`). Use `sqlc.embed(t)` for JOINs.
-3. **Run `make generate`** to regenerate `internal/sqlc/`. Commit generated code alongside changes.
-4. **Update [`internal/postgres/repository.go`](internal/postgres/repository.go)** (and [`converters.go`](internal/postgres/converters.go) if new column needs domain mapping). Domain types (`auth.Installation`, `auth.APIKey`, `sessionpin.Pin`) must not leak `pgtype` / `uuid` concerns — convert at adapter boundary.
-
-### Adding a doc under `docs/`
-
-Every Markdown doc under `router/docs/` (active or archived) indexed in [`docs/README.md`](docs/README.md). When adding new doc, same change must update index — drift between doc tree and index = bug.
-
-1. **Top of new file:** include standard two-line header before H1:
-
-   ```
-   Created: YYYY-MM-DD
-   Last edited: YYYY-MM-DD
-   ```
-
-   `Created` date is load-bearing — `docs/README.md` orders TOC by it. Don't backdate; if doc takes multiple days, leave `Created` on day it first landed and bump `Last edited` as it changes.
-
-2. **Append row to [`docs/README.md`](docs/README.md)** in correct section (Active or Archived), keeping each table sorted by `Created` ascending. Write one- or two-sentence summary covering what doc is for and (for archived) why archived plus link to active replacement.
-
-3. **If archiving active doc:** move row from active table to archived with short reason, mirror entry in [`docs/plans/archive/README.md`](docs/plans/archive/README.md). Move file with `git mv` so history follows.
-
-4. **Renaming or deleting doc:** update both this rule's index and inbound links. `grep -rn 'old/path' router/` before merging.
-
-### Adding a new helper
+## Adding a new helper
 
 Don't, unless same logic needed in 3+ places and no plausible existing home. Canonical homes:
 
@@ -204,19 +147,6 @@ If new helper doesn't fit, justify new package in code comment before creating.
 - In-memory fakes for repos/routers/provider clients are cheap + far better than mocks for unit testing Service.
 - No DB-backed integration tests in `internal/`. If need real Postgres, `docker compose` stack is runtime fixture; write scripts under `scripts/` rather than `*_test.go`.
 
-### SQL and migrations
-
-- Always named params (`@param::varchar`), never numbered (`$1`).
-- Always include type casts so SQLC inference unambiguous.
-- Query names use consistent prefixes: `Insert*`, `Upsert*`, `Get*`, `Update*`, `Delete*`.
-- Every query gets explanatory comment (SQLC turns into godoc on generated function).
-- No-rows single-row queries return error — check `errors.Is(err, sql.ErrNoRows)`.
-- Always wrap migrations in `BEGIN; ... COMMIT;`.
-- Never create migration files manually — use `make migrate-create NAME=<name>`.
-- Down migrations must be precise rollbacks. No `IF EXISTS` guards. Don't separately drop indexes when dropping tables.
-- `organization_id` + `created_by` = opaque external identifiers — never add foreign keys to tables outside router's own schema.
-- Soft-delete via `deleted_at TIMESTAMP` on tables needing lifecycle. Hot-path queries filter `WHERE deleted_at IS NULL`.
-
 ### Logging
 
 - Log message explains in plain English what happened. Include `err` + relevant context (IDs, counts, status codes).
@@ -237,102 +167,6 @@ If new helper doesn't fit, justify new package in code comment before creating.
 - **Never log secrets, raw API keys, or full request bodies.** First 8 + last 4 chars on `auth.APIKey` are safe form. BYOK secrets at rest go through `auth.Encryptor` (Tink AES-256-GCM); plaintext only in memory for request lifetime.
 - **Never edit generated files** under `internal/sqlc/`. Regenerate with `make generate`. SQLC's "DO NOT EDIT" header is load-bearing.
 
-## Cluster routing (P0)
-
-`internal/router/cluster` = AvengersPro-derived primary router (arxiv 2508.12631, DAI 2025). Full design in [`docs/plans/archive/CLUSTER_ROUTING_PLAN.md`](docs/plans/archive/CLUSTER_ROUTING_PLAN.md); this section is rules-for-AI subset.
-
-**What's load-bearing:**
-
-- Package compiles in **two layered modes via build tags**:
-  - `embedder_onnx.go` vs `embedder_stub.go` — gated by `no_onnx`. Default builds compile real hugot-backed embedder; `-tags=no_onnx` swaps in stub `NewEmbedder` that always errors. Used by contributors without `libonnxruntime`.
-  - `-tags ORT` — required by **hugot v0.7+** to enable ONNX Runtime backend. Without it, `hugot.NewORTSession` returns "to enable ORT, run `go build -tags ORT`" and `cluster.NewEmbedder` fails. Dockerfile builds with `-tags ORT`. **Do not drop this tag from any production-bound build.**
-  - To run parity integration test, combine: `-tags "onnx_integration ORT"`.
-- Local-dev build env (Apple Silicon):
-  - `libtokenizers` static lib must be on linker path. Pre-built releases at https://github.com/daulet/tokenizers/releases/. Extract `libtokenizers.darwin-arm64.tar.gz` somewhere user-writable + set `CGO_LDFLAGS=-L/path/to/dir`.
-  - `libonnxruntime` shared lib via `brew install onnxruntime`. brew installs to `/opt/homebrew/lib`, hugot defaults to `/usr/local/lib` lookup. Set `ROUTER_ONNX_LIBRARY_DIR=/opt/homebrew/lib` to override. (Linux containers using Dockerfile don't need this — `/usr/lib/libonnxruntime.so` is default, populated by runtime stage.)
-- **Versioned artifacts.** Every committed bundle lives at `internal/router/cluster/artifacts/v<X.Y>/` with four files: `centroids.bin`, `rankings.json`, `model_registry.json`, `metadata.yaml`. `artifacts/latest` pointer file (single line, e.g. `v0.37`) names version runtime serves by default; `ROUTER_CLUSTER_VERSION` env overrides. Promotion = one-line edit to `latest` + redeploy. Committed history spans v0.21 through current `latest` — earlier pruned once they fell out of eval comparison.
-- Go runtime builds **only served default version** by default (`cmd/router/main.go`'s `buildClusterScorer`). Setting `ROUTER_CLUSTER_BUILD_ALL_VERSIONS=true` switches to building **one Scorer per committed bundle** so callers can pin per-request to sibling version with `x-weave-cluster-version: v0.X` via `middleware.WithClusterVersionOverride`. "Compare-against-each-other" mechanism — staging/eval deploys set flag so single deploy carries every committed bundle + eval harness flips between them per-request. Prod leaves flag off: only default bundle loaded into memory, header override is no-op.
-- **Centroids/rankings are write-once.** `train_cluster_router.py` always writes to `artifacts/v<X.Y>/` and never overwrites previous version (auto-bumps from `latest` when `--version` omitted). Pass `--from v0.36` to clone previous version's `model_registry.json` before training new one. **Never edit `centroids.bin` / `rankings.json` by hand.** `model_registry.json` is only hand-editable file in a bundle (training script reads it).
-- `metadata.yaml` is informational at runtime — carries version changelog, training params, deployed models, α-blend cost values. Go runtime parses for `/health`-style provenance; eval harness reads offline. Keep accurate but does not affect routing decisions.
-- `assets/model.onnx` is **NOT in git.** Use Jina's own INT8 export at `jinaai/jina-embeddings-v2-base-code`, file path `onnx/model_quantized.onnx`. Dockerfile pulls anonymously during build (Jina repo public — self-hosters don't need creds); local dev pulls via `scripts/download_from_hf.py`. `HF_TOKEN` build secret is *optional* (raises rate limits in CI) + `required=false` in Dockerfile. Go embedder reads from `/opt/router/assets/model.onnx` (override via `ROUTER_ONNX_ASSETS_DIR`). If missing or <1 MiB, `cluster.NewEmbedder` errors at boot + `main.go` panics — router refuses to start rather than silently degrading. `HF_MODEL_REVISION` pinned to Jina SHA by default; bump deliberately to pick up new upstream export.
-- **Cost values** used in α-blend live in `train_cluster_router.py`'s `DEFAULT_COST_PER_1K_INPUT`. Baked into `rankings.json` at training time, not looked up at request time (paper §3 — runtime scoring is single argmax). When Anthropic changes prices, update dict + rerun training.
-
-**What to NOT do:**
-
-- **Don't add per-request cost lookup or runtime α knob.** α baked at training time; changing requires retraining. Per-request override (`x-weave-routing-alpha`) is P1, not P0 — wait for customer ask before shipping.
-- **Don't loosen `MaxPromptChars = 1024` cap** without re-running latency test. BERT inference is O(n²) attention; cap is load-bearing.
-- **Don't add fail-open fallbacks.** Cluster scorer returns `ErrClusterUnavailable` on every failure path (embed timeout, embed error, dim mismatch, prompt too short, empty argmax). API handlers map to HTTP 503. Previous `heuristic` fallback removed because it silently degraded routing — every request that should have hit cluster scorer instead got `claude-haiku-4-5`, masking real regressions in eval + prod. New failure modes return sentinel; no default-model shortcut "for safety".
-- **Don't change centroid format without bumping magic string.** `loadCentroids` uses magic + version header to refuse mismatched binaries; if layout changes, bump `centroidsMagic` from `CRT1` to `CRT2` so next deploy refuses old binary instead of silently misrouting.
-- **Don't overwrite previously committed artifact version.** Versions frozen for comparison — once `v0.37` committed, train to `v0.38` rather than re-running `train_cluster_router.py` against `v0.37`. Training script auto-bumps; only override with `--version v0.X` for in-place fixes intended to land as separate commit.
-- **Don't bypass version pointer.** `artifacts/latest` is single source of truth for default served version. Don't hardcode version in `cmd/router/main.go`; let `cluster.ResolveVersion` read pointer.
-
-
-## Multi-provider routing (Anthropic / OpenAI / Google / OpenRouter / Fireworks)
-
-Router serves five vendor pools from one composition root. Single routing decision picks `(Provider, Model)` + proxy dispatches accordingly. Cross-format translation lives in `internal/translate` so handlers never juggle wire formats.
-
-**Architecture:**
-
-- `cmd/router/main.go` registers each provider client. In **selfhosted** mode each provider's deployment-level key read from env var (`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `GOOGLE_API_KEY`, `OPENROUTER_API_KEY`, `FIREWORKS_API_KEY`); missing key keeps provider registered for BYOK / client-passthrough but excludes from `envKeyedProviders` (set hard-pin resolver may pin to). In **managed** mode (`ROUTER_DEPLOYMENT_MODE=managed`) every provider registered unconditionally with empty key + proxy service flipped into BYOK-only mode — request without BYOK or client-supplied creds for chosen provider 400s at scorer rather than silently spending platform budget on customer traffic. Single source of truth for provider→env-var mapping = `providers.APIKeyEnvVars` in [`internal/providers/provider.go`](internal/providers/provider.go).
-- `cluster.NewScorer` filters `model_registry.json`'s `deployed_models` list to entries whose `provider` is in `availableProviders`. argmax runs over filtered list, so deploy without OpenRouter key cannot accidentally emit `deepseek-*` decision.
-- `model_registry.json` = flat list of `{model, provider, bench_column, proxy?, proxy_note?}` entries. Direct columns are 1:1 with OpenRouterBench; proxy entries (`proxy: true`) reuse another column's score until direct ranking data available. Training script copies bench-column scores onto every deployed entry referencing that column rather than averaging columns — that's how scorer can rank `gpt-5` and proxy `claude-opus-4-7` distinctly.
-- `internal/translate` has all three directions (Anthropic ⇄ OpenAI ⇄ Gemini) routed through `RequestEnvelope` intermediate. Streaming decorators in `stream.go` / `gemini_stream.go` translate SSE events on fly. `proxy.Service` is only caller of `translate`.
-- **`internal/providers/google` ships native Generative Language REST client** (`NativeClient` against `https://generativelanguage.googleapis.com/v1beta/models/{model}:generateContent`). OpenAI-compat surface at `/v1beta/openai` does **not** preserve opaque `thought_signature` field that multi-turn tool use against Gemini 3.x preview models requires, so native client is mandatory for those flows. Auth via `x-goog-api-key` header. Old OpenAI-compat path remains in file but no longer wired into `main.go`.
-- `internal/providers/openaicompat` = generic OpenAI Chat Completions adapter, used today for OpenRouter (`https://openrouter.ai/api/v1`) + Fireworks (`https://api.fireworks.ai/inference/v1`). New OpenAI-compatible upstreams (vLLM, Together, DeepInfra, customer-hosted) should plug in here under new provider-name constant rather than getting own adapter package.
-- `internal/providers/noop` = placeholder client returning `providers.ErrNotImplemented`. Use when wiring new `availableProviders` key whose adapter hasn't landed yet so cluster scorer can already filter against it.
-
-**What is load-bearing:**
-
-- **Training script is only writer of `rankings.json`.** Hand-editing breaks cluster geometry guarantee (`scorer.go`'s sorted-candidate ordering must match what training produced). Re-run `train_cluster_router.py` after touching `model_registry.json` + commit regenerated artifact.
-- **Cluster scorer is availability-aware at boot, not request time.** Filter happens in `NewScorer`; runtime argmax unchanged. Empty filtered set = hard boot error so misconfigured deploys fail loud.
-- **Anthropic-only fields (`thinking`, `cache_control`, `metadata`, Anthropic beta headers) stripped at translation time + again defensively in OpenAI / openaicompat adapters.** Keep both checks — belt-and-suspenders intentional because field set drifts as Anthropic adds beta features.
-
-**What to NOT do:**
-
-- **Don't bypass provider filter.** If need to route to provider whose key isn't registered (and not reachable via BYOK or client passthrough), register provider — don't add special-case path that ignores `availableProviders`.
-- **Don't add bench-column averaging back to training script.** 1:1 mapping is the point. Two entries that share column copy same score; they don't average across columns.
-- **Don't route Gemini 3.x preview tool-use through OpenAI-compat surface.** Loses `thought_signature` and second turn 400s. Use `google.NewNativeClient` (already wired default).
-- **Don't add per-installation provider preference yet.** Deploy-time env config + cluster scorer's per-prompt argmax cover v1 use cases; per-installation routing = follow-up PR with DB migration on `model_router_installations`.
-
-## Cache-aware turn routing (planner / handover / session pin / cache)
-
-Proxy's per-turn flow is more than "scorer → dispatch". Pinned session, planner verdict, optional handover summary, semantic response cache all sit between inbound request and upstream provider. Packages intentionally small + single-purpose so each unit-testable without others.
-
-**Packages:**
-
-- [`internal/router/sessionpin`](internal/router/sessionpin) — `Pin` type + `Store` interface for sticky per-session routing. Keyed by `(api_key_id, session_key, role)` where `session_key` = 16-byte sha256 truncation derived from inbound request (see [`internal/proxy/session_key.go`](internal/proxy/session_key.go)). Stage 1 emits `role="default"` only; column exists so turn-type detector can land role-conditioned pinning without schema change. Postgres adapter in `internal/postgres/`; `runSessionPinSweep` in `main.go` runs TTL sweep loop.
-- [`internal/router/turntype`](internal/router/turntype) — classifies inbound requests into `MainLoop`, `ToolResult`, `SubAgentDispatch`, `Compaction`, `Probe`. Used by proxy to short-circuit to session pin on tool-result turns (whose embeddings are mostly noise), force Haiku on compaction turns, bypass routing entirely on probe turns. Pure, no I/O.
-- [`internal/router/capability`](internal/router/capability) — hand-maintained `Tier` table (Low / Mid / High) for each deployed model. Used by planner to overturn cost-driven "stay" when fresh decision is in strictly higher capability tier than pin. `Validate()` called at boot so any deployed model missing tier entry fails build loudly rather than silently bypassing guard.
-- [`internal/router/pricing`](internal/router/pricing) — per-model USD pricing + per-model cache-read multipliers (Anthropic 0.10, OpenAI 0.50, Gemini 0.25, DeepSeek 0.10; `DefaultCacheReadMultiplier = 0.5` for unspecified). Pure data + lookup helpers; OTel layer also reads this so cost attributes on spans can't drift from what planner used.
-- [`internal/router/planner`](internal/router/planner) — Prism-style cache-aware EV policy. Per turn, decides STAY (preserve pinned model's upstream prompt cache) vs SWITCH (take cluster scorer's fresh decision + eat one-time cache miss). Math compares expected per-turn savings over remaining horizon against eviction cost of warming new cache; tier-upgrade guard fires when STAY would clearly under-serve prompt. Pure function of `(pin, fresh decision, estimated tokens, available models)`; no I/O.
-- [`internal/router/handover`](internal/router/handover) — `Summarizer` interface + envelope-rewrite helpers. When planner decides SWITCH, proxy asks small model to summarize prior conversation + rewrites message history to `[synthesizedSummary, latestUser]` before dispatching to new model. Bounds switch turn's input cost regardless of session length. Provider-backed implementation in `internal/proxy/handover.go`; inner-ring package only defines contract. On summarizer timeout or error, proxy falls back to `handover.TrimLastN`.
-- [`internal/router/cache`](internal/router/cache) — cross-request semantic response cache. Short-circuits near-duplicate non-streaming requests by cosine similarity on cluster scorer's prompt embedding; captured wire-format bytes replayed without invoking upstream. Per-(installation, inbound-format) isolation, since captured bytes are post-translation. Streaming bypasses cache entirely. `buildSemanticCache` in `main.go` constructs singleton.
-
-**What's load-bearing:**
-
-- **Planner is pure function.** Inputs = pin row, fresh `router.Decision`, estimated token count, available-model set resolved at boot. No DB lookups, no provider calls. Tests cover EV math without spinning anything up.
-- **Capability tiers hand-maintained.** Deriving from price rejected because would silently move models on every pricing change. Every deployed model must have entry in `capability.Table`; `Validate()` enforces at boot.
-- **Cache-read multipliers per-provider, not global.** Single global multiplier makes cross-provider switches (opus → gpt-5) economically wrong. Read multipliers via `pricing.Pricing.EffectiveCacheReadMultiplier`, never bare struct field.
-- **Session-pin store interface in inner ring; impl in `internal/postgres`.** Proxy service unit-tested with in-memory fake (`internal/proxy/service_test.go`); Postgres adapter exercised end-to-end via docker-compose stack.
-- **`OnUpstreamMeta` callbacks** let provider adapters report streaming usage back to proxy without coupling provider packages to proxy internals. Pricing / planner stack depends on per-turn token counts being recorded promptly; don't add provider that forgets to call callback.
-
-**What to NOT do:**
-
-- **Don't move provider-call logic into planner.** Planner must remain pure so we can prove correctness of EV math. Anything needing network call goes in `proxy.Service`.
-- **Don't add handover path that doesn't time out.** Summarizer contract says implementations MUST respect context deadline. Falling back to `TrimLastN` on timeout is correct, not a bug; do not "fix" by waiting longer.
-- **Don't cache streaming responses.** Streaming bypasses cache on purpose — captured bytes would be post-translation SSE frames + lookup latency budget is hostile to first-token-time. If you think we should change, write a doc first.
-- **Don't put pricing data in two places.** `pricing.Pricing` is single source of truth. OTel emitter + planner both read same map.
-
-## Anthropic usage-bypass gate
-
-[`internal/proxy/usage`](internal/proxy/usage) tracks most recent Anthropic unified rate-limit utilization (same data `claude /usage` CLI reads off `anthropic-ratelimit-unified-{5h,weekly}-*` response headers).
-
-When `ROUTER_USAGE_BYPASS_ENABLED=true`, requests whose recorded 5h + weekly utilization are both below `ROUTER_USAGE_BYPASS_THRESHOLD` (default `0.95`) pass straight through to Anthropic with requested model — no cluster routing, no planner verdict. Once either window crosses threshold, gate disengages for that credential + cluster scorer takes over. Observations expire after `ROUTER_USAGE_OBSERVATION_TTL` (default 10 minutes); torn-down key or long idle period falls back to "cold start = bypass" rather than pinning gate open on stale near-100% reading.
-
-Observer is pure in-memory state with no persistence; entries keyed by `usage.CredentialKey` (salted hash of upstream API key bytes) so logs + metrics never see raw token. Periodic sweep bounds memory by evicting expired entries.
-
-Gate exists because Anthropic-plan customers (Claude Code's logged-in flow) want unused quota spent on Anthropic, not silently redirected to cheaper substitute, until actually approaching cap.
-
 ## Deployment modes
 
 `ROUTER_DEPLOYMENT_MODE` read at boot in `cmd/router/main.go`:
@@ -342,30 +176,22 @@ Gate exists because Anthropic-plan customers (Claude Code's logged-in flow) want
 
 When adding new endpoint, put inside `selfhosted` block in `server.Register` unless part of product surface (`/v1/*`, `/v1beta/*`, `/health`, `/validate`). Do not re-expose admin surface in managed mode.
 
-## Eval harness (router/eval/)
+## Eval harness (sibling `router-internal/eval/`)
 
-Phase 1a's go/no-go gate. Sibling Poetry package to `router/scripts/`, runs as Modal app (`modal_app.py`); see [`eval/README.md`](eval/README.md).
+The eval harness is a sibling Poetry package, **not in this repo** — lives at `router-internal/eval/` in the WorkWeave monorepo and runs as a Modal app. It exercises the router via staging headers; see that package's README.
 
-**Per-request router selection:**
+**Per-request router selection (server side):**
 
-- `internal/server/middleware.WithClusterVersionOverride` reads `x-weave-cluster-version: v0.X` header + stashes version on request context. `cluster.Multiversion.Route` reads via `cluster.VersionFromContext` + dispatches to matching `Scorer`. Customer traffic (no header) always serves deployment's default version (`ROUTER_CLUSTER_VERSION` → `artifacts/latest`).
-- `internal/server/middleware.WithEmbedOnlyUserMessageOverride` honors `x-weave-embed-only-user-message: true|false` header, flipping proxy between embedding user-role text only (default) + concatenated turn stream. Used for orthogonal feature-extraction A/Bs against artifact-version axis.
-- Eval harness names cluster routers as `vX.Y-cluster` — any committed artifact directory under `internal/router/cluster/artifacts/` reachable by name, no Python Literal updates needed. `eval/types.py::CLUSTER_ROUTER_PATTERN` is regex; `parse_cluster_router` returns `(version, last_user_flag)` + `routing.py` translates into two staging headers.
+- [`internal/server/middleware`](internal/server/middleware).`WithClusterVersionOverride` reads `x-weave-cluster-version: v0.X` header + stashes version on request context. `cluster.Multiversion.Route` reads via `cluster.VersionFromContext` + dispatches to matching `Scorer`. Customer traffic (no header) always serves deployment's default version (`ROUTER_CLUSTER_VERSION` → `artifacts/latest`).
+- `WithEmbedOnlyUserMessageOverride` honors `x-weave-embed-only-user-message: true|false` header, flipping proxy between embedding user-role text only (default) + concatenated turn stream.
 
 **What to NOT do:**
 
 - **Do NOT re-introduce heuristic-vs-cluster A/B switch.** Heuristic retired because silent-fallback behavior masked cluster regressions. If need to compare strategies, ship alternate strategy as another `internal/router/X` package + promote on own merits, not as runtime fallback.
-- **Do NOT add runtime override that picks specific model directly.** Whole point is comparing *router strategies*, not per-request model overrides — different feature (P1, see `docs/plans/archive/CLUSTER_ROUTING_PLAN.md` open questions).
+- **Do NOT add runtime override that picks specific model directly.** Whole point is comparing *router strategies*, not per-request model overrides.
 
-## Quick reference for common questions
+## Quick reference
 
-- **"Where does feature X go?"** Pick by responsibility:
-  - Identity / API-key → method on `*auth.Service`.
-  - Routing / dispatch / cross-format proxying / per-turn orchestration → method on `*proxy.Service`.
-  - Wire-format conversion (no I/O) → function in `internal/translate/`.
-  - Pure routing-policy math (EV, tier, pricing) → new helper in matching `internal/router/<name>/` inner-ring subpackage, never proxy service.
-  Add new repo interface method (if touches DB) + adapter impl. Handler just adapts HTTP.
-- **"Should this be in `auth`/`proxy`/`translate`/`config`/`observability` or in package that uses it?"** In package that uses it, unless 3+ packages need same logic. Shared homes not catch-alls.
-- **"How do I add new OpenAI-compatible upstream?"** Add `*BaseURL` constant to `internal/providers/openaicompat`, provider-name constant + env-var entry to `internal/providers/provider.go`, registration block in `cmd/router/main.go`. No new adapter package.
 - **"Should I commit `internal/sqlc/`?"** Yes. Dockerfile + CI builds depend on generated code being present. Run `make generate` before committing migration or query changes.
 - **"How do I run one-off query against local DB?"** `docker compose exec postgres psql -U router -d router`. Migrate step has already applied schema. (Router lives in `router` schema; pool's `AfterConnect` hook pins `search_path` so accidental writes to `public.*` are impossible.)
+- **"How do I add new OpenAI-compatible upstream?"** Add `*BaseURL` constant to `internal/providers/openaicompat`, provider-name constant + env-var entry to `internal/providers/provider.go`, registration block in `cmd/router/main.go`. No new adapter package. See [internal/providers/CLAUDE.md](internal/providers/CLAUDE.md).

--- a/cmd/AGENTS.md
+++ b/cmd/AGENTS.md
@@ -1,0 +1,35 @@
+# cmd — AGENTS
+
+> **Mirror notice.** Verbatim sync with [CLAUDE.md](CLAUDE.md). **Update both together** — divergence = bug.
+
+Composition root. Only place that constructs concrete adapters + wires them together. Read [root CLAUDE.md](../CLAUDE.md) first.
+
+## Rules
+
+- **`cmd/router/main.go` is the only file that imports concrete `internal/providers/*` adapters and `internal/postgres`.** No other place wires things.
+- Keep `main.go` focused on wiring. Today's helpers:
+  - `buildClusterScorer` — per-version Scorer assembly + embedder warmup
+  - `buildSemanticCache` — response-cache assembly
+  - `buildOtelEmitter` — OTel span exporter
+  - `runSessionPinSweep` — TTL sweep loop
+  - `resolveHardPinModel` / `resolveDefaultBaselineModel` / `resolveAvailableModels` — boot-time model resolution
+  - small env parsers
+- **No more heuristic-fallback router.** If cluster routing fails to boot, `main.go` panics. Misconfiguration must abort the process rather than silently degrade.
+- **Never introduce DI container, reflection-based wiring, or service locator.** Composition = plain Go function calls.
+- **`panic` is reserved for startup-time fail-fast** (`config.MustGet`, cluster-scorer boot failure, invalid `ROUTER_DEPLOYMENT_MODE`). Never panic on request path.
+
+## Deployment-mode dispatch
+
+`ROUTER_DEPLOYMENT_MODE` is read at boot:
+
+- `selfhosted` (default): mounts dashboard at `/ui/*`, `/admin/v1/*` API, dashboard cookie auth. Provider keys read from env vars.
+- `managed`: dashboard + `/admin/v1/*` not mounted. Every provider registered with empty deployment key; proxy in BYOK-only mode.
+- Any other value → panic at boot.
+
+Provider registration:
+
+- Every provider goes into `providerMap` regardless of mode.
+- `envKeyedProviders` (parallel set) tracks which providers have a deployment-level key configured so the hard-pin resolver knows what's safe to pin to.
+- Managed-mode deploys register every provider with empty key + rely exclusively on BYOK / client-supplied auth.
+
+Single source of truth for provider→env-var mapping = `providers.APIKeyEnvVars` in [`../internal/providers/provider.go`](../internal/providers/provider.go). Admin `/config` view reads it so it can't drift from actual wiring.

--- a/cmd/CLAUDE.md
+++ b/cmd/CLAUDE.md
@@ -1,0 +1,35 @@
+# cmd — CLAUDE
+
+> **Mirror notice.** Verbatim sync with [AGENTS.md](AGENTS.md). **Update both together** — divergence = bug.
+
+Composition root. Only place that constructs concrete adapters + wires them together. Read [root CLAUDE.md](../CLAUDE.md) first.
+
+## Rules
+
+- **`cmd/router/main.go` is the only file that imports concrete `internal/providers/*` adapters and `internal/postgres`.** No other place wires things.
+- Keep `main.go` focused on wiring. Today's helpers:
+  - `buildClusterScorer` — per-version Scorer assembly + embedder warmup
+  - `buildSemanticCache` — response-cache assembly
+  - `buildOtelEmitter` — OTel span exporter
+  - `runSessionPinSweep` — TTL sweep loop
+  - `resolveHardPinModel` / `resolveDefaultBaselineModel` / `resolveAvailableModels` — boot-time model resolution
+  - small env parsers
+- **No more heuristic-fallback router.** If cluster routing fails to boot, `main.go` panics. Misconfiguration must abort the process rather than silently degrade.
+- **Never introduce DI container, reflection-based wiring, or service locator.** Composition = plain Go function calls.
+- **`panic` is reserved for startup-time fail-fast** (`config.MustGet`, cluster-scorer boot failure, invalid `ROUTER_DEPLOYMENT_MODE`). Never panic on request path.
+
+## Deployment-mode dispatch
+
+`ROUTER_DEPLOYMENT_MODE` is read at boot:
+
+- `selfhosted` (default): mounts dashboard at `/ui/*`, `/admin/v1/*` API, dashboard cookie auth. Provider keys read from env vars.
+- `managed`: dashboard + `/admin/v1/*` not mounted. Every provider registered with empty deployment key; proxy in BYOK-only mode.
+- Any other value → panic at boot.
+
+Provider registration:
+
+- Every provider goes into `providerMap` regardless of mode.
+- `envKeyedProviders` (parallel set) tracks which providers have a deployment-level key configured so the hard-pin resolver knows what's safe to pin to.
+- Managed-mode deploys register every provider with empty key + rely exclusively on BYOK / client-supplied auth.
+
+Single source of truth for provider→env-var mapping = `providers.APIKeyEnvVars` in [`../internal/providers/provider.go`](../internal/providers/provider.go). Admin `/config` view reads it so it can't drift from actual wiring.

--- a/db/AGENTS.md
+++ b/db/AGENTS.md
@@ -1,0 +1,30 @@
+# db — AGENTS
+
+> **Mirror notice.** Verbatim sync with [CLAUDE.md](CLAUDE.md). **Update both together** — divergence = bug.
+
+Migrations + SQLC query sources. Read [root CLAUDE.md](../CLAUDE.md) first. Adapter that consumes these lives in [`../internal/postgres`](../internal/postgres) — see [its CLAUDE.md](../internal/postgres/CLAUDE.md).
+
+## Layout
+
+- `migrations/` — `NNNN_<name>.up.sql` + `.down.sql` pairs, sequential numbering.
+- `queries/<table>.sql` — SQLC query sources.
+
+## Migration conventions
+
+- Always wrap migrations in `BEGIN; ... COMMIT;`.
+- Never create migration files manually — use `make migrate-create NAME=<name>`.
+- **Down migrations must be precise rollbacks.** No `IF EXISTS` guards. Don't separately drop indexes when dropping tables.
+- `organization_id` + `created_by` are opaque external identifiers — **never add foreign keys to tables outside the router's own schema.** Such tables don't exist in this project.
+- Soft-delete via `deleted_at TIMESTAMP` on tables that need lifecycle. Hot-path queries filter `WHERE deleted_at IS NULL`.
+
+## Query conventions
+
+- **Always named params** (`@param::varchar`), never numbered (`$1`).
+- **Always include type casts** so SQLC inference is unambiguous.
+- Query names use consistent prefixes: `Insert*`, `Upsert*`, `Get*`, `Update*`, `Delete*`.
+- Every query gets an explanatory comment (SQLC turns it into godoc on the generated function).
+- No-rows single-row queries return an error — caller checks `errors.Is(err, sql.ErrNoRows)`.
+
+## Regeneration
+
+After touching anything in `queries/`, run `make generate` and commit the regenerated `../internal/sqlc/` alongside the query change. CI fails if generated code drifts from sources.

--- a/db/CLAUDE.md
+++ b/db/CLAUDE.md
@@ -1,0 +1,30 @@
+# db — CLAUDE
+
+> **Mirror notice.** Verbatim sync with [AGENTS.md](AGENTS.md). **Update both together** — divergence = bug.
+
+Migrations + SQLC query sources. Read [root CLAUDE.md](../CLAUDE.md) first. Adapter that consumes these lives in [`../internal/postgres`](../internal/postgres) — see [its CLAUDE.md](../internal/postgres/CLAUDE.md).
+
+## Layout
+
+- `migrations/` — `NNNN_<name>.up.sql` + `.down.sql` pairs, sequential numbering.
+- `queries/<table>.sql` — SQLC query sources.
+
+## Migration conventions
+
+- Always wrap migrations in `BEGIN; ... COMMIT;`.
+- Never create migration files manually — use `make migrate-create NAME=<name>`.
+- **Down migrations must be precise rollbacks.** No `IF EXISTS` guards. Don't separately drop indexes when dropping tables.
+- `organization_id` + `created_by` are opaque external identifiers — **never add foreign keys to tables outside the router's own schema.** Such tables don't exist in this project.
+- Soft-delete via `deleted_at TIMESTAMP` on tables that need lifecycle. Hot-path queries filter `WHERE deleted_at IS NULL`.
+
+## Query conventions
+
+- **Always named params** (`@param::varchar`), never numbered (`$1`).
+- **Always include type casts** so SQLC inference is unambiguous.
+- Query names use consistent prefixes: `Insert*`, `Upsert*`, `Get*`, `Update*`, `Delete*`.
+- Every query gets an explanatory comment (SQLC turns it into godoc on the generated function).
+- No-rows single-row queries return an error — caller checks `errors.Is(err, sql.ErrNoRows)`.
+
+## Regeneration
+
+After touching anything in `queries/`, run `make generate` and commit the regenerated `../internal/sqlc/` alongside the query change. CI fails if generated code drifts from sources.

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -1,0 +1,26 @@
+# docs — AGENTS
+
+> **Mirror notice.** Verbatim sync with [CLAUDE.md](CLAUDE.md). **Update both together** — divergence = bug.
+
+All design + plan docs for the router subproject. Read [root CLAUDE.md](../CLAUDE.md) first.
+
+## Index is load-bearing
+
+Every Markdown doc under `router/docs/` (active or archived) is indexed in [`README.md`](README.md). When adding a new doc, the same change must update the index — drift between the doc tree and the index = bug.
+
+## Adding a doc
+
+1. **Top of new file:** include the standard two-line header before the H1:
+
+   ```
+   Created: YYYY-MM-DD
+   Last edited: YYYY-MM-DD
+   ```
+
+   `Created` date is load-bearing — `README.md` orders the TOC by it. Don't backdate; if the doc takes multiple days, leave `Created` on the day it first landed and bump `Last edited` as it changes.
+
+2. **Append a row to [`README.md`](README.md)** in the correct section (Active or Archived), keeping each table sorted by `Created` ascending. Write a one- or two-sentence summary covering what the doc is for and (for archived) why archived plus link to its active replacement.
+
+3. **If archiving an active doc:** move the row from the active table to archived with a short reason, mirror the entry in [`plans/archive/README.md`](plans/archive/README.md). Move the file with `git mv` so history follows.
+
+4. **Renaming or deleting a doc:** update both this rule's index and inbound links. `grep -rn 'old/path' router/` before merging.

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -1,0 +1,26 @@
+# docs — CLAUDE
+
+> **Mirror notice.** Verbatim sync with [AGENTS.md](AGENTS.md). **Update both together** — divergence = bug.
+
+All design + plan docs for the router subproject. Read [root CLAUDE.md](../CLAUDE.md) first.
+
+## Index is load-bearing
+
+Every Markdown doc under `router/docs/` (active or archived) is indexed in [`README.md`](README.md). When adding a new doc, the same change must update the index — drift between the doc tree and the index = bug.
+
+## Adding a doc
+
+1. **Top of new file:** include the standard two-line header before the H1:
+
+   ```
+   Created: YYYY-MM-DD
+   Last edited: YYYY-MM-DD
+   ```
+
+   `Created` date is load-bearing — `README.md` orders the TOC by it. Don't backdate; if the doc takes multiple days, leave `Created` on the day it first landed and bump `Last edited` as it changes.
+
+2. **Append a row to [`README.md`](README.md)** in the correct section (Active or Archived), keeping each table sorted by `Created` ascending. Write a one- or two-sentence summary covering what the doc is for and (for archived) why archived plus link to its active replacement.
+
+3. **If archiving an active doc:** move the row from the active table to archived with a short reason, mirror the entry in [`plans/archive/README.md`](plans/archive/README.md). Move the file with `git mv` so history follows.
+
+4. **Renaming or deleting a doc:** update both this rule's index and inbound links. `grep -rn 'old/path' router/` before merging.

--- a/internal/api/AGENTS.md
+++ b/internal/api/AGENTS.md
@@ -1,0 +1,33 @@
+# internal/api — AGENTS
+
+> **Mirror notice.** Verbatim sync with [CLAUDE.md](CLAUDE.md). **Update both together** — divergence = bug.
+
+Presentation layer. Handlers adapt HTTP ↔ Service. Read [root CLAUDE.md](../../CLAUDE.md) first.
+
+## Subpackages
+
+- `admin/` — operational endpoints: `/health`, `/validate`, `/admin/v1/*`
+- `anthropic/` — Anthropic Messages surface (`/v1/messages`, passthrough, `/v1/route`)
+- `openai/` — OpenAI Chat Completions (`/v1/chat/completions`)
+- `gemini/` — Gemini native (`/v1beta/models/:modelAction`)
+
+## Import rules
+
+- May import `internal/auth` (Service handle + middleware-context types) and `internal/proxy` (routing/dispatch service handle).
+- May import `internal/observability` for logging, `internal/providers` for shared sentinel errors, `internal/router/cluster` for `ErrClusterUnavailable` sentinel + `DeployedModelsSource` interface.
+- **Must not import** `internal/postgres`, any concrete `internal/providers/*` adapter, or `internal/translate` directly.
+- Concrete instances reach presentation only via constructor params from composition root.
+
+## Adding an HTTP endpoint
+
+1. **Decide timeout budget.** Cheap auth-only ops use `validateTimeout` / `healthTimeout` (1 s). Provider calls get own constant in [`../server/server.go`](../server/server.go) — pick budget + justify in comment.
+2. **Decide auth.** Routes needing valid `rk_` bearer go through `middleware.WithAuth(authSvc)`. Admin endpoints use `WithAdminOrAuth` (admin cookie OR bearer) or `WithAdminOnly` (admin cookie only). Unauthed routes (e.g. `/health`) attach no auth middleware.
+3. **Decide if self-hoster dashboard surface.** `/ui/*` static dashboard, `/admin/v1/auth/*`, `/admin/v1` mgmt group (metrics, keys, provider-keys, config, excluded-models) mount only when `mode == server.DeploymentModeSelfHosted`. New endpoints whose only consumer is self-hosted dashboard go inside that block; product-surface endpoints (`/v1/*`, `/v1beta/*`, `/health`, `/validate`) stay outside so they're available in `managed` mode too. **Do not** add new `/admin/v1/*` route outside the selfhosted block — would re-expose redundant control plane on Weave-managed deploys.
+4. **Pick (or create) the right subpackage.** Operational → `admin/`; Anthropic Messages → `anthropic/`; OpenAI → `openai/`; Gemini → `gemini/`. New surfaces get their own subpackage.
+5. **Use `observability.FromGin(c)` for request-scoped logger.** For authed installation: `middleware.InstallationFrom(c)` (nil if `WithAuth` not applied — handler should be on authed group). For BYOK secrets: `middleware.ExternalAPIKeysFrom(c)`.
+6. **Pick the right service.** Identity-only ops → `*auth.Service`. Routing/dispatch/translate → `*proxy.Service`. Don't touch repositories, router, providers, planner/handover/cache packages from a handler. Handler adapts HTTP ↔ service; service does the work.
+7. **Test with in-memory fakes + gin testing harness** (`httptest.NewRequest`/`ResponseRecorder`). No real DB for handler tests — use fakes from [`../auth/service_test.go`](../auth/service_test.go) and [`../proxy/service_test.go`](../proxy/service_test.go) as model.
+
+## History
+
+`internal/router/heuristic` and `internal/router/evalswitch` previously lived in the API ring; both removed when heuristic fallback retired in favor of `cluster.ErrClusterUnavailable` → HTTP 503.

--- a/internal/api/CLAUDE.md
+++ b/internal/api/CLAUDE.md
@@ -1,0 +1,33 @@
+# internal/api — CLAUDE
+
+> **Mirror notice.** Verbatim sync with [AGENTS.md](AGENTS.md). **Update both together** — divergence = bug.
+
+Presentation layer. Handlers adapt HTTP ↔ Service. Read [root CLAUDE.md](../../CLAUDE.md) first.
+
+## Subpackages
+
+- `admin/` — operational endpoints: `/health`, `/validate`, `/admin/v1/*`
+- `anthropic/` — Anthropic Messages surface (`/v1/messages`, passthrough, `/v1/route`)
+- `openai/` — OpenAI Chat Completions (`/v1/chat/completions`)
+- `gemini/` — Gemini native (`/v1beta/models/:modelAction`)
+
+## Import rules
+
+- May import `internal/auth` (Service handle + middleware-context types) and `internal/proxy` (routing/dispatch service handle).
+- May import `internal/observability` for logging, `internal/providers` for shared sentinel errors, `internal/router/cluster` for `ErrClusterUnavailable` sentinel + `DeployedModelsSource` interface.
+- **Must not import** `internal/postgres`, any concrete `internal/providers/*` adapter, or `internal/translate` directly.
+- Concrete instances reach presentation only via constructor params from composition root.
+
+## Adding an HTTP endpoint
+
+1. **Decide timeout budget.** Cheap auth-only ops use `validateTimeout` / `healthTimeout` (1 s). Provider calls get own constant in [`../server/server.go`](../server/server.go) — pick budget + justify in comment.
+2. **Decide auth.** Routes needing valid `rk_` bearer go through `middleware.WithAuth(authSvc)`. Admin endpoints use `WithAdminOrAuth` (admin cookie OR bearer) or `WithAdminOnly` (admin cookie only). Unauthed routes (e.g. `/health`) attach no auth middleware.
+3. **Decide if self-hoster dashboard surface.** `/ui/*` static dashboard, `/admin/v1/auth/*`, `/admin/v1` mgmt group (metrics, keys, provider-keys, config, excluded-models) mount only when `mode == server.DeploymentModeSelfHosted`. New endpoints whose only consumer is self-hosted dashboard go inside that block; product-surface endpoints (`/v1/*`, `/v1beta/*`, `/health`, `/validate`) stay outside so they're available in `managed` mode too. **Do not** add new `/admin/v1/*` route outside the selfhosted block — would re-expose redundant control plane on Weave-managed deploys.
+4. **Pick (or create) the right subpackage.** Operational → `admin/`; Anthropic Messages → `anthropic/`; OpenAI → `openai/`; Gemini → `gemini/`. New surfaces get their own subpackage.
+5. **Use `observability.FromGin(c)` for request-scoped logger.** For authed installation: `middleware.InstallationFrom(c)` (nil if `WithAuth` not applied — handler should be on authed group). For BYOK secrets: `middleware.ExternalAPIKeysFrom(c)`.
+6. **Pick the right service.** Identity-only ops → `*auth.Service`. Routing/dispatch/translate → `*proxy.Service`. Don't touch repositories, router, providers, planner/handover/cache packages from a handler. Handler adapts HTTP ↔ service; service does the work.
+7. **Test with in-memory fakes + gin testing harness** (`httptest.NewRequest`/`ResponseRecorder`). No real DB for handler tests — use fakes from [`../auth/service_test.go`](../auth/service_test.go) and [`../proxy/service_test.go`](../proxy/service_test.go) as model.
+
+## History
+
+`internal/router/heuristic` and `internal/router/evalswitch` previously lived in the API ring; both removed when heuristic fallback retired in favor of `cluster.ErrClusterUnavailable` → HTTP 503.

--- a/internal/auth/AGENTS.md
+++ b/internal/auth/AGENTS.md
@@ -1,0 +1,24 @@
+# internal/auth — AGENTS
+
+> **Mirror notice.** Verbatim sync with [CLAUDE.md](CLAUDE.md). **Update both together** — divergence = bug.
+
+Identity domain. Types, repos, `Service.VerifyAPIKey`, `APIKeyCache`, ID/hashing helpers, Tink encryptor. Read [root CLAUDE.md](../../CLAUDE.md) first.
+
+## Adding a method to `*auth.Service`
+
+1. **Define method on `*auth.Service`** in [`service.go`](service.go). No I/O directly here — push into repo. Inner-ring imports (`router`, `providers`, `translate`, `observability`, `internal/router/*` helper packages, `internal/proxy/usage`) + small utility libs are fine.
+2. **If you need new repo methods**, add to the interfaces in [`installation.go`](installation.go) / [`api_key.go`](api_key.go) / sibling files. Interface = contract; the Postgres adapter must satisfy it.
+3. **Implement new repo method in [`../postgres/repository.go`](../postgres/repository.go)** (or sibling in `internal/postgres/`), adding the SQLC query in `db/queries/`. Run `make generate` to regenerate `internal/sqlc/`.
+4. **Update matching `service_test.go` fakes** to satisfy the expanded interface. Tests use fakes; assert on real return values, not just that mocks were called.
+
+## Conventions
+
+- **Domain types must not leak `pgtype` / `uuid` concerns.** Convert at the adapter boundary in [`../postgres/converters.go`](../postgres/converters.go).
+- **`fireMarkUsed` is the documented "log-and-continue" exception.** Best-effort, off the request path — see [`service.go`](service.go). Everywhere else, errors flow up.
+- **Clock injection.** Use `auth.Clock = func() time.Time` rather than calling `time.Now()` directly — lets tests pin time.
+- **Token safety.** Never log raw bearer tokens. 8-char prefix + 4-char suffix (`KeyPrefix` / `KeySuffix` columns on `auth.APIKey`) are the only safe form.
+- **BYOK secrets at rest** go through `auth.Encryptor` (Tink AES-256-GCM). Plaintext only in memory for the request lifetime.
+
+## Helpers live here
+
+Auth-shaped helpers (token prefix, ID gen, hashing, encryption) belong in this package alongside the types they support — not in a generic `util/` package.

--- a/internal/auth/CLAUDE.md
+++ b/internal/auth/CLAUDE.md
@@ -1,0 +1,24 @@
+# internal/auth — CLAUDE
+
+> **Mirror notice.** Verbatim sync with [AGENTS.md](AGENTS.md). **Update both together** — divergence = bug.
+
+Identity domain. Types, repos, `Service.VerifyAPIKey`, `APIKeyCache`, ID/hashing helpers, Tink encryptor. Read [root CLAUDE.md](../../CLAUDE.md) first.
+
+## Adding a method to `*auth.Service`
+
+1. **Define method on `*auth.Service`** in [`service.go`](service.go). No I/O directly here — push into repo. Inner-ring imports (`router`, `providers`, `translate`, `observability`, `internal/router/*` helper packages, `internal/proxy/usage`) + small utility libs are fine.
+2. **If you need new repo methods**, add to the interfaces in [`installation.go`](installation.go) / [`api_key.go`](api_key.go) / sibling files. Interface = contract; the Postgres adapter must satisfy it.
+3. **Implement new repo method in [`../postgres/repository.go`](../postgres/repository.go)** (or sibling in `internal/postgres/`), adding the SQLC query in `db/queries/`. Run `make generate` to regenerate `internal/sqlc/`.
+4. **Update matching `service_test.go` fakes** to satisfy the expanded interface. Tests use fakes; assert on real return values, not just that mocks were called.
+
+## Conventions
+
+- **Domain types must not leak `pgtype` / `uuid` concerns.** Convert at the adapter boundary in [`../postgres/converters.go`](../postgres/converters.go).
+- **`fireMarkUsed` is the documented "log-and-continue" exception.** Best-effort, off the request path — see [`service.go`](service.go). Everywhere else, errors flow up.
+- **Clock injection.** Use `auth.Clock = func() time.Time` rather than calling `time.Now()` directly — lets tests pin time.
+- **Token safety.** Never log raw bearer tokens. 8-char prefix + 4-char suffix (`KeyPrefix` / `KeySuffix` columns on `auth.APIKey`) are the only safe form.
+- **BYOK secrets at rest** go through `auth.Encryptor` (Tink AES-256-GCM). Plaintext only in memory for the request lifetime.
+
+## Helpers live here
+
+Auth-shaped helpers (token prefix, ID gen, hashing, encryption) belong in this package alongside the types they support — not in a generic `util/` package.

--- a/internal/postgres/AGENTS.md
+++ b/internal/postgres/AGENTS.md
@@ -1,0 +1,36 @@
+# internal/postgres — AGENTS
+
+> **Mirror notice.** Verbatim sync with [CLAUDE.md](CLAUDE.md). **Update both together** — divergence = bug.
+
+Postgres adapter: SQLC over pgx, plus the session-pin store impl. Read [root CLAUDE.md](../../CLAUDE.md) first.
+
+## Layout
+
+- [`repository.go`](repository.go) — generic repo for auth + installation domain.
+- [`converters.go`](converters.go) — adapter-boundary mapping between `pgtype` / `uuid` and the domain types in [`../auth`](../auth) / [`../router/sessionpin`](../router/sessionpin).
+- Sibling files implement narrower repos.
+
+## Hard rules
+
+- **Adapter depends only on the inner ring** + may import `internal/sqlc`. Adapters never import each other — `internal/postgres` doesn't know `internal/api/admin` etc.
+- **Never write raw SQL outside `db/queries/`** or call `pgx.Pool` directly from anywhere except this package. SQLC is the only data mapper.
+- **Domain types must not leak `pgtype` / `uuid` concerns.** `auth.Installation`, `auth.APIKey`, `sessionpin.Pin` are all converted at the adapter boundary in `converters.go`.
+
+## Adding a column or query
+
+1. **Migration first.** Add `db/migrations/NNNN_<name>.up.sql` + `.down.sql` in sequential numbering. Wrap in `BEGIN`/`COMMIT`. Down migration must be a precise rollback — no `IF EXISTS` guards. See [`../../db/CLAUDE.md`](../../db/CLAUDE.md).
+2. **Add the query** to the appropriate `db/queries/<table>.sql`. Use named params with type casts (`@param::varchar`). Use `sqlc.embed(t)` for JOINs.
+3. **Run `make generate`** to regenerate `internal/sqlc/`. Commit the generated code alongside changes.
+4. **Update [`repository.go`](repository.go)** (and [`converters.go`](converters.go) if a new column needs domain mapping).
+
+## SQLC conventions
+
+- Always named params (`@param::varchar`), never numbered (`$1`).
+- Always include type casts so SQLC inference is unambiguous.
+- Query names use consistent prefixes: `Insert*`, `Upsert*`, `Get*`, `Update*`, `Delete*`.
+- Every query gets an explanatory comment (SQLC turns it into godoc on the generated function).
+- No-rows single-row queries return an error — check `errors.Is(err, sql.ErrNoRows)`.
+
+## Never edit generated files
+
+`internal/sqlc/` is generated. The "DO NOT EDIT" header is load-bearing. Regenerate with `make generate`.

--- a/internal/postgres/CLAUDE.md
+++ b/internal/postgres/CLAUDE.md
@@ -1,0 +1,36 @@
+# internal/postgres — CLAUDE
+
+> **Mirror notice.** Verbatim sync with [AGENTS.md](AGENTS.md). **Update both together** — divergence = bug.
+
+Postgres adapter: SQLC over pgx, plus the session-pin store impl. Read [root CLAUDE.md](../../CLAUDE.md) first.
+
+## Layout
+
+- [`repository.go`](repository.go) — generic repo for auth + installation domain.
+- [`converters.go`](converters.go) — adapter-boundary mapping between `pgtype` / `uuid` and the domain types in [`../auth`](../auth) / [`../router/sessionpin`](../router/sessionpin).
+- Sibling files implement narrower repos.
+
+## Hard rules
+
+- **Adapter depends only on the inner ring** + may import `internal/sqlc`. Adapters never import each other — `internal/postgres` doesn't know `internal/api/admin` etc.
+- **Never write raw SQL outside `db/queries/`** or call `pgx.Pool` directly from anywhere except this package. SQLC is the only data mapper.
+- **Domain types must not leak `pgtype` / `uuid` concerns.** `auth.Installation`, `auth.APIKey`, `sessionpin.Pin` are all converted at the adapter boundary in `converters.go`.
+
+## Adding a column or query
+
+1. **Migration first.** Add `db/migrations/NNNN_<name>.up.sql` + `.down.sql` in sequential numbering. Wrap in `BEGIN`/`COMMIT`. Down migration must be a precise rollback — no `IF EXISTS` guards. See [`../../db/CLAUDE.md`](../../db/CLAUDE.md).
+2. **Add the query** to the appropriate `db/queries/<table>.sql`. Use named params with type casts (`@param::varchar`). Use `sqlc.embed(t)` for JOINs.
+3. **Run `make generate`** to regenerate `internal/sqlc/`. Commit the generated code alongside changes.
+4. **Update [`repository.go`](repository.go)** (and [`converters.go`](converters.go) if a new column needs domain mapping).
+
+## SQLC conventions
+
+- Always named params (`@param::varchar`), never numbered (`$1`).
+- Always include type casts so SQLC inference is unambiguous.
+- Query names use consistent prefixes: `Insert*`, `Upsert*`, `Get*`, `Update*`, `Delete*`.
+- Every query gets an explanatory comment (SQLC turns it into godoc on the generated function).
+- No-rows single-row queries return an error — check `errors.Is(err, sql.ErrNoRows)`.
+
+## Never edit generated files
+
+`internal/sqlc/` is generated. The "DO NOT EDIT" header is load-bearing. Regenerate with `make generate`.

--- a/internal/providers/AGENTS.md
+++ b/internal/providers/AGENTS.md
@@ -1,0 +1,46 @@
+# internal/providers — AGENTS
+
+> **Mirror notice.** Verbatim sync with [CLAUDE.md](CLAUDE.md). **Update both together** — divergence = bug.
+
+Provider `Client` interface + canonical `Provider*` name constants + concrete adapters per upstream. Read [root CLAUDE.md](../../CLAUDE.md) first.
+
+## Layout
+
+- `provider.go` — `Client` interface, `Provider*` constants, `APIKeyEnvVars` map (single source of truth for provider→env-var mapping).
+- `anthropic/`, `openai/`, `google/`, `openaicompat/` — concrete adapters.
+- `noop/` — placeholder client returning `providers.ErrNotImplemented`. Use when wiring a new `availableProviders` key whose adapter hasn't landed yet so the cluster scorer can already filter against it.
+- `httputil/` — shared transport + streaming helpers.
+
+## Inward-pointing import (intentional)
+
+Provider adapters (`internal/providers/<name>/`) import `internal/proxy` for the `OnUpstreamMeta` callback so streaming responses record usage/headers back to proxy. This is one of the few inward-pointing adapter→inner-ring imports and is intentional.
+
+## Adding a new `providers.Client` adapter
+
+1. **Create `internal/providers/<name>/client.go`** with a `Client` struct + `NewClient(...)` constructor taking credentials (typically API key string + base URL). For OpenAI-compatible upstreams (vLLM, Together, DeepInfra, customer endpoints), **prefer adding a sibling `*BaseURL` constant in [`openaicompat`](openaicompat) over a new adapter** — the openaicompat client already covers OpenRouter + Fireworks under their own provider keys.
+2. **Implement `Proxy` and `Passthrough`.** The adapter translates the prepared request body to the provider's wire format, sends it with a pooled `http.Client` (use `httputil.NewTransport` and `httputil.StreamBody`), streams the response back. Adapters call `proxy.OnUpstreamMeta` when they observe usage/header data. Do not leak provider-specific types across the package boundary.
+3. **Add compile-time check:** `var _ providers.Client = (*Client)(nil)`.
+4. **Add a canonical name constant** to [`provider.go`](provider.go) (the `Provider*` block) + register the matching env-var name in `APIKeyEnvVars`. Today's wired keys: `"anthropic"`, `"openai"`, `"google"`, `"openrouter"`, `"fireworks"`. The composition root reads `APIKeyEnvVars`, so the admin `/config` view can't drift from actual wiring.
+5. **Wire in `../../cmd/router/main.go`.** Only place that imports the provider package directly. The provider must be added to `providerMap` regardless of mode; `envKeyedProviders` (parallel set) tracks which providers have a deployment-level key configured.
+
+## Multi-provider routing
+
+Router serves five vendor pools (Anthropic / OpenAI / Google / OpenRouter / Fireworks) from one composition root. A single routing decision picks `(Provider, Model)` + proxy dispatches accordingly.
+
+- `cluster.NewScorer` filters `model_registry.json`'s `deployed_models` list to entries whose `provider` is in `availableProviders`. argmax runs over the filtered list, so a deploy without an OpenRouter key cannot accidentally emit a `deepseek-*` decision.
+- `model_registry.json` = flat list of `{model, provider, bench_column, proxy?, proxy_note?}` entries. Direct columns are 1:1 with OpenRouterBench; proxy entries (`proxy: true`) reuse another column's score until direct ranking data is available. The training script copies bench-column scores onto every deployed entry referencing that column rather than averaging columns — that's how the scorer can rank `gpt-5` and proxy `claude-opus-4-7` distinctly.
+- **`google/` ships a native Generative Language REST client** (`NativeClient` against `https://generativelanguage.googleapis.com/v1beta/models/{model}:generateContent`). The OpenAI-compat surface at `/v1beta/openai` does **not** preserve the opaque `thought_signature` field that multi-turn tool use against Gemini 3.x preview models requires, so the native client is mandatory for those flows. Auth via `x-goog-api-key` header.
+- `openaicompat/` is the generic OpenAI Chat Completions adapter, used today for OpenRouter (`https://openrouter.ai/api/v1`) + Fireworks (`https://api.fireworks.ai/inference/v1`).
+
+## What is load-bearing
+
+- **The training script is the only writer of `rankings.json`.** Hand-editing breaks the cluster geometry guarantee (`scorer.go`'s sorted-candidate ordering must match what training produced). Re-run `train_cluster_router.py` after touching `model_registry.json` + commit the regenerated artifact.
+- **Cluster scorer is availability-aware at boot, not request time.** Filter happens in `NewScorer`; runtime argmax unchanged. Empty filtered set = hard boot error so misconfigured deploys fail loud.
+
+## What to NOT do
+
+- **Don't bypass the provider filter.** If you need to route to a provider whose key isn't registered (and isn't reachable via BYOK or client passthrough), register the provider — don't add a special-case path that ignores `availableProviders`.
+- **Don't add bench-column averaging back to the training script.** 1:1 mapping is the point. Two entries that share a column copy the same score; they don't average across columns.
+- **Don't route Gemini 3.x preview tool-use through OpenAI-compat surface.** Loses `thought_signature`; second turn 400s. Use `google.NewNativeClient` (already wired by default).
+- **Don't add per-installation provider preference yet.** Deploy-time env config + cluster scorer's per-prompt argmax cover v1. Per-installation routing = follow-up PR with a DB migration on `model_router_installations`.
+- **Don't leak provider-specific types** (`anthropic.MessageRequest`, OpenAI streaming chunk types, etc.) across the package boundary.

--- a/internal/providers/CLAUDE.md
+++ b/internal/providers/CLAUDE.md
@@ -1,0 +1,46 @@
+# internal/providers — CLAUDE
+
+> **Mirror notice.** Verbatim sync with [AGENTS.md](AGENTS.md). **Update both together** — divergence = bug.
+
+Provider `Client` interface + canonical `Provider*` name constants + concrete adapters per upstream. Read [root CLAUDE.md](../../CLAUDE.md) first.
+
+## Layout
+
+- `provider.go` — `Client` interface, `Provider*` constants, `APIKeyEnvVars` map (single source of truth for provider→env-var mapping).
+- `anthropic/`, `openai/`, `google/`, `openaicompat/` — concrete adapters.
+- `noop/` — placeholder client returning `providers.ErrNotImplemented`. Use when wiring a new `availableProviders` key whose adapter hasn't landed yet so the cluster scorer can already filter against it.
+- `httputil/` — shared transport + streaming helpers.
+
+## Inward-pointing import (intentional)
+
+Provider adapters (`internal/providers/<name>/`) import `internal/proxy` for the `OnUpstreamMeta` callback so streaming responses record usage/headers back to proxy. This is one of the few inward-pointing adapter→inner-ring imports and is intentional.
+
+## Adding a new `providers.Client` adapter
+
+1. **Create `internal/providers/<name>/client.go`** with a `Client` struct + `NewClient(...)` constructor taking credentials (typically API key string + base URL). For OpenAI-compatible upstreams (vLLM, Together, DeepInfra, customer endpoints), **prefer adding a sibling `*BaseURL` constant in [`openaicompat`](openaicompat) over a new adapter** — the openaicompat client already covers OpenRouter + Fireworks under their own provider keys.
+2. **Implement `Proxy` and `Passthrough`.** The adapter translates the prepared request body to the provider's wire format, sends it with a pooled `http.Client` (use `httputil.NewTransport` and `httputil.StreamBody`), streams the response back. Adapters call `proxy.OnUpstreamMeta` when they observe usage/header data. Do not leak provider-specific types across the package boundary.
+3. **Add compile-time check:** `var _ providers.Client = (*Client)(nil)`.
+4. **Add a canonical name constant** to [`provider.go`](provider.go) (the `Provider*` block) + register the matching env-var name in `APIKeyEnvVars`. Today's wired keys: `"anthropic"`, `"openai"`, `"google"`, `"openrouter"`, `"fireworks"`. The composition root reads `APIKeyEnvVars`, so the admin `/config` view can't drift from actual wiring.
+5. **Wire in `../../cmd/router/main.go`.** Only place that imports the provider package directly. The provider must be added to `providerMap` regardless of mode; `envKeyedProviders` (parallel set) tracks which providers have a deployment-level key configured.
+
+## Multi-provider routing
+
+Router serves five vendor pools (Anthropic / OpenAI / Google / OpenRouter / Fireworks) from one composition root. A single routing decision picks `(Provider, Model)` + proxy dispatches accordingly.
+
+- `cluster.NewScorer` filters `model_registry.json`'s `deployed_models` list to entries whose `provider` is in `availableProviders`. argmax runs over the filtered list, so a deploy without an OpenRouter key cannot accidentally emit a `deepseek-*` decision.
+- `model_registry.json` = flat list of `{model, provider, bench_column, proxy?, proxy_note?}` entries. Direct columns are 1:1 with OpenRouterBench; proxy entries (`proxy: true`) reuse another column's score until direct ranking data is available. The training script copies bench-column scores onto every deployed entry referencing that column rather than averaging columns — that's how the scorer can rank `gpt-5` and proxy `claude-opus-4-7` distinctly.
+- **`google/` ships a native Generative Language REST client** (`NativeClient` against `https://generativelanguage.googleapis.com/v1beta/models/{model}:generateContent`). The OpenAI-compat surface at `/v1beta/openai` does **not** preserve the opaque `thought_signature` field that multi-turn tool use against Gemini 3.x preview models requires, so the native client is mandatory for those flows. Auth via `x-goog-api-key` header.
+- `openaicompat/` is the generic OpenAI Chat Completions adapter, used today for OpenRouter (`https://openrouter.ai/api/v1`) + Fireworks (`https://api.fireworks.ai/inference/v1`).
+
+## What is load-bearing
+
+- **The training script is the only writer of `rankings.json`.** Hand-editing breaks the cluster geometry guarantee (`scorer.go`'s sorted-candidate ordering must match what training produced). Re-run `train_cluster_router.py` after touching `model_registry.json` + commit the regenerated artifact.
+- **Cluster scorer is availability-aware at boot, not request time.** Filter happens in `NewScorer`; runtime argmax unchanged. Empty filtered set = hard boot error so misconfigured deploys fail loud.
+
+## What to NOT do
+
+- **Don't bypass the provider filter.** If you need to route to a provider whose key isn't registered (and isn't reachable via BYOK or client passthrough), register the provider — don't add a special-case path that ignores `availableProviders`.
+- **Don't add bench-column averaging back to the training script.** 1:1 mapping is the point. Two entries that share a column copy the same score; they don't average across columns.
+- **Don't route Gemini 3.x preview tool-use through OpenAI-compat surface.** Loses `thought_signature`; second turn 400s. Use `google.NewNativeClient` (already wired by default).
+- **Don't add per-installation provider preference yet.** Deploy-time env config + cluster scorer's per-prompt argmax cover v1. Per-installation routing = follow-up PR with a DB migration on `model_router_installations`.
+- **Don't leak provider-specific types** (`anthropic.MessageRequest`, OpenAI streaming chunk types, etc.) across the package boundary.

--- a/internal/proxy/AGENTS.md
+++ b/internal/proxy/AGENTS.md
@@ -1,0 +1,52 @@
+# internal/proxy — AGENTS
+
+> **Mirror notice.** Verbatim sync with [CLAUDE.md](CLAUDE.md). **Update both together** — divergence = bug.
+
+Routing/dispatch service. Per-turn orchestrator that composes scorer, planner, handover, cache, sessionpin, pricing, capability, turntype, usage, providers, and translate. Read [root CLAUDE.md](../../CLAUDE.md) first.
+
+## Surface
+
+`*proxy.Service` in [`service.go`](service.go) exposes:
+
+- `Route` — returns `router.Decision`
+- `ProxyMessages` — Anthropic Messages surface
+- `ProxyOpenAIChatCompletion` — OpenAI Chat Completions
+- `ProxyGemini` — Gemini native generateContent
+
+Plus the turn loop, handover adapter, cache writer, and session-key derivation in sibling files.
+
+## Adding a method to `*proxy.Service`
+
+1. **Define method on `*proxy.Service`.** No I/O directly here — push into a provider adapter or repo. Inner-ring imports (`router`, `providers`, `translate`, `observability`, `internal/router/*`, `internal/proxy/usage`) + small utility libs are fine.
+2. **If you need new repo methods**, surface them as an interface in the inner-ring package, implement in `internal/postgres/`. Example: `sessionpin.Store` in [`../router/sessionpin/store.go`](../router/sessionpin/store.go), implemented by `postgres.SessionPinRepository`.
+3. **Update `service_test.go` fakes** to satisfy the expanded interface. Real assertions on return values, not "mock called with X".
+
+## Per-turn flow (cache-aware turn routing)
+
+The per-turn flow is more than "scorer → dispatch". Pinned session, planner verdict, optional handover summary, and the semantic response cache all sit between the inbound request and the upstream provider. Packages are intentionally small + single-purpose so each is unit-testable without the others.
+
+| Step | Package | Notes |
+|---|---|---|
+| Turn-type classification | [`../router/turntype`](../router/turntype) | MainLoop / ToolResult / SubAgentDispatch / Compaction / Probe |
+| Session-pin lookup | [`../router/sessionpin`](../router/sessionpin) | Sticky `(api_key_id, session_key, role)` pin |
+| Fresh routing decision | [`../router/cluster`](../router/cluster) | Cluster scorer argmax |
+| STAY vs SWITCH | [`../router/planner`](../router/planner) | Cache-aware EV policy |
+| Handover summary on SWITCH | [`../router/handover`](../router/handover) | Bounds switch-turn input cost |
+| Semantic response cache | [`../router/cache`](../router/cache) | Cross-request, non-streaming only |
+| Anthropic usage-bypass gate | [`usage`](usage) | See [`usage/CLAUDE.md`](usage/CLAUDE.md) |
+
+The provider-backed `Summarizer` implementation for handover lives in [`handover.go`](handover.go); the inner-ring `handover` package only defines the contract. On summarizer timeout or error, proxy falls back to `handover.TrimLastN`.
+
+## Translation
+
+`proxy.Service` is the **only caller of [`../translate`](../translate)**. Keep providers ignorant of cross-format concerns. See [translate/CLAUDE.md](../translate/CLAUDE.md) for the recipe.
+
+## `OnUpstreamMeta` callbacks
+
+Provider adapters call back into `proxy.OnUpstreamMeta` so streaming responses record usage/headers back to proxy without coupling provider packages to proxy internals. The pricing / planner stack depends on per-turn token counts being recorded promptly — **don't add a provider that forgets to call the callback.**
+
+## What NOT to do
+
+- **Don't move provider-call logic into planner.** Planner must remain pure so EV math is provable. Anything network-touching goes in `proxy.Service`.
+- **Don't add a handover path that doesn't time out.** `Summarizer` contract says implementations MUST respect the context deadline. Falling back to `TrimLastN` on timeout is correct, not a bug.
+- **Don't cache streaming responses.** Streaming bypasses cache on purpose — captured bytes would be post-translation SSE frames, and lookup latency budget is hostile to first-token-time. If you think this should change, write a doc first.

--- a/internal/proxy/CLAUDE.md
+++ b/internal/proxy/CLAUDE.md
@@ -1,0 +1,52 @@
+# internal/proxy — CLAUDE
+
+> **Mirror notice.** Verbatim sync with [AGENTS.md](AGENTS.md). **Update both together** — divergence = bug.
+
+Routing/dispatch service. Per-turn orchestrator that composes scorer, planner, handover, cache, sessionpin, pricing, capability, turntype, usage, providers, and translate. Read [root CLAUDE.md](../../CLAUDE.md) first.
+
+## Surface
+
+`*proxy.Service` in [`service.go`](service.go) exposes:
+
+- `Route` — returns `router.Decision`
+- `ProxyMessages` — Anthropic Messages surface
+- `ProxyOpenAIChatCompletion` — OpenAI Chat Completions
+- `ProxyGemini` — Gemini native generateContent
+
+Plus the turn loop, handover adapter, cache writer, and session-key derivation in sibling files.
+
+## Adding a method to `*proxy.Service`
+
+1. **Define method on `*proxy.Service`.** No I/O directly here — push into a provider adapter or repo. Inner-ring imports (`router`, `providers`, `translate`, `observability`, `internal/router/*`, `internal/proxy/usage`) + small utility libs are fine.
+2. **If you need new repo methods**, surface them as an interface in the inner-ring package, implement in `internal/postgres/`. Example: `sessionpin.Store` in [`../router/sessionpin/store.go`](../router/sessionpin/store.go), implemented by `postgres.SessionPinRepository`.
+3. **Update `service_test.go` fakes** to satisfy the expanded interface. Real assertions on return values, not "mock called with X".
+
+## Per-turn flow (cache-aware turn routing)
+
+The per-turn flow is more than "scorer → dispatch". Pinned session, planner verdict, optional handover summary, and the semantic response cache all sit between the inbound request and the upstream provider. Packages are intentionally small + single-purpose so each is unit-testable without the others.
+
+| Step | Package | Notes |
+|---|---|---|
+| Turn-type classification | [`../router/turntype`](../router/turntype) | MainLoop / ToolResult / SubAgentDispatch / Compaction / Probe |
+| Session-pin lookup | [`../router/sessionpin`](../router/sessionpin) | Sticky `(api_key_id, session_key, role)` pin |
+| Fresh routing decision | [`../router/cluster`](../router/cluster) | Cluster scorer argmax |
+| STAY vs SWITCH | [`../router/planner`](../router/planner) | Cache-aware EV policy |
+| Handover summary on SWITCH | [`../router/handover`](../router/handover) | Bounds switch-turn input cost |
+| Semantic response cache | [`../router/cache`](../router/cache) | Cross-request, non-streaming only |
+| Anthropic usage-bypass gate | [`usage`](usage) | See [`usage/CLAUDE.md`](usage/CLAUDE.md) |
+
+The provider-backed `Summarizer` implementation for handover lives in [`handover.go`](handover.go); the inner-ring `handover` package only defines the contract. On summarizer timeout or error, proxy falls back to `handover.TrimLastN`.
+
+## Translation
+
+`proxy.Service` is the **only caller of [`../translate`](../translate)**. Keep providers ignorant of cross-format concerns. See [translate/CLAUDE.md](../translate/CLAUDE.md) for the recipe.
+
+## `OnUpstreamMeta` callbacks
+
+Provider adapters call back into `proxy.OnUpstreamMeta` so streaming responses record usage/headers back to proxy without coupling provider packages to proxy internals. The pricing / planner stack depends on per-turn token counts being recorded promptly — **don't add a provider that forgets to call the callback.**
+
+## What NOT to do
+
+- **Don't move provider-call logic into planner.** Planner must remain pure so EV math is provable. Anything network-touching goes in `proxy.Service`.
+- **Don't add a handover path that doesn't time out.** `Summarizer` contract says implementations MUST respect the context deadline. Falling back to `TrimLastN` on timeout is correct, not a bug.
+- **Don't cache streaming responses.** Streaming bypasses cache on purpose — captured bytes would be post-translation SSE frames, and lookup latency budget is hostile to first-token-time. If you think this should change, write a doc first.

--- a/internal/proxy/usage/AGENTS.md
+++ b/internal/proxy/usage/AGENTS.md
@@ -1,0 +1,22 @@
+# internal/proxy/usage — AGENTS
+
+> **Mirror notice.** Verbatim sync with [CLAUDE.md](CLAUDE.md). **Update both together** — divergence = bug.
+
+Anthropic usage-bypass gate. Inner-ring, I/O-free. Read [root CLAUDE.md](../../../CLAUDE.md) first.
+
+## What it does
+
+Tracks the most recent Anthropic unified rate-limit utilization — the same data `claude /usage` CLI reads off `anthropic-ratelimit-unified-{5h,weekly}-*` response headers.
+
+When `ROUTER_USAGE_BYPASS_ENABLED=true`, requests whose recorded 5h + weekly utilization are both below `ROUTER_USAGE_BYPASS_THRESHOLD` (default `0.95`) pass straight through to Anthropic with the requested model — no cluster routing, no planner verdict. Once either window crosses threshold, the gate disengages for that credential + the cluster scorer takes over. Observations expire after `ROUTER_USAGE_OBSERVATION_TTL` (default 10 minutes); a torn-down key or long idle period falls back to "cold start = bypass" rather than pinning the gate open on a stale near-100% reading.
+
+## Why it exists
+
+Anthropic-plan customers (Claude Code's logged-in flow) want unused quota spent on Anthropic, not silently redirected to a cheaper substitute, until actually approaching cap.
+
+## Invariants
+
+- **Pure in-memory state, no persistence.**
+- Entries keyed by `usage.CredentialKey` (salted hash of upstream API key bytes) so logs + metrics never see the raw token.
+- Periodic sweep bounds memory by evicting expired entries.
+- I/O-free per the inner-ring rule — observer is just structs + maps + a mutex.

--- a/internal/proxy/usage/CLAUDE.md
+++ b/internal/proxy/usage/CLAUDE.md
@@ -1,0 +1,22 @@
+# internal/proxy/usage — CLAUDE
+
+> **Mirror notice.** Verbatim sync with [AGENTS.md](AGENTS.md). **Update both together** — divergence = bug.
+
+Anthropic usage-bypass gate. Inner-ring, I/O-free. Read [root CLAUDE.md](../../../CLAUDE.md) first.
+
+## What it does
+
+Tracks the most recent Anthropic unified rate-limit utilization — the same data `claude /usage` CLI reads off `anthropic-ratelimit-unified-{5h,weekly}-*` response headers.
+
+When `ROUTER_USAGE_BYPASS_ENABLED=true`, requests whose recorded 5h + weekly utilization are both below `ROUTER_USAGE_BYPASS_THRESHOLD` (default `0.95`) pass straight through to Anthropic with the requested model — no cluster routing, no planner verdict. Once either window crosses threshold, the gate disengages for that credential + the cluster scorer takes over. Observations expire after `ROUTER_USAGE_OBSERVATION_TTL` (default 10 minutes); a torn-down key or long idle period falls back to "cold start = bypass" rather than pinning the gate open on a stale near-100% reading.
+
+## Why it exists
+
+Anthropic-plan customers (Claude Code's logged-in flow) want unused quota spent on Anthropic, not silently redirected to a cheaper substitute, until actually approaching cap.
+
+## Invariants
+
+- **Pure in-memory state, no persistence.**
+- Entries keyed by `usage.CredentialKey` (salted hash of upstream API key bytes) so logs + metrics never see the raw token.
+- Periodic sweep bounds memory by evicting expired entries.
+- I/O-free per the inner-ring rule — observer is just structs + maps + a mutex.

--- a/internal/router/AGENTS.md
+++ b/internal/router/AGENTS.md
@@ -1,0 +1,34 @@
+# internal/router — AGENTS
+
+> **Mirror notice.** Verbatim sync with [CLAUDE.md](CLAUDE.md). **Update both together** — divergence = bug.
+
+Inner-ring `Router` interface + `Request`/`Decision`/`ModelSpec`/`ModelRegistry` value types. Plus subpackages for cache-aware turn-routing primitives. Read [root CLAUDE.md](../../CLAUDE.md) first.
+
+## Subpackages
+
+| Package | Role | Guide |
+|---|---|---|
+| [`cluster/`](cluster) | AvengersPro-derived primary `Router` impl (P0) | [cluster/CLAUDE.md](cluster/CLAUDE.md) |
+| [`planner/`](planner) | Cache-aware EV policy (STAY vs SWITCH) | [planner/CLAUDE.md](planner/CLAUDE.md) |
+| [`handover/`](handover) | `Summarizer` interface + envelope rewrite | [handover/CLAUDE.md](handover/CLAUDE.md) |
+| [`cache/`](cache) | Cross-request semantic response cache | [cache/CLAUDE.md](cache/CLAUDE.md) |
+| [`sessionpin/`](sessionpin) | Sticky per-session routing pin | [sessionpin/CLAUDE.md](sessionpin/CLAUDE.md) |
+| [`pricing/`](pricing) | Per-model USD + cache-read multipliers | [pricing/CLAUDE.md](pricing/CLAUDE.md) |
+| [`capability/`](capability) | Low/Mid/High capability tier table | [capability/CLAUDE.md](capability/CLAUDE.md) |
+| [`turntype/`](turntype) | Inbound turn-type classifier | [turntype/CLAUDE.md](turntype/CLAUDE.md) |
+
+All inner-ring, all I/O-free.
+
+## Adding a new `router.Router` implementation
+
+1. **Create a sibling subpackage to `cluster/`.** Today `cluster/` (AvengersPro, with `Multiversion` wrapper for per-request bundle selection) is the only `Router` impl in prod. New ones might be e.g. `shadow/` wrapping two others.
+2. **Implement `Route(ctx, router.Request) (router.Decision, error)`.**
+3. **Add compile-time check:** `var _ router.Router = (*X)(nil)`.
+4. **Wire in `../../cmd/router/main.go`** (replacing or wrapping the cluster scorer as needed).
+5. **If the impl needs CGO or external libs**, follow the build-tag pattern in `cluster/embedder_onnx.go` + `embedder_stub.go` so contributors without the library can still `go test` locally.
+6. **Failure modes return errors, not silent fallbacks.** The cluster scorer's `ErrClusterUnavailable` → HTTP 503 pattern is the model: silent fallback to a default model masks regressions + lets quality silently degrade in eval + prod.
+
+## Invariants
+
+- **No I/O in this ring.** Interfaces, value types, pure functions only. Adding an I/O method (HTTP, DB, queue, FS) on anything here is a layering violation — surface it on `auth.Service` / `proxy.Service` or an adapter subpackage instead.
+- **Pure-Go utility libs are fine** (`golang-lru`, `uuid`, error helpers).

--- a/internal/router/CLAUDE.md
+++ b/internal/router/CLAUDE.md
@@ -1,0 +1,34 @@
+# internal/router — CLAUDE
+
+> **Mirror notice.** Verbatim sync with [AGENTS.md](AGENTS.md). **Update both together** — divergence = bug.
+
+Inner-ring `Router` interface + `Request`/`Decision`/`ModelSpec`/`ModelRegistry` value types. Plus subpackages for cache-aware turn-routing primitives. Read [root CLAUDE.md](../../CLAUDE.md) first.
+
+## Subpackages
+
+| Package | Role | Guide |
+|---|---|---|
+| [`cluster/`](cluster) | AvengersPro-derived primary `Router` impl (P0) | [cluster/CLAUDE.md](cluster/CLAUDE.md) |
+| [`planner/`](planner) | Cache-aware EV policy (STAY vs SWITCH) | [planner/CLAUDE.md](planner/CLAUDE.md) |
+| [`handover/`](handover) | `Summarizer` interface + envelope rewrite | [handover/CLAUDE.md](handover/CLAUDE.md) |
+| [`cache/`](cache) | Cross-request semantic response cache | [cache/CLAUDE.md](cache/CLAUDE.md) |
+| [`sessionpin/`](sessionpin) | Sticky per-session routing pin | [sessionpin/CLAUDE.md](sessionpin/CLAUDE.md) |
+| [`pricing/`](pricing) | Per-model USD + cache-read multipliers | [pricing/CLAUDE.md](pricing/CLAUDE.md) |
+| [`capability/`](capability) | Low/Mid/High capability tier table | [capability/CLAUDE.md](capability/CLAUDE.md) |
+| [`turntype/`](turntype) | Inbound turn-type classifier | [turntype/CLAUDE.md](turntype/CLAUDE.md) |
+
+All inner-ring, all I/O-free.
+
+## Adding a new `router.Router` implementation
+
+1. **Create a sibling subpackage to `cluster/`.** Today `cluster/` (AvengersPro, with `Multiversion` wrapper for per-request bundle selection) is the only `Router` impl in prod. New ones might be e.g. `shadow/` wrapping two others.
+2. **Implement `Route(ctx, router.Request) (router.Decision, error)`.**
+3. **Add compile-time check:** `var _ router.Router = (*X)(nil)`.
+4. **Wire in `../../cmd/router/main.go`** (replacing or wrapping the cluster scorer as needed).
+5. **If the impl needs CGO or external libs**, follow the build-tag pattern in `cluster/embedder_onnx.go` + `embedder_stub.go` so contributors without the library can still `go test` locally.
+6. **Failure modes return errors, not silent fallbacks.** The cluster scorer's `ErrClusterUnavailable` → HTTP 503 pattern is the model: silent fallback to a default model masks regressions + lets quality silently degrade in eval + prod.
+
+## Invariants
+
+- **No I/O in this ring.** Interfaces, value types, pure functions only. Adding an I/O method (HTTP, DB, queue, FS) on anything here is a layering violation — surface it on `auth.Service` / `proxy.Service` or an adapter subpackage instead.
+- **Pure-Go utility libs are fine** (`golang-lru`, `uuid`, error helpers).

--- a/internal/router/cache/AGENTS.md
+++ b/internal/router/cache/AGENTS.md
@@ -1,0 +1,19 @@
+# internal/router/cache — AGENTS
+
+> **Mirror notice.** Verbatim sync with [CLAUDE.md](CLAUDE.md). **Update both together** — divergence = bug.
+
+Cross-request semantic response cache. Read [root CLAUDE.md](../../../CLAUDE.md) first.
+
+## What it does
+
+Short-circuits near-duplicate non-streaming requests by cosine similarity on the cluster scorer's prompt embedding. Captured wire-format bytes are replayed without invoking upstream.
+
+- **Isolation:** per-(installation, inbound-format) — captured bytes are post-translation, so reusing across installations or wire formats would corrupt.
+- **Streaming bypasses cache entirely.**
+- Singleton is constructed by `buildSemanticCache` in `cmd/router/main.go`.
+
+## What NOT to do
+
+- **Don't cache streaming responses.** Captured bytes would be post-translation SSE frames + lookup latency budget is hostile to first-token-time. If you think we should change this, write a doc first.
+- **Don't share entries across installations.** Post-translation bytes are caller-shaped.
+- **Don't make cache lookup blocking on a slow store.** The lookup happens on the request path; budget it tightly.

--- a/internal/router/cache/CLAUDE.md
+++ b/internal/router/cache/CLAUDE.md
@@ -1,0 +1,19 @@
+# internal/router/cache — CLAUDE
+
+> **Mirror notice.** Verbatim sync with [AGENTS.md](AGENTS.md). **Update both together** — divergence = bug.
+
+Cross-request semantic response cache. Read [root CLAUDE.md](../../../CLAUDE.md) first.
+
+## What it does
+
+Short-circuits near-duplicate non-streaming requests by cosine similarity on the cluster scorer's prompt embedding. Captured wire-format bytes are replayed without invoking upstream.
+
+- **Isolation:** per-(installation, inbound-format) — captured bytes are post-translation, so reusing across installations or wire formats would corrupt.
+- **Streaming bypasses cache entirely.**
+- Singleton is constructed by `buildSemanticCache` in `cmd/router/main.go`.
+
+## What NOT to do
+
+- **Don't cache streaming responses.** Captured bytes would be post-translation SSE frames + lookup latency budget is hostile to first-token-time. If you think we should change this, write a doc first.
+- **Don't share entries across installations.** Post-translation bytes are caller-shaped.
+- **Don't make cache lookup blocking on a slow store.** The lookup happens on the request path; budget it tightly.

--- a/internal/router/capability/AGENTS.md
+++ b/internal/router/capability/AGENTS.md
@@ -1,0 +1,19 @@
+# internal/router/capability — AGENTS
+
+> **Mirror notice.** Verbatim sync with [CLAUDE.md](CLAUDE.md). **Update both together** — divergence = bug.
+
+Hand-maintained `Tier` table (Low / Mid / High) for each deployed model. Read [root CLAUDE.md](../../../CLAUDE.md) first.
+
+## What it does
+
+Used by [`../planner`](../planner) to overturn a cost-driven "stay" when the fresh decision is in a strictly higher capability tier than the pin (tier-upgrade guard).
+
+## Invariants
+
+- **Hand-maintained.** Deriving tiers from price was rejected — would silently move models on every pricing change.
+- **Every deployed model must have an entry in `capability.Table`.** `Validate()` is called at boot so any deployed model missing a tier entry fails the build loudly rather than silently bypassing the guard.
+- **No I/O.** Static table + accessors.
+
+## When to update
+
+Add a row whenever a new model lands in any deployed `model_registry.json`. Removing a model from registries means the row is dead — remove it too.

--- a/internal/router/capability/CLAUDE.md
+++ b/internal/router/capability/CLAUDE.md
@@ -1,0 +1,19 @@
+# internal/router/capability — CLAUDE
+
+> **Mirror notice.** Verbatim sync with [AGENTS.md](AGENTS.md). **Update both together** — divergence = bug.
+
+Hand-maintained `Tier` table (Low / Mid / High) for each deployed model. Read [root CLAUDE.md](../../../CLAUDE.md) first.
+
+## What it does
+
+Used by [`../planner`](../planner) to overturn a cost-driven "stay" when the fresh decision is in a strictly higher capability tier than the pin (tier-upgrade guard).
+
+## Invariants
+
+- **Hand-maintained.** Deriving tiers from price was rejected — would silently move models on every pricing change.
+- **Every deployed model must have an entry in `capability.Table`.** `Validate()` is called at boot so any deployed model missing a tier entry fails the build loudly rather than silently bypassing the guard.
+- **No I/O.** Static table + accessors.
+
+## When to update
+
+Add a row whenever a new model lands in any deployed `model_registry.json`. Removing a model from registries means the row is dead — remove it too.

--- a/internal/router/cluster/AGENTS.md
+++ b/internal/router/cluster/AGENTS.md
@@ -1,0 +1,65 @@
+# internal/router/cluster — AGENTS
+
+> **Mirror notice.** Verbatim sync with [CLAUDE.md](CLAUDE.md). **Update both together** — divergence = bug.
+
+AvengersPro-derived primary router (arXiv 2508.12631, DAI 2025). **P0.** Full design in [`../../../docs/plans/archive/CLUSTER_ROUTING_PLAN.md`](../../../docs/plans/archive/CLUSTER_ROUTING_PLAN.md); this file is the rules-for-AI subset. Read [root CLAUDE.md](../../../CLAUDE.md) and [internal/router/CLAUDE.md](../CLAUDE.md) first.
+
+## What's load-bearing
+
+### Build tags
+
+Package compiles in **two layered modes via build tags**:
+
+- `embedder_onnx.go` vs `embedder_stub.go` — gated by `no_onnx`. Default builds compile the real hugot-backed embedder; `-tags=no_onnx` swaps in a stub `NewEmbedder` that always errors. Used by contributors without `libonnxruntime`.
+- `-tags ORT` — required by **hugot v0.7+** to enable the ONNX Runtime backend. Without it, `hugot.NewORTSession` returns "to enable ORT, run `go build -tags ORT`" and `cluster.NewEmbedder` fails. Dockerfile builds with `-tags ORT`. **Do not drop this tag from any production-bound build.**
+- To run the parity integration test, combine: `-tags "onnx_integration ORT"`.
+
+### Local-dev build env (Apple Silicon)
+
+- `libtokenizers` static lib must be on the linker path. Pre-built releases at https://github.com/daulet/tokenizers/releases/. Extract `libtokenizers.darwin-arm64.tar.gz` somewhere user-writable + set `CGO_LDFLAGS=-L/path/to/dir`.
+- `libonnxruntime` shared lib via `brew install onnxruntime`. brew installs to `/opt/homebrew/lib`, hugot defaults to `/usr/local/lib` lookup. Set `ROUTER_ONNX_LIBRARY_DIR=/opt/homebrew/lib` to override. (Linux containers using Dockerfile don't need this — `/usr/lib/libonnxruntime.so` is the default, populated by the runtime stage.)
+
+### Versioned artifacts
+
+Every committed bundle lives at `artifacts/v<X.Y>/` with four files: `centroids.bin`, `rankings.json`, `model_registry.json`, `metadata.yaml`.
+
+- `artifacts/latest` pointer file (single line, e.g. `v0.37`) names the version the runtime serves by default; `ROUTER_CLUSTER_VERSION` env overrides.
+- Promotion = one-line edit to `latest` + redeploy.
+- Committed history spans v0.21 through the current `latest` — earlier versions are pruned once they fall out of eval comparison.
+
+### Multi-version build flag
+
+Go runtime builds **only the served default version** by default (`cmd/router/main.go`'s `buildClusterScorer`). Setting `ROUTER_CLUSTER_BUILD_ALL_VERSIONS=true` switches to building **one Scorer per committed bundle** so callers can pin per-request to a sibling version with `x-weave-cluster-version: v0.X` via `middleware.WithClusterVersionOverride`.
+
+"Compare-against-each-other" mechanism — staging/eval deploys set the flag so a single deploy carries every committed bundle + the eval harness flips between them per-request. Prod leaves the flag off: only the default bundle is loaded into memory, and the header override is a no-op.
+
+### Centroids/rankings are write-once
+
+`train_cluster_router.py` always writes to `artifacts/v<X.Y>/` and never overwrites a previous version (auto-bumps from `latest` when `--version` is omitted). Pass `--from v0.36` to clone the previous version's `model_registry.json` before training a new one. **Never edit `centroids.bin` / `rankings.json` by hand.** `model_registry.json` is the only hand-editable file in a bundle (the training script reads it).
+
+### `metadata.yaml`
+
+Informational at runtime — carries version changelog, training params, deployed models, α-blend cost values. Go runtime parses it for `/health`-style provenance; eval harness reads it offline. Keep it accurate but it does not affect routing decisions.
+
+### `assets/model.onnx`
+
+**NOT in git.** Use Jina's own INT8 export at `jinaai/jina-embeddings-v2-base-code`, file path `onnx/model_quantized.onnx`.
+
+- Dockerfile pulls anonymously during build (Jina repo public — self-hosters don't need creds); local dev pulls via `scripts/download_from_hf.py`.
+- `HF_TOKEN` build secret is *optional* (raises rate limits in CI) + `required=false` in Dockerfile.
+- Go embedder reads from `/opt/router/assets/model.onnx` (override via `ROUTER_ONNX_ASSETS_DIR`).
+- If missing or <1 MiB, `cluster.NewEmbedder` errors at boot + `main.go` panics — router refuses to start rather than silently degrading.
+- `HF_MODEL_REVISION` pinned to Jina SHA by default; bump deliberately to pick up new upstream exports.
+
+### Cost values
+
+Used in α-blend, live in `train_cluster_router.py`'s `DEFAULT_COST_PER_1K_INPUT`. Baked into `rankings.json` at training time, not looked up at request time (paper §3 — runtime scoring is a single argmax). When Anthropic changes prices, update the dict + rerun training.
+
+## What to NOT do
+
+- **Don't add per-request cost lookup or runtime α knob.** α is baked at training time; changing it requires retraining. Per-request override (`x-weave-routing-alpha`) is P1, not P0 — wait for a customer ask before shipping.
+- **Don't loosen `MaxPromptChars = 1024` cap** without re-running the latency test. BERT inference is O(n²) attention; the cap is load-bearing.
+- **Don't add fail-open fallbacks.** Cluster scorer returns `ErrClusterUnavailable` on every failure path (embed timeout, embed error, dim mismatch, prompt too short, empty argmax). API handlers map it to HTTP 503. The previous `heuristic` fallback was removed because it silently degraded routing — every request that should have hit the cluster scorer instead got `claude-haiku-4-5`, masking real regressions in eval + prod. New failure modes return the sentinel; no default-model shortcut "for safety".
+- **Don't change the centroid format without bumping the magic string.** `loadCentroids` uses magic + version header to refuse mismatched binaries; if the layout changes, bump `centroidsMagic` from `CRT1` to `CRT2` so the next deploy refuses old binaries instead of silently misrouting.
+- **Don't overwrite a previously committed artifact version.** Versions are frozen for comparison — once `v0.37` is committed, train to `v0.38` rather than re-running `train_cluster_router.py` against `v0.37`. Training script auto-bumps; only override with `--version v0.X` for in-place fixes intended to land as a separate commit.
+- **Don't bypass the version pointer.** `artifacts/latest` is the single source of truth for the default served version. Don't hardcode a version in `cmd/router/main.go`; let `cluster.ResolveVersion` read the pointer.

--- a/internal/router/cluster/CLAUDE.md
+++ b/internal/router/cluster/CLAUDE.md
@@ -1,0 +1,65 @@
+# internal/router/cluster — CLAUDE
+
+> **Mirror notice.** Verbatim sync with [AGENTS.md](AGENTS.md). **Update both together** — divergence = bug.
+
+AvengersPro-derived primary router (arXiv 2508.12631, DAI 2025). **P0.** Full design in [`../../../docs/plans/archive/CLUSTER_ROUTING_PLAN.md`](../../../docs/plans/archive/CLUSTER_ROUTING_PLAN.md); this file is the rules-for-AI subset. Read [root CLAUDE.md](../../../CLAUDE.md) and [internal/router/CLAUDE.md](../CLAUDE.md) first.
+
+## What's load-bearing
+
+### Build tags
+
+Package compiles in **two layered modes via build tags**:
+
+- `embedder_onnx.go` vs `embedder_stub.go` — gated by `no_onnx`. Default builds compile the real hugot-backed embedder; `-tags=no_onnx` swaps in a stub `NewEmbedder` that always errors. Used by contributors without `libonnxruntime`.
+- `-tags ORT` — required by **hugot v0.7+** to enable the ONNX Runtime backend. Without it, `hugot.NewORTSession` returns "to enable ORT, run `go build -tags ORT`" and `cluster.NewEmbedder` fails. Dockerfile builds with `-tags ORT`. **Do not drop this tag from any production-bound build.**
+- To run the parity integration test, combine: `-tags "onnx_integration ORT"`.
+
+### Local-dev build env (Apple Silicon)
+
+- `libtokenizers` static lib must be on the linker path. Pre-built releases at https://github.com/daulet/tokenizers/releases/. Extract `libtokenizers.darwin-arm64.tar.gz` somewhere user-writable + set `CGO_LDFLAGS=-L/path/to/dir`.
+- `libonnxruntime` shared lib via `brew install onnxruntime`. brew installs to `/opt/homebrew/lib`, hugot defaults to `/usr/local/lib` lookup. Set `ROUTER_ONNX_LIBRARY_DIR=/opt/homebrew/lib` to override. (Linux containers using Dockerfile don't need this — `/usr/lib/libonnxruntime.so` is the default, populated by the runtime stage.)
+
+### Versioned artifacts
+
+Every committed bundle lives at `artifacts/v<X.Y>/` with four files: `centroids.bin`, `rankings.json`, `model_registry.json`, `metadata.yaml`.
+
+- `artifacts/latest` pointer file (single line, e.g. `v0.37`) names the version the runtime serves by default; `ROUTER_CLUSTER_VERSION` env overrides.
+- Promotion = one-line edit to `latest` + redeploy.
+- Committed history spans v0.21 through the current `latest` — earlier versions are pruned once they fall out of eval comparison.
+
+### Multi-version build flag
+
+Go runtime builds **only the served default version** by default (`cmd/router/main.go`'s `buildClusterScorer`). Setting `ROUTER_CLUSTER_BUILD_ALL_VERSIONS=true` switches to building **one Scorer per committed bundle** so callers can pin per-request to a sibling version with `x-weave-cluster-version: v0.X` via `middleware.WithClusterVersionOverride`.
+
+"Compare-against-each-other" mechanism — staging/eval deploys set the flag so a single deploy carries every committed bundle + the eval harness flips between them per-request. Prod leaves the flag off: only the default bundle is loaded into memory, and the header override is a no-op.
+
+### Centroids/rankings are write-once
+
+`train_cluster_router.py` always writes to `artifacts/v<X.Y>/` and never overwrites a previous version (auto-bumps from `latest` when `--version` is omitted). Pass `--from v0.36` to clone the previous version's `model_registry.json` before training a new one. **Never edit `centroids.bin` / `rankings.json` by hand.** `model_registry.json` is the only hand-editable file in a bundle (the training script reads it).
+
+### `metadata.yaml`
+
+Informational at runtime — carries version changelog, training params, deployed models, α-blend cost values. Go runtime parses it for `/health`-style provenance; eval harness reads it offline. Keep it accurate but it does not affect routing decisions.
+
+### `assets/model.onnx`
+
+**NOT in git.** Use Jina's own INT8 export at `jinaai/jina-embeddings-v2-base-code`, file path `onnx/model_quantized.onnx`.
+
+- Dockerfile pulls anonymously during build (Jina repo public — self-hosters don't need creds); local dev pulls via `scripts/download_from_hf.py`.
+- `HF_TOKEN` build secret is *optional* (raises rate limits in CI) + `required=false` in Dockerfile.
+- Go embedder reads from `/opt/router/assets/model.onnx` (override via `ROUTER_ONNX_ASSETS_DIR`).
+- If missing or <1 MiB, `cluster.NewEmbedder` errors at boot + `main.go` panics — router refuses to start rather than silently degrading.
+- `HF_MODEL_REVISION` pinned to Jina SHA by default; bump deliberately to pick up new upstream exports.
+
+### Cost values
+
+Used in α-blend, live in `train_cluster_router.py`'s `DEFAULT_COST_PER_1K_INPUT`. Baked into `rankings.json` at training time, not looked up at request time (paper §3 — runtime scoring is a single argmax). When Anthropic changes prices, update the dict + rerun training.
+
+## What to NOT do
+
+- **Don't add per-request cost lookup or runtime α knob.** α is baked at training time; changing it requires retraining. Per-request override (`x-weave-routing-alpha`) is P1, not P0 — wait for a customer ask before shipping.
+- **Don't loosen `MaxPromptChars = 1024` cap** without re-running the latency test. BERT inference is O(n²) attention; the cap is load-bearing.
+- **Don't add fail-open fallbacks.** Cluster scorer returns `ErrClusterUnavailable` on every failure path (embed timeout, embed error, dim mismatch, prompt too short, empty argmax). API handlers map it to HTTP 503. The previous `heuristic` fallback was removed because it silently degraded routing — every request that should have hit the cluster scorer instead got `claude-haiku-4-5`, masking real regressions in eval + prod. New failure modes return the sentinel; no default-model shortcut "for safety".
+- **Don't change the centroid format without bumping the magic string.** `loadCentroids` uses magic + version header to refuse mismatched binaries; if the layout changes, bump `centroidsMagic` from `CRT1` to `CRT2` so the next deploy refuses old binaries instead of silently misrouting.
+- **Don't overwrite a previously committed artifact version.** Versions are frozen for comparison — once `v0.37` is committed, train to `v0.38` rather than re-running `train_cluster_router.py` against `v0.37`. Training script auto-bumps; only override with `--version v0.X` for in-place fixes intended to land as a separate commit.
+- **Don't bypass the version pointer.** `artifacts/latest` is the single source of truth for the default served version. Don't hardcode a version in `cmd/router/main.go`; let `cluster.ResolveVersion` read the pointer.

--- a/internal/router/handover/AGENTS.md
+++ b/internal/router/handover/AGENTS.md
@@ -1,0 +1,19 @@
+# internal/router/handover — AGENTS
+
+> **Mirror notice.** Verbatim sync with [CLAUDE.md](CLAUDE.md). **Update both together** — divergence = bug.
+
+`Summarizer` interface + envelope-rewrite helpers. Read [root CLAUDE.md](../../../CLAUDE.md) first.
+
+## What it does
+
+When the planner decides SWITCH, proxy asks a small model to summarize prior conversation + rewrites the message history to `[synthesizedSummary, latestUser]` before dispatching to the new model. Bounds the switch turn's input cost regardless of session length.
+
+## Layout
+
+- Inner-ring package here defines the **contract only** (`Summarizer` interface, `TrimLastN` fallback, envelope helpers).
+- Provider-backed implementation lives in [`../../proxy/handover.go`](../../proxy/handover.go).
+
+## Invariants
+
+- **`Summarizer` implementations MUST respect the context deadline.** On summarizer timeout or error, proxy falls back to `handover.TrimLastN` — that is the correct behavior, not a bug. Do not "fix" by waiting longer.
+- **No I/O in this package.** All I/O lives in the proxy-side implementation.

--- a/internal/router/handover/CLAUDE.md
+++ b/internal/router/handover/CLAUDE.md
@@ -1,0 +1,19 @@
+# internal/router/handover — CLAUDE
+
+> **Mirror notice.** Verbatim sync with [AGENTS.md](AGENTS.md). **Update both together** — divergence = bug.
+
+`Summarizer` interface + envelope-rewrite helpers. Read [root CLAUDE.md](../../../CLAUDE.md) first.
+
+## What it does
+
+When the planner decides SWITCH, proxy asks a small model to summarize prior conversation + rewrites the message history to `[synthesizedSummary, latestUser]` before dispatching to the new model. Bounds the switch turn's input cost regardless of session length.
+
+## Layout
+
+- Inner-ring package here defines the **contract only** (`Summarizer` interface, `TrimLastN` fallback, envelope helpers).
+- Provider-backed implementation lives in [`../../proxy/handover.go`](../../proxy/handover.go).
+
+## Invariants
+
+- **`Summarizer` implementations MUST respect the context deadline.** On summarizer timeout or error, proxy falls back to `handover.TrimLastN` — that is the correct behavior, not a bug. Do not "fix" by waiting longer.
+- **No I/O in this package.** All I/O lives in the proxy-side implementation.

--- a/internal/router/planner/AGENTS.md
+++ b/internal/router/planner/AGENTS.md
@@ -1,0 +1,28 @@
+# internal/router/planner — AGENTS
+
+> **Mirror notice.** Verbatim sync with [CLAUDE.md](CLAUDE.md). **Update both together** — divergence = bug.
+
+Prism-style cache-aware EV policy. Decides STAY (preserve pinned model's upstream prompt cache) vs SWITCH (take cluster scorer's fresh decision + eat one-time cache miss) per turn. Read [root CLAUDE.md](../../../CLAUDE.md) first.
+
+## Contract
+
+```
+Decide(pin, fresh router.Decision, estimated tokens, available models) → STAY | SWITCH
+```
+
+- **Pure function.** No DB lookups, no provider calls.
+- Inputs are values: pin row, fresh decision, estimated token count, available-model set resolved at boot.
+
+## Math, briefly
+
+Compares expected per-turn savings over the remaining horizon against the eviction cost of warming a new cache. The **tier-upgrade guard** fires when STAY would clearly under-serve the prompt — uses [`../capability`](../capability)'s Low/Mid/High table to overturn a cost-driven "stay" when the fresh decision is in a strictly higher tier than the pin.
+
+## Invariants
+
+- **Pure.** Anything network-touching belongs in `proxy.Service`, not here.
+- **Tests cover EV math without spinning anything up.** Use in-memory fixtures; no `httptest`, no Postgres.
+
+## What NOT to do
+
+- **Don't add a runtime override that mutates α-blend.** Cost weighting is baked into the cluster scorer at training time. Per-request cost knobs are a separate (P1) feature, not a planner responsibility.
+- **Don't read pricing from anywhere but [`../pricing`](../pricing).** Single source of truth — the OTel emitter and planner must agree.

--- a/internal/router/planner/CLAUDE.md
+++ b/internal/router/planner/CLAUDE.md
@@ -1,0 +1,28 @@
+# internal/router/planner — CLAUDE
+
+> **Mirror notice.** Verbatim sync with [AGENTS.md](AGENTS.md). **Update both together** — divergence = bug.
+
+Prism-style cache-aware EV policy. Decides STAY (preserve pinned model's upstream prompt cache) vs SWITCH (take cluster scorer's fresh decision + eat one-time cache miss) per turn. Read [root CLAUDE.md](../../../CLAUDE.md) first.
+
+## Contract
+
+```
+Decide(pin, fresh router.Decision, estimated tokens, available models) → STAY | SWITCH
+```
+
+- **Pure function.** No DB lookups, no provider calls.
+- Inputs are values: pin row, fresh decision, estimated token count, available-model set resolved at boot.
+
+## Math, briefly
+
+Compares expected per-turn savings over the remaining horizon against the eviction cost of warming a new cache. The **tier-upgrade guard** fires when STAY would clearly under-serve the prompt — uses [`../capability`](../capability)'s Low/Mid/High table to overturn a cost-driven "stay" when the fresh decision is in a strictly higher tier than the pin.
+
+## Invariants
+
+- **Pure.** Anything network-touching belongs in `proxy.Service`, not here.
+- **Tests cover EV math without spinning anything up.** Use in-memory fixtures; no `httptest`, no Postgres.
+
+## What NOT to do
+
+- **Don't add a runtime override that mutates α-blend.** Cost weighting is baked into the cluster scorer at training time. Per-request cost knobs are a separate (P1) feature, not a planner responsibility.
+- **Don't read pricing from anywhere but [`../pricing`](../pricing).** Single source of truth — the OTel emitter and planner must agree.

--- a/internal/router/pricing/AGENTS.md
+++ b/internal/router/pricing/AGENTS.md
@@ -1,0 +1,23 @@
+# internal/router/pricing — AGENTS
+
+> **Mirror notice.** Verbatim sync with [CLAUDE.md](CLAUDE.md). **Update both together** — divergence = bug.
+
+Per-model USD pricing + per-model cache-read multipliers. Read [root CLAUDE.md](../../../CLAUDE.md) first.
+
+## What's here
+
+- Per-model input / output / cache-write USD rates.
+- Per-model cache-read multipliers: Anthropic 0.10, OpenAI 0.50, Gemini 0.25, DeepSeek 0.10.
+- `DefaultCacheReadMultiplier = 0.5` for unspecified models.
+- Pure data + lookup helpers.
+
+## Invariants
+
+- **Single source of truth.** The OTel emitter and the planner both read the same map. Don't introduce a parallel price table elsewhere.
+- **Per-provider cache-read multipliers, not global.** A single global multiplier makes cross-provider switches (opus → gpt-5) economically wrong.
+- **Always go through `pricing.Pricing.EffectiveCacheReadMultiplier`** — never read the bare struct field.
+- **No I/O.** Static data + accessors.
+
+## Updating prices
+
+When Anthropic / OpenAI / Google / OpenRouter / Fireworks change prices, update this map. For the α-blend cost values used by the cluster scorer, also update `train_cluster_router.py`'s `DEFAULT_COST_PER_1K_INPUT` + rerun training — those are baked at training time, not looked up at request time.

--- a/internal/router/pricing/CLAUDE.md
+++ b/internal/router/pricing/CLAUDE.md
@@ -1,0 +1,23 @@
+# internal/router/pricing — CLAUDE
+
+> **Mirror notice.** Verbatim sync with [AGENTS.md](AGENTS.md). **Update both together** — divergence = bug.
+
+Per-model USD pricing + per-model cache-read multipliers. Read [root CLAUDE.md](../../../CLAUDE.md) first.
+
+## What's here
+
+- Per-model input / output / cache-write USD rates.
+- Per-model cache-read multipliers: Anthropic 0.10, OpenAI 0.50, Gemini 0.25, DeepSeek 0.10.
+- `DefaultCacheReadMultiplier = 0.5` for unspecified models.
+- Pure data + lookup helpers.
+
+## Invariants
+
+- **Single source of truth.** The OTel emitter and the planner both read the same map. Don't introduce a parallel price table elsewhere.
+- **Per-provider cache-read multipliers, not global.** A single global multiplier makes cross-provider switches (opus → gpt-5) economically wrong.
+- **Always go through `pricing.Pricing.EffectiveCacheReadMultiplier`** — never read the bare struct field.
+- **No I/O.** Static data + accessors.
+
+## Updating prices
+
+When Anthropic / OpenAI / Google / OpenRouter / Fireworks change prices, update this map. For the α-blend cost values used by the cluster scorer, also update `train_cluster_router.py`'s `DEFAULT_COST_PER_1K_INPUT` + rerun training — those are baked at training time, not looked up at request time.

--- a/internal/router/sessionpin/AGENTS.md
+++ b/internal/router/sessionpin/AGENTS.md
@@ -1,0 +1,24 @@
+# internal/router/sessionpin — AGENTS
+
+> **Mirror notice.** Verbatim sync with [CLAUDE.md](CLAUDE.md). **Update both together** — divergence = bug.
+
+`Pin` type + `Store` interface for sticky per-session routing. Read [root CLAUDE.md](../../../CLAUDE.md) first.
+
+## Surface
+
+- `Pin` value type.
+- `Store` interface (inner-ring contract) — implemented by `postgres.SessionPinRepository` in [`../../postgres`](../../postgres).
+- Keyed by `(api_key_id, session_key, role)` where `session_key` = 16-byte sha256 truncation derived from the inbound request (see [`../../proxy/session_key.go`](../../proxy/session_key.go)).
+
+## Roles
+
+Stage 1 emits `role="default"` only. The column exists so a turn-type detector can land role-conditioned pinning later without a schema change.
+
+## TTL sweep
+
+`runSessionPinSweep` in `cmd/router/main.go` runs the TTL sweep loop. The store interface lives here; the loop and the Postgres adapter live outside the inner ring.
+
+## Invariants
+
+- **Interface in inner ring; impl in `internal/postgres`.** Proxy service is unit-tested with an in-memory fake; the Postgres adapter is exercised end-to-end via the docker-compose stack.
+- **No I/O in this package.** Just types + interface.

--- a/internal/router/sessionpin/CLAUDE.md
+++ b/internal/router/sessionpin/CLAUDE.md
@@ -1,0 +1,24 @@
+# internal/router/sessionpin — CLAUDE
+
+> **Mirror notice.** Verbatim sync with [AGENTS.md](AGENTS.md). **Update both together** — divergence = bug.
+
+`Pin` type + `Store` interface for sticky per-session routing. Read [root CLAUDE.md](../../../CLAUDE.md) first.
+
+## Surface
+
+- `Pin` value type.
+- `Store` interface (inner-ring contract) — implemented by `postgres.SessionPinRepository` in [`../../postgres`](../../postgres).
+- Keyed by `(api_key_id, session_key, role)` where `session_key` = 16-byte sha256 truncation derived from the inbound request (see [`../../proxy/session_key.go`](../../proxy/session_key.go)).
+
+## Roles
+
+Stage 1 emits `role="default"` only. The column exists so a turn-type detector can land role-conditioned pinning later without a schema change.
+
+## TTL sweep
+
+`runSessionPinSweep` in `cmd/router/main.go` runs the TTL sweep loop. The store interface lives here; the loop and the Postgres adapter live outside the inner ring.
+
+## Invariants
+
+- **Interface in inner ring; impl in `internal/postgres`.** Proxy service is unit-tested with an in-memory fake; the Postgres adapter is exercised end-to-end via the docker-compose stack.
+- **No I/O in this package.** Just types + interface.

--- a/internal/router/turntype/AGENTS.md
+++ b/internal/router/turntype/AGENTS.md
@@ -1,0 +1,22 @@
+# internal/router/turntype — AGENTS
+
+> **Mirror notice.** Verbatim sync with [CLAUDE.md](CLAUDE.md). **Update both together** — divergence = bug.
+
+Inbound turn-type classifier. Read [root CLAUDE.md](../../../CLAUDE.md) first.
+
+## What it does
+
+Classifies inbound requests into:
+
+- `MainLoop`
+- `ToolResult` — proxy short-circuits to the session pin (these turns' embeddings are mostly noise)
+- `SubAgentDispatch`
+- `Compaction` — proxy forces Haiku
+- `Probe` — proxy bypasses routing entirely
+
+Used by [`../../proxy`](../../proxy) to keep the turn loop cheap + correct.
+
+## Invariants
+
+- **Pure, no I/O.** Static classifier over `router.Request` shape.
+- **No upstream dependency in the inner ring.** Don't import providers, postgres, or proxy.

--- a/internal/router/turntype/CLAUDE.md
+++ b/internal/router/turntype/CLAUDE.md
@@ -1,0 +1,22 @@
+# internal/router/turntype — CLAUDE
+
+> **Mirror notice.** Verbatim sync with [AGENTS.md](AGENTS.md). **Update both together** — divergence = bug.
+
+Inbound turn-type classifier. Read [root CLAUDE.md](../../../CLAUDE.md) first.
+
+## What it does
+
+Classifies inbound requests into:
+
+- `MainLoop`
+- `ToolResult` — proxy short-circuits to the session pin (these turns' embeddings are mostly noise)
+- `SubAgentDispatch`
+- `Compaction` — proxy forces Haiku
+- `Probe` — proxy bypasses routing entirely
+
+Used by [`../../proxy`](../../proxy) to keep the turn loop cheap + correct.
+
+## Invariants
+
+- **Pure, no I/O.** Static classifier over `router.Request` shape.
+- **No upstream dependency in the inner ring.** Don't import providers, postgres, or proxy.

--- a/internal/translate/AGENTS.md
+++ b/internal/translate/AGENTS.md
@@ -1,0 +1,33 @@
+# internal/translate — AGENTS
+
+> **Mirror notice.** Verbatim sync with [CLAUDE.md](CLAUDE.md). **Update both together** — divergence = bug.
+
+Cross-format wire-format conversion. Pure functions, no I/O, no provider knowledge, no domain types. Read [root CLAUDE.md](../../CLAUDE.md) first.
+
+## Scope
+
+Covers all three directions: Anthropic ⇄ OpenAI and Gemini ⇄ {Anthropic, OpenAI} via a `RequestEnvelope` intermediate + per-target `emit_*.go` files.
+
+**Only [`../proxy`](../proxy) calls this package.** Providers stay ignorant of cross-format concerns.
+
+## Adding a wire-format pair
+
+When a new inbound format needs to talk to an existing upstream provider with a different wire format:
+
+1. **Add conversion functions to this package.** Pure functions only — no I/O, no provider knowledge, no domain types.
+2. **If response streaming, adapt [`stream.go`](stream.go) / [`gemini_stream.go`](gemini_stream.go)** or add a sibling decorator. Decorators wrap `http.ResponseWriter` and translate on the fly so we never buffer entire responses. Use [`../sse`](../sse) for zero-alloc SSE framing.
+3. **Compose the new translation in `proxy.Service.Proxy*`.** Proxy is the only caller of `translate`.
+
+## Anthropic-specific stripping (load-bearing)
+
+Anthropic-only fields (`thinking`, `cache_control`, `metadata`, Anthropic beta headers) are stripped at translation time **and again defensively in the OpenAI / openaicompat adapters**. Keep both checks — belt-and-suspenders is intentional because the field set drifts as Anthropic adds beta features.
+
+## Gemini 3.x `thoughtSignature` (load-bearing)
+
+The router translator must **round-trip `thoughtSignature` on text / thinking blocks as well as `functionCall` blocks**. Dropping it on text parts breaks the next turn against Gemini 3.x preview models with a 400. The native Generative Language REST client in [`../providers/google`](../providers/google) is mandatory for those flows; the OpenAI-compat surface at `/v1beta/openai` does **not** preserve `thoughtSignature`.
+
+## Invariants
+
+- **No I/O.** No HTTP, no DB, no filesystem.
+- **No domain types.** Don't import `auth`, `proxy`, or anything from `internal/router/*`.
+- **No provider package imports.** Translation must be addressable without pulling in `internal/providers/<name>`.

--- a/internal/translate/CLAUDE.md
+++ b/internal/translate/CLAUDE.md
@@ -1,0 +1,33 @@
+# internal/translate — CLAUDE
+
+> **Mirror notice.** Verbatim sync with [AGENTS.md](AGENTS.md). **Update both together** — divergence = bug.
+
+Cross-format wire-format conversion. Pure functions, no I/O, no provider knowledge, no domain types. Read [root CLAUDE.md](../../CLAUDE.md) first.
+
+## Scope
+
+Covers all three directions: Anthropic ⇄ OpenAI and Gemini ⇄ {Anthropic, OpenAI} via a `RequestEnvelope` intermediate + per-target `emit_*.go` files.
+
+**Only [`../proxy`](../proxy) calls this package.** Providers stay ignorant of cross-format concerns.
+
+## Adding a wire-format pair
+
+When a new inbound format needs to talk to an existing upstream provider with a different wire format:
+
+1. **Add conversion functions to this package.** Pure functions only — no I/O, no provider knowledge, no domain types.
+2. **If response streaming, adapt [`stream.go`](stream.go) / [`gemini_stream.go`](gemini_stream.go)** or add a sibling decorator. Decorators wrap `http.ResponseWriter` and translate on the fly so we never buffer entire responses. Use [`../sse`](../sse) for zero-alloc SSE framing.
+3. **Compose the new translation in `proxy.Service.Proxy*`.** Proxy is the only caller of `translate`.
+
+## Anthropic-specific stripping (load-bearing)
+
+Anthropic-only fields (`thinking`, `cache_control`, `metadata`, Anthropic beta headers) are stripped at translation time **and again defensively in the OpenAI / openaicompat adapters**. Keep both checks — belt-and-suspenders is intentional because the field set drifts as Anthropic adds beta features.
+
+## Gemini 3.x `thoughtSignature` (load-bearing)
+
+The router translator must **round-trip `thoughtSignature` on text / thinking blocks as well as `functionCall` blocks**. Dropping it on text parts breaks the next turn against Gemini 3.x preview models with a 400. The native Generative Language REST client in [`../providers/google`](../providers/google) is mandatory for those flows; the OpenAI-compat surface at `/v1beta/openai` does **not** preserve `thoughtSignature`.
+
+## Invariants
+
+- **No I/O.** No HTTP, no DB, no filesystem.
+- **No domain types.** Don't import `auth`, `proxy`, or anything from `internal/router/*`.
+- **No provider package imports.** Translation must be addressable without pulling in `internal/providers/<name>`.


### PR DESCRIPTION
## Summary

- Replace single 371-line `CLAUDE.md` / `AGENTS.md` at the router root with a slim root file plus per-package `CLAUDE.md` (and `AGENTS.md` mirror) so Claude Code / Cursor / generic agents only load the rules relevant to the file under edit.
- Root keeps cross-cutting concerns: engineering principles, layer model + hard rules, global Go / test / log conventions, "never do" list, deployment modes, eval-harness header contract, and a "where to put new code" table that links each subpackage's `CLAUDE.md`.
- Each per-package file carries the focused recipes, invariants, and "what not to do" items previously buried in the root doc.

## Files created

- `cmd/`
- `internal/api`, `internal/auth`, `internal/proxy`, `internal/proxy/usage`, `internal/translate`, `internal/providers`, `internal/postgres`
- `internal/router` (umbrella) and each subpackage: `cluster`, `planner`, `handover`, `cache`, `sessionpin`, `pricing`, `capability`, `turntype`
- `db/` (migrations + SQLC conventions)
- `docs/` (doc-index rule)

Each `AGENTS.md` is generated from the same source as its sibling `CLAUDE.md`; the mirror notice cross-references the other file.

## Test plan

- [ ] Skim each new `CLAUDE.md` for the package you know best — flag any rule lost in translation from the original root doc.
- [ ] Confirm `diff` between any `CLAUDE.md` and its `AGENTS.md` sibling only shows the title line + the mirror-notice cross-reference.
- [ ] Verify the root `CLAUDE.md` still has the layer-model ASCII diagram and the full hard-rules / never-do lists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)