### PR TITLE
translate: emit tools with strict mode for DeepSeek targets

### DIFF
--- a/internal/translate/emit_openai.go
+++ b/internal/translate/emit_openai.go
@@ -394,7 +394,7 @@ func applyStrictModeToParams(node any) {
 	if !ok {
 		return
 	}
-	if t, _ := m["type"].(string); t == "object" {
+	if isObjectType(m["type"]) {
 		m["additionalProperties"] = false
 		if props, ok := m["properties"].(map[string]any); ok && len(props) > 0 {
 			existing := map[string]struct{}{}
@@ -433,6 +433,25 @@ func applyStrictModeToParams(node any) {
 			}
 		}
 	}
+}
+
+// isObjectType reports whether a JSON Schema `type` value is "object", either
+// as a bare string or as part of a nullable union like ["object", "null"].
+// Optional nested objects pass through `makeNullable` before recursion, which
+// rewrites scalar `type: "object"` to a string-array, so the strict-mode pass
+// must accept both shapes or it skips invariants on those subtrees.
+func isObjectType(typ any) bool {
+	switch t := typ.(type) {
+	case string:
+		return t == "object"
+	case []any:
+		for _, v := range t {
+			if s, _ := v.(string); s == "object" {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 // applyStrictToolsToBody mutates the `tools` array of a serialized OpenAI body

--- a/internal/translate/emit_openai.go
+++ b/internal/translate/emit_openai.go
@@ -426,6 +426,13 @@ func applyStrictModeToParams(node any) {
 		}
 	}
 	applyStrictModeToParams(m["items"])
+	for _, key := range []string{"$defs", "definitions"} {
+		if defs, ok := m[key].(map[string]any); ok {
+			for _, v := range defs {
+				applyStrictModeToParams(v)
+			}
+		}
+	}
 	for _, key := range []string{"anyOf", "oneOf", "allOf"} {
 		if arr, ok := m[key].([]any); ok {
 			for _, v := range arr {

--- a/internal/translate/emit_openai.go
+++ b/internal/translate/emit_openai.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"sort"
 	"strings"
 
 	"workweave/router/internal/providers"
@@ -63,6 +64,12 @@ func (e *RequestEnvelope) buildOpenAIFromOpenAI(opts EmitOptions) ([]byte, error
 			return nil, fmt.Errorf("set tool temperature override: %w", err)
 		}
 	}
+	if openRouterStrictTools(opts.TargetModel) && gjson.GetBytes(body, "tools").Exists() {
+		body, err = applyStrictToolsToBody(body)
+		if err != nil {
+			return nil, fmt.Errorf("apply strict tools: %w", err)
+		}
+	}
 	return body, nil
 }
 
@@ -78,7 +85,7 @@ func (e *RequestEnvelope) buildOpenAIFromAnthropic(opts EmitOptions) ([]byte, er
 		return nil, err
 	}
 	pullAnthropicStopSequences(e.body, out)
-	if err := e.pullAnthropicTools(out); err != nil {
+	if err := e.pullAnthropicTools(out, openRouterStrictTools(opts.TargetModel)); err != nil {
 		return nil, err
 	}
 	pullAnthropicToolChoice(e.body, out)
@@ -342,7 +349,7 @@ func (e *RequestEnvelope) pullAnthropicSystemAndMessages(out map[string]any) err
 
 const openAIMaxTools = 128
 
-func (e *RequestEnvelope) pullAnthropicTools(out map[string]any) error {
+func (e *RequestEnvelope) pullAnthropicTools(out map[string]any, strict bool) error {
 	src, err := e.ensureSrc()
 	if err != nil {
 		return err
@@ -364,6 +371,10 @@ func (e *RequestEnvelope) pullAnthropicTools(out map[string]any) error {
 			"description": tool["description"],
 			"parameters":  params,
 		}
+		if strict {
+			applyStrictModeToParams(params)
+			fn["strict"] = true
+		}
 		result = append(result, map[string]any{"type": "function", "function": fn})
 	}
 	if len(result) > openAIMaxTools {
@@ -371,6 +382,109 @@ func (e *RequestEnvelope) pullAnthropicTools(out map[string]any) error {
 	}
 	out["tools"] = result
 	return nil
+}
+
+// applyStrictModeToParams mutates a JSON Schema so it satisfies OpenAI's
+// strict-mode tool-call requirements: every `type: "object"` schema gets
+// `additionalProperties: false` and every property is listed in `required`.
+// Properties not in the source `required` set are marked nullable via a type
+// union so the model can still pass null to preserve "optional" semantics.
+func applyStrictModeToParams(node any) {
+	m, ok := node.(map[string]any)
+	if !ok {
+		return
+	}
+	if t, _ := m["type"].(string); t == "object" {
+		m["additionalProperties"] = false
+		if props, ok := m["properties"].(map[string]any); ok && len(props) > 0 {
+			existing := map[string]struct{}{}
+			if reqArr, ok := m["required"].([]any); ok {
+				for _, r := range reqArr {
+					if s, ok := r.(string); ok {
+						existing[s] = struct{}{}
+					}
+				}
+			}
+			names := make([]string, 0, len(props))
+			for name := range props {
+				names = append(names, name)
+			}
+			sort.Strings(names)
+			required := make([]any, 0, len(names))
+			for _, name := range names {
+				required = append(required, name)
+				if _, wasRequired := existing[name]; !wasRequired {
+					makeNullable(props[name])
+				}
+			}
+			m["required"] = required
+		}
+	}
+	if props, ok := m["properties"].(map[string]any); ok {
+		for _, v := range props {
+			applyStrictModeToParams(v)
+		}
+	}
+	applyStrictModeToParams(m["items"])
+	for _, key := range []string{"anyOf", "oneOf", "allOf"} {
+		if arr, ok := m[key].([]any); ok {
+			for _, v := range arr {
+				applyStrictModeToParams(v)
+			}
+		}
+	}
+}
+
+// applyStrictToolsToBody mutates the `tools` array of a serialized OpenAI body
+// to add `function.strict = true` and tighten each parameter schema. Best-effort:
+// returns the input unchanged when `tools` cannot be parsed rather than failing
+// the request.
+func applyStrictToolsToBody(body []byte) ([]byte, error) {
+	toolsResult := gjson.GetBytes(body, "tools")
+	if !toolsResult.IsArray() {
+		return body, nil
+	}
+	var tools []any
+	if err := json.Unmarshal([]byte(toolsResult.Raw), &tools); err != nil {
+		return body, nil
+	}
+	for _, t := range tools {
+		tool, _ := t.(map[string]any)
+		if tool == nil {
+			continue
+		}
+		fn, _ := tool["function"].(map[string]any)
+		if fn == nil {
+			continue
+		}
+		applyStrictModeToParams(fn["parameters"])
+		fn["strict"] = true
+	}
+	return sjson.SetBytes(body, "tools", tools)
+}
+
+// makeNullable adds "null" to a schema's `type` so strict mode can still send
+// a null value for what was previously an optional property. No-op when the
+// schema lacks a `type` keyword or already permits null.
+func makeNullable(node any) {
+	m, ok := node.(map[string]any)
+	if !ok {
+		return
+	}
+	switch t := m["type"].(type) {
+	case string:
+		if t == "null" {
+			return
+		}
+		m["type"] = []any{t, "null"}
+	case []any:
+		for _, v := range t {
+			if s, _ := v.(string); s == "null" {
+				return
+			}
+		}
+		m["type"] = append(t, "null")
+	}
 }
 
 func sanitizeOpenAIToolSchema(node any) {

--- a/internal/translate/provider_hint.go
+++ b/internal/translate/provider_hint.go
@@ -42,3 +42,11 @@ func openRouterReasoningHint(model string) map[string]any {
 func openRouterForcesToolTemperatureZero(model string) bool {
 	return strings.HasPrefix(model, "deepseek/")
 }
+
+// openRouterStrictTools reports whether tool definitions should be emitted with
+// `strict: true` and a strict-mode-compatible parameter schema. Reserved for
+// models that drift tool-arg JSON from the declared schema (extra fields, wrong
+// types) badly enough that constrained decoding is worth the schema constraints.
+func openRouterStrictTools(model string) bool {
+	return strings.HasPrefix(model, "deepseek/")
+}

--- a/internal/translate/strict_tools_test.go
+++ b/internal/translate/strict_tools_test.go
@@ -186,6 +186,65 @@ func TestStrictTools_AnthropicSource_OptionalNestedObjectStillTightened(t *testi
 		"nullable nested objects still need their properties moved to required")
 }
 
+func TestStrictTools_AnthropicSource_RecursesIntoDefsAndDefinitions(t *testing.T) {
+	// Schemas using $ref / $defs reuse type definitions across properties.
+	// OpenAI strict mode requires object schemas inside $defs also have
+	// additionalProperties:false and all properties in required, otherwise
+	// validation 400s once the resolved schema is materialized upstream.
+	src := []byte(`{
+		"model":"claude-opus-4-7",
+		"messages":[{"role":"user","content":"hi"}],
+		"tools":[{
+			"name":"WithDefs",
+			"description":"uses defs",
+			"input_schema":{
+				"type":"object",
+				"properties":{"point":{"$ref":"#/$defs/Point"}},
+				"required":["point"],
+				"$defs":{
+					"Point":{
+						"type":"object",
+						"properties":{
+							"x":{"type":"number"},
+							"y":{"type":"number"}
+						},
+						"required":["x"]
+					}
+				},
+				"definitions":{
+					"Legacy":{
+						"type":"object",
+						"properties":{"name":{"type":"string"}}
+					}
+				}
+			}
+		}],
+		"max_tokens":256
+	}`)
+	env, err := translate.ParseAnthropic(src)
+	require.NoError(t, err)
+
+	out, err := env.PrepareOpenAI(nil, translate.EmitOptions{TargetModel: "deepseek/deepseek-v4-pro"})
+	require.NoError(t, err)
+
+	fn := firstToolFunction(t, out.Body)
+	params, _ := fn["parameters"].(map[string]any)
+
+	defs, _ := params["$defs"].(map[string]any)
+	require.NotNil(t, defs, "$defs must survive emit")
+	point, _ := defs["Point"].(map[string]any)
+	require.NotNil(t, point)
+	assert.Equal(t, false, point["additionalProperties"], "$defs entries must get additionalProperties:false")
+	pointRequired, _ := point["required"].([]any)
+	assert.ElementsMatch(t, []any{"x", "y"}, pointRequired, "$defs entries must move all properties to required")
+
+	definitions, _ := params["definitions"].(map[string]any)
+	require.NotNil(t, definitions, "legacy definitions must survive emit")
+	legacy, _ := definitions["Legacy"].(map[string]any)
+	require.NotNil(t, legacy)
+	assert.Equal(t, false, legacy["additionalProperties"], "legacy definitions also get tightened")
+}
+
 func TestStrictTools_OpenAISource_SetsStrictAndTightensSchemaForDeepSeek(t *testing.T) {
 	src := []byte(`{
 		"model":"x",

--- a/internal/translate/strict_tools_test.go
+++ b/internal/translate/strict_tools_test.go
@@ -1,0 +1,195 @@
+package translate_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"workweave/router/internal/translate"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// firstToolFunction returns `tools[0].function` from an emitted OpenAI body.
+func firstToolFunction(t *testing.T, body []byte) map[string]any {
+	t.Helper()
+	var doc map[string]any
+	require.NoError(t, json.Unmarshal(body, &doc))
+	tools, _ := doc["tools"].([]any)
+	require.NotEmpty(t, tools, "expected at least one tool in emitted body")
+	tool, _ := tools[0].(map[string]any)
+	require.NotNil(t, tool)
+	fn, _ := tool["function"].(map[string]any)
+	require.NotNil(t, fn)
+	return fn
+}
+
+func TestStrictTools_AnthropicSource_SetsStrictAndTightensSchemaForDeepSeek(t *testing.T) {
+	src := []byte(`{
+		"model":"claude-opus-4-7",
+		"messages":[{"role":"user","content":"hi"}],
+		"tools":[{
+			"name":"Edit",
+			"description":"edit a file",
+			"input_schema":{
+				"type":"object",
+				"properties":{
+					"file_path":{"type":"string"},
+					"old_string":{"type":"string"},
+					"new_string":{"type":"string"},
+					"replace_all":{"type":"boolean"}
+				},
+				"required":["file_path","old_string","new_string"]
+			}
+		}],
+		"max_tokens":256
+	}`)
+	env, err := translate.ParseAnthropic(src)
+	require.NoError(t, err)
+
+	out, err := env.PrepareOpenAI(nil, translate.EmitOptions{TargetModel: "deepseek/deepseek-v4-pro"})
+	require.NoError(t, err)
+
+	fn := firstToolFunction(t, out.Body)
+	assert.Equal(t, true, fn["strict"], "deepseek/* must get strict:true on function defs")
+
+	params, _ := fn["parameters"].(map[string]any)
+	require.NotNil(t, params)
+	assert.Equal(t, false, params["additionalProperties"], "object schemas must close additionalProperties for strict mode")
+
+	required, _ := params["required"].([]any)
+	assert.ElementsMatch(t, []any{"file_path", "old_string", "new_string", "replace_all"}, required,
+		"strict mode requires every property to appear in required")
+
+	props, _ := params["properties"].(map[string]any)
+	replaceAll, _ := props["replace_all"].(map[string]any)
+	require.NotNil(t, replaceAll)
+	assert.ElementsMatch(t, []any{"boolean", "null"}, replaceAll["type"],
+		"previously-optional properties must accept null to preserve optional semantics")
+
+	filePath, _ := props["file_path"].(map[string]any)
+	assert.Equal(t, "string", filePath["type"], "originally-required properties keep their scalar type")
+}
+
+func TestStrictTools_AnthropicSource_NoStrictForOtherModels(t *testing.T) {
+	cases := []string{"gpt-5", "moonshotai/kimi-k2.5", "qwen/qwen3-max", "google/gemini-2.5-pro"}
+	for _, model := range cases {
+		t.Run(model, func(t *testing.T) {
+			src := []byte(`{
+				"model":"claude-opus-4-7",
+				"messages":[{"role":"user","content":"hi"}],
+				"tools":[{
+					"name":"Edit",
+					"description":"edit",
+					"input_schema":{"type":"object","properties":{"x":{"type":"string"}}}
+				}],
+				"max_tokens":256
+			}`)
+			env, err := translate.ParseAnthropic(src)
+			require.NoError(t, err)
+
+			out, err := env.PrepareOpenAI(nil, translate.EmitOptions{TargetModel: model})
+			require.NoError(t, err)
+
+			fn := firstToolFunction(t, out.Body)
+			_, hasStrict := fn["strict"]
+			assert.False(t, hasStrict, "non-deepseek targets must not get strict mode")
+
+			params, _ := fn["parameters"].(map[string]any)
+			_, hasAdditional := params["additionalProperties"]
+			assert.False(t, hasAdditional, "non-strict targets keep schemas untouched")
+		})
+	}
+}
+
+func TestStrictTools_AnthropicSource_PropagatesIntoNestedObject(t *testing.T) {
+	src := []byte(`{
+		"model":"claude-opus-4-7",
+		"messages":[{"role":"user","content":"hi"}],
+		"tools":[{
+			"name":"NestedTool",
+			"description":"nested",
+			"input_schema":{
+				"type":"object",
+				"properties":{
+					"opts":{
+						"type":"object",
+						"properties":{
+							"flag":{"type":"boolean"}
+						}
+					}
+				},
+				"required":["opts"]
+			}
+		}],
+		"max_tokens":256
+	}`)
+	env, err := translate.ParseAnthropic(src)
+	require.NoError(t, err)
+
+	out, err := env.PrepareOpenAI(nil, translate.EmitOptions{TargetModel: "deepseek/deepseek-v4-pro"})
+	require.NoError(t, err)
+
+	fn := firstToolFunction(t, out.Body)
+	params, _ := fn["parameters"].(map[string]any)
+	props, _ := params["properties"].(map[string]any)
+	opts, _ := props["opts"].(map[string]any)
+	require.NotNil(t, opts)
+	assert.Equal(t, false, opts["additionalProperties"], "nested objects must also close additionalProperties")
+	required, _ := opts["required"].([]any)
+	assert.ElementsMatch(t, []any{"flag"}, required, "strict mode propagates to nested objects")
+}
+
+func TestStrictTools_OpenAISource_SetsStrictAndTightensSchemaForDeepSeek(t *testing.T) {
+	src := []byte(`{
+		"model":"x",
+		"messages":[{"role":"user","content":"hi"}],
+		"tools":[{
+			"type":"function",
+			"function":{
+				"name":"Edit",
+				"parameters":{
+					"type":"object",
+					"properties":{
+						"file_path":{"type":"string"},
+						"replace_all":{"type":"boolean"}
+					},
+					"required":["file_path"]
+				}
+			}
+		}],
+		"max_tokens":256
+	}`)
+	env, err := translate.ParseOpenAI(src)
+	require.NoError(t, err)
+
+	out, err := env.PrepareOpenAI(nil, translate.EmitOptions{TargetModel: "deepseek/deepseek-v4-pro"})
+	require.NoError(t, err)
+
+	fn := firstToolFunction(t, out.Body)
+	assert.Equal(t, true, fn["strict"], "OpenAI source path must also set strict on function defs for deepseek/*")
+
+	params, _ := fn["parameters"].(map[string]any)
+	require.NotNil(t, params)
+	assert.Equal(t, false, params["additionalProperties"])
+	required, _ := params["required"].([]any)
+	assert.ElementsMatch(t, []any{"file_path", "replace_all"}, required)
+}
+
+func TestStrictTools_NoTools_NoMutation(t *testing.T) {
+	src := []byte(`{
+		"model":"claude-opus-4-7",
+		"messages":[{"role":"user","content":"hi"}],
+		"max_tokens":256
+	}`)
+	env, err := translate.ParseAnthropic(src)
+	require.NoError(t, err)
+
+	out, err := env.PrepareOpenAI(nil, translate.EmitOptions{TargetModel: "deepseek/deepseek-v4-pro"})
+	require.NoError(t, err)
+
+	var doc map[string]any
+	require.NoError(t, json.Unmarshal(out.Body, &doc))
+	_, hasTools := doc["tools"]
+	assert.False(t, hasTools, "no tools in source means no tools field in output")
+}

--- a/internal/translate/strict_tools_test.go
+++ b/internal/translate/strict_tools_test.go
@@ -140,6 +140,52 @@ func TestStrictTools_AnthropicSource_PropagatesIntoNestedObject(t *testing.T) {
 	assert.ElementsMatch(t, []any{"flag"}, required, "strict mode propagates to nested objects")
 }
 
+func TestStrictTools_AnthropicSource_OptionalNestedObjectStillTightened(t *testing.T) {
+	// Regression: makeNullable rewrites an optional nested object's `type` from
+	// the scalar "object" to ["object","null"]. A naive recursive walk that
+	// matches only scalar "object" would skip the nested object's invariants,
+	// emitting a schema that fails strict-mode validation upstream.
+	src := []byte(`{
+		"model":"claude-opus-4-7",
+		"messages":[{"role":"user","content":"hi"}],
+		"tools":[{
+			"name":"NestedOptional",
+			"description":"nested optional",
+			"input_schema":{
+				"type":"object",
+				"properties":{
+					"opts":{
+						"type":"object",
+						"properties":{
+							"flag":{"type":"boolean"}
+						}
+					}
+				}
+			}
+		}],
+		"max_tokens":256
+	}`)
+	env, err := translate.ParseAnthropic(src)
+	require.NoError(t, err)
+
+	out, err := env.PrepareOpenAI(nil, translate.EmitOptions{TargetModel: "deepseek/deepseek-v4-pro"})
+	require.NoError(t, err)
+
+	fn := firstToolFunction(t, out.Body)
+	params, _ := fn["parameters"].(map[string]any)
+	props, _ := params["properties"].(map[string]any)
+	opts, _ := props["opts"].(map[string]any)
+	require.NotNil(t, opts)
+
+	assert.ElementsMatch(t, []any{"object", "null"}, opts["type"],
+		"optional nested object must be marked nullable")
+	assert.Equal(t, false, opts["additionalProperties"],
+		"nullable nested objects still need additionalProperties:false for strict mode")
+	required, _ := opts["required"].([]any)
+	assert.ElementsMatch(t, []any{"flag"}, required,
+		"nullable nested objects still need their properties moved to required")
+}
+
 func TestStrictTools_OpenAISource_SetsStrictAndTightensSchemaForDeepSeek(t *testing.T) {
 	src := []byte(`{
 		"model":"x",


### PR DESCRIPTION
## Summary
- Set `strict: true` on OpenAI function definitions and tighten each parameter schema when the target model is `deepseek/*`
- Schema tightening: every `type: "object"` gets `additionalProperties: false`; every property is added to `required`; properties not in the source `required` set are marked nullable via type union (`["boolean", "null"]`) so optional semantics are preserved via null values rather than absence
- Covers both source paths — Anthropic→OpenAI (`pullAnthropicTools`) and OpenAI→OpenAI (`applyStrictToolsToBody`)

## Why
DeepSeek V3/V4 (the OSS model we route a lot of agentic traffic to via OpenRouter) frequently drifts tool-call argument JSON from the declared schema: extra fields, wrong types, omitted required props. Constrained decoding via `strict: true` is the standard mitigation — DeepSeek's API and OpenRouter both pass it through to the constrained-decoding path. Pairs with the system reminder shipped in #137.

## Approach notes
- Optional → nullable via type union is the OpenAI-recommended pattern for strict mode (since strict requires every property in `required`). Previously-required properties keep their scalar type.
- Strict mode is applied recursively into nested object schemas via the existing `sanitizeOpenAIToolSchema` walk pattern.
- Best-effort on the OpenAI source path: if the body's `tools` field fails to parse as an array, the body passes through unmodified rather than failing the request.

## Test plan
- [x] `go test ./internal/translate/...` passes (5 new tests cover: required+optional matrix, non-DeepSeek targets unaffected, nested object recursion, OpenAI-source path, no-tools no-op)
- [x] `go build ./...` clean
- [ ] Staging deploy: monitor OpenRouter response logs for 400s on tool-bearing DeepSeek requests (sanitizer hitting an incompatible schema). Roll back via revert if rejection rate is non-zero.