### PR TITLE
translate: force temperature=0 on DeepSeek tool-calling turns

### DIFF
--- a/internal/translate/emit_openai.go
+++ b/internal/translate/emit_openai.go
@@ -55,6 +55,14 @@ func (e *RequestEnvelope) buildOpenAIFromOpenAI(opts EmitOptions) ([]byte, error
 			return nil, fmt.Errorf("set system reminder: %w", err)
 		}
 	}
+	if openRouterForcesToolTemperatureZero(opts.TargetModel) &&
+		gjson.GetBytes(body, "tools").Exists() &&
+		!gjson.GetBytes(body, "temperature").Exists() {
+		body, err = sjson.SetBytes(body, "temperature", 0)
+		if err != nil {
+			return nil, fmt.Errorf("set tool temperature override: %w", err)
+		}
+	}
 	return body, nil
 }
 
@@ -75,9 +83,18 @@ func (e *RequestEnvelope) buildOpenAIFromAnthropic(opts EmitOptions) ([]byte, er
 	}
 	pullAnthropicToolChoice(e.body, out)
 
+	clientSetTemp := false
 	for _, key := range []string{"temperature", "top_p"} {
 		if r := gjson.GetBytes(e.body, key); r.Exists() {
 			out[key] = r.Value()
+			if key == "temperature" {
+				clientSetTemp = true
+			}
+		}
+	}
+	if !clientSetTemp && openRouterForcesToolTemperatureZero(opts.TargetModel) {
+		if _, hasTools := out["tools"]; hasTools {
+			out["temperature"] = 0
 		}
 	}
 	if r := gjson.GetBytes(e.body, "max_tokens"); r.Exists() {

--- a/internal/translate/provider_hint.go
+++ b/internal/translate/provider_hint.go
@@ -33,3 +33,12 @@ func openRouterReasoningHint(model string) map[string]any {
 	}
 	return nil
 }
+
+// openRouterForcesToolTemperatureZero reports whether tool-calling turns for
+// this model should default to temperature 0. Reserved for models whose
+// sampling jitter measurably degrades tool-arg fidelity (whitespace, unicode)
+// — DeepSeek's reasoning-disabled tool turns are the documented case.
+// Callers still skip the override when the client set temperature explicitly.
+func openRouterForcesToolTemperatureZero(model string) bool {
+	return strings.HasPrefix(model, "deepseek/")
+}

--- a/internal/translate/tool_temperature_test.go
+++ b/internal/translate/tool_temperature_test.go
@@ -1,0 +1,140 @@
+package translate_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"workweave/router/internal/translate"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// temperatureField returns (value, present) from an emitted OpenAI body.
+func temperatureField(t *testing.T, body []byte) (float64, bool) {
+	t.Helper()
+	var doc map[string]any
+	require.NoError(t, json.Unmarshal(body, &doc))
+	raw, ok := doc["temperature"]
+	if !ok {
+		return 0, false
+	}
+	v, ok := raw.(float64)
+	require.True(t, ok, "temperature must be numeric")
+	return v, true
+}
+
+const editToolJSON = `[{"name":"Edit","description":"edit","input_schema":{"type":"object","properties":{"x":{"type":"string"}}}}]`
+const editToolOpenAIJSON = `[{"type":"function","function":{"name":"Edit","parameters":{"type":"object","properties":{"x":{"type":"string"}}}}}]`
+
+func TestToolTemperature_AnthropicSource_ForcesZeroForDeepSeekWithTools(t *testing.T) {
+	src := []byte(`{
+		"model":"claude-opus-4-7",
+		"messages":[{"role":"user","content":"hi"}],
+		"tools":` + editToolJSON + `,
+		"max_tokens":256
+	}`)
+	env, err := translate.ParseAnthropic(src)
+	require.NoError(t, err)
+
+	out, err := env.PrepareOpenAI(nil, translate.EmitOptions{TargetModel: "deepseek/deepseek-v4-pro"})
+	require.NoError(t, err)
+
+	temp, present := temperatureField(t, out.Body)
+	require.True(t, present, "deepseek/* with tools and no client temp must get temperature override")
+	assert.Equal(t, 0.0, temp)
+}
+
+func TestToolTemperature_AnthropicSource_ClientTempWins(t *testing.T) {
+	src := []byte(`{
+		"model":"claude-opus-4-7",
+		"messages":[{"role":"user","content":"hi"}],
+		"tools":` + editToolJSON + `,
+		"temperature":0.7,
+		"max_tokens":256
+	}`)
+	env, err := translate.ParseAnthropic(src)
+	require.NoError(t, err)
+
+	out, err := env.PrepareOpenAI(nil, translate.EmitOptions{TargetModel: "deepseek/deepseek-v4-pro"})
+	require.NoError(t, err)
+
+	temp, present := temperatureField(t, out.Body)
+	require.True(t, present)
+	assert.Equal(t, 0.7, temp, "client-set temperature must override the deepseek default-to-zero")
+}
+
+func TestToolTemperature_AnthropicSource_NoOverrideWithoutTools(t *testing.T) {
+	src := []byte(`{
+		"model":"claude-opus-4-7",
+		"messages":[{"role":"user","content":"hi"}],
+		"max_tokens":256
+	}`)
+	env, err := translate.ParseAnthropic(src)
+	require.NoError(t, err)
+
+	out, err := env.PrepareOpenAI(nil, translate.EmitOptions{TargetModel: "deepseek/deepseek-v4-pro"})
+	require.NoError(t, err)
+
+	_, present := temperatureField(t, out.Body)
+	assert.False(t, present, "no tools means no override")
+}
+
+func TestToolTemperature_AnthropicSource_NoOverrideForOtherModels(t *testing.T) {
+	cases := []string{"gpt-5", "moonshotai/kimi-k2.5", "qwen/qwen3-max", "google/gemini-2.5-pro"}
+	for _, model := range cases {
+		t.Run(model, func(t *testing.T) {
+			src := []byte(`{
+				"model":"claude-opus-4-7",
+				"messages":[{"role":"user","content":"hi"}],
+				"tools":` + editToolJSON + `,
+				"max_tokens":256
+			}`)
+			env, err := translate.ParseAnthropic(src)
+			require.NoError(t, err)
+
+			out, err := env.PrepareOpenAI(nil, translate.EmitOptions{TargetModel: model})
+			require.NoError(t, err)
+
+			_, present := temperatureField(t, out.Body)
+			assert.False(t, present, "non-deepseek targets must not receive a temperature override")
+		})
+	}
+}
+
+func TestToolTemperature_OpenAISource_ForcesZeroForDeepSeekWithTools(t *testing.T) {
+	src := []byte(`{
+		"model":"x",
+		"messages":[{"role":"user","content":"hi"}],
+		"tools":` + editToolOpenAIJSON + `,
+		"max_tokens":256
+	}`)
+	env, err := translate.ParseOpenAI(src)
+	require.NoError(t, err)
+
+	out, err := env.PrepareOpenAI(nil, translate.EmitOptions{TargetModel: "deepseek/deepseek-v4-pro"})
+	require.NoError(t, err)
+
+	temp, present := temperatureField(t, out.Body)
+	require.True(t, present, "OpenAI source path must also apply the override")
+	assert.Equal(t, 0.0, temp)
+}
+
+func TestToolTemperature_OpenAISource_ClientTempWins(t *testing.T) {
+	src := []byte(`{
+		"model":"x",
+		"messages":[{"role":"user","content":"hi"}],
+		"tools":` + editToolOpenAIJSON + `,
+		"temperature":0.5,
+		"max_tokens":256
+	}`)
+	env, err := translate.ParseOpenAI(src)
+	require.NoError(t, err)
+
+	out, err := env.PrepareOpenAI(nil, translate.EmitOptions{TargetModel: "deepseek/deepseek-v4-pro"})
+	require.NoError(t, err)
+
+	temp, present := temperatureField(t, out.Body)
+	require.True(t, present)
+	assert.Equal(t, 0.5, temp)
+}


### PR DESCRIPTION
## Summary
- Default `temperature: 0` when target is `deepseek/*`, the request carries tools, and the client did not set `temperature` explicitly
- Client-set `temperature` always wins — callers retain control when they need non-zero sampling
- Covers both source paths (`Anthropic→OpenAI` and `OpenAI→OpenAI`)

## Why
DeepSeek's sampling jitter measurably degrades tool-arg fidelity on the bytes that matter most for byte-exact Edit-tool matching: whitespace, tabs, em-dash vs hyphen, etc. Pinning temperature to 0 on tool-calling turns reduces that jitter without affecting non-tool conversational traffic (which keeps whatever temperature the client requested).

Pairs with the system reminder shipped in #137 and strict-mode #139 — same gating predicate family (`deepseek/*`).

## Test plan
- [x] `go test ./internal/translate/...` passes (6 new tests cover: deepseek + tools no client temp, client temp wins, no tools → no override, non-deepseek targets unaffected, OpenAI-source mirror)
- [x] `go build ./...` clean
- [ ] Staging: confirm `temperature: 0` appears in OpenRouter request logs for DeepSeek tool-calling turns from clients that don't set the field