### PR TITLE
translate: env-flagged escape repair for Edit-tool args

### DIFF
--- a/cmd/router/main.go
+++ b/cmd/router/main.go
@@ -37,6 +37,7 @@ import (
 	"workweave/router/internal/router/planner"
 	"workweave/router/internal/router/sessionpin"
 	"workweave/router/internal/server"
+	"workweave/router/internal/translate"
 
 	_ "time/tzdata"
 
@@ -285,6 +286,10 @@ func main() {
 		logger.Info("Cluster scorer embedding user-role text only (ROUTER_EMBED_ONLY_USER_MESSAGE=true)")
 	} else {
 		logger.Info("Cluster scorer embedding concatenated stream (ROUTER_EMBED_ONLY_USER_MESSAGE=false)")
+	}
+	if config.GetOr("ROUTER_DEEPSEEK_ESCAPE_NORMALIZE", "false") == "true" {
+		translate.EnableEditEscapeNormalize = true
+		logger.Info("Edit-tool escape-sequence repair enabled (ROUTER_DEEPSEEK_ESCAPE_NORMALIZE=true)")
 	}
 	emitter, err := buildOtelEmitter()
 	if err != nil {

--- a/internal/translate/escape_normalize.go
+++ b/internal/translate/escape_normalize.go
@@ -1,0 +1,79 @@
+package translate
+
+import "strings"
+
+// EnableEditEscapeNormalize gates the escape-sequence repair pass on file-edit
+// tool-call arguments. Set once at startup from the composition root. When
+// false, normalizeEditEscapes is a no-op for every call. Off by default
+// because the transform can corrupt legitimate code containing literal `\n` /
+// `\t` sequences in source (e.g. a Python string `"\\n"`).
+var EnableEditEscapeNormalize bool
+
+// editToolNames is the set of tool names whose string arguments may carry
+// file content that must round-trip whitespace exactly. Comparison is
+// case-insensitive against incoming tool names so client-defined casing
+// variants are caught.
+var editToolNames = map[string]struct{}{
+	"edit":      {},
+	"write":     {},
+	"multiedit": {},
+}
+
+// editEscapableFields is the per-tool allowlist of string fields where
+// backslash-letter escapes should be unescaped. `file_path` is deliberately
+// excluded — paths shouldn't contain newlines, and rewriting one risks
+// corrupting an otherwise-valid path containing a literal backslash.
+var editEscapableFields = map[string]struct{}{
+	"old_string": {},
+	"new_string": {},
+	"content":    {},
+}
+
+// normalizeEditEscapes repairs `\n` / `\t` / `\r` literal sequences that
+// upstream models occasionally emit in file-edit tool arguments where a real
+// newline / tab / carriage return was intended. Mutates `input` in place.
+// No-op when EnableEditEscapeNormalize is false, when `toolName` is not a
+// file-edit tool, or when `input` is not a JSON object.
+//
+// JSON decoding has already converted real escape sequences ("\n" in the wire
+// JSON) to actual newlines by the time we see `input`, so any remaining
+// backslash-letter sequence here is the broken case: the model emitted
+// double-escaped JSON ("\\n" on the wire) and our decoder produced literal
+// backslash-n.
+func normalizeEditEscapes(toolName string, input any) {
+	if !EnableEditEscapeNormalize {
+		return
+	}
+	if _, ok := editToolNames[strings.ToLower(toolName)]; !ok {
+		return
+	}
+	m, ok := input.(map[string]any)
+	if !ok {
+		return
+	}
+	for key, raw := range m {
+		if _, allowed := editEscapableFields[key]; !allowed {
+			continue
+		}
+		s, ok := raw.(string)
+		if !ok {
+			continue
+		}
+		m[key] = unescapeBackslashLiterals(s)
+	}
+}
+
+// unescapeBackslashLiterals rewrites the literal two-character sequences
+// `\n` / `\t` / `\r` (a real backslash followed by a real letter) to their
+// single-character escape values. Other escape sequences are left alone.
+func unescapeBackslashLiterals(s string) string {
+	if !strings.ContainsRune(s, '\\') {
+		return s
+	}
+	r := strings.NewReplacer(
+		`\n`, "\n",
+		`\t`, "\t",
+		`\r`, "\r",
+	)
+	return r.Replace(s)
+}

--- a/internal/translate/escape_normalize.go
+++ b/internal/translate/escape_normalize.go
@@ -40,6 +40,9 @@ var editEscapableFields = map[string]struct{}{
 // backslash-letter sequence here is the broken case: the model emitted
 // double-escaped JSON ("\\n" on the wire) and our decoder produced literal
 // backslash-n.
+//
+// MultiEdit nests per-edit `old_string`/`new_string` inside an `edits` array,
+// so each entry there is also walked.
 func normalizeEditEscapes(toolName string, input any) {
 	if !EnableEditEscapeNormalize {
 		return
@@ -51,6 +54,21 @@ func normalizeEditEscapes(toolName string, input any) {
 	if !ok {
 		return
 	}
+	rewriteAllowlistedFields(m)
+	if edits, ok := m["edits"].([]any); ok {
+		for _, e := range edits {
+			entry, ok := e.(map[string]any)
+			if !ok {
+				continue
+			}
+			rewriteAllowlistedFields(entry)
+		}
+	}
+}
+
+// rewriteAllowlistedFields applies escape repair to every allowlisted string
+// field in the given map. Caller gates by tool name.
+func rewriteAllowlistedFields(m map[string]any) {
 	for key, raw := range m {
 		if _, allowed := editEscapableFields[key]; !allowed {
 			continue

--- a/internal/translate/escape_normalize_test.go
+++ b/internal/translate/escape_normalize_test.go
@@ -1,0 +1,154 @@
+package translate_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"workweave/router/internal/translate"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// withEscapeNormalize toggles the package-level flag for the duration of one
+// subtest and restores it after.
+func withEscapeNormalize(t *testing.T, enabled bool) {
+	t.Helper()
+	prior := translate.EnableEditEscapeNormalize
+	translate.EnableEditEscapeNormalize = enabled
+	t.Cleanup(func() {
+		translate.EnableEditEscapeNormalize = prior
+	})
+}
+
+// editToolUseResponse builds a non-streaming OpenAI response with one tool_call
+// whose arguments are the provided JSON object string.
+func editToolUseResponse(t *testing.T, toolName, argsJSON string) []byte {
+	t.Helper()
+	body := map[string]any{
+		"id":    "resp_1",
+		"model": "deepseek/deepseek-v4-pro",
+		"choices": []any{
+			map[string]any{
+				"message": map[string]any{
+					"role": "assistant",
+					"tool_calls": []any{
+						map[string]any{
+							"id":   "call_1",
+							"type": "function",
+							"function": map[string]any{
+								"name":      toolName,
+								"arguments": argsJSON,
+							},
+						},
+					},
+				},
+				"finish_reason": "tool_calls",
+			},
+		},
+	}
+	out, err := json.Marshal(body)
+	require.NoError(t, err)
+	return out
+}
+
+// firstToolUseInput pulls the `input` map of the first tool_use block from an
+// Anthropic-format response body.
+func firstToolUseInput(t *testing.T, body []byte) map[string]any {
+	t.Helper()
+	var doc map[string]any
+	require.NoError(t, json.Unmarshal(body, &doc))
+	content, _ := doc["content"].([]any)
+	for _, b := range content {
+		block, _ := b.(map[string]any)
+		if block == nil {
+			continue
+		}
+		if t2, _ := block["type"].(string); t2 == "tool_use" {
+			in, _ := block["input"].(map[string]any)
+			return in
+		}
+	}
+	t.Fatal("expected at least one tool_use block")
+	return nil
+}
+
+func TestEscapeNormalize_FlagOff_DoesNothing(t *testing.T) {
+	withEscapeNormalize(t, false)
+	// JSON-encoded `\\n` lands as literal backslash-n after json.Unmarshal.
+	resp := editToolUseResponse(t, "Edit", `{"file_path":"a.go","old_string":"foo\\nbar","new_string":"baz"}`)
+
+	out, err := translate.OpenAIToAnthropicResponse(resp, "deepseek/deepseek-v4-pro")
+	require.NoError(t, err)
+
+	input := firstToolUseInput(t, out)
+	assert.Equal(t, `foo\nbar`, input["old_string"], "flag off must leave literal backslash-n untouched")
+}
+
+func TestEscapeNormalize_FlagOn_RewritesEditArgs(t *testing.T) {
+	withEscapeNormalize(t, true)
+	resp := editToolUseResponse(t, "Edit", `{"file_path":"a.go","old_string":"foo\\nbar","new_string":"baz\\tqux"}`)
+
+	out, err := translate.OpenAIToAnthropicResponse(resp, "deepseek/deepseek-v4-pro")
+	require.NoError(t, err)
+
+	input := firstToolUseInput(t, out)
+	assert.Equal(t, "foo\nbar", input["old_string"], "literal backslash-n must become real newline")
+	assert.Equal(t, "baz\tqux", input["new_string"], "literal backslash-t must become real tab")
+}
+
+func TestEscapeNormalize_FlagOn_LeavesRealNewlinesAlone(t *testing.T) {
+	withEscapeNormalize(t, true)
+	// `\n` in JSON decodes to a real newline before our code sees it; nothing to do.
+	resp := editToolUseResponse(t, "Edit", `{"old_string":"foo\nbar","new_string":"baz"}`)
+
+	out, err := translate.OpenAIToAnthropicResponse(resp, "deepseek/deepseek-v4-pro")
+	require.NoError(t, err)
+
+	input := firstToolUseInput(t, out)
+	assert.Equal(t, "foo\nbar", input["old_string"], "already-correct newlines pass through unchanged")
+}
+
+func TestEscapeNormalize_FlagOn_SkipsNonEditTools(t *testing.T) {
+	withEscapeNormalize(t, true)
+	cases := []string{"Read", "Bash", "Grep"}
+	for _, name := range cases {
+		t.Run(name, func(t *testing.T) {
+			resp := editToolUseResponse(t, name, `{"command":"echo foo\\nbar"}`)
+			out, err := translate.OpenAIToAnthropicResponse(resp, "deepseek/deepseek-v4-pro")
+			require.NoError(t, err)
+			input := firstToolUseInput(t, out)
+			assert.Equal(t, `echo foo\nbar`, input["command"], "non-edit tools must not be rewritten")
+		})
+	}
+}
+
+func TestEscapeNormalize_FlagOn_SkipsFilePath(t *testing.T) {
+	withEscapeNormalize(t, true)
+	resp := editToolUseResponse(t, "Edit", `{"file_path":"weird\\npath.go","old_string":"foo\\nbar"}`)
+
+	out, err := translate.OpenAIToAnthropicResponse(resp, "deepseek/deepseek-v4-pro")
+	require.NoError(t, err)
+
+	input := firstToolUseInput(t, out)
+	assert.Equal(t, `weird\npath.go`, input["file_path"], "file_path is excluded — paths can have backslashes legitimately")
+	assert.Equal(t, "foo\nbar", input["old_string"], "old_string still rewritten alongside")
+}
+
+func TestEscapeNormalize_FlagOn_CaseInsensitiveToolName(t *testing.T) {
+	withEscapeNormalize(t, true)
+	for _, name := range []string{"edit", "EDIT", "Write", "MultiEdit"} {
+		t.Run(name, func(t *testing.T) {
+			resp := editToolUseResponse(t, name, `{"old_string":"x\\nx","content":"y\\ny"}`)
+			out, err := translate.OpenAIToAnthropicResponse(resp, "deepseek/deepseek-v4-pro")
+			require.NoError(t, err)
+			input := firstToolUseInput(t, out)
+			if v, ok := input["old_string"]; ok {
+				assert.Equal(t, "x\nx", v)
+			}
+			if v, ok := input["content"]; ok {
+				assert.Equal(t, "y\ny", v)
+			}
+		})
+	}
+}

--- a/internal/translate/escape_normalize_test.go
+++ b/internal/translate/escape_normalize_test.go
@@ -135,6 +135,38 @@ func TestEscapeNormalize_FlagOn_SkipsFilePath(t *testing.T) {
 	assert.Equal(t, "foo\nbar", input["old_string"], "old_string still rewritten alongside")
 }
 
+func TestEscapeNormalize_FlagOn_RewritesMultiEditNestedEdits(t *testing.T) {
+	// MultiEdit's real shape nests per-edit fields inside an `edits` array.
+	// A flat-only walk would silently skip the strings that actually need
+	// repairing.
+	withEscapeNormalize(t, true)
+	args := `{
+		"file_path":"a.go",
+		"edits":[
+			{"old_string":"foo\\nbar","new_string":"baz"},
+			{"old_string":"alpha","new_string":"beta\\tgamma"}
+		]
+	}`
+	resp := editToolUseResponse(t, "MultiEdit", args)
+
+	out, err := translate.OpenAIToAnthropicResponse(resp, "deepseek/deepseek-v4-pro")
+	require.NoError(t, err)
+
+	input := firstToolUseInput(t, out)
+	assert.Equal(t, "a.go", input["file_path"])
+	edits, ok := input["edits"].([]any)
+	require.True(t, ok, "edits must round-trip as array")
+	require.Len(t, edits, 2)
+
+	first, _ := edits[0].(map[string]any)
+	assert.Equal(t, "foo\nbar", first["old_string"], "first edit's old_string must be unescaped")
+	assert.Equal(t, "baz", first["new_string"])
+
+	second, _ := edits[1].(map[string]any)
+	assert.Equal(t, "alpha", second["old_string"])
+	assert.Equal(t, "beta\tgamma", second["new_string"], "second edit's new_string must be unescaped")
+}
+
 func TestEscapeNormalize_FlagOn_CaseInsensitiveToolName(t *testing.T) {
 	withEscapeNormalize(t, true)
 	for _, name := range []string{"edit", "EDIT", "Write", "MultiEdit"} {

--- a/internal/translate/translate.go
+++ b/internal/translate/translate.go
@@ -213,6 +213,7 @@ func buildAnthropicContent(message map[string]any) []any {
 		if json.Unmarshal([]byte(argsStr), &input) != nil {
 			input = map[string]any{}
 		}
+		normalizeEditEscapes(name, input)
 		blocks = append(blocks, map[string]any{
 			"type":  "tool_use",
 			"id":    id,


### PR DESCRIPTION
## Summary
- Response-side repair pass that rewrites literal backslash-letter sequences (`\n` `\t` `\r`) to their single-character equivalents in `old_string` / `new_string` / `content` of Edit / Write / MultiEdit tool calls
- Gated by `ROUTER_DEEPSEEK_ESCAPE_NORMALIZE=true` env var — **off by default**
- Non-streaming response path only for this first cut (see Out-of-scope below)

## Why
DeepSeek occasionally double-escapes JSON when emitting file-edit tool arguments: the wire JSON carries `"\\n"` where it meant `"\n"`, so after `json.Unmarshal` we see literal backslash-n where the file has a real newline. Claude Code's byte-exact Edit match fails, the model retries with sed/python, files get corrupted (the original transcript from the conversation).

OpenCode handles the same class as one of nine fallback replacers (`packages/opencode/src/tool/edit.ts:L491` — `EscapeNormalizedReplacer`). They run it only when exact match has already failed and they have the file content in hand. We don't have file content router-side, so we ship narrower (only Edit-family tools, only specific allowlisted fields) and gated.

## Risk + rollback
The transform can corrupt legitimate code containing literal escape sequences in source (e.g. a Python string `"\\n"` becomes a real newline). This is exactly why the flag defaults to false.

Rollout plan: enable in staging, watch edit-success rate vs. file-corruption reports for one week. Promote to default-on only if the win is large and corruption rate is zero. One-line revert via env-var flip.

## Out of scope (follow-up)
**Streaming path** — SSE tool_use args arrive as a sequence of `input_json_delta` deltas. Normalizing requires buffering all partial_json chunks until `content_block_stop`, then emitting one consolidated delta. Worth its own PR with deliberate state-machine changes; the non-streaming path covers `proxy.Service.ProxyOpenAIChatCompletion` style traffic.

## Test plan
- [x] `go test ./internal/translate/...` passes (7 new tests cover: flag off no-op, flag on rewrite, real newlines untouched, non-edit tools skipped, file_path skipped, case-insensitive tool-name match)
- [x] `go build ./...` clean
- [ ] Staging: set `ROUTER_DEEPSEEK_ESCAPE_NORMALIZE=true`, run an Edit-heavy DeepSeek session, compare Edit-success rate to flag-off baseline before promoting default