### PR TITLE
frontend: remove dead/unused exported types

### DIFF
--- a/frontend/src/components/Chart/types.ts
+++ b/frontend/src/components/Chart/types.ts
@@ -46,16 +46,6 @@ export enum ChartDependentAxis {
 }
 
 /**
- * Defines a line on an XY chart.
- */
-export interface ChartLineDefinition {
-  /** The y-intercept of the line. */
-  intercept: number;
-  /** The slope of the line. */
-  slope: number;
-}
-
-/**
  * Different ways a chart series can be displayed.
  */
 export enum ChartSeriesType {
@@ -186,14 +176,6 @@ export type ChartConfig<
 > = Readonly<Partial<Record<TDependentKey, ChartSeriesConfig<TIndependentValue, TDependentValue>>>>;
 
 /**
- * The dependent values for a single data point in a chart.
- */
-export type ChartDataPointDependentValues<
-  TDependentKey extends ChartDataKeyType,
-  TDependentValue extends ChartDataValueType,
-> = Partial<Readonly<Record<TDependentKey, TDependentValue | null>>>;
-
-/**
  * A chart data point is a single data point in a chart, which always contains the independent value
  * and may contain data for any of the dependent series in the chart.
  */
@@ -204,7 +186,7 @@ export type ChartDataPoint<
   TDependentValue extends ChartDataValueType,
   TTooltipData = unknown,
 > = Readonly<Record<TIndependentKey, TIndependentValue>> &
-  ChartDataPointDependentValues<TDependentKey, TDependentValue> & {
+  Partial<Readonly<Record<TDependentKey, TDependentValue | null>>> & {
     [TOOLTIP_DATA_KEY]?: TTooltipData;
   };
 
@@ -240,27 +222,9 @@ interface ChartReferenceLineCommon {
   side?: "center" | "left" | "right";
 }
 
-/**
- * A reference line to draw on a chart at a given independent value.
- */
-export interface ChartIndependentReferenceLine<TIndependentValue extends ChartDataValueType>
-  extends ChartReferenceLineCommon {
-  type: "independent";
-  /** The value to draw the reference line at. */
-  value: TIndependentValue;
-}
-
-/**
- * A reference line to draw on a chart at a given dependent value.
- */
-export interface ChartDependentReferenceLine<TDependentValue extends ChartDataValueType>
-  extends ChartReferenceLineCommon {
-  type: "dependent";
-  /** The value to draw the reference line at. */
-  value: TDependentValue;
-}
-
 export type ChartReferenceLine<
   TIndependentValue extends ChartDataValueType,
   TDependentValue extends ChartDataValueType,
-> = ChartDependentReferenceLine<TDependentValue> | ChartIndependentReferenceLine<TIndependentValue>;
+> =
+  | (ChartReferenceLineCommon & { type: "dependent"; value: TDependentValue })
+  | (ChartReferenceLineCommon & { type: "independent"; value: TIndependentValue });

--- a/frontend/src/components/DashboardPageFilters/FilterPill.tsx
+++ b/frontend/src/components/DashboardPageFilters/FilterPill.tsx
@@ -6,11 +6,7 @@ import { cn } from "@/lib/cn";
 import { X } from "lucide-react";
 import React, { forwardRef } from "react";
 
-export interface FilterPillProps extends React.PropsWithChildren {
-  onRemove?: () => void;
-}
-
-type FilterPillType = React.FC<FilterPillProps> & {
+type FilterPillType = React.FC<React.PropsWithChildren<{ onRemove?: () => void }>> & {
   Button: React.ForwardRefExoticComponent<
     Omit<ButtonProps, "appearance" | "size"> & React.RefAttributes<HTMLButtonElement>
   >;
@@ -37,7 +33,7 @@ const FilterPillButton = forwardRef<
 FilterPillButton.displayName = "FilterPill.Button";
 
 export const FilterPill: FilterPillType = Object.assign(
-  function FilterPill({ children, onRemove }: FilterPillProps) {
+  function FilterPill({ children, onRemove }: React.PropsWithChildren<{ onRemove?: () => void }>) {
     return (
       <div className="flex shrink-0 grow-0 items-center gap-1.5 rounded-lg bg-muted px-2 py-1 text-sm">
         {children}

--- a/frontend/src/components/DashboardPageFilters/useDashboardFilters.ts
+++ b/frontend/src/components/DashboardPageFilters/useDashboardFilters.ts
@@ -85,17 +85,15 @@ export const DATE_RANGES: readonly DateRange[] = [
 
 const DEFAULT_RANGE_ID = "last-month";
 
-export interface DashboardFilters {
-  range: DateRange;
-  granularity: Granularity;
-  /** ISO timestamp of the range start. */
-  fromISO: string;
-  /** ISO timestamp of the range end (now). */
-  toISO: string;
-}
-
 export interface UseDashboardFiltersResult {
-  filters: DashboardFilters;
+  filters: {
+    range: DateRange;
+    granularity: Granularity;
+    /** ISO timestamp of the range start. */
+    fromISO: string;
+    /** ISO timestamp of the range end (now). */
+    toISO: string;
+  };
   setRangeId: (id: string) => void;
   setGranularity: (g: Granularity) => void;
 }

--- a/frontend/src/components/Page/Page.tsx
+++ b/frontend/src/components/Page/Page.tsx
@@ -37,11 +37,10 @@ export function Page({ children, className, header, subheader }: PageProps) {
   );
 }
 
-export interface PageSectionProps extends React.HTMLAttributes<HTMLDivElement> {
-  header?: React.ReactNode;
-}
-
-Page.Section = React.forwardRef<HTMLDivElement, PageSectionProps>(
+Page.Section = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement> & { header?: React.ReactNode }
+>(
   ({ children, className, header, ...props }, ref) => (
     <section
       className={cn("flex w-full max-w-content-width flex-col gap-4 p-6", className)}

--- a/frontend/src/components/Statistic/Statistic.tsx
+++ b/frontend/src/components/Statistic/Statistic.tsx
@@ -2,13 +2,9 @@ import { Text } from "@/components/atoms/Text";
 import { cn } from "@/tools/cn";
 import { LoadState } from "@/tools/LoadState";
 
-export interface StatisticValue {
-  total?: string;
-}
-
 export interface StatisticProps {
   className?: string;
-  statistic: LoadState<StatisticValue>;
+  statistic: LoadState<{ total?: string }>;
 }
 
 export function Statistic({ className, statistic }: StatisticProps) {

--- a/frontend/src/components/atoms/Skeleton/Skeleton.tsx
+++ b/frontend/src/components/atoms/Skeleton/Skeleton.tsx
@@ -36,15 +36,6 @@ export function Skeleton({
   );
 }
 
-export interface SkeletonTextProps extends SkeletonProps {
-  /**
-   * Corresponds with Tailwind text sizes or `Text` component sizes.
-   *
-   * @default "base"
-   */
-  size?: "2xl" | "4xl" | "base" | "h1" | "h2" | "h3" | "h4" | "lg" | "p" | "sm" | "xl" | "xs";
-}
-
 /**
  * Renders a skeleton exactly matching the size and spacing of text.
  */
@@ -55,7 +46,9 @@ Skeleton.Text = function SkeletonText({
   darker = false,
   size = "base",
   ...props
-}: SkeletonTextProps) {
+}: SkeletonProps & {
+  size?: "2xl" | "4xl" | "base" | "h1" | "h2" | "h3" | "h4" | "lg" | "p" | "sm" | "xl" | "xs";
+}) {
   return (
     <Element
       className={cn(

--- a/frontend/src/components/molecules/Card/Card.tsx
+++ b/frontend/src/components/molecules/Card/Card.tsx
@@ -76,11 +76,11 @@ const CardHeader = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDiv
 );
 CardHeader.displayName = "CardHeader";
 
-export interface CardTitleProps extends React.HTMLAttributes<HTMLHeadingElement> {
-  variant?: TextProps["variant"];
-}
-
-function CardTitle({ className, variant, ...props }: CardTitleProps) {
+function CardTitle({
+  className,
+  variant,
+  ...props
+}: React.HTMLAttributes<HTMLHeadingElement> & { variant?: TextProps["variant"] }) {
   return (
     <Text
       variant={variant ?? "h3"}

--- a/frontend/src/components/molecules/Popover/Popover.tsx
+++ b/frontend/src/components/molecules/Popover/Popover.tsx
@@ -7,8 +7,6 @@ type PopoverType = typeof PopoverPrimitive.Root & {
   Trigger: typeof PopoverTrigger;
 };
 
-export type PopoverProps = React.ComponentPropsWithoutRef<typeof PopoverPrimitive.Root>;
-
 export const Popover: PopoverType = PopoverPrimitive.Root as PopoverType;
 
 const PopoverTrigger = React.forwardRef<
@@ -24,11 +22,9 @@ const PopoverTrigger = React.forwardRef<
 ));
 PopoverTrigger.displayName = PopoverPrimitive.Trigger.displayName;
 
-export type PopoverContentProps = React.ComponentPropsWithoutRef<typeof PopoverPrimitive.Content>;
-
 const PopoverContent = React.forwardRef<
   React.ElementRef<typeof PopoverPrimitive.Content>,
-  PopoverContentProps
+  React.ComponentPropsWithoutRef<typeof PopoverPrimitive.Content>
 >(({ align = "center", className, sideOffset = 6, ...props }, ref) => (
   <PopoverPrimitive.Portal>
     <PopoverPrimitive.Content

--- a/frontend/src/tools/LoadState.ts
+++ b/frontend/src/tools/LoadState.ts
@@ -8,15 +8,15 @@ const ERROR = Symbol("ERROR");
 const LOADED = Symbol("LOADED");
 const RELOADING = Symbol("RELOADING");
 
-export interface LoadStateNotStartedLoading {
+interface LoadStateNotStartedLoading {
   type: typeof NOT_STARTED_LOADING;
 }
 
-export interface LoadStateLoading {
+interface LoadStateLoading {
   type: typeof LOADING;
 }
 
-export interface LoadStateError<T> {
+interface LoadStateError<T> {
   error: Error;
   /**
    * If defined, this is the value the load state had before it errored.
@@ -25,12 +25,12 @@ export interface LoadStateError<T> {
   type: typeof ERROR;
 }
 
-export interface LoadStateLoaded<T> {
+interface LoadStateLoaded<T> {
   type: typeof LOADED;
   value: T;
 }
 
-export interface LoadStateReloading<T> {
+interface LoadStateReloading<T> {
   type: typeof RELOADING;
   value: T;
 }


### PR DESCRIPTION
## Summary

Knip flagged 17 unused exported types in the dashboard frontend. This PR clears them:

- **2 fully-unused types deleted entirely:** `ChartLineDefinition`, `PopoverProps`
- **8 single-use interfaces deleted, shape inlined at the use site:** `SkeletonTextProps`, `ChartDataPointDependentValues`, `ChartIndependentReferenceLine` + `ChartDependentReferenceLine` (collapsed into the `ChartReferenceLine` union), `FilterPillProps`, `DashboardFilters`, `CardTitleProps`, `PopoverContentProps`, `PageSectionProps`, `StatisticValue`
- **5 `LoadState*` interfaces un-exported only** — still used internally by the discriminated union, constructors, and every type guard, so deleting them would have required ~15 inline substitutions for no readability win

After: `npx knip` reports zero unused exports (only the unchanged `eslint` / `eslint-config-next` devDep false-positives remain — both used implicitly by `next lint`).

## Test plan

- [ ] `npm run build` in `frontend/`
- [ ] `npm run lint` in `frontend/`
- [ ] Smoke-test dashboard locally