### PR TITLE
frontend: remove redundant comments

### DIFF
--- a/frontend/src/app/(app)/settings/page.tsx
+++ b/frontend/src/app/(app)/settings/page.tsx
@@ -110,9 +110,6 @@ export default function SettingsPage() {
   );
 }
 
-// ──────────────────────────────────────────────────────────────────────────
-// Router keys panel
-// ──────────────────────────────────────────────────────────────────────────
 
 function RouterKeysPanel() {
   const [keys, setKeys] = useState<APIKey[]>([]);
@@ -319,9 +316,6 @@ function RouterKeysPanel() {
   );
 }
 
-// ──────────────────────────────────────────────────────────────────────────
-// Provider keys panel
-// ──────────────────────────────────────────────────────────────────────────
 
 const PROVIDERS = ["anthropic", "openai", "google", "openrouter"] as const;
 type Provider = (typeof PROVIDERS)[number];
@@ -592,9 +586,6 @@ function ProviderPicker({
   );
 }
 
-// ──────────────────────────────────────────────────────────────────────────
-// Config panel
-// ──────────────────────────────────────────────────────────────────────────
 
 interface ConfigRow {
   label: string;
@@ -685,9 +676,6 @@ function ConfigPanel() {
   );
 }
 
-// ──────────────────────────────────────────────────────────────────────────
-// Model selection panel
-// ──────────────────────────────────────────────────────────────────────────
 
 function ModelSelectionPanel() {
   const [available, setAvailable] = useState<DeployedModel[] | null>(null);
@@ -823,9 +811,6 @@ function ModelSelectionPanel() {
   );
 }
 
-// ──────────────────────────────────────────────────────────────────────────
-// Helpers
-// ──────────────────────────────────────────────────────────────────────────
 
 function ErrorBanner({ children }: { children: React.ReactNode }) {
   return (

--- a/frontend/src/components/Chart/Chart.tsx
+++ b/frontend/src/components/Chart/Chart.tsx
@@ -278,9 +278,6 @@ export interface ChartProps<
   ) => ChartData<TIndependentKey, TDependentKey, TIndependentValue, TDependentValue>;
 }
 
-/**
- * Renders a chart.
- */
 export function Chart<
   TIndependentKey extends ChartDataKeyType,
   TDependentKey extends ChartDataKeyType,
@@ -804,7 +801,6 @@ export function Chart<
 
             {referenceLines != null &&
               LoadState.unwrap(referenceLines)?.map(line => {
-                // Extract scalar value for Recharts (handles both single values and tuples)
                 const getValue = (val: ChartDataValueType): number | string =>
                   Array.isArray(val) ? val[0] : val;
 

--- a/frontend/src/components/Chart/ChartContainer.tsx
+++ b/frontend/src/components/Chart/ChartContainer.tsx
@@ -4,9 +4,6 @@ import { forwardRef, useId } from "react";
 
 export interface ChartContainerProps extends React.HTMLAttributes<HTMLDivElement> {}
 
-/**
- * Renders a container for a chart. This component handles styling.
- */
 export const ChartContainer = forwardRef<HTMLDivElement, ChartContainerProps>(
   ({ children, className, id, ...props }, ref) => {
     const uniqueId = useId();

--- a/frontend/src/components/Chart/ChartLegend.tsx
+++ b/frontend/src/components/Chart/ChartLegend.tsx
@@ -6,10 +6,8 @@ import * as Recharts from "recharts";
 import { useChartContext } from "./ChartContext";
 import { ChartDataKeyType } from "./types";
 
-/** Maximum character length for legend labels before truncation */
 const LEGEND_TEXT_MAX_LENGTH = 40;
 
-/** Truncate text to a max length with ellipsis */
 function truncateText(text: string, maxLength: number): string {
   if (text.length <= maxLength) return text;
   return text.slice(0, maxLength - 3) + "...";
@@ -44,9 +42,6 @@ interface ChartLegendSeriesProps {
   series: Pick<RechartsLegendPayloadItem, "color" | "type" | "value">;
 }
 
-/**
- * Renders the content for a single series in the chart tooltip.
- */
 function ChartLegendSeries<TDependentKey extends ChartDataKeyType>({
   series,
 }: ChartLegendSeriesProps) {

--- a/frontend/src/components/Chart/ChartMessageCard.tsx
+++ b/frontend/src/components/Chart/ChartMessageCard.tsx
@@ -14,7 +14,6 @@ export interface ChartMessageCardProps extends CardProps {
   overlay?: boolean;
 }
 
-/** Renders a message on top of the chart. */
 export function ChartMessageCard({ className, overlay = false, ...props }: ChartMessageCardProps) {
   return (
     <>
@@ -37,9 +36,6 @@ interface ChartMessageCardEmptyProps {
   emptyMessage?: React.ReactNode;
 }
 
-/**
- * Renders an empty message on top of the chart.
- */
 ChartMessageCard.Empty = function ChartMessageCardEmpty({
   emptyMessage,
 }: ChartMessageCardEmptyProps) {
@@ -55,9 +51,6 @@ ChartMessageCard.Empty = function ChartMessageCardEmpty({
   );
 };
 
-/**
- * Renders a loading message on top of the chart.
- */
 ChartMessageCard.Loading = function ChartMessageCardLoading() {
   return (
     <ChartMessageCard className="w-min min-w-0 rounded-full p-2" overlay>
@@ -72,9 +65,6 @@ interface ChartMessageCardErrorProps {
   error: Error;
 }
 
-/**
- * Renders an error message on top of the chart.
- */
 ChartMessageCard.Error = function ChartMessageCardError({ error }: ChartMessageCardErrorProps) {
   return (
     <ChartMessageCard

--- a/frontend/src/components/Chart/ChartReferenceLineLabel.tsx
+++ b/frontend/src/components/Chart/ChartReferenceLineLabel.tsx
@@ -16,9 +16,6 @@ const TEXT_ANCHOR: Readonly<
   right: "start",
 };
 
-/**
- * Renders a label for a reference line.
- */
 export function ChartReferenceLineLabel({
   label,
   side = "center",

--- a/frontend/src/components/Chart/ChartTick.tsx
+++ b/frontend/src/components/Chart/ChartTick.tsx
@@ -12,9 +12,6 @@ export interface ChartTickProps<TIndependentValue extends ChartDataValueType> {
   y?: number | string;
 }
 
-/**
- * Renders a custom tick for the x-axis of a chart.
- */
 export function ChartTick<TIndependentValue extends ChartDataValueType>({
   height,
   index,

--- a/frontend/src/components/Chart/ChartTooltip.tsx
+++ b/frontend/src/components/Chart/ChartTooltip.tsx
@@ -61,9 +61,6 @@ export interface ChartTooltipProps<
   fadeInactiveSeries?: boolean;
 }
 
-/**
- * Renders the content for the chart tooltip.
- */
 export function ChartTooltip<
   TIndependentKey extends ChartDataKeyType,
   TDependentKey extends ChartDataKeyType,
@@ -136,7 +133,6 @@ export function ChartTooltip<
   if (payload == null || payload.length === 0) return null;
   const independentValue = label as TIndependentValue | null | undefined;
 
-  // Use series-aware formatter if provided, otherwise fall back to basic formatter
   const title =
     independentValue != null && formatIndependentValueForSeries != null ?
       formatIndependentValueForSeries(independentValue, activeSeries ?? null)
@@ -240,9 +236,6 @@ interface ChartTooltipSeriesProps<
   >;
 }
 
-/**
- * Renders the content for a single series in the chart tooltip.
- */
 function ChartTooltipSeries<
   TIndependentKey extends ChartDataKeyType,
   TDependentKey extends ChartDataKeyType,

--- a/frontend/src/components/Chart/useToggleSeriesVisibility.ts
+++ b/frontend/src/components/Chart/useToggleSeriesVisibility.ts
@@ -15,9 +15,6 @@ interface UseToggleSeriesVisibilityResult<TDependentKey extends ChartDataKeyType
   toggleSeriesVisibility: (key: TDependentKey, exclusive?: boolean) => void;
 }
 
-/**
- * Returns a callback to toggle the visibility of a series.
- */
 export function useToggleSeriesVisibility<TDependentKey extends ChartDataKeyType>({
   dependentKeys,
   hiddenSeriesExternal,

--- a/frontend/src/components/atoms/Skeleton/Skeleton.tsx
+++ b/frontend/src/components/atoms/Skeleton/Skeleton.tsx
@@ -15,9 +15,6 @@ export interface SkeletonProps extends React.ComponentProps<"div"> {
   darker?: boolean;
 }
 
-/**
- * Renders a loading skeleton.
- */
 export function Skeleton({
   as: Element = "div",
   className,
@@ -36,9 +33,6 @@ export function Skeleton({
   );
 }
 
-/**
- * Renders a skeleton exactly matching the size and spacing of text.
- */
 Skeleton.Text = function SkeletonText({
   as: Element = "div",
   children,

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -34,8 +34,6 @@ async function request<T>(path: string, init?: RequestInit): Promise<T> {
   return res.json() as Promise<T>;
 }
 
-// --- types ---
-
 export interface MetricsSummary {
   request_count: number;
   total_tokens: number;
@@ -125,8 +123,6 @@ export interface ExcludedModelsResponse {
   excluded: string[];
   env_override_active: boolean;
 }
-
-// --- API calls ---
 
 export const api = {
   auth: {

--- a/frontend/src/tools/LoadState.ts
+++ b/frontend/src/tools/LoadState.ts
@@ -187,7 +187,6 @@ function map(...args: unknown[]): LoadState<unknown> {
     //  5. Loaded
 
     if (LoadState.isError(acc) && acc.previousValue !== undefined) {
-      // push the current value to the error accumulator, if possible
       const value =
         LoadState.isError(state) && state.previousValue !== undefined ? state.previousValue
         : LoadState.isReady(state) ? state.value


### PR DESCRIPTION
## Summary
- Strip JSDoc/inline comments that restate well-named code (e.g. `Renders a loading skeleton.`)
- Remove section-banner comments in `settings/page.tsx` and `lib/api.ts`
- Preserve all substantive "why" comments: Recharts workarounds, security invariants, partial unique index notes, animation/render coordination, etc.

12 files, 64 deletions, 0 logic changes.

## Test plan
- [ ] `yarn typecheck` / `yarn lint` green in CI