### PR TITLE
chore: prep router repo for public source release

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,6 +13,7 @@
 # Full Postgres connection string. Takes precedence over POSTGRES_* below.
 # DATABASE_URL=postgresql://router:router@localhost:5433/router?sslmode=disable
 
+# DEV ONLY defaults — match docker-compose.yml. Replace in any deployment.
 POSTGRES_USER=router
 POSTGRES_PASSWORD=router
 POSTGRES_DB=router
@@ -50,8 +51,8 @@ PORT=8080
 # `managed` skips both (for SaaS deployments with a separate admin frontend).
 ROUTER_DEPLOYMENT_MODE=selfhosted
 
-# Admin dashboard password. Defaults to "admin" when unset (logs a warning).
-# Set this in any deployment exposed to the internet.
+# Admin dashboard password. Defaults to "admin" when unset (logs a warning) —
+# DEV ONLY behavior. REQUIRED in any deployment exposed beyond localhost.
 # ROUTER_ADMIN_PASSWORD=change-me
 
 # Cookie security flag for the admin dashboard. Set to `true` only when

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,9 @@
 # Local docker stack for the router. Brings up Postgres, applies migrations, and
-# starts the server end-to-end. Suitable for `docker compose up` smoke tests; not
-# tuned for production (single-instance Postgres, no resource limits).
+# starts the server end-to-end. Suitable for `docker compose up` smoke tests.
+#
+# DEV ONLY — not tuned for production (single-instance Postgres, no resource
+# limits, default credentials below). Do not deploy this compose file to any
+# environment exposed beyond localhost.
 #
 # Usage:
 #   docker compose up --build
@@ -15,6 +18,7 @@
 services:
   postgres:
     image: postgres:15-alpine
+    # DEV ONLY credentials — replace before exposing this stack anywhere.
     environment:
       POSTGRES_USER: router
       POSTGRES_PASSWORD: router

--- a/internal/router/cluster/artifacts/v0.25/metadata.yaml
+++ b/internal/router/cluster/artifacts/v0.25/metadata.yaml
@@ -19,7 +19,7 @@ training:
     d1: 1.0
     d2: 0.0
     d3: 0.0
-  include_routerarena_labels: "/Users/steventohme/Desktop/workweave4/router-internal/eval/results/_unsorted/routerarena_labels_full.jsonl"
+  include_routerarena_labels: "routerarena_labels_full.jsonl"
   routerarena_only: true
   exclude_prompts: null
   n_excluded_prompts: 0

--- a/internal/router/cluster/artifacts/v0.25/rankings.json
+++ b/internal/router/cluster/artifacts/v0.25/rankings.json
@@ -25,7 +25,7 @@
     },
     "embedder_model": "jina-v2-base-code-int8",
     "exclude_prompts": null,
-    "include_routerarena_labels": "/Users/steventohme/Desktop/workweave4/router-internal/eval/results/_unsorted/routerarena_labels_full.jsonl",
+    "include_routerarena_labels": "routerarena_labels_full.jsonl",
     "k": 10,
     "n_excluded_prompts": 0,
     "n_prompts": 8013,

--- a/internal/router/cluster/artifacts/v0.26/metadata.yaml
+++ b/internal/router/cluster/artifacts/v0.26/metadata.yaml
@@ -19,7 +19,7 @@ training:
     d1: 1.0
     d2: 0.0
     d3: 0.0
-  include_routerarena_labels: "/Users/steventohme/Desktop/workweave4/router-internal/eval/results/_unsorted/routerarena_labels_full.jsonl"
+  include_routerarena_labels: "routerarena_labels_full.jsonl"
   routerarena_only: true
   exclude_prompts: null
   n_excluded_prompts: 0

--- a/internal/router/cluster/artifacts/v0.26/rankings.json
+++ b/internal/router/cluster/artifacts/v0.26/rankings.json
@@ -25,7 +25,7 @@
     },
     "embedder_model": "jina-v2-base-code-int8",
     "exclude_prompts": null,
-    "include_routerarena_labels": "/Users/steventohme/Desktop/workweave4/router-internal/eval/results/_unsorted/routerarena_labels_full.jsonl",
+    "include_routerarena_labels": "routerarena_labels_full.jsonl",
     "k": 10,
     "n_excluded_prompts": 0,
     "n_prompts": 8013,

--- a/internal/router/cluster/artifacts/v0.27/metadata.yaml
+++ b/internal/router/cluster/artifacts/v0.27/metadata.yaml
@@ -19,7 +19,7 @@ training:
     d1: 1.0
     d2: 0.0
     d3: 0.0
-  include_routerarena_labels: "/Users/steventohme/Desktop/workweave4/router-internal/eval/results/_unsorted/routerarena_labels_full.jsonl"
+  include_routerarena_labels: "routerarena_labels_full.jsonl"
   routerarena_only: true
   exclude_prompts: null
   n_excluded_prompts: 0

--- a/internal/router/cluster/artifacts/v0.27/rankings.json
+++ b/internal/router/cluster/artifacts/v0.27/rankings.json
@@ -25,7 +25,7 @@
     },
     "embedder_model": "jina-v2-base-code-int8",
     "exclude_prompts": null,
-    "include_routerarena_labels": "/Users/steventohme/Desktop/workweave4/router-internal/eval/results/_unsorted/routerarena_labels_full.jsonl",
+    "include_routerarena_labels": "routerarena_labels_full.jsonl",
     "k": 10,
     "n_excluded_prompts": 0,
     "n_prompts": 8013,

--- a/internal/router/cluster/artifacts/v0.32/metadata.yaml
+++ b/internal/router/cluster/artifacts/v0.32/metadata.yaml
@@ -19,7 +19,7 @@ training:
     d1: 1.0
     d2: 0.0
     d3: 0.0
-  include_routerarena_labels: "/Users/steventohme/Desktop/workweave4/router-internal/eval/results/_unsorted/routerarena_labels_full.jsonl"
+  include_routerarena_labels: "routerarena_labels_full.jsonl"
   routerarena_only: true
   exclude_prompts: null
   n_excluded_prompts: 0

--- a/internal/router/cluster/artifacts/v0.32/rankings.json
+++ b/internal/router/cluster/artifacts/v0.32/rankings.json
@@ -25,7 +25,7 @@
     },
     "embedder_model": "nomic-embed-text-v1.5-int8",
     "exclude_prompts": null,
-    "include_routerarena_labels": "/Users/steventohme/Desktop/workweave4/router-internal/eval/results/_unsorted/routerarena_labels_full.jsonl",
+    "include_routerarena_labels": "routerarena_labels_full.jsonl",
     "k": 10,
     "n_excluded_prompts": 0,
     "n_prompts": 8013,

--- a/internal/router/cluster/artifacts/v0.33/metadata.yaml
+++ b/internal/router/cluster/artifacts/v0.33/metadata.yaml
@@ -19,7 +19,7 @@ training:
     d1: 1.0
     d2: 0.0
     d3: 0.0
-  include_routerarena_labels: "/Users/steventohme/Desktop/workweave4/router-internal/eval/results/_unsorted/routerarena_labels_full.jsonl"
+  include_routerarena_labels: "routerarena_labels_full.jsonl"
   routerarena_only: true
   exclude_prompts: null
   n_excluded_prompts: 0

--- a/internal/router/cluster/artifacts/v0.33/rankings.json
+++ b/internal/router/cluster/artifacts/v0.33/rankings.json
@@ -25,7 +25,7 @@
     },
     "embedder_model": "gte-modernbert-base-int8",
     "exclude_prompts": null,
-    "include_routerarena_labels": "/Users/steventohme/Desktop/workweave4/router-internal/eval/results/_unsorted/routerarena_labels_full.jsonl",
+    "include_routerarena_labels": "routerarena_labels_full.jsonl",
     "k": 10,
     "n_excluded_prompts": 0,
     "n_prompts": 8013,

--- a/internal/router/cluster/artifacts/v0.34/metadata.yaml
+++ b/internal/router/cluster/artifacts/v0.34/metadata.yaml
@@ -19,7 +19,7 @@ training:
     d1: 1.0
     d2: 0.0
     d3: 0.0
-  include_routerarena_labels: "/Users/steventohme/Desktop/workweave4/router-internal/eval/results/_unsorted/routerarena_labels_full.jsonl"
+  include_routerarena_labels: "routerarena_labels_full.jsonl"
   routerarena_only: true
   exclude_prompts: null
   n_excluded_prompts: 0

--- a/internal/router/cluster/artifacts/v0.34/rankings.json
+++ b/internal/router/cluster/artifacts/v0.34/rankings.json
@@ -25,7 +25,7 @@
     },
     "embedder_model": "jina-v2-base-code-int8",
     "exclude_prompts": null,
-    "include_routerarena_labels": "/Users/steventohme/Desktop/workweave4/router-internal/eval/results/_unsorted/routerarena_labels_full.jsonl",
+    "include_routerarena_labels": "routerarena_labels_full.jsonl",
     "k": 16,
     "n_excluded_prompts": 0,
     "n_prompts": 8013,

--- a/internal/router/cluster/artifacts/v0.35/metadata.yaml
+++ b/internal/router/cluster/artifacts/v0.35/metadata.yaml
@@ -19,7 +19,7 @@ training:
     d1: 1.0
     d2: 0.0
     d3: 0.0
-  include_routerarena_labels: "/Users/steventohme/Desktop/workweave4/router-internal/eval/results/_unsorted/routerarena_plus_shortprompts.jsonl"
+  include_routerarena_labels: "routerarena_plus_shortprompts.jsonl"
   routerarena_only: true
   exclude_prompts: null
   n_excluded_prompts: 0

--- a/internal/router/cluster/artifacts/v0.35/rankings.json
+++ b/internal/router/cluster/artifacts/v0.35/rankings.json
@@ -25,7 +25,7 @@
     },
     "embedder_model": "jina-v2-base-code-int8",
     "exclude_prompts": null,
-    "include_routerarena_labels": "/Users/steventohme/Desktop/workweave4/router-internal/eval/results/_unsorted/routerarena_plus_shortprompts.jsonl",
+    "include_routerarena_labels": "routerarena_plus_shortprompts.jsonl",
     "k": 16,
     "n_excluded_prompts": 0,
     "n_prompts": 8416,

--- a/internal/router/cluster/artifacts/v0.36/metadata.yaml
+++ b/internal/router/cluster/artifacts/v0.36/metadata.yaml
@@ -19,7 +19,7 @@ training:
     d1: 1.0
     d2: 0.0
     d3: 0.0
-  include_routerarena_labels: "/Users/steventohme/Desktop/workweave4/router-internal/eval/results/_unsorted/routerarena_plus_shortprompts.jsonl"
+  include_routerarena_labels: "routerarena_plus_shortprompts.jsonl"
   routerarena_only: true
   exclude_prompts: null
   n_excluded_prompts: 0

--- a/internal/router/cluster/artifacts/v0.36/rankings.json
+++ b/internal/router/cluster/artifacts/v0.36/rankings.json
@@ -25,7 +25,7 @@
     },
     "embedder_model": "jina-v2-base-code-int8",
     "exclude_prompts": null,
-    "include_routerarena_labels": "/Users/steventohme/Desktop/workweave4/router-internal/eval/results/_unsorted/routerarena_plus_shortprompts.jsonl",
+    "include_routerarena_labels": "routerarena_plus_shortprompts.jsonl",
     "k": 16,
     "n_excluded_prompts": 0,
     "n_prompts": 8416,

--- a/internal/router/cluster/artifacts/v0.37/metadata.yaml
+++ b/internal/router/cluster/artifacts/v0.37/metadata.yaml
@@ -20,7 +20,7 @@ training:
     d2: 0.0
     d3: 0.0
   output_cost_ratio: 5.0
-  include_routerarena_labels: "/Users/steventohme/Desktop/workweave4/router-internal/eval/results/_unsorted/routerarena_plus_shortprompts.jsonl"
+  include_routerarena_labels: "routerarena_plus_shortprompts.jsonl"
   routerarena_only: true
   exclude_prompts: null
   n_excluded_prompts: 0

--- a/internal/router/cluster/artifacts/v0.37/rankings.json
+++ b/internal/router/cluster/artifacts/v0.37/rankings.json
@@ -25,7 +25,7 @@
     },
     "embedder_model": "jina-v2-base-code-int8",
     "exclude_prompts": null,
-    "include_routerarena_labels": "/Users/steventohme/Desktop/workweave4/router-internal/eval/results/_unsorted/routerarena_plus_shortprompts.jsonl",
+    "include_routerarena_labels": "routerarena_plus_shortprompts.jsonl",
     "k": 16,
     "n_excluded_prompts": 0,
     "n_prompts": 8416,


### PR DESCRIPTION
## Summary
- Strip personal absolute paths (`/Users/steventohme/Desktop/workweave4/router-internal/eval/results/_unsorted/...`) from `internal/router/cluster/artifacts/v0.{25..37}/{metadata.yaml,rankings.json}`. Reduces to just the basename. The `include_routerarena_labels` field isn't referenced in code (pure provenance metadata), so the basename is enough.
- Label DEV ONLY in `docker-compose.yml` (header + Postgres user/password/db block) and `.env.example` (Postgres defaults + `ROUTER_ADMIN_PASSWORD` fallback) so contributors don't accidentally carry those over into real deployments.

Part of the pre-public-source audit. Other items from that audit (git history scrub, README badge org-id, customer-name shoutout, `SECURITY.md`, LICENSE decision) are out of scope for this PR.

## Test plan
- [ ] `grep -r "/Users/" internal/router/cluster/artifacts/` returns nothing
- [ ] `docker compose up --build` still boots the stack
- [ ] CI green