### PR TITLE
fix(pricing): add claude-opus-4-6 to pricing and capability tier tables

### DIFF
--- a/install/cc-statusline.sh
+++ b/install/cc-statusline.sh
@@ -130,6 +130,7 @@ normalize_model() {
 prices='{
   "input": {
     "claude-haiku-4-5":                 0.0008,
+    "claude-opus-4-6":                  0.015,
     "claude-opus-4-7":                  0.015,
     "claude-sonnet-4-5":                0.003,
     "deepseek/deepseek-v4-flash":       0.00014,
@@ -171,6 +172,7 @@ prices='{
   },
   "output": {
     "claude-haiku-4-5":                 0.004,
+    "claude-opus-4-6":                  0.075,
     "claude-opus-4-7":                  0.075,
     "claude-sonnet-4-5":                0.015,
     "deepseek/deepseek-v4-flash":       0.00028,

--- a/install/install.sh
+++ b/install/install.sh
@@ -587,6 +587,7 @@ normalize_model() {
 prices='{
   "input": {
     "claude-haiku-4-5":                 0.0008,
+    "claude-opus-4-6":                  0.015,
     "claude-opus-4-7":                  0.015,
     "claude-sonnet-4-5":                0.003,
     "deepseek/deepseek-v4-flash":       0.00014,
@@ -628,6 +629,7 @@ prices='{
   },
   "output": {
     "claude-haiku-4-5":                 0.004,
+    "claude-opus-4-6":                  0.075,
     "claude-opus-4-7":                  0.075,
     "claude-sonnet-4-5":                0.015,
     "deepseek/deepseek-v4-flash":       0.00028,

--- a/internal/router/capability/tier.go
+++ b/internal/router/capability/tier.go
@@ -63,6 +63,7 @@ var tiers = map[string]Tier{
 
 	// --- High ---
 	"claude-opus-4-7":          TierHigh,
+	"claude-opus-4-6":          TierHigh,
 	"gemini-3-pro-preview":     TierHigh,
 	"gemini-3.1-pro-preview":   TierHigh,
 	"gpt-5":                    TierHigh,

--- a/internal/router/pricing/pricing.go
+++ b/internal/router/pricing/pricing.go
@@ -39,6 +39,7 @@ func All() map[string]Pricing {
 var table = map[string]Pricing{
 	// Anthropic (cache reads at 10% of base)
 	"claude-opus-4-7":   {InputUSDPer1M: 15.00, OutputUSDPer1M: 75.00, CacheReadMultiplier: 0.10},
+	"claude-opus-4-6":   {InputUSDPer1M: 15.00, OutputUSDPer1M: 75.00, CacheReadMultiplier: 0.10},
 	"claude-sonnet-4-5": {InputUSDPer1M: 3.00, OutputUSDPer1M: 15.00, CacheReadMultiplier: 0.10},
 	"claude-haiku-4-5":  {InputUSDPer1M: 0.80, OutputUSDPer1M: 4.00, CacheReadMultiplier: 0.10},
 


### PR DESCRIPTION
## Summary

- `claude-opus-4-6` was registered in `internal/router/model.go` but missing from the pricing and capability tier tables, causing incorrect routing behavior when Claude Code is set to Opus 4.6
- Adds `claude-opus-4-6` to `internal/router/pricing/pricing.go` at $15/$75 per 1M tokens (same as `claude-opus-4-7`), with 0.10 cache read multiplier
- Adds `claude-opus-4-6` as `TierHigh` in `internal/router/capability/tier.go`
- Regenerates the pricing block in `install/cc-statusline.sh` and `install/install.sh` via `go run ./cmd/genprices`

**Without this fix:**
- `capability.TierFor("claude-opus-4-6")` returned `TierUnknown`, disabling tier-ceiling clamping and putting Opus 4.6 sessions in the wrong pin bucket (`DefaultRole` instead of `_high`)
- `pricing.For("claude-opus-4-6")` returned `false`, so `baselineFor()` fell back to `defaultBaselineModel` — wrong EV math in the planner

## Test plan

- [x] `wv mr tc`: clean
- [x] All router tests pass (`go test ./...`)