### PR TITLE
docs: lead README with npx install, drop em dashes

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,17 +39,17 @@ loved by Robinhood, PostHog & Reducto.*
 
 Point Claude Code, Cursor, or your own app at `localhost:8080`. The router:
 
-- 🎯 **Routes per request** — an AvengersPro-derived cluster scorer picks the
+- 🎯 **Routes per request.** An AvengersPro-derived cluster scorer picks the
   right model from your enabled providers, every turn.
-- 🔌 **Speaks everyone's API** — Anthropic Messages, OpenAI Chat Completions,
+- 🔌 **Speaks everyone's API.** Anthropic Messages, OpenAI Chat Completions,
   Gemini native. Streaming, tools, vision, the works.
-- 🧠 **Knows OSS too** — DeepSeek, Kimi, GLM, Qwen, Llama, Mistral via
+- 🧠 **Knows OSS too.** DeepSeek, Kimi, GLM, Qwen, Llama, Mistral via
   OpenRouter (or any OpenAI-compatible endpoint).
-- 🔒 **BYOK by default** — provider keys stay on your box, encrypted at rest.
-- 📊 **Observable** — OTLP traces out of the box. Drop in Honeycomb, Datadog,
+- 🔒 **BYOK by default.** Provider keys stay on your box, encrypted at rest.
+- 📊 **Observable.** OTLP traces out of the box. Drop in Honeycomb, Datadog,
   Grafana, whatever.
 
-No silent fallbacks. No vibes. Routing failures return 503 — loud by design.
+No silent fallbacks. No vibes. Routing failures return 503; loud by design.
 
 ## 60-second quickstart
 
@@ -84,16 +84,13 @@ curl -sS http://localhost:8080/v1/route -H "Authorization: Bearer rk_..." -d '..
 
 ## Wire it into your tools
 
-**Claude Code**
+**Claude Code.** `make full-setup` already runs the Claude Code installer
+interactively at the end. Just say yes when it asks, and pick user scope
+or a project directory. Done.
 
-```bash
-export ANTHROPIC_BASE_URL=http://localhost:8080
-export ANTHROPIC_CUSTOM_HEADERS="X-Weave-Router-Key: rk_..."
-claude
-```
-
-**Cursor** — Settings → Models → *Override OpenAI Base URL* →
-`http://localhost:8080/v1`, paste `rk_...` as the API key.
+**Cursor** *(early beta, performance may not be the best).* Settings →
+Models → *Override OpenAI Base URL* → `http://localhost:8080/v1`, paste
+`rk_...` as the API key.
 
 > Two keys, don't mix them up:
 > - `sk-or-...` / `sk-ant-...` / `sk-...` = your **upstream** provider key. Lives in `.env.local`.
@@ -103,20 +100,20 @@ claude
 
 | Endpoint                       | Format                                   |
 | ------------------------------ | ---------------------------------------- |
-| `POST /v1/messages`            | Anthropic Messages — routed              |
-| `POST /v1/chat/completions`    | OpenAI Chat Completions — routed         |
-| `POST /v1beta/models/:action`  | Gemini `generateContent` — routed        |
+| `POST /v1/messages`            | Anthropic Messages, routed               |
+| `POST /v1/chat/completions`    | OpenAI Chat Completions, routed          |
+| `POST /v1beta/models/:action`  | Gemini `generateContent`, routed         |
 | `POST /v1/route`               | Returns the decision, no upstream call   |
 | `GET /v1/models` &nbsp;·&nbsp; `POST /v1/messages/count_tokens` | Anthropic passthrough |
 | `GET /health` &nbsp;·&nbsp; `GET /validate` | liveness + key check         |
 
 ## Deeper docs
 
-- 📐 [**Configuration reference**](docs/CONFIGURATION.md) — every env var,
+- 📐 [**Configuration reference**](docs/CONFIGURATION.md): every env var,
   BYOK encryption, OTel knobs, cluster routing.
-- 🛠️ [**Contributing**](CONTRIBUTING.md) — layering rules, hot-reload dev,
+- 🛠️ [**Contributing**](CONTRIBUTING.md): layering rules, hot-reload dev,
   migrations, tests, the whole engineering loop.
-- 🏗️ [**Architecture**](AGENTS.md) — package layout, import contracts,
+- 🏗️ [**Architecture**](AGENTS.md): package layout, import contracts,
   recipes for adding endpoints / providers / strategies.
 
 ## Roadmap

--- a/README.md
+++ b/README.md
@@ -51,19 +51,42 @@ Point Claude Code, Cursor, or your own app at `localhost:8080`. The router:
 
 No silent fallbacks. No vibes. Routing failures return 503; loud by design.
 
-## 60-second quickstart
+## 30-second quickstart
+
+The fastest way: point Claude Code at the **hosted** Weave Router with one
+command. No clone, no Docker, no Postgres.
+
+```bash
+npx @workweave/router
+```
+
+That's it. The installer walks you through scope (user vs. project), grabs
+a router key, and wires Claude Code. Other flavors:
+
+```bash
+npx @workweave/router --scope project       # per-repo, commits settings.json
+npx @workweave/router --local               # self-hosted localhost:8080
+npx @workweave/router --base-url https://router.acme.internal
+npx @workweave/router@0.1.0                 # pin a version
+```
+
+Requires Node ≥ 18 and `jq`. Full flag reference: [install/npm/README.md](install/npm/README.md).
+
+### Or: self-host the whole stack
+
+If you want the router (and dashboard) running on your own box:
 
 ```bash
 # 1. Drop a provider key in. OpenRouter is the recommended baseline.
 echo "OPENROUTER_API_KEY=sk-or-v1-..." >> .env.local
 
-# 2. Boot the stack (Postgres + router on :8080, seeds an rk_ key).
+# 2. Boot Postgres + router on :8080 and seed an rk_ key.
 make full-setup
 ```
 
-That's it. The router is up at <http://localhost:8080>, the dashboard at
-<http://localhost:8080/ui/> (password: `admin`), and your `rk_...` key is
-printed in the logs.
+The router is up at <http://localhost:8080>, the dashboard at
+<http://localhost:8080/ui/> (password: `admin`), and your `rk_...` key
+prints in the logs.
 
 ```bash
 # Call it like Anthropic
@@ -72,7 +95,7 @@ curl -sS http://localhost:8080/v1/messages \
   -d '{"model":"claude-sonnet-4-5","max_tokens":256,
        "messages":[{"role":"user","content":"hi"}]}'
 
-# …or like OpenAI
+# ...or like OpenAI
 curl -sS http://localhost:8080/v1/chat/completions \
   -H "Authorization: Bearer rk_..." \
   -d '{"model":"gpt-4o-mini",
@@ -84,9 +107,10 @@ curl -sS http://localhost:8080/v1/route -H "Authorization: Bearer rk_..." -d '..
 
 ## Wire it into your tools
 
-**Claude Code.** `make full-setup` already runs the Claude Code installer
-interactively at the end. Just say yes when it asks, and pick user scope
-or a project directory. Done.
+**Claude Code.** Run `make install-cc` to wire Claude Code at the local
+self-hosted router (it's also invoked automatically at the end of
+`make full-setup`). For the hosted router, use `npx @workweave/router`
+above.
 
 **Cursor** *(early beta, performance may not be the best).* Settings →
 Models → *Override OpenAI Base URL* → `http://localhost:8080/v1`, paste


### PR DESCRIPTION
## Summary

Follow-ups that missed the #154 merge window.

- Lead the README with `npx @workweave/router` as the primary 30-second install path (hosted router, no Docker/Postgres needed).
- Demote `make full-setup` to a secondary "self-host the whole stack" section.
- Claude Code wiring now references `make install-cc` (the dedicated target for re-running just the installer against the local stack).
- Mark Cursor support as early beta with a performance caveat.
- Replace all em dashes with periods/commas/colons.

## Test plan

- [ ] README renders cleanly on GitHub
- [ ] `npx @workweave/router` block is the first thing under the quickstart heading
- [ ] No em dashes remain (`grep "—" README.md` is empty)
- [ ] All internal links still resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)