### PR TITLE
feat: allow multiple API keys per installation

### DIFF
--- a/db/migrations/0004_multiple-api-keys-per-installation.down.sql
+++ b/db/migrations/0004_multiple-api-keys-per-installation.down.sql
@@ -1,5 +1,22 @@
 BEGIN;
 
+-- Collapse to one active key per installation before re-adding the partial
+-- unique index. Without this step the CREATE UNIQUE INDEX below would fail
+-- with a 23505 on any installation that issued a second key while the up
+-- migration was in force. Newest-created wins; older active rows are
+-- soft-deleted so the audit trail is preserved.
+WITH ranked AS (
+    SELECT id,
+           row_number() OVER (PARTITION BY installation_id ORDER BY created_at DESC, id DESC) AS rn
+    FROM router.model_router_api_keys
+    WHERE deleted_at IS NULL
+)
+UPDATE router.model_router_api_keys
+SET deleted_at = NOW()
+FROM ranked
+WHERE ranked.id = router.model_router_api_keys.id
+  AND ranked.rn > 1;
+
 CREATE UNIQUE INDEX model_router_api_keys_installation_active_unique
   ON router.model_router_api_keys(installation_id)
   WHERE deleted_at IS NULL;

--- a/db/migrations/0004_multiple-api-keys-per-installation.down.sql
+++ b/db/migrations/0004_multiple-api-keys-per-installation.down.sql
@@ -1,0 +1,12 @@
+BEGIN;
+
+CREATE UNIQUE INDEX model_router_api_keys_installation_active_unique
+  ON router.model_router_api_keys(installation_id)
+  WHERE deleted_at IS NULL;
+
+COMMENT ON INDEX router.model_router_api_keys_installation_active_unique IS
+  'One active key per installation. Identity is carried by router.model_router_users; a key is an installation-scoped secret, not a per-user credential.';
+
+COMMENT ON TABLE router.model_router_api_keys IS 'Rotatable bearer keys (rk_ prefix) per installation';
+
+COMMIT;

--- a/db/migrations/0004_multiple-api-keys-per-installation.up.sql
+++ b/db/migrations/0004_multiple-api-keys-per-installation.up.sql
@@ -1,0 +1,12 @@
+BEGIN;
+
+-- Allow multiple active router API keys per installation. The partial unique
+-- index treated keys as the installation's single bearer secret; we now treat
+-- them as named credentials the customer can issue, rotate, and revoke
+-- individually.
+DROP INDEX router.model_router_api_keys_installation_active_unique;
+
+COMMENT ON TABLE router.model_router_api_keys IS
+  'Rotatable bearer keys (rk_ prefix). An installation may hold multiple active keys; identity is carried by router.model_router_users.';
+
+COMMIT;

--- a/frontend/src/app/(app)/settings/page.tsx
+++ b/frontend/src/app/(app)/settings/page.tsx
@@ -117,15 +117,11 @@ function RouterKeysPanel() {
   const [error, setError] = useState<string | null>(null);
   const [name, setName] = useState("");
   const [creating, setCreating] = useState(false);
-  const [rotating, setRotating] = useState(false);
+  const [rotating, setRotating] = useState<string | null>(null);
   const [deleting, setDeleting] = useState<string | null>(null);
   const [newToken, setNewToken] = useState<string | null>(null);
   const [copied, setCopied] = useState(false);
 
-  // hasKey is only meaningful once the list has loaded. Without the loaded
-  // gate, the "Issue a new key" form would flash on every page load even
-  // when an active key exists, implying multi-key support that the
-  // installation_id-scoped partial unique index now forbids.
   const hasKey = keys.length > 0;
 
   function load() {
@@ -145,7 +141,6 @@ function RouterKeysPanel() {
 
   async function handleCreate(e: React.FormEvent) {
     e.preventDefault();
-    if (hasKey) return; // Belt-and-suspenders against a stale-render submit.
     setCreating(true);
     try {
       const res = await api.keys.issue(name.trim() || undefined);
@@ -159,21 +154,20 @@ function RouterKeysPanel() {
     }
   }
 
-  async function handleRotate() {
-    if (!hasKey) return;
+  async function handleRotate(id: string) {
     const confirmed = window.confirm(
       "Rotate this API key?\n\nThe current token will stop working immediately. A new token will be shown once.",
     );
     if (!confirmed) return;
-    setRotating(true);
+    setRotating(id);
     try {
-      const res = await api.keys.rotate();
+      const res = await api.keys.rotate(id);
       setNewToken(res.token);
       load();
     } catch (err: unknown) {
       setError(err instanceof Error ? err.message : "Failed to rotate key");
     } finally {
-      setRotating(false);
+      setRotating(null);
     }
   }
 
@@ -228,7 +222,7 @@ function RouterKeysPanel() {
         </div>
       )}
 
-      {loaded && !hasKey && (
+      {loaded && (
         <Card>
           <Card.Header>
             <Card.Title variant="h4">Issue a new key</Card.Title>
@@ -265,7 +259,7 @@ function RouterKeysPanel() {
       {hasKey ? (
         <Card className="p-0">
           <Card.Header className="border-b border-border px-5 py-3">
-            <Card.Title variant="h4">Active router key</Card.Title>
+            <Card.Title variant="h4">Active router keys</Card.Title>
           </Card.Header>
           <Card.Content>
             <ul className="divide-y divide-border">
@@ -287,18 +281,18 @@ function RouterKeysPanel() {
                     <Button
                       appearance={Appearance.Outlined}
                       size="sm"
-                      onClick={handleRotate}
-                      disabled={rotating || deleting != null}
+                      onClick={() => handleRotate(k.id)}
+                      disabled={rotating != null || deleting != null}
                     >
                       <RotateCw className="size-3.5" />
-                      {rotating ? "Rotating…" : "Rotate"}
+                      {rotating === k.id ? "Rotating…" : "Rotate"}
                     </Button>
                     <Button
                       appearance={Appearance.Hollow}
                       intent={Intent.Danger}
                       size="icon"
                       onClick={() => handleDelete(k.id)}
-                      disabled={deleting === k.id || rotating}
+                      disabled={deleting === k.id || rotating != null}
                       title="Revoke key"
                     >
                       <Trash2 className="size-3.5" />

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -160,11 +160,11 @@ export const api = {
         method: "POST",
         body: JSON.stringify({ name: name ?? "" }),
       }),
-    // Soft-deletes the current active key and issues a replacement in one
-    // round-trip. The previous token stops working immediately. Carries
-    // forward the previous key's name server-side.
-    rotate: () =>
-      request<IssueAPIKeyResponse>("/keys/rotate", { method: "POST" }),
+    // Soft-deletes the named key and issues a replacement in one round-trip.
+    // The previous token stops working immediately. Carries forward the
+    // previous key's name server-side.
+    rotate: (id: string) =>
+      request<IssueAPIKeyResponse>(`/keys/${id}/rotate`, { method: "POST" }),
     delete: (id: string) => request<void>(`/keys/${id}`, { method: "DELETE" }),
   },
   providerKeys: {

--- a/internal/api/admin/keys.go
+++ b/internal/api/admin/keys.go
@@ -58,23 +58,13 @@ func ListAPIKeysHandler(authSvc *auth.Service) gin.HandlerFunc {
 	}
 }
 
-// IssueAPIKeyHandler creates the installation's first router API key.
-// Returns 409 if an active key exists — the partial unique index on
-// (installation_id) WHERE deleted_at IS NULL would reject the insert regardless.
+// IssueAPIKeyHandler creates a new router API key for the installation. An
+// installation may hold multiple active keys at a time; callers issue, rotate,
+// and revoke them individually.
 func IssueAPIKeyHandler(authSvc *auth.Service) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		installation, ok := resolveInstallation(c, authSvc)
 		if !ok {
-			return
-		}
-		// Pre-check in front of the DB constraint so callers get a clean 409 instead of a generic 500.
-		existing, err := authSvc.ListAPIKeys(c.Request.Context(), installation.ID)
-		if err != nil {
-			c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"error": "failed to look up existing api key"})
-			return
-		}
-		if len(existing) > 0 {
-			c.AbortWithStatusJSON(http.StatusConflict, gin.H{"error": "installation already has an active api key; rotate it instead"})
 			return
 		}
 		var req issueAPIKeyRequest
@@ -85,10 +75,6 @@ func IssueAPIKeyHandler(authSvc *auth.Service) gin.HandlerFunc {
 		}
 		key, rawToken, err := authSvc.IssueAPIKey(c.Request.Context(), installation.ID, name, nil)
 		if err != nil {
-			if errors.Is(err, auth.ErrActiveKeyExists) {
-				c.AbortWithStatusJSON(http.StatusConflict, gin.H{"error": "installation already has an active api key; rotate it instead"})
-				return
-			}
 			c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"error": "failed to issue api key"})
 			return
 		}
@@ -99,15 +85,26 @@ func IssueAPIKeyHandler(authSvc *auth.Service) gin.HandlerFunc {
 	}
 }
 
-// RotateAPIKeyHandler soft-deletes the current active key and issues a replacement.
+// RotateAPIKeyHandler soft-deletes the specified key and issues a replacement
+// against the same installation, carrying forward the previous key's name.
+// 404 when the id is not owned by the caller's installation.
 func RotateAPIKeyHandler(authSvc *auth.Service) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		installation, ok := resolveInstallation(c, authSvc)
 		if !ok {
 			return
 		}
-		key, rawToken, err := authSvc.RotateAPIKey(c.Request.Context(), installation.ID, nil)
+		id := c.Param("id")
+		if id == "" {
+			c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": "missing id"})
+			return
+		}
+		key, rawToken, err := authSvc.RotateAPIKey(c.Request.Context(), installation.ID, id, nil)
 		if err != nil {
+			if errors.Is(err, auth.ErrAPIKeyNotFound) {
+				c.AbortWithStatusJSON(http.StatusNotFound, gin.H{"error": "api key not found"})
+				return
+			}
 			c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"error": "failed to rotate api key"})
 			return
 		}

--- a/internal/auth/errors.go
+++ b/internal/auth/errors.go
@@ -8,6 +8,7 @@ var (
 	ErrInvalidPrefix = errors.New("invalid bearer key prefix")
 	ErrInvalidToken  = errors.New("invalid bearer key")
 
-	// ErrActiveKeyExists is returned when the installation already has an active key.
-	ErrActiveKeyExists = errors.New("installation already has an active api key")
+	// ErrAPIKeyNotFound is returned when a rotate/delete targets a key that is
+	// either missing or owned by a different installation.
+	ErrAPIKeyNotFound = errors.New("api key not found")
 )

--- a/internal/auth/service.go
+++ b/internal/auth/service.go
@@ -126,24 +126,32 @@ func (s *Service) ListAPIKeys(ctx context.Context, installationID string) ([]*AP
 	return s.apiKeys.ListForInstallation(ctx, installationID)
 }
 
-// RotateAPIKey soft-deletes all active keys and issues a new one, carrying forward the name.
-// Not wrapped in a tx: a brief "no active key" window is acceptable because rotation's purpose
-// is to invalidate the old token anyway.
-func (s *Service) RotateAPIKey(ctx context.Context, installationID string, createdBy *string) (*APIKey, string, error) {
+// RotateAPIKey soft-deletes the named key and issues a replacement under the
+// same installation, carrying forward the previous key's name. Returns
+// ErrAPIKeyNotFound when keyID does not match an active key owned by the
+// installation, so a tenant who learns a foreign key UUID cannot rotate it.
+//
+// Not wrapped in a tx: a brief "no active key" window is acceptable because
+// rotation's purpose is to invalidate the old token anyway.
+func (s *Service) RotateAPIKey(ctx context.Context, installationID, keyID string, createdBy *string) (*APIKey, string, error) {
 	existing, err := s.apiKeys.ListForInstallation(ctx, installationID)
 	if err != nil {
 		return nil, "", err
 	}
-	var name *string
+	var target *APIKey
 	for _, k := range existing {
-		if k.Name != nil && name == nil {
-			name = k.Name
-		}
-		if err := s.apiKeys.SoftDelete(ctx, k.ID); err != nil {
-			return nil, "", err
+		if k.ID == keyID {
+			target = k
+			break
 		}
 	}
-	key, raw, err := s.IssueAPIKey(ctx, installationID, name, createdBy)
+	if target == nil {
+		return nil, "", ErrAPIKeyNotFound
+	}
+	if err := s.apiKeys.SoftDelete(ctx, target.ID); err != nil {
+		return nil, "", err
+	}
+	key, raw, err := s.IssueAPIKey(ctx, installationID, target.Name, createdBy)
 	if err != nil {
 		return nil, "", err
 	}

--- a/internal/postgres/repository.go
+++ b/internal/postgres/repository.go
@@ -3,20 +3,12 @@ package postgres
 
 import (
 	"context"
-	"errors"
 
 	"workweave/router/internal/auth"
 	"workweave/router/internal/sqlc"
 
 	"github.com/google/uuid"
-	"github.com/jackc/pgx/v5/pgconn"
 )
-
-// activeKeyUniqueIndex enforces one active key per installation (migration 0007).
-const activeKeyUniqueIndex = "model_router_api_keys_installation_active_unique"
-
-// uniqueViolation is Postgres SQLSTATE 23505.
-const uniqueViolation = "23505"
 
 // Repository aggregates all repositories backed by the same DBTX.
 type Repository struct {
@@ -132,10 +124,6 @@ func (r *apiKeyRepo) Create(ctx context.Context, params auth.CreateAPIKeyParams)
 		CreatedBy:      params.CreatedBy,
 	})
 	if err != nil {
-		var pgErr *pgconn.PgError
-		if errors.As(err, &pgErr) && pgErr.Code == uniqueViolation && pgErr.ConstraintName == activeKeyUniqueIndex {
-			return nil, auth.ErrActiveKeyExists
-		}
 		return nil, err
 	}
 	return toAuthAPIKey(row), nil

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -77,7 +77,7 @@ func Register(engine *gin.Engine, authSvc *auth.Service, proxySvc *proxy.Service
 		mgmt := engine.Group("/admin/v1", middleware.WithTimeout(adminTimeout), middleware.WithAdminOnly(authSvc))
 		mgmt.GET("/keys", admin.ListAPIKeysHandler(authSvc))
 		mgmt.POST("/keys", admin.IssueAPIKeyHandler(authSvc))
-		mgmt.POST("/keys/rotate", admin.RotateAPIKeyHandler(authSvc))
+		mgmt.POST("/keys/:id/rotate", admin.RotateAPIKeyHandler(authSvc))
 		mgmt.DELETE("/keys/:id", admin.DeleteAPIKeyHandler(authSvc))
 		mgmt.GET("/provider-keys", admin.ListExternalKeysHandler(authSvc))
 		mgmt.POST("/provider-keys", admin.UpsertExternalKeyHandler(authSvc))

--- a/internal/sqlc/models.go
+++ b/internal/sqlc/models.go
@@ -9,7 +9,7 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 )
 
-// Rotatable bearer keys (rk_ prefix) per installation
+// Rotatable bearer keys (rk_ prefix). An installation may hold multiple active keys; identity is carried by router.model_router_users.
 type RouterModelRouterAPIKey struct {
 	ID             uuid.UUID
 	InstallationID uuid.UUID


### PR DESCRIPTION
## Summary
- Drops the `model_router_api_keys_installation_active_unique` partial unique index so an installation can hold any number of active `rk_` keys
- `auth.Service.RotateAPIKey` now rotates a single key by id (was: rotate-all-keys-for-installation); `ErrActiveKeyExists` removed, `ErrAPIKeyNotFound` added
- `POST /admin/v1/keys` no longer 409s when a key exists; rotation endpoint moves to `POST /admin/v1/keys/:id/rotate`
- Self-hosted dashboard always shows the issue-key form and rotates per-row

## Test plan
- [x] `go test ./...`
- [ ] Apply migration on a staging DB and confirm a second `POST /admin/v1/keys` succeeds where it previously 409'd
- [ ] Rotate one of two keys and confirm only that key is soft-deleted

🤖 Generated with [Claude Code](https://claude.com/claude-code)