### PR TITLE
fix(translate): keep `type: object`/`array` scalar in strict-mode tool schemas

### DIFF
--- a/internal/translate/emit_openai.go
+++ b/internal/translate/emit_openai.go
@@ -443,10 +443,11 @@ func applyStrictModeToParams(node any) {
 }
 
 // isObjectType reports whether a JSON Schema `type` value is "object", either
-// as a bare string or as part of a nullable union like ["object", "null"].
-// Optional nested objects pass through `makeNullable` before recursion, which
-// rewrites scalar `type: "object"` to a string-array, so the strict-mode pass
-// must accept both shapes or it skips invariants on those subtrees.
+// as a bare string or as part of a union like ["object", "null"]. The router's
+// own strict-mode pass no longer produces `["object", "null"]` (see
+// makeNullable — DeepSeek rejects it), but a hand-written source schema can
+// still arrive in that shape, so we keep the union check for defensive
+// coverage on the recursion's "is this still an object subtree?" question.
 func isObjectType(typ any) bool {
 	switch t := typ.(type) {
 	case string:
@@ -492,6 +493,14 @@ func applyStrictToolsToBody(body []byte) ([]byte, error) {
 // makeNullable adds "null" to a schema's `type` so strict mode can still send
 // a null value for what was previously an optional property. No-op when the
 // schema lacks a `type` keyword or already permits null.
+//
+// "object" and "array" are deliberately skipped: DeepSeek's tool-schema
+// parser only accepts string|number|integer|boolean|null as members of a
+// `type` array, so emitting `["object", "null"]` 400s upstream even though
+// the union is standard JSON Schema. Strict mode forces every property
+// into `required` anyway, so the model has to construct the value to
+// invoke the tool either way — dropping the nullable affordance for these
+// types removes a path the model can't usefully take.
 func makeNullable(node any) {
 	m, ok := node.(map[string]any)
 	if !ok {
@@ -499,13 +508,24 @@ func makeNullable(node any) {
 	}
 	switch t := m["type"].(type) {
 	case string:
-		if t == "null" {
+		if t == "null" || t == "object" || t == "array" {
 			return
 		}
 		m["type"] = []any{t, "null"}
 	case []any:
 		for _, v := range t {
 			if s, _ := v.(string); s == "null" {
+				return
+			}
+		}
+		// If a hand-written source schema already declared a type union
+		// containing "object" or "array", DeepSeek would reject it on its
+		// own merits — adding "null" doesn't worsen that, but adding it to
+		// a union that's already DeepSeek-incompatible has no upside. Leave
+		// it alone so the error message points at the source field, not at
+		// the strict-mode pass.
+		for _, v := range t {
+			if s, _ := v.(string); s == "object" || s == "array" {
 				return
 			}
 		}

--- a/internal/translate/strict_tools_test.go
+++ b/internal/translate/strict_tools_test.go
@@ -141,10 +141,12 @@ func TestStrictTools_AnthropicSource_PropagatesIntoNestedObject(t *testing.T) {
 }
 
 func TestStrictTools_AnthropicSource_OptionalNestedObjectStillTightened(t *testing.T) {
-	// Regression: makeNullable rewrites an optional nested object's `type` from
-	// the scalar "object" to ["object","null"]. A naive recursive walk that
-	// matches only scalar "object" would skip the nested object's invariants,
-	// emitting a schema that fails strict-mode validation upstream.
+	// Regression: an optional nested object schema must still get strict-mode
+	// invariants (additionalProperties:false, all properties moved to
+	// required) and must appear in its parent's `required` list. The `type`
+	// itself stays the scalar "object" — emitting `["object", "null"]`
+	// would 400 against DeepSeek's tool-schema parser, which only accepts
+	// string|number|integer|boolean|null as members of a type array.
 	src := []byte(`{
 		"model":"claude-opus-4-7",
 		"messages":[{"role":"user","content":"hi"}],
@@ -173,17 +175,59 @@ func TestStrictTools_AnthropicSource_OptionalNestedObjectStillTightened(t *testi
 
 	fn := firstToolFunction(t, out.Body)
 	params, _ := fn["parameters"].(map[string]any)
+	parentRequired, _ := params["required"].([]any)
+	assert.Contains(t, parentRequired, "opts",
+		"strict mode forces every property into required; the optional becomes effectively required")
+
 	props, _ := params["properties"].(map[string]any)
 	opts, _ := props["opts"].(map[string]any)
 	require.NotNil(t, opts)
 
-	assert.ElementsMatch(t, []any{"object", "null"}, opts["type"],
-		"optional nested object must be marked nullable")
+	assert.Equal(t, "object", opts["type"],
+		"keep scalar `type: object` — DeepSeek's parser rejects 'object' as a member of a type array")
 	assert.Equal(t, false, opts["additionalProperties"],
-		"nullable nested objects still need additionalProperties:false for strict mode")
+		"nested object still needs additionalProperties:false for strict mode")
 	required, _ := opts["required"].([]any)
 	assert.ElementsMatch(t, []any{"flag"}, required,
-		"nullable nested objects still need their properties moved to required")
+		"nested object still needs its properties moved to required")
+}
+
+func TestStrictTools_AnthropicSource_OptionalNestedArrayKeepsScalarType(t *testing.T) {
+	// Mirror of OptionalNestedObject for `type: array`. DeepSeek's parser
+	// rejects "array" inside a type union the same way it rejects "object",
+	// so the strict-mode pass must keep arrays scalar.
+	src := []byte(`{
+		"model":"claude-opus-4-7",
+		"messages":[{"role":"user","content":"hi"}],
+		"tools":[{
+			"name":"NestedArray",
+			"description":"nested optional array",
+			"input_schema":{
+				"type":"object",
+				"properties":{
+					"items":{
+						"type":"array",
+						"items":{"type":"string"}
+					}
+				}
+			}
+		}],
+		"max_tokens":256
+	}`)
+	env, err := translate.ParseAnthropic(src)
+	require.NoError(t, err)
+
+	out, err := env.PrepareOpenAI(nil, translate.EmitOptions{TargetModel: "deepseek/deepseek-v4-pro"})
+	require.NoError(t, err)
+
+	fn := firstToolFunction(t, out.Body)
+	params, _ := fn["parameters"].(map[string]any)
+	props, _ := params["properties"].(map[string]any)
+	items, _ := props["items"].(map[string]any)
+	require.NotNil(t, items)
+
+	assert.Equal(t, "array", items["type"],
+		"keep scalar `type: array` — DeepSeek's parser rejects 'array' as a member of a type array")
 }
 
 func TestStrictTools_AnthropicSource_RecursesIntoDefsAndDefinitions(t *testing.T) {


### PR DESCRIPTION
## Summary

DeepSeek 400s every tool-calling turn the cluster scorer sends it. The error:

```
Invalid tool parameters schema : field `type`: unknown variant `object`,
expected one of `string`, `number`, `integer`, `boolean`, `null`
```

DeepSeek's tool-schema deserializer uses a custom enum for `type` array members and accepts **only the primitive types** — `"object"` and `"array"` are not valid variants in a union, even though both are standard JSON Schema.

PR #139's strict-mode pass added `makeNullable`, which converts every optional property's scalar `type` into `[t, "null"]` so the model can still pass null under OpenAI strict mode. Claude Code's tools (`Edit`, `Bash`, `Task`, …) have plenty of optional nested-object and array-typed properties, so this rewrites them to `["object", "null"]` / `["array", "null"]` — exactly the shape DeepSeek rejects.

## Fix

`makeNullable` now short-circuits when the existing scalar type is `"object"` or `"array"`. The property still ends up in `required` (strict mode forces every property into `required`), so the model has to construct the value to invoke the tool — we just stop offering it a "pass null instead" affordance DeepSeek can't accept anyway. Tightening invariants (`additionalProperties:false`, propagating nested required-from-properties) keep applying through the recursion that runs after `makeNullable`.

The `[]any` branch also gets a defensive guard: if a hand-written source already declares a union containing `object`/`array`, DeepSeek would reject it on its own merits; we don't make it worse by appending `"null"`.

## Test plan

- [x] `TestStrictTools_AnthropicSource_OptionalNestedObjectStillTightened` updated — now asserts the scalar `type: "object"` and that the parent's `required` list contains the property.
- [x] New `TestStrictTools_AnthropicSource_OptionalNestedArrayKeepsScalarType` covering the array case.
- [x] `go test -tags no_onnx -count=1 ./internal/translate/...` passes.
- [x] Full repo build + short test sweep passes.

## Out of scope

- Adding a per-model "supports complex tool schemas" capability filter so the scorer never picks DeepSeek for tool turns. Useful follow-up if DeepSeek's parser surfaces more strict-mode incompatibilities — kept out here so the urgent fix lands fast.

🤖 Generated with [Claude Code](https://claude.com/claude-code)