### PR TITLE
feat: migrate telemetry cost columns to BIGINT micros

### DIFF
--- a/db/migrations/0005_telemetry-costs-to-micros.down.sql
+++ b/db/migrations/0005_telemetry-costs-to-micros.down.sql
@@ -1,0 +1,17 @@
+BEGIN;
+
+ALTER TABLE router.model_router_request_telemetry
+    ALTER COLUMN requested_input_cost_usd  DROP DEFAULT,
+    ALTER COLUMN requested_output_cost_usd DROP DEFAULT,
+    ALTER COLUMN actual_input_cost_usd     DROP DEFAULT,
+    ALTER COLUMN actual_output_cost_usd    DROP DEFAULT,
+    ALTER COLUMN requested_input_cost_usd  TYPE NUMERIC(16, 6) USING (requested_input_cost_usd  / 1000000.0)::NUMERIC(16, 6),
+    ALTER COLUMN requested_output_cost_usd TYPE NUMERIC(16, 6) USING (requested_output_cost_usd / 1000000.0)::NUMERIC(16, 6),
+    ALTER COLUMN actual_input_cost_usd     TYPE NUMERIC(16, 6) USING (actual_input_cost_usd     / 1000000.0)::NUMERIC(16, 6),
+    ALTER COLUMN actual_output_cost_usd    TYPE NUMERIC(16, 6) USING (actual_output_cost_usd    / 1000000.0)::NUMERIC(16, 6),
+    ALTER COLUMN requested_input_cost_usd  SET DEFAULT 0,
+    ALTER COLUMN requested_output_cost_usd SET DEFAULT 0,
+    ALTER COLUMN actual_input_cost_usd     SET DEFAULT 0,
+    ALTER COLUMN actual_output_cost_usd    SET DEFAULT 0;
+
+COMMIT;

--- a/db/migrations/0005_telemetry-costs-to-micros.up.sql
+++ b/db/migrations/0005_telemetry-costs-to-micros.up.sql
@@ -1,0 +1,22 @@
+BEGIN;
+
+-- Convert telemetry cost columns from NUMERIC(16,6) USD to BIGINT micros
+-- (USD x 1e6). Integer math avoids the rounding-edge surprises pgtype.Numeric
+-- introduces at the Go/Postgres boundary and aligns this table with the
+-- credit ledger introduced in the billing MVP, which represents money as
+-- BIGINT micros.
+ALTER TABLE router.model_router_request_telemetry
+    ALTER COLUMN requested_input_cost_usd  DROP DEFAULT,
+    ALTER COLUMN requested_output_cost_usd DROP DEFAULT,
+    ALTER COLUMN actual_input_cost_usd     DROP DEFAULT,
+    ALTER COLUMN actual_output_cost_usd    DROP DEFAULT,
+    ALTER COLUMN requested_input_cost_usd  TYPE BIGINT USING ROUND(requested_input_cost_usd  * 1000000)::BIGINT,
+    ALTER COLUMN requested_output_cost_usd TYPE BIGINT USING ROUND(requested_output_cost_usd * 1000000)::BIGINT,
+    ALTER COLUMN actual_input_cost_usd     TYPE BIGINT USING ROUND(actual_input_cost_usd     * 1000000)::BIGINT,
+    ALTER COLUMN actual_output_cost_usd    TYPE BIGINT USING ROUND(actual_output_cost_usd    * 1000000)::BIGINT,
+    ALTER COLUMN requested_input_cost_usd  SET DEFAULT 0,
+    ALTER COLUMN requested_output_cost_usd SET DEFAULT 0,
+    ALTER COLUMN actual_input_cost_usd     SET DEFAULT 0,
+    ALTER COLUMN actual_output_cost_usd    SET DEFAULT 0;
+
+COMMIT;

--- a/db/migrations/0005_telemetry-costs-to-micros.up.sql
+++ b/db/migrations/0005_telemetry-costs-to-micros.up.sql
@@ -10,10 +10,14 @@ ALTER TABLE router.model_router_request_telemetry
     ALTER COLUMN requested_output_cost_usd DROP DEFAULT,
     ALTER COLUMN actual_input_cost_usd     DROP DEFAULT,
     ALTER COLUMN actual_output_cost_usd    DROP DEFAULT,
-    ALTER COLUMN requested_input_cost_usd  TYPE BIGINT USING ROUND(requested_input_cost_usd  * 1000000)::BIGINT,
-    ALTER COLUMN requested_output_cost_usd TYPE BIGINT USING ROUND(requested_output_cost_usd * 1000000)::BIGINT,
-    ALTER COLUMN actual_input_cost_usd     TYPE BIGINT USING ROUND(actual_input_cost_usd     * 1000000)::BIGINT,
-    ALTER COLUMN actual_output_cost_usd    TYPE BIGINT USING ROUND(actual_output_cost_usd    * 1000000)::BIGINT,
+    -- COALESCE on the way in: a previous toNumeric bug silently persisted
+    -- some historical rows with NULL cost values. Coerce those to 0 micros
+    -- so row queries that scan the result into a non-pointer int64 don't
+    -- choke on NULL.
+    ALTER COLUMN requested_input_cost_usd  TYPE BIGINT USING ROUND(COALESCE(requested_input_cost_usd,  0) * 1000000)::BIGINT,
+    ALTER COLUMN requested_output_cost_usd TYPE BIGINT USING ROUND(COALESCE(requested_output_cost_usd, 0) * 1000000)::BIGINT,
+    ALTER COLUMN actual_input_cost_usd     TYPE BIGINT USING ROUND(COALESCE(actual_input_cost_usd,     0) * 1000000)::BIGINT,
+    ALTER COLUMN actual_output_cost_usd    TYPE BIGINT USING ROUND(COALESCE(actual_output_cost_usd,    0) * 1000000)::BIGINT,
     ALTER COLUMN requested_input_cost_usd  SET DEFAULT 0,
     ALTER COLUMN requested_output_cost_usd SET DEFAULT 0,
     ALTER COLUMN actual_input_cost_usd     SET DEFAULT 0,

--- a/db/queries/model_router_request_telemetry.sql
+++ b/db/queries/model_router_request_telemetry.sql
@@ -53,10 +53,10 @@ INSERT INTO router.model_router_request_telemetry (
     @embed_input::varchar,
     @input_tokens::int,
     @output_tokens::int,
-    @requested_input_cost_usd::numeric,
-    @requested_output_cost_usd::numeric,
-    @actual_input_cost_usd::numeric,
-    @actual_output_cost_usd::numeric,
+    @requested_input_cost_usd::bigint,
+    @requested_output_cost_usd::bigint,
+    @actual_input_cost_usd::bigint,
+    @actual_output_cost_usd::bigint,
     @route_latency_ms::bigint,
     @upstream_latency_ms::bigint,
     @total_latency_ms::bigint,
@@ -82,12 +82,12 @@ ON CONFLICT (installation_id, request_id, span_type) DO NOTHING;
 SELECT
     COUNT(*)::bigint                                            AS request_count,
     COALESCE(SUM(input_tokens + output_tokens), 0)::bigint     AS total_tokens,
-    COALESCE(SUM(requested_input_cost_usd + requested_output_cost_usd), 0)::numeric AS total_requested_cost_usd,
-    COALESCE(SUM(actual_input_cost_usd + actual_output_cost_usd), 0)::numeric       AS total_actual_cost_usd,
+    COALESCE(SUM(requested_input_cost_usd + requested_output_cost_usd), 0)::bigint AS total_requested_cost_usd,
+    COALESCE(SUM(actual_input_cost_usd + actual_output_cost_usd), 0)::bigint       AS total_actual_cost_usd,
     COALESCE(SUM(
         (requested_input_cost_usd + requested_output_cost_usd) -
         (actual_input_cost_usd + actual_output_cost_usd)
-    ), 0)::numeric                                             AS total_savings_usd
+    ), 0)::bigint                                             AS total_savings_usd
 FROM router.model_router_request_telemetry
 WHERE span_type = 'router.upstream'
   AND timestamp >= @from_time::timestamptz
@@ -97,8 +97,8 @@ WHERE span_type = 'router.upstream'
 -- name: GetTelemetryTimeseriesHourlyAll :many
 SELECT
     date_trunc('hour', timestamp)::timestamptz                                       AS bucket,
-    COALESCE(SUM(requested_input_cost_usd + requested_output_cost_usd), 0)::numeric AS requested_cost_usd,
-    COALESCE(SUM(actual_input_cost_usd + actual_output_cost_usd), 0)::numeric       AS actual_cost_usd
+    COALESCE(SUM(requested_input_cost_usd + requested_output_cost_usd), 0)::bigint AS requested_cost_usd,
+    COALESCE(SUM(actual_input_cost_usd + actual_output_cost_usd), 0)::bigint       AS actual_cost_usd
 FROM router.model_router_request_telemetry
 WHERE span_type = 'router.upstream'
   AND timestamp >= @from_time::timestamptz
@@ -110,8 +110,8 @@ ORDER BY bucket ASC;
 -- name: GetTelemetryTimeseriesDailyAll :many
 SELECT
     date_trunc('day', timestamp)::timestamptz                                        AS bucket,
-    COALESCE(SUM(requested_input_cost_usd + requested_output_cost_usd), 0)::numeric AS requested_cost_usd,
-    COALESCE(SUM(actual_input_cost_usd + actual_output_cost_usd), 0)::numeric       AS actual_cost_usd
+    COALESCE(SUM(requested_input_cost_usd + requested_output_cost_usd), 0)::bigint AS requested_cost_usd,
+    COALESCE(SUM(actual_input_cost_usd + actual_output_cost_usd), 0)::bigint       AS actual_cost_usd
 FROM router.model_router_request_telemetry
 WHERE span_type = 'router.upstream'
   AND timestamp >= @from_time::timestamptz
@@ -123,8 +123,8 @@ ORDER BY bucket ASC;
 -- name: GetTelemetryTimeseriesWeeklyAll :many
 SELECT
     date_trunc('week', timestamp)::timestamptz                                       AS bucket,
-    COALESCE(SUM(requested_input_cost_usd + requested_output_cost_usd), 0)::numeric AS requested_cost_usd,
-    COALESCE(SUM(actual_input_cost_usd + actual_output_cost_usd), 0)::numeric       AS actual_cost_usd
+    COALESCE(SUM(requested_input_cost_usd + requested_output_cost_usd), 0)::bigint AS requested_cost_usd,
+    COALESCE(SUM(actual_input_cost_usd + actual_output_cost_usd), 0)::bigint       AS actual_cost_usd
 FROM router.model_router_request_telemetry
 WHERE span_type = 'router.upstream'
   AND timestamp >= @from_time::timestamptz
@@ -137,12 +137,12 @@ ORDER BY bucket ASC;
 SELECT
     COUNT(*)::bigint                                            AS request_count,
     COALESCE(SUM(input_tokens + output_tokens), 0)::bigint     AS total_tokens,
-    COALESCE(SUM(requested_input_cost_usd + requested_output_cost_usd), 0)::numeric AS total_requested_cost_usd,
-    COALESCE(SUM(actual_input_cost_usd + actual_output_cost_usd), 0)::numeric       AS total_actual_cost_usd,
+    COALESCE(SUM(requested_input_cost_usd + requested_output_cost_usd), 0)::bigint AS total_requested_cost_usd,
+    COALESCE(SUM(actual_input_cost_usd + actual_output_cost_usd), 0)::bigint       AS total_actual_cost_usd,
     COALESCE(SUM(
         (requested_input_cost_usd + requested_output_cost_usd) -
         (actual_input_cost_usd + actual_output_cost_usd)
-    ), 0)::numeric                                             AS total_savings_usd
+    ), 0)::bigint                                             AS total_savings_usd
 FROM router.model_router_request_telemetry
 WHERE installation_id = @installation_id::uuid
   AND span_type = 'router.upstream'
@@ -153,8 +153,8 @@ WHERE installation_id = @installation_id::uuid
 -- name: GetTelemetryTimeseriesHourly :many
 SELECT
     date_trunc('hour', timestamp)::timestamptz                                       AS bucket,
-    COALESCE(SUM(requested_input_cost_usd + requested_output_cost_usd), 0)::numeric AS requested_cost_usd,
-    COALESCE(SUM(actual_input_cost_usd + actual_output_cost_usd), 0)::numeric       AS actual_cost_usd
+    COALESCE(SUM(requested_input_cost_usd + requested_output_cost_usd), 0)::bigint AS requested_cost_usd,
+    COALESCE(SUM(actual_input_cost_usd + actual_output_cost_usd), 0)::bigint       AS actual_cost_usd
 FROM router.model_router_request_telemetry
 WHERE installation_id = @installation_id::uuid
   AND span_type = 'router.upstream'
@@ -167,8 +167,8 @@ ORDER BY bucket ASC;
 -- name: GetTelemetryTimeseriesDaily :many
 SELECT
     date_trunc('day', timestamp)::timestamptz                                        AS bucket,
-    COALESCE(SUM(requested_input_cost_usd + requested_output_cost_usd), 0)::numeric AS requested_cost_usd,
-    COALESCE(SUM(actual_input_cost_usd + actual_output_cost_usd), 0)::numeric       AS actual_cost_usd
+    COALESCE(SUM(requested_input_cost_usd + requested_output_cost_usd), 0)::bigint AS requested_cost_usd,
+    COALESCE(SUM(actual_input_cost_usd + actual_output_cost_usd), 0)::bigint       AS actual_cost_usd
 FROM router.model_router_request_telemetry
 WHERE installation_id = @installation_id::uuid
   AND span_type = 'router.upstream'
@@ -181,8 +181,8 @@ ORDER BY bucket ASC;
 -- name: GetTelemetryTimeseriesWeekly :many
 SELECT
     date_trunc('week', timestamp)::timestamptz                                       AS bucket,
-    COALESCE(SUM(requested_input_cost_usd + requested_output_cost_usd), 0)::numeric AS requested_cost_usd,
-    COALESCE(SUM(actual_input_cost_usd + actual_output_cost_usd), 0)::numeric       AS actual_cost_usd
+    COALESCE(SUM(requested_input_cost_usd + requested_output_cost_usd), 0)::bigint AS requested_cost_usd,
+    COALESCE(SUM(actual_input_cost_usd + actual_output_cost_usd), 0)::bigint       AS actual_cost_usd
 FROM router.model_router_request_telemetry
 WHERE installation_id = @installation_id::uuid
   AND span_type = 'router.upstream'
@@ -207,8 +207,8 @@ SELECT
     output_tokens,
     cache_creation_tokens,
     cache_read_tokens,
-    (requested_input_cost_usd + requested_output_cost_usd)::numeric AS requested_cost_usd,
-    (actual_input_cost_usd + actual_output_cost_usd)::numeric       AS actual_cost_usd,
+    (requested_input_cost_usd + requested_output_cost_usd)::bigint AS requested_cost_usd,
+    (actual_input_cost_usd + actual_output_cost_usd)::bigint       AS actual_cost_usd,
     total_latency_ms,
     upstream_status_code
 FROM router.model_router_request_telemetry
@@ -232,8 +232,8 @@ SELECT
     output_tokens,
     cache_creation_tokens,
     cache_read_tokens,
-    (requested_input_cost_usd + requested_output_cost_usd)::numeric AS requested_cost_usd,
-    (actual_input_cost_usd + actual_output_cost_usd)::numeric       AS actual_cost_usd,
+    (requested_input_cost_usd + requested_output_cost_usd)::bigint AS requested_cost_usd,
+    (actual_input_cost_usd + actual_output_cost_usd)::bigint       AS actual_cost_usd,
     total_latency_ms,
     upstream_status_code
 FROM router.model_router_request_telemetry

--- a/db/queries/model_router_request_telemetry.sql
+++ b/db/queries/model_router_request_telemetry.sql
@@ -207,8 +207,8 @@ SELECT
     output_tokens,
     cache_creation_tokens,
     cache_read_tokens,
-    (requested_input_cost_usd + requested_output_cost_usd)::bigint AS requested_cost_usd,
-    (actual_input_cost_usd + actual_output_cost_usd)::bigint       AS actual_cost_usd,
+    COALESCE(requested_input_cost_usd + requested_output_cost_usd, 0)::bigint AS requested_cost_usd,
+    COALESCE(actual_input_cost_usd + actual_output_cost_usd, 0)::bigint       AS actual_cost_usd,
     total_latency_ms,
     upstream_status_code
 FROM router.model_router_request_telemetry
@@ -232,8 +232,8 @@ SELECT
     output_tokens,
     cache_creation_tokens,
     cache_read_tokens,
-    (requested_input_cost_usd + requested_output_cost_usd)::bigint AS requested_cost_usd,
-    (actual_input_cost_usd + actual_output_cost_usd)::bigint       AS actual_cost_usd,
+    COALESCE(requested_input_cost_usd + requested_output_cost_usd, 0)::bigint AS requested_cost_usd,
+    COALESCE(actual_input_cost_usd + actual_output_cost_usd, 0)::bigint       AS actual_cost_usd,
     total_latency_ms,
     upstream_status_code
 FROM router.model_router_request_telemetry

--- a/internal/postgres/telemetry.go
+++ b/internal/postgres/telemetry.go
@@ -3,7 +3,6 @@ package postgres
 import (
 	"context"
 	"math"
-	"math/big"
 	"time"
 
 	"workweave/router/internal/proxy"
@@ -12,6 +11,26 @@ import (
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgtype"
 )
+
+// usdPerMicro converts BIGINT micros (USD x 1e6) back to a float64 USD value
+// at the adapter boundary. The router's in-Go cost math is float64 USD;
+// micros is the storage representation only.
+const usdPerMicro = 1.0 / 1_000_000.0
+
+// usdToMicros rounds a float64 USD value to BIGINT micros (USD x 1e6) for
+// persistence. NaN/Inf collapse to 0 — we never want to write nonsense.
+func usdToMicros(f float64) int64 {
+	if math.IsNaN(f) || math.IsInf(f, 0) {
+		return 0
+	}
+	return int64(math.Round(f * 1_000_000))
+}
+
+// microsToUSD is the inverse of usdToMicros, used when projecting stored
+// telemetry rows back into the proxy domain types.
+func microsToUSD(micros int64) float64 {
+	return float64(micros) * usdPerMicro
+}
 
 // TelemetryRepo implements proxy.TelemetryRepository via SQLC.
 type TelemetryRepo struct {
@@ -46,10 +65,10 @@ func (r *TelemetryRepo) InsertRequestTelemetry(ctx context.Context, p proxy.Inse
 		EmbedInput:             p.EmbedInput,
 		InputTokens:            p.InputTokens,
 		OutputTokens:           p.OutputTokens,
-		RequestedInputCostUsd:  toNumeric(p.RequestedInputCostUSD),
-		RequestedOutputCostUsd: toNumeric(p.RequestedOutputCostUSD),
-		ActualInputCostUsd:     toNumeric(p.ActualInputCostUSD),
-		ActualOutputCostUsd:    toNumeric(p.ActualOutputCostUSD),
+		RequestedInputCostUsd:  usdToMicros(p.RequestedInputCostUSD),
+		RequestedOutputCostUsd: usdToMicros(p.RequestedOutputCostUSD),
+		ActualInputCostUsd:     usdToMicros(p.ActualInputCostUSD),
+		ActualOutputCostUsd:    usdToMicros(p.ActualOutputCostUSD),
 		RouteLatencyMs:         p.RouteLatencyMs,
 		UpstreamLatencyMs:      p.UpstreamLatencyMs,
 		TotalLatencyMs:         p.TotalLatencyMs,
@@ -85,9 +104,9 @@ func (r *TelemetryRepo) GetTelemetrySummary(ctx context.Context, installationID 
 	return proxy.TelemetrySummary{
 		RequestCount:          row.RequestCount,
 		TotalTokens:           row.TotalTokens,
-		TotalRequestedCostUSD: numericToFloat(row.TotalRequestedCostUsd),
-		TotalActualCostUSD:    numericToFloat(row.TotalActualCostUsd),
-		TotalSavingsUSD:       numericToFloat(row.TotalSavingsUsd),
+		TotalRequestedCostUSD: microsToUSD(row.TotalRequestedCostUsd),
+		TotalActualCostUSD:    microsToUSD(row.TotalActualCostUsd),
+		TotalSavingsUSD:       microsToUSD(row.TotalSavingsUsd),
 	}, nil
 }
 
@@ -112,8 +131,8 @@ func (r *TelemetryRepo) GetTelemetryTimeseries(ctx context.Context, installation
 		for _, row := range rows {
 			out = append(out, proxy.TelemetryBucket{
 				Bucket:           row.Bucket.Time,
-				RequestedCostUSD: numericToFloat(row.RequestedCostUsd),
-				ActualCostUSD:    numericToFloat(row.ActualCostUsd),
+				RequestedCostUSD: microsToUSD(row.RequestedCostUsd),
+				ActualCostUSD:    microsToUSD(row.ActualCostUsd),
 			})
 		}
 		return out, nil
@@ -130,8 +149,8 @@ func (r *TelemetryRepo) GetTelemetryTimeseries(ctx context.Context, installation
 		for _, row := range rows {
 			out = append(out, proxy.TelemetryBucket{
 				Bucket:           row.Bucket.Time,
-				RequestedCostUSD: numericToFloat(row.RequestedCostUsd),
-				ActualCostUSD:    numericToFloat(row.ActualCostUsd),
+				RequestedCostUSD: microsToUSD(row.RequestedCostUsd),
+				ActualCostUSD:    microsToUSD(row.ActualCostUsd),
 			})
 		}
 		return out, nil
@@ -149,8 +168,8 @@ func (r *TelemetryRepo) GetTelemetryTimeseries(ctx context.Context, installation
 	for _, row := range rows {
 		out = append(out, proxy.TelemetryBucket{
 			Bucket:           row.Bucket.Time,
-			RequestedCostUSD: numericToFloat(row.RequestedCostUsd),
-			ActualCostUSD:    numericToFloat(row.ActualCostUsd),
+			RequestedCostUSD: microsToUSD(row.RequestedCostUsd),
+			ActualCostUSD:    microsToUSD(row.ActualCostUsd),
 		})
 	}
 	return out, nil
@@ -169,9 +188,9 @@ func (r *TelemetryRepo) GetTelemetrySummaryAll(ctx context.Context, from, to tim
 	return proxy.TelemetrySummary{
 		RequestCount:          row.RequestCount,
 		TotalTokens:           row.TotalTokens,
-		TotalRequestedCostUSD: numericToFloat(row.TotalRequestedCostUsd),
-		TotalActualCostUSD:    numericToFloat(row.TotalActualCostUsd),
-		TotalSavingsUSD:       numericToFloat(row.TotalSavingsUsd),
+		TotalRequestedCostUSD: microsToUSD(row.TotalRequestedCostUsd),
+		TotalActualCostUSD:    microsToUSD(row.TotalActualCostUsd),
+		TotalSavingsUSD:       microsToUSD(row.TotalSavingsUsd),
 	}, nil
 }
 
@@ -192,8 +211,8 @@ func (r *TelemetryRepo) GetTelemetryTimeseriesAll(ctx context.Context, from, to 
 		for _, row := range rows {
 			out = append(out, proxy.TelemetryBucket{
 				Bucket:           row.Bucket.Time,
-				RequestedCostUSD: numericToFloat(row.RequestedCostUsd),
-				ActualCostUSD:    numericToFloat(row.ActualCostUsd),
+				RequestedCostUSD: microsToUSD(row.RequestedCostUsd),
+				ActualCostUSD:    microsToUSD(row.ActualCostUsd),
 			})
 		}
 		return out, nil
@@ -209,8 +228,8 @@ func (r *TelemetryRepo) GetTelemetryTimeseriesAll(ctx context.Context, from, to 
 		for _, row := range rows {
 			out = append(out, proxy.TelemetryBucket{
 				Bucket:           row.Bucket.Time,
-				RequestedCostUSD: numericToFloat(row.RequestedCostUsd),
-				ActualCostUSD:    numericToFloat(row.ActualCostUsd),
+				RequestedCostUSD: microsToUSD(row.RequestedCostUsd),
+				ActualCostUSD:    microsToUSD(row.ActualCostUsd),
 			})
 		}
 		return out, nil
@@ -227,8 +246,8 @@ func (r *TelemetryRepo) GetTelemetryTimeseriesAll(ctx context.Context, from, to 
 	for _, row := range rows {
 		out = append(out, proxy.TelemetryBucket{
 			Bucket:           row.Bucket.Time,
-			RequestedCostUSD: numericToFloat(row.RequestedCostUsd),
-			ActualCostUSD:    numericToFloat(row.ActualCostUsd),
+			RequestedCostUSD: microsToUSD(row.RequestedCostUsd),
+			ActualCostUSD:    microsToUSD(row.ActualCostUsd),
 		})
 	}
 	return out, nil
@@ -321,8 +340,8 @@ func telemetryRowFromRow(
 	outputTokens *int32,
 	cacheCreationTokens *int32,
 	cacheReadTokens *int32,
-	requestedCostUsd pgtype.Numeric,
-	actualCostUsd pgtype.Numeric,
+	requestedCostUsdMicros int64,
+	actualCostUsdMicros int64,
 	totalLatencyMs *int64,
 	upstreamStatusCode *int32,
 ) proxy.TelemetryRow {
@@ -357,43 +376,9 @@ func telemetryRowFromRow(
 		OutputTokens:        derefInt32(outputTokens),
 		CacheCreationTokens: cacheCreationTokens,
 		CacheReadTokens:     cacheReadTokens,
-		RequestedCostUSD:    numericToFloat(requestedCostUsd),
-		ActualCostUSD:       numericToFloat(actualCostUsd),
+		RequestedCostUSD:    microsToUSD(requestedCostUsdMicros),
+		ActualCostUSD:       microsToUSD(actualCostUsdMicros),
 		TotalLatencyMs:      derefInt64(totalLatencyMs),
 		UpstreamStatusCode:  derefInt32(upstreamStatusCode),
 	}
-}
-
-// toNumeric converts a float64 cost value to pgtype.Numeric.
-//
-// pgtype.Numeric.Scan only accepts string/[]byte/nil — passing a float64
-// returns an error which silently leaves the value Valid:false, so every
-// cost ended up persisting as NULL (→ DEFAULT 0). Build the Numeric by
-// hand from the float's mantissa/exponent at fixed scale instead.
-func toNumeric(f float64) pgtype.Numeric {
-	if math.IsNaN(f) || math.IsInf(f, 0) {
-		return pgtype.Numeric{Valid: false}
-	}
-	// Cost columns are NUMERIC(16,6). Match that scale: multiply by 1e6,
-	// round to int, store with Exp = -6.
-	const scale = 6
-	scaled := math.Round(f * 1e6)
-	return pgtype.Numeric{
-		Int:   new(big.Int).SetInt64(int64(scaled)),
-		Exp:   -scale,
-		Valid: true,
-	}
-}
-
-// numericToFloat converts a pgtype.Numeric to float64, returning 0 on failure.
-// Uses Float64Value because Scan silently no-ops on a *float64 destination.
-func numericToFloat(n pgtype.Numeric) float64 {
-	if !n.Valid {
-		return 0
-	}
-	f8, err := n.Float64Value()
-	if err != nil || !f8.Valid {
-		return 0
-	}
-	return f8.Float64
 }

--- a/internal/sqlc/model_router_request_telemetry.sql.go
+++ b/internal/sqlc/model_router_request_telemetry.sql.go
@@ -25,8 +25,8 @@ SELECT
     output_tokens,
     cache_creation_tokens,
     cache_read_tokens,
-    (requested_input_cost_usd + requested_output_cost_usd)::bigint AS requested_cost_usd,
-    (actual_input_cost_usd + actual_output_cost_usd)::bigint       AS actual_cost_usd,
+    COALESCE(requested_input_cost_usd + requested_output_cost_usd, 0)::bigint AS requested_cost_usd,
+    COALESCE(actual_input_cost_usd + actual_output_cost_usd, 0)::bigint       AS actual_cost_usd,
     total_latency_ms,
     upstream_status_code
 FROM router.model_router_request_telemetry
@@ -77,8 +77,8 @@ type GetTelemetryRowsRow struct {
 //	    output_tokens,
 //	    cache_creation_tokens,
 //	    cache_read_tokens,
-//	    (requested_input_cost_usd + requested_output_cost_usd)::bigint AS requested_cost_usd,
-//	    (actual_input_cost_usd + actual_output_cost_usd)::bigint       AS actual_cost_usd,
+//	    COALESCE(requested_input_cost_usd + requested_output_cost_usd, 0)::bigint AS requested_cost_usd,
+//	    COALESCE(actual_input_cost_usd + actual_output_cost_usd, 0)::bigint       AS actual_cost_usd,
 //	    total_latency_ms,
 //	    upstream_status_code
 //	FROM router.model_router_request_telemetry
@@ -142,8 +142,8 @@ SELECT
     output_tokens,
     cache_creation_tokens,
     cache_read_tokens,
-    (requested_input_cost_usd + requested_output_cost_usd)::bigint AS requested_cost_usd,
-    (actual_input_cost_usd + actual_output_cost_usd)::bigint       AS actual_cost_usd,
+    COALESCE(requested_input_cost_usd + requested_output_cost_usd, 0)::bigint AS requested_cost_usd,
+    COALESCE(actual_input_cost_usd + actual_output_cost_usd, 0)::bigint       AS actual_cost_usd,
     total_latency_ms,
     upstream_status_code
 FROM router.model_router_request_telemetry
@@ -194,8 +194,8 @@ type GetTelemetryRowsAllRow struct {
 //	    output_tokens,
 //	    cache_creation_tokens,
 //	    cache_read_tokens,
-//	    (requested_input_cost_usd + requested_output_cost_usd)::bigint AS requested_cost_usd,
-//	    (actual_input_cost_usd + actual_output_cost_usd)::bigint       AS actual_cost_usd,
+//	    COALESCE(requested_input_cost_usd + requested_output_cost_usd, 0)::bigint AS requested_cost_usd,
+//	    COALESCE(actual_input_cost_usd + actual_output_cost_usd, 0)::bigint       AS actual_cost_usd,
 //	    total_latency_ms,
 //	    upstream_status_code
 //	FROM router.model_router_request_telemetry

--- a/internal/sqlc/model_router_request_telemetry.sql.go
+++ b/internal/sqlc/model_router_request_telemetry.sql.go
@@ -25,8 +25,8 @@ SELECT
     output_tokens,
     cache_creation_tokens,
     cache_read_tokens,
-    (requested_input_cost_usd + requested_output_cost_usd)::numeric AS requested_cost_usd,
-    (actual_input_cost_usd + actual_output_cost_usd)::numeric       AS actual_cost_usd,
+    (requested_input_cost_usd + requested_output_cost_usd)::bigint AS requested_cost_usd,
+    (actual_input_cost_usd + actual_output_cost_usd)::bigint       AS actual_cost_usd,
     total_latency_ms,
     upstream_status_code
 FROM router.model_router_request_telemetry
@@ -57,8 +57,8 @@ type GetTelemetryRowsRow struct {
 	OutputTokens        *int32
 	CacheCreationTokens *int32
 	CacheReadTokens     *int32
-	RequestedCostUsd    pgtype.Numeric
-	ActualCostUsd       pgtype.Numeric
+	RequestedCostUsd    int64
+	ActualCostUsd       int64
 	TotalLatencyMs      *int64
 	UpstreamStatusCode  *int32
 }
@@ -77,8 +77,8 @@ type GetTelemetryRowsRow struct {
 //	    output_tokens,
 //	    cache_creation_tokens,
 //	    cache_read_tokens,
-//	    (requested_input_cost_usd + requested_output_cost_usd)::numeric AS requested_cost_usd,
-//	    (actual_input_cost_usd + actual_output_cost_usd)::numeric       AS actual_cost_usd,
+//	    (requested_input_cost_usd + requested_output_cost_usd)::bigint AS requested_cost_usd,
+//	    (actual_input_cost_usd + actual_output_cost_usd)::bigint       AS actual_cost_usd,
 //	    total_latency_ms,
 //	    upstream_status_code
 //	FROM router.model_router_request_telemetry
@@ -142,8 +142,8 @@ SELECT
     output_tokens,
     cache_creation_tokens,
     cache_read_tokens,
-    (requested_input_cost_usd + requested_output_cost_usd)::numeric AS requested_cost_usd,
-    (actual_input_cost_usd + actual_output_cost_usd)::numeric       AS actual_cost_usd,
+    (requested_input_cost_usd + requested_output_cost_usd)::bigint AS requested_cost_usd,
+    (actual_input_cost_usd + actual_output_cost_usd)::bigint       AS actual_cost_usd,
     total_latency_ms,
     upstream_status_code
 FROM router.model_router_request_telemetry
@@ -172,8 +172,8 @@ type GetTelemetryRowsAllRow struct {
 	OutputTokens        *int32
 	CacheCreationTokens *int32
 	CacheReadTokens     *int32
-	RequestedCostUsd    pgtype.Numeric
-	ActualCostUsd       pgtype.Numeric
+	RequestedCostUsd    int64
+	ActualCostUsd       int64
 	TotalLatencyMs      *int64
 	UpstreamStatusCode  *int32
 }
@@ -194,8 +194,8 @@ type GetTelemetryRowsAllRow struct {
 //	    output_tokens,
 //	    cache_creation_tokens,
 //	    cache_read_tokens,
-//	    (requested_input_cost_usd + requested_output_cost_usd)::numeric AS requested_cost_usd,
-//	    (actual_input_cost_usd + actual_output_cost_usd)::numeric       AS actual_cost_usd,
+//	    (requested_input_cost_usd + requested_output_cost_usd)::bigint AS requested_cost_usd,
+//	    (actual_input_cost_usd + actual_output_cost_usd)::bigint       AS actual_cost_usd,
 //	    total_latency_ms,
 //	    upstream_status_code
 //	FROM router.model_router_request_telemetry
@@ -244,12 +244,12 @@ const getTelemetrySummary = `-- name: GetTelemetrySummary :one
 SELECT
     COUNT(*)::bigint                                            AS request_count,
     COALESCE(SUM(input_tokens + output_tokens), 0)::bigint     AS total_tokens,
-    COALESCE(SUM(requested_input_cost_usd + requested_output_cost_usd), 0)::numeric AS total_requested_cost_usd,
-    COALESCE(SUM(actual_input_cost_usd + actual_output_cost_usd), 0)::numeric       AS total_actual_cost_usd,
+    COALESCE(SUM(requested_input_cost_usd + requested_output_cost_usd), 0)::bigint AS total_requested_cost_usd,
+    COALESCE(SUM(actual_input_cost_usd + actual_output_cost_usd), 0)::bigint       AS total_actual_cost_usd,
     COALESCE(SUM(
         (requested_input_cost_usd + requested_output_cost_usd) -
         (actual_input_cost_usd + actual_output_cost_usd)
-    ), 0)::numeric                                             AS total_savings_usd
+    ), 0)::bigint                                             AS total_savings_usd
 FROM router.model_router_request_telemetry
 WHERE installation_id = $1::uuid
   AND span_type = 'router.upstream'
@@ -266,9 +266,9 @@ type GetTelemetrySummaryParams struct {
 type GetTelemetrySummaryRow struct {
 	RequestCount          int64
 	TotalTokens           int64
-	TotalRequestedCostUsd pgtype.Numeric
-	TotalActualCostUsd    pgtype.Numeric
-	TotalSavingsUsd       pgtype.Numeric
+	TotalRequestedCostUsd int64
+	TotalActualCostUsd    int64
+	TotalSavingsUsd       int64
 }
 
 // Returns aggregated cost and token totals for the dashboard cards.
@@ -276,12 +276,12 @@ type GetTelemetrySummaryRow struct {
 //	SELECT
 //	    COUNT(*)::bigint                                            AS request_count,
 //	    COALESCE(SUM(input_tokens + output_tokens), 0)::bigint     AS total_tokens,
-//	    COALESCE(SUM(requested_input_cost_usd + requested_output_cost_usd), 0)::numeric AS total_requested_cost_usd,
-//	    COALESCE(SUM(actual_input_cost_usd + actual_output_cost_usd), 0)::numeric       AS total_actual_cost_usd,
+//	    COALESCE(SUM(requested_input_cost_usd + requested_output_cost_usd), 0)::bigint AS total_requested_cost_usd,
+//	    COALESCE(SUM(actual_input_cost_usd + actual_output_cost_usd), 0)::bigint       AS total_actual_cost_usd,
 //	    COALESCE(SUM(
 //	        (requested_input_cost_usd + requested_output_cost_usd) -
 //	        (actual_input_cost_usd + actual_output_cost_usd)
-//	    ), 0)::numeric                                             AS total_savings_usd
+//	    ), 0)::bigint                                             AS total_savings_usd
 //	FROM router.model_router_request_telemetry
 //	WHERE installation_id = $1::uuid
 //	  AND span_type = 'router.upstream'
@@ -304,12 +304,12 @@ const getTelemetrySummaryAll = `-- name: GetTelemetrySummaryAll :one
 SELECT
     COUNT(*)::bigint                                            AS request_count,
     COALESCE(SUM(input_tokens + output_tokens), 0)::bigint     AS total_tokens,
-    COALESCE(SUM(requested_input_cost_usd + requested_output_cost_usd), 0)::numeric AS total_requested_cost_usd,
-    COALESCE(SUM(actual_input_cost_usd + actual_output_cost_usd), 0)::numeric       AS total_actual_cost_usd,
+    COALESCE(SUM(requested_input_cost_usd + requested_output_cost_usd), 0)::bigint AS total_requested_cost_usd,
+    COALESCE(SUM(actual_input_cost_usd + actual_output_cost_usd), 0)::bigint       AS total_actual_cost_usd,
     COALESCE(SUM(
         (requested_input_cost_usd + requested_output_cost_usd) -
         (actual_input_cost_usd + actual_output_cost_usd)
-    ), 0)::numeric                                             AS total_savings_usd
+    ), 0)::bigint                                             AS total_savings_usd
 FROM router.model_router_request_telemetry
 WHERE span_type = 'router.upstream'
   AND timestamp >= $1::timestamptz
@@ -324,9 +324,9 @@ type GetTelemetrySummaryAllParams struct {
 type GetTelemetrySummaryAllRow struct {
 	RequestCount          int64
 	TotalTokens           int64
-	TotalRequestedCostUsd pgtype.Numeric
-	TotalActualCostUsd    pgtype.Numeric
-	TotalSavingsUsd       pgtype.Numeric
+	TotalRequestedCostUsd int64
+	TotalActualCostUsd    int64
+	TotalSavingsUsd       int64
 }
 
 // Returns aggregated cost and token totals across every installation.
@@ -336,12 +336,12 @@ type GetTelemetrySummaryAllRow struct {
 //	SELECT
 //	    COUNT(*)::bigint                                            AS request_count,
 //	    COALESCE(SUM(input_tokens + output_tokens), 0)::bigint     AS total_tokens,
-//	    COALESCE(SUM(requested_input_cost_usd + requested_output_cost_usd), 0)::numeric AS total_requested_cost_usd,
-//	    COALESCE(SUM(actual_input_cost_usd + actual_output_cost_usd), 0)::numeric       AS total_actual_cost_usd,
+//	    COALESCE(SUM(requested_input_cost_usd + requested_output_cost_usd), 0)::bigint AS total_requested_cost_usd,
+//	    COALESCE(SUM(actual_input_cost_usd + actual_output_cost_usd), 0)::bigint       AS total_actual_cost_usd,
 //	    COALESCE(SUM(
 //	        (requested_input_cost_usd + requested_output_cost_usd) -
 //	        (actual_input_cost_usd + actual_output_cost_usd)
-//	    ), 0)::numeric                                             AS total_savings_usd
+//	    ), 0)::bigint                                             AS total_savings_usd
 //	FROM router.model_router_request_telemetry
 //	WHERE span_type = 'router.upstream'
 //	  AND timestamp >= $1::timestamptz
@@ -362,8 +362,8 @@ func (q *Queries) GetTelemetrySummaryAll(ctx context.Context, arg GetTelemetrySu
 const getTelemetryTimeseriesDaily = `-- name: GetTelemetryTimeseriesDaily :many
 SELECT
     date_trunc('day', timestamp)::timestamptz                                        AS bucket,
-    COALESCE(SUM(requested_input_cost_usd + requested_output_cost_usd), 0)::numeric AS requested_cost_usd,
-    COALESCE(SUM(actual_input_cost_usd + actual_output_cost_usd), 0)::numeric       AS actual_cost_usd
+    COALESCE(SUM(requested_input_cost_usd + requested_output_cost_usd), 0)::bigint AS requested_cost_usd,
+    COALESCE(SUM(actual_input_cost_usd + actual_output_cost_usd), 0)::bigint       AS actual_cost_usd
 FROM router.model_router_request_telemetry
 WHERE installation_id = $1::uuid
   AND span_type = 'router.upstream'
@@ -381,16 +381,16 @@ type GetTelemetryTimeseriesDailyParams struct {
 
 type GetTelemetryTimeseriesDailyRow struct {
 	Bucket           pgtype.Timestamptz
-	RequestedCostUsd pgtype.Numeric
-	ActualCostUsd    pgtype.Numeric
+	RequestedCostUsd int64
+	ActualCostUsd    int64
 }
 
 // Returns per-day cost buckets for the cost savings chart.
 //
 //	SELECT
 //	    date_trunc('day', timestamp)::timestamptz                                        AS bucket,
-//	    COALESCE(SUM(requested_input_cost_usd + requested_output_cost_usd), 0)::numeric AS requested_cost_usd,
-//	    COALESCE(SUM(actual_input_cost_usd + actual_output_cost_usd), 0)::numeric       AS actual_cost_usd
+//	    COALESCE(SUM(requested_input_cost_usd + requested_output_cost_usd), 0)::bigint AS requested_cost_usd,
+//	    COALESCE(SUM(actual_input_cost_usd + actual_output_cost_usd), 0)::bigint       AS actual_cost_usd
 //	FROM router.model_router_request_telemetry
 //	WHERE installation_id = $1::uuid
 //	  AND span_type = 'router.upstream'
@@ -421,8 +421,8 @@ func (q *Queries) GetTelemetryTimeseriesDaily(ctx context.Context, arg GetTeleme
 const getTelemetryTimeseriesDailyAll = `-- name: GetTelemetryTimeseriesDailyAll :many
 SELECT
     date_trunc('day', timestamp)::timestamptz                                        AS bucket,
-    COALESCE(SUM(requested_input_cost_usd + requested_output_cost_usd), 0)::numeric AS requested_cost_usd,
-    COALESCE(SUM(actual_input_cost_usd + actual_output_cost_usd), 0)::numeric       AS actual_cost_usd
+    COALESCE(SUM(requested_input_cost_usd + requested_output_cost_usd), 0)::bigint AS requested_cost_usd,
+    COALESCE(SUM(actual_input_cost_usd + actual_output_cost_usd), 0)::bigint       AS actual_cost_usd
 FROM router.model_router_request_telemetry
 WHERE span_type = 'router.upstream'
   AND timestamp >= $1::timestamptz
@@ -438,16 +438,16 @@ type GetTelemetryTimeseriesDailyAllParams struct {
 
 type GetTelemetryTimeseriesDailyAllRow struct {
 	Bucket           pgtype.Timestamptz
-	RequestedCostUsd pgtype.Numeric
-	ActualCostUsd    pgtype.Numeric
+	RequestedCostUsd int64
+	ActualCostUsd    int64
 }
 
 // Per-day cost buckets across every installation. Admin-only.
 //
 //	SELECT
 //	    date_trunc('day', timestamp)::timestamptz                                        AS bucket,
-//	    COALESCE(SUM(requested_input_cost_usd + requested_output_cost_usd), 0)::numeric AS requested_cost_usd,
-//	    COALESCE(SUM(actual_input_cost_usd + actual_output_cost_usd), 0)::numeric       AS actual_cost_usd
+//	    COALESCE(SUM(requested_input_cost_usd + requested_output_cost_usd), 0)::bigint AS requested_cost_usd,
+//	    COALESCE(SUM(actual_input_cost_usd + actual_output_cost_usd), 0)::bigint       AS actual_cost_usd
 //	FROM router.model_router_request_telemetry
 //	WHERE span_type = 'router.upstream'
 //	  AND timestamp >= $1::timestamptz
@@ -477,8 +477,8 @@ func (q *Queries) GetTelemetryTimeseriesDailyAll(ctx context.Context, arg GetTel
 const getTelemetryTimeseriesHourly = `-- name: GetTelemetryTimeseriesHourly :many
 SELECT
     date_trunc('hour', timestamp)::timestamptz                                       AS bucket,
-    COALESCE(SUM(requested_input_cost_usd + requested_output_cost_usd), 0)::numeric AS requested_cost_usd,
-    COALESCE(SUM(actual_input_cost_usd + actual_output_cost_usd), 0)::numeric       AS actual_cost_usd
+    COALESCE(SUM(requested_input_cost_usd + requested_output_cost_usd), 0)::bigint AS requested_cost_usd,
+    COALESCE(SUM(actual_input_cost_usd + actual_output_cost_usd), 0)::bigint       AS actual_cost_usd
 FROM router.model_router_request_telemetry
 WHERE installation_id = $1::uuid
   AND span_type = 'router.upstream'
@@ -496,16 +496,16 @@ type GetTelemetryTimeseriesHourlyParams struct {
 
 type GetTelemetryTimeseriesHourlyRow struct {
 	Bucket           pgtype.Timestamptz
-	RequestedCostUsd pgtype.Numeric
-	ActualCostUsd    pgtype.Numeric
+	RequestedCostUsd int64
+	ActualCostUsd    int64
 }
 
 // Returns per-hour cost buckets for the cost savings chart.
 //
 //	SELECT
 //	    date_trunc('hour', timestamp)::timestamptz                                       AS bucket,
-//	    COALESCE(SUM(requested_input_cost_usd + requested_output_cost_usd), 0)::numeric AS requested_cost_usd,
-//	    COALESCE(SUM(actual_input_cost_usd + actual_output_cost_usd), 0)::numeric       AS actual_cost_usd
+//	    COALESCE(SUM(requested_input_cost_usd + requested_output_cost_usd), 0)::bigint AS requested_cost_usd,
+//	    COALESCE(SUM(actual_input_cost_usd + actual_output_cost_usd), 0)::bigint       AS actual_cost_usd
 //	FROM router.model_router_request_telemetry
 //	WHERE installation_id = $1::uuid
 //	  AND span_type = 'router.upstream'
@@ -536,8 +536,8 @@ func (q *Queries) GetTelemetryTimeseriesHourly(ctx context.Context, arg GetTelem
 const getTelemetryTimeseriesHourlyAll = `-- name: GetTelemetryTimeseriesHourlyAll :many
 SELECT
     date_trunc('hour', timestamp)::timestamptz                                       AS bucket,
-    COALESCE(SUM(requested_input_cost_usd + requested_output_cost_usd), 0)::numeric AS requested_cost_usd,
-    COALESCE(SUM(actual_input_cost_usd + actual_output_cost_usd), 0)::numeric       AS actual_cost_usd
+    COALESCE(SUM(requested_input_cost_usd + requested_output_cost_usd), 0)::bigint AS requested_cost_usd,
+    COALESCE(SUM(actual_input_cost_usd + actual_output_cost_usd), 0)::bigint       AS actual_cost_usd
 FROM router.model_router_request_telemetry
 WHERE span_type = 'router.upstream'
   AND timestamp >= $1::timestamptz
@@ -553,16 +553,16 @@ type GetTelemetryTimeseriesHourlyAllParams struct {
 
 type GetTelemetryTimeseriesHourlyAllRow struct {
 	Bucket           pgtype.Timestamptz
-	RequestedCostUsd pgtype.Numeric
-	ActualCostUsd    pgtype.Numeric
+	RequestedCostUsd int64
+	ActualCostUsd    int64
 }
 
 // Per-hour cost buckets across every installation. Admin-only.
 //
 //	SELECT
 //	    date_trunc('hour', timestamp)::timestamptz                                       AS bucket,
-//	    COALESCE(SUM(requested_input_cost_usd + requested_output_cost_usd), 0)::numeric AS requested_cost_usd,
-//	    COALESCE(SUM(actual_input_cost_usd + actual_output_cost_usd), 0)::numeric       AS actual_cost_usd
+//	    COALESCE(SUM(requested_input_cost_usd + requested_output_cost_usd), 0)::bigint AS requested_cost_usd,
+//	    COALESCE(SUM(actual_input_cost_usd + actual_output_cost_usd), 0)::bigint       AS actual_cost_usd
 //	FROM router.model_router_request_telemetry
 //	WHERE span_type = 'router.upstream'
 //	  AND timestamp >= $1::timestamptz
@@ -592,8 +592,8 @@ func (q *Queries) GetTelemetryTimeseriesHourlyAll(ctx context.Context, arg GetTe
 const getTelemetryTimeseriesWeekly = `-- name: GetTelemetryTimeseriesWeekly :many
 SELECT
     date_trunc('week', timestamp)::timestamptz                                       AS bucket,
-    COALESCE(SUM(requested_input_cost_usd + requested_output_cost_usd), 0)::numeric AS requested_cost_usd,
-    COALESCE(SUM(actual_input_cost_usd + actual_output_cost_usd), 0)::numeric       AS actual_cost_usd
+    COALESCE(SUM(requested_input_cost_usd + requested_output_cost_usd), 0)::bigint AS requested_cost_usd,
+    COALESCE(SUM(actual_input_cost_usd + actual_output_cost_usd), 0)::bigint       AS actual_cost_usd
 FROM router.model_router_request_telemetry
 WHERE installation_id = $1::uuid
   AND span_type = 'router.upstream'
@@ -611,16 +611,16 @@ type GetTelemetryTimeseriesWeeklyParams struct {
 
 type GetTelemetryTimeseriesWeeklyRow struct {
 	Bucket           pgtype.Timestamptz
-	RequestedCostUsd pgtype.Numeric
-	ActualCostUsd    pgtype.Numeric
+	RequestedCostUsd int64
+	ActualCostUsd    int64
 }
 
 // Returns per-ISO-week cost buckets for the cost savings chart.
 //
 //	SELECT
 //	    date_trunc('week', timestamp)::timestamptz                                       AS bucket,
-//	    COALESCE(SUM(requested_input_cost_usd + requested_output_cost_usd), 0)::numeric AS requested_cost_usd,
-//	    COALESCE(SUM(actual_input_cost_usd + actual_output_cost_usd), 0)::numeric       AS actual_cost_usd
+//	    COALESCE(SUM(requested_input_cost_usd + requested_output_cost_usd), 0)::bigint AS requested_cost_usd,
+//	    COALESCE(SUM(actual_input_cost_usd + actual_output_cost_usd), 0)::bigint       AS actual_cost_usd
 //	FROM router.model_router_request_telemetry
 //	WHERE installation_id = $1::uuid
 //	  AND span_type = 'router.upstream'
@@ -651,8 +651,8 @@ func (q *Queries) GetTelemetryTimeseriesWeekly(ctx context.Context, arg GetTelem
 const getTelemetryTimeseriesWeeklyAll = `-- name: GetTelemetryTimeseriesWeeklyAll :many
 SELECT
     date_trunc('week', timestamp)::timestamptz                                       AS bucket,
-    COALESCE(SUM(requested_input_cost_usd + requested_output_cost_usd), 0)::numeric AS requested_cost_usd,
-    COALESCE(SUM(actual_input_cost_usd + actual_output_cost_usd), 0)::numeric       AS actual_cost_usd
+    COALESCE(SUM(requested_input_cost_usd + requested_output_cost_usd), 0)::bigint AS requested_cost_usd,
+    COALESCE(SUM(actual_input_cost_usd + actual_output_cost_usd), 0)::bigint       AS actual_cost_usd
 FROM router.model_router_request_telemetry
 WHERE span_type = 'router.upstream'
   AND timestamp >= $1::timestamptz
@@ -668,16 +668,16 @@ type GetTelemetryTimeseriesWeeklyAllParams struct {
 
 type GetTelemetryTimeseriesWeeklyAllRow struct {
 	Bucket           pgtype.Timestamptz
-	RequestedCostUsd pgtype.Numeric
-	ActualCostUsd    pgtype.Numeric
+	RequestedCostUsd int64
+	ActualCostUsd    int64
 }
 
 // Per-ISO-week cost buckets across every installation. Admin-only.
 //
 //	SELECT
 //	    date_trunc('week', timestamp)::timestamptz                                       AS bucket,
-//	    COALESCE(SUM(requested_input_cost_usd + requested_output_cost_usd), 0)::numeric AS requested_cost_usd,
-//	    COALESCE(SUM(actual_input_cost_usd + actual_output_cost_usd), 0)::numeric       AS actual_cost_usd
+//	    COALESCE(SUM(requested_input_cost_usd + requested_output_cost_usd), 0)::bigint AS requested_cost_usd,
+//	    COALESCE(SUM(actual_input_cost_usd + actual_output_cost_usd), 0)::bigint       AS actual_cost_usd
 //	FROM router.model_router_request_telemetry
 //	WHERE span_type = 'router.upstream'
 //	  AND timestamp >= $1::timestamptz
@@ -754,10 +754,10 @@ INSERT INTO router.model_router_request_telemetry (
     $12::varchar,
     $13::int,
     $14::int,
-    $15::numeric,
-    $16::numeric,
-    $17::numeric,
-    $18::numeric,
+    $15::bigint,
+    $16::bigint,
+    $17::bigint,
+    $18::bigint,
     $19::bigint,
     $20::bigint,
     $21::bigint,
@@ -792,10 +792,10 @@ type InsertRequestTelemetryParams struct {
 	EmbedInput             string
 	InputTokens            int32
 	OutputTokens           int32
-	RequestedInputCostUsd  pgtype.Numeric
-	RequestedOutputCostUsd pgtype.Numeric
-	ActualInputCostUsd     pgtype.Numeric
-	ActualOutputCostUsd    pgtype.Numeric
+	RequestedInputCostUsd  int64
+	RequestedOutputCostUsd int64
+	ActualInputCostUsd     int64
+	ActualOutputCostUsd    int64
 	RouteLatencyMs         int64
 	UpstreamLatencyMs      int64
 	TotalLatencyMs         int64
@@ -868,10 +868,10 @@ type InsertRequestTelemetryParams struct {
 //	    $12::varchar,
 //	    $13::int,
 //	    $14::int,
-//	    $15::numeric,
-//	    $16::numeric,
-//	    $17::numeric,
-//	    $18::numeric,
+//	    $15::bigint,
+//	    $16::bigint,
+//	    $17::bigint,
+//	    $18::bigint,
 //	    $19::bigint,
 //	    $20::bigint,
 //	    $21::bigint,

--- a/internal/sqlc/models.go
+++ b/internal/sqlc/models.go
@@ -74,10 +74,10 @@ type RouterModelRouterRequestTelemetry struct {
 	EmbedInput             *string
 	InputTokens            *int32
 	OutputTokens           *int32
-	RequestedInputCostUsd  pgtype.Numeric
-	RequestedOutputCostUsd pgtype.Numeric
-	ActualInputCostUsd     pgtype.Numeric
-	ActualOutputCostUsd    pgtype.Numeric
+	RequestedInputCostUsd  *int64
+	RequestedOutputCostUsd *int64
+	ActualInputCostUsd     *int64
+	ActualOutputCostUsd    *int64
 	RouteLatencyMs         *int64
 	UpstreamLatencyMs      *int64
 	TotalLatencyMs         *int64


### PR DESCRIPTION
## Summary

Prep PR for the Router Credits MVP. Converts the four cost columns on `router.model_router_request_telemetry` from `NUMERIC(16,6)` USD to `BIGINT` micros (USD x 1e6):

- `requested_input_cost_usd`
- `requested_output_cost_usd`
- `actual_input_cost_usd`
- `actual_output_cost_usd`

Integer math avoids the rounding-edge surprises `pgtype.Numeric` introduced at the Go/Postgres boundary (`toNumeric` had to be hand-built from mantissa/exponent because `pgtype.Numeric.Scan` silently dropped float64 inputs), and aligns this table's representation with the credit ledger introduced in the billing MVP, which also stores money as `BIGINT` micros.

## Scope

- `db/migrations/0005_telemetry-costs-to-micros.{up,down}.sql` — `ALTER COLUMN ... TYPE BIGINT USING ROUND(x * 1000000)::BIGINT` and the precise reverse. Default 0 preserved.
- `db/queries/model_router_request_telemetry.sql` — INSERT param casts and SUM aggregate casts switched from `::numeric` to `::bigint`.
- `internal/postgres/telemetry.go` — replaced `toNumeric` / `numericToFloat` / `math/big` plumbing with two-line `usdToMicros` / `microsToUSD` helpers. Conversion happens at the adapter boundary so the proxy domain types (`InsertTelemetryParams`, `TelemetrySummary`, `TelemetryBucket`, `TelemetryRow`) stay `float64 USD`. OTel span attrs (`cost.requested_input_usd`, etc.) and admin JSON wire format (consumed by the dashboard) are unchanged.
- Regenerated `internal/sqlc/model_router_request_telemetry.sql.go` and `internal/sqlc/models.go` — cost fields now `int64` / `*int64` instead of `pgtype.Numeric`.

## Test plan

- [x] `go build ./...`
- [x] `go test ./...` — all packages green
- [ ] Apply migration locally against the docker stack and confirm a row with non-zero cost columns round-trips USD → micros → USD without loss
- [ ] Apply migration against staging and confirm dashboard queries continue to return the same USD totals (modulo sub-microcent rounding)

## Follow-up

PR #2 (the MVP) lands once this is verified in staging. It adds the credit ledger / balance / override tables in the same schema with the same `BIGINT` micros representation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)