### PR TITLE
fix(install): drop /ui suffix from rejected-key dashboard URL

### DIFF
--- a/install/install.sh
+++ b/install/install.sh
@@ -928,7 +928,7 @@ if [ -n "$api_key" ]; then
       | curl -fsS --max-time 5 --header @- "$base_url/validate"
   }
   if ! spin "Validating API key" validate_key; then
-    warn "Router rejected the API key (check it matches the dashboard at $base_url/ui/)."
+    warn "Router rejected the API key (check it matches the dashboard at $base_url)."
   fi
 fi
 


### PR DESCRIPTION
## Summary
- The warning shown when `npx @workweave/router` rejects an API key told users to visit `$base_url/ui/` — but `/ui` only exists on self-hosted instances; managed `router.workweave.ai` serves the dashboard at the root path
- Dropped the `/ui/` suffix so the URL is just `$base_url`

## Test plan
- [ ] Run `npx @workweave/router` with an invalid key and confirm the warning shows `router.workweave.ai` (not `router.workweave.ai/ui/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)