### PR TITLE
feat(installer): inject X-Weave-User-Email so router attributes traffic on shared keys

### DIFF
--- a/install/install.sh
+++ b/install/install.sh
@@ -235,6 +235,87 @@ refuse_if_symlink() {
 WEAVE_CODEX_BEGIN_MARKER="# >>> weave-router managed (do not edit between markers) >>>"
 WEAVE_CODEX_END_MARKER="# <<< weave-router managed <<<"
 
+# normalize_email mirrors the router's proxy.NormalizeEmail: trim, lowercase,
+# enforce a single '@' with non-empty local + domain parts, and cap at 254
+# chars (RFC 5321). Returns the cleaned address on stdout, or empty string if
+# the input is missing or malformed. We validate locally so the installer
+# never plants a header value the router would silently drop, and so a
+# typo'd git config doesn't end up as a per-request identity claim.
+normalize_email() {
+  local raw="${1:-}"
+  # Trim whitespace then lowercase. tr is POSIX; the [:upper:]/[:lower:] form
+  # works on both macOS (BSD) and Linux (GNU) without needing LANG tweaks.
+  local trimmed="${raw#"${raw%%[![:space:]]*}"}"
+  trimmed="${trimmed%"${trimmed##*[![:space:]]}"}"
+  local lowered
+  lowered="$(printf '%s' "$trimmed" | tr '[:upper:]' '[:lower:]')"
+  if [ -z "$lowered" ] || [ "${#lowered}" -gt 254 ]; then
+    printf ''
+    return
+  fi
+  case "$lowered" in
+    *@*@*) printf ''; return ;;
+    @*|*@) printf ''; return ;;
+    *@*)   printf '%s' "$lowered" ;;
+    *)     printf '' ;;
+  esac
+}
+
+# resolve_user_email picks the email to plant in router request headers so the
+# router can attribute traffic to a person even on shared API keys. Priority:
+# WEAVE_USER_EMAIL env override → git config user.email → interactive prompt
+# (pre-filled with whatever we found). In --non-interactive mode we never
+# prompt, so unset/invalid means we ship no header (router treats that as
+# account_uuid-only, same as today). Echoes the validated email on stdout.
+resolve_user_email() {
+  local candidate=""
+  if [ -n "${WEAVE_USER_EMAIL:-}" ]; then
+    candidate="$(normalize_email "$WEAVE_USER_EMAIL")"
+    if [ -z "$candidate" ]; then
+      warn "WEAVE_USER_EMAIL=\"$WEAVE_USER_EMAIL\" is not a valid email; ignoring."
+    fi
+  fi
+  if [ -z "$candidate" ]; then
+    local git_email
+    git_email="$(git config --global user.email 2>/dev/null || true)"
+    candidate="$(normalize_email "$git_email")"
+  fi
+  if [ "$non_interactive" = "true" ] || [ ! -r /dev/tty ]; then
+    printf '%s' "$candidate"
+    return
+  fi
+  # Interactive: confirm/edit. Empty input keeps the suggested default; a
+  # literal `-` lets the user opt out (ship no header). This stays out of
+  # --quiet runs because --quiet implies the caller doesn't want prompts;
+  # they can still use WEAVE_USER_EMAIL to provide one explicitly.
+  if [ "$quiet" = "true" ]; then
+    printf '%s' "$candidate"
+    return
+  fi
+  local prompt_default="$candidate"
+  local response=""
+  if [ -n "$prompt_default" ]; then
+    printf "%sIdentify router traffic as %s[%s]%s (Enter to accept, '-' to skip): " \
+      "$C_DIM" "$C_BOLD" "$prompt_default" "$C_RESET" >/dev/tty
+  else
+    printf "%sEmail to identify your router traffic (blank to skip): %s" \
+      "$C_DIM" "$C_RESET" >/dev/tty
+  fi
+  read -r response </dev/tty || response=""
+  case "$response" in
+    "")   printf '%s' "$prompt_default" ;;
+    "-")  printf '' ;;
+    *)
+      local cleaned
+      cleaned="$(normalize_email "$response")"
+      if [ -z "$cleaned" ]; then
+        warn "\"$response\" is not a valid email; skipping identity header."
+      fi
+      printf '%s' "$cleaned"
+      ;;
+  esac
+}
+
 # write_codex_config writes a managed [model_providers.weave] block to the
 # Codex CLI's config.toml. Sets `model_provider = "weave"` at the top level so
 # Codex picks the routed provider by default. Both lines live inside the
@@ -244,11 +325,22 @@ WEAVE_CODEX_END_MARKER="# <<< weave-router managed <<<"
 # that). Inline `model_provider` keys inside `[profiles.*]` sections stay
 # untouched.
 #
-# Usage: write_codex_config <config_file_path> <base_url> <api_key>
+# Usage: write_codex_config <config_file_path> <base_url> <api_key> [user_email]
 write_codex_config() {
   local config_file="$1"
   local block_url="$2"
   local block_key="$3"
+  local block_email="${4:-}"
+
+  # When we have an identity email, plant it alongside the router key so the
+  # router can attribute Codex traffic to a person on shared keys. Empty
+  # email = omit the entry entirely; we never emit a header with no value.
+  local headers_line
+  if [ -n "$block_email" ]; then
+    headers_line="http_headers = { \"X-Weave-Router-Key\" = \"${block_key}\", \"X-Weave-User-Email\" = \"${block_email}\" }"
+  else
+    headers_line="http_headers = { \"X-Weave-Router-Key\" = \"${block_key}\" }"
+  fi
 
   local block
   block="$(cat <<TOML
@@ -262,7 +354,7 @@ model_provider = "weave"
 name = "Weave Router"
 base_url = "${block_url}/v1"
 wire_api = "responses"
-http_headers = { "X-Weave-Router-Key" = "${block_key}" }
+${headers_line}
 ${WEAVE_CODEX_END_MARKER}
 TOML
 )"
@@ -641,10 +733,27 @@ if [ -n "${WEAVE_ROUTER_KEY:-}" ]; then
     [ -n "$api_key" ] || { err "no key provided"; exit 1; }
   fi
 
+# ---------- identity (user email) ----------
+#
+# The router parses X-Weave-User-Email on every protocol (Anthropic,
+# OpenAI/Codex, Gemini) and persists it onto router.model_router_users.email
+# so customers can attribute traffic to a person even when many people share
+# one API key. We plant the header at install time because Claude Code's
+# metadata.user_id payload carries only account_uuid (no email), and Codex
+# carries no identity at all — without this step the router only ever sees
+# anonymous UUIDs for non-OTLP customers.
+
+user_email="$(resolve_user_email)"
+if [ -n "$user_email" ]; then
+  ok "Will identify router traffic as $user_email"
+else
+  info "No identity email set — router traffic will be attributed by account UUID only."
+fi
+
 # ---------- codex install path (dispatch + exit before the Claude-only writes) ----------
 
 if [ "$target" = "codex" ]; then
-  write_codex_config "$codex_config_file" "$base_url" "$api_key"
+  write_codex_config "$codex_config_file" "$base_url" "$api_key" "$user_email"
   ok "Codex config written to $codex_config_file"
 
   # Project scope: ensure the per-teammate config (which holds the router key)
@@ -1081,13 +1190,23 @@ tmp_patch="$(mktemp)"
 # leave the cursor hidden if Ctrl-C lands during settings.json patching.
 trap '_spin_cleanup; rm -f "$tmp_patch"' EXIT INT TERM HUP
 
+# Claude Code splits ANTHROPIC_CUSTOM_HEADERS on newlines, so multiple
+# headers ride in the same env var separated by \n. We append the identity
+# header alongside the router key so a single var carries both. When no
+# email is set, we keep the single-header form so a re-install for a user
+# who opted out cleanly removes the old line.
+custom_headers="$router_key_header: $api_key"
+if [ -n "$user_email" ]; then
+  custom_headers="$custom_headers"$'\n'"X-Weave-User-Email: $user_email"
+fi
+
 if [ "$scope" = "project" ] && [ -z "$install_dir" ]; then
   jq -n --arg url "$base_url" --arg sl "$statusline_path_for_settings" '{
     env: { ANTHROPIC_BASE_URL: $url },
     statusLine: { type: "command", command: $sl }
   }' >"$tmp_patch"
 else
-  jq -n --arg url "$base_url" --arg header "$router_key_header: $api_key" --arg sl "$statusline_path_for_settings" '{
+  jq -n --arg url "$base_url" --arg header "$custom_headers" --arg sl "$statusline_path_for_settings" '{
     env: { ANTHROPIC_BASE_URL: $url, ANTHROPIC_CUSTOM_HEADERS: $header },
     statusLine: { type: "command", command: $sl }
   }' >"$tmp_patch"
@@ -1113,7 +1232,7 @@ fi
 ok "Settings written to $settings_file"
 
 if [ "$scope" = "project" ] && [ -z "$install_dir" ]; then
-  jq -n --arg header "$router_key_header: $api_key" '{
+  jq -n --arg header "$custom_headers" '{
     env: { ANTHROPIC_CUSTOM_HEADERS: $header }
   }' >"$tmp_patch"
   if [ -f "$local_settings_file" ]; then


### PR DESCRIPTION
## Why

The router parses `X-Weave-User-Email` on every protocol (Anthropic, OpenAI/Codex, Gemini) and persists it onto `router.model_router_users.email` — but **no client ever sends it**. Claude Code's `metadata.user_id` payload carries only `account_uuid` (no email), and Codex carries no identity at all. Customers without OTLP telemetry therefore see only anonymous account-UUIDs in router data, making per-person attribution on shared API keys impossible.

The fix is to plant the header at install time, since the installer is the one place we know who the operator is.

## What

- `install/install.sh` resolves the operator email once (priority: `WEAVE_USER_EMAIL` env var → `git config --global user.email` → interactive confirm/edit with `-` to skip). Non-interactive / `--quiet` runs use the candidate silently; if nothing is found we ship no header (router falls back to today's account-UUID-only behavior).
- Validation mirrors the router's `proxy.NormalizeEmail` (single `@`, non-empty parts, ≤254 chars, lowercased) so the installer never plants a value the router would silently drop.
- Claude Code: the header is appended to `ANTHROPIC_CUSTOM_HEADERS` as a second line (Claude Code splits on `\n`), in both the shared-settings and `settings.local.json` jq patches.
- Codex: `write_codex_config` now emits `"X-Weave-User-Email" = "..."` inside the managed `[model_providers.weave].http_headers` block.

## Test plan

- [ ] Fresh install on a machine with `git config --global user.email` set → interactive run shows the suggested email; confirming writes both router-key and user-email headers.
- [ ] `WEAVE_USER_EMAIL=a@b.com … --non-interactive` overrides the git value silently.
- [ ] `WEAVE_USER_EMAIL=not-an-email` falls back to git / prompt and emits a warning.
- [ ] `--codex` path writes both `X-Weave-Router-Key` and `X-Weave-User-Email` inside the managed TOML block; uninstall removes the whole block cleanly.
- [ ] Re-install for a user who answers `-` (skip) removes the prior email header from `ANTHROPIC_CUSTOM_HEADERS` / TOML.
- [ ] Send a request through the router with the installed config; verify `model_router_users.email` is populated.

Stacked on #159.