### PR TITLE
fix(deps): bump next to 15.3.9 for additional security advisories

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -18,7 +18,7 @@
         "date-fns": "^4.1.0",
         "date-fns-tz": "^3.2.0",
         "lucide-react": "^0.408.0",
-        "next": "15.3.6",
+        "next": "15.3.9",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "recharts": "^3.7.0",
@@ -737,9 +737,9 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "15.3.6",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-15.3.6.tgz",
-      "integrity": "sha512-/cK+QPcfRbDZxmI/uckT4lu9pHCfRIPBLqy88MhE+7Vg5hKrEYc333Ae76dn/cw2FBP2bR/GoK/4DU+U7by/Nw==",
+      "version": "15.3.9",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-15.3.9.tgz",
+      "integrity": "sha512-I7wMCjlHc85EvAebNYJCRBZ+shdrGhcIXBviWmDzGYXwTQ+WrYpfg1LBOnTK1Bn3b+ud5apesNObXKEGqi/C3g==",
       "license": "MIT"
     },
     "node_modules/@next/eslint-plugin-next": {
@@ -5316,13 +5316,12 @@
       "license": "MIT"
     },
     "node_modules/next": {
-      "version": "15.3.6",
-      "resolved": "https://registry.npmjs.org/next/-/next-15.3.6.tgz",
-      "integrity": "sha512-oI6D1zbbsh6JzzZFDCSHnnx6Qpvd1fSkVJu/5d8uluqnxzuoqtodVZjYvNovooznUq8udSAiKp7MbwlfZ8Gm6w==",
-      "deprecated": "This version has a security vulnerability. Please upgrade to a patched version. See https://nextjs.org/blog/security-update-2025-12-11 for more details.",
+      "version": "15.3.9",
+      "resolved": "https://registry.npmjs.org/next/-/next-15.3.9.tgz",
+      "integrity": "sha512-bat50ogkh2esjfkbqmVocL5QunR9RGCSO2oQKFjKeDcEylIgw3JY6CMfGnzoVfXJ9SDLHI546sHmsk90D2ivwQ==",
       "license": "MIT",
       "dependencies": {
-        "@next/env": "15.3.6",
+        "@next/env": "15.3.9",
         "@swc/counter": "0.1.3",
         "@swc/helpers": "0.5.15",
         "busboy": "1.6.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -19,7 +19,7 @@
     "date-fns": "^4.1.0",
     "date-fns-tz": "^3.2.0",
     "lucide-react": "^0.408.0",
-    "next": "15.3.6",
+    "next": "15.3.9",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "recharts": "^3.7.0",


### PR DESCRIPTION
## Summary

Follow-up to #173. The lockfile flagged `next@15.3.6` as deprecated due to additional advisories disclosed 2025-12-11:

- **CVE-2025-55184** ([GHSA-q4gf-8mx6-v5v3](https://github.com/advisories/GHSA-q4gf-8mx6-v5v3)) — high-severity DoS with Server Components
- **CVE-2025-55183** ([GHSA-w37m-7fhw-fmv9](https://github.com/advisories/GHSA-w37m-7fhw-fmv9)) — moderate-severity Server Actions source code exposure

Patched in 15.3.8+. Bumping to the latest 15.3.x patch (15.3.9).

## Test plan

- [x] `npm install` resolves cleanly
- [x] `npm run build` (Next.js production build) succeeds
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)