### PR TITLE
refactor(billing): hardcode MinBalanceMicros, drop env var

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -54,11 +54,6 @@ PORT=8080
 # falls back to BYOK-only behavior (safe rollback path).
 ROUTER_DEPLOYMENT_MODE=selfhosted
 
-# Minimum balance (USD micros = USD * 1e6) below which the router 402s an
-# inference request. Default $1.00 = 1_000_000 micros. Read only when
-# credit billing is active (managed mode + billing tables present).
-# ROUTER_BILLING_MIN_BALANCE_MICROS=1000000
-
 # Admin dashboard password. Defaults to "admin" when unset (logs a warning) —
 # DEV ONLY behavior. REQUIRED in any deployment exposed beyond localhost.
 # ROUTER_ADMIN_PASSWORD=change-me

--- a/cmd/router/main.go
+++ b/cmd/router/main.go
@@ -138,7 +138,6 @@ func main() {
 	// router to disable billing without code changes. Self-hosted
 	// deployments never wire billing.
 	var billingSvc *billing.Service
-	var billingMinBalanceMicros int64
 	if deploymentMode == server.DeploymentModeManaged {
 		billingRepo := postgres.NewBillingRepo(pool)
 		bootCtx, bootCancel := context.WithTimeout(context.Background(), 5*time.Second)
@@ -151,8 +150,7 @@ func main() {
 			logger.Warn("Billing tables missing from router schema; staying in BYOK-only mode. Apply db migration 0006_credit_billing to enable billing.")
 		default:
 			billingSvc = billing.NewService(billingRepo)
-			billingMinBalanceMicros = parseEnvInt64("ROUTER_BILLING_MIN_BALANCE_MICROS", 1_000_000)
-			logger.Info("Router billing enabled", "min_balance_usd_micros", billingMinBalanceMicros)
+			logger.Info("Router billing enabled", "min_balance_usd_micros", billing.MinBalanceMicros)
 		}
 	}
 
@@ -505,7 +503,7 @@ func main() {
 	// handler can surface the universe of deployed models. The fallback nil
 	// keeps non-cluster routers (heuristic dev override, etc.) bootable.
 	deployedModels, _ := rtr.(*cluster.Multiversion)
-	server.Register(engine, authSvc, proxySvc, deployedModels, deploymentMode, billingSvc, billingMinBalanceMicros)
+	server.Register(engine, authSvc, proxySvc, deployedModels, deploymentMode, billingSvc)
 
 	srv := &http.Server{
 		Addr:    ":" + config.GetOr("PORT", "8080"),
@@ -782,23 +780,6 @@ func boolDefault(b bool) string {
 		return "true"
 	}
 	return "false"
-}
-
-// parseEnvInt64 reads an env var as a non-negative int64. Returns fallback
-// when unset, empty, or unparseable. Accepts 0 — a legitimate operational
-// value for thresholds (e.g. ROUTER_BILLING_MIN_BALANCE_MICROS=0 means
-// "only 402 when the balance is actually at or below zero").
-func parseEnvInt64(key string, fallback int64) int64 {
-	raw := config.GetOr(key, "")
-	if raw == "" {
-		return fallback
-	}
-	n, err := strconv.ParseInt(raw, 10, 64)
-	if err != nil || n < 0 {
-		observability.Get().Warn("Invalid env var; using default", "key", key, "value", raw, "default", fallback)
-		return fallback
-	}
-	return n
 }
 
 // parseEnvDurationMs reads an env var as a millisecond integer and returns

--- a/internal/billing/service.go
+++ b/internal/billing/service.go
@@ -34,6 +34,13 @@ func HasOverrideFromContext(ctx context.Context) bool {
 // constraint on router.organization_credit_ledger.entry_type.
 const EntryTypeInference = "inference"
 
+// MinBalanceMicros is the balance threshold (in USD micros) below which
+// the router returns HTTP 402. Hardcoded rather than env-tunable: the
+// floor is a product decision shared with the dashboard's low-balance
+// copy, and a typo in a Cloud Run env var should not be able to silently
+// flip the gating threshold.
+const MinBalanceMicros int64 = 1_000_000
+
 // Service orchestrates balance reads and debits. No I/O of its own — all
 // persistence flows through the Repo interface.
 type Service struct {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -55,7 +55,7 @@ const (
 // are present; when set, every inference route is gated on prepaid balance
 // via middleware.WithBalanceCheck. nil leaves inference routes open (BYOK
 // or platform key still controls upstream auth).
-func Register(engine *gin.Engine, authSvc *auth.Service, proxySvc *proxy.Service, deployedModels admin.DeployedModelsSource, mode DeploymentMode, billingSvc *billing.Service, billingMinBalanceMicros int64) {
+func Register(engine *gin.Engine, authSvc *auth.Service, proxySvc *proxy.Service, deployedModels admin.DeployedModelsSource, mode DeploymentMode, billingSvc *billing.Service) {
 	engine.GET("/health", middleware.WithTimeout(healthTimeout), admin.HealthHandler)
 
 	// /validate is a token-validity probe used by clients (not the dashboard), so it stays mounted in both modes.
@@ -101,7 +101,7 @@ func Register(engine *gin.Engine, authSvc *auth.Service, proxySvc *proxy.Service
 		middleware.WithAuth(authSvc),
 	}
 	if billingSvc != nil {
-		messagesMiddleware = append(messagesMiddleware, middleware.WithBalanceCheck(billingSvc, billingMinBalanceMicros))
+		messagesMiddleware = append(messagesMiddleware, middleware.WithBalanceCheck(billingSvc, billing.MinBalanceMicros))
 	}
 	messagesMiddleware = append(messagesMiddleware,
 		middleware.WithEmbedOnlyUserMessageOverride(),
@@ -116,7 +116,7 @@ func Register(engine *gin.Engine, authSvc *auth.Service, proxySvc *proxy.Service
 		middleware.WithAuth(authSvc),
 	}
 	if billingSvc != nil {
-		chatCompletionMiddleware = append(chatCompletionMiddleware, middleware.WithBalanceCheck(billingSvc, billingMinBalanceMicros))
+		chatCompletionMiddleware = append(chatCompletionMiddleware, middleware.WithBalanceCheck(billingSvc, billing.MinBalanceMicros))
 	}
 	chatCompletionMiddleware = append(chatCompletionMiddleware,
 		middleware.WithEmbedOnlyUserMessageOverride(),
@@ -145,7 +145,7 @@ func Register(engine *gin.Engine, authSvc *auth.Service, proxySvc *proxy.Service
 		middleware.WithAuth(authSvc),
 	}
 	if billingSvc != nil {
-		routeMiddleware = append(routeMiddleware, middleware.WithBalanceCheck(billingSvc, billingMinBalanceMicros))
+		routeMiddleware = append(routeMiddleware, middleware.WithBalanceCheck(billingSvc, billing.MinBalanceMicros))
 	}
 	routeMiddleware = append(routeMiddleware,
 		middleware.WithEmbedOnlyUserMessageOverride(),

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -64,7 +64,7 @@ func TestRegister_DeploymentMode(t *testing.T) {
 	t.Run("selfhosted mounts dashboard and product routes", func(t *testing.T) {
 		engine := gin.New()
 		// Nil services are fine: engine.Routes() inspection never invokes the closure-captured handlers.
-		server.Register(engine, nil, nil, fakeDeployedModelsSource{}, server.DeploymentModeSelfHosted, nil, 0)
+		server.Register(engine, nil, nil, fakeDeployedModelsSource{}, server.DeploymentModeSelfHosted, nil)
 		got := routeSet(engine)
 		for _, want := range productRoutes {
 			assert.Contains(t, got, want, "product route missing in selfhosted mode")
@@ -76,7 +76,7 @@ func TestRegister_DeploymentMode(t *testing.T) {
 
 	t.Run("managed skips dashboard but keeps product routes", func(t *testing.T) {
 		engine := gin.New()
-		server.Register(engine, nil, nil, nil, server.DeploymentModeManaged, nil, 0)
+		server.Register(engine, nil, nil, nil, server.DeploymentModeManaged, nil)
 		got := routeSet(engine)
 		for _, want := range productRoutes {
 			assert.Contains(t, got, want, "product route missing in managed mode")


### PR DESCRIPTION
## Summary

- Promote the \$1.00 minimum-balance floor from a tunable env var (`ROUTER_BILLING_MIN_BALANCE_MICROS`) to a compile-time constant `billing.MinBalanceMicros = 1_000_000`.
- The floor is a product decision shared with the dashboard's low-balance copy; a typo in a Cloud Run env var should not be able to silently flip the gating threshold.
- Aligns with the existing hardcoded topup percentage and minimum fee in the billing package.

## Changes

- Add `billing.MinBalanceMicros` constant
- Drop `ROUTER_BILLING_MIN_BALANCE_MICROS` env parsing and the `parseEnvInt64` helper from `cmd/router/main.go` (no other call sites)
- Remove `billingMinBalanceMicros` parameter from `server.Register`; middleware reads `billing.MinBalanceMicros` directly
- Update `server_test.go` to the new signature
- Remove the env var doc from `.env.example`

## Test plan

- [x] `wv mr tc` green
- [x] `wv mr t` green (all packages including `internal/billing` and `internal/server/middleware`)
- [ ] Manual: confirm router boots in managed mode with billing enabled and gates inference at <\$1.00 balance