### PR TITLE
fix(billing): lower MinBalanceMicros to $0

### DIFF
--- a/internal/billing/service.go
+++ b/internal/billing/service.go
@@ -34,12 +34,10 @@ func HasOverrideFromContext(ctx context.Context) bool {
 // constraint on router.organization_credit_ledger.entry_type.
 const EntryTypeInference = "inference"
 
-// MinBalanceMicros is the balance threshold (in USD micros) below which
-// the router returns HTTP 402. Hardcoded rather than env-tunable: the
-// floor is a product decision shared with the dashboard's low-balance
-// copy, and a typo in a Cloud Run env var should not be able to silently
-// flip the gating threshold.
-const MinBalanceMicros int64 = 1_000_000
+// MinBalanceMicros: new requests 402 when balance <= this (USD micros).
+// 0 matches OpenAI/Anthropic prepaid semantics — block at zero, let
+// in-flight debits settle (post-request balance can dip by one req cost).
+const MinBalanceMicros int64 = 0
 
 // Service orchestrates balance reads and debits. No I/O of its own — all
 // persistence flows through the Repo interface.


### PR DESCRIPTION
## Summary

Drop the inference-gating threshold from \$1.00 → \$0.

The \$1 floor introduced in #177 was stricter than the prepaid services we model on. OpenAI and Anthropic both gate at zero: stop accepting new requests when credits hit zero, let in-flight debits settle even if that pushes the post-request balance modestly negative. OpenRouter is the lenient outlier and tolerates negatives well past zero.

This matches the OpenAI/Anthropic contract: customers serve traffic as long as their balance is positive, and the worst-case negative excursion is bounded by max single-request cost.

## Test plan

- [x] `wv mr tc` green
- [x] `wv mr t` green (`internal/server/middleware` tests parameterize the threshold and continue to pass)
- [ ] Manual: confirm router gates inference at \$0 and lets debits settle into slight negatives
- [ ] Pair with WorkWeave PR #7572 to bump the dashboard mirror in lockstep