### PR TITLE
fix(auth): drop BYOK from request context in managed mode

### DIFF
--- a/internal/server/middleware/auth.go
+++ b/internal/server/middleware/auth.go
@@ -23,16 +23,25 @@ const (
 const RouterKeyHeader = "X-Weave-Router-Key"
 
 // WithAuth validates the inbound request via a bearer rk_ token only. Used on data-plane routes (`/v1/*`). On failure, short-circuits 401.
-func WithAuth(svc *auth.Service) gin.HandlerFunc {
-	return withAPIKey(svc)
+//
+// byokDisabled drops any BYOK (customer-owned provider) keys at the middleware
+// boundary so downstream proxy code can't see them. Managed-mode deployments
+// pass true: they bill via prepaid credits against the platform key and must
+// never honor a leftover row in router.model_router_external_api_keys, or the
+// customer would be charged twice (once upstream, once via credits).
+// Self-hosted passes false; BYOK is the only credentialing path there.
+func WithAuth(svc *auth.Service, byokDisabled bool) gin.HandlerFunc {
+	return withAPIKey(svc, byokDisabled)
 }
 
 // WithAdminOrAuth accepts either a signed admin session cookie OR a bearer rk_ token.
 //
 // Do not use on `/v1/*` data-plane routes — a dashboard cookie must not call provider proxy endpoints.
 // Do not use on control-plane mutations — a leaked rk_ must not mint fresh keys or rotate provider credentials; use WithAdminOnly instead.
-func WithAdminOrAuth(svc *auth.Service) gin.HandlerFunc {
-	apiKeyMW := withAPIKey(svc)
+//
+// See WithAuth for the byokDisabled semantics.
+func WithAdminOrAuth(svc *auth.Service, byokDisabled bool) gin.HandlerFunc {
+	apiKeyMW := withAPIKey(svc, byokDisabled)
 	return func(c *gin.Context) {
 		if principal := tryAdminCookie(c, svc); principal != nil {
 			c.Set(ctxKeyAdminPrincipal, principal)
@@ -61,7 +70,13 @@ func WithAdminOnly(svc *auth.Service) gin.HandlerFunc {
 }
 
 // withAPIKey is the bearer-only auth path shared by WithAuth and the fall-through branch of WithAdminOrAuth.
-func withAPIKey(svc *auth.Service) gin.HandlerFunc {
+//
+// When byokDisabled is true, BYOK rows returned by svc.VerifyAPIKey are
+// dropped before reaching the request context. Every downstream consumer of
+// the BYOK ctx value (proxy credential resolution, provider gating, usage
+// bookkeeping) reads from that single key, so gating it here makes the entire
+// code path BYOK-blind without further surgery.
+func withAPIKey(svc *auth.Service, byokDisabled bool) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		token := extractToken(c)
 		installation, apiKey, externalKeys, err := svc.VerifyAPIKey(c.Request.Context(), token)
@@ -86,7 +101,7 @@ func withAPIKey(svc *auth.Service) gin.HandlerFunc {
 				ctx = context.WithValue(ctx, proxy.InstallationExcludedModelsContextKey{}, installation.ExcludedModels)
 			}
 		}
-		if externalKeys != nil {
+		if externalKeys != nil && !byokDisabled {
 			ctx = context.WithValue(ctx, proxy.ExternalAPIKeysContextKey{}, externalKeys)
 		}
 		if installation != nil && installation.ID != "" {

--- a/internal/server/middleware/auth_test.go
+++ b/internal/server/middleware/auth_test.go
@@ -11,12 +11,37 @@ import (
 	"time"
 
 	"workweave/router/internal/auth"
+	"workweave/router/internal/proxy"
 	"workweave/router/internal/server/middleware"
 
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+type fakeExternalAPIKeyRepository struct {
+	byInstallationID map[string][]*auth.ExternalAPIKey
+}
+
+func (f *fakeExternalAPIKeyRepository) Create(context.Context, auth.CreateExternalAPIKeyParams) (*auth.ExternalAPIKey, error) {
+	return nil, errors.New("not used")
+}
+
+func (f *fakeExternalAPIKeyRepository) GetForInstallation(_ context.Context, installationID string) ([]*auth.ExternalAPIKey, error) {
+	return f.byInstallationID[installationID], nil
+}
+
+func (f *fakeExternalAPIKeyRepository) SoftDeleteByProvider(context.Context, string, string) error {
+	return errors.New("not used")
+}
+
+func (f *fakeExternalAPIKeyRepository) SoftDelete(context.Context, string, string) error {
+	return errors.New("not used")
+}
+
+func (f *fakeExternalAPIKeyRepository) MarkUsed(context.Context, string) error {
+	return nil
+}
 
 type fakeAPIKeyRepository struct {
 	byHash map[string]fakeKeyRow
@@ -92,7 +117,7 @@ func TestWithAuthPrefersRouterKeyHeader(t *testing.T) {
 	})
 
 	engine := gin.New()
-	engine.Use(middleware.WithAuth(svc))
+	engine.Use(middleware.WithAuth(svc, false))
 	engine.GET("/probe", func(c *gin.Context) {
 		assert.Equal(t, installation, middleware.InstallationFrom(c))
 		assert.Equal(t, apiKey, middleware.APIKeyFrom(c))
@@ -102,6 +127,70 @@ func TestWithAuthPrefersRouterKeyHeader(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/probe", nil)
 	req.Header.Set(middleware.RouterKeyHeader, routerToken)
 	req.Header.Set("Authorization", "Bearer anthropic-oauth-token")
+	rr := httptest.NewRecorder()
+	engine.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+}
+
+func TestWithAuthManagedModeDropsBYOKFromContext(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	const routerToken = "rk_managed"
+	hash, prefix, suffix := auth.APITokenFingerprint(routerToken)
+	apiKey := &auth.APIKey{ID: "key-managed", InstallationID: "inst-managed", KeyHash: hash, KeyPrefix: prefix, KeySuffix: suffix}
+	installation := &auth.Installation{ID: "inst-managed", ExternalID: "ext-managed"}
+	repo := &fakeAPIKeyRepository{byHash: map[string]fakeKeyRow{
+		hash: {apiKey: apiKey, installation: installation},
+	}}
+	// VerifyAPIKey returns this row, so without the managed-mode gate the
+	// middleware would stash it on the request context.
+	externalRepo := &fakeExternalAPIKeyRepository{byInstallationID: map[string][]*auth.ExternalAPIKey{
+		installation.ID: {{ID: "ext-leftover", InstallationID: installation.ID, Provider: "anthropic", Plaintext: []byte("sk-ant-leftover")}},
+	}}
+	svc := auth.NewService(fakeInstallationRepository{}, repo, externalRepo, nil, auth.NoOpAPIKeyCache{}, nil, func() time.Time { return time.Now() })
+
+	engine := gin.New()
+	engine.Use(middleware.WithAuth(svc, true))
+	engine.GET("/probe", func(c *gin.Context) {
+		assert.Nil(t, c.Request.Context().Value(proxy.ExternalAPIKeysContextKey{}),
+			"managed mode must drop BYOK rows at the middleware boundary; a leftover row in the table must not reach the proxy ctx")
+		c.Status(http.StatusOK)
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/probe", nil)
+	req.Header.Set(middleware.RouterKeyHeader, routerToken)
+	rr := httptest.NewRecorder()
+	engine.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+}
+
+func TestWithAuthSelfHostedKeepsBYOKInContext(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	const routerToken = "rk_selfhosted"
+	hash, prefix, suffix := auth.APITokenFingerprint(routerToken)
+	apiKey := &auth.APIKey{ID: "key-self", InstallationID: "inst-self", KeyHash: hash, KeyPrefix: prefix, KeySuffix: suffix}
+	installation := &auth.Installation{ID: "inst-self", ExternalID: "ext-self"}
+	repo := &fakeAPIKeyRepository{byHash: map[string]fakeKeyRow{
+		hash: {apiKey: apiKey, installation: installation},
+	}}
+	externalRepo := &fakeExternalAPIKeyRepository{byInstallationID: map[string][]*auth.ExternalAPIKey{
+		installation.ID: {{ID: "ext-byok", InstallationID: installation.ID, Provider: "anthropic", Plaintext: []byte("sk-ant-byok")}},
+	}}
+	svc := auth.NewService(fakeInstallationRepository{}, repo, externalRepo, nil, auth.NoOpAPIKeyCache{}, nil, func() time.Time { return time.Now() })
+
+	engine := gin.New()
+	engine.Use(middleware.WithAuth(svc, false))
+	engine.GET("/probe", func(c *gin.Context) {
+		v, ok := c.Request.Context().Value(proxy.ExternalAPIKeysContextKey{}).([]*auth.ExternalAPIKey)
+		require.True(t, ok, "self-hosted mode must propagate BYOK rows to the proxy ctx")
+		require.Len(t, v, 1)
+		assert.Equal(t, "anthropic", v[0].Provider)
+		c.Status(http.StatusOK)
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/probe", nil)
+	req.Header.Set(middleware.RouterKeyHeader, routerToken)
 	rr := httptest.NewRecorder()
 	engine.ServeHTTP(rr, req)
 
@@ -120,7 +209,7 @@ func TestWithAuthKeepsLegacyBearerFallback(t *testing.T) {
 	svc := auth.NewService(fakeInstallationRepository{}, repo, nil, nil, auth.NoOpAPIKeyCache{}, nil, func() time.Time { return time.Now() })
 
 	engine := gin.New()
-	engine.Use(middleware.WithAuth(svc))
+	engine.Use(middleware.WithAuth(svc, false))
 	engine.GET("/probe", func(c *gin.Context) { c.Status(http.StatusOK) })
 
 	req := httptest.NewRequest(http.MethodGet, "/probe", nil)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -56,10 +56,16 @@ const (
 // via middleware.WithBalanceCheck. nil leaves inference routes open (BYOK
 // or platform key still controls upstream auth).
 func Register(engine *gin.Engine, authSvc *auth.Service, proxySvc *proxy.Service, deployedModels admin.DeployedModelsSource, mode DeploymentMode, billingSvc *billing.Service) {
+	// Managed mode bills via prepaid credits against the platform key; any
+	// BYOK row left over in router.model_router_external_api_keys would
+	// silently double-charge the customer (upstream provider + Weave credits).
+	// Drop BYOK at the middleware boundary so no downstream consumer can see it.
+	byokDisabled := mode == DeploymentModeManaged
+
 	engine.GET("/health", middleware.WithTimeout(healthTimeout), admin.HealthHandler)
 
 	// /validate is a token-validity probe used by clients (not the dashboard), so it stays mounted in both modes.
-	adminAuthed := engine.Group("", middleware.WithTimeout(validateTimeout), middleware.WithAuth(authSvc))
+	adminAuthed := engine.Group("", middleware.WithTimeout(validateTimeout), middleware.WithAuth(authSvc, byokDisabled))
 	adminAuthed.GET("/validate", admin.ValidateHandler)
 
 	if mode == DeploymentModeSelfHosted {
@@ -74,7 +80,7 @@ func Register(engine *gin.Engine, authSvc *auth.Service, proxySvc *proxy.Service
 		authPublic.GET("/me", admin.MeHandler(authSvc))
 
 		// Read-only metrics: dashboard cookie OR rk_ bearer so an installation can fetch its own data for monitoring scripts. Per-installation scoping is enforced inside the handlers.
-		metrics := engine.Group("/admin/v1", middleware.WithTimeout(adminTimeout), middleware.WithAdminOrAuth(authSvc))
+		metrics := engine.Group("/admin/v1", middleware.WithTimeout(adminTimeout), middleware.WithAdminOrAuth(authSvc, byokDisabled))
 		metrics.GET("/metrics/summary", admin.MetricsSummaryHandler(proxySvc))
 		metrics.GET("/metrics/timeseries", admin.MetricsTimeseriesHandler(proxySvc))
 		metrics.GET("/metrics/details", admin.MetricsDetailsHandler(proxySvc))
@@ -98,7 +104,7 @@ func Register(engine *gin.Engine, authSvc *auth.Service, proxySvc *proxy.Service
 	messagesMiddleware := []gin.HandlerFunc{
 		middleware.WithTimingEntry(),
 		middleware.WithTimeout(messagesTimeout),
-		middleware.WithAuth(authSvc),
+		middleware.WithAuth(authSvc, byokDisabled),
 	}
 	if billingSvc != nil {
 		messagesMiddleware = append(messagesMiddleware, middleware.WithBalanceCheck(billingSvc, billing.MinBalanceMicros))
@@ -113,7 +119,7 @@ func Register(engine *gin.Engine, authSvc *auth.Service, proxySvc *proxy.Service
 	chatCompletionMiddleware := []gin.HandlerFunc{
 		middleware.WithTimingEntry(),
 		middleware.WithTimeout(chatCompletionTimeout),
-		middleware.WithAuth(authSvc),
+		middleware.WithAuth(authSvc, byokDisabled),
 	}
 	if billingSvc != nil {
 		chatCompletionMiddleware = append(chatCompletionMiddleware, middleware.WithBalanceCheck(billingSvc, billing.MinBalanceMicros))
@@ -134,7 +140,7 @@ func Register(engine *gin.Engine, authSvc *auth.Service, proxySvc *proxy.Service
 	// make clients fail to negotiate before any inference happens.
 	passthroughGroup := engine.Group("",
 		middleware.WithTimeout(passthroughTimeout),
-		middleware.WithAuth(authSvc),
+		middleware.WithAuth(authSvc, byokDisabled),
 	)
 	passthroughGroup.POST("/v1/messages/count_tokens", anthropicapi.PassthroughHandler(proxySvc))
 	passthroughGroup.GET("/v1/models", anthropicapi.PassthroughHandler(proxySvc))
@@ -142,7 +148,7 @@ func Register(engine *gin.Engine, authSvc *auth.Service, proxySvc *proxy.Service
 
 	routeMiddleware := []gin.HandlerFunc{
 		middleware.WithTimeout(routeTimeout),
-		middleware.WithAuth(authSvc),
+		middleware.WithAuth(authSvc, byokDisabled),
 	}
 	if billingSvc != nil {
 		routeMiddleware = append(routeMiddleware, middleware.WithBalanceCheck(billingSvc, billing.MinBalanceMicros))


### PR DESCRIPTION
## Summary
- Add a `byokDisabled` parameter to `WithAuth` / `withAPIKey` / `WithAdminOrAuth`. When true, the middleware skips the `context.WithValue(ctx, proxy.ExternalAPIKeysContextKey{}, externalKeys)` call so no downstream consumer (`resolveAndInjectCredentials`, provider gating, etc.) sees BYOK rows.
- Derive `byokDisabled := mode == DeploymentModeManaged` once in `server.Register` and thread it to every middleware constructor.
- Self-hosted mode continues to propagate BYOK unchanged (it's the only credentialing path there).

## Why
Managed deployments bill via prepaid credits against the platform key. A leftover or accidentally-inserted row in `router.model_router_external_api_keys` would otherwise be honored by the proxy and silently double-charge the customer (upstream provider + Weave credits). Paired with the WorkWeave-side PR that removes the BYOK upload surface and soft-deletes existing rows; this is the defense-in-depth backstop for rollbacks, replication lag, or a future row sneaking back in.

## Test plan
- [x] `go test ./...` clean
- [x] New `TestWithAuthManagedModeDropsBYOKFromContext` asserts the context key is absent when `byokDisabled=true`
- [x] New `TestWithAuthSelfHostedKeepsBYOKInContext` asserts the context key still carries the BYOK slice when `byokDisabled=false`
- [x] Existing `TestWithAuthPrefersRouterKeyHeader` / `TestWithAuthKeepsLegacyBearerFallback` pass with `byokDisabled=false`

🤖 Generated with [Claude Code](https://claude.com/claude-code)