### PR TITLE
feat(router): Fireworks for deepseek-v4-pro; drop qwen3-30b-a3b-instruct-2507

### DIFF
--- a/install/cc-statusline.sh
+++ b/install/cc-statusline.sh
@@ -134,7 +134,7 @@ prices='{
     "claude-opus-4-7":                  0.015,
     "claude-sonnet-4-5":                0.003,
     "deepseek/deepseek-v4-flash":       0.00014,
-    "deepseek/deepseek-v4-pro":         0.000435,
+    "deepseek/deepseek-v4-pro":         0.00174,
     "gemini-2.0-flash":                 0.0001,
     "gemini-2.0-flash-lite":            0.000075,
     "gemini-2.5-flash":                 0.0003,
@@ -163,7 +163,6 @@ prices='{
     "gpt-5.5-pro":                      0.03,
     "moonshotai/kimi-k2.5":             0.00044,
     "qwen/qwen3-235b-a22b-2507":        0.000071,
-    "qwen/qwen3-30b-a3b-instruct-2507": 0.00008,
     "qwen/qwen3-coder":                 0.00022,
     "qwen/qwen3-coder-next":            0.00007,
     "qwen/qwen3-next-80b-a3b-instruct": 0.00009
@@ -174,7 +173,7 @@ prices='{
     "claude-opus-4-7":                  0.075,
     "claude-sonnet-4-5":                0.015,
     "deepseek/deepseek-v4-flash":       0.00028,
-    "deepseek/deepseek-v4-pro":         0.00087,
+    "deepseek/deepseek-v4-pro":         0.00348,
     "gemini-2.0-flash":                 0.0004,
     "gemini-2.0-flash-lite":            0.0003,
     "gemini-2.5-flash":                 0.0012,
@@ -203,7 +202,6 @@ prices='{
     "gpt-5.5-pro":                      0.12,
     "moonshotai/kimi-k2.5":             0.002,
     "qwen/qwen3-235b-a22b-2507":        0.000463,
-    "qwen/qwen3-30b-a3b-instruct-2507": 0.00033,
     "qwen/qwen3-coder":                 0.0018,
     "qwen/qwen3-coder-next":            0.0003,
     "qwen/qwen3-next-80b-a3b-instruct": 0.0011

--- a/install/install.sh
+++ b/install/install.sh
@@ -592,7 +592,7 @@ prices='{
     "claude-opus-4-7":                  0.015,
     "claude-sonnet-4-5":                0.003,
     "deepseek/deepseek-v4-flash":       0.00014,
-    "deepseek/deepseek-v4-pro":         0.000435,
+    "deepseek/deepseek-v4-pro":         0.00174,
     "gemini-2.0-flash":                 0.0001,
     "gemini-2.0-flash-lite":            0.000075,
     "gemini-2.5-flash":                 0.0003,
@@ -621,7 +621,6 @@ prices='{
     "gpt-5.5-pro":                      0.03,
     "moonshotai/kimi-k2.5":             0.00044,
     "qwen/qwen3-235b-a22b-2507":        0.000071,
-    "qwen/qwen3-30b-a3b-instruct-2507": 0.00008,
     "qwen/qwen3-coder":                 0.00022,
     "qwen/qwen3-coder-next":            0.00007,
     "qwen/qwen3-next-80b-a3b-instruct": 0.00009
@@ -632,7 +631,7 @@ prices='{
     "claude-opus-4-7":                  0.075,
     "claude-sonnet-4-5":                0.015,
     "deepseek/deepseek-v4-flash":       0.00028,
-    "deepseek/deepseek-v4-pro":         0.00087,
+    "deepseek/deepseek-v4-pro":         0.00348,
     "gemini-2.0-flash":                 0.0004,
     "gemini-2.0-flash-lite":            0.0003,
     "gemini-2.5-flash":                 0.0012,
@@ -661,7 +660,6 @@ prices='{
     "gpt-5.5-pro":                      0.12,
     "moonshotai/kimi-k2.5":             0.002,
     "qwen/qwen3-235b-a22b-2507":        0.000463,
-    "qwen/qwen3-30b-a3b-instruct-2507": 0.00033,
     "qwen/qwen3-coder":                 0.0018,
     "qwen/qwen3-coder-next":            0.0003,
     "qwen/qwen3-next-80b-a3b-instruct": 0.0011

--- a/internal/router/capability/tier.go
+++ b/internal/router/capability/tier.go
@@ -43,7 +43,6 @@ var tiers = map[string]Tier{
 	"gemini-2.5-flash":                 TierLow,
 	"gpt-4.1-nano":                     TierLow,
 	"gpt-4.1-mini":                     TierLow,
-	"qwen/qwen3-30b-a3b-instruct-2507": TierLow,
 	"deepseek/deepseek-v4-flash":       TierLow,
 
 	// --- Mid ---

--- a/internal/router/capability/tier_test.go
+++ b/internal/router/capability/tier_test.go
@@ -62,7 +62,6 @@ func TestValidate(t *testing.T) {
 			"gpt-5.5",
 			"gemini-2.5-flash",
 			"qwen/qwen3-235b-a22b-2507",
-			"qwen/qwen3-30b-a3b-instruct-2507",
 			"qwen/qwen3-coder-next",
 			"qwen/qwen3-next-80b-a3b-instruct",
 			"qwen/qwen3-coder",

--- a/internal/router/cluster/artifacts/v0.38/metadata.yaml
+++ b/internal/router/cluster/artifacts/v0.38/metadata.yaml
@@ -26,6 +26,7 @@ training:
   n_excluded_prompts: 0
 deployed_providers:
   - anthropic
+  - fireworks
   - google
   - openai
   - openrouter
@@ -44,7 +45,6 @@ deployed_models:
   - gpt-5.5
   - moonshotai/kimi-k2.5
   - qwen/qwen3-235b-a22b-2507
-  - qwen/qwen3-30b-a3b-instruct-2507
   - qwen/qwen3-coder
   - qwen/qwen3-coder-next
   - qwen/qwen3-next-80b-a3b-instruct
@@ -63,8 +63,7 @@ cost_per_1k_input_usd:
   gpt-5.5: 0.20500000000000002
   moonshotai/kimi-k2.5: 0.01044
   qwen/qwen3-235b-a22b-2507: 0.0023859999999999997
-  qwen/qwen3-30b-a3b-instruct-2507: 0.00173
   qwen/qwen3-coder: 0.009219999999999999
   qwen/qwen3-coder-next: 0.0015699999999999998
   qwen/qwen3-next-80b-a3b-instruct: 0.00559
-changelog: "v0.38: v0.37 minus mistralai/mistral-small-2603 and qwen/qwen3.5-flash-02-23 (both underperformed in eval). centroids.bin reused verbatim from v0.37; rankings/registry stripped of the two model columns. No retraining — PR 7 (v0.39) will retrain on the SOC 2 direct-provider price set."
+changelog: "v0.38: v0.37 minus mistralai/mistral-small-2603, qwen/qwen3.5-flash-02-23, and qwen/qwen3-30b-a3b-instruct-2507 (the first two underperformed in eval; the third is dedicated-only on Fireworks, not available on any SOC 2-compliant serverless provider). deepseek/deepseek-v4-pro re-pointed from openrouter → fireworks for SOC 2 isolation. centroids.bin reused verbatim from v0.37; rankings/registry stripped of the three dropped models. No retraining — PR 7 (v0.39) will retrain on the SOC 2 direct-provider price set."

--- a/internal/router/cluster/artifacts/v0.38/model_registry.json
+++ b/internal/router/cluster/artifacts/v0.38/model_registry.json
@@ -1,6 +1,6 @@
 {
   "meta": {
-    "comment": "v0.38 = v0.37 minus two underperforming models (mistralai/mistral-small-2603, qwen/qwen3.5-flash-02-23). centroids.bin reused verbatim from v0.37 (clustering is model-independent). rankings.json + metadata.yaml stripped of both models — argmax now operates over the smaller deployed set. No retraining; PR 7 (v0.39) replaces this bundle once direct-provider pricing lands.",
+    "comment": "v0.38 = v0.37 minus three models (mistralai/mistral-small-2603, qwen/qwen3.5-flash-02-23 — both underperformed in eval; qwen/qwen3-30b-a3b-instruct-2507 — dedicated-only on Fireworks, not available on any SOC 2-compliant serverless provider) and with deepseek/deepseek-v4-pro re-pointed from openrouter → fireworks for SOC 2 isolation. centroids.bin reused verbatim from v0.37 (clustering is model-independent). rankings.json + metadata.yaml stripped of the three dropped models. No retraining; PR 7 (v0.39) replaces this bundle once full direct-provider pricing lands.",
     "last_refreshed": "2026-05-17",
     "parent": "v0.37",
     "training_recipe": "inherited from v0.37 (no retrain — model set stripped post-training)."
@@ -17,13 +17,12 @@
     {"model": "gpt-5.5",                          "provider": "openai",     "bench_column": "routerarena_gpt-5.5",                          "direct_label": "routerarena"},
     {"model": "gemini-2.5-flash",                 "provider": "google",     "bench_column": "routerarena_gemini-2.5-flash",                 "direct_label": "routerarena"},
     {"model": "qwen/qwen3-235b-a22b-2507",        "provider": "openrouter", "bench_column": "routerarena_qwen/qwen3-235b-a22b-2507",        "direct_label": "routerarena"},
-    {"model": "qwen/qwen3-30b-a3b-instruct-2507", "provider": "openrouter", "bench_column": "routerarena_qwen/qwen3-30b-a3b-instruct-2507", "direct_label": "routerarena"},
     {"model": "qwen/qwen3-coder-next",            "provider": "openrouter", "bench_column": "routerarena_qwen/qwen3-coder-next",            "direct_label": "routerarena"},
     {"model": "qwen/qwen3-next-80b-a3b-instruct", "provider": "openrouter", "bench_column": "routerarena_qwen/qwen3-next-80b-a3b-instruct", "direct_label": "routerarena"},
 
     {"model": "qwen/qwen3-coder",                 "provider": "openrouter", "bench_column": "routerarena_qwen/qwen3-coder",                 "direct_label": "routerarena"},
     {"model": "deepseek/deepseek-v4-flash",       "provider": "openrouter", "bench_column": "routerarena_deepseek/deepseek-v4-flash",       "direct_label": "routerarena"},
-    {"model": "deepseek/deepseek-v4-pro",         "provider": "openrouter", "bench_column": "routerarena_deepseek/deepseek-v4-pro",         "direct_label": "routerarena"},
+    {"model": "deepseek/deepseek-v4-pro",         "provider": "fireworks",  "bench_column": "routerarena_deepseek/deepseek-v4-pro",         "direct_label": "routerarena"},
     {"model": "moonshotai/kimi-k2.5",             "provider": "openrouter", "bench_column": "routerarena_moonshotai/kimi-k2.5",             "direct_label": "routerarena"}
   ]
 }

--- a/internal/router/cluster/artifacts/v0.38/rankings.json
+++ b/internal/router/cluster/artifacts/v0.38/rankings.json
@@ -16,7 +16,6 @@
       "gpt-5.5": 0.20500000000000002,
       "moonshotai/kimi-k2.5": 0.01044,
       "qwen/qwen3-235b-a22b-2507": 0.0023859999999999997,
-      "qwen/qwen3-30b-a3b-instruct-2507": 0.00173,
       "qwen/qwen3-coder": 0.009219999999999999,
       "qwen/qwen3-coder-next": 0.0015699999999999998,
       "qwen/qwen3-next-80b-a3b-instruct": 0.00559
@@ -57,7 +56,6 @@
       "gpt-5.5": 0.48954894788590797,
       "moonshotai/kimi-k2.5": 0.8710678148573947,
       "qwen/qwen3-235b-a22b-2507": 0.6245288184134836,
-      "qwen/qwen3-30b-a3b-instruct-2507": 0.4501322032589482,
       "qwen/qwen3-coder": 0.48241551053064624,
       "qwen/qwen3-coder-next": 0.4753661616334615,
       "qwen/qwen3-next-80b-a3b-instruct": 0.5310647390414883
@@ -77,7 +75,6 @@
       "gpt-5.5": 0.7642112779343085,
       "moonshotai/kimi-k2.5": 0.889315837351212,
       "qwen/qwen3-235b-a22b-2507": 0.6970003773071541,
-      "qwen/qwen3-30b-a3b-instruct-2507": 0.4798109401443426,
       "qwen/qwen3-coder": 0.6390781869552583,
       "qwen/qwen3-coder-next": 0.5824468974814361,
       "qwen/qwen3-next-80b-a3b-instruct": 0.6299162307023257
@@ -97,7 +94,6 @@
       "gpt-5.5": 0.7642112779343085,
       "moonshotai/kimi-k2.5": 0.9175342278935199,
       "qwen/qwen3-235b-a22b-2507": 0.6637727000777001,
-      "qwen/qwen3-30b-a3b-instruct-2507": 0.6166181232788157,
       "qwen/qwen3-coder": 0.6481340436123385,
       "qwen/qwen3-coder-next": 0.6602214006047934,
       "qwen/qwen3-next-80b-a3b-instruct": 0.6556352548620946
@@ -117,7 +113,6 @@
       "gpt-5.5": 0.5330178205084126,
       "moonshotai/kimi-k2.5": 0.7892301998910392,
       "qwen/qwen3-235b-a22b-2507": 0.7516523702666238,
-      "qwen/qwen3-30b-a3b-instruct-2507": 0.6335364412763316,
       "qwen/qwen3-coder": 0.7048639252886739,
       "qwen/qwen3-coder-next": 0.756146678068635,
       "qwen/qwen3-next-80b-a3b-instruct": 0.8110047313060406
@@ -137,7 +132,6 @@
       "gpt-5.5": 0.6963772807714734,
       "moonshotai/kimi-k2.5": 0.8685781496089567,
       "qwen/qwen3-235b-a22b-2507": 0.6665835752828,
-      "qwen/qwen3-30b-a3b-instruct-2507": 0.5842187977833659,
       "qwen/qwen3-coder": 0.626107574556571,
       "qwen/qwen3-coder-next": 0.5631948836520047,
       "qwen/qwen3-next-80b-a3b-instruct": 0.6126478972188485
@@ -157,7 +151,6 @@
       "gpt-5.5": 0.7431506322227074,
       "moonshotai/kimi-k2.5": 0.901748340915413,
       "qwen/qwen3-235b-a22b-2507": 0.8207369142386196,
-      "qwen/qwen3-30b-a3b-instruct-2507": 0.7874826492128564,
       "qwen/qwen3-coder": 0.7788787643069888,
       "qwen/qwen3-coder-next": 0.8290246233045633,
       "qwen/qwen3-next-80b-a3b-instruct": 0.7695194978686162
@@ -177,7 +170,6 @@
       "gpt-5.5": 0.7093877458984548,
       "moonshotai/kimi-k2.5": 0.9173730978667927,
       "qwen/qwen3-235b-a22b-2507": 0.815439325756123,
-      "qwen/qwen3-30b-a3b-instruct-2507": 0.7817265079513122,
       "qwen/qwen3-coder": 0.8644186516929504,
       "qwen/qwen3-coder-next": 0.7675992141367954,
       "qwen/qwen3-next-80b-a3b-instruct": 0.7209711670790183
@@ -197,7 +189,6 @@
       "gpt-5.5": 0.7152190861756434,
       "moonshotai/kimi-k2.5": 0.909906141296184,
       "qwen/qwen3-235b-a22b-2507": 0.8281572837420225,
-      "qwen/qwen3-30b-a3b-instruct-2507": 0.7021447813871953,
       "qwen/qwen3-coder": 0.7745154039640525,
       "qwen/qwen3-coder-next": 0.7869315045224654,
       "qwen/qwen3-next-80b-a3b-instruct": 0.7403357950418816
@@ -217,7 +208,6 @@
       "gpt-5.5": 0.7642112779343085,
       "moonshotai/kimi-k2.5": 0.8406361398293016,
       "qwen/qwen3-235b-a22b-2507": 0.7336055056529036,
-      "qwen/qwen3-30b-a3b-instruct-2507": 0.44957736693812955,
       "qwen/qwen3-coder": 0.7162827847747599,
       "qwen/qwen3-coder-next": 0.5684789545475912,
       "qwen/qwen3-next-80b-a3b-instruct": 0.5472099526238796
@@ -237,7 +227,6 @@
       "gpt-5.5": 0.7341702970510193,
       "moonshotai/kimi-k2.5": 0.9213650392073327,
       "qwen/qwen3-235b-a22b-2507": 0.7043228949514447,
-      "qwen/qwen3-30b-a3b-instruct-2507": 0.5288766848954702,
       "qwen/qwen3-coder": 0.637375223769965,
       "qwen/qwen3-coder-next": 0.6035317181856381,
       "qwen/qwen3-next-80b-a3b-instruct": 0.6201869672849345
@@ -257,7 +246,6 @@
       "gpt-5.5": 0.7642112779343085,
       "moonshotai/kimi-k2.5": 0.929807488920565,
       "qwen/qwen3-235b-a22b-2507": 0.4962124249564315,
-      "qwen/qwen3-30b-a3b-instruct-2507": 0.5137618418731535,
       "qwen/qwen3-coder": 0.5053646562424675,
       "qwen/qwen3-coder-next": 0.5250302861738423,
       "qwen/qwen3-next-80b-a3b-instruct": 0.5533392147954117
@@ -277,7 +265,6 @@
       "gpt-5.5": 0.7642112779343085,
       "moonshotai/kimi-k2.5": 0.9033391669716189,
       "qwen/qwen3-235b-a22b-2507": 0.7486131725140674,
-      "qwen/qwen3-30b-a3b-instruct-2507": 0.44957736693812955,
       "qwen/qwen3-coder": 0.7177558303725016,
       "qwen/qwen3-coder-next": 0.5736850149945096,
       "qwen/qwen3-next-80b-a3b-instruct": 0.6897552997258409
@@ -297,7 +284,6 @@
       "gpt-5.5": 0.7302018768017958,
       "moonshotai/kimi-k2.5": 0.9624167407688109,
       "qwen/qwen3-235b-a22b-2507": 0.7588095911044961,
-      "qwen/qwen3-30b-a3b-instruct-2507": 0.5138070765819512,
       "qwen/qwen3-coder": 0.7379720340920599,
       "qwen/qwen3-coder-next": 0.6277487193813827,
       "qwen/qwen3-next-80b-a3b-instruct": 0.6412327645717263
@@ -317,7 +303,6 @@
       "gpt-5.5": 0.5439937906813384,
       "moonshotai/kimi-k2.5": 0.9388408818026135,
       "qwen/qwen3-235b-a22b-2507": 0.6937322704239084,
-      "qwen/qwen3-30b-a3b-instruct-2507": 0.6166809774473885,
       "qwen/qwen3-coder": 0.6280181141194909,
       "qwen/qwen3-coder-next": 0.6309247295577541,
       "qwen/qwen3-next-80b-a3b-instruct": 0.6593273222173457
@@ -337,7 +322,6 @@
       "gpt-5.5": 0.7642112779343085,
       "moonshotai/kimi-k2.5": 0.9053890576103669,
       "qwen/qwen3-235b-a22b-2507": 0.7227478095844051,
-      "qwen/qwen3-30b-a3b-instruct-2507": 0.591077486647451,
       "qwen/qwen3-coder": 0.7429337438491865,
       "qwen/qwen3-coder-next": 0.5948808831944363,
       "qwen/qwen3-next-80b-a3b-instruct": 0.7306139957992992
@@ -357,7 +341,6 @@
       "gpt-5.5": 0.7216712507940385,
       "moonshotai/kimi-k2.5": 0.9459962744117775,
       "qwen/qwen3-235b-a22b-2507": 0.9154214336281287,
-      "qwen/qwen3-30b-a3b-instruct-2507": 0.9030446809621345,
       "qwen/qwen3-coder": 0.7790535485327494,
       "qwen/qwen3-coder-next": 0.8967474577668377,
       "qwen/qwen3-next-80b-a3b-instruct": 0.7319337901203817

--- a/internal/router/model.go
+++ b/internal/router/model.go
@@ -131,7 +131,6 @@ var registry = map[string]ModelSpec{
 	"gemini-2.0-flash-lite": googleBase,
 
 	"qwen/qwen3-235b-a22b-2507":        openAICompatBase,
-	"qwen/qwen3-30b-a3b-instruct-2507": openAICompatBase,
 	"qwen/qwen3-coder-next":            openAICompatBase,
 	"qwen/qwen3-next-80b-a3b-instruct": openAICompatBase,
 }

--- a/internal/router/pricing/pricing.go
+++ b/internal/router/pricing/pricing.go
@@ -87,14 +87,13 @@ var table = map[string]Pricing{
 
 	// OpenRouter OSS pool
 	"qwen/qwen3-235b-a22b-2507":        {InputUSDPer1M: 0.071, OutputUSDPer1M: 0.463},
-	"qwen/qwen3-30b-a3b-instruct-2507": {InputUSDPer1M: 0.080, OutputUSDPer1M: 0.330},
 	"qwen/qwen3-coder-next":            {InputUSDPer1M: 0.070, OutputUSDPer1M: 0.300},
 	"qwen/qwen3-next-80b-a3b-instruct": {InputUSDPer1M: 0.090, OutputUSDPer1M: 1.100},
 
 	// OpenRouter OSS pool: v0.25 expansion
 	"qwen/qwen3-coder":           {InputUSDPer1M: 0.220, OutputUSDPer1M: 1.800},
 	"deepseek/deepseek-v4-flash": {InputUSDPer1M: 0.140, OutputUSDPer1M: 0.280, CacheReadMultiplier: 0.10},
-	"deepseek/deepseek-v4-pro":   {InputUSDPer1M: 0.435, OutputUSDPer1M: 0.870, CacheReadMultiplier: 0.10},
+	"deepseek/deepseek-v4-pro":   {InputUSDPer1M: 1.740, OutputUSDPer1M: 3.480, CacheReadMultiplier: 0.0862}, // Fireworks serverless
 	"moonshotai/kimi-k2.5":       {InputUSDPer1M: 0.440, OutputUSDPer1M: 2.000},
 }
 

--- a/internal/router/pricing/pricing_test.go
+++ b/internal/router/pricing/pricing_test.go
@@ -65,7 +65,7 @@ func TestCacheReadMultiplier_PerProvider(t *testing.T) {
 		{"gpt-5", 0.50, "OpenAI"},
 		{"gpt-4.1", 0.50, "OpenAI legacy"},
 		{"gemini-3.1-pro-preview", 0.25, "Google"},
-		{"deepseek/deepseek-v4-pro", 0.10, "DeepSeek"},
+		{"deepseek/deepseek-v4-pro", 0.0862, "Fireworks (DeepSeek V4 Pro)"},
 	}
 	for _, tc := range cases {
 		p, ok := pricing.For(tc.model)


### PR DESCRIPTION
## Summary

- **deepseek-v4-pro** flips `openrouter` → `fireworks` in v0.38. Verified serverless at $1.74 / $3.48 with cache-read $0.15 (multiplier ≈ 0.0862) via docs.fireworks.ai/serverless/pricing.
- **qwen3-30b-a3b-instruct-2507** is dropped from v0.38 entirely — Fireworks' per-model page reports "Serverless: Not supported" (dedicated GPU only), and the model is not in the DeepInfra or Bedrock catalogs, so it has no SOC 2-compliant serverless home.

Removal touches: model_registry, rankings (meta cost map + per-prompt scores), metadata.yaml (deployed_models + cost map), capability tier table, pricing table, `openAICompatBase` map, install scripts. `fireworks` added to `deployed_providers`.

In-place edit on v0.38 per request — no v0.39 bump (v0.39 is reserved for the post-rollout retrain).

## Test plan

- [x] `wv mr tc` clean
- [x] `wv mr t` green (pricing_test `TestCacheReadMultiplier_PerProvider` updated: DeepSeek-via-Fireworks expected 0.0862, not the 0.10 DeepSeek-native rate)
- [ ] Staging smoke: real `chat.completions` against `deepseek/deepseek-v4-pro` via Fireworks (tool-use, streaming, `response_format`, reasoning-block round-trip)
- [ ] Staging traffic split via `x-weave-cluster-version: v0.38`; per-provider error rate clean for 1h

## Notes

Discovered while verifying: Fireworks now serves Kimi K2.6 ($0.95 / $4.00). The plan's "stay on K2.5 until Bedrock has K2.6" lock-in is overly conservative — flagged for PR 6 / PR 7 revisit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)