### PR TITLE
feat(providers): DeepInfra for deepseek-v4-flash + openaicompat model ID rewrite hook

### DIFF
--- a/cmd/router/main.go
+++ b/cmd/router/main.go
@@ -241,6 +241,32 @@ func main() {
 	}
 
 	{
+		// DeepInfra OpenAI-compatible surface. DeepInfra uses HuggingFace-form
+		// model IDs (e.g. "deepseek-ai/DeepSeek-V4-Flash"); the registry
+		// carries the router's public slash-form slugs (e.g.
+		// "deepseek/deepseek-v4-flash"). The modelIDMap rewrites the body's
+		// "model" field at proxy time so the public IDs stay stable.
+		deepInfraBaseURL := config.GetOr("DEEPINFRA_BASE_URL", openaiCompatProvider.DeepInfraBaseURL)
+		deepInfraKey := ""
+		if !byokOnly {
+			deepInfraKey = config.GetOr("DEEPINFRA_API_KEY", "")
+		}
+		deepInfraModelIDMap := map[string]string{
+			"deepseek/deepseek-v4-flash": "deepseek-ai/DeepSeek-V4-Flash",
+		}
+		providerMap[providers.ProviderDeepInfra] = openaiCompatProvider.NewClientWithModelIDMap(deepInfraKey, deepInfraBaseURL, deepInfraModelIDMap)
+		switch {
+		case byokOnly:
+			logger.Info("DeepInfra provider enabled (BYOK only)", "base_url", deepInfraBaseURL)
+		case deepInfraKey != "":
+			envKeyedProviders[providers.ProviderDeepInfra] = struct{}{}
+			logger.Info("DeepInfra provider enabled", "base_url", deepInfraBaseURL)
+		default:
+			logger.Info("DeepInfra provider registered (BYOK only — set DEEPINFRA_API_KEY for deployment-level use)", "base_url", deepInfraBaseURL)
+		}
+	}
+
+	{
 		// Native Generative Language REST surface — required for multi-turn
 		// tool use against Gemini 3.x preview models, whose opaque
 		// thought_signature field is not exposed by the OpenAI-compat

--- a/internal/providers/openaicompat/client.go
+++ b/internal/providers/openaicompat/client.go
@@ -4,6 +4,7 @@ package openaicompat
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -21,22 +22,41 @@ import (
 const (
 	DefaultBaseURL   = "https://openrouter.ai/api/v1"
 	FireworksBaseURL = "https://api.fireworks.ai/inference/v1"
+	DeepInfraBaseURL = "https://api.deepinfra.com/v1/openai"
 )
 
+// Client is the generic OpenAI Chat Completions adapter. The optional
+// modelIDMap rewrites the request body's top-level "model" field before
+// forwarding — needed for upstreams (DeepInfra HF-form IDs, Bedrock dot-form
+// IDs) whose canonical model strings differ from the OpenRouter-form slugs
+// the router uses as public IDs.
 type Client struct {
-	apiKey  string
-	baseURL string
-	http    *http.Client
+	apiKey      string
+	baseURL     string
+	http        *http.Client
+	modelIDMap  map[string]string // empty = pass `decision.Model` through unchanged
 }
 
+// NewClient constructs an OpenAI-compatible client that forwards the
+// `decision.Model` value as-is to the upstream.
 func NewClient(apiKey, baseURL string) *Client {
+	return NewClientWithModelIDMap(apiKey, baseURL, nil)
+}
+
+// NewClientWithModelIDMap is like NewClient but rewrites the request body's
+// top-level "model" field according to modelIDMap before forwarding. Keys are
+// router-internal model IDs (the slash-form public IDs); values are the
+// upstream-format IDs the provider expects. Models not in the map pass through
+// unchanged. Pass nil for no rewriting.
+func NewClientWithModelIDMap(apiKey, baseURL string, modelIDMap map[string]string) *Client {
 	if baseURL == "" {
 		baseURL = DefaultBaseURL
 	}
 	return &Client{
-		apiKey:  apiKey,
-		baseURL: strings.TrimRight(baseURL, "/"),
-		http:    &http.Client{Transport: httputil.NewTransport(5*time.Second, 5*time.Second)},
+		apiKey:     apiKey,
+		baseURL:    strings.TrimRight(baseURL, "/"),
+		http:       &http.Client{Transport: httputil.NewTransport(5*time.Second, 5*time.Second)},
+		modelIDMap: modelIDMap,
 	}
 }
 
@@ -52,7 +72,15 @@ func (c *Client) setAuth(ctx context.Context, upstream *http.Request) {
 }
 
 func (c *Client) Proxy(ctx context.Context, decision router.Decision, prep providers.PreparedRequest, w http.ResponseWriter, r *http.Request) error {
-	upstream, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/chat/completions", bytes.NewReader(prep.Body))
+	body := prep.Body
+	if upstreamModel, ok := c.modelIDMap[decision.Model]; ok {
+		rewritten, err := rewriteModelField(body, upstreamModel)
+		if err != nil {
+			return fmt.Errorf("rewrite model field for %q → %q: %w", decision.Model, upstreamModel, err)
+		}
+		body = rewritten
+	}
+	upstream, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/chat/completions", bytes.NewReader(body))
 	if err != nil {
 		return fmt.Errorf("build upstream request: %w", err)
 	}
@@ -162,6 +190,28 @@ func (c *Client) Passthrough(ctx context.Context, prep providers.PreparedRequest
 	}
 	_, err = io.Copy(w, resp.Body)
 	return err
+}
+
+// rewriteModelField replaces the top-level "model" field of an OpenAI Chat
+// Completions request body with newModel, preserving every other field
+// verbatim. Used by providers (DeepInfra HF-form IDs, Bedrock dot-form IDs)
+// whose canonical model strings differ from the router's public slash-form
+// slugs.
+func rewriteModelField(body []byte, newModel string) ([]byte, error) {
+	var m map[string]json.RawMessage
+	if err := json.Unmarshal(body, &m); err != nil {
+		return nil, fmt.Errorf("parse request body: %w", err)
+	}
+	encoded, err := json.Marshal(newModel)
+	if err != nil {
+		return nil, fmt.Errorf("encode upstream model id: %w", err)
+	}
+	m["model"] = encoded
+	out, err := json.Marshal(m)
+	if err != nil {
+		return nil, fmt.Errorf("re-encode request body: %w", err)
+	}
+	return out, nil
 }
 
 // logUpstreamStatus logs non-2xx upstream responses with a body preview.

--- a/internal/providers/openaicompat/client_test.go
+++ b/internal/providers/openaicompat/client_test.go
@@ -112,6 +112,79 @@ func TestProxy_DevModeEnvKeyUsedWhenNoCredentialsOnContext(t *testing.T) {
 		"when no credentials are on context (dev mode / no BYOK), the deployment env key must be sent to OpenRouter")
 }
 
+// TestProxy_RewritesModelIDWhenMapped covers the DeepInfra / Bedrock-mantle
+// case: the registry carries a public slash-form model ID, but the upstream
+// expects a different canonical form (HuggingFace `deepseek-ai/DeepSeek-V4-Flash`,
+// Bedrock dot-form, etc.). When the client is constructed with a modelIDMap,
+// the body's top-level "model" field must be rewritten before forwarding,
+// while every other field stays verbatim.
+func TestProxy_RewritesModelIDWhenMapped(t *testing.T) {
+	var gotBody map[string]any
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		require.NoError(t, json.Unmarshal(body, &gotBody))
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"id":"chatcmpl-1","object":"chat.completion"}`))
+	}))
+	defer upstream.Close()
+
+	c := openaicompat.NewClientWithModelIDMap(
+		"test-key",
+		upstream.URL+"/v1",
+		map[string]string{"deepseek/deepseek-v4-flash": "deepseek-ai/DeepSeek-V4-Flash"},
+	)
+	rec := httptest.NewRecorder()
+	clientReq := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(""))
+
+	body := []byte(`{"model":"deepseek/deepseek-v4-flash","messages":[{"role":"user","content":"hi"}],"temperature":0.7}`)
+	prep := providers.PreparedRequest{Body: body, Headers: make(http.Header)}
+	err := c.Proxy(context.Background(), router.Decision{Model: "deepseek/deepseek-v4-flash"}, prep, rec, clientReq)
+
+	require.NoError(t, err)
+	assert.Equal(t, "deepseek-ai/DeepSeek-V4-Flash", gotBody["model"],
+		"mapped model IDs must be rewritten to the upstream form")
+	assert.Equal(t, 0.7, gotBody["temperature"], "non-model fields must pass through verbatim")
+	require.IsType(t, []any{}, gotBody["messages"])
+}
+
+// TestProxy_PassesUnmappedModelThrough covers the OpenRouter / Fireworks
+// path: no modelIDMap entry for a model means the body's "model" field is
+// forwarded unchanged. Guards against accidental rewriting when the map is
+// non-nil but doesn't contain this model.
+func TestProxy_PassesUnmappedModelThrough(t *testing.T) {
+	var gotBody map[string]any
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		require.NoError(t, json.Unmarshal(body, &gotBody))
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer upstream.Close()
+
+	c := openaicompat.NewClientWithModelIDMap(
+		"test-key",
+		upstream.URL+"/v1",
+		map[string]string{"deepseek/deepseek-v4-flash": "deepseek-ai/DeepSeek-V4-Flash"},
+	)
+	rec := httptest.NewRecorder()
+	clientReq := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(""))
+
+	body := []byte(`{"model":"deepseek/deepseek-v4-pro","messages":[]}`)
+	prep := providers.PreparedRequest{Body: body, Headers: make(http.Header)}
+	err := c.Proxy(context.Background(), router.Decision{Model: "deepseek/deepseek-v4-pro"}, prep, rec, clientReq)
+
+	require.NoError(t, err)
+	assert.Equal(t, "deepseek/deepseek-v4-pro", gotBody["model"],
+		"models not in the rewrite map must pass through unchanged")
+}
+
+func TestDeepInfraBaseURL(t *testing.T) {
+	assert.Equal(t, "https://api.deepinfra.com/v1/openai", openaicompat.DeepInfraBaseURL)
+}
+
 func TestPassthrough_StripsInboundV1Prefix(t *testing.T) {
 	var gotPath string
 

--- a/internal/providers/provider.go
+++ b/internal/providers/provider.go
@@ -17,6 +17,7 @@ const (
 	ProviderGoogle     = "google"
 	ProviderOpenRouter = "openrouter"
 	ProviderFireworks  = "fireworks"
+	ProviderDeepInfra  = "deepinfra"
 )
 
 // APIKeyEnvVars maps provider name to the env var providing its deployment-level upstream API key.
@@ -26,6 +27,7 @@ var APIKeyEnvVars = map[string]string{
 	ProviderGoogle:     "GOOGLE_API_KEY",
 	ProviderOpenRouter: "OPENROUTER_API_KEY",
 	ProviderFireworks:  "FIREWORKS_API_KEY",
+	ProviderDeepInfra:  "DEEPINFRA_API_KEY",
 }
 
 // APIKeyEnvVar returns the env-var name for the given provider, or empty

--- a/internal/router/cluster/artifacts/v0.38/metadata.yaml
+++ b/internal/router/cluster/artifacts/v0.38/metadata.yaml
@@ -26,6 +26,7 @@ training:
   n_excluded_prompts: 0
 deployed_providers:
   - anthropic
+  - deepinfra
   - google
   - openai
   - openrouter

--- a/internal/router/cluster/artifacts/v0.38/model_registry.json
+++ b/internal/router/cluster/artifacts/v0.38/model_registry.json
@@ -1,6 +1,6 @@
 {
   "meta": {
-    "comment": "v0.38 = v0.37 minus two underperforming models (mistralai/mistral-small-2603, qwen/qwen3.5-flash-02-23). centroids.bin reused verbatim from v0.37 (clustering is model-independent). rankings.json + metadata.yaml stripped of both models — argmax now operates over the smaller deployed set. No retraining; PR 7 (v0.39) replaces this bundle once direct-provider pricing lands.",
+    "comment": "v0.38 = v0.37 minus two underperforming models (mistralai/mistral-small-2603, qwen/qwen3.5-flash-02-23), with deepseek/deepseek-v4-flash re-pointed from openrouter → deepinfra for SOC 2 isolation. centroids.bin reused verbatim from v0.37 (clustering is model-independent). rankings.json + metadata.yaml stripped of the dropped models — argmax now operates over the smaller deployed set. No retraining; PR 7 (v0.39) replaces this bundle once full direct-provider pricing lands.",
     "last_refreshed": "2026-05-17",
     "parent": "v0.37",
     "training_recipe": "inherited from v0.37 (no retrain — model set stripped post-training)."
@@ -22,7 +22,7 @@
     {"model": "qwen/qwen3-next-80b-a3b-instruct", "provider": "openrouter", "bench_column": "routerarena_qwen/qwen3-next-80b-a3b-instruct", "direct_label": "routerarena"},
 
     {"model": "qwen/qwen3-coder",                 "provider": "openrouter", "bench_column": "routerarena_qwen/qwen3-coder",                 "direct_label": "routerarena"},
-    {"model": "deepseek/deepseek-v4-flash",       "provider": "openrouter", "bench_column": "routerarena_deepseek/deepseek-v4-flash",       "direct_label": "routerarena"},
+    {"model": "deepseek/deepseek-v4-flash",       "provider": "deepinfra",  "bench_column": "routerarena_deepseek/deepseek-v4-flash",       "direct_label": "routerarena"},
     {"model": "deepseek/deepseek-v4-pro",         "provider": "openrouter", "bench_column": "routerarena_deepseek/deepseek-v4-pro",         "direct_label": "routerarena"},
     {"model": "moonshotai/kimi-k2.5",             "provider": "openrouter", "bench_column": "routerarena_moonshotai/kimi-k2.5",             "direct_label": "routerarena"}
   ]

--- a/internal/router/pricing/pricing.go
+++ b/internal/router/pricing/pricing.go
@@ -93,7 +93,7 @@ var table = map[string]Pricing{
 
 	// OpenRouter OSS pool: v0.25 expansion
 	"qwen/qwen3-coder":           {InputUSDPer1M: 0.220, OutputUSDPer1M: 1.800},
-	"deepseek/deepseek-v4-flash": {InputUSDPer1M: 0.140, OutputUSDPer1M: 0.280, CacheReadMultiplier: 0.10},
+	"deepseek/deepseek-v4-flash": {InputUSDPer1M: 0.140, OutputUSDPer1M: 0.280, CacheReadMultiplier: 0.20}, // DeepInfra: cache $0.028 → 0.028/0.14 = 0.20
 	"deepseek/deepseek-v4-pro":   {InputUSDPer1M: 0.435, OutputUSDPer1M: 0.870, CacheReadMultiplier: 0.10},
 	"moonshotai/kimi-k2.5":       {InputUSDPer1M: 0.440, OutputUSDPer1M: 2.000},
 }


### PR DESCRIPTION
## Summary

- Wires **DeepInfra** as a new OpenAI-compatible provider at `api.deepinfra.com/v1/openai`. Flips `deepseek/deepseek-v4-flash` in v0.38 from `openrouter` → `deepinfra`. Verified serverless at \$0.14 / \$0.28 with cache reads at \$0.028 (multiplier `0.20`, not the `0.10` DeepSeek-native rate the table was using).
- Adds a **per-provider model ID rewrite map** to `openaicompat.Client` via the new `NewClientWithModelIDMap` constructor. The body's top-level `"model"` field is rewritten via `map[string]json.RawMessage` before forwarding, so non-model fields pass through verbatim. This keeps public model IDs (slash-form like `deepseek/deepseek-v4-flash`) stable while still hitting upstreams that demand a different canonical form (DeepInfra HF-form `deepseek-ai/DeepSeek-V4-Flash`; Bedrock dot-form `qwen.qwen3-235b-a22b-2507` in PR 6).

## Touched

- `openaicompat/client.go`: `DeepInfraBaseURL` const; `NewClientWithModelIDMap`; `rewriteModelField` helper.
- `providers/provider.go`: `ProviderDeepInfra` const + `DEEPINFRA_API_KEY` in `APIKeyEnvVars` (single source of truth for admin `/config` view).
- `cmd/router/main.go`: DeepInfra registration block with the slug→HF map.
- `internal/router/cluster/artifacts/v0.38/model_registry.json`: `deepseek-v4-flash` → `deepinfra`; comment updated.
- `internal/router/cluster/artifacts/v0.38/metadata.yaml`: `deepinfra` added to `deployed_providers`.
- `internal/router/pricing/pricing.go`: cache multiplier `0.10` → `0.20` for v4-flash.
- Tests: rewrite-when-mapped, pass-through-when-unmapped, DeepInfra URL constant.

## Test plan

- [x] `wv mr tc` clean
- [x] `wv mr t` green (3 new openaicompat tests pass)
- [ ] Staging smoke: real `chat.completions` against `deepseek/deepseek-v4-flash` via DeepInfra (tool-use, streaming, system reminders)
- [ ] Staging traffic split via `x-weave-cluster-version: v0.38`; per-provider error rate clean for 1h
- [ ] Verify the rewritten upstream model ID in DeepInfra access logs matches `deepseek-ai/DeepSeek-V4-Flash`

## Notes

This PR stacks on PR #182 (Fireworks for deepseek-v4-pro / drop qwen3-30b) but is independent — both touch the v0.38 registry and metadata.yaml `deployed_providers`. Trivial rebase whichever lands second.

🤖 Generated with [Claude Code](https://claude.com/claude-code)