### PR TITLE
chore(npm): bump @workweave/router to 0.1.2

### DIFF
--- a/install/npm/package.json
+++ b/install/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@workweave/router",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "One-command installer that points Claude Code at the Weave Router.",
   "bin": {
     "weave-router": "bin.js"


### PR DESCRIPTION
## Summary
- Bumps the npm package to `0.1.2` so a fresh tarball ships with the current `install.sh` (the published `0.1.1` still has the `/ui` suffix in the dashboard URL fixed in #170).

## Publish
- After merge, push tag `router-v0.1.2` to trigger `publish_npm.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)