### PR TITLE
ci(publish): fix unresolvable actions/setup-node SHA

### DIFF
--- a/.github/workflows/publish_npm.yml
+++ b/.github/workflows/publish_npm.yml
@@ -43,7 +43,7 @@ jobs:
         # (actions/setup-node#1477). v4/v5 unconditionally write
         # `//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}` into .npmrc,
         # which short-circuits the OIDC code path and 401s at publish.
-        uses: actions/setup-node@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           # Node 24 ships with npm ≥ 11.5, which is the minimum that supports
           # OIDC trusted publishing. Node 20 (npm 10) would 401 at publish.


### PR DESCRIPTION
## Summary
- `actions/setup-node@de0fac…` doesn't exist — caused the `router-v0.1.2` publish to fail at action resolution.
- Repins to the real v6.4.0 SHA so the next tag publish actually runs.

## After merge
- Delete and recreate the `router-v0.1.2` tag on the new main tip to re-trigger the publish workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)