### PR TITLE
fix(billing): default to billing-enabled when boot health check errors

### DIFF
--- a/cmd/router/main.go
+++ b/cmd/router/main.go
@@ -132,10 +132,12 @@ func main() {
 	// every inbound request carrying Anthropic credentials.
 	anthropicPassthroughEligible := false
 
-	// Credit billing service: wired only in managed mode and only when the
-	// router-schema billing tables exist. The boot-time health check
-	// provides a safe rollback path — drop the tables and restart the
-	// router to disable billing without code changes. Self-hosted
+	// Credit billing service: wired by default in managed mode. The
+	// boot-time health check exists only to surface the "tables actually
+	// missing" rollback path — if the check errors (timeout, transient
+	// pool unreadiness on a cold replica), we default to billing-enabled
+	// rather than silently falling into BYOK-only mode, which would 400
+	// every request for "no provider keys available". Self-hosted
 	// deployments never wire billing.
 	var billingSvc *billing.Service
 	if deploymentMode == server.DeploymentModeManaged {
@@ -145,7 +147,8 @@ func main() {
 		bootCancel()
 		switch {
 		case billingCheckErr != nil:
-			logger.Warn("Boot billing health check failed; staying in BYOK-only mode", "err", billingCheckErr)
+			logger.Warn("Boot billing health check errored; defaulting to billing-enabled in managed mode", "err", billingCheckErr)
+			billingSvc = billing.NewService(billingRepo)
 		case !tablesExist:
 			logger.Warn("Billing tables missing from router schema; staying in BYOK-only mode. Apply db migration 0006_credit_billing to enable billing.")
 		default:


### PR DESCRIPTION
## Summary
- Managed-mode router was falling into BYOK-only mode on cold replicas because the 5s boot \`billingTablesExist\` check timed out before the pgx pool warmed.
- BYOK-only with no inbound BYOK key returns \`EnabledProviders={}\`, which the cluster scorer maps to \`ErrNoEligibleProvider\` → HTTP 400 \`"no provider keys available for any deployed model"\`.
- Production prod logs (workweave-prod-01) show this on every new instance: \`Boot billing health check failed; staying in BYOK-only mode err="context deadline exceeded"\`.
- Tables actually exist in prod (verified). The check is supposed to be a rollback escape hatch, not a fail-closed gate.

## Fix
- \`check errored\` → assume billing-enabled (the safe default in managed mode).
- \`check returned !tablesExist\` → still stays BYOK-only (rollback path preserved).

## Test plan
- [ ] Unit/integration: existing tests pass
- [ ] Manual prod check after deploy: \`router-internal/router/cmd/router/main.go\` boot log shows \`Boot billing health check errored; defaulting to billing-enabled\` OR \`Router billing enabled\`, never \`staying in BYOK-only mode\`
- [ ] \`npx @workweave/router\` install + a real \`/v1/messages\` request no longer 400s with the no-provider-keys error

🤖 Generated with [Claude Code](https://claude.com/claude-code)