### PR TITLE
fix(translate): gate OpenRouter hints on resolved target provider

### DIFF
--- a/internal/proxy/gemini.go
+++ b/internal/proxy/gemini.go
@@ -132,6 +132,7 @@ func (s *Service) ProxyGeminiGenerateContent(ctx context.Context, body []byte, w
 
 	opts := translate.EmitOptions{
 		TargetModel:        decision.Model,
+		TargetProvider:     decision.Provider,
 		Capabilities:       router.Lookup(decision.Model),
 		IncludeStreamUsage: s.usageRequired(),
 	}

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -765,6 +765,7 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 
 	opts := translate.EmitOptions{
 		TargetModel:        decision.Model,
+		TargetProvider:     decision.Provider,
 		Capabilities:       router.Lookup(decision.Model),
 		IncludeStreamUsage: s.usageRequired(),
 	}
@@ -1520,6 +1521,7 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 
 	opts := translate.EmitOptions{
 		TargetModel:        decision.Model,
+		TargetProvider:     decision.Provider,
 		Capabilities:       router.Lookup(decision.Model),
 		IncludeStreamUsage: s.usageRequired(),
 	}

--- a/internal/translate/emit_openai.go
+++ b/internal/translate/emit_openai.go
@@ -37,33 +37,49 @@ func (e *RequestEnvelope) buildOpenAIFromOpenAI(opts EmitOptions) ([]byte, error
 	if err != nil {
 		return nil, err
 	}
-	if hint := openRouterProviderHint(opts.TargetModel); hint != nil {
-		body, err = sjson.SetBytes(body, "provider", hint)
-		if err != nil {
-			return nil, fmt.Errorf("set openrouter provider hint: %w", err)
+	if targetIsOpenRouter(opts) {
+		if hint := openRouterProviderHint(opts.TargetModel); hint != nil {
+			body, err = sjson.SetBytes(body, "provider", hint)
+			if err != nil {
+				return nil, fmt.Errorf("set openrouter provider hint: %w", err)
+			}
 		}
-	}
-	if reasoning := openRouterReasoningHint(opts.TargetModel); reasoning != nil {
-		body, err = sjson.SetBytes(body, "reasoning", reasoning)
-		if err != nil {
-			return nil, fmt.Errorf("set openrouter reasoning hint: %w", err)
+		if reasoning := openRouterReasoningHint(opts.TargetModel); reasoning != nil {
+			body, err = sjson.SetBytes(body, "reasoning", reasoning)
+			if err != nil {
+				return nil, fmt.Errorf("set openrouter reasoning hint: %w", err)
+			}
 		}
-	}
-	if reminder := openRouterSystemReminder(opts.TargetModel); reminder != "" && gjson.GetBytes(body, "tools").Exists() {
-		body, err = applySystemReminderToBody(body, reminder)
-		if err != nil {
-			return nil, fmt.Errorf("set system reminder: %w", err)
+		if reminder := openRouterSystemReminder(opts.TargetModel); reminder != "" && gjson.GetBytes(body, "tools").Exists() {
+			body, err = applySystemReminderToBody(body, reminder)
+			if err != nil {
+				return nil, fmt.Errorf("set system reminder: %w", err)
+			}
 		}
-	}
-	if openRouterForcesToolTemperatureZero(opts.TargetModel) &&
-		gjson.GetBytes(body, "tools").Exists() &&
-		!gjson.GetBytes(body, "temperature").Exists() {
-		body, err = sjson.SetBytes(body, "temperature", 0)
-		if err != nil {
-			return nil, fmt.Errorf("set tool temperature override: %w", err)
+		if openRouterForcesToolTemperatureZero(opts.TargetModel) &&
+			gjson.GetBytes(body, "tools").Exists() &&
+			!gjson.GetBytes(body, "temperature").Exists() {
+			body, err = sjson.SetBytes(body, "temperature", 0)
+			if err != nil {
+				return nil, fmt.Errorf("set tool temperature override: %w", err)
+			}
 		}
 	}
 	return body, nil
+}
+
+// targetIsOpenRouter reports whether the emit target is the OpenRouter
+// upstream. OpenRouter-specific body fields (`provider`, `reasoning`),
+// system reminders, and tool-turn temperature overrides only belong on
+// the OpenRouter wire; direct upstreams (Fireworks/DeepInfra/Bedrock)
+// reject them. Empty TargetProvider falls back to the model-slug match
+// so the historical single-binding behavior keeps working for callers
+// that haven't been plumbed through yet (the handover summarizer).
+func targetIsOpenRouter(opts EmitOptions) bool {
+	if opts.TargetProvider != "" {
+		return opts.TargetProvider == providers.ProviderOpenRouter
+	}
+	return true
 }
 
 func (e *RequestEnvelope) buildOpenAIFromAnthropic(opts EmitOptions) ([]byte, error) {
@@ -92,7 +108,7 @@ func (e *RequestEnvelope) buildOpenAIFromAnthropic(opts EmitOptions) ([]byte, er
 			}
 		}
 	}
-	if !clientSetTemp && openRouterForcesToolTemperatureZero(opts.TargetModel) {
+	if !clientSetTemp && targetIsOpenRouter(opts) && openRouterForcesToolTemperatureZero(opts.TargetModel) {
 		if _, hasTools := out["tools"]; hasTools {
 			out["temperature"] = 0
 		}
@@ -115,16 +131,18 @@ func (e *RequestEnvelope) buildOpenAIFromAnthropic(opts EmitOptions) ([]byte, er
 		injectStreamUsageOption(out)
 	}
 
-	if hint := openRouterProviderHint(opts.TargetModel); hint != nil {
-		out["provider"] = hint
-	}
-	if reasoning := openRouterReasoningHint(opts.TargetModel); reasoning != nil {
-		out["reasoning"] = reasoning
-	}
-	if reminder := openRouterSystemReminder(opts.TargetModel); reminder != "" {
-		if _, hasTools := out["tools"]; hasTools {
-			msgs, _ := out["messages"].([]any)
-			out["messages"] = injectSystemReminder(msgs, reminder)
+	if targetIsOpenRouter(opts) {
+		if hint := openRouterProviderHint(opts.TargetModel); hint != nil {
+			out["provider"] = hint
+		}
+		if reasoning := openRouterReasoningHint(opts.TargetModel); reasoning != nil {
+			out["reasoning"] = reasoning
+		}
+		if reminder := openRouterSystemReminder(opts.TargetModel); reminder != "" {
+			if _, hasTools := out["tools"]; hasTools {
+				msgs, _ := out["messages"].([]any)
+				out["messages"] = injectSystemReminder(msgs, reminder)
+			}
 		}
 	}
 

--- a/internal/translate/envelope.go
+++ b/internal/translate/envelope.go
@@ -31,7 +31,17 @@ const (
 
 // EmitOptions parameterizes output-body construction.
 type EmitOptions struct {
-	TargetModel        string
+	TargetModel string
+	// TargetProvider is the resolved upstream provider name (the
+	// providers.Provider* constant, e.g. "openrouter", "fireworks",
+	// "deepinfra", "bedrock"). OpenAI-compat emission keys provider-
+	// specific hints (the OpenRouter `provider`/`reasoning` body fields,
+	// tool-turn temperature override, system reminders) on this so the
+	// same model slug routed to a non-OpenRouter binding (post SOC 2
+	// isolation) doesn't carry OpenRouter-only fields the direct upstream
+	// rejects with 400. Empty falls back to model-slug behavior for
+	// callers that don't plumb a provider through yet (handover summary).
+	TargetProvider     string
 	Capabilities       router.ModelSpec
 	IncludeStreamUsage bool
 }

--- a/internal/translate/provider_hint_test.go
+++ b/internal/translate/provider_hint_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"testing"
 
+	"workweave/router/internal/providers"
 	"workweave/router/internal/router"
 	"workweave/router/internal/translate"
 
@@ -143,6 +144,71 @@ func TestPrepareOpenAI_NoReasoningOverrideForNonDeepSeek(t *testing.T) {
 				"non-deepseek targets must not get a reasoning override")
 		})
 	}
+}
+
+// SOC 2 isolation routes deepseek/moonshotai/qwen slugs to direct
+// upstreams (Fireworks/DeepInfra/Bedrock) where the OpenRouter-only
+// `provider` and `reasoning` body fields cause a 400. The emit path
+// must gate those fields on the resolved target provider.
+func TestPrepareOpenAI_AnthropicSource_SkipsHintsForNonOpenRouterProvider(t *testing.T) {
+	src := []byte(`{"model":"claude-opus-4-7","messages":[{"role":"user","content":"hi"}],"max_tokens":256}`)
+	cases := []struct {
+		name     string
+		target   string
+		provider string
+	}{
+		{"fireworks dispatches deepseek", "deepseek/deepseek-v4-pro", providers.ProviderFireworks},
+		{"deepinfra dispatches deepseek", "deepseek/deepseek-v4-flash", providers.ProviderDeepInfra},
+		{"bedrock dispatches moonshotai", "moonshotai/kimi-k2.5", providers.ProviderBedrock},
+		{"bedrock dispatches qwen", "qwen/qwen3-coder-next", providers.ProviderBedrock},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			env, err := translate.ParseAnthropic(src)
+			require.NoError(t, err)
+
+			out, err := env.PrepareOpenAI(nil, translate.EmitOptions{
+				TargetModel:    tc.target,
+				TargetProvider: tc.provider,
+			})
+			require.NoError(t, err)
+
+			assert.Nil(t, providerField(t, out.Body),
+				"%s must not receive OpenRouter `provider` hint", tc.provider)
+			assert.Nil(t, reasoningField(t, out.Body),
+				"%s must not receive OpenRouter `reasoning` hint", tc.provider)
+		})
+	}
+}
+
+func TestPrepareOpenAI_OpenAISource_SkipsHintsForNonOpenRouterProvider(t *testing.T) {
+	src := []byte(`{"model":"x","messages":[{"role":"user","content":"hi"}],"max_tokens":256}`)
+	env, err := translate.ParseOpenAI(src)
+	require.NoError(t, err)
+
+	out, err := env.PrepareOpenAI(nil, translate.EmitOptions{
+		TargetModel:    "deepseek/deepseek-v4-pro",
+		TargetProvider: providers.ProviderFireworks,
+	})
+	require.NoError(t, err)
+
+	assert.Nil(t, providerField(t, out.Body))
+	assert.Nil(t, reasoningField(t, out.Body))
+}
+
+func TestPrepareOpenAI_ExplicitOpenRouterProviderStillGetsHints(t *testing.T) {
+	src := []byte(`{"model":"claude-opus-4-7","messages":[{"role":"user","content":"hi"}],"max_tokens":256}`)
+	env, err := translate.ParseAnthropic(src)
+	require.NoError(t, err)
+
+	out, err := env.PrepareOpenAI(nil, translate.EmitOptions{
+		TargetModel:    "deepseek/deepseek-v4-pro",
+		TargetProvider: providers.ProviderOpenRouter,
+	})
+	require.NoError(t, err)
+
+	require.NotNil(t, providerField(t, out.Body))
+	require.NotNil(t, reasoningField(t, out.Body))
 }
 
 func TestPrepareOpenAI_QwenAndGoogleGetSortHint(t *testing.T) {


### PR DESCRIPTION
## Summary

Live prod test against `router.workweave.ai` with the SOC 2 isolation PR (#187) merged surfaced a 400 from Fireworks on every dispatch to `deepseek/deepseek-v4-pro`:

```
{"error":{"message":"2 request validation errors:
   Extra inputs are not permitted, field: 'provider';
   Extra inputs are not permitted, field: 'reasoning'","type":"invalid_request_error"}}
```

Root cause: `internal/translate/emit_openai.go` was applying OpenRouter-only body fields (`provider` routing hint, `reasoning: {enabled:false}`, system reminder injection, tool-turn temperature override) on **model slug** alone. That was correct while `deepseek/`, `moonshotai/`, and `qwen/` slugs always meant OpenRouter. After the SOC 2 flip the same slugs dispatch to Fireworks / DeepInfra / Bedrock too, and those upstreams reject the OpenRouter-only fields.

## Fix

- Add `TargetProvider` to `translate.EmitOptions`.
- New helper `targetIsOpenRouter(opts)` gates all four OpenRouter-specific emissions in `buildOpenAIFromOpenAI` and `buildOpenAIFromAnthropic`.
- `proxy.Service` plumbs `decision.Provider` through at every `PrepareOpenAI` call site (Anthropic surface, OpenAI surface, Gemini cross-format).
- Empty `TargetProvider` falls back to the previous slug-only behavior so the handover summary path (no provider context yet) keeps working unchanged.

## Test plan

- [x] `go test -tags no_onnx ./...` — all green
- [x] New tests cover Fireworks / DeepInfra / Bedrock for the deepseek / moonshotai / qwen slugs (no hints emitted) plus an explicit-OpenRouter case (hints still fire)
- [ ] Smoke re-test against prod after merge + gitlink bump: send a tool-using `claude-opus-4-7` request and confirm Fireworks returns 200 for `deepseek-v4-pro`

🤖 Generated with [Claude Code](https://claude.com/claude-code)