### PR TITLE
fix(proxy): dispatch DeepInfra and Bedrock decisions through openaicompat

### DIFF
--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -798,7 +798,7 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 			proxyWriter = extractor
 		}
 		proxyErr = p.Proxy(ctx, decision, prep, proxyWriter, r)
-	case providers.ProviderOpenAI, providers.ProviderOpenRouter, providers.ProviderFireworks:
+	case providers.ProviderOpenAI, providers.ProviderOpenRouter, providers.ProviderFireworks, providers.ProviderDeepInfra, providers.ProviderBedrock:
 		crossFormat = true
 		prep, emitErr := env.PrepareOpenAI(r.Header, opts)
 		if emitErr != nil {
@@ -1541,7 +1541,7 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 	var extractor *otel.UsageExtractor
 
 	switch decision.Provider {
-	case providers.ProviderOpenAI, providers.ProviderOpenRouter, providers.ProviderFireworks:
+	case providers.ProviderOpenAI, providers.ProviderOpenRouter, providers.ProviderFireworks, providers.ProviderDeepInfra, providers.ProviderBedrock:
 		prep, emitErr := env.PrepareOpenAI(r.Header, opts)
 		if emitErr != nil {
 			log.Error("Failed to emit OpenAI body", "err", emitErr)

--- a/internal/proxy/service_test.go
+++ b/internal/proxy/service_test.go
@@ -436,6 +436,76 @@ func TestService_ProxyOpenAIChatCompletion_NativeOpenRouter(t *testing.T) {
 	assert.Contains(t, rec.Body.String(), `"chat.completion"`)
 }
 
+// SOC 2 isolation adds DeepInfra and Bedrock as direct providers
+// served by the openaicompat client. Both surfaces must route those
+// decisions through the OpenAI-emission case rather than the default
+// "no translation path" branch; otherwise the scorer's argmax silently
+// 502s for every prompt that lands on them.
+func TestService_ProxyMessages_DispatchesDeepInfraAndBedrock(t *testing.T) {
+	cases := []struct {
+		name     string
+		provider string
+		model    string
+	}{
+		{"deepinfra", providers.ProviderDeepInfra, "deepseek/deepseek-v4-flash"},
+		{"bedrock", providers.ProviderBedrock, "moonshotai/kimi-k2.5"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			p := &fakeProvider{
+				proxyResponse: func(w http.ResponseWriter) {
+					w.Header().Set("Content-Type", "application/json")
+					w.WriteHeader(http.StatusOK)
+					_, _ = io.WriteString(w, `{"id":"chatcmpl-1","object":"chat.completion","choices":[{"message":{"role":"assistant","content":"ok"}}]}`)
+				},
+			}
+			svc := makeProxyService(
+				router.Decision{Provider: tc.provider, Model: tc.model, Reason: "test"},
+				map[string]providers.Client{tc.provider: p},
+			)
+			// Tools present + opus requested keeps the turn out of the
+			// classifier-hard-pin path so the test exercises the
+			// switch we just widened, not the hard-pin fallback.
+			body := []byte(`{"model":"claude-opus-4-7","max_tokens":16,"tools":[{"name":"calc","description":"add","input_schema":{"type":"object","properties":{"a":{"type":"integer"},"b":{"type":"integer"}},"required":["a","b"]}}],"messages":[{"role":"user","content":"What is 7+5? Use calc."}]}`)
+			rec := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(string(body)))
+			require.NoError(t, svc.ProxyMessages(context.Background(), body, rec, req))
+			require.Len(t, p.proxyBodies, 1, "%s must reach the upstream", tc.provider)
+		})
+	}
+}
+
+func TestService_ProxyOpenAIChatCompletion_DispatchesDeepInfraAndBedrock(t *testing.T) {
+	cases := []struct {
+		name     string
+		provider string
+		model    string
+	}{
+		{"deepinfra", providers.ProviderDeepInfra, "deepseek/deepseek-v4-flash"},
+		{"bedrock", providers.ProviderBedrock, "qwen/qwen3-coder-next"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			p := &fakeProvider{
+				proxyResponse: func(w http.ResponseWriter) {
+					w.Header().Set("Content-Type", "application/json")
+					w.WriteHeader(http.StatusOK)
+					_, _ = io.WriteString(w, `{"id":"chatcmpl-1","object":"chat.completion"}`)
+				},
+			}
+			svc := makeProxyService(
+				router.Decision{Provider: tc.provider, Model: tc.model, Reason: "test"},
+				map[string]providers.Client{tc.provider: p},
+			)
+			body := `{"model":"gpt-4o","messages":[{"role":"user","content":"hi"}]}`
+			rec := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(body))
+			require.NoError(t, svc.ProxyOpenAIChatCompletion(context.Background(), []byte(body), rec, req))
+			require.Len(t, p.proxyBodies, 1, "%s must reach the upstream", tc.provider)
+		})
+	}
+}
+
 // TestService_WithByokOnly_FiltersUnauthedProvidersFromScorer: with
 // WithByokOnly(true), registered providers must not appear in EnabledProviders
 // without per-request credentials, or argmax routes to the platform key and 402s.


### PR DESCRIPTION
## Summary

Live prod sweep after the openrouter-hints fix (#190) merged surfaced a second SOC 2-isolation gap: every routing decision landing on DeepInfra or Bedrock fell through the default case of `proxy.Service`'s provider switch and synthesized `ErrProviderNotConfigured`. The Anthropic handler's catch-all then mapped that to a generic *"upstream call failed"* (HTTP 502), so the symptom looked like an upstream outage but the proxy never actually dispatched.

The OpenAI surface had a more honest error: *"provider not configured: deepinfra (no translation path defined)"*.

DeepInfra and Bedrock are both served by the openaicompat client (same wire as OpenRouter and Fireworks), so they belong in the OpenAI-emission case of both `ProxyMessages` and `ProxyOpenAIChatCompletion`. Two-line change:

```go
- case providers.ProviderOpenAI, providers.ProviderOpenRouter, providers.ProviderFireworks:
+ case providers.ProviderOpenAI, providers.ProviderOpenRouter, providers.ProviderFireworks, providers.ProviderDeepInfra, providers.ProviderBedrock:
```

## Test plan

- [x] `go test -tags no_onnx ./...` — all green
- [x] New tests cover Anthropic→openaicompat cross-format dispatch for both DeepInfra (deepseek-v4-flash) and Bedrock (kimi-k2.5 / qwen3-coder-next), plus the native OpenAI surface path
- [x] Anthropic-side cases ride a tool-using turn so they skirt classifier-hard-pin and actually exercise the widened switch
- [ ] After merge + gitlink bump, re-run the live prod sweep: every OSS-model dispatch should reach the upstream (200 or upstream-rejection, never the proxy's `ErrProviderNotConfigured` synthetic 502)

🤖 Generated with [Claude Code](https://claude.com/claude-code)