### PR TITLE
feat(identity): X-Weave-User-Email and X-Weave-User-Name headers

### DIFF
--- a/db/migrations/0007_user_display_name.down.sql
+++ b/db/migrations/0007_user_display_name.down.sql
@@ -1,0 +1,6 @@
+BEGIN;
+
+ALTER TABLE router.model_router_users
+  DROP COLUMN display_name;
+
+COMMIT;

--- a/db/migrations/0007_user_display_name.up.sql
+++ b/db/migrations/0007_user_display_name.up.sql
@@ -1,0 +1,13 @@
+BEGIN;
+
+-- Adds a free-form display name to router users so the Weave dashboard can
+-- render a human-readable label even when email is NULL (Claude CLI versions
+-- that ship only account_uuid in metadata.user_id). Sourced from the
+-- X-Weave-User-Name header that the installer plants from git user.name.
+ALTER TABLE router.model_router_users
+  ADD COLUMN display_name TEXT;
+
+COMMENT ON COLUMN router.model_router_users.display_name IS
+  'Free-form user display name (typically git user.name) carried on the X-Weave-User-Name request header. Nullable: requests without the header leave the column NULL; existing rows are not back-filled.';
+
+COMMIT;

--- a/db/queries/model_router_users.sql
+++ b/db/queries/model_router_users.sql
@@ -1,22 +1,26 @@
 -- Upserts an end-user identity keyed on (installation_id, email), refreshing
--- last_seen_at on every hit. claude_account_uuid is overwritten only when
--- the new value is non-NULL so a request from a non-Claude-Code client
--- can't blank out the field. Returns the row so the caller can stash
--- user_id on the request context.
+-- last_seen_at on every hit. claude_account_uuid and display_name are
+-- overwritten only when the new value is non-NULL so a request from a
+-- non-Claude-Code client (or one that omits the X-Weave-User-Name header)
+-- can't blank out fields populated by earlier requests. Returns the row so
+-- the caller can stash user_id on the request context.
 -- name: UpsertModelRouterUserByEmail :one
 INSERT INTO router.model_router_users (
     installation_id,
     email,
-    claude_account_uuid
+    claude_account_uuid,
+    display_name
 )
 VALUES (
     @installation_id::uuid,
     @email::text,
-    sqlc.narg('claude_account_uuid')::uuid
+    sqlc.narg('claude_account_uuid')::uuid,
+    sqlc.narg('display_name')::text
 )
 ON CONFLICT (installation_id, email) WHERE deleted_at IS NULL DO UPDATE SET
     last_seen_at        = CURRENT_TIMESTAMP,
-    claude_account_uuid = COALESCE(EXCLUDED.claude_account_uuid, router.model_router_users.claude_account_uuid)
+    claude_account_uuid = COALESCE(EXCLUDED.claude_account_uuid, router.model_router_users.claude_account_uuid),
+    display_name        = COALESCE(EXCLUDED.display_name, router.model_router_users.display_name)
 RETURNING *;
 
 -- Upserts an end-user identity keyed on (installation_id, claude_account_uuid)
@@ -30,16 +34,20 @@ RETURNING *;
 INSERT INTO router.model_router_users (
     installation_id,
     email,
-    claude_account_uuid
+    claude_account_uuid,
+    display_name
 )
 VALUES (
     @installation_id::uuid,
     NULL,
-    @claude_account_uuid::uuid
+    @claude_account_uuid::uuid,
+    sqlc.narg('display_name')::text
 )
 ON CONFLICT (installation_id, claude_account_uuid)
   WHERE email IS NULL AND claude_account_uuid IS NOT NULL AND deleted_at IS NULL
-DO UPDATE SET last_seen_at = CURRENT_TIMESTAMP
+DO UPDATE SET
+    last_seen_at = CURRENT_TIMESTAMP,
+    display_name = COALESCE(EXCLUDED.display_name, router.model_router_users.display_name)
 RETURNING *;
 
 -- Single-row read by id; returns sql.ErrNoRows when missing or soft-deleted.

--- a/install/install.sh
+++ b/install/install.sh
@@ -207,6 +207,130 @@ refuse_if_symlink() {
   fi
 }
 
+# ---------- identity helpers ----------
+#
+# The router parses X-Weave-User-Email and X-Weave-User-Name on every protocol
+# (Anthropic, OpenAI, Gemini) and persists them onto router.model_router_users
+# so customers can attribute traffic to a person even when many people share
+# one API key. Claude Code's metadata.user_id carries only account_uuid (no
+# email), so without these headers the router only ever sees anonymous UUIDs.
+
+# normalize_email mirrors the router's proxy.NormalizeEmail: trim, lowercase,
+# enforce a single '@' with non-empty local + domain parts, and cap at 254
+# chars (RFC 5321). Returns the cleaned address on stdout, or empty string if
+# the input is missing or malformed. We validate locally so the installer
+# never plants a header value the router would silently drop, and so a
+# typo'd git config doesn't end up as a per-request identity claim.
+normalize_email() {
+  local raw="${1:-}"
+  # Trim whitespace then lowercase. tr is POSIX; the [:upper:]/[:lower:] form
+  # works on both macOS (BSD) and Linux (GNU) without needing LANG tweaks.
+  local trimmed="${raw#"${raw%%[![:space:]]*}"}"
+  trimmed="${trimmed%"${trimmed##*[![:space:]]}"}"
+  local lowered
+  lowered="$(printf '%s' "$trimmed" | tr '[:upper:]' '[:lower:]')"
+  if [ -z "$lowered" ] || [ "${#lowered}" -gt 254 ]; then
+    printf ''
+    return
+  fi
+  case "$lowered" in
+    *@*@*) printf ''; return ;;
+    @*|*@) printf ''; return ;;
+    *@*)   printf '%s' "$lowered" ;;
+    *)     printf '' ;;
+  esac
+}
+
+# normalize_name trims whitespace, rejects empty/oversized, and strips control
+# chars + the colon/CR/LF chars HTTP forbids in header values. Display names
+# are free-form so we don't case-fold; we just keep the header well-formed.
+normalize_name() {
+  local raw="${1:-}"
+  local trimmed="${raw#"${raw%%[![:space:]]*}"}"
+  trimmed="${trimmed%"${trimmed##*[![:space:]]}"}"
+  # Drop CR/LF/colon (header smuggling) and other control chars. tr's -d
+  # with a character class is portable across BSD/GNU.
+  local cleaned
+  cleaned="$(printf '%s' "$trimmed" | tr -d '\r\n:' | tr -d '[:cntrl:]')"
+  if [ -z "$cleaned" ] || [ "${#cleaned}" -gt 128 ]; then
+    printf ''
+    return
+  fi
+  printf '%s' "$cleaned"
+}
+
+# resolve_user_email picks the email to plant in router request headers so the
+# router can attribute traffic to a person even on shared API keys. Priority:
+# WEAVE_USER_EMAIL env override -> git config user.email -> interactive prompt
+# (pre-filled with whatever we found). In --non-interactive mode we never
+# prompt, so unset/invalid means we ship no header (router treats that as
+# account_uuid-only, same as today). Echoes the validated email on stdout.
+resolve_user_email() {
+  local candidate=""
+  if [ -n "${WEAVE_USER_EMAIL:-}" ]; then
+    candidate="$(normalize_email "$WEAVE_USER_EMAIL")"
+    if [ -z "$candidate" ]; then
+      warn "WEAVE_USER_EMAIL=\"$WEAVE_USER_EMAIL\" is not a valid email; ignoring."
+    fi
+  fi
+  if [ -z "$candidate" ]; then
+    local git_email
+    git_email="$(git config --global user.email 2>/dev/null || true)"
+    candidate="$(normalize_email "$git_email")"
+  fi
+  if [ "$non_interactive" = "true" ] || [ ! -r /dev/tty ]; then
+    printf '%s' "$candidate"
+    return
+  fi
+  if [ "$quiet" = "true" ]; then
+    printf '%s' "$candidate"
+    return
+  fi
+  local prompt_default="$candidate"
+  local response=""
+  if [ -n "$prompt_default" ]; then
+    printf "%sIdentify router traffic as %s[%s]%s (Enter to accept, '-' to skip): " \
+      "$C_DIM" "$C_BOLD" "$prompt_default" "$C_RESET" >/dev/tty
+  else
+    printf "%sEmail to identify your router traffic (blank to skip): %s" \
+      "$C_DIM" "$C_RESET" >/dev/tty
+  fi
+  read -r response </dev/tty || response=""
+  case "$response" in
+    "")   printf '%s' "$prompt_default" ;;
+    "-")  printf '' ;;
+    *)
+      local cleaned
+      cleaned="$(normalize_email "$response")"
+      if [ -z "$cleaned" ]; then
+        warn "\"$response\" is not a valid email; skipping identity header."
+      fi
+      printf '%s' "$cleaned"
+      ;;
+  esac
+}
+
+# resolve_user_name mirrors resolve_user_email but for display name. Priority:
+# WEAVE_USER_NAME env override -> git config user.name -> empty. We don't
+# prompt for name independently: if email prompting yielded nothing, name
+# almost certainly will too, and a second prompt is noise. Echoes the
+# validated name on stdout.
+resolve_user_name() {
+  local candidate=""
+  if [ -n "${WEAVE_USER_NAME:-}" ]; then
+    candidate="$(normalize_name "$WEAVE_USER_NAME")"
+    if [ -z "$candidate" ]; then
+      warn "WEAVE_USER_NAME=\"$WEAVE_USER_NAME\" is not a usable name; ignoring."
+    fi
+  fi
+  if [ -z "$candidate" ]; then
+    local git_name
+    git_name="$(git config --global user.name 2>/dev/null || true)"
+    candidate="$(normalize_name "$git_name")"
+  fi
+  printf '%s' "$candidate"
+}
+
 # ---------- uninstall delegation ----------
 #
 # `--uninstall` flips this script into a thin shim for uninstall.sh: the
@@ -452,6 +576,25 @@ if [ -n "${WEAVE_ROUTER_KEY:-}" ]; then
     printf "\n"
     [ -n "$api_key" ] || { err "no key provided"; exit 1; }
   fi
+
+# ---------- identity (user email + name) ----------
+#
+# Resolved after api_key so the prompt sequence reads naturally: key first,
+# then "who are you?". Both end up as request headers the router parses on
+# every protocol so customers can link router users to Weave accounts on the
+# dashboard. Empty values = no header (router stays in account_uuid-only
+# mode), so existing behavior is preserved when git config is unset.
+user_email="$(resolve_user_email)"
+user_name="$(resolve_user_name)"
+if [ -n "$user_email" ] && [ -n "$user_name" ]; then
+  ok "Will identify router traffic as $user_name <$user_email>"
+elif [ -n "$user_email" ]; then
+  ok "Will identify router traffic as $user_email"
+elif [ -n "$user_name" ]; then
+  ok "Will identify router traffic as $user_name"
+else
+  info "No identity set — router traffic will be attributed by account UUID only."
+fi
 
 # ---------- write the statusline script ----------
 
@@ -831,13 +974,26 @@ tmp_patch="$(mktemp)"
 # leave the cursor hidden if Ctrl-C lands during settings.json patching.
 trap '_spin_cleanup; rm -f "$tmp_patch"' EXIT INT TERM HUP
 
+# Claude Code splits ANTHROPIC_CUSTOM_HEADERS on newlines, so multiple headers
+# ride in the same env var separated by \n. Append identity headers alongside
+# the router key so a single var carries them all. When email/name are empty
+# we keep the bare router-key form so a re-install for a user who opted out
+# cleanly removes the old line.
+custom_headers="$router_key_header: $api_key"
+if [ -n "$user_email" ]; then
+  custom_headers="$custom_headers"$'\n'"X-Weave-User-Email: $user_email"
+fi
+if [ -n "$user_name" ]; then
+  custom_headers="$custom_headers"$'\n'"X-Weave-User-Name: $user_name"
+fi
+
 if [ "$scope" = "project" ] && [ -z "$install_dir" ]; then
   jq -n --arg url "$base_url" --arg sl "$statusline_path_for_settings" '{
     env: { ANTHROPIC_BASE_URL: $url },
     statusLine: { type: "command", command: $sl }
   }' >"$tmp_patch"
 else
-  jq -n --arg url "$base_url" --arg header "$router_key_header: $api_key" --arg sl "$statusline_path_for_settings" '{
+  jq -n --arg url "$base_url" --arg header "$custom_headers" --arg sl "$statusline_path_for_settings" '{
     env: { ANTHROPIC_BASE_URL: $url, ANTHROPIC_CUSTOM_HEADERS: $header },
     statusLine: { type: "command", command: $sl }
   }' >"$tmp_patch"
@@ -863,7 +1019,7 @@ fi
 ok "Settings written to $settings_file"
 
 if [ "$scope" = "project" ] && [ -z "$install_dir" ]; then
-  jq -n --arg header "$router_key_header: $api_key" '{
+  jq -n --arg header "$custom_headers" '{
     env: { ANTHROPIC_CUSTOM_HEADERS: $header }
   }' >"$tmp_patch"
   if [ -f "$local_settings_file" ]; then

--- a/internal/api/anthropic/messages.go
+++ b/internal/api/anthropic/messages.go
@@ -127,13 +127,15 @@ func stashClientIdentity(ctx context.Context, h http.Header, body []byte) contex
 	if email == "" {
 		email = proxy.NormalizeEmail(h.Get("X-Weave-User-Email"))
 	}
+	displayName := proxy.NormalizeDisplayName(h.Get("X-Weave-User-Name"))
 	id := proxy.ClientIdentity{
-		DeviceID:  proxy.NormalizeClientIdentifier(meta.DeviceID),
-		AccountID: proxy.NormalizeClientIdentifier(meta.AccountID),
-		SessionID: proxy.NormalizeClientIdentifier(sessionID),
-		Email:     email,
-		UserAgent: h.Get("User-Agent"),
-		ClientApp: h.Get("X-App"),
+		DeviceID:    proxy.NormalizeClientIdentifier(meta.DeviceID),
+		AccountID:   proxy.NormalizeClientIdentifier(meta.AccountID),
+		SessionID:   proxy.NormalizeClientIdentifier(sessionID),
+		Email:       email,
+		DisplayName: displayName,
+		UserAgent:   h.Get("User-Agent"),
+		ClientApp:   h.Get("X-App"),
 	}
 	observability.Get().Debug("anthropic stashClientIdentity",
 		"meta_raw_len", len(metaRaw),
@@ -144,7 +146,9 @@ func stashClientIdentity(ctx context.Context, h http.Header, body []byte) contex
 		"parsed_account_len", len(meta.AccountID),
 		"final_email_present", id.Email != "",
 		"final_account_present", id.AccountID != "",
+		"final_name_present", id.DisplayName != "",
 		"header_email_present", h.Get("X-Weave-User-Email") != "",
+		"header_name_present", h.Get("X-Weave-User-Name") != "",
 	)
 	return context.WithValue(ctx, proxy.ClientIdentityContextKey{}, id)
 }

--- a/internal/api/gemini/generate_content.go
+++ b/internal/api/gemini/generate_content.go
@@ -142,10 +142,11 @@ func injectModelAndStream(body []byte, model string, stream bool) ([]byte, error
 
 func stashClientIdentity(ctx context.Context, h http.Header) context.Context {
 	id := proxy.ClientIdentity{
-		SessionID: proxy.NormalizeClientIdentifier(h.Get("X-Claude-Code-Session-Id")),
-		Email:     proxy.NormalizeEmail(h.Get("X-Weave-User-Email")),
-		UserAgent: h.Get("User-Agent"),
-		ClientApp: h.Get("X-App"),
+		SessionID:   proxy.NormalizeClientIdentifier(h.Get("X-Claude-Code-Session-Id")),
+		Email:       proxy.NormalizeEmail(h.Get("X-Weave-User-Email")),
+		DisplayName: proxy.NormalizeDisplayName(h.Get("X-Weave-User-Name")),
+		UserAgent:   h.Get("User-Agent"),
+		ClientApp:   h.Get("X-App"),
 	}
 	return context.WithValue(ctx, proxy.ClientIdentityContextKey{}, id)
 }

--- a/internal/api/openai/completions.go
+++ b/internal/api/openai/completions.go
@@ -84,10 +84,11 @@ func ChatCompletionHandler(svc *proxy.Service, authSvc *auth.Service) gin.Handle
 
 func stashClientIdentity(ctx context.Context, h http.Header) context.Context {
 	id := proxy.ClientIdentity{
-		SessionID: proxy.NormalizeClientIdentifier(h.Get("X-Claude-Code-Session-Id")),
-		Email:     proxy.NormalizeEmail(h.Get("X-Weave-User-Email")),
-		UserAgent: h.Get("User-Agent"),
-		ClientApp: h.Get("X-App"),
+		SessionID:   proxy.NormalizeClientIdentifier(h.Get("X-Claude-Code-Session-Id")),
+		Email:       proxy.NormalizeEmail(h.Get("X-Weave-User-Email")),
+		DisplayName: proxy.NormalizeDisplayName(h.Get("X-Weave-User-Name")),
+		UserAgent:   h.Get("User-Agent"),
+		ClientApp:   h.Get("X-App"),
 	}
 	return context.WithValue(ctx, proxy.ClientIdentityContextKey{}, id)
 }

--- a/internal/auth/service.go
+++ b/internal/auth/service.go
@@ -284,9 +284,10 @@ func (s *Service) VerifyAPIKey(ctx context.Context, rawToken string) (*Installat
 
 // ResolveAndStashUser upserts a router user and stashes the ID on ctx.
 // Email takes precedence as the lookup key. When only claudeAccountUUID is present,
-// the row is keyed on account_uuid with NULL email.
+// the row is keyed on account_uuid with NULL email. displayName is best-effort
+// metadata persisted alongside the identity; empty = leave existing value.
 // Best-effort: returns ctx unchanged on failure — must never fail an authenticated request.
-func (s *Service) ResolveAndStashUser(ctx context.Context, installationID, email, claudeAccountUUID string) context.Context {
+func (s *Service) ResolveAndStashUser(ctx context.Context, installationID, email, claudeAccountUUID, displayName string) context.Context {
 	log := observability.Get()
 	if s.users == nil || installationID == "" {
 		log.Info("ResolveAndStashUser bailout", "reason", "nil_users_or_empty_inst", "users_nil", s.users == nil, "inst_empty", installationID == "")
@@ -303,7 +304,12 @@ func (s *Service) ResolveAndStashUser(ctx context.Context, installationID, email
 		return context.WithValue(ctx, UserIDContextKey{}, cached)
 	}
 
-	log.Debug("ResolveAndStashUser upsert", "installation_id", installationID, "email_present", email != "", "account_present", claudeAccountUUID != "")
+	var namePtr *string
+	if displayName != "" {
+		namePtr = &displayName
+	}
+
+	log.Debug("ResolveAndStashUser upsert", "installation_id", installationID, "email_present", email != "", "account_present", claudeAccountUUID != "", "name_present", namePtr != nil)
 	var user *User
 	var err error
 	if email != "" {
@@ -315,11 +321,13 @@ func (s *Service) ResolveAndStashUser(ctx context.Context, installationID, email
 			InstallationID:    installationID,
 			Email:             email,
 			ClaudeAccountUUID: accountPtr,
+			DisplayName:       namePtr,
 		})
 	} else {
 		user, err = s.users.UpsertByAccountUUID(ctx, UpsertUserByAccountUUIDParams{
 			InstallationID:    installationID,
 			ClaudeAccountUUID: claudeAccountUUID,
+			DisplayName:       namePtr,
 		})
 	}
 	if err != nil {

--- a/internal/auth/user.go
+++ b/internal/auth/user.go
@@ -20,6 +20,7 @@ type User struct {
 	InstallationID    string
 	Email             string // empty when account-uuid-only
 	ClaudeAccountUUID *string
+	DisplayName       *string // free-form name from X-Weave-User-Name (git user.name)
 	FirstSeenAt       time.Time
 	LastSeenAt        time.Time
 	DeletedAt         *time.Time
@@ -31,12 +32,14 @@ type UpsertUserParams struct {
 	InstallationID    string
 	Email             string
 	ClaudeAccountUUID *string
+	DisplayName       *string
 }
 
 // UpsertUserByAccountUUIDParams is the input to UserRepository.UpsertByAccountUUID.
 type UpsertUserByAccountUUIDParams struct {
 	InstallationID    string
 	ClaudeAccountUUID string
+	DisplayName       *string
 }
 
 // UserRepository is the data-access port for end-user identities.

--- a/internal/auth/user_test.go
+++ b/internal/auth/user_test.go
@@ -66,7 +66,7 @@ func TestResolveAndStashUser_UpsertsAndStashesID(t *testing.T) {
 	repo := &fakeUserRepo{user: &auth.User{ID: "user-42", InstallationID: "inst-1", Email: "alice@example.com"}}
 	svc := makeServiceWithUsers(t, repo)
 
-	ctx := svc.ResolveAndStashUser(context.Background(), "inst-1", "alice@example.com", "claude-acct-9")
+	ctx := svc.ResolveAndStashUser(context.Background(), "inst-1", "alice@example.com", "claude-acct-9", "")
 
 	require.Len(t, repo.upserts, 1)
 	assert.Equal(t, "inst-1", repo.upserts[0].InstallationID)
@@ -80,7 +80,7 @@ func TestResolveAndStashUser_NoIdentitySignalIsNoOp(t *testing.T) {
 	repo := &fakeUserRepo{}
 	svc := makeServiceWithUsers(t, repo)
 
-	ctx := svc.ResolveAndStashUser(context.Background(), "inst-1", "", "")
+	ctx := svc.ResolveAndStashUser(context.Background(), "inst-1", "", "", "")
 
 	assert.Empty(t, repo.upserts)
 	assert.Empty(t, repo.accountUpserts)
@@ -94,7 +94,7 @@ func TestResolveAndStashUser_AccountUUIDOnlyUsesAccountUpsert(t *testing.T) {
 	repo := &fakeUserRepo{user: &auth.User{ID: "user-9", InstallationID: "inst-1"}}
 	svc := makeServiceWithUsers(t, repo)
 
-	ctx := svc.ResolveAndStashUser(context.Background(), "inst-1", "", "2c2aace8-82e9-4cb1-8d1f-2f822da43177")
+	ctx := svc.ResolveAndStashUser(context.Background(), "inst-1", "", "2c2aace8-82e9-4cb1-8d1f-2f822da43177", "")
 
 	assert.Empty(t, repo.upserts, "email-empty input must NOT call UpsertByEmail")
 	require.Len(t, repo.accountUpserts, 1)
@@ -110,7 +110,7 @@ func TestResolveAndStashUser_EmailPathBeatsAccountUUIDPath(t *testing.T) {
 	repo := &fakeUserRepo{user: &auth.User{ID: "user-3"}}
 	svc := makeServiceWithUsers(t, repo)
 
-	svc.ResolveAndStashUser(context.Background(), "inst-1", "alice@example.com", "2c2aace8-82e9-4cb1-8d1f-2f822da43177")
+	svc.ResolveAndStashUser(context.Background(), "inst-1", "alice@example.com", "2c2aace8-82e9-4cb1-8d1f-2f822da43177", "")
 
 	require.Len(t, repo.upserts, 1)
 	assert.Empty(t, repo.accountUpserts, "email-present input must NOT call UpsertByAccountUUID")
@@ -122,7 +122,7 @@ func TestResolveAndStashUser_NoInstallationIsNoOp(t *testing.T) {
 	repo := &fakeUserRepo{}
 	svc := makeServiceWithUsers(t, repo)
 
-	ctx := svc.ResolveAndStashUser(context.Background(), "", "alice@example.com", "")
+	ctx := svc.ResolveAndStashUser(context.Background(), "", "alice@example.com", "", "")
 
 	assert.Empty(t, repo.upserts)
 	assert.Equal(t, "", auth.UserIDFrom(ctx))
@@ -132,10 +132,46 @@ func TestResolveAndStashUser_OmitsClaudeAccountWhenEmpty(t *testing.T) {
 	repo := &fakeUserRepo{user: &auth.User{ID: "user-1"}}
 	svc := makeServiceWithUsers(t, repo)
 
-	svc.ResolveAndStashUser(context.Background(), "inst-1", "alice@example.com", "")
+	svc.ResolveAndStashUser(context.Background(), "inst-1", "alice@example.com", "", "")
 
 	require.Len(t, repo.upserts, 1)
 	assert.Nil(t, repo.upserts[0].ClaudeAccountUUID)
+}
+
+func TestResolveAndStashUser_PropagatesDisplayNameOnEmailPath(t *testing.T) {
+	repo := &fakeUserRepo{user: &auth.User{ID: "user-1"}}
+	svc := makeServiceWithUsers(t, repo)
+
+	svc.ResolveAndStashUser(context.Background(), "inst-1", "alice@example.com", "", "Alice Liddell")
+
+	require.Len(t, repo.upserts, 1)
+	require.NotNil(t, repo.upserts[0].DisplayName)
+	assert.Equal(t, "Alice Liddell", *repo.upserts[0].DisplayName)
+}
+
+func TestResolveAndStashUser_PropagatesDisplayNameOnAccountUUIDPath(t *testing.T) {
+	// Claude CLI v2.1.x ships only account_uuid in metadata.user_id, but the
+	// X-Weave-User-Name header still carries the git user.name. The display
+	// name must reach the account-uuid-keyed upsert so the dashboard has a
+	// human-readable label even when email is NULL.
+	repo := &fakeUserRepo{user: &auth.User{ID: "user-9"}}
+	svc := makeServiceWithUsers(t, repo)
+
+	svc.ResolveAndStashUser(context.Background(), "inst-1", "", "2c2aace8-82e9-4cb1-8d1f-2f822da43177", "Alice Liddell")
+
+	require.Len(t, repo.accountUpserts, 1)
+	require.NotNil(t, repo.accountUpserts[0].DisplayName)
+	assert.Equal(t, "Alice Liddell", *repo.accountUpserts[0].DisplayName)
+}
+
+func TestResolveAndStashUser_OmitsDisplayNameWhenEmpty(t *testing.T) {
+	repo := &fakeUserRepo{user: &auth.User{ID: "user-1"}}
+	svc := makeServiceWithUsers(t, repo)
+
+	svc.ResolveAndStashUser(context.Background(), "inst-1", "alice@example.com", "", "")
+
+	require.Len(t, repo.upserts, 1)
+	assert.Nil(t, repo.upserts[0].DisplayName, "empty header must map to nil so COALESCE preserves any existing row value")
 }
 
 func TestResolveAndStashUser_RepoErrorDoesNotPropagate(t *testing.T) {
@@ -143,7 +179,7 @@ func TestResolveAndStashUser_RepoErrorDoesNotPropagate(t *testing.T) {
 	svc := makeServiceWithUsers(t, repo)
 
 	// Must return the original ctx unchanged so the request still proceeds.
-	ctx := svc.ResolveAndStashUser(context.Background(), "inst-1", "alice@example.com", "")
+	ctx := svc.ResolveAndStashUser(context.Background(), "inst-1", "alice@example.com", "", "")
 
 	assert.Equal(t, "", auth.UserIDFrom(ctx))
 }
@@ -151,7 +187,7 @@ func TestResolveAndStashUser_RepoErrorDoesNotPropagate(t *testing.T) {
 func TestResolveAndStashUser_NilUsersIsNoOp(t *testing.T) {
 	svc := makeServiceWithUsers(t, nil)
 
-	ctx := svc.ResolveAndStashUser(context.Background(), "inst-1", "alice@example.com", "")
+	ctx := svc.ResolveAndStashUser(context.Background(), "inst-1", "alice@example.com", "", "")
 
 	assert.Equal(t, "", auth.UserIDFrom(ctx))
 }
@@ -170,12 +206,12 @@ func TestResolveAndStashUser_CacheHitSkipsRepo(t *testing.T) {
 	)
 
 	// First call hits repo and populates cache.
-	ctx1 := svc.ResolveAndStashUser(context.Background(), "inst-1", "alice@example.com", "")
+	ctx1 := svc.ResolveAndStashUser(context.Background(), "inst-1", "alice@example.com", "", "")
 	require.Equal(t, "user-1", auth.UserIDFrom(ctx1))
 	require.Len(t, repo.upserts, 1)
 
 	// Second call must hit cache and skip the upsert entirely.
-	ctx2 := svc.ResolveAndStashUser(context.Background(), "inst-1", "alice@example.com", "")
+	ctx2 := svc.ResolveAndStashUser(context.Background(), "inst-1", "alice@example.com", "", "")
 	assert.Equal(t, "user-1", auth.UserIDFrom(ctx2))
 	assert.Len(t, repo.upserts, 1, "cache hit must not call repo.Upsert again")
 }

--- a/internal/postgres/user_repo.go
+++ b/internal/postgres/user_repo.go
@@ -29,6 +29,7 @@ func (r *userRepo) UpsertByEmail(ctx context.Context, params auth.UpsertUserPara
 		InstallationID:    installationID,
 		Email:             params.Email,
 		ClaudeAccountUUID: claudeAccountUUIDArg(params.ClaudeAccountUUID),
+		DisplayName:       nullableTextArg(params.DisplayName),
 	})
 	if err != nil {
 		return nil, err
@@ -49,6 +50,7 @@ func (r *userRepo) UpsertByAccountUUID(ctx context.Context, params auth.UpsertUs
 	row, err := q.UpsertModelRouterUserByAccountUUID(ctx, sqlc.UpsertModelRouterUserByAccountUUIDParams{
 		InstallationID:    installationID,
 		ClaudeAccountUUID: accountUUID,
+		DisplayName:       nullableTextArg(params.DisplayName),
 	})
 	if err != nil {
 		return nil, err
@@ -101,6 +103,10 @@ func toAuthUser(row sqlc.RouterModelRouterUser) *auth.User {
 		s := uuid.UUID(row.ClaudeAccountUUID.Bytes).String()
 		user.ClaudeAccountUUID = &s
 	}
+	if row.DisplayName != nil {
+		s := *row.DisplayName
+		user.DisplayName = &s
+	}
 	return user
 }
 
@@ -113,4 +119,14 @@ func claudeAccountUUIDArg(s *string) pgtype.UUID {
 		return pgtype.UUID{Valid: false}
 	}
 	return pgtype.UUID{Bytes: parsed, Valid: true}
+}
+
+// nullableTextArg lifts an optional Go string into the *string shape SQLC
+// generates for sqlc.narg('display_name')::text. Empty values map to NULL so
+// COALESCE on conflict preserves the row's existing value.
+func nullableTextArg(s *string) *string {
+	if s == nil || *s == "" {
+		return nil
+	}
+	return s
 }

--- a/internal/proxy/client_identity.go
+++ b/internal/proxy/client_identity.go
@@ -10,14 +10,16 @@ import (
 )
 
 // ClientIdentity holds per-request user identification signals. Email is the
-// cross-protocol identity persisted to router.model_router_users.email.
+// cross-protocol identity persisted to router.model_router_users.email;
+// DisplayName is the optional free-form label persisted to display_name.
 type ClientIdentity struct {
-	DeviceID  string
-	AccountID string
-	SessionID string
-	Email     string
-	UserAgent string
-	ClientApp string
+	DeviceID    string
+	AccountID   string
+	SessionID   string
+	Email       string
+	DisplayName string
+	UserAgent   string
+	ClientApp   string
 }
 
 // ClientIdentityContextKey is the request-context key for client identity.
@@ -55,8 +57,9 @@ func ResolveUserFromContext(ctx context.Context, authSvc *auth.Service, installa
 		"installation_id", installation.ID,
 		"email_present", id.Email != "",
 		"account_present", id.AccountID != "",
+		"name_present", id.DisplayName != "",
 	)
-	return authSvc.ResolveAndStashUser(ctx, installation.ID, id.Email, id.AccountID)
+	return authSvc.ResolveAndStashUser(ctx, installation.ID, id.Email, id.AccountID, id.DisplayName)
 }
 
 // ClaudeCodeMetadata mirrors the JSON Claude Code encodes into
@@ -116,4 +119,35 @@ func NormalizeEmail(s string) string {
 		return ""
 	}
 	return s
+}
+
+// MaxDisplayNameLen bounds the free-form display name. 128 mirrors the
+// installer-side cap; longer values almost certainly indicate a header
+// smuggling attempt rather than a real name.
+const MaxDisplayNameLen = 128
+
+// NormalizeDisplayName trims and strips control characters from a free-form
+// display name. Returns "" when empty or oversized. We don't case-fold —
+// names are free-form, not lookup keys — but we do drop control bytes a
+// malicious header could carry so the value is safe to persist and render.
+func NormalizeDisplayName(s string) string {
+	s = strings.TrimSpace(s)
+	if s == "" || len(s) > MaxDisplayNameLen {
+		return ""
+	}
+	var b strings.Builder
+	b.Grow(len(s))
+	for _, r := range s {
+		// Drop ASCII control chars (incl. CR/LF) and the C1 block. Printable
+		// Unicode passes through so non-ASCII names render correctly.
+		if r < 0x20 || r == 0x7f || (r >= 0x80 && r < 0xa0) {
+			continue
+		}
+		b.WriteRune(r)
+	}
+	out := strings.TrimSpace(b.String())
+	if out == "" {
+		return ""
+	}
+	return out
 }

--- a/internal/proxy/client_identity_test.go
+++ b/internal/proxy/client_identity_test.go
@@ -84,6 +84,33 @@ func TestNormalizeEmail_RejectsOverLength(t *testing.T) {
 	assert.Equal(t, "", proxy.NormalizeEmail(overCap))
 }
 
+func TestNormalizeDisplayName_TrimsAndPassesUnicode(t *testing.T) {
+	assert.Equal(t, "Alice Liddell", proxy.NormalizeDisplayName("  Alice Liddell  "))
+	assert.Equal(t, "Renée Fleming", proxy.NormalizeDisplayName("Renée Fleming"))
+	assert.Equal(t, "", proxy.NormalizeDisplayName(""))
+	assert.Equal(t, "", proxy.NormalizeDisplayName("   "))
+}
+
+func TestNormalizeDisplayName_StripsControlBytes(t *testing.T) {
+	// CR/LF + control bytes must be dropped so the value can't break log
+	// lines or smuggle extra HTTP headers. Surrounding visible chars stay.
+	out := proxy.NormalizeDisplayName("Alice\r\nMallory")
+	assert.NotContains(t, out, "\r")
+	assert.NotContains(t, out, "\n")
+	assert.Equal(t, "AliceMallory", out)
+	assert.Equal(t, "Alice", proxy.NormalizeDisplayName("Alice\x00\x07"))
+}
+
+func TestNormalizeDisplayName_RejectsOverLength(t *testing.T) {
+	atCap := strings.Repeat("a", proxy.MaxDisplayNameLen)
+	require.Len(t, atCap, proxy.MaxDisplayNameLen)
+	assert.Equal(t, atCap, proxy.NormalizeDisplayName(atCap))
+
+	overCap := strings.Repeat("a", proxy.MaxDisplayNameLen+1)
+	require.Greater(t, len(overCap), proxy.MaxDisplayNameLen)
+	assert.Equal(t, "", proxy.NormalizeDisplayName(overCap))
+}
+
 func TestNormalizeClientIdentifier_PassesThroughShortValues(t *testing.T) {
 	assert.Equal(t, "dev-abc123", proxy.NormalizeClientIdentifier("dev-abc123"))
 	assert.Equal(t, "550e8400-e29b-41d4-a716-446655440000",

--- a/internal/sqlc/model_router_users.sql.go
+++ b/internal/sqlc/model_router_users.sql.go
@@ -13,7 +13,7 @@ import (
 )
 
 const getModelRouterUser = `-- name: GetModelRouterUser :one
-SELECT id, installation_id, email, claude_account_uuid, first_seen_at, last_seen_at, deleted_at
+SELECT id, installation_id, email, claude_account_uuid, first_seen_at, last_seen_at, deleted_at, display_name
 FROM router.model_router_users
 WHERE id = $1::uuid
   AND deleted_at IS NULL
@@ -21,7 +21,7 @@ WHERE id = $1::uuid
 
 // Single-row read by id; returns sql.ErrNoRows when missing or soft-deleted.
 //
-//	SELECT id, installation_id, email, claude_account_uuid, first_seen_at, last_seen_at, deleted_at
+//	SELECT id, installation_id, email, claude_account_uuid, first_seen_at, last_seen_at, deleted_at, display_name
 //	FROM router.model_router_users
 //	WHERE id = $1::uuid
 //	  AND deleted_at IS NULL
@@ -36,12 +36,13 @@ func (q *Queries) GetModelRouterUser(ctx context.Context, id uuid.UUID) (RouterM
 		&i.FirstSeenAt,
 		&i.LastSeenAt,
 		&i.DeletedAt,
+		&i.DisplayName,
 	)
 	return i, err
 }
 
 const listModelRouterUsersForInstallation = `-- name: ListModelRouterUsersForInstallation :many
-SELECT id, installation_id, email, claude_account_uuid, first_seen_at, last_seen_at, deleted_at
+SELECT id, installation_id, email, claude_account_uuid, first_seen_at, last_seen_at, deleted_at, display_name
 FROM router.model_router_users
 WHERE installation_id = $1::uuid
   AND deleted_at IS NULL
@@ -50,7 +51,7 @@ ORDER BY last_seen_at DESC
 
 // Lists active users for an installation (admin / dashboard; not on the request path).
 //
-//	SELECT id, installation_id, email, claude_account_uuid, first_seen_at, last_seen_at, deleted_at
+//	SELECT id, installation_id, email, claude_account_uuid, first_seen_at, last_seen_at, deleted_at, display_name
 //	FROM router.model_router_users
 //	WHERE installation_id = $1::uuid
 //	  AND deleted_at IS NULL
@@ -72,6 +73,7 @@ func (q *Queries) ListModelRouterUsersForInstallation(ctx context.Context, insta
 			&i.FirstSeenAt,
 			&i.LastSeenAt,
 			&i.DeletedAt,
+			&i.DisplayName,
 		); err != nil {
 			return nil, err
 		}
@@ -87,22 +89,27 @@ const upsertModelRouterUserByAccountUUID = `-- name: UpsertModelRouterUserByAcco
 INSERT INTO router.model_router_users (
     installation_id,
     email,
-    claude_account_uuid
+    claude_account_uuid,
+    display_name
 )
 VALUES (
     $1::uuid,
     NULL,
-    $2::uuid
+    $2::uuid,
+    $3::text
 )
 ON CONFLICT (installation_id, claude_account_uuid)
   WHERE email IS NULL AND claude_account_uuid IS NOT NULL AND deleted_at IS NULL
-DO UPDATE SET last_seen_at = CURRENT_TIMESTAMP
-RETURNING id, installation_id, email, claude_account_uuid, first_seen_at, last_seen_at, deleted_at
+DO UPDATE SET
+    last_seen_at = CURRENT_TIMESTAMP,
+    display_name = COALESCE(EXCLUDED.display_name, router.model_router_users.display_name)
+RETURNING id, installation_id, email, claude_account_uuid, first_seen_at, last_seen_at, deleted_at, display_name
 `
 
 type UpsertModelRouterUserByAccountUUIDParams struct {
 	InstallationID    uuid.UUID
 	ClaudeAccountUUID uuid.UUID
+	DisplayName       *string
 }
 
 // Upserts an end-user identity keyed on (installation_id, claude_account_uuid)
@@ -116,19 +123,23 @@ type UpsertModelRouterUserByAccountUUIDParams struct {
 //	INSERT INTO router.model_router_users (
 //	    installation_id,
 //	    email,
-//	    claude_account_uuid
+//	    claude_account_uuid,
+//	    display_name
 //	)
 //	VALUES (
 //	    $1::uuid,
 //	    NULL,
-//	    $2::uuid
+//	    $2::uuid,
+//	    $3::text
 //	)
 //	ON CONFLICT (installation_id, claude_account_uuid)
 //	  WHERE email IS NULL AND claude_account_uuid IS NOT NULL AND deleted_at IS NULL
-//	DO UPDATE SET last_seen_at = CURRENT_TIMESTAMP
-//	RETURNING id, installation_id, email, claude_account_uuid, first_seen_at, last_seen_at, deleted_at
+//	DO UPDATE SET
+//	    last_seen_at = CURRENT_TIMESTAMP,
+//	    display_name = COALESCE(EXCLUDED.display_name, router.model_router_users.display_name)
+//	RETURNING id, installation_id, email, claude_account_uuid, first_seen_at, last_seen_at, deleted_at, display_name
 func (q *Queries) UpsertModelRouterUserByAccountUUID(ctx context.Context, arg UpsertModelRouterUserByAccountUUIDParams) (RouterModelRouterUser, error) {
-	row := q.db.QueryRow(ctx, upsertModelRouterUserByAccountUUID, arg.InstallationID, arg.ClaudeAccountUUID)
+	row := q.db.QueryRow(ctx, upsertModelRouterUserByAccountUUID, arg.InstallationID, arg.ClaudeAccountUUID, arg.DisplayName)
 	var i RouterModelRouterUser
 	err := row.Scan(
 		&i.ID,
@@ -138,6 +149,7 @@ func (q *Queries) UpsertModelRouterUserByAccountUUID(ctx context.Context, arg Up
 		&i.FirstSeenAt,
 		&i.LastSeenAt,
 		&i.DeletedAt,
+		&i.DisplayName,
 	)
 	return i, err
 }
@@ -146,47 +158,60 @@ const upsertModelRouterUserByEmail = `-- name: UpsertModelRouterUserByEmail :one
 INSERT INTO router.model_router_users (
     installation_id,
     email,
-    claude_account_uuid
+    claude_account_uuid,
+    display_name
 )
 VALUES (
     $1::uuid,
     $2::text,
-    $3::uuid
+    $3::uuid,
+    $4::text
 )
 ON CONFLICT (installation_id, email) WHERE deleted_at IS NULL DO UPDATE SET
     last_seen_at        = CURRENT_TIMESTAMP,
-    claude_account_uuid = COALESCE(EXCLUDED.claude_account_uuid, router.model_router_users.claude_account_uuid)
-RETURNING id, installation_id, email, claude_account_uuid, first_seen_at, last_seen_at, deleted_at
+    claude_account_uuid = COALESCE(EXCLUDED.claude_account_uuid, router.model_router_users.claude_account_uuid),
+    display_name        = COALESCE(EXCLUDED.display_name, router.model_router_users.display_name)
+RETURNING id, installation_id, email, claude_account_uuid, first_seen_at, last_seen_at, deleted_at, display_name
 `
 
 type UpsertModelRouterUserByEmailParams struct {
 	InstallationID    uuid.UUID
 	Email             string
 	ClaudeAccountUUID pgtype.UUID
+	DisplayName       *string
 }
 
 // Upserts an end-user identity keyed on (installation_id, email), refreshing
-// last_seen_at on every hit. claude_account_uuid is overwritten only when
-// the new value is non-NULL so a request from a non-Claude-Code client
-// can't blank out the field. Returns the row so the caller can stash
-// user_id on the request context.
+// last_seen_at on every hit. claude_account_uuid and display_name are
+// overwritten only when the new value is non-NULL so a request from a
+// non-Claude-Code client (or one that omits the X-Weave-User-Name header)
+// can't blank out fields populated by earlier requests. Returns the row so
+// the caller can stash user_id on the request context.
 //
 //	INSERT INTO router.model_router_users (
 //	    installation_id,
 //	    email,
-//	    claude_account_uuid
+//	    claude_account_uuid,
+//	    display_name
 //	)
 //	VALUES (
 //	    $1::uuid,
 //	    $2::text,
-//	    $3::uuid
+//	    $3::uuid,
+//	    $4::text
 //	)
 //	ON CONFLICT (installation_id, email) WHERE deleted_at IS NULL DO UPDATE SET
 //	    last_seen_at        = CURRENT_TIMESTAMP,
-//	    claude_account_uuid = COALESCE(EXCLUDED.claude_account_uuid, router.model_router_users.claude_account_uuid)
-//	RETURNING id, installation_id, email, claude_account_uuid, first_seen_at, last_seen_at, deleted_at
+//	    claude_account_uuid = COALESCE(EXCLUDED.claude_account_uuid, router.model_router_users.claude_account_uuid),
+//	    display_name        = COALESCE(EXCLUDED.display_name, router.model_router_users.display_name)
+//	RETURNING id, installation_id, email, claude_account_uuid, first_seen_at, last_seen_at, deleted_at, display_name
 func (q *Queries) UpsertModelRouterUserByEmail(ctx context.Context, arg UpsertModelRouterUserByEmailParams) (RouterModelRouterUser, error) {
-	row := q.db.QueryRow(ctx, upsertModelRouterUserByEmail, arg.InstallationID, arg.Email, arg.ClaudeAccountUUID)
+	row := q.db.QueryRow(ctx, upsertModelRouterUserByEmail,
+		arg.InstallationID,
+		arg.Email,
+		arg.ClaudeAccountUUID,
+		arg.DisplayName,
+	)
 	var i RouterModelRouterUser
 	err := row.Scan(
 		&i.ID,
@@ -196,6 +221,7 @@ func (q *Queries) UpsertModelRouterUserByEmail(ctx context.Context, arg UpsertMo
 		&i.FirstSeenAt,
 		&i.LastSeenAt,
 		&i.DeletedAt,
+		&i.DisplayName,
 	)
 	return i, err
 }

--- a/internal/sqlc/models.go
+++ b/internal/sqlc/models.go
@@ -107,6 +107,8 @@ type RouterModelRouterUser struct {
 	FirstSeenAt       pgtype.Timestamp
 	LastSeenAt        pgtype.Timestamp
 	DeletedAt         pgtype.Timestamp
+	// Free-form user display name (typically git user.name) carried on the X-Weave-User-Name request header. Nullable: requests without the header leave the column NULL; existing rows are not back-filled.
+	DisplayName *string
 }
 
 type RouterOrganizationBillingOverride struct {


### PR DESCRIPTION
## Summary

The router could only attribute traffic to a person via Claude Code's `metadata.user_id`, which on current clients carries only `account_uuid` (no email), so `router.model_router_users.email` stayed `NULL` on every request and the Weave dashboard's email-keyed linking suggestions never fired. Codex carries no identity at all.

This change plants identity at install time from `git config` so customers can link router users to Weave accounts on the dashboard even on shared API keys. Both fields are best-effort — empty header = preserve existing value via `COALESCE`, so a re-install that opts out doesn't blank rows.

### Installer (`install/install.sh`)
- `normalize_email` / `normalize_name` validate locally before planting (header smuggling defenses, RFC 5321 cap)
- `resolve_user_email` / `resolve_user_name` prefer `WEAVE_USER_EMAIL` / `WEAVE_USER_NAME` env, fall back to `git config --global`, prompt interactively (email only) with `-` opt-out
- `ANTHROPIC_CUSTOM_HEADERS` gets a multi-line value carrying the router key + both identity headers when present

### Router
- New migration `0007_user_display_name` adds `router.model_router_users.display_name`
- `UpsertModelRouterUserBy{Email,AccountUUID}` take an optional display name with `COALESCE` so subsequent requests can't blank it
- `proxy.NormalizeDisplayName` mirrors the installer-side normalizer
- `auth.Service.ResolveAndStashUser` plumbs the new field on all three protocols (Anthropic, OpenAI, Gemini)

This effectively re-lands a non-Codex version of #172 plus the display-name addition. PR #172 lived on the unmerged Codex branch and got lost.

## Test plan

- [x] `make build` clean
- [x] `make test` — all 21 packages pass, including new tests for `NormalizeDisplayName` (trim/unicode/control-byte stripping/length cap) and `ResolveAndStashUser` display-name propagation on both email and account-uuid paths
- [x] `bash -n install/install.sh` syntax check
- [ ] Manual: re-run `npx @workweave/router` on a workstation with `git config user.email` + `user.name` set, hit the router, verify `model_router_users.email` and `display_name` populate
- [ ] Manual: same with `WEAVE_USER_EMAIL=` and `--non-interactive` to verify env override / opt-out paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)