### PR TITLE
chore(npm): bump @workweave/router to 0.1.3

### DIFF
--- a/install/npm/package.json
+++ b/install/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@workweave/router",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "One-command installer that points Claude Code at the Weave Router.",
   "bin": {
     "weave-router": "bin.js"


### PR DESCRIPTION
## Summary

- Bumps \`install/npm/package.json\` from \`0.1.2\` to \`0.1.3\` so the next tag push (\`router-v0.1.3\`) republishes the npm package with the X-Weave-User-Email / X-Weave-User-Name installer support.

## Why

\`0.1.2\` was tagged before PRs #192 and #193 landed, so today's \`npx @workweave/router\` ships an \`install.sh\` that knows nothing about identity headers. Backend-served installs (curl) and the router itself already carry the feature; this just brings the npm distribution channel into parity so teams using \`npx\` start sending email + name on every Claude Code request.

## Release steps after merge

1. Tag the merge commit \`router-v0.1.3\` and push the tag.
2. \`publish_npm.yml\` workflow validates the tag is reachable from \`main\` and publishes to npm.
3. \`npx @workweave/router@latest\` then resolves to \`0.1.3\`.

## Test plan

- [ ] CI green
- [ ] After tag + publish, \`npm view @workweave/router version\` returns \`0.1.3\`
- [ ] \`npx @workweave/router@0.1.3 --help\` (or equivalent dry-run) doesn't regress
- [ ] Fresh \`npx\` install on a clean machine writes \`X-Weave-User-Email\` into \`~/.claude/settings.json\` \`custom_headers\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)