### PR TITLE
fix(auth): merge email into UUID-only orphan instead of inserting

### DIFF
--- a/db/queries/model_router_users.sql
+++ b/db/queries/model_router_users.sql
@@ -4,24 +4,49 @@
 -- non-Claude-Code client (or one that omits the X-Weave-User-Name header)
 -- can't blank out fields populated by earlier requests. Returns the row so
 -- the caller can stash user_id on the request context.
+--
+-- Merge path: when claude_account_uuid is non-NULL and a UUID-only orphan
+-- already exists for this account (created by an earlier email-less request
+-- via UpsertModelRouterUserByAccountUUID), we update that row's email +
+-- display_name in place instead of inserting a new email-keyed row. Without
+-- this, every installer upgrade that introduces X-Weave-User-Email creates
+-- duplicate rows for the same human and the dashboard picker shows both.
+-- The fallback INSERT keeps the original ON CONFLICT path so concurrent
+-- email-bearing requests still collapse onto a single row.
 -- name: UpsertModelRouterUserByEmail :one
-INSERT INTO router.model_router_users (
-    installation_id,
-    email,
-    claude_account_uuid,
-    display_name
+WITH merged AS (
+    UPDATE router.model_router_users
+    SET email        = @email::text,
+        display_name = COALESCE(sqlc.narg('display_name')::text, display_name),
+        last_seen_at = CURRENT_TIMESTAMP
+    WHERE installation_id     = @installation_id::uuid
+      AND claude_account_uuid = sqlc.narg('claude_account_uuid')::uuid
+      AND email IS NULL
+      AND deleted_at IS NULL
+    RETURNING *
+),
+inserted AS (
+    INSERT INTO router.model_router_users (
+        installation_id,
+        email,
+        claude_account_uuid,
+        display_name
+    )
+    SELECT
+        @installation_id::uuid,
+        @email::text,
+        sqlc.narg('claude_account_uuid')::uuid,
+        sqlc.narg('display_name')::text
+    WHERE NOT EXISTS (SELECT 1 FROM merged)
+    ON CONFLICT (installation_id, email) WHERE deleted_at IS NULL DO UPDATE SET
+        last_seen_at        = CURRENT_TIMESTAMP,
+        claude_account_uuid = COALESCE(EXCLUDED.claude_account_uuid, router.model_router_users.claude_account_uuid),
+        display_name        = COALESCE(EXCLUDED.display_name, router.model_router_users.display_name)
+    RETURNING *
 )
-VALUES (
-    @installation_id::uuid,
-    @email::text,
-    sqlc.narg('claude_account_uuid')::uuid,
-    sqlc.narg('display_name')::text
-)
-ON CONFLICT (installation_id, email) WHERE deleted_at IS NULL DO UPDATE SET
-    last_seen_at        = CURRENT_TIMESTAMP,
-    claude_account_uuid = COALESCE(EXCLUDED.claude_account_uuid, router.model_router_users.claude_account_uuid),
-    display_name        = COALESCE(EXCLUDED.display_name, router.model_router_users.display_name)
-RETURNING *;
+SELECT * FROM merged
+UNION ALL
+SELECT * FROM inserted;
 
 -- Upserts an end-user identity keyed on (installation_id, claude_account_uuid)
 -- for inbound requests that carry no email. Claude CLI v2.1.x ships only

--- a/internal/postgres/user_repo.go
+++ b/internal/postgres/user_repo.go
@@ -34,7 +34,18 @@ func (r *userRepo) UpsertByEmail(ctx context.Context, params auth.UpsertUserPara
 	if err != nil {
 		return nil, err
 	}
-	return toAuthUser(row), nil
+	// The merge-or-insert CTE returns a generated UNION row type with the
+	// same fields as RouterModelRouterUser; map by field to reuse toAuthUser.
+	return toAuthUser(sqlc.RouterModelRouterUser{
+		ID:                row.ID,
+		InstallationID:    row.InstallationID,
+		Email:             row.Email,
+		ClaudeAccountUUID: row.ClaudeAccountUUID,
+		FirstSeenAt:       row.FirstSeenAt,
+		LastSeenAt:        row.LastSeenAt,
+		DeletedAt:         row.DeletedAt,
+		DisplayName:       row.DisplayName,
+	}), nil
 }
 
 func (r *userRepo) UpsertByAccountUUID(ctx context.Context, params auth.UpsertUserByAccountUUIDParams) (*auth.User, error) {

--- a/internal/sqlc/model_router_users.sql.go
+++ b/internal/sqlc/model_router_users.sql.go
@@ -155,29 +155,56 @@ func (q *Queries) UpsertModelRouterUserByAccountUUID(ctx context.Context, arg Up
 }
 
 const upsertModelRouterUserByEmail = `-- name: UpsertModelRouterUserByEmail :one
-INSERT INTO router.model_router_users (
-    installation_id,
-    email,
-    claude_account_uuid,
-    display_name
+WITH merged AS (
+    UPDATE router.model_router_users
+    SET email        = $1::text,
+        display_name = COALESCE($2::text, display_name),
+        last_seen_at = CURRENT_TIMESTAMP
+    WHERE installation_id     = $3::uuid
+      AND claude_account_uuid = $4::uuid
+      AND email IS NULL
+      AND deleted_at IS NULL
+    RETURNING id, installation_id, email, claude_account_uuid, first_seen_at, last_seen_at, deleted_at, display_name
+),
+inserted AS (
+    INSERT INTO router.model_router_users (
+        installation_id,
+        email,
+        claude_account_uuid,
+        display_name
+    )
+    SELECT
+        $3::uuid,
+        $1::text,
+        $4::uuid,
+        $2::text
+    WHERE NOT EXISTS (SELECT 1 FROM merged)
+    ON CONFLICT (installation_id, email) WHERE deleted_at IS NULL DO UPDATE SET
+        last_seen_at        = CURRENT_TIMESTAMP,
+        claude_account_uuid = COALESCE(EXCLUDED.claude_account_uuid, router.model_router_users.claude_account_uuid),
+        display_name        = COALESCE(EXCLUDED.display_name, router.model_router_users.display_name)
+    RETURNING id, installation_id, email, claude_account_uuid, first_seen_at, last_seen_at, deleted_at, display_name
 )
-VALUES (
-    $1::uuid,
-    $2::text,
-    $3::uuid,
-    $4::text
-)
-ON CONFLICT (installation_id, email) WHERE deleted_at IS NULL DO UPDATE SET
-    last_seen_at        = CURRENT_TIMESTAMP,
-    claude_account_uuid = COALESCE(EXCLUDED.claude_account_uuid, router.model_router_users.claude_account_uuid),
-    display_name        = COALESCE(EXCLUDED.display_name, router.model_router_users.display_name)
-RETURNING id, installation_id, email, claude_account_uuid, first_seen_at, last_seen_at, deleted_at, display_name
+SELECT id, installation_id, email, claude_account_uuid, first_seen_at, last_seen_at, deleted_at, display_name FROM merged
+UNION ALL
+SELECT id, installation_id, email, claude_account_uuid, first_seen_at, last_seen_at, deleted_at, display_name FROM inserted
 `
 
 type UpsertModelRouterUserByEmailParams struct {
-	InstallationID    uuid.UUID
 	Email             string
+	DisplayName       *string
+	InstallationID    uuid.UUID
 	ClaudeAccountUUID pgtype.UUID
+}
+
+type UpsertModelRouterUserByEmailRow struct {
+	ID                uuid.UUID
+	InstallationID    uuid.UUID
+	Email             *string
+	ClaudeAccountUUID pgtype.UUID
+	FirstSeenAt       pgtype.Timestamp
+	LastSeenAt        pgtype.Timestamp
+	DeletedAt         pgtype.Timestamp
 	DisplayName       *string
 }
 
@@ -188,31 +215,56 @@ type UpsertModelRouterUserByEmailParams struct {
 // can't blank out fields populated by earlier requests. Returns the row so
 // the caller can stash user_id on the request context.
 //
-//	INSERT INTO router.model_router_users (
-//	    installation_id,
-//	    email,
-//	    claude_account_uuid,
-//	    display_name
+// Merge path: when claude_account_uuid is non-NULL and a UUID-only orphan
+// already exists for this account (created by an earlier email-less request
+// via UpsertModelRouterUserByAccountUUID), we update that row's email +
+// display_name in place instead of inserting a new email-keyed row. Without
+// this, every installer upgrade that introduces X-Weave-User-Email creates
+// duplicate rows for the same human and the dashboard picker shows both.
+// The fallback INSERT keeps the original ON CONFLICT path so concurrent
+// email-bearing requests still collapse onto a single row.
+//
+//	WITH merged AS (
+//	    UPDATE router.model_router_users
+//	    SET email        = $1::text,
+//	        display_name = COALESCE($2::text, display_name),
+//	        last_seen_at = CURRENT_TIMESTAMP
+//	    WHERE installation_id     = $3::uuid
+//	      AND claude_account_uuid = $4::uuid
+//	      AND email IS NULL
+//	      AND deleted_at IS NULL
+//	    RETURNING id, installation_id, email, claude_account_uuid, first_seen_at, last_seen_at, deleted_at, display_name
+//	),
+//	inserted AS (
+//	    INSERT INTO router.model_router_users (
+//	        installation_id,
+//	        email,
+//	        claude_account_uuid,
+//	        display_name
+//	    )
+//	    SELECT
+//	        $3::uuid,
+//	        $1::text,
+//	        $4::uuid,
+//	        $2::text
+//	    WHERE NOT EXISTS (SELECT 1 FROM merged)
+//	    ON CONFLICT (installation_id, email) WHERE deleted_at IS NULL DO UPDATE SET
+//	        last_seen_at        = CURRENT_TIMESTAMP,
+//	        claude_account_uuid = COALESCE(EXCLUDED.claude_account_uuid, router.model_router_users.claude_account_uuid),
+//	        display_name        = COALESCE(EXCLUDED.display_name, router.model_router_users.display_name)
+//	    RETURNING id, installation_id, email, claude_account_uuid, first_seen_at, last_seen_at, deleted_at, display_name
 //	)
-//	VALUES (
-//	    $1::uuid,
-//	    $2::text,
-//	    $3::uuid,
-//	    $4::text
-//	)
-//	ON CONFLICT (installation_id, email) WHERE deleted_at IS NULL DO UPDATE SET
-//	    last_seen_at        = CURRENT_TIMESTAMP,
-//	    claude_account_uuid = COALESCE(EXCLUDED.claude_account_uuid, router.model_router_users.claude_account_uuid),
-//	    display_name        = COALESCE(EXCLUDED.display_name, router.model_router_users.display_name)
-//	RETURNING id, installation_id, email, claude_account_uuid, first_seen_at, last_seen_at, deleted_at, display_name
-func (q *Queries) UpsertModelRouterUserByEmail(ctx context.Context, arg UpsertModelRouterUserByEmailParams) (RouterModelRouterUser, error) {
+//	SELECT id, installation_id, email, claude_account_uuid, first_seen_at, last_seen_at, deleted_at, display_name FROM merged
+//	UNION ALL
+//	SELECT id, installation_id, email, claude_account_uuid, first_seen_at, last_seen_at, deleted_at, display_name FROM inserted
+func (q *Queries) UpsertModelRouterUserByEmail(ctx context.Context, arg UpsertModelRouterUserByEmailParams) (UpsertModelRouterUserByEmailRow, error) {
 	row := q.db.QueryRow(ctx, upsertModelRouterUserByEmail,
-		arg.InstallationID,
 		arg.Email,
-		arg.ClaudeAccountUUID,
 		arg.DisplayName,
+		arg.InstallationID,
+		arg.ClaudeAccountUUID,
 	)
-	var i RouterModelRouterUser
+	var i UpsertModelRouterUserByEmailRow
 	err := row.Scan(
 		&i.ID,
 		&i.InstallationID,


### PR DESCRIPTION
## Summary

- Rewrites \`UpsertModelRouterUserByEmail\` as a CTE that first attempts to UPDATE an existing UUID-only orphan in place (matched on \`(installation_id, claude_account_uuid)\` with \`email IS NULL\`), only INSERTing when no orphan exists.
- The fallback INSERT keeps the original ON CONFLICT email-keyed upsert so concurrent email-bearing requests still collapse onto a single row.

## Why

The previous query conflicted only on \`(installation_id, email)\`. When a request arrived with **both** \`email\` and \`account_uuid\` for an installation that already had a UUID-only row (created by an earlier email-less request via \`UpsertModelRouterUserByAccountUUID\`), it INSERTed a second row instead of merging — leaving the orphan permanently behind.

This is the exact path every customer hits the first time their team upgrades to an installer that sets \`X-Weave-User-Email\`. We reproduced it in WorkWeave prod immediately after redeploying with the identity headers feature: steven's UUID-only row from 2026-05-12 stayed orphaned, a new email+name row showed up next to it, and the dashboard picker now shows duplicates.

## Behavior matrix (verified locally against docker compose router DB)

| Initial state | Inbound | Expected result | Verified |
|---|---|---|---|
| Orphan row \`(uuid=X, email=NULL)\` | request with \`(uuid=X, email=Y, name=Z)\` | UPDATE in place — same \`id\`, email/name populated, \`first_seen_at\` preserved | ✅ |
| No row for \`uuid=X\` | request with \`(uuid=X, email=Y, name=Z)\` | INSERT new row | ✅ |
| Row already exists with \`email=Y\` | request with \`(uuid=X, email=Y, name=Z)\` | ON CONFLICT refresh \`last_seen_at\`, no new row | ✅ |

## Test plan

- [ ] CI green (existing \`internal/auth\` tests still pass with the regen'd sqlc — \`go test ./internal/auth/...\` passes locally)
- [ ] After this lands + WorkWeave bumps the gitlink, manually verify in WorkWeave prod that a teammate re-running the installer updates their existing \`account_uuid\`-only row in place rather than creating a second row.
- [ ] Existing email-bearing rows still refresh \`last_seen_at\` on every hit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)