### PR TITLE
fix(translate): inline $defs/$ref in tool schemas for OpenAI-compat upstreams

### DIFF
--- a/internal/translate/emit_openai.go
+++ b/internal/translate/emit_openai.go
@@ -375,7 +375,7 @@ func (e *RequestEnvelope) pullAnthropicTools(out map[string]any) error {
 		if tool == nil {
 			continue
 		}
-		params := tool["input_schema"]
+		params := inlineSchemaDefs(tool["input_schema"])
 		sanitizeOpenAIToolSchema(params)
 		fn := map[string]any{
 			"name":        tool["name"],
@@ -389,6 +389,93 @@ func (e *RequestEnvelope) pullAnthropicTools(out map[string]any) error {
 	}
 	out["tools"] = result
 	return nil
+}
+
+// inlineSchemaDefs replaces "$ref" pointers to "#/$defs/<name>" or
+// "#/definitions/<name>" with a deep copy of the referenced definition, then
+// strips the defs maps from the schema. Some OpenAI-compatible upstreams
+// (notably Fireworks) do not dereference $ref themselves and return a 400
+// ("Error resolving schema reference '#/$defs/X': AttributeError('NoneType'
+// object has no attribute 'lookup')") on tool schemas that use $defs. Inlining
+// before forwarding keeps the schema self-contained so it works on every
+// OpenAI-compat backend regardless of how its validator handles $ref.
+//
+// Cyclic refs are left intact (no infinite recursion); unresolvable refs are
+// left intact so the upstream can surface its own clearer error.
+func inlineSchemaDefs(node any) any {
+	root, ok := node.(map[string]any)
+	if !ok {
+		return node
+	}
+	defs := map[string]any{}
+	for _, key := range []string{"$defs", "definitions"} {
+		d, ok := root[key].(map[string]any)
+		if !ok {
+			continue
+		}
+		for name, v := range d {
+			defs[key+"/"+name] = v
+		}
+	}
+	if len(defs) == 0 {
+		return node
+	}
+	resolved, _ := resolveSchemaRefs(node, defs, map[string]struct{}{}).(map[string]any)
+	delete(resolved, "$defs")
+	delete(resolved, "definitions")
+	return resolved
+}
+
+func resolveSchemaRefs(node any, defs map[string]any, visited map[string]struct{}) any {
+	switch v := node.(type) {
+	case map[string]any:
+		if ref, ok := v["$ref"].(string); ok && len(v) == 1 {
+			name := strings.TrimPrefix(ref, "#/")
+			if _, cycle := visited[name]; cycle {
+				return v
+			}
+			target, ok := defs[name]
+			if !ok {
+				return v
+			}
+			visited[name] = struct{}{}
+			out := resolveSchemaRefs(deepCopyJSON(target), defs, visited)
+			delete(visited, name)
+			return out
+		}
+		out := make(map[string]any, len(v))
+		for k, child := range v {
+			out[k] = resolveSchemaRefs(child, defs, visited)
+		}
+		return out
+	case []any:
+		out := make([]any, len(v))
+		for i, child := range v {
+			out[i] = resolveSchemaRefs(child, defs, visited)
+		}
+		return out
+	default:
+		return v
+	}
+}
+
+func deepCopyJSON(node any) any {
+	switch v := node.(type) {
+	case map[string]any:
+		out := make(map[string]any, len(v))
+		for k, c := range v {
+			out[k] = deepCopyJSON(c)
+		}
+		return out
+	case []any:
+		out := make([]any, len(v))
+		for i, c := range v {
+			out[i] = deepCopyJSON(c)
+		}
+		return out
+	default:
+		return v
+	}
 }
 
 func sanitizeOpenAIToolSchema(node any) {

--- a/internal/translate/inline_defs_test.go
+++ b/internal/translate/inline_defs_test.go
@@ -1,0 +1,157 @@
+package translate
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestInlineSchemaDefs_resolvesDefsRef(t *testing.T) {
+	in := map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"attachment": map[string]any{"$ref": "#/$defs/Attachment"},
+		},
+		"$defs": map[string]any{
+			"Attachment": map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"url": map[string]any{"type": "string"},
+				},
+			},
+		},
+	}
+
+	out := inlineSchemaDefs(in).(map[string]any)
+
+	if _, ok := out["$defs"]; ok {
+		t.Fatalf("$defs not stripped: %#v", out)
+	}
+	got := out["properties"].(map[string]any)["attachment"]
+	want := map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"url": map[string]any{"type": "string"},
+		},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("ref not inlined.\n got=%#v\nwant=%#v", got, want)
+	}
+}
+
+func TestInlineSchemaDefs_resolvesDefinitionsRef(t *testing.T) {
+	in := map[string]any{
+		"properties": map[string]any{
+			"x": map[string]any{"$ref": "#/definitions/Foo"},
+		},
+		"definitions": map[string]any{
+			"Foo": map[string]any{"type": "string"},
+		},
+	}
+	out := inlineSchemaDefs(in).(map[string]any)
+	if _, ok := out["definitions"]; ok {
+		t.Fatalf("definitions not stripped")
+	}
+	got := out["properties"].(map[string]any)["x"]
+	want := map[string]any{"type": "string"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("got=%#v want=%#v", got, want)
+	}
+}
+
+func TestInlineSchemaDefs_resolvesNestedRef(t *testing.T) {
+	in := map[string]any{
+		"properties": map[string]any{
+			"outer": map[string]any{"$ref": "#/$defs/Outer"},
+		},
+		"$defs": map[string]any{
+			"Outer": map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"inner": map[string]any{"$ref": "#/$defs/Inner"},
+				},
+			},
+			"Inner": map[string]any{"type": "integer"},
+		},
+	}
+	out := inlineSchemaDefs(in).(map[string]any)
+	outer := out["properties"].(map[string]any)["outer"].(map[string]any)
+	inner := outer["properties"].(map[string]any)["inner"]
+	want := map[string]any{"type": "integer"}
+	if !reflect.DeepEqual(inner, want) {
+		t.Fatalf("nested ref not inlined: %#v", inner)
+	}
+}
+
+func TestInlineSchemaDefs_handlesCycle(t *testing.T) {
+	in := map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"root": map[string]any{"$ref": "#/$defs/Node"},
+		},
+		"$defs": map[string]any{
+			"Node": map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"next": map[string]any{"$ref": "#/$defs/Node"},
+				},
+			},
+		},
+	}
+	// Must not infinite-loop. The inner $ref is left intact when cycle detected.
+	out := inlineSchemaDefs(in).(map[string]any)
+	root := out["properties"].(map[string]any)["root"].(map[string]any)
+	next := root["properties"].(map[string]any)["next"].(map[string]any)
+	if next["$ref"] != "#/$defs/Node" {
+		t.Fatalf("expected cyclic $ref preserved, got %#v", next)
+	}
+}
+
+func TestInlineSchemaDefs_unresolvedRefPreserved(t *testing.T) {
+	in := map[string]any{
+		"properties": map[string]any{
+			"x": map[string]any{"$ref": "#/$defs/Missing"},
+		},
+		"$defs": map[string]any{
+			"Other": map[string]any{"type": "string"},
+		},
+	}
+	out := inlineSchemaDefs(in).(map[string]any)
+	got := out["properties"].(map[string]any)["x"].(map[string]any)
+	if got["$ref"] != "#/$defs/Missing" {
+		t.Fatalf("unresolved $ref dropped: %#v", got)
+	}
+}
+
+func TestInlineSchemaDefs_noDefsIsNoop(t *testing.T) {
+	in := map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"a": map[string]any{"type": "string"},
+		},
+	}
+	out := inlineSchemaDefs(in)
+	if !reflect.DeepEqual(out, in) {
+		t.Fatalf("no-defs case mutated input: %#v", out)
+	}
+}
+
+func TestInlineSchemaDefs_inlineCopiesNotShares(t *testing.T) {
+	// Two refs to the same def should produce independent copies, so a later
+	// in-place mutation (e.g. sanitizeOpenAIToolSchema) can't bleed across.
+	in := map[string]any{
+		"properties": map[string]any{
+			"a": map[string]any{"$ref": "#/$defs/T"},
+			"b": map[string]any{"$ref": "#/$defs/T"},
+		},
+		"$defs": map[string]any{
+			"T": map[string]any{"type": "array"},
+		},
+	}
+	out := inlineSchemaDefs(in).(map[string]any)
+	a := out["properties"].(map[string]any)["a"].(map[string]any)
+	b := out["properties"].(map[string]any)["b"].(map[string]any)
+	a["mutated"] = true
+	if _, leaked := b["mutated"]; leaked {
+		t.Fatalf("inlined refs share underlying map: %#v", b)
+	}
+}


### PR DESCRIPTION
## Summary

- Inline `$defs` / `definitions` `$ref` pointers in tool `input_schema` before forwarding to OpenAI-compat upstreams. Some backends (notably **Fireworks**) do not dereference `$ref` themselves and return a 400, breaking any Claude Code / MCP tool whose schema factors complex types into `$defs`.
- Cycles are detected (the `$ref` is left intact rather than infinite-looping); unresolvable refs are also preserved so upstream surfaces a clearer error than ours.

## Evidence (prod logs, `workweave-prod-01`)

Recurring every few minutes today on the router service:

```
level=ERROR msg="Upstream OpenAI-compatible provider returned error status"
status=400
base_url=https://api.fireworks.ai/inference/v1
routed_model=deepseek/deepseek-v4-pro
body_preview="...Error resolving schema reference '#/$defs/Attachment':
             AttributeError(\"'NoneType' object has no attribute 'lookup'\")"
```

A second variant (`#/properties/operations/items/anyOf/2/properties/asset_id`) confirms this isn't an "Attachment"-specific bug — it's any tool whose schema uses `$ref` against a sibling `$defs`. Affected users are those whose Claude Code session has such an MCP loaded **and** got routed to a Fireworks-hosted OSS model.

## Scope

Fix is intentionally limited to the OpenAI-compat emit path (`pullAnthropicTools` → `inlineSchemaDefs`) since that's where the 400s are observed. The Gemini path uses an allow-list that silently drops `$ref`s — a separate latent bug worth a follow-up, but not what's biting users right now.

## Test plan

- [x] `go test ./internal/translate/` passes (incl. 7 new tests in `inline_defs_test.go` covering `$defs` refs, `definitions` refs, nested refs, cycles, missing refs, no-defs no-op, and shared-reference copy isolation).
- [x] `go build ./...` clean.
- [ ] After merge: bump WorkWeave gitlink and confirm Fireworks 400s drop to zero in `workweave-prod-01` router logs.