### PR TITLE
fix(translate): guard empty-tools OpenRouter overrides and inline $defs in same-format Gemini path

### DIFF
--- a/internal/translate/crossformat_request_test.go
+++ b/internal/translate/crossformat_request_test.go
@@ -1286,6 +1286,62 @@ func TestCrossFormat_OpenAIToGemini_InvalidToolArgsReturnsError(t *testing.T) {
 	assert.Error(t, err, "invalid tool_call arguments should produce an error, not silently substitute {}")
 }
 
+func TestCrossFormat_AnthropicToOpenAI_EmptyToolsNoTemperatureOverride(t *testing.T) {
+	body := []byte(`{
+		"model": "claude-sonnet-4-20250514",
+		"messages": [
+			{"role": "user", "content": [{"type": "text", "text": "hi"}]}
+		],
+		"tools": [],
+		"max_tokens": 1024
+	}`)
+	env, err := translate.ParseAnthropic(body)
+	require.NoError(t, err)
+	// DeepSeek triggers tool-temperature-zero and system-reminder overrides.
+	prep, err := env.PrepareOpenAI(http.Header{}, translate.EmitOptions{
+		TargetModel: "deepseek/deepseek-chat",
+	})
+	require.NoError(t, err)
+
+	var doc map[string]any
+	require.NoError(t, json.Unmarshal(prep.Body, &doc))
+
+	// Empty tools must not trigger DeepSeek-specific overrides.
+	_, hasTemp := doc["temperature"]
+	assert.False(t, hasTemp, "empty tools must not trigger temperature override")
+}
+
+func TestCrossFormat_AnthropicToOpenAI_EmptyToolsNoSystemReminder(t *testing.T) {
+	body := []byte(`{
+		"model": "claude-sonnet-4-20250514",
+		"system": "You are helpful.",
+		"messages": [
+			{"role": "user", "content": [{"type": "text", "text": "hi"}]}
+		],
+		"tools": [],
+		"max_tokens": 1024
+	}`)
+	env, err := translate.ParseAnthropic(body)
+	require.NoError(t, err)
+	prep, err := env.PrepareOpenAI(http.Header{}, translate.EmitOptions{
+		TargetModel: "deepseek/deepseek-chat",
+	})
+	require.NoError(t, err)
+
+	var doc map[string]any
+	require.NoError(t, json.Unmarshal(prep.Body, &doc))
+
+	msgs := getArray(t, doc, "messages")
+	for _, m := range msgs {
+		msg := m.(map[string]any)
+		if msg["role"] == "system" {
+			content, _ := msg["content"].(string)
+			assert.NotContains(t, content, "file-edit tools",
+				"empty tools must not inject DeepSeek system reminder")
+		}
+	}
+}
+
 func TestCrossFormat_AnthropicToOpenAI_ToolUseWithMissingName(t *testing.T) {
 	// tool_use block with missing "name" field — must produce valid JSON, not malformed
 	body := []byte(`{

--- a/internal/translate/emit_gemini.go
+++ b/internal/translate/emit_gemini.go
@@ -115,7 +115,7 @@ func sanitizeGeminiToolsRaw(v any) any {
 			}
 			if params, ok := fdMap["parameters"]; ok && params != nil {
 				fdMap = copyMap(fdMap)
-				fdMap["parameters"] = sanitizeSchemaForGemini(params)
+				fdMap["parameters"] = sanitizeSchemaForGemini(inlineSchemaDefs(params))
 			}
 			sanitized[j] = fdMap
 		}

--- a/internal/translate/emit_openai.go
+++ b/internal/translate/emit_openai.go
@@ -13,6 +13,11 @@ import (
 	"github.com/tidwall/sjson"
 )
 
+func hasNonEmptyTools(body []byte) bool {
+	tools := gjson.GetBytes(body, "tools")
+	return tools.Exists() && tools.IsArray() && tools.Get("#").Int() > 0
+}
+
 // PrepareOpenAI builds an OpenAI Chat Completions request body.
 func (e *RequestEnvelope) PrepareOpenAI(in http.Header, opts EmitOptions) (providers.PreparedRequest, error) {
 	var body []byte
@@ -50,14 +55,14 @@ func (e *RequestEnvelope) buildOpenAIFromOpenAI(opts EmitOptions) ([]byte, error
 				return nil, fmt.Errorf("set openrouter reasoning hint: %w", err)
 			}
 		}
-		if reminder := openRouterSystemReminder(opts.TargetModel); reminder != "" && gjson.GetBytes(body, "tools").Exists() {
+		if reminder := openRouterSystemReminder(opts.TargetModel); reminder != "" && hasNonEmptyTools(body) {
 			body, err = applySystemReminderToBody(body, reminder)
 			if err != nil {
 				return nil, fmt.Errorf("set system reminder: %w", err)
 			}
 		}
 		if openRouterForcesToolTemperatureZero(opts.TargetModel) &&
-			gjson.GetBytes(body, "tools").Exists() &&
+			hasNonEmptyTools(body) &&
 			!gjson.GetBytes(body, "temperature").Exists() {
 			body, err = sjson.SetBytes(body, "temperature", 0)
 			if err != nil {
@@ -124,7 +129,7 @@ func (e *RequestEnvelope) buildOpenAIFromAnthropic(opts EmitOptions) ([]byte, er
 
 	// Tool temperature override for OpenRouter
 	if !clientSetTemp && targetIsOpenRouter(opts) && openRouterForcesToolTemperatureZero(opts.TargetModel) {
-		if gjson.GetBytes(body, "tools").Exists() {
+		if hasNonEmptyTools(body) {
 			jw.Key("temperature")
 			jw.Int(0)
 		}
@@ -166,8 +171,7 @@ func (e *RequestEnvelope) buildOpenAIFromAnthropic(opts EmitOptions) ([]byte, er
 // converting the Anthropic system field and messages array to OpenAI format.
 func writeOpenAISystemAndMessagesFromAnthropic(jw *jsonWriter, body []byte, opts EmitOptions) {
 	systemText := flattenAnthropicSystemGJSON(gjson.GetBytes(body, "system"))
-	hasTools := gjson.GetBytes(body, "tools").Exists()
-	if targetIsOpenRouter(opts) && hasTools {
+	if targetIsOpenRouter(opts) && hasNonEmptyTools(body) {
 		if reminder := openRouterSystemReminder(opts.TargetModel); reminder != "" {
 			if systemText == "" {
 				systemText = reminder

--- a/internal/translate/gemini_test.go
+++ b/internal/translate/gemini_test.go
@@ -878,6 +878,40 @@ func TestPrepareGemini_GeminiFormatSanitizesTools(t *testing.T) {
 	assert.NotNil(t, params["properties"])
 }
 
+func TestPrepareGemini_GeminiFormatInlinesSchemaRefs(t *testing.T) {
+	// Same-format Gemini path must inline $ref/$defs before sanitization,
+	// otherwise Gemini's allowlist strips them silently.
+	body := []byte(`{
+		"model": "gemini-3.1-pro-preview",
+		"contents": [{"role":"user","parts":[{"text":"hi"}]}],
+		"tools": [{
+			"functionDeclarations": [{
+				"name":"test",
+				"parameters":{
+					"type":"object",
+					"properties":{
+						"item": {"$ref": "#/$defs/Item"}
+					},
+					"$defs": {
+						"Item": {"type":"object","properties":{"name":{"type":"string"}}}
+					}
+				}
+			}]
+		}]
+	}`)
+	env, err := translate.ParseGemini(body)
+	require.NoError(t, err)
+	prep, err := env.PrepareGemini(http.Header{}, translate.EmitOptions{})
+	require.NoError(t, err)
+
+	out := mustUnmarshal(t, prep.Body)
+	params := out["tools"].([]any)[0].(map[string]any)["functionDeclarations"].([]any)[0].(map[string]any)["parameters"].(map[string]any)
+	item := params["properties"].(map[string]any)["item"].(map[string]any)
+	assert.NotContains(t, item, "$ref", "$ref must be inlined, not left as pointer")
+	assert.Equal(t, "object", item["type"], "inlined item should have type:object")
+	assert.NotContains(t, params, "$defs", "$defs must be removed after inlining")
+}
+
 func TestPrepareGemini_ConvertsBoolPropertySchemas(t *testing.T) {
 	// JSON Schema allows boolean schemas as property values (true = any type).
 	// Gemini's proto Schema rejects them. They must be converted to empty Schema.

--- a/internal/translate/provider_hint_test.go
+++ b/internal/translate/provider_hint_test.go
@@ -229,3 +229,20 @@ func TestPrepareOpenAI_QwenAndGoogleGetSortHint(t *testing.T) {
 		})
 	}
 }
+
+func TestPrepareOpenAI_OpenAISource_EmptyToolsNoOverrides(t *testing.T) {
+	src := []byte(`{"model":"x","messages":[{"role":"user","content":"hi"}],"tools":[],"max_tokens":256}`)
+	env, err := translate.ParseOpenAI(src)
+	require.NoError(t, err)
+
+	out, err := env.PrepareOpenAI(nil, translate.EmitOptions{
+		TargetModel: "deepseek/deepseek-chat",
+	})
+	require.NoError(t, err)
+
+	var doc map[string]any
+	require.NoError(t, json.Unmarshal(out.Body, &doc))
+
+	_, hasTemp := doc["temperature"]
+	assert.False(t, hasTemp, "empty tools must not trigger temperature override")
+}


### PR DESCRIPTION
## Summary

Two pre-existing bugs found by Cursor Bugbot on PR #198 (filed against the final squash-merged commit). Neither was introduced by that PR — both exist on main.

### Bug 1: Empty tools array triggers OpenRouter-only overrides

`gjson.GetBytes(body, "tools").Exists()` returns `true` for `"tools": []` and `"tools": null`. The tool-temperature override (forces `temperature: 0` for DeepSeek) and system-reminder injection both gated on `.Exists()`, meaning requests with empty/null tools arrays got these overrides applied despite no tools appearing in the output.

**Fix**: Extract `hasNonEmptyTools()` that checks `exists && isArray && count > 0`. Applied to all four gating locations (same-format OpenAI path: system reminder + temperature; cross-format Anthropic→OpenAI path: temperature + system reminder).

### Bug 2: Same-format Gemini path missing `inlineSchemaDefs`

`sanitizeGeminiToolsRaw` called `sanitizeSchemaForGemini` but not `inlineSchemaDefs` first. MCP tools with `$ref`/`$defs` in their JSON Schema parameters had those references silently stripped by Gemini's allowlist sanitizer, degrading the schema. The cross-format paths (OpenAI→Gemini, Anthropic→Gemini) were already fixed in #198; the same-format path was missed.

**Fix**: Add `inlineSchemaDefs()` call before `sanitizeSchemaForGemini()` in `sanitizeGeminiToolsRaw`.

## Test plan

- [x] `TestCrossFormat_AnthropicToOpenAI_EmptyToolsNoTemperatureOverride` — empty tools must not force temperature=0
- [x] `TestCrossFormat_AnthropicToOpenAI_EmptyToolsNoSystemReminder` — empty tools must not inject DeepSeek system reminder
- [x] `TestPrepareOpenAI_OpenAISource_EmptyToolsNoOverrides` — same-format path empty tools guard
- [x] `TestPrepareGemini_GeminiFormatInlinesSchemaRefs` — same-format Gemini path resolves $ref/$defs before sanitization
- [x] Full test suite passes (all packages)

🤖 Generated with [Claude Code](https://claude.com/claude-code)