### PR TITLE
refactor(proxy): simplify user-facing routing marker

### DIFF
--- a/internal/proxy/marker_internal_test.go
+++ b/internal/proxy/marker_internal_test.go
@@ -13,7 +13,7 @@ import (
 func TestRoutingMarkerFor_TierClampNote(t *testing.T) {
 	t.Parallel()
 
-	t.Run("haiku-ceiling clamp suggests sonnet upsell", func(t *testing.T) {
+	t.Run("low-tier clamp names the would-have model", func(t *testing.T) {
 		res := turnLoopResult{
 			Decision:      router.Decision{Model: "claude-haiku-4-5", Provider: "anthropic"},
 			TierClamped:   true,
@@ -21,13 +21,12 @@ func TestRoutingMarkerFor_TierClampNote(t *testing.T) {
 			RequestedTier: catalog.TierLow,
 		}
 		got := routingMarkerFor(res)
-		assert.Contains(t, got, "second-choice pick")
-		assert.Contains(t, got, "deepseek/deepseek-v4-pro")
-		assert.Contains(t, got, "low tier")
-		assert.Contains(t, got, "claude-sonnet-4-5")
+		assert.Contains(t, got, "second-choice pick at low tier")
+		assert.Contains(t, got, "(would have used deepseek/deepseek-v4-pro)")
+		assert.NotContains(t, got, "to unlock", "upsell suffix dropped from the simplified note")
 	})
 
-	t.Run("sonnet-ceiling clamp suggests opus upsell", func(t *testing.T) {
+	t.Run("mid-tier clamp names the would-have model", func(t *testing.T) {
 		res := turnLoopResult{
 			Decision:      router.Decision{Model: "claude-sonnet-4-5", Provider: "anthropic"},
 			TierClamped:   true,
@@ -35,9 +34,9 @@ func TestRoutingMarkerFor_TierClampNote(t *testing.T) {
 			RequestedTier: catalog.TierMid,
 		}
 		got := routingMarkerFor(res)
-		assert.Contains(t, got, "claude-opus-4-7")
-		assert.Contains(t, got, "mid tier")
-		assert.Contains(t, got, "claude-opus-4-7 to unlock")
+		assert.Contains(t, got, "second-choice pick at mid tier")
+		assert.Contains(t, got, "(would have used claude-opus-4-7)")
+		assert.NotContains(t, got, "to unlock")
 	})
 
 	t.Run("no clamp emits no note", func(t *testing.T) {
@@ -69,13 +68,12 @@ func TestRoutingMarkerFor_PlannerPaths(t *testing.T) {
 				PlannerDecision: planner.Decision{Reason: planner.ReasonEVPositive},
 			},
 			wantContains: []string{
-				"✦ **Weave Router** → deepseek/deepseek-v4-pro (openrouter)",
-				"reason: switched to save on cache reads",
+				"✦ **Weave Router** → deepseek/deepseek-v4-pro · switched for cheaper cache reuse",
 			},
 			wantNotContain: []string{
+				"(openrouter)",
+				"reason:",
 				"ev_positive",
-				"est. save",
-				"saved $",
 			},
 		},
 		{
@@ -85,37 +83,88 @@ func TestRoutingMarkerFor_PlannerPaths(t *testing.T) {
 				PlannerDecision: planner.Decision{Reason: planner.ReasonEVNegative},
 			},
 			wantContains: []string{
-				"reason: stayed: cache reuse beats the switch",
+				"· stayed on your last pick",
 			},
 			wantNotContain: []string{
+				"(openrouter)",
+				"reason:",
 				"ev_negative",
-				"est. save",
 			},
 		},
 		{
-			name: "same_model: planner ran with trivial outcome",
+			name: "no_prior_usage: collapses into stayed bucket",
+			res: turnLoopResult{
+				Decision:        decision,
+				PlannerDecision: planner.Decision{Reason: planner.ReasonNoPriorUsage},
+			},
+			wantContains: []string{
+				"· stayed on your last pick",
+			},
+			wantNotContain: []string{
+				"no cache stats",
+			},
+		},
+		{
+			name: "same_model: collapses into best-pick bucket",
 			res: turnLoopResult{
 				Decision:        decision,
 				PlannerDecision: planner.Decision{Reason: planner.ReasonSameModel},
 			},
 			wantContains: []string{
-				"reason: scorer matches the pin",
+				"· best pick for this turn",
 			},
 			wantNotContain: []string{
-				"est. save",
-				"same_model",
+				"scorer matches the pin",
+				"reason:",
 			},
 		},
 		{
-			name: "no planner ran, fresh decision: top-scorer fallback reason",
+			name: "tier_upgrade: planner bumped to a higher tier",
+			res: turnLoopResult{
+				Decision:        decision,
+				PlannerDecision: planner.Decision{Reason: planner.ReasonTierUpgrade},
+			},
+			wantContains: []string{
+				"· upgraded to a stronger tier",
+			},
+		},
+		{
+			name: "pricing_missing: recovery code is silenced",
+			res: turnLoopResult{
+				Decision:        decision,
+				PlannerDecision: planner.Decision{Reason: planner.ReasonPricingMissing},
+			},
+			wantContains: []string{
+				"✦ **Weave Router** → deepseek/deepseek-v4-pro",
+			},
+			wantNotContain: []string{
+				"·",
+				"pricing",
+				"missing",
+			},
+		},
+		{
+			name: "pin_model_missing: recovery code is silenced",
+			res: turnLoopResult{
+				Decision:        decision,
+				PlannerDecision: planner.Decision{Reason: planner.ReasonPinModelMissing},
+			},
+			wantNotContain: []string{
+				"·",
+				"pin model",
+			},
+		},
+		{
+			name: "no planner ran, fresh decision: best-pick fallback",
 			res: turnLoopResult{
 				Decision: decision,
 			},
 			wantContains: []string{
-				"reason: top scorer",
+				"· best pick for this turn",
 			},
 			wantNotContain: []string{
-				"est. save",
+				"top scorer",
+				"reason:",
 			},
 		},
 		{
@@ -125,10 +174,11 @@ func TestRoutingMarkerFor_PlannerPaths(t *testing.T) {
 				HardPinned: true,
 			},
 			wantContains: []string{
-				"reason: hard pin (compaction / sub-agent)",
+				"· pinned for compaction / sub-agent",
 			},
 			wantNotContain: []string{
-				"est. save",
+				"hard pin",
+				"reason:",
 			},
 		},
 		{
@@ -165,19 +215,22 @@ func TestRoutingMarkerFor_EmptyDecisionEmitsNothing(t *testing.T) {
 	assert.Empty(t, got)
 }
 
-func TestRoutingMarkerFor_OmitsProviderParensWhenProviderMissing(t *testing.T) {
+func TestRoutingMarkerFor_DropsProviderEvenWhenSet(t *testing.T) {
 	got := routingMarkerFor(turnLoopResult{
-		Decision: router.Decision{Model: "claude-haiku-4-5"},
+		Decision: router.Decision{Model: "claude-haiku-4-5", Provider: "anthropic"},
 		PlannerDecision: planner.Decision{
 			Reason: planner.ReasonNoPin,
 		},
 	})
 	assert.Contains(t, got, "✦ **Weave Router** → claude-haiku-4-5 ·")
+	assert.NotContains(t, got, "(anthropic)", "provider must not leak into the user-facing marker")
 	assert.NotContains(t, got, "()")
-	assert.Contains(t, got, "reason: top scorer")
+	assert.Contains(t, got, "· best pick for this turn")
 }
 
-func TestHumanReasonFromPlanner_UnknownCodePassesThrough(t *testing.T) {
+func TestHumanReasonFromPlanner_UnknownCodeIsSilenced(t *testing.T) {
+	// Unknown codes return empty so a new planner reason can't leak its
+	// snake_case label into the user-facing marker.
 	got := humanReasonFromPlanner("brand_new_reason_v9")
-	assert.Equal(t, "brand_new_reason_v9", got)
+	assert.Empty(t, got)
 }

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -114,8 +114,8 @@ type InstallationExcludedModelsContextKey struct{}
 // installationExcludedModelsFromContext returns the per-installation exclusion
 // list stashed on ctx by the auth middleware, or nil when none is present.
 
-// routingMarkerFor builds the "brand -> model . reason" snippet emitted
-// at the start of every cross-format streamed response.
+// routingMarkerFor builds the "brand → model · note" snippet emitted at the
+// start of every cross-format streamed response.
 func routingMarkerFor(res turnLoopResult) string {
 	decision := res.Decision
 	if decision.Model == "" {
@@ -127,11 +127,8 @@ func routingMarkerFor(res turnLoopResult) string {
 		return ""
 	}
 	parts := []string{"✦ **Weave Router** → " + decision.Model}
-	if decision.Provider != "" {
-		parts[0] += " (" + decision.Provider + ")"
-	}
 	if reason := routingReasonShort(res); reason != "" {
-		parts = append(parts, "reason: "+reason)
+		parts = append(parts, reason)
 	}
 	if note := clampNote(res); note != "" {
 		parts = append(parts, note)
@@ -144,61 +141,36 @@ func clampNote(res turnLoopResult) string {
 	if !res.TierClamped || res.PreClampModel == "" {
 		return ""
 	}
-	upsell := upsellModelFor(res.RequestedTier)
-	if upsell == "" {
-		return fmt.Sprintf("second-choice pick (would have used %s — capped to your requested %s tier)", res.PreClampModel, res.RequestedTier.String())
-	}
-	return fmt.Sprintf("second-choice pick (would have used %s — capped to your requested %s tier; request %s to unlock higher-tier picks)", res.PreClampModel, res.RequestedTier.String(), upsell)
+	return fmt.Sprintf("second-choice pick at %s tier (would have used %s)", res.RequestedTier.String(), res.PreClampModel)
 }
 
-// upsellModelFor returns the conventional next-tier-up model name for the
-// clamp note. High tier has no upsell.
-func upsellModelFor(t catalog.Tier) string {
-	switch t {
-	case catalog.TierLow:
-		return "claude-sonnet-4-5"
-	case catalog.TierMid:
-		return "claude-opus-4-7"
-	default:
-		return ""
-	}
-}
-
-// routingReasonShort returns a human-readable reason for the marker.
+// routingReasonShort returns a short user-facing reason for the routing
+// decision, or empty when the underlying code is internal recovery noise.
 func routingReasonShort(res turnLoopResult) string {
+	if res.HardPinned {
+		return "pinned for compaction / sub-agent"
+	}
 	if res.PlannerDecision.Reason != "" {
 		return humanReasonFromPlanner(res.PlannerDecision.Reason)
 	}
-	if res.HardPinned {
-		return "hard pin (compaction / sub-agent)"
-	}
-	if res.StickyHit {
-		return "tool-result follow-up"
-	}
-	return "top scorer"
+	return "best pick for this turn"
 }
 
-// humanReasonFromPlanner maps planner reason codes to marker prose.
+// humanReasonFromPlanner maps planner reason codes to short user-facing prose.
+// Recovery codes (pin_model_missing, pricing_missing) and unknown codes return
+// empty so the marker stays clean.
 func humanReasonFromPlanner(code string) string {
 	switch code {
 	case planner.ReasonEVPositive:
-		return "switched to save on cache reads"
-	case planner.ReasonEVNegative:
-		return "stayed: cache reuse beats the switch"
-	case planner.ReasonSameModel:
-		return "scorer matches the pin"
-	case planner.ReasonNoPin:
-		return "top scorer"
-	case planner.ReasonNoPriorUsage:
-		return "no cache stats yet"
-	case planner.ReasonPinModelMissing:
-		return "pin model no longer available"
-	case planner.ReasonPricingMissing:
-		return "missing pricing for a candidate"
+		return "switched for cheaper cache reuse"
+	case planner.ReasonEVNegative, planner.ReasonNoPriorUsage:
+		return "stayed on your last pick"
 	case planner.ReasonTierUpgrade:
-		return "model tier upgrade"
+		return "upgraded to a stronger tier"
+	case planner.ReasonNoPin, planner.ReasonSameModel:
+		return "best pick for this turn"
 	default:
-		return code
+		return ""
 	}
 }
 

--- a/internal/translate/strip_marker_test.go
+++ b/internal/translate/strip_marker_test.go
@@ -15,17 +15,16 @@ import (
 const markerSentinel = "✦ **Weave Router**"
 
 // Sample markers covering every humanReasonFromPlanner output and the
-// no-planner fallbacks ("hard pin", "tool-result follow-up", "top scorer")
-// plus the clamp note tail. Keep in sync with internal/proxy/service.go.
+// no-planner fallbacks plus the clamp note tail.
+// Keep in sync with internal/proxy/service.go.
 var sampleMarkers = []string{
-	"✦ **Weave Router** → claude-haiku-4-5 (anthropic) · reason: top scorer\n\n",
-	"✦ **Weave Router** → deepseek/deepseek-v4-pro (openrouter) · reason: scorer matches the pin\n\n",
-	"✦ **Weave Router** → deepseek/deepseek-v4-pro (openrouter) · reason: tool-result follow-up\n\n",
-	"✦ **Weave Router** → deepseek/deepseek-v4-pro (openrouter) · reason: switched to save on cache reads\n\n",
-	"✦ **Weave Router** → deepseek/deepseek-v4-pro (openrouter) · reason: stayed: cache reuse beats the switch\n\n",
-	"✦ **Weave Router** → claude-sonnet-4-5 (anthropic) · reason: model tier upgrade\n\n",
-	"✦ **Weave Router** → gemini-3.1-flash-lite-preview (google) · reason: hard pin (compaction / sub-agent)\n\n",
-	"✦ **Weave Router** → claude-opus-4-7 · reason: top scorer · second-choice pick (would have used claude-sonnet-4-5 — capped to your requested mid tier; request claude-opus-4-7 to unlock higher-tier picks)\n\n",
+	"✦ **Weave Router** → claude-haiku-4-5 · best pick for this turn\n\n",
+	"✦ **Weave Router** → deepseek/deepseek-v4-pro · switched for cheaper cache reuse\n\n",
+	"✦ **Weave Router** → deepseek/deepseek-v4-pro · stayed on your last pick\n\n",
+	"✦ **Weave Router** → claude-sonnet-4-5 · upgraded to a stronger tier\n\n",
+	"✦ **Weave Router** → gemini-3.1-flash-lite-preview · pinned for compaction / sub-agent\n\n",
+	"✦ **Weave Router** → deepseek/deepseek-v4-pro\n\n",
+	"✦ **Weave Router** → claude-haiku-4-5 · best pick for this turn · second-choice pick at low tier (would have used deepseek/deepseek-v4-pro)\n\n",
 }
 
 func TestStripRoutingMarker_AssistantBlockExactMatch(t *testing.T) {


### PR DESCRIPTION
## Summary

The routing marker injected at the start of every cross-format response (`✦ **Weave Router** → ...`) had grown verbose. Two specific complaints:

- The `(provider)` parenthetical leaks an implementation detail end users don't care about.
- The reason strings use internal vocabulary (`scorer`, `pin`, `cache reuse beats the switch`) that's confusing without the codebase open.

This trims the marker on three axes:

1. **Drop the provider.** `… → claude-haiku-4-5 (anthropic) …` → `… → claude-haiku-4-5 …`.
2. **Drop the `reason:` label.** Redundant — the snippet's role is already understood as routing context.
3. **Collapse the 8 planner reasons into 4 user-meaningful buckets.** Silence the two recovery codes entirely so the user just sees the model with no jargon.

| planner reason | before | after |
|---|---|---|
| `ev_positive` | switched to save on cache reads | switched for cheaper cache reuse |
| `ev_negative` | stayed: cache reuse beats the switch | stayed on your last pick |
| `no_prior_usage` | no cache stats yet | stayed on your last pick |
| `tier_upgrade` | model tier upgrade | upgraded to a stronger tier |
| `no_pin` | top scorer | best pick for this turn |
| `same_model` | scorer matches the pin | best pick for this turn |
| `pin_model_missing` | pin model no longer available | *(silent, marker shows model only)* |
| `pricing_missing` | missing pricing for a candidate | *(silent, marker shows model only)* |
| unknown code | (leaked raw snake_case) | *(silent)* |

The `hard pin (compaction / sub-agent)` and `tool-result follow-up` no-planner branches also shrink: `hard pin` becomes `pinned for compaction / sub-agent`, and the `tool-result follow-up` string is gone (only reachable on `StickyHit + TierClamped`, where the clamp note already conveys what's interesting).

The tier-clamp note loses its em-dash and upsell hint:

```
before: second-choice pick (would have used deepseek/deepseek-v4-pro — capped to your requested low tier; request claude-sonnet-4-5 to unlock higher-tier picks)
after:  second-choice pick at low tier (would have used deepseek/deepseek-v4-pro)
```

`upsellModelFor` is removed (was only used by the dropped suffix).

## Before vs after

```
old: ✦ **Weave Router** → deepseek/deepseek-v4-pro (openrouter) · reason: switched to save on cache reads
new: ✦ **Weave Router** → deepseek/deepseek-v4-pro · switched for cheaper cache reuse

old: ✦ **Weave Router** → claude-haiku-4-5 (anthropic) · reason: top scorer · second-choice pick (would have used deepseek/deepseek-v4-pro — capped to your requested low tier; request claude-sonnet-4-5 to unlock higher-tier picks)
new: ✦ **Weave Router** → claude-haiku-4-5 · best pick for this turn · second-choice pick at low tier (would have used deepseek/deepseek-v4-pro)

old: ✦ **Weave Router** → claude-opus-4-7 (anthropic) · reason: missing pricing for a candidate
new: ✦ **Weave Router** → claude-opus-4-7
```

## Test plan

- [x] `go test ./internal/proxy/ -run 'TestRoutingMarker|TestHumanReason' -count=1 -v` — all pass
- [x] `go test ./internal/translate/ -run TestStripRoutingMarker -count=1` — all pass (envelope strip regex is unchanged; sample markers updated to the new shapes)
- [x] `go build ./internal/proxy/ ./internal/translate/` — clean
- [ ] Manually verify a streamed `/v1/messages` response carries the trimmed marker and the strip step removes it on the next turn

🤖 Generated with [Claude Code](https://claude.com/claude-code)