### PR TITLE
fix(translate): strip orphaned tool_results after handover trim

### DIFF
--- a/internal/router/handover/summarizer_test.go
+++ b/internal/router/handover/summarizer_test.go
@@ -1,6 +1,7 @@
 package handover_test
 
 import (
+	"net/http"
 	"strings"
 	"testing"
 
@@ -8,6 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/tidwall/gjson"
 
+	"workweave/router/internal/router"
 	"workweave/router/internal/router/handover"
 	"workweave/router/internal/translate"
 )
@@ -201,4 +203,208 @@ func TestTrimLastN_NilEnvelopeReturnsZero(t *testing.T) {
 
 	got := handover.TrimLastN(nil, 5)
 	assert.Equal(t, 0, got)
+}
+
+func TestTrimLastN_StripsOrphanedAnthropicToolResults(t *testing.T) {
+	t.Parallel()
+
+	// 5 messages: user text, assistant with tool_use, user with tool_result,
+	// assistant text, user text. TrimLastN(3) keeps the last 3, which starts
+	// with the user tool_result whose matching tool_use was trimmed.
+	const body = `{
+  "model": "claude-opus-4-7",
+  "messages": [
+    {"role": "user", "content": "hello"},
+    {"role": "assistant", "content": [{"type": "tool_use", "id": "t1", "name": "bash", "input": {}}]},
+    {"role": "user", "content": [{"type": "tool_result", "tool_use_id": "t1", "content": "ok"}]},
+    {"role": "assistant", "content": "done"},
+    {"role": "user", "content": "next question"}
+  ]
+}`
+	env, err := translate.ParseAnthropic([]byte(body))
+	require.NoError(t, err)
+
+	elided := handover.TrimLastN(env, 3)
+	assert.Equal(t, 2, elided)
+
+	prep, err := env.PrepareAnthropic(nil, translate.EmitOptions{TargetModel: "claude-opus-4-7"})
+	require.NoError(t, err)
+	msgs := gjson.GetBytes(prep.Body, "messages").Array()
+
+	// The orphaned tool_result user message should be stripped entirely,
+	// leaving only [assistant "done", user "next question"].
+	require.Len(t, msgs, 2)
+	assert.Equal(t, "assistant", msgs[0].Get("role").String())
+	assert.Equal(t, "done", msgs[0].Get("content").String())
+	assert.Equal(t, "user", msgs[1].Get("role").String())
+	assert.Equal(t, "next question", msgs[1].Get("content").String())
+}
+
+func TestTrimLastN_PreservesMatchedToolResults(t *testing.T) {
+	t.Parallel()
+
+	// Last 3 messages include both tool_use and tool_result — should be preserved.
+	const body = `{
+  "model": "claude-opus-4-7",
+  "messages": [
+    {"role": "user", "content": "start"},
+    {"role": "assistant", "content": "ack"},
+    {"role": "user", "content": "do it"},
+    {"role": "assistant", "content": [{"type": "tool_use", "id": "t2", "name": "edit", "input": {}}]},
+    {"role": "user", "content": [{"type": "tool_result", "tool_use_id": "t2", "content": "edited"}]}
+  ]
+}`
+	env, err := translate.ParseAnthropic([]byte(body))
+	require.NoError(t, err)
+
+	elided := handover.TrimLastN(env, 3)
+	assert.Equal(t, 2, elided)
+
+	prep, err := env.PrepareAnthropic(nil, translate.EmitOptions{TargetModel: "claude-opus-4-7"})
+	require.NoError(t, err)
+	msgs := gjson.GetBytes(prep.Body, "messages").Array()
+
+	require.Len(t, msgs, 3)
+	assert.Equal(t, "user", msgs[0].Get("role").String())
+	assert.Equal(t, "assistant", msgs[1].Get("role").String())
+	assert.Equal(t, "edit", msgs[1].Get("content.0.name").String())
+	assert.Equal(t, "user", msgs[2].Get("role").String())
+	assert.Equal(t, "t2", msgs[2].Get("content.0.tool_use_id").String())
+}
+
+func TestTrimLastN_StripsOrphanedOpenAIToolMessages(t *testing.T) {
+	t.Parallel()
+
+	const body = `{
+  "model": "gpt-5",
+  "messages": [
+    {"role": "system", "content": "sys"},
+    {"role": "user", "content": "hi"},
+    {"role": "assistant", "content": null, "tool_calls": [{"id": "tc1", "type": "function", "function": {"name": "search", "arguments": "{}"}}]},
+    {"role": "tool", "tool_call_id": "tc1", "content": "result"},
+    {"role": "assistant", "content": "here you go"},
+    {"role": "user", "content": "thanks"}
+  ]
+}`
+	env, err := translate.ParseOpenAI([]byte(body))
+	require.NoError(t, err)
+
+	elided := handover.TrimLastN(env, 3)
+	assert.Equal(t, 2, elided)
+
+	prep, err := env.PrepareOpenAI(nil, translate.EmitOptions{TargetModel: "gpt-5"})
+	require.NoError(t, err)
+	msgs := gjson.GetBytes(prep.Body, "messages").Array()
+
+	// system preserved + orphaned tool message stripped → [system, assistant, user]
+	require.Len(t, msgs, 3)
+	assert.Equal(t, "system", msgs[0].Get("role").String())
+	assert.Equal(t, "assistant", msgs[1].Get("role").String())
+	assert.Equal(t, "here you go", msgs[1].Get("content").String())
+	assert.Equal(t, "user", msgs[2].Get("role").String())
+}
+
+func TestRewriteEnvelope_StripsToolResultsFromLatestUser(t *testing.T) {
+	t.Parallel()
+
+	// Conversation ends with a user tool_result message (mid-tool-use).
+	const body = `{
+  "model": "claude-opus-4-7",
+  "system": "sys",
+  "messages": [
+    {"role": "user", "content": "run a search"},
+    {"role": "assistant", "content": [{"type": "tool_use", "id": "t1", "name": "search", "input": {}}]},
+    {"role": "user", "content": [{"type": "tool_result", "tool_use_id": "t1", "content": "found it"}]}
+  ]
+}`
+	env, err := translate.ParseAnthropic([]byte(body))
+	require.NoError(t, err)
+
+	elided := handover.RewriteEnvelope(env, "User asked for a search.")
+
+	// Latest user had only tool_results which are all orphaned after rewrite
+	// (summary has no tool_use). It gets dropped → only summary remains.
+	assert.Equal(t, 3, elided)
+
+	prep, err := env.PrepareAnthropic(nil, translate.EmitOptions{TargetModel: "claude-opus-4-7"})
+	require.NoError(t, err)
+	msgs := gjson.GetBytes(prep.Body, "messages").Array()
+	require.Len(t, msgs, 1, "only summary when latest user was purely tool_results")
+	assert.Equal(t, "assistant", msgs[0].Get("role").String())
+}
+
+// Regression test for the exact failure path observed in production:
+// mid-session model switch triggers TrimLastN → orphaned tool_result blocks
+// survive into the Anthropic→Gemini translation → empty function_response.name
+// → Gemini 400.
+func TestTrimLastN_ThenPrepareGemini_NoEmptyFunctionResponseName(t *testing.T) {
+	t.Parallel()
+
+	// Simulates a Conductor/Claude-Code session with multiple tool-use rounds
+	// followed by a text turn. TrimLastN(3) orphans the tool_result in msg[4].
+	const body = `{
+  "model": "claude-opus-4-7",
+  "system": "You are a helpful assistant.",
+  "messages": [
+    {"role": "user", "content": "explain deepinfra pricing"},
+    {"role": "assistant", "content": [
+      {"type": "text", "text": "Let me look that up."},
+      {"type": "tool_use", "id": "tu_web1", "name": "WebFetch", "input": {"url": "https://deepinfra.com/pricing"}},
+      {"type": "tool_use", "id": "tu_web2", "name": "WebSearch", "input": {"query": "deepinfra pricing"}}
+    ]},
+    {"role": "user", "content": [
+      {"type": "tool_result", "tool_use_id": "tu_web1", "content": "pricing page content"},
+      {"type": "tool_result", "tool_use_id": "tu_web2", "content": "search results"}
+    ]},
+    {"role": "assistant", "content": [{"type": "text", "text": "Here are the pricing details..."}]},
+    {"role": "user", "content": "now compare with fireworks"},
+    {"role": "assistant", "content": [
+      {"type": "tool_use", "id": "tu_web3", "name": "WebFetch", "input": {"url": "https://fireworks.ai/pricing"}},
+      {"type": "tool_use", "id": "tu_web4", "name": "WebSearch", "input": {"query": "fireworks pricing"}}
+    ]},
+    {"role": "user", "content": [
+      {"type": "tool_result", "tool_use_id": "tu_web3", "content": "fireworks pricing"},
+      {"type": "tool_result", "tool_use_id": "tu_web4", "content": "fireworks search results"}
+    ]},
+    {"role": "assistant", "content": [{"type": "text", "text": "Fireworks costs $X..."}]},
+    {"role": "user", "content": "give me similar analysis for together.ai"}
+  ]
+}`
+	env, err := translate.ParseAnthropic([]byte(body))
+	require.NoError(t, err)
+
+	// Simulate the handover switch path (summarizer not wired → TrimLastN).
+	handover.TrimLastN(env, 3)
+
+	// Now translate to Gemini — this is the path that produced the 400.
+	prep, err := env.PrepareGemini(http.Header{}, translate.EmitOptions{
+		TargetModel:  "gemini-3.1-flash-lite-preview",
+		Capabilities: router.ModelSpec{},
+	})
+	require.NoError(t, err)
+
+	// Walk every part in the Gemini output and verify no functionResponse
+	// has an empty name.
+	contents := gjson.GetBytes(prep.Body, "contents")
+	require.True(t, contents.IsArray(), "expected contents array")
+
+	contents.ForEach(func(_, entry gjson.Result) bool {
+		entry.Get("parts").ForEach(func(_, part gjson.Result) bool {
+			fr := part.Get("functionResponse")
+			if !fr.Exists() {
+				return true
+			}
+			name := fr.Get("name").String()
+			assert.NotEmpty(t, name,
+				"functionResponse.name must not be empty (would cause Gemini 400); contents entry role=%s",
+				entry.Get("role").String())
+			return true
+		})
+		return true
+	})
+
+	// Also verify the conversation is structurally valid — should have the
+	// trimmed messages without orphaned tool results.
+	contentsArr := contents.Array()
+	assert.GreaterOrEqual(t, len(contentsArr), 2, "should have at least the last assistant + user turns")
 }

--- a/internal/translate/emit_gemini.go
+++ b/internal/translate/emit_gemini.go
@@ -250,6 +250,9 @@ func writeGeminiFromOpenAI(jw *jsonWriter, body []byte, opts EmitOptions) error 
 		case "tool":
 			tcID := msg.Get("tool_call_id").String()
 			name := toolNames[tcID]
+			if name == "" {
+				return true
+			}
 			result := toolResultContentGJSON(msg.Get("content"))
 			if !hasContents {
 				jw.Key("contents")
@@ -712,6 +715,9 @@ func anthropicUserPartsGJSON(content gjson.Result, toolNames map[string]string) 
 			case "tool_result":
 				id := block.Get("tool_use_id").String()
 				name := toolNames[id]
+				if name == "" {
+					return true
+				}
 				result := toolResultContentGJSON(block.Get("content"))
 				pw := newJSONWriter()
 				pw.Obj()

--- a/internal/translate/gemini_test.go
+++ b/internal/translate/gemini_test.go
@@ -217,6 +217,57 @@ func TestPrepareGemini_FromAnthropic_SystemAndToolUseRoundTripsSignature(t *test
 	assert.Equal(t, "bash", fr["name"])
 }
 
+func TestPrepareGemini_FromAnthropic_DropsOrphanedToolResult(t *testing.T) {
+	// tool_result without matching tool_use — name lookup yields "".
+	// The emitter must skip it rather than producing empty function_response.name.
+	body := []byte(`{
+		"messages": [
+			{"role":"user","content":[
+				{"type":"tool_result","tool_use_id":"orphan","content":"stale result"},
+				{"type":"text","text":"hello"}
+			]}
+		]
+	}`)
+	env, _ := translate.ParseAnthropic(body)
+	prep, err := env.PrepareGemini(http.Header{}, translate.EmitOptions{Capabilities: router.ModelSpec{}})
+	require.NoError(t, err)
+
+	out := mustUnmarshal(t, prep.Body)
+	contents := out["contents"].([]any)
+	require.Len(t, contents, 1)
+	parts := contents[0].(map[string]any)["parts"].([]any)
+	require.Len(t, parts, 1, "orphaned tool_result must be dropped")
+	assert.NotNil(t, parts[0].(map[string]any)["text"], "only the text part should remain")
+}
+
+func TestPrepareGemini_FromOpenAI_DropsOrphanedToolMessage(t *testing.T) {
+	body := []byte(`{
+		"model": "gemini-3.1-flash-lite-preview",
+		"messages": [
+			{"role":"user","content":"hi"},
+			{"role":"tool","tool_call_id":"orphan","content":"stale result"},
+			{"role":"assistant","content":"done"},
+			{"role":"user","content":"next"}
+		]
+	}`)
+	env, _ := translate.ParseOpenAI(body)
+	prep, err := env.PrepareGemini(http.Header{}, translate.EmitOptions{Capabilities: router.ModelSpec{}})
+	require.NoError(t, err)
+
+	out := mustUnmarshal(t, prep.Body)
+	contents := out["contents"].([]any)
+	// user "hi", model "done", user "next" — orphaned tool message skipped.
+	require.Len(t, contents, 3)
+	for _, c := range contents {
+		entry := c.(map[string]any)
+		for _, p := range entry["parts"].([]any) {
+			part := p.(map[string]any)
+			_, hasFR := part["functionResponse"]
+			assert.False(t, hasFR, "orphaned functionResponse must not appear")
+		}
+	}
+}
+
 // ----- Gemini → OpenAI response -----
 
 func TestGeminiToOpenAIResponse_TextOnly(t *testing.T) {

--- a/internal/translate/handover.go
+++ b/internal/translate/handover.go
@@ -77,8 +77,13 @@ func (e *RequestEnvelope) rewriteAnthropicForHandover(summary string) int {
 	rebuilt := []string{summaryBlock}
 	preserved := 0
 	if latestUser.Exists() {
-		rebuilt = append(rebuilt, latestUser.Raw)
-		preserved = 1
+		// Strip tool_result blocks: the summary has no tool_use blocks,
+		// so any tool_results would be orphaned.
+		cleaned := stripAnthropicToolResultMsg(latestUser, nil)
+		if cleaned != "" {
+			rebuilt = append(rebuilt, cleaned)
+			preserved = 1
+		}
 	}
 
 	// elided counts original conversation messages no longer present;
@@ -124,17 +129,14 @@ func (e *RequestEnvelope) trimAnthropicLastN(n int) int {
 		return 0
 	}
 	keep := all[len(all)-n:]
-	rebuilt := make([]string, 0, len(keep))
-	for _, m := range keep {
-		rebuilt = append(rebuilt, m.Raw)
-	}
+	rebuilt := stripOrphanedAnthropicToolResults(keep)
 	newMessages := "[" + strings.Join(rebuilt, ",") + "]"
 	out, err := sjson.SetRawBytes(e.body, "messages", []byte(newMessages))
 	if err != nil {
 		return 0
 	}
 	e.body = out
-	return len(all) - len(keep)
+	return len(all) - n
 }
 
 // rewriteOpenAIForHandover preserves role=="system" messages and replaces
@@ -233,16 +235,17 @@ func (e *RequestEnvelope) trimOpenAILastN(n int) int {
 		return 0
 	}
 	keep := others[len(others)-n:]
-	rebuilt := make([]string, 0, len(systems)+len(keep))
+	cleaned := stripOrphanedOpenAIToolMessages(keep)
+	rebuilt := make([]string, 0, len(systems)+len(cleaned))
 	rebuilt = append(rebuilt, systems...)
-	rebuilt = append(rebuilt, keep...)
+	rebuilt = append(rebuilt, cleaned...)
 	newMessages := "[" + strings.Join(rebuilt, ",") + "]"
 	out, err := sjson.SetRawBytes(e.body, "messages", []byte(newMessages))
 	if err != nil {
 		return 0
 	}
 	e.body = out
-	return len(others) - len(keep)
+	return len(others) - n
 }
 
 // rewriteGeminiForHandover mirrors the Anthropic path against Gemini's
@@ -312,4 +315,120 @@ func (e *RequestEnvelope) trimGeminiLastN(n int) int {
 	}
 	e.body = out
 	return len(all) - len(keep)
+}
+
+// stripOrphanedAnthropicToolResults removes tool_result content blocks from
+// Anthropic-format user messages when the referenced tool_use_id has no
+// matching tool_use block in any assistant message in the set. User messages
+// left with no content blocks after stripping are omitted entirely.
+func stripOrphanedAnthropicToolResults(msgs []gjson.Result) []string {
+	knownIDs := collectAnthropicToolUseIDs(msgs)
+	result := make([]string, 0, len(msgs))
+	for _, m := range msgs {
+		if m.Get("role").String() != "user" {
+			result = append(result, m.Raw)
+			continue
+		}
+		cleaned := stripAnthropicToolResultMsg(m, knownIDs)
+		if cleaned != "" {
+			result = append(result, cleaned)
+		}
+	}
+	return result
+}
+
+// collectAnthropicToolUseIDs returns the set of tool_use IDs present in
+// assistant messages.
+func collectAnthropicToolUseIDs(msgs []gjson.Result) map[string]struct{} {
+	ids := make(map[string]struct{})
+	for _, m := range msgs {
+		if m.Get("role").String() != "assistant" {
+			continue
+		}
+		m.Get("content").ForEach(func(_, block gjson.Result) bool {
+			if block.Get("type").String() == "tool_use" {
+				if id := block.Get("id").String(); id != "" {
+					ids[id] = struct{}{}
+				}
+			}
+			return true
+		})
+	}
+	return ids
+}
+
+// stripAnthropicToolResultMsg removes tool_result blocks from a user message
+// whose tool_use_id is not in knownIDs. A nil knownIDs strips all
+// tool_results. Returns "" if the message is left with no content.
+func stripAnthropicToolResultMsg(msg gjson.Result, knownIDs map[string]struct{}) string {
+	content := msg.Get("content")
+	if !content.IsArray() {
+		return msg.Raw
+	}
+
+	hasOrphans := false
+	content.ForEach(func(_, block gjson.Result) bool {
+		if block.Get("type").String() == "tool_result" {
+			id := block.Get("tool_use_id").String()
+			if _, ok := knownIDs[id]; !ok {
+				hasOrphans = true
+				return false
+			}
+		}
+		return true
+	})
+	if !hasOrphans {
+		return msg.Raw
+	}
+
+	var kept []string
+	content.ForEach(func(_, block gjson.Result) bool {
+		if block.Get("type").String() == "tool_result" {
+			id := block.Get("tool_use_id").String()
+			if _, ok := knownIDs[id]; !ok {
+				return true
+			}
+		}
+		kept = append(kept, block.Raw)
+		return true
+	})
+	if len(kept) == 0 {
+		return ""
+	}
+	newContent := "[" + strings.Join(kept, ",") + "]"
+	out, err := sjson.SetRawBytes([]byte(msg.Raw), "content", []byte(newContent))
+	if err != nil {
+		return msg.Raw
+	}
+	return string(out)
+}
+
+// stripOrphanedOpenAIToolMessages removes role:"tool" messages whose
+// tool_call_id doesn't match any assistant tool_calls[].id in the set.
+func stripOrphanedOpenAIToolMessages(msgs []string) []string {
+	knownIDs := make(map[string]struct{})
+	for _, raw := range msgs {
+		parsed := gjson.Parse(raw)
+		if parsed.Get("role").String() != "assistant" {
+			continue
+		}
+		parsed.Get("tool_calls").ForEach(func(_, tc gjson.Result) bool {
+			if id := tc.Get("id").String(); id != "" {
+				knownIDs[id] = struct{}{}
+			}
+			return true
+		})
+	}
+	result := make([]string, 0, len(msgs))
+	for _, raw := range msgs {
+		parsed := gjson.Parse(raw)
+		if parsed.Get("role").String() == "tool" {
+			tcID := parsed.Get("tool_call_id").String()
+			if _, ok := knownIDs[tcID]; !ok {
+				continue
+			}
+		}
+		result = append(result, raw)
+	}
+	return result
 }


### PR DESCRIPTION
## Summary

- **Root cause**: When the planner switches models mid-session, `TrimLastN(env, 3)` keeps the last N messages by simple array slicing. If the first kept message is a user message with `tool_result` blocks, the preceding assistant message containing the matching `tool_use` blocks has been trimmed away. The Anthropic→Gemini translation then can't resolve the function name, producing empty `function_response.name` → Gemini 400.
- **Primary fix**: `TrimLastN` and `RewriteForHandover` now strip orphaned `tool_result` blocks (Anthropic) and orphaned `role:"tool"` messages (OpenAI) whose matching `tool_use`/`tool_calls` were trimmed.
- **Defense-in-depth**: Gemini emitter skips `function_response` parts with empty names in both Anthropic→Gemini and OpenAI→Gemini paths.
- **Regression test**: End-to-end test reproducing the exact production failure: multi-turn tool-use conversation → `TrimLastN(3)` → `PrepareGemini` → assert no empty `function_response.name`.

## Test plan

- [x] All 12 handover tests pass (5 new, including e2e regression test)
- [x] All translate tests pass (2 new Gemini emit defense-in-depth tests)
- [x] Full test suite green (20 packages, pre-commit hook)

🤖 Generated with [Claude Code](https://claude.com/claude-code)