### PR TITLE
feat(catalog): add 5 AA top-performer OSS models

### DIFF
--- a/install/cc-statusline.sh
+++ b/install/cc-statusline.sh
@@ -162,11 +162,16 @@ prices='{
     "gpt-5.5-mini":                     0.0005,
     "gpt-5.5-nano":                     0.00015,
     "gpt-5.5-pro":                      0.03,
+    "minimax/minimax-m2.7":             0.0003,
     "moonshotai/kimi-k2.5":             0.0006,
     "moonshotai/kimi-k2.6":             0.00095,
     "qwen/qwen3-235b-a22b-2507":        0.000071,
     "qwen/qwen3-coder-next":            0.0005,
-    "qwen/qwen3-next-80b-a3b-instruct": 0.00015
+    "qwen/qwen3-next-80b-a3b-instruct": 0.00015,
+    "qwen/qwen3.6-35b-a3b":             0.00015,
+    "xiaomi/mimo-v2.5":                 0.0004,
+    "xiaomi/mimo-v2.5-pro":             0.001,
+    "z-ai/glm-5":                       0.0006
   },
   "output": {
     "claude-haiku-4-5":                 0.004,
@@ -202,11 +207,16 @@ prices='{
     "gpt-5.5-mini":                     0.0025,
     "gpt-5.5-nano":                     0.0006,
     "gpt-5.5-pro":                      0.12,
+    "minimax/minimax-m2.7":             0.0012,
     "moonshotai/kimi-k2.5":             0.003,
     "moonshotai/kimi-k2.6":             0.004,
     "qwen/qwen3-235b-a22b-2507":        0.000463,
     "qwen/qwen3-coder-next":            0.0012,
-    "qwen/qwen3-next-80b-a3b-instruct": 0.0012
+    "qwen/qwen3-next-80b-a3b-instruct": 0.0012,
+    "qwen/qwen3.6-35b-a3b":             0.00095,
+    "xiaomi/mimo-v2.5":                 0.002,
+    "xiaomi/mimo-v2.5-pro":             0.003,
+    "z-ai/glm-5":                       0.00208
   }
 }'
 # END_GENERATED_PRICES

--- a/install/install.sh
+++ b/install/install.sh
@@ -778,11 +778,16 @@ prices='{
     "gpt-5.5-mini":                     0.0005,
     "gpt-5.5-nano":                     0.00015,
     "gpt-5.5-pro":                      0.03,
+    "minimax/minimax-m2.7":             0.0003,
     "moonshotai/kimi-k2.5":             0.0006,
     "moonshotai/kimi-k2.6":             0.00095,
     "qwen/qwen3-235b-a22b-2507":        0.000071,
     "qwen/qwen3-coder-next":            0.0005,
-    "qwen/qwen3-next-80b-a3b-instruct": 0.00015
+    "qwen/qwen3-next-80b-a3b-instruct": 0.00015,
+    "qwen/qwen3.6-35b-a3b":             0.00015,
+    "xiaomi/mimo-v2.5":                 0.0004,
+    "xiaomi/mimo-v2.5-pro":             0.001,
+    "z-ai/glm-5":                       0.0006
   },
   "output": {
     "claude-haiku-4-5":                 0.004,
@@ -818,11 +823,16 @@ prices='{
     "gpt-5.5-mini":                     0.0025,
     "gpt-5.5-nano":                     0.0006,
     "gpt-5.5-pro":                      0.12,
+    "minimax/minimax-m2.7":             0.0012,
     "moonshotai/kimi-k2.5":             0.003,
     "moonshotai/kimi-k2.6":             0.004,
     "qwen/qwen3-235b-a22b-2507":        0.000463,
     "qwen/qwen3-coder-next":            0.0012,
-    "qwen/qwen3-next-80b-a3b-instruct": 0.0012
+    "qwen/qwen3-next-80b-a3b-instruct": 0.0012,
+    "qwen/qwen3.6-35b-a3b":             0.00095,
+    "xiaomi/mimo-v2.5":                 0.002,
+    "xiaomi/mimo-v2.5-pro":             0.003,
+    "z-ai/glm-5":                       0.00208
   }
 }'
 # END_GENERATED_PRICES

--- a/internal/router/catalog/catalog.go
+++ b/internal/router/catalog/catalog.go
@@ -274,4 +274,46 @@ var Models = []Model{
 			Price: Pricing{InputUSDPer1M: 0.950, OutputUSDPer1M: 4.000, CacheReadMultiplier: 0.1684}},
 		{Provider: providers.ProviderOpenRouter, Price: Pricing{InputUSDPer1M: 0.950, OutputUSDPer1M: 4.000, CacheReadMultiplier: 0.10}},
 	}},
+	// AA top-performer additions (2026-05-18).
+	//
+	// Selection ranked OSS models on the artificialanalysis.ai API by a
+	// composite of quality (Intelligence Index v4.0), cost (blended
+	// 3:1 input:output), and effective time per 2k-token query
+	// (median TTFT + 2000/TPS). Provider availability verified against
+	// per-model "API providers" pages and OpenRouter's v1/models API.
+	//
+	// xiaomi/mimo-v2.5 — OpenRouter-only on the SOC-2 set. AA per-provider
+	// page lists only GMI + Xiaomi-direct, neither of which we currently
+	// onboard, so managed-prod resolves nothing here while self-hosters
+	// with an OpenRouter key get the trailing binding.
+	{ID: "xiaomi/mimo-v2.5", Tier: TierMid, Providers: []ProviderBinding{
+		{Provider: providers.ProviderOpenRouter, Price: Pricing{InputUSDPer1M: 0.400, OutputUSDPer1M: 2.000, CacheReadMultiplier: 0.10}},
+	}},
+	{ID: "xiaomi/mimo-v2.5-pro", Tier: TierHigh, Providers: []ProviderBinding{
+		{Provider: providers.ProviderDeepInfra, UpstreamID: "XiaomiMiMo/MiMo-V2.5-Pro",
+			Price: Pricing{InputUSDPer1M: 1.000, OutputUSDPer1M: 3.000}},
+		{Provider: providers.ProviderOpenRouter, Price: Pricing{InputUSDPer1M: 1.000, OutputUSDPer1M: 3.000, CacheReadMultiplier: 0.10}},
+	}},
+	// qwen3.6-35b-a3b is a 35B-A3B MoE — Intel 44 at ~13s wall-clock per
+	// 2k tokens on DeepInfra FP8, the speed/cost end of the new Qwen3.6
+	// family. TierLow despite the MoE size because the active parameter
+	// budget + AA's Coding Index put it below v4-flash.
+	{ID: "qwen/qwen3.6-35b-a3b", Tier: TierLow, Providers: []ProviderBinding{
+		{Provider: providers.ProviderDeepInfra, UpstreamID: "Qwen/Qwen3.6-35B-A3B",
+			Price: Pricing{InputUSDPer1M: 0.150, OutputUSDPer1M: 0.950}},
+		{Provider: providers.ProviderOpenRouter, Price: Pricing{InputUSDPer1M: 0.150, OutputUSDPer1M: 1.000, CacheReadMultiplier: 0.10}},
+	}},
+	// minimax-m2.7 sits in an unusual quality/cost spot: Intel 50 at
+	// $0.52 blended, cheaper than every TierMid model. Letting the
+	// trainer find its niche rather than pinning a tier by price alone.
+	{ID: "minimax/minimax-m2.7", Tier: TierHigh, Providers: []ProviderBinding{
+		{Provider: providers.ProviderFireworks, UpstreamID: "accounts/fireworks/models/minimax-m2p7",
+			Price: Pricing{InputUSDPer1M: 0.300, OutputUSDPer1M: 1.200}},
+		{Provider: providers.ProviderOpenRouter, Price: Pricing{InputUSDPer1M: 0.279, OutputUSDPer1M: 1.200, CacheReadMultiplier: 0.10}},
+	}},
+	{ID: "z-ai/glm-5", Tier: TierHigh, Providers: []ProviderBinding{
+		{Provider: providers.ProviderDeepInfra, UpstreamID: "zai-org/GLM-5",
+			Price: Pricing{InputUSDPer1M: 0.600, OutputUSDPer1M: 2.080}},
+		{Provider: providers.ProviderOpenRouter, Price: Pricing{InputUSDPer1M: 0.600, OutputUSDPer1M: 1.920, CacheReadMultiplier: 0.10}},
+	}},
 }


### PR DESCRIPTION
## Summary

Adds five OSS models to the catalog selected from [artificialanalysis.ai](https://artificialanalysis.ai/leaderboards/models)'s leaderboard, ranked by a 3-axis composite (Intelligence Index v4.0 + blended 3:1 cost + median TTFT + 2000/TPS wall-clock).

| Model | Tier | Intel | \$/1M | sec/2k | Primary | Fallback |
|---|---|---|---|---|---|---|
| `xiaomi/mimo-v2.5` | Mid | 49 | \$0.72 | 23 | OpenRouter only | — |
| `xiaomi/mimo-v2.5-pro` | High | 54 | \$1.50 | 38 | DeepInfra | OpenRouter |
| `qwen/qwen3.6-35b-a3b` | Low | 44 | \$0.56 | 13 | DeepInfra FP8 | OpenRouter |
| `minimax/minimax-m2.7` | High | 50 | \$0.53 | 39 | Fireworks | OpenRouter |
| `z-ai/glm-5` | High | 50 | \$1.55 | 27 | DeepInfra FP8 | OpenRouter |

Provider availability verified against AA's per-model "API providers" pages and OpenRouter's `v1/models` API; all upstream IDs are HuggingFace-form for DeepInfra (`Qwen/Qwen3.6-35B-A3B`, `XiaomiMiMo/MiMo-V2.5-Pro`, `zai-org/GLM-5`), Fireworks slash-form for Fireworks (`accounts/fireworks/models/minimax-m2p7`), and OR canonical slugs for OpenRouter fallbacks.

## Notable picks

- **`xiaomi/mimo-v2.5`** is OpenRouter-only on the SOC-2 set. AA lists only GMI + Xiaomi-direct providers, neither of which we currently onboard, so managed-prod's `ResolveBinding` finds nothing here while self-hosters with an OpenRouter key get the trailing binding. Same pattern as `qwen/qwen3-235b-a22b-2507`.
- **`minimax/minimax-m2.7`** sits at Intel 50 for \$0.52 blended — cheaper than every existing TierMid model. Tagging TierHigh by quality, but the trainer will find its niche on the v0.40 retrain.
- **`qwen/qwen3.6-35b-a3b`** is the small MoE end of the new Qwen 3.6 family — 35B total with only 3B active. TierLow despite the parameter count because AA's Coding Index puts it below DeepSeek V4 Flash.

## Notes / follow-ups

- This PR is catalog-only. None of these models are in any cluster artifact's `model_registry.json` yet — they become routable once a future retrain (v0.40+) decides to include them.
- Pricing values come from each provider's public pricing page (DeepInfra) or the AA per-provider benchmarks page (Fireworks). Cache-read multipliers default to 0.10 on OpenRouter (no upstream cache-pricing disclosure) and are omitted for DeepInfra/Fireworks since none of them ship a documented cache discount yet.

## Test plan

- [x] `go test ./internal/router/catalog/...` — passes
- [x] Full router test suite (`wv mr t`) — all packages pass
- [x] `go run ./cmd/genprices` — `install/install.sh` + `install/cc-statusline.sh` regenerated
- [ ] Once merged: WorkWeave bump-router-pin workflow picks up the new commit; `syncrouterinstall/install_template.sh` resyncs from `install/install.sh` automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)