### PR TITLE
fix(translate): resolve $ref when sibling keys present

### DIFF
--- a/internal/translate/emit_openai.go
+++ b/internal/translate/emit_openai.go
@@ -570,6 +570,12 @@ func writeOpenAIMaxTokensFromAnthropic(jw *jsonWriter, body []byte, opts EmitOpt
 // before forwarding keeps the schema self-contained so it works on every
 // OpenAI-compat backend regardless of how its validator handles $ref.
 //
+// A $ref with sibling keys (e.g. {"$ref": "#/$defs/X", "description": "..."},
+// emitted by Pydantic v2 / OpenAPI 3.1 / many MCP servers including Intuit
+// QuickBooks) is resolved the same way: per JSON Schema Draft 7, siblings to
+// $ref are ignored, so dropping them on substitution is spec-compliant and
+// keeps the upstream from seeing an unresolvable ref after $defs is stripped.
+//
 // Cyclic refs are left intact (no infinite recursion); unresolvable refs are
 // left intact so the upstream can surface its own clearer error.
 func inlineSchemaDefs(node any) any {
@@ -599,7 +605,7 @@ func inlineSchemaDefs(node any) any {
 func resolveSchemaRefs(node any, defs map[string]any, visited map[string]struct{}) any {
 	switch v := node.(type) {
 	case map[string]any:
-		if ref, ok := v["$ref"].(string); ok && len(v) == 1 {
+		if ref, ok := v["$ref"].(string); ok {
 			name := strings.TrimPrefix(ref, "#/")
 			if _, cycle := visited[name]; cycle {
 				return v

--- a/internal/translate/inline_defs_test.go
+++ b/internal/translate/inline_defs_test.go
@@ -135,6 +135,41 @@ func TestInlineSchemaDefs_noDefsIsNoop(t *testing.T) {
 	}
 }
 
+func TestInlineSchemaDefs_resolvesRefWithSiblingKeys(t *testing.T) {
+	// Pydantic v2 / OpenAPI 3.1 (and MCP servers built on them, e.g. Intuit
+	// QuickBooks) emit a $ref alongside annotation siblings like description
+	// or title. Per JSON Schema Draft 7 siblings to $ref are ignored, so the
+	// $ref must still be resolved — otherwise $defs gets stripped and the
+	// upstream sees an unresolvable reference (Fireworks 400s with
+	// "Error resolving schema reference '#/$defs/X'").
+	in := map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"payment_link_type": map[string]any{
+				"$ref":        "#/$defs/PaymentLinkType",
+				"description": "Type of payment link",
+			},
+		},
+		"$defs": map[string]any{
+			"PaymentLinkType": map[string]any{
+				"enum": []any{"link", "ach"},
+				"type": "string",
+			},
+		},
+	}
+	out := inlineSchemaDefs(in).(map[string]any)
+	if _, ok := out["$defs"]; ok {
+		t.Fatalf("$defs not stripped: %#v", out)
+	}
+	got := out["properties"].(map[string]any)["payment_link_type"].(map[string]any)
+	if _, hasRef := got["$ref"]; hasRef {
+		t.Fatalf("unresolved $ref remains alongside siblings: %#v", got)
+	}
+	if got["type"] != "string" {
+		t.Fatalf("target type not inlined: %#v", got)
+	}
+}
+
 func TestInlineSchemaDefs_inlineCopiesNotShares(t *testing.T) {
 	// Two refs to the same def should produce independent copies, so a later
 	// in-place mutation (e.g. sanitizeOpenAIToolSchema) can't bleed across.


### PR DESCRIPTION
## Summary

`inlineSchemaDefs` guard `len(v) == 1` was skipping `$ref` objects with sibling keys, but `$defs` was still stripped from the root afterward — leaving the upstream with an unresolvable reference. Fireworks (and any OpenAI-compat upstream that doesn't natively dereference `$ref`) returns:

```
Error resolving schema reference '#/$defs/PaymentLinkType':
AttributeError("'NoneType' object has no attribute 'lookup'")
```

Pydantic v2 / OpenAPI 3.1 (and MCP servers built on them, e.g. Intuit QuickBooks) routinely emit `{"$ref": "#/$defs/X", "description": "..."}` on property schemas. Per JSON Schema Draft 7 siblings to `$ref` are ignored, so dropping them on substitution is spec-compliant.

Drops the guard so the ref is resolved regardless of siblings.

## Test plan

- [x] `wv mr t ./internal/translate/...` — all 60+ translate tests pass including new regression test
- [x] `wv mr tc` — typecheck clean
- [x] New test `TestInlineSchemaDefs_resolvesRefWithSiblingKeys` covers the Pydantic-style sibling pattern that triggered the QuickBooks MCP failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)