### PR TITLE
feat(client_identity): classify client_app from X-App + UA fallback

### DIFF
--- a/install/install.sh
+++ b/install/install.sh
@@ -395,6 +395,10 @@ write_codex_config() {
   if [ -n "$block_name" ]; then
     headers_parts="${headers_parts}, \"X-Weave-User-Name\" = \"${esc_name}\""
   fi
+  # Tag the client so telemetry can attribute traffic to Codex vs other CLIs
+  # that share the same router key. The router otherwise has to guess from
+  # User-Agent.
+  headers_parts="${headers_parts}, \"X-App\" = \"codex\""
   local headers_line="http_headers = { ${headers_parts} }"
 
   local block
@@ -1299,6 +1303,7 @@ fi
 if [ -n "$user_name" ]; then
   custom_headers="$custom_headers"$'\n'"X-Weave-User-Name: $user_name"
 fi
+custom_headers="$custom_headers"$'\n'"X-App: claude-code"
 
 if [ "$scope" = "project" ] && [ -z "$install_dir" ]; then
   jq -n --arg url "$base_url" --arg sl "$statusline_path_for_settings" '{

--- a/internal/api/anthropic/messages.go
+++ b/internal/api/anthropic/messages.go
@@ -135,7 +135,7 @@ func stashClientIdentity(ctx context.Context, h http.Header, body []byte) contex
 		Email:       email,
 		DisplayName: displayName,
 		UserAgent:   h.Get("User-Agent"),
-		ClientApp:   h.Get("X-App"),
+		ClientApp:   proxy.NormalizeClientApp(h.Get("X-App"), h.Get("User-Agent")),
 	}
 	observability.Get().Debug("anthropic stashClientIdentity",
 		"meta_raw_len", len(metaRaw),

--- a/internal/api/gemini/generate_content.go
+++ b/internal/api/gemini/generate_content.go
@@ -146,7 +146,7 @@ func stashClientIdentity(ctx context.Context, h http.Header) context.Context {
 		Email:       proxy.NormalizeEmail(h.Get("X-Weave-User-Email")),
 		DisplayName: proxy.NormalizeDisplayName(h.Get("X-Weave-User-Name")),
 		UserAgent:   h.Get("User-Agent"),
-		ClientApp:   h.Get("X-App"),
+		ClientApp:   proxy.NormalizeClientApp(h.Get("X-App"), h.Get("User-Agent")),
 	}
 	return context.WithValue(ctx, proxy.ClientIdentityContextKey{}, id)
 }

--- a/internal/api/openai/completions.go
+++ b/internal/api/openai/completions.go
@@ -88,7 +88,7 @@ func stashClientIdentity(ctx context.Context, h http.Header) context.Context {
 		Email:       proxy.NormalizeEmail(h.Get("X-Weave-User-Email")),
 		DisplayName: proxy.NormalizeDisplayName(h.Get("X-Weave-User-Name")),
 		UserAgent:   h.Get("User-Agent"),
-		ClientApp:   h.Get("X-App"),
+		ClientApp:   proxy.NormalizeClientApp(h.Get("X-App"), h.Get("User-Agent")),
 	}
 	return context.WithValue(ctx, proxy.ClientIdentityContextKey{}, id)
 }

--- a/internal/proxy/client_identity.go
+++ b/internal/proxy/client_identity.go
@@ -121,6 +121,45 @@ func NormalizeEmail(s string) string {
 	return s
 }
 
+// Canonical client_app values. Kept in one place so telemetry, dashboards,
+// and tests don't drift on capitalization.
+const (
+	ClientAppClaudeCode = "claude-code"
+	ClientAppCodex      = "codex"
+	ClientAppCursor     = "cursor"
+	ClientAppGeminiCLI  = "gemini-cli"
+)
+
+// MaxClientAppLen bounds the X-App header. Canonical values are short
+// (claude-code, codex, cursor); longer values are header smuggling attempts.
+const MaxClientAppLen = 32
+
+// NormalizeClientApp returns the canonical client_app for a request. If the
+// caller sent an explicit X-App header within length bounds, we trust it
+// (lower-cased). Otherwise we fall back to a coarse User-Agent classifier so
+// older installs that don't yet send X-App still get attributed. Returns ""
+// when neither signal is recognized — telemetry leaves the column NULL.
+func NormalizeClientApp(xApp, userAgent string) string {
+	xApp = strings.ToLower(strings.TrimSpace(xApp))
+	if xApp != "" && len(xApp) <= MaxClientAppLen {
+		return xApp
+	}
+	ua := strings.ToLower(userAgent)
+	switch {
+	case ua == "":
+		return ""
+	case strings.Contains(ua, "claude-cli"):
+		return ClientAppClaudeCode
+	case strings.Contains(ua, "codex_cli") || strings.Contains(ua, "codex-cli") || strings.HasPrefix(ua, "codex/"):
+		return ClientAppCodex
+	case strings.Contains(ua, "cursor"):
+		return ClientAppCursor
+	case strings.Contains(ua, "gemini-cli") || strings.Contains(ua, "google-genai"):
+		return ClientAppGeminiCLI
+	}
+	return ""
+}
+
 // MaxDisplayNameLen bounds the free-form display name. 128 mirrors the
 // installer-side cap; longer values almost certainly indicate a header
 // smuggling attempt rather than a real name.

--- a/internal/proxy/client_identity_test.go
+++ b/internal/proxy/client_identity_test.go
@@ -162,6 +162,32 @@ func TestResolveUserFromContext_EmailOnlyReachesEmailUpsert(t *testing.T) {
 	assert.Equal(t, "user-from-email", auth.UserIDFrom(ctx))
 }
 
+func TestNormalizeClientApp(t *testing.T) {
+	cases := []struct {
+		name      string
+		xApp      string
+		userAgent string
+		want      string
+	}{
+		{"explicit header wins", "codex", "claude-cli/2.0.1", proxy.ClientAppCodex},
+		{"explicit header lowercased", "Claude-Code", "", proxy.ClientAppClaudeCode},
+		{"explicit header trimmed", "  cursor  ", "", proxy.ClientAppCursor},
+		{"oversized header falls through to UA", strings.Repeat("a", proxy.MaxClientAppLen+1), "claude-cli/2.0.1", proxy.ClientAppClaudeCode},
+		{"UA claude-cli", "", "claude-cli/2.0.1 (cli, win32)", proxy.ClientAppClaudeCode},
+		{"UA codex_cli_rs", "", "codex_cli_rs/0.39.0 (darwin)", proxy.ClientAppCodex},
+		{"UA cursor", "", "Cursor/0.42.1 (darwin x64)", proxy.ClientAppCursor},
+		{"UA gemini-cli", "", "gemini-cli/1.0.0 (linux)", proxy.ClientAppGeminiCLI},
+		{"UA unknown returns empty", "", "curl/8.4.0", ""},
+		{"both empty returns empty", "", "", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := proxy.NormalizeClientApp(tc.xApp, tc.userAgent)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
 func TestResolveUserFromContext_BothMissingIsNoOp(t *testing.T) {
 	repo := &captureUserRepo{}
 	svc := newTestAuthSvc(repo)


### PR DESCRIPTION
## Summary

- Add `proxy.NormalizeClientApp(xApp, userAgent)` that trusts an explicit `X-App` header but falls back to a coarse User-Agent classifier (`claude-cli` → `claude-code`, `codex_cli_rs` → `codex`, `cursor`, `gemini-cli`). Existing installs get attributed without re-running the installer.
- Wire all three API stash sites (`anthropic`, `openai`, `gemini`) through the new helper.
- Add `X-App` to fresh installs:
  - Codex TOML headers: `X-App = "codex"`
  - Claude Code `ANTHROPIC_CUSTOM_HEADERS`: `X-App: claude-code`
- Unit tests cover both code paths + canonical values.

## Why

Today the router has `ClientApp` plumbed straight from `X-App`, which no current installer sets. That means the `client.app` OTEL span attribute is always empty in production, and the Weave side can't attribute traffic to Codex vs Claude Code on shared router keys. Weave's drilldown follow-up depends on this being populated.

## Test plan
- [x] `go test ./internal/proxy/... -run TestNormalizeClientApp`
- [x] `go test ./...`
- [ ] After merge: Weave bumps gitlink + syncs `install_template.sh`; verify `client.app` span attribute is non-empty on a fresh Codex request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)