### PR TITLE
fix(auth): guard email-merge UPDATE against existing email-keyed row

### DIFF
--- a/db/queries/model_router_users.sql
+++ b/db/queries/model_router_users.sql
@@ -13,6 +13,16 @@
 -- duplicate rows for the same human and the dashboard picker shows both.
 -- The fallback INSERT keeps the original ON CONFLICT path so concurrent
 -- email-bearing requests still collapse onto a single row.
+--
+-- Merge is gated on the absence of an existing email-keyed row for the same
+-- (installation_id, email): if one already exists (created by an earlier
+-- email-bearing request that didn't carry account_uuid), the orphan UPDATE
+-- would collide with the partial unique index
+-- model_router_users_installation_email_unique and fail the whole upsert
+-- with SQLSTATE 23505. In that case we let the INSERT path take over so the
+-- existing email-keyed row gets its claude_account_uuid backfilled via the
+-- ON CONFLICT DO UPDATE clause; the orphan stays in place (dashboard surfaces
+-- the email-keyed row, which is the canonical identity).
 -- name: UpsertModelRouterUserByEmail :one
 WITH merged AS (
     UPDATE router.model_router_users
@@ -23,6 +33,12 @@ WITH merged AS (
       AND claude_account_uuid = sqlc.narg('claude_account_uuid')::uuid
       AND email IS NULL
       AND deleted_at IS NULL
+      AND NOT EXISTS (
+          SELECT 1 FROM router.model_router_users
+          WHERE installation_id = @installation_id::uuid
+            AND email = @email::text
+            AND deleted_at IS NULL
+      )
     RETURNING *
 ),
 inserted AS (

--- a/internal/sqlc/model_router_users.sql.go
+++ b/internal/sqlc/model_router_users.sql.go
@@ -164,6 +164,12 @@ WITH merged AS (
       AND claude_account_uuid = $4::uuid
       AND email IS NULL
       AND deleted_at IS NULL
+      AND NOT EXISTS (
+          SELECT 1 FROM router.model_router_users
+          WHERE installation_id = $3::uuid
+            AND email = $1::text
+            AND deleted_at IS NULL
+      )
     RETURNING id, installation_id, email, claude_account_uuid, first_seen_at, last_seen_at, deleted_at, display_name
 ),
 inserted AS (
@@ -224,6 +230,16 @@ type UpsertModelRouterUserByEmailRow struct {
 // The fallback INSERT keeps the original ON CONFLICT path so concurrent
 // email-bearing requests still collapse onto a single row.
 //
+// Merge is gated on the absence of an existing email-keyed row for the same
+// (installation_id, email): if one already exists (created by an earlier
+// email-bearing request that didn't carry account_uuid), the orphan UPDATE
+// would collide with the partial unique index
+// model_router_users_installation_email_unique and fail the whole upsert
+// with SQLSTATE 23505. In that case we let the INSERT path take over so the
+// existing email-keyed row gets its claude_account_uuid backfilled via the
+// ON CONFLICT DO UPDATE clause; the orphan stays in place (dashboard surfaces
+// the email-keyed row, which is the canonical identity).
+//
 //	WITH merged AS (
 //	    UPDATE router.model_router_users
 //	    SET email        = $1::text,
@@ -233,6 +249,12 @@ type UpsertModelRouterUserByEmailRow struct {
 //	      AND claude_account_uuid = $4::uuid
 //	      AND email IS NULL
 //	      AND deleted_at IS NULL
+//	      AND NOT EXISTS (
+//	          SELECT 1 FROM router.model_router_users
+//	          WHERE installation_id = $3::uuid
+//	            AND email = $1::text
+//	            AND deleted_at IS NULL
+//	      )
 //	    RETURNING id, installation_id, email, claude_account_uuid, first_seen_at, last_seen_at, deleted_at, display_name
 //	),
 //	inserted AS (


### PR DESCRIPTION
## Problem

\`UpsertModelRouterUserByEmail\` fails with SQLSTATE 23505 (unique constraint \`model_router_users_installation_email_unique\`) whenever a request carries both an email and a \`claude_account_uuid\`, and:

- a UUID-only orphan row exists for that \`(installation_id, account_uuid)\` — from an earlier email-less request (Claude CLI v2.1.x), AND
- an email-keyed row already exists for that \`(installation_id, email)\` — from an earlier email-bearing request that didn't carry account_uuid.

The \`merged\` CTE tries to UPDATE the orphan and set \`email=X\`, but the partial unique index already has a row at \`(installation_id, X)\`. The whole upsert fails. \`ResolveAndStashUser\` swallows the error (best-effort), so requests still succeed — but \`user_id\` never gets stashed and a WARN fires on every subsequent turn.

Observed in prod for installation \`b56c5517-b9f6-4dbe-957a-7df6f43e6815\`: dozens of WARNs in a single 10-minute window.

## Fix

Add a \`NOT EXISTS\` guard to the \`merged\` CTE: only merge the orphan if no email-keyed row already exists for that \`(installation_id, email)\`. When one does, the \`INSERT\` path takes over and the existing email-keyed row gets its \`claude_account_uuid\` backfilled via the original \`ON CONFLICT DO UPDATE\` clause.

The orphan stays in place. The dashboard surfaces the email-keyed row, which is the canonical identity.

## Test plan

- [ ] Existing unit tests still pass (\`go test ./...\`)
- [ ] After merge, monitor prod logs for \`Failed to resolve router user\` WARNs filtered by installation \`b56c5517-b9f6-4dbe-957a-7df6f43e6815\` — should drop to zero