### PR TITLE
feat(translate): inject routing marker into OpenAI and Gemini SSE streams

### DIFF
--- a/internal/proxy/gemini.go
+++ b/internal/proxy/gemini.go
@@ -146,12 +146,15 @@ func (s *Service) ProxyGeminiGenerateContent(ctx context.Context, body []byte, w
 
 	proxyStart := time.Now()
 	var extractor *otel.UsageExtractor
-	proxyWriter := http.ResponseWriter(w)
-	if s.usageRequired() {
-		extractor = otel.NewUsageExtractor(w, decision.Provider)
-		proxyWriter = extractor
+	var sink http.ResponseWriter = w
+	if marker := routingMarkerFor(routeRes); marker != "" {
+		sink = translate.NewGeminiRoutingMarkerWriter(sink, marker)
 	}
-	proxyErr := p.Proxy(ctx, decision, prep, proxyWriter, r)
+	if s.usageRequired() {
+		extractor = otel.NewUsageExtractor(sink, decision.Provider)
+		sink = extractor
+	}
+	proxyErr := p.Proxy(ctx, decision, prep, sink, r)
 	proxyMs := time.Since(proxyStart).Milliseconds()
 
 	in, out := extractor.Tokens()

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -1427,6 +1427,10 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 	installationID := installationIDFromContext(ctx)
 	clientID := ClientIdentityFrom(ctx)
 
+	body, stripErr := translate.StripRoutingMarkerFromMessages(body)
+	if stripErr != nil {
+		log.Error("Failed to strip routing marker from OpenAI messages", "err", stripErr)
+	}
 	env, parseErr := translate.ParseOpenAI(body)
 	if parseErr != nil {
 		log.Error("Failed to parse OpenAI request", "err", parseErr)
@@ -1554,6 +1558,10 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 	if cacheEligible {
 		captureW = newCaptureWriter(w, semanticCacheMaxBodyBytes)
 		sink = captureW
+	}
+
+	if marker := routingMarkerFor(routeRes); marker != "" {
+		sink = translate.NewOpenAIRoutingMarkerWriter(sink, decision.Model, marker)
 	}
 
 	proxyStart := time.Now()

--- a/internal/translate/envelope.go
+++ b/internal/translate/envelope.go
@@ -392,7 +392,36 @@ func StripRoutingMarkerFromMessages(body []byte) ([]byte, error) {
 
 	messages.ForEach(func(_, msg gjson.Result) bool {
 		content := msg.Get("content")
-		if !content.Exists() || !content.IsArray() {
+		if !content.Exists() {
+			msgRaws = append(msgRaws, msg.Raw)
+			return true
+		}
+
+		// OpenAI format: content is a plain string.
+		if content.Type == gjson.String {
+			text := content.String()
+			if !routingMarkerPattern.MatchString(text) {
+				msgRaws = append(msgRaws, msg.Raw)
+				return true
+			}
+			stripped := routingMarkerPattern.ReplaceAllString(text, "")
+			anyChanged = true
+			encoded, err := encodeJSONStringNoHTMLEscape(stripped)
+			if err != nil {
+				walkErr = fmt.Errorf("marshal stripped string content: %w", err)
+				return false
+			}
+			newMsg, err := sjson.SetRawBytes([]byte(msg.Raw), "content", encoded)
+			if err != nil {
+				walkErr = fmt.Errorf("replace string content in message: %w", err)
+				return false
+			}
+			msgRaws = append(msgRaws, string(newMsg))
+			return true
+		}
+
+		// Anthropic format: content is an array of typed blocks.
+		if !content.IsArray() {
 			msgRaws = append(msgRaws, msg.Raw)
 			return true
 		}

--- a/internal/translate/gemini_marker.go
+++ b/internal/translate/gemini_marker.go
@@ -1,0 +1,82 @@
+package translate
+
+import (
+	"bufio"
+	"net/http"
+	"strings"
+
+	"workweave/router/internal/sse"
+)
+
+// GeminiRoutingMarkerWriter wraps an http.ResponseWriter and injects a
+// routing-marker chunk at the start of a Gemini-format SSE stream.
+// Non-streaming responses pass through unmodified.
+type GeminiRoutingMarkerWriter struct {
+	inner   http.ResponseWriter
+	flusher http.Flusher
+	bw      *bufio.Writer
+
+	marker string
+
+	streaming     bool
+	markerEmitted bool
+}
+
+// NewGeminiRoutingMarkerWriter creates a writer that emits marker as the first
+// Gemini SSE candidate before any upstream data. If marker is empty, all
+// writes pass through unchanged.
+func NewGeminiRoutingMarkerWriter(w http.ResponseWriter, marker string) *GeminiRoutingMarkerWriter {
+	flusher, _ := w.(http.Flusher)
+	return &GeminiRoutingMarkerWriter{
+		inner:   w,
+		flusher: flusher,
+		bw:      bufio.NewWriterSize(w, 4096),
+		marker:  marker,
+	}
+}
+
+func (w *GeminiRoutingMarkerWriter) Header() http.Header {
+	return w.inner.Header()
+}
+
+func (w *GeminiRoutingMarkerWriter) WriteHeader(code int) {
+	ct := w.inner.Header().Get("Content-Type")
+	w.streaming = strings.Contains(ct, "text/event-stream") && code < 400
+	w.inner.WriteHeader(code)
+}
+
+func (w *GeminiRoutingMarkerWriter) Write(data []byte) (int, error) {
+	if w.streaming && !w.markerEmitted {
+		w.markerEmitted = true
+		if w.marker != "" {
+			if err := w.emitMarkerChunk(); err != nil {
+				return 0, err
+			}
+		}
+	}
+	return w.inner.Write(data)
+}
+
+// Flush implements http.Flusher.
+func (w *GeminiRoutingMarkerWriter) Flush() {
+	if w.flusher != nil {
+		w.flusher.Flush()
+	}
+}
+
+func (w *GeminiRoutingMarkerWriter) emitMarkerChunk() error {
+	w.bw.WriteString(`data: {"candidates":[{"content":{"parts":[{"text":`)
+	sse.WriteJSONString(w.bw, w.marker)
+	w.bw.WriteString(`}],"role":"model"},"index":0}]}`)
+	w.bw.WriteString("\n\n")
+	if err := w.bw.Flush(); err != nil {
+		return err
+	}
+	if w.flusher != nil {
+		w.flusher.Flush()
+	}
+	return nil
+}
+
+var _ http.ResponseWriter = (*GeminiRoutingMarkerWriter)(nil)
+var _ http.Flusher = (*GeminiRoutingMarkerWriter)(nil)

--- a/internal/translate/gemini_marker_test.go
+++ b/internal/translate/gemini_marker_test.go
@@ -1,0 +1,65 @@
+package translate_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"workweave/router/internal/translate"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+)
+
+func TestGeminiRoutingMarkerWriter_StreamingInjectsMarker(t *testing.T) {
+	rec := httptest.NewRecorder()
+	w := translate.NewGeminiRoutingMarkerWriter(rec, "✦ **Weave Router** → gemini-2.0-flash · best pick for this turn\n\n")
+
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.WriteHeader(http.StatusOK)
+
+	upstreamChunk := `data: {"candidates":[{"content":{"parts":[{"text":"Hello"}],"role":"model"},"index":0}]}` + "\n\n"
+	_, err := w.Write([]byte(upstreamChunk))
+	require.NoError(t, err)
+
+	body := rec.Body.String()
+	events := splitSSEEvents(body)
+	require.Len(t, events, 2, "expected marker chunk + upstream chunk")
+
+	markerData := strings.TrimPrefix(events[0], "data: ")
+	text := gjson.Get(markerData, "candidates.0.content.parts.0.text").String()
+	assert.Contains(t, text, "Weave Router")
+	assert.Contains(t, text, "gemini-2.0-flash")
+	assert.Equal(t, "model", gjson.Get(markerData, "candidates.0.content.role").String())
+}
+
+func TestGeminiRoutingMarkerWriter_EmptyMarkerNoInjection(t *testing.T) {
+	rec := httptest.NewRecorder()
+	w := translate.NewGeminiRoutingMarkerWriter(rec, "")
+
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.WriteHeader(http.StatusOK)
+
+	upstreamChunk := `data: {"candidates":[{"content":{"parts":[{"text":"Hello"}],"role":"model"}}]}` + "\n\n"
+	_, err := w.Write([]byte(upstreamChunk))
+	require.NoError(t, err)
+
+	events := splitSSEEvents(rec.Body.String())
+	assert.Len(t, events, 1, "empty marker should not inject a chunk")
+}
+
+func TestGeminiRoutingMarkerWriter_NonStreamingPassthrough(t *testing.T) {
+	rec := httptest.NewRecorder()
+	w := translate.NewGeminiRoutingMarkerWriter(rec, "✦ marker")
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+
+	body := `{"candidates":[{"content":{"parts":[{"text":"Hello"}],"role":"model"}}]}`
+	_, err := w.Write([]byte(body))
+	require.NoError(t, err)
+
+	assert.Equal(t, body, rec.Body.String(), "non-streaming responses should pass through unmodified")
+}

--- a/internal/translate/openai_marker.go
+++ b/internal/translate/openai_marker.go
@@ -1,0 +1,91 @@
+package translate
+
+import (
+	"bufio"
+	"net/http"
+	"strings"
+	"time"
+
+	"workweave/router/internal/sse"
+)
+
+// OpenAIRoutingMarkerWriter wraps an http.ResponseWriter and injects a
+// routing-marker chunk at the start of an OpenAI-format SSE stream.
+// Non-streaming responses pass through unmodified.
+type OpenAIRoutingMarkerWriter struct {
+	inner   http.ResponseWriter
+	flusher http.Flusher
+	bw      *bufio.Writer
+
+	marker string
+	model  string
+
+	streaming     bool
+	markerEmitted bool
+}
+
+// NewOpenAIRoutingMarkerWriter creates a writer that emits marker as the first
+// chat.completion.chunk before any upstream data. If marker is empty, all
+// writes pass through unchanged.
+func NewOpenAIRoutingMarkerWriter(w http.ResponseWriter, model, marker string) *OpenAIRoutingMarkerWriter {
+	flusher, _ := w.(http.Flusher)
+	return &OpenAIRoutingMarkerWriter{
+		inner:   w,
+		flusher: flusher,
+		bw:      bufio.NewWriterSize(w, 4096),
+		marker:  marker,
+		model:   model,
+	}
+}
+
+func (w *OpenAIRoutingMarkerWriter) Header() http.Header {
+	return w.inner.Header()
+}
+
+func (w *OpenAIRoutingMarkerWriter) WriteHeader(code int) {
+	ct := w.inner.Header().Get("Content-Type")
+	w.streaming = strings.Contains(ct, "text/event-stream") && code < 400
+	w.inner.WriteHeader(code)
+}
+
+func (w *OpenAIRoutingMarkerWriter) Write(data []byte) (int, error) {
+	if w.streaming && !w.markerEmitted {
+		w.markerEmitted = true
+		if w.marker != "" {
+			if err := w.emitMarkerChunk(); err != nil {
+				return 0, err
+			}
+		}
+	}
+	return w.inner.Write(data)
+}
+
+// Flush implements http.Flusher.
+func (w *OpenAIRoutingMarkerWriter) Flush() {
+	if w.flusher != nil {
+		w.flusher.Flush()
+	}
+}
+
+func (w *OpenAIRoutingMarkerWriter) emitMarkerChunk() error {
+	w.bw.WriteString(`data: {"id":`)
+	sse.WriteJSONString(w.bw, generateChatCmplID())
+	w.bw.WriteString(`,"object":"chat.completion.chunk","created":`)
+	sse.WriteJSONInt(w.bw, time.Now().Unix())
+	w.bw.WriteString(`,"model":`)
+	sse.WriteJSONString(w.bw, w.model)
+	w.bw.WriteString(`,"choices":[{"index":0,"delta":{"role":"assistant","content":`)
+	sse.WriteJSONString(w.bw, w.marker)
+	w.bw.WriteString(`},"finish_reason":null}]}`)
+	w.bw.WriteString("\n\n")
+	if err := w.bw.Flush(); err != nil {
+		return err
+	}
+	if w.flusher != nil {
+		w.flusher.Flush()
+	}
+	return nil
+}
+
+var _ http.ResponseWriter = (*OpenAIRoutingMarkerWriter)(nil)
+var _ http.Flusher = (*OpenAIRoutingMarkerWriter)(nil)

--- a/internal/translate/openai_marker_test.go
+++ b/internal/translate/openai_marker_test.go
@@ -1,0 +1,122 @@
+package translate_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"workweave/router/internal/translate"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+)
+
+func TestOpenAIRoutingMarkerWriter_StreamingInjectsMarker(t *testing.T) {
+	rec := httptest.NewRecorder()
+	w := translate.NewOpenAIRoutingMarkerWriter(rec, "gpt-4o", "✦ **Weave Router** → gpt-4o · best pick for this turn\n\n")
+
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.WriteHeader(http.StatusOK)
+
+	upstreamChunk := `data: {"id":"chatcmpl-1","object":"chat.completion.chunk","created":1234567890,"model":"gpt-4o","choices":[{"index":0,"delta":{"role":"assistant","content":""},"finish_reason":null}]}` + "\n\n"
+	_, err := w.Write([]byte(upstreamChunk))
+	require.NoError(t, err)
+
+	body := rec.Body.String()
+	events := splitSSEEvents(body)
+	require.Len(t, events, 2, "expected marker chunk + upstream chunk")
+
+	marker := events[0]
+	assert.Contains(t, marker, `"chat.completion.chunk"`)
+	markerData := strings.TrimPrefix(marker, "data: ")
+	assert.Equal(t, "assistant", gjson.Get(markerData, "choices.0.delta.role").String())
+	assert.Contains(t, gjson.Get(markerData, "choices.0.delta.content").String(), "Weave Router")
+	assert.Contains(t, gjson.Get(markerData, "choices.0.delta.content").String(), "gpt-4o")
+	assert.Equal(t, "gpt-4o", gjson.Get(markerData, "model").String())
+}
+
+func TestOpenAIRoutingMarkerWriter_EmptyMarkerNoInjection(t *testing.T) {
+	rec := httptest.NewRecorder()
+	w := translate.NewOpenAIRoutingMarkerWriter(rec, "gpt-4o", "")
+
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.WriteHeader(http.StatusOK)
+
+	upstreamChunk := `data: {"id":"chatcmpl-1","object":"chat.completion.chunk","created":1234567890,"model":"gpt-4o","choices":[{"index":0,"delta":{"role":"assistant","content":""},"finish_reason":null}]}` + "\n\n"
+	_, err := w.Write([]byte(upstreamChunk))
+	require.NoError(t, err)
+
+	events := splitSSEEvents(rec.Body.String())
+	assert.Len(t, events, 1, "empty marker should not inject a chunk")
+}
+
+func TestOpenAIRoutingMarkerWriter_NonStreamingPassthrough(t *testing.T) {
+	rec := httptest.NewRecorder()
+	w := translate.NewOpenAIRoutingMarkerWriter(rec, "gpt-4o", "✦ marker")
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+
+	body := `{"id":"chatcmpl-1","object":"chat.completion","model":"gpt-4o","choices":[{"message":{"role":"assistant","content":"Hello"}}]}`
+	_, err := w.Write([]byte(body))
+	require.NoError(t, err)
+
+	assert.Equal(t, body, rec.Body.String(), "non-streaming responses should pass through unmodified")
+}
+
+func TestOpenAIRoutingMarkerWriter_ErrorResponsePassthrough(t *testing.T) {
+	rec := httptest.NewRecorder()
+	w := translate.NewOpenAIRoutingMarkerWriter(rec, "gpt-4o", "✦ marker")
+
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.WriteHeader(http.StatusTooManyRequests)
+
+	errBody := `{"error":{"message":"rate limited"}}`
+	_, err := w.Write([]byte(errBody))
+	require.NoError(t, err)
+
+	assert.Equal(t, errBody, rec.Body.String(), "error responses should pass through unmodified")
+}
+
+func TestOpenAIRoutingMarkerWriter_MarkerEmittedOnce(t *testing.T) {
+	rec := httptest.NewRecorder()
+	w := translate.NewOpenAIRoutingMarkerWriter(rec, "gpt-4o", "✦ marker\n\n")
+
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.WriteHeader(http.StatusOK)
+
+	chunk1 := "data: {\"choices\":[{\"delta\":{\"content\":\"Hi\"}}]}\n\n"
+	chunk2 := "data: {\"choices\":[{\"delta\":{\"content\":\" there\"}}]}\n\n"
+	_, _ = w.Write([]byte(chunk1))
+	_, _ = w.Write([]byte(chunk2))
+
+	events := splitSSEEvents(rec.Body.String())
+	assert.Len(t, events, 3, "marker + 2 upstream chunks")
+
+	markerCount := 0
+	for _, e := range events {
+		if strings.Contains(e, "Weave") {
+			// Not all markers contain "Weave" — count by the specific marker content.
+		}
+		data := strings.TrimPrefix(e, "data: ")
+		if content := gjson.Get(data, "choices.0.delta.content").String(); strings.Contains(content, "marker") {
+			markerCount++
+		}
+	}
+	assert.Equal(t, 1, markerCount, "marker should be emitted exactly once")
+}
+
+// splitSSEEvents splits SSE text into individual events (each terminated by \n\n).
+func splitSSEEvents(s string) []string {
+	raw := strings.Split(s, "\n\n")
+	var events []string
+	for _, e := range raw {
+		e = strings.TrimSpace(e)
+		if e != "" {
+			events = append(events, e)
+		}
+	}
+	return events
+}

--- a/internal/translate/strip_marker_test.go
+++ b/internal/translate/strip_marker_test.go
@@ -148,14 +148,32 @@ func TestStripRoutingMarker_EmptyAndMissingMessages(t *testing.T) {
 	}
 }
 
-func TestStripRoutingMarker_StringContentNoOp(t *testing.T) {
-	// Some clients send messages[].content as a plain string. The marker is
-	// only injected inside content arrays, so string-content messages must be
-	// returned unchanged.
+func TestStripRoutingMarker_StringContentNoMarkerNoOp(t *testing.T) {
 	body := []byte(`{"messages":[{"role":"user","content":"hello"}]}`)
 	out, err := translate.StripRoutingMarkerFromMessages(body)
 	require.NoError(t, err)
 	assert.Equal(t, body, out)
+}
+
+func TestStripRoutingMarker_StringContentStripsMarker(t *testing.T) {
+	for _, marker := range sampleMarkers {
+		body := []byte(`{"messages":[{"role":"assistant","content":"` +
+			strings.ReplaceAll(strings.ReplaceAll(marker, `"`, `\"`), "\n", `\n`) +
+			`Hello, how can I help?"}]}`)
+		out, err := translate.StripRoutingMarkerFromMessages(body)
+		require.NoError(t, err)
+		assert.NotContains(t, string(out), markerSentinel)
+		assert.Equal(t, "Hello, how can I help?", gjson.GetBytes(out, "messages.0.content").String())
+	}
+}
+
+func TestStripRoutingMarker_StringContentOnlyMarkerBecomesEmpty(t *testing.T) {
+	body := []byte(`{"messages":[{"role":"assistant","content":"` +
+		strings.ReplaceAll(strings.ReplaceAll(sampleMarkers[0], `"`, `\"`), "\n", `\n`) +
+		`"}]}`)
+	out, err := translate.StripRoutingMarkerFromMessages(body)
+	require.NoError(t, err)
+	assert.NotContains(t, string(out), markerSentinel)
 }
 
 func TestStripRoutingMarker_PreservesAdjacentFields(t *testing.T) {


### PR DESCRIPTION
## Summary

- Inject the `✦ **Weave Router** → model · reason` routing marker into OpenAI and Gemini streaming responses, matching the existing behavior for Anthropic-format responses
- Cursor and other OpenAI-compatible clients now see which model was chosen and why at the start of each response
- Strip routing markers from inbound OpenAI string-content messages to prevent accumulation across turns

## Details

Previously the routing marker was only emitted for Anthropic Messages responses (via `AnthropicSSETranslator.WithRoutingMarker`). OpenAI and Gemini surfaces only set `x-router-*` response headers, which clients like Cursor don't surface.

New `OpenAIRoutingMarkerWriter` and `GeminiRoutingMarkerWriter` wrap the response writer and emit a marker chunk before the first upstream SSE event. Non-streaming responses pass through unmodified.

`StripRoutingMarkerFromMessages` is extended to handle OpenAI string content (it previously only handled Anthropic content-block arrays) and is now called in `ProxyOpenAIChatCompletion`.

## Test plan

- [x] `go test ./...` — all passing
- [x] curl verified: marker appears as first `chat.completion.chunk` in OpenAI streaming responses
- [x] Marker not emitted for non-streaming or error responses
- [x] Marker emitted exactly once per response
- [x] Empty marker (sticky hit, no routing decision) correctly skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)