### PR TITLE
chore(npm): bump @workweave/router to 0.1.5

### DIFF
--- a/install/npm/package.json
+++ b/install/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@workweave/router",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "One-command installer that points Claude Code at the Weave Router.",
   "bin": {
     "weave-router": "bin.js"


### PR DESCRIPTION
## Summary
- Bumps `install/npm/package.json` from 0.1.4 → 0.1.5.

Picks up the `/force-model` + `/unforce-model` slash-command wrappers (`install/commands/`) that ship into `~/.claude/commands/` for Claude Code and `~/.codex/prompts/` for Codex CLI on install.

## Test plan
- [ ] CI green
- [ ] After merge: tag `router-v0.1.5` to trigger the publish workflow
- [ ] Verify on https://www.npmjs.com/package/@workweave/router that 0.1.5 is published with provenance
- [ ] `npx @workweave/router@0.1.5 --claude --local --non-interactive` (with `WEAVE_ROUTER_KEY` set) drops the two `.md` files into `~/.claude/commands/`