### PR TITLE
feat: add /v1/router/models catalog endpoint

### DIFF
--- a/internal/api/admin/catalog.go
+++ b/internal/api/admin/catalog.go
@@ -1,0 +1,27 @@
+package admin
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+)
+
+// CatalogModelsResponse is the shape returned by GET /v1/router/models.
+// Kept stable so the Weave control plane can rely on the wire format without
+// re-checking the artifact JSON shape on every router gitlink bump.
+type CatalogModelsResponse struct {
+	Models []deployedModelDTO `json:"models"`
+}
+
+// CatalogModelsHandler returns the deployed-models catalog for the active
+// cluster artifact. Read-only, unauthed metadata — mounted in both selfhosted
+// and managed deployment modes so the Weave control plane (which is the only
+// caller in managed mode) can fetch it without juggling router API keys.
+//
+// The list is publicly known (we publish per-version model registries on the
+// RouterArena leaderboard) so there is no leak risk from leaving this open.
+func CatalogModelsHandler(models DeployedModelsSource) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		c.JSON(http.StatusOK, CatalogModelsResponse{Models: deployedModelsDTO(models)})
+	}
+}

--- a/internal/api/admin/catalog_test.go
+++ b/internal/api/admin/catalog_test.go
@@ -1,0 +1,70 @@
+package admin_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"workweave/router/internal/api/admin"
+	"workweave/router/internal/router/cluster"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeDeployedModels struct {
+	entries []cluster.DeployedEntry
+}
+
+func (f fakeDeployedModels) DefaultDeployedModels() []cluster.DeployedEntry { return f.entries }
+
+func TestCatalogModelsHandler_SortsByProviderThenModel(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	src := fakeDeployedModels{entries: []cluster.DeployedEntry{
+		{Model: "gpt-5.5", Provider: "openai"},
+		{Model: "claude-opus-4-7", Provider: "anthropic"},
+		{Model: "claude-haiku-4-5", Provider: "anthropic"},
+		{Model: "gpt-5.4-mini", Provider: "openai"},
+	}}
+
+	engine := gin.New()
+	engine.GET("/v1/router/models", admin.CatalogModelsHandler(src))
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/router/models", nil)
+	rec := httptest.NewRecorder()
+	engine.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var got admin.CatalogModelsResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
+
+	require.Len(t, got.Models, 4)
+	assert.Equal(t, "anthropic", got.Models[0].Provider)
+	assert.Equal(t, "claude-haiku-4-5", got.Models[0].Model)
+	assert.Equal(t, "anthropic", got.Models[1].Provider)
+	assert.Equal(t, "claude-opus-4-7", got.Models[1].Model)
+	assert.Equal(t, "openai", got.Models[2].Provider)
+	assert.Equal(t, "gpt-5.4-mini", got.Models[2].Model)
+	assert.Equal(t, "openai", got.Models[3].Provider)
+	assert.Equal(t, "gpt-5.5", got.Models[3].Model)
+}
+
+func TestCatalogModelsHandler_EmptyListReturnsEmptyArray(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	engine := gin.New()
+	engine.GET("/v1/router/models", admin.CatalogModelsHandler(fakeDeployedModels{}))
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/router/models", nil)
+	rec := httptest.NewRecorder()
+	engine.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	// Empty slice must round-trip as [], not null — the Weave control plane
+	// distinguishes "no models" from "missing field".
+	assert.JSONEq(t, `{"models":[]}`, rec.Body.String())
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -64,6 +64,17 @@ func Register(engine *gin.Engine, authSvc *auth.Service, proxySvc *proxy.Service
 
 	engine.GET("/health", middleware.WithTimeout(healthTimeout), admin.HealthHandler)
 
+	// /v1/router/models surfaces the active artifact's deployed-models list so
+	// the Weave control plane can validate per-org exclusion submissions
+	// against the live universe instead of hand-copying it on every gitlink
+	// bump. Read-only metadata — unauthed so managed mode (no admin keys
+	// issuable on-router) can call it; the list is published publicly on the
+	// RouterArena leaderboard so there is no leak risk. nil source skips the
+	// route in tests that don't wire a cluster scorer.
+	if deployedModels != nil {
+		engine.GET("/v1/router/models", middleware.WithTimeout(healthTimeout), admin.CatalogModelsHandler(deployedModels))
+	}
+
 	// /validate is a token-validity probe used by clients (not the dashboard), so it stays mounted in both modes.
 	adminAuthed := engine.Group("", middleware.WithTimeout(validateTimeout), middleware.WithAuth(authSvc, byokDisabled))
 	adminAuthed.GET("/validate", admin.ValidateHandler)

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -32,6 +32,7 @@ func TestRegister_DeploymentMode(t *testing.T) {
 	productRoutes := []string{
 		"GET /health",
 		"GET /validate",
+		"GET /v1/router/models",
 		"POST /v1/messages",
 		"POST /v1/chat/completions",
 		"POST /v1/responses",
@@ -77,7 +78,10 @@ func TestRegister_DeploymentMode(t *testing.T) {
 
 	t.Run("managed skips dashboard but keeps product routes", func(t *testing.T) {
 		engine := gin.New()
-		server.Register(engine, nil, nil, nil, server.DeploymentModeManaged, nil)
+		// Pass a non-nil DeployedModelsSource: managed prod always boots a
+		// *cluster.Multiversion router, so the catalog endpoint must mount
+		// even though the dashboard does not.
+		server.Register(engine, nil, nil, fakeDeployedModelsSource{}, server.DeploymentModeManaged, nil)
 		got := routeSet(engine)
 		for _, want := range productRoutes {
 			assert.Contains(t, got, want, "product route missing in managed mode")
@@ -85,5 +89,12 @@ func TestRegister_DeploymentMode(t *testing.T) {
 		for _, unwanted := range dashboardRoutes {
 			assert.NotContains(t, got, unwanted, "dashboard route must not be mounted in managed mode")
 		}
+	})
+
+	t.Run("nil deployed-models source skips catalog endpoint", func(t *testing.T) {
+		engine := gin.New()
+		server.Register(engine, nil, nil, nil, server.DeploymentModeManaged, nil)
+		got := routeSet(engine)
+		assert.NotContains(t, got, "GET /v1/router/models", "catalog endpoint must not mount without a deployed-models source")
 	})
 }


### PR DESCRIPTION
## Summary

Surfaces the active cluster artifact's deployed-models list as a read-only product-surface endpoint at \`GET /v1/router/models\` so the Weave control plane can validate per-org exclusion submissions against the live universe instead of hand-copying the list into backend code on every router gitlink bump.

Today the backend's \`weaverouter/deployed_models.go\` is a hand-maintained copy of the active artifact's \`model_registry.json\`. When the gitlink moves and the copy isn't refreshed, the per-org settings page rejects every save with \"Unknown model id\" — happened on prod earlier today (v0.21-era list still in the backend while the router served v0.52). Backend follow-up PR will replace the hardcoded list with a startup call to this endpoint.

## Design

- **Unauthed.** The list is already public via the RouterArena leaderboard, and managed-mode deploys cannot issue router admin keys — a bearer gate would force a new key-distribution flow for no security gain.
- **Both deployment modes.** Mounted outside the selfhosted block, gated on a non-nil \`DeployedModelsSource\` so server tests without a cluster scorer keep their existing zero-wire behavior. Real prod always wires \`*cluster.Multiversion\`.
- **Wire shape stable.** Reuses the existing \`deployedModelsDTO\` helper so the response can't drift from the admin/excluded-models surface.

## Test plan

- [x] \`go test ./internal/api/admin/... ./internal/server/...\` passes
- [ ] Manually hit \`curl localhost:8080/v1/router/models\` against local stack and confirm \`{\"models\":[{\"model\":\"...\",\"provider\":\"...\"}, ...]}\`
- [ ] Verify endpoint mounts in managed mode (server_test now covers this)