### PR TITLE
feat(installer): add --opencode target

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,28 +55,29 @@ Point Claude Code, Codex, Cursor, or your own app at `localhost:8080`. The route
 
 ## 30-second quickstart
 
-The fastest way: point Claude Code or Codex at the **hosted** Weave Router
-with one command. No clone, no Docker, no Postgres.
+The fastest way: point Claude Code, Codex, or opencode at the **hosted**
+Weave Router with one command. No clone, no Docker, no Postgres.
 
 ```bash
 npx @workweave/router
 ```
 
-That's it. The installer asks which tool (Claude Code or Codex), walks you
-through scope (user vs. project), grabs a router key, and wires the right
-config file. Other flavors:
+That's it. The installer asks which tool (Claude Code, Codex, or opencode),
+walks you through scope (user vs. project), grabs a router key, and wires
+the right config file. Other flavors:
 
 ```bash
 npx @workweave/router --claude              # skip the picker, Claude Code
 npx @workweave/router --codex               # skip the picker, OpenAI Codex CLI
-npx @workweave/router --scope project       # per-repo, commits settings.json (or .codex/)
+npx @workweave/router --opencode            # skip the picker, opencode
+npx @workweave/router --scope project       # per-repo, commits settings.json (or .codex/ / opencode.json)
 npx @workweave/router --local               # self-hosted localhost:8080
 npx @workweave/router --base-url https://router.acme.internal
 npx @workweave/router@0.1.0                 # pin a version
 ```
 
-Requires Node ≥ 18 (Claude Code path also needs `jq`). Full flag reference:
-[install/npm/README.md](install/npm/README.md).
+Requires Node ≥ 18 (Claude Code and opencode paths also need `jq`). Full
+flag reference: [install/npm/README.md](install/npm/README.md).
 
 ### Or: self-host the whole stack
 
@@ -125,6 +126,14 @@ Codex's existing `OPENAI_API_KEY` flows through to api.openai.com for the
 plan-based passthrough; the router key rides in an `X-Weave-Router-Key` HTTP
 header. Re-install and `--uninstall --codex` rewrite/remove only the managed
 block, leaving the rest of your Codex config untouched.
+
+**opencode.** `npx @workweave/router --opencode` merges a `provider.weave`
+entry into `~/.config/opencode/opencode.json` (or `<repo>/opencode.json`
+with `--scope project`). It uses opencode's bundled `@ai-sdk/anthropic`
+provider pointed at the router's `/v1` endpoint — the router speaks the
+Anthropic Messages API natively, so opencode works unmodified. The router
+key and identity headers ride alongside the provider config; re-install
+rewrites only the managed block and `--uninstall --opencode` strips it.
 
 **Cursor** *(early beta, performance may not be the best).* Settings →
 Models → *Override OpenAI Base URL* → `http://localhost:8080/v1`, paste

--- a/install/README.md
+++ b/install/README.md
@@ -1,23 +1,25 @@
-# Weave Router — Claude Code + Codex installer
+# Weave Router — Claude Code + Codex + opencode installer
 
-One command to point Claude Code or the OpenAI Codex CLI at the Weave Router
-permanently. No shell exports, no manual config edits.
+One command to point Claude Code, the OpenAI Codex CLI, or opencode at the
+Weave Router permanently. No shell exports, no manual config edits.
 
 ## Quick start
 
 ### Hosted Weave Router
 
 ```bash
-# Interactive: the installer asks Claude Code or Codex, then user vs. project
+# Interactive: the installer asks Claude Code / Codex / opencode, then user vs. project
 npx @workweave/router
 
 # Skip the target picker:
 npx @workweave/router --claude                     # Claude Code, user scope
 npx @workweave/router --codex                      # Codex, user scope
+npx @workweave/router --opencode                   # opencode, user scope
 
 # Project scope — only when running inside this repo:
-npx @workweave/router --claude --scope project     # Claude Code
-npx @workweave/router --codex  --scope project     # Codex
+npx @workweave/router --claude   --scope project   # Claude Code
+npx @workweave/router --codex    --scope project   # Codex
+npx @workweave/router --opencode --scope project   # opencode
 ```
 
 Prefer `curl`? The same installer is also served as a shell script:
@@ -25,6 +27,7 @@ Prefer `curl`? The same installer is also served as a shell script:
 ```bash
 curl -fsSL https://weave.ai/cc/install.sh | sh
 curl -fsSL https://weave.ai/cc/install.sh | sh -s -- --codex
+curl -fsSL https://weave.ai/cc/install.sh | sh -s -- --opencode
 curl -fsSL https://weave.ai/cc/install.sh | sh -s -- --scope project
 ```
 
@@ -34,14 +37,15 @@ Or from a clone of this repo:
 ./router/install/install.sh                    # prompts: target, then scope
 ./router/install/install.sh --claude           # skip picker, Claude Code
 ./router/install/install.sh --codex            # skip picker, Codex
+./router/install/install.sh --opencode         # skip picker, opencode
 ./router/install/install.sh --scope project    # team install
 ```
 
-When run interactively without `--claude` / `--codex`, the installer asks
-which tool to target (defaults to Claude Code on Enter). Without `--scope`,
-it then asks user vs. project (defaults to user). `--non-interactive` skips
-both prompts (target defaults to Claude Code) — useful for CI and
-`curl | sh` pipelines.
+When run interactively without `--claude` / `--codex` / `--opencode`, the
+installer asks which tool to target (defaults to Claude Code on Enter).
+Without `--scope`, it then asks user vs. project (defaults to user).
+`--non-interactive` skips both prompts (target defaults to Claude Code) —
+useful for CI and `curl | sh` pipelines.
 
 The installer also prompts for your API key (or reads `$WEAVE_ROUTER_KEY`
 for non-interactive installs).
@@ -124,14 +128,36 @@ Re-running the installer rewrites only the managed block (TOML between the
 markers + a top-level `model_provider =` outside it). Everything else —
 profiles, alternate providers, comments — stays untouched.
 
-**Onboarding flow for a new teammate (either target):**
+### opencode (`--opencode`)
+
+**User scope:**
+
+| Path                                       | Purpose                                                       |
+| ------------------------------------------ | ------------------------------------------------------------- |
+| `~/.config/opencode/opencode.json`         | Merges a `provider.weave` entry backed by opencode's `@ai-sdk/anthropic`, pointed at `<base-url>/v1`. Headers carry `X-Weave-Router-Key` plus the identity headers (`X-Weave-User-Email`, `X-Weave-User-Name`, `X-App: opencode`). Top-level `model` is set to `weave/claude-sonnet-4-6` when no model is already configured. |
+
+**Project scope (`--scope project`):**
+
+| Path                       | Committed? | Purpose                                                       |
+| -------------------------- | ---------- | ------------------------------------------------------------- |
+| `<repo>/opencode.json`     | ❌ ignored | Per-teammate config (holds the router key). Each teammate runs the installer for their own key. |
+| `<repo>/.gitignore`        | ✅ commit  | Adds `opencode.json` to the ignore list.                       |
+
+The router speaks the Anthropic Messages API natively, so opencode talks to
+it through its bundled `@ai-sdk/anthropic` provider without any patching.
+Re-running the installer rewrites only the managed `provider.weave` block;
+other providers, MCP servers, agents, and your top-level model choice stay
+untouched. `--uninstall --opencode` strips the block (and `model` only when
+it points at `weave/...`).
+
+**Onboarding flow for a new teammate (any target):**
 
 ```bash
 git clone <repo>
 cd <repo>
-npx @workweave/router --claude --scope project   # or --codex
+npx @workweave/router --claude --scope project   # or --codex / --opencode
 export WEAVE_ROUTER_KEY=rk_...                    # in shell rc / dotenv / 1Password
-claude                                             # or `CODEX_HOME=.codex codex`
+claude                                             # or `CODEX_HOME=.codex codex` / `opencode`
 ```
 
 The `--scope project` step only needs to run once per checkout (re-run if
@@ -143,6 +169,7 @@ The `--scope project` step only needs to run once per checkout (re-run if
 | -------------------------- | ----------------------------- | ---------------------------------------------------------------------- |
 | `--claude`                 | (target picker if interactive) | Skip the target picker; install for Claude Code.                       |
 | `--codex`                  | (target picker if interactive) | Skip the target picker; install for the OpenAI Codex CLI.              |
+| `--opencode`               | (target picker if interactive) | Skip the target picker; install for opencode.                          |
 | `--scope user\|project`    | interactive prompt (default `user`) | User-level install (everywhere) vs project-level (this repo only).      |
 | `--local`                  | off                           | Shortcut for the bundled docker-compose router (`localhost:8080`).      |
 | `--base-url <url>`         | `https://router.workweave.ai` | Override the router endpoint. Use for self-hosted / custom port.        |
@@ -172,13 +199,24 @@ errors invoking `cc-statusline.sh`. The script needs `jq` on PATH.
 3. Check the router's dashboard at `<base-url>/ui/dashboard` to see the
    routed decision.
 
+**opencode:**
+
+1. Open `~/.config/opencode/opencode.json` (or `<repo>/opencode.json` for
+   project scope) and confirm `provider.weave` exists with your
+   `X-Weave-Router-Key` in `options.headers`.
+2. Run `opencode` and pick one of the `weave/...` models. Issue a turn.
+3. Check the router's dashboard at `<base-url>/ui/dashboard` — traffic
+   should be tagged `X-App: opencode`.
+
 ## Uninstall
 
 ```bash
 npx @workweave/router --uninstall                       # Claude Code, user scope
 npx @workweave/router --uninstall --codex               # Codex, user scope
+npx @workweave/router --uninstall --opencode            # opencode, user scope
 npx @workweave/router --uninstall --scope project       # Claude Code, in the repo
 npx @workweave/router --uninstall --codex --scope project
+npx @workweave/router --uninstall --opencode --scope project
 ```
 
 Removes only the keys / block this installer added; everything else in

--- a/install/install.sh
+++ b/install/install.sh
@@ -1,28 +1,35 @@
 #!/usr/bin/env bash
 #
-# Weave Router installer for Claude Code and Codex.
+# Weave Router installer for Claude Code, Codex, and opencode.
 #
-# Configures Claude Code (default) or the OpenAI Codex CLI (`--codex`) to
-# permanently route through the Weave Router. For Claude Code this writes
-# the router base URL, router auth header, and a status line into Claude
-# Code's settings.json. For Codex it writes a `model_providers.weave`
-# entry plus `model_provider = "weave"` into ~/.codex/config.toml (managed
-# block delimited by markers so re-install / uninstall is clean).
+# Configures Claude Code (default), the OpenAI Codex CLI (`--codex`), or
+# opencode (`--opencode`) to permanently route through the Weave Router.
+# For Claude Code this writes the router base URL, router auth header,
+# and a status line into Claude Code's settings.json. For Codex it writes
+# a `model_providers.weave` entry plus `model_provider = "weave"` into
+# ~/.codex/config.toml (managed block delimited by markers). For opencode
+# it merges a `provider.weave` block (anthropic-compatible) into
+# opencode.json — since the file is JSON, install/uninstall are structural
+# (jq) rather than marker-delimited.
 #
-# Two scopes (apply to both targets):
+# Two scopes (apply to all targets):
 #   - user (default):  ~/.claude/settings.json  + ~/.weave/cc-statusline.sh
 #                      ~/.codex/config.toml                       (with --codex)
+#                      ~/.config/opencode/opencode.json           (with --opencode)
 #   - project:         <repo>/.claude/settings.json + <repo>/.claude/cc-statusline.sh
 #                      <repo>/.codex/config.toml                  (with --codex)
+#                      <repo>/opencode.json                       (with --opencode)
 #
 # Or pass --dir to install into any directory:
 #   - dir:              <dir>/.claude/settings.json + <dir>/.claude/cc-statusline.sh
 #                       <dir>/.codex/config.toml                  (with --codex)
+#                       <dir>/opencode.json                       (with --opencode)
 #
 # Usage:
-#   npx @workweave/router                                  # interactive picker (Claude Code or Codex)
+#   npx @workweave/router                                  # interactive picker (Claude Code, Codex, opencode)
 #   npx @workweave/router --claude                         # skip the picker, target Claude Code
 #   npx @workweave/router --codex                          # skip the picker, target the OpenAI Codex CLI
+#   npx @workweave/router --opencode                       # skip the picker, target opencode
 #   npx @workweave/router --scope project                  # commit-with-team install
 #   npx @workweave/router --dir /tmp/my-sandbox            # isolated throwaway install
 #   npx @workweave/router --local                          # local router on localhost:8080
@@ -47,11 +54,14 @@ non_interactive="false"
 quiet="false"
 router_key_header="X-Weave-Router-Key"
 # Target tool whose config we patch. "claude" (default) writes Claude Code
-# settings.json; "codex" writes ~/.codex/config.toml. Each target carries its
-# own credential-passthrough story in the router: Claude Code's logged-in
-# Anthropic key flows through unchanged, and Codex's `OPENAI_API_KEY` flows
-# through via the same header path. target_explicit tracks whether --claude
-# or --codex was passed so an interactive run can prompt for the choice.
+# settings.json; "codex" writes ~/.codex/config.toml; "opencode" merges a
+# provider block into opencode.json. Each target carries its own
+# credential-passthrough story in the router: Claude Code's logged-in
+# Anthropic key flows through unchanged, Codex's `OPENAI_API_KEY` flows
+# through via the same header path, and opencode talks to the router via
+# its anthropic-compatible API surface. target_explicit tracks whether
+# --claude / --codex / --opencode was passed so an interactive run can
+# prompt for the choice.
 target="claude"
 target_explicit="false"
 
@@ -97,8 +107,9 @@ print_banner() {
   [ "$tty_out" = "true" ] || return 0
   local target_label
   case "$target" in
-    codex) target_label="Codex installer" ;;
-    *)     target_label="Claude Code installer" ;;
+    codex)    target_label="Codex installer" ;;
+    opencode) target_label="opencode installer" ;;
+    *)        target_label="Claude Code installer" ;;
   esac
   printf '\n'
   printf '%s  ╦ ╦╔═╗╔═╗╦  ╦╔═╗%s\n' "$C_BRAND" "$C_RESET"
@@ -473,6 +484,83 @@ TOML
   chmod 600 "$config_file"
 }
 
+# write_opencode_config merges a managed `provider.weave` entry into opencode's
+# opencode.json (anthropic-compatible — the router speaks the Anthropic
+# Messages API natively, so opencode's bundled @ai-sdk/anthropic provider
+# works unmodified). Re-running rewrites the block in-place via jq; uninstall
+# strips it the same way. We also set `model` at the top level so a fresh
+# `opencode` invocation picks the router by default; if the user has set
+# their own model already, we leave it alone.
+#
+# Usage: write_opencode_config <config_file_path> <base_url> <api_key> [user_email] [user_name]
+write_opencode_config() {
+  local config_file="$1"
+  local block_url="$2"
+  local block_key="$3"
+  local block_email="${4:-}"
+  local block_name="${5:-}"
+
+  # Build the headers object piecewise so empty email/name vanish from the
+  # final JSON. opencode forwards the `headers` map verbatim to the upstream
+  # provider, so the router sees the same X-Weave-* triplet here that it
+  # would from Claude Code or Codex. The X-App tag lets router telemetry
+  # attribute traffic to opencode specifically.
+  local headers_json
+  headers_json="$(jq -n \
+    --arg key   "$block_key" \
+    --arg email "$block_email" \
+    --arg name  "$block_name" '
+    {"X-Weave-Router-Key": $key, "X-App": "opencode"}
+    | (if $email != "" then . + {"X-Weave-User-Email": $email} else . end)
+    | (if $name  != "" then . + {"X-Weave-User-Name":  $name } else . end)
+  ')"
+
+  # Headline models we surface in opencode's picker. The router re-routes
+  # each request anyway, so this list is mostly UX — what shows up when the
+  # user runs /models inside opencode. Keep it short and Anthropic-shaped
+  # so the bundled @ai-sdk/anthropic provider can request them.
+  local block
+  block="$(jq -n \
+    --arg url "$block_url/v1" \
+    --argjson headers "$headers_json" '
+    {
+      npm: "@ai-sdk/anthropic",
+      name: "Weave Router",
+      options: { baseURL: $url, headers: $headers },
+      models: {
+        "claude-opus-4-7":   { name: "Claude Opus 4.7 (via Weave Router)" },
+        "claude-sonnet-4-6": { name: "Claude Sonnet 4.6 (via Weave Router)" },
+        "claude-haiku-4-5":  { name: "Claude Haiku 4.5 (via Weave Router)" }
+      }
+    }
+  ')"
+
+  # Merge into any existing opencode.json. We always overwrite provider.weave
+  # so re-install reflects the latest key/identity, but we leave the rest of
+  # the file (other providers, mcp, agent settings) untouched. Top-level
+  # `model` is only set when the user hasn't already picked one.
+  local merged
+  if [ -f "$config_file" ]; then
+    merged="$(jq --argjson block "$block" '
+      .provider = ((.provider // {}) | .weave = $block)
+      | (if (.model // "") == "" then .model = "weave/claude-sonnet-4-6" else . end)
+      | (.["$schema"] //= "https://opencode.ai/config.json")
+    ' "$config_file")"
+  else
+    merged="$(jq -n --argjson block "$block" '
+      {
+        "$schema": "https://opencode.ai/config.json",
+        model: "weave/claude-sonnet-4-6",
+        provider: { weave: $block }
+      }
+    ')"
+  fi
+  printf '%s\n' "$merged" >"$config_file"
+  # 0600: the file holds a router key. Even at user scope, mode 644 would
+  # leak the key to any local user on a shared box.
+  chmod 600 "$config_file"
+}
+
 # resolve_user_name mirrors resolve_user_email but for display name. Priority:
 # WEAVE_USER_NAME env override → git config user.name → empty. We don't
 # prompt for name independently: if email prompting yielded nothing, name
@@ -575,9 +663,13 @@ while [ $# -gt 0 ]; do
     --codex)
       target="codex"; target_explicit="true"; shift
       ;;
+    --opencode)
+      target="opencode"; target_explicit="true"; shift
+      ;;
     --claude)
-      # No-op selector for symmetry with --codex. Useful in pipelines that
-      # want to skip the interactive picker without depending on the default.
+      # No-op selector for symmetry with --codex / --opencode. Useful in
+      # pipelines that want to skip the interactive picker without depending
+      # on the default.
       target="claude"; target_explicit="true"; shift
       ;;
     -h|--help)
@@ -607,11 +699,13 @@ if [ "$target_explicit" = "false" ] && [ "$non_interactive" = "false" ] && [ -r 
   printf "%sInstall target:%s\n" "$C_BOLD" "$C_RESET"
   printf "  %s1)%s Claude Code  %s— patches ~/.claude/settings.json (or <repo>/.claude/)%s\n" "$C_BRAND" "$C_RESET" "$C_DIM" "$C_RESET"
   printf "  %s2)%s Codex        %s— patches ~/.codex/config.toml (or <repo>/.codex/)%s\n" "$C_BRAND" "$C_RESET" "$C_DIM" "$C_RESET"
-  printf "Choose %s[1/2]%s (default %s1%s): " "$C_BOLD" "$C_RESET" "$C_BOLD" "$C_RESET"
+  printf "  %s3)%s opencode     %s— patches ~/.config/opencode/opencode.json (or <repo>/opencode.json)%s\n" "$C_BRAND" "$C_RESET" "$C_DIM" "$C_RESET"
+  printf "Choose %s[1/2/3]%s (default %s1%s): " "$C_BOLD" "$C_RESET" "$C_BOLD" "$C_RESET"
   read -r target_choice </dev/tty || target_choice=""
   case "${target_choice:-1}" in
     1|""|claude|c|C)  target="claude" ;;
     2|codex|x|X)      target="codex" ;;
+    3|opencode|o|O)   target="opencode" ;;
     *) err "invalid choice: $target_choice"; exit 2 ;;
   esac
 fi
@@ -634,6 +728,11 @@ if [ -z "$install_dir" ] && [ "$scope_explicit" = "false" ] && [ "$non_interacti
       scope_user_path="~/.codex/"
       scope_project_path="<repo>/.codex/"
       scope_cli_label="codex"
+      ;;
+    opencode)
+      scope_user_path="~/.config/opencode/"
+      scope_project_path="<repo>/opencode.json"
+      scope_cli_label="opencode"
       ;;
     *)
       scope_user_path="~/.claude/"
@@ -678,8 +777,9 @@ fi
 [ "$quiet" = "true" ] || info "scope=${C_BOLD}${scope}${C_RESET}  target=${C_BOLD}${target}${C_RESET}  base_url=${C_BOLD}${base_url}${C_RESET}"
 
 # Codex install only writes a TOML file (managed via awk) so jq isn't needed.
-# Claude Code's settings.json patching uses jq to deep-merge env keys.
-if [ "$target" = "claude" ]; then
+# Claude Code's settings.json and opencode's opencode.json patching both use
+# jq to deep-merge / structurally rewrite JSON.
+if [ "$target" = "claude" ] || [ "$target" = "opencode" ]; then
   require_cmd jq    "macOS: 'brew install jq' · Debian/Ubuntu: 'sudo apt install jq'"
 fi
 require_cmd curl  "macOS/Linux: usually preinstalled — check your package manager"
@@ -695,6 +795,12 @@ case "$target" in
     if ! command -v codex >/dev/null 2>&1; then
       warn "'codex' not found on PATH. Install via 'npm install -g @openai/codex' (or brew install codex), then re-run this script."
       warn "Continuing — config.toml will be written and will take effect once Codex is installed."
+    fi
+    ;;
+  opencode)
+    if ! command -v opencode >/dev/null 2>&1; then
+      warn "'opencode' not found on PATH. Install from https://opencode.ai (or 'npm install -g opencode-ai'), then re-run this script."
+      warn "Continuing — opencode.json will be written and will take effect once opencode is installed."
     fi
     ;;
 esac
@@ -767,7 +873,7 @@ if [ "$target" = "claude" ]; then
   fi
 
   mkdir -p "$settings_dir" "$statusline_dir"
-else
+elif [ "$target" = "codex" ]; then
   # Codex CLI reads config from ~/.codex/config.toml by default. For project
   # scope we write to <repo>/.codex/config.toml; the user invokes Codex with
   # `CODEX_HOME=<repo>/.codex codex` (or runs from the repo if Codex auto-
@@ -782,6 +888,34 @@ else
   fi
 
   mkdir -p "$codex_dir"
+else
+  # opencode discovers config in this order: $XDG_CONFIG_HOME/opencode/opencode.json
+  # (or ~/.config/opencode/opencode.json) for user scope, and opencode.json /
+  # opencode.jsonc walked up from CWD for project scope. We standardize on
+  # opencode.json at the repo root for project scope (the option teammates can
+  # commit) and the XDG path for user scope. The router key is embedded so
+  # opencode.json goes in .gitignore for project scope, same as Codex.
+  case "$scope" in
+    user)
+      opencode_dir="${XDG_CONFIG_HOME:-$settings_base/.config}/opencode"
+      ;;
+    project)
+      opencode_dir="$settings_base"
+      ;;
+  esac
+  # --dir overrides both scopes: drop opencode.json straight into <dir>/ so
+  # the sandbox is self-contained (mirrors how --dir behaves for Codex).
+  if [ -n "$install_dir" ]; then
+    opencode_dir="$install_dir"
+  fi
+  opencode_config_file="$opencode_dir/opencode.json"
+
+  if [ "$scope" = "project" ] || [ -n "$install_dir" ]; then
+    refuse_if_symlink "$opencode_dir"
+    refuse_if_symlink "$opencode_config_file"
+  fi
+
+  mkdir -p "$opencode_dir"
 fi
 
 # ---------- token handling ----------
@@ -939,6 +1073,56 @@ if [ "$target" = "codex" ]; then
     # Codex auto-discovers ~/.codex; for non-user installs the caller has to
     # point CODEX_HOME at the directory we wrote so Codex finds our config.
     info "Run Codex with CODEX_HOME=$codex_dir codex so it picks up this config."
+  fi
+  exit 0
+fi
+
+# ---------- opencode install path (dispatch + exit before the Claude-only writes) ----------
+
+if [ "$target" = "opencode" ]; then
+  write_opencode_config "$opencode_config_file" "$base_url" "$api_key" "$user_email" "$user_name"
+  ok "opencode config written to $opencode_config_file"
+
+  # Project scope: the per-teammate config carries the router key, so it
+  # stays out of git. Same reasoning as the Codex path — base URL is shared,
+  # but the key is per-person.
+  if [ "$scope" = "project" ] && [ -z "$install_dir" ] && [ -n "${git_root:-}" ]; then
+    gitignore="$git_root/.gitignore"
+    refuse_if_symlink "$gitignore"
+    for entry in \
+      "opencode.json"
+    do
+      if [ ! -f "$gitignore" ] || ! grep -qxF "$entry" "$gitignore"; then
+        printf '%s\n' "$entry" >>"$gitignore"
+      fi
+    done
+    ok "Updated $gitignore (ignored opencode.json)"
+  fi
+
+  # Post-install verification: same probes the Claude/Codex paths run.
+  if [ "$quiet" != "true" ]; then
+    if ! spin "Pinging $base_url/health" curl -fsS --max-time 5 "$base_url/health"; then
+      warn "Could not reach $base_url/health within 5s. Settings are written; verify the router is running."
+    fi
+  fi
+
+  if [ -n "$api_key" ]; then
+    validate_opencode_key() {
+      printf '%s: %s\n' "$router_key_header" "$api_key" \
+        | curl -fsS --max-time 5 --header @- "$base_url/validate"
+    }
+    if ! spin "Validating API key" validate_opencode_key; then
+      warn "Router rejected the API key (check it matches the dashboard at $base_url/ui/)."
+    fi
+  fi
+
+  printf "\n"
+  printf "%s✓%s %s%sWeave Router installed for opencode.%s\n" \
+    "$C_GREEN" "$C_RESET" "$C_BOLD" "$C_BRAND" "$C_RESET"
+  if [ -n "$install_dir" ]; then
+    # --dir installs land outside opencode's discovery roots, so the caller
+    # has to point opencode at the file explicitly.
+    info "Run opencode with OPENCODE_CONFIG=$opencode_config_file opencode."
   fi
   exit 0
 fi

--- a/install/npm/README.md
+++ b/install/npm/README.md
@@ -1,12 +1,13 @@
 # @workweave/router
 
-One command, anywhere, to point Claude Code or Codex at the Weave Router.
+One command, anywhere, to point Claude Code, Codex, or opencode at the Weave Router.
 
 ```bash
-npx @workweave/router                       # interactive: pick Claude Code or Codex, then scope
+npx @workweave/router                       # interactive: pick Claude Code / Codex / opencode, then scope
 npx @workweave/router --claude              # skip the picker, target Claude Code
 npx @workweave/router --codex               # skip the picker, target the OpenAI Codex CLI
-npx @workweave/router --scope project       # per-repo install, commit settings.json (or .codex/)
+npx @workweave/router --opencode            # skip the picker, target opencode
+npx @workweave/router --scope project       # per-repo install, commit settings.json (or .codex/ / opencode.json)
 npx @workweave/router --local               # self-hosted via docker-compose (localhost:8080)
 npx @workweave/router --base-url https://router.acme.internal
 npx @workweave/router --non-interactive     # reads $WEAVE_ROUTER_KEY, no prompts (defaults to claude)
@@ -23,6 +24,7 @@ Uninstall:
 ```bash
 npx @workweave/router --uninstall                       # Claude Code, user scope
 npx @workweave/router --uninstall --codex               # Codex, user scope
+npx @workweave/router --uninstall --opencode            # opencode, user scope
 npx @workweave/router --uninstall --scope project       # Claude Code, inside the repo
 npx @workweave/router --uninstall --codex --scope project
 ```
@@ -35,7 +37,7 @@ Node ≥ 18 — no `curl | sh`, no Git clone, no PATH fiddling. Everything the
 shell installer documents (targets, scopes, flags, environment variables)
 works identically here.
 
-Two install targets:
+Three install targets:
 
 - **Claude Code** (default) — patches `~/.claude/settings.json` (or
   `<repo>/.claude/settings.json` with `--scope project`) so `claude` routes
@@ -47,6 +49,13 @@ Two install targets:
   through to api.openai.com. The block lives between begin/end markers so
   re-running the installer rewrites it cleanly and `--uninstall --codex`
   removes it without touching the rest of your config.
+- **opencode** (`--opencode`) — merges a `provider.weave` entry (backed by
+  opencode's built-in `@ai-sdk/anthropic` provider) into
+  `~/.config/opencode/opencode.json` (or `<repo>/opencode.json` with
+  `--scope project`). The router speaks the Anthropic Messages API
+  natively, so opencode talks to it unmodified. Re-install rewrites only
+  the managed `provider.weave` block; `--uninstall --opencode` strips it
+  and leaves your other providers and settings alone.
 
 See the [main installer docs](https://github.com/workweave/router/tree/main/install)
 for the full reference.
@@ -55,8 +64,8 @@ for the full reference.
 
 - Node ≥ 18 (ships with `npx`)
 - `bash` on PATH (macOS / Linux native; Windows needs Git Bash or WSL)
-- `jq` on PATH — used by the Claude Code status line script. Not required
-  for the Codex path.
+- `jq` on PATH — used by the Claude Code status line script and the
+  opencode JSON merge. Not required for the Codex path.
 
 ## Why npx
 

--- a/install/uninstall.sh
+++ b/install/uninstall.sh
@@ -1,16 +1,20 @@
 #!/usr/bin/env bash
 #
-# Weave Router uninstaller for Claude Code and Codex.
+# Weave Router uninstaller for Claude Code, Codex, and opencode.
 #
 # Default target is Claude Code: removes the env vars, statusLine, and local
 # router auth that install.sh added; leaves the rest of settings.json
 # untouched. Pass --codex to strip the managed [model_providers.weave]
 # block (and the matching top-level `model_provider`) from Codex's
-# config.toml — anything outside the markers is preserved.
+# config.toml — anything outside the markers is preserved. Pass --opencode
+# to strip the `provider.weave` block (and the top-level `model` key when
+# it points at the router) from opencode.json; other providers and user
+# settings are preserved.
 #
 # Usage:
 #   npx @workweave/router --uninstall                            # Claude Code, user scope
 #   npx @workweave/router --uninstall --codex                    # Codex, user scope
+#   npx @workweave/router --uninstall --opencode                 # opencode, user scope
 #   npx @workweave/router --uninstall --scope project            # run inside the repo
 #   npx @workweave/router --uninstall --dir /tmp/test            # --dir alone (user scope, .weave/)
 #   npx @workweave/router --uninstall --scope project --dir /tmp # --dir + project scope (.claude/)
@@ -52,10 +56,14 @@ while [ $# -gt 0 ]; do
     --codex)
       target="codex"; shift
       ;;
+    --opencode)
+      target="opencode"; shift
+      ;;
     --claude)
-      # No-op selector for symmetry with --codex and install.sh's --claude.
-      # Lets `./install.sh --uninstall --claude` (which forwards remaining
-      # args here) succeed instead of hitting the unknown-flag catch-all.
+      # No-op selector for symmetry with --codex / --opencode and install.sh's
+      # --claude. Lets `./install.sh --uninstall --claude` (which forwards
+      # remaining args here) succeed instead of hitting the unknown-flag
+      # catch-all.
       target="claude"; shift
       ;;
     -h|--help)
@@ -69,8 +77,8 @@ while [ $# -gt 0 ]; do
   esac
 done
 
-if [ "$target" = "claude" ] && ! command -v jq >/dev/null 2>&1; then
-  err "jq is required for the Claude Code uninstall path."
+if { [ "$target" = "claude" ] || [ "$target" = "opencode" ]; } && ! command -v jq >/dev/null 2>&1; then
+  err "jq is required for the $target uninstall path."
   exit 1
 fi
 
@@ -96,6 +104,82 @@ strip_codex_block() {
   ' "$config_file" >"$tmp"
   mv "$tmp" "$config_file"
 }
+
+# ---------- opencode uninstall path ----------
+
+if [ "$target" = "opencode" ]; then
+  # Resolve opencode_config_file based on scope/dir. Mirrors install.sh so
+  # an `install --opencode --scope project` is exactly reversed by an
+  # `uninstall --opencode --scope project`.
+  if [ -n "$install_dir" ]; then
+    install_dir="$(cd "$install_dir" 2>/dev/null && pwd || echo "$install_dir")"
+    opencode_dir="$install_dir"
+    refuse_if_symlink "$opencode_dir"
+  elif [ "$scope" = "user" ]; then
+    opencode_dir="${XDG_CONFIG_HOME:-$HOME/.config}/opencode"
+  else
+    # Project scope: same prompt + git-root fallback as install.sh.
+    project_dir=""
+    if [ "$scope_explicit" = "false" ] && [ -r /dev/tty ]; then
+      default_project_dir="$(pwd)"
+      printf "Project directory to uninstall from [default: %s]: " "$default_project_dir"
+      read -r project_dir_choice </dev/tty || project_dir_choice=""
+      project_dir="${project_dir_choice:-$default_project_dir}"
+      case "$project_dir" in
+        "~")    project_dir="$HOME" ;;
+        "~/"*)  project_dir="$HOME/${project_dir#~/}" ;;
+      esac
+      if [ ! -d "$project_dir" ]; then
+        err "directory does not exist: $project_dir"
+        exit 1
+      fi
+      project_dir="$(cd "$project_dir" && pwd)"
+    fi
+    if [ -n "${project_dir:-}" ]; then
+      opencode_dir="$project_dir"
+    else
+      if ! git_root="$(git rev-parse --show-toplevel 2>/dev/null)"; then
+        err "--scope project must be run inside a git repo, or use --dir <path>."
+        exit 1
+      fi
+      opencode_dir="$git_root"
+    fi
+    refuse_if_symlink "$opencode_dir"
+  fi
+  opencode_config_file="$opencode_dir/opencode.json"
+  refuse_if_symlink "$opencode_config_file"
+
+  if [ -f "$opencode_config_file" ]; then
+    # Strip `provider.weave` and any router-pointing top-level model. Other
+    # providers, user-set models that don't reference the router, and any
+    # unrelated keys are preserved.
+    cleaned="$(jq '
+      (if .provider.weave then del(.provider.weave) else . end)
+      | (if (.provider // {}) == {} then del(.provider) else . end)
+      | (if (.model // "" | tostring | startswith("weave/")) then del(.model) else . end)
+    ' "$opencode_config_file")"
+    printf '%s\n' "$cleaned" >"$opencode_config_file"
+
+    # If only the $schema marker remains (or the file is empty), drop the
+    # file entirely so we don't leave a one-key artifact.
+    remaining_keys="$(jq -r 'del(."$schema") | keys | length' "$opencode_config_file" 2>/dev/null || echo 0)"
+    if [ "$remaining_keys" = "0" ]; then
+      rm -f "$opencode_config_file"
+      ok "Removed empty $opencode_config_file"
+    else
+      ok "Cleaned $opencode_config_file"
+    fi
+  else
+    info "No opencode config at $opencode_config_file (already uninstalled?)"
+  fi
+
+  if [ -n "$install_dir" ]; then
+    ok "Weave Router uninstalled from $install_dir (opencode)."
+  else
+    ok "Weave Router uninstalled (opencode, scope=$scope)."
+  fi
+  exit 0
+fi
 
 # ---------- codex uninstall path ----------
 


### PR DESCRIPTION
## Summary

Adds opencode (https://opencode.ai) as a third install target alongside Claude Code and Codex. One command — `npx @workweave/router --opencode` — and opencode routes through the Weave Router. No router-side change needed; the router speaks Anthropic Messages natively, so opencode's bundled `@ai-sdk/anthropic` provider talks to it unmodified.

## What's in the diff

- **`install/install.sh`** — new `--opencode` flag, picker entry (option 3), per-target scope path resolution, and a `write_opencode_config()` helper that jq-merges a managed `provider.weave` block into `opencode.json`. Dispatch block parallels the existing `--codex` branch (health ping, key validation, gitignore for project scope, `OPENCODE_CONFIG=` hint for `--dir` installs).
- **`install/uninstall.sh`** — `--opencode` strip path. Structurally removes `provider.weave` and the top-level `model` only when it points at `weave/...`; deletes the file if nothing non-schema remains.
- **READMEs** — root `README.md`, `install/README.md`, and `install/npm/README.md` updated with the new flag, scope paths, and onboarding flow.

## Config layout

| Scope | Path |
|---|---|
| user | `~/.config/opencode/opencode.json` (honors `$XDG_CONFIG_HOME`) |
| project | `<repo>/opencode.json` (gitignored, per-teammate key) |
| `--dir <d>` | `<d>/opencode.json` (caller sets `OPENCODE_CONFIG`) |

Managed block:

```json
"provider": {
  "weave": {
    "npm": "@ai-sdk/anthropic",
    "name": "Weave Router",
    "options": {
      "baseURL": "https://router.workweave.ai/v1",
      "headers": {
        "X-Weave-Router-Key": "rk_...",
        "X-App": "opencode",
        "X-Weave-User-Email": "...",
        "X-Weave-User-Name": "..."
      }
    },
    "models": { "claude-opus-4-7": {...}, "claude-sonnet-4-6": {...}, "claude-haiku-4-5": {...} }
  }
}
```

Top-level `model` is set to `weave/claude-sonnet-4-6` only when the user hasn't already chosen one. Other providers, MCP servers, agents, and unrelated keys are preserved across re-install / uninstall.

## Test plan

- [x] `bash -n install/install.sh` and `bash -n install/uninstall.sh` clean
- [x] Fresh install (`--opencode --dir <tmp> --non-interactive`) — file 0600, well-formed, identity headers landed
- [x] Idempotent re-install over an `opencode.json` that already has a user-chosen `model` and an unrelated `provider.openai` — both preserved, `weave` merged alongside
- [x] Full roundtrip: install → uninstall preserves user data
- [x] Uninstall on a clean-install file deletes it (no zero-key artifact)
- [ ] Live test with the `opencode` CLI installed (smoke tests ran without `opencode` on PATH; CLI presence is a warning, not a hard fail)

## Follow-ups (not in this PR)

- WorkWeave-side gitlink bump + `syncrouterinstall/install_template.sh` mirror sync once this merges
- Bump `@workweave/router` npm package version after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)