### PR TITLE
fix(router): statusline token dedup, translator id fallback, context-fit filter for flash models

### DIFF
--- a/install/cc-statusline.sh
+++ b/install/cc-statusline.sh
@@ -282,9 +282,24 @@ if [[ -n "$transcript_path" && -f "$transcript_path" ]]; then
   # The marker regex tolerates the optional "(<provider>)" segment and a
   # `[1m]` / `-YYYYMMDD` suffix on either model name so transcripts written
   # against context-tiered or dated model ids still parse cleanly.
+  #
+  # Dedup note: CC writes one JSONL entry per *content block* in an
+  # assistant turn (text, text, tool_use → 3 entries), and every entry
+  # carries the same `message.usage`. Summing per-entry triple-counts the
+  # turn. We dedupe on (message.id, message.usage) before summing:
+  #   * For native Anthropic upstreams message.id is unique per turn, so
+  #     this collapses the content-block fan-out cleanly.
+  #   * For non-Anthropic upstreams that round-trip through the router's
+  #     translator, message.id can be a constant placeholder
+  #     ("msg_translated"); usage still differs per turn (input_tokens
+  #     grows), so the composite key keeps turns distinct. Two turns with
+  #     byte-identical id AND usage would still collapse, but that's a
+  #     genuine retry/duplicate we want to drop.
   read -r session_savings tot_in tot_out tot_cache_read tot_cache_write < <(
-    jq -r --argjson p "$prices" --arg requested "$requested_norm" '
-      select(.type=="assistant") |
+    jq -rs --argjson p "$prices" --arg requested "$requested_norm" '
+      [.[] | select(.type=="assistant")] |
+      unique_by([.message.id, .message.usage]) |
+      .[] |
       .message as $m |
       ($m.model // "" | sub("\\[[^]]*\\]$"; "") | sub("-[0-9]{8}$"; "")) as $rm |
       {

--- a/internal/translate/stream.go
+++ b/internal/translate/stream.go
@@ -546,10 +546,17 @@ func (t *AnthropicSSETranslator) translateOpenAIEvent(raw []byte) error {
 
 	// strings.Clone: gjson returns strings backed by the buffer via unsafe;
 	// these fields outlive the event, so copy to survive buffer compaction.
-	if id := gjson.GetBytes(data, "id"); id.Exists() && t.messageID == "" {
+	//
+	// Check Str != "" rather than Exists(): some OpenAI-compat upstreams
+	// (notably OpenRouter for certain models) send chunks with `"id": ""`
+	// in early SSE frames before settling on a real id. gjson treats that
+	// as Exists()=true, Str="", which would latch the empty string and
+	// prevent later non-empty ids from overwriting — leaving message_start
+	// to fall back to the "msg_translated" placeholder. Same for model.
+	if id := gjson.GetBytes(data, "id"); id.Str != "" && t.messageID == "" {
 		t.messageID = strings.Clone(id.Str)
 	}
-	if m := gjson.GetBytes(data, "model"); m.Exists() && t.modelFromUpstream == "" {
+	if m := gjson.GetBytes(data, "model"); m.Str != "" && t.modelFromUpstream == "" {
 		t.modelFromUpstream = strings.Clone(m.Str)
 	}
 


### PR DESCRIPTION
## Summary

Two unrelated correctness fixes surfaced from a session where the statusline showed `saved $5.84 · 387.2k in / 674 out` for a session whose actual totals were `$2.94 · 194.8k in / 327 out`.

### `install/cc-statusline.sh` — token/savings inflation

Claude Code writes **one JSONL entry per *content block*** of an assistant turn (e.g. `text` + `text` + `tool_use` → 3 entries). Every entry carries the same `message.usage` payload. The existing `jq` filter ran `select(.type=="assistant")` and summed per entry, double- or triple-counting every multi-block turn — observed ~2× inflation in a real qwen session, can hit 3× for turns with two text blocks before a tool call.

Dedupe on `(message.id, message.usage)` before summing:

- Native Anthropic upstreams: `message.id` is unique per turn → collapses content-block fan-out cleanly.
- Translator round-trips: `message.id` can be a constant placeholder (`msg_translated`); `usage` still differs per turn (input_tokens grows), so the composite key keeps real turns distinct. Two turns with byte-identical id AND usage would still collapse — that's a genuine retry/duplicate we want to drop.

Verified: same transcript that produced `387.2k in / saved $5.84` now produces `194.8k in / saved $2.94`, matching independent jq dedup math within $0.005.

### `internal/translate/stream.go` — empty-string `id` latched

`if id := gjson.GetBytes(data, "id"); id.Exists() && t.messageID == ""` latches the first `id` field present in the SSE stream. Some OpenAI-compat upstreams (observed: OpenRouter for certain models) send early chunks with `"id": ""` before settling on a real id. `gjson` reports `Exists()=true, Str=""` for that, so the empty string was being latched — never overwritten — and `emitMessageStart` fell back to the `"msg_translated"` placeholder, breaking any downstream that dedupes by message id.

Switched the gate to `Str != ""` (same for `model`). Strictly tightens behavior: only latches non-empty strings.

## Test plan

- [x] Manually replayed a real transcript through the patched `cc-statusline.sh` and verified output matches hand-computed dedup'd totals.
- [ ] Confirm `internal/translate` unit tests still pass (none currently exercise the empty-`id` chunk case — could add one in a follow-up).
- [ ] Once merged, bump the gitlink in the workweave repo + copy `install/cc-statusline.sh` into `syncrouterinstall/install_template.sh` so the heredoc-embedded copy stays in lockstep.