### PR TITLE
fix(installer): apply statusline dedup fix to inlined heredoc in install.sh

### DIFF
--- a/install/install.sh
+++ b/install/install.sh
@@ -1431,9 +1431,24 @@ if [[ -n "$transcript_path" && -f "$transcript_path" ]]; then
   # The marker regex tolerates the optional "(<provider>)" segment and a
   # `[1m]` / `-YYYYMMDD` suffix on either model name so transcripts written
   # against context-tiered or dated model ids still parse cleanly.
+  #
+  # Dedup note: CC writes one JSONL entry per *content block* in an
+  # assistant turn (text, text, tool_use → 3 entries), and every entry
+  # carries the same `message.usage`. Summing per-entry triple-counts the
+  # turn. We dedupe on (message.id, message.usage) before summing:
+  #   * For native Anthropic upstreams message.id is unique per turn, so
+  #     this collapses the content-block fan-out cleanly.
+  #   * For non-Anthropic upstreams that round-trip through the router's
+  #     translator, message.id can be a constant placeholder
+  #     ("msg_translated"); usage still differs per turn (input_tokens
+  #     grows), so the composite key keeps turns distinct. Two turns with
+  #     byte-identical id AND usage would still collapse, but that's a
+  #     genuine retry/duplicate we want to drop.
   read -r session_savings tot_in tot_out tot_cache_read tot_cache_write < <(
-    jq -r --argjson p "$prices" --arg requested "$requested_norm" '
-      select(.type=="assistant") |
+    jq -rs --argjson p "$prices" --arg requested "$requested_norm" '
+      [.[] | select(.type=="assistant")] |
+      unique_by([.message.id, .message.usage]) |
+      .[] |
       .message as $m |
       ($m.model // "" | sub("\\[[^]]*\\]$"; "") | sub("-[0-9]{8}$"; "")) as $rm |
       {

--- a/install/npm/package.json
+++ b/install/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@workweave/router",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "One-command installer that points Claude Code at the Weave Router.",
   "bin": {
     "weave-router": "bin.js"


### PR DESCRIPTION
## Summary

PR #225 fixed `install/cc-statusline.sh` to use `jq -rs` slurp mode + `unique_by([.message.id, .message.usage])` so per-content-block JSONL entries don't triple-count tokens and savings.

The inlined heredoc copy inside `install/install.sh` (lines ~1434-1463) — which fresh installs via `make full-setup` or `curl | sh` write to disk as the statusline script — wasn't updated, so new installs continued to ship the stale un-deduped jq and kept double/triple-counting tokens and savings.

This applies the same fix to the heredoc.

## Test plan

- [ ] Diff `install/install.sh` heredoc body against `install/cc-statusline.sh` — should be byte-equivalent for the jq block
- [ ] Run a fresh `make full-setup` and confirm the generated `~/.claude/statusline.sh` contains `jq -rs` + `unique_by` (not bare `jq -r` + `select`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)