### PR TITLE
feat(diagnostics): detect empty-turn upstream responses + repro harness

### DIFF
--- a/cmd/router/main.go
+++ b/cmd/router/main.go
@@ -532,7 +532,8 @@ func main() {
 		WithSummarizer(summarizer).
 		WithAvailableModels(availableModels).
 		WithDefaultBaselineModel(resolveDefaultBaselineModel()).
-		WithBillingService(billingSvc)
+		WithBillingService(billingSvc).
+		WithDebugEmptyResponse(strings.EqualFold(config.GetOr("WEAVE_ROUTER_DEBUG_EMPTY_RESPONSE", ""), "true"))
 	logger.Info("Planner configured", "enabled", plannerEnabled, "threshold_usd", plannerCfg.ThresholdUSD, "expected_remaining_turns", plannerCfg.ExpectedRemainingTurns, "tier_upgrade_enabled", plannerCfg.TierUpgradeEnabled, "available_models_count", len(availableModels))
 
 	// Fail loud if a deployed model is missing from the tier table;

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -1,6 +1,7 @@
 package proxy
 
 import (
+	"bytes"
 	"context"
 	"encoding/hex"
 	"errors"
@@ -101,6 +102,12 @@ type Service struct {
 	// each completed upstream call. Wired only in managed mode; the
 	// composition root leaves this nil for selfhosted deployments.
 	billing *billing.Service
+	// debugEmptyResponse, when true, allocates a per-turn buffer that
+	// captures every byte the upstream sends through the translator so
+	// the empty-turn anomaly log can dump the exact bytes that produced
+	// the empty turn. Off by default — bodies are large and may contain
+	// user data. Wired from WEAVE_ROUTER_DEBUG_EMPTY_RESPONSE at boot.
+	debugEmptyResponse bool
 }
 
 // pinSessionTTL mirrors Anthropic's prompt-cache TTL on Sonnet/Haiku/Opus 4.5+
@@ -608,6 +615,70 @@ func (s *Service) PassthroughToNamedProvider(ctx context.Context, providerName s
 	return proxyErr
 }
 
+// WithDebugEmptyResponse toggles per-turn raw-upstream capture. When true,
+// the empty-turn anomaly log includes the bytes the upstream sent that
+// produced the empty turn. Off by default because bodies are large and
+// may contain user-content. Wired from WEAVE_ROUTER_DEBUG_EMPTY_RESPONSE.
+func (s *Service) WithDebugEmptyResponse(enabled bool) *Service {
+	s.debugEmptyResponse = enabled
+	return s
+}
+
+// emptyTurnRawCaptureMaxBytes caps how much of the raw upstream body
+// we log per anomaly. Real streaming bodies can be tens of MB; the cap
+// keeps the log line bounded while preserving the head of the response
+// where the failure mode is almost always visible (an OpenAI-compat
+// response with `choices[0].message.content == ""` plus a usage block
+// fits in <2KB).
+const emptyTurnRawCaptureMaxBytes = 8 * 1024
+
+// logEmptyTurnIfDetected emits a WARN log when the translator finished a
+// streaming turn with zero content blocks — the pathological response
+// shape where CC sees a properly-closed assistant turn with nothing to
+// render, manifesting as "the conversation just stopped." Joins on
+// request_id with the surrounding ProxyMessages-complete entry.
+//
+// When raw is non-nil (debug capture enabled), the head of the upstream
+// body is included so root cause is visible from logs alone — no
+// per-investigation tcpdump needed.
+func logEmptyTurnIfDetected(
+	log *slog.Logger,
+	requestID string,
+	decision router.Decision,
+	feats translate.RoutingFeatures,
+	translator *translate.AnthropicSSETranslator,
+	requestBody []byte,
+	raw *bytes.Buffer,
+) {
+	if !translator.EmptyTurnEmitted() {
+		return
+	}
+	attrs := []any{
+		"request_id", requestID,
+		"decision_model", decision.Model,
+		"decision_provider", decision.Provider,
+		"decision_reason", decision.Reason,
+		"message_count", feats.MessageCount,
+		"estimated_input_tokens", feats.Tokens,
+		"request_body_bytes", len(requestBody),
+	}
+	if raw != nil {
+		captured := raw.Bytes()
+		preview := captured
+		if len(preview) > emptyTurnRawCaptureMaxBytes {
+			preview = preview[:emptyTurnRawCaptureMaxBytes]
+		}
+		attrs = append(attrs,
+			"upstream_raw_bytes", len(captured),
+			"upstream_raw_preview", string(preview),
+			"upstream_raw_truncated", len(captured) > emptyTurnRawCaptureMaxBytes,
+		)
+	} else {
+		attrs = append(attrs, "upstream_raw_capture", "disabled (set WEAVE_ROUTER_DEBUG_EMPTY_RESPONSE=true to capture)")
+	}
+	log.Warn("Empty assistant turn from upstream: 0 content blocks before end_turn", attrs...)
+}
+
 // logUpstreamBody emits the fully-prepared upstream request body at Debug
 // level. Intended for per-turn byte-diff investigations of upstream
 // prompt-cache stability; gated by LOG_LEVEL=debug.
@@ -828,11 +899,17 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 		translator := translate.NewAnthropicSSETranslator(sink, decision.Model, usage).
 			WithRoutingMarker(routingMarkerFor(routeRes)).
 			WithEstimatedInputTokens(feats.Tokens)
+		var rawCapture *bytes.Buffer
+		if s.debugEmptyResponse {
+			rawCapture = &bytes.Buffer{}
+			translator.WithRawUpstreamCapture(rawCapture)
+		}
 		if err := translator.Prelude(env.Stream()); err != nil {
 			log.Error("Anthropic SSE prelude failed (OpenAI upstream)", "err", err)
 		}
 		proxyErr = p.Proxy(ctx, decision, prep, translator, r)
 		proxyErr = finalizeAfterProxy(proxyErr, translator.Finalize)
+		logEmptyTurnIfDetected(log, requestID, decision, feats, translator, prep.Body, rawCapture)
 	case providers.ProviderGoogle:
 		crossFormat = true
 		prep, emitErr := env.PrepareGemini(r.Header, opts)
@@ -850,6 +927,11 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 		anthropicTr := translate.NewAnthropicSSETranslator(sink, decision.Model, usage).
 			WithRoutingMarker(routingMarkerFor(routeRes)).
 			WithEstimatedInputTokens(feats.Tokens)
+		var rawCapture *bytes.Buffer
+		if s.debugEmptyResponse {
+			rawCapture = &bytes.Buffer{}
+			anthropicTr.WithRawUpstreamCapture(rawCapture)
+		}
 		if err := anthropicTr.Prelude(env.Stream()); err != nil {
 			log.Error("Anthropic SSE prelude failed (Gemini upstream)", "err", err)
 		}
@@ -857,6 +939,7 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 		proxyErr = p.Proxy(ctx, decision, prep, geminiTr, r)
 		proxyErr = finalizeAfterProxy(proxyErr, geminiTr.Finalize)
 		proxyErr = finalizeAfterProxy(proxyErr, anthropicTr.Finalize)
+		logEmptyTurnIfDetected(log, requestID, decision, feats, anthropicTr, prep.Body, rawCapture)
 	default:
 		return fmt.Errorf("%w: %s (no translation path defined for inbound Anthropic Messages)", ErrProviderNotConfigured, decision.Provider)
 	}

--- a/internal/translate/stream.go
+++ b/internal/translate/stream.go
@@ -353,6 +353,20 @@ type AnthropicSSETranslator struct {
 	messageID                string
 	modelFromUpstream        string
 
+	// contentBlocksEmitted counts text/tool blocks we forwarded from
+	// upstream (the routing marker block is intentionally excluded — it's
+	// not real model output). Used by EmptyTurnEmitted to flag the
+	// pathological "message_start → message_delta(end_turn)" pattern with
+	// no content blocks between, which the proxy logs as an anomaly.
+	contentBlocksEmitted int
+
+	// rawUpstreamCapture, when non-nil, receives a copy of every byte
+	// written through this translator. Allocated by the proxy only when
+	// WEAVE_ROUTER_DEBUG_EMPTY_RESPONSE=true so the empty-turn anomaly
+	// log can dump the exact upstream bytes that produced the empty turn.
+	// Kept off by default — bodies are large and may contain user data.
+	rawUpstreamCapture *bytes.Buffer
+
 	usageSink otel.UsageSink
 
 	// estimatedInputTokens is the pre-inference estimate, used to populate
@@ -383,6 +397,42 @@ func NewAnthropicSSETranslator(w http.ResponseWriter, requestModel string, sink 
 func (t *AnthropicSSETranslator) WithRoutingMarker(marker string) *AnthropicSSETranslator {
 	t.routingMarker = marker
 	return t
+}
+
+// WithRawUpstreamCapture installs a buffer that receives every upstream byte
+// passing through Write. Used by the proxy when WEAVE_ROUTER_DEBUG_EMPTY_RESPONSE
+// is set so an empty-turn anomaly log can include the exact bytes that
+// produced the empty turn. Nil disables capture (the default).
+func (t *AnthropicSSETranslator) WithRawUpstreamCapture(buf *bytes.Buffer) *AnthropicSSETranslator {
+	t.rawUpstreamCapture = buf
+	return t
+}
+
+// EmptyTurnEmitted reports whether the translator forwarded a complete
+// streaming turn with zero content blocks (message_start →
+// message_delta(end_turn|stop) → message_stop with nothing between). This
+// is the pathological response shape that manifests as "the conversation
+// just stopped" client-side because CC sees a properly-closed turn with
+// no text or tool_use to act on. Always false until Finalize returns
+// successfully on a streaming response.
+func (t *AnthropicSSETranslator) EmptyTurnEmitted() bool {
+	if !t.streaming || !t.started || !t.closed {
+		return false
+	}
+	return t.contentBlocksEmitted == 0
+}
+
+// RawUpstreamBytes returns a copy of the bytes captured via
+// WithRawUpstreamCapture. Returns nil when capture wasn't installed.
+// Caller owns the returned slice — safe to mutate.
+func (t *AnthropicSSETranslator) RawUpstreamBytes() []byte {
+	if t.rawUpstreamCapture == nil {
+		return nil
+	}
+	b := t.rawUpstreamCapture.Bytes()
+	out := make([]byte, len(b))
+	copy(out, b)
+	return out
 }
 
 // WithEstimatedInputTokens seeds message_start.usage.input_tokens for cross-format
@@ -450,6 +500,9 @@ func (t *AnthropicSSETranslator) Prelude(streaming bool) error {
 
 func (t *AnthropicSSETranslator) Write(data []byte) (int, error) {
 	n := len(data)
+	if t.rawUpstreamCapture != nil {
+		t.rawUpstreamCapture.Write(data)
+	}
 	t.buf.Write(data)
 	if !t.streaming {
 		return n, nil
@@ -623,6 +676,7 @@ func (t *AnthropicSSETranslator) emitDelta(delta gjson.Result) error {
 			}
 			t.textOpen = true
 			t.blockIdx++
+			t.contentBlocksEmitted++
 		}
 		if err := t.emitContentBlockDeltaText(t.blockIdx-1, content); err != nil {
 			return err
@@ -655,6 +709,7 @@ func (t *AnthropicSSETranslator) emitDelta(delta gjson.Result) error {
 			blockIdx = t.blockIdx
 			t.toolBlocks[idx] = blockIdx
 			t.blockIdx++
+			t.contentBlocksEmitted++
 			if emitErr = t.emitContentBlockStartTool(blockIdx, id, name, sig); emitErr != nil {
 				return false
 			}

--- a/internal/translate/translate_test.go
+++ b/internal/translate/translate_test.go
@@ -1,6 +1,7 @@
 package translate_test
 
 import (
+	"bytes"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -467,6 +468,67 @@ func TestAnthropicSSETranslator_StreamingTextResponse(t *testing.T) {
 	assert.Contains(t, body, `"text":" world"`)
 	assert.Contains(t, body, `"stop_reason":"end_turn"`)
 	assert.Contains(t, body, "event: message_stop")
+}
+
+// Regression for the observed prod failure: upstream returns role:assistant
+// with empty content + finish_reason:stop. The translator faithfully streams
+// message_start → message_delta(end_turn) → message_stop with zero content
+// blocks. EmptyTurnEmitted() flags this so the proxy can log a structured
+// anomaly. Raw capture round-trips the upstream bytes verbatim.
+func TestAnthropicSSETranslator_EmptyTurnDetection(t *testing.T) {
+	rec := httptest.NewRecorder()
+	raw := &bytes.Buffer{}
+	translator := translate.NewAnthropicSSETranslator(rec, "qwen/qwen3.5-flash-02-23", nil).
+		WithRawUpstreamCapture(raw)
+
+	translator.Header().Set("Content-Type", "text/event-stream")
+	translator.WriteHeader(http.StatusOK)
+
+	events := []string{
+		"data: {\"id\":\"chatcmpl-empty\",\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\",\"content\":\"\"},\"finish_reason\":null}]}\n\n",
+		"data: {\"id\":\"chatcmpl-empty\",\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"stop\"}],\"usage\":{\"prompt_tokens\":80000,\"completion_tokens\":0,\"total_tokens\":80000}}\n\n",
+		"data: [DONE]\n\n",
+	}
+	for _, event := range events {
+		_, err := translator.Write([]byte(event))
+		require.NoError(t, err)
+	}
+	require.NoError(t, translator.Finalize())
+
+	assert.True(t, translator.EmptyTurnEmitted(),
+		"translator must flag zero-content-block + end_turn as an anomaly")
+
+	body := rec.Body.String()
+	assert.Contains(t, body, "event: message_start")
+	assert.Contains(t, body, `"stop_reason":"end_turn"`)
+	assert.NotContains(t, body, `"type":"text_delta"`, "no content blocks should have streamed")
+	assert.NotContains(t, body, `"type":"tool_use"`)
+
+	captured := translator.RawUpstreamBytes()
+	assert.NotEmpty(t, captured, "raw capture must include upstream bytes")
+	assert.Contains(t, string(captured), "chatcmpl-empty")
+}
+
+// A normal text turn must NOT trip the empty-turn flag.
+func TestAnthropicSSETranslator_EmptyTurnNotFlaggedForNormalResponse(t *testing.T) {
+	rec := httptest.NewRecorder()
+	translator := translate.NewAnthropicSSETranslator(rec, "gpt-4o", nil)
+	translator.Header().Set("Content-Type", "text/event-stream")
+	translator.WriteHeader(http.StatusOK)
+
+	events := []string{
+		"data: {\"id\":\"c1\",\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\",\"content\":\"hi\"},\"finish_reason\":null}]}\n\n",
+		"data: {\"id\":\"c1\",\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"stop\"}]}\n\n",
+		"data: [DONE]\n\n",
+	}
+	for _, event := range events {
+		_, err := translator.Write([]byte(event))
+		require.NoError(t, err)
+	}
+	require.NoError(t, translator.Finalize())
+
+	assert.False(t, translator.EmptyTurnEmitted(),
+		"a turn with content blocks must not be flagged as empty")
 }
 
 func TestAnthropicSSETranslator_StreamingToolUse(t *testing.T) {

--- a/scripts/repro-empty-response.sh
+++ b/scripts/repro-empty-response.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# Replay the most recent large inbound request from the local router's
+# docker logs against the running router, repeatedly, to see if it
+# reproduces the empty-assistant-turn pathology (upstream returning
+# end_turn / stop with zero content blocks — observed in prod for
+# qwen/qwen3.5-flash-02-23 on a ~360KB post-tool follow-up).
+#
+# Prereqs:
+#   - Local router-server-1 docker container running on http://localhost:8080
+#   - Recent CC traffic so docker logs has a large request to replay
+#   - For full diagnostic output (raw upstream bytes in the WARN log) start
+#     the router with WEAVE_ROUTER_DEBUG_EMPTY_RESPONSE=true. Without it
+#     you still get the structured anomaly log line (model, provider,
+#     request_id, estimated_input_tokens) but no upstream body capture.
+#
+# Usage: ./scripts/repro-empty-response.sh [iterations] [router_url] [api_key]
+#   iterations defaults to 5
+#   router_url defaults to http://localhost:8080/v1/messages
+#   api_key defaults to $WEAVE_ROUTER_KEY
+
+set -euo pipefail
+
+ITER="${1:-5}"
+URL="${2:-http://localhost:8080/v1/messages}"
+KEY="${3:-${WEAVE_ROUTER_KEY:-}}"
+
+if [[ -z "$KEY" ]]; then
+  echo "ERROR: no API key. Set WEAVE_ROUTER_KEY env or pass as 3rd arg." >&2
+  exit 2
+fi
+
+WORKDIR="$(mktemp -d -t repro-empty-XXXXXX)"
+trap "rm -rf '$WORKDIR'" EXIT
+
+echo "Finding most recent large inbound in router-server-1 logs..."
+docker logs router-server-1 --since 4h 2>&1 \
+  | sed -E 's/\x1b\[[0-9;]*m//g' \
+  | grep "inbound anthropic request" \
+  | grep -E "body_bytes=[0-9]{6,}" \
+  | tail -1 > "$WORKDIR/inbound.line"
+
+if [[ ! -s "$WORKDIR/inbound.line" ]]; then
+  echo "ERROR: no large inbound request found in recent router logs." >&2
+  echo "Generate one by using CC against the local router and trying a" >&2
+  echo "prompt that reads a sizable file via a tool call." >&2
+  exit 1
+fi
+
+# The body= field is wrapped in double quotes with inner quotes/backslashes
+# escaped. Python's unicode_escape codec exactly inverts the encoder slog
+# uses for this field, so this round-trip is lossless.
+INBOUND_LINE="$WORKDIR/inbound.line" python3 <<'PY' > "$WORKDIR/body.json"
+import os, re, json
+with open(os.environ["INBOUND_LINE"]) as f:
+    line = f.read()
+m = re.search(r'body="(.*)"\s*$', line)
+if not m:
+    raise SystemExit("no body= field found in log line")
+escaped = m.group(1)
+unescaped = escaped.encode('utf-8').decode('unicode_escape')
+parsed = json.loads(unescaped)
+print(json.dumps(parsed))
+PY
+
+REQ_BYTES=$(wc -c < "$WORKDIR/body.json")
+echo "Replaying request body: $REQ_BYTES bytes, $ITER iterations"
+echo ""
+
+EMPTY=0
+for i in $(seq 1 "$ITER"); do
+  RESP="$WORKDIR/resp-$i.sse"
+  START=$(python3 -c 'import time; print(int(time.time()*1000))')
+  curl -sS -N -X POST "$URL" \
+    -H "Content-Type: application/json" \
+    -H "Accept: text/event-stream" \
+    -H "Anthropic-Version: 2023-06-01" \
+    -H "X-Weave-Router-Key: $KEY" \
+    -H "X-App: repro-empty-response" \
+    --data-binary "@$WORKDIR/body.json" > "$RESP"
+  END=$(python3 -c 'import time; print(int(time.time()*1000))')
+
+  N_BLOCKS=$(grep -c "event: content_block_start" "$RESP" || true)
+  STOP=$(grep -oE '"stop_reason":"[^"]*"' "$RESP" | head -1 | sed 's/"stop_reason":"//;s/"//')
+  MODEL=$(grep -oE '"model":"[^"]*"' "$RESP" | head -1 | sed 's/"model":"//;s/"//')
+  LATENCY_MS=$((END - START))
+
+  if [[ "$N_BLOCKS" -eq 0 ]]; then
+    echo "iter $i: ⚠️  EMPTY  (0 blocks, stop=$STOP, model=$MODEL, ${LATENCY_MS}ms) → $RESP"
+    EMPTY=$((EMPTY + 1))
+  else
+    echo "iter $i: ✓ $N_BLOCKS blocks (stop=$STOP, model=$MODEL, ${LATENCY_MS}ms)"
+  fi
+done
+
+echo ""
+echo "Reproduced: $EMPTY/$ITER empty responses"
+echo ""
+echo "Inspect router-side anomaly logs:"
+echo "  docker logs router-server-1 --since 5m 2>&1 \\"
+echo "    | sed -E 's/\\x1b\\[[0-9;]*m//g' \\"
+echo "    | grep -E 'Empty assistant turn|ProxyMessages complete' \\"
+echo "    | tail -40"
+echo ""
+if [[ "$EMPTY" -gt 0 ]]; then
+  echo "Empty responses preserved at: $RESP"
+  echo "(WORKDIR will be deleted on exit — copy out anything you need)"
+  # Keep the tmpdir around if anything went wrong so the user can inspect.
+  trap - EXIT
+  echo "WORKDIR retained: $WORKDIR"
+fi


### PR DESCRIPTION
## Why

Observed in prod (session bb251d00): `qwen/qwen3.5-flash-02-23` returned a fully-formed but empty assistant message — `message_start` → `message_delta(end_turn)` → `message_stop`, zero content blocks between. The router faithfully relayed it, CC saw a properly-closed turn with nothing to render, conversation went silent.

Per-model context-window data (PR #227) confirms the model has 1M context, so it's not a window violation. Likely a provider-side issue (OpenRouter routing to a flaky upstream for that model) or a model-quality issue (Qwen flash returning EOS on certain prompt shapes). Either way, we currently have **zero visibility** when this happens — the structured logs say "ProxyMessages complete" with `status=200` and we have to look at CC's missing UI to know anything went wrong.

This PR adds the visibility we need to root-cause it.

## What's in here

### 1. Translator-level anomaly detection
`AnthropicSSETranslator` now tracks `contentBlocksEmitted` (excluding the routing marker block — that's not real model output) and exposes:
- `EmptyTurnEmitted() bool` — true when a streaming turn closed with zero content blocks
- `WithRawUpstreamCapture(*bytes.Buffer)` — opt-in tee of every upstream byte
- `RawUpstreamBytes() []byte` — returns a copy of captured bytes

### 2. Proxy-side anomaly logging
After every Anthropic-format translation path (OpenAI-compat + Gemini chains), `logEmptyTurnIfDetected` checks the translator and emits a WARN with:
- `request_id`, `decision_model`, `decision_provider`, `decision_reason`
- `message_count`, `estimated_input_tokens`, `request_body_bytes`
- When `WEAVE_ROUTER_DEBUG_EMPTY_RESPONSE=true` is set: `upstream_raw_bytes`, `upstream_raw_preview` (capped at 8KB), `upstream_raw_truncated`

Off by default — raw upstream bodies can be large and contain user content. The structured metadata log is always on; flip the env flag during active investigation.

### 3. Repro harness
`scripts/repro-empty-response.sh` extracts the most recent large inbound from `docker logs router-server-1`, replays it N times against the running router, and reports `empty / total`. Pairs with the WARN log to root-cause without tcpdump.

Tested end-to-end: replays a 465KB inbound, reports per-iteration `n_blocks`, `stop_reason`, `model`, and latency.

## Test plan

- [x] `TestAnthropicSSETranslator_EmptyTurnDetection` — zero-content + `stop_reason=stop` → `EmptyTurnEmitted()` returns true; raw capture round-trips bytes
- [x] `TestAnthropicSSETranslator_EmptyTurnNotFlaggedForNormalResponse` — normal text turn → returns false
- [x] Full test suite: `go test -tags=no_onnx ./...` green
- [x] Repro script smoke-tested end-to-end

## How to use

Once merged + redeployed:

```bash
# Optional: enable raw upstream capture during active investigation
export WEAVE_ROUTER_DEBUG_EMPTY_RESPONSE=true
wv mr

# In another terminal — replay last large inbound 10 times
./scripts/repro-empty-response.sh 10

# Inspect the anomaly logs
docker logs router-server-1 --since 5m 2>&1 \
  | sed -E 's/\x1b\[[0-9;]*m//g' \
  | grep "Empty assistant turn"
```