### PR TITLE
fix(routing): break runaway tool-call auto-continue loop

### DIFF
--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -107,6 +107,14 @@ type Service struct {
 // so the pin lifecycle tracks the cache it's keeping warm.
 const pinSessionTTL = time.Hour
 
+// prevTurnMaxedOutThreshold is the LastOutputTokens count above which we treat
+// the previous turn as having saturated the output cap. Set just under the
+// 8192 defaultMaxOutputTokenCap; legitimate end_turn completions almost never
+// approach this on tool-calling turns, while OSS-model parse-failure runaways
+// land exactly at the cap. Used by runTurnLoop to break the auto-continue
+// loop by excluding the pinned model for the next turn.
+const prevTurnMaxedOutThreshold = 8000
+
 // APIKeyIDContextKey is the request-context key for the authenticated api_key_id.
 type APIKeyIDContextKey struct{}
 

--- a/internal/proxy/turnloop.go
+++ b/internal/proxy/turnloop.go
@@ -209,6 +209,31 @@ func (s *Service) runTurnLoop(
 		pin = sessionpin.Pin{}
 	}
 
+	// Previous-turn-maxed-out guard: when an OSS model's tool-call tokens fail
+	// to parse server-side (kimi <|tool_call_begin|>, qwen3 <tool_call> XML)
+	// the upstream emits them as content and generates to the output cap.
+	// Claude Code's "Output token limit hit. Resume directly…" auto-continue
+	// then re-pins the same broken model, producing a multi-minute loop. When
+	// the previous turn saturated the output cap, exclude the pinned model for
+	// this turn and treat the pin as missing so downstream sticky branches
+	// (ToolResult, !plannerEnabled) cannot re-anchor it before the scorer runs.
+	if pinFound && pin.LastOutputTokens >= prevTurnMaxedOutThreshold {
+		log.Info("Session pin maxed out on previous turn; excluding for this turn",
+			"pin_model", pin.Model,
+			"pin_provider", pin.Provider,
+			"last_output_tokens", pin.LastOutputTokens,
+		)
+		// Defensive copy: callers may share the ExcludedModels map across requests.
+		excluded := make(map[string]struct{}, len(req.ExcludedModels)+1)
+		for k := range req.ExcludedModels {
+			excluded[k] = struct{}{}
+		}
+		excluded[pin.Model] = struct{}{}
+		req.ExcludedModels = excluded
+		pinFound = false
+		pin = sessionpin.Pin{}
+	}
+
 	// Tool-result turns are mid-turn continuations. Re-routing them on
 	// trailing tool_result embedding flips decisions to noisy candidates;
 	// reuse the pin verbatim when present and refresh the TTL.

--- a/internal/proxy/turnloop_test.go
+++ b/internal/proxy/turnloop_test.go
@@ -350,6 +350,67 @@ func TestTurnLoop_UsageWritebackPersistsCacheStats(t *testing.T) {
 	assert.Equal(t, 200, got.CachedWriteTokens)
 }
 
+// TestTurnLoop_MaxedOutPinExcludedFromCandidates locks in the
+// runaway-tool-call escape hatch: when the previous turn saturated the
+// output cap (a hallmark of OSS-model parse-failure runaways), the pinned
+// model is excluded from the candidate set and the pin is treated as
+// missing so sticky branches cannot re-anchor it before the scorer runs.
+// Without this, Claude Code's "Output token limit hit. Resume directly…"
+// auto-continue locks the session into the broken model for minutes.
+func TestTurnLoop_MaxedOutPinExcludedFromCandidates(t *testing.T) {
+	store := newFakePinStore()
+	store.hasPin = true
+	store.pin = sessionpin.Pin{
+		Provider:         providers.ProviderOpenRouter,
+		Model:            "moonshotai/kimi-k2.6",
+		Reason:           "cluster:v0.52",
+		PinnedUntil:      time.Now().Add(time.Hour),
+		LastOutputTokens: 8192, // saturated previous turn
+		LastTurnEndedAt:  time.Now().Add(-10 * time.Second),
+	}
+	fr := &fakeRouter{decision: router.Decision{Provider: providers.ProviderAnthropic, Model: "claude-haiku-4-5", Reason: "fresh"}}
+	svc := newPinSvc(fr, store)
+
+	ctx := authedCtx(uuid.New().String())
+	rec := httptest.NewRecorder()
+	httpReq := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(""))
+	require.NoError(t, svc.ProxyMessages(ctx, []byte(pinTestBody), rec, httpReq))
+
+	require.NotNil(t, fr.capturedReq, "scorer must run after a maxed-out pin is dropped")
+	assert.Contains(t, fr.capturedReq.ExcludedModels, "moonshotai/kimi-k2.6",
+		"pinned model must be excluded from candidates after a maxed-out turn")
+	assert.Equal(t, "claude-haiku-4-5", rec.Header().Get("x-router-model"),
+		"router must serve the fresh decision, not the broken pin")
+}
+
+// TestTurnLoop_UnderMaxedOutThresholdKeepsPin guards against false positives:
+// a turn that produced output well below the cap is healthy, so the pin
+// must not be excluded and the planner's normal STAY logic applies.
+func TestTurnLoop_UnderMaxedOutThresholdKeepsPin(t *testing.T) {
+	store := newFakePinStore()
+	store.hasPin = true
+	store.pin = sessionpin.Pin{
+		Provider:         providers.ProviderAnthropic,
+		Model:            "claude-haiku-4-5",
+		Reason:           "cluster:v0.52",
+		PinnedUntil:      time.Now().Add(time.Hour),
+		LastOutputTokens: 1024, // healthy, well below threshold
+		LastTurnEndedAt:  time.Now().Add(-10 * time.Second),
+	}
+	fr := &fakeRouter{decision: router.Decision{Provider: providers.ProviderAnthropic, Model: "claude-haiku-4-5", Reason: "fresh"}}
+	svc := newPinSvc(fr, store)
+
+	ctx := authedCtx(uuid.New().String())
+	rec := httptest.NewRecorder()
+	httpReq := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(""))
+	require.NoError(t, svc.ProxyMessages(ctx, []byte(pinTestBody), rec, httpReq))
+
+	require.NotNil(t, fr.capturedReq)
+	assert.NotContains(t, fr.capturedReq.ExcludedModels, "claude-haiku-4-5",
+		"healthy pin must not be excluded from candidates")
+	assert.Equal(t, "claude-haiku-4-5", rec.Header().Get("x-router-model"))
+}
+
 // recordingTelemetry is the minimum no-op telemetry repository that
 // flips proxy.Service.usageRequired() on so the OTel extractor wires up.
 // We do not assert on telemetry rows here.

--- a/internal/translate/provider_hint.go
+++ b/internal/translate/provider_hint.go
@@ -27,8 +27,18 @@ func openRouterProviderHint(model string) map[string]any {
 // openRouterReasoningHint returns the OpenRouter `reasoning` field to disable
 // reasoning on models that burn the entire max_tokens budget on hidden thinking.
 // Native DeepSeek serving defaults to reasoning-on and ignores effort=minimal.
+//
+// Extended to moonshotai/* (Kimi K2.x) and xiaomi/* (MiMo) because on
+// tool-calling turns these models otherwise emit native tool-call tokens
+// (<|tool_call_begin|>, Hermes <tool_call> XML) inside an unbounded reasoning
+// segment that OpenRouter's tool-call parser misses, leaving structured
+// tool_calls empty and generation running to the output cap.
+// (hermes-agent #24534, vllm #39056).
 func openRouterReasoningHint(model string) map[string]any {
-	if strings.HasPrefix(model, "deepseek/") {
+	switch {
+	case strings.HasPrefix(model, "deepseek/"),
+		strings.HasPrefix(model, "moonshotai/"),
+		strings.HasPrefix(model, "xiaomi/"):
 		return map[string]any{"enabled": false}
 	}
 	return nil

--- a/internal/translate/provider_hint_test.go
+++ b/internal/translate/provider_hint_test.go
@@ -129,8 +129,36 @@ func TestPrepareOpenAI_OpenAISource_DisablesReasoningForDeepSeek(t *testing.T) {
 	assert.Equal(t, false, r["enabled"])
 }
 
-func TestPrepareOpenAI_NoReasoningOverrideForNonDeepSeek(t *testing.T) {
-	cases := []string{"moonshotai/kimi-k2.5", "qwen/qwen3-max", "google/gemini-2.5-pro", "gpt-5"}
+func TestPrepareOpenAI_DisablesReasoningForMoonshotAndXiaomi(t *testing.T) {
+	// Kimi K2.x and MiMo emit native tool-call tokens (<|tool_call_begin|>,
+	// Hermes <tool_call> XML) inside reasoning segments that OpenRouter's
+	// tool-call parser misses, leaving structured tool_calls empty and
+	// generation running to the output cap. Disabling reasoning at the
+	// OpenRouter layer prevents that runaway. See hermes-agent#24534 and
+	// vllm#39056 for the upstream parser bugs that motivate this.
+	cases := []string{"moonshotai/kimi-k2.5", "moonshotai/kimi-k2.6", "xiaomi/mimo-v2.5", "xiaomi/mimo-v2.5-pro"}
+	for _, model := range cases {
+		t.Run(model, func(t *testing.T) {
+			src := []byte(`{"model":"claude-opus-4-7","messages":[{"role":"user","content":"hi"}],"max_tokens":256}`)
+			env, err := translate.ParseAnthropic(src)
+			require.NoError(t, err)
+
+			out, err := env.PrepareOpenAI(nil, translate.EmitOptions{TargetModel: model})
+			require.NoError(t, err)
+
+			r := reasoningField(t, out.Body)
+			require.NotNil(t, r, "%s must get a reasoning override", model)
+			assert.Equal(t, false, r["enabled"])
+		})
+	}
+}
+
+func TestPrepareOpenAI_NoReasoningOverrideForOtherModels(t *testing.T) {
+	// Qwen on OpenRouter is intentionally NOT included: its variants split
+	// across thinking and non-thinking models, and forcing reasoning off
+	// would degrade the thinking variants. The runaway-tool-call escape
+	// hatch for qwen is the turnloop maxed-out exclusion in proxy.
+	cases := []string{"qwen/qwen3-max", "qwen/qwen3-coder-next", "google/gemini-2.5-pro", "gpt-5"}
 	for _, model := range cases {
 		t.Run(model, func(t *testing.T) {
 			src := []byte(`{"model":"claude-opus-4-7","messages":[{"role":"user","content":"hi"}],"max_tokens":256}`)
@@ -141,7 +169,7 @@ func TestPrepareOpenAI_NoReasoningOverrideForNonDeepSeek(t *testing.T) {
 			require.NoError(t, err)
 
 			assert.Nil(t, reasoningField(t, out.Body),
-				"non-deepseek targets must not get a reasoning override")
+				"%s must not get a reasoning override", model)
 		})
 	}
 }


### PR DESCRIPTION
## Problem

Customer report: Claude Code sessions appear to "hang" for 5+ minutes on tool-call turns when routed to certain OSS models. Production telemetry for one org showed back-to-back 80–112s requests, all generating exactly 8192 output tokens (the cap), all `sticky_hit=true`:

| Model | Provider | Latency | Output tokens |
|---|---|---|---|
| `moonshotai/kimi-k2.6` | fireworks | 90–113s | 8192 (capped) |
| `xiaomi/mimo-v2.5` | openrouter | 81–89s | 8192 (capped) |
| `qwen/qwen3.6-35b-a3b` | deepinfra | 27–66s | 8192 or near-cap |

The `last_preview` field on every slow request read verbatim: *"Output token limit hit. Resume directly — no apology, no recap of what you were doing…"* — that is Claude Code's built-in auto-continuation prompt fired on `stop_reason=max_tokens`.

## Root cause

Two layers compounding:

1. **Provider-side parser failure.** Kimi K2 emits `<|tool_call_begin|>...<|tool_call_end|>` special tokens; Qwen3.x emits Hermes-style `<tool_call>` XML; MiMo emits something similar. When the provider's OpenAI-compat shim (Fireworks / OpenRouter / DeepInfra) fails to extract these — particularly when they land inside a reasoning segment — the tokens leak into `message.content`, the structured `tool_calls` array stays empty, and the model has no learned reason to stop. Generation runs to `max_tokens`. Documented at [hermes-agent#24534](https://github.com/NousResearch/hermes-agent/issues/24534), [vllm#39056](https://github.com/vllm-project/vllm/issues/39056), [HF Kimi-K2.5 #40](https://huggingface.co/moonshotai/Kimi-K2.5/discussions/40).

2. **Sticky pin re-anchors the broken model.** The planner (`internal/router/planner/policy.go`) only weighs cache-cost EV. It has no signal for "previous turn was degenerate." So when Claude Code's auto-continue fires, the session pin keeps routing to the same broken upstream and the loop continues. From the user's POV: 3–6 back-to-back 100s generations on the same model = one multi-minute hang.

## Fix

Two layered changes, kept minimal:

### 1. `proxy/turnloop`: drop the pin when the previous turn maxed out

When `pinFound && pin.LastOutputTokens >= 8000` (just under the 8192 default cap), exclude the pinned model from the candidate set for this turn and treat the pin as missing. The scorer naturally picks a different model and the planner re-pins fresh. Single-turn only — if the scorer organically re-picks the same model on the next turn, that's a separate decision.

Uses signals that already exist: `Pin.LastOutputTokens` is already populated in the LRU after every turn, and `router.Request.ExcludedModels` is already respected by the cluster scorer.

User-forced pins (`/force-model`) are exempt — the existing user-force check at line 190 short-circuits before this guard runs.

### 2. `translate/provider_hint`: extend reasoning-off to Kimi/MiMo on OpenRouter

Extends the existing DeepSeek reasoning-off hint to `moonshotai/*` and `xiaomi/*`. DeepSeek's precedent (commit comment: *"DeepSeek burns the entire max_tokens budget on hidden thinking"*) applies directly to Kimi K2.x and MiMo on OpenRouter. The hint is already gated by `targetIsOpenRouter(opts)` so direct upstreams (Fireworks, DeepInfra, Bedrock) are unaffected.

**Qwen on OpenRouter is intentionally not included** — its variants split across thinking and non-thinking models, and forcing reasoning off would degrade the thinking variants. The turnloop guard from #1 is the safety net for Qwen on DeepInfra.

## Test plan

- [x] New `TestTurnLoop_MaxedOutPinExcludedFromCandidates` — maxed-out pin causes the pinned model to land in `ExcludedModels` and the response serves the fresh decision
- [x] New `TestTurnLoop_UnderMaxedOutThresholdKeepsPin` — healthy pin (LastOutputTokens=1024) is untouched
- [x] New `TestPrepareOpenAI_DisablesReasoningForMoonshotAndXiaomi` — moonshotai/kimi-k2.{5,6}, xiaomi/mimo-v2.5{,-pro} all get `reasoning.enabled=false`
- [x] Updated `TestPrepareOpenAI_NoReasoningOverrideForOtherModels` — qwen/google/gpt still excluded
- [x] Existing `TestPrepareOpenAI_AnthropicSource_SkipsHintsForNonOpenRouterProvider` still passes — direct upstreams unaffected
- [x] `wv mr tc && wv mr t` — clean

## Out of scope / follow-ups

- Defensive content-side tool-call parsing (when `finish_reason="length"` and content contains `<|tool_call_begin|>`, post-parse into synthetic `tool_use`). Higher complexity, defer.
- Provider-specific `stop` sequences for the native end-tokens.
- Recording `stop_reason` properly on the pin (today we proxy via `LastOutputTokens >= 8000`); promote to a real field when we touch the pin schema next.