### PR TITLE
fix(translate): route OpenAI-compat reasoning to Anthropic thinking blocks

### DIFF
--- a/internal/translate/stream.go
+++ b/internal/translate/stream.go
@@ -341,8 +341,14 @@ type AnthropicSSETranslator struct {
 	closed   bool
 	blockIdx int
 	// textOpen avoids empty text blocks for tool-only responses.
-	textOpen   bool
-	toolBlocks map[int]int
+	textOpen bool
+	// thinkingOpen tracks an open Anthropic thinking content block carrying
+	// upstream reasoning (OpenRouter `reasoning`, DeepSeek/Qwen `reasoning_content`).
+	// Without this, reasoning either gets dropped or leaks into the visible
+	// text channel; clients see "Let me check..." narration mixed with the
+	// real answer.
+	thinkingOpen bool
+	toolBlocks   map[int]int
 
 	finishReason             string
 	usageInputTokens         int
@@ -616,7 +622,40 @@ func (t *AnthropicSSETranslator) extractAndForwardUsage(data []byte) {
 }
 
 func (t *AnthropicSSETranslator) emitDelta(delta gjson.Result) error {
+	// Reasoning arrives under different keys depending on upstream:
+	//   - OpenRouter normalizes to `reasoning`
+	//   - DeepSeek / Qwen native expose `reasoning_content`
+	// Either way it must surface as an Anthropic thinking block, not text.
+	reasoning := delta.Get("reasoning_content").Str
+	if reasoning == "" {
+		reasoning = delta.Get("reasoning").Str
+	}
+	if reasoning != "" {
+		if t.textOpen {
+			if err := t.emitContentBlockStop(t.blockIdx - 1); err != nil {
+				return err
+			}
+			t.textOpen = false
+		}
+		if !t.thinkingOpen {
+			if err := t.emitContentBlockStartThinking(t.blockIdx); err != nil {
+				return err
+			}
+			t.thinkingOpen = true
+			t.blockIdx++
+		}
+		if err := t.emitContentBlockDeltaThinking(t.blockIdx-1, reasoning); err != nil {
+			return err
+		}
+	}
+
 	if content := delta.Get("content").Str; content != "" {
+		if t.thinkingOpen {
+			if err := t.emitContentBlockStop(t.blockIdx - 1); err != nil {
+				return err
+			}
+			t.thinkingOpen = false
+		}
 		if !t.textOpen {
 			if err := t.emitContentBlockStartText(t.blockIdx); err != nil {
 				return err
@@ -645,6 +684,13 @@ func (t *AnthropicSSETranslator) emitDelta(delta gjson.Result) error {
 					return false
 				}
 				t.textOpen = false
+			}
+			if t.thinkingOpen {
+				if err := t.emitContentBlockStop(t.blockIdx - 1); err != nil {
+					emitErr = err
+					return false
+				}
+				t.thinkingOpen = false
 			}
 			id := tc.Get("id").Str
 			name := tc.Get("function.name").Str
@@ -705,6 +751,12 @@ func (t *AnthropicSSETranslator) finishStream() error {
 			return err
 		}
 		t.textOpen = false
+	}
+	if t.thinkingOpen {
+		if err := t.emitContentBlockStop(t.blockIdx - 1); err != nil {
+			return err
+		}
+		t.thinkingOpen = false
 	}
 	for _, blockIdx := range t.toolBlocks {
 		if err := t.emitContentBlockStop(blockIdx); err != nil {
@@ -767,6 +819,24 @@ func (t *AnthropicSSETranslator) emitContentBlockStartTool(index int, id, name, 
 		sse.WriteJSONString(t.bw, sig)
 	}
 	t.bw.WriteString(",\"input\":{}}}\n\n")
+	return t.flushEvent()
+}
+
+func (t *AnthropicSSETranslator) emitContentBlockStartThinking(index int) error {
+	observability.Get().Debug("AnthropicSSE emit", "event", "content_block_start", "type", "thinking")
+	t.bw.WriteString("event: content_block_start\ndata: {\"type\":\"content_block_start\",\"index\":")
+	sse.WriteJSONInt(t.bw, int64(index))
+	t.bw.WriteString(",\"content_block\":{\"type\":\"thinking\",\"thinking\":\"\"}}\n\n")
+	return t.flushEvent()
+}
+
+func (t *AnthropicSSETranslator) emitContentBlockDeltaThinking(index int, text string) error {
+	observability.Get().Debug("AnthropicSSE emit", "event", "content_block_delta", "type", "thinking_delta")
+	t.bw.WriteString("event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":")
+	sse.WriteJSONInt(t.bw, int64(index))
+	t.bw.WriteString(",\"delta\":{\"type\":\"thinking_delta\",\"thinking\":")
+	sse.WriteJSONString(t.bw, text)
+	t.bw.WriteString("}}\n\n")
 	return t.flushEvent()
 }
 

--- a/internal/translate/translate.go
+++ b/internal/translate/translate.go
@@ -200,6 +200,18 @@ func OpenAIToAnthropicResponse(body []byte, requestModel string) ([]byte, error)
 
 func writeAnthropicContentFromOpenAI(jw *jsonWriter, message gjson.Result) {
 	jw.Arr()
+	reasoning := message.Get("reasoning_content").String()
+	if reasoning == "" {
+		reasoning = message.Get("reasoning").String()
+	}
+	if reasoning != "" {
+		jw.Obj()
+		jw.Key("type")
+		jw.Str("thinking")
+		jw.Key("thinking")
+		jw.Str(reasoning)
+		jw.EndObj()
+	}
 	if text := message.Get("content").String(); text != "" {
 		jw.Obj()
 		jw.Key("type")

--- a/internal/translate/translate_test.go
+++ b/internal/translate/translate_test.go
@@ -555,6 +555,100 @@ func TestAnthropicSSETranslator_NonStreamingResponse(t *testing.T) {
 	assert.Equal(t, "Hello!", block["text"])
 }
 
+// Qwen via OpenRouter (and DeepSeek native) emit reasoning traces in
+// `reasoning` / `reasoning_content` deltas. Without translation these either
+// vanished or — when the model embedded the reasoning inline — leaked into the
+// visible text channel.
+func TestAnthropicSSETranslator_StreamingReasoningEmitsThinkingBlock(t *testing.T) {
+	rec := httptest.NewRecorder()
+	translator := translate.NewAnthropicSSETranslator(rec, "qwen/qwen3-coder-next", nil)
+
+	translator.Header().Set("Content-Type", "text/event-stream")
+	translator.WriteHeader(http.StatusOK)
+
+	events := []string{
+		"data: {\"id\":\"chatcmpl-r1\",\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\",\"content\":\"\"},\"finish_reason\":null}]}\n\n",
+		"data: {\"id\":\"chatcmpl-r1\",\"choices\":[{\"index\":0,\"delta\":{\"reasoning\":\"Let me check the layout file.\"},\"finish_reason\":null}]}\n\n",
+		"data: {\"id\":\"chatcmpl-r1\",\"choices\":[{\"index\":0,\"delta\":{\"reasoning\":\" Then the admin section.\"},\"finish_reason\":null}]}\n\n",
+		"data: {\"id\":\"chatcmpl-r1\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"The scrollbar comes from html overflow.\"},\"finish_reason\":null}]}\n\n",
+		"data: {\"id\":\"chatcmpl-r1\",\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"stop\"}],\"usage\":{\"prompt_tokens\":10,\"completion_tokens\":12,\"total_tokens\":22}}\n\n",
+		"data: [DONE]\n\n",
+	}
+	for _, e := range events {
+		_, err := translator.Write([]byte(e))
+		require.NoError(t, err)
+	}
+	require.NoError(t, translator.Finalize())
+
+	body := rec.Body.String()
+	assert.Contains(t, body, `"type":"thinking"`, "thinking content_block_start must be emitted")
+	assert.Contains(t, body, `"type":"thinking_delta"`)
+	assert.Contains(t, body, `"thinking":"Let me check the layout file."`)
+	assert.Contains(t, body, `"thinking":" Then the admin section."`)
+	assert.Contains(t, body, `"type":"text_delta"`)
+	assert.Contains(t, body, `"text":"The scrollbar comes from html overflow."`)
+	// Reasoning prose must not leak into the visible text channel.
+	assert.NotContains(t, body, `"text":"Let me check the layout file."`)
+
+	// Block ordering: thinking block opens, stops, then text block opens.
+	thinkingStart := strings.Index(body, `"content_block":{"type":"thinking"`)
+	textStart := strings.Index(body, `"content_block":{"type":"text"`)
+	require.GreaterOrEqual(t, thinkingStart, 0)
+	require.GreaterOrEqual(t, textStart, 0)
+	assert.Less(t, thinkingStart, textStart, "thinking block must precede text block")
+}
+
+// DeepSeek and some Qwen variants surface reasoning under `reasoning_content`
+// rather than the OpenRouter-normalized `reasoning`. Both paths must work.
+func TestAnthropicSSETranslator_StreamingReasoningContentField(t *testing.T) {
+	rec := httptest.NewRecorder()
+	translator := translate.NewAnthropicSSETranslator(rec, "deepseek/deepseek-v4-pro", nil)
+
+	translator.Header().Set("Content-Type", "text/event-stream")
+	translator.WriteHeader(http.StatusOK)
+
+	events := []string{
+		"data: {\"id\":\"chatcmpl-r2\",\"choices\":[{\"index\":0,\"delta\":{\"reasoning_content\":\"thought\"},\"finish_reason\":null}]}\n\n",
+		"data: {\"id\":\"chatcmpl-r2\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"answer\"},\"finish_reason\":null}]}\n\n",
+		"data: {\"id\":\"chatcmpl-r2\",\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"stop\"}]}\n\n",
+		"data: [DONE]\n\n",
+	}
+	for _, e := range events {
+		_, err := translator.Write([]byte(e))
+		require.NoError(t, err)
+	}
+	require.NoError(t, translator.Finalize())
+
+	body := rec.Body.String()
+	assert.Contains(t, body, `"thinking":"thought"`)
+	assert.Contains(t, body, `"text":"answer"`)
+}
+
+func TestAnthropicSSETranslator_NonStreamingReasoningEmitsThinkingBlock(t *testing.T) {
+	rec := httptest.NewRecorder()
+	translator := translate.NewAnthropicSSETranslator(rec, "qwen/qwen3-coder-next", nil)
+
+	translator.Header().Set("Content-Type", "application/json")
+	translator.WriteHeader(http.StatusOK)
+
+	openAIResp := `{"id":"chatcmpl-r3","object":"chat.completion","created":1234567890,"model":"qwen/qwen3-coder-next","choices":[{"index":0,"message":{"role":"assistant","reasoning":"Let me think.","content":"The answer is 42."},"finish_reason":"stop"}],"usage":{"prompt_tokens":10,"completion_tokens":8,"total_tokens":18}}`
+	_, err := translator.Write([]byte(openAIResp))
+	require.NoError(t, err)
+	require.NoError(t, translator.Finalize())
+
+	var doc map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &doc))
+
+	content, _ := doc["content"].([]any)
+	require.Len(t, content, 2)
+	thinkBlk, _ := content[0].(map[string]any)
+	textBlk, _ := content[1].(map[string]any)
+	assert.Equal(t, "thinking", thinkBlk["type"])
+	assert.Equal(t, "Let me think.", thinkBlk["thinking"])
+	assert.Equal(t, "text", textBlk["type"])
+	assert.Equal(t, "The answer is 42.", textBlk["text"])
+}
+
 func TestAnthropicSSETranslator_EmptyStreamEmitsSyntheticMessage(t *testing.T) {
 	rec := httptest.NewRecorder()
 	translator := translate.NewAnthropicSSETranslator(rec, "gpt-4o", nil)


### PR DESCRIPTION
## Problem

Qwen models routed through OpenRouter (and DeepSeek native) emit reasoning traces in `delta.reasoning` / `delta.reasoning_content`. The `AnthropicSSETranslator` only read `delta.content`, so reasoning either silently dropped or — when the model embedded its planning narration inline — bled into the visible text channel. Observed symptom: Claude Code clients saw repeated "Let me check..." narration mixed into the answer instead of a clean response.

## Fix

`internal/translate/stream.go`
- New state field `thinkingOpen` plus `emitContentBlockStartThinking` / `emitContentBlockDeltaThinking` helpers.
- `emitDelta` reads `reasoning_content` (DeepSeek/Qwen native) then `reasoning` (OpenRouter normalized) and emits Anthropic `thinking` content blocks. The block-open state machine closes thinking before opening text / tool_use (and vice versa), with `finishStream` closing any still-open thinking block.

`internal/translate/translate.go`
- `writeAnthropicContentFromOpenAI` emits a `thinking` block before the text block when the buffered (non-streaming) response carries `reasoning` / `reasoning_content`.

## Tests

Added in `translate_test.go`:
- `TestAnthropicSSETranslator_StreamingReasoningEmitsThinkingBlock` — `reasoning` deltas followed by `content` produce a thinking block then a text block in that order; reasoning prose is asserted to NOT appear in the text channel.
- `TestAnthropicSSETranslator_StreamingReasoningContentField` — `reasoning_content` (DeepSeek convention) maps to the same thinking block.
- `TestAnthropicSSETranslator_NonStreamingReasoningEmitsThinkingBlock` — buffered responses emit thinking block before text block.

`go test ./internal/translate/...` and `go test ./internal/proxy/...` both pass.

## Test plan

- [ ] CI green
- [ ] Manual check: route a Qwen3 (or DeepSeek-V4-Pro) turn via the router and confirm Claude Code renders reasoning in its thinking pane rather than as inline assistant text.