### PR TITLE
fix(force-model): skip leading injected tag blocks before leading-line guard

### DIFF
--- a/internal/translate/force_model.go
+++ b/internal/translate/force_model.go
@@ -100,8 +100,17 @@ func (env *RequestEnvelope) extractForceModelFromMessages() (ForceModelResult, b
 // deliberate guard: pasted content (snippets, transcripts) frequently contains
 // strings starting with "/" that would otherwise silently rewrite session
 // routing without explicit user intent.
+//
+// Complete leading <tag>...</tag> blocks (Claude Code injects <system-reminder>,
+// <command-name>, <local-command-stdout>, etc. ahead of the user's typed text)
+// are skipped before the leading-line check is applied. Skipped blocks are
+// preserved in the stripped output so downstream prompt context is intact.
 func parseForceModelCommand(text string) (res ForceModelResult, found bool, stripped string) {
-	lines := strings.Split(text, "\n")
+	prefixEnd := leadingInjectedPrefixEnd(text)
+	prefix := text[:prefixEnd]
+	body := text[prefixEnd:]
+
+	lines := strings.Split(body, "\n")
 	cmdIdx := -1
 	cmdTail := ""
 	for i, line := range lines {
@@ -135,6 +144,64 @@ func parseForceModelCommand(text string) (res ForceModelResult, found bool, stri
 		remaining = append(remaining, cmdTail)
 	}
 	remaining = append(remaining, lines[cmdIdx+1:]...)
-	stripped = strings.TrimSpace(strings.Join(remaining, "\n"))
+	bodyStripped := strings.Join(remaining, "\n")
+	stripped = strings.TrimSpace(prefix + bodyStripped)
 	return res, true, stripped
+}
+
+// leadingInjectedPrefixEnd returns the byte offset in text after any leading
+// whitespace and complete <tag>...</tag> blocks. Only simple tag names (letters,
+// digits, '-', '_') with no attributes are recognized so that arbitrary pasted
+// XML/HTML — which may contain a stray /force-model line — does not satisfy the
+// guard. Unclosed or attribute-bearing tags terminate the prefix scan.
+func leadingInjectedPrefixEnd(text string) int {
+	i := 0
+	for i < len(text) {
+		// Skip whitespace between blocks.
+		j := i
+		for j < len(text) {
+			c := text[j]
+			if c != ' ' && c != '\t' && c != '\r' && c != '\n' {
+				break
+			}
+			j++
+		}
+		if j >= len(text) || text[j] != '<' {
+			return i
+		}
+		// Parse the opening tag name.
+		nameStart := j + 1
+		nameEnd := nameStart
+		for nameEnd < len(text) {
+			c := text[nameEnd]
+			if c == '>' {
+				break
+			}
+			if !isTagNameByte(c, nameEnd == nameStart) {
+				return i
+			}
+			nameEnd++
+		}
+		if nameEnd >= len(text) || nameEnd == nameStart {
+			return i
+		}
+		closeTag := "</" + text[nameStart:nameEnd] + ">"
+		closeIdx := strings.Index(text[nameEnd+1:], closeTag)
+		if closeIdx < 0 {
+			return i
+		}
+		i = nameEnd + 1 + closeIdx + len(closeTag)
+	}
+	return i
+}
+
+func isTagNameByte(c byte, first bool) bool {
+	switch {
+	case c >= 'a' && c <= 'z', c >= 'A' && c <= 'Z':
+		return true
+	case !first && (c >= '0' && c <= '9' || c == '-' || c == '_'):
+		return true
+	default:
+		return false
+	}
 }

--- a/internal/translate/force_model_test.go
+++ b/internal/translate/force_model_test.go
@@ -72,6 +72,45 @@ func TestParseForceModelCommand_ForceModel(t *testing.T) {
 			wantFound:    true,
 			wantStripped: "",
 		},
+		{
+			// Claude Code injects <system-reminder> blocks ahead of the user's
+			// typed text. The command must still be recognized; injected blocks
+			// must be preserved in the stripped output.
+			name:         "leading system-reminder before command",
+			input:        "<system-reminder>be helpful</system-reminder>\n/force-model gpt-5",
+			wantModel:    "gpt-5",
+			wantFound:    true,
+			wantStripped: "<system-reminder>be helpful</system-reminder>",
+		},
+		{
+			name:         "multiple leading injected tag blocks",
+			input:        "<system-reminder>foo</system-reminder>\n<command-name>x</command-name>\n/force-model claude-opus-4-7\nthen help",
+			wantModel:    "claude-opus-4-7",
+			wantFound:    true,
+			wantStripped: "<system-reminder>foo</system-reminder>\n<command-name>x</command-name>\nthen help",
+		},
+		{
+			name:         "multiline system-reminder body",
+			input:        "<system-reminder>\nline one\nline two\n</system-reminder>\n/force-model gemini-2.5-pro",
+			wantModel:    "gemini-2.5-pro",
+			wantFound:    true,
+			wantStripped: "<system-reminder>\nline one\nline two\n</system-reminder>",
+		},
+		{
+			// Security guard preserved: an unclosed tag does not satisfy the
+			// prefix matcher, so a stray /force-model after it is still ignored.
+			name:      "unclosed tag does not unlock leading-line guard",
+			input:     "<system-reminder>unclosed\n/force-model gpt-5",
+			wantFound: false,
+		},
+		{
+			// Tags with attributes are not part of Claude Code's injection set
+			// and must not unlock the guard — they may originate from pasted
+			// HTML/XML content.
+			name:      "tag with attributes does not unlock leading-line guard",
+			input:     "<div class=\"x\">hi</div>\n/force-model gpt-5",
+			wantFound: false,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

`/force-model` and `/unforce-model` silently no-op'd in prod (`reason=no_pin` on every request) because Claude Code prepends `<system-reminder>`, `<command-name>`, `<local-command-stdout>`, etc. ahead of the user's typed text on every turn. The parser's leading-non-empty-line guard saw the injected tag instead of the command and bailed; the pin was never written, cluster routing picked the default, sticky affinity latched the session onto whatever the scorer chose.

`leadingInjectedPrefixEnd` skips complete `<tag>...</tag>` blocks at the head of the message before applying the leading-line check. Strict tag-name matching (identifier only — letters, digits, `-`, `_`, no attributes) preserves the original paste-safety guard: arbitrary HTML/XML, unclosed tags, and attribute-bearing tags still terminate the prefix scan, so a stray `/force-model` buried in pasted content is still ignored.

Skipped blocks are preserved in the stripped body so downstream prompt context (system-reminders, command metadata) reaches the upstream intact.

## Test plan

- [x] `go test ./internal/translate/... ./internal/proxy/...` — all green
- [x] New cases in `force_model_test.go`:
  - leading `<system-reminder>` before command
  - multiple stacked tag blocks
  - multi-line tag body
  - unclosed tag does NOT unlock the guard
  - tag with attributes does NOT unlock the guard