### PR TITLE
fix(qwen3): break tool-call loops + presence_penalty on outbound

### DIFF
--- a/internal/proxy/loop_detection.go
+++ b/internal/proxy/loop_detection.go
@@ -1,0 +1,131 @@
+package proxy
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"time"
+
+	"workweave/router/internal/observability"
+	"workweave/router/internal/router/sessionpin"
+	"workweave/router/internal/translate"
+
+	"github.com/google/uuid"
+)
+
+// Loop-detection knobs. Window is the number of recent tool calls inspected;
+// MaxRepeats is the count of identical (name+args) calls within the window
+// that trips the break. Values mirror charmbracelet/crush's loop detector:
+// large enough to absorb legitimate retries of a tool that returns the same
+// result twice, small enough to catch the qwen3 "same call N times in a row"
+// failure mode within a few seconds rather than minutes.
+const (
+	loopDetectionWindowSize = 10
+	loopDetectionMaxRepeats = 5
+)
+
+// detectToolCallLoop scans the trailing tool-call signatures in the assistant's
+// message history and reports whether the same (tool_name, args) signature
+// appears at least loopDetectionMaxRepeats times within the most recent
+// loopDetectionWindowSize entries.
+//
+// Returns the looping signature and its count so the caller can surface them
+// in logs and the synthetic stop message.
+func detectToolCallLoop(env *translate.RequestEnvelope) (looped bool, sig translate.ToolCallSig, count int) {
+	sigs := env.AssistantToolCallSignatures()
+	if len(sigs) < loopDetectionMaxRepeats {
+		return false, translate.ToolCallSig{}, 0
+	}
+	start := 0
+	if len(sigs) > loopDetectionWindowSize {
+		start = len(sigs) - loopDetectionWindowSize
+	}
+	window := sigs[start:]
+	counts := make(map[string]int, len(window))
+	keys := make(map[string]translate.ToolCallSig, len(window))
+	for _, s := range window {
+		key := s.Name + "\x00" + s.InputHash
+		counts[key]++
+		keys[key] = s
+		if counts[key] >= loopDetectionMaxRepeats {
+			return true, s, counts[key]
+		}
+	}
+	return false, translate.ToolCallSig{}, 0
+}
+
+// handleToolCallLoopBreak short-circuits a runaway tool-call loop. It writes a
+// synthetic end_turn response in the inbound wire format and expires the
+// session pin so the next user turn re-routes to a fresh decision rather than
+// re-anchoring on the model that produced the loop.
+//
+// Pin expiry is best-effort: a Postgres write failure logs but does not block
+// the response, because the client is already stuck and getting a clean break
+// out is more important than guaranteeing the pin row reflects the new state.
+func (s *Service) handleToolCallLoopBreak(
+	w http.ResponseWriter,
+	env *translate.RequestEnvelope,
+	sig translate.ToolCallSig,
+	count int,
+	installationID uuid.UUID,
+	sessionKey [sessionpin.SessionKeyLen]byte,
+	role string,
+	decisionModel string,
+	decisionProvider string,
+) error {
+	log := observability.Get()
+
+	msg := fmt.Sprintf(
+		"✦ **Weave Router** → tool-call loop detected: `%s` was called %d times in the last %d turns with identical arguments. Stopping this turn and clearing the session pin so the next message re-routes to a fresh model.\n\nIf the task is genuinely incomplete, send a follow-up message describing what's still needed; the router will pick a different model.\n\n",
+		sig.Name, count, loopDetectionWindowSize,
+	)
+	if env.SourceFormat() == translate.FormatOpenAI {
+		msg = fmt.Sprintf(
+			"Weave Router: tool-call loop detected (%s called %d times with identical args). Stopping and clearing the session pin. Send a follow-up message to resume; the router will pick a different model.",
+			sig.Name, count,
+		)
+	}
+
+	log.Info("Tool-call loop detected; breaking turn",
+		"tool_name", sig.Name,
+		"repeat_count", count,
+		"window_size", loopDetectionWindowSize,
+		"decision_model", decisionModel,
+		"decision_provider", decisionProvider,
+		"session_key_hex", fmt.Sprintf("%x", sessionKey),
+		"role", role,
+	)
+
+	// Expire the session pin so the NEXT user turn re-routes. We cannot
+	// simply Remove() the in-proc cache without also pushing an expired row
+	// to Postgres — a racing reader on another pod would repopulate the LRU
+	// from the stale row and re-anchor on the bad model.
+	if s.pinStore != nil && installationID != uuid.Nil {
+		expired := sessionpin.Pin{
+			SessionKey:     sessionKey,
+			Role:           role,
+			InstallationID: installationID,
+			Provider:       "",
+			Model:          "",
+			Reason:         "tool_call_loop_break",
+			TurnCount:      1,
+			PinnedUntil:    time.Now().Add(-time.Second),
+		}
+		// context.Background() — the request ctx may already be canceled by
+		// the time we get here (Claude Code drops slow turns). Upserting on
+		// a canceled context would silently fail and leave the bad pin.
+		if err := s.pinStore.Upsert(context.Background(), expired); err != nil {
+			log.Error("loop-break: pin store upsert failed", "err", err)
+		}
+	}
+	if s.pinCache != nil {
+		s.pinCache.Remove(sessionPinCacheKey(sessionKey, role))
+	}
+
+	switch env.SourceFormat() {
+	case translate.FormatOpenAI:
+		return writeSyntheticOpenAIResponse(w, env, msg)
+	default:
+		return writeSyntheticAnthropicResponse(w, env, msg)
+	}
+}

--- a/internal/proxy/loop_detection_test.go
+++ b/internal/proxy/loop_detection_test.go
@@ -1,0 +1,145 @@
+package proxy
+
+import (
+	"encoding/json"
+	"testing"
+
+	"workweave/router/internal/translate"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDetectToolCallLoop_TripsAtMaxRepeats(t *testing.T) {
+	// 5 identical (ls, /tmp) tool calls in a row → trip on the 5th.
+	body := buildBodyWithToolCalls(t, []toolCall{
+		{name: "ls", input: map[string]any{"path": "/tmp"}},
+		{name: "ls", input: map[string]any{"path": "/tmp"}},
+		{name: "ls", input: map[string]any{"path": "/tmp"}},
+		{name: "ls", input: map[string]any{"path": "/tmp"}},
+		{name: "ls", input: map[string]any{"path": "/tmp"}},
+	})
+	env, err := translate.ParseAnthropic(body)
+	require.NoError(t, err)
+
+	loop, sig, count := detectToolCallLoop(env)
+	assert.True(t, loop)
+	assert.Equal(t, "ls", sig.Name)
+	assert.GreaterOrEqual(t, count, loopDetectionMaxRepeats)
+}
+
+func TestDetectToolCallLoop_NoLoopBelowThreshold(t *testing.T) {
+	body := buildBodyWithToolCalls(t, []toolCall{
+		{name: "ls", input: map[string]any{"path": "/tmp"}},
+		{name: "ls", input: map[string]any{"path": "/tmp"}},
+		{name: "ls", input: map[string]any{"path": "/tmp"}},
+		{name: "ls", input: map[string]any{"path": "/tmp"}},
+	})
+	env, err := translate.ParseAnthropic(body)
+	require.NoError(t, err)
+
+	loop, _, _ := detectToolCallLoop(env)
+	assert.False(t, loop, "4 identical calls must not trip the detector (threshold is 5)")
+}
+
+func TestDetectToolCallLoop_DifferentArgsDoNotTrip(t *testing.T) {
+	body := buildBodyWithToolCalls(t, []toolCall{
+		{name: "ls", input: map[string]any{"path": "/a"}},
+		{name: "ls", input: map[string]any{"path": "/b"}},
+		{name: "ls", input: map[string]any{"path": "/c"}},
+		{name: "ls", input: map[string]any{"path": "/d"}},
+		{name: "ls", input: map[string]any{"path": "/e"}},
+	})
+	env, err := translate.ParseAnthropic(body)
+	require.NoError(t, err)
+
+	loop, _, _ := detectToolCallLoop(env)
+	assert.False(t, loop, "same tool name but distinct args must not trip the detector")
+}
+
+func TestDetectToolCallLoop_WindowedOldEntriesDropOut(t *testing.T) {
+	// Window is 10. Put 4 (ls,/tmp) entries spaced far apart (separated by
+	// many distinct calls). The window should be small enough that the
+	// (ls,/tmp) count drops below threshold by the time we sample it.
+	calls := []toolCall{
+		{name: "ls", input: map[string]any{"path": "/tmp"}},
+		{name: "ls", input: map[string]any{"path": "/tmp"}},
+	}
+	for i := range 15 {
+		calls = append(calls, toolCall{name: "read", input: map[string]any{"path": "/etc", "n": i}})
+	}
+	body := buildBodyWithToolCalls(t, calls)
+	env, err := translate.ParseAnthropic(body)
+	require.NoError(t, err)
+
+	loop, _, _ := detectToolCallLoop(env)
+	assert.False(t, loop, "stale repeats outside the window must not trip the detector")
+}
+
+func TestDetectToolCallLoop_AlternatingPairStillTripsOnRepeats(t *testing.T) {
+	// An A/B alternating loop (Hermes-style qwen3 failure mode) still trips
+	// because each leg accrues count independently.
+	calls := []toolCall{
+		{name: "ls", input: map[string]any{"path": "/tmp"}},
+		{name: "read", input: map[string]any{"path": "/etc/hosts"}},
+		{name: "ls", input: map[string]any{"path": "/tmp"}},
+		{name: "read", input: map[string]any{"path": "/etc/hosts"}},
+		{name: "ls", input: map[string]any{"path": "/tmp"}},
+		{name: "read", input: map[string]any{"path": "/etc/hosts"}},
+		{name: "ls", input: map[string]any{"path": "/tmp"}},
+		{name: "read", input: map[string]any{"path": "/etc/hosts"}},
+		{name: "ls", input: map[string]any{"path": "/tmp"}},
+	}
+	body := buildBodyWithToolCalls(t, calls)
+	env, err := translate.ParseAnthropic(body)
+	require.NoError(t, err)
+
+	loop, sig, count := detectToolCallLoop(env)
+	assert.True(t, loop)
+	assert.Equal(t, "ls", sig.Name)
+	assert.GreaterOrEqual(t, count, loopDetectionMaxRepeats)
+}
+
+// --- helpers ---
+
+type toolCall struct {
+	name  string
+	input map[string]any
+}
+
+func buildBodyWithToolCalls(t *testing.T, calls []toolCall) []byte {
+	t.Helper()
+	msgs := []any{
+		map[string]any{"role": "user", "content": "do the thing"},
+	}
+	for i, c := range calls {
+		id := "toolu_" + itoa(i)
+		msgs = append(msgs,
+			map[string]any{"role": "assistant", "content": []any{
+				map[string]any{"type": "tool_use", "id": id, "name": c.name, "input": c.input},
+			}},
+			map[string]any{"role": "user", "content": []any{
+				map[string]any{"type": "tool_result", "tool_use_id": id, "content": "result"},
+			}},
+		)
+	}
+	body, err := json.Marshal(map[string]any{
+		"model":      "claude-sonnet-4-6",
+		"max_tokens": 256,
+		"messages":   msgs,
+	})
+	require.NoError(t, err)
+	return body
+}
+
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	digits := ""
+	for n > 0 {
+		digits = string('0'+byte(n%10)) + digits
+		n /= 10
+	}
+	return digits
+}

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -689,6 +689,18 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 		}
 	}
 
+	// Tool-call loop break: when the same (tool_name, args) appears at least
+	// loopDetectionMaxRepeats times in the last loopDetectionWindowSize
+	// assistant turns, synthesize end_turn and expire the session pin. Catches
+	// runaway OSS-model tool-call cycles (qwen3, in particular) that the
+	// previous-turn-maxed-out guard misses because each individual tool call
+	// returns quickly and well under the output cap.
+	if loop, sig, count := detectToolCallLoop(env); loop {
+		loopSessionKey := DeriveSessionKey(env, apiKeyID)
+		loopRole := roleForTier(catalog.TierFor(feats.Model))
+		return s.handleToolCallLoopBreak(w, env, sig, count, installationID, loopSessionKey, loopRole, feats.Model, providers.ProviderAnthropic)
+	}
+
 	// Anthropic packs sub-agent identity into metadata.user_id; the
 	// x-weave-subagent-type header is for non-Anthropic ingress only.
 	routeStart := time.Now()
@@ -1491,6 +1503,14 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 		if cmd, hasCmd := env.ExtractForceModelCommand(); hasCmd {
 			return s.handleForceModelCommand(w, env, cmd, installationID, cmdSessionKey)
 		}
+	}
+
+	// Tool-call loop break: same path as the Anthropic ingress. See the
+	// detectToolCallLoop / handleToolCallLoopBreak doc comments for rationale.
+	if loop, sig, count := detectToolCallLoop(env); loop {
+		loopSessionKey := DeriveSessionKey(env, apiKeyID)
+		loopRole := roleForTier(catalog.TierFor(feats.Model))
+		return s.handleToolCallLoopBreak(w, env, sig, count, installationID, loopSessionKey, loopRole, feats.Model, providers.ProviderOpenAI)
 	}
 
 	// OpenAI signals sub-agent identity via x-weave-subagent-type (no metadata.user_id).

--- a/internal/translate/emit_openai.go
+++ b/internal/translate/emit_openai.go
@@ -69,6 +69,15 @@ func (e *RequestEnvelope) buildOpenAIFromOpenAI(opts EmitOptions) ([]byte, error
 				return nil, fmt.Errorf("set tool temperature override: %w", err)
 			}
 		}
+		// Qwen3 anti-loop: presence_penalty=1.5 per the Qwen3 model card.
+		// Only applied when the client has not specified one itself, so a
+		// caller that has its own tuning preference still wins.
+		if isQwen3Family(opts.TargetModel) && !gjson.GetBytes(body, "presence_penalty").Exists() {
+			body, err = sjson.SetBytes(body, "presence_penalty", qwen3PresencePenalty)
+			if err != nil {
+				return nil, fmt.Errorf("set qwen3 presence_penalty: %w", err)
+			}
+		}
 	}
 	return body, nil
 }
@@ -133,6 +142,14 @@ func (e *RequestEnvelope) buildOpenAIFromAnthropic(opts EmitOptions) ([]byte, er
 			jw.Key("temperature")
 			jw.Int(0)
 		}
+	}
+
+	// Qwen3 anti-loop presence_penalty (cross-format). Only added when the
+	// client did not set one. Mirrors the same-format branch above.
+	if targetIsOpenRouter(opts) && isQwen3Family(opts.TargetModel) &&
+		!gjson.GetBytes(body, "presence_penalty").Exists() {
+		jw.Key("presence_penalty")
+		jw.Float(qwen3PresencePenalty)
 	}
 
 	// Max tokens

--- a/internal/translate/loop_detection.go
+++ b/internal/translate/loop_detection.go
@@ -1,0 +1,206 @@
+package translate
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"strings"
+
+	"github.com/tidwall/gjson"
+)
+
+// ToolCallSig identifies a single tool invocation by callee + canonical-JSON
+// hash of its arguments. Two invocations with the same Name and InputHash are
+// treated as identical for loop-detection purposes.
+type ToolCallSig struct {
+	Name      string
+	InputHash string
+}
+
+// AssistantToolCallSignatures returns the ordered list of tool invocations
+// emitted by assistant messages in the request body. Order matches message
+// order, and within a message, content-block order.
+//
+// Used by the proxy's loop detector to identify runaway tool-call cycles. An
+// OSS model (notably qwen3 variants) that fails to recognize when a task is
+// complete will alternate or repeat the same tool calls indefinitely; counting
+// signature occurrences in a recent window catches both patterns.
+//
+// Returns nil for Gemini-format requests (not currently supported) and for
+// requests with no assistant tool calls.
+func (e *RequestEnvelope) AssistantToolCallSignatures() []ToolCallSig {
+	switch e.format {
+	case FormatAnthropic:
+		return anthropicAssistantToolCallSigs(e.body)
+	case FormatOpenAI:
+		return openAIAssistantToolCallSigs(e.body)
+	default:
+		return nil
+	}
+}
+
+func anthropicAssistantToolCallSigs(body []byte) []ToolCallSig {
+	msgs := gjson.GetBytes(body, "messages")
+	if !msgs.IsArray() {
+		return nil
+	}
+	var sigs []ToolCallSig
+	msgs.ForEach(func(_, msg gjson.Result) bool {
+		if msg.Get("role").String() != "assistant" {
+			return true
+		}
+		content := msg.Get("content")
+		if !content.IsArray() {
+			return true
+		}
+		content.ForEach(func(_, block gjson.Result) bool {
+			if block.Get("type").String() != "tool_use" {
+				return true
+			}
+			name := block.Get("name").String()
+			input := block.Get("input").Raw
+			sigs = append(sigs, ToolCallSig{Name: name, InputHash: hashCanonicalJSON(input)})
+			return true
+		})
+		return true
+	})
+	return sigs
+}
+
+func openAIAssistantToolCallSigs(body []byte) []ToolCallSig {
+	msgs := gjson.GetBytes(body, "messages")
+	if !msgs.IsArray() {
+		return nil
+	}
+	var sigs []ToolCallSig
+	msgs.ForEach(func(_, msg gjson.Result) bool {
+		if msg.Get("role").String() != "assistant" {
+			return true
+		}
+		toolCalls := msg.Get("tool_calls")
+		if !toolCalls.IsArray() {
+			return true
+		}
+		toolCalls.ForEach(func(_, tc gjson.Result) bool {
+			if tc.Get("type").String() != "function" {
+				return true
+			}
+			name := tc.Get("function.name").String()
+			// OpenAI delivers arguments as a JSON-encoded string. Hash the
+			// canonical form so semantically-identical args with different
+			// whitespace still collide.
+			argsRaw := tc.Get("function.arguments").String()
+			sigs = append(sigs, ToolCallSig{Name: name, InputHash: hashCanonicalJSON(argsRaw)})
+			return true
+		})
+		return true
+	})
+	return sigs
+}
+
+// hashCanonicalJSON returns a stable hex sha256 of the canonical form of a
+// JSON document. Whitespace and key order are normalized via gjson's parsed
+// representation so equivalent JSON values produce identical hashes. Invalid
+// JSON is hashed verbatim — same-string inputs still collide, which is the
+// property the loop detector relies on.
+func hashCanonicalJSON(raw string) string {
+	if raw == "" {
+		h := sha256.Sum256(nil)
+		return hex.EncodeToString(h[:])
+	}
+	parsed := gjson.Parse(raw)
+	if !parsed.Exists() {
+		h := sha256.Sum256([]byte(raw))
+		return hex.EncodeToString(h[:])
+	}
+	canonical := canonicalize(parsed)
+	h := sha256.Sum256([]byte(canonical))
+	return hex.EncodeToString(h[:])
+}
+
+// canonicalize serializes a gjson.Result with sorted object keys.
+func canonicalize(r gjson.Result) string {
+	var b strings.Builder
+	canonicalizeInto(&b, r)
+	return b.String()
+}
+
+func canonicalizeInto(b *strings.Builder, r gjson.Result) {
+	switch {
+	case r.IsObject():
+		keys := make([]string, 0, 8)
+		fields := make(map[string]gjson.Result, 8)
+		r.ForEach(func(k, v gjson.Result) bool {
+			ks := k.String()
+			keys = append(keys, ks)
+			fields[ks] = v
+			return true
+		})
+		sortStrings(keys)
+		b.WriteByte('{')
+		for i, k := range keys {
+			if i > 0 {
+				b.WriteByte(',')
+			}
+			b.WriteString(jsonQuote(k))
+			b.WriteByte(':')
+			canonicalizeInto(b, fields[k])
+		}
+		b.WriteByte('}')
+	case r.IsArray():
+		b.WriteByte('[')
+		first := true
+		r.ForEach(func(_, v gjson.Result) bool {
+			if !first {
+				b.WriteByte(',')
+			}
+			first = false
+			canonicalizeInto(b, v)
+			return true
+		})
+		b.WriteByte(']')
+	default:
+		b.WriteString(r.Raw)
+	}
+}
+
+func sortStrings(s []string) {
+	for i := 1; i < len(s); i++ {
+		for j := i; j > 0 && s[j-1] > s[j]; j-- {
+			s[j-1], s[j] = s[j], s[j-1]
+		}
+	}
+}
+
+func jsonQuote(s string) string {
+	out := []byte{'"'}
+	for _, r := range s {
+		switch r {
+		case '"':
+			out = append(out, '\\', '"')
+		case '\\':
+			out = append(out, '\\', '\\')
+		case '\n':
+			out = append(out, '\\', 'n')
+		case '\r':
+			out = append(out, '\\', 'r')
+		case '\t':
+			out = append(out, '\\', 't')
+		default:
+			if r < 0x20 {
+				out = append(out, '\\', 'u', '0', '0',
+					hexDigit(byte(r>>4)), hexDigit(byte(r&0xf)))
+			} else {
+				out = append(out, []byte(string(r))...)
+			}
+		}
+	}
+	out = append(out, '"')
+	return string(out)
+}
+
+func hexDigit(n byte) byte {
+	if n < 10 {
+		return '0' + n
+	}
+	return 'a' + n - 10
+}

--- a/internal/translate/loop_detection_test.go
+++ b/internal/translate/loop_detection_test.go
@@ -1,0 +1,121 @@
+package translate_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"workweave/router/internal/translate"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAssistantToolCallSignatures_Anthropic(t *testing.T) {
+	body := mustMarshalJSON(t, map[string]any{
+		"model": "claude-sonnet-4-6",
+		"messages": []any{
+			map[string]any{"role": "user", "content": "do stuff"},
+			map[string]any{"role": "assistant", "content": []any{
+				map[string]any{"type": "tool_use", "id": "1", "name": "ls", "input": map[string]any{"path": "/tmp"}},
+			}},
+			map[string]any{"role": "user", "content": []any{
+				map[string]any{"type": "tool_result", "tool_use_id": "1", "content": "a"},
+			}},
+			map[string]any{"role": "assistant", "content": []any{
+				map[string]any{"type": "tool_use", "id": "2", "name": "ls", "input": map[string]any{"path": "/tmp"}},
+				map[string]any{"type": "text", "text": "ignore me"},
+				map[string]any{"type": "tool_use", "id": "3", "name": "read", "input": map[string]any{"path": "/etc/hosts"}},
+			}},
+		},
+		"max_tokens": 256,
+	})
+	env, err := translate.ParseAnthropic(body)
+	require.NoError(t, err)
+
+	sigs := env.AssistantToolCallSignatures()
+	require.Len(t, sigs, 3)
+	assert.Equal(t, "ls", sigs[0].Name)
+	assert.Equal(t, "ls", sigs[1].Name)
+	assert.Equal(t, "read", sigs[2].Name)
+	assert.Equal(t, sigs[0].InputHash, sigs[1].InputHash, "identical args must produce identical hash")
+	assert.NotEqual(t, sigs[1].InputHash, sigs[2].InputHash, "different tool args must produce different hash")
+}
+
+func TestAssistantToolCallSignatures_Anthropic_KeyOrderInvariant(t *testing.T) {
+	bodyA := mustMarshalJSON(t, map[string]any{
+		"model": "claude-sonnet-4-6",
+		"messages": []any{
+			map[string]any{"role": "assistant", "content": []any{
+				map[string]any{"type": "tool_use", "id": "1", "name": "x", "input": map[string]any{"a": 1, "b": 2}},
+			}},
+		},
+		"max_tokens": 256,
+	})
+	// Build the alternate form with the same keys in opposite order. We
+	// can't rely on json.Marshal ordering, so write the raw JSON directly.
+	bodyB := []byte(`{"model":"claude-sonnet-4-6","max_tokens":256,"messages":[{"role":"assistant","content":[{"type":"tool_use","id":"1","name":"x","input":{"b":2,"a":1}}]}]}`)
+
+	envA, err := translate.ParseAnthropic(bodyA)
+	require.NoError(t, err)
+	envB, err := translate.ParseAnthropic(bodyB)
+	require.NoError(t, err)
+
+	sigsA := envA.AssistantToolCallSignatures()
+	sigsB := envB.AssistantToolCallSignatures()
+	require.Len(t, sigsA, 1)
+	require.Len(t, sigsB, 1)
+	assert.Equal(t, sigsA[0].InputHash, sigsB[0].InputHash, "canonical hashing must be key-order-invariant")
+}
+
+func TestAssistantToolCallSignatures_OpenAI(t *testing.T) {
+	body := mustMarshalJSON(t, map[string]any{
+		"model": "gpt-4o",
+		"messages": []any{
+			map[string]any{"role": "user", "content": "do stuff"},
+			map[string]any{"role": "assistant", "tool_calls": []any{
+				map[string]any{
+					"id":   "call_1",
+					"type": "function",
+					"function": map[string]any{
+						"name":      "ls",
+						"arguments": `{"path":"/tmp"}`,
+					},
+				},
+				map[string]any{
+					"id":   "call_2",
+					"type": "function",
+					"function": map[string]any{
+						"name":      "ls",
+						"arguments": `{"path": "/tmp"}`, // whitespace differs
+					},
+				},
+			}},
+		},
+	})
+	env, err := translate.ParseOpenAI(body)
+	require.NoError(t, err)
+
+	sigs := env.AssistantToolCallSignatures()
+	require.Len(t, sigs, 2)
+	assert.Equal(t, sigs[0].InputHash, sigs[1].InputHash, "whitespace-only differences must not affect the hash")
+}
+
+func TestAssistantToolCallSignatures_EmptyAndNonAssistant(t *testing.T) {
+	body := mustMarshalJSON(t, map[string]any{
+		"model": "claude-sonnet-4-6",
+		"messages": []any{
+			map[string]any{"role": "user", "content": "hi"},
+			map[string]any{"role": "user", "content": []any{
+				map[string]any{"type": "tool_result", "tool_use_id": "x", "content": "noise"},
+			}},
+		},
+		"max_tokens": 256,
+	})
+	env, err := translate.ParseAnthropic(body)
+	require.NoError(t, err)
+	assert.Nil(t, env.AssistantToolCallSignatures())
+}
+
+// mustMarshalJSON is shared with force_model_test.go; redeclared here would be
+// a compile error so the existing one is reused.
+var _ = json.Marshal

--- a/internal/translate/provider_hint.go
+++ b/internal/translate/provider_hint.go
@@ -52,3 +52,16 @@ func openRouterReasoningHint(model string) map[string]any {
 func openRouterForcesToolTemperatureZero(model string) bool {
 	return strings.HasPrefix(model, "deepseek/")
 }
+
+// isQwen3Family reports whether the model id belongs to the qwen3.x family.
+// Qwen3 variants (instruct, coder, qwen3-next, qwen3.6-*) are documented to
+// drift into tool-call / thinking loops without a non-zero presence_penalty;
+// the Qwen3 model card recommends presence_penalty=1.5 to suppress this.
+func isQwen3Family(model string) bool {
+	return strings.HasPrefix(model, "qwen/qwen3")
+}
+
+// qwen3PresencePenalty is the recommended Qwen3 presence_penalty value from
+// the official model card; applied only when the client has not set
+// presence_penalty itself.
+const qwen3PresencePenalty = 1.5

--- a/internal/translate/qwen3_sampling_test.go
+++ b/internal/translate/qwen3_sampling_test.go
@@ -1,0 +1,84 @@
+package translate_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"workweave/router/internal/providers"
+	"workweave/router/internal/router"
+	"workweave/router/internal/translate"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Qwen3 anti-loop sampling: the router injects presence_penalty=1.5 when an
+// OpenRouter-bound request targets a qwen3 model and the client did not set
+// one itself. Validates both the OpenAI same-format path and the
+// Anthropic→OpenAI cross-format path.
+
+func TestQwen3PresencePenalty_OpenAISameFormat_InjectedForQwen3(t *testing.T) {
+	body := []byte(`{"model":"gpt-4o","messages":[{"role":"user","content":"hi"}]}`)
+	env, err := translate.ParseOpenAI(body)
+	require.NoError(t, err)
+	prep, err := env.PrepareOpenAI(http.Header{}, translate.EmitOptions{
+		TargetModel:    "qwen/qwen3.6-35b-a3b",
+		TargetProvider: providers.ProviderOpenRouter,
+		Capabilities:   router.Lookup("qwen/qwen3.6-35b-a3b"),
+	})
+	require.NoError(t, err)
+	var out map[string]any
+	require.NoError(t, json.Unmarshal(prep.Body, &out))
+	assert.Equal(t, 1.5, out["presence_penalty"], "qwen3 must receive presence_penalty=1.5")
+}
+
+func TestQwen3PresencePenalty_NotInjectedForNonQwen(t *testing.T) {
+	body := []byte(`{"model":"gpt-4o","messages":[{"role":"user","content":"hi"}]}`)
+	env, err := translate.ParseOpenAI(body)
+	require.NoError(t, err)
+	prep, err := env.PrepareOpenAI(http.Header{}, translate.EmitOptions{
+		TargetModel:    "deepseek/deepseek-v4-pro",
+		TargetProvider: providers.ProviderOpenRouter,
+		Capabilities:   router.Lookup("deepseek/deepseek-v4-pro"),
+	})
+	require.NoError(t, err)
+	var out map[string]any
+	require.NoError(t, json.Unmarshal(prep.Body, &out))
+	_, has := out["presence_penalty"]
+	assert.False(t, has, "non-qwen3 models must not receive the presence_penalty override")
+}
+
+func TestQwen3PresencePenalty_DoesNotOverrideClientValue(t *testing.T) {
+	body := []byte(`{"model":"gpt-4o","messages":[{"role":"user","content":"hi"}],"presence_penalty":0.2}`)
+	env, err := translate.ParseOpenAI(body)
+	require.NoError(t, err)
+	prep, err := env.PrepareOpenAI(http.Header{}, translate.EmitOptions{
+		TargetModel:    "qwen/qwen3.6-35b-a3b",
+		TargetProvider: providers.ProviderOpenRouter,
+		Capabilities:   router.Lookup("qwen/qwen3.6-35b-a3b"),
+	})
+	require.NoError(t, err)
+	var out map[string]any
+	require.NoError(t, json.Unmarshal(prep.Body, &out))
+	assert.Equal(t, 0.2, out["presence_penalty"], "client-set presence_penalty must win over the qwen3 default")
+}
+
+func TestQwen3PresencePenalty_AnthropicToOpenAI(t *testing.T) {
+	body := []byte(`{
+		"model": "claude-opus-4-7",
+		"max_tokens": 256,
+		"messages": [{"role":"user","content":"hi"}]
+	}`)
+	env, err := translate.ParseAnthropic(body)
+	require.NoError(t, err)
+	prep, err := env.PrepareOpenAI(http.Header{}, translate.EmitOptions{
+		TargetModel:    "qwen/qwen3.6-35b-a3b",
+		TargetProvider: providers.ProviderOpenRouter,
+		Capabilities:   router.Lookup("qwen/qwen3.6-35b-a3b"),
+	})
+	require.NoError(t, err)
+	var out map[string]any
+	require.NoError(t, json.Unmarshal(prep.Body, &out))
+	assert.Equal(t, 1.5, out["presence_penalty"], "cross-format emit must inject qwen3 presence_penalty")
+}


### PR DESCRIPTION
## Summary

Two-part fix for qwen3 sessions getting stuck in autonomous tool-call loops that the existing previous-turn-maxed-out guard (#229) misses because each individual tool call returns quickly under the output cap.

**Symptom in prod:** every ProxyMessages line shows `last_kind=tool_result message_count=3 decision_model=qwen/qwen3.6-35b-a3b`, never reaching `end_turn`. Claude Code's `/force-model` slash command can't escape because the user message slot is always filled with a `tool_result`, not text.

## Changes

**1. Tool-call loop detector** (`translate/loop_detection.go`, `proxy/loop_detection.go`)

- New `RequestEnvelope.AssistantToolCallSignatures()` walks assistant messages and returns ordered `(tool_name, canonical-args-hash)` pairs. Works for both Anthropic and OpenAI ingress formats. Hashing is key-order- and whitespace-invariant.
- New `proxy.detectToolCallLoop` with window=10, threshold=5 — mirrors [charmbracelet/crush's loop detector](https://github.com/charmbracelet/crush/blob/main/internal/agent/loop_detection.go).
- On trip, `handleToolCallLoopBreak` synthesizes an `end_turn` SSE/JSON response in the inbound wire format AND expires the session pin so the next user turn re-routes to a fresh model.
- Wired into both `ProxyMessages` (Anthropic) and `ProxyOpenAIChatCompletion` (OpenAI), after the `/force-model` handler.

**2. Qwen3 anti-loop sampling** (`translate/provider_hint.go`, `translate/emit_openai.go`)

- Injects `presence_penalty=1.5` on outbound OpenRouter requests when the target is a qwen3 family model AND the client did not set a value itself. Per the Qwen3 model card recommendation — mitigates the "model doesn't know it's done" failure mode at the source.
- Applied in both same-format and Anthropic→OpenAI cross-format emit paths.

## Why this isn't redundant with #229

#229 catches the `output_cap_saturated` runaway (model fails to emit a stop token, generates to the 8192 cap, Claude Code auto-continues). This PR catches the `successful_tool_calls_in_a_loop` case where qwen3 keeps emitting valid tool calls but never decides the task is done.

## Test plan

- [x] `go test ./...` passes
- [x] New unit tests cover signature extraction (key-order/whitespace invariance), detector trips (threshold, alternating pairs), non-trips (distinct args, window drop-out), and presence_penalty injection (both emit paths, doesn't override client value)
- [ ] Manual prod verification after deploy: send a tool-result message history with 5 identical tool calls and confirm `end_turn` synthesized response

🤖 Generated with [Claude Code](https://claude.com/claude-code)