### PR TITLE
fix(force-model): parse directive across all text blocks in array content

### DIFF
--- a/internal/translate/force_model.go
+++ b/internal/translate/force_model.go
@@ -68,27 +68,37 @@ func (env *RequestEnvelope) extractForceModelFromMessages() (ForceModelResult, b
 		return res, true
 
 	case lastContent.Type == gjson.JSON && lastContent.IsArray():
-		textIdx := -1
-		var textVal string
+		// Scan every text block in order. Claude Code clients sometimes split
+		// the user turn into multiple text parts (one carrying injected
+		// <command-name>/<command-args> tags, another carrying the typed
+		// directive), so inspecting only the first block silently lets
+		// /force-model fall through to upstream routing.
+		type textBlock struct {
+			idx  int
+			text string
+		}
+		var blocks []textBlock
 		lastContent.ForEach(func(key, block gjson.Result) bool {
-			if block.Get("type").String() == "text" && textIdx < 0 {
-				textIdx = int(key.Int())
-				textVal = block.Get("text").String()
+			if block.Get("type").String() == "text" {
+				blocks = append(blocks, textBlock{idx: int(key.Int()), text: block.Get("text").String()})
 			}
 			return true
 		})
-		if textIdx < 0 {
+		if len(blocks) == 0 {
 			return ForceModelResult{}, false
 		}
-		res, found, stripped := parseForceModelCommand(textVal)
-		if !found {
-			return ForceModelResult{}, false
+		for _, b := range blocks {
+			res, found, stripped := parseForceModelCommand(b.text)
+			if !found {
+				continue
+			}
+			blockPath := "messages." + idxStr + ".content." + strconv.Itoa(b.idx) + ".text"
+			if newBody, err := sjson.SetBytes(env.body, blockPath, stripped); err == nil {
+				env.body = newBody
+			}
+			return res, true
 		}
-		blockPath := "messages." + idxStr + ".content." + strconv.Itoa(textIdx) + ".text"
-		if newBody, err := sjson.SetBytes(env.body, blockPath, stripped); err == nil {
-			env.body = newBody
-		}
-		return res, true
+		return ForceModelResult{}, false
 
 	default:
 		return ForceModelResult{}, false

--- a/internal/translate/force_model_test.go
+++ b/internal/translate/force_model_test.go
@@ -184,6 +184,43 @@ func TestExtractForceModelCommand_ArrayContent(t *testing.T) {
 	assert.Equal(t, "Help me.", stripped)
 }
 
+func TestExtractForceModelCommand_ArrayContentMultipleTextBlocks(t *testing.T) {
+	// Claude Code clients sometimes split a slash-command turn into multiple
+	// text blocks: one carries the injected <command-name>/<command-args>
+	// tags, and the typed directive lands in a separate block. The parser
+	// must scan every text block, not just the first.
+	body := mustMarshalJSON(t, map[string]any{
+		"model": "claude-sonnet-4-6",
+		"messages": []any{
+			map[string]any{
+				"role": "user",
+				"content": []any{
+					map[string]any{"type": "text", "text": "<command-message>force-model</command-message>\n<command-name>/force-model</command-name>\n<command-args>qwen/qwen3.6-35b-a3b</command-args>"},
+					map[string]any{"type": "text", "text": "/force-model qwen/qwen3.6-35b-a3b"},
+				},
+			},
+		},
+		"max_tokens": 1024,
+	})
+	env, err := translate.ParseAnthropic(body)
+	require.NoError(t, err)
+
+	res, found := env.ExtractForceModelCommand()
+	require.True(t, found, "directive in a non-first text block must still be recognized")
+	assert.Equal(t, "qwen/qwen3.6-35b-a3b", res.Model)
+
+	// The directive block should be empty (or stripped) after extraction.
+	raw, _ := env.PrepareAnthropic(nil, translate.EmitOptions{TargetModel: "claude-sonnet-4-6"})
+	var got map[string]any
+	require.NoError(t, json.Unmarshal(raw.Body, &got))
+	msgs, _ := got["messages"].([]any)
+	last, _ := msgs[len(msgs)-1].(map[string]any)
+	blocks, _ := last["content"].([]any)
+	require.Len(t, blocks, 2)
+	second, _ := blocks[1].(map[string]any)
+	assert.Equal(t, "", second["text"], "the directive-bearing text block must be stripped")
+}
+
 func TestExtractForceModelCommand_NoUserMessage(t *testing.T) {
 	body := mustMarshalJSON(t, map[string]any{
 		"model": "claude-sonnet-4-6",


### PR DESCRIPTION
## Summary

`/force-model` was silently falling through to upstream when Claude Code split the user turn into multiple text blocks. The parser only inspected the first text block, so payloads where CC injected `<command-name>`/`<command-args>` into block 0 and the typed directive landed in block 1 missed the extractor and got cluster-routed (and billed) like a normal turn.

Fix: scan every text block in the last user message; strip whichever one contains the directive.

## Repro (before fix)

```
curl -X POST :8080/v1/messages -d '{"model":"claude-opus-4-7","max_tokens":256,"messages":[{"role":"user","content":[
  {"type":"text","text":"<command-message>...</command-message>\n<command-name>/force-model</command-name>\n<command-args>qwen/qwen3.6-35b-a3b</command-args>"},
  {"type":"text","text":"/force-model qwen/qwen3.6-35b-a3b"}
]}]}'
```

Before: routes through cluster scorer → bedrock qwen, ~1.4s, 46 input tokens billed.
After: synthetic `force-model applied` ack, 0 upstream tokens, no inference.

## Test plan

- [x] New `TestExtractForceModelCommand_ArrayContentMultipleTextBlocks` covers the multi-block CC payload
- [x] Existing single-string and single-block array tests still pass (`go test ./internal/translate/ -run ForceModel`)
- [x] Local docker rebuild + curl repro confirms synthetic short-circuit

🤖 Generated with [Claude Code](https://claude.com/claude-code)