### PR TITLE
router: loop detector hardening, canonical force-model, drop mimo-v2.5 base

### DIFF
--- a/install/cc-statusline.sh
+++ b/install/cc-statusline.sh
@@ -174,7 +174,6 @@ prices='{
     "qwen/qwen3-next-80b-a3b-instruct": 0.00015,
     "qwen/qwen3.5-flash-02-23":         0.00005,
     "qwen/qwen3.6-35b-a3b":             0.00015,
-    "xiaomi/mimo-v2.5":                 0.0004,
     "xiaomi/mimo-v2.5-pro":             0.001,
     "z-ai/glm-5":                       0.0006
   },
@@ -224,7 +223,6 @@ prices='{
     "qwen/qwen3-next-80b-a3b-instruct": 0.0012,
     "qwen/qwen3.5-flash-02-23":         0.00015,
     "qwen/qwen3.6-35b-a3b":             0.00095,
-    "xiaomi/mimo-v2.5":                 0.002,
     "xiaomi/mimo-v2.5-pro":             0.003,
     "z-ai/glm-5":                       0.00208
   }

--- a/install/install.sh
+++ b/install/install.sh
@@ -1323,7 +1323,6 @@ prices='{
     "qwen/qwen3-next-80b-a3b-instruct": 0.00015,
     "qwen/qwen3.5-flash-02-23":         0.00005,
     "qwen/qwen3.6-35b-a3b":             0.00015,
-    "xiaomi/mimo-v2.5":                 0.0004,
     "xiaomi/mimo-v2.5-pro":             0.001,
     "z-ai/glm-5":                       0.0006
   },
@@ -1373,7 +1372,6 @@ prices='{
     "qwen/qwen3-next-80b-a3b-instruct": 0.0012,
     "qwen/qwen3.5-flash-02-23":         0.00015,
     "qwen/qwen3.6-35b-a3b":             0.00095,
-    "xiaomi/mimo-v2.5":                 0.002,
     "xiaomi/mimo-v2.5-pro":             0.003,
     "z-ai/glm-5":                       0.00208
   }

--- a/internal/proxy/force_model.go
+++ b/internal/proxy/force_model.go
@@ -18,26 +18,54 @@ import (
 	"github.com/google/uuid"
 )
 
-// inferProviderForModel returns the provider name for a given model identifier
-// using well-known naming conventions. Falls back to Anthropic for unrecognized
-// models so the forced pin is routable; the upstream call will 400 if wrong,
-// surfacing the mistyped model name to the user.
-func inferProviderForModel(model string) string {
+// resolveForceModel maps a user-typed model identifier to its canonical
+// catalog ID and primary provider binding. The catalog is the source of
+// truth — heuristics are only a fallback for models not yet listed there.
+//
+// Resolution order:
+//  1. Exact match against `catalog.ByID` (the input is already canonical).
+//  2. Suffix match: scan the catalog for any model whose ID ends with
+//     "/" + input. Lets users type bare names like `qwen3-235b-a22b-2507`
+//     and have the pin route to `qwen/qwen3-235b-a22b-2507` on its real
+//     binding (bedrock, in this case) instead of misclassifying it as
+//     Anthropic.
+//  3. Naming heuristic for slash-prefixed IDs not in the catalog (e.g. a
+//     user pinning a bare OpenRouter model we haven't curated yet).
+//  4. Final fallback for well-known proprietary prefixes.
+//
+// Returns the canonical ID (possibly different from input) and the
+// provider name to attach to the session pin.
+func resolveForceModel(model string) (canonicalID, provider string) {
+	if m, ok := catalog.ByID(model); ok && len(m.Providers) > 0 {
+		return m.ID, m.Providers[0].Provider
+	}
+	if !strings.Contains(model, "/") {
+		suffix := "/" + model
+		var matched catalog.Model
+		var matches int
+		for _, m := range catalog.Models {
+			if strings.HasSuffix(m.ID, suffix) {
+				matched = m
+				matches++
+			}
+		}
+		if matches == 1 && len(matched.Providers) > 0 {
+			return matched.ID, matched.Providers[0].Provider
+		}
+	}
 	switch {
 	case strings.HasPrefix(model, "claude-"):
-		return providers.ProviderAnthropic
+		return model, providers.ProviderAnthropic
 	case strings.HasPrefix(model, "gpt-"),
 		model == "o1", model == "o3", model == "o1-pro", model == "o3-pro",
 		strings.HasPrefix(model, "o1-"), strings.HasPrefix(model, "o3-"), strings.HasPrefix(model, "o4-"):
-		return providers.ProviderOpenAI
+		return model, providers.ProviderOpenAI
 	case strings.HasPrefix(model, "gemini-"):
-		return providers.ProviderGoogle
+		return model, providers.ProviderGoogle
 	case strings.Contains(model, "/"):
-		// Slash-prefixed IDs (deepseek/deepseek-v4-pro, qwen/qwen3-*, etc.)
-		// are OpenRouter-namespaced.
-		return providers.ProviderOpenRouter
+		return model, providers.ProviderOpenRouter
 	default:
-		return providers.ProviderAnthropic
+		return model, providers.ProviderAnthropic
 	}
 }
 
@@ -105,13 +133,13 @@ func (s *Service) handleForceModelCommand(
 			"role", role,
 		)
 	} else {
-		provider := inferProviderForModel(cmd.Model)
+		canonicalModel, provider := resolveForceModel(cmd.Model)
 		forced := sessionpin.Pin{
 			SessionKey:     sessionKey,
 			Role:           role,
 			InstallationID: installationID,
 			Provider:       provider,
-			Model:          cmd.Model,
+			Model:          canonicalModel,
 			Reason:         translate.ReasonUserForceModel,
 			TurnCount:      1,
 			PinnedUntil:    time.Now().Add(pinSessionTTL),
@@ -125,12 +153,13 @@ func (s *Service) handleForceModelCommand(
 		if s.pinCache != nil {
 			s.pinCache.Add(pinCacheKey, forced)
 		}
-		msg = fmt.Sprintf("✦ **Weave Router** → force-model applied: %s (%s) · use /unforce-model to clear\n\n", cmd.Model, provider)
+		msg = fmt.Sprintf("✦ **Weave Router** → force-model applied: %s (%s) · use /unforce-model to clear\n\n", canonicalModel, provider)
 		if env.SourceFormat() == translate.FormatOpenAI {
-			msg = fmt.Sprintf("Weave Router: force-model applied: %s (%s). Use /unforce-model to clear.", cmd.Model, provider)
+			msg = fmt.Sprintf("Weave Router: force-model applied: %s (%s). Use /unforce-model to clear.", canonicalModel, provider)
 		}
 		log.Debug("/force-model: session pin set",
-			"model", cmd.Model,
+			"input_model", cmd.Model,
+			"canonical_model", canonicalModel,
 			"provider", provider,
 			"session_key_hex", fmt.Sprintf("%x", sessionKey),
 			"role", role,

--- a/internal/proxy/force_model_test.go
+++ b/internal/proxy/force_model_test.go
@@ -8,33 +8,71 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestInferProviderForModel(t *testing.T) {
+func TestResolveForceModel(t *testing.T) {
 	tests := []struct {
-		model    string
-		expected string
+		name         string
+		input        string
+		wantID       string
+		wantProvider string
 	}{
-		{"claude-opus-4-7", providers.ProviderAnthropic},
-		{"claude-sonnet-4-6", providers.ProviderAnthropic},
-		{"claude-haiku-4-5", providers.ProviderAnthropic},
-		{"gpt-5", providers.ProviderOpenAI},
-		{"gpt-4o", providers.ProviderOpenAI},
-		{"o1", providers.ProviderOpenAI},
-		{"o3", providers.ProviderOpenAI},
-		{"o3-mini", providers.ProviderOpenAI},
-		{"o4-mini", providers.ProviderOpenAI},
-		{"gemini-2.5-pro", providers.ProviderGoogle},
-		{"gemini-3.1-flash-lite-preview", providers.ProviderGoogle},
-		{"deepseek/deepseek-v4-pro", providers.ProviderOpenRouter},
-		{"qwen/qwen3-235b-a22b-2507", providers.ProviderOpenRouter},
-		{"mistral/mistral-small-2603", providers.ProviderOpenRouter},
-		// Unrecognized model falls back to Anthropic.
-		{"unknown-model-xyz", providers.ProviderAnthropic},
+		// Catalog matches: provider comes from the primary binding, even
+		// when the model name doesn't follow the bare-prefix heuristic.
+		{
+			name:         "catalog anthropic",
+			input:        "claude-opus-4-7",
+			wantID:       "claude-opus-4-7",
+			wantProvider: providers.ProviderAnthropic,
+		},
+		{
+			name:         "catalog google",
+			input:        "gemini-3.1-flash-lite-preview",
+			wantID:       "gemini-3.1-flash-lite-preview",
+			wantProvider: providers.ProviderGoogle,
+		},
+		{
+			name:         "catalog bedrock — slash form",
+			input:        "qwen/qwen3-235b-a22b-2507",
+			wantID:       "qwen/qwen3-235b-a22b-2507",
+			wantProvider: providers.ProviderBedrock,
+		},
+		{
+			name:         "catalog bedrock — bare suffix match",
+			input:        "qwen3-235b-a22b-2507",
+			wantID:       "qwen/qwen3-235b-a22b-2507",
+			wantProvider: providers.ProviderBedrock,
+		},
+		// Heuristic fallback for models not in the catalog.
+		{
+			name:         "heuristic openai — gpt-5 not in v0.54 catalog",
+			input:        "gpt-5",
+			wantID:       "gpt-5",
+			wantProvider: providers.ProviderOpenAI,
+		},
+		{
+			name:         "heuristic openai — o3",
+			input:        "o3",
+			wantID:       "o3",
+			wantProvider: providers.ProviderOpenAI,
+		},
+		{
+			name:         "heuristic openrouter — unknown slash model",
+			input:        "mistral/mistral-small-2603",
+			wantID:       "mistral/mistral-small-2603",
+			wantProvider: providers.ProviderOpenRouter,
+		},
+		{
+			name:         "heuristic anthropic — unknown bareword",
+			input:        "totally-not-a-model",
+			wantID:       "totally-not-a-model",
+			wantProvider: providers.ProviderAnthropic,
+		},
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.model, func(t *testing.T) {
-			got := inferProviderForModel(tt.model)
-			assert.Equal(t, tt.expected, got)
+		t.Run(tt.name, func(t *testing.T) {
+			gotID, gotProvider := resolveForceModel(tt.input)
+			assert.Equal(t, tt.wantID, gotID, "canonical id")
+			assert.Equal(t, tt.wantProvider, gotProvider, "provider")
 		})
 	}
 }

--- a/internal/proxy/loop_detection.go
+++ b/internal/proxy/loop_detection.go
@@ -48,6 +48,18 @@ func detectToolCallLoop(env *translate.RequestEnvelope) (looped bool, sig transl
 		counts[key]++
 		keys[key] = s
 		if counts[key] >= loopDetectionMaxRepeats {
+			// Dump the full ordered window so we can tell a real loop
+			// (5× identical args) from a false positive (5 distinct
+			// args that canonicalize-collide). On a true loop every
+			// printed entry will match; on a false positive they'll
+			// look different in this log even though they share a hash.
+			log := observability.Get()
+			args := env.AssistantToolCallArgsPreview(start, 200)
+			log.Info("loop detector window dump",
+				"tool_name", s.Name,
+				"input_hash", s.InputHash,
+				"window_args", args,
+			)
 			return true, s, counts[key]
 		}
 	}

--- a/internal/router/catalog/catalog.go
+++ b/internal/router/catalog/catalog.go
@@ -295,17 +295,12 @@ var Models = []Model{
 	// (median TTFT + 2000/TPS). Provider availability verified against
 	// per-model "API providers" pages and OpenRouter's v1/models API.
 	//
-	// xiaomi/mimo-v2.5 — DeepInfra now hosts the base variant at parity
-	// pricing with OpenRouter ($0.40 in / $2.00 out / $0.08 cached per 1M,
-	// verified 2026-05-22). Moving primary off OpenRouter because OR's
-	// stream:true honoring is provider-dependent (observed non-SSE
-	// responses on the Google-hosted Qwen line). DeepInfra terminates SSE
-	// itself so the AnthropicSSETranslator sees real chunks.
-	{ID: "xiaomi/mimo-v2.5", Tier: TierMid, Providers: []ProviderBinding{
-		{Provider: providers.ProviderDeepInfra, UpstreamID: "XiaomiMiMo/MiMo-V2.5",
-			Price: Pricing{InputUSDPer1M: 0.400, OutputUSDPer1M: 2.000, CacheReadMultiplier: 0.20}},
-		{Provider: providers.ProviderOpenRouter, Price: Pricing{InputUSDPer1M: 0.400, OutputUSDPer1M: 2.000, CacheReadMultiplier: 0.10}},
-	}},
+	// xiaomi/mimo-v2.5 (base) was removed 2026-05-23 after sustained
+	// tool-calling failures in real Claude Code sessions: malformed empty-input
+	// tool_use blocks, hallucinated tool names, and same-tool same-args
+	// re-issue loops on weak agent prompts. Matches public reports against
+	// OpenCode (#24095) and Crush (#1699). The pro variant is kept — slower
+	// but doesn't exhibit the same instability in our sweep.
 	{ID: "xiaomi/mimo-v2.5-pro", Tier: TierHigh, Providers: []ProviderBinding{
 		{Provider: providers.ProviderDeepInfra, UpstreamID: "XiaomiMiMo/MiMo-V2.5-Pro",
 			Price: Pricing{InputUSDPer1M: 1.000, OutputUSDPer1M: 3.000}},

--- a/internal/router/cluster/artifacts/v0.54/model_registry.json
+++ b/internal/router/cluster/artifacts/v0.54/model_registry.json
@@ -22,7 +22,6 @@
     {"model": "deepseek/deepseek-v4-pro",         "provider": "fireworks",  "bench_column": "routerarena_deepseek/deepseek-v4-pro",         "direct_label": "routerarena"},
     {"model": "moonshotai/kimi-k2.6",             "provider": "fireworks",  "bench_column": "routerarena_moonshotai/kimi-k2.6",             "direct_label": "routerarena"},
 
-    {"model": "xiaomi/mimo-v2.5",                 "provider": "openrouter", "bench_column": "routerarena_xiaomi/mimo-v2.5",                 "direct_label": "aa"},
     {"model": "xiaomi/mimo-v2.5-pro",             "provider": "deepinfra",  "bench_column": "routerarena_xiaomi/mimo-v2.5-pro",             "direct_label": "aa"},
     {"model": "qwen/qwen3.6-35b-a3b",             "provider": "deepinfra",  "bench_column": "routerarena_qwen/qwen3.6-35b-a3b",             "direct_label": "aa"},
     {"model": "minimax/minimax-m2.7",             "provider": "fireworks",  "bench_column": "routerarena_minimax/minimax-m2.7",             "direct_label": "aa"},

--- a/internal/router/cluster/artifacts/v0.54/rankings.json
+++ b/internal/router/cluster/artifacts/v0.54/rankings.json
@@ -38,7 +38,6 @@
       "qwen/qwen3-coder-next": 0.0007999999999999999,
       "qwen/qwen3-next-80b-a3b-instruct": 0.00045,
       "qwen/qwen3.6-35b-a3b": 0.0003875,
-      "xiaomi/mimo-v2.5": 0.0009,
       "xiaomi/mimo-v2.5-pro": 0.00175,
       "z-ai/glm-5": 0.00112
     },
@@ -85,7 +84,6 @@
       "qwen/qwen3-coder-next": 0.35252528915510345,
       "qwen/qwen3-next-80b-a3b-instruct": 0.37593978545138135,
       "qwen/qwen3.6-35b-a3b": 0.5704998158649766,
-      "xiaomi/mimo-v2.5": 0.699996555801556,
       "xiaomi/mimo-v2.5-pro": 0.7822343185810811,
       "z-ai/glm-5": 0.8936817261928024
     },
@@ -106,7 +104,6 @@
       "qwen/qwen3-coder-next": 0.34837390018245223,
       "qwen/qwen3-next-80b-a3b-instruct": 0.42240257260235514,
       "qwen/qwen3.6-35b-a3b": 0.4905244729395958,
-      "xiaomi/mimo-v2.5": 0.5105737292073746,
       "xiaomi/mimo-v2.5-pro": 0.5310162250661231,
       "z-ai/glm-5": 0.7692704909670776
     },
@@ -127,7 +124,6 @@
       "qwen/qwen3-coder-next": 0.6697979924477476,
       "qwen/qwen3-next-80b-a3b-instruct": 0.29527455009899717,
       "qwen/qwen3.6-35b-a3b": 0.97352930032908,
-      "xiaomi/mimo-v2.5": 0.8841040626651673,
       "xiaomi/mimo-v2.5-pro": 0.898422057660986,
       "z-ai/glm-5": 0.8543263834343885
     },
@@ -148,7 +144,6 @@
       "qwen/qwen3-coder-next": 0.582863139973623,
       "qwen/qwen3-next-80b-a3b-instruct": 0.5688388326478295,
       "qwen/qwen3.6-35b-a3b": 0.4047185691810727,
-      "xiaomi/mimo-v2.5": 0.7579312816585422,
       "xiaomi/mimo-v2.5-pro": 0.7577365907431335,
       "z-ai/glm-5": 0.8130924993515677
     },
@@ -169,7 +164,6 @@
       "qwen/qwen3-coder-next": 0.27988256777697157,
       "qwen/qwen3-next-80b-a3b-instruct": 0.3369767523674063,
       "qwen/qwen3.6-35b-a3b": 0.5218330264405713,
-      "xiaomi/mimo-v2.5": 0.46502448100912075,
       "xiaomi/mimo-v2.5-pro": 0.4884898664807283,
       "z-ai/glm-5": 0.49126319254996126
     },
@@ -190,7 +184,6 @@
       "qwen/qwen3-coder-next": 0.7539219654546686,
       "qwen/qwen3-next-80b-a3b-instruct": 0.29527455009899717,
       "qwen/qwen3.6-35b-a3b": 0.9847013088540844,
-      "xiaomi/mimo-v2.5": 0.922141674256954,
       "xiaomi/mimo-v2.5-pro": 0.9188632524122177,
       "z-ai/glm-5": 0.9727426939902845
     },
@@ -211,7 +204,6 @@
       "qwen/qwen3-coder-next": 0.37867376001439856,
       "qwen/qwen3-next-80b-a3b-instruct": 0.29527455009899717,
       "qwen/qwen3.6-35b-a3b": 0.5029869621889194,
-      "xiaomi/mimo-v2.5": 0.6486914974937175,
       "xiaomi/mimo-v2.5-pro": 0.7204654322406285,
       "z-ai/glm-5": 0.784582814779983
     },
@@ -232,7 +224,6 @@
       "qwen/qwen3-coder-next": 0.541050729021217,
       "qwen/qwen3-next-80b-a3b-instruct": 0.5291476257097094,
       "qwen/qwen3.6-35b-a3b": 0.6573975646056172,
-      "xiaomi/mimo-v2.5": 0.7059787724371869,
       "xiaomi/mimo-v2.5-pro": 0.6887643391203133,
       "z-ai/glm-5": 0.8038528117526952
     },
@@ -253,7 +244,6 @@
       "qwen/qwen3-coder-next": 0.6208680566707612,
       "qwen/qwen3-next-80b-a3b-instruct": 0.7168949889507442,
       "qwen/qwen3.6-35b-a3b": 0.7204080508288612,
-      "xiaomi/mimo-v2.5": 0.9164574285193309,
       "xiaomi/mimo-v2.5-pro": 0.626004353605694,
       "z-ai/glm-5": 0.6406989233955681
     },
@@ -274,7 +264,6 @@
       "qwen/qwen3-coder-next": 0.5478865237315088,
       "qwen/qwen3-next-80b-a3b-instruct": 0.5134326445417199,
       "qwen/qwen3.6-35b-a3b": 0.4988053973423508,
-      "xiaomi/mimo-v2.5": 0.6080819469631238,
       "xiaomi/mimo-v2.5-pro": 0.6449771556860636,
       "z-ai/glm-5": 0.27274269399028456
     },
@@ -295,7 +284,6 @@
       "qwen/qwen3-coder-next": 0.27988256777697157,
       "qwen/qwen3-next-80b-a3b-instruct": 0.9914629330935297,
       "qwen/qwen3.6-35b-a3b": 0.7327111086864792,
-      "xiaomi/mimo-v2.5": 0.8490631472399417,
       "xiaomi/mimo-v2.5-pro": 0.8535239030044864,
       "z-ai/glm-5": 0.895228933823757
     },
@@ -316,7 +304,6 @@
       "qwen/qwen3-coder-next": 0.6970459156248071,
       "qwen/qwen3-next-80b-a3b-instruct": 0.8054432885252819,
       "qwen/qwen3.6-35b-a3b": 0.8381628495835487,
-      "xiaomi/mimo-v2.5": 0.8619236269175174,
       "xiaomi/mimo-v2.5-pro": 0.8473606727202195,
       "z-ai/glm-5": 0.9227715961664212
     },
@@ -337,7 +324,6 @@
       "qwen/qwen3-coder-next": 0.27988256777697157,
       "qwen/qwen3-next-80b-a3b-instruct": 0.41417866664250885,
       "qwen/qwen3.6-35b-a3b": 0.7003028878997436,
-      "xiaomi/mimo-v2.5": 0.636227037441545,
       "xiaomi/mimo-v2.5-pro": 0.6407768659233108,
       "z-ai/glm-5": 0.8121838910160394
     },
@@ -358,7 +344,6 @@
       "qwen/qwen3-coder-next": 0.7110624552158994,
       "qwen/qwen3-next-80b-a3b-instruct": 0.9952745500989971,
       "qwen/qwen3.6-35b-a3b": 0.8856227817389298,
-      "xiaomi/mimo-v2.5": 0.7972434054420161,
       "xiaomi/mimo-v2.5-pro": 0.7873941505851532,
       "z-ai/glm-5": 0.8469062576875247
     },
@@ -379,7 +364,6 @@
       "qwen/qwen3-coder-next": 0.6203288270666856,
       "qwen/qwen3-next-80b-a3b-instruct": 0.6112087595925136,
       "qwen/qwen3.6-35b-a3b": 0.5090673888168192,
-      "xiaomi/mimo-v2.5": 0.6452911383478361,
       "xiaomi/mimo-v2.5-pro": 0.6327603982195331,
       "z-ai/glm-5": 0.5363457193921402
     },
@@ -400,7 +384,6 @@
       "qwen/qwen3-coder-next": 0.42207524867028084,
       "qwen/qwen3-next-80b-a3b-instruct": 0.3675373524949058,
       "qwen/qwen3.6-35b-a3b": 0.5809110808330457,
-      "xiaomi/mimo-v2.5": 0.5595095649364059,
       "xiaomi/mimo-v2.5-pro": 0.6144709064654685,
       "z-ai/glm-5": 0.7981470614378917
     }

--- a/internal/translate/loop_detection.go
+++ b/internal/translate/loop_detection.go
@@ -16,6 +16,99 @@ type ToolCallSig struct {
 	InputHash string
 }
 
+// AssistantToolCallArgsPreview returns short string previews of the raw
+// argument JSON for each assistant tool call, in order, starting at offset.
+// Used by the proxy's loop detector to log what was actually in the window
+// when a loop trips, so a real loop (5 identical args) can be told apart
+// from a false positive (5 distinct args sharing a canonicalize hash) at a
+// glance in the logs. Names are included so multi-tool windows are readable.
+func (e *RequestEnvelope) AssistantToolCallArgsPreview(offset, maxLen int) []string {
+	switch e.format {
+	case FormatAnthropic:
+		return anthropicAssistantToolCallArgsPreview(e.body, offset, maxLen)
+	case FormatOpenAI:
+		return openAIAssistantToolCallArgsPreview(e.body, offset, maxLen)
+	default:
+		return nil
+	}
+}
+
+func anthropicAssistantToolCallArgsPreview(body []byte, offset, maxLen int) []string {
+	var out []string
+	idx := 0
+	msgs := gjson.GetBytes(body, "messages")
+	if !msgs.IsArray() {
+		return nil
+	}
+	msgs.ForEach(func(_, msg gjson.Result) bool {
+		if msg.Get("role").String() != "assistant" {
+			return true
+		}
+		content := msg.Get("content")
+		if !content.IsArray() {
+			return true
+		}
+		content.ForEach(func(_, block gjson.Result) bool {
+			if block.Get("type").String() != "tool_use" {
+				return true
+			}
+			name := block.Get("name").String()
+			if name == "" {
+				return true
+			}
+			if idx >= offset {
+				preview := block.Get("input").Raw
+				if len(preview) > maxLen {
+					preview = preview[:maxLen] + "…"
+				}
+				out = append(out, name+":"+preview)
+			}
+			idx++
+			return true
+		})
+		return true
+	})
+	return out
+}
+
+func openAIAssistantToolCallArgsPreview(body []byte, offset, maxLen int) []string {
+	var out []string
+	idx := 0
+	msgs := gjson.GetBytes(body, "messages")
+	if !msgs.IsArray() {
+		return nil
+	}
+	msgs.ForEach(func(_, msg gjson.Result) bool {
+		if msg.Get("role").String() != "assistant" {
+			return true
+		}
+		toolCalls := msg.Get("tool_calls")
+		if !toolCalls.IsArray() {
+			return true
+		}
+		toolCalls.ForEach(func(_, tc gjson.Result) bool {
+			if tc.Get("type").String() != "function" {
+				return true
+			}
+			name := tc.Get("function.name").String()
+			if name == "" {
+				return true
+			}
+			if idx >= offset {
+				preview := tc.Get("function.arguments").String()
+				if len(preview) > maxLen {
+					preview = preview[:maxLen] + "…"
+				}
+				out = append(out, name+":"+preview)
+			}
+			idx++
+			return true
+		})
+		return true
+	})
+	return out
+}
+
 // AssistantToolCallSignatures returns the ordered list of tool invocations
 // emitted by assistant messages in the request body. Order matches message
 // order, and within a message, content-block order.
@@ -57,8 +150,21 @@ func anthropicAssistantToolCallSigs(body []byte) []ToolCallSig {
 				return true
 			}
 			name := block.Get("name").String()
-			input := block.Get("input").Raw
-			sigs = append(sigs, ToolCallSig{Name: name, InputHash: hashCanonicalJSON(input)})
+			if name == "" {
+				return true
+			}
+			// Skip entries with empty input. Cross-format translation of a
+			// stream-incomplete tool call (OpenAI/openaicompat upstream →
+			// Anthropic inbound) can emit `input:{}` to satisfy the schema.
+			// Claude Code echoes those back in the assistant history; with no
+			// real args every empty-input call collides to the same hash and
+			// 5 of them in a window false-positive trip the loop detector.
+			// Real tool calls always carry at least one argument.
+			input := block.Get("input")
+			if !isMeaningfulInput(input) {
+				return true
+			}
+			sigs = append(sigs, ToolCallSig{Name: name, InputHash: hashCanonicalJSON(input.Raw)})
 			return true
 		})
 		return true
@@ -85,16 +191,62 @@ func openAIAssistantToolCallSigs(body []byte) []ToolCallSig {
 				return true
 			}
 			name := tc.Get("function.name").String()
-			// OpenAI delivers arguments as a JSON-encoded string. Hash the
-			// canonical form so semantically-identical args with different
-			// whitespace still collide.
+			if name == "" {
+				return true
+			}
+			// OpenAI delivers arguments as a JSON-encoded string. Skip
+			// empty/object-empty values for the same reason the Anthropic
+			// path does — stream-incomplete tool_calls produce hash
+			// collisions that aren't real loops.
 			argsRaw := tc.Get("function.arguments").String()
+			if !isMeaningfulInputRaw(argsRaw) {
+				return true
+			}
 			sigs = append(sigs, ToolCallSig{Name: name, InputHash: hashCanonicalJSON(argsRaw)})
 			return true
 		})
 		return true
 	})
 	return sigs
+}
+
+// isMeaningfulInput reports whether a tool_use input field carries any real
+// arguments. Missing, null, empty-string, and empty-object inputs are
+// rejected — they're artifacts of stream-incomplete tool calls bouncing
+// through cross-format translation, not real model invocations.
+func isMeaningfulInput(r gjson.Result) bool {
+	if !r.Exists() {
+		return false
+	}
+	if r.IsObject() {
+		empty := true
+		r.ForEach(func(_, _ gjson.Result) bool {
+			empty = false
+			return false
+		})
+		return !empty
+	}
+	return isMeaningfulInputRaw(r.Raw)
+}
+
+// isMeaningfulInputRaw is the string-input variant (OpenAI tool_calls deliver
+// arguments as a JSON-encoded string). Treats "", "{}", and "null" as empty.
+func isMeaningfulInputRaw(raw string) bool {
+	switch raw {
+	case "", "{}", "null":
+		return false
+	}
+	parsed := gjson.Parse(raw)
+	if !parsed.IsObject() {
+		// Any non-empty scalar / array counts as meaningful.
+		return raw != ""
+	}
+	empty := true
+	parsed.ForEach(func(_, _ gjson.Result) bool {
+		empty = false
+		return false
+	})
+	return !empty
 }
 
 // hashCanonicalJSON returns a stable hex sha256 of the canonical form of a

--- a/internal/translate/loop_detection_test.go
+++ b/internal/translate/loop_detection_test.go
@@ -41,6 +41,87 @@ func TestAssistantToolCallSignatures_Anthropic(t *testing.T) {
 	assert.NotEqual(t, sigs[1].InputHash, sigs[2].InputHash, "different tool args must produce different hash")
 }
 
+func TestAssistantToolCallSignatures_SkipsEmptyNameEntries(t *testing.T) {
+	// Some upstreams emit tool_use blocks without a `name` field (mid-stream
+	// snapshots, cross-format translation artifacts). Counting them collapses
+	// every nameless entry to the same map key and false-positive trips the
+	// loop detector after 5 distinct real tool calls. They must be ignored.
+	body := mustMarshalJSON(t, map[string]any{
+		"model": "claude-sonnet-4-6",
+		"messages": []any{
+			map[string]any{"role": "assistant", "content": []any{
+				map[string]any{"type": "tool_use", "id": "1", "name": "Read", "input": map[string]any{"path": "a"}},
+				map[string]any{"type": "tool_use", "id": "2", "input": map[string]any{}},
+				map[string]any{"type": "tool_use", "id": "3", "name": "", "input": map[string]any{}},
+				map[string]any{"type": "tool_use", "id": "4", "name": "Bash", "input": map[string]any{"command": "ls"}},
+			}},
+		},
+		"max_tokens": 256,
+	})
+	env, err := translate.ParseAnthropic(body)
+	require.NoError(t, err)
+
+	sigs := env.AssistantToolCallSignatures()
+	require.Len(t, sigs, 2, "nameless tool_use entries must be filtered")
+	assert.Equal(t, "Read", sigs[0].Name)
+	assert.Equal(t, "Bash", sigs[1].Name)
+}
+
+func TestAssistantToolCallSignatures_SkipsEmptyInputEntries(t *testing.T) {
+	// Cross-format translation of stream-incomplete tool calls (deepinfra /
+	// openaicompat upstream → Anthropic inbound) emits `input:{}` to satisfy
+	// the schema. Claude Code echoes those back in the assistant history.
+	// Without filtering, 5 of them all hash to the same empty-canonical key
+	// and false-positive trip the loop detector even when the surrounding
+	// real Read calls each have distinct file paths. This is the bug
+	// observed against xiaomi/mimo-v2.5 on deepinfra in dev.
+	body := mustMarshalJSON(t, map[string]any{
+		"model": "claude-sonnet-4-6",
+		"messages": []any{
+			map[string]any{"role": "assistant", "content": []any{
+				map[string]any{"type": "tool_use", "id": "1", "name": "Read", "input": map[string]any{"file_path": "/a"}},
+				map[string]any{"type": "tool_use", "id": "2", "name": "Read", "input": map[string]any{}},
+				map[string]any{"type": "tool_use", "id": "3", "name": "Read", "input": map[string]any{"file_path": "/b"}},
+				map[string]any{"type": "tool_use", "id": "4", "name": "Read", "input": map[string]any{}},
+				map[string]any{"type": "tool_use", "id": "5", "name": "Read", "input": map[string]any{"file_path": "/c"}},
+				map[string]any{"type": "tool_use", "id": "6", "name": "Read", "input": map[string]any{}},
+				map[string]any{"type": "tool_use", "id": "7", "name": "Read", "input": map[string]any{}},
+			}},
+		},
+		"max_tokens": 256,
+	})
+	env, err := translate.ParseAnthropic(body)
+	require.NoError(t, err)
+
+	sigs := env.AssistantToolCallSignatures()
+	require.Len(t, sigs, 3, "empty-input tool_use entries must be filtered")
+	// The three real Reads have distinct file_paths, so their hashes differ.
+	assert.NotEqual(t, sigs[0].InputHash, sigs[1].InputHash)
+	assert.NotEqual(t, sigs[1].InputHash, sigs[2].InputHash)
+}
+
+func TestAssistantToolCallSignatures_OpenAI_SkipsEmptyNameEntries(t *testing.T) {
+	body := mustMarshalJSON(t, map[string]any{
+		"model": "gpt-4o",
+		"messages": []any{
+			map[string]any{"role": "assistant", "tool_calls": []any{
+				map[string]any{"id": "1", "type": "function", "function": map[string]any{"name": "ls", "arguments": `{"path":"/a"}`}},
+				map[string]any{"id": "2", "type": "function", "function": map[string]any{"arguments": `{"path":"/b"}`}}, // missing name
+				map[string]any{"id": "3", "type": "function", "function": map[string]any{"name": "", "arguments": `{"path":"/c"}`}}, // empty name
+				map[string]any{"id": "4", "type": "function", "function": map[string]any{"name": "ls", "arguments": "{}"}},          // empty args
+				map[string]any{"id": "5", "type": "function", "function": map[string]any{"name": "cat", "arguments": `{"file":"/d"}`}},
+			}},
+		},
+	})
+	env, err := translate.ParseOpenAI(body)
+	require.NoError(t, err)
+
+	sigs := env.AssistantToolCallSignatures()
+	require.Len(t, sigs, 2, "missing-name, empty-name, and empty-args entries all filtered")
+	assert.Equal(t, "ls", sigs[0].Name)
+	assert.Equal(t, "cat", sigs[1].Name)
+}
+
 func TestAssistantToolCallSignatures_Anthropic_KeyOrderInvariant(t *testing.T) {
 	bodyA := mustMarshalJSON(t, map[string]any{
 		"model": "claude-sonnet-4-6",

--- a/internal/translate/loop_detection_test.go
+++ b/internal/translate/loop_detection_test.go
@@ -106,7 +106,7 @@ func TestAssistantToolCallSignatures_OpenAI_SkipsEmptyNameEntries(t *testing.T) 
 		"messages": []any{
 			map[string]any{"role": "assistant", "tool_calls": []any{
 				map[string]any{"id": "1", "type": "function", "function": map[string]any{"name": "ls", "arguments": `{"path":"/a"}`}},
-				map[string]any{"id": "2", "type": "function", "function": map[string]any{"arguments": `{"path":"/b"}`}}, // missing name
+				map[string]any{"id": "2", "type": "function", "function": map[string]any{"arguments": `{"path":"/b"}`}},             // missing name
 				map[string]any{"id": "3", "type": "function", "function": map[string]any{"name": "", "arguments": `{"path":"/c"}`}}, // empty name
 				map[string]any{"id": "4", "type": "function", "function": map[string]any{"name": "ls", "arguments": "{}"}},          // empty args
 				map[string]any{"id": "5", "type": "function", "function": map[string]any{"name": "cat", "arguments": `{"file":"/d"}`}},

--- a/internal/translate/provider_hint_test.go
+++ b/internal/translate/provider_hint_test.go
@@ -136,7 +136,7 @@ func TestPrepareOpenAI_DisablesReasoningForMoonshotAndXiaomi(t *testing.T) {
 	// generation running to the output cap. Disabling reasoning at the
 	// OpenRouter layer prevents that runaway. See hermes-agent#24534 and
 	// vllm#39056 for the upstream parser bugs that motivate this.
-	cases := []string{"moonshotai/kimi-k2.5", "moonshotai/kimi-k2.6", "xiaomi/mimo-v2.5", "xiaomi/mimo-v2.5-pro"}
+	cases := []string{"moonshotai/kimi-k2.5", "moonshotai/kimi-k2.6", "xiaomi/mimo-v2.5-pro"}
 	for _, model := range cases {
 		t.Run(model, func(t *testing.T) {
 			src := []byte(`{"model":"claude-opus-4-7","messages":[{"role":"user","content":"hi"}],"max_tokens":256}`)


### PR DESCRIPTION
## Summary

Three independent fixes that all surfaced from a dev session against `xiaomi/mimo-v2.5`:

1. **Loop detector: filter empty-name and empty-input tool_use entries.** Cross-format translation of stream-incomplete tool_calls (deepinfra/openaicompat → Anthropic) emits `input:{}` to satisfy schema; Claude Code echoes them back. Five collapse to the same `name+empty_hash` key and false-positive trip the detector. Skip them at extraction time. Also adds a one-shot window dump on trip so future false-positives are diagnosable without re-instrumenting.
2. **Force-model: resolve provider via catalog + canonicalize id.** `/force-model qwen3-235b-a22b-2507` (no slash) used to default to Anthropic and store a broken pin. Now: catalog exact-match → suffix-match → naming heuristic fallback. Acknowledgment and stored pin both use the canonical id (`qwen/qwen3-235b-a22b-2507` on bedrock).
3. **Remove `xiaomi/mimo-v2.5` (base) from registry.** Sustained tool-calling failures in real CC sessions: hallucinated tool names, empty-input tool_use spam, real same-call repeat loops. Matches public reports against OpenCode (#24095) and Crush (#1699). Pro variant stays.

## Repro confirmed in dev

| Scenario | Before | After |
|---|---|---|
| mimo audit task (10 calls, 5 real Reads + 4 `Read:{}` artifacts) | spurious loop-break | runs to completion; only real 5x identical-Read loops trip |
| `/force-model qwen3-235b-a22b-2507` ack | `(anthropic)` — wrong | `qwen/qwen3-235b-a22b-2507 (bedrock)` |
| Boot model count | 19 | 18 (no `xiaomi/mimo-v2.5`) |

## Test plan

- [x] `go test ./...` passes
- [x] New `TestAssistantToolCallSignatures_SkipsEmptyInputEntries` covers the mimo false-positive shape (3 distinct Reads + 4 empty-input Reads → 3 sigs, no collision)
- [x] New `TestResolveForceModel` covers catalog hits (bedrock for qwen 235b slash or bare), heuristic fallbacks, and unknown bareword
- [x] Boot log confirms 18-model catalog without mimo-v2.5 base
- [x] Live curl confirms canonical id + bedrock provider in /force-model ack

🤖 Generated with [Claude Code](https://claude.com/claude-code)