### PR TITLE
router: SSE watchdog + provider failover + tool-use blacklist + Qwen samplers + no-progress detector

### DIFF
--- a/internal/providers/anthropic/client.go
+++ b/internal/providers/anthropic/client.go
@@ -55,6 +55,9 @@ func (c *Client) setAuth(ctx context.Context, upstream *http.Request, inbound *h
 }
 
 func (c *Client) Proxy(ctx context.Context, decision router.Decision, prep providers.PreparedRequest, w http.ResponseWriter, r *http.Request) error {
+	ctx, cancel := context.WithCancelCause(ctx)
+	defer cancel(nil)
+
 	upstream, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/v1/messages", bytes.NewReader(prep.Body))
 	if err != nil {
 		return fmt.Errorf("build upstream request: %w", err)
@@ -107,7 +110,7 @@ func (c *Client) Proxy(ctx context.Context, decision router.Decision, prep provi
 		return &providers.UpstreamStatusError{Status: resp.StatusCode}
 	}
 
-	return httputil.StreamBody(resp.Body, resp.StatusCode, w, t)
+	return httputil.StreamBody(ctx, cancel, httputil.DefaultSSEIdleTimeout, resp.Body, resp.StatusCode, w, t)
 }
 
 func (c *Client) Passthrough(ctx context.Context, prep providers.PreparedRequest, w http.ResponseWriter, r *http.Request) error {

--- a/internal/providers/google/client.go
+++ b/internal/providers/google/client.go
@@ -38,6 +38,9 @@ func NewClient(apiKey, baseURL string) *Client {
 }
 
 func (c *Client) Proxy(ctx context.Context, decision router.Decision, prep providers.PreparedRequest, w http.ResponseWriter, r *http.Request) error {
+	ctx, cancel := context.WithCancelCause(ctx)
+	defer cancel(nil)
+
 	upstream, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/chat/completions", bytes.NewReader(prep.Body))
 	if err != nil {
 		return fmt.Errorf("build upstream request: %w", err)
@@ -66,7 +69,7 @@ func (c *Client) Proxy(ctx context.Context, decision router.Decision, prep provi
 
 	providers.CopyUpstreamHeaders(w, resp)
 	w.WriteHeader(resp.StatusCode)
-	return httputil.StreamBody(resp.Body, resp.StatusCode, w, t)
+	return httputil.StreamBody(ctx, cancel, httputil.DefaultSSEIdleTimeout, resp.Body, resp.StatusCode, w, t)
 }
 
 // Passthrough strips the inbound /v1 prefix to avoid double-prefixing with DefaultBaseURL.

--- a/internal/providers/google/native_client.go
+++ b/internal/providers/google/native_client.go
@@ -43,6 +43,9 @@ func NewNativeClient(apiKey, baseURL string) *NativeClient {
 
 // Proxy posts to :generateContent or :streamGenerateContent?alt=sse depending on the Gemini stream hint header.
 func (c *NativeClient) Proxy(ctx context.Context, decision router.Decision, prep providers.PreparedRequest, w http.ResponseWriter, r *http.Request) error {
+	ctx, cancel := context.WithCancelCause(ctx)
+	defer cancel(nil)
+
 	stream := prep.Headers.Get(translate.GeminiStreamHintHeader) == "true"
 	prep.Headers.Del(translate.GeminiStreamHintHeader)
 
@@ -107,7 +110,7 @@ func (c *NativeClient) Proxy(ctx context.Context, decision router.Decision, prep
 		return &providers.UpstreamStatusError{Status: resp.StatusCode}
 	}
 
-	return httputil.StreamBody(resp.Body, resp.StatusCode, w, t)
+	return httputil.StreamBody(ctx, cancel, httputil.DefaultSSEIdleTimeout, resp.Body, resp.StatusCode, w, t)
 }
 
 // Passthrough rewrites inbound /v1/ paths to /v1beta/ for the native API surface.

--- a/internal/providers/httputil/httputil.go
+++ b/internal/providers/httputil/httputil.go
@@ -2,9 +2,15 @@
 package httputil
 
 import (
+	"context"
+	"errors"
 	"io"
 	"net"
 	"net/http"
+	"os"
+	"strconv"
+	"sync"
+	"sync/atomic"
 	"time"
 
 	"workweave/router/internal/observability/otel"
@@ -14,7 +20,42 @@ import (
 // FlushChunk is the read buffer size used by all streaming provider adapters.
 const FlushChunk = 4 * 1024
 
+// ErrUpstreamIdleTimeout is the sentinel cause set on the request context when
+// the SSE inactivity watchdog fires. Provider adapters can check
+// errors.Is(err, httputil.ErrUpstreamIdleTimeout) (or context.Cause(ctx)) to
+// distinguish a real upstream stall from caller-initiated cancellation, and
+// the proxy's failover logic keys on this to retry against the next binding.
+var ErrUpstreamIdleTimeout = errors.New("upstream sse idle timeout")
+
+// DefaultSSEIdleTimeout is the per-read inactivity threshold for streaming
+// upstream responses. AWS NAT Gateway / NLB / VPC-endpoint reapers silently
+// drop idle TCP connections at 350s; a watchdog below that surfaces stalls
+// as a clean error within tens of seconds instead of letting the request
+// hang for the full overall deadline.
+//
+// Tunable via ROUTER_SSE_IDLE_TIMEOUT_SECONDS. Healthy generations stream a
+// chunk at least every few seconds, so 45s of silence is unambiguously a stall.
+var DefaultSSEIdleTimeout = sseIdleTimeoutFromEnv()
+
+func sseIdleTimeoutFromEnv() time.Duration {
+	v := os.Getenv("ROUTER_SSE_IDLE_TIMEOUT_SECONDS")
+	if v == "" {
+		return 45 * time.Second
+	}
+	n, err := strconv.Atoi(v)
+	if err != nil || n <= 0 {
+		return 45 * time.Second
+	}
+	return time.Duration(n) * time.Second
+}
+
 // NewTransport returns a pooled http.Transport sized for sustained traffic to a single upstream host.
+//
+// KeepAlive=30s is the critical setting against AWS NAT-GW / NLB / VPC-endpoint
+// reapers (350s fixed idle): the dialer's TCP keepalives keep the connection
+// live so the zero-byte-stall failure mode can't accumulate at the network layer.
+// ResponseHeaderTimeout=30s only guards time-to-first-byte; per-read inactivity
+// during streaming is enforced by StreamBody's watchdog.
 func NewTransport(dialTimeout, tlsTimeout time.Duration) *http.Transport {
 	return &http.Transport{
 		Proxy: http.ProxyFromEnvironment,
@@ -32,14 +73,60 @@ func NewTransport(dialTimeout, tlsTimeout time.Duration) *http.Transport {
 	}
 }
 
+// StartIdleWatchdog starts a goroutine that cancels ctx with ErrUpstreamIdleTimeout
+// when more than idleTimeout has elapsed without a Mark call. The returned mark
+// function should be invoked on every successful upstream read (or other progress
+// signal). The returned stop function terminates the watchdog goroutine and must
+// be called via defer in the caller's scope.
+//
+// idleTimeout <= 0 or cancel == nil disables the watchdog (no-op mark/stop).
+func StartIdleWatchdog(ctx context.Context, cancel context.CancelCauseFunc, idleTimeout time.Duration) (mark func(), stop func()) {
+	if idleTimeout <= 0 || cancel == nil {
+		return func() {}, func() {}
+	}
+	var lastNS atomic.Int64
+	lastNS.Store(time.Now().UnixNano())
+	done := make(chan struct{})
+	go func() {
+		interval := max(idleTimeout/3, 100*time.Millisecond)
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-done:
+				return
+			case <-ticker.C:
+				if time.Since(time.Unix(0, lastNS.Load())) > idleTimeout {
+					cancel(ErrUpstreamIdleTimeout)
+					return
+				}
+			}
+		}
+	}()
+	return func() { lastNS.Store(time.Now().UnixNano()) },
+		sync.OnceFunc(func() { close(done) })
+}
+
 // StreamBody reads r chunk-by-chunk into w, flushing after each write. Returns
 // UpstreamStatusError when status is non-2xx.
-func StreamBody(r io.Reader, status int, w http.ResponseWriter, t *otel.Timing) error {
+//
+// When idleTimeout > 0 a watchdog goroutine cancels ctx via cancel with
+// ErrUpstreamIdleTimeout if no upstream bytes arrive for idleTimeout. Callers
+// must pass a context wrapped via context.WithCancelCause so the cause survives
+// to the error site. On stall, returns ErrUpstreamIdleTimeout directly so the
+// caller does not need to inspect context.Cause itself.
+func StreamBody(ctx context.Context, cancel context.CancelCauseFunc, idleTimeout time.Duration, r io.Reader, status int, w http.ResponseWriter, t *otel.Timing) error {
+	mark, stop := StartIdleWatchdog(ctx, cancel, idleTimeout)
+	defer stop()
+
 	flusher, _ := w.(http.Flusher)
 	buf := make([]byte, FlushChunk)
 	for {
 		n, readErr := r.Read(buf)
 		if n > 0 {
+			mark()
 			t.StampUpstreamFirstByte()
 			if _, writeErr := w.Write(buf[:n]); writeErr != nil {
 				return writeErr
@@ -56,6 +143,9 @@ func StreamBody(r io.Reader, status int, w http.ResponseWriter, t *otel.Timing) 
 			return nil
 		}
 		if readErr != nil {
+			if cause := context.Cause(ctx); errors.Is(cause, ErrUpstreamIdleTimeout) {
+				return ErrUpstreamIdleTimeout
+			}
 			return readErr
 		}
 	}

--- a/internal/providers/httputil/httputil_test.go
+++ b/internal/providers/httputil/httputil_test.go
@@ -1,0 +1,196 @@
+package httputil
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"workweave/router/internal/observability/otel"
+	"workweave/router/internal/providers"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// pacedReader emits bytes from chunks on a per-chunk delay schedule. A delay of
+// 0 means "stall until ctx cancels" — mirrors how a real net.Conn unblocks Read
+// when its parent http.Request context is canceled.
+type pacedReader struct {
+	ctx    context.Context
+	chunks []string
+	delays []time.Duration
+	i      int
+	closed atomic.Bool
+}
+
+func (p *pacedReader) Read(buf []byte) (int, error) {
+	if p.closed.Load() {
+		return 0, io.EOF
+	}
+	if p.i >= len(p.chunks) {
+		return 0, io.EOF
+	}
+	d := p.delays[p.i]
+	if d == 0 {
+		<-p.ctx.Done()
+		return 0, p.ctx.Err()
+	}
+	select {
+	case <-p.ctx.Done():
+		return 0, p.ctx.Err()
+	case <-time.After(d):
+	}
+	n := copy(buf, p.chunks[p.i])
+	p.i++
+	return n, nil
+}
+
+func TestStreamBody_NoWatchdogPath(t *testing.T) {
+	ctx := context.Background()
+	r := &pacedReader{
+		ctx:    ctx,
+		chunks: []string{"hello ", "world"},
+		delays: []time.Duration{1 * time.Millisecond, 1 * time.Millisecond},
+	}
+	w := httptest.NewRecorder()
+
+	err := StreamBody(ctx, nil, 0, r, 200, w, &otel.Timing{})
+	require.NoError(t, err)
+	assert.Equal(t, "hello world", w.Body.String())
+}
+
+func TestStreamBody_WatchdogDoesNotFireOnLivelyStream(t *testing.T) {
+	ctx, cancel := context.WithCancelCause(context.Background())
+	defer cancel(nil)
+	r := &pacedReader{
+		ctx:    ctx,
+		chunks: []string{"a", "b", "c", "d"},
+		delays: []time.Duration{20 * time.Millisecond, 20 * time.Millisecond, 20 * time.Millisecond, 20 * time.Millisecond},
+	}
+	w := httptest.NewRecorder()
+
+	err := StreamBody(ctx, cancel, 200*time.Millisecond, r, 200, w, &otel.Timing{})
+	require.NoError(t, err)
+	assert.Equal(t, "abcd", w.Body.String())
+}
+
+func TestStreamBody_WatchdogFiresOnStall(t *testing.T) {
+	ctx, cancel := context.WithCancelCause(context.Background())
+	defer cancel(nil)
+	// Emits one chunk then stalls forever — watchdog should fire shortly after
+	// the stall begins. The second chunk is unreachable because delays[1]=0
+	// holds the reader on ctx.Done until the watchdog cancels.
+	r := &pacedReader{
+		ctx:    ctx,
+		chunks: []string{"hello", "unreachable"},
+		delays: []time.Duration{1 * time.Millisecond, 0},
+	}
+	w := httptest.NewRecorder()
+
+	start := time.Now()
+	err := StreamBody(ctx, cancel, 150*time.Millisecond, r, 200, w, &otel.Timing{})
+	elapsed := time.Since(start)
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrUpstreamIdleTimeout)
+	// Generous upper bound (watchdog ticks at idleTimeout/3 = 50ms).
+	assert.Less(t, elapsed, 500*time.Millisecond, "stall should surface well before any deadlock")
+	assert.GreaterOrEqual(t, elapsed, 100*time.Millisecond, "stall should not surface before idleTimeout")
+	assert.Equal(t, "hello", w.Body.String(), "bytes received before the stall must still be flushed")
+}
+
+func TestStreamBody_WatchdogFiresWithZeroPriorBytes(t *testing.T) {
+	ctx, cancel := context.WithCancelCause(context.Background())
+	defer cancel(nil)
+	r := &pacedReader{
+		ctx:    ctx,
+		chunks: []string{"unused"},
+		delays: []time.Duration{0},
+	}
+	w := httptest.NewRecorder()
+
+	err := StreamBody(ctx, cancel, 100*time.Millisecond, r, 200, w, &otel.Timing{})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrUpstreamIdleTimeout)
+}
+
+func TestStreamBody_NonStreamingStatus(t *testing.T) {
+	r := strings.NewReader("upstream error body")
+	w := httptest.NewRecorder()
+	ctx, cancel := context.WithCancelCause(context.Background())
+	defer cancel(nil)
+
+	err := StreamBody(ctx, cancel, 200*time.Millisecond, r, 500, w, &otel.Timing{})
+	var statusErr *providers.UpstreamStatusError
+	require.ErrorAs(t, err, &statusErr)
+	assert.Equal(t, 500, statusErr.Status)
+}
+
+func TestStartIdleWatchdog_NoOpOnZeroTimeout(t *testing.T) {
+	ctx, cancel := context.WithCancelCause(context.Background())
+	defer cancel(nil)
+	mark, stop := StartIdleWatchdog(ctx, cancel, 0)
+	mark()
+	stop()
+	// No assertion — just confirming the calls don't panic and don't deadlock.
+	assert.NoError(t, context.Cause(ctx))
+}
+
+func TestStartIdleWatchdog_FiresOnInactivity(t *testing.T) {
+	ctx, cancel := context.WithCancelCause(context.Background())
+	defer cancel(nil)
+	_, stop := StartIdleWatchdog(ctx, cancel, 80*time.Millisecond)
+	defer stop()
+
+	// Don't call mark — let the watchdog fire.
+	deadline := time.NewTimer(500 * time.Millisecond)
+	defer deadline.Stop()
+	select {
+	case <-ctx.Done():
+	case <-deadline.C:
+		t.Fatal("watchdog never fired")
+	}
+	assert.ErrorIs(t, context.Cause(ctx), ErrUpstreamIdleTimeout)
+}
+
+func TestStartIdleWatchdog_DoesNotFireWhenMarked(t *testing.T) {
+	ctx, cancel := context.WithCancelCause(context.Background())
+	defer cancel(nil)
+	mark, stop := StartIdleWatchdog(ctx, cancel, 100*time.Millisecond)
+	defer stop()
+
+	// Call mark faster than the timeout for ~3 timeouts worth.
+	tickEnd := time.Now().Add(350 * time.Millisecond)
+	for time.Now().Before(tickEnd) {
+		mark()
+		time.Sleep(20 * time.Millisecond)
+	}
+	assert.NoError(t, ctx.Err(), "watchdog should not cancel while mark is being called")
+
+	// After stop, the ctx should still be alive (no watchdog cancellation).
+	stop()
+	assert.NoError(t, context.Cause(ctx))
+}
+
+func TestSSEIdleTimeoutFromEnv_DefaultsTo45s(t *testing.T) {
+	t.Setenv("ROUTER_SSE_IDLE_TIMEOUT_SECONDS", "")
+	assert.Equal(t, 45*time.Second, sseIdleTimeoutFromEnv())
+}
+
+func TestSSEIdleTimeoutFromEnv_OverrideRespected(t *testing.T) {
+	t.Setenv("ROUTER_SSE_IDLE_TIMEOUT_SECONDS", "10")
+	assert.Equal(t, 10*time.Second, sseIdleTimeoutFromEnv())
+}
+
+func TestSSEIdleTimeoutFromEnv_BadValueFallsBack(t *testing.T) {
+	t.Setenv("ROUTER_SSE_IDLE_TIMEOUT_SECONDS", "garbage")
+	assert.Equal(t, 45*time.Second, sseIdleTimeoutFromEnv())
+}
+
+// Sanity guard: ensure the exported sentinel is actually used.
+var _ = errors.Is(ErrUpstreamIdleTimeout, ErrUpstreamIdleTimeout)

--- a/internal/providers/openai/client.go
+++ b/internal/providers/openai/client.go
@@ -4,6 +4,7 @@ package openai
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -78,6 +79,9 @@ func (c *Client) setAuth(ctx context.Context, upstream *http.Request, inbound *h
 }
 
 func (c *Client) Proxy(ctx context.Context, decision router.Decision, prep providers.PreparedRequest, w http.ResponseWriter, r *http.Request) error {
+	ctx, cancel := context.WithCancelCause(ctx)
+	defer cancel(nil)
+
 	upstream, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/v1/chat/completions", bytes.NewReader(prep.Body))
 	if err != nil {
 		return fmt.Errorf("build upstream request: %w", err)
@@ -115,8 +119,11 @@ func (c *Client) Proxy(ctx context.Context, decision router.Decision, prep provi
 
 	// Manual stream loop for per-chunk diagnostics; non-debug takes the fast path.
 	if !log.Enabled(ctx, slog.LevelDebug) {
-		return httputil.StreamBody(resp.Body, status, w, t)
+		return httputil.StreamBody(ctx, cancel, httputil.DefaultSSEIdleTimeout, resp.Body, status, w, t)
 	}
+
+	mark, stop := httputil.StartIdleWatchdog(ctx, cancel, httputil.DefaultSSEIdleTimeout)
+	defer stop()
 
 	flusher, _ := w.(http.Flusher)
 	buf := make([]byte, httputil.FlushChunk)
@@ -124,6 +131,7 @@ func (c *Client) Proxy(ctx context.Context, decision router.Decision, prep provi
 	for {
 		n, readErr := resp.Body.Read(buf)
 		if n > 0 {
+			mark()
 			t.StampUpstreamFirstByte()
 			if bytesRead == 0 {
 				log.Debug("OpenAI upstream first chunk",
@@ -149,6 +157,10 @@ func (c *Client) Proxy(ctx context.Context, decision router.Decision, prep provi
 			return nil
 		}
 		if readErr != nil {
+			if cause := context.Cause(ctx); errors.Is(cause, httputil.ErrUpstreamIdleTimeout) {
+				log.Debug("OpenAI upstream sse idle", "bytes_read", bytesRead)
+				return httputil.ErrUpstreamIdleTimeout
+			}
 			log.Debug("OpenAI upstream read failed", "err", readErr, "bytes_read", bytesRead)
 			return readErr
 		}

--- a/internal/providers/openaicompat/client.go
+++ b/internal/providers/openaicompat/client.go
@@ -104,6 +104,9 @@ func (c *Client) setAuth(ctx context.Context, upstream *http.Request) {
 }
 
 func (c *Client) Proxy(ctx context.Context, decision router.Decision, prep providers.PreparedRequest, w http.ResponseWriter, r *http.Request) error {
+	ctx, cancel := context.WithCancelCause(ctx)
+	defer cancel(nil)
+
 	body := rewriteModelField(prep.Body, c.modelIDMap)
 	upstream, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/chat/completions", bytes.NewReader(body))
 	if err != nil {
@@ -158,7 +161,7 @@ func (c *Client) Proxy(ctx context.Context, decision router.Decision, prep provi
 		return &providers.UpstreamStatusError{Status: resp.StatusCode}
 	}
 
-	return httputil.StreamBody(resp.Body, resp.StatusCode, w, t)
+	return httputil.StreamBody(ctx, cancel, httputil.DefaultSSEIdleTimeout, resp.Body, resp.StatusCode, w, t)
 }
 
 // Passthrough strips the inbound /v1 prefix to avoid double-prefixing with the configured baseURL.

--- a/internal/proxy/AGENTS.md
+++ b/internal/proxy/AGENTS.md
@@ -1,6 +1,6 @@
-# internal/proxy — AGENTS
+# internal/proxy — CLAUDE
 
-> **Mirror notice.** Verbatim sync with [CLAUDE.md](CLAUDE.md). **Update both together** — divergence = bug.
+> **Mirror notice.** Verbatim sync with [AGENTS.md](AGENTS.md). **Update both together** — divergence = bug.
 
 Routing/dispatch service. Per-turn orchestrator that composes scorer, planner, handover, cache, sessionpin, pricing, capability, turntype, usage, providers, and translate. Read [root CLAUDE.md](../../CLAUDE.md) first.
 
@@ -40,6 +40,16 @@ The provider-backed `Summarizer` implementation for handover lives in [`handover
 ## Translation
 
 `proxy.Service` is the **only caller of [`../translate`](../translate)**. Keep providers ignorant of cross-format concerns. See [translate/CLAUDE.md](../translate/CLAUDE.md) for the recipe.
+
+## Runtime provider fallback
+
+The OpenAI-compat dispatch branches (Anthropic→OpenAI cross-format and OpenAI same-format) go through `proxyWithFallback` in [`provider_fallback.go`](provider_fallback.go). On a pre-first-byte retryable failure (`httputil.ErrUpstreamIdleTimeout` or `UpstreamStatusError{Status: 5xx}`) it walks `catalog.Model.Providers`, swaps to the next eligible binding, re-emits the body for the new TargetProvider, and retries once. After fallback the caller's `*router.Decision` reflects the actually-served provider so cost math, billing, and the ProxyMessages/ProxyOpenAIChatCompletion complete logs are accurate.
+
+**Invariants:**
+- Retry only when `otel.Timing.UpstreamFirstByteNanos == 0`. Once any upstream byte has reached the translator, switching providers mid-stream would interleave two model outputs in one Anthropic message envelope.
+- One retry attempt, not a chain. If the second binding also fails, the error is returned.
+- Skipped for 4xx (client error) and non-classified failures (connect-time errors, body parse errors).
+- The original `message_start` event (already emitted by the translator's Prelude) carries the original model name — content from the new binding flows in after as deltas. This is a deliberate trade: the alternative is buffering the prelude in memory until first byte, which complicates the translator.
 
 ## `OnUpstreamMeta` callbacks
 

--- a/internal/proxy/CLAUDE.md
+++ b/internal/proxy/CLAUDE.md
@@ -41,6 +41,16 @@ The provider-backed `Summarizer` implementation for handover lives in [`handover
 
 `proxy.Service` is the **only caller of [`../translate`](../translate)**. Keep providers ignorant of cross-format concerns. See [translate/CLAUDE.md](../translate/CLAUDE.md) for the recipe.
 
+## Runtime provider fallback
+
+The OpenAI-compat dispatch branches (Anthropic→OpenAI cross-format and OpenAI same-format) go through `proxyWithFallback` in [`provider_fallback.go`](provider_fallback.go). On a pre-first-byte retryable failure (`httputil.ErrUpstreamIdleTimeout` or `UpstreamStatusError{Status: 5xx}`) it walks `catalog.Model.Providers`, swaps to the next eligible binding, re-emits the body for the new TargetProvider, and retries once. After fallback the caller's `*router.Decision` reflects the actually-served provider so cost math, billing, and the ProxyMessages/ProxyOpenAIChatCompletion complete logs are accurate.
+
+**Invariants:**
+- Retry only when `otel.Timing.UpstreamFirstByteNanos == 0`. Once any upstream byte has reached the translator, switching providers mid-stream would interleave two model outputs in one Anthropic message envelope.
+- One retry attempt, not a chain. If the second binding also fails, the error is returned.
+- Skipped for 4xx (client error) and non-classified failures (connect-time errors, body parse errors).
+- The original `message_start` event (already emitted by the translator's Prelude) carries the original model name — content from the new binding flows in after as deltas. This is a deliberate trade: the alternative is buffering the prelude in memory until first byte, which complicates the translator.
+
 ## `OnUpstreamMeta` callbacks
 
 Provider adapters call back into `proxy.OnUpstreamMeta` so streaming responses record usage/headers back to proxy without coupling provider packages to proxy internals. The pricing / planner stack depends on per-turn token counts being recorded promptly — **don't add a provider that forgets to call the callback.**

--- a/internal/proxy/loop_detection.go
+++ b/internal/proxy/loop_detection.go
@@ -104,7 +104,7 @@ func (s *Service) handleToolCallLoopBreak(
 		"window_size", loopDetectionWindowSize,
 		"decision_model", decisionModel,
 		"decision_provider", decisionProvider,
-		"session_key_hex", fmt.Sprintf("%x", sessionKey),
+		"session_key_prefix", shortSessionKey(sessionKey),
 		"role", role,
 	)
 

--- a/internal/proxy/no_progress.go
+++ b/internal/proxy/no_progress.go
@@ -1,0 +1,178 @@
+package proxy
+
+import (
+	"context"
+	"crypto/sha256"
+	"fmt"
+	"net/http"
+	"sync"
+	"time"
+
+	"workweave/router/internal/observability"
+	"workweave/router/internal/router"
+	"workweave/router/internal/router/sessionpin"
+	"workweave/router/internal/translate"
+
+	"github.com/google/uuid"
+	lru "github.com/hashicorp/golang-lru/v2/expirable"
+)
+
+// Cross-envelope tool-call loop detection.
+//
+// The within-envelope detector in loop_detection.go catches one assistant
+// looping inside a single request body. Claude Code's sub-agent failure
+// mode is different: the parent agent keeps spawning fresh sub-conversations
+// that each make one tool call, get back an identical empty result, and the
+// router only sees N independent envelope-1 requests. To the per-envelope
+// detector each envelope looks fine in isolation.
+//
+// noProgressTracker keys an in-process LRU on the inbound session key and
+// holds a ring of recent dispatch fingerprints. When the same fingerprint
+// appears noProgressMatchThreshold times within noProgressTimeWindow the
+// session is declared stuck; the proxy emits a synthetic stop and expires
+// the pin so the next user turn re-routes fresh.
+
+const (
+	noProgressCacheSize      = 4096
+	noProgressCacheTTL       = 5 * time.Minute
+	noProgressWindowSize     = 8
+	noProgressMatchThreshold = 5
+	noProgressTimeWindow     = 90 * time.Second
+	noProgressPromptPrefix   = 512
+)
+
+// noProgressFingerprint identifies one dispatch attempt by routed model,
+// provider, and a stable hash of the prompt prefix.
+type noProgressFingerprint [32]byte
+
+func computeNoProgressFingerprint(decision router.Decision, promptText string) noProgressFingerprint {
+	p := promptText
+	if len(p) > noProgressPromptPrefix {
+		p = p[:noProgressPromptPrefix]
+	}
+	return sha256.Sum256([]byte(decision.Model + "\x00" + decision.Provider + "\x00" + p))
+}
+
+type fingerprintEntry struct {
+	fp   noProgressFingerprint
+	when time.Time
+}
+
+type fingerprintRing struct {
+	mu      sync.Mutex
+	entries []fingerprintEntry
+}
+
+func (r *fingerprintRing) recordAndDetect(fp noProgressFingerprint, now time.Time) (looped bool, count int) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.entries = append(r.entries, fingerprintEntry{fp: fp, when: now})
+	if len(r.entries) > noProgressWindowSize {
+		r.entries = r.entries[len(r.entries)-noProgressWindowSize:]
+	}
+	cutoff := now.Add(-noProgressTimeWindow)
+	n := 0
+	for _, e := range r.entries {
+		if e.fp == fp && !e.when.Before(cutoff) {
+			n++
+		}
+	}
+	return n >= noProgressMatchThreshold, n
+}
+
+// noProgressTracker is the package-level tracker. Construct via
+// newNoProgressTracker; nil receivers are valid (no-op).
+type noProgressTracker struct {
+	cache *lru.LRU[string, *fingerprintRing]
+}
+
+func newNoProgressTracker() *noProgressTracker {
+	return &noProgressTracker{
+		cache: lru.NewLRU[string, *fingerprintRing](noProgressCacheSize, nil, noProgressCacheTTL),
+	}
+}
+
+// recordAndDetect records the fingerprint against the session's ring and
+// reports whether the burst now exceeds the loop threshold. A nil tracker
+// returns (false, 0) so production-style construction can stay optional in
+// tests and selfhosted deploys.
+func (t *noProgressTracker) recordAndDetect(sessionKey [sessionpin.SessionKeyLen]byte, role string, fp noProgressFingerprint, now time.Time) (looped bool, count int) {
+	if t == nil || t.cache == nil {
+		return false, 0
+	}
+	key := sessionPinCacheKey(sessionKey, role)
+	ring, ok := t.cache.Get(key)
+	if !ok || ring == nil {
+		ring = &fingerprintRing{}
+		t.cache.Add(key, ring)
+	}
+	return ring.recordAndDetect(fp, now)
+}
+
+// handleNoProgressBreak writes a synthetic end_turn response, expires the
+// session pin, and returns a non-nil error so caller error-handling
+// (telemetry, billing skip) treats it as a failed dispatch.
+//
+// Mirrors handleToolCallLoopBreak's mechanics — same pin-expiry contract,
+// same synthetic-response writer paths — but the message explains the
+// cross-envelope nature so a human reading the chat history can tell the
+// two break modes apart.
+func (s *Service) handleNoProgressBreak(
+	w http.ResponseWriter,
+	env *translate.RequestEnvelope,
+	count int,
+	installationID uuid.UUID,
+	sessionKey [sessionpin.SessionKeyLen]byte,
+	role string,
+	decisionModel string,
+	decisionProvider string,
+) error {
+	log := observability.Get()
+
+	msg := fmt.Sprintf(
+		"✦ **Weave Router** → no-progress loop detected: %d consecutive requests under this session routed to `%s` (`%s`) with no observable progress in %s. Stopping this turn and clearing the session pin so the next message re-routes.\n\nIf the task is genuinely incomplete, send a follow-up message describing what's still needed; the router will pick a different model.\n\n",
+		count, decisionModel, decisionProvider, noProgressTimeWindow,
+	)
+	if env.SourceFormat() == translate.FormatOpenAI {
+		msg = fmt.Sprintf(
+			"Weave Router: no-progress loop detected (%d consecutive routes to %s/%s with no progress in %s). Stopping and clearing the session pin.",
+			count, decisionModel, decisionProvider, noProgressTimeWindow,
+		)
+	}
+
+	log.Info("No-progress loop detected; breaking turn",
+		"repeat_count", count,
+		"window_size", noProgressWindowSize,
+		"time_window", noProgressTimeWindow.String(),
+		"decision_model", decisionModel,
+		"decision_provider", decisionProvider,
+		"session_key_hex", fmt.Sprintf("%x", sessionKey),
+		"role", role,
+	)
+
+	if s.pinStore != nil && installationID != uuid.Nil {
+		expired := sessionpin.Pin{
+			SessionKey:     sessionKey,
+			Role:           role,
+			InstallationID: installationID,
+			Provider:       "",
+			Model:          "",
+			Reason:         "no_progress_loop_break",
+			TurnCount:      1,
+			PinnedUntil:    time.Now().Add(-time.Second),
+		}
+		if err := s.pinStore.Upsert(context.Background(), expired); err != nil {
+			log.Error("no-progress-break: pin store upsert failed", "err", err)
+		}
+	}
+	if s.pinCache != nil {
+		s.pinCache.Remove(sessionPinCacheKey(sessionKey, role))
+	}
+
+	switch env.SourceFormat() {
+	case translate.FormatOpenAI:
+		return writeSyntheticOpenAIResponse(w, env, msg)
+	default:
+		return writeSyntheticAnthropicResponse(w, env, msg)
+	}
+}

--- a/internal/proxy/no_progress.go
+++ b/internal/proxy/no_progress.go
@@ -96,8 +96,17 @@ func newNoProgressTracker() *noProgressTracker {
 // reports whether the burst now exceeds the loop threshold. A nil tracker
 // returns (false, 0) so production-style construction can stay optional in
 // tests and selfhosted deploys.
+//
+// Zero-valued sessionKey is treated as "no anchor available" and skipped.
+// runTurnLoop leaves SessionKey unset on hard-pin paths (Explore
+// SubAgentDispatch when hardPinExplore is on) and when pinStore is nil; the
+// all-zero key would otherwise collapse unrelated sessions into one LRU
+// bucket and false-positive trip the detector on cross-session bursts.
 func (t *noProgressTracker) recordAndDetect(sessionKey [sessionpin.SessionKeyLen]byte, role string, fp noProgressFingerprint, now time.Time) (looped bool, count int) {
 	if t == nil || t.cache == nil {
+		return false, 0
+	}
+	if sessionKey == ([sessionpin.SessionKeyLen]byte{}) {
 		return false, 0
 	}
 	key := sessionPinCacheKey(sessionKey, role)

--- a/internal/proxy/no_progress.go
+++ b/internal/proxy/no_progress.go
@@ -92,30 +92,65 @@ func newNoProgressTracker() *noProgressTracker {
 	}
 }
 
-// recordAndDetect records the fingerprint against the session's ring and
-// reports whether the burst now exceeds the loop threshold. A nil tracker
-// returns (false, 0) so production-style construction can stay optional in
-// tests and selfhosted deploys.
+// recordAndDetect records the fingerprint against a bucket keyed by
+// sessionKey (preferred) or installationID (fallback) and reports whether
+// the burst now exceeds the loop threshold. A nil tracker returns (false, 0)
+// so production-style construction can stay optional in tests and
+// selfhosted deploys.
 //
-// Zero-valued sessionKey is treated as "no anchor available" and skipped.
-// runTurnLoop leaves SessionKey unset on hard-pin paths (Explore
-// SubAgentDispatch when hardPinExplore is on) and when pinStore is nil; the
-// all-zero key would otherwise collapse unrelated sessions into one LRU
-// bucket and false-positive trip the detector on cross-session bursts.
-func (t *noProgressTracker) recordAndDetect(sessionKey [sessionpin.SessionKeyLen]byte, role string, fp noProgressFingerprint, now time.Time) (looped bool, count int) {
+// Bucket selection:
+//   - non-zero sessionKey → per-session bucket (normal path)
+//   - zero sessionKey + non-nil installationID → per-installation bucket,
+//     used by hard-pin paths (Explore SubAgentDispatch under hardPinExplore)
+//     and routing with pinStore nil. Coarser than per-session but still
+//     keeps detection coverage; the fingerprint's (model, provider, prompt)
+//     tuple distinguishes unrelated work in the same installation from a
+//     real loop.
+//   - zero sessionKey + nil installationID → no anchor available; skipped
+//     to avoid one global zero-key bucket false-positive-tripping across
+//     unrelated unauthenticated traffic.
+func (t *noProgressTracker) recordAndDetect(sessionKey [sessionpin.SessionKeyLen]byte, installationID uuid.UUID, role string, fp noProgressFingerprint, now time.Time) (looped bool, count int) {
 	if t == nil || t.cache == nil {
 		return false, 0
 	}
-	if sessionKey == ([sessionpin.SessionKeyLen]byte{}) {
+	key, ok := noProgressBucketKey(sessionKey, installationID, role)
+	if !ok {
 		return false, 0
 	}
-	key := sessionPinCacheKey(sessionKey, role)
-	ring, ok := t.cache.Get(key)
-	if !ok || ring == nil {
+	ring, ringOk := t.cache.Get(key)
+	if !ringOk || ring == nil {
 		ring = &fingerprintRing{}
 		t.cache.Add(key, ring)
 	}
 	return ring.recordAndDetect(fp, now)
+}
+
+// noProgressBucketKey picks the LRU bucket for a dispatch. Returns ok=false
+// when neither anchor is available — the caller must skip detection rather
+// than falling back to a global zero-keyed bucket.
+func noProgressBucketKey(sessionKey [sessionpin.SessionKeyLen]byte, installationID uuid.UUID, role string) (string, bool) {
+	if sessionKey != ([sessionpin.SessionKeyLen]byte{}) {
+		return "session:" + sessionPinCacheKey(sessionKey, role), true
+	}
+	if installationID != uuid.Nil {
+		return "install:" + installationID.String() + ":" + role, true
+	}
+	return "", false
+}
+
+// shortSessionKey returns the first 16 hex chars (64 bits) of a session key
+// for use in Info-level logs. Mirrors the auth.APIKey "KeyPrefix" convention
+// (8-char prefix is considered safe) at a wider bit margin so an incident
+// triager can still correlate two log lines from the same break event,
+// while limiting long-window cross-request correlation across retained logs.
+//
+// "" for an all-zero key so logs visibly distinguish missing-anchor breaks
+// from real-session breaks.
+func shortSessionKey(sessionKey [sessionpin.SessionKeyLen]byte) string {
+	if sessionKey == ([sessionpin.SessionKeyLen]byte{}) {
+		return ""
+	}
+	return fmt.Sprintf("%x", sessionKey[:8])
 }
 
 // handleNoProgressBreak writes a synthetic end_turn response, expires the
@@ -155,11 +190,15 @@ func (s *Service) handleNoProgressBreak(
 		"time_window", noProgressTimeWindow.String(),
 		"decision_model", decisionModel,
 		"decision_provider", decisionProvider,
-		"session_key_hex", fmt.Sprintf("%x", sessionKey),
+		"session_key_prefix", shortSessionKey(sessionKey),
 		"role", role,
 	)
 
-	if s.pinStore != nil && installationID != uuid.Nil {
+	// Skip pin upsert when sessionKey is zero — writing a zero-keyed pin row
+	// would create a zombie entry shared by every zero-keyed session in the
+	// pin store. Hard-pin paths and selfhosted deploys without a pinStore
+	// hit this path and don't need persisted pin expiry anyway.
+	if s.pinStore != nil && installationID != uuid.Nil && sessionKey != ([sessionpin.SessionKeyLen]byte{}) {
 		expired := sessionpin.Pin{
 			SessionKey:     sessionKey,
 			Role:           role,

--- a/internal/proxy/no_progress_internal_test.go
+++ b/internal/proxy/no_progress_internal_test.go
@@ -7,6 +7,7 @@ import (
 	"workweave/router/internal/router"
 	"workweave/router/internal/router/sessionpin"
 
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -47,17 +48,18 @@ func TestComputeNoProgressFingerprint_PromptPrefixOnly(t *testing.T) {
 func TestNoProgressTracker_TripsAfterThresholdHits(t *testing.T) {
 	tr := newNoProgressTracker()
 	key := sessionKeyFromString("session-abc")
+	install := uuid.New()
 	d := router.Decision{Model: "qwen/qwen3-235b-a22b-2507", Provider: "bedrock"}
 	fp := computeNoProgressFingerprint(d, "prompt")
 	now := time.Now()
 
 	for i := 1; i < noProgressMatchThreshold; i++ {
-		looped, count := tr.recordAndDetect(key, "high", fp, now)
+		looped, count := tr.recordAndDetect(key, install, "high", fp, now)
 		assert.False(t, looped, "must not trip before threshold (call %d)", i)
 		assert.Equal(t, i, count)
 	}
 
-	looped, count := tr.recordAndDetect(key, "high", fp, now)
+	looped, count := tr.recordAndDetect(key, install, "high", fp, now)
 	assert.True(t, looped)
 	assert.Equal(t, noProgressMatchThreshold, count)
 }
@@ -65,12 +67,13 @@ func TestNoProgressTracker_TripsAfterThresholdHits(t *testing.T) {
 func TestNoProgressTracker_DoesNotTripWhenFingerprintsDiffer(t *testing.T) {
 	tr := newNoProgressTracker()
 	key := sessionKeyFromString("session-xyz")
+	install := uuid.New()
 	now := time.Now()
 
 	for i := 0; i < noProgressMatchThreshold*2; i++ {
 		d := router.Decision{Model: "qwen/qwen3-235b-a22b-2507", Provider: "bedrock"}
 		fp := computeNoProgressFingerprint(d, "prompt-distinct-"+time.Duration(i).String())
-		looped, _ := tr.recordAndDetect(key, "high", fp, now)
+		looped, _ := tr.recordAndDetect(key, install, "high", fp, now)
 		assert.False(t, looped, "distinct fingerprints must not trip the detector (call %d)", i)
 	}
 }
@@ -78,26 +81,46 @@ func TestNoProgressTracker_DoesNotTripWhenFingerprintsDiffer(t *testing.T) {
 func TestNoProgressTracker_AgesOutOldEntries(t *testing.T) {
 	tr := newNoProgressTracker()
 	key := sessionKeyFromString("session-aging")
+	install := uuid.New()
 	d := router.Decision{Model: "qwen/qwen3-235b-a22b-2507", Provider: "bedrock"}
 	fp := computeNoProgressFingerprint(d, "prompt")
 
 	old := time.Now().Add(-2 * noProgressTimeWindow)
 	for i := 0; i < noProgressMatchThreshold-1; i++ {
-		tr.recordAndDetect(key, "high", fp, old)
+		tr.recordAndDetect(key, install, "high", fp, old)
 	}
 
 	// One fresh hit: the stale entries should not contribute to the count.
-	looped, count := tr.recordAndDetect(key, "high", fp, time.Now())
+	looped, count := tr.recordAndDetect(key, install, "high", fp, time.Now())
 	assert.False(t, looped, "stale entries (outside window) must not push us over the threshold")
 	assert.Equal(t, 1, count)
 }
 
-func TestNoProgressTracker_ZeroSessionKeyIsSkipped(t *testing.T) {
-	// runTurnLoop leaves routeRes.SessionKey at the zero value on hard-pin
-	// paths (Explore SubAgentDispatch under hardPinExplore) and when
-	// pinStore is nil. Without this guard those dispatches would all share
-	// one LRU bucket and trip the detector even though they come from
-	// unrelated sessions.
+func TestNoProgressTracker_ZeroSessionKeyWithInstallationFallsBack(t *testing.T) {
+	// Hard-pin paths (Explore SubAgentDispatch when hardPinExplore is on)
+	// and routing with pinStore nil leave SessionKey at zero. The detector
+	// must still cover them — bucketing by installationID keeps the
+	// per-installation isolation while restoring detection coverage.
+	tr := newNoProgressTracker()
+	var zero [sessionpin.SessionKeyLen]byte
+	install := uuid.New()
+	d := router.Decision{Model: "qwen/qwen3-235b-a22b-2507", Provider: "bedrock"}
+	fp := computeNoProgressFingerprint(d, "prompt")
+	now := time.Now()
+
+	for i := 1; i < noProgressMatchThreshold; i++ {
+		looped, _ := tr.recordAndDetect(zero, install, "high", fp, now)
+		assert.False(t, looped, "must not trip before threshold on the installation-fallback path (call %d)", i)
+	}
+	looped, count := tr.recordAndDetect(zero, install, "high", fp, now)
+	assert.True(t, looped, "installation-fallback path must still detect loops")
+	assert.Equal(t, noProgressMatchThreshold, count)
+}
+
+func TestNoProgressTracker_ZeroSessionKeyAndZeroInstallationIsSkipped(t *testing.T) {
+	// Unauthenticated/test paths can have neither anchor — must skip rather
+	// than fall back to a global zero-keyed bucket that unrelated traffic
+	// would share.
 	tr := newNoProgressTracker()
 	var zero [sessionpin.SessionKeyLen]byte
 	d := router.Decision{Model: "qwen/qwen3-235b-a22b-2507", Provider: "bedrock"}
@@ -105,10 +128,30 @@ func TestNoProgressTracker_ZeroSessionKeyIsSkipped(t *testing.T) {
 	now := time.Now()
 
 	for i := 0; i < noProgressMatchThreshold*2; i++ {
-		looped, count := tr.recordAndDetect(zero, "high", fp, now)
-		assert.False(t, looped, "zero session key must never trip the detector (call %d)", i)
+		looped, count := tr.recordAndDetect(zero, uuid.Nil, "high", fp, now)
+		assert.False(t, looped, "no anchor available → detector must never trip (call %d)", i)
 		assert.Equal(t, 0, count)
 	}
+}
+
+func TestNoProgressTracker_ZeroSessionDifferentInstallationsAreIsolated(t *testing.T) {
+	// Two distinct installations each emit the same fingerprint on the
+	// zero-session-key fallback path. Their buckets must not collide.
+	tr := newNoProgressTracker()
+	var zero [sessionpin.SessionKeyLen]byte
+	installA := uuid.New()
+	installB := uuid.New()
+	d := router.Decision{Model: "qwen/qwen3-235b-a22b-2507", Provider: "bedrock"}
+	fp := computeNoProgressFingerprint(d, "prompt")
+	now := time.Now()
+
+	for i := 0; i < noProgressMatchThreshold-1; i++ {
+		tr.recordAndDetect(zero, installA, "high", fp, now)
+	}
+	// installB shouldn't see installA's history at all.
+	looped, count := tr.recordAndDetect(zero, installB, "high", fp, now)
+	assert.False(t, looped)
+	assert.Equal(t, 1, count)
 }
 
 func TestNoProgressTracker_NilReceiverIsNoOp(t *testing.T) {
@@ -116,7 +159,7 @@ func TestNoProgressTracker_NilReceiverIsNoOp(t *testing.T) {
 	key := sessionKeyFromString("session-nil")
 	d := router.Decision{Model: "x", Provider: "y"}
 	fp := computeNoProgressFingerprint(d, "p")
-	looped, count := tr.recordAndDetect(key, "high", fp, time.Now())
+	looped, count := tr.recordAndDetect(key, uuid.New(), "high", fp, time.Now())
 	assert.False(t, looped)
 	assert.Equal(t, 0, count)
 }
@@ -126,6 +169,7 @@ func TestNoProgressTracker_SeparateSessionsDoNotInterfere(t *testing.T) {
 	d := router.Decision{Model: "qwen/qwen3-235b-a22b-2507", Provider: "bedrock"}
 	fp := computeNoProgressFingerprint(d, "prompt")
 	now := time.Now()
+	install := uuid.New()
 
 	// Two distinct sessions emit the same fingerprint many times; neither
 	// should trip because the count is per-session.
@@ -133,14 +177,13 @@ func TestNoProgressTracker_SeparateSessionsDoNotInterfere(t *testing.T) {
 	keyB := sessionKeyFromString("session-B")
 
 	for i := 0; i < noProgressMatchThreshold-1; i++ {
-		tr.recordAndDetect(keyA, "high", fp, now)
-		tr.recordAndDetect(keyB, "high", fp, now)
+		tr.recordAndDetect(keyA, install, "high", fp, now)
+		tr.recordAndDetect(keyB, install, "high", fp, now)
 	}
 
-	// One more hit on each — neither has reached the threshold *for its own session*.
-	loopedA, _ := tr.recordAndDetect(keyA, "high", fp, now)
-	loopedB, _ := tr.recordAndDetect(keyB, "high", fp, now)
-	// Each session has reached the threshold (4 prior + this one = 5).
+	// One more hit on each — each has reached the threshold for its own session.
+	loopedA, _ := tr.recordAndDetect(keyA, install, "high", fp, now)
+	loopedB, _ := tr.recordAndDetect(keyB, install, "high", fp, now)
 	require.True(t, loopedA)
 	require.True(t, loopedB)
 }
@@ -148,6 +191,7 @@ func TestNoProgressTracker_SeparateSessionsDoNotInterfere(t *testing.T) {
 func TestNoProgressTracker_DifferentRolesAreSeparateRings(t *testing.T) {
 	tr := newNoProgressTracker()
 	key := sessionKeyFromString("session-roles")
+	install := uuid.New()
 	d := router.Decision{Model: "x", Provider: "y"}
 	fp := computeNoProgressFingerprint(d, "p")
 	now := time.Now()
@@ -155,9 +199,19 @@ func TestNoProgressTracker_DifferentRolesAreSeparateRings(t *testing.T) {
 	// Same session key, different role → different LRU entry. Filling the
 	// "high" ring should not affect the "low" ring.
 	for i := 0; i < noProgressMatchThreshold; i++ {
-		tr.recordAndDetect(key, "high", fp, now)
+		tr.recordAndDetect(key, install, "high", fp, now)
 	}
-	looped, count := tr.recordAndDetect(key, "low", fp, now)
+	looped, count := tr.recordAndDetect(key, install, "low", fp, now)
 	assert.False(t, looped)
 	assert.Equal(t, 1, count)
+}
+
+func TestShortSessionKey_TruncatesAndRedactsZero(t *testing.T) {
+	var zero [sessionpin.SessionKeyLen]byte
+	assert.Equal(t, "", shortSessionKey(zero), "zero key must produce empty so logs distinguish missing-anchor from real")
+
+	key := sessionKeyFromString("0123456789ABCDEFsomemore")
+	got := shortSessionKey(key)
+	assert.Len(t, got, 16, "must log only the first 8 bytes (16 hex chars) to limit cross-request correlation")
+	assert.NotContains(t, got, "somemore", "tail bytes must not appear in logs")
 }

--- a/internal/proxy/no_progress_internal_test.go
+++ b/internal/proxy/no_progress_internal_test.go
@@ -92,6 +92,25 @@ func TestNoProgressTracker_AgesOutOldEntries(t *testing.T) {
 	assert.Equal(t, 1, count)
 }
 
+func TestNoProgressTracker_ZeroSessionKeyIsSkipped(t *testing.T) {
+	// runTurnLoop leaves routeRes.SessionKey at the zero value on hard-pin
+	// paths (Explore SubAgentDispatch under hardPinExplore) and when
+	// pinStore is nil. Without this guard those dispatches would all share
+	// one LRU bucket and trip the detector even though they come from
+	// unrelated sessions.
+	tr := newNoProgressTracker()
+	var zero [sessionpin.SessionKeyLen]byte
+	d := router.Decision{Model: "qwen/qwen3-235b-a22b-2507", Provider: "bedrock"}
+	fp := computeNoProgressFingerprint(d, "prompt")
+	now := time.Now()
+
+	for i := 0; i < noProgressMatchThreshold*2; i++ {
+		looped, count := tr.recordAndDetect(zero, "high", fp, now)
+		assert.False(t, looped, "zero session key must never trip the detector (call %d)", i)
+		assert.Equal(t, 0, count)
+	}
+}
+
 func TestNoProgressTracker_NilReceiverIsNoOp(t *testing.T) {
 	var tr *noProgressTracker
 	key := sessionKeyFromString("session-nil")

--- a/internal/proxy/no_progress_internal_test.go
+++ b/internal/proxy/no_progress_internal_test.go
@@ -1,0 +1,144 @@
+package proxy
+
+import (
+	"testing"
+	"time"
+
+	"workweave/router/internal/router"
+	"workweave/router/internal/router/sessionpin"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func sessionKeyFromString(s string) [sessionpin.SessionKeyLen]byte {
+	var k [sessionpin.SessionKeyLen]byte
+	copy(k[:], []byte(s))
+	return k
+}
+
+func TestComputeNoProgressFingerprint_StableAcrossCalls(t *testing.T) {
+	d := router.Decision{Model: "qwen/qwen3-235b-a22b-2507", Provider: "bedrock"}
+	a := computeNoProgressFingerprint(d, "explore RSVP files in this repository")
+	b := computeNoProgressFingerprint(d, "explore RSVP files in this repository")
+	assert.Equal(t, a, b)
+}
+
+func TestComputeNoProgressFingerprint_DistinguishesModel(t *testing.T) {
+	d1 := router.Decision{Model: "qwen/qwen3-235b-a22b-2507", Provider: "bedrock"}
+	d2 := router.Decision{Model: "deepseek/deepseek-v4-flash", Provider: "deepinfra"}
+	a := computeNoProgressFingerprint(d1, "explore")
+	b := computeNoProgressFingerprint(d2, "explore")
+	assert.NotEqual(t, a, b)
+}
+
+func TestComputeNoProgressFingerprint_PromptPrefixOnly(t *testing.T) {
+	d := router.Decision{Model: "x", Provider: "y"}
+	// Identical 512-byte prefix; suffix differs — must still collide.
+	prefix := make([]byte, noProgressPromptPrefix)
+	for i := range prefix {
+		prefix[i] = 'a'
+	}
+	a := computeNoProgressFingerprint(d, string(prefix)+"suffix1")
+	b := computeNoProgressFingerprint(d, string(prefix)+"suffix2")
+	assert.Equal(t, a, b, "only the first %d bytes of prompt text matter for the fingerprint", noProgressPromptPrefix)
+}
+
+func TestNoProgressTracker_TripsAfterThresholdHits(t *testing.T) {
+	tr := newNoProgressTracker()
+	key := sessionKeyFromString("session-abc")
+	d := router.Decision{Model: "qwen/qwen3-235b-a22b-2507", Provider: "bedrock"}
+	fp := computeNoProgressFingerprint(d, "prompt")
+	now := time.Now()
+
+	for i := 1; i < noProgressMatchThreshold; i++ {
+		looped, count := tr.recordAndDetect(key, "high", fp, now)
+		assert.False(t, looped, "must not trip before threshold (call %d)", i)
+		assert.Equal(t, i, count)
+	}
+
+	looped, count := tr.recordAndDetect(key, "high", fp, now)
+	assert.True(t, looped)
+	assert.Equal(t, noProgressMatchThreshold, count)
+}
+
+func TestNoProgressTracker_DoesNotTripWhenFingerprintsDiffer(t *testing.T) {
+	tr := newNoProgressTracker()
+	key := sessionKeyFromString("session-xyz")
+	now := time.Now()
+
+	for i := 0; i < noProgressMatchThreshold*2; i++ {
+		d := router.Decision{Model: "qwen/qwen3-235b-a22b-2507", Provider: "bedrock"}
+		fp := computeNoProgressFingerprint(d, "prompt-distinct-"+time.Duration(i).String())
+		looped, _ := tr.recordAndDetect(key, "high", fp, now)
+		assert.False(t, looped, "distinct fingerprints must not trip the detector (call %d)", i)
+	}
+}
+
+func TestNoProgressTracker_AgesOutOldEntries(t *testing.T) {
+	tr := newNoProgressTracker()
+	key := sessionKeyFromString("session-aging")
+	d := router.Decision{Model: "qwen/qwen3-235b-a22b-2507", Provider: "bedrock"}
+	fp := computeNoProgressFingerprint(d, "prompt")
+
+	old := time.Now().Add(-2 * noProgressTimeWindow)
+	for i := 0; i < noProgressMatchThreshold-1; i++ {
+		tr.recordAndDetect(key, "high", fp, old)
+	}
+
+	// One fresh hit: the stale entries should not contribute to the count.
+	looped, count := tr.recordAndDetect(key, "high", fp, time.Now())
+	assert.False(t, looped, "stale entries (outside window) must not push us over the threshold")
+	assert.Equal(t, 1, count)
+}
+
+func TestNoProgressTracker_NilReceiverIsNoOp(t *testing.T) {
+	var tr *noProgressTracker
+	key := sessionKeyFromString("session-nil")
+	d := router.Decision{Model: "x", Provider: "y"}
+	fp := computeNoProgressFingerprint(d, "p")
+	looped, count := tr.recordAndDetect(key, "high", fp, time.Now())
+	assert.False(t, looped)
+	assert.Equal(t, 0, count)
+}
+
+func TestNoProgressTracker_SeparateSessionsDoNotInterfere(t *testing.T) {
+	tr := newNoProgressTracker()
+	d := router.Decision{Model: "qwen/qwen3-235b-a22b-2507", Provider: "bedrock"}
+	fp := computeNoProgressFingerprint(d, "prompt")
+	now := time.Now()
+
+	// Two distinct sessions emit the same fingerprint many times; neither
+	// should trip because the count is per-session.
+	keyA := sessionKeyFromString("session-A")
+	keyB := sessionKeyFromString("session-B")
+
+	for i := 0; i < noProgressMatchThreshold-1; i++ {
+		tr.recordAndDetect(keyA, "high", fp, now)
+		tr.recordAndDetect(keyB, "high", fp, now)
+	}
+
+	// One more hit on each — neither has reached the threshold *for its own session*.
+	loopedA, _ := tr.recordAndDetect(keyA, "high", fp, now)
+	loopedB, _ := tr.recordAndDetect(keyB, "high", fp, now)
+	// Each session has reached the threshold (4 prior + this one = 5).
+	require.True(t, loopedA)
+	require.True(t, loopedB)
+}
+
+func TestNoProgressTracker_DifferentRolesAreSeparateRings(t *testing.T) {
+	tr := newNoProgressTracker()
+	key := sessionKeyFromString("session-roles")
+	d := router.Decision{Model: "x", Provider: "y"}
+	fp := computeNoProgressFingerprint(d, "p")
+	now := time.Now()
+
+	// Same session key, different role → different LRU entry. Filling the
+	// "high" ring should not affect the "low" ring.
+	for i := 0; i < noProgressMatchThreshold; i++ {
+		tr.recordAndDetect(key, "high", fp, now)
+	}
+	looped, count := tr.recordAndDetect(key, "low", fp, now)
+	assert.False(t, looped)
+	assert.Equal(t, 1, count)
+}

--- a/internal/proxy/provider_fallback.go
+++ b/internal/proxy/provider_fallback.go
@@ -1,0 +1,138 @@
+package proxy
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+
+	"workweave/router/internal/observability/otel"
+	"workweave/router/internal/providers"
+	"workweave/router/internal/providers/httputil"
+	"workweave/router/internal/router"
+	"workweave/router/internal/router/catalog"
+	"workweave/router/internal/translate"
+)
+
+// fallbackOutcome captures the result of a single fallback attempt, surfaced
+// into the ProxyMessages complete log so a postmortem on a Bedrock-mantle
+// stall can tell whether the retry path saved the request or not.
+type fallbackOutcome struct {
+	Attempted    bool
+	FromProvider string
+	ToProvider   string
+	Reason       string // "sse_idle" | "5xx" | "connect"
+	FirstErr     error
+}
+
+// proxyWithFallback dispatches the OpenAI-compat-formatted request via the
+// chosen provider and, on a pre-first-byte retryable failure, re-emits the
+// body for the next eligible binding in the catalog and tries once more.
+//
+// Retryable failures: ErrUpstreamIdleTimeout (SSE inactivity watchdog) and
+// UpstreamStatusError{Status: 5xx}. We can only retry safely while
+// t.UpstreamFirstByteNanos is zero — once any upstream byte has been
+// translated into the response writer, the client has committed to this
+// response and the second attempt would mix two streams.
+//
+// On fallback the caller's decision.Provider is mutated to the new binding
+// so downstream cost math, billing, and the ProxyMessages complete log
+// reflect the actually-served provider. decision.Model is unchanged because
+// catalog bindings share a model id.
+func (s *Service) proxyWithFallback(
+	ctx context.Context,
+	decision *router.Decision,
+	env *translate.RequestEnvelope,
+	opts translate.EmitOptions,
+	sink http.ResponseWriter,
+	r *http.Request,
+) (proxyErr error, outcome fallbackOutcome) {
+	t := otel.TimingFrom(ctx)
+
+	p, err := s.provider(decision.Provider)
+	if err != nil {
+		return err, outcome
+	}
+	prep, err := env.PrepareOpenAI(r.Header, opts)
+	if err != nil {
+		return fmt.Errorf("emit body: %w", err), outcome
+	}
+	proxyErr = p.Proxy(ctx, *decision, prep, sink, r)
+	if proxyErr == nil {
+		return nil, outcome
+	}
+
+	// Can we retry?
+	reason, retryable := classifyFallbackError(proxyErr)
+	if !retryable {
+		return proxyErr, outcome
+	}
+	if t != nil && t.UpstreamFirstByteNanos.Load() != 0 {
+		// Upstream already streamed at least one byte; the translator has
+		// emitted deltas. Switching providers mid-stream would interleave
+		// two model outputs in one Anthropic message envelope.
+		return proxyErr, outcome
+	}
+
+	nextBinding, ok := s.findFallbackBinding(decision.Model, decision.Provider)
+	if !ok {
+		return proxyErr, outcome
+	}
+
+	origProvider := decision.Provider
+	decision.Provider = nextBinding.Provider
+	opts.TargetProvider = nextBinding.Provider
+
+	prep2, err := env.PrepareOpenAI(r.Header, opts)
+	if err != nil {
+		return fmt.Errorf("emit body (fallback): %w", err), outcome
+	}
+
+	ctx2 := resolveAndInjectCredentials(ctx, decision.Provider, r.Header)
+	p2, err := s.provider(decision.Provider)
+	if err != nil {
+		return err, outcome
+	}
+
+	outcome = fallbackOutcome{
+		Attempted:    true,
+		FromProvider: origProvider,
+		ToProvider:   nextBinding.Provider,
+		Reason:       reason,
+		FirstErr:     proxyErr,
+	}
+	return p2.Proxy(ctx2, *decision, prep2, sink, r), outcome
+}
+
+// classifyFallbackError reports whether err warrants a single retry against
+// the next eligible binding and returns a short reason tag for logs.
+func classifyFallbackError(err error) (reason string, retryable bool) {
+	if errors.Is(err, httputil.ErrUpstreamIdleTimeout) {
+		return "sse_idle", true
+	}
+	var statusErr *providers.UpstreamStatusError
+	if errors.As(err, &statusErr) && statusErr.Status >= 500 {
+		return "5xx", true
+	}
+	return "", false
+}
+
+// findFallbackBinding walks the catalog's ordered binding list and returns
+// the first entry whose provider is wired in this deploy and is not the
+// just-failed provider. Returns false when no eligible alternative exists.
+func (s *Service) findFallbackBinding(modelID, failedProvider string) (catalog.ProviderBinding, bool) {
+	m, ok := catalog.ByID(modelID)
+	if !ok {
+		return catalog.ProviderBinding{}, false
+	}
+	for _, b := range m.Providers {
+		if b.Provider == failedProvider {
+			continue
+		}
+		if _, wired := s.providers[b.Provider]; !wired {
+			continue
+		}
+		return b, true
+	}
+	return catalog.ProviderBinding{}, false
+}

--- a/internal/proxy/provider_fallback.go
+++ b/internal/proxy/provider_fallback.go
@@ -95,7 +95,15 @@ func (s *Service) proxyWithFallback(
 		return fmt.Errorf("emit body (fallback): %w", err), outcome
 	}
 
-	ctx2 := resolveAndInjectCredentials(ctx, decision.Provider, r.Header)
+	// Strip the original provider's credentials from ctx before re-resolving
+	// for the fallback target. BYOK credentials and inbound client headers are
+	// provider-specific; without this, a Bedrock BYOK key in ctx would be
+	// forwarded as the Authorization header to OpenRouter when
+	// resolveAndInjectCredentials finds no creds for the new provider and
+	// leaves the original CredentialsContextKey value in place. That's a
+	// cross-provider credential leak.
+	ctx2 := context.WithValue(ctx, CredentialsContextKey{}, (*Credentials)(nil))
+	ctx2 = resolveAndInjectCredentials(ctx2, decision.Provider, r.Header)
 	p2, err := s.provider(decision.Provider)
 	if err != nil {
 		return err, outcome

--- a/internal/proxy/provider_fallback.go
+++ b/internal/proxy/provider_fallback.go
@@ -35,6 +35,12 @@ type fallbackOutcome struct {
 // translated into the response writer, the client has committed to this
 // response and the second attempt would mix two streams.
 //
+// enabledProviders carries the per-request provider eligibility set produced
+// by enabledProvidersForRequest — BYOK requests narrow this beyond the
+// deploy-wired set, and a fallback that ignored it could silently spend
+// deployment credentials on a provider the request never authorized. A nil
+// or empty map disables the eligibility filter (deploy-wired only).
+//
 // On fallback the caller's decision.Provider is mutated to the new binding
 // so downstream cost math, billing, and the ProxyMessages complete log
 // reflect the actually-served provider. decision.Model is unchanged because
@@ -44,6 +50,7 @@ func (s *Service) proxyWithFallback(
 	decision *router.Decision,
 	env *translate.RequestEnvelope,
 	opts translate.EmitOptions,
+	enabledProviders map[string]struct{},
 	sink http.ResponseWriter,
 	r *http.Request,
 ) (proxyErr error, outcome fallbackOutcome) {
@@ -74,7 +81,7 @@ func (s *Service) proxyWithFallback(
 		return proxyErr, outcome
 	}
 
-	nextBinding, ok := s.findFallbackBinding(decision.Model, decision.Provider)
+	nextBinding, ok := s.findFallbackBinding(decision.Model, decision.Provider, enabledProviders)
 	if !ok {
 		return proxyErr, outcome
 	}
@@ -118,9 +125,16 @@ func classifyFallbackError(err error) (reason string, retryable bool) {
 }
 
 // findFallbackBinding walks the catalog's ordered binding list and returns
-// the first entry whose provider is wired in this deploy and is not the
-// just-failed provider. Returns false when no eligible alternative exists.
-func (s *Service) findFallbackBinding(modelID, failedProvider string) (catalog.ProviderBinding, bool) {
+// the first entry that is (a) wired in this deploy, (b) eligible for this
+// request, and (c) not the just-failed provider. Returns false when no
+// eligible alternative exists.
+//
+// enabledProviders is the per-request eligibility set from
+// enabledProvidersForRequest — BYOK requests narrow it beyond the deploy-wired
+// set, and routing on a binding outside this set would charge deployment
+// credentials for a provider the request did not authorize. nil disables the
+// per-request filter (deploy-wired only).
+func (s *Service) findFallbackBinding(modelID, failedProvider string, enabledProviders map[string]struct{}) (catalog.ProviderBinding, bool) {
 	m, ok := catalog.ByID(modelID)
 	if !ok {
 		return catalog.ProviderBinding{}, false
@@ -131,6 +145,11 @@ func (s *Service) findFallbackBinding(modelID, failedProvider string) (catalog.P
 		}
 		if _, wired := s.providers[b.Provider]; !wired {
 			continue
+		}
+		if enabledProviders != nil {
+			if _, eligible := enabledProviders[b.Provider]; !eligible {
+				continue
+			}
 		}
 		return b, true
 	}

--- a/internal/proxy/provider_fallback_internal_test.go
+++ b/internal/proxy/provider_fallback_internal_test.go
@@ -80,7 +80,7 @@ func TestProxyWithFallback_HappyPathNoFallback(t *testing.T) {
 
 	w := httptest.NewRecorder()
 	r := httptest.NewRequest(http.MethodPost, "/v1/messages", nil)
-	err, outcome := s.proxyWithFallback(ctx, &decision, env, translate.EmitOptions{TargetModel: decision.Model, TargetProvider: decision.Provider}, w, r)
+	err, outcome := s.proxyWithFallback(ctx, &decision, env, translate.EmitOptions{TargetModel: decision.Model, TargetProvider: decision.Provider}, nil, w, r)
 
 	require.NoError(t, err)
 	assert.False(t, outcome.Attempted)
@@ -104,7 +104,7 @@ func TestProxyWithFallback_RetriesOnIdleTimeoutBeforeFirstByte(t *testing.T) {
 
 	w := httptest.NewRecorder()
 	r := httptest.NewRequest(http.MethodPost, "/v1/messages", nil)
-	err, outcome := s.proxyWithFallback(ctx, &decision, env, translate.EmitOptions{TargetModel: decision.Model, TargetProvider: providers.ProviderBedrock}, w, r)
+	err, outcome := s.proxyWithFallback(ctx, &decision, env, translate.EmitOptions{TargetModel: decision.Model, TargetProvider: providers.ProviderBedrock}, nil, w, r)
 
 	require.NoError(t, err)
 	assert.True(t, outcome.Attempted)
@@ -132,7 +132,7 @@ func TestProxyWithFallback_RetriesOnUpstream5xxBeforeFirstByte(t *testing.T) {
 
 	w := httptest.NewRecorder()
 	r := httptest.NewRequest(http.MethodPost, "/v1/messages", nil)
-	err, outcome := s.proxyWithFallback(ctx, &decision, env, translate.EmitOptions{TargetModel: decision.Model, TargetProvider: providers.ProviderBedrock}, w, r)
+	err, outcome := s.proxyWithFallback(ctx, &decision, env, translate.EmitOptions{TargetModel: decision.Model, TargetProvider: providers.ProviderBedrock}, nil, w, r)
 
 	require.NoError(t, err)
 	assert.True(t, outcome.Attempted)
@@ -161,7 +161,7 @@ func TestProxyWithFallback_NoRetryAfterFirstByte(t *testing.T) {
 
 	w := httptest.NewRecorder()
 	r := httptest.NewRequest(http.MethodPost, "/v1/messages", nil)
-	err, outcome := s.proxyWithFallback(ctx, &decision, env, translate.EmitOptions{TargetModel: decision.Model, TargetProvider: providers.ProviderBedrock}, w, r)
+	err, outcome := s.proxyWithFallback(ctx, &decision, env, translate.EmitOptions{TargetModel: decision.Model, TargetProvider: providers.ProviderBedrock}, nil, w, r)
 
 	require.Error(t, err)
 	assert.ErrorIs(t, err, httputil.ErrUpstreamIdleTimeout)
@@ -185,7 +185,7 @@ func TestProxyWithFallback_NoRetryOn4xx(t *testing.T) {
 
 	w := httptest.NewRecorder()
 	r := httptest.NewRequest(http.MethodPost, "/v1/messages", nil)
-	err, outcome := s.proxyWithFallback(ctx, &decision, env, translate.EmitOptions{TargetModel: decision.Model, TargetProvider: providers.ProviderBedrock}, w, r)
+	err, outcome := s.proxyWithFallback(ctx, &decision, env, translate.EmitOptions{TargetModel: decision.Model, TargetProvider: providers.ProviderBedrock}, nil, w, r)
 
 	require.Error(t, err)
 	assert.False(t, outcome.Attempted, "4xx (e.g. 429 rate-limit) is the caller's problem; do not retry against another provider")
@@ -206,7 +206,7 @@ func TestProxyWithFallback_NoBindingsToFallbackToReturnsOriginalError(t *testing
 
 	w := httptest.NewRecorder()
 	r := httptest.NewRequest(http.MethodPost, "/v1/messages", nil)
-	err, outcome := s.proxyWithFallback(ctx, &decision, env, translate.EmitOptions{TargetModel: decision.Model, TargetProvider: providers.ProviderAnthropic}, w, r)
+	err, outcome := s.proxyWithFallback(ctx, &decision, env, translate.EmitOptions{TargetModel: decision.Model, TargetProvider: providers.ProviderAnthropic}, nil, w, r)
 
 	require.Error(t, err)
 	assert.False(t, outcome.Attempted)
@@ -228,10 +228,65 @@ func TestProxyWithFallback_SkipsBindingsWithUnwiredProvider(t *testing.T) {
 
 	w := httptest.NewRecorder()
 	r := httptest.NewRequest(http.MethodPost, "/v1/messages", nil)
-	err, outcome := s.proxyWithFallback(ctx, &decision, env, translate.EmitOptions{TargetModel: decision.Model, TargetProvider: providers.ProviderBedrock}, w, r)
+	err, outcome := s.proxyWithFallback(ctx, &decision, env, translate.EmitOptions{TargetModel: decision.Model, TargetProvider: providers.ProviderBedrock}, nil, w, r)
 
 	require.Error(t, err)
 	assert.False(t, outcome.Attempted)
+}
+
+func TestProxyWithFallback_RespectsEnabledProviders_BYOK(t *testing.T) {
+	// BYOK request: customer only authorized the deploy to spend its
+	// Bedrock credentials. After a Bedrock idle timeout the catalog still
+	// lists OpenRouter as the next binding and the deploy has an OpenRouter
+	// client wired, but the request never authorized that provider — silently
+	// falling over would charge deployment credentials for a provider the
+	// request did not opt into.
+	first := &scriptedClient{name: "bedrock", errs: []error{httputil.ErrUpstreamIdleTimeout}}
+	second := &scriptedClient{name: "openrouter"}
+	clients := map[string]providers.Client{
+		providers.ProviderBedrock:    first,
+		providers.ProviderOpenRouter: second,
+	}
+	s := newFallbackService(t, clients)
+
+	ctx, _ := otel.WithTiming(context.Background())
+	decision := router.Decision{Model: "qwen/qwen3-235b-a22b-2507", Provider: providers.ProviderBedrock}
+	env := envelopeFromAnthropic(t)
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodPost, "/v1/messages", nil)
+	enabledProviders := map[string]struct{}{providers.ProviderBedrock: {}}
+	err, outcome := s.proxyWithFallback(ctx, &decision, env, translate.EmitOptions{TargetModel: decision.Model, TargetProvider: providers.ProviderBedrock}, enabledProviders, w, r)
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, httputil.ErrUpstreamIdleTimeout)
+	assert.False(t, outcome.Attempted, "OpenRouter is wired but not in the request's eligible set; fallback must not fire")
+	assert.Equal(t, int32(0), second.calls.Load(), "openrouter must not be dispatched against")
+	assert.Equal(t, providers.ProviderBedrock, decision.Provider, "no eligible fallback → decision stays on the original provider")
+}
+
+func TestProxyWithFallback_RespectsEnabledProviders_AllowsEligible(t *testing.T) {
+	// Same setup but the request authorized both providers — fallback fires.
+	first := &scriptedClient{name: "bedrock", errs: []error{httputil.ErrUpstreamIdleTimeout}}
+	second := &scriptedClient{name: "openrouter"}
+	clients := map[string]providers.Client{
+		providers.ProviderBedrock:    first,
+		providers.ProviderOpenRouter: second,
+	}
+	s := newFallbackService(t, clients)
+
+	ctx, _ := otel.WithTiming(context.Background())
+	decision := router.Decision{Model: "qwen/qwen3-235b-a22b-2507", Provider: providers.ProviderBedrock}
+	env := envelopeFromAnthropic(t)
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodPost, "/v1/messages", nil)
+	enabledProviders := map[string]struct{}{providers.ProviderBedrock: {}, providers.ProviderOpenRouter: {}}
+	err, outcome := s.proxyWithFallback(ctx, &decision, env, translate.EmitOptions{TargetModel: decision.Model, TargetProvider: providers.ProviderBedrock}, enabledProviders, w, r)
+
+	require.NoError(t, err)
+	assert.True(t, outcome.Attempted)
+	assert.Equal(t, providers.ProviderOpenRouter, decision.Provider)
 }
 
 func TestClassifyFallbackError(t *testing.T) {

--- a/internal/proxy/provider_fallback_internal_test.go
+++ b/internal/proxy/provider_fallback_internal_test.go
@@ -1,0 +1,259 @@
+package proxy
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"workweave/router/internal/observability/otel"
+	"workweave/router/internal/providers"
+	"workweave/router/internal/providers/httputil"
+	"workweave/router/internal/router"
+	"workweave/router/internal/translate"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// scriptedClient is a stub providers.Client where each Proxy call returns the
+// next entry in the err slice. recordedDecisions captures the decisions the
+// helper actually dispatched against, in order, so the test can assert which
+// provider got called when.
+type scriptedClient struct {
+	name             string
+	errs             []error
+	stampFirstByte   bool
+	calls            atomic.Int32
+	gotDecisions     []router.Decision
+	gotPreparedModel []string
+}
+
+func (c *scriptedClient) Proxy(ctx context.Context, decision router.Decision, prep providers.PreparedRequest, w http.ResponseWriter, r *http.Request) error {
+	idx := int(c.calls.Add(1) - 1)
+	c.gotDecisions = append(c.gotDecisions, decision)
+	c.gotPreparedModel = append(c.gotPreparedModel, decision.Model)
+	if c.stampFirstByte {
+		otel.TimingFrom(ctx).StampUpstreamFirstByte()
+	}
+	if idx >= len(c.errs) {
+		return nil
+	}
+	return c.errs[idx]
+}
+
+func (c *scriptedClient) Passthrough(ctx context.Context, prep providers.PreparedRequest, w http.ResponseWriter, r *http.Request) error {
+	return nil
+}
+
+// envelopeFromAnthropic builds a trivial RequestEnvelope so PrepareOpenAI works.
+func envelopeFromAnthropic(t *testing.T) *translate.RequestEnvelope {
+	t.Helper()
+	env, err := translate.ParseAnthropic([]byte(`{
+		"model": "claude-opus-4-7",
+		"max_tokens": 64,
+		"messages": [{"role":"user","content":"hi"}]
+	}`))
+	require.NoError(t, err)
+	return env
+}
+
+func newFallbackService(t *testing.T, clients map[string]providers.Client) *Service {
+	t.Helper()
+	return &Service{
+		providers: clients,
+		// Other fields default to zero; proxyWithFallback only reads providers.
+	}
+}
+
+func TestProxyWithFallback_HappyPathNoFallback(t *testing.T) {
+	clients := map[string]providers.Client{
+		providers.ProviderBedrock: &scriptedClient{name: "bedrock"},
+	}
+	s := newFallbackService(t, clients)
+
+	ctx, _ := otel.WithTiming(context.Background())
+	decision := router.Decision{Model: "qwen/qwen3-235b-a22b-2507", Provider: providers.ProviderBedrock}
+	env := envelopeFromAnthropic(t)
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodPost, "/v1/messages", nil)
+	err, outcome := s.proxyWithFallback(ctx, &decision, env, translate.EmitOptions{TargetModel: decision.Model, TargetProvider: decision.Provider}, w, r)
+
+	require.NoError(t, err)
+	assert.False(t, outcome.Attempted)
+	assert.Equal(t, providers.ProviderBedrock, decision.Provider, "decision must remain on the original provider")
+}
+
+func TestProxyWithFallback_RetriesOnIdleTimeoutBeforeFirstByte(t *testing.T) {
+	// qwen3-235b-a22b-2507 has bindings [bedrock, openrouter]; the bedrock
+	// client returns an idle-timeout, the openrouter client succeeds.
+	first := &scriptedClient{name: "bedrock", errs: []error{httputil.ErrUpstreamIdleTimeout}}
+	second := &scriptedClient{name: "openrouter"}
+	clients := map[string]providers.Client{
+		providers.ProviderBedrock:    first,
+		providers.ProviderOpenRouter: second,
+	}
+	s := newFallbackService(t, clients)
+
+	ctx, _ := otel.WithTiming(context.Background())
+	decision := router.Decision{Model: "qwen/qwen3-235b-a22b-2507", Provider: providers.ProviderBedrock}
+	env := envelopeFromAnthropic(t)
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodPost, "/v1/messages", nil)
+	err, outcome := s.proxyWithFallback(ctx, &decision, env, translate.EmitOptions{TargetModel: decision.Model, TargetProvider: providers.ProviderBedrock}, w, r)
+
+	require.NoError(t, err)
+	assert.True(t, outcome.Attempted)
+	assert.Equal(t, providers.ProviderBedrock, outcome.FromProvider)
+	assert.Equal(t, providers.ProviderOpenRouter, outcome.ToProvider)
+	assert.Equal(t, "sse_idle", outcome.Reason)
+	assert.ErrorIs(t, outcome.FirstErr, httputil.ErrUpstreamIdleTimeout)
+	assert.Equal(t, int32(1), first.calls.Load())
+	assert.Equal(t, int32(1), second.calls.Load())
+	assert.Equal(t, providers.ProviderOpenRouter, decision.Provider, "decision must reflect the actually-served provider")
+}
+
+func TestProxyWithFallback_RetriesOnUpstream5xxBeforeFirstByte(t *testing.T) {
+	first := &scriptedClient{name: "bedrock", errs: []error{&providers.UpstreamStatusError{Status: 503}}}
+	second := &scriptedClient{name: "openrouter"}
+	clients := map[string]providers.Client{
+		providers.ProviderBedrock:    first,
+		providers.ProviderOpenRouter: second,
+	}
+	s := newFallbackService(t, clients)
+
+	ctx, _ := otel.WithTiming(context.Background())
+	decision := router.Decision{Model: "qwen/qwen3-235b-a22b-2507", Provider: providers.ProviderBedrock}
+	env := envelopeFromAnthropic(t)
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodPost, "/v1/messages", nil)
+	err, outcome := s.proxyWithFallback(ctx, &decision, env, translate.EmitOptions{TargetModel: decision.Model, TargetProvider: providers.ProviderBedrock}, w, r)
+
+	require.NoError(t, err)
+	assert.True(t, outcome.Attempted)
+	assert.Equal(t, "5xx", outcome.Reason)
+}
+
+func TestProxyWithFallback_NoRetryAfterFirstByte(t *testing.T) {
+	// Even though the error is idle-timeout, the upstream produced bytes
+	// before stalling — the translator has emitted deltas, so retrying
+	// against a different provider would interleave two streams.
+	first := &scriptedClient{
+		name:           "bedrock",
+		errs:           []error{httputil.ErrUpstreamIdleTimeout},
+		stampFirstByte: true,
+	}
+	second := &scriptedClient{name: "openrouter"}
+	clients := map[string]providers.Client{
+		providers.ProviderBedrock:    first,
+		providers.ProviderOpenRouter: second,
+	}
+	s := newFallbackService(t, clients)
+
+	ctx, _ := otel.WithTiming(context.Background())
+	decision := router.Decision{Model: "qwen/qwen3-235b-a22b-2507", Provider: providers.ProviderBedrock}
+	env := envelopeFromAnthropic(t)
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodPost, "/v1/messages", nil)
+	err, outcome := s.proxyWithFallback(ctx, &decision, env, translate.EmitOptions{TargetModel: decision.Model, TargetProvider: providers.ProviderBedrock}, w, r)
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, httputil.ErrUpstreamIdleTimeout)
+	assert.False(t, outcome.Attempted, "retry must not fire once any upstream byte has reached the translator")
+	assert.Equal(t, int32(0), second.calls.Load())
+	assert.Equal(t, providers.ProviderBedrock, decision.Provider, "no retry → decision stays on original provider")
+}
+
+func TestProxyWithFallback_NoRetryOn4xx(t *testing.T) {
+	first := &scriptedClient{name: "bedrock", errs: []error{&providers.UpstreamStatusError{Status: 429}}}
+	second := &scriptedClient{name: "openrouter"}
+	clients := map[string]providers.Client{
+		providers.ProviderBedrock:    first,
+		providers.ProviderOpenRouter: second,
+	}
+	s := newFallbackService(t, clients)
+
+	ctx, _ := otel.WithTiming(context.Background())
+	decision := router.Decision{Model: "qwen/qwen3-235b-a22b-2507", Provider: providers.ProviderBedrock}
+	env := envelopeFromAnthropic(t)
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodPost, "/v1/messages", nil)
+	err, outcome := s.proxyWithFallback(ctx, &decision, env, translate.EmitOptions{TargetModel: decision.Model, TargetProvider: providers.ProviderBedrock}, w, r)
+
+	require.Error(t, err)
+	assert.False(t, outcome.Attempted, "4xx (e.g. 429 rate-limit) is the caller's problem; do not retry against another provider")
+	assert.Equal(t, int32(0), second.calls.Load())
+}
+
+func TestProxyWithFallback_NoBindingsToFallbackToReturnsOriginalError(t *testing.T) {
+	// claude-opus-4-7 is anthropic-only — single binding, no fallback available.
+	first := &scriptedClient{name: "anthropic", errs: []error{httputil.ErrUpstreamIdleTimeout}}
+	clients := map[string]providers.Client{
+		providers.ProviderAnthropic: first,
+	}
+	s := newFallbackService(t, clients)
+
+	ctx, _ := otel.WithTiming(context.Background())
+	decision := router.Decision{Model: "claude-opus-4-7", Provider: providers.ProviderAnthropic}
+	env := envelopeFromAnthropic(t)
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodPost, "/v1/messages", nil)
+	err, outcome := s.proxyWithFallback(ctx, &decision, env, translate.EmitOptions{TargetModel: decision.Model, TargetProvider: providers.ProviderAnthropic}, w, r)
+
+	require.Error(t, err)
+	assert.False(t, outcome.Attempted)
+}
+
+func TestProxyWithFallback_SkipsBindingsWithUnwiredProvider(t *testing.T) {
+	// catalog has [bedrock, openrouter] for qwen3-235b; this deploy only
+	// wired bedrock. With no openrouter client in the providers map, there
+	// is no eligible fallback target.
+	first := &scriptedClient{name: "bedrock", errs: []error{httputil.ErrUpstreamIdleTimeout}}
+	clients := map[string]providers.Client{
+		providers.ProviderBedrock: first,
+	}
+	s := newFallbackService(t, clients)
+
+	ctx, _ := otel.WithTiming(context.Background())
+	decision := router.Decision{Model: "qwen/qwen3-235b-a22b-2507", Provider: providers.ProviderBedrock}
+	env := envelopeFromAnthropic(t)
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodPost, "/v1/messages", nil)
+	err, outcome := s.proxyWithFallback(ctx, &decision, env, translate.EmitOptions{TargetModel: decision.Model, TargetProvider: providers.ProviderBedrock}, w, r)
+
+	require.Error(t, err)
+	assert.False(t, outcome.Attempted)
+}
+
+func TestClassifyFallbackError(t *testing.T) {
+	cases := []struct {
+		name        string
+		err         error
+		wantReason  string
+		wantRetryOK bool
+	}{
+		{"idle", httputil.ErrUpstreamIdleTimeout, "sse_idle", true},
+		{"500", &providers.UpstreamStatusError{Status: 500}, "5xx", true},
+		{"503", &providers.UpstreamStatusError{Status: 503}, "5xx", true},
+		{"429", &providers.UpstreamStatusError{Status: 429}, "", false},
+		{"400", &providers.UpstreamStatusError{Status: 400}, "", false},
+		{"nil", nil, "", false},
+		{"unknown", errors.New("other"), "", false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			reason, ok := classifyFallbackError(c.err)
+			assert.Equal(t, c.wantRetryOK, ok)
+			assert.Equal(t, c.wantReason, reason)
+		})
+	}
+}

--- a/internal/proxy/provider_fallback_internal_test.go
+++ b/internal/proxy/provider_fallback_internal_test.go
@@ -21,7 +21,9 @@ import (
 // scriptedClient is a stub providers.Client where each Proxy call returns the
 // next entry in the err slice. recordedDecisions captures the decisions the
 // helper actually dispatched against, in order, so the test can assert which
-// provider got called when.
+// provider got called when. gotCredentials captures the credentials observed
+// on ctx at dispatch time so tests can assert credential isolation across
+// the fallback boundary.
 type scriptedClient struct {
 	name             string
 	errs             []error
@@ -29,12 +31,14 @@ type scriptedClient struct {
 	calls            atomic.Int32
 	gotDecisions     []router.Decision
 	gotPreparedModel []string
+	gotCredentials   []*Credentials
 }
 
 func (c *scriptedClient) Proxy(ctx context.Context, decision router.Decision, prep providers.PreparedRequest, w http.ResponseWriter, r *http.Request) error {
 	idx := int(c.calls.Add(1) - 1)
 	c.gotDecisions = append(c.gotDecisions, decision)
 	c.gotPreparedModel = append(c.gotPreparedModel, decision.Model)
+	c.gotCredentials = append(c.gotCredentials, CredentialsFromContext(ctx))
 	if c.stampFirstByte {
 		otel.TimingFrom(ctx).StampUpstreamFirstByte()
 	}
@@ -287,6 +291,46 @@ func TestProxyWithFallback_RespectsEnabledProviders_AllowsEligible(t *testing.T)
 	require.NoError(t, err)
 	assert.True(t, outcome.Attempted)
 	assert.Equal(t, providers.ProviderOpenRouter, decision.Provider)
+}
+
+func TestProxyWithFallback_StripsOriginalProviderCredentials(t *testing.T) {
+	// Original provider had BYOK credentials in ctx. The fallback target has
+	// no BYOK match; resolveAndInjectCredentials returns ctx unchanged for the
+	// new provider, but we must NOT carry the original provider's
+	// CredentialsContextKey value across the boundary — otherwise the next
+	// upstream sees an Authorization header populated from a different
+	// provider's BYOK key.
+	first := &scriptedClient{name: "bedrock", errs: []error{httputil.ErrUpstreamIdleTimeout}}
+	second := &scriptedClient{name: "openrouter"}
+	clients := map[string]providers.Client{
+		providers.ProviderBedrock:    first,
+		providers.ProviderOpenRouter: second,
+	}
+	s := newFallbackService(t, clients)
+
+	ctx, _ := otel.WithTiming(context.Background())
+	// Seed BYOK credentials bound to Bedrock.
+	bedrockCreds := &Credentials{APIKey: []byte("sk-bedrock-byok")}
+	ctx = context.WithValue(ctx, CredentialsContextKey{}, bedrockCreds)
+
+	decision := router.Decision{Model: "qwen/qwen3-235b-a22b-2507", Provider: providers.ProviderBedrock}
+	env := envelopeFromAnthropic(t)
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodPost, "/v1/messages", nil)
+	enabledProviders := map[string]struct{}{providers.ProviderBedrock: {}, providers.ProviderOpenRouter: {}}
+	err, outcome := s.proxyWithFallback(ctx, &decision, env, translate.EmitOptions{TargetModel: decision.Model, TargetProvider: providers.ProviderBedrock}, enabledProviders, w, r)
+
+	require.NoError(t, err)
+	require.True(t, outcome.Attempted)
+	// First call: bedrock provider, original BYOK creds OK.
+	require.Equal(t, int32(1), first.calls.Load())
+	require.Len(t, first.gotCredentials, 1)
+	assert.Equal(t, bedrockCreds, first.gotCredentials[0], "first attempt must see the original BYOK creds")
+	// Fallback call: openrouter provider, must NOT inherit bedrock creds.
+	require.Equal(t, int32(1), second.calls.Load())
+	require.Len(t, second.gotCredentials, 1)
+	assert.Nil(t, second.gotCredentials[0], "fallback provider must not inherit the original provider's BYOK credentials")
 }
 
 func TestClassifyFallbackError(t *testing.T) {

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -739,7 +739,7 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 	// stop instead.
 	if fp := computeNoProgressFingerprint(decision, promptText); s.noProgress != nil {
 		role := roleForTier(catalog.TierFor(feats.Model))
-		if looped, count := s.noProgress.recordAndDetect(routeRes.SessionKey, role, fp, time.Now()); looped {
+		if looped, count := s.noProgress.recordAndDetect(routeRes.SessionKey, installationID, role, fp, time.Now()); looped {
 			return s.handleNoProgressBreak(w, env, count, installationID, routeRes.SessionKey, role, decision.Model, decision.Provider)
 		}
 	}

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -817,6 +817,7 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 	var proxyErr error
 	crossFormat := false
 	var extractor *otel.UsageExtractor
+	var fallback fallbackOutcome
 
 	switch decision.Provider {
 	case providers.ProviderAnthropic:
@@ -834,12 +835,6 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 		proxyErr = p.Proxy(ctx, decision, prep, proxyWriter, r)
 	case providers.ProviderOpenAI, providers.ProviderOpenRouter, providers.ProviderFireworks, providers.ProviderDeepInfra, providers.ProviderBedrock:
 		crossFormat = true
-		prep, emitErr := env.PrepareOpenAI(r.Header, opts)
-		if emitErr != nil {
-			log.Error("Failed to translate Anthropic request to OpenAI format", "err", emitErr, "decision_provider", decision.Provider)
-			return fmt.Errorf("translate anthropic request: %w", emitErr)
-		}
-		logUpstreamBody(log, routeRes.SessionKey, decision, feats, prep.Body)
 		var usage otel.UsageSink
 		if s.usageRequired() {
 			extractor = otel.NewUsageExtractor(nil, decision.Provider)
@@ -851,7 +846,7 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 		if err := translator.Prelude(env.Stream()); err != nil {
 			log.Error("Anthropic SSE prelude failed (OpenAI upstream)", "err", err)
 		}
-		proxyErr = p.Proxy(ctx, decision, prep, translator, r)
+		proxyErr, fallback = s.proxyWithFallback(ctx, &decision, env, opts, translator, r)
 		proxyErr = finalizeAfterProxy(proxyErr, translator.Finalize)
 	case providers.ProviderGoogle:
 		crossFormat = true
@@ -979,7 +974,7 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 		s.emitBilling(ctx, requestID, externalID, decision, actPricing, routeRes, in, out, cacheCreation, cacheRead)
 	}
 
-	log.Info("ProxyMessages complete", "requested_model", feats.Model, "baseline_model", s.baselineFor(feats.Model), "decision_model", decision.Model, "decision_provider", decision.Provider, "decision_reason", decision.Reason, "requested_tier", routeRes.RequestedTier.String(), "decision_tier", catalog.TierFor(decision.Model).String(), "tier_clamped", routeRes.TierClamped, "pre_clamp_model", routeRes.PreClampModel, "embedded_tokens", len(promptText)/4, "total_input_tokens", feats.Tokens, "has_tools", feats.HasTools, "message_count", feats.MessageCount, "last_kind", feats.LastKind, "last_preview", feats.LastPreview, "embed_input", embedInput, "cross_format", crossFormat, "sticky_hit", stickyHit, "route_ms", routeMs, "proxy_ms", proxyMs, "proxy_err", proxyErr, "upstream_status", upstreamStatus(proxyErr))
+	log.Info("ProxyMessages complete", "requested_model", feats.Model, "baseline_model", s.baselineFor(feats.Model), "decision_model", decision.Model, "decision_provider", decision.Provider, "decision_reason", decision.Reason, "requested_tier", routeRes.RequestedTier.String(), "decision_tier", catalog.TierFor(decision.Model).String(), "tier_clamped", routeRes.TierClamped, "pre_clamp_model", routeRes.PreClampModel, "embedded_tokens", len(promptText)/4, "total_input_tokens", feats.Tokens, "has_tools", feats.HasTools, "message_count", feats.MessageCount, "last_kind", feats.LastKind, "last_preview", feats.LastPreview, "embed_input", embedInput, "cross_format", crossFormat, "sticky_hit", stickyHit, "route_ms", routeMs, "proxy_ms", proxyMs, "proxy_err", proxyErr, "upstream_status", upstreamStatus(proxyErr), "fallback_attempted", fallback.Attempted, "fallback_from_provider", fallback.FromProvider, "fallback_to_provider", fallback.ToProvider, "fallback_reason", fallback.Reason)
 	return proxyErr
 }
 
@@ -1645,20 +1640,16 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 	var proxyErr error
 	crossFormat := false
 	var extractor *otel.UsageExtractor
+	var fallback fallbackOutcome
 
 	switch decision.Provider {
 	case providers.ProviderOpenAI, providers.ProviderOpenRouter, providers.ProviderFireworks, providers.ProviderDeepInfra, providers.ProviderBedrock:
-		prep, emitErr := env.PrepareOpenAI(r.Header, opts)
-		if emitErr != nil {
-			log.Error("Failed to emit OpenAI body", "err", emitErr)
-			return fmt.Errorf("emit body: %w", emitErr)
-		}
 		proxyWriter := sink
 		if s.usageRequired() {
 			extractor = otel.NewUsageExtractor(sink, decision.Provider)
 			proxyWriter = extractor
 		}
-		proxyErr = p.Proxy(ctx, decision, prep, proxyWriter, r)
+		proxyErr, fallback = s.proxyWithFallback(ctx, &decision, env, opts, proxyWriter, r)
 	case providers.ProviderGoogle:
 		crossFormat = true
 		prep, emitErr := env.PrepareGemini(r.Header, opts)
@@ -1787,7 +1778,7 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 		})
 	}
 
-	log.Info("ProxyOpenAIChatCompletion complete", "requested_model", feats.Model, "baseline_model", s.baselineFor(feats.Model), "decision_model", decision.Model, "decision_provider", decision.Provider, "decision_reason", decision.Reason, "requested_tier", routeRes.RequestedTier.String(), "decision_tier", catalog.TierFor(decision.Model).String(), "tier_clamped", routeRes.TierClamped, "pre_clamp_model", routeRes.PreClampModel, "embedded_tokens", len(promptText)/4, "total_input_tokens", feats.Tokens, "has_tools", feats.HasTools, "embed_input", embedInput, "cross_format", crossFormat, "sticky_hit", stickyHit, "pin_tier", pinTier, "turn_type", string(tt), "route_ms", routeMs, "proxy_ms", proxyMs, "proxy_err", proxyErr, "upstream_status", upstreamStatus(proxyErr))
+	log.Info("ProxyOpenAIChatCompletion complete", "requested_model", feats.Model, "baseline_model", s.baselineFor(feats.Model), "decision_model", decision.Model, "decision_provider", decision.Provider, "decision_reason", decision.Reason, "requested_tier", routeRes.RequestedTier.String(), "decision_tier", catalog.TierFor(decision.Model).String(), "tier_clamped", routeRes.TierClamped, "pre_clamp_model", routeRes.PreClampModel, "embedded_tokens", len(promptText)/4, "total_input_tokens", feats.Tokens, "has_tools", feats.HasTools, "embed_input", embedInput, "cross_format", crossFormat, "sticky_hit", stickyHit, "pin_tier", pinTier, "turn_type", string(tt), "route_ms", routeMs, "proxy_ms", proxyMs, "proxy_err", proxyErr, "upstream_status", upstreamStatus(proxyErr), "fallback_attempted", fallback.Attempted, "fallback_from_provider", fallback.FromProvider, "fallback_to_provider", fallback.ToProvider, "fallback_reason", fallback.Reason)
 	return proxyErr
 }
 

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -708,13 +708,14 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 
 	// Anthropic packs sub-agent identity into metadata.user_id; the
 	// x-weave-subagent-type header is for non-Anthropic ingress only.
+	enabledProviders := s.enabledProvidersForRequest(ctx, providers.ProviderAnthropic, r.Header)
 	routeStart := time.Now()
 	routeRes, routeErr := s.runTurnLoop(ctx, env, feats, apiKeyID, installationID, "", r.Header, router.Request{
 		RequestedModel:       feats.Model,
 		EstimatedInputTokens: feats.Tokens,
 		HasTools:             feats.HasTools,
 		PromptText:           promptText,
-		EnabledProviders:     s.enabledProvidersForRequest(ctx, providers.ProviderAnthropic, r.Header),
+		EnabledProviders:     enabledProviders,
 		ExcludedModels:       s.excludedModelsForRequest(ctx),
 		RoutingKnobs:         router.RoutingKnobsFromContext(ctx),
 	})
@@ -864,7 +865,7 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 		if err := translator.Prelude(env.Stream()); err != nil {
 			log.Error("Anthropic SSE prelude failed (OpenAI upstream)", "err", err)
 		}
-		proxyErr, fallback = s.proxyWithFallback(ctx, &decision, env, opts, translator, r)
+		proxyErr, fallback = s.proxyWithFallback(ctx, &decision, env, opts, enabledProviders, translator, r)
 		proxyErr = finalizeAfterProxy(proxyErr, translator.Finalize)
 	case providers.ProviderGoogle:
 		crossFormat = true
@@ -1529,13 +1530,14 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 	// OpenAI signals sub-agent identity via x-weave-subagent-type (no metadata.user_id).
 	subAgentHint := r.Header.Get("x-weave-subagent-type")
 
+	enabledProviders := s.enabledProvidersForRequest(ctx, providers.ProviderOpenAI, r.Header)
 	routeStart := time.Now()
 	routeRes, err := s.runTurnLoop(ctx, env, feats, apiKeyID, installationID, subAgentHint, r.Header, router.Request{
 		RequestedModel:       feats.Model,
 		EstimatedInputTokens: feats.Tokens,
 		HasTools:             feats.HasTools,
 		PromptText:           promptText,
-		EnabledProviders:     s.enabledProvidersForRequest(ctx, providers.ProviderOpenAI, r.Header),
+		EnabledProviders:     enabledProviders,
 		ExcludedModels:       s.excludedModelsForRequest(ctx),
 		RoutingKnobs:         router.RoutingKnobsFromContext(ctx),
 	})
@@ -1667,7 +1669,7 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 			extractor = otel.NewUsageExtractor(sink, decision.Provider)
 			proxyWriter = extractor
 		}
-		proxyErr, fallback = s.proxyWithFallback(ctx, &decision, env, opts, proxyWriter, r)
+		proxyErr, fallback = s.proxyWithFallback(ctx, &decision, env, opts, enabledProviders, proxyWriter, r)
 	case providers.ProviderGoogle:
 		crossFormat = true
 		prep, emitErr := env.PrepareGemini(r.Header, opts)

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -41,6 +41,10 @@ type Service struct {
 	// pinCache absorbs the hot path; 30s TTL is short enough that pinned_until
 	// in the pin store remains source of truth for validity.
 	pinCache *expirable.LRU[string, sessionpin.Pin]
+	// noProgress tracks per-session dispatch fingerprints to catch the
+	// cross-envelope subagent loop (parent agent re-spawning identical
+	// sub-conversations). Nil disables the detector.
+	noProgress *noProgressTracker
 	// pinWriteSem bounds concurrent async pin-upsert goroutines with drop-on-full semantics.
 	pinWriteSem chan struct{}
 	// usageWriteSem bounds concurrent async last-turn-usage writeback goroutines,
@@ -257,6 +261,7 @@ func NewService(r router.Router, providerMap map[string]providers.Client, emitte
 		semanticCache:        semanticCache,
 		pinStore:             pinStore,
 		pinCache:             pinCache,
+		noProgress:           newNoProgressTracker(),
 		pinWriteSem:          pinWriteSem,
 		usageWriteSem:        usageWriteSem,
 		hardPinExplore:       hardPinExplore,
@@ -724,6 +729,19 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 	pinAgeSec := routeRes.PinAgeSec
 	routeMs := time.Since(routeStart).Milliseconds()
 	s.logPlannerOutcome(routeRes)
+
+	// Cross-envelope no-progress detector: if this session has dispatched the
+	// same (decision_model, decision_provider, prompt-prefix) burst >=
+	// noProgressMatchThreshold times within noProgressTimeWindow, the parent
+	// agent is in a sub-agent spawn loop and another dispatch will only
+	// reproduce the same useless response. Break the pin and emit a synthetic
+	// stop instead.
+	if fp := computeNoProgressFingerprint(decision, promptText); s.noProgress != nil {
+		role := roleForTier(catalog.TierFor(feats.Model))
+		if looped, count := s.noProgress.recordAndDetect(routeRes.SessionKey, role, fp, time.Now()); looped {
+			return s.handleNoProgressBreak(w, env, count, installationID, routeRes.SessionKey, role, decision.Model, decision.Provider)
+		}
+	}
 
 	// Semantic-cache eligibility: configured, non-streaming, decision has
 	// metadata, externalID present, not eval traffic.

--- a/internal/router/catalog/catalog.go
+++ b/internal/router/catalog/catalog.go
@@ -83,6 +83,19 @@ type ProviderBinding struct {
 	Price Pricing
 }
 
+// ToolUseQuality marks a model's qualitative reliability under has_tools=true
+// turns. ToolUseUnknown (the zero value) means "no concerns recorded"; ToolUseLow
+// flags models that hallucinate tool calls, emit malformed tool_use blocks, or
+// loop on the same tool. The cluster scorer excludes ToolUseLow models from
+// argmax when the inbound request carries tools, falling back to the unfiltered
+// pool only if the blacklist would otherwise empty the eligible set.
+type ToolUseQuality int
+
+const (
+	ToolUseUnknown ToolUseQuality = iota
+	ToolUseLow
+)
+
 // Model is one logical model — the unit the router decides on.
 type Model struct {
 	// ID is the public slash-form (or bare) model ID exposed to clients,
@@ -91,6 +104,10 @@ type Model struct {
 	// Tier is the coarse capability bucket. TierUnknown means the model
 	// is not deployable as a routing target (passthrough only).
 	Tier Tier
+	// ToolUseQuality marks a model's reliability under has_tools=true. Zero
+	// value (ToolUseUnknown) is the default — set ToolUseLow to remove the
+	// model from agentic argmax pools.
+	ToolUseQuality ToolUseQuality
 	// Providers is the ordered fallback list. First binding whose
 	// Provider name is in the available set wins. Must be non-empty.
 	Providers []ProviderBinding
@@ -252,7 +269,13 @@ var Models = []Model{
 	//   stays as a trailing fallback for self-hosters without an AWS key.
 	//   The OR primary was dropped because we observed non-SSE responses
 	//   when OR routed Qwen through Google's hosting (silent CC stalls).
-	{ID: "qwen/qwen3-235b-a22b-2507", Tier: TierMid, Providers: []ProviderBinding{
+	//   ToolUseLow: Instruct-2507 is the non-thinking variant and is
+	//   documented (Qwen model card, arxiv 2604.02155) to under-perform
+	//   the Thinking variant on tool use; production traffic against the
+	//   Bedrock binding (2026-05-23) showed the model returning narrative
+	//   "I edited the file" responses with zero tool_use blocks. Excluded
+	//   from agentic argmax pools until the Thinking variant lands.
+	{ID: "qwen/qwen3-235b-a22b-2507", Tier: TierMid, ToolUseQuality: ToolUseLow, Providers: []ProviderBinding{
 		{Provider: providers.ProviderBedrock, UpstreamID: "qwen.qwen3-235b-a22b-2507",
 			Price: Pricing{InputUSDPer1M: 0.2266, OutputUSDPer1M: 0.9064}},
 		{Provider: providers.ProviderOpenRouter, Price: Pricing{InputUSDPer1M: 0.071, OutputUSDPer1M: 0.463}},

--- a/internal/router/catalog/catalog_test.go
+++ b/internal/router/catalog/catalog_test.go
@@ -107,6 +107,34 @@ func TestAllowedAtOrBelow_FiltersOutUnknownTier(t *testing.T) {
 	assert.False(t, high)
 }
 
+func TestToolUseLowSet_IncludesQwen3_235BInstruct(t *testing.T) {
+	// Production traffic on 2026-05-23 saw Instruct-2507 emit narrative
+	// "I edited the file" without tool_use blocks — flagged ToolUseLow so
+	// the cluster scorer excludes it from agentic argmax. If this assertion
+	// fires, either the entry was downgraded back to ToolUseUnknown or the
+	// catalog row was renamed.
+	set := ToolUseLowSet()
+	_, found := set["qwen/qwen3-235b-a22b-2507"]
+	assert.True(t, found, "qwen/qwen3-235b-a22b-2507 must be marked ToolUseLow")
+}
+
+func TestToolUseLowSet_OmitsHealthyModels(t *testing.T) {
+	set := ToolUseLowSet()
+	for _, id := range []string{"claude-opus-4-7", "deepseek/deepseek-v4-pro", "moonshotai/kimi-k2.5"} {
+		_, found := set[id]
+		assert.Falsef(t, found, "%s must NOT be in the ToolUseLow set", id)
+	}
+}
+
+func TestModel_ToolUseQualityDefaultsToUnknown(t *testing.T) {
+	// Zero-value safety: an unset ToolUseQuality must default to
+	// ToolUseUnknown so the scorer treats the model as healthy until
+	// proven otherwise. Guards against a future iota reorder that would
+	// silently flip every catalog row to ToolUseLow.
+	var m Model
+	assert.Equal(t, ToolUseUnknown, m.ToolUseQuality)
+}
+
 func TestValidateDeployed_FlagsMissingAndUntiered(t *testing.T) {
 	err := ValidateDeployed([]string{"claude-opus-4-7"})
 	assert.NoError(t, err)

--- a/internal/router/catalog/lookup.go
+++ b/internal/router/catalog/lookup.go
@@ -106,6 +106,21 @@ func AllowedAtOrBelow(ceiling Tier) map[string]struct{} {
 	return out
 }
 
+// ToolUseLowSet returns the set of model IDs whose ToolUseQuality is
+// ToolUseLow. The cluster scorer subtracts this set from the eligible pool
+// when req.HasTools is true; falls back to the unfiltered pool when the
+// subtraction would empty the eligible set so a routing decision is always
+// returned.
+func ToolUseLowSet() map[string]struct{} {
+	out := make(map[string]struct{}, len(Models))
+	for _, m := range Models {
+		if m.ToolUseQuality == ToolUseLow {
+			out[m.ID] = struct{}{}
+		}
+	}
+	return out
+}
+
 // AllPrimaryPricing returns a copy of the primary-binding pricing for
 // every known model, keyed by model ID. Used by the OTel emitter and the
 // genprices install-script generator.

--- a/internal/router/cluster/scorer.go
+++ b/internal/router/cluster/scorer.go
@@ -338,6 +338,34 @@ func (s *Scorer) Route(ctx context.Context, req router.Request) (router.Decision
 		eligibleModels = filtered
 	}
 
+	// Tool-use quality filter. When the inbound carries tools, drop any
+	// model the catalog has marked ToolUseLow (e.g. instruct-only variants
+	// that hallucinate tool calls). Soft filter: if the subtraction would
+	// empty the eligible pool, fall back to the unfiltered set rather than
+	// 4xx-ing the request — this is a quality preference, not a correctness
+	// gate.
+	if req.HasTools {
+		if blacklist := catalog.ToolUseLowSet(); len(blacklist) > 0 {
+			filtered := eligibleModels[:0:0]
+			var dropped []string
+			for _, m := range eligibleModels {
+				if _, drop := blacklist[m]; drop {
+					dropped = append(dropped, m)
+					continue
+				}
+				filtered = append(filtered, m)
+			}
+			if len(filtered) > 0 && len(dropped) > 0 {
+				log.Debug(
+					"Cluster scorer: tool-use blacklist applied",
+					"dropped_models", dropped,
+					"requested_model", req.RequestedModel,
+				)
+				eligibleModels = filtered
+			}
+		}
+	}
+
 	scoreStart := time.Now()
 	topClusters := topPNearest(vec, s.centroids, s.cfg.TopP)
 

--- a/internal/router/cluster/scorer_test.go
+++ b/internal/router/cluster/scorer_test.go
@@ -680,6 +680,72 @@ func TestScorer_ExcludedModelsEmptyingPoolReturnsErrNoEligibleProvider(t *testin
 	assert.False(t, errors.Is(err, ErrClusterUnavailable))
 }
 
+// has_tools=true must subtract catalog.ToolUseLowSet from the argmax pool
+// so qwen3-235b-Instruct (and other instruct-only weak tool callers) cannot
+// be picked for agentic workloads.
+func TestScorer_HasToolsExcludesToolUseLowFromArgmax(t *testing.T) {
+	dim := EmbedDim
+	c0 := make([]float32, dim)
+	c0[0] = 1
+	cb := buildCentroidsBlob(t, 1, dim, c0)
+	// Ranking puts qwen3-235b above claude-opus so without the filter it
+	// would win; the filter must demote it on has_tools=true.
+	rb := []byte(`{"rankings": {"0": {
+		"qwen/qwen3-235b-a22b-2507": 0.95,
+		"claude-opus-4-7": 0.10
+	}}}`)
+	regb := []byte(`{
+		"deployed_models": [
+			{"model": "qwen/qwen3-235b-a22b-2507", "provider": "bedrock", "bench_column": "routerarena_qwen/qwen3-235b-a22b-2507"},
+			{"model": "claude-opus-4-7", "provider": "anthropic", "bench_column": "gpt-5", "proxy": true}
+		]
+	}`)
+	cfg := cfgForTest()
+	cfg.TopP = 1
+	s, err := NewScorer(bundleFromBlobs(t, "v-test-toolfilter", cb, rb, regb), cfg, &fakeEmbedder{vec: makeOpusVec()},
+		map[string]struct{}{"bedrock": {}, "anthropic": {}})
+	require.NoError(t, err)
+
+	// No tools: qwen3-235b wins (highest score).
+	got, err := s.Route(context.Background(), router.Request{PromptText: strings.Repeat("x", 100)})
+	require.NoError(t, err)
+	assert.Equal(t, "qwen/qwen3-235b-a22b-2507", got.Model, "without tools, qwen3-235b should win on score")
+
+	// With tools: filter drops qwen3-235b → claude-opus wins.
+	got, err = s.Route(context.Background(), router.Request{PromptText: strings.Repeat("x", 100), HasTools: true})
+	require.NoError(t, err)
+	assert.Equal(t, "claude-opus-4-7", got.Model, "has_tools=true must drop ToolUseLow models from argmax")
+}
+
+// Soft-filter regression: if the ToolUseLow filter would empty the eligible
+// pool, fall back to the unfiltered set rather than 4xx-ing — this is a
+// quality preference, not a correctness gate.
+func TestScorer_HasToolsFallsBackWhenFilterEmptiesPool(t *testing.T) {
+	dim := EmbedDim
+	c0 := make([]float32, dim)
+	c0[0] = 1
+	cb := buildCentroidsBlob(t, 1, dim, c0)
+	rb := []byte(`{"rankings": {"0": {
+		"qwen/qwen3-235b-a22b-2507": 0.95
+	}}}`)
+	regb := []byte(`{
+		"deployed_models": [
+			{"model": "qwen/qwen3-235b-a22b-2507", "provider": "bedrock", "bench_column": "routerarena_qwen/qwen3-235b-a22b-2507"}
+		]
+	}`)
+	cfg := cfgForTest()
+	cfg.TopP = 1
+	s, err := NewScorer(bundleFromBlobs(t, "v-test-fallback", cb, rb, regb), cfg, &fakeEmbedder{vec: makeOpusVec()},
+		map[string]struct{}{"bedrock": {}})
+	require.NoError(t, err)
+
+	// has_tools=true: filter would empty the pool, so we keep qwen3-235b
+	// rather than returning an error.
+	got, err := s.Route(context.Background(), router.Request{PromptText: strings.Repeat("x", 100), HasTools: true})
+	require.NoError(t, err)
+	assert.Equal(t, "qwen/qwen3-235b-a22b-2507", got.Model, "filter must fall back when it would empty the pool")
+}
+
 // DeployedModels returns the full provider-filtered candidate list, not the
 // per-request eligible subset.
 func TestScorer_DeployedModelsReturnsBootCandidates(t *testing.T) {

--- a/internal/translate/emit_openai.go
+++ b/internal/translate/emit_openai.go
@@ -69,15 +69,10 @@ func (e *RequestEnvelope) buildOpenAIFromOpenAI(opts EmitOptions) ([]byte, error
 				return nil, fmt.Errorf("set tool temperature override: %w", err)
 			}
 		}
-		// Qwen3 anti-loop: presence_penalty=1.5 per the Qwen3 model card.
-		// Only applied when the client has not specified one itself, so a
-		// caller that has its own tuning preference still wins.
-		if isQwen3Family(opts.TargetModel) && !gjson.GetBytes(body, "presence_penalty").Exists() {
-			body, err = sjson.SetBytes(body, "presence_penalty", qwen3PresencePenalty)
-			if err != nil {
-				return nil, fmt.Errorf("set qwen3 presence_penalty: %w", err)
-			}
-		}
+	}
+	body, err = applyQwen3SamplersIfNeeded(body, opts.TargetModel)
+	if err != nil {
+		return nil, err
 	}
 	return body, nil
 }
@@ -144,14 +139,6 @@ func (e *RequestEnvelope) buildOpenAIFromAnthropic(opts EmitOptions) ([]byte, er
 		}
 	}
 
-	// Qwen3 anti-loop presence_penalty (cross-format). Only added when the
-	// client did not set one. Mirrors the same-format branch above.
-	if targetIsOpenRouter(opts) && isQwen3Family(opts.TargetModel) &&
-		!gjson.GetBytes(body, "presence_penalty").Exists() {
-		jw.Key("presence_penalty")
-		jw.Float(qwen3PresencePenalty)
-	}
-
 	// Max tokens
 	writeOpenAIMaxTokensFromAnthropic(jw, body, opts)
 
@@ -181,7 +168,40 @@ func (e *RequestEnvelope) buildOpenAIFromAnthropic(opts EmitOptions) ([]byte, er
 	}
 
 	jw.EndObj()
-	return jw.Bytes(), nil
+	return applyQwen3SamplersIfNeeded(jw.Bytes(), opts.TargetModel)
+}
+
+// applyQwen3SamplersIfNeeded layers the Qwen3 model-card sampling defaults onto
+// the outbound body when the target is a qwen3-family model and the client did
+// not set them. Applied across all OpenAI-compat providers (OpenRouter, Bedrock,
+// DeepInfra, Fireworks) — the recommendation is model-keyed, not provider-keyed,
+// and Qwen3 only routes to OpenAI-compat backends so unknown-field rejection
+// (e.g. OpenAI native strict mode) is not in scope.
+func applyQwen3SamplersIfNeeded(body []byte, model string) ([]byte, error) {
+	if !isQwen3Family(model) {
+		return body, nil
+	}
+	type sampler struct {
+		key string
+		val float64
+	}
+	defaults := []sampler{
+		{"temperature", qwen3Temperature},
+		{"top_p", qwen3TopP},
+		{"presence_penalty", qwen3PresencePenalty},
+		{"repetition_penalty", qwen3RepetitionPenalty},
+	}
+	for _, s := range defaults {
+		if gjson.GetBytes(body, s.key).Exists() {
+			continue
+		}
+		out, err := sjson.SetBytes(body, s.key, s.val)
+		if err != nil {
+			return nil, fmt.Errorf("set qwen3 %s: %w", s.key, err)
+		}
+		body = out
+	}
+	return body, nil
 }
 
 // writeOpenAISystemAndMessagesFromAnthropic emits the "messages" key into jw by

--- a/internal/translate/provider_hint.go
+++ b/internal/translate/provider_hint.go
@@ -55,13 +55,22 @@ func openRouterForcesToolTemperatureZero(model string) bool {
 
 // isQwen3Family reports whether the model id belongs to the qwen3.x family.
 // Qwen3 variants (instruct, coder, qwen3-next, qwen3.6-*) are documented to
-// drift into tool-call / thinking loops without a non-zero presence_penalty;
-// the Qwen3 model card recommends presence_penalty=1.5 to suppress this.
+// drift into tool-call / thinking loops without the recommended sampling
+// defaults; the Qwen3 model card publishes a tuned set of params for
+// agentic/code workloads which we layer in when the client did not set them.
 func isQwen3Family(model string) bool {
 	return strings.HasPrefix(model, "qwen/qwen3")
 }
 
-// qwen3PresencePenalty is the recommended Qwen3 presence_penalty value from
-// the official model card; applied only when the client has not set
-// presence_penalty itself.
-const qwen3PresencePenalty = 1.5
+// Qwen3 sampling defaults from the official model card and Unsloth runbook
+// (huggingface.co/Qwen/Qwen3-235B-A22B-Instruct-2507 — "Sampling Parameters").
+// Applied only when the client has not set the corresponding field, so callers
+// with their own tuning still win. presence_penalty=1.5 specifically suppresses
+// the "same tool, same args, N times in a row" loop the Instruct variant is
+// prone to without CoT.
+const (
+	qwen3Temperature       = 0.7
+	qwen3TopP              = 0.8
+	qwen3PresencePenalty   = 1.5
+	qwen3RepetitionPenalty = 1.05
+)

--- a/internal/translate/qwen3_sampling_test.go
+++ b/internal/translate/qwen3_sampling_test.go
@@ -13,12 +13,28 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// Qwen3 anti-loop sampling: the router injects presence_penalty=1.5 when an
-// OpenRouter-bound request targets a qwen3 model and the client did not set
-// one itself. Validates both the OpenAI same-format path and the
-// Anthropic→OpenAI cross-format path.
+// Qwen3 sampling defaults: the router layers the Qwen3 model-card recommended
+// sampling parameters onto outbound bodies when the target is a qwen3 model
+// and the client did not set the corresponding field. Applies across all
+// OpenAI-compat backends (OpenRouter, Bedrock, DeepInfra, Fireworks) because
+// the recommendation is model-keyed, not provider-keyed.
 
-func TestQwen3PresencePenalty_OpenAISameFormat_InjectedForQwen3(t *testing.T) {
+const qwen3PresencePenaltyExpected = 1.5
+const qwen3TemperatureExpected = 0.7
+const qwen3TopPExpected = 0.8
+const qwen3RepetitionPenaltyExpected = 1.05
+
+func assertQwen3Defaults(t *testing.T, body []byte) {
+	t.Helper()
+	var out map[string]any
+	require.NoError(t, json.Unmarshal(body, &out))
+	assert.Equal(t, qwen3TemperatureExpected, out["temperature"], "qwen3 must receive temperature=0.7")
+	assert.Equal(t, qwen3TopPExpected, out["top_p"], "qwen3 must receive top_p=0.8")
+	assert.Equal(t, qwen3PresencePenaltyExpected, out["presence_penalty"], "qwen3 must receive presence_penalty=1.5")
+	assert.Equal(t, qwen3RepetitionPenaltyExpected, out["repetition_penalty"], "qwen3 must receive repetition_penalty=1.05")
+}
+
+func TestQwen3Samplers_OpenAISameFormat_InjectedForQwen3(t *testing.T) {
 	body := []byte(`{"model":"gpt-4o","messages":[{"role":"user","content":"hi"}]}`)
 	env, err := translate.ParseOpenAI(body)
 	require.NoError(t, err)
@@ -28,43 +44,10 @@ func TestQwen3PresencePenalty_OpenAISameFormat_InjectedForQwen3(t *testing.T) {
 		Capabilities:   router.Lookup("qwen/qwen3.6-35b-a3b"),
 	})
 	require.NoError(t, err)
-	var out map[string]any
-	require.NoError(t, json.Unmarshal(prep.Body, &out))
-	assert.Equal(t, 1.5, out["presence_penalty"], "qwen3 must receive presence_penalty=1.5")
+	assertQwen3Defaults(t, prep.Body)
 }
 
-func TestQwen3PresencePenalty_NotInjectedForNonQwen(t *testing.T) {
-	body := []byte(`{"model":"gpt-4o","messages":[{"role":"user","content":"hi"}]}`)
-	env, err := translate.ParseOpenAI(body)
-	require.NoError(t, err)
-	prep, err := env.PrepareOpenAI(http.Header{}, translate.EmitOptions{
-		TargetModel:    "deepseek/deepseek-v4-pro",
-		TargetProvider: providers.ProviderOpenRouter,
-		Capabilities:   router.Lookup("deepseek/deepseek-v4-pro"),
-	})
-	require.NoError(t, err)
-	var out map[string]any
-	require.NoError(t, json.Unmarshal(prep.Body, &out))
-	_, has := out["presence_penalty"]
-	assert.False(t, has, "non-qwen3 models must not receive the presence_penalty override")
-}
-
-func TestQwen3PresencePenalty_DoesNotOverrideClientValue(t *testing.T) {
-	body := []byte(`{"model":"gpt-4o","messages":[{"role":"user","content":"hi"}],"presence_penalty":0.2}`)
-	env, err := translate.ParseOpenAI(body)
-	require.NoError(t, err)
-	prep, err := env.PrepareOpenAI(http.Header{}, translate.EmitOptions{
-		TargetModel:    "qwen/qwen3.6-35b-a3b",
-		TargetProvider: providers.ProviderOpenRouter,
-		Capabilities:   router.Lookup("qwen/qwen3.6-35b-a3b"),
-	})
-	require.NoError(t, err)
-	var out map[string]any
-	require.NoError(t, json.Unmarshal(prep.Body, &out))
-	assert.Equal(t, 0.2, out["presence_penalty"], "client-set presence_penalty must win over the qwen3 default")
-}
-
-func TestQwen3PresencePenalty_AnthropicToOpenAI(t *testing.T) {
+func TestQwen3Samplers_AnthropicCrossFormat_InjectedForQwen3(t *testing.T) {
 	body := []byte(`{
 		"model": "claude-opus-4-7",
 		"max_tokens": 256,
@@ -78,7 +61,93 @@ func TestQwen3PresencePenalty_AnthropicToOpenAI(t *testing.T) {
 		Capabilities:   router.Lookup("qwen/qwen3.6-35b-a3b"),
 	})
 	require.NoError(t, err)
+	assertQwen3Defaults(t, prep.Body)
+}
+
+func TestQwen3Samplers_AppliedOnBedrockTarget(t *testing.T) {
+	// Production bedrock-mantle traffic was previously skipping the qwen3
+	// sampler block because the targetIsOpenRouter gate excluded it. With
+	// the model-keyed application, samplers now reach Bedrock too.
+	body := []byte(`{
+		"model": "claude-opus-4-7",
+		"max_tokens": 256,
+		"messages": [{"role":"user","content":"hi"}]
+	}`)
+	env, err := translate.ParseAnthropic(body)
+	require.NoError(t, err)
+	prep, err := env.PrepareOpenAI(http.Header{}, translate.EmitOptions{
+		TargetModel:    "qwen/qwen3-235b-a22b-2507",
+		TargetProvider: providers.ProviderBedrock,
+		Capabilities:   router.Lookup("qwen/qwen3-235b-a22b-2507"),
+	})
+	require.NoError(t, err)
+	assertQwen3Defaults(t, prep.Body)
+}
+
+func TestQwen3Samplers_NotInjectedForNonQwen(t *testing.T) {
+	body := []byte(`{"model":"gpt-4o","messages":[{"role":"user","content":"hi"}]}`)
+	env, err := translate.ParseOpenAI(body)
+	require.NoError(t, err)
+	prep, err := env.PrepareOpenAI(http.Header{}, translate.EmitOptions{
+		TargetModel:    "deepseek/deepseek-v4-pro",
+		TargetProvider: providers.ProviderOpenRouter,
+		Capabilities:   router.Lookup("deepseek/deepseek-v4-pro"),
+	})
+	require.NoError(t, err)
 	var out map[string]any
 	require.NoError(t, json.Unmarshal(prep.Body, &out))
-	assert.Equal(t, 1.5, out["presence_penalty"], "cross-format emit must inject qwen3 presence_penalty")
+	for _, key := range []string{"top_p", "presence_penalty", "repetition_penalty"} {
+		_, has := out[key]
+		assert.False(t, has, "non-qwen3 models must not receive the %s default", key)
+	}
+}
+
+func TestQwen3Samplers_DoNotOverrideClientValues(t *testing.T) {
+	body := []byte(`{
+		"model":"gpt-4o",
+		"messages":[{"role":"user","content":"hi"}],
+		"temperature":0.1,
+		"top_p":0.5,
+		"presence_penalty":0.2,
+		"repetition_penalty":1.2
+	}`)
+	env, err := translate.ParseOpenAI(body)
+	require.NoError(t, err)
+	prep, err := env.PrepareOpenAI(http.Header{}, translate.EmitOptions{
+		TargetModel:    "qwen/qwen3.6-35b-a3b",
+		TargetProvider: providers.ProviderOpenRouter,
+		Capabilities:   router.Lookup("qwen/qwen3.6-35b-a3b"),
+	})
+	require.NoError(t, err)
+	var out map[string]any
+	require.NoError(t, json.Unmarshal(prep.Body, &out))
+	assert.Equal(t, 0.1, out["temperature"], "client temperature must win")
+	assert.Equal(t, 0.5, out["top_p"], "client top_p must win")
+	assert.Equal(t, 0.2, out["presence_penalty"], "client presence_penalty must win")
+	assert.Equal(t, 1.2, out["repetition_penalty"], "client repetition_penalty must win")
+}
+
+func TestQwen3Samplers_PartialClientOverridesFillRest(t *testing.T) {
+	// Client sets only temperature; the router should still fill the other
+	// three defaults but leave temperature alone.
+	body := []byte(`{
+		"model": "claude-opus-4-7",
+		"max_tokens": 256,
+		"messages": [{"role":"user","content":"hi"}],
+		"temperature": 0.3
+	}`)
+	env, err := translate.ParseAnthropic(body)
+	require.NoError(t, err)
+	prep, err := env.PrepareOpenAI(http.Header{}, translate.EmitOptions{
+		TargetModel:    "qwen/qwen3.6-35b-a3b",
+		TargetProvider: providers.ProviderOpenRouter,
+		Capabilities:   router.Lookup("qwen/qwen3.6-35b-a3b"),
+	})
+	require.NoError(t, err)
+	var out map[string]any
+	require.NoError(t, json.Unmarshal(prep.Body, &out))
+	assert.Equal(t, 0.3, out["temperature"], "client temperature must win")
+	assert.Equal(t, qwen3TopPExpected, out["top_p"])
+	assert.Equal(t, qwen3PresencePenaltyExpected, out["presence_penalty"])
+	assert.Equal(t, qwen3RepetitionPenaltyExpected, out["repetition_penalty"])
 }

--- a/internal/translate/tool_temperature_test.go
+++ b/internal/translate/tool_temperature_test.go
@@ -81,7 +81,10 @@ func TestToolTemperature_AnthropicSource_NoOverrideWithoutTools(t *testing.T) {
 }
 
 func TestToolTemperature_AnthropicSource_NoOverrideForOtherModels(t *testing.T) {
-	cases := []string{"gpt-5", "moonshotai/kimi-k2.5", "qwen/qwen3-max", "google/gemini-2.5-pro"}
+	// qwen3 models get their own non-zero temperature default from the Qwen
+	// sampler block (covered in qwen3_sampling_test.go); deepseek is the
+	// only family with a tool-turn temperature=0 override.
+	cases := []string{"gpt-5", "moonshotai/kimi-k2.5", "google/gemini-2.5-pro"}
 	for _, model := range cases {
 		t.Run(model, func(t *testing.T) {
 			src := []byte(`{


### PR DESCRIPTION
## Summary

Production traffic on 2026-05-23 hit two cascading reliability failures: `qwen3-235b-a22b-2507` on `bedrock-mantle.us-east-1` stalled five consecutive 10-min hangs (zero upstream bytes, watchdog-less SSE held the connection until the request budget expired), and a Claude Code Explore sub-agent looped 13 identical empty-result tool calls inside 90 seconds. Five commits, each addressing one root cause; full plan + research at `/Users/steventohme/.claude/plans/given-all-the-einformation-wiggly-graham.md` (research citations: AWS NAT-GW 350s reaper KB, Qwen3 sampler model card, arxiv 2512.04419 on penalty-knob effectiveness, OpenClaw loop-detection spec, plus public Bedrock-Mantle Qwen3 reports).

### What's in this PR (ordered commits)

1. **SSE inactivity watchdog (`httputil.StreamBody`)** — adds `httputil.StartIdleWatchdog` + a per-read deadline that cancels the request ctx with `ErrUpstreamIdleTimeout` after 45s of upstream silence (env-tunable via `ROUTER_SSE_IDLE_TIMEOUT_SECONDS`). Threads through all five provider adapters. A Bedrock stall now surfaces in <60s instead of consuming the full ~10-min context deadline.

2. **Qwen3 sampler defaults across all providers (`translate.emit_openai`)** — extends the existing `presence_penalty=1.5` injection to the full Qwen3 model-card set (temperature=0.7, top_p=0.8, repetition_penalty=1.05) and lifts it out of the `targetIsOpenRouter` gate so Bedrock, DeepInfra, and Fireworks also receive the tuned defaults. Client-set values still win per-field.

3. **`ToolUseLow` blacklist in catalog/scorer** — adds `catalog.ToolUseQuality` and marks `qwen/qwen3-235b-a22b-2507` (Instruct-2507, non-thinking variant) as `ToolUseLow` after production hallucinated "I edited the file" responses with zero tool_use blocks. Scorer subtracts ToolUseLow models from argmax when `req.HasTools` is true; soft filter (falls back to unfiltered set rather than 4xx-ing if the subtraction would empty the pool).

4. **Runtime provider fallback (`proxy.proxyWithFallback`)** — on a pre-first-byte retryable failure (`ErrUpstreamIdleTimeout` or `UpstreamStatusError{Status: 5xx}`), walks `catalog.Model.Providers` to the next eligible binding, re-emits the body for the new target, and retries once. Decision is mutated so cost math, billing, and the `ProxyMessages` complete log reflect the actually-served provider. New log fields: `fallback_attempted`, `fallback_from_provider`, `fallback_to_provider`, `fallback_reason`. For the production qwen3-235b case: a Bedrock stall flips to OpenRouter and the user gets a real response.

5. **Cross-envelope no-progress detector (`proxy.noProgressTracker`)** — keys an expirable LRU on inbound session_key, holds a ring buffer of recent dispatch fingerprints (decision_model + decision_provider + first 512 bytes of prompt). When the same fingerprint repeats 5x within 90s the proxy emits a synthetic stop and expires the pin, mirroring `handleToolCallLoopBreak` but for the Claude Code sub-agent spawn loop the per-envelope detector cannot see.

### Test plan

- [x] `go build ./...` clean on all packages
- [x] `go test ./...` green (full router suite, 60s ceiling per package)
- [x] `gofmt -l .` clean
- [x] `httputil_test.go` — 11 cases covering watchdog firing on stall, not firing on lively stream, env-var override, status-error fallthrough
- [x] `qwen3_sampling_test.go` — same-format + cross-format + Bedrock-target + client-override + partial-override coverage; updated `tool_temperature_test.go` to drop qwen3-max (now correctly receives temperature=0.7 from the Qwen sampler block)
- [x] `catalog_test.go` + `scorer_test.go` — verifies `qwen/qwen3-235b-a22b-2507` is in `ToolUseLowSet`, scorer drops it on `HasTools=true`, soft-falls-back when the subtraction would empty the pool
- [x] `provider_fallback_internal_test.go` — happy path, idle-timeout retry, 5xx retry, no retry after first byte, no retry on 4xx, no retry when bindings exhausted, no retry when no other provider wired
- [x] `no_progress_internal_test.go` — threshold tripping, age-out, nil-receiver safety, per-session isolation, per-role isolation, fingerprint stability + model/provider distinction
- [ ] Manual production rehearsal: re-run the wedding-RSVP turn against the same input; expect either a clean response (via fallback) or a clean ~45-s error, never a 10-min hang. Verify GCP log shows `fallback_attempted=true` under real load within 24h of deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)