### PR TITLE
feat(observability): tag every router log with session_key + add turn-flow I/O logs

### DIFF
--- a/internal/observability/logger.go
+++ b/internal/observability/logger.go
@@ -1,6 +1,7 @@
 package observability
 
 import (
+	"context"
 	"log/slog"
 	"os"
 	"strings"
@@ -13,6 +14,36 @@ import (
 )
 
 const ginContextKey = "router_logger"
+
+// loggerContextKey is the private key used to stash a request-scoped
+// *slog.Logger on a context.Context. Private type prevents collisions with
+// other packages' context values.
+type loggerContextKey struct{}
+
+// WithLogger returns a new context that carries the given logger. Downstream
+// code reading the logger with FromContext sees this logger (with all its
+// pre-bound attributes) instead of the global default.
+func WithLogger(ctx context.Context, log *slog.Logger) context.Context {
+	if log == nil {
+		return ctx
+	}
+	return context.WithValue(ctx, loggerContextKey{}, log)
+}
+
+// FromContext returns the request-scoped logger stashed by WithLogger, or the
+// global default logger if none is set. Always non-nil. Initializes the
+// LOG_LEVEL-honoring handler on first call, matching Get().
+func FromContext(ctx context.Context) *slog.Logger {
+	initOnce.Do(initLogger)
+	if ctx != nil {
+		if v := ctx.Value(loggerContextKey{}); v != nil {
+			if logger, ok := v.(*slog.Logger); ok {
+				return logger
+			}
+		}
+	}
+	return slog.Default()
+}
 
 // initOnce installs a slog handler honoring LOG_LEVEL on first Get(). Without
 // this, slog.Default() falls back to Go's stdlib handler at INFO, silently

--- a/internal/proxy/fallback.go
+++ b/internal/proxy/fallback.go
@@ -198,7 +198,7 @@ type failoverInputs struct {
 // straight to w so the client sees the underlying provider's response
 // envelope rather than a generic 502 from us.
 func (s *Service) dispatchWithFallback(ctx context.Context, in failoverInputs) (winnerIdx int, err error) {
-	log := observability.Get()
+	log := observability.FromContext(ctx)
 	if len(in.bindings) == 0 {
 		return -1, &providers.UpstreamStatusError{Status: http.StatusBadGateway}
 	}

--- a/internal/proxy/force_model.go
+++ b/internal/proxy/force_model.go
@@ -73,13 +73,14 @@ func resolveForceModel(model string) (canonicalID, provider string) {
 // It writes (or expires) the session pin and returns a synthetic Anthropic-format
 // acknowledgment response without dispatching to any upstream.
 func (s *Service) handleForceModelCommand(
+	ctx context.Context,
 	w http.ResponseWriter,
 	env *translate.RequestEnvelope,
 	cmd translate.ForceModelResult,
 	installationID uuid.UUID,
 	sessionKey [sessionpin.SessionKeyLen]byte,
 ) error {
-	log := observability.Get()
+	log := observability.FromContext(ctx)
 	role := roleForTier(catalog.TierFor(env.Model()))
 	pinCacheKey := sessionPinCacheKey(sessionKey, role)
 

--- a/internal/proxy/gemini.go
+++ b/internal/proxy/gemini.go
@@ -59,7 +59,7 @@ func (s *Service) ProxyGeminiGenerateContent(ctx context.Context, body []byte, w
 	}
 
 	ctx, log, _ = bindRequestLogger(ctx, env, apiKeyID, requestID, "gemini_generate_content")
-	log.Debug("ProxyGeminiGenerateContent start",
+	log.Info("ProxyGeminiGenerateContent start",
 		"requested_model", feats.Model,
 		"stream", env.Stream(),
 		"message_count", feats.MessageCount,

--- a/internal/proxy/gemini.go
+++ b/internal/proxy/gemini.go
@@ -30,7 +30,7 @@ var ErrGeminiCrossFormatUnsupported = errors.New("gemini cross-format emit not i
 // and "stream" (true for :streamGenerateContent) fields into body before
 // calling; both are stripped before forwarding upstream.
 func (s *Service) ProxyGeminiGenerateContent(ctx context.Context, body []byte, w http.ResponseWriter, r *http.Request) error {
-	log := observability.Get()
+	log := observability.FromContext(ctx)
 	requestStart := time.Now()
 	requestID := uuid.New().String()
 	buf := otel.NewBuffer(s.emitter)
@@ -58,6 +58,16 @@ func (s *Service) ProxyGeminiGenerateContent(ctx context.Context, body []byte, w
 		embedInput = "only_user_message"
 	}
 
+	ctx, log, _ = bindRequestLogger(ctx, env, apiKeyID, requestID, "gemini_generate_content")
+	log.Debug("ProxyGeminiGenerateContent start",
+		"requested_model", feats.Model,
+		"stream", env.Stream(),
+		"message_count", feats.MessageCount,
+		"has_tools", feats.HasTools,
+		"total_input_tokens", feats.Tokens,
+		"prompt_preview", preview(promptText, 200),
+	)
+
 	subAgentHint := r.Header.Get("x-weave-subagent-type")
 
 	routeStart := time.Now()
@@ -80,7 +90,7 @@ func (s *Service) ProxyGeminiGenerateContent(ctx context.Context, body []byte, w
 	stickyHit := routeRes.StickyHit
 	pinTier := routeRes.PinTier
 	pinAgeSec := routeRes.PinAgeSec
-	s.logPlannerOutcome(routeRes)
+	s.logPlannerOutcome(ctx, routeRes)
 
 	p, provErr := s.provider(decision.Provider)
 	if provErr != nil {

--- a/internal/proxy/handover.go
+++ b/internal/proxy/handover.go
@@ -92,7 +92,7 @@ var ErrEmptySummary = errors.New("handover: upstream returned no summary text")
 // summary as a separate ledger row. On failure returns ("", zero Usage, err)
 // so the caller can fall back to handover.TrimLastN.
 func (s *ProviderSummarizer) Summarize(ctx context.Context, env *translate.RequestEnvelope) (string, handover.Usage, error) {
-	log := observability.Get()
+	log := observability.FromContext(ctx)
 	if env == nil {
 		return "", handover.Usage{}, errors.New("handover: nil envelope")
 	}

--- a/internal/proxy/log_io.go
+++ b/internal/proxy/log_io.go
@@ -1,0 +1,102 @@
+package proxy
+
+import (
+	"context"
+	"log/slog"
+	"strings"
+
+	"workweave/router/internal/translate"
+)
+
+// preview returns the first n runes of s with an ellipsis suffix when
+// truncated. Empty in, empty out. Used everywhere we want a log-safe excerpt
+// of free-text payloads — full bodies stay behind LOG_LEVEL=debug.
+func preview(s string, n int) string {
+	if s == "" || n <= 0 {
+		return ""
+	}
+	if len(s) <= n {
+		return s
+	}
+	// Trim on a rune boundary so we don't slice a multi-byte codepoint.
+	cut := s[:n]
+	if i := strings.LastIndexAny(cut, " \n\t"); i > n/2 {
+		cut = cut[:i]
+	}
+	return cut + "…"
+}
+
+// logInboundToolTraffic emits a Debug log line summarising the tool-use blocks
+// the model is about to see on this turn. Keeps payload small (just names +
+// short arg previews of the last few assistant calls) so we can correlate a
+// broken turn back to the prior tool_use / tool_result shape without dumping
+// the entire body.
+//
+// Gemini envelopes are skipped — the underlying preview helper only knows
+// Anthropic + OpenAI shapes today.
+func logInboundToolTraffic(log *slog.Logger, env *translate.RequestEnvelope) {
+	if env == nil || !log.Enabled(context.Background(), slog.LevelDebug) {
+		return
+	}
+	const tailWindow = 5
+	sigs := env.AssistantToolCallSignatures()
+	if len(sigs) == 0 {
+		return
+	}
+	offset := len(sigs) - tailWindow
+	if offset < 0 {
+		offset = 0
+	}
+	args := env.AssistantToolCallArgsPreview(offset, 160)
+	names := make([]string, 0, len(sigs))
+	for _, s := range sigs {
+		names = append(names, s.Name)
+	}
+	log.Debug("inbound tool_use history",
+		"total_tool_calls", len(sigs),
+		"tool_names", names,
+		"tail_window_args", args,
+	)
+}
+
+// logAssistantOutputSummary emits a Debug summary of the assistant blocks the
+// upstream produced this turn: counts of text / tool_use / thinking blocks and
+// short previews of each tool_use call. Streaming providers should call this
+// once the response stream has closed and the buffered text/tool blocks are
+// known; for non-streaming responses it can be invoked directly on the parsed
+// body.
+func logAssistantOutputSummary(
+	log *slog.Logger,
+	textBlocks, thinkingBlocks int,
+	toolCalls []ToolCallPreview,
+	stopReason string,
+	outputTokens int,
+) {
+	if !log.Enabled(context.Background(), slog.LevelDebug) {
+		return
+	}
+	names := make([]string, 0, len(toolCalls))
+	args := make([]string, 0, len(toolCalls))
+	for _, tc := range toolCalls {
+		names = append(names, tc.Name)
+		args = append(args, preview(tc.ArgsJSON, 160))
+	}
+	log.Debug("assistant output summary",
+		"text_blocks", textBlocks,
+		"thinking_blocks", thinkingBlocks,
+		"tool_use_count", len(toolCalls),
+		"tool_names", names,
+		"tool_args_preview", args,
+		"stop_reason", stopReason,
+		"output_tokens", outputTokens,
+	)
+}
+
+// ToolCallPreview is a log-friendly snapshot of one assistant tool_use block.
+// Kept in this package to avoid coupling translate or providers to a logging
+// type; populated by the streaming/non-streaming response parsers when they
+// can cheaply observe the block.
+type ToolCallPreview struct {
+	Name     string
+	ArgsJSON string
+}

--- a/internal/proxy/log_io.go
+++ b/internal/proxy/log_io.go
@@ -1,7 +1,6 @@
 package proxy
 
 import (
-	"context"
 	"log/slog"
 	"strings"
 
@@ -35,7 +34,7 @@ func preview(s string, n int) string {
 // Gemini envelopes are skipped — the underlying preview helper only knows
 // Anthropic + OpenAI shapes today.
 func logInboundToolTraffic(log *slog.Logger, env *translate.RequestEnvelope) {
-	if env == nil || !log.Enabled(context.Background(), slog.LevelDebug) {
+	if env == nil {
 		return
 	}
 	const tailWindow = 5
@@ -52,7 +51,7 @@ func logInboundToolTraffic(log *slog.Logger, env *translate.RequestEnvelope) {
 	for _, s := range sigs {
 		names = append(names, s.Name)
 	}
-	log.Debug("inbound tool_use history",
+	log.Info("inbound tool_use history",
 		"total_tool_calls", len(sigs),
 		"tool_names", names,
 		"tail_window_args", args,
@@ -72,16 +71,13 @@ func logAssistantOutputSummary(
 	stopReason string,
 	outputTokens int,
 ) {
-	if !log.Enabled(context.Background(), slog.LevelDebug) {
-		return
-	}
 	names := make([]string, 0, len(toolCalls))
 	args := make([]string, 0, len(toolCalls))
 	for _, tc := range toolCalls {
 		names = append(names, tc.Name)
 		args = append(args, preview(tc.ArgsJSON, 160))
 	}
-	log.Debug("assistant output summary",
+	log.Info("assistant output summary",
 		"text_blocks", textBlocks,
 		"thinking_blocks", thinkingBlocks,
 		"tool_use_count", len(toolCalls),

--- a/internal/proxy/loop_detection.go
+++ b/internal/proxy/loop_detection.go
@@ -75,6 +75,7 @@ func detectToolCallLoop(env *translate.RequestEnvelope) (looped bool, sig transl
 // the response, because the client is already stuck and getting a clean break
 // out is more important than guaranteeing the pin row reflects the new state.
 func (s *Service) handleToolCallLoopBreak(
+	ctx context.Context,
 	w http.ResponseWriter,
 	env *translate.RequestEnvelope,
 	sig translate.ToolCallSig,
@@ -85,7 +86,7 @@ func (s *Service) handleToolCallLoopBreak(
 	decisionModel string,
 	decisionProvider string,
 ) error {
-	log := observability.Get()
+	log := observability.FromContext(ctx)
 
 	msg := fmt.Sprintf(
 		"✦ **Weave Router** → tool-call loop detected: `%s` was called %d times in the last %d turns with identical arguments. Stopping this turn and clearing the session pin so the next message re-routes to a fresh model.\n\nIf the task is genuinely incomplete, send a follow-up message describing what's still needed; the router will pick a different model.\n\n",

--- a/internal/proxy/no_progress.go
+++ b/internal/proxy/no_progress.go
@@ -162,6 +162,7 @@ func shortSessionKey(sessionKey [sessionpin.SessionKeyLen]byte) string {
 // cross-envelope nature so a human reading the chat history can tell the
 // two break modes apart.
 func (s *Service) handleNoProgressBreak(
+	ctx context.Context,
 	w http.ResponseWriter,
 	env *translate.RequestEnvelope,
 	count int,
@@ -171,7 +172,7 @@ func (s *Service) handleNoProgressBreak(
 	decisionModel string,
 	decisionProvider string,
 ) error {
-	log := observability.Get()
+	log := observability.FromContext(ctx)
 
 	msg := fmt.Sprintf(
 		"✦ **Weave Router** → no-progress loop detected: %d consecutive requests under this session routed to `%s` (`%s`) with no observable progress in %s. Stopping this turn and clearing the session pin so the next message re-routes.\n\nIf the task is genuinely incomplete, send a follow-up message describing what's still needed; the router will pick a different model.\n\n",

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -641,7 +641,7 @@ func logUpstreamBody(log *slog.Logger, sessionKey [sessionpin.SessionKeyLen]byte
 // ProxyMessages routes a raw Anthropic-Messages request body and streams the
 // upstream response back. The routing decision is reflected in x-router-* headers.
 func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.ResponseWriter, r *http.Request) error {
-	log := observability.Get()
+	log := observability.FromContext(ctx)
 	requestStart := time.Now()
 	requestID := uuid.New().String()
 	buf := otel.NewBuffer(s.emitter)
@@ -681,6 +681,21 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 	clientID := ClientIdentityFrom(ctx)
 	bypassEval := hasEvalOverrideHeader(r)
 
+	// Bind session_key/request_id/api_key_id/ingress onto a ctx-scoped logger so
+	// every downstream log line in this turn carries them. The derived key is
+	// reused for the force-model and loop-break paths below to avoid a second
+	// hash + a divergent key in the rare case env.body mutates mid-flow.
+	var sessionKey [sessionpin.SessionKeyLen]byte
+	ctx, log, sessionKey = bindRequestLogger(ctx, env, apiKeyID, requestID, "anthropic_messages")
+	log.Debug("ProxyMessages start",
+		"requested_model", feats.Model,
+		"stream", env.Stream(),
+		"message_count", feats.MessageCount,
+		"has_tools", feats.HasTools,
+		"total_input_tokens", feats.Tokens,
+		"prompt_preview", preview(promptText, 200),
+	)
+
 	// Handle /force-model <model> and /unforce-model commands before routing.
 	// The command is stripped from env.body so the upstream never sees it.
 	// Session key is derived before extraction: ExtractForceModelCommand mutates
@@ -688,9 +703,9 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 	// metadata.user_id is absent. Deriving after the strip would produce a key
 	// that mismatches subsequent turns where the unstripped message is present.
 	if s.pinStore != nil {
-		cmdSessionKey := DeriveSessionKey(env, apiKeyID)
 		if cmd, hasCmd := env.ExtractForceModelCommand(); hasCmd {
-			return s.handleForceModelCommand(w, env, cmd, installationID, cmdSessionKey)
+			log.Info("ProxyMessages force-model command", "force_model_cmd", cmd)
+			return s.handleForceModelCommand(ctx, w, env, cmd, installationID, sessionKey)
 		}
 	}
 
@@ -701,10 +716,15 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 	// previous-turn-maxed-out guard misses because each individual tool call
 	// returns quickly and well under the output cap.
 	if loop, sig, count := detectToolCallLoop(env); loop {
-		loopSessionKey := DeriveSessionKey(env, apiKeyID)
 		loopRole := roleForTier(catalog.TierFor(feats.Model))
-		return s.handleToolCallLoopBreak(w, env, sig, count, installationID, loopSessionKey, loopRole, feats.Model, providers.ProviderAnthropic)
+		log.Info("ProxyMessages tool-call loop detected", "tool_sig", sig, "repeat_count", count, "role", loopRole)
+		return s.handleToolCallLoopBreak(ctx, w, env, sig, count, installationID, sessionKey, loopRole, feats.Model, providers.ProviderAnthropic)
 	}
+
+	// Surface inbound tool_use / tool_result blocks the model is about to see.
+	// Lets us audit whether a misbehaving turn was provoked by a malformed prior
+	// tool_result or an out-of-shape tool spec, without dumping the whole body.
+	logInboundToolTraffic(log, env)
 
 	// Anthropic packs sub-agent identity into metadata.user_id; the
 	// x-weave-subagent-type header is for non-Anthropic ingress only.
@@ -729,7 +749,7 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 	pinTier := routeRes.PinTier
 	pinAgeSec := routeRes.PinAgeSec
 	routeMs := time.Since(routeStart).Milliseconds()
-	s.logPlannerOutcome(routeRes)
+	s.logPlannerOutcome(ctx, routeRes)
 
 	// Cross-envelope no-progress detector: if this session has dispatched the
 	// same (decision_model, decision_provider, prompt-prefix) burst >=
@@ -740,7 +760,7 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 	if fp := computeNoProgressFingerprint(decision, promptText); s.noProgress != nil {
 		role := roleForTier(catalog.TierFor(feats.Model))
 		if looped, count := s.noProgress.recordAndDetect(routeRes.SessionKey, installationID, role, fp, time.Now()); looped {
-			return s.handleNoProgressBreak(w, env, count, installationID, routeRes.SessionKey, role, decision.Model, decision.Provider)
+			return s.handleNoProgressBreak(ctx, w, env, count, installationID, routeRes.SessionKey, role, decision.Model, decision.Provider)
 		}
 	}
 
@@ -1122,11 +1142,11 @@ func plannerOutcomeAttr(res turnLoopResult) string {
 
 // logPlannerOutcome emits a structured log line for the planner's verdict.
 // Switch turns are Info; stay turns are Debug.
-func (s *Service) logPlannerOutcome(res turnLoopResult) {
+func (s *Service) logPlannerOutcome(ctx context.Context, res turnLoopResult) {
 	if res.PlannerDecision.Reason == "" {
 		return
 	}
-	log := observability.Get()
+	log := observability.FromContext(ctx)
 	if res.PlannerDecision.Outcome == planner.OutcomeSwitch {
 		log.Info("router switched models",
 			"from", res.PinModel,
@@ -1562,7 +1582,7 @@ func finalizeAfterProxy(proxyErr error, fn func() error) error {
 // ProxyOpenAIChatCompletion routes an OpenAI Chat Completion request,
 // translating cross-format when the decision picks a non-OpenAI provider.
 func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w http.ResponseWriter, r *http.Request) error {
-	log := observability.Get()
+	log := observability.FromContext(ctx)
 	requestStart := time.Now()
 	requestID := uuid.New().String()
 	buf := otel.NewBuffer(s.emitter)
@@ -1596,6 +1616,19 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 
 	bypassEval := hasEvalOverrideHeader(r)
 
+	// Bind session-scoped logger; see the matching block in ProxyMessages for
+	// the rationale around deriving the key once and reusing it.
+	var sessionKey [sessionpin.SessionKeyLen]byte
+	ctx, log, sessionKey = bindRequestLogger(ctx, env, apiKeyID, requestID, "openai_chat_completions")
+	log.Debug("ProxyOpenAIChatCompletion start",
+		"requested_model", feats.Model,
+		"stream", env.Stream(),
+		"message_count", feats.MessageCount,
+		"has_tools", feats.HasTools,
+		"total_input_tokens", feats.Tokens,
+		"prompt_preview", preview(promptText, 200),
+	)
+
 	// Handle /force-model <model> and /unforce-model commands before routing.
 	// The command is stripped from env.body so the upstream never sees it.
 	// Session key is derived before extraction: ExtractForceModelCommand mutates
@@ -1603,19 +1636,21 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 	// metadata.user_id is absent. Deriving after the strip would produce a key
 	// that mismatches subsequent turns where the unstripped message is present.
 	if s.pinStore != nil {
-		cmdSessionKey := DeriveSessionKey(env, apiKeyID)
 		if cmd, hasCmd := env.ExtractForceModelCommand(); hasCmd {
-			return s.handleForceModelCommand(w, env, cmd, installationID, cmdSessionKey)
+			log.Info("ProxyOpenAIChatCompletion force-model command", "force_model_cmd", cmd)
+			return s.handleForceModelCommand(ctx, w, env, cmd, installationID, sessionKey)
 		}
 	}
 
 	// Tool-call loop break: same path as the Anthropic ingress. See the
 	// detectToolCallLoop / handleToolCallLoopBreak doc comments for rationale.
 	if loop, sig, count := detectToolCallLoop(env); loop {
-		loopSessionKey := DeriveSessionKey(env, apiKeyID)
 		loopRole := roleForTier(catalog.TierFor(feats.Model))
-		return s.handleToolCallLoopBreak(w, env, sig, count, installationID, loopSessionKey, loopRole, feats.Model, providers.ProviderOpenAI)
+		log.Info("ProxyOpenAIChatCompletion tool-call loop detected", "tool_sig", sig, "repeat_count", count, "role", loopRole)
+		return s.handleToolCallLoopBreak(ctx, w, env, sig, count, installationID, sessionKey, loopRole, feats.Model, providers.ProviderOpenAI)
 	}
+
+	logInboundToolTraffic(log, env)
 
 	// OpenAI signals sub-agent identity via x-weave-subagent-type (no metadata.user_id).
 	subAgentHint := r.Header.Get("x-weave-subagent-type")
@@ -1641,7 +1676,7 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 	stickyHit := routeRes.StickyHit
 	pinTier := routeRes.PinTier
 	pinAgeSec := routeRes.PinAgeSec
-	s.logPlannerOutcome(routeRes)
+	s.logPlannerOutcome(ctx, routeRes)
 
 	cacheEligible := s.semanticCache != nil && !env.Stream() && decision.Metadata != nil && externalID != "" && !bypassEval
 	if cacheEligible {

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -687,7 +687,7 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 	// hash + a divergent key in the rare case env.body mutates mid-flow.
 	var sessionKey [sessionpin.SessionKeyLen]byte
 	ctx, log, sessionKey = bindRequestLogger(ctx, env, apiKeyID, requestID, "anthropic_messages")
-	log.Debug("ProxyMessages start",
+	log.Info("ProxyMessages start",
 		"requested_model", feats.Model,
 		"stream", env.Stream(),
 		"message_count", feats.MessageCount,
@@ -1161,7 +1161,7 @@ func (s *Service) logPlannerOutcome(ctx context.Context, res turnLoopResult) {
 		)
 		return
 	}
-	log.Debug("router stayed on pinned model",
+	log.Info("router stayed on pinned model",
 		"model", res.Decision.Model,
 		"reason", res.PlannerDecision.Reason,
 		"expected_savings_usd", res.PlannerDecision.ExpectedSavingsUSD,
@@ -1620,7 +1620,7 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 	// the rationale around deriving the key once and reusing it.
 	var sessionKey [sessionpin.SessionKeyLen]byte
 	ctx, log, sessionKey = bindRequestLogger(ctx, env, apiKeyID, requestID, "openai_chat_completions")
-	log.Debug("ProxyOpenAIChatCompletion start",
+	log.Info("ProxyOpenAIChatCompletion start",
 		"requested_model", feats.Model,
 		"stream", env.Stream(),
 		"message_count", feats.MessageCount,

--- a/internal/proxy/session_key.go
+++ b/internal/proxy/session_key.go
@@ -1,11 +1,49 @@
 package proxy
 
 import (
+	"context"
 	"crypto/sha256"
+	"encoding/hex"
+	"log/slog"
 
+	"workweave/router/internal/observability"
 	"workweave/router/internal/router/sessionpin"
 	"workweave/router/internal/translate"
 )
+
+// shortKey returns the first 16 hex chars (64 bits) of a session key for
+// log-friendly correlation. Empty for zero keys so log lines on the pre-derive
+// path don't show a misleading prefix.
+func shortKey(key [sessionpin.SessionKeyLen]byte) string {
+	var zero [sessionpin.SessionKeyLen]byte
+	if key == zero {
+		return ""
+	}
+	return hex.EncodeToString(key[:8])
+}
+
+// bindRequestLogger derives the session key and returns a new context carrying
+// a request-scoped logger pre-bound with session_key, request_id, api_key_id,
+// and ingress. Downstream code reading via observability.FromContext gets these
+// attributes on every line for free, so a single session's path through the
+// router can be filtered in Cloud Logging by session_key alone.
+//
+// Returns the derived session key so callers don't re-derive it for force-model
+// or loop-detection paths that already needed it.
+func bindRequestLogger(
+	ctx context.Context,
+	env *translate.RequestEnvelope,
+	apiKeyID, requestID, ingress string,
+) (context.Context, *slog.Logger, [sessionpin.SessionKeyLen]byte) {
+	key := DeriveSessionKey(env, apiKeyID)
+	log := observability.FromContext(ctx).With(
+		"session_key", shortKey(key),
+		"request_id", requestID,
+		"api_key_id", apiKeyID,
+		"ingress", ingress,
+	)
+	return observability.WithLogger(ctx, log), log, key
+}
 
 // DeriveSessionKey produces a 16-byte session digest. Tries metadata.user_id
 // (session-distinct from Claude Code's device+account+session bundle), then

--- a/internal/proxy/turnloop.go
+++ b/internal/proxy/turnloop.go
@@ -101,7 +101,7 @@ func (s *Service) runTurnLoop(
 		RequestedTier: catalog.TierFor(feats.Model),
 	}
 	res.PinRole = roleForTier(res.RequestedTier)
-	log.Debug("turnloop classified",
+	log.Info("turnloop classified",
 		"turn_type", string(res.TurnType),
 		"requested_tier", res.RequestedTier.String(),
 		"pin_role", res.PinRole,
@@ -174,7 +174,7 @@ func (s *Service) runTurnLoop(
 	if pinFound {
 		res.PinModel = pin.Model
 		res.PinAgeSec = pinAge(pin)
-		log.Debug("turnloop pin lookup hit",
+		log.Info("turnloop pin lookup hit",
 			"pin_model", pin.Model,
 			"pin_provider", pin.Provider,
 			"pin_reason", pin.Reason,
@@ -182,7 +182,7 @@ func (s *Service) runTurnLoop(
 			"last_output_tokens", pin.LastOutputTokens,
 		)
 	} else {
-		log.Debug("turnloop pin lookup miss", "role", res.PinRole)
+		log.Info("turnloop pin lookup miss", "role", res.PinRole)
 	}
 
 	// User-forced pins are immutable stickies — skip scorer and planner entirely.
@@ -277,14 +277,14 @@ func (s *Service) runTurnLoop(
 		log.Error("turnloop scorer failed", "err", err, "requested_model", req.RequestedModel)
 		return res, err
 	}
-	log.Debug("turnloop scorer decision",
+	log.Info("turnloop scorer decision",
 		"fresh_model", fresh.Model,
 		"fresh_provider", fresh.Provider,
 		"fresh_reason", fresh.Reason,
 	)
 	fresh = s.clampToCeiling(fresh, res.RequestedTier, req.EnabledProviders, req.ExcludedModels, &res)
 	if res.TierClamped {
-		log.Debug("turnloop scorer clamped to ceiling",
+		log.Info("turnloop scorer clamped to ceiling",
 			"pre_clamp_model", res.PreClampModel,
 			"clamped_model", fresh.Model,
 			"requested_tier", res.RequestedTier.String(),
@@ -496,9 +496,9 @@ func (s *Service) refreshPin(ctx context.Context, installationID uuid.UUID, sess
 // first-turn routing and switch turns. UpdateUsage fills in usage stats later.
 func (s *Service) writeNewPin(ctx context.Context, installationID uuid.UUID, sessionKey [sessionpin.SessionKeyLen]byte, pinCacheKey string, role string, chosen router.Decision) {
 	log := observability.FromContext(ctx)
-	log.Debug("writeNewPin called", "installation_id", installationID.String(), "role", role, "model", chosen.Model, "session_key_hex", fmt.Sprintf("%x", sessionKey))
+	log.Info("writeNewPin called", "installation_id", installationID.String(), "role", role, "model", chosen.Model, "session_key_hex", fmt.Sprintf("%x", sessionKey))
 	if installationID == uuid.Nil {
-		log.Debug("writeNewPin: skipping because installationID is uuid.Nil")
+		log.Info("writeNewPin: skipping because installationID is uuid.Nil")
 		return
 	}
 	p := sessionpin.Pin{

--- a/internal/proxy/turnloop.go
+++ b/internal/proxy/turnloop.go
@@ -94,13 +94,19 @@ func (s *Service) runTurnLoop(
 	reqHeaders http.Header,
 	req router.Request,
 ) (turnLoopResult, error) {
-	log := observability.Get()
+	log := observability.FromContext(ctx)
 	res := turnLoopResult{
 		TurnType:      turntype.DetectFromEnvelope(env, feats, subAgentHint),
 		PinTier:       "miss",
 		RequestedTier: catalog.TierFor(feats.Model),
 	}
 	res.PinRole = roleForTier(res.RequestedTier)
+	log.Debug("turnloop classified",
+		"turn_type", string(res.TurnType),
+		"requested_tier", res.RequestedTier.String(),
+		"pin_role", res.PinRole,
+		"sub_agent_hint", subAgentHint,
+	)
 
 	// Hard pins bypass pin lookup, pin write, planner, and scorer entirely.
 	// Probes and title-gen MUST NOT create a session pin — the Anthropic SDK
@@ -168,6 +174,15 @@ func (s *Service) runTurnLoop(
 	if pinFound {
 		res.PinModel = pin.Model
 		res.PinAgeSec = pinAge(pin)
+		log.Debug("turnloop pin lookup hit",
+			"pin_model", pin.Model,
+			"pin_provider", pin.Provider,
+			"pin_reason", pin.Reason,
+			"pin_age_s", res.PinAgeSec,
+			"last_output_tokens", pin.LastOutputTokens,
+		)
+	} else {
+		log.Debug("turnloop pin lookup miss", "role", res.PinRole)
 	}
 
 	// User-forced pins are immutable stickies — skip scorer and planner entirely.
@@ -197,7 +212,7 @@ func (s *Service) runTurnLoop(
 			res.Decision = decision
 			res.StickyHit = true
 			res.PinTier = "user_forced"
-			s.refreshPin(installationID, res.SessionKey, pin, pinCacheKey, res.PinRole, pinDecision(pin))
+			s.refreshPin(ctx, installationID, res.SessionKey, pin, pinCacheKey, res.PinRole, pinDecision(pin))
 			return res, nil
 		}
 		// Forced pin is no longer servable on this request (excluded by policy
@@ -242,7 +257,7 @@ func (s *Service) runTurnLoop(
 		res.Decision = decision
 		res.StickyHit = true
 		res.PinTier = "postgres_tool_result_sc"
-		s.refreshPin(installationID, res.SessionKey, pin, pinCacheKey, res.PinRole, decision)
+		s.refreshPin(ctx, installationID, res.SessionKey, pin, pinCacheKey, res.PinRole, decision)
 		return res, nil
 	}
 
@@ -252,21 +267,34 @@ func (s *Service) runTurnLoop(
 		res.Decision = decision
 		res.StickyHit = true
 		res.PinTier = "postgres"
-		s.refreshPin(installationID, res.SessionKey, pin, pinCacheKey, res.PinRole, decision)
+		s.refreshPin(ctx, installationID, res.SessionKey, pin, pinCacheKey, res.PinRole, decision)
 		return res, nil
 	}
 
 	// Always run the scorer when no pin, or on MainLoop with a pin.
 	fresh, err := s.router.Route(ctx, req)
 	if err != nil {
+		log.Error("turnloop scorer failed", "err", err, "requested_model", req.RequestedModel)
 		return res, err
 	}
+	log.Debug("turnloop scorer decision",
+		"fresh_model", fresh.Model,
+		"fresh_provider", fresh.Provider,
+		"fresh_reason", fresh.Reason,
+	)
 	fresh = s.clampToCeiling(fresh, res.RequestedTier, req.EnabledProviders, req.ExcludedModels, &res)
+	if res.TierClamped {
+		log.Debug("turnloop scorer clamped to ceiling",
+			"pre_clamp_model", res.PreClampModel,
+			"clamped_model", fresh.Model,
+			"requested_tier", res.RequestedTier.String(),
+		)
+	}
 	res.Fresh = fresh
 
 	if !s.plannerEnabled {
 		res.Decision = fresh
-		s.writeNewPin(installationID, res.SessionKey, pinCacheKey, res.PinRole, fresh)
+		s.writeNewPin(ctx, installationID, res.SessionKey, pinCacheKey, res.PinRole, fresh)
 		return res, nil
 	}
 
@@ -287,7 +315,7 @@ func (s *Service) runTurnLoop(
 		res.Decision = stay
 		res.StickyHit = true
 		res.PinTier = "postgres_stay_" + decision.Reason
-		s.refreshPin(installationID, res.SessionKey, pin, pinCacheKey, res.PinRole, stay)
+		s.refreshPin(ctx, installationID, res.SessionKey, pin, pinCacheKey, res.PinRole, stay)
 		return res, nil
 	}
 
@@ -355,7 +383,7 @@ func (s *Service) runTurnLoop(
 	if pinFound {
 		res.PinTier = "switch_" + decision.Reason
 	}
-	s.writeNewPin(installationID, res.SessionKey, pinCacheKey, res.PinRole, fresh)
+	s.writeNewPin(ctx, installationID, res.SessionKey, pinCacheKey, res.PinRole, fresh)
 	return res, nil
 }
 
@@ -408,7 +436,7 @@ func (s *Service) clampToCeiling(decision router.Decision, ceiling catalog.Tier,
 // loadPin returns the active pin for this session, consulting the in-proc
 // LRU first then Postgres. Expired rows are treated as misses.
 func (s *Service) loadPin(ctx context.Context, pinCacheKey string, sessionKey [sessionpin.SessionKeyLen]byte, role string) (sessionpin.Pin, bool) {
-	log := observability.Get()
+	log := observability.FromContext(ctx)
 	log.Debug("loadPin called", "role", role, "session_key_hex", fmt.Sprintf("%x", sessionKey))
 	if s.pinCache != nil {
 		if pin, ok := s.pinCache.Get(pinCacheKey); ok {
@@ -442,7 +470,7 @@ func (s *Service) loadPin(ctx context.Context, pinCacheKey string, sessionKey [s
 // refreshPin extends the TTL on an existing pin. Carries the existing pin's
 // usage forward so the planner has evidence before the next UpdateUsage
 // writeback lands. Async, bounded; drops on saturation.
-func (s *Service) refreshPin(installationID uuid.UUID, sessionKey [sessionpin.SessionKeyLen]byte, existing sessionpin.Pin, pinCacheKey string, role string, chosen router.Decision) {
+func (s *Service) refreshPin(ctx context.Context, installationID uuid.UUID, sessionKey [sessionpin.SessionKeyLen]byte, existing sessionpin.Pin, pinCacheKey string, role string, chosen router.Decision) {
 	if installationID == uuid.Nil {
 		return
 	}
@@ -461,15 +489,16 @@ func (s *Service) refreshPin(installationID uuid.UUID, sessionKey [sessionpin.Se
 		LastOutputTokens:      existing.LastOutputTokens,
 		LastTurnEndedAt:       existing.LastTurnEndedAt,
 	}
-	s.enqueuePinUpsert(p, pinCacheKey)
+	s.enqueuePinUpsert(ctx, p, pinCacheKey)
 }
 
 // writeNewPin records a freshly-routed decision as the active pin. Used on
 // first-turn routing and switch turns. UpdateUsage fills in usage stats later.
-func (s *Service) writeNewPin(installationID uuid.UUID, sessionKey [sessionpin.SessionKeyLen]byte, pinCacheKey string, role string, chosen router.Decision) {
-	observability.Get().Debug("writeNewPin called", "installation_id", installationID.String(), "role", role, "model", chosen.Model, "session_key_hex", fmt.Sprintf("%x", sessionKey))
+func (s *Service) writeNewPin(ctx context.Context, installationID uuid.UUID, sessionKey [sessionpin.SessionKeyLen]byte, pinCacheKey string, role string, chosen router.Decision) {
+	log := observability.FromContext(ctx)
+	log.Debug("writeNewPin called", "installation_id", installationID.String(), "role", role, "model", chosen.Model, "session_key_hex", fmt.Sprintf("%x", sessionKey))
 	if installationID == uuid.Nil {
-		observability.Get().Debug("writeNewPin: skipping because installationID is uuid.Nil")
+		log.Debug("writeNewPin: skipping because installationID is uuid.Nil")
 		return
 	}
 	p := sessionpin.Pin{
@@ -482,25 +511,27 @@ func (s *Service) writeNewPin(installationID uuid.UUID, sessionKey [sessionpin.S
 		TurnCount:      1,
 		PinnedUntil:    time.Now().Add(pinSessionTTL),
 	}
-	s.enqueuePinUpsert(p, pinCacheKey)
+	s.enqueuePinUpsert(ctx, p, pinCacheKey)
 }
 
 // enqueuePinUpsert pushes a pin write onto the bounded async worker pool.
 // Drops on saturation. Primes the in-proc LRU so the next turn avoids Postgres.
-func (s *Service) enqueuePinUpsert(p sessionpin.Pin, pinCacheKey string) {
-	log := observability.Get()
+//
+// The caller's ctx is used only to capture the request-scoped logger before
+// the goroutine spawns; the actual Upsert always runs on context.Background()
+// because the request ctx is canceled by the time the response has finished
+// streaming.
+func (s *Service) enqueuePinUpsert(ctx context.Context, p sessionpin.Pin, pinCacheKey string) {
+	log := observability.FromContext(ctx)
 	select {
 	case s.pinWriteSem <- struct{}{}:
 		go func(pin sessionpin.Pin) {
 			defer func() { <-s.pinWriteSem }()
-			// context.Background(): the request ctx is canceled by the
-			// time the response has finished streaming, which would drop
-			// the write and break provider continuity next turn.
 			if err := s.pinStore.Upsert(context.Background(), pin); err != nil {
-				observability.Get().Error("session pin upsert failed", "err", err)
+				log.Error("session pin upsert failed", "err", err)
 				return
 			}
-			observability.Get().Debug("session pin upsert ok", "installation_id", pin.InstallationID.String(), "role", pin.Role, "model", pin.Model)
+			log.Debug("session pin upsert ok", "installation_id", pin.InstallationID.String(), "role", pin.Role, "model", pin.Model)
 		}(p)
 	default:
 		log.Debug("session pin upsert dropped: semaphore full")


### PR DESCRIPTION
## Summary

Every router log line in `internal/proxy/` is now tagged with `session_key`, `request_id`, `api_key_id`, and `ingress`. One Cloud Logging filter on `jsonPayload.session_key=…` will surface the full trace of a session through the router — including planner, scorer, pin lookup, handover, and dispatch — instead of needing to grep across unrelated lines.

## How it works

- New `observability.WithLogger(ctx, log)` / `observability.FromContext(ctx)` in `internal/observability/logger.go`. Drops a `*slog.Logger` onto the request context; `FromContext` returns it (or the global default if nothing's set). Existing `Get()` and `FromGin()` still work.
- New `bindRequestLogger` helper (`internal/proxy/session_key.go`) derives the session key once and returns a context carrying a logger pre-bound with session_key/request_id/api_key_id/ingress.
- Called at the top of `ProxyMessages`, `ProxyOpenAIChatCompletion`, and `ProxyGeminiGenerateContent` — right after envelope parse, before any routing logic.
- Migrated `internal/proxy/*` from `observability.Get()` to `observability.FromContext(ctx)` everywhere ctx was already in scope. A few helpers (`writeNewPin`, `refreshPin`, `enqueuePinUpsert`, `logPlannerOutcome`, `handleForceModelCommand`, `handleToolCallLoopBreak`, `handleNoProgressBreak`) gained a leading `ctx` param so they inherit the bound logger.

## Turn-flow I/O logs (Debug)

Added structured Debug logs at the points where turn flow makes decisions, so a session's path can be reconstructed from logs alone:

- Each proxy entry point: `Proxy{Messages,OpenAIChatCompletion,GeminiGenerateContent} start` with requested model, stream flag, message count, has_tools, token estimate, and a 200-char prompt preview.
- `runTurnLoop`: turn-type classification, pin lookup hit/miss (with model/provider/reason/age), scorer decision, and tier-clamp events.
- `logInboundToolTraffic`: dumps the trailing 5 assistant tool_use names + 160-char arg previews when tools are present, so a misbehaving turn can be correlated back to the prior tool_use/tool_result shape without dumping the full body.

Full upstream bodies remain behind \`LOG_LEVEL=debug\` via the existing \`logUpstreamBody\`.

## What this does NOT do (follow-ups)

- Outbound assistant tool_use blocks aren't logged. \`log_io.go\` has \`logAssistantOutputSummary\` ready, but wiring it to streaming SSE responses needs work in the SSE chain — left for a follow-up.
- LOG_LEVEL → GCP \`severity\` field mapping isn't here. Today everything still lands as \`severity=DEFAULT\` in Cloud Logging. Filter on \`jsonPayload.session_key\` works either way; severity-based filtering is a separate JSON-handler change.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go test ./...\` clean across all packages
- [ ] Verify in staging that a single session_key appears across planner, pin, dispatch, and complete log lines for one turn