### PR TITLE
feat(observability): bind client_session_id (Claude Code / Codex / OpenCode) to logs

### DIFF
--- a/internal/proxy/session_key.go
+++ b/internal/proxy/session_key.go
@@ -42,6 +42,14 @@ func bindRequestLogger(
 		"api_key_id", apiKeyID,
 		"ingress", ingress,
 	)
+	// client_session_id is the calling client's own session id (e.g. Claude
+	// Code's /status UUID). Bound when the client surfaces one so operators
+	// can grep logs by the id the user actually sees.
+	if env != nil {
+		if cs := env.ClientSessionID(); cs != "" {
+			log = log.With("client_session_id", cs)
+		}
+	}
 	return observability.WithLogger(ctx, log), log, key
 }
 

--- a/internal/translate/client_session_id_test.go
+++ b/internal/translate/client_session_id_test.go
@@ -1,0 +1,87 @@
+package translate_test
+
+import (
+	"testing"
+
+	"workweave/router/internal/translate"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRequestEnvelope_ClientSessionID_Anthropic(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+		want string
+	}{
+		{
+			name: "claude code bundle yields bare session uuid",
+			body: `{"messages":[{"role":"user","content":"hi"}],"metadata":{"user_id":"user_abcd1234-5678-90ab-cdef-1234567890ab_account__session_4dbee464-ebf7-437f-9f20-db5a6f7fe3b4"}}`,
+			want: "4dbee464-ebf7-437f-9f20-db5a6f7fe3b4",
+		},
+		{
+			name: "bare uuid in metadata.user_id",
+			body: `{"messages":[{"role":"user","content":"hi"}],"metadata":{"user_id":"31ab679a-f79b-4860-881e-a184dc3d2e2d"}}`,
+			want: "31ab679a-f79b-4860-881e-a184dc3d2e2d",
+		},
+		{
+			name: "non-uuid free-form string truncated to 64",
+			body: `{"messages":[{"role":"user","content":"hi"}],"metadata":{"user_id":"some-very-long-free-form-identifier-that-keeps-going-past-the-sixty-four-character-limit-and-then-some"}}`,
+			want: "some-very-long-free-form-identifier-that-keeps-going-past-the-si",
+		},
+		{
+			name: "missing metadata returns empty",
+			body: `{"messages":[{"role":"user","content":"hi"}]}`,
+			want: "",
+		},
+		{
+			name: "empty user_id returns empty",
+			body: `{"messages":[{"role":"user","content":"hi"}],"metadata":{"user_id":""}}`,
+			want: "",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			env, err := translate.ParseAnthropic([]byte(tc.body))
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, env.ClientSessionID())
+		})
+	}
+}
+
+func TestRequestEnvelope_ClientSessionID_OpenAI(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+		want string
+	}{
+		{
+			name: "user field with bare uuid (codex / opencode shape)",
+			body: `{"model":"gpt-4o","messages":[{"role":"user","content":"hi"}],"user":"4dbee464-ebf7-437f-9f20-db5a6f7fe3b4"}`,
+			want: "4dbee464-ebf7-437f-9f20-db5a6f7fe3b4",
+		},
+		{
+			name: "user field with session marker",
+			body: `{"model":"gpt-4o","messages":[{"role":"user","content":"hi"}],"user":"codex_session_31ab679a-f79b-4860-881e-a184dc3d2e2d"}`,
+			want: "31ab679a-f79b-4860-881e-a184dc3d2e2d",
+		},
+		{
+			name: "falls back to metadata.user_id when user is empty",
+			body: `{"model":"gpt-4o","messages":[{"role":"user","content":"hi"}],"metadata":{"user_id":"50a14434-357e-4b84-9d59-39cc6ee6eb1d"}}`,
+			want: "50a14434-357e-4b84-9d59-39cc6ee6eb1d",
+		},
+		{
+			name: "no identifier at all",
+			body: `{"model":"gpt-4o","messages":[{"role":"user","content":"hi"}]}`,
+			want: "",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			env, err := translate.ParseOpenAI([]byte(tc.body))
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, env.ClientSessionID())
+		})
+	}
+}

--- a/internal/translate/envelope.go
+++ b/internal/translate/envelope.go
@@ -111,6 +111,66 @@ func (e *RequestEnvelope) MetadataUserID() string {
 	return gjson.GetBytes(e.body, "metadata.user_id").String()
 }
 
+// clientSessionEmbeddedUUID matches a UUID following an explicit "session_" or
+// "session-" or "sessionId=" / "sessionId:" marker. Lets us pull the bare
+// session UUID out of bundled identifiers like Claude Code's
+// "user_<account>_account__session_<session>".
+var clientSessionEmbeddedUUID = regexp.MustCompile(
+	`(?i)session[_\-]?(?:id[=:])?([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})`,
+)
+
+// clientSessionTrailingUUID matches a UUID at the end of a string. Fallback for
+// formats that just dump the session UUID with no marker prefix.
+var clientSessionTrailingUUID = regexp.MustCompile(
+	`([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})$`,
+)
+
+const clientSessionIDMaxLen = 64
+
+// ClientSessionID returns the calling client's own session identifier, suitable
+// for log correlation. Unlike the internal session_key (a sha256 over apiKeyID
+// + user_id used for sticky-pin lookup), this is the value the client knows
+// itself by — so running `/status` in Claude Code (or the equivalent in
+// OpenCode / Codex) yields a string the operator can grep for in router logs.
+//
+// Per-ingress source:
+//   - Anthropic (`metadata.user_id`): Claude Code packs the bundle
+//     "user_<account>_account__session_<session>"; we pull the trailing UUID.
+//   - OpenAI (`user`): Codex / OpenCode put the session UUID here directly;
+//     same extraction handles wrapped forms.
+//   - Gemini: no canonical field today; we still check `metadata.user_id` so a
+//     wrapper that sets it gets picked up.
+//
+// If the raw value contains a UUID-shaped session marker we return the bare
+// UUID; otherwise we return the raw value truncated to clientSessionIDMaxLen
+// so a free-form string still grep-correlates without bloating log lines.
+// Returns "" when nothing usable is set.
+func (e *RequestEnvelope) ClientSessionID() string {
+	var raw string
+	switch e.format {
+	case FormatAnthropic, FormatGemini:
+		raw = gjson.GetBytes(e.body, "metadata.user_id").String()
+	case FormatOpenAI:
+		raw = gjson.GetBytes(e.body, "user").String()
+		if raw == "" {
+			raw = gjson.GetBytes(e.body, "metadata.user_id").String()
+		}
+	}
+	if raw == "" {
+		return ""
+	}
+	if m := clientSessionEmbeddedUUID.FindStringSubmatch(raw); m != nil {
+		return m[1]
+	}
+	if m := clientSessionTrailingUUID.FindStringSubmatch(raw); m != nil {
+		return m[1]
+	}
+	if len(raw) > clientSessionIDMaxLen {
+		return raw[:clientSessionIDMaxLen]
+	}
+	return raw
+}
+
 // SystemText returns the concatenated system-prompt text format-neutrally.
 func (e *RequestEnvelope) SystemText() string {
 	switch e.format {


### PR DESCRIPTION
## Summary
- Adds `RequestEnvelope.ClientSessionID()` that pulls the *client's own* session id out of the request body, per ingress format.
- `bindRequestLogger` now attaches it as `client_session_id` on every log line for the turn.
- Operators can grep Cloud Logging by the UUID Claude Code shows in `/status` (or the Codex / OpenCode equivalent) instead of needing to recompute the internal sha256 `session_key`.

Per-ingress source:
- **Anthropic** (`metadata.user_id`): Claude Code packs `user_<acct>_account__session_<sessionUUID>`; we extract the trailing UUID.
- **OpenAI** (top-level `user`): Codex / OpenCode put a session UUID there; falls back to `metadata.user_id` if absent.
- **Gemini**: no canonical field today, but we still read `metadata.user_id` so wrappers that set it get picked up.

Free-form non-UUID values are truncated to 64 chars; missing values omit the attribute entirely. `DeriveSessionKey` is unchanged — sticky session-pin lookups still use the apiKeyID-scoped hash, only the log-correlation surface changes.

## Test plan
- [x] `go test ./internal/translate/... ./internal/proxy/... -count=1`
- [x] `wv mr tc`
- [ ] After deploy: send a Claude Code message, confirm `client_session_id=<uuid>` appears on `ProxyMessages complete` and intermediate turn logs, and matches the UUID from `/status`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)