### PR TITLE
feat(observability): parse client session_id out of JSON-encoded metadata.user_id

### DIFF
--- a/internal/translate/client_session_id_test.go
+++ b/internal/translate/client_session_id_test.go
@@ -21,6 +21,21 @@ func TestRequestEnvelope_ClientSessionID_Anthropic(t *testing.T) {
 			want: "4dbee464-ebf7-437f-9f20-db5a6f7fe3b4",
 		},
 		{
+			name: "claude code stringified-json metadata.user_id",
+			body: `{"messages":[{"role":"user","content":"hi"}],"metadata":{"user_id":"{\"device_id\":\"71490f370101aac16255e0a02d8db8039ca8db7608335ae1b4\",\"account_id\":\"abcd1234\",\"session_id\":\"7937b7f5-465f-4419-99f3-2d1666ba13db\"}"}}`,
+			want: "7937b7f5-465f-4419-99f3-2d1666ba13db",
+		},
+		{
+			name: "stringified-json metadata.user_id sessionId camelCase",
+			body: `{"messages":[{"role":"user","content":"hi"}],"metadata":{"user_id":"{\"deviceId\":\"x\",\"sessionId\":\"3abddf3d-dc4a-4102-96c1-e675b5c790cb\"}"}}`,
+			want: "3abddf3d-dc4a-4102-96c1-e675b5c790cb",
+		},
+		{
+			name: "json object with no recognized session key falls back to truncation",
+			body: `{"messages":[{"role":"user","content":"hi"}],"metadata":{"user_id":"{\"device_id\":\"abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123\",\"account_id\":\"xyz\"}"}}`,
+			want: `{"device_id":"abcdef0123456789abcdef0123456789abcdef0123456789ab`,
+		},
+		{
 			name: "bare uuid in metadata.user_id",
 			body: `{"messages":[{"role":"user","content":"hi"}],"metadata":{"user_id":"31ab679a-f79b-4860-881e-a184dc3d2e2d"}}`,
 			want: "31ab679a-f79b-4860-881e-a184dc3d2e2d",

--- a/internal/translate/envelope.go
+++ b/internal/translate/envelope.go
@@ -159,6 +159,13 @@ func (e *RequestEnvelope) ClientSessionID() string {
 	if raw == "" {
 		return ""
 	}
+	// Claude Code (post 0.x) packs the identifier as a stringified JSON object
+	// like {"device_id":"…","session_id":"<uuid>","account_id":"…"}. Probe the
+	// well-known session-id keys first; only fall through to regex on the raw
+	// string when no key matches.
+	if id := jsonSessionIDField(raw); id != "" {
+		return id
+	}
 	if m := clientSessionEmbeddedUUID.FindStringSubmatch(raw); m != nil {
 		return m[1]
 	}
@@ -169,6 +176,25 @@ func (e *RequestEnvelope) ClientSessionID() string {
 		return raw[:clientSessionIDMaxLen]
 	}
 	return raw
+}
+
+// jsonSessionIDField returns the value of the first matching session-id field
+// when raw is a JSON object, else "". Order matches observed client shapes:
+// Claude Code uses "session_id"; OpenAI surfaces have variously used
+// "sessionId", and chat-style clients sometimes use "conversation_id".
+func jsonSessionIDField(raw string) string {
+	if len(raw) == 0 || raw[0] != '{' {
+		return ""
+	}
+	if !gjson.Valid(raw) {
+		return ""
+	}
+	for _, key := range [...]string{"session_id", "sessionId", "conversation_id", "conversationId"} {
+		if v := gjson.Get(raw, key).String(); v != "" {
+			return v
+		}
+	}
+	return ""
 }
 
 // SystemText returns the concatenated system-prompt text format-neutrally.


### PR DESCRIPTION
## Summary
Claude Code (post 0.x) sends `metadata.user_id` as a **stringified JSON object** — e.g. `{\"device_id\":\"...\",\"session_id\":\"<uuid>\",\"account_id\":\"...\"}`. The previous extractor (shipped in #247) regex-matched on the raw string and, because that JSON is longer than 64 chars, returned a truncated blob starting with `{\"device_id\":\"…` instead of the bare session UUID. Result: `client_session_id` was in the logs, but the value the user sees in Claude Code's `/status` didn't grep.

This PR makes `ClientSessionID` try JSON-parsing first when the raw value looks like a JSON object, probing the well-known session-id field names in order — `session_id`, `sessionId`, `conversation_id`, `conversationId` — and only falling through to the existing regex + truncation behavior when nothing matches.

## Test plan
- [x] `go test ./internal/translate/... ./internal/proxy/... -count=1`
- [x] `wv mr tc`
- [x] New test cases:
  - Claude Code stringified JSON with `session_id` → bare UUID
  - Stringified JSON with `sessionId` (camelCase) → bare UUID
  - JSON object with no recognized key → falls back to 64-char truncation
- [ ] After deploy: confirm `client_session_id=<bare-uuid>` in prod logs (no leading `{`), matching `/status` UUID in Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)