### PR TITLE
fix(translate): force stop_reason=tool_use when tool blocks emitted

### DIFF
--- a/internal/translate/crossformat_response_test.go
+++ b/internal/translate/crossformat_response_test.go
@@ -411,6 +411,29 @@ func TestOpenAIToAnthropicResponse_StopReasonMapping(t *testing.T) {
 	}
 }
 
+// Anthropic invariant: when the OpenAI message carries tool_calls, the
+// translated response must report stop_reason="tool_use" regardless of the
+// upstream finish_reason. GLM-5.1 on DeepInfra and other vLLM-backed OpenAI-
+// compat serves close tool-emitting turns with finish_reason="stop"; without
+// promotion the client sees tool_use blocks + stop_reason="end_turn" and
+// Claude Code loops on the partial tool call.
+func TestOpenAIToAnthropicResponse_PromotesStopReasonWhenToolCallsPresent(t *testing.T) {
+	body := []byte(`{
+		"id": "chatcmpl-glm",
+		"object": "chat.completion",
+		"model": "z-ai/glm-5.1",
+		"choices": [{"index": 0, "message": {"role": "assistant", "content": null, "tool_calls": [
+			{"id": "call_glm", "type": "function", "function": {"name": "Read", "arguments": "{\"path\":\"a.go\"}"}}
+		]}, "finish_reason": "stop"}],
+		"usage": {"prompt_tokens": 40, "completion_tokens": 20, "total_tokens": 60}
+	}`)
+	out, err := translate.OpenAIToAnthropicResponse(body, "z-ai/glm-5.1")
+	require.NoError(t, err)
+	doc := unmarshal(t, out)
+	assert.Equal(t, "tool_use", doc["stop_reason"],
+		"tool_calls present → stop_reason must be tool_use even when upstream finish_reason=stop")
+}
+
 func TestOpenAIToAnthropicResponse_UsageTranslation(t *testing.T) {
 	out, err := translate.OpenAIToAnthropicResponse(openAITextResponse, "gpt-4")
 	require.NoError(t, err)

--- a/internal/translate/stream.go
+++ b/internal/translate/stream.go
@@ -349,6 +349,10 @@ type AnthropicSSETranslator struct {
 	// real answer.
 	thinkingOpen bool
 	toolBlocks   map[int]int
+	// toolUseEmitted latches true the first time a tool_use content block is
+	// opened. finishStream clears toolBlocks before emitMessageDelta, so we
+	// can't read len(toolBlocks) at delta time; the latch outlives the map.
+	toolUseEmitted bool
 
 	finishReason             string
 	usageInputTokens         int
@@ -700,6 +704,7 @@ func (t *AnthropicSSETranslator) emitDelta(delta gjson.Result) error {
 			}
 			blockIdx = t.blockIdx
 			t.toolBlocks[idx] = blockIdx
+			t.toolUseEmitted = true
 			t.blockIdx++
 			if emitErr = t.emitContentBlockStartTool(blockIdx, id, name, sig); emitErr != nil {
 				return false
@@ -870,6 +875,16 @@ func (t *AnthropicSSETranslator) emitContentBlockStop(index int) error {
 
 func (t *AnthropicSSETranslator) emitMessageDelta() error {
 	stopReason := openAIFinishToAnthropic(t.finishReason)
+	// Anthropic invariant: a response containing tool_use blocks MUST report
+	// stop_reason="tool_use". OpenAI-compat upstreams (notably GLM-5.1 on
+	// DeepInfra/vLLM, plus various Qwen/MiMo serves) sometimes close a tool
+	// turn with finish_reason="stop" or "" instead of "tool_calls". Without
+	// this promotion, the client receives tool_use blocks alongside
+	// stop_reason="end_turn"; Claude Code executes the (often partial-arg)
+	// tool_use anyway, gets the same result, and we loop.
+	if t.toolUseEmitted {
+		stopReason = "tool_use"
+	}
 	observability.Get().Debug("AnthropicSSE emit", "event", "message_delta", "stop_reason", stopReason)
 	t.bw.WriteString("event: message_delta\ndata: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":")
 	sse.WriteJSONString(t.bw, stopReason)

--- a/internal/translate/translate.go
+++ b/internal/translate/translate.go
@@ -175,6 +175,13 @@ func OpenAIToAnthropicResponse(body []byte, requestModel string) ([]byte, error)
 	firstChoice := gjson.GetBytes(body, "choices.0")
 	message := firstChoice.Get("message")
 	finishReason := firstChoice.Get("finish_reason").String()
+	// Anthropic invariant: tool_use blocks ⇒ stop_reason="tool_use". Some
+	// OpenAI-compat upstreams (GLM-5.1 on DeepInfra, vLLM Qwen/MiMo serves)
+	// close a tool turn with finish_reason="stop" instead of "tool_calls".
+	// Mirror the streaming-path promotion in emitMessageDelta.
+	if tc := message.Get("tool_calls"); tc.IsArray() && len(tc.Array()) > 0 {
+		finishReason = "tool_calls"
+	}
 
 	jw := newJSONWriter()
 	jw.Obj()

--- a/internal/translate/translate_test.go
+++ b/internal/translate/translate_test.go
@@ -501,6 +501,42 @@ func TestAnthropicSSETranslator_StreamingToolUse(t *testing.T) {
 	assert.Contains(t, body, "event: message_stop")
 }
 
+// Anthropic invariant: any response containing tool_use blocks MUST report
+// stop_reason="tool_use", regardless of what the OpenAI-compat upstream sent
+// as finish_reason. GLM-5.1 on DeepInfra (vLLM, tool_stream=true) and other
+// OpenAI-compat serves have been observed closing tool-emitting turns with
+// finish_reason="stop" or "" instead of "tool_calls"; without this promotion
+// the client receives tool_use blocks alongside stop_reason="end_turn" and
+// Claude Code executes the (often partial-arg) tool_use anyway, looping on
+// the identical result.
+func TestAnthropicSSETranslator_PromotesStopReasonWhenToolUseEmitted(t *testing.T) {
+	rec := httptest.NewRecorder()
+	translator := translate.NewAnthropicSSETranslator(rec, "z-ai/glm-5.1", nil)
+
+	translator.Header().Set("Content-Type", "text/event-stream")
+	translator.WriteHeader(http.StatusOK)
+
+	events := []string{
+		"data: {\"id\":\"chatcmpl-glm\",\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\",\"content\":null,\"tool_calls\":[{\"index\":0,\"id\":\"call_glm\",\"type\":\"function\",\"function\":{\"name\":\"Read\",\"arguments\":\"\"}}]},\"finish_reason\":null}]}\n\n",
+		"data: {\"id\":\"chatcmpl-glm\",\"choices\":[{\"index\":0,\"delta\":{\"tool_calls\":[{\"index\":0,\"function\":{\"arguments\":\"{\\\"path\\\":\\\"a\\\"}\"}}]},\"finish_reason\":null}]}\n\n",
+		// vLLM/DeepInfra bug: tool turn closes with finish_reason="stop", not "tool_calls".
+		"data: {\"id\":\"chatcmpl-glm\",\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"stop\"}],\"usage\":{\"prompt_tokens\":20,\"completion_tokens\":5,\"total_tokens\":25}}\n\n",
+		"data: [DONE]\n\n",
+	}
+	for _, event := range events {
+		_, err := translator.Write([]byte(event))
+		require.NoError(t, err)
+	}
+	require.NoError(t, translator.Finalize())
+
+	body := rec.Body.String()
+	assert.Contains(t, body, `"type":"tool_use"`)
+	assert.Contains(t, body, `"stop_reason":"tool_use"`,
+		"tool_use blocks present → stop_reason must be tool_use even when upstream finish_reason=stop")
+	assert.NotContains(t, body, `"stop_reason":"end_turn"`,
+		"end_turn alongside emitted tool_use violates Anthropic spec and triggers client loops")
+}
+
 // Load-bearing: Gemini 3.x requires the opaque thought_signature round-tripped
 // on the next turn's functionCall part. The Gemini→OpenAI translator smuggles
 // it as function.thought_signature on the tool_call chunk; AnthropicSSE must


### PR DESCRIPTION
## Summary

OpenAI-compat upstreams — notably **GLM-5.1 on DeepInfra/vLLM** with `tool_stream=true`, plus some Qwen/MiMo serves — close tool-emitting turns with `finish_reason="stop"` (or `""`) instead of `"tool_calls"`. The translator faithfully streamed the `tool_use` content blocks but mapped the trailing `finish_reason` straight through, emitting `tool_use` blocks alongside `stop_reason="end_turn"`.

That violates the Anthropic invariant that **any response containing `tool_use` must report `stop_reason="tool_use"`**. Claude Code executes the (often partial-arg) tool_use anyway, gets an identical result, re-routes through the sticky session pin to the same model, and loops indefinitely.

### Observed in prod
Session `a035852f-d3f8-43ed-a79d-cdb232e6b80f`: 13 consecutive sticky-hit turns to `z-ai/glm-5.1` on deepinfra, input growing ~600 tok/turn, never terminating. Just below the cross-envelope no-progress detector's 5-in-90s threshold, so it never tripped.

## Fix
Promote `stop_reason` → `tool_use` whenever a tool block was emitted:
- **Streaming** (`emitMessageDelta`): latched via a new `toolUseEmitted` flag, because `finishStream` clears `toolBlocks` before the delta is emitted.
- **Non-streaming** (`OpenAIToAnthropicResponse`): when `message.tool_calls` is a non-empty array.

This is a wire-format invariant in `internal/translate/`, not a model-specific hack — it protects every OpenAI-compat upstream that ever emits an inconsistent finish_reason on a tool turn.

## Test plan
- [x] `TestAnthropicSSETranslator_PromotesStopReasonWhenToolUseEmitted` (streaming, fails before fix)
- [x] `TestOpenAIToAnthropicResponse_PromotesStopReasonWhenToolCallsPresent` (non-streaming, fails before fix)
- [x] Existing tool_use / stop_reason mapping tests still pass
- [x] `wv mr t` (full suite) + `wv mr tc` green