### PR TITLE
feat(observability): log translated-response summary on ProxyMessages complete

### DIFF
--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -909,6 +909,11 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 	var proxyErr error
 	crossFormat := false
 	var extractor *otel.UsageExtractor
+	// respSummary captures the winning attempt's translated-response signals
+	// (finish_reason, emitted stop_reason, tool_use count) for the completion
+	// log. Populated by the translator-backed paths; stays zero for the
+	// Anthropic-native passthrough path, which has no translator.
+	var respSummary translate.ResponseSummary
 
 	var attempt dispatchAttempt
 	switch decision.Provider {
@@ -969,7 +974,9 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 			if err != nil && env.Stream() && preludeBuf == nil {
 				err = emitAnthropicSSEErrorEvent(sink, err)
 			}
-			return finalizeAfterProxy(err, translator.Finalize)
+			finErr := finalizeAfterProxy(err, translator.Finalize)
+			respSummary = translator.Summary()
+			return finErr
 		}
 	case providers.ProviderGoogle:
 		crossFormat = true
@@ -1004,7 +1011,9 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 				err = emitAnthropicSSEErrorEvent(sink, err)
 			}
 			err = finalizeAfterProxy(err, geminiTr.Finalize)
-			return finalizeAfterProxy(err, anthropicTr.Finalize)
+			finErr := finalizeAfterProxy(err, anthropicTr.Finalize)
+			respSummary = anthropicTr.Summary()
+			return finErr
 		}
 	default:
 		return fmt.Errorf("%w: %s (no translation path defined for inbound Anthropic Messages)", ErrProviderNotConfigured, decision.Provider)
@@ -1137,7 +1146,7 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 		s.emitBilling(ctx, requestID, externalID, decision, actPricing, routeRes, in, out, cacheCreation, cacheRead)
 	}
 
-	log.Info("ProxyMessages complete", "requested_model", feats.Model, "baseline_model", s.baselineFor(feats.Model), "decision_model", decision.Model, "decision_provider", decision.Provider, "primary_provider", primaryProvider, "fallback_attempts", winnerIdx, "failover_used", finalProvider != primaryProvider, "decision_reason", decision.Reason, "requested_tier", routeRes.RequestedTier.String(), "decision_tier", catalog.TierFor(decision.Model).String(), "tier_clamped", routeRes.TierClamped, "pre_clamp_model", routeRes.PreClampModel, "embedded_tokens", len(promptText)/4, "total_input_tokens", feats.Tokens, "has_tools", feats.HasTools, "message_count", feats.MessageCount, "last_kind", feats.LastKind, "last_preview", feats.LastPreview, "embed_input", embedInput, "cross_format", crossFormat, "sticky_hit", stickyHit, "route_ms", routeMs, "proxy_ms", proxyMs, "proxy_err", proxyErr, "upstream_status", upstreamStatus(proxyErr))
+	log.Info("ProxyMessages complete", "requested_model", feats.Model, "baseline_model", s.baselineFor(feats.Model), "decision_model", decision.Model, "decision_provider", decision.Provider, "primary_provider", primaryProvider, "fallback_attempts", winnerIdx, "failover_used", finalProvider != primaryProvider, "decision_reason", decision.Reason, "requested_tier", routeRes.RequestedTier.String(), "decision_tier", catalog.TierFor(decision.Model).String(), "tier_clamped", routeRes.TierClamped, "pre_clamp_model", routeRes.PreClampModel, "embedded_tokens", len(promptText)/4, "total_input_tokens", feats.Tokens, "has_tools", feats.HasTools, "message_count", feats.MessageCount, "last_kind", feats.LastKind, "last_preview", feats.LastPreview, "embed_input", embedInput, "cross_format", crossFormat, "sticky_hit", stickyHit, "route_ms", routeMs, "proxy_ms", proxyMs, "proxy_err", proxyErr, "upstream_status", upstreamStatus(proxyErr), "upstream_finish_reason", respSummary.UpstreamFinishReason, "resp_stop_reason", respSummary.StopReason, "stop_reason_promoted", respSummary.StopReasonPromoted, "tool_use_blocks", respSummary.ToolUseBlocks, "resp_output_tokens", respSummary.OutputTokens)
 	return proxyErr
 }
 

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -945,6 +945,7 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 		attempt = func(actx context.Context, d router.Decision, p providers.Client) error {
 			attemptOpts := opts
 			attemptOpts.TargetProvider = d.Provider
+			respSummary = translate.ResponseSummary{}
 			prep, emitErr := env.PrepareOpenAI(r.Header, attemptOpts)
 			if emitErr != nil {
 				log.Error("Failed to translate Anthropic request to OpenAI format", "err", emitErr, "decision_provider", d.Provider)
@@ -987,6 +988,7 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 		}
 		logUpstreamBody(log, routeRes.SessionKey, decision, feats, prep.Body)
 		attempt = func(actx context.Context, d router.Decision, p providers.Client) error {
+			respSummary = translate.ResponseSummary{}
 			var usage otel.UsageSink
 			if s.usageRequired() {
 				extractor = otel.NewUsageExtractor(nil, d.Provider)

--- a/internal/translate/stream.go
+++ b/internal/translate/stream.go
@@ -353,6 +353,14 @@ type AnthropicSSETranslator struct {
 	// opened. finishStream clears toolBlocks before emitMessageDelta, so we
 	// can't read len(toolBlocks) at delta time; the latch outlives the map.
 	toolUseEmitted bool
+	// toolUseCount counts tool_use content blocks opened across the response.
+	// Like toolUseEmitted it outlives toolBlocks (which finishStream clears),
+	// so a post-stream observer can report how many tools the model emitted.
+	toolUseCount int
+	// emittedStopReason records the stop_reason actually written by
+	// emitMessageDelta (after the tool_use promotion). Surfaced via Summary so
+	// the proxy can log what the client saw without re-deriving it.
+	emittedStopReason string
 
 	finishReason             string
 	usageInputTokens         int
@@ -402,6 +410,38 @@ func (t *AnthropicSSETranslator) WithEstimatedInputTokens(n int) *AnthropicSSETr
 		t.estimatedInputTokens = n
 	}
 	return t
+}
+
+// ResponseSummary reports translated-response signals an observer can log
+// after the stream completes. It exists to answer, from logs alone, what an
+// OpenAI-compat upstream actually returned and whether the tool_use stop_reason
+// promotion (see emitMessageDelta) had to fire for this turn.
+type ResponseSummary struct {
+	// UpstreamFinishReason is the raw OpenAI finish_reason as received
+	// ("stop", "tool_calls", "length", ""), before any Anthropic mapping.
+	UpstreamFinishReason string
+	// StopReason is the Anthropic stop_reason actually emitted to the client
+	// (post tool_use promotion). Empty if the stream ended before message_delta.
+	StopReason string
+	// StopReasonPromoted is true when tool_use blocks forced stop_reason to
+	// "tool_use" over an upstream finish_reason that mapped to something else.
+	StopReasonPromoted bool
+	// ToolUseBlocks is the number of tool_use content blocks emitted.
+	ToolUseBlocks int
+	// OutputTokens is the upstream completion_tokens count, when reported.
+	OutputTokens int
+}
+
+// Summary returns the response summary for observability. Call after Finalize;
+// before the stream completes the fields reflect partial state.
+func (t *AnthropicSSETranslator) Summary() ResponseSummary {
+	return ResponseSummary{
+		UpstreamFinishReason: t.finishReason,
+		StopReason:           t.emittedStopReason,
+		StopReasonPromoted:   t.toolUseEmitted && openAIFinishToAnthropic(t.finishReason) != "tool_use",
+		ToolUseBlocks:        t.toolUseCount,
+		OutputTokens:         t.usageOutputTokens,
+	}
 }
 
 func (t *AnthropicSSETranslator) Header() http.Header {
@@ -705,6 +745,7 @@ func (t *AnthropicSSETranslator) emitDelta(delta gjson.Result) error {
 			blockIdx = t.blockIdx
 			t.toolBlocks[idx] = blockIdx
 			t.toolUseEmitted = true
+			t.toolUseCount++
 			t.blockIdx++
 			if emitErr = t.emitContentBlockStartTool(blockIdx, id, name, sig); emitErr != nil {
 				return false
@@ -885,6 +926,7 @@ func (t *AnthropicSSETranslator) emitMessageDelta() error {
 	if t.toolUseEmitted {
 		stopReason = "tool_use"
 	}
+	t.emittedStopReason = stopReason
 	observability.Get().Debug("AnthropicSSE emit", "event", "message_delta", "stop_reason", stopReason)
 	t.bw.WriteString("event: message_delta\ndata: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":")
 	sse.WriteJSONString(t.bw, stopReason)

--- a/internal/translate/translate_test.go
+++ b/internal/translate/translate_test.go
@@ -537,6 +537,68 @@ func TestAnthropicSSETranslator_PromotesStopReasonWhenToolUseEmitted(t *testing.
 		"end_turn alongside emitted tool_use violates Anthropic spec and triggers client loops")
 }
 
+// Summary must expose, post-stream, the signals needed to diagnose the
+// GLM-5.1/DeepInfra tool loop from logs alone: the raw upstream finish_reason,
+// the promoted stop_reason, the fact that promotion fired, the tool_use block
+// count, and the upstream completion-token count.
+func TestAnthropicSSETranslator_SummaryReportsPromotionAndToolUse(t *testing.T) {
+	rec := httptest.NewRecorder()
+	translator := translate.NewAnthropicSSETranslator(rec, "z-ai/glm-5.1", nil)
+
+	translator.Header().Set("Content-Type", "text/event-stream")
+	translator.WriteHeader(http.StatusOK)
+
+	events := []string{
+		"data: {\"id\":\"chatcmpl-glm\",\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\",\"content\":null,\"tool_calls\":[{\"index\":0,\"id\":\"call_a\",\"type\":\"function\",\"function\":{\"name\":\"Read\",\"arguments\":\"{}\"}}]},\"finish_reason\":null}]}\n\n",
+		// Second distinct tool call (new index) must count as a separate block.
+		"data: {\"id\":\"chatcmpl-glm\",\"choices\":[{\"index\":0,\"delta\":{\"tool_calls\":[{\"index\":1,\"id\":\"call_b\",\"type\":\"function\",\"function\":{\"name\":\"Grep\",\"arguments\":\"{}\"}}]},\"finish_reason\":null}]}\n\n",
+		// vLLM/DeepInfra bug: tool turn closes with finish_reason="stop", not "tool_calls".
+		"data: {\"id\":\"chatcmpl-glm\",\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"stop\"}],\"usage\":{\"prompt_tokens\":40,\"completion_tokens\":12,\"total_tokens\":52}}\n\n",
+		"data: [DONE]\n\n",
+	}
+	for _, event := range events {
+		_, err := translator.Write([]byte(event))
+		require.NoError(t, err)
+	}
+	require.NoError(t, translator.Finalize())
+
+	got := translator.Summary()
+	assert.Equal(t, "stop", got.UpstreamFinishReason,
+		"raw upstream finish_reason must be preserved for diagnosis, not the promoted value")
+	assert.Equal(t, "tool_use", got.StopReason, "emitted stop_reason reflects the promotion")
+	assert.True(t, got.StopReasonPromoted,
+		"promotion must be flagged when finish_reason=stop carries tool_use blocks")
+	assert.Equal(t, 2, got.ToolUseBlocks, "both emitted tool calls must be counted")
+	assert.Equal(t, 12, got.OutputTokens, "upstream completion_tokens must be surfaced")
+}
+
+// When the upstream closes cleanly with finish_reason="stop" and no tool calls,
+// Summary must NOT report a promotion — otherwise the flag is meaningless.
+func TestAnthropicSSETranslator_SummaryNoPromotionOnPlainStop(t *testing.T) {
+	rec := httptest.NewRecorder()
+	translator := translate.NewAnthropicSSETranslator(rec, "z-ai/glm-5.1", nil)
+
+	translator.Header().Set("Content-Type", "text/event-stream")
+	translator.WriteHeader(http.StatusOK)
+
+	events := []string{
+		"data: {\"id\":\"chatcmpl-glm\",\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\",\"content\":\"done\"},\"finish_reason\":null}]}\n\n",
+		"data: {\"id\":\"chatcmpl-glm\",\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"stop\"}],\"usage\":{\"prompt_tokens\":10,\"completion_tokens\":2,\"total_tokens\":12}}\n\n",
+		"data: [DONE]\n\n",
+	}
+	for _, event := range events {
+		_, err := translator.Write([]byte(event))
+		require.NoError(t, err)
+	}
+	require.NoError(t, translator.Finalize())
+
+	got := translator.Summary()
+	assert.Equal(t, "stop", got.UpstreamFinishReason)
+	assert.Equal(t, "end_turn", got.StopReason, "plain stop maps to end_turn")
+	assert.False(t, got.StopReasonPromoted, "no tool_use blocks → no promotion")
+	assert.Equal(t, 0, got.ToolUseBlocks)
+}
+
 // Load-bearing: Gemini 3.x requires the opaque thought_signature round-tripped
 // on the next turn's functionCall part. The Gemini→OpenAI translator smuggles
 // it as function.thought_signature on the tool_call chunk; AnthropicSSE must


### PR DESCRIPTION
## Summary
- `ProxyMessages complete` logged only request-side fields, so when a session loops on an OpenAI-compat upstream (e.g. the GLM-5.1/DeepInfra no-progress loop) we can't tell from logs what the model returned or whether the #250 `tool_use` stop_reason promotion fired.
- Surfaces a `ResponseSummary` from `AnthropicSSETranslator` and adds it to the completion log: `upstream_finish_reason` (raw upstream value), `resp_stop_reason` (emitted, post-promotion), `stop_reason_promoted`, `tool_use_blocks`, `resp_output_tokens`.
- Populated on the streaming translator paths (OpenAI-compat + Gemini). The Anthropic-native passthrough and buffered non-streaming paths report zero values.

## Why
Follow-up to #250. A prod session (`client_session_id 75b987f0…`) still hit the no-progress break on the revision that already includes #250, and request-only logs can't tell us whether glm-5.1 emitted `tool_use` with `finish_reason=stop` (the promotion path) or degenerated some other way. These fields make the next occurrence diagnosable from logs alone — in particular `stop_reason_promoted` directly shows whether #250 engaged.

## Test plan
- [x] `go build ./...` and `go vet ./internal/proxy/ ./internal/translate/` clean
- [x] New unit tests: `Summary` reports promotion + tool_use count when glm closes with `finish_reason=stop`, and reports no promotion on plain stop
- [x] Full `internal/translate` + `internal/proxy` packages pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)