### PR TITLE
fix(translate): drop nameless tool_calls instead of emitting empty tool_use

### DIFF
--- a/internal/translate/nameless_tool_call_test.go
+++ b/internal/translate/nameless_tool_call_test.go
@@ -1,0 +1,141 @@
+package translate_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"workweave/router/internal/translate"
+)
+
+// A nameless tool_call is the cross-model loop trap: GLM, Qwen, Kimi, and
+// gpt-oss on vLLM/SGLang/DeepInfra all intermittently emit a tool_call with a
+// blank function name (often closing the turn with finish_reason="stop").
+// Forwarding it as a tool_use block makes Claude Code invoke tool "" ->
+// "No such tool available" -> retry -> infinite loop until the proxy's
+// no-progress breaker trips. Both the streaming and non-streaming translators
+// must drop the nameless call and leave the turn's real stop_reason intact.
+
+// driveAnthropicSSE feeds OpenAI chat.completion.chunk events through the
+// translator and returns the translated Anthropic SSE body.
+func driveAnthropicSSE(t *testing.T, model string, events []string) string {
+	t.Helper()
+	rec := httptest.NewRecorder()
+	translator := translate.NewAnthropicSSETranslator(rec, model, nil)
+	translator.Header().Set("Content-Type", "text/event-stream")
+	translator.WriteHeader(http.StatusOK)
+	for _, e := range events {
+		_, err := translator.Write([]byte(e))
+		require.NoError(t, err)
+	}
+	return rec.Body.String()
+}
+
+func TestAnthropicSSETranslator_DropsNamelessToolCall(t *testing.T) {
+	// Every OpenAI-compat upstream we route to can produce this shape, so the
+	// guard must be model-agnostic, not keyed on a model name.
+	models := []string{"z-ai/glm-5.1", "qwen/qwen3-coder", "moonshotai/kimi-k2", "openai/gpt-oss-120b"}
+	for _, model := range models {
+		t.Run(model, func(t *testing.T) {
+			body := driveAnthropicSSE(t, model, []string{
+				`data: {"id":"c1","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"role":"assistant","content":"The proof is complete."},"finish_reason":null}]}` + "\n\n",
+				// Nameless tool_call: function.name absent. The model is actually done.
+				`data: {"id":"c1","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_x","type":"function","function":{"name":"","arguments":""}}]},"finish_reason":null}]}` + "\n\n",
+				`data: {"id":"c1","choices":[{"index":0,"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":10,"completion_tokens":5}}` + "\n\n",
+				"data: [DONE]\n\n",
+			})
+
+			assert.NotContains(t, body, `"type":"tool_use"`, "nameless tool_call must not become a tool_use block")
+			assert.Contains(t, body, "The proof is complete.", "streamed text must survive")
+			// No tool_use block => no promotion => the real stop_reason wins.
+			assert.Contains(t, body, `"stop_reason":"end_turn"`)
+			assert.NotContains(t, body, `"stop_reason":"tool_use"`)
+		})
+	}
+}
+
+func TestAnthropicSSETranslator_DropsNamelessToolCallWithArgFragments(t *testing.T) {
+	// Arguments stream in later chunks that reuse the same index but carry no
+	// name. A naive guard that only checks the first chunk would still leak a
+	// content_block_delta into a stale/zero block index.
+	body := driveAnthropicSSE(t, "z-ai/glm-5.1", []string{
+		`data: {"id":"c1","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_x","type":"function","function":{"name":""}}]},"finish_reason":null}]}` + "\n\n",
+		`data: {"id":"c1","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{\"path\":"}}]},"finish_reason":null}]}` + "\n\n",
+		`data: {"id":"c1","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\"a.go\"}"}}]},"finish_reason":null}]}` + "\n\n",
+		`data: {"id":"c1","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}` + "\n\n",
+		"data: [DONE]\n\n",
+	})
+
+	assert.NotContains(t, body, `"type":"tool_use"`)
+	assert.NotContains(t, body, "content_block_delta", "no args delta may stream for a dropped tool block")
+	assert.Contains(t, body, `"stop_reason":"end_turn"`)
+}
+
+func TestAnthropicSSETranslator_KeepsNamedToolDropsNameless(t *testing.T) {
+	// A legitimate named tool_call alongside a nameless one: the named call
+	// must survive (and promote stop_reason to tool_use), the nameless dropped.
+	body := driveAnthropicSSE(t, "z-ai/glm-5.1", []string{
+		`data: {"id":"c1","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_good","type":"function","function":{"name":"Read","arguments":"{\"path\":\"a.go\"}"}}]},"finish_reason":null}]}` + "\n\n",
+		`data: {"id":"c1","choices":[{"index":1,"delta":{"tool_calls":[{"index":1,"id":"call_bad","type":"function","function":{"name":"","arguments":""}}]},"finish_reason":null}]}` + "\n\n",
+		`data: {"id":"c1","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}` + "\n\n",
+		"data: [DONE]\n\n",
+	})
+
+	assert.Equal(t, 1, strings.Count(body, `"type":"tool_use"`), "exactly the named tool_use block survives")
+	assert.Contains(t, body, `"name":"Read"`)
+	assert.NotContains(t, body, `"name":""`)
+	// Upstream finish_reason="stop" but a real tool_use block => promotion.
+	assert.Contains(t, body, `"stop_reason":"tool_use"`)
+}
+
+func TestOpenAIToAnthropicResponse_DropsNamelessToolCall(t *testing.T) {
+	// Non-streaming twin of the streaming loop trap.
+	resp := []byte(`{
+		"id": "chatcmpl-x",
+		"object": "chat.completion",
+		"model": "z-ai/glm-5.1",
+		"choices": [{"index": 0, "message": {"role": "assistant", "content": "Done.", "tool_calls": [
+			{"id": "call_bad", "type": "function", "function": {"name": "", "arguments": ""}}
+		]}, "finish_reason": "stop"}],
+		"usage": {"prompt_tokens": 10, "completion_tokens": 3, "total_tokens": 13}
+	}`)
+
+	out, err := translate.OpenAIToAnthropicResponse(resp, "z-ai/glm-5.1")
+	require.NoError(t, err)
+	doc := unmarshal(t, out)
+
+	// No tool_use block => promotion must not fire => end_turn, not tool_use.
+	assert.Equal(t, "end_turn", doc["stop_reason"])
+	for _, raw := range content(t, doc) {
+		blk, _ := raw.(map[string]any)
+		assert.NotEqual(t, "tool_use", blk["type"], "nameless tool_call must be dropped")
+	}
+}
+
+func TestOpenAIToAnthropicResponse_KeepsNamedToolDropsNameless(t *testing.T) {
+	resp := []byte(`{
+		"id": "chatcmpl-y",
+		"object": "chat.completion",
+		"model": "z-ai/glm-5.1",
+		"choices": [{"index": 0, "message": {"role": "assistant", "content": null, "tool_calls": [
+			{"id": "call_good", "type": "function", "function": {"name": "Read", "arguments": "{\"path\":\"a.go\"}"}},
+			{"id": "call_bad", "type": "function", "function": {"name": "", "arguments": ""}}
+		]}, "finish_reason": "stop"}],
+		"usage": {"prompt_tokens": 10, "completion_tokens": 3, "total_tokens": 13}
+	}`)
+
+	out, err := translate.OpenAIToAnthropicResponse(resp, "z-ai/glm-5.1")
+	require.NoError(t, err)
+	doc := unmarshal(t, out)
+
+	assert.Equal(t, "tool_use", doc["stop_reason"], "a surviving named tool_call still promotes")
+	blocks := content(t, doc)
+	require.Len(t, blocks, 1, "only the named tool_use survives")
+	blk, _ := blocks[0].(map[string]any)
+	assert.Equal(t, "tool_use", blk["type"])
+	assert.Equal(t, "Read", blk["name"])
+}

--- a/internal/translate/stream.go
+++ b/internal/translate/stream.go
@@ -349,6 +349,10 @@ type AnthropicSSETranslator struct {
 	// real answer.
 	thinkingOpen bool
 	toolBlocks   map[int]int
+	// suppressedTools holds tool_call indices we refused to open because the
+	// first delta carried no function name (see emitDelta). Later argument
+	// fragments reuse the same index, so we must remember to drop them too.
+	suppressedTools map[int]struct{}
 	// toolUseEmitted latches true the first time a tool_use content block is
 	// opened. finishStream clears toolBlocks before emitMessageDelta, so we
 	// can't read len(toolBlocks) at delta time; the latch outlives the map.
@@ -387,12 +391,13 @@ type AnthropicSSETranslator struct {
 func NewAnthropicSSETranslator(w http.ResponseWriter, requestModel string, sink otel.UsageSink) *AnthropicSSETranslator {
 	flusher, _ := w.(http.Flusher)
 	return &AnthropicSSETranslator{
-		inner:        w,
-		flusher:      flusher,
-		bw:           bufio.NewWriterSize(w, 8192),
-		requestModel: requestModel,
-		toolBlocks:   make(map[int]int),
-		usageSink:    sink,
+		inner:           w,
+		flusher:         flusher,
+		bw:              bufio.NewWriterSize(w, 8192),
+		requestModel:    requestModel,
+		toolBlocks:      make(map[int]int),
+		suppressedTools: make(map[int]struct{}),
+		usageSink:       sink,
 	}
 }
 
@@ -720,8 +725,28 @@ func (t *AnthropicSSETranslator) emitDelta(delta gjson.Result) error {
 	var emitErr error
 	toolCalls.ForEach(func(_, tc gjson.Result) bool {
 		idx := int(tc.Get("index").Int())
+		if _, suppressed := t.suppressedTools[idx]; suppressed {
+			// Argument fragments of a tool_call we refused to open. Drop them
+			// so they don't stream into a stale/zero block index.
+			return true
+		}
 		blockIdx, ok := t.toolBlocks[idx]
 		if !ok {
+			id := tc.Get("id").Str
+			name := tc.Get("function.name").Str
+			// A tool_call whose first delta carries no function name is
+			// malformed. OpenAI-compat upstreams (GLM, Qwen, Kimi, gpt-oss on
+			// vLLM/SGLang/DeepInfra) intermittently emit one, often closing the
+			// turn with finish_reason="stop". Emitting it as a tool_use block
+			// makes the client invoke tool "" -> "No such tool available" ->
+			// retry -> infinite loop. Drop it: the turn ends on its real
+			// stop_reason and any text already streamed survives. Guard runs
+			// before closing text/thinking so a dropped tool can't truncate a
+			// legitimate text block.
+			if name == "" {
+				t.suppressedTools[idx] = struct{}{}
+				return true
+			}
 			if t.textOpen {
 				if err := t.emitContentBlockStop(t.blockIdx - 1); err != nil {
 					emitErr = err
@@ -736,8 +761,6 @@ func (t *AnthropicSSETranslator) emitDelta(delta gjson.Result) error {
 				}
 				t.thinkingOpen = false
 			}
-			id := tc.Get("id").Str
-			name := tc.Get("function.name").Str
 			sig := tc.Get("function.thought_signature").Str
 			if sig == "" {
 				sig = tc.Get("thought_signature").Str

--- a/internal/translate/translate.go
+++ b/internal/translate/translate.go
@@ -178,8 +178,11 @@ func OpenAIToAnthropicResponse(body []byte, requestModel string) ([]byte, error)
 	// Anthropic invariant: tool_use blocks ⇒ stop_reason="tool_use". Some
 	// OpenAI-compat upstreams (GLM-5.1 on DeepInfra, vLLM Qwen/MiMo serves)
 	// close a tool turn with finish_reason="stop" instead of "tool_calls".
-	// Mirror the streaming-path promotion in emitMessageDelta.
-	if tc := message.Get("tool_calls"); tc.IsArray() && len(tc.Array()) > 0 {
+	// Mirror the streaming-path promotion in emitMessageDelta. Count only
+	// named tool calls: nameless ones are dropped in
+	// writeAnthropicContentFromOpenAI, so promoting on their presence would
+	// force stop_reason="tool_use" with no tool_use block — the loop again.
+	if anyNamedToolCall(message.Get("tool_calls")) {
 		finishReason = "tool_calls"
 	}
 
@@ -230,6 +233,11 @@ func writeAnthropicContentFromOpenAI(jw *jsonWriter, message gjson.Result) {
 	message.Get("tool_calls").ForEach(func(_, tc gjson.Result) bool {
 		id := tc.Get("id").String()
 		name := tc.Get("function.name").String()
+		// Drop nameless tool_calls; see anyNamedToolCall. Mirrors the
+		// streaming guard in emitDelta.
+		if name == "" {
+			return true
+		}
 		argsStr := tc.Get("function.arguments").String()
 
 		var inputRaw string
@@ -265,6 +273,25 @@ func writeAnthropicContentFromOpenAI(jw *jsonWriter, message gjson.Result) {
 		return true
 	})
 	jw.EndArr()
+}
+
+// anyNamedToolCall reports whether the OpenAI tool_calls array contains at
+// least one call with a non-empty function name. A nameless tool_call is
+// malformed: OpenAI-compat upstreams (GLM, Qwen, Kimi, gpt-oss on
+// vLLM/SGLang/DeepInfra) intermittently emit one, often alongside
+// finish_reason="stop". Forwarding it as an Anthropic tool_use block makes the
+// client invoke tool "" -> "No such tool available" -> retry -> infinite loop,
+// so such calls are dropped and must not drive the stop_reason promotion.
+func anyNamedToolCall(toolCalls gjson.Result) bool {
+	found := false
+	toolCalls.ForEach(func(_, tc gjson.Result) bool {
+		if tc.Get("function.name").String() != "" {
+			found = true
+			return false
+		}
+		return true
+	})
+	return found
 }
 
 // isEditToolName reports whether name is a file-edit tool subject to escape normalization.


### PR DESCRIPTION
## Summary

Fixes an infinite-loop failure mode observed in production with GLM-5.1 on DeepInfra (Claude Code session `64409614…`): the model finished its turn (streamed a full answer, `finish_reason=stop`) but tacked on a `tool_call` with an **empty `function.name`**. The translator faithfully emitted an Anthropic `tool_use` block with `"name":""`, and the stop_reason promotion from #250 flipped the clean `stop` into `stop_reason=tool_use`. Claude Code then tried to invoke tool `""` → `No such tool available:` → fed the error back → the model emitted another nameless tool_call → loop, until the proxy's no-progress breaker tripped at 5.

This is **not GLM-specific** — vLLM/SGLang/DeepInfra serves of Qwen, Kimi, and gpt-oss all intermittently emit nameless/partial tool_calls (vLLM #38603/#39598, LiteLLM #17753/#19061). The fix keys on the *shape* (empty name), so every OpenAI-compat upstream is covered.

## Changes

- **`stream.go`** — streaming path drops a tool_call whose first delta has an empty `function.name`; the index is suppressed so later argument fragments don't stream into a stale block. The check runs before closing any open text/thinking block, so a dropped tool can't truncate legitimate text. No block opens ⇒ `toolUseEmitted` stays false ⇒ the #250 promotion doesn't fire ⇒ real `end_turn` survives.
- **`translate.go`** — non-streaming path skips nameless tool_calls, and the stop_reason promotion now counts only *named* calls (otherwise an all-nameless response would still promote to `tool_use` with zero blocks — the loop again).
- **`nameless_tool_call_test.go`** — regression tests: streaming drop asserted across GLM/Qwen/Kimi/gpt-oss, arg-fragment drop, mixed named+nameless (named survives & promotes), plus non-streaming twins.

## Test plan

- [x] `wv mr tc` passes
- [x] `go test ./internal/translate/` passes (new + existing)
- [ ] Confirm in prod logs that `64409614`-style no-progress breaks stop recurring for OSS models

🤖 Generated with [Claude Code](https://claude.com/claude-code)