### PR TITLE
catalog: add claude-opus-4-8 + correct opus-4.6/4.7 pricing to $5/$25

### DIFF
--- a/install/cc-statusline.sh
+++ b/install/cc-statusline.sh
@@ -130,8 +130,9 @@ normalize_model() {
 prices='{
   "input": {
     "claude-haiku-4-5":                 0.0008,
-    "claude-opus-4-6":                  0.015,
-    "claude-opus-4-7":                  0.015,
+    "claude-opus-4-6":                  0.005,
+    "claude-opus-4-7":                  0.005,
+    "claude-opus-4-8":                  0.005,
     "claude-sonnet-4-5":                0.003,
     "claude-sonnet-4-6":                0.003,
     "deepseek/deepseek-v4-flash":       0.00014,
@@ -180,8 +181,9 @@ prices='{
   },
   "output": {
     "claude-haiku-4-5":                 0.004,
-    "claude-opus-4-6":                  0.075,
-    "claude-opus-4-7":                  0.075,
+    "claude-opus-4-6":                  0.025,
+    "claude-opus-4-7":                  0.025,
+    "claude-opus-4-8":                  0.025,
     "claude-sonnet-4-5":                0.015,
     "claude-sonnet-4-6":                0.015,
     "deepseek/deepseek-v4-flash":       0.00028,

--- a/install/install.sh
+++ b/install/install.sh
@@ -537,6 +537,7 @@ write_opencode_config() {
       name: "Weave Router",
       options: { apiKey: $key, baseURL: $url, headers: $headers },
       models: {
+        "claude-opus-4-8":   { name: "Claude Opus 4.8 (via Weave Router)" },
         "claude-opus-4-7":   { name: "Claude Opus 4.7 (via Weave Router)" },
         "claude-sonnet-4-6": { name: "Claude Sonnet 4.6 (via Weave Router)" },
         "claude-haiku-4-5":  { name: "Claude Haiku 4.5 (via Weave Router)" }
@@ -1279,8 +1280,9 @@ normalize_model() {
 prices='{
   "input": {
     "claude-haiku-4-5":                 0.0008,
-    "claude-opus-4-6":                  0.015,
-    "claude-opus-4-7":                  0.015,
+    "claude-opus-4-6":                  0.005,
+    "claude-opus-4-7":                  0.005,
+    "claude-opus-4-8":                  0.005,
     "claude-sonnet-4-5":                0.003,
     "claude-sonnet-4-6":                0.003,
     "deepseek/deepseek-v4-flash":       0.00014,
@@ -1329,8 +1331,9 @@ prices='{
   },
   "output": {
     "claude-haiku-4-5":                 0.004,
-    "claude-opus-4-6":                  0.075,
-    "claude-opus-4-7":                  0.075,
+    "claude-opus-4-6":                  0.025,
+    "claude-opus-4-7":                  0.025,
+    "claude-opus-4-8":                  0.025,
     "claude-sonnet-4-5":                0.015,
     "claude-sonnet-4-6":                0.015,
     "deepseek/deepseek-v4-flash":       0.00028,

--- a/internal/observability/otel/pricing_test.go
+++ b/internal/observability/otel/pricing_test.go
@@ -16,7 +16,9 @@ func TestLookup(t *testing.T) {
 		wantOutput float64
 	}{
 		// ── Anthropic ──────────────────────────────────────────
-		{name: "claude-opus-4-7", model: "claude-opus-4-7", wantInput: 15.00, wantOutput: 75.00},
+		{name: "claude-opus-4-8", model: "claude-opus-4-8", wantInput: 5.00, wantOutput: 25.00},
+		{name: "claude-opus-4-7", model: "claude-opus-4-7", wantInput: 5.00, wantOutput: 25.00},
+		{name: "claude-opus-4-6", model: "claude-opus-4-6", wantInput: 5.00, wantOutput: 25.00},
 		{name: "claude-sonnet-4-5", model: "claude-sonnet-4-5", wantInput: 3.00, wantOutput: 15.00},
 		{name: "claude-haiku-4-5", model: "claude-haiku-4-5", wantInput: 0.80, wantOutput: 4.00},
 
@@ -61,7 +63,8 @@ func TestLookup(t *testing.T) {
 		// ── Dated variants (8-digit suffix normalization) ──────
 		{name: "claude-haiku-4-5-20251001", model: "claude-haiku-4-5-20251001", wantInput: 0.80, wantOutput: 4.00},
 		{name: "claude-sonnet-4-5-20260315", model: "claude-sonnet-4-5-20260315", wantInput: 3.00, wantOutput: 15.00},
-		{name: "claude-opus-4-7-20260101", model: "claude-opus-4-7-20260101", wantInput: 15.00, wantOutput: 75.00},
+		{name: "claude-opus-4-7-20260101", model: "claude-opus-4-7-20260101", wantInput: 5.00, wantOutput: 25.00},
+		{name: "claude-opus-4-8-20260528", model: "claude-opus-4-8-20260528", wantInput: 5.00, wantOutput: 25.00},
 		{name: "gpt-5-12345678", model: "gpt-5-12345678", wantInput: 2.50, wantOutput: 10.00},
 		{name: "gpt-4o-20250101", model: "gpt-4o-20250101", wantInput: 2.50, wantOutput: 10.00},
 		{name: "gpt-4o-mini-20260601", model: "gpt-4o-mini-20260601", wantInput: 0.15, wantOutput: 0.60},

--- a/internal/router/catalog/catalog.go
+++ b/internal/router/catalog/catalog.go
@@ -145,11 +145,18 @@ var Models = []Model{
 	{ID: "claude-sonnet-4-6", Tier: TierMid, Providers: []ProviderBinding{
 		{Provider: providers.ProviderAnthropic, Price: Pricing{InputUSDPer1M: 3.00, OutputUSDPer1M: 15.00, CacheReadMultiplier: 0.10}},
 	}},
+	// Opus 4.5+ shipped at $5/$25 per MTok (down from $15/$75 on Opus 4.1
+	// and earlier). The 4.6 / 4.7 entries were stale at the legacy price
+	// until 4.8 landed and forced a triple-check against
+	// platform.claude.com/docs/en/about-claude/pricing.
 	{ID: "claude-opus-4-6", Tier: TierHigh, Providers: []ProviderBinding{
-		{Provider: providers.ProviderAnthropic, Price: Pricing{InputUSDPer1M: 15.00, OutputUSDPer1M: 75.00, CacheReadMultiplier: 0.10}},
+		{Provider: providers.ProviderAnthropic, Price: Pricing{InputUSDPer1M: 5.00, OutputUSDPer1M: 25.00, CacheReadMultiplier: 0.10}},
 	}},
 	{ID: "claude-opus-4-7", Tier: TierHigh, Providers: []ProviderBinding{
-		{Provider: providers.ProviderAnthropic, Price: Pricing{InputUSDPer1M: 15.00, OutputUSDPer1M: 75.00, CacheReadMultiplier: 0.10}},
+		{Provider: providers.ProviderAnthropic, Price: Pricing{InputUSDPer1M: 5.00, OutputUSDPer1M: 25.00, CacheReadMultiplier: 0.10}},
+	}},
+	{ID: "claude-opus-4-8", Tier: TierHigh, Providers: []ProviderBinding{
+		{Provider: providers.ProviderAnthropic, Price: Pricing{InputUSDPer1M: 5.00, OutputUSDPer1M: 25.00, CacheReadMultiplier: 0.10}},
 	}},
 
 	// --- OpenAI GPT-4.x (legacy) ---

--- a/internal/router/catalog/catalog_test.go
+++ b/internal/router/catalog/catalog_test.go
@@ -72,7 +72,7 @@ func TestPriceFor_UnknownProviderForKnownModel(t *testing.T) {
 func TestPriceFor_KnownPair(t *testing.T) {
 	p, ok := PriceFor(providers.ProviderAnthropic, "claude-opus-4-7")
 	require.True(t, ok)
-	assert.Equal(t, 15.00, p.InputUSDPer1M)
+	assert.Equal(t, 5.00, p.InputUSDPer1M)
 	assert.Equal(t, 0.10, p.CacheReadMultiplier)
 }
 

--- a/internal/router/model.go
+++ b/internal/router/model.go
@@ -65,6 +65,7 @@ var googleBase = NewSpec()
 var openAICompatBase = NewSpec()
 
 var registry = map[string]ModelSpec{
+	"claude-opus-4-8":   anthropicFull,
 	"claude-opus-4-7":   anthropicFull,
 	"claude-sonnet-4-6": anthropicFull,
 	"claude-opus-4-6":   anthropicFull,

--- a/internal/router/planner/policy_test.go
+++ b/internal/router/planner/policy_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	modelOpus    = "claude-opus-4-7"   // $15.00 input / $75.00 output per 1M, cache mult 0.10
+	modelOpus    = "claude-opus-4-7"   // $5.00 input / $25.00 output per 1M, cache mult 0.10
 	modelSonnet  = "claude-sonnet-4-5" // $3.00 input / $15.00 output, cache mult 0.10
 	modelHaiku   = "claude-haiku-4-5"  // $0.80 input / $4.00 output, cache mult 0.10
 	modelGPT5    = "gpt-5"             // $2.50 input / $10.00 output, cache mult 0.50 (cross-provider)
@@ -138,10 +138,10 @@ func TestDecide(t *testing.T) {
 			// EV math for switch from opus -> haiku, 50k input, 3 turns.
 			// Savings are multiplied by CacheReadMultiplier (0.1) because in
 			// steady state most input tokens come from cache on both models:
-			//   savingsPerTurn = (15.00 - 0.80) * 0.1 * 50000 / 1e6 = $0.071
-			//   evictionCost   = 0.80 * 50000 * 0.9 / 1e6           = $0.036
-			//   expectedSavings = 0.071 * 3 = $0.213
-			//   delta = 0.213 - 0.036 = $0.177 >> $0.001 -> Switch.
+			//   savingsPerTurn = (5.00 - 0.80) * 0.1 * 50000 / 1e6 = $0.021
+			//   evictionCost   = 0.80 * 50000 * 0.9 / 1e6          = $0.036
+			//   expectedSavings = 0.021 * 3 = $0.063
+			//   delta = 0.063 - 0.036 = $0.027 > $0.001 -> Switch.
 			name: "ev_positive: opus -> haiku on a large prompt",
 			in: planner.Inputs{
 				Pin:                  pinWithUsage(modelOpus),
@@ -152,15 +152,15 @@ func TestDecide(t *testing.T) {
 			cfg:                    defaultCfg,
 			want:                   planner.Decision{Outcome: planner.OutcomeSwitch, Reason: planner.ReasonEVPositive},
 			expectEVMath:           true,
-			wantExpectedSavingsUSD: 0.213,
+			wantExpectedSavingsUSD: 0.063,
 			wantEvictionCostUSD:    0.036,
 		},
 		{
 			// Symmetric flip: pinning haiku, fresh recommends opus.
-			//   savingsPerTurn = (0.80 - 15.00) * 0.1 * 50000 / 1e6 = -$0.071
-			//   evictionCost   = 15.00 * 50000 * 0.9 / 1e6          = $0.675
-			//   expectedSavings = -0.071 * 3 = -$0.213
-			//   delta = -0.213 - 0.675 = -$0.888 < $0.001 -> Stay.
+			//   savingsPerTurn = (0.80 - 5.00) * 0.1 * 50000 / 1e6 = -$0.021
+			//   evictionCost   = 5.00 * 50000 * 0.9 / 1e6          = $0.225
+			//   expectedSavings = -0.021 * 3 = -$0.063
+			//   delta = -0.063 - 0.225 = -$0.288 < $0.001 -> Stay.
 			name: "ev_negative: haiku -> opus is a huge net loss",
 			in: planner.Inputs{
 				Pin:                  pinWithUsage(modelHaiku),
@@ -171,69 +171,71 @@ func TestDecide(t *testing.T) {
 			cfg:                    defaultCfg,
 			want:                   planner.Decision{Outcome: planner.OutcomeStay, Reason: planner.ReasonEVNegative},
 			expectEVMath:           true,
-			wantExpectedSavingsUSD: -0.213,
-			wantEvictionCostUSD:    0.675,
+			wantExpectedSavingsUSD: -0.063,
+			wantEvictionCostUSD:    0.225,
 		},
 		{
-			// Opus -> sonnet, tuned to land just BELOW threshold under the
-			// corrected (cache-read-aware) EV math.
-			//   per-token net = (3 * 0.1 * (15.00 - 3.00) - 0.9 * 3.00) / 1e6
-			//                 = (3.60 - 2.70) / 1e6 = 0.90 / 1e6
-			//   at tokens = 1111: net = 0.90 * 1111 / 1e6 = $0.0009999
-			//   threshold = $0.001 -> net is 0.01% below.
-			//   expectedSavings = (15.00 - 3.00) * 0.1 * 1111 / 1e6 * 3 = $0.0039996
-			//   evictionCost    = 3.00 * 1111 * 0.9 / 1e6              = $0.0029997
-			//   delta = 0.0039996 - 0.0029997 = $0.0009999 -> Stay.
-			// (sonnet -> haiku no longer straddles threshold: under the
-			// corrected math its per-token net is negative at every horizon.)
+			// Opus -> haiku, tuned to land just BELOW threshold under the
+			// corrected (cache-read-aware) EV math at the new $5/$25 opus
+			// pricing (was $15/$75; the old opus->sonnet boundary case no
+			// longer straddles — sonnet's $3 input dominates opus's $0.50
+			// cache-read at every horizon).
+			//   per-token net = (3 * 0.1 * (5.00 - 0.80) - 0.9 * 0.80) / 1e6
+			//                 = (1.26 - 0.72) / 1e6 = 0.54 / 1e6
+			//   at tokens = 1851: net = 0.54 * 1851 / 1e6 = $0.00099954
+			//   threshold = $0.001 -> net is 0.05% below.
+			//   expectedSavings = (5.00 - 0.80) * 0.1 * 1851 / 1e6 * 3 = $0.00233226
+			//   evictionCost    = 0.80 * 1851 * 0.9 / 1e6              = $0.00133272
+			//   delta = 0.00233226 - 0.00133272 = $0.00099954 -> Stay.
 			name: "ev_near_threshold: just below threshold stays stable",
 			in: planner.Inputs{
 				Pin:                  pinWithUsage(modelOpus),
-				Fresh:                router.Decision{Model: modelSonnet},
-				EstimatedInputTokens: 1111,
+				Fresh:                router.Decision{Model: modelHaiku},
+				EstimatedInputTokens: 1851,
 				AvailableModels:      availableAll,
 			},
 			cfg:                    defaultCfg,
 			want:                   planner.Decision{Outcome: planner.OutcomeStay, Reason: planner.ReasonEVNegative},
 			expectEVMath:           true,
-			wantExpectedSavingsUSD: 0.0039996,
-			wantEvictionCostUSD:    0.0029997,
+			wantExpectedSavingsUSD: 0.00233226,
+			wantEvictionCostUSD:    0.00133272,
 		},
 		{
-			// Same opus -> sonnet math, one extra token nudges across:
-			//   at tokens = 1112: net = 0.90 * 1112 / 1e6 = $0.0010008
-			//   threshold = $0.001 -> net is 0.08% above.
-			//   expectedSavings = (15.00 - 3.00) * 0.1 * 1112 / 1e6 * 3 = $0.0040032
-			//   evictionCost    = 3.00 * 1112 * 0.9 / 1e6              = $0.0030024
-			//   delta = 0.0040032 - 0.0030024 = $0.0010008 -> Switch.
+			// Same opus -> haiku math, two extra tokens nudge across:
+			//   at tokens = 1853: net = 0.54 * 1853 / 1e6 = $0.00100062
+			//   threshold = $0.001 -> net is 0.06% above.
+			//   expectedSavings = (5.00 - 0.80) * 0.1 * 1853 / 1e6 * 3 = $0.00233478
+			//   evictionCost    = 0.80 * 1853 * 0.9 / 1e6              = $0.00133416
+			//   delta = 0.00233478 - 0.00133416 = $0.00100062 -> Switch.
 			name: "ev_near_threshold: just above threshold flips to switch",
 			in: planner.Inputs{
 				Pin:                  pinWithUsage(modelOpus),
-				Fresh:                router.Decision{Model: modelSonnet},
-				EstimatedInputTokens: 1112,
+				Fresh:                router.Decision{Model: modelHaiku},
+				EstimatedInputTokens: 1853,
 				AvailableModels:      availableAll,
 			},
 			cfg:                    defaultCfg,
 			want:                   planner.Decision{Outcome: planner.OutcomeSwitch, Reason: planner.ReasonEVPositive},
 			expectEVMath:           true,
-			wantExpectedSavingsUSD: 0.0040032,
-			wantEvictionCostUSD:    0.0030024,
+			wantExpectedSavingsUSD: 0.00233478,
+			wantEvictionCostUSD:    0.00133416,
 		},
 		{
 			// Cross-provider regression: opus (Anthropic, mult 0.10) ->
-			// gpt-5 (OpenAI, mult 0.50) on a 50k prompt.
-			//   savingsPerTurn  = (15.00 * 0.10 - 2.50 * 0.50) * 50000 / 1e6
-			//                   = (1.50 - 1.25) * 0.05 = $0.0125
-			//   expectedSavings = 0.0125 * 3 = $0.0375
+			// gpt-5 (OpenAI, mult 0.50) on a 50k prompt at the new $5/$25
+			// opus pricing.
+			//   savingsPerTurn  = (5.00 * 0.10 - 2.50 * 0.50) * 50000 / 1e6
+			//                   = (0.50 - 1.25) * 0.05 = -$0.0375
+			//   expectedSavings = -0.0375 * 3 = -$0.1125
 			//   evictionCost    = 2.50 * 50000 * (1 - 0.50) / 1e6 = $0.0625
-			//   delta = 0.0375 - 0.0625 = -$0.025 -> Stay.
+			//   delta = -0.1125 - 0.0625 = -$0.175 -> Stay.
 			//
-			// Sanity vs the old (broken) global-0.10 math: that path would
-			// have computed savingsPerTurn = (15 - 2.5) * 0.10 * 0.05 =
-			// $0.0625 and evictionCost = 2.50 * 0.05 * 0.90 = $0.1125, delta
-			// $0.075 — i.e. would have wrongly chosen to switch. Per-model
-			// multipliers correctly say "stay on opus" because gpt-5's
-			// 50% cache-read pricing eats most of the per-turn savings.
+			// Under the (now-corrected) catalog pricing, opus's per-token
+			// cost matches gpt-5's nominal input price, but gpt-5's 50%
+			// cache-read multiplier (vs opus's 10%) actually makes gpt-5
+			// *more* expensive in cache steady-state — so the planner
+			// stays on opus regardless of any prompt size. The old global-
+			// 0.10 path would have wrongly switched here.
 			name: "ev_cross_provider: opus -> gpt-5 stays under per-model math",
 			in: planner.Inputs{
 				Pin:                  pinWithUsage(modelOpus),
@@ -244,7 +246,7 @@ func TestDecide(t *testing.T) {
 			cfg:                    defaultCfg,
 			want:                   planner.Decision{Outcome: planner.OutcomeStay, Reason: planner.ReasonEVNegative},
 			expectEVMath:           true,
-			wantExpectedSavingsUSD: 0.0375,
+			wantExpectedSavingsUSD: -0.1125,
 			wantEvictionCostUSD:    0.0625,
 		},
 		{
@@ -260,8 +262,8 @@ func TestDecide(t *testing.T) {
 			cfg:                    defaultCfg, // TierUpgradeEnabled = false
 			want:                   planner.Decision{Outcome: planner.OutcomeStay, Reason: planner.ReasonEVNegative},
 			expectEVMath:           true,
-			wantExpectedSavingsUSD: -0.213,
-			wantEvictionCostUSD:    0.675,
+			wantExpectedSavingsUSD: -0.063,
+			wantEvictionCostUSD:    0.225,
 		},
 		{
 			// Same EV-loss as above; guard on flips it because opus is
@@ -276,8 +278,8 @@ func TestDecide(t *testing.T) {
 			cfg:                    tierUpgradeCfg,
 			want:                   planner.Decision{Outcome: planner.OutcomeSwitch, Reason: planner.ReasonTierUpgrade},
 			expectEVMath:           true,
-			wantExpectedSavingsUSD: -0.213,
-			wantEvictionCostUSD:    0.675,
+			wantExpectedSavingsUSD: -0.063,
+			wantEvictionCostUSD:    0.225,
 		},
 		{
 			// Sonnet (Mid) -> haiku (Low) is a downgrade; guard must


### PR DESCRIPTION
## What

- Adds `claude-opus-4-8` to the catalog and model registry (TierHigh, $5/$25 per MTok, cache-read 0.10x).
- Corrects `claude-opus-4-6` and `claude-opus-4-7` pricing from a stale $15/$75 down to the actual $5/$25 — Opus 4.5+ shipped at $5/$25 but the catalog never caught up.
- Regenerates `install/install.sh` and `install/cc-statusline.sh` via `go run ./cmd/genprices`.
- Adds claude-opus-4-8 to the OpenCode config block in `install.sh` (hand-maintained, not gen-driven).
- Re-tunes the planner EV-math tests for the corrected opus pricing.

## Why

Spotted while adding `claude-opus-4-8` (just released) — the planned $15/$75 entry triggered a sanity-check against [platform.claude.com/docs/en/about-claude/pricing](https://platform.claude.com/docs/en/about-claude/pricing), which lists all of Opus 4.5 → 4.8 at $5/$25. Means OTel cost telemetry, billing debits, planner EV math, and statusline display have all been over-counting opus-4.6/4.7 spend by 3x since 4.6 landed.

## EV-math test retune

Old opus → sonnet boundary at 1111/1112 tokens no longer straddles the $0.001 threshold:
- per-token net = `(3 * 0.1 * (5 - 3) - 0.9 * 3) / 1e6 = -2.1 / 1e6` — negative at every horizon (sonnet's $3 uncached input dominates opus's $0.50 cache-read price).

Swapped to opus → haiku, where the boundary shifts to ~1852 tokens at horizon=3:
- per-token net = `(3 * 0.1 * (5 - 0.8) - 0.9 * 0.8) / 1e6 = 0.54 / 1e6`
- 1851 → $0.00099954 (just below threshold → Stay)
- 1853 → $0.00100062 (just above threshold → Switch)

Full math is documented in the test comments.

## Not done here

- **Cluster-scorer artifact** (`internal/router/cluster/artifacts/v0.X/model_registry.json`) is unchanged. Opus 4.8 has no quality priors yet, so promoting it to a routing target on a stale α-blend would route blindly. Picked up by the next retrain.

## Test plan

- `go test ./...` — all green locally (catalog, planner, otel/pricing, full suite).
- `go run ./cmd/genprices` — regenerates the install scripts deterministically; diff shows only the three opus rows and the new opus-4.8 entries changing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)