### PR TITLE
fix(proxy): fold message count into no-progress fingerprint

### DIFF
--- a/internal/proxy/no_progress.go
+++ b/internal/proxy/no_progress.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"fmt"
 	"net/http"
+	"strconv"
 	"sync"
 	"time"
 
@@ -42,15 +43,33 @@ const (
 )
 
 // noProgressFingerprint identifies one dispatch attempt by routed model,
-// provider, and a stable hash of the prompt prefix.
+// provider, message count, and a stable hash of the prompt prefix.
 type noProgressFingerprint [32]byte
 
-func computeNoProgressFingerprint(decision router.Decision, promptText string) noProgressFingerprint {
+// computeNoProgressFingerprint hashes the routed (model, provider), the
+// conversation's message count, and the prompt prefix into a single
+// fingerprint.
+//
+// messageCount is load-bearing for false-positive avoidance. The prompt
+// prefix alone is constant across a single agentic task: in the default
+// embed-only-user-message mode promptText is the user's typed task (tool
+// results are stripped), so every iteration of a healthy tool-call loop
+// shares the same prefix and the bare (model, provider, prefix) fingerprint
+// would collide on every dispatch — tripping the detector on any session that
+// fires >= noProgressMatchThreshold turns to one model within the window.
+//
+// A genuinely stuck sub-agent spawn loop replays independent envelope-1
+// requests, so its message count stays flat and the fingerprints still
+// collide. A progressing agent appends an assistant turn plus a tool_result
+// turn each iteration, so its message count climbs monotonically and each
+// dispatch yields a distinct fingerprint that never accumulates to the
+// threshold. Folding messageCount in is what separates the two.
+func computeNoProgressFingerprint(decision router.Decision, promptText string, messageCount int) noProgressFingerprint {
 	p := promptText
 	if len(p) > noProgressPromptPrefix {
 		p = p[:noProgressPromptPrefix]
 	}
-	return sha256.Sum256([]byte(decision.Model + "\x00" + decision.Provider + "\x00" + p))
+	return sha256.Sum256([]byte(decision.Model + "\x00" + decision.Provider + "\x00" + strconv.Itoa(messageCount) + "\x00" + p))
 }
 
 type fingerprintEntry struct {

--- a/internal/proxy/no_progress_internal_test.go
+++ b/internal/proxy/no_progress_internal_test.go
@@ -20,16 +20,16 @@ func sessionKeyFromString(s string) [sessionpin.SessionKeyLen]byte {
 
 func TestComputeNoProgressFingerprint_StableAcrossCalls(t *testing.T) {
 	d := router.Decision{Model: "qwen/qwen3-235b-a22b-2507", Provider: "bedrock"}
-	a := computeNoProgressFingerprint(d, "explore RSVP files in this repository")
-	b := computeNoProgressFingerprint(d, "explore RSVP files in this repository")
+	a := computeNoProgressFingerprint(d, "explore RSVP files in this repository", 1)
+	b := computeNoProgressFingerprint(d, "explore RSVP files in this repository", 1)
 	assert.Equal(t, a, b)
 }
 
 func TestComputeNoProgressFingerprint_DistinguishesModel(t *testing.T) {
 	d1 := router.Decision{Model: "qwen/qwen3-235b-a22b-2507", Provider: "bedrock"}
 	d2 := router.Decision{Model: "deepseek/deepseek-v4-flash", Provider: "deepinfra"}
-	a := computeNoProgressFingerprint(d1, "explore")
-	b := computeNoProgressFingerprint(d2, "explore")
+	a := computeNoProgressFingerprint(d1, "explore", 1)
+	b := computeNoProgressFingerprint(d2, "explore", 1)
 	assert.NotEqual(t, a, b)
 }
 
@@ -40,9 +40,57 @@ func TestComputeNoProgressFingerprint_PromptPrefixOnly(t *testing.T) {
 	for i := range prefix {
 		prefix[i] = 'a'
 	}
-	a := computeNoProgressFingerprint(d, string(prefix)+"suffix1")
-	b := computeNoProgressFingerprint(d, string(prefix)+"suffix2")
+	a := computeNoProgressFingerprint(d, string(prefix)+"suffix1", 1)
+	b := computeNoProgressFingerprint(d, string(prefix)+"suffix2", 1)
 	assert.Equal(t, a, b, "only the first %d bytes of prompt text matter for the fingerprint", noProgressPromptPrefix)
+}
+
+func TestComputeNoProgressFingerprint_DistinguishesMessageCount(t *testing.T) {
+	d := router.Decision{Model: "gemini-3.1-pro-preview", Provider: "google"}
+	// Same model/provider/prompt-prefix, different message count: a healthy
+	// agentic loop grows its transcript each turn, so the fingerprints must
+	// diverge even though the user's typed task (the prompt prefix) is constant.
+	a := computeNoProgressFingerprint(d, "explore RSVP files", 10)
+	b := computeNoProgressFingerprint(d, "explore RSVP files", 12)
+	assert.NotEqual(t, a, b, "a growing message count must change the fingerprint")
+}
+
+func TestNoProgressTracker_DoesNotTripWhenMessageCountGrows(t *testing.T) {
+	// Regression: a fast Claude Code tool-call loop fires well over the
+	// threshold of dispatches to one model within the window, all sharing the
+	// same routed (model, provider) and the same user-task prompt prefix
+	// (tool_result turns are stripped from promptText in embed-only mode). It
+	// must NOT trip, because the transcript grows by an assistant + tool_result
+	// turn each iteration.
+	tr := newNoProgressTracker()
+	key := sessionKeyFromString("session-healthy-loop")
+	install := uuid.New()
+	d := router.Decision{Model: "gemini-3.1-pro-preview", Provider: "google"}
+	now := time.Now()
+
+	for i := 0; i < noProgressMatchThreshold*2; i++ {
+		fp := computeNoProgressFingerprint(d, "implement the feature", 4+2*i)
+		looped, _ := tr.recordAndDetect(key, install, "high", fp, now)
+		assert.False(t, looped, "a progressing loop (growing message count) must not trip (call %d)", i)
+	}
+}
+
+func TestNoProgressTracker_TripsWhenMessageCountFlat(t *testing.T) {
+	// A genuine sub-agent spawn loop replays independent envelope-1 requests:
+	// the transcript never grows, so message count stays flat and the detector
+	// must still fire.
+	tr := newNoProgressTracker()
+	key := sessionKeyFromString("session-spawn-loop")
+	install := uuid.New()
+	d := router.Decision{Model: "gemini-3.1-pro-preview", Provider: "google"}
+	now := time.Now()
+	fp := computeNoProgressFingerprint(d, "spawn sub-agent", 2)
+
+	var looped bool
+	for i := 0; i < noProgressMatchThreshold; i++ {
+		looped, _ = tr.recordAndDetect(key, install, "high", fp, now)
+	}
+	assert.True(t, looped, "a flat-transcript spawn loop must still trip the detector")
 }
 
 func TestNoProgressTracker_TripsAfterThresholdHits(t *testing.T) {
@@ -50,7 +98,7 @@ func TestNoProgressTracker_TripsAfterThresholdHits(t *testing.T) {
 	key := sessionKeyFromString("session-abc")
 	install := uuid.New()
 	d := router.Decision{Model: "qwen/qwen3-235b-a22b-2507", Provider: "bedrock"}
-	fp := computeNoProgressFingerprint(d, "prompt")
+	fp := computeNoProgressFingerprint(d, "prompt", 1)
 	now := time.Now()
 
 	for i := 1; i < noProgressMatchThreshold; i++ {
@@ -72,7 +120,7 @@ func TestNoProgressTracker_DoesNotTripWhenFingerprintsDiffer(t *testing.T) {
 
 	for i := 0; i < noProgressMatchThreshold*2; i++ {
 		d := router.Decision{Model: "qwen/qwen3-235b-a22b-2507", Provider: "bedrock"}
-		fp := computeNoProgressFingerprint(d, "prompt-distinct-"+time.Duration(i).String())
+		fp := computeNoProgressFingerprint(d, "prompt-distinct-"+time.Duration(i).String(), 1)
 		looped, _ := tr.recordAndDetect(key, install, "high", fp, now)
 		assert.False(t, looped, "distinct fingerprints must not trip the detector (call %d)", i)
 	}
@@ -83,7 +131,7 @@ func TestNoProgressTracker_AgesOutOldEntries(t *testing.T) {
 	key := sessionKeyFromString("session-aging")
 	install := uuid.New()
 	d := router.Decision{Model: "qwen/qwen3-235b-a22b-2507", Provider: "bedrock"}
-	fp := computeNoProgressFingerprint(d, "prompt")
+	fp := computeNoProgressFingerprint(d, "prompt", 1)
 
 	old := time.Now().Add(-2 * noProgressTimeWindow)
 	for i := 0; i < noProgressMatchThreshold-1; i++ {
@@ -105,7 +153,7 @@ func TestNoProgressTracker_ZeroSessionKeyWithInstallationFallsBack(t *testing.T)
 	var zero [sessionpin.SessionKeyLen]byte
 	install := uuid.New()
 	d := router.Decision{Model: "qwen/qwen3-235b-a22b-2507", Provider: "bedrock"}
-	fp := computeNoProgressFingerprint(d, "prompt")
+	fp := computeNoProgressFingerprint(d, "prompt", 1)
 	now := time.Now()
 
 	for i := 1; i < noProgressMatchThreshold; i++ {
@@ -124,7 +172,7 @@ func TestNoProgressTracker_ZeroSessionKeyAndZeroInstallationIsSkipped(t *testing
 	tr := newNoProgressTracker()
 	var zero [sessionpin.SessionKeyLen]byte
 	d := router.Decision{Model: "qwen/qwen3-235b-a22b-2507", Provider: "bedrock"}
-	fp := computeNoProgressFingerprint(d, "prompt")
+	fp := computeNoProgressFingerprint(d, "prompt", 1)
 	now := time.Now()
 
 	for i := 0; i < noProgressMatchThreshold*2; i++ {
@@ -142,7 +190,7 @@ func TestNoProgressTracker_ZeroSessionDifferentInstallationsAreIsolated(t *testi
 	installA := uuid.New()
 	installB := uuid.New()
 	d := router.Decision{Model: "qwen/qwen3-235b-a22b-2507", Provider: "bedrock"}
-	fp := computeNoProgressFingerprint(d, "prompt")
+	fp := computeNoProgressFingerprint(d, "prompt", 1)
 	now := time.Now()
 
 	for i := 0; i < noProgressMatchThreshold-1; i++ {
@@ -158,7 +206,7 @@ func TestNoProgressTracker_NilReceiverIsNoOp(t *testing.T) {
 	var tr *noProgressTracker
 	key := sessionKeyFromString("session-nil")
 	d := router.Decision{Model: "x", Provider: "y"}
-	fp := computeNoProgressFingerprint(d, "p")
+	fp := computeNoProgressFingerprint(d, "p", 1)
 	looped, count := tr.recordAndDetect(key, uuid.New(), "high", fp, time.Now())
 	assert.False(t, looped)
 	assert.Equal(t, 0, count)
@@ -167,7 +215,7 @@ func TestNoProgressTracker_NilReceiverIsNoOp(t *testing.T) {
 func TestNoProgressTracker_SeparateSessionsDoNotInterfere(t *testing.T) {
 	tr := newNoProgressTracker()
 	d := router.Decision{Model: "qwen/qwen3-235b-a22b-2507", Provider: "bedrock"}
-	fp := computeNoProgressFingerprint(d, "prompt")
+	fp := computeNoProgressFingerprint(d, "prompt", 1)
 	now := time.Now()
 	install := uuid.New()
 
@@ -193,7 +241,7 @@ func TestNoProgressTracker_DifferentRolesAreSeparateRings(t *testing.T) {
 	key := sessionKeyFromString("session-roles")
 	install := uuid.New()
 	d := router.Decision{Model: "x", Provider: "y"}
-	fp := computeNoProgressFingerprint(d, "p")
+	fp := computeNoProgressFingerprint(d, "p", 1)
 	now := time.Now()
 
 	// Same session key, different role → different LRU entry. Filling the

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -793,12 +793,14 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 	s.logPlannerOutcome(ctx, routeRes)
 
 	// Cross-envelope no-progress detector: if this session has dispatched the
-	// same (decision_model, decision_provider, prompt-prefix) burst >=
-	// noProgressMatchThreshold times within noProgressTimeWindow, the parent
-	// agent is in a sub-agent spawn loop and another dispatch will only
+	// same (decision_model, decision_provider, message_count, prompt-prefix)
+	// burst >= noProgressMatchThreshold times within noProgressTimeWindow, the
+	// parent agent is in a sub-agent spawn loop and another dispatch will only
 	// reproduce the same useless response. Break the pin and emit a synthetic
-	// stop instead.
-	if fp := computeNoProgressFingerprint(decision, promptText); s.noProgress != nil {
+	// stop instead. message_count is folded in so a progressing agent (whose
+	// transcript grows each turn) yields a distinct fingerprint per dispatch
+	// and is never mistaken for a flat-transcript spawn loop.
+	if fp := computeNoProgressFingerprint(decision, promptText, feats.MessageCount); s.noProgress != nil {
 		role := roleForTier(catalog.TierFor(feats.Model))
 		if looped, count := s.noProgress.recordAndDetect(routeRes.SessionKey, installationID, role, fp, time.Now()); looped {
 			return s.handleNoProgressBreak(ctx, w, env, count, installationID, routeRes.SessionKey, role, decision.Model, decision.Provider)


### PR DESCRIPTION
## Problem

`org_H30nkAr1AhTOwfOUIGorfQzp` reported their Claude Code sessions being killed mid-task with a synthetic:

> ✦ **Weave Router** → no-progress loop detected: 5 consecutive requests under this session routed to `gemini-3.1-pro-preview` (`google`) with no observable progress in 1m30s…

The sessions were **not** stuck. Prod telemetry for one broken session shows a healthy, fast tool-call loop: input tokens climbing 25k → 35k (tool results accumulating), each turn emitting a ~20-30-token tool call, prefix cache hitting ~24k — ~6 Read/Grep/Bash turns in ~20 seconds. Dozens of these false breaks across distinct sessions for this org, against `gemini-3.1-pro-preview`, `gemini-3.5-flash`, and `claude-haiku-4-5`.

## Root cause

`computeNoProgressFingerprint` keyed on `(decision_model, decision_provider, first 512 chars of promptText)`.

In prod `ROUTER_EMBED_ONLY_USER_MESSAGE` defaults to `true`, so `promptText = OnlyUserMessageText`, which `userPromptTextGJSON` builds with `tool_result` blocks (and Claude-Code-injected blocks) **stripped**. That leaves essentially the user's original typed task — **constant for the entire agentic turn sequence**.

So the fingerprint collapsed to `(model, provider, head-of-task)`, identical on every iteration. The only thing that actually changes between dispatches — accumulating `tool_result` content, i.e. the real progress signal — was precisely what got stripped before fingerprinting. The detector could not tell a genuinely-stuck spawn loop from a healthy fast loop; any session firing ≥ `noProgressMatchThreshold` turns to one model within the 90s window tripped.

## Fix

Fold the conversation's **message count** (`feats.MessageCount`) into the fingerprint:

- **Progressing agent** → appends an assistant + tool_result turn each iteration → message count climbs → distinct fingerprint per dispatch → never accumulates to threshold → no false break.
- **Genuine sub-agent spawn loop** → replays independent envelope-1 requests with a flat message count → fingerprints still collide → detector still fires.

The within-envelope tool-call loop detector (`detectToolCallLoop`) is unchanged and still covers same-conversation repeated-tool-call pathologies.

## Tests

- `TestComputeNoProgressFingerprint_DistinguishesMessageCount` — same model/provider/prefix, different message count → different fingerprint.
- `TestNoProgressTracker_DoesNotTripWhenMessageCountGrows` — regression: a loop well over threshold with growing message count does not trip.
- `TestNoProgressTracker_TripsWhenMessageCountFlat` — flat-transcript spawn loop still trips.
- Existing tests updated to the 3-arg signature; full `internal/proxy` suite + `go vet` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)