### PR TITLE
fix(install): make uninstall hint copy-paste-safe and quiet-aware

### DIFF
--- a/install/install.sh
+++ b/install/install.sh
@@ -103,19 +103,20 @@ skip() { printf "%s⊙%s %s%s%s\n" "$C_DIM" "$C_RESET" "$C_DIM" "$*" "$C_RESET";
 # print after a successful install is copy-paste-correct. Kept in sync with
 # uninstall.sh's flag surface.
 uninstall_cmd() {
-  local cmd="npx @workweave/router --uninstall"
+  local cmd="npx -y @workweave/router --uninstall"
   case "$target" in
     codex)    cmd="$cmd --codex" ;;
     opencode) cmd="$cmd --opencode" ;;
   esac
   [ "$scope" = "project" ] && cmd="$cmd --scope project"
-  [ -n "$install_dir" ] && cmd="$cmd --dir $install_dir"
+  [ -n "$install_dir" ] && cmd="$cmd --dir $(printf '%q' "$install_dir")"
   printf '%s' "$cmd"
 }
 
 # print_uninstall_hint prints the reverse command on its own labeled line so
 # every successful install ends by telling the user exactly how to undo it.
 print_uninstall_hint() {
+  [ "$quiet" = "true" ] && return 0
   printf "%sTo uninstall:%s %s%s%s\n" \
     "$C_BOLD" "$C_RESET" "$C_CYAN" "$(uninstall_cmd)" "$C_RESET"
 }


### PR DESCRIPTION
Fixes three rough edges in the `--uninstall` hint that `install.sh` prints after a successful install (and that the Weave dashboard surfaces via the synced `install_template.sh`):

- **Missing `-y`** — pasting the hint triggered npx's interactive "Need to install the following packages" prompt. Now `npx -y @workweave/router --uninstall`, matching every install command and the dashboard one-liners.
- **Unquoted `--dir`** — install dirs with spaces produced a broken command. Now shell-quoted via `printf '%q'`.
- **Ignored `--quiet`** — quiet installs still emitted a trailing tip. `print_uninstall_hint` now returns early under `--quiet`, like `print_banner`.

Surfaced by review bots on workweave/WorkWeave#7974.

🤖 Generated with [Claude Code](https://claude.com/claude-code)