### PR TITLE
chore(npm): bump @workweave/router to 0.1.7

### DIFF
--- a/install/npm/package.json
+++ b/install/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@workweave/router",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "One-command installer that points Claude Code at the Weave Router.",
   "bin": {
     "weave-router": "bin.js"


### PR DESCRIPTION
Bumps the npm package to **0.1.7** so `npx @workweave/router` ships the off/on/status toggle merged in #258.

The published tarball bundles `install.sh`, `uninstall.sh`, and `commands/` (incl. the new `router-{off,on,status}.md` wrappers) via the `prepack` copy step, so this version carries the toggle to npx users.

**Release:** after this merges, push tag `router-v0.1.7` (must match `package.json` and be reachable from `main`) to trigger the OIDC publish workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)