### PR TITLE
feat(install): add --pi target + @workweave/pi-router extension

### DIFF
--- a/.github/workflows/publish_npm_pi_router.yml
+++ b/.github/workflows/publish_npm_pi_router.yml
@@ -1,0 +1,78 @@
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+#
+# Publish the @workweave/pi-router npm package (the pi extension) on tag push.
+#
+# Trigger: push a tag matching `pi-router-v*` (e.g. `pi-router-v0.1.0`). Kept on
+# its own tag prefix (not the installer's `router-v*`) so the extension and the
+# installer shim version independently. The job asserts the tag's version
+# matches install/pi-router/package.json before publishing — a mismatched tag
+# fails fast instead of shipping a wrong version.
+#
+# No build step: pi loads the TypeScript via jiti at runtime, so the published
+# tarball ships src/ as-is (see package.json "files").
+#
+# Publish auth: npm OIDC trusted publishing (no secret in the repo). Configure
+# the @workweave/pi-router package on npmjs.com → Settings → Trusted Publishers
+# → GitHub Actions with org=workweave, repo=router,
+# workflow=publish_npm_pi_router.yml.
+name: Publish npm (pi-router)
+
+on:
+  push:
+    tags:
+      - "pi-router-v*"
+
+jobs:
+  publish:
+    name: Publish @workweave/pi-router
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write # required for npm OIDC + provenance
+    defaults:
+      run:
+        working-directory: install/pi-router
+    steps:
+      # Third-party actions pinned to commit SHAs because this job has
+      # `id-token: write` and publishes to npm — a retargeted floating tag
+      # would let an upstream-action compromise publish a malicious package.
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          # Full history so the "verify tag is reachable from main" step can
+          # walk the commit graph (default shallow clone can't prove ancestry).
+          fetch-depth: 0
+
+      - name: Set up Node
+        # setup-node v6 is the first release with npm OIDC support; v4/v5
+        # unconditionally write the auth token into .npmrc and 401 at publish.
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          # Node 24 ships npm >= 11.5, the minimum for OIDC trusted publishing.
+          node-version: "24"
+          registry-url: "https://registry.npmjs.org"
+
+      # Reject tags pointing at unreviewed commits: require the tagged commit to
+      # be reachable from origin/main so a side-branch tag can't bypass review.
+      - name: Verify tag is reachable from main
+        working-directory: ${{ github.workspace }}
+        run: |
+          git fetch origin main --no-tags
+          if ! git merge-base --is-ancestor "$GITHUB_SHA" origin/main; then
+            echo "::error::Tag ${GITHUB_REF#refs/tags/} (commit $GITHUB_SHA) is not reachable from origin/main. Only main-reachable tags may publish."
+            exit 1
+          fi
+          echo "Tag commit is on main, OK to publish."
+
+      - name: Verify tag matches package.json version
+        run: |
+          tag="${GITHUB_REF#refs/tags/pi-router-v}"
+          pkg_version="$(node -p "require('./package.json').version")"
+          if [ "$tag" != "$pkg_version" ]; then
+            echo "::error::Tag version ($tag) does not match package.json version ($pkg_version)"
+            exit 1
+          fi
+          echo "Publishing @workweave/pi-router@$pkg_version"
+
+      - name: Publish to npm
+        run: npm publish --provenance --access public

--- a/install/install.sh
+++ b/install/install.sh
@@ -576,6 +576,12 @@ write_opencode_config() {
   # a startup error before the router ever sees a request. The router itself
   # ignores the value (auth runs off X-Weave-Router-Key); apiKey here is just
   # a placeholder that satisfies the SDK's "is auth configured" check.
+  # baseURL KEEPS its /v1 here — do NOT align it with the pi block, which is
+  # root. opencode's @ai-sdk/anthropic (Vercel) appends only /messages to
+  # baseURL (its default is api.anthropic.com/v1), so /v1 yields the correct
+  # /v1/messages. Dropping it would hit /messages and 404. (pi uses the official
+  # @anthropic-ai/sdk, which appends /v1/messages to a root baseURL — opposite
+  # convention.) Verified by install/pi-router/test/opencode_smoke.sh.
   local block
   block="$(jq -n \
     --arg url "$block_url/v1" \
@@ -660,9 +666,14 @@ write_pi_models_config() {
   # Headline models surfaced in pi's /model picker. The router re-routes every
   # request regardless, so this list is UX; keep it Anthropic-shaped and in
   # sync with @workweave/pi-router's WEAVE_MODELS constant.
+  #
+  # baseUrl is the router ROOT (no /v1): pi's anthropic-messages provider uses
+  # @anthropic-ai/sdk, which appends /v1/messages itself. Unlike the codex block
+  # above (OpenAI-style, base ends in /v1), a /v1 suffix here would produce
+  # /v1/v1/messages and 404.
   local block
   block="$(jq -n \
-    --arg url "$block_url/v1" \
+    --arg url "$block_url" \
     --arg key "$block_key" \
     --argjson headers "$headers_json" '
     {

--- a/install/install.sh
+++ b/install/install.sh
@@ -1770,7 +1770,12 @@ if [ "$target" = "pi" ]; then
   # git. Same reasoning as the Codex/opencode paths — base URL is shared, the
   # key is per-person.
   if [ "$scope" = "project" ] && [ -z "$install_dir" ] && [ -n "${git_root:-}" ]; then
-    gitignore="$git_root/.gitignore"
+    # Write the .gitignore in the directory that CONTAINS .pi (the chosen project
+    # dir), not the git root: gitignore entries with a slash are anchored to the
+    # .gitignore's own location, so a root-level ".pi/models.json" would NOT match
+    # a nested <subdir>/.pi/ — leaking the router key. dirname "$pi_dir" == the
+    # project dir (== git root when they're the same).
+    gitignore="$(dirname "$pi_dir")/.gitignore"
     refuse_if_symlink "$gitignore"
     for entry in \
       ".pi/models.json" \

--- a/install/install.sh
+++ b/install/install.sh
@@ -654,6 +654,7 @@ write_pi_models_config() {
     {
       "X-Weave-Router-Key": $key,
       "X-App": "pi",
+      "x-weave-routing-marker": "off",
       "x-weave-routing-alpha": "0.8",
       "x-weave-routing-speed-weight": "0.05",
       "x-weave-routing-output-cost-ratio": "0.5",

--- a/install/install.sh
+++ b/install/install.sh
@@ -1,35 +1,42 @@
 #!/usr/bin/env bash
 #
-# Weave Router installer for Claude Code, Codex, and opencode.
+# Weave Router installer for Claude Code, Codex, opencode, and pi.
 #
-# Configures Claude Code (default), the OpenAI Codex CLI (`--codex`), or
-# opencode (`--opencode`) to permanently route through the Weave Router.
-# For Claude Code this writes the router base URL, router auth header,
-# and a status line into Claude Code's settings.json. For Codex it writes
-# a `model_providers.weave` entry plus `model_provider = "weave"` into
+# Configures Claude Code (default), the OpenAI Codex CLI (`--codex`),
+# opencode (`--opencode`), or pi (`--pi`) to permanently route through the
+# Weave Router. For Claude Code this writes the router base URL, router auth
+# header, and a status line into Claude Code's settings.json. For Codex it
+# writes a `model_providers.weave` entry plus `model_provider = "weave"` into
 # ~/.codex/config.toml (managed block delimited by markers). For opencode
 # it merges a `provider.weave` block (anthropic-compatible) into
 # opencode.json — since the file is JSON, install/uninstall are structural
-# (jq) rather than marker-delimited.
+# (jq) rather than marker-delimited. For pi it merges a `weave` provider into
+# ~/.pi/agent/models.json, sets it as the default in settings.json, and adds
+# the @workweave/pi-router extension (which also adds a parallel subagent
+# `dispatch` tool) — all structural (jq) merges.
 #
 # Two scopes (apply to all targets):
 #   - user (default):  ~/.claude/settings.json  + ~/.weave/cc-statusline.sh
 #                      ~/.codex/config.toml                       (with --codex)
 #                      ~/.config/opencode/opencode.json           (with --opencode)
+#                      ~/.pi/agent/{models,settings}.json         (with --pi)
 #   - project:         <repo>/.claude/settings.json + <repo>/.claude/cc-statusline.sh
 #                      <repo>/.codex/config.toml                  (with --codex)
 #                      <repo>/opencode.json                       (with --opencode)
+#                      <repo>/.pi/ (run: PI_CODING_AGENT_DIR=<repo>/.pi pi)  (with --pi)
 #
 # Or pass --dir to install into any directory:
 #   - dir:              <dir>/.claude/settings.json + <dir>/.claude/cc-statusline.sh
 #                       <dir>/.codex/config.toml                  (with --codex)
 #                       <dir>/opencode.json                       (with --opencode)
+#                       <dir>/.pi/ (run: PI_CODING_AGENT_DIR=<dir>/.pi pi)   (with --pi)
 #
 # Usage:
 #   npx @workweave/router                                  # interactive picker (Claude Code, Codex, opencode)
 #   npx @workweave/router --claude                         # skip the picker, target Claude Code
 #   npx @workweave/router --codex                          # skip the picker, target the OpenAI Codex CLI
 #   npx @workweave/router --opencode                       # skip the picker, target opencode
+#   npx @workweave/router --pi                              # skip the picker, target pi
 #   npx @workweave/router --scope project                  # commit-with-team install
 #   npx @workweave/router --dir /tmp/my-sandbox            # isolated throwaway install
 #   npx @workweave/router --local                          # local router on localhost:8080
@@ -124,6 +131,7 @@ uninstall_cmd() {
   case "$target" in
     codex)    cmd="$cmd --codex" ;;
     opencode) cmd="$cmd --opencode" ;;
+    pi)       cmd="$cmd --pi" ;;
   esac
   [ "$scope" = "project" ] && cmd="$cmd --scope project"
   [ -n "$install_dir" ] && cmd="$cmd --dir $(printf '%q' "$install_dir")"
@@ -149,6 +157,7 @@ print_banner() {
   case "$target" in
     codex)    target_label="Codex installer" ;;
     opencode) target_label="opencode installer" ;;
+    pi)       target_label="pi installer" ;;
     *)        target_label="Claude Code installer" ;;
   esac
   printf '\n'
@@ -611,6 +620,107 @@ write_opencode_config() {
   chmod 600 "$config_file"
 }
 
+# write_pi_models_config merges a managed `weave` provider into pi's
+# models.json (anthropic-compatible — the router speaks Anthropic Messages
+# natively). The header set carries identity plus the main-loop routing knobs
+# (quality bias); the @workweave/pi-router extension re-registers the provider
+# per process to flip those knobs for subagents/compaction. apiKey is the
+# router key as well as a header — pi treats apiKey as required to consider auth
+# configured, but the router authenticates off X-Weave-Router-Key
+# (authHeader:false keeps Authorization free for BYOK). Re-running rewrites
+# `.providers.weave` in place; uninstall strips it. chmod 600 — holds the key.
+#
+# Usage: write_pi_models_config <models_file> <base_url> <api_key> [user_email] [user_name]
+write_pi_models_config() {
+  local config_file="$1"
+  local block_url="$2"
+  local block_key="$3"
+  local block_email="${4:-}"
+  local block_name="${5:-}"
+
+  # Identity + the main-loop (quality) routing knobs. Built piecewise so an
+  # empty email/name vanishes from the JSON entirely.
+  local headers_json
+  headers_json="$(jq -n \
+    --arg key   "$block_key" \
+    --arg email "$block_email" \
+    --arg name  "$block_name" '
+    {
+      "X-Weave-Router-Key": $key,
+      "X-App": "pi",
+      "x-weave-routing-alpha": "0.8",
+      "x-weave-routing-speed-weight": "0.05",
+      "x-weave-routing-output-cost-ratio": "0.5",
+      "x-weave-routing-expected-output-tokens": "3000"
+    }
+    | (if $email != "" then . + {"X-Weave-User-Email": $email} else . end)
+    | (if $name  != "" then . + {"X-Weave-User-Name":  $name } else . end)
+  ')"
+
+  # Headline models surfaced in pi's /model picker. The router re-routes every
+  # request regardless, so this list is UX; keep it Anthropic-shaped and in
+  # sync with @workweave/pi-router's WEAVE_MODELS constant.
+  local block
+  block="$(jq -n \
+    --arg url "$block_url/v1" \
+    --arg key "$block_key" \
+    --argjson headers "$headers_json" '
+    {
+      baseUrl: $url,
+      api: "anthropic-messages",
+      apiKey: $key,
+      authHeader: false,
+      headers: $headers,
+      models: [
+        { id: "claude-opus-4-8",   name: "Claude Opus 4.8 (via Weave Router)",   reasoning: true, input: ["text","image"], contextWindow: 200000, maxTokens: 64000 },
+        { id: "claude-opus-4-7",   name: "Claude Opus 4.7 (via Weave Router)",   reasoning: true, input: ["text","image"], contextWindow: 200000, maxTokens: 64000 },
+        { id: "claude-sonnet-4-6", name: "Claude Sonnet 4.6 (via Weave Router)", reasoning: true, input: ["text","image"], contextWindow: 200000, maxTokens: 64000 },
+        { id: "claude-haiku-4-5",  name: "Claude Haiku 4.5 (via Weave Router)",  reasoning: true, input: ["text","image"], contextWindow: 200000, maxTokens: 32000 }
+      ]
+    }
+  ')"
+
+  # Overwrite provider.weave only; leave any other providers/models the user
+  # added untouched.
+  local merged
+  if [ -f "$config_file" ]; then
+    merged="$(jq --argjson block "$block" '.providers = ((.providers // {}) | .weave = $block)' "$config_file")"
+  else
+    merged="$(jq -n --argjson block "$block" '{ providers: { weave: $block } }')"
+  fi
+  printf '%s\n' "$merged" >"$config_file"
+  # 0600: the headers + apiKey hold the router key.
+  chmod 600 "$config_file"
+}
+
+# write_pi_settings_config makes the `weave` provider pi's default and loads the
+# @workweave/pi-router extension. defaultProvider/defaultModel are set only when
+# unset (don't clobber a user's pick); the npm package source is appended to
+# `packages` idempotently — pi auto-installs missing packages on startup, so the
+# source entry is enough. No secret lives here, so no chmod 600.
+#
+# Usage: write_pi_settings_config <settings_file>
+write_pi_settings_config() {
+  local settings_file="$1"
+  local pkg="npm:@workweave/pi-router"
+  local merged
+  if [ -f "$settings_file" ]; then
+    merged="$(jq --arg pkg "$pkg" '
+      (.packages //= [])
+      | (if (.packages | index($pkg)) then . else .packages += [$pkg] end)
+      | (if (.defaultProvider // "") == "" then .defaultProvider = "weave" else . end)
+      | (if (.defaultModel // "") == "" then .defaultModel = "claude-sonnet-4-6" else . end)
+    ' "$settings_file")"
+  else
+    merged="$(jq -n --arg pkg "$pkg" '{
+      defaultProvider: "weave",
+      defaultModel: "claude-sonnet-4-6",
+      packages: [$pkg]
+    }')"
+  fi
+  printf '%s\n' "$merged" >"$settings_file"
+}
+
 # resolve_user_name mirrors resolve_user_email but for display name. Priority:
 # WEAVE_USER_NAME env override → git config user.name → empty. We don't
 # prompt for name independently: if email prompting yielded nothing, name
@@ -716,6 +826,9 @@ while [ $# -gt 0 ]; do
     --opencode)
       target="opencode"; target_explicit="true"; shift
       ;;
+    --pi)
+      target="pi"; target_explicit="true"; shift
+      ;;
     --claude)
       # No-op selector for symmetry with --codex / --opencode. Useful in
       # pipelines that want to skip the interactive picker without depending
@@ -747,6 +860,14 @@ if [ "$mode" != "install" ]; then
   fi
 fi
 
+# Toggle verbs (off/on/status) aren't implemented for pi — its config is a
+# structural models.json/settings.json merge, reversed by the uninstaller
+# rather than a single env/key line we can park and restore.
+if [ "$mode" != "install" ] && [ "$target" = "pi" ]; then
+  err "toggle verbs (off/on/status) aren't supported for --pi. Use 'npx @workweave/router --uninstall --pi' to remove, or re-run the installer to refresh."
+  exit 2
+fi
+
 if [ -z "$base_url" ]; then
   base_url="$DEFAULT_BASE_URL"
 fi
@@ -766,12 +887,14 @@ if [ "$target_explicit" = "false" ] && [ "$non_interactive" = "false" ] && [ -r 
   printf "  %s1)%s Claude Code  %s— patches ~/.claude/settings.json (or <repo>/.claude/)%s\n" "$C_BRAND" "$C_RESET" "$C_DIM" "$C_RESET"
   printf "  %s2)%s Codex        %s— patches ~/.codex/config.toml (or <repo>/.codex/)%s\n" "$C_BRAND" "$C_RESET" "$C_DIM" "$C_RESET"
   printf "  %s3)%s opencode     %s— patches ~/.config/opencode/opencode.json (or <repo>/opencode.json)%s\n" "$C_BRAND" "$C_RESET" "$C_DIM" "$C_RESET"
-  printf "Choose %s[1/2/3]%s (default %s1%s): " "$C_BOLD" "$C_RESET" "$C_BOLD" "$C_RESET"
+  printf "  %s4)%s pi           %s— patches ~/.pi/agent/models.json + settings.json (or <repo>/.pi/)%s\n" "$C_BRAND" "$C_RESET" "$C_DIM" "$C_RESET"
+  printf "Choose %s[1/2/3/4]%s (default %s1%s): " "$C_BOLD" "$C_RESET" "$C_BOLD" "$C_RESET"
   read -r target_choice </dev/tty || target_choice=""
   case "${target_choice:-1}" in
     1|""|claude|c|C)  target="claude" ;;
     2|codex|x|X)      target="codex" ;;
     3|opencode|o|O)   target="opencode" ;;
+    4|pi|p|P)         target="pi" ;;
     *) err "invalid choice: $target_choice"; exit 2 ;;
   esac
 fi
@@ -808,6 +931,11 @@ if [ -z "$install_dir" ] && [ "$scope_explicit" = "false" ] && [ "$non_interacti
       fi
       scope_project_path="<repo>/opencode.json"
       scope_cli_label="opencode"
+      ;;
+    pi)
+      scope_user_path="~/.pi/agent/"
+      scope_project_path="<repo>/.pi/"
+      scope_cli_label="pi"
       ;;
     *)
       scope_user_path="~/.claude/"
@@ -859,7 +987,7 @@ fi
 # Claude Code's settings.json and opencode's opencode.json patching both use
 # jq to deep-merge / structurally rewrite JSON. Toggling those clients reads
 # and rewrites the same JSON, so jq is required there too.
-if [ "$target" = "claude" ] || [ "$target" = "opencode" ]; then
+if [ "$target" = "claude" ] || [ "$target" = "opencode" ] || [ "$target" = "pi" ]; then
   require_cmd jq    "macOS: 'brew install jq' · Debian/Ubuntu: 'sudo apt install jq'"
 fi
 # curl is only used by the install path's health/validate probes; toggles never
@@ -883,6 +1011,12 @@ case "$target" in
     if ! command -v opencode >/dev/null 2>&1; then
       warn "'opencode' not found on PATH. Install from https://opencode.ai (or 'npm install -g opencode-ai'), then re-run this script."
       warn "Continuing — opencode.json will be written and will take effect once opencode is installed."
+    fi
+    ;;
+  pi)
+    if ! command -v pi >/dev/null 2>&1; then
+      warn "'pi' not found on PATH. Install with 'npm install -g @mariozechner/pi-coding-agent', then re-run this script."
+      warn "Continuing — models.json/settings.json will be written and take effect once pi is installed."
     fi
     ;;
 esac
@@ -970,6 +1104,31 @@ elif [ "$target" = "codex" ]; then
   fi
 
   mkdir -p "$codex_dir"
+elif [ "$target" = "pi" ]; then
+  # pi reads ~/.pi/agent/ by default, so a plain `pi` picks up a user-scope
+  # install with no env var. models.json is global-only in pi (there is no
+  # project-level models file), so for project/--dir scope we point
+  # PI_CODING_AGENT_DIR at a repo-local .pi that holds the whole config
+  # (models.json + settings.json + key) — the same shape as Codex's CODEX_HOME.
+  # The router key is embedded, so .pi goes in .gitignore for project scope.
+  case "$scope" in
+    user)    pi_dir="$settings_base/.pi/agent" ;;
+    project) pi_dir="$settings_base/.pi" ;;
+  esac
+  # --dir is a self-contained sandbox: flat .pi, launched via PI_CODING_AGENT_DIR.
+  [ -n "$install_dir" ] && pi_dir="$install_dir/.pi"
+  pi_models_file="$pi_dir/models.json"
+  pi_settings_file="$pi_dir/settings.json"
+  pi_key_file="$pi_dir/.weave_router_key"
+
+  if [ "$scope" = "project" ] || [ -n "$install_dir" ]; then
+    refuse_if_symlink "$pi_dir"
+    refuse_if_symlink "$pi_models_file"
+    refuse_if_symlink "$pi_settings_file"
+    refuse_if_symlink "$pi_key_file"
+  fi
+
+  mkdir -p "$pi_dir"
 else
   # opencode discovers config in this order: $XDG_CONFIG_HOME/opencode/opencode.json
   # (or ~/.config/opencode/opencode.json) for user scope, and opencode.json /
@@ -1576,6 +1735,69 @@ if [ "$target" = "opencode" ]; then
     # --dir installs land outside opencode's discovery roots, so the caller
     # has to point opencode at the file explicitly.
     info "Run opencode with OPENCODE_CONFIG=$opencode_config_file opencode."
+  fi
+  print_uninstall_hint
+  exit 0
+fi
+
+# ---------- pi install path (dispatch + exit before the Claude-only writes) ----------
+
+if [ "$target" = "pi" ]; then
+  write_pi_models_config "$pi_models_file" "$base_url" "$api_key" "$user_email" "$user_name"
+  ok "pi models config written to $pi_models_file"
+  write_pi_settings_config "$pi_settings_file"
+  ok "pi settings written to $pi_settings_file (provider weave + @workweave/pi-router)"
+
+  if [ -n "$api_key" ]; then
+    printf '%s\n' "$api_key" >"$pi_key_file"
+    chmod 600 "$pi_key_file"
+    ok "Router key written to $pi_key_file"
+  fi
+
+  # Project scope: the repo-local .pi carries the router key, so keep it out of
+  # git. Same reasoning as the Codex/opencode paths — base URL is shared, the
+  # key is per-person.
+  if [ "$scope" = "project" ] && [ -z "$install_dir" ] && [ -n "${git_root:-}" ]; then
+    gitignore="$git_root/.gitignore"
+    refuse_if_symlink "$gitignore"
+    for entry in \
+      ".pi/models.json" \
+      ".pi/settings.json" \
+      ".pi/.weave_router_key"
+    do
+      if [ ! -f "$gitignore" ] || ! grep -qxF "$entry" "$gitignore"; then
+        printf '%s\n' "$entry" >>"$gitignore"
+      fi
+    done
+    ok "Updated $gitignore (ignored repo-local .pi router config)"
+  fi
+
+  # Post-install verification: same probes the Claude/Codex/opencode paths run.
+  if [ "$quiet" != "true" ]; then
+    if ! spin "Pinging $base_url/health" curl -fsS --max-time 5 "$base_url/health"; then
+      warn "Could not reach $base_url/health within 5s. Settings are written; verify the router is running."
+    fi
+  fi
+
+  if [ -n "$api_key" ]; then
+    validate_pi_key() {
+      printf '%s: %s\n' "$router_key_header" "$api_key" \
+        | curl -fsS --max-time 5 --header @- "$base_url/validate"
+    }
+    if ! spin "Validating API key" validate_pi_key; then
+      warn "Router rejected the API key (check it matches the dashboard at $base_url/ui/)."
+    fi
+  fi
+
+  printf "\n"
+  printf "%s✓%s %s%sWeave Router installed for pi.%s\n" \
+    "$C_GREEN" "$C_RESET" "$C_BOLD" "$C_BRAND" "$C_RESET"
+  # Billing note: pi normally draws on a Claude subscription (OAuth); routing
+  # through the router switches to per-token billing on the router deployment
+  # key (or BYOK). Surface it at install so the change isn't a surprise.
+  info "pi now bills per token on the Weave Router key, not your Claude subscription."
+  if [ "$scope" = "project" ] || [ -n "$install_dir" ]; then
+    info "Run pi with PI_CODING_AGENT_DIR=$pi_dir pi so it picks up this config."
   fi
   print_uninstall_hint
   exit 0

--- a/install/pi-router/README.md
+++ b/install/pi-router/README.md
@@ -1,0 +1,65 @@
+# @workweave/pi-router
+
+A [pi](https://pi.dev) extension that routes every request through the
+[WorkWeave Router](https://github.com/workweave/router) — a trained, per-request
+LLM proxy that picks the most cost-efficient model that still solves each task.
+
+Installed automatically by the Weave Router installer:
+
+```bash
+WEAVE_ROUTER_KEY=rk_… npx -y @workweave/router --pi          # user scope
+WEAVE_ROUTER_KEY=rk_… npx -y @workweave/router --pi --local  # local router (http://localhost:8080)
+```
+
+That writes `~/.pi/agent/models.json` (the `weave` provider), adds
+`npm:@workweave/pi-router` to `~/.pi/agent/settings.json` `packages`, and stores
+the key in `~/.pi/agent/.weave_router_key`. pi auto-installs this package from
+npm on next start.
+
+## What it does
+
+- **Automatic model selection.** All pi traffic flows through the router, which
+  selects the model per request. You don't pick a model — the router does.
+- **Per-process routing bias.** Static `x-weave-routing-*` knob headers bias the
+  router: quality on the main loop, speed + cheap on subagents, cheapest on
+  compaction.
+- **Sticky sessions.** `metadata.user_id = "pi:<sessionId>"` pins the main loop
+  to one model for the session; subagents get their own pins.
+- **`dispatch` tool — parallel, context-isolated subagents.** pi has none
+  natively. `dispatch` spawns child `pi` processes (read-only by default), runs
+  them concurrently, and returns only each subagent's final answer — intermediate
+  tool output stays in the child, so the main context stays small.
+- **Routed-model display.** Shows the model the router actually chose
+  (`x-router-model`) in the status bar.
+- **Safety backstop.** Blocks a few catastrophic shell commands (`rm -rf /`,
+  `mkfs`, `dd of=/dev/…`, fork bombs, force-push to main). Disable with
+  `WEAVE_NO_SAFETY=1`.
+
+## Configuration (environment)
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `WEAVE_ROUTER_URL` | `http://localhost:8080` | Router base URL (children inherit it) |
+| `WEAVE_ROUTER_KEY` | — | Router key (else read from `.weave_router_key`) |
+| `WEAVE_ROUTER_KEY_FILE` | `<agentDir>/.weave_router_key` | Override key file path |
+| `WEAVE_USER_EMAIL` / `WEAVE_USER_NAME` | from `git config` | Identity headers for attribution |
+| `WEAVE_PI_SUBAGENT_MODEL` | `claude-sonnet-4-6` | `weave/<model>` handle children launch with (router re-routes) |
+| `WEAVE_PI_DISPATCH_CONCURRENCY` | `4` | Max concurrent subagents |
+| `WEAVE_PI_SUBAGENT_TIMEOUT_MS` | `600000` | Per-subagent timeout |
+| `WEAVE_ROUTING_ALPHA` / `…_SPEED_WEIGHT` / `…_OUTPUT_COST_RATIO` / `…_EXPECTED_OUTPUT_TOKENS` | role preset | Override individual routing knobs |
+| `WEAVE_NO_SAFETY` | unset | `1` disables the catastrophic-bash gate |
+| `WEAVE_CHEAP_COMPACTION` | unset | `1` enables the (experimental) cheap-compaction path |
+
+Internal: `WEAVE_PI_SUBAGENT=1` and `WEAVE_PI_SUBAGENT_ID` are set by `dispatch`
+on child processes; don't set them yourself.
+
+## Billing
+
+Routing through the router switches pi from Claude **subscription OAuth** to
+**per-token** billing on the router deployment's key (or your BYOK key). BYOK
+skips cross-provider failover; deployment-key billing is the default.
+
+## Notes
+
+- Cheap compaction is currently a reserved flag — the handler defers to pi's
+  built-in compaction until the router-routed path is validated end-to-end.

--- a/install/pi-router/README.md
+++ b/install/pi-router/README.md
@@ -30,7 +30,9 @@ npm on next start.
   them concurrently, and returns only each subagent's final answer — intermediate
   tool output stays in the child, so the main context stays small.
 - **Routed-model display.** Shows the model the router actually chose
-  (`x-router-model`) in the status bar.
+  (`x-router-model`) in the status bar, and opts the request out of the router's
+  in-band routing badge (`X-Weave-Routing-Marker: off`) — pi can't render that
+  separate marker text block inline, and the status bar already conveys the model.
 - **Safety backstop.** Blocks a few catastrophic shell commands (`rm -rf /`,
   `mkfs`, `dd of=/dev/…`, fork bombs, force-push to main). Disable with
   `WEAVE_NO_SAFETY=1`.

--- a/install/pi-router/README.md
+++ b/install/pi-router/README.md
@@ -46,7 +46,8 @@ npm on next start.
 | `WEAVE_PI_SUBAGENT_MODEL` | `claude-sonnet-4-6` | `weave/<model>` handle children launch with (router re-routes) |
 | `WEAVE_PI_DISPATCH_CONCURRENCY` | `4` | Max concurrent subagents |
 | `WEAVE_PI_SUBAGENT_TIMEOUT_MS` | `600000` | Per-subagent timeout |
-| `WEAVE_ROUTING_ALPHA` / `…_SPEED_WEIGHT` / `…_OUTPUT_COST_RATIO` / `…_EXPECTED_OUTPUT_TOKENS` | role preset | Override individual routing knobs |
+| `WEAVE_PI_ALLOW_SUBAGENT_TOOLS` | unset | `1` lets `dispatch` grant subagents write/exec tools (bash, write, edit); default strips them |
+| `WEAVE_ROUTING_ALPHA` / `…_SPEED_WEIGHT` / `…_OUTPUT_COST_RATIO` / `…_EXPECTED_OUTPUT_TOKENS` | role preset | Override individual routing knobs (main process only — children always use their role preset) |
 | `WEAVE_NO_SAFETY` | unset | `1` disables the catastrophic-bash gate |
 | `WEAVE_CHEAP_COMPACTION` | unset | `1` enables the (experimental) cheap-compaction path |
 

--- a/install/pi-router/package.json
+++ b/install/pi-router/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "@workweave/pi-router",
+  "version": "0.1.0",
+  "description": "Route the pi coding agent through the WorkWeave Router: automatic per-request model selection, quality/speed knob biasing, sticky sessions, and parallel context-isolated subagents.",
+  "type": "module",
+  "license": "SEE LICENSE IN LICENSE",
+  "keywords": [
+    "pi-package",
+    "weave",
+    "router",
+    "pi",
+    "llm-router",
+    "anthropic"
+  ],
+  "pi": {
+    "extensions": [
+      "./src/index.ts"
+    ]
+  },
+  "files": [
+    "src",
+    "README.md"
+  ],
+  "peerDependencies": {
+    "@mariozechner/pi-agent-core": "*",
+    "@mariozechner/pi-ai": "*",
+    "@mariozechner/pi-coding-agent": "*",
+    "@mariozechner/pi-tui": "*",
+    "typebox": "*"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/workweave/router.git",
+    "directory": "install/pi-router"
+  },
+  "homepage": "https://workweave.ai"
+}

--- a/install/pi-router/src/compaction.ts
+++ b/install/pi-router/src/compaction.ts
@@ -1,0 +1,26 @@
+/**
+ * EXPERIMENTAL, off by default (enable with WEAVE_CHEAP_COMPACTION=1).
+ *
+ * Intent: run context compaction through the cheapest routing knobs. The
+ * catch is that compaction bypasses provider hooks and reuses the session's
+ * static provider headers (the main loop's quality knobs), and
+ * `session_before_compact` is the only per-turn lever. Producing a fully
+ * router-routed cheap CompactionResult here is not yet validated, so this
+ * handler currently defers to pi's built-in compaction (returns no override)
+ * and only reserves the flag + surfaces that it's active. Promote to a real
+ * cheap path once validated end-to-end.
+ */
+
+import type { ExtensionAPI, ExtensionContext, SessionBeforeCompactEvent } from "@mariozechner/pi-coding-agent";
+
+export function registerCheapCompaction(pi: ExtensionAPI): void {
+	let announced = false;
+	pi.on("session_before_compact", (_event: SessionBeforeCompactEvent, ctx: ExtensionContext) => {
+		if (ctx.hasUI && !announced) {
+			announced = true;
+			ctx.ui.setStatus("weave-compaction", "cheap compaction: experimental (using built-in)");
+		}
+		// Defer to built-in compaction until the router-routed cheap path is validated.
+		return undefined;
+	});
+}

--- a/install/pi-router/src/config.ts
+++ b/install/pi-router/src/config.ts
@@ -89,7 +89,10 @@ function readWeaveProvider(): WeaveProviderConfig {
 	} catch {
 		/* no models.json — fall through to env/defaults */
 	}
-	cachedWeaveProvider = result;
+	// Cache only a successful, non-empty read. An empty result (file missing or no
+	// weave block yet) must not be cached forever — a later install/write should be
+	// picked up on the next call.
+	if (result.baseUrl || result.apiKey) cachedWeaveProvider = result;
 	return result;
 }
 

--- a/install/pi-router/src/config.ts
+++ b/install/pi-router/src/config.ts
@@ -1,0 +1,243 @@
+/**
+ * Environment, routing-knob presets, identity, and the static per-process
+ * header policy shared by every part of the extension.
+ *
+ * The whole design hinges on one pi constraint: `before_provider_request` can
+ * mutate the request body but cannot set HTTP headers (headers bind when the
+ * Anthropic client is created, before the hook runs). So routing-knob headers
+ * are *static per provider config*, i.e. static per process. Subagents are
+ * separate processes, which is exactly why "quality for the main loop, speed
+ * for subagents" maps cleanly onto process identity (`WEAVE_PI_SUBAGENT`).
+ */
+
+import { execFileSync } from "node:child_process";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import type { ProviderModelConfig } from "@mariozechner/pi-coding-agent";
+
+/** Provider name. NOT "anthropic" — overriding the built-in provider hijacks the Claude OAuth token. */
+export const PROVIDER_NAME = "weave";
+
+export type Role = "main" | "subagent";
+
+/** Children spawned by the dispatch tool run with WEAVE_PI_SUBAGENT=1. */
+export function isSubagent(): boolean {
+	return process.env.WEAVE_PI_SUBAGENT === "1";
+}
+
+export function getRole(): Role {
+	return isSubagent() ? "subagent" : "main";
+}
+
+function numEnv(name: string, fallback: number): number {
+	const raw = process.env[name];
+	if (raw === undefined || raw.trim() === "") return fallback;
+	const n = Number(raw);
+	return Number.isFinite(n) ? n : fallback;
+}
+
+// ---------- router endpoint ----------
+
+/**
+ * Router base URL (no trailing slash). Order: WEAVE_ROUTER_URL env (children
+ * inherit it), then the installer-written models.json baseUrl (so the extension
+ * always agrees with however the user installed — hosted, --local, or custom),
+ * then the local default. Without the models.json fallback, a hosted install
+ * with no env var would be silently re-pointed at localhost.
+ */
+export function getRouterBaseUrl(): string {
+	const env = process.env.WEAVE_ROUTER_URL?.trim();
+	if (env) return env.replace(/\/+$/, "");
+	const fromModels = readWeaveProvider().baseUrl?.trim();
+	if (fromModels) return fromModels.replace(/\/v1\/?$/, "").replace(/\/+$/, "");
+	return "http://localhost:8080";
+}
+
+export function getRouterV1Url(): string {
+	return `${getRouterBaseUrl()}/v1`;
+}
+
+// ---------- router key resolution ----------
+
+/** Agent config dir, honoring PI_CODING_AGENT_DIR (set for project-scope installs). */
+function getAgentDir(): string {
+	const env = process.env.PI_CODING_AGENT_DIR?.trim();
+	if (env) return env.startsWith("~/") ? path.join(os.homedir(), env.slice(2)) : env;
+	return path.join(os.homedir(), ".pi", "agent");
+}
+
+export function getKeyFilePath(): string {
+	return process.env.WEAVE_ROUTER_KEY_FILE?.trim() || path.join(getAgentDir(), ".weave_router_key");
+}
+
+interface WeaveProviderConfig {
+	baseUrl?: string;
+	apiKey?: string;
+}
+
+let cachedWeaveProvider: WeaveProviderConfig | undefined;
+
+/** Read the installer-written `weave` provider block from models.json (cached). */
+function readWeaveProvider(): WeaveProviderConfig {
+	if (cachedWeaveProvider) return cachedWeaveProvider;
+	let result: WeaveProviderConfig = {};
+	try {
+		const raw = fs.readFileSync(path.join(getAgentDir(), "models.json"), "utf-8");
+		const parsed = JSON.parse(raw) as { providers?: { weave?: WeaveProviderConfig } };
+		result = parsed.providers?.weave ?? {};
+	} catch {
+		/* no models.json — fall through to env/defaults */
+	}
+	cachedWeaveProvider = result;
+	return result;
+}
+
+/** Router key from WEAVE_ROUTER_KEY, else the installer-written key file, else models.json. */
+export function resolveRouterKey(): string | undefined {
+	const envKey = process.env.WEAVE_ROUTER_KEY?.trim();
+	if (envKey) return envKey;
+	try {
+		const contents = fs.readFileSync(getKeyFilePath(), "utf-8").trim();
+		if (contents) return contents;
+	} catch {
+		/* no key file — fall through */
+	}
+	return readWeaveProvider().apiKey?.trim() || undefined;
+}
+
+// ---------- identity ----------
+
+export interface Identity {
+	email?: string;
+	name?: string;
+}
+
+function gitConfig(key: string): string | undefined {
+	try {
+		const out = execFileSync("git", ["config", "--get", key], {
+			encoding: "utf-8",
+			stdio: ["ignore", "pipe", "ignore"],
+		}).trim();
+		return out || undefined;
+	} catch {
+		return undefined;
+	}
+}
+
+let cachedIdentity: Identity | undefined;
+
+/** Resolve user identity the same way the installer does: env overrides, then git config. */
+export function resolveIdentity(): Identity {
+	if (cachedIdentity) return cachedIdentity;
+	const email = process.env.WEAVE_USER_EMAIL?.trim() || gitConfig("user.email");
+	const name = process.env.WEAVE_USER_NAME?.trim() || gitConfig("user.name");
+	cachedIdentity = { email: email || undefined, name: name || undefined };
+	return cachedIdentity;
+}
+
+// ---------- routing-knob presets ----------
+
+export interface Knobs {
+	alpha: number;
+	speedWeight: number;
+	outputCostRatio: number;
+	expectedOutputTokens: number;
+}
+
+// Validated against the scorer: alpha + speedWeight <= 1.
+//   main:       0.80 + 0.05 = 0.85  (quality-biased; first turn pins a high tier)
+//   subagent:   0.25 + 0.45 = 0.70  (speed + cheap fan-out, isolated session)
+//   compaction: 0.05 + 0.55 = 0.60  (cheapest — summarization is throwaway)
+const MAIN_LOOP_KNOBS: Knobs = { alpha: 0.8, speedWeight: 0.05, outputCostRatio: 0.5, expectedOutputTokens: 3000 };
+const FAST_CHEAP_KNOBS: Knobs = { alpha: 0.25, speedWeight: 0.45, outputCostRatio: 2.0, expectedOutputTokens: 1500 };
+const COMPACTION_KNOBS: Knobs = { alpha: 0.05, speedWeight: 0.55, outputCostRatio: 3.0, expectedOutputTokens: 1000 };
+
+/** Knobs for this process, with per-knob env overrides applied on top of the role preset. */
+export function knobsForRole(role: Role): Knobs {
+	const base = role === "subagent" ? FAST_CHEAP_KNOBS : MAIN_LOOP_KNOBS;
+	return {
+		alpha: numEnv("WEAVE_ROUTING_ALPHA", base.alpha),
+		speedWeight: numEnv("WEAVE_ROUTING_SPEED_WEIGHT", base.speedWeight),
+		outputCostRatio: numEnv("WEAVE_ROUTING_OUTPUT_COST_RATIO", base.outputCostRatio),
+		expectedOutputTokens: numEnv("WEAVE_ROUTING_EXPECTED_OUTPUT_TOKENS", base.expectedOutputTokens),
+	};
+}
+
+export function compactionKnobs(): Knobs {
+	return { ...COMPACTION_KNOBS };
+}
+
+// ---------- header builders ----------
+
+const KNOB_HEADER = {
+	alpha: "x-weave-routing-alpha",
+	speedWeight: "x-weave-routing-speed-weight",
+	outputCostRatio: "x-weave-routing-output-cost-ratio",
+	expectedOutputTokens: "x-weave-routing-expected-output-tokens",
+} as const;
+
+export function knobHeaders(k: Knobs): Record<string, string> {
+	return {
+		[KNOB_HEADER.alpha]: String(k.alpha),
+		[KNOB_HEADER.speedWeight]: String(k.speedWeight),
+		[KNOB_HEADER.outputCostRatio]: String(k.outputCostRatio),
+		[KNOB_HEADER.expectedOutputTokens]: String(k.expectedOutputTokens),
+	};
+}
+
+/** Identity + auth headers. The router authenticates off X-Weave-Router-Key (authHeader stays false). */
+export function identityHeaders(role: Role, key: string): Record<string, string> {
+	const id = resolveIdentity();
+	const headers: Record<string, string> = {
+		"X-Weave-Router-Key": key,
+		"X-App": role === "subagent" ? "pi-subagent" : "pi",
+	};
+	if (id.email) headers["X-Weave-User-Email"] = id.email;
+	if (id.name) headers["X-Weave-User-Name"] = id.name;
+	return headers;
+}
+
+/** The full static header set for this process's `weave` provider. */
+export function providerHeaders(role: Role, key: string): Record<string, string> {
+	return { ...identityHeaders(role, key), ...knobHeaders(knobsForRole(role)) };
+}
+
+// ---------- model list ----------
+
+// Carried as a shared constant rather than relying on registerProvider preserving
+// an omitted `models` list, so the extension is self-sufficient: a freshly
+// dispatched child (and a `pi -e` smoke test with no models.json) can still
+// resolve `weave/<model>`. The list mirrors the installer's headline models;
+// the router re-routes every request regardless, so this is a UX/label surface.
+export const WEAVE_MODELS: ProviderModelConfig[] = [
+	model("claude-opus-4-8", "Claude Opus 4.8 (via Weave Router)", 64000),
+	model("claude-opus-4-7", "Claude Opus 4.7 (via Weave Router)", 64000),
+	model("claude-sonnet-4-6", "Claude Sonnet 4.6 (via Weave Router)", 64000),
+	model("claude-haiku-4-5", "Claude Haiku 4.5 (via Weave Router)", 32000),
+];
+
+function model(id: string, name: string, maxTokens: number): ProviderModelConfig {
+	return {
+		id,
+		name,
+		reasoning: true,
+		input: ["text", "image"],
+		// Real cost is decided by the router per request and is unknown client-side.
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 200000,
+		maxTokens,
+	};
+}
+
+// ---------- dispatch / misc tunables ----------
+
+export const ROUTED_MODEL_HEADER = (process.env.WEAVE_ROUTED_MODEL_HEADER || "x-router-model").toLowerCase();
+/** Marker a headless child prints to stderr so the parent dispatch can read its routed model. */
+export const ROUTED_MODEL_STDERR_PREFIX = "weave-routed-model:";
+
+export const SUBAGENT_MODEL = process.env.WEAVE_PI_SUBAGENT_MODEL?.trim() || "claude-sonnet-4-6";
+export const DISPATCH_CONCURRENCY = Math.max(1, numEnv("WEAVE_PI_DISPATCH_CONCURRENCY", 4));
+export const MAX_SUBAGENTS = 8;
+export const SUBAGENT_TIMEOUT_MS = Math.max(1000, numEnv("WEAVE_PI_SUBAGENT_TIMEOUT_MS", 600000));
+export const DEFAULT_READONLY_TOOLS = ["read", "grep", "find", "ls"];

--- a/install/pi-router/src/config.ts
+++ b/install/pi-router/src/config.ts
@@ -200,7 +200,14 @@ export function identityHeaders(role: Role, key: string): Record<string, string>
 
 /** The full static header set for this process's `weave` provider. */
 export function providerHeaders(role: Role, key: string): Record<string, string> {
-	return { ...identityHeaders(role, key), ...knobHeaders(knobsForRole(role)) };
+	return {
+		...identityHeaders(role, key),
+		...knobHeaders(knobsForRole(role)),
+		// pi surfaces the routed model in its status bar (from x-router-model), so
+		// opt out of the router's in-band "✦ Weave Router → …" badge — it arrives as
+		// a separate text block that hides the answer in pi's renderer. (router #263)
+		"X-Weave-Routing-Marker": "off",
+	};
 }
 
 // ---------- model list ----------

--- a/install/pi-router/src/config.ts
+++ b/install/pi-router/src/config.ts
@@ -40,22 +40,22 @@ function numEnv(name: string, fallback: number): number {
 // ---------- router endpoint ----------
 
 /**
- * Router base URL (no trailing slash). Order: WEAVE_ROUTER_URL env (children
- * inherit it), then the installer-written models.json baseUrl (so the extension
- * always agrees with however the user installed — hosted, --local, or custom),
- * then the local default. Without the models.json fallback, a hosted install
- * with no env var would be silently re-pointed at localhost.
+ * Router base URL — the ROOT, with no /v1 and no trailing slash. pi's
+ * anthropic-messages provider uses @anthropic-ai/sdk, which appends /v1/messages
+ * to this; a trailing /v1 would produce /v1/v1/messages and 404. Order:
+ * WEAVE_ROUTER_URL env (children inherit it), then the installer-written
+ * models.json baseUrl (so the extension always agrees with however the user
+ * installed — hosted, --local, or custom), then the local default. Without the
+ * models.json fallback, a hosted install with no env var would be silently
+ * re-pointed at localhost. The /v1 strip on the models.json value keeps installs
+ * written by an older installer (which appended /v1) working after an update.
  */
 export function getRouterBaseUrl(): string {
 	const env = process.env.WEAVE_ROUTER_URL?.trim();
-	if (env) return env.replace(/\/+$/, "");
+	if (env) return env.replace(/\/v1\/?$/, "").replace(/\/+$/, "");
 	const fromModels = readWeaveProvider().baseUrl?.trim();
 	if (fromModels) return fromModels.replace(/\/v1\/?$/, "").replace(/\/+$/, "");
 	return "http://localhost:8080";
-}
-
-export function getRouterV1Url(): string {
-	return `${getRouterBaseUrl()}/v1`;
 }
 
 // ---------- router key resolution ----------

--- a/install/pi-router/src/config.ts
+++ b/install/pi-router/src/config.ts
@@ -241,3 +241,11 @@ export const DISPATCH_CONCURRENCY = Math.max(1, numEnv("WEAVE_PI_DISPATCH_CONCUR
 export const MAX_SUBAGENTS = 8;
 export const SUBAGENT_TIMEOUT_MS = Math.max(1000, numEnv("WEAVE_PI_SUBAGENT_TIMEOUT_MS", 600000));
 export const DEFAULT_READONLY_TOOLS = ["read", "grep", "find", "ls"];
+
+// Tools that let a subagent mutate the filesystem or run arbitrary commands.
+// dispatch strips these from model-requested per-task `tools` (and downgrades
+// readOnly:false's "all tools") unless WEAVE_PI_ALLOW_SUBAGENT_TOOLS=1, so a
+// prompt-injected main loop can't silently escalate a read-only fan-out into
+// writes/exec. The catastrophic-command gate in safety.ts is a separate, narrower
+// backstop; this is the capability gate.
+export const DANGEROUS_SUBAGENT_TOOLS = new Set(["bash", "edit", "write", "patch", "multiedit", "apply_patch"]);

--- a/install/pi-router/src/dispatch.ts
+++ b/install/pi-router/src/dispatch.ts
@@ -21,6 +21,7 @@ import type { Message } from "@mariozechner/pi-ai";
 import { Text } from "@mariozechner/pi-tui";
 import { Type } from "typebox";
 import {
+	DANGEROUS_SUBAGENT_TOOLS,
 	DEFAULT_READONLY_TOOLS,
 	DISPATCH_CONCURRENCY,
 	getRouterBaseUrl,
@@ -39,7 +40,7 @@ const TaskItem = Type.Object({
 	prompt: Type.String({ description: "The full instruction for this subagent." }),
 	tools: Type.Optional(
 		Type.Array(Type.String(), {
-			description: "Tool names this subagent may use (e.g. read, grep, bash). Overrides readOnly for this task.",
+			description: "Tool names this subagent may use (e.g. read, grep). Overrides readOnly for this task. Dangerous tools (bash, write, edit) are ignored unless WEAVE_PI_ALLOW_SUBAGENT_TOOLS=1.",
 		}),
 	),
 	cwd: Type.Optional(Type.String({ description: "Working directory for this subagent. Defaults to the parent cwd." })),
@@ -54,7 +55,7 @@ const DispatchParams = Type.Object({
 	readOnly: Type.Optional(
 		Type.Boolean({
 			default: true,
-			description: "When true (default), subagents get read-only tools (read, grep, find, ls). Per-task `tools` overrides this.",
+			description: "When true (default), subagents get read-only tools (read, grep, find, ls). Per-task `tools` overrides this. Without WEAVE_PI_ALLOW_SUBAGENT_TOOLS=1, readOnly:false still yields read-only tools (no silent bash/write).",
 		}),
 	),
 });
@@ -105,7 +106,7 @@ function finalAssistantText(messages: Message[]): string {
 	for (let i = messages.length - 1; i >= 0; i--) {
 		const msg = messages[i];
 		if (msg.role !== "assistant") continue;
-		for (const part of msg.content) {
+		for (const part of msg.content ?? []) {
 			if (part.type === "text") return part.text;
 		}
 	}
@@ -122,7 +123,26 @@ function runChild(
 	index: number,
 ): Promise<ChildResult> {
 	const args = ["--print", "--mode", "json", "--no-session", "-e", selfPath, "--model", `${PROVIDER_NAME}/${SUBAGENT_MODEL}`];
-	const tools = task.tools && task.tools.length > 0 ? task.tools : readOnly ? DEFAULT_READONLY_TOOLS : undefined;
+
+	// Secure-by-default tool gating. Task input is model-influenced, so without an
+	// explicit opt-in we never hand a child write/exec tools: model-requested
+	// `tools` are stripped of dangerous entries, and readOnly:false's "all tools"
+	// is downgraded to read-only. WEAVE_PI_ALLOW_SUBAGENT_TOOLS=1 restores full
+	// flexibility. Stops a prompt-injected main loop from escalating a read-only
+	// fan-out into arbitrary command/file execution under the user's identity.
+	const allowDangerousTools = process.env.WEAVE_PI_ALLOW_SUBAGENT_TOOLS === "1";
+	let tools: string[] | undefined;
+	if (task.tools && task.tools.length > 0) {
+		tools = task.tools;
+	} else if (readOnly || !allowDangerousTools) {
+		tools = DEFAULT_READONLY_TOOLS;
+	} else {
+		tools = undefined; // readOnly:false + opt-in => full toolset
+	}
+	if (tools && !allowDangerousTools) {
+		tools = tools.filter((t) => !DANGEROUS_SUBAGENT_TOOLS.has(t.toLowerCase()));
+		if (tools.length === 0) tools = DEFAULT_READONLY_TOOLS;
+	}
 	if (tools) args.push("--tools", tools.join(","));
 	args.push(task.prompt);
 
@@ -134,6 +154,13 @@ function runChild(
 		WEAVE_ROUTER_KEY: key,
 		WEAVE_ROUTER_URL: getRouterBaseUrl(),
 	};
+	// Don't let the main loop's per-knob routing overrides leak into children:
+	// knobsForRole prefers env values over the role preset, which would route
+	// subagents on the main loop's quality knobs instead of the speed/cheap ones.
+	delete env.WEAVE_ROUTING_ALPHA;
+	delete env.WEAVE_ROUTING_SPEED_WEIGHT;
+	delete env.WEAVE_ROUTING_OUTPUT_COST_RATIO;
+	delete env.WEAVE_ROUTING_EXPECTED_OUTPUT_TOKENS;
 	if (identity.email) env.WEAVE_USER_EMAIL = identity.email;
 	if (identity.name) env.WEAVE_USER_NAME = identity.name;
 
@@ -180,15 +207,17 @@ function runChild(
 		const timer = setTimeout(() => {
 			timedOut = true;
 			proc.kill("SIGTERM");
+			// proc.killed flips true the instant SIGTERM is *sent*, so escalate based
+			// on whether the process actually exited (settled), not proc.killed.
 			setTimeout(() => {
-				if (!proc.killed) proc.kill("SIGKILL");
+				if (!settled) proc.kill("SIGKILL");
 			}, SIGKILL_GRACE_MS);
 		}, SUBAGENT_TIMEOUT_MS);
 
 		const onAbort = () => {
 			proc.kill("SIGTERM");
 			setTimeout(() => {
-				if (!proc.killed) proc.kill("SIGKILL");
+				if (!settled) proc.kill("SIGKILL");
 			}, SIGKILL_GRACE_MS);
 		};
 		if (signal) {
@@ -201,17 +230,22 @@ function runChild(
 			settled = true;
 			clearTimeout(timer);
 			signal?.removeEventListener("abort", onAbort);
-			if (stdoutBuf.trim()) processLine(stdoutBuf);
-
 			result.exitCode = exitCode;
-			result.finalText = finalAssistantText(messages);
-			result.routedModel = lastRoutedModel(stderrBuf);
-			if (exitCode !== 0 && !result.finalText) {
-				result.error = timedOut
-					? `timed out after ${Math.round(SUBAGENT_TIMEOUT_MS / 1000)}s`
-					: signal?.aborted
-						? "aborted"
-						: lastStderrLine(stderrBuf) || `exited with code ${exitCode}`;
+			// resolve() must always run — a parse error here would otherwise strand
+			// this promise and block the whole dispatch via mapWithConcurrencyLimit.
+			try {
+				if (stdoutBuf.trim()) processLine(stdoutBuf);
+				result.finalText = finalAssistantText(messages);
+				result.routedModel = lastRoutedModel(stderrBuf);
+				if (exitCode !== 0 && !result.finalText) {
+					result.error = timedOut
+						? `timed out after ${Math.round(SUBAGENT_TIMEOUT_MS / 1000)}s`
+						: signal?.aborted
+							? "aborted"
+							: lastStderrLine(stderrBuf) || `exited with code ${exitCode}`;
+				}
+			} catch (err) {
+				if (!result.error) result.error = `failed to read subagent output: ${(err as Error).message}`;
 			}
 			resolve(result);
 		};

--- a/install/pi-router/src/dispatch.ts
+++ b/install/pi-router/src/dispatch.ts
@@ -1,0 +1,303 @@
+/**
+ * `dispatch` — parallel, context-isolated subagents.
+ *
+ * pi has no native subagents. The canonical pattern (examples/extensions/
+ * subagent) is to spawn a fresh `pi --print --mode json --no-session` process
+ * per task: true context isolation, reuses pi's own agent loop, and an
+ * independent router session. We layer Weave routing on top by loading this
+ * same extension in each child (`-e <self>`) with WEAVE_PI_SUBAGENT=1, so the
+ * child registers the `weave` provider with the speed/cheap knobs and a
+ * "subagent:" session id. Only the final assistant text comes back to the
+ * parent — intermediate tool output stays in the child, keeping the main
+ * context tiny.
+ */
+
+import { spawn } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { Message } from "@mariozechner/pi-ai";
+import { Text } from "@mariozechner/pi-tui";
+import { Type } from "typebox";
+import {
+	DEFAULT_READONLY_TOOLS,
+	DISPATCH_CONCURRENCY,
+	getRouterBaseUrl,
+	MAX_SUBAGENTS,
+	PROVIDER_NAME,
+	resolveIdentity,
+	resolveRouterKey,
+	ROUTED_MODEL_STDERR_PREFIX,
+	SUBAGENT_MODEL,
+	SUBAGENT_TIMEOUT_MS,
+} from "./config.js";
+
+const SIGKILL_GRACE_MS = 5000;
+
+const TaskItem = Type.Object({
+	prompt: Type.String({ description: "The full instruction for this subagent." }),
+	tools: Type.Optional(
+		Type.Array(Type.String(), {
+			description: "Tool names this subagent may use (e.g. read, grep, bash). Overrides readOnly for this task.",
+		}),
+	),
+	cwd: Type.Optional(Type.String({ description: "Working directory for this subagent. Defaults to the parent cwd." })),
+});
+
+const DispatchParams = Type.Object({
+	tasks: Type.Array(TaskItem, {
+		minItems: 1,
+		maxItems: MAX_SUBAGENTS,
+		description: "Tasks to run as parallel, context-isolated subagents.",
+	}),
+	readOnly: Type.Optional(
+		Type.Boolean({
+			default: true,
+			description: "When true (default), subagents get read-only tools (read, grep, find, ls). Per-task `tools` overrides this.",
+		}),
+	),
+});
+
+interface ChildResult {
+	index: number;
+	finalText: string;
+	routedModel?: string;
+	exitCode: number;
+	error?: string;
+}
+
+/** Resolve how to launch a nested pi (node/bun script, compiled binary, or `pi` on PATH). */
+function getPiInvocation(args: string[]): { command: string; args: string[] } {
+	const currentScript = process.argv[1];
+	const isBunVirtualScript = currentScript?.startsWith("/$bunfs/root/");
+	if (currentScript && !isBunVirtualScript && fs.existsSync(currentScript)) {
+		return { command: process.execPath, args: [currentScript, ...args] };
+	}
+	const execName = path.basename(process.execPath).toLowerCase();
+	const isGenericRuntime = /^(node|bun)(\.exe)?$/.test(execName);
+	if (!isGenericRuntime) return { command: process.execPath, args };
+	return { command: "pi", args };
+}
+
+async function mapWithConcurrencyLimit<TIn, TOut>(
+	items: TIn[],
+	concurrency: number,
+	fn: (item: TIn, index: number) => Promise<TOut>,
+): Promise<TOut[]> {
+	if (items.length === 0) return [];
+	const limit = Math.max(1, Math.min(concurrency, items.length));
+	const results: TOut[] = new Array(items.length);
+	let nextIndex = 0;
+	const workers = new Array(limit).fill(null).map(async () => {
+		while (true) {
+			const current = nextIndex++;
+			if (current >= items.length) return;
+			results[current] = await fn(items[current], current);
+		}
+	});
+	await Promise.all(workers);
+	return results;
+}
+
+/** Last assistant text block across the child's emitted messages. */
+function finalAssistantText(messages: Message[]): string {
+	for (let i = messages.length - 1; i >= 0; i--) {
+		const msg = messages[i];
+		if (msg.role !== "assistant") continue;
+		for (const part of msg.content) {
+			if (part.type === "text") return part.text;
+		}
+	}
+	return "";
+}
+
+function runChild(
+	selfPath: string,
+	task: { prompt: string; tools?: string[]; cwd?: string },
+	readOnly: boolean,
+	defaultCwd: string,
+	key: string,
+	signal: AbortSignal | undefined,
+	index: number,
+): Promise<ChildResult> {
+	const args = ["--print", "--mode", "json", "--no-session", "-e", selfPath, "--model", `${PROVIDER_NAME}/${SUBAGENT_MODEL}`];
+	const tools = task.tools && task.tools.length > 0 ? task.tools : readOnly ? DEFAULT_READONLY_TOOLS : undefined;
+	if (tools) args.push("--tools", tools.join(","));
+	args.push(task.prompt);
+
+	const identity = resolveIdentity();
+	const env: NodeJS.ProcessEnv = {
+		...process.env,
+		WEAVE_PI_SUBAGENT: "1",
+		WEAVE_PI_SUBAGENT_ID: randomUUID(),
+		WEAVE_ROUTER_KEY: key,
+		WEAVE_ROUTER_URL: getRouterBaseUrl(),
+	};
+	if (identity.email) env.WEAVE_USER_EMAIL = identity.email;
+	if (identity.name) env.WEAVE_USER_NAME = identity.name;
+
+	const result: ChildResult = { index, finalText: "", exitCode: 0 };
+	const messages: Message[] = [];
+
+	return new Promise<ChildResult>((resolve) => {
+		const invocation = getPiInvocation(args);
+		const proc = spawn(invocation.command, invocation.args, {
+			cwd: task.cwd ?? defaultCwd,
+			shell: false,
+			stdio: ["ignore", "pipe", "pipe"],
+			env,
+		});
+
+		let stdoutBuf = "";
+		let stderrBuf = "";
+		let settled = false;
+		let timedOut = false;
+
+		const processLine = (line: string) => {
+			if (!line.trim()) return;
+			let event: { type?: string; message?: Message };
+			try {
+				event = JSON.parse(line);
+			} catch {
+				return;
+			}
+			if ((event.type === "message_end" || event.type === "tool_result_end") && event.message) {
+				messages.push(event.message);
+			}
+		};
+
+		proc.stdout.on("data", (data) => {
+			stdoutBuf += data.toString();
+			const lines = stdoutBuf.split("\n");
+			stdoutBuf = lines.pop() ?? "";
+			for (const line of lines) processLine(line);
+		});
+		proc.stderr.on("data", (data) => {
+			stderrBuf += data.toString();
+		});
+
+		const timer = setTimeout(() => {
+			timedOut = true;
+			proc.kill("SIGTERM");
+			setTimeout(() => {
+				if (!proc.killed) proc.kill("SIGKILL");
+			}, SIGKILL_GRACE_MS);
+		}, SUBAGENT_TIMEOUT_MS);
+
+		const onAbort = () => {
+			proc.kill("SIGTERM");
+			setTimeout(() => {
+				if (!proc.killed) proc.kill("SIGKILL");
+			}, SIGKILL_GRACE_MS);
+		};
+		if (signal) {
+			if (signal.aborted) onAbort();
+			else signal.addEventListener("abort", onAbort, { once: true });
+		}
+
+		const settle = (exitCode: number) => {
+			if (settled) return;
+			settled = true;
+			clearTimeout(timer);
+			signal?.removeEventListener("abort", onAbort);
+			if (stdoutBuf.trim()) processLine(stdoutBuf);
+
+			result.exitCode = exitCode;
+			result.finalText = finalAssistantText(messages);
+			result.routedModel = lastRoutedModel(stderrBuf);
+			if (exitCode !== 0 && !result.finalText) {
+				result.error = timedOut
+					? `timed out after ${Math.round(SUBAGENT_TIMEOUT_MS / 1000)}s`
+					: signal?.aborted
+						? "aborted"
+						: lastStderrLine(stderrBuf) || `exited with code ${exitCode}`;
+			}
+			resolve(result);
+		};
+
+		proc.on("close", (code) => settle(code ?? 0));
+		proc.on("error", (err) => {
+			stderrBuf += `${err.message}\n`;
+			settle(1);
+		});
+	});
+}
+
+function lastRoutedModel(stderr: string): string | undefined {
+	let found: string | undefined;
+	for (const line of stderr.split("\n")) {
+		const idx = line.indexOf(ROUTED_MODEL_STDERR_PREFIX);
+		if (idx !== -1) found = line.slice(idx + ROUTED_MODEL_STDERR_PREFIX.length).trim();
+	}
+	return found || undefined;
+}
+
+function lastStderrLine(stderr: string): string {
+	const lines = stderr
+		.split("\n")
+		.map((l) => l.trim())
+		.filter(Boolean);
+	return lines.length > 0 ? lines[lines.length - 1] : "";
+}
+
+export function registerDispatch(pi: ExtensionAPI, selfPath: string): void {
+	pi.registerTool({
+		name: "dispatch",
+		label: "Dispatch",
+		description: [
+			"Run tasks as parallel, context-isolated subagents (separate pi processes).",
+			"Each subagent has its own context window and routes through the Weave Router on speed/cheap knobs;",
+			"only its final answer returns here, so intermediate work never bloats this context.",
+			"Subagents are read-only by default (read, grep, find, ls); pass per-task `tools` to widen.",
+			"Use for fan-out investigation/search across independent questions.",
+		].join(" "),
+		parameters: DispatchParams,
+		executionMode: "parallel",
+
+		async execute(_toolCallId, params, signal, _onUpdate, ctx) {
+			const key = resolveRouterKey();
+			if (!key) {
+				return {
+					content: [
+						{ type: "text", text: "Weave dispatch unavailable: no router key (set WEAVE_ROUTER_KEY or run the --pi installer)." },
+					],
+					details: { results: [] as ChildResult[] },
+					isError: true,
+				};
+			}
+
+			const readOnly = params.readOnly ?? true;
+			const results = await mapWithConcurrencyLimit(params.tasks, DISPATCH_CONCURRENCY, (task, index) =>
+				runChild(selfPath, task, readOnly, ctx.cwd, key, signal, index),
+			);
+
+			const succeeded = results.filter((r) => r.exitCode === 0 && !r.error).length;
+			const blocks = results.map((r) => {
+				const tags = [r.routedModel ? `routed: ${r.routedModel}` : null, r.exitCode === 0 && !r.error ? null : "FAILED"]
+					.filter(Boolean)
+					.join(" · ");
+				const header = `## Subagent ${r.index + 1}${tags ? ` (${tags})` : ""}`;
+				const body = r.error ? `Error: ${r.error}` : r.finalText || "(no output)";
+				return `${header}\n${body}`;
+			});
+
+			return {
+				content: [{ type: "text", text: `${succeeded}/${results.length} subagents succeeded\n\n${blocks.join("\n\n")}` }],
+				details: { results },
+				isError: succeeded === 0,
+			};
+		},
+
+		renderCall(args, theme) {
+			const tasks = args.tasks ?? [];
+			let text = `${theme.fg("toolTitle", theme.bold("dispatch "))}${theme.fg("accent", `${tasks.length} subagent${tasks.length === 1 ? "" : "s"}`)}`;
+			for (const t of tasks.slice(0, 3)) {
+				const preview = t.prompt.length > 60 ? `${t.prompt.slice(0, 60)}...` : t.prompt;
+				text += `\n  ${theme.fg("dim", preview)}`;
+			}
+			if (tasks.length > 3) text += `\n  ${theme.fg("muted", `... +${tasks.length - 3} more`)}`;
+			return new Text(text, 0, 0);
+		},
+	});
+}

--- a/install/pi-router/src/dispatch.ts
+++ b/install/pi-router/src/dispatch.ts
@@ -101,14 +101,16 @@ async function mapWithConcurrencyLimit<TIn, TOut>(
 	return results;
 }
 
-/** Last assistant text block across the child's emitted messages. */
+/** Full text of the child's last assistant message (all text blocks joined). */
 function finalAssistantText(messages: Message[]): string {
 	for (let i = messages.length - 1; i >= 0; i--) {
 		const msg = messages[i];
 		if (msg.role !== "assistant") continue;
+		const texts: string[] = [];
 		for (const part of msg.content ?? []) {
-			if (part.type === "text") return part.text;
+			if (part.type === "text") texts.push(part.text);
 		}
+		if (texts.length > 0) return texts.join("");
 	}
 	return "";
 }
@@ -140,7 +142,9 @@ function runChild(
 		tools = undefined; // readOnly:false + opt-in => full toolset
 	}
 	if (tools && !allowDangerousTools) {
-		tools = tools.filter((t) => !DANGEROUS_SUBAGENT_TOOLS.has(t.toLowerCase()));
+		// Trim first: pi's `--tools` parser trims each entry, so " bash" would slip
+		// past a non-trimmed check here and then get re-enabled downstream.
+		tools = tools.map((t) => t.trim()).filter((t) => t !== "" && !DANGEROUS_SUBAGENT_TOOLS.has(t.toLowerCase()));
 		if (tools.length === 0) tools = DEFAULT_READONLY_TOOLS;
 	}
 	if (tools) args.push("--tools", tools.join(","));
@@ -250,7 +254,10 @@ function runChild(
 			resolve(result);
 		};
 
-		proc.on("close", (code) => settle(code ?? 0));
+		// A null exit code means the child was killed by a signal (timeout / abort /
+		// crash) — settle as failure (1), not success (0), so a killed subagent with
+		// no output can't be counted as succeeded.
+		proc.on("close", (code) => settle(code ?? 1));
 		proc.on("error", (err) => {
 			stderrBuf += `${err.message}\n`;
 			settle(1);

--- a/install/pi-router/src/index.ts
+++ b/install/pi-router/src/index.ts
@@ -1,0 +1,49 @@
+/**
+ * @workweave/pi-router — route the pi coding agent through the WorkWeave Router.
+ *
+ * Wiring (all on the existing router surface — no router source change beyond
+ * the installer):
+ *   - provider:     register `weave` with per-process knob headers (quality on
+ *                   the main loop, speed/cheap in subagents).
+ *   - metadata:     stamp body.metadata.user_id for sticky sessions + subagent
+ *                   detection.
+ *   - routed-model: show which model the router actually picked.
+ *   - safety:       block catastrophic bash (unless WEAVE_NO_SAFETY=1).
+ *   - compaction:   experimental cheap path (only when WEAVE_CHEAP_COMPACTION=1).
+ *   - dispatch:     parallel, context-isolated subagents — top-level process
+ *                   only (no grandchildren).
+ *
+ * The same module loads in dispatched children via `-e <self>`; WEAVE_PI_SUBAGENT
+ * flips the provider knobs and suppresses the dispatch tool so fan-out doesn't recurse.
+ */
+
+import { fileURLToPath } from "node:url";
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import { isSubagent } from "./config.js";
+import { registerCheapCompaction } from "./compaction.js";
+import { registerDispatch } from "./dispatch.js";
+import { registerMetadata } from "./metadata.js";
+import { registerRoutedModel } from "./routed-model.js";
+import { registerSafety } from "./safety.js";
+import { registerWeave } from "./provider.js";
+
+const SELF_PATH = fileURLToPath(import.meta.url);
+
+export default function (pi: ExtensionAPI): void {
+	// Register at load so the provider is available for `--list-models` and
+	// print mode (dispatched children), and again on session_start so the right
+	// knob headers survive `/reload` and new/resumed sessions.
+	registerWeave(pi);
+	pi.on("session_start", () => registerWeave(pi));
+
+	registerMetadata(pi);
+	registerRoutedModel(pi);
+
+	if (process.env.WEAVE_NO_SAFETY !== "1") registerSafety(pi);
+	if (process.env.WEAVE_CHEAP_COMPACTION === "1") registerCheapCompaction(pi);
+
+	// Only the top-level process fans out. Children (WEAVE_PI_SUBAGENT=1) load
+	// this same extension but get no dispatch tool, so subagents can't spawn
+	// grandchildren.
+	if (!isSubagent()) registerDispatch(pi, SELF_PATH);
+}

--- a/install/pi-router/src/metadata.ts
+++ b/install/pi-router/src/metadata.ts
@@ -1,0 +1,32 @@
+/**
+ * Injects `metadata.user_id` into the request body so the router can:
+ *   - keep the main loop on a sticky session pin ("pi:<sessionId>"), and
+ *   - detect subagents ("subagent:<uuid>") for an independent pin + server-side
+ *     SubAgentDispatch handling.
+ *
+ * This is the one body-level signal we control (the session pin key derives
+ * from metadata.user_id when present; subagent detection on the Anthropic
+ * ingress path keys off a "subagent:" prefix). Headers can't carry it because
+ * before_provider_request can't set headers.
+ */
+
+import { randomUUID } from "node:crypto";
+import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
+import { isSubagent } from "./config.js";
+
+// One id per child process so all of a subagent's requests share a single pin.
+// The parent passes WEAVE_PI_SUBAGENT_ID; a standalone child falls back to a uuid.
+const SUBAGENT_USER_ID = `subagent:${process.env.WEAVE_PI_SUBAGENT_ID?.trim() || randomUUID()}`;
+
+export function registerMetadata(pi: ExtensionAPI): void {
+	pi.on("before_provider_request", (event, ctx: ExtensionContext) => {
+		const body = event.payload as { metadata?: { user_id?: string } } | undefined;
+		if (!body || typeof body !== "object") return undefined;
+
+		const userId = isSubagent() ? SUBAGENT_USER_ID : `pi:${ctx.sessionManager.getSessionId()}`;
+		if (body.metadata?.user_id === userId) return undefined;
+
+		body.metadata = { ...(body.metadata ?? {}), user_id: userId };
+		return body;
+	});
+}

--- a/install/pi-router/src/provider.ts
+++ b/install/pi-router/src/provider.ts
@@ -1,0 +1,49 @@
+/**
+ * Registers the `weave` provider with the per-process header policy.
+ *
+ * Re-registered on each `session_start` (and once at load) so the right knob
+ * headers are always live and the provider survives `/reload`. We register a
+ * new provider named "weave" rather than overriding the built-in "anthropic"
+ * provider — overriding "anthropic" would hijack the Claude OAuth token.
+ */
+
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import {
+	getRole,
+	getRouterV1Url,
+	isSubagent,
+	PROVIDER_NAME,
+	providerHeaders,
+	resolveRouterKey,
+	WEAVE_MODELS,
+} from "./config.js";
+
+export function registerWeave(pi: ExtensionAPI): void {
+	const key = resolveRouterKey();
+	const role = getRole();
+
+	if (!key) {
+		// The main loop can still run off the installer-written models.json
+		// provider. A subagent MUST apply the speed/cheap knobs, so a missing
+		// key there is fatal rather than silently routing on quality knobs.
+		if (isSubagent()) {
+			throw new Error(
+				"Weave: no router key found (set WEAVE_ROUTER_KEY or write ~/.pi/agent/.weave_router_key).",
+			);
+		}
+		return;
+	}
+
+	pi.registerProvider(PROVIDER_NAME, {
+		name: "Weave Router",
+		baseUrl: getRouterV1Url(),
+		// Planted to satisfy pi's "is auth configured" check. The router ignores
+		// it (auth runs off X-Weave-Router-Key); authHeader:false keeps
+		// Authorization free for BYOK.
+		apiKey: key,
+		api: "anthropic-messages",
+		authHeader: false,
+		headers: providerHeaders(role, key),
+		models: WEAVE_MODELS,
+	});
+}

--- a/install/pi-router/src/provider.ts
+++ b/install/pi-router/src/provider.ts
@@ -10,7 +10,7 @@
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import {
 	getRole,
-	getRouterV1Url,
+	getRouterBaseUrl,
 	isSubagent,
 	PROVIDER_NAME,
 	providerHeaders,
@@ -36,7 +36,9 @@ export function registerWeave(pi: ExtensionAPI): void {
 
 	pi.registerProvider(PROVIDER_NAME, {
 		name: "Weave Router",
-		baseUrl: getRouterV1Url(),
+		// Root URL, no /v1: the anthropic-messages provider uses @anthropic-ai/sdk,
+		// which appends /v1/messages to baseUrl. A /v1 here yields /v1/v1/messages.
+		baseUrl: getRouterBaseUrl(),
 		// Planted to satisfy pi's "is auth configured" check. The router ignores
 		// it (auth runs off X-Weave-Router-Key); authHeader:false keeps
 		// Authorization free for BYOK.

--- a/install/pi-router/src/routed-model.ts
+++ b/install/pi-router/src/routed-model.ts
@@ -1,0 +1,31 @@
+/**
+ * Surfaces which model the router actually picked for each request.
+ *
+ * The router sets `x-router-model` on every response (streaming, non-streaming,
+ * and cache hits). In the interactive UI we show it in the status bar and
+ * notify on change. In a headless child (print/RPC — e.g. a dispatch subagent)
+ * there is no UI, so we print a marker to stderr that the parent dispatch tool
+ * parses to attribute each subagent's work to a model.
+ */
+
+import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
+import { ROUTED_MODEL_HEADER, ROUTED_MODEL_STDERR_PREFIX } from "./config.js";
+
+const STATUS_KEY = "weave";
+
+export function registerRoutedModel(pi: ExtensionAPI): void {
+	let last: string | undefined;
+
+	pi.on("after_provider_response", (event, ctx: ExtensionContext) => {
+		const model = event.headers?.[ROUTED_MODEL_HEADER];
+		if (!model || model === last) return;
+		last = model;
+
+		if (ctx.hasUI) {
+			ctx.ui.setStatus(STATUS_KEY, `routed: ${model}`);
+			ctx.ui.notify(`Weave routed to ${model}`, "info");
+		} else {
+			process.stderr.write(`${ROUTED_MODEL_STDERR_PREFIX} ${model}\n`);
+		}
+	});
+}

--- a/install/pi-router/src/safety.ts
+++ b/install/pi-router/src/safety.ts
@@ -1,0 +1,66 @@
+/**
+ * Last-resort guard against a handful of catastrophic, effectively
+ * irreversible shell commands. pi already confirms normal tool calls; this
+ * matters most in non-interactive subagents where there is no human to
+ * confirm. It blocks ONLY the obviously-destructive forms below — it is a
+ * backstop, not a sandbox. Disable with WEAVE_NO_SAFETY=1.
+ */
+
+import { type ExtensionAPI, type ExtensionContext, isToolCallEventType, type ToolCallEvent } from "@mariozechner/pi-coding-agent";
+
+interface Rule {
+	test: (cmd: string) => boolean;
+	reason: string;
+}
+
+const hasRecursive = (c: string) => /(?:\s|^)-\w*r/i.test(c) || /--recursive\b/.test(c);
+const hasForce = (c: string) => /(?:\s|^)-\w*f/i.test(c) || /--force\b/.test(c);
+const targetsRoot = (c: string) =>
+	/--no-preserve-root\b/.test(c) || /(?:\s|^)(?:\/|~|\$HOME|\/\*)(?:\s|$)/.test(c);
+
+const RULES: Rule[] = [
+	{
+		test: (c) => /\brm\b/.test(c) && hasRecursive(c) && hasForce(c) && targetsRoot(c),
+		reason: "recursive force-remove of a root/home path",
+	},
+	{
+		test: (c) => /\bmkfs(\.\w+)?\b/.test(c),
+		reason: "filesystem format (mkfs)",
+	},
+	{
+		test: (c) => /\bdd\b[^\n]*\bof=\/dev\//.test(c),
+		reason: "dd writing directly to a device",
+	},
+	{
+		test: (c) => />\s*\/dev\/(?:sd|nvme|disk|hd|mapper)/.test(c),
+		reason: "redirect overwriting a raw block device",
+	},
+	{
+		test: (c) => /:\s*\(\s*\)\s*\{[^}]*\|[^}]*&[^}]*\}\s*;\s*:/.test(c),
+		reason: "fork bomb",
+	},
+	{
+		test: (c) =>
+			/\bgit\s+push\b/.test(c) &&
+			(/(?:--force(?!-with-lease)|\s-f\b)/.test(c) || /\+(?:main|master)\b/.test(c)) &&
+			/\b(?:main|master)\b/.test(c),
+		reason: "force-push to main/master",
+	},
+];
+
+function catastrophicReason(command: string): string | undefined {
+	const cmd = command.trim();
+	for (const rule of RULES) {
+		if (rule.test(cmd)) return rule.reason;
+	}
+	return undefined;
+}
+
+export function registerSafety(pi: ExtensionAPI): void {
+	pi.on("tool_call", (event: ToolCallEvent, _ctx: ExtensionContext) => {
+		if (!isToolCallEventType("bash", event)) return undefined;
+		const reason = catastrophicReason(event.input.command ?? "");
+		if (!reason) return undefined;
+		return { block: true, reason: `Weave safety: blocked ${reason}. Set WEAVE_NO_SAFETY=1 to override.` };
+	});
+}

--- a/install/pi-router/test/e2e.sh
+++ b/install/pi-router/test/e2e.sh
@@ -138,6 +138,8 @@ fi
   && ok "main loop: X-Weave-Router-Key forwarded" || bad "router key not forwarded"
 [ "$(jqcount '.app=="pi" and .email=="e2e@workweave.ai"')" -ge 1 ] \
   && ok "main loop: identity email forwarded" || bad "identity email not forwarded"
+[ "$(jqcount '.app=="pi" and .marker_opt=="off"')" -ge 1 ] \
+  && ok "main loop: opted out of in-band routing marker (X-Weave-Routing-Marker: off)" || bad "routing-marker opt-out header not sent"
 grep -q "weave-routed-model: claude-opus-4-8" "$WORK/main.out" \
   && ok "x-router-model surfaced (headless stderr marker)" || bad "routed-model marker absent (see $WORK/main.out)"
 
@@ -161,6 +163,8 @@ SUBAGENT_REQS="$(jqcount '.app=="pi-subagent"')"
   && ok "subagents: speed/cheap knobs 0.25 / 0.45 / 2 / 1500 (parent WEAVE_ROUTING_* not inherited)" || bad "subagent knobs wrong (did parent WEAVE_ROUTING_* leak into children?)"
 [ "$(jqcount '.app=="pi-subagent" and (.user_id // "" | startswith("subagent:"))')" -ge 2 ] \
   && ok "subagents: metadata.user_id = subagent:<uuid>" || bad "subagent user_id wrong"
+[ "$(jqcount '.app=="pi-subagent" and .marker_opt=="off"')" -ge 2 ] \
+  && ok "subagents: opted out of in-band routing marker (else finalText = the badge)" || bad "subagent routing-marker opt-out not sent"
 UNIQUE_SUBAGENT_IDS="$(jq -s '[.[] | select(.app=="pi-subagent") | .user_id] | unique | length' "$LOG")"
 [ "$UNIQUE_SUBAGENT_IDS" -ge 2 ] \
   && ok "each subagent got a distinct session id ($UNIQUE_SUBAGENT_IDS unique)" || bad "subagent ids not distinct ($UNIQUE_SUBAGENT_IDS)"

--- a/install/pi-router/test/e2e.sh
+++ b/install/pi-router/test/e2e.sh
@@ -1,0 +1,195 @@
+#!/usr/bin/env bash
+#
+# End-to-end test for @workweave/pi-router + the `install.sh --pi` target.
+#
+# Drives a REAL `pi` process against a mock Weave Router (mock_router.py) and
+# asserts the routed-request shape the router actually receives: routing knobs,
+# identity headers, and the metadata.user_id session/subagent signal -- for the
+# main loop, for dispatch subagents, and for on-disk (key-file + models.json)
+# resolution. No real model spend; no network beyond localhost.
+#
+# Requires: pi, jq, python3, curl. Run from anywhere:
+#   install/pi-router/test/e2e.sh
+#
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PKG_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+INSTALL_SH="$(cd "$PKG_DIR/.." && pwd)/install.sh"
+EXT="$PKG_DIR/src/index.ts"
+MOCK="$SCRIPT_DIR/mock_router.py"
+
+PORT="${MOCK_PORT:-8899}"
+BASE_URL="http://127.0.0.1:$PORT"
+
+for tool in pi jq python3 curl; do
+  command -v "$tool" >/dev/null 2>&1 || { echo "FATAL: '$tool' not on PATH"; exit 2; }
+done
+[ -f "$EXT" ]        || { echo "FATAL: extension not found: $EXT"; exit 2; }
+[ -f "$INSTALL_SH" ] || { echo "FATAL: installer not found: $INSTALL_SH"; exit 2; }
+[ -f "$MOCK" ]       || { echo "FATAL: mock not found: $MOCK"; exit 2; }
+
+WORK="$(mktemp -d)"
+LOG="$WORK/requests.jsonl"
+PI_DIR="$WORK/.pi"
+MOCK_PID=""
+KEEP_WORK=0
+
+cleanup() {
+  [ -n "$MOCK_PID" ] && kill "$MOCK_PID" 2>/dev/null || true
+  [ -n "$MOCK_PID" ] && wait "$MOCK_PID" 2>/dev/null || true
+  if [ "$KEEP_WORK" = "1" ]; then
+    echo "diagnostics preserved in $WORK"
+  else
+    rm -rf "$WORK"
+  fi
+}
+trap cleanup EXIT
+
+# Deterministic identity + key. The mock accepts any key value.
+export WEAVE_ROUTER_KEY="rk_e2e_testkey_abcd"
+export WEAVE_USER_EMAIL="e2e@workweave.ai"
+export WEAVE_USER_NAME="E2E Tester"
+
+PASS=0
+FAIL=0
+ok()  { printf '  \033[32mPASS\033[0m %s\n' "$1"; PASS=$((PASS + 1)); }
+bad() { printf '  \033[31mFAIL\033[0m %s\n' "$1"; FAIL=$((FAIL + 1)); }
+phase() { printf '\n\033[1m== %s ==\033[0m\n' "$1"; }
+
+# jqcount <filter> -> number of JSONL records matching the boolean jq filter
+jqcount() { jq -s "[.[] | select($1)] | length" "$LOG"; }
+
+# with_timeout <secs> <cmd...>  (macOS has no coreutils `timeout`)
+with_timeout() {
+  local secs="$1"; shift
+  "$@" &
+  local pid=$!
+  ( sleep "$secs"; kill "$pid" 2>/dev/null ) &
+  local wd=$!
+  disown "$wd" 2>/dev/null || true  # suppress the job-control "Terminated" line
+  local rc=0
+  wait "$pid" 2>/dev/null || rc=$?
+  kill "$wd" 2>/dev/null || true
+  return "$rc"
+}
+
+# -------------------------------------------------------------------------
+# Start the mock router and wait for it to accept connections.
+# -------------------------------------------------------------------------
+MOCK_LOG="$LOG" MOCK_PORT="$PORT" python3 "$MOCK" &
+MOCK_PID=$!
+for _ in $(seq 1 50); do
+  curl -fsS "$BASE_URL/health" >/dev/null 2>&1 && break
+  sleep 0.1
+done
+curl -fsS "$BASE_URL/health" >/dev/null 2>&1 || { echo "FATAL: mock did not come up on $BASE_URL"; exit 2; }
+
+# -------------------------------------------------------------------------
+phase "Phase 1 — installer (install.sh --pi)"
+# -------------------------------------------------------------------------
+bash "$INSTALL_SH" --pi --base-url "$BASE_URL" --dir "$WORK" >"$WORK/install.out" 2>&1 </dev/null || true
+
+[ -f "$PI_DIR/models.json" ]       && ok "models.json written"  || bad "models.json missing (see $WORK/install.out)"
+[ -f "$PI_DIR/settings.json" ]     && ok "settings.json written" || bad "settings.json missing"
+[ -f "$PI_DIR/.weave_router_key" ] && ok "router key file written" || bad "key file missing"
+
+jq -e --arg u "$BASE_URL" '.providers.weave.baseUrl == $u' "$PI_DIR/models.json" >/dev/null 2>&1 \
+  && ok "models.json baseUrl = $BASE_URL (root, no /v1)" || bad "models.json baseUrl wrong (want root, no /v1)"
+jq -e '.providers.weave.api == "anthropic-messages" and .providers.weave.authHeader == false' "$PI_DIR/models.json" >/dev/null 2>&1 \
+  && ok "provider api=anthropic-messages, authHeader=false" || bad "provider api/authHeader wrong"
+jq -e '.providers.weave.headers["x-weave-routing-alpha"] == "0.8" and .providers.weave.headers["x-weave-routing-speed-weight"] == "0.05"' "$PI_DIR/models.json" >/dev/null 2>&1 \
+  && ok "models.json carries main-loop knobs (0.8 / 0.05)" || bad "models.json knobs wrong"
+jq -e '.providers.weave.headers["X-Weave-User-Email"] == "e2e@workweave.ai"' "$PI_DIR/models.json" >/dev/null 2>&1 \
+  && ok "identity baked into models.json headers" || bad "identity header missing in models.json"
+
+PERM="$(stat -f '%Lp' "$PI_DIR/.weave_router_key" 2>/dev/null || stat -c '%a' "$PI_DIR/.weave_router_key" 2>/dev/null || echo '?')"
+[ "$PERM" = "600" ] && ok "key file mode 600" || bad "key file mode $PERM (want 600)"
+
+grep -q '"path":"/health"'   "$LOG" && ok "installer pinged /health"      || bad "no /health probe reached mock"
+grep -q '"path":"/validate"' "$LOG" && ok "installer validated key (/validate)" || bad "no /validate probe reached mock"
+
+# Idempotency: a second install must not duplicate the package entry.
+bash "$INSTALL_SH" --pi --base-url "$BASE_URL" --dir "$WORK" >>"$WORK/install.out" 2>&1 </dev/null || true
+PKGCOUNT="$(jq '[.packages[]? | select(. == "npm:@workweave/pi-router")] | length' "$PI_DIR/settings.json")"
+[ "$PKGCOUNT" = "1" ] && ok "idempotent re-install: single pi-router package entry" || bad "package entry count = $PKGCOUNT (want 1)"
+
+# The npm package is not published pre-merge; drop it so `-e` is the sole loader.
+STRIPPED="$(jq 'del(.packages)' "$PI_DIR/settings.json")"
+printf '%s\n' "$STRIPPED" >"$PI_DIR/settings.json"
+
+# -------------------------------------------------------------------------
+phase "Phase 2 — main-loop routing (real pi -p)"
+# -------------------------------------------------------------------------
+with_timeout 90 env PI_CODING_AGENT_DIR="$PI_DIR" \
+  pi -e "$EXT" --no-session --offline --model weave/claude-sonnet-4-6 \
+  -p "Say hello in three words." >"$WORK/main.out" 2>&1 </dev/null || true
+
+if [ "$(jqcount '.method=="POST" and .app=="pi" and .path=="/v1/messages" and .rejected==false')" -ge 1 ]; then
+  ok "pi sent a routed request to /v1/messages"
+else
+  bad "no valid main-loop request reached /v1/messages (see $WORK/main.out)"
+fi
+[ "$(jqcount '.app=="pi" and .knobs["x-weave-routing-alpha"]=="0.8" and .knobs["x-weave-routing-speed-weight"]=="0.05" and .knobs["x-weave-routing-output-cost-ratio"]=="0.5" and .knobs["x-weave-routing-expected-output-tokens"]=="3000"')" -ge 1 ] \
+  && ok "main loop: quality knobs 0.8 / 0.05 / 0.5 / 3000" || bad "main-loop knobs wrong"
+[ "$(jqcount '.app=="pi" and (.user_id // "" | startswith("pi:")) and (.user_id // "" | length) > 3')" -ge 1 ] \
+  && ok "main loop: metadata.user_id = pi:<session>" || bad "main-loop user_id wrong"
+[ "$(jqcount '.app=="pi" and .key_present==true')" -ge 1 ] \
+  && ok "main loop: X-Weave-Router-Key forwarded" || bad "router key not forwarded"
+[ "$(jqcount '.app=="pi" and .email=="e2e@workweave.ai"')" -ge 1 ] \
+  && ok "main loop: identity email forwarded" || bad "identity email not forwarded"
+grep -q "weave-routed-model: claude-opus-4-8" "$WORK/main.out" \
+  && ok "x-router-model surfaced (headless stderr marker)" || bad "routed-model marker absent (see $WORK/main.out)"
+
+# -------------------------------------------------------------------------
+phase "Phase 3 — dispatch fan-out (real subagent processes)"
+# -------------------------------------------------------------------------
+with_timeout 120 env PI_CODING_AGENT_DIR="$PI_DIR" \
+  pi -e "$EXT" --no-session --offline --model weave/claude-sonnet-4-6 \
+  -p "__DISPATCH__ run two quick parallel checks." >"$WORK/dispatch.out" 2>&1 </dev/null || true
+
+[ "$(jqcount '.app=="pi" and .served=="tool_use"')" -ge 1 ] \
+  && ok "main loop invoked the dispatch tool" || bad "dispatch tool_use was never served (see $WORK/dispatch.out)"
+SUBAGENT_REQS="$(jqcount '.app=="pi-subagent"')"
+[ "$SUBAGENT_REQS" -ge 2 ] \
+  && ok "spawned $SUBAGENT_REQS subagent requests (>=2 expected)" || bad "only $SUBAGENT_REQS subagent requests (want >=2)"
+[ "$(jqcount '.app=="pi-subagent" and .knobs["x-weave-routing-alpha"]=="0.25" and .knobs["x-weave-routing-speed-weight"]=="0.45" and .knobs["x-weave-routing-output-cost-ratio"]=="2" and .knobs["x-weave-routing-expected-output-tokens"]=="1500"')" -ge 2 ] \
+  && ok "subagents: speed/cheap knobs 0.25 / 0.45 / 2 / 1500" || bad "subagent knobs wrong"
+[ "$(jqcount '.app=="pi-subagent" and (.user_id // "" | startswith("subagent:"))')" -ge 2 ] \
+  && ok "subagents: metadata.user_id = subagent:<uuid>" || bad "subagent user_id wrong"
+UNIQUE_SUBAGENT_IDS="$(jq -s '[.[] | select(.app=="pi-subagent") | .user_id] | unique | length' "$LOG")"
+[ "$UNIQUE_SUBAGENT_IDS" -ge 2 ] \
+  && ok "each subagent got a distinct session id ($UNIQUE_SUBAGENT_IDS unique)" || bad "subagent ids not distinct ($UNIQUE_SUBAGENT_IDS)"
+[ "$(jqcount '.app=="pi" and .has_tool_result==true')" -ge 1 ] \
+  && ok "main loop resumed after tool_result (loop terminated cleanly)" || bad "no post-dispatch main turn (loop did not complete)"
+
+# -------------------------------------------------------------------------
+phase "Phase 4 — on-disk resolution (no env; key file + models.json)"
+# -------------------------------------------------------------------------
+# Unset every WEAVE_* override so the extension MUST resolve the key from the
+# installer-written key file and the base URL from models.json (the bug fix).
+with_timeout 90 env -u WEAVE_ROUTER_KEY -u WEAVE_ROUTER_URL -u WEAVE_USER_EMAIL -u WEAVE_USER_NAME \
+  PI_CODING_AGENT_DIR="$PI_DIR" \
+  pi -e "$EXT" --no-session --offline --model weave/claude-sonnet-4-6 \
+  -p "Resolve credentials from disk." >"$WORK/resolve.out" 2>&1 </dev/null || true
+
+# Requests carrying our test key's suffix prove key-file + models.json resolution
+# worked with no env vars set (the request reached the mock at all == baseUrl ok).
+[ "$(jqcount '.app=="pi" and .key_present==true and .key_suffix=="abcd"')" -ge 1 ] \
+  && ok "resolved key from key file + baseUrl from models.json (no env)" || bad "on-disk resolution failed (see $WORK/resolve.out)"
+
+# -------------------------------------------------------------------------
+phase "Result"
+# -------------------------------------------------------------------------
+# Endpoint correctness across every phase: the Anthropic SDK appends
+# /v1/messages to baseUrl, so a baseUrl ending in /v1 yields /v1/v1/messages and
+# 404s on the real router. Any rejected POST means a wrong baseUrl shipped.
+WRONGPATH="$(jqcount '.method=="POST" and .rejected==true')"
+[ "$WRONGPATH" -eq 0 ] \
+  && ok "all routed POSTs hit /v1/messages (no /v1 doubling)" \
+  || bad "$WRONGPATH POST(s) hit a non-/v1/messages path -> would 404 on the real router"
+
+printf 'requests logged: %s\n' "$(wc -l <"$LOG" | tr -d ' ')"
+printf '\033[1m%s passed, %s failed\033[0m\n' "$PASS" "$FAIL"
+if [ "$FAIL" -ne 0 ]; then KEEP_WORK=1; echo "FAILED"; exit 1; fi
+echo "ALL GREEN"

--- a/install/pi-router/test/e2e.sh
+++ b/install/pi-router/test/e2e.sh
@@ -144,7 +144,11 @@ grep -q "weave-routed-model: claude-opus-4-8" "$WORK/main.out" \
 # -------------------------------------------------------------------------
 phase "Phase 3 — dispatch fan-out (real subagent processes)"
 # -------------------------------------------------------------------------
+# WEAVE_ROUTING_* are set on the PARENT on purpose: dispatch must NOT leak them
+# into children, so the subagent-knob assertion below (still 0.25/0.45) doubles
+# as the regression test for that env-isolation fix.
 with_timeout 120 env PI_CODING_AGENT_DIR="$PI_DIR" \
+  WEAVE_ROUTING_ALPHA=0.99 WEAVE_ROUTING_SPEED_WEIGHT=0.02 \
   pi -e "$EXT" --no-session --offline --model weave/claude-sonnet-4-6 \
   -p "__DISPATCH__ run two quick parallel checks." >"$WORK/dispatch.out" 2>&1 </dev/null || true
 
@@ -154,7 +158,7 @@ SUBAGENT_REQS="$(jqcount '.app=="pi-subagent"')"
 [ "$SUBAGENT_REQS" -ge 2 ] \
   && ok "spawned $SUBAGENT_REQS subagent requests (>=2 expected)" || bad "only $SUBAGENT_REQS subagent requests (want >=2)"
 [ "$(jqcount '.app=="pi-subagent" and .knobs["x-weave-routing-alpha"]=="0.25" and .knobs["x-weave-routing-speed-weight"]=="0.45" and .knobs["x-weave-routing-output-cost-ratio"]=="2" and .knobs["x-weave-routing-expected-output-tokens"]=="1500"')" -ge 2 ] \
-  && ok "subagents: speed/cheap knobs 0.25 / 0.45 / 2 / 1500" || bad "subagent knobs wrong"
+  && ok "subagents: speed/cheap knobs 0.25 / 0.45 / 2 / 1500 (parent WEAVE_ROUTING_* not inherited)" || bad "subagent knobs wrong (did parent WEAVE_ROUTING_* leak into children?)"
 [ "$(jqcount '.app=="pi-subagent" and (.user_id // "" | startswith("subagent:"))')" -ge 2 ] \
   && ok "subagents: metadata.user_id = subagent:<uuid>" || bad "subagent user_id wrong"
 UNIQUE_SUBAGENT_IDS="$(jq -s '[.[] | select(.app=="pi-subagent") | .user_id] | unique | length' "$LOG")"

--- a/install/pi-router/test/mock_router.py
+++ b/install/pi-router/test/mock_router.py
@@ -300,6 +300,7 @@ class Handler(BaseHTTPRequestHandler):
                 "email": self.headers.get("x-weave-user-email"),
                 "name": self.headers.get("x-weave-user-name"),
                 "knobs": {h: self.headers.get(h) for h in KNOB_HEADERS},
+                "marker_opt": self.headers.get("x-weave-routing-marker"),
                 "has_tool_result": tool_result_present,
                 "user_text": user_text[:60],
                 "served": served,

--- a/install/pi-router/test/mock_router.py
+++ b/install/pi-router/test/mock_router.py
@@ -1,0 +1,334 @@
+#!/usr/bin/env python3
+"""Mock Weave Router for the @workweave/pi-router end-to-end test.
+
+Speaks just enough of the Anthropic Messages API to drive a real pi process
+headlessly, with no real model spend and no network beyond localhost:
+
+  GET  /health, /validate    -> 200            (the install.sh --pi probes)
+  POST <any path>            -> Anthropic Messages response (SSE or JSON)
+
+It also *is* the model. To exercise the `dispatch` tool it returns a tool_use
+block for `dispatch` when the latest user turn contains DISPATCH_MARKER and no
+tool_result is present yet; once the tool_result comes back it answers with
+plain text so the agent loop terminates. Subagent calls (X-App: pi-subagent)
+always get plain text. Every response carries an `x-router-model` header so the
+extension's routed-model path fires.
+
+Every request is appended as one JSON object per line to MOCK_LOG so the e2e
+script can assert the header / knob / metadata.user_id shape. The router key is
+never logged in full -- only presence + last 4 chars.
+
+Env:
+  MOCK_PORT          listen port                       (default 8899)
+  MOCK_LOG           request log path (JSONL)          (default ./requests.jsonl)
+  MOCK_MAIN_MODEL    x-router-model for main requests  (default claude-opus-4-8)
+  MOCK_SUBAGENT_MODEL x-router-model for subagents     (default claude-haiku-4-5)
+  DISPATCH_MARKER    main-loop prompt trigger          (default __DISPATCH__)
+"""
+
+import json
+import os
+import sys
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+PORT = int(os.environ.get("MOCK_PORT", "8899"))
+LOG_PATH = os.environ.get("MOCK_LOG", os.path.join(os.getcwd(), "requests.jsonl"))
+MAIN_MODEL = os.environ.get("MOCK_MAIN_MODEL", "claude-opus-4-8")
+SUBAGENT_MODEL = os.environ.get("MOCK_SUBAGENT_MODEL", "claude-haiku-4-5")
+DISPATCH_MARKER = os.environ.get("DISPATCH_MARKER", "__DISPATCH__")
+
+# The real router serves the Anthropic Messages API at exactly this path. We
+# reject anything else with 404 so a wrong baseUrl (e.g. a doubled /v1 from the
+# Anthropic SDK appending /v1/messages to a baseUrl that already ends in /v1)
+# fails the test instead of being silently absorbed by a catch-all.
+MESSAGES_PATH = "/v1/messages"
+
+KNOB_HEADERS = (
+    "x-weave-routing-alpha",
+    "x-weave-routing-speed-weight",
+    "x-weave-routing-output-cost-ratio",
+    "x-weave-routing-expected-output-tokens",
+)
+DISPATCH_TASKS = [
+    {"prompt": "Reply with exactly: SUBAGENT_ONE_OK"},
+    {"prompt": "Reply with exactly: SUBAGENT_TWO_OK"},
+]
+
+_log_lock = threading.Lock()
+
+
+def log_request(record: dict) -> None:
+    line = json.dumps(record, separators=(",", ":"))
+    with _log_lock:
+        with open(LOG_PATH, "a", encoding="utf-8") as fh:
+            fh.write(line + "\n")
+    print(
+        f"[mock] {record['method']} {record['path']} "
+        f"app={record.get('app')} user_id={record.get('user_id')} "
+        f"served={record.get('served', '-')}",
+        file=sys.stderr,
+        flush=True,
+    )
+
+
+def latest_user_text(messages: list) -> str:
+    for msg in reversed(messages):
+        if not isinstance(msg, dict) or msg.get("role") != "user":
+            continue
+        content = msg.get("content")
+        if isinstance(content, str):
+            return content
+        if isinstance(content, list):
+            parts = [
+                b.get("text", "")
+                for b in content
+                if isinstance(b, dict) and b.get("type") == "text"
+            ]
+            return " ".join(parts)
+        return ""
+    return ""
+
+
+def has_tool_result(messages: list) -> bool:
+    for msg in messages:
+        if not isinstance(msg, dict):
+            continue
+        content = msg.get("content")
+        if isinstance(content, list):
+            for block in content:
+                if isinstance(block, dict) and block.get("type") == "tool_result":
+                    return True
+    return False
+
+
+class Handler(BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"
+
+    def log_message(self, *_args) -> None:  # silence the default access log
+        return
+
+    # ---- helpers -------------------------------------------------------
+
+    def _send_json(self, code: int, obj: dict, extra_headers: dict | None = None) -> None:
+        payload = json.dumps(obj).encode("utf-8")
+        self.send_response(code)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(payload)))
+        for key, val in (extra_headers or {}).items():
+            self.send_header(key, val)
+        self.end_headers()
+        try:
+            self.wfile.write(payload)
+        except BrokenPipeError:
+            pass
+
+    def _send_sse(self, events: list, routed_model: str) -> None:
+        body = "".join(
+            f"event: {ev}\ndata: {json.dumps(data)}\n\n" for ev, data in events
+        ).encode("utf-8")
+        self.send_response(200)
+        self.send_header("Content-Type", "text/event-stream")
+        self.send_header("Content-Length", str(len(body)))
+        self.send_header("x-router-model", routed_model)
+        self.end_headers()
+        try:
+            self.wfile.write(body)
+        except BrokenPipeError:
+            pass
+
+    # ---- response builders --------------------------------------------
+
+    @staticmethod
+    def _message_obj(block: dict, stop_reason: str, routed_model: str) -> dict:
+        return {
+            "id": "msg_mock",
+            "type": "message",
+            "role": "assistant",
+            "model": routed_model,
+            "content": [block],
+            "stop_reason": stop_reason,
+            "stop_sequence": None,
+            "usage": {"input_tokens": 12, "output_tokens": 8},
+        }
+
+    @staticmethod
+    def _sse_events(block: dict, stop_reason: str, routed_model: str) -> list:
+        start_msg = {
+            "id": "msg_mock",
+            "type": "message",
+            "role": "assistant",
+            "model": routed_model,
+            "content": [],
+            "stop_reason": None,
+            "stop_sequence": None,
+            "usage": {"input_tokens": 12, "output_tokens": 1},
+        }
+        events = [("message_start", {"type": "message_start", "message": start_msg})]
+        if block["type"] == "text":
+            events += [
+                (
+                    "content_block_start",
+                    {
+                        "type": "content_block_start",
+                        "index": 0,
+                        "content_block": {"type": "text", "text": ""},
+                    },
+                ),
+                (
+                    "content_block_delta",
+                    {
+                        "type": "content_block_delta",
+                        "index": 0,
+                        "delta": {"type": "text_delta", "text": block["text"]},
+                    },
+                ),
+            ]
+        else:  # tool_use
+            events += [
+                (
+                    "content_block_start",
+                    {
+                        "type": "content_block_start",
+                        "index": 0,
+                        "content_block": {
+                            "type": "tool_use",
+                            "id": block["id"],
+                            "name": block["name"],
+                            "input": {},
+                        },
+                    },
+                ),
+                (
+                    "content_block_delta",
+                    {
+                        "type": "content_block_delta",
+                        "index": 0,
+                        "delta": {
+                            "type": "input_json_delta",
+                            "partial_json": json.dumps(block["input"]),
+                        },
+                    },
+                ),
+            ]
+        events += [
+            ("content_block_stop", {"type": "content_block_stop", "index": 0}),
+            (
+                "message_delta",
+                {
+                    "type": "message_delta",
+                    "delta": {"stop_reason": stop_reason, "stop_sequence": None},
+                    "usage": {"output_tokens": 8},
+                },
+            ),
+            ("message_stop", {"type": "message_stop"}),
+        ]
+        return events
+
+    # ---- handlers ------------------------------------------------------
+
+    def do_GET(self) -> None:  # noqa: N802 (stdlib naming)
+        path = self.path.split("?")[0]
+        log_request({"method": "GET", "path": path, "app": self.headers.get("x-app")})
+        self._send_json(200, {"status": "ok"})
+
+    def do_POST(self) -> None:  # noqa: N802 (stdlib naming)
+        length = int(self.headers.get("content-length") or 0)
+        raw = self.rfile.read(length) if length else b""  # always drain the body
+        path = self.path.split("?")[0]
+
+        if path != MESSAGES_PATH:
+            log_request(
+                {"method": "POST", "path": path, "app": self.headers.get("x-app"), "rejected": True}
+            )
+            self._send_json(
+                404,
+                {"type": "error", "error": {"type": "not_found_error", "message": f"no route for POST {path}"}},
+            )
+            return
+
+        try:
+            body = json.loads(raw or b"{}")
+        except json.JSONDecodeError:
+            body = {}
+
+        messages = body.get("messages") or []
+        app = self.headers.get("x-app") or "pi"
+        is_subagent = app == "pi-subagent"
+        key = self.headers.get("x-weave-router-key") or ""
+        metadata = body.get("metadata") or {}
+        user_text = latest_user_text(messages)
+        tool_result_present = has_tool_result(messages)
+        stream = bool(body.get("stream"))
+
+        want_dispatch = (
+            DISPATCH_MARKER in user_text and not is_subagent and not tool_result_present
+        )
+        routed_model = SUBAGENT_MODEL if is_subagent else MAIN_MODEL
+
+        if want_dispatch:
+            block = {
+                "type": "tool_use",
+                "id": "toolu_mock_dispatch",
+                "name": "dispatch",
+                "input": {"tasks": DISPATCH_TASKS},
+            }
+            stop_reason = "tool_use"
+            served = "tool_use"
+        else:
+            if is_subagent:
+                reply = "SUBAGENT_OK"
+            elif tool_result_present:
+                reply = "DISPATCH_COMPLETE_OK"
+            else:
+                reply = "MAIN_LOOP_OK"
+            block = {"type": "text", "text": reply}
+            stop_reason = "end_turn"
+            served = "text"
+
+        log_request(
+            {
+                "method": "POST",
+                "path": path,
+                "rejected": False,
+                "app": app,
+                "model": body.get("model"),
+                "stream": stream,
+                "user_id": metadata.get("user_id"),
+                "key_present": bool(key),
+                "key_suffix": key[-4:] if key else "",
+                "email": self.headers.get("x-weave-user-email"),
+                "name": self.headers.get("x-weave-user-name"),
+                "knobs": {h: self.headers.get(h) for h in KNOB_HEADERS},
+                "has_tool_result": tool_result_present,
+                "user_text": user_text[:60],
+                "served": served,
+            }
+        )
+
+        if stream:
+            self._send_sse(self._sse_events(block, stop_reason, routed_model), routed_model)
+        else:
+            self._send_json(
+                200,
+                self._message_obj(block, stop_reason, routed_model),
+                extra_headers={"x-router-model": routed_model},
+            )
+
+
+def main() -> None:
+    open(LOG_PATH, "w", encoding="utf-8").close()  # truncate per run
+    server = ThreadingHTTPServer(("127.0.0.1", PORT), Handler)
+    print(
+        f"[mock] listening on http://127.0.0.1:{PORT}  log={LOG_PATH}",
+        file=sys.stderr,
+        flush=True,
+    )
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        pass
+
+
+if __name__ == "__main__":
+    main()

--- a/install/pi-router/test/opencode_smoke.sh
+++ b/install/pi-router/test/opencode_smoke.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+#
+# Endpoint smoke test for the `install.sh --opencode` target.
+#
+# opencode routes through a DIFFERENT SDK than pi: @ai-sdk/anthropic (Vercel),
+# which appends only /messages to baseURL — so opencode's config correctly keeps
+# the /v1 suffix (baseURL = <url>/v1 -> /v1/messages). This is the OPPOSITE of
+# pi's @anthropic-ai/sdk, which appends /v1/messages to a root baseURL. This
+# guard proves opencode keeps landing on /v1/messages so nobody "aligns" the two
+# baseURLs and breaks one. Reuses mock_router.py (404s any path != /v1/messages).
+#
+# Requires: opencode, jq, python3, curl. Run from anywhere:
+#   install/pi-router/test/opencode_smoke.sh
+#
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+INSTALL_SH="$(cd "$SCRIPT_DIR/../.." && pwd)/install.sh"
+MOCK="$SCRIPT_DIR/mock_router.py"
+
+PORT="${MOCK_PORT:-8911}"
+BASE_URL="http://127.0.0.1:$PORT"
+
+for tool in opencode jq python3 curl; do
+  command -v "$tool" >/dev/null 2>&1 || { echo "FATAL: '$tool' not on PATH"; exit 2; }
+done
+[ -f "$INSTALL_SH" ] || { echo "FATAL: installer not found: $INSTALL_SH"; exit 2; }
+[ -f "$MOCK" ]       || { echo "FATAL: mock not found: $MOCK"; exit 2; }
+
+WORK="$(mktemp -d)"
+LOG="$WORK/requests.jsonl"
+MOCK_PID=""
+KEEP_WORK=0
+cleanup() {
+  [ -n "$MOCK_PID" ] && kill "$MOCK_PID" 2>/dev/null || true
+  [ -n "$MOCK_PID" ] && wait "$MOCK_PID" 2>/dev/null || true
+  [ "$KEEP_WORK" = "1" ] && echo "diagnostics preserved in $WORK" || rm -rf "$WORK"
+}
+trap cleanup EXIT
+
+export WEAVE_ROUTER_KEY="rk_oc_smoke_key"
+export WEAVE_USER_EMAIL="oc@workweave.ai"
+export WEAVE_USER_NAME="OC Smoke"
+
+PASS=0; FAIL=0
+ok()  { printf '  \033[32mPASS\033[0m %s\n' "$1"; PASS=$((PASS + 1)); }
+bad() { printf '  \033[31mFAIL\033[0m %s\n' "$1"; FAIL=$((FAIL + 1)); }
+jqcount() { jq -s "[.[] | select($1)] | length" "$LOG"; }
+
+MOCK_LOG="$LOG" MOCK_PORT="$PORT" python3 "$MOCK" &
+MOCK_PID=$!
+for _ in $(seq 1 50); do curl -fsS "$BASE_URL/health" >/dev/null 2>&1 && break; sleep 0.1; done
+curl -fsS "$BASE_URL/health" >/dev/null 2>&1 || { echo "FATAL: mock did not come up"; exit 2; }
+
+printf '\033[1m== install (install.sh --opencode --dir) ==\033[0m\n'
+bash "$INSTALL_SH" --opencode --base-url "$BASE_URL" --dir "$WORK" >"$WORK/install.out" 2>&1 </dev/null || true
+jq -e --arg u "$BASE_URL/v1" '.provider.weave.options.baseURL == $u' "$WORK/opencode.json" >/dev/null 2>&1 \
+  && ok "opencode.json baseURL = $BASE_URL/v1 (Vercel SDK convention — keeps /v1)" \
+  || bad "opencode.json baseURL wrong (see $WORK/install.out)"
+jq -e '.provider.weave.npm == "@ai-sdk/anthropic"' "$WORK/opencode.json" >/dev/null 2>&1 \
+  && ok "opencode provider uses @ai-sdk/anthropic" || bad "opencode provider npm wrong"
+
+printf '\033[1m== run (opencode run, headless, isolated XDG) ==\033[0m\n'
+mkdir -p "$WORK/xdg"
+(
+  cd "$WORK" || exit 1
+  XDG_CONFIG_HOME="$WORK/xdg" opencode run "say hi in three words" >"$WORK/oc.out" 2>&1 </dev/null
+) &
+RPID=$!
+( sleep 150; kill "$RPID" 2>/dev/null ) & WD=$!
+disown "$WD" 2>/dev/null || true
+wait "$RPID" 2>/dev/null || true
+kill "$WD" 2>/dev/null || true
+
+[ "$(jqcount '.method=="POST" and .app=="opencode" and .path=="/v1/messages" and .rejected==false')" -ge 1 ] \
+  && ok "opencode hit /v1/messages (served, app=opencode)" \
+  || bad "opencode did not reach /v1/messages (see $WORK/oc.out)"
+WRONG="$(jqcount '.method=="POST" and .rejected==true')"
+[ "$WRONG" -eq 0 ] \
+  && ok "no /v1 doubling — every opencode POST hit /v1/messages" \
+  || bad "$WRONG opencode POST(s) hit a wrong path -> would 404 on the real router"
+
+printf '\033[1m== Result ==\033[0m\n'
+printf '\033[1m%s passed, %s failed\033[0m\n' "$PASS" "$FAIL"
+if [ "$FAIL" -ne 0 ]; then KEEP_WORK=1; echo "FAILED"; exit 1; fi
+echo "ALL GREEN"

--- a/install/uninstall.sh
+++ b/install/uninstall.sh
@@ -264,12 +264,17 @@ if [ "$target" = "pi" ]; then
   # settings.json: drop our package and revert defaults that still point at the
   # router. Leaving defaultProvider="weave" after removing the provider would
   # break pi startup, so reverting is the correct reverse of the install.
+  # defaultModel is reverted ONLY when defaultProvider was "weave" (the state
+  # install creates): install sets defaultModel only when it was empty, so a user
+  # who independently picked claude-sonnet-4-6 with their own provider keeps it.
   if [ -f "$pi_settings_file" ]; then
     cleaned="$(jq '
       (if .packages then .packages -= ["npm:@workweave/pi-router"] else . end)
       | (if (.packages // []) == [] then del(.packages) else . end)
-      | (if .defaultProvider == "weave" then del(.defaultProvider) else . end)
-      | (if .defaultModel == "claude-sonnet-4-6" then del(.defaultModel) else . end)
+      | (if .defaultProvider == "weave"
+           then del(.defaultProvider)
+                | (if .defaultModel == "claude-sonnet-4-6" then del(.defaultModel) else . end)
+           else . end)
     ' "$pi_settings_file")"
     printf '%s\n' "$cleaned" >"$pi_settings_file"
     if [ "$(jq -r 'keys | length' "$pi_settings_file" 2>/dev/null || echo 0)" = "0" ]; then

--- a/install/uninstall.sh
+++ b/install/uninstall.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Weave Router uninstaller for Claude Code, Codex, and opencode.
+# Weave Router uninstaller for Claude Code, Codex, opencode, and pi.
 #
 # Default target is Claude Code: removes the env vars, statusLine, and local
 # router auth that install.sh added; leaves the rest of settings.json
@@ -9,12 +9,15 @@
 # config.toml — anything outside the markers is preserved. Pass --opencode
 # to strip the `provider.weave` block (and the top-level `model` key when
 # it points at the router) from opencode.json; other providers and user
-# settings are preserved.
+# settings are preserved. Pass --pi to strip the `weave` provider from
+# pi's models.json, drop @workweave/pi-router from settings.json, revert the
+# weave defaults, and remove the router key file.
 #
 # Usage:
 #   npx @workweave/router --uninstall                            # Claude Code, user scope
 #   npx @workweave/router --uninstall --codex                    # Codex, user scope
 #   npx @workweave/router --uninstall --opencode                 # opencode, user scope
+#   npx @workweave/router --uninstall --pi                       # pi, user scope
 #   npx @workweave/router --uninstall --scope project            # run inside the repo
 #   npx @workweave/router --uninstall --dir /tmp/test            # --dir alone (user scope, .weave/)
 #   npx @workweave/router --uninstall --scope project --dir /tmp # --dir + project scope (.claude/)
@@ -59,6 +62,9 @@ while [ $# -gt 0 ]; do
     --opencode)
       target="opencode"; shift
       ;;
+    --pi)
+      target="pi"; shift
+      ;;
     --claude)
       # No-op selector for symmetry with --codex / --opencode and install.sh's
       # --claude. Lets `./install.sh --uninstall --claude` (which forwards
@@ -77,7 +83,7 @@ while [ $# -gt 0 ]; do
   esac
 done
 
-if { [ "$target" = "claude" ] || [ "$target" = "opencode" ]; } && ! command -v jq >/dev/null 2>&1; then
+if { [ "$target" = "claude" ] || [ "$target" = "opencode" ] || [ "$target" = "pi" ]; } && ! command -v jq >/dev/null 2>&1; then
   err "jq is required for the $target uninstall path."
   exit 1
 fi
@@ -185,6 +191,106 @@ if [ "$target" = "opencode" ]; then
     ok "Weave Router uninstalled from $install_dir (opencode)."
   else
     ok "Weave Router uninstalled (opencode, scope=$scope)."
+  fi
+  exit 0
+fi
+
+# ---------- pi uninstall path ----------
+
+if [ "$target" = "pi" ]; then
+  # Resolve the pi agent dir based on scope/dir. Mirrors install.sh: user scope
+  # is pi's default ~/.pi/agent; project/--dir scope is a repo-local .pi.
+  if [ -n "$install_dir" ]; then
+    install_dir="$(cd "$install_dir" 2>/dev/null && pwd || echo "$install_dir")"
+    pi_dir="$install_dir/.pi"
+    refuse_if_symlink "$pi_dir"
+  elif [ "$scope" = "user" ]; then
+    pi_dir="$HOME/.pi/agent"
+  else
+    # Project scope: same prompt + git-root fallback as the opencode path.
+    project_dir=""
+    if [ "$scope_explicit" = "false" ] && [ -r /dev/tty ]; then
+      default_project_dir="$(pwd)"
+      printf "Project directory to uninstall from [default: %s]: " "$default_project_dir"
+      read -r project_dir_choice </dev/tty || project_dir_choice=""
+      project_dir="${project_dir_choice:-$default_project_dir}"
+      case "$project_dir" in
+        "~")    project_dir="$HOME" ;;
+        "~/"*)  project_dir="$HOME/${project_dir#~/}" ;;
+      esac
+      if [ ! -d "$project_dir" ]; then
+        err "directory does not exist: $project_dir"
+        exit 1
+      fi
+      project_dir="$(cd "$project_dir" && pwd)"
+    fi
+    if [ -n "${project_dir:-}" ]; then
+      pi_dir="$project_dir/.pi"
+    else
+      if ! git_root="$(git rev-parse --show-toplevel 2>/dev/null)"; then
+        err "--scope project must be run inside a git repo, or use --dir <path>."
+        exit 1
+      fi
+      pi_dir="$git_root/.pi"
+    fi
+    refuse_if_symlink "$pi_dir"
+  fi
+
+  pi_models_file="$pi_dir/models.json"
+  pi_settings_file="$pi_dir/settings.json"
+  pi_key_file="$pi_dir/.weave_router_key"
+  refuse_if_symlink "$pi_models_file"
+  refuse_if_symlink "$pi_settings_file"
+  refuse_if_symlink "$pi_key_file"
+
+  # models.json: drop provider.weave; remove the file if nothing else remains.
+  # Other providers/models the user added are preserved.
+  if [ -f "$pi_models_file" ]; then
+    cleaned="$(jq '
+      (if .providers.weave then del(.providers.weave) else . end)
+      | (if (.providers // {}) == {} then del(.providers) else . end)
+    ' "$pi_models_file")"
+    printf '%s\n' "$cleaned" >"$pi_models_file"
+    if [ "$(jq -r 'keys | length' "$pi_models_file" 2>/dev/null || echo 0)" = "0" ]; then
+      rm -f "$pi_models_file"
+      ok "Removed empty $pi_models_file"
+    else
+      ok "Cleaned $pi_models_file"
+    fi
+  else
+    info "No pi models config at $pi_models_file (already uninstalled?)"
+  fi
+
+  # settings.json: drop our package and revert defaults that still point at the
+  # router. Leaving defaultProvider="weave" after removing the provider would
+  # break pi startup, so reverting is the correct reverse of the install.
+  if [ -f "$pi_settings_file" ]; then
+    cleaned="$(jq '
+      (if .packages then .packages -= ["npm:@workweave/pi-router"] else . end)
+      | (if (.packages // []) == [] then del(.packages) else . end)
+      | (if .defaultProvider == "weave" then del(.defaultProvider) else . end)
+      | (if .defaultModel == "claude-sonnet-4-6" then del(.defaultModel) else . end)
+    ' "$pi_settings_file")"
+    printf '%s\n' "$cleaned" >"$pi_settings_file"
+    if [ "$(jq -r 'keys | length' "$pi_settings_file" 2>/dev/null || echo 0)" = "0" ]; then
+      rm -f "$pi_settings_file"
+      ok "Removed empty $pi_settings_file"
+    else
+      ok "Cleaned $pi_settings_file"
+    fi
+  else
+    info "No pi settings at $pi_settings_file (already uninstalled?)"
+  fi
+
+  if [ -f "$pi_key_file" ]; then
+    rm -f "$pi_key_file"
+    ok "Removed $pi_key_file"
+  fi
+
+  if [ -n "$install_dir" ]; then
+    ok "Weave Router uninstalled from $install_dir (pi)."
+  else
+    ok "Weave Router uninstalled (pi, scope=$scope)."
   fi
   exit 0
 fi


### PR DESCRIPTION
## What

Adds a **`--pi` installer target** and a new **`@workweave/pi-router`** pi extension, so the [`pi` coding agent](https://www.npmjs.com/package/@mariozechner/pi-coding-agent) routes every request through the Weave Router — automatic per-request model selection, quality/speed knob biasing, sticky sessions, and a parallel context-isolated subagent tool. Mirrors the existing `--opencode` target.

## Why

`pi` is fast and native-Anthropic but has no subagents and no built-in router integration. Routing all pi traffic through the trained router *is* the per-task model selector; knob headers bias it (quality on the driver loop, speed+cheap on fan-out), session pins keep the main loop steady, and a new `dispatch` tool fans work out into isolated child `pi` processes so only conclusions return to the main context.

## Changes

**`install/pi-router/` — `@workweave/pi-router`** (TypeScript, jiti-loaded, peerDeps only):
- Registers a **new** `weave` provider (never overrides built-in `anthropic` — that would hijack the Claude OAuth token).
- Per-process routing-knob headers (static, because `before_provider_request` can't set headers): quality on the main loop, speed+cheap in subagents (`WEAVE_PI_SUBAGENT`), cheapest for compaction.
- `metadata.user_id` signaling: `pi:<session>` (sticky pin) / `subagent:<uuid>` (own pin + server-side SubAgentDispatch).
- `dispatch` tool: parallel subagents as child `pi --print --mode json --no-session -e <self>` processes (read-only by default, concurrency 4, per-child timeout, SIGTERM→SIGKILL); only each child's final text returns.
- Routed-model status display (`x-router-model`); catastrophic-bash safety gate (`WEAVE_NO_SAFETY=1` to disable); experimental cheap-compaction scaffold (off unless `WEAVE_CHEAP_COMPACTION=1`).
- Base URL / key resolve from env → installer key file → the installed `models.json`, so the extension always agrees with how the user installed (hosted, `--local`, or custom).

**`install/install.sh` + `install/uninstall.sh`**: `--pi` everywhere `--opencode` lives (picker, arg parse, banner, re-run hint, tool/jq checks, docs); idempotent `jq` writers for `~/.pi/agent/models.json` + `settings.json`; `0600` key file; project/`--dir` scope uses a repo-local `.pi` launched via `PI_CODING_AGENT_DIR` (pi has no project-level models.json — mirrors Codex's `CODEX_HOME`); `/health`+`/validate` probes; per-token billing note. `uninstall --pi` reverses everything while preserving unrelated user config.

**`.github/workflows/publish_npm_pi_router.yml`**: OIDC trusted publish on `pi-router-v*` tags (independent of the installer's `router-v*` cadence).

## Validation

- ✅ Extension loads via jiti (pi's real mechanism) in **both** main and subagent roles; registers `weave` + 4 models; no-ops cleanly without a key.
- ✅ `tsc --strict` against pi's actual published types — clean.
- ✅ Installer: fresh write, idempotent re-run, merge into pre-existing config (preserves user providers/packages, doesn't clobber `defaultProvider`), full + partial uninstall; `bash -n` clean.
- ✅ pi reads the generated `models.json` (all 4 weave models list); installer `/health` + `/validate` probes succeed against a live endpoint.
- ⚠️ A full live request **round-trip** (pi → router → response, dispatch spawning live children) was **not** captured: in this headless `pi --print` sandbox, pi resolves the `weave` provider but emits no provider HTTP call (instant empty `stop`, zero usage). This **reproduces with `--no-extensions` and a hand-written `models.json`**, so it's a pi headless-mode behavior, not this code. The request *shape* (knob headers + `metadata.user_id`) is verified via the generated `models.json` and the typechecked `before_provider_request` handler.

**Recommended on merge:** `WEAVE_ROUTER_KEY=rk_… npx -y @workweave/router --pi --local`, then an interactive `pi "explain this repo"` to confirm a live routed turn + `dispatch`.

## Ordering / follow-ups

- Publish: tag `pi-router-v0.1.0` after merge so `packages: ["npm:@workweave/pi-router"]` resolves.
- The WorkWeave-side installer mirror + `GenerateInstallCommandPi*` + GraphQL/frontend wiring is a **separate follow-up PR gated on this landing** — its drift test compares `install_template.sh` byte-for-byte against this `install.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
