### PR TITLE
feat(proxy): opt out of in-band routing marker via X-Weave-Routing-Marker

### DIFF
--- a/internal/proxy/gemini.go
+++ b/internal/proxy/gemini.go
@@ -158,7 +158,7 @@ func (s *Service) ProxyGeminiGenerateContent(ctx context.Context, body []byte, w
 	proxyStart := time.Now()
 	var extractor *otel.UsageExtractor
 	var sink http.ResponseWriter = w
-	if marker := routingMarkerFor(routeRes); marker != "" {
+	if marker := suppressMarkerIfRequested(r.Header, routingMarkerFor(routeRes)); marker != "" {
 		mw := translate.NewGeminiRoutingMarkerWriter(sink, marker)
 		// Flush marker + HTTP 200 immediately so TTFB is decoupled from
 		// upstream prefill. Locks status to 200.

--- a/internal/proxy/marker_optout_internal_test.go
+++ b/internal/proxy/marker_optout_internal_test.go
@@ -1,0 +1,40 @@
+package proxy
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestSuppressMarkerIfRequested pins the opt-out decision: the routing marker is
+// dropped only for the recognized disable values, and preserved otherwise.
+func TestSuppressMarkerIfRequested(t *testing.T) {
+	const marker = "✦ **Weave Router** → deepseek/deepseek-v4-flash · best pick for this turn\n\n"
+	cases := []struct {
+		name      string
+		setHeader bool
+		value     string
+		want      string
+	}{
+		{name: "absent header keeps marker", setHeader: false, want: marker},
+		{name: "off suppresses", setHeader: true, value: "off", want: ""},
+		{name: "OFF is case-insensitive", setHeader: true, value: "OFF", want: ""},
+		{name: "surrounding whitespace tolerated", setHeader: true, value: "  off  ", want: ""},
+		{name: "false suppresses", setHeader: true, value: "false", want: ""},
+		{name: "0 suppresses", setHeader: true, value: "0", want: ""},
+		{name: "none suppresses", setHeader: true, value: "none", want: ""},
+		{name: "on keeps marker", setHeader: true, value: "on", want: marker},
+		{name: "unrecognized value keeps marker", setHeader: true, value: "yes", want: marker},
+		{name: "empty value keeps marker", setHeader: true, value: "", want: marker},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			h := http.Header{}
+			if tc.setHeader {
+				h.Set(routingMarkerHeader, tc.value)
+			}
+			assert.Equal(t, tc.want, suppressMarkerIfRequested(h, marker))
+		})
+	}
+}

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -135,6 +135,26 @@ type InstallationExcludedModelsContextKey struct{}
 // installationExcludedModelsFromContext returns the per-installation exclusion
 // list stashed on ctx by the auth middleware, or nil when none is present.
 
+// routingMarkerHeader lets a client suppress the in-band "✦ **Weave Router** → …"
+// routing badge. Programmatic clients that surface the routed model out-of-band
+// (e.g. pi reads the x-router-model response header into its status bar) and
+// render the assistant message into their own UI can't show a standalone marker
+// text block without it hiding the actual answer. Any of off/false/0/none
+// disables it; absent or anything else keeps the default.
+const routingMarkerHeader = "X-Weave-Routing-Marker"
+
+// suppressMarkerIfRequested returns "" when the request opted out of the routing
+// marker via routingMarkerHeader, otherwise the marker unchanged. Scoped to the
+// per-turn routing badge; the no-progress / loop / force-model markers are
+// standalone single-block messages and are intentionally always emitted.
+func suppressMarkerIfRequested(h http.Header, marker string) string {
+	switch strings.ToLower(strings.TrimSpace(h.Get(routingMarkerHeader))) {
+	case "off", "false", "0", "none":
+		return ""
+	}
+	return marker
+}
+
 // routingMarkerFor builds the "brand → model · note" snippet emitted at the
 // start of every cross-format streamed response.
 func routingMarkerFor(res turnLoopResult) string {
@@ -960,7 +980,7 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 				usage = extractor
 			}
 			translator := translate.NewAnthropicSSETranslator(sink, d.Model, usage).
-				WithRoutingMarker(routingMarkerFor(routeRes)).
+				WithRoutingMarker(suppressMarkerIfRequested(r.Header, routingMarkerFor(routeRes))).
 				WithEstimatedInputTokens(feats.Tokens)
 			if err := translator.Prelude(env.Stream()); err != nil {
 				log.Error("Anthropic SSE prelude failed (OpenAI upstream)", "err", err)
@@ -998,7 +1018,7 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 			}
 			// SSE chain: Gemini → OpenAI → Anthropic.
 			anthropicTr := translate.NewAnthropicSSETranslator(sink, d.Model, usage).
-				WithRoutingMarker(routingMarkerFor(routeRes)).
+				WithRoutingMarker(suppressMarkerIfRequested(r.Header, routingMarkerFor(routeRes))).
 				WithEstimatedInputTokens(feats.Tokens)
 			if err := anthropicTr.Prelude(env.Stream()); err != nil {
 				log.Error("Anthropic SSE prelude failed (Gemini upstream)", "err", err)
@@ -1839,7 +1859,7 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 		sink = captureW
 	}
 
-	marker := routingMarkerFor(routeRes)
+	marker := suppressMarkerIfRequested(r.Header, routingMarkerFor(routeRes))
 	_, isResponses := w.(*translate.ResponsesWriter)
 	// markerSink wraps sink with an OpenAIRoutingMarkerWriter that emits
 	// the routing-marker chunk + HTTP 200 eagerly (Prelude). Skipped when


### PR DESCRIPTION
## Problem

The `✦ **Weave Router** → model · …` routing badge is prepended as a **standalone assistant text block** on cross-format (OpenAI/Gemini-upstream) responses. Human terminal clients (Claude Code, Codex, opencode) render the assistant message verbatim, so it just shows as a line above the answer — fine.

But a programmatic client like **pi** parses the message into its own TUI and already surfaces the routed model out-of-band (the `x-router-model` response header → status bar). For pi, the leading marker text block (content block 0) hides the actual answer (content block 1) — the user sees only "routed to deepseek-v4-flash" and no response. Confirmed by curling prod: the SSE has two text blocks, marker then answer.

## Fix

A request that sends `X-Weave-Routing-Marker: off` (also `false`/`0`/`none`) gets **no** marker, on every surface — `ProxyMessages` (×2 cross-format paths), `ProxyOpenAIChatCompletion`, and `ProxyGemini`. Default behavior is unchanged when the header is absent.

Scoped to the per-turn routing badge only; the no-progress / loop-detection / force-model markers are single-block status messages and still always emit.

The pi extension will set this header on every request (WorkWeave router PR #262). pi loses nothing — the routed model is still shown via the status bar.

## Test

- New unit test `TestSuppressMarkerIfRequested` (decision logic: off/false/0/none suppress; absent/on/unknown keep).
- `go build ./...` + `go vet ./internal/proxy/` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)