### PR TITLE
feat(observability): emit GCP-structured JSON logs in non-TTY environments

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -182,6 +182,11 @@ PUBSUB_SUBSCRIPTION_ROUTER_INVALIDATION=router-installation-invalidate
 # slog level: debug | info | warn | error.
 LOG_LEVEL=info
 
+# Log handler format: json | text | color (alias: tint). Unset = auto: a TTY
+# gets colorized output, everything else (Cloud Run, piped) gets GCP-structured
+# JSON so severity/timestamp/message map onto Cloud Logging fields.
+# LOG_FORMAT=json
+
 # Verbose proxy tracing. Off in production — these are very noisy.
 # ROUTER_DEBUG_WRITER_TRACE=false
 

--- a/.env.example
+++ b/.env.example
@@ -183,8 +183,9 @@ PUBSUB_SUBSCRIPTION_ROUTER_INVALIDATION=router-installation-invalidate
 LOG_LEVEL=info
 
 # Log handler format: json | text | color (alias: tint). Unset = auto: a TTY
-# gets colorized output, everything else (Cloud Run, piped) gets GCP-structured
-# JSON so severity/timestamp/message map onto Cloud Logging fields.
+# gets human-readable output (colorized unless NO_COLOR/LOG_COLOR disables it),
+# everything else (Cloud Run, piped) gets GCP-structured JSON so
+# severity/timestamp/message map onto Cloud Logging fields.
 # LOG_FORMAT=json
 
 # Verbose proxy tracing. Off in production — these are very noisy.

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,9 @@ require (
 	github.com/tidwall/gjson v1.18.0
 	github.com/tidwall/sjson v1.2.5
 	github.com/tink-crypto/tink-go/v2 v2.2.0
+	github.com/vlad-tokarev/sloggcp v0.0.0-20230820053939-1b7dbb8c7b58
 	go.opentelemetry.io/contrib/instrumentation/github.com/gin-gonic/gin/otelgin v0.61.0
+	go.opentelemetry.io/contrib/instrumentation/runtime v0.61.0
 	go.opentelemetry.io/otel v1.42.0
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v1.42.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.42.0
@@ -87,7 +89,6 @@ require (
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.61.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.61.0 // indirect
-	go.opentelemetry.io/contrib/instrumentation/runtime v0.61.0 // indirect
 	go.opentelemetry.io/otel/metric v1.42.0 // indirect
 	go.opentelemetry.io/otel/trace v1.42.0 // indirect
 	golang.org/x/arch v0.17.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -241,6 +241,8 @@ github.com/ugorji/go/codec v1.2.12 h1:9LC83zGrHhuUA9l16C9AHXAqEV/2wBQ4nkvumAE65E
 github.com/ugorji/go/codec v1.2.12/go.mod h1:UNopzCgEMSXjBc6AOMqYvWC1ktqTAfzJZUZgYf6w6lg=
 github.com/viant/afs v1.30.0 h1:dbgVVSCPwGHUgpgkWJ5gdjKBqssT7OV7Z2M81CjwZEY=
 github.com/viant/afs v1.30.0/go.mod h1:rScbFd9LJPGTM8HOI8Kjwee0AZ+MZMupAvFpPg+Qdj4=
+github.com/vlad-tokarev/sloggcp v0.0.0-20230820053939-1b7dbb8c7b58 h1:sqdArBvz81qKBllnqime5QDuIoiPb871K5N40hMnorY=
+github.com/vlad-tokarev/sloggcp v0.0.0-20230820053939-1b7dbb8c7b58/go.mod h1:h+csr3AM3SV5jTnXSvHPRPZdwoOg+TxGCWNmAcDolbA=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
 github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e h1:JVG44RsyaB9T2KIHavMF/ppJZNG9ZpyihvCd0w101no=

--- a/internal/observability/logger.go
+++ b/internal/observability/logger.go
@@ -11,6 +11,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/lmittmann/tint"
 	"github.com/mattn/go-isatty"
+	"github.com/vlad-tokarev/sloggcp"
 )
 
 const ginContextKey = "router_logger"
@@ -60,21 +61,55 @@ func initLogger() {
 	case "error":
 		level = slog.LevelError
 	}
-	var handler slog.Handler
-	if useColor() {
-		handler = tint.NewHandler(os.Stderr, &tint.Options{
-			Level:      level,
-			TimeFormat: time.Kitchen,
-		})
-	} else {
-		handler = slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: level})
-	}
-	slog.SetDefault(slog.New(handler))
+	slog.SetDefault(slog.New(newHandler(level)))
 }
 
-// useColor returns true when tint's ANSI-colored handler should be used.
-// Respects LOG_COLOR={1,true,yes,on} / {0,false,no,off}; otherwise auto-detects
-// based on whether stderr is a TTY and NO_COLOR is unset (https://no-color.org).
+// newHandler builds the slog handler for the resolved format. JSON output maps
+// attributes to GCP Cloud Logging fields (severity/time/message) via
+// sloggcp.ReplaceAttr so lines render correctly when the router runs on Cloud
+// Run; tint gives a colorized human-readable stream for local dev.
+func newHandler(level slog.Level) slog.Handler {
+	switch logFormat() {
+	case "json":
+		return slog.NewJSONHandler(os.Stderr, &slog.HandlerOptions{
+			Level:       level,
+			ReplaceAttr: sloggcp.ReplaceAttr,
+		})
+	case "text":
+		return slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: level})
+	case "tint":
+		return tint.NewHandler(os.Stderr, &tint.Options{Level: level, TimeFormat: time.Kitchen})
+	}
+	// Auto: a TTY (local dev) gets pretty colorized output; everything else
+	// (Cloud Run, piped, redirected) gets structured GCP JSON.
+	if useColor() {
+		return tint.NewHandler(os.Stderr, &tint.Options{Level: level, TimeFormat: time.Kitchen})
+	}
+	return slog.NewJSONHandler(os.Stderr, &slog.HandlerOptions{
+		Level:       level,
+		ReplaceAttr: sloggcp.ReplaceAttr,
+	})
+}
+
+// logFormat returns the explicitly requested handler format, or "" to let the
+// handler auto-detect based on whether stderr is a TTY. Honors
+// LOG_FORMAT={json,text,color,tint}.
+func logFormat() string {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv("LOG_FORMAT"))) {
+	case "json":
+		return "json"
+	case "text":
+		return "text"
+	case "color", "tint":
+		return "tint"
+	}
+	return ""
+}
+
+// useColor reports whether the auto format should pick tint's ANSI-colored
+// handler (vs structured JSON). Respects LOG_COLOR={1,true,yes,on} /
+// {0,false,no,off}; otherwise auto-detects based on whether stderr is a TTY and
+// NO_COLOR is unset (https://no-color.org).
 func useColor() bool {
 	switch strings.ToLower(strings.TrimSpace(os.Getenv("LOG_COLOR"))) {
 	case "1", "true", "yes", "on":

--- a/internal/observability/logger.go
+++ b/internal/observability/logger.go
@@ -80,10 +80,14 @@ func newHandler(level slog.Level) slog.Handler {
 	case "tint":
 		return tint.NewHandler(os.Stderr, &tint.Options{Level: level, TimeFormat: time.Kitchen})
 	}
-	// Auto: a TTY (local dev) gets pretty colorized output; everything else
-	// (Cloud Run, piped, redirected) gets structured GCP JSON.
+	// Auto: a TTY (local dev) gets human-readable output — colorized when color
+	// is enabled, plain text when NO_COLOR/LOG_COLOR disables it. Only non-TTY
+	// streams (Cloud Run, piped, redirected) get structured GCP JSON.
 	if useColor() {
 		return tint.NewHandler(os.Stderr, &tint.Options{Level: level, TimeFormat: time.Kitchen})
+	}
+	if isTerminal() {
+		return slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: level})
 	}
 	return slog.NewJSONHandler(os.Stderr, &slog.HandlerOptions{
 		Level:       level,
@@ -120,6 +124,13 @@ func useColor() bool {
 	if _, ok := os.LookupEnv("NO_COLOR"); ok {
 		return false
 	}
+	return isTerminal()
+}
+
+// isTerminal reports whether stderr is an interactive terminal, independent of
+// any color preference. The auto format uses this to keep TTY output
+// human-readable (text) rather than JSON when color is disabled.
+func isTerminal() bool {
 	return isatty.IsTerminal(os.Stderr.Fd()) || isatty.IsCygwinTerminal(os.Stderr.Fd())
 }
 


### PR DESCRIPTION
## What

The router's slog logger only had two handlers — tint (color) and plain text. On Cloud Run that meant unstructured text logs, and Cloud Logging couldn't pick up severity/timestamp/message fields.

This adds a JSON handler branch that maps attributes onto GCP Cloud Logging fields via `sloggcp.ReplaceAttr` — the same library and pinned version (`v0.0.0-20230820053939-1b7dbb8c7b58`) the main WorkWeave backend uses ([reference `log.go`](https://github.com/workweave/WorkWeave/blob/57e392e7e063cb60fc86d2dd40c56133a3114e81/backend/internal/pkg/log/log.go)).

## Format selection

Auto by default — no config needed in prod:

- **TTY** (local dev) → colorized tint output
- **non-TTY** (Cloud Run, piped, redirected) → GCP-structured JSON

Override with `LOG_FORMAT={json,text,color}`. `LOG_LEVEL` / `LOG_COLOR` / `NO_COLOR` behave as before.

## Behavior note

The auto-default for non-TTY changed from plain text → JSON. That's the intended improvement (Cloud Run gets structured logs with zero config); anyone who wants the old format can set `LOG_FORMAT=text`.

## Infra

No Terraform/deploy change required — nothing sets `LOG_FORMAT`/`LOG_COLOR` in the Dockerfile or deploy config, so the auto-detect activates on Cloud Run automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)