### PR TITLE
feat(router): tier-clamp + hard-pin select fastest model, not cheapest

### DIFF
--- a/cmd/router/main.go
+++ b/cmd/router/main.go
@@ -460,9 +460,9 @@ func main() {
 			if bundle, bErr := cluster.LoadBundle(version); bErr == nil {
 				meta, registry := bundle.Metadata, bundle.Registry
 				hardPinResolver = func(enabled map[string]struct{}) (string, string, bool) {
-					return cluster.CheapestModel(meta, registry, enabled)
+					return cluster.FastestModel(meta, registry, enabled)
 				}
-				logger.Info("Hard-pin resolver wired for byokOnly mode (per-request cheapest model from cluster bundle)", "version", version)
+				logger.Info("Hard-pin resolver wired for byokOnly mode (per-request fastest model from cluster bundle)", "version", version)
 			} else {
 				logger.Warn("Hard-pin resolver disabled: cluster bundle failed to load; byokOnly hard-pin will fall back to boot-time defaults", "err", bErr, "version", version)
 			}
@@ -472,11 +472,12 @@ func main() {
 	}
 
 	// Tier-clamp resolver enforces the requested-model ceiling. Loads the
-	// default cluster bundle once and, on each call, returns the cheapest
-	// deployed model whose capability tier is at or below the ceiling and
-	// whose provider is in the request's enabled set. Nil when the bundle
-	// can't load — the proxy then leaves all decisions un-clamped (preserves
-	// pre-tier-ceiling behavior).
+	// default cluster bundle once and, on each call, returns the fastest
+	// (by measured tok/s) deployed model whose capability tier is at or below
+	// the ceiling and whose provider is in the request's enabled set, falling
+	// back to cheapest when the bundle lacks speed annotations. Nil when the
+	// bundle can't load — the proxy then leaves all decisions un-clamped
+	// (preserves pre-tier-ceiling behavior).
 	var tierClampResolver func(map[string]struct{}, map[string]struct{}, catalog.Tier) (string, string, bool)
 	{
 		reqVersion := config.GetOr("ROUTER_CLUSTER_VERSION", cluster.LatestVersion)
@@ -485,7 +486,7 @@ func main() {
 				meta, registry := bundle.Metadata, bundle.Registry
 				tierClampResolver = func(enabled, excluded map[string]struct{}, ceiling catalog.Tier) (string, string, bool) {
 					allowed := catalog.AllowedAtOrBelow(ceiling)
-					return cluster.CheapestModelInSet(meta, registry, enabled, excluded, allowed)
+					return cluster.FastestModelInSet(meta, registry, enabled, excluded, allowed)
 				}
 				logger.Info("Tier-clamp resolver wired", "version", version)
 			} else {
@@ -1035,8 +1036,9 @@ func resolveDefaultBaselineModel() string {
 }
 
 // resolveHardPinModel returns the (provider, model) to use for compaction and
-// Explore hard-pins. Operator override wins; otherwise the cheapest model in
-// the default artifact bundle among available providers is selected.
+// Explore hard-pins. Operator override wins; otherwise the fastest model (by
+// measured tok/s) in the default artifact bundle among available providers is
+// selected, falling back to cheapest when the bundle lacks speed annotations.
 // Falls back to (defaultHardPinProvider, defaultHardPinModel) when no bundle is loadable.
 func resolveHardPinModel(available map[string]struct{}, logger *slog.Logger) (provider, model string) {
 	if m := config.GetOr("ROUTER_HARD_PIN_MODEL", ""); m != "" {
@@ -1055,9 +1057,9 @@ func resolveHardPinModel(available map[string]struct{}, logger *slog.Logger) (pr
 		logger.Warn("Hard-pin model: could not load bundle; using default", "err", err, "default_model", defaultHardPinModel)
 		return defaultHardPinProvider, defaultHardPinModel
 	}
-	p, m, ok := cluster.CheapestModel(bundle.Metadata, bundle.Registry, available)
+	p, m, ok := cluster.FastestModel(bundle.Metadata, bundle.Registry, available)
 	if !ok {
-		logger.Warn("Hard-pin model: no cost-annotated model found for available providers; using default", "default_model", defaultHardPinModel)
+		logger.Warn("Hard-pin model: no model found for available providers; using default", "default_model", defaultHardPinModel)
 		return defaultHardPinProvider, defaultHardPinModel
 	}
 	return p, m

--- a/internal/router/cluster/artifacts.go
+++ b/internal/router/cluster/artifacts.go
@@ -117,7 +117,15 @@ type ArtifactMetadata struct {
 	DeployedProviders []string           `yaml:"deployed_providers,omitempty"`
 	DeployedModels    []string           `yaml:"deployed_models,omitempty"`
 	CostPer1KInputUSD map[string]float64 `yaml:"cost_per_1k_input_usd,omitempty"`
-	Changelog         string             `yaml:"changelog,omitempty"`
+	// TokPerS holds measured median output throughput (tokens/sec) keyed by
+	// provider then model — e.g. TokPerS["google"]["gemini-3.1-flash-lite-preview"].
+	// Provider-keyed because the same model's throughput varies sharply by
+	// provider. Consumed by FastestModel to break the tier-clamp / hard-pin
+	// out of cost-only selection; absent or partial annotation degrades to
+	// cost-only via CheapestModel. Informational to the scorer (which carries
+	// its own speed_weight); only the clamp/hard-pin selectors read it.
+	TokPerS   map[string]map[string]float64 `yaml:"tok_per_s,omitempty"`
+	Changelog string                        `yaml:"changelog,omitempty"`
 	// CacheConfig carries per-version semantic-cache knobs.
 	CacheConfig *ArtifactCacheConfig `yaml:"cache_config,omitempty"`
 }
@@ -565,6 +573,62 @@ func cheapestModelFiltered(meta *ArtifactMetadata, registry *ModelRegistry, avai
 			model = e.Model
 			ok = true
 		}
+	}
+	return
+}
+
+// FastestModel returns the highest measured-throughput (tok/s) entry among
+// registry entries whose provider is in available. Throughput is read from
+// meta.TokPerS keyed by the resolved provider, so the same model on a slow
+// provider can lose to a different model on a fast one. Falls back to
+// CheapestModel when the bundle carries no usable speed annotation — it
+// never returns a worse decision than the cost-only selector.
+func FastestModel(meta *ArtifactMetadata, registry *ModelRegistry, available map[string]struct{}) (provider, model string, ok bool) {
+	return fastestModelFiltered(meta, registry, available, nil, nil)
+}
+
+// FastestModelInSet is FastestModel restricted to an allowlist and denylist.
+// Used by the tier-clamp resolver, where allowSet is the at-or-below-ceiling
+// model set.
+func FastestModelInSet(meta *ArtifactMetadata, registry *ModelRegistry, available, denySet, allowSet map[string]struct{}) (provider, model string, ok bool) {
+	return fastestModelFiltered(meta, registry, available, denySet, allowSet)
+}
+
+func fastestModelFiltered(meta *ArtifactMetadata, registry *ModelRegistry, available, denySet, allowSet map[string]struct{}) (provider, model string, ok bool) {
+	var bestSpeed float64 = -1
+	for _, e := range registry.DeployedModels {
+		resolved := resolveProviderFor(e.Model, e.Provider, available)
+		if resolved == "" {
+			continue
+		}
+		if allowSet != nil {
+			if _, allowed := allowSet[e.Model]; !allowed {
+				continue
+			}
+		}
+		if _, denied := denySet[e.Model]; denied {
+			continue
+		}
+		byModel, hasProvider := meta.TokPerS[resolved]
+		if !hasProvider {
+			continue
+		}
+		speed, hasSpeed := byModel[e.Model]
+		if !hasSpeed {
+			continue
+		}
+		if speed > bestSpeed {
+			bestSpeed = speed
+			provider = resolved
+			model = e.Model
+			ok = true
+		}
+	}
+	if !ok {
+		// No speed-annotated candidate resolved (un-annotated bundle, or
+		// every in-ceiling model lacks a tok/s entry). Preserve the
+		// established cost-only behavior rather than failing the clamp.
+		return cheapestModelFiltered(meta, registry, available, denySet, allowSet)
 	}
 	return
 }

--- a/internal/router/cluster/artifacts/v0.57/metadata.yaml
+++ b/internal/router/cluster/artifacts/v0.57/metadata.yaml
@@ -85,4 +85,24 @@ cost_per_1k_input_usd:
   qwen/qwen3-next-80b-a3b-instruct: 0.00045
   xiaomi/mimo-v2.5-pro: 0.00175
   z-ai/glm-5.1: 0.0022637342322749023
-changelog: "v0.57: measured Tier1 (tier1-20260526 Aider Polyglot) speed+verbosity overrides on v0.56 base (glm-5.1 alias). Real eval wall-clock sec/query + completion-token means replace AA timing/verbosity for the 9 evaluated models; deepseek-v4-pro/flash timeout-floor latency 200s/170s (ranked slowest). AA priors from glm-5.1 variant (aa_quality_priors_v0.56.json). Full 8013 prompts. Validated via true 80/20 holdout (v3.03): regret 0.125 vs v0.55 0.139. parent v0.56, PROMOTED."
+# Measured median output throughput (tokens/sec), provider -> model. Sourced
+# from production router_telemetry p50 over 30d (output_tokens>100). Read only
+# by the tier-clamp and hard-pin selectors (FastestModel) to prefer fast over
+# cheap; the scorer carries its own speed_weight and ignores this. Only the
+# nine models with adequate prod volume are annotated; un-annotated models
+# fall through to cost-only selection.
+tok_per_s:
+  google:
+    gemini-3.1-flash-lite-preview: 157.9
+    gemini-3.5-flash: 77.3
+    gemini-3.1-pro-preview: 35.1
+  fireworks:
+    moonshotai/kimi-k2.6: 63.7
+    deepseek/deepseek-v4-pro: 42.4
+  anthropic:
+    claude-haiku-4-5: 60.2
+    claude-opus-4-7: 55.3
+  deepinfra:
+    z-ai/glm-5.1: 26.4
+    deepseek/deepseek-v4-flash: 24.0
+changelog: "v0.57: measured Tier1 (tier1-20260526 Aider Polyglot) speed+verbosity overrides on v0.56 base (glm-5.1 alias). Real eval wall-clock sec/query + completion-token means replace AA timing/verbosity for the 9 evaluated models; deepseek-v4-pro/flash timeout-floor latency 200s/170s (ranked slowest). AA priors from glm-5.1 variant (aa_quality_priors_v0.56.json). Full 8013 prompts. Validated via true 80/20 holdout (v3.03): regret 0.125 vs v0.55 0.139. parent v0.56, PROMOTED. tok_per_s: added measured prod throughput (p50/30d) for clamp+hard-pin FastestModel selection (routing centroids/rankings unchanged)."

--- a/internal/router/cluster/artifacts_test.go
+++ b/internal/router/cluster/artifacts_test.go
@@ -9,6 +9,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"workweave/router/internal/router/catalog"
 )
 
 // buildCentroidsBlob produces centroids.bin bytes from in-memory data,
@@ -331,4 +333,147 @@ func TestCheapestModelInSet(t *testing.T) {
 		_, _, ok := CheapestModelInSet(meta, registry, available, deny, nil)
 		assert.False(t, ok)
 	})
+}
+
+func TestFastestModel(t *testing.T) {
+	// model-c is cheapest but slowest; model-a is fastest. A cost-only
+	// selector returns model-c — FastestModel must return model-a.
+	meta := &ArtifactMetadata{
+		CostPer1KInputUSD: map[string]float64{
+			"model-a": 3.00,
+			"model-b": 0.50,
+			"model-c": 0.10,
+		},
+		TokPerS: map[string]map[string]float64{
+			"anthropic": {"model-a": 150.0},
+			"google":    {"model-b": 80.0, "model-c": 20.0},
+		},
+	}
+	registry := &ModelRegistry{
+		DeployedModels: []DeployedEntry{
+			{Model: "model-a", Provider: "anthropic", BenchColumn: "col-a"},
+			{Model: "model-b", Provider: "google", BenchColumn: "col-b"},
+			{Model: "model-c", Provider: "google", BenchColumn: "col-c"},
+		},
+	}
+
+	t.Run("picks fastest across providers, not cheapest", func(t *testing.T) {
+		available := map[string]struct{}{"anthropic": {}, "google": {}}
+		p, m, ok := FastestModel(meta, registry, available)
+		require.True(t, ok)
+		assert.Equal(t, "anthropic", p)
+		assert.Equal(t, "model-a", m, "model-c is cheapest but slowest")
+	})
+
+	t.Run("speed is provider-keyed", func(t *testing.T) {
+		// Only google available: model-a's anthropic speed is unreachable,
+		// so the fastest reachable model is model-b (80) over model-c (20).
+		available := map[string]struct{}{"google": {}}
+		p, m, ok := FastestModel(meta, registry, available)
+		require.True(t, ok)
+		assert.Equal(t, "google", p)
+		assert.Equal(t, "model-b", m)
+	})
+
+	t.Run("falls back to cheapest when bundle has no tok_per_s", func(t *testing.T) {
+		metaNoSpeed := &ArtifactMetadata{CostPer1KInputUSD: meta.CostPer1KInputUSD}
+		available := map[string]struct{}{"anthropic": {}, "google": {}}
+		p, m, ok := FastestModel(metaNoSpeed, registry, available)
+		require.True(t, ok)
+		assert.Equal(t, "google", p)
+		assert.Equal(t, "model-c", m, "no speed data → cost-only cheapest")
+	})
+
+	t.Run("ok=false when no provider matches", func(t *testing.T) {
+		available := map[string]struct{}{"openai": {}}
+		_, _, ok := FastestModel(meta, registry, available)
+		assert.False(t, ok)
+	})
+}
+
+func TestFastestModelInSet(t *testing.T) {
+	meta := &ArtifactMetadata{
+		CostPer1KInputUSD: map[string]float64{
+			"flash-lite": 0.20, // cheapest-ish, fastest
+			"v4-flash":   0.10, // cheapest, slowest
+			"mid-model":  1.00,
+		},
+		TokPerS: map[string]map[string]float64{
+			"google":    {"flash-lite": 158.0, "mid-model": 35.0},
+			"deepinfra": {"v4-flash": 24.0},
+		},
+	}
+	registry := &ModelRegistry{
+		DeployedModels: []DeployedEntry{
+			{Model: "flash-lite", Provider: "google", BenchColumn: "col-fl"},
+			{Model: "v4-flash", Provider: "deepinfra", BenchColumn: "col-vf"},
+			{Model: "mid-model", Provider: "google", BenchColumn: "col-mid"},
+		},
+	}
+	available := map[string]struct{}{"google": {}, "deepinfra": {}}
+
+	t.Run("low-tier clamp prefers fast flash-lite over cheap v4-flash", func(t *testing.T) {
+		// Mirrors the real haiku-tier clamp: both models are in-ceiling;
+		// cost-only picks v4-flash (the slow one), FastestModel picks
+		// flash-lite.
+		allow := map[string]struct{}{"flash-lite": {}, "v4-flash": {}}
+		p, m, ok := FastestModelInSet(meta, registry, available, nil, allow)
+		require.True(t, ok)
+		assert.Equal(t, "google", p)
+		assert.Equal(t, "flash-lite", m)
+	})
+
+	t.Run("falls back to cheapest within allowSet when none annotated", func(t *testing.T) {
+		metaNoSpeed := &ArtifactMetadata{CostPer1KInputUSD: meta.CostPer1KInputUSD}
+		allow := map[string]struct{}{"flash-lite": {}, "v4-flash": {}}
+		p, m, ok := FastestModelInSet(metaNoSpeed, registry, available, nil, allow)
+		require.True(t, ok)
+		assert.Equal(t, "deepinfra", p)
+		assert.Equal(t, "v4-flash", m, "no speed → cheapest in allowSet")
+	})
+
+	t.Run("denySet excludes the fastest, falls to next fastest", func(t *testing.T) {
+		allow := map[string]struct{}{"flash-lite": {}, "mid-model": {}}
+		deny := map[string]struct{}{"flash-lite": {}}
+		p, m, ok := FastestModelInSet(meta, registry, available, deny, allow)
+		require.True(t, ok)
+		assert.Equal(t, "google", p)
+		assert.Equal(t, "mid-model", m, "flash-lite faster but denylisted")
+	})
+
+	t.Run("ok=false when allowSet has no available model", func(t *testing.T) {
+		allow := map[string]struct{}{"nope": {}}
+		_, _, ok := FastestModelInSet(meta, registry, available, nil, allow)
+		assert.False(t, ok)
+	})
+}
+
+// Integration guard against the real shipped bundle: the low-tier clamp
+// (the path that funneled production traffic onto the slowest provider)
+// must now resolve to the fastest annotated low-tier model rather than the
+// cheapest. Pins the actual symptom this change fixes; will fail loudly if
+// a future bundle drops the flash-lite speed annotation or its tier.
+func TestFastestModel_RealLatestBundle_LowTierPrefersFastFlash(t *testing.T) {
+	version, err := ResolveVersion(LatestVersion)
+	require.NoError(t, err)
+	bundle, err := LoadBundle(version)
+	require.NoError(t, err)
+	if len(bundle.Metadata.TokPerS) == 0 {
+		t.Skip("latest bundle carries no tok_per_s annotations yet")
+	}
+	available := make(map[string]struct{}, len(bundle.Metadata.DeployedProviders))
+	for _, p := range bundle.Metadata.DeployedProviders {
+		available[p] = struct{}{}
+	}
+	allow := catalog.AllowedAtOrBelow(catalog.TierLow)
+
+	fastP, fastM, ok := FastestModelInSet(bundle.Metadata, bundle.Registry, available, nil, allow)
+	require.True(t, ok)
+	_, cheapM, ok := CheapestModelInSet(bundle.Metadata, bundle.Registry, available, nil, allow)
+	require.True(t, ok)
+
+	assert.Equal(t, "gemini-3.1-flash-lite-preview", fastM, "fastest low-tier model")
+	assert.Equal(t, "google", fastP)
+	assert.Equal(t, "deepseek/deepseek-v4-flash", cheapM, "cheapest low-tier model (the slow incumbent)")
+	assert.NotEqual(t, cheapM, fastM, "fastest must diverge from cheapest on the low-tier clamp")
 }


### PR DESCRIPTION
## Problem

Investigating a slow/failing Claude Code session (9-min hang + slow turns) traced back to routing: the **dominant production route** — `cluster+tier_clamp → deepseek-v4-flash @ deepinfra` (1,066 turns/7d, the #1 path) — lands low-tier requests on the **slowest model+provider we route to**:

| model @ provider | p50 tok/s |
|---|---|
| gemini-3.1-flash-lite @ google | **158** |
| gemini-3.5-flash @ google | 77 |
| v4-flash @ openrouter | 63 |
| **v4-flash @ deepinfra** ← where low-tier lands | **24** |

Both the tier-clamp resolver and the Explore/compaction hard-pin used cost-only selectors (`CheapestModel*`). These paths **bypass the cluster scorer**, so the scorer's `speed_weight` never applied — they always picked the cheapest in-ceiling model, which is the slow one.

## Change

- **`tok_per_s` artifact annotation** (provider → model → measured p50 tok/s), sourced from prod telemetry (30d, output>100). Provider-keyed because the same model's throughput varies sharply by provider (v4-flash: 24 deepinfra vs 63 openrouter).
- **`FastestModel` / `FastestModelInSet`** selectors mirroring the cheapest ones but maximizing throughput across in-ceiling provider bindings.
- **Wired** the tier-clamp resolver + both hard-pin call sites to the fastest selectors.
- **Safe fallback**: when a bundle has no `tok_per_s` (legacy/un-annotated), `FastestModel` degrades to `CheapestModel` — never a worse decision than today.
- v0.57 annotates the nine models with adequate prod volume. Routing centroids/rankings are unchanged.

For the low-tier (haiku) ceiling, the clamp now resolves to `gemini-3.1-flash-lite-preview` (158 tok/s) instead of `deepseek-v4-flash` (24 tok/s) — a ~6.5× throughput improvement on the path that caused the original report.

## Tests

- `FastestModel` / `FastestModelInSet`: picks fastest-not-cheapest, provider-keyed lookup, denylist, no-match, and cheapest-fallback when unannotated.
- Integration guard against the **real shipped v0.57 bundle**: confirms the low-tier clamp now diverges from cheapest and resolves to flash-lite.
- gofmt / go vet / `go build ./...` / cluster + proxy suites all green.

## Follow-up (not in this PR)

The Explore hard-pin never fires in prod (`turn_type=sub_agent_dispatch` = 0 occurrences/7d): Claude Code Explore traffic carries none of the detection signals (`x-weave-subagent-type` header, `subagent:` user_id, `<transcript>` wrapper) on the raw Anthropic ingress. The hard-pin now points at fastest too, but engaging it needs a **client-side change** to inject `x-weave-subagent-type` — tracked separately. The clamp change here fixes the real-world symptom regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)