### PR TITLE
feat(providers): add Parasail provider; route deepseek-v4-flash to it

### DIFF
--- a/cmd/router/main.go
+++ b/cmd/router/main.go
@@ -275,6 +275,28 @@ func main() {
 	}
 
 	{
+		// Parasail OpenAI-compatible serverless surface. Parasail uses its
+		// own "parasail-"-prefixed model slugs while the router exposes
+		// slash-form slugs; modelIDMap is derived from the catalog's
+		// per-binding UpstreamID at boot.
+		parasailBaseURL := config.GetOr("PARASAIL_BASE_URL", openaiCompatProvider.ParasailBaseURL)
+		parasailKey := ""
+		if !byokOnly {
+			parasailKey = config.GetOr("PARASAIL_API_KEY", "")
+		}
+		providerMap[providers.ProviderParasail] = openaiCompatProvider.NewClientWithModelIDMap(parasailKey, parasailBaseURL, upstreamIDsForProvider(providers.ProviderParasail))
+		switch {
+		case byokOnly:
+			logger.Info("Parasail provider enabled (BYOK only)", "base_url", parasailBaseURL)
+		case parasailKey != "":
+			envKeyedProviders[providers.ProviderParasail] = struct{}{}
+			logger.Info("Parasail provider enabled", "base_url", parasailBaseURL)
+		default:
+			logger.Info("Parasail provider registered (BYOK only — set PARASAIL_API_KEY for deployment-level use)", "base_url", parasailBaseURL)
+		}
+	}
+
+	{
 		// Bedrock via the OpenAI-compatible "bedrock-mantle" surface
 		// (https://bedrock-mantle.{region}.api.aws/v1). AWS recommends this
 		// over the model-native bedrock-runtime/InvokeModel surface; both

--- a/internal/providers/openaicompat/client.go
+++ b/internal/providers/openaicompat/client.go
@@ -27,6 +27,10 @@ const (
 	// HuggingFace-form model IDs; pair with NewClientWithModelIDMap to rewrite
 	// the router's public slash-form slugs on the wire.
 	DeepInfraBaseURL = "https://api.deepinfra.com/v1/openai"
+	// ParasailBaseURL is Parasail's OpenAI-compatible serverless surface.
+	// Parasail uses its own "parasail-"-prefixed model slugs; pair with
+	// NewClientWithModelIDMap to rewrite the router's public slash-form slugs.
+	ParasailBaseURL = "https://api.parasail.io/v1"
 )
 
 // BedrockMantleBaseURLTemplate is the OpenAI-compatible bedrock-mantle endpoint

--- a/internal/providers/provider.go
+++ b/internal/providers/provider.go
@@ -19,6 +19,7 @@ const (
 	ProviderFireworks  = "fireworks"
 	ProviderDeepInfra  = "deepinfra"
 	ProviderBedrock    = "bedrock"
+	ProviderParasail   = "parasail"
 )
 
 // APIKeyEnvVars maps provider name to the env var providing its deployment-level upstream API key.
@@ -31,6 +32,7 @@ var APIKeyEnvVars = map[string]string{
 	ProviderFireworks:  "FIREWORKS_API_KEY",
 	ProviderDeepInfra:  "DEEPINFRA_API_KEY",
 	ProviderBedrock:    "AWS_BEARER_TOKEN_BEDROCK",
+	ProviderParasail:   "PARASAIL_API_KEY",
 }
 
 // APIKeyEnvVar returns the env-var name for the given provider, or empty

--- a/internal/router/catalog/catalog.go
+++ b/internal/router/catalog/catalog.go
@@ -297,7 +297,17 @@ var Models = []Model{
 			Price: Pricing{InputUSDPer1M: 0.150, OutputUSDPer1M: 1.200}},
 		{Provider: providers.ProviderOpenRouter, Price: Pricing{InputUSDPer1M: 0.090, OutputUSDPer1M: 1.100}},
 	}},
+	// Parasail primary: AA/OpenRouter p50s (2026-06-01) put it ahead of
+	// DeepInfra on V4 Flash end-to-end — ~0.6s TTFT vs ~1.3s and ~34 vs ~23
+	// tok/s — at the same $0.14/$0.28. DeepInfra stays as the first fallback;
+	// a Parasail 5xx/408/429 fails over to it. Parasail publishes no prompt
+	// caching (CacheReadMultiplier defaults to the conservative 0.5).
+	// UpstreamID is Parasail's serverless slug — VERIFY against GET
+	// /v1/models with a live key before deploy; a wrong slug 404s (non-
+	// retryable) instead of failing over.
 	{ID: "deepseek/deepseek-v4-flash", Tier: TierLow, Providers: []ProviderBinding{
+		{Provider: providers.ProviderParasail, UpstreamID: "parasail-deepseek-v4-flash",
+			Price: Pricing{InputUSDPer1M: 0.140, OutputUSDPer1M: 0.280}},
 		{Provider: providers.ProviderDeepInfra, UpstreamID: "deepseek-ai/DeepSeek-V4-Flash",
 			Price: Pricing{InputUSDPer1M: 0.140, OutputUSDPer1M: 0.280, CacheReadMultiplier: 0.20}},
 		{Provider: providers.ProviderOpenRouter, Price: Pricing{InputUSDPer1M: 0.140, OutputUSDPer1M: 0.280, CacheReadMultiplier: 0.10}},

--- a/internal/router/catalog/catalog_test.go
+++ b/internal/router/catalog/catalog_test.go
@@ -33,6 +33,7 @@ func TestCatalog_BindingsReferenceCanonicalProviders(t *testing.T) {
 		providers.ProviderFireworks:  {},
 		providers.ProviderDeepInfra:  {},
 		providers.ProviderBedrock:    {},
+		providers.ProviderParasail:   {},
 	}
 	for _, m := range Models {
 		for i, b := range m.Providers {


### PR DESCRIPTION
## What

Adds [Parasail](https://parasail.io) — a SOC-2-compliant, OpenAI-compatible serverless inference provider — and routes `deepseek/deepseek-v4-flash` to it.

Parasail speaks the OpenAI Chat Completions spec, so it reuses the existing `openaicompat` adapter (like OpenRouter / Fireworks / DeepInfra). No new adapter package, no translation layer.

## Changes

- **`internal/providers/provider.go`** — `ProviderParasail` constant + `PARASAIL_API_KEY` entry in `APIKeyEnvVars`.
- **`internal/providers/openaicompat/client.go`** — `ParasailBaseURL` (`https://api.parasail.io/v1`).
- **`cmd/router/main.go`** — registration block mirroring DeepInfra; `modelIDMap` derived from the catalog's `UpstreamID` via `upstreamIDsForProvider`.
- **`internal/router/catalog/catalog.go`** — Parasail becomes the **primary** binding for `deepseek/deepseek-v4-flash`; DeepInfra and OpenRouter remain ordered fallbacks.
- **`internal/router/catalog/catalog_test.go`** — add Parasail to the canonical-provider set.

Because `cluster.resolveProviderFor` resolves the dispatch provider from the catalog's ordered binding list (first available wins), making Parasail the first binding is sufficient to route Flash to it — `model_registry.json` does **not** need editing.

## Why Flash / why primary

Same price as our current DeepInfra binding (\$0.14 / \$0.28 per MTok), but OpenRouter p50s (2026-06-01) show Parasail faster **end-to-end** on V4 Flash: ~0.6s TTFT & ~34 tok/s vs DeepInfra's ~1.3s & ~23 tok/s. (Parasail has great TTFT but weak throughput on *larger* models — Flash is the one OSS target where it wins on total wall-clock, which is why this PR scopes to Flash only.)

## ⚠️ Before deploy — verify the upstream slug

`UpstreamID: "parasail-deepseek-v4-flash"` is a **best-effort** serverless slug. Parasail uses `parasail-`-prefixed IDs and the `/v1/models` endpoint requires a key, so it couldn't be confirmed from public docs. **Verify against `GET https://api.parasail.io/v1/models` with a live key before deploy** — a wrong slug returns 404, which is *non-retryable*, so it surfaces to the client instead of failing over to DeepInfra.

Parasail also won't serve any traffic until `PARASAIL_API_KEY` is set in the deploy env; until then Flash transparently falls through to DeepInfra.

## Testing

- `wv mr tc` — clean
- `wv mr test` — full suite passes (catalog test updated for the new provider)
- `go run ./cmd/genprices` — install scripts unchanged (price identical)

## Follow-up

Once a key is configured, benchmark via `/force-model` on real Claude Code sessions to confirm the end-to-end win holds under our (long-context, tool-heavy) traffic before considering Parasail for other models.

🤖 Generated with [Claude Code](https://claude.com/claude-code)