### PR TITLE
fix(proxy): suppress routing badge for suggestion-mode parallel requests

### DIFF
--- a/internal/proxy/gemini.go
+++ b/internal/proxy/gemini.go
@@ -85,6 +85,7 @@ func (s *Service) ProxyGeminiGenerateContent(ctx context.Context, body []byte, w
 		log.Error("Routing failed for Gemini request", "err", err, "route_ms", routeMs, "requested_model", feats.Model, "total_input_tokens", feats.Tokens)
 		return err
 	}
+	routeRes.SuggestionMode = r.Header.Get("x-weave-suggestion-mode") == "true"
 	decision := routeRes.Decision
 	tt := routeRes.TurnType
 	stickyHit := routeRes.StickyHit

--- a/internal/proxy/marker_internal_test.go
+++ b/internal/proxy/marker_internal_test.go
@@ -215,6 +215,18 @@ func TestRoutingMarkerFor_EmptyDecisionEmitsNothing(t *testing.T) {
 	assert.Empty(t, got)
 }
 
+func TestRoutingMarkerFor_SuggestionModeSuppressed(t *testing.T) {
+	res := turnLoopResult{
+		Decision:       router.Decision{Model: "gpt-5.5", Provider: "openai"},
+		SuggestionMode: true,
+		PlannerDecision: planner.Decision{
+			Reason: planner.ReasonSameModel,
+		},
+	}
+	got := routingMarkerFor(res)
+	assert.Empty(t, got, "suggestion-mode responses must not emit the routing badge")
+}
+
 func TestRoutingMarkerFor_DropsProviderEvenWhenSet(t *testing.T) {
 	got := routingMarkerFor(turnLoopResult{
 		Decision: router.Decision{Model: "claude-haiku-4-5", Provider: "anthropic"},

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -162,6 +162,9 @@ func routingMarkerFor(res turnLoopResult) string {
 	if decision.Model == "" {
 		return ""
 	}
+	if res.SuggestionMode {
+		return ""
+	}
 	// Suppress the marker on tool-result follow-ups: every post-tool turn would
 	// otherwise re-emit a duplicate mid-stream.
 	if res.PlannerDecision.Reason == "" && !res.HardPinned && !res.TierClamped && res.StickyHit {
@@ -804,6 +807,7 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 		log.Error("Routing failed", "err", routeErr, "route_ms", time.Since(routeStart).Milliseconds(), "requested_model", feats.Model, "total_input_tokens", feats.Tokens)
 		return routeErr
 	}
+	routeRes.SuggestionMode = r.Header.Get("x-weave-suggestion-mode") == "true"
 	decision := routeRes.Decision
 	tt := routeRes.TurnType
 	stickyHit := routeRes.StickyHit
@@ -1745,6 +1749,7 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 		log.Error("Routing failed for OpenAI request", "err", err, "route_ms", routeMs, "requested_model", feats.Model, "total_input_tokens", feats.Tokens)
 		return err
 	}
+	routeRes.SuggestionMode = r.Header.Get("x-weave-suggestion-mode") == "true"
 	decision := routeRes.Decision
 	tt := routeRes.TurnType
 	stickyHit := routeRes.StickyHit

--- a/internal/proxy/turnloop.go
+++ b/internal/proxy/turnloop.go
@@ -64,6 +64,10 @@ type turnLoopResult struct {
 	PinModel string
 	// Handover captures the summarize-or-trim step when the planner switched.
 	Handover handoverOutcome
+	// SuggestionMode is true when the request arrived with the
+	// x-weave-suggestion-mode header. The routing marker is suppressed so
+	// the badge does not appear in suggestion-overlay responses.
+	SuggestionMode bool
 }
 
 // handoverOutcome describes the synchronous handover step.


### PR DESCRIPTION
## Summary

- Adds `SuggestionMode bool` to `turnLoopResult`, set from the `x-weave-suggestion-mode: true` request header
- `routingMarkerFor()` returns empty when `SuggestionMode` is true, suppressing the `✦ Weave Router` badge
- Covers both `ProxyMessages` (Anthropic surface) and `ProxyOpenAIChatCompletion` (OpenAI surface)

## Background

When Claude Code sends concurrent suggestion-mode requests alongside the real user turn, both responses got the routing marker injected (the suppression at line 147 only fires for ToolResult turns where `PlannerDecision.Reason == ""`; suggestion-mode calls are classified as MainLoop and go through the full planner, so `PlannerDecision.Reason = "same_model"` — non-empty, so the check failed). Both streamed responses reached the TUI, causing the badge to render twice.

The fix is inert until the Claude Code harness sends `x-weave-suggestion-mode: true` on its parallel suggestion requests.

## Test plan

- [ ] `TestRoutingMarkerFor_SuggestionModeSuppressed` added and passing
- [ ] All existing proxy marker tests pass (`go test ./internal/proxy/ -run TestRoutingMarkerFor`)
- [ ] Send a request with `x-weave-suggestion-mode: true` header and verify no badge in the response

🤖 Generated with [Claude Code](https://claude.com/claude-code)