### PR TITLE
fix(router): pin sessions to a replica via prompt-cache affinity hints

### DIFF
--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -910,6 +910,7 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 		TargetProvider:     decision.Provider,
 		Capabilities:       router.Lookup(decision.Model),
 		IncludeStreamUsage: s.usageRequired(),
+		SessionAffinity:    sessionAffinityHint(routeRes.SessionKey),
 	}
 
 	ctx = resolveAndInjectCredentials(ctx, decision.Provider, r.Header)
@@ -1834,6 +1835,7 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 		TargetProvider:     decision.Provider,
 		Capabilities:       router.Lookup(decision.Model),
 		IncludeStreamUsage: s.usageRequired(),
+		SessionAffinity:    sessionAffinityHint(routeRes.SessionKey),
 	}
 
 	ctx = resolveAndInjectCredentials(ctx, decision.Provider, r.Header)

--- a/internal/proxy/session_key.go
+++ b/internal/proxy/session_key.go
@@ -22,6 +22,18 @@ func shortKey(key [sessionpin.SessionKeyLen]byte) string {
 	return hex.EncodeToString(key[:8])
 }
 
+// sessionAffinityHint returns the full hex session key for use as an upstream
+// prompt-cache stickiness hint (translate.EmitOptions.SessionAffinity), or ""
+// for the zero key so requests with no derivable session don't all collapse
+// onto one synthetic affinity bucket.
+func sessionAffinityHint(key [sessionpin.SessionKeyLen]byte) string {
+	var zero [sessionpin.SessionKeyLen]byte
+	if key == zero {
+		return ""
+	}
+	return hex.EncodeToString(key[:])
+}
+
 // bindRequestLogger derives the session key and returns a new context carrying
 // a request-scoped logger pre-bound with session_key, request_id, api_key_id,
 // and ingress. Downstream code reading via observability.FromContext gets these

--- a/internal/translate/emit_openai.go
+++ b/internal/translate/emit_openai.go
@@ -33,7 +33,45 @@ func (e *RequestEnvelope) PrepareOpenAI(in http.Header, opts EmitOptions) (provi
 	if err != nil {
 		return providers.PreparedRequest{}, err
 	}
-	return providers.PreparedRequest{Body: body, Headers: make(http.Header)}, nil
+	headers := make(http.Header)
+	body, err = applySessionAffinity(body, headers, opts)
+	if err != nil {
+		return providers.PreparedRequest{}, err
+	}
+	return providers.PreparedRequest{Body: body, Headers: headers}, nil
+}
+
+// applySessionAffinity attaches an upstream-specific prompt-cache routing hint
+// derived from opts.SessionAffinity (a stable per-conversation identifier).
+// Serverless upstreams fan a session's turns across replicas and hold the
+// prefix KV-cache per replica; without a stickiness hint, a turn can land on a
+// cold replica and pay a full prefill (the deepseek-v4-pro/Fireworks incident:
+// 60k-token turn, zero cache read, 26s TTFT). Each upstream exposes a different
+// knob:
+//   - Fireworks / DeepInfra: x-session-affinity request header
+//   - OpenRouter: x-session-id request header (its sticky-routing key, ≤256 chars)
+//   - OpenAI: prompt_cache_key body field (combined with the prefix hash)
+//
+// Bedrock (explicit cachePoint caching, centrally routed — no replica roulette)
+// and any unrecognized target get nothing. No-op when SessionAffinity is empty,
+// which also covers the handover summarizer's empty-TargetProvider calls.
+func applySessionAffinity(body []byte, headers http.Header, opts EmitOptions) ([]byte, error) {
+	if opts.SessionAffinity == "" {
+		return body, nil
+	}
+	switch opts.TargetProvider {
+	case providers.ProviderFireworks, providers.ProviderDeepInfra:
+		headers.Set("x-session-affinity", opts.SessionAffinity)
+	case providers.ProviderOpenRouter:
+		headers.Set("x-session-id", opts.SessionAffinity)
+	case providers.ProviderOpenAI:
+		out, err := sjson.SetBytes(body, "prompt_cache_key", opts.SessionAffinity)
+		if err != nil {
+			return nil, fmt.Errorf("set prompt_cache_key: %w", err)
+		}
+		return out, nil
+	}
+	return body, nil
 }
 
 func (e *RequestEnvelope) buildOpenAIFromOpenAI(opts EmitOptions) ([]byte, error) {

--- a/internal/translate/envelope.go
+++ b/internal/translate/envelope.go
@@ -44,6 +44,12 @@ type EmitOptions struct {
 	TargetProvider     string
 	Capabilities       router.ModelSpec
 	IncludeStreamUsage bool
+	// SessionAffinity is a stable per-conversation identifier forwarded to
+	// the upstream as a prompt-cache stickiness hint so a session's turns
+	// land on the same serverless replica (where the prefix KV-cache lives)
+	// rather than being load-balanced to a cold one. The knob differs per
+	// upstream — see applySessionAffinity. Empty disables the hint.
+	SessionAffinity string
 }
 
 // RequestEnvelope wraps a parsed request body regardless of wire format.

--- a/internal/translate/session_affinity_test.go
+++ b/internal/translate/session_affinity_test.go
@@ -1,0 +1,122 @@
+package translate_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"workweave/router/internal/providers"
+	"workweave/router/internal/translate"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const affinityKey = "0123456789abcdef0123456789abcdef"
+
+func anthropicSrc() []byte {
+	return []byte(`{"model":"claude-opus-4-7","messages":[{"role":"user","content":"hi"}],"max_tokens":256}`)
+}
+
+func promptCacheKey(t *testing.T, body []byte) (string, bool) {
+	t.Helper()
+	var doc map[string]any
+	require.NoError(t, json.Unmarshal(body, &doc))
+	v, ok := doc["prompt_cache_key"].(string)
+	return v, ok
+}
+
+func TestSessionAffinity_FireworksSetsHeaderNotBody(t *testing.T) {
+	env, err := translate.ParseAnthropic(anthropicSrc())
+	require.NoError(t, err)
+
+	out, err := env.PrepareOpenAI(nil, translate.EmitOptions{
+		TargetModel:     "deepseek/deepseek-v4-pro",
+		TargetProvider:  providers.ProviderFireworks,
+		SessionAffinity: affinityKey,
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, affinityKey, out.Headers.Get("x-session-affinity"))
+	assert.Empty(t, out.Headers.Get("x-session-id"))
+	_, hasBody := promptCacheKey(t, out.Body)
+	assert.False(t, hasBody, "Fireworks must not carry the OpenAI prompt_cache_key body field")
+}
+
+func TestSessionAffinity_DeepInfraSetsHeader(t *testing.T) {
+	env, err := translate.ParseAnthropic(anthropicSrc())
+	require.NoError(t, err)
+
+	out, err := env.PrepareOpenAI(nil, translate.EmitOptions{
+		TargetModel:     "deepseek/deepseek-v4-flash",
+		TargetProvider:  providers.ProviderDeepInfra,
+		SessionAffinity: affinityKey,
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, affinityKey, out.Headers.Get("x-session-affinity"))
+}
+
+func TestSessionAffinity_OpenRouterUsesSessionIDHeader(t *testing.T) {
+	env, err := translate.ParseAnthropic(anthropicSrc())
+	require.NoError(t, err)
+
+	out, err := env.PrepareOpenAI(nil, translate.EmitOptions{
+		TargetModel:     "deepseek/deepseek-v4-pro",
+		TargetProvider:  providers.ProviderOpenRouter,
+		SessionAffinity: affinityKey,
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, affinityKey, out.Headers.Get("x-session-id"))
+	assert.Empty(t, out.Headers.Get("x-session-affinity"))
+}
+
+func TestSessionAffinity_OpenAIUsesPromptCacheKeyBody(t *testing.T) {
+	env, err := translate.ParseAnthropic(anthropicSrc())
+	require.NoError(t, err)
+
+	out, err := env.PrepareOpenAI(nil, translate.EmitOptions{
+		TargetModel:     "gpt-5.5",
+		TargetProvider:  providers.ProviderOpenAI,
+		SessionAffinity: affinityKey,
+	})
+	require.NoError(t, err)
+
+	v, ok := promptCacheKey(t, out.Body)
+	require.True(t, ok, "OpenAI must carry prompt_cache_key in the body")
+	assert.Equal(t, affinityKey, v)
+	assert.Empty(t, out.Headers.Get("x-session-affinity"))
+	assert.Empty(t, out.Headers.Get("x-session-id"))
+}
+
+func TestSessionAffinity_BedrockGetsNoHint(t *testing.T) {
+	env, err := translate.ParseAnthropic(anthropicSrc())
+	require.NoError(t, err)
+
+	out, err := env.PrepareOpenAI(nil, translate.EmitOptions{
+		TargetModel:     "moonshotai/kimi-k2.5",
+		TargetProvider:  providers.ProviderBedrock,
+		SessionAffinity: affinityKey,
+	})
+	require.NoError(t, err)
+
+	assert.Empty(t, out.Headers.Get("x-session-affinity"))
+	assert.Empty(t, out.Headers.Get("x-session-id"))
+	_, hasBody := promptCacheKey(t, out.Body)
+	assert.False(t, hasBody)
+}
+
+func TestSessionAffinity_EmptyIsNoOp(t *testing.T) {
+	env, err := translate.ParseAnthropic(anthropicSrc())
+	require.NoError(t, err)
+
+	out, err := env.PrepareOpenAI(nil, translate.EmitOptions{
+		TargetModel:    "deepseek/deepseek-v4-pro",
+		TargetProvider: providers.ProviderFireworks,
+	})
+	require.NoError(t, err)
+
+	assert.Empty(t, out.Headers.Get("x-session-affinity"))
+	_, hasBody := promptCacheKey(t, out.Body)
+	assert.False(t, hasBody)
+}


### PR DESCRIPTION
## Problem

Serverless upstreams (Fireworks, DeepInfra) fan a single session's turns across replicas, and the prefix KV-cache lives **per replica**. We sent **no stickiness hint**, so consecutive turns of the same conversation were load-balanced to whatever replica was free — and a turn that lands on a cold replica pays a full prefill.

Found this diagnosing a prod `deepseek-v4-pro`/Fireworks session (`b16c5b9e`):

| input | cache read | TTFT |
|---|---|---|
| ~29k | ~16k | 2.5–5s (warm replica) |
| **60k** | **0** | **26.4s** (cold replica) |

The heaviest turns then blew past Fireworks' ~30s idle timeout and failed over — to an OpenRouter binding that's separately out of credits (402). It's also a cost bug: deepseek-v4-pro caches at 8.6% of input price, so every miss bills ~11.6× on those tokens.

This is documented Fireworks behavior — serverless needs a per-session hint to keep cache hit rates up ([docs](https://docs.fireworks.ai/guides/prompt-caching)).

## Fix

Forward the derived session key (`translate.EmitOptions.SessionAffinity`) as the upstream-appropriate hint, keyed on `TargetProvider` in `applySessionAffinity`:

- **Fireworks / DeepInfra** → `x-session-affinity` request header
- **OpenRouter** → `x-session-id` request header (its documented sticky-routing key)
- **OpenAI** → `prompt_cache_key` body field (combines with the prefix hash; one customer saw hit rate 60→87%)

Both the openaicompat and openai-native clients already forward `prep.Headers`, and all five OpenAI-family providers build their body through `PrepareOpenAI`, so the whole mapping lives in one place.

## Providers with no replica-roulette failure mode (unchanged)

- **Bedrock** — explicit `cachePoint` caching, centrally routed; no per-caller affinity knob (and bedrock-mantle may reject unknown fields).
- **Anthropic** — caching is explicit `cache_control`, routed centrally by Anthropic.
- **Gemini** — server-managed implicit caching; no caller affinity field.

## Caveats

- It's a *hint*, not a guarantee — replicas still evict under TTL/load, so the occasional cold turn remains; this kills the every-few-turns roulette.
- It doesn't bound context growth — a warm 60k turn that appends a fresh tool result still prefills the new tail. Context management on long-lived pins is a separate follow-up.

## Tests

`internal/translate/session_affinity_test.go` — per-provider hint placement (header vs body), Bedrock/empty no-op. `wv mr tc` + `go test ./internal/translate/ ./internal/proxy/` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)