### PR TITLE
feat(translate): Gemini 3.x tool-use reminder + tool_use args JSON validation gate

### DIFF
--- a/internal/translate/emit_gemini.go
+++ b/internal/translate/emit_gemini.go
@@ -193,6 +193,9 @@ func writeGeminiFromOpenAI(jw *jsonWriter, body []byte, opts EmitOptions) error 
 		}
 		return true
 	})
+	if reminder := geminiSystemReminder(opts.TargetModel); reminder != "" && hasNonEmptyTools(body) {
+		sysParts = append(sysParts, reminder)
+	}
 	if len(sysParts) > 0 {
 		jw.Key("systemInstruction")
 		jw.Obj()
@@ -586,6 +589,9 @@ func writeGeminiFromAnthropic(jw *jsonWriter, body []byte, opts EmitOptions) {
 			}
 			return true
 		})
+	}
+	if reminder := geminiSystemReminder(opts.TargetModel); reminder != "" && hasNonEmptyTools(body) {
+		sysParts = append(sysParts, reminder)
 	}
 	if len(sysParts) > 0 {
 		jw.Key("systemInstruction")

--- a/internal/translate/stream.go
+++ b/internal/translate/stream.go
@@ -353,6 +353,20 @@ type AnthropicSSETranslator struct {
 	// first delta carried no function name (see emitDelta). Later argument
 	// fragments reuse the same index, so we must remember to drop them too.
 	suppressedTools map[int]struct{}
+	// toolArgsBuffer accumulates input_json_delta fragments per Anthropic
+	// content-block index so we can validate the final concatenated args at
+	// content_block_stop. OpenAI-compat upstreams (GLM, Kimi, Qwen, gpt-oss on
+	// vLLM/SGLang) intermittently emit a JSON object whose final form fails
+	// to parse — partial keys, unbalanced braces, mid-string truncation.
+	// Without validation we relay malformed tool_use input downstream and
+	// the client retries or errors silently; with it we get a structured
+	// warn log on every malformed turn for observability and an explicit
+	// signal that active drop is the next step if this turns out frequent.
+	toolArgsBuffer map[int]*strings.Builder
+	// toolArgsInvalid latches per-block-index when buffered args fail to
+	// parse as JSON at content_block_stop. Surfaced via Summary so the
+	// proxy can count malformed-tool turns from logs alone.
+	toolArgsInvalid map[int]struct{}
 	// toolUseEmitted latches true the first time a tool_use content block is
 	// opened. finishStream clears toolBlocks before emitMessageDelta, so we
 	// can't read len(toolBlocks) at delta time; the latch outlives the map.
@@ -397,6 +411,8 @@ func NewAnthropicSSETranslator(w http.ResponseWriter, requestModel string, sink 
 		requestModel:    requestModel,
 		toolBlocks:      make(map[int]int),
 		suppressedTools: make(map[int]struct{}),
+		toolArgsBuffer:  make(map[int]*strings.Builder),
+		toolArgsInvalid: make(map[int]struct{}),
 		usageSink:       sink,
 	}
 }
@@ -433,6 +449,12 @@ type ResponseSummary struct {
 	StopReasonPromoted bool
 	// ToolUseBlocks is the number of tool_use content blocks emitted.
 	ToolUseBlocks int
+	// InvalidToolArgsBlocks counts tool_use blocks whose buffered
+	// input_json_delta payload failed JSON validation at content_block_stop.
+	// Non-zero indicates an OpenAI-compat upstream emitted malformed tool
+	// arguments that the client will likely fail to parse. See
+	// validateBufferedToolArgs.
+	InvalidToolArgsBlocks int
 	// OutputTokens is the upstream completion_tokens count, when reported.
 	OutputTokens int
 }
@@ -441,11 +463,12 @@ type ResponseSummary struct {
 // before the stream completes the fields reflect partial state.
 func (t *AnthropicSSETranslator) Summary() ResponseSummary {
 	return ResponseSummary{
-		UpstreamFinishReason: t.finishReason,
-		StopReason:           t.emittedStopReason,
-		StopReasonPromoted:   t.toolUseEmitted && openAIFinishToAnthropic(t.finishReason) != "tool_use",
-		ToolUseBlocks:        t.toolUseCount,
-		OutputTokens:         t.usageOutputTokens,
+		UpstreamFinishReason:  t.finishReason,
+		StopReason:            t.emittedStopReason,
+		StopReasonPromoted:    t.toolUseEmitted && openAIFinishToAnthropic(t.finishReason) != "tool_use",
+		ToolUseBlocks:         t.toolUseCount,
+		InvalidToolArgsBlocks: len(t.toolArgsInvalid),
+		OutputTokens:          t.usageOutputTokens,
 	}
 }
 
@@ -778,10 +801,46 @@ func (t *AnthropicSSETranslator) emitDelta(delta gjson.Result) error {
 			if emitErr = t.emitContentBlockDeltaJSON(blockIdx, args); emitErr != nil {
 				return false
 			}
+			buf, ok := t.toolArgsBuffer[blockIdx]
+			if !ok {
+				buf = &strings.Builder{}
+				t.toolArgsBuffer[blockIdx] = buf
+			}
+			buf.WriteString(args)
 		}
 		return true
 	})
 	return emitErr
+}
+
+// validateBufferedToolArgs checks the accumulated input_json_delta payload for
+// a tool_use block at content_block_stop time. Logs a structured warn and
+// latches t.toolArgsInvalid when the payload fails to parse as JSON, so the
+// proxy can count malformed-tool turns from logs without re-deriving them.
+// Args are not modified — active drop is a follow-up gated on observed
+// frequency from this signal.
+func (t *AnthropicSSETranslator) validateBufferedToolArgs(blockIdx int) {
+	buf, ok := t.toolArgsBuffer[blockIdx]
+	if !ok {
+		return
+	}
+	args := buf.String()
+	if args == "" || gjson.Valid(args) {
+		return
+	}
+	t.toolArgsInvalid[blockIdx] = struct{}{}
+	preview := args
+	const previewMax = 200
+	if len(preview) > previewMax {
+		preview = preview[:previewMax]
+	}
+	observability.Get().Warn(
+		"AnthropicSSE tool_use args failed JSON validation",
+		"block_index", blockIdx,
+		"upstream_model", t.modelFromUpstream,
+		"args_len", len(args),
+		"args_preview", preview,
+	)
 }
 
 // emitRoutingMarkerIfConfigured emits the routing marker as a standalone text
@@ -828,6 +887,7 @@ func (t *AnthropicSSETranslator) finishStream() error {
 		t.thinkingOpen = false
 	}
 	for _, blockIdx := range t.toolBlocks {
+		t.validateBufferedToolArgs(blockIdx)
 		if err := t.emitContentBlockStop(blockIdx); err != nil {
 			return err
 		}

--- a/internal/translate/system_reminder.go
+++ b/internal/translate/system_reminder.go
@@ -24,7 +24,25 @@ func openRouterSystemReminder(model string) string {
 	return ""
 }
 
+// geminiSystemReminder returns a system-message addendum for Gemini 3.x. Empty
+// for non-Gemini models or older Gemini families.
+//
+// Gemini 3.x in agentic-coding traces (SWE-bench Verified) reads source files
+// extensively, then ends turns describing the proposed edit in markdown
+// instead of calling Edit/Write. The behavior persists even when the request
+// carries Edit/Write tool schemas. This addendum is the Gemini analogue to
+// deepseekToolUseReminder: it tells the model the exploration-only turn is
+// the failure mode, not the success mode.
+func geminiSystemReminder(model string) string {
+	if isGemini3xModel(model) {
+		return geminiToolUseReminder
+	}
+	return ""
+}
+
 const deepseekToolUseReminder = "When using file-edit tools, copy `old_string` byte-for-byte from the most recent file read — preserve tabs, leading and trailing whitespace, and unicode characters (em-dash —, smart quotes, non-breaking spaces) exactly. If an Edit call fails, re-read the file before retrying. Never fall back to shell commands (sed, awk, python) to modify files."
+
+const geminiToolUseReminder = "When asked to fix code, always call the Edit or Write tool to apply changes — do not describe the edit in prose or markdown and stop. A turn that explores files without producing an Edit/Write call counts as the model giving up. After you have read enough to know what to change, the next step is the tool call, not a summary."
 
 // applySystemReminderToBody injects the reminder into a serialized OpenAI body's
 // `messages` array. Best-effort: returns the input unchanged on parse failure

--- a/internal/translate/system_reminder_test.go
+++ b/internal/translate/system_reminder_test.go
@@ -172,3 +172,103 @@ func TestSystemReminder_OpenAISource_SkipsWithoutTools(t *testing.T) {
 
 	assert.NotContains(t, systemContent(emittedMessages(t, out.Body)), reminderSnippet)
 }
+
+const geminiReminderSnippet = "always call the Edit or Write tool"
+
+// geminiSystemInstructionText extracts the concatenated systemInstruction.parts[*].text
+// from a serialized Gemini request body, or "" when no systemInstruction is set.
+func geminiSystemInstructionText(t *testing.T, body []byte) string {
+	t.Helper()
+	var doc map[string]any
+	require.NoError(t, json.Unmarshal(body, &doc))
+	sys, _ := doc["systemInstruction"].(map[string]any)
+	if sys == nil {
+		return ""
+	}
+	parts, _ := sys["parts"].([]any)
+	var out []string
+	for _, p := range parts {
+		part, _ := p.(map[string]any)
+		if part == nil {
+			continue
+		}
+		if text, _ := part["text"].(string); text != "" {
+			out = append(out, text)
+		}
+	}
+	return strings.Join(out, "\n")
+}
+
+func TestGeminiSystemReminder_AnthropicSource_AppendsForGemini3xWithTools(t *testing.T) {
+	src := []byte(`{
+		"model":"claude-opus-4-7",
+		"system":"You are a helpful coding assistant.",
+		"messages":[{"role":"user","content":"hi"}],
+		"tools":[{"name":"Edit","description":"edit","input_schema":{"type":"object"}}],
+		"max_tokens":256
+	}`)
+	env, err := translate.ParseAnthropic(src)
+	require.NoError(t, err)
+
+	out, err := env.PrepareGemini(nil, translate.EmitOptions{TargetModel: "gemini-3.1-pro-preview"})
+	require.NoError(t, err)
+
+	got := geminiSystemInstructionText(t, out.Body)
+	assert.Contains(t, got, "You are a helpful coding assistant.", "original system text must survive")
+	assert.Contains(t, got, geminiReminderSnippet, "gemini-3.x with tools must get the reminder")
+}
+
+func TestGeminiSystemReminder_AnthropicSource_SkipsWithoutTools(t *testing.T) {
+	src := []byte(`{
+		"model":"claude-opus-4-7",
+		"system":"sys",
+		"messages":[{"role":"user","content":"hi"}],
+		"max_tokens":256
+	}`)
+	env, err := translate.ParseAnthropic(src)
+	require.NoError(t, err)
+
+	out, err := env.PrepareGemini(nil, translate.EmitOptions{TargetModel: "gemini-3.1-pro-preview"})
+	require.NoError(t, err)
+
+	assert.NotContains(t, geminiSystemInstructionText(t, out.Body), geminiReminderSnippet)
+}
+
+func TestGeminiSystemReminder_AnthropicSource_SkipsForGemini2x(t *testing.T) {
+	src := []byte(`{
+		"model":"claude-opus-4-7",
+		"system":"sys",
+		"messages":[{"role":"user","content":"hi"}],
+		"tools":[{"name":"Edit","description":"edit","input_schema":{"type":"object"}}],
+		"max_tokens":256
+	}`)
+	env, err := translate.ParseAnthropic(src)
+	require.NoError(t, err)
+
+	out, err := env.PrepareGemini(nil, translate.EmitOptions{TargetModel: "gemini-2.5-pro"})
+	require.NoError(t, err)
+
+	assert.NotContains(t, geminiSystemInstructionText(t, out.Body), geminiReminderSnippet,
+		"reminder targets 3.x specifically; 2.x must pass through unchanged")
+}
+
+func TestGeminiSystemReminder_OpenAISource_AppendsForGemini3xWithTools(t *testing.T) {
+	src := []byte(`{
+		"model":"x",
+		"messages":[
+			{"role":"system","content":"be concise"},
+			{"role":"user","content":"hi"}
+		],
+		"tools":[{"type":"function","function":{"name":"Edit","parameters":{"type":"object"}}}],
+		"max_tokens":256
+	}`)
+	env, err := translate.ParseOpenAI(src)
+	require.NoError(t, err)
+
+	out, err := env.PrepareGemini(nil, translate.EmitOptions{TargetModel: "gemini-3.1-pro-preview"})
+	require.NoError(t, err)
+
+	got := geminiSystemInstructionText(t, out.Body)
+	assert.Contains(t, got, "be concise", "original system content preserved")
+	assert.Contains(t, got, geminiReminderSnippet, "OpenAI→Gemini path must inject reminder for gemini-3.x with tools")
+}

--- a/internal/translate/tool_args_validation_test.go
+++ b/internal/translate/tool_args_validation_test.go
@@ -1,0 +1,102 @@
+package translate_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"workweave/router/internal/translate"
+)
+
+// OpenAI-compat upstreams on vLLM/SGLang sometimes emit malformed JSON in
+// tool_call.function.arguments — partial keys, unbalanced braces, mid-string
+// truncation. The translator can't repair the payload at content_block_stop
+// time without breaking the already-streamed input_json_delta fragments, but
+// it MUST surface a structured signal so the proxy can count malformed-tool
+// turns from logs. validateBufferedToolArgs is that signal; these tests
+// pin its semantics.
+
+// driveAnthropicSSEWithSummary feeds events through a translator and returns
+// the final response summary alongside the translated body, so tests can
+// assert on InvalidToolArgsBlocks.
+func driveAnthropicSSEWithSummary(
+	t *testing.T,
+	model string,
+	events []string,
+) (string, translate.ResponseSummary) {
+	t.Helper()
+	rec := httptest.NewRecorder()
+	translator := translate.NewAnthropicSSETranslator(rec, model, nil)
+	translator.Header().Set("Content-Type", "text/event-stream")
+	translator.WriteHeader(http.StatusOK)
+	for _, e := range events {
+		_, err := translator.Write([]byte(e))
+		require.NoError(t, err)
+	}
+	require.NoError(t, translator.Finalize())
+	return rec.Body.String(), translator.Summary()
+}
+
+func TestAnthropicSSETranslator_FlagsInvalidToolArgs(t *testing.T) {
+	// Truncated JSON: opening brace, key, colon, opening string — then EOF.
+	// This is the most common malformed shape seen from GLM/Kimi on vLLM
+	// when the model hits the max_tokens cap mid-tool-call.
+	body, summary := driveAnthropicSSEWithSummary(t, "z-ai/glm-5.1", []string{
+		`data: {"id":"c1","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_x","type":"function","function":{"name":"Edit","arguments":"{\"path\":\"a.go\",\"old_string\":\"hel"}}]},"finish_reason":null}]}` + "\n\n",
+		`data: {"id":"c1","choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}],"usage":{"prompt_tokens":10,"completion_tokens":5}}` + "\n\n",
+		"data: [DONE]\n\n",
+	})
+
+	// The tool_use block still emits so the response stays protocol-valid;
+	// drop is deliberately a follow-up gated on the frequency this surfaces.
+	assert.Contains(t, body, `"type":"tool_use"`)
+	assert.Contains(t, body, `"name":"Edit"`)
+	assert.Equal(t, 1, summary.InvalidToolArgsBlocks,
+		"truncated JSON args must be flagged in Summary so the proxy can log the malformed turn")
+}
+
+func TestAnthropicSSETranslator_AcceptsValidToolArgs(t *testing.T) {
+	_, summary := driveAnthropicSSEWithSummary(t, "z-ai/glm-5.1", []string{
+		`data: {"id":"c1","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_x","type":"function","function":{"name":"Edit","arguments":"{\"path\":\"a.go\","}}]},"finish_reason":null}]}` + "\n\n",
+		`data: {"id":"c1","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\"old_string\":\"x\",\"new_string\":\"y\"}"}}]},"finish_reason":null}]}` + "\n\n",
+		`data: {"id":"c1","choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}]}` + "\n\n",
+		"data: [DONE]\n\n",
+	})
+
+	assert.Equal(t, 0, summary.InvalidToolArgsBlocks,
+		"well-formed JSON args concatenated across fragments must not be flagged")
+	assert.Equal(t, 1, summary.ToolUseBlocks)
+}
+
+func TestAnthropicSSETranslator_FlagsEachInvalidBlockIndependently(t *testing.T) {
+	// Two tool_calls: one with valid args, one truncated. Each block is
+	// buffered + validated under its own Anthropic content-block index, so
+	// the count tracks blocks not turns.
+	_, summary := driveAnthropicSSEWithSummary(t, "z-ai/glm-5.1", []string{
+		`data: {"id":"c1","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_a","type":"function","function":{"name":"Read","arguments":"{\"path\":\"a.go\"}"}}]},"finish_reason":null}]}` + "\n\n",
+		`data: {"id":"c1","choices":[{"index":0,"delta":{"tool_calls":[{"index":1,"id":"call_b","type":"function","function":{"name":"Edit","arguments":"{\"path\":\"b.go"}}]},"finish_reason":null}]}` + "\n\n",
+		`data: {"id":"c1","choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}]}` + "\n\n",
+		"data: [DONE]\n\n",
+	})
+
+	assert.Equal(t, 2, summary.ToolUseBlocks)
+	assert.Equal(t, 1, summary.InvalidToolArgsBlocks,
+		"only the truncated block must be flagged; the valid sibling is unaffected")
+}
+
+func TestAnthropicSSETranslator_EmptyArgsNotFlagged(t *testing.T) {
+	// Some tools take no input. The upstream emits no arguments fragment at
+	// all (or an empty one). An empty buffer is the trivial case — not
+	// malformed, not flagged.
+	_, summary := driveAnthropicSSEWithSummary(t, "z-ai/glm-5.1", []string{
+		`data: {"id":"c1","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_x","type":"function","function":{"name":"Ping"}}]},"finish_reason":null}]}` + "\n\n",
+		`data: {"id":"c1","choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}]}` + "\n\n",
+		"data: [DONE]\n\n",
+	})
+
+	assert.Equal(t, 0, summary.InvalidToolArgsBlocks,
+		"a tool with no streamed arguments is not the malformed-args case")
+}


### PR DESCRIPTION
## Summary

Two router-side mitigations for SWE-bench Verified empty-patch failures, prioritized by evidence from the v0.57 / v0.58 eval runs.

### Mitigation 2: Gemini 3.x tool-use reminder

Mirrors the existing `deepseekToolUseReminder` pattern for `gemini-3.x` targets. When the request carries tools AND the picked model is `gemini-3.*`, append an addendum to `systemInstruction` telling the model the exploration-only turn is the failure mode — \"after you have read enough to know what to change, the next step is the tool call, not a summary.\"

Wired into both `writeGeminiFromAnthropic` (the Claude Code path) and `writeGeminiFromOpenAI`. Same-format Gemini→Gemini pass-through is intentionally out of scope — it's not the Claude Code use case and the deepseek precedent didn't cover its analog either.

Evidence: v0.57 SWE-bench Verified leaderboard run produced 41 empty-patch shards on the router; Gemini 3.x routes dominated the \"explored without editing\" failure mode (D).

### Mitigation 5: tool_use args JSON validation gate

`AnthropicSSETranslator` now buffers streamed `input_json_delta` fragments per Anthropic content-block index and runs `gjson.Valid` at `content_block_stop` time. Mismatches latch `t.toolArgsInvalid[blockIdx]` and emit a structured warn (`block_index`, `upstream_model`, `args_len`, `args_preview`) so the proxy can count malformed-tool turns from logs alone via `Summary.InvalidToolArgsBlocks`.

Why log-only and not active drop: by the time the truncated JSON is detectable at `content_block_stop`, `content_block_start` and earlier `input_json_delta` fragments are already on the wire. Active drop would require deferring tool-block emission until full args are buffered, which is a bigger semantic change to the streaming contract. This PR lays the buffering foundation and the observability signal; if cloud-logs show the failure is common enough to warrant it, the follow-up deferral lands in a separate PR.

Evidence: prior PRs #229 (runaway tool-call auto-continue loop) and #252 (nameless tool_call drop) addressed sibling symptoms in the same OpenAI-compat tool-call family.

## Files

- `internal/translate/system_reminder.go` — `geminiSystemReminder` + `geminiToolUseReminder` const
- `internal/translate/emit_gemini.go` — wire reminder into Anthropic→Gemini and OpenAI→Gemini paths
- `internal/translate/stream.go` — `toolArgsBuffer`, `toolArgsInvalid`, `validateBufferedToolArgs`, surface `InvalidToolArgsBlocks` in `Summary`
- `internal/translate/system_reminder_test.go` — 4 new tests (Anthropic+OpenAI source × gemini-3.x positive / gemini-2.x negative / no-tools negative)
- `internal/translate/tool_args_validation_test.go` — 4 new tests (truncated JSON flagged, valid args not flagged, per-block independence, empty-args not flagged)

## Test plan

- [x] \`go test ./internal/translate/\` — all green including 8 new tests
- [x] \`go test ./...\` — full router suite green
- [ ] Land then watch staging logs for \`AnthropicSSE tool_use args failed JSON validation\` to size Mitigation 5 follow-up
- [ ] Re-run a 50-shard SWE-bench bake-off with this patch + v0.57 cluster to measure empty-patch delta

## Follow-ups

- **Mitigation 1** (strip Claude-Code-only tools when routing non-Anthropic). Background research confirmed 224 phantom CC-tool calls from non-Anthropic upstreams on the v0.57 eval (96% in the \`Task*\` family). Justified as ship-now; separate PR to keep this one reviewable.
- **Mitigation 5 active drop** — gated on log-volume from this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)