### PR TITLE
feat(translate): strip Claude-Code-only tools on Anthropic→non-Anthropic emit

### DIFF
--- a/internal/translate/claudecode_tool_filter.go
+++ b/internal/translate/claudecode_tool_filter.go
@@ -1,0 +1,99 @@
+package translate
+
+import (
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
+)
+
+// claudeCodeOnlyToolNames is the set of tools Claude Code (the client)
+// implements internally — Task subagent dispatch, plan-mode toggles, Skill
+// invocation, etc. They have no corresponding server-side behavior in any
+// upstream provider, so emitting their schemas to non-Anthropic models is
+// pure noise; worse, non-Anthropic models routinely hallucinate calls to
+// them. On the v0.57 SWE-bench Verified eval, 224 phantom tool_use blocks
+// for these names were observed across 150 router shards routed to
+// non-Anthropic upstreams — 96% of them in the Task* family — with 27%
+// clustering on the empty-patch failure subset.
+//
+// Anthropic models recognize these as native sub-tools and dispatch them
+// correctly via the client; non-Anthropic models cannot. The filter applies
+// only on Anthropic→non-Anthropic emit paths (buildOpenAIFromAnthropic and
+// the Anthropic case of PrepareGemini). The Anthropic→Anthropic passthrough
+// preserves them.
+var claudeCodeOnlyToolNames = map[string]struct{}{
+	"Task":                 {},
+	"TaskCreate":           {},
+	"TaskUpdate":           {},
+	"TaskGet":              {},
+	"TaskList":             {},
+	"TaskOutput":           {},
+	"TaskStop":             {},
+	"EnterPlanMode":        {},
+	"ExitPlanMode":         {},
+	"Skill":                {},
+	"Workflow":             {},
+	"AskUserQuestion":      {},
+	"CronCreate":           {},
+	"CronDelete":           {},
+	"CronList":             {},
+	"Monitor":              {},
+	"PushNotification":     {},
+	"RemoteTrigger":        {},
+	"EnterWorktree":        {},
+	"ExitWorktree":         {},
+	"LSP":                  {},
+	"ListMcpResourcesTool": {},
+	"ReadMcpResourceTool":  {},
+	"NotebookEdit":         {},
+}
+
+// isClaudeCodeOnlyTool reports whether name is one of the tools Claude Code
+// dispatches internally and that should not be forwarded to non-Anthropic
+// upstreams. Names are compared case-sensitively because Claude Code emits
+// them in PascalCase verbatim.
+func isClaudeCodeOnlyTool(name string) bool {
+	_, ok := claudeCodeOnlyToolNames[name]
+	return ok
+}
+
+// filterClaudeCodeOnlyToolsFromAnthropicBody returns body with any
+// Claude-Code-only tools removed from the top-level "tools" array. Returns
+// body unchanged when none match, so callers can apply this unconditionally
+// without paying a re-serialize cost on the common case.
+//
+// Only the tools array is rewritten; tool_choice and message content are
+// left alone. tool_choice is rare and Anthropic only honors "any"/"auto"/
+// name=X anyway, so a stale tool_choice referencing a stripped CC-only name
+// would be ignored upstream. Message content (existing tool_use/tool_result
+// blocks from past turns) is not rewritten because those represent history
+// the model has already acted on — rewriting it would invalidate prompt
+// caches and could leave dangling tool_use_id references.
+func filterClaudeCodeOnlyToolsFromAnthropicBody(body []byte) ([]byte, error) {
+	tools := gjson.GetBytes(body, "tools")
+	if !tools.Exists() || !tools.IsArray() {
+		return body, nil
+	}
+
+	anyMatch := false
+	tools.ForEach(func(_, t gjson.Result) bool {
+		if isClaudeCodeOnlyTool(t.Get("name").String()) {
+			anyMatch = true
+			return false
+		}
+		return true
+	})
+	if !anyMatch {
+		return body, nil
+	}
+
+	jw := newJSONWriter()
+	jw.Arr()
+	tools.ForEach(func(_, t gjson.Result) bool {
+		if !isClaudeCodeOnlyTool(t.Get("name").String()) {
+			jw.Raw(t.Raw)
+		}
+		return true
+	})
+	jw.EndArr()
+	return sjson.SetRawBytes(body, "tools", jw.Bytes())
+}

--- a/internal/translate/claudecode_tool_filter_test.go
+++ b/internal/translate/claudecode_tool_filter_test.go
@@ -1,0 +1,214 @@
+package translate_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"workweave/router/internal/translate"
+)
+
+// On the v0.57 SWE-bench Verified router eval, 224 phantom CC-only tool_use
+// blocks (96% in the Task* family) were emitted by non-Anthropic upstreams
+// — Gemini 3.x, gpt-5.5, etc. — because the request body still carried
+// schemas for tools the model has no business invoking (Task subagent
+// dispatch, plan-mode toggles, Skill calls, etc.). These tests pin the
+// filter that drops those schemas on Anthropic→non-Anthropic emit paths
+// while leaving the Anthropic→Anthropic passthrough untouched.
+
+// emittedToolNames extracts the top-level OpenAI tool names from an emitted
+// chat-completions body.
+func emittedToolNames(t *testing.T, body []byte) []string {
+	t.Helper()
+	var doc map[string]any
+	require.NoError(t, json.Unmarshal(body, &doc))
+	raw, _ := doc["tools"].([]any)
+	out := make([]string, 0, len(raw))
+	for _, r := range raw {
+		tool, _ := r.(map[string]any)
+		if tool == nil {
+			continue
+		}
+		fn, _ := tool["function"].(map[string]any)
+		if fn == nil {
+			continue
+		}
+		name, _ := fn["name"].(string)
+		if name != "" {
+			out = append(out, name)
+		}
+	}
+	return out
+}
+
+// emittedGeminiToolNames extracts function-declaration names from an emitted
+// Gemini request body.
+func emittedGeminiToolNames(t *testing.T, body []byte) []string {
+	t.Helper()
+	var doc map[string]any
+	require.NoError(t, json.Unmarshal(body, &doc))
+	tools, _ := doc["tools"].([]any)
+	var out []string
+	for _, t := range tools {
+		tool, _ := t.(map[string]any)
+		if tool == nil {
+			continue
+		}
+		decls, _ := tool["functionDeclarations"].([]any)
+		for _, d := range decls {
+			decl, _ := d.(map[string]any)
+			if decl == nil {
+				continue
+			}
+			if name, _ := decl["name"].(string); name != "" {
+				out = append(out, name)
+			}
+		}
+	}
+	return out
+}
+
+// claudeCodeMixedToolBody is a representative Anthropic request body carrying
+// the real coding tools Claude Code uses (Read/Edit/Write/Bash) interleaved
+// with the Claude-Code-only tools that have no upstream behavior.
+const claudeCodeMixedToolBody = `{
+	"model":"claude-opus-4-7",
+	"system":"You are a helpful coding assistant.",
+	"messages":[{"role":"user","content":"fix the bug"}],
+	"tools":[
+		{"name":"Read","description":"r","input_schema":{"type":"object"}},
+		{"name":"Edit","description":"e","input_schema":{"type":"object"}},
+		{"name":"Write","description":"w","input_schema":{"type":"object"}},
+		{"name":"Bash","description":"b","input_schema":{"type":"object"}},
+		{"name":"Task","description":"sub-agent dispatch","input_schema":{"type":"object"}},
+		{"name":"TaskCreate","description":"","input_schema":{"type":"object"}},
+		{"name":"TaskUpdate","description":"","input_schema":{"type":"object"}},
+		{"name":"TaskList","description":"","input_schema":{"type":"object"}},
+		{"name":"EnterPlanMode","description":"","input_schema":{"type":"object"}},
+		{"name":"ExitPlanMode","description":"","input_schema":{"type":"object"}},
+		{"name":"Skill","description":"","input_schema":{"type":"object"}},
+		{"name":"Workflow","description":"","input_schema":{"type":"object"}},
+		{"name":"AskUserQuestion","description":"","input_schema":{"type":"object"}},
+		{"name":"NotebookEdit","description":"","input_schema":{"type":"object"}}
+	],
+	"max_tokens":256
+}`
+
+func TestStripCCTools_AnthropicSourceOpenAITarget_DropsCCOnlyKeepsReal(t *testing.T) {
+	env, err := translate.ParseAnthropic([]byte(claudeCodeMixedToolBody))
+	require.NoError(t, err)
+
+	out, err := env.PrepareOpenAI(nil, translate.EmitOptions{TargetModel: "deepseek/deepseek-v4-pro"})
+	require.NoError(t, err)
+
+	names := emittedToolNames(t, out.Body)
+	assert.ElementsMatch(t, []string{"Read", "Edit", "Write", "Bash"}, names,
+		"only real coding tools survive; every CC-only schema must be stripped on the Anthropic→OpenAI emit path")
+}
+
+func TestStripCCTools_AnthropicSourceGeminiTarget_DropsCCOnlyKeepsReal(t *testing.T) {
+	env, err := translate.ParseAnthropic([]byte(claudeCodeMixedToolBody))
+	require.NoError(t, err)
+
+	out, err := env.PrepareGemini(http.Header{}, translate.EmitOptions{TargetModel: "gemini-3.1-pro-preview"})
+	require.NoError(t, err)
+
+	names := emittedGeminiToolNames(t, out.Body)
+	assert.ElementsMatch(t, []string{"Read", "Edit", "Write", "Bash"}, names,
+		"Anthropic→Gemini emit path must drop CC-only schemas before functionDeclarations")
+}
+
+func TestStripCCTools_AnthropicSourceAnthropicTarget_KeepsCCOnly(t *testing.T) {
+	// Anthropic models DO know how to dispatch Task/Skill/etc. via the
+	// client. The Anthropic→Anthropic passthrough must not strip them.
+	env, err := translate.ParseAnthropic([]byte(claudeCodeMixedToolBody))
+	require.NoError(t, err)
+
+	out, err := env.PrepareAnthropic(nil, translate.EmitOptions{TargetModel: "claude-opus-4-7"})
+	require.NoError(t, err)
+
+	var doc map[string]any
+	require.NoError(t, json.Unmarshal(out.Body, &doc))
+	tools, _ := doc["tools"].([]any)
+	var got []string
+	for _, t := range tools {
+		tool, _ := t.(map[string]any)
+		if tool == nil {
+			continue
+		}
+		if name, _ := tool["name"].(string); name != "" {
+			got = append(got, name)
+		}
+	}
+	assert.Contains(t, got, "Task", "Anthropic passthrough must keep Task — only the cross-provider emit strips it")
+	assert.Contains(t, got, "TaskUpdate")
+	assert.Contains(t, got, "Skill")
+	assert.Contains(t, got, "Read", "real coding tools must also survive on passthrough")
+}
+
+func TestStripCCTools_NoCCToolsNoRewrite(t *testing.T) {
+	// When the request carries no CC-only tools, the filter must not
+	// re-serialize the body (cheap fast path).
+	src := []byte(`{
+		"model":"claude-opus-4-7",
+		"system":"sys",
+		"messages":[{"role":"user","content":"hi"}],
+		"tools":[
+			{"name":"Read","description":"r","input_schema":{"type":"object"}},
+			{"name":"Bash","description":"b","input_schema":{"type":"object"}}
+		],
+		"max_tokens":256
+	}`)
+	env, err := translate.ParseAnthropic(src)
+	require.NoError(t, err)
+
+	out, err := env.PrepareOpenAI(nil, translate.EmitOptions{TargetModel: "deepseek/deepseek-v4-pro"})
+	require.NoError(t, err)
+
+	assert.ElementsMatch(t, []string{"Read", "Bash"}, emittedToolNames(t, out.Body))
+}
+
+func TestStripCCTools_NoToolsAtAll(t *testing.T) {
+	// Requests without a tools field must pass through unchanged — the
+	// filter is a no-op on the most common shape.
+	src := []byte(`{
+		"model":"claude-opus-4-7",
+		"messages":[{"role":"user","content":"hi"}],
+		"max_tokens":256
+	}`)
+	env, err := translate.ParseAnthropic(src)
+	require.NoError(t, err)
+
+	out, err := env.PrepareOpenAI(nil, translate.EmitOptions{TargetModel: "deepseek/deepseek-v4-pro"})
+	require.NoError(t, err)
+
+	var doc map[string]any
+	require.NoError(t, json.Unmarshal(out.Body, &doc))
+	_, has := doc["tools"]
+	assert.False(t, has, "no tools field on input must mean no tools field on output")
+}
+
+func TestStripCCTools_AllToolsCCOnly_DropsToEmpty(t *testing.T) {
+	// Degenerate case: every tool is CC-only. Filter returns an empty
+	// tools array. Downstream emit must treat this as no-tools (the
+	// reminder gate uses hasNonEmptyTools which checks length).
+	src := []byte(`{
+		"model":"claude-opus-4-7",
+		"messages":[{"role":"user","content":"hi"}],
+		"tools":[
+			{"name":"Task","input_schema":{"type":"object"}},
+			{"name":"Skill","input_schema":{"type":"object"}}
+		],
+		"max_tokens":256
+	}`)
+	env, err := translate.ParseAnthropic(src)
+	require.NoError(t, err)
+
+	out, err := env.PrepareOpenAI(nil, translate.EmitOptions{TargetModel: "deepseek/deepseek-v4-pro"})
+	require.NoError(t, err)
+
+	assert.Empty(t, emittedToolNames(t, out.Body))
+}

--- a/internal/translate/emit_gemini.go
+++ b/internal/translate/emit_gemini.go
@@ -50,7 +50,11 @@ func (e *RequestEnvelope) PrepareGemini(_ http.Header, opts EmitOptions) (provid
 			return providers.PreparedRequest{}, err
 		}
 	case FormatAnthropic:
-		writeGeminiFromAnthropic(jw, e.body, opts)
+		filtered, err := filterClaudeCodeOnlyToolsFromAnthropicBody(e.body)
+		if err != nil {
+			return providers.PreparedRequest{}, fmt.Errorf("strip claude-code-only tools: %w", err)
+		}
+		writeGeminiFromAnthropic(jw, filtered, opts)
 	default:
 		return providers.PreparedRequest{}, fmt.Errorf("unsupported source format for Gemini emit: %d", e.format)
 	}

--- a/internal/translate/emit_openai.go
+++ b/internal/translate/emit_openai.go
@@ -134,7 +134,10 @@ func targetIsOpenRouter(opts EmitOptions) bool {
 }
 
 func (e *RequestEnvelope) buildOpenAIFromAnthropic(opts EmitOptions) ([]byte, error) {
-	body := e.body
+	body, err := filterClaudeCodeOnlyToolsFromAnthropicBody(e.body)
+	if err != nil {
+		return nil, fmt.Errorf("strip claude-code-only tools: %w", err)
+	}
 	jw := newJSONWriter()
 	jw.Obj()
 	jw.Key("model")
@@ -210,7 +213,7 @@ func (e *RequestEnvelope) buildOpenAIFromAnthropic(opts EmitOptions) ([]byte, er
 	}
 
 	jw.EndObj()
-	body, err := applyQwen3SamplersIfNeeded(jw.Bytes(), opts.TargetModel)
+	body, err = applyQwen3SamplersIfNeeded(jw.Bytes(), opts.TargetModel)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary

Mitigation #1 from the v0.57 SWE-bench Verified empty-patch postmortem. Strips Claude-Code-only tool schemas (Task family, plan-mode toggles, Skill, Workflow, AskUserQuestion, Cron*, NotebookEdit, Monitor, PushNotification, RemoteTrigger, Worktree*, LSP, *McpResourceTool — 24 names total) from the request body before serializing to OpenAI-compat or Gemini upstreams.

## Why

These tools are implemented by Claude Code internally — they have no server-side behavior in any provider. Anthropic models recognize them and dispatch via the client; non-Anthropic models routinely hallucinate calls to them, wasting turns and producing empty patches.

**Evidence from the v0.57 eval (background grep audit, 299 router shards across v0.57+v0.58 runs):**

- **224 phantom CC-only `tool_use` blocks** emitted by non-Anthropic upstreams on the v0.57 run.
- **96%** of phantom calls in the `Task*` family — TaskUpdate (108), TaskCreate (36), TaskList (12), TaskGet (rest).
- **Dominant offenders:** gemini-3.1-pro-preview (123), gemini-3.5-flash (54), gpt-5.5 (47).
- **31 distinct shards** emitted ≥1 CC-only call; 11 of those landed in the 41-shard empty-patch subset (27%).
- Anthropic models also emitted CC-tool calls (6 across 17 pure-Anthropic shards) but at ~5× lower rate per shard, AND Anthropic dispatches them correctly — so we deliberately keep them on the Anthropic→Anthropic path.

## What changed

- `filterClaudeCodeOnlyToolsFromAnthropicBody(body) ([]byte, error)` — gjson scan, sjson rewrite, no-op fast path on bodies that don't carry any matching tools.
- `buildOpenAIFromAnthropic` (`emit_openai.go`) — calls the filter before the OpenAI conversion. Anthropic→non-Anthropic-OpenAI emit path.
- `PrepareGemini` `FormatAnthropic` branch (`emit_gemini.go`) — calls the filter before `writeGeminiFromAnthropic`. Anthropic→Gemini emit path.
- Anthropic→Anthropic passthrough and the same-format OpenAI→OpenAI / Gemini→Gemini emit paths are untouched.

## Files

- `internal/translate/claudecode_tool_filter.go` — filter implementation + the 24-name set
- `internal/translate/claudecode_tool_filter_test.go` — 6 new tests
- `internal/translate/emit_openai.go` — wire filter into `buildOpenAIFromAnthropic`
- `internal/translate/emit_gemini.go` — wire filter into `PrepareGemini` Anthropic case

## Test plan

- [x] Filter strips CC-only tools on Anthropic→OpenAI emit; real coding tools (Read/Edit/Write/Bash) survive
- [x] Same on Anthropic→Gemini emit
- [x] Anthropic→Anthropic passthrough keeps CC-only tools (correctness for Anthropic models that need them)
- [x] No-op fast path on bodies with no CC tools and on bodies with no tools array at all
- [x] All-CC-only edge case: filter returns empty tools array; downstream emit handles correctly
- [x] Full router test suite passes
- [ ] Land then re-run a 50-shard SWE-bench bake-off on v0.58 to measure the empty-patch delta
- [ ] Watch staging logs for any post-deploy 4xx spike from upstream complaining about a now-missing tool the model expected

## Follow-ups

- This is one of three mitigations from the v0.57 postmortem. #276 (Gemini reminder + JSON validation gate) already merged.
- Mitigations #3 (Gemini temp=1.0) and #4 (persisted-output synthetic user) remain deferred pending evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)