### PR TITLE
fix(translate): widen deepseek OpenRouter failover to a caching-capable backend list

### DIFF
--- a/internal/translate/provider_hint.go
+++ b/internal/translate/provider_hint.go
@@ -6,11 +6,20 @@ import "strings"
 // that need pinning to caching-capable backends. Without a hint, OpenRouter
 // load-balances by price and picks hosts without prefix caching, which breaks
 // agentic workloads re-sending large transcripts each turn.
+//
+// The order lists multiple full-precision, prefix-caching backends rather than a
+// single one: with allow_fallbacks:false a one-element order makes OpenRouter
+// return 404 ("No endpoints found") whenever that single backend has no live
+// endpoint, which turns a transient backend outage into a hard request failure —
+// fatal on the failover path where OpenRouter is already the last resort after a
+// direct-provider timeout. Listing deepseek then fireworks keeps the strict
+// caching guarantee (allow_fallbacks stays false, so OpenRouter never drops to a
+// non-caching or quantized host) while surviving a single backend going dark.
 func openRouterProviderHint(model string) map[string]any {
 	switch {
 	case strings.HasPrefix(model, "deepseek/"):
 		return map[string]any{
-			"order":           []string{"deepseek"},
+			"order":           []string{"deepseek", "fireworks"},
 			"allow_fallbacks": false,
 		}
 	case strings.HasPrefix(model, "moonshotai/"):

--- a/internal/translate/provider_hint_test.go
+++ b/internal/translate/provider_hint_test.go
@@ -36,9 +36,10 @@ func TestPrepareOpenAI_AnthropicSource_InjectsDeepSeekProviderHint(t *testing.T)
 	p := providerField(t, out.Body)
 	require.NotNil(t, p, "expected provider hint for deepseek/* target")
 	order, _ := p["order"].([]any)
-	require.Len(t, order, 1)
-	assert.Equal(t, "deepseek", order[0])
-	assert.Equal(t, false, p["allow_fallbacks"])
+	require.Len(t, order, 2)
+	assert.Equal(t, "deepseek", order[0], "native DeepSeek (cheapest cache reads) stays the preferred backend")
+	assert.Equal(t, "fireworks", order[1], "fireworks is the full-precision caching fallback when deepseek is unavailable")
+	assert.Equal(t, false, p["allow_fallbacks"], "fallbacks stay disabled so OpenRouter never drops to a non-caching/quantized host")
 }
 
 func TestPrepareOpenAI_AnthropicSource_InjectsMoonshotProviderHint(t *testing.T) {
@@ -72,8 +73,9 @@ func TestPrepareOpenAI_OpenAISource_InjectsProviderHint(t *testing.T) {
 	p := providerField(t, out.Body)
 	require.NotNil(t, p, "OpenAI→OpenAI path must inject the hint too")
 	order, _ := p["order"].([]any)
-	require.Len(t, order, 1)
+	require.Len(t, order, 2)
 	assert.Equal(t, "deepseek", order[0])
+	assert.Equal(t, "fireworks", order[1])
 }
 
 func TestPrepareOpenAI_NoHintForUnrecognizedModel(t *testing.T) {


### PR DESCRIPTION
## Problem

A production `deepseek/deepseek-v4-pro` request failed over from Fireworks (which hit an `http2: timeout awaiting response headers`) to OpenRouter and got:

```
{"error":{"message":"No endpoints found for deepseek/deepseek-v4-pro.","code":404}}
```

The OpenRouter body was `{"provider":{"order":["deepseek"],"allow_fallbacks":false}}`. With a single-element `order` and fallbacks disabled, OpenRouter returns **404** whenever that one backend (native DeepSeek) has no live endpoint at request time. The slug itself is valid and currently served by 14 backends — this was a transient single-backend outage being turned into a hard request failure, on the path that is *already* the last resort after a direct-provider timeout.

## Fix

Widen the deepseek `order` to `["deepseek", "fireworks"]`. Both are full-precision, prefix-caching backends, and `allow_fallbacks` stays `false` so OpenRouter still never load-balances onto a non-caching or quantized (fp8/fp4) host. Native DeepSeek — by far the cheapest cache reads (~$0.0036/1M vs fireworks ~$0.145/1M) — stays preferred; fireworks only serves when DeepSeek is unavailable.

## Scope note

The `moonshotai/*` hint has the same single-element `order` + `allow_fallbacks:false` shape and the same latent failure mode, but it hasn't fired in prod, so it's left unchanged here to keep this scoped to the observed incident.

## Test

Updated `provider_hint_test.go` to assert the two-backend order and that `allow_fallbacks` stays false. Existing failover integration test (`TestProxyMessages_FireworksFailureFallbackToOpenRouter`) still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)