### PR TITLE
fix(proxy): universal preludeBuffer + invalid_tool_args_blocks observability

### DIFF
--- a/internal/proxy/failover_integration_test.go
+++ b/internal/proxy/failover_integration_test.go
@@ -232,14 +232,15 @@ func TestProxyMessages_SingleBindingPreservesEagerPrelude(t *testing.T) {
 	assert.Empty(t, rec.Header().Get("x-router-fallback-from"))
 }
 
-// TestProxyMessages_SingleBindingStreamingErrorAfterPrelude reproduces the
-// review finding: when a single-binding cross-format streaming request
-// has Prelude committed (HTTP 200 + `message_start` already on the wire)
-// and the upstream then returns a buffered 503, the response must
-// terminate as an in-stream `event: error` SSE frame — NOT a trailing
-// JSON envelope, which would corrupt the SSE stream the client is
-// parsing.
-func TestProxyMessages_SingleBindingStreamingErrorAfterPrelude(t *testing.T) {
+// TestProxyMessages_SingleBindingStreamingPreCommitError asserts the fixed
+// behavior: when a single-binding cross-format streaming request gets an
+// upstream error BEFORE any upstream byte arrives, the preludeBuffer
+// discards the buffered prelude and the client receives a clean
+// Anthropic-shape JSON error envelope at the upstream's status — not a
+// stranded `message_start` text-only turn that Claude Code would reject
+// for missing tool_use. This is the v0.58 SWE-bench bake-off regression
+// fix.
+func TestProxyMessages_SingleBindingStreamingPreCommitError(t *testing.T) {
 	// Stub upstream OpenAI-compat provider that 503s on every request.
 	stub := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
@@ -265,14 +266,16 @@ func TestProxyMessages_SingleBindingStreamingErrorAfterPrelude(t *testing.T) {
 
 	_ = svc.ProxyMessages(context.Background(), body, rec, req)
 
-	assert.Equal(t, http.StatusOK, rec.Code, "Prelude already committed 200; status stays 200")
-	assert.Equal(t, "text/event-stream", rec.Header().Get("Content-Type"),
-		"Content-Type stays SSE; we do not write a trailing JSON envelope that would corrupt the stream")
+	assert.Equal(t, http.StatusServiceUnavailable, rec.Code,
+		"pre-commit upstream error surfaces upstream's status, not a stranded HTTP 200")
+	assert.Equal(t, "application/json", rec.Header().Get("Content-Type"),
+		"pre-commit error is a clean JSON envelope, not a half-emitted SSE stream")
 
 	respBody := rec.Body.String()
-	assert.Contains(t, respBody, "event: message_start", "Prelude bytes still on the wire")
-	assert.Contains(t, respBody, "event: error", "in-stream error event terminates the SSE stream coherently")
-	assert.Contains(t, respBody, `"type":"error"`, "error event body is Anthropic-shape")
+	assert.NotContains(t, respBody, "event: message_start",
+		"prelude bytes were buffered and discarded — no stranded marker on the wire")
+	assert.NotContains(t, respBody, "✦ **Weave Router**",
+		"routing marker discarded with the prelude buffer")
+	assert.Contains(t, respBody, `"type":"error"`, "Anthropic-shape error envelope")
 	assert.Contains(t, respBody, "upstream unavailable", "translated upstream message reaches the client")
-	assert.NotContains(t, respBody, "\n\n{", "no trailing JSON-after-double-newline that would break SSE parsers")
 }

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -915,19 +915,21 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 
 	ctx = resolveAndInjectCredentials(ctx, decision.Provider, r.Header)
 
-	// Determine binding list up front. When more than one is eligible, wrap
-	// the client writer with a preludeBuffer so the per-attempt Prelude
-	// bytes don't commit the response before the upstream first byte —
-	// otherwise the first attempt's Prelude would lock in HTTP 200 +
-	// message_start and any retry would smash a second response envelope
-	// onto the wire.
+	// Wrap the client writer in a preludeBuffer for every request, not just
+	// multi-binding ones. The buffer absorbs per-attempt Prelude bytes (the
+	// routing-marker text block + message_start) so that when the upstream
+	// errors before producing its first byte, we discard the buffered prelude
+	// and render an upstream-error envelope instead of stranding the marker
+	// on the wire. Single-binding requests previously bypassed the buffer for
+	// TTFB, but the v0.58 SWE-bench bake-off attributed 46/84 empty-patch
+	// failures to that bypass: half of all upstream calls api_error'd, and
+	// each one delivered a turn that was just `✦ **Weave Router** → …` text
+	// to Claude Code, which then rejected the turn for missing tool_use.
+	// The TTFB cost is a single round-trip's worth of buffered SSE bytes
+	// (~200B) released the moment the upstream's first byte arrives.
 	bindings := s.resolveBindingsForDispatch(ctx, decision)
-	var preludeBuf *preludeBuffer
-	var rootSink http.ResponseWriter = w
-	if len(bindings) > 1 {
-		preludeBuf = newPreludeBuffer(w)
-		rootSink = preludeBuf
-	}
+	preludeBuf := newPreludeBuffer(w)
+	var rootSink http.ResponseWriter = preludeBuf
 	var captureW *captureWriter
 	var sink http.ResponseWriter = rootSink
 	if cacheEligible {
@@ -997,12 +999,14 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 				preludeBuf.Seal()
 			}
 			err := p.Proxy(actx, d, prep, translator, r)
-			// Single-binding streaming: Prelude already committed
-			// HTTP 200 + message_start; render the upstream error as
-			// an in-stream `event: error` frame so the SSE stream
-			// stays coherent rather than getting a trailing JSON
-			// envelope appended by the dispatch loop's flushErr.
-			if err != nil && env.Stream() && preludeBuf == nil {
+			// Post-commit streaming error: the preludeBuffer has already
+			// flushed HTTP 200 + message_start past the buffer to the
+			// wire, so the dispatch loop's flushErr would append a
+			// trailing JSON envelope that corrupts the SSE stream.
+			// Render the upstream error as an in-stream `event: error`
+			// frame instead. Pre-commit errors are handled cleanly by
+			// dispatchWithFallback (Discard + flushErr).
+			if err != nil && env.Stream() && preludeBuf.Committed() {
 				err = emitAnthropicSSEErrorEvent(sink, err)
 			}
 			finErr := finalizeAfterProxy(err, translator.Finalize)
@@ -1036,10 +1040,10 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 			}
 			geminiTr := translate.NewGeminiToOpenAISSETranslator(anthropicTr, d.Model, nil)
 			err := p.Proxy(actx, d, prep, geminiTr, r)
-			// Single-binding streaming: see ProxyMessages OpenAI-compat
+			// Post-commit streaming error: see ProxyMessages OpenAI-compat
 			// case for rationale — render upstream error as in-stream
 			// `event: error` rather than corrupt the SSE stream.
-			if err != nil && env.Stream() && preludeBuf == nil {
+			if err != nil && env.Stream() && preludeBuf.Committed() {
 				err = emitAnthropicSSEErrorEvent(sink, err)
 			}
 			err = finalizeAfterProxy(err, geminiTr.Finalize)
@@ -1178,7 +1182,7 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 		s.emitBilling(ctx, requestID, externalID, decision, actPricing, routeRes, in, out, cacheCreation, cacheRead)
 	}
 
-	log.Info("ProxyMessages complete", "requested_model", feats.Model, "baseline_model", s.baselineFor(feats.Model), "decision_model", decision.Model, "decision_provider", decision.Provider, "primary_provider", primaryProvider, "fallback_attempts", winnerIdx, "failover_used", finalProvider != primaryProvider, "decision_reason", decision.Reason, "requested_tier", routeRes.RequestedTier.String(), "decision_tier", catalog.TierFor(decision.Model).String(), "tier_clamped", routeRes.TierClamped, "pre_clamp_model", routeRes.PreClampModel, "embedded_tokens", len(promptText)/4, "total_input_tokens", feats.Tokens, "has_tools", feats.HasTools, "message_count", feats.MessageCount, "last_kind", feats.LastKind, "last_preview", feats.LastPreview, "embed_input", embedInput, "cross_format", crossFormat, "sticky_hit", stickyHit, "route_ms", routeMs, "proxy_ms", proxyMs, "proxy_err", proxyErr, "upstream_status", upstreamStatus(proxyErr), "upstream_finish_reason", respSummary.UpstreamFinishReason, "resp_stop_reason", respSummary.StopReason, "stop_reason_promoted", respSummary.StopReasonPromoted, "tool_use_blocks", respSummary.ToolUseBlocks, "resp_output_tokens", respSummary.OutputTokens)
+	log.Info("ProxyMessages complete", "requested_model", feats.Model, "baseline_model", s.baselineFor(feats.Model), "decision_model", decision.Model, "decision_provider", decision.Provider, "primary_provider", primaryProvider, "fallback_attempts", winnerIdx, "failover_used", finalProvider != primaryProvider, "decision_reason", decision.Reason, "requested_tier", routeRes.RequestedTier.String(), "decision_tier", catalog.TierFor(decision.Model).String(), "tier_clamped", routeRes.TierClamped, "pre_clamp_model", routeRes.PreClampModel, "embedded_tokens", len(promptText)/4, "total_input_tokens", feats.Tokens, "has_tools", feats.HasTools, "message_count", feats.MessageCount, "last_kind", feats.LastKind, "last_preview", feats.LastPreview, "embed_input", embedInput, "cross_format", crossFormat, "sticky_hit", stickyHit, "route_ms", routeMs, "proxy_ms", proxyMs, "proxy_err", proxyErr, "upstream_status", upstreamStatus(proxyErr), "upstream_finish_reason", respSummary.UpstreamFinishReason, "resp_stop_reason", respSummary.StopReason, "stop_reason_promoted", respSummary.StopReasonPromoted, "tool_use_blocks", respSummary.ToolUseBlocks, "invalid_tool_args_blocks", respSummary.InvalidToolArgsBlocks, "resp_output_tokens", respSummary.OutputTokens, "prelude_committed", preludeBuf.Committed())
 	return proxyErr
 }
 
@@ -1840,16 +1844,12 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 
 	ctx = resolveAndInjectCredentials(ctx, decision.Provider, r.Header)
 
-	// See ProxyMessages for the preludeBuffer rationale — wrap only when
-	// failover is possible so single-binding requests keep main #220's
-	// TTFB-decoupled Prelude semantics exactly.
+	// See ProxyMessages for the preludeBuffer rationale — wrap unconditionally
+	// so single-binding upstream errors don't strand the routing-marker chunk
+	// on the wire when the upstream never produces a first byte.
 	bindings := s.resolveBindingsForDispatch(ctx, decision)
-	var preludeBuf *preludeBuffer
-	var rootSink http.ResponseWriter = w
-	if len(bindings) > 1 {
-		preludeBuf = newPreludeBuffer(w)
-		rootSink = preludeBuf
-	}
+	preludeBuf := newPreludeBuffer(w)
+	var rootSink http.ResponseWriter = preludeBuf
 
 	// Responses entry point delegates the eager response.created emit to
 	// this layer because it has the post-routing binding count. Fire only
@@ -1918,11 +1918,13 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 				preludeBuf.Seal()
 			}
 			err := p.Proxy(actx, d, prep, proxyWriter, r)
-			// Single-binding streaming: the routing-marker Prelude already
-			// committed HTTP 200 + the marker chunk to the wire; render the
-			// upstream error as an in-stream `data: {...}` frame instead of
-			// letting dispatch's flushErr append a corrupting JSON envelope.
-			if err != nil && env.Stream() && preludeBuf == nil {
+			// Post-commit streaming error: the routing-marker chunk has
+			// already been flushed past the buffer to the wire; render
+			// the upstream error as an in-stream `data: {...}` frame
+			// instead of letting dispatch's flushErr append a corrupting
+			// JSON envelope. Pre-commit errors are handled by
+			// dispatchWithFallback (Discard + flushErr).
+			if err != nil && env.Stream() && preludeBuf.Committed() {
 				err = emitOpenAISSEErrorEvent(sink, err)
 			}
 			return err
@@ -1946,8 +1948,8 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 				preludeBuf.Seal()
 			}
 			err := p.Proxy(actx, d, prep, translator, r)
-			// Single-binding streaming: see same-format OpenAI case above.
-			if err != nil && env.Stream() && preludeBuf == nil {
+			// Post-commit streaming error: see same-format OpenAI case above.
+			if err != nil && env.Stream() && preludeBuf.Committed() {
 				err = emitOpenAISSEErrorEvent(sink, err)
 			}
 			return finalizeAfterProxy(err, translator.Finalize)
@@ -1971,8 +1973,8 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 				preludeBuf.Seal()
 			}
 			err := p.Proxy(actx, d, prep, translator, r)
-			// Single-binding streaming: see same-format OpenAI case above.
-			if err != nil && env.Stream() && preludeBuf == nil {
+			// Post-commit streaming error: see same-format OpenAI case above.
+			if err != nil && env.Stream() && preludeBuf.Committed() {
 				err = emitOpenAISSEErrorEvent(sink, err)
 			}
 			return finalizeAfterProxy(err, translator.Finalize)


### PR DESCRIPTION
## Summary

**The bug.** Single-binding requests bypassed `preludeBuffer` for TTFB. The routing-marker text block (`✦ **Weave Router** → <model> · best pick for this turn`) was flushed to the client immediately, before the upstream call. When the upstream then api_error'd before producing a first byte, Claude Code received a turn that was just the marker — parser rejected it with "tool call could not be parsed", empty patch.

**The data.** v0.58 SWE-bench Verified bake-off (`gs://workweave-prod-01-models-v2-training/router-eval/swebench-cc-v058-postfixes-20260602/`):
- 150 shards, 84 empty-patch (56%), 51 resolved (34%), 15 unresolved
- **73 of 150 shards (49%) stopped on `api_error`**
- Audit of all 84 empty-patch transcripts: 82/84 were bucket-C "CC parser rejected the model's turn", **46/84 (55%) had a final assistant turn containing ONLY the marker preamble — no tool_use, no other text**
- The failure hit every upstream including claude-opus-4-8 (16 empties), not just Gemini / GLM

**The fix.** Wrap every `ProxyMessages` and `ProxyOpenAIChatCompletion` request in `preludeBuffer`, not just multi-binding ones. Pre-commit upstream error → `preludeBuffer.Discard()` + dispatch loop's `flushErr` writes a clean Anthropic-shape JSON error envelope at the upstream's status. Client sees an error, not a stranded marker.

**Trade-off.** ~one round-trip's worth of buffered SSE bytes (~200B) sits in the buffer until the upstream's first byte arrives, then releases all at once. TTFB for the success path is dominated by upstream prefill, not the marker emit — perceptible cost near zero.

## Observability

Also fold two fields into the `ProxyMessages complete` log line:
- `invalid_tool_args_blocks` — the counter [#276](https://github.com/workweave/router/pull/276) added to flag tool_use blocks whose buffered `input_json_delta` payload failed JSON validation at `content_block_stop`. Previously computed and silently discarded; we had no log signal that the validator was firing.
- `prelude_committed` — direct proxy for "did the upstream produce any bytes" on every request.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./...` — all packages pass (full suite, not just touched files)
- [x] Updated `TestProxyMessages_SingleBindingStreamingErrorAfterPrelude` → `TestProxyMessages_SingleBindingStreamingPreCommitError`. Old test asserted buggy behavior (stranded message_start + in-stream event:error); new test asserts fixed behavior (clean 503 + JSON envelope, no marker on wire).
- [x] Post-commit error path (upstream sends some bytes then errors) still emits in-stream `event: error` — gated on `preludeBuf.Committed()` instead of `preludeBuf == nil`, since the buffer is now always non-nil. Existing failover integration tests cover this path.
- [ ] Stage to staging, re-run v0.58 SWE-bench-CC bake-off, verify empty-patch rate drops from 56% and that no shards return turns containing only the marker.

## Follow-ups (separate PRs)

- **Investigate the 49% api_error rate itself.** Universal buffering turns those errors into clean envelopes, but does not reduce the rate. Likely candidates: OpenRouter 429 on GLM-5.1, Gemini-3.x preview throttling, idle-timeout on long agentic turns. Memory note saved for the next bake-off pre-flight.
- **Surface `gemini_reminder_injected` + `cc_only_tools_stripped`** via a new `Stats` field on `providers.PreparedRequest`, populated by `emit_gemini.go` and `emit_openai.go`. Same observability gap as `invalid_tool_args_blocks` — currently we can't tell from logs whether [#276](https://github.com/workweave/router/pull/276)'s reminder or [#277](https://github.com/workweave/router/pull/277)'s tool filter is firing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)