### PR TITLE
fix(translate): upconvert thinking.type=enabled to adaptive for opus-4-6+

### DIFF
--- a/internal/router/model.go
+++ b/internal/router/model.go
@@ -49,7 +49,10 @@ func Lookup(model string) ModelSpec {
 }
 
 var (
-	anthropicFull     = NewSpec(CapAdaptiveThinking, CapExtendedThinking)
+	// claude-opus-4-6+ and claude-sonnet-4-6+ only accept thinking.type=adaptive;
+	// the legacy thinking.type=enabled shape returns 400 from Anthropic since the
+	// rollout of output_config.effort.
+	anthropicAdaptive = NewSpec(CapAdaptiveThinking)
 	anthropicExtended = NewSpec(CapExtendedThinking)
 )
 
@@ -65,10 +68,10 @@ var googleBase = NewSpec()
 var openAICompatBase = NewSpec()
 
 var registry = map[string]ModelSpec{
-	"claude-opus-4-8":   anthropicFull,
-	"claude-opus-4-7":   anthropicFull,
-	"claude-sonnet-4-6": anthropicFull,
-	"claude-opus-4-6":   anthropicFull,
+	"claude-opus-4-8":   anthropicAdaptive,
+	"claude-opus-4-7":   anthropicAdaptive,
+	"claude-sonnet-4-6": anthropicAdaptive,
+	"claude-opus-4-6":   anthropicAdaptive,
 
 	// claude-haiku-4-5 returns 400 "adaptive thinking is not supported on
 	// this model" when a Claude Code body with thinking.type=adaptive is

--- a/internal/router/model_test.go
+++ b/internal/router/model_test.go
@@ -24,7 +24,7 @@ func TestLookup_DateSuffixNormalization(t *testing.T) {
 		wantReasoning bool
 	}{
 		{"anthropic haiku dated", "claude-haiku-4-5-20251001", false, true, false},
-		{"anthropic opus dated", "claude-opus-4-7-20260301", true, true, false},
+		{"anthropic opus dated", "claude-opus-4-7-20260301", true, false, false},
 		{"openai dated", "gpt-4o-2024-08-06", false, false, false},
 		{"google flash registered", "gemini-2.5-flash", false, false, false},
 		{"google pro registered", "gemini-2.5-pro", false, false, false},

--- a/internal/translate/emit_same_format_test.go
+++ b/internal/translate/emit_same_format_test.go
@@ -2,6 +2,7 @@ package translate_test
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"testing"
 
@@ -243,7 +244,7 @@ func TestAnthropicSameFormat_RedactedThinkingBlocksFiltered(t *testing.T) {
 }
 
 func TestAnthropicSameFormat_ThinkingBlocksKeptForCapableModel(t *testing.T) {
-	body := []byte(`{"model":"claude-sonnet-4-6","messages":[{"role":"user","content":"hi"},{"role":"assistant","content":[{"type":"thinking","thinking":"thought"},{"type":"text","text":"reply"}]}],"max_tokens":1024,"thinking":{"type":"enabled","budget_tokens":5000}}`)
+	body := []byte(`{"model":"claude-sonnet-4-6","messages":[{"role":"user","content":"hi"},{"role":"assistant","content":[{"type":"thinking","thinking":"thought"},{"type":"text","text":"reply"}]}],"max_tokens":1024,"thinking":{"type":"adaptive"}}`)
 	opts := translate.EmitOptions{
 		TargetModel:  "claude-opus-4-7",
 		Capabilities: router.Lookup("claude-opus-4-7"),
@@ -254,6 +255,63 @@ func TestAnthropicSameFormat_ThinkingBlocksKeptForCapableModel(t *testing.T) {
 	assistantMsg, _ := msgs[1].(map[string]any)
 	content, _ := assistantMsg["content"].([]any)
 	require.Len(t, content, 2, "thinking blocks should be preserved for capable models")
+}
+
+// Pi and other legacy Anthropic clients still send the pre-rollout
+// thinking.type=enabled shape. claude-opus-4-6+ rejects that with HTTP 400, so
+// the router must upconvert to thinking.type=adaptive and inject
+// output_config.effort derived from budget_tokens. Production session
+// 019e89de-f555-755b-a98b-d00cbef7a299 hit this on 2026-06-02.
+func TestAnthropicSameFormat_EnabledThinkingUpconvertedToAdaptive(t *testing.T) {
+	tests := []struct {
+		name         string
+		budgetTokens int
+		wantEffort   string
+	}{
+		{"low budget", 2048, "low"},
+		{"medium budget (pi default)", 8192, "medium"},
+		{"high budget", 32000, "high"},
+		{"missing budget defaults to medium", 0, "medium"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			thinkingField := `"thinking":{"type":"enabled"}`
+			if tc.budgetTokens > 0 {
+				thinkingField = fmt.Sprintf(`"thinking":{"type":"enabled","budget_tokens":%d}`, tc.budgetTokens)
+			}
+			body := []byte(`{"model":"claude-opus-4-7","messages":[{"role":"user","content":"hi"}],"max_tokens":1024,` + thinkingField + `}`)
+			opts := translate.EmitOptions{
+				TargetModel:  "claude-opus-4-7",
+				Capabilities: router.Lookup("claude-opus-4-7"),
+			}
+			out := parseAndEmit(t, body, "anthropic", opts)
+
+			thinking, _ := out["thinking"].(map[string]any)
+			require.NotNil(t, thinking, "thinking should remain on the body")
+			assert.Equal(t, "adaptive", thinking["type"], "legacy enabled must be upconverted to adaptive")
+			_, hasBudget := thinking["budget_tokens"]
+			assert.False(t, hasBudget, "budget_tokens has no meaning under adaptive thinking and must be dropped")
+
+			outputConfig, _ := out["output_config"].(map[string]any)
+			require.NotNil(t, outputConfig, "output_config.effort is required when adaptive thinking is set")
+			assert.Equal(t, tc.wantEffort, outputConfig["effort"])
+		})
+	}
+}
+
+// Inbound clients that already specify output_config.effort should win over
+// the budget-derived default — the router only fills in a default when the
+// caller said nothing.
+func TestAnthropicSameFormat_EnabledThinkingPreservesExplicitEffort(t *testing.T) {
+	body := []byte(`{"model":"claude-opus-4-7","messages":[{"role":"user","content":"hi"}],"max_tokens":1024,"thinking":{"type":"enabled","budget_tokens":8192},"output_config":{"effort":"high"}}`)
+	opts := translate.EmitOptions{
+		TargetModel:  "claude-opus-4-7",
+		Capabilities: router.Lookup("claude-opus-4-7"),
+	}
+	out := parseAndEmit(t, body, "anthropic", opts)
+	outputConfig, _ := out["output_config"].(map[string]any)
+	require.NotNil(t, outputConfig)
+	assert.Equal(t, "high", outputConfig["effort"], "caller-supplied effort must not be overwritten")
 }
 
 func TestPassthroughSameFormat_FieldsScrubbed(t *testing.T) {

--- a/internal/translate/envelope.go
+++ b/internal/translate/envelope.go
@@ -304,6 +304,11 @@ type EmitOverrides struct {
 	DefaultMaxTokensValue   int64
 	InjectStreamUsage       bool
 	StripThinkingBlocks     bool
+	// RewriteThinkingAdaptive replaces the inbound thinking block with
+	// {"type":"adaptive"} and sets output_config.effort. Used when the target
+	// model only accepts adaptive thinking (claude-opus-4-6+ / sonnet-4-6+).
+	RewriteThinkingAdaptive bool
+	OutputConfigEffort      string
 }
 
 func (e *RequestEnvelope) emitSameFormat(ov EmitOverrides) ([]byte, error) {
@@ -355,6 +360,21 @@ func applyOverrides(body []byte, ov EmitOverrides) ([]byte, error) {
 			out, err = sjson.SetBytes(out, "stream_options.include_usage", true)
 			if err != nil {
 				return nil, fmt.Errorf("set stream_options.include_usage: %w", err)
+			}
+		}
+	}
+
+	if ov.RewriteThinkingAdaptive {
+		out, err = sjson.SetBytes(out, "thinking", map[string]string{"type": "adaptive"})
+		if err != nil {
+			return nil, fmt.Errorf("rewrite thinking to adaptive: %w", err)
+		}
+		if ov.OutputConfigEffort != "" {
+			if !gjson.GetBytes(out, "output_config.effort").Exists() {
+				out, err = sjson.SetBytes(out, "output_config.effort", ov.OutputConfigEffort)
+				if err != nil {
+					return nil, fmt.Errorf("set output_config.effort: %w", err)
+				}
 			}
 		}
 	}
@@ -630,6 +650,24 @@ func resolveOpenAIOverrides(body []byte, opts EmitOptions) EmitOverrides {
 	return ov
 }
 
+// effortForBudget maps the legacy thinking.budget_tokens value onto the
+// adaptive output_config.effort tier. The thresholds match Anthropic's
+// published guidance: ≤4k tokens is "low" headroom, ≤16k is "medium", and
+// anything larger is "high". Zero or missing budget defaults to "medium" so
+// pre-rollout clients keep working.
+func effortForBudget(budgetTokens int64) string {
+	switch {
+	case budgetTokens <= 0:
+		return "medium"
+	case budgetTokens <= 4096:
+		return "low"
+	case budgetTokens <= 16384:
+		return "medium"
+	default:
+		return "high"
+	}
+}
+
 func resolveAnthropicOverrides(body []byte, opts EmitOptions) EmitOverrides {
 	ov := EmitOverrides{
 		Model: opts.TargetModel,
@@ -643,7 +681,14 @@ func resolveAnthropicOverrides(body []byte, opts EmitOptions) EmitOverrides {
 		case "adaptive":
 			shouldDelete = !opts.Capabilities.Supports(router.CapAdaptiveThinking)
 		case "enabled":
-			shouldDelete = !opts.Capabilities.Supports(router.CapExtendedThinking)
+			if opts.Capabilities.Supports(router.CapExtendedThinking) {
+				// Target accepts the legacy shape; leave it untouched.
+			} else if opts.Capabilities.Supports(router.CapAdaptiveThinking) {
+				ov.RewriteThinkingAdaptive = true
+				ov.OutputConfigEffort = effortForBudget(thinkingResult.Get("budget_tokens").Int())
+			} else {
+				shouldDelete = true
+			}
 		default:
 			shouldDelete = !opts.Capabilities.Supports(router.CapAdaptiveThinking) && !opts.Capabilities.Supports(router.CapExtendedThinking)
 		}


### PR DESCRIPTION
## Summary

Anthropic now returns HTTP 400 on `claude-opus-4-6` / `4-7` / `4-8` and `claude-sonnet-4-6` when callers send the legacy `thinking.type=enabled` shape:

> `"thinking.type.enabled" is not supported for this model. Use "thinking.type.adaptive" and "output_config.effort" to control thinking behavior.`

The router was passing the legacy block through unchanged on same-format Anthropic→Anthropic requests because the catalog claimed those models still supported both shapes.

Hit in production on 2026-06-02 — session `019e89de-f555-755b-a98b-d00cbef7a299`, `request_id req_011Cbf2ksCRVbzKQB38kAy4f`. The trim-handover fallback path re-emitted pi's original `thinking:{type:"enabled",budget_tokens:8192}` to opus-4-7 and 400'd; the session is still pinned to opus-4-7 so the user keeps failing on subsequent turns.

## Changes

1. **Catalog (`internal/router/model.go`)**: drop `CapExtendedThinking` from opus-4-6 / 4-7 / 4-8 and sonnet-4-6 — they only accept adaptive thinking now. Replace the unused `anthropicFull` spec with `anthropicAdaptive`.
2. **Translator (`internal/translate/envelope.go`)**: when the inbound block is `thinking.type=enabled` and the target is adaptive-only, rewrite the block to `{"type":"adaptive"}` and synthesize `output_config.effort` from `budget_tokens`:
   - `≤ 4096` → `low`
   - `≤ 16384` → `medium`
   - `> 16384` → `high`
   - missing / zero → `medium` (default)

   Caller-supplied `output_config.effort` wins over the derived value.

The reverse direction (adaptive → strip, for haiku-4-5 / opus-4-5 / 4-1 / 4-0 which only do extended) is unchanged.

## Test plan

- [x] `go test ./internal/translate/ ./internal/router/`
- [x] `go test ./...` — all packages green
- [x] `go vet ./...` — clean
- [x] New: `TestAnthropicSameFormat_EnabledThinkingUpconvertedToAdaptive` covers the four budget bands
- [x] New: `TestAnthropicSameFormat_EnabledThinkingPreservesExplicitEffort` covers the caller-wins case
- [x] Updated: `TestAnthropicSameFormat_ThinkingBlocksKeptForCapableModel` now uses adaptive (legacy enabled is no longer "kept" for capable models)
- [x] Updated: `TestLookup_DateSuffixNormalization` flips opus-4-7 expectation to adaptive-only