### PR TITLE
feat(translate): synthesize Bash nudge when upstream emits no tool_use on a tool-bearing request

### DIFF
--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -991,7 +991,8 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 			}
 			translator := translate.NewAnthropicSSETranslator(sink, d.Model, usage).
 				WithRoutingMarker(suppressMarkerIfRequested(r.Header, routingMarkerFor(routeRes))).
-				WithEstimatedInputTokens(feats.Tokens)
+				WithEstimatedInputTokens(feats.Tokens).
+				WithRequestHadTools(feats.HasTools)
 			if err := translator.Prelude(env.Stream()); err != nil {
 				log.Error("Anthropic SSE prelude failed (OpenAI upstream)", "err", err)
 			}
@@ -1031,7 +1032,8 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 			// SSE chain: Gemini → OpenAI → Anthropic.
 			anthropicTr := translate.NewAnthropicSSETranslator(sink, d.Model, usage).
 				WithRoutingMarker(suppressMarkerIfRequested(r.Header, routingMarkerFor(routeRes))).
-				WithEstimatedInputTokens(feats.Tokens)
+				WithEstimatedInputTokens(feats.Tokens).
+				WithRequestHadTools(feats.HasTools)
 			if err := anthropicTr.Prelude(env.Stream()); err != nil {
 				log.Error("Anthropic SSE prelude failed (Gemini upstream)", "err", err)
 			}
@@ -1182,7 +1184,7 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 		s.emitBilling(ctx, requestID, externalID, decision, actPricing, routeRes, in, out, cacheCreation, cacheRead)
 	}
 
-	log.Info("ProxyMessages complete", "requested_model", feats.Model, "baseline_model", s.baselineFor(feats.Model), "decision_model", decision.Model, "decision_provider", decision.Provider, "primary_provider", primaryProvider, "fallback_attempts", winnerIdx, "failover_used", finalProvider != primaryProvider, "decision_reason", decision.Reason, "requested_tier", routeRes.RequestedTier.String(), "decision_tier", catalog.TierFor(decision.Model).String(), "tier_clamped", routeRes.TierClamped, "pre_clamp_model", routeRes.PreClampModel, "embedded_tokens", len(promptText)/4, "total_input_tokens", feats.Tokens, "has_tools", feats.HasTools, "message_count", feats.MessageCount, "last_kind", feats.LastKind, "last_preview", feats.LastPreview, "embed_input", embedInput, "cross_format", crossFormat, "sticky_hit", stickyHit, "route_ms", routeMs, "proxy_ms", proxyMs, "proxy_err", proxyErr, "upstream_status", upstreamStatus(proxyErr), "upstream_finish_reason", respSummary.UpstreamFinishReason, "resp_stop_reason", respSummary.StopReason, "stop_reason_promoted", respSummary.StopReasonPromoted, "tool_use_blocks", respSummary.ToolUseBlocks, "invalid_tool_args_blocks", respSummary.InvalidToolArgsBlocks, "resp_output_tokens", respSummary.OutputTokens, "prelude_committed", preludeBuf.Committed())
+	log.Info("ProxyMessages complete", "requested_model", feats.Model, "baseline_model", s.baselineFor(feats.Model), "decision_model", decision.Model, "decision_provider", decision.Provider, "primary_provider", primaryProvider, "fallback_attempts", winnerIdx, "failover_used", finalProvider != primaryProvider, "decision_reason", decision.Reason, "requested_tier", routeRes.RequestedTier.String(), "decision_tier", catalog.TierFor(decision.Model).String(), "tier_clamped", routeRes.TierClamped, "pre_clamp_model", routeRes.PreClampModel, "embedded_tokens", len(promptText)/4, "total_input_tokens", feats.Tokens, "has_tools", feats.HasTools, "message_count", feats.MessageCount, "last_kind", feats.LastKind, "last_preview", feats.LastPreview, "embed_input", embedInput, "cross_format", crossFormat, "sticky_hit", stickyHit, "route_ms", routeMs, "proxy_ms", proxyMs, "proxy_err", proxyErr, "upstream_status", upstreamStatus(proxyErr), "upstream_finish_reason", respSummary.UpstreamFinishReason, "resp_stop_reason", respSummary.StopReason, "stop_reason_promoted", respSummary.StopReasonPromoted, "tool_use_blocks", respSummary.ToolUseBlocks, "invalid_tool_args_blocks", respSummary.InvalidToolArgsBlocks, "text_only_turn_nudged", respSummary.TextOnlyTurnNudged, "resp_output_tokens", respSummary.OutputTokens, "prelude_committed", preludeBuf.Committed())
 	return proxyErr
 }
 

--- a/internal/translate/stream.go
+++ b/internal/translate/stream.go
@@ -3,6 +3,7 @@ package translate
 import (
 	"bufio"
 	"bytes"
+	"encoding/json"
 	"net/http"
 	"strings"
 	"time"
@@ -399,6 +400,18 @@ type AnthropicSSETranslator struct {
 	// routingMarker is emitted as a standalone text block at index 0.
 	routingMarker string
 	markerEmitted bool
+
+	// requestHadTools is true when the inbound Anthropic Messages request
+	// carried a non-empty tools array. Used at finishStream to detect the
+	// "model produced no tool_use when tools were available" case (Gemini-3.1
+	// and Mimo-v2.5 sometimes emit prose + <think> XML as plain text instead
+	// of tool_use blocks) and synthesize a recovery nudge that keeps Claude
+	// Code's agentic loop alive.
+	requestHadTools bool
+
+	// nudgeEmitted latches true when finishStream emitted the text-only
+	// recovery nudge, so Summary can surface it for log analysis.
+	nudgeEmitted bool
 }
 
 // NewAnthropicSSETranslator wraps w. Call Finalize after upstream returns.
@@ -433,6 +446,16 @@ func (t *AnthropicSSETranslator) WithEstimatedInputTokens(n int) *AnthropicSSETr
 	return t
 }
 
+// WithRequestHadTools tells the translator whether the inbound Anthropic
+// Messages request carried tools. Enables the finishStream recovery path
+// that synthesizes a Bash nudge when the upstream emitted prose/thinking
+// text but no tool_use block — the dominant residual empty-patch failure
+// mode on Gemini-3.1-Pro and Mimo-v2.5-Pro after PRs #280 / #281.
+func (t *AnthropicSSETranslator) WithRequestHadTools(hadTools bool) *AnthropicSSETranslator {
+	t.requestHadTools = hadTools
+	return t
+}
+
 // ResponseSummary reports translated-response signals an observer can log
 // after the stream completes. It exists to answer, from logs alone, what an
 // OpenAI-compat upstream actually returned and whether the tool_use stop_reason
@@ -455,6 +478,10 @@ type ResponseSummary struct {
 	// arguments that the client will likely fail to parse. See
 	// validateBufferedToolArgs.
 	InvalidToolArgsBlocks int
+	// TextOnlyTurnNudged is true when finishStream synthesized a Bash
+	// recovery nudge because the upstream produced no tool_use block on a
+	// request that had tools available. See synthesizeTextOnlyTurnNudge.
+	TextOnlyTurnNudged bool
 	// OutputTokens is the upstream completion_tokens count, when reported.
 	OutputTokens int
 }
@@ -468,6 +495,7 @@ func (t *AnthropicSSETranslator) Summary() ResponseSummary {
 		StopReasonPromoted:    t.toolUseEmitted && openAIFinishToAnthropic(t.finishReason) != "tool_use",
 		ToolUseBlocks:         t.toolUseCount,
 		InvalidToolArgsBlocks: len(t.toolArgsInvalid),
+		TextOnlyTurnNudged:    t.nudgeEmitted,
 		OutputTokens:          t.usageOutputTokens,
 	}
 }
@@ -872,6 +900,62 @@ func (t *AnthropicSSETranslator) emitValidatedToolArgsDelta(blockIdx int) error 
 	return t.emitContentBlockDeltaJSON(blockIdx, payload)
 }
 
+// routerNudgeCommand is the Bash payload synthesized when the upstream
+// produced no tool_use on a request that had tools available. The echo
+// surfaces as a tool_result in the next turn's context, nudging the model
+// to use a real tool. Bash is chosen because every Claude Code request
+// includes it in tools, making the fabricated call dispatchable.
+const routerNudgeCommand = "echo '[router] previous turn produced no tool_use; please use Edit/Write/Read/Bash/Grep — do not respond with prose or <think> tags only.'"
+
+// synthesizeTextOnlyTurnNudge fabricates a single Bash tool_use block when the
+// upstream produced an assistant turn with no tool_use blocks AND the inbound
+// request had tools available. Targets the bucket-C residual empty-patch
+// failure mode: Gemini-3.1-Pro and Mimo-v2.5-Pro sometimes emit prose plus
+// XML <think> tags as plain text, which Claude Code's strict parser refuses
+// with "tool call could not be parsed (retry also failed)" and the session
+// dies. Substituting a synthetic Bash echo turns the dead-end into a normal
+// tool_use turn: Claude Code dispatches the Bash, gets the nudge as a
+// tool_result, the next assistant turn re-emits with a real tool, and the
+// agentic loop survives.
+//
+// No-op when the upstream already emitted a tool_use, when the inbound
+// request had no tools (the model legitimately had nothing else to do), or
+// when nothing has been written to the stream yet (an unrelated upstream
+// error — preludeBuffer + flushErr handles that path).
+func (t *AnthropicSSETranslator) synthesizeTextOnlyTurnNudge() error {
+	if t.toolUseEmitted || !t.requestHadTools || !t.started {
+		return nil
+	}
+	blockIdx := t.blockIdx
+	id := "toolu_router_nudge_" + t.messageID
+	if err := t.emitContentBlockStartTool(blockIdx, id, "Bash", ""); err != nil {
+		return err
+	}
+	args, err := json.Marshal(map[string]string{
+		"command":     routerNudgeCommand,
+		"description": "router recovery nudge: previous turn had no tool_use",
+	})
+	if err != nil {
+		return err
+	}
+	if err := t.emitContentBlockDeltaJSON(blockIdx, string(args)); err != nil {
+		return err
+	}
+	if err := t.emitContentBlockStop(blockIdx); err != nil {
+		return err
+	}
+	t.blockIdx++
+	t.toolUseEmitted = true
+	t.toolUseCount++
+	t.nudgeEmitted = true
+	observability.Get().Error(
+		"AnthropicSSE synthesized text-only-turn recovery nudge",
+		"upstream_model", t.modelFromUpstream,
+		"request_model", t.requestModel,
+	)
+	return nil
+}
+
 // emitRoutingMarkerIfConfigured emits the routing marker as a standalone text
 // block at the current index, once per response.
 func (t *AnthropicSSETranslator) emitRoutingMarkerIfConfigured() error {
@@ -925,6 +1009,10 @@ func (t *AnthropicSSETranslator) finishStream() error {
 		}
 	}
 	t.toolBlocks = map[int]int{}
+
+	if err := t.synthesizeTextOnlyTurnNudge(); err != nil {
+		return err
+	}
 
 	if err := t.emitMessageDelta(); err != nil {
 		return err

--- a/internal/translate/tool_args_validation_test.go
+++ b/internal/translate/tool_args_validation_test.go
@@ -102,6 +102,84 @@ func TestAnthropicSSETranslator_FlagsEachInvalidBlockIndependently(t *testing.T)
 		"only the truncated block must be flagged; the valid sibling is unaffected")
 }
 
+// driveAnthropicSSEWithTools is driveAnthropicSSEWithSummary plus an
+// explicit "request had tools" flag, enabling the text-only-turn nudge
+// synthesis path.
+func driveAnthropicSSEWithTools(
+	t *testing.T,
+	model string,
+	hadTools bool,
+	events []string,
+) (string, translate.ResponseSummary) {
+	t.Helper()
+	rec := httptest.NewRecorder()
+	translator := translate.NewAnthropicSSETranslator(rec, model, nil).
+		WithRequestHadTools(hadTools)
+	translator.Header().Set("Content-Type", "text/event-stream")
+	translator.WriteHeader(http.StatusOK)
+	for _, e := range events {
+		_, err := translator.Write([]byte(e))
+		require.NoError(t, err)
+	}
+	require.NoError(t, translator.Finalize())
+	return rec.Body.String(), translator.Summary()
+}
+
+func TestAnthropicSSETranslator_TextOnlyTurnNudge_SynthesizesBash(t *testing.T) {
+	// Gemini / Mimo failure mode: upstream emits prose + <think> XML as
+	// plain text deltas, no tool_calls. Request HAD tools available.
+	// finishStream must synthesize a Bash tool_use so Claude Code's loop
+	// doesn't die on "tool call could not be parsed".
+	body, summary := driveAnthropicSSEWithTools(t, "gemini-3.1-pro-preview", true, []string{
+		`data: {"id":"c1","choices":[{"index":0,"delta":{"content":"<think>Let me look at the file…</think>"},"finish_reason":null}]}` + "\n\n",
+		`data: {"id":"c1","choices":[{"index":0,"delta":{"content":" I will read the relevant code first."},"finish_reason":null}]}` + "\n\n",
+		`data: {"id":"c1","choices":[{"index":0,"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":40,"completion_tokens":15}}` + "\n\n",
+		"data: [DONE]\n\n",
+	})
+
+	assert.True(t, summary.TextOnlyTurnNudged,
+		"upstream emitted no tool_use on a request with tools — nudge must fire")
+	assert.Equal(t, 1, summary.ToolUseBlocks,
+		"after the nudge the response carries exactly one synthetic tool_use block")
+	assert.Equal(t, "tool_use", summary.StopReason,
+		"stop_reason promotes to tool_use so Claude Code dispatches the synthetic call")
+	assert.Contains(t, body, `"name":"Bash"`, "synthetic call routes through Bash")
+	assert.Contains(t, body, "previous turn produced no tool_use",
+		"nudge text instructs the model to switch to real tools")
+	assert.Contains(t, body, `"id":"toolu_router_nudge_`,
+		"synthetic id is prefixed so log auditors can match it in stream transcripts")
+}
+
+func TestAnthropicSSETranslator_TextOnlyTurnNudge_NoToolsInRequest(t *testing.T) {
+	// When the inbound request had no tools the model legitimately had
+	// nothing else to do — nudge must NOT fire (would inject a Bash call
+	// the client never declared).
+	body, summary := driveAnthropicSSEWithTools(t, "claude-opus-4-8", false, []string{
+		`data: {"id":"c1","choices":[{"index":0,"delta":{"content":"Here is the explanation you asked for."},"finish_reason":null}]}` + "\n\n",
+		`data: {"id":"c1","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}` + "\n\n",
+		"data: [DONE]\n\n",
+	})
+
+	assert.False(t, summary.TextOnlyTurnNudged,
+		"text-only response is correct when no tools were available")
+	assert.Equal(t, 0, summary.ToolUseBlocks)
+	assert.NotContains(t, body, "toolu_router_nudge_",
+		"no synthetic block when tools weren't available")
+}
+
+func TestAnthropicSSETranslator_TextOnlyTurnNudge_SkippedWhenToolUseAlreadyEmitted(t *testing.T) {
+	// Normal happy path: model emitted a real tool_use. Nudge must skip.
+	_, summary := driveAnthropicSSEWithTools(t, "claude-opus-4-8", true, []string{
+		`data: {"id":"c1","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_a","type":"function","function":{"name":"Read","arguments":"{\"path\":\"a.go\"}"}}]},"finish_reason":null}]}` + "\n\n",
+		`data: {"id":"c1","choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}]}` + "\n\n",
+		"data: [DONE]\n\n",
+	})
+
+	assert.False(t, summary.TextOnlyTurnNudged,
+		"a real tool_use was emitted; nudge must not fire")
+	assert.Equal(t, 1, summary.ToolUseBlocks, "exactly one real tool_use, no synthetic addition")
+}
+
 func TestAnthropicSSETranslator_EmptyArgsNotFlagged(t *testing.T) {
 	// Some tools take no input. The upstream emits no arguments fragment at
 	// all (or an empty one). An empty buffer is the trivial case — not


### PR DESCRIPTION
## Summary

**Bucket-C fix** from the v0.59 SWE-bench Claude Code empty-patch audit (run `swebench-cc-v059-fixes-20260602`): **12 of 24 residual empty shards (50%)** were Gemini-3.1-Pro / Mimo-v2.5-Pro emitting prose plus XML `<think>` tags as plain text deltas, with **no `tool_use` block at all**. Claude Code's strict parser killed those turns with `"tool call could not be parsed (retry also failed)."` PR [#281](https://github.com/workweave/router/pull/281)'s `{}` substitute did nothing because there was no `tool_use` block to substitute INTO.

When `AnthropicSSETranslator` reaches `finishStream` with `toolUseEmitted=false` AND the inbound request had a non-empty `tools` array, synthesize a single Bash `tool_use` block carrying an echo that nudges the model toward a real tool. Claude Code dispatches the synthetic Bash, gets the echo back as a `tool_result`, and the next assistant turn re-emits in context of that reminder — the agentic loop survives instead of hitting CC's dead-end sentinel.

## Plumbing

- `AnthropicSSETranslator` gains `requestHadTools` + `nudgeEmitted` fields
- New builder `WithRequestHadTools(bool)`, wired from `feats.HasTools` at both translator construction sites in `proxy/service.go` (OpenAI-compat upstream + Gemini upstream)
- `ResponseSummary` surfaces `TextOnlyTurnNudged`; `ProxyMessages complete` log line now includes `text_only_turn_nudged` so we can measure firing rate

## Skipped when

- A real `tool_use` already emitted (happy path) — `toolUseEmitted` already true
- Inbound request had no tools (the model legitimately had nothing else to do) — `requestHadTools` false
- Nothing has been written to the stream yet (unrelated upstream error handled by `preludeBuffer` + `flushErr`) — `started` false

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./...` — all packages pass
- [x] `TestAnthropicSSETranslator_TextOnlyTurnNudge_SynthesizesBash`: asserts synthetic Bash + `stop_reason=tool_use` + recognizable `toolu_router_nudge_` ID prefix
- [x] `TestAnthropicSSETranslator_TextOnlyTurnNudge_NoToolsInRequest`: asserts the nudge does NOT fire on text-only responses to tool-less requests
- [x] `TestAnthropicSSETranslator_TextOnlyTurnNudge_SkippedWhenToolUseAlreadyEmitted`: asserts the nudge skips on the happy path
- [ ] After merge + WW gitlink bump + staging deploy: re-run SWE-bench-CC slice with `ROUTER_CLUSTER_VERSION=v0.59`. Expect (1) bucket-C empties to drop from 12 to ~0, (2) resolve rate to climb above 78%, (3) `text_only_turn_nudged=true` log entries on the surviving Gemini-3.1-Pro turns that would have died

## Related work

Companion PRs landing alongside:
- Bucket B (explore-without-edit) — separate PR
- Bucket A (preludeBuffer marker-rescue) — separate PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)