### PR TITLE
feat(translate): inject explore-loop system reminder after ≥10 Read/Grep/Glob with zero Edit

### DIFF
--- a/internal/translate/emit_anthropic.go
+++ b/internal/translate/emit_anthropic.go
@@ -527,6 +527,15 @@ func writeAnthropicSharedParams(jw *jsonWriter, body []byte) {
 }
 
 func (e *RequestEnvelope) buildAnthropicFromAnthropic(opts EmitOptions) ([]byte, error) {
+	// Apply the explore-loop reminder to the inbound Anthropic body before
+	// passing it through. emitSameFormat re-serialises e.body so we mutate
+	// e.body directly. The reminder no-ops on requests below the
+	// exploreLoopMinReads threshold or where Edit/Write has already fired.
+	mutated, _, err := applyExploreLoopReminderToAnthropicBody(e.body)
+	if err != nil {
+		return nil, fmt.Errorf("inject explore-loop reminder: %w", err)
+	}
+	e.body = mutated
 	ov := resolveAnthropicOverrides(e.body, opts)
 	return e.emitSameFormat(ov)
 }

--- a/internal/translate/emit_gemini.go
+++ b/internal/translate/emit_gemini.go
@@ -54,6 +54,10 @@ func (e *RequestEnvelope) PrepareGemini(_ http.Header, opts EmitOptions) (provid
 		if err != nil {
 			return providers.PreparedRequest{}, fmt.Errorf("strip claude-code-only tools: %w", err)
 		}
+		filtered, _, err = applyExploreLoopReminderToAnthropicBody(filtered)
+		if err != nil {
+			return providers.PreparedRequest{}, fmt.Errorf("inject explore-loop reminder: %w", err)
+		}
 		writeGeminiFromAnthropic(jw, filtered, opts)
 	default:
 		return providers.PreparedRequest{}, fmt.Errorf("unsupported source format for Gemini emit: %d", e.format)

--- a/internal/translate/emit_openai.go
+++ b/internal/translate/emit_openai.go
@@ -138,6 +138,10 @@ func (e *RequestEnvelope) buildOpenAIFromAnthropic(opts EmitOptions) ([]byte, er
 	if err != nil {
 		return nil, fmt.Errorf("strip claude-code-only tools: %w", err)
 	}
+	body, _, err = applyExploreLoopReminderToAnthropicBody(body)
+	if err != nil {
+		return nil, fmt.Errorf("inject explore-loop reminder: %w", err)
+	}
 	jw := newJSONWriter()
 	jw.Obj()
 	jw.Key("model")

--- a/internal/translate/explore_loop_reminder.go
+++ b/internal/translate/explore_loop_reminder.go
@@ -1,0 +1,122 @@
+package translate
+
+import (
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
+)
+
+// exploreLoopMinReads is the explore-tool count above which a request that
+// hasn't yet seen an Edit/Write/MultiEdit tool_use triggers the explore-loop
+// reminder. Set at 10 from the v0.59 SWE-bench Claude Code empty-patch
+// audit: bucket-B failures averaged 45+ Read/Grep calls before the model
+// gave up; reminding at 10 catches the loop before it cements.
+const exploreLoopMinReads = 10
+
+// exploreLoopReminderText is appended to the request's system prompt when the
+// detector fires. The wording mirrors geminiSystemReminder's framing but is
+// upstream-agnostic — bucket-B failures hit Gemini-3.1-Pro AND Opus-4.8.
+const exploreLoopReminderText = "You have spent multiple turns exploring this codebase with Read/Grep/Glob without applying an Edit, Write, or MultiEdit. The task requires modifying code; exploration alone will not solve it. After your next Read or Grep call, your next step MUST be an Edit/Write/MultiEdit call. A turn that explores files without producing an edit counts as the model giving up."
+
+// claudeCodeExploreToolNames is the set of tools the detector counts as
+// "explore" actions on Claude Code Anthropic Messages requests. Bash is
+// deliberately excluded — Bash can be either explore (ls, grep) or edit
+// (echo >file, sed -i) and over-counting would fire the reminder on legit
+// repair sessions.
+var claudeCodeExploreToolNames = map[string]struct{}{
+	"Read": {},
+	"Grep": {},
+	"Glob": {},
+	"LS":   {},
+}
+
+// claudeCodeEditToolNames is the set of tools that, if present anywhere in
+// the conversation history, suppress the reminder. The model has clearly
+// already crossed from exploration into edit, so further Read calls are not
+// a stuck-loop signal.
+var claudeCodeEditToolNames = map[string]struct{}{
+	"Edit":         {},
+	"Write":        {},
+	"MultiEdit":    {},
+	"NotebookEdit": {},
+}
+
+// countAnthropicExploreVsEditTools walks an Anthropic Messages request body
+// and counts tool_use blocks in assistant-role messages, bucketing into
+// "explore" and "edit". Used by applyExploreLoopReminderToAnthropicBody.
+func countAnthropicExploreVsEditTools(body []byte) (explores, edits int) {
+	messages := gjson.GetBytes(body, "messages")
+	if !messages.Exists() || !messages.IsArray() {
+		return 0, 0
+	}
+	messages.ForEach(func(_, msg gjson.Result) bool {
+		if msg.Get("role").String() != "assistant" {
+			return true
+		}
+		content := msg.Get("content")
+		if !content.IsArray() {
+			return true
+		}
+		content.ForEach(func(_, block gjson.Result) bool {
+			if block.Get("type").String() != "tool_use" {
+				return true
+			}
+			name := block.Get("name").String()
+			if _, ok := claudeCodeExploreToolNames[name]; ok {
+				explores++
+			} else if _, ok := claudeCodeEditToolNames[name]; ok {
+				edits++
+			}
+			return true
+		})
+		return true
+	})
+	return explores, edits
+}
+
+// applyExploreLoopReminderToAnthropicBody mutates the request body to append
+// exploreLoopReminderText to the `system` field IFF the conversation history
+// shows ≥exploreLoopMinReads Read/Grep/Glob/LS tool_use blocks AND zero
+// Edit/Write/MultiEdit blocks. Returns (mutatedBody, fired, err). On parse
+// failure or when the detector doesn't fire, returns (body, false, nil) so
+// callers can apply it unconditionally without paying a re-serialize cost.
+//
+// Bucket-B fix from the v0.59 SWE-bench Claude Code empty-patch audit:
+// 8 of 24 residual empty shards (33%) were Gemini-3.1-Pro and Opus-4.8
+// running 45+ Read/Grep calls per session without ever calling Edit/Write,
+// then end_turning. This reminder injects after the 10th explore tool,
+// nudging the model to switch from research to action.
+//
+// Handles all three Anthropic `system` shapes: absent (omit, fine), string
+// (append with double newline), array of content blocks (append text block).
+func applyExploreLoopReminderToAnthropicBody(body []byte) ([]byte, bool, error) {
+	explores, edits := countAnthropicExploreVsEditTools(body)
+	if explores < exploreLoopMinReads || edits > 0 {
+		return body, false, nil
+	}
+	systemResult := gjson.GetBytes(body, "system")
+	if !systemResult.Exists() {
+		out, err := sjson.SetBytes(body, "system", exploreLoopReminderText)
+		return out, err == nil, err
+	}
+	if systemResult.Type == gjson.String {
+		newContent := systemResult.String() + "\n\n" + exploreLoopReminderText
+		out, err := sjson.SetBytes(body, "system", newContent)
+		return out, err == nil, err
+	}
+	if systemResult.IsArray() {
+		jw := newJSONWriter()
+		jw.Obj()
+		jw.Key("type")
+		jw.Str("text")
+		jw.Key("text")
+		jw.Str(exploreLoopReminderText)
+		jw.EndObj()
+		out, err := sjson.SetRawBytes(body, "system.-1", jw.Bytes())
+		return out, err == nil, err
+	}
+	// Unknown shape (object, number, etc.) — leave body alone rather than
+	// corrupt it. The detector having fired with no injection happens is
+	// recoverable: the reminder doesn't reach the model this turn but the
+	// next turn re-evaluates.
+	return body, false, nil
+}

--- a/internal/translate/explore_loop_reminder_test.go
+++ b/internal/translate/explore_loop_reminder_test.go
@@ -1,0 +1,106 @@
+package translate
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+)
+
+// helper: build an Anthropic Messages body with N assistant turns each
+// containing one tool_use block. The first len(names) turns use the names
+// listed; remaining turns repeat the last name.
+func anthropicBodyWithToolHistory(t *testing.T, names ...string) []byte {
+	t.Helper()
+	var b strings.Builder
+	b.WriteString(`{"model":"claude-opus-4-8","max_tokens":1024,"messages":[`)
+	b.WriteString(`{"role":"user","content":"fix the bug"}`)
+	for i, name := range names {
+		b.WriteString(`,{"role":"assistant","content":[{"type":"tool_use","id":"toolu_`)
+		b.WriteString(strings.Repeat("a", i+1))
+		b.WriteString(`","name":"`)
+		b.WriteString(name)
+		b.WriteString(`","input":{}}]}`)
+		b.WriteString(`,{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_`)
+		b.WriteString(strings.Repeat("a", i+1))
+		b.WriteString(`","content":"ok"}]}`)
+	}
+	b.WriteString(`]}`)
+	out := []byte(b.String())
+	require.True(t, gjson.ValidBytes(out), "test fixture must be valid JSON")
+	return out
+}
+
+func TestApplyExploreLoopReminder_FiresAtThreshold(t *testing.T) {
+	// 11 Reads, 0 Edits — over the 10-Read threshold.
+	body := anthropicBodyWithToolHistory(t,
+		"Read", "Read", "Read", "Grep", "Read", "Read", "Read", "Glob", "Read", "Read", "Read")
+	out, fired, err := applyExploreLoopReminderToAnthropicBody(body)
+	require.NoError(t, err)
+	assert.True(t, fired, "11 explore tool_uses with zero edits must fire the reminder")
+	system := gjson.GetBytes(out, "system").String()
+	assert.Contains(t, system, "exploration alone will not solve it",
+		"reminder text must land in the system field")
+}
+
+func TestApplyExploreLoopReminder_SkipsBelowThreshold(t *testing.T) {
+	// 9 Reads, under the 10 threshold.
+	body := anthropicBodyWithToolHistory(t,
+		"Read", "Read", "Read", "Grep", "Read", "Read", "Read", "Glob", "Read")
+	_, fired, err := applyExploreLoopReminderToAnthropicBody(body)
+	require.NoError(t, err)
+	assert.False(t, fired, "under threshold — reminder must not fire yet")
+}
+
+func TestApplyExploreLoopReminder_SkipsAfterEditFires(t *testing.T) {
+	// 12 Reads but one Edit also present — model already crossed into edit mode.
+	body := anthropicBodyWithToolHistory(t,
+		"Read", "Read", "Read", "Read", "Read", "Read", "Read", "Read", "Read", "Edit",
+		"Read", "Read", "Read")
+	_, fired, err := applyExploreLoopReminderToAnthropicBody(body)
+	require.NoError(t, err)
+	assert.False(t, fired,
+		"a single Edit anywhere in history must suppress the reminder")
+}
+
+func TestApplyExploreLoopReminder_BashIsNotCountedAsExplore(t *testing.T) {
+	// 12 Bash + zero Reads — Bash is ambiguous (could be edits via sed/echo),
+	// so the detector must NOT count it as explore.
+	body := anthropicBodyWithToolHistory(t,
+		"Bash", "Bash", "Bash", "Bash", "Bash", "Bash",
+		"Bash", "Bash", "Bash", "Bash", "Bash", "Bash")
+	_, fired, err := applyExploreLoopReminderToAnthropicBody(body)
+	require.NoError(t, err)
+	assert.False(t, fired, "Bash must not count as explore — could be edits via sed/echo")
+}
+
+func TestApplyExploreLoopReminder_AppendsToStringSystem(t *testing.T) {
+	body := anthropicBodyWithToolHistory(t,
+		"Read", "Read", "Read", "Read", "Read", "Read", "Read", "Read", "Read", "Read", "Read")
+	body = []byte(strings.Replace(string(body), `"messages":[`,
+		`"system":"You are a coding agent.","messages":[`, 1))
+	out, fired, err := applyExploreLoopReminderToAnthropicBody(body)
+	require.NoError(t, err)
+	assert.True(t, fired)
+	system := gjson.GetBytes(out, "system").String()
+	assert.True(t, strings.HasPrefix(system, "You are a coding agent."),
+		"existing string system content must be preserved as a prefix")
+	assert.Contains(t, system, "exploration alone will not solve it")
+}
+
+func TestApplyExploreLoopReminder_AppendsToArraySystem(t *testing.T) {
+	body := anthropicBodyWithToolHistory(t,
+		"Read", "Read", "Read", "Read", "Read", "Read", "Read", "Read", "Read", "Read", "Read")
+	body = []byte(strings.Replace(string(body), `"messages":[`,
+		`"system":[{"type":"text","text":"You are a coding agent."}],"messages":[`, 1))
+	out, fired, err := applyExploreLoopReminderToAnthropicBody(body)
+	require.NoError(t, err)
+	assert.True(t, fired)
+	system := gjson.GetBytes(out, "system")
+	require.True(t, system.IsArray(), "array shape must be preserved")
+	parts := system.Array()
+	require.Len(t, parts, 2, "original block plus appended reminder")
+	assert.Contains(t, parts[1].Get("text").String(), "exploration alone will not solve it")
+}


### PR DESCRIPTION
## Summary

**Bucket-B fix** from the v0.59 SWE-bench Claude Code empty-patch audit: **8 of 24 residual empty shards (33%)** were Gemini-3.1-Pro and Opus-4.8 running 45+ Read/Grep/Glob calls per session without ever calling Edit/Write/MultiEdit, then end_turning. The model never crossed from exploration into editing.

Detector walks the inbound Anthropic Messages body's `messages` array, counts `tool_use` blocks per name across assistant turns. When the explore count (Read + Grep + Glob + LS) hits **≥10** AND the edit count (Edit + Write + MultiEdit + NotebookEdit) is **0**, append a system-prompt reminder telling the model the next step MUST be an Edit/Write call. Bash is deliberately excluded from the explore count — it's ambiguous (could be edits via sed/echo) and over-counting would fire the reminder on legitimate repair sessions.

## Wiring

Wired into all three Anthropic-source emit paths so it covers every upstream that handles Claude Code traffic:
- `PrepareAnthropic` (Anthropic → Anthropic passthrough, claude-opus-4-8)
- `PrepareOpenAI` (Anthropic → OpenAI-compat, deepseek/qwen/etc.)
- `PrepareGemini` (Anthropic → Gemini, gemini-3.x)

Handles all three Anthropic `system` shapes:
- **Absent** → set to reminder
- **String** → append with double newline
- **Array of content blocks** → append a new `{type:"text"}` block

Non-firing path returns the body unchanged so callers can apply unconditionally with no re-serialise cost on the happy path.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./...` — all packages pass
- [x] `FiresAtThreshold` — 11 Reads, zero edits → reminder in system
- [x] `SkipsBelowThreshold` — 9 Reads → no reminder yet
- [x] `SkipsAfterEditFires` — 12 Reads but one Edit anywhere in history → no reminder (model already crossed into edit mode)
- [x] `BashIsNotCountedAsExplore` — 12 Bash, no Reads → no reminder
- [x] `AppendsToStringSystem` — preserves existing string content as prefix
- [x] `AppendsToArraySystem` — preserves existing array shape, adds new text block
- [ ] After merge + WW gitlink bump + staging deploy: re-run SWE-bench-CC slice with `ROUTER_CLUSTER_VERSION=v0.59`. Expect (1) bucket-B empties (Gemini Read-loops with no Edit) to drop, (2) average turn-to-first-Edit to decrease.

## Related work

Companion PRs (same v0.59 audit):
- [#284](https://github.com/workweave/router/pull/284) — Bucket C: synthesize Bash nudge on no-tool-use turn (covers ~63% of remaining empties)
- Bucket A (preludeBuffer marker-rescue) — incidentally covered by #284 since the nudge fires on any no-tool-use turn

🤖 Generated with [Claude Code](https://claude.com/claude-code)