### PR TITLE
feat(proxy+translate): surface cc_only_tools_stripped + gemini_reminder_injected in summary log

### DIFF
--- a/internal/providers/provider.go
+++ b/internal/providers/provider.go
@@ -156,6 +156,28 @@ func IsRetryable(err error) bool {
 type PreparedRequest struct {
 	Body    []byte
 	Headers http.Header
+	// Stats records translation-time mutations applied to the body, for
+	// observability. Zero-value when no mutation fired; populated by the
+	// translate package as a side effect of Prepare*. The proxy reads these
+	// after dispatch and folds them into the ProxyMessages-complete log so
+	// per-PR mitigation impact can be measured in production traffic.
+	Stats RequestMutationStats
+}
+
+// RequestMutationStats reports translation-time mitigations the router
+// applied to the upstream request body. Surfaced in the ProxyMessages-
+// complete log with keys:
+//   - cc_only_tools_stripped
+//   - gemini_reminder_injected
+type RequestMutationStats struct {
+	// CCOnlyToolsStripped is the count of Claude-Code-only tools removed
+	// from the request before dispatching to a non-Anthropic upstream. See
+	// translate/claudecode_tool_filter.go (router PR #277).
+	CCOnlyToolsStripped int
+	// GeminiReminderInjected is true when the Gemini 3.x tool-use reminder
+	// (geminiToolUseReminder) was appended to systemInstruction for this
+	// request. See translate/system_reminder.go (router PR #276).
+	GeminiReminderInjected bool
 }
 
 type Client interface {

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -946,6 +946,11 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 	// log. Populated by the translator-backed paths; stays zero for the
 	// Anthropic-native passthrough path, which has no translator.
 	var respSummary translate.ResponseSummary
+	// reqStats captures the translation-time mutations applied to the
+	// winning attempt's upstream request body. Overwritten on each attempt;
+	// on dispatch success it reflects the binding that actually ran. Zero
+	// for Anthropic-native passthrough — that path skips the translator.
+	var reqStats providers.RequestMutationStats
 
 	var attempt dispatchAttempt
 	switch decision.Provider {
@@ -983,6 +988,7 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 				log.Error("Failed to translate Anthropic request to OpenAI format", "err", emitErr, "decision_provider", d.Provider)
 				return fmt.Errorf("translate anthropic request: %w", emitErr)
 			}
+			reqStats = prep.Stats
 			logUpstreamBody(log, routeRes.SessionKey, d, feats, prep.Body)
 			var usage otel.UsageSink
 			if s.usageRequired() {
@@ -1017,6 +1023,7 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 	case providers.ProviderGoogle:
 		crossFormat = true
 		prep, emitErr := env.PrepareGemini(r.Header, opts)
+		reqStats = prep.Stats
 		if emitErr != nil {
 			log.Error("Failed to translate Anthropic request to Gemini format", "err", emitErr)
 			return fmt.Errorf("translate anthropic request to gemini: %w", emitErr)
@@ -1184,7 +1191,7 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 		s.emitBilling(ctx, requestID, externalID, decision, actPricing, routeRes, in, out, cacheCreation, cacheRead)
 	}
 
-	log.Info("ProxyMessages complete", "requested_model", feats.Model, "baseline_model", s.baselineFor(feats.Model), "decision_model", decision.Model, "decision_provider", decision.Provider, "primary_provider", primaryProvider, "fallback_attempts", winnerIdx, "failover_used", finalProvider != primaryProvider, "decision_reason", decision.Reason, "requested_tier", routeRes.RequestedTier.String(), "decision_tier", catalog.TierFor(decision.Model).String(), "tier_clamped", routeRes.TierClamped, "pre_clamp_model", routeRes.PreClampModel, "embedded_tokens", len(promptText)/4, "total_input_tokens", feats.Tokens, "has_tools", feats.HasTools, "message_count", feats.MessageCount, "last_kind", feats.LastKind, "last_preview", feats.LastPreview, "embed_input", embedInput, "cross_format", crossFormat, "sticky_hit", stickyHit, "route_ms", routeMs, "proxy_ms", proxyMs, "proxy_err", proxyErr, "upstream_status", upstreamStatus(proxyErr), "upstream_finish_reason", respSummary.UpstreamFinishReason, "resp_stop_reason", respSummary.StopReason, "stop_reason_promoted", respSummary.StopReasonPromoted, "tool_use_blocks", respSummary.ToolUseBlocks, "invalid_tool_args_blocks", respSummary.InvalidToolArgsBlocks, "text_only_turn_nudged", respSummary.TextOnlyTurnNudged, "resp_output_tokens", respSummary.OutputTokens, "prelude_committed", preludeBuf.Committed())
+	log.Info("ProxyMessages complete", "requested_model", feats.Model, "baseline_model", s.baselineFor(feats.Model), "decision_model", decision.Model, "decision_provider", decision.Provider, "primary_provider", primaryProvider, "fallback_attempts", winnerIdx, "failover_used", finalProvider != primaryProvider, "decision_reason", decision.Reason, "requested_tier", routeRes.RequestedTier.String(), "decision_tier", catalog.TierFor(decision.Model).String(), "tier_clamped", routeRes.TierClamped, "pre_clamp_model", routeRes.PreClampModel, "embedded_tokens", len(promptText)/4, "total_input_tokens", feats.Tokens, "has_tools", feats.HasTools, "message_count", feats.MessageCount, "last_kind", feats.LastKind, "last_preview", feats.LastPreview, "embed_input", embedInput, "cross_format", crossFormat, "sticky_hit", stickyHit, "route_ms", routeMs, "proxy_ms", proxyMs, "proxy_err", proxyErr, "upstream_status", upstreamStatus(proxyErr), "upstream_finish_reason", respSummary.UpstreamFinishReason, "resp_stop_reason", respSummary.StopReason, "stop_reason_promoted", respSummary.StopReasonPromoted, "tool_use_blocks", respSummary.ToolUseBlocks, "invalid_tool_args_blocks", respSummary.InvalidToolArgsBlocks, "text_only_turn_nudged", respSummary.TextOnlyTurnNudged, "cc_only_tools_stripped", reqStats.CCOnlyToolsStripped, "gemini_reminder_injected", reqStats.GeminiReminderInjected, "resp_output_tokens", respSummary.OutputTokens, "prelude_committed", preludeBuf.Committed())
 	return proxyErr
 }
 

--- a/internal/translate/claudecode_tool_filter.go
+++ b/internal/translate/claudecode_tool_filter.go
@@ -68,22 +68,20 @@ func isClaudeCodeOnlyTool(name string) bool {
 // blocks from past turns) is not rewritten because those represent history
 // the model has already acted on — rewriting it would invalidate prompt
 // caches and could leave dangling tool_use_id references.
-func filterClaudeCodeOnlyToolsFromAnthropicBody(body []byte) ([]byte, error) {
+func filterClaudeCodeOnlyToolsFromAnthropicBody(body []byte) (out []byte, removed int, err error) {
 	tools := gjson.GetBytes(body, "tools")
 	if !tools.Exists() || !tools.IsArray() {
-		return body, nil
+		return body, 0, nil
 	}
 
-	anyMatch := false
 	tools.ForEach(func(_, t gjson.Result) bool {
 		if isClaudeCodeOnlyTool(t.Get("name").String()) {
-			anyMatch = true
-			return false
+			removed++
 		}
 		return true
 	})
-	if !anyMatch {
-		return body, nil
+	if removed == 0 {
+		return body, 0, nil
 	}
 
 	jw := newJSONWriter()
@@ -95,5 +93,6 @@ func filterClaudeCodeOnlyToolsFromAnthropicBody(body []byte) ([]byte, error) {
 		return true
 	})
 	jw.EndArr()
-	return sjson.SetRawBytes(body, "tools", jw.Bytes())
+	out, err = sjson.SetRawBytes(body, "tools", jw.Bytes())
+	return out, removed, err
 }

--- a/internal/translate/emit_gemini.go
+++ b/internal/translate/emit_gemini.go
@@ -42,6 +42,7 @@ func (e *RequestEnvelope) PrepareGemini(_ http.Header, opts EmitOptions) (provid
 		return providers.PreparedRequest{Body: body, Headers: headers}, nil
 	}
 
+	var stats providers.RequestMutationStats
 	jw := newJSONWriter()
 	jw.Obj()
 	switch e.format {
@@ -50,13 +51,21 @@ func (e *RequestEnvelope) PrepareGemini(_ http.Header, opts EmitOptions) (provid
 			return providers.PreparedRequest{}, err
 		}
 	case FormatAnthropic:
-		filtered, err := filterClaudeCodeOnlyToolsFromAnthropicBody(e.body)
+		filtered, removed, err := filterClaudeCodeOnlyToolsFromAnthropicBody(e.body)
 		if err != nil {
 			return providers.PreparedRequest{}, fmt.Errorf("strip claude-code-only tools: %w", err)
 		}
+		stats.CCOnlyToolsStripped = removed
 		filtered, _, err = applyExploreLoopReminderToAnthropicBody(filtered)
 		if err != nil {
 			return providers.PreparedRequest{}, fmt.Errorf("inject explore-loop reminder: %w", err)
+		}
+		// Mirror writeGeminiFromAnthropic's reminder gate so Stats reflects
+		// whether the system-prompt reminder reached upstream. Computing it
+		// here costs only the model-prefix check + a tools array length
+		// glance, both already cached by the body emit path.
+		if reminder := geminiSystemReminder(opts.TargetModel); reminder != "" && hasNonEmptyTools(filtered) {
+			stats.GeminiReminderInjected = true
 		}
 		writeGeminiFromAnthropic(jw, filtered, opts)
 	default:
@@ -70,7 +79,7 @@ func (e *RequestEnvelope) PrepareGemini(_ http.Header, opts EmitOptions) (provid
 	if e.Stream() {
 		headers.Set(GeminiStreamHintHeader, "true")
 	}
-	return providers.PreparedRequest{Body: body, Headers: headers}, nil
+	return providers.PreparedRequest{Body: body, Headers: headers, Stats: stats}, nil
 }
 
 // GeminiStreamHintHeader is the synthetic header PrepareGemini sets when the

--- a/internal/translate/emit_openai.go
+++ b/internal/translate/emit_openai.go
@@ -21,12 +21,13 @@ func hasNonEmptyTools(body []byte) bool {
 // PrepareOpenAI builds an OpenAI Chat Completions request body.
 func (e *RequestEnvelope) PrepareOpenAI(in http.Header, opts EmitOptions) (providers.PreparedRequest, error) {
 	var body []byte
+	var stats providers.RequestMutationStats
 	var err error
 	switch e.format {
 	case FormatOpenAI:
 		body, err = e.buildOpenAIFromOpenAI(opts)
 	case FormatAnthropic:
-		body, err = e.buildOpenAIFromAnthropic(opts)
+		body, stats, err = e.buildOpenAIFromAnthropic(opts)
 	default:
 		return providers.PreparedRequest{}, fmt.Errorf("unsupported source format for OpenAI emit: %d", e.format)
 	}
@@ -38,7 +39,7 @@ func (e *RequestEnvelope) PrepareOpenAI(in http.Header, opts EmitOptions) (provi
 	if err != nil {
 		return providers.PreparedRequest{}, err
 	}
-	return providers.PreparedRequest{Body: body, Headers: headers}, nil
+	return providers.PreparedRequest{Body: body, Headers: headers, Stats: stats}, nil
 }
 
 // applySessionAffinity attaches an upstream-specific prompt-cache routing hint
@@ -133,14 +134,16 @@ func targetIsOpenRouter(opts EmitOptions) bool {
 	return true
 }
 
-func (e *RequestEnvelope) buildOpenAIFromAnthropic(opts EmitOptions) ([]byte, error) {
-	body, err := filterClaudeCodeOnlyToolsFromAnthropicBody(e.body)
+func (e *RequestEnvelope) buildOpenAIFromAnthropic(opts EmitOptions) ([]byte, providers.RequestMutationStats, error) {
+	var stats providers.RequestMutationStats
+	body, removed, err := filterClaudeCodeOnlyToolsFromAnthropicBody(e.body)
 	if err != nil {
-		return nil, fmt.Errorf("strip claude-code-only tools: %w", err)
+		return nil, stats, fmt.Errorf("strip claude-code-only tools: %w", err)
 	}
+	stats.CCOnlyToolsStripped = removed
 	body, _, err = applyExploreLoopReminderToAnthropicBody(body)
 	if err != nil {
-		return nil, fmt.Errorf("inject explore-loop reminder: %w", err)
+		return nil, stats, fmt.Errorf("inject explore-loop reminder: %w", err)
 	}
 	jw := newJSONWriter()
 	jw.Obj()
@@ -219,9 +222,13 @@ func (e *RequestEnvelope) buildOpenAIFromAnthropic(opts EmitOptions) ([]byte, er
 	jw.EndObj()
 	body, err = applyQwen3SamplersIfNeeded(jw.Bytes(), opts.TargetModel)
 	if err != nil {
-		return nil, err
+		return nil, stats, err
 	}
-	return applyGLM51FlagsIfNeeded(body, opts)
+	body, err = applyGLM51FlagsIfNeeded(body, opts)
+	if err != nil {
+		return nil, stats, err
+	}
+	return body, stats, nil
 }
 
 // applyGLM51FlagsIfNeeded sets the request-body knobs GLM-5.1 needs to behave


### PR DESCRIPTION
## Summary

**Deferred observability pass** from PR [#280](https://github.com/workweave/router/pull/280). The JSON validation counter and CC-only tool filter from PRs [#276](https://github.com/workweave/router/pull/276) and [#277](https://github.com/workweave/router/pull/277) fire silently. `validateBufferedToolArgs` is already in `ResponseSummary` and surfaced via #280, but the **request-side mutations have no Stats carrier at all**. After v0.59's audit we cannot tell from production logs whether the Gemini tool-use reminder is reaching upstream or whether the CC-only tool filter is removing the expected 24-name set. Empty-patch postmortems have to scrape `upstream prepared body` logs that truncate at 8KB, hiding the middle of the request.

## Change

Adds a translation-time stats carrier:

```go
// internal/providers/provider.go
type PreparedRequest struct {
    Body    []byte
    Headers http.Header
    Stats   RequestMutationStats
}

type RequestMutationStats struct {
    CCOnlyToolsStripped     int   // count from filterClaudeCodeOnlyToolsFromAnthropicBody
    GeminiReminderInjected  bool  // true when geminiSystemReminder fired
}
```

Populated in `PrepareOpenAI` and `PrepareGemini` for `FormatAnthropic` source (Claude Code path); zero-value for non-mutating paths. Threaded into `ProxyMessages`'s outer scope and folded into the existing `ProxyMessages complete` log line under keys `cc_only_tools_stripped` and `gemini_reminder_injected`.

`filterClaudeCodeOnlyToolsFromAnthropicBody` signature changes from `([]byte, error) → ([]byte, int, error)` — the removed count replaces an internal `anyMatch` flag. Both call sites updated.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./...` — all packages pass
- [ ] After deploy: query the next bake-off's logs with:
  ```
  gcloud logging read 'jsonPayload.message="ProxyMessages complete"' --format json \
    | jq -r '.[] | [.jsonPayload.decision_provider, .jsonPayload.gemini_reminder_injected, .jsonPayload.cc_only_tools_stripped] | @tsv' \
    | sort | uniq -c
  ```
  Expect Gemini-3.x requests to consistently show `gemini_reminder_injected=true` and CC-Code requests to consistently strip the same number of tools (24-name set ∩ inbound).

## Related work

Companion PRs (same v0.59 audit):
- [#284](https://github.com/workweave/router/pull/284) — Bucket C: synthesize Bash nudge on text-only turns
- [#285](https://github.com/workweave/router/pull/285) — Bucket B: explore-loop system reminder after ≥10 Read/Grep with zero Edit

After #285 lands, a follow-up will extend `RequestMutationStats` with `ExploreLoopReminderInjected` so we can measure its firing rate too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)