### PR TITLE
feat(planner): price stale pins uncached — provider-aware cache TTL

### DIFF
--- a/internal/providers/cache_ttl_test.go
+++ b/internal/providers/cache_ttl_test.go
@@ -1,0 +1,26 @@
+package providers_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"workweave/router/internal/providers"
+)
+
+func TestCacheTTLFor(t *testing.T) {
+	t.Parallel()
+
+	// Anthropic sells a 1h extended cache; the pin TTL is sized to it.
+	assert.Equal(t, time.Hour, providers.CacheTTLFor(providers.ProviderAnthropic),
+		"anthropic should report the 1h extended-cache window")
+
+	// The OSS/compat providers cache best-effort on a minutes-scale window.
+	assert.Equal(t, 5*time.Minute, providers.CacheTTLFor(providers.ProviderFireworks),
+		"fireworks should report the short best-effort window")
+
+	// Unknown providers fall back to the conservative default.
+	assert.Equal(t, providers.DefaultCacheTTL, providers.CacheTTLFor("nonexistent-provider"),
+		"unknown provider should fall back to the default TTL")
+}

--- a/internal/providers/provider.go
+++ b/internal/providers/provider.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
+	"time"
 
 	"workweave/router/internal/router"
 )
@@ -37,6 +38,36 @@ var APIKeyEnvVars = map[string]string{
 // when the provider is unknown.
 func APIKeyEnvVar(provider string) string {
 	return APIKeyEnvVars[provider]
+}
+
+// CacheTTL is the best-effort upstream prompt-cache lifetime per provider —
+// roughly how long a cached prefix survives between turns of the same session.
+// Anthropic sells a 1h extended cache, which is what pinSessionTTL is sized to;
+// the OpenAI-compatible OSS providers cache on a best-effort, minutes-scale
+// window with no documented TTL guarantee, so a pin can long outlive the cache
+// it was meant to keep warm. The planner reads this to stop crediting a stale
+// pin a cache-read discount it no longer earns.
+var CacheTTL = map[string]time.Duration{
+	ProviderAnthropic:  time.Hour,
+	ProviderOpenAI:     5 * time.Minute,
+	ProviderGoogle:     5 * time.Minute,
+	ProviderOpenRouter: 5 * time.Minute,
+	ProviderFireworks:  5 * time.Minute,
+	ProviderDeepInfra:  5 * time.Minute,
+	ProviderBedrock:    5 * time.Minute,
+}
+
+// DefaultCacheTTL is the conservative fallback cache lifetime for providers
+// absent from CacheTTL.
+const DefaultCacheTTL = 5 * time.Minute
+
+// CacheTTLFor returns the best-effort prompt-cache lifetime for a provider,
+// falling back to DefaultCacheTTL for unknown providers.
+func CacheTTLFor(provider string) time.Duration {
+	if ttl, ok := CacheTTL[provider]; ok {
+		return ttl
+	}
+	return DefaultCacheTTL
 }
 
 // HopByHopHeaders are stripped from upstream responses per RFC 7230 §6.1.

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -1213,6 +1213,7 @@ func applyPlannerAttrs(b *otel.AttrBuilder, res turnLoopResult) *otel.AttrBuilde
 		String("planner.pin_model", res.PinModel).
 		String("planner.fresh_model", res.Fresh.Model).
 		String("planner.chosen_model", res.Decision.Model).
+		Bool("planner.pin_cache_warm", !res.PlannerDecision.PinCacheCold).
 		Bool("handover.invoked", res.Handover.Invoked).
 		Int64("handover.latency_ms", res.Handover.LatencyMS).
 		Int64("handover.summary_tokens", int64(res.Handover.SummaryTokens)).
@@ -1250,6 +1251,7 @@ func (s *Service) logPlannerOutcome(ctx context.Context, res turnLoopResult) {
 			"expected_savings_usd", res.PlannerDecision.ExpectedSavingsUSD,
 			"eviction_cost_usd", res.PlannerDecision.EvictionCostUSD,
 			"threshold_usd", res.PlannerDecision.ThresholdUSD,
+			"pin_cache_warm", !res.PlannerDecision.PinCacheCold,
 			"handover_invoked", res.Handover.Invoked,
 			"handover_fallback_to_trim", res.Handover.FallbackToTrim,
 			"handover_latency_ms", res.Handover.LatencyMS,
@@ -1262,6 +1264,7 @@ func (s *Service) logPlannerOutcome(ctx context.Context, res turnLoopResult) {
 		"expected_savings_usd", res.PlannerDecision.ExpectedSavingsUSD,
 		"eviction_cost_usd", res.PlannerDecision.EvictionCostUSD,
 		"threshold_usd", res.PlannerDecision.ThresholdUSD,
+		"pin_cache_warm", !res.PlannerDecision.PinCacheCold,
 	)
 }
 

--- a/internal/proxy/turnloop.go
+++ b/internal/proxy/turnloop.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"workweave/router/internal/observability"
+	"workweave/router/internal/providers"
 	"workweave/router/internal/router"
 	"workweave/router/internal/router/catalog"
 	"workweave/router/internal/router/cluster"
@@ -33,6 +34,16 @@ func installationIDFromContext(ctx context.Context) uuid.UUID {
 		return uuid.Nil
 	}
 	return id
+}
+
+// cacheWarm reports whether the pin's upstream prompt cache is likely still
+// warm — a prior turn completed within the pinned provider's best-effort cache
+// TTL. A cold pin earns no cache-read discount in the planner's EV math.
+func cacheWarm(pin sessionpin.Pin) bool {
+	if pin.LastTurnEndedAt.IsZero() {
+		return false
+	}
+	return time.Since(pin.LastTurnEndedAt) < providers.CacheTTLFor(pin.Provider)
 }
 
 // turnLoopResult bundles the routing decision and pin/planner state.
@@ -183,6 +194,7 @@ func (s *Service) runTurnLoop(
 			"pin_provider", pin.Provider,
 			"pin_reason", pin.Reason,
 			"pin_age_s", res.PinAgeSec,
+			"pin_cache_warm", cacheWarm(pin),
 			"last_output_tokens", pin.LastOutputTokens,
 		)
 	} else {
@@ -307,6 +319,7 @@ func (s *Service) runTurnLoop(
 		Fresh:                fresh,
 		EstimatedInputTokens: feats.Tokens,
 		AvailableModels:      s.availableModels,
+		PinCacheCold:         pinFound && !cacheWarm(pin),
 	}
 	if !pinFound {
 		plannerIn.Pin = sessionpin.Pin{}

--- a/internal/router/planner/AGENTS.md
+++ b/internal/router/planner/AGENTS.md
@@ -10,12 +10,14 @@ Prism-style cache-aware EV policy. Decides STAY (preserve pinned model's upstrea
 Decide(pin, fresh router.Decision, estimated tokens, available models) → STAY | SWITCH
 ```
 
-- **Pure function.** No DB lookups, no provider calls.
-- Inputs are values: pin row, fresh decision, estimated token count, available-model set resolved at boot.
+- **Pure function.** No DB lookups, no provider calls. No clock — the proxy computes cache warmth (it owns the clock) and passes it in as `Inputs.PinCacheCold`.
+- Inputs are values: pin row, fresh decision, estimated token count, available-model set resolved at boot, and a cache-cold flag.
 
 ## Math, briefly
 
 Compares expected per-turn savings over the remaining horizon against the eviction cost of warming a new cache. The **tier-upgrade guard** fires when STAY would clearly under-serve the prompt — uses [`../catalog`](../catalog)'s Low/Mid/High tier to overturn a cost-driven "stay" when the fresh decision is in a strictly higher tier than the pin.
+
+**Cache-warmth gate.** The cache-read multipliers and eviction cost only apply while the pin's upstream cache is warm. When `Inputs.PinCacheCold` is set (the pinned provider's cache TTL has lapsed — short and best-effort on the OSS compat providers vs Anthropic's 1h window; see [`../../providers`](../../providers).`CacheTTLFor`), both sides are priced uncached so raw economics + the tier guard decide, instead of a phantom cache gluing the session to a stale pin. The zero value means "assume warm", preserving the original behavior.
 
 ## Invariants
 

--- a/internal/router/planner/CLAUDE.md
+++ b/internal/router/planner/CLAUDE.md
@@ -10,12 +10,14 @@ Prism-style cache-aware EV policy. Decides STAY (preserve pinned model's upstrea
 Decide(pin, fresh router.Decision, estimated tokens, available models) → STAY | SWITCH
 ```
 
-- **Pure function.** No DB lookups, no provider calls.
-- Inputs are values: pin row, fresh decision, estimated token count, available-model set resolved at boot.
+- **Pure function.** No DB lookups, no provider calls. No clock — the proxy computes cache warmth (it owns the clock) and passes it in as `Inputs.PinCacheCold`.
+- Inputs are values: pin row, fresh decision, estimated token count, available-model set resolved at boot, and a cache-cold flag.
 
 ## Math, briefly
 
 Compares expected per-turn savings over the remaining horizon against the eviction cost of warming a new cache. The **tier-upgrade guard** fires when STAY would clearly under-serve the prompt — uses [`../catalog`](../catalog)'s Low/Mid/High tier to overturn a cost-driven "stay" when the fresh decision is in a strictly higher tier than the pin.
+
+**Cache-warmth gate.** The cache-read multipliers and eviction cost only apply while the pin's upstream cache is warm. When `Inputs.PinCacheCold` is set (the pinned provider's cache TTL has lapsed — short and best-effort on the OSS compat providers vs Anthropic's 1h window; see [`../../providers`](../../providers).`CacheTTLFor`), both sides are priced uncached so raw economics + the tier guard decide, instead of a phantom cache gluing the session to a stale pin. The zero value means "assume warm", preserving the original behavior.
 
 ## Invariants
 

--- a/internal/router/planner/policy.go
+++ b/internal/router/planner/policy.go
@@ -12,6 +12,15 @@
 // catalog.Pricing.EffectiveCacheReadMultiplier. Switches when
 // (expected_savings − eviction_cost) > threshold, or when tier-upgrade
 // guard fires (fresh is strictly higher tier than pin).
+//
+// Cache-warmth gate: the cache-read multipliers and the eviction cost only
+// apply while the pin's upstream prompt cache is still warm. When Inputs
+// reports the pin cold (the provider's cache TTL has lapsed — short and
+// best-effort on the OSS compat providers, unlike Anthropic's 1h window),
+// both sides are priced uncached (pinMult = freshMult = 1, eviction_cost = 0):
+// staying buys no cache reuse the fresh route wouldn't also pay, and the
+// one-time prefill is incurred either way. This stops a phantom cache from
+// gluing a session to a stale pin once the real cache is gone.
 package planner
 
 import (
@@ -35,6 +44,9 @@ type Decision struct {
 	ExpectedSavingsUSD float64
 	EvictionCostUSD    float64
 	ThresholdUSD       float64
+	// PinCacheCold echoes the warmth assumption the EV math ran under, for
+	// observability. Only meaningful on the EV path; false on early returns.
+	PinCacheCold bool
 }
 
 // EVConfig parameterizes the policy. Constructed once at boot from env.
@@ -56,6 +68,13 @@ type Inputs struct {
 	Fresh                router.Decision
 	EstimatedInputTokens int
 	AvailableModels      map[string]struct{}
+	// PinCacheCold reports that the pin's upstream prompt cache has lapsed —
+	// no turn completed within the pinned provider's cache TTL. The proxy
+	// computes this (it owns the clock); the planner stays a pure function.
+	// When true, the EV math prices both sides uncached. The zero value means
+	// "assume warm", preserving the original cache-discounted behavior for any
+	// caller that does not supply warmth information.
+	PinCacheCold bool
 }
 
 const (
@@ -100,17 +119,25 @@ func Decide(in Inputs, cfg EVConfig) Decision {
 
 	tokens := float64(in.EstimatedInputTokens)
 	// Per-model cache-read multipliers scale savings: only the cache-read
-	// portion of per-turn delta accrues over the horizon.
-	pinMult := pinPrice.EffectiveCacheReadMultiplier()
-	freshMult := freshPrice.EffectiveCacheReadMultiplier()
+	// portion of per-turn delta accrues over the horizon — but only while the
+	// pin's cache is warm. A cold pin earns no discount and switching evicts
+	// nothing (both sides pay one cold prefill), so price both uncached and
+	// let raw economics and the tier guard decide.
+	pinMult, freshMult := 1.0, 1.0
+	var evictionCost float64
+	if !in.PinCacheCold {
+		pinMult = pinPrice.EffectiveCacheReadMultiplier()
+		freshMult = freshPrice.EffectiveCacheReadMultiplier()
+		evictionCost = freshPrice.InputUSDPer1M * tokens * (1 - freshMult) / 1e6
+	}
 	savingsPerTurn := (pinPrice.InputUSDPer1M*pinMult - freshPrice.InputUSDPer1M*freshMult) * tokens / 1e6
-	evictionCost := freshPrice.InputUSDPer1M * tokens * (1 - freshMult) / 1e6
 	expectedSavings := savingsPerTurn * float64(cfg.ExpectedRemainingTurns)
 
 	d := Decision{
 		ExpectedSavingsUSD: expectedSavings,
 		EvictionCostUSD:    evictionCost,
 		ThresholdUSD:       cfg.ThresholdUSD,
+		PinCacheCold:       in.PinCacheCold,
 	}
 	switch {
 	case expectedSavings-evictionCost > cfg.ThresholdUSD:

--- a/internal/router/planner/policy_test.go
+++ b/internal/router/planner/policy_test.go
@@ -300,6 +300,93 @@ func TestDecide(t *testing.T) {
 			wantExpectedSavingsUSD: 0.00066,
 			wantEvictionCostUSD:    0.00072,
 		},
+		{
+			// Cold pin: the provider's cache TTL lapsed, so neither the pin's
+			// cache-read discount nor the eviction cost applies — both sides are
+			// priced uncached. opus -> haiku still switches, but on raw input
+			// price rather than the cache-read delta.
+			//   savingsPerTurn  = (5.00 - 0.80) * 50000 / 1e6 = $0.21
+			//   expectedSavings = 0.21 * 3 = $0.63
+			//   evictionCost    = 0 (nothing warm to evict)
+			//   delta = 0.63 - 0 = $0.63 > $0.001 -> Switch.
+			name: "cold_ev_positive: opus -> haiku prices uncached",
+			in: planner.Inputs{
+				Pin:                  pinWithUsage(modelOpus),
+				Fresh:                router.Decision{Model: modelHaiku},
+				EstimatedInputTokens: 50_000,
+				AvailableModels:      availableAll,
+				PinCacheCold:         true,
+			},
+			cfg:                    defaultCfg,
+			want:                   planner.Decision{Outcome: planner.OutcomeSwitch, Reason: planner.ReasonEVPositive},
+			expectEVMath:           true,
+			wantExpectedSavingsUSD: 0.63,
+			wantEvictionCostUSD:    0,
+		},
+		{
+			// Regression guard: the warm twin of this case (ev_cross_provider)
+			// STAYS because gpt-5's 0.50 cache-read multiplier makes it pricier
+			// than opus in cache steady-state. Once the cache is cold that
+			// multiplier no longer applies, so the raw $2.50 vs $5.00 input
+			// price wins and the planner correctly switches instead of clinging
+			// to a stale pin.
+			//   savingsPerTurn  = (5.00 - 2.50) * 50000 / 1e6 = $0.125
+			//   expectedSavings = 0.125 * 3 = $0.375
+			//   evictionCost    = 0
+			//   delta = 0.375 > $0.001 -> Switch.
+			name: "cold_cross_provider: opus -> gpt-5 switches once cache is cold",
+			in: planner.Inputs{
+				Pin:                  pinWithUsage(modelOpus),
+				Fresh:                router.Decision{Model: modelGPT5},
+				EstimatedInputTokens: 50_000,
+				AvailableModels:      availableAll,
+				PinCacheCold:         true,
+			},
+			cfg:                    defaultCfg,
+			want:                   planner.Decision{Outcome: planner.OutcomeSwitch, Reason: planner.ReasonEVPositive},
+			expectEVMath:           true,
+			wantExpectedSavingsUSD: 0.375,
+			wantEvictionCostUSD:    0,
+		},
+		{
+			// Cold pin but the pin is the cheaper model: no cache to preserve,
+			// yet switching to the pricier fresh model is a raw-price loss, so
+			// the planner stays. evictionCost is still zero.
+			//   savingsPerTurn  = (0.80 - 5.00) * 50000 / 1e6 = -$0.21
+			//   expectedSavings = -0.21 * 3 = -$0.63
+			//   delta = -0.63 < $0.001 -> Stay.
+			name: "cold_ev_negative: haiku -> opus stays on raw price",
+			in: planner.Inputs{
+				Pin:                  pinWithUsage(modelHaiku),
+				Fresh:                router.Decision{Model: modelOpus},
+				EstimatedInputTokens: 50_000,
+				AvailableModels:      availableAll,
+				PinCacheCold:         true,
+			},
+			cfg:                    defaultCfg,
+			want:                   planner.Decision{Outcome: planner.OutcomeStay, Reason: planner.ReasonEVNegative},
+			expectEVMath:           true,
+			wantExpectedSavingsUSD: -0.63,
+			wantEvictionCostUSD:    0,
+		},
+		{
+			// Cold pin does not disable the tier-upgrade guard: haiku -> opus is
+			// a raw-price loss (would stay on EV alone) but opus is strictly
+			// higher tier, so the guard still flips it to switch.
+			name: "cold_tier_upgrade: guard still fires when cache is cold",
+			in: planner.Inputs{
+				Pin:                  pinWithUsage(modelHaiku),
+				Fresh:                router.Decision{Model: modelOpus},
+				EstimatedInputTokens: 50_000,
+				AvailableModels:      availableAll,
+				PinCacheCold:         true,
+			},
+			cfg:                    tierUpgradeCfg,
+			want:                   planner.Decision{Outcome: planner.OutcomeSwitch, Reason: planner.ReasonTierUpgrade},
+			expectEVMath:           true,
+			wantExpectedSavingsUSD: -0.63,
+			wantEvictionCostUSD:    0,
+		},
 	}
 
 	for _, tc := range cases {
@@ -315,6 +402,7 @@ func TestDecide(t *testing.T) {
 				assert.InDelta(t, tc.wantExpectedSavingsUSD, got.ExpectedSavingsUSD, 1e-9, "expected_savings_usd")
 				assert.InDelta(t, tc.wantEvictionCostUSD, got.EvictionCostUSD, 1e-9, "eviction_cost_usd")
 				assert.Equal(t, tc.cfg.ThresholdUSD, got.ThresholdUSD, "threshold_usd echoed")
+				assert.Equal(t, tc.in.PinCacheCold, got.PinCacheCold, "pin_cache_cold echoed")
 			} else {
 				// When the EV math never ran, all three USD fields are
 				// left zero — this is what the orchestrator stamps for


### PR DESCRIPTION
## Why

The cache-aware planner (STAY vs SWITCH) assumed a pinned session's upstream prompt cache stays warm for the full 1h pin TTL. That only holds for **Anthropic** — `pinSessionTTL = time.Hour` is explicitly sized to its 1h extended cache. On the OSS OpenAI-compatible providers (**Fireworks, DeepInfra, OpenRouter**) the prompt cache is best-effort and minutes-scale, so a pin routinely outlives the cache it was meant to keep warm.

Observed in prod: a session pinned to `deepseek-v4-pro`/fireworks went idle ~12 min; the provider cache evicted (`cache_read_tokens` = 0) and the next turn paid a full cold prefill (~9.3s TTFT on 57k tokens). For the *fresh ≠ pin* case after such a gap, the planner still credited the pin a cache-read discount and charged a phantom eviction cost to switch — keeping sessions glued to a stale pin whose cache was already gone.

> Note: this corrects the planner's **economics** for idle-resume when the scorer's fresh pick differs from the pin. It does **not** by itself change the same-model cold-prefill case (where the scorer independently re-picks the pinned model); reducing that latency is a separate routing-policy follow-up.

## What

- **`providers.CacheTTL` / `CacheTTLFor`** — per-provider best-effort prompt-cache lifetime (Anthropic 1h; OSS/compat 5m; conservative 5m default).
- **`planner.Inputs.PinCacheCold`** — when set, the EV math prices both pin and fresh **uncached** (`pinMult = freshMult = 1`, `eviction_cost = 0`), so raw economics + the tier-upgrade guard decide instead of a phantom cache. **Zero value = assume warm**, preserving the original behavior (additive, opt-in). The planner stays a pure, clock-free function — the proxy computes warmth from the pinned provider's TTL and the prior turn's end time.
- **Observability** — `pin_cache_warm` on the turnloop pin-lookup-hit log, the planner stay/switch logs, and the `router.upstream` span, for the cold-resume telemetry follow-up.

## Tests

- Existing EV cases are warm-by-default and unchanged.
- Adds cold-path cases incl. the cross-provider regression where a cold cache correctly flips a STAY into a SWITCH, a cold STAY when the pin is cheaper, and a cold tier-upgrade.
- `CacheTTLFor` unit test.

Full `go build ./...`, `go vet`, and `go test ./...` pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)