### PR TITLE
fix(proxy): harden /force-model pinning and cross-replica pin coherence

### DIFF
--- a/internal/proxy/force_model.go
+++ b/internal/proxy/force_model.go
@@ -20,7 +20,8 @@ import (
 
 // resolveForceModel maps a user-typed model identifier to its canonical
 // catalog ID and primary provider binding. The catalog is the source of
-// truth — heuristics are only a fallback for models not yet listed there.
+// truth — heuristics are only a best-effort provider guess for inputs that
+// are not in it.
 //
 // Resolution order:
 //  1. Exact match against `catalog.ByID` (the input is already canonical).
@@ -29,15 +30,18 @@ import (
 //     and have the pin route to `qwen/qwen3-235b-a22b-2507` on its real
 //     binding (bedrock, in this case) instead of misclassifying it as
 //     Anthropic.
-//  3. Naming heuristic for slash-prefixed IDs not in the catalog (e.g. a
-//     user pinning a bare OpenRouter model we haven't curated yet).
-//  4. Final fallback for well-known proprietary prefixes.
+//  3. Naming heuristic for IDs not in the catalog (provider guess only).
 //
-// Returns the canonical ID (possibly different from input) and the
-// provider name to attach to the session pin.
-func resolveForceModel(model string) (canonicalID, provider string) {
+// The returned `known` flag is true only for catalog matches (1 and 2). A
+// false `known` means the input has no catalog entry and therefore no known
+// tier: the requested-model tier ceiling would rewrite a pin to it on every
+// turn (clampToCeiling treats unknown tiers as above-ceiling), so the user
+// would never actually be served the model. Callers must reject the command
+// rather than pin an unservable directive. The heuristic provider is still
+// returned for logging.
+func resolveForceModel(model string) (canonicalID, provider string, known bool) {
 	if m, ok := catalog.ByID(model); ok && len(m.Providers) > 0 {
-		return m.ID, m.Providers[0].Provider
+		return m.ID, m.Providers[0].Provider, true
 	}
 	if !strings.Contains(model, "/") {
 		suffix := "/" + model
@@ -50,22 +54,22 @@ func resolveForceModel(model string) (canonicalID, provider string) {
 			}
 		}
 		if matches == 1 && len(matched.Providers) > 0 {
-			return matched.ID, matched.Providers[0].Provider
+			return matched.ID, matched.Providers[0].Provider, true
 		}
 	}
 	switch {
 	case strings.HasPrefix(model, "claude-"):
-		return model, providers.ProviderAnthropic
+		return model, providers.ProviderAnthropic, false
 	case strings.HasPrefix(model, "gpt-"),
 		model == "o1", model == "o3", model == "o1-pro", model == "o3-pro",
 		strings.HasPrefix(model, "o1-"), strings.HasPrefix(model, "o3-"), strings.HasPrefix(model, "o4-"):
-		return model, providers.ProviderOpenAI
+		return model, providers.ProviderOpenAI, false
 	case strings.HasPrefix(model, "gemini-"):
-		return model, providers.ProviderGoogle
+		return model, providers.ProviderGoogle, false
 	case strings.Contains(model, "/"):
-		return model, providers.ProviderOpenRouter
+		return model, providers.ProviderOpenRouter, false
 	default:
-		return model, providers.ProviderAnthropic
+		return model, providers.ProviderAnthropic, false
 	}
 }
 
@@ -133,8 +137,24 @@ func (s *Service) handleForceModelCommand(
 			"session_key_hex", fmt.Sprintf("%x", sessionKey),
 			"role", role,
 		)
+	} else if canonicalModel, provider, known := resolveForceModel(cmd.Model); !known {
+		// The model isn't in the catalog, so it has no known tier. A pin to an
+		// unknown-tier model is rewritten by the requested-model tier ceiling on
+		// every turn (clampToCeiling treats unknown tiers as above-ceiling), so
+		// the user would silently be served a tier-default model instead of the
+		// one they asked for — e.g. a truncated "/force-model gpt-" routing to an
+		// OSS fallback. Reject the directive rather than pin something we can't
+		// honor; the previous pin (if any) is left untouched.
+		log.Info("/force-model: rejected unknown model",
+			"input_model", cmd.Model,
+			"session_key_hex", fmt.Sprintf("%x", sessionKey),
+			"role", role,
+		)
+		msg = fmt.Sprintf("✦ **Weave Router** → force-model: %q isn't a recognized model · keeping automatic routing. Use a full model id, e.g. claude-opus-4-8, gpt-5.5, or gemini-3-pro-preview.\n\n", cmd.Model)
+		if env.SourceFormat() == translate.FormatOpenAI {
+			msg = fmt.Sprintf("Weave Router: force-model: %q isn't a recognized model; keeping automatic routing. Use a full model id, e.g. claude-opus-4-8, gpt-5.5, or gemini-3-pro-preview.", cmd.Model)
+		}
 	} else {
-		canonicalModel, provider := resolveForceModel(cmd.Model)
 		forced := sessionpin.Pin{
 			SessionKey:     sessionKey,
 			Role:           role,

--- a/internal/proxy/force_model_test.go
+++ b/internal/proxy/force_model_test.go
@@ -14,65 +14,87 @@ func TestResolveForceModel(t *testing.T) {
 		input        string
 		wantID       string
 		wantProvider string
+		wantKnown    bool
 	}{
 		// Catalog matches: provider comes from the primary binding, even
-		// when the model name doesn't follow the bare-prefix heuristic.
+		// when the model name doesn't follow the bare-prefix heuristic. These
+		// resolve to a real catalog entry, so known is true.
 		{
 			name:         "catalog anthropic",
 			input:        "claude-opus-4-7",
 			wantID:       "claude-opus-4-7",
 			wantProvider: providers.ProviderAnthropic,
+			wantKnown:    true,
 		},
 		{
 			name:         "catalog google",
 			input:        "gemini-3.1-flash-lite-preview",
 			wantID:       "gemini-3.1-flash-lite-preview",
 			wantProvider: providers.ProviderGoogle,
+			wantKnown:    true,
 		},
 		{
 			name:         "catalog bedrock — slash form",
 			input:        "qwen/qwen3-235b-a22b-2507",
 			wantID:       "qwen/qwen3-235b-a22b-2507",
 			wantProvider: providers.ProviderBedrock,
+			wantKnown:    true,
 		},
 		{
 			name:         "catalog bedrock — bare suffix match",
 			input:        "qwen3-235b-a22b-2507",
 			wantID:       "qwen/qwen3-235b-a22b-2507",
 			wantProvider: providers.ProviderBedrock,
+			wantKnown:    true,
 		},
-		// Heuristic fallback for models not in the catalog.
+		// Heuristic fallback: not in the catalog, so known is false. The
+		// provider is a best-effort guess for logging only; the handler rejects
+		// these rather than pinning a model with no known tier.
 		{
-			name:         "heuristic openai — gpt-5 not in v0.54 catalog",
-			input:        "gpt-5",
-			wantID:       "gpt-5",
+			name:         "heuristic openai — gpt-6 not in catalog",
+			input:        "gpt-6",
+			wantID:       "gpt-6",
 			wantProvider: providers.ProviderOpenAI,
+			wantKnown:    false,
 		},
 		{
 			name:         "heuristic openai — o3",
 			input:        "o3",
 			wantID:       "o3",
 			wantProvider: providers.ProviderOpenAI,
+			wantKnown:    false,
 		},
 		{
 			name:         "heuristic openrouter — unknown slash model",
 			input:        "mistral/mistral-small-2603",
 			wantID:       "mistral/mistral-small-2603",
 			wantProvider: providers.ProviderOpenRouter,
+			wantKnown:    false,
 		},
 		{
 			name:         "heuristic anthropic — unknown bareword",
 			input:        "totally-not-a-model",
 			wantID:       "totally-not-a-model",
 			wantProvider: providers.ProviderAnthropic,
+			wantKnown:    false,
+		},
+		// Truncated command (the bug this guard closes): "/force-model gpt-"
+		// parses to "gpt-", which matches no catalog entry.
+		{
+			name:         "truncated gpt- is not known",
+			input:        "gpt-",
+			wantID:       "gpt-",
+			wantProvider: providers.ProviderOpenAI,
+			wantKnown:    false,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotID, gotProvider := resolveForceModel(tt.input)
+			gotID, gotProvider, gotKnown := resolveForceModel(tt.input)
 			assert.Equal(t, tt.wantID, gotID, "canonical id")
 			assert.Equal(t, tt.wantProvider, gotProvider, "provider")
+			assert.Equal(t, tt.wantKnown, gotKnown, "known")
 		})
 	}
 }

--- a/internal/proxy/service_session_pin_test.go
+++ b/internal/proxy/service_session_pin_test.go
@@ -779,6 +779,67 @@ func TestService_TierClamp_PinAboveCeilingIsClamped(t *testing.T) {
 	assert.Equal(t, "claude-haiku-4-5", rec.Header().Get("x-router-model"))
 }
 
+// TestService_ForcedPin_ClampedReasonSurfacesTierClamp guards the reporting
+// half of the force-model fix: when a user-forced model exceeds the turn's
+// tier ceiling and is downgraded, the decision reason must carry the
+// "+tier_clamp" suffix instead of being overwritten back to plain
+// "user_forced". Otherwise the decision log and x-router-decision badge claim
+// the turn was served on the forced model when it was actually clamped away.
+func TestService_ForcedPin_ClampedReasonSurfacesTierClamp(t *testing.T) {
+	store := newFakePinStore()
+	store.hasPin = true
+	store.pin = sessionpin.Pin{
+		Provider:    providers.ProviderAnthropic,
+		Model:       "claude-opus-4-7", // High-tier forced model
+		Reason:      translate.ReasonUserForceModel,
+		PinnedUntil: time.Now().Add(30 * time.Minute),
+	}
+	fr := &fakeRouter{decision: router.Decision{Provider: providers.ProviderAnthropic, Model: "claude-opus-4-7", Reason: "cluster:v0.37"}}
+
+	svc := newPinSvc(fr, store).WithTierClampResolver(func(_, _ map[string]struct{}, _ catalog.Tier) (string, string, bool) {
+		return providers.ProviderAnthropic, "claude-haiku-4-5", true
+	})
+
+	ctx := authedCtx(uuid.New().String())
+	rec := httptest.NewRecorder()
+	httpReq := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(""))
+	// Requesting haiku (Low ceiling) forces the High forced pin to clamp.
+	require.NoError(t, svc.ProxyMessages(ctx, []byte(haikuClampBody), rec, httpReq))
+
+	assert.Equal(t, "claude-haiku-4-5", rec.Header().Get("x-router-model"), "clamped forced pin must serve the in-ceiling model")
+	assert.Equal(t, translate.ReasonUserForceModel+"+tier_clamp", rec.Header().Get("x-router-decision"), "clamped forced pin must report the tier_clamp suffix, not plain user_forced")
+}
+
+// TestService_ForcedPin_UnclampedReasonStaysUserForced is the companion: an
+// in-ceiling forced pin keeps the plain "user_forced" reason.
+func TestService_ForcedPin_UnclampedReasonStaysUserForced(t *testing.T) {
+	store := newFakePinStore()
+	store.hasPin = true
+	store.pin = sessionpin.Pin{
+		Provider:    providers.ProviderAnthropic,
+		Model:       "claude-opus-4-7",
+		Reason:      translate.ReasonUserForceModel,
+		PinnedUntil: time.Now().Add(30 * time.Minute),
+	}
+	fr := &fakeRouter{decision: router.Decision{Provider: providers.ProviderAnthropic, Model: "claude-opus-4-7", Reason: "cluster:v0.37"}}
+
+	clampCalls := 0
+	svc := newPinSvc(fr, store).WithTierClampResolver(func(_, _ map[string]struct{}, _ catalog.Tier) (string, string, bool) {
+		clampCalls++
+		return providers.ProviderAnthropic, "claude-haiku-4-5", true
+	})
+
+	ctx := authedCtx(uuid.New().String())
+	rec := httptest.NewRecorder()
+	httpReq := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(""))
+	// Requesting opus (High ceiling) leaves the High forced pin in-ceiling.
+	require.NoError(t, svc.ProxyMessages(ctx, []byte(pinTestBody), rec, httpReq))
+
+	assert.Equal(t, 0, clampCalls, "in-ceiling forced pin must not invoke the clamp resolver")
+	assert.Equal(t, "claude-opus-4-7", rec.Header().Get("x-router-model"))
+	assert.Equal(t, translate.ReasonUserForceModel, rec.Header().Get("x-router-decision"), "in-ceiling forced pin keeps the plain user_forced reason")
+}
+
 // TestService_TierClamp_UnknownRequestedModelDisablesClamp regression-
 // guards the PR #100 finding: RequestedTier must be derived from
 // catalog.TierFor(feats.Model) directly, not via

--- a/internal/proxy/turnloop.go
+++ b/internal/proxy/turnloop.go
@@ -212,10 +212,21 @@ func (s *Service) runTurnLoop(
 		providerEligible := req.EnabledProviders == nil || providerEnabled
 		if !excluded && providerEligible {
 			decision := s.clampToCeiling(pinDecision(pin), res.RequestedTier, req.EnabledProviders, req.ExcludedModels, &res)
-			decision.Reason = translate.ReasonUserForceModel
+			if res.TierClamped {
+				// The forced model exceeds this turn's tier ceiling and was
+				// downgraded. Keep clampToCeiling's "user_forced+tier_clamp"
+				// reason rather than overwriting it back to plain "user_forced":
+				// otherwise the decision log and routing badge misreport the turn
+				// as served on the user's forced model when it was not. The pin
+				// itself is still refreshed with the original forced decision
+				// below, so the directive survives the transient clamp.
+				res.PinTier = "user_forced+tier_clamp"
+			} else {
+				decision.Reason = translate.ReasonUserForceModel
+				res.PinTier = "user_forced"
+			}
 			res.Decision = decision
 			res.StickyHit = true
-			res.PinTier = "user_forced"
 			s.refreshPin(ctx, installationID, res.SessionKey, pin, pinCacheKey, res.PinRole, pinDecision(pin))
 			return res, nil
 		}
@@ -448,10 +459,18 @@ func (s *Service) loadPin(ctx context.Context, pinCacheKey string, sessionKey [s
 			// turn (resetting the 30s eviction clock), so without this guard
 			// an expired entry whose refreshPin write was dropped could keep
 			// being served past its PinnedUntil.
-			if pin.PinnedUntil.After(time.Now()) {
+			if !pin.PinnedUntil.After(time.Now()) {
+				s.pinCache.Remove(pinCacheKey)
+			} else if pin.Reason != translate.ReasonUserForceModel {
 				return pin, true
 			}
-			s.pinCache.Remove(pinCacheKey)
+			// User-forced pins fall through to Postgres on every turn instead of
+			// trusting the LRU. /force-model on one Cloud Run replica rewrites the
+			// Postgres row but cannot evict another replica's cached pin, and that
+			// entry's TTL keeps resetting every turn (recordTurnUsage re-Adds it),
+			// so a corrected re-force is otherwise shadowed by the stale local copy
+			// indefinitely. Forced pins are rare and explicit; the extra per-turn
+			// read keeps replicas converged on the user's latest directive.
 		}
 	}
 	pin, found, err := s.pinStore.Get(ctx, sessionKey, role)

--- a/internal/proxy/turnloop_internal_test.go
+++ b/internal/proxy/turnloop_internal_test.go
@@ -11,13 +11,18 @@ import (
 
 	"workweave/router/internal/router"
 	"workweave/router/internal/router/sessionpin"
+	"workweave/router/internal/translate"
 )
 
 // stubPinStore is a minimal sessionpin.Store for testing recordTurnUsage.
+// getPin/getFound configure the Get response; both default to a miss so
+// existing tests that rely on "no Postgres row" keep working unchanged.
 type stubPinStore struct {
 	mu          sync.Mutex
 	lastUsage   sessionpin.Usage
 	usageCalled chan struct{}
+	getPin      sessionpin.Pin
+	getFound    bool
 }
 
 func newStubPinStore() *stubPinStore {
@@ -25,7 +30,9 @@ func newStubPinStore() *stubPinStore {
 }
 
 func (s *stubPinStore) Get(context.Context, [sessionpin.SessionKeyLen]byte, string) (sessionpin.Pin, bool, error) {
-	return sessionpin.Pin{}, false, nil
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.getPin, s.getFound, nil
 }
 
 func (s *stubPinStore) Upsert(context.Context, sessionpin.Pin) error { return nil }
@@ -185,4 +192,61 @@ func TestLoadPin_ServesFreshLRUEntry(t *testing.T) {
 	require.True(t, found, "non-expired LRU entry should be returned without hitting Postgres")
 	assert.Equal(t, fresh.Model, pin.Model)
 	assert.Equal(t, fresh.Provider, pin.Provider)
+}
+
+// TestLoadPin_ForcedPinBypassesStaleLRU guards the cross-replica coherence
+// fix for user-forced pins. /force-model on one Cloud Run replica rewrites the
+// Postgres row but cannot evict another replica's LRU entry, and that entry's
+// TTL keeps resetting every turn — so a corrected re-force is shadowed by the
+// stale local copy indefinitely. loadPin must ignore a cached user_forced pin
+// and re-read Postgres so the latest directive wins.
+func TestLoadPin_ForcedPinBypassesStaleLRU(t *testing.T) {
+	store := newStubPinStore()
+	svc := NewService(
+		nil,
+		nil,
+		nil,
+		false,
+		nil,
+		store,
+		false,
+		"anthropic", "claude-haiku-4-5",
+		nil,
+	)
+	require.NotNil(t, svc.pinCache)
+
+	var sessionKey [sessionpin.SessionKeyLen]byte
+	for i := range sessionKey {
+		sessionKey[i] = byte(i + 1)
+	}
+	cacheKey := sessionPinCacheKey(sessionKey, sessionpin.DefaultRole)
+
+	// Stale forced pin cached locally (the truncated "gpt-" from the first,
+	// botched /force-model), still well within its TTL.
+	stale := sessionpin.Pin{
+		SessionKey:  sessionKey,
+		Role:        sessionpin.DefaultRole,
+		Provider:    "openai",
+		Model:       "gpt-",
+		Reason:      translate.ReasonUserForceModel,
+		TurnCount:   1,
+		PinnedUntil: time.Now().Add(time.Hour),
+	}
+	svc.pinCache.Add(cacheKey, stale)
+
+	// Postgres holds the corrected re-force written by another replica.
+	store.getPin = sessionpin.Pin{
+		SessionKey:  sessionKey,
+		Role:        sessionpin.DefaultRole,
+		Provider:    "openai",
+		Model:       "gpt-5.5",
+		Reason:      translate.ReasonUserForceModel,
+		TurnCount:   1,
+		PinnedUntil: time.Now().Add(time.Hour),
+	}
+	store.getFound = true
+
+	pin, found := svc.loadPin(context.Background(), cacheKey, sessionKey, sessionpin.DefaultRole)
+	require.True(t, found, "forced pin must resolve from Postgres")
+	assert.Equal(t, "gpt-5.5", pin.Model, "forced pin must re-read Postgres, not serve the stale LRU copy")
 }


### PR DESCRIPTION
## Context

Investigating a real session (router `session_key fa956916be0ee7ec`) where a user reported that a `/force-model` pin "didn't go to the model" and the agent "started repeating itself." Root cause was a chain of three issues around forced pins. This PR fixes all three.

What actually happened in that session:
- `20:09:54` user sent `/force-model gpt-` (truncated — hit enter before finishing `gpt-5.5`).
- `20:10:01` user corrected to `/force-model gpt-5.5`.
- The corrected pin flapped and the stale `gpt-` won for ~70 min. Because `gpt-` has no catalog entry, every turn clamped it to the tier-default OSS model (`moonshotai/kimi-k2.6` on fireworks) while still reporting `decision_reason=user_forced` / `sticky_hit=true`. The user thought they were on GPT; they were on Kimi. Kimi then churned on the same task across 11+ turns, which read as "repeating."

## Fixes

### 1. Validate the model before pinning (`force_model.go`)
`resolveForceModel` now returns a `known` flag, true only for real catalog matches (exact `ByID` or unique suffix). The handler rejects unknown models with a helpful message and leaves any existing pin untouched, instead of pinning a string like `"gpt-"` that the tier ceiling silently rewrites every turn.

⚠️ **Behavior change to call out:** this also rejects models reachable only via the naming heuristic (e.g. `o3` when it isn't in the catalog). Those were already unservable for normal (known-tier) inbound requests — `clampToCeiling` treats unknown tiers as above-ceiling and downgraded them every turn — so a clear rejection is strictly better than silently serving a fallback. Shout if you'd rather keep heuristic models pinnable.

### 2. Surface tier clamping on forced pins (`turnloop.go`)
When a forced model exceeds the turn's tier ceiling and is clamped, the reason was being overwritten from `user_forced+tier_clamp` back to plain `user_forced`, so the decision log and `x-router-decision` badge misreported the turn as served on the forced model. We now keep the `+tier_clamp` suffix and set `pin_tier=user_forced+tier_clamp`. The pin itself is still refreshed with the original forced decision, so the directive survives the transient clamp.

### 3. Keep forced pins coherent across Cloud Run replicas (`turnloop.go`)
This is what caused the `gpt-5.5 → gpt-` flap. A `/force-model` on one replica rewrites the Postgres row but can't evict another replica's in-proc LRU entry, and that entry's 30s TTL keeps resetting every turn (`recordTurnUsage` re-`Add`s it under agentic cadence — the existing comment in `recordTurnUsage` even notes this), so a corrected re-force is shadowed by the stale local copy indefinitely. In the logs, replica `…970152a` served `gpt-` while `…49ebc` served `gpt-5.5` for the same session.

`loadPin` now bypasses the LRU for `user_forced` pins and re-reads Postgres each turn, so the latest directive converges within one turn. Forced pins are rare and explicit, so the extra per-turn read is negligible.

## Tests
- `TestResolveForceModel` — adds `known`-flag assertions for catalog vs heuristic, plus a case for the truncated `gpt-`.
- `TestService_ForcedPin_ClampedReasonSurfacesTierClamp` / `…_UnclampedReasonStaysUserForced` — assert the `x-router-decision` reason for clamped vs in-ceiling forced pins.
- `TestLoadPin_ForcedPinBypassesStaleLRU` — a stale forced pin in the LRU must not shadow the corrected Postgres value.

Full `go build ./...` and `go test ./...` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)