### PR TITLE
revert: undo thinking.enabled → adaptive upconvert (#283)

### DIFF
--- a/internal/router/model.go
+++ b/internal/router/model.go
@@ -49,10 +49,7 @@ func Lookup(model string) ModelSpec {
 }
 
 var (
-	// claude-opus-4-6+ and claude-sonnet-4-6+ only accept thinking.type=adaptive;
-	// the legacy thinking.type=enabled shape returns 400 from Anthropic since the
-	// rollout of output_config.effort.
-	anthropicAdaptive = NewSpec(CapAdaptiveThinking)
+	anthropicFull     = NewSpec(CapAdaptiveThinking, CapExtendedThinking)
 	anthropicExtended = NewSpec(CapExtendedThinking)
 )
 
@@ -68,10 +65,10 @@ var googleBase = NewSpec()
 var openAICompatBase = NewSpec()
 
 var registry = map[string]ModelSpec{
-	"claude-opus-4-8":   anthropicAdaptive,
-	"claude-opus-4-7":   anthropicAdaptive,
-	"claude-sonnet-4-6": anthropicAdaptive,
-	"claude-opus-4-6":   anthropicAdaptive,
+	"claude-opus-4-8":   anthropicFull,
+	"claude-opus-4-7":   anthropicFull,
+	"claude-sonnet-4-6": anthropicFull,
+	"claude-opus-4-6":   anthropicFull,
 
 	// claude-haiku-4-5 returns 400 "adaptive thinking is not supported on
 	// this model" when a Claude Code body with thinking.type=adaptive is

--- a/internal/router/model_test.go
+++ b/internal/router/model_test.go
@@ -24,7 +24,7 @@ func TestLookup_DateSuffixNormalization(t *testing.T) {
 		wantReasoning bool
 	}{
 		{"anthropic haiku dated", "claude-haiku-4-5-20251001", false, true, false},
-		{"anthropic opus dated", "claude-opus-4-7-20260301", true, false, false},
+		{"anthropic opus dated", "claude-opus-4-7-20260301", true, true, false},
 		{"openai dated", "gpt-4o-2024-08-06", false, false, false},
 		{"google flash registered", "gemini-2.5-flash", false, false, false},
 		{"google pro registered", "gemini-2.5-pro", false, false, false},

--- a/internal/translate/emit_same_format_test.go
+++ b/internal/translate/emit_same_format_test.go
@@ -2,7 +2,6 @@ package translate_test
 
 import (
 	"encoding/json"
-	"fmt"
 	"net/http"
 	"testing"
 
@@ -244,7 +243,7 @@ func TestAnthropicSameFormat_RedactedThinkingBlocksFiltered(t *testing.T) {
 }
 
 func TestAnthropicSameFormat_ThinkingBlocksKeptForCapableModel(t *testing.T) {
-	body := []byte(`{"model":"claude-sonnet-4-6","messages":[{"role":"user","content":"hi"},{"role":"assistant","content":[{"type":"thinking","thinking":"thought"},{"type":"text","text":"reply"}]}],"max_tokens":1024,"thinking":{"type":"adaptive"}}`)
+	body := []byte(`{"model":"claude-sonnet-4-6","messages":[{"role":"user","content":"hi"},{"role":"assistant","content":[{"type":"thinking","thinking":"thought"},{"type":"text","text":"reply"}]}],"max_tokens":1024,"thinking":{"type":"enabled","budget_tokens":5000}}`)
 	opts := translate.EmitOptions{
 		TargetModel:  "claude-opus-4-7",
 		Capabilities: router.Lookup("claude-opus-4-7"),
@@ -255,63 +254,6 @@ func TestAnthropicSameFormat_ThinkingBlocksKeptForCapableModel(t *testing.T) {
 	assistantMsg, _ := msgs[1].(map[string]any)
 	content, _ := assistantMsg["content"].([]any)
 	require.Len(t, content, 2, "thinking blocks should be preserved for capable models")
-}
-
-// Pi and other legacy Anthropic clients still send the pre-rollout
-// thinking.type=enabled shape. claude-opus-4-6+ rejects that with HTTP 400, so
-// the router must upconvert to thinking.type=adaptive and inject
-// output_config.effort derived from budget_tokens. Production session
-// 019e89de-f555-755b-a98b-d00cbef7a299 hit this on 2026-06-02.
-func TestAnthropicSameFormat_EnabledThinkingUpconvertedToAdaptive(t *testing.T) {
-	tests := []struct {
-		name         string
-		budgetTokens int
-		wantEffort   string
-	}{
-		{"low budget", 2048, "low"},
-		{"medium budget (pi default)", 8192, "medium"},
-		{"high budget", 32000, "high"},
-		{"missing budget defaults to medium", 0, "medium"},
-	}
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			thinkingField := `"thinking":{"type":"enabled"}`
-			if tc.budgetTokens > 0 {
-				thinkingField = fmt.Sprintf(`"thinking":{"type":"enabled","budget_tokens":%d}`, tc.budgetTokens)
-			}
-			body := []byte(`{"model":"claude-opus-4-7","messages":[{"role":"user","content":"hi"}],"max_tokens":1024,` + thinkingField + `}`)
-			opts := translate.EmitOptions{
-				TargetModel:  "claude-opus-4-7",
-				Capabilities: router.Lookup("claude-opus-4-7"),
-			}
-			out := parseAndEmit(t, body, "anthropic", opts)
-
-			thinking, _ := out["thinking"].(map[string]any)
-			require.NotNil(t, thinking, "thinking should remain on the body")
-			assert.Equal(t, "adaptive", thinking["type"], "legacy enabled must be upconverted to adaptive")
-			_, hasBudget := thinking["budget_tokens"]
-			assert.False(t, hasBudget, "budget_tokens has no meaning under adaptive thinking and must be dropped")
-
-			outputConfig, _ := out["output_config"].(map[string]any)
-			require.NotNil(t, outputConfig, "output_config.effort is required when adaptive thinking is set")
-			assert.Equal(t, tc.wantEffort, outputConfig["effort"])
-		})
-	}
-}
-
-// Inbound clients that already specify output_config.effort should win over
-// the budget-derived default — the router only fills in a default when the
-// caller said nothing.
-func TestAnthropicSameFormat_EnabledThinkingPreservesExplicitEffort(t *testing.T) {
-	body := []byte(`{"model":"claude-opus-4-7","messages":[{"role":"user","content":"hi"}],"max_tokens":1024,"thinking":{"type":"enabled","budget_tokens":8192},"output_config":{"effort":"high"}}`)
-	opts := translate.EmitOptions{
-		TargetModel:  "claude-opus-4-7",
-		Capabilities: router.Lookup("claude-opus-4-7"),
-	}
-	out := parseAndEmit(t, body, "anthropic", opts)
-	outputConfig, _ := out["output_config"].(map[string]any)
-	require.NotNil(t, outputConfig)
-	assert.Equal(t, "high", outputConfig["effort"], "caller-supplied effort must not be overwritten")
 }
 
 func TestPassthroughSameFormat_FieldsScrubbed(t *testing.T) {

--- a/internal/translate/envelope.go
+++ b/internal/translate/envelope.go
@@ -304,11 +304,6 @@ type EmitOverrides struct {
 	DefaultMaxTokensValue   int64
 	InjectStreamUsage       bool
 	StripThinkingBlocks     bool
-	// RewriteThinkingAdaptive replaces the inbound thinking block with
-	// {"type":"adaptive"} and sets output_config.effort. Used when the target
-	// model only accepts adaptive thinking (claude-opus-4-6+ / sonnet-4-6+).
-	RewriteThinkingAdaptive bool
-	OutputConfigEffort      string
 }
 
 func (e *RequestEnvelope) emitSameFormat(ov EmitOverrides) ([]byte, error) {
@@ -360,21 +355,6 @@ func applyOverrides(body []byte, ov EmitOverrides) ([]byte, error) {
 			out, err = sjson.SetBytes(out, "stream_options.include_usage", true)
 			if err != nil {
 				return nil, fmt.Errorf("set stream_options.include_usage: %w", err)
-			}
-		}
-	}
-
-	if ov.RewriteThinkingAdaptive {
-		out, err = sjson.SetBytes(out, "thinking", map[string]string{"type": "adaptive"})
-		if err != nil {
-			return nil, fmt.Errorf("rewrite thinking to adaptive: %w", err)
-		}
-		if ov.OutputConfigEffort != "" {
-			if !gjson.GetBytes(out, "output_config.effort").Exists() {
-				out, err = sjson.SetBytes(out, "output_config.effort", ov.OutputConfigEffort)
-				if err != nil {
-					return nil, fmt.Errorf("set output_config.effort: %w", err)
-				}
 			}
 		}
 	}
@@ -650,24 +630,6 @@ func resolveOpenAIOverrides(body []byte, opts EmitOptions) EmitOverrides {
 	return ov
 }
 
-// effortForBudget maps the legacy thinking.budget_tokens value onto the
-// adaptive output_config.effort tier. The thresholds match Anthropic's
-// published guidance: ≤4k tokens is "low" headroom, ≤16k is "medium", and
-// anything larger is "high". Zero or missing budget defaults to "medium" so
-// pre-rollout clients keep working.
-func effortForBudget(budgetTokens int64) string {
-	switch {
-	case budgetTokens <= 0:
-		return "medium"
-	case budgetTokens <= 4096:
-		return "low"
-	case budgetTokens <= 16384:
-		return "medium"
-	default:
-		return "high"
-	}
-}
-
 func resolveAnthropicOverrides(body []byte, opts EmitOptions) EmitOverrides {
 	ov := EmitOverrides{
 		Model: opts.TargetModel,
@@ -681,14 +643,7 @@ func resolveAnthropicOverrides(body []byte, opts EmitOptions) EmitOverrides {
 		case "adaptive":
 			shouldDelete = !opts.Capabilities.Supports(router.CapAdaptiveThinking)
 		case "enabled":
-			if opts.Capabilities.Supports(router.CapExtendedThinking) {
-				// Target accepts the legacy shape; leave it untouched.
-			} else if opts.Capabilities.Supports(router.CapAdaptiveThinking) {
-				ov.RewriteThinkingAdaptive = true
-				ov.OutputConfigEffort = effortForBudget(thinkingResult.Get("budget_tokens").Int())
-			} else {
-				shouldDelete = true
-			}
+			shouldDelete = !opts.Capabilities.Supports(router.CapExtendedThinking)
 		default:
 			shouldDelete = !opts.Capabilities.Supports(router.CapAdaptiveThinking) && !opts.Capabilities.Supports(router.CapExtendedThinking)
 		}


### PR DESCRIPTION
## Summary

Reverts #283. The v0.59-buckets SWE-bench Claude Code bake-off
(`swebench-cc-v059-buckets-20260602`, 150 shards × 3 seeds) shows
substantial regression vs the v0.59 baseline (`swebench-cc-v059-fixes-20260602`)
on the **same cluster artifact**. PRs #283/#284/#285/#286 shipped together;
#283 is the only one that mutates **turn-1** request bytes on every
Anthropic→Anthropic call to opus-4-6+ / sonnet-4-6+, making it the most
likely cause of the turn-1 routing divergence we observed.

## Headline numbers (same cluster, same instances, same seeds)

| Metric | v0.59 baseline | v0.59 + #283-286 |
|---|---:|---:|
| resolved % | 78.0 ± 1.6 | 72.0 ± 5.9 |
| empty_patch count | 24 | 32 |
| $/resolved | $0.25 | $0.37 |
| sec/task | 205 | 241 |
| **turns p50** | **22** | **62** |

Per-instance diff (149 common shards):
- 18 regressions (resolved → empty/unresolved)
- 9 recoveries (empty/unresolved → resolved)
- Net: −9 resolved (2:1 asymmetric, not noise)

## Most damning data point

- Only **38/149 shards (25.5%)** landed on the same dominant upstream in both runs. **74.5% rerouted.**
- Even on the 38 same-model shards, **p50 turn count went 22.5 → 84.5** — sessions running ~3× longer **on the same model**.
- That rules out LLM non-determinism as primary cause and points to a request-body mutation driving downstream divergence.

## Why #283 is the suspect

#283 is the only one of the four bucket-fix PRs that mutates turn-1 bytes:

| PR | Mutation | When fires |
|---|---|---|
| **#283** | `thinking.enabled` → `thinking.adaptive` + `output_config.effort` mapped from `budget_tokens` | **Every** opus-4-6+/sonnet-4-6+ request (incl. turn 1) |
| #284 | Synthesizes Bash nudge | Only when upstream emits text-only on tool-bearing request. Logs show 7× total in the bake-off. |
| #285 | Appends explore-loop reminder to system field | Only when ≥10 Read/Grep with no Edit. Never on turn 1. |
| #286 | Observability log fields | No behavior change. |

## Reproduction

`sympy__sympy-23534` — all 3 seeds:
- **Baseline:** routed to deepseek-v4-pro / gemini-pro, non-empty patches
- **Post-#283:** all 3 seeds routed to `xiaomi/mimo-v2.5-pro`, empty patches

The only PR that could have flipped turn-1 routing for this prompt is #283.

## Plan

- This PR reverts #283 only. #284, #285, #286 stay on main pending re-bake-off.
- After merge + staging redeploy, re-run the bake-off on the same 50 instances × 3 seeds.
- If resolved % restores to ~78%, this isolates #283 as the regression source.
- Then revisit #283 with a narrower fix (e.g. restrict upconvert to clients that explicitly send the post-rollout shape, or make it opt-in via header). The original session-failure case (`019e89de-f555-755b-a98b-d00cbef7a299`, opus-4-6 400ing on `thinking.enabled`) still needs a fix — just not one that disturbs steady-state Anthropic traffic.

## Test plan

- [x] `go test ./internal/translate/... ./internal/router/...` — all green
- [ ] Merge → bump WW gitlink → deploy to staging
- [ ] Re-run `modal run -m modal_swebench_claudecode::full --conditions router --num-instances 50 --seeds 3` and compare RESULTS.md
- [ ] If restored, file follow-up issue for a narrower thinking-format upconvert

🤖 Generated with [Claude Code](https://claude.com/claude-code)