### PR TITLE
fix: surface OpenAI 4xx for failover + two-strike sticky-pin eviction

### DIFF
--- a/db/migrations/0009_session_pin_consecutive_upstream_errors.down.sql
+++ b/db/migrations/0009_session_pin_consecutive_upstream_errors.down.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+ALTER TABLE router.session_pins DROP COLUMN consecutive_upstream_errors;
+
+COMMIT;

--- a/db/migrations/0009_session_pin_consecutive_upstream_errors.up.sql
+++ b/db/migrations/0009_session_pin_consecutive_upstream_errors.up.sql
@@ -1,0 +1,12 @@
+BEGIN;
+
+-- Counts consecutive turns ending in non-retryable upstream errors (4xx
+-- other than 408/429) for a sticky-pinned session. The turn loop resets
+-- this column to 0 on any successful turn and evicts the pin when the
+-- count reaches the two-strike threshold, so a session can't wedge on a
+-- bad sticky decision the way it did when we observed four consecutive
+-- 400s on a gpt-5.5 pin with no auto-recovery.
+ALTER TABLE router.session_pins
+  ADD COLUMN consecutive_upstream_errors INTEGER NOT NULL DEFAULT 0;
+
+COMMIT;

--- a/db/queries/session_pins.sql
+++ b/db/queries/session_pins.sql
@@ -19,6 +19,12 @@ WHERE session_key = @session_key::bytea
 -- from the ON CONFLICT update set: only UpdateSessionPinUsage writes
 -- them, so the at-start-of-turn refresh here cannot clobber the
 -- previous turn's usage with zeros before the planner reads it.
+--
+-- consecutive_upstream_errors is preserved on a same-model refresh (so
+-- the two-strike eviction counter accumulates across turns of the same
+-- sticky pin) but reset to 0 on a switch (different model = clean
+-- slate). The reset on switch also covers the loop-break / force-model
+-- pin-expiry writes, which set pinned_model to the empty string.
 -- name: UpsertSessionPin :exec
 INSERT INTO router.session_pins (
   session_key, role, installation_id, pinned_provider,
@@ -34,7 +40,12 @@ ON CONFLICT (session_key, role) DO UPDATE SET
   decision_reason = EXCLUDED.decision_reason,
   turn_count      = router.session_pins.turn_count + 1,
   pinned_until    = EXCLUDED.pinned_until,
-  last_seen_at    = CURRENT_TIMESTAMP;
+  last_seen_at    = CURRENT_TIMESTAMP,
+  consecutive_upstream_errors = CASE
+    WHEN router.session_pins.pinned_model = EXCLUDED.pinned_model
+      THEN router.session_pins.consecutive_upstream_errors
+    ELSE 0
+  END;
 
 -- Records the previous turn's upstream token usage on an existing pin
 -- row. Fired off the request path after the upstream response
@@ -52,6 +63,29 @@ SET last_input_tokens        = @last_input_tokens::int,
     last_turn_ended_at       = @last_turn_ended_at::timestamptz
 WHERE session_key = @session_key::bytea
   AND role        = @role::varchar;
+
+-- Atomically increments consecutive_upstream_errors and returns the
+-- new value. The turn loop calls this after a non-retryable upstream
+-- 4xx on a sticky-pinned turn; the returned count drives the
+-- two-strike eviction decision. Returns sql.ErrNoRows if no pin
+-- exists, which the adapter maps to a no-op (pin must already be
+-- evicted by another path, e.g. force-model / loop-break).
+-- name: IncrementSessionPinUpstreamErrors :one
+UPDATE router.session_pins
+SET consecutive_upstream_errors = consecutive_upstream_errors + 1
+WHERE session_key = @session_key::bytea
+  AND role        = @role::varchar
+RETURNING consecutive_upstream_errors;
+
+-- Clears the two-strike counter after a successful turn. UPDATE
+-- matches by (session_key, role); zero rows affected on missing pin
+-- is a successful no-op like UpdateSessionPinUsage.
+-- name: ResetSessionPinUpstreamErrors :exec
+UPDATE router.session_pins
+SET consecutive_upstream_errors = 0
+WHERE session_key = @session_key::bytea
+  AND role        = @role::varchar
+  AND consecutive_upstream_errors > 0;
 
 -- Garbage-collects pins that have been expired for >24h. The 24h grace
 -- means a transient Postgres outage doesn't immediately prune live pins;

--- a/internal/postgres/session_pin_repo.go
+++ b/internal/postgres/session_pin_repo.go
@@ -77,6 +77,37 @@ func (r *SessionPinRepo) UpdateUsage(ctx context.Context, sessionKey [sessionpin
 	})
 }
 
+// IncrementUpstreamErrors atomically bumps the consecutive-error
+// counter and returns the new value. A missing pin (already evicted
+// by force-model or loop-break, or never created) surfaces as
+// (0, nil) so the turn loop's two-strike check treats it as a no-op
+// — the relevant signal is gone and there's no row left to evict.
+func (r *SessionPinRepo) IncrementUpstreamErrors(ctx context.Context, sessionKey [sessionpin.SessionKeyLen]byte, role string) (int, error) {
+	q := sqlc.New(r.tx)
+	count, err := q.IncrementSessionPinUpstreamErrors(ctx, sqlc.IncrementSessionPinUpstreamErrorsParams{
+		SessionKey: sessionKey[:],
+		Role:       role,
+	})
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return 0, nil
+		}
+		return 0, err
+	}
+	return int(count), nil
+}
+
+// ResetUpstreamErrors clears the consecutive-error counter after a
+// successful turn. Missing pin = successful no-op (mirrors
+// UpdateUsage's semantics).
+func (r *SessionPinRepo) ResetUpstreamErrors(ctx context.Context, sessionKey [sessionpin.SessionKeyLen]byte, role string) error {
+	q := sqlc.New(r.tx)
+	return q.ResetSessionPinUpstreamErrors(ctx, sqlc.ResetSessionPinUpstreamErrorsParams{
+		SessionKey: sessionKey[:],
+		Role:       role,
+	})
+}
+
 func (r *SessionPinRepo) SweepExpired(ctx context.Context) error {
 	q := sqlc.New(r.tx)
 	return q.SweepExpiredSessionPins(ctx)

--- a/internal/providers/openai/client.go
+++ b/internal/providers/openai/client.go
@@ -113,6 +113,38 @@ func (c *Client) Proxy(ctx context.Context, decision router.Decision, prep provi
 		"request_id", resp.Header.Get("X-Request-Id"),
 	)
 
+	// Buffer non-2xx and surface as UpstreamErrorResponse so the dispatch
+	// loop can fail over (multi-binding models) or render the upstream error
+	// envelope in the inbound format (single-binding models like gpt-*).
+	// Writing the upstream status straight through corrupts the SSE stream
+	// when a translator's Prelude already committed `200 + message_start`
+	// to the prelude buffer, and silently drops the upstream error body —
+	// neither debugging signal nor failover survive.
+	if resp.StatusCode >= 400 {
+		bufBody, totalRead, drainErr := readCapped(resp.Body, providers.MaxBufferedErrorBytes)
+		if len(bufBody) > 0 {
+			t.StampUpstreamFirstByte()
+		}
+		if drainErr == nil {
+			t.StampUpstreamEOF()
+		}
+		logUpstreamStatus(
+			"Upstream OpenAI returned error status",
+			resp.StatusCode,
+			"base_url", c.baseURL,
+			"routed_model", decision.Model,
+			"body_preview", previewBytes(bufBody),
+			"body_total_bytes", totalRead,
+		)
+		errHeaders := http.Header{}
+		providers.CopyUpstreamHeaders(headerCapture{errHeaders}, resp)
+		return &providers.UpstreamErrorResponse{
+			Status:  resp.StatusCode,
+			Headers: errHeaders,
+			Body:    bufBody,
+		}
+	}
+
 	providers.CopyUpstreamHeaders(w, resp)
 	w.WriteHeader(resp.StatusCode)
 	status := resp.StatusCode
@@ -203,8 +235,75 @@ func (c *Client) Passthrough(ctx context.Context, prep providers.PreparedRequest
 
 	providers.CopyUpstreamHeaders(w, resp)
 	w.WriteHeader(resp.StatusCode)
+	if resp.StatusCode >= 400 {
+		var snip [1024]byte
+		n, _ := io.ReadFull(resp.Body, snip[:])
+		_, snipWriteErr := w.Write(snip[:n])
+		rest, copyErr := io.Copy(w, resp.Body)
+		logUpstreamStatus(
+			"Upstream OpenAI returned error status (passthrough)",
+			resp.StatusCode,
+			"base_url", c.baseURL,
+			"path", r.URL.Path,
+			"body_preview", string(snip[:n]),
+			"body_total_bytes", int64(n)+rest,
+		)
+		if snipWriteErr != nil {
+			return snipWriteErr
+		}
+		if copyErr != nil {
+			return copyErr
+		}
+		return &providers.UpstreamStatusError{Status: resp.StatusCode}
+	}
 	_, err = io.Copy(w, resp.Body)
 	return err
+}
+
+// readCapped reads up to limit bytes from r into a buffer, then drains the
+// rest without retention up to maxDrain to bound failover latency on a slow
+// upstream returning a large error body. The connection is closed by the
+// caller's defer regardless, so the unread tail is discarded by Close.
+func readCapped(r io.Reader, limit int) ([]byte, int64, error) {
+	prefix, err := io.ReadAll(io.LimitReader(r, int64(limit)))
+	totalRead := int64(len(prefix))
+	if err != nil {
+		return prefix, totalRead, err
+	}
+	const maxDrain = 1 << 20 // 1 MiB
+	rest, drainErr := io.Copy(io.Discard, io.LimitReader(r, maxDrain))
+	totalRead += rest
+	return prefix, totalRead, drainErr
+}
+
+// previewBytes returns the first 1KB of body as a string for logging.
+func previewBytes(body []byte) string {
+	const previewLimit = 1024
+	if len(body) > previewLimit {
+		return string(body[:previewLimit])
+	}
+	return string(body)
+}
+
+// headerCapture is a minimal http.ResponseWriter that captures headers only,
+// used to reuse providers.CopyUpstreamHeaders against an http.Header we own.
+// Write/WriteHeader are no-ops.
+type headerCapture struct{ h http.Header }
+
+func (c headerCapture) Header() http.Header       { return c.h }
+func (c headerCapture) Write([]byte) (int, error) { return 0, nil }
+func (c headerCapture) WriteHeader(int)           {}
+
+// logUpstreamStatus logs non-2xx upstream responses with a body preview.
+// Severity is ERROR for >=500 and >=400 except 429 (which is a routine
+// rate-limit signal that callers handle via failover).
+func logUpstreamStatus(msg string, status int, attrs ...any) {
+	merged := append([]any{"status", status}, attrs...)
+	if status >= 500 || (status >= 400 && status != http.StatusTooManyRequests) {
+		observability.Get().Error(msg, merged...)
+		return
+	}
+	observability.Get().Warn(msg, merged...)
 }
 
 var _ providers.Client = (*Client)(nil)

--- a/internal/providers/openai/client_test.go
+++ b/internal/providers/openai/client_test.go
@@ -132,6 +132,71 @@ func TestProxy_StampsTimingMilestones(t *testing.T) {
 	assert.LessOrEqual(t, tm.UpstreamFirstByteNanos.Load(), tm.UpstreamEOFNanos.Load())
 }
 
+// TestProxy_BuffersUpstream4xx pins the fix for the gpt-5.5 wedge
+// (session 93e918bf): a 4xx from the OpenAI upstream must come back as
+// *providers.UpstreamErrorResponse with the upstream body buffered, so
+// the dispatch loop can render it in the inbound wire format (or fail
+// over on a multi-binding model). The prior behavior wrote the upstream
+// 4xx straight through, corrupting the SSE stream when the translator's
+// Prelude had already buffered HTTP 200 + message_start, and surfaced
+// only an opaque *UpstreamStatusError to the proxy — failover never
+// fired and the body_preview log site never executed.
+func TestProxy_BuffersUpstream4xx(t *testing.T) {
+	const upstreamBody = `{"error":{"message":"max_completion_tokens exceeds model limit","type":"invalid_request_error"}}`
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("X-Custom-Upstream", "abc")
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(upstreamBody))
+	}))
+	defer upstream.Close()
+
+	c := openai.NewClient("k", upstream.URL)
+	rec := httptest.NewRecorder()
+	clientReq := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(""))
+
+	prep := providers.PreparedRequest{Body: []byte(`{"model":"gpt-5.5"}`), Headers: make(http.Header)}
+	err := c.Proxy(context.Background(), router.Decision{Model: "gpt-5.5"}, prep, rec, clientReq)
+	require.Error(t, err)
+
+	var buffered *providers.UpstreamErrorResponse
+	require.ErrorAs(t, err, &buffered,
+		"non-2xx upstream must surface as *UpstreamErrorResponse so dispatch can fail over / render in-format")
+	assert.Equal(t, http.StatusBadRequest, buffered.Status)
+	assert.Equal(t, upstreamBody, string(buffered.Body),
+		"buffered body must round-trip the upstream error envelope verbatim")
+	assert.Equal(t, "abc", buffered.Headers.Get("X-Custom-Upstream"),
+		"adapter must capture upstream headers so dispatch can preserve them when flushing")
+	assert.Equal(t, http.StatusOK, rec.Code,
+		"adapter must NOT touch the response writer on 4xx; the dispatch loop decides what the client sees")
+	assert.Empty(t, rec.Body.String(),
+		"writing the upstream body directly corrupts the SSE stream when the prelude is buffered")
+}
+
+// TestProxy_5xxIsBufferedToo guards that 5xx follows the same buffered
+// path as 4xx; on multi-binding models the dispatch loop's IsRetryable
+// check needs the typed UpstreamErrorResponse to fail over to OpenRouter.
+func TestProxy_5xxIsBufferedToo(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadGateway)
+		_, _ = w.Write([]byte(`upstream bad gateway`))
+	}))
+	defer upstream.Close()
+
+	c := openai.NewClient("k", upstream.URL)
+	rec := httptest.NewRecorder()
+	clientReq := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(""))
+
+	prep := providers.PreparedRequest{Body: []byte(`{"model":"x"}`), Headers: make(http.Header)}
+	err := c.Proxy(context.Background(), router.Decision{Model: "m"}, prep, rec, clientReq)
+
+	var buffered *providers.UpstreamErrorResponse
+	require.ErrorAs(t, err, &buffered)
+	assert.Equal(t, http.StatusBadGateway, buffered.Status)
+	assert.True(t, providers.IsRetryable(err),
+		"5xx must remain retryable so multi-binding models can fail over")
+}
+
 func TestPassthrough_ForwardsPathAndAuth(t *testing.T) {
 	var (
 		gotPath string

--- a/internal/proxy/pin_eviction.go
+++ b/internal/proxy/pin_eviction.go
@@ -1,0 +1,142 @@
+package proxy
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"workweave/router/internal/observability"
+	"workweave/router/internal/providers"
+	"workweave/router/internal/router/sessionpin"
+	"workweave/router/internal/translate"
+
+	"github.com/google/uuid"
+)
+
+// pinEvictionStrikeThreshold is the consecutive-non-retryable-4xx count
+// that trips a sticky pin to expire. Two strikes (not one) tolerates a
+// single transient 400 — e.g. a malformed prompt or a brief upstream
+// schema-validation hiccup — without flushing a working pin's prompt
+// cache. Hit two in a row and the model is wedged for this session;
+// re-route via the cluster scorer rather than wait for the user to
+// notice and manually /force-model out.
+const pinEvictionStrikeThreshold = 2
+
+// maybeEvictPinAfterUpstreamErr applies the two-strike pin-eviction
+// policy on every turn that ran against a sticky session pin:
+//
+//   - Successful turn → reset the counter to 0 (any prior strikes are
+//     forgiven the moment the model serves a real response).
+//   - Non-retryable upstream 4xx → atomically increment the counter
+//     on the existing pin row and, when the new count reaches
+//     pinEvictionStrikeThreshold, expire the pin so the NEXT turn
+//     re-routes via the cluster scorer.
+//
+// Skipped paths:
+//   - !stickyHit: the pin row was just written this turn with
+//     counter=0 (writeNewPin) or doesn't exist; no decision-history
+//     yet.
+//   - Zero session_key / installation_id: no addressable pin row.
+//   - User-forced pins (ReasonUserForceModel or its tier_clamp
+//     variant): user explicitly chose this model; auto-eviction would
+//     silently override an explicit command. The user retains
+//     /unforce-model as the escape hatch.
+//   - Retryable upstream status (408 / 429 / 5xx): handled by
+//     dispatchWithFallback's retry loop OR represent transient
+//     upstream conditions that don't indict the model choice.
+//
+// Errors from the increment/reset/upsert paths are logged and
+// swallowed — eviction is a recovery optimization on a turn that
+// already succeeded or failed; failing it must not change the
+// client-visible outcome.
+func (s *Service) maybeEvictPinAfterUpstreamErr(
+	ctx context.Context,
+	stickyHit bool,
+	proxyErr error,
+	decisionReason string,
+	installationID uuid.UUID,
+	sessionKey [sessionpin.SessionKeyLen]byte,
+	role string,
+) {
+	if !stickyHit || s.pinStore == nil || installationID == uuid.Nil {
+		return
+	}
+	if sessionKey == ([sessionpin.SessionKeyLen]byte{}) {
+		return
+	}
+	// Force-model pins are user commands; the router does not auto-evict
+	// them. ReasonUserForceModel + the "+tier_clamp" suffix are both
+	// surfaced verbatim in decision_reason; cover both with a prefix
+	// check.
+	if strings.HasPrefix(decisionReason, translate.ReasonUserForceModel) {
+		return
+	}
+
+	log := observability.FromContext(ctx)
+	pinCacheKey := sessionPinCacheKey(sessionKey, role)
+
+	if proxyErr == nil {
+		// Background ctx: the request ctx is canceled by the time the
+		// response has finished streaming, but the success-reset is a
+		// best-effort no-op on a missing pin so we don't want it
+		// silently dropped by ctx cancellation.
+		if err := s.pinStore.ResetUpstreamErrors(context.Background(), sessionKey, role); err != nil {
+			log.Error("pin error-counter reset failed", "err", err, "role", role)
+		}
+		return
+	}
+
+	status := upstreamStatus(proxyErr)
+	if status == 0 {
+		// Non-upstream error (transport blowup, deadline, etc.) — not a
+		// model-quality signal; leave the counter alone.
+		return
+	}
+	if providers.IsRetryableStatus(status) {
+		return
+	}
+
+	count, err := s.pinStore.IncrementUpstreamErrors(context.Background(), sessionKey, role)
+	if err != nil {
+		log.Error("pin error-counter increment failed", "err", err, "role", role, "upstream_status", status)
+		return
+	}
+	if count < pinEvictionStrikeThreshold {
+		log.Debug("pin error-counter incremented",
+			"role", role,
+			"upstream_status", status,
+			"consecutive_errors", count,
+			"strike_threshold", pinEvictionStrikeThreshold,
+		)
+		return
+	}
+
+	// Threshold reached. Expire the pin so the NEXT turn re-routes via
+	// the cluster scorer. Mirrors the loop-break / no-progress / force
+	// -model "expired pin" pattern: upsert a row with PinnedUntil in
+	// the past so loadPin discards it, plus an in-proc cache evict so
+	// the next turn doesn't serve the stale entry.
+	expired := sessionpin.Pin{
+		SessionKey:     sessionKey,
+		Role:           role,
+		InstallationID: installationID,
+		Provider:       "",
+		Model:          "",
+		Reason:         "upstream_error_strike_threshold",
+		TurnCount:      1,
+		PinnedUntil:    time.Now().Add(-time.Second),
+	}
+	if err := s.pinStore.Upsert(context.Background(), expired); err != nil {
+		log.Error("pin eviction upsert failed", "err", err, "role", role)
+		return
+	}
+	if s.pinCache != nil {
+		s.pinCache.Remove(pinCacheKey)
+	}
+	log.Info("session pin evicted after consecutive upstream errors",
+		"role", role,
+		"upstream_status", status,
+		"consecutive_errors", count,
+		"strike_threshold", pinEvictionStrikeThreshold,
+	)
+}

--- a/internal/proxy/pin_eviction_internal_test.go
+++ b/internal/proxy/pin_eviction_internal_test.go
@@ -1,0 +1,312 @@
+package proxy
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"sync"
+	"testing"
+	"time"
+
+	"workweave/router/internal/providers"
+	"workweave/router/internal/router/sessionpin"
+	"workweave/router/internal/translate"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// evictionStubPinStore records every call to IncrementUpstreamErrors /
+// ResetUpstreamErrors / Upsert so each two-strike branch can be
+// asserted independently. The increment counter is configurable to
+// drive the threshold path without re-running the whole turn loop.
+type evictionStubPinStore struct {
+	mu             sync.Mutex
+	incrementCalls int
+	incrementNext  []int // values returned by IncrementUpstreamErrors, in order
+	resetCalls     int
+	upserts        []sessionpin.Pin
+}
+
+func (s *evictionStubPinStore) Get(context.Context, [sessionpin.SessionKeyLen]byte, string) (sessionpin.Pin, bool, error) {
+	return sessionpin.Pin{}, false, nil
+}
+
+func (s *evictionStubPinStore) Upsert(_ context.Context, p sessionpin.Pin) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.upserts = append(s.upserts, p)
+	return nil
+}
+
+func (s *evictionStubPinStore) UpdateUsage(context.Context, [sessionpin.SessionKeyLen]byte, string, sessionpin.Usage) error {
+	return nil
+}
+
+func (s *evictionStubPinStore) IncrementUpstreamErrors(context.Context, [sessionpin.SessionKeyLen]byte, string) (int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.incrementCalls++
+	if len(s.incrementNext) == 0 {
+		return 0, nil
+	}
+	v := s.incrementNext[0]
+	s.incrementNext = s.incrementNext[1:]
+	return v, nil
+}
+
+func (s *evictionStubPinStore) ResetUpstreamErrors(context.Context, [sessionpin.SessionKeyLen]byte, string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.resetCalls++
+	return nil
+}
+
+func (s *evictionStubPinStore) SweepExpired(context.Context) error { return nil }
+
+func newEvictionTestService(store *evictionStubPinStore) *Service {
+	return NewService(
+		nil,
+		nil,
+		nil,
+		false,
+		nil,
+		store,
+		false,
+		"anthropic", "claude-haiku-4-5",
+		nil,
+	)
+}
+
+func nonZeroSessionKey() [sessionpin.SessionKeyLen]byte {
+	var k [sessionpin.SessionKeyLen]byte
+	for i := range k {
+		k[i] = byte(i + 1)
+	}
+	return k
+}
+
+// TestMaybeEvictPin_FirstStrikeOnlyIncrements pins the two-strike
+// invariant: a SINGLE 400 must increment the counter but NOT expire
+// the pin. The eviction must wait for the second consecutive strike,
+// so an isolated bad request (a one-off malformed prompt, brief
+// upstream schema validation hiccup) doesn't flush an otherwise-warm
+// session's cache.
+func TestMaybeEvictPin_FirstStrikeOnlyIncrements(t *testing.T) {
+	store := &evictionStubPinStore{incrementNext: []int{1}}
+	svc := newEvictionTestService(store)
+
+	upstreamErr := &providers.UpstreamErrorResponse{Status: http.StatusBadRequest}
+	svc.maybeEvictPinAfterUpstreamErr(
+		context.Background(),
+		true, // stickyHit
+		upstreamErr,
+		"cluster:v0.57 model=gpt-5.5 provider=openai",
+		uuid.New(),
+		nonZeroSessionKey(),
+		sessionpin.DefaultRole,
+	)
+
+	assert.Equal(t, 1, store.incrementCalls, "first 4xx must increment exactly once")
+	assert.Equal(t, 0, store.resetCalls, "reset must not fire on a failed turn")
+	assert.Empty(t, store.upserts, "first strike must not expire the pin — eviction waits for strike #2")
+}
+
+// TestMaybeEvictPin_SecondStrikeExpires guards the actual eviction
+// path. The session 93e918bf wedge happened because there was NO
+// eviction path at all; this test fails the moment that regression
+// returns.
+func TestMaybeEvictPin_SecondStrikeExpires(t *testing.T) {
+	store := &evictionStubPinStore{incrementNext: []int{pinEvictionStrikeThreshold}}
+	svc := newEvictionTestService(store)
+
+	upstreamErr := &providers.UpstreamStatusError{Status: http.StatusBadRequest}
+	installationID := uuid.New()
+	sessionKey := nonZeroSessionKey()
+
+	svc.maybeEvictPinAfterUpstreamErr(
+		context.Background(),
+		true,
+		upstreamErr,
+		"cluster:v0.57 model=gpt-5.5 provider=openai",
+		installationID,
+		sessionKey,
+		sessionpin.DefaultRole,
+	)
+
+	require.Len(t, store.upserts, 1, "threshold strike must trigger an expired-pin upsert")
+	expired := store.upserts[0]
+	assert.Equal(t, sessionpin.DefaultRole, expired.Role)
+	assert.Equal(t, installationID, expired.InstallationID)
+	assert.Empty(t, expired.Provider, "expired pin must clear provider so loadPin discards it")
+	assert.Empty(t, expired.Model, "expired pin must clear model so loadPin discards it")
+	assert.True(t, expired.PinnedUntil.Before(time.Now()),
+		"PinnedUntil must be in the past so loadPin's expiry check discards the row")
+	assert.Equal(t, "upstream_error_strike_threshold", expired.Reason,
+		"eviction reason is the audit trail that distinguishes this path from force-model / loop-break")
+}
+
+// TestMaybeEvictPin_SuccessResets verifies that a successful turn
+// clears the counter so the strike count truly tracks CONSECUTIVE
+// failures (not lifetime failures). Without this, a session could
+// accumulate strikes across hours of healthy turns and trigger a
+// stale eviction on a single bad request.
+func TestMaybeEvictPin_SuccessResets(t *testing.T) {
+	store := &evictionStubPinStore{}
+	svc := newEvictionTestService(store)
+
+	svc.maybeEvictPinAfterUpstreamErr(
+		context.Background(),
+		true,
+		nil, // success
+		"cluster:v0.57 model=gpt-5.5 provider=openai",
+		uuid.New(),
+		nonZeroSessionKey(),
+		sessionpin.DefaultRole,
+	)
+
+	assert.Equal(t, 1, store.resetCalls, "successful turn on a sticky pin must clear the strike counter")
+	assert.Equal(t, 0, store.incrementCalls)
+	assert.Empty(t, store.upserts)
+}
+
+// TestMaybeEvictPin_RetryableStatusIgnored guards the IsRetryableStatus
+// gate. 429 / 408 / 5xx are upstream-transient and handled by
+// dispatchWithFallback; they must not drain the strike counter, since
+// a rate-limited request says nothing about whether the model itself
+// is wedged.
+func TestMaybeEvictPin_RetryableStatusIgnored(t *testing.T) {
+	for _, status := range []int{http.StatusRequestTimeout, http.StatusTooManyRequests, http.StatusInternalServerError, http.StatusBadGateway, http.StatusServiceUnavailable} {
+		store := &evictionStubPinStore{incrementNext: []int{99}}
+		svc := newEvictionTestService(store)
+
+		svc.maybeEvictPinAfterUpstreamErr(
+			context.Background(),
+			true,
+			&providers.UpstreamErrorResponse{Status: status},
+			"cluster:v0.57 model=gpt-5.5 provider=openai",
+			uuid.New(),
+			nonZeroSessionKey(),
+			sessionpin.DefaultRole,
+		)
+
+		assert.Zero(t, store.incrementCalls, "status %d is retryable and must not bump the strike counter", status)
+		assert.Empty(t, store.upserts, "status %d must not trigger eviction", status)
+	}
+}
+
+// TestMaybeEvictPin_UserForcedSkipped pins the user-command override:
+// a force-model'd session is the user explicitly choosing this
+// provider/model, and auto-eviction would silently revert that
+// command on the next turn. /unforce-model remains the escape hatch.
+// Covers both the plain reason and the "+tier_clamp" suffix variant.
+func TestMaybeEvictPin_UserForcedSkipped(t *testing.T) {
+	for _, reason := range []string{translate.ReasonUserForceModel, translate.ReasonUserForceModel + "+tier_clamp"} {
+		store := &evictionStubPinStore{incrementNext: []int{pinEvictionStrikeThreshold}}
+		svc := newEvictionTestService(store)
+
+		svc.maybeEvictPinAfterUpstreamErr(
+			context.Background(),
+			true,
+			&providers.UpstreamErrorResponse{Status: http.StatusBadRequest},
+			reason,
+			uuid.New(),
+			nonZeroSessionKey(),
+			sessionpin.DefaultRole,
+		)
+
+		assert.Zero(t, store.incrementCalls, "user-forced pins (%q) must skip the counter increment", reason)
+		assert.Zero(t, store.resetCalls)
+		assert.Empty(t, store.upserts, "user-forced pins must never be auto-evicted (%q)", reason)
+	}
+}
+
+// TestMaybeEvictPin_NoStickyHitSkipped verifies the cheap fast-path:
+// when this turn freshly routed via the scorer (no sticky pin), there
+// is no prior decision to second-guess. The Upsert that just wrote
+// this turn's pin already resets the counter via the SQL CASE clause,
+// so any reset call here would be redundant work.
+func TestMaybeEvictPin_NoStickyHitSkipped(t *testing.T) {
+	store := &evictionStubPinStore{incrementNext: []int{pinEvictionStrikeThreshold}}
+	svc := newEvictionTestService(store)
+
+	svc.maybeEvictPinAfterUpstreamErr(
+		context.Background(),
+		false, // !stickyHit
+		&providers.UpstreamErrorResponse{Status: http.StatusBadRequest},
+		"cluster:v0.57 model=gpt-5.5 provider=openai",
+		uuid.New(),
+		nonZeroSessionKey(),
+		sessionpin.DefaultRole,
+	)
+
+	assert.Zero(t, store.incrementCalls)
+	assert.Zero(t, store.resetCalls)
+	assert.Empty(t, store.upserts)
+}
+
+// TestMaybeEvictPin_ZeroSessionKeySkipped guards against a corrupted
+// pin row shared by every zero-keyed caller — mirrors the same guard
+// in no_progress.go.
+func TestMaybeEvictPin_ZeroSessionKeySkipped(t *testing.T) {
+	store := &evictionStubPinStore{incrementNext: []int{pinEvictionStrikeThreshold}}
+	svc := newEvictionTestService(store)
+
+	svc.maybeEvictPinAfterUpstreamErr(
+		context.Background(),
+		true,
+		&providers.UpstreamErrorResponse{Status: http.StatusBadRequest},
+		"cluster:v0.57 model=gpt-5.5 provider=openai",
+		uuid.New(),
+		[sessionpin.SessionKeyLen]byte{}, // zero key
+		sessionpin.DefaultRole,
+	)
+
+	assert.Zero(t, store.incrementCalls)
+	assert.Empty(t, store.upserts)
+}
+
+// TestMaybeEvictPin_NilInstallationSkipped covers the unauthenticated
+// path (no installation_id resolved). Selfhosted / fakes / dev
+// scenarios hit this; the eviction must no-op rather than write a
+// uuid.Nil-installed row to Postgres.
+func TestMaybeEvictPin_NilInstallationSkipped(t *testing.T) {
+	store := &evictionStubPinStore{incrementNext: []int{pinEvictionStrikeThreshold}}
+	svc := newEvictionTestService(store)
+
+	svc.maybeEvictPinAfterUpstreamErr(
+		context.Background(),
+		true,
+		&providers.UpstreamErrorResponse{Status: http.StatusBadRequest},
+		"cluster:v0.57 model=gpt-5.5 provider=openai",
+		uuid.Nil,
+		nonZeroSessionKey(),
+		sessionpin.DefaultRole,
+	)
+
+	assert.Zero(t, store.incrementCalls)
+	assert.Empty(t, store.upserts)
+}
+
+// TestMaybeEvictPin_NonUpstreamErrorIgnored guards the upstreamStatus
+// gate: a generic transport / build / context-cancel error has no
+// upstream status and is not a model-quality signal, so the counter
+// must NOT advance.
+func TestMaybeEvictPin_NonUpstreamErrorIgnored(t *testing.T) {
+	store := &evictionStubPinStore{incrementNext: []int{pinEvictionStrikeThreshold}}
+	svc := newEvictionTestService(store)
+
+	svc.maybeEvictPinAfterUpstreamErr(
+		context.Background(),
+		true,
+		errors.New("upstream call: dial tcp: connection refused"),
+		"cluster:v0.57 model=gpt-5.5 provider=openai",
+		uuid.New(),
+		nonZeroSessionKey(),
+		sessionpin.DefaultRole,
+	)
+
+	assert.Zero(t, store.incrementCalls)
+	assert.Empty(t, store.upserts)
+}

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -1191,6 +1191,13 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 		s.emitBilling(ctx, requestID, externalID, decision, actPricing, routeRes, in, out, cacheCreation, cacheRead)
 	}
 
+	// Two-strike pin eviction: a session pinned to a model that keeps
+	// returning non-retryable 4xx wedges until the user manually
+	// /force-model's out. Increment a persistent counter and expire the
+	// pin once it reaches the threshold so the next turn re-routes.
+	// Successful turns reset the counter.
+	s.maybeEvictPinAfterUpstreamErr(ctx, stickyHit, proxyErr, decision.Reason, installationID, routeRes.SessionKey, routeRes.PinRole)
+
 	log.Info("ProxyMessages complete", "requested_model", feats.Model, "baseline_model", s.baselineFor(feats.Model), "decision_model", decision.Model, "decision_provider", decision.Provider, "primary_provider", primaryProvider, "fallback_attempts", winnerIdx, "failover_used", finalProvider != primaryProvider, "decision_reason", decision.Reason, "requested_tier", routeRes.RequestedTier.String(), "decision_tier", catalog.TierFor(decision.Model).String(), "tier_clamped", routeRes.TierClamped, "pre_clamp_model", routeRes.PreClampModel, "embedded_tokens", len(promptText)/4, "total_input_tokens", feats.Tokens, "has_tools", feats.HasTools, "message_count", feats.MessageCount, "last_kind", feats.LastKind, "last_preview", feats.LastPreview, "embed_input", embedInput, "cross_format", crossFormat, "sticky_hit", stickyHit, "route_ms", routeMs, "proxy_ms", proxyMs, "proxy_err", proxyErr, "upstream_status", upstreamStatus(proxyErr), "upstream_finish_reason", respSummary.UpstreamFinishReason, "resp_stop_reason", respSummary.StopReason, "stop_reason_promoted", respSummary.StopReasonPromoted, "tool_use_blocks", respSummary.ToolUseBlocks, "invalid_tool_args_blocks", respSummary.InvalidToolArgsBlocks, "text_only_turn_nudged", respSummary.TextOnlyTurnNudged, "cc_only_tools_stripped", reqStats.CCOnlyToolsStripped, "gemini_reminder_injected", reqStats.GeminiReminderInjected, "resp_output_tokens", respSummary.OutputTokens, "prelude_committed", preludeBuf.Committed())
 	return proxyErr
 }
@@ -2076,6 +2083,9 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 	if proxyErr == nil {
 		s.emitBilling(ctx, requestID, externalID, decision, actPricing, routeRes, in, out, cacheCreation, cacheRead)
 	}
+
+	// See ProxyMessages for the two-strike eviction rationale.
+	s.maybeEvictPinAfterUpstreamErr(ctx, stickyHit, proxyErr, decision.Reason, installationIDFromContext(ctx), routeRes.SessionKey, routeRes.PinRole)
 
 	installationIDOAI, _ := ctx.Value(InstallationIDContextKey{}).(string)
 	if installationIDOAI != "" {

--- a/internal/proxy/service_session_pin_test.go
+++ b/internal/proxy/service_session_pin_test.go
@@ -26,15 +26,18 @@ import (
 )
 
 type fakePinStore struct {
-	mu       sync.Mutex
-	pin      sessionpin.Pin
-	hasPin   bool
-	getErr   error
-	getCalls int
-	upserts  []sessionpin.Pin
-	upsertCh chan struct{}
-	usages   []sessionpin.Usage
-	usageCh  chan struct{}
+	mu               sync.Mutex
+	pin              sessionpin.Pin
+	hasPin           bool
+	getErr           error
+	getCalls         int
+	upserts          []sessionpin.Pin
+	upsertCh         chan struct{}
+	usages           []sessionpin.Usage
+	usageCh          chan struct{}
+	incrementCalls   int
+	incrementReturns int // value returned by IncrementUpstreamErrors when hasPin is true
+	resetCalls       int
 }
 
 func newFakePinStore() *fakePinStore {
@@ -79,6 +82,23 @@ func (f *fakePinStore) UpdateUsage(ctx context.Context, key [sessionpin.SessionK
 	case f.usageCh <- struct{}{}:
 	default:
 	}
+	return nil
+}
+
+func (f *fakePinStore) IncrementUpstreamErrors(ctx context.Context, key [sessionpin.SessionKeyLen]byte, role string) (int, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.incrementCalls++
+	if !f.hasPin {
+		return 0, nil
+	}
+	return f.incrementReturns, nil
+}
+
+func (f *fakePinStore) ResetUpstreamErrors(ctx context.Context, key [sessionpin.SessionKeyLen]byte, role string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.resetCalls++
 	return nil
 }
 

--- a/internal/proxy/turnloop_internal_test.go
+++ b/internal/proxy/turnloop_internal_test.go
@@ -48,6 +48,14 @@ func (s *stubPinStore) UpdateUsage(_ context.Context, _ [sessionpin.SessionKeyLe
 	return nil
 }
 
+func (s *stubPinStore) IncrementUpstreamErrors(context.Context, [sessionpin.SessionKeyLen]byte, string) (int, error) {
+	return 0, nil
+}
+
+func (s *stubPinStore) ResetUpstreamErrors(context.Context, [sessionpin.SessionKeyLen]byte, string) error {
+	return nil
+}
+
 func (s *stubPinStore) SweepExpired(context.Context) error { return nil }
 
 // TestRecordTurnUsage_UpdatesInProcCache guards the LRU-coherence invariant:

--- a/internal/router/sessionpin/store.go
+++ b/internal/router/sessionpin/store.go
@@ -25,22 +25,31 @@ const DefaultRole = "default"
 // and are written by Store.UpdateUsage after a turn completes. They are
 // deliberately left untouched by Upsert so an at-start-of-turn refresh
 // cannot clobber them with zeros.
+//
+// ConsecutiveUpstreamErrors counts consecutive turns ending in a
+// non-retryable upstream error (4xx other than 408/429). The turn loop
+// increments via Store.IncrementUpstreamErrors after a sticky-pinned
+// turn fails and evicts the pin once the count hits the two-strike
+// threshold; Store.ResetUpstreamErrors clears it on any successful
+// turn. Upsert preserves it on a same-model refresh and resets it on
+// a switch (different model).
 type Pin struct {
-	SessionKey            [SessionKeyLen]byte
-	Role                  string
-	InstallationID        uuid.UUID
-	Provider              string
-	Model                 string
-	Reason                string
-	TurnCount             int
-	PinnedUntil           time.Time
-	FirstPinnedAt         time.Time
-	LastSeenAt            time.Time
-	LastInputTokens       int
-	LastCachedReadTokens  int
-	LastCachedWriteTokens int
-	LastOutputTokens      int
-	LastTurnEndedAt       time.Time
+	SessionKey                [SessionKeyLen]byte
+	Role                      string
+	InstallationID            uuid.UUID
+	Provider                  string
+	Model                     string
+	Reason                    string
+	TurnCount                 int
+	PinnedUntil               time.Time
+	FirstPinnedAt             time.Time
+	LastSeenAt                time.Time
+	LastInputTokens           int
+	LastCachedReadTokens      int
+	LastCachedWriteTokens     int
+	LastOutputTokens          int
+	LastTurnEndedAt           time.Time
+	ConsecutiveUpstreamErrors int
 }
 
 // Usage captures the previous turn's upstream token accounting.
@@ -53,11 +62,20 @@ type Usage struct {
 }
 
 // Store is the I/O surface for session pins. Get returns (zero, false, nil)
-// when no row exists. UpdateUsage is a no-op when the pin has been evicted
-// or never existed.
+// when no row exists. UpdateUsage, IncrementUpstreamErrors, and
+// ResetUpstreamErrors are no-ops when the pin has been evicted or never
+// existed.
+//
+// IncrementUpstreamErrors atomically increments the consecutive-error
+// counter on the existing pin and returns the new count, so the turn
+// loop can apply a two-strike eviction without a read-modify-write race
+// across pods. Returns (0, nil) for a missing pin — the caller treats
+// that as "pin already evicted" rather than an error.
 type Store interface {
 	Get(ctx context.Context, sessionKey [SessionKeyLen]byte, role string) (Pin, bool, error)
 	Upsert(ctx context.Context, p Pin) error
 	UpdateUsage(ctx context.Context, sessionKey [SessionKeyLen]byte, role string, usage Usage) error
+	IncrementUpstreamErrors(ctx context.Context, sessionKey [SessionKeyLen]byte, role string) (int, error)
+	ResetUpstreamErrors(ctx context.Context, sessionKey [SessionKeyLen]byte, role string) error
 	SweepExpired(ctx context.Context) error
 }

--- a/internal/sqlc/models.go
+++ b/internal/sqlc/models.go
@@ -144,18 +144,19 @@ type RouterSessionPin struct {
 	// 16-byte digest derived from api_key_id + (metadata.user_id | system+first-user hashes)
 	SessionKey []byte
 	// Stage 1 always emits "default"; turn-type roles land with §3.3
-	Role                  string
-	InstallationID        uuid.UUID
-	PinnedProvider        string
-	PinnedModel           string
-	DecisionReason        string
-	TurnCount             int32
-	PinnedUntil           pgtype.Timestamp
-	FirstPinnedAt         pgtype.Timestamp
-	LastSeenAt            pgtype.Timestamp
-	LastInputTokens       int32
-	LastCachedReadTokens  int32
-	LastCachedWriteTokens int32
-	LastOutputTokens      int32
-	LastTurnEndedAt       pgtype.Timestamptz
+	Role                      string
+	InstallationID            uuid.UUID
+	PinnedProvider            string
+	PinnedModel               string
+	DecisionReason            string
+	TurnCount                 int32
+	PinnedUntil               pgtype.Timestamp
+	FirstPinnedAt             pgtype.Timestamp
+	LastSeenAt                pgtype.Timestamp
+	LastInputTokens           int32
+	LastCachedReadTokens      int32
+	LastCachedWriteTokens     int32
+	LastOutputTokens          int32
+	LastTurnEndedAt           pgtype.Timestamptz
+	ConsecutiveUpstreamErrors int32
 }

--- a/internal/sqlc/session_pins.sql.go
+++ b/internal/sqlc/session_pins.sql.go
@@ -13,7 +13,7 @@ import (
 )
 
 const getSessionPin = `-- name: GetSessionPin :one
-SELECT session_key, role, installation_id, pinned_provider, pinned_model, decision_reason, turn_count, pinned_until, first_pinned_at, last_seen_at, last_input_tokens, last_cached_read_tokens, last_cached_write_tokens, last_output_tokens, last_turn_ended_at
+SELECT session_key, role, installation_id, pinned_provider, pinned_model, decision_reason, turn_count, pinned_until, first_pinned_at, last_seen_at, last_input_tokens, last_cached_read_tokens, last_cached_write_tokens, last_output_tokens, last_turn_ended_at, consecutive_upstream_errors
 FROM router.session_pins
 WHERE session_key = $1::bytea
   AND role        = $2::varchar
@@ -31,7 +31,7 @@ type GetSessionPinParams struct {
 // last_turn_ended_at carry the previous turn's upstream usage; the
 // planner reads them to weigh switch EV against eviction cost.
 //
-//	SELECT session_key, role, installation_id, pinned_provider, pinned_model, decision_reason, turn_count, pinned_until, first_pinned_at, last_seen_at, last_input_tokens, last_cached_read_tokens, last_cached_write_tokens, last_output_tokens, last_turn_ended_at
+//	SELECT session_key, role, installation_id, pinned_provider, pinned_model, decision_reason, turn_count, pinned_until, first_pinned_at, last_seen_at, last_input_tokens, last_cached_read_tokens, last_cached_write_tokens, last_output_tokens, last_turn_ended_at, consecutive_upstream_errors
 //	FROM router.session_pins
 //	WHERE session_key = $1::bytea
 //	  AND role        = $2::varchar
@@ -54,8 +54,68 @@ func (q *Queries) GetSessionPin(ctx context.Context, arg GetSessionPinParams) (R
 		&i.LastCachedWriteTokens,
 		&i.LastOutputTokens,
 		&i.LastTurnEndedAt,
+		&i.ConsecutiveUpstreamErrors,
 	)
 	return i, err
+}
+
+const incrementSessionPinUpstreamErrors = `-- name: IncrementSessionPinUpstreamErrors :one
+UPDATE router.session_pins
+SET consecutive_upstream_errors = consecutive_upstream_errors + 1
+WHERE session_key = $1::bytea
+  AND role        = $2::varchar
+RETURNING consecutive_upstream_errors
+`
+
+type IncrementSessionPinUpstreamErrorsParams struct {
+	SessionKey []byte
+	Role       string
+}
+
+// Atomically increments consecutive_upstream_errors and returns the
+// new value. The turn loop calls this after a non-retryable upstream
+// 4xx on a sticky-pinned turn; the returned count drives the
+// two-strike eviction decision. Returns sql.ErrNoRows if no pin
+// exists, which the adapter maps to a no-op (pin must already be
+// evicted by another path, e.g. force-model / loop-break).
+//
+//	UPDATE router.session_pins
+//	SET consecutive_upstream_errors = consecutive_upstream_errors + 1
+//	WHERE session_key = $1::bytea
+//	  AND role        = $2::varchar
+//	RETURNING consecutive_upstream_errors
+func (q *Queries) IncrementSessionPinUpstreamErrors(ctx context.Context, arg IncrementSessionPinUpstreamErrorsParams) (int32, error) {
+	row := q.db.QueryRow(ctx, incrementSessionPinUpstreamErrors, arg.SessionKey, arg.Role)
+	var consecutive_upstream_errors int32
+	err := row.Scan(&consecutive_upstream_errors)
+	return consecutive_upstream_errors, err
+}
+
+const resetSessionPinUpstreamErrors = `-- name: ResetSessionPinUpstreamErrors :exec
+UPDATE router.session_pins
+SET consecutive_upstream_errors = 0
+WHERE session_key = $1::bytea
+  AND role        = $2::varchar
+  AND consecutive_upstream_errors > 0
+`
+
+type ResetSessionPinUpstreamErrorsParams struct {
+	SessionKey []byte
+	Role       string
+}
+
+// Clears the two-strike counter after a successful turn. UPDATE
+// matches by (session_key, role); zero rows affected on missing pin
+// is a successful no-op like UpdateSessionPinUsage.
+//
+//	UPDATE router.session_pins
+//	SET consecutive_upstream_errors = 0
+//	WHERE session_key = $1::bytea
+//	  AND role        = $2::varchar
+//	  AND consecutive_upstream_errors > 0
+func (q *Queries) ResetSessionPinUpstreamErrors(ctx context.Context, arg ResetSessionPinUpstreamErrorsParams) error {
+	_, err := q.db.Exec(ctx, resetSessionPinUpstreamErrors, arg.SessionKey, arg.Role)
+	return err
 }
 
 const sweepExpiredSessionPins = `-- name: SweepExpiredSessionPins :exec
@@ -140,7 +200,12 @@ ON CONFLICT (session_key, role) DO UPDATE SET
   decision_reason = EXCLUDED.decision_reason,
   turn_count      = router.session_pins.turn_count + 1,
   pinned_until    = EXCLUDED.pinned_until,
-  last_seen_at    = CURRENT_TIMESTAMP
+  last_seen_at    = CURRENT_TIMESTAMP,
+  consecutive_upstream_errors = CASE
+    WHEN router.session_pins.pinned_model = EXCLUDED.pinned_model
+      THEN router.session_pins.consecutive_upstream_errors
+    ELSE 0
+  END
 `
 
 type UpsertSessionPinParams struct {
@@ -164,6 +229,12 @@ type UpsertSessionPinParams struct {
 // them, so the at-start-of-turn refresh here cannot clobber the
 // previous turn's usage with zeros before the planner reads it.
 //
+// consecutive_upstream_errors is preserved on a same-model refresh (so
+// the two-strike eviction counter accumulates across turns of the same
+// sticky pin) but reset to 0 on a switch (different model = clean
+// slate). The reset on switch also covers the loop-break / force-model
+// pin-expiry writes, which set pinned_model to the empty string.
+//
 //	INSERT INTO router.session_pins (
 //	  session_key, role, installation_id, pinned_provider,
 //	  pinned_model, decision_reason, turn_count, pinned_until
@@ -178,7 +249,12 @@ type UpsertSessionPinParams struct {
 //	  decision_reason = EXCLUDED.decision_reason,
 //	  turn_count      = router.session_pins.turn_count + 1,
 //	  pinned_until    = EXCLUDED.pinned_until,
-//	  last_seen_at    = CURRENT_TIMESTAMP
+//	  last_seen_at    = CURRENT_TIMESTAMP,
+//	  consecutive_upstream_errors = CASE
+//	    WHEN router.session_pins.pinned_model = EXCLUDED.pinned_model
+//	      THEN router.session_pins.consecutive_upstream_errors
+//	    ELSE 0
+//	  END
 func (q *Queries) UpsertSessionPin(ctx context.Context, arg UpsertSessionPinParams) error {
 	_, err := q.db.Exec(ctx, upsertSessionPin,
 		arg.SessionKey,


### PR DESCRIPTION
## Summary

Two related router fixes, prompted by investigating session `93e918bf-64ce-4450-b20b-8fde8dbc242a`, which got wedged on `gpt-5.5` for four consecutive turns of upstream 400s before the customer manually `/force-model`'d out. Investigation surfaced two distinct bugs.

### 1. `internal/providers/openai` swallowed 4xx upstream bodies

The native OpenAI client (a06bd25) streamed non-2xx responses straight through and returned `*UpstreamStatusError`. That:

- **Suppressed the `body_preview` log site** — `Upstream OpenAI returned error status` was the only place where the upstream's actual 400 reason ("max_completion_tokens exceeds model limit", malformed tool schema, etc.) would be visible. Across the whole session window, the `body_preview` log fired zero times despite four 400s.
- **Corrupted the response stream.** `*UpstreamStatusError` is non-retryable because "bytes already on the wire," but on this path no bytes were actually on the wire yet — the preludeBuffer had captured `200 + message_start` pre-Seal. `WriteHeader(400)` then committed `HTTP 400 + Anthropic SSE message_start + raw OpenAI JSON`, which Cloud Run surfaces as 502 to the customer.

Mirror the openaicompat adapter's pattern: read up to `MaxBufferedErrorBytes`, call `logUpstreamStatus` with `body_preview` + `routed_model` + `body_total_bytes`, and return `*UpstreamErrorResponse` so `dispatchWithFallback` can render the upstream error envelope in the inbound wire format (or fail over on a multi-binding model). Same body_preview log added to `Passthrough` for symmetry.

### 2. Sticky pins never auto-evicted on persistent upstream errors

The v0.57 cluster pinned `gpt-5.5` 27 minutes before any error. Once the upstream started 400'ing, `sticky_hit=true` re-used the exact same pin every turn, and the proxy had no signal that the model had gone bad. The customer had to manually `/force-model` to escape.

Add a persistent `consecutive_upstream_errors` counter on `router.session_pins` (migration 0009). The turn loop calls `Store.IncrementUpstreamErrors` after a sticky-pinned turn ends in a non-retryable upstream 4xx (i.e. not 408/429/5xx — those are transient or handled by `dispatchWithFallback`). When the count reaches the two-strike threshold, the pin expires via the same `PinnedUntil-1s + LRU-evict` pattern that `loop-break` / `no-progress` / `force-model` already use, so the **next** turn re-routes via the cluster scorer. A successful turn resets the counter so the count tracks *consecutive* failures, not lifetime failures.

**Skip paths** (in `maybeEvictPinAfterUpstreamErr`):
- `!stickyHit` — no prior decision to second-guess
- zero `session_key` / `installation_id` — no addressable row (mirrors the same guard in `no_progress.go`)
- user-forced pins (`ReasonUserForceModel` + `+tier_clamp` variant) — the user explicitly chose this model; `/unforce-model` is the escape hatch
- retryable upstream statuses (408, 429, 5xx)

**SQL details:** `UpsertSessionPin` now preserves the counter on a same-model refresh and resets it on a switch (different model = clean slate), via a `CASE` clause on `pinned_model`. This handles the loop-break / force-model "expired pin" writes too — they set `pinned_model = ''`, so the counter resets.

Errors from the increment/reset/upsert paths are logged and swallowed: eviction is a recovery optimization on a turn that already succeeded or failed, and failing it must not change the client-visible outcome.

## Test plan

- [x] `go test ./...` passes
- [x] `go vet ./...` clean
- [x] `gofmt -l` clean
- [x] New tests:
  - `TestProxy_BuffersUpstream4xx` / `TestProxy_5xxIsBufferedToo` in `internal/providers/openai/client_test.go`
  - `TestMaybeEvictPin_*` (8 cases covering first-strike-increments, second-strike-expires, success-resets, retryable-ignored, user-forced-skipped, !stickyHit, zero-session-key, nil-installation, non-upstream-error) in `internal/proxy/pin_eviction_internal_test.go`
- [ ] Migration apply/rollback exercised in staging before merge
- [ ] Watch GCP for `Upstream OpenAI returned error status` log lines once deployed — they should now appear on every gpt-* 4xx and surface the upstream body

## Notes

- SQLC regen done with v1.30.0 to match CI (`.github/workflows/test.yml:46`).
- One PR, two commits — each commit compiles + tests pass independently so they can be reverted in isolation if needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)