### PR TITLE
fix(translate): suppress text-only-turn nudge on Gemini-3.x (history poison)

### DIFF
--- a/internal/translate/stream.go
+++ b/internal/translate/stream.go
@@ -922,8 +922,28 @@ const routerNudgeCommand = "echo '[router] previous turn produced no tool_use; p
 // request had no tools (the model legitimately had nothing else to do), or
 // when nothing has been written to the stream yet (an unrelated upstream
 // error — preludeBuffer + flushErr handles that path).
+//
+// CRITICAL no-op on Gemini-3.x: the synthesized block is a tool_use with no
+// thoughtSignature. Gemini-3.x requires a thoughtSignature on every
+// functionCall part across turns; on the next turn writeGeminiFromAnthropic
+// sees the sig-less nudge, sets anyToolUseMissingSig and drops the ENTIRE
+// tool_use/tool_result history (emit_gemini.go dropToolBlocks). That wipes
+// every prior Read/Grep/Bash result, so the model loses its working context,
+// re-runs the same discovery commands, never edits, and loops to the turn
+// ceiling (error_max_turns). Empirically this nudge made Gemini-3.x strictly
+// worse (≥90-turn loops 4 → 46 across the v0.59 SWE-bench bake-off), so we
+// suppress it here and let the turn end as text. The OpenAI-compat models the
+// nudge was built for (e.g. Mimo-v2.5) have no such guard and still benefit.
 func (t *AnthropicSSETranslator) synthesizeTextOnlyTurnNudge() error {
 	if t.toolUseEmitted || !t.requestHadTools || !t.started {
+		return nil
+	}
+	if isGemini3xModel(t.requestModel) || isGemini3xModel(t.modelFromUpstream) {
+		observability.Get().Debug(
+			"AnthropicSSE suppressed text-only-turn nudge on Gemini-3.x (sig-less tool_use would poison next-turn history)",
+			"upstream_model", t.modelFromUpstream,
+			"request_model", t.requestModel,
+		)
 		return nil
 	}
 	blockIdx := t.blockIdx

--- a/internal/translate/tool_args_validation_test.go
+++ b/internal/translate/tool_args_validation_test.go
@@ -126,11 +126,12 @@ func driveAnthropicSSEWithTools(
 }
 
 func TestAnthropicSSETranslator_TextOnlyTurnNudge_SynthesizesBash(t *testing.T) {
-	// Gemini / Mimo failure mode: upstream emits prose + <think> XML as
-	// plain text deltas, no tool_calls. Request HAD tools available.
-	// finishStream must synthesize a Bash tool_use so Claude Code's loop
-	// doesn't die on "tool call could not be parsed".
-	body, summary := driveAnthropicSSEWithTools(t, "gemini-3.1-pro-preview", true, []string{
+	// OpenAI-compat failure mode (e.g. Mimo-v2.5): upstream emits prose +
+	// <think> XML as plain text deltas, no tool_calls. Request HAD tools
+	// available. finishStream must synthesize a Bash tool_use so Claude
+	// Code's loop doesn't die on "tool call could not be parsed". (Gemini-3.x
+	// is deliberately excluded — see the _SuppressedOnGemini3x test below.)
+	body, summary := driveAnthropicSSEWithTools(t, "mimo-v2.5-pro", true, []string{
 		`data: {"id":"c1","choices":[{"index":0,"delta":{"content":"<think>Let me look at the file…</think>"},"finish_reason":null}]}` + "\n\n",
 		`data: {"id":"c1","choices":[{"index":0,"delta":{"content":" I will read the relevant code first."},"finish_reason":null}]}` + "\n\n",
 		`data: {"id":"c1","choices":[{"index":0,"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":40,"completion_tokens":15}}` + "\n\n",
@@ -148,6 +149,28 @@ func TestAnthropicSSETranslator_TextOnlyTurnNudge_SynthesizesBash(t *testing.T) 
 		"nudge text instructs the model to switch to real tools")
 	assert.Contains(t, body, `"id":"toolu_router_nudge_`,
 		"synthetic id is prefixed so log auditors can match it in stream transcripts")
+}
+
+func TestAnthropicSSETranslator_TextOnlyTurnNudge_SuppressedOnGemini3x(t *testing.T) {
+	// Regression: the synthetic Bash block has no thoughtSignature. On
+	// Gemini-3.x the next turn drops the ENTIRE tool_use/tool_result history
+	// (anyToolUseMissingSig → dropToolBlocks in emit_gemini.go), wiping the
+	// agent's working context and looping it to the turn ceiling. So even
+	// though the request had tools and the upstream emitted only text, the
+	// nudge MUST be suppressed when the routed model is Gemini-3.x.
+	body, summary := driveAnthropicSSEWithTools(t, "gemini-3.1-pro-preview", true, []string{
+		`data: {"id":"c1","choices":[{"index":0,"delta":{"content":"<think>Let me look at the file…</think>"},"finish_reason":null}]}` + "\n\n",
+		`data: {"id":"c1","choices":[{"index":0,"delta":{"content":" I will read the relevant code first."},"finish_reason":null}]}` + "\n\n",
+		`data: {"id":"c1","choices":[{"index":0,"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":40,"completion_tokens":15}}` + "\n\n",
+		"data: [DONE]\n\n",
+	})
+
+	assert.False(t, summary.TextOnlyTurnNudged,
+		"nudge must be suppressed on Gemini-3.x — a sig-less tool_use poisons the next turn's history")
+	assert.Equal(t, 0, summary.ToolUseBlocks,
+		"no synthetic tool_use is emitted on the Gemini-3.x path")
+	assert.NotContains(t, body, "toolu_router_nudge_",
+		"no synthetic nudge block reaches a Gemini-3.x client")
 }
 
 func TestAnthropicSSETranslator_TextOnlyTurnNudge_NoToolsInRequest(t *testing.T) {


### PR DESCRIPTION
## Root cause

PR #284 (`ac402c5`) added `synthesizeTextOnlyTurnNudge`: when an upstream produces a text-only turn on a tool-bearing request, it fabricates a `Bash` `tool_use` block to keep Claude Code's agentic loop alive. But that block is emitted with an **empty `thoughtSignature`** (`emitContentBlockStartTool(blockIdx, id, "Bash", "")`).

Gemini-3.x requires a `thoughtSignature` on every `functionCall` part across turns. On the **next** turn, `writeGeminiFromAnthropic` sees the sig-less nudge → sets `anyToolUseMissingSig` → `dropToolBlocks` (`emit_gemini.go`) → **drops the entire `tool_use`/`tool_result` history**, replacing it with placeholder text. The model loses every prior Read/Grep/Bash result, re-runs the same discovery commands, never edits, and loops to the turn ceiling (`error_max_turns`, surfaced as `api_error`). It's self-reinforcing: each empty turn re-arms it.

## Evidence — v0.59 SWE-bench × Claude Code bake-off

Gemini-dominant shards at ≥90 turns (the looping signature):

| run | #284 present? | gemini shards ≥90 turns | api_error |
|---|---|---|---|
| baseline (da2d0e1) | no | 4 | 16 |
| da2d0e1 rerun | no | 0 | 15 |
| bucket batch | **yes** | **46/46** | 46 |
| revert285 (d886638) | **yes** | **40/41** | 41 |

Presence of #284 tracks the looping exactly. Reverting #285 didn't help because #284 was untouched. #284 also made Gemini empty-patch *worse* (24 → 32) — it's net-negative on Gemini.

## Fix

Suppress the nudge when the routed/upstream model is Gemini-3.x and let the turn end as text (matching the better `da2d0e1` baseline). OpenAI-compat models the nudge was built for (e.g. Mimo-v2.5) go through `emit_openai` and have no sig-drop guard, so they keep the benefit.

Guards on both `requestModel` (= `decision.Model`, always set on the gemini chain via `NewGeminiToOpenAISSETranslator(anthropicTr, d.Model, ...)`) and `modelFromUpstream` (belt-and-suspenders).

## Tests

- Repointed the positive `_SynthesizesBash` test to `mimo-v2.5-pro` (the OpenAI-compat case the nudge targets).
- Added `_SuppressedOnGemini3x` asserting no synthetic block is emitted on `gemini-3.1-pro-preview`.
- `go build ./...`, `go vet`, and full `internal/translate` suite pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)