### PR TITLE
fix: exclude router nudges from loop/no-progress detectors

### DIFF
--- a/internal/translate/loop_detection.go
+++ b/internal/translate/loop_detection.go
@@ -153,6 +153,15 @@ func anthropicAssistantToolCallSigs(body []byte) []ToolCallSig {
 			if name == "" {
 				return true
 			}
+			// Skip router-synthesized recovery nudges. Nudges carry a constant
+			// command string (routerNudgeCommand), so their InputHash never
+			// changes. If a model emits consecutive text-only turns the router
+			// injects a nudge each time; once 5 accumulate in the window both
+			// detectToolCallLoop and toolProgressMarker see 5 identical Bash
+			// sigs and fire — killing the session the nudge was meant to rescue.
+			if strings.HasPrefix(block.Get("id").String(), "toolu_router_nudge_") {
+				return true
+			}
 			// Skip entries with empty input. Cross-format translation of a
 			// stream-incomplete tool call (OpenAI/openaicompat upstream →
 			// Anthropic inbound) can emit `input:{}` to satisfy the schema.

--- a/internal/translate/loop_detection_test.go
+++ b/internal/translate/loop_detection_test.go
@@ -197,6 +197,48 @@ func TestAssistantToolCallSignatures_EmptyAndNonAssistant(t *testing.T) {
 	assert.Nil(t, env.AssistantToolCallSignatures())
 }
 
+func TestAssistantToolCallSignatures_SkipsRouterNudgeEntries(t *testing.T) {
+	// Router-synthesized recovery nudges have a constant command string so their
+	// InputHash never changes. If a model emits consecutive text-only turns the
+	// router injects a nudge each time; once 5 accumulate in the history both
+	// detectToolCallLoop and toolProgressMarker see 5 identical Bash sigs and
+	// fire — killing the session the nudge was trying to rescue. Nudges must be
+	// invisible to the detectors.
+	body := mustMarshalJSON(t, map[string]any{
+		"model": "claude-sonnet-4-6",
+		"messages": []any{
+			map[string]any{"role": "assistant", "content": []any{
+				map[string]any{"type": "tool_use", "id": "toolu_router_nudge_msg1", "name": "Bash", "input": map[string]any{
+					"command":     "echo '[router] previous turn produced no tool_use; please use Edit/Write/Read/Bash/Grep — do not respond with prose or <think> tags only.'",
+					"description": "router recovery nudge: previous turn had no tool_use",
+				}},
+			}},
+			map[string]any{"role": "user", "content": []any{
+				map[string]any{"type": "tool_result", "tool_use_id": "toolu_router_nudge_msg1", "content": ""},
+			}},
+			map[string]any{"role": "assistant", "content": []any{
+				map[string]any{"type": "tool_use", "id": "toolu_router_nudge_msg2", "name": "Bash", "input": map[string]any{
+					"command":     "echo '[router] previous turn produced no tool_use; please use Edit/Write/Read/Bash/Grep — do not respond with prose or <think> tags only.'",
+					"description": "router recovery nudge: previous turn had no tool_use",
+				}},
+			}},
+			map[string]any{"role": "user", "content": []any{
+				map[string]any{"type": "tool_result", "tool_use_id": "toolu_router_nudge_msg2", "content": ""},
+			}},
+			map[string]any{"role": "assistant", "content": []any{
+				map[string]any{"type": "tool_use", "id": "toolu_real_1", "name": "Read", "input": map[string]any{"file_path": "/foo.go"}},
+			}},
+		},
+		"max_tokens": 256,
+	})
+	env, err := translate.ParseAnthropic(body)
+	require.NoError(t, err)
+
+	sigs := env.AssistantToolCallSignatures()
+	require.Len(t, sigs, 1, "router nudge tool_use entries must be filtered; only the real Read should appear")
+	assert.Equal(t, "Read", sigs[0].Name)
+}
+
 // mustMarshalJSON is shared with force_model_test.go; redeclared here would be
 // a compile error so the existing one is reused.
 var _ = json.Marshal


### PR DESCRIPTION
## Problem

`toolu_router_nudge_*` tool calls carry a constant command string (`routerNudgeCommand`), so every nudge produces the **same `InputHash`**. When a stuck model emits consecutive text-only turns, the router injects a nudge each time. After 5 accumulate in the 10-entry history window:

- `detectToolCallLoop` sees 5 identical `{Name: "Bash", InputHash: <fixed>}` entries and fires — killing the session the nudge was trying to rescue
- `toolProgressMarker` also stays flat (same count + same last-sig), causing `computeNoProgressFingerprint` to collide and the cross-envelope no-progress detector to fire

Investigated via session `f131e724-d293-445a-bf95-8e180c955ce1`.

## Fix

Added a `strings.HasPrefix(id, "toolu_router_nudge_")` guard in `anthropicAssistantToolCallSigs` so router-synthesized nudges are invisible to `AssistantToolCallSignatures()` — and therefore to both `detectToolCallLoop` and `toolProgressMarker`.

## Test

Added `TestAssistantToolCallSignatures_SkipsRouterNudgeEntries` covering the 2-nudge + 1-real-tool scenario: only the real `Read` call appears in the returned signatures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)