### PR TITLE
fix(proxy): no-progress false positive + compaction-aware handover for non-Anthropic routes

### DIFF
--- a/internal/proxy/handover.go
+++ b/internal/proxy/handover.go
@@ -263,8 +263,11 @@ var _ handover.Summarizer = (*ProviderSummarizer)(nil)
 // wired and credentials allow, fall back to TrimLastN on any error. Errors are
 // logged but never returned — a failed compaction rewrite is better than a
 // failed request; the model will at least see the compacted body.
-func (s *Service) runCompactionHandover(ctx context.Context, env *translate.RequestEnvelope, reqHeaders http.Header, decisionModel string) {
+// Returns a handoverOutcome so the caller can bill the summary upstream call.
+func (s *Service) runCompactionHandover(ctx context.Context, env *translate.RequestEnvelope, reqHeaders http.Header, decisionModel string) handoverOutcome {
 	log := observability.FromContext(ctx)
+	var out handoverOutcome
+	out.Invoked = true
 
 	var (
 		sumProvider       string
@@ -281,26 +284,35 @@ func (s *Service) runCompactionHandover(ctx context.Context, env *translate.Requ
 	switch {
 	case s.summarizer == nil:
 		elided := handover.TrimLastN(env, 3)
+		out.FallbackToTrim = true
 		log.Info("Compaction handover: summarizer not wired; trimmed instead", "elided_messages", elided, "decision_model", decisionModel)
 	case !canCallSummarizer:
 		elided := handover.TrimLastN(env, 3)
+		out.FallbackToTrim = true
 		log.Info("Compaction handover: summarizer skipped (tenant boundary); trimmed instead", "elided_messages", elided, "decision_model", decisionModel)
 	default:
 		summCtx := ctx
 		if sumCreds != nil {
 			summCtx = context.WithValue(ctx, CredentialsContextKey{}, sumCreds)
 		}
-		summary, _, sumErr := s.summarizer.Summarize(summCtx, env)
+		start := time.Now()
+		summary, summaryUsage, sumErr := s.summarizer.Summarize(summCtx, env)
+		out.LatencyMS = time.Since(start).Milliseconds()
 		switch {
 		case sumErr != nil:
 			elided := handover.TrimLastN(env, 3)
+			out.FallbackToTrim = true
 			log.Warn("Compaction handover: summarizer failed; trimmed instead", "err", sumErr, "elided_messages", elided, "decision_model", decisionModel)
 		case summary == "":
 			elided := handover.TrimLastN(env, 3)
+			out.FallbackToTrim = true
 			log.Warn("Compaction handover: summarizer returned empty; trimmed instead", "elided_messages", elided, "decision_model", decisionModel)
 		default:
 			handover.RewriteEnvelope(env, summary)
+			out.SummaryTokens = estimateSummaryTokens(summary)
+			out.SummaryUsage = summaryUsage
 			log.Info("Compaction handover: context rewritten with summary", "summary_len", len(summary), "decision_model", decisionModel)
 		}
 	}
+	return out
 }

--- a/internal/proxy/handover.go
+++ b/internal/proxy/handover.go
@@ -252,3 +252,55 @@ func extractAnthropicAssistantText(body []byte) string {
 }
 
 var _ handover.Summarizer = (*ProviderSummarizer)(nil)
+
+// runCompactionHandover rewrites env in-place with a handover summary when
+// Claude Code context compaction is detected on a non-Anthropic route. The
+// compaction already dropped old turns from the client's history; without this
+// step the non-Anthropic model has no awareness of edits or decisions that
+// lived only in those elided turns.
+//
+// Mirrors the model-switch handover in runTurnLoop: run the summarizer when
+// wired and credentials allow, fall back to TrimLastN on any error. Errors are
+// logged but never returned — a failed compaction rewrite is better than a
+// failed request; the model will at least see the compacted body.
+func (s *Service) runCompactionHandover(ctx context.Context, env *translate.RequestEnvelope, reqHeaders http.Header, decisionModel string) {
+	log := observability.FromContext(ctx)
+
+	var (
+		sumProvider       string
+		sumCreds          *Credentials
+		canCallSummarizer bool
+	)
+	if s.summarizer != nil {
+		sumProvider = s.summarizer.Provider()
+		sumCreds = resolveSummarizerCreds(ctx, sumProvider, reqHeaders)
+		nonDepCreds := s.requestUsesNonDeploymentCreds(ctx, reqHeaders)
+		canCallSummarizer = sumCreds != nil || !nonDepCreds
+	}
+
+	switch {
+	case s.summarizer == nil:
+		elided := handover.TrimLastN(env, 3)
+		log.Info("Compaction handover: summarizer not wired; trimmed instead", "elided_messages", elided, "decision_model", decisionModel)
+	case !canCallSummarizer:
+		elided := handover.TrimLastN(env, 3)
+		log.Info("Compaction handover: summarizer skipped (tenant boundary); trimmed instead", "elided_messages", elided, "decision_model", decisionModel)
+	default:
+		summCtx := ctx
+		if sumCreds != nil {
+			summCtx = context.WithValue(ctx, CredentialsContextKey{}, sumCreds)
+		}
+		summary, _, sumErr := s.summarizer.Summarize(summCtx, env)
+		switch {
+		case sumErr != nil:
+			elided := handover.TrimLastN(env, 3)
+			log.Warn("Compaction handover: summarizer failed; trimmed instead", "err", sumErr, "elided_messages", elided, "decision_model", decisionModel)
+		case summary == "":
+			elided := handover.TrimLastN(env, 3)
+			log.Warn("Compaction handover: summarizer returned empty; trimmed instead", "elided_messages", elided, "decision_model", decisionModel)
+		default:
+			handover.RewriteEnvelope(env, summary)
+			log.Info("Compaction handover: context rewritten with summary", "summary_len", len(summary), "decision_model", decisionModel)
+		}
+	}
+}

--- a/internal/proxy/no_progress.go
+++ b/internal/proxy/no_progress.go
@@ -141,28 +141,49 @@ func newNoProgressTracker() *noProgressTracker {
 	}
 }
 
-// compactionTracker detects Claude Code context compaction events by comparing
-// each turn's message count against the last seen count for the same session.
-// A drop in message count indicates that the client replaced old turns with a
-// summary block, which can leave a non-Anthropic model unaware of completed
-// work (edits, decisions) that were only visible in the now-elided turns.
+// compactionState is what compactionTracker stores per session: the last-seen
+// top-level message count and the last-seen assistant tool-call count.
+// Both can independently signal that the client trimmed its history window.
+type compactionState struct {
+	msgCount      int
+	toolCallCount int
+}
+
+// compactionTracker detects Claude Code context window trimming by comparing
+// each turn's message count and assistant tool-call count against the last
+// seen values for the same session. Either count dropping is a signal that the
+// client elided old turns, which can leave a non-Anthropic model unaware of
+// completed work (edits, decisions) that were only visible in the now-elided
+// turns.
+//
+// Two independent signals are needed because Claude Code can trim history in
+// two distinct ways:
+//   - Full compaction: replaces all old messages with a summary block, so
+//     messageCount drops sharply (e.g. 20 → 3).
+//   - Rolling-window trimming: drops the oldest message pair each turn to
+//     keep a roughly fixed window, so messageCount stays flat while the
+//     assistant tool-call count shrinks by one per turn (the pattern
+//     observed in session 543151ce: 9 → 8 → 7 → 6 → 5).
+//
+// Detecting only messageCount drops misses the rolling-window case.
 //
 // nil receivers are valid (no-op), matching noProgressTracker semantics.
 type compactionTracker struct {
-	cache *lru.LRU[string, int]
+	cache *lru.LRU[string, compactionState]
 }
 
 func newCompactionTracker() *compactionTracker {
 	return &compactionTracker{
-		cache: lru.NewLRU[string, int](noProgressCacheSize, nil, noProgressCacheTTL),
+		cache: lru.NewLRU[string, compactionState](noProgressCacheSize, nil, noProgressCacheTTL),
 	}
 }
 
-// checkAndRecord records messageCount for the session and reports whether this
-// turn's count is lower than the previously recorded count (compaction event).
-// Returns false on the first observation for a session (no prior count to
-// compare against). Also returns false when no bucket anchor is available.
-func (t *compactionTracker) checkAndRecord(sessionKey [sessionpin.SessionKeyLen]byte, installationID uuid.UUID, role string, messageCount int) bool {
+// checkAndRecord records the session's current message count and tool-call
+// count, then reports whether either dropped versus the prior observation
+// (history-trimming event). Returns false on the first observation for a
+// session (no prior state to compare against) and when no bucket anchor is
+// available.
+func (t *compactionTracker) checkAndRecord(sessionKey [sessionpin.SessionKeyLen]byte, installationID uuid.UUID, role string, messageCount, toolCallCount int) bool {
 	if t == nil || t.cache == nil {
 		return false
 	}
@@ -171,8 +192,8 @@ func (t *compactionTracker) checkAndRecord(sessionKey [sessionpin.SessionKeyLen]
 		return false
 	}
 	last, found := t.cache.Get(key)
-	t.cache.Add(key, messageCount)
-	return found && messageCount < last
+	t.cache.Add(key, compactionState{msgCount: messageCount, toolCallCount: toolCallCount})
+	return found && (messageCount < last.msgCount || toolCallCount < last.toolCallCount)
 }
 
 // recordAndDetect records the fingerprint against a bucket keyed by

--- a/internal/proxy/no_progress.go
+++ b/internal/proxy/no_progress.go
@@ -141,6 +141,40 @@ func newNoProgressTracker() *noProgressTracker {
 	}
 }
 
+// compactionTracker detects Claude Code context compaction events by comparing
+// each turn's message count against the last seen count for the same session.
+// A drop in message count indicates that the client replaced old turns with a
+// summary block, which can leave a non-Anthropic model unaware of completed
+// work (edits, decisions) that were only visible in the now-elided turns.
+//
+// nil receivers are valid (no-op), matching noProgressTracker semantics.
+type compactionTracker struct {
+	cache *lru.LRU[string, int]
+}
+
+func newCompactionTracker() *compactionTracker {
+	return &compactionTracker{
+		cache: lru.NewLRU[string, int](noProgressCacheSize, nil, noProgressCacheTTL),
+	}
+}
+
+// checkAndRecord records messageCount for the session and reports whether this
+// turn's count is lower than the previously recorded count (compaction event).
+// Returns false on the first observation for a session (no prior count to
+// compare against). Also returns false when no bucket anchor is available.
+func (t *compactionTracker) checkAndRecord(sessionKey [sessionpin.SessionKeyLen]byte, installationID uuid.UUID, role string, messageCount int) bool {
+	if t == nil || t.cache == nil {
+		return false
+	}
+	key, ok := noProgressBucketKey(sessionKey, installationID, role)
+	if !ok {
+		return false
+	}
+	last, found := t.cache.Get(key)
+	t.cache.Add(key, messageCount)
+	return found && messageCount < last
+}
+
 // recordAndDetect records the fingerprint against a bucket keyed by
 // sessionKey (preferred) or installationID (fallback) and reports whether
 // the burst now exceeds the loop threshold. A nil tracker returns (false, 0)

--- a/internal/proxy/no_progress_internal_test.go
+++ b/internal/proxy/no_progress_internal_test.go
@@ -338,3 +338,49 @@ func TestShortSessionKey_TruncatesAndRedactsZero(t *testing.T) {
 	assert.Len(t, got, 16, "must log only the first 8 bytes (16 hex chars) to limit cross-request correlation")
 	assert.NotContains(t, got, "somemore", "tail bytes must not appear in logs")
 }
+
+func TestCompactionTracker_DetectsMessageCountDrop(t *testing.T) {
+	ct := newCompactionTracker()
+	key := sessionKeyFromString("session-compaction")
+	install := uuid.New()
+
+	// First observation: no prior — must return false.
+	assert.False(t, ct.checkAndRecord(key, install, "high", 10), "first observation must not report compaction")
+
+	// Count grows: progressing session.
+	assert.False(t, ct.checkAndRecord(key, install, "high", 12), "growing count must not report compaction")
+
+	// Count drops: compaction event.
+	assert.True(t, ct.checkAndRecord(key, install, "high", 5), "drop in message count must be reported as compaction")
+
+	// Count stable after compaction.
+	assert.False(t, ct.checkAndRecord(key, install, "high", 5), "stable count must not report compaction")
+}
+
+func TestCompactionTracker_NilReceiverIsNoOp(t *testing.T) {
+	var ct *compactionTracker
+	key := sessionKeyFromString("session-nil")
+	assert.False(t, ct.checkAndRecord(key, uuid.New(), "high", 5))
+}
+
+func TestCompactionTracker_ZeroAnchorsSkipped(t *testing.T) {
+	ct := newCompactionTracker()
+	var zero [sessionpin.SessionKeyLen]byte
+	// No session key, no installation — must skip rather than bucket globally.
+	ct.checkAndRecord(zero, uuid.Nil, "high", 10)
+	assert.False(t, ct.checkAndRecord(zero, uuid.Nil, "high", 5), "no anchor → compaction detection must be skipped")
+}
+
+func TestCompactionTracker_SeparateSessionsAreIsolated(t *testing.T) {
+	ct := newCompactionTracker()
+	install := uuid.New()
+	keyA := sessionKeyFromString("session-A")
+	keyB := sessionKeyFromString("session-B")
+
+	ct.checkAndRecord(keyA, install, "high", 20)
+	ct.checkAndRecord(keyB, install, "high", 10)
+
+	// Drop on A must not affect B's baseline.
+	assert.True(t, ct.checkAndRecord(keyA, install, "high", 5), "drop on A must be detected")
+	assert.False(t, ct.checkAndRecord(keyB, install, "high", 12), "B growing from 10→12 must not be compaction")
+}

--- a/internal/proxy/no_progress_internal_test.go
+++ b/internal/proxy/no_progress_internal_test.go
@@ -340,35 +340,63 @@ func TestShortSessionKey_TruncatesAndRedactsZero(t *testing.T) {
 }
 
 func TestCompactionTracker_DetectsMessageCountDrop(t *testing.T) {
+	// Full compaction: messageCount drops sharply, tool-call count also drops.
 	ct := newCompactionTracker()
 	key := sessionKeyFromString("session-compaction")
 	install := uuid.New()
 
 	// First observation: no prior — must return false.
-	assert.False(t, ct.checkAndRecord(key, install, "high", 10), "first observation must not report compaction")
+	assert.False(t, ct.checkAndRecord(key, install, "high", 20, 9), "first observation must not report compaction")
 
-	// Count grows: progressing session.
-	assert.False(t, ct.checkAndRecord(key, install, "high", 12), "growing count must not report compaction")
+	// Both counts grow: progressing session.
+	assert.False(t, ct.checkAndRecord(key, install, "high", 22, 10), "growing counts must not report compaction")
 
-	// Count drops: compaction event.
-	assert.True(t, ct.checkAndRecord(key, install, "high", 5), "drop in message count must be reported as compaction")
+	// messageCount drops sharply (full compaction): fire.
+	assert.True(t, ct.checkAndRecord(key, install, "high", 3, 0), "sharp messageCount drop must be reported as compaction")
 
-	// Count stable after compaction.
-	assert.False(t, ct.checkAndRecord(key, install, "high", 5), "stable count must not report compaction")
+	// Counts stable after compaction.
+	assert.False(t, ct.checkAndRecord(key, install, "high", 5, 2), "growing counts after compaction must not report compaction")
+}
+
+func TestCompactionTracker_DetectsRollingWindowTrimming(t *testing.T) {
+	// Rolling-window trimming (the pattern observed in session 543151ce):
+	// messageCount stays flat because old message pairs are swapped for new
+	// ones, but the assistant tool-call count shrinks by one per turn as the
+	// oldest tool call drops out of the visible window.
+	ct := newCompactionTracker()
+	key := sessionKeyFromString("session-rolling")
+	install := uuid.New()
+
+	// Establish baseline: 10 messages, 9 tool calls.
+	ct.checkAndRecord(key, install, "high", 10, 9)
+
+	// messageCount flat (10→10), toolCallCount drops (9→8): fire.
+	assert.True(t, ct.checkAndRecord(key, install, "high", 10, 8),
+		"flat messageCount + shrinking toolCallCount must be detected as rolling-window trim")
+}
+
+func TestCompactionTracker_NoFalsePositiveWhenBothGrow(t *testing.T) {
+	ct := newCompactionTracker()
+	key := sessionKeyFromString("session-growing")
+	install := uuid.New()
+
+	ct.checkAndRecord(key, install, "high", 10, 5)
+	assert.False(t, ct.checkAndRecord(key, install, "high", 12, 6), "both counts growing must not fire")
+	assert.False(t, ct.checkAndRecord(key, install, "high", 14, 6), "flat toolCallCount (no new tool call) must not fire")
 }
 
 func TestCompactionTracker_NilReceiverIsNoOp(t *testing.T) {
 	var ct *compactionTracker
 	key := sessionKeyFromString("session-nil")
-	assert.False(t, ct.checkAndRecord(key, uuid.New(), "high", 5))
+	assert.False(t, ct.checkAndRecord(key, uuid.New(), "high", 5, 3))
 }
 
 func TestCompactionTracker_ZeroAnchorsSkipped(t *testing.T) {
 	ct := newCompactionTracker()
 	var zero [sessionpin.SessionKeyLen]byte
 	// No session key, no installation — must skip rather than bucket globally.
-	ct.checkAndRecord(zero, uuid.Nil, "high", 10)
-	assert.False(t, ct.checkAndRecord(zero, uuid.Nil, "high", 5), "no anchor → compaction detection must be skipped")
+	ct.checkAndRecord(zero, uuid.Nil, "high", 10, 5)
+	assert.False(t, ct.checkAndRecord(zero, uuid.Nil, "high", 5, 3), "no anchor → compaction detection must be skipped")
 }
 
 func TestCompactionTracker_SeparateSessionsAreIsolated(t *testing.T) {
@@ -377,10 +405,10 @@ func TestCompactionTracker_SeparateSessionsAreIsolated(t *testing.T) {
 	keyA := sessionKeyFromString("session-A")
 	keyB := sessionKeyFromString("session-B")
 
-	ct.checkAndRecord(keyA, install, "high", 20)
-	ct.checkAndRecord(keyB, install, "high", 10)
+	ct.checkAndRecord(keyA, install, "high", 20, 9)
+	ct.checkAndRecord(keyB, install, "high", 10, 5)
 
 	// Drop on A must not affect B's baseline.
-	assert.True(t, ct.checkAndRecord(keyA, install, "high", 5), "drop on A must be detected")
-	assert.False(t, ct.checkAndRecord(keyB, install, "high", 12), "B growing from 10→12 must not be compaction")
+	assert.True(t, ct.checkAndRecord(keyA, install, "high", 5, 3), "drop on A must be detected")
+	assert.False(t, ct.checkAndRecord(keyB, install, "high", 12, 6), "B growing from 10→12 must not be compaction")
 }

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -902,18 +902,19 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 		}
 	}
 
-	// Compaction-aware handover: when Claude Code's context compaction fires,
-	// it replaces old turns with a summary block and messageCount drops. On
-	// non-Anthropic upstreams this is dangerous — the model loses awareness of
-	// completed edits and decisions that lived only in the now-elided turns,
-	// causing it to re-apply work it already did. Detect the drop and rewrite
-	// the envelope with a handover summary so the non-Anthropic model gets
-	// explicit "work already done" context before seeing the compacted history.
+	// Compaction-aware handover: Claude Code can trim its history window in two
+	// ways — full compaction (messageCount drops sharply) or rolling-window
+	// trimming (messageCount flat but tool-call count shrinks by one per turn).
+	// Either case leaves the non-Anthropic model without awareness of edits and
+	// decisions that lived only in the now-elided turns. Detect either drop and
+	// rewrite the envelope with a handover summary before dispatch.
 	if decision.Provider != providers.ProviderAnthropic && s.compaction != nil {
 		role := roleForTier(catalog.TierFor(feats.Model))
-		if s.compaction.checkAndRecord(routeRes.SessionKey, installationID, role, feats.MessageCount) {
-			log.Info("Compaction detected on non-Anthropic route; rewriting context with handover summary",
+		toolCallCount := len(env.AssistantToolCallSignatures())
+		if s.compaction.checkAndRecord(routeRes.SessionKey, installationID, role, feats.MessageCount, toolCallCount) {
+			log.Info("Context trimming detected on non-Anthropic route; rewriting context with handover summary",
 				"message_count", feats.MessageCount,
+				"tool_call_count", toolCallCount,
 				"decision_model", decision.Model,
 				"decision_provider", decision.Provider,
 			)

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -861,6 +861,13 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 		)
 	}
 
+	// Snapshot inbound tool-call count before runTurnLoop potentially mutates
+	// env (model-switch handover calls TrimLastN / RewriteForHandover). The
+	// compaction tracker must compare the count the client actually sent, not
+	// the post-router-trim count, to avoid false-positive detection when the
+	// router itself is the one that shortened the message window.
+	inboundToolCallCount := len(env.AssistantToolCallSignatures())
+
 	routeStart := time.Now()
 	routeRes, routeErr := s.runTurnLoop(ctx, env, feats, apiKeyID, installationID, "", r.Header, router.Request{
 		RequestedModel:       feats.Model,
@@ -911,11 +918,10 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 	compactionHandoverRan := false
 	if decision.Provider != providers.ProviderAnthropic && s.compaction != nil {
 		role := roleForTier(catalog.TierFor(feats.Model))
-		toolCallCount := len(env.AssistantToolCallSignatures())
-		if s.compaction.checkAndRecord(routeRes.SessionKey, installationID, role, feats.MessageCount, toolCallCount) {
+		if s.compaction.checkAndRecord(routeRes.SessionKey, installationID, role, feats.MessageCount, inboundToolCallCount) {
 			log.Info("Context trimming detected on non-Anthropic route; rewriting context with handover summary",
 				"message_count", feats.MessageCount,
-				"tool_call_count", toolCallCount,
+				"tool_call_count", inboundToolCallCount,
 				"decision_model", decision.Model,
 				"decision_provider", decision.Provider,
 			)

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -22,7 +22,6 @@ import (
 	"workweave/router/internal/router/handover"
 	"workweave/router/internal/router/planner"
 	"workweave/router/internal/router/sessionpin"
-	"workweave/router/internal/router/turntype"
 	"workweave/router/internal/translate"
 
 	"github.com/google/uuid"
@@ -918,13 +917,14 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 	// rewrite the envelope with a handover summary before dispatch.
 	compactionHandoverRan := false
 	var compactionHandoverOutcome handoverOutcome
-	// Skip detection on genuine Claude Code compaction turns (turntype.Compaction):
-	// those requests are Claude Code asking the router to summarize, not a
-	// main-loop turn where the model needs completed-work context. Applying the
-	// handover rewrite there would corrupt the summarization request, and recording
-	// the trimmed baseline from the compaction body would poison the tracker so
-	// the immediately-following main-loop turn never sees a count drop.
-	if decision.Provider != providers.ProviderAnthropic && s.compaction != nil && tt != turntype.Compaction {
+	// Skip detection for all hard-pinned turn types (Compaction, Probe, TitleGen,
+	// Classifier, SubAgentDispatch with hardPinExplore). These turns carry far
+	// fewer messages than main-loop turns — a Probe or TitleGen after a long
+	// session would show a sharp count drop that mimics client history trimming
+	// and falsely trigger runCompactionHandover. Hard-pinned turns also do not
+	// model the conversational context the compaction handover is meant to
+	// preserve, so rewrites there would be both wrong and wasteful.
+	if decision.Provider != providers.ProviderAnthropic && s.compaction != nil && !routeRes.HardPinned {
 		role := roleForTier(catalog.TierFor(feats.Model))
 		if s.compaction.checkAndRecord(routeRes.SessionKey, installationID, role, feats.MessageCount, inboundToolCallCount) {
 			log.Info("Context trimming detected on non-Anthropic route; rewriting context with handover summary",

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -908,6 +908,7 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 	// Either case leaves the non-Anthropic model without awareness of edits and
 	// decisions that lived only in the now-elided turns. Detect either drop and
 	// rewrite the envelope with a handover summary before dispatch.
+	compactionHandoverRan := false
 	if decision.Provider != providers.ProviderAnthropic && s.compaction != nil {
 		role := roleForTier(catalog.TierFor(feats.Model))
 		toolCallCount := len(env.AssistantToolCallSignatures())
@@ -919,12 +920,16 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 				"decision_provider", decision.Provider,
 			)
 			s.runCompactionHandover(ctx, env, r.Header, decision.Model)
+			compactionHandoverRan = true
 		}
 	}
 
 	// Semantic-cache eligibility: configured, non-streaming, decision has
 	// metadata, externalID present, not eval traffic.
-	cacheEligible := s.semanticCache != nil && !env.Stream() && decision.Metadata != nil && externalID != "" && !bypassEval
+	// Skip when a compaction handover rewrote env: the embedding in
+	// decision.Metadata was computed from the pre-handover body, so a cache
+	// hit would return a response built for different upstream context.
+	cacheEligible := s.semanticCache != nil && !env.Stream() && decision.Metadata != nil && externalID != "" && !bypassEval && !compactionHandoverRan
 	if cacheEligible {
 		if resp, hit := s.semanticCache.Lookup(externalID, cache.FormatAnthropic, decision.Metadata.Embedding, decision.Metadata.ClusterIDs, decision.Metadata.ClusterRouterVersion, decision.Metadata.EffectiveKnobsHash); hit {
 			s.writeCachedResponse(w, resp, decision)

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -924,7 +924,11 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 	// and falsely trigger runCompactionHandover. Hard-pinned turns also do not
 	// model the conversational context the compaction handover is meant to
 	// preserve, so rewrites there would be both wrong and wasteful.
-	if decision.Provider != providers.ProviderAnthropic && s.compaction != nil && !routeRes.HardPinned {
+	//
+	// Also skip when the planner already ran a model-switch handover for this
+	// turn (routeRes.Handover.Invoked). Applying runCompactionHandover on top of
+	// an already-rewritten envelope would double-trim it.
+	if decision.Provider != providers.ProviderAnthropic && s.compaction != nil && !routeRes.HardPinned && !routeRes.Handover.Invoked {
 		role := roleForTier(catalog.TierFor(feats.Model))
 		if s.compaction.checkAndRecord(routeRes.SessionKey, installationID, role, feats.MessageCount, inboundToolCallCount) {
 			log.Info("Context trimming detected on non-Anthropic route; rewriting context with handover summary",

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -22,6 +22,7 @@ import (
 	"workweave/router/internal/router/handover"
 	"workweave/router/internal/router/planner"
 	"workweave/router/internal/router/sessionpin"
+	"workweave/router/internal/router/turntype"
 	"workweave/router/internal/translate"
 
 	"github.com/google/uuid"
@@ -916,7 +917,14 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 	// decisions that lived only in the now-elided turns. Detect either drop and
 	// rewrite the envelope with a handover summary before dispatch.
 	compactionHandoverRan := false
-	if decision.Provider != providers.ProviderAnthropic && s.compaction != nil {
+	var compactionHandoverOutcome handoverOutcome
+	// Skip detection on genuine Claude Code compaction turns (turntype.Compaction):
+	// those requests are Claude Code asking the router to summarize, not a
+	// main-loop turn where the model needs completed-work context. Applying the
+	// handover rewrite there would corrupt the summarization request, and recording
+	// the trimmed baseline from the compaction body would poison the tracker so
+	// the immediately-following main-loop turn never sees a count drop.
+	if decision.Provider != providers.ProviderAnthropic && s.compaction != nil && tt != turntype.Compaction {
 		role := roleForTier(catalog.TierFor(feats.Model))
 		if s.compaction.checkAndRecord(routeRes.SessionKey, installationID, role, feats.MessageCount, inboundToolCallCount) {
 			log.Info("Context trimming detected on non-Anthropic route; rewriting context with handover summary",
@@ -925,7 +933,7 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 				"decision_model", decision.Model,
 				"decision_provider", decision.Provider,
 			)
-			s.runCompactionHandover(ctx, env, r.Header, decision.Model)
+			compactionHandoverOutcome = s.runCompactionHandover(ctx, env, r.Header, decision.Model)
 			compactionHandoverRan = true
 		}
 	}
@@ -1289,6 +1297,24 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 	// point on a real upstream call.
 	if proxyErr == nil {
 		s.emitBilling(ctx, requestID, externalID, decision, actPricing, routeRes, in, out, cacheCreation, cacheRead)
+		if compactionHandoverOutcome.Invoked && !compactionHandoverOutcome.FallbackToTrim {
+			sumUsage := compactionHandoverOutcome.SummaryUsage
+			if sumUsage.Model != "" && (sumUsage.InputTokens > 0 || sumUsage.OutputTokens > 0) {
+				sumPricing, _ := catalog.PrimaryPriceFor(sumUsage.Model)
+				s.fireBilling(ctx, billing.DebitInferenceParams{
+					OrganizationID:  externalID,
+					RouterRequestID: requestID + "_compaction_summary",
+					Model:           sumUsage.Model,
+					Provider:        sumUsage.Provider,
+					InputTokens:     sumUsage.InputTokens,
+					OutputTokens:    sumUsage.OutputTokens,
+					CacheCreation:   sumUsage.CacheCreation,
+					CacheRead:       sumUsage.CacheRead,
+					Pricing:         sumPricing,
+					HasOverride:     billing.HasOverrideFromContext(ctx),
+				})
+			}
+		}
 	}
 
 	// Two-strike pin eviction: a session pinned to a model that keeps

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -45,6 +45,10 @@ type Service struct {
 	// cross-envelope subagent loop (parent agent re-spawning identical
 	// sub-conversations). Nil disables the detector.
 	noProgress *noProgressTracker
+	// compaction detects Claude Code context compaction events (message count
+	// drops) so the router can rewrite non-Anthropic requests with a handover
+	// summary before the model loses awareness of prior completed work.
+	compaction *compactionTracker
 	// pinWriteSem bounds concurrent async pin-upsert goroutines with drop-on-full semantics.
 	pinWriteSem chan struct{}
 	// usageWriteSem bounds concurrent async last-turn-usage writeback goroutines,
@@ -330,6 +334,7 @@ func NewService(r router.Router, providerMap map[string]providers.Client, emitte
 		pinStore:             pinStore,
 		pinCache:             pinCache,
 		noProgress:           newNoProgressTracker(),
+		compaction:           newCompactionTracker(),
 		pinWriteSem:          pinWriteSem,
 		usageWriteSem:        usageWriteSem,
 		hardPinExplore:       hardPinExplore,
@@ -894,6 +899,25 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 		role := roleForTier(catalog.TierFor(feats.Model))
 		if looped, count := s.noProgress.recordAndDetect(routeRes.SessionKey, installationID, role, fp, time.Now()); looped {
 			return s.handleNoProgressBreak(ctx, w, env, count, installationID, routeRes.SessionKey, role, decision.Model, decision.Provider)
+		}
+	}
+
+	// Compaction-aware handover: when Claude Code's context compaction fires,
+	// it replaces old turns with a summary block and messageCount drops. On
+	// non-Anthropic upstreams this is dangerous — the model loses awareness of
+	// completed edits and decisions that lived only in the now-elided turns,
+	// causing it to re-apply work it already did. Detect the drop and rewrite
+	// the envelope with a handover summary so the non-Anthropic model gets
+	// explicit "work already done" context before seeing the compacted history.
+	if decision.Provider != providers.ProviderAnthropic && s.compaction != nil {
+		role := roleForTier(catalog.TierFor(feats.Model))
+		if s.compaction.checkAndRecord(routeRes.SessionKey, installationID, role, feats.MessageCount) {
+			log.Info("Compaction detected on non-Anthropic route; rewriting context with handover summary",
+				"message_count", feats.MessageCount,
+				"decision_model", decision.Model,
+				"decision_provider", decision.Provider,
+			)
+			s.runCompactionHandover(ctx, env, r.Header, decision.Model)
 		}
 	}
 


### PR DESCRIPTION
## Context

Investigated session `543151ce-729c-46c1-b43c-53babdb49234` which appeared to reset mid-session and produced a duplicate Edit. Root cause was two separate bugs:

1. Claude Code context compaction kept `messageCount` flat → no-progress detector false-fired after 5 turns, emitting a synthetic stop + clearing the session pin (the apparent "reset")
2. Compaction dropped the prior Edit + tool_result from history → DeepSeek had no record the edit happened and re-applied it

## Changes

### Bug fix: no-progress fingerprint now includes tool call signatures

`computeNoProgressFingerprint` gains a `toolCallSigs []translate.ToolCallSig` parameter. The SHA-256 of the tail-5 assistant tool call signatures is folded into the fingerprint alongside `messageCount`.

- **Compaction scenario** (false positive we're fixing): `messageCount` flat, but model making new tool calls each turn → tail hash changes → fingerprints diverge → detector doesn't fire ✓
- **Genuine spawn loop** (true positive we must keep): same Bash call repeated, flat `messageCount` → identical tail hashes → fingerprints collide → detector fires ✓
- **Fresh sub-envelope** (the original use case): no tool calls in envelope → empty tail → same behavior as before ✓

### New feature: compaction-aware handover for non-Anthropic routes

New `compactionTracker` (same LRU/session-bucket pattern as `noProgressTracker`) records `messageCount` per turn and returns `true` when it drops — the signature of a Claude Code context compaction event.

When a drop is detected and the routing target is non-Anthropic, `runCompactionHandover` rewrites the envelope with a full handover summary (via the existing `ProviderSummarizer` infrastructure) before dispatch. This gives the non-Anthropic model explicit "work already done" context that would otherwise have been silently lost in the compacted turns.

Falls back to `TrimLastN(3)` on:
- Summarizer not wired
- BYOK tenant boundary (no matching creds for summarizer provider)
- Summarizer error or empty response

This mirrors the existing model-switch handover contract in `runTurnLoop` exactly.

## Test plan

- [x] All existing no-progress tests pass with `nil` sigs (backwards-compatible fingerprint behavior)
- [x] `TestComputeNoProgressFingerprint_DistinguishesToolCallSigs` — flat messageCount + different sigs → different fingerprints
- [x] `TestComputeNoProgressFingerprint_SameToolCallSigsCollide` — same repeated Bash call → still collides
- [x] `TestComputeNoProgressFingerprint_NilAndEmptySigsAreEquivalent` — nil vs empty slice behave identically
- [x] Full proxy test suite green (`go test workweave/router/internal/proxy`)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)