### PR TITLE
fix(proxy): clarify EV-positive routing marker wording

### DIFF
--- a/internal/proxy/marker_internal_test.go
+++ b/internal/proxy/marker_internal_test.go
@@ -68,7 +68,7 @@ func TestRoutingMarkerFor_PlannerPaths(t *testing.T) {
 				PlannerDecision: planner.Decision{Reason: planner.ReasonEVPositive},
 			},
 			wantContains: []string{
-				"✦ **Weave Router** → deepseek/deepseek-v4-pro · switched for cheaper cache reuse",
+				"✦ **Weave Router** → deepseek/deepseek-v4-pro · switched for positive EV after cache eviction",
 			},
 			wantNotContain: []string{
 				"(openrouter)",

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -210,7 +210,7 @@ func routingReasonShort(res turnLoopResult) string {
 func humanReasonFromPlanner(code string) string {
 	switch code {
 	case planner.ReasonEVPositive:
-		return "switched for cheaper cache reuse"
+		return "switched for positive EV after cache eviction"
 	case planner.ReasonEVNegative, planner.ReasonNoPriorUsage:
 		return "stayed on your last pick"
 	case planner.ReasonTierUpgrade:


### PR DESCRIPTION
## What

Rewords the user-facing routing marker for an EV-positive model switch in `humanReasonFromPlanner`:

- **Before:** `switched for cheaper cache reuse`
- **After:** `switched for positive EV after cache eviction`

## Why

The old string is misleading. A switch **evicts** the pinned model's warm prompt cache — it doesn't reuse it. The planner (`internal/router/planner/policy.go`) sets `ReasonEVPositive` when `expectedSavings - evictionCost > ThresholdUSD`, i.e. the new model is cheap enough to come out ahead *even after* paying the one-time eviction cost. It also re-evaluates every turn and can flip back, so framing it as a durable cache-reuse win overstates what happened.

The new wording states exactly what the planner decided and keeps the same lowercase prose shape as the sibling markers (`stayed on your last pick`, `upgraded to a stronger tier`, `best pick for this turn`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)