### PR TITLE
refactor(proxy): make routing-marker prose single-source constants

### DIFF
--- a/internal/proxy/marker_internal_test.go
+++ b/internal/proxy/marker_internal_test.go
@@ -68,7 +68,7 @@ func TestRoutingMarkerFor_PlannerPaths(t *testing.T) {
 				PlannerDecision: planner.Decision{Reason: planner.ReasonEVPositive},
 			},
 			wantContains: []string{
-				"✦ **Weave Router** → deepseek/deepseek-v4-pro · switched for positive EV after cache eviction",
+				"✦ **Weave Router** → deepseek/deepseek-v4-pro · " + markerReasonSwitched,
 			},
 			wantNotContain: []string{
 				"(openrouter)",
@@ -83,7 +83,7 @@ func TestRoutingMarkerFor_PlannerPaths(t *testing.T) {
 				PlannerDecision: planner.Decision{Reason: planner.ReasonEVNegative},
 			},
 			wantContains: []string{
-				"· stayed on your last pick",
+				"· " + markerReasonStayed,
 			},
 			wantNotContain: []string{
 				"(openrouter)",
@@ -98,7 +98,7 @@ func TestRoutingMarkerFor_PlannerPaths(t *testing.T) {
 				PlannerDecision: planner.Decision{Reason: planner.ReasonNoPriorUsage},
 			},
 			wantContains: []string{
-				"· stayed on your last pick",
+				"· " + markerReasonStayed,
 			},
 			wantNotContain: []string{
 				"no cache stats",
@@ -111,7 +111,7 @@ func TestRoutingMarkerFor_PlannerPaths(t *testing.T) {
 				PlannerDecision: planner.Decision{Reason: planner.ReasonSameModel},
 			},
 			wantContains: []string{
-				"· best pick for this turn",
+				"· " + markerReasonBestPick,
 			},
 			wantNotContain: []string{
 				"scorer matches the pin",
@@ -125,7 +125,7 @@ func TestRoutingMarkerFor_PlannerPaths(t *testing.T) {
 				PlannerDecision: planner.Decision{Reason: planner.ReasonTierUpgrade},
 			},
 			wantContains: []string{
-				"· upgraded to a stronger tier",
+				"· " + markerReasonTierUpgrade,
 			},
 		},
 		{
@@ -160,7 +160,7 @@ func TestRoutingMarkerFor_PlannerPaths(t *testing.T) {
 				Decision: decision,
 			},
 			wantContains: []string{
-				"· best pick for this turn",
+				"· " + markerReasonBestPick,
 			},
 			wantNotContain: []string{
 				"top scorer",
@@ -174,7 +174,7 @@ func TestRoutingMarkerFor_PlannerPaths(t *testing.T) {
 				HardPinned: true,
 			},
 			wantContains: []string{
-				"· pinned for compaction / sub-agent",
+				"· " + markerReasonHardPinned,
 			},
 			wantNotContain: []string{
 				"hard pin",
@@ -237,7 +237,7 @@ func TestRoutingMarkerFor_DropsProviderEvenWhenSet(t *testing.T) {
 	assert.Contains(t, got, "✦ **Weave Router** → claude-haiku-4-5 ·")
 	assert.NotContains(t, got, "(anthropic)", "provider must not leak into the user-facing marker")
 	assert.NotContains(t, got, "()")
-	assert.Contains(t, got, "· best pick for this turn")
+	assert.Contains(t, got, "· "+markerReasonBestPick)
 }
 
 func TestHumanReasonFromPlanner_UnknownCodeIsSilenced(t *testing.T) {

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -192,16 +192,27 @@ func clampNote(res turnLoopResult) string {
 	return fmt.Sprintf("second-choice pick at %s tier (would have used %s)", res.RequestedTier.String(), res.PreClampModel)
 }
 
+// User-facing routing-marker prose. These are the single source of truth for
+// the marker wording; tests assert the mapping against these constants rather
+// than re-spelling the literals.
+const (
+	markerReasonHardPinned  = "pinned for compaction / sub-agent"
+	markerReasonSwitched    = "switched for positive EV after cache eviction"
+	markerReasonStayed      = "stayed on your last pick"
+	markerReasonTierUpgrade = "upgraded to a stronger tier"
+	markerReasonBestPick    = "best pick for this turn"
+)
+
 // routingReasonShort returns a short user-facing reason for the routing
 // decision, or empty when the underlying code is internal recovery noise.
 func routingReasonShort(res turnLoopResult) string {
 	if res.HardPinned {
-		return "pinned for compaction / sub-agent"
+		return markerReasonHardPinned
 	}
 	if res.PlannerDecision.Reason != "" {
 		return humanReasonFromPlanner(res.PlannerDecision.Reason)
 	}
-	return "best pick for this turn"
+	return markerReasonBestPick
 }
 
 // humanReasonFromPlanner maps planner reason codes to short user-facing prose.
@@ -210,13 +221,13 @@ func routingReasonShort(res turnLoopResult) string {
 func humanReasonFromPlanner(code string) string {
 	switch code {
 	case planner.ReasonEVPositive:
-		return "switched for positive EV after cache eviction"
+		return markerReasonSwitched
 	case planner.ReasonEVNegative, planner.ReasonNoPriorUsage:
-		return "stayed on your last pick"
+		return markerReasonStayed
 	case planner.ReasonTierUpgrade:
-		return "upgraded to a stronger tier"
+		return markerReasonTierUpgrade
 	case planner.ReasonNoPin, planner.ReasonSameModel:
-		return "best pick for this turn"
+		return markerReasonBestPick
 	default:
 		return ""
 	}


### PR DESCRIPTION
## What

Extracts the five user-facing routing-marker strings in `internal/proxy/service.go` into package-level constants (`markerReasonHardPinned`, `markerReasonSwitched`, `markerReasonStayed`, `markerReasonTierUpgrade`, `markerReasonBestPick`). Both `humanReasonFromPlanner` / `routingReasonShort` and `marker_internal_test.go` now reference the same constants instead of re-spelling the literals.

Follow-up to #302, which reworded one of these markers and required editing the literal in two places (prod + test) in lock-step — the smell this removes.

## Why

- **Single source of truth.** Rewording a marker is now a one-line change; the test follows automatically instead of failing on a stale hardcoded copy.
- **Removes pre-existing duplication.** `"best pick for this turn"` was already hardcoded twice within `service.go` alone (`routingReasonShort` fallback + the planner switch).
- **Test stays non-tautological.** It still asserts the reason-code → bucket mapping (e.g. `ReasonNoPriorUsage` collapsing into the "stayed" bucket), the `· ` separator, and the blank-line terminator. It just no longer re-spells the prose. The only thing it stops guarding is a wording typo — which is moot once the constant *is* the source of truth.

No behavior change; pure refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)