### PR TITLE
refactor(proxy): single-source x-router-* response header names

### DIFF
--- a/internal/proxy/failover_integration_test.go
+++ b/internal/proxy/failover_integration_test.go
@@ -103,8 +103,8 @@ func TestProxyMessages_FireworksFailureFallbackToOpenRouter(t *testing.T) {
 	assert.Contains(t, respBody, "event: message_stop", "Anthropic stream should end with message_stop")
 
 	// Fallback headers surface the primary that failed.
-	assert.Equal(t, "fireworks", rec.Header().Get("x-router-fallback-from"))
-	assert.Equal(t, "1", rec.Header().Get("x-router-fallback-attempt"))
+	assert.Equal(t, "fireworks", rec.Header().Get(proxy.HeaderRouterFallbackFrom))
+	assert.Equal(t, "1", rec.Header().Get(proxy.HeaderRouterFallbackAttempt))
 
 	// Per-attempt prep verification: OpenRouter received a body that
 	// includes the OpenRouter-only gates from emit_openai.go. Without the
@@ -229,7 +229,7 @@ func TestProxyMessages_SingleBindingPreservesEagerPrelude(t *testing.T) {
 	assert.Contains(t, respBody, "message_start")
 	assert.Contains(t, respBody, "message_stop")
 	// No fallback header for single-binding requests.
-	assert.Empty(t, rec.Header().Get("x-router-fallback-from"))
+	assert.Empty(t, rec.Header().Get(proxy.HeaderRouterFallbackFrom))
 }
 
 // TestProxyMessages_SingleBindingStreamingPreCommitError asserts the fixed

--- a/internal/proxy/fallback.go
+++ b/internal/proxy/fallback.go
@@ -240,10 +240,10 @@ func (s *Service) dispatchWithFallback(ctx context.Context, in failoverInputs) (
 		// Safe to rewrite until the buffer commits; on retry the previous
 		// value is overwritten via Discard's header restore + this Set.
 		if !committed(in.buf) {
-			in.w.Header().Set("x-router-provider", b.Provider)
+			in.w.Header().Set(HeaderRouterProvider, b.Provider)
 			if i > 0 {
-				in.w.Header().Set("x-router-fallback-from", in.bindings[0].Provider)
-				in.w.Header().Set("x-router-fallback-attempt", attemptIdxLabel(i))
+				in.w.Header().Set(HeaderRouterFallbackFrom, in.bindings[0].Provider)
+				in.w.Header().Set(HeaderRouterFallbackAttempt, attemptIdxLabel(i))
 			}
 		}
 

--- a/internal/proxy/fallback_test.go
+++ b/internal/proxy/fallback_test.go
@@ -137,7 +137,7 @@ func TestDispatchWithFallback_RetriesOnRetryableBufferedError(t *testing.T) {
 	assert.Equal(t, 1, primary.calls)
 	assert.Equal(t, 1, fallback.calls)
 	assert.Equal(t, "rescued", rec.Body.String(), "client sees only the fallback's successful bytes")
-	assert.Equal(t, "fireworks", rec.Header().Get("x-router-fallback-from"))
+	assert.Equal(t, "fireworks", rec.Header().Get(HeaderRouterFallbackFrom))
 }
 
 func TestDispatchWithFallback_RetriesOnTransportError(t *testing.T) {
@@ -465,7 +465,7 @@ func TestPreludeBuffer_DiscardResetsBufferAndHeaders(t *testing.T) {
 	// Attempt 1: Prelude writes + status + body.
 	buf.Header().Set("Content-Type", "text/event-stream")
 	buf.Header().Del("Content-Length")
-	buf.Header().Set("x-router-fallback-from", "fireworks")
+	buf.Header().Set(HeaderRouterFallbackFrom, "fireworks")
 	buf.WriteHeader(http.StatusOK)
 	_, _ = buf.Write([]byte("attempt-1-prelude"))
 
@@ -477,7 +477,7 @@ func TestPreludeBuffer_DiscardResetsBufferAndHeaders(t *testing.T) {
 		"Content-Type restored to construction-time snapshot")
 	assert.Equal(t, "0", rec.Header().Get("Content-Length"),
 		"Content-Length deleted by Prelude restored")
-	assert.Empty(t, rec.Header().Get("x-router-fallback-from"),
+	assert.Empty(t, rec.Header().Get(HeaderRouterFallbackFrom),
 		"Prelude-added headers removed")
 
 	// Attempt 2: Prelude + success.

--- a/internal/proxy/gemini.go
+++ b/internal/proxy/gemini.go
@@ -98,9 +98,9 @@ func (s *Service) ProxyGeminiGenerateContent(ctx context.Context, body []byte, w
 		return provErr
 	}
 
-	w.Header().Set("x-router-decision", decision.Reason)
-	w.Header().Set("x-router-provider", decision.Provider)
-	w.Header().Set("x-router-model", decision.Model)
+	w.Header().Set(HeaderRouterDecision, decision.Reason)
+	w.Header().Set(HeaderRouterProvider, decision.Provider)
+	w.Header().Set(HeaderRouterModel, decision.Model)
 
 	reqPricing := otel.Lookup(s.baselineFor(feats.Model))
 	actPricing := otel.Lookup(decision.Model)

--- a/internal/proxy/gemini_test.go
+++ b/internal/proxy/gemini_test.go
@@ -44,8 +44,8 @@ func TestProxyGeminiGenerateContent_RoutesToGoogleProvider(t *testing.T) {
 	httpReq := httptest.NewRequest(http.MethodPost, "/v1beta/models/gemini-1.5-pro:generateContent", strings.NewReader(""))
 	require.NoError(t, svc.ProxyGeminiGenerateContent(ctx, []byte(geminiInjectedBody), rec, httpReq))
 
-	assert.Equal(t, "gemini-2.5-pro", rec.Header().Get("x-router-model"))
-	assert.Equal(t, providers.ProviderGoogle, rec.Header().Get("x-router-provider"))
+	assert.Equal(t, "gemini-2.5-pro", rec.Header().Get(proxy.HeaderRouterModel))
+	assert.Equal(t, providers.ProviderGoogle, rec.Header().Get(proxy.HeaderRouterProvider))
 	require.Len(t, googleProv.proxyBodies, 1, "the upstream Google client must be invoked once")
 	body := string(googleProv.proxyBodies[0])
 	assert.NotContains(t, body, `"model"`,

--- a/internal/proxy/headers.go
+++ b/internal/proxy/headers.go
@@ -1,0 +1,27 @@
+package proxy
+
+// Response-header names the router sets on proxied responses to surface its
+// routing decision to clients. These are the single source of truth for the
+// header contract; prod write sites and tests reference these constants rather
+// than re-spelling the literals.
+const (
+	// HeaderRouterDecision carries the routing decision reason.
+	HeaderRouterDecision = "x-router-decision"
+	// HeaderRouterProvider carries the upstream provider that served the turn.
+	HeaderRouterProvider = "x-router-provider"
+	// HeaderRouterModel carries the model that served the turn.
+	HeaderRouterModel = "x-router-model"
+	// HeaderRouterCache reports semantic-cache status; value is RouterCacheHit
+	// on a cache hit and the header is omitted otherwise.
+	HeaderRouterCache = "x-router-cache"
+	// HeaderRouterFallbackFrom names the primary provider that was abandoned
+	// when runtime provider failover served the turn from a fallback binding.
+	HeaderRouterFallbackFrom = "x-router-fallback-from"
+	// HeaderRouterFallbackAttempt carries the zero-based fallback attempt index
+	// that ultimately served the turn.
+	HeaderRouterFallbackAttempt = "x-router-fallback-attempt"
+)
+
+// RouterCacheHit is the HeaderRouterCache value set when a response is served
+// from the semantic cache.
+const RouterCacheHit = "hit"

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -605,10 +605,10 @@ func (s *Service) writeCachedResponse(w http.ResponseWriter, resp cache.CachedRe
 			w.Header().Add(k, v)
 		}
 	}
-	w.Header().Set("x-router-decision", decision.Reason)
-	w.Header().Set("x-router-provider", decision.Provider)
-	w.Header().Set("x-router-model", decision.Model)
-	w.Header().Set("x-router-cache", "hit")
+	w.Header().Set(HeaderRouterDecision, decision.Reason)
+	w.Header().Set(HeaderRouterProvider, decision.Provider)
+	w.Header().Set(HeaderRouterModel, decision.Model)
+	w.Header().Set(HeaderRouterCache, RouterCacheHit)
 	if resp.StatusCode != 0 && resp.StatusCode != http.StatusOK {
 		w.WriteHeader(resp.StatusCode)
 	}
@@ -971,9 +971,9 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 		}
 	}
 
-	w.Header().Set("x-router-decision", decision.Reason)
-	w.Header().Set("x-router-provider", decision.Provider)
-	w.Header().Set("x-router-model", decision.Model)
+	w.Header().Set(HeaderRouterDecision, decision.Reason)
+	w.Header().Set(HeaderRouterProvider, decision.Provider)
+	w.Header().Set(HeaderRouterModel, decision.Model)
 
 	if _, err := s.provider(decision.Provider); err != nil {
 		return err
@@ -1960,9 +1960,9 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 		return err
 	}
 
-	w.Header().Set("x-router-decision", decision.Reason)
-	w.Header().Set("x-router-provider", decision.Provider)
-	w.Header().Set("x-router-model", decision.Model)
+	w.Header().Set(HeaderRouterDecision, decision.Reason)
+	w.Header().Set(HeaderRouterProvider, decision.Provider)
+	w.Header().Set(HeaderRouterModel, decision.Model)
 
 	reqPricing := otel.Lookup(s.baselineFor(feats.Model))
 	actPricing := otel.Lookup(decision.Model)

--- a/internal/proxy/service_cache_test.go
+++ b/internal/proxy/service_cache_test.go
@@ -102,7 +102,7 @@ func TestService_Cache_HitShortCircuitsProvider(t *testing.T) {
 	assert.Len(t, provider.proxyBodies, 1, "cache hit must not invoke provider a second time")
 
 	assert.Equal(t, `{"id":"first","content":"hi"}`, rec2.Body.String())
-	assert.Equal(t, "hit", rec2.Header().Get("x-router-cache"))
+	assert.Equal(t, proxy.RouterCacheHit, rec2.Header().Get(proxy.HeaderRouterCache))
 }
 
 func TestService_Cache_StreamingBypasses(t *testing.T) {
@@ -126,7 +126,7 @@ func TestService_Cache_StreamingBypasses(t *testing.T) {
 	require.NoError(t, svc.ProxyMessages(ctx, body, rec2, httpReq2))
 
 	assert.Len(t, provider.proxyBodies, 2, "streaming requests must always hit the provider — no caching")
-	assert.Empty(t, rec2.Header().Get("x-router-cache"), "streaming responses carry no x-router-cache marker")
+	assert.Empty(t, rec2.Header().Get(proxy.HeaderRouterCache), "streaming responses carry no x-router-cache marker")
 }
 
 func TestService_Cache_HeuristicDecisionBypasses(t *testing.T) {
@@ -197,5 +197,5 @@ func TestService_Cache_DisabledByNilCache(t *testing.T) {
 	require.NoError(t, svc.ProxyMessages(ctx, body, rec2, httpReq2))
 
 	assert.Len(t, provider.proxyBodies, 2, "nil cache must be a transparent passthrough")
-	assert.Empty(t, rec2.Header().Get("x-router-cache"))
+	assert.Empty(t, rec2.Header().Get(proxy.HeaderRouterCache))
 }

--- a/internal/proxy/service_session_pin_test.go
+++ b/internal/proxy/service_session_pin_test.go
@@ -179,7 +179,7 @@ func TestService_SessionPin_PostgresHitKeepsPinnedModel(t *testing.T) {
 	// planner then keeps the pinned model because we have no prior-turn
 	// usage to justify paying eviction cost.
 	assert.Equal(t, 1, fr.routeCalls, "scorer runs every MainLoop turn under the planner")
-	assert.Equal(t, "claude-haiku-4-5", rec.Header().Get("x-router-model"))
+	assert.Equal(t, "claude-haiku-4-5", rec.Header().Get(proxy.HeaderRouterModel))
 	waitForUpsert(t, store)
 }
 
@@ -241,7 +241,7 @@ func TestService_SessionPin_ExpiredPinIsIgnored(t *testing.T) {
 	require.NoError(t, svc.ProxyMessages(ctx, []byte(pinTestBody), rec, httpReq))
 
 	assert.Equal(t, 1, fr.routeCalls, "expired pin must not be served (sweep races leave stale rows)")
-	assert.Equal(t, "claude-opus-4-7", rec.Header().Get("x-router-model"))
+	assert.Equal(t, "claude-opus-4-7", rec.Header().Get(proxy.HeaderRouterModel))
 }
 
 // Eval-override headers must NOT bypass session-key pinning; the
@@ -264,7 +264,7 @@ func TestService_SessionPin_EvalOverrideHeaderKeepsSessionKeyPinning(t *testing.
 	// wins under ReasonNoPriorUsage.
 	assert.Equal(t, 1, fr.routeCalls, "scorer runs every MainLoop turn under the planner")
 	assert.Equal(t, 1, store.getCalls)
-	assert.Equal(t, "claude-haiku-4-5", rec.Header().Get("x-router-model"))
+	assert.Equal(t, "claude-haiku-4-5", rec.Header().Get(proxy.HeaderRouterModel))
 }
 
 // compactionBody triggers the compaction detector (§3.4).
@@ -319,7 +319,7 @@ func TestService_HardPin_Compaction_ByokOnly_UsesRequestResolver(t *testing.T) {
 	require.NoError(t, svc.ProxyMessages(ctx, []byte(compactionBody), rec, httpReq))
 
 	assert.Equal(t, 0, fr.routeCalls, "compaction must bypass the cluster scorer")
-	assert.Equal(t, "claude-haiku-anthropic-byok", rec.Header().Get("x-router-model"),
+	assert.Equal(t, "claude-haiku-anthropic-byok", rec.Header().Get(proxy.HeaderRouterModel),
 		"per-request resolver must land hard-pin on the installation's BYOK provider, not the boot-time default")
 }
 
@@ -364,7 +364,7 @@ func TestService_HardPin_CompactionAlwaysRoutesToHaiku(t *testing.T) {
 	require.NoError(t, svc.ProxyMessages(ctx, []byte(compactionBody), rec, httpReq))
 
 	assert.Equal(t, 0, fr.routeCalls, "compaction must bypass the cluster scorer")
-	assert.Equal(t, "claude-haiku-4-5", rec.Header().Get("x-router-model"))
+	assert.Equal(t, "claude-haiku-4-5", rec.Header().Get(proxy.HeaderRouterModel))
 	assert.Equal(t, 0, store.getCalls, "compaction must not consult the pin store")
 
 	select {
@@ -396,7 +396,7 @@ func TestService_HardPin_ExploreRoutesToHaikuWhenFlagOn(t *testing.T) {
 	require.NoError(t, svc.ProxyMessages(ctx, []byte(exploreBody), rec, httpReq))
 
 	assert.Equal(t, 0, fr.routeCalls, "Explore must bypass cluster scorer when hardPinExplore=on")
-	assert.Equal(t, "claude-haiku-4-5", rec.Header().Get("x-router-model"))
+	assert.Equal(t, "claude-haiku-4-5", rec.Header().Get(proxy.HeaderRouterModel))
 
 	select {
 	case <-store.upsertCh:
@@ -416,7 +416,7 @@ func TestService_HardPin_ExploreFallsThroughWhenFlagOff(t *testing.T) {
 	require.NoError(t, svc.ProxyMessages(ctx, []byte(exploreBody), rec, httpReq))
 
 	assert.Equal(t, 1, fr.routeCalls, "Explore must fall through when hardPinExplore=off")
-	assert.Equal(t, "claude-opus-4-7", rec.Header().Get("x-router-model"))
+	assert.Equal(t, "claude-opus-4-7", rec.Header().Get(proxy.HeaderRouterModel))
 }
 
 // OpenAI ingress: same Stage 1 path via ProxyOpenAIChatCompletion.
@@ -464,7 +464,7 @@ func TestService_SessionPin_OpenAI_PostgresHitKeepsPinnedModel(t *testing.T) {
 	require.NoError(t, svc.ProxyOpenAIChatCompletion(ctx, []byte(openAIPinTestBody), rec, httpReq))
 
 	assert.Equal(t, 1, fr.routeCalls, "scorer runs every MainLoop turn under the planner")
-	assert.Equal(t, "gpt-5", rec.Header().Get("x-router-model"))
+	assert.Equal(t, "gpt-5", rec.Header().Get(proxy.HeaderRouterModel))
 	waitForUpsert(t, store)
 }
 
@@ -610,7 +610,7 @@ func TestService_SessionPin_OpenAI_ToolResultShortCircuit(t *testing.T) {
 	require.NoError(t, svc.ProxyOpenAIChatCompletion(ctx, []byte(toolResultBody), rec, httpReq))
 
 	assert.Equal(t, 0, fr.routeCalls, "tool-result with existing pin must not re-run the scorer")
-	assert.Equal(t, "gpt-5", rec.Header().Get("x-router-model"))
+	assert.Equal(t, "gpt-5", rec.Header().Get(proxy.HeaderRouterModel))
 }
 
 // newOpenAIHardPinSvc configures a service whose hard-pin target is on the
@@ -658,7 +658,7 @@ func TestService_OpenAI_CompactionPhraseDoesNotHardPin(t *testing.T) {
 	require.NoError(t, svc.ProxyOpenAIChatCompletion(ctx, []byte(compactionOpenAIBody), rec, httpReq))
 
 	assert.Equal(t, 1, fr.routeCalls, "OpenAI body must run the scorer, not hard-pin")
-	assert.Equal(t, "gpt-4o", rec.Header().Get("x-router-model"))
+	assert.Equal(t, "gpt-4o", rec.Header().Get(proxy.HeaderRouterModel))
 }
 
 func TestService_HardPin_OpenAI_SubAgentHeaderHintRoutesToHardPin(t *testing.T) {
@@ -673,7 +673,7 @@ func TestService_HardPin_OpenAI_SubAgentHeaderHintRoutesToHardPin(t *testing.T) 
 	require.NoError(t, svc.ProxyOpenAIChatCompletion(ctx, []byte(openAIPinTestBody), rec, httpReq))
 
 	assert.Equal(t, 0, fr.routeCalls, "x-weave-subagent-type must trigger Explore hard-pin")
-	assert.Equal(t, "gpt-4o-mini", rec.Header().Get("x-router-model"))
+	assert.Equal(t, "gpt-4o-mini", rec.Header().Get(proxy.HeaderRouterModel))
 }
 
 // TestService_HardPin_BypassesTierCeiling regression-guards the PR #100
@@ -712,7 +712,7 @@ func TestService_HardPin_BypassesTierCeiling(t *testing.T) {
 	body := `{"model":"claude-haiku-4-5","system":"Your task is to create a detailed summary of the conversation so far.","messages":[{"role":"user","content":"go"}]}`
 	require.NoError(t, svc.ProxyMessages(ctx, []byte(body), rec, httpReq))
 
-	assert.Equal(t, "claude-opus-4-7", rec.Header().Get("x-router-model"), "operator hard-pin must win over the tier ceiling")
+	assert.Equal(t, "claude-opus-4-7", rec.Header().Get(proxy.HeaderRouterModel), "operator hard-pin must win over the tier ceiling")
 }
 
 // haikuClampBody requests a Low-tier model (haiku); the scorer is
@@ -743,7 +743,7 @@ func TestService_TierClamp_HaikuRequestedClampsHighScore(t *testing.T) {
 	httpReq := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(""))
 	require.NoError(t, svc.ProxyMessages(ctx, []byte(haikuClampBody), rec, httpReq))
 
-	assert.Equal(t, "claude-haiku-4-5", rec.Header().Get("x-router-model"), "decision must be clamped to in-ceiling model")
+	assert.Equal(t, "claude-haiku-4-5", rec.Header().Get(proxy.HeaderRouterModel), "decision must be clamped to in-ceiling model")
 }
 
 // TestService_TierClamp_OpusRequestedNoClamp confirms High-tier
@@ -765,7 +765,7 @@ func TestService_TierClamp_OpusRequestedNoClamp(t *testing.T) {
 	httpReq := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(""))
 	require.NoError(t, svc.ProxyMessages(ctx, []byte(pinTestBody), rec, httpReq))
 
-	assert.Equal(t, "claude-opus-4-7", rec.Header().Get("x-router-model"), "opus ceiling allows High picks unchanged")
+	assert.Equal(t, "claude-opus-4-7", rec.Header().Get(proxy.HeaderRouterModel), "opus ceiling allows High picks unchanged")
 	assert.Equal(t, 0, resolverCalls, "resolver must not be called when decision is at or below ceiling")
 }
 
@@ -796,7 +796,7 @@ func TestService_TierClamp_PinAboveCeilingIsClamped(t *testing.T) {
 	httpReq := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(""))
 	require.NoError(t, svc.ProxyMessages(ctx, []byte(haikuClampBody), rec, httpReq))
 
-	assert.Equal(t, "claude-haiku-4-5", rec.Header().Get("x-router-model"))
+	assert.Equal(t, "claude-haiku-4-5", rec.Header().Get(proxy.HeaderRouterModel))
 }
 
 // TestService_ForcedPin_ClampedReasonSurfacesTierClamp guards the reporting
@@ -826,8 +826,8 @@ func TestService_ForcedPin_ClampedReasonSurfacesTierClamp(t *testing.T) {
 	// Requesting haiku (Low ceiling) forces the High forced pin to clamp.
 	require.NoError(t, svc.ProxyMessages(ctx, []byte(haikuClampBody), rec, httpReq))
 
-	assert.Equal(t, "claude-haiku-4-5", rec.Header().Get("x-router-model"), "clamped forced pin must serve the in-ceiling model")
-	assert.Equal(t, translate.ReasonUserForceModel+"+tier_clamp", rec.Header().Get("x-router-decision"), "clamped forced pin must report the tier_clamp suffix, not plain user_forced")
+	assert.Equal(t, "claude-haiku-4-5", rec.Header().Get(proxy.HeaderRouterModel), "clamped forced pin must serve the in-ceiling model")
+	assert.Equal(t, translate.ReasonUserForceModel+"+tier_clamp", rec.Header().Get(proxy.HeaderRouterDecision), "clamped forced pin must report the tier_clamp suffix, not plain user_forced")
 }
 
 // TestService_ForcedPin_UnclampedReasonStaysUserForced is the companion: an
@@ -856,8 +856,8 @@ func TestService_ForcedPin_UnclampedReasonStaysUserForced(t *testing.T) {
 	require.NoError(t, svc.ProxyMessages(ctx, []byte(pinTestBody), rec, httpReq))
 
 	assert.Equal(t, 0, clampCalls, "in-ceiling forced pin must not invoke the clamp resolver")
-	assert.Equal(t, "claude-opus-4-7", rec.Header().Get("x-router-model"))
-	assert.Equal(t, translate.ReasonUserForceModel, rec.Header().Get("x-router-decision"), "in-ceiling forced pin keeps the plain user_forced reason")
+	assert.Equal(t, "claude-opus-4-7", rec.Header().Get(proxy.HeaderRouterModel))
+	assert.Equal(t, translate.ReasonUserForceModel, rec.Header().Get(proxy.HeaderRouterDecision), "in-ceiling forced pin keeps the plain user_forced reason")
 }
 
 // TestService_TierClamp_UnknownRequestedModelDisablesClamp regression-
@@ -889,7 +889,7 @@ func TestService_TierClamp_UnknownRequestedModelDisablesClamp(t *testing.T) {
 	require.NoError(t, svc.ProxyMessages(ctx, []byte(body), rec, httpReq))
 
 	assert.Equal(t, 0, resolverCalls, "unknown requested model must yield TierUnknown ceiling, disabling the clamp")
-	assert.Equal(t, "claude-opus-4-7", rec.Header().Get("x-router-model"), "scorer pick must pass through unclamped for unknown requested models")
+	assert.Equal(t, "claude-opus-4-7", rec.Header().Get(proxy.HeaderRouterModel), "scorer pick must pass through unclamped for unknown requested models")
 }
 
 // TestService_TierClamp_ExcludedModelsThreadedToResolver regression-
@@ -962,7 +962,7 @@ func TestService_TierClamp_StaleFlagClearedOnUnclampedFinal(t *testing.T) {
 	httpReq := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(""))
 	require.NoError(t, svc.ProxyMessages(ctx, []byte(pinTestBody), rec, httpReq))
 
-	assert.Equal(t, "claude-opus-4-7", rec.Header().Get("x-router-model"))
+	assert.Equal(t, "claude-opus-4-7", rec.Header().Get(proxy.HeaderRouterModel))
 	assert.Equal(t, 0, clampCalls, "no clamp should fire under a High ceiling with in-ceiling models")
 	// Implicit: by passing through without clamp, the log would record
 	// tier_clamped=false / pre_clamp_model="" — the regression would
@@ -997,7 +997,7 @@ func TestService_UserForcedPin_TierClampDoesNotOverwritePin(t *testing.T) {
 	require.NoError(t, svc.ProxyMessages(ctx, []byte(haikuClampBody), rec, httpReq))
 
 	// This turn is clamped down to the in-ceiling model.
-	assert.Equal(t, "claude-haiku-4-5", rec.Header().Get("x-router-model"))
+	assert.Equal(t, "claude-haiku-4-5", rec.Header().Get(proxy.HeaderRouterModel))
 	assert.Equal(t, 0, fr.routeCalls, "user_forced pin must skip the scorer")
 
 	// The refreshed pin must keep the ORIGINAL forced model — not the clamp.
@@ -1035,5 +1035,5 @@ func TestService_UserForcedPin_IneligibleProviderFallsThrough(t *testing.T) {
 	require.NoError(t, svc.ProxyMessages(ctx, []byte(pinTestBody), rec, httpReq))
 
 	assert.Equal(t, 1, fr.routeCalls, "ineligible-provider forced pin must fall through to the scorer")
-	assert.Equal(t, "claude-haiku-4-5", rec.Header().Get("x-router-model"), "must dispatch to the eligible provider, not gpt-5/openai")
+	assert.Equal(t, "claude-haiku-4-5", rec.Header().Get(proxy.HeaderRouterModel), "must dispatch to the eligible provider, not gpt-5/openai")
 }

--- a/internal/proxy/turnloop_test.go
+++ b/internal/proxy/turnloop_test.go
@@ -136,7 +136,7 @@ func TestTurnLoop_ToolResultWithPinSkipsScorerAndPlanner(t *testing.T) {
 	require.NoError(t, svc.ProxyMessages(ctx, []byte(toolResultBody), rec, httpReq))
 
 	assert.Equal(t, 0, fr.routeCalls, "tool_result must not invoke the scorer")
-	assert.Equal(t, "claude-haiku-4-5", rec.Header().Get("x-router-model"))
+	assert.Equal(t, "claude-haiku-4-5", rec.Header().Get(proxy.HeaderRouterModel))
 }
 
 // TestTurnLoop_PlannerStaysWhenScorerAgrees verifies the same-model
@@ -161,7 +161,7 @@ func TestTurnLoop_PlannerStaysWhenScorerAgrees(t *testing.T) {
 	require.NoError(t, svc.ProxyMessages(ctx, []byte(pinTestBody), rec, httpReq))
 
 	assert.Equal(t, 1, fr.routeCalls, "planner re-eval still runs the scorer")
-	assert.Equal(t, "claude-haiku-4-5", rec.Header().Get("x-router-model"))
+	assert.Equal(t, "claude-haiku-4-5", rec.Header().Get(proxy.HeaderRouterModel))
 }
 
 // TestTurnLoop_PlannerSwitchesOnPositiveEV constructs a scenario where
@@ -189,7 +189,7 @@ func TestTurnLoop_PlannerSwitchesOnPositiveEV(t *testing.T) {
 	require.NoError(t, svc.ProxyMessages(ctx, largeBody(t), rec, httpReq))
 
 	assert.Equal(t, 1, fr.routeCalls)
-	assert.Equal(t, "claude-haiku-4-5", rec.Header().Get("x-router-model"), "planner must switch to fresh model")
+	assert.Equal(t, "claude-haiku-4-5", rec.Header().Get(proxy.HeaderRouterModel), "planner must switch to fresh model")
 	assert.Equal(t, int32(1), sz.calls.Load(), "summarizer must be invoked on switch")
 
 	waitForUpsert(t, store)
@@ -222,7 +222,7 @@ func TestTurnLoop_SummarizerErrorFallsBackToTrim(t *testing.T) {
 	require.NoError(t, svc.ProxyMessages(ctx, largeBody(t), rec, httpReq))
 
 	assert.Equal(t, int32(1), sz.calls.Load(), "summarizer must be tried before fallback")
-	assert.Equal(t, "claude-haiku-4-5", rec.Header().Get("x-router-model"), "switch must still happen on summarizer error")
+	assert.Equal(t, "claude-haiku-4-5", rec.Header().Get(proxy.HeaderRouterModel), "switch must still happen on summarizer error")
 }
 
 // TestTurnLoop_HandoverFallsBackToTrimWhenSummarizerNotWired guards the
@@ -250,7 +250,7 @@ func TestTurnLoop_HandoverFallsBackToTrimWhenSummarizerNotWired(t *testing.T) {
 	httpReq := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(""))
 	require.NoError(t, svc.ProxyMessages(ctx, largeBody(t), rec, httpReq))
 
-	assert.Equal(t, "claude-haiku-4-5", rec.Header().Get("x-router-model"), "switch must proceed even without a summarizer")
+	assert.Equal(t, "claude-haiku-4-5", rec.Header().Get(proxy.HeaderRouterModel), "switch must proceed even without a summarizer")
 }
 
 // TestTurnLoop_HandoverUsesClientCredsForSummarizerProvider verifies the
@@ -283,7 +283,7 @@ func TestTurnLoop_HandoverUsesClientCredsForSummarizerProvider(t *testing.T) {
 	require.NoError(t, svc.ProxyMessages(ctx, largeBody(t), rec, httpReq))
 
 	assert.Equal(t, int32(1), sz.calls.Load(), "summarizer must run with the caller's own Anthropic key (no tenant boundary crossed)")
-	assert.Equal(t, "claude-haiku-4-5", rec.Header().Get("x-router-model"))
+	assert.Equal(t, "claude-haiku-4-5", rec.Header().Get(proxy.HeaderRouterModel))
 }
 
 // TestTurnLoop_HandoverSkippedWhenClientCredsCrossProvider keeps the
@@ -314,7 +314,7 @@ func TestTurnLoop_HandoverSkippedWhenClientCredsCrossProvider(t *testing.T) {
 	require.NoError(t, svc.ProxyMessages(ctx, largeBody(t), rec, httpReq))
 
 	assert.Equal(t, int32(0), sz.calls.Load(), "summarizer must NOT run when client creds are for a different provider than the summarizer")
-	assert.Equal(t, "claude-haiku-4-5", rec.Header().Get("x-router-model"), "switch must still happen via TrimLastN fallback")
+	assert.Equal(t, "claude-haiku-4-5", rec.Header().Get(proxy.HeaderRouterModel), "switch must still happen via TrimLastN fallback")
 }
 
 // TestTurnLoop_PlannerDisabledPreservesFirstDecisionWins exercises the
@@ -338,7 +338,7 @@ func TestTurnLoop_PlannerDisabledPreservesFirstDecisionWins(t *testing.T) {
 	require.NoError(t, svc.ProxyMessages(ctx, []byte(pinTestBody), rec, httpReq))
 
 	assert.Equal(t, 0, fr.routeCalls, "planner-disabled with pin must skip the scorer")
-	assert.Equal(t, "claude-haiku-4-5", rec.Header().Get("x-router-model"))
+	assert.Equal(t, "claude-haiku-4-5", rec.Header().Get(proxy.HeaderRouterModel))
 }
 
 // TestTurnLoop_UsageWritebackPersistsCacheStats wires a usage-emitting
@@ -411,7 +411,7 @@ func TestTurnLoop_MaxedOutPinExcludedFromCandidates(t *testing.T) {
 	require.NotNil(t, fr.capturedReq, "scorer must run after a maxed-out pin is dropped")
 	assert.Contains(t, fr.capturedReq.ExcludedModels, "moonshotai/kimi-k2.6",
 		"pinned model must be excluded from candidates after a maxed-out turn")
-	assert.Equal(t, "claude-haiku-4-5", rec.Header().Get("x-router-model"),
+	assert.Equal(t, "claude-haiku-4-5", rec.Header().Get(proxy.HeaderRouterModel),
 		"router must serve the fresh decision, not the broken pin")
 }
 
@@ -440,7 +440,7 @@ func TestTurnLoop_UnderMaxedOutThresholdKeepsPin(t *testing.T) {
 	require.NotNil(t, fr.capturedReq)
 	assert.NotContains(t, fr.capturedReq.ExcludedModels, "claude-haiku-4-5",
 		"healthy pin must not be excluded from candidates")
-	assert.Equal(t, "claude-haiku-4-5", rec.Header().Get("x-router-model"))
+	assert.Equal(t, "claude-haiku-4-5", rec.Header().Get(proxy.HeaderRouterModel))
 }
 
 // recordingTelemetry is the minimum no-op telemetry repository that


### PR DESCRIPTION
## What

Extracts the `x-router-*` response-header names into exported constants in a new `internal/proxy/headers.go`:

- `HeaderRouterDecision` = `x-router-decision`
- `HeaderRouterProvider` = `x-router-provider`
- `HeaderRouterModel` = `x-router-model`
- `HeaderRouterCache` = `x-router-cache`
- `HeaderRouterFallbackFrom` = `x-router-fallback-from`
- `HeaderRouterFallbackAttempt` = `x-router-fallback-attempt`
- `RouterCacheHit` = `hit` (the `x-router-cache` hit value)

All prod write sites (`service.go` ×3 blocks, `gemini.go`, `fallback.go`) and the ~40 test assertions across six `_test.go` files now reference these constants.

## Why

Follow-up to the routing-marker constant work (#304). Same pattern: these header names were bare literals duplicated across **4 prod write sites** plus dozens of test assertions, with no single definition — renaming or retyping any of them was a lock-step edit across many files. Only the header *names* were extracted; the asserted *values* (model names, provider names) stay as literals since those are the actual expected data, not a shared contract.

## Scope notes

- **Pure refactor, no behavior change.** The emitted headers and values are byte-identical.
- `translate/responses.go` still reads the `x-router-model` literal directly. The layer rules forbid `translate` (inner-ring) from importing `proxy`, so that single defensive read stays a literal by design.
- Not touched: a `setRoutingHeaders(w, decision)` helper would further DRY the 4 near-identical write blocks, but that's a behavioral refactor beyond single-sourcing the names — happy to do it as a separate change if wanted.

Verified: `go build ./...`, `go vet ./internal/proxy/`, and `go test ./internal/proxy/` all pass; `gofmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)