### PR TITLE
Don't use in-memory cache for pin lookups

### DIFF
--- a/internal/proxy/force_model.go
+++ b/internal/proxy/force_model.go
@@ -86,19 +86,11 @@ func (s *Service) handleForceModelCommand(
 ) error {
 	log := observability.FromContext(ctx)
 	role := roleForTier(catalog.TierFor(env.Model()))
-	pinCacheKey := sessionPinCacheKey(sessionKey, role)
 
 	// Acknowledgment text is formatted as a routing marker (✦ **Weave Router** → …\n\n)
 	// so the existing StripRoutingMarkerFromMessages ingress stripper removes it from
 	// subsequent inbound requests. Without this, the text persists in conversation
 	// history and leaks router internals to the upstream on every following turn.
-	// Pin writes for /force-model and /unforce-model are SYNCHRONOUS by design.
-	// The async enqueuePinUpsert path drops on semaphore saturation, which here
-	// would leave Postgres holding the old active forced pin while the client
-	// gets a "cleared" acknowledgment — a subsequent loadPin would evict the
-	// in-proc expired entry and resurrect the stale row from Postgres. These
-	// are explicit user commands, not hot-path turns; an extra DB round-trip is
-	// acceptable to guarantee the pin state matches the acknowledgment.
 	var msg string
 	if cmd.Clear {
 		if s.pinStore != nil && installationID != uuid.Nil {
@@ -119,11 +111,6 @@ func (s *Service) handleForceModelCommand(
 				log.Error("/unforce-model: pin store upsert failed", "err", err)
 				return err
 			}
-		}
-		// Evict the in-proc cache entry AFTER Postgres is updated so a racing
-		// reader can't repopulate the LRU from a stale Postgres row.
-		if s.pinCache != nil {
-			s.pinCache.Remove(pinCacheKey)
 		}
 		msg = "✦ **Weave Router** → force-model cleared · resuming automatic model selection\n\n"
 		if env.SourceFormat() == translate.FormatOpenAI {
@@ -155,13 +142,15 @@ func (s *Service) handleForceModelCommand(
 			msg = fmt.Sprintf("Weave Router: force-model: %q isn't a recognized model; keeping automatic routing. Use a full model id, e.g. claude-opus-4-8, gpt-5.5, or gemini-3-pro-preview.", cmd.Model)
 		}
 	} else {
-		// Preserve LastServedModel from the existing LRU entry so the next turn
-		// can still detect a model switch and strip stale Anthropic thinking-block
+		// Preserve LastServedModel from the prior pin so the next turn can still
+		// detect a model switch and strip stale Anthropic thinking-block
 		// signatures. Without this carry-forward, the full Pin replacement here
 		// would zero out LastServedModel, defeating the /force-model switch detection.
 		var lastServedModel string
-		if s.pinCache != nil {
-			if existing, ok := s.pinCache.Get(pinCacheKey); ok {
+		if s.pinStore != nil {
+			if existing, found, err := s.pinStore.Get(ctx, sessionKey, role); err != nil {
+				log.Error("/force-model: prior pin lookup failed", "err", err)
+			} else if found {
 				lastServedModel = existing.LastServedModel
 			}
 		}
@@ -181,9 +170,6 @@ func (s *Service) handleForceModelCommand(
 				log.Error("/force-model: pin store upsert failed", "err", err)
 				return err
 			}
-		}
-		if s.pinCache != nil {
-			s.pinCache.Add(pinCacheKey, forced)
 		}
 		msg = fmt.Sprintf("✦ **Weave Router** → force-model applied: %s (%s) · use /unforce-model to clear\n\n", canonicalModel, provider)
 		if env.SourceFormat() == translate.FormatOpenAI {

--- a/internal/proxy/loop_detection.go
+++ b/internal/proxy/loop_detection.go
@@ -131,9 +131,6 @@ func (s *Service) handleToolCallLoopBreak(
 			log.Error("loop-break: pin store upsert failed", "err", err)
 		}
 	}
-	if s.pinCache != nil {
-		s.pinCache.Remove(sessionPinCacheKey(sessionKey, role))
-	}
 
 	switch env.SourceFormat() {
 	case translate.FormatOpenAI:

--- a/internal/proxy/no_progress.go
+++ b/internal/proxy/no_progress.go
@@ -3,6 +3,7 @@ package proxy
 import (
 	"context"
 	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"net/http"
 	"strconv"
@@ -234,7 +235,7 @@ func (t *noProgressTracker) recordAndDetect(sessionKey [sessionpin.SessionKeyLen
 // than falling back to a global zero-keyed bucket.
 func noProgressBucketKey(sessionKey [sessionpin.SessionKeyLen]byte, installationID uuid.UUID, role string) (string, bool) {
 	if sessionKey != ([sessionpin.SessionKeyLen]byte{}) {
-		return "session:" + sessionPinCacheKey(sessionKey, role), true
+		return "session:" + hex.EncodeToString(sessionKey[:]) + ":" + role, true
 	}
 	if installationID != uuid.Nil {
 		return "install:" + installationID.String() + ":" + role, true
@@ -317,9 +318,6 @@ func (s *Service) handleNoProgressBreak(
 		if err := s.pinStore.Upsert(context.Background(), expired); err != nil {
 			log.Error("no-progress-break: pin store upsert failed", "err", err)
 		}
-	}
-	if s.pinCache != nil {
-		s.pinCache.Remove(sessionPinCacheKey(sessionKey, role))
 	}
 
 	switch env.SourceFormat() {

--- a/internal/proxy/pin_eviction.go
+++ b/internal/proxy/pin_eviction.go
@@ -73,7 +73,6 @@ func (s *Service) maybeEvictPinAfterUpstreamErr(
 	}
 
 	log := observability.FromContext(ctx)
-	pinCacheKey := sessionPinCacheKey(sessionKey, role)
 
 	if proxyErr == nil {
 		// Background ctx: the request ctx is canceled by the time the
@@ -114,8 +113,7 @@ func (s *Service) maybeEvictPinAfterUpstreamErr(
 	// Threshold reached. Expire the pin so the NEXT turn re-routes via
 	// the cluster scorer. Mirrors the loop-break / no-progress / force
 	// -model "expired pin" pattern: upsert a row with PinnedUntil in
-	// the past so loadPin discards it, plus an in-proc cache evict so
-	// the next turn doesn't serve the stale entry.
+	// the past so loadPin discards it.
 	expired := sessionpin.Pin{
 		SessionKey:     sessionKey,
 		Role:           role,
@@ -129,9 +127,6 @@ func (s *Service) maybeEvictPinAfterUpstreamErr(
 	if err := s.pinStore.Upsert(context.Background(), expired); err != nil {
 		log.Error("pin eviction upsert failed", "err", err, "role", role)
 		return
-	}
-	if s.pinCache != nil {
-		s.pinCache.Remove(pinCacheKey)
 	}
 	log.Info("session pin evicted after consecutive upstream errors",
 		"role", role,

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -25,7 +25,6 @@ import (
 	"workweave/router/internal/translate"
 
 	"github.com/google/uuid"
-	"github.com/hashicorp/golang-lru/v2/expirable"
 )
 
 // Service orchestrates routing decisions and provider dispatch.
@@ -38,9 +37,6 @@ type Service struct {
 	// pinStore persists session-sticky routing decisions. Nil when the feature
 	// flag is off; the orchestrator then runs the scorer every turn.
 	pinStore sessionpin.Store
-	// pinCache absorbs the hot path; 30s TTL is short enough that pinned_until
-	// in the pin store remains source of truth for validity.
-	pinCache *expirable.LRU[string, sessionpin.Pin]
 	// noProgress tracks per-session dispatch fingerprints to catch the
 	// cross-envelope subagent loop (parent agent re-spawning identical
 	// sub-conversations). Nil disables the detector.
@@ -49,11 +45,6 @@ type Service struct {
 	// drops) so the router can rewrite non-Anthropic requests with a handover
 	// summary before the model loses awareness of prior completed work.
 	compaction *compactionTracker
-	// pinWriteSem bounds concurrent async pin-upsert goroutines with drop-on-full semantics.
-	pinWriteSem chan struct{}
-	// usageWriteSem bounds concurrent async last-turn-usage writeback goroutines,
-	// with the same drop-on-full semantics as pinWriteSem.
-	usageWriteSem chan struct{}
 	// hardPinExplore gates the Explore sub-agent hard-pin.
 	hardPinExplore bool
 	// hardPinProvider/hardPinModel route compaction (and, when hardPinExplore is
@@ -328,14 +319,6 @@ const DefaultPlannerExpectedRemainingTurns = 3
 const DefaultPlannerTierUpgradeEnabled = true
 
 func NewService(r router.Router, providerMap map[string]providers.Client, emitter *otel.Emitter, embedOnlyUserMessage bool, semanticCache *cache.Cache, pinStore sessionpin.Store, hardPinExplore bool, hardPinProvider, hardPinModel string, telemetry TelemetryRepository) *Service {
-	var pinCache *expirable.LRU[string, sessionpin.Pin]
-	var pinWriteSem chan struct{}
-	var usageWriteSem chan struct{}
-	if pinStore != nil {
-		pinCache = expirable.NewLRU[string, sessionpin.Pin](10000, nil, 30*time.Second)
-		pinWriteSem = make(chan struct{}, 64)
-		usageWriteSem = make(chan struct{}, 64)
-	}
 	return &Service{
 		router:               r,
 		providers:            providerMap,
@@ -343,11 +326,8 @@ func NewService(r router.Router, providerMap map[string]providers.Client, emitte
 		embedOnlyUserMessage: embedOnlyUserMessage,
 		semanticCache:        semanticCache,
 		pinStore:             pinStore,
-		pinCache:             pinCache,
 		noProgress:           newNoProgressTracker(),
 		compaction:           newCompactionTracker(),
-		pinWriteSem:          pinWriteSem,
-		usageWriteSem:        usageWriteSem,
 		hardPinExplore:       hardPinExplore,
 		hardPinProvider:      hardPinProvider,
 		hardPinModel:         hardPinModel,
@@ -1343,12 +1323,6 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 	return proxyErr
 }
 
-// sessionPinCacheKey produces the in-proc LRU key for a (session_key, role)
-// pair. Hex-encoded for the string-keyed LRU.
-func sessionPinCacheKey(key [sessionpin.SessionKeyLen]byte, role string) string {
-	return hex.EncodeToString(key[:]) + ":" + role
-}
-
 // applyPlannerAttrs stamps planner and handover attributes onto a span
 // attribute builder. Safe when the planner didn't run (uses "skipped" outcome).
 func applyPlannerAttrs(b *otel.AttrBuilder, res turnLoopResult) *otel.AttrBuilder {
@@ -1416,10 +1390,6 @@ func (s *Service) logPlannerOutcome(ctx context.Context, res turnLoopResult) {
 	)
 }
 
-// recordTurnUsage writes upstream token usage back to the session pin row
-// for the planner's next-turn EV math. Bounded async; drops on saturation.
-// Uses context.Background() so the DB write outlives the request ctx.
-
 func (s *Service) recordTurnUsage(res turnLoopResult, in, out, cacheCreation, cacheRead int) {
 	if s.pinStore == nil || res.HardPinned {
 		return
@@ -1439,40 +1409,12 @@ func (s *Service) recordTurnUsage(res turnLoopResult, in, out, cacheCreation, ca
 		EndedAt:           time.Now(),
 		ServedModel:       res.Decision.Model,
 	}
-	key := res.SessionKey
 	role := res.PinRole
 	if role == "" {
 		role = sessionpin.DefaultRole
 	}
-
-	// Keep the in-proc LRU coherent with the DB writeback. Without this,
-	// loadPin's Tier-1 hit serves a stale pin with zero usage and the
-	// planner returns ReasonNoPriorUsage forever (the 30s LRU TTL keeps
-	// resetting under typical agentic turn cadence), which silently
-	// disables EV-based switching for all active sessions.
-	if s.pinCache != nil {
-		pinCacheKey := sessionPinCacheKey(key, role)
-		if pin, ok := s.pinCache.Get(pinCacheKey); ok {
-			pin.LastInputTokens = usage.InputTokens
-			pin.LastCachedReadTokens = usage.CachedReadTokens
-			pin.LastCachedWriteTokens = usage.CachedWriteTokens
-			pin.LastOutputTokens = usage.OutputTokens
-			pin.LastTurnEndedAt = usage.EndedAt
-			pin.LastServedModel = usage.ServedModel
-			s.pinCache.Add(pinCacheKey, pin)
-		}
-	}
-
-	select {
-	case s.usageWriteSem <- struct{}{}:
-		go func() {
-			defer func() { <-s.usageWriteSem }()
-			if err := s.pinStore.UpdateUsage(context.Background(), key, role, usage); err != nil {
-				observability.Get().Debug("session pin usage writeback failed", "err", err)
-			}
-		}()
-	default:
-		observability.Get().Debug("session pin usage writeback dropped: semaphore full")
+	if err := s.pinStore.UpdateUsage(context.Background(), res.SessionKey, role, usage); err != nil {
+		observability.Get().Error("session pin usage writeback failed", "err", err)
 	}
 }
 

--- a/internal/proxy/service_session_pin_test.go
+++ b/internal/proxy/service_session_pin_test.go
@@ -183,31 +183,27 @@ func TestService_SessionPin_PostgresHitKeepsPinnedModel(t *testing.T) {
 	waitForUpsert(t, store)
 }
 
-// In-proc LRU short-circuits the Postgres GET on a hit. The scorer
-// still runs every MainLoop turn under the planner, but Tier-2 must
-// only be consulted on Tier-1 miss.
-func TestService_SessionPin_InProcCacheAvoidsPostgresOnSecondTurn(t *testing.T) {
+// Every turn must consult Postgres for its session pin — there is no
+// in-process cache. The scorer still runs every MainLoop turn under the
+// planner regardless of pin state.
+func TestService_SessionPin_EveryTurnReadsPostgres(t *testing.T) {
 	store := newFakePinStore()
 	fr := &fakeRouter{decision: router.Decision{Provider: "anthropic", Model: "claude-haiku-4-5", Reason: "fresh"}}
 	svc := newPinSvc(fr, store)
 
 	ctx := authedCtx(uuid.New().String())
 
-	// Turn 1: fresh route + async upsert + LRU populate.
 	rec1 := httptest.NewRecorder()
 	httpReq1 := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(""))
 	require.NoError(t, svc.ProxyMessages(ctx, []byte(pinTestBody), rec1, httpReq1))
-	waitForUpsert(t, store)
 	require.Equal(t, 1, fr.routeCalls)
-	require.Equal(t, 1, store.getCalls, "tier-1 miss must consult tier-2 once")
+	require.Equal(t, 1, store.getCalls, "first turn must read the pin store")
 
-	// Turn 2: in-proc LRU hit; scorer runs (planner re-eval) but
-	// tier-2 must not be consulted.
 	rec2 := httptest.NewRecorder()
 	httpReq2 := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(""))
 	require.NoError(t, svc.ProxyMessages(ctx, []byte(pinTestBody), rec2, httpReq2))
 	assert.Equal(t, 2, fr.routeCalls, "planner re-evaluates every MainLoop turn")
-	assert.Equal(t, 1, store.getCalls, "second turn must be served by tier-1; tier-2 must not be consulted")
+	assert.Equal(t, 2, store.getCalls, "second turn must also read Postgres — there is no in-process cache")
 }
 
 func TestService_SessionPin_StoreErrorFallsThroughToFreshRoute(t *testing.T) {

--- a/internal/proxy/turnloop.go
+++ b/internal/proxy/turnloop.go
@@ -189,9 +189,8 @@ func (s *Service) runTurnLoop(
 	}
 
 	res.SessionKey = DeriveSessionKey(env, apiKeyID)
-	pinCacheKey := sessionPinCacheKey(res.SessionKey, res.PinRole)
 
-	pin, pinFound := s.loadPin(ctx, pinCacheKey, res.SessionKey, res.PinRole)
+	pin, pinFound := s.loadPin(ctx, res.SessionKey, res.PinRole)
 	if pinFound {
 		res.PinModel = pin.Model
 		res.PriorServedModel = pin.LastServedModel
@@ -246,7 +245,7 @@ func (s *Service) runTurnLoop(
 			}
 			res.Decision = decision
 			res.StickyHit = true
-			s.refreshPin(ctx, installationID, res.SessionKey, pin, pinCacheKey, res.PinRole, pinDecision(pin))
+			s.refreshPin(ctx, installationID, res.SessionKey, pin, res.PinRole, pinDecision(pin))
 			return res, nil
 		}
 		// Forced pin is no longer servable on this request (excluded by policy
@@ -309,7 +308,7 @@ func (s *Service) runTurnLoop(
 		res.Decision = decision
 		res.StickyHit = true
 		res.PinTier = "postgres_tool_result_sc"
-		s.refreshPin(ctx, installationID, res.SessionKey, pin, pinCacheKey, res.PinRole, decision)
+		s.refreshPin(ctx, installationID, res.SessionKey, pin, res.PinRole, decision)
 		return res, nil
 	}
 
@@ -319,7 +318,7 @@ func (s *Service) runTurnLoop(
 		res.Decision = decision
 		res.StickyHit = true
 		res.PinTier = "postgres"
-		s.refreshPin(ctx, installationID, res.SessionKey, pin, pinCacheKey, res.PinRole, decision)
+		s.refreshPin(ctx, installationID, res.SessionKey, pin, res.PinRole, decision)
 		return res, nil
 	}
 
@@ -346,7 +345,7 @@ func (s *Service) runTurnLoop(
 
 	if !s.plannerEnabled {
 		res.Decision = fresh
-		s.writeNewPin(ctx, installationID, res.SessionKey, pinCacheKey, res.PinRole, fresh)
+		s.writeNewPin(ctx, installationID, res.SessionKey, res.PinRole, fresh)
 		return res, nil
 	}
 
@@ -368,7 +367,7 @@ func (s *Service) runTurnLoop(
 		res.Decision = stay
 		res.StickyHit = true
 		res.PinTier = "postgres_stay_" + decision.Reason
-		s.refreshPin(ctx, installationID, res.SessionKey, pin, pinCacheKey, res.PinRole, stay)
+		s.refreshPin(ctx, installationID, res.SessionKey, pin, res.PinRole, stay)
 		return res, nil
 	}
 
@@ -436,7 +435,7 @@ func (s *Service) runTurnLoop(
 	if pinFound {
 		res.PinTier = "switch_" + decision.Reason
 	}
-	s.writeNewPin(ctx, installationID, res.SessionKey, pinCacheKey, res.PinRole, fresh)
+	s.writeNewPin(ctx, installationID, res.SessionKey, res.PinRole, fresh)
 	return res, nil
 }
 
@@ -486,31 +485,11 @@ func (s *Service) clampToCeiling(decision router.Decision, ceiling catalog.Tier,
 	}
 }
 
-// loadPin returns the active pin for this session, consulting the in-proc
-// LRU first then Postgres. Expired rows are treated as misses.
-func (s *Service) loadPin(ctx context.Context, pinCacheKey string, sessionKey [sessionpin.SessionKeyLen]byte, role string) (sessionpin.Pin, bool) {
+// loadPin returns the active pin for this session from Postgres.
+// Expired rows are treated as misses.
+func (s *Service) loadPin(ctx context.Context, sessionKey [sessionpin.SessionKeyLen]byte, role string) (sessionpin.Pin, bool) {
 	log := observability.FromContext(ctx)
 	log.Debug("loadPin called", "role", role, "session_key_hex", fmt.Sprintf("%x", sessionKey))
-	if s.pinCache != nil {
-		if pin, ok := s.pinCache.Get(pinCacheKey); ok {
-			// Check expiry: recordTurnUsage refreshes LRU entries on every
-			// turn (resetting the 30s eviction clock), so without this guard
-			// an expired entry whose refreshPin write was dropped could keep
-			// being served past its PinnedUntil.
-			if !pin.PinnedUntil.After(time.Now()) {
-				s.pinCache.Remove(pinCacheKey)
-			} else if pin.Reason != translate.ReasonUserForceModel {
-				return pin, true
-			}
-			// User-forced pins fall through to Postgres on every turn instead of
-			// trusting the LRU. /force-model on one Cloud Run replica rewrites the
-			// Postgres row but cannot evict another replica's cached pin, and that
-			// entry's TTL keeps resetting every turn (recordTurnUsage re-Adds it),
-			// so a corrected re-force is otherwise shadowed by the stale local copy
-			// indefinitely. Forced pins are rare and explicit; the extra per-turn
-			// read keeps replicas converged on the user's latest directive.
-		}
-	}
 	pin, found, err := s.pinStore.Get(ctx, sessionKey, role)
 	if err != nil {
 		log.Error("session pin store unavailable; falling through to cluster scorer", "err", err)
@@ -522,16 +501,13 @@ func (s *Service) loadPin(ctx context.Context, pinCacheKey string, sessionKey [s
 	if !pin.PinnedUntil.After(time.Now()) {
 		return sessionpin.Pin{}, false
 	}
-	if s.pinCache != nil {
-		s.pinCache.Add(pinCacheKey, pin)
-	}
 	return pin, true
 }
 
 // refreshPin extends the TTL on an existing pin. Carries the existing pin's
 // usage forward so the planner has evidence before the next UpdateUsage
-// writeback lands. Async, bounded; drops on saturation.
-func (s *Service) refreshPin(ctx context.Context, installationID uuid.UUID, sessionKey [sessionpin.SessionKeyLen]byte, existing sessionpin.Pin, pinCacheKey string, role string, chosen router.Decision) {
+// writeback lands.
+func (s *Service) refreshPin(ctx context.Context, installationID uuid.UUID, sessionKey [sessionpin.SessionKeyLen]byte, existing sessionpin.Pin, role string, chosen router.Decision) {
 	if installationID == uuid.Nil {
 		return
 	}
@@ -551,12 +527,12 @@ func (s *Service) refreshPin(ctx context.Context, installationID uuid.UUID, sess
 		LastTurnEndedAt:       existing.LastTurnEndedAt,
 		LastServedModel:       existing.LastServedModel,
 	}
-	s.enqueuePinUpsert(ctx, p, pinCacheKey)
+	s.upsertPin(ctx, p)
 }
 
 // writeNewPin records a freshly-routed decision as the active pin. Used on
 // first-turn routing and switch turns. UpdateUsage fills in usage stats later.
-func (s *Service) writeNewPin(ctx context.Context, installationID uuid.UUID, sessionKey [sessionpin.SessionKeyLen]byte, pinCacheKey string, role string, chosen router.Decision) {
+func (s *Service) writeNewPin(ctx context.Context, installationID uuid.UUID, sessionKey [sessionpin.SessionKeyLen]byte, role string, chosen router.Decision) {
 	log := observability.FromContext(ctx)
 	log.Info("writeNewPin called", "installation_id", installationID.String(), "role", role, "model", chosen.Model, "session_key_hex", fmt.Sprintf("%x", sessionKey))
 	if installationID == uuid.Nil {
@@ -573,34 +549,19 @@ func (s *Service) writeNewPin(ctx context.Context, installationID uuid.UUID, ses
 		TurnCount:      1,
 		PinnedUntil:    time.Now().Add(pinSessionTTL),
 	}
-	s.enqueuePinUpsert(ctx, p, pinCacheKey)
+	s.upsertPin(ctx, p)
 }
 
-// enqueuePinUpsert pushes a pin write onto the bounded async worker pool.
-// Drops on saturation. Primes the in-proc LRU so the next turn avoids Postgres.
-//
-// The caller's ctx is used only to capture the request-scoped logger before
-// the goroutine spawns; the actual Upsert always runs on context.Background()
-// because the request ctx is canceled by the time the response has finished
-// streaming.
-func (s *Service) enqueuePinUpsert(ctx context.Context, p sessionpin.Pin, pinCacheKey string) {
+// upsertPin synchronously persists a pin write. context.Background() is used
+// so the DB write survives request-ctx cancellation after the response has
+// finished streaming.
+func (s *Service) upsertPin(ctx context.Context, p sessionpin.Pin) {
 	log := observability.FromContext(ctx)
-	select {
-	case s.pinWriteSem <- struct{}{}:
-		go func(pin sessionpin.Pin) {
-			defer func() { <-s.pinWriteSem }()
-			if err := s.pinStore.Upsert(context.Background(), pin); err != nil {
-				log.Error("session pin upsert failed", "err", err)
-				return
-			}
-			log.Debug("session pin upsert ok", "installation_id", pin.InstallationID.String(), "role", pin.Role, "model", pin.Model)
-		}(p)
-	default:
-		log.Debug("session pin upsert dropped: semaphore full")
+	if err := s.pinStore.Upsert(context.Background(), p); err != nil {
+		log.Error("session pin upsert failed", "err", err)
+		return
 	}
-	if s.pinCache != nil {
-		s.pinCache.Add(pinCacheKey, p)
-	}
+	log.Debug("session pin upsert ok", "installation_id", p.InstallationID.String(), "role", p.Role, "model", p.Model)
 }
 
 // estimateSummaryTokens is a rough char/4 estimate. The summarizer

--- a/internal/proxy/turnloop_internal_test.go
+++ b/internal/proxy/turnloop_internal_test.go
@@ -11,22 +11,21 @@ import (
 
 	"workweave/router/internal/router"
 	"workweave/router/internal/router/sessionpin"
-	"workweave/router/internal/translate"
 )
 
 // stubPinStore is a minimal sessionpin.Store for testing recordTurnUsage.
 // getPin/getFound configure the Get response; both default to a miss so
 // existing tests that rely on "no Postgres row" keep working unchanged.
 type stubPinStore struct {
-	mu          sync.Mutex
-	lastUsage   sessionpin.Usage
-	usageCalled chan struct{}
-	getPin      sessionpin.Pin
-	getFound    bool
+	mu        sync.Mutex
+	lastUsage sessionpin.Usage
+	usageHits int
+	getPin    sessionpin.Pin
+	getFound  bool
 }
 
 func newStubPinStore() *stubPinStore {
-	return &stubPinStore{usageCalled: make(chan struct{}, 1)}
+	return &stubPinStore{}
 }
 
 func (s *stubPinStore) Get(context.Context, [sessionpin.SessionKeyLen]byte, string) (sessionpin.Pin, bool, error) {
@@ -39,12 +38,9 @@ func (s *stubPinStore) Upsert(context.Context, sessionpin.Pin) error { return ni
 
 func (s *stubPinStore) UpdateUsage(_ context.Context, _ [sessionpin.SessionKeyLen]byte, _ string, u sessionpin.Usage) error {
 	s.mu.Lock()
+	defer s.mu.Unlock()
 	s.lastUsage = u
-	s.mu.Unlock()
-	select {
-	case s.usageCalled <- struct{}{}:
-	default:
-	}
+	s.usageHits++
 	return nil
 }
 
@@ -58,13 +54,12 @@ func (s *stubPinStore) ResetUpstreamErrors(context.Context, [sessionpin.SessionK
 
 func (s *stubPinStore) SweepExpired(context.Context) error { return nil }
 
-// TestRecordTurnUsage_UpdatesInProcCache guards the LRU-coherence invariant:
-// when recordTurnUsage persists usage, the in-proc pin cache entry must
-// reflect the new Last* fields. Without this, loadPin's Tier-1 hit serves a
-// stale zero-usage pin and the planner returns ReasonNoPriorUsage forever.
-func TestRecordTurnUsage_UpdatesInProcCache(t *testing.T) {
+// TestRecordTurnUsage_WritesToStore guards the synchronous UpdateUsage write:
+// recordTurnUsage must persist Last* fields to Postgres in-line on the request
+// path so the planner has prior-turn evidence by the time the next turn loads
+// the pin.
+func TestRecordTurnUsage_WritesToStore(t *testing.T) {
 	store := newStubPinStore()
-	// NewService wires a real expirable LRU when pinStore is set.
 	svc := NewService(
 		nil,
 		nil,
@@ -76,52 +71,35 @@ func TestRecordTurnUsage_UpdatesInProcCache(t *testing.T) {
 		"anthropic", "claude-haiku-4-5",
 		nil,
 	)
-	require.NotNil(t, svc.pinCache, "Service must wire an in-proc pin cache when pinStore is set")
 
 	var sessionKey [sessionpin.SessionKeyLen]byte
 	for i := range sessionKey {
 		sessionKey[i] = byte(i + 1)
 	}
-	cacheKey := sessionPinCacheKey(sessionKey, sessionpin.DefaultRole)
-
-	// Pre-warm the cache as writeNewPin/refreshPin would.
-	initial := sessionpin.Pin{
-		SessionKey:  sessionKey,
-		Role:        sessionpin.DefaultRole,
-		Provider:    "anthropic",
-		Model:       "claude-opus-4-7",
-		Reason:      "fresh",
-		TurnCount:   1,
-		PinnedUntil: time.Now().Add(time.Hour),
-	}
-	svc.pinCache.Add(cacheKey, initial)
 
 	res := turnLoopResult{
 		Decision:   router.Decision{Provider: "anthropic", Model: "claude-opus-4-7"},
 		SessionKey: sessionKey,
+		PinRole:    sessionpin.DefaultRole,
 	}
 	svc.recordTurnUsage(res, 1200, 80, 200, 900)
 
-	select {
-	case <-store.usageCalled:
-	case <-time.After(2 * time.Second):
-		t.Fatal("expected UpdateUsage on the store within 2s; none observed")
-	}
-
-	got, ok := svc.pinCache.Get(cacheKey)
-	require.True(t, ok, "LRU entry must survive recordTurnUsage")
-	assert.Equal(t, 1200, got.LastInputTokens, "LRU LastInputTokens must reflect recorded usage")
-	assert.Equal(t, 900, got.LastCachedReadTokens, "LRU LastCachedReadTokens must reflect recorded usage")
-	assert.Equal(t, 200, got.LastCachedWriteTokens, "LRU LastCachedWriteTokens must reflect recorded usage")
-	assert.Equal(t, 80, got.LastOutputTokens, "LRU LastOutputTokens must reflect recorded usage")
-	assert.False(t, got.LastTurnEndedAt.IsZero(), "LRU LastTurnEndedAt must be stamped — the planner uses IsZero() as its no-prior-usage gate")
+	store.mu.Lock()
+	defer store.mu.Unlock()
+	assert.Equal(t, 1, store.usageHits, "UpdateUsage must run synchronously on the request path")
+	assert.Equal(t, 1200, store.lastUsage.InputTokens)
+	assert.Equal(t, 900, store.lastUsage.CachedReadTokens)
+	assert.Equal(t, 200, store.lastUsage.CachedWriteTokens)
+	assert.Equal(t, 80, store.lastUsage.OutputTokens)
+	assert.Equal(t, "claude-opus-4-7", store.lastUsage.ServedModel)
+	assert.False(t, store.lastUsage.EndedAt.IsZero(), "EndedAt must be stamped — the planner uses IsZero() as its no-prior-usage gate")
 }
 
-// TestLoadPin_EvictsExpiredLRUEntry guards the LRU tier's expiry check.
-// recordTurnUsage refreshes LRU entries on every turn, so expired entries
-// could keep being served if expiry isn't checked — particularly when
-// refreshPin's bounded enqueue drops but recordTurnUsage keeps landing.
-func TestLoadPin_EvictsExpiredLRUEntry(t *testing.T) {
+// TestLoadPin_DiscardsExpiredPostgresPin guards the expiry filter: rows whose
+// PinnedUntil has passed must be treated as misses so the orchestrator
+// re-routes via the cluster scorer. The sweeper is best-effort and races
+// against high-throughput sessions, so loadPin must guard for itself.
+func TestLoadPin_DiscardsExpiredPostgresPin(t *testing.T) {
 	store := newStubPinStore()
 	svc := NewService(
 		nil,
@@ -134,18 +112,14 @@ func TestLoadPin_EvictsExpiredLRUEntry(t *testing.T) {
 		"anthropic", "claude-haiku-4-5",
 		nil,
 	)
-	require.NotNil(t, svc.pinCache)
+	require.NotNil(t, svc.pinStore)
 
 	var sessionKey [sessionpin.SessionKeyLen]byte
 	for i := range sessionKey {
 		sessionKey[i] = byte(i + 1)
 	}
-	cacheKey := sessionPinCacheKey(sessionKey, sessionpin.DefaultRole)
 
-	// Pre-warm the LRU with an expired pin. The stub store returns no rows
-	// on Get, so any non-expired LRU entry would be the only source of a
-	// "found" result.
-	expired := sessionpin.Pin{
+	store.getPin = sessionpin.Pin{
 		SessionKey:  sessionKey,
 		Role:        sessionpin.DefaultRole,
 		Provider:    "anthropic",
@@ -154,18 +128,16 @@ func TestLoadPin_EvictsExpiredLRUEntry(t *testing.T) {
 		TurnCount:   1,
 		PinnedUntil: time.Now().Add(-time.Minute),
 	}
-	svc.pinCache.Add(cacheKey, expired)
+	store.getFound = true
 
-	pin, found := svc.loadPin(context.Background(), cacheKey, sessionKey, sessionpin.DefaultRole)
-	assert.False(t, found, "expired LRU entry must not be served")
+	pin, found := svc.loadPin(context.Background(), sessionKey, sessionpin.DefaultRole)
+	assert.False(t, found, "expired Postgres row must not be served")
 	assert.Equal(t, sessionpin.Pin{}, pin, "miss must return the zero pin")
-	_, stillCached := svc.pinCache.Get(cacheKey)
-	assert.False(t, stillCached, "expired LRU entry must be evicted on lookup so subsequent turns hit Postgres")
 }
 
-// TestLoadPin_ServesFreshLRUEntry is the companion test: a non-expired LRU
-// entry hits Tier 1 without touching Postgres.
-func TestLoadPin_ServesFreshLRUEntry(t *testing.T) {
+// TestLoadPin_ServesFreshPostgresPin is the companion: a non-expired Postgres
+// row is returned verbatim.
+func TestLoadPin_ServesFreshPostgresPin(t *testing.T) {
 	store := newStubPinStore()
 	svc := NewService(
 		nil,
@@ -183,9 +155,8 @@ func TestLoadPin_ServesFreshLRUEntry(t *testing.T) {
 	for i := range sessionKey {
 		sessionKey[i] = byte(i + 1)
 	}
-	cacheKey := sessionPinCacheKey(sessionKey, sessionpin.DefaultRole)
 
-	fresh := sessionpin.Pin{
+	store.getPin = sessionpin.Pin{
 		SessionKey:  sessionKey,
 		Role:        sessionpin.DefaultRole,
 		Provider:    "anthropic",
@@ -194,67 +165,10 @@ func TestLoadPin_ServesFreshLRUEntry(t *testing.T) {
 		TurnCount:   1,
 		PinnedUntil: time.Now().Add(time.Hour),
 	}
-	svc.pinCache.Add(cacheKey, fresh)
-
-	pin, found := svc.loadPin(context.Background(), cacheKey, sessionKey, sessionpin.DefaultRole)
-	require.True(t, found, "non-expired LRU entry should be returned without hitting Postgres")
-	assert.Equal(t, fresh.Model, pin.Model)
-	assert.Equal(t, fresh.Provider, pin.Provider)
-}
-
-// TestLoadPin_ForcedPinBypassesStaleLRU guards the cross-replica coherence
-// fix for user-forced pins. /force-model on one Cloud Run replica rewrites the
-// Postgres row but cannot evict another replica's LRU entry, and that entry's
-// TTL keeps resetting every turn — so a corrected re-force is shadowed by the
-// stale local copy indefinitely. loadPin must ignore a cached user_forced pin
-// and re-read Postgres so the latest directive wins.
-func TestLoadPin_ForcedPinBypassesStaleLRU(t *testing.T) {
-	store := newStubPinStore()
-	svc := NewService(
-		nil,
-		nil,
-		nil,
-		false,
-		nil,
-		store,
-		false,
-		"anthropic", "claude-haiku-4-5",
-		nil,
-	)
-	require.NotNil(t, svc.pinCache)
-
-	var sessionKey [sessionpin.SessionKeyLen]byte
-	for i := range sessionKey {
-		sessionKey[i] = byte(i + 1)
-	}
-	cacheKey := sessionPinCacheKey(sessionKey, sessionpin.DefaultRole)
-
-	// Stale forced pin cached locally (the truncated "gpt-" from the first,
-	// botched /force-model), still well within its TTL.
-	stale := sessionpin.Pin{
-		SessionKey:  sessionKey,
-		Role:        sessionpin.DefaultRole,
-		Provider:    "openai",
-		Model:       "gpt-",
-		Reason:      translate.ReasonUserForceModel,
-		TurnCount:   1,
-		PinnedUntil: time.Now().Add(time.Hour),
-	}
-	svc.pinCache.Add(cacheKey, stale)
-
-	// Postgres holds the corrected re-force written by another replica.
-	store.getPin = sessionpin.Pin{
-		SessionKey:  sessionKey,
-		Role:        sessionpin.DefaultRole,
-		Provider:    "openai",
-		Model:       "gpt-5.5",
-		Reason:      translate.ReasonUserForceModel,
-		TurnCount:   1,
-		PinnedUntil: time.Now().Add(time.Hour),
-	}
 	store.getFound = true
 
-	pin, found := svc.loadPin(context.Background(), cacheKey, sessionKey, sessionpin.DefaultRole)
-	require.True(t, found, "forced pin must resolve from Postgres")
-	assert.Equal(t, "gpt-5.5", pin.Model, "forced pin must re-read Postgres, not serve the stale LRU copy")
+	pin, found := svc.loadPin(context.Background(), sessionKey, sessionpin.DefaultRole)
+	require.True(t, found, "non-expired Postgres row must be returned")
+	assert.Equal(t, "claude-opus-4-7", pin.Model)
+	assert.Equal(t, "anthropic", pin.Provider)
 }


### PR DESCRIPTION
Justification:

- In memory cache is wrong if a different server serves the same session
- Latency from postgres reads/writes is very low (couple ms normally)