### PR TITLE
Strip invalid thinking blocks if model has ever switched

### DIFF
--- a/db/migrations/0011_session_pin_has_ever_switched.down.sql
+++ b/db/migrations/0011_session_pin_has_ever_switched.down.sql
@@ -1,0 +1,6 @@
+BEGIN;
+
+ALTER TABLE router.session_pins
+  DROP COLUMN has_ever_switched;
+
+COMMIT;

--- a/db/migrations/0011_session_pin_has_ever_switched.up.sql
+++ b/db/migrations/0011_session_pin_has_ever_switched.up.sql
@@ -1,0 +1,16 @@
+BEGIN;
+
+-- Latches true once a session has ever served two different models, set only
+-- by UpdateSessionPinUsage when the just-served model differs from the prior
+-- last_served_model. Anthropic thinking-block signatures are valid only for
+-- the model that produced them, but Claude Code re-sends its full transcript
+-- every turn, so the stale-signed blocks from a cross-model excursion persist
+-- in the client history indefinitely. ModelSwitched alone strips them on the
+-- single transition turn; this latch lets the emit path keep stripping on
+-- every subsequent same-model turn for the life of the session, which is the
+-- only window in which those poisoned blocks would otherwise reach Anthropic
+-- and 400 with `Invalid signature in thinking block`.
+ALTER TABLE router.session_pins
+  ADD COLUMN has_ever_switched BOOLEAN NOT NULL DEFAULT FALSE;
+
+COMMIT;

--- a/db/queries/session_pins.sql
+++ b/db/queries/session_pins.sql
@@ -57,6 +57,14 @@ ON CONFLICT (session_key, role) DO UPDATE SET
 -- served this turn; it lives here (not in UpsertSessionPin) so a
 -- /force-model upsert cannot overwrite the genuinely-last-served model
 -- before the next turn reads it to detect a mid-session model switch.
+-- has_ever_switched latches true the first time the just-served model
+-- differs from a prior non-empty last_served_model. ModelSwitched (derived
+-- from last_served_model) strips stale Anthropic thinking-block signatures
+-- only on the single transition turn, but Claude Code re-sends its full
+-- transcript every turn, so once a session has switched at all, the latch
+-- keeps the emit path stripping on every subsequent same-model turn for the
+-- session's life — the only window in which those poisoned blocks would
+-- otherwise reach Anthropic and 400.
 -- name: UpdateSessionPinUsage :exec
 UPDATE router.session_pins
 SET last_input_tokens        = @last_input_tokens::int,
@@ -64,6 +72,8 @@ SET last_input_tokens        = @last_input_tokens::int,
     last_cached_write_tokens = @last_cached_write_tokens::int,
     last_output_tokens       = @last_output_tokens::int,
     last_turn_ended_at       = @last_turn_ended_at::timestamptz,
+    has_ever_switched        = has_ever_switched
+      OR (last_served_model <> '' AND last_served_model <> @last_served_model::varchar),
     last_served_model        = @last_served_model::varchar
 WHERE session_key = @session_key::bytea
   AND role        = @role::varchar;

--- a/internal/postgres/session_pin_repo.go
+++ b/internal/postgres/session_pin_repo.go
@@ -131,6 +131,7 @@ func toSessionPin(row sqlc.RouterSessionPin) sessionpin.Pin {
 		LastOutputTokens:      int(row.LastOutputTokens),
 		LastTurnEndedAt:       timestamptzOrZero(row.LastTurnEndedAt),
 		LastServedModel:       row.LastServedModel,
+		HasEverSwitched:       row.HasEverSwitched,
 	}
 	// Bounded copy guards against a corrupt row panicking the request handler.
 	copy(pin.SessionKey[:], row.SessionKey)

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -1013,7 +1013,7 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 		Capabilities:       router.Lookup(decision.Model),
 		IncludeStreamUsage: s.usageRequired(),
 		SessionAffinity:    sessionAffinityHint(routeRes.SessionKey),
-		ModelSwitched:      routeRes.PriorServedModel != "" && routeRes.PriorServedModel != decision.Model,
+		ModelSwitched:      routeRes.modelSwitched(),
 	}
 
 	ctx = resolveAndInjectCredentials(ctx, decision.Provider, r.Header)
@@ -1960,7 +1960,7 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 		Capabilities:       router.Lookup(decision.Model),
 		IncludeStreamUsage: s.usageRequired(),
 		SessionAffinity:    sessionAffinityHint(routeRes.SessionKey),
-		ModelSwitched:      routeRes.PriorServedModel != "" && routeRes.PriorServedModel != decision.Model,
+		ModelSwitched:      routeRes.modelSwitched(),
 	}
 
 	ctx = resolveAndInjectCredentials(ctx, decision.Provider, r.Header)

--- a/internal/proxy/turnloop.go
+++ b/internal/proxy/turnloop.go
@@ -79,12 +79,32 @@ type turnLoopResult struct {
 	// current decision model to detect a mid-session switch so the Anthropic
 	// emit path can strip thinking blocks whose signatures the new model rejects.
 	PriorServedModel string
+	// SessionEverSwitched is the pin's latched has_ever_switched flag: true once
+	// the session has served two different models at any point. PriorServedModel
+	// only flags the single switch-back turn, but the stale-signed thinking
+	// blocks a cross-model excursion left in the client transcript persist on
+	// every later turn, so the emit path ORs this into ModelSwitched to keep
+	// stripping them for the life of the session.
+	SessionEverSwitched bool
 	// Handover captures the summarize-or-trim step when the planner switched.
 	Handover handoverOutcome
 	// SuggestionMode is true when the request arrived with the
 	// x-weave-suggestion-mode header. The routing marker is suppressed so
 	// the badge does not appear in suggestion-overlay responses.
 	SuggestionMode bool
+}
+
+// modelSwitched reports whether the Anthropic emit path must strip historical
+// thinking blocks for this turn. Two cases force a strip: the transition turn
+// itself (the model serving this turn differs from the one that served the
+// previous turn), and any turn in a session that has ever switched — because
+// Claude Code re-sends its full transcript every turn, so the stale-signed
+// blocks an earlier cross-model excursion left behind keep coming back and
+// would 400 with `Invalid signature in thinking block` on every later turn,
+// not just the switch-back.
+func (r turnLoopResult) modelSwitched() bool {
+	transition := r.PriorServedModel != "" && r.PriorServedModel != r.Decision.Model
+	return transition || r.SessionEverSwitched
 }
 
 // handoverOutcome describes the synchronous handover step.
@@ -194,6 +214,7 @@ func (s *Service) runTurnLoop(
 	if pinFound {
 		res.PinModel = pin.Model
 		res.PriorServedModel = pin.LastServedModel
+		res.SessionEverSwitched = pin.HasEverSwitched
 		res.PinAgeSec = pinAge(pin)
 		log.Info("turnloop pin lookup hit",
 			"pin_model", pin.Model,
@@ -202,6 +223,7 @@ func (s *Service) runTurnLoop(
 			"pin_age_s", res.PinAgeSec,
 			"pin_cache_warm", cacheWarm(pin),
 			"last_output_tokens", pin.LastOutputTokens,
+			"session_ever_switched", pin.HasEverSwitched,
 		)
 	} else {
 		log.Info("turnloop pin lookup miss", "role", res.PinRole)

--- a/internal/proxy/turnloop.go
+++ b/internal/proxy/turnloop.go
@@ -211,10 +211,10 @@ func (s *Service) runTurnLoop(
 	res.SessionKey = DeriveSessionKey(env, apiKeyID)
 
 	pin, pinFound := s.loadPin(ctx, res.SessionKey, res.PinRole)
+	res.PriorServedModel = pin.LastServedModel
+	res.SessionEverSwitched = pin.HasEverSwitched
 	if pinFound {
 		res.PinModel = pin.Model
-		res.PriorServedModel = pin.LastServedModel
-		res.SessionEverSwitched = pin.HasEverSwitched
 		res.PinAgeSec = pinAge(pin)
 		log.Info("turnloop pin lookup hit",
 			"pin_model", pin.Model,
@@ -507,8 +507,9 @@ func (s *Service) clampToCeiling(decision router.Decision, ceiling catalog.Tier,
 	}
 }
 
-// loadPin returns the active pin for this session from Postgres.
-// Expired rows are treated as misses.
+// loadPin returns the stored pin and whether it may actively serve this turn.
+// Expired rows are misses for routing, but their history fields still protect
+// Anthropic emit from stale thinking-block signatures in the client transcript.
 func (s *Service) loadPin(ctx context.Context, sessionKey [sessionpin.SessionKeyLen]byte, role string) (sessionpin.Pin, bool) {
 	log := observability.FromContext(ctx)
 	log.Debug("loadPin called", "role", role, "session_key_hex", fmt.Sprintf("%x", sessionKey))
@@ -521,7 +522,7 @@ func (s *Service) loadPin(ctx context.Context, sessionKey [sessionpin.SessionKey
 		return sessionpin.Pin{}, false
 	}
 	if !pin.PinnedUntil.After(time.Now()) {
-		return sessionpin.Pin{}, false
+		return pin, false
 	}
 	return pin, true
 }

--- a/internal/proxy/turnloop_internal_test.go
+++ b/internal/proxy/turnloop_internal_test.go
@@ -172,3 +172,60 @@ func TestLoadPin_ServesFreshPostgresPin(t *testing.T) {
 	assert.Equal(t, "claude-opus-4-7", pin.Model)
 	assert.Equal(t, "anthropic", pin.Provider)
 }
+
+// TestModelSwitched covers the switch → stay → stay lifecycle that motivated
+// the has_ever_switched latch. The transition turn alone is not enough: once a
+// session has served two models, the stale-signed thinking blocks persist in
+// the client transcript, so every subsequent same-model turn must keep
+// stripping or Anthropic 400s.
+func TestModelSwitched(t *testing.T) {
+	tests := []struct {
+		name             string
+		priorServedModel string
+		decisionModel    string
+		everSwitched     bool
+		want             bool
+	}{
+		{
+			name:          "first turn of a session never switches",
+			decisionModel: "claude-opus-4-7",
+			want:          false,
+		},
+		{
+			name:             "steady-state same model, never switched",
+			priorServedModel: "claude-opus-4-7",
+			decisionModel:    "claude-opus-4-7",
+			want:             false,
+		},
+		{
+			name:             "transition turn flips models",
+			priorServedModel: "deepseek-v4-pro",
+			decisionModel:    "claude-opus-4-7",
+			want:             true,
+		},
+		{
+			name:             "switch-back transition turn",
+			priorServedModel: "deepseek-v4-pro",
+			decisionModel:    "claude-opus-4-7",
+			everSwitched:     true,
+			want:             true,
+		},
+		{
+			name:             "stay turn after a prior switch still strips",
+			priorServedModel: "claude-opus-4-7",
+			decisionModel:    "claude-opus-4-7",
+			everSwitched:     true,
+			want:             true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			res := turnLoopResult{
+				Decision:            router.Decision{Model: tc.decisionModel},
+				PriorServedModel:    tc.priorServedModel,
+				SessionEverSwitched: tc.everSwitched,
+			}
+			assert.Equal(t, tc.want, res.modelSwitched())
+		})
+	}
+}

--- a/internal/proxy/turnloop_internal_test.go
+++ b/internal/proxy/turnloop_internal_test.go
@@ -95,11 +95,11 @@ func TestRecordTurnUsage_WritesToStore(t *testing.T) {
 	assert.False(t, store.lastUsage.EndedAt.IsZero(), "EndedAt must be stamped — the planner uses IsZero() as its no-prior-usage gate")
 }
 
-// TestLoadPin_DiscardsExpiredPostgresPin guards the expiry filter: rows whose
-// PinnedUntil has passed must be treated as misses so the orchestrator
-// re-routes via the cluster scorer. The sweeper is best-effort and races
-// against high-throughput sessions, so loadPin must guard for itself.
-func TestLoadPin_DiscardsExpiredPostgresPin(t *testing.T) {
+// TestLoadPin_DoesNotServeExpiredPostgresPinButKeepsEmitHistory guards the
+// expiry filter: expired rows must be routing misses, but their
+// has_ever_switched / last_served_model history still protects Anthropic emit
+// from poisoned thinking blocks that remain in the client transcript.
+func TestLoadPin_DoesNotServeExpiredPostgresPinButKeepsEmitHistory(t *testing.T) {
 	store := newStubPinStore()
 	svc := NewService(
 		nil,
@@ -120,19 +120,29 @@ func TestLoadPin_DiscardsExpiredPostgresPin(t *testing.T) {
 	}
 
 	store.getPin = sessionpin.Pin{
-		SessionKey:  sessionKey,
-		Role:        sessionpin.DefaultRole,
-		Provider:    "anthropic",
-		Model:       "claude-opus-4-7",
-		Reason:      "fresh",
-		TurnCount:   1,
-		PinnedUntil: time.Now().Add(-time.Minute),
+		SessionKey:      sessionKey,
+		Role:            sessionpin.DefaultRole,
+		Provider:        "anthropic",
+		Model:           "claude-opus-4-7",
+		Reason:          "fresh",
+		TurnCount:       1,
+		PinnedUntil:     time.Now().Add(-time.Minute),
+		LastServedModel: "claude-opus-4-7",
+		HasEverSwitched: true,
 	}
 	store.getFound = true
 
 	pin, found := svc.loadPin(context.Background(), sessionKey, sessionpin.DefaultRole)
 	assert.False(t, found, "expired Postgres row must not be served")
-	assert.Equal(t, sessionpin.Pin{}, pin, "miss must return the zero pin")
+	assert.Equal(t, "claude-opus-4-7", pin.LastServedModel, "expired row history must be available for emit")
+	assert.True(t, pin.HasEverSwitched, "expired row latch must be available for emit")
+
+	res := turnLoopResult{
+		Decision:            router.Decision{Model: "claude-opus-4-7"},
+		PriorServedModel:    pin.LastServedModel,
+		SessionEverSwitched: pin.HasEverSwitched,
+	}
+	assert.True(t, res.modelSwitched(), "expired switched-session history must still strip thinking blocks")
 }
 
 // TestLoadPin_ServesFreshPostgresPin is the companion: a non-expired Postgres

--- a/internal/router/sessionpin/store.go
+++ b/internal/router/sessionpin/store.go
@@ -57,6 +57,13 @@ type Pin struct {
 	// mid-session model switch (and strip Anthropic thinking-block signatures
 	// the new model would otherwise reject with a 400).
 	LastServedModel string
+	// HasEverSwitched latches true the first time this session served a model
+	// different from the prior LastServedModel. It stays set for the life of
+	// the pin and is flipped atomically inside Store.UpdateUsage. The emit
+	// path ORs it into ModelSwitched so the stale-signed thinking blocks an
+	// earlier cross-model excursion left in the client transcript are stripped
+	// on every subsequent turn, not just the single switch-back turn.
+	HasEverSwitched bool
 }
 
 // Usage captures the previous turn's upstream token accounting.

--- a/internal/sqlc/models.go
+++ b/internal/sqlc/models.go
@@ -160,4 +160,5 @@ type RouterSessionPin struct {
 	LastTurnEndedAt           pgtype.Timestamptz
 	ConsecutiveUpstreamErrors int32
 	LastServedModel           string
+	HasEverSwitched           bool
 }

--- a/internal/sqlc/session_pins.sql.go
+++ b/internal/sqlc/session_pins.sql.go
@@ -13,7 +13,7 @@ import (
 )
 
 const getSessionPin = `-- name: GetSessionPin :one
-SELECT session_key, role, installation_id, pinned_provider, pinned_model, decision_reason, turn_count, pinned_until, first_pinned_at, last_seen_at, last_input_tokens, last_cached_read_tokens, last_cached_write_tokens, last_output_tokens, last_turn_ended_at, consecutive_upstream_errors, last_served_model
+SELECT session_key, role, installation_id, pinned_provider, pinned_model, decision_reason, turn_count, pinned_until, first_pinned_at, last_seen_at, last_input_tokens, last_cached_read_tokens, last_cached_write_tokens, last_output_tokens, last_turn_ended_at, consecutive_upstream_errors, last_served_model, has_ever_switched
 FROM router.session_pins
 WHERE session_key = $1::bytea
   AND role        = $2::varchar
@@ -31,7 +31,7 @@ type GetSessionPinParams struct {
 // last_turn_ended_at carry the previous turn's upstream usage; the
 // planner reads them to weigh switch EV against eviction cost.
 //
-//	SELECT session_key, role, installation_id, pinned_provider, pinned_model, decision_reason, turn_count, pinned_until, first_pinned_at, last_seen_at, last_input_tokens, last_cached_read_tokens, last_cached_write_tokens, last_output_tokens, last_turn_ended_at, consecutive_upstream_errors, last_served_model
+//	SELECT session_key, role, installation_id, pinned_provider, pinned_model, decision_reason, turn_count, pinned_until, first_pinned_at, last_seen_at, last_input_tokens, last_cached_read_tokens, last_cached_write_tokens, last_output_tokens, last_turn_ended_at, consecutive_upstream_errors, last_served_model, has_ever_switched
 //	FROM router.session_pins
 //	WHERE session_key = $1::bytea
 //	  AND role        = $2::varchar
@@ -56,6 +56,7 @@ func (q *Queries) GetSessionPin(ctx context.Context, arg GetSessionPinParams) (R
 		&i.LastTurnEndedAt,
 		&i.ConsecutiveUpstreamErrors,
 		&i.LastServedModel,
+		&i.HasEverSwitched,
 	)
 	return i, err
 }
@@ -143,6 +144,8 @@ SET last_input_tokens        = $1::int,
     last_cached_write_tokens = $3::int,
     last_output_tokens       = $4::int,
     last_turn_ended_at       = $5::timestamptz,
+    has_ever_switched        = has_ever_switched
+      OR (last_served_model <> '' AND last_served_model <> $6::varchar),
     last_served_model        = $6::varchar
 WHERE session_key = $7::bytea
   AND role        = $8::varchar
@@ -169,6 +172,14 @@ type UpdateSessionPinUsageParams struct {
 // served this turn; it lives here (not in UpsertSessionPin) so a
 // /force-model upsert cannot overwrite the genuinely-last-served model
 // before the next turn reads it to detect a mid-session model switch.
+// has_ever_switched latches true the first time the just-served model
+// differs from a prior non-empty last_served_model. ModelSwitched (derived
+// from last_served_model) strips stale Anthropic thinking-block signatures
+// only on the single transition turn, but Claude Code re-sends its full
+// transcript every turn, so once a session has switched at all, the latch
+// keeps the emit path stripping on every subsequent same-model turn for the
+// session's life — the only window in which those poisoned blocks would
+// otherwise reach Anthropic and 400.
 //
 //	UPDATE router.session_pins
 //	SET last_input_tokens        = $1::int,
@@ -176,6 +187,8 @@ type UpdateSessionPinUsageParams struct {
 //	    last_cached_write_tokens = $3::int,
 //	    last_output_tokens       = $4::int,
 //	    last_turn_ended_at       = $5::timestamptz,
+//	    has_ever_switched        = has_ever_switched
+//	      OR (last_served_model <> '' AND last_served_model <> $6::varchar),
 //	    last_served_model        = $6::varchar
 //	WHERE session_key = $7::bytea
 //	  AND role        = $8::varchar


### PR DESCRIPTION
If we don't do this we get 400 errors when moving from an openai-compat model to Opus