### PR TITLE
feat(routing): per-installation quality vs price dial

### DIFF
--- a/db/migrations/0025_installation-routing-preference.down.sql
+++ b/db/migrations/0025_installation-routing-preference.down.sql
@@ -1,0 +1,6 @@
+BEGIN;
+
+ALTER TABLE router.model_router_installations
+  DROP COLUMN routing_quality_weight;
+
+COMMIT;

--- a/db/migrations/0025_installation-routing-preference.up.sql
+++ b/db/migrations/0025_installation-routing-preference.up.sql
@@ -1,0 +1,11 @@
+BEGIN;
+
+-- Per-installation routing preference (the "quality vs price" dial). Stored as
+-- the scorer's quality weight (Alpha) -- a normalized fraction in [0, 1] where
+-- 1.0 biases routing fully toward quality and 0.0 fully toward price. The
+-- implied price weight is the remainder (1 - quality). NULL means "no
+-- preference" -- the scorer keeps its tuned per-cluster defaults.
+ALTER TABLE router.model_router_installations
+  ADD COLUMN routing_quality_weight DOUBLE PRECISION;
+
+COMMIT;

--- a/db/queries/model_router_installations.sql
+++ b/db/queries/model_router_installations.sql
@@ -55,3 +55,14 @@ SET excluded_providers = @excluded_providers::text[],
 WHERE id = @id::uuid
   AND external_id = @external_id::varchar
   AND deleted_at IS NULL;
+
+-- Sets the routing preference quality weight (a normalized fraction in [0, 1]),
+-- scoped to an external_id to prevent cross-tenant updates. NULL clears the
+-- preference so the scorer reverts to its tuned defaults.
+-- name: UpdateModelRouterInstallationRoutingPreference :exec
+UPDATE router.model_router_installations
+SET routing_quality_weight = sqlc.narg('routing_quality_weight'),
+    updated_at = NOW()
+WHERE id = @id::uuid
+  AND external_id = @external_id::varchar
+  AND deleted_at IS NULL;

--- a/frontend/src/app/(app)/settings/page.tsx
+++ b/frontend/src/app/(app)/settings/page.tsx
@@ -16,7 +16,7 @@ import {
   type ExternalKey,
   type RouterConfig,
 } from "@/lib/api";
-import { ChevronDown, Copy, Filter, KeyRound, Network, Plug, RotateCw, Settings as SettingsIcon, Trash2 } from "lucide-react";
+import { ChevronDown, Copy, Filter, KeyRound, Network, Plug, RotateCw, Settings as SettingsIcon, SlidersHorizontal, Trash2 } from "lucide-react";
 import { useEffect, useState } from "react";
 
 export default function SettingsPage() {
@@ -87,6 +87,25 @@ export default function SettingsPage() {
             installation. Unchecked models are skipped at request time.
           </Text>
           <ModelSelectionPanel />
+        </Page.Section>
+
+        <Page.Section
+          className="py-3"
+          header={
+            <Page.SectionHeader>
+              <SlidersHorizontal className="size-4" />
+              <Text variant="h4" as="h3">
+                Routing priority
+              </Text>
+            </Page.SectionHeader>
+          }
+        >
+          <Text className="text-xs text-muted-foreground">
+            Bias routing toward stronger models or cheaper ones. Every request
+            is balanced between the two. Leave as default to let the router
+            decide.
+          </Text>
+          <RoutingPriorityPanel />
         </Page.Section>
 
         <Page.Section
@@ -944,6 +963,276 @@ function ProviderSelectionPanel() {
   );
 }
 
+
+// Routing dials, rendered as proportional weights (sum to 100%) — mirrors the
+// metric-weights editor in the main Weave app. Quality is the scorer's Alpha;
+// price is the implied remainder.
+const ROUTING_DIALS = [
+  { key: "quality", label: "Quality" },
+  { key: "price", label: "Price" },
+] as const;
+const DIAL_COLORS = ["bg-primary", "bg-warning"];
+const DEFAULT_QUALITY = 70;
+
+// Distributes a changed weight against the others so they always sum to 100,
+// using largest-remainder rounding. Carried over from the main app's
+// AggregateMetricWeightsSection so both surfaces behave identically.
+function adjustWeightsProportionally(
+  weights: Record<string, number>,
+  changedKey: string,
+  newValue: number,
+): Record<string, number> {
+  const clamped = Math.max(0, Math.min(100, newValue));
+  const keys = Object.keys(weights);
+  const otherKeys = keys.filter(k => k !== changedKey);
+
+  if (otherKeys.length === 0) {
+    return { [changedKey]: 100 };
+  }
+  if (clamped === 100) {
+    const result: Record<string, number> = { [changedKey]: 100 };
+    for (const k of otherKeys) {
+      result[k] = 0;
+    }
+    return result;
+  }
+
+  const remaining = 100 - clamped;
+  const othersSum = otherKeys.reduce((s, k) => s + weights[k], 0);
+
+  const exact: Record<string, number> = {};
+  if (othersSum === 0) {
+    const each = remaining / otherKeys.length;
+    for (const k of otherKeys) {
+      exact[k] = each;
+    }
+  } else {
+    for (const k of otherKeys) {
+      exact[k] = (weights[k] / othersSum) * remaining;
+    }
+  }
+
+  const floored: Record<string, number> = {};
+  let flooredSum = 0;
+  for (const k of otherKeys) {
+    floored[k] = Math.floor(exact[k]);
+    flooredSum += floored[k];
+  }
+
+  let leftover = remaining - flooredSum;
+  const remainders = otherKeys
+    .map(k => ({ key: k, remainder: exact[k] - floored[k] }))
+    .sort((a, b) => b.remainder - a.remainder);
+  for (const { key } of remainders) {
+    if (leftover <= 0) break;
+    floored[key] += 1;
+    leftover -= 1;
+  }
+
+  const result: Record<string, number> = { [changedKey]: clamped };
+  for (const k of otherKeys) {
+    result[k] = floored[k];
+  }
+  return result;
+}
+
+function DistributionBar({ weights }: { weights: Record<string, number> }) {
+  return (
+    <div className="flex h-2 overflow-hidden rounded-full">
+      {ROUTING_DIALS.map((dial, i) => (
+        <div
+          key={dial.key}
+          className={`${DIAL_COLORS[i % DIAL_COLORS.length]} transition-all duration-200`}
+          style={{ width: `${weights[dial.key] ?? 0}%` }}
+        />
+      ))}
+    </div>
+  );
+}
+
+function RoutingPriorityPanel() {
+  const [weights, setWeights] = useState<Record<string, number>>({
+    quality: DEFAULT_QUALITY,
+    price: 100 - DEFAULT_QUALITY,
+  });
+  const [saved, setSaved] = useState<Record<string, number>>({
+    quality: DEFAULT_QUALITY,
+    price: 100 - DEFAULT_QUALITY,
+  });
+  const [focusedKey, setFocusedKey] = useState<string | null>(null);
+  const [focusedValue, setFocusedValue] = useState("");
+  const [isDefault, setIsDefault] = useState(true);
+  const [loaded, setLoaded] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  function apply(res: { quality: number; is_default: boolean }) {
+    const quality = Math.round(res.quality);
+    const next = { quality, price: 100 - quality };
+    setWeights(next);
+    setSaved(next);
+    setFocusedKey(null);
+    setIsDefault(res.is_default);
+  }
+
+  useEffect(() => {
+    api.routingPreferences
+      .get()
+      .then(res => {
+        apply(res);
+        setLoaded(true);
+      })
+      .catch((err: unknown) => {
+        setError(err instanceof Error ? err.message : "Failed to load routing priority");
+        setLoaded(true);
+      });
+  }, []);
+
+  const dirty = weights.quality !== saved.quality;
+
+  function applyProportionalAdjustment(key: string, rawValue: string) {
+    const val = parseInt(rawValue, 10);
+    if (isNaN(val)) {
+      setFocusedKey(null);
+      return;
+    }
+    setWeights(prev => adjustWeightsProportionally(prev, key, val));
+    setFocusedKey(null);
+  }
+
+  async function save() {
+    setSaving(true);
+    setError(null);
+    try {
+      apply(await api.routingPreferences.update({ quality: weights.quality, price: weights.price }));
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err.message : "Failed to save");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function reset() {
+    setSaving(true);
+    setError(null);
+    try {
+      apply(await api.routingPreferences.reset());
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err.message : "Failed to reset");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  if (!loaded) {
+    return (
+      <Card className="p-0">
+        <Card.Content>
+          <div className="px-5 py-8 text-center text-2xs text-muted-foreground">
+            {error != null ? "Failed to load" : "Loading…"}
+          </div>
+        </Card.Content>
+      </Card>
+    );
+  }
+
+  return (
+    <>
+      {error && <ErrorBanner>{error}</ErrorBanner>}
+      <Card className="p-0">
+        <Card.Content className="flex flex-col gap-4 p-5">
+          {isDefault && (
+            <div className="rounded-md border border-border bg-muted/30 p-3 text-2xs text-muted-foreground">
+              Using the router&apos;s default routing. Adjust a weight and save to set a preference.
+            </div>
+          )}
+
+          <DistributionBar weights={weights} />
+
+          {ROUTING_DIALS.map((dial, i) => (
+            <div key={dial.key} className="flex items-center justify-between gap-2">
+              <div className="flex items-center gap-1.5">
+                <div className={`size-2 rounded-full ${DIAL_COLORS[i % DIAL_COLORS.length]}`} />
+                <span className="text-sm text-foreground">{dial.label}</span>
+              </div>
+              <div className="flex items-center gap-1">
+                <Input
+                  type="number"
+                  min={0}
+                  max={100}
+                  step={1}
+                  className="w-16 text-right text-sm"
+                  disabled={saving}
+                  value={focusedKey === dial.key ? focusedValue : (weights[dial.key] ?? 0)}
+                  onFocus={() => {
+                    setFocusedKey(dial.key);
+                    setFocusedValue(String(weights[dial.key] ?? 0));
+                  }}
+                  onChange={e => {
+                    const newVal = e.target.value;
+                    setFocusedValue(newVal);
+                    const parsed = parseInt(newVal, 10);
+                    const current = weights[dial.key] ?? 0;
+                    if (!isNaN(parsed) && Math.abs(parsed - current) === 1) {
+                      setWeights(prev => {
+                        const adjusted = adjustWeightsProportionally(prev, dial.key, parsed);
+                        setFocusedValue(String(adjusted[dial.key] ?? parsed));
+                        return adjusted;
+                      });
+                    }
+                  }}
+                  onBlur={() => {
+                    if (focusedKey === dial.key) {
+                      applyProportionalAdjustment(dial.key, focusedValue);
+                    }
+                  }}
+                  onKeyDown={e => {
+                    if (e.key === "ArrowUp" || e.key === "ArrowDown") {
+                      e.preventDefault();
+                      const delta = e.key === "ArrowUp" ? 1 : -1;
+                      setWeights(prev => {
+                        const current = prev[dial.key] ?? 0;
+                        const next = Math.max(0, Math.min(100, current + delta));
+                        const adjusted = adjustWeightsProportionally(prev, dial.key, next);
+                        setFocusedValue(String(adjusted[dial.key] ?? next));
+                        return adjusted;
+                      });
+                    }
+                    if (e.key === "Enter") {
+                      applyProportionalAdjustment(dial.key, focusedValue);
+                      (e.target as HTMLInputElement).blur();
+                    }
+                  }}
+                />
+                <span className="text-xs text-muted-foreground">%</span>
+              </div>
+            </div>
+          ))}
+        </Card.Content>
+        <Card.Footer className="flex items-center justify-between border-t border-border px-5 py-3">
+          <span className="text-2xs text-muted-foreground">
+            Higher quality favors stronger models; higher price favors cheaper ones.
+          </span>
+          <div className="flex items-center gap-2">
+            {!isDefault && (
+              <Button appearance={Appearance.Outlined} onClick={reset} disabled={saving}>
+                Reset to default
+              </Button>
+            )}
+            <Button
+              onClick={save}
+              disabled={!dirty || saving}
+              intent={Intent.Primary}
+              appearance={Appearance.Filled}
+            >
+              {saving ? "Saving…" : "Save"}
+            </Button>
+          </div>
+        </Card.Footer>
+      </Card>
+    </>
+  );
+}
 
 function ErrorBanner({ children }: { children: React.ReactNode }) {
   return (

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -134,6 +134,12 @@ export interface ExcludedProvidersResponse {
   env_override_active: boolean;
 }
 
+export interface RoutingPreferencesResponse {
+  quality: number;
+  price: number;
+  is_default: boolean;
+}
+
 export const api = {
   auth: {
     me: () => request<MeResponse>("/auth/me"),
@@ -203,6 +209,19 @@ export const api = {
       request<ExcludedProvidersResponse>("/excluded-providers", {
         method: "PUT",
         body: JSON.stringify({ excluded }),
+      }),
+  },
+  routingPreferences: {
+    get: () => request<RoutingPreferencesResponse>("/routing-preferences"),
+    update: (body: { quality: number; price: number }) =>
+      request<RoutingPreferencesResponse>("/routing-preferences", {
+        method: "PUT",
+        body: JSON.stringify(body),
+      }),
+    reset: () =>
+      request<RoutingPreferencesResponse>("/routing-preferences", {
+        method: "PUT",
+        body: JSON.stringify({ reset: true }),
       }),
   },
 };

--- a/internal/api/admin/routing_preferences.go
+++ b/internal/api/admin/routing_preferences.go
@@ -1,0 +1,136 @@
+package admin
+
+import (
+	"net/http"
+
+	"workweave/router/internal/auth"
+	"workweave/router/internal/observability"
+
+	"github.com/gin-gonic/gin"
+)
+
+// Neutral starting point shown when no preference is stored. Mirrors the
+// managed control plane's defaults so both surfaces present the same dial.
+const (
+	defaultQualityPct = 70.0
+	defaultPricePct   = 30.0
+)
+
+type routingPreferencesResponse struct {
+	Quality   float64 `json:"quality"`
+	Price     float64 `json:"price"`
+	IsDefault bool    `json:"is_default"`
+}
+
+// updateRoutingPreferencesRequest carries the raw slider values. They need not
+// sum to 100 -- the server normalizes them into a quality weight. reset=true
+// clears the preference so the scorer reverts to its tuned defaults.
+type updateRoutingPreferencesRequest struct {
+	Reset   bool    `json:"reset"`
+	Quality float64 `json:"quality"`
+	Price   float64 `json:"price"`
+}
+
+func defaultRoutingPreferences() routingPreferencesResponse {
+	return routingPreferencesResponse{
+		Quality:   defaultQualityPct,
+		Price:     defaultPricePct,
+		IsDefault: true,
+	}
+}
+
+// routingPreferencesFor renders the stored quality weight as percentages (price
+// is the implied remainder), or the neutral default when no preference is set.
+func routingPreferencesFor(installation *auth.Installation) routingPreferencesResponse {
+	if installation.RoutingQualityWeight == nil {
+		return defaultRoutingPreferences()
+	}
+	quality := *installation.RoutingQualityWeight
+	price := 1.0 - quality
+	if price < 0 {
+		price = 0
+	}
+	return routingPreferencesResponse{
+		Quality:   quality * 100,
+		Price:     price * 100,
+		IsDefault: false,
+	}
+}
+
+// normalizeRoutingWeight converts the raw quality/price slider values into a
+// quality weight in [0, 1] (price is the implied remainder). ok is false when
+// either value is negative or the total is non-positive, so the weight can't be
+// normalized.
+func normalizeRoutingWeight(quality, price float64) (qualityWeight float64, ok bool) {
+	if quality < 0 || price < 0 {
+		return 0, false
+	}
+	total := quality + price
+	if total <= 0 {
+		return 0, false
+	}
+	return quality / total, true
+}
+
+// GetRoutingPreferencesHandler returns the installation's routing dial as
+// percentages, or the neutral default when none is stored.
+func GetRoutingPreferencesHandler(authSvc *auth.Service) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		installation, ok := resolveInstallation(c, authSvc)
+		if !ok {
+			return
+		}
+		c.JSON(http.StatusOK, routingPreferencesFor(installation))
+	}
+}
+
+// UpdateRoutingPreferencesHandler normalizes the raw slider values into a
+// quality weight and persists it. reset=true clears the preference. Rejects a
+// non-positive total with 400.
+func UpdateRoutingPreferencesHandler(authSvc *auth.Service) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		log := observability.FromGin(c)
+		installation, ok := resolveInstallation(c, authSvc)
+		if !ok {
+			return
+		}
+
+		var req updateRoutingPreferencesRequest
+		if err := c.ShouldBindJSON(&req); err != nil {
+			c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": "invalid request body"})
+			return
+		}
+
+		if req.Reset {
+			if err := authSvc.SetInstallationRoutingPreference(c.Request.Context(), installation.ExternalID, installation.ID, nil); err != nil {
+				log.Error("Failed to clear routing preference", "err", err, "installation_id", installation.ID)
+				c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"error": "failed to update routing preference"})
+				return
+			}
+			c.JSON(http.StatusOK, defaultRoutingPreferences())
+			return
+		}
+
+		qualityWeight, ok := normalizeRoutingWeight(req.Quality, req.Price)
+		if !ok {
+			c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": "at least one routing preference must be greater than zero"})
+			return
+		}
+
+		if err := authSvc.SetInstallationRoutingPreference(c.Request.Context(), installation.ExternalID, installation.ID, &qualityWeight); err != nil {
+			log.Error("Failed to update routing preference", "err", err, "installation_id", installation.ID)
+			c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"error": "failed to update routing preference"})
+			return
+		}
+
+		priceWeight := 1.0 - qualityWeight
+		if priceWeight < 0 {
+			priceWeight = 0
+		}
+		c.JSON(http.StatusOK, routingPreferencesResponse{
+			Quality:   qualityWeight * 100,
+			Price:     priceWeight * 100,
+			IsDefault: false,
+		})
+	}
+}

--- a/internal/api/admin/routing_preferences_internal_test.go
+++ b/internal/api/admin/routing_preferences_internal_test.go
@@ -1,0 +1,50 @@
+package admin
+
+import (
+	"testing"
+
+	"workweave/router/internal/auth"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNormalizeRoutingWeight(t *testing.T) {
+	t.Run("normalizes to a quality weight in [0, 1]", func(t *testing.T) {
+		q, ok := normalizeRoutingWeight(70, 30) // total 100
+		assert.True(t, ok)
+		assert.InDelta(t, 0.7, q, 0.001)
+	})
+
+	t.Run("normalizes when the raw values don't sum to 100", func(t *testing.T) {
+		q, ok := normalizeRoutingWeight(60, 20) // total 80
+		assert.True(t, ok)
+		assert.InDelta(t, 0.75, q, 0.001)
+	})
+
+	t.Run("rejects all-zero", func(t *testing.T) {
+		_, ok := normalizeRoutingWeight(0, 0)
+		assert.False(t, ok)
+	})
+
+	t.Run("rejects negative", func(t *testing.T) {
+		_, ok := normalizeRoutingWeight(-1, 50)
+		assert.False(t, ok)
+	})
+}
+
+func TestRoutingPreferencesFor(t *testing.T) {
+	t.Run("nil weight renders the neutral default", func(t *testing.T) {
+		got := routingPreferencesFor(&auth.Installation{})
+		assert.True(t, got.IsDefault)
+		assert.Equal(t, defaultQualityPct, got.Quality)
+		assert.Equal(t, defaultPricePct, got.Price)
+	})
+
+	t.Run("set weight renders as percentages with price as the remainder", func(t *testing.T) {
+		quality := 0.8
+		got := routingPreferencesFor(&auth.Installation{RoutingQualityWeight: &quality})
+		assert.False(t, got.IsDefault)
+		assert.InDelta(t, 80.0, got.Quality, 0.001)
+		assert.InDelta(t, 20.0, got.Price, 0.001)
+	})
+}

--- a/internal/auth/installation.go
+++ b/internal/auth/installation.go
@@ -21,6 +21,13 @@ type Installation struct {
 	// ExcludedProviders is the per-installation provider exclusion list.
 	// Empty means no exclusion.
 	ExcludedProviders []string
+	// RoutingQualityWeight is the per-installation routing preference (the
+	// "quality vs price" dial), stored as the scorer's quality weight (Alpha)
+	// -- a normalized fraction in [0, 1] where 1.0 biases routing fully toward
+	// quality and 0.0 fully toward price. The implied price weight is the
+	// remainder. nil means no preference -- the scorer keeps its tuned
+	// per-cluster defaults.
+	RoutingQualityWeight *float64
 }
 
 type CreateInstallationParams struct {
@@ -40,4 +47,8 @@ type InstallationRepository interface {
 	// UpdateExcludedProviders replaces the per-installation provider
 	// exclusion list. An empty (or nil) slice clears the list.
 	UpdateExcludedProviders(ctx context.Context, externalID, id string, providerNames []string) error
+	// UpdateRoutingPreference sets the routing quality weight (a normalized
+	// fraction in [0, 1]). Passing nil clears the preference so the scorer
+	// reverts to its tuned per-cluster defaults.
+	UpdateRoutingPreference(ctx context.Context, externalID, id string, qualityWeight *float64) error
 }

--- a/internal/auth/service.go
+++ b/internal/auth/service.go
@@ -271,6 +271,19 @@ func (s *Service) SetInstallationExcludedProviders(ctx context.Context, external
 	return out, nil
 }
 
+// SetInstallationRoutingPreference persists the routing quality weight (a
+// normalized fraction in [0, 1]) on the installation. Passing nil clears the
+// preference so the scorer reverts to its tuned per-cluster defaults.
+// Invalidates the API-key cache so the change takes effect on the next request
+// rather than after the cache TTL.
+func (s *Service) SetInstallationRoutingPreference(ctx context.Context, externalID, installationID string, qualityWeight *float64) error {
+	if err := s.installations.UpdateRoutingPreference(ctx, externalID, installationID, qualityWeight); err != nil {
+		return err
+	}
+	s.invalidateInstallation(installationID)
+	return nil
+}
+
 // VerifyAPIKey authenticates a raw bearer token against the API key cache then Postgres.
 // Returns ErrInvalidPrefix/ErrInvalidToken for unauthenticated cases.
 // Returned ExternalAPIKey slice has Plaintext populated; nil when none exist.

--- a/internal/auth/service_test.go
+++ b/internal/auth/service_test.go
@@ -98,6 +98,7 @@ type fakeInstallationRepository struct {
 	excludedModelsExternalByID    map[string]string
 	excludedProvidersByID         map[string][]string
 	excludedProvidersExternalByID map[string]string
+	routingQualityByID            map[string]*float64
 }
 
 func (fakeInstallationRepository) Create(ctx context.Context, params auth.CreateInstallationParams) (*auth.Installation, error) {
@@ -132,6 +133,13 @@ func (f *fakeInstallationRepository) UpdateExcludedProviders(ctx context.Context
 	}
 	f.excludedProvidersByID[id] = append([]string{}, providerNames...)
 	f.excludedProvidersExternalByID[id] = externalID
+	return nil
+}
+func (f *fakeInstallationRepository) UpdateRoutingPreference(ctx context.Context, externalID, id string, qualityWeight *float64) error {
+	if f.routingQualityByID == nil {
+		f.routingQualityByID = map[string]*float64{}
+	}
+	f.routingQualityByID[id] = qualityWeight
 	return nil
 }
 
@@ -671,6 +679,25 @@ func TestService_SetInstallationExcludedProviders(t *testing.T) {
 	})
 }
 
+func TestService_SetInstallationRoutingPreference(t *testing.T) {
+	installRepo := &fakeInstallationRepository{}
+	svc := auth.NewService(installRepo, &fakeAPIKeyRepository{byHash: map[string]fakeKeyRow{}}, nil, nil, auth.NoOpAPIKeyCache{}, nil, frozenClock())
+
+	t.Run("persists quality weight scoped by external_id", func(t *testing.T) {
+		quality := 0.6
+		err := svc.SetInstallationRoutingPreference(context.Background(), "ext-1", "inst-1", &quality)
+		require.NoError(t, err)
+		require.NotNil(t, installRepo.routingQualityByID["inst-1"])
+		assert.Equal(t, 0.6, *installRepo.routingQualityByID["inst-1"])
+	})
+
+	t.Run("nil clears the preference", func(t *testing.T) {
+		err := svc.SetInstallationRoutingPreference(context.Background(), "ext-1", "inst-1", nil)
+		require.NoError(t, err)
+		assert.Nil(t, installRepo.routingQualityByID["inst-1"])
+	})
+}
+
 type recordingNotifier struct {
 	mu  sync.Mutex
 	ids []string
@@ -721,6 +748,17 @@ func TestService_WriteHooksInvalidateAndNotify(t *testing.T) {
 			"excluded-model writes must call cache.InvalidateInstallation so the next request sees the new list")
 		assert.Equal(t, []string{installID}, nf.snapshot(),
 			"excluded-model writes must publish NOTIFY so peer replicas drop their cache too")
+	})
+
+	t.Run("SetInstallationRoutingPreference", func(t *testing.T) {
+		svc, cache, nf := makeSvc()
+		quality := 0.6
+		err := svc.SetInstallationRoutingPreference(context.Background(), "ext-1", installID, &quality)
+		require.NoError(t, err)
+		assert.Equal(t, []string{installID}, cache.invalidationSnapshot(),
+			"routing-preference writes must drop the cached installation so the next request sees the new dial")
+		assert.Equal(t, []string{installID}, nf.snapshot(),
+			"routing-preference writes must publish NOTIFY so peer replicas drop their cache too")
 	})
 
 	t.Run("UpsertExternalAPIKey", func(t *testing.T) {

--- a/internal/postgres/converters.go
+++ b/internal/postgres/converters.go
@@ -20,15 +20,16 @@ func toAuthInstallation(row sqlc.RouterModelRouterInstallation) *auth.Installati
 		excludedProviders = []string{}
 	}
 	return &auth.Installation{
-		ID:                row.ID.String(),
-		ExternalID:        row.ExternalID,
-		Name:              row.Name,
-		CreatedAt:         timestampOrZero(row.CreatedAt),
-		UpdatedAt:         timestampOrZero(row.UpdatedAt),
-		DeletedAt:         timestampPtr(row.DeletedAt),
-		CreatedBy:         row.CreatedBy,
-		ExcludedModels:    excluded,
-		ExcludedProviders: excludedProviders,
+		ID:                   row.ID.String(),
+		ExternalID:           row.ExternalID,
+		Name:                 row.Name,
+		CreatedAt:            timestampOrZero(row.CreatedAt),
+		UpdatedAt:            timestampOrZero(row.UpdatedAt),
+		DeletedAt:            timestampPtr(row.DeletedAt),
+		CreatedBy:            row.CreatedBy,
+		ExcludedModels:       excluded,
+		ExcludedProviders:    excludedProviders,
+		RoutingQualityWeight: row.RoutingQualityWeight,
 	}
 }
 

--- a/internal/postgres/converters_test.go
+++ b/internal/postgres/converters_test.go
@@ -1,0 +1,32 @@
+package postgres
+
+import (
+	"testing"
+
+	"workweave/router/internal/sqlc"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestToAuthInstallationRoutingQualityWeight(t *testing.T) {
+	t.Run("set weight maps to pointer", func(t *testing.T) {
+		quality := 0.7
+		inst := toAuthInstallation(sqlc.RouterModelRouterInstallation{
+			ID:                   uuid.New(),
+			ExternalID:           "org-1",
+			RoutingQualityWeight: &quality,
+		})
+		require.NotNil(t, inst.RoutingQualityWeight)
+		assert.Equal(t, 0.7, *inst.RoutingQualityWeight)
+	})
+
+	t.Run("null weight maps to nil", func(t *testing.T) {
+		inst := toAuthInstallation(sqlc.RouterModelRouterInstallation{
+			ID:         uuid.New(),
+			ExternalID: "org-2",
+		})
+		assert.Nil(t, inst.RoutingQualityWeight)
+	})
+}

--- a/internal/postgres/repository.go
+++ b/internal/postgres/repository.go
@@ -122,6 +122,19 @@ func (r *installationRepo) UpdateExcludedProviders(ctx context.Context, external
 	})
 }
 
+func (r *installationRepo) UpdateRoutingPreference(ctx context.Context, externalID, id string, qualityWeight *float64) error {
+	parsed, err := uuid.Parse(id)
+	if err != nil {
+		return err
+	}
+	q := sqlc.New(r.tx)
+	return q.UpdateModelRouterInstallationRoutingPreference(ctx, sqlc.UpdateModelRouterInstallationRoutingPreferenceParams{
+		ID:                   parsed,
+		ExternalID:           externalID,
+		RoutingQualityWeight: qualityWeight,
+	})
+}
+
 type apiKeyRepo struct {
 	tx sqlc.DBTX
 }

--- a/internal/proxy/routing_knobs_internal_test.go
+++ b/internal/proxy/routing_knobs_internal_test.go
@@ -1,0 +1,40 @@
+package proxy
+
+import (
+	"context"
+	"testing"
+
+	"workweave/router/internal/router"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRoutingKnobsForRequest(t *testing.T) {
+	ptr := func(f float64) *float64 { return &f }
+
+	t.Run("nil when neither header nor installation knobs present", func(t *testing.T) {
+		assert.Nil(t, routingKnobsForRequest(context.Background()))
+	})
+
+	t.Run("installation knobs apply when no header override", func(t *testing.T) {
+		ctx := context.WithValue(context.Background(), InstallationRoutingKnobsContextKey{}, &router.Overrides{
+			Alpha: ptr(0.6),
+		})
+		got := routingKnobsForRequest(ctx)
+		require.NotNil(t, got)
+		require.NotNil(t, got.Alpha)
+		assert.Equal(t, 0.6, *got.Alpha)
+	})
+
+	t.Run("header override wins over installation knobs", func(t *testing.T) {
+		ctx := context.WithValue(context.Background(), InstallationRoutingKnobsContextKey{}, &router.Overrides{
+			Alpha: ptr(0.6),
+		})
+		ctx = router.WithRoutingKnobs(ctx, &router.Overrides{Alpha: ptr(0.95)})
+		got := routingKnobsForRequest(ctx)
+		require.NotNil(t, got)
+		require.NotNil(t, got.Alpha)
+		assert.Equal(t, 0.95, *got.Alpha)
+	})
+}

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -219,6 +219,13 @@ type InstallationExcludedModelsContextKey struct{}
 // installation's provider exclusion list. Carried as []string.
 type InstallationExcludedProvidersContextKey struct{}
 
+// InstallationRoutingKnobsContextKey is the context key for the authed
+// installation's persisted routing preference (the "quality vs price" dial).
+// Carried as *router.Overrides with only Alpha (quality weight) set; the
+// per-request x-weave-routing-* header override takes precedence over it. See
+// routingKnobsForRequest.
+type InstallationRoutingKnobsContextKey struct{}
+
 // installationExcludedModelsFromContext returns the per-installation exclusion
 // list stashed on ctx by the auth middleware, or nil when none is present.
 
@@ -315,6 +322,20 @@ func installationExcludedModelsFromContext(ctx context.Context) []string {
 	}
 	out, _ := v.([]string)
 	return out
+}
+
+// routingKnobsForRequest resolves the routing knobs for a request. The
+// per-request x-weave-routing-* header override (used by the eval harness)
+// wins; otherwise the authed installation's persisted preference applies;
+// otherwise nil leaves the scorer on its tuned bundle defaults.
+func routingKnobsForRequest(ctx context.Context) *router.Overrides {
+	if k := router.RoutingKnobsFromContext(ctx); k != nil {
+		return k
+	}
+	if v, ok := ctx.Value(InstallationRoutingKnobsContextKey{}).(*router.Overrides); ok {
+		return v
+	}
+	return nil
 }
 
 // excludedModelsForRequest returns the request's model exclusion set.
@@ -1297,7 +1318,7 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 		PromptText:           promptText,
 		EnabledProviders:     enabledProviders,
 		ExcludedModels:       excluded,
-		RoutingKnobs:         router.RoutingKnobsFromContext(ctx),
+		RoutingKnobs:         routingKnobsForRequest(ctx),
 	})
 	if routeErr != nil {
 		log.Error("Routing failed", "err", routeErr, "route_ms", time.Since(routeStart).Milliseconds(), "requested_model", feats.Model, "total_input_tokens", feats.Tokens)
@@ -2653,7 +2674,7 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 		PromptText:           promptText,
 		EnabledProviders:     enabledProviders,
 		ExcludedModels:       excludedOAI,
-		RoutingKnobs:         router.RoutingKnobsFromContext(ctx),
+		RoutingKnobs:         routingKnobsForRequest(ctx),
 	})
 	routeMs := time.Since(routeStart).Milliseconds()
 	if err != nil {

--- a/internal/server/middleware/auth.go
+++ b/internal/server/middleware/auth.go
@@ -9,6 +9,7 @@ import (
 	"workweave/router/internal/auth"
 	"workweave/router/internal/observability"
 	"workweave/router/internal/proxy"
+	"workweave/router/internal/router"
 
 	"github.com/gin-gonic/gin"
 )
@@ -108,6 +109,11 @@ func withAPIKey(svc *auth.Service, byokDisabled bool) gin.HandlerFunc {
 			}
 			if len(installation.ExcludedProviders) > 0 {
 				ctx = context.WithValue(ctx, proxy.InstallationExcludedProvidersContextKey{}, installation.ExcludedProviders)
+			}
+			if installation.RoutingQualityWeight != nil {
+				ctx = context.WithValue(ctx, proxy.InstallationRoutingKnobsContextKey{}, &router.Overrides{
+					Alpha: installation.RoutingQualityWeight,
+				})
 			}
 		}
 		if externalKeys != nil && !byokDisabled {

--- a/internal/server/middleware/auth_test.go
+++ b/internal/server/middleware/auth_test.go
@@ -107,6 +107,10 @@ func (fakeInstallationRepository) UpdateExcludedProviders(ctx context.Context, e
 	return errors.New("not used")
 }
 
+func (fakeInstallationRepository) UpdateRoutingPreference(ctx context.Context, externalID, id string, qualityWeight *float64) error {
+	return errors.New("not used")
+}
+
 func TestWithAuthPrefersRouterKeyHeader(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	const routerToken = "rk_router"

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -110,6 +110,8 @@ func Register(engine *gin.Engine, authSvc *auth.Service, proxySvc *proxy.Service
 		mgmt.POST("/provider-keys", admin.UpsertExternalKeyHandler(authSvc))
 		mgmt.DELETE("/provider-keys/:id", admin.DeleteExternalKeyHandler(authSvc))
 		mgmt.GET("/config", admin.ConfigHandler)
+		mgmt.GET("/routing-preferences", admin.GetRoutingPreferencesHandler(authSvc))
+		mgmt.PUT("/routing-preferences", admin.UpdateRoutingPreferencesHandler(authSvc))
 		if deployedModels != nil {
 			mgmt.GET("/excluded-models", admin.GetExcludedModelsHandler(authSvc, deployedModels, proxySvc))
 			mgmt.PUT("/excluded-models", admin.UpdateExcludedModelsHandler(authSvc, deployedModels, proxySvc))

--- a/internal/sqlc/model_router_api_keys.sql.go
+++ b/internal/sqlc/model_router_api_keys.sql.go
@@ -92,7 +92,7 @@ func (q *Queries) CreateModelRouterAPIKey(ctx context.Context, arg CreateModelRo
 }
 
 const getActiveModelRouterAPIKeyWithInstallationByHash = `-- name: GetActiveModelRouterAPIKeyWithInstallationByHash :one
-SELECT k.id, k.installation_id, k.external_id, k.name, k.key_prefix, k.key_hash, k.key_suffix, k.last_used_at, k.created_at, k.deleted_at, k.created_by, i.id, i.external_id, i.name, i.created_at, i.updated_at, i.deleted_at, i.created_by, i.excluded_models, i.excluded_providers
+SELECT k.id, k.installation_id, k.external_id, k.name, k.key_prefix, k.key_hash, k.key_suffix, k.last_used_at, k.created_at, k.deleted_at, k.created_by, i.id, i.external_id, i.name, i.created_at, i.updated_at, i.deleted_at, i.created_by, i.excluded_models, i.excluded_providers, i.routing_quality_weight
 FROM router.model_router_api_keys k
 INNER JOIN router.model_router_installations i ON i.id = k.installation_id
 WHERE k.key_hash = $1::varchar
@@ -111,7 +111,7 @@ type GetActiveModelRouterAPIKeyWithInstallationByHashRow struct {
 // both sides so a soft-deleted installation invalidates all its keys without per-key
 // updates.
 //
-//	SELECT k.id, k.installation_id, k.external_id, k.name, k.key_prefix, k.key_hash, k.key_suffix, k.last_used_at, k.created_at, k.deleted_at, k.created_by, i.id, i.external_id, i.name, i.created_at, i.updated_at, i.deleted_at, i.created_by, i.excluded_models, i.excluded_providers
+//	SELECT k.id, k.installation_id, k.external_id, k.name, k.key_prefix, k.key_hash, k.key_suffix, k.last_used_at, k.created_at, k.deleted_at, k.created_by, i.id, i.external_id, i.name, i.created_at, i.updated_at, i.deleted_at, i.created_by, i.excluded_models, i.excluded_providers, i.routing_quality_weight
 //	FROM router.model_router_api_keys k
 //	INNER JOIN router.model_router_installations i ON i.id = k.installation_id
 //	WHERE k.key_hash = $1::varchar
@@ -141,6 +141,7 @@ func (q *Queries) GetActiveModelRouterAPIKeyWithInstallationByHash(ctx context.C
 		&i.RouterModelRouterInstallation.CreatedBy,
 		&i.RouterModelRouterInstallation.ExcludedModels,
 		&i.RouterModelRouterInstallation.ExcludedProviders,
+		&i.RouterModelRouterInstallation.RoutingQualityWeight,
 	)
 	return i, err
 }

--- a/internal/sqlc/model_router_installations.sql.go
+++ b/internal/sqlc/model_router_installations.sql.go
@@ -22,7 +22,7 @@ VALUES (
     $2::varchar,
     $3
 )
-RETURNING id, external_id, name, created_at, updated_at, deleted_at, created_by, excluded_models, excluded_providers
+RETURNING id, external_id, name, created_at, updated_at, deleted_at, created_by, excluded_models, excluded_providers, routing_quality_weight
 `
 
 type CreateModelRouterInstallationParams struct {
@@ -43,7 +43,7 @@ type CreateModelRouterInstallationParams struct {
 //	    $2::varchar,
 //	    $3
 //	)
-//	RETURNING id, external_id, name, created_at, updated_at, deleted_at, created_by, excluded_models, excluded_providers
+//	RETURNING id, external_id, name, created_at, updated_at, deleted_at, created_by, excluded_models, excluded_providers, routing_quality_weight
 func (q *Queries) CreateModelRouterInstallation(ctx context.Context, arg CreateModelRouterInstallationParams) (RouterModelRouterInstallation, error) {
 	row := q.db.QueryRow(ctx, createModelRouterInstallation, arg.ExternalID, arg.Name, arg.CreatedBy)
 	var i RouterModelRouterInstallation
@@ -57,12 +57,13 @@ func (q *Queries) CreateModelRouterInstallation(ctx context.Context, arg CreateM
 		&i.CreatedBy,
 		&i.ExcludedModels,
 		&i.ExcludedProviders,
+		&i.RoutingQualityWeight,
 	)
 	return i, err
 }
 
 const getModelRouterInstallation = `-- name: GetModelRouterInstallation :one
-SELECT id, external_id, name, created_at, updated_at, deleted_at, created_by, excluded_models, excluded_providers
+SELECT id, external_id, name, created_at, updated_at, deleted_at, created_by, excluded_models, excluded_providers, routing_quality_weight
 FROM router.model_router_installations
 WHERE id = $1::uuid
   AND external_id = $2::varchar
@@ -76,7 +77,7 @@ type GetModelRouterInstallationParams struct {
 
 // Gets an installation by id, scoped to an external_id to prevent cross-tenant access.
 //
-//	SELECT id, external_id, name, created_at, updated_at, deleted_at, created_by, excluded_models, excluded_providers
+//	SELECT id, external_id, name, created_at, updated_at, deleted_at, created_by, excluded_models, excluded_providers, routing_quality_weight
 //	FROM router.model_router_installations
 //	WHERE id = $1::uuid
 //	  AND external_id = $2::varchar
@@ -94,12 +95,13 @@ func (q *Queries) GetModelRouterInstallation(ctx context.Context, arg GetModelRo
 		&i.CreatedBy,
 		&i.ExcludedModels,
 		&i.ExcludedProviders,
+		&i.RoutingQualityWeight,
 	)
 	return i, err
 }
 
 const listModelRouterInstallationsForExternalID = `-- name: ListModelRouterInstallationsForExternalID :many
-SELECT id, external_id, name, created_at, updated_at, deleted_at, created_by, excluded_models, excluded_providers
+SELECT id, external_id, name, created_at, updated_at, deleted_at, created_by, excluded_models, excluded_providers, routing_quality_weight
 FROM router.model_router_installations
 WHERE external_id = $1::varchar
   AND deleted_at IS NULL
@@ -108,7 +110,7 @@ ORDER BY created_at DESC
 
 // ListModelRouterInstallationsForExternalID
 //
-//	SELECT id, external_id, name, created_at, updated_at, deleted_at, created_by, excluded_models, excluded_providers
+//	SELECT id, external_id, name, created_at, updated_at, deleted_at, created_by, excluded_models, excluded_providers, routing_quality_weight
 //	FROM router.model_router_installations
 //	WHERE external_id = $1::varchar
 //	  AND deleted_at IS NULL
@@ -132,6 +134,7 @@ func (q *Queries) ListModelRouterInstallationsForExternalID(ctx context.Context,
 			&i.CreatedBy,
 			&i.ExcludedModels,
 			&i.ExcludedProviders,
+			&i.RoutingQualityWeight,
 		); err != nil {
 			return nil, err
 		}
@@ -225,5 +228,35 @@ type UpdateModelRouterInstallationExcludedProvidersParams struct {
 //	  AND deleted_at IS NULL
 func (q *Queries) UpdateModelRouterInstallationExcludedProviders(ctx context.Context, arg UpdateModelRouterInstallationExcludedProvidersParams) error {
 	_, err := q.db.Exec(ctx, updateModelRouterInstallationExcludedProviders, arg.ExcludedProviders, arg.ID, arg.ExternalID)
+	return err
+}
+
+const updateModelRouterInstallationRoutingPreference = `-- name: UpdateModelRouterInstallationRoutingPreference :exec
+UPDATE router.model_router_installations
+SET routing_quality_weight = $1,
+    updated_at = NOW()
+WHERE id = $2::uuid
+  AND external_id = $3::varchar
+  AND deleted_at IS NULL
+`
+
+type UpdateModelRouterInstallationRoutingPreferenceParams struct {
+	RoutingQualityWeight *float64
+	ID                   uuid.UUID
+	ExternalID           string
+}
+
+// Sets the routing preference quality weight (a normalized fraction in [0, 1]),
+// scoped to an external_id to prevent cross-tenant updates. NULL clears the
+// preference so the scorer reverts to its tuned defaults.
+//
+//	UPDATE router.model_router_installations
+//	SET routing_quality_weight = $1,
+//	    updated_at = NOW()
+//	WHERE id = $2::uuid
+//	  AND external_id = $3::varchar
+//	  AND deleted_at IS NULL
+func (q *Queries) UpdateModelRouterInstallationRoutingPreference(ctx context.Context, arg UpdateModelRouterInstallationRoutingPreferenceParams) error {
+	_, err := q.db.Exec(ctx, updateModelRouterInstallationRoutingPreference, arg.RoutingQualityWeight, arg.ID, arg.ExternalID)
 	return err
 }

--- a/internal/sqlc/models.go
+++ b/internal/sqlc/models.go
@@ -66,15 +66,16 @@ type RouterModelRouterExternalAPIKey struct {
 
 // Customer router installations; owns API keys
 type RouterModelRouterInstallation struct {
-	ID                uuid.UUID
-	ExternalID        string
-	Name              string
-	CreatedAt         pgtype.Timestamp
-	UpdatedAt         pgtype.Timestamp
-	DeletedAt         pgtype.Timestamp
-	CreatedBy         *string
-	ExcludedModels    []string
-	ExcludedProviders []string
+	ID                   uuid.UUID
+	ExternalID           string
+	Name                 string
+	CreatedAt            pgtype.Timestamp
+	UpdatedAt            pgtype.Timestamp
+	DeletedAt            pgtype.Timestamp
+	CreatedBy            *string
+	ExcludedModels       []string
+	ExcludedProviders    []string
+	RoutingQualityWeight *float64
 }
 
 type RouterModelRouterRequestTelemetry struct {


### PR DESCRIPTION
## What

A per-installation **quality vs price routing dial** — the user-facing "alpha knob" — plumbed end-to-end on the router side, with both control surfaces:

- **Managed (Weave SaaS):** the WorkWeave control plane writes the new column directly (separate WorkWeave PR, gated on this merge).
- **Self-hosted:** the router's own dashboard + `/admin/v1/routing-preferences` API edit it.

**Speed is intentionally not a user dial.** It was in an earlier draft of this PR; it's been dropped. The scorer's `SpeedWeight` stays on its tuned per-cluster default — only the quality/price tradeoff is exposed to people.

## How it maps to the scorer

The V2 scorer blends weights per candidate: `wQ` (quality, = per-cluster `Alpha`), `wS` (`SpeedWeight`), `wC` (cost). The dial feeds quality directly:

- `routing_quality_weight` → `Overrides.Alpha`
- price → the scorer's implied remainder
- `SpeedWeight` is untouched (no override emitted), so the existing `Alpha + SpeedWeight ≤ 1` validation always holds.

## Commit 1 — data path + column

- **migration 0025**: nullable `routing_quality_weight` on `model_router_installations`. **NULL = no preference** → scorer keeps its tuned per-cluster defaults.
- hydrate onto `auth.Installation` (carried by the API-key cache via `sqlc.embed`); map in the postgres converter.
- stash on request context in `withAPIKey`; apply in the proxy via `routingKnobsForRequest` (header `x-weave-routing-*` override still wins).
- write path: `UpdateModelRouterInstallationRoutingPreference` + repo method + `auth.Service.SetInstallationRoutingPreference` (invalidates the API-key cache + NOTIFYs peers, same as excluded-models writes).

## Commit 2 — self-hosted control surface

- `/admin/v1/routing-preferences` GET/PUT (selfhosted-only, in the `WithAdminOnly` mgmt group), normalizing raw slider values into a quality weight; `reset` clears the preference.
- dashboard **Routing priority** panel: a single Quality↔Price slider + live normalized bar, Save / Reset to default.

## Tests

- converter NULL/value mapping; proxy precedence (header > installation > none); admin normalize/render helpers; `auth.Service` write-through + cache invalidation
- `sqlc generate` output committed; `go build ./...` + full `go test ./...` green; dashboard `tsc --noEmit` clean

## Rollout

The column is additive and nullable — safe to deploy before the WorkWeave side. The WorkWeave gitlink bump + managed settings UI land in a follow-up WorkWeave PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)