### PR TITLE
feat(proxy): add x-weave-force-model header (headless /force-model)

### DIFF
--- a/internal/proxy/force_model.go
+++ b/internal/proxy/force_model.go
@@ -18,6 +18,16 @@ import (
 	"github.com/google/uuid"
 )
 
+// ForceModelHeader pins the session to a specific model, mirroring the
+// /force-model chat command. The header form exists so the directive is usable
+// from headless clients (the eval harness, CI smoke runs) where the slash
+// command is unreliable: Claude Code eats "/force-model …" as a client-side
+// slash command before it ever reaches the router, and a typed two-call pin
+// consumes a turn. A header rides on every request, so the pin is (re)written
+// and served on the same turn. Empty or unrecognized values are ignored and
+// routing proceeds automatically rather than failing the request.
+const ForceModelHeader = "x-weave-force-model"
+
 var forceModelAliases = map[string]string{
 	"anthropic":      "claude-opus-4-8",
 	"claude":         "claude-opus-4-8",
@@ -122,6 +132,89 @@ func resolveForceModel(model string) (canonicalID, provider string, known bool) 
 	}
 }
 
+// setForceModelPin upserts an immutable user-forced session pin for the given
+// session/role. It preserves the prior pin's LastServedModel so the next turn
+// can still detect a mid-session model switch and strip stale Anthropic
+// thinking-block signatures. No-op when the pin store is unconfigured or
+// installationID is nil (pin rows require an installation_id).
+func (s *Service) setForceModelPin(
+	ctx context.Context,
+	sessionKey [sessionpin.SessionKeyLen]byte,
+	role string,
+	installationID uuid.UUID,
+	canonicalModel, provider string,
+) error {
+	if s.pinStore == nil || installationID == uuid.Nil {
+		return nil
+	}
+	log := observability.FromContext(ctx)
+	var lastServedModel string
+	existing, found, err := s.pinStore.Get(ctx, sessionKey, role)
+	if err != nil {
+		log.Error("force-model: prior pin lookup failed", "err", err)
+	} else if found {
+		lastServedModel = existing.LastServedModel
+	}
+	forced := sessionpin.Pin{
+		SessionKey:      sessionKey,
+		Role:            role,
+		InstallationID:  installationID,
+		Provider:        provider,
+		Model:           canonicalModel,
+		Reason:          translate.ReasonUserForceModel,
+		TurnCount:       1,
+		PinnedUntil:     time.Now().Add(pinSessionTTL),
+		LastServedModel: lastServedModel,
+	}
+	// context.Background(): the request ctx may already be canceled by the time
+	// this runs (synthetic response written, or client disconnected). Upserting
+	// on a canceled context would leave Postgres holding the prior pin.
+	return s.pinStore.Upsert(context.Background(), forced)
+}
+
+// applyForceModelHeader honors the x-weave-force-model request header by writing
+// a user-forced session pin, the same sticky the /force-model command writes.
+// The pin is (re)written on every request that carries the header, so the turn
+// loop's user-forced branch serves the requested model on this turn and stays on
+// it for the session. Unrecognized models are ignored (routing proceeds
+// automatically); the request is never failed on a bad header value.
+func (s *Service) applyForceModelHeader(
+	ctx context.Context,
+	r *http.Request,
+	env *translate.RequestEnvelope,
+	installationID uuid.UUID,
+	sessionKey [sessionpin.SessionKeyLen]byte,
+) {
+	if s.pinStore == nil {
+		return
+	}
+	raw := strings.TrimSpace(r.Header.Get(ForceModelHeader))
+	if raw == "" {
+		return
+	}
+	log := observability.FromContext(ctx)
+	canonicalModel, provider, known := resolveForceModel(raw)
+	if !known {
+		log.Info("x-weave-force-model: ignoring unrecognized model; routing automatically",
+			"input_model", raw,
+			"session_key_hex", fmt.Sprintf("%x", sessionKey),
+		)
+		return
+	}
+	role := roleForTier(catalog.TierFor(env.Model()))
+	if err := s.setForceModelPin(ctx, sessionKey, role, installationID, canonicalModel, provider); err != nil {
+		log.Error("x-weave-force-model: pin store upsert failed", "err", err)
+		return
+	}
+	log.Info("x-weave-force-model applied",
+		"input_model", raw,
+		"canonical_model", canonicalModel,
+		"provider", provider,
+		"session_key_hex", fmt.Sprintf("%x", sessionKey),
+		"role", role,
+	)
+}
+
 // handleForceModelCommand processes a /force-model or /unforce-model directive.
 // It writes (or expires) the session pin and returns a synthetic Anthropic-format
 // acknowledgment response without dispatching to any upstream.
@@ -191,34 +284,9 @@ func (s *Service) handleForceModelCommand(
 			msg = fmt.Sprintf("Weave Router: force-model: %q isn't a recognized model; keeping automatic routing. Use a full model id, e.g. claude-opus-4-8, gpt-5.5, or gemini-3-pro-preview.", cmd.Model)
 		}
 	} else {
-		// Preserve LastServedModel from the prior pin so the next turn can still
-		// detect a model switch and strip stale Anthropic thinking-block
-		// signatures. Without this carry-forward, the full Pin replacement here
-		// would zero out LastServedModel, defeating the /force-model switch detection.
-		var lastServedModel string
-		if s.pinStore != nil {
-			if existing, found, err := s.pinStore.Get(ctx, sessionKey, role); err != nil {
-				log.Error("/force-model: prior pin lookup failed", "err", err)
-			} else if found {
-				lastServedModel = existing.LastServedModel
-			}
-		}
-		forced := sessionpin.Pin{
-			SessionKey:      sessionKey,
-			Role:            role,
-			InstallationID:  installationID,
-			Provider:        provider,
-			Model:           canonicalModel,
-			Reason:          translate.ReasonUserForceModel,
-			TurnCount:       1,
-			PinnedUntil:     time.Now().Add(pinSessionTTL),
-			LastServedModel: lastServedModel,
-		}
-		if s.pinStore != nil && installationID != uuid.Nil {
-			if err := s.pinStore.Upsert(context.Background(), forced); err != nil {
-				log.Error("/force-model: pin store upsert failed", "err", err)
-				return err
-			}
+		if err := s.setForceModelPin(ctx, sessionKey, role, installationID, canonicalModel, provider); err != nil {
+			log.Error("/force-model: pin store upsert failed", "err", err)
+			return err
 		}
 		msg = fmt.Sprintf("✦ **Weave Router** → force-model applied: %s (%s) · use /unforce-model to clear\n\n", canonicalModel, provider)
 		if env.SourceFormat() == translate.FormatOpenAI {

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -818,6 +818,11 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 		}
 	}
 
+	// Honor the x-weave-force-model header (headless equivalent of /force-model).
+	// Writes the user-forced pin and falls through to normal routing, which picks
+	// the pin up and serves the requested model on this same turn.
+	s.applyForceModelHeader(ctx, r, env, installationID, sessionKey)
+
 	// Tool-call loop break: when the same (tool_name, args) appears at least
 	// loopDetectionMaxRepeats times in the last loopDetectionWindowSize
 	// assistant turns, synthesize end_turn and expire the session pin. Catches
@@ -1835,6 +1840,11 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 			return s.handleForceModelCommand(ctx, w, env, cmd, installationID, sessionKey)
 		}
 	}
+
+	// Honor the x-weave-force-model header (headless equivalent of /force-model).
+	// Writes the user-forced pin and falls through to normal routing, which picks
+	// the pin up and serves the requested model on this same turn.
+	s.applyForceModelHeader(ctx, r, env, installationID, sessionKey)
 
 	// Tool-call loop break: same path as the Anthropic ingress. See the
 	// detectToolCallLoop / handleToolCallLoopBreak doc comments for rationale.

--- a/internal/proxy/service_session_pin_test.go
+++ b/internal/proxy/service_session_pin_test.go
@@ -1033,3 +1033,53 @@ func TestService_UserForcedPin_IneligibleProviderFallsThrough(t *testing.T) {
 	assert.Equal(t, 1, fr.routeCalls, "ineligible-provider forced pin must fall through to the scorer")
 	assert.Equal(t, "claude-haiku-4-5", rec.Header().Get(proxy.HeaderRouterModel), "must dispatch to the eligible provider, not gpt-5/openai")
 }
+
+// The x-weave-force-model header is the headless equivalent of /force-model:
+// it must write an immutable user_forced pin for the alias-resolved canonical
+// model so the turn loop's user-forced branch serves it for the session.
+func TestService_ForceModelHeader_WritesUserForcedPin(t *testing.T) {
+	store := newFakePinStore()
+	fr := &fakeRouter{decision: router.Decision{Provider: providers.ProviderAnthropic, Model: "claude-haiku-4-5", Reason: "fresh"}}
+	svc := newPinSvc(fr, store)
+
+	ctx := authedCtx(uuid.New().String())
+	rec := httptest.NewRecorder()
+	httpReq := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(""))
+	httpReq.Header.Set(proxy.ForceModelHeader, "opus")
+	require.NoError(t, svc.ProxyMessages(ctx, []byte(pinTestBody), rec, httpReq))
+
+	store.mu.Lock()
+	defer store.mu.Unlock()
+	var forced *sessionpin.Pin
+	for i := range store.upserts {
+		if store.upserts[i].Reason == translate.ReasonUserForceModel {
+			forced = &store.upserts[i]
+			break
+		}
+	}
+	require.NotNil(t, forced, "header must write a user_forced pin upsert")
+	assert.Equal(t, "claude-opus-4-8", forced.Model, "alias 'opus' resolves to the canonical id")
+	assert.Equal(t, providers.ProviderAnthropic, forced.Provider)
+}
+
+// An unrecognized x-weave-force-model value must be ignored: routing proceeds
+// automatically and no user_forced pin is written, so a typo can't strand a
+// session on an unservable directive.
+func TestService_ForceModelHeader_UnknownModelIgnored(t *testing.T) {
+	store := newFakePinStore()
+	fr := &fakeRouter{decision: router.Decision{Provider: providers.ProviderAnthropic, Model: "claude-haiku-4-5", Reason: "fresh"}}
+	svc := newPinSvc(fr, store)
+
+	ctx := authedCtx(uuid.New().String())
+	rec := httptest.NewRecorder()
+	httpReq := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(""))
+	httpReq.Header.Set(proxy.ForceModelHeader, "totally-not-a-model")
+	require.NoError(t, svc.ProxyMessages(ctx, []byte(pinTestBody), rec, httpReq))
+
+	waitForUpsert(t, store) // normal routing still writes a fresh pin
+	store.mu.Lock()
+	defer store.mu.Unlock()
+	for _, p := range store.upserts {
+		assert.NotEqual(t, translate.ReasonUserForceModel, p.Reason, "unrecognized header must not write a user_forced pin")
+	}
+}


### PR DESCRIPTION
## What

Exposes the existing `/force-model` feature as a request header: `x-weave-force-model: <model>`.

## Why

The `/force-model` slash command is unusable from headless clients (the eval harness, CI smoke runs):
- Claude Code eats `/force-model …` as a client-side slash command before it ever reaches the router.
- A typed two-call pin is session-scoped and consumes a turn, making it unreliable to drive programmatically.

A header rides on **every** request, so the `user_forced` pin is (re)written and served on the **same** turn — which is exactly what headless testing needs.

## How

- Reuses the existing `resolveForceModel` alias table (`opus`, `gpt`, `sonnet`, full ids, slash forms) and the existing **`user_forced` session-pin** mechanism — **not** a new direct-model bypass. The turn loop's existing immutable-sticky branch serves it and keeps all its invariants (tier-clamp handling, provider eligibility, exclusion policy).
- Pin-writing extracted into `setForceModelPin` so the header path and the `/force-model` command path can't drift.
- Applied to both `ProxyMessages` (Anthropic) and `ProxyOpenAIChatCompletion` (OpenAI), matching the command's format coverage.
- Unrecognized values are **ignored** (logged, routing proceeds automatically) rather than failing the request — a typo can't strand a session on an unservable directive.

## Tests

- `TestService_ForceModelHeader_WritesUserForcedPin` — header writes a `user_forced` pin for the alias-resolved canonical model.
- `TestService_ForceModelHeader_UnknownModelIgnored` — unrecognized value writes no `user_forced` pin.

`go build`, `go vet`, proxy + translate suites all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)