### PR TITLE
fix(proxy): preserve full history on handover failure instead of trim-to-3

### DIFF
--- a/internal/proxy/AGENTS.md
+++ b/internal/proxy/AGENTS.md
@@ -35,7 +35,7 @@ The per-turn flow is more than "scorer → dispatch". Pinned session, planner ve
 | Semantic response cache | [`../router/cache`](../router/cache) | Cross-request, non-streaming only |
 | Anthropic usage-bypass gate | [`usage`](usage) | See [`usage/CLAUDE.md`](usage/CLAUDE.md) |
 
-The provider-backed `Summarizer` implementation for handover lives in [`handover.go`](handover.go); the inner-ring `handover` package only defines the contract. On summarizer timeout or error, proxy falls back to `handover.TrimLastN`.
+The provider-backed `Summarizer` implementation for handover lives in [`handover.go`](handover.go); the inner-ring `handover` package only defines the contract. On summarizer timeout or error, proxy keeps the full prior history unchanged (it does **not** trim) — a pricier switch turn beats silently dropping the conversation the switched-to model needs.
 
 ## Translation
 
@@ -68,5 +68,5 @@ Provider adapters call back into `proxy.OnUpstreamMeta` so streaming responses r
 ## What NOT to do
 
 - **Don't move provider-call logic into planner.** Planner must remain pure so EV math is provable. Anything network-touching goes in `proxy.Service`.
-- **Don't add a handover path that doesn't time out.** `Summarizer` contract says implementations MUST respect the context deadline. Falling back to `TrimLastN` on timeout is correct, not a bug.
+- **Don't add a handover path that doesn't time out.** `Summarizer` contract says implementations MUST respect the context deadline. On timeout/error the proxy keeps the full prior history unchanged — do NOT reintroduce a silent trim-to-last-N fallback (it lobotomized switched-to models; see the handover-fallback fix).
 - **Don't cache streaming responses.** Streaming bypasses cache on purpose — captured bytes would be post-translation SSE frames, and lookup latency budget is hostile to first-token-time. If you think this should change, write a doc first.

--- a/internal/proxy/CLAUDE.md
+++ b/internal/proxy/CLAUDE.md
@@ -35,7 +35,7 @@ The per-turn flow is more than "scorer → dispatch". Pinned session, planner ve
 | Semantic response cache | [`../router/cache`](../router/cache) | Cross-request, non-streaming only |
 | Anthropic usage-bypass gate | [`usage`](usage) | See [`usage/CLAUDE.md`](usage/CLAUDE.md) |
 
-The provider-backed `Summarizer` implementation for handover lives in [`handover.go`](handover.go); the inner-ring `handover` package only defines the contract. On summarizer timeout or error, proxy falls back to `handover.TrimLastN`.
+The provider-backed `Summarizer` implementation for handover lives in [`handover.go`](handover.go); the inner-ring `handover` package only defines the contract. On summarizer timeout or error, proxy keeps the full prior history unchanged (it does **not** trim) — a pricier switch turn beats silently dropping the conversation the switched-to model needs.
 
 ## Translation
 
@@ -68,5 +68,5 @@ Provider adapters call back into `proxy.OnUpstreamMeta` so streaming responses r
 ## What NOT to do
 
 - **Don't move provider-call logic into planner.** Planner must remain pure so EV math is provable. Anything network-touching goes in `proxy.Service`.
-- **Don't add a handover path that doesn't time out.** `Summarizer` contract says implementations MUST respect the context deadline. Falling back to `TrimLastN` on timeout is correct, not a bug.
+- **Don't add a handover path that doesn't time out.** `Summarizer` contract says implementations MUST respect the context deadline. On timeout/error the proxy keeps the full prior history unchanged — do NOT reintroduce a silent trim-to-last-N fallback (it lobotomized switched-to models; see the handover-fallback fix).
 - **Don't cache streaming responses.** Streaming bypasses cache on purpose — captured bytes would be post-translation SSE frames, and lookup latency budget is hostile to first-token-time. If you think this should change, write a doc first.

--- a/internal/proxy/handover.go
+++ b/internal/proxy/handover.go
@@ -90,7 +90,7 @@ var ErrEmptySummary = errors.New("handover: upstream returned no summary text")
 // dispatches through the configured client under a hard timeout. Returns the
 // summary text and the upstream usage breakdown so callers can debit the
 // summary as a separate ledger row. On failure returns ("", zero Usage, err)
-// so the caller can fall back to handover.TrimLastN.
+// so the caller can pass the full prior history through unchanged.
 func (s *ProviderSummarizer) Summarize(ctx context.Context, env *translate.RequestEnvelope) (string, handover.Usage, error) {
 	log := observability.FromContext(ctx)
 	if env == nil {
@@ -260,9 +260,11 @@ var _ handover.Summarizer = (*ProviderSummarizer)(nil)
 // lived only in those elided turns.
 //
 // Mirrors the model-switch handover in runTurnLoop: run the summarizer when
-// wired and credentials allow, fall back to TrimLastN on any error. Errors are
-// logged but never returned — a failed compaction rewrite is better than a
-// failed request; the model will at least see the compacted body.
+// wired and credentials allow, and on any failure pass the compacted body
+// through unchanged rather than trimming it. Errors are logged but never
+// returned — a failed compaction rewrite is better than a failed request, and
+// passing the full compacted body keeps Claude Code's own compaction summary
+// intact (trimming to the last few turns would discard it).
 // Returns a handoverOutcome so the caller can bill the summary upstream call.
 func (s *Service) runCompactionHandover(ctx context.Context, env *translate.RequestEnvelope, reqHeaders http.Header, decisionModel string) handoverOutcome {
 	log := observability.FromContext(ctx)
@@ -283,13 +285,11 @@ func (s *Service) runCompactionHandover(ctx context.Context, env *translate.Requ
 
 	switch {
 	case s.summarizer == nil:
-		elided := handover.TrimLastN(env, 3)
-		out.FallbackToTrim = true
-		log.Info("Compaction handover: summarizer not wired; trimmed instead", "elided_messages", elided, "decision_model", decisionModel)
+		out.FallbackToFullHistory = true
+		log.Info("Compaction handover: summarizer not wired; preserved compacted body instead", "decision_model", decisionModel)
 	case !canCallSummarizer:
-		elided := handover.TrimLastN(env, 3)
-		out.FallbackToTrim = true
-		log.Info("Compaction handover: summarizer skipped (tenant boundary); trimmed instead", "elided_messages", elided, "decision_model", decisionModel)
+		out.FallbackToFullHistory = true
+		log.Info("Compaction handover: summarizer skipped (tenant boundary); preserved compacted body instead", "decision_model", decisionModel)
 	default:
 		summCtx := ctx
 		if sumCreds != nil {
@@ -300,13 +300,11 @@ func (s *Service) runCompactionHandover(ctx context.Context, env *translate.Requ
 		out.LatencyMS = time.Since(start).Milliseconds()
 		switch {
 		case sumErr != nil:
-			elided := handover.TrimLastN(env, 3)
-			out.FallbackToTrim = true
-			log.Warn("Compaction handover: summarizer failed; trimmed instead", "err", sumErr, "elided_messages", elided, "decision_model", decisionModel)
+			out.FallbackToFullHistory = true
+			log.Warn("Compaction handover: summarizer failed; preserved compacted body instead", "err", sumErr, "decision_model", decisionModel)
 		case summary == "":
-			elided := handover.TrimLastN(env, 3)
-			out.FallbackToTrim = true
-			log.Warn("Compaction handover: summarizer returned empty; trimmed instead", "elided_messages", elided, "decision_model", decisionModel)
+			out.FallbackToFullHistory = true
+			log.Warn("Compaction handover: summarizer returned empty; preserved compacted body instead", "decision_model", decisionModel)
 		default:
 			handover.RewriteEnvelope(env, summary)
 			out.SummaryTokens = estimateSummaryTokens(summary)

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -87,7 +87,7 @@ type Service struct {
 	// back to first-decision-wins behavior.
 	plannerEnabled bool
 	// summarizer produces a bounded-cost handover summary on switch turns.
-	// nil falls straight to handover.TrimLastN.
+	// nil passes the full prior history through unchanged.
 	summarizer handover.Summarizer
 	// availableModels is the boot-time set of model names whose providers are
 	// registered. Read by the planner to decide whether a pin's model is still
@@ -368,7 +368,8 @@ func (s *Service) WithPlannerEnabled(enabled bool) *Service {
 }
 
 // WithSummarizer installs the cheap-model summarizer for handover on switch
-// turns. nil disables the summary step; TrimLastN is used instead.
+// turns. nil disables the summary step; the full prior history is passed
+// through unchanged.
 func (s *Service) WithSummarizer(sz handover.Summarizer) *Service {
 	s.summarizer = sz
 	return s
@@ -865,10 +866,10 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 	}
 
 	// Snapshot inbound tool-call count before runTurnLoop potentially mutates
-	// env (model-switch handover calls TrimLastN / RewriteForHandover). The
-	// compaction tracker must compare the count the client actually sent, not
-	// the post-router-trim count, to avoid false-positive detection when the
-	// router itself is the one that shortened the message window.
+	// env (model-switch handover may call RewriteForHandover). The compaction
+	// tracker must compare the count the client actually sent, not the
+	// post-rewrite count, to avoid false-positive detection when the router
+	// itself is the one that shortened the message window.
 	inboundToolCallCount := len(env.AssistantToolCallSignatures())
 
 	routeStart := time.Now()
@@ -1304,7 +1305,7 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 	// point on a real upstream call.
 	if proxyErr == nil {
 		s.emitBilling(ctx, requestID, externalID, decision, actPricing, routeRes, in, out, cacheCreation, cacheRead)
-		if compactionHandoverOutcome.Invoked && !compactionHandoverOutcome.FallbackToTrim {
+		if compactionHandoverOutcome.Invoked && !compactionHandoverOutcome.FallbackToFullHistory {
 			sumUsage := compactionHandoverOutcome.SummaryUsage
 			if sumUsage.Model != "" && (sumUsage.InputTokens > 0 || sumUsage.OutputTokens > 0) {
 				sumPricing, _ := catalog.PrimaryPriceFor(sumUsage.Model)
@@ -1351,7 +1352,7 @@ func applyPlannerAttrs(b *otel.AttrBuilder, res turnLoopResult) *otel.AttrBuilde
 		Bool("handover.invoked", res.Handover.Invoked).
 		Int64("handover.latency_ms", res.Handover.LatencyMS).
 		Int64("handover.summary_tokens", int64(res.Handover.SummaryTokens)).
-		Bool("handover.fallback_to_trim", res.Handover.FallbackToTrim)
+		Bool("handover.fallback_to_full_history", res.Handover.FallbackToFullHistory)
 	return b
 }
 
@@ -1387,7 +1388,7 @@ func (s *Service) logPlannerOutcome(ctx context.Context, res turnLoopResult) {
 			"threshold_usd", res.PlannerDecision.ThresholdUSD,
 			"pin_cache_warm", !res.PlannerDecision.PinCacheCold,
 			"handover_invoked", res.Handover.Invoked,
-			"handover_fallback_to_trim", res.Handover.FallbackToTrim,
+			"handover_fallback_to_full_history", res.Handover.FallbackToFullHistory,
 			"handover_latency_ms", res.Handover.LatencyMS,
 		)
 		return
@@ -1483,8 +1484,8 @@ func externalKeysFromContext(ctx context.Context) []*auth.ExternalAPIKey {
 // or client-supplied creds for upstream calls. The summarizer is wired with
 // deployment-level creds; calling it on a BYOK request would route prior
 // conversation context through the platform account, violating tenant data
-// boundaries. The orchestrator uses this to skip the summarizer and fall
-// through to TrimLastN.
+// boundaries. The orchestrator uses this to skip the summarizer and pass the
+// full prior history through unchanged.
 func (s *Service) requestUsesNonDeploymentCreds(ctx context.Context, headers http.Header) bool {
 	if s.byokOnly {
 		return true
@@ -1667,7 +1668,7 @@ func (s *Service) emitBilling(ctx context.Context, requestID, externalID string,
 		HasOverride:     hasOverride,
 	})
 
-	if routeRes.Handover.Invoked && !routeRes.Handover.FallbackToTrim {
+	if routeRes.Handover.Invoked && !routeRes.Handover.FallbackToFullHistory {
 		sumUsage := routeRes.Handover.SummaryUsage
 		if sumUsage.Model != "" && (sumUsage.InputTokens > 0 || sumUsage.OutputTokens > 0) {
 			sumPricing, _ := catalog.PrimaryPriceFor(sumUsage.Model)

--- a/internal/proxy/turnloop.go
+++ b/internal/proxy/turnloop.go
@@ -109,10 +109,15 @@ func (r turnLoopResult) modelSwitched() bool {
 
 // handoverOutcome describes the synchronous handover step.
 type handoverOutcome struct {
-	Invoked        bool
-	LatencyMS      int64
-	SummaryTokens  int
-	FallbackToTrim bool
+	Invoked       bool
+	LatencyMS     int64
+	SummaryTokens int
+	// FallbackToFullHistory is set when handover was invoked but no summary
+	// was applied (summarizer unwired, tenant-boundary skip, timeout, error,
+	// or empty summary). The original body is passed through unchanged rather
+	// than trimmed, so the model keeps full prior context. No summary ledger
+	// row is billed on this path.
+	FallbackToFullHistory bool
 	// SummaryUsage captures upstream token usage for the summarizer call
 	// so proxy.fireBilling can debit it as a separate ledger row with the
 	// "_summary" request_id suffix. Zero on fallback/error paths.
@@ -394,7 +399,9 @@ func (s *Service) runTurnLoop(
 	}
 
 	// Switch path: when switching off a warm cache, attempt bounded-cost
-	// handover. On summarizer error fall back to TrimLastN.
+	// handover. On any summarizer failure we keep the full prior history
+	// rather than trimming it — a more expensive switch turn is always
+	// preferable to silently dropping the conversation the new model needs.
 	//
 	// Privacy guard: the summarizer is wired with deployment-level creds.
 	// Routing a BYOK/client request's prior conversation through that
@@ -403,7 +410,8 @@ func (s *Service) runTurnLoop(
 	// caller forwarded them (BYOK or inbound Authorization/x-api-key for
 	// that provider) — that's the caller's own account, not the platform's.
 	// Only when the request is BYOK/client-keyed AND no matching creds for
-	// the summarizer's provider were forwarded do we skip and trim.
+	// the summarizer's provider were forwarded do we skip summarization and
+	// pass the full history through.
 	if pinFound {
 		var (
 			sumProvider       string
@@ -418,15 +426,13 @@ func (s *Service) runTurnLoop(
 		}
 		switch {
 		case s.summarizer == nil:
-			elided := handover.TrimLastN(env, 3)
 			res.Handover.Invoked = true
-			res.Handover.FallbackToTrim = true
-			log.Info("Handover summarizer not wired; trimmed envelope instead", "elided_messages", elided, "pin_model", pin.Model, "fresh_model", fresh.Model)
+			res.Handover.FallbackToFullHistory = true
+			log.Info("Handover summarizer not wired; preserved full history instead", "pin_model", pin.Model, "fresh_model", fresh.Model)
 		case !canCallSummarizer:
-			elided := handover.TrimLastN(env, 3)
 			res.Handover.Invoked = true
-			res.Handover.FallbackToTrim = true
-			log.Info("Handover summarizer skipped to preserve tenant boundary; trimmed envelope instead", "elided_messages", elided, "pin_model", pin.Model, "fresh_model", fresh.Model, "sum_provider", sumProvider)
+			res.Handover.FallbackToFullHistory = true
+			log.Info("Handover summarizer skipped to preserve tenant boundary; preserved full history instead", "pin_model", pin.Model, "fresh_model", fresh.Model, "sum_provider", sumProvider)
 		default:
 			summCtx := ctx
 			if sumCreds != nil {
@@ -438,13 +444,11 @@ func (s *Service) runTurnLoop(
 			res.Handover.LatencyMS = time.Since(start).Milliseconds()
 			switch {
 			case sumErr != nil:
-				elided := handover.TrimLastN(env, 3)
-				res.Handover.FallbackToTrim = true
-				log.Warn("Handover summarizer failed; trimmed envelope instead", "err", sumErr, "elided_messages", elided, "pin_model", pin.Model, "fresh_model", fresh.Model)
+				res.Handover.FallbackToFullHistory = true
+				log.Warn("Handover summarizer failed; preserved full history instead", "err", sumErr, "pin_model", pin.Model, "fresh_model", fresh.Model)
 			case summary == "":
-				elided := handover.TrimLastN(env, 3)
-				res.Handover.FallbackToTrim = true
-				log.Warn("Handover summarizer returned empty summary; trimmed envelope instead", "elided_messages", elided, "pin_model", pin.Model, "fresh_model", fresh.Model)
+				res.Handover.FallbackToFullHistory = true
+				log.Warn("Handover summarizer returned empty summary; preserved full history instead", "pin_model", pin.Model, "fresh_model", fresh.Model)
 			default:
 				handover.RewriteEnvelope(env, summary)
 				res.Handover.SummaryTokens = estimateSummaryTokens(summary)

--- a/internal/proxy/turnloop_test.go
+++ b/internal/proxy/turnloop_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
 )
 
 // fakeSummarizer is a deterministic handover.Summarizer for tests.
@@ -101,6 +102,51 @@ func largeBody(t *testing.T) []byte {
 		"system":"sys",
 		"messages":[{"role":"user","content":"` + prompt + `"}]
 	}`)
+}
+
+// largeMultiTurnBody yields a ~10k-token conversation of six non-system
+// messages so a trim-to-last-3 fallback would be observable: the forwarded
+// body would shrink from 6 messages to 3. Used to prove the handover failure
+// path preserves the full history rather than trimming it.
+func largeMultiTurnBody(t *testing.T) []byte {
+	t.Helper()
+	chunk := strings.Repeat("aaaa ", 1600) // ~2k tokens each
+	msgs := []string{
+		`{"role":"user","content":"FIRST-USER-MARKER ` + chunk + `"}`,
+		`{"role":"assistant","content":"` + chunk + `"}`,
+		`{"role":"user","content":"` + chunk + `"}`,
+		`{"role":"assistant","content":"` + chunk + `"}`,
+		`{"role":"user","content":"` + chunk + `"}`,
+		`{"role":"user","content":"latest question"}`,
+	}
+	return []byte(`{"model":"claude-opus-4-7","system":"sys","messages":[` + strings.Join(msgs, ",") + `]}`)
+}
+
+// forwardedMessageCount returns the number of messages in the body the
+// orchestrator forwarded to the upstream provider on its first Proxy call.
+func forwardedMessageCount(t *testing.T, p *fakeProvider) int {
+	t.Helper()
+	require.NotEmpty(t, p.proxyBodies, "upstream must have been called")
+	return int(gjson.GetBytes(p.proxyBodies[0], "messages.#").Int())
+}
+
+// newPinSvcCapturing mirrors newPinSvc but returns the upstream fakeProvider
+// so a test can inspect the body forwarded after handover.
+func newPinSvcCapturing(fr *fakeRouter, store *fakePinStore) (*proxy.Service, *fakeProvider) {
+	p := &fakeProvider{}
+	svc := proxy.NewService(
+		fr,
+		map[string]providers.Client{providers.ProviderAnthropic: p},
+		nil,
+		false,
+		nil,
+		store,
+		false,
+		providers.ProviderAnthropic,
+		"claude-haiku-4-5",
+		nil,
+	)
+	return svc, p
 }
 
 // TestTurnLoop_ToolResultWithPinSkipsScorerAndPlanner pins down the
@@ -198,10 +244,12 @@ func TestTurnLoop_PlannerSwitchesOnPositiveEV(t *testing.T) {
 	assert.Equal(t, "claude-haiku-4-5", last.Model, "switch must persist the new model on the pin")
 }
 
-// TestTurnLoop_SummarizerErrorFallsBackToTrim asserts the graceful-
-// degradation path: a summarizer error must not abort the request; the
-// orchestrator falls back to trim-last-N and proceeds with the switch.
-func TestTurnLoop_SummarizerErrorFallsBackToTrim(t *testing.T) {
+// TestTurnLoop_SummarizerErrorPreservesFullHistory asserts the failure
+// path: a summarizer error must not abort the request, and must NOT trim the
+// conversation — the orchestrator forwards the full prior history to the new
+// model so it keeps the context it needs. Trimming to the last few turns
+// silently lobotomized switched-to models in prod.
+func TestTurnLoop_SummarizerErrorPreservesFullHistory(t *testing.T) {
 	store := newFakePinStore()
 	store.hasPin = true
 	store.pin = sessionpin.Pin{
@@ -214,23 +262,25 @@ func TestTurnLoop_SummarizerErrorFallsBackToTrim(t *testing.T) {
 	}
 	fr := &fakeRouter{decision: router.Decision{Provider: providers.ProviderAnthropic, Model: "claude-haiku-4-5", Reason: "cluster:v0.2"}}
 	sz := &fakeSummarizer{errOnCall: errors.New("upstream haiku 500")}
-	svc := newPinSvc(fr, store).WithSummarizer(sz)
+	svc, provider := newPinSvcCapturing(fr, store)
+	svc.WithSummarizer(sz)
 
 	ctx := authedCtx(uuid.New().String())
 	rec := httptest.NewRecorder()
 	httpReq := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(""))
-	require.NoError(t, svc.ProxyMessages(ctx, largeBody(t), rec, httpReq))
+	require.NoError(t, svc.ProxyMessages(ctx, largeMultiTurnBody(t), rec, httpReq))
 
-	assert.Equal(t, int32(1), sz.calls.Load(), "summarizer must be tried before fallback")
+	assert.Equal(t, int32(1), sz.calls.Load(), "summarizer must be tried before the fallback")
 	assert.Equal(t, "claude-haiku-4-5", rec.Header().Get(proxy.HeaderRouterModel), "switch must still happen on summarizer error")
+	assert.Equal(t, 6, forwardedMessageCount(t, provider), "all 6 messages must be forwarded — the failure path must not trim history")
+	assert.Contains(t, string(provider.proxyBodies[0]), "FIRST-USER-MARKER", "the earliest user turn must survive (trim-to-last-N would drop it)")
 }
 
-// TestTurnLoop_HandoverFallsBackToTrimWhenSummarizerNotWired guards the
-// documented graceful-degrade path: when no summarizer is wired (e.g. a
-// self-hoster without an Anthropic key for handover), the switch turn
-// must still bound the input to the new model by trimming history, not
-// forward the full conversation unchanged.
-func TestTurnLoop_HandoverFallsBackToTrimWhenSummarizerNotWired(t *testing.T) {
+// TestTurnLoop_HandoverPreservesFullHistoryWhenSummarizerNotWired guards the
+// no-summarizer path: when no summarizer is wired (e.g. a self-hoster without
+// an Anthropic key for handover), the switch turn must forward the full
+// conversation unchanged rather than trimming it.
+func TestTurnLoop_HandoverPreservesFullHistoryWhenSummarizerNotWired(t *testing.T) {
 	store := newFakePinStore()
 	store.hasPin = true
 	store.pin = sessionpin.Pin{
@@ -243,14 +293,15 @@ func TestTurnLoop_HandoverFallsBackToTrimWhenSummarizerNotWired(t *testing.T) {
 	}
 	fr := &fakeRouter{decision: router.Decision{Provider: providers.ProviderAnthropic, Model: "claude-haiku-4-5", Reason: "cluster:v0.2"}}
 	// No WithSummarizer call — Service.summarizer stays nil.
-	svc := newPinSvc(fr, store)
+	svc, provider := newPinSvcCapturing(fr, store)
 
 	ctx := authedCtx(uuid.New().String())
 	rec := httptest.NewRecorder()
 	httpReq := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(""))
-	require.NoError(t, svc.ProxyMessages(ctx, largeBody(t), rec, httpReq))
+	require.NoError(t, svc.ProxyMessages(ctx, largeMultiTurnBody(t), rec, httpReq))
 
 	assert.Equal(t, "claude-haiku-4-5", rec.Header().Get(proxy.HeaderRouterModel), "switch must proceed even without a summarizer")
+	assert.Equal(t, 6, forwardedMessageCount(t, provider), "all 6 messages must be forwarded when no summarizer is wired — no trimming")
 }
 
 // TestTurnLoop_HandoverUsesClientCredsForSummarizerProvider verifies the
@@ -290,7 +341,7 @@ func TestTurnLoop_HandoverUsesClientCredsForSummarizerProvider(t *testing.T) {
 // tenant-boundary guard: if the request is BYOK/client-keyed for a
 // DIFFERENT provider than the summarizer's, the deployment summarizer
 // would route prior conversation through the platform account. Skip
-// summarization in that case and fall back to TrimLastN.
+// summarization in that case and pass the full history through unchanged.
 func TestTurnLoop_HandoverSkippedWhenClientCredsCrossProvider(t *testing.T) {
 	store := newFakePinStore()
 	store.hasPin = true
@@ -314,7 +365,7 @@ func TestTurnLoop_HandoverSkippedWhenClientCredsCrossProvider(t *testing.T) {
 	require.NoError(t, svc.ProxyMessages(ctx, largeBody(t), rec, httpReq))
 
 	assert.Equal(t, int32(0), sz.calls.Load(), "summarizer must NOT run when client creds are for a different provider than the summarizer")
-	assert.Equal(t, "claude-haiku-4-5", rec.Header().Get(proxy.HeaderRouterModel), "switch must still happen via TrimLastN fallback")
+	assert.Equal(t, "claude-haiku-4-5", rec.Header().Get(proxy.HeaderRouterModel), "switch must still happen with full history passed through")
 }
 
 // TestTurnLoop_PlannerDisabledPreservesFirstDecisionWins exercises the

--- a/internal/router/handover/AGENTS.md
+++ b/internal/router/handover/AGENTS.md
@@ -10,10 +10,10 @@ When the planner decides SWITCH, proxy asks a small model to summarize prior con
 
 ## Layout
 
-- Inner-ring package here defines the **contract only** (`Summarizer` interface, `TrimLastN` fallback, envelope helpers).
+- Inner-ring package here defines the **contract only** (`Summarizer` interface, envelope helpers, `TrimLastN` bounded-trim primitive — no longer the failure path).
 - Provider-backed implementation lives in [`../../proxy/handover.go`](../../proxy/handover.go).
 
 ## Invariants
 
-- **`Summarizer` implementations MUST respect the context deadline.** On summarizer timeout or error, proxy falls back to `handover.TrimLastN` — that is the correct behavior, not a bug. Do not "fix" by waiting longer.
+- **`Summarizer` implementations MUST respect the context deadline.** On summarizer timeout or error, proxy keeps the full prior history unchanged (no trim) — a pricier switch turn beats silently dropping context. Do not "fix" by waiting longer, and do not reintroduce a silent trim fallback.
 - **No I/O in this package.** All I/O lives in the proxy-side implementation.

--- a/internal/router/handover/CLAUDE.md
+++ b/internal/router/handover/CLAUDE.md
@@ -10,10 +10,10 @@ When the planner decides SWITCH, proxy asks a small model to summarize prior con
 
 ## Layout
 
-- Inner-ring package here defines the **contract only** (`Summarizer` interface, `TrimLastN` fallback, envelope helpers).
+- Inner-ring package here defines the **contract only** (`Summarizer` interface, envelope helpers, `TrimLastN` bounded-trim primitive — no longer the failure path).
 - Provider-backed implementation lives in [`../../proxy/handover.go`](../../proxy/handover.go).
 
 ## Invariants
 
-- **`Summarizer` implementations MUST respect the context deadline.** On summarizer timeout or error, proxy falls back to `handover.TrimLastN` — that is the correct behavior, not a bug. Do not "fix" by waiting longer.
+- **`Summarizer` implementations MUST respect the context deadline.** On summarizer timeout or error, proxy keeps the full prior history unchanged (no trim) — a pricier switch turn beats silently dropping context. Do not "fix" by waiting longer, and do not reintroduce a silent trim fallback.
 - **No I/O in this package.** All I/O lives in the proxy-side implementation.

--- a/internal/router/handover/summarizer.go
+++ b/internal/router/handover/summarizer.go
@@ -34,8 +34,8 @@ type Usage struct {
 // seeding a new model's context after a router switch.
 //
 // Implementations SHOULD respect the context deadline. On timeout or
-// error, callers fall back to TrimLastN. Usage is reported on success;
-// on error it is the zero value.
+// error, callers pass the full prior history through unchanged rather than
+// dropping it. Usage is reported on success; on error it is the zero value.
 //
 // Provider returns the upstream provider this summarizer dispatches to
 // (e.g. "anthropic"). The orchestrator uses this to plumb matching
@@ -59,9 +59,16 @@ func RewriteEnvelope(env *translate.RequestEnvelope, summary string) int {
 	return env.RewriteForHandover(summary)
 }
 
-// TrimLastN is the graceful-degradation path when summarization fails or
-// times out. Keeps the most recent n non-system messages plus system
-// blocks; n <= 0 is treated as 3. Returns the number of messages elided.
+// TrimLastN is a bounded-trim primitive that keeps the most recent n
+// non-system messages plus system blocks; n <= 0 is treated as 3. Returns
+// the number of messages elided.
+//
+// NOTE: this is no longer the handover failure path — on summarizer failure
+// the orchestrator keeps the full prior history rather than trimming, because
+// silently dropping the conversation a switched-to model needs is worse than a
+// pricier switch turn. Retained as a primitive for a future context-window
+// overflow guard (trim only when full history would exceed the target model's
+// context window).
 //
 // Pure: no I/O. Returns 0 when env is nil.
 func TrimLastN(env *translate.RequestEnvelope, n int) int {


### PR DESCRIPTION
## Problem

On a mid-session model switch the proxy summarizes the prior conversation (cheap Haiku call) to bound switch-turn input cost. On **any** summarizer failure — timeout, error, empty summary — and on the no-summarizer and tenant-boundary-skip paths, the fallback was `handover.TrimLastN(env, 3)`: silently drop everything but the last 3 messages. A switched-to model (usually non-Anthropic) then loses the entire conversation and behaves as if the session just started.

This is the root cause behind session `6585f8d7-…` ("the model seemed to forget the entire previous conversation").

## Prod evidence (Cloud Run, ~3.5 days)

- **~14% of mid-session main-loop switches** hit the trim fallback (~4/day, 14 events / 97 switches).
- Elisions up to **60 / 80 / 128 messages**; one session got lobotomized twice.
- **~30% of failures are HTTP 400** from the summarizer request itself (`upstream returned status 400`) — immune to any timeout increase, so "bump the timeout" wouldn't fix them.
- The cost the trim actually saved: **~$7 over two weeks** of uncached input tokens. Negligible vs. the failure mode.

The compaction-aware path (`runCompactionHandover`) had the same bug — trimming to last-3 there *also* discards Claude Code's own compaction summary, contradicting that function's own comment ("the model will at least see the compacted body").

## Fix

On every handover fallback path (model-switch **and** compaction-aware), **keep the full prior body unchanged** instead of trimming. A pricier switch turn is always preferable to silently dropping the context the new model needs. The summary stays a pure best-effort optimization; failure now degrades to correct-but-slightly-pricier, never a lobotomy.

- `turnloop.go` + `handover.go`: remove `TrimLastN(3)` from all fallback branches.
- Rename `handoverOutcome.FallbackToTrim` → `FallbackToFullHistory` and telemetry keys `handover.fallback_to_trim` → `handover.fallback_to_full_history` so the metric matches reality. **Dashboards/alerts keyed on the old name must rename.**
- `handover.TrimLastN` retained as a bounded-trim **primitive** (no longer auto-invoked) for a future context-window overflow guard (`catalog.ContextWindowFor` exists).
- Update `internal/proxy` and `internal/router/handover` CLAUDE.md/AGENTS.md contracts (they previously asserted trim-on-failure was "correct, not a bug").
- Tests: strengthened to assert all 6 messages are forwarded on summarizer error and when no summarizer is wired (previously only asserted the switch proceeded). `go test ./...` + `go vet ./...` green.

## Accepted tradeoff / follow-ups

- Passing full history on a switch to a **smaller-context** model could 400 on overflow. That's a loud, retryable error the client (CC) handles via its own compaction — strictly better than silent corruption. A context-window-aware guard (trim only when full history would overflow the target model) is the natural follow-up and is what `TrimLastN` is retained for.
- Separately: the ~30% summarizer 400s are a real bug in the handover request body (likely oversized/malformed after translation) worth its own investigation — this PR removes their *impact*, not their cause.