### PR TITLE
fix(translate): map Anthropic thinking budget → reasoning_effort/thinkingConfig (un-lobotomize gpt-5.5/gemini)

### DIFF
--- a/internal/translate/emit_gemini.go
+++ b/internal/translate/emit_gemini.go
@@ -560,8 +560,8 @@ func writeGeminiGenerationConfigFromOpenAI(jw *jsonWriter, body []byte, model st
 			fields = append(fields, field{"responseMimeType", `"application/json"`})
 		}
 	}
-	if r := gjson.GetBytes(body, "reasoning_effort"); r.Exists() && r.Type == gjson.String {
-		if raw := thinkingConfigRaw(r.String()); raw != "" {
+	if effort := geminiReasoningEffort(body); effort != "" {
+		if raw := thinkingConfigRaw(effort); raw != "" {
 			fields = append(fields, field{"thinkingConfig", raw})
 		}
 	}
@@ -1106,6 +1106,13 @@ func writeGeminiGenerationConfigFromAnthropic(jw *jsonWriter, body []byte, model
 			fields = append(fields, field{"stopSequences", raw})
 		}
 	}
+	// Claude Code drives reasoning via `thinking`; without mapping it to a
+	// Gemini thinkingConfig the target reasons at its minimal default.
+	if effort := geminiReasoningEffort(body); effort != "" {
+		if raw := thinkingConfigRaw(effort); raw != "" {
+			fields = append(fields, field{"thinkingConfig", raw})
+		}
+	}
 
 	if len(fields) == 0 {
 		return
@@ -1155,6 +1162,21 @@ func stopToArrayRaw(r gjson.Result) string {
 		return ""
 	}
 	return "[" + strings.Join(items, ",") + "]"
+}
+
+// geminiReasoningEffort resolves the reasoning effort for a Gemini request,
+// preferring an explicit reasoning_effort and falling back to an Anthropic-style
+// thinking budget. Claude Code (an Anthropic client) sends `thinking`, not
+// `reasoning_effort`; without this fallback the Gemini target gets no
+// thinkingConfig and runs at its minimal default.
+func geminiReasoningEffort(body []byte) string {
+	if r := gjson.GetBytes(body, "reasoning_effort"); r.Exists() && r.Type == gjson.String {
+		return r.String()
+	}
+	if t := gjson.GetBytes(body, "thinking"); t.Exists() {
+		return effortForBudget(t.Get("budget_tokens").Int())
+	}
+	return ""
 }
 
 // thinkingConfigRaw returns the raw JSON for a Gemini thinkingConfig given an

--- a/internal/translate/emit_openai.go
+++ b/internal/translate/emit_openai.go
@@ -190,6 +190,21 @@ func (e *RequestEnvelope) buildOpenAIFromAnthropic(opts EmitOptions) ([]byte, pr
 	// Max tokens
 	writeOpenAIMaxTokensFromAnthropic(jw, body, opts)
 
+	// Reasoning effort: Claude Code (an Anthropic client) drives reasoning via
+	// `thinking`, not `reasoning_effort`. Map the thinking budget onto
+	// reasoning_effort for reasoning-capable targets so the upstream actually
+	// reasons — without this, reasoning models (gpt-5.x) run at their minimal
+	// default. A client-set reasoning_effort wins.
+	if opts.Capabilities.Supports(router.CapReasoning) {
+		if r := gjson.GetBytes(body, "reasoning_effort"); r.Exists() && r.Type == gjson.String {
+			jw.Key("reasoning_effort")
+			jw.Str(r.String())
+		} else if t := gjson.GetBytes(body, "thinking"); t.Exists() {
+			jw.Key("reasoning_effort")
+			jw.Str(effortForBudget(t.Get("budget_tokens").Int()))
+		}
+	}
+
 	// Stream usage option
 	if opts.IncludeStreamUsage && gjson.GetBytes(body, "stream").Bool() {
 		jw.Key("stream_options")

--- a/internal/translate/envelope.go
+++ b/internal/translate/envelope.go
@@ -336,6 +336,10 @@ type EmitOverrides struct {
 	// model only accepts adaptive thinking (claude-opus-4-6+ / sonnet-4-6+).
 	RewriteThinkingAdaptive bool
 	OutputConfigEffort      string
+	// SetReasoningEffort sets `reasoning_effort` on an OpenAI-format request.
+	// Translates an Anthropic client's `thinking` budget into the OpenAI
+	// reasoning control so reasoning-capable targets actually reason.
+	SetReasoningEffort string
 }
 
 func (e *RequestEnvelope) emitSameFormat(ov EmitOverrides) ([]byte, error) {
@@ -403,6 +407,13 @@ func applyOverrides(body []byte, ov EmitOverrides) ([]byte, error) {
 					return nil, fmt.Errorf("set output_config.effort: %w", err)
 				}
 			}
+		}
+	}
+
+	if ov.SetReasoningEffort != "" {
+		out, err = sjson.SetBytes(out, "reasoning_effort", ov.SetReasoningEffort)
+		if err != nil {
+			return nil, fmt.Errorf("set reasoning_effort: %w", err)
 		}
 	}
 
@@ -630,15 +641,24 @@ func resolveOpenAIOverrides(body []byte, opts EmitOptions) EmitOverrides {
 		Model: opts.TargetModel,
 	}
 
+	// Anthropic clients (e.g. Claude Code) drive reasoning via `thinking`, not
+	// `reasoning_effort`. Map the thinking budget onto reasoning_effort for
+	// reasoning-capable OpenAI targets so the upstream actually reasons; without
+	// this the `thinking` delete below leaves the model at its minimal default.
+	thinking := gjson.GetBytes(body, "thinking")
+	hasInboundEffort := gjson.GetBytes(body, "reasoning_effort").Exists()
+	supportsReasoning := opts.Capabilities.Supports(router.CapReasoning)
+
 	ov.DeleteKeys = append(ov.DeleteKeys, "thinking")
 
-	if gjson.GetBytes(body, "reasoning_effort").Exists() && !opts.Capabilities.Supports(router.CapReasoning) {
+	if hasInboundEffort && !supportsReasoning {
 		ov.DeleteKeys = append(ov.DeleteKeys, "reasoning_effort")
+	} else if !hasInboundEffort && supportsReasoning && thinking.Exists() {
+		ov.SetReasoningEffort = effortForBudget(thinking.Get("budget_tokens").Int())
 	}
 
 	hasMaxTokens := gjson.GetBytes(body, "max_tokens").Exists()
 	hasMaxComp := gjson.GetBytes(body, "max_completion_tokens").Exists()
-	supportsReasoning := opts.Capabilities.Supports(router.CapReasoning)
 
 	if hasMaxTokens && supportsReasoning {
 		if !hasMaxComp {

--- a/internal/translate/reasoning_effort_translate_test.go
+++ b/internal/translate/reasoning_effort_translate_test.go
@@ -1,0 +1,119 @@
+package translate_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"workweave/router/internal/router"
+	"workweave/router/internal/translate"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// An Anthropic client (Claude Code) drives reasoning via `thinking`, not
+// `reasoning_effort`. The router must translate the thinking budget into the
+// OpenAI reasoning control for reasoning-capable targets, else the upstream
+// runs at its minimal default (the gpt-5.5 lobotomy).
+func TestAnthropicThinkingMapsToOpenAIReasoningEffort(t *testing.T) {
+	cases := []struct {
+		budget int
+		want   string
+	}{
+		{2048, "low"},
+		{8192, "medium"},
+		{31999, "high"},
+	}
+	for _, tc := range cases {
+		body := []byte(`{"model":"claude-opus-4-8","max_tokens":1024,"messages":[{"role":"user","content":"hi"}],"thinking":{"type":"enabled","budget_tokens":` +
+			itoa(tc.budget) + `}}`)
+		env, err := translate.ParseAnthropic(body)
+		require.NoError(t, err)
+		p, err := env.PrepareOpenAI(http.Header{}, translate.EmitOptions{
+			TargetModel:  "gpt-5.5",
+			Capabilities: router.Lookup("gpt-5.5"),
+		})
+		require.NoError(t, err)
+		var out map[string]any
+		require.NoError(t, json.Unmarshal(p.Body, &out))
+		assert.Equal(t, tc.want, out["reasoning_effort"], "budget %d", tc.budget)
+		_, hasThinking := out["thinking"]
+		assert.False(t, hasThinking, "thinking must be stripped from the OpenAI body")
+	}
+}
+
+// Non-reasoning OpenAI targets (e.g. gpt-4.1) must NOT get a reasoning_effort —
+// they reject it.
+func TestAnthropicThinkingNotMappedForNonReasoningTarget(t *testing.T) {
+	body := []byte(`{"model":"claude-opus-4-8","max_tokens":1024,"messages":[{"role":"user","content":"hi"}],"thinking":{"type":"enabled","budget_tokens":31999}}`)
+	env, err := translate.ParseAnthropic(body)
+	require.NoError(t, err)
+	p, err := env.PrepareOpenAI(http.Header{}, translate.EmitOptions{
+		TargetModel:  "gpt-4.1",
+		Capabilities: router.Lookup("gpt-4.1"),
+	})
+	require.NoError(t, err)
+	var out map[string]any
+	require.NoError(t, json.Unmarshal(p.Body, &out))
+	_, has := out["reasoning_effort"]
+	assert.False(t, has, "non-reasoning target must not receive reasoning_effort")
+}
+
+// A client that already specified reasoning_effort wins — the thinking-derived
+// value must not overwrite it.
+func TestExplicitReasoningEffortNotOverwrittenByThinking(t *testing.T) {
+	body := []byte(`{"model":"claude-opus-4-8","max_tokens":1024,"messages":[{"role":"user","content":"hi"}],"reasoning_effort":"low","thinking":{"type":"enabled","budget_tokens":31999}}`)
+	env, err := translate.ParseAnthropic(body)
+	require.NoError(t, err)
+	p, err := env.PrepareOpenAI(http.Header{}, translate.EmitOptions{
+		TargetModel:  "gpt-5.5",
+		Capabilities: router.Lookup("gpt-5.5"),
+	})
+	require.NoError(t, err)
+	var out map[string]any
+	require.NoError(t, json.Unmarshal(p.Body, &out))
+	assert.Equal(t, "low", out["reasoning_effort"], "caller-supplied reasoning_effort must win")
+}
+
+// The same thinking budget must reach a native-Gemini target as a
+// thinkingConfig.thinkingBudget, so gemini-3.x reasons instead of defaulting.
+func TestAnthropicThinkingMapsToGeminiThinkingConfig(t *testing.T) {
+	body := []byte(`{"model":"claude-opus-4-8","max_tokens":1024,"messages":[{"role":"user","content":"hi"}],"thinking":{"type":"enabled","budget_tokens":31999}}`)
+	env, err := translate.ParseAnthropic(body)
+	require.NoError(t, err)
+	p, err := env.PrepareGemini(nil, translate.EmitOptions{
+		TargetModel:  "gemini-3.1-pro-preview",
+		Capabilities: router.Lookup("gemini-3.1-pro-preview"),
+	})
+	require.NoError(t, err)
+	var out map[string]any
+	require.NoError(t, json.Unmarshal(p.Body, &out))
+	gen, ok := out["generationConfig"].(map[string]any)
+	require.True(t, ok, "generationConfig must be present")
+	tc, ok := gen["thinkingConfig"].(map[string]any)
+	require.True(t, ok, "thinkingConfig must be set from the thinking budget")
+	assert.EqualValues(t, 24576, tc["thinkingBudget"], "high budget -> gemini high thinkingBudget")
+}
+
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	neg := n < 0
+	if neg {
+		n = -n
+	}
+	var b [20]byte
+	i := len(b)
+	for n > 0 {
+		i--
+		b[i] = byte('0' + n%10)
+		n /= 10
+	}
+	if neg {
+		i--
+		b[i] = '-'
+	}
+	return string(b[i:])
+}


### PR DESCRIPTION
## The bug

Claude Code is an Anthropic client — it drives reasoning via `thinking: {type, budget_tokens}`, **not** `reasoning_effort`. When the router routed a Claude-Code request to:
- a reasoning **OpenAI** model (gpt-5.5): `buildOpenAIFromAnthropic` emitted no `reasoning_effort` at all, and
- a native **Gemini** model (gemini-3.x): `writeGeminiGenerationConfigFromAnthropic` had no `thinkingConfig`,

…so those models ran at their **minimal default reasoning**.

## Evidence (v0.66 SWE-bench Pro live bake-off)

| model | path | mean thinking blocks | Pro solve |
|---|---|---:|---:|
| opus-4-8 | Anthropic (thinking kept) | 13.8 | 43% |
| deepseek-v4-pro | reasons by default | 21.0 | 33% |
| **gpt-5.5** | **Anthropic→OpenAI (dropped)** | **1.1** | **6%** |
| **gemini-3.1-pro** | **Anthropic→Gemini (no config)** | **0.3** | **0%** |

This is a **prod bug** (real Claude Code traffic to OpenAI/Gemini models under-reasons), not just an eval artifact.

## Fix

- `buildOpenAIFromAnthropic`: emit `reasoning_effort = effortForBudget(thinking.budget_tokens)` for `CapReasoning` targets.
- `writeGeminiGenerationConfigFromAnthropic`: derive `thinkingConfig` from the same budget (shared `geminiReasoningEffort` helper).
- Mirrored on the OpenAI same-format override path for completeness.
- A client-set `reasoning_effort` always wins; non-reasoning targets untouched.

## Tests
`reasoning_effort_translate_test.go`: budget→effort ladder (low/med/high) for OpenAI; non-reasoning target gets none; explicit `reasoning_effort` not overwritten; Gemini thinkingConfig set from thinking budget. Full `internal/translate` + proxy/router suites pass.

## Follow-up
Enables the gpt-5.5 / gemini-3.1-pro low-vs-high "thinking solos" — measure each at controlled effort (real Claude-Code agent) and, if high recovers them on hard coding, add fixed-effort pool variants.

🤖 Generated with [Claude Code](https://claude.com/claude-code)