### PR TITLE
feat(translate): fix gpt-5.x medium-effort dead-zone + gemini-3.x thinkingLevel

### DIFF
--- a/internal/translate/emit_gemini.go
+++ b/internal/translate/emit_gemini.go
@@ -561,7 +561,7 @@ func writeGeminiGenerationConfigFromOpenAI(jw *jsonWriter, body []byte, model st
 		}
 	}
 	if r := gjson.GetBytes(body, "reasoning_effort"); r.Exists() && r.Type == gjson.String {
-		if raw := thinkingConfigRaw(r.String()); raw != "" {
+		if raw := thinkingConfigRaw(r.String(), model); raw != "" {
 			fields = append(fields, field{"thinkingConfig", raw})
 		}
 	}
@@ -1110,7 +1110,7 @@ func writeGeminiGenerationConfigFromAnthropic(jw *jsonWriter, body []byte, model
 	// thinkingConfig (native generateContent honors it) so gemini-3.x reasons
 	// instead of running at its minimal default. reasoning_effort wins if set.
 	if effort := geminiReasoningEffort(body); effort != "" {
-		if raw := thinkingConfigRaw(effort); raw != "" {
+		if raw := thinkingConfigRaw(effort, model); raw != "" {
 			fields = append(fields, field{"thinkingConfig", raw})
 		}
 	}
@@ -1180,7 +1180,28 @@ func geminiReasoningEffort(body []byte) string {
 	return ""
 }
 
-func thinkingConfigRaw(effort string) string {
+func thinkingConfigRaw(effort, model string) string {
+	// Gemini 3.x uses thinkingLevel (string); the legacy numeric thinkingBudget
+	// is "accepted for backwards compatibility" but documented as suboptimal for
+	// 3.x, and mixing both fields 400s. Gemini 2.5 keeps thinkingBudget.
+	if isGemini3xModel(model) {
+		var level string
+		switch effort {
+		case "low", "medium", "high":
+			level = effort
+		default:
+			// "none"/unknown: 3.x cannot disable thinking — omit the config and
+			// let the model use its default level rather than send an invalid value.
+			return ""
+		}
+		fw := newJSONWriter()
+		fw.Obj()
+		fw.Key("thinkingLevel")
+		fw.Str(level)
+		fw.EndObj()
+		return string(fw.Bytes())
+	}
+
 	var budget int64
 	switch effort {
 	case "none":

--- a/internal/translate/emit_openai_responses.go
+++ b/internal/translate/emit_openai_responses.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strings"
 
 	"workweave/router/internal/providers"
 	"workweave/router/internal/router"
@@ -65,6 +66,19 @@ func reasoningEffortFromAnthropic(body []byte) string {
 	return ""
 }
 
+// responsesReasoningEffort applies model-specific effort policy on top of the
+// budget-derived effort. gpt-5.x has a measured "medium" dead-zone on hard
+// agentic coding (SWE-bench Pro: low 16%, medium 0%, high 41% ≈ opus) — medium
+// is strictly dominated by both neighbors, so never serve it to a gpt-5.x
+// reasoning model; promote to high. Small budgets still resolve to low via
+// effortForBudget, so easy traffic is untouched. Other models pass through.
+func responsesReasoningEffort(eff, model string) string {
+	if eff == "medium" && strings.HasPrefix(model, "gpt-5") {
+		return "high"
+	}
+	return eff
+}
+
 func (e *RequestEnvelope) buildResponsesFromAnthropic(opts EmitOptions) ([]byte, providers.RequestMutationStats, error) {
 	var stats providers.RequestMutationStats
 	body, removed, err := filterClaudeCodeOnlyToolsFromAnthropicBody(e.body)
@@ -91,7 +105,7 @@ func (e *RequestEnvelope) buildResponsesFromAnthropic(opts EmitOptions) ([]byte,
 	}
 
 	if opts.Capabilities.Supports(router.CapReasoning) {
-		if eff := reasoningEffortFromAnthropic(body); eff != "" {
+		if eff := responsesReasoningEffort(reasoningEffortFromAnthropic(body), opts.TargetModel); eff != "" {
 			jw.Key("reasoning")
 			jw.Obj()
 			jw.Key("effort")

--- a/internal/translate/gemini_test.go
+++ b/internal/translate/gemini_test.go
@@ -147,16 +147,34 @@ func TestPrepareGemini_ToolChoiceVariants(t *testing.T) {
 }
 
 func TestPrepareGemini_ReasoningEffortMapsToThinkingBudget(t *testing.T) {
+	// No target model => legacy (gemini-2.5) path: numeric thinkingBudget.
 	cases := map[string]int{"low": 1024, "medium": 8192, "high": 24576, "none": 0}
 	for effort, budget := range cases {
 		body := []byte(`{"messages":[{"role":"user","content":"x"}],"reasoning_effort":"` + effort + `"}`)
 		env, _ := translate.ParseOpenAI(body)
-		prep, err := env.PrepareGemini(http.Header{}, translate.EmitOptions{})
+		prep, err := env.PrepareGemini(http.Header{}, translate.EmitOptions{TargetModel: "gemini-2.5-pro"})
 		require.NoError(t, err, effort)
 		out := mustUnmarshal(t, prep.Body)
 		gc := out["generationConfig"].(map[string]any)
 		tc := gc["thinkingConfig"].(map[string]any)
 		assert.EqualValues(t, budget, tc["thinkingBudget"], effort)
+	}
+}
+
+func TestPrepareGemini_ReasoningEffortMapsToThinkingLevel_Gemini3x(t *testing.T) {
+	// OpenAI-format ingress (reasoning_effort) → gemini-3.x: string thinkingLevel,
+	// no legacy thinkingBudget. "none" is omitted (3.x cannot disable thinking).
+	for _, effort := range []string{"low", "medium", "high"} {
+		body := []byte(`{"messages":[{"role":"user","content":"x"}],"reasoning_effort":"` + effort + `"}`)
+		env, _ := translate.ParseOpenAI(body)
+		prep, err := env.PrepareGemini(http.Header{}, translate.EmitOptions{TargetModel: "gemini-3.1-pro-preview"})
+		require.NoError(t, err, effort)
+		out := mustUnmarshal(t, prep.Body)
+		gc := out["generationConfig"].(map[string]any)
+		tc := gc["thinkingConfig"].(map[string]any)
+		assert.Equal(t, effort, tc["thinkingLevel"], effort)
+		_, hasBudget := tc["thinkingBudget"]
+		assert.False(t, hasBudget, "gemini-3.x must not send thinkingBudget (%s)", effort)
 	}
 }
 

--- a/internal/translate/responses_outbound_test.go
+++ b/internal/translate/responses_outbound_test.go
@@ -106,10 +106,13 @@ func TestPrepareOpenAIResponses_RequestShape(t *testing.T) {
 
 // budget→effort ladder.
 func TestPrepareOpenAIResponses_EffortLadder(t *testing.T) {
+	// gpt-5.x has a measured "medium" dead-zone on hard agentic coding (Pro:
+	// low 16%, medium 0%, high 41%), so the medium band (budget ≤16384) is
+	// promoted to high. Small budgets still resolve to low — easy stays cheap.
 	for _, tc := range []struct {
 		budget int
 		want   string
-	}{{2048, "low"}, {8192, "medium"}, {31999, "high"}} {
+	}{{2048, "low"}, {8192, "high"}, {16384, "high"}, {31999, "high"}} {
 		body := []byte(`{"model":"claude-opus-4-8","max_tokens":1024,"messages":[{"role":"user","content":"hi"}],"thinking":{"type":"enabled","budget_tokens":` + itoa(tc.budget) + `}}`)
 		env, err := translate.ParseAnthropic(body)
 		require.NoError(t, err)
@@ -175,7 +178,8 @@ func TestResponsesToAnthropicResponse_StopReasons(t *testing.T) {
 }
 
 // gemini-3.x (native) must receive a thinkingConfig derived from the Anthropic
-// thinking budget so it reasons.
+// thinking budget so it reasons. Gemini 3.x uses the string `thinkingLevel`;
+// the legacy numeric `thinkingBudget` is suboptimal for 3.x and mixing both 400s.
 func TestPrepareGemini_ThinkingBudgetToThinkingConfig(t *testing.T) {
 	body := []byte(`{"model":"claude-opus-4-8","max_tokens":1024,"messages":[{"role":"user","content":"hi"}],"thinking":{"type":"enabled","budget_tokens":31999}}`)
 	env, err := translate.ParseAnthropic(body)
@@ -188,5 +192,24 @@ func TestPrepareGemini_ThinkingBudgetToThinkingConfig(t *testing.T) {
 	require.True(t, ok, "generationConfig present")
 	tc, ok := gen["thinkingConfig"].(map[string]any)
 	require.True(t, ok, "thinkingConfig set from thinking budget")
-	assert.EqualValues(t, 24576, tc["thinkingBudget"], "high budget -> gemini high thinkingBudget")
+	assert.Equal(t, "high", tc["thinkingLevel"], "high budget -> gemini-3.x thinkingLevel high")
+	_, hasBudget := tc["thinkingBudget"]
+	assert.False(t, hasBudget, "gemini-3.x must NOT send the legacy thinkingBudget")
+}
+
+// gemini-2.5 (legacy) keeps the numeric thinkingBudget — thinkingLevel is 3.x only.
+func TestPrepareGemini_ThinkingBudget_Legacy25(t *testing.T) {
+	body := []byte(`{"model":"claude-opus-4-8","max_tokens":1024,"messages":[{"role":"user","content":"hi"}],"thinking":{"type":"enabled","budget_tokens":31999}}`)
+	env, err := translate.ParseAnthropic(body)
+	require.NoError(t, err)
+	prep, err := env.PrepareGemini(nil, translate.EmitOptions{TargetModel: "gemini-2.5-pro"})
+	require.NoError(t, err)
+	var out map[string]any
+	require.NoError(t, json.Unmarshal(prep.Body, &out))
+	gen, _ := out["generationConfig"].(map[string]any)
+	tc, ok := gen["thinkingConfig"].(map[string]any)
+	require.True(t, ok, "thinkingConfig set from thinking budget")
+	assert.EqualValues(t, 24576, tc["thinkingBudget"], "high budget -> gemini-2.5 thinkingBudget 24576")
+	_, hasLevel := tc["thinkingLevel"]
+	assert.False(t, hasLevel, "gemini-2.5 must NOT send thinkingLevel")
 }


### PR DESCRIPTION
## Summary

Two reasoning-effort dispatch corrections in `internal/translate`, both grounded in SWE-bench Pro measurements. Follows up #325 (which wired gpt-5.x → Responses API and gemini-3.x → native thinkingConfig).

### 1. gpt-5.x `medium` dead-zone → promote to `high`

`reasoningEffortFromAnthropic` maps Claude Code's per-turn `thinking.budget_tokens` to a Responses `reasoning.effort` via `effortForBudget`: `(4096, 16384] → medium`. But gpt-5.5 has a **measured `medium` dead-zone on hard agentic coding**:

| effort | SWE-bench Pro resolved |
|---|---:|
| low | 16% |
| **medium** | **0%** |
| high | 41% (≈ opus 43%) |

`medium` is strictly dominated by both neighbors, so any turn whose budget landed in that band was silently served gpt-5.5 at its *worst* tier — the likely cause of routed gpt-5.5 underperforming live despite reasoning being requested. Fix: in `buildResponsesFromAnthropic`, promote `medium → high` for gpt-5.x models only. Small budgets still resolve to `low`, so easy/general traffic is untouched.

### 2. gemini-3.x → `thinkingLevel` (not legacy `thinkingBudget`)

`thinkingConfigRaw` emitted `{"thinkingBudget": N}` for all Gemini models. Gemini 3.x wants `{"thinkingLevel": "low|medium|high"}`; Google documents `thinkingBudget` as suboptimal for 3.x, and **sending both fields 400s**. Now model-aware: 3.x → `thinkingLevel`, 2.5 → `thinkingBudget` (unchanged). Covers both callers (`writeGeminiGenerationConfigFromOpenAI` and `writeGeminiGenerationConfigFromAnthropic`, the CC path).

This is a **correctness** fix — a re-measurement on the correct knob confirmed gemini-3.1-pro stays capability-limited on hard coding (~7–13% at any thinkingLevel), so it doesn't change routing, but it stops driving 3.x via a deprecated control.

## Scope / non-goals
- No routing-artifact changes. Effort policy is applied at the translate layer.
- Deferred: `xhigh` (passes through verbatim today; no client emits it), and a routing-context `ForceEffort` lever (blocked on a machine-readable coding-cluster label).

## Test plan
- `go test ./internal/translate/...` passes; `go build ./...` and `go vet ./internal/translate/...` clean.
- Updated `TestPrepareOpenAIResponses_EffortLadder` (8192/16384 now → high for gpt-5.5).
- Updated `TestPrepareGemini_ThinkingBudgetToThinkingConfig` (3.x asserts thinkingLevel + absence of thinkingBudget); added `TestPrepareGemini_ThinkingBudget_Legacy25` and `TestPrepareGemini_ReasoningEffortMapsToThinkingLevel_Gemini3x`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)