### PR TITLE
fix(translate): stream gpt-5.x Responses API to end header-timeout hangs

### DIFF
--- a/internal/providers/httputil/httputil.go
+++ b/internal/providers/httputil/httputil.go
@@ -49,14 +49,31 @@ func sseIdleTimeoutFromEnv() time.Duration {
 	return time.Duration(n) * time.Second
 }
 
+// DefaultResponseHeaderTimeout is the time-to-first-byte guard applied by
+// NewTransport. Streaming upstreams return headers immediately, so 30s is ample
+// for them; it only bites a non-streaming upstream that buffers a slow response.
+const DefaultResponseHeaderTimeout = 30 * time.Second
+
 // NewTransport returns a pooled http.Transport sized for sustained traffic to a single upstream host.
 //
 // KeepAlive=30s is the critical setting against AWS NAT-GW / NLB / VPC-endpoint
 // reapers (350s fixed idle): the dialer's TCP keepalives keep the connection
 // live so the zero-byte-stall failure mode can't accumulate at the network layer.
-// ResponseHeaderTimeout=30s only guards time-to-first-byte; per-read inactivity
+// ResponseHeaderTimeout only guards time-to-first-byte; per-read inactivity
 // during streaming is enforced by StreamBody's watchdog.
 func NewTransport(dialTimeout, tlsTimeout time.Duration) *http.Transport {
+	return NewTransportWithResponseHeaderTimeout(dialTimeout, tlsTimeout, DefaultResponseHeaderTimeout)
+}
+
+// NewTransportWithResponseHeaderTimeout is NewTransport with a caller-chosen
+// time-to-first-byte guard. Upstreams whose first byte can legitimately arrive
+// later than the 30s default pass a larger value: the OpenAI Responses API for
+// gpt-5.x high-effort reasoning can take well over 30s to emit its first SSE
+// event, so a 30s header timeout false-trips even when the model is healthy.
+// Per-read inactivity once the stream is flowing is still bounded by
+// StreamBody's idle watchdog (DefaultSSEIdleTimeout), so a generous header
+// timeout does not reintroduce an unbounded hang.
+func NewTransportWithResponseHeaderTimeout(dialTimeout, tlsTimeout, responseHeaderTimeout time.Duration) *http.Transport {
 	return &http.Transport{
 		Proxy: http.ProxyFromEnvironment,
 		DialContext: (&net.Dialer{
@@ -68,7 +85,7 @@ func NewTransport(dialTimeout, tlsTimeout time.Duration) *http.Transport {
 		IdleConnTimeout:       90 * time.Second,
 		TLSHandshakeTimeout:   tlsTimeout,
 		ExpectContinueTimeout: 1 * time.Second,
-		ResponseHeaderTimeout: 30 * time.Second,
+		ResponseHeaderTimeout: responseHeaderTimeout,
 		ForceAttemptHTTP2:     true,
 	}
 }

--- a/internal/providers/openai/client.go
+++ b/internal/providers/openai/client.go
@@ -23,6 +23,15 @@ import (
 
 const DefaultBaseURL = "https://api.openai.com"
 
+// responseHeaderTimeout guards time-to-first-byte for OpenAI upstreams. It is
+// raised above the 30s default because the Responses API (gpt-5.x reasoning)
+// can take well over 30s to emit its first streamed event under high effort;
+// the default would false-trip "http2: timeout awaiting response headers" on a
+// healthy model. Once the stream is flowing, inter-event gaps are bounded by
+// StreamBody's idle watchdog, so this generous header budget cannot reintroduce
+// an unbounded hang. Applies to both /v1/chat/completions and /v1/responses.
+const responseHeaderTimeout = 120 * time.Second
+
 type Client struct {
 	apiKey  string
 	baseURL string
@@ -36,7 +45,7 @@ func NewClient(apiKey, baseURL string) *Client {
 	return &Client{
 		apiKey:  apiKey,
 		baseURL: baseURL,
-		http:    &http.Client{Transport: httputil.NewTransport(5*time.Second, 5*time.Second)},
+		http:    &http.Client{Transport: httputil.NewTransportWithResponseHeaderTimeout(5*time.Second, 5*time.Second, responseHeaderTimeout)},
 	}
 }
 

--- a/internal/translate/emit_openai_responses.go
+++ b/internal/translate/emit_openai_responses.go
@@ -16,8 +16,13 @@ import (
 // request from an Anthropic Messages envelope. Reasoning-capable OpenAI models
 // (gpt-5.x) reject `reasoning_effort` + tools on `/v1/chat/completions`, so an
 // agentic Anthropic client (Claude Code) that wants the model to reason must go
-// through the Responses API instead. Phase 1: non-streaming upstream
-// (`stream:false`); the caller buffers + re-emits as Anthropic.
+// through the Responses API instead. The upstream call streams (`stream:true`):
+// a non-streaming Responses call buffers the entire reasoning+output before
+// emitting any response headers, which for gpt-5.x at high effort routinely
+// exceeds the transport's response-header timeout and fails the turn with
+// "http2: timeout awaiting response headers". Streaming returns headers + the
+// first event immediately; ResponsesToAnthropicWriter translates the event
+// stream into Anthropic SSE on the fly.
 func (e *RequestEnvelope) PrepareOpenAIResponses(in http.Header, opts EmitOptions) (providers.PreparedRequest, error) {
 	if e.format != FormatAnthropic {
 		return providers.PreparedRequest{}, fmt.Errorf("PrepareOpenAIResponses: only Anthropic ingress is supported, got format %d", e.format)
@@ -92,10 +97,10 @@ func (e *RequestEnvelope) buildResponsesFromAnthropic(opts EmitOptions) ([]byte,
 	jw.Key("model")
 	jw.Str(opts.TargetModel)
 	jw.Key("stream")
-	jw.Bool(false)
+	jw.Bool(true)
 	// Stateless: we send the full history each turn and don't rely on
-	// server-side state. (Phase 1 also omits echoing prior reasoning items;
-	// the model reasons fresh from the message history.)
+	// server-side state. (We also omit echoing prior reasoning items; the model
+	// reasons fresh from the message history.)
 	jw.Key("store")
 	jw.Bool(false)
 

--- a/internal/translate/responses_outbound_test.go
+++ b/internal/translate/responses_outbound_test.go
@@ -54,7 +54,7 @@ func TestPrepareOpenAIResponses_RequestShape(t *testing.T) {
 	require.NoError(t, json.Unmarshal(prep.Body, &out))
 
 	assert.Equal(t, "gpt-5.5", out["model"])
-	assert.Equal(t, false, out["stream"])
+	assert.Equal(t, true, out["stream"], "Responses upstream must stream so a slow gpt-5.x prefill doesn't trip the response-header timeout")
 	assert.Equal(t, false, out["store"])
 	assert.Equal(t, "You are helpful.", out["instructions"])
 	reasoning, _ := out["reasoning"].(map[string]any)

--- a/internal/translate/responses_to_anthropic_writer.go
+++ b/internal/translate/responses_to_anthropic_writer.go
@@ -232,11 +232,11 @@ func (t *ResponsesToAnthropicWriter) translateResponsesEvent(raw []byte) error {
 		// event instead of closing the turn as if it succeeded.
 		return t.emitStreamErrorEvent(gjson.GetBytes(data, "code").String(), gjson.GetBytes(data, "message").String())
 	case "response.failed":
-		if e := gjson.GetBytes(data, "response.error"); e.Exists() {
-			return t.emitStreamErrorEvent(e.Get("code").String(), e.Get("message").String())
-		}
-		t.captureFinalResponse(data)
-		return nil
+		// response.failed is always an upstream failure — surface it as an error
+		// even when no error object rode along (responsesError fills a generic
+		// message), matching the buffered path's status:"failed" rejection.
+		e := gjson.GetBytes(data, "response.error")
+		return t.emitStreamErrorEvent(e.Get("code").String(), e.Get("message").String())
 	case "response.completed", "response.incomplete":
 		t.captureFinalResponse(data)
 		return nil

--- a/internal/translate/responses_to_anthropic_writer.go
+++ b/internal/translate/responses_to_anthropic_writer.go
@@ -208,7 +208,13 @@ func (t *ResponsesToAnthropicWriter) translateResponsesEvent(raw []byte) error {
 	case "response.reasoning_summary_text.delta", "response.reasoning_text.delta":
 		return t.handleReasoningDelta(data)
 	case "response.function_call_arguments.delta":
-		t.bufferToolArgs(data)
+		t.bufferToolArgs(data, "delta", true)
+		return nil
+	case "response.function_call_arguments.done":
+		// The terminal arg event carries the complete `arguments` string. Adopt
+		// it as authoritative so a tool call whose deltas were absent or lost
+		// still emits the real parameters rather than `{}`.
+		t.bufferToolArgs(data, "arguments", false)
 		return nil
 	case "response.output_item.done":
 		return t.handleOutputItemDone(data)
@@ -253,14 +259,24 @@ func (t *ResponsesToAnthropicWriter) handleReasoningDelta(data []byte) error {
 	return t.emitContentBlockDeltaThinking(idx, gjson.GetBytes(data, "delta").String())
 }
 
-func (t *ResponsesToAnthropicWriter) bufferToolArgs(data []byte) {
+// bufferToolArgs accumulates a tool call's arguments for an output_index.
+// appendMode=true appends a streamed fragment from `field`; appendMode=false
+// replaces the buffer with an authoritative complete value from `field`.
+func (t *ResponsesToAnthropicWriter) bufferToolArgs(data []byte, field string, appendMode bool) {
+	s := gjson.GetBytes(data, field).String()
+	if s == "" && appendMode {
+		return
+	}
 	oi := int(gjson.GetBytes(data, "output_index").Int())
 	buf, ok := t.toolArgs[oi]
 	if !ok {
 		buf = &strings.Builder{}
 		t.toolArgs[oi] = buf
 	}
-	buf.WriteString(gjson.GetBytes(data, "delta").String())
+	if !appendMode {
+		buf.Reset()
+	}
+	buf.WriteString(s)
 }
 
 func (t *ResponsesToAnthropicWriter) handleOutputItemDone(data []byte) error {
@@ -270,7 +286,9 @@ func (t *ResponsesToAnthropicWriter) handleOutputItemDone(data []byte) error {
 		return nil
 	}
 	if t.itemKind[oi] == "tool_use" {
-		if err := t.emitValidatedToolArgsDelta(oi, idx); err != nil {
+		// item.arguments on the terminal event is the authoritative complete
+		// args; use it when the streamed deltas were absent or malformed.
+		if err := t.emitValidatedToolArgsDelta(oi, idx, gjson.GetBytes(data, "item.arguments").String()); err != nil {
 			return err
 		}
 	}
@@ -332,22 +350,23 @@ func (t *ResponsesToAnthropicWriter) captureFinalResponse(data []byte) {
 }
 
 func (t *ResponsesToAnthropicWriter) finishStream() error {
-	// Close any still-open blocks (a tool block's args are flushed at
-	// output_item.done; reaching here with one open means the stream ended
-	// early, so close defensively without args).
+	// Close any still-open blocks. Reaching here with one open means the stream
+	// ended before its output_item.done (truncation); flush any buffered tool
+	// args first so a partial tool call still delivers its input_json_delta.
 	for oi, idx := range t.itemBlocks {
+		if t.itemKind[oi] == "tool_use" {
+			if err := t.emitValidatedToolArgsDelta(oi, idx, ""); err != nil {
+				return err
+			}
+		}
 		delete(t.itemBlocks, oi)
 		delete(t.itemKind, oi)
 		if err := t.emitContentBlockStop(idx); err != nil {
 			return err
 		}
 	}
-	stop := t.finalStopReason
-	if stop == "" {
-		stop = "end_turn"
-	}
-	t.emittedStopReason = stop
-	if err := t.emitMessageDelta(stop); err != nil {
+	t.emittedStopReason = t.reconciledStopReason()
+	if err := t.emitMessageDelta(t.emittedStopReason); err != nil {
 		return err
 	}
 	if err := t.emitMessageStop(); err != nil {
@@ -355,6 +374,23 @@ func (t *ResponsesToAnthropicWriter) finishStream() error {
 	}
 	t.closed = true
 	return nil
+}
+
+// reconciledStopReason enforces the Anthropic invariant that a turn with
+// tool_use blocks reports stop_reason "tool_use" and one without never does —
+// independent of the terminal Responses payload, which can be absent (truncated
+// stream) or disagree with what was actually streamed. Mirrors the promotion /
+// demotion in AnthropicSSETranslator.emitMessageDelta.
+func (t *ResponsesToAnthropicWriter) reconciledStopReason() string {
+	switch {
+	case t.toolUseCount > 0:
+		return "tool_use"
+	case t.finalStopReason == "" || t.finalStopReason == "tool_use":
+		// No terminal event, or it claimed tool_use with no block surviving.
+		return "end_turn"
+	default:
+		return t.finalStopReason
+	}
 }
 
 // --- non-streaming path ---
@@ -528,22 +564,30 @@ func (t *ResponsesToAnthropicWriter) emitContentBlockDeltaThinking(index int, te
 }
 
 // emitValidatedToolArgsDelta emits a single input_json_delta for a tool block,
-// carrying the buffered arguments — or `{}` when they are empty or fail to
-// parse, so a malformed concatenation can't break the client's tool-args parser.
-func (t *ResponsesToAnthropicWriter) emitValidatedToolArgsDelta(oi, index int) error {
+// carrying the buffered arguments. When those are empty or fail to parse it
+// falls back to fallback (the authoritative `arguments` from the terminal
+// item), and only as a last resort `{}` — so a malformed concatenation or a
+// lost delta stream can't break the client's tool-args parser.
+func (t *ResponsesToAnthropicWriter) emitValidatedToolArgsDelta(oi, index int, fallback string) error {
 	buf, ok := t.toolArgs[oi]
 	delete(t.toolArgs, oi)
-	args := "{}"
+	buffered := ""
 	if ok {
-		if s := buf.String(); s != "" && gjson.Valid(s) {
-			args = s
-		} else if s != "" {
-			observability.Get().Error(
-				"ResponsesToAnthropic tool_use args failed JSON validation — substituting empty args",
-				"block_index", index,
-				"args_len", len(s),
-			)
-		}
+		buffered = buf.String()
+	}
+	args := "{}"
+	switch {
+	case buffered != "" && gjson.Valid(buffered):
+		args = buffered
+	case fallback != "" && gjson.Valid(fallback):
+		args = fallback
+	case buffered != "" || fallback != "":
+		observability.Get().Error(
+			"ResponsesToAnthropic tool_use args failed JSON validation — substituting empty args",
+			"block_index", index,
+			"buffered_len", len(buffered),
+			"fallback_len", len(fallback),
+		)
 	}
 	t.bw.WriteString("event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":")
 	sse.WriteJSONInt(t.bw, int64(index))

--- a/internal/translate/responses_to_anthropic_writer.go
+++ b/internal/translate/responses_to_anthropic_writer.go
@@ -198,14 +198,17 @@ func (t *ResponsesToAnthropicWriter) processResponsesSSEBuffer() error {
 }
 
 func (t *ResponsesToAnthropicWriter) translateResponsesEvent(raw []byte) error {
+	if t.closed {
+		return nil
+	}
 	_, data := sse.ParseEvent(raw)
 	if len(data) == 0 {
 		return nil
 	}
 	// Match on the in-payload `type` (the `event:` line duplicates it but is
 	// sometimes dropped by intermediaries). Unknown response.* events are
-	// ignored; the ones below cover reasoning, text, tool calls, and the
-	// terminal envelope.
+	// ignored; the ones below cover reasoning, text, tool calls, the terminal
+	// envelope, and stream-level failures.
 	switch gjson.GetBytes(data, "type").String() {
 	case "response.output_item.added":
 		return t.handleOutputItemAdded(data)
@@ -224,7 +227,17 @@ func (t *ResponsesToAnthropicWriter) translateResponsesEvent(raw []byte) error {
 		return nil
 	case "response.output_item.done":
 		return t.handleOutputItemDone(data)
-	case "response.completed", "response.incomplete", "response.failed":
+	case "error":
+		// Stream-level failure over HTTP 200 — surface it as an Anthropic error
+		// event instead of closing the turn as if it succeeded.
+		return t.emitStreamErrorEvent(gjson.GetBytes(data, "code").String(), gjson.GetBytes(data, "message").String())
+	case "response.failed":
+		if e := gjson.GetBytes(data, "response.error"); e.Exists() {
+			return t.emitStreamErrorEvent(e.Get("code").String(), e.Get("message").String())
+		}
+		t.captureFinalResponse(data)
+		return nil
+	case "response.completed", "response.incomplete":
 		t.captureFinalResponse(data)
 		return nil
 	}
@@ -775,6 +788,20 @@ func (t *ResponsesToAnthropicWriter) emitMessageDelta(stopReason string) error {
 func (t *ResponsesToAnthropicWriter) emitMessageStop() error {
 	t.bw.WriteString("event: message_stop\ndata: {\"type\":\"message_stop\"}\n\n")
 	return t.flushEvent()
+}
+
+// emitStreamErrorEvent writes an Anthropic `event: error` frame for a
+// stream-level failure (an `error` or `response.failed` event over HTTP 200) and
+// marks the stream closed so finishStream does not also emit a success trailer.
+func (t *ResponsesToAnthropicWriter) emitStreamErrorEvent(errType, msg string) error {
+	t.bw.WriteString("event: error\ndata: ")
+	t.bw.Write(responsesError(errType, msg))
+	t.bw.WriteString("\n\n")
+	if err := t.flushEvent(); err != nil {
+		return err
+	}
+	t.closed = true
+	return nil
 }
 
 func (t *ResponsesToAnthropicWriter) flushEvent() error {

--- a/internal/translate/responses_to_anthropic_writer.go
+++ b/internal/translate/responses_to_anthropic_writer.go
@@ -325,12 +325,12 @@ func (t *ResponsesToAnthropicWriter) handleOutputItemDone(data []byte) error {
 	item := gjson.GetBytes(data, "item")
 	idx, ok := t.itemBlocks[oi]
 	if !ok {
-		// No delta opened a block for this item. Some upstreams send a
-		// message/reasoning item's full content only on output_item.done; without
-		// this a delta-less item would yield an empty assistant turn on the
-		// streaming path (the non-streaming path already rebuilds from
+		// No delta opened a block for this item. Some upstreams send an item's
+		// full content only on output_item.done (or output_item.added was lost);
+		// without this a delta-less item would yield an empty assistant turn on
+		// the streaming path (the non-streaming path already rebuilds from
 		// response.completed). Synthesize the block from the terminal item.
-		return t.emitDoneOnlyItem(item)
+		return t.emitDoneOnlyItem(oi, item)
 	}
 	if t.itemKind[oi] == "tool_use" {
 		// item.arguments on the terminal event is the authoritative complete
@@ -345,11 +345,27 @@ func (t *ResponsesToAnthropicWriter) handleOutputItemDone(data []byte) error {
 }
 
 // emitDoneOnlyItem synthesizes a content block from a completed output item that
-// opened no block via streamed deltas — some upstreams deliver a message's full
-// text or a reasoning item's summary only on output_item.done. Emitted as one
-// start/delta/stop so a delta-less item still produces visible content.
-func (t *ResponsesToAnthropicWriter) emitDoneOnlyItem(item gjson.Result) error {
+// opened no block via streamed deltas — some upstreams deliver an item's full
+// content only on output_item.done, or output_item.added was lost. Emitted as
+// one start/delta/stop so a delta-less item still produces content.
+func (t *ResponsesToAnthropicWriter) emitDoneOnlyItem(oi int, item gjson.Result) error {
 	switch item.Get("type").String() {
+	case "function_call":
+		name := item.Get("name").String()
+		if name == "" {
+			delete(t.toolArgs, oi)
+			return nil // nameless call → drop, as in handleOutputItemAdded
+		}
+		idx := t.blockIdx
+		t.blockIdx++
+		t.toolUseCount++
+		if err := t.emitContentBlockStartTool(idx, item.Get("call_id").String(), name); err != nil {
+			return err
+		}
+		if err := t.emitValidatedToolArgsDelta(oi, idx, item.Get("arguments").String()); err != nil {
+			return err
+		}
+		return t.emitContentBlockStop(idx)
 	case "message":
 		var text strings.Builder
 		item.Get("content").ForEach(func(_, part gjson.Result) bool {

--- a/internal/translate/responses_to_anthropic_writer.go
+++ b/internal/translate/responses_to_anthropic_writer.go
@@ -281,20 +281,70 @@ func (t *ResponsesToAnthropicWriter) bufferToolArgs(data []byte, field string, a
 
 func (t *ResponsesToAnthropicWriter) handleOutputItemDone(data []byte) error {
 	oi := int(gjson.GetBytes(data, "output_index").Int())
+	item := gjson.GetBytes(data, "item")
 	idx, ok := t.itemBlocks[oi]
 	if !ok {
-		return nil
+		// No delta opened a block for this item. Some upstreams send a
+		// message/reasoning item's full content only on output_item.done; without
+		// this a delta-less item would yield an empty assistant turn on the
+		// streaming path (the non-streaming path already rebuilds from
+		// response.completed). Synthesize the block from the terminal item.
+		return t.emitDoneOnlyItem(item)
 	}
 	if t.itemKind[oi] == "tool_use" {
 		// item.arguments on the terminal event is the authoritative complete
 		// args; use it when the streamed deltas were absent or malformed.
-		if err := t.emitValidatedToolArgsDelta(oi, idx, gjson.GetBytes(data, "item.arguments").String()); err != nil {
+		if err := t.emitValidatedToolArgsDelta(oi, idx, item.Get("arguments").String()); err != nil {
 			return err
 		}
 	}
 	delete(t.itemBlocks, oi)
 	delete(t.itemKind, oi)
 	return t.emitContentBlockStop(idx)
+}
+
+// emitDoneOnlyItem synthesizes a content block from a completed output item that
+// opened no block via streamed deltas — some upstreams deliver a message's full
+// text or a reasoning item's summary only on output_item.done. Emitted as one
+// start/delta/stop so a delta-less item still produces visible content.
+func (t *ResponsesToAnthropicWriter) emitDoneOnlyItem(item gjson.Result) error {
+	switch item.Get("type").String() {
+	case "message":
+		var text strings.Builder
+		item.Get("content").ForEach(func(_, part gjson.Result) bool {
+			if part.Get("type").String() == "output_text" {
+				text.WriteString(part.Get("text").String())
+			}
+			return true
+		})
+		if text.Len() == 0 {
+			return nil
+		}
+		idx := t.blockIdx
+		t.blockIdx++
+		if err := t.emitContentBlockStartText(idx); err != nil {
+			return err
+		}
+		if err := t.emitContentBlockDeltaText(idx, text.String()); err != nil {
+			return err
+		}
+		return t.emitContentBlockStop(idx)
+	case "reasoning":
+		text := joinReasoningSummary(item.Get("summary"))
+		if text == "" {
+			return nil
+		}
+		idx := t.blockIdx
+		t.blockIdx++
+		if err := t.emitContentBlockStartThinking(idx); err != nil {
+			return err
+		}
+		if err := t.emitContentBlockDeltaThinking(idx, text); err != nil {
+			return err
+		}
+		return t.emitContentBlockStop(idx)
+	}
+	return nil
 }
 
 // openBlock returns the Anthropic block index for output_index oi, opening a
@@ -582,11 +632,22 @@ func (t *ResponsesToAnthropicWriter) emitValidatedToolArgsDelta(oi, index int, f
 	case fallback != "" && gjson.Valid(fallback):
 		args = fallback
 	case buffered != "" || fallback != "":
+		bad := buffered
+		if bad == "" {
+			bad = fallback
+		}
+		const previewMax = 200
+		preview := bad
+		if len(preview) > previewMax {
+			preview = preview[:previewMax]
+		}
 		observability.Get().Error(
 			"ResponsesToAnthropic tool_use args failed JSON validation — substituting empty args",
 			"block_index", index,
+			"request_model", t.requestModel,
 			"buffered_len", len(buffered),
 			"fallback_len", len(fallback),
+			"args_preview", preview,
 		)
 	}
 	t.bw.WriteString("event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":")

--- a/internal/translate/responses_to_anthropic_writer.go
+++ b/internal/translate/responses_to_anthropic_writer.go
@@ -514,6 +514,15 @@ func (t *ResponsesToAnthropicWriter) finalizeBuffered() error {
 		observability.Get().Error("ResponsesToAnthropic: no terminal response event in stream")
 		return t.finalizeError()
 	}
+	// A failed terminal response is an error, not an (empty) assistant turn —
+	// surface it the way the streaming path does, rather than building success
+	// JSON from a failed payload. `incomplete` (max_output_tokens) is a valid
+	// truncated response and is left to ResponsesToAnthropicResponse.
+	respErr := gjson.GetBytes(finalResp, "error")
+	if gjson.GetBytes(finalResp, "status").String() == "failed" || (respErr.Exists() && respErr.Type != gjson.Null) {
+		observability.Get().Error("ResponsesToAnthropic: upstream response failed", "request_model", t.requestModel)
+		return t.finalizeError()
+	}
 	anthropic, err := ResponsesToAnthropicResponse(finalResp, t.requestModel)
 	if err != nil {
 		observability.Get().Error("ResponsesToAnthropic: translate failed", "err", err)

--- a/internal/translate/responses_to_anthropic_writer.go
+++ b/internal/translate/responses_to_anthropic_writer.go
@@ -2,7 +2,9 @@ package translate
 
 import (
 	"bufio"
+	"bytes"
 	"net/http"
+	"strings"
 
 	"workweave/router/internal/observability"
 	"workweave/router/internal/observability/otel"
@@ -11,12 +13,15 @@ import (
 	"github.com/tidwall/gjson"
 )
 
-// ResponsesToAnthropicWriter adapts a NON-streaming OpenAI Responses upstream
-// response into an Anthropic Messages response for the client. It buffers the
-// upstream JSON, translates it with ResponsesToAnthropicResponse, then either
-// writes a one-shot Anthropic JSON body (non-streaming client) or replays it as
-// a synthetic Anthropic SSE sequence (streaming client). It exposes the same
-// Prelude/Write/Finalize/Summary surface the proxy's OpenAI dispatch expects.
+// ResponsesToAnthropicWriter adapts a STREAMING OpenAI Responses upstream
+// (`POST /v1/responses` with `stream:true`) into an Anthropic Messages response
+// for the client. For a streaming client it parses the Responses SSE event
+// stream and emits Anthropic SSE incrementally (reasoning → thinking, output
+// text → text, function_call → tool_use); for a non-streaming client it buffers
+// the stream and renders a one-shot Anthropic JSON body from the terminal
+// `response.completed` event via ResponsesToAnthropicResponse. It exposes the
+// Prelude/Write/Finalize/Summary surface the proxy's OpenAI dispatch expects,
+// mirroring AnthropicSSETranslator so the dispatch closure is identical.
 type ResponsesToAnthropicWriter struct {
 	inner        http.ResponseWriter
 	flusher      http.Flusher
@@ -28,19 +33,44 @@ type ResponsesToAnthropicWriter struct {
 	estimatedInputTokens int
 	requestHadTools      bool
 
-	buf            []byte
+	buf            bytes.Buffer
 	statusCode     int
 	streaming      bool
 	headersEmitted bool
 	started        bool
+	// closed guards against a second close after Finalize emits the trailer.
+	closed bool
 
-	// summary fields
-	emittedStopReason string
+	// blockIdx is the next Anthropic content-block index to assign.
+	blockIdx int
+	// itemBlocks maps an OpenAI Responses output_index to the Anthropic content
+	// block index opened for it. Responses emits output items sequentially, but
+	// keying by output_index keeps each item's deltas correlated to its block
+	// regardless of ordering.
+	itemBlocks map[int]int
+	// itemKind records the Anthropic block kind per output_index so the matching
+	// output_item.done can close it correctly.
+	itemKind map[int]string
+	// toolArgs accumulates function_call_arguments deltas per output_index. The
+	// concatenated payload is validated and emitted as a single input_json_delta
+	// at item close — mirroring AnthropicSSETranslator, a payload that fails to
+	// parse becomes `{}` rather than killing the client's strict tool-args
+	// parser mid-turn.
+	toolArgs map[int]*strings.Builder
+
+	// Captured from the terminal response.completed/.failed/.incomplete event.
+	finalStopReason string
+	hasUsage        bool
+	usageInput      int
+	usageOutput     int
+	usageCacheRead  int
+
+	// Summary fields.
 	toolUseCount      int
-	outputTokens      int
+	emittedStopReason string
 }
 
-// NewResponsesToAnthropicWriter wraps w to translate a buffered Responses
+// NewResponsesToAnthropicWriter wraps w to translate a streaming Responses
 // upstream into Anthropic for the client.
 func NewResponsesToAnthropicWriter(w http.ResponseWriter, requestModel string, sink otel.UsageSink) *ResponsesToAnthropicWriter {
 	flusher, _ := w.(http.Flusher)
@@ -51,6 +81,9 @@ func NewResponsesToAnthropicWriter(w http.ResponseWriter, requestModel string, s
 		requestModel: requestModel,
 		usageSink:    sink,
 		statusCode:   http.StatusOK,
+		itemBlocks:   make(map[int]int),
+		itemKind:     make(map[int]string),
+		toolArgs:     make(map[int]*strings.Builder),
 	}
 }
 
@@ -73,9 +106,8 @@ func (t *ResponsesToAnthropicWriter) WithRequestHadTools(hadTools bool) *Respons
 
 func (t *ResponsesToAnthropicWriter) Header() http.Header { return t.inner.Header() }
 
-// WriteHeader captures the upstream status. The Responses upstream is always
-// non-streaming JSON, so we never switch to SSE here — the streaming decision
-// is the CLIENT's, committed in Prelude.
+// WriteHeader captures the upstream status. The streaming decision is the
+// CLIENT's, committed in Prelude, so we never flip to SSE here.
 func (t *ResponsesToAnthropicWriter) WriteHeader(code int) {
 	if t.headersEmitted {
 		return
@@ -83,9 +115,16 @@ func (t *ResponsesToAnthropicWriter) WriteHeader(code int) {
 	t.statusCode = code
 }
 
+// Write receives upstream Responses bytes. When the client is streaming, it
+// parses complete SSE events and emits Anthropic frames on the fly; otherwise
+// it buffers the raw stream for Finalize.
 func (t *ResponsesToAnthropicWriter) Write(data []byte) (int, error) {
-	t.buf = append(t.buf, data...)
-	return len(data), nil
+	n := len(data)
+	t.buf.Write(data)
+	if !t.streaming {
+		return n, nil
+	}
+	return n, t.processResponsesSSEBuffer()
 }
 
 func (t *ResponsesToAnthropicWriter) Flush() {
@@ -94,10 +133,9 @@ func (t *ResponsesToAnthropicWriter) Flush() {
 	}
 }
 
-// Prelude commits SSE headers + message_start eagerly when the client requested
-// streaming, mirroring AnthropicSSETranslator so the dispatch closure is
-// identical. The content blocks are emitted later in Finalize once the buffered
-// upstream body is translated.
+// Prelude commits SSE headers + message_start (+ routing marker block) eagerly
+// when the client requested streaming, so the client sees the message envelope
+// while the upstream is still reasoning.
 func (t *ResponsesToAnthropicWriter) Prelude(streaming bool) error {
 	if !streaming || t.started {
 		return nil
@@ -110,198 +148,265 @@ func (t *ResponsesToAnthropicWriter) Prelude(streaming bool) error {
 	t.inner.WriteHeader(http.StatusOK)
 	t.headersEmitted = true
 	t.started = true
-	if err := t.emitMessageStartFrame(t.requestModel, "msg_responses", t.estimatedInputTokens); err != nil {
+	if err := t.emitMessageStart(); err != nil {
 		return err
 	}
-	return t.emitRoutingMarkerFrame()
+	return t.emitRoutingMarkerIfConfigured()
 }
 
-// Finalize translates the buffered Responses body and emits it: SSE replay for
-// a streaming client, one-shot JSON otherwise.
+// Finalize emits the streaming trailer (message_delta + message_stop) for a
+// streaming client, or renders the buffered stream as one-shot Anthropic JSON
+// for a non-streaming client.
 func (t *ResponsesToAnthropicWriter) Finalize() error {
-	if t.statusCode >= 400 {
-		return t.finalizeError()
+	if t.streaming {
+		if t.closed {
+			return nil
+		}
+		return t.finishStream()
 	}
-	anthropic, err := ResponsesToAnthropicResponse(t.buf, t.requestModel)
-	if err != nil {
-		observability.Get().Error("ResponsesToAnthropic: translate failed", "err", err)
-		return t.finalizeError()
-	}
-	root := gjson.ParseBytes(anthropic)
-	t.recordUsage(root.Get("usage"))
-	t.emittedStopReason = root.Get("stop_reason").String()
-	t.outputTokens = int(root.Get("usage.output_tokens").Int())
-
-	if !t.streaming {
-		t.inner.Header().Set("Content-Type", "application/json")
-		t.inner.Header().Del("Content-Length")
-		t.inner.WriteHeader(http.StatusOK)
-		_, err := t.inner.Write(anthropic)
-		return err
-	}
-	return t.replayAsSSE(root)
+	return t.finalizeBuffered()
 }
 
 func (t *ResponsesToAnthropicWriter) Summary() ResponseSummary {
 	return ResponseSummary{
 		StopReason:    t.emittedStopReason,
 		ToolUseBlocks: t.toolUseCount,
-		OutputTokens:  t.outputTokens,
+		OutputTokens:  t.usageOutput,
 	}
 }
 
-func (t *ResponsesToAnthropicWriter) recordUsage(usage gjson.Result) {
+// --- streaming path ---
+
+func (t *ResponsesToAnthropicWriter) processResponsesSSEBuffer() error {
+	for {
+		event, n := sse.SplitNext(t.buf.Bytes())
+		if n == 0 {
+			return nil
+		}
+		err := t.translateResponsesEvent(event)
+		t.buf.Next(n)
+		if err != nil {
+			return err
+		}
+	}
+}
+
+func (t *ResponsesToAnthropicWriter) translateResponsesEvent(raw []byte) error {
+	_, data := sse.ParseEvent(raw)
+	if len(data) == 0 {
+		return nil
+	}
+	// Match on the in-payload `type` (the `event:` line duplicates it but is
+	// sometimes dropped by intermediaries). Unknown response.* events are
+	// ignored; the ones below cover reasoning, text, tool calls, and the
+	// terminal envelope.
+	switch gjson.GetBytes(data, "type").String() {
+	case "response.output_item.added":
+		return t.handleOutputItemAdded(data)
+	case "response.output_text.delta":
+		return t.handleTextDelta(data)
+	case "response.reasoning_summary_text.delta", "response.reasoning_text.delta":
+		return t.handleReasoningDelta(data)
+	case "response.function_call_arguments.delta":
+		t.bufferToolArgs(data)
+		return nil
+	case "response.output_item.done":
+		return t.handleOutputItemDone(data)
+	case "response.completed", "response.incomplete", "response.failed":
+		t.captureFinalResponse(data)
+		return nil
+	}
+	return nil
+}
+
+func (t *ResponsesToAnthropicWriter) handleOutputItemAdded(data []byte) error {
+	oi := int(gjson.GetBytes(data, "output_index").Int())
+	item := gjson.GetBytes(data, "item")
+	if item.Get("type").String() != "function_call" {
+		// message / reasoning blocks open lazily on their first delta so a
+		// reasoning item that surfaces no summary text never opens an empty
+		// thinking block.
+		return nil
+	}
+	idx := t.blockIdx
+	t.itemBlocks[oi] = idx
+	t.itemKind[oi] = "tool_use"
+	t.toolUseCount++
+	t.blockIdx++
+	// Anthropic tool_use.id maps from call_id (not the fc_ item id).
+	return t.emitContentBlockStartTool(idx, item.Get("call_id").String(), item.Get("name").String())
+}
+
+func (t *ResponsesToAnthropicWriter) handleTextDelta(data []byte) error {
+	idx, err := t.openBlock(int(gjson.GetBytes(data, "output_index").Int()), "text")
+	if err != nil {
+		return err
+	}
+	return t.emitContentBlockDeltaText(idx, gjson.GetBytes(data, "delta").String())
+}
+
+func (t *ResponsesToAnthropicWriter) handleReasoningDelta(data []byte) error {
+	idx, err := t.openBlock(int(gjson.GetBytes(data, "output_index").Int()), "thinking")
+	if err != nil {
+		return err
+	}
+	return t.emitContentBlockDeltaThinking(idx, gjson.GetBytes(data, "delta").String())
+}
+
+func (t *ResponsesToAnthropicWriter) bufferToolArgs(data []byte) {
+	oi := int(gjson.GetBytes(data, "output_index").Int())
+	buf, ok := t.toolArgs[oi]
+	if !ok {
+		buf = &strings.Builder{}
+		t.toolArgs[oi] = buf
+	}
+	buf.WriteString(gjson.GetBytes(data, "delta").String())
+}
+
+func (t *ResponsesToAnthropicWriter) handleOutputItemDone(data []byte) error {
+	oi := int(gjson.GetBytes(data, "output_index").Int())
+	idx, ok := t.itemBlocks[oi]
+	if !ok {
+		return nil
+	}
+	if t.itemKind[oi] == "tool_use" {
+		if err := t.emitValidatedToolArgsDelta(oi, idx); err != nil {
+			return err
+		}
+	}
+	delete(t.itemBlocks, oi)
+	delete(t.itemKind, oi)
+	return t.emitContentBlockStop(idx)
+}
+
+// openBlock returns the Anthropic block index for output_index oi, opening a
+// new block of the given kind (text/thinking) on first use.
+func (t *ResponsesToAnthropicWriter) openBlock(oi int, kind string) (int, error) {
+	if idx, ok := t.itemBlocks[oi]; ok {
+		return idx, nil
+	}
+	idx := t.blockIdx
+	t.itemBlocks[oi] = idx
+	t.itemKind[oi] = kind
+	t.blockIdx++
+	if kind == "thinking" {
+		return idx, t.emitContentBlockStartThinking(idx)
+	}
+	return idx, t.emitContentBlockStartText(idx)
+}
+
+// captureFinalResponse records usage + stop reason from a terminal event's
+// nested `response` object.
+func (t *ResponsesToAnthropicWriter) captureFinalResponse(data []byte) {
+	resp := gjson.GetBytes(data, "response")
+	if !resp.Exists() {
+		return
+	}
+	hasToolCall := false
+	resp.Get("output").ForEach(func(_, item gjson.Result) bool {
+		if item.Get("type").String() == "function_call" {
+			hasToolCall = true
+			return false
+		}
+		return true
+	})
+	switch {
+	case hasToolCall:
+		t.finalStopReason = "tool_use"
+	case resp.Get("incomplete_details.reason").String() == "max_output_tokens" || resp.Get("status").String() == "incomplete":
+		t.finalStopReason = "max_tokens"
+	default:
+		t.finalStopReason = "end_turn"
+	}
+	usage := resp.Get("usage")
+	if usage.Exists() {
+		t.hasUsage = true
+		t.usageInput = int(usage.Get("input_tokens").Int())
+		t.usageOutput = int(usage.Get("output_tokens").Int())
+		t.usageCacheRead = int(usage.Get("input_tokens_details.cached_tokens").Int())
+		if t.usageSink != nil {
+			t.usageSink.RecordUsage(t.usageInput, t.usageOutput)
+			t.usageSink.RecordCacheUsage(0, t.usageCacheRead)
+		}
+	}
+}
+
+func (t *ResponsesToAnthropicWriter) finishStream() error {
+	// Close any still-open blocks (a tool block's args are flushed at
+	// output_item.done; reaching here with one open means the stream ended
+	// early, so close defensively without args).
+	for oi, idx := range t.itemBlocks {
+		delete(t.itemBlocks, oi)
+		delete(t.itemKind, oi)
+		if err := t.emitContentBlockStop(idx); err != nil {
+			return err
+		}
+	}
+	stop := t.finalStopReason
+	if stop == "" {
+		stop = "end_turn"
+	}
+	t.emittedStopReason = stop
+	if err := t.emitMessageDelta(stop); err != nil {
+		return err
+	}
+	if err := t.emitMessageStop(); err != nil {
+		return err
+	}
+	t.closed = true
+	return nil
+}
+
+// --- non-streaming path ---
+
+// finalizeBuffered renders the buffered Responses stream as a one-shot Anthropic
+// JSON body for a non-streaming client. It extracts the final `response` object
+// from the terminal SSE event and reuses ResponsesToAnthropicResponse.
+func (t *ResponsesToAnthropicWriter) finalizeBuffered() error {
+	if t.statusCode >= 400 {
+		return t.finalizeError()
+	}
+	finalResp := extractFinalResponseObject(t.buf.Bytes())
+	if finalResp == nil {
+		observability.Get().Error("ResponsesToAnthropic: no terminal response event in stream")
+		return t.finalizeError()
+	}
+	anthropic, err := ResponsesToAnthropicResponse(finalResp, t.requestModel)
+	if err != nil {
+		observability.Get().Error("ResponsesToAnthropic: translate failed", "err", err)
+		return t.finalizeError()
+	}
+	root := gjson.ParseBytes(anthropic)
+	t.recordBufferedUsage(root.Get("usage"))
+	t.emittedStopReason = root.Get("stop_reason").String()
+	t.usageOutput = int(root.Get("usage.output_tokens").Int())
+	root.Get("content").ForEach(func(_, block gjson.Result) bool {
+		if block.Get("type").String() == "tool_use" {
+			t.toolUseCount++
+		}
+		return true
+	})
+
+	t.inner.Header().Set("Content-Type", "application/json")
+	t.inner.Header().Del("Content-Length")
+	t.inner.WriteHeader(http.StatusOK)
+	_, err = t.inner.Write(anthropic)
+	return err
+}
+
+func (t *ResponsesToAnthropicWriter) recordBufferedUsage(usage gjson.Result) {
 	if t.usageSink == nil || !usage.Exists() {
 		return
 	}
-	in := int(usage.Get("input_tokens").Int())
-	out := int(usage.Get("output_tokens").Int())
-	cacheRead := int(usage.Get("cache_read_input_tokens").Int())
-	t.usageSink.RecordUsage(in, out)
-	t.usageSink.RecordCacheUsage(0, cacheRead)
+	t.usageSink.RecordUsage(int(usage.Get("input_tokens").Int()), int(usage.Get("output_tokens").Int()))
+	t.usageSink.RecordCacheUsage(0, int(usage.Get("cache_read_input_tokens").Int()))
 }
 
-// replayAsSSE emits the translated Anthropic message as an SSE sequence.
-// message_start (+ routing marker) was already emitted by Prelude; here we emit
-// the content blocks starting at the next index, then message_delta + stop.
-func (t *ResponsesToAnthropicWriter) replayAsSSE(msg gjson.Result) error {
-	idx := 0
-	if t.routingMarker != "" {
-		idx = 1 // routing marker occupies block 0
-	}
-	var emitErr error
-	msg.Get("content").ForEach(func(_, block gjson.Result) bool {
-		switch block.Get("type").String() {
-		case "thinking":
-			emitErr = t.emitThinkingBlock(idx, block.Get("thinking").String())
-		case "text":
-			emitErr = t.emitTextBlock(idx, block.Get("text").String())
-		case "tool_use":
-			t.toolUseCount++
-			emitErr = t.emitToolUseBlock(idx, block.Get("id").String(), block.Get("name").String(), block.Get("input").Raw)
-		default:
-			return true
-		}
-		idx++
-		return emitErr == nil
-	})
-	if emitErr != nil {
-		return emitErr
-	}
-	if err := t.emitMessageDeltaFrame(msg.Get("stop_reason").String(), t.outputTokens); err != nil {
-		return err
-	}
-	return t.emitMessageStopFrame()
-}
-
-// --- SSE frame emitters (self-contained; mirror AnthropicSSETranslator wire shapes) ---
-
-func (t *ResponsesToAnthropicWriter) flushEvent() error {
-	if err := t.bw.Flush(); err != nil {
-		return err
-	}
-	if t.flusher != nil {
-		t.flusher.Flush()
-	}
-	return nil
-}
-
-func (t *ResponsesToAnthropicWriter) emitMessageStartFrame(model, id string, inputTokens int) error {
-	t.bw.WriteString("event: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"id\":")
-	sse.WriteJSONString(t.bw, id)
-	t.bw.WriteString(",\"type\":\"message\",\"role\":\"assistant\",\"content\":[],\"model\":")
-	sse.WriteJSONString(t.bw, model)
-	t.bw.WriteString(",\"stop_reason\":null,\"stop_sequence\":null,\"usage\":{\"input_tokens\":")
-	sse.WriteJSONInt(t.bw, int64(inputTokens))
-	t.bw.WriteString(",\"output_tokens\":0}}}\n\n")
-	return t.flushEvent()
-}
-
-func (t *ResponsesToAnthropicWriter) emitRoutingMarkerFrame() error {
-	if t.routingMarker == "" {
-		return nil
-	}
-	if err := t.emitTextBlock(0, t.routingMarker); err != nil {
-		return err
-	}
-	return nil
-}
-
-func (t *ResponsesToAnthropicWriter) emitTextBlock(index int, text string) error {
-	t.bw.WriteString("event: content_block_start\ndata: {\"type\":\"content_block_start\",\"index\":")
-	sse.WriteJSONInt(t.bw, int64(index))
-	t.bw.WriteString(",\"content_block\":{\"type\":\"text\",\"text\":\"\"}}\n\n")
-	t.bw.WriteString("event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":")
-	sse.WriteJSONInt(t.bw, int64(index))
-	t.bw.WriteString(",\"delta\":{\"type\":\"text_delta\",\"text\":")
-	sse.WriteJSONString(t.bw, text)
-	t.bw.WriteString("}}\n\n")
-	return t.emitBlockStop(index)
-}
-
-func (t *ResponsesToAnthropicWriter) emitThinkingBlock(index int, text string) error {
-	t.bw.WriteString("event: content_block_start\ndata: {\"type\":\"content_block_start\",\"index\":")
-	sse.WriteJSONInt(t.bw, int64(index))
-	t.bw.WriteString(",\"content_block\":{\"type\":\"thinking\",\"thinking\":\"\"}}\n\n")
-	t.bw.WriteString("event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":")
-	sse.WriteJSONInt(t.bw, int64(index))
-	t.bw.WriteString(",\"delta\":{\"type\":\"thinking_delta\",\"thinking\":")
-	sse.WriteJSONString(t.bw, text)
-	t.bw.WriteString("}}\n\n")
-	return t.emitBlockStop(index)
-}
-
-func (t *ResponsesToAnthropicWriter) emitToolUseBlock(index int, id, name, inputRaw string) error {
-	if inputRaw == "" {
-		inputRaw = "{}"
-	}
-	t.bw.WriteString("event: content_block_start\ndata: {\"type\":\"content_block_start\",\"index\":")
-	sse.WriteJSONInt(t.bw, int64(index))
-	t.bw.WriteString(",\"content_block\":{\"type\":\"tool_use\",\"id\":")
-	sse.WriteJSONString(t.bw, id)
-	t.bw.WriteString(",\"name\":")
-	sse.WriteJSONString(t.bw, name)
-	t.bw.WriteString(",\"input\":{}}}\n\n")
-	t.bw.WriteString("event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":")
-	sse.WriteJSONInt(t.bw, int64(index))
-	t.bw.WriteString(",\"delta\":{\"type\":\"input_json_delta\",\"partial_json\":")
-	sse.WriteJSONString(t.bw, inputRaw)
-	t.bw.WriteString("}}\n\n")
-	return t.emitBlockStop(index)
-}
-
-func (t *ResponsesToAnthropicWriter) emitBlockStop(index int) error {
-	t.bw.WriteString("event: content_block_stop\ndata: {\"type\":\"content_block_stop\",\"index\":")
-	sse.WriteJSONInt(t.bw, int64(index))
-	t.bw.WriteString("}\n\n")
-	return t.flushEvent()
-}
-
-func (t *ResponsesToAnthropicWriter) emitMessageDeltaFrame(stopReason string, outputTokens int) error {
-	if stopReason == "" {
-		stopReason = "end_turn"
-	}
-	t.bw.WriteString("event: message_delta\ndata: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":")
-	sse.WriteJSONString(t.bw, stopReason)
-	t.bw.WriteString(",\"stop_sequence\":null},\"usage\":{\"output_tokens\":")
-	sse.WriteJSONInt(t.bw, int64(outputTokens))
-	t.bw.WriteString("}}\n\n")
-	return t.flushEvent()
-}
-
-func (t *ResponsesToAnthropicWriter) emitMessageStopFrame() error {
-	t.bw.WriteString("event: message_stop\ndata: {\"type\":\"message_stop\"}\n\n")
-	return t.flushEvent()
-}
-
+// finalizeError renders a one-shot Anthropic error body. Only reached on the
+// non-streaming path; streaming errors are rendered by the dispatch's
+// emitAnthropicSSEErrorEvent before Finalize and closed out by finishStream.
 func (t *ResponsesToAnthropicWriter) finalizeError() error {
-	errBody := ResponsesToAnthropicError(t.buf)
-	if t.streaming {
-		t.bw.WriteString("event: error\ndata: ")
-		t.bw.Write(errBody)
-		t.bw.WriteString("\n\n")
-		return t.flushEvent()
-	}
+	errBody := ResponsesToAnthropicError(t.buf.Bytes())
 	if !t.headersEmitted {
 		t.inner.Header().Set("Content-Type", "application/json")
 		t.inner.Header().Del("Content-Length")
@@ -314,3 +419,184 @@ func (t *ResponsesToAnthropicWriter) finalizeError() error {
 	_, err := t.inner.Write(errBody)
 	return err
 }
+
+// extractFinalResponseObject scans a buffered Responses SSE stream for the last
+// terminal event (response.completed/.incomplete/.failed) and returns its
+// nested `response` object as raw JSON, or nil if none is present.
+func extractFinalResponseObject(sseBytes []byte) []byte {
+	var out []byte
+	rest := sseBytes
+	for {
+		event, n := sse.SplitNext(rest)
+		if n == 0 {
+			break
+		}
+		rest = rest[n:]
+		_, data := sse.ParseEvent(event)
+		if len(data) == 0 {
+			continue
+		}
+		switch gjson.GetBytes(data, "type").String() {
+		case "response.completed", "response.incomplete", "response.failed":
+			if resp := gjson.GetBytes(data, "response"); resp.Exists() {
+				out = []byte(resp.Raw)
+			}
+		}
+	}
+	return out
+}
+
+// --- Anthropic SSE frame emitters (wire shapes mirror AnthropicSSETranslator) ---
+
+func (t *ResponsesToAnthropicWriter) emitMessageStart() error {
+	model := t.requestModel
+	t.bw.WriteString("event: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"id\":")
+	sse.WriteJSONString(t.bw, "msg_responses")
+	t.bw.WriteString(",\"type\":\"message\",\"role\":\"assistant\",\"content\":[],\"model\":")
+	sse.WriteJSONString(t.bw, model)
+	t.bw.WriteString(",\"stop_reason\":null,\"stop_sequence\":null,\"usage\":{\"input_tokens\":")
+	sse.WriteJSONInt(t.bw, int64(t.estimatedInputTokens))
+	t.bw.WriteString(",\"output_tokens\":0}}}\n\n")
+	return t.flushEvent()
+}
+
+func (t *ResponsesToAnthropicWriter) emitRoutingMarkerIfConfigured() error {
+	if t.routingMarker == "" {
+		return nil
+	}
+	idx := t.blockIdx
+	if err := t.emitContentBlockStartText(idx); err != nil {
+		return err
+	}
+	if err := t.emitContentBlockDeltaText(idx, t.routingMarker); err != nil {
+		return err
+	}
+	if err := t.emitContentBlockStop(idx); err != nil {
+		return err
+	}
+	t.blockIdx++
+	return nil
+}
+
+func (t *ResponsesToAnthropicWriter) emitContentBlockStartText(index int) error {
+	t.bw.WriteString("event: content_block_start\ndata: {\"type\":\"content_block_start\",\"index\":")
+	sse.WriteJSONInt(t.bw, int64(index))
+	t.bw.WriteString(",\"content_block\":{\"type\":\"text\",\"text\":\"\"}}\n\n")
+	return t.flushEvent()
+}
+
+func (t *ResponsesToAnthropicWriter) emitContentBlockStartThinking(index int) error {
+	t.bw.WriteString("event: content_block_start\ndata: {\"type\":\"content_block_start\",\"index\":")
+	sse.WriteJSONInt(t.bw, int64(index))
+	t.bw.WriteString(",\"content_block\":{\"type\":\"thinking\",\"thinking\":\"\"}}\n\n")
+	return t.flushEvent()
+}
+
+func (t *ResponsesToAnthropicWriter) emitContentBlockStartTool(index int, id, name string) error {
+	t.bw.WriteString("event: content_block_start\ndata: {\"type\":\"content_block_start\",\"index\":")
+	sse.WriteJSONInt(t.bw, int64(index))
+	t.bw.WriteString(",\"content_block\":{\"type\":\"tool_use\",\"id\":")
+	sse.WriteJSONString(t.bw, id)
+	t.bw.WriteString(",\"name\":")
+	sse.WriteJSONString(t.bw, name)
+	t.bw.WriteString(",\"input\":{}}}\n\n")
+	return t.flushEvent()
+}
+
+func (t *ResponsesToAnthropicWriter) emitContentBlockDeltaText(index int, text string) error {
+	if text == "" {
+		return nil
+	}
+	t.bw.WriteString("event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":")
+	sse.WriteJSONInt(t.bw, int64(index))
+	t.bw.WriteString(",\"delta\":{\"type\":\"text_delta\",\"text\":")
+	sse.WriteJSONString(t.bw, text)
+	t.bw.WriteString("}}\n\n")
+	return t.flushEvent()
+}
+
+func (t *ResponsesToAnthropicWriter) emitContentBlockDeltaThinking(index int, text string) error {
+	if text == "" {
+		return nil
+	}
+	t.bw.WriteString("event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":")
+	sse.WriteJSONInt(t.bw, int64(index))
+	t.bw.WriteString(",\"delta\":{\"type\":\"thinking_delta\",\"thinking\":")
+	sse.WriteJSONString(t.bw, text)
+	t.bw.WriteString("}}\n\n")
+	return t.flushEvent()
+}
+
+// emitValidatedToolArgsDelta emits a single input_json_delta for a tool block,
+// carrying the buffered arguments — or `{}` when they are empty or fail to
+// parse, so a malformed concatenation can't break the client's tool-args parser.
+func (t *ResponsesToAnthropicWriter) emitValidatedToolArgsDelta(oi, index int) error {
+	buf, ok := t.toolArgs[oi]
+	delete(t.toolArgs, oi)
+	args := "{}"
+	if ok {
+		if s := buf.String(); s != "" && gjson.Valid(s) {
+			args = s
+		} else if s != "" {
+			observability.Get().Error(
+				"ResponsesToAnthropic tool_use args failed JSON validation — substituting empty args",
+				"block_index", index,
+				"args_len", len(s),
+			)
+		}
+	}
+	t.bw.WriteString("event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":")
+	sse.WriteJSONInt(t.bw, int64(index))
+	t.bw.WriteString(",\"delta\":{\"type\":\"input_json_delta\",\"partial_json\":")
+	sse.WriteJSONString(t.bw, args)
+	t.bw.WriteString("}}\n\n")
+	return t.flushEvent()
+}
+
+func (t *ResponsesToAnthropicWriter) emitContentBlockStop(index int) error {
+	t.bw.WriteString("event: content_block_stop\ndata: {\"type\":\"content_block_stop\",\"index\":")
+	sse.WriteJSONInt(t.bw, int64(index))
+	t.bw.WriteString("}\n\n")
+	return t.flushEvent()
+}
+
+func (t *ResponsesToAnthropicWriter) emitMessageDelta(stopReason string) error {
+	t.bw.WriteString("event: message_delta\ndata: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":")
+	sse.WriteJSONString(t.bw, stopReason)
+	t.bw.WriteString(",\"stop_sequence\":null},\"usage\":{")
+	if t.hasUsage {
+		// Anthropic's input_tokens is fresh-only; subtract cached reads so the
+		// statusline formula doesn't double-count.
+		freshInput := max(0, t.usageInput-t.usageCacheRead)
+		t.bw.WriteString("\"input_tokens\":")
+		sse.WriteJSONInt(t.bw, int64(freshInput))
+		t.bw.WriteString(",\"output_tokens\":")
+		sse.WriteJSONInt(t.bw, int64(t.usageOutput))
+		if t.usageCacheRead > 0 {
+			t.bw.WriteString(",\"cache_read_input_tokens\":")
+			sse.WriteJSONInt(t.bw, int64(t.usageCacheRead))
+		}
+	} else {
+		t.bw.WriteString("\"output_tokens\":0")
+	}
+	t.bw.WriteString("}}\n\n")
+	return t.flushEvent()
+}
+
+func (t *ResponsesToAnthropicWriter) emitMessageStop() error {
+	t.bw.WriteString("event: message_stop\ndata: {\"type\":\"message_stop\"}\n\n")
+	return t.flushEvent()
+}
+
+func (t *ResponsesToAnthropicWriter) flushEvent() error {
+	if err := t.bw.Flush(); err != nil {
+		return err
+	}
+	if t.flusher != nil {
+		t.flusher.Flush()
+	}
+	return nil
+}
+
+var _ http.ResponseWriter = (*ResponsesToAnthropicWriter)(nil)
+var _ http.Flusher = (*ResponsesToAnthropicWriter)(nil)

--- a/internal/translate/responses_to_anthropic_writer.go
+++ b/internal/translate/responses_to_anthropic_writer.go
@@ -57,6 +57,11 @@ type ResponsesToAnthropicWriter struct {
 	// parse becomes `{}` rather than killing the client's strict tool-args
 	// parser mid-turn.
 	toolArgs map[int]*strings.Builder
+	// suppressed holds output_indexes of function_call items dropped for carrying
+	// no name. A nameless tool_use makes the client invoke tool "" in a loop, so
+	// (mirroring AnthropicSSETranslator) we never open a block for it and drop its
+	// later arg deltas / done event.
+	suppressed map[int]struct{}
 
 	// Captured from the terminal response.completed/.failed/.incomplete event.
 	finalStopReason string
@@ -84,6 +89,7 @@ func NewResponsesToAnthropicWriter(w http.ResponseWriter, requestModel string, s
 		itemBlocks:   make(map[int]int),
 		itemKind:     make(map[int]string),
 		toolArgs:     make(map[int]*strings.Builder),
+		suppressed:   make(map[int]struct{}),
 	}
 }
 
@@ -234,13 +240,27 @@ func (t *ResponsesToAnthropicWriter) handleOutputItemAdded(data []byte) error {
 		// thinking block.
 		return nil
 	}
+	name := item.Get("name").String()
+	if name == "" {
+		// A nameless tool call would make the client invoke tool "" and loop.
+		// Drop it: skip the block, drop later arg deltas + the done event. The
+		// turn ends on its real stop_reason (reconciledStopReason demotes a
+		// terminal tool_use claim with no surviving block to end_turn).
+		t.suppressed[oi] = struct{}{}
+		observability.Get().Error(
+			"ResponsesToAnthropic dropping nameless function_call",
+			"request_model", t.requestModel,
+			"call_id", item.Get("call_id").String(),
+		)
+		return nil
+	}
 	idx := t.blockIdx
 	t.itemBlocks[oi] = idx
 	t.itemKind[oi] = "tool_use"
 	t.toolUseCount++
 	t.blockIdx++
 	// Anthropic tool_use.id maps from call_id (not the fc_ item id).
-	return t.emitContentBlockStartTool(idx, item.Get("call_id").String(), item.Get("name").String())
+	return t.emitContentBlockStartTool(idx, item.Get("call_id").String(), name)
 }
 
 func (t *ResponsesToAnthropicWriter) handleTextDelta(data []byte) error {
@@ -268,6 +288,9 @@ func (t *ResponsesToAnthropicWriter) bufferToolArgs(data []byte, field string, a
 		return
 	}
 	oi := int(gjson.GetBytes(data, "output_index").Int())
+	if _, dropped := t.suppressed[oi]; dropped {
+		return
+	}
 	buf, ok := t.toolArgs[oi]
 	if !ok {
 		buf = &strings.Builder{}
@@ -281,6 +304,11 @@ func (t *ResponsesToAnthropicWriter) bufferToolArgs(data []byte, field string, a
 
 func (t *ResponsesToAnthropicWriter) handleOutputItemDone(data []byte) error {
 	oi := int(gjson.GetBytes(data, "output_index").Int())
+	if _, dropped := t.suppressed[oi]; dropped {
+		delete(t.suppressed, oi)
+		delete(t.toolArgs, oi)
+		return nil
+	}
 	item := gjson.GetBytes(data, "item")
 	idx, ok := t.itemBlocks[oi]
 	if !ok {
@@ -492,7 +520,7 @@ func (t *ResponsesToAnthropicWriter) recordBufferedUsage(usage gjson.Result) {
 // non-streaming path; streaming errors are rendered by the dispatch's
 // emitAnthropicSSEErrorEvent before Finalize and closed out by finishStream.
 func (t *ResponsesToAnthropicWriter) finalizeError() error {
-	errBody := ResponsesToAnthropicError(t.buf.Bytes())
+	errBody := t.anthropicErrorFromBuffer()
 	if !t.headersEmitted {
 		t.inner.Header().Set("Content-Type", "application/json")
 		t.inner.Header().Del("Content-Length")
@@ -504,6 +532,62 @@ func (t *ResponsesToAnthropicWriter) finalizeError() error {
 	}
 	_, err := t.inner.Write(errBody)
 	return err
+}
+
+// anthropicErrorFromBuffer builds an Anthropic error envelope from whatever the
+// upstream left in buf. With stream:true the buffer is raw SSE, not a JSON error
+// body, so feeding it straight to ResponsesToAnthropicError yields an empty
+// message; instead scan the stream for a terminal `error` event or a failed
+// response's error, falling back to a clear generic message.
+func (t *ResponsesToAnthropicWriter) anthropicErrorFromBuffer() []byte {
+	b := t.buf.Bytes()
+	if gjson.ValidBytes(b) && gjson.GetBytes(b, "error").Exists() {
+		return ResponsesToAnthropicError(b)
+	}
+	rest := b
+	for {
+		event, n := sse.SplitNext(rest)
+		if n == 0 {
+			break
+		}
+		rest = rest[n:]
+		_, data := sse.ParseEvent(event)
+		if len(data) == 0 {
+			continue
+		}
+		switch gjson.GetBytes(data, "type").String() {
+		case "error":
+			return responsesError(gjson.GetBytes(data, "code").String(), gjson.GetBytes(data, "message").String())
+		case "response.failed", "response.incomplete":
+			if e := gjson.GetBytes(data, "response.error"); e.Exists() {
+				return responsesError(e.Get("code").String(), e.Get("message").String())
+			}
+		}
+	}
+	return responsesError("api_error", "upstream Responses stream ended without a terminal response event")
+}
+
+// responsesError builds an Anthropic error envelope from a Responses-style
+// type/message pair, routed through ResponsesToAnthropicError so the wire shape
+// stays single-sourced.
+func responsesError(errType, msg string) []byte {
+	if errType == "" {
+		errType = "api_error"
+	}
+	if msg == "" {
+		msg = "upstream Responses request failed"
+	}
+	jw := newJSONWriter()
+	jw.Obj()
+	jw.Key("error")
+	jw.Obj()
+	jw.Key("type")
+	jw.Str(errType)
+	jw.Key("message")
+	jw.Str(msg)
+	jw.EndObj()
+	jw.EndObj()
+	return ResponsesToAnthropicError(jw.Bytes())
 }
 
 // extractFinalResponseObject scans a buffered Responses SSE stream for the last

--- a/internal/translate/responses_to_anthropic_writer_stream_test.go
+++ b/internal/translate/responses_to_anthropic_writer_stream_test.go
@@ -143,6 +143,63 @@ func TestResponsesToAnthropicWriter_NonStreamingClient(t *testing.T) {
 	assert.Equal(t, "NYC", input["location"])
 }
 
+// A function_call that streams no argument deltas still delivers its real
+// arguments: the translator falls back to the authoritative item.arguments on
+// the terminal output_item.done rather than emitting {}.
+func TestResponsesToAnthropicWriter_ToolArgsFromDoneEvent(t *testing.T) {
+	const fixture = `event: response.output_item.added
+data: {"type":"response.output_item.added","output_index":0,"item":{"id":"fc_1","type":"function_call","call_id":"call_a","name":"Read","arguments":"","status":"in_progress"}}
+
+event: response.output_item.done
+data: {"type":"response.output_item.done","output_index":0,"item":{"id":"fc_1","type":"function_call","call_id":"call_a","name":"Read","arguments":"{\"path\":\"x.go\"}","status":"completed"}}
+
+event: response.completed
+data: {"type":"response.completed","response":{"id":"r","status":"completed","output":[{"id":"fc_1","type":"function_call","call_id":"call_a","name":"Read","arguments":"{\"path\":\"x.go\"}"}],"usage":{"input_tokens":10,"output_tokens":5}}}
+
+`
+	rec := httptest.NewRecorder()
+	w := translate.NewResponsesToAnthropicWriter(rec, "gpt-5.5", nil)
+	require.NoError(t, w.Prelude(true))
+	_, err := w.Write([]byte(fixture))
+	require.NoError(t, err)
+	require.NoError(t, w.Finalize())
+
+	body := rec.Body.String()
+	assert.Contains(t, body, `"partial_json":"{\"path\":\"x.go\"}"`,
+		"no arg deltas → fall back to item.arguments on output_item.done, not {}")
+	assert.NotContains(t, body, `"partial_json":"{}"`)
+	assert.Contains(t, body, `"stop_reason":"tool_use"`)
+}
+
+// A stream truncated before response.completed still reconciles to
+// stop_reason=tool_use (a tool block was emitted) and flushes the partial
+// tool args, rather than defaulting to end_turn with a dropped input_json_delta.
+func TestResponsesToAnthropicWriter_TruncatedToolStream(t *testing.T) {
+	const fixture = `event: response.output_item.added
+data: {"type":"response.output_item.added","output_index":0,"item":{"id":"fc_1","type":"function_call","call_id":"call_a","name":"Bash","arguments":"","status":"in_progress"}}
+
+event: response.function_call_arguments.delta
+data: {"type":"response.function_call_arguments.delta","item_id":"fc_1","output_index":0,"delta":"{\"command\":"}
+
+event: response.function_call_arguments.delta
+data: {"type":"response.function_call_arguments.delta","item_id":"fc_1","output_index":0,"delta":"\"ls\"}"}
+
+`
+	rec := httptest.NewRecorder()
+	w := translate.NewResponsesToAnthropicWriter(rec, "gpt-5.5", nil)
+	require.NoError(t, w.Prelude(true))
+	_, err := w.Write([]byte(fixture))
+	require.NoError(t, err)
+	require.NoError(t, w.Finalize()) // no response.completed arrived
+
+	body := rec.Body.String()
+	assert.Contains(t, body, `"partial_json":"{\"command\":\"ls\"}"`,
+		"buffered tool args flushed on early close")
+	assert.Contains(t, body, `"stop_reason":"tool_use"`,
+		"a tool_use block was emitted → invariant forces tool_use even with no terminal event")
+	assert.Contains(t, body, "event: message_stop")
+}
+
 // A routing marker is emitted as content block 0; upstream content then starts
 // at block 1.
 func TestResponsesToAnthropicWriter_RoutingMarker(t *testing.T) {

--- a/internal/translate/responses_to_anthropic_writer_stream_test.go
+++ b/internal/translate/responses_to_anthropic_writer_stream_test.go
@@ -317,6 +317,25 @@ data: {"type":"response.failed","response":{"id":"r","status":"failed","error":{
 	assert.NotContains(t, body, "event: message_stop", "no success trailer after an error close")
 }
 
+// response.failed with no error object is still surfaced as an error (generic
+// message), not a normal success close.
+func TestResponsesToAnthropicWriter_StreamingFailedNoErrorObject(t *testing.T) {
+	const fixture = `event: response.failed
+data: {"type":"response.failed","response":{"id":"r","status":"failed","output":[]}}
+
+`
+	rec := httptest.NewRecorder()
+	w := translate.NewResponsesToAnthropicWriter(rec, "gpt-5.5", nil)
+	require.NoError(t, w.Prelude(true))
+	_, err := w.Write([]byte(fixture))
+	require.NoError(t, err)
+	require.NoError(t, w.Finalize())
+
+	body := rec.Body.String()
+	assert.Contains(t, body, "event: error")
+	assert.NotContains(t, body, "event: message_stop")
+}
+
 // A function_call delivered only on output_item.done (no output_item.added)
 // still opens a tool_use block with its real id/name/args.
 func TestResponsesToAnthropicWriter_DoneOnlyToolCall(t *testing.T) {

--- a/internal/translate/responses_to_anthropic_writer_stream_test.go
+++ b/internal/translate/responses_to_anthropic_writer_stream_test.go
@@ -235,6 +235,62 @@ data: {"type":"response.completed","response":{"id":"r","status":"completed","ou
 	assert.Contains(t, body, `"stop_reason":"end_turn"`)
 }
 
+// A function_call with no name is dropped (never opened as a tool_use block),
+// so the client can't be sent on an invoke-"" loop; the turn demotes to
+// end_turn since no tool_use block survives.
+func TestResponsesToAnthropicWriter_NamelessToolDropped(t *testing.T) {
+	const fixture = `event: response.output_item.added
+data: {"type":"response.output_item.added","output_index":0,"item":{"id":"fc_x","type":"function_call","call_id":"call_x","name":"","arguments":"","status":"in_progress"}}
+
+event: response.function_call_arguments.delta
+data: {"type":"response.function_call_arguments.delta","item_id":"fc_x","output_index":0,"delta":"{\"a\":1}"}
+
+event: response.output_item.done
+data: {"type":"response.output_item.done","output_index":0,"item":{"id":"fc_x","type":"function_call","call_id":"call_x","name":"","arguments":"{\"a\":1}","status":"completed"}}
+
+event: response.completed
+data: {"type":"response.completed","response":{"id":"r","status":"completed","output":[{"id":"fc_x","type":"function_call","call_id":"call_x","name":"","arguments":"{\"a\":1}"}],"usage":{"input_tokens":3,"output_tokens":1}}}
+
+`
+	rec := httptest.NewRecorder()
+	w := translate.NewResponsesToAnthropicWriter(rec, "gpt-5.5", nil)
+	require.NoError(t, w.Prelude(true))
+	_, err := w.Write([]byte(fixture))
+	require.NoError(t, err)
+	require.NoError(t, w.Finalize())
+
+	body := rec.Body.String()
+	assert.NotContains(t, body, `"type":"tool_use"`, "nameless function_call must not open a tool_use block")
+	assert.NotContains(t, body, "input_json_delta")
+	assert.Contains(t, body, `"stop_reason":"end_turn"`, "no surviving tool_use block → demote to end_turn")
+	assert.Contains(t, body, "event: message_stop")
+}
+
+// On the non-streaming path, an upstream stream that ends without a terminal
+// response event but carries an `error` event yields a real Anthropic error
+// envelope — not an empty 502 from feeding raw SSE to the JSON error mapper.
+func TestResponsesToAnthropicWriter_NonStreamingErrorFromStream(t *testing.T) {
+	const fixture = `event: error
+data: {"type":"error","code":"server_error","message":"upstream exploded"}
+
+`
+	rec := httptest.NewRecorder()
+	w := translate.NewResponsesToAnthropicWriter(rec, "gpt-5.5", nil)
+	require.NoError(t, w.Prelude(false)) // non-streaming client → buffered
+	_, err := w.Write([]byte(fixture))
+	require.NoError(t, err)
+	require.NoError(t, w.Finalize())
+
+	assert.Equal(t, "application/json", rec.Header().Get("Content-Type"))
+	assert.NotContains(t, rec.Body.String(), "event: ")
+	var msg map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &msg))
+	assert.Equal(t, "error", msg["type"])
+	e, _ := msg["error"].(map[string]any)
+	require.NotNil(t, e)
+	assert.Contains(t, e["message"], "upstream exploded", "real upstream message surfaced, not empty")
+}
+
 // A routing marker is emitted as content block 0; upstream content then starts
 // at block 1.
 func TestResponsesToAnthropicWriter_RoutingMarker(t *testing.T) {

--- a/internal/translate/responses_to_anthropic_writer_stream_test.go
+++ b/internal/translate/responses_to_anthropic_writer_stream_test.go
@@ -340,6 +340,29 @@ data: {"type":"response.completed","response":{"id":"r","status":"completed","ou
 	assert.Contains(t, body, `"stop_reason":"tool_use"`)
 }
 
+// A non-streaming client also gets an error envelope (not empty success JSON)
+// when the buffered stream ends in response.failed — symmetric with the
+// streaming path's event: error.
+func TestResponsesToAnthropicWriter_NonStreamingFailedResponse(t *testing.T) {
+	const fixture = `event: response.failed
+data: {"type":"response.failed","response":{"id":"r","status":"failed","error":{"code":"server_error","message":"boom"},"output":[]}}
+
+`
+	rec := httptest.NewRecorder()
+	w := translate.NewResponsesToAnthropicWriter(rec, "gpt-5.5", nil)
+	require.NoError(t, w.Prelude(false))
+	_, err := w.Write([]byte(fixture))
+	require.NoError(t, err)
+	require.NoError(t, w.Finalize())
+
+	var msg map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &msg))
+	assert.Equal(t, "error", msg["type"], "failed response → error envelope, not an empty assistant message")
+	e, _ := msg["error"].(map[string]any)
+	require.NotNil(t, e)
+	assert.Contains(t, e["message"], "boom")
+}
+
 // A routing marker is emitted as content block 0; upstream content then starts
 // at block 1.
 func TestResponsesToAnthropicWriter_RoutingMarker(t *testing.T) {

--- a/internal/translate/responses_to_anthropic_writer_stream_test.go
+++ b/internal/translate/responses_to_anthropic_writer_stream_test.go
@@ -317,6 +317,29 @@ data: {"type":"response.failed","response":{"id":"r","status":"failed","error":{
 	assert.NotContains(t, body, "event: message_stop", "no success trailer after an error close")
 }
 
+// A function_call delivered only on output_item.done (no output_item.added)
+// still opens a tool_use block with its real id/name/args.
+func TestResponsesToAnthropicWriter_DoneOnlyToolCall(t *testing.T) {
+	const fixture = `event: response.output_item.done
+data: {"type":"response.output_item.done","output_index":0,"item":{"id":"fc_1","type":"function_call","call_id":"call_z","name":"Grep","arguments":"{\"pattern\":\"foo\"}","status":"completed"}}
+
+event: response.completed
+data: {"type":"response.completed","response":{"id":"r","status":"completed","output":[{"id":"fc_1","type":"function_call","call_id":"call_z","name":"Grep","arguments":"{\"pattern\":\"foo\"}"}],"usage":{"input_tokens":4,"output_tokens":2}}}
+
+`
+	rec := httptest.NewRecorder()
+	w := translate.NewResponsesToAnthropicWriter(rec, "gpt-5.5", nil)
+	require.NoError(t, w.Prelude(true))
+	_, err := w.Write([]byte(fixture))
+	require.NoError(t, err)
+	require.NoError(t, w.Finalize())
+
+	body := rec.Body.String()
+	assert.Contains(t, body, `"type":"tool_use","id":"call_z","name":"Grep"`)
+	assert.Contains(t, body, `"partial_json":"{\"pattern\":\"foo\"}"`)
+	assert.Contains(t, body, `"stop_reason":"tool_use"`)
+}
+
 // A routing marker is emitted as content block 0; upstream content then starts
 // at block 1.
 func TestResponsesToAnthropicWriter_RoutingMarker(t *testing.T) {

--- a/internal/translate/responses_to_anthropic_writer_stream_test.go
+++ b/internal/translate/responses_to_anthropic_writer_stream_test.go
@@ -291,6 +291,32 @@ data: {"type":"error","code":"server_error","message":"upstream exploded"}
 	assert.Contains(t, e["message"], "upstream exploded", "real upstream message surfaced, not empty")
 }
 
+// A streaming client sees a stream-level failure (response.failed over HTTP 200)
+// as an Anthropic `event: error`, not a silent normal close.
+func TestResponsesToAnthropicWriter_StreamingErrorEvent(t *testing.T) {
+	const fixture = `event: response.output_item.added
+data: {"type":"response.output_item.added","output_index":0,"item":{"id":"msg_1","type":"message","role":"assistant","status":"in_progress","content":[]}}
+
+event: response.output_text.delta
+data: {"type":"response.output_text.delta","item_id":"msg_1","output_index":0,"content_index":0,"delta":"partial"}
+
+event: response.failed
+data: {"type":"response.failed","response":{"id":"r","status":"failed","error":{"code":"server_error","message":"model crashed mid-stream"}}}
+
+`
+	rec := httptest.NewRecorder()
+	w := translate.NewResponsesToAnthropicWriter(rec, "gpt-5.5", nil)
+	require.NoError(t, w.Prelude(true))
+	_, err := w.Write([]byte(fixture))
+	require.NoError(t, err)
+	require.NoError(t, w.Finalize())
+
+	body := rec.Body.String()
+	assert.Contains(t, body, "event: error", "stream-level failure surfaces as an Anthropic error event")
+	assert.Contains(t, body, "model crashed mid-stream")
+	assert.NotContains(t, body, "event: message_stop", "no success trailer after an error close")
+}
+
 // A routing marker is emitted as content block 0; upstream content then starts
 // at block 1.
 func TestResponsesToAnthropicWriter_RoutingMarker(t *testing.T) {

--- a/internal/translate/responses_to_anthropic_writer_stream_test.go
+++ b/internal/translate/responses_to_anthropic_writer_stream_test.go
@@ -200,6 +200,41 @@ data: {"type":"response.function_call_arguments.delta","item_id":"fc_1","output_
 	assert.Contains(t, body, "event: message_stop")
 }
 
+// An upstream that delivers a reasoning summary and message text only on
+// output_item.done (no *.delta events) still produces visible thinking + text
+// blocks on the streaming path, rather than an empty assistant turn.
+func TestResponsesToAnthropicWriter_DoneOnlyContent(t *testing.T) {
+	const fixture = `event: response.output_item.added
+data: {"type":"response.output_item.added","output_index":0,"item":{"id":"rs_1","type":"reasoning","summary":[],"status":"in_progress"}}
+
+event: response.output_item.done
+data: {"type":"response.output_item.done","output_index":0,"item":{"id":"rs_1","type":"reasoning","summary":[{"type":"summary_text","text":"weighed the options"}],"status":"completed"}}
+
+event: response.output_item.added
+data: {"type":"response.output_item.added","output_index":1,"item":{"id":"msg_1","type":"message","role":"assistant","status":"in_progress","content":[]}}
+
+event: response.output_item.done
+data: {"type":"response.output_item.done","output_index":1,"item":{"id":"msg_1","type":"message","role":"assistant","status":"completed","content":[{"type":"output_text","text":"final answer"}]}}
+
+event: response.completed
+data: {"type":"response.completed","response":{"id":"r","status":"completed","output":[{"id":"rs_1","type":"reasoning","summary":[{"type":"summary_text","text":"weighed the options"}]},{"id":"msg_1","type":"message","role":"assistant","content":[{"type":"output_text","text":"final answer"}]}],"usage":{"input_tokens":7,"output_tokens":3}}}
+
+`
+	rec := httptest.NewRecorder()
+	w := translate.NewResponsesToAnthropicWriter(rec, "gpt-5.5", nil)
+	require.NoError(t, w.Prelude(true))
+	_, err := w.Write([]byte(fixture))
+	require.NoError(t, err)
+	require.NoError(t, w.Finalize())
+
+	body := rec.Body.String()
+	assert.Contains(t, body, `"content_block":{"type":"thinking"`)
+	assert.Contains(t, body, `"thinking_delta","thinking":"weighed the options"`)
+	assert.Contains(t, body, `"content_block":{"type":"text"`)
+	assert.Contains(t, body, `"text_delta","text":"final answer"`)
+	assert.Contains(t, body, `"stop_reason":"end_turn"`)
+}
+
 // A routing marker is emitted as content block 0; upstream content then starts
 // at block 1.
 func TestResponsesToAnthropicWriter_RoutingMarker(t *testing.T) {

--- a/internal/translate/responses_to_anthropic_writer_stream_test.go
+++ b/internal/translate/responses_to_anthropic_writer_stream_test.go
@@ -1,0 +1,166 @@
+package translate_test
+
+import (
+	"encoding/json"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"workweave/router/internal/translate"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// responsesStreamFixture is a representative OpenAI Responses streaming SSE
+// sequence: a reasoning summary, an output_text message, and one function_call
+// whose arguments arrive split across two deltas, terminated by
+// response.completed carrying usage + status.
+const responsesStreamFixture = `event: response.created
+data: {"type":"response.created","response":{"id":"resp_abc","status":"in_progress","model":"gpt-5.5","output":[]}}
+
+event: response.output_item.added
+data: {"type":"response.output_item.added","output_index":0,"item":{"id":"rs_1","type":"reasoning","summary":[],"status":"in_progress"}}
+
+event: response.reasoning_summary_text.delta
+data: {"type":"response.reasoning_summary_text.delta","item_id":"rs_1","output_index":0,"summary_index":0,"delta":"Checking the weather "}
+
+event: response.reasoning_summary_text.delta
+data: {"type":"response.reasoning_summary_text.delta","item_id":"rs_1","output_index":0,"summary_index":0,"delta":"tool."}
+
+event: response.output_item.done
+data: {"type":"response.output_item.done","output_index":0,"item":{"id":"rs_1","type":"reasoning","summary":[{"type":"summary_text","text":"Checking the weather tool."}],"status":"completed"}}
+
+event: response.output_item.added
+data: {"type":"response.output_item.added","output_index":1,"item":{"id":"msg_1","type":"message","role":"assistant","status":"in_progress","content":[]}}
+
+event: response.output_text.delta
+data: {"type":"response.output_text.delta","item_id":"msg_1","output_index":1,"content_index":0,"delta":"Let me check"}
+
+event: response.output_text.delta
+data: {"type":"response.output_text.delta","item_id":"msg_1","output_index":1,"content_index":0,"delta":" the weather."}
+
+event: response.output_item.done
+data: {"type":"response.output_item.done","output_index":1,"item":{"id":"msg_1","type":"message","role":"assistant","status":"completed","content":[{"type":"output_text","text":"Let me check the weather."}]}}
+
+event: response.output_item.added
+data: {"type":"response.output_item.added","output_index":2,"item":{"id":"fc_1","type":"function_call","call_id":"call_xyz","name":"get_weather","arguments":"","status":"in_progress"}}
+
+event: response.function_call_arguments.delta
+data: {"type":"response.function_call_arguments.delta","item_id":"fc_1","output_index":2,"delta":"{\"location\":"}
+
+event: response.function_call_arguments.delta
+data: {"type":"response.function_call_arguments.delta","item_id":"fc_1","output_index":2,"delta":"\"NYC\"}"}
+
+event: response.output_item.done
+data: {"type":"response.output_item.done","output_index":2,"item":{"id":"fc_1","type":"function_call","call_id":"call_xyz","name":"get_weather","arguments":"{\"location\":\"NYC\"}","status":"completed"}}
+
+event: response.completed
+data: {"type":"response.completed","response":{"id":"resp_abc","status":"completed","model":"gpt-5.5","incomplete_details":null,"output":[{"id":"rs_1","type":"reasoning","summary":[{"type":"summary_text","text":"Checking the weather tool."}]},{"id":"msg_1","type":"message","role":"assistant","content":[{"type":"output_text","text":"Let me check the weather."}]},{"id":"fc_1","type":"function_call","call_id":"call_xyz","name":"get_weather","arguments":"{\"location\":\"NYC\"}"}],"usage":{"input_tokens":150,"input_tokens_details":{"cached_tokens":0},"output_tokens":45}}}
+
+`
+
+// A streaming client gets the Responses event stream translated to Anthropic SSE
+// incrementally: thinking → text → tool_use blocks in order, then a
+// message_delta carrying stop_reason=tool_use and the upstream usage.
+func TestResponsesToAnthropicWriter_StreamingClient(t *testing.T) {
+	rec := httptest.NewRecorder()
+	w := translate.NewResponsesToAnthropicWriter(rec, "gpt-5.5", nil)
+
+	require.NoError(t, w.Prelude(true))
+	_, err := w.Write([]byte(responsesStreamFixture))
+	require.NoError(t, err)
+	require.NoError(t, w.Finalize())
+
+	body := rec.Body.String()
+
+	// Frame presence.
+	assert.Contains(t, body, "event: message_start")
+	assert.Contains(t, body, `"content_block":{"type":"thinking"`)
+	assert.Contains(t, body, "Checking the weather ")
+	assert.Contains(t, body, "tool.")
+	assert.Contains(t, body, `"content_block":{"type":"text"`)
+	// Text arrives as separate live deltas, not one concatenated string.
+	assert.Contains(t, body, `"text_delta","text":"Let me check"`)
+	assert.Contains(t, body, `"text_delta","text":" the weather."`)
+	assert.Contains(t, body, `"type":"tool_use","id":"call_xyz","name":"get_weather"`)
+	assert.Contains(t, body, `"partial_json":"{\"location\":\"NYC\"}"`,
+		"tool args concatenated from both deltas and emitted as one validated input_json_delta")
+	assert.Contains(t, body, `"stop_reason":"tool_use"`)
+	assert.Contains(t, body, `"output_tokens":45`)
+	assert.Contains(t, body, `"input_tokens":150`)
+	assert.Contains(t, body, "event: message_stop")
+
+	// Block ordering: thinking (0) → text (1) → tool_use (2), all between
+	// message_start and message_delta.
+	order := []string{
+		"event: message_start",
+		`"content_block":{"type":"thinking"`,
+		`"content_block":{"type":"text"`,
+		`"type":"tool_use","id":"call_xyz"`,
+		"event: message_delta",
+		"event: message_stop",
+	}
+	prev := -1
+	for _, marker := range order {
+		at := strings.Index(body, marker)
+		require.GreaterOrEqual(t, at, 0, "missing %q", marker)
+		assert.Greater(t, at, prev, "out of order: %q", marker)
+		prev = at
+	}
+
+	// Anthropic block indices must be dense and contiguous from 0.
+	assert.Contains(t, body, `"content_block_start","index":0`)
+	assert.Contains(t, body, `"content_block_start","index":1`)
+	assert.Contains(t, body, `"content_block_start","index":2`)
+}
+
+// A non-streaming client gets a one-shot Anthropic JSON body reconstructed from
+// the terminal response.completed event in the (still-streamed) upstream.
+func TestResponsesToAnthropicWriter_NonStreamingClient(t *testing.T) {
+	rec := httptest.NewRecorder()
+	w := translate.NewResponsesToAnthropicWriter(rec, "gpt-5.5", nil)
+
+	// Prelude(false): client did not request streaming, so the writer buffers.
+	require.NoError(t, w.Prelude(false))
+	_, err := w.Write([]byte(responsesStreamFixture))
+	require.NoError(t, err)
+	require.NoError(t, w.Finalize())
+
+	assert.Equal(t, "application/json", rec.Header().Get("Content-Type"))
+	assert.NotContains(t, rec.Body.String(), "event: ", "non-streaming client gets JSON, not SSE")
+
+	var msg map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &msg))
+	assert.Equal(t, "message", msg["type"])
+	assert.Equal(t, "tool_use", msg["stop_reason"])
+	content, _ := msg["content"].([]any)
+	require.Len(t, content, 3)
+	b2, _ := content[2].(map[string]any)
+	assert.Equal(t, "tool_use", b2["type"])
+	assert.Equal(t, "call_xyz", b2["id"])
+	input, _ := b2["input"].(map[string]any)
+	assert.Equal(t, "NYC", input["location"])
+}
+
+// A routing marker is emitted as content block 0; upstream content then starts
+// at block 1.
+func TestResponsesToAnthropicWriter_RoutingMarker(t *testing.T) {
+	rec := httptest.NewRecorder()
+	w := translate.NewResponsesToAnthropicWriter(rec, "gpt-5.5", nil).WithRoutingMarker("[routed: gpt-5.5]")
+
+	require.NoError(t, w.Prelude(true))
+	_, err := w.Write([]byte(responsesStreamFixture))
+	require.NoError(t, err)
+	require.NoError(t, w.Finalize())
+
+	body := rec.Body.String()
+	assert.Contains(t, body, "[routed: gpt-5.5]")
+	markerAt := strings.Index(body, "[routed: gpt-5.5]")
+	thinkingAt := strings.Index(body, `"content_block":{"type":"thinking"`)
+	require.GreaterOrEqual(t, markerAt, 0)
+	require.GreaterOrEqual(t, thinkingAt, 0)
+	assert.Less(t, markerAt, thinkingAt, "routing marker precedes upstream content")
+	// Marker occupies block 0, so reasoning opens at block 1.
+	assert.Contains(t, body, `"content_block_start","index":1`)
+}


### PR DESCRIPTION
## Problem

gpt-5.x reasoning routes through the OpenAI **Responses API** (`POST /v1/responses`), but the request was emitted with **`stream:false`**. OpenAI then buffers the entire reasoning + output before sending *any* response headers. At high effort that routinely exceeds the transport's `ResponseHeaderTimeout` (30s), so the turn fails with:

```
upstream call: Post "https://api.openai.com/v1/responses": http2: timeout awaiting response headers
```

`dispatchWithFallback` retries the same binding twice (~90s total, no failover), and the client gets no response — it just burns tokens and appears to hang. This is the dominant failure mode for trial users routed to gpt-5.x (observed in prod: a steady stream of `Proxy failed` / `dispatchWithFallback: retrying same binding` over a 20-min session, `proxy_ms ≈ 91699`, `failover_used:false`).

This is a [known](https://github.com/NousResearch/hermes-agent/issues/21444) [issue](https://github.com/openai/openai-python/issues/2725) with gpt-5.x + high reasoning on the Responses API — TTFB can be minutes; streaming is the consensus fix.

## Fix

1. **Emit `stream:true`** on the Responses request (`emit_openai_responses.go`). Headers + the first SSE event arrive immediately, so the header timeout can't trip. Inter-event gaps during reasoning are bounded by `StreamBody`'s existing SSE idle watchdog instead.
2. **Rewrite `ResponsesToAnthropicWriter`** to translate the Responses SSE event stream into Anthropic SSE incrementally:
   - `response.reasoning_summary_text.delta` / `response.reasoning_text.delta` → `thinking`
   - `response.output_text.delta` → `text`
   - `response.output_item.added`(function_call) → `tool_use` (id from `call_id`); args buffered from `function_call_arguments.delta` and emitted as one **JSON-validated** `input_json_delta` at item close (invalid → `{}`, mirroring `AnthropicSSETranslator`)
   - usage + stop reason captured from the terminal `response.completed`/`.failed`/`.incomplete`
   - **non-streaming clients** reconstruct a one-shot Anthropic body from the terminal event, reusing `ResponsesToAnthropicResponse`
3. **Raise the OpenAI transport's response-header timeout to 120s** (`httputil.NewTransportWithResponseHeaderTimeout`) as a belt-and-suspenders guard against a slow first byte. Streaming makes it moot, but it prevents a 30s false-trip if a path ever regresses to non-streaming.

The translator is driven by the existing dispatch exactly like `AnthropicSSETranslator` (Prelude → Proxy streams into Write → `finalizeAfterProxy`→Finalize), so failover/error handling is unchanged.

## Tests

- `TestResponsesToAnthropicWriter_StreamingClient` — full Responses SSE fixture (reasoning + text + split-delta function_call + `response.completed`) → asserts ordered Anthropic frames, dense block indices, validated tool args, stop_reason/usage.
- `TestResponsesToAnthropicWriter_NonStreamingClient` — buffered → one-shot JSON.
- `TestResponsesToAnthropicWriter_RoutingMarker` — marker occupies block 0, content starts at block 1.
- Updated `TestPrepareOpenAIResponses_RequestShape` (`stream` is now `true`).

`go test ./...`, `go vet`, `gofmt` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)