### PR TITLE
fix(translate): hoist role:system messages out of the Anthropic messages array

### DIFF
--- a/internal/translate/emit_anthropic.go
+++ b/internal/translate/emit_anthropic.go
@@ -9,6 +9,7 @@ import (
 	"workweave/router/internal/router"
 
 	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
 )
 
 // PrepareAnthropic builds an Anthropic Messages request body.
@@ -530,8 +531,103 @@ func writeAnthropicSharedParams(jw *jsonWriter, body []byte) {
 }
 
 func (e *RequestEnvelope) buildAnthropicFromAnthropic(opts EmitOptions) ([]byte, error) {
-	ov := resolveAnthropicOverrides(e.body, opts)
-	return e.emitSameFormat(ov)
+	body, err := hoistAnthropicSystemMessages(e.body)
+	if err != nil {
+		return nil, fmt.Errorf("hoist system messages: %w", err)
+	}
+	ov := resolveAnthropicOverrides(body, opts)
+	return applyOverrides(body, ov)
+}
+
+// hoistAnthropicSystemMessages moves any role:"system" entries out of the
+// "messages" array and merges their text into the top-level "system" field.
+// Anthropic's Messages API rejects a system role inside messages (400
+// "role 'system' must precede an 'assistant' message or end the array"); a
+// system-bearing body can reach this same-format emit path on a mid-session
+// switch back to an Anthropic model. The OpenAI->Anthropic emit path already
+// hoists in writeAnthropicSystemAndMessages; this is the same guarantee for the
+// same-format path. No-op when no system message is present.
+func hoistAnthropicSystemMessages(body []byte) ([]byte, error) {
+	msgs := gjson.GetBytes(body, "messages")
+	if !msgs.IsArray() {
+		return body, nil
+	}
+
+	var hoisted []string // text extracted from in-array system messages, in order
+	var kept []string    // raw non-system message objects
+	for _, msg := range msgs.Array() {
+		if msg.Get("role").String() == "system" {
+			hoisted = append(hoisted, anthropicSystemTexts(msg.Get("content"))...)
+			continue
+		}
+		kept = append(kept, msg.Raw)
+	}
+	if len(hoisted) == 0 {
+		return body, nil
+	}
+
+	// Merge: existing top-level system blocks first, then the hoisted text.
+	sw := newJSONWriter()
+	sw.Arr()
+	switch existing := gjson.GetBytes(body, "system"); {
+	case existing.Type == gjson.String:
+		if s := existing.String(); s != "" {
+			writeAnthropicTextBlock(sw, s)
+		}
+	case existing.IsArray():
+		existing.ForEach(func(_, b gjson.Result) bool {
+			sw.Raw(b.Raw)
+			return true
+		})
+	}
+	for _, t := range hoisted {
+		writeAnthropicTextBlock(sw, t)
+	}
+	sw.EndArr()
+
+	out, err := sjson.SetRawBytes(body, "messages", []byte("["+strings.Join(kept, ",")+"]"))
+	if err != nil {
+		return nil, fmt.Errorf("rebuild messages: %w", err)
+	}
+	out, err = sjson.SetRawBytes(out, "system", sw.Bytes())
+	if err != nil {
+		return nil, fmt.Errorf("set system: %w", err)
+	}
+	return out, nil
+}
+
+// anthropicSystemTexts extracts text strings from a system message's content,
+// which may be a plain string or an array of content blocks.
+func anthropicSystemTexts(content gjson.Result) []string {
+	if content.Type == gjson.String {
+		if s := content.String(); s != "" {
+			return []string{s}
+		}
+		return nil
+	}
+	if !content.IsArray() {
+		return nil
+	}
+	var out []string
+	content.ForEach(func(_, part gjson.Result) bool {
+		if part.Get("type").String() == "text" {
+			if t := part.Get("text").String(); t != "" {
+				out = append(out, t)
+			}
+		}
+		return true
+	})
+	return out
+}
+
+// writeAnthropicTextBlock writes a {"type":"text","text":...} object.
+func writeAnthropicTextBlock(jw *jsonWriter, text string) {
+	jw.Obj()
+	jw.Key("type")
+	jw.Str("text")
+	jw.Key("text")
+	jw.Str(text)
+	jw.EndObj()
 }
 
 // sanitizeToolUseID replaces characters that Anthropic rejects in tool_use.id

--- a/internal/translate/emit_same_format_test.go
+++ b/internal/translate/emit_same_format_test.go
@@ -164,6 +164,61 @@ func TestAnthropicSameFormat_ModelRewrite(t *testing.T) {
 	require.Len(t, msgs, 1)
 }
 
+func TestAnthropicSameFormat_SystemMessageHoistedWhenNoSystemField(t *testing.T) {
+	// A role:"system" message inside the messages array is invalid for the
+	// Anthropic Messages API; it must be hoisted to the top-level system field.
+	body := []byte(`{"model":"claude-sonnet-4-20250514","messages":[{"role":"user","content":"hi"},{"role":"system","content":"be terse"},{"role":"assistant","content":"ok"}],"max_tokens":1024}`)
+	opts := translate.EmitOptions{
+		TargetModel:  "claude-opus-4-7",
+		Capabilities: router.Lookup("claude-opus-4-7"),
+	}
+	out := parseAndEmit(t, body, "anthropic", opts)
+
+	msgs, _ := out["messages"].([]any)
+	require.Len(t, msgs, 2, "system message removed from array")
+	for _, m := range msgs {
+		mm, _ := m.(map[string]any)
+		assert.NotEqual(t, "system", mm["role"], "no system role left in messages")
+	}
+	sys, _ := out["system"].([]any)
+	require.Len(t, sys, 1)
+	block, _ := sys[0].(map[string]any)
+	assert.Equal(t, "text", block["type"])
+	assert.Equal(t, "be terse", block["text"])
+}
+
+func TestAnthropicSameFormat_SystemMessageMergedWithExistingSystem(t *testing.T) {
+	// Existing top-level system is preserved and the hoisted text appended.
+	body := []byte(`{"model":"claude-sonnet-4-20250514","system":"top-level rules","messages":[{"role":"system","content":[{"type":"text","text":"extra rule"}]},{"role":"user","content":"hi"}],"max_tokens":1024}`)
+	opts := translate.EmitOptions{
+		TargetModel:  "claude-opus-4-7",
+		Capabilities: router.Lookup("claude-opus-4-7"),
+	}
+	out := parseAndEmit(t, body, "anthropic", opts)
+
+	msgs, _ := out["messages"].([]any)
+	require.Len(t, msgs, 1)
+	sys, _ := out["system"].([]any)
+	require.Len(t, sys, 2, "existing system block kept, hoisted block appended")
+	first, _ := sys[0].(map[string]any)
+	second, _ := sys[1].(map[string]any)
+	assert.Equal(t, "top-level rules", first["text"])
+	assert.Equal(t, "extra rule", second["text"])
+}
+
+func TestAnthropicSameFormat_NoSystemMessageIsNoOp(t *testing.T) {
+	// Common case: no in-array system message — body passes through unchanged.
+	body := []byte(`{"model":"claude-sonnet-4-20250514","system":"rules","messages":[{"role":"user","content":"hi"}],"max_tokens":1024}`)
+	opts := translate.EmitOptions{
+		TargetModel:  "claude-opus-4-7",
+		Capabilities: router.Lookup("claude-opus-4-7"),
+	}
+	out := parseAndEmit(t, body, "anthropic", opts)
+	assert.Equal(t, "rules", out["system"], "untouched string system field")
+	msgs, _ := out["messages"].([]any)
+	require.Len(t, msgs, 1)
+}
+
 func TestAnthropicSameFormat_UnknownFieldsPreserved(t *testing.T) {
 	body := []byte(`{"model":"claude-sonnet-4-20250514","messages":[{"role":"user","content":"hi"}],"max_tokens":1024,"custom_field":"preserved","metadata":{"key":"val"}}`)
 	opts := translate.EmitOptions{


### PR DESCRIPTION
## Problem

A `role:"system"` message inside the `messages` array is rejected by the Anthropic Messages API:

```
400 invalid_request_error: messages.N: role 'system' must precede an 'assistant' message or end the array
```

The OpenAI→Anthropic emit path (`writeAnthropicSystemAndMessages`) already hoists system-role messages into the top-level `system` field. The **same-format** path (`buildAnthropicFromAnthropic` → `emitSameFormat` → `applyOverrides`) did **not** — it passed the body through verbatim, so a system-bearing body reaching that path 400s.

## Why it matters (eval-data grounded)

Analysis of the v0.66 staging bake-off (Pro + Atlas, 2026-06-06) upstream error logs:

- **36/38 upstream errors were deterministic 400s**, not flaky 5xx.
- **31/38** were this exact `role 'system'` error, **all on `claude-haiku-4-5`** — the model Claude Code uses for subagent / Explore / auto-compaction calls (22–27% of calls even in the direct-opus arm).
- In the direct-opus arm those haiku calls are formatted by CC and go straight to Anthropic (succeed). Through the router they hit the broken same-format translator → 400 → the sub-call fails → the agent retries and loops → `error_max_turns`. That thrash is the bulk of the router's Atlas reliability gap vs direct opus (router 33–56% error rate across v0.64/v0.65/v0.66 vs direct opus 1–2/63).

Full write-up: `router-internal/docs/eval/RESULTS_opus_gap_decomposition.md` (WorkWeave repo).

## Fix

Add `hoistAnthropicSystemMessages` to the same-format Anthropic emit path: extract any in-array `role:"system"` text, remove those messages, and merge the text into the top-level `system` field (after existing system content). No-op when no in-array system message is present (the common case — single `gjson` array check).

## Tests

- `TestAnthropicSameFormat_SystemMessageHoistedWhenNoSystemField`
- `TestAnthropicSameFormat_SystemMessageMergedWithExistingSystem`
- `TestAnthropicSameFormat_NoSystemMessageIsNoOp`

`go build ./...`, `go vet`, `gofmt`, and full `internal/translate` suite all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)