### PR TITLE
fix(proxy): stop compaction-handover false-firing on Explore sub-agents

### DIFF
--- a/internal/proxy/no_progress.go
+++ b/internal/proxy/no_progress.go
@@ -150,6 +150,25 @@ type compactionState struct {
 	toolCallCount int
 }
 
+// compactionMinHistoryMessages is the smallest conversation size for which a
+// count drop is read as real history trimming. Below it there is no substantial
+// history to lose, so a drop is some other (benign) shape:
+//   - A freshly spawned sub-agent opens its turn at messageCount=1, which looks
+//     like a sharp drop relative to the prior sub-agent that shared the same
+//     (session, role) bucket and left it at ~3.
+//   - Claude Code's Explore sub-agent holds a flat ~3-message window and varies
+//     its per-turn assistant tool-call count widely (e.g. 11→6→3); every such
+//     decrease would otherwise false-trip the rolling-window signal.
+//
+// Real full compaction comes from a large conversation (the client compacts on
+// token pressure, so the prior message count is in the dozens-plus), and real
+// rolling-window trimming keeps a correspondingly large flat window — both stay
+// well above this floor. Erring toward fewer fires is the safe bias: skipping
+// the handover passes the body (including Claude Code's own compaction summary)
+// through unchanged, whereas a false fire replaces live context with a lossy
+// summary and corrupts an in-flight sub-agent.
+const compactionMinHistoryMessages = 8
+
 // compactionTracker detects Claude Code context window trimming by comparing
 // each turn's message count and assistant tool-call count against the last
 // seen values for the same session. Either count dropping is a signal that the
@@ -167,6 +186,10 @@ type compactionState struct {
 //     observed in session 543151ce: 9 → 8 → 7 → 6 → 5).
 //
 // Detecting only messageCount drops misses the rolling-window case.
+//
+// Both signals are gated by compactionMinHistoryMessages so the small flat
+// windows of freshly spawned sub-agents and Claude Code's Explore sub-agent are
+// not mistaken for trimming (see that constant's doc).
 //
 // nil receivers are valid (no-op), matching noProgressTracker semantics.
 type compactionTracker struct {
@@ -194,7 +217,24 @@ func (t *compactionTracker) checkAndRecord(sessionKey [sessionpin.SessionKeyLen]
 	}
 	last, found := t.cache.Get(key)
 	t.cache.Add(key, compactionState{msgCount: messageCount, toolCallCount: toolCallCount})
-	return found && (messageCount < last.msgCount || toolCallCount < last.toolCallCount)
+	if !found {
+		return false
+	}
+	// Full compaction: a messageCount drop from a substantial prior conversation.
+	// Gating on the prior size rejects the fresh-sub-agent case (a new dispatch
+	// opening at messageCount=1 against a prior sub-agent's small count in the
+	// shared bucket), which is not history loss.
+	if messageCount < last.msgCount && last.msgCount >= compactionMinHistoryMessages {
+		return true
+	}
+	// Rolling-window trimming: messageCount stays flat while the assistant
+	// tool-call count shrinks. Gating on a substantial current window rejects
+	// Claude Code's Explore sub-agent, which holds a flat ~3-message window and
+	// swings its per-turn tool-call count widely without any trimming.
+	if toolCallCount < last.toolCallCount && messageCount >= compactionMinHistoryMessages {
+		return true
+	}
+	return false
 }
 
 // recordAndDetect records the fingerprint against a bucket keyed by

--- a/internal/proxy/no_progress_internal_test.go
+++ b/internal/proxy/no_progress_internal_test.go
@@ -375,6 +375,40 @@ func TestCompactionTracker_DetectsRollingWindowTrimming(t *testing.T) {
 		"flat messageCount + shrinking toolCallCount must be detected as rolling-window trim")
 }
 
+func TestCompactionTracker_NoFalsePositiveOnFreshSubAgentDispatch(t *testing.T) {
+	// A sub-agent shares the (session, role) bucket with the previous sub-agent
+	// of the same tier. When a new sub-agent is spawned its opening turn carries
+	// messageCount=1, which is a drop relative to the prior sub-agent's small
+	// count — but it is a fresh dispatch, not history trimming, so it must not
+	// fire (the prior conversation was too small to have lost anything).
+	ct := newCompactionTracker()
+	key := sessionKeyFromString("session-subagent")
+	install := uuid.New()
+
+	// Prior sub-agent left the bucket at a small count.
+	ct.checkAndRecord(key, install, "low", 3, 2)
+
+	// Fresh sub-agent dispatch opens at messageCount=1, tool-call count 0.
+	assert.False(t, ct.checkAndRecord(key, install, "low", 1, 0),
+		"fresh sub-agent dispatch (small prior, mc=1) must not be reported as compaction")
+}
+
+func TestCompactionTracker_NoFalsePositiveOnExploreToolCallSwing(t *testing.T) {
+	// Claude Code's Explore sub-agent holds a flat ~3-message window and varies
+	// its per-turn assistant tool-call count widely. A decrease in that count is
+	// natural model behavior, not rolling-window trimming, and must not fire
+	// because the window is too small to be a real rolling window.
+	ct := newCompactionTracker()
+	key := sessionKeyFromString("session-explore")
+	install := uuid.New()
+
+	ct.checkAndRecord(key, install, "low", 3, 11)
+	assert.False(t, ct.checkAndRecord(key, install, "low", 3, 6),
+		"flat small-window tool-call decrease (Explore) must not be reported as trimming")
+	assert.False(t, ct.checkAndRecord(key, install, "low", 3, 3),
+		"further small-window tool-call decrease must not be reported as trimming")
+}
+
 func TestCompactionTracker_NoFalsePositiveWhenBothGrow(t *testing.T) {
 	ct := newCompactionTracker()
 	key := sessionKeyFromString("session-growing")


### PR DESCRIPTION
## Problem

Prod session `84c549ff-89ae-48ee-bf60-1e7d969f2427` (Claude Code via `sdk-ts`) reported sub-agents never returning. The sub-agent (requested `claude-sonnet-4-6`, tier-clamped to `deepseek/deepseek-v4-flash` on deepinfra) tripped `"Context trimming detected on non-Anthropic route; rewriting context with handover summary"` **4 times**, all on the sub-agent route — each one rewriting its context with a haiku handover summary.

The compaction tracker (`compactionTracker.checkAndRecord`) flags trimming when the top-level message count **or** the inbound assistant tool-call count drops versus the prior turn in the same `(session, role)` bucket. Two false-positive shapes hit Claude Code's Explore sub-agent:

1. **Fresh sub-agent dispatch.** A newly spawned sub-agent opens at `messageCount=1` — a drop relative to the prior sub-agent that shared the same `(session, role)` bucket and left it at ~3. Read as a sharp full-compaction (events at `message_count=1, tool_call_count=0`).
2. **Explore tool-call swing.** The Explore agent holds a flat ~3-message window (acknowledged at `service.go:974`) and swings its per-turn tool-call count widely (11→6→3). Every decrease tripped the rolling-window signal.

Each false fire replaced the sub-agent's live context with a lossy summary, so it lost its accumulated search findings, kept re-searching, and never converged to a final answer — exactly the "sub-agent not returning" symptom. The message count never grew past 3 across the whole run.

## Fix

Gate both signals on a new `compactionMinHistoryMessages` floor (8):

- The **messageCount-drop** (full-compaction) signal requires the **prior** count to be substantial — rejects the fresh-dispatch `mc=1` case.
- The **toolCallCount-drop** (rolling-window) signal requires the **current** window to be substantial — rejects the flat ~3-message Explore window.

Real full compaction comes from a large conversation (the client compacts on token pressure) and real rolling-window trimming keeps a correspondingly large flat window, so both stay well above the floor. Erring toward fewer fires is the safe bias: a missed fire passes the body — including Claude Code's own compaction summary — through unchanged, whereas a false fire corrupts an in-flight agent.

## Tests

Existing `TestCompactionTracker_*` (full compaction 20→3, rolling-window 10→10/9→8) still pass. Added:
- `TestCompactionTracker_NoFalsePositiveOnFreshSubAgentDispatch`
- `TestCompactionTracker_NoFalsePositiveOnExploreToolCallSwing`

`go test ./internal/proxy/` green; `wv mr tc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)