### PR TITLE
test(proxy): translation-conformance CI across provider wire formats

### DIFF
--- a/internal/providers/openai/client.go
+++ b/internal/providers/openai/client.go
@@ -39,13 +39,22 @@ type Client struct {
 }
 
 func NewClient(apiKey, baseURL string) *Client {
+	return NewClientWithResponseHeaderTimeout(apiKey, baseURL, responseHeaderTimeout)
+}
+
+// NewClientWithResponseHeaderTimeout is NewClient with a caller-chosen
+// time-to-first-byte guard. Production uses the 120s default via NewClient;
+// the override exists so a test can inject a small timeout and exercise the
+// bounded-stall behavior (a stalled upstream surfaces an error, not a hang —
+// the #331 belt-and-suspenders) without waiting the full default.
+func NewClientWithResponseHeaderTimeout(apiKey, baseURL string, headerTimeout time.Duration) *Client {
 	if baseURL == "" {
 		baseURL = DefaultBaseURL
 	}
 	return &Client{
 		apiKey:  apiKey,
 		baseURL: baseURL,
-		http:    &http.Client{Transport: httputil.NewTransportWithResponseHeaderTimeout(5*time.Second, 5*time.Second, responseHeaderTimeout)},
+		http:    &http.Client{Transport: httputil.NewTransportWithResponseHeaderTimeout(5*time.Second, 5*time.Second, headerTimeout)},
 	}
 }
 

--- a/internal/providers/openai/client_timeout_test.go
+++ b/internal/providers/openai/client_timeout_test.go
@@ -1,0 +1,67 @@
+package openai_test
+
+// Guards the transport-timeout half of router #331. The dominant gpt-5.x failure
+// was a stream:false Responses request: OpenAI buffered the whole reasoning+output
+// before sending ANY response headers, so the request hung past the header
+// timeout and the turn died (~90s, no failover). The fix forces stream:true (a
+// regression of which the conformance suite catches via the upstream stream flag)
+// AND keeps a bounded — not infinite — ResponseHeaderTimeout. This test guards
+// the bound: a stalled-header upstream must surface an error promptly, never hang.
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"workweave/router/internal/providers"
+	"workweave/router/internal/providers/openai"
+	"workweave/router/internal/router"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestProxy_StalledHeadersSurfaceErrorNotHang(t *testing.T) {
+	// The upstream never sends headers; it blocks until the test releases it. The
+	// only timer is the injected tiny header timeout, so the outcome is
+	// deterministic — no sleep, no race. release is closed (defer, LIFO) BEFORE
+	// upstream.Close() so the handler returns first; otherwise Close() blocks
+	// waiting on the still-serving connection (a client-side header timeout does
+	// not reliably cancel the server's request context).
+	release := make(chan struct{})
+	upstream := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		select {
+		case <-release:
+		case <-r.Context().Done():
+		}
+	}))
+	defer upstream.Close()
+	defer close(release)
+
+	const headerTimeout = 50 * time.Millisecond
+	c := openai.NewClientWithResponseHeaderTimeout("test-key", upstream.URL, headerTimeout)
+	rec := httptest.NewRecorder()
+	clientReq := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(""))
+	prep := providers.PreparedRequest{
+		Body:     []byte(`{"model":"gpt-5.5","stream":true}`),
+		Headers:  make(http.Header),
+		Endpoint: providers.EndpointResponses,
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		done <- c.Proxy(context.Background(), router.Decision{Model: "gpt-5.5"}, prep, rec, clientReq)
+	}()
+
+	select {
+	case err := <-done:
+		require.Error(t, err, "a stalled-header upstream must surface an error, not nil")
+		assert.Contains(t, err.Error(), "timeout awaiting response headers",
+			"the bounded ResponseHeaderTimeout must fire — a regression to an infinite timeout would hang the turn (router #331)")
+	case <-time.After(5 * time.Second):
+		t.Fatal("Proxy hung far past the 50ms header timeout — the bounded ResponseHeaderTimeout regressed to unbounded")
+	}
+}

--- a/internal/proxy/conformance_anthropic_test.go
+++ b/internal/proxy/conformance_anthropic_test.go
@@ -1,0 +1,57 @@
+package proxy_test
+
+// Anthropic same-format conformance cases. The Anthropic provider is a
+// passthrough (no response translation), so these mainly guard request-side
+// emit behavior — notably hoisting a role:system message out of the messages
+// array, which otherwise 400s on a same-format bounce.
+
+import (
+	"net/http"
+	"testing"
+
+	"workweave/router/internal/providers"
+	"workweave/router/internal/providers/anthropic"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/tidwall/gjson"
+)
+
+func anthropicClient(baseURL string) providers.Client {
+	return anthropic.NewClient("test-key", baseURL)
+}
+
+func TestConformance_Anthropic(t *testing.T) {
+	cases := []conformanceCase{
+		{
+			name:            "anthropic/passthrough_text",
+			provider:        providers.ProviderAnthropic,
+			model:           "claude-opus-4-8",
+			newClient:       anthropicClient,
+			inbound:         `{"model":"claude-opus-4-8","stream":true,"max_tokens":1024,"messages":[{"role":"user","content":"Say hi."}]}`,
+			stream:          true,
+			upstreamFixture: "anthropic/basic_text.upstream.sse",
+			wantUpstream: func(t *testing.T, path string, _ []byte, _ http.Header) {
+				assert.Equal(t, "/v1/messages", path)
+			},
+		},
+		{
+			// Guards router #332: a role:system message inside the messages array
+			// must be hoisted to the top-level system field; left in place it 400s
+			// on a same-format Anthropic bounce.
+			name:            "anthropic/system_role_hoisted",
+			provider:        providers.ProviderAnthropic,
+			model:           "claude-opus-4-8",
+			newClient:       anthropicClient,
+			inbound:         `{"model":"claude-opus-4-8","stream":true,"max_tokens":1024,"messages":[{"role":"system","content":"Be terse."},{"role":"user","content":"hi"}]}`,
+			stream:          true,
+			upstreamFixture: "anthropic/basic_text.upstream.sse",
+			wantUpstream: func(t *testing.T, _ string, body []byte, _ http.Header) {
+				assert.Contains(t, gjson.GetBytes(body, "system").Raw, "Be terse", "role:system must be hoisted into the top-level system field")
+				assert.NotEqual(t, "system", gjson.GetBytes(body, "messages.0.role").String(), "no system role may remain in the messages array")
+			},
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) { runConformanceCase(t, c) })
+	}
+}

--- a/internal/proxy/conformance_gemini_test.go
+++ b/internal/proxy/conformance_gemini_test.go
@@ -1,0 +1,106 @@
+package proxy_test
+
+// Gemini native (:generateContent / :streamGenerateContent) conformance cases.
+// The router serves Gemini through the native REST surface (not the OpenAI-compat
+// one) because only native preserves thoughtSignature for Gemini 3.x tool use.
+// These pin the recent Gemini request-translation regressions: thinkingLevel vs
+// legacy thinkingBudget, and thoughtSignature round-trip.
+
+import (
+	"net/http"
+	"testing"
+
+	"workweave/router/internal/providers"
+	"workweave/router/internal/providers/google"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/tidwall/gjson"
+)
+
+func geminiClient(baseURL string) providers.Client {
+	return google.NewNativeClient("test-key", baseURL)
+}
+
+func TestConformance_GeminiNative(t *testing.T) {
+	cases := []conformanceCase{
+		{
+			name:            "gemini_native/basic_text",
+			provider:        providers.ProviderGoogle,
+			model:           "gemini-3.1-pro-preview",
+			newClient:       geminiClient,
+			inbound:         `{"model":"gemini-3.1-pro-preview","stream":true,"max_tokens":1024,"messages":[{"role":"user","content":"Say hi."}]}`,
+			stream:          true,
+			upstreamFixture: "gemini_native/basic_text.upstream.sse",
+			wantUpstream: func(t *testing.T, path string, body []byte, _ http.Header) {
+				assert.Contains(t, path, "gemini-3.1-pro-preview:streamGenerateContent", "streaming inbound must hit the native streaming surface")
+				assert.Equal(t, "user", gjson.GetBytes(body, "contents.0.role").String())
+			},
+		},
+		{
+			name:            "gemini_native/toolcall",
+			provider:        providers.ProviderGoogle,
+			model:           "gemini-3.1-pro-preview",
+			newClient:       geminiClient,
+			inbound:         `{"model":"gemini-3.1-pro-preview","stream":true,"max_tokens":1024,"tools":` + weatherTool + `,"messages":[{"role":"user","content":"Weather in NYC?"}]}`,
+			stream:          true,
+			upstreamFixture: "gemini_native/toolcall.upstream.sse",
+			wantUpstream: func(t *testing.T, _ string, body []byte, _ http.Header) {
+				assert.Equal(t, "get_weather", gjson.GetBytes(body, "tools.0.functionDeclarations.0.name").String(), "Anthropic tools must map to Gemini functionDeclarations")
+			},
+		},
+		{
+			// Guards router #328/#121: Gemini 3.x must use thinkingLevel (string),
+			// NOT the legacy numeric thinkingBudget — mixing both 400s.
+			name:            "gemini_native/thinking_level_gemini3",
+			provider:        providers.ProviderGoogle,
+			model:           "gemini-3.1-pro-preview",
+			newClient:       geminiClient,
+			inbound:         `{"model":"gemini-3.1-pro-preview","stream":true,"max_tokens":1024,"thinking":{"type":"enabled","budget_tokens":24576},"messages":[{"role":"user","content":"Think hard."}]}`,
+			stream:          true,
+			upstreamFixture: "gemini_native/basic_text.upstream.sse",
+			wantUpstream: func(t *testing.T, _ string, body []byte, _ http.Header) {
+				tc := gjson.GetBytes(body, "generationConfig.thinkingConfig")
+				assert.Equal(t, "high", tc.Get("thinkingLevel").String(), "gemini-3.x must send a string thinkingLevel")
+				assert.False(t, tc.Get("thinkingBudget").Exists(), "gemini-3.x must NOT send the legacy numeric thinkingBudget")
+			},
+		},
+		{
+			// The 2.5 counterpart: numeric thinkingBudget, no thinkingLevel.
+			name:            "gemini_native/thinking_budget_gemini25",
+			provider:        providers.ProviderGoogle,
+			model:           "gemini-2.5-pro",
+			newClient:       geminiClient,
+			inbound:         `{"model":"gemini-2.5-pro","stream":true,"max_tokens":1024,"thinking":{"type":"enabled","budget_tokens":24576},"messages":[{"role":"user","content":"Think hard."}]}`,
+			stream:          true,
+			upstreamFixture: "gemini_native/basic_text.upstream.sse",
+			wantUpstream: func(t *testing.T, _ string, body []byte, _ http.Header) {
+				tc := gjson.GetBytes(body, "generationConfig.thinkingConfig")
+				assert.EqualValues(t, 24576, tc.Get("thinkingBudget").Int(), "gemini-2.5 keeps the numeric thinkingBudget")
+				assert.False(t, tc.Get("thinkingLevel").Exists(), "gemini-2.5 must NOT send thinkingLevel")
+			},
+		},
+		{
+			// Guards the load-bearing thoughtSignature round-trip: a prior assistant
+			// tool_use's signature must ride back onto the Gemini functionCall part,
+			// or the next turn 400s on Gemini 3.x preview models.
+			name:      "gemini_native/thought_signature_roundtrip",
+			provider:  providers.ProviderGoogle,
+			model:     "gemini-3.1-pro-preview",
+			newClient: geminiClient,
+			inbound: `{"model":"gemini-3.1-pro-preview","stream":true,"max_tokens":1024,"tools":` + weatherTool + `,"messages":[` +
+				`{"role":"user","content":"Weather in NYC?"},` +
+				`{"role":"assistant","content":[{"type":"tool_use","id":"toolu_1","name":"get_weather","input":{"city":"NYC"},"thought_signature":"SIG_ROUNDTRIP"}]},` +
+				`{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_1","content":"sunny"}]}` +
+				`]}`,
+			stream:          true,
+			upstreamFixture: "gemini_native/basic_text.upstream.sse",
+			wantUpstream: func(t *testing.T, _ string, body []byte, _ http.Header) {
+				assert.Contains(t, string(body), `"thoughtSignature":"SIG_ROUNDTRIP"`,
+					"prior assistant tool_use signature must round-trip onto the Gemini functionCall part")
+			},
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) { runConformanceCase(t, c) })
+	}
+}

--- a/internal/proxy/conformance_golden_test.go
+++ b/internal/proxy/conformance_golden_test.go
@@ -1,0 +1,173 @@
+package proxy_test
+
+// Golden-file helpers for the translation-conformance suite. The router writes
+// translated responses with a fixed key order (hand-written JSON buffers, not
+// Go maps), and every input here is fixture-driven, so output is deterministic.
+// normalizeResponse re-canonicalizes anyway — it parses the response, redacts
+// the handful of volatile values (generated message ids, timestamps), and
+// re-serializes with sorted keys — so a golden never flakes on key order and a
+// diff pinpoints a real translation change. Run `go test -update` to (re)write
+// goldens, then review the diff before committing.
+
+import (
+	"bytes"
+	"encoding/json"
+	"flag"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+
+	"workweave/router/internal/sse"
+
+	"github.com/stretchr/testify/require"
+)
+
+var updateGolden = flag.Bool("update", false, "rewrite conformance golden files from current output")
+
+// goldenPath maps a case name (e.g. "openai_chat/basic_text") to its golden file.
+func goldenPath(name string) string {
+	return filepath.Join("testdata", "conformance", name+".golden")
+}
+
+// fixturePath maps an upstream-fixture name to its file under testdata.
+func fixturePath(name string) string {
+	return filepath.Join("testdata", "conformance", name)
+}
+
+// readFixture loads an upstream-response fixture (what the mock provider replays).
+func readFixture(t *testing.T, name string) []byte {
+	t.Helper()
+	b, err := os.ReadFile(fixturePath(name))
+	require.NoError(t, err, "read upstream fixture %s", name)
+	return b
+}
+
+// golden compares got against the committed golden for name. With -update it
+// rewrites the golden instead (review the diff before committing).
+func golden(t *testing.T, name string, got []byte) {
+	t.Helper()
+	path := goldenPath(name)
+	if *updateGolden {
+		require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+		require.NoError(t, os.WriteFile(path, got, 0o644))
+		return
+	}
+	want, err := os.ReadFile(path)
+	require.NoError(t, err, "missing golden %s — run `go test -update` to generate it", path)
+	require.Equal(t, string(want), string(got),
+		"golden mismatch for %s — the router's translated output changed; run `go test -update` and review the diff", name)
+}
+
+// normalizedFrame is one canonicalized SSE event (or the single body of a
+// non-streaming response, with event "").
+type normalizedFrame struct {
+	Event string                 `json:"event,omitempty"`
+	Data  map[string]interface{} `json:"data"`
+}
+
+// normalizeResponse canonicalizes a client-facing Anthropic response (SSE stream
+// or one-shot JSON) into stable, diffable bytes: volatile values redacted, JSON
+// keys sorted. SSE vs JSON is detected from the recorded body.
+func normalizeResponse(t *testing.T, contentType string, raw []byte) []byte {
+	t.Helper()
+	trimmed := bytes.TrimSpace(raw)
+	isSSE := strings.Contains(contentType, "event-stream") ||
+		bytes.Contains(trimmed, []byte("event:")) ||
+		bytes.HasPrefix(trimmed, []byte("data:"))
+	if isSSE {
+		return normalizeSSE(t, raw)
+	}
+	return normalizeJSON(t, raw)
+}
+
+func normalizeSSE(t *testing.T, raw []byte) []byte {
+	t.Helper()
+	var frames []normalizedFrame
+	buf := raw
+	for {
+		event, n := sse.SplitNext(buf)
+		if n == 0 {
+			break
+		}
+		buf = buf[n:]
+		eventType, data := sse.ParseEvent(event)
+		if len(data) == 0 || bytes.Equal(bytes.TrimSpace(data), []byte("[DONE]")) {
+			continue
+		}
+		frames = append(frames, normalizedFrame{Event: string(eventType), Data: redactJSON(t, data)})
+	}
+	return marshalCanonical(t, frames)
+}
+
+func normalizeJSON(t *testing.T, raw []byte) []byte {
+	t.Helper()
+	return marshalCanonical(t, normalizedFrame{Data: redactJSON(t, bytes.TrimSpace(raw))})
+}
+
+// marshalCanonical renders v as indented JSON with sorted map keys (encoding/json
+// sorts map keys) and HTML escaping off, so goldens stay readable (`<id>`, not
+// the <id> escape) and any < > & in model text isn't mangled.
+func marshalCanonical(t *testing.T, v interface{}) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	enc.SetEscapeHTML(false)
+	enc.SetIndent("", "  ")
+	require.NoError(t, enc.Encode(v))
+	return buf.Bytes()
+}
+
+// redactJSON unmarshals one JSON object and replaces values that the translator
+// generates fresh (so they vary even with a fixed fixture) with stable
+// placeholders: a message's generated id and any wire timestamp. Everything that
+// flows deterministically from the fixture (text, tool args, tool_use ids that
+// echo the upstream call id, usage, stop_reason) is left intact so the golden
+// asserts real translation behavior.
+func redactJSON(t *testing.T, data []byte) map[string]interface{} {
+	t.Helper()
+	var m map[string]interface{}
+	require.NoError(t, json.Unmarshal(data, &m), "response frame is not a JSON object: %s", string(data))
+	redactVolatile(m)
+	return m
+}
+
+// synthToolID matches a tool-call id the translator generates from scratch
+// (Gemini has no native call id: gemini_response.go uses "call_"+randomHex(4) =
+// 8 hex chars). Upstream-echoed ids in fixtures ("call_abc", "call_x") don't
+// match, so they stay in the golden and assert the echo behavior; only the
+// random ones get neutralized.
+var synthToolID = regexp.MustCompile(`^call_[0-9a-f]{8}$`)
+
+// redactVolatile walks a decoded response frame and replaces the values the
+// translator generates fresh — a message's id and any synthesized tool-call id —
+// with stable placeholders, and drops wire timestamps. Everything fixture-driven
+// stays intact so the golden still asserts real translation behavior.
+func redactVolatile(v interface{}) {
+	switch x := v.(type) {
+	case map[string]interface{}:
+		if t, _ := x["type"].(string); t == "message" || t == "message_start" {
+			if _, has := x["id"]; has {
+				x["id"] = "<id>"
+			}
+			if msg, ok := x["message"].(map[string]interface{}); ok {
+				if _, has := msg["id"]; has {
+					msg["id"] = "<id>"
+				}
+			}
+		}
+		delete(x, "created")
+		for k, val := range x {
+			if s, ok := val.(string); ok && synthToolID.MatchString(s) {
+				x[k] = "<tool_id>"
+				continue
+			}
+			redactVolatile(val)
+		}
+	case []interface{}:
+		for _, item := range x {
+			redactVolatile(item)
+		}
+	}
+}

--- a/internal/proxy/conformance_mock_test.go
+++ b/internal/proxy/conformance_mock_test.go
@@ -1,0 +1,95 @@
+package proxy_test
+
+// mockUpstream is a fake provider endpoint for the conformance suite. It records
+// the request the router sent (path, body, headers) so a case can assert the
+// outbound translation, then replays a canned provider-format response (loaded
+// from a testdata fixture) so a case can assert the inbound translation. One
+// shape serves every format — OpenAI /v1/chat/completions, OpenAI /v1/responses,
+// and Gemini :generateContent / :streamGenerateContent — because the router
+// targets them all with the same client.Do call; only the path and body differ.
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"workweave/router/internal/sse"
+
+	"github.com/stretchr/testify/require"
+)
+
+type mockUpstream struct {
+	// response to serve
+	streaming bool // serve as text/event-stream (true) or application/json (false)
+	status    int  // 0 => 200
+	body      []byte
+
+	mu      sync.Mutex
+	gotPath string
+	gotBody []byte
+	gotHdr  http.Header
+}
+
+// newMockUpstream starts an httptest server replaying fixture in the given mode
+// and returns it plus its base URL. Caller defers srv.Close().
+func newMockUpstream(t *testing.T, streaming bool, status int, fixture []byte) (*mockUpstream, *httptest.Server) {
+	t.Helper()
+	m := &mockUpstream{streaming: streaming, status: status, body: fixture}
+	srv := httptest.NewServer(http.HandlerFunc(m.handle))
+	t.Cleanup(srv.Close)
+	return m, srv
+}
+
+func (m *mockUpstream) handle(w http.ResponseWriter, r *http.Request) {
+	body, _ := io.ReadAll(r.Body)
+	m.mu.Lock()
+	m.gotPath = r.URL.Path
+	m.gotBody = body
+	m.gotHdr = r.Header.Clone()
+	m.mu.Unlock()
+
+	status := m.status
+	if status == 0 {
+		status = http.StatusOK
+	}
+	if !m.streaming {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(status)
+		_, _ = w.Write(m.body)
+		return
+	}
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.WriteHeader(status)
+	flusher, _ := w.(http.Flusher)
+	// Replay frame-by-frame with a flush between each, mirroring a real upstream
+	// streaming the SSE wire. The translator must reassemble incrementally.
+	buf := m.body
+	for {
+		_, n := sse.SplitNext(buf)
+		if n == 0 {
+			break
+		}
+		_, _ = w.Write(buf[:n])
+		if flusher != nil {
+			flusher.Flush()
+		}
+		buf = buf[n:]
+	}
+	if len(buf) > 0 {
+		_, _ = w.Write(buf)
+		if flusher != nil {
+			flusher.Flush()
+		}
+	}
+}
+
+// captured returns the recorded upstream request path, body, and headers.
+func (m *mockUpstream) captured(t *testing.T) (path string, body []byte, hdr http.Header) {
+	t.Helper()
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	require.NotEmpty(t, m.gotBody, "mock upstream was never called")
+	return m.gotPath, m.gotBody, m.gotHdr
+}

--- a/internal/proxy/conformance_openai_test.go
+++ b/internal/proxy/conformance_openai_test.go
@@ -1,0 +1,111 @@
+package proxy_test
+
+// OpenAI /v1/chat/completions conformance cases (the format every OpenAI-compat
+// upstream shares: OpenAI, OpenRouter, Fireworks, DeepInfra, Bedrock). Each
+// pins a known translation behavior or past regression.
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+
+	"workweave/router/internal/providers"
+	"workweave/router/internal/providers/openaicompat"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/tidwall/gjson"
+)
+
+func openRouterClient(baseURL string) providers.Client {
+	return openaicompat.NewClient("test-key", baseURL)
+}
+
+const weatherTool = `[{"name":"get_weather","description":"Get the weather","input_schema":{"type":"object","properties":{"city":{"type":"string"}},"required":["city"]}}]`
+
+func TestConformance_OpenAIChat(t *testing.T) {
+	cases := []conformanceCase{
+		{
+			name:            "openai_chat/basic_text",
+			provider:        providers.ProviderOpenRouter,
+			model:           "deepseek/deepseek-v4-pro",
+			newClient:       openRouterClient,
+			inbound:         `{"model":"deepseek/deepseek-v4-pro","stream":true,"max_tokens":1024,"messages":[{"role":"user","content":"Say hi."}]}`,
+			stream:          true,
+			upstreamFixture: "openai_chat/basic_text.upstream.sse",
+			wantUpstream: func(t *testing.T, path string, body []byte, _ http.Header) {
+				assert.True(t, strings.HasSuffix(path, "/chat/completions"), "path=%s", path)
+				assert.Equal(t, "deepseek/deepseek-v4-pro", gjson.GetBytes(body, "model").String())
+				assert.True(t, gjson.GetBytes(body, "stream").Bool(), "inbound stream must propagate upstream")
+				assert.Equal(t, "user", gjson.GetBytes(body, "messages.0.role").String())
+			},
+		},
+		{
+			name:            "openai_chat/basic_text_nonstream",
+			provider:        providers.ProviderOpenRouter,
+			model:           "deepseek/deepseek-v4-pro",
+			newClient:       openRouterClient,
+			inbound:         `{"model":"deepseek/deepseek-v4-pro","stream":false,"max_tokens":1024,"messages":[{"role":"user","content":"Say hi."}]}`,
+			stream:          false,
+			upstreamFixture: "openai_chat/basic_text.upstream.json",
+			wantUpstream: func(t *testing.T, _ string, body []byte, _ http.Header) {
+				assert.False(t, gjson.GetBytes(body, "stream").Bool(), "non-streaming inbound must not request an upstream stream")
+			},
+		},
+		{
+			name:            "openai_chat/toolcall",
+			provider:        providers.ProviderOpenRouter,
+			model:           "deepseek/deepseek-v4-pro",
+			newClient:       openRouterClient,
+			inbound:         `{"model":"deepseek/deepseek-v4-pro","stream":true,"max_tokens":1024,"tools":` + weatherTool + `,"messages":[{"role":"user","content":"Weather in NYC?"}]}`,
+			stream:          true,
+			upstreamFixture: "openai_chat/toolcall.upstream.sse",
+			wantUpstream: func(t *testing.T, _ string, body []byte, _ http.Header) {
+				assert.Equal(t, "get_weather", gjson.GetBytes(body, "tools.0.function.name").String(), "Anthropic tool must translate to OpenAI function shape")
+			},
+		},
+		{
+			// Guards router #293: an upstream that closes finish_reason="tool_calls"
+			// but emits no usable (named) tool_use block must demote stop_reason to
+			// end_turn, not strand the agent waiting for a tool call that never comes.
+			name:            "openai_chat/degenerate_toolcall_demotes",
+			provider:        providers.ProviderOpenRouter,
+			model:           "deepseek/deepseek-v4-pro",
+			newClient:       openRouterClient,
+			inbound:         `{"model":"deepseek/deepseek-v4-pro","stream":true,"max_tokens":1024,"tools":` + weatherTool + `,"messages":[{"role":"user","content":"Run the tool."}]}`,
+			stream:          true,
+			upstreamFixture: "openai_chat/degenerate_toolcall.upstream.sse",
+		},
+		{
+			// Guards the OpenRouter-only request gates: deepseek/* must carry the
+			// provider-pin hint and reasoning:{enabled:false} so OpenRouter pins a
+			// prefix-caching host and doesn't burn max_tokens on hidden thinking.
+			name:            "openai_chat/openrouter_gates",
+			provider:        providers.ProviderOpenRouter,
+			model:           "deepseek/deepseek-v4-pro",
+			newClient:       openRouterClient,
+			inbound:         `{"model":"deepseek/deepseek-v4-pro","stream":true,"max_tokens":1024,"messages":[{"role":"user","content":"Say hi."}]}`,
+			stream:          true,
+			upstreamFixture: "openai_chat/basic_text.upstream.sse",
+			wantUpstream: func(t *testing.T, _ string, body []byte, _ http.Header) {
+				assert.Equal(t, "deepseek", gjson.GetBytes(body, "provider.order.0").String(), "deepseek/* must pin the deepseek upstream on OpenRouter")
+				assert.False(t, gjson.GetBytes(body, "reasoning.enabled").Bool(), "reasoning must be disabled to avoid burning max_tokens on hidden thinking")
+			},
+		},
+		{
+			name:            "openai_chat/system_prompt",
+			provider:        providers.ProviderOpenRouter,
+			model:           "deepseek/deepseek-v4-pro",
+			newClient:       openRouterClient,
+			inbound:         `{"model":"deepseek/deepseek-v4-pro","stream":true,"max_tokens":1024,"system":"You are a helpful assistant.","messages":[{"role":"user","content":"Say hi."}]}`,
+			stream:          true,
+			upstreamFixture: "openai_chat/basic_text.upstream.sse",
+			wantUpstream: func(t *testing.T, _ string, body []byte, _ http.Header) {
+				assert.Equal(t, "system", gjson.GetBytes(body, "messages.0.role").String(), "top-level Anthropic system must become a leading system message")
+				assert.Contains(t, gjson.GetBytes(body, "messages.0.content").String(), "helpful assistant")
+			},
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) { runConformanceCase(t, c) })
+	}
+}

--- a/internal/proxy/conformance_responses_test.go
+++ b/internal/proxy/conformance_responses_test.go
@@ -1,0 +1,80 @@
+package proxy_test
+
+// OpenAI Responses API (/v1/responses) conformance cases. Reasoning gpt-5.x with
+// tools routes here instead of /v1/chat/completions. These guard router #331
+// (the request MUST stream upstream, or the header-timeout hang returns) and the
+// Responses-SSE -> Anthropic translation, plus the #328 medium-effort promotion.
+
+import (
+	"net/http"
+	"testing"
+
+	"workweave/router/internal/providers"
+	"workweave/router/internal/providers/openai"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/tidwall/gjson"
+)
+
+func openAIClient(baseURL string) providers.Client {
+	return openai.NewClient("test-key", baseURL)
+}
+
+func TestConformance_OpenAIResponses(t *testing.T) {
+	// gpt-5.x + tools + a thinking budget is what trips the Responses dispatch.
+	const reasoningToolTurn = `"max_tokens":2048,"thinking":{"type":"enabled","budget_tokens":24576},"tools":` + weatherTool + `,"messages":[{"role":"user","content":"Weather in NYC?"}]`
+
+	cases := []conformanceCase{
+		{
+			// Streaming client: full Responses-SSE -> Anthropic translation
+			// (reasoning->thinking, output_text->text, function_call->tool_use)
+			// plus the load-bearing stream:true guard.
+			name:            "responses/toolcall_stream",
+			provider:        providers.ProviderOpenAI,
+			model:           "gpt-5.5",
+			newClient:       openAIClient,
+			inbound:         `{"model":"gpt-5.5","stream":true,` + reasoningToolTurn + `}`,
+			stream:          true,
+			upstreamFixture: "responses/toolcall.upstream.sse",
+			wantUpstream: func(t *testing.T, path string, body []byte, _ http.Header) {
+				assert.Equal(t, "/v1/responses", path, "gpt-5.x reasoning+tools must use the Responses API, not chat/completions")
+				assert.True(t, gjson.GetBytes(body, "stream").Bool(),
+					"Responses request MUST set stream:true — a stream:false regression reintroduces the #331 header-timeout hang")
+				assert.Equal(t, "high", gjson.GetBytes(body, "reasoning.effort").String())
+			},
+		},
+		{
+			// Non-streaming client still streams UPSTREAM (#331) and gets a
+			// reconstructed one-shot Anthropic body.
+			name:            "responses/toolcall_nonstream_client",
+			provider:        providers.ProviderOpenAI,
+			model:           "gpt-5.5",
+			newClient:       openAIClient,
+			inbound:         `{"model":"gpt-5.5","stream":false,` + reasoningToolTurn + `}`,
+			stream:          false,
+			upstreamFixture: "responses/toolcall.upstream.sse",
+			wantUpstream: func(t *testing.T, _ string, body []byte, _ http.Header) {
+				assert.True(t, gjson.GetBytes(body, "stream").Bool(),
+					"Responses upstream MUST stream even for a non-streaming client (#331)")
+			},
+		},
+		{
+			// Guards router #328: gpt-5.x has a measured "medium" dead-zone, so a
+			// budget that resolves to medium must be promoted to high.
+			name:            "responses/effort_medium_promotes_high",
+			provider:        providers.ProviderOpenAI,
+			model:           "gpt-5.5",
+			newClient:       openAIClient,
+			inbound:         `{"model":"gpt-5.5","stream":true,"max_tokens":2048,"thinking":{"type":"enabled","budget_tokens":8192},"tools":` + weatherTool + `,"messages":[{"role":"user","content":"Weather in NYC?"}]}`,
+			stream:          true,
+			upstreamFixture: "responses/toolcall.upstream.sse",
+			wantUpstream: func(t *testing.T, _ string, body []byte, _ http.Header) {
+				assert.Equal(t, "high", gjson.GetBytes(body, "reasoning.effort").String(),
+					"a medium-effort budget must promote to high for gpt-5.x (router #328 dead-zone)")
+			},
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) { runConformanceCase(t, c) })
+	}
+}

--- a/internal/proxy/conformance_test.go
+++ b/internal/proxy/conformance_test.go
@@ -1,0 +1,85 @@
+package proxy_test
+
+// Translation-conformance suite. Each case drives a full ProxyMessages turn
+// against a mock provider endpoint (newMockUpstream) and asserts BOTH directions
+// of translation: the request the router sent upstream (wantUpstream, explicit
+// field checks) and the Anthropic response it handed back (golden, full-output
+// compare). The mock and golden infra live in conformance_mock_test.go and
+// conformance_golden_test.go. Cases are grouped by upstream wire format in the
+// conformance_<format>_test.go files.
+//
+// Adding a case when a new provider quirk surfaces: author an upstream fixture
+// under testdata/conformance/<format>/, add a conformanceCase asserting the
+// outbound field that should change, run `go test -update`, eyeball the golden.
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"workweave/router/internal/providers"
+	"workweave/router/internal/proxy"
+	"workweave/router/internal/router"
+
+	"github.com/stretchr/testify/require"
+)
+
+// routingMarkerHeader opts a request out of the per-turn routing badge so goldens
+// don't carry the volatile marker block (mirrors proxy.routingMarkerHeader).
+const routingMarkerHeader = "X-Weave-Routing-Marker"
+
+type conformanceCase struct {
+	// name is the subtest name and the testdata golden path, e.g. "openai_chat/basic_text".
+	name string
+	// provider is both the router.Decision.Provider and the providerMap key.
+	provider string
+	// model is the router.Decision.Model — must be a real catalog id so
+	// router.Lookup resolves the right capabilities (the Responses-API dispatch
+	// gate keys on CapReasoning).
+	model string
+	// newClient builds the real provider client pointed at the mock base URL.
+	newClient func(baseURL string) providers.Client
+	// inbound is the Anthropic Messages request body the client sends.
+	inbound string
+	// stream is the inbound stream flag; the mock replays the fixture in the
+	// matching mode (SSE when true, one JSON body when false).
+	stream bool
+	// upstreamFixture is the testdata path (under testdata/conformance) of the
+	// canned provider response the mock replays.
+	upstreamFixture string
+	// upstreamStatus overrides the mock response status (0 => 200).
+	upstreamStatus int
+	// wantUpstream asserts the request the router actually sent the provider.
+	wantUpstream func(t *testing.T, path string, body []byte, hdr http.Header)
+}
+
+func runConformanceCase(t *testing.T, c conformanceCase) {
+	t.Helper()
+	fixture := readFixture(t, c.upstreamFixture)
+	// The mock serves SSE iff the fixture is an SSE file. This is decoupled from
+	// the inbound stream flag on purpose: the OpenAI Responses path always streams
+	// upstream (stream:true) even for a non-streaming client, so a .sse fixture
+	// pairs with a stream:false inbound there.
+	mockStreaming := strings.HasSuffix(c.upstreamFixture, ".sse")
+	mock, srv := newMockUpstream(t, mockStreaming, c.upstreamStatus, fixture)
+
+	svc := proxy.NewService(
+		&fakeRouter{decision: router.Decision{Provider: c.provider, Model: c.model}},
+		map[string]providers.Client{c.provider: c.newClient(srv.URL)},
+		nil, false, nil, nil, false, providers.ProviderAnthropic, "claude-haiku-4-5", nil,
+	).WithDeploymentKeyedProviders(map[string]struct{}{c.provider: {}})
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(""))
+	req.Header.Set(routingMarkerHeader, "off")
+	require.NoError(t, svc.ProxyMessages(context.Background(), []byte(c.inbound), rec, req),
+		"ProxyMessages should succeed for a healthy upstream")
+
+	if c.wantUpstream != nil {
+		path, body, hdr := mock.captured(t)
+		c.wantUpstream(t, path, body, hdr)
+	}
+	golden(t, c.name, normalizeResponse(t, rec.Header().Get("Content-Type"), rec.Body.Bytes()))
+}

--- a/internal/proxy/testdata/conformance/anthropic/basic_text.upstream.sse
+++ b/internal/proxy/testdata/conformance/anthropic/basic_text.upstream.sse
@@ -1,0 +1,18 @@
+event: message_start
+data: {"type":"message_start","message":{"id":"msg_up","type":"message","role":"assistant","model":"claude-opus-4-8","content":[],"usage":{"input_tokens":5,"output_tokens":0}}}
+
+event: content_block_start
+data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hi there!"}}
+
+event: content_block_stop
+data: {"type":"content_block_stop","index":0}
+
+event: message_delta
+data: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":3}}
+
+event: message_stop
+data: {"type":"message_stop"}
+

--- a/internal/proxy/testdata/conformance/anthropic/passthrough_text.golden
+++ b/internal/proxy/testdata/conformance/anthropic/passthrough_text.golden
@@ -1,0 +1,66 @@
+[
+  {
+    "event": "message_start",
+    "data": {
+      "message": {
+        "content": [],
+        "id": "<id>",
+        "model": "claude-opus-4-8",
+        "role": "assistant",
+        "type": "message",
+        "usage": {
+          "input_tokens": 5,
+          "output_tokens": 0
+        }
+      },
+      "type": "message_start"
+    }
+  },
+  {
+    "event": "content_block_start",
+    "data": {
+      "content_block": {
+        "text": "",
+        "type": "text"
+      },
+      "index": 0,
+      "type": "content_block_start"
+    }
+  },
+  {
+    "event": "content_block_delta",
+    "data": {
+      "delta": {
+        "text": "Hi there!",
+        "type": "text_delta"
+      },
+      "index": 0,
+      "type": "content_block_delta"
+    }
+  },
+  {
+    "event": "content_block_stop",
+    "data": {
+      "index": 0,
+      "type": "content_block_stop"
+    }
+  },
+  {
+    "event": "message_delta",
+    "data": {
+      "delta": {
+        "stop_reason": "end_turn"
+      },
+      "type": "message_delta",
+      "usage": {
+        "output_tokens": 3
+      }
+    }
+  },
+  {
+    "event": "message_stop",
+    "data": {
+      "type": "message_stop"
+    }
+  }
+]

--- a/internal/proxy/testdata/conformance/anthropic/system_role_hoisted.golden
+++ b/internal/proxy/testdata/conformance/anthropic/system_role_hoisted.golden
@@ -1,0 +1,66 @@
+[
+  {
+    "event": "message_start",
+    "data": {
+      "message": {
+        "content": [],
+        "id": "<id>",
+        "model": "claude-opus-4-8",
+        "role": "assistant",
+        "type": "message",
+        "usage": {
+          "input_tokens": 5,
+          "output_tokens": 0
+        }
+      },
+      "type": "message_start"
+    }
+  },
+  {
+    "event": "content_block_start",
+    "data": {
+      "content_block": {
+        "text": "",
+        "type": "text"
+      },
+      "index": 0,
+      "type": "content_block_start"
+    }
+  },
+  {
+    "event": "content_block_delta",
+    "data": {
+      "delta": {
+        "text": "Hi there!",
+        "type": "text_delta"
+      },
+      "index": 0,
+      "type": "content_block_delta"
+    }
+  },
+  {
+    "event": "content_block_stop",
+    "data": {
+      "index": 0,
+      "type": "content_block_stop"
+    }
+  },
+  {
+    "event": "message_delta",
+    "data": {
+      "delta": {
+        "stop_reason": "end_turn"
+      },
+      "type": "message_delta",
+      "usage": {
+        "output_tokens": 3
+      }
+    }
+  },
+  {
+    "event": "message_stop",
+    "data": {
+      "type": "message_stop"
+    }
+  }
+]

--- a/internal/proxy/testdata/conformance/gemini_native/basic_text.golden
+++ b/internal/proxy/testdata/conformance/gemini_native/basic_text.golden
@@ -1,0 +1,81 @@
+[
+  {
+    "event": "message_start",
+    "data": {
+      "message": {
+        "content": [],
+        "id": "<id>",
+        "model": "gemini-3.1-pro-preview",
+        "role": "assistant",
+        "stop_reason": null,
+        "stop_sequence": null,
+        "type": "message",
+        "usage": {
+          "input_tokens": 1,
+          "output_tokens": 0
+        }
+      },
+      "type": "message_start"
+    }
+  },
+  {
+    "event": "content_block_start",
+    "data": {
+      "content_block": {
+        "text": "",
+        "type": "text"
+      },
+      "index": 0,
+      "type": "content_block_start"
+    }
+  },
+  {
+    "event": "content_block_delta",
+    "data": {
+      "delta": {
+        "text": "Hi",
+        "type": "text_delta"
+      },
+      "index": 0,
+      "type": "content_block_delta"
+    }
+  },
+  {
+    "event": "content_block_delta",
+    "data": {
+      "delta": {
+        "text": " there!",
+        "type": "text_delta"
+      },
+      "index": 0,
+      "type": "content_block_delta"
+    }
+  },
+  {
+    "event": "content_block_stop",
+    "data": {
+      "index": 0,
+      "type": "content_block_stop"
+    }
+  },
+  {
+    "event": "message_delta",
+    "data": {
+      "delta": {
+        "stop_reason": "end_turn",
+        "stop_sequence": null
+      },
+      "type": "message_delta",
+      "usage": {
+        "input_tokens": 5,
+        "output_tokens": 3
+      }
+    }
+  },
+  {
+    "event": "message_stop",
+    "data": {
+      "type": "message_stop"
+    }
+  }
+]

--- a/internal/proxy/testdata/conformance/gemini_native/basic_text.upstream.sse
+++ b/internal/proxy/testdata/conformance/gemini_native/basic_text.upstream.sse
@@ -1,0 +1,4 @@
+data: {"candidates":[{"content":{"role":"model","parts":[{"text":"Hi"}]},"index":0}]}
+
+data: {"candidates":[{"content":{"role":"model","parts":[{"text":" there!"}]},"finishReason":"STOP","index":0}],"usageMetadata":{"promptTokenCount":5,"candidatesTokenCount":3,"totalTokenCount":8}}
+

--- a/internal/proxy/testdata/conformance/gemini_native/thinking_budget_gemini25.golden
+++ b/internal/proxy/testdata/conformance/gemini_native/thinking_budget_gemini25.golden
@@ -1,0 +1,81 @@
+[
+  {
+    "event": "message_start",
+    "data": {
+      "message": {
+        "content": [],
+        "id": "<id>",
+        "model": "gemini-2.5-pro",
+        "role": "assistant",
+        "stop_reason": null,
+        "stop_sequence": null,
+        "type": "message",
+        "usage": {
+          "input_tokens": 2,
+          "output_tokens": 0
+        }
+      },
+      "type": "message_start"
+    }
+  },
+  {
+    "event": "content_block_start",
+    "data": {
+      "content_block": {
+        "text": "",
+        "type": "text"
+      },
+      "index": 0,
+      "type": "content_block_start"
+    }
+  },
+  {
+    "event": "content_block_delta",
+    "data": {
+      "delta": {
+        "text": "Hi",
+        "type": "text_delta"
+      },
+      "index": 0,
+      "type": "content_block_delta"
+    }
+  },
+  {
+    "event": "content_block_delta",
+    "data": {
+      "delta": {
+        "text": " there!",
+        "type": "text_delta"
+      },
+      "index": 0,
+      "type": "content_block_delta"
+    }
+  },
+  {
+    "event": "content_block_stop",
+    "data": {
+      "index": 0,
+      "type": "content_block_stop"
+    }
+  },
+  {
+    "event": "message_delta",
+    "data": {
+      "delta": {
+        "stop_reason": "end_turn",
+        "stop_sequence": null
+      },
+      "type": "message_delta",
+      "usage": {
+        "input_tokens": 5,
+        "output_tokens": 3
+      }
+    }
+  },
+  {
+    "event": "message_stop",
+    "data": {
+      "type": "message_stop"
+    }
+  }
+]

--- a/internal/proxy/testdata/conformance/gemini_native/thinking_level_gemini3.golden
+++ b/internal/proxy/testdata/conformance/gemini_native/thinking_level_gemini3.golden
@@ -1,0 +1,81 @@
+[
+  {
+    "event": "message_start",
+    "data": {
+      "message": {
+        "content": [],
+        "id": "<id>",
+        "model": "gemini-3.1-pro-preview",
+        "role": "assistant",
+        "stop_reason": null,
+        "stop_sequence": null,
+        "type": "message",
+        "usage": {
+          "input_tokens": 2,
+          "output_tokens": 0
+        }
+      },
+      "type": "message_start"
+    }
+  },
+  {
+    "event": "content_block_start",
+    "data": {
+      "content_block": {
+        "text": "",
+        "type": "text"
+      },
+      "index": 0,
+      "type": "content_block_start"
+    }
+  },
+  {
+    "event": "content_block_delta",
+    "data": {
+      "delta": {
+        "text": "Hi",
+        "type": "text_delta"
+      },
+      "index": 0,
+      "type": "content_block_delta"
+    }
+  },
+  {
+    "event": "content_block_delta",
+    "data": {
+      "delta": {
+        "text": " there!",
+        "type": "text_delta"
+      },
+      "index": 0,
+      "type": "content_block_delta"
+    }
+  },
+  {
+    "event": "content_block_stop",
+    "data": {
+      "index": 0,
+      "type": "content_block_stop"
+    }
+  },
+  {
+    "event": "message_delta",
+    "data": {
+      "delta": {
+        "stop_reason": "end_turn",
+        "stop_sequence": null
+      },
+      "type": "message_delta",
+      "usage": {
+        "input_tokens": 5,
+        "output_tokens": 3
+      }
+    }
+  },
+  {
+    "event": "message_stop",
+    "data": {
+      "type": "message_stop"
+    }
+  }
+]

--- a/internal/proxy/testdata/conformance/gemini_native/thought_signature_roundtrip.golden
+++ b/internal/proxy/testdata/conformance/gemini_native/thought_signature_roundtrip.golden
@@ -1,0 +1,81 @@
+[
+  {
+    "event": "message_start",
+    "data": {
+      "message": {
+        "content": [],
+        "id": "<id>",
+        "model": "gemini-3.1-pro-preview",
+        "role": "assistant",
+        "stop_reason": null,
+        "stop_sequence": null,
+        "type": "message",
+        "usage": {
+          "input_tokens": 3,
+          "output_tokens": 0
+        }
+      },
+      "type": "message_start"
+    }
+  },
+  {
+    "event": "content_block_start",
+    "data": {
+      "content_block": {
+        "text": "",
+        "type": "text"
+      },
+      "index": 0,
+      "type": "content_block_start"
+    }
+  },
+  {
+    "event": "content_block_delta",
+    "data": {
+      "delta": {
+        "text": "Hi",
+        "type": "text_delta"
+      },
+      "index": 0,
+      "type": "content_block_delta"
+    }
+  },
+  {
+    "event": "content_block_delta",
+    "data": {
+      "delta": {
+        "text": " there!",
+        "type": "text_delta"
+      },
+      "index": 0,
+      "type": "content_block_delta"
+    }
+  },
+  {
+    "event": "content_block_stop",
+    "data": {
+      "index": 0,
+      "type": "content_block_stop"
+    }
+  },
+  {
+    "event": "message_delta",
+    "data": {
+      "delta": {
+        "stop_reason": "end_turn",
+        "stop_sequence": null
+      },
+      "type": "message_delta",
+      "usage": {
+        "input_tokens": 5,
+        "output_tokens": 3
+      }
+    }
+  },
+  {
+    "event": "message_stop",
+    "data": {
+      "type": "message_stop"
+    }
+  }
+]

--- a/internal/proxy/testdata/conformance/gemini_native/toolcall.golden
+++ b/internal/proxy/testdata/conformance/gemini_native/toolcall.golden
@@ -1,0 +1,72 @@
+[
+  {
+    "event": "message_start",
+    "data": {
+      "message": {
+        "content": [],
+        "id": "<id>",
+        "model": "gemini-3.1-pro-preview",
+        "role": "assistant",
+        "stop_reason": null,
+        "stop_sequence": null,
+        "type": "message",
+        "usage": {
+          "input_tokens": 3,
+          "output_tokens": 0
+        }
+      },
+      "type": "message_start"
+    }
+  },
+  {
+    "event": "content_block_start",
+    "data": {
+      "content_block": {
+        "id": "<tool_id>",
+        "input": {},
+        "name": "get_weather",
+        "type": "tool_use"
+      },
+      "index": 0,
+      "type": "content_block_start"
+    }
+  },
+  {
+    "event": "content_block_delta",
+    "data": {
+      "delta": {
+        "partial_json": "{\"city\":\"NYC\"}",
+        "type": "input_json_delta"
+      },
+      "index": 0,
+      "type": "content_block_delta"
+    }
+  },
+  {
+    "event": "content_block_stop",
+    "data": {
+      "index": 0,
+      "type": "content_block_stop"
+    }
+  },
+  {
+    "event": "message_delta",
+    "data": {
+      "delta": {
+        "stop_reason": "tool_use",
+        "stop_sequence": null
+      },
+      "type": "message_delta",
+      "usage": {
+        "input_tokens": 20,
+        "output_tokens": 10
+      }
+    }
+  },
+  {
+    "event": "message_stop",
+    "data": {
+      "type": "message_stop"
+    }
+  }
+]

--- a/internal/proxy/testdata/conformance/gemini_native/toolcall.upstream.sse
+++ b/internal/proxy/testdata/conformance/gemini_native/toolcall.upstream.sse
@@ -1,0 +1,2 @@
+data: {"candidates":[{"content":{"role":"model","parts":[{"functionCall":{"name":"get_weather","args":{"city":"NYC"}}}]},"finishReason":"STOP","index":0}],"usageMetadata":{"promptTokenCount":20,"candidatesTokenCount":10,"totalTokenCount":30}}
+

--- a/internal/proxy/testdata/conformance/openai_chat/basic_text.golden
+++ b/internal/proxy/testdata/conformance/openai_chat/basic_text.golden
@@ -1,0 +1,70 @@
+[
+  {
+    "event": "message_start",
+    "data": {
+      "message": {
+        "content": [],
+        "id": "<id>",
+        "model": "deepseek/deepseek-v4-pro",
+        "role": "assistant",
+        "stop_reason": null,
+        "stop_sequence": null,
+        "type": "message",
+        "usage": {
+          "input_tokens": 1,
+          "output_tokens": 0
+        }
+      },
+      "type": "message_start"
+    }
+  },
+  {
+    "event": "content_block_start",
+    "data": {
+      "content_block": {
+        "text": "",
+        "type": "text"
+      },
+      "index": 0,
+      "type": "content_block_start"
+    }
+  },
+  {
+    "event": "content_block_delta",
+    "data": {
+      "delta": {
+        "text": "Hi there!",
+        "type": "text_delta"
+      },
+      "index": 0,
+      "type": "content_block_delta"
+    }
+  },
+  {
+    "event": "content_block_stop",
+    "data": {
+      "index": 0,
+      "type": "content_block_stop"
+    }
+  },
+  {
+    "event": "message_delta",
+    "data": {
+      "delta": {
+        "stop_reason": "end_turn",
+        "stop_sequence": null
+      },
+      "type": "message_delta",
+      "usage": {
+        "input_tokens": 9,
+        "output_tokens": 3
+      }
+    }
+  },
+  {
+    "event": "message_stop",
+    "data": {
+      "type": "message_stop"
+    }
+  }
+]

--- a/internal/proxy/testdata/conformance/openai_chat/basic_text.upstream.json
+++ b/internal/proxy/testdata/conformance/openai_chat/basic_text.upstream.json
@@ -1,0 +1,1 @@
+{"id":"chatcmpl-3","object":"chat.completion","created":1,"model":"deepseek/deepseek-v4-pro","choices":[{"index":0,"message":{"role":"assistant","content":"Hello!"},"finish_reason":"stop"}],"usage":{"prompt_tokens":5,"completion_tokens":2}}

--- a/internal/proxy/testdata/conformance/openai_chat/basic_text.upstream.sse
+++ b/internal/proxy/testdata/conformance/openai_chat/basic_text.upstream.sse
@@ -1,0 +1,6 @@
+data: {"id":"chatcmpl-1","object":"chat.completion.chunk","created":1,"model":"deepseek/deepseek-v4-pro","choices":[{"index":0,"delta":{"role":"assistant","content":"Hi there!"},"finish_reason":null}]}
+
+data: {"id":"chatcmpl-1","object":"chat.completion.chunk","created":1,"model":"deepseek/deepseek-v4-pro","choices":[{"index":0,"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":9,"completion_tokens":3}}
+
+data: [DONE]
+

--- a/internal/proxy/testdata/conformance/openai_chat/basic_text_nonstream.golden
+++ b/internal/proxy/testdata/conformance/openai_chat/basic_text_nonstream.golden
@@ -1,0 +1,20 @@
+{
+  "data": {
+    "content": [
+      {
+        "text": "Hello!",
+        "type": "text"
+      }
+    ],
+    "id": "<id>",
+    "model": "deepseek/deepseek-v4-pro",
+    "role": "assistant",
+    "stop_reason": "end_turn",
+    "stop_sequence": null,
+    "type": "message",
+    "usage": {
+      "input_tokens": 5,
+      "output_tokens": 2
+    }
+  }
+}

--- a/internal/proxy/testdata/conformance/openai_chat/degenerate_toolcall.upstream.sse
+++ b/internal/proxy/testdata/conformance/openai_chat/degenerate_toolcall.upstream.sse
@@ -1,0 +1,8 @@
+data: {"id":"c1","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"role":"assistant","content":"Let me run that for you."},"finish_reason":null}]}
+
+data: {"id":"c1","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_x","type":"function","function":{"name":"","arguments":"{}"}}]},"finish_reason":null}]}
+
+data: {"id":"c1","choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}],"usage":{"prompt_tokens":20,"completion_tokens":8}}
+
+data: [DONE]
+

--- a/internal/proxy/testdata/conformance/openai_chat/degenerate_toolcall_demotes.golden
+++ b/internal/proxy/testdata/conformance/openai_chat/degenerate_toolcall_demotes.golden
@@ -1,0 +1,70 @@
+[
+  {
+    "event": "message_start",
+    "data": {
+      "message": {
+        "content": [],
+        "id": "<id>",
+        "model": "deepseek/deepseek-v4-pro",
+        "role": "assistant",
+        "stop_reason": null,
+        "stop_sequence": null,
+        "type": "message",
+        "usage": {
+          "input_tokens": 3,
+          "output_tokens": 0
+        }
+      },
+      "type": "message_start"
+    }
+  },
+  {
+    "event": "content_block_start",
+    "data": {
+      "content_block": {
+        "text": "",
+        "type": "text"
+      },
+      "index": 0,
+      "type": "content_block_start"
+    }
+  },
+  {
+    "event": "content_block_delta",
+    "data": {
+      "delta": {
+        "text": "Let me run that for you.",
+        "type": "text_delta"
+      },
+      "index": 0,
+      "type": "content_block_delta"
+    }
+  },
+  {
+    "event": "content_block_stop",
+    "data": {
+      "index": 0,
+      "type": "content_block_stop"
+    }
+  },
+  {
+    "event": "message_delta",
+    "data": {
+      "delta": {
+        "stop_reason": "end_turn",
+        "stop_sequence": null
+      },
+      "type": "message_delta",
+      "usage": {
+        "input_tokens": 20,
+        "output_tokens": 8
+      }
+    }
+  },
+  {
+    "event": "message_stop",
+    "data": {
+      "type": "message_stop"
+    }
+  }
+]

--- a/internal/proxy/testdata/conformance/openai_chat/openrouter_gates.golden
+++ b/internal/proxy/testdata/conformance/openai_chat/openrouter_gates.golden
@@ -1,0 +1,70 @@
+[
+  {
+    "event": "message_start",
+    "data": {
+      "message": {
+        "content": [],
+        "id": "<id>",
+        "model": "deepseek/deepseek-v4-pro",
+        "role": "assistant",
+        "stop_reason": null,
+        "stop_sequence": null,
+        "type": "message",
+        "usage": {
+          "input_tokens": 1,
+          "output_tokens": 0
+        }
+      },
+      "type": "message_start"
+    }
+  },
+  {
+    "event": "content_block_start",
+    "data": {
+      "content_block": {
+        "text": "",
+        "type": "text"
+      },
+      "index": 0,
+      "type": "content_block_start"
+    }
+  },
+  {
+    "event": "content_block_delta",
+    "data": {
+      "delta": {
+        "text": "Hi there!",
+        "type": "text_delta"
+      },
+      "index": 0,
+      "type": "content_block_delta"
+    }
+  },
+  {
+    "event": "content_block_stop",
+    "data": {
+      "index": 0,
+      "type": "content_block_stop"
+    }
+  },
+  {
+    "event": "message_delta",
+    "data": {
+      "delta": {
+        "stop_reason": "end_turn",
+        "stop_sequence": null
+      },
+      "type": "message_delta",
+      "usage": {
+        "input_tokens": 9,
+        "output_tokens": 3
+      }
+    }
+  },
+  {
+    "event": "message_stop",
+    "data": {
+      "type": "message_stop"
+    }
+  }
+]

--- a/internal/proxy/testdata/conformance/openai_chat/system_prompt.golden
+++ b/internal/proxy/testdata/conformance/openai_chat/system_prompt.golden
@@ -1,0 +1,70 @@
+[
+  {
+    "event": "message_start",
+    "data": {
+      "message": {
+        "content": [],
+        "id": "<id>",
+        "model": "deepseek/deepseek-v4-pro",
+        "role": "assistant",
+        "stop_reason": null,
+        "stop_sequence": null,
+        "type": "message",
+        "usage": {
+          "input_tokens": 9,
+          "output_tokens": 0
+        }
+      },
+      "type": "message_start"
+    }
+  },
+  {
+    "event": "content_block_start",
+    "data": {
+      "content_block": {
+        "text": "",
+        "type": "text"
+      },
+      "index": 0,
+      "type": "content_block_start"
+    }
+  },
+  {
+    "event": "content_block_delta",
+    "data": {
+      "delta": {
+        "text": "Hi there!",
+        "type": "text_delta"
+      },
+      "index": 0,
+      "type": "content_block_delta"
+    }
+  },
+  {
+    "event": "content_block_stop",
+    "data": {
+      "index": 0,
+      "type": "content_block_stop"
+    }
+  },
+  {
+    "event": "message_delta",
+    "data": {
+      "delta": {
+        "stop_reason": "end_turn",
+        "stop_sequence": null
+      },
+      "type": "message_delta",
+      "usage": {
+        "input_tokens": 9,
+        "output_tokens": 3
+      }
+    }
+  },
+  {
+    "event": "message_stop",
+    "data": {
+      "type": "message_stop"
+    }
+  }
+]

--- a/internal/proxy/testdata/conformance/openai_chat/toolcall.golden
+++ b/internal/proxy/testdata/conformance/openai_chat/toolcall.golden
@@ -1,0 +1,72 @@
+[
+  {
+    "event": "message_start",
+    "data": {
+      "message": {
+        "content": [],
+        "id": "<id>",
+        "model": "deepseek/deepseek-v4-pro",
+        "role": "assistant",
+        "stop_reason": null,
+        "stop_sequence": null,
+        "type": "message",
+        "usage": {
+          "input_tokens": 3,
+          "output_tokens": 0
+        }
+      },
+      "type": "message_start"
+    }
+  },
+  {
+    "event": "content_block_start",
+    "data": {
+      "content_block": {
+        "id": "call_abc",
+        "input": {},
+        "name": "get_weather",
+        "type": "tool_use"
+      },
+      "index": 0,
+      "type": "content_block_start"
+    }
+  },
+  {
+    "event": "content_block_delta",
+    "data": {
+      "delta": {
+        "partial_json": "{\"city\":\"NYC\"}",
+        "type": "input_json_delta"
+      },
+      "index": 0,
+      "type": "content_block_delta"
+    }
+  },
+  {
+    "event": "content_block_stop",
+    "data": {
+      "index": 0,
+      "type": "content_block_stop"
+    }
+  },
+  {
+    "event": "message_delta",
+    "data": {
+      "delta": {
+        "stop_reason": "tool_use",
+        "stop_sequence": null
+      },
+      "type": "message_delta",
+      "usage": {
+        "input_tokens": 30,
+        "output_tokens": 12
+      }
+    }
+  },
+  {
+    "event": "message_stop",
+    "data": {
+      "type": "message_stop"
+    }
+  }
+]

--- a/internal/proxy/testdata/conformance/openai_chat/toolcall.upstream.sse
+++ b/internal/proxy/testdata/conformance/openai_chat/toolcall.upstream.sse
@@ -1,0 +1,10 @@
+data: {"id":"chatcmpl-2","object":"chat.completion.chunk","created":1,"model":"deepseek/deepseek-v4-pro","choices":[{"index":0,"delta":{"role":"assistant","content":""},"finish_reason":null}]}
+
+data: {"id":"chatcmpl-2","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_abc","type":"function","function":{"name":"get_weather","arguments":""}}]},"finish_reason":null}]}
+
+data: {"id":"chatcmpl-2","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{\"city\":\"NYC\"}"}}]},"finish_reason":null}]}
+
+data: {"id":"chatcmpl-2","choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}],"usage":{"prompt_tokens":30,"completion_tokens":12}}
+
+data: [DONE]
+

--- a/internal/proxy/testdata/conformance/responses/effort_medium_promotes_high.golden
+++ b/internal/proxy/testdata/conformance/responses/effort_medium_promotes_high.golden
@@ -1,0 +1,152 @@
+[
+  {
+    "event": "message_start",
+    "data": {
+      "message": {
+        "content": [],
+        "id": "<id>",
+        "model": "gpt-5.5",
+        "role": "assistant",
+        "stop_reason": null,
+        "stop_sequence": null,
+        "type": "message",
+        "usage": {
+          "input_tokens": 3,
+          "output_tokens": 0
+        }
+      },
+      "type": "message_start"
+    }
+  },
+  {
+    "event": "content_block_start",
+    "data": {
+      "content_block": {
+        "thinking": "",
+        "type": "thinking"
+      },
+      "index": 0,
+      "type": "content_block_start"
+    }
+  },
+  {
+    "event": "content_block_delta",
+    "data": {
+      "delta": {
+        "thinking": "Checking the weather ",
+        "type": "thinking_delta"
+      },
+      "index": 0,
+      "type": "content_block_delta"
+    }
+  },
+  {
+    "event": "content_block_delta",
+    "data": {
+      "delta": {
+        "thinking": "tool.",
+        "type": "thinking_delta"
+      },
+      "index": 0,
+      "type": "content_block_delta"
+    }
+  },
+  {
+    "event": "content_block_stop",
+    "data": {
+      "index": 0,
+      "type": "content_block_stop"
+    }
+  },
+  {
+    "event": "content_block_start",
+    "data": {
+      "content_block": {
+        "text": "",
+        "type": "text"
+      },
+      "index": 1,
+      "type": "content_block_start"
+    }
+  },
+  {
+    "event": "content_block_delta",
+    "data": {
+      "delta": {
+        "text": "Let me check",
+        "type": "text_delta"
+      },
+      "index": 1,
+      "type": "content_block_delta"
+    }
+  },
+  {
+    "event": "content_block_delta",
+    "data": {
+      "delta": {
+        "text": " the weather.",
+        "type": "text_delta"
+      },
+      "index": 1,
+      "type": "content_block_delta"
+    }
+  },
+  {
+    "event": "content_block_stop",
+    "data": {
+      "index": 1,
+      "type": "content_block_stop"
+    }
+  },
+  {
+    "event": "content_block_start",
+    "data": {
+      "content_block": {
+        "id": "call_xyz",
+        "input": {},
+        "name": "get_weather",
+        "type": "tool_use"
+      },
+      "index": 2,
+      "type": "content_block_start"
+    }
+  },
+  {
+    "event": "content_block_delta",
+    "data": {
+      "delta": {
+        "partial_json": "{\"city\":\"NYC\"}",
+        "type": "input_json_delta"
+      },
+      "index": 2,
+      "type": "content_block_delta"
+    }
+  },
+  {
+    "event": "content_block_stop",
+    "data": {
+      "index": 2,
+      "type": "content_block_stop"
+    }
+  },
+  {
+    "event": "message_delta",
+    "data": {
+      "delta": {
+        "stop_reason": "tool_use",
+        "stop_sequence": null
+      },
+      "type": "message_delta",
+      "usage": {
+        "input_tokens": 150,
+        "output_tokens": 45
+      }
+    }
+  },
+  {
+    "event": "message_stop",
+    "data": {
+      "type": "message_stop"
+    }
+  }
+]

--- a/internal/proxy/testdata/conformance/responses/toolcall.upstream.sse
+++ b/internal/proxy/testdata/conformance/responses/toolcall.upstream.sse
@@ -1,0 +1,42 @@
+event: response.created
+data: {"type":"response.created","response":{"id":"resp_abc","status":"in_progress","model":"gpt-5.5","output":[]}}
+
+event: response.output_item.added
+data: {"type":"response.output_item.added","output_index":0,"item":{"id":"rs_1","type":"reasoning","summary":[],"status":"in_progress"}}
+
+event: response.reasoning_summary_text.delta
+data: {"type":"response.reasoning_summary_text.delta","item_id":"rs_1","output_index":0,"summary_index":0,"delta":"Checking the weather "}
+
+event: response.reasoning_summary_text.delta
+data: {"type":"response.reasoning_summary_text.delta","item_id":"rs_1","output_index":0,"summary_index":0,"delta":"tool."}
+
+event: response.output_item.done
+data: {"type":"response.output_item.done","output_index":0,"item":{"id":"rs_1","type":"reasoning","summary":[{"type":"summary_text","text":"Checking the weather tool."}],"status":"completed"}}
+
+event: response.output_item.added
+data: {"type":"response.output_item.added","output_index":1,"item":{"id":"msg_1","type":"message","role":"assistant","status":"in_progress","content":[]}}
+
+event: response.output_text.delta
+data: {"type":"response.output_text.delta","item_id":"msg_1","output_index":1,"content_index":0,"delta":"Let me check"}
+
+event: response.output_text.delta
+data: {"type":"response.output_text.delta","item_id":"msg_1","output_index":1,"content_index":0,"delta":" the weather."}
+
+event: response.output_item.done
+data: {"type":"response.output_item.done","output_index":1,"item":{"id":"msg_1","type":"message","role":"assistant","status":"completed","content":[{"type":"output_text","text":"Let me check the weather."}]}}
+
+event: response.output_item.added
+data: {"type":"response.output_item.added","output_index":2,"item":{"id":"fc_1","type":"function_call","call_id":"call_xyz","name":"get_weather","arguments":"","status":"in_progress"}}
+
+event: response.function_call_arguments.delta
+data: {"type":"response.function_call_arguments.delta","item_id":"fc_1","output_index":2,"delta":"{\"city\":"}
+
+event: response.function_call_arguments.delta
+data: {"type":"response.function_call_arguments.delta","item_id":"fc_1","output_index":2,"delta":"\"NYC\"}"}
+
+event: response.output_item.done
+data: {"type":"response.output_item.done","output_index":2,"item":{"id":"fc_1","type":"function_call","call_id":"call_xyz","name":"get_weather","arguments":"{\"city\":\"NYC\"}","status":"completed"}}
+
+event: response.completed
+data: {"type":"response.completed","response":{"id":"resp_abc","status":"completed","model":"gpt-5.5","incomplete_details":null,"output":[{"id":"rs_1","type":"reasoning","summary":[{"type":"summary_text","text":"Checking the weather tool."}]},{"id":"msg_1","type":"message","role":"assistant","content":[{"type":"output_text","text":"Let me check the weather."}]},{"id":"fc_1","type":"function_call","call_id":"call_xyz","name":"get_weather","arguments":"{\"city\":\"NYC\"}"}],"usage":{"input_tokens":150,"input_tokens_details":{"cached_tokens":0},"output_tokens":45}}}
+

--- a/internal/proxy/testdata/conformance/responses/toolcall_nonstream_client.golden
+++ b/internal/proxy/testdata/conformance/responses/toolcall_nonstream_client.golden
@@ -1,0 +1,34 @@
+{
+  "data": {
+    "content": [
+      {
+        "signature": "rs_1",
+        "thinking": "Checking the weather tool.",
+        "type": "thinking"
+      },
+      {
+        "text": "Let me check the weather.",
+        "type": "text"
+      },
+      {
+        "id": "call_xyz",
+        "input": {
+          "city": "NYC"
+        },
+        "name": "get_weather",
+        "type": "tool_use"
+      }
+    ],
+    "id": "<id>",
+    "model": "gpt-5.5",
+    "role": "assistant",
+    "stop_reason": "tool_use",
+    "stop_sequence": null,
+    "type": "message",
+    "usage": {
+      "cache_read_input_tokens": 0,
+      "input_tokens": 150,
+      "output_tokens": 45
+    }
+  }
+}

--- a/internal/proxy/testdata/conformance/responses/toolcall_stream.golden
+++ b/internal/proxy/testdata/conformance/responses/toolcall_stream.golden
@@ -1,0 +1,152 @@
+[
+  {
+    "event": "message_start",
+    "data": {
+      "message": {
+        "content": [],
+        "id": "<id>",
+        "model": "gpt-5.5",
+        "role": "assistant",
+        "stop_reason": null,
+        "stop_sequence": null,
+        "type": "message",
+        "usage": {
+          "input_tokens": 3,
+          "output_tokens": 0
+        }
+      },
+      "type": "message_start"
+    }
+  },
+  {
+    "event": "content_block_start",
+    "data": {
+      "content_block": {
+        "thinking": "",
+        "type": "thinking"
+      },
+      "index": 0,
+      "type": "content_block_start"
+    }
+  },
+  {
+    "event": "content_block_delta",
+    "data": {
+      "delta": {
+        "thinking": "Checking the weather ",
+        "type": "thinking_delta"
+      },
+      "index": 0,
+      "type": "content_block_delta"
+    }
+  },
+  {
+    "event": "content_block_delta",
+    "data": {
+      "delta": {
+        "thinking": "tool.",
+        "type": "thinking_delta"
+      },
+      "index": 0,
+      "type": "content_block_delta"
+    }
+  },
+  {
+    "event": "content_block_stop",
+    "data": {
+      "index": 0,
+      "type": "content_block_stop"
+    }
+  },
+  {
+    "event": "content_block_start",
+    "data": {
+      "content_block": {
+        "text": "",
+        "type": "text"
+      },
+      "index": 1,
+      "type": "content_block_start"
+    }
+  },
+  {
+    "event": "content_block_delta",
+    "data": {
+      "delta": {
+        "text": "Let me check",
+        "type": "text_delta"
+      },
+      "index": 1,
+      "type": "content_block_delta"
+    }
+  },
+  {
+    "event": "content_block_delta",
+    "data": {
+      "delta": {
+        "text": " the weather.",
+        "type": "text_delta"
+      },
+      "index": 1,
+      "type": "content_block_delta"
+    }
+  },
+  {
+    "event": "content_block_stop",
+    "data": {
+      "index": 1,
+      "type": "content_block_stop"
+    }
+  },
+  {
+    "event": "content_block_start",
+    "data": {
+      "content_block": {
+        "id": "call_xyz",
+        "input": {},
+        "name": "get_weather",
+        "type": "tool_use"
+      },
+      "index": 2,
+      "type": "content_block_start"
+    }
+  },
+  {
+    "event": "content_block_delta",
+    "data": {
+      "delta": {
+        "partial_json": "{\"city\":\"NYC\"}",
+        "type": "input_json_delta"
+      },
+      "index": 2,
+      "type": "content_block_delta"
+    }
+  },
+  {
+    "event": "content_block_stop",
+    "data": {
+      "index": 2,
+      "type": "content_block_stop"
+    }
+  },
+  {
+    "event": "message_delta",
+    "data": {
+      "delta": {
+        "stop_reason": "tool_use",
+        "stop_sequence": null
+      },
+      "type": "message_delta",
+      "usage": {
+        "input_tokens": 150,
+        "output_tokens": 45
+      }
+    }
+  },
+  {
+    "event": "message_stop",
+    "data": {
+      "type": "message_stop"
+    }
+  }
+]

--- a/scripts/record_provider_fixtures/README.md
+++ b/scripts/record_provider_fixtures/README.md
@@ -1,0 +1,38 @@
+# record_provider_fixtures
+
+Refreshes the translation-conformance **upstream fixtures** from live providers.
+
+The conformance suite (`internal/proxy/conformance_*_test.go`) is hermetic: a mock
+provider replays a canned response from `internal/proxy/testdata/conformance/`, and
+the test asserts the router translated it correctly. Those canned responses should
+be *real* provider output. This tool regenerates them: for each case it runs the
+same inbound Anthropic body through the router's own `Prepare*` emit, sends the
+translated request to the real upstream, and writes the raw response to the fixture.
+
+It is **not** a test (`package main`), so `go test ./...` never runs it and CI never
+hits the network. It is gated on `RECORD=1` and the relevant API key being set;
+cases whose key is missing are skipped.
+
+## Usage (from the repo root)
+
+```bash
+RECORD=1 \
+  OPENROUTER_API_KEY=… \
+  OPENAI_API_KEY=… \
+  GOOGLE_API_KEY=… \
+  go run ./scripts/record_provider_fixtures
+```
+
+Then regenerate the goldens and review the diff before committing:
+
+```bash
+go test ./internal/proxy/ -run TestConformance -update
+git diff internal/proxy/testdata/conformance
+```
+
+## Adding a case
+
+Add an entry to `cases` in `main.go` whose `fixture` path matches the
+`upstreamFixture` of the conformance case that reads it. Keep the inbound
+Anthropic body identical to the conformance case so the recorded response
+corresponds to the request the suite actually sends.

--- a/scripts/record_provider_fixtures/main.go
+++ b/scripts/record_provider_fixtures/main.go
@@ -61,13 +61,13 @@ var cases = []recordCase{
 	{"openai_chat/basic_text.upstream.sse", formatOpenAIChat, "deepseek/deepseek-v4-pro", providers.ProviderOpenRouter,
 		`{"model":"deepseek/deepseek-v4-pro","stream":true,"max_tokens":1024,"messages":[{"role":"user","content":"Say hi."}]}`},
 	{"openai_chat/toolcall.upstream.sse", formatOpenAIChat, "deepseek/deepseek-v4-pro", providers.ProviderOpenRouter,
-		`{"model":"deepseek/deepseek-v4-pro","stream":true,"max_tokens":1024,"tools":` + weatherTool + `,"messages":[{"role":"user","content":"Weather in NYC? Use the tool."}]}`},
+		`{"model":"deepseek/deepseek-v4-pro","stream":true,"max_tokens":1024,"tools":` + weatherTool + `,"messages":[{"role":"user","content":"Weather in NYC?"}]}`},
 	{"gemini_native/basic_text.upstream.sse", formatGemini, "gemini-3.1-pro-preview", providers.ProviderGoogle,
 		`{"model":"gemini-3.1-pro-preview","stream":true,"max_tokens":1024,"messages":[{"role":"user","content":"Say hi."}]}`},
 	{"gemini_native/toolcall.upstream.sse", formatGemini, "gemini-3.1-pro-preview", providers.ProviderGoogle,
-		`{"model":"gemini-3.1-pro-preview","stream":true,"max_tokens":1024,"tools":` + weatherTool + `,"messages":[{"role":"user","content":"Weather in NYC? Use the tool."}]}`},
+		`{"model":"gemini-3.1-pro-preview","stream":true,"max_tokens":1024,"tools":` + weatherTool + `,"messages":[{"role":"user","content":"Weather in NYC?"}]}`},
 	{"responses/toolcall.upstream.sse", formatOpenAIResponses, "gpt-5.5", providers.ProviderOpenAI,
-		`{"model":"gpt-5.5","stream":true,"max_tokens":2048,"thinking":{"type":"enabled","budget_tokens":24576},"tools":` + weatherTool + `,"messages":[{"role":"user","content":"Weather in NYC? Use the tool."}]}`},
+		`{"model":"gpt-5.5","stream":true,"max_tokens":2048,"thinking":{"type":"enabled","budget_tokens":24576},"tools":` + weatherTool + `,"messages":[{"role":"user","content":"Weather in NYC?"}]}`},
 }
 
 const weatherTool = `[{"name":"get_weather","description":"Get the weather","input_schema":{"type":"object","properties":{"city":{"type":"string"}},"required":["city"]}}]`

--- a/scripts/record_provider_fixtures/main.go
+++ b/scripts/record_provider_fixtures/main.go
@@ -1,0 +1,207 @@
+// Command record_provider_fixtures refreshes the translation-conformance
+// upstream fixtures from live providers. For each case it runs the SAME inbound
+// Anthropic body through the router's own Prepare* emit, sends the translated
+// request to the real upstream, and writes the raw response to the fixture the
+// conformance suite (internal/proxy/conformance_*_test.go) replays offline.
+//
+// It is a separate main package (not a _test.go), so `go test ./...` never runs
+// it and CI never touches the network. It is further gated on RECORD=1 and the
+// per-provider API key being present.
+//
+// Usage (from the repo root):
+//
+//	RECORD=1 OPENAI_API_KEY=… GOOGLE_API_KEY=… OPENROUTER_API_KEY=… \
+//	    go run ./scripts/record_provider_fixtures
+//
+// After recording, regenerate the goldens and review the diff:
+//
+//	go test ./internal/proxy/ -run TestConformance -update
+//	git diff internal/proxy/testdata/conformance
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"time"
+
+	"workweave/router/internal/providers"
+	"workweave/router/internal/router"
+	"workweave/router/internal/translate"
+)
+
+// fixtureRoot is where the conformance suite reads upstream fixtures from,
+// relative to the repo root (the recorder's expected working directory).
+const fixtureRoot = "internal/proxy/testdata/conformance"
+
+type format int
+
+const (
+	formatOpenAIChat format = iota
+	formatOpenAIResponses
+	formatGemini
+	formatAnthropic
+)
+
+type recordCase struct {
+	fixture       string // path under fixtureRoot, e.g. "openai_chat/basic_text.upstream.sse"
+	format        format
+	model         string
+	provider      string
+	anthropicBody string
+}
+
+// cases mirror the conformance suite's fixtures. Keep them in sync: a new
+// conformance case that wants live-recorded input adds an entry here.
+var cases = []recordCase{
+	{"openai_chat/basic_text.upstream.sse", formatOpenAIChat, "deepseek/deepseek-v4-pro", providers.ProviderOpenRouter,
+		`{"model":"deepseek/deepseek-v4-pro","stream":true,"max_tokens":1024,"messages":[{"role":"user","content":"Say hi."}]}`},
+	{"openai_chat/toolcall.upstream.sse", formatOpenAIChat, "deepseek/deepseek-v4-pro", providers.ProviderOpenRouter,
+		`{"model":"deepseek/deepseek-v4-pro","stream":true,"max_tokens":1024,"tools":` + weatherTool + `,"messages":[{"role":"user","content":"Weather in NYC? Use the tool."}]}`},
+	{"gemini_native/basic_text.upstream.sse", formatGemini, "gemini-3.1-pro-preview", providers.ProviderGoogle,
+		`{"model":"gemini-3.1-pro-preview","stream":true,"max_tokens":1024,"messages":[{"role":"user","content":"Say hi."}]}`},
+	{"gemini_native/toolcall.upstream.sse", formatGemini, "gemini-3.1-pro-preview", providers.ProviderGoogle,
+		`{"model":"gemini-3.1-pro-preview","stream":true,"max_tokens":1024,"tools":` + weatherTool + `,"messages":[{"role":"user","content":"Weather in NYC? Use the tool."}]}`},
+	{"responses/toolcall.upstream.sse", formatOpenAIResponses, "gpt-5.5", providers.ProviderOpenAI,
+		`{"model":"gpt-5.5","stream":true,"max_tokens":2048,"thinking":{"type":"enabled","budget_tokens":24576},"tools":` + weatherTool + `,"messages":[{"role":"user","content":"Weather in NYC? Use the tool."}]}`},
+}
+
+const weatherTool = `[{"name":"get_weather","description":"Get the weather","input_schema":{"type":"object","properties":{"city":{"type":"string"}},"required":["city"]}}]`
+
+func main() {
+	if os.Getenv("RECORD") != "1" {
+		fmt.Println("refusing to hit live providers without RECORD=1 (see file header for usage)")
+		return
+	}
+	client := &http.Client{Timeout: 180 * time.Second}
+	var recorded, skipped, failed int
+	for _, c := range cases {
+		key, keyEnv := apiKeyFor(c.format)
+		if key == "" {
+			fmt.Printf("SKIP  %s (%s not set)\n", c.fixture, keyEnv)
+			skipped++
+			continue
+		}
+		if err := record(client, c, key); err != nil {
+			fmt.Printf("FAIL  %s: %v\n", c.fixture, err)
+			failed++
+			continue
+		}
+		fmt.Printf("OK    %s\n", c.fixture)
+		recorded++
+	}
+	fmt.Printf("\nrecorded=%d skipped=%d failed=%d\n", recorded, skipped, failed)
+	if failed > 0 {
+		os.Exit(1)
+	}
+}
+
+func record(client *http.Client, c recordCase, apiKey string) (err error) {
+	env, err := translate.ParseAnthropic([]byte(c.anthropicBody))
+	if err != nil {
+		return fmt.Errorf("parse anthropic body: %w", err)
+	}
+	opts := translate.EmitOptions{
+		TargetModel:    c.model,
+		TargetProvider: c.provider,
+		Capabilities:   router.Lookup(c.model),
+	}
+
+	prep, err := prepare(env, c.format, opts)
+	if err != nil {
+		return fmt.Errorf("emit upstream request: %w", err)
+	}
+
+	url, hdr := endpoint(c, apiKey, prep)
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, url, bytes.NewReader(prep.Body))
+	if err != nil {
+		return fmt.Errorf("build request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "text/event-stream")
+	for k, v := range hdr {
+		req.Header.Set(k, v)
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("upstream call: %w", err)
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("read response: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("upstream status %d: %s", resp.StatusCode, truncate(body, 400))
+	}
+
+	path := filepath.Join(fixtureRoot, c.fixture)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	return os.WriteFile(path, body, 0o644)
+}
+
+func prepare(env *translate.RequestEnvelope, f format, opts translate.EmitOptions) (providers.PreparedRequest, error) {
+	switch f {
+	case formatOpenAIChat:
+		return env.PrepareOpenAI(http.Header{}, opts)
+	case formatOpenAIResponses:
+		return env.PrepareOpenAIResponses(http.Header{}, opts)
+	case formatGemini:
+		return env.PrepareGemini(http.Header{}, opts)
+	case formatAnthropic:
+		return env.PrepareAnthropic(http.Header{}, opts)
+	default:
+		return providers.PreparedRequest{}, fmt.Errorf("unknown format %d", f)
+	}
+}
+
+// endpoint returns the live upstream URL and auth headers for a case.
+func endpoint(c recordCase, apiKey string, prep providers.PreparedRequest) (string, map[string]string) {
+	switch c.format {
+	case formatOpenAIChat:
+		if c.provider == providers.ProviderOpenRouter {
+			return "https://openrouter.ai/api/v1/chat/completions", map[string]string{"Authorization": "Bearer " + apiKey}
+		}
+		return "https://api.openai.com/v1/chat/completions", map[string]string{"Authorization": "Bearer " + apiKey}
+	case formatOpenAIResponses:
+		return "https://api.openai.com/v1/responses", map[string]string{"Authorization": "Bearer " + apiKey}
+	case formatGemini:
+		return "https://generativelanguage.googleapis.com/v1beta/models/" + c.model + ":streamGenerateContent?alt=sse",
+			map[string]string{"x-goog-api-key": apiKey}
+	case formatAnthropic:
+		return "https://api.anthropic.com/v1/messages",
+			map[string]string{"x-api-key": apiKey, "anthropic-version": "2023-06-01"}
+	default:
+		return "", nil
+	}
+}
+
+func apiKeyFor(f format) (key, env string) {
+	switch f {
+	case formatOpenAIChat:
+		// OpenRouter is the recorded OpenAI-compat provider for the chat cases.
+		return os.Getenv("OPENROUTER_API_KEY"), "OPENROUTER_API_KEY"
+	case formatOpenAIResponses:
+		return os.Getenv("OPENAI_API_KEY"), "OPENAI_API_KEY"
+	case formatGemini:
+		return os.Getenv("GOOGLE_API_KEY"), "GOOGLE_API_KEY"
+	case formatAnthropic:
+		return os.Getenv("ANTHROPIC_API_KEY"), "ANTHROPIC_API_KEY"
+	default:
+		return "", ""
+	}
+}
+
+func truncate(b []byte, n int) string {
+	if len(b) <= n {
+		return string(b)
+	}
+	return string(b[:n]) + "…"
+}


### PR DESCRIPTION
## Why

We keep hand-fixing cross-format translation bugs (Gemini `thoughtSignature`, `thinkingLevel` vs `thinkingBudget`, gpt-5.x `reasoning_effort` dead-zone, `role:system` in the messages array, degenerate `tool_calls`, the #331 Responses hang). Each got a unit test *after* it bit us. There was no systematic net proving "for a realistic request, the router sends the provider the right thing **and** hands back the right thing" across every format.

## What

A hermetic, offline conformance suite. Each case stands up a mock provider endpoint (`httptest`), points the real provider client at it, drives a full `ProxyMessages` turn, and asserts **both** directions:
- **Request side** — explicit field checks on what the router sent upstream.
- **Response side** — golden full-output compare of the translated Anthropic response.

Organized by the **three real outbound wire formats** (translation is format-keyed, not per-provider):

| Format | Cases |
|---|---|
| OpenAI `/v1/chat/completions` | basic text (stream + non-stream), tool-use, **degenerate tool_calls demote (#293)**, OpenRouter gates, system prompt |
| Gemini native | text, tool-use, **thinkingLevel (3.x) vs thinkingBudget (2.5) (#328/#121)**, **thoughtSignature round-trip** |
| OpenAI Responses (gpt-5.x) | **stream:true guard (#331)**, Responses-SSE→Anthropic translation (stream + non-stream client), **medium→high effort (#328)** |
| Anthropic same-format | passthrough, **role:system hoist (#332)** |

Plus a focused `openai` client test guarding the #331 belt-and-suspenders: a stalled-header upstream surfaces a **bounded error, never an unbounded hang**.

## Does it catch real regressions?

Yes — verified by reverting the #331 `stream:true` emit: `responses/toolcall_stream` immediately failed with *"Responses request MUST set stream:true — a stream:false regression reintroduces the #331 header-timeout hang."* Each case pins a known past fix.

## Flakiness & runtime

- Hermetic: no network, no DB, no real providers.
- Non-flaky by construction: semantic JSON compare (not byte/key-order), volatile values redacted (generated message ids, synthesized tool-call ids, timestamps), and the timeout test is **channel-gated with an injected tiny header timeout** — no sleeps, no races.
- Verified under `-race -count=5`: clean. ~1.5s for the whole matrix.
- Runs under the existing `go test ./...` CI — **no workflow change**.

## Extending

Author an upstream fixture under `internal/proxy/testdata/conformance/<format>/`, add a `conformanceCase`, run `go test -update`, eyeball the golden. `scripts/record_provider_fixtures` (gated on `RECORD=1` + keys, never in CI) refreshes those fixtures from real providers via the router's own emit.

## Scope notes (honest)

- The model-switch stale-thinking-signature strip needs session-pin state to trigger e2e; it stays covered by the existing `emit_same_format_test.go` unit test rather than adding a pin-store fake here.
- One small prod seam: `openai.NewClientWithResponseHeaderTimeout` (mirrors the existing `httputil.NewTransportWithResponseHeaderTimeout`) so the timeout test injects a tiny header timeout instead of waiting 120s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)