### PR TITLE
feat(proxy): escalate cyclic tool-call loops to opus + loop_escalation telemetry

### DIFF
--- a/internal/proxy/loop_detection.go
+++ b/internal/proxy/loop_detection.go
@@ -152,6 +152,7 @@ func (s *Service) handleLoopEscalation(
 	log := observability.FromContext(ctx)
 
 	loopingModel := routedModel
+	userForced := false
 	if s.pinStore != nil && installationID != uuid.Nil {
 		existing, found, err := s.pinStore.Get(ctx, sessionKey, role)
 		if err != nil {
@@ -160,13 +161,19 @@ func (s *Service) handleLoopEscalation(
 			if existing.Reason == translate.ReasonLoopEscalation {
 				return // already rescued this session; don't re-pin or double-log
 			}
+			// A user's explicit /force-model (or x-weave-force-model) choice
+			// outranks auto-escalation — never silently overwrite it. Record the
+			// loop for telemetry, but leave the forced pin in place.
+			if existing.Reason == translate.ReasonUserForceModel {
+				userForced = true
+			}
 			if existing.Model != "" {
 				loopingModel = existing.Model
 			}
 		}
 	}
 
-	willEscalate := loopingModel != escalateModel
+	willEscalate := !userForced && loopingModel != escalateModel
 
 	// First-class telemetry. This (session, looping_model) → looped event is the
 	// exact misroute the embedder cannot predict up front, so it is a training
@@ -177,6 +184,7 @@ func (s *Service) handleLoopEscalation(
 	log.Info("router.loop_escalation",
 		"looping_model", loopingModel,
 		"escalated", willEscalate,
+		"user_forced", userForced,
 		"escalation_target", escalateModel,
 		"loop_tool", top.Name,
 		"loop_input_hash", top.InputHash,

--- a/internal/proxy/loop_detection.go
+++ b/internal/proxy/loop_detection.go
@@ -7,11 +7,15 @@ import (
 	"time"
 
 	"workweave/router/internal/observability"
+	"workweave/router/internal/providers"
 	"workweave/router/internal/router/sessionpin"
 	"workweave/router/internal/translate"
 
 	"github.com/google/uuid"
 )
+
+// escalateModel is the strong model a looping cheap/mid session is rescued onto.
+const escalateModel = "claude-opus-4-8"
 
 // Loop-detection knobs. Window is the number of recent tool calls inspected;
 // MaxRepeats is the count of identical (name+args) calls within the window
@@ -64,6 +68,153 @@ func detectToolCallLoop(env *translate.RequestEnvelope) (looped bool, sig transl
 		}
 	}
 	return false, translate.ToolCallSig{}, 0
+}
+
+// Cyclic-loop-detection knobs. Where detectToolCallLoop catches a TIGHT loop
+// (the same single call >=5x in the last 10), this catches a WIDER cycle: an
+// agent re-reading the same small set of files over and over across dozens of
+// turns (observed in the post-#332 re-bake — gpt-5.5/haiku reading defaults.ini
+// x45, package.json x51 across 400 turns, never editing, ending error_max_turns).
+const (
+	cyclicLoopWindowSize       = 30
+	cyclicLoopMinCalls         = 24
+	cyclicLoopMaxDistinctRatio = 0.4
+)
+
+// editToolNames are tool calls that constitute real progress; their presence in
+// the window means the agent is changing the repo, not stuck re-reading.
+var editToolNames = map[string]struct{}{
+	"Edit": {}, "Write": {}, "MultiEdit": {}, "NotebookEdit": {},
+}
+
+// detectCyclicToolCallLoop reports whether the trailing tool-call window is a
+// wide re-read cycle: at least cyclicLoopMinCalls calls whose distinct
+// (name, args) fraction is below cyclicLoopMaxDistinctRatio, with no edit/write
+// call in the window (the no-progress guard). A healthy Explore sub-agent reads
+// MANY DISTINCT files (high diversity → no trip); a stuck agent re-reads the
+// SAME few (low diversity → trip) — the #271 false-positive guard applied to the
+// wide-cycle case. Returns the most-repeated signature + count, the distinct
+// ratio, and the window size, for telemetry.
+func detectCyclicToolCallLoop(env *translate.RequestEnvelope) (looped bool, top translate.ToolCallSig, topCount int, distinctRatio float64, total int) {
+	sigs := env.AssistantToolCallSignatures()
+	if len(sigs) < cyclicLoopMinCalls {
+		return false, translate.ToolCallSig{}, 0, 0, 0
+	}
+	start := 0
+	if len(sigs) > cyclicLoopWindowSize {
+		start = len(sigs) - cyclicLoopWindowSize
+	}
+	window := sigs[start:]
+	counts := make(map[string]int, len(window))
+	keys := make(map[string]translate.ToolCallSig, len(window))
+	for _, s := range window {
+		if _, isEdit := editToolNames[s.Name]; isEdit {
+			// Real progress in the window — not a stuck loop.
+			return false, translate.ToolCallSig{}, 0, 0, len(window)
+		}
+		key := s.Name + "\x00" + s.InputHash
+		counts[key]++
+		keys[key] = s
+	}
+	distinctRatio = float64(len(counts)) / float64(len(window))
+	if distinctRatio >= cyclicLoopMaxDistinctRatio {
+		return false, translate.ToolCallSig{}, 0, distinctRatio, len(window)
+	}
+	for k, c := range counts {
+		if c > topCount {
+			topCount, top = c, keys[k]
+		}
+	}
+	return true, top, topCount, distinctRatio, len(window)
+}
+
+// handleLoopEscalation rescues a session stuck in a wide tool-call cycle by
+// pinning it to opus for the remainder of its life, and records a structured
+// telemetry event. It does NOT write a synthetic response — the caller falls
+// through to normal routing, which loads the just-written escalation pin (an
+// immutable sticky, like /force-model) and dispatches this turn to opus.
+//
+// Idempotent: a session already on a loop_escalation pin is left alone, so the
+// telemetry fires once per session. When the looping model is ALREADY opus the
+// event is recorded but no pin is written (a genuinely hard task, not a
+// misroute) — still a useful training signal.
+func (s *Service) handleLoopEscalation(
+	ctx context.Context,
+	top translate.ToolCallSig,
+	topCount int,
+	distinctRatio float64,
+	window int,
+	installationID uuid.UUID,
+	sessionKey [sessionpin.SessionKeyLen]byte,
+	role string,
+	routedModel string,
+) {
+	log := observability.FromContext(ctx)
+
+	loopingModel := routedModel
+	if s.pinStore != nil && installationID != uuid.Nil {
+		existing, found, err := s.pinStore.Get(ctx, sessionKey, role)
+		if err != nil {
+			log.Error("loop-escalation: prior pin lookup failed", "err", err)
+		} else if found {
+			if existing.Reason == translate.ReasonLoopEscalation {
+				return // already rescued this session; don't re-pin or double-log
+			}
+			if existing.Model != "" {
+				loopingModel = existing.Model
+			}
+		}
+	}
+
+	willEscalate := loopingModel != escalateModel
+
+	// First-class telemetry. This (session, looping_model) → looped event is the
+	// exact misroute the embedder cannot predict up front, so it is a training
+	// label for the difficulty/routing model. Emit for prod AND eval traffic; the
+	// post-escalation outcome is joined offline by session_key against the final
+	// shard result. (Durable router.loop_escalation_events table: see
+	// docs/plans/SPEC_loop_detect_escalate.md — fast-follow.)
+	log.Info("router.loop_escalation",
+		"looping_model", loopingModel,
+		"escalated", willEscalate,
+		"escalation_target", escalateModel,
+		"loop_tool", top.Name,
+		"loop_input_hash", top.InputHash,
+		"repeat_count", topCount,
+		"distinct_ratio", distinctRatio,
+		"window_size", window,
+		"session_key_prefix", shortSessionKey(sessionKey),
+		"role", role,
+	)
+
+	if !willEscalate {
+		return // already on opus — record-only
+	}
+
+	// Pin opus for the rest of the session (immutable sticky via ReasonLoopEscalation).
+	// context.Background(): the request ctx may already be canceled by the time
+	// this runs; the pin write must still land or the next turn re-loops.
+	if s.pinStore == nil || installationID == uuid.Nil {
+		return
+	}
+	var lastServed string
+	if existing, found, err := s.pinStore.Get(ctx, sessionKey, role); err == nil && found {
+		lastServed = existing.LastServedModel
+	}
+	pin := sessionpin.Pin{
+		SessionKey:      sessionKey,
+		Role:            role,
+		InstallationID:  installationID,
+		Provider:        providers.ProviderAnthropic,
+		Model:           escalateModel,
+		Reason:          translate.ReasonLoopEscalation,
+		TurnCount:       1,
+		PinnedUntil:     time.Now().Add(pinSessionTTL),
+		LastServedModel: lastServed,
+	}
+	if err := s.pinStore.Upsert(context.Background(), pin); err != nil {
+		log.Error("loop-escalation: pin upsert failed", "err", err)
+	}
 }
 
 // handleToolCallLoopBreak short-circuits a runaway tool-call loop. It writes a

--- a/internal/proxy/loop_detection_test.go
+++ b/internal/proxy/loop_detection_test.go
@@ -143,3 +143,52 @@ func itoa(n int) string {
 	}
 	return digits
 }
+
+// ---- cyclic (wide re-read) loop detector ----
+
+func cyclicReads(nFiles, total int) []toolCall {
+	calls := make([]toolCall, 0, total)
+	for i := 0; i < total; i++ {
+		calls = append(calls, toolCall{name: "Read", input: map[string]any{"file_path": "/app/f" + itoa(i%nFiles) + ".go"}})
+	}
+	return calls
+}
+
+func TestDetectCyclicToolCallLoop_TripsOnLowDiversityCycle(t *testing.T) {
+	// 30 Reads cycling over 5 files (each 6x) → distinct ratio 5/30 ≈ 0.17 < 0.4.
+	env, err := translate.ParseAnthropic(buildBodyWithToolCalls(t, cyclicReads(5, 30)))
+	require.NoError(t, err)
+	looped, top, count, ratio, total := detectCyclicToolCallLoop(env)
+	assert.True(t, looped, "low-diversity re-read cycle must trip")
+	assert.Equal(t, "Read", top.Name)
+	assert.GreaterOrEqual(t, count, 2)
+	assert.Less(t, ratio, cyclicLoopMaxDistinctRatio)
+	assert.Equal(t, cyclicLoopWindowSize, total)
+}
+
+func TestDetectCyclicToolCallLoop_BroadDistinctReadsDoNotTrip(t *testing.T) {
+	// A healthy Explore reads MANY DISTINCT files → high diversity → no trip.
+	env, err := translate.ParseAnthropic(buildBodyWithToolCalls(t, cyclicReads(30, 30)))
+	require.NoError(t, err)
+	looped, _, _, ratio, _ := detectCyclicToolCallLoop(env)
+	assert.False(t, looped, "broad distinct exploration must not trip (the #271 guard)")
+	assert.GreaterOrEqual(t, ratio, cyclicLoopMaxDistinctRatio)
+}
+
+func TestDetectCyclicToolCallLoop_EditInWindowIsProgress(t *testing.T) {
+	// Same low-diversity cycle but with a real Edit in the window → progress, no trip.
+	calls := cyclicReads(5, 29)
+	calls = append(calls, toolCall{name: "Edit", input: map[string]any{"file_path": "/app/f0.go", "old_string": "a", "new_string": "b"}})
+	env, err := translate.ParseAnthropic(buildBodyWithToolCalls(t, calls))
+	require.NoError(t, err)
+	looped, _, _, _, _ := detectCyclicToolCallLoop(env)
+	assert.False(t, looped, "an edit in the window means the agent is progressing, not stuck")
+}
+
+func TestDetectCyclicToolCallLoop_BelowMinCallsDoesNotTrip(t *testing.T) {
+	// Fewer than cyclicLoopMinCalls tool calls → too early to call it a loop.
+	env, err := translate.ParseAnthropic(buildBodyWithToolCalls(t, cyclicReads(3, 20)))
+	require.NoError(t, err)
+	looped, _, _, _, _ := detectCyclicToolCallLoop(env)
+	assert.False(t, looped, "below the min-calls floor must not trip")
+}

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -898,10 +898,23 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 	// runaway OSS-model tool-call cycles (qwen3, in particular) that the
 	// previous-turn-maxed-out guard misses because each individual tool call
 	// returns quickly and well under the output cap.
-	if loop, sig, count := detectToolCallLoop(env); loop {
+	// Wide cyclic re-read loop on a cheap/mid model (re-reading the same few
+	// files for dozens of turns, no edits) → escalate the session to opus and
+	// fall through to normal routing. The escalation pin (an immutable sticky)
+	// takes effect from the next turn, like /force-model. This takes precedence
+	// over the tight-loop break below: rescuing the session beats stopping it.
+	escalatedLoop := false
+	if cyc, csig, ccount, cratio, cwin := detectCyclicToolCallLoop(env); cyc {
 		loopRole := roleForTier(catalog.TierFor(feats.Model))
-		log.Info("ProxyMessages tool-call loop detected", "tool_sig", sig, "repeat_count", count, "role", loopRole)
-		return s.handleToolCallLoopBreak(ctx, w, env, sig, count, installationID, sessionKey, loopRole, feats.Model, providers.ProviderAnthropic)
+		s.handleLoopEscalation(ctx, csig, ccount, cratio, cwin, installationID, sessionKey, loopRole, feats.Model)
+		escalatedLoop = true
+	}
+	if !escalatedLoop {
+		if loop, sig, count := detectToolCallLoop(env); loop {
+			loopRole := roleForTier(catalog.TierFor(feats.Model))
+			log.Info("ProxyMessages tool-call loop detected", "tool_sig", sig, "repeat_count", count, "role", loopRole)
+			return s.handleToolCallLoopBreak(ctx, w, env, sig, count, installationID, sessionKey, loopRole, feats.Model, providers.ProviderAnthropic)
+		}
 	}
 
 	// Surface inbound tool_use / tool_result blocks the model is about to see.
@@ -1964,12 +1977,22 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 	// the pin up and serves the requested model on this same turn.
 	s.applyForceModelHeader(ctx, r, env, installationID, sessionKey)
 
+	// Wide cyclic re-read loop → escalate to opus (same path as the Anthropic
+	// ingress). See detectCyclicToolCallLoop / handleLoopEscalation.
+	escalatedLoop := false
+	if cyc, csig, ccount, cratio, cwin := detectCyclicToolCallLoop(env); cyc {
+		loopRole := roleForTier(catalog.TierFor(feats.Model))
+		s.handleLoopEscalation(ctx, csig, ccount, cratio, cwin, installationID, sessionKey, loopRole, feats.Model)
+		escalatedLoop = true
+	}
 	// Tool-call loop break: same path as the Anthropic ingress. See the
 	// detectToolCallLoop / handleToolCallLoopBreak doc comments for rationale.
-	if loop, sig, count := detectToolCallLoop(env); loop {
-		loopRole := roleForTier(catalog.TierFor(feats.Model))
-		log.Info("ProxyOpenAIChatCompletion tool-call loop detected", "tool_sig", sig, "repeat_count", count, "role", loopRole)
-		return s.handleToolCallLoopBreak(ctx, w, env, sig, count, installationID, sessionKey, loopRole, feats.Model, providers.ProviderOpenAI)
+	if !escalatedLoop {
+		if loop, sig, count := detectToolCallLoop(env); loop {
+			loopRole := roleForTier(catalog.TierFor(feats.Model))
+			log.Info("ProxyOpenAIChatCompletion tool-call loop detected", "tool_sig", sig, "repeat_count", count, "role", loopRole)
+			return s.handleToolCallLoopBreak(ctx, w, env, sig, count, installationID, sessionKey, loopRole, feats.Model, providers.ProviderOpenAI)
+		}
 	}
 
 	logInboundRequestDiagnostics(log, env)

--- a/internal/proxy/service_session_pin_test.go
+++ b/internal/proxy/service_session_pin_test.go
@@ -899,6 +899,31 @@ func TestService_ForcedPin_UnclampedReasonStaysUserForced(t *testing.T) {
 	assert.Equal(t, translate.ReasonUserForceModel, rec.Header().Get(proxy.HeaderRouterDecision), "in-ceiling forced pin keeps the plain user_forced reason")
 }
 
+// TestService_LoopEscalationPin_HonoredAsImmutableSticky verifies a
+// loop_escalation pin is treated like a /force-model pin: the scorer's (cheap)
+// decision is bypassed and the session stays on the escalated opus model.
+func TestService_LoopEscalationPin_HonoredAsImmutableSticky(t *testing.T) {
+	store := newFakePinStore()
+	store.hasPin = true
+	store.pin = sessionpin.Pin{
+		Provider:    providers.ProviderAnthropic,
+		Model:       "claude-opus-4-8",
+		Reason:      translate.ReasonLoopEscalation,
+		PinnedUntil: time.Now().Add(30 * time.Minute),
+	}
+	// Scorer would pick a cheap model; the escalation pin must win.
+	fr := &fakeRouter{decision: router.Decision{Provider: providers.ProviderAnthropic, Model: "claude-haiku-4-5", Reason: "cluster:v0.65"}}
+	svc := newPinSvc(fr, store)
+
+	ctx := authedCtx(uuid.New().String())
+	rec := httptest.NewRecorder()
+	httpReq := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(""))
+	require.NoError(t, svc.ProxyMessages(ctx, []byte(pinTestBody), rec, httpReq))
+
+	assert.Equal(t, "claude-opus-4-8", rec.Header().Get(proxy.HeaderRouterModel), "escalation pin must keep the session on opus")
+	assert.Equal(t, translate.ReasonLoopEscalation, rec.Header().Get(proxy.HeaderRouterDecision), "escalation pin must report loop_escalation, not the scorer reason")
+}
+
 // TestService_TierClamp_UnknownRequestedModelDisablesClamp regression-
 // guards the PR #100 finding: RequestedTier must be derived from
 // catalog.TierFor(feats.Model) directly, not via

--- a/internal/proxy/service_session_pin_test.go
+++ b/internal/proxy/service_session_pin_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"strings"
 	"sync"
 	"testing"
@@ -922,6 +923,55 @@ func TestService_LoopEscalationPin_HonoredAsImmutableSticky(t *testing.T) {
 
 	assert.Equal(t, "claude-opus-4-8", rec.Header().Get(proxy.HeaderRouterModel), "escalation pin must keep the session on opus")
 	assert.Equal(t, translate.ReasonLoopEscalation, rec.Header().Get(proxy.HeaderRouterDecision), "escalation pin must report loop_escalation, not the scorer reason")
+}
+
+// buildCyclicLoopBody returns an Anthropic request whose assistant history is a
+// wide re-read cycle (same few files Read many times, no edits) — enough to trip
+// detectCyclicToolCallLoop.
+func buildCyclicLoopBody(t *testing.T, nFiles, total int) []byte {
+	t.Helper()
+	msgs := []any{map[string]any{"role": "user", "content": "do the task"}}
+	for i := 0; i < total; i++ {
+		id := "toolu_" + strconv.Itoa(i)
+		msgs = append(msgs,
+			map[string]any{"role": "assistant", "content": []any{
+				map[string]any{"type": "tool_use", "id": id, "name": "Read",
+					"input": map[string]any{"file_path": "/app/f" + strconv.Itoa(i%nFiles) + ".go"}},
+			}},
+			map[string]any{"role": "user", "content": []any{
+				map[string]any{"type": "tool_result", "tool_use_id": id, "content": "x"},
+			}},
+		)
+	}
+	b, err := json.Marshal(map[string]any{"model": "claude-opus-4-8", "max_tokens": 256, "messages": msgs})
+	require.NoError(t, err)
+	return b
+}
+
+// TestService_LoopEscalation_DoesNotOverwriteUserForcedPin verifies a user's
+// explicit /force-model choice outranks auto-escalation: a cyclic loop on a
+// forced session is recorded but must NOT replace the user_forced pin with opus.
+func TestService_LoopEscalation_DoesNotOverwriteUserForcedPin(t *testing.T) {
+	store := newFakePinStore()
+	store.hasPin = true
+	store.pin = sessionpin.Pin{
+		Provider:    providers.ProviderAnthropic,
+		Model:       "claude-haiku-4-5",
+		Reason:      translate.ReasonUserForceModel,
+		PinnedUntil: time.Now().Add(30 * time.Minute),
+	}
+	fr := &fakeRouter{decision: router.Decision{Provider: providers.ProviderAnthropic, Model: "claude-haiku-4-5", Reason: "cluster:v0.65"}}
+	svc := newPinSvc(fr, store)
+
+	ctx := authedCtx(uuid.New().String())
+	rec := httptest.NewRecorder()
+	httpReq := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(""))
+	require.NoError(t, svc.ProxyMessages(ctx, buildCyclicLoopBody(t, 5, 26), rec, httpReq))
+
+	for _, p := range store.upserts {
+		assert.NotEqual(t, translate.ReasonLoopEscalation, p.Reason, "escalation must not overwrite a user_forced pin")
+	}
+	assert.Equal(t, "claude-haiku-4-5", rec.Header().Get(proxy.HeaderRouterModel), "session stays on the user's forced model, not opus")
 }
 
 // TestService_TierClamp_UnknownRequestedModelDisablesClamp regression-

--- a/internal/proxy/turnloop.go
+++ b/internal/proxy/turnloop.go
@@ -265,24 +265,25 @@ func (s *Service) runTurnLoop(
 	//      may downgrade the decision for this turn (and appends "+tier_clamp" to
 	//      the reason), but the pin is refreshed with the ORIGINAL pin decision so
 	//      a transient ceiling never permanently overwrites the user's directive.
-	if pinFound && pin.Reason == translate.ReasonUserForceModel {
+	if pinFound && (pin.Reason == translate.ReasonUserForceModel || pin.Reason == translate.ReasonLoopEscalation) {
 		_, excluded := req.ExcludedModels[pin.Model]
 		_, providerEnabled := req.EnabledProviders[pin.Provider]
 		providerEligible := req.EnabledProviders == nil || providerEnabled
 		if !excluded && providerEligible {
 			decision := s.clampToCeiling(pinDecision(pin), res.RequestedTier, req.HasImages, req.EnabledProviders, req.ExcludedModels, &res)
 			if res.TierClamped {
-				// The forced model exceeds this turn's tier ceiling and was
-				// downgraded. Keep clampToCeiling's "user_forced+tier_clamp"
-				// reason rather than overwriting it back to plain "user_forced":
-				// otherwise the decision log and routing badge misreport the turn
-				// as served on the user's forced model when it was not. The pin
-				// itself is still refreshed with the original forced decision
-				// below, so the directive survives the transient clamp.
-				res.PinTier = "user_forced+tier_clamp"
+				// The pinned model exceeds this turn's tier ceiling and was
+				// downgraded. Keep clampToCeiling's "<reason>+tier_clamp" reason
+				// rather than overwriting it back to the plain reason: otherwise
+				// the decision log and routing badge misreport the turn as served
+				// on the pinned model when it was not. The pin itself is still
+				// refreshed with the original decision below, so the directive
+				// survives the transient clamp. (A loop_escalation pin is opus,
+				// which is unlikely to clamp, but the path is shared.)
+				res.PinTier = pin.Reason + "+tier_clamp"
 			} else {
-				decision.Reason = translate.ReasonUserForceModel
-				res.PinTier = "user_forced"
+				decision.Reason = pin.Reason
+				res.PinTier = pin.Reason
 			}
 			res.Decision = decision
 			res.StickyHit = true

--- a/internal/translate/force_model.go
+++ b/internal/translate/force_model.go
@@ -14,6 +14,13 @@ import (
 // lifetime until /unforce-model clears it.
 const ReasonUserForceModel = "user_forced"
 
+// ReasonLoopEscalation is the decision_reason stored in the session pin when the
+// router detects a cyclic tool-call loop on a cheap/mid model and escalates the
+// session to opus. The turn loop treats it as an immutable sticky (same as
+// ReasonUserForceModel) so the rescued session stays on the strong model for the
+// rest of its life rather than re-routing back into the loop.
+const ReasonLoopEscalation = "loop_escalation"
+
 // ForceModelResult holds the parsed outcome of a force-model command.
 type ForceModelResult struct {
 	// Model is the target model name; empty when Clear is true.


### PR DESCRIPTION
## Problem (from the post-#332 re-bake)

With the translation-bug 400s verifiably gone (#332/#333/#334), the residual router↔opus gap on agentic QnA/coding is **cheap/mid models stuck in a wide re-read cycle**. Stream forensics on the `v065-postfix-atlas` thrash shards:

- 418-turn shard: 379 consecutive gpt-5.5 turns re-reading `defaults.ini` ×45, `setting.go` ×44 — no edits, no answer — ending `error_max_turns`, **$11.13 burned**.
- 384-turn shard: `package.json` ×51, `jest.config.js` ×41. Same loop.
- Dominant-model split (Atlas router): opus resolves 16/18; haiku 1/10, gpt-5.5 1/5, mimo thrash.

The existing `detectToolCallLoop` only catches **tight** loops (same single call ≥5× in the last 10), so a wider cycle over ~6 files slips through — and its action (break + expire pin) just *stops* the agent in headless runs rather than rescuing it.

Full analysis + spec: `router-internal/docs/eval/RESULTS_opus_gap_decomposition.md`, `router-internal/docs/plans/SPEC_loop_detect_escalate.md`.

## Change

- **`detectCyclicToolCallLoop`** — trips when a long window (≥24 calls) has a distinct-signature ratio **< 0.4** with **no Edit/Write** in the window. Healthy Explore reads many *distinct* files (high diversity → no trip); a stuck agent re-reads the *same* few (low diversity → trip). This is the #271 false-positive guard applied to the wide-cycle case.
- **`handleLoopEscalation`** — pins the session to opus via a new `ReasonLoopEscalation`, honored as an **immutable sticky** (same path as `/force-model`), so the rescued session stays on the strong model. Idempotent (once/session); **record-only when already on opus** (a genuinely hard task, still a useful signal).
- **First-class telemetry** — a structured `router.loop_escalation` event with `looping_model`, loop signature + `repeat_count`, `distinct_ratio`, `window_size`, and `escalated`. This is the `(session, looping_model) → looped` **training label** for the difficulty/routing model — the exact misroute the embedder can't predict up front. Emitted for **prod and eval**. Durable `router.loop_escalation_events` table is a fast-follow (in the spec).
- Wired ahead of the tight-loop break on both Anthropic + OpenAI ingress; escalation takes precedence (rescue beats stop) and takes effect from the next turn like a force-model pin.

## Tests
- `detectCyclicToolCallLoop`: trips on low-diversity cycle; does NOT trip on broad-distinct Explore, on an edit-in-window (progress), or below the min-calls floor.
- `TestService_LoopEscalationPin_HonoredAsImmutableSticky`: a `loop_escalation` pin bypasses the (cheap) scorer decision and keeps the session on opus.
- Existing force-model / tight-loop suites still green; `go vet` + `gofmt` clean.

## Follow-ups (in the spec)
- Durable `router.loop_escalation_events` table (SQLC) for the training corpus + session-end outcome join.
- Offline replay to tune `W/R/D` against the archived thrash streams before live.
- Live A/B (lever on/off) to confirm the `error_max_turns` rate and `$/resolved` drop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)