### PR TITLE
feat(router): per-installation provider exclusion (excluded_providers)

### DIFF
--- a/cmd/router/main.go
+++ b/cmd/router/main.go
@@ -605,6 +605,20 @@ func main() {
 		logger.Info("Model exclusion override active", "excluded_models", cleaned)
 	}
 
+	// ROUTER_EXCLUDED_PROVIDERS pins a deployment-wide provider exclusion
+	// list, overriding per-installation DB state. Empty / unset → DB takes over.
+	if excludedRaw := strings.TrimSpace(config.GetOr("ROUTER_EXCLUDED_PROVIDERS", "")); excludedRaw != "" {
+		parts := strings.Split(excludedRaw, ",")
+		cleaned := make([]string, 0, len(parts))
+		for _, p := range parts {
+			if trimmed := strings.TrimSpace(p); trimmed != "" {
+				cleaned = append(cleaned, trimmed)
+			}
+		}
+		proxySvc = proxySvc.WithExcludedProvidersOverride(cleaned)
+		logger.Info("Provider exclusion override active", "excluded_providers", cleaned)
+	}
+
 	// APM (SigNoz) — adds standard HTTP server spans and Go runtime metrics
 	// to the same OTel resource shape as the rest of the Weave services.
 	// No-op when WV_APM_OTLP_ENDPOINT is unset. Flushed explicitly in the

--- a/db/migrations/0013_installation-excluded-providers.down.sql
+++ b/db/migrations/0013_installation-excluded-providers.down.sql
@@ -1,0 +1,6 @@
+BEGIN;
+
+ALTER TABLE router.model_router_installations
+  DROP COLUMN excluded_providers;
+
+COMMIT;

--- a/db/migrations/0013_installation-excluded-providers.up.sql
+++ b/db/migrations/0013_installation-excluded-providers.up.sql
@@ -1,0 +1,11 @@
+BEGIN;
+
+-- Per-installation provider exclusion list. When an entry is present, the
+-- provider is removed from the request's enabled-provider set, so the
+-- scorer, session pins, tier clamp, and dispatch fallback all skip it
+-- (sibling to excluded_models, which drops individual models).
+-- Empty array means "no exclusion" -- the default.
+ALTER TABLE router.model_router_installations
+  ADD COLUMN excluded_providers TEXT[] NOT NULL DEFAULT '{}';
+
+COMMIT;

--- a/db/queries/model_router_installations.sql
+++ b/db/queries/model_router_installations.sql
@@ -44,3 +44,14 @@ SET excluded_models = @excluded_models::text[],
 WHERE id = @id::uuid
   AND external_id = @external_id::varchar
   AND deleted_at IS NULL;
+
+-- Replaces the per-installation provider exclusion list, scoped to an
+-- external_id to prevent cross-tenant updates. Empty array means "no
+-- exclusion". Bumps updated_at so dashboards see the change.
+-- name: UpdateModelRouterInstallationExcludedProviders :exec
+UPDATE router.model_router_installations
+SET excluded_providers = @excluded_providers::text[],
+    updated_at = NOW()
+WHERE id = @id::uuid
+  AND external_id = @external_id::varchar
+  AND deleted_at IS NULL;

--- a/frontend/src/app/(app)/settings/page.tsx
+++ b/frontend/src/app/(app)/settings/page.tsx
@@ -16,7 +16,7 @@ import {
   type ExternalKey,
   type RouterConfig,
 } from "@/lib/api";
-import { ChevronDown, Copy, Filter, KeyRound, Plug, RotateCw, Settings as SettingsIcon, Trash2 } from "lucide-react";
+import { ChevronDown, Copy, Filter, KeyRound, Network, Plug, RotateCw, Settings as SettingsIcon, Trash2 } from "lucide-react";
 import { useEffect, useState } from "react";
 
 export default function SettingsPage() {
@@ -87,6 +87,25 @@ export default function SettingsPage() {
             installation. Unchecked models are skipped at request time.
           </Text>
           <ModelSelectionPanel />
+        </Page.Section>
+
+        <Page.Section
+          className="py-3"
+          header={
+            <Page.SectionHeader>
+              <Network className="size-4" />
+              <Text variant="h4" as="h3">
+                Provider selection
+              </Text>
+            </Page.SectionHeader>
+          }
+        >
+          <Text className="text-xs text-muted-foreground">
+            Uncheck a provider to never serve requests through it, including
+            failover. Models hosted only by unchecked providers become
+            unroutable.
+          </Text>
+          <ProviderSelectionPanel />
         </Page.Section>
 
         <Page.Section
@@ -788,6 +807,125 @@ function ModelSelectionPanel() {
                 </div>
               ))}
             </div>
+          )}
+        </Card.Content>
+        <Card.Footer className="border-t border-border px-5 py-3">
+          <Button
+            onClick={save}
+            disabled={!dirty || saving || envOverrideActive}
+            intent={Intent.Primary}
+            appearance={Appearance.Filled}
+          >
+            {saving ? "Saving…" : "Save"}
+          </Button>
+        </Card.Footer>
+      </Card>
+    </>
+  );
+}
+
+
+function ProviderSelectionPanel() {
+  const [available, setAvailable] = useState<string[] | null>(null);
+  const [excluded, setExcluded] = useState<Set<string>>(new Set());
+  const [savedExcluded, setSavedExcluded] = useState<Set<string>>(new Set());
+  const [envOverrideActive, setEnvOverrideActive] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    api.excludedProviders
+      .get()
+      .then(res => {
+        setAvailable(res.available);
+        const ex = new Set(res.excluded);
+        setExcluded(ex);
+        setSavedExcluded(ex);
+        setEnvOverrideActive(res.env_override_active);
+      })
+      .catch((err: unknown) =>
+        setError(err instanceof Error ? err.message : "Failed to load providers"),
+      );
+  }, []);
+
+  const dirty =
+    excluded.size !== savedExcluded.size ||
+    Array.from(excluded).some(p => !savedExcluded.has(p));
+
+  function toggle(provider: string) {
+    if (envOverrideActive) return;
+    setExcluded(prev => {
+      const next = new Set(prev);
+      if (next.has(provider)) next.delete(provider);
+      else next.add(provider);
+      return next;
+    });
+  }
+
+  async function save() {
+    setSaving(true);
+    setError(null);
+    try {
+      const res = await api.excludedProviders.update(Array.from(excluded));
+      const ex = new Set(res.excluded);
+      setExcluded(ex);
+      setSavedExcluded(ex);
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err.message : "Failed to save");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  if (available == null) {
+    return (
+      <Card className="p-0">
+        <Card.Content>
+          <div className="px-5 py-8 text-center text-2xs text-muted-foreground">
+            {error != null ? "Failed to load" : "Loading…"}
+          </div>
+        </Card.Content>
+      </Card>
+    );
+  }
+
+  return (
+    <>
+      {error && <ErrorBanner>{error}</ErrorBanner>}
+      {envOverrideActive && (
+        <div className="rounded-md border border-border bg-muted/30 p-3 text-2xs text-muted-foreground">
+          Exclusion list is pinned by <code className="font-mono">ROUTER_EXCLUDED_PROVIDERS</code>;
+          clear the env var to edit here.
+        </div>
+      )}
+      <Card className="p-0">
+        <Card.Content>
+          {available.length === 0 ? (
+            <EmptyHint>No deployed providers. Check ROUTER_CLUSTER_VERSION and provider keys.</EmptyHint>
+          ) : (
+            <ul className="space-y-1 px-5 py-3">
+              {available.map(p => {
+                const isExcluded = excluded.has(p);
+                return (
+                  <li key={p} className="flex items-center gap-2">
+                    <input
+                      type="checkbox"
+                      id={`provider-${p}`}
+                      checked={!isExcluded}
+                      onChange={() => toggle(p)}
+                      disabled={envOverrideActive}
+                      className="size-3.5"
+                    />
+                    <label
+                      htmlFor={`provider-${p}`}
+                      className="cursor-pointer font-mono text-xs text-foreground"
+                    >
+                      {p}
+                    </label>
+                  </li>
+                );
+              })}
+            </ul>
           )}
         </Card.Content>
         <Card.Footer className="border-t border-border px-5 py-3">

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -124,6 +124,12 @@ export interface ExcludedModelsResponse {
   env_override_active: boolean;
 }
 
+export interface ExcludedProvidersResponse {
+  available: string[];
+  excluded: string[];
+  env_override_active: boolean;
+}
+
 export const api = {
   auth: {
     me: () => request<MeResponse>("/auth/me"),
@@ -183,6 +189,14 @@ export const api = {
     get: () => request<ExcludedModelsResponse>("/excluded-models"),
     update: (excluded: string[]) =>
       request<ExcludedModelsResponse>("/excluded-models", {
+        method: "PUT",
+        body: JSON.stringify({ excluded }),
+      }),
+  },
+  excludedProviders: {
+    get: () => request<ExcludedProvidersResponse>("/excluded-providers"),
+    update: (excluded: string[]) =>
+      request<ExcludedProvidersResponse>("/excluded-providers", {
         method: "PUT",
         body: JSON.stringify({ excluded }),
       }),

--- a/internal/api/admin/excluded_providers.go
+++ b/internal/api/admin/excluded_providers.go
@@ -1,0 +1,129 @@
+package admin
+
+import (
+	"errors"
+	"net/http"
+	"sort"
+
+	"workweave/router/internal/auth"
+	"workweave/router/internal/observability"
+	"workweave/router/internal/proxy"
+
+	"github.com/gin-gonic/gin"
+)
+
+// ProviderExclusionOverrideSource reports whether ROUTER_EXCLUDED_PROVIDERS
+// (or an equivalent deployment-wide override) is in effect, and what its
+// contents are. Implemented by *proxy.Service.
+type ProviderExclusionOverrideSource interface {
+	HasExcludedProvidersOverride() bool
+	ExcludedProvidersOverride() []string
+}
+
+type excludedProvidersResponse struct {
+	Available         []string `json:"available"`
+	Excluded          []string `json:"excluded"`
+	EnvOverrideActive bool     `json:"env_override_active"`
+}
+
+type updateExcludedProvidersRequest struct {
+	Excluded []string `json:"excluded"`
+}
+
+// deployedProvidersDTO returns the distinct provider names behind the
+// deployed-models registry, sorted. Centralized so the GET and PUT responses
+// cannot drift apart.
+func deployedProvidersDTO(models DeployedModelsSource) []string {
+	seen := make(map[string]struct{})
+	out := make([]string, 0)
+	for _, e := range models.DefaultDeployedModels() {
+		if _, dup := seen[e.Provider]; dup {
+			continue
+		}
+		seen[e.Provider] = struct{}{}
+		out = append(out, e.Provider)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// GetExcludedProvidersHandler returns the deployed provider names and the
+// installation's provider exclusion list. When a deployment-wide env override
+// is active, `env_override_active` is true and the UI must render the
+// checklist read-only.
+func GetExcludedProvidersHandler(authSvc *auth.Service, models DeployedModelsSource, override ProviderExclusionOverrideSource) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		installation, ok := resolveInstallation(c, authSvc)
+		if !ok {
+			return
+		}
+
+		envActive := override != nil && override.HasExcludedProvidersOverride()
+		var excluded []string
+		if envActive {
+			excluded = override.ExcludedProvidersOverride()
+		} else {
+			excluded = append([]string{}, installation.ExcludedProviders...)
+			sort.Strings(excluded)
+		}
+		if excluded == nil {
+			excluded = []string{}
+		}
+
+		c.JSON(http.StatusOK, excludedProvidersResponse{
+			Available:         deployedProvidersDTO(models),
+			Excluded:          excluded,
+			EnvOverrideActive: envActive,
+		})
+	}
+}
+
+// UpdateExcludedProvidersHandler replaces the installation's provider
+// exclusion list. Rejects unknown provider names with 400. Returns 403 when
+// the env override is active so the UI never silently loses a save.
+func UpdateExcludedProvidersHandler(authSvc *auth.Service, models DeployedModelsSource, override ProviderExclusionOverrideSource) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		log := observability.FromGin(c)
+		installation, ok := resolveInstallation(c, authSvc)
+		if !ok {
+			return
+		}
+		if override != nil && override.HasExcludedProvidersOverride() {
+			c.AbortWithStatusJSON(http.StatusForbidden, gin.H{
+				"error": "exclusion list is pinned by ROUTER_EXCLUDED_PROVIDERS; clear the env var to edit",
+			})
+			return
+		}
+
+		var req updateExcludedProvidersRequest
+		if err := c.ShouldBindJSON(&req); err != nil {
+			c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": "invalid request body"})
+			return
+		}
+
+		available := deployedProvidersDTO(models)
+		allowed := make(map[string]struct{}, len(available))
+		for _, p := range available {
+			allowed[p] = struct{}{}
+		}
+
+		stored, err := authSvc.SetInstallationExcludedProviders(c.Request.Context(), installation.ExternalID, installation.ID, req.Excluded, allowed)
+		if err != nil {
+			if errors.Is(err, auth.ErrUnknownProvider) {
+				c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+				return
+			}
+			log.Error("Failed to update excluded providers", "err", err, "installation_id", installation.ID)
+			c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"error": "failed to update excluded providers"})
+			return
+		}
+
+		sort.Strings(stored)
+		c.JSON(http.StatusOK, excludedProvidersResponse{
+			Available: available,
+			Excluded:  stored,
+		})
+	}
+}
+
+var _ ProviderExclusionOverrideSource = (*proxy.Service)(nil)

--- a/internal/auth/installation.go
+++ b/internal/auth/installation.go
@@ -18,6 +18,9 @@ type Installation struct {
 	// ExcludedModels is the per-installation model exclusion list.
 	// Empty means no exclusion.
 	ExcludedModels []string
+	// ExcludedProviders is the per-installation provider exclusion list.
+	// Empty means no exclusion.
+	ExcludedProviders []string
 }
 
 type CreateInstallationParams struct {
@@ -34,4 +37,7 @@ type InstallationRepository interface {
 	// UpdateExcludedModels replaces the per-installation exclusion list.
 	// An empty (or nil) slice clears the list.
 	UpdateExcludedModels(ctx context.Context, externalID, id string, models []string) error
+	// UpdateExcludedProviders replaces the per-installation provider
+	// exclusion list. An empty (or nil) slice clears the list.
+	UpdateExcludedProviders(ctx context.Context, externalID, id string, providerNames []string) error
 }

--- a/internal/auth/service.go
+++ b/internal/auth/service.go
@@ -16,6 +16,9 @@ import (
 // ErrUnknownModel is returned when a requested model ID is not in the caller-supplied allowed set.
 var ErrUnknownModel = errors.New("auth: unknown model id")
 
+// ErrUnknownProvider is returned when a requested provider name is not in the caller-supplied allowed set.
+var ErrUnknownProvider = errors.New("auth: unknown provider")
+
 type Clock func() time.Time
 
 // InstallationChangeNotifier fans out installation-change events to peer replicas.
@@ -232,6 +235,36 @@ func (s *Service) SetInstallationExcludedModels(ctx context.Context, externalID,
 		out = append(out, m)
 	}
 	if err := s.installations.UpdateExcludedModels(ctx, externalID, installationID, out); err != nil {
+		return nil, err
+	}
+	s.invalidateInstallation(installationID)
+	return out, nil
+}
+
+// SetInstallationExcludedProviders replaces the per-installation provider exclusion list.
+// allowed is the set of valid provider names; passing nil skips validation.
+func (s *Service) SetInstallationExcludedProviders(ctx context.Context, externalID, installationID string, providerNames []string, allowed map[string]struct{}) ([]string, error) {
+	if providerNames == nil {
+		providerNames = []string{}
+	}
+	if allowed != nil {
+		for _, p := range providerNames {
+			if _, ok := allowed[p]; !ok {
+				return nil, fmt.Errorf("%w: %q", ErrUnknownProvider, p)
+			}
+		}
+	}
+	// De-dupe while preserving order so the persisted list is stable.
+	seen := make(map[string]struct{}, len(providerNames))
+	out := make([]string, 0, len(providerNames))
+	for _, p := range providerNames {
+		if _, dup := seen[p]; dup {
+			continue
+		}
+		seen[p] = struct{}{}
+		out = append(out, p)
+	}
+	if err := s.installations.UpdateExcludedProviders(ctx, externalID, installationID, out); err != nil {
 		return nil, err
 	}
 	s.invalidateInstallation(installationID)

--- a/internal/auth/service_test.go
+++ b/internal/auth/service_test.go
@@ -94,8 +94,10 @@ func (f *fakeExternalAPIKeyRepo) MarkUsed(ctx context.Context, id string) error 
 }
 
 type fakeInstallationRepository struct {
-	excludedModelsByID         map[string][]string
-	excludedModelsExternalByID map[string]string
+	excludedModelsByID            map[string][]string
+	excludedModelsExternalByID    map[string]string
+	excludedProvidersByID         map[string][]string
+	excludedProvidersExternalByID map[string]string
 }
 
 func (fakeInstallationRepository) Create(ctx context.Context, params auth.CreateInstallationParams) (*auth.Installation, error) {
@@ -119,6 +121,17 @@ func (f *fakeInstallationRepository) UpdateExcludedModels(ctx context.Context, e
 	}
 	f.excludedModelsByID[id] = append([]string{}, models...)
 	f.excludedModelsExternalByID[id] = externalID
+	return nil
+}
+func (f *fakeInstallationRepository) UpdateExcludedProviders(ctx context.Context, externalID, id string, providerNames []string) error {
+	if f.excludedProvidersByID == nil {
+		f.excludedProvidersByID = map[string][]string{}
+	}
+	if f.excludedProvidersExternalByID == nil {
+		f.excludedProvidersExternalByID = map[string]string{}
+	}
+	f.excludedProvidersByID[id] = append([]string{}, providerNames...)
+	f.excludedProvidersExternalByID[id] = externalID
 	return nil
 }
 
@@ -620,6 +633,41 @@ func TestService_SetInstallationExcludedModels(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, []string{}, out)
 		assert.Equal(t, []string{}, installRepo.excludedModelsByID["inst-3"])
+	})
+}
+
+func TestService_SetInstallationExcludedProviders(t *testing.T) {
+	installRepo := &fakeInstallationRepository{}
+	svc := auth.NewService(installRepo, &fakeAPIKeyRepository{byHash: map[string]fakeKeyRow{}}, nil, nil, auth.NoOpAPIKeyCache{}, nil, frozenClock())
+
+	allowed := map[string]struct{}{"anthropic": {}, "fireworks": {}}
+
+	t.Run("persists deduped list scoped by external_id", func(t *testing.T) {
+		out, err := svc.SetInstallationExcludedProviders(context.Background(), "ext-1", "inst-1", []string{"fireworks", "fireworks", "anthropic"}, allowed)
+		require.NoError(t, err)
+		assert.Equal(t, []string{"fireworks", "anthropic"}, out, "duplicates collapsed; order preserved")
+		assert.Equal(t, []string{"fireworks", "anthropic"}, installRepo.excludedProvidersByID["inst-1"])
+		assert.Equal(t, "ext-1", installRepo.excludedProvidersExternalByID["inst-1"],
+			"external_id must be propagated to the repo for cross-tenant scoping")
+	})
+
+	t.Run("rejects unknown provider with ErrUnknownProvider", func(t *testing.T) {
+		_, err := svc.SetInstallationExcludedProviders(context.Background(), "ext-1", "inst-1", []string{"acme-cloud"}, allowed)
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, auth.ErrUnknownProvider))
+	})
+
+	t.Run("nil allowed skips validation", func(t *testing.T) {
+		out, err := svc.SetInstallationExcludedProviders(context.Background(), "ext-2", "inst-2", []string{"anything-goes"}, nil)
+		require.NoError(t, err)
+		assert.Equal(t, []string{"anything-goes"}, out)
+	})
+
+	t.Run("nil providers persists empty slice", func(t *testing.T) {
+		out, err := svc.SetInstallationExcludedProviders(context.Background(), "ext-3", "inst-3", nil, allowed)
+		require.NoError(t, err)
+		assert.Equal(t, []string{}, out)
+		assert.Equal(t, []string{}, installRepo.excludedProvidersByID["inst-3"])
 	})
 }
 

--- a/internal/postgres/converters.go
+++ b/internal/postgres/converters.go
@@ -14,15 +14,20 @@ func toAuthInstallation(row sqlc.RouterModelRouterInstallation) *auth.Installati
 	if excluded == nil {
 		excluded = []string{}
 	}
+	excludedProviders := row.ExcludedProviders
+	if excludedProviders == nil {
+		excludedProviders = []string{}
+	}
 	return &auth.Installation{
-		ID:             row.ID.String(),
-		ExternalID:     row.ExternalID,
-		Name:           row.Name,
-		CreatedAt:      timestampOrZero(row.CreatedAt),
-		UpdatedAt:      timestampOrZero(row.UpdatedAt),
-		DeletedAt:      timestampPtr(row.DeletedAt),
-		CreatedBy:      row.CreatedBy,
-		ExcludedModels: excluded,
+		ID:                row.ID.String(),
+		ExternalID:        row.ExternalID,
+		Name:              row.Name,
+		CreatedAt:         timestampOrZero(row.CreatedAt),
+		UpdatedAt:         timestampOrZero(row.UpdatedAt),
+		DeletedAt:         timestampPtr(row.DeletedAt),
+		CreatedBy:         row.CreatedBy,
+		ExcludedModels:    excluded,
+		ExcludedProviders: excludedProviders,
 	}
 }
 

--- a/internal/postgres/repository.go
+++ b/internal/postgres/repository.go
@@ -104,6 +104,22 @@ func (r *installationRepo) UpdateExcludedModels(ctx context.Context, externalID,
 	})
 }
 
+func (r *installationRepo) UpdateExcludedProviders(ctx context.Context, externalID, id string, providerNames []string) error {
+	parsed, err := uuid.Parse(id)
+	if err != nil {
+		return err
+	}
+	if providerNames == nil {
+		providerNames = []string{}
+	}
+	q := sqlc.New(r.tx)
+	return q.UpdateModelRouterInstallationExcludedProviders(ctx, sqlc.UpdateModelRouterInstallationExcludedProvidersParams{
+		ID:                parsed,
+		ExternalID:        externalID,
+		ExcludedProviders: providerNames,
+	})
+}
+
 type apiKeyRepo struct {
 	tx sqlc.DBTX
 }

--- a/internal/proxy/enabled_providers_internal_test.go
+++ b/internal/proxy/enabled_providers_internal_test.go
@@ -52,6 +52,53 @@ func TestEnabledProvidersForRequest_PassthroughIsSurfaceScoped(t *testing.T) {
 	})
 }
 
+// TestEnabledProvidersForRequest_ExcludedProvidersSubtracted confirms the
+// per-installation provider exclusion list removes providers from the
+// eligible set even when their credentials are wired — the single seam
+// through which the scorer, hard pins, session pins, and tier clamp all
+// inherit the exclusion.
+func TestEnabledProvidersForRequest_ExcludedProvidersSubtracted(t *testing.T) {
+	makeService := func() *Service {
+		return &Service{
+			providers: map[string]providers.Client{
+				providers.ProviderAnthropic: nil,
+				providers.ProviderOpenAI:    nil,
+			},
+			deploymentKeyedProviders: map[string]struct{}{
+				providers.ProviderAnthropic: {},
+				providers.ProviderOpenAI:    {},
+			},
+			passthroughEligibleProviders: map[string]struct{}{},
+		}
+	}
+
+	t.Run("installation exclusion removes a deployment-keyed provider", func(t *testing.T) {
+		s := makeService()
+		ctx := context.WithValue(context.Background(), InstallationExcludedProvidersContextKey{}, []string{providers.ProviderOpenAI})
+		got := s.enabledProvidersForRequest(ctx, providers.ProviderAnthropic, http.Header{})
+		assert.Contains(t, got, providers.ProviderAnthropic)
+		assert.NotContains(t, got, providers.ProviderOpenAI,
+			"an excluded provider must be dropped even though its deployment key is wired")
+	})
+
+	t.Run("env override replaces the installation list", func(t *testing.T) {
+		s := makeService().WithExcludedProvidersOverride([]string{providers.ProviderAnthropic})
+		ctx := context.WithValue(context.Background(), InstallationExcludedProvidersContextKey{}, []string{providers.ProviderOpenAI})
+		got := s.enabledProvidersForRequest(ctx, providers.ProviderAnthropic, http.Header{})
+		assert.NotContains(t, got, providers.ProviderAnthropic,
+			"the deployment-wide override list must be enforced")
+		assert.Contains(t, got, providers.ProviderOpenAI,
+			"the override REPLACES the installation list rather than merging with it")
+	})
+
+	t.Run("no exclusions leaves the set untouched", func(t *testing.T) {
+		s := makeService()
+		got := s.enabledProvidersForRequest(context.Background(), providers.ProviderAnthropic, http.Header{})
+		assert.Contains(t, got, providers.ProviderAnthropic)
+		assert.Contains(t, got, providers.ProviderOpenAI)
+	})
+}
+
 // TestEnabledProvidersForRequest_DeploymentKeyedStillCrossSurface confirms
 // that env-keyed providers stay eligible regardless of surface (their keys
 // are trusted and don't depend on inbound headers).

--- a/internal/proxy/fallback.go
+++ b/internal/proxy/fallback.go
@@ -412,6 +412,18 @@ func (s *Service) resolveBindingsForDispatch(ctx context.Context, decision route
 		// avoid retrying on providers whose keys aren't actually wired.
 		return []catalog.ProviderBinding{primary}
 	}
+	// Provider exclusions must hold during failover too — otherwise a
+	// fallback binding could resurrect a provider the scorer already
+	// filtered out via enabledProvidersForRequest.
+	if excluded := s.excludedProvidersForRequest(ctx); len(excluded) > 0 {
+		filtered := make(map[string]struct{}, len(available))
+		for p := range available {
+			if _, drop := excluded[p]; !drop {
+				filtered[p] = struct{}{}
+			}
+		}
+		available = filtered
+	}
 	bindings := catalog.AvailableBindings(decision.Model, available)
 	if len(bindings) <= 1 {
 		return []catalog.ProviderBinding{primary}

--- a/internal/proxy/fallback.go
+++ b/internal/proxy/fallback.go
@@ -415,7 +415,8 @@ func (s *Service) resolveBindingsForDispatch(ctx context.Context, decision route
 	// Provider exclusions must hold during failover too — otherwise a
 	// fallback binding could resurrect a provider the scorer already
 	// filtered out via enabledProvidersForRequest.
-	if excluded := s.excludedProvidersForRequest(ctx); len(excluded) > 0 {
+	excluded := s.excludedProvidersForRequest(ctx)
+	if len(excluded) > 0 {
 		filtered := make(map[string]struct{}, len(available))
 		for p := range available {
 			if _, drop := excluded[p]; !drop {
@@ -424,15 +425,22 @@ func (s *Service) resolveBindingsForDispatch(ctx context.Context, decision route
 		}
 		available = filtered
 	}
+	_, primaryExcluded := excluded[decision.Provider]
 	bindings := catalog.AvailableBindings(decision.Model, available)
-	if len(bindings) <= 1 {
+	if len(bindings) == 0 || (len(bindings) == 1 && !primaryExcluded) {
 		return []catalog.ProviderBinding{primary}
 	}
 	// Defensive: the scorer picks bindings[0] at boot time; if for any
 	// reason the runtime decision lists a different provider, keep that
 	// as the primary attempt and treat the rest as ordered fallbacks
-	// minus duplicates.
+	// minus duplicates. Exception: an excluded primary is never re-added —
+	// routing already filters excluded providers, so a decision naming one
+	// is a bug upstream, and dispatching to it would break the exclusion
+	// contract. Serve only the eligible bindings in that case.
 	if bindings[0].Provider != decision.Provider {
+		if primaryExcluded {
+			return bindings
+		}
 		out := []catalog.ProviderBinding{primary}
 		for _, b := range bindings {
 			if b.Provider != decision.Provider {

--- a/internal/proxy/fallback.go
+++ b/internal/proxy/fallback.go
@@ -427,7 +427,18 @@ func (s *Service) resolveBindingsForDispatch(ctx context.Context, decision route
 	}
 	_, primaryExcluded := excluded[decision.Provider]
 	bindings := catalog.AvailableBindings(decision.Model, available)
-	if len(bindings) == 0 || (len(bindings) == 1 && !primaryExcluded) {
+	if len(bindings) == 0 {
+		if primaryExcluded {
+			// Every binding for the model is excluded AND the decision names
+			// an excluded provider (a bug upstream — routing filters these).
+			// Returning the primary would dispatch to the forbidden provider;
+			// an empty walk makes dispatchWithFallback fail with a clean 502
+			// instead.
+			return nil
+		}
+		return []catalog.ProviderBinding{primary}
+	}
+	if len(bindings) == 1 && !primaryExcluded {
 		return []catalog.ProviderBinding{primary}
 	}
 	// Defensive: the scorer picks bindings[0] at boot time; if for any

--- a/internal/proxy/fallback_test.go
+++ b/internal/proxy/fallback_test.go
@@ -597,6 +597,24 @@ func TestResolveBindingsForDispatch(t *testing.T) {
 		require.Len(t, bs, 1, "openrouter fallback binding must be filtered out by the provider exclusion")
 		assert.Equal(t, "fireworks", bs[0].Provider)
 	})
+	t.Run("all bindings excluded with excluded primary returns empty walk", func(t *testing.T) {
+		// When exclusion filters out every binding AND the decision names an
+		// excluded provider, the walk must be empty so dispatchWithFallback
+		// 502s instead of serving the forbidden provider.
+		s := &Service{deploymentKeyedProviders: map[string]struct{}{"fireworks": {}, "openrouter": {}}}
+		ctx := context.WithValue(context.Background(), InstallationExcludedProvidersContextKey{}, []string{"fireworks", "openrouter"})
+		bs := s.resolveBindingsForDispatch(ctx, router.Decision{Model: "deepseek/deepseek-v4-pro", Provider: "fireworks"})
+		assert.Empty(t, bs, "no eligible binding may remain when the primary itself is excluded")
+	})
+	t.Run("catalog-miss model keeps legacy single-attempt primary", func(t *testing.T) {
+		// A model with no catalog bindings (zero before any filtering) must
+		// keep the legacy [primary] walk when the primary is not excluded.
+		s := &Service{deploymentKeyedProviders: map[string]struct{}{"anthropic": {}}}
+		ctx := context.WithValue(context.Background(), InstallationExcludedProvidersContextKey{}, []string{"openrouter"})
+		bs := s.resolveBindingsForDispatch(ctx, router.Decision{Model: "not-in-catalog", Provider: "anthropic"})
+		require.Len(t, bs, 1)
+		assert.Equal(t, "anthropic", bs[0].Provider)
+	})
 	t.Run("excluded primary is never re-added as the first attempt", func(t *testing.T) {
 		// Defense in depth: routing already filters excluded providers, so a
 		// decision naming one is an upstream bug — dispatch must serve only

--- a/internal/proxy/fallback_test.go
+++ b/internal/proxy/fallback_test.go
@@ -597,6 +597,20 @@ func TestResolveBindingsForDispatch(t *testing.T) {
 		require.Len(t, bs, 1, "openrouter fallback binding must be filtered out by the provider exclusion")
 		assert.Equal(t, "fireworks", bs[0].Provider)
 	})
+	t.Run("excluded primary is never re-added as the first attempt", func(t *testing.T) {
+		// Defense in depth: routing already filters excluded providers, so a
+		// decision naming one is an upstream bug — dispatch must serve only
+		// the eligible bindings rather than re-prepending the excluded
+		// primary.
+		s := &Service{deploymentKeyedProviders: map[string]struct{}{"fireworks": {}, "openrouter": {}}}
+		ctx := context.WithValue(context.Background(), InstallationExcludedProvidersContextKey{}, []string{"fireworks"})
+		bs := s.resolveBindingsForDispatch(ctx, router.Decision{Model: "deepseek/deepseek-v4-pro", Provider: "fireworks"})
+		require.NotEmpty(t, bs)
+		for _, b := range bs {
+			assert.NotEqual(t, "fireworks", b.Provider,
+				"an excluded provider must not appear anywhere in the dispatch walk")
+		}
+	})
 }
 
 // TestProvidersIsRetryable round-trips the dispatcher's classifier

--- a/internal/proxy/fallback_test.go
+++ b/internal/proxy/fallback_test.go
@@ -590,6 +590,13 @@ func TestResolveBindingsForDispatch(t *testing.T) {
 		require.Len(t, bs, 1)
 		assert.Equal(t, "anthropic", bs[0].Provider)
 	})
+	t.Run("excluded provider cannot be resurrected as a fallback binding", func(t *testing.T) {
+		s := &Service{deploymentKeyedProviders: map[string]struct{}{"fireworks": {}, "openrouter": {}}}
+		ctx := context.WithValue(context.Background(), InstallationExcludedProvidersContextKey{}, []string{"openrouter"})
+		bs := s.resolveBindingsForDispatch(ctx, router.Decision{Model: "deepseek/deepseek-v4-pro", Provider: "fireworks"})
+		require.Len(t, bs, 1, "openrouter fallback binding must be filtered out by the provider exclusion")
+		assert.Equal(t, "fireworks", bs[0].Provider)
+	})
 }
 
 // TestProvidersIsRetryable round-trips the dispatcher's classifier

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -68,6 +68,10 @@ type Service struct {
 	// excludedModelsOverride, when non-nil, replaces the per-installation
 	// exclusion list on every request. Set from ROUTER_EXCLUDED_MODELS at boot.
 	excludedModelsOverride map[string]struct{}
+	// excludedProvidersOverride, when non-nil, replaces the per-installation
+	// provider exclusion list on every request. Set from
+	// ROUTER_EXCLUDED_PROVIDERS at boot.
+	excludedProvidersOverride map[string]struct{}
 	// deploymentKeyedProviders is the subset of registered providers whose
 	// upstream API key is configured at the deployment level. When nil, all
 	// registered providers are treated as deployment-keyed (legacy behavior).
@@ -135,6 +139,10 @@ type CredentialsContextKey struct{}
 // InstallationExcludedModelsContextKey is the context key for the authed
 // installation's model exclusion list. Carried as []string.
 type InstallationExcludedModelsContextKey struct{}
+
+// InstallationExcludedProvidersContextKey is the context key for the authed
+// installation's provider exclusion list. Carried as []string.
+type InstallationExcludedProvidersContextKey struct{}
 
 // installationExcludedModelsFromContext returns the per-installation exclusion
 // list stashed on ctx by the auth middleware, or nil when none is present.
@@ -258,6 +266,32 @@ func (s *Service) excludedModelsForRequest(ctx context.Context) map[string]struc
 	out := make(map[string]struct{}, len(excluded))
 	for _, m := range excluded {
 		out[m] = struct{}{}
+	}
+	return out
+}
+
+func installationExcludedProvidersFromContext(ctx context.Context) []string {
+	v := ctx.Value(InstallationExcludedProvidersContextKey{})
+	if v == nil {
+		return nil
+	}
+	out, _ := v.([]string)
+	return out
+}
+
+// excludedProvidersForRequest returns the request's provider exclusion set.
+// Env override wins; otherwise the installation list is converted to a set.
+func (s *Service) excludedProvidersForRequest(ctx context.Context) map[string]struct{} {
+	if s.excludedProvidersOverride != nil {
+		return s.excludedProvidersOverride
+	}
+	excluded := installationExcludedProvidersFromContext(ctx)
+	if len(excluded) == 0 {
+		return nil
+	}
+	out := make(map[string]struct{}, len(excluded))
+	for _, p := range excluded {
+		out[p] = struct{}{}
 	}
 	return out
 }
@@ -523,6 +557,39 @@ func (s *Service) ExcludedModelsOverride() []string {
 	out := make([]string, 0, len(s.excludedModelsOverride))
 	for m := range s.excludedModelsOverride {
 		out = append(out, m)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// WithExcludedProvidersOverride pins the per-request provider exclusion list
+// to a deployment-wide set. Pass nil or empty slice to clear the override.
+func (s *Service) WithExcludedProvidersOverride(providerNames []string) *Service {
+	if len(providerNames) == 0 {
+		s.excludedProvidersOverride = nil
+		return s
+	}
+	set := make(map[string]struct{}, len(providerNames))
+	for _, p := range providerNames {
+		set[p] = struct{}{}
+	}
+	s.excludedProvidersOverride = set
+	return s
+}
+
+// HasExcludedProvidersOverride reports whether an excluded-providers override is active.
+func (s *Service) HasExcludedProvidersOverride() bool {
+	return s.excludedProvidersOverride != nil
+}
+
+// ExcludedProvidersOverride returns a sorted copy of the override list.
+func (s *Service) ExcludedProvidersOverride() []string {
+	if s.excludedProvidersOverride == nil {
+		return nil
+	}
+	out := make([]string, 0, len(s.excludedProvidersOverride))
+	for p := range s.excludedProvidersOverride {
+		out = append(out, p)
 	}
 	sort.Strings(out)
 	return out
@@ -1721,6 +1788,14 @@ func (s *Service) enabledProvidersForRequest(ctx context.Context, surfaceProvide
 				out[surfaceProvider] = struct{}{}
 			}
 		}
+	}
+	// Provider exclusions trump every enrollment path above: an excluded
+	// provider must not be served even when credentials exist for it. The
+	// scorer, hard-pin resolver, session pins, and tier clamp all consume
+	// this set, so subtracting here enforces the exclusion everywhere a
+	// routing decision is made.
+	for p := range s.excludedProvidersForRequest(ctx) {
+		delete(out, p)
 	}
 	return out
 }

--- a/internal/proxy/turnloop.go
+++ b/internal/proxy/turnloop.go
@@ -342,6 +342,25 @@ func (s *Service) runTurnLoop(
 		}
 	}
 
+	// Provider-eligibility guard: when the pinned provider is no longer in
+	// this request's enabled set (installation/env provider exclusion, or a
+	// BYOK request without that provider's creds), treat the pin as missing
+	// so the sticky branches below (ToolResult, OutcomeStay, !plannerEnabled)
+	// cannot keep serving through a provider the request must not use.
+	// Mirrors the providerEligible check on the user-forced pin path above —
+	// without it, a session pinned before the exclusion was saved would keep
+	// hitting the excluded provider until the pin expired.
+	if pinFound && req.EnabledProviders != nil {
+		if _, ok := req.EnabledProviders[pin.Provider]; !ok {
+			log.Info("Session pin provider not in enabled set; falling through to scorer",
+				"pin_model", pin.Model,
+				"pin_provider", pin.Provider,
+			)
+			pinFound = false
+			pin = sessionpin.Pin{}
+		}
+	}
+
 	// Image-input guard: when this turn carries image content but the pinned
 	// model is text-only, drop the pin and fall through to the scorer so an
 	// image-capable model is chosen. The scorer's own image-input filter then

--- a/internal/proxy/turnloop_test.go
+++ b/internal/proxy/turnloop_test.go
@@ -185,6 +185,64 @@ func TestTurnLoop_ToolResultWithPinSkipsScorerAndPlanner(t *testing.T) {
 	assert.Equal(t, "claude-haiku-4-5", rec.Header().Get(proxy.HeaderRouterModel))
 }
 
+// TestTurnLoop_ToolResultPinOnExcludedProviderFallsThroughToScorer guards the
+// provider-eligibility pin guard: a session pinned to a provider that has
+// since been excluded (installation list, env override, or BYOK narrowing)
+// must NOT be served through the sticky branches — the turn falls through to
+// the scorer, which routes within the remaining enabled set. Without the
+// guard, ordinary stickies (unlike user-forced pins) kept hitting the
+// excluded provider until the pin expired.
+func TestTurnLoop_ToolResultPinOnExcludedProviderFallsThroughToScorer(t *testing.T) {
+	const toolResultBody = `{
+		"model":"claude-opus-4-7",
+		"system":"sys",
+		"messages":[
+			{"role":"user","content":"plan"},
+			{"role":"assistant","content":[{"type":"tool_use","id":"t1","name":"R","input":{}}]},
+			{"role":"user","content":[{"type":"tool_result","tool_use_id":"t1","content":"ok"}]}
+		]
+	}`
+	store := newFakePinStore()
+	store.hasPin = true
+	store.pin = sessionpin.Pin{
+		Provider:    providers.ProviderOpenAI,
+		Model:       "gpt-5.5",
+		Reason:      "cluster:v0.2",
+		PinnedUntil: time.Now().Add(time.Hour),
+	}
+	fr := &fakeRouter{decision: router.Decision{
+		Provider: providers.ProviderAnthropic,
+		Model:    "claude-haiku-4-5",
+		Reason:   "cluster:v0.2",
+	}}
+	svc := proxy.NewService(
+		fr,
+		map[string]providers.Client{
+			providers.ProviderAnthropic: &fakeProvider{},
+			providers.ProviderOpenAI:    &fakeProvider{},
+		},
+		nil,
+		false,
+		nil,
+		store,
+		false,
+		providers.ProviderAnthropic,
+		"claude-haiku-4-5",
+		nil,
+	)
+
+	ctx := context.WithValue(authedCtx(uuid.New().String()),
+		proxy.InstallationExcludedProvidersContextKey{}, []string{providers.ProviderOpenAI})
+	rec := httptest.NewRecorder()
+	httpReq := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(""))
+	require.NoError(t, svc.ProxyMessages(ctx, []byte(toolResultBody), rec, httpReq))
+
+	assert.Equal(t, 1, fr.routeCalls,
+		"pin on an excluded provider must fall through to the scorer instead of being served sticky")
+	assert.Equal(t, "claude-haiku-4-5", rec.Header().Get(proxy.HeaderRouterModel),
+		"the turn must be served on the scorer's fresh decision, not the excluded pin")
+}
+
 // TestTurnLoop_PlannerStaysWhenScorerAgrees verifies the same-model
 // trivial-stay branch: scorer recommends the pin's model, planner
 // returns reason=same_model, pin wins.

--- a/internal/server/middleware/auth.go
+++ b/internal/server/middleware/auth.go
@@ -100,6 +100,9 @@ func withAPIKey(svc *auth.Service, byokDisabled bool) gin.HandlerFunc {
 			if len(installation.ExcludedModels) > 0 {
 				ctx = context.WithValue(ctx, proxy.InstallationExcludedModelsContextKey{}, installation.ExcludedModels)
 			}
+			if len(installation.ExcludedProviders) > 0 {
+				ctx = context.WithValue(ctx, proxy.InstallationExcludedProvidersContextKey{}, installation.ExcludedProviders)
+			}
 		}
 		if externalKeys != nil && !byokDisabled {
 			ctx = context.WithValue(ctx, proxy.ExternalAPIKeysContextKey{}, externalKeys)

--- a/internal/server/middleware/auth_test.go
+++ b/internal/server/middleware/auth_test.go
@@ -103,6 +103,10 @@ func (fakeInstallationRepository) UpdateExcludedModels(ctx context.Context, exte
 	return errors.New("not used")
 }
 
+func (fakeInstallationRepository) UpdateExcludedProviders(ctx context.Context, externalID, id string, providerNames []string) error {
+	return errors.New("not used")
+}
+
 func TestWithAuthPrefersRouterKeyHeader(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	const routerToken = "rk_router"

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -109,6 +109,8 @@ func Register(engine *gin.Engine, authSvc *auth.Service, proxySvc *proxy.Service
 		if deployedModels != nil {
 			mgmt.GET("/excluded-models", admin.GetExcludedModelsHandler(authSvc, deployedModels, proxySvc))
 			mgmt.PUT("/excluded-models", admin.UpdateExcludedModelsHandler(authSvc, deployedModels, proxySvc))
+			mgmt.GET("/excluded-providers", admin.GetExcludedProvidersHandler(authSvc, deployedModels, proxySvc))
+			mgmt.PUT("/excluded-providers", admin.UpdateExcludedProvidersHandler(authSvc, deployedModels, proxySvc))
 		}
 	}
 

--- a/internal/sqlc/model_router_api_keys.sql.go
+++ b/internal/sqlc/model_router_api_keys.sql.go
@@ -92,7 +92,7 @@ func (q *Queries) CreateModelRouterAPIKey(ctx context.Context, arg CreateModelRo
 }
 
 const getActiveModelRouterAPIKeyWithInstallationByHash = `-- name: GetActiveModelRouterAPIKeyWithInstallationByHash :one
-SELECT k.id, k.installation_id, k.external_id, k.name, k.key_prefix, k.key_hash, k.key_suffix, k.last_used_at, k.created_at, k.deleted_at, k.created_by, i.id, i.external_id, i.name, i.created_at, i.updated_at, i.deleted_at, i.created_by, i.excluded_models
+SELECT k.id, k.installation_id, k.external_id, k.name, k.key_prefix, k.key_hash, k.key_suffix, k.last_used_at, k.created_at, k.deleted_at, k.created_by, i.id, i.external_id, i.name, i.created_at, i.updated_at, i.deleted_at, i.created_by, i.excluded_models, i.excluded_providers
 FROM router.model_router_api_keys k
 INNER JOIN router.model_router_installations i ON i.id = k.installation_id
 WHERE k.key_hash = $1::varchar
@@ -111,7 +111,7 @@ type GetActiveModelRouterAPIKeyWithInstallationByHashRow struct {
 // both sides so a soft-deleted installation invalidates all its keys without per-key
 // updates.
 //
-//	SELECT k.id, k.installation_id, k.external_id, k.name, k.key_prefix, k.key_hash, k.key_suffix, k.last_used_at, k.created_at, k.deleted_at, k.created_by, i.id, i.external_id, i.name, i.created_at, i.updated_at, i.deleted_at, i.created_by, i.excluded_models
+//	SELECT k.id, k.installation_id, k.external_id, k.name, k.key_prefix, k.key_hash, k.key_suffix, k.last_used_at, k.created_at, k.deleted_at, k.created_by, i.id, i.external_id, i.name, i.created_at, i.updated_at, i.deleted_at, i.created_by, i.excluded_models, i.excluded_providers
 //	FROM router.model_router_api_keys k
 //	INNER JOIN router.model_router_installations i ON i.id = k.installation_id
 //	WHERE k.key_hash = $1::varchar
@@ -140,6 +140,7 @@ func (q *Queries) GetActiveModelRouterAPIKeyWithInstallationByHash(ctx context.C
 		&i.RouterModelRouterInstallation.DeletedAt,
 		&i.RouterModelRouterInstallation.CreatedBy,
 		&i.RouterModelRouterInstallation.ExcludedModels,
+		&i.RouterModelRouterInstallation.ExcludedProviders,
 	)
 	return i, err
 }

--- a/internal/sqlc/model_router_installations.sql.go
+++ b/internal/sqlc/model_router_installations.sql.go
@@ -22,7 +22,7 @@ VALUES (
     $2::varchar,
     $3
 )
-RETURNING id, external_id, name, created_at, updated_at, deleted_at, created_by, excluded_models
+RETURNING id, external_id, name, created_at, updated_at, deleted_at, created_by, excluded_models, excluded_providers
 `
 
 type CreateModelRouterInstallationParams struct {
@@ -43,7 +43,7 @@ type CreateModelRouterInstallationParams struct {
 //	    $2::varchar,
 //	    $3
 //	)
-//	RETURNING id, external_id, name, created_at, updated_at, deleted_at, created_by, excluded_models
+//	RETURNING id, external_id, name, created_at, updated_at, deleted_at, created_by, excluded_models, excluded_providers
 func (q *Queries) CreateModelRouterInstallation(ctx context.Context, arg CreateModelRouterInstallationParams) (RouterModelRouterInstallation, error) {
 	row := q.db.QueryRow(ctx, createModelRouterInstallation, arg.ExternalID, arg.Name, arg.CreatedBy)
 	var i RouterModelRouterInstallation
@@ -56,12 +56,13 @@ func (q *Queries) CreateModelRouterInstallation(ctx context.Context, arg CreateM
 		&i.DeletedAt,
 		&i.CreatedBy,
 		&i.ExcludedModels,
+		&i.ExcludedProviders,
 	)
 	return i, err
 }
 
 const getModelRouterInstallation = `-- name: GetModelRouterInstallation :one
-SELECT id, external_id, name, created_at, updated_at, deleted_at, created_by, excluded_models
+SELECT id, external_id, name, created_at, updated_at, deleted_at, created_by, excluded_models, excluded_providers
 FROM router.model_router_installations
 WHERE id = $1::uuid
   AND external_id = $2::varchar
@@ -75,7 +76,7 @@ type GetModelRouterInstallationParams struct {
 
 // Gets an installation by id, scoped to an external_id to prevent cross-tenant access.
 //
-//	SELECT id, external_id, name, created_at, updated_at, deleted_at, created_by, excluded_models
+//	SELECT id, external_id, name, created_at, updated_at, deleted_at, created_by, excluded_models, excluded_providers
 //	FROM router.model_router_installations
 //	WHERE id = $1::uuid
 //	  AND external_id = $2::varchar
@@ -92,12 +93,13 @@ func (q *Queries) GetModelRouterInstallation(ctx context.Context, arg GetModelRo
 		&i.DeletedAt,
 		&i.CreatedBy,
 		&i.ExcludedModels,
+		&i.ExcludedProviders,
 	)
 	return i, err
 }
 
 const listModelRouterInstallationsForExternalID = `-- name: ListModelRouterInstallationsForExternalID :many
-SELECT id, external_id, name, created_at, updated_at, deleted_at, created_by, excluded_models
+SELECT id, external_id, name, created_at, updated_at, deleted_at, created_by, excluded_models, excluded_providers
 FROM router.model_router_installations
 WHERE external_id = $1::varchar
   AND deleted_at IS NULL
@@ -106,7 +108,7 @@ ORDER BY created_at DESC
 
 // ListModelRouterInstallationsForExternalID
 //
-//	SELECT id, external_id, name, created_at, updated_at, deleted_at, created_by, excluded_models
+//	SELECT id, external_id, name, created_at, updated_at, deleted_at, created_by, excluded_models, excluded_providers
 //	FROM router.model_router_installations
 //	WHERE external_id = $1::varchar
 //	  AND deleted_at IS NULL
@@ -129,6 +131,7 @@ func (q *Queries) ListModelRouterInstallationsForExternalID(ctx context.Context,
 			&i.DeletedAt,
 			&i.CreatedBy,
 			&i.ExcludedModels,
+			&i.ExcludedProviders,
 		); err != nil {
 			return nil, err
 		}
@@ -192,5 +195,35 @@ type UpdateModelRouterInstallationExcludedModelsParams struct {
 //	  AND deleted_at IS NULL
 func (q *Queries) UpdateModelRouterInstallationExcludedModels(ctx context.Context, arg UpdateModelRouterInstallationExcludedModelsParams) error {
 	_, err := q.db.Exec(ctx, updateModelRouterInstallationExcludedModels, arg.ExcludedModels, arg.ID, arg.ExternalID)
+	return err
+}
+
+const updateModelRouterInstallationExcludedProviders = `-- name: UpdateModelRouterInstallationExcludedProviders :exec
+UPDATE router.model_router_installations
+SET excluded_providers = $1::text[],
+    updated_at = NOW()
+WHERE id = $2::uuid
+  AND external_id = $3::varchar
+  AND deleted_at IS NULL
+`
+
+type UpdateModelRouterInstallationExcludedProvidersParams struct {
+	ExcludedProviders []string
+	ID                uuid.UUID
+	ExternalID        string
+}
+
+// Replaces the per-installation provider exclusion list, scoped to an
+// external_id to prevent cross-tenant updates. Empty array means "no
+// exclusion". Bumps updated_at so dashboards see the change.
+//
+//	UPDATE router.model_router_installations
+//	SET excluded_providers = $1::text[],
+//	    updated_at = NOW()
+//	WHERE id = $2::uuid
+//	  AND external_id = $3::varchar
+//	  AND deleted_at IS NULL
+func (q *Queries) UpdateModelRouterInstallationExcludedProviders(ctx context.Context, arg UpdateModelRouterInstallationExcludedProvidersParams) error {
+	_, err := q.db.Exec(ctx, updateModelRouterInstallationExcludedProviders, arg.ExcludedProviders, arg.ID, arg.ExternalID)
 	return err
 }

--- a/internal/sqlc/models.go
+++ b/internal/sqlc/models.go
@@ -48,14 +48,15 @@ type RouterModelRouterExternalAPIKey struct {
 
 // Customer router installations; owns API keys
 type RouterModelRouterInstallation struct {
-	ID             uuid.UUID
-	ExternalID     string
-	Name           string
-	CreatedAt      pgtype.Timestamp
-	UpdatedAt      pgtype.Timestamp
-	DeletedAt      pgtype.Timestamp
-	CreatedBy      *string
-	ExcludedModels []string
+	ID                uuid.UUID
+	ExternalID        string
+	Name              string
+	CreatedAt         pgtype.Timestamp
+	UpdatedAt         pgtype.Timestamp
+	DeletedAt         pgtype.Timestamp
+	CreatedBy         *string
+	ExcludedModels    []string
+	ExcludedProviders []string
 }
 
 type RouterModelRouterRequestTelemetry struct {


### PR DESCRIPTION
## Summary

True **provider exclusion** as a sibling to `excluded_models`: an excluded provider is never served for an installation — not by the scorer, hard pins, session pins, tier clamp, or dispatch failover. Backs new provider checkboxes in both the self-hosted dashboard and the Weave settings page (WorkWeave-side PR follows after this deploys).

## Why

Unchecking all of a provider's models is not the same as excluding the provider: multi-binding models (deepseek/qwen/kimi) can fail over to alternate providers, and new models added to a provider in future cluster versions would silently re-enable it. `excluded_providers` is the durable "never serve via X" control (e.g. subprocessor/compliance requirements).

## How

- **Migration 0013**: `excluded_providers TEXT[] NOT NULL DEFAULT '{}'` on `router.model_router_installations` (mirrors 0002).
- **auth**: `Installation.ExcludedProviders`, `Service.SetInstallationExcludedProviders` (order-preserving de-dupe, validates against the deployed-provider set, `ErrUnknownProvider`), repo + SQLC plumbing.
- **proxy enforcement, two seams**:
  - `enabledProvidersForRequest` subtracts the exclusion set last, so every consumer of `EnabledProviders` (cluster scorer provider resolution, hard-pin resolver, session-pin eligibility, tier clamp) inherits it.
  - `resolveBindingsForDispatch` filters the failover binding list — without this an excluded provider could be resurrected as a fallback binding mid-dispatch.
- **Env override**: `ROUTER_EXCLUDED_PROVIDERS` (comma-separated) pins a deployment-wide list and makes the dashboard checklist read-only, exactly like `ROUTER_EXCLUDED_MODELS`.
- **Admin API**: `GET/PUT /admin/v1/excluded-providers` (selfhosted block only), available set = distinct providers from `DefaultDeployedModels()`.
- **Dashboard**: "Provider selection" checkbox panel on `/ui/settings` mirroring the model panel.

## Testing

- `go build ./...`, `go vet ./...`, `gofmt` clean
- Full `go test ./...`: 25 packages pass
- New tests: auth setter (de-dupe / unknown-provider / nil cases), enabled-set subtraction incl. env-override-replaces-DB semantics, failover-binding filtering
- Self-hosted frontend `tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)