### PR TITLE
feat(cluster): pluggable dual-embedder architecture for Qwen3-0.6B

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
 # syntax=docker/dockerfile:1
 #
 # The router uses hugot + onnxruntime_go (CGO; dynamic-links against
-# libonnxruntime.so) to run the cluster scorer's Jina v2 embedder
-# in-process. That requires a glibc base — Alpine/musl can't load the
-# library out of the box. Builder is bookworm-glibc; runtime is
-# distroless/cc-debian12 so we get the C runtime without the rest of
-# Debian's userland.
+# libonnxruntime.so) to run the cluster scorer's embedders (Jina v2,
+# Qwen3-0.6B) in-process. That requires a glibc base — Alpine/musl
+# can't load the library out of the box. Builder is bookworm-glibc;
+# runtime is distroless/cc-debian12 so we get the C runtime without
+# the rest of Debian's userland.
 #
 # The mini UI is a Next.js static export built by a Node.js stage and
 # copied into assets/ui/ before the Go binary is assembled.
@@ -23,6 +23,14 @@ ARG HF_MODEL_REPO=jinaai/jina-embeddings-v2-base-code
 # Apr 2024 so drift risk is low, but pinning eliminates "the build
 # silently picked up new weights" surprises. Bump deliberately.
 ARG HF_MODEL_REVISION=516f4baf13dec4ddddda8631e019b5737c8bc250
+# Second embedder: Qwen3-Embedding-0.6B exported with last-token
+# pooling baked into the graph (scripts/export_qwen3_onnx.py). Empty
+# HF_QWEN_REPO skips the pull — the runtime constructs embedders
+# lazily, so deploys serving only Jina bundles don't need the asset.
+# Once the export is uploaded, set the repo default here and pin
+# HF_QWEN_REVISION to the upload commit SHA printed by the script.
+ARG HF_QWEN_REPO=
+ARG HF_QWEN_REVISION=main
 
 # --- Stage 1: build the Next.js mini UI ---
 FROM node:22-alpine AS ui-builder
@@ -41,6 +49,8 @@ ARG ONNXRUNTIME_VERSION
 ARG TOKENIZERS_VERSION
 ARG HF_MODEL_REPO
 ARG HF_MODEL_REVISION
+ARG HF_QWEN_REPO
+ARG HF_QWEN_REVISION
 # TARGETARCH is set automatically by buildx (`amd64` or `arm64`) so we
 # can pull the matching native ONNX Runtime + libtokenizers tarball.
 # Without this, building on Apple Silicon / Graviton picks up x86_64
@@ -70,54 +80,91 @@ RUN set -eux; \
     tar -xzf /tmp/libtokenizers.tar.gz -C /opt/libtokenizers; \
     rm /tmp/libtokenizers.tar.gz
 
-# Pull the embedder artifacts from Jina's official HuggingFace repo.
-# It's public — self-hosters and CI build with no token. The
+# Pull the embedder artifacts from HuggingFace. Each embedder lives in
+# its own subdir of /opt/router/assets/ keyed by its EmbedderSpec ID
+# (see internal/router/cluster/embedder.go); the runtime constructs
+# embedders lazily per artifact bundle, so a deploy whose bundles only
+# use one embedder never touches the other's files.
+#
+# Jina's repo is public — self-hosters and CI build with no token. The
 # hf_token build secret is *optional*: if provided (e.g. inside our
 # CI to avoid public-rate-limits), curl uses it.
 #
 # Required files (model + tokenizer) fail the build on miss; the
-# small transformers companion JSONs are best-effort. The runtime
-# stage copies the whole assets dir into /opt/router/assets/,
-# matching defaultAssetsDir in internal/router/cluster/embedder_onnx.go.
+# small transformers companion JSONs are best-effort.
 #
-# File-path mapping (must stay in sync with scripts/hf_files.py):
+# Jina file-path mapping (must stay in sync with scripts/hf_files.py):
 #   model.onnx              <- onnx/model_quantized.onnx (162 MB INT8)
 #   tokenizer.json          <- tokenizer.json
 #   {config,tokenizer_config,special_tokens_map}.json -> identity
+#
+# Qwen3 repo is the scripts/export_qwen3_onnx.py output (pooling baked
+# into the graph): model.onnx + tokenizer.json at the repo root. Empty
+# HF_QWEN_REPO skips the pull.
 RUN --mount=type=secret,id=hf_token,required=false \
     set -eux; \
-    mkdir -p /opt/router/assets; \
     if [ -s /run/secrets/hf_token ]; then \
       auth_header="Authorization: Bearer $(cat /run/secrets/hf_token)"; \
     else \
       auth_header=""; \
     fi; \
+    jina_dir=/opt/router/assets/jina-v2-base-code-int8; \
+    mkdir -p "$jina_dir"; \
     base="https://huggingface.co/${HF_MODEL_REPO}/resolve/${HF_MODEL_REVISION}"; \
     curl --fail --silent --show-error --location \
       ${auth_header:+--header "$auth_header"} \
-      "${base}/onnx/model_quantized.onnx" -o /opt/router/assets/model.onnx; \
+      "${base}/onnx/model_quantized.onnx" -o "$jina_dir/model.onnx"; \
     curl --fail --silent --show-error --location \
       ${auth_header:+--header "$auth_header"} \
-      "${base}/tokenizer.json" -o /opt/router/assets/tokenizer.json; \
+      "${base}/tokenizer.json" -o "$jina_dir/tokenizer.json"; \
     for f in config.json tokenizer_config.json special_tokens_map.json; do \
       curl --silent --show-error --location \
         ${auth_header:+--header "$auth_header"} \
         --write-out "%{http_code}" \
-        "${base}/${f}" -o "/opt/router/assets/${f}" \
+        "${base}/${f}" -o "$jina_dir/${f}" \
         > /tmp/code; \
       code=$(cat /tmp/code); \
       case "$code" in \
         200) ;; \
-        404) rm -f "/opt/router/assets/${f}" ;; \
+        404) rm -f "$jina_dir/${f}" ;; \
         *) echo "ERROR: unexpected HTTP $code for $f"; exit 1 ;; \
       esac; \
     done; \
-    sz=$(stat -c '%s' /opt/router/assets/model.onnx); \
+    sz=$(stat -c '%s' "$jina_dir/model.onnx"); \
     if [ "$sz" -lt 1048576 ]; then \
-      echo "ERROR: model.onnx is only $sz bytes (HF download likely returned a pointer or auth issue)"; \
+      echo "ERROR: jina model.onnx is only $sz bytes (HF download likely returned a pointer or auth issue)"; \
       exit 1; \
     fi; \
-    ls -la /opt/router/assets/
+    if [ -n "${HF_QWEN_REPO}" ]; then \
+      qwen_dir=/opt/router/assets/qwen3-embedding-0.6b-int8; \
+      mkdir -p "$qwen_dir"; \
+      qbase="https://huggingface.co/${HF_QWEN_REPO}/resolve/${HF_QWEN_REVISION}"; \
+      curl --fail --silent --show-error --location \
+        ${auth_header:+--header "$auth_header"} \
+        "${qbase}/model.onnx" -o "$qwen_dir/model.onnx"; \
+      curl --fail --silent --show-error --location \
+        ${auth_header:+--header "$auth_header"} \
+        "${qbase}/tokenizer.json" -o "$qwen_dir/tokenizer.json"; \
+      for f in tokenizer_config.json special_tokens_map.json; do \
+        curl --silent --show-error --location \
+          ${auth_header:+--header "$auth_header"} \
+          --write-out "%{http_code}" \
+          "${qbase}/${f}" -o "$qwen_dir/${f}" \
+          > /tmp/code; \
+        code=$(cat /tmp/code); \
+        case "$code" in \
+          200) ;; \
+          404) rm -f "$qwen_dir/${f}" ;; \
+          *) echo "ERROR: unexpected HTTP $code for $f"; exit 1 ;; \
+        esac; \
+      done; \
+      qsz=$(stat -c '%s' "$qwen_dir/model.onnx"); \
+      if [ "$qsz" -lt 1048576 ]; then \
+        echo "ERROR: qwen model.onnx is only $qsz bytes (HF download likely returned a pointer or auth issue)"; \
+        exit 1; \
+      fi; \
+    fi; \
+    ls -laR /opt/router/assets/
 
 WORKDIR /app
 
@@ -155,9 +202,10 @@ FROM gcr.io/distroless/cc-debian12 AS build-release-stage
 # canonical home and is already on the search path on debian12.
 COPY --from=build-stage /opt/onnxruntime/lib/libonnxruntime.so* /usr/lib/
 
-# Cluster-scorer assets fetched from HF in the build stage. The Go
-# embedder (internal/router/cluster/embedder_onnx.go) reads from this
-# directory by default; ROUTER_ONNX_ASSETS_DIR overrides if needed.
+# Cluster-scorer assets fetched from HF in the build stage, one subdir
+# per embedder ID. The Go embedders
+# (internal/router/cluster/embedder_onnx.go) read from this root by
+# default; ROUTER_ONNX_ASSETS_DIR overrides if needed.
 COPY --from=build-stage /opt/router/assets/ /opt/router/assets/
 
 WORKDIR /

--- a/cmd/router/main.go
+++ b/cmd/router/main.go
@@ -779,7 +779,7 @@ func buildClusterScorer(availableProviders map[string]struct{}) (router.Router, 
 		versions = []string{defaultVersion}
 	}
 
-	embedder, err := cluster.NewEmbedder()
+	embedders, err := cluster.NewEmbedderSet()
 	if err != nil {
 		return nil, err
 	}
@@ -795,10 +795,11 @@ func buildClusterScorer(availableProviders map[string]struct{}) (router.Router, 
 		}
 	}
 	scorers := make(map[string]*cluster.Scorer, len(versions))
+	warmed := make(map[string]cluster.Embedder)
 	for _, v := range versions {
 		bundle, err := cluster.LoadBundle(v)
 		if err != nil {
-			_ = embedder.Close()
+			_ = embedders.Close()
 			return nil, fmt.Errorf("load bundle %s: %w", v, err)
 		}
 
@@ -818,57 +819,75 @@ func buildClusterScorer(availableProviders map[string]struct{}) (router.Router, 
 			)
 		}
 
+		// Lazily construct only the embedders the built versions need:
+		// prod (single default version) loads exactly one model.
+		embedder, err := embedders.Get(bundle.EmbedderID())
+		if err != nil {
+			// The default version's embedder must construct; sibling
+			// versions degrade like any other per-version build failure.
+			if v == defaultVersion {
+				_ = embedders.Close()
+				return nil, fmt.Errorf("construct embedder %q for default cluster version %s: %w", bundle.EmbedderID(), v, err)
+			}
+			logger.Warn("Cluster scorer version skipped; embedder unavailable", "cluster_version", v, "embedder", bundle.EmbedderID(), "err", err)
+			continue
+		}
+		warmed[embedder.ID()] = embedder
+
 		scorer, err := cluster.NewScorer(bundle, cfg, embedder, availableProviders)
 		if err != nil {
 			logger.Warn("Cluster scorer version skipped", "cluster_version", v, "err", err)
 			continue
 		}
 		scorers[v] = scorer
-		logger.Info("Cluster scorer version built", "cluster_version", v, "models", bundle.Registry.Models())
+		logger.Info("Cluster scorer version built", "cluster_version", v, "embedder", bundle.EmbedderID(), "models", bundle.Registry.Models())
 	}
 
 	if _, ok := scorers[defaultVersion]; !ok {
-		_ = embedder.Close()
+		_ = embedders.Close()
 		return nil, fmt.Errorf("default cluster version %q failed to build (likely no registered provider covers its deployed_models); set ROUTER_CLUSTER_VERSION to a version that does, or register the missing provider key", defaultVersion)
 	}
 
 	multi, err := cluster.NewMultiversion(defaultVersion, scorers)
 	if err != nil {
-		_ = embedder.Close()
+		_ = embedders.Close()
 		return nil, fmt.Errorf("build multiversion router: %w", err)
 	}
 	logger.Info(
 		"Cluster multiversion router ready",
 		"default_version", defaultVersion,
 		"built_versions", multi.Built(),
+		"built_embedders", embedders.Built(),
 		"requested_version", requestedVersion,
 		"build_all_versions", buildAll,
 	)
 
-	// Warmup: burn the lazy ONNX graph-optimization cost at boot.
-	type warmupResult struct {
-		err error
-	}
-	warmupDone := make(chan warmupResult, 1)
-	go func() {
-		_, err := embedder.Embed(context.Background(), "warmup")
-		warmupDone <- warmupResult{err: err}
-	}()
-	select {
-	case res := <-warmupDone:
-		if res.err != nil {
-			_ = embedder.Close()
-			return nil, res.err
+	// Warmup: burn each embedder's lazy ONNX graph-optimization cost at boot.
+	for id, embedder := range warmed {
+		type warmupResult struct {
+			err error
 		}
-	case <-time.After(5 * time.Second):
-		// Drain the goroutine before closing to avoid use-after-free.
-		go func() {
-			<-warmupDone
-			_ = embedder.Close()
-		}()
-		return nil, fmt.Errorf("cluster embedder warmup timed out after 5s")
+		warmupDone := make(chan warmupResult, 1)
+		go func(e cluster.Embedder) {
+			_, err := e.Embed(context.Background(), "warmup")
+			warmupDone <- warmupResult{err: err}
+		}(embedder)
+		select {
+		case res := <-warmupDone:
+			if res.err != nil {
+				_ = embedders.Close()
+				return nil, fmt.Errorf("warm embedder %q: %w", id, res.err)
+			}
+		case <-time.After(15 * time.Second):
+			// Drain the goroutine before closing to avoid use-after-free.
+			go func() {
+				<-warmupDone
+				_ = embedders.Close()
+			}()
+			return nil, fmt.Errorf("cluster embedder %q warmup timed out after 15s", id)
+		}
+		logger.Info("Cluster embedder warmed", "embedder", id, "embed_dim", embedder.Dim())
 	}
-	logger.Info("Cluster embedder warmed", "embedder", "jina-v2-base-code-int8", "embed_dim", cluster.EmbedDim)
 
 	return multi, nil
 }

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -121,29 +121,44 @@ The first five follow the [OTel SDK env spec](https://opentelemetry.io/docs/spec
 
 ## Cluster-routing artifacts
 
-The cluster scorer needs two files at runtime: `model.onnx` (the INT8-quantized
-embedder) and `tokenizer.json`. Neither is committed to git — both come from
-the public [`jinaai/jina-embeddings-v2-base-code`](https://huggingface.co/jinaai/jina-embeddings-v2-base-code)
-HuggingFace repo. We use Jina's own INT8 export; we don't maintain our own
-quantization.
+Each embedder the cluster scorer can use needs two files at runtime —
+`model.onnx` (INT8-quantized) and `tokenizer.json` — in its own subdirectory
+of the assets root, keyed by embedder ID:
 
-**Docker (default):** the Dockerfile downloads both files at image build time
-into `/opt/router/assets/`. Nothing for you to do.
+- `jina-v2-base-code-int8/` — from the public
+  [`jinaai/jina-embeddings-v2-base-code`](https://huggingface.co/jinaai/jina-embeddings-v2-base-code)
+  HuggingFace repo (Jina's own INT8 export; we don't maintain our own
+  quantization). Default for every bundle through v0.66; the flat legacy
+  layout (`<root>/model.onnx`) still resolves for this embedder.
+- `qwen3-embedding-0.6b-int8/` — produced by `scripts/export_qwen3_onnx.py`
+  (Qwen3-Embedding-0.6B with last-token pooling baked into the graph) and
+  uploaded to a Weave HF repo. Only needed when serving a bundle whose
+  `metadata.yaml` declares this embedder; the runtime loads embedders lazily.
 
-**`make dev` (host-mode hot reload):** fetch them once into a local directory
-and point `ROUTER_ONNX_ASSETS_DIR` at it:
+Neither is committed to git.
+
+**Docker (default):** the Dockerfile downloads the files at image build time
+into `/opt/router/assets/<embedder-id>/`. The Qwen pull runs only when the
+`HF_QWEN_REPO` build arg is set. Nothing for you to do.
+
+**`make dev` (host-mode hot reload):** fetch the Jina files once into a local
+directory and point `ROUTER_ONNX_ASSETS_DIR` at it:
 
 ```bash
-mkdir -p assets
+mkdir -p assets/jina-v2-base-code-int8
 BASE="https://huggingface.co/jinaai/jina-embeddings-v2-base-code/resolve/516f4baf13dec4ddddda8631e019b5737c8bc250"
-curl -L "$BASE/onnx/model_quantized.onnx" -o assets/model.onnx
-curl -L "$BASE/tokenizer.json" -o assets/tokenizer.json
+curl -L "$BASE/onnx/model_quantized.onnx" -o assets/jina-v2-base-code-int8/model.onnx
+curl -L "$BASE/tokenizer.json" -o assets/jina-v2-base-code-int8/tokenizer.json
 echo "ROUTER_ONNX_ASSETS_DIR=$(pwd)/assets" >> .env.local
 ```
 
-The pinned revision matches `HF_MODEL_REVISION` in the Dockerfile, so local
-dev and the container build use the same weights. Bump both together if you
-want a newer upstream export.
+To also serve Qwen bundles locally, run `scripts/export_qwen3_onnx.py
+--out-dir assets/qwen3-embedding-0.6b-int8` (or download the uploaded export
+into that directory).
+
+The pinned revisions (`HF_MODEL_REVISION`, `HF_QWEN_REVISION`) in the
+Dockerfile keep local dev and the container build on the same weights. Bump
+deliberately if you want a newer export.
 
 The committed cluster artifacts (centroids, rankings, model registry,
 metadata) live under `internal/router/cluster/artifacts/v<X.Y>/`. The

--- a/internal/router/cluster/AGENTS.md
+++ b/internal/router/cluster/AGENTS.md
@@ -41,15 +41,29 @@ Go runtime builds **only the served default version** by default (`cmd/router/ma
 
 Informational at runtime — carries version changelog, training params, deployed models, α-blend cost values. Go runtime parses it for `/health`-style provenance; eval harness reads it offline. Keep it accurate but it does not affect routing decisions.
 
-### `assets/model.onnx`
+### Embedders (per-bundle, pluggable)
 
-**NOT in git.** Use Jina's own INT8 export at `jinaai/jina-embeddings-v2-base-code`, file path `onnx/model_quantized.onnx`.
+Embedder is a **per-bundle property**: each bundle's `metadata.yaml` `embedder.model` + `embedder.embed_dim` name the embedding space its centroids live in. `NewScorer` refuses an embedder whose `ID()`/`Dim()` don't match the bundle (silent misrouting protection — dim alone is not enough since two models can share a dim). Bundles without an embedder block default to Jina/768.
+
+Registered specs (`embedder.go` `embedderSpecs`):
+
+- `jina-v2-base-code-int8` — 768d BERT encoder, mean-pooled by hugot. Legacy default; all bundles ≤ v0.66.
+- `qwen3-embedding-0.6b-int8` — 1024d Qwen3-Embedding-0.6B, **last-token pooling baked into the ONNX graph** (export emits 2D `[batch, dim]`, which hugot returns as-is; hugot only mean-pools 3D outputs). Produced by `scripts/export_qwen3_onnx.py`.
+
+`cluster.EmbedderSet` (composition root) owns one shared ORT session and lazily constructs one pipeline per embedder ID actually required by built bundles — prod (single default version) loads exactly one model into memory.
+
+### Embedder assets
+
+**NOT in git.** One subdir per embedder ID under the assets root:
+
+- `<root>/jina-v2-base-code-int8/{model.onnx,tokenizer.json}` — Jina's own INT8 export at `jinaai/jina-embeddings-v2-base-code`, file path `onnx/model_quantized.onnx`. Flat legacy layout (`<root>/model.onnx`) still resolves for Jina in local dev.
+- `<root>/qwen3-embedding-0.6b-int8/{model.onnx,tokenizer.json}` — `scripts/export_qwen3_onnx.py` output uploaded to a Weave HF repo; Dockerfile pulls it only when `HF_QWEN_REPO` is set.
 
 - Dockerfile pulls anonymously during build (Jina repo public — self-hosters don't need creds); local dev pulls via `scripts/download_from_hf.py`.
 - `HF_TOKEN` build secret is *optional* (raises rate limits in CI) + `required=false` in Dockerfile.
-- Go embedder reads from `/opt/router/assets/model.onnx` (override via `ROUTER_ONNX_ASSETS_DIR`).
-- If missing or <1 MiB, `cluster.NewEmbedder` errors at boot + `main.go` panics — router refuses to start rather than silently degrading.
-- `HF_MODEL_REVISION` pinned to Jina SHA by default; bump deliberately to pick up new upstream exports.
+- Go embedders read from `/opt/router/assets/<id>/` (override root via `ROUTER_ONNX_ASSETS_DIR`).
+- If missing or <1 MiB, the embedder constructor errors at boot + `main.go` panics — router refuses to start rather than silently degrading.
+- `HF_MODEL_REVISION` pinned to Jina SHA by default; `HF_QWEN_REVISION` must be pinned to the upload commit SHA. Bump deliberately to pick up new upstream exports.
 
 ### Cost values
 
@@ -59,6 +73,8 @@ Used in α-blend, live in `train_cluster_router.py`'s `DEFAULT_COST_PER_1K_INPUT
 
 - **Don't add per-request cost lookup or runtime α knob.** α is baked at training time; changing it requires retraining. Per-request override (`x-weave-routing-alpha`) is P1, not P0 — wait for a customer ask before shipping.
 - **Don't loosen `MaxPromptChars = 1024` cap** without re-running the latency test. BERT inference is O(n²) attention; the cap is load-bearing.
+- **Don't promote a Qwen-embedder bundle without a latency gate.** Measure Qwen3-0.6B INT8 embed p95 on the target CPU against the 1500 ms `EmbedTimeout` before pointing `latest` at a `qwen3-embedding-0.6b-int8` bundle — embed timeouts surface as `ErrClusterUnavailable` → 503, not as degraded routing.
+- **Don't score a bundle with a different embedder than it was trained with.** `NewScorer` enforces ID + dim; never weaken that check. Trainer-side embedding (model, pooling, L2 norm, no instruction prefix, tail truncation) must match the runtime exactly.
 - **Don't add fail-open fallbacks.** Cluster scorer returns `ErrClusterUnavailable` on every failure path (embed timeout, embed error, dim mismatch, prompt too short, empty argmax). API handlers map it to HTTP 503. The previous `heuristic` fallback was removed because it silently degraded routing — every request that should have hit the cluster scorer instead got `claude-haiku-4-5`, masking real regressions in eval + prod. New failure modes return the sentinel; no default-model shortcut "for safety".
 - **Don't change the centroid format without bumping the magic string.** `loadCentroids` uses magic + version header to refuse mismatched binaries; if the layout changes, bump `centroidsMagic` from `CRT1` to `CRT2` so the next deploy refuses old binaries instead of silently misrouting.
 - **Don't overwrite a previously committed artifact version.** Versions are frozen for comparison — once `v0.37` is committed, train to `v0.38` rather than re-running `train_cluster_router.py` against `v0.37`. Training script auto-bumps; only override with `--version v0.X` for in-place fixes intended to land as a separate commit.

--- a/internal/router/cluster/CLAUDE.md
+++ b/internal/router/cluster/CLAUDE.md
@@ -41,15 +41,29 @@ Go runtime builds **only the served default version** by default (`cmd/router/ma
 
 Informational at runtime — carries version changelog, training params, deployed models, α-blend cost values. Go runtime parses it for `/health`-style provenance; eval harness reads it offline. Keep it accurate but it does not affect routing decisions.
 
-### `assets/model.onnx`
+### Embedders (per-bundle, pluggable)
 
-**NOT in git.** Use Jina's own INT8 export at `jinaai/jina-embeddings-v2-base-code`, file path `onnx/model_quantized.onnx`.
+Embedder is a **per-bundle property**: each bundle's `metadata.yaml` `embedder.model` + `embedder.embed_dim` name the embedding space its centroids live in. `NewScorer` refuses an embedder whose `ID()`/`Dim()` don't match the bundle (silent misrouting protection — dim alone is not enough since two models can share a dim). Bundles without an embedder block default to Jina/768.
+
+Registered specs (`embedder.go` `embedderSpecs`):
+
+- `jina-v2-base-code-int8` — 768d BERT encoder, mean-pooled by hugot. Legacy default; all bundles ≤ v0.66.
+- `qwen3-embedding-0.6b-int8` — 1024d Qwen3-Embedding-0.6B, **last-token pooling baked into the ONNX graph** (export emits 2D `[batch, dim]`, which hugot returns as-is; hugot only mean-pools 3D outputs). Produced by `scripts/export_qwen3_onnx.py`.
+
+`cluster.EmbedderSet` (composition root) owns one shared ORT session and lazily constructs one pipeline per embedder ID actually required by built bundles — prod (single default version) loads exactly one model into memory.
+
+### Embedder assets
+
+**NOT in git.** One subdir per embedder ID under the assets root:
+
+- `<root>/jina-v2-base-code-int8/{model.onnx,tokenizer.json}` — Jina's own INT8 export at `jinaai/jina-embeddings-v2-base-code`, file path `onnx/model_quantized.onnx`. Flat legacy layout (`<root>/model.onnx`) still resolves for Jina in local dev.
+- `<root>/qwen3-embedding-0.6b-int8/{model.onnx,tokenizer.json}` — `scripts/export_qwen3_onnx.py` output uploaded to a Weave HF repo; Dockerfile pulls it only when `HF_QWEN_REPO` is set.
 
 - Dockerfile pulls anonymously during build (Jina repo public — self-hosters don't need creds); local dev pulls via `scripts/download_from_hf.py`.
 - `HF_TOKEN` build secret is *optional* (raises rate limits in CI) + `required=false` in Dockerfile.
-- Go embedder reads from `/opt/router/assets/model.onnx` (override via `ROUTER_ONNX_ASSETS_DIR`).
-- If missing or <1 MiB, `cluster.NewEmbedder` errors at boot + `main.go` panics — router refuses to start rather than silently degrading.
-- `HF_MODEL_REVISION` pinned to Jina SHA by default; bump deliberately to pick up new upstream exports.
+- Go embedders read from `/opt/router/assets/<id>/` (override root via `ROUTER_ONNX_ASSETS_DIR`).
+- If missing or <1 MiB, the embedder constructor errors at boot + `main.go` panics — router refuses to start rather than silently degrading.
+- `HF_MODEL_REVISION` pinned to Jina SHA by default; `HF_QWEN_REVISION` must be pinned to the upload commit SHA. Bump deliberately to pick up new upstream exports.
 
 ### Cost values
 
@@ -59,6 +73,8 @@ Used in α-blend, live in `train_cluster_router.py`'s `DEFAULT_COST_PER_1K_INPUT
 
 - **Don't add per-request cost lookup or runtime α knob.** α is baked at training time; changing it requires retraining. Per-request override (`x-weave-routing-alpha`) is P1, not P0 — wait for a customer ask before shipping.
 - **Don't loosen `MaxPromptChars = 1024` cap** without re-running the latency test. BERT inference is O(n²) attention; the cap is load-bearing.
+- **Don't promote a Qwen-embedder bundle without a latency gate.** Measure Qwen3-0.6B INT8 embed p95 on the target CPU against the 1500 ms `EmbedTimeout` before pointing `latest` at a `qwen3-embedding-0.6b-int8` bundle — embed timeouts surface as `ErrClusterUnavailable` → 503, not as degraded routing.
+- **Don't score a bundle with a different embedder than it was trained with.** `NewScorer` enforces ID + dim; never weaken that check. Trainer-side embedding (model, pooling, L2 norm, no instruction prefix, tail truncation) must match the runtime exactly.
 - **Don't add fail-open fallbacks.** Cluster scorer returns `ErrClusterUnavailable` on every failure path (embed timeout, embed error, dim mismatch, prompt too short, empty argmax). API handlers map it to HTTP 503. The previous `heuristic` fallback was removed because it silently degraded routing — every request that should have hit the cluster scorer instead got `claude-haiku-4-5`, masking real regressions in eval + prod. New failure modes return the sentinel; no default-model shortcut "for safety".
 - **Don't change the centroid format without bumping the magic string.** `loadCentroids` uses magic + version header to refuse mismatched binaries; if the layout changes, bump `centroidsMagic` from `CRT1` to `CRT2` so the next deploy refuses old binaries instead of silently misrouting.
 - **Don't overwrite a previously committed artifact version.** Versions are frozen for comparison — once `v0.37` is committed, train to `v0.38` rather than re-running `train_cluster_router.py` against `v0.37`. Training script auto-bumps; only override with `--version v0.X` for in-place fixes intended to land as a separate commit.

--- a/internal/router/cluster/artifacts.go
+++ b/internal/router/cluster/artifacts.go
@@ -189,6 +189,25 @@ type Bundle struct {
 	MedianVerbosity float64 // Precomputed median verbosity for V2 bundles
 }
 
+// EmbedderID returns the embedder model recorded in metadata.yaml,
+// defaulting to the Jina v2 embedder for legacy bundles without an
+// embedder block.
+func (b *Bundle) EmbedderID() string {
+	if b.Metadata != nil && b.Metadata.Embedder.Model != "" {
+		return b.Metadata.Embedder.Model
+	}
+	return EmbedderJinaV2
+}
+
+// EmbedDim returns the embedding dimensionality declared in
+// metadata.yaml, defaulting to the Jina v2 dim for legacy bundles.
+func (b *Bundle) EmbedDim() int {
+	if b.Metadata != nil && b.Metadata.Embedder.EmbedDim > 0 {
+		return b.Metadata.Embedder.EmbedDim
+	}
+	return EmbedDim
+}
+
 // ListVersions returns sorted version directories under artifacts/.
 func ListVersions() ([]string, error) {
 	entries, err := fs.ReadDir(embeddedArtifacts, "artifacts")
@@ -302,6 +321,10 @@ func loadBundleFromPath(fsys fs.FS, version, dir string) (*Bundle, error) {
 			return nil, fmt.Errorf("artifacts %s: parse metadata.yaml: %w", version, err)
 		}
 		meta = &m
+	}
+
+	if err := validateDeclaredDim(version, centroids, meta); err != nil {
+		return nil, err
 	}
 
 	var isV2 bool
@@ -433,6 +456,9 @@ func loadBundleV1Only(fsys fs.FS, version, dir string) (*Bundle, error) {
 		}
 		meta = &m
 	}
+	if err := validateDeclaredDim(version, centroids, meta); err != nil {
+		return nil, err
+	}
 	return &Bundle{
 		Version:   version,
 		Centroids: centroids,
@@ -441,6 +467,22 @@ func loadBundleV1Only(fsys fs.FS, version, dir string) (*Bundle, error) {
 		Metadata:  meta,
 		IsV2:      false,
 	}, nil
+}
+
+// validateDeclaredDim cross-checks the dim recorded in metadata.yaml's
+// embedder block against the centroids.bin header. Legacy bundles
+// without a metadata embedder block must match the Jina default.
+func validateDeclaredDim(version string, centroids *Centroids, meta *ArtifactMetadata) error {
+	declared := EmbedDim
+	source := "legacy default"
+	if meta != nil && meta.Embedder.EmbedDim > 0 {
+		declared = meta.Embedder.EmbedDim
+		source = "metadata.yaml embedder.embed_dim"
+	}
+	if centroids.Dim != declared {
+		return fmt.Errorf("artifacts %s: centroids.bin dim %d != declared %d (%s); embedder mismatch", version, centroids.Dim, declared, source)
+	}
+	return nil
 }
 
 // LoadBundleV1Only reads a bundle from disk forcing v1 (rankings.json)
@@ -462,8 +504,8 @@ func loadCentroids(raw []byte) (*Centroids, error) {
 	}
 	k := binary.LittleEndian.Uint32(raw[8:12])
 	dim := binary.LittleEndian.Uint32(raw[12:16])
-	if dim != EmbedDim {
-		return nil, fmt.Errorf("centroids.bin dim %d, expected %d (embedder mismatch)", dim, EmbedDim)
+	if dim == 0 {
+		return nil, fmt.Errorf("centroids.bin has dim=0")
 	}
 	if k == 0 {
 		return nil, fmt.Errorf("centroids.bin has K=0; run router/scripts/train_cluster_router.py")

--- a/internal/router/cluster/artifacts/README.md
+++ b/internal/router/cluster/artifacts/README.md
@@ -41,6 +41,53 @@ The loader probes for `quality_means.json` to detect v2; falls back to
 `rankings.json` for v1. A v2 directory may co-host both files during
 the trainer's dual-write window.
 
+## Embedder
+
+Each bundle's `metadata.yaml` `embedder` block names the embedding
+space its `centroids.bin` lives in:
+
+```yaml
+embedder:
+  model: jina-v2-base-code-int8   # or qwen3-embedding-0.6b-int8
+  embed_dim: 768                  # 1024 for qwen3
+  max_tokens: 256
+```
+
+The loader cross-checks `embed_dim` against the centroids.bin header,
+and `NewScorer` refuses to pair a bundle with an embedder whose ID or
+dim differs — a bundle trained in one embedding space can never be
+scored in another. Bundles without an embedder block default to
+`jina-v2-base-code-int8` / 768. The runtime constructs only the
+embedders its built bundles require, so Jina and Qwen3 bundles can
+coexist in one deploy (staging `ROUTER_CLUSTER_BUILD_ALL_VERSIONS=true`)
+while prod loads exactly one model.
+
+### Trainer contract (must match runtime exactly)
+
+`train_cluster_router.py` (sibling `router-internal/eval/`) must embed
+training prompts identically to how the Go runtime embeds requests, or
+the bundle silently misroutes — there is no runtime error for a
+training/serving embedding mismatch beyond the ID/dim guard.
+
+For a `qwen3-embedding-0.6b-int8` bundle (e.g. v0.67):
+
+| Aspect | Required value |
+|---|---|
+| Model | `Qwen/Qwen3-Embedding-0.6B` (the exact export served at runtime; prefer embedding through the same INT8 ONNX produced by `scripts/export_qwen3_onnx.py`) |
+| Pooling | Last-token (attention-mask-aware; baked into the ONNX graph) |
+| Normalization | L2 (runtime applies hugot `WithNormalization`) |
+| Instruction prefix | **None** — raw prompt text, document-style (matches Jina behavior) |
+| Truncation | Tail-truncate to 1024 chars (`MaxPromptChars`), UTF-8 boundary snapped |
+| metadata.yaml | `embedder: {model: qwen3-embedding-0.6b-int8, embed_dim: 1024, max_tokens: 256}` |
+
+For `jina-v2-base-code-int8` bundles the existing trainer path is
+unchanged (mean pooling, L2 norm, no prefix, same truncation).
+
+Before promoting any Qwen bundle (pointing `latest` at it), run the
+latency gate: Qwen3-0.6B INT8 embed p95 on the target prod CPU must
+clear the 1500 ms `EmbedTimeout` with margin; timeouts surface as
+HTTP 503, not degraded routing.
+
 ## Working with bundles
 
 - Use `train_cluster_router.py` to write a new version; the script

--- a/internal/router/cluster/artifacts_test.go
+++ b/internal/router/cluster/artifacts_test.go
@@ -31,7 +31,6 @@ func buildCentroidsBlob(t *testing.T, k, dim int, data []float32) []byte {
 
 func TestLoadCentroids_Roundtrip(t *testing.T) {
 	data := []float32{1, 2, 3, 4, 5, 6, 7, 8}
-	// Loader rejects dim != EmbedDim; build at real dim and zero-pad.
 	dim := EmbedDim
 	k := 2
 	full := make([]float32, k*dim)
@@ -58,13 +57,51 @@ func TestLoadCentroids_TooShort(t *testing.T) {
 	assert.Contains(t, err.Error(), "too short")
 }
 
-func TestLoadCentroids_DimMismatch(t *testing.T) {
-	// dim=128 must be rejected; EmbedDim is 768.
-	dim := 128
+func TestLoadCentroids_ArbitraryDimAccepted(t *testing.T) {
+	// Dim is per-bundle now; loadCentroids accepts any non-zero dim and
+	// validateDeclaredDim cross-checks it against metadata.
+	dim := 1024
 	blob := buildCentroidsBlob(t, 1, dim, make([]float32, dim))
-	_, err := loadCentroids(blob)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "embedder mismatch")
+	got, err := loadCentroids(blob)
+	require.NoError(t, err)
+	assert.Equal(t, dim, got.Dim)
+}
+
+func TestValidateDeclaredDim(t *testing.T) {
+	t.Run("legacy bundle without metadata must match Jina default", func(t *testing.T) {
+		c := &Centroids{K: 1, Dim: EmbedDim}
+		require.NoError(t, validateDeclaredDim("v-test", c, nil))
+
+		bad := &Centroids{K: 1, Dim: 1024}
+		err := validateDeclaredDim("v-test", bad, nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "embedder mismatch")
+	})
+
+	t.Run("declared dim must match centroids header", func(t *testing.T) {
+		meta := &ArtifactMetadata{Embedder: ArtifactEmbedder{Model: EmbedderQwen3, EmbedDim: 1024}}
+		require.NoError(t, validateDeclaredDim("v-test", &Centroids{K: 1, Dim: 1024}, meta))
+
+		err := validateDeclaredDim("v-test", &Centroids{K: 1, Dim: EmbedDim}, meta)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "embedder mismatch")
+	})
+}
+
+func TestBundleEmbedderDefaults(t *testing.T) {
+	t.Run("nil metadata defaults to Jina", func(t *testing.T) {
+		b := &Bundle{}
+		assert.Equal(t, EmbedderJinaV2, b.EmbedderID())
+		assert.Equal(t, EmbedDim, b.EmbedDim())
+	})
+
+	t.Run("metadata embedder block wins", func(t *testing.T) {
+		b := &Bundle{Metadata: &ArtifactMetadata{
+			Embedder: ArtifactEmbedder{Model: EmbedderQwen3, EmbedDim: 1024},
+		}}
+		assert.Equal(t, EmbedderQwen3, b.EmbedderID())
+		assert.Equal(t, 1024, b.EmbedDim())
+	})
 }
 
 func TestLoadCentroids_ZeroK(t *testing.T) {

--- a/internal/router/cluster/embedder.go
+++ b/internal/router/cluster/embedder.go
@@ -7,10 +7,49 @@ package cluster
 
 import "context"
 
-// EmbedDim is the Jina v2 base-code output dimensionality.
+// EmbedDim is the Jina v2 base-code output dimensionality. Retained as
+// the legacy default for bundles whose metadata.yaml lacks an embedder
+// block; per-bundle dims are otherwise read from metadata.
 const EmbedDim = 768
 
-// Embedder produces an L2-normalized [EmbedDim]float32 for prompt text.
+// Embedder model IDs as recorded in each bundle's metadata.yaml
+// embedder.model field. The runtime refuses to score a bundle with an
+// embedder whose ID differs (see NewScorer).
+const (
+	// EmbedderJinaV2 is the original mean-pooled BERT encoder (768d).
+	EmbedderJinaV2 = "jina-v2-base-code-int8"
+	// EmbedderQwen3 is the Qwen3-Embedding-0.6B export with last-token
+	// pooling baked into the ONNX graph (1024d).
+	EmbedderQwen3 = "qwen3-embedding-0.6b-int8"
+)
+
+// EmbedderSpec describes one loadable embedding model: its identity,
+// output dimensionality, and where its assets live under the assets root.
+type EmbedderSpec struct {
+	ID          string
+	Dim         int
+	AssetSubdir string
+}
+
+// embedderSpecs is the registry of embedders the runtime knows how to
+// construct, keyed by ID.
+var embedderSpecs = map[string]EmbedderSpec{
+	EmbedderJinaV2: {ID: EmbedderJinaV2, Dim: 768, AssetSubdir: EmbedderJinaV2},
+	EmbedderQwen3:  {ID: EmbedderQwen3, Dim: 1024, AssetSubdir: EmbedderQwen3},
+}
+
+// SpecForEmbedder returns the registered spec for an embedder ID.
+func SpecForEmbedder(id string) (EmbedderSpec, bool) {
+	s, ok := embedderSpecs[id]
+	return s, ok
+}
+
+// Embedder produces an L2-normalized [Dim()]float32 for prompt text.
 type Embedder interface {
 	Embed(ctx context.Context, text string) ([]float32, error)
+	// ID is the embedder model identity, matched against the bundle's
+	// metadata.yaml embedder.model at NewScorer time.
+	ID() string
+	// Dim is the output dimensionality, matched against centroids.bin.
+	Dim() int
 }

--- a/internal/router/cluster/embedder_onnx.go
+++ b/internal/router/cluster/embedder_onnx.go
@@ -14,20 +14,21 @@ import (
 	"github.com/knights-analytics/hugot/pipelines"
 )
 
-// model.onnx and tokenizer.json are versioned together on HF Hub.
-// Override with ROUTER_ONNX_ASSETS_DIR for local dev.
+// Each embedder's model.onnx and tokenizer.json live under
+// <assetsRoot>/<EmbedderSpec.AssetSubdir>/. Override the root with
+// ROUTER_ONNX_ASSETS_DIR for local dev.
 const defaultAssetsDir = "/opt/router/assets"
 
 // minModelSizeBytes catches unpopulated HF downloads or placeholders.
-// Real INT8-quantized jina-v2-base-code is ~160 MB.
+// Real INT8-quantized embedders are >100 MB.
 const minModelSizeBytes = 1 << 20
 
-// onnxEmbedder is the production Embedder. Owns one hugot session and
-// pipeline; both goroutine-safe so one instance serves all requests.
+// onnxEmbedder is the production Embedder for one EmbedderSpec. The
+// pipeline is goroutine-safe so one instance serves all requests; the
+// hugot session is owned by the EmbedderSet, not the embedder.
 type onnxEmbedder struct {
-	session   *hugot.Session
-	pipeline  *pipelines.FeatureExtractionPipeline
-	closeOnce sync.Once
+	spec     EmbedderSpec
+	pipeline *pipelines.FeatureExtractionPipeline
 }
 
 // resolveAssetsDir returns ROUTER_ONNX_ASSETS_DIR if set, else defaultAssetsDir.
@@ -38,51 +39,58 @@ func resolveAssetsDir() string {
 	return defaultAssetsDir
 }
 
-// NewEmbedder reads model.onnx and tokenizer.json from disk and
-// constructs the shared session + pipeline.
-func NewEmbedder() (*onnxEmbedder, error) {
-	assetsDir := resolveAssetsDir()
+// assetsDirForSpec resolves the model directory for a spec. The Jina
+// embedder falls back to the flat legacy layout (<root>/model.onnx)
+// when its subdir is absent, so existing local-dev setups keep working.
+func assetsDirForSpec(spec EmbedderSpec) string {
+	root := resolveAssetsDir()
+	dir := filepath.Join(root, spec.AssetSubdir)
+	if _, err := os.Stat(filepath.Join(dir, "model.onnx")); err == nil {
+		return dir
+	}
+	if spec.ID == EmbedderJinaV2 {
+		if _, err := os.Stat(filepath.Join(root, "model.onnx")); err == nil {
+			return root
+		}
+	}
+	return dir
+}
+
+// newONNXEmbedder builds the feature-extraction pipeline for one spec on
+// a shared hugot session.
+//
+// Pooling contract: the Jina export emits token-level (3D) outputs which
+// hugot mean-pools; the Qwen3 export bakes last-token pooling into the
+// graph and emits a pooled (2D) output which hugot returns as-is. Both
+// are L2-normalized via WithNormalization.
+func newONNXEmbedder(session *hugot.Session, spec EmbedderSpec) (*onnxEmbedder, error) {
+	assetsDir := assetsDirForSpec(spec)
 	modelPath := filepath.Join(assetsDir, "model.onnx")
 	tokenizerPath := filepath.Join(assetsDir, "tokenizer.json")
 
 	info, err := os.Stat(modelPath)
 	if err != nil {
-		return nil, fmt.Errorf("cluster: stat model.onnx at %s: %w (set ROUTER_ONNX_ASSETS_DIR to a directory containing model.onnx and tokenizer.json)", modelPath, err)
+		return nil, fmt.Errorf("cluster: stat model.onnx for embedder %s at %s: %w (set ROUTER_ONNX_ASSETS_DIR to a directory containing %s/{model.onnx,tokenizer.json})", spec.ID, modelPath, err, spec.AssetSubdir)
 	}
 	if info.Size() < minModelSizeBytes {
-		return nil, fmt.Errorf("cluster: model.onnx at %s is %d bytes (< %d); likely a placeholder or interrupted download", modelPath, info.Size(), minModelSizeBytes)
+		return nil, fmt.Errorf("cluster: model.onnx for embedder %s at %s is %d bytes (< %d); likely a placeholder or interrupted download", spec.ID, modelPath, info.Size(), minModelSizeBytes)
 	}
 	if _, err := os.Stat(tokenizerPath); err != nil {
-		return nil, fmt.Errorf("cluster: stat tokenizer.json at %s: %w", tokenizerPath, err)
-	}
-
-	// hugot defaults to /usr/lib (Linux) / /usr/local/lib (macOS);
-	// ROUTER_ONNX_LIBRARY_DIR overrides (macOS brew → /opt/homebrew/lib).
-	var sessOpts []options.WithOption
-	if dir := os.Getenv("ROUTER_ONNX_LIBRARY_DIR"); dir != "" {
-		sessOpts = append(sessOpts, options.WithOnnxLibraryPath(dir))
-	}
-	session, err := hugot.NewORTSession(sessOpts...)
-	if err != nil {
-		return nil, fmt.Errorf("cluster: ort session: %w", err)
+		return nil, fmt.Errorf("cluster: stat tokenizer.json for embedder %s at %s: %w", spec.ID, tokenizerPath, err)
 	}
 
 	pipelineCfg := hugot.FeatureExtractionConfig{
 		ModelPath:    assetsDir,
-		Name:         "weave-router-jina-v2",
+		Name:         "weave-router-" + spec.ID,
 		OnnxFilename: "model.onnx",
 		Options:      []hugot.FeatureExtractionOption{pipelines.WithNormalization()},
 	}
 	pipeline, err := hugot.NewPipeline(session, pipelineCfg)
 	if err != nil {
-		_ = session.Destroy()
-		return nil, fmt.Errorf("cluster: feature-extraction pipeline: %w", err)
+		return nil, fmt.Errorf("cluster: feature-extraction pipeline for embedder %s: %w", spec.ID, err)
 	}
 
-	return &onnxEmbedder{
-		session:  session,
-		pipeline: pipeline,
-	}, nil
+	return &onnxEmbedder{spec: spec, pipeline: pipeline}, nil
 }
 
 // Embed runs the pipeline on a single text. ctx is ignored because hugot
@@ -97,18 +105,87 @@ func (e *onnxEmbedder) Embed(_ context.Context, text string) ([]float32, error) 
 		return nil, fmt.Errorf("pipeline returned %d embeddings, want 1", len(out.Embeddings))
 	}
 	vec := out.Embeddings[0]
-	if len(vec) != EmbedDim {
-		return nil, fmt.Errorf("embedding dim %d, want %d", len(vec), EmbedDim)
+	if len(vec) != e.spec.Dim {
+		return nil, fmt.Errorf("embedding dim %d, want %d", len(vec), e.spec.Dim)
 	}
 	return vec, nil
 }
 
-// Close releases the ORT session. Idempotent.
-func (e *onnxEmbedder) Close() error {
+// ID returns the embedder model identity.
+func (e *onnxEmbedder) ID() string { return e.spec.ID }
+
+// Dim returns the output dimensionality.
+func (e *onnxEmbedder) Dim() int { return e.spec.Dim }
+
+var _ Embedder = (*onnxEmbedder)(nil)
+
+// EmbedderSet lazily constructs and caches one Embedder per registered
+// spec, all sharing a single ORT session. Construct in the composition
+// root; Get only the IDs the built artifact versions require so prod
+// (single default version) loads exactly one model into memory.
+type EmbedderSet struct {
+	mu        sync.Mutex
+	session   *hugot.Session
+	embedders map[string]*onnxEmbedder
+	closeOnce sync.Once
+}
+
+// NewEmbedderSet creates the shared ORT session. No model is loaded
+// until Get is called.
+func NewEmbedderSet() (*EmbedderSet, error) {
+	// hugot defaults to /usr/lib (Linux) / /usr/local/lib (macOS);
+	// ROUTER_ONNX_LIBRARY_DIR overrides (macOS brew → /opt/homebrew/lib).
+	var sessOpts []options.WithOption
+	if dir := os.Getenv("ROUTER_ONNX_LIBRARY_DIR"); dir != "" {
+		sessOpts = append(sessOpts, options.WithOnnxLibraryPath(dir))
+	}
+	session, err := hugot.NewORTSession(sessOpts...)
+	if err != nil {
+		return nil, fmt.Errorf("cluster: ort session: %w", err)
+	}
+	return &EmbedderSet{
+		session:   session,
+		embedders: make(map[string]*onnxEmbedder),
+	}, nil
+}
+
+// Get returns the cached Embedder for id, constructing it on first use.
+func (s *EmbedderSet) Get(id string) (Embedder, error) {
+	spec, ok := SpecForEmbedder(id)
+	if !ok {
+		return nil, fmt.Errorf("cluster: unknown embedder %q (known: %s, %s)", id, EmbedderJinaV2, EmbedderQwen3)
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if e, ok := s.embedders[id]; ok {
+		return e, nil
+	}
+	e, err := newONNXEmbedder(s.session, spec)
+	if err != nil {
+		return nil, err
+	}
+	s.embedders[id] = e
+	return e, nil
+}
+
+// Built returns the IDs of embedders constructed so far.
+func (s *EmbedderSet) Built() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]string, 0, len(s.embedders))
+	for id := range s.embedders {
+		out = append(out, id)
+	}
+	return out
+}
+
+// Close releases the shared ORT session (and with it every pipeline).
+// Idempotent.
+func (s *EmbedderSet) Close() error {
 	var firstErr error
-	e.closeOnce.Do(func() {
-		if e.session != nil {
-			if err := e.session.Destroy(); err != nil {
+	s.closeOnce.Do(func() {
+		if s.session != nil {
+			if err := s.session.Destroy(); err != nil {
 				firstErr = err
 			}
 		}
@@ -116,4 +193,28 @@ func (e *onnxEmbedder) Close() error {
 	return firstErr
 }
 
-var _ Embedder = (*onnxEmbedder)(nil)
+// StandaloneEmbedder couples one Embedder with its owning EmbedderSet
+// so single-embedder callers (integration tests) can Close the session.
+type StandaloneEmbedder struct {
+	Embedder
+	set *EmbedderSet
+}
+
+// Close releases the underlying ORT session. Idempotent.
+func (s *StandaloneEmbedder) Close() error { return s.set.Close() }
+
+// NewEmbedder constructs a standalone Jina v2 embedder with its own
+// session. Retained for the parity integration tests; the composition
+// root uses NewEmbedderSet directly.
+func NewEmbedder() (*StandaloneEmbedder, error) {
+	set, err := NewEmbedderSet()
+	if err != nil {
+		return nil, err
+	}
+	e, err := set.Get(EmbedderJinaV2)
+	if err != nil {
+		_ = set.Close()
+		return nil, err
+	}
+	return &StandaloneEmbedder{Embedder: e, set: set}, nil
+}

--- a/internal/router/cluster/embedder_stub.go
+++ b/internal/router/cluster/embedder_stub.go
@@ -8,19 +8,42 @@ import (
 )
 
 // stubEmbedder is the no_onnx-tag impl for environments without
-// libonnxruntime. NewEmbedder errors so cluster.Scorer fails to
+// libonnxruntime. NewEmbedderSet errors so cluster.Scorer fails to
 // construct — the documented dev-convenience escape hatch.
 type stubEmbedder struct{}
-
-// NewEmbedder always fails under -tags=no_onnx.
-func NewEmbedder() (*stubEmbedder, error) {
-	return nil, fmt.Errorf("cluster: built with -tags=no_onnx; the ONNX-backed embedder is unavailable in this build")
-}
 
 func (*stubEmbedder) Embed(_ context.Context, _ string) ([]float32, error) {
 	return nil, fmt.Errorf("cluster: embedder unavailable (no_onnx build tag)")
 }
 
+func (*stubEmbedder) ID() string { return "" }
+
+func (*stubEmbedder) Dim() int { return 0 }
+
 func (*stubEmbedder) Close() error { return nil }
 
 var _ Embedder = (*stubEmbedder)(nil)
+
+// EmbedderSet is the no_onnx stub; NewEmbedderSet always fails.
+type EmbedderSet struct{}
+
+// NewEmbedderSet always fails under -tags=no_onnx.
+func NewEmbedderSet() (*EmbedderSet, error) {
+	return nil, fmt.Errorf("cluster: built with -tags=no_onnx; the ONNX-backed embedder is unavailable in this build")
+}
+
+// Get always fails under -tags=no_onnx.
+func (*EmbedderSet) Get(_ string) (Embedder, error) {
+	return nil, fmt.Errorf("cluster: embedder unavailable (no_onnx build tag)")
+}
+
+// Built returns no embedders under -tags=no_onnx.
+func (*EmbedderSet) Built() []string { return nil }
+
+// Close is a no-op under -tags=no_onnx.
+func (*EmbedderSet) Close() error { return nil }
+
+// NewEmbedder always fails under -tags=no_onnx.
+func NewEmbedder() (*stubEmbedder, error) {
+	return nil, fmt.Errorf("cluster: built with -tags=no_onnx; the ONNX-backed embedder is unavailable in this build")
+}

--- a/internal/router/cluster/embedder_test.go
+++ b/internal/router/cluster/embedder_test.go
@@ -71,6 +71,52 @@ func TestEmbedder_PythonGoParity(t *testing.T) {
 	}
 }
 
+// TestEmbedder_Qwen3PythonGoParity mirrors the Jina parity test for the
+// Qwen3 embedder. The fixture is produced by scripts/export_qwen3_onnx.py
+// (copy its fixture.json to testdata/fixture_qwen3.json); the assets must
+// live under <assets>/qwen3-embedding-0.6b-int8/. Skips when either is
+// absent so the Jina-only suite keeps passing on machines without the
+// Qwen export.
+func TestEmbedder_Qwen3PythonGoParity(t *testing.T) {
+	pointEmbedderAtAssets(t)
+	raw, err := os.ReadFile(filepath.Join("testdata", "fixture_qwen3.json"))
+	if os.IsNotExist(err) {
+		t.Skip("testdata/fixture_qwen3.json absent; run scripts/export_qwen3_onnx.py to produce it")
+	}
+	require.NoError(t, err)
+	var f onnxFixture
+	require.NoError(t, json.Unmarshal(raw, &f))
+	spec, ok := SpecForEmbedder(EmbedderQwen3)
+	require.True(t, ok)
+	require.Equal(t, spec.Dim, f.EmbedDim, "fixture EmbedDim must match the registered Qwen3 spec")
+	require.Equal(t, spec.ID, f.EmbedderName)
+	require.NotEmpty(t, f.Texts)
+	require.Equal(t, len(f.Texts), len(f.Reference))
+
+	set, err := NewEmbedderSet()
+	require.NoError(t, err)
+	defer set.Close()
+	emb, err := set.Get(EmbedderQwen3)
+	if err != nil {
+		t.Skipf("qwen3 assets unavailable: %v", err)
+	}
+
+	cosines := make([]float32, len(f.Texts))
+	for i, text := range f.Texts {
+		vec, err := emb.Embed(context.Background(), text)
+		require.NoError(t, err, "text %d: %s", i, text)
+		require.Len(t, vec, spec.Dim)
+		cosines[i] = cosine(vec, f.Reference[i])
+	}
+	for i, c := range cosines {
+		t.Logf("cosine[%d]=%.4f text=%q", i, c, f.Texts[i])
+	}
+	for i, c := range cosines {
+		assert.GreaterOrEqual(t, c, float32(0.98),
+			"text %d: cosine(go, py) = %.4f, want ≥ 0.98 (text=%q)", i, c, f.Texts[i])
+	}
+}
+
 // cosine is dot product over L2-normalized vectors.
 func cosine(a, b []float32) float32 {
 	var sum float64

--- a/internal/router/cluster/scorer.go
+++ b/internal/router/cluster/scorer.go
@@ -103,6 +103,16 @@ func NewScorer(bundle *Bundle, cfg Config, embed Embedder, availableProviders ma
 		return nil, fmt.Errorf("cluster: availableProviders must not be empty")
 	}
 
+	// Embedder-identity guard: a bundle trained in one embedding space
+	// must never be scored with a different embedder. Dim alone is not
+	// enough (two models can share a dim), so both ID and dim are checked.
+	if embed.ID() != bundle.EmbedderID() {
+		return nil, fmt.Errorf("cluster %s: bundle declares embedder %q but runtime embedder is %q", bundle.Version, bundle.EmbedderID(), embed.ID())
+	}
+	if embed.Dim() != bundle.Centroids.Dim {
+		return nil, fmt.Errorf("cluster %s: embedder dim %d != centroids dim %d", bundle.Version, embed.Dim(), bundle.Centroids.Dim)
+	}
+
 	if bundle.Centroids.K < cfg.TopP {
 		return nil, fmt.Errorf("cluster %s: K=%d < TopP=%d", bundle.Version, bundle.Centroids.K, cfg.TopP)
 	}

--- a/internal/router/cluster/scorer_test.go
+++ b/internal/router/cluster/scorer_test.go
@@ -14,10 +14,13 @@ import (
 )
 
 // fakeEmbedder returns a fixed vector or error; captures last text so
-// tests can assert tail-truncation happened upstream.
+// tests can assert tail-truncation happened upstream. Zero-value id/dim
+// default to the Jina identity so legacy-shaped fixtures keep working.
 type fakeEmbedder struct {
 	vec      []float32
 	err      error
+	id       string
+	dim      int
 	lastText string
 	calls    int
 }
@@ -26,6 +29,20 @@ func (f *fakeEmbedder) Embed(_ context.Context, text string) ([]float32, error) 
 	f.calls++
 	f.lastText = text
 	return f.vec, f.err
+}
+
+func (f *fakeEmbedder) ID() string {
+	if f.id == "" {
+		return EmbedderJinaV2
+	}
+	return f.id
+}
+
+func (f *fakeEmbedder) Dim() int {
+	if f.dim == 0 {
+		return EmbedDim
+	}
+	return f.dim
 }
 
 // l2norm normalizes v in place; test fixtures honor the L2-normed
@@ -357,6 +374,65 @@ func TestNewScorer_RejectsEmptyAvailableProviders(t *testing.T) {
 	assert.Contains(t, err.Error(), "availableProviders")
 }
 
+// The identity guard: a bundle trained in one embedding space must never
+// be scored with a different embedder, even at a matching dim.
+func TestNewScorer_RejectsEmbedderIDMismatch(t *testing.T) {
+	cb, rb, regb := twoClusterArtifacts(t)
+	bundle := bundleFromBlobs(t, "v-test", cb, rb, regb)
+	// Legacy bundle (no metadata) declares Jina; a Qwen embedder at the
+	// same dim must be refused.
+	_, err := NewScorer(bundle, cfgForTest(), &fakeEmbedder{id: EmbedderQwen3, dim: EmbedDim}, allProviders())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "declares embedder")
+}
+
+func TestNewScorer_RejectsEmbedderDimMismatch(t *testing.T) {
+	cb, rb, regb := twoClusterArtifacts(t)
+	bundle := bundleFromBlobs(t, "v-test", cb, rb, regb)
+	_, err := NewScorer(bundle, cfgForTest(), &fakeEmbedder{dim: 1024}, allProviders())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "centroids dim")
+}
+
+// A 1024d Qwen bundle loads and routes end-to-end with a matching
+// embedder — the dual-embedder path is not Jina-special-cased.
+func TestScorer_QwenBundleRoutes(t *testing.T) {
+	dim := 1024
+	c0 := make([]float32, dim)
+	c0[0] = 1
+	c1 := make([]float32, dim)
+	c1[1] = 1
+	full := append(append([]float32{}, c0...), c1...)
+	cb := buildCentroidsBlob(t, 2, dim, full)
+	rb := []byte(`{
+		"rankings": {
+			"0": {"claude-opus-4-7": 0.9, "claude-haiku-4-5": 0.1},
+			"1": {"claude-opus-4-7": 0.1, "claude-haiku-4-5": 0.9}
+		}
+	}`)
+	regb := []byte(`{
+		"deployed_models": [
+			{"model": "claude-opus-4-7", "provider": "anthropic", "bench_column": "gpt-5", "proxy": true},
+			{"model": "claude-haiku-4-5", "provider": "anthropic", "bench_column": "gemini-2.5-flash", "proxy": true}
+		]
+	}`)
+	bundle := bundleFromBlobs(t, "v-qwen-test", cb, rb, regb)
+	bundle.Metadata = &ArtifactMetadata{
+		Embedder: ArtifactEmbedder{Model: EmbedderQwen3, EmbedDim: dim},
+	}
+
+	vec := make([]float32, dim)
+	vec[0] = 1 // aligned with cluster 0 (Opus)
+	emb := &fakeEmbedder{id: EmbedderQwen3, dim: dim, vec: vec}
+	s, err := NewScorer(bundle, cfgForTest(), emb, allProviders())
+	require.NoError(t, err)
+
+	d, err := s.Route(context.Background(), router.Request{PromptText: "design a distributed system"})
+	require.NoError(t, err)
+	assert.Equal(t, "claude-opus-4-7", d.Model)
+	assert.Equal(t, "anthropic", d.Provider)
+}
+
 func TestNewScorer_RejectsRankingsMissingDeployedModel(t *testing.T) {
 	dim := EmbedDim
 	c0 := make([]float32, dim)
@@ -584,6 +660,10 @@ func (s *slowEmbedder) Embed(ctx context.Context, _ string) ([]float32, error) {
 		return nil, ctx.Err()
 	}
 }
+
+func (s *slowEmbedder) ID() string { return EmbedderJinaV2 }
+
+func (s *slowEmbedder) Dim() int { return EmbedDim }
 
 func TestTailTruncate(t *testing.T) {
 	got := tailTruncate("abcdef", 3)

--- a/scripts/export_qwen3_onnx.py
+++ b/scripts/export_qwen3_onnx.py
@@ -1,0 +1,249 @@
+#!/usr/bin/env python3
+"""Export Qwen3-Embedding-0.6B to ONNX with last-token pooling baked in.
+
+The router's Go embedder (hugot FeatureExtractionPipeline) mean-pools
+3D token-level outputs — wrong for Qwen3, which requires last-token
+pooling. Baking the pooling into the graph makes the export emit a 2D
+[batch, 1024] output that hugot returns as-is (it only mean-pools 3D),
+so the Go side needs no model-specific pooling code and train/runtime
+parity is guaranteed by construction.
+
+Pipeline:
+  1. Load Qwen/Qwen3-Embedding-0.6B (transformers AutoModel).
+  2. Wrap with attention-mask-aware last-token pooling (no L2 norm in
+     the graph; hugot's WithNormalization applies it, matching Jina).
+  3. Export to ONNX with dynamic batch/sequence axes.
+  4. INT8 dynamic quantization (onnxruntime).
+  5. Parity self-check vs sentence-transformers reference (cosine
+     >= 0.99 fp32, >= 0.98 int8) and emit a Go test fixture JSON.
+  6. Optionally upload to a Weave-owned HF repo (--upload).
+
+Usage:
+  python scripts/export_qwen3_onnx.py --out-dir ./qwen3-export
+  python scripts/export_qwen3_onnx.py --out-dir ./qwen3-export \
+      --upload weave-ai/qwen3-embedding-0.6b-onnx-router
+
+Requires: torch>=2.2, transformers>=4.51, onnx, onnxruntime,
+          sentence-transformers>=2.7 (parity check), huggingface_hub
+          (upload only).
+
+The output directory layout matches what the Dockerfile pulls and what
+internal/router/cluster expects under assets/qwen3-embedding-0.6b-int8/:
+  model.onnx       (INT8, pooled output [batch, 1024])
+  model_fp32.onnx  (provenance; not deployed)
+  tokenizer.json
+  fixture.json     (Go parity-test fixture, copy to
+                    internal/router/cluster/testdata/fixture_qwen3.json)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import sys
+import tempfile
+from pathlib import Path
+
+MODEL_ID = "Qwen/Qwen3-Embedding-0.6B"
+EMBED_DIM = 1024
+EMBEDDER_NAME = "qwen3-embedding-0.6b-int8"
+OPSET = 17
+
+# Mirrors the prompts in scripts/dump_cluster_test_vector.py so the Go
+# parity suite exercises the same multilingual/code coverage.
+PARITY_TEXTS = [
+    "How do I reverse a linked list in Python?",
+    "Refactor this Go HTTP handler to use context cancellation.",
+    "What is the capital of France?",
+    "def quicksort(arr):\n    if len(arr) <= 1:\n        return arr",
+    "Explique-moi la différence entre un processus et un thread.",
+    "SELECT id, name FROM users WHERE created_at > now() - interval '7 days';",
+    "Write a unit test for a debounce function in TypeScript.",
+    "深圳的天气怎么样？",
+]
+
+
+def build_wrapper(model):
+    import torch
+
+    class LastTokenPooled(torch.nn.Module):
+        """Emits [batch, hidden] by gathering each row's last real token.
+
+        Works for right-padded batches (gather at mask.sum()-1) and
+        degenerates correctly for left-padded ones (last column), the
+        same logic as the HF model card's last_token_pool.
+        """
+
+        def __init__(self, base):
+            super().__init__()
+            self.base = base
+
+        def forward(self, input_ids, attention_mask):
+            hidden = self.base(
+                input_ids=input_ids, attention_mask=attention_mask
+            ).last_hidden_state
+            seq_lengths = attention_mask.sum(dim=1) - 1
+            batch = torch.arange(hidden.shape[0], device=hidden.device)
+            return hidden[batch, seq_lengths]
+
+    return LastTokenPooled(model)
+
+
+def export_fp32(out_path: Path):
+    import torch
+    from transformers import AutoModel, AutoTokenizer
+
+    print(f"Loading {MODEL_ID} ...")
+    tokenizer = AutoTokenizer.from_pretrained(MODEL_ID, padding_side="right")
+    model = AutoModel.from_pretrained(MODEL_ID, torch_dtype=torch.float32)
+    model.eval()
+    wrapper = build_wrapper(model)
+
+    sample = tokenizer(
+        ["export sample one", "a slightly longer export sample two"],
+        padding=True,
+        return_tensors="pt",
+    )
+
+    print(f"Exporting fp32 ONNX (opset {OPSET}) -> {out_path}")
+    torch.onnx.export(
+        wrapper,
+        (sample["input_ids"], sample["attention_mask"]),
+        str(out_path),
+        input_names=["input_ids", "attention_mask"],
+        output_names=["sentence_embedding"],
+        dynamic_axes={
+            "input_ids": {0: "batch", 1: "sequence"},
+            "attention_mask": {0: "batch", 1: "sequence"},
+            "sentence_embedding": {0: "batch"},
+        },
+        opset_version=OPSET,
+    )
+    return tokenizer
+
+
+def quantize_int8(fp32_path: Path, int8_path: Path):
+    from onnxruntime.quantization import QuantType, quantize_dynamic
+
+    print(f"Quantizing INT8 -> {int8_path}")
+    quantize_dynamic(
+        model_input=str(fp32_path),
+        model_output=str(int8_path),
+        weight_type=QuantType.QInt8,
+    )
+
+
+def onnx_embed(onnx_path: Path, tokenizer, texts: list[str]):
+    """Embed texts one at a time (the router embeds single prompts) and
+    L2-normalize, mirroring hugot's WithNormalization."""
+    import numpy as np
+    import onnxruntime as ort
+
+    sess = ort.InferenceSession(str(onnx_path), providers=["CPUExecutionProvider"])
+    out = []
+    for text in texts:
+        enc = tokenizer([text], padding=True, truncation=True, max_length=8192, return_tensors="np")
+        (vec,) = sess.run(
+            ["sentence_embedding"],
+            {"input_ids": enc["input_ids"], "attention_mask": enc["attention_mask"]},
+        )
+        v = vec[0].astype(np.float64)
+        v /= max(float((v**2).sum() ** 0.5), 1e-12)
+        out.append(v)
+    return out
+
+
+def reference_embed(texts: list[str]):
+    """sentence-transformers ground truth, no instruction prompt — the
+    router embeds raw prompt text (document-style), matching training."""
+    from sentence_transformers import SentenceTransformer
+
+    model = SentenceTransformer(MODEL_ID)
+    return model.encode(texts, normalize_embeddings=True)
+
+
+def cosine(a, b) -> float:
+    import numpy as np
+
+    return float(np.dot(np.asarray(a, dtype=np.float64), np.asarray(b, dtype=np.float64)))
+
+
+def parity_check(onnx_path: Path, tokenizer, threshold: float, label: str):
+    print(f"Parity check ({label}, threshold {threshold}) ...")
+    got = onnx_embed(onnx_path, tokenizer, PARITY_TEXTS)
+    ref = reference_embed(PARITY_TEXTS)
+    worst = 1.0
+    for text, g, r in zip(PARITY_TEXTS, got, ref):
+        c = cosine(g, r)
+        worst = min(worst, c)
+        print(f"  cosine={c:.5f}  {text[:60]!r}")
+        if c < threshold:
+            sys.exit(f"FAIL: cosine {c:.5f} < {threshold} for {text!r} ({label})")
+    print(f"  worst={worst:.5f} OK")
+    return ref
+
+
+def write_fixture(out_dir: Path, reference):
+    fixture = {
+        "texts": PARITY_TEXTS,
+        "reference": [[float(x) for x in row] for row in reference],
+        "embedder_name": EMBEDDER_NAME,
+        "embed_dim": EMBED_DIM,
+        "quantization": "int8-dynamic",
+    }
+    path = out_dir / "fixture.json"
+    path.write_text(json.dumps(fixture))
+    print(f"Wrote Go parity fixture -> {path}")
+    print("Copy to internal/router/cluster/testdata/fixture_qwen3.json for the Go suite.")
+
+
+def upload(out_dir: Path, repo: str):
+    from huggingface_hub import HfApi
+
+    api = HfApi()
+    print(f"Uploading {out_dir} -> {repo}")
+    api.create_repo(repo, exist_ok=True)
+    info = api.upload_folder(
+        folder_path=str(out_dir),
+        repo_id=repo,
+        commit_message=f"Export {MODEL_ID} with baked last-token pooling (opset {OPSET}, int8)",
+    )
+    print(f"Uploaded. Pin HF_QWEN_REVISION to the new commit SHA: {info.oid}")
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--out-dir", required=True, type=Path)
+    ap.add_argument("--upload", metavar="HF_REPO", help="upload the export to this HF repo after parity passes")
+    ap.add_argument("--fp32-threshold", type=float, default=0.99)
+    ap.add_argument("--int8-threshold", type=float, default=0.98)
+    args = ap.parse_args()
+
+    out_dir: Path = args.out_dir
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    fp32_path = out_dir / "model_fp32.onnx"
+    int8_path = out_dir / "model.onnx"
+
+    tokenizer = export_fp32(fp32_path)
+    quantize_int8(fp32_path, int8_path)
+
+    with tempfile.TemporaryDirectory() as td:
+        tokenizer.save_pretrained(td)
+        shutil.copy(Path(td) / "tokenizer.json", out_dir / "tokenizer.json")
+        for companion in ("tokenizer_config.json", "special_tokens_map.json"):
+            src = Path(td) / companion
+            if src.exists():
+                shutil.copy(src, out_dir / companion)
+
+    parity_check(fp32_path, tokenizer, args.fp32_threshold, "fp32")
+    reference = parity_check(int8_path, tokenizer, args.int8_threshold, "int8")
+    write_fixture(out_dir, reference)
+
+    if args.upload:
+        upload(out_dir, args.upload)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Makes the cluster embedder a per-bundle property: each artifact bundle declares its embedding space in `metadata.yaml` (`embedder.model` + `embedder.embed_dim`), and `NewScorer` refuses to pair a bundle with a mismatched embedder ID or dimension.
- Adds `EmbedderSet` with lazy per-ID ONNX pipeline construction so prod loads only the default bundle's embedder while staging (`ROUTER_CLUSTER_BUILD_ALL_VERSIONS=true`) can carry both Jina-v2 (768d) and Qwen3-Embedding-0.6B (1024d) for A/B via `x-weave-cluster-version`.
- Ships `scripts/export_qwen3_onnx.py` (last-token pooling baked into the ONNX graph, INT8 quantize, parity self-check) and Dockerfile support for per-embedder asset subdirs; Qwen pull is gated on `HF_QWEN_REPO` so builds stay green until the export is uploaded.

Existing v0.21–v0.66 bundles and `artifacts/latest` are untouched — zero prod behavior change until a Qwen-trained bundle is committed and promoted.

## Test plan

- [x] `go test ./...` passes
- [x] `go vet` clean across `no_onnx`, `ORT`, `onnx_integration ORT`, `diff_v2` tag combos
- [ ] Run `scripts/export_qwen3_onnx.py`, upload to Weave HF repo, pin `HF_QWEN_REVISION` in follow-up PR
- [ ] Latency gate: Qwen3 INT8 embed p95 on target CPU vs 1500 ms `EmbedTimeout`
- [ ] Train v0.67 in `router-internal/eval/` per trainer contract in `artifacts/README.md`
- [ ] Staging A/B: `ROUTER_CLUSTER_BUILD_ALL_VERSIONS=true` + eval harness header flip


Made with [Cursor](https://cursor.com)