### PR TITLE
feat(docker): pin Qwen3 embedder assets to weave-eng HF repo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,13 +24,14 @@ ARG HF_MODEL_REPO=jinaai/jina-embeddings-v2-base-code
 # silently picked up new weights" surprises. Bump deliberately.
 ARG HF_MODEL_REVISION=516f4baf13dec4ddddda8631e019b5737c8bc250
 # Second embedder: Qwen3-Embedding-0.6B exported with last-token
-# pooling baked into the graph (scripts/export_qwen3_onnx.py). Empty
-# HF_QWEN_REPO skips the pull — the runtime constructs embedders
-# lazily, so deploys serving only Jina bundles don't need the asset.
-# Once the export is uploaded, set the repo default here and pin
-# HF_QWEN_REVISION to the upload commit SHA printed by the script.
-ARG HF_QWEN_REPO=
-ARG HF_QWEN_REVISION=main
+# pooling baked into the graph (scripts/export_qwen3_onnx.py). The
+# repo is private — builds must pass `--secret id=hf_token,...`.
+# Set HF_QWEN_REPO= (empty) to skip the pull; the runtime constructs
+# embedders lazily, so deploys serving only Jina bundles don't need
+# the asset. Pin HF_QWEN_REVISION to the upload commit SHA printed by
+# the export script. Bump deliberately.
+ARG HF_QWEN_REPO=weave-eng/qwen3-embedding-0.6b-onnx-router
+ARG HF_QWEN_REVISION=a43740ed1bb6436deaa4b79c9a132a3d98756ace
 
 # --- Stage 1: build the Next.js mini UI ---
 FROM node:22-alpine AS ui-builder

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,12 +24,12 @@ ARG HF_MODEL_REPO=jinaai/jina-embeddings-v2-base-code
 # silently picked up new weights" surprises. Bump deliberately.
 ARG HF_MODEL_REVISION=516f4baf13dec4ddddda8631e019b5737c8bc250
 # Second embedder: Qwen3-Embedding-0.6B exported with last-token
-# pooling baked into the graph (scripts/export_qwen3_onnx.py). The
-# repo is private — builds must pass `--secret id=hf_token,...`.
-# Set HF_QWEN_REPO= (empty) to skip the pull; the runtime constructs
-# embedders lazily, so deploys serving only Jina bundles don't need
-# the asset. Pin HF_QWEN_REVISION to the upload commit SHA printed by
-# the export script. Bump deliberately.
+# pooling baked into the graph (scripts/export_qwen3_onnx.py),
+# uploaded to a public Weave-owned repo (Apache-2.0 derivative, same
+# public-pull model as Jina). Set HF_QWEN_REPO= (empty) to skip the
+# pull; the runtime constructs embedders lazily, so deploys serving
+# only Jina bundles don't need the asset. Pin HF_QWEN_REVISION to the
+# upload commit SHA printed by the export script. Bump deliberately.
 ARG HF_QWEN_REPO=weave-eng/qwen3-embedding-0.6b-onnx-router
 ARG HF_QWEN_REVISION=a43740ed1bb6436deaa4b79c9a132a3d98756ace
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -132,14 +132,17 @@ of the assets root, keyed by embedder ID:
   layout (`<root>/model.onnx`) still resolves for this embedder.
 - `qwen3-embedding-0.6b-int8/` — produced by `scripts/export_qwen3_onnx.py`
   (Qwen3-Embedding-0.6B with last-token pooling baked into the graph) and
-  uploaded to a Weave HF repo. Only needed when serving a bundle whose
-  `metadata.yaml` declares this embedder; the runtime loads embedders lazily.
+  uploaded to the private
+  [`weave-eng/qwen3-embedding-0.6b-onnx-router`](https://huggingface.co/weave-eng/qwen3-embedding-0.6b-onnx-router)
+  HF repo. Only needed when serving a bundle whose `metadata.yaml` declares
+  this embedder; the runtime loads embedders lazily.
 
 Neither is committed to git.
 
 **Docker (default):** the Dockerfile downloads the files at image build time
-into `/opt/router/assets/<embedder-id>/`. The Qwen pull runs only when the
-`HF_QWEN_REPO` build arg is set. Nothing for you to do.
+into `/opt/router/assets/<embedder-id>/`. The Qwen repo is private, so builds
+must pass an HF token (`docker build --secret id=hf_token,src=...`); set
+`HF_QWEN_REPO=` (empty) to skip the Qwen pull for Jina-only deploys.
 
 **`make dev` (host-mode hot reload):** fetch the Jina files once into a local
 directory and point `ROUTER_ONNX_ASSETS_DIR` at it:

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -132,7 +132,7 @@ of the assets root, keyed by embedder ID:
   layout (`<root>/model.onnx`) still resolves for this embedder.
 - `qwen3-embedding-0.6b-int8/` — produced by `scripts/export_qwen3_onnx.py`
   (Qwen3-Embedding-0.6B with last-token pooling baked into the graph) and
-  uploaded to the private
+  uploaded to the public
   [`weave-eng/qwen3-embedding-0.6b-onnx-router`](https://huggingface.co/weave-eng/qwen3-embedding-0.6b-onnx-router)
   HF repo. Only needed when serving a bundle whose `metadata.yaml` declares
   this embedder; the runtime loads embedders lazily.
@@ -140,9 +140,9 @@ of the assets root, keyed by embedder ID:
 Neither is committed to git.
 
 **Docker (default):** the Dockerfile downloads the files at image build time
-into `/opt/router/assets/<embedder-id>/`. The Qwen repo is private, so builds
-must pass an HF token (`docker build --secret id=hf_token,src=...`); set
-`HF_QWEN_REPO=` (empty) to skip the Qwen pull for Jina-only deploys.
+into `/opt/router/assets/<embedder-id>/`. Both repos are public — no token
+needed (the optional `hf_token` secret still works for rate-limit headroom);
+set `HF_QWEN_REPO=` (empty) to skip the Qwen pull for Jina-only deploys.
 
 **`make dev` (host-mode hot reload):** fetch the Jina files once into a local
 directory and point `ROUTER_ONNX_ASSETS_DIR` at it:


### PR DESCRIPTION
## Summary

Final wiring step for the dual-embedder rollout (#346, #349). The Qwen3-0.6B ONNX export (INT8 per-channel, down_proj/o_proj fp32, last-token pooling baked in) is uploaded to the private [weave-eng/qwen3-embedding-0.6b-onnx-router](https://huggingface.co/weave-eng/qwen3-embedding-0.6b-onnx-router) repo.

- Pins `HF_QWEN_REPO=weave-eng/qwen3-embedding-0.6b-onnx-router`, `HF_QWEN_REVISION=a43740ed1bb6436deaa4b79c9a132a3d98756ace` (upload commit SHA).
- Uploaded `model.onnx` matches the export that passed the parity gates (int8 0.983 vs reference, Go-vs-Python 0.981) and is byte-identical to the fixture's source (1,042,047,545 bytes).
- Docs: note the private repo + `--secret id=hf_token` requirement.

## Deploy note

Image builds now require `docker build --secret id=hf_token,src=<token-file>` (the Dockerfile already threads the token through every HF curl). Verified the resolve URL returns 200 with token, 401 without. Jina-only deploys can pass `--build-arg HF_QWEN_REPO=` to skip.

## Test plan

- [ ] Deploy-pipeline build passes with the hf_token secret mounted
- [ ] Booted image constructs the Qwen embedder when a Qwen bundle is the default version

Made with [Cursor](https://cursor.com)