### PR TITLE
feat(cluster): ROUTER_CLUSTER_TOP_P env override

### DIFF
--- a/cmd/router/main.go
+++ b/cmd/router/main.go
@@ -828,6 +828,15 @@ func buildClusterScorer(availableProviders map[string]struct{}) (router.Router, 
 			logger.Info("Cluster embed timeout overridden", "embed_timeout_ms", ms.Milliseconds())
 		}
 	}
+	if v := config.GetOr("ROUTER_CLUSTER_TOP_P", ""); v != "" {
+		n, parseErr := strconv.Atoi(v)
+		if parseErr != nil || n <= 0 {
+			logger.Warn("Invalid ROUTER_CLUSTER_TOP_P; using default", "value", v, "default", cfg.TopP)
+		} else {
+			cfg.TopP = n
+			logger.Info("Cluster top_p overridden", "top_p", n)
+		}
+	}
 	scorers := make(map[string]*cluster.Scorer, len(versions))
 	warmed := make(map[string]cluster.Embedder)
 	for _, v := range versions {


### PR DESCRIPTION
## What

Add a `ROUTER_CLUSTER_TOP_P` env override for the cluster scorer's `top_p`, mirroring the existing `ROUTER_CLUSTER_EMBED_TIMEOUT_MS` override right above it. Default is unchanged (`DefaultConfig()` = 4).

## Why

`top_p` (how many nearest centroids' ranking rows get summed before argmax) was hardcoded to 4 and not runtime-configurable — the bundle `metadata.yaml` `top_p` field is provenance-only and never read into `cluster.Config`.

With `K=16`, `top_p=4` means every routing decision averages over a **quarter of the cluster space**, which washes out distinctive per-cluster picks. Offline, on real agentic traffic the same v0.66 bundle routes:

| top_p | opus/fable share | swebpro (offline) | atlasqna (offline) |
|---|---:|---:|---:|
| 4 (current) | 98.5% | 35.8 | 42.7 |
| 2 | 86.5% | 35.8 | 39.7 |
| 1 | 42.6% | 26.7 ❌ | 16.8 ❌ |

`top_p=2` holds the hard guardrail (Pro exact, Atlas within noise) while letting the clearly-cheap tail route off opus; `top_p=1` craters it. This override lets us validate `top_p=2` live on staging (`--cluster-version v0.66` vs the existing v0.66@4 baseline) without a rebuild, before considering any default change.

## Risk

Minimal — additive env parse, default behavior unchanged, validated (`<=0` or unparseable falls back to default with a warn). `NewScorer` already guards `K >= TopP`.