### PR TITLE
fix(translate): clamp effort xhigh on re-route to models without it

### DIFF
--- a/internal/proxy/conformance_anthropic_test.go
+++ b/internal/proxy/conformance_anthropic_test.go
@@ -50,6 +50,24 @@ func TestConformance_Anthropic(t *testing.T) {
 				assert.NotEqual(t, "system", gjson.GetBytes(body, "messages.0.role").String(), "no system role may remain in the messages array")
 			},
 		},
+		{
+			// Guards the 2026-06-09 re-route 400: a session running with
+			// output_config.effort="xhigh" (valid for the requested opus-4-7+)
+			// re-routed onto claude-sonnet-4-6 must have the effort clamped to
+			// "max" — sonnet's menu has no xhigh and the resulting 400 is
+			// non-retryable, killing the session.
+			name:            "anthropic/xhigh_effort_clamped_on_reroute",
+			provider:        providers.ProviderAnthropic,
+			model:           "claude-sonnet-4-6",
+			newClient:       anthropicClient,
+			inbound:         `{"model":"claude-opus-4-7","stream":true,"max_tokens":1024,"thinking":{"type":"adaptive"},"output_config":{"effort":"xhigh"},"messages":[{"role":"user","content":"hi"}]}`,
+			stream:          true,
+			upstreamFixture: "anthropic/basic_text.upstream.sse",
+			wantUpstream: func(t *testing.T, _ string, body []byte, _ http.Header) {
+				assert.Equal(t, "claude-sonnet-4-6", gjson.GetBytes(body, "model").String())
+				assert.Equal(t, "max", gjson.GetBytes(body, "output_config.effort").String(), "xhigh must clamp to max for models without CapXhighEffort")
+			},
+		},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) { runConformanceCase(t, c) })

--- a/internal/proxy/testdata/conformance/anthropic/xhigh_effort_clamped_on_reroute.golden
+++ b/internal/proxy/testdata/conformance/anthropic/xhigh_effort_clamped_on_reroute.golden
@@ -1,0 +1,66 @@
+[
+  {
+    "event": "message_start",
+    "data": {
+      "message": {
+        "content": [],
+        "id": "<id>",
+        "model": "claude-opus-4-8",
+        "role": "assistant",
+        "type": "message",
+        "usage": {
+          "input_tokens": 5,
+          "output_tokens": 0
+        }
+      },
+      "type": "message_start"
+    }
+  },
+  {
+    "event": "content_block_start",
+    "data": {
+      "content_block": {
+        "text": "",
+        "type": "text"
+      },
+      "index": 0,
+      "type": "content_block_start"
+    }
+  },
+  {
+    "event": "content_block_delta",
+    "data": {
+      "delta": {
+        "text": "Hi there!",
+        "type": "text_delta"
+      },
+      "index": 0,
+      "type": "content_block_delta"
+    }
+  },
+  {
+    "event": "content_block_stop",
+    "data": {
+      "index": 0,
+      "type": "content_block_stop"
+    }
+  },
+  {
+    "event": "message_delta",
+    "data": {
+      "delta": {
+        "stop_reason": "end_turn"
+      },
+      "type": "message_delta",
+      "usage": {
+        "output_tokens": 3
+      }
+    }
+  },
+  {
+    "event": "message_stop",
+    "data": {
+      "type": "message_stop"
+    }
+  }
+]

--- a/internal/router/model.go
+++ b/internal/router/model.go
@@ -10,6 +10,12 @@ const (
 	CapExtendedThinking ModelCapability = "extended_thinking"
 	CapReasoning        ModelCapability = "reasoning"
 	CapExtendedContext  ModelCapability = "extended_context"
+	// CapXhighEffort marks Anthropic adaptive models whose output_config.effort
+	// menu includes "xhigh". All adaptive models accept low/medium/high/max;
+	// xhigh is opus-4-7+ only — claude-sonnet-4-6 rejects it with 400 "This
+	// model does not support effort level 'xhigh'". Emit clamps xhigh to "max"
+	// when the target lacks this capability.
+	CapXhighEffort ModelCapability = "xhigh_effort"
 )
 
 // ModelSpec describes what a model supports. Zero value is safe: provider
@@ -56,7 +62,10 @@ var (
 	// Opus 4.6+, Opus 4.7+, Opus 4.8, and Sonnet 4.6 support 1M context via
 	// context-1m-2025-08-07 beta; Haiku 4.5 and Sonnet 4.5 are limited to 200K.
 	anthropicAdaptive = NewSpec(CapAdaptiveThinking, CapExtendedContext)
-	anthropicExtended = NewSpec(CapExtendedThinking)
+	// Opus 4.7+ (and fable) additionally accept effort level "xhigh"; the
+	// older adaptive models (opus-4-6, sonnet-4-6) top out at "max".
+	anthropicAdaptiveXhigh = NewSpec(CapAdaptiveThinking, CapExtendedContext, CapXhighEffort)
+	anthropicExtended      = NewSpec(CapExtendedThinking)
 )
 
 var (
@@ -74,9 +83,9 @@ var registry = map[string]ModelSpec{
 	// claude-fable-5: adaptive thinking is always on (thinking.type=disabled
 	// is rejected); 1M context is native, so CapExtendedContext only makes the
 	// context-1m beta header a harmless no-op.
-	"claude-fable-5":    anthropicAdaptive,
-	"claude-opus-4-8":   anthropicAdaptive,
-	"claude-opus-4-7":   anthropicAdaptive,
+	"claude-fable-5":    anthropicAdaptiveXhigh,
+	"claude-opus-4-8":   anthropicAdaptiveXhigh,
+	"claude-opus-4-7":   anthropicAdaptiveXhigh,
 	"claude-sonnet-4-6": anthropicAdaptive,
 	"claude-opus-4-6":   anthropicAdaptive,
 

--- a/internal/translate/emit_same_format_test.go
+++ b/internal/translate/emit_same_format_test.go
@@ -615,3 +615,60 @@ func TestAnthropicSameFormat_BodyIsImmutable(t *testing.T) {
 
 	assert.Equal(t, original, body, "original body bytes must not be modified")
 }
+
+// Prod repro (2026-06-09 customer benchmark): a session running with
+// output_config.effort="xhigh" (valid for the requested opus) was re-routed
+// mid-session to claude-sonnet-4-6, whose effort menu tops out at "max".
+// The body went through with only the model swapped and Anthropic rejected it
+// with a non-retryable 400 ("This model does not support effort level
+// 'xhigh'"), killing the session. The emit layer must clamp xhigh to max for
+// adaptive targets without CapXhighEffort.
+func TestAnthropicSameFormat_XhighEffortClampedOnReroute(t *testing.T) {
+	body := []byte(`{"model":"claude-opus-4-7","messages":[{"role":"user","content":"hi"}],"max_tokens":1024,"thinking":{"type":"adaptive"},"output_config":{"effort":"xhigh"}}`)
+	opts := translate.EmitOptions{
+		TargetModel:  "claude-sonnet-4-6",
+		Capabilities: router.Lookup("claude-sonnet-4-6"),
+	}
+	out := parseAndEmit(t, body, "anthropic", opts)
+	outputConfig, _ := out["output_config"].(map[string]any)
+	require.NotNil(t, outputConfig)
+	assert.Equal(t, "max", outputConfig["effort"], "xhigh must clamp to max for models without CapXhighEffort")
+}
+
+// Top-level `effort` follows the same menu as output_config.effort.
+func TestAnthropicSameFormat_XhighTopLevelEffortClampedOnReroute(t *testing.T) {
+	body := []byte(`{"model":"claude-opus-4-8","messages":[{"role":"user","content":"hi"}],"max_tokens":1024,"thinking":{"type":"adaptive"},"effort":"xhigh"}`)
+	opts := translate.EmitOptions{
+		TargetModel:  "claude-sonnet-4-6",
+		Capabilities: router.Lookup("claude-sonnet-4-6"),
+	}
+	out := parseAndEmit(t, body, "anthropic", opts)
+	assert.Equal(t, "max", out["effort"], "top-level xhigh must clamp to max for models without CapXhighEffort")
+}
+
+// xhigh stays untouched when the target supports it (opus-4-7+).
+func TestAnthropicSameFormat_XhighEffortPreservedForCapableModel(t *testing.T) {
+	body := []byte(`{"model":"claude-opus-4-7","messages":[{"role":"user","content":"hi"}],"max_tokens":1024,"thinking":{"type":"adaptive"},"output_config":{"effort":"xhigh"}}`)
+	opts := translate.EmitOptions{
+		TargetModel:  "claude-opus-4-8",
+		Capabilities: router.Lookup("claude-opus-4-8"),
+	}
+	out := parseAndEmit(t, body, "anthropic", opts)
+	outputConfig, _ := out["output_config"].(map[string]any)
+	require.NotNil(t, outputConfig)
+	assert.Equal(t, "xhigh", outputConfig["effort"], "xhigh must pass through to models with CapXhighEffort")
+}
+
+// Levels below xhigh are on every adaptive model's menu; the clamp must not
+// touch them even when the target lacks CapXhighEffort.
+func TestAnthropicSameFormat_NonXhighEffortUntouchedByClamp(t *testing.T) {
+	body := []byte(`{"model":"claude-opus-4-7","messages":[{"role":"user","content":"hi"}],"max_tokens":1024,"thinking":{"type":"adaptive"},"output_config":{"effort":"high"}}`)
+	opts := translate.EmitOptions{
+		TargetModel:  "claude-sonnet-4-6",
+		Capabilities: router.Lookup("claude-sonnet-4-6"),
+	}
+	out := parseAndEmit(t, body, "anthropic", opts)
+	outputConfig, _ := out["output_config"].(map[string]any)
+	require.NotNil(t, outputConfig)
+	assert.Equal(t, "high", outputConfig["effort"], "supported effort levels must pass through unchanged")
+}

--- a/internal/translate/envelope.go
+++ b/internal/translate/envelope.go
@@ -368,6 +368,13 @@ type EmitOverrides struct {
 	// model only accepts adaptive thinking (claude-opus-4-6+ / sonnet-4-6+).
 	RewriteThinkingAdaptive bool
 	OutputConfigEffort      string
+	// ClampEffortXhighTo downgrades a caller-supplied effort level of "xhigh"
+	// (top-level `effort` and `output_config.effort`) to this value. Set when
+	// the target model's effort menu lacks xhigh (router.CapXhighEffort): a
+	// mid-session re-route from opus to sonnet otherwise forwards the client's
+	// xhigh verbatim and Anthropic rejects the request with a non-retryable
+	// 400, killing the session.
+	ClampEffortXhighTo string
 }
 
 func (e *RequestEnvelope) emitSameFormat(ov EmitOverrides) ([]byte, error) {
@@ -441,6 +448,18 @@ func applyOverrides(body []byte, ov EmitOverrides) ([]byte, error) {
 				if err != nil {
 					return nil, fmt.Errorf("set output_config.effort: %w", err)
 				}
+			}
+		}
+	}
+
+	if ov.ClampEffortXhighTo != "" {
+		for _, key := range []string{"effort", "output_config.effort"} {
+			if gjson.GetBytes(out, key).String() != effortXhigh {
+				continue
+			}
+			out, err = sjson.SetBytes(out, key, ov.ClampEffortXhighTo)
+			if err != nil {
+				return nil, fmt.Errorf("clamp %s: %w", key, err)
 			}
 		}
 	}
@@ -807,6 +826,13 @@ func resolveOpenAIOverrides(body []byte, opts EmitOptions) EmitOverrides {
 	return ov
 }
 
+// Anthropic adaptive effort levels referenced by emit logic. Every adaptive
+// model accepts low/medium/high/max; xhigh requires router.CapXhighEffort.
+const (
+	effortMax   = "max"
+	effortXhigh = "xhigh"
+)
+
 // effortForBudget maps the legacy thinking.budget_tokens value onto the
 // adaptive output_config.effort tier. The thresholds match Anthropic's
 // published guidance: ≤4k tokens is "low" headroom, ≤16k is "medium", and
@@ -861,6 +887,14 @@ func resolveAnthropicOverrides(body []byte, opts EmitOptions) EmitOverrides {
 				ov.DeleteKeys = append(ov.DeleteKeys, key)
 			}
 		}
+	}
+
+	// Adaptive targets keep caller-supplied effort, but the menu differs per
+	// model: "xhigh" is opus-4-7+ only. Clamp to the highest level every
+	// adaptive model accepts so a re-route never manufactures an invalid
+	// request out of a valid one.
+	if opts.Capabilities.Supports(router.CapAdaptiveThinking) && !opts.Capabilities.Supports(router.CapXhighEffort) {
+		ov.ClampEffortXhighTo = effortMax
 	}
 
 	if !opts.Capabilities.Supports(router.CapAdaptiveThinking) && !opts.Capabilities.Supports(router.CapExtendedThinking) {


### PR DESCRIPTION
## Problem

Prod incident 2026-06-09 (customer benchmark, org_H30nkAr1AhTOwfOUIGorfQzp): a Claude Code session sending `output_config.effort: "xhigh"` (valid for its requested opus-4-7) was re-routed mid-session to **claude-sonnet-4-6** after a maxed-output turn evicted its gpt-5.5 pin. The same-format Anthropic dispatch swaps only the `model` field, so xhigh went upstream verbatim:

> `400 This model does not support effort level 'xhigh'. Supported levels: high, low, max, medium.`

400s are non-retryable (correctly, in general), so no failover fired and the error killed the session — 69 turns of work lost, one turn before the agent's first edit. The router manufactured an invalid request out of a valid one.

## Fix

- New capability `router.CapXhighEffort`: xhigh is on the effort menu for opus-4-7+, opus-4-8, and fable; opus-4-6 / sonnet-4-6 top out at `max`.
- Emit clamp in `resolveAnthropicOverrides`: for adaptive targets **without** the capability, `xhigh` → `max` (both top-level `effort` and `output_config.effort`). Supported levels pass through untouched; capable targets still get xhigh verbatim — the existing caller-effort-wins contract is preserved for every value the target actually accepts.
- Conformance case `anthropic/xhigh_effort_clamped_on_reroute` + 4 emit-level tests (clamp, top-level clamp, preserved-for-capable, non-xhigh-untouched).

## Notes

- The handover summarizer path already deletes effort keys (`handover.go`), so this emit seam is the only one that forwards caller effort to a rewritten model.
- Follow-up candidate (not in this PR): classify "does not support effort level" 400s as repairable (strip/clamp + same-binding retry) as defense in depth for future menu drift.
- Occurrence: 1× in prod over 3 days, but latent for every opus-requesting session that gets re-routed to sonnet.

Tests: `go test ./...` green (26 packages).

🤖 Generated with [Claude Code](https://claude.com/claude-code)