### PR TITLE
fix(translate): unique message ids on Responses and chat-completions streaming paths

### DIFF
--- a/.claude/skills/debug-claude-session/SKILL.md
+++ b/.claude/skills/debug-claude-session/SKILL.md
@@ -132,10 +132,10 @@ From the `message.model` field (step 2), note the served model. This tells you:
 - **Which upstream** (e.g. `gpt-*` → OpenAI, `claude-*` → Anthropic, `gemini-*` → Google).
 - **Which translation code** handles it (e.g. `gpt-*` Responses → `internal/translate/responses_to_anthropic_writer.go`).
 
-Also note `message.id`:
-- `msg_responses` → OpenAI Responses API path.
-- `msg_anthropic` → Anthropic Messages path (passthrough).
-- `msg_gemini` → Google Generative Language API path.
+Also note `message.id` (ids are unique per response; the prefix marks the path):
+- `msg_responses_*` → OpenAI Responses API path (streaming).
+- `msg_translated_*` → OpenAI chat-completions path (router-generated id; upstream-provided ids pass through unchanged).
+- `msg_01...` (Anthropic-native id) → Anthropic Messages path (passthrough).
 
 ### 5. Fetch cloud logs for the matching UTC window
 

--- a/internal/translate/responses_outbound_test.go
+++ b/internal/translate/responses_outbound_test.go
@@ -232,6 +232,7 @@ func TestResponsesToAnthropicResponse(t *testing.T) {
 	require.NoError(t, json.Unmarshal(out, &msg))
 
 	assert.Equal(t, "message", msg["type"])
+	assert.Equal(t, "resp_abc", msg["id"], "upstream response id passes through as the message id")
 	assert.Equal(t, "tool_use", msg["stop_reason"], "a function_call output → stop_reason tool_use")
 	content, _ := msg["content"].([]any)
 	require.Len(t, content, 3)

--- a/internal/translate/responses_to_anthropic_writer.go
+++ b/internal/translate/responses_to_anthropic_writer.go
@@ -29,6 +29,15 @@ type ResponsesToAnthropicWriter struct {
 	bw           *bufio.Writer
 	requestModel string
 	usageSink    otel.UsageSink
+	// messageID is the Anthropic message id emitted in message_start. It is
+	// generated fresh per response: message_start fires eagerly from Prelude,
+	// before the upstream Responses connection produces a `resp_...` id, so a
+	// passthrough is impossible — but the id MUST be unique per response
+	// because clients (notably ccusage) dedupe usage records by message id. A
+	// constant id collapses every turn of a session into one record and
+	// massively undercounts tokens/cost. The "msg_responses_" prefix is kept
+	// as a route marker for transcript debugging.
+	messageID string
 
 	routingMarker        string
 	estimatedInputTokens int
@@ -99,6 +108,7 @@ func NewResponsesToAnthropicWriter(w http.ResponseWriter, requestModel string, s
 		bw:                  bufio.NewWriterSize(w, 8192),
 		requestModel:        requestModel,
 		usageSink:           sink,
+		messageID:           "msg_responses_" + randomHex(8),
 		statusCode:          http.StatusOK,
 		itemBlocks:          make(map[int]int),
 		itemKind:            make(map[int]string),
@@ -727,7 +737,7 @@ func extractFinalResponseObject(sseBytes []byte) []byte {
 func (t *ResponsesToAnthropicWriter) emitMessageStart() error {
 	model := t.requestModel
 	t.bw.WriteString("event: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"id\":")
-	sse.WriteJSONString(t.bw, "msg_responses")
+	sse.WriteJSONString(t.bw, t.messageID)
 	t.bw.WriteString(",\"type\":\"message\",\"role\":\"assistant\",\"content\":[],\"model\":")
 	sse.WriteJSONString(t.bw, model)
 	t.bw.WriteString(",\"stop_reason\":null,\"stop_sequence\":null,\"usage\":{\"input_tokens\":")

--- a/internal/translate/responses_to_anthropic_writer_stream_test.go
+++ b/internal/translate/responses_to_anthropic_writer_stream_test.go
@@ -140,6 +140,39 @@ func TestResponsesToAnthropicWriter_StreamingClient(t *testing.T) {
 	assert.Contains(t, body, `"content_block_start","index":2`)
 }
 
+// message_start ids must be unique per response. Clients (notably ccusage)
+// dedupe usage records by message id, so the old constant "msg_responses" id
+// collapsed every turn of a session into one record and massively undercounted
+// tokens/cost. The "msg_responses_" prefix is kept as a route marker.
+func TestResponsesToAnthropicWriter_MessageStartIDUniquePerResponse(t *testing.T) {
+	startID := func() string {
+		rec := httptest.NewRecorder()
+		w := translate.NewResponsesToAnthropicWriter(rec, "gpt-5.5", nil)
+		require.NoError(t, w.Prelude(true))
+		_, err := w.Write([]byte(responsesStreamFixture))
+		require.NoError(t, err)
+		require.NoError(t, w.Finalize())
+		for _, line := range strings.Split(rec.Body.String(), "\n") {
+			data, ok := strings.CutPrefix(line, "data: ")
+			if !ok || gjson.Get(data, "type").String() != "message_start" {
+				continue
+			}
+			id := gjson.Get(data, "message.id").String()
+			require.NotEmpty(t, id)
+			return id
+		}
+		t.Fatal("missing message_start event")
+		return ""
+	}
+
+	first := startID()
+	second := startID()
+	assert.True(t, strings.HasPrefix(first, "msg_responses_"),
+		"generated id keeps the route-marker prefix, got %q", first)
+	assert.NotEqual(t, "msg_responses", first, "constant placeholder id")
+	assert.NotEqual(t, first, second, "message ids must differ across responses")
+}
+
 // A non-streaming client gets a one-shot Anthropic JSON body reconstructed from
 // the terminal response.completed event in the (still-streamed) upstream.
 func TestResponsesToAnthropicWriter_NonStreamingClient(t *testing.T) {

--- a/internal/translate/stream.go
+++ b/internal/translate/stream.go
@@ -727,7 +727,8 @@ func (t *AnthropicSSETranslator) translateOpenAIEvent(raw []byte) error {
 	// in early SSE frames before settling on a real id. gjson treats that
 	// as Exists()=true, Str="", which would latch the empty string and
 	// prevent later non-empty ids from overwriting — leaving message_start
-	// to fall back to the "msg_translated" placeholder. Same for model.
+	// to fall back to a generated "msg_translated_*" placeholder. Same for
+	// model.
 	if id := gjson.GetBytes(data, "id"); id.Str != "" && t.messageID == "" {
 		t.messageID = strings.Clone(id.Str)
 	}
@@ -1197,9 +1198,16 @@ func (t *AnthropicSSETranslator) emitMessageStart() error {
 	if model == "" {
 		model = t.requestModel
 	}
+	// message_start usually fires eagerly from Prelude, before any upstream
+	// chunk carries an id, so a generated fallback is the common case. It MUST
+	// be unique per response: clients (notably ccusage) dedupe usage records
+	// by message id, so a constant placeholder collapses every turn of a
+	// session into one record and massively undercounts tokens/cost. The
+	// "msg_translated_" prefix is kept as a route marker for debugging.
 	id := t.messageID
 	if id == "" {
-		id = "msg_translated"
+		id = "msg_translated_" + randomHex(8)
+		t.messageID = id
 	}
 	observability.Get().Debug("AnthropicSSE emit", "event", "message_start")
 	t.bw.WriteString("event: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"id\":")

--- a/internal/translate/translate.go
+++ b/internal/translate/translate.go
@@ -180,7 +180,9 @@ func openAIToAnthropicResponse(body []byte, requestModel string, toolValidator *
 	}
 	id := gjson.GetBytes(body, "id").String()
 	if id == "" {
-		id = "msg_translated"
+		// Unique per response: clients (notably ccusage) dedupe usage records
+		// by message id, so a constant placeholder undercounts tokens/cost.
+		id = "msg_translated_" + randomHex(8)
 	}
 	model := gjson.GetBytes(body, "model").String()
 	if model == "" {

--- a/internal/translate/translate_test.go
+++ b/internal/translate/translate_test.go
@@ -469,6 +469,60 @@ func TestAnthropicSSETranslator_StreamingTextResponse(t *testing.T) {
 	assert.Contains(t, body, "event: message_stop")
 }
 
+// messageStartID extracts message.id from the first message_start event in an
+// Anthropic SSE body.
+func messageStartID(t *testing.T, body string) string {
+	t.Helper()
+	for _, line := range strings.Split(body, "\n") {
+		data, ok := strings.CutPrefix(line, "data: ")
+		if !ok {
+			continue
+		}
+		var frame struct {
+			Type    string `json:"type"`
+			Message struct {
+				ID string `json:"id"`
+			} `json:"message"`
+		}
+		if err := json.Unmarshal([]byte(data), &frame); err != nil || frame.Type != "message_start" {
+			continue
+		}
+		return frame.Message.ID
+	}
+	t.Fatal("missing message_start event")
+	return ""
+}
+
+// On the eager-Prelude path (the normal streaming dispatch), message_start
+// fires before any upstream chunk carries an id, so the translator generates
+// the message id itself. It must be unique per response — clients (notably
+// ccusage) dedupe usage records by message id, so a constant placeholder
+// collapses every turn of a session into one record and undercounts cost.
+func TestAnthropicSSETranslator_EagerPreludeMessageIDUniquePerResponse(t *testing.T) {
+	startID := func() string {
+		rec := httptest.NewRecorder()
+		translator := translate.NewAnthropicSSETranslator(rec, "gpt-4o", nil)
+		require.NoError(t, translator.Prelude(true))
+		events := []string{
+			"data: {\"id\":\"chatcmpl-1\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"Hello\"},\"finish_reason\":null}]}\n\n",
+			"data: {\"id\":\"chatcmpl-1\",\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"stop\"}]}\n\n",
+			"data: [DONE]\n\n",
+		}
+		for _, event := range events {
+			_, err := translator.Write([]byte(event))
+			require.NoError(t, err)
+		}
+		return messageStartID(t, rec.Body.String())
+	}
+
+	first := startID()
+	second := startID()
+	assert.True(t, strings.HasPrefix(first, "msg_translated_"),
+		"generated id keeps the route-marker prefix, got %q", first)
+	assert.NotEqual(t, "msg_translated", first, "constant placeholder id")
+	assert.NotEqual(t, first, second, "message ids must differ across responses")
+}
+
 func TestAnthropicSSETranslator_StreamingToolUse(t *testing.T) {
 	rec := httptest.NewRecorder()
 	translator := translate.NewAnthropicSSETranslator(rec, "gpt-4o", nil)


### PR DESCRIPTION
## Problem

Found in a customer benchmark audit (2026-06-10): every assistant message served via the OpenAI Responses streaming path carries the constant message id `msg_responses` — one transcript had **79 assistant events, all with the same id**.

ccusage (the cost-accounting tool Claude Code users run) dedupes usage records by message id, so it collapses all of those turns into a single record. Observed impact: **117k reported vs 533k actual input tokens** for one session. Customer-facing cost reporting is silently wrong for any session routed through this path.

While auditing the other translators, the chat-completions streaming path turned out to have the identical bug: `AnthropicSSETranslator.Prelude` emits `message_start` eagerly (before any upstream chunk carries an id), so its `msg_translated` fallback was effectively the constant id for **every** cross-format streaming turn (all OSS/openai-compat routed models), not a rare edge case. The non-streaming Responses path (upstream `resp_*` id passthrough) and the Gemini path (`generateAnthropicMsgID()` = `msg_` + crypto/rand hex) were already unique.

## Fix

`message_start` fires before the upstream connection produces an id, so passthrough is impossible there. Instead, generate a unique crypto/rand id per response (reusing the existing `randomHex` helper that `generateAnthropicMsgID` is built on), keeping a path prefix as a transcript-debugging route marker:

- Responses streaming: `msg_responses` → `msg_responses_<hex8>` (per-writer, set at construction)
- chat-completions streaming eager-Prelude fallback: `msg_translated` → `msg_translated_<hex8>`
- chat-completions non-streaming fallback (upstream omitted id): same
- Upstream ids still pass through unchanged wherever they are available (non-streaming Responses, lazy-start streaming, non-streaming chat completions).

Updated the `debug-claude-session` skill doc, which keyed on the literal ids as route markers (its `msg_anthropic`/`msg_gemini` entries were stale — those constants don't exist in code).

## Safety checks

- **Loop detection / no-progress fingerprinting do not key on message id**: the cyclic-loop detector fingerprints tool name + canonical-arg hash per session key; the no-progress detector hashes (model, provider, message count, tool-progress marker, prompt prefix). Verified in `internal/proxy/loop_detection.go`, `internal/proxy/no_progress.go`, `internal/translate/loop_detection.go` (the latter matches the `toolu_router_nudge_` prefix only, which is preserved).
- **Conformance goldens unaffected**: `redactVolatile` already replaces `message`/`message_start` ids with `<id>`, so no golden updates needed (suite passes unchanged).
- No other code references the literal `msg_responses` / `msg_translated` values.

## Tests

- `TestResponsesToAnthropicWriter_MessageStartIDUniquePerResponse`: two translated streams get different `message_start` ids, both `msg_responses_*`-prefixed.
- `TestAnthropicSSETranslator_EagerPreludeMessageIDUniquePerResponse`: same for the eager-Prelude chat-completions path.
- `TestResponsesToAnthropicResponse`: now also asserts the upstream `resp_abc` id passes through as the message id.
- `go build ./...` and `go test ./...` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)