### PR TITLE
feat(telemetry): persist turn_type on request telemetry

### DIFF
--- a/db/migrations/0016_telemetry-turn-type.down.sql
+++ b/db/migrations/0016_telemetry-turn-type.down.sql
@@ -1,0 +1,6 @@
+BEGIN;
+
+ALTER TABLE router.model_router_request_telemetry
+    DROP COLUMN turn_type;
+
+COMMIT;

--- a/db/migrations/0016_telemetry-turn-type.up.sql
+++ b/db/migrations/0016_telemetry-turn-type.up.sql
@@ -1,0 +1,6 @@
+BEGIN;
+
+ALTER TABLE router.model_router_request_telemetry
+    ADD COLUMN turn_type VARCHAR;
+
+COMMIT;

--- a/db/queries/model_router_request_telemetry.sql
+++ b/db/queries/model_router_request_telemetry.sql
@@ -3,6 +3,9 @@
 -- chosen_score, candidate_scores, propensity, alpha_breakdown,
 -- cluster_router_version, ttft_ms, cache_*_tokens, device_id, session_id) are
 -- nullable; non-cluster decisions and pinned-route turns leave them NULL.
+-- turn_type is the turntype classification (main_loop, tool_result, probe,
+-- title_gen, compaction, classifier, sub_agent_dispatch); NULL only on rows
+-- written before the column existed.
 -- name: InsertRequestTelemetry :exec
 INSERT INTO router.model_router_request_telemetry (
     installation_id,
@@ -41,7 +44,8 @@ INSERT INTO router.model_router_request_telemetry (
     device_id,
     session_id,
     router_user_id,
-    client_app
+    client_app,
+    turn_type
 ) VALUES (
     @installation_id::uuid,
     @request_id::varchar,
@@ -79,7 +83,8 @@ INSERT INTO router.model_router_request_telemetry (
     sqlc.narg('device_id')::varchar,
     sqlc.narg('session_id')::varchar,
     sqlc.narg('router_user_id')::uuid,
-    sqlc.narg('client_app')::text
+    sqlc.narg('client_app')::text,
+    @turn_type::varchar
 )
 ON CONFLICT (installation_id, request_id, span_type) DO NOTHING;
 
@@ -221,6 +226,7 @@ SELECT
     t.upstream_status_code,
     t.router_user_id,
     t.client_app,
+    COALESCE(t.turn_type, '')::varchar AS turn_type,
     u.email AS user_email
 FROM router.model_router_request_telemetry t
 LEFT JOIN router.model_router_users u
@@ -252,6 +258,7 @@ SELECT
     t.upstream_status_code,
     t.router_user_id,
     t.client_app,
+    COALESCE(t.turn_type, '')::varchar AS turn_type,
     u.email AS user_email
 FROM router.model_router_request_telemetry t
 LEFT JOIN router.model_router_users u

--- a/frontend/src/components/charts/DrillDownModal.tsx
+++ b/frontend/src/components/charts/DrillDownModal.tsx
@@ -98,6 +98,30 @@ function ClientAppLabel({ clientApp }: { clientApp: string }) {
   return <>{CLIENT_APP_LABEL[clientApp] ?? clientApp}</>;
 }
 
+/** Turn-type value → display label. Mirrors `internal/router/turntype` on the
+ *  Go side. System turn types (probe, title_gen, compaction, classifier) are
+ *  automated traffic — render them muted so user turns stand out. */
+const TURN_TYPE_LABEL: Record<string, string> = {
+  main_loop: "Main loop",
+  tool_result: "Tool result",
+  sub_agent_dispatch: "Subagent",
+  compaction: "Compaction",
+  probe: "Probe",
+  title_gen: "Title gen",
+  classifier: "Classifier",
+};
+
+const SYSTEM_TURN_TYPES = new Set(["probe", "title_gen", "compaction", "classifier"]);
+
+function TurnTypeLabel({ turnType }: { turnType: string }) {
+  if (turnType === "") return <>—</>;
+  const label = TURN_TYPE_LABEL[turnType] ?? turnType;
+  if (SYSTEM_TURN_TYPES.has(turnType)) {
+    return <span className="text-muted-foreground">{label}</span>;
+  }
+  return <>{label}</>;
+}
+
 /** Renders the user identity for a drill-down row: the linked email when the
  *  router resolved one, otherwise an em dash. */
 function UserLabel({ email }: { email: string }) {
@@ -116,6 +140,7 @@ const COLUMNS: ColumnDef[] = [
   { key: "time", label: "Time", className: "w-[160px]" },
   { key: "user", label: "User" },
   { key: "tool", label: "AI tool" },
+  { key: "turn_type", label: "Turn type" },
   { key: "requested", label: "Requested model" },
   { key: "decision", label: "Decision model" },
   { key: "provider", label: "Provider" },
@@ -224,6 +249,9 @@ export function DrillDownModal({
                       </td>
                       <td className="whitespace-nowrap px-4 py-3">
                         <ClientAppLabel clientApp={r.client_app} />
+                      </td>
+                      <td className="whitespace-nowrap px-4 py-3">
+                        <TurnTypeLabel turnType={r.turn_type} />
                       </td>
                       <td className="whitespace-nowrap px-4 py-3">{r.requested_model || "—"}</td>
                       <td

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -70,6 +70,7 @@ export interface MetricsDetailRow {
   upstream_status_code: number;
   router_user_id: string;
   client_app: string;
+  turn_type: string;
   user_email: string;
 }
 

--- a/internal/api/admin/metrics.go
+++ b/internal/api/admin/metrics.go
@@ -119,6 +119,7 @@ type metricsDetailRow struct {
 	UpstreamStatusCode  int32   `json:"upstream_status_code"`
 	RouterUserID        string  `json:"router_user_id"`
 	ClientApp           string  `json:"client_app"`
+	TurnType            string  `json:"turn_type"`
 	UserEmail           string  `json:"user_email"`
 }
 
@@ -180,6 +181,7 @@ func MetricsDetailsHandler(proxySvc *proxy.Service) gin.HandlerFunc {
 				UpstreamStatusCode:  r.UpstreamStatusCode,
 				RouterUserID:        r.RouterUserID,
 				ClientApp:           r.ClientApp,
+				TurnType:            r.TurnType,
 				UserEmail:           r.UserEmail,
 			})
 		}

--- a/internal/postgres/telemetry.go
+++ b/internal/postgres/telemetry.go
@@ -88,6 +88,7 @@ func (r *TelemetryRepo) InsertRequestTelemetry(ctx context.Context, p proxy.Inse
 		SessionID:              stringPtrOrNil(p.SessionID),
 		RouterUserID:           uuidOrNil(p.RouterUserID),
 		ClientApp:              stringPtrOrNil(p.ClientApp),
+		TurnType:               p.TurnType,
 	})
 }
 
@@ -324,6 +325,7 @@ func (r *TelemetryRepo) GetTelemetryRows(ctx context.Context, installationID str
 			row.UpstreamStatusCode,
 			uuidString(row.RouterUserID),
 			row.ClientApp,
+			row.TurnType,
 			row.UserEmail,
 		))
 	}
@@ -361,6 +363,7 @@ func (r *TelemetryRepo) GetTelemetryRowsAll(ctx context.Context, from, to time.T
 			row.UpstreamStatusCode,
 			uuidString(row.RouterUserID),
 			row.ClientApp,
+			row.TurnType,
 			row.UserEmail,
 		))
 	}
@@ -387,6 +390,7 @@ func telemetryRowFromRow(
 	upstreamStatusCode *int32,
 	routerUserID string,
 	clientApp *string,
+	turnType string,
 	userEmail *string,
 ) proxy.TelemetryRow {
 	deref := func(s *string) string {
@@ -426,6 +430,7 @@ func telemetryRowFromRow(
 		UpstreamStatusCode:  derefInt32(upstreamStatusCode),
 		RouterUserID:        routerUserID,
 		ClientApp:           deref(clientApp),
+		TurnType:            turnType,
 		UserEmail:           deref(userEmail),
 	}
 }

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -1545,6 +1545,7 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 			SessionID:              clientID.SessionID,
 			RouterUserID:           auth.UserIDFrom(ctx),
 			ClientApp:              clientID.ClientApp,
+			TurnType:               string(routeRes.TurnType),
 		})
 	}
 
@@ -2535,6 +2536,7 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 			SessionID:              clientID.SessionID,
 			RouterUserID:           auth.UserIDFrom(ctx),
 			ClientApp:              clientID.ClientApp,
+			TurnType:               string(routeRes.TurnType),
 		})
 	}
 

--- a/internal/proxy/service_observation_test.go
+++ b/internal/proxy/service_observation_test.go
@@ -258,3 +258,53 @@ func TestProxyMessages_NoMetadataOmitsClusterFields(t *testing.T) {
 	assert.Nil(t, row.CandidateScores)
 	assert.Nil(t, row.Propensity)
 }
+
+// TestProxyMessages_PersistsTurnType asserts the turntype classification
+// lands on the telemetry row, so dashboard/analytics queries can separate
+// automated turns (probe, title_gen, compaction, classifier) from user
+// traffic when computing per-model shares.
+func TestProxyMessages_PersistsTurnType(t *testing.T) {
+	const installID = "55555555-5555-5555-5555-555555555555"
+	decision := router.Decision{
+		Provider: providers.ProviderAnthropic,
+		Model:    "claude-haiku-4-5",
+		Reason:   "pin",
+	}
+
+	cases := []struct {
+		name     string
+		body     string
+		turnType string
+	}{
+		{
+			name:     "main loop",
+			body:     `{"model":"claude-opus-4-7","messages":[{"role":"user","content":"hello"}]}`,
+			turnType: "main_loop",
+		},
+		{
+			name:     "probe",
+			body:     `{"model":"claude-opus-4-7","max_tokens":1,"messages":[{"role":"user","content":"quota"}]}`,
+			turnType: "probe",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			telem := newCaptureTelemetry()
+			svc := proxy.NewService(
+				&fakeRouter{decision: decision},
+				map[string]providers.Client{providers.ProviderAnthropic: &fakeProvider{}},
+				nil, false, nil, nil, false,
+				providers.ProviderAnthropic, "claude-haiku-4-5",
+				telem,
+			)
+
+			ctx := context.WithValue(context.Background(), proxy.InstallationIDContextKey{}, installID)
+			rec := httptest.NewRecorder()
+			httpReq := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(""))
+			require.NoError(t, svc.ProxyMessages(ctx, []byte(tc.body), rec, httpReq))
+
+			row := telem.firstRow(t)
+			assert.Equal(t, tc.turnType, row.TurnType)
+		})
+	}
+}

--- a/internal/proxy/telemetry.go
+++ b/internal/proxy/telemetry.go
@@ -59,6 +59,7 @@ type InsertTelemetryParams struct {
 	SessionID            string
 	RouterUserID         string
 	ClientApp            string
+	TurnType             string
 }
 
 // TelemetrySummary holds aggregated totals for the dashboard cards.
@@ -96,5 +97,6 @@ type TelemetryRow struct {
 	UpstreamStatusCode  int32
 	RouterUserID        string
 	ClientApp           string
+	TurnType            string
 	UserEmail           string
 }

--- a/internal/sqlc/model_router_request_telemetry.sql.go
+++ b/internal/sqlc/model_router_request_telemetry.sql.go
@@ -31,6 +31,7 @@ SELECT
     t.upstream_status_code,
     t.router_user_id,
     t.client_app,
+    COALESCE(t.turn_type, '')::varchar AS turn_type,
     u.email AS user_email
 FROM router.model_router_request_telemetry t
 LEFT JOIN router.model_router_users u
@@ -69,6 +70,7 @@ type GetTelemetryRowsRow struct {
 	UpstreamStatusCode  *int32
 	RouterUserID        pgtype.UUID
 	ClientApp           *string
+	TurnType            string
 	UserEmail           *string
 }
 
@@ -92,6 +94,7 @@ type GetTelemetryRowsRow struct {
 //	    t.upstream_status_code,
 //	    t.router_user_id,
 //	    t.client_app,
+//	    COALESCE(t.turn_type, '')::varchar AS turn_type,
 //	    u.email AS user_email
 //	FROM router.model_router_request_telemetry t
 //	LEFT JOIN router.model_router_users u
@@ -135,6 +138,7 @@ func (q *Queries) GetTelemetryRows(ctx context.Context, arg GetTelemetryRowsPara
 			&i.UpstreamStatusCode,
 			&i.RouterUserID,
 			&i.ClientApp,
+			&i.TurnType,
 			&i.UserEmail,
 		); err != nil {
 			return nil, err
@@ -166,6 +170,7 @@ SELECT
     t.upstream_status_code,
     t.router_user_id,
     t.client_app,
+    COALESCE(t.turn_type, '')::varchar AS turn_type,
     u.email AS user_email
 FROM router.model_router_request_telemetry t
 LEFT JOIN router.model_router_users u
@@ -202,6 +207,7 @@ type GetTelemetryRowsAllRow struct {
 	UpstreamStatusCode  *int32
 	RouterUserID        pgtype.UUID
 	ClientApp           *string
+	TurnType            string
 	UserEmail           *string
 }
 
@@ -227,6 +233,7 @@ type GetTelemetryRowsAllRow struct {
 //	    t.upstream_status_code,
 //	    t.router_user_id,
 //	    t.client_app,
+//	    COALESCE(t.turn_type, '')::varchar AS turn_type,
 //	    u.email AS user_email
 //	FROM router.model_router_request_telemetry t
 //	LEFT JOIN router.model_router_users u
@@ -264,6 +271,7 @@ func (q *Queries) GetTelemetryRowsAll(ctx context.Context, arg GetTelemetryRowsA
 			&i.UpstreamStatusCode,
 			&i.RouterUserID,
 			&i.ClientApp,
+			&i.TurnType,
 			&i.UserEmail,
 		); err != nil {
 			return nil, err
@@ -778,7 +786,8 @@ INSERT INTO router.model_router_request_telemetry (
     device_id,
     session_id,
     router_user_id,
-    client_app
+    client_app,
+    turn_type
 ) VALUES (
     $1::uuid,
     $2::varchar,
@@ -816,7 +825,8 @@ INSERT INTO router.model_router_request_telemetry (
     $34::varchar,
     $35::varchar,
     $36::uuid,
-    $37::text
+    $37::text,
+    $38::varchar
 )
 ON CONFLICT (installation_id, request_id, span_type) DO NOTHING
 `
@@ -859,6 +869,7 @@ type InsertRequestTelemetryParams struct {
 	SessionID              *string
 	RouterUserID           pgtype.UUID
 	ClientApp              *string
+	TurnType               string
 }
 
 // Records a completed proxied request for the dashboard UI and routing
@@ -866,6 +877,9 @@ type InsertRequestTelemetryParams struct {
 // chosen_score, candidate_scores, propensity, alpha_breakdown,
 // cluster_router_version, ttft_ms, cache_*_tokens, device_id, session_id) are
 // nullable; non-cluster decisions and pinned-route turns leave them NULL.
+// turn_type is the turntype classification (main_loop, tool_result, probe,
+// title_gen, compaction, classifier, sub_agent_dispatch); NULL only on rows
+// written before the column existed.
 //
 //	INSERT INTO router.model_router_request_telemetry (
 //	    installation_id,
@@ -904,7 +918,8 @@ type InsertRequestTelemetryParams struct {
 //	    device_id,
 //	    session_id,
 //	    router_user_id,
-//	    client_app
+//	    client_app,
+//	    turn_type
 //	) VALUES (
 //	    $1::uuid,
 //	    $2::varchar,
@@ -942,7 +957,8 @@ type InsertRequestTelemetryParams struct {
 //	    $34::varchar,
 //	    $35::varchar,
 //	    $36::uuid,
-//	    $37::text
+//	    $37::text,
+//	    $38::varchar
 //	)
 //	ON CONFLICT (installation_id, request_id, span_type) DO NOTHING
 func (q *Queries) InsertRequestTelemetry(ctx context.Context, arg InsertRequestTelemetryParams) error {
@@ -984,6 +1000,7 @@ func (q *Queries) InsertRequestTelemetry(ctx context.Context, arg InsertRequestT
 		arg.SessionID,
 		arg.RouterUserID,
 		arg.ClientApp,
+		arg.TurnType,
 	)
 	return err
 }

--- a/internal/sqlc/models.go
+++ b/internal/sqlc/models.go
@@ -117,6 +117,7 @@ type RouterModelRouterRequestTelemetry struct {
 	Propensity             *float64
 	RouterUserID           pgtype.UUID
 	ClientApp              *string
+	TurnType               *string
 }
 
 // End-user identities seen on inbound requests, scoped to an installation. Replaces the per-user API key pattern.


### PR DESCRIPTION
## Why

Probe pings, title-gen, compaction, and classifier turns land in `model_router_request_telemetry` indistinguishable from real user turns. Since those are all hard-pinned to cheap models, any per-model share computed over the table makes Haiku look chosen for user queries far more often than it actually is. The classification already exists at request time (`turntype.DetectFromEnvelope`) — it just was never persisted.

## What

- Migration `0016`: nullable `turn_type VARCHAR` on `router.model_router_request_telemetry` (NULL = rows written before the column existed)
- Populate it from `routeRes.TurnType` at both `fireTelemetry` call sites (Anthropic + OpenAI ingress)
- Expose it in `GetTelemetryRows{,All}`, the `/admin/v1/metrics/details` response, and as a "Turn type" column in the dashboard drill-down (system turn types render muted)
- Summary/timeseries aggregates are intentionally unchanged — system turns are real spend

Exclude automated traffic in analysis with:

```sql
WHERE turn_type NOT IN ('probe', 'title_gen', 'compaction', 'classifier')
```

## Testing

- `make check` (generate, fmt, vet, build, test) passes
- New `TestProxyMessages_PersistsTurnType` pins main_loop and probe classification onto the telemetry row
- `tsc --noEmit` clean on the dashboard frontend

🤖 Generated with [Claude Code](https://claude.com/claude-code)