### PR TITLE
fix(providers): idle-progress watchdog for zero-token mid-stream stalls on /v1/responses

### DIFF
--- a/internal/providers/httputil/httputil.go
+++ b/internal/providers/httputil/httputil.go
@@ -25,7 +25,11 @@ const FlushChunk = 4 * 1024
 // errors.Is(err, httputil.ErrUpstreamIdleTimeout) (or context.Cause(ctx)) to
 // distinguish a real upstream stall from caller-initiated cancellation, and
 // the proxy's failover logic keys on this to retry against the next binding.
-var ErrUpstreamIdleTimeout = errors.New("upstream sse idle timeout")
+//
+// Aliases providers.ErrUpstreamIdleTimeout — the sentinel lives there so
+// providers.IsRetryable can classify it explicitly without an import cycle
+// (this package imports providers). errors.Is matches against either name.
+var ErrUpstreamIdleTimeout = providers.ErrUpstreamIdleTimeout
 
 // DefaultSSEIdleTimeout is the per-read inactivity threshold for streaming
 // upstream responses. AWS NAT Gateway / NLB / VPC-endpoint reapers silently
@@ -35,16 +39,31 @@ var ErrUpstreamIdleTimeout = errors.New("upstream sse idle timeout")
 //
 // Tunable via ROUTER_SSE_IDLE_TIMEOUT_SECONDS. Healthy generations stream a
 // chunk at least every few seconds, so 45s of silence is unambiguously a stall.
-var DefaultSSEIdleTimeout = sseIdleTimeoutFromEnv()
+var DefaultSSEIdleTimeout = idleTimeoutFromEnv("ROUTER_SSE_IDLE_TIMEOUT_SECONDS", 45*time.Second)
 
-func sseIdleTimeoutFromEnv() time.Duration {
-	v := os.Getenv("ROUTER_SSE_IDLE_TIMEOUT_SECONDS")
+// DefaultResponsesSSEIdleTimeout is the idle-progress threshold for OpenAI
+// Responses API (/v1/responses) streams. More generous than
+// DefaultSSEIdleTimeout because a gpt-5.x reasoning turn can go tens of
+// seconds between SSE frames while the model thinks (reasoning-summary deltas
+// lag the actual reasoning). ANY received bytes count as progress — event
+// frames, reasoning deltas, keepalives — so only a zero-progress gap trips
+// it. The real stalls observed in prod (2026-06-09: two /v1/responses streams
+// at zero output tokens until the 600s request cap) produced no bytes at all,
+// so 90s separates them cleanly from healthy long-thinking turns.
+//
+// Tunable via ROUTER_RESPONSES_SSE_IDLE_TIMEOUT_SECONDS.
+var DefaultResponsesSSEIdleTimeout = idleTimeoutFromEnv("ROUTER_RESPONSES_SSE_IDLE_TIMEOUT_SECONDS", 90*time.Second)
+
+// idleTimeoutFromEnv reads a whole-seconds override from envVar, falling back
+// to fallback when unset, unparsable, or non-positive.
+func idleTimeoutFromEnv(envVar string, fallback time.Duration) time.Duration {
+	v := os.Getenv(envVar)
 	if v == "" {
-		return 45 * time.Second
+		return fallback
 	}
 	n, err := strconv.Atoi(v)
 	if err != nil || n <= 0 {
-		return 45 * time.Second
+		return fallback
 	}
 	return time.Duration(n) * time.Second
 }

--- a/internal/providers/httputil/httputil_test.go
+++ b/internal/providers/httputil/httputil_test.go
@@ -179,17 +179,30 @@ func TestStartIdleWatchdog_DoesNotFireWhenMarked(t *testing.T) {
 
 func TestSSEIdleTimeoutFromEnv_DefaultsTo45s(t *testing.T) {
 	t.Setenv("ROUTER_SSE_IDLE_TIMEOUT_SECONDS", "")
-	assert.Equal(t, 45*time.Second, sseIdleTimeoutFromEnv())
+	assert.Equal(t, 45*time.Second, idleTimeoutFromEnv("ROUTER_SSE_IDLE_TIMEOUT_SECONDS", 45*time.Second))
 }
 
 func TestSSEIdleTimeoutFromEnv_OverrideRespected(t *testing.T) {
 	t.Setenv("ROUTER_SSE_IDLE_TIMEOUT_SECONDS", "10")
-	assert.Equal(t, 10*time.Second, sseIdleTimeoutFromEnv())
+	assert.Equal(t, 10*time.Second, idleTimeoutFromEnv("ROUTER_SSE_IDLE_TIMEOUT_SECONDS", 45*time.Second))
 }
 
 func TestSSEIdleTimeoutFromEnv_BadValueFallsBack(t *testing.T) {
 	t.Setenv("ROUTER_SSE_IDLE_TIMEOUT_SECONDS", "garbage")
-	assert.Equal(t, 45*time.Second, sseIdleTimeoutFromEnv())
+	assert.Equal(t, 45*time.Second, idleTimeoutFromEnv("ROUTER_SSE_IDLE_TIMEOUT_SECONDS", 45*time.Second))
+}
+
+func TestResponsesSSEIdleTimeoutFromEnv_OverrideRespected(t *testing.T) {
+	t.Setenv("ROUTER_RESPONSES_SSE_IDLE_TIMEOUT_SECONDS", "120")
+	assert.Equal(t, 120*time.Second, idleTimeoutFromEnv("ROUTER_RESPONSES_SSE_IDLE_TIMEOUT_SECONDS", 90*time.Second))
+}
+
+// IsRetryable must see idle-timeout stalls as retryable through the alias —
+// this is what lets dispatchWithFallback rescue a mid-stream stall on the
+// next binding (prod incident 2026-06-09).
+func TestErrUpstreamIdleTimeout_AliasIsRetryable(t *testing.T) {
+	assert.True(t, errors.Is(ErrUpstreamIdleTimeout, providers.ErrUpstreamIdleTimeout))
+	assert.True(t, providers.IsRetryable(ErrUpstreamIdleTimeout))
 }
 
 // Sanity guard: ensure the exported sentinel is actually used.

--- a/internal/providers/openai/client.go
+++ b/internal/providers/openai/client.go
@@ -36,6 +36,13 @@ type Client struct {
 	apiKey  string
 	baseURL string
 	http    *http.Client
+	// sseIdleTimeout, when > 0, overrides the per-endpoint idle-progress
+	// threshold (httputil.DefaultSSEIdleTimeout for chat/completions,
+	// httputil.DefaultResponsesSSEIdleTimeout for /v1/responses). Production
+	// always uses the defaults via NewClient; tests inject a small value to
+	// exercise the mid-stream stall watchdog without waiting out the real
+	// threshold (mirrors the header-timeout injection below).
+	sseIdleTimeout time.Duration
 }
 
 func NewClient(apiKey, baseURL string) *Client {
@@ -56,6 +63,27 @@ func NewClientWithResponseHeaderTimeout(apiKey, baseURL string, headerTimeout ti
 		baseURL: baseURL,
 		http:    &http.Client{Transport: httputil.NewTransportWithResponseHeaderTimeout(5*time.Second, 5*time.Second, headerTimeout)},
 	}
+}
+
+// NewClientWithTimeouts is NewClientWithResponseHeaderTimeout with an
+// additional injected SSE idle-progress threshold; see Client.sseIdleTimeout.
+func NewClientWithTimeouts(apiKey, baseURL string, headerTimeout, sseIdleTimeout time.Duration) *Client {
+	c := NewClientWithResponseHeaderTimeout(apiKey, baseURL, headerTimeout)
+	c.sseIdleTimeout = sseIdleTimeout
+	return c
+}
+
+// idleTimeoutFor picks the idle-progress watchdog threshold for the upstream
+// endpoint. /v1/responses gets the more generous reasoning budget — see
+// httputil.DefaultResponsesSSEIdleTimeout.
+func (c *Client) idleTimeoutFor(endpoint providers.Endpoint) time.Duration {
+	if c.sseIdleTimeout > 0 {
+		return c.sseIdleTimeout
+	}
+	if endpoint == providers.EndpointResponses {
+		return httputil.DefaultResponsesSSEIdleTimeout
+	}
+	return httputil.DefaultSSEIdleTimeout
 }
 
 // setAuth applies authentication to the upstream request. Precedence:
@@ -126,6 +154,7 @@ func (c *Client) Proxy(ctx context.Context, decision router.Decision, prep provi
 	defer resp.Body.Close()
 	t.StampUpstreamHeaders()
 
+	idleTimeout := c.idleTimeoutFor(prep.Endpoint)
 	log := observability.Get()
 	log.Debug("OpenAI upstream response",
 		"status", resp.StatusCode,
@@ -143,7 +172,18 @@ func (c *Client) Proxy(ctx context.Context, decision router.Decision, prep provi
 	// to the prelude buffer, and silently drops the upstream error body —
 	// neither debugging signal nor failover survive.
 	if resp.StatusCode >= 400 {
-		bufBody, totalRead, drainErr := readCapped(resp.Body, providers.MaxBufferedErrorBytes)
+		// Guard the error-body read with the same idle watchdog as the
+		// streaming path below: readCapped's blocking reads would otherwise
+		// hang indefinitely on an upstream that returns error headers and
+		// then stalls the body — the response-header timeout no longer
+		// applies once headers have arrived.
+		mark, stop := httputil.StartIdleWatchdog(ctx, cancel, idleTimeout)
+		body := &progressReader{r: resp.Body, mark: mark}
+		bufBody, totalRead, drainErr := readCapped(body, providers.MaxBufferedErrorBytes)
+		stop()
+		if errors.Is(context.Cause(ctx), httputil.ErrUpstreamIdleTimeout) {
+			logStreamStall(decision.Model, path, idleTimeout, totalRead)
+		}
 		if len(bufBody) > 0 {
 			t.StampUpstreamFirstByte()
 		}
@@ -173,10 +213,15 @@ func (c *Client) Proxy(ctx context.Context, decision router.Decision, prep provi
 
 	// Manual stream loop for per-chunk diagnostics; non-debug takes the fast path.
 	if !log.Enabled(ctx, slog.LevelDebug) {
-		return httputil.StreamBody(ctx, cancel, httputil.DefaultSSEIdleTimeout, resp.Body, status, w, t)
+		body := &progressReader{r: resp.Body}
+		streamErr := httputil.StreamBody(ctx, cancel, idleTimeout, body, status, w, t)
+		if errors.Is(streamErr, httputil.ErrUpstreamIdleTimeout) {
+			logStreamStall(decision.Model, path, idleTimeout, body.n)
+		}
+		return streamErr
 	}
 
-	mark, stop := httputil.StartIdleWatchdog(ctx, cancel, httputil.DefaultSSEIdleTimeout)
+	mark, stop := httputil.StartIdleWatchdog(ctx, cancel, idleTimeout)
 	defer stop()
 
 	flusher, _ := w.(http.Flusher)
@@ -212,13 +257,53 @@ func (c *Client) Proxy(ctx context.Context, decision router.Decision, prep provi
 		}
 		if readErr != nil {
 			if cause := context.Cause(ctx); errors.Is(cause, httputil.ErrUpstreamIdleTimeout) {
-				log.Debug("OpenAI upstream sse idle", "bytes_read", bytesRead)
+				logStreamStall(decision.Model, path, idleTimeout, int64(bytesRead))
 				return httputil.ErrUpstreamIdleTimeout
 			}
 			log.Debug("OpenAI upstream read failed", "err", readErr, "bytes_read", bytesRead)
 			return readErr
 		}
 	}
+}
+
+// progressReader counts upstream bytes and reports each successful read as
+// watchdog progress. The byte count feeds the stall log's bytes_received
+// field; mark (optional, nil-safe) feeds StartIdleWatchdog on paths that do
+// not go through StreamBody's built-in marking. Single-goroutine use only —
+// the count is read by the same goroutine after the stream loop returns.
+type progressReader struct {
+	r    io.Reader
+	mark func()
+	n    int64
+}
+
+func (p *progressReader) Read(buf []byte) (n int, err error) {
+	n, err = p.r.Read(buf)
+	if n > 0 {
+		p.n += int64(n)
+		if p.mark != nil {
+			p.mark()
+		}
+	}
+	return n, err
+}
+
+// logStreamStall reports an SSE idle-watchdog trip at ERROR: the upstream
+// accepted the request and returned headers, then produced zero bytes for the
+// full idle budget (prod incident 2026-06-09: two /v1/responses streams sat
+// at zero output tokens until the 600s request cap, burning 10 minutes of the
+// customer's agent budget each). The returned ErrUpstreamIdleTimeout is
+// classified retryable, so dispatchWithFallback re-attempts when nothing has
+// been committed to the client; this log is the paper trail for how often
+// that happens per model.
+func logStreamStall(model, path string, idleTimeout time.Duration, bytesReceived int64) {
+	observability.Get().Error("OpenAI upstream stream stalled mid-response; aborting for retry",
+		"model", model,
+		"provider", providers.ProviderOpenAI,
+		"path", path,
+		"idle_ms", idleTimeout.Milliseconds(),
+		"bytes_received", bytesReceived,
+	)
 }
 
 func truncateBytes(b []byte, n int) string {

--- a/internal/providers/openai/client_stall_test.go
+++ b/internal/providers/openai/client_stall_test.go
@@ -1,0 +1,157 @@
+package openai_test
+
+// Guards the mid-stream half of the gpt-5.x stall protection (the
+// time-to-first-byte half lives in client_timeout_test.go). Prod incident
+// 2026-06-09 (customer benchmark org): two /v1/responses streams returned
+// headers and then produced ZERO output tokens until the router's 600s cap
+// (proxy_ms 599,991 and 599,880, both resp_output_tokens=0). The
+// ResponseHeaderTimeout cannot fire once headers have arrived, so the only
+// guard against a post-header stall is the idle-progress watchdog. These
+// tests pin its contract: a zero-progress stall aborts at the idle threshold,
+// the error is retryable (so dispatchWithFallback re-attempts), and no
+// response bytes reach the client writer; a slow-but-flowing stream — long
+// reasoning turns emit SSE event frames even while "thinking", and ANY bytes
+// count as progress — is never aborted; and a stalled >=400 error body cannot
+// hang the buffered-error read.
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"workweave/router/internal/providers"
+	"workweave/router/internal/providers/httputil"
+	"workweave/router/internal/providers/openai"
+	"workweave/router/internal/router"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const stallTestHeaderTimeout = 5 * time.Second
+
+func responsesPrep() providers.PreparedRequest {
+	return providers.PreparedRequest{
+		Body:     []byte(`{"model":"gpt-5.5","stream":true}`),
+		Headers:  make(http.Header),
+		Endpoint: providers.EndpointResponses,
+	}
+}
+
+func TestProxy_MidStreamStallAbortsRetryableNothingWritten(t *testing.T) {
+	// The upstream commits 200 + SSE headers, then goes silent forever. The
+	// only timer in play is the injected tiny idle threshold; release is
+	// closed (defer, LIFO) before upstream.Close() so the handler unblocks
+	// even if the watchdog's cancel didn't already end its request context.
+	release := make(chan struct{})
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		w.(http.Flusher).Flush()
+		select {
+		case <-release:
+		case <-r.Context().Done():
+		}
+	}))
+	defer upstream.Close()
+	defer close(release)
+
+	const idleTimeout = 100 * time.Millisecond
+	c := openai.NewClientWithTimeouts("test-key", upstream.URL, stallTestHeaderTimeout, idleTimeout)
+	rec := httptest.NewRecorder()
+	clientReq := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(""))
+
+	start := time.Now()
+	err := c.Proxy(context.Background(), router.Decision{Model: "gpt-5.5"}, responsesPrep(), rec, clientReq)
+	elapsed := time.Since(start)
+
+	require.Error(t, err, "a post-header zero-progress stall must surface an error, not hang")
+	assert.ErrorIs(t, err, httputil.ErrUpstreamIdleTimeout)
+	assert.True(t, providers.IsRetryable(err),
+		"the stall must classify retryable so dispatchWithFallback can re-attempt the binding")
+	assert.GreaterOrEqual(t, elapsed, idleTimeout, "must not abort before the idle threshold")
+	assert.Less(t, elapsed, stallTestHeaderTimeout,
+		"must abort at the idle threshold — a regression here re-opens the 600s zero-token hang")
+	// In the dispatch path the per-attempt writer is the preludeBuffer chain,
+	// and failover is only legal while it holds zero committed bytes. A stall
+	// with no upstream bytes must therefore leave the writer body empty.
+	assert.Zero(t, rec.Body.Len(), "no response bytes may reach the client writer on a zero-byte stall")
+}
+
+func TestProxy_SlowButFlowingStreamIsNotAborted(t *testing.T) {
+	// Frames arrive slower than a fast stream but well inside the idle
+	// budget; the stream's TOTAL duration exceeds the idle budget several
+	// times over. Only a zero-progress gap may trip the watchdog — total
+	// duration never does (long thinking turns with progress must survive).
+	const frame = "event: response.in_progress\ndata: {}\n\n"
+	const frames = 5
+	const frameInterval = 60 * time.Millisecond
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		f := w.(http.Flusher)
+		f.Flush()
+		for range frames {
+			select {
+			case <-r.Context().Done():
+				return
+			case <-time.After(frameInterval):
+			}
+			_, _ = io.WriteString(w, frame)
+			f.Flush()
+		}
+	}))
+	defer upstream.Close()
+
+	const idleTimeout = 150 * time.Millisecond
+	c := openai.NewClientWithTimeouts("test-key", upstream.URL, stallTestHeaderTimeout, idleTimeout)
+	rec := httptest.NewRecorder()
+	clientReq := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(""))
+
+	err := c.Proxy(context.Background(), router.Decision{Model: "gpt-5.5"}, responsesPrep(), rec, clientReq)
+
+	require.NoError(t, err, "a stream that keeps producing bytes must never trip the idle watchdog")
+	assert.Equal(t, strings.Repeat(frame, frames), rec.Body.String(),
+		"every upstream frame must be relayed to the client writer")
+}
+
+func TestProxy_StalledErrorBodyDoesNotHang(t *testing.T) {
+	// The upstream returns 500 headers, promises a body, and never sends it.
+	// The buffered-error read must abort on the idle watchdog and still
+	// surface the status-classified *UpstreamErrorResponse so the dispatch
+	// loop's status-based retry logic applies.
+	release := make(chan struct{})
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Content-Length", "4096")
+		w.WriteHeader(http.StatusInternalServerError)
+		w.(http.Flusher).Flush()
+		select {
+		case <-release:
+		case <-r.Context().Done():
+		}
+	}))
+	defer upstream.Close()
+	defer close(release)
+
+	const idleTimeout = 100 * time.Millisecond
+	c := openai.NewClientWithTimeouts("test-key", upstream.URL, stallTestHeaderTimeout, idleTimeout)
+	rec := httptest.NewRecorder()
+	clientReq := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(""))
+
+	start := time.Now()
+	err := c.Proxy(context.Background(), router.Decision{Model: "gpt-5.5"}, responsesPrep(), rec, clientReq)
+	elapsed := time.Since(start)
+
+	var upstreamErr *providers.UpstreamErrorResponse
+	require.ErrorAs(t, err, &upstreamErr, "a stalled error body must still buffer as *UpstreamErrorResponse")
+	assert.Equal(t, http.StatusInternalServerError, upstreamErr.Status)
+	assert.True(t, providers.IsRetryable(err), "a buffered 500 stays retryable by status")
+	assert.Less(t, elapsed, stallTestHeaderTimeout,
+		"the error-body read must abort at the idle threshold, not hang on the missing body")
+	assert.Zero(t, rec.Body.Len(), "buffered upstream errors must not touch the client writer")
+}

--- a/internal/providers/provider.go
+++ b/internal/providers/provider.go
@@ -141,6 +141,16 @@ func (e *UpstreamErrorResponse) Error() string {
 // of the upstream stream is drained without retention.
 const MaxBufferedErrorBytes = 64 * 1024
 
+// ErrUpstreamIdleTimeout is the sentinel cause set on a request context when
+// a provider adapter's SSE inactivity watchdog fires: the upstream accepted
+// the request and returned headers, then stopped producing bytes for the full
+// idle budget. It marks the stall as upstream-owned, as opposed to
+// caller-initiated cancellation. Defined here (rather than in httputil, which
+// owns the watchdog) so IsRetryable can classify it explicitly without an
+// import cycle — httputil imports providers and re-exports this value as
+// httputil.ErrUpstreamIdleTimeout.
+var ErrUpstreamIdleTimeout = errors.New("upstream sse idle timeout")
+
 // IsRetryableStatus reports whether an upstream HTTP status is worth
 // retrying on a different provider. Covers transient upstream-side faults
 // (5xx + 408 timeout + 429 rate-limit). 4xx ≠ 408/429 are the client's
@@ -164,6 +174,16 @@ func IsRetryable(err error) bool {
 		return false
 	}
 	if isResponseHeaderTimeout(err) {
+		return true
+	}
+	// An SSE idle-timeout stall is upstream-owned even though the watchdog
+	// surfaces it by canceling the request context: the upstream returned
+	// headers and then went silent. A retry on the same or a different
+	// binding can still serve the turn, so this must be classified before
+	// the caller-cancellation guard below (the underlying transport error
+	// in the chain may also carry context.Canceled from the watchdog's
+	// cancel call).
+	if errors.Is(err, ErrUpstreamIdleTimeout) {
 		return true
 	}
 	// Client-side cancellation and per-request deadlines are owned by the

--- a/internal/providers/provider_retry_test.go
+++ b/internal/providers/provider_retry_test.go
@@ -2,6 +2,7 @@ package providers_test
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -13,6 +14,16 @@ import (
 
 	"workweave/router/internal/providers"
 )
+
+// TestIsRetryable_UpstreamIdleTimeout pins the classification of the SSE
+// idle-watchdog sentinel: a mid-stream zero-progress stall is the upstream's
+// fault and must be retryable so dispatchWithFallback can rescue the turn on
+// the next attempt. Both the bare sentinel and a wrapped chain must classify,
+// since adapters may annotate the error on the way out.
+func TestIsRetryable_UpstreamIdleTimeout(t *testing.T) {
+	assert.True(t, providers.IsRetryable(providers.ErrUpstreamIdleTimeout))
+	assert.True(t, providers.IsRetryable(fmt.Errorf("stream upstream response: %w", providers.ErrUpstreamIdleTimeout)))
+}
 
 func TestIsRetryable_ResponseHeaderTimeout(t *testing.T) {
 	release := make(chan struct{})

--- a/internal/proxy/fallback_test.go
+++ b/internal/proxy/fallback_test.go
@@ -245,6 +245,53 @@ func TestDispatchWithFallback_RetriesOnResponseHeaderTimeout(t *testing.T) {
 	assert.Equal(t, providers.ProviderDeepInfra, rec.Header().Get(HeaderRouterFallbackFrom))
 }
 
+// TestDispatchWithFallback_RetriesOnUpstreamIdleTimeout covers the mid-stream
+// stall watchdog (prod incident 2026-06-09: /v1/responses streams went silent
+// after headers, zero output tokens until the 600s cap). The adapter aborts
+// the stalled stream and returns providers.ErrUpstreamIdleTimeout without
+// having written anything through the prelude buffer, so the dispatch loop
+// must rescue the turn on the next binding.
+func TestDispatchWithFallback_RetriesOnUpstreamIdleTimeout(t *testing.T) {
+	primary := &fakeClient{
+		name:     "openai",
+		outcomes: []fakeOutcome{{err: providers.ErrUpstreamIdleTimeout}},
+	}
+	fallback := &fakeClient{
+		name:     "openrouter",
+		outcomes: []fakeOutcome{{writeBytes: []byte("rescued")}},
+	}
+
+	s := newServiceWithProviders(t, map[string]providers.Client{
+		providers.ProviderOpenAI:     primary,
+		providers.ProviderOpenRouter: fallback,
+	})
+
+	rec := httptest.NewRecorder()
+	buf := newPreludeBuffer(rec)
+	r := httptest.NewRequest(http.MethodPost, "/v1/messages", nil)
+
+	winnerIdx, err := s.dispatchWithFallback(context.Background(), failoverInputs{
+		w:               rec,
+		buf:             buf,
+		initialDecision: router.Decision{Model: "gpt-5.5"},
+		bindings: []catalog.ProviderBinding{
+			{Provider: providers.ProviderOpenAI},
+			{Provider: providers.ProviderOpenRouter},
+		},
+		attempt: func(ctx context.Context, d router.Decision, p providers.Client) error {
+			buf.Seal()
+			return p.Proxy(ctx, d, providers.PreparedRequest{}, buf, r)
+		},
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, 1, winnerIdx)
+	assert.Equal(t, 1, primary.calls)
+	assert.Equal(t, 1, fallback.calls)
+	assert.Equal(t, "rescued", rec.Body.String())
+	assert.Equal(t, providers.ProviderOpenAI, rec.Header().Get(HeaderRouterFallbackFrom))
+}
+
 func TestDispatchWithFallback_NoRetryOnNonRetryableStatus(t *testing.T) {
 	primary := &fakeClient{
 		name:     "fireworks",


### PR DESCRIPTION
## Incident

On 2026-06-09 a customer (benchmark org) hit two gpt-5.5 requests via the OpenAI Responses API that stalled **mid-stream after headers were received**: the upstream connection stayed open but produced zero output tokens, running until the router's 600s cap / the client's 600s timeout (proxy_ms 599,991 and 599,880, both `resp_output_tokens=0`, status 0, client canceled). Each stall burned 10 minutes of the customer's 1200s agent budget with no failover.

## Why the header timeout doesn't cover this

#331 added a 120s `ResponseHeaderTimeout` for the *pre-header* hang (stream:false Responses buffering the whole reasoning pass). That timer stops the moment upstream headers arrive — a connection that returns headers and then goes silent is invisible to it. The remaining guards had two holes on the OpenAI adapter:

- the `>=400` buffered-error path read the error body with a plain blocking `io.ReadAll` (`readCapped`) — an upstream that sends error headers and stalls the body hung unboundedly with no watchdog and nothing ever written to the client (matches the status-0 profile);
- the 2xx streaming path's idle watchdog had no per-endpoint budget for `/v1/responses`, no ERROR-level observability when it tripped, and its retryable classification was an implicit fall-through in `IsRetryable` with no test pinning it.

## Design: idle-progress, not total duration

Long thinking turns legitimately take 100-300s **with** bytes flowing — the Responses SSE stream emits event frames (`response.created` / `response.in_progress` / reasoning-summary deltas) even while the model is "thinking", so ANY received SSE bytes count as progress and only a zero-progress gap trips the watchdog. That makes a 90s idle budget safe for `/v1/responses`; real stalls (this incident) produce zero bytes for the entire request lifetime.

- `httputil.DefaultResponsesSSEIdleTimeout` = 90s for `/v1/responses` (env override `ROUTER_RESPONSES_SSE_IDLE_TIMEOUT_SECONDS`, mirroring the existing `ROUTER_SSE_IDLE_TIMEOUT_SECONDS` pattern); chat/completions keeps the existing 45s default.
- The `>=400` error-body read is now guarded by the same `StartIdleWatchdog` + a progress-marking reader, so a stalled error body aborts at the idle threshold and still surfaces the status-classified `*UpstreamErrorResponse`.
- Watchdog trips log at ERROR with `model`, `provider`, `path`, `idle_ms`, `bytes_received`.

## Retryable classification + commit safety

`ErrUpstreamIdleTimeout` moves from `httputil` to `providers` (httputil re-exports an alias, so all existing `errors.Is` call sites keep working) and `providers.IsRetryable` now classifies it **explicitly**, ahead of the caller-cancellation guard — previously it was only retryable by falling through the default branch, which a future tightening could silently break. With nothing committed, `dispatchWithFallback` does same-binding retry / multi-binding failover as usual; if bytes were already committed to the client, the existing `preludeBuffer.Committed()` gate keeps failover off and the request fails with the in-stream error frame, unchanged.

## Tests

- `TestProxy_MidStreamStallAbortsRetryableNothingWritten` — mock SSE upstream sends headers then goes silent: aborts at the idle threshold, `errors.Is(err, ErrUpstreamIdleTimeout)`, `IsRetryable(err)`, zero bytes written to the client writer.
- `TestProxy_SlowButFlowingStreamIsNotAborted` — frames every 60ms with a 150ms idle budget and total stream duration ≈ 2x the budget: no trip, all frames relayed.
- `TestProxy_StalledErrorBodyDoesNotHang` — 500 headers + stalled body: surfaces `*UpstreamErrorResponse{500}` at the idle threshold instead of hanging.
- `TestIsRetryable_UpstreamIdleTimeout` (bare + wrapped) and `TestDispatchWithFallback_RetriesOnUpstreamIdleTimeout` (fallback rescue), mirroring the #353 pattern.

`go build ./...` clean; `go test ./...` green across the module; new timing-sensitive tests pass `-race -count=3`.

Known follow-up (out of scope here): the anthropic/openaicompat adapters have the same unguarded `readCapped` on their `>=400` paths, and the `Passthrough` surfaces use plain `io.Copy`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)