### PR TITLE
Log x-weave-rollout-id into request telemetry for bandit reward joining

### DIFF
--- a/db/migrations/0017_telemetry_rollout_id.down.sql
+++ b/db/migrations/0017_telemetry_rollout_id.down.sql
@@ -1,0 +1,6 @@
+BEGIN;
+
+ALTER TABLE router.model_router_request_telemetry
+    DROP COLUMN rollout_id;
+
+COMMIT;

--- a/db/migrations/0017_telemetry_rollout_id.up.sql
+++ b/db/migrations/0017_telemetry_rollout_id.up.sql
@@ -1,0 +1,16 @@
+BEGIN;
+
+-- Client-supplied rollout correlation id (x-weave-rollout-id header). Set by
+-- eval/training harnesses so a sandbox rollout's graded reward can be joined
+-- back onto every routing decision made inside it (bandit closed loop).
+-- NULL for all non-harness traffic.
+ALTER TABLE router.model_router_request_telemetry
+    ADD COLUMN rollout_id VARCHAR;
+
+-- The reward join scans by rollout id; partial index keeps the hot
+-- production path (rollout_id IS NULL) free.
+CREATE INDEX model_router_request_telemetry_rollout_id_idx
+    ON router.model_router_request_telemetry (rollout_id)
+    WHERE rollout_id IS NOT NULL;
+
+COMMIT;

--- a/db/queries/model_router_request_telemetry.sql
+++ b/db/queries/model_router_request_telemetry.sql
@@ -6,6 +6,9 @@
 -- turn_type is the turntype classification (main_loop, tool_result, probe,
 -- title_gen, compaction, classifier, sub_agent_dispatch); NULL only on rows
 -- written before the column existed.
+-- rollout_id is the client-supplied x-weave-rollout-id correlation id used by
+-- eval/training harnesses to join graded rollout rewards onto decisions; NULL
+-- for all non-harness traffic.
 -- name: InsertRequestTelemetry :exec
 INSERT INTO router.model_router_request_telemetry (
     installation_id,
@@ -45,7 +48,8 @@ INSERT INTO router.model_router_request_telemetry (
     session_id,
     router_user_id,
     client_app,
-    turn_type
+    turn_type,
+    rollout_id
 ) VALUES (
     @installation_id::uuid,
     @request_id::varchar,
@@ -84,7 +88,8 @@ INSERT INTO router.model_router_request_telemetry (
     sqlc.narg('session_id')::varchar,
     sqlc.narg('router_user_id')::uuid,
     sqlc.narg('client_app')::text,
-    @turn_type::varchar
+    @turn_type::varchar,
+    sqlc.narg('rollout_id')::varchar
 )
 ON CONFLICT (installation_id, request_id, span_type) DO NOTHING;
 

--- a/internal/api/anthropic/messages.go
+++ b/internal/api/anthropic/messages.go
@@ -141,6 +141,7 @@ func stashClientIdentity(ctx context.Context, h http.Header, body []byte) contex
 		DisplayName: displayName,
 		UserAgent:   h.Get("User-Agent"),
 		ClientApp:   proxy.NormalizeClientApp(h.Get("X-App"), h.Get("User-Agent")),
+		RolloutID:   proxy.NormalizeRolloutID(h.Get(proxy.RolloutIDHeader)),
 	}
 	observability.Get().Debug("anthropic stashClientIdentity",
 		"meta_raw_len", len(metaRaw),

--- a/internal/api/gemini/generate_content.go
+++ b/internal/api/gemini/generate_content.go
@@ -152,6 +152,7 @@ func stashClientIdentity(ctx context.Context, h http.Header) context.Context {
 		DisplayName: proxy.NormalizeDisplayName(h.Get("X-Weave-User-Name")),
 		UserAgent:   h.Get("User-Agent"),
 		ClientApp:   proxy.NormalizeClientApp(h.Get("X-App"), h.Get("User-Agent")),
+		RolloutID:   proxy.NormalizeRolloutID(h.Get(proxy.RolloutIDHeader)),
 	}
 	return context.WithValue(ctx, proxy.ClientIdentityContextKey{}, id)
 }

--- a/internal/api/openai/completions.go
+++ b/internal/api/openai/completions.go
@@ -94,6 +94,7 @@ func stashClientIdentity(ctx context.Context, h http.Header) context.Context {
 		DisplayName: proxy.NormalizeDisplayName(h.Get("X-Weave-User-Name")),
 		UserAgent:   h.Get("User-Agent"),
 		ClientApp:   proxy.NormalizeClientApp(h.Get("X-App"), h.Get("User-Agent")),
+		RolloutID:   proxy.NormalizeRolloutID(h.Get(proxy.RolloutIDHeader)),
 	}
 	return context.WithValue(ctx, proxy.ClientIdentityContextKey{}, id)
 }

--- a/internal/postgres/telemetry.go
+++ b/internal/postgres/telemetry.go
@@ -88,6 +88,7 @@ func (r *TelemetryRepo) InsertRequestTelemetry(ctx context.Context, p proxy.Inse
 		SessionID:              stringPtrOrNil(p.SessionID),
 		RouterUserID:           uuidOrNil(p.RouterUserID),
 		ClientApp:              stringPtrOrNil(p.ClientApp),
+		RolloutID:              stringPtrOrNil(p.RolloutID),
 		TurnType:               p.TurnType,
 	})
 }

--- a/internal/proxy/client_identity.go
+++ b/internal/proxy/client_identity.go
@@ -20,6 +20,10 @@ type ClientIdentity struct {
 	DisplayName string
 	UserAgent   string
 	ClientApp   string
+	// RolloutID is the eval/training-harness correlation id from the
+	// x-weave-rollout-id header. Joins a sandbox rollout's graded reward
+	// onto every routing decision made inside it. Empty for normal traffic.
+	RolloutID string
 }
 
 // ClientIdentityContextKey is the request-context key for client identity.
@@ -96,6 +100,25 @@ const MaxClientIdentifierLen = 128
 // valid but no longer correlates.
 func NormalizeClientIdentifier(s string) string {
 	if len(s) > MaxClientIdentifierLen {
+		return ""
+	}
+	return s
+}
+
+// RolloutIDHeader carries the eval/training-harness rollout correlation id.
+const RolloutIDHeader = "X-Weave-Rollout-Id"
+
+// MaxRolloutIDLen bounds the rollout correlation id. Harness ids compose
+// run_id/condition/seed/instance_id and can exceed the 128-byte client
+// identifier cap; 256 covers them with flood-protection headroom.
+const MaxRolloutIDLen = 256
+
+// NormalizeRolloutID trims and bounds a rollout id. Rejection (not
+// truncation) for the same reason as NormalizeClientIdentifier: a truncated
+// id looks valid but no longer joins.
+func NormalizeRolloutID(s string) string {
+	s = strings.TrimSpace(s)
+	if len(s) > MaxRolloutIDLen {
 		return ""
 	}
 	return s

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -1546,6 +1546,7 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 			RouterUserID:           auth.UserIDFrom(ctx),
 			ClientApp:              clientID.ClientApp,
 			TurnType:               string(routeRes.TurnType),
+			RolloutID:              clientID.RolloutID,
 		})
 	}
 
@@ -2537,6 +2538,7 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 			RouterUserID:           auth.UserIDFrom(ctx),
 			ClientApp:              clientID.ClientApp,
 			TurnType:               string(routeRes.TurnType),
+			RolloutID:              clientID.RolloutID,
 		})
 	}
 

--- a/internal/proxy/service_observation_test.go
+++ b/internal/proxy/service_observation_test.go
@@ -308,3 +308,43 @@ func TestProxyMessages_PersistsTurnType(t *testing.T) {
 		})
 	}
 }
+
+// TestProxyMessages_PersistsRolloutID asserts the eval/training-harness
+// rollout correlation id flows from ClientIdentity to the telemetry row —
+// the join key for bandit-loop reward attribution. Empty stays empty (NULL
+// column) for normal traffic.
+func TestProxyMessages_PersistsRolloutID(t *testing.T) {
+	const installID = "66666666-6666-6666-6666-666666666666"
+	const rolloutID = "swerebench-cc-r1/router-v0.65/0/owner__repo-123"
+	decision := router.Decision{
+		Provider: providers.ProviderAnthropic,
+		Model:    "claude-haiku-4-5",
+		Reason:   "pin",
+	}
+	telem := newCaptureTelemetry()
+	svc := proxy.NewService(
+		&fakeRouter{decision: decision},
+		map[string]providers.Client{providers.ProviderAnthropic: &fakeProvider{}},
+		nil, false, nil, nil, false,
+		providers.ProviderAnthropic, "claude-haiku-4-5",
+		telem,
+	)
+
+	ctx := context.WithValue(context.Background(), proxy.InstallationIDContextKey{}, installID)
+	ctx = context.WithValue(ctx, proxy.ClientIdentityContextKey{}, proxy.ClientIdentity{RolloutID: rolloutID})
+	rec := httptest.NewRecorder()
+	body := []byte(`{"model":"claude-opus-4-7","messages":[{"role":"user","content":"hello"}]}`)
+	httpReq := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(""))
+	require.NoError(t, svc.ProxyMessages(ctx, body, rec, httpReq))
+
+	row := telem.firstRow(t)
+	assert.Equal(t, rolloutID, row.RolloutID)
+}
+
+// TestNormalizeRolloutID covers the bound: oversized ids are rejected (not
+// truncated) so a stored id always joins back to a real rollout.
+func TestNormalizeRolloutID(t *testing.T) {
+	assert.Equal(t, "run/cond/0/iid", proxy.NormalizeRolloutID("  run/cond/0/iid "))
+	assert.Equal(t, "", proxy.NormalizeRolloutID(strings.Repeat("x", 257)))
+	assert.Equal(t, strings.Repeat("x", 256), proxy.NormalizeRolloutID(strings.Repeat("x", 256)))
+}

--- a/internal/proxy/telemetry.go
+++ b/internal/proxy/telemetry.go
@@ -60,6 +60,9 @@ type InsertTelemetryParams struct {
 	RouterUserID         string
 	ClientApp            string
 	TurnType             string
+	// RolloutID joins eval/training-harness rollout rewards onto decisions
+	// (x-weave-rollout-id header). Empty for normal traffic → NULL column.
+	RolloutID string
 }
 
 // TelemetrySummary holds aggregated totals for the dashboard cards.

--- a/internal/sqlc/model_router_request_telemetry.sql.go
+++ b/internal/sqlc/model_router_request_telemetry.sql.go
@@ -787,7 +787,8 @@ INSERT INTO router.model_router_request_telemetry (
     session_id,
     router_user_id,
     client_app,
-    turn_type
+    turn_type,
+    rollout_id
 ) VALUES (
     $1::uuid,
     $2::varchar,
@@ -826,7 +827,8 @@ INSERT INTO router.model_router_request_telemetry (
     $35::varchar,
     $36::uuid,
     $37::text,
-    $38::varchar
+    $38::varchar,
+    $39::varchar
 )
 ON CONFLICT (installation_id, request_id, span_type) DO NOTHING
 `
@@ -870,6 +872,7 @@ type InsertRequestTelemetryParams struct {
 	RouterUserID           pgtype.UUID
 	ClientApp              *string
 	TurnType               string
+	RolloutID              *string
 }
 
 // Records a completed proxied request for the dashboard UI and routing
@@ -880,6 +883,9 @@ type InsertRequestTelemetryParams struct {
 // turn_type is the turntype classification (main_loop, tool_result, probe,
 // title_gen, compaction, classifier, sub_agent_dispatch); NULL only on rows
 // written before the column existed.
+// rollout_id is the client-supplied x-weave-rollout-id correlation id used by
+// eval/training harnesses to join graded rollout rewards onto decisions; NULL
+// for all non-harness traffic.
 //
 //	INSERT INTO router.model_router_request_telemetry (
 //	    installation_id,
@@ -919,7 +925,8 @@ type InsertRequestTelemetryParams struct {
 //	    session_id,
 //	    router_user_id,
 //	    client_app,
-//	    turn_type
+//	    turn_type,
+//	    rollout_id
 //	) VALUES (
 //	    $1::uuid,
 //	    $2::varchar,
@@ -958,7 +965,8 @@ type InsertRequestTelemetryParams struct {
 //	    $35::varchar,
 //	    $36::uuid,
 //	    $37::text,
-//	    $38::varchar
+//	    $38::varchar,
+//	    $39::varchar
 //	)
 //	ON CONFLICT (installation_id, request_id, span_type) DO NOTHING
 func (q *Queries) InsertRequestTelemetry(ctx context.Context, arg InsertRequestTelemetryParams) error {
@@ -1001,6 +1009,7 @@ func (q *Queries) InsertRequestTelemetry(ctx context.Context, arg InsertRequestT
 		arg.RouterUserID,
 		arg.ClientApp,
 		arg.TurnType,
+		arg.RolloutID,
 	)
 	return err
 }

--- a/internal/sqlc/models.go
+++ b/internal/sqlc/models.go
@@ -118,6 +118,7 @@ type RouterModelRouterRequestTelemetry struct {
 	RouterUserID           pgtype.UUID
 	ClientApp              *string
 	TurnType               *string
+	RolloutID              *string
 }
 
 // End-user identities seen on inbound requests, scoped to an installation. Replaces the per-user API key pattern.


### PR DESCRIPTION
## Summary
- New nullable `rollout_id` column on `router.model_router_request_telemetry` (+ partial index on non-NULL), migration `0017`
- All three API surfaces (Anthropic / OpenAI / Gemini) read the `X-Weave-Rollout-Id` header into `ClientIdentity` (bounded at 256 bytes, reject-not-truncate)
- `ProxyMessages` / `ProxyOpenAIChatCompletion` persist it on the telemetry row

This is Phase 3 of the bandit closed loop (`router-internal/docs/plans/ROUTER_BANDIT_CLOSED_LOOP.md` in WorkWeave): the SWE-rebench Claude Code harness sends `x-weave-rollout-id: <run_id>/<condition>/<seed>/<instance_id>` per rollout, and the graded `resolved` reward joins onto every routing decision sharing that id. NULL for all non-harness traffic; no behavior change on the request path.

## Test plan
- [x] `go test ./internal/proxy/... ./internal/api/... ./internal/postgres/...`
- [x] New `TestProxyMessages_PersistsRolloutID` + `TestNormalizeRolloutID`
- [x] `make generate` committed (sqlc)
- [ ] After merge: `wv db run-migrations -r` + staging smoke (header → telemetry row)

Made with [Cursor](https://cursor.com)