### PR TITLE
fix(translate): strictify must handle propertyNames (playwright MCP kills gpt-5.x sessions)

### DIFF
--- a/internal/translate/strictify_openai.go
+++ b/internal/translate/strictify_openai.go
@@ -15,7 +15,10 @@ const (
 
 // strictifyBailKeywords are JSON Schema constructs OpenAI strict mode cannot
 // express; their presence anywhere makes the schema non-strictifiable.
-var strictifyBailKeywords = []string{"oneOf", "allOf", "not", "if", "then", "else", "patternProperties", "$ref"}
+var strictifyBailKeywords = []string{
+	"oneOf", "allOf", "not", "if", "then", "else", "patternProperties", "$ref",
+	"dependentSchemas", "unevaluatedProperties", "unevaluatedItems", "prefixItems",
+}
 
 // strictifyDropKeywords are constraint keywords strict mode rejects; they are
 // stripped from the node and appended to its description so the model still
@@ -25,6 +28,11 @@ var strictifyDropKeywords = []string{
 	"minimum", "maximum", "exclusiveMinimum", "exclusiveMaximum", "multipleOf",
 	"minLength", "maxLength", "minItems", "maxItems", "uniqueItems",
 	"minProperties", "maxProperties",
+	// Key/membership constraints strict mode rejects outright. propertyNames
+	// in particular rode through untouched and 400'd the whole request
+	// ("'propertyNames' is not permitted") for any session carrying the
+	// playwright MCP tools (browser_drop) on the gpt-5.x Responses path.
+	"propertyNames", "contains", "minContains", "maxContains", "dependentRequired",
 }
 
 // strictifyOpenAISchema converts a tool input_schema (already $ref-inlined by

--- a/internal/translate/strictify_openai_test.go
+++ b/internal/translate/strictify_openai_test.go
@@ -152,3 +152,42 @@ func TestStrictify_DoesNotMutateInput(t *testing.T) {
 	assert.JSONEq(t, raw, string(reMarshaled),
 		"the caller may emit the original schema on other paths — strictify must not mutate it")
 }
+
+// Prod repro (2026-06-10, Lucanet benchmark re-run): the playwright MCP
+// server's browser_drop tool nests propertyNames inside a property schema.
+// Pre-fix it rode through strictification untouched and OpenAI rejected the
+// whole request with 400 "In context=('properties', 'data'), 'propertyNames'
+// is not permitted" — killing the session on the first call.
+func TestStrictify_PropertyNamesDroppedToDescription(t *testing.T) {
+	out, ok := strictifyFromJSON(t, `{
+		"type":"object",
+		"properties":{
+			"data":{
+				"type":"object",
+				"properties":{},
+				"propertyNames":{"pattern":"^[a-z]+$"}
+			}
+		},
+		"required":["data"]
+	}`)
+	require.True(t, ok, "propertyNames must not make the schema non-strictifiable")
+
+	props := out["properties"].(map[string]any)
+	data := props["data"].(map[string]any)
+	_, present := data["propertyNames"]
+	assert.False(t, present, "propertyNames must be stripped for strict mode")
+	desc, _ := data["description"].(string)
+	assert.Contains(t, desc, "propertyNames", "dropped constraint must survive as description guidance")
+}
+
+// Schema-defining keywords strict mode cannot express must bail to the
+// non-strict fallback rather than emit a lossy strict schema.
+func TestStrictify_UnevaluatedPropertiesBails(t *testing.T) {
+	_, ok := strictifyFromJSON(t, `{
+		"type":"object",
+		"properties":{"x":{"type":"string"}},
+		"unevaluatedProperties":false,
+		"required":["x"]
+	}`)
+	require.False(t, ok, "unevaluatedProperties is not expressible in strict mode; must bail")
+}


### PR DESCRIPTION
## Problem

**Live prod regression introduced with #343's strict:true rollout** (pin 7d24fbb, deployed 2026-06-10 ~21:13Z). `strictifyOpenAISchema` has a bail list and a drop list, but `propertyNames` is in neither — it passes through into the `strict:true` schema and OpenAI rejects the whole request:

> `400 Invalid schema for function 'mcp__playwright__browser_drop': In context=('properties', 'data'), 'propertyNames' is not permitted.`

The playwright MCP server's `browser_drop` tool nests `propertyNames` under `properties.data`, so **any Claude Code session with playwright MCP connected dies on its first gpt-5.x Responses call**. Caught within hours of deploy by re-running the Lucanet customer benchmark (3/3 phoenix trials killed instantly; the same tools passed fine on the pre-strict pin).

## Fix

- **Drop list** (strip → description guidance, strict stays on): `propertyNames`, `contains`, `minContains`, `maxContains`, `dependentRequired` — key/membership constraints, same semantics as the existing drop keywords.
- **Bail list** (fall back to non-strict original schema): `dependentSchemas`, `unevaluatedProperties`, `unevaluatedItems`, `prefixItems` — these define schemas strict mode can't express; the design contract is "never fail the request over strictness".
- Regression tests: playwright-shaped propertyNames repro + unevaluatedProperties bail.

Tests: `go test ./...` green (26 packages).

This should go out in the next pin bump ASAP — it's killing playwright-MCP sessions in prod right now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)