### PR TITLE
feat(telemetry): response-outcome columns, eval hygiene view, degenerate shadow

### DIFF
--- a/db/migrations/0019_telemetry-response-outcome.down.sql
+++ b/db/migrations/0019_telemetry-response-outcome.down.sql
@@ -1,0 +1,13 @@
+BEGIN;
+
+DROP VIEW IF EXISTS router.production_request_telemetry;
+
+ALTER TABLE router.model_router_request_telemetry
+    DROP COLUMN IF EXISTS upstream_finish_reason,
+    DROP COLUMN IF EXISTS stop_reason,
+    DROP COLUMN IF EXISTS tool_use_blocks,
+    DROP COLUMN IF EXISTS invalid_tool_args_blocks,
+    DROP COLUMN IF EXISTS failover_used,
+    DROP COLUMN IF EXISTS degenerate_shadow;
+
+COMMIT;

--- a/db/migrations/0019_telemetry-response-outcome.up.sql
+++ b/db/migrations/0019_telemetry-response-outcome.up.sql
@@ -1,0 +1,24 @@
+BEGIN;
+
+-- Add per-response outcome columns so routing-health queries can see finish
+-- reason, tool-call counts, failover usage, and degenerate-response shadow
+-- events without parsing log lines.  All columns nullable: OpenAI-path and
+-- Gemini rows leave them NULL; old rows are unaffected.
+ALTER TABLE router.model_router_request_telemetry
+    ADD COLUMN upstream_finish_reason TEXT,
+    ADD COLUMN stop_reason            TEXT,
+    ADD COLUMN tool_use_blocks        INT,
+    ADD COLUMN invalid_tool_args_blocks INT,
+    ADD COLUMN failover_used          BOOLEAN,
+    ADD COLUMN degenerate_shadow      BOOLEAN;
+
+-- Canonical production-traffic view.  Filters out eval/knob-sweep traffic
+-- tagged via X-App: weave-eval* so routing-health queries don't need to
+-- re-derive the predicate ad hoc.  For historical rows (before eval harnesses
+-- sent the weave-eval prefix) additionally filter session_id IS NOT NULL.
+CREATE VIEW router.production_request_telemetry AS
+SELECT * FROM router.model_router_request_telemetry
+WHERE span_type = 'router.upstream'
+  AND (client_app IS NULL OR client_app NOT LIKE 'weave-eval%');
+
+COMMIT;

--- a/db/queries/model_router_request_telemetry.sql
+++ b/db/queries/model_router_request_telemetry.sql
@@ -49,7 +49,13 @@ INSERT INTO router.model_router_request_telemetry (
     router_user_id,
     client_app,
     turn_type,
-    rollout_id
+    rollout_id,
+    upstream_finish_reason,
+    stop_reason,
+    tool_use_blocks,
+    invalid_tool_args_blocks,
+    failover_used,
+    degenerate_shadow
 ) VALUES (
     @installation_id::uuid,
     @request_id::varchar,
@@ -89,7 +95,13 @@ INSERT INTO router.model_router_request_telemetry (
     sqlc.narg('router_user_id')::uuid,
     sqlc.narg('client_app')::text,
     @turn_type::varchar,
-    sqlc.narg('rollout_id')::varchar
+    sqlc.narg('rollout_id')::varchar,
+    sqlc.narg('upstream_finish_reason')::text,
+    sqlc.narg('stop_reason')::text,
+    sqlc.narg('tool_use_blocks')::int,
+    sqlc.narg('invalid_tool_args_blocks')::int,
+    sqlc.narg('failover_used')::boolean,
+    sqlc.narg('degenerate_shadow')::boolean
 )
 ON CONFLICT (installation_id, request_id, span_type) DO NOTHING;
 

--- a/internal/postgres/telemetry.go
+++ b/internal/postgres/telemetry.go
@@ -90,6 +90,12 @@ func (r *TelemetryRepo) InsertRequestTelemetry(ctx context.Context, p proxy.Inse
 		ClientApp:              stringPtrOrNil(p.ClientApp),
 		RolloutID:              stringPtrOrNil(p.RolloutID),
 		TurnType:               p.TurnType,
+		UpstreamFinishReason:   p.UpstreamFinishReason,
+		StopReason:             p.StopReason,
+		ToolUseBlocks:          p.ToolUseBlocks,
+		InvalidToolArgsBlocks:  p.InvalidToolArgsBlocks,
+		FailoverUsed:           p.FailoverUsed,
+		DegenerateShadow:       p.DegenerateShadow,
 	})
 }
 

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -1626,8 +1626,8 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 			// look like a measured zero-tool turn rather than missing data.
 			ToolUseBlocks:         int32PtrIfKnown(int32(respSummary.ToolUseBlocks), respSummary.StopReason != ""),
 			InvalidToolArgsBlocks: int32PtrIfKnown(int32(respSummary.InvalidToolArgsBlocks), respSummary.StopReason != ""),
-			FailoverUsed:           boolPtrTrue(failoverUsed),
-			DegenerateShadow:       boolPtrOrNil(degShadow),
+			FailoverUsed:          boolPtrTrue(failoverUsed),
+			DegenerateShadow:      boolPtrOrNil(degShadow),
 		})
 	}
 

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -1567,7 +1567,7 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 
 	if installationID != uuid.Nil {
 		failoverUsed := finalProvider != primaryProvider
-		degShadow := isDegenerateResponse(out, respSummary.ToolUseBlocks, respSummary.StopReason, respSummary.StopReasonDemoted)
+		degShadow := proxyErr == nil && isDegenerateResponse(out, respSummary.ToolUseBlocks, respSummary.StopReason, respSummary.StopReasonDemoted)
 		if degShadow {
 			log.Info("router.degenerate_shadow",
 				"model", decision.Model,

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -1620,8 +1620,12 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 			RolloutID:              clientID.RolloutID,
 			UpstreamFinishReason:   stringPtrOrEmpty(respSummary.UpstreamFinishReason),
 			StopReason:             stringPtrOrEmpty(respSummary.StopReason),
-			ToolUseBlocks:          int32Ptr(int32(respSummary.ToolUseBlocks)),
-			InvalidToolArgsBlocks:  int32Ptr(int32(respSummary.InvalidToolArgsBlocks)),
+			// ToolUseBlocks and InvalidToolArgsBlocks are only valid when a
+			// translator ran (StopReason is populated). The Anthropic-native
+			// passthrough path leaves respSummary zero; storing 0 there would
+			// look like a measured zero-tool turn rather than missing data.
+			ToolUseBlocks:         int32PtrIfKnown(int32(respSummary.ToolUseBlocks), respSummary.StopReason != ""),
+			InvalidToolArgsBlocks: int32PtrIfKnown(int32(respSummary.InvalidToolArgsBlocks), respSummary.StopReason != ""),
 			FailoverUsed:           boolPtrTrue(failoverUsed),
 			DegenerateShadow:       boolPtrOrNil(degShadow),
 		})
@@ -1977,9 +1981,14 @@ func cacheTokenPtr(n int) *int32 {
 	return &v
 }
 
-// int32Ptr returns a pointer to v. Used to record nullable integer telemetry
-// columns where 0 is a valid value (e.g. tool_use_blocks = 0 means zero tools).
-func int32Ptr(v int32) *int32 {
+// int32PtrIfKnown returns a pointer to v when known is true, else nil.
+// Used for nullable integer telemetry columns where 0 is a valid value
+// (e.g. tool_use_blocks = 0 means zero tools) but the value may be absent
+// when the translator did not run (Anthropic-native passthrough path).
+func int32PtrIfKnown(v int32, known bool) *int32 {
+	if !known {
+		return nil
+	}
 	return &v
 }
 

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -1566,6 +1566,19 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 	s.recordTurnUsage(routeRes, in, out, cacheCreation, cacheRead)
 
 	if installationID != uuid.Nil {
+		failoverUsed := finalProvider != primaryProvider
+		degShadow := isDegenerateResponse(out, respSummary.ToolUseBlocks, respSummary.StopReason)
+		if degShadow {
+			log.Info("router.degenerate_shadow",
+				"model", decision.Model,
+				"provider", finalProvider,
+				"output_tokens", out,
+				"tool_use_blocks", respSummary.ToolUseBlocks,
+				"stop_reason", respSummary.StopReason,
+				"upstream_finish_reason", respSummary.UpstreamFinishReason,
+				"would_failover", true,
+			)
+		}
 		s.fireTelemetry(InsertTelemetryParams{
 			InstallationID:         installationID.String(),
 			RequestID:              requestID,
@@ -1605,6 +1618,12 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 			ClientApp:              clientID.ClientApp,
 			TurnType:               string(routeRes.TurnType),
 			RolloutID:              clientID.RolloutID,
+			UpstreamFinishReason:   stringPtrOrEmpty(respSummary.UpstreamFinishReason),
+			StopReason:             stringPtrOrEmpty(respSummary.StopReason),
+			ToolUseBlocks:          int32Ptr(int32(respSummary.ToolUseBlocks)),
+			InvalidToolArgsBlocks:  int32Ptr(int32(respSummary.InvalidToolArgsBlocks)),
+			FailoverUsed:           boolPtrTrue(failoverUsed),
+			DegenerateShadow:       boolPtrOrNil(degShadow),
 		})
 	}
 
@@ -1956,6 +1975,49 @@ func cacheTokenPtr(n int) *int32 {
 	}
 	v := int32(n)
 	return &v
+}
+
+// int32Ptr returns a pointer to v. Used to record nullable integer telemetry
+// columns where 0 is a valid value (e.g. tool_use_blocks = 0 means zero tools).
+func int32Ptr(v int32) *int32 {
+	return &v
+}
+
+// boolPtrOrNil returns a pointer to v only when v is true. False is treated as
+// "not set" so routine non-events don't fill nullable boolean columns.
+func boolPtrOrNil(v bool) *bool {
+	if !v {
+		return nil
+	}
+	return &v
+}
+
+// boolPtrTrue always returns a non-nil pointer to v. Used for failover_used
+// where both true and false are meaningful values to record.
+func boolPtrTrue(v bool) *bool {
+	return &v
+}
+
+// stringPtrOrEmpty returns a pointer to s when it is non-empty, else nil.
+func stringPtrOrEmpty(s string) *string {
+	if s == "" {
+		return nil
+	}
+	return &s
+}
+
+// degenerateOutputThreshold is the output-token count below which a
+// normal-completion response with no tool calls is flagged as degenerate.
+const degenerateOutputThreshold = 10
+
+// isDegenerateResponse returns true when the upstream produced a suspiciously
+// short response: fewer than degenerateOutputThreshold output tokens, no tool
+// calls emitted, and a normal end_turn stop reason. A valid tool-only turn or
+// a brief legitimate end_turn must not trip this.
+func isDegenerateResponse(outputTokens int, toolUseBlocks int, stopReason string) bool {
+	return outputTokens < degenerateOutputThreshold &&
+		toolUseBlocks == 0 &&
+		stopReason == "end_turn"
 }
 
 // fireTelemetry persists a telemetry row asynchronously. Telemetry loss is acceptable.
@@ -2597,6 +2659,7 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 			ClientApp:              clientID.ClientApp,
 			TurnType:               string(routeRes.TurnType),
 			RolloutID:              clientID.RolloutID,
+			FailoverUsed:           boolPtrTrue(finalProvider != primaryProvider),
 		})
 	}
 

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -1567,7 +1567,7 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 
 	if installationID != uuid.Nil {
 		failoverUsed := finalProvider != primaryProvider
-		degShadow := isDegenerateResponse(out, respSummary.ToolUseBlocks, respSummary.StopReason)
+		degShadow := isDegenerateResponse(out, respSummary.ToolUseBlocks, respSummary.StopReason, respSummary.StopReasonDemoted)
 		if degShadow {
 			log.Info("router.degenerate_shadow",
 				"model", decision.Model,
@@ -2023,10 +2023,16 @@ const degenerateOutputThreshold = 10
 // short response: fewer than degenerateOutputThreshold output tokens, no tool
 // calls emitted, and a normal end_turn stop reason. A valid tool-only turn or
 // a brief legitimate end_turn must not trip this.
-func isDegenerateResponse(outputTokens int, toolUseBlocks int, stopReason string) bool {
+//
+// stopReasonDemoted guards against false positives from cross-format demotions:
+// broken finish_reason="tool_calls" turns that the translator demotes to end_turn
+// (zero surviving tool blocks) must not fire the degenerate shadow — they are
+// handled translation failures, not genuinely empty completions.
+func isDegenerateResponse(outputTokens, toolUseBlocks int, stopReason string, stopReasonDemoted bool) bool {
 	return outputTokens < degenerateOutputThreshold &&
 		toolUseBlocks == 0 &&
-		stopReason == "end_turn"
+		stopReason == "end_turn" &&
+		!stopReasonDemoted
 }
 
 // fireTelemetry persists a telemetry row asynchronously. Telemetry loss is acceptable.

--- a/internal/proxy/telemetry.go
+++ b/internal/proxy/telemetry.go
@@ -63,6 +63,13 @@ type InsertTelemetryParams struct {
 	// RolloutID joins eval/training-harness rollout rewards onto decisions
 	// (x-weave-rollout-id header). Empty for normal traffic → NULL column.
 	RolloutID string
+
+	UpstreamFinishReason  *string
+	StopReason            *string
+	ToolUseBlocks         *int32
+	InvalidToolArgsBlocks *int32
+	FailoverUsed          *bool
+	DegenerateShadow      *bool
 }
 
 // TelemetrySummary holds aggregated totals for the dashboard cards.

--- a/internal/sqlc/model_router_request_telemetry.sql.go
+++ b/internal/sqlc/model_router_request_telemetry.sql.go
@@ -788,7 +788,13 @@ INSERT INTO router.model_router_request_telemetry (
     router_user_id,
     client_app,
     turn_type,
-    rollout_id
+    rollout_id,
+    upstream_finish_reason,
+    stop_reason,
+    tool_use_blocks,
+    invalid_tool_args_blocks,
+    failover_used,
+    degenerate_shadow
 ) VALUES (
     $1::uuid,
     $2::varchar,
@@ -828,7 +834,13 @@ INSERT INTO router.model_router_request_telemetry (
     $36::uuid,
     $37::text,
     $38::varchar,
-    $39::varchar
+    $39::varchar,
+    $40::text,
+    $41::text,
+    $42::int,
+    $43::int,
+    $44::boolean,
+    $45::boolean
 )
 ON CONFLICT (installation_id, request_id, span_type) DO NOTHING
 `
@@ -873,6 +885,12 @@ type InsertRequestTelemetryParams struct {
 	ClientApp              *string
 	TurnType               string
 	RolloutID              *string
+	UpstreamFinishReason   *string
+	StopReason             *string
+	ToolUseBlocks          *int32
+	InvalidToolArgsBlocks  *int32
+	FailoverUsed           *bool
+	DegenerateShadow       *bool
 }
 
 // Records a completed proxied request for the dashboard UI and routing
@@ -926,7 +944,13 @@ type InsertRequestTelemetryParams struct {
 //	    router_user_id,
 //	    client_app,
 //	    turn_type,
-//	    rollout_id
+//	    rollout_id,
+//	    upstream_finish_reason,
+//	    stop_reason,
+//	    tool_use_blocks,
+//	    invalid_tool_args_blocks,
+//	    failover_used,
+//	    degenerate_shadow
 //	) VALUES (
 //	    $1::uuid,
 //	    $2::varchar,
@@ -966,7 +990,13 @@ type InsertRequestTelemetryParams struct {
 //	    $36::uuid,
 //	    $37::text,
 //	    $38::varchar,
-//	    $39::varchar
+//	    $39::varchar,
+//	    $40::text,
+//	    $41::text,
+//	    $42::int,
+//	    $43::int,
+//	    $44::boolean,
+//	    $45::boolean
 //	)
 //	ON CONFLICT (installation_id, request_id, span_type) DO NOTHING
 func (q *Queries) InsertRequestTelemetry(ctx context.Context, arg InsertRequestTelemetryParams) error {
@@ -1010,6 +1040,12 @@ func (q *Queries) InsertRequestTelemetry(ctx context.Context, arg InsertRequestT
 		arg.ClientApp,
 		arg.TurnType,
 		arg.RolloutID,
+		arg.UpstreamFinishReason,
+		arg.StopReason,
+		arg.ToolUseBlocks,
+		arg.InvalidToolArgsBlocks,
+		arg.FailoverUsed,
+		arg.DegenerateShadow,
 	)
 	return err
 }

--- a/internal/sqlc/models.go
+++ b/internal/sqlc/models.go
@@ -119,6 +119,12 @@ type RouterModelRouterRequestTelemetry struct {
 	ClientApp              *string
 	TurnType               *string
 	RolloutID              *string
+	UpstreamFinishReason   *string
+	StopReason             *string
+	ToolUseBlocks          *int32
+	InvalidToolArgsBlocks  *int32
+	FailoverUsed           *bool
+	DegenerateShadow       *bool
 }
 
 // End-user identities seen on inbound requests, scoped to an installation. Replaces the per-user API key pattern.
@@ -162,6 +168,56 @@ type RouterOrganizationCreditLedger struct {
 	RouterModel           *string
 	CreatedAt             pgtype.Timestamptz
 	Memo                  *string
+}
+
+type RouterProductionRequestTelemetry struct {
+	ID                     uuid.UUID
+	InstallationID         uuid.UUID
+	RequestID              string
+	SpanType               string
+	TraceID                string
+	Timestamp              pgtype.Timestamptz
+	RequestedModel         *string
+	DecisionModel          *string
+	DecisionProvider       *string
+	DecisionReason         *string
+	EstimatedInputTokens   *int32
+	StickyHit              *bool
+	EmbedInput             *string
+	InputTokens            *int32
+	OutputTokens           *int32
+	RequestedInputCostUsd  *int64
+	RequestedOutputCostUsd *int64
+	ActualInputCostUsd     *int64
+	ActualOutputCostUsd    *int64
+	RouteLatencyMs         *int64
+	UpstreamLatencyMs      *int64
+	TotalLatencyMs         *int64
+	CrossFormat            *bool
+	UpstreamStatusCode     *int32
+	CreatedAt              pgtype.Timestamptz
+	ClusterIds             []int32
+	CandidateModels        []string
+	ChosenScore            *float64
+	AlphaBreakdown         []byte
+	ClusterRouterVersion   *string
+	TtftMs                 *int64
+	CacheCreationTokens    *int32
+	CacheReadTokens        *int32
+	DeviceID               *string
+	SessionID              *string
+	CandidateScores        []byte
+	Propensity             *float64
+	RouterUserID           pgtype.UUID
+	ClientApp              *string
+	TurnType               *string
+	RolloutID              *string
+	UpstreamFinishReason   *string
+	StopReason             *string
+	ToolUseBlocks          *int32
+	InvalidToolArgsBlocks  *int32
+	FailoverUsed           *bool
+	DegenerateShadow       *bool
 }
 
 // Session-sticky routing pins; sliding 1h TTL matching Anthropic prompt cache


### PR DESCRIPTION
## Summary

- **Migration 0015**: Adds 6 nullable columns to `router.model_router_request_telemetry` — `upstream_finish_reason`, `stop_reason`, `tool_use_blocks`, `invalid_tool_args_blocks`, `failover_used`, `degenerate_shadow`
- **Production view**: Creates `router.production_request_telemetry` filtering `client_app NOT LIKE 'weave-eval%'` so routing-health queries exclude eval traffic without re-deriving the predicate ad hoc
- **ProxyMessages telemetry**: Populates all 6 new fields from `respSummary`; OpenAI path gets `failover_used` only (no translator summary)
- **Degenerate shadow detector**: Shadow-logs `router.degenerate_shadow` INFO when `output_tokens < 10 AND tool_use_blocks == 0 AND stop_reason == "end_turn"` — no failover yet, shadow phase to validate the predicate first

## Context

Driven by the 2026-06-11 routing-health read where a single offline knob-sweep install contributed ~944 one-day calls and swamped a 7d aggregate (faking a "gemini-3.1-pro returns 90% empty" alarm — it had 1 real call). See `docs/plans/ROUTER_TELEMETRY_HYGIENE_AND_EMPTY_GUARD.md`.

## Test plan

- [ ] `wv mr tc` passes
- [ ] `wv mr t` passes
- [ ] `wv db run-migrations -r` applies cleanly after router merge+deploy
- [ ] After a few days, query `SELECT client_app, COUNT(*) FROM router.production_request_telemetry GROUP BY 1` to confirm eval traffic is excluded

🤖 Generated with [Claude Code](https://claude.com/claude-code)