### PR TITLE
feat(cluster): lambda_cost objective for absolute quality scoring

### DIFF
--- a/db/migrations/0019_phase0_trajectory_cache_ledger.down.sql
+++ b/db/migrations/0019_phase0_trajectory_cache_ledger.down.sql
@@ -1,0 +1,19 @@
+BEGIN;
+
+ALTER TABLE router.model_router_request_telemetry
+    DROP COLUMN trajectory_id,
+    DROP COLUMN turn_idx,
+    DROP COLUMN step_record,
+    DROP COLUMN step_record_version,
+    DROP COLUMN action_distribution,
+    DROP COLUMN eligible_models,
+    DROP COLUMN override_reason;
+
+ALTER TABLE router.session_pins
+    DROP COLUMN trajectory_id,
+    DROP COLUMN parent_trajectory_id,
+    DROP COLUMN cache_ledger,
+    DROP COLUMN cumulative_spend_microusd,
+    DROP COLUMN switch_count;
+
+COMMIT;

--- a/db/migrations/0019_phase0_trajectory_cache_ledger.up.sql
+++ b/db/migrations/0019_phase0_trajectory_cache_ledger.up.sql
@@ -1,0 +1,71 @@
+BEGIN;
+
+-- Phase 0 of the learned-routing-policy plan (docs/new_architecture/PLAN.md):
+-- the trajectory + cache-ledger substrate every later phase trains on.
+
+-- ---------------------------------------------------------------------------
+-- session_pins: cache ledger + session aggregates + stable trajectory id.
+--
+-- trajectory_id is minted once per pin row and survives session-key drift
+-- (the derived key can shift when compaction rewrites the first user
+-- message); telemetry rows copy it so trajectories are joinable offline.
+--
+-- cache_ledger is an LRU map over the last few (provider, model) pairs the
+-- session has been served by. Per entry: last-turn timestamp, last usage
+-- token counts, consecutive turns, and the last warm-prefix reconciliation
+-- error. It generalizes the single-slot last_* columns (which stay for the
+-- planner) so a policy can see that switching BACK to a recently-used model
+-- within its provider's cache TTL is nearly free.
+-- ---------------------------------------------------------------------------
+ALTER TABLE router.session_pins
+    ADD COLUMN trajectory_id             UUID NOT NULL DEFAULT gen_random_uuid(),
+    ADD COLUMN parent_trajectory_id      UUID,
+    ADD COLUMN cache_ledger              JSONB NOT NULL DEFAULT '{}'::jsonb,
+    ADD COLUMN cumulative_spend_microusd BIGINT NOT NULL DEFAULT 0,
+    ADD COLUMN switch_count              INT NOT NULL DEFAULT 0;
+
+COMMENT ON COLUMN router.session_pins.trajectory_id IS
+  'Stable trajectory UUID minted on first pin; survives session-key drift, copied onto telemetry rows';
+COMMENT ON COLUMN router.session_pins.parent_trajectory_id IS
+  'Trajectory of the dispatching parent session for sub-agent threads; NULL for main loops';
+COMMENT ON COLUMN router.session_pins.cache_ledger IS
+  'LRU map keyed "provider/model" -> {last_turn_at, last_input_tokens, last_cache_read_tokens, last_cache_creation_tokens, last_output_tokens, consecutive_turns, last_reconcile_error_tokens}';
+COMMENT ON COLUMN router.session_pins.cumulative_spend_microusd IS
+  'Running actual upstream spend for the session in micro-USD, accumulated on usage writeback';
+COMMENT ON COLUMN router.session_pins.switch_count IS
+  'Number of served-model switches observed on usage writeback (complements has_ever_switched latch)';
+
+-- ---------------------------------------------------------------------------
+-- request telemetry: the logged observation/action record the trainer
+-- consumes verbatim (log-and-train-on-logged; PLAN.md G10). step_record is
+-- the versioned fixed-shape observation the policy saw; action_distribution
+-- is the full behavior-policy distribution over the eligible set (model ->
+-- propensity), not just the chosen action's propensity, so DR can evaluate
+-- any target policy later.
+-- ---------------------------------------------------------------------------
+ALTER TABLE router.model_router_request_telemetry
+    ADD COLUMN trajectory_id        UUID,
+    ADD COLUMN turn_idx             INT,
+    ADD COLUMN step_record          JSONB,
+    ADD COLUMN step_record_version  INT,
+    ADD COLUMN action_distribution  JSONB,
+    ADD COLUMN eligible_models      TEXT[],
+    ADD COLUMN override_reason      VARCHAR;
+
+COMMENT ON COLUMN router.model_router_request_telemetry.trajectory_id IS
+  'Copied from session_pins.trajectory_id at decision time; the offline trajectory join key';
+COMMENT ON COLUMN router.model_router_request_telemetry.turn_idx IS
+  'Atomic per-trajectory turn counter (pins row), not timestamp ordering';
+COMMENT ON COLUMN router.model_router_request_telemetry.step_record IS
+  'Versioned observation record computed in the Go hot path; trainers consume it verbatim and never reconstruct features';
+COMMENT ON COLUMN router.model_router_request_telemetry.step_record_version IS
+  'Schema version of step_record; trainers refuse mixed versions without a migration map';
+COMMENT ON COLUMN router.model_router_request_telemetry.action_distribution IS
+  'Behavior policy distribution over eligible models {model: probability}; NULL on non-policy spans';
+COMMENT ON COLUMN router.model_router_request_telemetry.eligible_models IS
+  'Eligible set after provider/exclusion/capability/context filters, at decision time';
+COMMENT ON COLUMN router.model_router_request_telemetry.override_reason IS
+  'Set when a safety override (hard pin, force-model, error failover) bypassed the policy; row excluded from policy training';
+
+
+COMMIT;

--- a/db/queries/session_pins.sql
+++ b/db/queries/session_pins.sql
@@ -65,6 +65,14 @@ ON CONFLICT (session_key, role) DO UPDATE SET
 -- keeps the emit path stripping on every subsequent same-model turn for the
 -- session's life — the only window in which those poisoned blocks would
 -- otherwise reach Anthropic and 400.
+-- The cache_ledger merge upserts this turn's (provider, model) entry in the
+-- same atomic UPDATE: consecutive_turns increments while the served model is
+-- unchanged and resets to 1 on a switch; last_reconcile_error_tokens records,
+-- on revisit of an existing entry, the signed gap between the cache reuse the
+-- entry predicted (its previous last_input_tokens) and the cache_read the
+-- provider actually reported — a learnable provider-cache-reliability signal.
+-- switch_count and cumulative_spend_microusd are session aggregates for the
+-- step record. Entry count is bounded by roster size + pin TTL; no LRU trim.
 -- name: UpdateSessionPinUsage :exec
 UPDATE router.session_pins
 SET last_input_tokens        = @last_input_tokens::int,
@@ -74,6 +82,32 @@ SET last_input_tokens        = @last_input_tokens::int,
     last_turn_ended_at       = @last_turn_ended_at::timestamptz,
     has_ever_switched        = has_ever_switched
       OR (last_served_model <> '' AND last_served_model <> @last_served_model::varchar),
+    switch_count             = switch_count
+      + CASE WHEN last_served_model <> '' AND last_served_model <> @last_served_model::varchar
+          THEN 1 ELSE 0 END,
+    cumulative_spend_microusd = cumulative_spend_microusd + @turn_spend_microusd::bigint,
+    cache_ledger             = jsonb_set(
+      cache_ledger,
+      ARRAY[@ledger_key::text],
+      jsonb_build_object(
+        'last_turn_at',               to_jsonb(@last_turn_ended_at::timestamptz),
+        'last_input_tokens',          @last_input_tokens::int,
+        'last_cache_read_tokens',     @last_cached_read_tokens::int,
+        'last_cache_creation_tokens', @last_cached_write_tokens::int,
+        'last_output_tokens',         @last_output_tokens::int,
+        'consecutive_turns', CASE
+          WHEN last_served_model = @last_served_model::varchar
+            THEN COALESCE((cache_ledger->(@ledger_key::text)->>'consecutive_turns')::int, 0) + 1
+          ELSE 1
+        END,
+        'last_reconcile_error_tokens', CASE
+          WHEN jsonb_exists(cache_ledger, @ledger_key::text)
+            THEN to_jsonb((@last_cached_read_tokens::int)
+              - COALESCE((cache_ledger->(@ledger_key::text)->>'last_input_tokens')::int, 0))
+          ELSE 'null'::jsonb
+        END
+      )
+    ),
     last_served_model        = @last_served_model::varchar
 WHERE session_key = @session_key::bytea
   AND role        = @role::varchar;

--- a/internal/postgres/session_pin_repo.go
+++ b/internal/postgres/session_pin_repo.go
@@ -3,12 +3,14 @@ package postgres
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"errors"
 	"time"
 
 	"workweave/router/internal/router/sessionpin"
 	"workweave/router/internal/sqlc"
 
+	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgtype"
 )
 
@@ -75,6 +77,8 @@ func (r *SessionPinRepo) UpdateUsage(ctx context.Context, sessionKey [sessionpin
 		LastOutputTokens:      int32(usage.OutputTokens),
 		LastTurnEndedAt:       pgtype.Timestamptz{Time: endedAt.UTC(), Valid: true},
 		LastServedModel:       usage.ServedModel,
+		TurnSpendMicrousd:     usage.TurnSpendMicroUSD,
+		LedgerKey:             sessionpin.LedgerKey(usage.ServedProvider, usage.ServedModel),
 	})
 }
 
@@ -133,10 +137,41 @@ func toSessionPin(row sqlc.RouterSessionPin) sessionpin.Pin {
 		LastServedModel:           row.LastServedModel,
 		HasEverSwitched:           row.HasEverSwitched,
 		ConsecutiveUpstreamErrors: int(row.ConsecutiveUpstreamErrors),
+		TrajectoryID:              row.TrajectoryID,
+		ParentTrajectoryID:        uuidOrZero(row.ParentTrajectoryID),
+		Ledger:                    toCacheLedger(row.CacheLedger),
+		CumulativeSpendMicroUSD:   row.CumulativeSpendMicrousd,
+		SwitchCount:               int(row.SwitchCount),
 	}
 	// Bounded copy guards against a corrupt row panicking the request handler.
 	copy(pin.SessionKey[:], row.SessionKey)
 	return pin
+}
+
+// toCacheLedger decodes the cache_ledger JSONB column. A corrupt or empty
+// blob degrades to a nil ledger (cache features read as cold) rather than
+// failing the pin read — routing must not 503 on ledger damage.
+func toCacheLedger(raw []byte) sessionpin.CacheLedger {
+	if len(raw) == 0 {
+		return nil
+	}
+	var ledger sessionpin.CacheLedger
+	if err := json.Unmarshal(raw, &ledger); err != nil {
+		return nil
+	}
+	if len(ledger) == 0 {
+		return nil
+	}
+	return ledger
+}
+
+// uuidOrZero surfaces a NULL uuid column as the zero uuid.UUID so domain
+// types stay free of pgtype concerns.
+func uuidOrZero(u pgtype.UUID) uuid.UUID {
+	if !u.Valid {
+		return uuid.UUID{}
+	}
+	return u.Bytes
 }
 
 // timestamptzOrZero mirrors timestampOrZero for TIMESTAMPTZ columns;

--- a/internal/proxy/gemini.go
+++ b/internal/proxy/gemini.go
@@ -214,7 +214,7 @@ func (s *Service) ProxyGeminiGenerateContent(ctx context.Context, body []byte, w
 
 	// Persist last-turn usage to the pin row so the next turn's planner
 	// has cache-hit evidence. Off the request path; drops on saturation.
-	s.recordTurnUsage(routeRes, in, out, cacheCreation, cacheRead)
+	s.recordTurnUsage(routeRes, actPricing, in, out, cacheCreation, cacheRead)
 
 	if proxyErr == nil {
 		s.emitBilling(ctx, requestID, externalID, decision, actPricing, routeRes, in, out, cacheCreation, cacheRead)

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -1563,7 +1563,7 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 	})
 	otel.Flush(ctx)
 
-	s.recordTurnUsage(routeRes, in, out, cacheCreation, cacheRead)
+	s.recordTurnUsage(routeRes, actPricing, in, out, cacheCreation, cacheRead)
 
 	if installationID != uuid.Nil {
 		s.fireTelemetry(InsertTelemetryParams{
@@ -1728,7 +1728,7 @@ func (s *Service) logPlannerOutcome(ctx context.Context, res turnLoopResult) {
 	)
 }
 
-func (s *Service) recordTurnUsage(res turnLoopResult, in, out, cacheCreation, cacheRead int) {
+func (s *Service) recordTurnUsage(res turnLoopResult, actPricing catalog.Pricing, in, out, cacheCreation, cacheRead int) {
 	if s.pinStore == nil || res.HardPinned {
 		return
 	}
@@ -1739,6 +1739,8 @@ func (s *Service) recordTurnUsage(res turnLoopResult, in, out, cacheCreation, ca
 	if in == 0 && out == 0 && cacheCreation == 0 && cacheRead == 0 {
 		return
 	}
+	turnCostUSD := catalog.EffectiveInputCost(in, cacheCreation, cacheRead, actPricing.InputUSDPer1M, actPricing, res.Decision.Provider) +
+		catalog.EffectiveOutputCost(out, actPricing.OutputUSDPer1M)
 	usage := sessionpin.Usage{
 		InputTokens:       in,
 		CachedReadTokens:  cacheRead,
@@ -1746,6 +1748,8 @@ func (s *Service) recordTurnUsage(res turnLoopResult, in, out, cacheCreation, ca
 		OutputTokens:      out,
 		EndedAt:           time.Now(),
 		ServedModel:       res.Decision.Model,
+		ServedProvider:    res.Decision.Provider,
+		TurnSpendMicroUSD: int64(turnCostUSD * 1e6),
 	}
 	role := res.PinRole
 	if role == "" {
@@ -2547,7 +2551,7 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 	})
 	otel.Flush(ctx)
 
-	s.recordTurnUsage(routeRes, in, out, cacheCreation, cacheRead)
+	s.recordTurnUsage(routeRes, actPricing, in, out, cacheCreation, cacheRead)
 
 	if proxyErr == nil {
 		s.emitBilling(ctx, requestID, externalID, decision, actPricing, routeRes, in, out, cacheCreation, cacheRead)

--- a/internal/proxy/turnloop_internal_test.go
+++ b/internal/proxy/turnloop_internal_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"workweave/router/internal/router"
+	"workweave/router/internal/router/catalog"
 	"workweave/router/internal/router/sessionpin"
 )
 
@@ -92,7 +93,9 @@ func TestRecordTurnUsage_WritesToStore(t *testing.T) {
 		SessionKey: sessionKey,
 		PinRole:    sessionpin.DefaultRole,
 	}
-	svc.recordTurnUsage(res, 1200, 80, 200, 900)
+	pricing, ok := catalog.PrimaryPriceFor("claude-opus-4-7")
+	require.True(t, ok)
+	svc.recordTurnUsage(res, pricing, 1200, 80, 200, 900)
 
 	store.mu.Lock()
 	defer store.mu.Unlock()
@@ -102,6 +105,8 @@ func TestRecordTurnUsage_WritesToStore(t *testing.T) {
 	assert.Equal(t, 200, store.lastUsage.CachedWriteTokens)
 	assert.Equal(t, 80, store.lastUsage.OutputTokens)
 	assert.Equal(t, "claude-opus-4-7", store.lastUsage.ServedModel)
+	assert.Equal(t, "anthropic", store.lastUsage.ServedProvider, "ServedProvider keys the cache-ledger entry")
+	assert.Positive(t, store.lastUsage.TurnSpendMicroUSD, "turn spend must accumulate onto the session's cumulative spend")
 	assert.False(t, store.lastUsage.EndedAt.IsZero(), "EndedAt must be stamped — the planner uses IsZero() as its no-prior-usage gate")
 }
 

--- a/internal/router/cluster/artifacts.go
+++ b/internal/router/cluster/artifacts.go
@@ -161,11 +161,11 @@ type RecommendedKnobs struct {
 }
 
 type ArtifactTraining struct {
-	K                     int                          `yaml:"k"`
-	TopP                  int                          `yaml:"top_p"`
-	Alpha                 float64                      `yaml:"alpha"`
-	Seed                  int                          `yaml:"seed"`
-	NPrompts              int                          `yaml:"n_prompts"`
+	K        int     `yaml:"k"`
+	TopP     int     `yaml:"top_p"`
+	Alpha    float64 `yaml:"alpha"`
+	Seed     int     `yaml:"seed"`
+	NPrompts int     `yaml:"n_prompts"`
 	// Objective selects the runtime scoring function. "lambda_cost" uses
 	// absolute quality_means with score = q - lambda_cost * dollar_cost.
 	Objective             string                       `yaml:"objective,omitempty"`

--- a/internal/router/cluster/artifacts.go
+++ b/internal/router/cluster/artifacts.go
@@ -148,12 +148,16 @@ type DefaultRoutingKnobs struct {
 	OutputCostRatio      float64   `yaml:"output_cost_ratio"`
 	ExpectedOutputTokens int       `yaml:"expected_output_tokens"`
 	PerModelVerbosity    bool      `yaml:"per_model_verbosity"`
+	// LambdaCost weights the dollar-cost term when objective=lambda_cost:
+	// score = q - lambda_cost * estimated_query_cost_usd.
+	LambdaCost float64 `yaml:"lambda_cost,omitempty"`
 }
 
 type RecommendedKnobs struct {
 	Alpha           float64 `yaml:"alpha"`
 	SpeedWeight     float64 `yaml:"speed_weight"`
 	OutputCostRatio float64 `yaml:"output_cost_ratio"`
+	LambdaCost      float64 `yaml:"lambda_cost,omitempty"`
 }
 
 type ArtifactTraining struct {
@@ -162,6 +166,9 @@ type ArtifactTraining struct {
 	Alpha                 float64                      `yaml:"alpha"`
 	Seed                  int                          `yaml:"seed"`
 	NPrompts              int                          `yaml:"n_prompts"`
+	// Objective selects the runtime scoring function. "lambda_cost" uses
+	// absolute quality_means with score = q - lambda_cost * dollar_cost.
+	Objective             string                       `yaml:"objective,omitempty"`
 	TrainingDataMix       map[string]float64           `yaml:"training_data_mix,omitempty"`
 	DefaultRoutingKnobs   *DefaultRoutingKnobs         `yaml:"default_routing_knobs,omitempty"`
 	RecommendedUIDefaults map[string]*RecommendedKnobs `yaml:"recommended_ui_defaults,omitempty"`

--- a/internal/router/cluster/scorer.go
+++ b/internal/router/cluster/scorer.go
@@ -459,6 +459,9 @@ func (s *Scorer) Route(ctx context.Context, req router.Request) (router.Decision
 			if req.RoutingKnobs.PerModelVerbosity != nil {
 				activeKnobs.PerModelVerbosity = *req.RoutingKnobs.PerModelVerbosity
 			}
+			if req.RoutingKnobs.LambdaCost != nil {
+				activeKnobs.LambdaCost = *req.RoutingKnobs.LambdaCost
+			}
 		}
 
 		// Validate effective knobs. Alpha length is sanity-checked here as a
@@ -497,6 +500,18 @@ func (s *Scorer) Route(ctx context.Context, req router.Request) (router.Decision
 			return router.Decision{}, fmt.Errorf("%w: expected_output_tokens (%d) must be in [0, 100000]", ErrInvalidRoutingKnobs, activeKnobs.ExpectedOutputTokens)
 		}
 
+		useLambdaCost := s.metadata != nil &&
+			s.metadata.Training.Objective == "lambda_cost"
+		if useLambdaCost {
+			lambda := activeKnobs.LambdaCost
+			if req.RoutingKnobs != nil && req.RoutingKnobs.LambdaCost != nil {
+				lambda = *req.RoutingKnobs.LambdaCost
+			}
+			if lambda < 0 {
+				return router.Decision{}, fmt.Errorf("%w: lambda_cost (%f) must be >= 0", ErrInvalidRoutingKnobs, lambda)
+			}
+		}
+
 		effectiveKnobsHash = ComputeKnobsHash(
 			activeKnobs.Alpha,
 			activeKnobs.SpeedWeight,
@@ -504,6 +519,33 @@ func (s *Scorer) Route(ctx context.Context, req router.Request) (router.Decision
 			activeKnobs.ExpectedOutputTokens,
 			activeKnobs.PerModelVerbosity,
 		)
+
+		if useLambdaCost {
+			lambda := activeKnobs.LambdaCost
+			inputTokens := req.EstimatedInputTokens
+			if inputTokens <= 0 {
+				inputTokens = len(text) / 4
+				if inputTokens <= 0 {
+					inputTokens = 1
+				}
+			}
+			scores = make(map[string]float32, len(eligibleModels))
+			for _, k := range topClusters {
+				row := s.qualityMeans[k]
+				for _, m := range eligibleModels {
+					qVal := row[m]
+					dollars := estimateQueryCostUSD(
+						s.modelAxes[m],
+						inputTokens,
+						activeKnobs.ExpectedOutputTokens,
+						activeKnobs.OutputCostRatio,
+						activeKnobs.PerModelVerbosity,
+						s.medianVerbosity,
+					)
+					scores[m] += float32(qVal) - float32(lambda*dollars)
+				}
+			}
+		} else {
 
 		// 2. Effective per-model cost (knob-dependent)
 		costs := make(map[string]float64, len(s.models))
@@ -661,6 +703,7 @@ func (s *Scorer) Route(ctx context.Context, req router.Request) (router.Decision
 					}
 				}
 			}
+		}
 		}
 	} else {
 		// Legacy v1 flow
@@ -849,6 +892,32 @@ func tailTruncate(s string, maxChars int) string {
 		cut++
 	}
 	return s[cut:]
+}
+
+// estimateQueryCostUSD returns a rough per-query dollar estimate from model_axes.
+func estimateQueryCostUSD(
+	axis ModelAxis,
+	inputTokens int,
+	expectedOutputTokens int,
+	outputCostRatio float64,
+	perModelVerbosity bool,
+	medianVerbosity float64,
+) float64 {
+	inputPer1K := 0.0
+	if axis.InputPer1KUSD != nil {
+		inputPer1K = *axis.InputPer1KUSD
+	}
+	outputPer1K := 0.0
+	if axis.OutputPer1KUSD != nil {
+		outputPer1K = *axis.OutputPer1KUSD
+	}
+	vFactor := 1.0
+	if perModelVerbosity && axis.VerbosityTokens != nil && medianVerbosity > 0 {
+		vFactor = *axis.VerbosityTokens / medianVerbosity
+	}
+	inputUSD := (float64(inputTokens) / 1000.0) * inputPer1K
+	outputUSD := (float64(expectedOutputTokens) / 1000.0) * outputPer1K * outputCostRatio * vFactor
+	return inputUSD + outputUSD
 }
 
 func clusterIDsString(ks []int) string {

--- a/internal/router/cluster/scorer.go
+++ b/internal/router/cluster/scorer.go
@@ -547,163 +547,163 @@ func (s *Scorer) Route(ctx context.Context, req router.Request) (router.Decision
 			}
 		} else {
 
-		// 2. Effective per-model cost (knob-dependent)
-		costs := make(map[string]float64, len(s.models))
-		for _, m := range s.models {
-			axis := s.modelAxes[m]
-			vFactor := 1.0
-			if activeKnobs.PerModelVerbosity && axis.VerbosityTokens != nil && s.medianVerbosity > 0 {
-				vFactor = *axis.VerbosityTokens / s.medianVerbosity
-			}
-			inputPer1K := 0.0
-			if axis.InputPer1KUSD != nil {
-				inputPer1K = *axis.InputPer1KUSD
-			}
-			outputPer1K := 0.0
-			if axis.OutputPer1KUSD != nil {
-				outputPer1K = *axis.OutputPer1KUSD
-			}
-			costs[m] = inputPer1K + activeKnobs.OutputCostRatio*outputPer1K*vFactor
-		}
-
-		// 3. Effective per-model speed
-		speeds := make(map[string]*float64, len(s.models))
-		for _, m := range s.models {
-			axis := s.modelAxes[m]
-			if axis.TTFTSeconds != nil && axis.TPS != nil && *axis.TPS > 0 {
-				val := *axis.TTFTSeconds + float64(activeKnobs.ExpectedOutputTokens) / *axis.TPS
-				speeds[m] = &val
-			} else {
-				speeds[m] = nil
-			}
-		}
-
-		// 4. Normalize over DEPLOYED model set
-		qMin := make(map[int]float32)
-		qMax := make(map[int]float32)
-		for _, k := range topClusters {
-			row := s.qualityMeans[k]
-			first := true
+			// 2. Effective per-model cost (knob-dependent)
+			costs := make(map[string]float64, len(s.models))
 			for _, m := range s.models {
-				qVal := row[m]
-				if first {
-					qMin[k] = qVal
-					qMax[k] = qVal
-					first = false
+				axis := s.modelAxes[m]
+				vFactor := 1.0
+				if activeKnobs.PerModelVerbosity && axis.VerbosityTokens != nil && s.medianVerbosity > 0 {
+					vFactor = *axis.VerbosityTokens / s.medianVerbosity
+				}
+				inputPer1K := 0.0
+				if axis.InputPer1KUSD != nil {
+					inputPer1K = *axis.InputPer1KUSD
+				}
+				outputPer1K := 0.0
+				if axis.OutputPer1KUSD != nil {
+					outputPer1K = *axis.OutputPer1KUSD
+				}
+				costs[m] = inputPer1K + activeKnobs.OutputCostRatio*outputPer1K*vFactor
+			}
+
+			// 3. Effective per-model speed
+			speeds := make(map[string]*float64, len(s.models))
+			for _, m := range s.models {
+				axis := s.modelAxes[m]
+				if axis.TTFTSeconds != nil && axis.TPS != nil && *axis.TPS > 0 {
+					val := *axis.TTFTSeconds + float64(activeKnobs.ExpectedOutputTokens) / *axis.TPS
+					speeds[m] = &val
 				} else {
-					if qVal < qMin[k] {
+					speeds[m] = nil
+				}
+			}
+
+			// 4. Normalize over DEPLOYED model set
+			qMin := make(map[int]float32)
+			qMax := make(map[int]float32)
+			for _, k := range topClusters {
+				row := s.qualityMeans[k]
+				first := true
+				for _, m := range s.models {
+					qVal := row[m]
+					if first {
 						qMin[k] = qVal
-					}
-					if qVal > qMax[k] {
 						qMax[k] = qVal
+						first = false
+					} else {
+						if qVal < qMin[k] {
+							qMin[k] = qVal
+						}
+						if qVal > qMax[k] {
+							qMax[k] = qVal
+						}
 					}
 				}
 			}
-		}
 
-		var cMin, cMax float64
-		firstC := true
-		for _, m := range s.models {
-			cVal := costs[m]
-			if firstC {
-				cMin = cVal
-				cMax = cVal
-				firstC = false
-			} else {
-				if cVal < cMin {
-					cMin = cVal
-				}
-				if cVal > cMax {
-					cMax = cVal
-				}
-			}
-		}
-		cRange := cMax - cMin
-
-		useSpeed := activeKnobs.SpeedWeight > 0
-		var sMin, sMax float64
-		firstS := true
-		for _, m := range s.models {
-			if !useSpeed {
-				break
-			}
-			sPtr := speeds[m]
-			if sPtr == nil {
-				continue
-			}
-			sVal := *sPtr
-			if firstS {
-				sMin = sVal
-				sMax = sVal
-				firstS = false
-			} else {
-				if sVal < sMin {
-					sMin = sVal
-				}
-				if sVal > sMax {
-					sMax = sVal
-				}
-			}
-		}
-		sRange := 0.0
-		if useSpeed && !firstS {
-			sRange = sMax - sMin
-		}
-
-		// 6. Blend per top-P cluster
-		scores = make(map[string]float32, len(eligibleModels))
-		for _, k := range topClusters {
-			row := s.qualityMeans[k]
-			wQ := float32(activeKnobs.Alpha[k])
-			wS := float32(0.0)
-			if useSpeed {
-				wS = float32(activeKnobs.SpeedWeight)
-			}
-			wC := float32(1.0) - wQ - wS
-
-			qRange := qMax[k] - qMin[k]
-
-			for _, m := range eligibleModels {
-				qVal := row[m]
-				qNorm := float32(0.0)
-				if qRange > 0 {
-					qNorm = (qVal - qMin[k]) / qRange
-				}
-
+			var cMin, cMax float64
+			firstC := true
+			for _, m := range s.models {
 				cVal := costs[m]
-				cNorm := float32(0.0)
-				if cRange > 0 {
-					cNorm = float32((cVal - cMin) / cRange)
-				}
-
-				sPtr := speeds[m]
-				if sRange > 0 {
-					// Mixed-timing pool: untimed peers are treated as
-					// worst-case speed (sNorm=1, no wS bonus). This keeps
-					// wQ/wC weighting consistent across timed and untimed
-					// models — without this, the redistribution branch
-					// would silently drop the cost axis when wC=0.
-					var sNorm float32 = 1.0
-					if sPtr != nil {
-						sNorm = float32((*sPtr - sMin) / sRange)
-					}
-					blend := wQ*qNorm + wC*(1.0-cNorm) + wS*(1.0-sNorm)
-					scores[m] += blend
+				if firstC {
+					cMin = cVal
+					cMax = cVal
+					firstC = false
 				} else {
-					// No timing differentiation across the entire pool
-					// (all models lack AA timing, or all share the same
-					// speed). Redistribute wS into wQ and wC so the
-					// remaining weights still sum to 1.
-					total := wQ + wC
-					if total > 0 {
-						blend := (wQ/total)*qNorm + (wC/total)*(1.0-cNorm)
+					if cVal < cMin {
+						cMin = cVal
+					}
+					if cVal > cMax {
+						cMax = cVal
+					}
+				}
+			}
+			cRange := cMax - cMin
+
+			useSpeed := activeKnobs.SpeedWeight > 0
+			var sMin, sMax float64
+			firstS := true
+			for _, m := range s.models {
+				if !useSpeed {
+					break
+				}
+				sPtr := speeds[m]
+				if sPtr == nil {
+					continue
+				}
+				sVal := *sPtr
+				if firstS {
+					sMin = sVal
+					sMax = sVal
+					firstS = false
+				} else {
+					if sVal < sMin {
+						sMin = sVal
+					}
+					if sVal > sMax {
+						sMax = sVal
+					}
+				}
+			}
+			sRange := 0.0
+			if useSpeed && !firstS {
+				sRange = sMax - sMin
+			}
+
+			// 6. Blend per top-P cluster
+			scores = make(map[string]float32, len(eligibleModels))
+			for _, k := range topClusters {
+				row := s.qualityMeans[k]
+				wQ := float32(activeKnobs.Alpha[k])
+				wS := float32(0.0)
+				if useSpeed {
+					wS = float32(activeKnobs.SpeedWeight)
+				}
+				wC := float32(1.0) - wQ - wS
+
+				qRange := qMax[k] - qMin[k]
+
+				for _, m := range eligibleModels {
+					qVal := row[m]
+					qNorm := float32(0.0)
+					if qRange > 0 {
+						qNorm = (qVal - qMin[k]) / qRange
+					}
+
+					cVal := costs[m]
+					cNorm := float32(0.0)
+					if cRange > 0 {
+						cNorm = float32((cVal - cMin) / cRange)
+					}
+
+					sPtr := speeds[m]
+					if sRange > 0 {
+						// Mixed-timing pool: untimed peers are treated as
+						// worst-case speed (sNorm=1, no wS bonus). This keeps
+						// wQ/wC weighting consistent across timed and untimed
+						// models — without this, the redistribution branch
+						// would silently drop the cost axis when wC=0.
+						var sNorm float32 = 1.0
+						if sPtr != nil {
+							sNorm = float32((*sPtr - sMin) / sRange)
+						}
+						blend := wQ*qNorm + wC*(1.0-cNorm) + wS*(1.0-sNorm)
 						scores[m] += blend
 					} else {
-						scores[m] += qNorm
+						// No timing differentiation across the entire pool
+						// (all models lack AA timing, or all share the same
+						// speed). Redistribute wS into wQ and wC so the
+						// remaining weights still sum to 1.
+						total := wQ + wC
+						if total > 0 {
+							blend := (wQ/total)*qNorm + (wC/total)*(1.0-cNorm)
+							scores[m] += blend
+						} else {
+							scores[m] += qNorm
+						}
 					}
 				}
 			}
-		}
 		}
 	} else {
 		// Legacy v1 flow

--- a/internal/router/cluster/scorer_test.go
+++ b/internal/router/cluster/scorer_test.go
@@ -1067,8 +1067,8 @@ func TestScorer_LambdaCostObjective(t *testing.T) {
 	haikuInput := 0.00025
 	haikuOutput := 0.00125
 	modelAxes := map[string]ModelAxis{
-		"claude-opus-4-7":   {InputPer1KUSD: &opusInput, OutputPer1KUSD: &opusOutput},
-		"claude-haiku-4-5":  {InputPer1KUSD: &haikuInput, OutputPer1KUSD: &haikuOutput},
+		"claude-opus-4-7":  {InputPer1KUSD: &opusInput, OutputPer1KUSD: &opusOutput},
+		"claude-haiku-4-5": {InputPer1KUSD: &haikuInput, OutputPer1KUSD: &haikuOutput},
 	}
 
 	lambda := 0.0

--- a/internal/router/cluster/scorer_test.go
+++ b/internal/router/cluster/scorer_test.go
@@ -1038,6 +1038,89 @@ func TestScorer_V2DynamicScoring(t *testing.T) {
 	assert.ErrorIs(t, err, ErrInvalidRoutingKnobs)
 }
 
+func TestScorer_LambdaCostObjective(t *testing.T) {
+	dim := EmbedDim
+	c0 := make([]float32, dim)
+	c0[0] = 1
+	c1 := make([]float32, dim)
+	c1[1] = 1
+	full := append(append([]float32{}, c0...), c1...)
+	centroidsBlob := buildCentroidsBlob(t, 2, dim, full)
+	centroids, err := loadCentroids(centroidsBlob)
+	require.NoError(t, err)
+	regBlob := []byte(`{
+		"deployed_models": [
+			{"model": "claude-opus-4-7", "provider": "anthropic", "bench_column": "gpt-5", "proxy": true},
+			{"model": "claude-haiku-4-5", "provider": "anthropic", "bench_column": "gemini-2.5-flash", "proxy": true}
+		]
+	}`)
+	registry, err := loadRegistry(regBlob)
+	require.NoError(t, err)
+
+	qualityMeans := Rankings{
+		0: map[string]float32{"claude-opus-4-7": 0.95, "claude-haiku-4-5": 0.20},
+		1: map[string]float32{"claude-opus-4-7": 0.10, "claude-haiku-4-5": 0.90},
+	}
+
+	opusInput := 0.015
+	opusOutput := 0.075
+	haikuInput := 0.00025
+	haikuOutput := 0.00125
+	modelAxes := map[string]ModelAxis{
+		"claude-opus-4-7":   {InputPer1KUSD: &opusInput, OutputPer1KUSD: &opusOutput},
+		"claude-haiku-4-5":  {InputPer1KUSD: &haikuInput, OutputPer1KUSD: &haikuOutput},
+	}
+
+	lambda := 0.0
+	meta := &ArtifactMetadata{
+		FormatVersion: 2,
+		Training: ArtifactTraining{
+			K:         2,
+			TopP:      2,
+			Objective: "lambda_cost",
+			DefaultRoutingKnobs: &DefaultRoutingKnobs{
+				Alpha:                []float64{0.5, 0.5},
+				LambdaCost:           lambda,
+				OutputCostRatio:      1.0,
+				ExpectedOutputTokens: 2000,
+			},
+		},
+	}
+
+	bundle := &Bundle{
+		Version:      "v2-lambda-test",
+		Centroids:    centroids,
+		Registry:     registry,
+		Metadata:     meta,
+		IsV2:         true,
+		QualityMeans: qualityMeans,
+		ModelAxes:    modelAxes,
+	}
+
+	cfg := DefaultConfig()
+	cfg.TopP = 1
+	scorer, err := NewScorer(bundle, cfg, &fakeEmbedder{vec: makeOpusVec()}, allProviders())
+	require.NoError(t, err)
+
+	decQuality, err := scorer.Route(context.Background(), router.Request{
+		RequestedModel: "auto",
+		PromptText:     "test",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "claude-opus-4-7", decQuality.Model)
+
+	lambdaHigh := 50.0
+	decCost, err := scorer.Route(context.Background(), router.Request{
+		RequestedModel: "auto",
+		PromptText:     "test",
+		RoutingKnobs: &router.Overrides{
+			LambdaCost: &lambdaHigh,
+		},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "claude-haiku-4-5", decCost.Model)
+}
+
 // v2BundleOpts is the optional knob configuration for newV2BundleForTest.
 type v2BundleOpts struct {
 	qualityMeans    Rankings // overrides the default opus/haiku table

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -9,6 +9,7 @@ type Overrides struct {
 	OutputCostRatio      *float64
 	ExpectedOutputTokens *int
 	PerModelVerbosity    *bool
+	LambdaCost           *float64
 }
 
 type Request struct {

--- a/internal/router/sessionpin/ledger.go
+++ b/internal/router/sessionpin/ledger.go
@@ -1,0 +1,65 @@
+package sessionpin
+
+import (
+	"time"
+)
+
+// CacheLedger is the per-session map of recently served (provider, model)
+// pairs and their last-turn usage, keyed by LedgerKey. It is maintained
+// atomically in SQL on usage writeback (UpdateSessionPinUsage); Go only
+// reads it to derive cache-warmth features at decision time. Entry count is
+// bounded in practice by the deployed roster size and the pin row's TTL, so
+// no LRU trim is enforced on write.
+type CacheLedger map[string]LedgerEntry
+
+// LedgerEntry records the last completed turn served by one
+// (provider, model) pair within the session.
+type LedgerEntry struct {
+	LastTurnAt              time.Time `json:"last_turn_at"`
+	LastInputTokens         int       `json:"last_input_tokens"`
+	LastCacheReadTokens     int       `json:"last_cache_read_tokens"`
+	LastCacheCreationTokens int       `json:"last_cache_creation_tokens"`
+	LastOutputTokens        int       `json:"last_output_tokens"`
+	ConsecutiveTurns        int       `json:"consecutive_turns"`
+	// LastReconcileErrorTokens is the signed gap between the cache reuse a
+	// warm ledger entry predicted (the entry's previous last_input_tokens)
+	// and the cache_read tokens the provider actually reported, written on
+	// the first revisit of an existing entry. Nil until a pair is revisited.
+	// Persistently large magnitudes mark a provider whose cache is
+	// best-effort; the value is a learnable reliability feature, not an
+	// alarm.
+	LastReconcileErrorTokens *int `json:"last_reconcile_error_tokens,omitempty"`
+}
+
+// LedgerKey is the CacheLedger map key for a (provider, model) pair.
+func LedgerKey(provider, model string) string {
+	return provider + "/" + model
+}
+
+// WarmPrefixTokens estimates the warm cached prefix a candidate
+// (provider, model) still holds for this session: the entry's last input
+// size while the provider's cache TTL has not lapsed, else 0. Prefixes grow
+// monotonically within a CC session, so last input is a lower bound on the
+// reusable prefix.
+func (l CacheLedger) WarmPrefixTokens(provider, model string, now time.Time, ttl time.Duration) int {
+	e, ok := l[LedgerKey(provider, model)]
+	if !ok || ttl <= 0 || now.Sub(e.LastTurnAt) >= ttl {
+		return 0
+	}
+	return e.LastInputTokens
+}
+
+// TTLRemainingFrac is the fraction of the provider cache TTL still
+// remaining for a (provider, model) entry, in [0, 1]. 0 for unknown pairs,
+// lapsed entries, or non-positive TTLs.
+func (l CacheLedger) TTLRemainingFrac(provider, model string, now time.Time, ttl time.Duration) float64 {
+	e, ok := l[LedgerKey(provider, model)]
+	if !ok || ttl <= 0 {
+		return 0
+	}
+	remaining := ttl - now.Sub(e.LastTurnAt)
+	if remaining <= 0 {
+		return 0
+	}
+	return float64(remaining) / float64(ttl)
+}

--- a/internal/router/sessionpin/ledger_test.go
+++ b/internal/router/sessionpin/ledger_test.go
@@ -1,0 +1,65 @@
+package sessionpin_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"workweave/router/internal/router/sessionpin"
+)
+
+func TestLedgerKey(t *testing.T) {
+	assert.Equal(t, "anthropic/claude-opus-4-8", sessionpin.LedgerKey("anthropic", "claude-opus-4-8"))
+}
+
+func TestWarmPrefixTokens(t *testing.T) {
+	now := time.Now()
+	ledger := sessionpin.CacheLedger{
+		sessionpin.LedgerKey("anthropic", "claude-opus-4-8"): {
+			LastTurnAt:      now.Add(-10 * time.Minute),
+			LastInputTokens: 42_000,
+		},
+		sessionpin.LedgerKey("fireworks", "deepseek/deepseek-v4-pro"): {
+			LastTurnAt:      now.Add(-30 * time.Minute),
+			LastInputTokens: 9_000,
+		},
+	}
+
+	hourTTL := time.Hour
+	assert.Equal(t, 42_000, ledger.WarmPrefixTokens("anthropic", "claude-opus-4-8", now, hourTTL),
+		"entry inside TTL reports its last input size as the warm prefix")
+
+	fiveMinTTL := 5 * time.Minute
+	assert.Equal(t, 0, ledger.WarmPrefixTokens("fireworks", "deepseek/deepseek-v4-pro", now, fiveMinTTL),
+		"entry past the provider TTL is cold")
+
+	assert.Equal(t, 0, ledger.WarmPrefixTokens("openai", "gpt-5.5", now, hourTTL),
+		"unknown pair is cold")
+	assert.Equal(t, 0, ledger.WarmPrefixTokens("anthropic", "claude-opus-4-8", now, 0),
+		"non-positive TTL is cold")
+}
+
+func TestTTLRemainingFrac(t *testing.T) {
+	now := time.Now()
+	ledger := sessionpin.CacheLedger{
+		sessionpin.LedgerKey("anthropic", "claude-opus-4-8"): {
+			LastTurnAt: now.Add(-15 * time.Minute),
+		},
+	}
+
+	frac := ledger.TTLRemainingFrac("anthropic", "claude-opus-4-8", now, time.Hour)
+	assert.InDelta(t, 0.75, frac, 0.01, "15 of 60 minutes elapsed leaves 75% of the TTL")
+
+	assert.Zero(t, ledger.TTLRemainingFrac("anthropic", "claude-opus-4-8", now, 10*time.Minute),
+		"lapsed entry reports 0")
+	assert.Zero(t, ledger.TTLRemainingFrac("openai", "gpt-5.5", now, time.Hour),
+		"unknown pair reports 0")
+}
+
+func TestNilLedgerIsCold(t *testing.T) {
+	var ledger sessionpin.CacheLedger
+	now := time.Now()
+	assert.Equal(t, 0, ledger.WarmPrefixTokens("anthropic", "claude-opus-4-8", now, time.Hour))
+	assert.Zero(t, ledger.TTLRemainingFrac("anthropic", "claude-opus-4-8", now, time.Hour))
+}

--- a/internal/router/sessionpin/store.go
+++ b/internal/router/sessionpin/store.go
@@ -64,6 +64,23 @@ type Pin struct {
 	// earlier cross-model excursion left in the client transcript are stripped
 	// on every subsequent turn, not just the single switch-back turn.
 	HasEverSwitched bool
+	// TrajectoryID is the stable per-session trajectory UUID, minted by the
+	// database on first insert. It survives session-key drift (compaction can
+	// rewrite the first user message the key derives from) and is copied
+	// onto telemetry rows as the offline trajectory join key.
+	TrajectoryID uuid.UUID
+	// ParentTrajectoryID links a sub-agent session to the dispatching parent
+	// trajectory. Zero UUID for main loops.
+	ParentTrajectoryID uuid.UUID
+	// Ledger is the per-(provider, model) cache ledger, maintained atomically
+	// in SQL by Store.UpdateUsage and read here to derive cache-warmth
+	// features at decision time.
+	Ledger CacheLedger
+	// CumulativeSpendMicroUSD accumulates the session's actual upstream
+	// spend across turns, written by Store.UpdateUsage.
+	CumulativeSpendMicroUSD int64
+	// SwitchCount counts served-model switches observed on usage writeback.
+	SwitchCount int
 }
 
 // Usage captures the previous turn's upstream token accounting.
@@ -75,6 +92,12 @@ type Usage struct {
 	EndedAt           time.Time
 	// ServedModel is the model that served the turn this usage came from.
 	ServedModel string
+	// ServedProvider is the provider binding that actually served the turn
+	// (post-failover). Keys the cache-ledger entry together with ServedModel.
+	ServedProvider string
+	// TurnSpendMicroUSD is the turn's actual upstream cost in micro-USD,
+	// accumulated onto the pin row's cumulative session spend.
+	TurnSpendMicroUSD int64
 }
 
 // Store is the I/O surface for session pins. Get returns (zero, false, nil)

--- a/internal/sqlc/models.go
+++ b/internal/sqlc/models.go
@@ -119,6 +119,20 @@ type RouterModelRouterRequestTelemetry struct {
 	ClientApp              *string
 	TurnType               *string
 	RolloutID              *string
+	// Copied from session_pins.trajectory_id at decision time; the offline trajectory join key
+	TrajectoryID pgtype.UUID
+	// Atomic per-trajectory turn counter (pins row), not timestamp ordering
+	TurnIdx *int32
+	// Versioned observation record computed in the Go hot path; trainers consume it verbatim and never reconstruct features
+	StepRecord []byte
+	// Schema version of step_record; trainers refuse mixed versions without a migration map
+	StepRecordVersion *int32
+	// Behavior policy distribution over eligible models {model: probability}; NULL on non-policy spans
+	ActionDistribution []byte
+	// Eligible set after provider/exclusion/capability/context filters, at decision time
+	EligibleModels []string
+	// Set when a safety override (hard pin, force-model, error failover) bypassed the policy; row excluded from policy training
+	OverrideReason *string
 }
 
 // End-user identities seen on inbound requests, scoped to an installation. Replaces the per-user API key pattern.
@@ -186,6 +200,16 @@ type RouterSessionPin struct {
 	ConsecutiveUpstreamErrors int32
 	LastServedModel           string
 	HasEverSwitched           bool
+	// Stable trajectory UUID minted on first pin; survives session-key drift, copied onto telemetry rows
+	TrajectoryID uuid.UUID
+	// Trajectory of the dispatching parent session for sub-agent threads; NULL for main loops
+	ParentTrajectoryID pgtype.UUID
+	// LRU map keyed "provider/model" -> {last_turn_at, last_input_tokens, last_cache_read_tokens, last_cache_creation_tokens, last_output_tokens, consecutive_turns, last_reconcile_error_tokens}
+	CacheLedger []byte
+	// Running actual upstream spend for the session in micro-USD, accumulated on usage writeback
+	CumulativeSpendMicrousd int64
+	// Number of served-model switches observed on usage writeback (complements has_ever_switched latch)
+	SwitchCount int32
 }
 
 // Shadow-mode spiral (death-march) detections: log-only fire-rate corpus measured on live traffic before escalation is armed

--- a/internal/sqlc/session_pins.sql.go
+++ b/internal/sqlc/session_pins.sql.go
@@ -13,7 +13,7 @@ import (
 )
 
 const getSessionPin = `-- name: GetSessionPin :one
-SELECT session_key, role, installation_id, pinned_provider, pinned_model, decision_reason, turn_count, pinned_until, first_pinned_at, last_seen_at, last_input_tokens, last_cached_read_tokens, last_cached_write_tokens, last_output_tokens, last_turn_ended_at, consecutive_upstream_errors, last_served_model, has_ever_switched
+SELECT session_key, role, installation_id, pinned_provider, pinned_model, decision_reason, turn_count, pinned_until, first_pinned_at, last_seen_at, last_input_tokens, last_cached_read_tokens, last_cached_write_tokens, last_output_tokens, last_turn_ended_at, consecutive_upstream_errors, last_served_model, has_ever_switched, trajectory_id, parent_trajectory_id, cache_ledger, cumulative_spend_microusd, switch_count
 FROM router.session_pins
 WHERE session_key = $1::bytea
   AND role        = $2::varchar
@@ -31,7 +31,7 @@ type GetSessionPinParams struct {
 // last_turn_ended_at carry the previous turn's upstream usage; the
 // planner reads them to weigh switch EV against eviction cost.
 //
-//	SELECT session_key, role, installation_id, pinned_provider, pinned_model, decision_reason, turn_count, pinned_until, first_pinned_at, last_seen_at, last_input_tokens, last_cached_read_tokens, last_cached_write_tokens, last_output_tokens, last_turn_ended_at, consecutive_upstream_errors, last_served_model, has_ever_switched
+//	SELECT session_key, role, installation_id, pinned_provider, pinned_model, decision_reason, turn_count, pinned_until, first_pinned_at, last_seen_at, last_input_tokens, last_cached_read_tokens, last_cached_write_tokens, last_output_tokens, last_turn_ended_at, consecutive_upstream_errors, last_served_model, has_ever_switched, trajectory_id, parent_trajectory_id, cache_ledger, cumulative_spend_microusd, switch_count
 //	FROM router.session_pins
 //	WHERE session_key = $1::bytea
 //	  AND role        = $2::varchar
@@ -57,6 +57,11 @@ func (q *Queries) GetSessionPin(ctx context.Context, arg GetSessionPinParams) (R
 		&i.ConsecutiveUpstreamErrors,
 		&i.LastServedModel,
 		&i.HasEverSwitched,
+		&i.TrajectoryID,
+		&i.ParentTrajectoryID,
+		&i.CacheLedger,
+		&i.CumulativeSpendMicrousd,
+		&i.SwitchCount,
 	)
 	return i, err
 }
@@ -146,9 +151,35 @@ SET last_input_tokens        = $1::int,
     last_turn_ended_at       = $5::timestamptz,
     has_ever_switched        = has_ever_switched
       OR (last_served_model <> '' AND last_served_model <> $6::varchar),
+    switch_count             = switch_count
+      + CASE WHEN last_served_model <> '' AND last_served_model <> $6::varchar
+          THEN 1 ELSE 0 END,
+    cumulative_spend_microusd = cumulative_spend_microusd + $7::bigint,
+    cache_ledger             = jsonb_set(
+      cache_ledger,
+      ARRAY[$8::text],
+      jsonb_build_object(
+        'last_turn_at',               to_jsonb($5::timestamptz),
+        'last_input_tokens',          $1::int,
+        'last_cache_read_tokens',     $2::int,
+        'last_cache_creation_tokens', $3::int,
+        'last_output_tokens',         $4::int,
+        'consecutive_turns', CASE
+          WHEN last_served_model = $6::varchar
+            THEN COALESCE((cache_ledger->($8::text)->>'consecutive_turns')::int, 0) + 1
+          ELSE 1
+        END,
+        'last_reconcile_error_tokens', CASE
+          WHEN jsonb_exists(cache_ledger, $8::text)
+            THEN to_jsonb(($2::int)
+              - COALESCE((cache_ledger->($8::text)->>'last_input_tokens')::int, 0))
+          ELSE 'null'::jsonb
+        END
+      )
+    ),
     last_served_model        = $6::varchar
-WHERE session_key = $7::bytea
-  AND role        = $8::varchar
+WHERE session_key = $9::bytea
+  AND role        = $10::varchar
 `
 
 type UpdateSessionPinUsageParams struct {
@@ -158,6 +189,8 @@ type UpdateSessionPinUsageParams struct {
 	LastOutputTokens      int32
 	LastTurnEndedAt       pgtype.Timestamptz
 	LastServedModel       string
+	TurnSpendMicrousd     int64
+	LedgerKey             string
 	SessionKey            []byte
 	Role                  string
 }
@@ -180,6 +213,14 @@ type UpdateSessionPinUsageParams struct {
 // keeps the emit path stripping on every subsequent same-model turn for the
 // session's life — the only window in which those poisoned blocks would
 // otherwise reach Anthropic and 400.
+// The cache_ledger merge upserts this turn's (provider, model) entry in the
+// same atomic UPDATE: consecutive_turns increments while the served model is
+// unchanged and resets to 1 on a switch; last_reconcile_error_tokens records,
+// on revisit of an existing entry, the signed gap between the cache reuse the
+// entry predicted (its previous last_input_tokens) and the cache_read the
+// provider actually reported — a learnable provider-cache-reliability signal.
+// switch_count and cumulative_spend_microusd are session aggregates for the
+// step record. Entry count is bounded by roster size + pin TTL; no LRU trim.
 //
 //	UPDATE router.session_pins
 //	SET last_input_tokens        = $1::int,
@@ -189,9 +230,35 @@ type UpdateSessionPinUsageParams struct {
 //	    last_turn_ended_at       = $5::timestamptz,
 //	    has_ever_switched        = has_ever_switched
 //	      OR (last_served_model <> '' AND last_served_model <> $6::varchar),
+//	    switch_count             = switch_count
+//	      + CASE WHEN last_served_model <> '' AND last_served_model <> $6::varchar
+//	          THEN 1 ELSE 0 END,
+//	    cumulative_spend_microusd = cumulative_spend_microusd + $7::bigint,
+//	    cache_ledger             = jsonb_set(
+//	      cache_ledger,
+//	      ARRAY[$8::text],
+//	      jsonb_build_object(
+//	        'last_turn_at',               to_jsonb($5::timestamptz),
+//	        'last_input_tokens',          $1::int,
+//	        'last_cache_read_tokens',     $2::int,
+//	        'last_cache_creation_tokens', $3::int,
+//	        'last_output_tokens',         $4::int,
+//	        'consecutive_turns', CASE
+//	          WHEN last_served_model = $6::varchar
+//	            THEN COALESCE((cache_ledger->($8::text)->>'consecutive_turns')::int, 0) + 1
+//	          ELSE 1
+//	        END,
+//	        'last_reconcile_error_tokens', CASE
+//	          WHEN jsonb_exists(cache_ledger, $8::text)
+//	            THEN to_jsonb(($2::int)
+//	              - COALESCE((cache_ledger->($8::text)->>'last_input_tokens')::int, 0))
+//	          ELSE 'null'::jsonb
+//	        END
+//	      )
+//	    ),
 //	    last_served_model        = $6::varchar
-//	WHERE session_key = $7::bytea
-//	  AND role        = $8::varchar
+//	WHERE session_key = $9::bytea
+//	  AND role        = $10::varchar
 func (q *Queries) UpdateSessionPinUsage(ctx context.Context, arg UpdateSessionPinUsageParams) error {
 	_, err := q.db.Exec(ctx, updateSessionPinUsage,
 		arg.LastInputTokens,
@@ -200,6 +267,8 @@ func (q *Queries) UpdateSessionPinUsage(ctx context.Context, arg UpdateSessionPi
 		arg.LastOutputTokens,
 		arg.LastTurnEndedAt,
 		arg.LastServedModel,
+		arg.TurnSpendMicrousd,
+		arg.LedgerKey,
 		arg.SessionKey,
 		arg.Role,
 	)


### PR DESCRIPTION
## Summary
- Add bundle-gated `objective=lambda_cost` scoring: `q - λ·estimated_query_cost_usd`
- Expose `LambdaCost` on routing knobs / request overrides
- Add `TestScorer_LambdaCostObjective` regression test

## Test plan
- [x] `go test ./internal/router/cluster/... -run TestScorer_LambdaCostObjective`
- [ ] WorkWeave gitlink bump + offline screen after trainer ships lambda_cost bundle


Made with [Cursor](https://cursor.com)