### PR TITLE
feat(telemetry): high-fidelity OTLP log stream + opt-in content capture

### DIFF
--- a/cmd/router/main.go
+++ b/cmd/router/main.go
@@ -405,7 +405,7 @@ func main() {
 		translate.EnableEditEscapeNormalize = true
 		logger.Info("Edit-tool escape-sequence repair enabled (ROUTER_DEEPSEEK_ESCAPE_NORMALIZE=true)")
 	}
-	emitter, err := buildOtelEmitter()
+	emitter, err := buildOtelEmitter(string(deploymentMode))
 	if err != nil {
 		logger.Error("Failed to create OTel emitter", "err", err)
 		panic(err)
@@ -583,7 +583,15 @@ func main() {
 	// wrapped. Prod leaves ROUTER_EXPLORE_ENABLED unset → deterministic argmax.
 	routeEntry := buildExploringRouter(rtr, logger)
 
+	// High-fidelity OTLP content capture. Off unless WV_CAPTURE_CONTENT is set
+	// (opt-in for self-hosted/OSS); Weave-managed deploys set it to "full" in
+	// their deploy config. Redactor is nil here (no-op); managed wires one.
+	captureMode := proxy.ParseCaptureMode(config.GetOr("WV_CAPTURE_CONTENT", ""))
+	captureMaxBytes := parseEnvInt("WV_CAPTURE_MAX_BYTES", 1<<20)
+	logger.Info("Router content capture configured", "mode", captureMode.String(), "max_bytes", captureMaxBytes)
+
 	proxySvc := proxy.NewService(routeEntry, providerMap, emitter, embedOnlyUser, semanticCache, pinStore, hardPinExplore, hardPinProvider, hardPinModel, repo.Telemetry).
+		WithContentCapture(captureMode, captureMaxBytes, nil).
 		WithByokOnly(byokOnly).
 		WithDeploymentKeyedProviders(deploymentEligible).
 		WithPassthroughEligibleProviders(passthroughEligible).
@@ -945,7 +953,7 @@ func buildClusterScorer(availableProviders map[string]struct{}) (router.Router, 
 
 // buildOtelEmitter constructs the OTel span emitter from environment
 // variables. Returns (nil, nil) when OTEL_EXPORTER_OTLP_ENDPOINT is unset.
-func buildOtelEmitter() (*otel.Emitter, error) {
+func buildOtelEmitter(deploymentMode string) (*otel.Emitter, error) {
 	logger := observability.Get()
 
 	endpoint := config.GetOr("OTEL_EXPORTER_OTLP_ENDPOINT", "")
@@ -953,11 +961,19 @@ func buildOtelEmitter() (*otel.Emitter, error) {
 		return nil, nil
 	}
 
+	// router.deployment_mode lets the collector branch ingest behavior
+	// (e.g. redaction / content-opt-out) without inspecting per-record attrs.
+	resourceAttrs := parseOtelHeaders(config.GetOr("OTEL_RESOURCE_ATTRIBUTES", ""))
+	if resourceAttrs == nil {
+		resourceAttrs = map[string]string{}
+	}
+	resourceAttrs["router.deployment_mode"] = deploymentMode
+
 	cfg := otel.EmitterConfig{
 		Endpoint:      endpoint,
 		Headers:       parseOtelHeaders(config.GetOr("OTEL_EXPORTER_OTLP_HEADERS", "")),
 		ServiceName:   config.GetOr("OTEL_SERVICE_NAME", "router"),
-		ResourceAttrs: parseOtelHeaders(config.GetOr("OTEL_RESOURCE_ATTRIBUTES", "")),
+		ResourceAttrs: resourceAttrs,
 		Workers:       parseEnvInt("OTEL_EXPORT_WORKERS", 2),
 		QueueSize:     parseEnvInt("OTEL_BSP_MAX_QUEUE_SIZE", 1000),
 		BatchSize:     parseEnvInt("OTEL_BSP_MAX_EXPORT_BATCH_SIZE", 50),

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -101,7 +101,29 @@ The router exports per-request trace spans to any OTLP-compatible collector.
 Each proxied request emits two spans (`router.decision` and `router.upstream`)
 with routing decisions, token usage, cost estimates, and latency. Export is
 async/non-blocking; when `OTEL_EXPORTER_OTLP_ENDPOINT` is unset, OTel is
-fully disabled at zero runtime cost.
+fully disabled at zero runtime cost. Everything the router records leaves the
+process over OTLP only — there is no hardcoded analytics endpoint.
+
+### High-fidelity content capture (`router.call` log records)
+
+When `WV_CAPTURE_CONTENT` is set, the router additionally emits a `router.call`
+OTLP **log record** per upstream call to `${OTEL_EXPORTER_OTLP_ENDPOINT}/v1/logs`.
+Each record carries the same routing/decision metadata as the spans plus the
+call outcome, and — depending on the mode — the request/response bodies. This
+is the ML-ready event stream (one record per LLM call, full inputs and
+outputs). It is **opt-in**: with `WV_CAPTURE_CONTENT` unset (the default) no
+log records are emitted and behavior is unchanged.
+
+| Variable             | Default | Purpose |
+| -------------------- | ------- | ------- |
+| `WV_CAPTURE_CONTENT` | `off`   | `off` = no log records; `hashed` = metadata + SHA-256 content hashes (no raw text); `full` = metadata + raw request/response bodies. |
+| `WV_CAPTURE_MAX_BYTES` | `1048576` | Max buffered response bytes; larger responses are dropped and flagged `io.truncated=true` (the client still receives the full stream). |
+
+Captured bodies are in the client's native wire format (Anthropic / OpenAI /
+Gemini, matching the inbound surface). The `router.deployment_mode` resource
+attribute (`selfhosted` / `managed`) is stamped on every export so a collector
+can branch redaction or content-opt-out by deployment.
+
 
 | Variable                         | Default      | Purpose |
 | -------------------------------- | ------------ | ------- |
@@ -113,7 +135,7 @@ fully disabled at zero runtime cost.
 | `OTEL_BSP_MAX_QUEUE_SIZE`        | `1000`       | Span queue capacity. Spans drop when full. |
 | `OTEL_BSP_MAX_EXPORT_BATCH_SIZE` | `50`         | Max spans per OTLP POST. |
 | `OTEL_BSP_SCHEDULE_DELAY`        | `500`        | Partial-batch flush interval in ms. |
-| `OTEL_EXPORT_WORKERS`            | `2`          | Export-goroutine count. |
+| `OTEL_EXPORT_WORKERS`            | `2`          | Export-goroutine count (spans and logs each get this many workers). |
 
 The first five follow the [OTel SDK env spec](https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/);
 `OTEL_BSP_*` follows the [Batch Span Processor spec](https://opentelemetry.io/docs/specs/otel/trace/sdk/#batch-span-processor).

--- a/internal/observability/otel/buffer.go
+++ b/internal/observability/otel/buffer.go
@@ -12,6 +12,7 @@ type Buffer struct {
 	traceID [16]byte
 	mu      sync.Mutex
 	spans   []Span
+	logs    []LogRecord
 }
 
 // NewBuffer creates a request-scoped span buffer. Returns nil when emitter is
@@ -36,19 +37,35 @@ func (b *Buffer) Record(s Span) {
 	b.mu.Unlock()
 }
 
-// Flush drains all buffered spans into the emitter's async export queue.
+// RecordLog appends a log record to the buffer. Safe for concurrent use.
+func (b *Buffer) RecordLog(r LogRecord) {
+	if b == nil {
+		return
+	}
+	b.mu.Lock()
+	b.logs = append(b.logs, r)
+	b.mu.Unlock()
+}
+
+// Flush drains all buffered spans and log records into the emitter's async
+// export queues. Spans and logs share this request's traceID.
 func (b *Buffer) Flush() {
 	if b == nil {
 		return
 	}
 
 	b.mu.Lock()
-	pending := b.spans
+	pendingSpans := b.spans
 	b.spans = nil
+	pendingLogs := b.logs
+	b.logs = nil
 	b.mu.Unlock()
 
-	for _, s := range pending {
+	for _, s := range pendingSpans {
 		b.emitter.Enqueue(spanToProto(s, b.traceID))
+	}
+	for _, r := range pendingLogs {
+		b.emitter.EnqueueLog(logRecordToProto(r, b.traceID))
 	}
 }
 
@@ -70,7 +87,16 @@ func Record(ctx context.Context, s Span) {
 	}
 }
 
-// Flush retrieves the Buffer from ctx and flushes all buffered spans.
+// RecordLog retrieves the Buffer from ctx and appends the log record. No-op
+// when the context does not carry a buffer (OTel disabled or pre-buffer
+// middleware).
+func RecordLog(ctx context.Context, r LogRecord) {
+	if buf, ok := ctx.Value(bufferKey{}).(*Buffer); ok {
+		buf.RecordLog(r)
+	}
+}
+
+// Flush retrieves the Buffer from ctx and flushes all buffered spans and logs.
 func Flush(ctx context.Context) {
 	if buf, ok := ctx.Value(bufferKey{}).(*Buffer); ok {
 		buf.Flush()

--- a/internal/observability/otel/emitter.go
+++ b/internal/observability/otel/emitter.go
@@ -12,8 +12,10 @@ import (
 
 	"google.golang.org/protobuf/proto"
 
+	collogspb "go.opentelemetry.io/proto/otlp/collector/logs/v1"
 	coltracepb "go.opentelemetry.io/proto/otlp/collector/trace/v1"
 	commonv1 "go.opentelemetry.io/proto/otlp/common/v1"
+	logsv1 "go.opentelemetry.io/proto/otlp/logs/v1"
 	resourcev1 "go.opentelemetry.io/proto/otlp/resource/v1"
 	tracev1 "go.opentelemetry.io/proto/otlp/trace/v1"
 )
@@ -34,15 +36,17 @@ type EmitterConfig struct {
 // Emitter batches OTLP spans and exports them via HTTP POST. Safe for concurrent
 // use. A nil *Emitter means OTel is disabled; all methods no-op.
 type Emitter struct {
-	queue    chan *tracev1.Span
-	client   *http.Client
-	endpoint string
-	headers  map[string]string
-	resource *resourcev1.Resource
-	batchSz  int
-	flushInt time.Duration
-	dropped  atomic.Int64
-	wg       sync.WaitGroup
+	queue       chan *tracev1.Span
+	logQueue    chan *logsv1.LogRecord
+	client      *http.Client
+	endpoint    string
+	logEndpoint string
+	headers     map[string]string
+	resource    *resourcev1.Resource
+	batchSz     int
+	flushInt    time.Duration
+	dropped     atomic.Int64
+	wg          sync.WaitGroup
 	// closeMu coordinates Shutdown's queue close against in-flight Enqueue
 	// calls so a late Enqueue cannot panic with "send on closed channel".
 	// Enqueue acquires RLock for the lifetime of the send; Shutdown takes
@@ -78,18 +82,21 @@ func NewEmitter(cfg EmitterConfig) (*Emitter, error) {
 	}
 
 	e := &Emitter{
-		queue:    make(chan *tracev1.Span, cfg.QueueSize),
-		client:   &http.Client{Timeout: cfg.ExportTimeout},
-		endpoint: strings.TrimRight(cfg.Endpoint, "/") + "/v1/traces",
-		headers:  cfg.Headers,
-		resource: buildResource(cfg.ServiceName, cfg.ResourceAttrs),
-		batchSz:  cfg.BatchSize,
-		flushInt: cfg.FlushInterval,
+		queue:       make(chan *tracev1.Span, cfg.QueueSize),
+		logQueue:    make(chan *logsv1.LogRecord, cfg.QueueSize),
+		client:      &http.Client{Timeout: cfg.ExportTimeout},
+		endpoint:    strings.TrimRight(cfg.Endpoint, "/") + "/v1/traces",
+		logEndpoint: strings.TrimRight(cfg.Endpoint, "/") + "/v1/logs",
+		headers:     cfg.Headers,
+		resource:    buildResource(cfg.ServiceName, cfg.ResourceAttrs),
+		batchSz:     cfg.BatchSize,
+		flushInt:    cfg.FlushInterval,
 	}
 
-	e.wg.Add(cfg.Workers)
+	e.wg.Add(cfg.Workers * 2)
 	for range cfg.Workers {
 		go e.worker()
+		go e.logWorker()
 	}
 
 	return e, nil
@@ -114,6 +121,25 @@ func (e *Emitter) Enqueue(s *tracev1.Span) {
 	}
 }
 
+// EnqueueLog submits a log record to the export queue. Non-blocking: drops on
+// queue-full or post-shutdown. Nil receiver is a no-op.
+func (e *Emitter) EnqueueLog(r *logsv1.LogRecord) {
+	if e == nil {
+		return
+	}
+	e.closeMu.RLock()
+	defer e.closeMu.RUnlock()
+	if e.closed.Load() {
+		e.dropped.Add(1)
+		return
+	}
+	select {
+	case e.logQueue <- r:
+	default:
+		e.dropped.Add(1)
+	}
+}
+
 // Shutdown closes the queue and waits for workers to drain. Blocks until all
 // workers finish or ctx expires. Idempotent; nil receiver is a no-op.
 func (e *Emitter) Shutdown(c context.Context) error {
@@ -127,6 +153,7 @@ func (e *Emitter) Shutdown(c context.Context) error {
 		return nil
 	}
 	close(e.queue)
+	close(e.logQueue)
 	e.closeMu.Unlock()
 
 	done := make(chan struct{})
@@ -183,6 +210,40 @@ func (e *Emitter) worker() {
 	}
 }
 
+// logWorker mirrors worker for the log-record export pipeline.
+func (e *Emitter) logWorker() {
+	defer e.wg.Done()
+
+	batch := make([]*logsv1.LogRecord, 0, e.batchSz)
+	timer := time.NewTimer(e.flushInt)
+	defer timer.Stop()
+
+	for {
+		select {
+		case rec, ok := <-e.logQueue:
+			if !ok {
+				if len(batch) > 0 {
+					e.exportLogBatch(batch)
+				}
+				return
+			}
+			batch = append(batch, rec)
+			if len(batch) >= e.batchSz {
+				e.exportLogBatch(batch)
+				batch = batch[:0]
+				timer.Reset(e.flushInt)
+			}
+
+		case <-timer.C:
+			if len(batch) > 0 {
+				e.exportLogBatch(batch)
+				batch = batch[:0]
+			}
+			timer.Reset(e.flushInt)
+		}
+	}
+}
+
 func (e *Emitter) exportBatch(spans []*tracev1.Span) {
 	req := &coltracepb.ExportTraceServiceRequest{
 		ResourceSpans: []*tracev1.ResourceSpans{{
@@ -199,8 +260,32 @@ func (e *Emitter) exportBatch(spans []*tracev1.Span) {
 		slog.Warn("Failed to marshal OTLP export request", "err", err)
 		return
 	}
+	e.post(e.endpoint, body)
+}
 
-	httpReq, err := http.NewRequest(http.MethodPost, e.endpoint, bytes.NewReader(body))
+func (e *Emitter) exportLogBatch(records []*logsv1.LogRecord) {
+	req := &collogspb.ExportLogsServiceRequest{
+		ResourceLogs: []*logsv1.ResourceLogs{{
+			Resource: e.resource,
+			ScopeLogs: []*logsv1.ScopeLogs{{
+				Scope:      &commonv1.InstrumentationScope{Name: "workweave-router"},
+				LogRecords: records,
+			}},
+		}},
+	}
+
+	body, err := proto.Marshal(req)
+	if err != nil {
+		slog.Warn("Failed to marshal OTLP log export request", "err", err)
+		return
+	}
+	e.post(e.logEndpoint, body)
+}
+
+// post sends a marshaled OTLP protobuf body to endpoint. Failures are logged,
+// not returned: telemetry export is best-effort and never blocks the request.
+func (e *Emitter) post(endpoint string, body []byte) {
+	httpReq, err := http.NewRequest(http.MethodPost, endpoint, bytes.NewReader(body))
 	if err != nil {
 		slog.Warn("Failed to create OTLP export HTTP request", "err", err)
 		return

--- a/internal/observability/otel/logs.go
+++ b/internal/observability/otel/logs.go
@@ -1,0 +1,61 @@
+package otel
+
+import (
+	"time"
+
+	commonv1 "go.opentelemetry.io/proto/otlp/common/v1"
+	logsv1 "go.opentelemetry.io/proto/otlp/logs/v1"
+)
+
+// Severity is the log-record level. Kept as a small local enum so the buffer /
+// proxy API does not leak the OTLP proto severity type.
+type Severity int
+
+const (
+	// SeverityInfo marks routine high-fidelity events (decision, call).
+	SeverityInfo Severity = iota
+	// SeverityError marks upstream/router failures.
+	SeverityError
+)
+
+// LogRecord is a lightweight high-fidelity event converted to an OTLP log
+// record at flush time. Name becomes the log body (event name, matching the
+// Claude Code plugin convention); structured fields live in Attrs.
+type LogRecord struct {
+	Name     string
+	Time     time.Time
+	Severity Severity
+	Attrs    []*commonv1.KeyValue
+}
+
+func (s Severity) otlp() logsv1.SeverityNumber {
+	if s == SeverityError {
+		return logsv1.SeverityNumber_SEVERITY_NUMBER_ERROR
+	}
+	return logsv1.SeverityNumber_SEVERITY_NUMBER_INFO
+}
+
+func (s Severity) text() string {
+	if s == SeverityError {
+		return "ERROR"
+	}
+	return "INFO"
+}
+
+// logRecordToProto converts a LogRecord into its OTLP wire form. The record
+// shares the request's traceID so the collector can correlate it with the
+// request's spans, and gets a fresh span ID for uniqueness.
+func logRecordToProto(r LogRecord, traceID [16]byte) *logsv1.LogRecord {
+	spanID := generateSpanID()
+	ts := uint64(r.Time.UnixNano())
+	return &logsv1.LogRecord{
+		TimeUnixNano:         ts,
+		ObservedTimeUnixNano: ts,
+		SeverityNumber:       r.Severity.otlp(),
+		SeverityText:         r.Severity.text(),
+		Body:                 &commonv1.AnyValue{Value: &commonv1.AnyValue_StringValue{StringValue: r.Name}},
+		Attributes:           r.Attrs,
+		TraceId:              traceID[:],
+		SpanId:               spanID[:],
+	}
+}

--- a/internal/observability/otel/logs_test.go
+++ b/internal/observability/otel/logs_test.go
@@ -1,0 +1,171 @@
+package otel_test
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+
+	collogspb "go.opentelemetry.io/proto/otlp/collector/logs/v1"
+
+	"workweave/router/internal/observability/otel"
+)
+
+// pathCollector records request bodies keyed by the URL path so trace and log
+// exports can be told apart (both hit the same base endpoint).
+type pathCollector struct {
+	server *httptest.Server
+	mu     sync.Mutex
+	byPath map[string][][]byte
+}
+
+func newPathCollector(t *testing.T) *pathCollector {
+	t.Helper()
+	c := &pathCollector{byPath: map[string][][]byte{}}
+	c.server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		c.mu.Lock()
+		c.byPath[r.URL.Path] = append(c.byPath[r.URL.Path], body)
+		c.mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(c.server.Close)
+	return c
+}
+
+func (c *pathCollector) logRecords(t *testing.T) []*logRecordView {
+	t.Helper()
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	var out []*logRecordView
+	for path, payloads := range c.byPath {
+		if !strings.HasSuffix(path, "/v1/logs") {
+			continue
+		}
+		for _, p := range payloads {
+			var req collogspb.ExportLogsServiceRequest
+			require.NoError(t, proto.Unmarshal(p, &req))
+			for _, rl := range req.ResourceLogs {
+				for _, sl := range rl.ScopeLogs {
+					for _, lr := range sl.LogRecords {
+						out = append(out, &logRecordView{
+							body:    lr.GetBody().GetStringValue(),
+							traceID: lr.GetTraceId(),
+							attrs:   map[string]string{},
+							sevText: lr.GetSeverityText(),
+						})
+						for _, kv := range lr.Attributes {
+							out[len(out)-1].attrs[kv.Key] = kv.GetValue().GetStringValue()
+						}
+					}
+				}
+			}
+		}
+	}
+	return out
+}
+
+type logRecordView struct {
+	body    string
+	sevText string
+	traceID []byte
+	attrs   map[string]string
+}
+
+func newPathEmitter(t *testing.T, endpoint string) *otel.Emitter {
+	t.Helper()
+	em, err := otel.NewEmitter(otel.EmitterConfig{
+		Endpoint:      endpoint,
+		ServiceName:   "test",
+		Workers:       1,
+		QueueSize:     100,
+		BatchSize:     100,
+		FlushInterval: time.Second,
+	})
+	require.NoError(t, err)
+	return em
+}
+
+func TestBuffer_RecordLogAndFlush(t *testing.T) {
+	coll := newPathCollector(t)
+	em := newPathEmitter(t, coll.server.URL)
+
+	buf := otel.NewBuffer(em)
+	require.NotNil(t, buf)
+
+	now := time.Now()
+	buf.RecordLog(otel.LogRecord{
+		Name:     "router.call",
+		Time:     now,
+		Severity: otel.SeverityInfo,
+		Attrs: otel.NewAttrBuilder(2).
+			String("decision.model", "claude-opus-4-8").
+			String("io.request_body", `{"messages":[]}`).
+			Build(),
+	})
+	buf.RecordLog(otel.LogRecord{
+		Name:     "router.call",
+		Time:     now,
+		Severity: otel.SeverityError,
+		Attrs:    otel.NewAttrBuilder(1).Int64("upstream.status_code", 500).Build(),
+	})
+	buf.Flush()
+
+	require.NoError(t, em.Shutdown(context.Background()))
+
+	recs := coll.logRecords(t)
+	require.Len(t, recs, 2)
+	assert.Equal(t, "router.call", recs[0].body)
+	// Both records share the buffer's single trace ID.
+	assert.Equal(t, recs[0].traceID, recs[1].traceID)
+
+	var info, errRec *logRecordView
+	for _, r := range recs {
+		switch r.sevText {
+		case "INFO":
+			info = r
+		case "ERROR":
+			errRec = r
+		}
+	}
+	require.NotNil(t, info)
+	require.NotNil(t, errRec)
+	assert.Equal(t, "claude-opus-4-8", info.attrs["decision.model"])
+	assert.Equal(t, `{"messages":[]}`, info.attrs["io.request_body"])
+}
+
+func TestBuffer_SpansAndLogsShareTraceID(t *testing.T) {
+	coll := newPathCollector(t)
+	em := newPathEmitter(t, coll.server.URL)
+
+	buf := otel.NewBuffer(em)
+	buf.Record(makeSpan("router.upstream"))
+	buf.RecordLog(otel.LogRecord{Name: "router.call", Time: time.Now(), Severity: otel.SeverityInfo})
+	buf.Flush()
+
+	require.NoError(t, em.Shutdown(context.Background()))
+
+	recs := coll.logRecords(t)
+	require.Len(t, recs, 1)
+	// Spans went to /v1/traces, logs to /v1/logs — distinct endpoints hit.
+	assert.Contains(t, coll.byPath, "/v1/traces")
+	assert.Contains(t, coll.byPath, "/v1/logs")
+}
+
+func TestRecordLog_NilBufferNoPanic(t *testing.T) {
+	var buf *otel.Buffer
+	assert.NotPanics(t, func() { buf.RecordLog(otel.LogRecord{Name: "x"}) })
+	assert.NotPanics(t, func() { otel.RecordLog(context.Background(), otel.LogRecord{Name: "x"}) })
+}

--- a/internal/proxy/gemini.go
+++ b/internal/proxy/gemini.go
@@ -191,6 +191,9 @@ func (s *Service) ProxyGeminiGenerateContent(ctx context.Context, body []byte, w
 		String("client.app", clientID.ClientApp).
 		String("requested.model", feats.Model).
 		String("decision.model", decision.Model).
+		String("decision.provider", decision.Provider).
+		String("decision.reason", decision.Reason).
+		String("routing.turn_type", string(tt)).
 		Int64("usage.input_tokens", int64(in)).
 		Int64("usage.output_tokens", int64(out)).
 		Int64("usage.cache_creation_input_tokens", int64(cacheCreation)).

--- a/internal/proxy/gemini.go
+++ b/internal/proxy/gemini.go
@@ -161,7 +161,8 @@ func (s *Service) ProxyGeminiGenerateContent(ctx context.Context, body []byte, w
 
 	proxyStart := time.Now()
 	var extractor *otel.UsageExtractor
-	var sink http.ResponseWriter = w
+	contentSink, contentCap := s.maybeCaptureResponse(w)
+	var sink http.ResponseWriter = contentSink
 	if marker := suppressMarkerIfRequested(r.Header, routingMarkerFor(routeRes)); marker != "" {
 		mw := translate.NewGeminiRoutingMarkerWriter(sink, marker)
 		// Flush marker + HTTP 200 immediately so TTFB is decoupled from
@@ -210,6 +211,8 @@ func (s *Service) ProxyGeminiGenerateContent(ctx context.Context, body []byte, w
 		End:   time.Now(),
 		Attrs: geminiUpstreamBuilder.Build(),
 	})
+	respBody, respTrunc := capturedResponse(contentCap)
+	s.recordCallLog(ctx, geminiUpstreamBuilder.Build(), proxyErr != nil, body, respBody, respTrunc)
 	otel.Flush(ctx)
 
 	// Persist last-turn usage to the pin row so the next turn's planner

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -63,6 +63,15 @@ type Service struct {
 	tierClampResolver func(enabled, excluded map[string]struct{}, ceiling catalog.Tier) (provider, model string, ok bool)
 	// telemetry is an optional repository for persisting per-request telemetry.
 	telemetry TelemetryRepository
+	// captureMode controls whether high-fidelity `router.call` OTLP log
+	// records carry full request/response bodies, content hashes, or are
+	// suppressed entirely. Default CaptureOff (no log records emitted).
+	captureMode ContentCaptureMode
+	// captureMaxBytes caps the buffered response body when capture is on;
+	// larger bodies are dropped and flagged io.truncated.
+	captureMaxBytes int
+	// redactor scrubs captured content before export. Nil passes through.
+	redactor Redactor
 	// byokOnly disables deployment-level credential fallback so customer
 	// requests never silently consume the platform's API key budget.
 	byokOnly bool
@@ -523,6 +532,19 @@ func (s *Service) WithSpiralShadowStore(store SpiralShadowStore) *Service {
 // submissions (router.router_feedback). Nil degrades to span + log only.
 func (s *Service) WithRouterFeedbackStore(store RouterFeedbackStore) *Service {
 	s.feedbackStore = store
+	return s
+}
+
+// WithContentCapture configures high-fidelity `router.call` OTLP log emission.
+// mode selects off/hashed/full; maxBytes caps the buffered response body;
+// redactor (optional) scrubs content before export. No-op effect when the
+// emitter is disabled. Default (unset) is CaptureOff.
+func (s *Service) WithContentCapture(mode ContentCaptureMode, maxBytes int, redactor Redactor) *Service {
+	s.captureMode = mode
+	if maxBytes > 0 {
+		s.captureMaxBytes = maxBytes
+	}
+	s.redactor = redactor
 	return s
 }
 
@@ -1309,7 +1331,8 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 	// The TTFB cost is a single round-trip's worth of buffered SSE bytes
 	// (~200B) released the moment the upstream's first byte arrives.
 	bindings := s.resolveBindingsForDispatch(ctx, decision)
-	preludeBuf := newPreludeBuffer(w)
+	contentSink, contentCap := s.maybeCaptureResponse(w)
+	preludeBuf := newPreludeBuffer(contentSink)
 	var rootSink http.ResponseWriter = preludeBuf
 	var captureW *captureWriter
 	var sink http.ResponseWriter = rootSink
@@ -1575,6 +1598,8 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 		End:   time.Now(),
 		Attrs: upstreamBuilder.Build(),
 	})
+	respBody, respTrunc := capturedResponse(contentCap)
+	s.recordCallLog(ctx, upstreamBuilder.Build(), proxyErr != nil, body, respBody, respTrunc)
 	otel.Flush(ctx)
 
 	s.recordTurnUsage(routeRes, in, out, cacheCreation, cacheRead)
@@ -2429,7 +2454,8 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 	// so single-binding upstream errors don't strand the routing-marker chunk
 	// on the wire when the upstream never produces a first byte.
 	bindings := s.resolveBindingsForDispatch(ctx, decision)
-	preludeBuf := newPreludeBuffer(w)
+	contentSink, contentCap := s.maybeCaptureResponse(w)
+	preludeBuf := newPreludeBuffer(contentSink)
 	var rootSink http.ResponseWriter = preludeBuf
 
 	// Responses entry point delegates the eager response.created emit to
@@ -2640,6 +2666,8 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 		End:   time.Now(),
 		Attrs: openaiUpstreamBuilder.Build(),
 	})
+	respBody, respTrunc := capturedResponse(contentCap)
+	s.recordCallLog(ctx, openaiUpstreamBuilder.Build(), proxyErr != nil, body, respBody, respTrunc)
 	otel.Flush(ctx)
 
 	s.recordTurnUsage(routeRes, in, out, cacheCreation, cacheRead)

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -2666,9 +2666,21 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 		End:   time.Now(),
 		Attrs: openaiUpstreamBuilder.Build(),
 	})
-	respBody, respTrunc := capturedResponse(contentCap)
-	s.recordCallLog(ctx, openaiUpstreamBuilder.Build(), proxyErr != nil, body, respBody, respTrunc)
-	otel.Flush(ctx)
+	callLogBase := openaiUpstreamBuilder.Build()
+	emitCallLog := func() {
+		respBody, respTrunc := capturedResponse(contentCap)
+		s.recordCallLog(ctx, callLogBase, proxyErr != nil, body, respBody, respTrunc)
+		otel.Flush(ctx)
+	}
+	// The /v1/responses surface (ProxyOpenAIResponses) finalizes its
+	// ResponsesWriter only after this function returns, so the captured body
+	// isn't complete yet — defer the read+emit to run post-Finalize. All other
+	// callers emit inline.
+	if h := deferredCallLogFrom(ctx); h != nil {
+		h.fn = emitCallLog
+	} else {
+		emitCallLog()
+	}
 
 	s.recordTurnUsage(routeRes, in, out, cacheCreation, cacheRead)
 
@@ -2739,6 +2751,10 @@ func (s *Service) ProxyOpenAIResponses(ctx context.Context, body []byte, w http.
 		return fmt.Errorf("translate responses request: %w", err)
 	}
 	wrapper := translate.NewResponsesWriter(w, model)
+	// Defer the high-fidelity call-log emission until after Finalize: the
+	// ResponsesWriter buffers (non-streaming) and emits tail events only in
+	// Finalize, so the captured io.response_body is incomplete until then.
+	ctx, deferredLog := withDeferredCallLog(ctx)
 	// Prelude (response.created emit) deferred to ProxyOpenAIChatCompletion.
 	// It knows the post-routing decision and the binding count; only fires
 	// eagerly when the request is single-binding (no failover possible).
@@ -2752,7 +2768,10 @@ func (s *Service) ProxyOpenAIResponses(ctx context.Context, body []byte, w http.
 		// On error, let the handler write the error envelope unless we've
 		// already committed to streaming — in which case the chat-completions
 		// path will have surfaced a status error and we just propagate.
+		deferredLog.run()
 		return proxyErr
 	}
-	return wrapper.Finalize()
+	finErr := wrapper.Finalize()
+	deferredLog.run()
+	return finErr
 }

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -1572,6 +1572,11 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 		String("client.app", clientID.ClientApp).
 		String("requested.model", feats.Model).
 		String("decision.model", decision.Model).
+		String("decision.provider", finalProvider).
+		String("decision.reason", decision.Reason).
+		String("routing.turn_type", string(routeRes.TurnType)).
+		String("upstream.finish_reason", respSummary.UpstreamFinishReason).
+		String("upstream.stop_reason", respSummary.StopReason).
 		Int64("usage.input_tokens", int64(in)).
 		Int64("usage.output_tokens", int64(out)).
 		Int64("usage.cache_creation_input_tokens", int64(cacheCreation)).
@@ -2642,6 +2647,9 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 		String("client.app", clientID.ClientApp).
 		String("requested.model", feats.Model).
 		String("decision.model", decision.Model).
+		String("decision.provider", finalProvider).
+		String("decision.reason", decision.Reason).
+		String("routing.turn_type", string(routeRes.TurnType)).
 		Int64("usage.input_tokens", int64(in)).
 		Int64("usage.output_tokens", int64(out)).
 		Int64("usage.cache_creation_input_tokens", int64(cacheCreation)).

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -2680,8 +2680,12 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 	})
 	callLogBase := openaiUpstreamBuilder.Build()
 	emitCallLog := func() {
+		reqBody := body
+		if h := deferredCallLogFrom(ctx); h != nil && h.requestBody != nil {
+			reqBody = h.requestBody
+		}
 		respBody, respTrunc := capturedResponse(contentCap)
-		s.recordCallLog(ctx, callLogBase, proxyErr != nil, body, respBody, respTrunc)
+		s.recordCallLog(ctx, callLogBase, proxyErr != nil, reqBody, respBody, respTrunc)
 		otel.Flush(ctx)
 	}
 	// The /v1/responses surface (ProxyOpenAIResponses) finalizes its
@@ -2767,6 +2771,10 @@ func (s *Service) ProxyOpenAIResponses(ctx context.Context, body []byte, w http.
 	// ResponsesWriter buffers (non-streaming) and emits tail events only in
 	// Finalize, so the captured io.response_body is incomplete until then.
 	ctx, deferredLog := withDeferredCallLog(ctx)
+	// Capture the client's original Responses JSON as the request body so the
+	// call log's io.request_body matches the Responses-format response body
+	// (ProxyOpenAIChatCompletion otherwise sees the translated chatBody).
+	deferredLog.requestBody = body
 	// Prelude (response.created emit) deferred to ProxyOpenAIChatCompletion.
 	// It knows the post-routing decision and the binding count; only fires
 	// eagerly when the request is single-binding (no failover possible).

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -1520,7 +1520,9 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 	primaryProvider := decision.Provider
 	var winnerIdx int
 	winnerIdx, proxyErr = s.dispatchWithFallback(ctx, failoverInputs{
-		w:               w,
+		// contentSink routes the failover-exhaustion error envelope through the
+		// content-capture writer; it is the raw w when capture is off.
+		w:               contentSink,
 		buf:             preludeBuf,
 		initialDecision: decision,
 		bindings:        bindings,
@@ -2593,7 +2595,9 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 	primaryProvider := decision.Provider
 	var winnerIdx int
 	winnerIdx, proxyErr = s.dispatchWithFallback(ctx, failoverInputs{
-		w:               w,
+		// contentSink routes the failover-exhaustion error envelope through the
+		// content-capture writer; it is the raw w when capture is off.
+		w:               contentSink,
 		buf:             preludeBuf,
 		initialDecision: decision,
 		bindings:        bindings,

--- a/internal/proxy/turn_logs.go
+++ b/internal/proxy/turn_logs.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"workweave/router/internal/observability/otel"
+	"workweave/router/internal/translate"
 
 	commonv1 "go.opentelemetry.io/proto/otlp/common/v1"
 )
@@ -73,9 +74,24 @@ func (m ContentCaptureMode) String() string {
 // enabled. The returned captureWriter (nil when off) mirrors the exact bytes
 // delivered to the client, so the captured response is in the client's native
 // wire format regardless of which upstream served it.
+//
+// The /v1/responses surface hands us a *translate.ResponsesWriter that performs
+// its own surface translation and emits an eager prelude straight to its inner
+// writer. Wrapping it externally would capture the pre-translation event stream
+// and miss the prelude, so for that case we splice the capture writer in at the
+// ResponsesWriter's true client boundary instead — yielding the exact Responses
+// wire, prelude included — and return the ResponsesWriter unchanged as the sink.
 func (s *Service) maybeCaptureResponse(w http.ResponseWriter) (http.ResponseWriter, *captureWriter) {
 	if s.captureMode == CaptureOff {
 		return w, nil
+	}
+	if rw, ok := w.(*translate.ResponsesWriter); ok {
+		var cw *captureWriter
+		rw.WrapInner(func(inner http.ResponseWriter) http.ResponseWriter {
+			cw = newCaptureWriter(inner, s.captureMaxBytes)
+			return cw
+		})
+		return w, cw
 	}
 	cw := newCaptureWriter(w, s.captureMaxBytes)
 	return cw, cw

--- a/internal/proxy/turn_logs.go
+++ b/internal/proxy/turn_logs.go
@@ -1,0 +1,147 @@
+package proxy
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"net/http"
+	"slices"
+	"strings"
+	"time"
+
+	"workweave/router/internal/observability/otel"
+
+	commonv1 "go.opentelemetry.io/proto/otlp/common/v1"
+)
+
+// ContentCaptureMode controls how much request/response content the router
+// emits over OTLP as high-fidelity `router.call` log records.
+type ContentCaptureMode int
+
+const (
+	// CaptureOff emits no `router.call` log records. Spans and the existing
+	// telemetry row are unaffected. Default for self-hosted / OSS.
+	CaptureOff ContentCaptureMode = iota
+	// CaptureHashed emits log records with metadata + SHA-256 content hashes
+	// but no raw text — dedup/cache analysis without exposing prompts.
+	CaptureHashed
+	// CaptureFull emits log records with full raw request/response bodies
+	// (after the redaction hook). Default for Weave-managed deploys.
+	CaptureFull
+)
+
+// ContentKind tells the redaction hook whether it is scrubbing a request or a
+// response body, so callers can apply asymmetric policies.
+type ContentKind int
+
+const (
+	// ContentKindRequest marks an inbound request body.
+	ContentKindRequest ContentKind = iota
+	// ContentKindResponse marks an outbound response body.
+	ContentKindResponse
+)
+
+// Redactor scrubs sensitive content before it enters the OTLP export queue.
+// A nil redactor passes content through unchanged.
+type Redactor func(content string, kind ContentKind) string
+
+// ParseCaptureMode maps a config string to a ContentCaptureMode. Unknown or
+// empty values fall back to CaptureOff (the safe default).
+func ParseCaptureMode(raw string) ContentCaptureMode {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case "full":
+		return CaptureFull
+	case "hashed":
+		return CaptureHashed
+	default:
+		return CaptureOff
+	}
+}
+
+func (m ContentCaptureMode) String() string {
+	switch m {
+	case CaptureFull:
+		return "full"
+	case CaptureHashed:
+		return "hashed"
+	default:
+		return "off"
+	}
+}
+
+// maybeCaptureResponse wraps w with a content-capturing writer when capture is
+// enabled. The returned captureWriter (nil when off) mirrors the exact bytes
+// delivered to the client, so the captured response is in the client's native
+// wire format regardless of which upstream served it.
+func (s *Service) maybeCaptureResponse(w http.ResponseWriter) (http.ResponseWriter, *captureWriter) {
+	if s.captureMode == CaptureOff {
+		return w, nil
+	}
+	cw := newCaptureWriter(w, s.captureMaxBytes)
+	return cw, cw
+}
+
+// capturedResponse extracts the buffered response body. truncated is true when
+// the body exceeded the capture cap (the buffer is then dropped).
+func capturedResponse(c *captureWriter) (body []byte, truncated bool) {
+	if c == nil {
+		return nil, false
+	}
+	b, _, ok := c.captured()
+	if !ok {
+		return nil, true
+	}
+	return b, false
+}
+
+func (s *Service) redact(content []byte, kind ContentKind) string {
+	if s.redactor == nil {
+		return string(content)
+	}
+	return s.redactor(string(content), kind)
+}
+
+func sha256Hex(b []byte) string {
+	sum := sha256.Sum256(b)
+	return hex.EncodeToString(sum[:])
+}
+
+// recordCallLog emits a high-fidelity `router.call` OTLP log record for one
+// upstream call. It reuses the upstream span's already-built attributes as the
+// metadata base (decision, tokens, cost, latency, cluster scoring) and appends
+// content attributes per the capture mode. No-op when capture is off, when the
+// emitter is disabled (RecordLog finds no buffer), so callers need not guard.
+//
+// base is the slice returned by the upstream span's AttrBuilder.Build(); it is
+// cloned before appending so the span's attributes are never mutated.
+func (s *Service) recordCallLog(ctx context.Context, base []*commonv1.KeyValue, isErr bool, reqBody, respBody []byte, respTruncated bool) {
+	if s.captureMode == CaptureOff {
+		return
+	}
+
+	content := otel.NewAttrBuilder(6).
+		Int64("io.request_bytes", int64(len(reqBody))).
+		Int64("io.response_bytes", int64(len(respBody))).
+		Bool("io.truncated", respTruncated)
+
+	switch s.captureMode {
+	case CaptureFull:
+		content.String("io.request_body", s.redact(reqBody, ContentKindRequest)).
+			String("io.response_body", s.redact(respBody, ContentKindResponse))
+	case CaptureHashed:
+		content.String("io.request_sha256", sha256Hex(reqBody)).
+			String("io.response_sha256", sha256Hex(respBody))
+	}
+
+	attrs := append(slices.Clone(base), content.Build()...)
+	sev := otel.SeverityInfo
+	if isErr {
+		sev = otel.SeverityError
+	}
+	otel.RecordLog(ctx, otel.LogRecord{
+		Name:     "router.call",
+		Time:     time.Now(),
+		Severity: sev,
+		Attrs:    attrs,
+	})
+}

--- a/internal/proxy/turn_logs.go
+++ b/internal/proxy/turn_logs.go
@@ -110,6 +110,35 @@ func capturedResponse(c *captureWriter) (body []byte, truncated bool) {
 	return b, false
 }
 
+// deferredCallLog lets a wrapping handler run the call-log emission after the
+// response body is fully written. The /v1/responses surface wraps the client
+// in a translate.ResponsesWriter and calls Finalize only after
+// ProxyOpenAIChatCompletion returns; reading the captured body before Finalize
+// would yield empty/partial content. When a holder is present on the context,
+// ProxyOpenAIChatCompletion stores its emit closure here instead of running it
+// inline, and the wrapper invokes run() post-Finalize.
+type deferredCallLog struct{ fn func() }
+
+type deferredCallLogKey struct{}
+
+func withDeferredCallLog(ctx context.Context) (context.Context, *deferredCallLog) {
+	h := &deferredCallLog{}
+	return context.WithValue(ctx, deferredCallLogKey{}, h), h
+}
+
+func deferredCallLogFrom(ctx context.Context) *deferredCallLog {
+	h, _ := ctx.Value(deferredCallLogKey{}).(*deferredCallLog)
+	return h
+}
+
+// run invokes the deferred emit if one was registered. Safe on nil receiver
+// and when no emit was stored (e.g. the request errored before any call).
+func (d *deferredCallLog) run() {
+	if d != nil && d.fn != nil {
+		d.fn()
+	}
+}
+
 func (s *Service) redact(content []byte, kind ContentKind) string {
 	if s.redactor == nil {
 		return string(content)

--- a/internal/proxy/turn_logs.go
+++ b/internal/proxy/turn_logs.go
@@ -117,7 +117,14 @@ func capturedResponse(c *captureWriter) (body []byte, truncated bool) {
 // would yield empty/partial content. When a holder is present on the context,
 // ProxyOpenAIChatCompletion stores its emit closure here instead of running it
 // inline, and the wrapper invokes run() post-Finalize.
-type deferredCallLog struct{ fn func() }
+type deferredCallLog struct {
+	fn func()
+	// requestBody, when set, overrides the captured request body for the call
+	// log. ProxyOpenAIResponses sets it to the client's original Responses JSON
+	// so io.request_body matches the Responses-format response body, rather than
+	// the translated Chat Completions payload ProxyOpenAIChatCompletion sees.
+	requestBody []byte
+}
 
 type deferredCallLogKey struct{}
 

--- a/internal/proxy/turn_logs_internal_test.go
+++ b/internal/proxy/turn_logs_internal_test.go
@@ -1,0 +1,212 @@
+package proxy
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+
+	collogspb "go.opentelemetry.io/proto/otlp/collector/logs/v1"
+
+	"workweave/router/internal/observability/otel"
+)
+
+func TestParseCaptureMode(t *testing.T) {
+	assert.Equal(t, CaptureOff, ParseCaptureMode(""))
+	assert.Equal(t, CaptureOff, ParseCaptureMode("nonsense"))
+	assert.Equal(t, CaptureHashed, ParseCaptureMode("hashed"))
+	assert.Equal(t, CaptureFull, ParseCaptureMode("FULL"))
+	assert.Equal(t, CaptureFull, ParseCaptureMode(" full "))
+	assert.Equal(t, "off", CaptureOff.String())
+	assert.Equal(t, "hashed", CaptureHashed.String())
+	assert.Equal(t, "full", CaptureFull.String())
+}
+
+func TestMaybeCaptureResponse_OffReturnsNil(t *testing.T) {
+	s := &Service{captureMode: CaptureOff}
+	rec := httptest.NewRecorder()
+	sink, cw := s.maybeCaptureResponse(rec)
+	assert.Nil(t, cw)
+	assert.Same(t, http.ResponseWriter(rec), sink)
+
+	body, trunc := capturedResponse(nil)
+	assert.Nil(t, body)
+	assert.False(t, trunc)
+}
+
+func TestMaybeCaptureResponse_CapturesAndTruncates(t *testing.T) {
+	s := &Service{captureMode: CaptureFull, captureMaxBytes: 1024}
+	rec := httptest.NewRecorder()
+	sink, cw := s.maybeCaptureResponse(rec)
+	require.NotNil(t, cw)
+	_, _ = sink.Write([]byte("hello world"))
+	body, trunc := capturedResponse(cw)
+	assert.False(t, trunc)
+	assert.Equal(t, "hello world", string(body))
+	assert.Equal(t, "hello world", rec.Body.String())
+
+	// Over-cap response is dropped and flagged truncated.
+	small := &Service{captureMode: CaptureFull, captureMaxBytes: 4}
+	rec2 := httptest.NewRecorder()
+	sink2, cap2 := small.maybeCaptureResponse(rec2)
+	_, _ = sink2.Write([]byte("way too long"))
+	body2, trunc2 := capturedResponse(cap2)
+	assert.Nil(t, body2)
+	assert.True(t, trunc2)
+	// Client still received the full bytes despite capture overflow.
+	assert.Equal(t, "way too long", rec2.Body.String())
+}
+
+// logCollector captures OTLP /v1/logs exports for assertion.
+type logCollector struct {
+	server *httptest.Server
+	mu     sync.Mutex
+	bodies [][]byte
+}
+
+func newLogCollector(t *testing.T) *logCollector {
+	t.Helper()
+	c := &logCollector{}
+	c.server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		if strings.HasSuffix(r.URL.Path, "/v1/logs") {
+			c.mu.Lock()
+			c.bodies = append(c.bodies, b)
+			c.mu.Unlock()
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(c.server.Close)
+	return c
+}
+
+func (c *logCollector) attrs(t *testing.T) map[string]string {
+	t.Helper()
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	out := map[string]string{}
+	for _, b := range c.bodies {
+		var req collogspb.ExportLogsServiceRequest
+		require.NoError(t, proto.Unmarshal(b, &req))
+		for _, rl := range req.ResourceLogs {
+			for _, sl := range rl.ScopeLogs {
+				for _, lr := range sl.LogRecords {
+					for _, kv := range lr.Attributes {
+						out[kv.Key] = kv.GetValue().GetStringValue()
+					}
+				}
+			}
+		}
+	}
+	return out
+}
+
+func (c *logCollector) count(t *testing.T) int {
+	t.Helper()
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	n := 0
+	for _, b := range c.bodies {
+		var req collogspb.ExportLogsServiceRequest
+		require.NoError(t, proto.Unmarshal(b, &req))
+		for _, rl := range req.ResourceLogs {
+			for _, sl := range rl.ScopeLogs {
+				n += len(sl.LogRecords)
+			}
+		}
+	}
+	return n
+}
+
+func newServiceWithEmitter(t *testing.T, mode ContentCaptureMode, redactor Redactor, endpoint string) (*Service, *otel.Emitter) {
+	t.Helper()
+	em, err := otel.NewEmitter(otel.EmitterConfig{
+		Endpoint:      endpoint,
+		ServiceName:   "test",
+		Workers:       1,
+		QueueSize:     100,
+		BatchSize:     100,
+		FlushInterval: time.Second,
+	})
+	require.NoError(t, err)
+	return &Service{emitter: em, captureMode: mode, captureMaxBytes: 1 << 20, redactor: redactor}, em
+}
+
+func TestRecordCallLog_OffEmitsNothing(t *testing.T) {
+	coll := newLogCollector(t)
+	s, em := newServiceWithEmitter(t, CaptureOff, nil, coll.server.URL)
+
+	buf := otel.NewBuffer(em)
+	ctx := buf.WithContext(context.Background())
+	base := otel.NewAttrBuilder(1).String("decision.model", "claude-opus-4-8").Build()
+	s.recordCallLog(ctx, base, false, []byte("req"), []byte("resp"), false)
+	otel.Flush(ctx)
+
+	require.NoError(t, em.Shutdown(context.Background()))
+	assert.Equal(t, 0, coll.count(t))
+}
+
+func TestRecordCallLog_FullCapturesBodies(t *testing.T) {
+	coll := newLogCollector(t)
+	s, em := newServiceWithEmitter(t, CaptureFull, nil, coll.server.URL)
+
+	buf := otel.NewBuffer(em)
+	ctx := buf.WithContext(context.Background())
+	base := otel.NewAttrBuilder(1).String("decision.model", "claude-opus-4-8").Build()
+	s.recordCallLog(ctx, base, false, []byte(`{"req":1}`), []byte(`{"resp":2}`), false)
+	otel.Flush(ctx)
+
+	require.NoError(t, em.Shutdown(context.Background()))
+	require.Equal(t, 1, coll.count(t))
+	a := coll.attrs(t)
+	assert.Equal(t, "claude-opus-4-8", a["decision.model"]) // base metadata carried over
+	assert.Equal(t, `{"req":1}`, a["io.request_body"])
+	assert.Equal(t, `{"resp":2}`, a["io.response_body"])
+	assert.Empty(t, a["io.request_sha256"])
+}
+
+func TestRecordCallLog_HashedOmitsRawText(t *testing.T) {
+	coll := newLogCollector(t)
+	s, em := newServiceWithEmitter(t, CaptureHashed, nil, coll.server.URL)
+
+	buf := otel.NewBuffer(em)
+	ctx := buf.WithContext(context.Background())
+	s.recordCallLog(ctx, nil, false, []byte("secret-prompt"), []byte("secret-response"), false)
+	otel.Flush(ctx)
+
+	require.NoError(t, em.Shutdown(context.Background()))
+	a := coll.attrs(t)
+	assert.NotEmpty(t, a["io.request_sha256"])
+	assert.NotEmpty(t, a["io.response_sha256"])
+	assert.Empty(t, a["io.request_body"])
+	assert.NotContains(t, a["io.request_sha256"], "secret")
+}
+
+func TestRecordCallLog_RedactorApplied(t *testing.T) {
+	coll := newLogCollector(t)
+	redactor := func(content string, kind ContentKind) string {
+		if kind == ContentKindRequest {
+			return "REDACTED-REQ"
+		}
+		return "REDACTED-RESP"
+	}
+	s, em := newServiceWithEmitter(t, CaptureFull, redactor, coll.server.URL)
+
+	buf := otel.NewBuffer(em)
+	ctx := buf.WithContext(context.Background())
+	s.recordCallLog(ctx, nil, false, []byte("raw-req"), []byte("raw-resp"), false)
+	otel.Flush(ctx)
+
+	require.NoError(t, em.Shutdown(context.Background()))
+	a := coll.attrs(t)
+	assert.Equal(t, "REDACTED-REQ", a["io.request_body"])
+	assert.Equal(t, "REDACTED-RESP", a["io.response_body"])
+}

--- a/internal/proxy/turn_logs_internal_test.go
+++ b/internal/proxy/turn_logs_internal_test.go
@@ -190,6 +190,44 @@ func TestRecordCallLog_HashedOmitsRawText(t *testing.T) {
 	assert.NotContains(t, a["io.request_sha256"], "secret")
 }
 
+func TestDeferredCallLog_ReadsBodyAtRunTime(t *testing.T) {
+	coll := newLogCollector(t)
+	s, em := newServiceWithEmitter(t, CaptureFull, nil, coll.server.URL)
+
+	ctx, h := withDeferredCallLog(context.Background())
+	require.NotNil(t, deferredCallLogFrom(ctx), "holder must be retrievable from ctx")
+
+	buf := otel.NewBuffer(em)
+	ctx = buf.WithContext(ctx)
+
+	// Simulate the ProxyOpenAIChatCompletion tail: capture writer is wired, but
+	// the (buffered) ResponsesWriter hasn't written the body yet — the emit is
+	// deferred rather than run inline.
+	rec := httptest.NewRecorder()
+	_, cw := s.maybeCaptureResponse(rec)
+	base := otel.NewAttrBuilder(1).String("decision.model", "m").Build()
+	h.fn = func() {
+		body, trunc := capturedResponse(cw)
+		s.recordCallLog(ctx, base, false, []byte("req"), body, trunc)
+		otel.Flush(ctx)
+	}
+
+	// Body arrives during "Finalize", after the deferral was registered.
+	_, _ = cw.Write([]byte(`{"final":"body"}`))
+	h.run()
+
+	require.NoError(t, em.Shutdown(context.Background()))
+	a := coll.attrs(t)
+	assert.Equal(t, `{"final":"body"}`, a["io.response_body"], "deferred emit must read the post-Finalize body")
+}
+
+func TestDeferredCallLog_SafeWhenAbsent(t *testing.T) {
+	assert.Nil(t, deferredCallLogFrom(context.Background()))
+	var d *deferredCallLog
+	assert.NotPanics(t, func() { d.run() })           // nil receiver
+	assert.NotPanics(t, func() { (&deferredCallLog{}).run() }) // no fn registered
+}
+
 func TestRecordCallLog_RedactorApplied(t *testing.T) {
 	coll := newLogCollector(t)
 	redactor := func(content string, kind ContentKind) string {

--- a/internal/proxy/turn_logs_internal_test.go
+++ b/internal/proxy/turn_logs_internal_test.go
@@ -224,7 +224,7 @@ func TestDeferredCallLog_ReadsBodyAtRunTime(t *testing.T) {
 func TestDeferredCallLog_SafeWhenAbsent(t *testing.T) {
 	assert.Nil(t, deferredCallLogFrom(context.Background()))
 	var d *deferredCallLog
-	assert.NotPanics(t, func() { d.run() })           // nil receiver
+	assert.NotPanics(t, func() { d.run() })                    // nil receiver
 	assert.NotPanics(t, func() { (&deferredCallLog{}).run() }) // no fn registered
 }
 

--- a/internal/translate/responses.go
+++ b/internal/translate/responses.go
@@ -333,6 +333,18 @@ func NewResponsesWriter(w http.ResponseWriter, model string) *ResponsesWriter {
 	}
 }
 
+// WrapInner inserts fn between this writer and the underlying client writer,
+// rebinding both the raw inner and the buffered writer so every emitted byte —
+// eager prelude, SSE events, and the final JSON envelope — flows through fn.
+// Used to splice in a content-capture writer at the true client boundary for
+// high-fidelity telemetry. Must be called before any bytes are written.
+func (t *ResponsesWriter) WrapInner(fn func(http.ResponseWriter) http.ResponseWriter) {
+	wrapped := fn(t.inner)
+	t.inner = wrapped
+	t.flusher, _ = wrapped.(http.Flusher)
+	t.bw = bufio.NewWriterSize(wrapped, 8192)
+}
+
 func (t *ResponsesWriter) Header() http.Header { return t.inner.Header() }
 
 func (t *ResponsesWriter) WriteHeader(code int) {

--- a/internal/translate/responses_wrapinner_test.go
+++ b/internal/translate/responses_wrapinner_test.go
@@ -1,0 +1,54 @@
+package translate_test
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"workweave/router/internal/translate"
+)
+
+// teeWriter mirrors every byte written to it into capture, simulating the
+// content-capture writer the proxy splices in via WrapInner.
+type teeWriter struct {
+	inner   http.ResponseWriter
+	capture *bytes.Buffer
+}
+
+func (t *teeWriter) Header() http.Header { return t.inner.Header() }
+func (t *teeWriter) WriteHeader(c int)   { t.inner.WriteHeader(c) }
+func (t *teeWriter) Write(p []byte) (int, error) {
+	t.capture.Write(p)
+	return t.inner.Write(p)
+}
+func (t *teeWriter) Flush() {
+	if f, ok := t.inner.(http.Flusher); ok {
+		f.Flush()
+	}
+}
+
+// TestResponsesWriter_WrapInnerCapturesPrelude asserts WrapInner reroutes both
+// the buffered writer and the raw inner so the eager response.created prelude —
+// which previously bypassed an externally-wrapped capture writer — reaches the
+// spliced-in writer, and that what it captures equals what the client receives.
+func TestResponsesWriter_WrapInnerCapturesPrelude(t *testing.T) {
+	rec := httptest.NewRecorder()
+	rw := translate.NewResponsesWriter(rec, "claude-opus-4-8")
+
+	var captured bytes.Buffer
+	rw.WrapInner(func(inner http.ResponseWriter) http.ResponseWriter {
+		return &teeWriter{inner: inner, capture: &captured}
+	})
+
+	require.NoError(t, rw.Prelude(true))
+	rw.Flush()
+
+	assert.NotEmpty(t, captured.Bytes(), "prelude bytes must reach the wrapped writer")
+	assert.Contains(t, captured.String(), "response.created")
+	// Capture is byte-identical to what the client actually received.
+	assert.Equal(t, rec.Body.String(), captured.String())
+}


### PR DESCRIPTION
## What

Phase 1 of the router high-fidelity telemetry program (spec: WorkWeave `specs/router_high_fidelity_telemetry.md`). Brings the router's emitted telemetry up to the fidelity of the Claude Code plugin — every upstream LLM call, full inputs and outputs, decision metadata, and outcome — **emitted over OTLP only** (no direct DB/URL sink).

Adds a new `router.call` OTLP **log record** per upstream call, posted to `${OTEL_EXPORTER_OTLP_ENDPOINT}/v1/logs` alongside the existing `router.decision` / `router.upstream` spans. Each record:
- reuses the upstream span's routing/decision/cost/latency/cluster-scoring attributes as its metadata base,
- adds the call outcome (status, severity = ERROR on failure),
- and — gated by `WV_CAPTURE_CONTENT` — the request and response bodies (or SHA-256 hashes).

This is the ML-ready event stream: one record per LLM call, full I/O, ready for the Weave-side collector to land in trajectory tables.

## How

- **`internal/observability/otel`** — `LogRecord` type + OTLP logs proto (`logs.go`); the `Emitter` gains a parallel log pipeline (queue / worker / export to `/v1/logs`) mirroring the span pipeline; `Buffer` carries log records and flushes them under the request's shared trace ID.
- **`internal/proxy`** — an outermost content-capture writer mirrors the exact client-facing bytes (native wire format per surface) across all three proxy paths (Anthropic / OpenAI / Gemini); `recordCallLog` builds the event with a pluggable redaction hook and `off`/`hashed`/`full` modes.
- **`cmd/router/main.go`** — `WV_CAPTURE_CONTENT` (default `off`) + `WV_CAPTURE_MAX_BYTES`; stamps `router.deployment_mode` on every export so a collector can branch redaction / content-opt-out.

## Behavior / safety

- **Opt-in.** With `WV_CAPTURE_CONTENT` unset (default), no log records are emitted and behavior is unchanged. Self-hosted operators opt in explicitly; Weave-managed deploys set `full` in their deploy config.
- Spans and the existing `model_router_request_telemetry` row are untouched — no dashboard/billing regression.
- Captured bodies pass through an optional redaction hook before export; response capture is size-capped (`io.truncated=true` on overflow; the client still receives the full stream).
- Everything leaves the process over OTLP — no hardcoded analytics endpoint.

## Tests

- `otel`: log-record flush, spans+logs share trace ID, distinct `/v1/traces` vs `/v1/logs` endpoints, nil-buffer safety.
- `proxy`: capture-mode parsing, writer capture + truncation, and `recordCallLog` across off/full/hashed + redactor.
- Full module `go build` / `go vet` / `go test ./...` green.

## Follow-ups (not in this PR)

- WorkWeave collector PR: `/api/ingest/router/v1/logs` route + `ProcessRouterLogs` + `router_plugin_*` trajectory tables + ClickHouse denorm, then gitlink bump.
- ML loader: `router` source in `ml_dev/agent_flow`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)