### PR TITLE
feat(feedback): emit external_id on router.feedback span

### DIFF
--- a/internal/proxy/router_feedback.go
+++ b/internal/proxy/router_feedback.go
@@ -80,6 +80,7 @@ func (s *Service) handleRouterFeedbackCommand(
 
 	clientID := ClientIdentityFrom(ctx)
 	routerUserID := auth.UserIDFrom(ctx)
+	externalID, _ := ctx.Value(ExternalIDContextKey{}).(string)
 
 	if s.feedbackStore != nil && installationID != uuid.Nil {
 		event := RouterFeedbackEvent{
@@ -107,7 +108,8 @@ func (s *Service) handleRouterFeedbackCommand(
 		Name:  "router.feedback",
 		Start: now,
 		End:   now,
-		Attrs: otel.NewAttrBuilder(9).
+		Attrs: otel.NewAttrBuilder(10).
+			String("external_id", externalID).
 			String("router_user_id", routerUserID).
 			String("client.device_id", clientID.DeviceID).
 			String("client.session_id", clientID.SessionID).


### PR DESCRIPTION
## What

Adds `external_id` (the installation's organization identifier) to the `router.feedback` telemetry span emitted by the `/router-feedback` command.

## Why

The `router.feedback` span omitted `external_id`, even though every other router span (`router.decision`, `router.upstream`) carries it. On the Weave backend side, attributing feedback to an org/account therefore required an **org-less reverse lookup by `router_user_id`**, which:

- forces a sequential scan of `account_weave_router_user_connections` (the table's indexes are all `organization_id`-leading), and
- risks **cross-tenant attribution**, since `router_user_id` uniqueness is only enforced per-org (`UNIQUE(organization_id, router_user_id)`).

Both issues were flagged by automated review on the backend PR. Emitting `external_id` here lets the backend reuse its existing org-scoped resolution path (same one the decision/upstream analytics use), eliminating the unscoped query entirely.

## Change

`handleRouterFeedbackCommand` now pulls `external_id` from the request context (`ExternalIDContextKey`) — exactly as `ProxyMessages`/`ProxyOpenAIChatCompletion` do for the decision span — and adds it as the first attribute on the `router.feedback` span.

## Testing

- `wv mr tc`
- `go test ./internal/proxy/ -run RouterFeedback`

🤖 Generated with [Claude Code](https://claude.com/claude-code)