### PR TITLE
fix(catalog): correct stale context windows across the model roster

### DIFF
--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -376,18 +376,19 @@ func contextWindowForRequest(modelID string, extendedContextRequested bool) int 
 }
 
 // excludeContextOverflowModels returns a copy of excluded augmented with every
-// model in available whose context window is too small to serve the request.
+// model in available whose context window is too small to serve the request,
+// plus the sorted IDs of the models it newly excluded (for logging).
 // est is the full-body token estimate (translate.RequestEnvelope.FullTokenEstimate).
 // outputReserve is the expected output budget (feats.MaxTokens or the const above).
 // extendedContextRequested indicates whether the client sent context-1m-2025-08-07 beta.
-// Returns the original excluded map unchanged when no models are added.
-func excludeContextOverflowModels(est, outputReserve int, excluded, available map[string]struct{}, extendedContextRequested bool) (map[string]struct{}, int) {
+// Returns the original excluded map unchanged and a nil slice when no models are added.
+func excludeContextOverflowModels(est, outputReserve int, excluded, available map[string]struct{}, extendedContextRequested bool) (map[string]struct{}, []string) {
 	if est <= 0 {
-		return excluded, 0
+		return excluded, nil
 	}
 	needed := est + outputReserve
 	var out map[string]struct{}
-	added := 0
+	var overflowed []string
 	for model := range available {
 		if _, alreadyExcluded := excluded[model]; alreadyExcluded {
 			continue
@@ -403,12 +404,13 @@ func excludeContextOverflowModels(est, outputReserve int, excluded, available ma
 			}
 		}
 		out[model] = struct{}{}
-		added++
+		overflowed = append(overflowed, model)
 	}
-	if added == 0 {
-		return excluded, 0
+	if len(overflowed) == 0 {
+		return excluded, nil
 	}
-	return out, added
+	sort.Strings(overflowed)
+	return out, overflowed
 }
 
 // restrictToTier returns a copy of excluded augmented with every routable model
@@ -1157,12 +1159,13 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 	}
 	baseExcluded := s.excludedModelsForRequest(ctx)
 	extendedContext := hasContext1MBeta(r.Header)
-	excluded, ctxExcluded := excludeContextOverflowModels(env.FullTokenEstimate(), outputReserve, baseExcluded, s.availableModels, extendedContext)
-	if ctxExcluded > 0 {
+	excluded, ctxOverflowed := excludeContextOverflowModels(env.FullTokenEstimate(), outputReserve, baseExcluded, s.availableModels, extendedContext)
+	if len(ctxOverflowed) > 0 {
 		log.Info("context window pre-filter: excluded over-capacity models",
 			"full_token_estimate", env.FullTokenEstimate(),
 			"output_reserve", outputReserve,
-			"excluded_count", ctxExcluded,
+			"excluded_count", len(ctxOverflowed),
+			"excluded_models", strings.Join(ctxOverflowed, ","),
 		)
 	}
 
@@ -2385,12 +2388,13 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 		outputReserveOAI = feats.MaxTokens
 	}
 	baseExcludedOAI := s.excludedModelsForRequest(ctx)
-	excludedOAI, ctxExcludedOAI := excludeContextOverflowModels(env.FullTokenEstimate(), outputReserveOAI, baseExcludedOAI, s.availableModels, false)
-	if ctxExcludedOAI > 0 {
+	excludedOAI, ctxOverflowedOAI := excludeContextOverflowModels(env.FullTokenEstimate(), outputReserveOAI, baseExcludedOAI, s.availableModels, false)
+	if len(ctxOverflowedOAI) > 0 {
 		log.Info("context window pre-filter: excluded over-capacity models",
 			"full_token_estimate", env.FullTokenEstimate(),
 			"output_reserve", outputReserveOAI,
-			"excluded_count", ctxExcludedOAI,
+			"excluded_count", len(ctxOverflowedOAI),
+			"excluded_models", strings.Join(ctxOverflowedOAI, ","),
 		)
 	}
 

--- a/internal/router/catalog/catalog.go
+++ b/internal/router/catalog/catalog.go
@@ -314,37 +314,41 @@ var Models = []Model{
 	//   Bedrock binding (2026-05-23) showed the model returning narrative
 	//   "I edited the file" responses with zero tool_use blocks. Excluded
 	//   from agentic argmax pools until the Thinking variant lands.
-	{ID: "qwen/qwen3-235b-a22b-2507", Tier: TierMid, ContextWindow: 131_072, ToolUseQuality: ToolUseLow, ImageInput: ImageInputUnsupported, Providers: []ProviderBinding{
+	{ID: "qwen/qwen3-235b-a22b-2507", Tier: TierMid, ContextWindow: 262_144, ToolUseQuality: ToolUseLow, ImageInput: ImageInputUnsupported, Providers: []ProviderBinding{
 		{Provider: providers.ProviderBedrock, UpstreamID: "qwen.qwen3-235b-a22b-2507",
 			Price: Pricing{InputUSDPer1M: 0.2266, OutputUSDPer1M: 0.9064}},
 		{Provider: providers.ProviderOpenRouter, Price: Pricing{InputUSDPer1M: 0.071, OutputUSDPer1M: 0.463}},
 	}},
-	{ID: "qwen/qwen3-coder-next", Tier: TierMid, ContextWindow: 131_072, ImageInput: ImageInputUnsupported, Providers: []ProviderBinding{
+	{ID: "qwen/qwen3-coder-next", Tier: TierMid, ContextWindow: 262_144, ImageInput: ImageInputUnsupported, Providers: []ProviderBinding{
 		{Provider: providers.ProviderBedrock, UpstreamID: "qwen.qwen3-coder-next",
 			Price: Pricing{InputUSDPer1M: 0.500, OutputUSDPer1M: 1.200}},
 		{Provider: providers.ProviderOpenRouter, Price: Pricing{InputUSDPer1M: 0.070, OutputUSDPer1M: 0.300}},
 	}},
-	{ID: "qwen/qwen3-next-80b-a3b-instruct", Tier: TierMid, ContextWindow: 131_072, ImageInput: ImageInputUnsupported, Providers: []ProviderBinding{
+	{ID: "qwen/qwen3-next-80b-a3b-instruct", Tier: TierMid, ContextWindow: 262_144, ImageInput: ImageInputUnsupported, Providers: []ProviderBinding{
 		{Provider: providers.ProviderBedrock, UpstreamID: "qwen.qwen3-next-80b-a3b-instruct",
 			Price: Pricing{InputUSDPer1M: 0.150, OutputUSDPer1M: 1.200}},
 		{Provider: providers.ProviderOpenRouter, Price: Pricing{InputUSDPer1M: 0.090, OutputUSDPer1M: 1.100}},
 	}},
-	{ID: "deepseek/deepseek-v4-flash", Tier: TierLow, ContextWindow: 131_072, ImageInput: ImageInputUnsupported, Providers: []ProviderBinding{
+	// DeepSeek V4 (Flash + Pro) natively serves a 1,048,576-token context;
+	// DeepInfra (Flash primary) and Fireworks (Pro primary) both serve the full
+	// window. The 131_072 carried over from V3.2 was filtering these out of any
+	// request over ~128K tokens (see excludeContextOverflowModels in proxy/service.go).
+	{ID: "deepseek/deepseek-v4-flash", Tier: TierLow, ContextWindow: 1_048_576, ImageInput: ImageInputUnsupported, Providers: []ProviderBinding{
 		{Provider: providers.ProviderDeepInfra, UpstreamID: "deepseek-ai/DeepSeek-V4-Flash",
 			Price: Pricing{InputUSDPer1M: 0.140, OutputUSDPer1M: 0.280, CacheReadMultiplier: 0.20}},
 		{Provider: providers.ProviderOpenRouter, Price: Pricing{InputUSDPer1M: 0.140, OutputUSDPer1M: 0.280, CacheReadMultiplier: 0.10}},
 	}},
-	{ID: "deepseek/deepseek-v4-pro", Tier: TierHigh, ContextWindow: 131_072, ImageInput: ImageInputUnsupported, Providers: []ProviderBinding{
+	{ID: "deepseek/deepseek-v4-pro", Tier: TierHigh, ContextWindow: 1_048_576, ImageInput: ImageInputUnsupported, Providers: []ProviderBinding{
 		{Provider: providers.ProviderFireworks, UpstreamID: "accounts/fireworks/models/deepseek-v4-pro",
 			Price: Pricing{InputUSDPer1M: 1.740, OutputUSDPer1M: 3.480, CacheReadMultiplier: 0.0862}},
 		{Provider: providers.ProviderOpenRouter, Price: Pricing{InputUSDPer1M: 0.435, OutputUSDPer1M: 0.870, CacheReadMultiplier: 0.10}},
 	}},
-	{ID: "moonshotai/kimi-k2.5", Tier: TierHigh, ContextWindow: 131_072, ImageInput: ImageInputUnsupported, Providers: []ProviderBinding{
+	{ID: "moonshotai/kimi-k2.5", Tier: TierHigh, ContextWindow: 262_144, ImageInput: ImageInputUnsupported, Providers: []ProviderBinding{
 		{Provider: providers.ProviderBedrock, UpstreamID: "moonshotai.kimi-k2.5",
 			Price: Pricing{InputUSDPer1M: 0.600, OutputUSDPer1M: 3.000}},
 		{Provider: providers.ProviderOpenRouter, Price: Pricing{InputUSDPer1M: 0.440, OutputUSDPer1M: 2.000}},
 	}},
-	{ID: "moonshotai/kimi-k2.6", Tier: TierHigh, ContextWindow: 131_072, ImageInput: ImageInputUnsupported, Providers: []ProviderBinding{
+	{ID: "moonshotai/kimi-k2.6", Tier: TierHigh, ContextWindow: 262_144, ImageInput: ImageInputUnsupported, Providers: []ProviderBinding{
 		{Provider: providers.ProviderFireworks, UpstreamID: "accounts/fireworks/models/kimi-k2p6",
 			Price: Pricing{InputUSDPer1M: 0.950, OutputUSDPer1M: 4.000, CacheReadMultiplier: 0.1684}},
 		{Provider: providers.ProviderOpenRouter, Price: Pricing{InputUSDPer1M: 0.950, OutputUSDPer1M: 4.000, CacheReadMultiplier: 0.10}},
@@ -363,7 +367,7 @@ var Models = []Model{
 	// re-issue loops on weak agent prompts. Matches public reports against
 	// OpenCode (#24095) and Crush (#1699). The pro variant is kept — slower
 	// but doesn't exhibit the same instability in our sweep.
-	{ID: "xiaomi/mimo-v2.5-pro", Tier: TierHigh, ContextWindow: 131_072, ImageInput: ImageInputUnsupported, Providers: []ProviderBinding{
+	{ID: "xiaomi/mimo-v2.5-pro", Tier: TierHigh, ContextWindow: 1_048_576, ImageInput: ImageInputUnsupported, Providers: []ProviderBinding{
 		{Provider: providers.ProviderDeepInfra, UpstreamID: "XiaomiMiMo/MiMo-V2.5-Pro",
 			Price: Pricing{InputUSDPer1M: 1.000, OutputUSDPer1M: 3.000}},
 		{Provider: providers.ProviderOpenRouter, Price: Pricing{InputUSDPer1M: 1.000, OutputUSDPer1M: 3.000, CacheReadMultiplier: 0.10}},
@@ -372,7 +376,7 @@ var Models = []Model{
 	// 2k tokens on DeepInfra FP8, the speed/cost end of the new Qwen3.6
 	// family. TierLow despite the MoE size because the active parameter
 	// budget + AA's Coding Index put it below v4-flash.
-	{ID: "qwen/qwen3.6-35b-a3b", Tier: TierLow, ContextWindow: 131_072, ImageInput: ImageInputUnsupported, Providers: []ProviderBinding{
+	{ID: "qwen/qwen3.6-35b-a3b", Tier: TierLow, ContextWindow: 262_144, ImageInput: ImageInputUnsupported, Providers: []ProviderBinding{
 		{Provider: providers.ProviderDeepInfra, UpstreamID: "Qwen/Qwen3.6-35B-A3B",
 			Price: Pricing{InputUSDPer1M: 0.150, OutputUSDPer1M: 0.950}},
 		{Provider: providers.ProviderOpenRouter, Price: Pricing{InputUSDPer1M: 0.150, OutputUSDPer1M: 1.000, CacheReadMultiplier: 0.10}},
@@ -380,12 +384,15 @@ var Models = []Model{
 	// minimax-m2.7 sits in an unusual quality/cost spot: Intel 50 at
 	// $0.52 blended, cheaper than every TierMid model. Letting the
 	// trainer find its niche rather than pinning a tier by price alone.
-	{ID: "minimax/minimax-m2.7", Tier: TierHigh, ContextWindow: 1_000_000, ImageInput: ImageInputUnsupported, Providers: []ProviderBinding{
+	// Context window is 204,800 on both Fireworks and OpenRouter despite
+	// MiniMax's "1M" marketing — do NOT raise without re-confirming the
+	// served cap, or requests over ~205K tokens will hard-400 (no failover).
+	{ID: "minimax/minimax-m2.7", Tier: TierHigh, ContextWindow: 204_800, ImageInput: ImageInputUnsupported, Providers: []ProviderBinding{
 		{Provider: providers.ProviderFireworks, UpstreamID: "accounts/fireworks/models/minimax-m2p7",
 			Price: Pricing{InputUSDPer1M: 0.300, OutputUSDPer1M: 1.200}},
 		{Provider: providers.ProviderOpenRouter, Price: Pricing{InputUSDPer1M: 0.279, OutputUSDPer1M: 1.200, CacheReadMultiplier: 0.10}},
 	}},
-	{ID: "z-ai/glm-5", Tier: TierHigh, ContextWindow: 131_072, ImageInput: ImageInputUnsupported, Providers: []ProviderBinding{
+	{ID: "z-ai/glm-5", Tier: TierHigh, ContextWindow: 202_752, ImageInput: ImageInputUnsupported, Providers: []ProviderBinding{
 		{Provider: providers.ProviderDeepInfra, UpstreamID: "zai-org/GLM-5",
 			Price: Pricing{InputUSDPer1M: 0.600, OutputUSDPer1M: 2.080}},
 		{Provider: providers.ProviderOpenRouter, Price: Pricing{InputUSDPer1M: 0.600, OutputUSDPer1M: 1.920, CacheReadMultiplier: 0.10}},
@@ -393,7 +400,7 @@ var Models = []Model{
 	// GLM-5.1 ships the streaming tool-call fix that GLM-5 lacks (tool_stream=true
 	// per Z.AI docs). Wired up for /force-model testing and v0.56 routing; the
 	// emit_openai layer injects tool_stream + disables thinking for this slug.
-	{ID: "z-ai/glm-5.1", Tier: TierHigh, ContextWindow: 131_072, ImageInput: ImageInputUnsupported, Providers: []ProviderBinding{
+	{ID: "z-ai/glm-5.1", Tier: TierHigh, ContextWindow: 202_752, ImageInput: ImageInputUnsupported, Providers: []ProviderBinding{
 		{Provider: providers.ProviderDeepInfra, UpstreamID: "zai-org/GLM-5.1",
 			Price: Pricing{InputUSDPer1M: 1.050, OutputUSDPer1M: 3.500}},
 		{Provider: providers.ProviderOpenRouter, Price: Pricing{InputUSDPer1M: 0.980, OutputUSDPer1M: 3.080, CacheReadMultiplier: 0.18 / 0.98}},
@@ -402,20 +409,20 @@ var Models = []Model{
 	// an OpenRouter trailing binding so managed-prod deploys without a
 	// Fireworks key can still resolve them; pricing reflects the
 	// OpenRouter list price for the public model card on 2026-05-20.
-	{ID: "mistralai/mistral-small-2603", Tier: TierMid, ContextWindow: 131_072, Providers: []ProviderBinding{
+	{ID: "mistralai/mistral-small-2603", Tier: TierMid, ContextWindow: 262_144, Providers: []ProviderBinding{
 		{Provider: providers.ProviderOpenRouter, Price: Pricing{InputUSDPer1M: 0.200, OutputUSDPer1M: 0.600, CacheReadMultiplier: 0.10}},
 	}},
-	{ID: "qwen/qwen3-30b-a3b-instruct-2507", Tier: TierMid, ContextWindow: 131_072, ImageInput: ImageInputUnsupported, Providers: []ProviderBinding{
+	{ID: "qwen/qwen3-30b-a3b-instruct-2507", Tier: TierMid, ContextWindow: 262_144, ImageInput: ImageInputUnsupported, Providers: []ProviderBinding{
 		{Provider: providers.ProviderFireworks, UpstreamID: "accounts/fireworks/models/qwen3-30b-a3b-instruct-2507",
 			Price: Pricing{InputUSDPer1M: 0.150, OutputUSDPer1M: 0.600, CacheReadMultiplier: 0.1684}},
 		{Provider: providers.ProviderOpenRouter, Price: Pricing{InputUSDPer1M: 0.100, OutputUSDPer1M: 0.300, CacheReadMultiplier: 0.10}},
 	}},
-	{ID: "qwen/qwen3-coder", Tier: TierHigh, ContextWindow: 131_072, ImageInput: ImageInputUnsupported, Providers: []ProviderBinding{
+	{ID: "qwen/qwen3-coder", Tier: TierHigh, ContextWindow: 262_144, ImageInput: ImageInputUnsupported, Providers: []ProviderBinding{
 		{Provider: providers.ProviderFireworks, UpstreamID: "accounts/fireworks/models/qwen3-coder-480b-a35b-instruct",
 			Price: Pricing{InputUSDPer1M: 0.900, OutputUSDPer1M: 2.700, CacheReadMultiplier: 0.1684}},
 		{Provider: providers.ProviderOpenRouter, Price: Pricing{InputUSDPer1M: 1.000, OutputUSDPer1M: 5.000, CacheReadMultiplier: 0.10}},
 	}},
-	{ID: "qwen/qwen3.5-flash-02-23", Tier: TierLow, ContextWindow: 131_072, ImageInput: ImageInputUnsupported, Providers: []ProviderBinding{
+	{ID: "qwen/qwen3.5-flash-02-23", Tier: TierLow, ContextWindow: 1_000_000, ImageInput: ImageInputUnsupported, Providers: []ProviderBinding{
 		{Provider: providers.ProviderOpenRouter, Price: Pricing{InputUSDPer1M: 0.050, OutputUSDPer1M: 0.150, CacheReadMultiplier: 0.10}},
 	}},
 }

--- a/internal/router/catalog/catalog_test.go
+++ b/internal/router/catalog/catalog_test.go
@@ -187,9 +187,14 @@ func TestContextWindowFor_KnownModels(t *testing.T) {
 	assert.Equal(t, 1_047_576, ContextWindowFor("gpt-4.1"))
 	// Gemini models have 1M context.
 	assert.Equal(t, 1_048_576, ContextWindowFor("gemini-3.5-flash"))
-	// OSS models have 128K-131K context.
-	assert.Equal(t, 131_072, ContextWindowFor("deepseek/deepseek-v4-pro"))
-	assert.Equal(t, 131_072, ContextWindowFor("moonshotai/kimi-k2.5"))
+	// DeepSeek V4 (Flash + Pro) serves the full 1,048,576-token window.
+	assert.Equal(t, 1_048_576, ContextWindowFor("deepseek/deepseek-v4-pro"))
+	assert.Equal(t, 1_048_576, ContextWindowFor("deepseek/deepseek-v4-flash"))
+	// Most OSS models serve a 256K window (Qwen3 / Kimi families).
+	assert.Equal(t, 262_144, ContextWindowFor("moonshotai/kimi-k2.5"))
+	// GLM-5 serves ~200K (max_position_embeddings 202752); MiniMax M2.7 is 204800.
+	assert.Equal(t, 202_752, ContextWindowFor("z-ai/glm-5"))
+	assert.Equal(t, 204_800, ContextWindowFor("minimax/minimax-m2.7"))
 	// Unknown model falls back to DefaultContextWindow.
 	assert.Equal(t, DefaultContextWindow, ContextWindowFor("not-a-real-model"))
 }


### PR DESCRIPTION
## Problem

Every OSS routing target carried `131_072` (the V3.x-era 128K window), and one model (`minimax-m2.7`) was overstated at 1M. The context-window pre-filter (`excludeContextOverflowModels` in `proxy/service.go`) uses these values to drop candidates that can't fit a request:

- **Understated** → a usable model is silently removed from the candidate set on long agent sessions (e.g. DeepSeek dropped on any request >128K despite serving 1M).
- **Overstated** → a hard upstream **400** (context overflow is not retryable and has no failover) — `minimax-m2.7` was a live risk on requests over ~205K tokens.

This started as a DeepSeek fix and expanded to a full roster audit.

## What changed

Each value verified against the model's **primary provider page** (the binding managed-prod actually serves), not just the native spec:

| Model | Primary | Before | After | Source |
|---|---|---|---|---|
| deepseek-v4-flash | DeepInfra | 131,072 | **1,048,576** | deepinfra.com page |
| deepseek-v4-pro | Fireworks | 131,072 | **1,048,576** | fireworks / morphllm |
| xiaomi/mimo-v2.5-pro | DeepInfra | 131,072 | **1,048,576** | deepinfra.com page |
| qwen3.5-flash-02-23 | OpenRouter | 131,072 | **1,000,000** | openrouter.ai page |
| qwen3-235b-a22b-2507 | Bedrock | 131,072 | **262,144** | AWS Bedrock model card |
| qwen3-coder-next | Bedrock | 131,072 | **262,144** | AWS Bedrock model card |
| qwen3-next-80b-a3b-instruct | Bedrock | 131,072 | **262,144** | AWS Bedrock model card |
| qwen3-30b-a3b-instruct-2507 | Fireworks | 131,072 | **262,144** | fireworks.ai page |
| qwen3-coder (480b) | Fireworks | 131,072 | **262,144** | fireworks.ai page |
| qwen3.6-35b-a3b | DeepInfra | 131,072 | **262,144** | deepinfra.com page |
| kimi-k2.5 | Bedrock | 131,072 | **262,144** | AWS Bedrock model card |
| kimi-k2.6 | Fireworks | 131,072 | **262,144** | fireworks.ai page |
| mistral-small-2603 | OpenRouter | 131,072 | **262,144** | openrouter.ai page |
| z-ai/glm-5 | DeepInfra | 131,072 | **202,752** | deepinfra / HF max_position_embeddings |
| z-ai/glm-5.1 | DeepInfra | 131,072 | **202,752** | deepinfra / HF max_position_embeddings |
| **minimax-m2.7** | Fireworks | **1,000,000** | **204,800** | openrouter / fireworks — **was a live 400 risk** |

Spot-checked and already correct (no change): Anthropic (200K + 1M beta path), GPT-4o (128K), GPT-5 (400K), GPT-4.1 / Gemini (1M+), claude-fable-5 (1M).

### Logging

The pre-filter Info log only emitted `excluded_count`, so a model silently dropped for context never showed up by name. `excludeContextOverflowModels` now returns the sorted IDs of the models it excluded, logged as `excluded_models` at both the Anthropic and OpenAI-compat call sites — so "model chosen but not routed due to context window" is now visible in prod logs.

## Risk notes

- All bumps are sourced from the **served** window on the primary provider page (high confidence), so they don't introduce 400s. `glm-5.1`'s served number was medium-confidence on the page but matches its native `max_position_embeddings: 202752`, so 202,752 is safe.
- `minimax-m2.7` is the only **decrease** — strictly safer, and it fixes existing 400s. Carries an inline comment so it isn't "fixed" back up.

## Test

- `go build ./...`, `go vet`, `gofmt` clean
- `go test ./internal/proxy/ ./internal/router/catalog/` green (updated `TestContextWindowFor_KnownModels`)
- `go run ./cmd/genprices` produces no install-script drift (context window isn't in generated pricing files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)