### PR TITLE
fix(translate): strip Gemini thought_signature from tool_use before Anthropic emit

### DIFF
--- a/internal/translate/crossformat_request_test.go
+++ b/internal/translate/crossformat_request_test.go
@@ -1697,3 +1697,38 @@ func TestSanitizeToolUseIDs_AnthropicToAnthropic(t *testing.T) {
 	result := user["content"].([]any)[0].(map[string]any)
 	assert.Equal(t, "functions_Grep_11", result["tool_use_id"], "tool_use_id must be sanitized in same-format path")
 }
+
+// TestStripToolUseThoughtSignature_AnthropicToAnthropic checks that a Gemini
+// thought_signature carried on a tool_use block in Anthropic-format history is
+// stripped before forwarding to Anthropic, which rejects the unknown field with
+// a 400 ("tool_use.thought_signature: Extra inputs are not permitted"). The
+// rest of the block — including the id that smuggles the signature for a later
+// switch back to Gemini — must survive untouched.
+func TestStripToolUseThoughtSignature_AnthropicToAnthropic(t *testing.T) {
+	body := []byte(`{
+		"model": "claude-opus-4-8",
+		"messages": [
+			{"role": "assistant", "content": [
+				{"type": "tool_use", "id": "toolu_01__thought__c2ln", "name": "Read", "input": {"path": "x"}, "thought_signature": "c2lnbWE"}
+			]},
+			{"role": "user", "content": [
+				{"type": "tool_result", "tool_use_id": "toolu_01__thought__c2ln", "content": "ok"}
+			]}
+		]
+	}`)
+	env, err := translate.ParseAnthropic(body)
+	require.NoError(t, err)
+	prep, err := env.PrepareAnthropic(http.Header{}, translate.EmitOptions{TargetModel: "claude-opus-4-8"})
+	require.NoError(t, err)
+
+	var out map[string]any
+	require.NoError(t, json.Unmarshal(prep.Body, &out))
+	msgs := out["messages"].([]any)
+
+	block := msgs[0].(map[string]any)["content"].([]any)[0].(map[string]any)
+	_, hasSig := block["thought_signature"]
+	assert.False(t, hasSig, "thought_signature must be stripped from tool_use before forwarding to Anthropic")
+	assert.Equal(t, "toolu_01__thought__c2ln", block["id"], "tool_use.id (signature round-trip channel) must be preserved")
+	assert.Equal(t, "Read", block["name"], "tool_use.name must be preserved")
+	assert.Equal(t, map[string]any{"path": "x"}, block["input"], "tool_use.input must be preserved")
+}

--- a/internal/translate/envelope.go
+++ b/internal/translate/envelope.go
@@ -363,6 +363,17 @@ type EmitOverrides struct {
 	// non-Anthropic upstreams (e.g. Kimi-k2.6) emit IDs like "functions.Read:0"
 	// that Anthropic rejects when the history is forwarded back to it.
 	SanitizeToolUseIDs bool
+	// StripToolUseThoughtSignature removes the `thought_signature` field from
+	// tool_use blocks in messages[*].content[*]. Set when targeting Anthropic:
+	// Gemini 3.x emits a thoughtSignature that the response translator surfaces
+	// as a `thought_signature` field on the tool_use block so it round-trips via
+	// the client. When the session is re-routed to an Anthropic model, that field
+	// is forwarded verbatim and Anthropic rejects it with a non-retryable 400
+	// ("tool_use.thought_signature: Extra inputs are not permitted"), killing the
+	// session. The opaque signature still round-trips through the tool_use.id
+	// channel (embedSignatureInID), so stripping the field here is lossless for a
+	// later switch back to Gemini.
+	StripToolUseThoughtSignature bool
 	// RewriteThinkingAdaptive replaces the inbound thinking block with
 	// {"type":"adaptive"} and sets output_config.effort. Used when the target
 	// model only accepts adaptive thinking (claude-opus-4-6+ / sonnet-4-6+).
@@ -390,6 +401,13 @@ func applyOverrides(body []byte, ov EmitOverrides) ([]byte, error) {
 		out, err = stripThinkingBlocksBytes(out)
 		if err != nil {
 			return nil, fmt.Errorf("strip thinking blocks: %w", err)
+		}
+	}
+
+	if ov.StripToolUseThoughtSignature {
+		out, err = stripToolUseThoughtSignatureBytes(out)
+		if err != nil {
+			return nil, fmt.Errorf("strip tool_use thought_signature: %w", err)
 		}
 	}
 
@@ -647,6 +665,80 @@ func sanitizeToolUseIDsBytes(body []byte) ([]byte, error) {
 	return sjson.SetRawBytes(body, "messages", []byte("["+strings.Join(msgRaws, ",")+"]"))
 }
 
+// stripToolUseThoughtSignatureBytes removes the `thought_signature` field from
+// tool_use blocks in messages[*].content[*]. Gemini 3.x emits a thoughtSignature
+// that the response translator surfaces as this field so it round-trips via the
+// client; Anthropic rejects the unknown field with a 400 when the history is
+// forwarded back to it. The signature is also smuggled in tool_use.id, so the
+// round-trip survives a later switch back to Gemini.
+func stripToolUseThoughtSignatureBytes(body []byte) ([]byte, error) {
+	messages := gjson.GetBytes(body, "messages")
+	if !messages.Exists() || !messages.IsArray() {
+		return body, nil
+	}
+
+	anyChanged := false
+	var msgRaws []string
+	var walkErr error
+
+	messages.ForEach(func(_, msg gjson.Result) bool {
+		content := msg.Get("content")
+		if !content.Exists() || !content.IsArray() {
+			msgRaws = append(msgRaws, msg.Raw)
+			return true
+		}
+
+		needsStrip := false
+		content.ForEach(func(_, block gjson.Result) bool {
+			if block.Get("type").String() == "tool_use" && block.Get("thought_signature").Exists() {
+				needsStrip = true
+				return false
+			}
+			return true
+		})
+
+		if !needsStrip {
+			msgRaws = append(msgRaws, msg.Raw)
+			return true
+		}
+
+		anyChanged = true
+		var rewritten []string
+		content.ForEach(func(_, block gjson.Result) bool {
+			raw := block.Raw
+			if block.Get("type").String() == "tool_use" && block.Get("thought_signature").Exists() {
+				var err error
+				raw, err = sjson.Delete(raw, "thought_signature")
+				if err != nil {
+					walkErr = fmt.Errorf("delete tool_use thought_signature: %w", err)
+					return false
+				}
+			}
+			rewritten = append(rewritten, raw)
+			return true
+		})
+		if walkErr != nil {
+			return false
+		}
+
+		newMsg, err := sjson.SetRaw(msg.Raw, "content", "["+strings.Join(rewritten, ",")+"]")
+		if err != nil {
+			walkErr = fmt.Errorf("replace content in message: %w", err)
+			return false
+		}
+		msgRaws = append(msgRaws, newMsg)
+		return true
+	})
+
+	if walkErr != nil {
+		return nil, walkErr
+	}
+	if !anyChanged {
+		return body, nil
+	}
+	return sjson.SetRawBytes(body, "messages", []byte("["+strings.Join(msgRaws, ",")+"]"))
+}
+
 // encodeJSONStringNoHTMLEscape marshals s without HTML-escaping <, >, or &.
 // Preserves the client's original escaping for upstream prompt-cache keys.
 func encodeJSONStringNoHTMLEscape(s string) ([]byte, error) {
@@ -853,8 +945,9 @@ func effortForBudget(budgetTokens int64) string {
 
 func resolveAnthropicOverrides(body []byte, opts EmitOptions) EmitOverrides {
 	ov := EmitOverrides{
-		Model:              opts.TargetModel,
-		SanitizeToolUseIDs: true,
+		Model:                        opts.TargetModel,
+		SanitizeToolUseIDs:           true,
+		StripToolUseThoughtSignature: true,
 	}
 
 	thinkingResult := gjson.GetBytes(body, "thinking")


### PR DESCRIPTION
## Problem

In prod (router pin `ac603eb` / v0.67), Claude Code sessions hit a non-retryable Anthropic 400 mid-stream:

```
Upstream Anthropic returned error status  status=400  routed_model=claude-opus-4-8 / claude-haiku-4-5
"messages.N.content.0.tool_use.thought_signature: Extra inputs are not permitted"
→ Proxy failed mid-stream: upstream returned status 400 (buffered)
```

It reads as "a Gemini error" but lands on Anthropic. Root cause is cross-provider history contamination:

1. A session does some turns on **gemini-3.1-flash-lite-preview**. Gemini 3.x emits a `thoughtSignature`, which the response translator surfaces as a `thought_signature` field on the tool_use block (so it round-trips via the client — load-bearing per `internal/translate/CLAUDE.md`).
2. The client echoes those tool_use blocks back in the next request's history.
3. The session's next turn routes to an **Anthropic** model. The same-format passthrough forwards the history verbatim, including the `thought_signature` field, and Anthropic rejects the unknown field with a 400 that kills the turn.

**Why now:** v0.67 floors several low/mid clusters onto gemini-flash-lite (>2k routes/24h in prod, more than opus + haiku combined), so far more sessions accumulate Gemini signatures and then trip this on their next opus/haiku turn.

The sibling symptom is the OpenAI `call_id` overflow (`string too long … max 64, got 1363`) from the same signature smuggled in the id — handled separately by `clampOpenAIToolCallID`; not in scope here.

## Fix

Add a `StripToolUseThoughtSignature` emit override that deletes the `thought_signature` field from `tool_use` blocks in `messages[*].content[*]`, set in `resolveAnthropicOverrides` alongside `SanitizeToolUseIDs`. Implementation mirrors `sanitizeToolUseIDsBytes` (two-phase, O(B), no-op when absent).

Scoped to the **Anthropic-bound outbound copy only** — the client's stored history and the Gemini emit path are untouched, and the opaque signature still round-trips through the `tool_use.id` channel (`embedSignatureInID`). So a later switch back to Gemini is unaffected and the load-bearing Gemini round-trip invariant holds.

## Test

`TestStripToolUseThoughtSignature_AnthropicToAnthropic` asserts the field is stripped while `id` (the signature round-trip channel), `name`, and `input` survive. Full `internal/translate/...` suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)