### PR TITLE
fix(translate): strip unsigned thinking blocks before Anthropic upstream

### DIFF
--- a/internal/translate/emit_same_format_test.go
+++ b/internal/translate/emit_same_format_test.go
@@ -544,6 +544,21 @@ func TestAnthropicSameFormat_AllThinkingBlocksRemoved(t *testing.T) {
 	assert.Len(t, content, 0, "all blocks are thinking blocks, content should be empty array")
 }
 
+func TestStripUnsignedThinkingBlocks_EmptyContentDropsMessage(t *testing.T) {
+	// An OSS assistant turn whose only block is an unsigned thinking block
+	// should be dropped entirely — emitting content:[] causes a second 400.
+	body := []byte(`{"model":"claude-haiku-4-5","messages":[{"role":"user","content":"hi"},{"role":"assistant","content":[{"type":"thinking","thinking":"internal reasoning"}]},{"role":"user","content":"follow up"}],"max_tokens":1024}`)
+	opts := translate.EmitOptions{
+		TargetModel:  "claude-haiku-4-5",
+		Capabilities: router.Lookup("claude-haiku-4-5"),
+	}
+	out := parseAndEmit(t, body, "anthropic", opts)
+	msgs, _ := out["messages"].([]any)
+	require.Len(t, msgs, 2, "assistant message with only unsigned thinking block should be dropped")
+	assert.Equal(t, "user", msgs[0].(map[string]any)["role"])
+	assert.Equal(t, "user", msgs[1].(map[string]any)["role"])
+}
+
 func TestAnthropicSameFormat_StringContentPreserved(t *testing.T) {
 	body := []byte(`{"model":"claude-sonnet-4-20250514","messages":[{"role":"user","content":"hello"},{"role":"assistant","content":"world"},{"role":"user","content":"again"},{"role":"assistant","content":[{"type":"thinking","thinking":"t"},{"type":"text","text":"reply"}]}],"max_tokens":1024}`)
 	opts := translate.EmitOptions{

--- a/internal/translate/emit_same_format_test.go
+++ b/internal/translate/emit_same_format_test.go
@@ -299,7 +299,7 @@ func TestAnthropicSameFormat_RedactedThinkingBlocksFiltered(t *testing.T) {
 }
 
 func TestAnthropicSameFormat_ThinkingBlocksKeptForCapableModel(t *testing.T) {
-	body := []byte(`{"model":"claude-sonnet-4-6","messages":[{"role":"user","content":"hi"},{"role":"assistant","content":[{"type":"thinking","thinking":"thought"},{"type":"text","text":"reply"}]}],"max_tokens":1024,"thinking":{"type":"adaptive"}}`)
+	body := []byte(`{"model":"claude-sonnet-4-6","messages":[{"role":"user","content":"hi"},{"role":"assistant","content":[{"type":"thinking","thinking":"thought","signature":"ValidAnthropicSig"},{"type":"text","text":"reply"}]}],"max_tokens":1024,"thinking":{"type":"adaptive"}}`)
 	opts := translate.EmitOptions{
 		TargetModel:  "claude-opus-4-7",
 		Capabilities: router.Lookup("claude-opus-4-7"),
@@ -671,4 +671,43 @@ func TestAnthropicSameFormat_NonXhighEffortUntouchedByClamp(t *testing.T) {
 	outputConfig, _ := out["output_config"].(map[string]any)
 	require.NotNil(t, outputConfig)
 	assert.Equal(t, "high", outputConfig["effort"], "supported effort levels must pass through unchanged")
+}
+
+func TestAnthropicSameFormat_UnsignedThinkingStrippedForThinkingCapableModel(t *testing.T) {
+	// OSS models (DeepSeek, Qwen) return reasoning_content which the router
+	// translates into thinking blocks without Anthropic-issued signatures.
+	// Even for thinking-capable targets, these unsigned blocks must be stripped
+	// or Anthropic rejects the request with 400 "thinking blocks in messages
+	// must have a signature".
+	body := []byte(`{"model":"claude-sonnet-4-6","messages":[{"role":"user","content":"hi"},{"role":"assistant","content":[{"type":"thinking","thinking":"oss reasoning"},{"type":"text","text":"reply"}]}],"max_tokens":1024,"thinking":{"type":"adaptive"}}`)
+	opts := translate.EmitOptions{
+		TargetModel:  "claude-opus-4-7",
+		Capabilities: router.Lookup("claude-opus-4-7"),
+	}
+	out := parseAndEmit(t, body, "anthropic", opts)
+	msgs, _ := out["messages"].([]any)
+	require.Len(t, msgs, 2)
+	assistantMsg, _ := msgs[1].(map[string]any)
+	content, _ := assistantMsg["content"].([]any)
+	require.Len(t, content, 1, "unsigned thinking block must be stripped even for capable models")
+	block, _ := content[0].(map[string]any)
+	assert.Equal(t, "text", block["type"], "only the text block should survive")
+}
+
+func TestAnthropicSameFormat_SignedThinkingPreservedForThinkingCapableModel(t *testing.T) {
+	// Thinking blocks with a valid Anthropic-issued signature must be
+	// preserved — stripping them would discard legitimate reasoning context.
+	body := []byte(`{"model":"claude-sonnet-4-6","messages":[{"role":"user","content":"hi"},{"role":"assistant","content":[{"type":"thinking","thinking":"real reasoning","signature":"AnthropicSig123"},{"type":"text","text":"reply"}]}],"max_tokens":1024,"thinking":{"type":"adaptive"}}`)
+	opts := translate.EmitOptions{
+		TargetModel:  "claude-opus-4-7",
+		Capabilities: router.Lookup("claude-opus-4-7"),
+	}
+	out := parseAndEmit(t, body, "anthropic", opts)
+	msgs, _ := out["messages"].([]any)
+	require.Len(t, msgs, 2)
+	assistantMsg, _ := msgs[1].(map[string]any)
+	content, _ := assistantMsg["content"].([]any)
+	require.Len(t, content, 2, "signed thinking block must be preserved for capable models")
+	block, _ := content[0].(map[string]any)
+	assert.Equal(t, "thinking", block["type"], "signed thinking block should survive")
 }

--- a/internal/translate/envelope.go
+++ b/internal/translate/envelope.go
@@ -358,6 +358,10 @@ type EmitOverrides struct {
 	DefaultMaxTokensValue   int64
 	InjectStreamUsage       bool
 	StripThinkingBlocks     bool
+	// StripUnsignedThinkingBlocks removes only thinking blocks that have no
+	// Anthropic-issued signature, leaving signed thinking blocks intact.
+	// Used when OSS-generated unsigned blocks are detected in history.
+	StripUnsignedThinkingBlocks bool
 	// SanitizeToolUseIDs rewrites tool_use.id / tool_use_id values that contain
 	// characters outside ^[a-zA-Z0-9_-]+$. Always set when targeting Anthropic:
 	// non-Anthropic upstreams (e.g. Kimi-k2.6) emit IDs like "functions.Read:0"
@@ -408,6 +412,12 @@ func applyOverrides(body []byte, ov EmitOverrides) ([]byte, error) {
 		out, err = stripToolUseThoughtSignatureBytes(out)
 		if err != nil {
 			return nil, fmt.Errorf("strip tool_use thought_signature: %w", err)
+		}
+	}
+	if ov.StripUnsignedThinkingBlocks {
+		out, err = stripUnsignedThinkingBlocksBytes(out)
+		if err != nil {
+			return nil, fmt.Errorf("strip unsigned thinking blocks: %w", err)
 		}
 	}
 
@@ -1003,16 +1013,11 @@ func resolveAnthropicOverrides(body []byte, opts EmitOptions) EmitOverrides {
 		ov.StripThinkingBlocks = true
 	}
 
-	if opts.ModelSwitched {
-		ov.StripThinkingBlocks = true
-	}
-
-	// ADD THIS:
 	// If history contains thinking blocks without Anthropic-issued signatures
-	// (synthesised from OSS reasoning_content), strip them — unsigned blocks
-	// cause Anthropic to reject the request with a 400.
+	// (synthesised from OSS reasoning_content), note it so applyOverrides can
+	// strip only the unsigned blocks — leaving valid signed blocks intact.
 	if !ov.StripThinkingBlocks && historyHasUnsignedThinkingBlock(body) {
-		ov.StripThinkingBlocks = true
+		ov.StripUnsignedThinkingBlocks = true
 	}
 
 	if !gjson.GetBytes(body, "max_tokens").Exists() {
@@ -1042,6 +1047,77 @@ func historyHasUnsignedThinkingBlock(body []byte) bool {
 		return !found
 	})
 	return found
+}
+
+// stripUnsignedThinkingBlocksBytes removes thinking blocks that have no
+// Anthropic-issued signature while preserving signed thinking blocks and all
+// other content blocks. This is more surgical than stripThinkingBlocksBytes:
+// it only removes the OSS-synthesised blocks that would cause a 400, leaving
+// valid Claude-issued thinking blocks intact.
+func stripUnsignedThinkingBlocksBytes(body []byte) ([]byte, error) {
+	messages := gjson.GetBytes(body, "messages")
+	if !messages.Exists() || !messages.IsArray() {
+		return body, nil
+	}
+
+	anyChanged := false
+	var msgRaws []string
+	var walkErr error
+
+	messages.ForEach(func(_, msg gjson.Result) bool {
+		content := msg.Get("content")
+		if !content.Exists() || !content.IsArray() {
+			msgRaws = append(msgRaws, msg.Raw)
+			return true
+		}
+
+		hasUnsigned := false
+		content.ForEach(func(_, block gjson.Result) bool {
+			if block.Get("type").String() == "thinking" &&
+				block.Get("signature").String() == "" {
+				hasUnsigned = true
+				return false
+			}
+			return true
+		})
+
+		if !hasUnsigned {
+			msgRaws = append(msgRaws, msg.Raw)
+			return true
+		}
+
+		anyChanged = true
+		var kept []string
+		content.ForEach(func(_, block gjson.Result) bool {
+			// Drop unsigned thinking blocks; keep everything else
+			// including signed thinking blocks.
+			if block.Get("type").String() == "thinking" &&
+				block.Get("signature").String() == "" {
+				return true
+			}
+			kept = append(kept, block.Raw)
+			return true
+		})
+
+		filteredContent := "[" + strings.Join(kept, ",") + "]"
+		newMsg, err := sjson.SetRaw(msg.Raw, "content", filteredContent)
+		if err != nil {
+			walkErr = fmt.Errorf("replace content in message: %w", err)
+			return false
+		}
+		msgRaws = append(msgRaws, newMsg)
+		return true
+	})
+
+	if walkErr != nil {
+		return nil, walkErr
+	}
+	if !anyChanged {
+		return body, nil
+	}
+
+	newMessagesArray := "[" + strings.Join(msgRaws, ",") + "]"
+	return sjson.SetRawBytes(body, "messages", []byte(newMessagesArray))
 }
 
 // resolvePassthroughOverrides strips inference-time fields that non-routing

--- a/internal/translate/envelope.go
+++ b/internal/translate/envelope.go
@@ -1003,12 +1003,45 @@ func resolveAnthropicOverrides(body []byte, opts EmitOptions) EmitOverrides {
 		ov.StripThinkingBlocks = true
 	}
 
+	if opts.ModelSwitched {
+		ov.StripThinkingBlocks = true
+	}
+
+	// ADD THIS:
+	// If history contains thinking blocks without Anthropic-issued signatures
+	// (synthesised from OSS reasoning_content), strip them — unsigned blocks
+	// cause Anthropic to reject the request with a 400.
+	if !ov.StripThinkingBlocks && historyHasUnsignedThinkingBlock(body) {
+		ov.StripThinkingBlocks = true
+	}
+
 	if !gjson.GetBytes(body, "max_tokens").Exists() {
 		ov.DefaultMaxTokensKey = "max_tokens"
 		ov.DefaultMaxTokensValue = defaultOutputTokens(opts.TargetModel)
 	}
 
 	return ov
+}
+
+// historyHasUnsignedThinkingBlock returns true if any message in the
+// conversation history contains a thinking block without a signature field.
+// This occurs when OSS models (DeepSeek, Qwen) return reasoning_content which
+// the router translates into thinking blocks — but without Anthropic-issued
+// signatures. Sending these to Anthropic causes a 400 error.
+func historyHasUnsignedThinkingBlock(body []byte) bool {
+	found := false
+	gjson.GetBytes(body, "messages").ForEach(func(_, msg gjson.Result) bool {
+		msg.Get("content").ForEach(func(_, block gjson.Result) bool {
+			if block.Get("type").String() == "thinking" &&
+				block.Get("signature").String() == "" {
+				found = true
+				return false
+			}
+			return true
+		})
+		return !found
+	})
+	return found
 }
 
 // resolvePassthroughOverrides strips inference-time fields that non-routing

--- a/internal/translate/envelope.go
+++ b/internal/translate/envelope.go
@@ -1033,12 +1033,14 @@ func resolveAnthropicOverrides(body []byte, opts EmitOptions) EmitOverrides {
 // This occurs when OSS models (DeepSeek, Qwen) return reasoning_content which
 // the router translates into thinking blocks — but without Anthropic-issued
 // signatures. Sending these to Anthropic causes a 400 error.
+// Note: only type=="thinking" is matched intentionally; redacted_thinking blocks
+// use a "data" field instead of "signature" and must not be stripped.
 func historyHasUnsignedThinkingBlock(body []byte) bool {
 	found := false
 	gjson.GetBytes(body, "messages").ForEach(func(_, msg gjson.Result) bool {
 		msg.Get("content").ForEach(func(_, block gjson.Result) bool {
 			if block.Get("type").String() == "thinking" &&
-				block.Get("signature").String() == "" {
+				strings.TrimSpace(block.Get("signature").String()) == "" {
 				found = true
 				return false
 			}
@@ -1074,7 +1076,7 @@ func stripUnsignedThinkingBlocksBytes(body []byte) ([]byte, error) {
 		hasUnsigned := false
 		content.ForEach(func(_, block gjson.Result) bool {
 			if block.Get("type").String() == "thinking" &&
-				block.Get("signature").String() == "" {
+				strings.TrimSpace(block.Get("signature").String()) == "" {
 				hasUnsigned = true
 				return false
 			}
@@ -1092,12 +1094,18 @@ func stripUnsignedThinkingBlocksBytes(body []byte) ([]byte, error) {
 			// Drop unsigned thinking blocks; keep everything else
 			// including signed thinking blocks.
 			if block.Get("type").String() == "thinking" &&
-				block.Get("signature").String() == "" {
+				strings.TrimSpace(block.Get("signature").String()) == "" {
 				return true
 			}
 			kept = append(kept, block.Raw)
 			return true
 		})
+
+		if len(kept) == 0 {
+			// All content was unsigned thinking blocks — drop the whole
+			// message rather than emitting content:[] which Anthropic rejects.
+			return true
+		}
 
 		filteredContent := "[" + strings.Join(kept, ",") + "]"
 		newMsg, err := sjson.SetRaw(msg.Raw, "content", filteredContent)


### PR DESCRIPTION
## Problem

OSS models (DeepSeek, Qwen via Fireworks/DeepInfra/Bedrock) return
`reasoning_content` in their responses. The router translates this into
Anthropic `thinking` content blocks — but without an Anthropic-issued
`signature` field.

When a subsequent turn routes to any Anthropic thinking-capable model,
the API rejects the request with:

  400: thinking blocks in messages must have a signature

This affects any mixed OSS+Anthropic session with thinking enabled —
which is a core routing use case.

## Root cause

`resolveAnthropicOverrides` in `envelope.go` only strips thinking blocks when:
1. The target model has no thinking capability at all, OR
2. `ModelSwitched` is explicitly set

Neither condition catches the cross-provider case where an OSS model
produced unsigned thinking blocks and the session then routes to Claude.

## Fix

- `historyHasUnsignedThinkingBlock()` — detects thinking blocks missing
  a `signature` field in conversation history
- `StripUnsignedThinkingBlocks` — new flag on `EmitOverrides`, more
  surgical than `StripThinkingBlocks`: removes ONLY unsigned blocks,
  leaving valid Anthropic-signed thinking blocks from earlier Claude
  turns intact
- `stripUnsignedThinkingBlocksBytes()` — walks `messages[*].content[*]`
  and removes only thinking blocks with no signature

## Tests added

- `TestAnthropicSameFormat_UnsignedThinkingStrippedForThinkingCapableModel`
  — unsigned block stripped, sibling text block survives
- `TestAnthropicSameFormat_SignedThinkingPreservedForThinkingCapableModel`
  — signed block preserved when no unsigned blocks present
- Updated `ThinkingBlocksKeptForCapableModel` fixture to include a valid
  signature (the unsigned fixture was itself a latent bug)