### PR TITLE
fix(proxy): show forced-model badge and guard tier bypass regressions

### DIFF
--- a/internal/proxy/marker_internal_test.go
+++ b/internal/proxy/marker_internal_test.go
@@ -7,6 +7,7 @@ import (
 
 	"workweave/router/internal/router"
 	"workweave/router/internal/router/planner"
+	"workweave/router/internal/translate"
 )
 
 func TestRoutingMarkerFor_PlannerPaths(t *testing.T) {
@@ -137,6 +138,19 @@ func TestRoutingMarkerFor_PlannerPaths(t *testing.T) {
 			wantNotContain: []string{
 				"hard pin",
 				"reason:",
+			},
+		},
+		{
+			name: "user-forced pin: mark the explicit directive",
+			res: turnLoopResult{
+				Decision: router.Decision{Model: "claude-opus-4-8", Provider: "anthropic"},
+				PinTier:  translate.ReasonUserForceModel,
+			},
+			wantContains: []string{
+				"· " + markerReasonForced,
+			},
+			wantNotContain: []string{
+				markerReasonBestPick,
 			},
 		},
 		{

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -236,6 +236,7 @@ func routingMarkerFor(res turnLoopResult) string {
 // than re-spelling the literals.
 const (
 	markerReasonHardPinned  = "pinned for compaction / sub-agent"
+	markerReasonForced      = "forced — /unforce-model to clear"
 	markerReasonSwitched    = "switched for positive EV after cache eviction"
 	markerReasonStayed      = "stayed on your last pick"
 	markerReasonTierUpgrade = "upgraded to a stronger tier"
@@ -247,6 +248,9 @@ const (
 func routingReasonShort(res turnLoopResult) string {
 	if res.HardPinned {
 		return markerReasonHardPinned
+	}
+	if res.PinTier == translate.ReasonUserForceModel {
+		return markerReasonForced
 	}
 	if res.PlannerDecision.Reason != "" {
 		return humanReasonFromPlanner(res.PlannerDecision.Reason)

--- a/internal/proxy/service_session_pin_test.go
+++ b/internal/proxy/service_session_pin_test.go
@@ -847,6 +847,56 @@ func TestService_ForcedPin_ReasonStaysUserForced(t *testing.T) {
 	assert.Equal(t, translate.ReasonUserForceModel, rec.Header().Get(proxy.HeaderRouterDecision), "forced pin keeps the plain user_forced reason")
 }
 
+// TestService_ForcedPin_BypassesTierCeiling verifies /force-model pins are served
+// unchanged even when the client sends a lower-tier model id (e.g. haiku on a
+// mid-tier session). This is the regression that produced the "would have used
+// claude-opus" badge while silently serving gemini flash-lite.
+func TestService_ForcedPin_BypassesTierCeiling(t *testing.T) {
+	store := newFakePinStore()
+	store.hasPin = true
+	store.pin = sessionpin.Pin{
+		Provider:    providers.ProviderAnthropic,
+		Model:       "claude-opus-4-7",
+		Reason:      translate.ReasonUserForceModel,
+		PinnedUntil: time.Now().Add(30 * time.Minute),
+	}
+	fr := &fakeRouter{decision: router.Decision{Provider: providers.ProviderAnthropic, Model: "claude-haiku-4-5", Reason: "cluster:v0.37"}}
+	svc := newPinSvc(fr, store)
+
+	ctx := authedCtx(uuid.New().String())
+	rec := httptest.NewRecorder()
+	httpReq := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(""))
+	require.NoError(t, svc.ProxyMessages(ctx, []byte(haikuClampBody), rec, httpReq))
+
+	assert.Equal(t, 0, fr.routeCalls, "forced pin must bypass the scorer")
+	assert.Equal(t, "claude-opus-4-7", rec.Header().Get(proxy.HeaderRouterModel), "forced pin must win over the requested tier")
+	assert.Equal(t, translate.ReasonUserForceModel, rec.Header().Get(proxy.HeaderRouterDecision))
+}
+
+// TestService_LoopEscalationPin_BypassesTierCeiling verifies loop_escalation pins
+// are served unchanged on lower-tier requests, same as /force-model pins.
+func TestService_LoopEscalationPin_BypassesTierCeiling(t *testing.T) {
+	store := newFakePinStore()
+	store.hasPin = true
+	store.pin = sessionpin.Pin{
+		Provider:    providers.ProviderAnthropic,
+		Model:       "claude-opus-4-8",
+		Reason:      translate.ReasonLoopEscalation,
+		PinnedUntil: time.Now().Add(30 * time.Minute),
+	}
+	fr := &fakeRouter{decision: router.Decision{Provider: providers.ProviderAnthropic, Model: "claude-haiku-4-5", Reason: "cluster:v0.65"}}
+	svc := newPinSvc(fr, store)
+
+	ctx := authedCtx(uuid.New().String())
+	rec := httptest.NewRecorder()
+	httpReq := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(""))
+	require.NoError(t, svc.ProxyMessages(ctx, []byte(haikuClampBody), rec, httpReq))
+
+	assert.Equal(t, 0, fr.routeCalls, "escalation pin must bypass the scorer")
+	assert.Equal(t, "claude-opus-4-8", rec.Header().Get(proxy.HeaderRouterModel))
+	assert.Equal(t, translate.ReasonLoopEscalation, rec.Header().Get(proxy.HeaderRouterDecision))
+}
+
 // TestService_LoopEscalationPin_HonoredAsImmutableSticky verifies a
 // loop_escalation pin is treated like a /force-model pin: the scorer's (cheap)
 // decision is bypassed and the session stays on the escalated opus model.

--- a/internal/proxy/turnloop.go
+++ b/internal/proxy/turnloop.go
@@ -256,8 +256,10 @@ func (s *Service) runTurnLoop(
 	//      forced gpt-5 but the current request only carries Anthropic BYOK creds).
 	//      Falling through to normal routing avoids a guaranteed 401/unauthenticated
 	//      upstream call.
-	//   3. The user's forced model is served as-is and the pin is refreshed with
-	//      the original decision, so the directive survives across turns.
+	//   3. User-forced and loop-escalation pins bypass the requested-model tier
+	//      ceiling (same as operator hard-pins): the forced model is served as-is
+	//      and the pin is refreshed with the original decision so the directive
+	//      survives across turns.
 	// forcedTierFloor preserves the user's tier intent when a user-forced pin
 	// is dropped below because its model can no longer serve this turn (most
 	// often the session outgrew the model's context window and the pre-filter


### PR DESCRIPTION
## Summary

- `/force-model` pins already bypass the requested-model tier ceiling on `main` (#384); this PR completes the remaining polish from the force-model bug investigation.
- Adds routing-marker wording (`forced — /unforce-model to clear`) so transition turns no longer misreport as "best pick for this turn".
- Adds regression tests ensuring user-forced and loop-escalation pins serve the pinned model on haiku-tier requests without invoking the scorer.

## Root cause (for context)

`/fm opus` was writing the pin correctly, but `clampToCeiling` silently downgraded High-tier forced models to the cheapest in-ceiling alternative (e.g. `gemini-3.1-flash-lite-preview`) when the client sent a mid/low-tier model id. #384 removed that clamp path; this PR guards against regressions and fixes the badge copy.

## Test plan

- [x] `go test ./internal/proxy/... -run 'TestService_ForcedPin|TestService_LoopEscalationPin|TestRoutingMarkerFor'`
- [ ] End-to-end: drive `claude -p` with `/fm opus` on a mid-tier session and confirm served model stays opus across turns


Made with [Cursor](https://cursor.com)