### PR TITLE
fix(translate): drop Gemini-unsupported tool-schema format values

### DIFF
--- a/internal/translate/emit_gemini.go
+++ b/internal/translate/emit_gemini.go
@@ -1309,6 +1309,21 @@ var geminiSchemaAllowedKeys = map[string]struct{}{
 	"propertyOrdering": {},
 }
 
+// geminiSupportedFormats is the set of JSON Schema "format" values Gemini's
+// function-calling API accepts: STRING allows enum + date-time, numeric types
+// allow float/double/int32/int64. Any other value (uri, email, uuid, hostname,
+// …) makes Google reject the whole request with a generic INVALID_ARGUMENT, so
+// sanitizeSchemaFiltered drops formats outside this set rather than forwarding
+// the key with its value intact.
+var geminiSupportedFormats = map[string]struct{}{
+	"enum":      {},
+	"date-time": {},
+	"float":     {},
+	"double":    {},
+	"int32":     {},
+	"int64":     {},
+}
+
 // sanitizeSchemaForGemini returns a deep copy of v containing only the JSON
 // Schema fields that Gemini's function-calling API accepts. Uses an allow-list
 // derived from the googleapis/go-genai Schema struct. Always returns a copy so
@@ -1338,6 +1353,17 @@ func sanitizeSchemaFiltered(v any, filterKeys bool) any {
 					continue
 				}
 				out[k] = cleaned
+				continue
+			}
+			// Gemini only accepts a narrow set of "format" values; forwarding
+			// anything else (e.g. "uri", "email") makes Google reject the whole
+			// request with INVALID_ARGUMENT. Keep supported values, drop the rest.
+			if k == "format" && filterKeys {
+				if s, ok := child.(string); ok {
+					if _, supported := geminiSupportedFormats[s]; supported {
+						out[k] = s
+					}
+				}
 				continue
 			}
 			// User-defined property names inside "properties" must not be

--- a/internal/translate/gemini_test.go
+++ b/internal/translate/gemini_test.go
@@ -679,7 +679,7 @@ func TestSanitizeSchemaForGemini_PreservesSupportedFields(t *testing.T) {
 				"type":"object",
 				"description":"Edit a file",
 				"properties":{
-					"path":{"type":"string","format":"uri"},
+					"path":{"type":"string","format":"date-time"},
 					"mode":{"type":"string","enum":["replace","append"]},
 					"line":{"type":"integer","nullable":true}
 				},
@@ -698,10 +698,52 @@ func TestSanitizeSchemaForGemini_PreservesSupportedFields(t *testing.T) {
 	assert.Equal(t, "object", params["type"])
 	assert.Equal(t, "Edit a file", params["description"])
 	props := params["properties"].(map[string]any)
-	assert.Equal(t, "uri", props["path"].(map[string]any)["format"], "format must survive")
+	assert.Equal(t, "date-time", props["path"].(map[string]any)["format"], "supported format must survive")
 	assert.Equal(t, []any{"replace", "append"}, props["mode"].(map[string]any)["enum"], "enum must survive")
 	assert.Equal(t, true, props["line"].(map[string]any)["nullable"], "nullable must survive")
 	assert.Equal(t, []any{"path", "mode"}, params["required"], "required must survive")
+}
+
+func TestPrepareGemini_DropsUnsupportedFormatValues(t *testing.T) {
+	// Regression: Gemini's function-calling Schema accepts "format" only with a
+	// narrow value set (strings: enum, date-time; numbers: float/double/int32/
+	// int64). Tool schemas from MCP servers and SDKs routinely carry "uri",
+	// "email", "uuid" etc., which Google rejects with a generic 400
+	// INVALID_ARGUMENT — observed on every tools-bearing Gemini request from
+	// tool-heavy clients. The sanitizer must drop unsupported format values
+	// while keeping supported ones and the rest of the property schema intact.
+	body := []byte(`{
+		"messages": [{"role":"user","content":"hi"}],
+		"tools": [{
+			"name":"submit",
+			"input_schema":{
+				"type":"object",
+				"properties":{
+					"homepage":{"type":"string","format":"uri","description":"site"},
+					"contact":{"type":"string","format":"email"},
+					"when":{"type":"string","format":"date-time"},
+					"score":{"type":"number","format":"double"}
+				},
+				"required":["homepage"]
+			}
+		}]
+	}`)
+	env, err := translate.ParseAnthropic(body)
+	require.NoError(t, err)
+	prep, err := env.PrepareGemini(http.Header{}, translate.EmitOptions{})
+	require.NoError(t, err)
+
+	params := mustUnmarshal(t, prep.Body)["tools"].([]any)[0].(map[string]any)["functionDeclarations"].([]any)[0].(map[string]any)["parameters"].(map[string]any)
+	props := params["properties"].(map[string]any)
+
+	homepage := props["homepage"].(map[string]any)
+	assert.NotContains(t, homepage, "format", "unsupported format \"uri\" must be dropped")
+	assert.Equal(t, "string", homepage["type"], "the rest of the property schema must survive")
+	assert.Equal(t, "site", homepage["description"], "sibling keys must survive format drop")
+	assert.NotContains(t, props["contact"].(map[string]any), "format", "unsupported format \"email\" must be dropped")
+
+	assert.Equal(t, "date-time", props["when"].(map[string]any)["format"], "supported string format must survive")
+	assert.Equal(t, "double", props["score"].(map[string]any)["format"], "supported numeric format must survive")
 }
 
 func TestPrepareGemini_CollapsesItemsBool(t *testing.T) {


### PR DESCRIPTION
## Problem

Tool-heavy clients (Claude Code / Cursor with many MCP servers) hit a 400 `INVALID_ARGUMENT` on **every** tools-bearing Gemini turn. Observed live in prod against a 195-tool client — both `gemini-3.1-flash-lite-preview` (tier-clamped low turns) and `gemini-3.1-pro-preview` failed, with **no failover**, surfacing a hard error to the user.

Root cause: Gemini's function-calling `Schema.format` accepts only a narrow value set — strings: `enum`, `date-time`; numbers: `float`/`double`/`int32`/`int64`. Our `sanitizeSchemaForGemini` allow-list correctly drops unsupported *keys* (`$schema`, `additionalProperties`, `$ref`, `const`, …) but allow-listed the `format` **key** and forwarded its **value** untouched. Schemas carrying `format: "uri"` / `"email"` / `"uuid"` (ubiquitous in MCP/SDK-derived tools) reached Google and 400'd the whole request.

Confirmed from captured prod request bodies: the failing tool sets contained `format` values `date-time`, `email`, `uri` — only `date-time` is accepted.

## Fix

Filter `format` against the supported-value set inside `sanitizeSchemaFiltered` (single recursive workhorse → covers Anthropic, OpenAI, and same-format Gemini emit paths), dropping unsupported values while preserving supported ones and all sibling keys.

## Tests

- `TestSanitizeSchemaForGemini_PreservesSupportedFields` previously asserted `format: "uri"` **survives** — that codified the bug. Updated to a genuinely supported value (`date-time`).
- Added `TestPrepareGemini_DropsUnsupportedFormatValues`: `uri`/`email` dropped, `date-time`/`double` preserved, sibling keys intact.
- `go build ./...`, `go vet`, full `internal/translate/...` suite green.

## Notes

- Router-only change; needs a WorkWeave gitlink bump to deploy (not included here).
- A sibling gap exists — clamped-model 400s don't fail over (`failover_used: false`). Out of scope for this PR; tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)