### PR TITLE
feat(statusline): show [forced] tag when a model is pinned via /force-model

### DIFF
--- a/install/cc-statusline.sh
+++ b/install/cc-statusline.sh
@@ -285,8 +285,14 @@ if [[ -n "$transcript_path" && -f "$transcript_path" ]]; then
   # [forced] tag and prefer the pinned model id parsed from the marker: once a
   # pin is live the routed model id is indistinguishable from automatic
   # routing, so the marker is the only signal that the choice was forced.
+  #
+  # Match only the router's own synthetic ack turns (message.model ==
+  # "weave-router"), never normal assistant replies — otherwise a model
+  # response that merely quotes "force-model applied:" / "force-model cleared"
+  # (e.g. explaining the feature) could outrank the real latest ack and flip
+  # the tag on or off incorrectly.
   force_marker="$("${reverse[@]}" "$transcript_path" 2>/dev/null \
-    | jq -r 'select(.type=="assistant") | .message.content[]? | select(.type? == "text") | .text // empty' 2>/dev/null \
+    | jq -r 'select(.type=="assistant" and .message.model=="weave-router") | .message.content[]? | select(.type? == "text") | .text // empty' 2>/dev/null \
     | grep -m1 -E 'force-model (applied|cleared)' || true)"
   if [[ "$force_marker" == *"force-model applied:"* ]]; then
     forced="true"

--- a/install/cc-statusline.sh
+++ b/install/cc-statusline.sh
@@ -275,28 +275,34 @@ if [[ -n "$transcript_path" && -f "$transcript_path" ]]; then
     routed="$(normalize_model "$routed")"
   fi
 
-  # Detect an active /force-model pin. When the user runs /force-model the
-  # router writes a synthetic acknowledgment turn into the transcript
-  # ("✦ Weave Router → force-model applied: <model> (<provider>) …"), and
-  # /unforce-model writes a matching "force-model cleared" turn. Neither is
-  # stripped from the on-disk transcript — the ingress stripper only scrubs
-  # these markers from requests forwarded upstream — so the latest of the two
-  # tells us whether the session is currently pinned. We surface that as a
-  # [forced] tag and prefer the pinned model id parsed from the marker: once a
-  # pin is live the routed model id is indistinguishable from automatic
-  # routing, so the marker is the only signal that the choice was forced.
-  #
-  # Match only the router's own synthetic ack turns (message.model ==
-  # "weave-router"), never normal assistant replies — otherwise a model
-  # response that merely quotes "force-model applied:" / "force-model cleared"
-  # (e.g. explaining the feature) could outrank the real latest ack and flip
-  # the tag on or off incorrectly.
-  force_marker="$("${reverse[@]}" "$transcript_path" 2>/dev/null \
-    | jq -r 'select(.type=="assistant" and .message.model=="weave-router") | .message.content[]? | select(.type? == "text") | .text // empty' 2>/dev/null \
-    | grep -m1 -E 'force-model (applied|cleared)' || true)"
-  if [[ "$force_marker" == *"force-model applied:"* ]]; then
+  # Detect an active /force-model pin from the router's synthetic ack turns —
+  # the only turns stamped message.model == "weave-router". The router emits
+  # one whenever a pin changes state:
+  #   * /force-model              → "force-model applied: <model> (<provider>) …"
+  #   * /unforce-model            → "force-model cleared …"
+  #   * loop / no-progress break  → "… clearing the session pin …" (expires the
+  #                                  pin, including a user-forced one)
+  #   * unrecognized model        → "… isn't a recognized model · keeping
+  #                                  automatic routing" — a NO-OP: the prior
+  #                                  pin, if any, is left untouched
+  # These persist on disk (the ingress stripper only scrubs them from upstream
+  # requests). Classify each weave-router turn newest-first, skip the no-op
+  # "rejected" acks, and let the latest real state change decide: an "applied"
+  # marker means the session is pinned (and names the model); anything else
+  # (cleared / loop-break / no-progress) means automatic routing has resumed.
+  # Restricting to weave-router turns keeps a normal reply that merely quotes
+  # these phrases from flipping the tag. (A silent server-side TTL expiry emits
+  # no turn and so can't be reflected here — the pin TTL outlives a session.)
+  force_state="$("${reverse[@]}" "$transcript_path" 2>/dev/null \
+    | jq -r 'select(.type=="assistant" and .message.model=="weave-router")
+        | ([.message.content[]? | select(.type? == "text") | .text] | join(" ") | gsub("[\n\r]"; " ")) as $t
+        | if ($t | test("force-model applied:")) then "APPLIED " + ($t | capture("force-model applied: (?<m>[^ ]+)").m)
+          elif ($t | test("isn.t a recognized model")) then "REJECTED"
+          else "CLEARED" end' 2>/dev/null \
+    | grep -m1 -v '^REJECTED$' || true)"
+  if [[ "$force_state" == APPLIED\ * ]]; then
     forced="true"
-    forced_model="$(printf '%s' "$force_marker" | sed -E 's/.*force-model applied: ([^ ]+).*/\1/')"
+    forced_model="${force_state#APPLIED }"
   fi
 
   # Compute a session running total: savings across every assistant turn

--- a/install/cc-statusline.sh
+++ b/install/cc-statusline.sh
@@ -236,6 +236,8 @@ prices='{
 # END_GENERATED_PRICES
 
 routed=""
+forced="false"
+forced_model=""
 session_savings=""
 tot_in=0
 tot_out=0
@@ -271,6 +273,24 @@ if [[ -n "$transcript_path" && -f "$transcript_path" ]]; then
     routed="failure"
   else
     routed="$(normalize_model "$routed")"
+  fi
+
+  # Detect an active /force-model pin. When the user runs /force-model the
+  # router writes a synthetic acknowledgment turn into the transcript
+  # ("✦ Weave Router → force-model applied: <model> (<provider>) …"), and
+  # /unforce-model writes a matching "force-model cleared" turn. Neither is
+  # stripped from the on-disk transcript — the ingress stripper only scrubs
+  # these markers from requests forwarded upstream — so the latest of the two
+  # tells us whether the session is currently pinned. We surface that as a
+  # [forced] tag and prefer the pinned model id parsed from the marker: once a
+  # pin is live the routed model id is indistinguishable from automatic
+  # routing, so the marker is the only signal that the choice was forced.
+  force_marker="$("${reverse[@]}" "$transcript_path" 2>/dev/null \
+    | jq -r 'select(.type=="assistant") | .message.content[]? | select(.type? == "text") | .text // empty' 2>/dev/null \
+    | grep -m1 -E 'force-model (applied|cleared)' || true)"
+  if [[ "$force_marker" == *"force-model applied:"* ]]; then
+    forced="true"
+    forced_model="$(printf '%s' "$force_marker" | sed -E 's/.*force-model applied: ([^ ]+).*/\1/')"
   fi
 
   # Compute a session running total: savings across every assistant turn
@@ -375,7 +395,14 @@ if [[ "$tot_in" -gt 0 || "$tot_out" -gt 0 || "$tot_cache_read" -gt 0 || "$tot_ca
   fi
 fi
 
-if [[ "$routed" == "failure" ]]; then
+if [[ "$forced" == "true" ]]; then
+  # Session is pinned via /force-model. The "← selection · saved $X" clause
+  # describes automatic routing and would be misleading on a manual pin, so
+  # show the pinned model with a [forced] tag instead. forced_model comes from
+  # the marker; fall back to the routed/selected id if parsing came up empty.
+  forced_display="${forced_model:-${routed:-$selected_display}}"
+  printf '%s — %s [forced]%s' "$brand" "$forced_display" "$tokens_clause"
+elif [[ "$routed" == "failure" ]]; then
   # Latest turn was a CC-synthesized error stub — don't claim a routing
   # swap or compute savings against a non-model.
   printf '%s — %s%s' "$brand" "$routed" "$tokens_clause"

--- a/install/install.sh
+++ b/install/install.sh
@@ -2107,28 +2107,34 @@ if [[ -n "$transcript_path" && -f "$transcript_path" ]]; then
     routed="$(normalize_model "$routed")"
   fi
 
-  # Detect an active /force-model pin. When the user runs /force-model the
-  # router writes a synthetic acknowledgment turn into the transcript
-  # ("✦ Weave Router → force-model applied: <model> (<provider>) …"), and
-  # /unforce-model writes a matching "force-model cleared" turn. Neither is
-  # stripped from the on-disk transcript — the ingress stripper only scrubs
-  # these markers from requests forwarded upstream — so the latest of the two
-  # tells us whether the session is currently pinned. We surface that as a
-  # [forced] tag and prefer the pinned model id parsed from the marker: once a
-  # pin is live the routed model id is indistinguishable from automatic
-  # routing, so the marker is the only signal that the choice was forced.
-  #
-  # Match only the router's own synthetic ack turns (message.model ==
-  # "weave-router"), never normal assistant replies — otherwise a model
-  # response that merely quotes "force-model applied:" / "force-model cleared"
-  # (e.g. explaining the feature) could outrank the real latest ack and flip
-  # the tag on or off incorrectly.
-  force_marker="$("${reverse[@]}" "$transcript_path" 2>/dev/null \
-    | jq -r 'select(.type=="assistant" and .message.model=="weave-router") | .message.content[]? | select(.type? == "text") | .text // empty' 2>/dev/null \
-    | grep -m1 -E 'force-model (applied|cleared)' || true)"
-  if [[ "$force_marker" == *"force-model applied:"* ]]; then
+  # Detect an active /force-model pin from the router's synthetic ack turns —
+  # the only turns stamped message.model == "weave-router". The router emits
+  # one whenever a pin changes state:
+  #   * /force-model              → "force-model applied: <model> (<provider>) …"
+  #   * /unforce-model            → "force-model cleared …"
+  #   * loop / no-progress break  → "… clearing the session pin …" (expires the
+  #                                  pin, including a user-forced one)
+  #   * unrecognized model        → "… isn't a recognized model · keeping
+  #                                  automatic routing" — a NO-OP: the prior
+  #                                  pin, if any, is left untouched
+  # These persist on disk (the ingress stripper only scrubs them from upstream
+  # requests). Classify each weave-router turn newest-first, skip the no-op
+  # "rejected" acks, and let the latest real state change decide: an "applied"
+  # marker means the session is pinned (and names the model); anything else
+  # (cleared / loop-break / no-progress) means automatic routing has resumed.
+  # Restricting to weave-router turns keeps a normal reply that merely quotes
+  # these phrases from flipping the tag. (A silent server-side TTL expiry emits
+  # no turn and so can't be reflected here — the pin TTL outlives a session.)
+  force_state="$("${reverse[@]}" "$transcript_path" 2>/dev/null \
+    | jq -r 'select(.type=="assistant" and .message.model=="weave-router")
+        | ([.message.content[]? | select(.type? == "text") | .text] | join(" ") | gsub("[\n\r]"; " ")) as $t
+        | if ($t | test("force-model applied:")) then "APPLIED " + ($t | capture("force-model applied: (?<m>[^ ]+)").m)
+          elif ($t | test("isn.t a recognized model")) then "REJECTED"
+          else "CLEARED" end' 2>/dev/null \
+    | grep -m1 -v '^REJECTED$' || true)"
+  if [[ "$force_state" == APPLIED\ * ]]; then
     forced="true"
-    forced_model="$(printf '%s' "$force_marker" | sed -E 's/.*force-model applied: ([^ ]+).*/\1/')"
+    forced_model="${force_state#APPLIED }"
   fi
 
   # Compute a session running total: savings across every assistant turn

--- a/install/install.sh
+++ b/install/install.sh
@@ -2117,8 +2117,14 @@ if [[ -n "$transcript_path" && -f "$transcript_path" ]]; then
   # [forced] tag and prefer the pinned model id parsed from the marker: once a
   # pin is live the routed model id is indistinguishable from automatic
   # routing, so the marker is the only signal that the choice was forced.
+  #
+  # Match only the router's own synthetic ack turns (message.model ==
+  # "weave-router"), never normal assistant replies — otherwise a model
+  # response that merely quotes "force-model applied:" / "force-model cleared"
+  # (e.g. explaining the feature) could outrank the real latest ack and flip
+  # the tag on or off incorrectly.
   force_marker="$("${reverse[@]}" "$transcript_path" 2>/dev/null \
-    | jq -r 'select(.type=="assistant") | .message.content[]? | select(.type? == "text") | .text // empty' 2>/dev/null \
+    | jq -r 'select(.type=="assistant" and .message.model=="weave-router") | .message.content[]? | select(.type? == "text") | .text // empty' 2>/dev/null \
     | grep -m1 -E 'force-model (applied|cleared)' || true)"
   if [[ "$force_marker" == *"force-model applied:"* ]]; then
     forced="true"

--- a/install/install.sh
+++ b/install/install.sh
@@ -2068,6 +2068,8 @@ prices='{
 # END_GENERATED_PRICES
 
 routed=""
+forced="false"
+forced_model=""
 session_savings=""
 tot_in=0
 tot_out=0
@@ -2103,6 +2105,24 @@ if [[ -n "$transcript_path" && -f "$transcript_path" ]]; then
     routed="failure"
   else
     routed="$(normalize_model "$routed")"
+  fi
+
+  # Detect an active /force-model pin. When the user runs /force-model the
+  # router writes a synthetic acknowledgment turn into the transcript
+  # ("✦ Weave Router → force-model applied: <model> (<provider>) …"), and
+  # /unforce-model writes a matching "force-model cleared" turn. Neither is
+  # stripped from the on-disk transcript — the ingress stripper only scrubs
+  # these markers from requests forwarded upstream — so the latest of the two
+  # tells us whether the session is currently pinned. We surface that as a
+  # [forced] tag and prefer the pinned model id parsed from the marker: once a
+  # pin is live the routed model id is indistinguishable from automatic
+  # routing, so the marker is the only signal that the choice was forced.
+  force_marker="$("${reverse[@]}" "$transcript_path" 2>/dev/null \
+    | jq -r 'select(.type=="assistant") | .message.content[]? | select(.type? == "text") | .text // empty' 2>/dev/null \
+    | grep -m1 -E 'force-model (applied|cleared)' || true)"
+  if [[ "$force_marker" == *"force-model applied:"* ]]; then
+    forced="true"
+    forced_model="$(printf '%s' "$force_marker" | sed -E 's/.*force-model applied: ([^ ]+).*/\1/')"
   fi
 
   # Compute a session running total: savings across every assistant turn
@@ -2207,7 +2227,14 @@ if [[ "$tot_in" -gt 0 || "$tot_out" -gt 0 || "$tot_cache_read" -gt 0 || "$tot_ca
   fi
 fi
 
-if [[ "$routed" == "failure" ]]; then
+if [[ "$forced" == "true" ]]; then
+  # Session is pinned via /force-model. The "← selection · saved $X" clause
+  # describes automatic routing and would be misleading on a manual pin, so
+  # show the pinned model with a [forced] tag instead. forced_model comes from
+  # the marker; fall back to the routed/selected id if parsing came up empty.
+  forced_display="${forced_model:-${routed:-$selected_display}}"
+  printf '%s — %s [forced]%s' "$brand" "$forced_display" "$tokens_clause"
+elif [[ "$routed" == "failure" ]]; then
   # Latest turn was a CC-synthesized error stub — don't claim a routing
   # swap or compute savings against a non-model.
   printf '%s — %s%s' "$brand" "$routed" "$tokens_clause"


### PR DESCRIPTION
## What

Adds a `[forced]` indicator to the Claude Code statusline whenever the session is pinned to a specific model via `/force-model`.

Before: `WEAVE ROUTER — claude-sonnet-4-6 ← claude-opus-4-8 · saved $0.42 · …`
After (pinned): `WEAVE ROUTER — claude-sonnet-4-6 [forced] · …`

## How

The router already writes a synthetic acknowledgment turn into the CC transcript when these commands run:
- `/force-model` → `✦ **Weave Router** → force-model applied: <model> (<provider>) · use /unforce-model to clear`
- `/unforce-model` → `✦ **Weave Router** → force-model cleared · resuming automatic model selection`

These persist in the on-disk transcript (the ingress stripper only scrubs the markers from requests forwarded upstream), so the statusline scans the transcript in reverse for the latest of the two markers to decide whether the session is currently pinned. The pinned model id is parsed directly from the marker rather than read off the routed turn — so it stays correct even on the transient ack turn (where `message.model` is the `weave-router` sentinel).

When pinned, the `← selection · saved $X` clause is suppressed: it describes automatic routing and would be misleading on a manual pin.

## Scope note

This covers the interactive `/force-model` path — the only case where a statusline is visible. The header-based `x-weave-force-model` path (headless/eval/CI) writes no ack turn and so won't show `[forced]`, but those contexts have no statusline anyway.

## Testing

Validated locally against synthetic transcripts:
- `/force-model claude-sonnet-4-6` → shows `claude-sonnet-4-6 [forced]`
- after `/unforce-model` → tag gone, back to normal auto display
- rejected model (`force-model: "gpt-" isn't a recognized model`) → not treated as forced
- ack turn is the latest turn → still shows the pinned model, not the `weave-router` sentinel
- `bash -n` syntax check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)