### PR TITLE
polish: sentence-case + punctuate OpenAI handler error envelopes

### DIFF
--- a/internal/api/openai/completions.go
+++ b/internal/api/openai/completions.go
@@ -27,11 +27,11 @@ func ChatCompletionHandler(svc *proxy.Service, authSvc *auth.Service) gin.Handle
 		body, err := io.ReadAll(io.LimitReader(c.Request.Body, maxBodyBytes+1))
 		if err != nil {
 			log.Debug("Failed to read request body", "err", err)
-			writeOpenAIError(c, http.StatusBadRequest, "invalid_request_error", "failed to read request body")
+			writeOpenAIError(c, http.StatusBadRequest, "invalid_request_error", "Failed to read request body.")
 			return
 		}
 		if len(body) > maxBodyBytes {
-			writeOpenAIError(c, http.StatusRequestEntityTooLarge, "invalid_request_error", "request body too large")
+			writeOpenAIError(c, http.StatusRequestEntityTooLarge, "invalid_request_error", "Request body too large.")
 			return
 		}
 
@@ -45,7 +45,7 @@ func ChatCompletionHandler(svc *proxy.Service, authSvc *auth.Service) gin.Handle
 				if c.Writer.Written() {
 					return
 				}
-				writeOpenAIError(c, statusErr.Status, "api_error", "upstream call failed")
+				writeOpenAIError(c, statusErr.Status, "api_error", "Upstream call failed.")
 				return
 			}
 			if c.Writer.Written() {
@@ -66,7 +66,7 @@ func ChatCompletionHandler(svc *proxy.Service, authSvc *auth.Service) gin.Handle
 			}
 			if errors.Is(err, cluster.ErrNoEligibleProvider) {
 				log.Warn("No eligible provider for request", "err", err)
-				writeOpenAIError(c, http.StatusBadRequest, "invalid_request_error", "no provider keys available for any deployed model: register a BYOK key or supply a provider Authorization header")
+				writeOpenAIError(c, http.StatusBadRequest, "invalid_request_error", "No provider keys available for any deployed model: register a BYOK key or supply a provider Authorization header.")
 				return
 			}
 			if errors.Is(err, cluster.ErrInvalidRoutingKnobs) {
@@ -77,11 +77,11 @@ func ChatCompletionHandler(svc *proxy.Service, authSvc *auth.Service) gin.Handle
 			if errors.Is(err, cluster.ErrClusterUnavailable) {
 				log.Error("Cluster routing unavailable", "err", err)
 				c.Header("Retry-After", "1")
-				writeOpenAIError(c, http.StatusServiceUnavailable, "api_error", "router unavailable: cluster scorer failed and no fallback is configured")
+				writeOpenAIError(c, http.StatusServiceUnavailable, "api_error", "Router unavailable: cluster scorer failed and no fallback is configured.")
 				return
 			}
 			log.Error("Proxy failed", "err", err)
-			writeOpenAIError(c, http.StatusBadGateway, "api_error", "upstream call failed")
+			writeOpenAIError(c, http.StatusBadGateway, "api_error", "Upstream call failed.")
 			return
 		}
 	}

--- a/internal/api/openai/responses.go
+++ b/internal/api/openai/responses.go
@@ -28,11 +28,11 @@ func ResponsesHandler(svc *proxy.Service, authSvc *auth.Service) gin.HandlerFunc
 		body, err := io.ReadAll(io.LimitReader(c.Request.Body, maxBodyBytes+1))
 		if err != nil {
 			log.Debug("Failed to read request body", "err", err)
-			writeOpenAIError(c, http.StatusBadRequest, "invalid_request_error", "failed to read request body")
+			writeOpenAIError(c, http.StatusBadRequest, "invalid_request_error", "Failed to read request body.")
 			return
 		}
 		if len(body) > maxBodyBytes {
-			writeOpenAIError(c, http.StatusRequestEntityTooLarge, "invalid_request_error", "request body too large")
+			writeOpenAIError(c, http.StatusRequestEntityTooLarge, "invalid_request_error", "Request body too large.")
 			return
 		}
 
@@ -46,7 +46,7 @@ func ResponsesHandler(svc *proxy.Service, authSvc *auth.Service) gin.HandlerFunc
 				if c.Writer.Written() {
 					return
 				}
-				writeOpenAIError(c, statusErr.Status, "api_error", "upstream call failed")
+				writeOpenAIError(c, statusErr.Status, "api_error", "Upstream call failed.")
 				return
 			}
 			if c.Writer.Written() {
@@ -67,7 +67,7 @@ func ResponsesHandler(svc *proxy.Service, authSvc *auth.Service) gin.HandlerFunc
 			}
 			if errors.Is(err, cluster.ErrNoEligibleProvider) {
 				log.Warn("No eligible provider for request", "err", err)
-				writeOpenAIError(c, http.StatusBadRequest, "invalid_request_error", "no provider keys available for any deployed model: register a BYOK key or supply a provider Authorization header")
+				writeOpenAIError(c, http.StatusBadRequest, "invalid_request_error", "No provider keys available for any deployed model: register a BYOK key or supply a provider Authorization header.")
 				return
 			}
 			if errors.Is(err, cluster.ErrInvalidRoutingKnobs) {
@@ -78,11 +78,11 @@ func ResponsesHandler(svc *proxy.Service, authSvc *auth.Service) gin.HandlerFunc
 			if errors.Is(err, cluster.ErrClusterUnavailable) {
 				log.Error("Cluster routing unavailable", "err", err)
 				c.Header("Retry-After", "1")
-				writeOpenAIError(c, http.StatusServiceUnavailable, "api_error", "router unavailable: cluster scorer failed and no fallback is configured")
+				writeOpenAIError(c, http.StatusServiceUnavailable, "api_error", "Router unavailable: cluster scorer failed and no fallback is configured.")
 				return
 			}
 			log.Error("Proxy failed", "err", err)
-			writeOpenAIError(c, http.StatusBadGateway, "api_error", "upstream call failed")
+			writeOpenAIError(c, http.StatusBadGateway, "api_error", "Upstream call failed.")
 			return
 		}
 	}


### PR DESCRIPTION
## Summary

The OpenAI `/v1/chat/completions` and `/v1/responses` handlers were returning lowercase-start error messages without trailing periods (e.g. `"failed to read request body"`, `"upstream call failed"`, `"router unavailable: cluster scorer failed and no fallback is configured"`). Clients see these strings verbatim — sentence-case + punctuate them to match the polish elsewhere in the codebase.

## Scope

- `internal/api/openai/completions.go` — 6 strings
- `internal/api/openai/responses.go` — 6 strings

## What's NOT changed

- The `type` / `code` machine-readable fields (`invalid_request_error`, `api_error`) — clients parse these.
- The sentinel error sentinels themselves (`cluster.ErrInvalidRoutingKnobs`, `proxy.ErrProviderNotConfigured`, etc.) — only the human-readable message is touched.
- HTTP status codes.
- The 4 sites that still pass raw `err.Error()` through — those are handled in a follow-up PR (A2) so the sentinel-leak fix can be reviewed separately from the pure copy polish.

## Test plan

- [x] `go build ./internal/api/openai/...` clean
- [ ] CI green on existing handler tests (none assert on these exact lowercase strings — verified with ripgrep over `*_test.go`).

Made with [Cursor](https://cursor.com)