### PR TITLE
polish: stop leaking raw err.Error() from OpenAI handler sentinels

### DIFF
--- a/internal/api/openai/completions.go
+++ b/internal/api/openai/completions.go
@@ -53,11 +53,11 @@ func ChatCompletionHandler(svc *proxy.Service, authSvc *auth.Service) gin.Handle
 				return
 			}
 			if errors.Is(err, providers.ErrNotImplemented) {
-				writeOpenAIError(c, http.StatusNotImplemented, "api_error", err.Error())
+				writeOpenAIError(c, http.StatusNotImplemented, "api_error", "Provider not implemented.")
 				return
 			}
 			if errors.Is(err, proxy.ErrProviderNotConfigured) {
-				writeOpenAIError(c, http.StatusBadGateway, "api_error", err.Error())
+				writeOpenAIError(c, http.StatusBadGateway, "api_error", "Provider not configured.")
 				return
 			}
 			if errors.Is(err, translate.ErrNotJSONObject) {
@@ -71,7 +71,7 @@ func ChatCompletionHandler(svc *proxy.Service, authSvc *auth.Service) gin.Handle
 			}
 			if errors.Is(err, cluster.ErrInvalidRoutingKnobs) {
 				log.Warn("Invalid routing knobs supplied", "err", err)
-				writeOpenAIError(c, http.StatusBadRequest, "invalid_request_error", err.Error())
+				writeOpenAIError(c, http.StatusBadRequest, "invalid_request_error", "Invalid routing knobs supplied.")
 				return
 			}
 			if errors.Is(err, cluster.ErrClusterUnavailable) {

--- a/internal/api/openai/responses.go
+++ b/internal/api/openai/responses.go
@@ -54,11 +54,11 @@ func ResponsesHandler(svc *proxy.Service, authSvc *auth.Service) gin.HandlerFunc
 				return
 			}
 			if errors.Is(err, providers.ErrNotImplemented) {
-				writeOpenAIError(c, http.StatusNotImplemented, "api_error", err.Error())
+				writeOpenAIError(c, http.StatusNotImplemented, "api_error", "Provider not implemented.")
 				return
 			}
 			if errors.Is(err, proxy.ErrProviderNotConfigured) {
-				writeOpenAIError(c, http.StatusBadGateway, "api_error", err.Error())
+				writeOpenAIError(c, http.StatusBadGateway, "api_error", "Provider not configured.")
 				return
 			}
 			if errors.Is(err, translate.ErrNotJSONObject) {
@@ -72,7 +72,7 @@ func ResponsesHandler(svc *proxy.Service, authSvc *auth.Service) gin.HandlerFunc
 			}
 			if errors.Is(err, cluster.ErrInvalidRoutingKnobs) {
 				log.Warn("Invalid routing knobs supplied", "err", err)
-				writeOpenAIError(c, http.StatusBadRequest, "invalid_request_error", err.Error())
+				writeOpenAIError(c, http.StatusBadRequest, "invalid_request_error", "Invalid routing knobs supplied.")
 				return
 			}
 			if errors.Is(err, cluster.ErrClusterUnavailable) {


### PR DESCRIPTION
## Summary

Three OpenAI handler sites pass `err.Error()` directly to clients for sentinel errors, leaking internal prefixes like `cluster:` and `provider:` plus inconsistent casing. Detect each sentinel with \`errors.Is\` and emit a clean, sentence-cased message instead.

## Scope

- \`internal/api/openai/completions.go\` — 3 sites
- \`internal/api/openai/responses.go\` — 3 sites

Sentinels mapped to clean strings:
- \`providers.ErrNotImplemented\` → \"Provider not implemented.\"
- \`proxy.ErrProviderNotConfigured\` → \"Provider not configured.\"
- \`cluster.ErrInvalidRoutingKnobs\` → \"Invalid routing knobs supplied.\"

## What's NOT changed

- The sentinel errors themselves (Go callers still match on them with \`errors.Is\`).
- HTTP status codes.
- The OpenAI envelope shape or \`type\`/\`code\` machine-readable fields.

Mirrors the pattern already used in \`internal/api/anthropic/messages.go\` for \`ErrProviderNotConfigured\`.

## Test plan

- [x] \`go build ./internal/api/openai/...\` clean
- [ ] CI green

Made with [Cursor](https://cursor.com)