### PR TITLE
polish: sentence-case + punctuate Anthropic handler error envelopes

### DIFF
--- a/internal/api/anthropic/messages.go
+++ b/internal/api/anthropic/messages.go
@@ -53,11 +53,11 @@ func MessagesHandler(svc *proxy.Service, authSvc *auth.Service) gin.HandlerFunc 
 		body, err := io.ReadAll(io.LimitReader(c.Request.Body, maxBodyBytes+1))
 		if err != nil {
 			log.Debug("Failed to read request body", "err", err)
-			writeAnthropicError(c, http.StatusBadRequest, "invalid_request_error", "failed to read request body")
+			writeAnthropicError(c, http.StatusBadRequest, "invalid_request_error", "Failed to read request body.")
 			return
 		}
 		if len(body) > maxBodyBytes {
-			writeAnthropicError(c, http.StatusRequestEntityTooLarge, "invalid_request_error", "request body too large")
+			writeAnthropicError(c, http.StatusRequestEntityTooLarge, "invalid_request_error", "Request body too large.")
 			return
 		}
 
@@ -83,7 +83,7 @@ func MessagesHandler(svc *proxy.Service, authSvc *auth.Service) gin.HandlerFunc 
 				if c.Writer.Written() {
 					return
 				}
-				writeAnthropicError(c, statusErr.Status, "api_error", "upstream call failed")
+				writeAnthropicError(c, statusErr.Status, "api_error", "Upstream call failed.")
 				return
 			}
 			if c.Writer.Written() {
@@ -91,16 +91,16 @@ func MessagesHandler(svc *proxy.Service, authSvc *auth.Service) gin.HandlerFunc 
 				return
 			}
 			if errors.Is(err, providers.ErrNotImplemented) {
-				writeAnthropicError(c, http.StatusNotImplemented, "api_error", "provider not configured")
+				writeAnthropicError(c, http.StatusNotImplemented, "api_error", "Provider not implemented.")
 				return
 			}
 			if errors.Is(err, translate.ErrNotJSONObject) {
-				writeAnthropicError(c, http.StatusBadRequest, "invalid_request_error", "request body must be a JSON object")
+				writeAnthropicError(c, http.StatusBadRequest, "invalid_request_error", "Request body must be a JSON object.")
 				return
 			}
 			if errors.Is(err, cluster.ErrNoEligibleProvider) {
 				log.Warn("No eligible provider for request", "err", err)
-				writeAnthropicError(c, http.StatusBadRequest, "invalid_request_error", "no provider keys available for any deployed model: register a BYOK key or supply a provider Authorization header")
+				writeAnthropicError(c, http.StatusBadRequest, "invalid_request_error", "No provider keys available for any deployed model: register a BYOK key or supply a provider Authorization header.")
 				return
 			}
 			if errors.Is(err, cluster.ErrInvalidRoutingKnobs) {
@@ -111,11 +111,11 @@ func MessagesHandler(svc *proxy.Service, authSvc *auth.Service) gin.HandlerFunc 
 			if errors.Is(err, cluster.ErrClusterUnavailable) {
 				log.Error("Cluster routing unavailable", "err", err)
 				c.Header("Retry-After", "1")
-				writeAnthropicError(c, http.StatusServiceUnavailable, "api_error", "router unavailable: cluster scorer failed and no fallback is configured")
+				writeAnthropicError(c, http.StatusServiceUnavailable, "api_error", "Router unavailable: cluster scorer failed and no fallback is configured.")
 				return
 			}
 			log.Error("Proxy failed", "err", err)
-			writeAnthropicError(c, http.StatusBadGateway, "api_error", "upstream call failed")
+			writeAnthropicError(c, http.StatusBadGateway, "api_error", "Upstream call failed.")
 			return
 		}
 	}

--- a/internal/api/anthropic/passthrough.go
+++ b/internal/api/anthropic/passthrough.go
@@ -19,11 +19,11 @@ func PassthroughHandler(svc *proxy.Service) gin.HandlerFunc {
 		body, err := io.ReadAll(io.LimitReader(c.Request.Body, maxBodyBytes+1))
 		if err != nil {
 			log.Debug("Failed to read passthrough request body", "err", err)
-			writeAnthropicError(c, http.StatusBadRequest, "invalid_request_error", "failed to read request body")
+			writeAnthropicError(c, http.StatusBadRequest, "invalid_request_error", "Failed to read request body.")
 			return
 		}
 		if len(body) > maxBodyBytes {
-			writeAnthropicError(c, http.StatusRequestEntityTooLarge, "invalid_request_error", "request body too large")
+			writeAnthropicError(c, http.StatusRequestEntityTooLarge, "invalid_request_error", "Request body too large.")
 			return
 		}
 
@@ -33,7 +33,7 @@ func PassthroughHandler(svc *proxy.Service) gin.HandlerFunc {
 				if c.Writer.Written() {
 					return
 				}
-				writeAnthropicError(c, statusErr.Status, "api_error", "upstream call failed")
+				writeAnthropicError(c, statusErr.Status, "api_error", "Upstream call failed.")
 				return
 			}
 			if c.Writer.Written() {
@@ -41,11 +41,11 @@ func PassthroughHandler(svc *proxy.Service) gin.HandlerFunc {
 				return
 			}
 			if errors.Is(err, providers.ErrNotImplemented) {
-				writeAnthropicError(c, http.StatusNotImplemented, "api_error", "provider not configured")
+				writeAnthropicError(c, http.StatusNotImplemented, "api_error", "Provider not implemented.")
 				return
 			}
 			log.Error("Passthrough failed", "err", err, "path", c.Request.URL.Path)
-			writeAnthropicError(c, http.StatusBadGateway, "api_error", "upstream call failed")
+			writeAnthropicError(c, http.StatusBadGateway, "api_error", "Upstream call failed.")
 			return
 		}
 	}

--- a/internal/api/anthropic/route.go
+++ b/internal/api/anthropic/route.go
@@ -21,17 +21,17 @@ func RouteHandler(svc *proxy.Service) gin.HandlerFunc {
 		body, err := io.ReadAll(io.LimitReader(c.Request.Body, maxBodyBytes+1))
 		if err != nil {
 			log.Debug("Failed to read request body", "err", err)
-			writeAnthropicError(c, http.StatusBadRequest, "invalid_request_error", "failed to read request body")
+			writeAnthropicError(c, http.StatusBadRequest, "invalid_request_error", "Failed to read request body.")
 			return
 		}
 		if len(body) > maxBodyBytes {
-			writeAnthropicError(c, http.StatusRequestEntityTooLarge, "invalid_request_error", "request body too large")
+			writeAnthropicError(c, http.StatusRequestEntityTooLarge, "invalid_request_error", "Request body too large.")
 			return
 		}
 
 		env, parseErr := translate.ParseAnthropic(body)
 		if parseErr != nil {
-			writeAnthropicError(c, http.StatusBadRequest, "invalid_request_error", "request body must be a JSON object")
+			writeAnthropicError(c, http.StatusBadRequest, "invalid_request_error", "Request body must be a JSON object.")
 			return
 		}
 
@@ -56,7 +56,7 @@ func RouteHandler(svc *proxy.Service) gin.HandlerFunc {
 				return
 			}
 			log.Error("Routing failed", "err", routeErr)
-			writeAnthropicError(c, http.StatusBadGateway, "api_error", "routing failed")
+			writeAnthropicError(c, http.StatusBadGateway, "api_error", "Routing failed.")
 			return
 		}
 


### PR DESCRIPTION
## Summary

Same polish as #389 but for the Anthropic surface. The Anthropic handlers were returning lowercase-start strings without trailing periods. Also fixes the lowercase \`\"provider not configured\"\` text hardcoded under \`ErrNotImplemented\` (the sentinel is actually \`ErrNotImplemented\`, not \`ErrProviderNotConfigured\`) in \`messages.go\` and \`passthrough.go\`.

## Scope

- \`internal/api/anthropic/messages.go\` — 8 strings
- \`internal/api/anthropic/route.go\` — 4 strings
- \`internal/api/anthropic/passthrough.go\` — 5 strings

## What's NOT changed

- The Anthropic envelope shape (\`type: \"error\"\` + nested \`error.{type,message}\`) — clients depend on it.
- HTTP status codes.
- The 2 sites that still pass raw \`err.Error()\` through (route.go:55, messages.go:108 — both leak \`cluster:\` prefix). Those are handled in a follow-up PR (A4) so the sentinel-leak fix can be reviewed separately.

## Test plan

- [x] \`go build ./internal/api/anthropic/...\` clean
- [ ] CI green

Made with [Cursor](https://cursor.com)