### PR TITLE
polish: stop leaking 'cluster:' prefix in Anthropic routing errors

### DIFF
--- a/internal/api/anthropic/messages.go
+++ b/internal/api/anthropic/messages.go
@@ -105,7 +105,7 @@ func MessagesHandler(svc *proxy.Service, authSvc *auth.Service) gin.HandlerFunc 
 			}
 			if errors.Is(err, cluster.ErrInvalidRoutingKnobs) {
 				log.Warn("Invalid routing knobs supplied", "err", err)
-				writeAnthropicError(c, http.StatusBadRequest, "invalid_request_error", err.Error())
+				writeAnthropicError(c, http.StatusBadRequest, "invalid_request_error", "Invalid routing knobs supplied.")
 				return
 			}
 			if errors.Is(err, cluster.ErrClusterUnavailable) {

--- a/internal/api/anthropic/route.go
+++ b/internal/api/anthropic/route.go
@@ -52,7 +52,7 @@ func RouteHandler(svc *proxy.Service) gin.HandlerFunc {
 		if routeErr != nil {
 			if errors.Is(routeErr, cluster.ErrInvalidRoutingKnobs) {
 				log.Warn("Invalid routing knobs supplied on route", "err", routeErr)
-				writeAnthropicError(c, http.StatusBadRequest, "invalid_request_error", routeErr.Error())
+				writeAnthropicError(c, http.StatusBadRequest, "invalid_request_error", "Invalid routing knobs supplied.")
 				return
 			}
 			log.Error("Routing failed", "err", routeErr)


### PR DESCRIPTION
## Summary

Two Anthropic handler sites pass \`err.Error()\` verbatim for the \`cluster.ErrInvalidRoutingKnobs\` sentinel, leaking the internal \`cluster: invalid routing knobs: ...\` prefix to clients. Detect the sentinel with \`errors.Is\` and emit a clean, sentence-cased message instead — mirrors what #390 did for the OpenAI handler.

## Scope

- \`internal/api/anthropic/messages.go\` (line ~108)
- \`internal/api/anthropic/route.go\` (line ~55)

## Why two PRs instead of one (A3 + this)?

\`A3\` (#391) is pure copy polish on hardcoded strings. \`A4\` (this PR) is a behavioral change — the message clients see for invalid-routing-knobs requests goes from \`cluster: invalid routing knobs: ...\` to \`Invalid routing knobs supplied.\`. Keeping them separate so the behavior change is easy to review on its own.

## What's NOT changed

- The sentinel error itself.
- HTTP status, envelope shape, type/code field.

## Test plan

- [x] \`go build ./internal/api/anthropic/...\` clean
- [ ] CI green

Made with [Cursor](https://cursor.com)