### PR TITLE
polish: stop leaking raw err.Error() from Gemini handler sentinels

### DIFF
--- a/internal/api/gemini/generate_content.go
+++ b/internal/api/gemini/generate_content.go
@@ -78,15 +78,15 @@ func GenerateContentHandler(svc *proxy.Service, authSvc *auth.Service) gin.Handl
 				return
 			}
 			if errors.Is(err, proxy.ErrGeminiCrossFormatUnsupported) {
-				writeGeminiError(c, http.StatusNotImplemented, "UNIMPLEMENTED", err.Error())
+				writeGeminiError(c, http.StatusNotImplemented, "UNIMPLEMENTED", "Cross-format request not supported by the upstream Gemini provider.")
 				return
 			}
 			if errors.Is(err, providers.ErrNotImplemented) {
-				writeGeminiError(c, http.StatusNotImplemented, "UNIMPLEMENTED", err.Error())
+				writeGeminiError(c, http.StatusNotImplemented, "UNIMPLEMENTED", "Provider not implemented.")
 				return
 			}
 			if errors.Is(err, proxy.ErrProviderNotConfigured) {
-				writeGeminiError(c, http.StatusBadGateway, "FAILED_PRECONDITION", err.Error())
+				writeGeminiError(c, http.StatusBadGateway, "FAILED_PRECONDITION", "Provider not configured.")
 				return
 			}
 			if errors.Is(err, translate.ErrNotJSONObject) {


### PR DESCRIPTION
## Summary

Three Gemini handler sites pass \`err.Error()\` directly to clients for sentinel errors, leaking internal prefixes (\`cluster:\`, \`provider:\`) plus inconsistent casing. Detect each sentinel with \`errors.Is\` and emit a clean, sentence-cased message instead — mirrors the OpenAI fix in #390 and the Anthropic fix in #392.

## Scope

\`internal/api/gemini/generate_content.go\` — 3 sites:
- \`proxy.ErrGeminiCrossFormatUnsupported\` → \"Cross-format request not supported by the upstream Gemini provider.\"
- \`providers.ErrNotImplemented\` → \"Provider not implemented.\"
- \`proxy.ErrProviderNotConfigured\` → \"Provider not configured.\"

The \`ErrInvalidRoutingKnobs\` site (also leaks \`cluster:\`) is left untouched in this PR because A5 (#393) already touched the surrounding hardcoded message strings — kept separate to avoid double-touching the same line context.

## What's NOT changed

- The sentinel errors themselves (Go callers still use \`errors.Is\`).
- HTTP status codes, envelope shape, or the \`status\` machine-readable field.

## Test plan

- [x] \`go build ./internal/api/gemini/...\` clean
- [ ] CI green

Made with [Cursor](https://cursor.com)