### PR TITLE
Sentence-case admin metrics error messages

### DIFF
--- a/internal/api/admin/metrics.go
+++ b/internal/api/admin/metrics.go
@@ -48,7 +48,7 @@ func MetricsSummaryHandler(proxySvc *proxy.Service) gin.HandlerFunc {
 			summary, err = proxySvc.MetricsSummary(c.Request.Context(), installation.ID, from, to)
 		}
 		if err != nil {
-			c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"error": "failed to fetch metrics"})
+			c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"error": "Failed to fetch metrics."})
 			return
 		}
 
@@ -85,7 +85,7 @@ func MetricsTimeseriesHandler(proxySvc *proxy.Service) gin.HandlerFunc {
 			buckets, err = proxySvc.MetricsTimeseries(c.Request.Context(), installation.ID, from, to, granularity)
 		}
 		if err != nil {
-			c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"error": "failed to fetch timeseries"})
+			c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"error": "Failed to fetch timeseries."})
 			return
 		}
 
@@ -157,7 +157,7 @@ func MetricsDetailsHandler(proxySvc *proxy.Service) gin.HandlerFunc {
 			rows, err = proxySvc.MetricsRows(c.Request.Context(), installation.ID, from, to, limit)
 		}
 		if err != nil {
-			c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"error": "failed to fetch details"})
+			c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"error": "Failed to fetch details."})
 			return
 		}
 


### PR DESCRIPTION
## Summary
Sentence-case + period the three error strings returned from the admin metrics endpoints (`/admin/metrics`, `/admin/metrics/timeseries`, `/admin/metrics/details`).

Part of the router copy cleanup pass.

## Test plan
- [x] `go build ./internal/api/admin/...`
- [x] No tests assert against the old lowercase strings

Made with [Cursor](https://cursor.com)