### PR TITLE
Sentence-case admin excluded providers/models error messages

### DIFF
--- a/internal/api/admin/excluded_models.go
+++ b/internal/api/admin/excluded_models.go
@@ -105,14 +105,14 @@ func UpdateExcludedModelsHandler(authSvc *auth.Service, models DeployedModelsSou
 		}
 		if override != nil && override.HasExcludedModelsOverride() {
 			c.AbortWithStatusJSON(http.StatusForbidden, gin.H{
-				"error": "exclusion list is pinned by ROUTER_EXCLUDED_MODELS; clear the env var to edit",
+				"error": "Exclusion list is pinned by ROUTER_EXCLUDED_MODELS; clear the env var to edit.",
 			})
 			return
 		}
 
 		var req updateExcludedModelsRequest
 		if err := c.ShouldBindJSON(&req); err != nil {
-			c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": "invalid request body"})
+			c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": "Invalid request body."})
 			return
 		}
 
@@ -128,7 +128,7 @@ func UpdateExcludedModelsHandler(authSvc *auth.Service, models DeployedModelsSou
 				return
 			}
 			log.Error("Failed to update excluded models", "err", err, "installation_id", installation.ID)
-			c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"error": "failed to update excluded models"})
+			c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"error": "Failed to update excluded models."})
 			return
 		}
 

--- a/internal/api/admin/excluded_providers.go
+++ b/internal/api/admin/excluded_providers.go
@@ -90,14 +90,14 @@ func UpdateExcludedProvidersHandler(authSvc *auth.Service, models DeployedModels
 		}
 		if override != nil && override.HasExcludedProvidersOverride() {
 			c.AbortWithStatusJSON(http.StatusForbidden, gin.H{
-				"error": "exclusion list is pinned by ROUTER_EXCLUDED_PROVIDERS; clear the env var to edit",
+				"error": "Exclusion list is pinned by ROUTER_EXCLUDED_PROVIDERS; clear the env var to edit.",
 			})
 			return
 		}
 
 		var req updateExcludedProvidersRequest
 		if err := c.ShouldBindJSON(&req); err != nil {
-			c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": "invalid request body"})
+			c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": "Invalid request body."})
 			return
 		}
 
@@ -114,7 +114,7 @@ func UpdateExcludedProvidersHandler(authSvc *auth.Service, models DeployedModels
 				return
 			}
 			log.Error("Failed to update excluded providers", "err", err, "installation_id", installation.ID)
-			c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"error": "failed to update excluded providers"})
+			c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"error": "Failed to update excluded providers."})
 			return
 		}
 


### PR DESCRIPTION
## Summary
Sentence-case + period the user-facing error strings in the admin excluded providers/models endpoints.

Part of the router copy cleanup pass.

## Test plan
- [x] `go build ./internal/api/admin/...`
- [x] No tests assert against the old lowercase strings

Made with [Cursor](https://cursor.com)