### PR TITLE
Sentence-case admin login hints and installation error

### DIFF
--- a/internal/api/admin/auth.go
+++ b/internal/api/admin/auth.go
@@ -44,7 +44,7 @@ func LoginHandler(authSvc *auth.Service) gin.HandlerFunc {
 		if !authSvc.AdminLoginEnabled() {
 			c.AbortWithStatusJSON(http.StatusServiceUnavailable, gin.H{
 				"error": "admin_login_disabled",
-				"hint":  "set ROUTER_ADMIN_PASSWORD on the router to enable dashboard login",
+				"hint":  "Set ROUTER_ADMIN_PASSWORD on the router to enable dashboard login.",
 			})
 			return
 		}
@@ -61,7 +61,7 @@ func LoginHandler(authSvc *auth.Service) gin.HandlerFunc {
 				observability.FromGin(c).Info("Admin login rejected: rate limited", "remote_ip", peerIP)
 				c.AbortWithStatusJSON(http.StatusTooManyRequests, gin.H{
 					"error": "too_many_attempts",
-					"hint":  "wait a few minutes before trying again",
+					"hint":  "Wait a few minutes before trying again.",
 				})
 				return
 			}

--- a/internal/api/admin/installation.go
+++ b/internal/api/admin/installation.go
@@ -22,7 +22,7 @@ func resolveInstallation(c *gin.Context, authSvc *auth.Service) (*auth.Installat
 		installation, err := authSvc.EnsureAdminInstallation(c.Request.Context())
 		if err != nil {
 			observability.FromGin(c).Error("Failed to ensure admin installation", "err", err)
-			c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"error": "failed to resolve admin installation"})
+			c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"error": "Failed to resolve admin installation."})
 			return nil, false
 		}
 		return installation, true


### PR DESCRIPTION
## Summary
Sentence-case + period the user-facing `hint` strings in admin login and the installation-resolve error. Machine-readable `error` codes (e.g. `admin_login_disabled`, `too_many_attempts`) left untouched — they're API contracts.

Part of the router copy cleanup pass.

## Test plan
- [x] `go build ./internal/api/admin/...`
- [x] No tests assert against the old hint/error strings

Made with [Cursor](https://cursor.com)