### PR TITLE
fix(proxy): evict session pin after degenerate response

### DIFF
--- a/internal/proxy/pin_eviction.go
+++ b/internal/proxy/pin_eviction.go
@@ -22,6 +22,61 @@ import (
 // notice and manually /force-model out.
 const pinEvictionStrikeThreshold = 2
 
+// evictPinAfterDegenerateResponse expires the session pin immediately
+// after a degenerate response (end_turn with no tool calls and fewer
+// than degenerateOutputThreshold output tokens). The current turn has
+// already been streamed to the client and cannot be retried, but
+// evicting the pin ensures the NEXT turn re-scores rather than
+// continuing to serve the same misbehaving model.
+//
+// Skipped paths:
+//   - !stickyHit: the pin row was just written this turn; no decision
+//     history to evict yet.
+//   - Zero session_key / installation_id: no addressable pin row.
+//   - User-forced pins: the user explicitly chose this model; auto-eviction
+//     would silently override an explicit command.
+//
+// Errors from the upsert path are logged and swallowed — eviction is a
+// recovery optimization; failing it must not change the client outcome.
+func (s *Service) evictPinAfterDegenerateResponse(
+	ctx context.Context,
+	stickyHit bool,
+	decisionReason string,
+	installationID uuid.UUID,
+	sessionKey [sessionpin.SessionKeyLen]byte,
+	role string,
+) {
+	if !stickyHit || s.pinStore == nil || installationID == uuid.Nil {
+		return
+	}
+	if sessionKey == ([sessionpin.SessionKeyLen]byte{}) {
+		return
+	}
+	if strings.HasPrefix(decisionReason, translate.ReasonUserForceModel) {
+		return
+	}
+
+	log := observability.FromContext(ctx)
+
+	expired := sessionpin.Pin{
+		SessionKey:     sessionKey,
+		Role:           role,
+		InstallationID: installationID,
+		Provider:       "",
+		Model:          "",
+		Reason:         "degenerate_response",
+		TurnCount:      1,
+		PinnedUntil:    time.Now().Add(-time.Second),
+	}
+	if err := s.pinStore.Upsert(context.Background(), expired); err != nil {
+		log.Error("pin eviction after degenerate response failed", "err", err, "role", role)
+		return
+	}
+	log.Info("session pin evicted after degenerate response",
+		"role", role,
+	)
+}
+
 // maybeEvictPinAfterUpstreamErr applies the two-strike pin-eviction
 // policy on every turn that ran against a sticky session pin:
 //

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -1624,6 +1624,11 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 				"upstream_finish_reason", respSummary.UpstreamFinishReason,
 				"would_failover", true,
 			)
+			// Evict the session pin so the next turn re-scores instead of
+			// continuing to serve the same misbehaving model. The current
+			// turn has already been streamed (cannot retry), but eviction
+			// is the best available recovery for the session's next turn.
+			s.evictPinAfterDegenerateResponse(ctx, stickyHit, decision.Reason, installationID, routeRes.SessionKey, routeRes.PinRole)
 		}
 		s.fireTelemetry(InsertTelemetryParams{
 			InstallationID:         installationID.String(),


### PR DESCRIPTION
## Problem

`router.degenerate_shadow` logs `would_failover: true` but never actually does anything — the detector has been shadow-only since it shipped in #363. In the session `354ee849`, Gemini returned a 5-token `end_turn` response with 0 tool calls and the session continued on the same model for its next turns.

Same-turn retry is impossible (response already streamed), but we can recover the next turn.

## Solution

After a degenerate response is detected, immediately expire the session pin so the next turn falls through to the cluster scorer instead of sticking to the misbehaving model. Follows the exact same `PinnedUntil = now - 1s` eviction pattern used by the two-strike upstream-error eviction in `pin_eviction.go`.

## What changes

- `pin_eviction.go`: new `evictPinAfterDegenerateResponse` helper (same shape as `maybeEvictPinAfterUpstreamErr`)
- `service.go`: call it immediately after the `router.degenerate_shadow` log

## Skipped paths (same guards as upstream-error eviction)
- `!stickyHit`: no pin to evict  
- `uuid.Nil` installation: no addressable pin row  
- Force-model pins: user's explicit choice, router doesn't auto-override

🤖 Generated with [Claude Code](https://claude.com/claude-code)