### PR TITLE
Sentence-case /router-feedback synthetic acknowledgments

### DIFF
--- a/internal/proxy/router_feedback.go
+++ b/internal/proxy/router_feedback.go
@@ -57,9 +57,9 @@ func (s *Service) handleRouterFeedbackCommand(
 		// Acknowledgment text is formatted as a routing marker so the existing
 		// StripRoutingMarkerFromMessages ingress stripper removes it from
 		// subsequent inbound requests (see handleForceModelCommand).
-		msg := "✦ **Weave Router** → router-feedback needs a message, e.g. /router-feedback got stuck on Haiku for too long\n\n"
+		msg := "✦ **Weave Router** → Router-feedback needs a message, e.g. /router-feedback got stuck on Haiku for too long.\n\n"
 		if env.SourceFormat() == translate.FormatOpenAI {
-			msg = "Weave Router: router-feedback needs a message, e.g. /router-feedback got stuck on Haiku for too long"
+			msg = "Weave Router: router-feedback needs a message, e.g. /router-feedback got stuck on Haiku for too long."
 		}
 		return writeSyntheticCommandResponse(w, env, msg, inputTokens)
 	}
@@ -130,9 +130,9 @@ func (s *Service) handleRouterFeedbackCommand(
 		"role", role,
 	)
 
-	msg := "✦ **Weave Router** → feedback recorded, thank you\n\n"
+	msg := "✦ **Weave Router** → Feedback recorded. Thank you.\n\n"
 	if env.SourceFormat() == translate.FormatOpenAI {
-		msg = "Weave Router: feedback recorded, thank you."
+		msg = "Weave Router: Feedback recorded. Thank you."
 	}
 	return writeSyntheticCommandResponse(w, env, msg, inputTokens)
 }

--- a/internal/proxy/router_feedback_proxy_test.go
+++ b/internal/proxy/router_feedback_proxy_test.go
@@ -69,7 +69,7 @@ func TestService_RouterFeedbackCommand_PersistsAndAcks(t *testing.T) {
 	require.NotEmpty(t, blocks)
 	first, _ := blocks[0].(map[string]any)
 	text, _ := first["text"].(string)
-	assert.Contains(t, text, "feedback recorded")
+	assert.Contains(t, text, "Feedback recorded")
 }
 
 func TestService_RouterFeedbackCommand_OpenAIIngress(t *testing.T) {
@@ -102,7 +102,7 @@ func TestService_RouterFeedbackCommand_OpenAIIngress(t *testing.T) {
 	first, _ := choices[0].(map[string]any)
 	msg, _ := first["message"].(map[string]any)
 	content, _ := msg["content"].(string)
-	assert.Contains(t, content, "feedback recorded")
+	assert.Contains(t, content, "Feedback recorded")
 }
 
 func TestService_RouterFeedbackCommand_EmptyFeedbackAsksForText(t *testing.T) {


### PR DESCRIPTION
## Summary
Sentence-case + period the synthetic acknowledgments emitted by `/router-feedback` (both Anthropic-format and OpenAI-format variants). Also splits "feedback recorded, thank you" into two sentences per copy guidelines.

Tests assertions updated to match (case-sensitive `Contains`).

Part of the router copy cleanup pass.

## Test plan
- [x] `go test ./internal/proxy/ -run RouterFeedback`
- [x] Verified no install-script greps these strings (unlike the `force-model applied:` tokens consumed by `cc-statusline.sh`)

Made with [Cursor](https://cursor.com)