### PR TITLE
fix(proxy): re-anchor expired session pins to their prior model

### DIFF
--- a/internal/proxy/turnloop.go
+++ b/internal/proxy/turnloop.go
@@ -495,6 +495,13 @@ func (s *Service) runTurnLoop(
 	//   (c) the prior model is still routable (in availableModels)
 	//   (d) the prior model is not excluded (e.g. context-window overflow)
 	//   (e) the prior provider is still in the request's enabled set
+	//   (f) the prior turn did NOT saturate the output cap (maxed-out guard
+	//       mirrors the live-pin check above — re-anchoring a broken model
+	//       that already generated to the cap would restart the degenerate
+	//       auto-continue loop)
+	//   (g) this turn does NOT carry images if the prior model is text-only
+	//       (image guard mirrors the live-pin check above — re-anchoring a
+	//       text-only model on an image-bearing turn would immediately 4xx)
 	// When re-anchoring, write a new pin so the next turn is a sticky hit.
 	if !pinFound && pin.Model != "" {
 		pinTier := catalog.TierFor(pin.Model)
@@ -504,20 +511,33 @@ func (s *Service) runTurnLoop(
 				if _, available := s.availableModels[pin.Model]; available {
 					_, providerOK := req.EnabledProviders[pin.Provider]
 					if req.EnabledProviders == nil || providerOK {
-						priorDecision := s.clampToCeiling(pinDecision(pin), res.RequestedTier, req.HasImages, req.EnabledProviders, req.ExcludedModels, &res)
-						res.Decision = priorDecision
-						res.StickyHit = true
-						res.PinTier = "postgres_reanchor"
-						s.writeNewPin(ctx, installationID, res.SessionKey, res.PinRole, priorDecision)
-						log.Info("router re-anchored expired session pin",
-							"prior_model", pin.Model,
-							"prior_provider", pin.Provider,
-							"fresh_model", fresh.Model,
-							"fresh_provider", fresh.Provider,
-							"prior_tier", pinTier.String(),
-							"fresh_tier", freshTier.String(),
-						)
-						return res, nil
+						if pin.LastOutputTokens >= prevTurnMaxedOutThreshold {
+							log.Info("Expired session pin maxed out on previous turn; skipping re-anchor",
+								"pin_model", pin.Model,
+								"pin_provider", pin.Provider,
+								"last_output_tokens", pin.LastOutputTokens,
+							)
+						} else if req.HasImages && !catalog.AcceptsImages(pin.Model) {
+							log.Info("Expired session pin is text-only for image-bearing turn; skipping re-anchor",
+								"pin_model", pin.Model,
+								"pin_provider", pin.Provider,
+							)
+						} else {
+							priorDecision := pinDecision(pin)
+							res.Decision = priorDecision
+							res.StickyHit = true
+							res.PinTier = "postgres_reanchor"
+							s.writeNewPin(ctx, installationID, res.SessionKey, res.PinRole, priorDecision)
+							log.Info("router re-anchored expired session pin",
+								"prior_model", pin.Model,
+								"prior_provider", pin.Provider,
+								"fresh_model", fresh.Model,
+								"fresh_provider", fresh.Provider,
+								"prior_tier", pinTier.String(),
+								"fresh_tier", freshTier.String(),
+							)
+							return res, nil
+						}
 					}
 				}
 			}

--- a/internal/proxy/turnloop.go
+++ b/internal/proxy/turnloop.go
@@ -481,6 +481,49 @@ func (s *Service) runTurnLoop(
 	)
 	res.Fresh = fresh
 
+	// Expired-pin re-anchor: when the session pin has lapsed mid-session
+	// (!pinFound but pin.Model != "" — an expired row, not a first-turn
+	// miss), prefer staying on the prior model instead of taking whatever
+	// lateral switch the scorer happened to pick on the one expiry turn.
+	// A model-switch on a single expiry turn is frequently noise: the
+	// scorer may land in a different cluster on that turn and return a
+	// different model that the session then stays on for the rest of its
+	// life, even if subsequent turns would have scored the prior model
+	// equally well. Re-anchor when all of the following hold:
+	//   (a) both model tiers are known (TierUnknown falls through to scorer)
+	//   (b) the fresh recommendation is NOT a tier upgrade
+	//   (c) the prior model is still routable (in availableModels)
+	//   (d) the prior model is not excluded (e.g. context-window overflow)
+	//   (e) the prior provider is still in the request's enabled set
+	// When re-anchoring, write a new pin so the next turn is a sticky hit.
+	if !pinFound && pin.Model != "" {
+		pinTier := catalog.TierFor(pin.Model)
+		freshTier := catalog.TierFor(fresh.Model)
+		if pinTier != catalog.TierUnknown && freshTier != catalog.TierUnknown && freshTier <= pinTier {
+			if _, excluded := req.ExcludedModels[pin.Model]; !excluded {
+				if _, available := s.availableModels[pin.Model]; available {
+					_, providerOK := req.EnabledProviders[pin.Provider]
+					if req.EnabledProviders == nil || providerOK {
+						priorDecision := s.clampToCeiling(pinDecision(pin), res.RequestedTier, req.HasImages, req.EnabledProviders, req.ExcludedModels, &res)
+						res.Decision = priorDecision
+						res.StickyHit = true
+						res.PinTier = "postgres_reanchor"
+						s.writeNewPin(ctx, installationID, res.SessionKey, res.PinRole, priorDecision)
+						log.Info("router re-anchored expired session pin",
+							"prior_model", pin.Model,
+							"prior_provider", pin.Provider,
+							"fresh_model", fresh.Model,
+							"fresh_provider", fresh.Provider,
+							"prior_tier", pinTier.String(),
+							"fresh_tier", freshTier.String(),
+						)
+						return res, nil
+					}
+				}
+			}
+		}
+	}
+
 	if !s.plannerEnabled {
 		res.Decision = fresh
 		s.writeNewPin(ctx, installationID, res.SessionKey, res.PinRole, fresh)


### PR DESCRIPTION
## Problem

When a session pin's TTL elapses mid-session, the router zeroes out the pin and lets the fresh scorer result take effect. The planner then keeps the session on the new model because switching back is negatively-EV (the new model may be cheaper/different).

**Root cause in session `354ee849`:** Pin expired after ~10 min on `gpt-5.5`. Scorer returned `gemini-3.1-pro-preview` on that one expiry turn. All subsequent turns stayed on Gemini because switching back to `gpt-5.5` (more expensive) showed `ev_negative` — Gemini is cheaper per-token, so the planner correctly refused to switch back.

The actual fix gpt-5.5 applied was done at mc=28–30. The session then spent another ~90 turns on Gemini making tiny tool calls and ultimately producing a 5-token degenerate response.

## Solution

After the scorer runs, if the loaded pin is **expired** (not missing — `pin.Model != ""` but `!pinFound`), re-anchor to the prior model instead of taking the fresh pick, as long as:
- Both tiers are known (TierUnknown falls through to scorer)
- The fresh pick is **not** a strict tier upgrade
- The prior model is still routable, not context-window-excluded, and provider-eligible

Writes a fresh pin to the prior model so the next turn is a sticky hit.

**Tier upgrades always win:** compaction rewrite, long-context overflow, or a quality ceiling jump warrants a genuine switch. A lateral drift caused by the scorer landing in a different cluster on the one expiry turn does not.

## What changes

- `internal/proxy/turnloop.go`: 43-line guard between `res.Fresh = fresh` and `plannerIn := planner.Inputs{...}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)