### PR TITLE
Sentence-case loop-detection and no-progress synthetic acknowledgments

### DIFF
--- a/internal/proxy/loop_detection.go
+++ b/internal/proxy/loop_detection.go
@@ -376,7 +376,7 @@ func (s *Service) handleToolCallLoopBreak(
 	log := observability.FromContext(ctx)
 
 	msg := fmt.Sprintf(
-		"✦ **Weave Router** → tool-call loop detected: `%s` was called %d times in the last %d turns with identical arguments. Stopping this turn and clearing the session pin so the next message re-routes to a fresh model.\n\nIf the task is genuinely incomplete, send a follow-up message describing what's still needed; the router will pick a different model.\n\n",
+		"✦ **Weave Router** → Tool-call loop detected: `%s` was called %d times in the last %d turns with identical arguments. Stopping this turn and clearing the session pin so the next message re-routes to a fresh model.\n\nIf the task is genuinely incomplete, send a follow-up message describing what's still needed; the router will pick a different model.\n\n",
 		sig.Name, count, loopDetectionWindowSize,
 	)
 	if env.SourceFormat() == translate.FormatOpenAI {

--- a/internal/proxy/no_progress.go
+++ b/internal/proxy/no_progress.go
@@ -321,7 +321,7 @@ func (s *Service) handleNoProgressBreak(
 	log := observability.FromContext(ctx)
 
 	msg := fmt.Sprintf(
-		"✦ **Weave Router** → no-progress loop detected: %d consecutive requests under this session routed to `%s` (`%s`) with no observable progress in %s. Stopping this turn and clearing the session pin so the next message re-routes.\n\nIf the task is genuinely incomplete, send a follow-up message describing what's still needed; the router will pick a different model.\n\n",
+		"✦ **Weave Router** → No-progress loop detected: %d consecutive requests under this session routed to `%s` (`%s`) with no observable progress in %s. Stopping this turn and clearing the session pin so the next message re-routes.\n\nIf the task is genuinely incomplete, send a follow-up message describing what's still needed; the router will pick a different model.\n\n",
 		count, decisionModel, decisionProvider, noProgressTimeWindow,
 	)
 	if env.SourceFormat() == translate.FormatOpenAI {


### PR DESCRIPTION
## Summary
Sentence-case the first word after the `→` separator in the loop-detection and no-progress synthetic-assistant messages.

Part of the router copy cleanup pass.

## Test plan
- [x] `go build ./internal/proxy/...`
- [x] No tests assert against the old lowercase text
- [x] `install.sh` / `cc-statusline.sh` jq parsers only match `force-model applied:` / `isn't a recognized model` and fall through to CLEARED on anything else — case change here is invisible to them

Made with [Cursor](https://cursor.com)