### PR TITLE
fix(cluster): remove gemini-3.1-pro-preview from v0.67 deployed models

### DIFF
--- a/internal/router/cluster/artifacts/v0.67/model_registry.json
+++ b/internal/router/cluster/artifacts/v0.67/model_registry.json
@@ -43,15 +43,6 @@
       ]
     },
     {
-      "model": "gemini-3.1-pro-preview",
-      "provider": "google",
-      "bench_column": "routerarena_gemini-3.1-pro-preview",
-      "direct_label": "routerarena",
-      "extra_bench_columns": [
-        "swebench_gemini/gemini-3.1-pro-preview"
-      ]
-    },
-    {
       "model": "gemini-3.5-flash",
       "provider": "google",
       "bench_column": "routerarena_gemini-3.5-flash",


### PR DESCRIPTION
## Problem

`gemini-3.1-pro-preview` is in the v0.67 cluster's `model_registry.json` and the scorer routes coding sessions to it. In practice it produces:

- Micro tool-call responses (16–43 output tokens per turn) with no readable text
- A fully degenerate 5-token `end_turn` response on deep sessions (session `354ee849`, mc=118)

The session was already done by mc=28–30 (gpt-5.5 applied the CSS fix), but after switching to Gemini at pin expiry the session ran another ~90 turns producing nothing useful.

## Solution

Remove `gemini-3.1-pro-preview` from the v0.67 `deployed_models` list so the cluster scorer cannot route to it.

`gemini-3.1-flash-lite-preview` (the hard-pin model for title_gen / compaction) is a separate entry and is **not** affected.

## Note

This is a direct data change to `model_registry.json`. The artifact's centroids and rankings remain unchanged — removing a model from the deployed set just makes it ineligible for the scorer's argmax. No retraining needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)