### PR TITLE
Rebrand Responses translation badge to **Weave Router**

### DIFF
--- a/internal/translate/responses.go
+++ b/internal/translate/responses.go
@@ -207,7 +207,7 @@ func responsesInputItemToMessages(item gjson.Result) ([]map[string]any, error) {
 // don't accumulate per-turn variable badge text (which would defeat
 // prompt-cache reuse and waste tokens), and so the upstream provider never
 // sees router-injected content as part of the model's history.
-var responsesBadgePattern = regexp.MustCompile(`(?m)\A\*\*WEAVE ROUTER\*\* — [^\n]*\n\n`)
+var responsesBadgePattern = regexp.MustCompile(`(?im)\A\*\*WEAVE ROUTER\*\* — [^\n]*\n\n`)
 
 // responsesContentToChatContent flattens a content array. For assistant
 // messages we may also extract tool-call shells if a client embeds them.
@@ -615,8 +615,8 @@ func (t *ResponsesWriter) nextOutputIndex() int {
 // computeBadgeText builds the routing badge that's prepended to the
 // assistant's first text delta. Format mirrors the Claude Code statusline:
 //
-//	**WEAVE ROUTER** — <routed>
-//	**WEAVE ROUTER** — <routed> ← <requested>   (when the router swapped)
+//	**Weave Router** — <routed>
+//	**Weave Router** — <routed> ← <requested>   (when the router swapped)
 //
 // Returns the badge line including trailing blank line, or empty when there
 // is no routed model to surface yet.
@@ -624,7 +624,7 @@ func (t *ResponsesWriter) computeBadgeText() string {
 	if t.model == "" {
 		return ""
 	}
-	badge := "**WEAVE ROUTER** — " + t.model
+	badge := "**Weave Router** — " + t.model
 	if t.requestedModel != "" && t.requestedModel != t.model {
 		badge += " ← " + t.requestedModel
 	}

--- a/internal/translate/responses_test.go
+++ b/internal/translate/responses_test.go
@@ -210,7 +210,7 @@ func TestResponsesWriter_StreamingText(t *testing.T) {
 			continue
 		}
 		d := e["delta"].(string)
-		if strings.HasPrefix(d, "**WEAVE ROUTER**") {
+		if strings.HasPrefix(d, "**Weave Router**") {
 			continue
 		}
 		combined.WriteString(d)
@@ -252,8 +252,8 @@ func TestResponsesWriter_PrependsBadgeOnSwap(t *testing.T) {
 		}
 	}
 	require.Len(t, deltas, 3)
-	// Format: **WEAVE ROUTER** — claude-opus-4-7 ← gpt-5.5\n\n
-	assert.Contains(t, deltas[0], "**WEAVE ROUTER**")
+	// Format: **Weave Router** — claude-opus-4-7 ← gpt-5.5\n\n
+	assert.Contains(t, deltas[0], "**Weave Router**")
 	assert.Contains(t, deltas[0], "claude-opus-4-7")
 	assert.Contains(t, deltas[0], "← gpt-5.5")
 	assert.True(t, strings.HasSuffix(deltas[0], "\n\n"))
@@ -291,7 +291,7 @@ func TestResponsesWriter_BadgeWithoutSwapShowsModelOnly(t *testing.T) {
 			break
 		}
 	}
-	assert.Contains(t, firstDelta, "**WEAVE ROUTER**")
+	assert.Contains(t, firstDelta, "**Weave Router**")
 	assert.Contains(t, firstDelta, "claude-opus-4-7")
 	assert.NotContains(t, firstDelta, "←")
 }


### PR DESCRIPTION
## Summary
Switch the inline routing badge that `ResponsesWriter` prepends on the first assistant text delta from `**WEAVE ROUTER** — ...` to `**Weave Router** — ...` to match the brand casing used everywhere else (admin UI, install scripts' user-facing copy, synthetic-assistant messages).

To keep prompt-cache reuse working across the deploy boundary, also widen `responsesBadgePattern` to a case-insensitive regex so prior assistant turns from already-deployed clients (still carrying the old all-caps badge) continue to be stripped on ingress. Without this widening, old session history would leak per-turn router-injected bytes upstream.

The ANSI-colored `WEAVE ROUTER` brand in `install.sh` / `cc-statusline.sh` is a separate display surface and intentionally left unchanged.

Part of the router copy cleanup pass.

## Test plan
- [x] `go test ./internal/translate/ -run Responses`
- [x] Updated 3 test assertions checking output deltas
- [x] Left 3 input-strip tests using the old `**WEAVE ROUTER**` form unchanged — they now also verify backward-compat of the case-insensitive regex

Made with [Cursor](https://cursor.com)