### PR TITLE
Drop redundant "Please" from billing error and router nudge copy

### DIFF
--- a/internal/server/middleware/balance_check.go
+++ b/internal/server/middleware/balance_check.go
@@ -65,7 +65,7 @@ func WithBalanceCheck(svc *billing.Service, minBalanceMicros int64) gin.HandlerF
 			log.Error("Balance check failed; refusing request", "err", err, "organization_id", orgID)
 			c.AbortWithStatusJSON(http.StatusServiceUnavailable, gin.H{
 				"error":   "billing_unavailable",
-				"message": "Billing system is temporarily unavailable. Please retry in a few moments.",
+				"message": "Billing system is temporarily unavailable. Retry in a few moments.",
 			})
 			return
 		}

--- a/internal/translate/stream.go
+++ b/internal/translate/stream.go
@@ -1006,7 +1006,7 @@ func (t *AnthropicSSETranslator) emitValidatedToolArgsDelta(blockIdx int) error 
 // surfaces as a tool_result in the next turn's context, nudging the model
 // to use a real tool. Bash is chosen because every Claude Code request
 // includes it in tools, making the fabricated call dispatchable.
-const routerNudgeCommand = "echo '[router] previous turn produced no tool_use; please use Edit/Write/Read/Bash/Grep — do not respond with prose or thinking tags only.'"
+const routerNudgeCommand = "echo '[router] previous turn produced no tool_use; use Edit/Write/Read/Bash/Grep — do not respond with prose or thinking tags only.'"
 
 // leadingContentCap bounds how much of the content channel's opening text the
 // translator retains for the leadsWithToolishMarkup check. Large enough to hold


### PR DESCRIPTION
## Summary
Drop the filler "Please" from two user-facing strings:
- The `billing_unavailable` error message returned by `balance_check` middleware.
- The `[router]` recovery nudge command synthesized when the model emits no tool_use.

Per the project copy convention: "Please" is redundant in directives; drop it.

The nudge is detected by tool-use ID prefix (`toolu_router_nudge_`), not by command-text equality, so changing the text is safe.

Part of the router copy cleanup pass.

## Test plan
- [x] `go test ./internal/translate/`
- [x] `go build ./internal/server/middleware/...`

Made with [Cursor](https://cursor.com)