### PR TITLE
fix(proxy): direct fit-check before evicting session pin on context overflow

### DIFF
--- a/internal/proxy/turnloop.go
+++ b/internal/proxy/turnloop.go
@@ -327,18 +327,50 @@ func (s *Service) runTurnLoop(
 	// Context-window overflow guard: if the pre-filter in ProxyMessages /
 	// ProxyOpenAIChatCompletion added the pinned model to ExcludedModels
 	// (because this turn's estimated context exceeds the model's window),
-	// treat the pin as missing so downstream sticky branches (ToolResult,
-	// OutcomeStay, !plannerEnabled) cannot re-anchor to an over-capacity
-	// model. Sessions grow over time; the filter correctly evicts the pin
-	// on the turn where the window is first breached.
+	// verify with a direct fit-check before evicting the pin. The pre-filter
+	// uses body_bytes÷5 as a conservative token estimate; the pin guard uses
+	// the same formula but checks the model's actual context window, so a
+	// conservative over-estimate that only slightly overshoots a large-window
+	// model does not cause an unnecessary mid-session switch.
+	// A confirmed overflow (needed > model window) still evicts the pin.
 	if pinFound {
 		if _, overCapacity := req.ExcludedModels[pin.Model]; overCapacity {
-			log.Info("Session pin excluded by context-window pre-filter; falling through to scorer",
-				"pin_model", pin.Model,
-				"pin_provider", pin.Provider,
-			)
-			pinFound = false
-			pin = sessionpin.Pin{}
+			outputReserveForPin := contextWindowOutputReserve
+			if feats.MaxTokens > outputReserveForPin {
+				outputReserveForPin = feats.MaxTokens
+			}
+			needed := env.FullTokenEstimate() + outputReserveForPin
+			modelCW := contextWindowForRequest(pin.Model, false)
+			if needed > modelCW {
+				log.Info("Session pin excluded by context-window pre-filter; falling through to scorer",
+					"pin_model", pin.Model,
+					"pin_provider", pin.Provider,
+					"token_estimate", env.FullTokenEstimate(),
+					"needed", needed,
+					"model_context_window", modelCW,
+				)
+				pinFound = false
+				pin = sessionpin.Pin{}
+			} else {
+				// Pre-filter was overly conservative — pin model fits.
+				// Remove it from ExcludedModels so the scorer can also
+				// consider it when fresh routing runs this turn.
+				if len(req.ExcludedModels) > 0 {
+					pruned := make(map[string]struct{}, len(req.ExcludedModels)-1)
+					for k := range req.ExcludedModels {
+						if k != pin.Model {
+							pruned[k] = struct{}{}
+						}
+					}
+					req.ExcludedModels = pruned
+				}
+				log.Info("Session pin preserved despite context-window pre-filter exclusion",
+					"pin_model", pin.Model,
+					"token_estimate", env.FullTokenEstimate(),
+					"needed", needed,
+					"model_context_window", modelCW,
+				)
+			}
 		}
 	}
 

--- a/internal/proxy/turnloop.go
+++ b/internal/proxy/turnloop.go
@@ -353,16 +353,23 @@ func (s *Service) runTurnLoop(
 				pin = sessionpin.Pin{}
 			} else {
 				// Pre-filter was overly conservative — pin model fits.
-				// Remove it from ExcludedModels so the scorer can also
-				// consider it when fresh routing runs this turn.
-				if len(req.ExcludedModels) > 0 {
-					pruned := make(map[string]struct{}, len(req.ExcludedModels)-1)
-					for k := range req.ExcludedModels {
-						if k != pin.Model {
-							pruned[k] = struct{}{}
+				// Remove it from ExcludedModels only if it was added
+				// exclusively by the context-overflow filter, NOT by an
+				// operator/installation policy exclusion. Policy exclusions
+				// are a hard operator constraint; lifting them here would
+				// let sticky routing bypass an operator-excluded model on
+				// the very turns where the context window happens to fit.
+				policyExcluded := s.excludedModelsForRequest(ctx)
+				if _, policyExcludes := policyExcluded[pin.Model]; !policyExcludes {
+					if len(req.ExcludedModels) > 0 {
+						pruned := make(map[string]struct{}, len(req.ExcludedModels)-1)
+						for k := range req.ExcludedModels {
+							if k != pin.Model {
+								pruned[k] = struct{}{}
+							}
 						}
+						req.ExcludedModels = pruned
 					}
-					req.ExcludedModels = pruned
 				}
 				log.Info("Session pin preserved despite context-window pre-filter exclusion",
 					"pin_model", pin.Model,


### PR DESCRIPTION
## Problem

The context-window pre-filter uses `body_bytes÷5` as a conservative token estimate. When it adds a model to `ExcludedModels`, the pin guard in `runTurnLoop` drops the pin unconditionally — even when the model's actual context window is large enough to fit the request.

This can cause an unnecessary mid-session model switch when:
- The session is at e.g. 165k estimated tokens
- The pinned model has a 1M context window (fits comfortably)
- But `estimate + output_reserve` overshoots a smaller model in the pool, and the pre-filter overzealously adds even the large-window model to `ExcludedModels`

## Solution

Before evicting the pin, verify the fit directly: recompute `needed = FullTokenEstimate() + outputReserve` and compare against `contextWindowForRequest(pin.Model, false)`. Only evict if the model genuinely doesn't fit.

If the model fits, preserve the pin **and** remove it from `ExcludedModels` so the scorer considers it too on the fresh routing decision.

Confirmed overflow still evicts. Added log fields (`token_estimate`, `needed`, `model_context_window`) to both paths for auditability.

## What changes

- `internal/proxy/turnloop.go`: expand the context-window pin guard from a simple map-lookup drop to a direct fit-check with conditional pruning of `ExcludedModels`

🤖 Generated with [Claude Code](https://claude.com/claude-code)