### PR TITLE
fix(proxy): exclude Google provider for Claude Code sessions

### DIFF
--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -1103,6 +1103,14 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 	// Anthropic packs sub-agent identity into metadata.user_id; the
 	// x-weave-subagent-type header is for non-Anthropic ingress only.
 	enabledProviders := s.enabledProvidersForRequest(ctx, providers.ProviderAnthropic, r.Header)
+	// Claude Code sessions: remove Google from the eligible provider set.
+	// Gemini models consistently underperform on long agentic CC coding
+	// sessions — producing micro tool-call responses (16–43 tokens/turn)
+	// and degenerate empty completions. CC is identified by the x-app or
+	// user-agent header resolving to ClientAppClaudeCode via NormalizeClientApp.
+	if clientID.ClientApp == ClientAppClaudeCode {
+		delete(enabledProviders, providers.ProviderGoogle)
+	}
 
 	// Pre-filter models whose context window cannot fit this request.
 	// FullTokenEstimate uses raw body bytes (÷5) to capture tool definitions,
@@ -2334,6 +2342,9 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 	subAgentHint := r.Header.Get("x-weave-subagent-type")
 
 	enabledProviders := s.enabledProvidersForRequest(ctx, providers.ProviderOpenAI, r.Header)
+	if clientID.ClientApp == ClientAppClaudeCode {
+		delete(enabledProviders, providers.ProviderGoogle)
+	}
 
 	// Pre-filter models whose context window cannot fit this request.
 	outputReserveOAI := contextWindowOutputReserve


### PR DESCRIPTION
## Problem

Gemini models perform poorly on long agentic Claude Code sessions. In session `354ee849`:
- Session was on gpt-5.5 for 10 min, making real progress (fix applied at mc=28–30)
- Pin expired → scorer picked `gemini-3.1-pro-preview`
- Gemini issued 16–43 output-token tool calls for ~16 more turns without producing readable text
- Final turn: 5-token `end_turn` with 0 tool calls — fully degenerate

Gemini is a strong model generally, but not for this workload. Removing it from the cluster entirely (PR #404, closed) was too broad. This PR is harness-scoped.

## Solution

After `enabledProvidersForRequest` runs, delete `providers.ProviderGoogle` from the eligible set when `clientID.ClientApp == ClientAppClaudeCode`.

Detection relies on the existing `NormalizeClientApp` logic: Claude Code sends `x-app: cli` or `x-app: cli-bg`, both of which map to `ClientAppClaudeCode`. The deletion is a no-op if Google wasn't in the set (BYOK-only, self-hosted without Google creds, etc.).

## What changes

- `service.go`: 4-line guard in `ProxyMessages` (Anthropic surface, CC's primary path) and 3-line guard in `ProxyOpenAIChatCompletion` (belt-and-suspenders)

## Interaction with other PRs

- Works alongside #400 (degenerate eviction) — belt-and-suspenders for sessions that somehow reach Gemini
- Works alongside #402 (pin expiry hysteresis) — prevents the expiry-switch from landing on Gemini in the first place
- Gemini remains available for non-CC traffic (web, API, other harnesses)

🤖 Generated with [Claude Code](https://claude.com/claude-code)