### PR TITLE
fix(frontend): add trailing periods to data-load error messages

### DIFF
--- a/frontend/src/app/(app)/dashboard/page.tsx
+++ b/frontend/src/app/(app)/dashboard/page.tsx
@@ -54,7 +54,7 @@ export default function DashboardPage() {
       })
       .catch((err: unknown) => {
         if (cancelled) return;
-        setError(err instanceof Error ? err.message : "Failed to load metrics");
+        setError(err instanceof Error ? err.message : "Failed to load metrics.");
       });
     return () => {
       cancelled = true;

--- a/frontend/src/app/(app)/settings/page.tsx
+++ b/frontend/src/app/(app)/settings/page.tsx
@@ -151,7 +151,7 @@ function RouterKeysPanel() {
         setLoaded(true);
       })
       .catch((err: unknown) => {
-        setError(err instanceof Error ? err.message : "Failed to load keys");
+        setError(err instanceof Error ? err.message : "Failed to load keys.");
         setLoaded(true);
       });
   }
@@ -167,7 +167,7 @@ function RouterKeysPanel() {
       setName("");
       load();
     } catch (err: unknown) {
-      setError(err instanceof Error ? err.message : "Failed to create key");
+      setError(err instanceof Error ? err.message : "Failed to create key.");
     } finally {
       setCreating(false);
     }
@@ -184,7 +184,7 @@ function RouterKeysPanel() {
       setNewToken(res.token);
       load();
     } catch (err: unknown) {
-      setError(err instanceof Error ? err.message : "Failed to rotate key");
+      setError(err instanceof Error ? err.message : "Failed to rotate key.");
     } finally {
       setRotating(null);
     }
@@ -200,7 +200,7 @@ function RouterKeysPanel() {
       await api.keys.delete(id);
       load();
     } catch (err: unknown) {
-      setError(err instanceof Error ? err.message : "Failed to delete key");
+      setError(err instanceof Error ? err.message : "Failed to delete key.");
     } finally {
       setDeleting(null);
     }
@@ -366,7 +366,7 @@ function ProviderKeysPanel() {
       .list()
       .then(r => setKeys(r.keys ?? []))
       .catch((err: unknown) =>
-        setError(err instanceof Error ? err.message : "Failed to load keys"),
+        setError(err instanceof Error ? err.message : "Failed to load keys."),
       );
   }
 
@@ -417,7 +417,7 @@ function ProviderKeysPanel() {
       await api.providerKeys.delete(id);
       load();
     } catch (err: unknown) {
-      setError(err instanceof Error ? err.message : "Failed to delete key");
+      setError(err instanceof Error ? err.message : "Failed to delete key.");
     } finally {
       setDeleting(null);
     }
@@ -650,7 +650,7 @@ function ConfigPanel() {
       .get()
       .then(setConfig)
       .catch((err: unknown) =>
-        setError(err instanceof Error ? err.message : "Failed to load config"),
+        setError(err instanceof Error ? err.message : "Failed to load config."),
       );
   }, []);
 
@@ -709,7 +709,7 @@ function ModelSelectionPanel() {
         setEnvOverrideActive(res.env_override_active);
       })
       .catch((err: unknown) =>
-        setError(err instanceof Error ? err.message : "Failed to load models"),
+        setError(err instanceof Error ? err.message : "Failed to load models."),
       );
   }, []);
 
@@ -844,7 +844,7 @@ function ProviderSelectionPanel() {
         setEnvOverrideActive(res.env_override_active);
       })
       .catch((err: unknown) =>
-        setError(err instanceof Error ? err.message : "Failed to load providers"),
+        setError(err instanceof Error ? err.message : "Failed to load providers."),
       );
   }, []);
 

--- a/frontend/src/components/charts/DrillDownModal.tsx
+++ b/frontend/src/components/charts/DrillDownModal.tsx
@@ -180,7 +180,7 @@ export function DrillDownModal({
       })
       .catch((err: unknown) => {
         if (cancelled) return;
-        setError(err instanceof Error ? err.message : "Failed to load details");
+        setError(err instanceof Error ? err.message : "Failed to load details.");
       })
       .finally(() => {
         if (cancelled) return;


### PR DESCRIPTION
## Summary
- Inline error fallbacks on the dashboard, settings, and drill-down modal ("Failed to load keys", "Failed to create key", etc.) were missing terminal punctuation, unlike the rest of the UI's error copy.
- Adds trailing periods so sentence-style error banners read consistently.

Scope is punctuation only; the two vague `Failed to save` strings are intentionally left for a follow-up PR that rewrites them with specific subjects.

## Test plan
- [ ] Trigger a load failure (e.g. revoke admin cookie) and confirm the error banner reads `Failed to load keys.`

Made with [Cursor](https://cursor.com)