### PR TITLE
fix(frontend): give vague "Failed to save" errors a specific subject

### DIFF
--- a/frontend/src/app/(app)/settings/page.tsx
+++ b/frontend/src/app/(app)/settings/page.tsx
@@ -736,7 +736,7 @@ function ModelSelectionPanel() {
       setExcluded(ex);
       setSavedExcluded(ex);
     } catch (err: unknown) {
-      setError(err instanceof Error ? err.message : "Failed to save");
+      setError(err instanceof Error ? err.message : "Failed to save excluded models.");
     } finally {
       setSaving(false);
     }
@@ -871,7 +871,7 @@ function ProviderSelectionPanel() {
       setExcluded(ex);
       setSavedExcluded(ex);
     } catch (err: unknown) {
-      setError(err instanceof Error ? err.message : "Failed to save");
+      setError(err instanceof Error ? err.message : "Failed to save excluded providers.");
     } finally {
       setSaving(false);
     }


### PR DESCRIPTION
## Summary
- The excluded-models and excluded-providers settings panels both fell back to a bare `Failed to save` on error, leaving the user unable to tell which save failed.
- Names the subject (`Failed to save excluded models.` / `Failed to save excluded providers.`) and adds terminal punctuation.

## Test plan
- [ ] Force a save failure on the excluded-models panel and confirm the banner reads `Failed to save excluded models.`

Made with [Cursor](https://cursor.com)