### PR TITLE
fix(frontend): tidy tooltips on settings + sidebar

### DIFF
--- a/frontend/src/app/(app)/settings/page.tsx
+++ b/frontend/src/app/(app)/settings/page.tsx
@@ -312,7 +312,7 @@ function RouterKeysPanel() {
                       size="icon"
                       onClick={() => handleDelete(k.id)}
                       disabled={deleting === k.id || rotating != null}
-                      title="Revoke key"
+                      title="Revoke key."
                     >
                       <Trash2 className="size-3.5" />
                     </Button>
@@ -508,7 +508,7 @@ function ProviderKeysPanel() {
                     intent={Intent.Danger}
                     size="icon"
                     disabled
-                    title="Unset the env var and restart the router to remove"
+                    title="Unset the env var and restart the router to remove."
                   >
                     <Trash2 className="size-3.5" />
                   </Button>
@@ -535,6 +535,7 @@ function ProviderKeysPanel() {
                     size="icon"
                     onClick={() => handleDelete(k.id)}
                     disabled={deleting === k.id}
+                    title="Revoke key."
                   >
                     <Trash2 className="size-3.5" />
                   </Button>

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -77,7 +77,6 @@ export function Sidebar() {
             href="/settings"
             appearance={Appearance.Hollow}
             className={sidebarFooterButton}
-            title="Settings"
           >
             <Settings className="size-4" />
           </Button>
@@ -87,7 +86,6 @@ export function Sidebar() {
           <Button
             appearance={Appearance.Hollow}
             className={sidebarFooterButton}
-            title="Sign out"
             onClick={() => {
               void handleSignOut();
             }}


### PR DESCRIPTION
## Summary
- Add terminal periods to the `Revoke key` and `Unset the env var…` button tooltips.
- Add a missing `Revoke key.` tooltip to the icon-only delete button on the provider-keys table (previously unlabeled).
- Drop the redundant native `title=` on the Settings and Sign out sidebar buttons, which already have a custom `<Tooltip>` wrapper — Safari renders both, producing a double tooltip.

## Test plan
- [ ] Hover the sidebar Settings/Sign out buttons in Safari and confirm only one tooltip shows.
- [ ] Confirm the provider-key delete button now shows a `Revoke key.` tooltip.

Made with [Cursor](https://cursor.com)