### PR TITLE
fix(frontend): unify "Login" → "Sign in" on the auth page

### DIFF
--- a/frontend/src/app/(auth)/login/page.tsx
+++ b/frontend/src/app/(auth)/login/page.tsx
@@ -47,9 +47,9 @@ function LoginInner() {
       await api.auth.login(password);
       router.replace(next);
     } catch (err: unknown) {
-      const message = err instanceof Error ? err.message : "Login failed";
+      const message = err instanceof Error ? err.message : "Sign-in failed.";
       if (message.includes("503")) {
-        setError("Admin login is disabled. Set ROUTER_ADMIN_PASSWORD on the router and restart.");
+        setError("Admin sign-in is disabled. Set ROUTER_ADMIN_PASSWORD on the router and restart.");
       } else if (message.includes("401")) {
         setError("Wrong password.");
       } else {


### PR DESCRIPTION
## Summary
- The login page header, CTA, and submit button all say "Sign in", but the error fallbacks said "Login failed" / "Admin login is disabled".
- Aligns the error copy (`Sign-in failed.`, `Admin sign-in is disabled.`) so the page uses one consistent term, and adds a terminal period to the generic failure fallback.

## Test plan
- [ ] Trigger a 503 on the login page and confirm the error reads `Admin sign-in is disabled.`

Made with [Cursor](https://cursor.com)