### PR TITLE
fix(translate): flatten OpenAI parts-array assistant content on tool-call turns

### DIFF
--- a/internal/translate/crossformat_request_test.go
+++ b/internal/translate/crossformat_request_test.go
@@ -83,6 +83,26 @@ var openAIAssistantTextAndToolCalls = []byte(`{
 	"max_tokens": 1024
 }`)
 
+// openAIAssistantArrayContentAndToolCalls mirrors openAIAssistantTextAndToolCalls
+// but carries assistant content as an OpenAI parts array (the shape Cursor sends)
+// rather than a plain string. The array form must flatten to the inner text, not
+// be serialized verbatim into the Anthropic text block.
+var openAIAssistantArrayContentAndToolCalls = []byte(`{
+	"model": "gpt-4",
+	"messages": [
+		{"role": "user", "content": "Search for recent PRs"},
+		{"role": "assistant", "content": [{"type": "text", "text": "Let me search for that."}], "tool_calls": [
+			{"id": "call_search", "type": "function", "function": {"name": "search_prs", "arguments": "{\"query\":\"recent\"}"}}
+		]},
+		{"role": "tool", "tool_call_id": "call_search", "content": "Found 3 PRs"},
+		{"role": "user", "content": "Tell me about PR #1"}
+	],
+	"tools": [
+		{"type": "function", "function": {"name": "search_prs", "description": "Search PRs", "parameters": {"type": "object", "properties": {"query": {"type": "string"}}, "required": ["query"]}}}
+	],
+	"max_tokens": 1024
+}`)
+
 var openAIEmptyToolArgs = []byte(`{
 	"model": "gpt-4",
 	"messages": [
@@ -375,6 +395,37 @@ func TestCrossFormat_OpenAIToAnthropic_AssistantTextAndToolCalls(t *testing.T) {
 	textBlock := blocks[0].(map[string]any)
 	assert.Equal(t, "text", textBlock["type"])
 	assert.Equal(t, "Let me search for that.", textBlock["text"])
+	toolBlock := blocks[1].(map[string]any)
+	assert.Equal(t, "tool_use", toolBlock["type"])
+	assert.Equal(t, "search_prs", toolBlock["name"])
+}
+
+// TestCrossFormat_OpenAIToAnthropic_AssistantArrayContentAndToolCalls guards the
+// regression where an assistant message carrying tool_calls plus parts-array
+// content (the shape Cursor sends) had its content array serialized verbatim into
+// the Anthropic text block via gjson .String(). That produced a stringified
+// {"type":"text",...} block that the model echoed and compounded one level per
+// agentic turn, yielding deeply nested garbage on the client.
+func TestCrossFormat_OpenAIToAnthropic_AssistantArrayContentAndToolCalls(t *testing.T) {
+	env, err := translate.ParseOpenAI(openAIAssistantArrayContentAndToolCalls)
+	require.NoError(t, err)
+
+	prep, err := env.PrepareAnthropic(http.Header{}, translate.EmitOptions{TargetModel: "claude-sonnet-4-20250514"})
+	require.NoError(t, err)
+
+	doc := unmarshalBody(t, prep.Body)
+	msgs := getArray(t, doc, "messages")
+
+	assistantMsg := msgAt(t, msgs, 1)
+	assert.Equal(t, "assistant", assistantMsg["role"])
+	blocks := assistantMsg["content"].([]any)
+	require.Len(t, blocks, 2, "text block + tool_use block")
+	textBlock := blocks[0].(map[string]any)
+	assert.Equal(t, "text", textBlock["type"])
+	// Must flatten to the inner text, not the serialized parts array.
+	assert.Equal(t, "Let me search for that.", textBlock["text"])
+	assert.NotContains(t, textBlock["text"].(string), `"type":"text"`,
+		"parts array must not be serialized verbatim into the text block")
 	toolBlock := blocks[1].(map[string]any)
 	assert.Equal(t, "tool_use", toolBlock["type"])
 	assert.Equal(t, "search_prs", toolBlock["name"])

--- a/internal/translate/emit_anthropic.go
+++ b/internal/translate/emit_anthropic.go
@@ -311,9 +311,13 @@ func buildAnthropicAssistantMessage(msg gjson.Result) string {
 	}
 
 	// Has tool calls: build content array with optional text prefix + tool_use blocks.
+	// Content may be a plain string or an OpenAI parts array ([{"type":"text",...}]);
+	// openAIContentTextGJSON flattens both. Using gjson's .String() here would
+	// serialize a parts array into the text field verbatim, wrapping it in a
+	// stringified {"type":"text",...} block that compounds on every agentic turn.
 	jw.Key("content")
 	jw.Arr()
-	if text := msg.Get("content").String(); text != "" {
+	if text := openAIContentTextGJSON(msg.Get("content")); text != "" {
 		jw.Obj()
 		jw.Key("type")
 		jw.Str("text")


### PR DESCRIPTION
## Symptom

Cursor users in prod see assistant output degrade into deeply-nested, escalating-escape JSON:

```
[{"type":"text","text":"[{"type":"text","text":"[{\"type\":\"text\",\"text\":\"[{\\\"type\\\"...
```

## Root cause

`buildAnthropicAssistantMessage` (the OpenAI→Anthropic request converter) handles assistant messages **with `tool_calls`** by reading content as:

```go
if text := msg.Get("content").String(); text != "" { ... }
```

Cursor (OpenAI-format inbound) sends assistant `content` as a **parts array** — `[{"type":"text","text":"..."}]` — not a string. `gjson.Result.String()` on an array returns the raw `[{...}]` JSON verbatim, which we then emit as a single Anthropic text block. So on every Cursor agentic turn (assistant content array + tool_calls, routed cross-format to Anthropic) we feed the upstream model a stringified `{"type":"text",...}` block.

The model echoes that shape on some turns; the client stores and resends it, and the bug re-wraps it again next turn — compounding one nesting level per turn into the garbage above. The no-tool-call branch was already correct (it uses `writeAnthropicContentValue`, which walks the parts); only the tool-call branch regressed to `.String()`.

## Evidence (prod)

`router_plugin_calls` for the affected org: corrupted bodies are all `client_app=cursor`, `decision_provider=anthropic` (opus-4-7/4-8), `cross_format=true`, `turn_type=tool_result`. The request bodies are OpenAI-format and contain the assistant node `{"role":"assistant","content":[{"type":"text","text":"[{\"type\":\"text\"...}]"}],"tool_calls":[...]}` nested 4 levels deep around one real sentence. Our response stream for those calls is clean — the corruption is in the history the client resends, seeded by what we send upstream.

## Fix

Use `openAIContentTextGJSON` (the existing helper the no-tool-call branch already uses) to flatten string-or-array content before emitting the text prefix block.

## Test

Adds `TestCrossFormat_OpenAIToAnthropic_AssistantArrayContentAndToolCalls`: assistant message with a parts-array content + tool_calls must flatten to the inner text, not the serialized array. Verified it fails on the old code (`actual: "[{\"type\": \"text\", \"text\": \"Let me search for that.\"}]"`) and passes with the fix. Full `internal/translate` package green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)