### PR TITLE
fix(frontend): use "Weave Router" for logo alt text

### DIFF
--- a/frontend/src/app/(auth)/login/page.tsx
+++ b/frontend/src/app/(auth)/login/page.tsx
@@ -64,7 +64,7 @@ function LoginInner() {
     <div className="w-full max-w-sm rounded-lg border border-border-darker bg-background p-6 shadow-sm">
       <div className="mb-6 flex items-center gap-3">
         {/* eslint-disable-next-line @next/next/no-img-element */}
-        <img src="/ui/weave.svg" alt="Weave" width={32} height={32} className="size-8 rounded-lg" />
+        <img src="/ui/weave.svg" alt="Weave Router" width={32} height={32} className="size-8 rounded-lg" />
         <div>
           <h1 className="font-display text-base font-semibold text-foreground">Weave Router</h1>
           <p className="text-2xs text-muted-foreground">Sign in to the dashboard</p>

--- a/frontend/src/components/Logo.tsx
+++ b/frontend/src/components/Logo.tsx
@@ -13,7 +13,7 @@ export function Logo({ href = "/" }: LogoProps) {
   return (
     <Link href={href} className="inline-flex shrink-0" aria-label="Weave Router">
       {/* eslint-disable-next-line @next/next/no-img-element */}
-      <img src={LOGO_SRC} alt="Weave" width={32} height={32} className="size-8 shrink-0 grow-0 rounded-lg" />
+      <img src={LOGO_SRC} alt="Weave Router" width={32} height={32} className="size-8 shrink-0 grow-0 rounded-lg" />
     </Link>
   );
 }


### PR DESCRIPTION
## Summary
- The logo link is labeled `aria-label="Weave Router"` but the inner `<img>` had `alt="Weave"`, giving screen readers and search a less specific brand name.
- Aligns the `alt` text on both the sidebar logo and the login page logo to `Weave Router`.

## Test plan
- [ ] Inspect the rendered logo `<img>` and confirm `alt="Weave Router"`.

Made with [Cursor](https://cursor.com)