### PR TITLE
fix(frontend): use the ellipsis character in user-visible strings

### DIFF
--- a/frontend/src/app/(app)/settings/page.tsx
+++ b/frontend/src/app/(app)/settings/page.tsx
@@ -445,7 +445,7 @@ function ProviderKeysPanel() {
                   data-1p-ignore
                   data-lpignore="true"
                   data-form-type="other"
-                  placeholder="sk-..."
+                  placeholder="sk-…"
                   value={keyValue}
                   onChange={e => setKeyValue(e.target.value)}
                   required

--- a/frontend/src/components/Chart/ChartLegend.tsx
+++ b/frontend/src/components/Chart/ChartLegend.tsx
@@ -10,7 +10,7 @@ const LEGEND_TEXT_MAX_LENGTH = 40;
 
 function truncateText(text: string, maxLength: number): string {
   if (text.length <= maxLength) return text;
-  return text.slice(0, maxLength - 3) + "...";
+  return text.slice(0, maxLength - 1) + "…";
 }
 
 export interface ChartLegendProps extends React.HTMLAttributes<HTMLDivElement> {


### PR DESCRIPTION
## Summary
- The UI standardizes on `…` (e.g. `Saving…`, `Loading…`), but two strings still used three ASCII dots.
- Converts the API-key placeholder `sk-...` and the chart-legend truncation suffix to `…`.
- Updates the legend's reserved width from `maxLength - 3` to `maxLength - 1` to match the single-character ellipsis, so truncated labels keep their intended length.

## Test plan
- [ ] Render a chart with a long legend label and confirm it truncates with `…` at the same visible length.

Made with [Cursor](https://cursor.com)