### PR TITLE
fix(frontend): clearer admin-password placeholder

### DIFF
--- a/frontend/src/app/(auth)/login/page.tsx
+++ b/frontend/src/app/(auth)/login/page.tsx
@@ -83,7 +83,7 @@ function LoginInner() {
           autoFocus
           value={password}
           onChange={(e) => setPassword(e.target.value)}
-          placeholder="ROUTER_ADMIN_PASSWORD"
+          placeholder="Value of ROUTER_ADMIN_PASSWORD"
           required
         />
         {error && (


### PR DESCRIPTION
## Summary
- The login input placeholder was a bare `ROUTER_ADMIN_PASSWORD`, shouting an env-var name into the field.
- The field already carries an `Admin password` label, so the placeholder now hints at what to type: `Value of ROUTER_ADMIN_PASSWORD`.

## Test plan
- [ ] Open the login page and confirm the password field shows the new placeholder.

Made with [Cursor](https://cursor.com)