### PR TITLE
Capitalize genprices CLI output and error prefix

### DIFF
--- a/cmd/genprices/main.go
+++ b/cmd/genprices/main.go
@@ -32,10 +32,10 @@ func main() {
 	block := buildBlock(otel.AllPricing())
 	for _, path := range scriptPaths {
 		if err := spliceFile(path, block); err != nil {
-			fmt.Fprintf(os.Stderr, "error: %v\n", err)
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 			os.Exit(1)
 		}
-		fmt.Printf("wrote %s\n", path)
+		fmt.Printf("Wrote %s\n", path)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Sentence-case the stderr `Error:` prefix and the `Wrote <path>` success line in `cmd/genprices` to match the convention used by `cmd/seed` and `cmd/initdb`.

## Notes
- The wrapped error string (`reading %s: %w`) stays lowercase per Go convention (`ST1005`); it reads cleanly after the capitalized `Error:` prefix.

Made with [Cursor](https://cursor.com)