### PR TITLE
Sentence-case cmd/router startup error prefixes

### DIFF
--- a/cmd/router/main.go
+++ b/cmd/router/main.go
@@ -94,7 +94,7 @@ func main() {
 	switch deploymentMode {
 	case server.DeploymentModeSelfHosted, server.DeploymentModeManaged:
 	default:
-		err := fmt.Errorf("invalid ROUTER_DEPLOYMENT_MODE %q (expected %q or %q)", deploymentMode, server.DeploymentModeSelfHosted, server.DeploymentModeManaged)
+		err := fmt.Errorf("Invalid ROUTER_DEPLOYMENT_MODE %q (expected %q or %q)", deploymentMode, server.DeploymentModeSelfHosted, server.DeploymentModeManaged)
 		logger.Error("Refusing to boot with invalid deployment mode", "err", err)
 		panic(err)
 	}
@@ -782,7 +782,7 @@ func buildClusterScorer(availableProviders map[string]struct{}) (router.Router, 
 	requestedVersion := config.GetOr("ROUTER_CLUSTER_VERSION", cluster.LatestVersion)
 	defaultVersion, err := cluster.ResolveVersion(requestedVersion)
 	if err != nil {
-		return nil, fmt.Errorf("resolve cluster version %q: %w", requestedVersion, err)
+		return nil, fmt.Errorf("Resolve cluster version %q: %w", requestedVersion, err)
 	}
 
 	// Default to building only the served version. Staging/eval deployments
@@ -796,7 +796,7 @@ func buildClusterScorer(availableProviders map[string]struct{}) (router.Router, 
 	if buildAll {
 		versions, err = cluster.ListVersions()
 		if err != nil {
-			return nil, fmt.Errorf("list cluster versions: %w", err)
+			return nil, fmt.Errorf("List cluster versions: %w", err)
 		}
 	} else {
 		versions = []string{defaultVersion}
@@ -832,7 +832,7 @@ func buildClusterScorer(availableProviders map[string]struct{}) (router.Router, 
 		bundle, err := cluster.LoadBundle(v)
 		if err != nil {
 			_ = embedders.Close()
-			return nil, fmt.Errorf("load bundle %s: %w", v, err)
+			return nil, fmt.Errorf("Load bundle %s: %w", v, err)
 		}
 
 		missingProviders := map[string][]string{}
@@ -859,7 +859,7 @@ func buildClusterScorer(availableProviders map[string]struct{}) (router.Router, 
 			// versions degrade like any other per-version build failure.
 			if v == defaultVersion {
 				_ = embedders.Close()
-				return nil, fmt.Errorf("construct embedder %q for default cluster version %s: %w", bundle.EmbedderID(), v, err)
+				return nil, fmt.Errorf("Construct embedder %q for default cluster version %s: %w", bundle.EmbedderID(), v, err)
 			}
 			logger.Warn("Cluster scorer version skipped; embedder unavailable", "cluster_version", v, "embedder", bundle.EmbedderID(), "err", err)
 			continue
@@ -877,13 +877,13 @@ func buildClusterScorer(availableProviders map[string]struct{}) (router.Router, 
 
 	if _, ok := scorers[defaultVersion]; !ok {
 		_ = embedders.Close()
-		return nil, fmt.Errorf("default cluster version %q failed to build (likely no registered provider covers its deployed_models); set ROUTER_CLUSTER_VERSION to a version that does, or register the missing provider key", defaultVersion)
+		return nil, fmt.Errorf("Default cluster version %q failed to build (likely no registered provider covers its deployed_models); set ROUTER_CLUSTER_VERSION to a version that does, or register the missing provider key", defaultVersion)
 	}
 
 	multi, err := cluster.NewMultiversion(defaultVersion, scorers)
 	if err != nil {
 		_ = embedders.Close()
-		return nil, fmt.Errorf("build multiversion router: %w", err)
+		return nil, fmt.Errorf("Build multiversion router: %w", err)
 	}
 	logger.Info(
 		"Cluster multiversion router ready",
@@ -908,7 +908,7 @@ func buildClusterScorer(availableProviders map[string]struct{}) (router.Router, 
 		case res := <-warmupDone:
 			if res.err != nil {
 				_ = embedders.Close()
-				return nil, fmt.Errorf("warm embedder %q: %w", id, res.err)
+				return nil, fmt.Errorf("Warm embedder %q: %w", id, res.err)
 			}
 		case <-time.After(15 * time.Second):
 			// Drain the goroutine before closing to avoid use-after-free.
@@ -916,7 +916,7 @@ func buildClusterScorer(availableProviders map[string]struct{}) (router.Router, 
 				<-warmupDone
 				_ = embedders.Close()
 			}()
-			return nil, fmt.Errorf("cluster embedder %q warmup timed out after 15s", id)
+			return nil, fmt.Errorf("Cluster embedder %q warmup timed out after 15s", id)
 		}
 		logger.Info("Cluster embedder warmed", "embedder", id, "embed_dim", embedder.Dim())
 	}


### PR DESCRIPTION
## Summary
- Sentence-case the leading word of the 9 `fmt.Errorf` prefixes in `buildClusterScorer` (and the deployment-mode check) in `cmd/router/main.go`.

## Why
- These errors are `panic(err)`'d verbatim to stderr on boot failure (and surfaced in the structured `Cluster scorer failed to build` log). The bare string is the first thing an operator sees in the panic dump, so it should read as a proper sentence.

## Notes
- Confirmed no test asserts on these strings (`*_test.go` grep across the repo is clean), so capitalizing the prefix is safe.

Made with [Cursor](https://cursor.com)