### PR TITLE
Sentence-case dev-script CLI output

### DIFF
--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -8,7 +8,7 @@ cd "$(git rev-parse --show-toplevel)"
 echo "==> gofmt"
 UNFORMATTED=$(gofmt -l .)
 if [ -n "$UNFORMATTED" ]; then
-    echo "error: Go files are not formatted. Run 'gofmt -w .'"
+    echo "Error: Go files are not formatted. Run 'gofmt -w .'"
     echo "$UNFORMATTED"
     exit 1
 fi

--- a/scripts/record_provider_fixtures/main.go
+++ b/scripts/record_provider_fixtures/main.go
@@ -74,7 +74,7 @@ const weatherTool = `[{"name":"get_weather","description":"Get the weather","inp
 
 func main() {
 	if os.Getenv("RECORD") != "1" {
-		fmt.Println("refusing to hit live providers without RECORD=1 (see file header for usage)")
+		fmt.Println("Refusing to hit live providers without RECORD=1 (see file header for usage)")
 		return
 	}
 	client := &http.Client{Timeout: 180 * time.Second}


### PR DESCRIPTION
## Summary
- `scripts/pre-commit`: `error:` → `Error:` on the gofmt failure line.
- `scripts/record_provider_fixtures`: capitalize the `Refusing to hit live providers…` guard message.

## Notes
- Developer-facing dev scripts, low risk.
- Left the `fmt.Errorf` wrapped errors lowercase — they print after a `FAIL  <fixture>:` prefix, so lowercase reads correctly and matches Go convention.

Made with [Cursor](https://cursor.com)