### PR TITLE
Capitalize config MustGet panic message

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -9,7 +9,7 @@ import (
 func MustGet(key string) string {
 	v := os.Getenv(key)
 	if v == "" {
-		panic(fmt.Sprintf("missing required env var: %s", key))
+		panic(fmt.Sprintf("Missing required env var: %s", key))
 	}
 	return v
 }


### PR DESCRIPTION
## Summary
- Sentence-case the `Missing required env var: %s` panic in `internal/config.MustGet`, which is printed verbatim to stderr on a missing-env boot failure.

## Notes
- No test asserts on this string.

Made with [Cursor](https://cursor.com)