### PR TITLE
Fix OTel casing in span-ID panic messages

### DIFF
--- a/internal/observability/otel/spans.go
+++ b/internal/observability/otel/spans.go
@@ -20,7 +20,7 @@ type Span struct {
 func generateTraceID() [16]byte {
 	var id [16]byte
 	if _, err := rand.Read(id[:]); err != nil {
-		panic("otel: crypto/rand failed: " + err.Error())
+		panic("OTel: crypto/rand failed: " + err.Error())
 	}
 	return id
 }
@@ -28,7 +28,7 @@ func generateTraceID() [16]byte {
 func generateSpanID() [8]byte {
 	var id [8]byte
 	if _, err := rand.Read(id[:]); err != nil {
-		panic("otel: crypto/rand failed: " + err.Error())
+		panic("OTel: crypto/rand failed: " + err.Error())
 	}
 	return id
 }


### PR DESCRIPTION
## Summary
- `internal/observability/otel/spans.go`: `otel:` → `OTel:` in the two `crypto/rand failed` panic messages, matching the product casing used elsewhere in the codebase.

Made with [Cursor](https://cursor.com)