### PR TITLE
Polish force-model ack copy

### DIFF
--- a/internal/proxy/force_model.go
+++ b/internal/proxy/force_model.go
@@ -281,16 +281,16 @@ func (s *Service) handleForceModelCommand(
 			"session_key_hex", fmt.Sprintf("%x", sessionKey),
 			"role", role,
 		)
-		msg = fmt.Sprintf("✦ **Weave Router** → force-model: %q isn't a recognized model · keeping automatic routing. Use a full model id, e.g. claude-opus-4-8, gpt-5.5, or gemini-3-pro-preview.\n\n", cmd.Model)
+		msg = fmt.Sprintf("✦ **Weave Router** → force-model: %q isn't a recognized model · keeping automatic routing. Use a full model ID, e.g. claude-opus-4-8, gpt-5.5, or gemini-3-pro-preview.\n\n", cmd.Model)
 		if env.SourceFormat() == translate.FormatOpenAI {
-			msg = fmt.Sprintf("Weave Router: force-model: %q isn't a recognized model; keeping automatic routing. Use a full model id, e.g. claude-opus-4-8, gpt-5.5, or gemini-3-pro-preview.", cmd.Model)
+			msg = fmt.Sprintf("Weave Router: force-model: %q isn't a recognized model; keeping automatic routing. Use a full model ID, e.g. claude-opus-4-8, gpt-5.5, or gemini-3-pro-preview.", cmd.Model)
 		}
 	} else {
 		if err := s.setForceModelPin(ctx, sessionKey, role, installationID, canonicalModel, provider); err != nil {
 			log.Error("/force-model: pin store upsert failed", "err", err)
 			return err
 		}
-		msg = fmt.Sprintf("✦ **Weave Router** → force-model applied: %s (%s) · use /unforce-model to clear\n\n", canonicalModel, provider)
+		msg = fmt.Sprintf("✦ **Weave Router** → force-model applied: %s (%s) · Use /unforce-model to clear\n\n", canonicalModel, provider)
 		if env.SourceFormat() == translate.FormatOpenAI {
 			msg = fmt.Sprintf("Weave Router: force-model applied: %s (%s). Use /unforce-model to clear.", canonicalModel, provider)
 		}


### PR DESCRIPTION
## Summary
- `model id` → `model ID` (acronym) in the unrecognized-model acknowledgement (both the Anthropic and OpenAI variants).
- `· use /unforce-model` → `· Use /unforce-model` in the applied acknowledgement.

## Safety
- The installed `cc-statusline.sh` parser only `test()`s for `force-model applied:` and `isn't a recognized model`, and captures the model token via `force-model applied: (?<m>[^ ]+)` (stops at the first space). Neither edited substring (`model ID`, `· Use`) participates in those matches, so pin detection is unaffected.
- No Go test asserts on these strings.

Made with [Cursor](https://cursor.com)