### PR TITLE
Make unknown-flag errors actionable

### DIFF
--- a/install/install.sh
+++ b/install/install.sh
@@ -863,7 +863,7 @@ while [ $# -gt 0 ]; do
       usage 0
       ;;
     *)
-      err "unknown flag: $1"; usage 2
+      err "Unknown flag: $1."; usage 2
       ;;
   esac
 done

--- a/install/uninstall.sh
+++ b/install/uninstall.sh
@@ -78,7 +78,7 @@ while [ $# -gt 0 ]; do
       exit 0
       ;;
     *)
-      err "unknown flag: $1"; exit 2
+      err "Unknown flag: $1. Run --help for usage."; exit 2
       ;;
   esac
 done


### PR DESCRIPTION
## Summary
- `install/uninstall.sh`: `unknown flag: $1` → `Unknown flag: $1. Run --help for usage.` — it exits without printing usage, so the hint tells the user what to do.
- `install/install.sh`: `unknown flag: $1` → `Unknown flag: $1.` — it already calls `usage 2` immediately after, so the full usage is printed; adding the hint would just duplicate that.

## Validation
- `bash -n` passes on both scripts.

Made with [Cursor](https://cursor.com)