### PR TITLE
Fix "Weave router" → "Weave Router" brand casing in install scripts

### DIFF
--- a/install/cc-statusline.sh
+++ b/install/cc-statusline.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Claude Code statusline for the Weave router. CC pipes a JSON blob on stdin
+# Claude Code statusline for the Weave Router. CC pipes a JSON blob on stdin
 # whose `transcript_path` points at the JSONL log of the current session and
 # whose `model.display_name` is the user's CC-side model selection. The
 # router rewrites each request's `model` field before forwarding, so

--- a/install/install.sh
+++ b/install/install.sh
@@ -1832,7 +1832,7 @@ fi
 cat > "$statusline_file" << 'STATUSLINE_EOF'
 #!/usr/bin/env bash
 #
-# Claude Code statusline for the Weave router. CC pipes a JSON blob on stdin
+# Claude Code statusline for the Weave Router. CC pipes a JSON blob on stdin
 # whose `transcript_path` points at the JSONL log of the current session and
 # whose `model.display_name` is the user's CC-side model selection. The
 # router rewrites each request's `model` field before forwarding, so


### PR DESCRIPTION
## Summary
- `install/cc-statusline.sh`: header comment "Weave router" → "Weave Router".
- `install/install.sh`: the embedded statusline template header, same fix.

Comment-only; no behavior change.

Made with [Cursor](https://cursor.com)