### PR TITLE
Fix "WorkWeave Router" → "Weave Router" in pi-router header

### DIFF
--- a/install/pi-router/src/index.ts
+++ b/install/pi-router/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * @workweave/router — route the pi coding agent through the WorkWeave Router.
+ * @workweave/router — route the pi coding agent through the Weave Router.
  *
  * Wiring (all on the existing router surface — no router source change beyond
  * the installer):


### PR DESCRIPTION
## Summary
- `install/pi-router/src/index.ts`: file-header comment "WorkWeave Router" → "Weave Router".

Comment-only; no behavior change. (README left out of scope.)

Made with [Cursor](https://cursor.com)