### PR TITLE
Add missing "Router" to pi-router user-visible brand strings

### DIFF
--- a/install/pi-router/src/dispatch.ts
+++ b/install/pi-router/src/dispatch.ts
@@ -301,7 +301,7 @@ export function registerDispatch(pi: ExtensionAPI, selfPath: string): void {
 			if (!key) {
 				return {
 					content: [
-						{ type: "text", text: "Weave dispatch unavailable: no router key (set WEAVE_ROUTER_KEY or run the --pi installer)." },
+						{ type: "text", text: "Weave Router dispatch unavailable: no router key (set WEAVE_ROUTER_KEY or run the --pi installer)." },
 					],
 					details: { results: [] as ChildResult[] },
 					isError: true,

--- a/install/pi-router/src/provider.ts
+++ b/install/pi-router/src/provider.ts
@@ -28,7 +28,7 @@ export function registerWeave(pi: ExtensionAPI): void {
 		// key there is fatal rather than silently routing on quality knobs.
 		if (isSubagent()) {
 			throw new Error(
-				"Weave: no router key found (set WEAVE_ROUTER_KEY or write ~/.pi/agent/.weave_router_key).",
+				"Weave Router: no router key found (set WEAVE_ROUTER_KEY or write ~/.pi/agent/.weave_router_key).",
 			);
 		}
 		return;

--- a/install/pi-router/src/routed-model.ts
+++ b/install/pi-router/src/routed-model.ts
@@ -23,7 +23,7 @@ export function registerRoutedModel(pi: ExtensionAPI): void {
 
 		if (ctx.hasUI) {
 			ctx.ui.setStatus(STATUS_KEY, `routed: ${model}`);
-			ctx.ui.notify(`Weave routed to ${model}`, "info");
+			ctx.ui.notify(`Weave Router routed to ${model}`, "info");
 		} else {
 			process.stderr.write(`${ROUTED_MODEL_STDERR_PREFIX} ${model}\n`);
 		}


### PR DESCRIPTION
## Summary
- `dispatch.ts`: "Weave dispatch unavailable" → "Weave Router dispatch unavailable".
- `provider.ts`: "Weave: no router key found" → "Weave Router: no router key found".
- `routed-model.ts`: "Weave routed to …" → "Weave Router routed to …".

## Validation
- `test/e2e.sh` and `test/opencode_smoke.sh` only reference "Weave Router" in comments and grep for the unrelated `weave-routed-model:` stderr prefix; no assertion targets the changed substrings.

Made with [Cursor](https://cursor.com)