### PR TITLE
Use ellipsis character (…) in operator-facing install output

### DIFF
--- a/install/install.sh
+++ b/install/install.sh
@@ -1542,7 +1542,7 @@ if [ -n "${WEAVE_ROUTER_KEY:-}" ]; then
     # any exit path, so we don't need a separate trap here — that would
     # overwrite the spinner cleanup and leak the cursor / child PID on Ctrl-C.
     printf "%sGet your Weave Router API key at %s%s\n" "$C_BRAND" "$base_url" "$C_RESET"
-    printf "%sPaste your key here (rk_...):%s " "$C_DIM" "$C_RESET"
+    printf "%sPaste your key here (rk_…):%s " "$C_DIM" "$C_RESET"
     stty -echo </dev/tty 2>/dev/null || true
     read -r api_key </dev/tty
     stty echo </dev/tty 2>/dev/null || true

--- a/install/pi-router/src/dispatch.ts
+++ b/install/pi-router/src/dispatch.ts
@@ -337,7 +337,7 @@ export function registerDispatch(pi: ExtensionAPI, selfPath: string): void {
 				const preview = t.prompt.length > 60 ? `${t.prompt.slice(0, 60)}...` : t.prompt;
 				text += `\n  ${theme.fg("dim", preview)}`;
 			}
-			if (tasks.length > 3) text += `\n  ${theme.fg("muted", `... +${tasks.length - 3} more`)}`;
+			if (tasks.length > 3) text += `\n  ${theme.fg("muted", `… +${tasks.length - 3} more`)}`;
 			return new Text(text, 0, 0);
 		},
 	});


### PR DESCRIPTION
## Summary
- `install/install.sh`: "Paste your key here (rk_...):" → "(rk_…):".
- `install/pi-router/src/dispatch.ts`: the "+N more" overflow line uses the ellipsis character.

README occurrences left out of scope.

Made with [Cursor](https://cursor.com)