### PR TITLE
Add trailing periods to slash-command frontmatter descriptions

### DIFF
--- a/install/commands/fm.md
+++ b/install/commands/fm.md
@@ -1,5 +1,5 @@
 ---
-description: Alias for /force-model — pin this session to a specific model via the Weave Router
+description: Alias for /force-model — pin this session to a specific model via the Weave Router.
 argument-hint: <model-id>
 ---
 

--- a/install/commands/force-model.md
+++ b/install/commands/force-model.md
@@ -1,5 +1,5 @@
 ---
-description: Pin this session to a specific model via the Weave Router
+description: Pin this session to a specific model via the Weave Router.
 argument-hint: <model-id>
 ---
 

--- a/install/commands/rf.md
+++ b/install/commands/rf.md
@@ -1,5 +1,5 @@
 ---
-description: Alias for /router-feedback — submit feedback about router decision or model performance
+description: Alias for /router-feedback — submit feedback about router decision or model performance.
 argument-hint: <feedback-text>
 ---
 

--- a/install/commands/router-feedback.md
+++ b/install/commands/router-feedback.md
@@ -1,5 +1,5 @@
 ---
-description: Submit feedback about router decision or model performance
+description: Submit feedback about router decision or model performance.
 argument-hint: <feedback-text>
 ---
 

--- a/install/commands/router-off.md
+++ b/install/commands/router-off.md
@@ -1,5 +1,5 @@
 ---
-description: Route Claude Code directly to Anthropic again (turn the Weave Router off)
+description: Route Claude Code directly to Anthropic again (turn the Weave Router off).
 allowed-tools: Bash(npx:*)
 ---
 

--- a/install/commands/router-on.md
+++ b/install/commands/router-on.md
@@ -1,5 +1,5 @@
 ---
-description: Route Claude Code through the Weave Router again (turn it back on)
+description: Route Claude Code through the Weave Router again (turn it back on).
 allowed-tools: Bash(npx:*)
 ---
 

--- a/install/commands/router-status.md
+++ b/install/commands/router-status.md
@@ -1,5 +1,5 @@
 ---
-description: Show whether Claude Code is routing through the Weave Router or directly to Anthropic
+description: Show whether Claude Code is routing through the Weave Router or directly to Anthropic.
 allowed-tools: Bash(npx:*)
 ---
 

--- a/install/commands/ufm.md
+++ b/install/commands/ufm.md
@@ -1,5 +1,5 @@
 ---
-description: Alias for /unforce-model — clear an active /force-model pin and resume automatic routing
+description: Alias for /unforce-model — clear an active /force-model pin and resume automatic routing.
 ---
 
 /unforce-model

--- a/install/commands/unforce-model.md
+++ b/install/commands/unforce-model.md
@@ -1,5 +1,5 @@
 ---
-description: Clear an active /force-model pin and resume automatic routing
+description: Clear an active /force-model pin and resume automatic routing.
 ---
 
 /unforce-model


### PR DESCRIPTION
## Summary
- Adds a trailing period to the `description:` frontmatter of all nine `install/commands/*.md` files for consistency in the slash-command picker.

## Notes
- Stacked on #435 (D12) because the alias files (fm/rf/ufm) are touched by both; merging D12 first keeps this conflict-free.

Made with [Cursor](https://cursor.com)