### PR TITLE
fix(translate): surface upstream errors instead of masking Gemini failures as end_turn

### DIFF
--- a/internal/translate/gemini_error_masking_test.go
+++ b/internal/translate/gemini_error_masking_test.go
@@ -1,0 +1,72 @@
+package translate_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"workweave/router/internal/translate"
+)
+
+// When a cross-format upstream (notably Gemini native) returns a non-2xx AFTER
+// the eager Prelude has already committed message_start, the status can no
+// longer change the wire response. Previously the translator parsed the
+// upstream error body as SSE (yielding nothing) and finishStream emitted a
+// clean message_delta/end_turn — masking the failure as an empty successful
+// turn that agent harnesses silently drop. The translator must instead surface
+// an Anthropic `error` event so the client sees the failure.
+//
+// This reproduces the geminiTr -> anthropicTr forwarding on error: geminiTr's
+// non-streaming Finalize calls inner.WriteHeader(status) + inner.Write(error
+// envelope) after the AnthropicSSETranslator's Prelude already ran.
+func driveAnthropicSSEUpstreamError(t *testing.T, status int, errorBody string) string {
+	t.Helper()
+	rec := httptest.NewRecorder()
+	tr := translate.NewAnthropicSSETranslator(rec, "gemini-3.1-pro-preview", nil)
+	// Eager Prelude: commits SSE headers + message_start before the upstream
+	// produces a byte (the cross-format streaming path).
+	require.NoError(t, tr.Prelude(true))
+	// Upstream errored: status forwarded, then the (translated) error envelope.
+	tr.WriteHeader(status)
+	_, err := tr.Write([]byte(errorBody))
+	require.NoError(t, err)
+	require.NoError(t, tr.Finalize())
+	return rec.Body.String()
+}
+
+func TestAnthropicSSETranslator_SurfacesUpstreamErrorInsteadOfEndTurn(t *testing.T) {
+	// The exact Gemini 400 we observed in prod, after GeminiToOpenAIError
+	// reshapes it into an OpenAI-style envelope.
+	body := driveAnthropicSSEUpstreamError(t, http.StatusBadRequest,
+		`{"error":{"message":"Request contains an invalid argument.","type":"invalid_request_error"}}`)
+
+	assert.Contains(t, body, "event: error", "upstream failure must be surfaced as an error event")
+	assert.Contains(t, body, "Request contains an invalid argument.", "upstream message must be relayed")
+	assert.Contains(t, body, `"type":"invalid_request_error"`, "400 maps to invalid_request_error")
+	// The masking bug: a clean end_turn must NOT be synthesized for a failed turn.
+	assert.NotContains(t, body, `"stop_reason":"end_turn"`)
+	assert.NotContains(t, body, "event: message_delta")
+}
+
+func TestAnthropicSSETranslator_MapsUpstreamStatusToErrorType(t *testing.T) {
+	cases := []struct {
+		status   int
+		body     string
+		wantType string
+		wantMsg  string
+	}{
+		{http.StatusServiceUnavailable, `{"error":{"message":"Authentication backend unavailable.","status":"UNAVAILABLE"}}`, "overloaded_error", "Authentication backend unavailable."},
+		{http.StatusTooManyRequests, `{"error":{"message":"rate limited"}}`, "rate_limit_error", "rate limited"},
+		{http.StatusInternalServerError, `{}`, "api_error", "upstream provider returned HTTP 500"},
+	}
+	for _, tc := range cases {
+		body := driveAnthropicSSEUpstreamError(t, tc.status, tc.body)
+		assert.Contains(t, body, "event: error")
+		assert.Contains(t, body, tc.wantType)
+		assert.Contains(t, body, tc.wantMsg)
+		assert.NotContains(t, body, `"stop_reason":"end_turn"`)
+	}
+}

--- a/internal/translate/stream.go
+++ b/internal/translate/stream.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"strings"
 	"time"
@@ -454,7 +455,22 @@ type AnthropicSSETranslator struct {
 	// survived. Surfaced via Summary so the proxy can count the degenerate
 	// tool-call turns that previously dead-ended agent clients.
 	stopReasonDemoted bool
+
+	// upstreamErrorStatus is set when WriteHeader receives a >=400 status AFTER
+	// the eager Prelude already committed the SSE headers + message_start. In
+	// that window the wire status can no longer change, so without special
+	// handling the upstream error body is parsed as SSE (yielding nothing) and
+	// finishStream emits a clean message_delta/end_turn — masking the failure
+	// as an empty successful turn that silently drops the agent's turn. When
+	// set, Write diverts the upstream error body into upstreamErrorBody and
+	// finishStream emits an Anthropic `error` event instead.
+	upstreamErrorStatus int
+	upstreamErrorBody   strings.Builder
 }
+
+// upstreamErrorBodyCap bounds how much of an upstream error body is retained
+// for the surfaced error message, so a pathological body can't grow unbounded.
+const upstreamErrorBodyCap = 8 << 10
 
 // NewAnthropicSSETranslator wraps w. Call Finalize after upstream returns.
 func NewAnthropicSSETranslator(w http.ResponseWriter, requestModel string, sink otel.UsageSink) *AnthropicSSETranslator {
@@ -583,6 +599,13 @@ func (t *AnthropicSSETranslator) Header() http.Header {
 
 // WriteHeader routes streaming success responses through SSE.
 func (t *AnthropicSSETranslator) WriteHeader(code int) {
+	// Capture an upstream error status even when the eager Prelude has already
+	// emitted headers: in that case the status is dropped from the wire, but
+	// finishStream still needs to know the turn failed so it can surface an
+	// `error` event instead of synthesizing a clean end_turn.
+	if code >= 400 {
+		t.upstreamErrorStatus = code
+	}
 	if t.headersEmitted {
 		return
 	}
@@ -633,6 +656,20 @@ func (t *AnthropicSSETranslator) Prelude(streaming bool) error {
 
 func (t *AnthropicSSETranslator) Write(data []byte) (int, error) {
 	n := len(data)
+	// Once an upstream error status has been seen, the bytes that follow are
+	// the upstream error body, not SSE content. Divert them (bounded) so
+	// finishStream can surface them as an `error` event rather than feeding a
+	// non-SSE error envelope to the SSE parser (which silently yields nothing).
+	if t.upstreamErrorStatus != 0 {
+		if remaining := upstreamErrorBodyCap - t.upstreamErrorBody.Len(); remaining > 0 {
+			capped := data
+			if len(capped) > remaining {
+				capped = capped[:remaining]
+			}
+			t.upstreamErrorBody.Write(capped)
+		}
+		return n, nil
+	}
 	t.buf.Write(data)
 	if !t.streaming {
 		return n, nil
@@ -1204,6 +1241,21 @@ func (t *AnthropicSSETranslator) finishStream() error {
 	}
 	t.toolBlocks = map[int]int{}
 
+	// An upstream non-2xx seen after the Prelude committed: surface it as an
+	// Anthropic `error` event instead of message_delta/end_turn. Emitting a
+	// clean end_turn here would tell the client the model produced an empty
+	// turn, which agent harnesses accept and silently drop the turn.
+	if t.upstreamErrorStatus != 0 {
+		if err := t.emitErrorEvent(); err != nil {
+			return err
+		}
+		if err := t.emitMessageStop(); err != nil {
+			return err
+		}
+		t.closed = true
+		return nil
+	}
+
 	if err := t.synthesizeTextOnlyTurnNudge(); err != nil {
 		return err
 	}
@@ -1216,6 +1268,57 @@ func (t *AnthropicSSETranslator) finishStream() error {
 	}
 	t.closed = true
 	return nil
+}
+
+// emitErrorEvent emits an Anthropic streaming `error` event derived from the
+// captured upstream status and body. Anthropic clients surface this as a turn
+// error (and can retry) instead of treating the turn as an empty success.
+func (t *AnthropicSSETranslator) emitErrorEvent() error {
+	errType := anthropicErrorTypeForStatus(t.upstreamErrorStatus)
+	msg := upstreamErrorMessage(t.upstreamErrorBody.String(), t.upstreamErrorStatus)
+	observability.Get().Debug("AnthropicSSE emit",
+		"event", "error",
+		"upstream_status", t.upstreamErrorStatus,
+		"error_type", errType,
+	)
+	t.bw.WriteString("event: error\ndata: {\"type\":\"error\",\"error\":{\"type\":")
+	sse.WriteJSONString(t.bw, errType)
+	t.bw.WriteString(",\"message\":")
+	sse.WriteJSONString(t.bw, msg)
+	t.bw.WriteString("}}\n\n")
+	return t.flushEvent()
+}
+
+// anthropicErrorTypeForStatus maps an upstream HTTP status to the closest
+// Anthropic error type so clients apply the right retry/backoff semantics.
+func anthropicErrorTypeForStatus(status int) string {
+	switch {
+	case status == http.StatusTooManyRequests:
+		return "rate_limit_error"
+	case status == http.StatusServiceUnavailable:
+		return "overloaded_error"
+	case status >= 500:
+		return "api_error"
+	case status == http.StatusBadRequest:
+		return "invalid_request_error"
+	default:
+		return "api_error"
+	}
+}
+
+// upstreamErrorMessage extracts a human-readable message from a captured
+// upstream error body (OpenAI- or Anthropic-shaped error envelope), falling
+// back to a generic status line when the body carries no message.
+func upstreamErrorMessage(body string, status int) string {
+	if body != "" {
+		if m := gjson.Get(body, "error.message"); m.Exists() && m.String() != "" {
+			return m.String()
+		}
+		if m := gjson.Get(body, "message"); m.Exists() && m.String() != "" {
+			return m.String()
+		}
+	}
+	return fmt.Sprintf("upstream provider returned HTTP %d", status)
 }
 
 func (t *AnthropicSSETranslator) emitMessageStart() error {

--- a/internal/translate/stream.go
+++ b/internal/translate/stream.go
@@ -656,11 +656,14 @@ func (t *AnthropicSSETranslator) Prelude(streaming bool) error {
 
 func (t *AnthropicSSETranslator) Write(data []byte) (int, error) {
 	n := len(data)
-	// Once an upstream error status has been seen, the bytes that follow are
-	// the upstream error body, not SSE content. Divert them (bounded) so
+	// Streaming-only: once the Prelude has committed (t.streaming) and an
+	// upstream error status has been seen, the bytes that follow are the
+	// upstream error body, not SSE content. Divert them (bounded) so
 	// finishStream can surface them as an `error` event rather than feeding a
 	// non-SSE error envelope to the SSE parser (which silently yields nothing).
-	if t.upstreamErrorStatus != 0 {
+	// In the non-streaming case the body must stay in t.buf so Finalize can
+	// translate it into the Anthropic error envelope as before.
+	if t.upstreamErrorStatus != 0 && t.streaming {
 		if remaining := upstreamErrorBodyCap - t.upstreamErrorBody.Len(); remaining > 0 {
 			capped := data
 			if len(capped) > remaining {


### PR DESCRIPTION
## Symptom (prod)

On the Gemini path, upstream failures are silently masked as empty successful turns. The client (Claude Code) receives only the routing-marker banner + `stop_reason: end_turn` with `output_tokens: 0`, and the agent harness drops the turn without surfacing any error.

Measured in a single org over 24h: **~99 silently-lost gemini turns** (≈44 `is_error` + ≈55 `is_error=false`-but-empty). Anthropic/OpenAI upstream errors surface correctly — this was **Gemini-path-specific**.

GCP logs show the real upstream failures behind it:
- `400 INVALID_ARGUMENT — "Request contains an invalid argument."` (the dominant one; see the companion routing PR)
- `503 UNAVAILABLE — "Authentication backend unavailable."`
- `http2: timeout awaiting response headers`

All rendered to the client as a clean empty `end_turn`.

## Root cause

The claude-code→gemini stream chain is `GeminiToOpenAISSETranslator → AnthropicSSETranslator → client`. The proxy eagerly calls `Prelude(true)` on the `AnthropicSSETranslator`, committing SSE headers + `message_start` + the routing marker before the upstream produces a byte.

When Gemini then 400s:
1. `GeminiToOpenAISSETranslator.WriteHeader(400)` sets `streaming=false` (`code < 400` is false) so it does **not** forward the status to the inner translator; its non-streaming `Finalize` later writes the translated error envelope to the inner translator via `WriteHeader(400)` + `Write(...)`.
2. `AnthropicSSETranslator.WriteHeader(400)` **early-returns** because `headersEmitted` is already true (Prelude) — the status is dropped, `statusCode` stays 200.
3. The error envelope is fed to `Write`, parsed as OpenAI SSE, and yields nothing.
4. `finishStream` synthesizes `message_delta`/`end_turn` with zero output.

## Fix

In `AnthropicSSETranslator`:
- `WriteHeader`: capture a `>=400` status (`upstreamErrorStatus`) **even when headers were already emitted**.
- `Write`: once an error status is seen, divert subsequent bytes into a bounded `upstreamErrorBody` instead of the SSE parser.
- `finishStream`: when `upstreamErrorStatus != 0`, emit an Anthropic `error` event (status-mapped type — `invalid_request_error` / `rate_limit_error` / `overloaded_error` / `api_error` — and the relayed upstream message) instead of `message_delta`/`end_turn`.

## Test

`gemini_error_masking_test.go` reproduces the geminiTr→anthropicTr forwarding after an eager Prelude. Verified it **fails on the old code** (output is `message_start → message_delta end_turn → message_stop`, the exact prod masking) and passes with the fix. Covers 400/503/429/500 type mapping and message relay. Full `internal/translate` package green.

## Scope

Fixes the Anthropic-inbound (Claude Code) path, where all observed masking occurred. The OpenAI-inbound (Cursor)→gemini path renders errors via `GeminiToOpenAIError` and is not covered here — flagged as follow-up.

Companion PR addresses the **root cause** of the dominant 400s (routing foreign tool-call history into Gemini 3.x without a valid `thoughtSignature`); this PR ensures that whatever upstream failures remain (transient 503s, timeouts) are surfaced rather than silently lost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)