### PR TITLE
fix(proxy): don't route unsigned tool-call history into Gemini 3.x (root-cause of INVALID_ARGUMENT 400s)

### DIFF
--- a/internal/proxy/gemini_unsigned_history_internal_test.go
+++ b/internal/proxy/gemini_unsigned_history_internal_test.go
@@ -1,0 +1,45 @@
+package proxy
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"workweave/router/internal/translate"
+)
+
+func TestExcludeGemini3xOnUnsignedHistory_ExcludesGeminiKeepsOthers(t *testing.T) {
+	available := map[string]struct{}{
+		"gemini-3.1-pro-preview":        {},
+		"gemini-3.1-flash-lite-preview": {},
+		"claude-opus-4-8":               {},
+		"deepseek/deepseek-v4-pro":      {},
+	}
+	env, err := translate.ParseAnthropic([]byte(`{"model":"x","messages":[{"role":"assistant","content":[{"type":"tool_use","id":"toolu_1","name":"Bash","input":{}}]}]}`))
+	require.NoError(t, err)
+
+	out, added := excludeGemini3xOnUnsignedHistory(env, map[string]struct{}{}, available)
+	assert.ElementsMatch(t, []string{"gemini-3.1-flash-lite-preview", "gemini-3.1-pro-preview"}, added)
+	_, geminiExcluded := out["gemini-3.1-pro-preview"]
+	assert.True(t, geminiExcluded, "gemini-3.x is excluded when history carries unsigned tool calls")
+	_, opusExcluded := out["claude-opus-4-8"]
+	assert.False(t, opusExcluded, "non-gemini models stay eligible")
+}
+
+func TestExcludeGemini3xOnUnsignedHistory_SignedHistoryIsNoop(t *testing.T) {
+	available := map[string]struct{}{"gemini-3.1-pro-preview": {}, "claude-opus-4-8": {}}
+	env, err := translate.ParseAnthropic([]byte(`{"model":"x","messages":[{"role":"assistant","content":[{"type":"tool_use","id":"toolu_1__thought__c2ln","name":"Bash","input":{}}]}]}`))
+	require.NoError(t, err)
+
+	out, added := excludeGemini3xOnUnsignedHistory(env, map[string]struct{}{}, available)
+	assert.Nil(t, added, "signed (native Gemini) history must not exclude Gemini")
+	assert.Empty(t, out)
+}
+
+func TestGemini3xRequiresSignedHistory(t *testing.T) {
+	assert.True(t, gemini3xRequiresSignedHistory("gemini-3.1-pro-preview"))
+	assert.True(t, gemini3xRequiresSignedHistory("gemini-3.5-flash"))
+	assert.False(t, gemini3xRequiresSignedHistory("gemini-2.5-flash"))
+	assert.False(t, gemini3xRequiresSignedHistory("claude-opus-4-8"))
+}

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -399,6 +399,51 @@ func excludeContextOverflowModels(est, outputReserve int, excluded, available ma
 	return out, overflowed
 }
 
+// gemini3xRequiresSignedHistory reports whether model is a Gemini 3.x model,
+// which 400s (INVALID_ARGUMENT) when the request history carries function-call
+// parts lacking the thoughtSignature Gemini issued. Scoped by family name; if
+// the catalog later grows a per-model capability flag this should move there.
+func gemini3xRequiresSignedHistory(model string) bool {
+	return strings.HasPrefix(model, "gemini-3")
+}
+
+// excludeGemini3xOnUnsignedHistory augments excluded with every Gemini 3.x model
+// in available when the request history carries an assistant tool call lacking a
+// Gemini thoughtSignature. Routing such a turn into Gemini 3.x is a guaranteed
+// 400 (foreign/cross-model history — planner switch or tier clamp into Gemini),
+// so the models are made ineligible and the scorer/clamp pick a non-Gemini
+// candidate instead. Returns the original map unchanged (and nil) when nothing
+// is added. Native Gemini continuations round-trip their own signature and are
+// not affected.
+func excludeGemini3xOnUnsignedHistory(env *translate.RequestEnvelope, excluded, available map[string]struct{}) (map[string]struct{}, []string) {
+	if env == nil || !env.HasUnsignedToolCallHistory() {
+		return excluded, nil
+	}
+	var out map[string]struct{}
+	var added []string
+	for model := range available {
+		if !gemini3xRequiresSignedHistory(model) {
+			continue
+		}
+		if _, already := excluded[model]; already {
+			continue
+		}
+		if out == nil {
+			out = make(map[string]struct{}, len(excluded)+1)
+			for k := range excluded {
+				out[k] = struct{}{}
+			}
+		}
+		out[model] = struct{}{}
+		added = append(added, model)
+	}
+	if len(added) == 0 {
+		return excluded, nil
+	}
+	sort.Strings(added)
+	return out, added
+}
+
 // restrictToTier returns a copy of excluded augmented with every routable model
 // whose tier differs from the target. It is the scorer-side counterpart to a
 // dropped user-forced pin: when the forced model can no longer serve a turn
@@ -1146,6 +1191,12 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 			"output_reserve", outputReserve,
 			"excluded_count", len(ctxOverflowed),
 			"excluded_models", strings.Join(ctxOverflowed, ","),
+		)
+	}
+	excluded, geminiUnsigned := excludeGemini3xOnUnsignedHistory(env, excluded, s.availableModels)
+	if len(geminiUnsigned) > 0 {
+		log.Info("gemini pre-filter: excluded gemini-3.x for unsigned tool-call history",
+			"excluded_models", strings.Join(geminiUnsigned, ","),
 		)
 	}
 
@@ -2375,6 +2426,12 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 			"output_reserve", outputReserveOAI,
 			"excluded_count", len(ctxOverflowedOAI),
 			"excluded_models", strings.Join(ctxOverflowedOAI, ","),
+		)
+	}
+	excludedOAI, geminiUnsignedOAI := excludeGemini3xOnUnsignedHistory(env, excludedOAI, s.availableModels)
+	if len(geminiUnsignedOAI) > 0 {
+		log.Info("gemini pre-filter: excluded gemini-3.x for unsigned tool-call history",
+			"excluded_models", strings.Join(geminiUnsignedOAI, ","),
 		)
 	}
 

--- a/internal/translate/gemini_signature_history.go
+++ b/internal/translate/gemini_signature_history.go
@@ -1,0 +1,88 @@
+package translate
+
+import "github.com/tidwall/gjson"
+
+// HasUnsignedToolCallHistory reports whether the conversation history carries at
+// least one assistant tool call — Anthropic tool_use, OpenAI tool_calls, or
+// Gemini functionCall — that lacks a Gemini thoughtSignature.
+//
+// Gemini 3.x rejects (400 INVALID_ARGUMENT) any request whose history contains
+// function-call parts without the thoughtSignature it originally issued. That
+// happens whenever a session is routed into Gemini after prior turns were
+// served by a different model (a planner switch or a tier clamp): foreign
+// history never carried a Gemini signature, and the router smuggles Gemini's
+// own signatures via the tool-call id (see thought_signature_id.go), so a
+// native Gemini continuation round-trips them but a cross-model handoff cannot.
+//
+// The router uses this to make Gemini 3.x models ineligible for such a turn,
+// avoiding a guaranteed upstream 400. A single unsigned tool call is enough,
+// because Gemini validates every function-call part in the history.
+func (e *RequestEnvelope) HasUnsignedToolCallHistory() bool {
+	if e == nil {
+		return false
+	}
+	switch e.format {
+	case FormatAnthropic:
+		return anthropicHasUnsignedToolUse(e.body)
+	case FormatOpenAI:
+		return openAIHasUnsignedToolCalls(e.body)
+	case FormatGemini:
+		return geminiHasUnsignedFunctionCall(e.body)
+	default:
+		return false
+	}
+}
+
+func anthropicHasUnsignedToolUse(body []byte) bool {
+	found := false
+	gjson.GetBytes(body, "messages").ForEach(func(_, msg gjson.Result) bool {
+		if msg.Get("role").String() != "assistant" {
+			return true
+		}
+		msg.Get("content").ForEach(func(_, block gjson.Result) bool {
+			if block.Get("type").String() == "tool_use" && extractThoughtSignature(block) == "" {
+				found = true
+				return false
+			}
+			return true
+		})
+		return !found
+	})
+	return found
+}
+
+func openAIHasUnsignedToolCalls(body []byte) bool {
+	found := false
+	gjson.GetBytes(body, "messages").ForEach(func(_, msg gjson.Result) bool {
+		if msg.Get("role").String() != "assistant" {
+			return true
+		}
+		msg.Get("tool_calls").ForEach(func(_, tc gjson.Result) bool {
+			if extractThoughtSignature(tc) == "" {
+				found = true
+				return false
+			}
+			return true
+		})
+		return !found
+	})
+	return found
+}
+
+func geminiHasUnsignedFunctionCall(body []byte) bool {
+	found := false
+	gjson.GetBytes(body, "contents").ForEach(func(_, content gjson.Result) bool {
+		if content.Get("role").String() != "model" {
+			return true
+		}
+		content.Get("parts").ForEach(func(_, part gjson.Result) bool {
+			if part.Get("functionCall").Exists() && part.Get("thoughtSignature").String() == "" {
+				found = true
+				return false
+			}
+			return true
+		})
+		return !found
+	})
+	return found
+}

--- a/internal/translate/gemini_signature_history_test.go
+++ b/internal/translate/gemini_signature_history_test.go
@@ -1,0 +1,58 @@
+package translate_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"workweave/router/internal/translate"
+)
+
+// "c2ln" is base64url(RawURLEncoding) of "sig" — the embedded-signature form
+// embedSignatureInID produces in a tool-call id.
+const signedToolID = "toolu_1__thought__c2ln"
+
+func TestHasUnsignedToolCallHistory_AnthropicUnsigned(t *testing.T) {
+	env, err := translate.ParseAnthropic([]byte(`{
+		"model":"x","messages":[
+			{"role":"user","content":"hi"},
+			{"role":"assistant","content":[{"type":"tool_use","id":"toolu_1","name":"Bash","input":{}}]},
+			{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_1","content":"ok"}]}
+		]}`))
+	require.NoError(t, err)
+	assert.True(t, env.HasUnsignedToolCallHistory(), "a tool_use with no embedded signature is unsigned (foreign history)")
+}
+
+func TestHasUnsignedToolCallHistory_AnthropicSigned(t *testing.T) {
+	env, err := translate.ParseAnthropic([]byte(`{
+		"model":"x","messages":[
+			{"role":"assistant","content":[{"type":"tool_use","id":"` + signedToolID + `","name":"Bash","input":{}}]}
+		]}`))
+	require.NoError(t, err)
+	assert.False(t, env.HasUnsignedToolCallHistory(), "an embedded thoughtSignature makes the tool call signed (native Gemini continuation)")
+}
+
+func TestHasUnsignedToolCallHistory_NoToolCalls(t *testing.T) {
+	env, err := translate.ParseAnthropic([]byte(`{"model":"x","messages":[{"role":"assistant","content":[{"type":"text","text":"hi"}]}]}`))
+	require.NoError(t, err)
+	assert.False(t, env.HasUnsignedToolCallHistory(), "text-only history has no tool calls to validate")
+}
+
+func TestHasUnsignedToolCallHistory_OpenAIUnsigned(t *testing.T) {
+	env, err := translate.ParseOpenAI([]byte(`{
+		"model":"x","messages":[
+			{"role":"assistant","content":null,"tool_calls":[{"id":"call_1","type":"function","function":{"name":"Bash","arguments":"{}"}}]}
+		]}`))
+	require.NoError(t, err)
+	assert.True(t, env.HasUnsignedToolCallHistory())
+}
+
+func TestHasUnsignedToolCallHistory_OpenAISigned(t *testing.T) {
+	env, err := translate.ParseOpenAI([]byte(`{
+		"model":"x","messages":[
+			{"role":"assistant","content":null,"tool_calls":[{"id":"call_1__thought__c2ln","type":"function","function":{"name":"Bash","arguments":"{}"}}]}
+		]}`))
+	require.NoError(t, err)
+	assert.False(t, env.HasUnsignedToolCallHistory())
+}


### PR DESCRIPTION
## Symptom (prod)

Systematic `400 INVALID_ARGUMENT` ("Request contains an invalid argument.") from Google on the Gemini path. Confirmed from GCP logs (`Upstream Google returned error status`, status 400, identical 127-byte body).

## Root cause

Gemini 3.x rejects any request whose history carries **function-call parts without the `thoughtSignature` it issued**. The router smuggles Gemini's signatures via the tool-call id (`thought_signature_id.go`), so a **native Gemini continuation** round-trips them. But a session routed *into* Gemini after prior turns were served by a different model — a **planner switch** ("switched for positive EV after cache eviction") or a **tier clamp** to `gemini-3.1-flash-lite` — carries **foreign history that never had a Gemini signature**, so Google 400s every time.

### Evidence

Error rate splits hard on `sticky_hit` (24h, one org):

| model | sticky=false (switch/clamp-in) | sticky=true (native continuation) |
|---|---|---|
| gemini-3.1-flash-lite | **12.4%** | 0.23% |
| gemini-3.1-pro | **17.0%** | 0.24% |

100% of the 400s carry `tool_use` history; none carry a `thoughtSignature`. A 50–70× gap between cross-model handoff and native continuation.

## Fix

A candidate pre-filter mirroring `excludeContextOverflowModels`: when the inbound history contains an assistant tool call lacking a Gemini `thoughtSignature`, make every available Gemini 3.x model **ineligible for that turn**, so the scorer and the tier-clamp resolver pick a non-Gemini candidate instead of a guaranteed 400.

- `translate.RequestEnvelope.HasUnsignedToolCallHistory()` — detects an unsigned assistant tool call across Anthropic / OpenAI / Gemini inbound formats, reusing `extractThoughtSignature` (id-embedded-signature aware). One unsigned call is enough, since Gemini validates every function-call part.
- `proxy.excludeGemini3xOnUnsignedHistory(...)` — applied at both pre-filter call sites (Messages + OpenAI surfaces).

Native Gemini continuations are unaffected — their history is signed, so the detector returns false and Gemini stays eligible.

## Tests

- `gemini_signature_history_test.go`: signed vs unsigned detection across Anthropic + OpenAI history (signed = id carries an embedded `__thought__` signature).
- `gemini_unsigned_history_internal_test.go`: the pre-filter excludes Gemini 3.x and keeps non-Gemini models; signed history is a no-op; family matcher unit checks.

Full `internal/translate` + `internal/proxy` packages green.

## Notes / scope

- Gemini 3.x family is matched by name (`gemini-3` prefix). A per-model catalog capability flag would be a cleaner home — flagged as follow-up.
- The pre-filter relies on the `available` model set (same as `excludeContextOverflowModels`); with a nil available set it is a no-op.
- Companion PR (error masking) ensures any *residual* Gemini upstream failures (transient 503s / timeouts) surface as errors instead of being masked as empty `end_turn` turns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)