### PR TITLE
fix(translate): scope Gemini tool-use reminder to edit-intent

### DIFF
--- a/internal/translate/system_reminder.go
+++ b/internal/translate/system_reminder.go
@@ -30,9 +30,18 @@ func openRouterSystemReminder(model string) string {
 // Gemini 3.x in agentic-coding traces (SWE-bench Verified) reads source files
 // extensively, then ends turns describing the proposed edit in markdown
 // instead of calling Edit/Write. The behavior persists even when the request
-// carries Edit/Write tool schemas. This addendum is the Gemini analogue to
-// deepseekToolUseReminder: it tells the model the exploration-only turn is
-// the failure mode, not the success mode.
+// carries Edit/Write tool schemas. This addendum nudges it to apply edits via
+// the tools when the user asked for a change.
+//
+// The nudge is deliberately CONDITIONAL. An earlier unconditional phrasing
+// ("always call Edit/Write; a turn that only explores counts as giving up")
+// framed every explore-only turn as failure, which tipped advisory/read-only
+// requests ("what should I fix?") into unsolicited edits, commits, and PRs.
+// The conditional form preserves the under-calling fix on genuine edit turns
+// while leaving analysis/review requests in prose — mirroring the industry
+// norm of mode-scoped guidance (Cline plan/act, Aider ask/code) over a blunt
+// global imperative, which research shows over-pushes and is an unreliable
+// governor of model action.
 func geminiSystemReminder(model string) string {
 	if isGemini3xModel(model) {
 		return geminiToolUseReminder
@@ -42,7 +51,7 @@ func geminiSystemReminder(model string) string {
 
 const deepseekToolUseReminder = "When using file-edit tools, copy `old_string` byte-for-byte from the most recent file read — preserve tabs, leading and trailing whitespace, and unicode characters (em-dash —, smart quotes, non-breaking spaces) exactly. If an Edit call fails, re-read the file before retrying. Never fall back to shell commands (sed, awk, python) to modify files."
 
-const geminiToolUseReminder = "When asked to fix code, always call the Edit or Write tool to apply changes — do not describe the edit in prose or markdown and stop. A turn that explores files without producing an Edit/Write call counts as the model giving up. After you have read enough to know what to change, the next step is the tool call, not a summary."
+const geminiToolUseReminder = "When the user has asked you to apply a change, prefer calling the Edit or Write tool over describing the edit in prose or markdown; once you have read enough to know what to change, the next step is the Edit/Write call, not a summary. If the user only asked for analysis, a review, or what could be fixed, answer in prose — do not edit, commit, or push unless they asked you to."
 
 // applySystemReminderToBody injects the reminder into a serialized OpenAI body's
 // `messages` array. Best-effort: returns the input unchanged on parse failure

--- a/internal/translate/system_reminder_test.go
+++ b/internal/translate/system_reminder_test.go
@@ -173,7 +173,7 @@ func TestSystemReminder_OpenAISource_SkipsWithoutTools(t *testing.T) {
 	assert.NotContains(t, systemContent(emittedMessages(t, out.Body)), reminderSnippet)
 }
 
-const geminiReminderSnippet = "always call the Edit or Write tool"
+const geminiReminderSnippet = "prefer calling the Edit or Write tool"
 
 // geminiSystemInstructionText extracts the concatenated systemInstruction.parts[*].text
 // from a serialized Gemini request body, or "" when no systemInstruction is set.


### PR DESCRIPTION
## Problem

For Gemini 3.x requests carrying tools, the router appends a hardcoded reminder to `systemInstruction`:

> When asked to fix code, **always call the Edit or Write tool** to apply changes — do not describe the edit in prose or markdown and stop. **A turn that explores files without producing an Edit/Write call counts as the model giving up.** After you have read enough to know what to change, the next step is the tool call, not a summary.

It was added to fix Gemini 3.x under-calling Edit/Write on SWE-bench (it tends to describe edits in markdown instead of applying them). But it's an **unconditional imperative** that frames *any* explore-only turn as failure.

### Prod incident (session `fbd357cd-b864-4abb-a567-f9bbbe4e1acf`)

A user asked Gemini 3.1 Pro to *"check Andrew's review comments, which PRs, and what should I fix?"* — an advisory / read-only request. The model edited files, `git commit`, `git push`, and `gh pr create`, all unprompted.

Investigation confirmed:
- **Context fidelity was intact** — full 110-message history passed inbound and outbound; 48/48 `tool_use`→`functionCall` and 48/48 `tool_result`→`functionResponse` round-tripped to Gemini. Not a translation/truncation bug.
- This reminder was the **sole behavioral differentiator** vs a vanilla Gemini chatbot (`"always call the Edit or Write tool"`: 0 occurrences inbound, 1 outbound). `tool_choice` mapped to `VALIDATED` (non-forcing), so the prompt nudge — not the function-calling mode — drove the over-action.

## Fix

Reword the reminder to a **conditional** nudge:

> When the user has asked you to apply a change, prefer calling the Edit or Write tool over describing the edit in prose or markdown; once you have read enough to know what to change, the next step is the Edit/Write call, not a summary. If the user only asked for analysis, a review, or what could be fixed, answer in prose — do not edit, commit, or push unless they asked you to.

- Preserves the under-calling fix on genuine edit turns.
- Explicitly carves out advisory/review requests.
- Drops the "exploring = giving up" framing that over-pushed toward writes.

This mirrors the industry norm of **mode-scoped guidance** (Cline plan/act, Aider ask/code, Claude Code plan mode) over a blunt global imperative. Research backs this: forced/mandatory tool use degrades performance ([WTU-Eval](https://arxiv.org/abs/2407.12823)) and blunt imperative prompts are unreliable governors ([Anthropic agentic-misalignment](https://www.anthropic.com/research/agentic-misalignment)); the vendor-recommended pattern is non-forcing `auto` + scoped, request-level instructions ([Anthropic tool-use docs](https://platform.claude.com/docs/en/agents-and-tools/tool-use/implement-tool-use)).

## Scope

Single constant + its godoc in `internal/translate/system_reminder.go`, and the matching test snippet in `system_reminder_test.go`. Gating (Gemini-3.x + tools present), the injection sites, and `tool_choice` handling are all unchanged. `go build`, `go vet`, and the full `internal/translate` suite pass.

## Follow-up (not in this PR)

Re-run SWE-bench before/after to confirm the softer wording doesn't regress Gemini's Edit/Write call rate on genuine edit turns. If under-calling returns, the next step is to *scope* the nudge to detected edit-intent rather than re-strengthen the wording.

🤖 Generated with [Claude Code](https://claude.com/claude-code)