### PR TITLE
feat(translate): inject prompt-cache breakpoints on the OpenAI->Anthropic path

### DIFF
--- a/internal/translate/crossformat_request_test.go
+++ b/internal/translate/crossformat_request_test.go
@@ -254,7 +254,11 @@ func TestCrossFormat_OpenAIToAnthropic_SimpleText(t *testing.T) {
 
 	u2 := msgAt(t, msgs, 2)
 	assert.Equal(t, "user", u2["role"])
-	assert.Equal(t, "Now what about 3+3?", u2["content"])
+	// The final message's string content is promoted to a text block so it can
+	// carry the injected prompt-cache breakpoint (see the cache-injection test).
+	u2blocks := u2["content"].([]any)
+	require.Len(t, u2blocks, 1)
+	assert.Equal(t, "Now what about 3+3?", u2blocks[0].(map[string]any)["text"])
 
 	assert.Equal(t, float64(0.7), doc["temperature"])
 	assert.Equal(t, float64(1024), doc["max_tokens"])
@@ -310,7 +314,95 @@ func TestCrossFormat_OpenAIToAnthropic_ToolConversation(t *testing.T) {
 
 	finalUser := msgAt(t, msgs, 4)
 	assert.Equal(t, "user", finalUser["role"])
-	assert.Equal(t, "Now edit it to add a hello world print", finalUser["content"])
+	// Final message string content is promoted to a text block carrying the
+	// injected prompt-cache breakpoint (see the cache-injection test).
+	finalBlocks := finalUser["content"].([]any)
+	require.Len(t, finalBlocks, 1)
+	assert.Equal(t, "Now edit it to add a hello world print", finalBlocks[0].(map[string]any)["text"])
+}
+
+var openAICacheInjectionConversation = []byte(`{
+	"model": "gpt-4",
+	"messages": [
+		{"role": "system", "content": "First system."},
+		{"role": "system", "content": "Second system."},
+		{"role": "user", "content": "First question."},
+		{"role": "assistant", "content": "First answer."},
+		{"role": "user", "content": "Second question."}
+	],
+	"max_tokens": 1024
+}`)
+
+var ephemeral = map[string]any{"type": "ephemeral"}
+
+// TestCrossFormat_OpenAIToAnthropic_CacheControlInjection pins the prompt-cache
+// breakpoint injection on the OpenAI->Anthropic path: clients like Cursor send
+// no cache_control, so the router marks the last system block (caches the
+// tools+system floor) and the last block of the final message (caches the
+// conversation prefix) — and nothing else.
+func TestCrossFormat_OpenAIToAnthropic_CacheControlInjection(t *testing.T) {
+	env, err := translate.ParseOpenAI(openAICacheInjectionConversation)
+	require.NoError(t, err)
+
+	prep, err := env.PrepareAnthropic(http.Header{}, translate.EmitOptions{TargetModel: "claude-sonnet-4-20250514"})
+	require.NoError(t, err)
+	doc := unmarshalBody(t, prep.Body)
+
+	// Only the LAST system block carries the breakpoint.
+	sys := getArray(t, doc, "system")
+	require.Len(t, sys, 2)
+	assert.Nil(t, sys[0].(map[string]any)["cache_control"], "non-last system block must not be marked")
+	assert.Equal(t, ephemeral, sys[1].(map[string]any)["cache_control"], "last system block must be marked")
+
+	msgs := getArray(t, doc, "messages")
+	require.Len(t, msgs, 3)
+
+	// Non-last messages keep plain string content, unmarked.
+	first := msgAt(t, msgs, 0)
+	assert.Equal(t, "First question.", first["content"])
+
+	// The final message's string content is promoted to a single text block
+	// carrying the breakpoint.
+	last := msgAt(t, msgs, 2)
+	lastBlocks := last["content"].([]any)
+	require.Len(t, lastBlocks, 1)
+	lastBlock := lastBlocks[0].(map[string]any)
+	assert.Equal(t, "text", lastBlock["type"])
+	assert.Equal(t, "Second question.", lastBlock["text"])
+	assert.Equal(t, ephemeral, lastBlock["cache_control"])
+}
+
+var openAICacheInjectionToolResultLast = []byte(`{
+	"model": "gpt-4",
+	"messages": [
+		{"role": "user", "content": "Read it"},
+		{"role": "assistant", "content": null, "tool_calls": [
+			{"id": "call_1", "type": "function", "function": {"name": "Read", "arguments": "{}"}}
+		]},
+		{"role": "tool", "tool_call_id": "call_1", "content": "file contents"}
+	],
+	"max_tokens": 1024
+}`)
+
+// TestCrossFormat_OpenAIToAnthropic_CacheControlArrayLastBlock covers the case
+// where the final message already has array content (a tool_result batch): the
+// breakpoint attaches to the last block in place, without promotion.
+func TestCrossFormat_OpenAIToAnthropic_CacheControlArrayLastBlock(t *testing.T) {
+	env, err := translate.ParseOpenAI(openAICacheInjectionToolResultLast)
+	require.NoError(t, err)
+
+	prep, err := env.PrepareAnthropic(http.Header{}, translate.EmitOptions{TargetModel: "claude-sonnet-4-20250514"})
+	require.NoError(t, err)
+	doc := unmarshalBody(t, prep.Body)
+
+	msgs := getArray(t, doc, "messages")
+	last := msgAt(t, msgs, len(msgs)-1)
+	blocks := last["content"].([]any)
+	require.NotEmpty(t, blocks)
+	lastBlock := blocks[len(blocks)-1].(map[string]any)
+	assert.Equal(t, "tool_result", lastBlock["type"], "last block stays a tool_result")
+	assert.Equal(t, "file contents", lastBlock["content"])
+	assert.Equal(t, ephemeral, lastBlock["cache_control"], "breakpoint attaches to the existing last block")
 }
 
 func TestCrossFormat_OpenAIToAnthropic_Image(t *testing.T) {

--- a/internal/translate/emit_anthropic.go
+++ b/internal/translate/emit_anthropic.go
@@ -213,7 +213,12 @@ func writeAnthropicSystemAndMessages(jw *jsonWriter, body []byte) {
 	if len(systemBlocks) > 0 {
 		jw.Key("system")
 		jw.Arr()
-		for _, b := range systemBlocks {
+		for i, b := range systemBlocks {
+			// Cache the system + tools prefix (the large stable floor) by
+			// marking the last system block.
+			if i == len(systemBlocks)-1 {
+				b = appendCacheControl(b)
+			}
 			jw.Raw(b)
 		}
 		jw.EndArr()
@@ -222,11 +227,92 @@ func writeAnthropicSystemAndMessages(jw *jsonWriter, body []byte) {
 	if len(msgParts) > 0 {
 		jw.Key("messages")
 		jw.Arr()
-		for _, m := range msgParts {
+		for i, m := range msgParts {
+			// Cache the conversation prefix up to this turn by marking the
+			// last block of the final message; on the next turn that block is
+			// a stable prefix and reads from cache.
+			if i == len(msgParts)-1 {
+				m = cacheControlOnLastBlock(m)
+			}
 			jw.Raw(m)
 		}
 		jw.EndArr()
 	}
+}
+
+// cacheControlMember is the Anthropic prompt-cache breakpoint, serialized as a
+// JSON object member. OpenAI and Gemini clients never send cache_control, so on
+// the OpenAI->Anthropic path the router injects it: without breakpoints, clients
+// like Cursor re-bill the entire stable prefix (tools + system + prior turns) on
+// every turn at 0% cache hit, because Anthropic has no implicit prompt caching.
+// Below the model's minimum cacheable prefix the marker is a silent no-op, so it
+// is always safe to add.
+const cacheControlMember = `"cache_control":{"type":"ephemeral"}`
+
+// appendCacheControl inserts the cache_control marker into a raw JSON content
+// block. The block is one we constructed, so its final byte is the closing brace
+// of the outer object; the guard keeps it fail-open on anything unexpected.
+func appendCacheControl(block string) string {
+	if len(block) < 2 || block[len(block)-1] != '}' || !strings.Contains(block, ":") {
+		return block
+	}
+	return block[:len(block)-1] + "," + cacheControlMember + "}"
+}
+
+// cacheControlOnLastBlock returns a raw Anthropic message object with a
+// cache_control breakpoint on its final content block. String content is
+// promoted to a single text block to carry the marker (Anthropic treats "x" and
+// [{"type":"text","text":"x"}] identically). Messages built on this path only
+// ever carry "role" and "content", so rebuilding from those two is lossless.
+func cacheControlOnLastBlock(msg string) string {
+	content := gjson.Get(msg, "content")
+	role := gjson.Get(msg, "role").String()
+
+	if content.IsArray() {
+		blocks := content.Array()
+		if len(blocks) == 0 {
+			return msg
+		}
+		jw := newJSONWriter()
+		jw.Obj()
+		jw.Key("role")
+		jw.Str(role)
+		jw.Key("content")
+		jw.Arr()
+		for i, b := range blocks {
+			if i == len(blocks)-1 {
+				jw.Raw(appendCacheControl(b.Raw))
+			} else {
+				jw.Raw(b.Raw)
+			}
+		}
+		jw.EndArr()
+		jw.EndObj()
+		return string(jw.Bytes())
+	}
+
+	if content.Type == gjson.String {
+		jw := newJSONWriter()
+		jw.Obj()
+		jw.Key("role")
+		jw.Str(role)
+		jw.Key("content")
+		jw.Arr()
+		jw.Obj()
+		jw.Key("type")
+		jw.Str("text")
+		jw.Key("text")
+		jw.Str(content.String())
+		jw.Key("cache_control")
+		jw.Raw(`{"type":"ephemeral"}`)
+		jw.EndObj()
+		jw.EndArr()
+		jw.EndObj()
+		return string(jw.Bytes())
+	}
+
+	// null / scalar content: no block to attach a breakpoint to.
+	return msg
 }
 
 // buildToolResultBlock constructs a single Anthropic tool_result JSON object.


### PR DESCRIPTION
## Problem

OpenAI- and Gemini-format clients never send Anthropic `cache_control` breakpoints, and Anthropic has **no implicit prompt caching**. So any cross-format client re-bills the entire stable prefix (tools + system + prior turns) on **every** turn at ~0% cache hit.

A prod traffic study found this is the single largest cost line: **Cursor is ~78% of router spend at ~11.6% cache hit**, versus ~47% on native-Anthropic (Claude Code) traffic which sends its own breakpoints. The same Cursor traffic routed to Gemini caches at ~48% because Gemini does implicit caching — Anthropic is the outlier precisely because it requires explicit breakpoints.

## Change

In `buildAnthropicFromOpenAI` (the only path that builds an Anthropic body from a non-Anthropic client), inject two ephemeral breakpoints:

1. **last `system` block** — caches the tools + system floor (render order is tools → system, so one breakpoint on the last system block caches both).
2. **last block of the final message** — caches the conversation prefix up to this turn; on the next turn that block is a stable prefix and reads from cache (the standard multi-turn rolling pattern).

String content on the final message is promoted to a single text block to carry the marker (Anthropic treats `"x"` and `[{"type":"text","text":"x"}]` identically). Below a model's minimum cacheable prefix the marker is a silent no-op, so injection is always safe, and we use 2 of the 4 allowed breakpoints.

**Scope:** only `buildAnthropicFromOpenAI`. Native Anthropic clients are untouched — they hit a different path and bring their own `cache_control`. No new env flag / config plumbing.

## Tests

- New `TestCrossFormat_OpenAIToAnthropic_CacheControlInjection` — asserts only the last system block is marked (not earlier ones), the final string message is promoted + marked, and non-last messages stay unmarked.
- New `TestCrossFormat_OpenAIToAnthropic_CacheControlArrayLastBlock` — final message with array content (tool_result batch) gets the marker on the existing last block, in place, no promotion.
- Updated two existing crossformat assertions for the promoted final-message shape.
- Full suite green (`go build ./...`, `go vet`, `go test ./...` — 26 packages, 0 failures).

## Expected impact

~$2,900 per ~2-day window (~\$44k/mo at current Cursor volume), low risk — `cache_control` is append-only metadata and a misplaced breakpoint degrades to a cache miss, not a wrong answer. Verify post-deploy via `cache_read_input_tokens` on Cursor sessions (expect ~12% → ~50%+).

🤖 Generated with [Claude Code](https://claude.com/claude-code)