### PR TITLE
feat(telemetry): join request telemetry to spiral_shadow_events via session_key + role

### DIFF
--- a/db/migrations/0021_telemetry-session-key-join.down.sql
+++ b/db/migrations/0021_telemetry-session-key-join.down.sql
@@ -1,0 +1,16 @@
+BEGIN;
+
+-- Rebuild the view against the pre-0021 column set first (it would otherwise
+-- still reference the dropped columns through its frozen SELECT * list).
+DROP VIEW router.production_request_telemetry;
+
+ALTER TABLE router.model_router_request_telemetry
+    DROP COLUMN role,
+    DROP COLUMN session_key;
+
+CREATE VIEW router.production_request_telemetry AS
+SELECT * FROM router.model_router_request_telemetry
+WHERE span_type = 'router.upstream'
+  AND (client_app IS NULL OR client_app NOT LIKE 'weave-eval%');
+
+COMMIT;

--- a/db/migrations/0021_telemetry-session-key-join.up.sql
+++ b/db/migrations/0021_telemetry-session-key-join.up.sql
@@ -1,0 +1,32 @@
+BEGIN;
+
+-- Add the session join key so request telemetry can be correlated offline with
+-- the behavioral-signal sidecar in router.spiral_shadow_events. That table's
+-- own header documents the intended join "by session_key against
+-- model_router_request_telemetry", but the column was never wired in here, so
+-- the join was impossible. (session_key, role) together match the
+-- spiral_shadow_events / session_pins composite key exactly.
+--
+-- session_key is the same 16-byte one-way digest already persisted as BYTEA in
+-- session_pins and spiral_shadow_events -- no new identifier is exposed. Both
+-- columns are nullable: pre-existing rows stay NULL.
+ALTER TABLE router.model_router_request_telemetry
+    ADD COLUMN session_key BYTEA,
+    ADD COLUMN role        VARCHAR;
+
+COMMENT ON COLUMN router.model_router_request_telemetry.session_key IS
+    '16-byte session digest (matches session_pins / spiral_shadow_events). NULL on rows written before this column existed. Join key to spiral_shadow_events on (installation_id, session_key, role).';
+COMMENT ON COLUMN router.model_router_request_telemetry.role IS
+    'Session-pin role used for the turn (roleForTier of the requested model). Pairs with session_key to identify the turn thread; matches spiral_shadow_events.role.';
+
+-- Recreate the production-traffic view: a CREATE VIEW ... SELECT * freezes its
+-- column list at creation time, so the two new columns would never surface
+-- through the view without this rebuild. Definition otherwise unchanged from
+-- migration 0019.
+DROP VIEW router.production_request_telemetry;
+CREATE VIEW router.production_request_telemetry AS
+SELECT * FROM router.model_router_request_telemetry
+WHERE span_type = 'router.upstream'
+  AND (client_app IS NULL OR client_app NOT LIKE 'weave-eval%');
+
+COMMIT;

--- a/db/queries/model_router_request_telemetry.sql
+++ b/db/queries/model_router_request_telemetry.sql
@@ -9,6 +9,8 @@
 -- rollout_id is the client-supplied x-weave-rollout-id correlation id used by
 -- eval/training harnesses to join graded rollout rewards onto decisions; NULL
 -- for all non-harness traffic.
+-- session_key + role are the offline join key to router.spiral_shadow_events
+-- and session_pins; NULL on rows written before the columns existed.
 -- name: InsertRequestTelemetry :exec
 INSERT INTO router.model_router_request_telemetry (
     installation_id,
@@ -55,7 +57,9 @@ INSERT INTO router.model_router_request_telemetry (
     tool_use_blocks,
     invalid_tool_args_blocks,
     failover_used,
-    degenerate_shadow
+    degenerate_shadow,
+    session_key,
+    role
 ) VALUES (
     @installation_id::uuid,
     @request_id::varchar,
@@ -101,7 +105,9 @@ INSERT INTO router.model_router_request_telemetry (
     sqlc.narg('tool_use_blocks')::int,
     sqlc.narg('invalid_tool_args_blocks')::int,
     sqlc.narg('failover_used')::boolean,
-    sqlc.narg('degenerate_shadow')::boolean
+    sqlc.narg('degenerate_shadow')::boolean,
+    sqlc.narg('session_key')::bytea,
+    sqlc.narg('role')::varchar
 )
 ON CONFLICT (installation_id, request_id, span_type) DO NOTHING;
 

--- a/internal/postgres/telemetry.go
+++ b/internal/postgres/telemetry.go
@@ -96,6 +96,8 @@ func (r *TelemetryRepo) InsertRequestTelemetry(ctx context.Context, p proxy.Inse
 		InvalidToolArgsBlocks:  p.InvalidToolArgsBlocks,
 		FailoverUsed:           p.FailoverUsed,
 		DegenerateShadow:       p.DegenerateShadow,
+		SessionKey:             p.SessionKey,
+		Role:                   stringPtrOrNil(p.Role),
 	})
 }
 

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -1757,6 +1757,16 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 			InvalidToolArgsBlocks: int32PtrIfKnown(int32(respSummary.InvalidToolArgsBlocks), respSummary.StopReason != ""),
 			FailoverUsed:          boolPtrTrue(failoverUsed),
 			DegenerateShadow:      boolPtrOrNil(degShadow),
+			// (session_key, role) are the offline join key to spiral_shadow_events
+			// and session_pins. sessionKey is the bindRequestLogger digest — the
+			// SAME DeriveSessionKey(env, apiKeyID) the turn loop and spiral use, but
+			// computed unconditionally, so it is populated even on hard-pin turns
+			// and no-pin-store paths where routeRes.SessionKey stays zero. On the
+			// main_loop/tool_result turns spiral actually writes, the two are equal
+			// byte-for-byte. role mirrors routeRes.PinRole (set unconditionally) =
+			// roleForTier(catalog.TierFor(feats.Model)), the spiral join value.
+			SessionKey: sessionKey[:],
+			Role:       routeRes.PinRole,
 		})
 	}
 
@@ -2839,6 +2849,9 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 			TurnType:               string(routeRes.TurnType),
 			RolloutID:              clientID.RolloutID,
 			FailoverUsed:           boolPtrTrue(finalProvider != primaryProvider),
+			// (session_key, role) join key — see the Anthropic-path write site.
+			SessionKey: sessionKey[:],
+			Role:       routeRes.PinRole,
 		})
 	}
 

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -1271,7 +1271,13 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 	if s.spiralShadowEnabled && (tt == turntype.MainLoop || tt == turntype.ToolResult) {
 		if reasons := spiralReasons(inboundSpiralSignals); len(reasons) > 0 {
 			role := roleForTier(catalog.TierFor(feats.Model))
-			s.handleSpiralShadow(ctx, inboundSpiralSignals, reasons, installationID, routeRes.SessionKey, role, decision.Model, string(tt))
+			// Use the bindRequestLogger digest (same DeriveSessionKey, computed
+			// unconditionally) rather than routeRes.SessionKey, which is zero
+			// when no pin store is configured. This keeps the spiral event's
+			// session_key equal to the telemetry row's in every mode so the
+			// offline join holds; in the pinned production path the two are
+			// already identical, so this is a no-op there.
+			s.handleSpiralShadow(ctx, inboundSpiralSignals, reasons, installationID, sessionKey, role, decision.Model, string(tt))
 		}
 	}
 

--- a/internal/proxy/service_observation_test.go
+++ b/internal/proxy/service_observation_test.go
@@ -341,6 +341,41 @@ func TestProxyMessages_PersistsRolloutID(t *testing.T) {
 	assert.Equal(t, rolloutID, row.RolloutID)
 }
 
+// TestProxyMessages_PersistsSessionKeyAndRole asserts the offline join key to
+// router.spiral_shadow_events / session_pins lands on the telemetry row.
+// session_key must be the 16-byte digest (never empty for a real request), and
+// role must be roleForTier(TierFor(requestedModel)) — the exact value spiral
+// shadow events are keyed on, so the join matches byte-for-byte. The requested
+// model here is claude-opus-4-7 (TierHigh) → "default_high", regardless of the
+// cheaper decision model the router picked.
+func TestProxyMessages_PersistsSessionKeyAndRole(t *testing.T) {
+	const installID = "77777777-7777-7777-7777-777777777777"
+	decision := router.Decision{
+		Provider: providers.ProviderAnthropic,
+		Model:    "claude-haiku-4-5",
+		Reason:   "pin",
+	}
+	telem := newCaptureTelemetry()
+	svc := proxy.NewService(
+		&fakeRouter{decision: decision},
+		map[string]providers.Client{providers.ProviderAnthropic: &fakeProvider{}},
+		nil, false, nil, nil, false,
+		providers.ProviderAnthropic, "claude-haiku-4-5",
+		telem,
+	)
+
+	ctx := context.WithValue(context.Background(), proxy.InstallationIDContextKey{}, installID)
+	rec := httptest.NewRecorder()
+	body := []byte(`{"model":"claude-opus-4-7","messages":[{"role":"user","content":"hello"}]}`)
+	httpReq := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(""))
+	require.NoError(t, svc.ProxyMessages(ctx, body, rec, httpReq))
+
+	row := telem.firstRow(t)
+	require.Len(t, row.SessionKey, 16, "session_key must be the 16-byte digest, not empty")
+	assert.NotEqual(t, make([]byte, 16), row.SessionKey, "session_key must be a real (non-zero) digest")
+	assert.Equal(t, "default_high", row.Role, "role must be the requested model's pin role (opus-4-7 = TierHigh)")
+}
+
 // TestNormalizeRolloutID covers the bound: oversized ids are rejected (not
 // truncated) so a stored id always joins back to a real rollout.
 func TestNormalizeRolloutID(t *testing.T) {

--- a/internal/proxy/telemetry.go
+++ b/internal/proxy/telemetry.go
@@ -70,6 +70,12 @@ type InsertTelemetryParams struct {
 	InvalidToolArgsBlocks *int32
 	FailoverUsed          *bool
 	DegenerateShadow      *bool
+
+	// SessionKey + Role are the offline join key to spiral_shadow_events and
+	// session_pins (16-byte digest + roleForTier of the requested model). Nil /
+	// empty leaves the columns NULL.
+	SessionKey []byte
+	Role       string
 }
 
 // TelemetrySummary holds aggregated totals for the dashboard cards.

--- a/internal/sqlc/model_router_request_telemetry.sql.go
+++ b/internal/sqlc/model_router_request_telemetry.sql.go
@@ -794,7 +794,9 @@ INSERT INTO router.model_router_request_telemetry (
     tool_use_blocks,
     invalid_tool_args_blocks,
     failover_used,
-    degenerate_shadow
+    degenerate_shadow,
+    session_key,
+    role
 ) VALUES (
     $1::uuid,
     $2::varchar,
@@ -840,7 +842,9 @@ INSERT INTO router.model_router_request_telemetry (
     $42::int,
     $43::int,
     $44::boolean,
-    $45::boolean
+    $45::boolean,
+    $46::bytea,
+    $47::varchar
 )
 ON CONFLICT (installation_id, request_id, span_type) DO NOTHING
 `
@@ -891,6 +895,8 @@ type InsertRequestTelemetryParams struct {
 	InvalidToolArgsBlocks  *int32
 	FailoverUsed           *bool
 	DegenerateShadow       *bool
+	SessionKey             []byte
+	Role                   *string
 }
 
 // Records a completed proxied request for the dashboard UI and routing
@@ -904,6 +910,8 @@ type InsertRequestTelemetryParams struct {
 // rollout_id is the client-supplied x-weave-rollout-id correlation id used by
 // eval/training harnesses to join graded rollout rewards onto decisions; NULL
 // for all non-harness traffic.
+// session_key + role are the offline join key to router.spiral_shadow_events
+// and session_pins; NULL on rows written before the columns existed.
 //
 //	INSERT INTO router.model_router_request_telemetry (
 //	    installation_id,
@@ -950,7 +958,9 @@ type InsertRequestTelemetryParams struct {
 //	    tool_use_blocks,
 //	    invalid_tool_args_blocks,
 //	    failover_used,
-//	    degenerate_shadow
+//	    degenerate_shadow,
+//	    session_key,
+//	    role
 //	) VALUES (
 //	    $1::uuid,
 //	    $2::varchar,
@@ -996,7 +1006,9 @@ type InsertRequestTelemetryParams struct {
 //	    $42::int,
 //	    $43::int,
 //	    $44::boolean,
-//	    $45::boolean
+//	    $45::boolean,
+//	    $46::bytea,
+//	    $47::varchar
 //	)
 //	ON CONFLICT (installation_id, request_id, span_type) DO NOTHING
 func (q *Queries) InsertRequestTelemetry(ctx context.Context, arg InsertRequestTelemetryParams) error {
@@ -1046,6 +1058,8 @@ func (q *Queries) InsertRequestTelemetry(ctx context.Context, arg InsertRequestT
 		arg.InvalidToolArgsBlocks,
 		arg.FailoverUsed,
 		arg.DegenerateShadow,
+		arg.SessionKey,
+		arg.Role,
 	)
 	return err
 }

--- a/internal/sqlc/models.go
+++ b/internal/sqlc/models.go
@@ -125,6 +125,10 @@ type RouterModelRouterRequestTelemetry struct {
 	InvalidToolArgsBlocks  *int32
 	FailoverUsed           *bool
 	DegenerateShadow       *bool
+	// 16-byte session digest (matches session_pins / spiral_shadow_events). NULL on rows written before this column existed. Join key to spiral_shadow_events on (installation_id, session_key, role).
+	SessionKey []byte
+	// Session-pin role used for the turn (roleForTier of the requested model). Pairs with session_key to identify the turn thread; matches spiral_shadow_events.role.
+	Role *string
 }
 
 // End-user identities seen on inbound requests, scoped to an installation. Replaces the per-user API key pattern.
@@ -218,6 +222,8 @@ type RouterProductionRequestTelemetry struct {
 	InvalidToolArgsBlocks  *int32
 	FailoverUsed           *bool
 	DegenerateShadow       *bool
+	SessionKey             []byte
+	Role                   *string
 }
 
 // User-submitted /router-feedback about routing decisions or model performance


### PR DESCRIPTION
## Problem

`router.spiral_shadow_events` documents its intended correlation **"Joined offline by session_key against `model_router_request_telemetry`"** — but `model_router_request_telemetry` never had a `session_key` column (only `session_id`, which collapses sub-agent threads and isn't the pin key). So the join was impossible: the shadow spiral detectors we already ship emit events that can't be tied back to per-turn outcomes.

This is **action item #5** (the foundational one) from the router right-sizing study — the prerequisite to ever doing calibrated escalation / outcome-driven routing better than hand-tuned thresholds.

## What changed

Scope turned out smaller than the study's "add session_key **+** a new `turn_outcomes` table" framing: `model_router_request_telemetry` **already** captures the per-turn outcome signal set (`output_tokens`, `tool_use_blocks`, `invalid_tool_args_blocks`, `stop_reason`, `upstream_finish_reason`, `degenerate_shadow`, `failover_used`, `turn_type`, cache tokens). The behavioral signals it lacks (`err_streak`, `repeat_frac`, `monologue_len`) already live in `spiral_shadow_events`. So the **only** real gap was the join key.

- **Migration 0021**: add nullable `session_key BYTEA` + `role VARCHAR`; recreate `production_request_telemetry` (a `CREATE VIEW … SELECT *` freezes its column list at creation, so the new columns wouldn't surface through the view without a rebuild — body otherwise verbatim from 0019).
- `InsertRequestTelemetry` query + sqlc regen + `proxy.InsertTelemetryParams` / `postgres` adapter wiring.
- Populate at both write sites (`ProxyMessages` + `ProxyOpenAIChatCompletion`).

### Why the `bindRequestLogger` digest, not `routeRes.SessionKey`

`runTurnLoop` only sets `res.SessionKey` after the `pinStore == nil` early-return, and skips it entirely on the hard-pin path (probe/title-gen/compaction/classifier) — so `routeRes.SessionKey` is zero on those turns. The `sessionKey` local from `bindRequestLogger` is the **same** `DeriveSessionKey(env, apiKeyID)` computed **unconditionally**, so probe/compaction rows get a real key too. On the `main_loop`/`tool_result` turns spiral actually writes, the two values are equal byte-for-byte, so `(session_key, role)` matches the spiral join key exactly. `role` mirrors `routeRes.PinRole` = `roleForTier(catalog.TierFor(feats.Model))` — the same value spiral keys on (and it's set unconditionally at turnloop top).

## Risk

Additive, nullable columns; **no routing behavior changes**. `session_key` is the same 16-byte one-way digest already stored as BYTEA in `session_pins` and `spiral_shadow_events` — no new identifier is exposed.

## Tests

- `go build ./...`, `go vet ./...`, `go test ./...` — 26 packages, 0 failures.
- New `TestProxyMessages_PersistsSessionKeyAndRole` locks the join columns (16-byte non-zero key + correct pin role).
- **Not yet applied to a live Postgres** — validated via sqlc schema parse (which checks the view's column refs) + verbatim-from-0019 view body. Live apply via `wv db run-migrations -r`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)