### PR TITLE
feat(telemetry): capture fresh scorer recommendation on STAY turns (hysteresis shadow)

### DIFF
--- a/db/migrations/0022_telemetry-fresh-scorer-shadow.down.sql
+++ b/db/migrations/0022_telemetry-fresh-scorer-shadow.down.sql
@@ -1,0 +1,17 @@
+BEGIN;
+
+-- Rebuild the view against the pre-0022 column set first (its frozen SELECT *
+-- list still references the dropped columns otherwise).
+DROP VIEW router.production_request_telemetry;
+
+ALTER TABLE router.model_router_request_telemetry
+    DROP COLUMN pin_age_sec,
+    DROP COLUMN fresh_candidate_scores,
+    DROP COLUMN fresh_decision_model;
+
+CREATE VIEW router.production_request_telemetry AS
+SELECT * FROM router.model_router_request_telemetry
+WHERE span_type = 'router.upstream'
+  AND (client_app IS NULL OR client_app NOT LIKE 'weave-eval%');
+
+COMMIT;

--- a/db/migrations/0022_telemetry-fresh-scorer-shadow.up.sql
+++ b/db/migrations/0022_telemetry-fresh-scorer-shadow.up.sql
@@ -1,0 +1,37 @@
+BEGIN;
+
+-- Shadow-mode instrumentation for the right-sizing study's hysteresis lever
+-- (action item #2). On a main_loop turn the cluster scorer always runs and
+-- produces a fresh recommendation + score vector, but on a STAY outcome the
+-- final decision rehydrates from the session pin (which carries no scores), so
+-- buildObservationContext logged NULL candidate_scores. The fresh vector was
+-- computed and discarded -- exactly the turns where "we stayed on opus but a
+-- cheaper model was within tau" lives.
+--
+-- These columns capture the fresh scorer's recommendation on EVERY scored turn
+-- (including STAY), so the downgrade opportunity can be measured offline (sweep
+-- tau over fresh_candidate_scores vs decision_model + catalog tier) before any
+-- hysteresis downgrade is armed. Pure telemetry: no routing behavior changes.
+-- All nullable: hard-pin / tool_result / non-cluster turns leave them NULL.
+ALTER TABLE router.model_router_request_telemetry
+    ADD COLUMN fresh_decision_model   VARCHAR,
+    ADD COLUMN fresh_candidate_scores JSONB,
+    ADD COLUMN pin_age_sec            BIGINT;
+
+COMMENT ON COLUMN router.model_router_request_telemetry.fresh_decision_model IS
+    'The cluster scorer''s fresh pick for this turn, recorded even when the planner returned STAY (decision_model then names the pinned model served). NULL when the scorer did not run.';
+COMMENT ON COLUMN router.model_router_request_telemetry.fresh_candidate_scores IS
+    'The fresh pre-argmax score vector (model -> blended score) from this turn''s scorer run, recorded even on STAY. Sweep tau against served decision_model + catalog tier to measure the hysteresis downgrade opportunity. NULL when the scorer did not run.';
+COMMENT ON COLUMN router.model_router_request_telemetry.pin_age_sec IS
+    'Age of the loaded session pin in seconds at decision time; supports min-dwell analysis for the hysteresis policy. NULL when no pin was loaded.';
+
+-- Recreate the production-traffic view so the new columns surface through it
+-- (CREATE VIEW ... SELECT * freezes its column list at creation). Body
+-- unchanged from migration 0019/0021.
+DROP VIEW router.production_request_telemetry;
+CREATE VIEW router.production_request_telemetry AS
+SELECT * FROM router.model_router_request_telemetry
+WHERE span_type = 'router.upstream'
+  AND (client_app IS NULL OR client_app NOT LIKE 'weave-eval%');
+
+COMMIT;

--- a/db/queries/model_router_request_telemetry.sql
+++ b/db/queries/model_router_request_telemetry.sql
@@ -11,6 +11,11 @@
 -- for all non-harness traffic.
 -- session_key + role are the offline join key to router.spiral_shadow_events
 -- and session_pins; NULL on rows written before the columns existed.
+-- fresh_decision_model + fresh_candidate_scores capture the scorer's fresh
+-- recommendation even on STAY turns (where decision_model names the pinned
+-- model served); pin_age_sec supports min-dwell analysis. Shadow-mode
+-- instrumentation for the hysteresis downgrade lever; NULL when the scorer did
+-- not run / no pin was loaded.
 -- name: InsertRequestTelemetry :exec
 INSERT INTO router.model_router_request_telemetry (
     installation_id,
@@ -59,7 +64,10 @@ INSERT INTO router.model_router_request_telemetry (
     failover_used,
     degenerate_shadow,
     session_key,
-    role
+    role,
+    fresh_decision_model,
+    fresh_candidate_scores,
+    pin_age_sec
 ) VALUES (
     @installation_id::uuid,
     @request_id::varchar,
@@ -107,7 +115,10 @@ INSERT INTO router.model_router_request_telemetry (
     sqlc.narg('failover_used')::boolean,
     sqlc.narg('degenerate_shadow')::boolean,
     sqlc.narg('session_key')::bytea,
-    sqlc.narg('role')::varchar
+    sqlc.narg('role')::varchar,
+    sqlc.narg('fresh_decision_model')::varchar,
+    sqlc.narg('fresh_candidate_scores')::jsonb,
+    sqlc.narg('pin_age_sec')::bigint
 )
 ON CONFLICT (installation_id, request_id, span_type) DO NOTHING;
 

--- a/internal/postgres/telemetry.go
+++ b/internal/postgres/telemetry.go
@@ -98,6 +98,9 @@ func (r *TelemetryRepo) InsertRequestTelemetry(ctx context.Context, p proxy.Inse
 		DegenerateShadow:       p.DegenerateShadow,
 		SessionKey:             p.SessionKey,
 		Role:                   stringPtrOrNil(p.Role),
+		FreshDecisionModel:     stringPtrOrNil(p.FreshDecisionModel),
+		FreshCandidateScores:   p.FreshCandidateScores,
+		PinAgeSec:              p.PinAgeSec,
 	})
 }
 

--- a/internal/proxy/observation.go
+++ b/internal/proxy/observation.go
@@ -32,13 +32,39 @@ type observationContext struct {
 	// acting policy. Pointer so 0.0 stays distinct from "not a cluster
 	// decision". 1.0 for deterministic argmax.
 	Propensity *float64
+	// FreshDecisionModel is the scorer's fresh pick this turn, captured even
+	// when the planner returned STAY (decision_model then names the pinned model
+	// served). Empty when the scorer did not run. Shadow-mode instrumentation
+	// for the hysteresis downgrade lever.
+	FreshDecisionModel string
+	// FreshCandidateScores is the fresh scorer's pre-argmax score vector
+	// marshaled to JSON, captured even on STAY. Distinct from CandidateScores,
+	// which mirrors the FINAL decision and is NULL on STAY. nil when the scorer
+	// did not run / exposed no vector.
+	FreshCandidateScores []byte
 }
 
 // buildObservationContext derives the observation bundle from the routing
 // decision and request context. Nil-safe: returns a zero value when sources
-// are absent.
-func buildObservationContext(ctx context.Context, decision router.Decision) observationContext {
+// are absent. fresh is the scorer's recommendation this turn (which equals
+// decision on a SWITCH/fresh-pin write, but differs on a STAY where decision
+// rehydrates from the pin); its score vector is captured separately so the
+// hysteresis downgrade opportunity is measurable on STAY turns.
+func buildObservationContext(ctx context.Context, decision, fresh router.Decision) observationContext {
 	obs := observationContext{}
+	// Fresh scorer recommendation, captured independently of the final decision
+	// so STAY turns (decision == pin, no metadata) still record what a re-score
+	// would have picked.
+	if fresh.Model != "" {
+		obs.FreshDecisionModel = fresh.Model
+	}
+	if md := fresh.Metadata; md != nil && len(md.CandidateScores) > 0 {
+		if b, err := json.Marshal(md.CandidateScores); err == nil {
+			obs.FreshCandidateScores = b
+		} else {
+			observability.Get().Debug("Failed to marshal fresh_candidate_scores for telemetry", "err", err)
+		}
+	}
 	if md := decision.Metadata; md != nil {
 		if len(md.ClusterIDs) > 0 {
 			obs.ClusterIDs = make([]int32, len(md.ClusterIDs))

--- a/internal/proxy/observation_internal_test.go
+++ b/internal/proxy/observation_internal_test.go
@@ -1,0 +1,65 @@
+package proxy
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"workweave/router/internal/router"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestBuildObservationContext_CapturesFreshOnStay is the load-bearing assertion
+// for the hysteresis shadow instrumentation: on a STAY the final decision
+// rehydrates from the pin and carries NO metadata (so CandidateScores is NULL),
+// but the fresh scorer DID run this turn. buildObservationContext must capture
+// the fresh pick + score vector independently so the downgrade opportunity is
+// measurable offline.
+func TestBuildObservationContext_CapturesFreshOnStay(t *testing.T) {
+	// Final (served) decision = the pinned model, no metadata — the STAY shape.
+	served := router.Decision{
+		Provider: "anthropic",
+		Model:    "claude-opus-4-8",
+		Reason:   "pin",
+	}
+	// Fresh scorer recommendation this turn: a cheaper model nearly ties opus.
+	fresh := router.Decision{
+		Provider: "anthropic",
+		Model:    "claude-haiku-4-5",
+		Reason:   "cluster:v-test",
+		Metadata: &router.RoutingMetadata{
+			CandidateModels: []string{"claude-opus-4-8", "claude-haiku-4-5"},
+			ChosenScore:     0.82,
+			CandidateScores: map[string]float32{"claude-opus-4-8": 0.83, "claude-haiku-4-5": 0.82},
+			Propensity:      1.0,
+		},
+	}
+
+	obs := buildObservationContext(context.Background(), served, fresh)
+
+	// Final-decision columns stay NULL on a STAY (served pin has no metadata).
+	assert.Nil(t, obs.CandidateScores, "final CandidateScores must be NULL on a STAY")
+	assert.Nil(t, obs.ChosenScore)
+
+	// Fresh columns must be populated from the scorer's recommendation.
+	assert.Equal(t, "claude-haiku-4-5", obs.FreshDecisionModel)
+	require.NotNil(t, obs.FreshCandidateScores, "fresh score vector must be captured on a STAY")
+	var got map[string]float32
+	require.NoError(t, json.Unmarshal(obs.FreshCandidateScores, &got))
+	assert.InDelta(t, 0.83, got["claude-opus-4-8"], 1e-6)
+	assert.InDelta(t, 0.82, got["claude-haiku-4-5"], 1e-6)
+}
+
+// TestBuildObservationContext_NoScorerLeavesFreshNull: when the scorer did not
+// run (hard-pin / tool_result), fresh is a zero Decision, so the fresh columns
+// stay NULL rather than logging a phantom model.
+func TestBuildObservationContext_NoScorerLeavesFreshNull(t *testing.T) {
+	served := router.Decision{Provider: "anthropic", Model: "claude-opus-4-8", Reason: "tool_result_sc"}
+
+	obs := buildObservationContext(context.Background(), served, router.Decision{})
+
+	assert.Empty(t, obs.FreshDecisionModel)
+	assert.Nil(t, obs.FreshCandidateScores)
+}

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -1680,7 +1680,7 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 	applyPlannerAttrs(upstreamBuilder, routeRes)
 	addTimingAttrs(ctx, upstreamBuilder)
 
-	obs := buildObservationContext(ctx, decision)
+	obs := buildObservationContext(ctx, decision, routeRes.Fresh)
 	obs.applySpanAttrs(upstreamBuilder)
 
 	otel.Record(ctx, otel.Span{
@@ -1773,6 +1773,13 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 			// roleForTier(catalog.TierFor(feats.Model)), the spiral join value.
 			SessionKey: sessionKey[:],
 			Role:       routeRes.PinRole,
+			// Shadow-mode hysteresis instrumentation: the fresh scorer's pick +
+			// score vector (captured even on STAY, where obs.CandidateScores is
+			// NULL) and the loaded pin's age, so the downgrade opportunity is
+			// measurable offline. No routing action is taken on these.
+			FreshDecisionModel:   obs.FreshDecisionModel,
+			FreshCandidateScores: obs.FreshCandidateScores,
+			PinAgeSec:            int64PtrIf(stickyHit, pinAgeSec),
 		})
 	}
 
@@ -2149,6 +2156,16 @@ func boolPtrOrNil(v bool) *bool {
 // boolPtrTrue always returns a non-nil pointer to v. Used for failover_used
 // where both true and false are meaningful values to record.
 func boolPtrTrue(v bool) *bool {
+	return &v
+}
+
+// int64PtrIf returns a pointer to v when known is true, else nil. Used for
+// pin_age_sec, which is meaningful only when a session pin was actually loaded
+// (sticky_hit); a 0 on a no-pin turn would read as "freshly pinned this turn".
+func int64PtrIf(known bool, v int64) *int64 {
+	if !known {
+		return nil
+	}
 	return &v
 }
 
@@ -2775,7 +2792,7 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 	applyPlannerAttrs(openaiUpstreamBuilder, routeRes)
 	addTimingAttrs(ctx, openaiUpstreamBuilder)
 
-	openaiObs := buildObservationContext(ctx, decision)
+	openaiObs := buildObservationContext(ctx, decision, routeRes.Fresh)
 	openaiObs.applySpanAttrs(openaiUpstreamBuilder)
 
 	otel.Record(ctx, otel.Span{
@@ -2858,6 +2875,10 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 			// (session_key, role) join key — see the Anthropic-path write site.
 			SessionKey: sessionKey[:],
 			Role:       routeRes.PinRole,
+			// Shadow-mode hysteresis instrumentation — see the Anthropic-path site.
+			FreshDecisionModel:   openaiObs.FreshDecisionModel,
+			FreshCandidateScores: openaiObs.FreshCandidateScores,
+			PinAgeSec:            int64PtrIf(stickyHit, pinAgeSec),
 		})
 	}
 

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -1779,7 +1779,7 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 			// measurable offline. No routing action is taken on these.
 			FreshDecisionModel:   obs.FreshDecisionModel,
 			FreshCandidateScores: obs.FreshCandidateScores,
-			PinAgeSec:            int64PtrIf(stickyHit, pinAgeSec),
+			PinAgeSec:            int64PtrIf(stickyHit && pinAgeSec > 0, pinAgeSec),
 		})
 	}
 
@@ -2160,8 +2160,10 @@ func boolPtrTrue(v bool) *bool {
 }
 
 // int64PtrIf returns a pointer to v when known is true, else nil. Used for
-// pin_age_sec, which is meaningful only when a session pin was actually loaded
-// (sticky_hit); a 0 on a no-pin turn would read as "freshly pinned this turn".
+// pin_age_sec: callers gate on sticky_hit AND a positive age, so hard-pin turns
+// and no-pin turns (which carry sticky_hit but never compute a real age, leaving
+// it 0) stay NULL instead of recording a spurious measured zero that would skew
+// min-dwell analysis.
 func int64PtrIf(known bool, v int64) *int64 {
 	if !known {
 		return nil
@@ -2878,7 +2880,7 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 			// Shadow-mode hysteresis instrumentation — see the Anthropic-path site.
 			FreshDecisionModel:   openaiObs.FreshDecisionModel,
 			FreshCandidateScores: openaiObs.FreshCandidateScores,
-			PinAgeSec:            int64PtrIf(stickyHit, pinAgeSec),
+			PinAgeSec:            int64PtrIf(stickyHit && pinAgeSec > 0, pinAgeSec),
 		})
 	}
 

--- a/internal/proxy/telemetry.go
+++ b/internal/proxy/telemetry.go
@@ -76,6 +76,14 @@ type InsertTelemetryParams struct {
 	// empty leaves the columns NULL.
 	SessionKey []byte
 	Role       string
+
+	// FreshDecisionModel + FreshCandidateScores capture the scorer's fresh
+	// recommendation even on STAY turns (shadow-mode instrumentation for the
+	// hysteresis downgrade lever). PinAgeSec supports min-dwell analysis. Empty
+	// / nil leaves the columns NULL.
+	FreshDecisionModel   string
+	FreshCandidateScores []byte
+	PinAgeSec            *int64
 }
 
 // TelemetrySummary holds aggregated totals for the dashboard cards.

--- a/internal/sqlc/model_router_request_telemetry.sql.go
+++ b/internal/sqlc/model_router_request_telemetry.sql.go
@@ -796,7 +796,10 @@ INSERT INTO router.model_router_request_telemetry (
     failover_used,
     degenerate_shadow,
     session_key,
-    role
+    role,
+    fresh_decision_model,
+    fresh_candidate_scores,
+    pin_age_sec
 ) VALUES (
     $1::uuid,
     $2::varchar,
@@ -844,7 +847,10 @@ INSERT INTO router.model_router_request_telemetry (
     $44::boolean,
     $45::boolean,
     $46::bytea,
-    $47::varchar
+    $47::varchar,
+    $48::varchar,
+    $49::jsonb,
+    $50::bigint
 )
 ON CONFLICT (installation_id, request_id, span_type) DO NOTHING
 `
@@ -897,6 +903,9 @@ type InsertRequestTelemetryParams struct {
 	DegenerateShadow       *bool
 	SessionKey             []byte
 	Role                   *string
+	FreshDecisionModel     *string
+	FreshCandidateScores   []byte
+	PinAgeSec              *int64
 }
 
 // Records a completed proxied request for the dashboard UI and routing
@@ -912,6 +921,11 @@ type InsertRequestTelemetryParams struct {
 // for all non-harness traffic.
 // session_key + role are the offline join key to router.spiral_shadow_events
 // and session_pins; NULL on rows written before the columns existed.
+// fresh_decision_model + fresh_candidate_scores capture the scorer's fresh
+// recommendation even on STAY turns (where decision_model names the pinned
+// model served); pin_age_sec supports min-dwell analysis. Shadow-mode
+// instrumentation for the hysteresis downgrade lever; NULL when the scorer did
+// not run / no pin was loaded.
 //
 //	INSERT INTO router.model_router_request_telemetry (
 //	    installation_id,
@@ -960,7 +974,10 @@ type InsertRequestTelemetryParams struct {
 //	    failover_used,
 //	    degenerate_shadow,
 //	    session_key,
-//	    role
+//	    role,
+//	    fresh_decision_model,
+//	    fresh_candidate_scores,
+//	    pin_age_sec
 //	) VALUES (
 //	    $1::uuid,
 //	    $2::varchar,
@@ -1008,7 +1025,10 @@ type InsertRequestTelemetryParams struct {
 //	    $44::boolean,
 //	    $45::boolean,
 //	    $46::bytea,
-//	    $47::varchar
+//	    $47::varchar,
+//	    $48::varchar,
+//	    $49::jsonb,
+//	    $50::bigint
 //	)
 //	ON CONFLICT (installation_id, request_id, span_type) DO NOTHING
 func (q *Queries) InsertRequestTelemetry(ctx context.Context, arg InsertRequestTelemetryParams) error {
@@ -1060,6 +1080,9 @@ func (q *Queries) InsertRequestTelemetry(ctx context.Context, arg InsertRequestT
 		arg.DegenerateShadow,
 		arg.SessionKey,
 		arg.Role,
+		arg.FreshDecisionModel,
+		arg.FreshCandidateScores,
+		arg.PinAgeSec,
 	)
 	return err
 }

--- a/internal/sqlc/models.go
+++ b/internal/sqlc/models.go
@@ -129,6 +129,12 @@ type RouterModelRouterRequestTelemetry struct {
 	SessionKey []byte
 	// Session-pin role used for the turn (roleForTier of the requested model). Pairs with session_key to identify the turn thread; matches spiral_shadow_events.role.
 	Role *string
+	// The cluster scorer's fresh pick for this turn, recorded even when the planner returned STAY (decision_model then names the pinned model served). NULL when the scorer did not run.
+	FreshDecisionModel *string
+	// The fresh pre-argmax score vector (model -> blended score) from this turn's scorer run, recorded even on STAY. Sweep tau against served decision_model + catalog tier to measure the hysteresis downgrade opportunity. NULL when the scorer did not run.
+	FreshCandidateScores []byte
+	// Age of the loaded session pin in seconds at decision time; supports min-dwell analysis for the hysteresis policy. NULL when no pin was loaded.
+	PinAgeSec *int64
 }
 
 // End-user identities seen on inbound requests, scoped to an installation. Replaces the per-user API key pattern.
@@ -224,6 +230,9 @@ type RouterProductionRequestTelemetry struct {
 	DegenerateShadow       *bool
 	SessionKey             []byte
 	Role                   *string
+	FreshDecisionModel     *string
+	FreshCandidateScores   []byte
+	PinAgeSec              *int64
 }
 
 // User-submitted /router-feedback about routing decisions or model performance


### PR DESCRIPTION
> **Stacked on #443** (`steven/telemetry-session-key-join`). Review/merge that first; this PR's diff is only the 0022 migration + fresh-scorer capture. Rebase onto `main` once #443 lands.

## Problem

**Action item #2** from the router right-sizing study — *"~35-45% of opus turns are overkill"* — implemented as **shadow-mode instrumentation only** (no routing behavior change), so we can quantify the downgrade opportunity against real traffic before arming anything.

The overkill lives on **STAY turns**. The cluster scorer runs on every `main_loop` turn and produces a fresh recommendation + score vector, but on a STAY the final decision rehydrates from the session pin (which carries no scores), so `buildObservationContext` logged `NULL` `candidate_scores`. Prod confirms the gap — last 24h:

| turn_type | rows | with candidate_scores |
|---|---|---|
| tool_result | 2617 | 2 |
| main_loop | 291 | **77** |

The 77 are the SWITCH / fresh-pin writes. The other ~214 `main_loop` turns **computed a fresh vector and threw it away** — and those STAY turns are exactly where *"we stayed on opus but a cheaper model was within τ"* hides.

## What changed

Capture the discarded fresh vector. Then the downgrade opportunity is measurable **offline** (sweep τ over `fresh_candidate_scores` vs `decision_model` + catalog tier), no router behavior touched.

- **Migration 0022**: add nullable `fresh_decision_model VARCHAR`, `fresh_candidate_scores JSONB`, `pin_age_sec BIGINT`; recreate `production_request_telemetry` (its frozen `SELECT *` column list).
- `buildObservationContext` now takes the **fresh** decision and captures its pick + score vector **independently** of the final decision (which is the pin on STAY).
- Query + sqlc regen + proxy/postgres wiring; populated at both write sites (`ProxyMessages` + `ProxyOpenAIChatCompletion`). `pin_age_sec` is NULL on no-pin turns (a `0` would read as "freshly pinned this turn").

### Why telemetry columns, not a shadow-events table

The per-turn fresh vector is exactly what's missing; a deduped events table would lose per-turn granularity and duplicate `candidate_scores`. This reuses the existing per-turn row, needs no planner change (planner stays pure), and lets offline sweep τ freely.

## Risk

Pure telemetry enrichment. No planner change, no new table, no dedup, no flag, no behavior change.

## Tests

`go build`/`vet`/`test` — 26 packages, 0 failures. New internal test `TestBuildObservationContext_CapturesFreshOnStay` asserts the fresh vector is captured even when the final (pin) decision has no metadata, and `_NoScorerLeavesFreshNull` covers the hard-pin/tool_result path.

**Not applied to a live Postgres** (local compose DB wasn't up); validated via sqlc schema parse + verbatim-from-0021 view body. Applies via `wv db run-migrations -r`.

## The offline measurement this unlocks (run after deploy + a few days of data)

```sql
-- Per main_loop turn: served model's score vs the best CHEAPER-tier candidate.
-- Tier mapping applied offline from the Go catalog; gap <= tau => downgrade
-- candidate. session_key (PR #443) lets us fold in dwell / switching cost.
SELECT
  decision_model,
  (fresh_candidate_scores ->> decision_model)::float8        AS served_score,
  fresh_candidate_scores,
  pin_age_sec
FROM router.production_request_telemetry
WHERE turn_type = 'main_loop'
  AND fresh_candidate_scores IS NOT NULL
  AND sticky_hit = true;   -- the STAY turns we previously couldn't see
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)