### PR TITLE
feat(telemetry): record incoming tool_result bytes (tier-cap shadow)

### DIFF
--- a/db/migrations/0023_telemetry-tool-result-bytes.down.sql
+++ b/db/migrations/0023_telemetry-tool-result-bytes.down.sql
@@ -1,0 +1,15 @@
+BEGIN;
+
+-- Rebuild the view against the pre-0023 column set first (its frozen SELECT *
+-- list still references the dropped column otherwise).
+DROP VIEW router.production_request_telemetry;
+
+ALTER TABLE router.model_router_request_telemetry
+    DROP COLUMN tool_result_bytes;
+
+CREATE VIEW router.production_request_telemetry AS
+SELECT * FROM router.model_router_request_telemetry
+WHERE span_type = 'router.upstream'
+  AND (client_app IS NULL OR client_app NOT LIKE 'weave-eval%');
+
+COMMIT;

--- a/db/migrations/0023_telemetry-tool-result-bytes.up.sql
+++ b/db/migrations/0023_telemetry-tool-result-bytes.up.sql
@@ -1,0 +1,31 @@
+BEGIN;
+
+-- Shadow-mode instrumentation for the right-sizing study's tier-cap lever
+-- (action item #2, tool_result half). ~90% of turns are tool_result
+-- continuations that short-circuit to the session pin verbatim -- no scorer
+-- runs, so there is no score vector to reason about. The cheap structural
+-- triviality signal for those turns is the INCOMING tool-output size: a tiny
+-- tool_result almost always precedes a trivial continuation that a cheaper
+-- tier could serve, while a large one often precedes heavy work.
+--
+-- tool_result_bytes records that size (summed raw-JSON bytes of the trailing
+-- turn's tool_result payloads) so the tier-cap opportunity is measurable
+-- offline (size distribution x served model x output_tokens) before any cap is
+-- armed. Pure telemetry: no routing behavior changes. NULL when the turn
+-- carries no trailing tool_result.
+ALTER TABLE router.model_router_request_telemetry
+    ADD COLUMN tool_result_bytes INT;
+
+COMMENT ON COLUMN router.model_router_request_telemetry.tool_result_bytes IS
+    'Summed raw-JSON byte size of the trailing turn''s tool_result payload(s) -- the incoming tool-output size. Structural triviality proxy for the tier-cap shadow. NULL when the turn carries no trailing tool_result.';
+
+-- Recreate the production-traffic view so the new column surfaces through it
+-- (CREATE VIEW ... SELECT * freezes its column list at creation). Body
+-- unchanged from migration 0019/0021/0022.
+DROP VIEW router.production_request_telemetry;
+CREATE VIEW router.production_request_telemetry AS
+SELECT * FROM router.model_router_request_telemetry
+WHERE span_type = 'router.upstream'
+  AND (client_app IS NULL OR client_app NOT LIKE 'weave-eval%');
+
+COMMIT;

--- a/db/queries/model_router_request_telemetry.sql
+++ b/db/queries/model_router_request_telemetry.sql
@@ -67,7 +67,8 @@ INSERT INTO router.model_router_request_telemetry (
     role,
     fresh_decision_model,
     fresh_candidate_scores,
-    pin_age_sec
+    pin_age_sec,
+    tool_result_bytes
 ) VALUES (
     @installation_id::uuid,
     @request_id::varchar,
@@ -118,7 +119,8 @@ INSERT INTO router.model_router_request_telemetry (
     sqlc.narg('role')::varchar,
     sqlc.narg('fresh_decision_model')::varchar,
     sqlc.narg('fresh_candidate_scores')::jsonb,
-    sqlc.narg('pin_age_sec')::bigint
+    sqlc.narg('pin_age_sec')::bigint,
+    sqlc.narg('tool_result_bytes')::int
 )
 ON CONFLICT (installation_id, request_id, span_type) DO NOTHING;
 

--- a/internal/postgres/telemetry.go
+++ b/internal/postgres/telemetry.go
@@ -101,6 +101,7 @@ func (r *TelemetryRepo) InsertRequestTelemetry(ctx context.Context, p proxy.Inse
 		FreshDecisionModel:     stringPtrOrNil(p.FreshDecisionModel),
 		FreshCandidateScores:   p.FreshCandidateScores,
 		PinAgeSec:              p.PinAgeSec,
+		ToolResultBytes:        p.ToolResultBytes,
 	})
 }
 

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -1783,7 +1783,7 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 			// Shadow-mode tier-cap instrumentation: incoming tool-output size on
 			// tool_result turns (the structural triviality signal). NULL on turns
 			// with no trailing tool_result. No routing action is taken on it.
-			ToolResultBytes: toolResultBytesPtr(env),
+			ToolResultBytes: toolResultBytesPtr(env, tt),
 		})
 	}
 
@@ -2175,11 +2175,19 @@ func int64PtrIf(known bool, v int64) *int64 {
 	return &v
 }
 
-// toolResultBytesPtr returns the incoming tool-output size for telemetry when
-// the trailing turn carries a tool_result, else nil. Structural triviality
-// signal for the tier-cap shadow; NULL on turns with no tool_result so a 0
-// stays distinct from "no tool output this turn".
-func toolResultBytesPtr(env *translate.RequestEnvelope) *int32 {
+// toolResultBytesPtr returns the incoming tool-output size for telemetry on a
+// tool_result turn, else nil. Gated on the classified turn type, not just
+// LastUserMessage().HasToolResult: the Anthropic/Gemini walkers report the last
+// *user* message in the whole history, so a request ending in a trailing
+// assistant reply after a prior tool_result would otherwise write a stale
+// non-NULL value on a non-tool_result turn. turntype.ToolResult is itself
+// derived from LastKind=="tool_result" (the trailing message), so this ties the
+// column exactly to its meaning. NULL elsewhere so a 0 stays distinct from "no
+// tool output this turn".
+func toolResultBytesPtr(env *translate.RequestEnvelope, tt turntype.TurnType) *int32 {
+	if tt != turntype.ToolResult {
+		return nil
+	}
 	info := env.LastUserMessage()
 	if !info.HasToolResult {
 		return nil
@@ -2901,7 +2909,7 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 			// Shadow-mode tier-cap instrumentation: incoming tool-output size on
 			// tool_result turns (the structural triviality signal). NULL on turns
 			// with no trailing tool_result. No routing action is taken on it.
-			ToolResultBytes: toolResultBytesPtr(env),
+			ToolResultBytes: toolResultBytesPtr(env, tt),
 		})
 	}
 

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -1218,6 +1218,12 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 		inboundSpiralSignals = computeSpiralSignals(env, feats.MessageCount)
 	}
 
+	// Snapshot the inbound tool-output size before runTurnLoop, for the same
+	// reason: a model-switch / compaction handover RewriteForHandover strips
+	// tool_result blocks from env, which would zero out tool_result_bytes on a
+	// genuine tool_result turn read at telemetry time.
+	inboundLastUser := env.LastUserMessage()
+
 	routeStart := time.Now()
 	routeRes, routeErr := s.runTurnLoop(ctx, env, feats, apiKeyID, installationID, "", r.Header, router.Request{
 		RequestedModel:       feats.Model,
@@ -1783,7 +1789,7 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 			// Shadow-mode tier-cap instrumentation: incoming tool-output size on
 			// tool_result turns (the structural triviality signal). NULL on turns
 			// with no trailing tool_result. No routing action is taken on it.
-			ToolResultBytes: toolResultBytesPtr(env, tt),
+			ToolResultBytes: toolResultBytesPtr(inboundLastUser, tt),
 		})
 	}
 
@@ -2176,23 +2182,24 @@ func int64PtrIf(known bool, v int64) *int64 {
 }
 
 // toolResultBytesPtr returns the incoming tool-output size for telemetry on a
-// tool_result turn, else nil. Gated on the classified turn type, not just
-// LastUserMessage().HasToolResult: the Anthropic/Gemini walkers report the last
-// *user* message in the whole history, so a request ending in a trailing
-// assistant reply after a prior tool_result would otherwise write a stale
-// non-NULL value on a non-tool_result turn. turntype.ToolResult is itself
+// tool_result turn, else nil. It takes an inbound LastUserMessage snapshot, NOT
+// the live env: a model-switch or compaction handover may call RewriteForHandover
+// and strip tool_result blocks from env before the telemetry write, which would
+// otherwise read 0 bytes on a genuine tool_result turn. The snapshot is taken
+// before runTurnLoop, alongside inboundToolCallCount / inboundSpiralSignals.
+//
+// Gated on the classified turn type, not just info.HasToolResult: the
+// Anthropic/Gemini walkers report the last *user* message in the whole history,
+// so a request ending in a trailing assistant reply after a prior tool_result
+// would otherwise write a stale non-NULL value. turntype.ToolResult is itself
 // derived from LastKind=="tool_result" (the trailing message), so this ties the
 // column exactly to its meaning. NULL elsewhere so a 0 stays distinct from "no
 // tool output this turn".
-func toolResultBytesPtr(env *translate.RequestEnvelope, tt turntype.TurnType) *int32 {
-	if tt != turntype.ToolResult {
+func toolResultBytesPtr(inbound translate.LastUserMessageInfo, tt turntype.TurnType) *int32 {
+	if tt != turntype.ToolResult || !inbound.HasToolResult {
 		return nil
 	}
-	info := env.LastUserMessage()
-	if !info.HasToolResult {
-		return nil
-	}
-	v := int32(info.ToolResultBytes)
+	v := int32(inbound.ToolResultBytes)
 	return &v
 }
 
@@ -2499,6 +2506,10 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 			"excluded_models", strings.Join(geminiUnsignedOAI, ","),
 		)
 	}
+
+	// Snapshot the inbound tool-output size before runTurnLoop (which may rewrite
+	// env via switch handover); see toolResultBytesPtr.
+	inboundLastUser := env.LastUserMessage()
 
 	routeStart := time.Now()
 	routeRes, err := s.runTurnLoop(ctx, env, feats, apiKeyID, installationID, subAgentHint, r.Header, router.Request{
@@ -2909,7 +2920,7 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 			// Shadow-mode tier-cap instrumentation: incoming tool-output size on
 			// tool_result turns (the structural triviality signal). NULL on turns
 			// with no trailing tool_result. No routing action is taken on it.
-			ToolResultBytes: toolResultBytesPtr(env, tt),
+			ToolResultBytes: toolResultBytesPtr(inboundLastUser, tt),
 		})
 	}
 

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -1780,6 +1780,10 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 			FreshDecisionModel:   obs.FreshDecisionModel,
 			FreshCandidateScores: obs.FreshCandidateScores,
 			PinAgeSec:            int64PtrIf(stickyHit && pinAgeSec > 0, pinAgeSec),
+			// Shadow-mode tier-cap instrumentation: incoming tool-output size on
+			// tool_result turns (the structural triviality signal). NULL on turns
+			// with no trailing tool_result. No routing action is taken on it.
+			ToolResultBytes: toolResultBytesPtr(env),
 		})
 	}
 
@@ -2168,6 +2172,19 @@ func int64PtrIf(known bool, v int64) *int64 {
 	if !known {
 		return nil
 	}
+	return &v
+}
+
+// toolResultBytesPtr returns the incoming tool-output size for telemetry when
+// the trailing turn carries a tool_result, else nil. Structural triviality
+// signal for the tier-cap shadow; NULL on turns with no tool_result so a 0
+// stays distinct from "no tool output this turn".
+func toolResultBytesPtr(env *translate.RequestEnvelope) *int32 {
+	info := env.LastUserMessage()
+	if !info.HasToolResult {
+		return nil
+	}
+	v := int32(info.ToolResultBytes)
 	return &v
 }
 
@@ -2881,6 +2898,10 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 			FreshDecisionModel:   openaiObs.FreshDecisionModel,
 			FreshCandidateScores: openaiObs.FreshCandidateScores,
 			PinAgeSec:            int64PtrIf(stickyHit && pinAgeSec > 0, pinAgeSec),
+			// Shadow-mode tier-cap instrumentation: incoming tool-output size on
+			// tool_result turns (the structural triviality signal). NULL on turns
+			// with no trailing tool_result. No routing action is taken on it.
+			ToolResultBytes: toolResultBytesPtr(env),
 		})
 	}
 

--- a/internal/proxy/telemetry.go
+++ b/internal/proxy/telemetry.go
@@ -84,6 +84,11 @@ type InsertTelemetryParams struct {
 	FreshDecisionModel   string
 	FreshCandidateScores []byte
 	PinAgeSec            *int64
+
+	// ToolResultBytes is the incoming tool-output size on a tool_result turn
+	// (shadow-mode instrumentation for the tier-cap lever). nil when the turn
+	// carries no trailing tool_result.
+	ToolResultBytes *int32
 }
 
 // TelemetrySummary holds aggregated totals for the dashboard cards.

--- a/internal/proxy/toolresult_bytes_internal_test.go
+++ b/internal/proxy/toolresult_bytes_internal_test.go
@@ -1,0 +1,32 @@
+package proxy
+
+import (
+	"testing"
+
+	"workweave/router/internal/router/turntype"
+	"workweave/router/internal/translate"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestToolResultBytesPtr_GatedOnTurnType locks the fix for the trailing-assistant
+// case: LastUserMessage() reports the last *user* message in the whole history,
+// so a request ending in an assistant reply after a prior tool_result still has
+// HasToolResult==true. tool_result_bytes must only be written on a turn actually
+// classified as ToolResult, so it stays NULL on non-tool_result turns.
+func TestToolResultBytesPtr_GatedOnTurnType(t *testing.T) {
+	body := `{"messages":[{"role":"user","content":[{"type":"tool_result","tool_use_id":"t1","content":"out"}]}]}`
+	env, err := translate.ParseAnthropic([]byte(body))
+	require.NoError(t, err)
+
+	// A real tool_result turn records the incoming tool-output bytes.
+	got := toolResultBytesPtr(env, turntype.ToolResult)
+	require.NotNil(t, got, "tool_result turn must record bytes")
+	assert.Equal(t, int32(5), *got) // `"out"` raw JSON = 5 bytes
+
+	// Same body, but the turn was NOT classified as a tool_result (e.g. a
+	// trailing-assistant request whose last user message merely happens to
+	// carry a stale tool_result). Must be NULL, not a spurious value.
+	assert.Nil(t, toolResultBytesPtr(env, turntype.MainLoop), "non-tool_result turn must be NULL")
+}

--- a/internal/proxy/toolresult_bytes_internal_test.go
+++ b/internal/proxy/toolresult_bytes_internal_test.go
@@ -19,14 +19,15 @@ func TestToolResultBytesPtr_GatedOnTurnType(t *testing.T) {
 	body := `{"messages":[{"role":"user","content":[{"type":"tool_result","tool_use_id":"t1","content":"out"}]}]}`
 	env, err := translate.ParseAnthropic([]byte(body))
 	require.NoError(t, err)
+	inbound := env.LastUserMessage() // snapshot taken before any handover rewrite
 
 	// A real tool_result turn records the incoming tool-output bytes.
-	got := toolResultBytesPtr(env, turntype.ToolResult)
+	got := toolResultBytesPtr(inbound, turntype.ToolResult)
 	require.NotNil(t, got, "tool_result turn must record bytes")
 	assert.Equal(t, int32(5), *got) // `"out"` raw JSON = 5 bytes
 
-	// Same body, but the turn was NOT classified as a tool_result (e.g. a
+	// Same snapshot, but the turn was NOT classified as a tool_result (e.g. a
 	// trailing-assistant request whose last user message merely happens to
 	// carry a stale tool_result). Must be NULL, not a spurious value.
-	assert.Nil(t, toolResultBytesPtr(env, turntype.MainLoop), "non-tool_result turn must be NULL")
+	assert.Nil(t, toolResultBytesPtr(inbound, turntype.MainLoop), "non-tool_result turn must be NULL")
 }

--- a/internal/sqlc/model_router_request_telemetry.sql.go
+++ b/internal/sqlc/model_router_request_telemetry.sql.go
@@ -799,7 +799,8 @@ INSERT INTO router.model_router_request_telemetry (
     role,
     fresh_decision_model,
     fresh_candidate_scores,
-    pin_age_sec
+    pin_age_sec,
+    tool_result_bytes
 ) VALUES (
     $1::uuid,
     $2::varchar,
@@ -850,7 +851,8 @@ INSERT INTO router.model_router_request_telemetry (
     $47::varchar,
     $48::varchar,
     $49::jsonb,
-    $50::bigint
+    $50::bigint,
+    $51::int
 )
 ON CONFLICT (installation_id, request_id, span_type) DO NOTHING
 `
@@ -906,6 +908,7 @@ type InsertRequestTelemetryParams struct {
 	FreshDecisionModel     *string
 	FreshCandidateScores   []byte
 	PinAgeSec              *int64
+	ToolResultBytes        *int32
 }
 
 // Records a completed proxied request for the dashboard UI and routing
@@ -977,7 +980,8 @@ type InsertRequestTelemetryParams struct {
 //	    role,
 //	    fresh_decision_model,
 //	    fresh_candidate_scores,
-//	    pin_age_sec
+//	    pin_age_sec,
+//	    tool_result_bytes
 //	) VALUES (
 //	    $1::uuid,
 //	    $2::varchar,
@@ -1028,7 +1032,8 @@ type InsertRequestTelemetryParams struct {
 //	    $47::varchar,
 //	    $48::varchar,
 //	    $49::jsonb,
-//	    $50::bigint
+//	    $50::bigint,
+//	    $51::int
 //	)
 //	ON CONFLICT (installation_id, request_id, span_type) DO NOTHING
 func (q *Queries) InsertRequestTelemetry(ctx context.Context, arg InsertRequestTelemetryParams) error {
@@ -1083,6 +1088,7 @@ func (q *Queries) InsertRequestTelemetry(ctx context.Context, arg InsertRequestT
 		arg.FreshDecisionModel,
 		arg.FreshCandidateScores,
 		arg.PinAgeSec,
+		arg.ToolResultBytes,
 	)
 	return err
 }

--- a/internal/sqlc/models.go
+++ b/internal/sqlc/models.go
@@ -135,6 +135,8 @@ type RouterModelRouterRequestTelemetry struct {
 	FreshCandidateScores []byte
 	// Age of the loaded session pin in seconds at decision time; supports min-dwell analysis for the hysteresis policy. NULL when no pin was loaded.
 	PinAgeSec *int64
+	// Summed raw-JSON byte size of the trailing turn's tool_result payload(s) -- the incoming tool-output size. Structural triviality proxy for the tier-cap shadow. NULL when the turn carries no trailing tool_result.
+	ToolResultBytes *int32
 }
 
 // End-user identities seen on inbound requests, scoped to an installation. Replaces the per-user API key pattern.
@@ -233,6 +235,7 @@ type RouterProductionRequestTelemetry struct {
 	FreshDecisionModel     *string
 	FreshCandidateScores   []byte
 	PinAgeSec              *int64
+	ToolResultBytes        *int32
 }
 
 // User-submitted /router-feedback about routing decisions or model performance

--- a/internal/translate/envelope.go
+++ b/internal/translate/envelope.go
@@ -241,6 +241,11 @@ type LastUserMessageInfo struct {
 	HasToolResult   bool
 	ToolResultCount int
 	Text            string
+	// ToolResultBytes is the summed raw-JSON byte size of the trailing turn's
+	// tool_result payload(s) — the incoming tool-output size. A cheap structural
+	// triviality proxy for the right-sizing tier-cap shadow (tiny tool_result →
+	// likely-trivial continuation). 0 when no tool_result is present.
+	ToolResultBytes int
 }
 
 // LastUserMessage returns format-neutral information about the last user input.

--- a/internal/translate/envelope_extras_test.go
+++ b/internal/translate/envelope_extras_test.go
@@ -92,7 +92,7 @@ func TestRequestEnvelope_LastUserMessage_Anthropic(t *testing.T) {
 			body: `{"messages":[
 				{"role":"user","content":[{"type":"tool_result","tool_use_id":"t1","content":"out"}]}
 			]}`,
-			want: translate.LastUserMessageInfo{HasToolResult: true, ToolResultCount: 1},
+			want: translate.LastUserMessageInfo{HasToolResult: true, ToolResultCount: 1, ToolResultBytes: 5},
 		},
 		{
 			name: "mixed text + tool_result",
@@ -103,7 +103,7 @@ func TestRequestEnvelope_LastUserMessage_Anthropic(t *testing.T) {
 				]}
 			]}`,
 			want: translate.LastUserMessageInfo{
-				HasText: true, Text: "more please", HasToolResult: true, ToolResultCount: 1,
+				HasText: true, Text: "more please", HasToolResult: true, ToolResultCount: 1, ToolResultBytes: 5,
 			},
 		},
 		{
@@ -114,7 +114,7 @@ func TestRequestEnvelope_LastUserMessage_Anthropic(t *testing.T) {
 					{"type":"tool_result","tool_use_id":"t2","content":"b"}
 				]}
 			]}`,
-			want: translate.LastUserMessageInfo{HasToolResult: true, ToolResultCount: 2},
+			want: translate.LastUserMessageInfo{HasToolResult: true, ToolResultCount: 2, ToolResultBytes: 6},
 		},
 		{
 			name: "no user message",
@@ -157,7 +157,7 @@ func TestRequestEnvelope_LastUserMessage_OpenAI(t *testing.T) {
 				{"role":"assistant","content":null,"tool_calls":[{"id":"t1","type":"function","function":{"name":"Bash","arguments":"{}"}}]},
 				{"role":"tool","tool_call_id":"t1","content":"out"}
 			]}`,
-			want: translate.LastUserMessageInfo{HasToolResult: true, ToolResultCount: 1},
+			want: translate.LastUserMessageInfo{HasToolResult: true, ToolResultCount: 1, ToolResultBytes: 5},
 		},
 		{
 			name: "two trailing tool messages",
@@ -166,7 +166,7 @@ func TestRequestEnvelope_LastUserMessage_OpenAI(t *testing.T) {
 				{"role":"tool","tool_call_id":"t1","content":"a"},
 				{"role":"tool","tool_call_id":"t2","content":"b"}
 			]}`,
-			want: translate.LastUserMessageInfo{HasToolResult: true, ToolResultCount: 2},
+			want: translate.LastUserMessageInfo{HasToolResult: true, ToolResultCount: 2, ToolResultBytes: 6},
 		},
 		{
 			name: "tool then user",

--- a/internal/translate/features.go
+++ b/internal/translate/features.go
@@ -219,6 +219,7 @@ func anthropicLastUserMessage(body []byte) LastUserMessageInfo {
 		case "tool_result":
 			info.HasToolResult = true
 			info.ToolResultCount++
+			info.ToolResultBytes += len(block.Get("content").Raw)
 		case "text":
 			text := block.Get("text").String()
 			if text == "" {
@@ -256,6 +257,7 @@ func openAILastUserMessage(body []byte) LastUserMessageInfo {
 		case "tool":
 			info.HasToolResult = true
 			info.ToolResultCount++
+			info.ToolResultBytes += len(all[i].Get("content").Raw)
 			continue
 		case "user":
 			text := openAIContentTextGJSON(all[i].Get("content"))

--- a/internal/translate/features_gemini.go
+++ b/internal/translate/features_gemini.go
@@ -175,6 +175,7 @@ func geminiLastUserMessage(body []byte) LastUserMessageInfo {
 		if part.Get("functionResponse").Exists() {
 			info.HasToolResult = true
 			info.ToolResultCount++
+			info.ToolResultBytes += len(part.Get("functionResponse").Raw)
 			return true
 		}
 		text := part.Get("text").String()

--- a/internal/translate/gemini_envelope_test.go
+++ b/internal/translate/gemini_envelope_test.go
@@ -70,7 +70,7 @@ func TestRequestEnvelope_LastUserMessage_Gemini(t *testing.T) {
 				{"role":"model","parts":[{"functionCall":{"name":"Bash","args":{}}}]},
 				{"role":"user","parts":[{"functionResponse":{"name":"Bash","response":{"out":"x"}}}]}
 			]}`,
-			want: translate.LastUserMessageInfo{HasToolResult: true, ToolResultCount: 1},
+			want: translate.LastUserMessageInfo{HasToolResult: true, ToolResultCount: 1, ToolResultBytes: 38},
 		},
 		{
 			name: "mixed text + functionResponse",
@@ -80,7 +80,7 @@ func TestRequestEnvelope_LastUserMessage_Gemini(t *testing.T) {
 					{"text":"more please"}
 				]}
 			]}`,
-			want: translate.LastUserMessageInfo{HasText: true, Text: "more please", HasToolResult: true, ToolResultCount: 1},
+			want: translate.LastUserMessageInfo{HasText: true, Text: "more please", HasToolResult: true, ToolResultCount: 1, ToolResultBytes: 38},
 		},
 		{
 			name: "trailing model message ignored",


### PR DESCRIPTION
> **Stacked on #444** (`steven/rightsizing-shadow-telemetry`), which is stacked on #443. Review/merge in order; rebase onto `main` as each lands.

## Problem

**Action item #2**, the **tool_result half** — shadow-mode instrumentation only, no routing behavior change.

The hysteresis half (#444) only applies to `main_loop` turns, where the scorer runs. But **~90% of turns are `tool_result` continuations** that short-circuit straight to the session pin verbatim — no scorer, no score vector. For those, the cheap structural triviality signal is the **incoming tool-output size**: a tiny `tool_result` almost always precedes a trivial continuation a cheaper tier could serve; a large one often precedes heavy work (the study measured ~67% trivial output for tiny vs ~26% heavy for large).

That size isn't persisted anywhere today, so the tier-cap opportunity can't be measured. This records it.

## What changed

- **translate**: new `LastUserMessageInfo.ToolResultBytes` — summed raw-JSON byte size of the trailing turn's `tool_result` payload(s) — populated in all three format walkers (Anthropic `tool_result` content blocks, OpenAI `role=="tool"` messages, Gemini `functionResponse` parts).
- **Migration 0023**: add nullable `tool_result_bytes INT`; recreate `production_request_telemetry` (frozen `SELECT *` column list).
- Query + sqlc regen + proxy/postgres wiring; populated at both write sites via `toolResultBytesPtr(env)`. **NULL** when the turn carries no trailing `tool_result` (a `0` would read as "tool output of size zero" rather than "not a tool turn").

## Risk

Pure telemetry enrichment. No planner change, no new table, no flag, no behavior change.

## Tests

`go build`/`vet`/`test` — 26 packages, 0 failures. The existing `LastUserMessage` table tests (which assert the whole struct) were extended with byte expectations across all three formats (Anthropic 5/6, OpenAI 5/6, Gemini 38).

**Not applied to a live Postgres** (local compose DB wasn't up); validated via sqlc schema parse + verbatim-from-0022 view body. Applies via `wv db run-migrations -r`.

## The offline measurement this unlocks

```sql
-- tool_result turns served by a high/mid-tier model, bucketed by incoming
-- tool-output size vs the output they produced. Tiny incoming + tiny output =
-- tier-cap candidates. session_key (PR #443) folds in per-session context.
SELECT
  decision_model,
  width_bucket(tool_result_bytes, 0, 4096, 8) AS in_size_bucket,
  count(*)                                     AS turns,
  percentile_cont(0.5) WITHIN GROUP (ORDER BY output_tokens) AS median_out_tokens
FROM router.production_request_telemetry
WHERE turn_type = 'tool_result'
  AND tool_result_bytes IS NOT NULL
GROUP BY 1, 2
ORDER BY 1, 2;
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)