### PR TITLE
fix(translate): prune dangling "required" from Gemini tool schemas

### DIFF
--- a/internal/translate/emit_gemini.go
+++ b/internal/translate/emit_gemini.go
@@ -1415,7 +1415,15 @@ func sanitizeSchemaFiltered(v any, filterKeys bool) any {
 		// whole request with INVALID_ARGUMENT. The keyword allow-list above
 		// keeps these keys but never reconciles them, so prune "required"
 		// down to the properties that actually survived translation.
-		out = pruneDanglingRequired(out)
+		//
+		// Only do this in schema-node context (filterKeys). Inside a
+		// "properties" map (filterKeys == false) the keys are user-defined
+		// parameter names, so a parameter literally named "required" is a
+		// property schema — not the "required" keyword — and must be left
+		// untouched.
+		if filterKeys {
+			out = pruneDanglingRequired(out)
+		}
 		return out
 	case []any:
 		out := make([]any, len(node))

--- a/internal/translate/emit_gemini.go
+++ b/internal/translate/emit_gemini.go
@@ -1409,6 +1409,13 @@ func sanitizeSchemaFiltered(v any, filterKeys bool) any {
 				out["items"] = map[string]any{"type": "string"}
 			}
 		}
+		// Gemini's function-calling validator requires every entry in
+		// "required" to name a key present in "properties"; a dangling entry
+		// (common in hand-written MCP tool schemas) makes Google reject the
+		// whole request with INVALID_ARGUMENT. The keyword allow-list above
+		// keeps these keys but never reconciles them, so prune "required"
+		// down to the properties that actually survived translation.
+		out = pruneDanglingRequired(out)
 		return out
 	case []any:
 		out := make([]any, len(node))
@@ -1419,6 +1426,36 @@ func sanitizeSchemaFiltered(v any, filterKeys bool) any {
 	default:
 		return v
 	}
+}
+
+// pruneDanglingRequired drops any name in out["required"] that is not a key in
+// out["properties"], and removes "required" entirely when nothing valid remains
+// (or there are no properties at all). Gemini's strict function-calling schema
+// validator 400s ("Request contains an invalid argument") when "required"
+// references a property that does not exist — well-formed JSON Schema permits
+// it, so the inbound tool schema may carry one even after keyword filtering.
+func pruneDanglingRequired(out map[string]any) map[string]any {
+	req, ok := out["required"].([]any)
+	if !ok {
+		return out
+	}
+	props, _ := out["properties"].(map[string]any)
+	kept := make([]any, 0, len(req))
+	for _, name := range req {
+		s, isStr := name.(string)
+		if !isStr {
+			continue
+		}
+		if _, present := props[s]; present {
+			kept = append(kept, s)
+		}
+	}
+	if len(kept) == 0 {
+		delete(out, "required")
+		return out
+	}
+	out["required"] = kept
+	return out
 }
 
 // collapseTypeArray collapses JSON Schema ["array", "null"] into Gemini's

--- a/internal/translate/gemini_test.go
+++ b/internal/translate/gemini_test.go
@@ -614,6 +614,48 @@ func TestPrepareGemini_StripsJSONSchemaFieldsGoogleRejects(t *testing.T) {
 	assert.Equal(t, "URL to fetch", url["description"])
 }
 
+func TestPrepareGemini_PrunesDanglingRequired(t *testing.T) {
+	// Regression: Gemini's strict function-calling validator 400s
+	// ("Request contains an invalid argument") when "required" names a
+	// property that isn't in "properties". Well-formed JSON Schema permits
+	// it, so an inbound MCP tool schema can carry one; prune it.
+	body := []byte(`{
+		"messages": [{"role":"user","content":"hi"}],
+		"tools": [{
+			"name":"DoThing",
+			"description":"d",
+			"input_schema":{
+				"type":"object",
+				"properties":{"x":{"type":"string"}},
+				"required":["x","ghost"]
+			}
+		},{
+			"name":"AllDangling",
+			"description":"d",
+			"input_schema":{
+				"type":"object",
+				"properties":{"a":{"type":"string"}},
+				"required":["missing"]
+			}
+		}]
+	}`)
+	env, err := translate.ParseAnthropic(body)
+	require.NoError(t, err)
+	prep, err := env.PrepareGemini(http.Header{}, translate.EmitOptions{})
+	require.NoError(t, err)
+
+	out := mustUnmarshal(t, prep.Body)
+	decls := out["tools"].([]any)[0].(map[string]any)["functionDeclarations"].([]any)
+
+	// Tool 1: keep the real property, drop the dangling one.
+	p0 := decls[0].(map[string]any)["parameters"].(map[string]any)
+	assert.Equal(t, []any{"x"}, p0["required"], "dangling 'ghost' must be pruned, 'x' kept")
+
+	// Tool 2: nothing in required survives → drop the key entirely.
+	p1 := decls[1].(map[string]any)["parameters"].(map[string]any)
+	assert.NotContains(t, p1, "required", "an all-dangling required must be removed, not left empty")
+}
+
 func TestPrepareGemini_StripsVendorExtensionAndDollarPrefixedKeys(t *testing.T) {
 	// Regression: MCP tool schemas derived from Google APIs (and friends)
 	// embed vendor extensions like `x-google-enum-descriptions` at every

--- a/internal/translate/gemini_test.go
+++ b/internal/translate/gemini_test.go
@@ -656,6 +656,48 @@ func TestPrepareGemini_PrunesDanglingRequired(t *testing.T) {
 	assert.NotContains(t, p1, "required", "an all-dangling required must be removed, not left empty")
 }
 
+func TestPrepareGemini_PreservesPropertyNamedRequired(t *testing.T) {
+	// Pruning must run only in schema-node context: inside a "properties"
+	// map the keys are user-defined parameter names, so a parameter literally
+	// named "required" is a property schema, not the "required" keyword, and
+	// must survive untouched (incl. its own nested "required" keyword).
+	body := []byte(`{
+		"messages": [{"role":"user","content":"hi"}],
+		"tools": [{
+			"name":"DoThing",
+			"description":"d",
+			"input_schema":{
+				"type":"object",
+				"properties":{
+					"required":{
+						"type":"object",
+						"properties":{"inner":{"type":"string"}},
+						"required":["inner"]
+					}
+				},
+				"required":["required"]
+			}
+		}]
+	}`)
+	env, err := translate.ParseAnthropic(body)
+	require.NoError(t, err)
+	prep, err := env.PrepareGemini(http.Header{}, translate.EmitOptions{})
+	require.NoError(t, err)
+
+	out := mustUnmarshal(t, prep.Body)
+	params := out["tools"].([]any)[0].(map[string]any)["functionDeclarations"].([]any)[0].(map[string]any)["parameters"].(map[string]any)
+
+	// The schema-level "required" naming the real "required" property is kept.
+	assert.Equal(t, []any{"required"}, params["required"])
+	// The property named "required" is preserved as an object schema, not
+	// rewritten into an array or deleted.
+	prop, ok := params["properties"].(map[string]any)["required"].(map[string]any)
+	require.True(t, ok, `parameter named "required" must remain a schema object`)
+	assert.Equal(t, "object", prop["type"])
+	// Its own nested "required" keyword (valid: "inner" exists) is intact.
+	assert.Equal(t, []any{"inner"}, prop["required"])
+}
+
 func TestPrepareGemini_StripsVendorExtensionAndDollarPrefixedKeys(t *testing.T) {
 	// Regression: MCP tool schemas derived from Google APIs (and friends)
 	// embed vendor extensions like `x-google-enum-descriptions` at every


### PR DESCRIPTION
Prune `required` entries that name a property not present in `properties` before emitting Gemini function declarations.

## Why
Gemini’s strict function-calling validator hard-rejects the whole request with `400 INVALID_ARGUMENT` ("Request contains an invalid argument") when a tool parameter schema lists a `required` name that isn’t in `properties`. Well-formed JSON Schema allows this, so an inbound MCP/Claude-Code tool schema can carry one — and `sanitizeSchemaForGemini`’s keyword allow-list keeps `required` without reconciling it against the surviving `properties`.

When this happens, every tools-bearing turn routed to a Gemini model 400s, and the Gemini **native** path can’t recover: it streams the error to the client (returns a flushed, non-retryable `UpstreamStatusError`) and `gemini-3.1-pro-preview` is single-binding, so `failover_used` is always false and the turn dies. Observed in prod (session `5d47390c…`, request `dcc303c4…`).

## Fix
`sanitizeSchemaFiltered` now calls `pruneDanglingRequired` on every object node: keep only `required` names present in `properties`, and drop the key entirely when none survive.

## Verification
- New unit test `TestPrepareGemini_PrunesDanglingRequired` (partial + fully-dangling cases); full `internal/translate` suite green.
- **Live end-to-end** against `gemini-3.1-pro-preview`: the translator’s pre-fix emitted body returns **400**, the pruned body returns **200**.

## Follow-up (not in this PR)
This prevents one proven reject class. The cause-agnostic turn-saver — buffering Gemini native non-2xx (like the OpenAI-compat adapters) and escalating a single-binding premium model’s non-retryable 4xx to its baseline model — is a larger refactor of the per-attempt/dispatch path and will be a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)