### PR TITLE
fix(openai): output-progress watchdog for gpt-5.x Responses stalls

### DIFF
--- a/internal/providers/httputil/httputil.go
+++ b/internal/providers/httputil/httputil.go
@@ -31,6 +31,11 @@ const FlushChunk = 4 * 1024
 // (this package imports providers). errors.Is matches against either name.
 var ErrUpstreamIdleTimeout = providers.ErrUpstreamIdleTimeout
 
+// ErrUpstreamOutputStall re-exports providers.ErrUpstreamOutputStall — the
+// cause set when the output-progress watchdog (StartIdleWatchdogCause) trips
+// because the stream stayed byte-alive but produced no output-bearing content.
+var ErrUpstreamOutputStall = providers.ErrUpstreamOutputStall
+
 // DefaultSSEIdleTimeout is the per-read inactivity threshold for streaming
 // upstream responses. AWS NAT Gateway / NLB / VPC-endpoint reapers silently
 // drop idle TCP connections at 350s; a watchdog below that surfaces stalls
@@ -46,13 +51,33 @@ var DefaultSSEIdleTimeout = idleTimeoutFromEnv("ROUTER_SSE_IDLE_TIMEOUT_SECONDS"
 // DefaultSSEIdleTimeout because a gpt-5.x reasoning turn can go tens of
 // seconds between SSE frames while the model thinks (reasoning-summary deltas
 // lag the actual reasoning). ANY received bytes count as progress — event
-// frames, reasoning deltas, keepalives — so only a zero-progress gap trips
-// it. The real stalls observed in prod (2026-06-09: two /v1/responses streams
-// at zero output tokens until the 600s request cap) produced no bytes at all,
-// so 90s separates them cleanly from healthy long-thinking turns.
+// frames, reasoning deltas, keepalives — so only a zero-BYTE gap trips it.
+//
+// This catches the byte-silent stall (2026-06-09: two /v1/responses streams
+// produced no bytes at all until the 600s request cap). It does NOT catch a
+// byte-alive/output-silent stall — a stream that keeps dribbling non-output
+// frames (reasoning deltas, keepalives) while producing zero output tokens
+// (2026-06-16: gpt-5.5 sat at zero output for the full 600s, bytes flowing the
+// whole time). DefaultResponsesOutputStallTimeout guards that mode.
 //
 // Tunable via ROUTER_RESPONSES_SSE_IDLE_TIMEOUT_SECONDS.
 var DefaultResponsesSSEIdleTimeout = idleTimeoutFromEnv("ROUTER_RESPONSES_SSE_IDLE_TIMEOUT_SECONDS", 90*time.Second)
+
+// DefaultResponsesOutputStallTimeout is the OUTPUT-progress threshold for
+// OpenAI Responses streams: the maximum time the upstream may stay byte-alive
+// (resetting DefaultResponsesSSEIdleTimeout) while producing zero
+// output-bearing content (assistant text, tool-call arguments, or a terminal
+// response envelope). It is deliberately far larger than the idle timeout so a
+// genuinely long reasoning phase that eventually emits output is never clipped
+// — only a turn that thinks/keepalives for minutes without ever producing
+// output is aborted. Set below the 600s request cap so the watchdog (not the
+// cap) surfaces the stall as a retryable error, while staying generous enough
+// to clear realistic worst-case reasoning. The OUTPUT-progress mark is fed by
+// the Responses→Anthropic translator, which alone can tell output frames from
+// reasoning/keepalive frames.
+//
+// Tunable via ROUTER_RESPONSES_OUTPUT_STALL_TIMEOUT_SECONDS.
+var DefaultResponsesOutputStallTimeout = idleTimeoutFromEnv("ROUTER_RESPONSES_OUTPUT_STALL_TIMEOUT_SECONDS", 240*time.Second)
 
 // idleTimeoutFromEnv reads a whole-seconds override from envVar, falling back
 // to fallback when unset, unparsable, or non-positive.
@@ -117,6 +142,19 @@ func NewTransportWithResponseHeaderTimeout(dialTimeout, tlsTimeout, responseHead
 //
 // idleTimeout <= 0 or cancel == nil disables the watchdog (no-op mark/stop).
 func StartIdleWatchdog(ctx context.Context, cancel context.CancelCauseFunc, idleTimeout time.Duration) (mark func(), stop func()) {
+	return StartIdleWatchdogCause(ctx, cancel, idleTimeout, ErrUpstreamIdleTimeout)
+}
+
+// StartIdleWatchdogCause is StartIdleWatchdog with a caller-chosen cancel
+// cause. Use it to run a second, independent watchdog on the same request
+// context that measures a different progress signal — e.g. an output-progress
+// watchdog whose mark is fed only on output-bearing events (cause
+// ErrUpstreamOutputStall), running alongside the byte-idle watchdog (cause
+// ErrUpstreamIdleTimeout). Whichever watchdog trips first wins: context cancel
+// causes are set once, so a later cancel from the other watchdog is a no-op.
+//
+// idleTimeout <= 0 or cancel == nil disables the watchdog (no-op mark/stop).
+func StartIdleWatchdogCause(ctx context.Context, cancel context.CancelCauseFunc, idleTimeout time.Duration, cause error) (mark func(), stop func()) {
 	if idleTimeout <= 0 || cancel == nil {
 		return func() {}, func() {}
 	}
@@ -135,7 +173,7 @@ func StartIdleWatchdog(ctx context.Context, cancel context.CancelCauseFunc, idle
 				return
 			case <-ticker.C:
 				if time.Since(time.Unix(0, lastNS.Load())) > idleTimeout {
-					cancel(ErrUpstreamIdleTimeout)
+					cancel(cause)
 					return
 				}
 			}
@@ -179,8 +217,12 @@ func StreamBody(ctx context.Context, cancel context.CancelCauseFunc, idleTimeout
 			return nil
 		}
 		if readErr != nil {
-			if cause := context.Cause(ctx); errors.Is(cause, ErrUpstreamIdleTimeout) {
-				return ErrUpstreamIdleTimeout
+			// A second watchdog (e.g. the OpenAI output-progress watchdog) may
+			// share this ctx and cancel with a different cause; surface whichever
+			// sentinel tripped so the caller classifies it retryable instead of
+			// seeing a bare context.Canceled.
+			if cause := context.Cause(ctx); errors.Is(cause, ErrUpstreamIdleTimeout) || errors.Is(cause, ErrUpstreamOutputStall) {
+				return cause
 			}
 			return readErr
 		}

--- a/internal/providers/openai/client.go
+++ b/internal/providers/openai/client.go
@@ -43,6 +43,11 @@ type Client struct {
 	// exercise the mid-stream stall watchdog without waiting out the real
 	// threshold (mirrors the header-timeout injection below).
 	sseIdleTimeout time.Duration
+	// outputStall, when > 0, overrides httputil.DefaultResponsesOutputStallTimeout
+	// for the /v1/responses output-progress watchdog. Production uses the
+	// default via NewClient; tests inject a small value to exercise the
+	// output-stall trip without waiting out the real threshold.
+	outputStall time.Duration
 }
 
 func NewClient(apiKey, baseURL string) *Client {
@@ -73,6 +78,15 @@ func NewClientWithTimeouts(apiKey, baseURL string, headerTimeout, sseIdleTimeout
 	return c
 }
 
+// NewClientWithStallTimeouts is NewClientWithTimeouts with an additional
+// injected /v1/responses output-stall threshold; see Client.outputStall. Exists
+// so a test can drive the output-progress watchdog with a small budget.
+func NewClientWithStallTimeouts(apiKey, baseURL string, headerTimeout, sseIdleTimeout, outputStall time.Duration) *Client {
+	c := NewClientWithTimeouts(apiKey, baseURL, headerTimeout, sseIdleTimeout)
+	c.outputStall = outputStall
+	return c
+}
+
 // idleTimeoutFor picks the idle-progress watchdog threshold for the upstream
 // endpoint. /v1/responses gets the more generous reasoning budget — see
 // httputil.DefaultResponsesSSEIdleTimeout.
@@ -84,6 +98,25 @@ func (c *Client) idleTimeoutFor(endpoint providers.Endpoint) time.Duration {
 		return httputil.DefaultResponsesSSEIdleTimeout
 	}
 	return httputil.DefaultSSEIdleTimeout
+}
+
+// outputStallTimeout picks the /v1/responses output-progress watchdog budget:
+// the injected test override when set, else httputil.DefaultResponsesOutputStallTimeout.
+func (c *Client) outputStallTimeout() time.Duration {
+	if c.outputStall > 0 {
+		return c.outputStall
+	}
+	return httputil.DefaultResponsesOutputStallTimeout
+}
+
+// stallBudgetFor returns the budget that the watchdog identified by cause was
+// configured with, so logStreamStall reports the threshold that actually fired
+// (output-stall, not the byte-idle threshold the same call site also handles).
+func (c *Client) stallBudgetFor(endpoint providers.Endpoint, cause error) time.Duration {
+	if errors.Is(cause, httputil.ErrUpstreamOutputStall) {
+		return c.outputStallTimeout()
+	}
+	return c.idleTimeoutFor(endpoint)
 }
 
 // setAuth applies authentication to the upstream request. Precedence:
@@ -182,7 +215,7 @@ func (c *Client) Proxy(ctx context.Context, decision router.Decision, prep provi
 		bufBody, totalRead, drainErr := readCapped(body, providers.MaxBufferedErrorBytes)
 		stop()
 		if errors.Is(context.Cause(ctx), httputil.ErrUpstreamIdleTimeout) {
-			logStreamStall(decision.Model, path, idleTimeout, totalRead)
+			logStreamStall(decision.Model, path, idleTimeout, totalRead, httputil.ErrUpstreamIdleTimeout)
 		}
 		if len(bufBody) > 0 {
 			t.StampUpstreamFirstByte()
@@ -211,12 +244,33 @@ func (c *Client) Proxy(ctx context.Context, decision router.Decision, prep provi
 	w.WriteHeader(resp.StatusCode)
 	status := resp.StatusCode
 
+	// Output-progress watchdog (Responses streaming only). The byte-idle
+	// watchdog below resets on ANY upstream byte, so a stream that stays alive
+	// with non-output frames (reasoning deltas, keepalives) while producing zero
+	// output tokens rides to the 600s request cap (2026-06-16 incident). This
+	// second watchdog measures time-since-last-OUTPUT: its mark is fed by the
+	// Responses→Anthropic translator only on output-bearing events. On trip it
+	// cancels ctx with ErrUpstreamOutputStall (retryable; fails over while the
+	// preludeBuffer is still uncommitted). Only the translator can tell output
+	// frames from reasoning/keepalive frames, so it is wired via ArmOutputProgress;
+	// a non-streaming client parses events at Finalize and returns armed=false.
+	if prep.Endpoint == providers.EndpointResponses {
+		if arm, ok := w.(interface{ ArmOutputProgress(func()) bool }); ok {
+			outMark, outStop := httputil.StartIdleWatchdogCause(ctx, cancel, c.outputStallTimeout(), httputil.ErrUpstreamOutputStall)
+			if arm.ArmOutputProgress(outMark) {
+				defer outStop()
+			} else {
+				outStop()
+			}
+		}
+	}
+
 	// Manual stream loop for per-chunk diagnostics; non-debug takes the fast path.
 	if !log.Enabled(ctx, slog.LevelDebug) {
 		body := &progressReader{r: resp.Body}
 		streamErr := httputil.StreamBody(ctx, cancel, idleTimeout, body, status, w, t)
-		if errors.Is(streamErr, httputil.ErrUpstreamIdleTimeout) {
-			logStreamStall(decision.Model, path, idleTimeout, body.n)
+		if errors.Is(streamErr, httputil.ErrUpstreamIdleTimeout) || errors.Is(streamErr, httputil.ErrUpstreamOutputStall) {
+			logStreamStall(decision.Model, path, c.stallBudgetFor(prep.Endpoint, streamErr), body.n, streamErr)
 		}
 		return streamErr
 	}
@@ -256,9 +310,9 @@ func (c *Client) Proxy(ctx context.Context, decision router.Decision, prep provi
 			return nil
 		}
 		if readErr != nil {
-			if cause := context.Cause(ctx); errors.Is(cause, httputil.ErrUpstreamIdleTimeout) {
-				logStreamStall(decision.Model, path, idleTimeout, int64(bytesRead))
-				return httputil.ErrUpstreamIdleTimeout
+			if cause := context.Cause(ctx); errors.Is(cause, httputil.ErrUpstreamIdleTimeout) || errors.Is(cause, httputil.ErrUpstreamOutputStall) {
+				logStreamStall(decision.Model, path, c.stallBudgetFor(prep.Endpoint, cause), int64(bytesRead), cause)
+				return cause
 			}
 			log.Debug("OpenAI upstream read failed", "err", readErr, "bytes_read", bytesRead)
 			return readErr
@@ -288,20 +342,31 @@ func (p *progressReader) Read(buf []byte) (n int, err error) {
 	return n, err
 }
 
-// logStreamStall reports an SSE idle-watchdog trip at ERROR: the upstream
-// accepted the request and returned headers, then produced zero bytes for the
-// full idle budget (prod incident 2026-06-09: two /v1/responses streams sat
-// at zero output tokens until the 600s request cap, burning 10 minutes of the
-// customer's agent budget each). The returned ErrUpstreamIdleTimeout is
-// classified retryable, so dispatchWithFallback re-attempts when nothing has
-// been committed to the client; this log is the paper trail for how often
-// that happens per model.
-func logStreamStall(model, path string, idleTimeout time.Duration, bytesReceived int64) {
+// logStreamStall reports a watchdog trip at ERROR: the upstream accepted the
+// request and returned headers, then stalled for the full budget. Two stall
+// modes, distinguished by cause:
+//   - ErrUpstreamIdleTimeout (byte-idle): zero bytes for the idle budget (prod
+//     incident 2026-06-09: two /v1/responses streams produced no bytes until
+//     the 600s request cap).
+//   - ErrUpstreamOutputStall (output-idle): stream stayed byte-alive on
+//     reasoning/keepalive frames but produced zero output for the output-stall
+//     budget (prod incident 2026-06-16: gpt-5.5 at zero output tokens for the
+//     full 600s, bytes flowing the whole time).
+//
+// Both are classified retryable, so dispatchWithFallback re-attempts when
+// nothing has been committed to the client; this log is the per-model paper
+// trail for how often each mode happens. stall_kind tags which.
+func logStreamStall(model, path string, budget time.Duration, bytesReceived int64, cause error) {
+	stallKind := "byte_idle"
+	if errors.Is(cause, httputil.ErrUpstreamOutputStall) {
+		stallKind = "output_idle"
+	}
 	observability.Get().Error("OpenAI upstream stream stalled mid-response; aborting for retry",
 		"model", model,
 		"provider", providers.ProviderOpenAI,
 		"path", path,
-		"idle_ms", idleTimeout.Milliseconds(),
+		"stall_kind", stallKind,
+		"budget_ms", budget.Milliseconds(),
 		"bytes_received", bytesReceived,
 	)
 }

--- a/internal/providers/openai/client_output_stall_test.go
+++ b/internal/providers/openai/client_output_stall_test.go
@@ -1,0 +1,162 @@
+package openai_test
+
+// Guards the OUTPUT-progress watchdog — the second half of the gpt-5.x stall
+// protection, distinct from the byte-idle watchdog in client_stall_test.go.
+// Prod incident 2026-06-16: a /v1/responses stream stayed byte-alive (reasoning
+// deltas / keepalives kept the byte-idle watchdog reset) yet produced ZERO
+// output tokens until the router's 600s cap. The byte-idle watchdog cannot
+// catch that — only a watchdog that measures time-since-last-OUTPUT can. The
+// translator reports output progress via ArmOutputProgress; these tests stand
+// in a fake writer for it so the client half is pinned independently: a
+// byte-alive/output-silent stream aborts at the output-stall budget with a
+// retryable ErrUpstreamOutputStall, while a stream whose writer keeps marking
+// output progress is never aborted.
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"workweave/router/internal/providers"
+	"workweave/router/internal/providers/httputil"
+	"workweave/router/internal/providers/openai"
+	"workweave/router/internal/router"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeProgressWriter stands in for the Responses→Anthropic translator: it
+// exposes ArmOutputProgress so the client wires its output-progress watchdog,
+// and optionally calls the mark on each Write to simulate output flowing.
+type fakeProgressWriter struct {
+	mu          sync.Mutex
+	hdr         http.Header
+	bytesIn     int
+	mark        func()
+	armReturns  bool
+	markOnWrite bool
+}
+
+func (f *fakeProgressWriter) Header() http.Header {
+	if f.hdr == nil {
+		f.hdr = make(http.Header)
+	}
+	return f.hdr
+}
+
+func (f *fakeProgressWriter) Write(p []byte) (int, error) {
+	f.mu.Lock()
+	f.bytesIn += len(p)
+	mark := f.mark
+	markOnWrite := f.markOnWrite
+	f.mu.Unlock()
+	if markOnWrite && mark != nil {
+		mark()
+	}
+	return len(p), nil
+}
+
+func (f *fakeProgressWriter) WriteHeader(int) {}
+func (f *fakeProgressWriter) Flush()          {}
+
+func (f *fakeProgressWriter) ArmOutputProgress(mark func()) bool {
+	f.mu.Lock()
+	f.mark = mark
+	f.mu.Unlock()
+	return f.armReturns
+}
+
+// streamsNonOutputFramesForever returns an upstream that commits 200 + SSE
+// headers, then emits a non-output frame every interval until the client
+// disconnects. Bytes keep flowing (the byte-idle watchdog never trips); none of
+// them is output-bearing, so only the output-progress watchdog can end it.
+func streamsNonOutputFramesForever(interval time.Duration) *httptest.Server {
+	const frame = "event: response.in_progress\ndata: {\"type\":\"response.in_progress\"}\n\n"
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		f := w.(http.Flusher)
+		f.Flush()
+		for {
+			select {
+			case <-r.Context().Done():
+				return
+			case <-time.After(interval):
+			}
+			if _, err := io.WriteString(w, frame); err != nil {
+				return
+			}
+			f.Flush()
+		}
+	}))
+}
+
+func TestProxy_OutputStallAbortsRetryable_ByteAliveNoOutput(t *testing.T) {
+	upstream := streamsNonOutputFramesForever(15 * time.Millisecond)
+	defer upstream.Close()
+
+	// Byte-idle far longer than the frame interval (so it never fires);
+	// output-stall short (so it fires). This is the 2026-06-16 separation:
+	// bytes flowing, output silent.
+	const byteIdle = 5 * time.Second
+	const outputStall = 120 * time.Millisecond
+	c := openai.NewClientWithStallTimeouts("test-key", upstream.URL, stallTestHeaderTimeout, byteIdle, outputStall)
+	w := &fakeProgressWriter{armReturns: true} // streaming translator; never marks output
+	clientReq := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(""))
+
+	start := time.Now()
+	err := c.Proxy(context.Background(), router.Decision{Model: "gpt-5.5"}, responsesPrep(), w, clientReq)
+	elapsed := time.Since(start)
+
+	require.Error(t, err, "a byte-alive/output-silent stream must surface an error, not hang")
+	assert.ErrorIs(t, err, httputil.ErrUpstreamOutputStall)
+	assert.NotErrorIs(t, err, httputil.ErrUpstreamIdleTimeout,
+		"the byte-idle watchdog must not be what fired — bytes were flowing the whole time")
+	assert.True(t, providers.IsRetryable(err),
+		"the output stall must classify retryable so dispatchWithFallback can re-attempt")
+	assert.GreaterOrEqual(t, elapsed, outputStall, "must not abort before the output-stall budget")
+	assert.Less(t, elapsed, byteIdle, "must abort at the output-stall budget, not ride to the byte-idle/cap")
+	assert.Positive(t, w.bytesIn, "the upstream did keep the stream byte-alive (precondition for this stall mode)")
+}
+
+func TestProxy_OutputFlowingStreamIsNotOutputStalled(t *testing.T) {
+	// Same frame cadence, but the writer marks output progress on every relayed
+	// frame (simulating real output). The output-stall watchdog must keep
+	// resetting and never trip, even though total duration exceeds its budget.
+	const frame = "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"delta\":\"x\"}\n\n"
+	const frames = 6
+	const frameInterval = 20 * time.Millisecond
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		f := w.(http.Flusher)
+		f.Flush()
+		for range frames {
+			select {
+			case <-r.Context().Done():
+				return
+			case <-time.After(frameInterval):
+			}
+			_, _ = io.WriteString(w, frame)
+			f.Flush()
+		}
+	}))
+	defer upstream.Close()
+
+	const byteIdle = 5 * time.Second
+	const outputStall = 60 * time.Millisecond // < frames*frameInterval, so total duration exceeds it
+	c := openai.NewClientWithStallTimeouts("test-key", upstream.URL, stallTestHeaderTimeout, byteIdle, outputStall)
+	w := &fakeProgressWriter{armReturns: true, markOnWrite: true}
+	clientReq := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(""))
+
+	err := c.Proxy(context.Background(), router.Decision{Model: "gpt-5.5"}, responsesPrep(), w, clientReq)
+
+	require.NoError(t, err, "a stream that keeps producing output must never trip the output-stall watchdog")
+	assert.Positive(t, w.bytesIn)
+}

--- a/internal/providers/provider.go
+++ b/internal/providers/provider.go
@@ -151,6 +151,19 @@ const MaxBufferedErrorBytes = 64 * 1024
 // httputil.ErrUpstreamIdleTimeout.
 var ErrUpstreamIdleTimeout = errors.New("upstream sse idle timeout")
 
+// ErrUpstreamOutputStall is the sentinel cause set on a request context when a
+// provider adapter's OUTPUT-progress watchdog fires: the upstream returned
+// headers and keeps the stream alive (event frames, reasoning-summary deltas,
+// keepalives — so ErrUpstreamIdleTimeout never trips) yet produces no
+// output-bearing content (assistant text / tool-call args / a terminal
+// envelope) for the full output-stall budget. This is the gpt-5.x failure mode
+// behind the 2026-06-16 incident: a /v1/responses stream sat at zero output
+// tokens, dribbling non-output bytes, until the 600s request cap. Like
+// ErrUpstreamIdleTimeout it is upstream-owned and retryable. Defined here (not
+// in httputil) so IsRetryable can classify it without the import cycle;
+// httputil re-exports it as httputil.ErrUpstreamOutputStall.
+var ErrUpstreamOutputStall = errors.New("upstream sse output stall")
+
 // IsRetryableStatus reports whether an upstream HTTP status is worth
 // retrying on a different provider. Covers transient upstream-side faults
 // (5xx + 408 timeout + 429 rate-limit). 4xx ≠ 408/429 are the client's
@@ -184,6 +197,13 @@ func IsRetryable(err error) bool {
 	// in the chain may also carry context.Canceled from the watchdog's
 	// cancel call).
 	if errors.Is(err, ErrUpstreamIdleTimeout) {
+		return true
+	}
+	// An output-progress stall is likewise upstream-owned: the stream stayed
+	// byte-alive but produced no output for the full budget. Classified before
+	// the caller-cancellation guard for the same reason as ErrUpstreamIdleTimeout
+	// — the watchdog surfaces it via the request context's cancel cause.
+	if errors.Is(err, ErrUpstreamOutputStall) {
 		return true
 	}
 	// Client-side cancellation and per-request deadlines are owned by the

--- a/internal/translate/responses_output_progress_test.go
+++ b/internal/translate/responses_output_progress_test.go
@@ -1,0 +1,101 @@
+package translate_test
+
+import (
+	"net/http/httptest"
+	"testing"
+
+	"workweave/router/internal/translate"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// These tests pin the OUTPUT-progress classification the output-stall watchdog
+// depends on (see httputil.DefaultResponsesOutputStallTimeout). The translator
+// is the only layer that can tell an output-bearing Responses frame from a
+// reasoning/keepalive frame, so it owns the mark: reasoning deltas and reasoning
+// items must NOT count as progress (else the 2026-06-16 reasoning-only stall
+// would keep resetting the watchdog forever), while text, tool-call args, and
+// the terminal envelope must.
+
+// SSE events lifted from responsesStreamFixture, one per const so a test can
+// feed them individually and assert the mark fires (or not) per event.
+const (
+	evReasoningItemAdded = `event: response.output_item.added
+data: {"type":"response.output_item.added","output_index":0,"item":{"id":"rs_1","type":"reasoning","encrypted_content":"enc","summary":[],"status":"in_progress"}}
+
+`
+	evReasoningDelta = `event: response.reasoning_summary_text.delta
+data: {"type":"response.reasoning_summary_text.delta","item_id":"rs_1","output_index":0,"summary_index":0,"delta":"thinking"}
+
+`
+	evReasoningItemDone = `event: response.output_item.done
+data: {"type":"response.output_item.done","output_index":0,"item":{"id":"rs_1","type":"reasoning","encrypted_content":"enc","summary":[{"type":"summary_text","text":"thinking"}],"status":"completed"}}
+
+`
+	evMessageItemAdded = `event: response.output_item.added
+data: {"type":"response.output_item.added","output_index":1,"item":{"id":"msg_1","type":"message","role":"assistant","status":"in_progress","content":[]}}
+
+`
+	evTextDelta = `event: response.output_text.delta
+data: {"type":"response.output_text.delta","item_id":"msg_1","output_index":1,"content_index":0,"delta":"hi"}
+
+`
+	evToolArgsDelta = `event: response.function_call_arguments.delta
+data: {"type":"response.function_call_arguments.delta","item_id":"fc_1","output_index":2,"delta":"{\"q\":1}"}
+
+`
+	evCompleted = `event: response.completed
+data: {"type":"response.completed","response":{"id":"resp_abc","status":"completed","model":"gpt-5.5","incomplete_details":null,"output":[],"usage":{"input_tokens":1,"output_tokens":1}}}
+
+`
+)
+
+func newStreamingWriter(t *testing.T) (*translate.ResponsesToAnthropicWriter, *int) {
+	t.Helper()
+	w := translate.NewResponsesToAnthropicWriter(httptest.NewRecorder(), "gpt-5.5", nil)
+	require.NoError(t, w.Prelude(true))
+	count := 0
+	require.True(t, w.ArmOutputProgress(func() { count++ }),
+		"ArmOutputProgress must report armed for a streaming client")
+	return w, &count
+}
+
+func TestResponsesOutputProgress_ReasoningDoesNotCount(t *testing.T) {
+	w, count := newStreamingWriter(t)
+
+	// A reasoning item + its deltas + its done event: the entire thinking phase
+	// must leave the output-progress mark untouched.
+	_, err := w.Write([]byte(evReasoningItemAdded + evReasoningDelta + evReasoningDelta + evReasoningItemDone))
+	require.NoError(t, err)
+	assert.Zero(t, *count, "reasoning frames must not register as output progress")
+}
+
+func TestResponsesOutputProgress_OutputEventsCount(t *testing.T) {
+	tests := []struct {
+		name  string
+		event string
+	}{
+		{"message item added", evMessageItemAdded},
+		{"text delta", evTextDelta},
+		{"tool args delta", evToolArgsDelta},
+		{"terminal completed", evCompleted},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			w, count := newStreamingWriter(t)
+			_, err := w.Write([]byte(tc.event))
+			require.NoError(t, err)
+			assert.Positive(t, *count, "%s must register as output progress", tc.name)
+		})
+	}
+}
+
+func TestResponsesOutputProgress_NotArmedWhenNotStreaming(t *testing.T) {
+	// The buffered (non-streaming) path parses events only at Finalize, so it has
+	// nothing to mark mid-stream; arming there would guarantee a false trip.
+	w := translate.NewResponsesToAnthropicWriter(httptest.NewRecorder(), "gpt-5.5", nil)
+	require.NoError(t, w.Prelude(false))
+	assert.False(t, w.ArmOutputProgress(func() {}),
+		"ArmOutputProgress must report not-armed for a non-streaming client")
+}

--- a/internal/translate/responses_to_anthropic_writer.go
+++ b/internal/translate/responses_to_anthropic_writer.go
@@ -51,6 +51,14 @@ type ResponsesToAnthropicWriter struct {
 	// closed guards against a second close after Finalize emits the trailer.
 	closed bool
 
+	// onOutputProgress, when set via ArmOutputProgress, is invoked on every
+	// parsed output-bearing Responses event (assistant text, tool-call args, a
+	// non-reasoning output item, or a terminal envelope) and never on reasoning
+	// deltas or keepalives. It feeds the OpenAI client's output-progress
+	// watchdog so a stream that stays byte-alive while producing zero output is
+	// aborted (see httputil.DefaultResponsesOutputStallTimeout). nil disables it.
+	onOutputProgress func()
+
 	// blockIdx is the next Anthropic content-block index to assign.
 	blockIdx int
 	// itemBlocks maps an OpenAI Responses output_index to the Anthropic content
@@ -142,6 +150,29 @@ func (t *ResponsesToAnthropicWriter) WithEstimatedInputTokens(n int) *ResponsesT
 func (t *ResponsesToAnthropicWriter) WithRequestHadTools(hadTools bool) *ResponsesToAnthropicWriter {
 	t.requestHadTools = hadTools
 	return t
+}
+
+// ArmOutputProgress installs the output-progress watchdog mark. The translator
+// invokes mark whenever it parses an output-bearing Responses event — assistant
+// text, tool-call arguments, a non-reasoning output item, or a terminal
+// envelope — and never on reasoning deltas or keepalives, so the watchdog
+// measures time-since-last-output rather than time-since-last-byte. It returns
+// false (and installs nothing) when the client is not streaming: the buffered
+// path parses events only at Finalize, so an output-progress watchdog would
+// have nothing to mark and would false-trip. Call after Prelude, which sets the
+// streaming flag.
+func (t *ResponsesToAnthropicWriter) ArmOutputProgress(mark func()) (armed bool) {
+	if !t.streaming {
+		return false
+	}
+	t.onOutputProgress = mark
+	return true
+}
+
+func (t *ResponsesToAnthropicWriter) markOutputProgress() {
+	if t.onOutputProgress != nil {
+		t.onOutputProgress()
+	}
 }
 
 func (t *ResponsesToAnthropicWriter) Header() http.Header { return t.inner.Header() }
@@ -246,23 +277,39 @@ func (t *ResponsesToAnthropicWriter) translateResponsesEvent(raw []byte) error {
 	// sometimes dropped by intermediaries). Unknown response.* events are
 	// ignored; the ones below cover reasoning, text, tool calls, the terminal
 	// envelope, and stream-level failures.
+	// markOutputProgress feeds the output-progress watchdog: it is called on the
+	// branches below that represent the model producing OUTPUT (text, tool-call
+	// args, a non-reasoning output item, or a terminal envelope), and is
+	// deliberately NOT called on reasoning deltas/items or unknown frames — a
+	// stream that only ever reasons or keepalives must be allowed to trip the
+	// watchdog. output_item.added/done fire for reasoning items too, so those
+	// branches gate on item.type.
 	switch gjson.GetBytes(data, "type").String() {
 	case "response.output_item.added":
+		if gjson.GetBytes(data, "item.type").String() != "reasoning" {
+			t.markOutputProgress()
+		}
 		return t.handleOutputItemAdded(data)
 	case "response.output_text.delta":
+		t.markOutputProgress()
 		return t.handleTextDelta(data)
 	case "response.reasoning_summary_text.delta", "response.reasoning_text.delta":
 		return t.handleReasoningDelta(data)
 	case "response.function_call_arguments.delta":
+		t.markOutputProgress()
 		t.bufferToolArgs(data, "delta", true)
 		return nil
 	case "response.function_call_arguments.done":
 		// The terminal arg event carries the complete `arguments` string. Adopt
 		// it as authoritative so a tool call whose deltas were absent or lost
 		// still emits the real parameters rather than `{}`.
+		t.markOutputProgress()
 		t.bufferToolArgs(data, "arguments", false)
 		return nil
 	case "response.output_item.done":
+		if gjson.GetBytes(data, "item.type").String() != "reasoning" {
+			t.markOutputProgress()
+		}
 		return t.handleOutputItemDone(data)
 	case "error":
 		// Stream-level failure over HTTP 200 — surface it as an Anthropic error
@@ -275,6 +322,9 @@ func (t *ResponsesToAnthropicWriter) translateResponsesEvent(raw []byte) error {
 		e := gjson.GetBytes(data, "response.error")
 		return t.emitStreamErrorEvent(e.Get("code").String(), e.Get("message").String())
 	case "response.completed", "response.incomplete":
+		// Terminal envelope: the turn is finishing, so this is progress (and a
+		// post-trip cancel would be moot anyway).
+		t.markOutputProgress()
 		t.captureFinalResponse(data)
 		return nil
 	}


### PR DESCRIPTION
## Problem

Router session `055ca039` (prod, 2026-06-16): a gpt-5.5 `/v1/responses` turn hung for the full **600s** request cap with `resp_output_tokens=0`, then died as `proxy_err: "context canceled"`, `failover_used: false`. The user saw repeated "API calls timing out."

The existing byte-idle SSE watchdog (`DefaultResponsesSSEIdleTimeout`, 90s) **resets on every upstream byte** (`progressReader` / `StreamBody` mark on any `n>0` read). A stream that stays byte-alive on non-output frames — reasoning deltas, `response.in_progress` scaffolding, LB keepalives — while producing **zero output tokens** never trips it. It rode to the 600s cap. The byte-idle watchdog provably cannot catch this mode (its own comment assumed zero-output stalls "produced no bytes at all" — this incident disproves that).

## Fix

A second, independent watchdog on the same request context that measures **time since last OUTPUT**, not time since last byte. Only the Responses→Anthropic translator can distinguish an output-bearing frame from reasoning/keepalive, so it owns the mark via `ArmOutputProgress`:

- **Output-bearing** (resets the watchdog): `output_text.delta`, `function_call_arguments.delta/.done`, non-reasoning `output_item.added/.done`, `response.completed/.incomplete`.
- **Not** output-bearing (lets it trip): reasoning deltas, reasoning items, unknown frames, keepalives.

On trip it cancels with `ErrUpstreamOutputStall`, classified **retryable** alongside `ErrUpstreamIdleTimeout`. Because `preludeBuffer` doesn't commit `message_start` until the first real output byte, a stall that produced no output is still **uncommitted** → `dispatchWithFallback` fails over cleanly.

Default budget **240s** (`ROUTER_RESPONSES_OUTPUT_STALL_TIMEOUT_SECONDS`): well below the 600s cap, well above realistic worst-case reasoning, so a genuinely long thinking turn that eventually emits output is never clipped — only a turn that thinks/keepalives for minutes without ever producing output is aborted.

## Changes

- `providers`: `ErrUpstreamOutputStall` sentinel + `IsRetryable` classification
- `httputil`: `DefaultResponsesOutputStallTimeout` + `StartIdleWatchdogCause` (cause-parameterized); `StreamBody` surfaces either sentinel cause
- `openai/client`: arm the output watchdog for Responses streaming; `logStreamStall` now tags `stall_kind` (`byte_idle`|`output_idle`) and logs the budget that actually fired
- `translate`: `ResponsesToAnthropicWriter.ArmOutputProgress` + output-event marks

## Tests

- `translate`: reasoning frames don't count as output progress; text / tool-args / item-added / terminal do; `ArmOutputProgress` returns false for a non-streaming client
- `openai`: a byte-alive/output-silent stream aborts at the output-stall budget with a retryable `ErrUpstreamOutputStall` (not `ErrUpstreamIdleTimeout`), before the byte-idle budget; an output-flowing stream is never aborted

Backward-compatible: a plain `http.ResponseWriter` (no `ArmOutputProgress`) never arms the watchdog, so non-Responses and non-translator paths are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)