### PR TITLE
feat(proxy): use a caller's Codex subscription for their Codex turns

### DIFF
--- a/cmd/router/main.go
+++ b/cmd/router/main.go
@@ -204,6 +204,10 @@ func main() {
 		if !byokOnly {
 			openaiKey = config.GetOr("OPENAI_API_KEY", "")
 		}
+		// A caller's Codex (ChatGPT) subscription reroutes OpenAI turns to the
+		// Codex backend (chatgpt.com/backend-api/codex) over the Responses API;
+		// that switch lives in the OpenAI client, keyed off the resolved
+		// subscription credential — no separate wiring here.
 		providerMap[providers.ProviderOpenAI] = openaiProvider.NewClient(openaiKey, openaiBaseURL)
 		switch {
 		case byokOnly:

--- a/internal/observability/otel/usage.go
+++ b/internal/observability/otel/usage.go
@@ -252,6 +252,11 @@ func extractUsageGJSON(data []byte, provider string) (input, output, cacheCreati
 	if !usage.Exists() && provider == providerAnthropic {
 		usage = gjson.GetBytes(data, "message.usage")
 	}
+	// OpenAI Responses streaming nests usage under the terminal response event
+	// (response.completed); the non-streaming body carries it at the top level.
+	if !usage.Exists() && provider == providerOpenAI {
+		usage = gjson.GetBytes(data, "response.usage")
+	}
 	if !usage.Exists() {
 		return 0, 0, 0, 0, false
 	}
@@ -263,9 +268,19 @@ func extractUsageGJSON(data []byte, provider string) (input, output, cacheCreati
 		cacheCreation = int(usage.Get("cache_creation_input_tokens").Int())
 		cacheRead = int(usage.Get("cache_read_input_tokens").Int())
 	case providerOpenAI, providerGoogle:
-		input = int(usage.Get("prompt_tokens").Int())
-		output = int(usage.Get("completion_tokens").Int())
-		cacheRead = int(usage.Get("prompt_tokens_details.cached_tokens").Int())
+		// Chat Completions uses prompt_tokens/completion_tokens; the Responses
+		// API (Codex backend passthrough) uses input_tokens/output_tokens with
+		// input_tokens_details.cached_tokens. Probe both so one extractor serves
+		// both OpenAI surfaces.
+		if pt := usage.Get("prompt_tokens"); pt.Exists() {
+			input = int(pt.Int())
+			output = int(usage.Get("completion_tokens").Int())
+			cacheRead = int(usage.Get("prompt_tokens_details.cached_tokens").Int())
+		} else {
+			input = int(usage.Get("input_tokens").Int())
+			output = int(usage.Get("output_tokens").Int())
+			cacheRead = int(usage.Get("input_tokens_details.cached_tokens").Int())
+		}
 	default:
 		return 0, 0, 0, 0, false
 	}

--- a/internal/observability/otel/usage_test.go
+++ b/internal/observability/otel/usage_test.go
@@ -76,6 +76,44 @@ func TestUsageExtractor_OpenAIStreaming(t *testing.T) {
 	assert.Equal(t, 12, out)
 }
 
+func TestUsageExtractor_OpenAIResponsesStreaming(t *testing.T) {
+	// The Codex (ChatGPT) subscription backend streams the Responses API: usage
+	// lands on the terminal response.completed event, nested under response.usage
+	// with input_tokens/output_tokens (+ input_tokens_details.cached_tokens),
+	// not the chat-completions prompt_tokens shape. Billing the 5% subscription
+	// fee depends on this parse.
+	rec := httptest.NewRecorder()
+	ext := otel.NewUsageExtractor(rec, "openai")
+
+	events := []string{
+		"event: response.created\ndata: {\"type\":\"response.created\",\"response\":{\"id\":\"resp_1\"}}\n\n",
+		"event: response.completed\ndata: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_1\",\"usage\":{\"input_tokens\":120,\"output_tokens\":34,\"input_tokens_details\":{\"cached_tokens\":40}}}}\n\n",
+	}
+	for _, e := range events {
+		_, err := ext.Write([]byte(e))
+		require.NoError(t, err)
+	}
+
+	in, out := ext.Tokens()
+	assert.Equal(t, 120, in)
+	assert.Equal(t, 34, out)
+	_, cacheRead := ext.CacheTokens()
+	assert.Equal(t, 40, cacheRead, "Responses cached_tokens must map to cache-read for accurate subscription billing")
+}
+
+func TestUsageExtractor_OpenAIResponsesNonStreaming(t *testing.T) {
+	rec := httptest.NewRecorder()
+	ext := otel.NewUsageExtractor(rec, "openai")
+
+	body := `{"id":"resp_2","object":"response","usage":{"input_tokens":50,"output_tokens":9,"input_tokens_details":{"cached_tokens":0}}}`
+	_, err := ext.Write([]byte(body))
+	require.NoError(t, err)
+
+	in, out := ext.Tokens()
+	assert.Equal(t, 50, in)
+	assert.Equal(t, 9, out)
+}
+
 func TestUsageExtractor_GoogleStreaming(t *testing.T) {
 	rec := httptest.NewRecorder()
 	ext := otel.NewUsageExtractor(rec, "google")

--- a/internal/providers/openai/client.go
+++ b/internal/providers/openai/client.go
@@ -196,14 +196,18 @@ func (c *Client) Proxy(ctx context.Context, decision router.Decision, prep provi
 
 	// A Codex (ChatGPT) subscription turn dispatches to the Codex backend over
 	// the Responses API; everything else uses the configured base URL + the
-	// endpoint-appropriate path.
+	// endpoint-appropriate path. Gate on EndpointResponses so a chat-completions
+	// body that happens to resolve a Codex credential is never posted to the
+	// Codex /responses endpoint (which only accepts the Responses schema) — the
+	// routed Codex passthrough always builds a Responses-shaped request.
 	codexCreds := codexSubscriptionCreds(ctx)
+	useCodex := codexCreds != nil && prep.Endpoint == providers.EndpointResponses
 	baseURL := c.baseURL
 	path := "/v1/chat/completions"
 	if prep.Endpoint == providers.EndpointResponses {
 		path = "/v1/responses"
 	}
-	if codexCreds != nil {
+	if useCodex {
 		baseURL = c.codexBaseURL
 		path = codexResponsesPath
 	}
@@ -222,7 +226,7 @@ func (c *Client) Proxy(ctx context.Context, decision router.Decision, prep provi
 	// Codex backend required headers, set AFTER the prep.Headers copy so they
 	// are never clobbered. setAuth has already written Authorization: Bearer
 	// <jwt> from the resolved OAuth credential.
-	if codexCreds != nil {
+	if useCodex {
 		upstream.Header.Set(codexAccountIDHeader, string(codexCreds.AccountID))
 		upstream.Header.Set(codexOpenAIBetaHeader, codexOpenAIBetaValue)
 		upstream.Header.Set(codexOriginatorHeader, codexOriginatorValue)
@@ -430,14 +434,10 @@ func truncateBytes(b []byte, n int) string {
 }
 
 func (c *Client) Passthrough(ctx context.Context, prep providers.PreparedRequest, w http.ResponseWriter, r *http.Request) error {
-	// A Codex (ChatGPT) subscription authenticates only against the Codex
-	// backend's Responses endpoint; otherwise pass the inbound path through to
-	// the configured base URL.
-	codexCreds := codexSubscriptionCreds(ctx)
+	// Codex (ChatGPT) subscriptions are served only on the routed Responses
+	// dispatch (Proxy), never this non-routed passthrough path, so no Codex
+	// backend switch is applied here.
 	url := c.baseURL + r.URL.Path
-	if codexCreds != nil {
-		url = c.codexBaseURL + codexResponsesPath
-	}
 	if r.URL.RawQuery != "" {
 		url += "?" + r.URL.RawQuery
 	}
@@ -455,12 +455,6 @@ func (c *Client) Passthrough(ctx context.Context, prep providers.PreparedRequest
 	}
 	if v := r.Header.Get("Accept"); v != "" {
 		upstream.Header.Set("Accept", v)
-	}
-	if codexCreds != nil {
-		upstream.Header.Set(codexAccountIDHeader, string(codexCreds.AccountID))
-		upstream.Header.Set(codexOpenAIBetaHeader, codexOpenAIBetaValue)
-		upstream.Header.Set(codexOriginatorHeader, codexOriginatorValue)
-		upstream.Header.Set(codexUserAgentHeader, codexUserAgentValue)
 	}
 
 	resp, err := c.http.Do(upstream)

--- a/internal/providers/openai/client.go
+++ b/internal/providers/openai/client.go
@@ -23,6 +23,34 @@ import (
 
 const DefaultBaseURL = "https://api.openai.com"
 
+// Codex (ChatGPT) subscription backend. A caller's ChatGPT plan authenticates
+// only against this base URL over the Responses API — never api.openai.com —
+// and requires the ChatGPT-Account-ID header paired with the OAuth bearer
+// (401/403 without it). These mirror what the Codex CLI sends (codex_cli_rs).
+const (
+	chatGPTCodexBaseURL   = "https://chatgpt.com/backend-api/codex"
+	codexResponsesPath    = "/responses"
+	codexAccountIDHeader  = "ChatGPT-Account-ID"
+	codexOpenAIBetaHeader = "OpenAI-Beta"
+	codexOpenAIBetaValue  = "responses=experimental"
+	codexOriginatorHeader = "originator"
+	codexOriginatorValue  = "codex_cli_rs"
+	codexUserAgentHeader  = "User-Agent"
+	codexUserAgentValue   = "codex_cli_rs"
+)
+
+// codexSubscriptionCreds returns the resolved per-request credential when it is
+// a Codex (ChatGPT) subscription bearer — an OAuth token carrying a paired
+// ChatGPT account id — and nil otherwise. Such a turn must dispatch to the
+// Codex backend over the Responses API instead of api.openai.com.
+func codexSubscriptionCreds(ctx context.Context) *proxy.Credentials {
+	creds := proxy.CredentialsFromContext(ctx)
+	if creds != nil && creds.OAuth && len(creds.AccountID) > 0 {
+		return creds
+	}
+	return nil
+}
+
 // responseHeaderTimeout guards time-to-first-byte for OpenAI upstreams. It is
 // raised above the 30s default because the Responses API (gpt-5.x reasoning)
 // can take well over 30s to emit its first streamed event under high effort;
@@ -48,6 +76,10 @@ type Client struct {
 	// default via NewClient; tests inject a small value to exercise the
 	// output-stall trip without waiting out the real threshold.
 	outputStall time.Duration
+	// codexBaseURL is the base URL for the Codex (ChatGPT) subscription backend.
+	// Production uses chatGPTCodexBaseURL; tests override it to point a Codex
+	// dispatch at an httptest server.
+	codexBaseURL string
 }
 
 func NewClient(apiKey, baseURL string) *Client {
@@ -64,9 +96,10 @@ func NewClientWithResponseHeaderTimeout(apiKey, baseURL string, headerTimeout ti
 		baseURL = DefaultBaseURL
 	}
 	return &Client{
-		apiKey:  apiKey,
-		baseURL: baseURL,
-		http:    &http.Client{Transport: httputil.NewTransportWithResponseHeaderTimeout(5*time.Second, 5*time.Second, headerTimeout)},
+		apiKey:       apiKey,
+		baseURL:      baseURL,
+		codexBaseURL: chatGPTCodexBaseURL,
+		http:         &http.Client{Transport: httputil.NewTransportWithResponseHeaderTimeout(5*time.Second, 5*time.Second, headerTimeout)},
 	}
 }
 
@@ -161,11 +194,20 @@ func (c *Client) Proxy(ctx context.Context, decision router.Decision, prep provi
 	ctx, cancel := context.WithCancelCause(ctx)
 	defer cancel(nil)
 
+	// A Codex (ChatGPT) subscription turn dispatches to the Codex backend over
+	// the Responses API; everything else uses the configured base URL + the
+	// endpoint-appropriate path.
+	codexCreds := codexSubscriptionCreds(ctx)
+	baseURL := c.baseURL
 	path := "/v1/chat/completions"
 	if prep.Endpoint == providers.EndpointResponses {
 		path = "/v1/responses"
 	}
-	upstream, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+path, bytes.NewReader(prep.Body))
+	if codexCreds != nil {
+		baseURL = c.codexBaseURL
+		path = codexResponsesPath
+	}
+	upstream, err := http.NewRequestWithContext(ctx, http.MethodPost, baseURL+path, bytes.NewReader(prep.Body))
 	if err != nil {
 		return fmt.Errorf("build upstream request: %w", err)
 	}
@@ -176,6 +218,15 @@ func (c *Client) Proxy(ctx context.Context, decision router.Decision, prep provi
 	}
 	if v := r.Header.Get("Accept"); v != "" {
 		upstream.Header.Set("Accept", v)
+	}
+	// Codex backend required headers, set AFTER the prep.Headers copy so they
+	// are never clobbered. setAuth has already written Authorization: Bearer
+	// <jwt> from the resolved OAuth credential.
+	if codexCreds != nil {
+		upstream.Header.Set(codexAccountIDHeader, string(codexCreds.AccountID))
+		upstream.Header.Set(codexOpenAIBetaHeader, codexOpenAIBetaValue)
+		upstream.Header.Set(codexOriginatorHeader, codexOriginatorValue)
+		upstream.Header.Set(codexUserAgentHeader, codexUserAgentValue)
 	}
 
 	t := otel.TimingFrom(ctx)
@@ -379,7 +430,14 @@ func truncateBytes(b []byte, n int) string {
 }
 
 func (c *Client) Passthrough(ctx context.Context, prep providers.PreparedRequest, w http.ResponseWriter, r *http.Request) error {
+	// A Codex (ChatGPT) subscription authenticates only against the Codex
+	// backend's Responses endpoint; otherwise pass the inbound path through to
+	// the configured base URL.
+	codexCreds := codexSubscriptionCreds(ctx)
 	url := c.baseURL + r.URL.Path
+	if codexCreds != nil {
+		url = c.codexBaseURL + codexResponsesPath
+	}
 	if r.URL.RawQuery != "" {
 		url += "?" + r.URL.RawQuery
 	}
@@ -397,6 +455,12 @@ func (c *Client) Passthrough(ctx context.Context, prep providers.PreparedRequest
 	}
 	if v := r.Header.Get("Accept"); v != "" {
 		upstream.Header.Set("Accept", v)
+	}
+	if codexCreds != nil {
+		upstream.Header.Set(codexAccountIDHeader, string(codexCreds.AccountID))
+		upstream.Header.Set(codexOpenAIBetaHeader, codexOpenAIBetaValue)
+		upstream.Header.Set(codexOriginatorHeader, codexOriginatorValue)
+		upstream.Header.Set(codexUserAgentHeader, codexUserAgentValue)
 	}
 
 	resp, err := c.http.Do(upstream)

--- a/internal/providers/openai/codex_internal_test.go
+++ b/internal/providers/openai/codex_internal_test.go
@@ -66,6 +66,37 @@ func TestProxy_CodexSubscriptionDispatch(t *testing.T) {
 	assert.Equal(t, body, gotBody, "the prepared Responses body must reach the Codex backend unchanged")
 }
 
+// TestProxy_CodexCredOnChatEndpointDoesNotMisroute guards the Bugbot finding:
+// the Codex backend only accepts the Responses schema, so a chat-completions
+// prep that happens to resolve a Codex credential must NOT be posted to the
+// Codex /responses endpoint. The switch is gated on EndpointResponses.
+func TestProxy_CodexCredOnChatEndpointDoesNotMisroute(t *testing.T) {
+	var gotPath, gotAccount string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotAccount = r.Header.Get("ChatGPT-Account-ID")
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, "data: [DONE]\n\n")
+	}))
+	defer upstream.Close()
+
+	c := NewClient("deployment-key", upstream.URL)
+	c.codexBaseURL = "https://chatgpt.example.invalid" // must NOT be used for a chat body
+
+	// EndpointChatCompletions (zero value) — a chat-shaped body.
+	prep := providers.PreparedRequest{Body: []byte(`{"model":"gpt-5.5","messages":[]}`), Headers: make(http.Header)}
+	rec := httptest.NewRecorder()
+	clientReq := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(""))
+
+	ctx := codexCtx("eyJhbGciOiJ-codex-jwt", "acct-12345")
+	err := c.Proxy(ctx, router.Decision{Model: "gpt-5.5", Provider: providers.ProviderOpenAI}, prep, rec, clientReq)
+	require.NoError(t, err)
+
+	assert.Equal(t, "/v1/chat/completions", gotPath,
+		"a chat-completions body must never be posted to the Codex /responses endpoint, even with a Codex credential")
+	assert.Empty(t, gotAccount, "the Codex account-id header must not be set on a non-Responses dispatch")
+}
+
 // TestProxy_NoCodexCredHitsOpenAI confirms the Codex switch is gated on the
 // subscription credential: a normal (deployment-key) request still targets
 // api.openai.com and sends no ChatGPT-Account-ID header.

--- a/internal/providers/openai/codex_internal_test.go
+++ b/internal/providers/openai/codex_internal_test.go
@@ -1,0 +1,94 @@
+package openai
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"workweave/router/internal/providers"
+	"workweave/router/internal/proxy"
+	"workweave/router/internal/router"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func codexCtx(token, accountID string) context.Context {
+	return context.WithValue(context.Background(), proxy.CredentialsContextKey{}, &proxy.Credentials{
+		APIKey:    []byte(token),
+		AccountID: []byte(accountID),
+		Source:    "codex_subscription",
+		OAuth:     true,
+	})
+}
+
+// TestProxy_CodexSubscriptionDispatch verifies a Codex (ChatGPT) subscription
+// credential reroutes the upstream call to the Codex backend's /responses
+// endpoint with the required auth + account-id + beta + originator headers, and
+// forwards the prepared Responses body byte-for-byte.
+func TestProxy_CodexSubscriptionDispatch(t *testing.T) {
+	var gotPath, gotAuth, gotAccount, gotBeta, gotOriginator string
+	var gotBody []byte
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotAuth = r.Header.Get("Authorization")
+		gotAccount = r.Header.Get("ChatGPT-Account-ID")
+		gotBeta = r.Header.Get("OpenAI-Beta")
+		gotOriginator = r.Header.Get("originator")
+		gotBody, _ = io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, "event: response.completed\ndata: {\"type\":\"response.completed\"}\n\n")
+	}))
+	defer upstream.Close()
+
+	c := NewClient("deployment-key", upstream.URL)
+	c.codexBaseURL = upstream.URL // point the Codex backend at the test server
+
+	body := []byte(`{"model":"gpt-5.5","input":"hi","stream":true}`)
+	prep := providers.PreparedRequest{Body: body, Endpoint: providers.EndpointResponses, Headers: make(http.Header)}
+	rec := httptest.NewRecorder()
+	clientReq := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(""))
+
+	ctx := codexCtx("eyJhbGciOiJ-codex-jwt", "acct-12345")
+	err := c.Proxy(ctx, router.Decision{Model: "gpt-5.5", Provider: providers.ProviderOpenAI}, prep, rec, clientReq)
+	require.NoError(t, err)
+
+	assert.Equal(t, "/responses", gotPath, "a Codex subscription turn must hit the Codex backend's /responses endpoint, not api.openai.com")
+	assert.Equal(t, "Bearer eyJhbGciOiJ-codex-jwt", gotAuth, "the ChatGPT OAuth JWT must be sent as a Bearer token")
+	assert.Equal(t, "acct-12345", gotAccount, "the ChatGPT-Account-ID header is required by the Codex backend")
+	assert.Equal(t, "responses=experimental", gotBeta)
+	assert.Equal(t, "codex_cli_rs", gotOriginator)
+	assert.Empty(t, rec.Header().Get("x-api-key"))
+	assert.Equal(t, body, gotBody, "the prepared Responses body must reach the Codex backend unchanged")
+}
+
+// TestProxy_NoCodexCredHitsOpenAI confirms the Codex switch is gated on the
+// subscription credential: a normal (deployment-key) request still targets
+// api.openai.com and sends no ChatGPT-Account-ID header.
+func TestProxy_NoCodexCredHitsOpenAI(t *testing.T) {
+	var gotPath, gotAccount string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotAccount = r.Header.Get("ChatGPT-Account-ID")
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, "data: [DONE]\n\n")
+	}))
+	defer upstream.Close()
+
+	c := NewClient("deployment-key", upstream.URL)
+	c.codexBaseURL = "https://chatgpt.example.invalid" // must NOT be used
+
+	prep := providers.PreparedRequest{Body: []byte(`{"model":"gpt-5.5"}`), Headers: make(http.Header)}
+	rec := httptest.NewRecorder()
+	clientReq := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(""))
+
+	err := c.Proxy(context.Background(), router.Decision{Model: "gpt-5.5", Provider: providers.ProviderOpenAI}, prep, rec, clientReq)
+	require.NoError(t, err)
+
+	assert.Equal(t, "/v1/chat/completions", gotPath)
+	assert.Empty(t, gotAccount, "a non-subscription request must not send the Codex account-id header")
+}

--- a/internal/proxy/credentials.go
+++ b/internal/proxy/credentials.go
@@ -14,22 +14,34 @@ import (
 // the real-world sk-ant-oat01-… Claude Code subscription/access-token shapes.
 const subscriptionTokenPrefix = "sk-ant-oat"
 
+// chatGPTAccountIDHeader is the inbound header Codex sends alongside a ChatGPT
+// subscription bearer (self-hosted/passthrough path). Its presence disambiguates
+// a Codex subscription JWT from a plain OpenAI client API key. http.Header.Get
+// canonicalizes the key, so casing variants resolve to the same value.
+const chatGPTAccountIDHeader = "ChatGPT-Account-ID"
+
 // Credential sources, for logging and precedence reasoning. Never log the key
 // itself — only the source.
 const (
-	credSourceBYOK         = "byok"
-	credSourceClient       = "client"
-	credSourceSubscription = "subscription"
+	credSourceBYOK              = "byok"
+	credSourceClient            = "client"
+	credSourceSubscription      = "subscription"
+	credSourceCodexSubscription = "codex_subscription"
 )
 
 // Credentials holds the API key to use for an upstream request.
 type Credentials struct {
 	APIKey []byte // never logged
-	Source string // credSourceBYOK | credSourceClient | credSourceSubscription
-	// OAuth marks a Claude subscription bearer (sk-ant-oat-): it authenticates
-	// via Authorization: Bearer + the oauth beta header, never x-api-key, and is
-	// only ever resolved for Anthropic. Zero value (false) = a normal API key.
+	Source string // credSourceBYOK | credSourceClient | credSourceSubscription | credSourceCodexSubscription
+	// OAuth marks a subscription bearer — a Claude subscription token
+	// (sk-ant-oat-, resolved only for Anthropic) or a Codex ChatGPT JWT
+	// (resolved only for OpenAI). It authenticates via Authorization: Bearer
+	// and never x-api-key. Zero value (false) = a normal API key.
 	OAuth bool
+	// AccountID is the ChatGPT-Account-ID paired with a Codex subscription
+	// bearer; the Codex backend 401/403s without it. Set only for Codex
+	// subscription credentials, never logged, empty otherwise.
+	AccountID []byte
 }
 
 // ExternalAPIKeysContextKey is the request-context key for external API keys
@@ -99,6 +111,18 @@ func ExtractClientCredentials(provider string, headers http.Header) *Credentials
 		authHeader := headers.Get("Authorization")
 		if raw, found := strings.CutPrefix(authHeader, "Bearer "); found {
 			key := strings.TrimSpace(raw)
+			// A Codex ChatGPT subscription bearer arrives on the OpenAI surface
+			// with a ChatGPT-Account-ID header; that pairing is the signal that
+			// distinguishes the subscription JWT from a plain client API key, so
+			// we resolve it before the client-key branch. OpenAI-only — the JWT
+			// can't authenticate any other Bearer-using upstream, and a caller's
+			// stray ChatGPT-Account-ID on a non-OpenAI route must not reclassify
+			// that route's bearer.
+			if provider == providers.ProviderOpenAI {
+				if sub := codexSubscriptionCreds(key, headers.Get(chatGPTAccountIDHeader)); sub != nil {
+					return sub
+				}
+			}
 			// Reject Anthropic-shaped tokens (API keys AND OAuth bearers)
 			// here so one Bearer header doesn't get misidentified as creds
 			// for every Bearer-using provider.
@@ -135,6 +159,30 @@ func subscriptionCredsFromToken(token string) *Credentials {
 		return nil
 	}
 	return &Credentials{APIKey: []byte(token), Source: credSourceSubscription, OAuth: true}
+}
+
+// codexSubscriptionCreds returns Codex (ChatGPT) subscription credentials for a
+// bare OAuth access token paired with its ChatGPT account id, or nil if the
+// pair isn't a usable Codex subscription. The token is a ChatGPT-login JWT
+// (eyJ…); we reject router keys (rk_) and OpenAI API keys (sk-…), and require a
+// non-empty account id because the Codex backend (chatgpt.com/backend-api/codex)
+// 401/403s without the ChatGPT-Account-ID header. OpenAI-only: the JWT can't
+// authenticate any other upstream.
+func codexSubscriptionCreds(token, accountID string) *Credentials {
+	token = strings.TrimSpace(token)
+	accountID = strings.TrimSpace(accountID)
+	if token == "" || accountID == "" {
+		return nil
+	}
+	if auth.HasAPIKeyPrefix(token) || strings.HasPrefix(token, "sk-") {
+		return nil
+	}
+	return &Credentials{
+		APIKey:    []byte(token),
+		AccountID: []byte(accountID),
+		Source:    credSourceCodexSubscription,
+		OAuth:     true,
+	}
 }
 
 // subscriptionCredsFromHeaderValue resolves the dedicated

--- a/internal/proxy/credentials_test.go
+++ b/internal/proxy/credentials_test.go
@@ -264,3 +264,73 @@ func TestResolveCredentials_SubscriptionBeatsBYOK(t *testing.T) {
 	assert.True(t, creds.OAuth)
 	assert.Equal(t, []byte("sk-ant-oat01-subscription-token"), creds.APIKey)
 }
+
+const codexJWT = "eyJhbGciOiJSUzI1NiJ9.codex-access-token.signature"
+
+func TestExtractClientCredentials_CodexSubscription(t *testing.T) {
+	// A Codex (ChatGPT) subscription arrives on the OpenAI surface as an OAuth
+	// JWT bearer paired with a ChatGPT-Account-ID header. The pairing is what
+	// distinguishes it from a plain client API key, and both pieces are carried
+	// so the OpenAI client can reach the Codex backend.
+	headers := http.Header{
+		"Authorization":      []string{"Bearer " + codexJWT},
+		"Chatgpt-Account-Id": []string{"acct-12345"},
+	}
+	creds := proxy.ExtractClientCredentials("openai", headers)
+	require.NotNil(t, creds, "a Codex subscription JWT + account-id must be accepted for OpenAI")
+	assert.True(t, creds.OAuth, "a Codex subscription bearer must be flagged OAuth")
+	assert.Equal(t, "codex_subscription", creds.Source)
+	assert.Equal(t, []byte(codexJWT), creds.APIKey)
+	assert.Equal(t, []byte("acct-12345"), creds.AccountID)
+}
+
+func TestExtractClientCredentials_CodexJWTWithoutAccountIDIsNotSubscription(t *testing.T) {
+	// Without the account-id the Codex backend would 401, so the pair is not a
+	// usable subscription. The bearer falls through to the plain client-key path.
+	headers := http.Header{"Authorization": []string{"Bearer " + codexJWT}}
+	creds := proxy.ExtractClientCredentials("openai", headers)
+	require.NotNil(t, creds)
+	assert.False(t, creds.OAuth, "a JWT with no ChatGPT-Account-ID must not be treated as a Codex subscription")
+	assert.Empty(t, creds.AccountID)
+	assert.Equal(t, "client", creds.Source)
+}
+
+func TestExtractClientCredentials_OpenAIKeyWithAccountIDIsNotSubscription(t *testing.T) {
+	// An sk- key is an API key, not a ChatGPT OAuth JWT, even if an account-id
+	// header is (spuriously) present.
+	headers := http.Header{
+		"Authorization":      []string{"Bearer sk-oai-real-key"},
+		"Chatgpt-Account-Id": []string{"acct-12345"},
+	}
+	creds := proxy.ExtractClientCredentials("openai", headers)
+	require.NotNil(t, creds)
+	assert.False(t, creds.OAuth, "an sk- API key must never be classified as a Codex subscription")
+	assert.Equal(t, "client", creds.Source)
+}
+
+func TestExtractClientCredentials_CodexSubscriptionIsOpenAIOnly(t *testing.T) {
+	// The Codex JWT authenticates only the OpenAI Codex backend; a ChatGPT
+	// account-id header on another vendor's surface must not produce an OAuth
+	// credential for that vendor.
+	headers := http.Header{
+		"Authorization":      []string{"Bearer " + codexJWT},
+		"Chatgpt-Account-Id": []string{"acct-12345"},
+	}
+	for _, provider := range []string{"google", "openrouter", "fireworks"} {
+		creds := proxy.ExtractClientCredentials(provider, headers)
+		if creds != nil {
+			assert.Falsef(t, creds.OAuth, "a Codex subscription must never be resolved for %s", provider)
+			assert.Emptyf(t, creds.AccountID, "no Codex account-id must attach to %s creds", provider)
+		}
+	}
+}
+
+func TestExtractClientCredentials_RejectsRouterBearerEvenWithAccountID(t *testing.T) {
+	headers := http.Header{
+		"Authorization":      []string{"Bearer rk_router_key"},
+		"Chatgpt-Account-Id": []string{"acct-12345"},
+	}
+	creds := proxy.ExtractClientCredentials("openai", headers)
+	assert.Nil(t, creds,
+		"a router key must never be classified as a Codex subscription, account-id present or not")
+}

--- a/internal/proxy/enabled_providers_internal_test.go
+++ b/internal/proxy/enabled_providers_internal_test.go
@@ -169,6 +169,56 @@ func TestEnabledProvidersForRequest_SubscriptionEnrollsAnthropic(t *testing.T) {
 	})
 }
 
+// TestEnabledProvidersForRequest_CodexSubscriptionEnrollsOpenAI mirrors the
+// Anthropic enrollment for the Codex (ChatGPT) subscription: a router-keyed
+// byokOnly request carrying the dedicated Codex header pair — no BYOK, no
+// deployment key — must enroll OpenAI (and only OpenAI) so the scorer can pick
+// a Codex-eligible model. Enrollment requires BOTH token and account-id.
+func TestEnabledProvidersForRequest_CodexSubscriptionEnrollsOpenAI(t *testing.T) {
+	const codexJWT = "eyJhbGciOiJSUzI1NiJ9.codex.sig"
+	makeService := func() *Service {
+		return &Service{
+			byokOnly: true,
+			providers: map[string]providers.Client{
+				providers.ProviderAnthropic: nil,
+				providers.ProviderOpenAI:    nil,
+			},
+			deploymentKeyedProviders:     map[string]struct{}{},
+			passthroughEligibleProviders: map[string]struct{}{},
+		}
+	}
+	routerKeyed := func() context.Context {
+		return context.WithValue(context.Background(), InstallationIDContextKey{}, testInstallationID)
+	}
+
+	t.Run("dedicated Codex headers enroll openai only", func(t *testing.T) {
+		ctx := context.WithValue(routerKeyed(), OpenAISubscriptionContextKey{}, codexJWT)
+		ctx = context.WithValue(ctx, OpenAIAccountIDContextKey{}, "acct-123")
+		got := makeService().enabledProvidersForRequest(ctx, providers.ProviderOpenAI, http.Header{})
+		assert.Contains(t, got, providers.ProviderOpenAI,
+			"a Codex subscription must make OpenAI eligible so the scorer can route a Codex turn")
+		assert.NotContains(t, got, providers.ProviderAnthropic,
+			"the Codex token is OpenAI-only and must never enroll another upstream")
+	})
+
+	t.Run("token without account-id enrolls nothing (load-bearing)", func(t *testing.T) {
+		ctx := context.WithValue(routerKeyed(), OpenAISubscriptionContextKey{}, codexJWT)
+		got := makeService().enabledProvidersForRequest(ctx, providers.ProviderOpenAI, http.Header{})
+		assert.NotContains(t, got, providers.ProviderOpenAI,
+			"without the ChatGPT-Account-ID the subscription is unusable, so OpenAI must not be enrolled")
+		assert.Empty(t, got)
+	})
+
+	t.Run("an excluded OpenAI trumps the Codex enrollment", func(t *testing.T) {
+		ctx := context.WithValue(routerKeyed(), OpenAISubscriptionContextKey{}, codexJWT)
+		ctx = context.WithValue(ctx, OpenAIAccountIDContextKey{}, "acct-123")
+		ctx = context.WithValue(ctx, InstallationExcludedProvidersContextKey{}, []string{providers.ProviderOpenAI})
+		got := makeService().enabledProvidersForRequest(ctx, providers.ProviderOpenAI, http.Header{})
+		assert.NotContains(t, got, providers.ProviderOpenAI,
+			"a provider exclusion must subtract OpenAI even when a Codex subscription is present")
+	})
+}
+
 // TestEnabledProvidersForRequest_DeploymentKeyedStillCrossSurface confirms
 // that env-keyed providers stay eligible regardless of surface (their keys
 // are trusted and don't depend on inbound headers).

--- a/internal/proxy/enabled_providers_internal_test.go
+++ b/internal/proxy/enabled_providers_internal_test.go
@@ -201,6 +201,30 @@ func TestEnabledProvidersForRequest_CodexSubscriptionEnrollsOpenAI(t *testing.T)
 			"the Codex token is OpenAI-only and must never enroll another upstream")
 	})
 
+	t.Run("inbound Authorization Codex bearer enrolls openai on a router-keyed request", func(t *testing.T) {
+		// The managed Codex CLI path: router key in X-Weave-Router-Key, the
+		// ChatGPT JWT + account-id left in Authorization. OpenAI must be enrolled
+		// off the inbound bearer so the scorer can route a Codex turn.
+		headers := http.Header{
+			"Authorization":      []string{"Bearer " + codexJWT},
+			"Chatgpt-Account-Id": []string{"acct-123"},
+		}
+		got := makeService().enabledProvidersForRequest(routerKeyed(), providers.ProviderOpenAI, headers)
+		assert.Contains(t, got, providers.ProviderOpenAI,
+			"the inbound Codex subscription bearer (Codex-through-router) must enroll OpenAI even when router-keyed")
+		assert.NotContains(t, got, providers.ProviderAnthropic,
+			"the Codex token is OpenAI-only and must never enroll another upstream")
+	})
+
+	t.Run("inbound OpenAI API-key bearer does NOT enroll openai on a router-keyed request", func(t *testing.T) {
+		// Only the Codex OAuth subset (JWT + account-id) enrolls off the inbound
+		// bearer; a plain client API key with no account-id must not.
+		headers := http.Header{"Authorization": []string{"Bearer sk-proj-real-client-key"}}
+		got := makeService().enabledProvidersForRequest(routerKeyed(), providers.ProviderOpenAI, headers)
+		assert.NotContains(t, got, providers.ProviderOpenAI,
+			"a general inbound OpenAI API key must not enroll OpenAI on the router-key path")
+	})
+
 	t.Run("token without account-id enrolls nothing (load-bearing)", func(t *testing.T) {
 		ctx := context.WithValue(routerKeyed(), OpenAISubscriptionContextKey{}, codexJWT)
 		got := makeService().enabledProvidersForRequest(ctx, providers.ProviderOpenAI, http.Header{})

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -27,6 +27,7 @@ import (
 	"workweave/router/internal/translate"
 
 	"github.com/google/uuid"
+	"github.com/tidwall/sjson"
 )
 
 // Service orchestrates routing decisions and provider dispatch.
@@ -210,6 +211,20 @@ type CredentialsContextKey struct{}
 // Claude subscription OAuth token, stashed by the auth middleware from the
 // X-Weave-Anthropic-Subscription header on router-keyed requests.
 type AnthropicSubscriptionContextKey struct{}
+
+// OpenAISubscriptionContextKey and OpenAIAccountIDContextKey are the
+// request-context keys for a caller's raw Codex (ChatGPT) subscription OAuth JWT
+// and its paired ChatGPT-Account-ID, stashed by the auth middleware from the
+// X-Weave-OpenAI-Subscription / X-Weave-OpenAI-Account-ID headers on router-keyed
+// requests.
+type OpenAISubscriptionContextKey struct{}
+type OpenAIAccountIDContextKey struct{}
+
+// codexResponsesBodyContextKey carries the caller's ORIGINAL Responses request
+// body on a Codex (ChatGPT) subscription turn. ProxyOpenAIResponses stashes it
+// so ProxyOpenAIChatCompletion can route normally but dispatch the untranslated
+// Responses body to the Codex backend (its presence marks the passthrough).
+type codexResponsesBodyContextKey struct{}
 
 // InstallationExcludedModelsContextKey is the context key for the authed
 // installation's model exclusion list. Carried as []string.
@@ -548,13 +563,52 @@ func anthropicSubscriptionFromContext(ctx context.Context) string {
 }
 
 // servedOnSubscription reports whether the turn's resolved credential is a
-// Claude subscription OAuth token — i.e. the customer's own plan paid for it,
-// so billing applies only the subscription fee rather than full cost. The
-// credential is read from the same ctx that resolveAndInjectCredentials
+// subscription OAuth token (Claude or Codex) — i.e. the customer's own plan
+// paid for it, so billing applies only the subscription fee rather than full
+// cost. The credential is read from the same ctx that resolveAndInjectCredentials
 // stamped and dispatch used.
 func servedOnSubscription(ctx context.Context) bool {
 	creds := CredentialsFromContext(ctx)
 	return creds != nil && creds.OAuth
+}
+
+// openaiSubscriptionFromContext / openaiAccountIDFromContext return the raw Codex
+// (ChatGPT) subscription JWT and paired account-id stashed by the auth middleware
+// (router-keyed path), or "" when none.
+func openaiSubscriptionFromContext(ctx context.Context) string {
+	v, _ := ctx.Value(OpenAISubscriptionContextKey{}).(string)
+	return v
+}
+
+func openaiAccountIDFromContext(ctx context.Context) string {
+	v, _ := ctx.Value(OpenAIAccountIDContextKey{}).(string)
+	return v
+}
+
+// codexSubscriptionFromContext resolves a Codex subscription credential from the
+// dedicated router-keyed headers (token + account-id), or nil when either is
+// absent or the pair isn't a usable Codex subscription.
+func codexSubscriptionFromContext(ctx context.Context) *Credentials {
+	return codexSubscriptionCreds(openaiSubscriptionFromContext(ctx), openaiAccountIDFromContext(ctx))
+}
+
+// codexResponsesRequest reports whether this /v1/responses request carries a
+// usable Codex (ChatGPT) subscription — the dedicated header pair on a
+// router-keyed request, or (self-hosted, no router key) an inbound Authorization
+// bearer + ChatGPT-Account-ID. When true, ProxyOpenAIResponses routes the turn
+// to the Codex backend instead of the chat-completions canonical path. Mirrors
+// the resolution precedence in resolveAndInjectCredentials so detection and
+// injection never disagree.
+func codexResponsesRequest(ctx context.Context, headers http.Header) bool {
+	if codexSubscriptionFromContext(ctx) != nil {
+		return true
+	}
+	if installationIDFromContext(ctx) == (uuid.UUID{}) {
+		if c := ExtractClientCredentials(providers.ProviderOpenAI, headers); c != nil && c.OAuth {
+			return true
+		}
+	}
+	return false
 }
 
 // DefaultPlannerThresholdUSD is the minimum positive EV over remaining-turn
@@ -2137,6 +2191,18 @@ func (s *Service) enabledProvidersForRequest(ctx context.Context, surfaceProvide
 	if c := ExtractClientCredentials(providers.ProviderAnthropic, headers); c != nil && c.OAuth {
 		out[providers.ProviderAnthropic] = struct{}{}
 	}
+	// A caller's Codex (ChatGPT) subscription enrolls OpenAI for routing
+	// eligibility, mirroring the Anthropic block above so the scorer can pick an
+	// OpenAI model. The dedicated X-Weave-OpenAI-Subscription / -Account-ID
+	// headers unambiguously carry only a subscription, so they are honored even
+	// on router-keyed requests. Enrollment requires BOTH token and account-id
+	// (codexSubscriptionFromContext returns nil without the account-id) so the
+	// scorer can't pick OpenAI for a turn the Codex backend would 401 on for a
+	// missing ChatGPT-Account-ID. OpenAI-only: the JWT can't authenticate any
+	// other upstream.
+	if codexSubscriptionFromContext(ctx) != nil {
+		out[providers.ProviderOpenAI] = struct{}{}
+	}
 	// Passthrough-eligible providers are surface-scoped: a provider
 	// registered without a deployment key joins the eligible set only when
 	// the inbound surface matches. Otherwise an Anthropic-surface request's
@@ -2223,6 +2289,24 @@ func resolveAndInjectCredentials(ctx context.Context, provider string, headers h
 		if inbound := ExtractClientCredentials(provider, headers); inbound != nil && inbound.OAuth {
 			observability.FromContext(ctx).Debug("Resolved Claude subscription credential for Anthropic turn", "credential_source", inbound.Source)
 			return context.WithValue(ctx, CredentialsContextKey{}, inbound)
+		}
+	}
+	if provider == providers.ProviderOpenAI {
+		// Codex (ChatGPT) subscription-first (precedence: subscription -> BYOK ->
+		// deployment), mirroring the Anthropic block above. The dedicated headers
+		// carry token + account-id on router-keyed requests; otherwise the inbound
+		// Authorization bearer + ChatGPT-Account-ID resolve via
+		// ExtractClientCredentials. The Codex backend base-URL switch + required
+		// headers are applied in the OpenAI provider client off this credential.
+		if sub := codexSubscriptionFromContext(ctx); sub != nil {
+			observability.FromContext(ctx).Debug("Resolved Codex subscription credential for OpenAI turn", "credential_source", sub.Source)
+			return context.WithValue(ctx, CredentialsContextKey{}, sub)
+		}
+		if !routerKeyed {
+			if inbound := ExtractClientCredentials(provider, headers); inbound != nil && inbound.OAuth {
+				observability.FromContext(ctx).Debug("Resolved Codex subscription credential for OpenAI turn", "credential_source", inbound.Source)
+				return context.WithValue(ctx, CredentialsContextKey{}, inbound)
+			}
 		}
 	}
 	byok := BuildCredentialsMap(externalKeysFromContext(ctx))
@@ -2618,6 +2702,17 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 
 	enabledProviders := s.enabledProvidersForRequest(ctx, providers.ProviderOpenAI, r.Header)
 
+	// Codex (ChatGPT) subscription passthrough: ProxyOpenAIResponses stashed the
+	// caller's original Responses body. Such turns dispatch to the Codex backend
+	// over the Responses API and stream Responses SSE straight back, so they
+	// constrain routing to OpenAI (the only provider the ChatGPT plan can pay
+	// for) and skip the chat-completions routing marker + semantic cache below.
+	codexBody, _ := ctx.Value(codexResponsesBodyContextKey{}).([]byte)
+	codexPassthrough := len(codexBody) > 0
+	if codexPassthrough {
+		enabledProviders = map[string]struct{}{providers.ProviderOpenAI: {}}
+	}
+
 	// Pre-filter models whose context window cannot fit this request.
 	outputReserveOAI := contextWindowOutputReserve
 	if feats.MaxTokens > outputReserveOAI {
@@ -2668,7 +2763,7 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 	pinAgeSec := routeRes.PinAgeSec
 	s.logPlannerOutcome(ctx, routeRes)
 
-	cacheEligible := s.semanticCache != nil && !env.Stream() && decision.Metadata != nil && externalID != "" && !bypassEval
+	cacheEligible := s.semanticCache != nil && !env.Stream() && decision.Metadata != nil && externalID != "" && !bypassEval && !codexPassthrough
 	if cacheEligible {
 		if resp, hit := s.semanticCache.Lookup(externalID, cache.FormatOpenAI, decision.Metadata.Embedding, decision.Metadata.ClusterIDs, decision.Metadata.ClusterRouterVersion, decision.Metadata.EffectiveKnobsHash); hit {
 			s.writeCachedResponse(w, resp, decision)
@@ -2780,6 +2875,11 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 	}
 
 	marker := suppressMarkerIfRequested(r.Header, routingMarkerFor(routeRes))
+	if codexPassthrough {
+		// The client receives raw Responses SSE from the Codex backend; a
+		// chat-completions routing-marker chunk would corrupt that stream.
+		marker = ""
+	}
 	_, isResponses := w.(*translate.ResponsesWriter)
 	// markerSink wraps sink with an OpenAIRoutingMarkerWriter that emits
 	// the routing-marker chunk + HTTP 200 eagerly (Prelude). Skipped when
@@ -2811,12 +2911,27 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 		// Bedrock primary should not see. On failover to OpenRouter the
 		// body must be re-emitted with TargetProvider = openrouter.
 		attempt = func(actx context.Context, d router.Decision, p providers.Client) error {
-			attemptOpts := opts
-			attemptOpts.TargetProvider = d.Provider
-			prep, emitErr := env.PrepareOpenAI(r.Header, attemptOpts)
-			if emitErr != nil {
-				log.Error("Failed to emit OpenAI body", "err", emitErr, "decision_provider", d.Provider)
-				return fmt.Errorf("emit body: %w", emitErr)
+			var prep providers.PreparedRequest
+			if codexPassthrough {
+				// Dispatch the caller's ORIGINAL Responses body (untranslated)
+				// to the Codex backend, rewriting only the model to the routed
+				// pick. The OpenAI client switches to chatgpt.com/backend-api/
+				// codex when it sees the Codex subscription credential.
+				outBody, setErr := sjson.SetBytes(codexBody, "model", d.Model)
+				if setErr != nil {
+					log.Error("Failed to set routed model on Codex Responses body", "err", setErr, "decision_model", d.Model)
+					return fmt.Errorf("set codex model: %w", setErr)
+				}
+				prep = providers.PreparedRequest{Body: outBody, Endpoint: providers.EndpointResponses, Headers: make(http.Header)}
+			} else {
+				attemptOpts := opts
+				attemptOpts.TargetProvider = d.Provider
+				var emitErr error
+				prep, emitErr = env.PrepareOpenAI(r.Header, attemptOpts)
+				if emitErr != nil {
+					log.Error("Failed to emit OpenAI body", "err", emitErr, "decision_provider", d.Provider)
+					return fmt.Errorf("emit body: %w", emitErr)
+				}
 			}
 			attemptSink := makeMarkerSink()
 			proxyWriter := attemptSink
@@ -2833,8 +2948,11 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 			// the upstream error as an in-stream `data: {...}` frame
 			// instead of letting dispatch's flushErr append a corrupting
 			// JSON envelope. Pre-commit errors are handled by
-			// dispatchWithFallback (Discard + flushErr).
-			if err != nil && env.Stream() && preludeBuf.Committed() {
+			// dispatchWithFallback (Discard + flushErr). Skipped for the Codex
+			// passthrough: the client speaks Responses, so a chat-completions
+			// error frame would corrupt the stream — the upstream's own
+			// Responses error event has already reached the client.
+			if err != nil && !codexPassthrough && env.Stream() && preludeBuf.Committed() {
 				err = emitOpenAISSEErrorEvent(sink, err)
 			}
 			return err
@@ -3072,6 +3190,17 @@ func (s *Service) ProxyOpenAIResponses(ctx context.Context, body []byte, w http.
 	chatBody, _, model, err := translate.ResponsesToChatCompletions(body)
 	if err != nil {
 		return fmt.Errorf("translate responses request: %w", err)
+	}
+	// Codex (ChatGPT) subscription: serve the turn on the caller's plan via the
+	// Codex backend (chatgpt.com/backend-api/codex), which speaks the Responses
+	// API natively. Stash the caller's ORIGINAL Responses body and write the
+	// upstream Responses SSE straight to w (no ResponsesWriter round-trip), so
+	// reasoning/tool/encrypted content is never lossily re-translated through
+	// chat completions. Routing, billing (5% subscription fee), and telemetry
+	// are reused via ProxyOpenAIChatCompletion (chatBody feeds routing only).
+	if codexResponsesRequest(ctx, r.Header) {
+		ctx = context.WithValue(ctx, codexResponsesBodyContextKey{}, body)
+		return s.ProxyOpenAIChatCompletion(ctx, chatBody, w, r)
 	}
 	wrapper := translate.NewResponsesWriter(w, model)
 	// Defer the high-fidelity call-log emission until after Finalize: the

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -2203,6 +2203,16 @@ func (s *Service) enabledProvidersForRequest(ctx context.Context, surfaceProvide
 	if codexSubscriptionFromContext(ctx) != nil {
 		out[providers.ProviderOpenAI] = struct{}{}
 	}
+	// And, mirroring the Anthropic inbound-bearer block, a Codex subscription
+	// bearer in the inbound Authorization (paired with ChatGPT-Account-ID)
+	// enrolls OpenAI even on router-keyed requests — the managed Codex CLI path
+	// keeps its ChatGPT JWT in Authorization while the router key rides in
+	// X-Weave-Router-Key. OAuth-subset only (ExtractClientCredentials flags
+	// OAuth only for a JWT + account-id pairing): a plain client API key still
+	// cannot enroll OpenAI on the router-key path.
+	if c := ExtractClientCredentials(providers.ProviderOpenAI, headers); c != nil && c.OAuth {
+		out[providers.ProviderOpenAI] = struct{}{}
+	}
 	// Passthrough-eligible providers are surface-scoped: a provider
 	// registered without a deployment key joins the eligible set only when
 	// the inbound surface matches. Otherwise an Anthropic-surface request's
@@ -2294,19 +2304,23 @@ func resolveAndInjectCredentials(ctx context.Context, provider string, headers h
 	if provider == providers.ProviderOpenAI {
 		// Codex (ChatGPT) subscription-first (precedence: subscription -> BYOK ->
 		// deployment), mirroring the Anthropic block above. The dedicated headers
-		// carry token + account-id on router-keyed requests; otherwise the inbound
-		// Authorization bearer + ChatGPT-Account-ID resolve via
-		// ExtractClientCredentials. The Codex backend base-URL switch + required
-		// headers are applied in the OpenAI provider client off this credential.
+		// carry token + account-id on router-keyed requests.
 		if sub := codexSubscriptionFromContext(ctx); sub != nil {
 			observability.FromContext(ctx).Debug("Resolved Codex subscription credential for OpenAI turn", "credential_source", sub.Source)
 			return context.WithValue(ctx, CredentialsContextKey{}, sub)
 		}
-		if !routerKeyed {
-			if inbound := ExtractClientCredentials(provider, headers); inbound != nil && inbound.OAuth {
-				observability.FromContext(ctx).Debug("Resolved Codex subscription credential for OpenAI turn", "credential_source", inbound.Source)
-				return context.WithValue(ctx, CredentialsContextKey{}, inbound)
-			}
+		// A Codex subscription bearer (ChatGPT OAuth JWT paired with a
+		// ChatGPT-Account-ID) in the inbound Authorization is honored even on
+		// router-keyed requests. Codex CLI routed through the Weave Router keeps
+		// its own ChatGPT auth in Authorization while the router key rides in
+		// X-Weave-Router-Key, so a managed Codex turn pays from the caller's own
+		// plan without needing the dedicated header. Restricted to the OAuth
+		// subset: ExtractClientCredentials flags OAuth only for a JWT + account-id
+		// pairing, so a general inbound OpenAI API key is still NOT forwarded on
+		// the router-key path (the cross-provider-leak guard below still applies).
+		if inbound := ExtractClientCredentials(provider, headers); inbound != nil && inbound.OAuth {
+			observability.FromContext(ctx).Debug("Resolved Codex subscription credential for OpenAI turn", "credential_source", inbound.Source)
+			return context.WithValue(ctx, CredentialsContextKey{}, inbound)
 		}
 	}
 	byok := BuildCredentialsMap(externalKeysFromContext(ctx))

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -593,20 +593,20 @@ func codexSubscriptionFromContext(ctx context.Context) *Credentials {
 }
 
 // codexResponsesRequest reports whether this /v1/responses request carries a
-// usable Codex (ChatGPT) subscription — the dedicated header pair on a
-// router-keyed request, or (self-hosted, no router key) an inbound Authorization
-// bearer + ChatGPT-Account-ID. When true, ProxyOpenAIResponses routes the turn
-// to the Codex backend instead of the chat-completions canonical path. Mirrors
-// the resolution precedence in resolveAndInjectCredentials so detection and
-// injection never disagree.
+// usable Codex (ChatGPT) subscription — the dedicated header pair, or an inbound
+// Authorization bearer + ChatGPT-Account-ID. When true, ProxyOpenAIResponses
+// routes the turn to the Codex backend instead of the chat-completions canonical
+// path. Mirrors the resolution precedence in resolveAndInjectCredentials so
+// detection and injection never disagree: the inbound-bearer shape is honored
+// even on a router-keyed request (Codex CLI keeps its ChatGPT auth in
+// Authorization while the router key rides in X-Weave-Router-Key), so it must
+// not be gated on the installation being absent.
 func codexResponsesRequest(ctx context.Context, headers http.Header) bool {
 	if codexSubscriptionFromContext(ctx) != nil {
 		return true
 	}
-	if installationIDFromContext(ctx) == (uuid.UUID{}) {
-		if c := ExtractClientCredentials(providers.ProviderOpenAI, headers); c != nil && c.OAuth {
-			return true
-		}
+	if c := ExtractClientCredentials(providers.ProviderOpenAI, headers); c != nil && c.OAuth {
+		return true
 	}
 	return false
 }

--- a/internal/proxy/subscription_internal_test.go
+++ b/internal/proxy/subscription_internal_test.go
@@ -240,6 +240,19 @@ func TestCodexResponsesRequest(t *testing.T) {
 		}
 		assert.True(t, codexResponsesRequest(context.Background(), headers))
 	})
+	t.Run("inbound bearer + account-id on a router-keyed request", func(t *testing.T) {
+		// Managed Codex: the router key authenticates via X-Weave-Router-Key
+		// (installation set) while Codex CLI leaves its ChatGPT auth in
+		// Authorization, with no dedicated header. resolveAndInjectCredentials
+		// resolves this as the Codex subscription, so detection must agree and
+		// route to the Codex backend — not be gated on the installation's absence.
+		ctx := context.WithValue(context.Background(), InstallationIDContextKey{}, testInstallationID)
+		headers := http.Header{
+			"Authorization":      []string{"Bearer " + codexTestJWT},
+			"Chatgpt-Account-Id": []string{"acct-1"},
+		}
+		assert.True(t, codexResponsesRequest(ctx, headers))
+	})
 	t.Run("dedicated token without account-id is not a Codex request", func(t *testing.T) {
 		ctx := context.WithValue(context.Background(), InstallationIDContextKey{}, testInstallationID)
 		ctx = context.WithValue(ctx, OpenAISubscriptionContextKey{}, codexTestJWT)

--- a/internal/proxy/subscription_internal_test.go
+++ b/internal/proxy/subscription_internal_test.go
@@ -176,6 +176,38 @@ func TestResolveAndInjectCredentials_CodexInboundBeatsBYOK(t *testing.T) {
 	assert.Equal(t, []byte("acct-999"), creds.AccountID)
 }
 
+func TestResolveAndInjectCredentials_RouterKeyedInboundCodexSubscription(t *testing.T) {
+	// Codex CLI routed through the Weave Router: the router key authenticates via
+	// X-Weave-Router-Key (installation set), while Codex leaves its own ChatGPT
+	// auth in Authorization + ChatGPT-Account-ID. No dedicated header, no BYOK.
+	// The inbound bearer must resolve as the Codex subscription credential so the
+	// turn bills at the 5% fee — the managed-Codex case mirroring #460.
+	ctx := context.WithValue(context.Background(), InstallationIDContextKey{}, testInstallationID)
+	headers := http.Header{
+		"Authorization":      []string{"Bearer " + codexTestJWT},
+		"Chatgpt-Account-Id": []string{"acct-999"},
+	}
+	out := resolveAndInjectCredentials(ctx, providers.ProviderOpenAI, headers)
+	creds := CredentialsFromContext(out)
+	require.NotNil(t, creds)
+	assert.True(t, creds.OAuth,
+		"a managed Codex turn must resolve its inbound subscription bearer even when router-keyed")
+	assert.Equal(t, credSourceCodexSubscription, creds.Source)
+	assert.Equal(t, []byte("acct-999"), creds.AccountID)
+}
+
+func TestResolveAndInjectCredentials_RouterKeyedInboundOpenAIApiKeyNotForwarded(t *testing.T) {
+	// The router-key path still must NOT forward a general inbound OpenAI API key:
+	// only the Codex OAuth subset (JWT + ChatGPT-Account-ID) is honored. A plain
+	// client key in Authorization, with no account-id, must resolve to no
+	// credential so the deployment key is the upstream fallback.
+	ctx := context.WithValue(context.Background(), InstallationIDContextKey{}, testInstallationID)
+	headers := http.Header{"Authorization": []string{"Bearer sk-proj-real-client-key"}}
+	out := resolveAndInjectCredentials(ctx, providers.ProviderOpenAI, headers)
+	assert.Nil(t, CredentialsFromContext(out),
+		"a non-OAuth inbound OpenAI key must not be forwarded on the router-key path; the deployment key is the correct fallback")
+}
+
 func TestResolveAndInjectCredentials_CodexHeadersIgnoredForNonOpenAI(t *testing.T) {
 	// The Codex token can only pay for OpenAI; a non-OpenAI route must not
 	// resolve it.

--- a/internal/proxy/subscription_internal_test.go
+++ b/internal/proxy/subscription_internal_test.go
@@ -136,6 +136,88 @@ func TestResolveAndInjectCredentials_RouterKeyedInboundApiKeyNotForwarded(t *tes
 		"a non-OAuth inbound API key must not be forwarded on the router-key path; the deployment key is the correct fallback")
 }
 
+const codexTestJWT = "eyJhbGciOiJSUzI1NiJ9.codex-access.signature"
+
+func TestResolveAndInjectCredentials_CodexDedicatedHeadersBeatBYOK(t *testing.T) {
+	// Router-keyed request with a BYOK OpenAI key and the dedicated Codex
+	// subscription headers. The subscription must win and be read past the
+	// router-key guard, mirroring the Anthropic dedicated-header path.
+	ctx := context.WithValue(context.Background(), InstallationIDContextKey{}, testInstallationID)
+	ctx = context.WithValue(ctx, ExternalAPIKeysContextKey{}, []*auth.ExternalAPIKey{
+		{Provider: providers.ProviderOpenAI, Plaintext: []byte("sk-oai-byok")},
+	})
+	ctx = context.WithValue(ctx, OpenAISubscriptionContextKey{}, codexTestJWT)
+	ctx = context.WithValue(ctx, OpenAIAccountIDContextKey{}, "acct-999")
+
+	out := resolveAndInjectCredentials(ctx, providers.ProviderOpenAI, http.Header{})
+	creds := CredentialsFromContext(out)
+	require.NotNil(t, creds)
+	assert.True(t, creds.OAuth)
+	assert.Equal(t, credSourceCodexSubscription, creds.Source)
+	assert.Equal(t, []byte(codexTestJWT), creds.APIKey)
+	assert.Equal(t, []byte("acct-999"), creds.AccountID)
+}
+
+func TestResolveAndInjectCredentials_CodexInboundBeatsBYOK(t *testing.T) {
+	// Self-hosted (no router key): an inbound Authorization JWT + ChatGPT-Account-ID
+	// must beat a present BYOK OpenAI key so the turn bills at the subscription fee.
+	ctx := context.WithValue(context.Background(), ExternalAPIKeysContextKey{}, []*auth.ExternalAPIKey{
+		{Provider: providers.ProviderOpenAI, Plaintext: []byte("sk-oai-byok")},
+	})
+	headers := http.Header{
+		"Authorization":      []string{"Bearer " + codexTestJWT},
+		"Chatgpt-Account-Id": []string{"acct-999"},
+	}
+	out := resolveAndInjectCredentials(ctx, providers.ProviderOpenAI, headers)
+	creds := CredentialsFromContext(out)
+	require.NotNil(t, creds)
+	assert.True(t, creds.OAuth, "the inbound Codex subscription must win over BYOK")
+	assert.Equal(t, credSourceCodexSubscription, creds.Source)
+	assert.Equal(t, []byte("acct-999"), creds.AccountID)
+}
+
+func TestResolveAndInjectCredentials_CodexHeadersIgnoredForNonOpenAI(t *testing.T) {
+	// The Codex token can only pay for OpenAI; a non-OpenAI route must not
+	// resolve it.
+	ctx := context.WithValue(context.Background(), InstallationIDContextKey{}, testInstallationID)
+	ctx = context.WithValue(ctx, ExternalAPIKeysContextKey{}, []*auth.ExternalAPIKey{
+		{Provider: providers.ProviderAnthropic, Plaintext: []byte("sk-ant-api-byok")},
+	})
+	ctx = context.WithValue(ctx, OpenAISubscriptionContextKey{}, codexTestJWT)
+	ctx = context.WithValue(ctx, OpenAIAccountIDContextKey{}, "acct-999")
+
+	out := resolveAndInjectCredentials(ctx, providers.ProviderAnthropic, http.Header{})
+	creds := CredentialsFromContext(out)
+	require.NotNil(t, creds)
+	assert.False(t, creds.OAuth)
+	assert.Equal(t, []byte("sk-ant-api-byok"), creds.APIKey,
+		"an Anthropic route must use its own BYOK key, never the Codex subscription token")
+}
+
+func TestCodexResponsesRequest(t *testing.T) {
+	t.Run("dedicated headers on a router-keyed request", func(t *testing.T) {
+		ctx := context.WithValue(context.Background(), InstallationIDContextKey{}, testInstallationID)
+		ctx = context.WithValue(ctx, OpenAISubscriptionContextKey{}, codexTestJWT)
+		ctx = context.WithValue(ctx, OpenAIAccountIDContextKey{}, "acct-1")
+		assert.True(t, codexResponsesRequest(ctx, http.Header{}))
+	})
+	t.Run("inbound bearer + account-id off the router key", func(t *testing.T) {
+		headers := http.Header{
+			"Authorization":      []string{"Bearer " + codexTestJWT},
+			"Chatgpt-Account-Id": []string{"acct-1"},
+		}
+		assert.True(t, codexResponsesRequest(context.Background(), headers))
+	})
+	t.Run("dedicated token without account-id is not a Codex request", func(t *testing.T) {
+		ctx := context.WithValue(context.Background(), InstallationIDContextKey{}, testInstallationID)
+		ctx = context.WithValue(ctx, OpenAISubscriptionContextKey{}, codexTestJWT)
+		assert.False(t, codexResponsesRequest(ctx, http.Header{}))
+	})
+	t.Run("plain request is not a Codex request", func(t *testing.T) {
+		assert.False(t, codexResponsesRequest(context.Background(), http.Header{}))
+	})
+}
+
 func TestClearCredentials(t *testing.T) {
 	ctx := context.WithValue(context.Background(), CredentialsContextKey{},
 		&Credentials{APIKey: []byte("sk-ant-oat01-token"), Source: credSourceSubscription, OAuth: true})

--- a/internal/server/middleware/auth.go
+++ b/internal/server/middleware/auth.go
@@ -28,6 +28,18 @@ const RouterKeyHeader = "X-Weave-Router-Key"
 // the caller's own subscription pays, instead of the deployment API key.
 const AnthropicSubscriptionHeader = "X-Weave-Anthropic-Subscription"
 
+// OpenAISubscriptionHeader and OpenAIAccountIDHeader carry a caller's Codex
+// (ChatGPT) subscription on router-keyed requests, where Authorization already
+// holds the rk_ router key. The subscription header holds the ChatGPT OAuth JWT
+// and the account-id header holds the paired ChatGPT-Account-ID; both are
+// required because the Codex backend 401/403s on a token without its account id.
+// The proxy forwards them to OpenAI's Codex backend for OpenAI-model turns so
+// the caller's own ChatGPT plan pays, instead of the deployment API key.
+const (
+	OpenAISubscriptionHeader = "X-Weave-OpenAI-Subscription"
+	OpenAIAccountIDHeader    = "X-Weave-OpenAI-Account-ID"
+)
+
 // WithAuth validates the inbound request via a bearer rk_ token only. Used on data-plane routes (`/v1/*`). On failure, short-circuits 401.
 //
 // byokDisabled drops any BYOK (customer-owned provider) keys at the middleware
@@ -120,6 +132,15 @@ func withAPIKey(svc *auth.Service, byokDisabled bool) gin.HandlerFunc {
 		// proxy validates its shape and decides precedence. Never logged.
 		if sub := strings.TrimSpace(c.GetHeader(AnthropicSubscriptionHeader)); sub != "" {
 			ctx = context.WithValue(ctx, proxy.AnthropicSubscriptionContextKey{}, sub)
+		}
+		// Codex (ChatGPT) subscription, router-keyed path: stash the OAuth JWT
+		// and its paired ChatGPT-Account-ID raw; the proxy validates shape and
+		// decides precedence. Never logged.
+		if sub := strings.TrimSpace(c.GetHeader(OpenAISubscriptionHeader)); sub != "" {
+			ctx = context.WithValue(ctx, proxy.OpenAISubscriptionContextKey{}, sub)
+		}
+		if acct := strings.TrimSpace(c.GetHeader(OpenAIAccountIDHeader)); acct != "" {
+			ctx = context.WithValue(ctx, proxy.OpenAIAccountIDContextKey{}, acct)
 		}
 		c.Request = c.Request.WithContext(ctx)
 		c.Next()


### PR DESCRIPTION
Stacked on #447 (Claude-subscription passthrough). The OpenAI/Codex mirror, harness-matched: a **Codex CLI** user with a ChatGPT Pro/Plus subscription routes through the router and *their* plan pays for the OpenAI turn at the same **5% fee**, instead of the deployment `OPENAI_API_KEY`. (Anthropic-subscription → Claude Code; Codex-subscription → Codex CLI.)

### Why it's not a literal copy of #447
A Codex subscription is a ChatGPT OAuth **JWT** paired with a **`ChatGPT-Account-ID`** (401/403 without it), and authenticates only against the Codex backend `chatgpt.com/backend-api/codex/responses` over the **Responses API** — never `api.openai.com`. Since the router canonicalizes OpenAI traffic to Chat Completions, reusing that pipeline would force the client's Responses body through chat completions **4×** (lossy for reasoning/tool/encrypted content). Instead `ProxyOpenAIResponses` serves these turns as a **routed Responses passthrough**: route to pick an OpenAI model, rewrite it into the caller's *original* Responses body, stream straight to the Codex backend. Zero lossy translation.

### Changes
- **credentials**: `Credentials.AccountID` + `codexSubscriptionCreds` (JWT + account-id; rejects `sk-`/`rk_`); `ExtractClientCredentials` resolves a Codex sub on the OpenAI surface **only** when `ChatGPT-Account-ID` is present.
- **middleware**: dedicated `X-Weave-OpenAI-Subscription` / `X-Weave-OpenAI-Account-ID` headers (managed/router-keyed path), never logged.
- **service**: OpenAI enrollment + subscription→BYOK→deployment precedence; `ProxyOpenAIResponses` passthrough branch with routing constrained to OpenAI; reuses `runTurnLoop` + billing + telemetry.
- **openai client**: switches base URL + path + `ChatGPT-Account-ID`/`OpenAI-Beta: responses=experimental`/`originator: codex_cli_rs` headers to the Codex backend when the resolved cred is a Codex subscription.
- **otel usage**: parse Responses `response.completed` usage so the 5% fee bills on real tokens.

Billing (`servedOnSubscription`), the summarizer guard (declines OAuth creds), and failover-skip already key off `creds.OAuth`, so they cover Codex unchanged.

### Two entry paths
- **Managed/router-keyed**: dedicated header pair, read past the installation guard.
- **Self-hosted**: caller's inbound `Authorization: Bearer <jwt>` + `ChatGPT-Account-ID`.

### Tests
Codex cred detection/precedence, OpenAI-only enrollment, the client base-URL/header switch (httptest), and Responses usage parsing. `wv mr tc`, full `go test ./...`, and `gofmt` all green.

### Validate live before promote
1. **Model slugs** — confirm routed catalog OpenAI ids are accepted by the Codex backend; fall back to passing the requested model through if not.
2. **Responses usage shape** — confirm `response.completed.response.usage` maps correctly for the 5% debit.
3. Undocumented endpoint — gated behind explicit Codex subscription auth; never activates otherwise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)