### PR TITLE
feat(proxy): honor inbound subscription bearer on the router-keyed path

### DIFF
--- a/internal/proxy/enabled_providers_internal_test.go
+++ b/internal/proxy/enabled_providers_internal_test.go
@@ -130,6 +130,29 @@ func TestEnabledProvidersForRequest_SubscriptionEnrollsAnthropic(t *testing.T) {
 			"the subscription token is Anthropic-only and must never enroll another upstream")
 	})
 
+	t.Run("inbound Authorization subscription bearer enrolls anthropic on a router-keyed request", func(t *testing.T) {
+		// The managed Claude Code path: router key in X-Weave-Router-Key
+		// (installation set), the subscription OAuth token left in Authorization.
+		// Anthropic must be enrolled off the inbound bearer so the scorer can
+		// route a Claude turn the subscription will pay for.
+		headers := http.Header{"Authorization": []string{"Bearer sk-ant-oat01-subscription-token"}}
+		got := makeService().enabledProvidersForRequest(routerKeyed(), providers.ProviderAnthropic, headers)
+		assert.Contains(t, got, providers.ProviderAnthropic,
+			"the inbound subscription bearer (CC-through-router) must enroll Anthropic even when router-keyed")
+		assert.NotContains(t, got, providers.ProviderOpenAI,
+			"the subscription token is Anthropic-only and must never enroll another upstream")
+	})
+
+	t.Run("inbound API-key bearer does NOT enroll anthropic on a router-keyed request", func(t *testing.T) {
+		// Only the sk-ant-oat OAuth subset enrolls off the inbound bearer; a real
+		// client API key must not, mirroring resolveAndInjectCredentials and
+		// preserving the cross-provider-leak guard.
+		headers := http.Header{"Authorization": []string{"Bearer sk-ant-api-real-client-key"}}
+		got := makeService().enabledProvidersForRequest(routerKeyed(), providers.ProviderAnthropic, headers)
+		assert.NotContains(t, got, providers.ProviderAnthropic,
+			"a general inbound API key must not enroll Anthropic on the router-key path")
+	})
+
 	t.Run("no header leaves the set empty, proving the enrollment is load-bearing", func(t *testing.T) {
 		got := makeService().enabledProvidersForRequest(routerKeyed(), providers.ProviderAnthropic, http.Header{})
 		assert.NotContains(t, got, providers.ProviderAnthropic,

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -2127,6 +2127,16 @@ func (s *Service) enabledProvidersForRequest(ctx context.Context, surfaceProvide
 	if subscriptionCredsFromHeaderValue(anthropicSubscriptionFromContext(ctx)) != nil {
 		out[providers.ProviderAnthropic] = struct{}{}
 	}
+	// Likewise, a Claude subscription bearer (sk-ant-oat-) in the inbound
+	// Authorization enrolls Anthropic even on router-keyed requests — the
+	// managed Claude Code path keeps its OAuth token there while the router key
+	// rides in X-Weave-Router-Key. Mirrors resolveAndInjectCredentials so the
+	// scorer can pick a Claude model the subscription will pay for. OAuth-subset
+	// only (ExtractClientCredentials gates OAuth to sk-ant-oat-): a general
+	// inbound API key still cannot enroll a provider on the router-key path.
+	if c := ExtractClientCredentials(providers.ProviderAnthropic, headers); c != nil && c.OAuth {
+		out[providers.ProviderAnthropic] = struct{}{}
+	}
 	// Passthrough-eligible providers are surface-scoped: a provider
 	// registered without a deployment key joins the eligible set only when
 	// the inbound surface matches. Otherwise an Anthropic-surface request's
@@ -2175,16 +2185,17 @@ func (s *Service) enabledProvidersForRequest(ctx context.Context, surfaceProvide
 // (Anthropic only) first, then BYOK, then a client-supplied header credential.
 //
 // Subscription-first lets a caller's own Claude subscription pay for their
-// Claude turns. It arrives one of two ways: the dedicated
-// X-Weave-Anthropic-Subscription header on router-keyed requests (read past the
-// router-key guard below, since that header unambiguously carries only a
-// subscription token), or — when not authed via a router key — the inbound
-// Authorization bearer via ExtractClientCredentials.
+// Claude turns. It arrives one of two ways, both honored even on router-keyed
+// requests: the dedicated X-Weave-Anthropic-Subscription header, or a
+// subscription OAuth bearer (sk-ant-oat-) in the inbound Authorization — the
+// shape Claude Code sends when routed through the Weave Router (router key in
+// X-Weave-Router-Key, its own subscription token left in Authorization).
 //
-// When authed via a router key, inbound client-header extraction is otherwise
-// skipped: it prevents the client's inbound Anthropic key from being forwarded
-// to a different upstream provider. The deployment-level env key on the
-// provider client is the correct fallback in that case.
+// The inbound-bearer path is restricted to the OAuth subset: a general client
+// API key is still NOT extracted on the router-key path, since that would let
+// the client's inbound Anthropic key be forwarded to a different upstream
+// provider. The deployment-level env key on the provider client is the correct
+// fallback in that case.
 func resolveAndInjectCredentials(ctx context.Context, provider string, headers http.Header) context.Context {
 	routerKeyed := installationIDFromContext(ctx) != (uuid.UUID{})
 	if provider == providers.ProviderAnthropic {
@@ -2200,11 +2211,18 @@ func resolveAndInjectCredentials(ctx context.Context, provider string, headers h
 			observability.FromContext(ctx).Debug("Resolved Claude subscription credential for Anthropic turn", "credential_source", sub.Source)
 			return context.WithValue(ctx, CredentialsContextKey{}, sub)
 		}
-		if !routerKeyed {
-			if inbound := ExtractClientCredentials(provider, headers); inbound != nil && inbound.OAuth {
-				observability.FromContext(ctx).Debug("Resolved Claude subscription credential for Anthropic turn", "credential_source", inbound.Source)
-				return context.WithValue(ctx, CredentialsContextKey{}, inbound)
-			}
+		// A Claude subscription bearer (sk-ant-oat-) in the inbound Authorization
+		// is honored even on router-keyed requests. Claude Code routed through
+		// the Weave Router keeps its own subscription OAuth token in
+		// Authorization while the router key rides in X-Weave-Router-Key, so a
+		// managed CC turn pays from the caller's own plan without needing the
+		// dedicated header. Restricted to the OAuth subset: ExtractClientCredentials
+		// only sets OAuth for sk-ant-oat-, so a general inbound API key is still
+		// NOT forwarded on the router-key path (the cross-provider-leak guard
+		// below still applies to it).
+		if inbound := ExtractClientCredentials(provider, headers); inbound != nil && inbound.OAuth {
+			observability.FromContext(ctx).Debug("Resolved Claude subscription credential for Anthropic turn", "credential_source", inbound.Source)
+			return context.WithValue(ctx, CredentialsContextKey{}, inbound)
 		}
 	}
 	byok := BuildCredentialsMap(externalKeysFromContext(ctx))

--- a/internal/proxy/subscription_internal_test.go
+++ b/internal/proxy/subscription_internal_test.go
@@ -106,6 +106,36 @@ func TestResolveAndInjectCredentials_SelfHostedInboundSubscription(t *testing.T)
 	assert.Equal(t, credSourceSubscription, creds.Source)
 }
 
+func TestResolveAndInjectCredentials_RouterKeyedInboundSubscription(t *testing.T) {
+	// Claude Code routed through the Weave Router: the router key authenticates
+	// via X-Weave-Router-Key (installation set), while CC leaves its own
+	// subscription OAuth token in Authorization. No dedicated header, no BYOK.
+	// The inbound bearer must resolve as the subscription credential so the turn
+	// bills at the 5% fee — the managed-CC case this path exists for.
+	ctx := context.WithValue(context.Background(), InstallationIDContextKey{}, testInstallationID)
+	headers := http.Header{"Authorization": []string{"Bearer sk-ant-oat01-subscription-token"}}
+	out := resolveAndInjectCredentials(ctx, providers.ProviderAnthropic, headers)
+	creds := CredentialsFromContext(out)
+	require.NotNil(t, creds)
+	assert.True(t, creds.OAuth,
+		"a managed CC turn must resolve its inbound subscription bearer even when router-keyed")
+	assert.Equal(t, credSourceSubscription, creds.Source)
+	assert.Equal(t, []byte("sk-ant-oat01-subscription-token"), creds.APIKey)
+}
+
+func TestResolveAndInjectCredentials_RouterKeyedInboundApiKeyNotForwarded(t *testing.T) {
+	// The router-key path still must NOT forward a general inbound API key: only
+	// the sk-ant-oat OAuth subset is honored. A real client API key in
+	// Authorization must resolve to no credential, so the deployment key (not the
+	// client's key) is the upstream fallback — preserving the cross-provider-leak
+	// guard the OAuth carve-out is careful not to widen.
+	ctx := context.WithValue(context.Background(), InstallationIDContextKey{}, testInstallationID)
+	headers := http.Header{"Authorization": []string{"Bearer sk-ant-api-real-client-key"}}
+	out := resolveAndInjectCredentials(ctx, providers.ProviderAnthropic, headers)
+	assert.Nil(t, CredentialsFromContext(out),
+		"a non-OAuth inbound API key must not be forwarded on the router-key path; the deployment key is the correct fallback")
+}
+
 func TestClearCredentials(t *testing.T) {
 	ctx := context.WithValue(context.Background(), CredentialsContextKey{},
 		&Credentials{APIKey: []byte("sk-ant-oat01-token"), Source: credSourceSubscription, OAuth: true})


### PR DESCRIPTION
## Summary

#447 added the consumer side of subscription billing but only resolved the subscription credential from the dedicated `X-Weave-Anthropic-Subscription` header on router-keyed requests — and on that path it skipped inbound `Authorization` entirely. The installer never emits that dedicated header, so **managed Claude Code turns never used the subscription and billed full credit** instead of the 5% subscription fee.

I verified on the wire what Claude Code actually sends when routed through the Weave Router:

```json
{
  "authorization": { "scheme": "Bearer", "value_prefix": "sk-ant-oat01-…", "len": 108 },
  "x_api_key_prefix": null,
  "x_weave_router_key_present": true,
  "anthropic_beta": "…,oauth-2025-04-20,…"
}
```

The router key rides in `X-Weave-Router-Key`; Claude Code leaves its own (auto-refreshed) subscription OAuth token in `Authorization`. So the subscription token is already arriving — the router just wasn't reading it on the router-keyed path.

## Change

- `resolveAndInjectCredentials`: resolve an inbound `Authorization: Bearer sk-ant-oat…` as the subscription credential **even when router-keyed**.
- `enabledProvidersForRequest`: enroll Anthropic off the same inbound bearer so the scorer can pick a Claude model.

Both are restricted to the **OAuth subset** — `ExtractClientCredentials` only sets `OAuth=true` for `sk-ant-oat-`, so a general client API key is still NOT forwarded on the router-key path. The cross-provider-leak guard from #159/#447 is preserved.

No installer change required, and no token-staleness problem since Claude Code keeps the bearer fresh. Routing is unchanged — this only swaps which credential pays for the Claude turns the router already chooses; non-Anthropic turns and the synthetic summarizer call still run on the deployment key.

## Tests

- New: `TestResolveAndInjectCredentials_RouterKeyedInboundSubscription` (resolves) and `_RouterKeyedInboundApiKeyNotForwarded` (guard preserved).
- New enabled-provider subtests: inbound oat bearer enrolls Anthropic router-keyed; inbound API key does not.
- `go build`, `go vet`, and the `proxy` / `billing` / `providers/anthropic` packages all pass. Binary builds with `-tags ORT` and the cluster scorer warms (deployable).

## Validation still owed (post-deploy, staging)

Live 5%-billing proof: seed a staging router key, `curl /v1/messages` with `X-Weave-Router-Key: rk_…` + `Authorization: Bearer sk-ant-oat…`, confirm the `Resolved Claude subscription credential` log fires and the `organization_credit_ledger` row debits 5% of notional. (Couldn't complete a full live local run — the local Pub/Sub emulator topic setup, unrelated to this change, blocks boot.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)