### PR TITLE
fix(admin/ui): reject env-keyed provider writes at backend; don't fail open in ProviderKeysPanel

### DIFF
--- a/frontend/src/app/(app)/settings/page.tsx
+++ b/frontend/src/app/(app)/settings/page.tsx
@@ -353,7 +353,9 @@ function providerLabel(p: Provider): string {
 
 function ProviderKeysPanel() {
   const [keys, setKeys] = useState<ExternalKey[]>([]);
-  const [envKeyed, setEnvKeyed] = useState<Provider[]>([]);
+  // null = config not yet loaded; [] = loaded with no env-keyed providers
+  const [envKeyed, setEnvKeyed] = useState<Provider[] | null>(null);
+  const [configError, setConfigError] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [pickedProvider, setPickedProvider] = useState<Provider | null>(null);
   const [keyValue, setKeyValue] = useState("");
@@ -380,16 +382,18 @@ function ProviderKeysPanel() {
           (PROVIDERS as readonly string[]).includes(p),
         );
         setEnvKeyed(set);
+        setConfigError(null);
       })
       .catch(() => {
-        // Non-fatal: the panel still works, env-keyed providers just won't
-        // be flagged as read-only.
-        setEnvKeyed([]);
+        setConfigError("Couldn't verify provider configuration — refresh to try again");
       });
   }, []);
 
-  const taken = new Set<string>([...keys.map(k => k.provider), ...envKeyed]);
-  const available: Provider[] = PROVIDERS.filter(p => !taken.has(p));
+  const configReady = envKeyed !== null && configError === null;
+  const taken = new Set<string>([...keys.map(k => k.provider), ...(envKeyed ?? [])]);
+  // Only offer providers for addition once we know which are env-keyed; until
+  // then any of the four could be read-only and we must not silently offer them.
+  const available: Provider[] = configReady ? PROVIDERS.filter(p => !taken.has(p)) : [];
   const provider: Provider | null =
     pickedProvider != null && available.includes(pickedProvider)
       ? pickedProvider
@@ -423,10 +427,11 @@ function ProviderKeysPanel() {
     }
   }
 
-  const hasAnyKey = keys.length > 0 || envKeyed.length > 0;
+  const hasAnyKey = keys.length > 0 || (envKeyed ?? []).length > 0;
   return (
     <>
       {error && <ErrorBanner>{error}</ErrorBanner>}
+      {configError && <ErrorBanner>{configError}</ErrorBanner>}
 
       {available.length > 0 && provider != null ? (
         <Card>
@@ -485,7 +490,7 @@ function ProviderKeysPanel() {
           </Card.Header>
           <Card.Content>
             <ul className="divide-y divide-border">
-              {envKeyed.map(p => (
+              {(envKeyed ?? []).map(p => (
                 <li
                   key={`env-${p}`}
                   className="flex items-center justify-between px-5 py-3"

--- a/internal/api/admin/keys.go
+++ b/internal/api/admin/keys.go
@@ -3,6 +3,7 @@ package admin
 import (
 	"errors"
 	"net/http"
+	"strings"
 	"time"
 
 	"workweave/router/internal/auth"
@@ -208,7 +209,7 @@ func ListExternalKeysHandler(authSvc *auth.Service) gin.HandlerFunc {
 // write path can enforce it independently of whether /admin/v1/config ever
 // succeeds.
 func isEnvKeyed(provider string) bool {
-	return config.GetOr(providers.APIKeyEnvVar(provider), "") != ""
+	return config.GetOr(providers.APIKeyEnvVar(strings.ToLower(provider)), "") != ""
 }
 
 func UpsertExternalKeyHandler(authSvc *auth.Service) gin.HandlerFunc {

--- a/internal/api/admin/keys.go
+++ b/internal/api/admin/keys.go
@@ -4,8 +4,9 @@ import (
 	"errors"
 	"net/http"
 	"time"
-
 	"workweave/router/internal/auth"
+	"workweave/router/internal/config"
+	"workweave/router/internal/providers"
 
 	"github.com/gin-gonic/gin"
 )
@@ -200,6 +201,15 @@ func ListExternalKeysHandler(authSvc *auth.Service) gin.HandlerFunc {
 	}
 }
 
+// isEnvKeyed reports whether provider's upstream API key is supplied via a
+// deployment env var (e.g. ANTHROPIC_API_KEY). Mirrors the check ConfigHandler
+// uses to populate EnvProviderKeys — kept here as its own function so the
+// write path can enforce it independently of whether /admin/v1/config ever
+// succeeds.
+func isEnvKeyed(provider string) bool {
+	return config.GetOr(providers.APIKeyEnvVar(provider), "") != ""
+}
+
 func UpsertExternalKeyHandler(authSvc *auth.Service) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		installation, ok := resolveInstallation(c, authSvc)
@@ -209,6 +219,10 @@ func UpsertExternalKeyHandler(authSvc *auth.Service) gin.HandlerFunc {
 		var req upsertExternalKeyRequest
 		if err := c.ShouldBindJSON(&req); err != nil {
 			c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": "Provider and key are required."})
+			return
+		}
+		if isEnvKeyed(req.Provider) {
+			c.AbortWithStatusJSON(http.StatusConflict, gin.H{"error": "Provider already configured via deployment environment variable. Remove the env var before adding a dashboard key."})
 			return
 		}
 		key, err := authSvc.UpsertExternalAPIKey(c.Request.Context(), installation.ID, req.Provider, req.Key, req.Name, nil)

--- a/internal/api/admin/keys.go
+++ b/internal/api/admin/keys.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"net/http"
 	"time"
+
 	"workweave/router/internal/auth"
 	"workweave/router/internal/config"
 	"workweave/router/internal/providers"

--- a/internal/api/admin/keys_internal_test.go
+++ b/internal/api/admin/keys_internal_test.go
@@ -18,6 +18,11 @@ func TestIsEnvKeyed_TrueWhenEnvVarSet(t *testing.T) {
 	assert.True(t, isEnvKeyed("anthropic"))
 }
 
+func TestIsEnvKeyed_TrueWhenProviderIsMixedCase(t *testing.T) {
+	t.Setenv("ANTHROPIC_API_KEY", "sk-ant-test-value")
+	assert.True(t, isEnvKeyed("Anthropic"))
+	assert.True(t, isEnvKeyed("ANTHROPIC"))
+}
 func TestIsEnvKeyed_FalseWhenEnvVarUnset(t *testing.T) {
 	t.Setenv("OPENAI_API_KEY", "")
 	os.Unsetenv("OPENAI_API_KEY")

--- a/internal/api/admin/keys_internal_test.go
+++ b/internal/api/admin/keys_internal_test.go
@@ -1,9 +1,15 @@
 package admin
 
 import (
+	"net/http"
+	"net/http/httptest"
 	"os"
+	"strings"
 	"testing"
 
+	"workweave/router/internal/auth"
+
+	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -20,4 +26,29 @@ func TestIsEnvKeyed_FalseWhenEnvVarUnset(t *testing.T) {
 
 func TestIsEnvKeyed_FalseForUnknownProvider(t *testing.T) {
 	assert.False(t, isEnvKeyed("not-a-real-provider"))
+}
+
+func TestUpsertExternalKeyHandler_RejectsEnvKeyedProvider(t *testing.T) {
+	t.Setenv("ANTHROPIC_API_KEY", "sk-ant-env-set")
+	gin.SetMode(gin.TestMode)
+
+	engine := gin.New()
+	// Inject a fake installation so resolveInstallation passes auth,
+	// letting the isEnvKeyed guard fire.
+	engine.Use(func(c *gin.Context) {
+		c.Set("router_installation", &auth.Installation{ID: "test-install"})
+		c.Next()
+	})
+	// nil auth.Service is safe — isEnvKeyed fires before any service call.
+	engine.POST("/admin/v1/provider-keys", UpsertExternalKeyHandler(nil))
+
+	body := `{"provider":"anthropic","key":"sk-ant-should-be-rejected"}`
+	req := httptest.NewRequest(http.MethodPost, "/admin/v1/provider-keys", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+
+	engine.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusConflict, rec.Code)
+	assert.Contains(t, rec.Body.String(), "error")
 }

--- a/internal/api/admin/keys_internal_test.go
+++ b/internal/api/admin/keys_internal_test.go
@@ -1,0 +1,23 @@
+package admin
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsEnvKeyed_TrueWhenEnvVarSet(t *testing.T) {
+	t.Setenv("ANTHROPIC_API_KEY", "sk-ant-test-value")
+	assert.True(t, isEnvKeyed("anthropic"))
+}
+
+func TestIsEnvKeyed_FalseWhenEnvVarUnset(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", "")
+	os.Unsetenv("OPENAI_API_KEY")
+	assert.False(t, isEnvKeyed("openai"))
+}
+
+func TestIsEnvKeyed_FalseForUnknownProvider(t *testing.T) {
+	assert.False(t, isEnvKeyed("not-a-real-provider"))
+}


### PR DESCRIPTION
## What

Fixes #459 — two cooperating fixes for the same vulnerability:

**Backend (internal/api/admin/keys.go):** `UpsertExternalKeyHandler` had no guard against writing a BYOK key for a provider already configured via a deployment env var (e.g. `ANTHROPIC_API_KEY`). The only protection was UI-level. Add `isEnvKeyed(provider)` — a pure env-var read mirroring the check `ConfigHandler` already uses to populate `EnvProviderKeys` — and call it before `UpsertExternalAPIKey`. Returns 409 Conflict when the provider is env-keyed, regardless of whether the config endpoint is healthy.

**Frontend (frontend/src/app/(app)/settings/page.tsx):** `ProviderKeysPanel` initialised `envKeyed` as `[]` and silently fell back to `[]` on a failed `GET /admin/v1/config`, making every provider appear available for a BYOK write when config was transiently unreachable. `envKeyed` now starts as `null` (not yet loaded), a separate `configError` state replaces the silent catch, and the Add-a-key card is not rendered at all until `configReady`.

## Why this approach

The backend fix is the authoritative guard — it closes the hole regardless of frontend state or direct API access. The frontend fix removes the UI path that made the gap trivially reachable through normal dashboard use. This matches the project's existing stance against fail-open behavior (CONTRIBUTING.md: "Silent fallbacks... PRs re-introducing fail-open behavior will be rejected").

## How it was tested

- `make check` green (generate + vet + build + full test suite)
- Three new unit tests in `internal/api/admin/keys_internal_test.go` covering: env var set → rejected, env var unset → allowed, unknown provider → allowed
- Live end-to-end: blocked `GET /admin/v1/config` in DevTools — confirmed Add-a-key card no longer renders while config is unknown, error banner shown instead
- Live end-to-end: `curl POST /admin/v1/provider-keys` with `ANTHROPIC_API_KEY` set → confirmed 409 Conflict with correct error message
- Live end-to-end: unblocked config → confirmed ENV badges restore correctly, no regression in working case