### PR TITLE
fix(proxy): strip Claude Code's [1m] model variant tag before native Anthropic dispatch

### DIFF
--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -1065,6 +1065,18 @@ func (s *Service) PassthroughToNamedProvider(ctx context.Context, providerName s
 		return err
 	}
 
+	// Claude Code sends its 1M-context model variant tag (e.g.
+	// "claude-opus-4-8[1m]") in the body. It is a client display convention,
+	// not a real Anthropic model id, so a verbatim count_tokens / model-list
+	// passthrough to the native Anthropic API 404s ("the selected model may not
+	// exist"). Strip it to the canonical id; passthrough never rewrites the
+	// model otherwise.
+	if providerName == providers.ProviderAnthropic && len(body) > 0 {
+		if canon, had, cerr := translate.CanonicalizeModelInBody(body); cerr == nil && had {
+			body = canon
+		}
+	}
+
 	var prep providers.PreparedRequest
 	if providerName == providers.ProviderAnthropic && len(body) > 0 {
 		env, parseErr := translate.ParseAnthropic(body)
@@ -1164,6 +1176,17 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 	if stripErr != nil {
 		log.Error("Failed to strip routing marker from inbound messages", "err", stripErr)
 		return fmt.Errorf("strip routing marker: %w", stripErr)
+	}
+
+	// Strip Claude Code's 1M-context model variant tag (e.g.
+	// "claude-opus-4-8[1m]") to the canonical catalog id before parsing, so
+	// routing, session pins, and telemetry key off the real model — and so the
+	// tag never reaches a native Anthropic upstream, which 404s on it. The 1M
+	// window is enabled separately, size-triggered via the context-1m beta.
+	if canon, _, modelErr := translate.CanonicalizeModelInBody(body); modelErr != nil {
+		log.Error("Failed to canonicalize inbound model", "err", modelErr)
+	} else {
+		body = canon
 	}
 
 	env, parseErr := translate.ParseAnthropic(body)

--- a/internal/translate/model_variant.go
+++ b/internal/translate/model_variant.go
@@ -1,0 +1,47 @@
+package translate
+
+import (
+	"strings"
+
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
+)
+
+// contextWindowVariantTag is the suffix Claude Code appends to a model id to
+// mark its 1M-context variant in the picker and status line (e.g.
+// "claude-opus-4-8[1m]"). It is a client-side display convention, not a real
+// Anthropic model id: forwarding it verbatim to the native Anthropic API
+// returns 404 not_found_error ("the selected model may not exist"). The router
+// strips it back to the canonical id before dispatch; the 1M window itself is
+// enabled via the context-1m-2025-08-07 beta header (size-triggered in the
+// proxy), never via the model name.
+const contextWindowVariantTag = "[1m]"
+
+// CanonicalModel strips a Claude Code context-window variant tag from model
+// and reports whether one was present. Models without the tag pass through
+// unchanged.
+func CanonicalModel(model string) (canonical string, hadVariantTag bool) {
+	if strings.HasSuffix(model, contextWindowVariantTag) {
+		return model[:len(model)-len(contextWindowVariantTag)], true
+	}
+	return model, false
+}
+
+// CanonicalizeModelInBody rewrites the request body's top-level "model" field
+// to its canonical form (stripping a Claude Code context-window variant tag)
+// and reports whether the tag was present. A body whose model carries no tag —
+// or has no model field at all — is returned unchanged with hadVariantTag
+// false. This is the single normalization seam for inbound requests so the
+// tag never reaches a native Anthropic upstream, and so routing, pins, and
+// telemetry all key off the canonical id.
+func CanonicalizeModelInBody(body []byte) (out []byte, hadVariantTag bool, err error) {
+	canonical, had := CanonicalModel(gjson.GetBytes(body, "model").String())
+	if !had {
+		return body, false, nil
+	}
+	out, err = sjson.SetBytes(body, "model", canonical)
+	if err != nil {
+		return body, true, err
+	}
+	return out, true, nil
+}

--- a/internal/translate/model_variant_test.go
+++ b/internal/translate/model_variant_test.go
@@ -1,0 +1,63 @@
+package translate_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+
+	"workweave/router/internal/translate"
+)
+
+func TestCanonicalModel(t *testing.T) {
+	cases := []struct {
+		name      string
+		model     string
+		canonical string
+		hadTag    bool
+	}{
+		{"opus 1m variant", "claude-opus-4-8[1m]", "claude-opus-4-8", true},
+		{"sonnet 1m variant", "claude-sonnet-4-6[1m]", "claude-sonnet-4-6", true},
+		{"fable 1m variant", "claude-fable-5[1m]", "claude-fable-5", true},
+		{"no tag", "claude-opus-4-8", "claude-opus-4-8", false},
+		{"oss model untouched", "deepseek/deepseek-v4-pro", "deepseek/deepseek-v4-pro", false},
+		{"empty", "", "", false},
+		{"tag only at end", "claude[1m]-opus", "claude[1m]-opus", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, had := translate.CanonicalModel(tc.model)
+			assert.Equal(t, tc.canonical, got)
+			assert.Equal(t, tc.hadTag, had)
+		})
+	}
+}
+
+func TestCanonicalizeModelInBody(t *testing.T) {
+	t.Run("rewrites tagged model and preserves other fields", func(t *testing.T) {
+		body := []byte(`{"model":"claude-opus-4-8[1m]","max_tokens":1024,"stream":true}`)
+		out, had, err := translate.CanonicalizeModelInBody(body)
+		require.NoError(t, err)
+		assert.True(t, had)
+		assert.Equal(t, "claude-opus-4-8", gjson.GetBytes(out, "model").String())
+		assert.Equal(t, int64(1024), gjson.GetBytes(out, "max_tokens").Int())
+		assert.True(t, gjson.GetBytes(out, "stream").Bool())
+	})
+
+	t.Run("untagged body returned unchanged", func(t *testing.T) {
+		body := []byte(`{"model":"claude-opus-4-8","max_tokens":1024}`)
+		out, had, err := translate.CanonicalizeModelInBody(body)
+		require.NoError(t, err)
+		assert.False(t, had)
+		assert.Equal(t, body, out, "untagged body must be returned byte-identical")
+	})
+
+	t.Run("missing model field returned unchanged", func(t *testing.T) {
+		body := []byte(`{"max_tokens":1024}`)
+		out, had, err := translate.CanonicalizeModelInBody(body)
+		require.NoError(t, err)
+		assert.False(t, had)
+		assert.Equal(t, body, out)
+	})
+}


### PR DESCRIPTION
## Problem

Found while investigating the Redwood demo (session `d4294ec8`). Claude Code's 1M-context picker sends its model id with a `[1m]` variant tag on the wire — e.g. `claude-opus-4-8[1m]`. Prod router telemetry confirms it: `requested_model` rows like `claude-opus-4-8[1m]`, `claude-sonnet-4-6[1m]`, `claude-fable-5[1m]`.

`[1m]` is a Claude Code display convention, **not** a real Anthropic model id. Forwarding it verbatim to the native Anthropic API returns `404 not_found_error` → surfaced to the user as *"the selected model may not exist."*

Routed turns already emit the canonical `decision.Model`, so the tag doesn't reach Anthropic there. But the **`/v1/messages/count_tokens` (and model-list) passthrough** forwards the request body verbatim — `PassthroughToNamedProvider` explicitly does no model rewriting. Claude Code calls `count_tokens` frequently for context-window tracking, so the tagged model hits native Anthropic and 404s on every 1M-mode session.

> Note: this was a real latent bug but **not** the model-not-found the demo audience saw — that was a separate `deepseek-v4-pro` double-provider outage (Fireworks 503 → OpenRouter "no endpoints" 404), addressed in a follow-up PR.

## Fix

Normalize the inbound model to its canonical catalog id at two seams via a new pure `translate.CanonicalizeModelInBody` helper:

- **`ProxyMessages`**, before parsing — so routing, session pins, and telemetry key off the real model (telemetry was recording `claude-opus-4-8[1m]` as `requested_model`).
- **`PassthroughToNamedProvider`** — the actual 404 vector.

The 1M window itself is unchanged: it's enabled via the size-triggered `context-1m-2025-08-07` beta header (#458), never via the model name. Untagged models pass through byte-identical.

## Tests

- `TestCanonicalModel` / `TestCanonicalizeModelInBody` — tag stripping, untagged passthrough (byte-identical), missing-model-field, other fields preserved.
- Full `internal/proxy` + `internal/translate` suites pass; `go vet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)