### PR TITLE
Fix/delete api key cache invalidation

### DIFF
--- a/internal/api/admin/keys.go
+++ b/internal/api/admin/keys.go
@@ -145,7 +145,7 @@ func DeleteAPIKeyHandler(authSvc *auth.Service) gin.HandlerFunc {
 			c.AbortWithStatusJSON(http.StatusNotFound, gin.H{"error": "API key not found."})
 			return
 		}
-		if err := authSvc.DeleteAPIKey(c.Request.Context(), id); err != nil {
+		if err := authSvc.DeleteAPIKey(c.Request.Context(), installation.ID, id); err != nil {
 			c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"error": "Failed to delete API key."})
 			return
 		}

--- a/internal/auth/service.go
+++ b/internal/auth/service.go
@@ -162,9 +162,17 @@ func (s *Service) RotateAPIKey(ctx context.Context, installationID, keyID string
 	return key, raw, nil
 }
 
-// DeleteAPIKey soft-deletes an API key.
-func (s *Service) DeleteAPIKey(ctx context.Context, id string) error {
-	return s.apiKeys.SoftDelete(ctx, id)
+// DeleteAPIKey soft-deletes an API key and immediately invalidates the
+// installation's cache entry on this replica and all peers. Without the
+// invalidation the deleted key would remain usable for up to the positive
+// cache TTL (5 min) — the same window that RotateAPIKey closes via
+// invalidateInstallation.
+func (s *Service) DeleteAPIKey(ctx context.Context, installationID, id string) error {
+	if err := s.apiKeys.SoftDelete(ctx, id); err != nil {
+		return err
+	}
+	s.invalidateInstallation(installationID)
+	return nil
 }
 
 // ListExternalAPIKeys returns all active provider API keys for an installation.

--- a/internal/auth/service_test.go
+++ b/internal/auth/service_test.go
@@ -62,7 +62,7 @@ func (f *fakeAPIKeyRepository) MarkUsed(ctx context.Context, id string) error {
 }
 
 func (f *fakeAPIKeyRepository) SoftDelete(ctx context.Context, id string) error {
-	return errors.New("not used by these tests")
+	return f.override
 }
 
 type fakeExternalAPIKeyRepo struct {
@@ -776,5 +776,16 @@ func TestService_WriteHooksInvalidateAndNotify(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, []string{installID}, cache.invalidationSnapshot())
 		assert.Equal(t, []string{installID}, nf.snapshot())
+	})
+
+	t.Run("DeleteAPIKey", func(t *testing.T) {
+		svc, cache, nf := makeSvc()
+		err := svc.DeleteAPIKey(context.Background(), installID, "k1")
+		require.NoError(t, err)
+		assert.Equal(t, []string{installID}, cache.invalidationSnapshot(),
+			"DeleteAPIKey must call cache.InvalidateInstallation so the deleted key cannot "+
+				"authenticate for up to the 5-min positive cache TTL after revocation")
+		assert.Equal(t, []string{installID}, nf.snapshot(),
+			"DeleteAPIKey must publish NOTIFY so peer replicas also drop the deleted key immediately")
 	})
 }


### PR DESCRIPTION
## Summary

Fixes #473.

`auth.Service.DeleteAPIKey` soft-deleted an API key in Postgres but did not call `s.invalidateInstallation(installationID)`. Every other per-installation mutation method calls it; `DeleteAPIKey` was the sole exception.

After `DELETE /admin/v1/keys/:id`, the deleted key's positive cache entry (TTL 5 min) remained valid on every running replica, and the Pub/Sub notifier was never fired — so peer replicas were not told to drop their stale entries either.

## Changes

**`internal/auth/service.go`**

- Add `installationID string` parameter to `DeleteAPIKey`
- Call `s.invalidateInstallation(installationID)` after successful `SoftDelete`, matching the pattern used by every other mutation method

**`internal/api/admin/keys.go`**

- Pass `installation.ID` to `DeleteAPIKey` — already in scope from `resolveInstallation`, no additional DB round-trip

**`internal/auth/service_test.go`**

- Add `DeleteAPIKey` sub-test to `TestService_WriteHooksInvalidateAndNotify`, which was structurally designed to catch exactly this omission
- Change `fakeAPIKeyRepository.SoftDelete` to return `f.override` (nil by default) instead of a hardcoded error, consistent with how `override` is used in `GetActiveByHashWithInstallation`

## Verification

`go test ./... -race -count=1` — all 30 packages pass, zero DATA RACE.
`make check` — All checks passed.