### PR TITLE
feat(routing): dispersion-aware quality dial + model-mix distribution endpoint

### DIFF
--- a/internal/api/admin/routing_distribution.go
+++ b/internal/api/admin/routing_distribution.go
@@ -1,0 +1,56 @@
+package admin
+
+import (
+	"net/http"
+	"strconv"
+
+	"workweave/router/internal/router/cluster"
+
+	"github.com/gin-gonic/gin"
+)
+
+// RoutingDistributionSource projects the per-installation "quality vs price"
+// dial's model mix across a grid of dial positions. Implemented by
+// *cluster.Multiversion in production; callers can pass a fake in tests.
+type RoutingDistributionSource interface {
+	DefaultRoutingDistribution(gridN int) ([]cluster.DistributionPoint, error)
+}
+
+// maxDistributionGrid caps the requested grid size so a client can't ask the
+// scorer to evaluate an unbounded number of dial positions.
+const maxDistributionGrid = 101
+
+type routingDistributionResponse struct {
+	Points []cluster.DistributionPoint `json:"points"`
+}
+
+// RoutingDistributionHandler serves GET /v1/router/routing-distribution. For a
+// grid of dial positions in [0, 1] it returns the projected model mix the
+// QualityBias dial would produce (and the share-weighted input cost at each
+// position). Read-only, unauthed metadata derived from the publicly published
+// artifact — mounted like /v1/router/models so the Weave control plane can
+// render the dashboard preview without juggling router API keys.
+//
+// `grid` (optional) sets the number of dial positions in [2, 101]; omitted
+// leaves the scorer on its default grid.
+func RoutingDistributionHandler(dist RoutingDistributionSource) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		gridN := 0 // 0 -> scorer default
+		if raw := c.Query("grid"); raw != "" {
+			n, err := strconv.Atoi(raw)
+			if err != nil || n < 2 || n > maxDistributionGrid {
+				c.JSON(http.StatusBadRequest, gin.H{"error": "grid must be an integer in [2, 101]"})
+				return
+			}
+			gridN = n
+		}
+		points, err := dist.DefaultRoutingDistribution(gridN)
+		if err != nil {
+			c.JSON(http.StatusServiceUnavailable, gin.H{"error": "routing distribution unavailable"})
+			return
+		}
+		c.JSON(http.StatusOK, routingDistributionResponse{Points: points})
+	}
+}
+
+var _ RoutingDistributionSource = (*cluster.Multiversion)(nil)

--- a/internal/api/admin/routing_distribution_test.go
+++ b/internal/api/admin/routing_distribution_test.go
@@ -1,0 +1,87 @@
+package admin_test
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"workweave/router/internal/api/admin"
+	"workweave/router/internal/router/cluster"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeDistributionSource struct {
+	points   []cluster.DistributionPoint
+	err      error
+	lastGrid int
+}
+
+func (f *fakeDistributionSource) DefaultRoutingDistribution(gridN int) ([]cluster.DistributionPoint, error) {
+	f.lastGrid = gridN
+	return f.points, f.err
+}
+
+func newDistributionEngine(src admin.RoutingDistributionSource) *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	engine := gin.New()
+	engine.GET("/v1/router/routing-distribution", admin.RoutingDistributionHandler(src))
+	return engine
+}
+
+func TestRoutingDistributionHandler_ReturnsPoints(t *testing.T) {
+	src := &fakeDistributionSource{points: []cluster.DistributionPoint{
+		{QualityBias: 0, Models: []cluster.ModelShare{{Model: "deepseek-v4-flash", Share: 1}}, ProjectedCostPer1KInputUSD: 0.00014},
+		{QualityBias: 1, Models: []cluster.ModelShare{{Model: "claude-opus-4-8", Share: 1}}, ProjectedCostPer1KInputUSD: 0.005},
+	}}
+	engine := newDistributionEngine(src)
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/router/routing-distribution?grid=2", nil)
+	rec := httptest.NewRecorder()
+	engine.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, 2, src.lastGrid, "grid query param should reach the source")
+
+	var got struct {
+		Points []cluster.DistributionPoint `json:"points"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
+	require.Len(t, got.Points, 2)
+	assert.Equal(t, "deepseek-v4-flash", got.Points[0].Models[0].Model)
+	assert.Equal(t, "claude-opus-4-8", got.Points[1].Models[0].Model)
+}
+
+func TestRoutingDistributionHandler_DefaultsGridWhenAbsent(t *testing.T) {
+	src := &fakeDistributionSource{lastGrid: -999}
+	engine := newDistributionEngine(src)
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/router/routing-distribution", nil)
+	rec := httptest.NewRecorder()
+	engine.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, 0, src.lastGrid, "absent grid param should pass 0 (scorer default)")
+}
+
+func TestRoutingDistributionHandler_RejectsBadGrid(t *testing.T) {
+	engine := newDistributionEngine(&fakeDistributionSource{})
+	for _, bad := range []string{"1", "0", "-5", "abc", "1000"} {
+		req := httptest.NewRequest(http.MethodGet, "/v1/router/routing-distribution?grid="+bad, nil)
+		rec := httptest.NewRecorder()
+		engine.ServeHTTP(rec, req)
+		assert.Equal(t, http.StatusBadRequest, rec.Code, "grid=%q should be rejected", bad)
+	}
+}
+
+func TestRoutingDistributionHandler_SourceErrorIs503(t *testing.T) {
+	engine := newDistributionEngine(&fakeDistributionSource{err: errors.New("v1 bundle")})
+	req := httptest.NewRequest(http.MethodGet, "/v1/router/routing-distribution", nil)
+	rec := httptest.NewRecorder()
+	engine.ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusServiceUnavailable, rec.Code)
+}

--- a/internal/router/cluster/distribution.go
+++ b/internal/router/cluster/distribution.go
@@ -1,0 +1,122 @@
+package cluster
+
+import (
+	"fmt"
+	"sort"
+)
+
+// ModelShare is one model's share of a projected routing distribution.
+type ModelShare struct {
+	Model string  `json:"model"`
+	Share float64 `json:"share"` // fraction in [0, 1]
+}
+
+// DistributionPoint is the projected model mix at one dial position. Share
+// values sum to 1 (modulo rounding). ProjectedCostPer1KInputUSD is the
+// share-weighted input price, the basis for the dashboard's "spend vs all-Opus"
+// readout.
+type DistributionPoint struct {
+	QualityBias                float64      `json:"quality_bias"`
+	Models                     []ModelShare `json:"models"`
+	ProjectedCostPer1KInputUSD float64      `json:"projected_cost_per_1k_input_usd"`
+}
+
+// defaultActiveKnobs returns a fresh copy of the bundle's default routing knobs
+// (Alpha slice cloned so callers can mutate per request without leaking into
+// the shared bundle defaults). When the bundle ships no defaults it falls back
+// to a neutral alpha of 0.53 on every cluster. Single source of truth for both
+// Route and RoutingDistribution.
+func (s *Scorer) defaultActiveKnobs() DefaultRoutingKnobs {
+	if s.metadata != nil && s.metadata.Training.DefaultRoutingKnobs != nil {
+		knobs := *s.metadata.Training.DefaultRoutingKnobs
+		knobs.Alpha = append([]float64(nil), knobs.Alpha...)
+		return knobs
+	}
+	knobs := DefaultRoutingKnobs{
+		Alpha:                make([]float64, s.centroids.K),
+		SpeedWeight:          0.0,
+		OutputCostRatio:      0.0,
+		ExpectedOutputTokens: 2000,
+		PerModelVerbosity:    false,
+	}
+	for i := range knobs.Alpha {
+		knobs.Alpha[i] = 0.53
+	}
+	return knobs
+}
+
+// defaultDistributionGrid is the dial-position count used when a caller does
+// not request a specific grid size: 21 points = steps of 0.05, fine enough for
+// the dashboard to render a smooth curve and seat the slider handle.
+const defaultDistributionGrid = 21
+
+// RoutingDistribution projects the model mix the QualityBias dial would produce
+// across a grid of gridN evenly spaced dial positions in [0, 1].
+//
+// Each cluster centroid is treated as one representative request, routed with
+// the SAME scoring path as live traffic (deriveClusterAlpha -> blendScoresV2 ->
+// argmax), and the winners are tallied with equal weight. This makes the
+// preview a faithful read of the routing math; what it is NOT is traffic
+// weighted — every cluster counts once regardless of how much real traffic
+// lands there, so the dashboard should frame it as the mix "across request
+// types," not "your traffic." Per-installation model exclusions are not applied
+// (the catalog surface is global); the full deployed roster is eligible.
+//
+// gridN < 2 falls back to defaultDistributionGrid. Returns an error for v1
+// bundles, which have no quality_means to disperse over.
+func (s *Scorer) RoutingDistribution(gridN int) ([]DistributionPoint, error) {
+	if !s.isV2 {
+		return nil, fmt.Errorf("%w: routing distribution requires a v2 bundle", ErrClusterUnavailable)
+	}
+	if gridN < 2 {
+		gridN = defaultDistributionGrid
+	}
+
+	k := s.centroids.K
+	points := make([]DistributionPoint, 0, gridN)
+	for g := 0; g < gridN; g++ {
+		t := float64(g) / float64(gridN-1)
+
+		knobs := s.defaultActiveKnobs()
+		for i := range knobs.Alpha {
+			rank := 0.5
+			if i < len(s.qualityDispersionRank) {
+				rank = s.qualityDispersionRank[i]
+			}
+			knobs.Alpha[i] = deriveClusterAlpha(t, rank, qualityBiasDispersionSpread)
+		}
+
+		counts := make(map[string]int, len(s.models))
+		for c := 0; c < k; c++ {
+			topClusters := topPNearest(s.centroids.Row(c), s.centroids, s.cfg.TopP)
+			scores := s.blendScoresV2(topClusters, knobs, s.models)
+			winner, _ := argmax(scores, s.models)
+			if winner != "" {
+				counts[winner]++
+			}
+		}
+
+		shares := make([]ModelShare, 0, len(counts))
+		var projCost float64
+		for m, c := range counts {
+			share := float64(c) / float64(k)
+			shares = append(shares, ModelShare{Model: m, Share: share})
+			if axis, ok := s.modelAxes[m]; ok && axis.InputPer1KUSD != nil {
+				projCost += share * *axis.InputPer1KUSD
+			}
+		}
+		sort.Slice(shares, func(a, b int) bool {
+			if shares[a].Share != shares[b].Share {
+				return shares[a].Share > shares[b].Share
+			}
+			return shares[a].Model < shares[b].Model
+		})
+
+		points = append(points, DistributionPoint{
+			QualityBias:                t,
+			Models:                     shares,
+			ProjectedCostPer1KInputUSD: projCost,
+		})
+	}
+	return points, nil
+}

--- a/internal/router/cluster/distribution.go
+++ b/internal/router/cluster/distribution.go
@@ -73,6 +73,14 @@ func (s *Scorer) RoutingDistribution(gridN int) ([]DistributionPoint, error) {
 	}
 
 	k := s.centroids.K
+
+	// Each centroid's top-P clusters depend only on cluster geometry, not on
+	// the dial position, so compute them once instead of per grid step.
+	centroidTopClusters := make([][]int, k)
+	for c := 0; c < k; c++ {
+		centroidTopClusters[c] = topPNearest(s.centroids.Row(c), s.centroids, s.cfg.TopP)
+	}
+
 	points := make([]DistributionPoint, 0, gridN)
 	for g := 0; g < gridN; g++ {
 		t := float64(g) / float64(gridN-1)
@@ -88,8 +96,7 @@ func (s *Scorer) RoutingDistribution(gridN int) ([]DistributionPoint, error) {
 
 		counts := make(map[string]int, len(s.models))
 		for c := 0; c < k; c++ {
-			topClusters := topPNearest(s.centroids.Row(c), s.centroids, s.cfg.TopP)
-			scores := s.blendScoresV2(topClusters, knobs, s.models)
+			scores := s.blendScoresV2(centroidTopClusters[c], knobs, s.models)
 			winner, _ := argmax(scores, s.models)
 			if winner != "" {
 				counts[winner]++

--- a/internal/router/cluster/distribution_test.go
+++ b/internal/router/cluster/distribution_test.go
@@ -1,0 +1,128 @@
+package cluster
+
+import (
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDeriveClusterAlpha_EndpointsPinForEveryRank(t *testing.T) {
+	for _, rank := range []float64{0, 0.25, 0.5, 0.75, 1} {
+		assert.Equal(t, 0.0, deriveClusterAlpha(0, rank, qualityBiasDispersionSpread),
+			"t=0 must map to alpha 0 (all price) regardless of dispersion rank %v", rank)
+		assert.Equal(t, 1.0, deriveClusterAlpha(1, rank, qualityBiasDispersionSpread),
+			"t=1 must map to alpha 1 (all quality) regardless of dispersion rank %v", rank)
+	}
+}
+
+func TestDeriveClusterAlpha_MonotonicInDial(t *testing.T) {
+	for _, rank := range []float64{0, 0.5, 1} {
+		prev := -1.0
+		for g := 0; g <= 20; g++ {
+			a := deriveClusterAlpha(float64(g)/20, rank, qualityBiasDispersionSpread)
+			assert.GreaterOrEqual(t, a, prev, "alpha must be non-decreasing in the dial (rank %v)", rank)
+			prev = a
+		}
+	}
+}
+
+func TestDeriveClusterAlpha_HigherDispersionFavorsQualityEarlier(t *testing.T) {
+	// At a fixed mid-dial position, a higher-dispersion cluster (one whose
+	// strong models are much better than its cheap ones) should carry a higher
+	// quality weight than a low-dispersion cluster — that's what spreads the
+	// per-cluster crossovers into a gradient instead of a cliff.
+	for _, dial := range []float64{0.25, 0.5, 0.75} {
+		low := deriveClusterAlpha(dial, 0.0, qualityBiasDispersionSpread)
+		mid := deriveClusterAlpha(dial, 0.5, qualityBiasDispersionSpread)
+		high := deriveClusterAlpha(dial, 1.0, qualityBiasDispersionSpread)
+		assert.Less(t, low, mid, "dial=%v: low-dispersion alpha should trail median", dial)
+		assert.Less(t, mid, high, "dial=%v: median alpha should trail high-dispersion", dial)
+	}
+}
+
+func TestComputeQualityDispersionRank_OrdersBySpread(t *testing.T) {
+	models := []string{"a", "b"}
+	// cluster 0: spread 0 (both equal); cluster 1: spread 1; cluster 2: spread 4.
+	qm := Rankings{
+		0: {"a": 1, "b": 1},
+		1: {"a": 1, "b": 2},
+		2: {"a": 1, "b": 5},
+	}
+	ranks := computeQualityDispersionRank(qm, models, 3)
+	require.Len(t, ranks, 3)
+	assert.Equal(t, 0.0, ranks[0], "lowest-dispersion cluster ranks 0")
+	assert.Equal(t, 0.5, ranks[1], "middle-dispersion cluster ranks 0.5")
+	assert.Equal(t, 1.0, ranks[2], "highest-dispersion cluster ranks 1")
+}
+
+func TestComputeQualityDispersionRank_SingleClusterNeutral(t *testing.T) {
+	ranks := computeQualityDispersionRank(Rankings{0: {"a": 1, "b": 9}}, []string{"a", "b"}, 1)
+	require.Len(t, ranks, 1)
+	assert.Equal(t, 0.5, ranks[0], "with no other cluster to rank against, rank is neutral 0.5")
+}
+
+// loadV0_67 loads the committed v0.67 bundle through a fake embedder (matching
+// its jina-v2 id / 768 dim). RoutingDistribution never embeds, so no ONNX
+// runtime is needed; this keeps the test hermetic and in the default matrix.
+func loadV0_67(t *testing.T) *Scorer {
+	t.Helper()
+	bundle, err := LoadBundle("v0.67")
+	require.NoError(t, err)
+	require.True(t, bundle.IsV2)
+	s, err := NewScorer(bundle, DefaultConfig(), &fakeEmbedder{dim: bundle.Centroids.Dim}, allProviders())
+	require.NoError(t, err)
+	return s
+}
+
+func TestRoutingDistribution_EndpointsAndGradient(t *testing.T) {
+	s := loadV0_67(t)
+	const grid = 21
+	points, err := s.RoutingDistribution(grid)
+	require.NoError(t, err)
+	require.Len(t, points, grid)
+
+	// Shares sum to ~1 at every dial position.
+	for _, p := range points {
+		var sum float64
+		for _, m := range p.Models {
+			sum += m.Share
+		}
+		assert.InDelta(t, 1.0, sum, 1e-9, "shares must sum to 1 at quality_bias=%v", p.QualityBias)
+	}
+
+	// Price endpoint: pure cost → the single cheapest model wins every cluster.
+	require.NotEmpty(t, points[0].Models)
+	assert.Equal(t, 1.0, points[0].Models[0].Share, "at the price extreme one cheap model should take ~all traffic")
+
+	// The endpoints are the cost extremes: cheapest mix at t=0, priciest at t=1.
+	minCost, maxCost := points[0].ProjectedCostPer1KInputUSD, points[0].ProjectedCostPer1KInputUSD
+	for _, p := range points {
+		minCost = math.Min(minCost, p.ProjectedCostPer1KInputUSD)
+		maxCost = math.Max(maxCost, p.ProjectedCostPer1KInputUSD)
+	}
+	assert.Equal(t, minCost, points[0].ProjectedCostPer1KInputUSD, "price end should be the cheapest point")
+	assert.Equal(t, maxCost, points[len(points)-1].ProjectedCostPer1KInputUSD, "quality end should be the priciest point")
+	assert.Greater(t, maxCost, minCost, "the dial must actually move projected cost")
+
+	// Gradient, not cliff: several interior dial positions land strictly
+	// between the two cost extremes (a cliff would jump from min to max with
+	// nothing in between).
+	span := maxCost - minCost
+	interiorBetween := 0
+	for _, p := range points[1 : len(points)-1] {
+		if p.ProjectedCostPer1KInputUSD > minCost+0.02*span && p.ProjectedCostPer1KInputUSD < maxCost-0.02*span {
+			interiorBetween++
+		}
+	}
+	assert.GreaterOrEqual(t, interiorBetween, 3,
+		"expected a gradient of intermediate mixes across the dial, got %d interior points between the extremes", interiorBetween)
+}
+
+func TestRoutingDistribution_DefaultGridAndV1Guard(t *testing.T) {
+	s := loadV0_67(t)
+	points, err := s.RoutingDistribution(0) // 0 -> default grid
+	require.NoError(t, err)
+	assert.Len(t, points, defaultDistributionGrid)
+}

--- a/internal/router/cluster/distribution_test.go
+++ b/internal/router/cluster/distribution_test.go
@@ -57,6 +57,23 @@ func TestComputeQualityDispersionRank_OrdersBySpread(t *testing.T) {
 	assert.Equal(t, 1.0, ranks[2], "highest-dispersion cluster ranks 1")
 }
 
+func TestComputeQualityDispersionRank_TiesShareMidRank(t *testing.T) {
+	models := []string{"a", "b"}
+	// clusters 0 and 1 have identical spread (1); cluster 2 has spread 4.
+	// The two tied clusters should get the SAME rank (mid-rank of positions
+	// 0,1 = 0.5 -> 0.25), independent of their order in the bundle.
+	qm := Rankings{
+		0: {"a": 1, "b": 2},
+		1: {"a": 5, "b": 6},
+		2: {"a": 1, "b": 5},
+	}
+	ranks := computeQualityDispersionRank(qm, models, 3)
+	require.Len(t, ranks, 3)
+	assert.Equal(t, ranks[0], ranks[1], "tied-dispersion clusters must share a rank")
+	assert.Equal(t, 0.25, ranks[0], "two tied clusters at positions 0,1 get mid-rank 0.5/(k-1)")
+	assert.Equal(t, 1.0, ranks[2], "the distinct top-dispersion cluster ranks 1")
+}
+
 func TestComputeQualityDispersionRank_SingleClusterNeutral(t *testing.T) {
 	ranks := computeQualityDispersionRank(Rankings{0: {"a": 1, "b": 9}}, []string{"a", "b"}, 1)
 	require.Len(t, ranks, 1)

--- a/internal/router/cluster/multiversion.go
+++ b/internal/router/cluster/multiversion.go
@@ -70,6 +70,17 @@ func (m *Multiversion) DefaultDeployedModels() []DeployedEntry {
 	return s.DeployedModels()
 }
 
+// DefaultRoutingDistribution projects the QualityBias dial's model mix across a
+// grid of dial positions, using the default version's Scorer (the version live
+// traffic routes through absent a per-request override).
+func (m *Multiversion) DefaultRoutingDistribution(gridN int) ([]DistributionPoint, error) {
+	s, ok := m.Versions[m.Default]
+	if !ok {
+		return nil, fmt.Errorf("cluster multiversion: default version %q not built: %w", m.Default, ErrClusterUnavailable)
+	}
+	return s.RoutingDistribution(gridN)
+}
+
 // Route dispatches to the per-request version override if built, otherwise Default.
 func (m *Multiversion) Route(ctx context.Context, req router.Request) (router.Decision, error) {
 	requested := VersionFromContext(ctx)

--- a/internal/router/cluster/scorer.go
+++ b/internal/router/cluster/scorer.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math"
 	"sort"
 	"strings"
 	"time"
@@ -55,6 +56,16 @@ type Scorer struct {
 	qualityMeans    Rankings
 	modelAxes       map[string]ModelAxis
 	medianVerbosity float64
+	// qualityDispersionRank[k] is cluster k's quality dispersion expressed as a
+	// rank in [0, 1] (0 = lowest dispersion across all clusters, 1 = highest).
+	// Dispersion is the spread of raw quality_means across deployed models in
+	// the cluster: a high-dispersion cluster is one where the strong models are
+	// much better than the cheap ones (so it should keep quality models down to
+	// a low dial setting), a low-dispersion cluster is one where every model is
+	// about equally good (so it demotes to cheap early). Precomputed once at
+	// NewScorer over the full deployed set; drives deriveClusterAlpha for the
+	// QualityBias dial. Length K, v2 only (nil for v1 bundles).
+	qualityDispersionRank []float64
 }
 
 // Version returns the artifact version (e.g. "v0.2").
@@ -183,22 +194,123 @@ func NewScorer(bundle *Bundle, cfg Config, embed Embedder, availableProviders ma
 		}
 	}
 
+	var qualityDispersionRank []float64
+	if bundle.IsV2 {
+		qualityDispersionRank = computeQualityDispersionRank(bundle.QualityMeans, models, bundle.Centroids.K)
+	}
+
 	return &Scorer{
-		version:         bundle.Version,
-		cfg:             cfg,
-		embed:           embed,
-		centroids:       bundle.Centroids,
-		rankings:        bundle.Rankings,
-		registry:        bundle.Registry,
-		candidates:      candidates,
-		models:          models,
-		metadata:        bundle.Metadata,
-		isV2:            bundle.IsV2,
-		qualityMeans:    bundle.QualityMeans,
-		modelAxes:       bundle.ModelAxes,
-		medianVerbosity: bundle.MedianVerbosity,
+		version:               bundle.Version,
+		cfg:                   cfg,
+		embed:                 embed,
+		centroids:             bundle.Centroids,
+		rankings:              bundle.Rankings,
+		registry:              bundle.Registry,
+		candidates:            candidates,
+		models:                models,
+		metadata:              bundle.Metadata,
+		isV2:                  bundle.IsV2,
+		qualityMeans:          bundle.QualityMeans,
+		modelAxes:             bundle.ModelAxes,
+		medianVerbosity:       bundle.MedianVerbosity,
+		qualityDispersionRank: qualityDispersionRank,
 	}, nil
 }
+
+// computeQualityDispersionRank measures each cluster's quality dispersion — the
+// population standard deviation of its raw quality_means across the deployed
+// model set — and converts those into ranks in [0, 1] (0 = lowest-dispersion
+// cluster, 1 = highest). Dispersion is read from RAW quality_means, before the
+// per-cluster min-max normalization the scorer applies at request time: that
+// normalization deliberately flattens every cluster to the same [0, 1] range,
+// which is exactly what collapses the per-cluster crossovers into one cliff.
+// Ranking on the raw spread reintroduces the signal the dial needs.
+//
+// Returns a slice of length K. With fewer than two clusters every rank is 0.5
+// (no spread to rank against), which makes deriveClusterAlpha fall back to a
+// plain t curve.
+func computeQualityDispersionRank(qualityMeans Rankings, models []string, k int) []float64 {
+	disp := make([]float64, k)
+	for c := 0; c < k; c++ {
+		row := qualityMeans[c]
+		if len(models) == 0 {
+			continue
+		}
+		var sum float64
+		for _, m := range models {
+			sum += float64(row[m])
+		}
+		mean := sum / float64(len(models))
+		var variance float64
+		for _, m := range models {
+			d := float64(row[m]) - mean
+			variance += d * d
+		}
+		disp[c] = math.Sqrt(variance / float64(len(models)))
+	}
+
+	// Rank by dispersion via fractional ranks so ties share a position and the
+	// result is invariant to the absolute dispersion scale (which varies by
+	// bundle). order holds cluster indices sorted ascending by dispersion.
+	order := make([]int, k)
+	for i := range order {
+		order[i] = i
+	}
+	sort.SliceStable(order, func(a, b int) bool { return disp[order[a]] < disp[order[b]] })
+
+	ranks := make([]float64, k)
+	if k < 2 {
+		for i := range ranks {
+			ranks[i] = 0.5
+		}
+		return ranks
+	}
+	for pos, cluster := range order {
+		ranks[cluster] = float64(pos) / float64(k-1)
+	}
+	return ranks
+}
+
+// deriveClusterAlpha maps the global QualityBias dial t in [0, 1] to a single
+// cluster's quality weight, bending the curve by that cluster's quality
+// dispersion rank. The mapping is alpha = t^gamma where gamma = spread^(1 -
+// 2*rank):
+//
+//   - high-dispersion clusters (rank -> 1) get gamma < 1, a concave curve that
+//     rises fast — they reach a quality-favoring alpha at a low dial setting
+//     and hold strong models the longest;
+//   - low-dispersion clusters (rank -> 0) get gamma > 1, a convex curve that
+//     stays near zero — they keep routing cheap until the dial is high;
+//   - the median cluster (rank = 0.5) gets gamma = 1, a straight line.
+//
+// Because t^gamma pins to 0 at t=0 and 1 at t=1 for every gamma > 0, the slider
+// endpoints always resolve to all-cheapest / all-top-quality regardless of
+// dispersion; only the midrange spreads. spread > 1 controls how far the
+// per-cluster crossovers fan out (1 collapses back to a uniform t).
+func deriveClusterAlpha(t, rank, spread float64) float64 {
+	if t <= 0 {
+		return 0
+	}
+	if t >= 1 {
+		return 1
+	}
+	gamma := math.Pow(spread, 1-2*rank)
+	a := math.Pow(t, gamma)
+	if a < 0 {
+		return 0
+	}
+	if a > 1 {
+		return 1
+	}
+	return a
+}
+
+// qualityBiasDispersionSpread is the fan-out factor for deriveClusterAlpha. At
+// 3.0 the highest-dispersion cluster's crossover sits at roughly the cube root
+// of the lowest's, which spreads the 16 v0.67 clusters across the dial without
+// any single cluster dominating. Tunable; verified against the live bundle
+// centroids before promotion.
+const qualityBiasDispersionSpread = 3.0
 
 // resolveProviderFor walks the catalog's ordered ProviderBinding list for
 // modelID and returns the first binding whose Provider name is in
@@ -420,29 +532,30 @@ func (s *Scorer) Route(ctx context.Context, req router.Request) (router.Decision
 
 	if s.isV2 {
 		// 1. Resolve Knobs and Validate
-		var activeKnobs DefaultRoutingKnobs
-		if s.metadata != nil && s.metadata.Training.DefaultRoutingKnobs != nil {
-			activeKnobs = *s.metadata.Training.DefaultRoutingKnobs
-			// Struct copy shares the Alpha slice's backing array with the
-			// bundle defaults. Clone before any potential mutation so a
-			// per-request override doesn't leak into subsequent requests.
-			activeKnobs.Alpha = append([]float64(nil), activeKnobs.Alpha...)
-		} else {
-			activeKnobs = DefaultRoutingKnobs{
-				Alpha:                make([]float64, s.centroids.K),
-				SpeedWeight:          0.0,
-				OutputCostRatio:      0.0,
-				ExpectedOutputTokens: 2000,
-				PerModelVerbosity:    false,
-			}
-			for i := range activeKnobs.Alpha {
-				activeKnobs.Alpha[i] = 0.53
-			}
-		}
+		activeKnobs := s.defaultActiveKnobs()
 
 		if req.RoutingKnobs != nil {
-			if req.RoutingKnobs.Alpha != nil {
-				// Sledgehammer behavior: uniformly replace every alpha with the scalar
+			switch {
+			case req.RoutingKnobs.QualityBias != nil:
+				// Dial path: derive a per-cluster alpha from the single dial
+				// position, bent by each cluster's quality dispersion. The
+				// endpoints still pin to all-cheapest / all-top-quality; only
+				// the midrange fans out into a real mix. Takes precedence over
+				// a co-set Alpha (the higher-level intent wins).
+				t := *req.RoutingKnobs.QualityBias
+				if math.IsNaN(t) || math.IsInf(t, 0) || t < 0 || t > 1 {
+					return router.Decision{}, fmt.Errorf("%w: quality_bias (%f) must be a finite value in [0, 1]", ErrInvalidRoutingKnobs, t)
+				}
+				for i := range activeKnobs.Alpha {
+					rank := 0.5
+					if i < len(s.qualityDispersionRank) {
+						rank = s.qualityDispersionRank[i]
+					}
+					activeKnobs.Alpha[i] = deriveClusterAlpha(t, rank, qualityBiasDispersionSpread)
+				}
+			case req.RoutingKnobs.Alpha != nil:
+				// Sledgehammer behavior: uniformly replace every alpha with the
+				// scalar (eval/debug lever, ignores per-cluster dispersion).
 				for i := range activeKnobs.Alpha {
 					activeKnobs.Alpha[i] = *req.RoutingKnobs.Alpha
 				}
@@ -505,163 +618,7 @@ func (s *Scorer) Route(ctx context.Context, req router.Request) (router.Decision
 			activeKnobs.PerModelVerbosity,
 		)
 
-		// 2. Effective per-model cost (knob-dependent)
-		costs := make(map[string]float64, len(s.models))
-		for _, m := range s.models {
-			axis := s.modelAxes[m]
-			vFactor := 1.0
-			if activeKnobs.PerModelVerbosity && axis.VerbosityTokens != nil && s.medianVerbosity > 0 {
-				vFactor = *axis.VerbosityTokens / s.medianVerbosity
-			}
-			inputPer1K := 0.0
-			if axis.InputPer1KUSD != nil {
-				inputPer1K = *axis.InputPer1KUSD
-			}
-			outputPer1K := 0.0
-			if axis.OutputPer1KUSD != nil {
-				outputPer1K = *axis.OutputPer1KUSD
-			}
-			costs[m] = inputPer1K + activeKnobs.OutputCostRatio*outputPer1K*vFactor
-		}
-
-		// 3. Effective per-model speed
-		speeds := make(map[string]*float64, len(s.models))
-		for _, m := range s.models {
-			axis := s.modelAxes[m]
-			if axis.TTFTSeconds != nil && axis.TPS != nil && *axis.TPS > 0 {
-				val := *axis.TTFTSeconds + float64(activeKnobs.ExpectedOutputTokens) / *axis.TPS
-				speeds[m] = &val
-			} else {
-				speeds[m] = nil
-			}
-		}
-
-		// 4. Normalize over DEPLOYED model set
-		qMin := make(map[int]float32)
-		qMax := make(map[int]float32)
-		for _, k := range topClusters {
-			row := s.qualityMeans[k]
-			first := true
-			for _, m := range s.models {
-				qVal := row[m]
-				if first {
-					qMin[k] = qVal
-					qMax[k] = qVal
-					first = false
-				} else {
-					if qVal < qMin[k] {
-						qMin[k] = qVal
-					}
-					if qVal > qMax[k] {
-						qMax[k] = qVal
-					}
-				}
-			}
-		}
-
-		var cMin, cMax float64
-		firstC := true
-		for _, m := range s.models {
-			cVal := costs[m]
-			if firstC {
-				cMin = cVal
-				cMax = cVal
-				firstC = false
-			} else {
-				if cVal < cMin {
-					cMin = cVal
-				}
-				if cVal > cMax {
-					cMax = cVal
-				}
-			}
-		}
-		cRange := cMax - cMin
-
-		useSpeed := activeKnobs.SpeedWeight > 0
-		var sMin, sMax float64
-		firstS := true
-		for _, m := range s.models {
-			if !useSpeed {
-				break
-			}
-			sPtr := speeds[m]
-			if sPtr == nil {
-				continue
-			}
-			sVal := *sPtr
-			if firstS {
-				sMin = sVal
-				sMax = sVal
-				firstS = false
-			} else {
-				if sVal < sMin {
-					sMin = sVal
-				}
-				if sVal > sMax {
-					sMax = sVal
-				}
-			}
-		}
-		sRange := 0.0
-		if useSpeed && !firstS {
-			sRange = sMax - sMin
-		}
-
-		// 6. Blend per top-P cluster
-		scores = make(map[string]float32, len(eligibleModels))
-		for _, k := range topClusters {
-			row := s.qualityMeans[k]
-			wQ := float32(activeKnobs.Alpha[k])
-			wS := float32(0.0)
-			if useSpeed {
-				wS = float32(activeKnobs.SpeedWeight)
-			}
-			wC := float32(1.0) - wQ - wS
-
-			qRange := qMax[k] - qMin[k]
-
-			for _, m := range eligibleModels {
-				qVal := row[m]
-				qNorm := float32(0.0)
-				if qRange > 0 {
-					qNorm = (qVal - qMin[k]) / qRange
-				}
-
-				cVal := costs[m]
-				cNorm := float32(0.0)
-				if cRange > 0 {
-					cNorm = float32((cVal - cMin) / cRange)
-				}
-
-				sPtr := speeds[m]
-				if sRange > 0 {
-					// Mixed-timing pool: untimed peers are treated as
-					// worst-case speed (sNorm=1, no wS bonus). This keeps
-					// wQ/wC weighting consistent across timed and untimed
-					// models — without this, the redistribution branch
-					// would silently drop the cost axis when wC=0.
-					var sNorm float32 = 1.0
-					if sPtr != nil {
-						sNorm = float32((*sPtr - sMin) / sRange)
-					}
-					blend := wQ*qNorm + wC*(1.0-cNorm) + wS*(1.0-sNorm)
-					scores[m] += blend
-				} else {
-					// No timing differentiation across the entire pool
-					// (all models lack AA timing, or all share the same
-					// speed). Redistribute wS into wQ and wC so the
-					// remaining weights still sum to 1.
-					total := wQ + wC
-					if total > 0 {
-						blend := (wQ/total)*qNorm + (wC/total)*(1.0-cNorm)
-						scores[m] += blend
-					} else {
-						scores[m] += qNorm
-					}
-				}
-			}
-		}
+		scores = s.blendScoresV2(topClusters, activeKnobs, eligibleModels)
 	} else {
 		// Legacy v1 flow
 		scores = make(map[string]float32, len(eligibleModels))
@@ -865,3 +822,169 @@ func clusterIDsString(ks []int) string {
 }
 
 var _ router.Router = (*Scorer)(nil)
+
+// blendScoresV2 computes the v2 per-model blended scores for the given top-P
+// clusters under the effective knobs. Extracted from Route so the routing
+// distribution preview scores identically to live routing (single source of
+// truth for the cost/quality/speed blend). Caller owns knob validation and the
+// QualityBias->Alpha derivation; this method consumes the resolved alpha vector.
+func (s *Scorer) blendScoresV2(topClusters []int, activeKnobs DefaultRoutingKnobs, eligibleModels []string) map[string]float32 {
+	// 2. Effective per-model cost (knob-dependent)
+	costs := make(map[string]float64, len(s.models))
+	for _, m := range s.models {
+		axis := s.modelAxes[m]
+		vFactor := 1.0
+		if activeKnobs.PerModelVerbosity && axis.VerbosityTokens != nil && s.medianVerbosity > 0 {
+			vFactor = *axis.VerbosityTokens / s.medianVerbosity
+		}
+		inputPer1K := 0.0
+		if axis.InputPer1KUSD != nil {
+			inputPer1K = *axis.InputPer1KUSD
+		}
+		outputPer1K := 0.0
+		if axis.OutputPer1KUSD != nil {
+			outputPer1K = *axis.OutputPer1KUSD
+		}
+		costs[m] = inputPer1K + activeKnobs.OutputCostRatio*outputPer1K*vFactor
+	}
+
+	// 3. Effective per-model speed
+	speeds := make(map[string]*float64, len(s.models))
+	for _, m := range s.models {
+		axis := s.modelAxes[m]
+		if axis.TTFTSeconds != nil && axis.TPS != nil && *axis.TPS > 0 {
+			val := *axis.TTFTSeconds + float64(activeKnobs.ExpectedOutputTokens) / *axis.TPS
+			speeds[m] = &val
+		} else {
+			speeds[m] = nil
+		}
+	}
+
+	// 4. Normalize over DEPLOYED model set
+	qMin := make(map[int]float32)
+	qMax := make(map[int]float32)
+	for _, k := range topClusters {
+		row := s.qualityMeans[k]
+		first := true
+		for _, m := range s.models {
+			qVal := row[m]
+			if first {
+				qMin[k] = qVal
+				qMax[k] = qVal
+				first = false
+			} else {
+				if qVal < qMin[k] {
+					qMin[k] = qVal
+				}
+				if qVal > qMax[k] {
+					qMax[k] = qVal
+				}
+			}
+		}
+	}
+
+	var cMin, cMax float64
+	firstC := true
+	for _, m := range s.models {
+		cVal := costs[m]
+		if firstC {
+			cMin = cVal
+			cMax = cVal
+			firstC = false
+		} else {
+			if cVal < cMin {
+				cMin = cVal
+			}
+			if cVal > cMax {
+				cMax = cVal
+			}
+		}
+	}
+	cRange := cMax - cMin
+
+	useSpeed := activeKnobs.SpeedWeight > 0
+	var sMin, sMax float64
+	firstS := true
+	for _, m := range s.models {
+		if !useSpeed {
+			break
+		}
+		sPtr := speeds[m]
+		if sPtr == nil {
+			continue
+		}
+		sVal := *sPtr
+		if firstS {
+			sMin = sVal
+			sMax = sVal
+			firstS = false
+		} else {
+			if sVal < sMin {
+				sMin = sVal
+			}
+			if sVal > sMax {
+				sMax = sVal
+			}
+		}
+	}
+	sRange := 0.0
+	if useSpeed && !firstS {
+		sRange = sMax - sMin
+	}
+
+	// 6. Blend per top-P cluster
+	scores := make(map[string]float32, len(eligibleModels))
+	for _, k := range topClusters {
+		row := s.qualityMeans[k]
+		wQ := float32(activeKnobs.Alpha[k])
+		wS := float32(0.0)
+		if useSpeed {
+			wS = float32(activeKnobs.SpeedWeight)
+		}
+		wC := float32(1.0) - wQ - wS
+
+		qRange := qMax[k] - qMin[k]
+
+		for _, m := range eligibleModels {
+			qVal := row[m]
+			qNorm := float32(0.0)
+			if qRange > 0 {
+				qNorm = (qVal - qMin[k]) / qRange
+			}
+
+			cVal := costs[m]
+			cNorm := float32(0.0)
+			if cRange > 0 {
+				cNorm = float32((cVal - cMin) / cRange)
+			}
+
+			sPtr := speeds[m]
+			if sRange > 0 {
+				// Mixed-timing pool: untimed peers are treated as
+				// worst-case speed (sNorm=1, no wS bonus). This keeps
+				// wQ/wC weighting consistent across timed and untimed
+				// models — without this, the redistribution branch
+				// would silently drop the cost axis when wC=0.
+				var sNorm float32 = 1.0
+				if sPtr != nil {
+					sNorm = float32((*sPtr - sMin) / sRange)
+				}
+				blend := wQ*qNorm + wC*(1.0-cNorm) + wS*(1.0-sNorm)
+				scores[m] += blend
+			} else {
+				// No timing differentiation across the entire pool
+				// (all models lack AA timing, or all share the same
+				// speed). Redistribute wS into wQ and wC so the
+				// remaining weights still sum to 1.
+				total := wQ + wC
+				if total > 0 {
+					blend := (wQ/total)*qNorm + (wC/total)*(1.0-cNorm)
+					scores[m] += blend
+				} else {
+					scores[m] += qNorm
+				}
+			}
+		}
+	}
+	return scores
+}

--- a/internal/router/cluster/scorer.go
+++ b/internal/router/cluster/scorer.go
@@ -249,9 +249,9 @@ func computeQualityDispersionRank(qualityMeans Rankings, models []string, k int)
 		disp[c] = math.Sqrt(variance / float64(len(models)))
 	}
 
-	// Rank by dispersion via fractional ranks so ties share a position and the
-	// result is invariant to the absolute dispersion scale (which varies by
-	// bundle). order holds cluster indices sorted ascending by dispersion.
+	// Rank by dispersion as a fraction in [0, 1], invariant to the absolute
+	// dispersion scale (which varies by bundle). order holds cluster indices
+	// sorted ascending by dispersion.
 	order := make([]int, k)
 	for i := range order {
 		order[i] = i
@@ -265,8 +265,21 @@ func computeQualityDispersionRank(qualityMeans Rankings, models []string, k int)
 		}
 		return ranks
 	}
-	for pos, cluster := range order {
-		ranks[cluster] = float64(pos) / float64(k-1)
+	// Assign mid-ranks: clusters with equal dispersion share the average of
+	// their positions, so tied clusters get identical alphas regardless of
+	// their arbitrary order in the bundle. Walk the sorted slice in equal-value
+	// groups.
+	for i := 0; i < k; {
+		j := i + 1
+		for j < k && disp[order[j]] == disp[order[i]] {
+			j++
+		}
+		midPos := float64(i+j-1) / 2 // average of positions i..j-1
+		rank := midPos / float64(k-1)
+		for p := i; p < j; p++ {
+			ranks[order[p]] = rank
+		}
+		i = j
 	}
 	return ranks
 }
@@ -294,15 +307,11 @@ func deriveClusterAlpha(t, rank, spread float64) float64 {
 	if t >= 1 {
 		return 1
 	}
+	// For t in (0, 1) and gamma > 0 (guaranteed: spread > 0 so gamma =
+	// spread^(1-2*rank) is strictly positive), t^gamma is always in (0, 1) —
+	// no clamp needed.
 	gamma := math.Pow(spread, 1-2*rank)
-	a := math.Pow(t, gamma)
-	if a < 0 {
-		return 0
-	}
-	if a > 1 {
-		return 1
-	}
-	return a
+	return math.Pow(t, gamma)
 }
 
 // qualityBiasDispersionSpread is the fan-out factor for deriveClusterAlpha. At

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -4,7 +4,22 @@ package router
 import "context"
 
 type Overrides struct {
-	Alpha                *float64
+	// Alpha is the raw per-cluster quality weight, applied UNIFORMLY across
+	// every cluster (the "sledgehammer"). This is the eval/debug lever set by
+	// the x-weave-routing-alpha header; it deliberately ignores per-cluster
+	// quality dispersion so a bake-off can probe a single global alpha.
+	Alpha *float64
+	// QualityBias is the user-facing "quality vs price" dial in [0, 1] (0 =
+	// fully price, 1 = fully quality). Unlike Alpha, it is NOT applied
+	// uniformly: the scorer derives a per-cluster alpha from each cluster's
+	// quality dispersion (see deriveClusterAlpha), so the slider's midrange
+	// produces a real model mix instead of a cliff. The endpoints still pin to
+	// all-cheapest (0) and all-top-quality (1). Set by the per-installation
+	// routing-preference dial. routingKnobsForRequest returns either the header
+	// knobs or the installation knobs, never a merge, so Alpha and QualityBias
+	// do not normally coexist; if both are set, QualityBias wins (it is the
+	// higher-level intent).
+	QualityBias          *float64
 	SpeedWeight          *float64
 	OutputCostRatio      *float64
 	ExpectedOutputTokens *int

--- a/internal/server/middleware/auth.go
+++ b/internal/server/middleware/auth.go
@@ -111,8 +111,11 @@ func withAPIKey(svc *auth.Service, byokDisabled bool) gin.HandlerFunc {
 				ctx = context.WithValue(ctx, proxy.InstallationExcludedProvidersContextKey{}, installation.ExcludedProviders)
 			}
 			if installation.RoutingQualityWeight != nil {
+				// The stored weight is the user-facing dial position, so it
+				// flows in as QualityBias (per-cluster, dispersion-aware), not
+				// the uniform Alpha sledgehammer. See router.Overrides.
 				ctx = context.WithValue(ctx, proxy.InstallationRoutingKnobsContextKey{}, &router.Overrides{
-					Alpha: installation.RoutingQualityWeight,
+					QualityBias: installation.RoutingQualityWeight,
 				})
 			}
 		}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -77,6 +77,16 @@ func Register(engine *gin.Engine, authSvc *auth.Service, proxySvc *proxy.Service
 	// route in tests that don't wire a cluster scorer.
 	if deployedModels != nil {
 		engine.GET("/v1/router/models", middleware.WithTimeout(healthTimeout), admin.CatalogModelsHandler(deployedModels))
+
+		// /v1/router/routing-distribution projects the per-installation "quality
+		// vs price" dial's model mix across a grid of dial positions, so the
+		// dashboard can render the live distribution preview and calibrate the
+		// slider. Same read-only/unauthed rationale as /v1/router/models. The
+		// source is the same *cluster.Multiversion; the assertion skips the
+		// route for a deployedModels source that can't project a distribution.
+		if dist, ok := deployedModels.(admin.RoutingDistributionSource); ok {
+			engine.GET("/v1/router/routing-distribution", middleware.WithTimeout(healthTimeout), admin.RoutingDistributionHandler(dist))
+		}
 	}
 
 	// /validate is a token-validity probe used by clients (not the dashboard), so it stays mounted in both modes.


### PR DESCRIPTION
## Problem

The per-installation **quality vs price** dial flowed into the scorer as a single `Alpha` applied **uniformly across all 16 clusters**. Since each cluster min-max normalizes quality/cost independently, a uniform alpha makes every cluster cross cheap→opus at nearly the same dial position — a **cliff, not a gradient**. In practice the midpoint dumped all traffic to the cheapest model and the tuned default sent all of it to opus, so most of the slider was a dead zone.

## What changed

**1. `QualityBias` knob (per-cluster, dispersion-aware).**
The dial now arrives as `router.Overrides.QualityBias` — a single `t ∈ [0,1]` — instead of `Alpha`. The scorer derives a **per-cluster** alpha:

```
alpha[k] = t ^ gamma_k,   gamma_k = spread ^ (1 - 2*rank_k)
```

`rank_k` is cluster `k`'s quality-dispersion rank, precomputed in `NewScorer` from the **raw** `quality_means` spread (before the per-cluster normalization that flattens it — which is what collapsed the crossovers into one cliff). High-dispersion clusters (strong models much better than cheap ones) carry more quality weight at the same dial setting and hold quality models down to a low dial; low-dispersion clusters demote to cheap early. `t^gamma` pins to 0 at `t=0` and 1 at `t=1` for every gamma, so the **endpoints still resolve to all-cheapest / best-per-cluster** — only the midrange fans out into a real mix.

The `x-weave-routing-alpha` header keeps its uniform "sledgehammer" semantics for eval/bake-offs (unchanged).

**2. `GET /v1/router/routing-distribution`.**
Projects the dial's model mix across a grid of positions by routing each cluster centroid through the **same** scoring path as live traffic (`deriveClusterAlpha → blendScoresV2 → argmax`), tallying winners, plus the share-weighted input cost at each position. Drives the Weave dashboard's live distribution preview and slider calibration. Read-only/unauthed, mounted like `/v1/router/models`.

To avoid drift, the v2 blend is extracted into `Scorer.blendScoresV2` (shared by `Route` and the preview) and default-knob construction into `defaultActiveKnobs`.

## Verification

Against the live **v0.67** bundle, the projected cost ramps smoothly `$0.00010 → $0.00387`/1k with 3–4 models mixing through the midrange (no cliff). Unit tests cover `deriveClusterAlpha` endpoints/monotonicity/dispersion-ordering, dispersion ranking, the distribution endpoint (endpoints + gradient on the real bundle), and the handler. Full suite green; `go vet` + `gofmt` clean.

Two honest findings the preview now surfaces (reality, not bugs):
- **Price extreme is `gemini-3.1-flash-lite`** (cheapest at $0.0001), not deepseek-v4-flash.
- **Quality extreme is ~62% opus / 38% gemini-3.1-pro** (best-per-cluster on corrected labels) and plateaus from `t≈0.8`; the dashboard maps the slider onto the active `0→0.8` band using the returned curve.

## Follow-up (WorkWeave side, separate PR)
Bump the gitlink, send `QualityBias` from the stored dial weight, add a GraphQL passthrough for the distribution curve, and render the live model-mix bar + calibrated handle in `RoutingPriorityPanel`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)