### PR TITLE
feat(install): use a caller's Codex subscription for their opencode turns

### DIFF
--- a/install/install.sh
+++ b/install/install.sh
@@ -631,27 +631,45 @@ write_opencode_config() {
     }
   ')"
 
-  # Absolute path of the plugin we drop below; registered in opencode.json's
-  # `plugin` array so it loads regardless of scope. $config_file's dir is the
-  # already-created opencode_dir, so dirname is safe to resolve.
-  local plugin_dir plugin_spec
+  # Drop the Codex-subscription plugin next to the config and capture the
+  # absolute path we'll register in opencode.json's `plugin` array (so it loads
+  # regardless of scope). $config_file's dir is the already-created
+  # opencode_dir, so the `cd … && pwd` canonicalization is safe — uninstall.sh
+  # must canonicalize identically so the array entry matches on removal.
+  #
+  # Only register the path when the bundled source is actually present and
+  # copied: registering a path with no file on disk makes opencode fail to load
+  # a missing plugin. The plugin holds no secrets (router key lives in the
+  # config; ChatGPT tokens live in opencode's own auth store), so 644 is fine.
+  # Source is bundled alongside install.sh by the npm prepack
+  # (scripts/copy-installer.js), same as commands/ + pi-router/.
+  local plugin_dir plugin_spec plugin_src plugin_arg=""
   plugin_dir="$(cd "$(dirname "$config_file")" && pwd)/.weave"
   plugin_spec="$plugin_dir/opencode-weave.ts"
+  plugin_src="$script_dir/opencode-weave/src/index.ts"
+  if [ -f "$plugin_src" ]; then
+    mkdir -p "$plugin_dir"
+    cp "$plugin_src" "$plugin_spec"
+    chmod 644 "$plugin_spec"
+    plugin_arg="$plugin_spec"
+  else
+    warn "opencode Codex plugin source not found at $plugin_src — skipping the weave-codex plugin registration. (Use a packaged 'npx @workweave/router' install.)"
+  fi
 
   # Merge into any existing opencode.json. We always overwrite provider.weave
   # and provider."weave-codex" so re-install reflects the latest key/identity,
   # but we leave the rest of the file (other providers, mcp, agent settings)
   # untouched. Top-level `model` is only set when the user hasn't already
-  # picked one. The plugin path is added to `plugin` and de-duplicated so
-  # re-runs don't append it twice.
+  # picked one. The plugin path is added to `plugin` (de-duplicated so re-runs
+  # don't append it twice) only when we actually wrote the file above.
   local merged
   if [ -f "$config_file" ]; then
     merged="$(jq \
       --argjson block "$block" \
       --argjson codex "$codex_block" \
-      --arg plugin "$plugin_spec" '
+      --arg plugin "$plugin_arg" '
       .provider = ((.provider // {}) | .weave = $block | ."weave-codex" = $codex)
-      | .plugin = (((.plugin // []) + [$plugin]) | unique)
+      | (if $plugin != "" then .plugin = (((.plugin // []) + [$plugin]) | unique) else . end)
       | (if (.model // "") == "" then .model = "weave/claude-sonnet-4-6" else . end)
       | (.["$schema"] //= "https://opencode.ai/config.json")
     ' "$config_file")"
@@ -659,32 +677,19 @@ write_opencode_config() {
     merged="$(jq -n \
       --argjson block "$block" \
       --argjson codex "$codex_block" \
-      --arg plugin "$plugin_spec" '
+      --arg plugin "$plugin_arg" '
       {
         "$schema": "https://opencode.ai/config.json",
         model: "weave/claude-sonnet-4-6",
-        provider: { weave: $block, "weave-codex": $codex },
-        plugin: [$plugin]
+        provider: { weave: $block, "weave-codex": $codex }
       }
+      | (if $plugin != "" then .plugin = [$plugin] else . end)
     ')"
   fi
   printf '%s\n' "$merged" >"$config_file"
   # 0600: the file holds a router key. Even at user scope, mode 644 would
   # leak the key to any local user on a shared box.
   chmod 600 "$config_file"
-
-  # Drop the Codex-subscription plugin next to the config. The plugin holds no
-  # secrets (router key lives in the config; ChatGPT tokens live in opencode's
-  # own auth store), so 644 is fine. Source is bundled alongside install.sh by
-  # the npm prepack (scripts/copy-installer.js), same as commands/ + pi-router/.
-  local plugin_src="$script_dir/opencode-weave/src/index.ts"
-  if [ -f "$plugin_src" ]; then
-    mkdir -p "$plugin_dir"
-    cp "$plugin_src" "$plugin_spec"
-    chmod 644 "$plugin_spec"
-  else
-    warn "opencode Codex plugin source not found at $plugin_src — the weave-codex provider won't load until it's present. (Use a packaged 'npx @workweave/router' install.)"
-  fi
 }
 
 # write_pi_models_config merges a managed `weave` provider into pi's

--- a/install/install.sh
+++ b/install/install.sh
@@ -669,7 +669,7 @@ write_opencode_config() {
       --argjson codex "$codex_block" \
       --arg plugin "$plugin_arg" '
       .provider = ((.provider // {}) | .weave = $block | ."weave-codex" = $codex)
-      | (if $plugin != "" then .plugin = (((.plugin // []) + [$plugin]) | unique) else . end)
+      | (if $plugin != "" then .plugin = ((.plugin // []) | if index($plugin) then . else . + [$plugin] end) else . end)
       | (if (.model // "") == "" then .model = "weave/claude-sonnet-4-6" else . end)
       | (.["$schema"] //= "https://opencode.ai/config.json")
     ' "$config_file")"

--- a/install/install.sh
+++ b/install/install.sh
@@ -533,13 +533,20 @@ TOML
   chmod 600 "$config_file"
 }
 
-# write_opencode_config merges a managed `provider.weave` entry into opencode's
-# opencode.json (anthropic-compatible — the router speaks the Anthropic
-# Messages API natively, so opencode's bundled @ai-sdk/anthropic provider
-# works unmodified). Re-running rewrites the block in-place via jq; uninstall
-# strips it the same way. We also set `model` at the top level so a fresh
-# `opencode` invocation picks the router by default; if the user has set
-# their own model already, we leave it alone.
+# write_opencode_config merges TWO managed providers into opencode's
+# opencode.json plus the bundled Codex-subscription plugin:
+#   - provider.weave        : Anthropic-shaped (@ai-sdk/anthropic) — the router
+#                             speaks the Anthropic Messages API natively, so the
+#                             bundled provider works unmodified. The default.
+#   - provider.weave-codex  : OpenAI-shaped (@ai-sdk/openai, Responses wire) —
+#                             lets a caller's own ChatGPT (Codex) subscription
+#                             pay for their opencode turns. Dormant until the
+#                             user runs `opencode auth login` → ChatGPT and the
+#                             weave-codex plugin's loader injects the bearer.
+# The plugin (src bundled at $script_dir/opencode-weave/src/index.ts) is dropped
+# into $opencode_dir/.weave/ and registered via opencode.json's `plugin` array
+# by absolute path — scope-independent (no reliance on an auto-load dir).
+# Re-running rewrites both blocks in-place via jq; uninstall strips them.
 #
 # Usage: write_opencode_config <config_file_path> <base_url> <api_key> [user_email] [user_name]
 write_opencode_config() {
@@ -601,23 +608,63 @@ write_opencode_config() {
     }
   ')"
 
+  # The OpenAI-shaped Codex-subscription provider. Reuses the same X-Weave-*
+  # header triplet (router key + identity) — the plugin's loader adds only the
+  # dynamic subscription Authorization + ChatGPT-Account-Id on top. baseURL
+  # KEEPS /v1: opencode's @ai-sdk/openai provider appends /responses, yielding
+  # the router's /v1/responses Codex passthrough. apiKey is the router key as a
+  # parse-time placeholder (the loader overrides it once a subscription is
+  # linked), mirroring the weave block above.
+  local codex_block
+  codex_block="$(jq -n \
+    --arg url "$block_url/v1" \
+    --arg key "$block_key" \
+    --argjson headers "$headers_json" '
+    {
+      npm: "@ai-sdk/openai",
+      name: "Weave Router (Codex subscription)",
+      options: { apiKey: $key, baseURL: $url, headers: $headers },
+      models: {
+        "gpt-5.5": { name: "GPT-5.5 — Codex subscription (via Weave Router)" },
+        "gpt-5.4": { name: "GPT-5.4 — Codex subscription (via Weave Router)" }
+      }
+    }
+  ')"
+
+  # Absolute path of the plugin we drop below; registered in opencode.json's
+  # `plugin` array so it loads regardless of scope. $config_file's dir is the
+  # already-created opencode_dir, so dirname is safe to resolve.
+  local plugin_dir plugin_spec
+  plugin_dir="$(cd "$(dirname "$config_file")" && pwd)/.weave"
+  plugin_spec="$plugin_dir/opencode-weave.ts"
+
   # Merge into any existing opencode.json. We always overwrite provider.weave
-  # so re-install reflects the latest key/identity, but we leave the rest of
-  # the file (other providers, mcp, agent settings) untouched. Top-level
-  # `model` is only set when the user hasn't already picked one.
+  # and provider."weave-codex" so re-install reflects the latest key/identity,
+  # but we leave the rest of the file (other providers, mcp, agent settings)
+  # untouched. Top-level `model` is only set when the user hasn't already
+  # picked one. The plugin path is added to `plugin` and de-duplicated so
+  # re-runs don't append it twice.
   local merged
   if [ -f "$config_file" ]; then
-    merged="$(jq --argjson block "$block" '
-      .provider = ((.provider // {}) | .weave = $block)
+    merged="$(jq \
+      --argjson block "$block" \
+      --argjson codex "$codex_block" \
+      --arg plugin "$plugin_spec" '
+      .provider = ((.provider // {}) | .weave = $block | ."weave-codex" = $codex)
+      | .plugin = (((.plugin // []) + [$plugin]) | unique)
       | (if (.model // "") == "" then .model = "weave/claude-sonnet-4-6" else . end)
       | (.["$schema"] //= "https://opencode.ai/config.json")
     ' "$config_file")"
   else
-    merged="$(jq -n --argjson block "$block" '
+    merged="$(jq -n \
+      --argjson block "$block" \
+      --argjson codex "$codex_block" \
+      --arg plugin "$plugin_spec" '
       {
         "$schema": "https://opencode.ai/config.json",
         model: "weave/claude-sonnet-4-6",
-        provider: { weave: $block }
+        provider: { weave: $block, "weave-codex": $codex },
+        plugin: [$plugin]
       }
     ')"
   fi
@@ -625,6 +672,19 @@ write_opencode_config() {
   # 0600: the file holds a router key. Even at user scope, mode 644 would
   # leak the key to any local user on a shared box.
   chmod 600 "$config_file"
+
+  # Drop the Codex-subscription plugin next to the config. The plugin holds no
+  # secrets (router key lives in the config; ChatGPT tokens live in opencode's
+  # own auth store), so 644 is fine. Source is bundled alongside install.sh by
+  # the npm prepack (scripts/copy-installer.js), same as commands/ + pi-router/.
+  local plugin_src="$script_dir/opencode-weave/src/index.ts"
+  if [ -f "$plugin_src" ]; then
+    mkdir -p "$plugin_dir"
+    cp "$plugin_src" "$plugin_spec"
+    chmod 644 "$plugin_spec"
+  else
+    warn "opencode Codex plugin source not found at $plugin_src — the weave-codex provider won't load until it's present. (Use a packaged 'npx @workweave/router' install.)"
+  fi
 }
 
 # write_pi_models_config merges a managed `weave` provider into pi's
@@ -1716,18 +1776,20 @@ if [ "$target" = "opencode" ]; then
 
   # Project scope: the per-teammate config carries the router key, so it
   # stays out of git. Same reasoning as the Codex path — base URL is shared,
-  # but the key is per-person.
+  # but the key is per-person. The .weave/ plugin dir is per-person too (the
+  # config references it by absolute path), so ignore it alongside.
   if [ "$scope" = "project" ] && [ -z "$install_dir" ] && [ -n "${git_root:-}" ]; then
     gitignore="$git_root/.gitignore"
     refuse_if_symlink "$gitignore"
     for entry in \
-      "opencode.json"
+      "opencode.json" \
+      ".weave/"
     do
       if [ ! -f "$gitignore" ] || ! grep -qxF "$entry" "$gitignore"; then
         printf '%s\n' "$entry" >>"$gitignore"
       fi
     done
-    ok "Updated $gitignore (ignored opencode.json)"
+    ok "Updated $gitignore (ignored opencode.json, .weave/)"
   fi
 
   # Post-install verification: same probes the Claude/Codex paths run.
@@ -1750,6 +1812,9 @@ if [ "$target" = "opencode" ]; then
   printf "\n"
   printf "%s✓%s %s%sWeave Router installed for opencode.%s\n" \
     "$C_GREEN" "$C_RESET" "$C_BOLD" "$C_BRAND" "$C_RESET"
+  # Surface the optional Codex-subscription path. The weave-codex provider +
+  # plugin are installed but dormant until the user links their ChatGPT plan.
+  info "To pay for opencode turns with your own ChatGPT (Codex) subscription: run ${C_BOLD}opencode auth login${C_RESET} → ${C_BOLD}ChatGPT Pro/Plus${C_RESET}, then pick a ${C_BOLD}weave-codex${C_RESET} model."
   if [ -n "$install_dir" ]; then
     # --dir installs land outside opencode's discovery roots, so the caller
     # has to point opencode at the file explicitly.

--- a/install/npm/.gitignore
+++ b/install/npm/.gitignore
@@ -6,6 +6,7 @@ uninstall.sh
 cc-statusline.sh
 commands/
 pi-router/
+opencode-weave/
 LICENSE
 
 # Local `npm pack` / `npm install <tarball>` artifacts. The package has no

--- a/install/npm/package.json
+++ b/install/npm/package.json
@@ -17,6 +17,7 @@
     "cc-statusline.sh",
     "commands/",
     "pi-router/",
+    "opencode-weave/",
     "README.md",
     "LICENSE"
   ],

--- a/install/npm/scripts/copy-installer.js
+++ b/install/npm/scripts/copy-installer.js
@@ -56,6 +56,19 @@ for (const f of ["package.json", "README.md"]) {
 }
 console.log("Copied pi-router/ (extension).");
 
+// Bundle the opencode Codex-subscription plugin the same way. install.sh
+// (--codex/--opencode) drops opencode-weave/src/index.ts into the user's
+// opencode plugins dir and registers it via opencode.json's "plugin" array.
+// Source of truth lives at install/opencode-weave/src.
+const ocSrc = path.join(installDir, "opencode-weave", "src");
+const ocDst = path.join(root, "opencode-weave", "src");
+mkdirSync(path.dirname(ocDst), { recursive: true });
+cpSync(ocSrc, ocDst, { recursive: true });
+for (const f of ["package.json", "README.md"]) {
+  copyFileSync(path.join(installDir, "opencode-weave", f), path.join(root, "opencode-weave", f));
+}
+console.log("Copied opencode-weave/ (plugin).");
+
 // LICENSE lives at the repo root and applies to the whole project. npm
 // surfaces it on the package page when bundled alongside package.json.
 copyFileSync(path.join(repoRoot, "LICENSE"), path.join(root, "LICENSE"));

--- a/install/opencode-weave/README.md
+++ b/install/opencode-weave/README.md
@@ -1,0 +1,59 @@
+# opencode Weave Codex plugin
+
+Lets a caller's own **ChatGPT (Codex) subscription** pay for their **opencode**
+turns, routed through the Weave Router. Bundled into `@workweave/router`; the
+installer (`--codex` / `--opencode`) drops `src/index.ts` into the user's
+opencode plugins dir and writes a matching `weave-codex` provider block into
+`opencode.json`.
+
+## Why a plugin (config alone can't do it)
+
+opencode removed built-in subscription auth in 1.3.0 and binds OAuth to its own
+first-party providers — its bundled `openai/codex.ts` plugin hardcodes the
+upstream to `chatgpt.com` and binds provider id `openai`, so a custom router
+provider can't reuse it. And a subscription needs the caller's OAuth token in
+`Authorization`, which expires hourly — a static `options.headers` string can't
+refresh it.
+
+This plugin re-implements the same ChatGPT OAuth + refresh against a **custom**
+provider id (`weave-codex`) and, crucially, **leaves the request URL on the
+Weave Router** instead of rewriting it to `chatgpt.com`.
+
+## Wire shape it produces
+
+Matches the router's `/v1/responses` Codex passthrough:
+
+| | |
+|---|---|
+| `POST {router}/v1/responses` | Responses wire format (opencode's default for an `@ai-sdk/openai` provider) |
+| `Authorization: Bearer <ChatGPT JWT>` | the caller's subscription, refreshed on expiry |
+| `ChatGPT-Account-Id: <id>` | paired account id (required by the Codex backend) |
+| `X-Weave-Router-Key: rk_…` | from `opencode.json` `options.headers` — the router authenticates off this, leaving `Authorization` free for the JWT |
+| `originator`, `session-id` | from the plugin's `chat.headers` hook (Codex backend session continuity) |
+
+The router detects the inbound Codex bearer and serves the turn on the caller's
+own plan at the subscription fee.
+
+## Division of responsibility
+
+- **Installer** writes the router key + identity headers (`X-Weave-Router-Key`,
+  `X-App`, `X-Weave-User-Email`) into `opencode.json` `options.headers`.
+- **This plugin** manages only the dynamic, secret, refreshable subscription
+  credential (the `Authorization` bearer + `ChatGPT-Account-Id`) via the auth
+  `loader`, and the login flow via auth `methods` (browser PKCE + headless
+  device code). Tokens are stored in opencode's own auth store under the
+  `weave-codex` provider id.
+
+## Env overrides
+
+- `WEAVE_CODEX_OAUTH_ISSUER` — override the OpenAI auth issuer (self-hosted
+  OpenAI auth proxies; also used by the capture tests).
+
+## Verification
+
+Capture-tested end-to-end against a local server standing in for the router
+(opencode 1.17.9, real ChatGPT login): the inject path forwards the real JWT +
+account-id in Responses format to `/v1/responses`, and the refresh path detects
+an expired token, refreshes against the issuer, rotates + persists the tokens,
+and injects the refreshed bearer. Typechecks under `strict` against
+`@opencode-ai/plugin`.

--- a/install/opencode-weave/package.json
+++ b/install/opencode-weave/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@workweave/router-opencode-extension",
+  "private": true,
+  "type": "module",
+  "description": "The opencode Codex-subscription auth plugin bundled into @workweave/router. NOT published separately: src/ is copied into the @workweave/router package at prepack and dropped into the user's opencode plugins dir by install.sh (--codex/--opencode). Lets a caller's own ChatGPT (Codex) subscription pay for their opencode turns, routed through the Weave Router. This manifest just marks the sources as ESM and declares the opencode peer dep for local typecheck.",
+  "peerDependencies": {
+    "@opencode-ai/plugin": "*"
+  }
+}

--- a/install/opencode-weave/src/index.ts
+++ b/install/opencode-weave/src/index.ts
@@ -295,7 +295,10 @@ export const WeaveCodex: Plugin = async (input: PluginInput): Promise<Hooks> => 
                       path: { id: PROVIDER_ID },
                       body: {
                         type: "oauth",
-                        refresh: tokens.refresh_token,
+                        // OAuth 2.0 lets the issuer omit a new refresh_token on
+                        // refresh (the existing one stays valid). Keep the
+                        // stored one in that case rather than clearing it.
+                        refresh: tokens.refresh_token || currentAuth.refresh,
                         access: tokens.access_token,
                         expires: Date.now() + (tokens.expires_in ?? 3600) * 1000,
                         ...(accountId && { accountId }),

--- a/install/opencode-weave/src/index.ts
+++ b/install/opencode-weave/src/index.ts
@@ -1,0 +1,423 @@
+/**
+ * @workweave/router — use a caller's ChatGPT (Codex) subscription for their
+ * opencode turns, routed through the Weave Router.
+ *
+ * opencode removed built-in subscription auth in 1.3.0 and binds OAuth to its
+ * own first-party providers (the bundled `openai/codex.ts` plugin hardcodes the
+ * upstream to chatgpt.com and binds provider "openai"), so a custom router
+ * provider can't reuse it. This plugin re-implements the same ChatGPT OAuth +
+ * refresh against a CUSTOM provider id (`weave-codex`) and, crucially, leaves
+ * the request URL pointed at the Weave Router instead of chatgpt.com.
+ *
+ * Wire shape produced (matches the router's /v1/responses Codex passthrough):
+ *   - POST {router}/v1/responses                       (Responses wire format)
+ *   - Authorization: Bearer <ChatGPT JWT>              (the caller's subscription)
+ *   - ChatGPT-Account-Id: <account id>                 (paired, required by Codex backend)
+ *   - X-Weave-Router-Key: rk_...                       (from config options.headers)
+ *
+ * The router authenticates off X-Weave-Router-Key (so Authorization is free for
+ * the subscription JWT), detects the inbound Codex bearer, and serves the turn
+ * on the caller's own plan at the subscription fee. The router key + identity
+ * headers (X-App, X-Weave-User-Email) live in opencode.json `options.headers`
+ * written by the installer; this plugin manages only the dynamic, refreshable
+ * subscription credential.
+ */
+
+import type { Hooks, Plugin, PluginInput } from "@opencode-ai/plugin"
+
+const CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann"
+// Overridable for self-hosted OpenAI auth proxies and for tests (mirrors the
+// bundled codex plugin's `options.issuer`).
+const ISSUER = process.env.WEAVE_CODEX_OAUTH_ISSUER ?? "https://auth.openai.com"
+const OAUTH_PORT = 1455
+const OAUTH_POLLING_SAFETY_MARGIN_MS = 3000
+// Provider id this plugin owns. Must match the provider block the installer
+// writes into opencode.json. Deliberately NOT "openai" — that id is claimed by
+// opencode's bundled codex plugin, which rewrites the upstream to chatgpt.com.
+const PROVIDER_ID = "weave-codex"
+// Placeholder so the @ai-sdk/openai provider considers auth configured; the
+// loader's fetch overwrites Authorization with the real subscription bearer.
+const DUMMY_KEY = "weave-router-oauth"
+const USER_AGENT = "weave-router-opencode"
+
+interface PkceCodes {
+  verifier: string
+  challenge: string
+}
+
+function base64UrlEncode(buffer: ArrayBuffer): string {
+  const bytes = new Uint8Array(buffer)
+  const binary = String.fromCharCode(...bytes)
+  return btoa(binary)
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "")
+}
+
+async function generatePKCE(): Promise<PkceCodes> {
+  const chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~"
+  const verifier = Array.from(crypto.getRandomValues(new Uint8Array(43)))
+    .map((b) => chars[b % chars.length])
+    .join("")
+  const challenge = base64UrlEncode(await crypto.subtle.digest("SHA-256", new TextEncoder().encode(verifier)))
+  return { verifier, challenge }
+}
+
+interface IdTokenClaims {
+  chatgpt_account_id?: string
+  organizations?: Array<{ id: string }>
+  "https://api.openai.com/auth"?: { chatgpt_account_id?: string }
+}
+
+function parseJwtClaims(token: string): IdTokenClaims | undefined {
+  const parts = token.split(".")
+  if (parts.length !== 3) return undefined
+  try {
+    return JSON.parse(Buffer.from(parts[1], "base64url").toString())
+  } catch {
+    return undefined
+  }
+}
+
+function extractAccountIdFromClaims(claims: IdTokenClaims): string | undefined {
+  return (
+    claims.chatgpt_account_id ||
+    claims["https://api.openai.com/auth"]?.chatgpt_account_id ||
+    claims.organizations?.[0]?.id
+  )
+}
+
+function extractAccountId(tokens: TokenResponse): string | undefined {
+  if (tokens.id_token) {
+    const claims = parseJwtClaims(tokens.id_token)
+    const accountId = claims && extractAccountIdFromClaims(claims)
+    if (accountId) return accountId
+  }
+  if (tokens.access_token) {
+    const claims = parseJwtClaims(tokens.access_token)
+    return claims ? extractAccountIdFromClaims(claims) : undefined
+  }
+  return undefined
+}
+
+interface TokenResponse {
+  id_token: string
+  access_token: string
+  refresh_token: string
+  expires_in?: number
+}
+
+function buildAuthorizeUrl(redirectUri: string, pkce: PkceCodes, state: string): string {
+  const params = new URLSearchParams({
+    response_type: "code",
+    client_id: CLIENT_ID,
+    redirect_uri: redirectUri,
+    scope: "openid profile email offline_access",
+    code_challenge: pkce.challenge,
+    code_challenge_method: "S256",
+    id_token_add_organizations: "true",
+    codex_cli_simplified_flow: "true",
+    state,
+    originator: "codex_cli_ts",
+  })
+  return `${ISSUER}/oauth/authorize?${params.toString()}`
+}
+
+async function exchangeCodeForTokens(code: string, redirectUri: string, pkce: PkceCodes): Promise<TokenResponse> {
+  const response = await fetch(`${ISSUER}/oauth/token`, {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({
+      grant_type: "authorization_code",
+      code,
+      redirect_uri: redirectUri,
+      client_id: CLIENT_ID,
+      code_verifier: pkce.verifier,
+    }).toString(),
+  })
+  if (!response.ok) throw new Error(`Token exchange failed: ${response.status}`)
+  return response.json() as Promise<TokenResponse>
+}
+
+async function refreshAccessToken(refreshToken: string): Promise<TokenResponse> {
+  const response = await fetch(`${ISSUER}/oauth/token`, {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({
+      grant_type: "refresh_token",
+      refresh_token: refreshToken,
+      client_id: CLIENT_ID,
+    }).toString(),
+  })
+  if (!response.ok) throw new Error(`Token refresh failed: ${response.status}`)
+  return response.json() as Promise<TokenResponse>
+}
+
+// ---- Browser OAuth loopback server (PKCE) --------------------------------
+
+function escapeHtml(s: string): string {
+  return s.replace(/[&<>"']/g, (c) =>
+    ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" })[c] as string,
+  )
+}
+
+const HTML_SUCCESS = `<!doctype html><html><head><title>Weave Router — Codex authorized</title></head>
+<body style="font-family:system-ui;background:#131010;color:#f1ecec;display:flex;justify-content:center;align-items:center;height:100vh;margin:0">
+<div style="text-align:center"><h1>Authorization successful</h1><p>You can close this window and return to opencode.</p>
+<script>setTimeout(()=>window.close(),2000)</script></div></body></html>`
+
+const renderOAuthError = (error: string) => `<!doctype html><html><head><title>Weave Router — Codex authorization failed</title></head>
+<body style="font-family:system-ui;background:#131010;color:#f1ecec;display:flex;justify-content:center;align-items:center;height:100vh;margin:0">
+<div style="text-align:center"><h1 style="color:#fc533a">Authorization failed</h1>
+<div style="color:#ff917b;font-family:monospace;margin-top:1rem;padding:1rem;background:#3c140d;border-radius:.5rem">${escapeHtml(error)}</div></div></body></html>`
+
+interface PendingOAuth {
+  pkce: PkceCodes
+  state: string
+  resolve: (tokens: TokenResponse) => void
+  reject: (error: Error) => void
+}
+
+let oauthServer: import("http").Server | undefined
+let pendingOAuth: PendingOAuth | undefined
+
+async function startOAuthServer(): Promise<{ redirectUri: string }> {
+  const redirectUri = `http://localhost:${OAUTH_PORT}/auth/callback`
+  if (oauthServer) return { redirectUri }
+  const { createServer } = await import("node:http")
+  oauthServer = createServer((req, res) => {
+    const url = new URL(req.url || "/", `http://localhost:${OAUTH_PORT}`)
+    if (url.pathname !== "/auth/callback") {
+      res.writeHead(404)
+      res.end("Not found")
+      return
+    }
+    const code = url.searchParams.get("code")
+    const state = url.searchParams.get("state")
+    const error = url.searchParams.get("error_description") || url.searchParams.get("error")
+    const fail = (status: number, msg: string) => {
+      pendingOAuth?.reject(new Error(msg))
+      pendingOAuth = undefined
+      res.writeHead(status, { "Content-Type": "text/html; charset=utf-8" })
+      res.end(renderOAuthError(msg))
+    }
+    if (error) return fail(200, error)
+    if (!code) return fail(400, "Missing authorization code")
+    if (!pendingOAuth || state !== pendingOAuth.state) return fail(400, "Invalid state - potential CSRF attack")
+    const current = pendingOAuth
+    pendingOAuth = undefined
+    exchangeCodeForTokens(code, redirectUri, current.pkce)
+      .then((tokens) => current.resolve(tokens))
+      .catch((err) => current.reject(err))
+    res.writeHead(200, { "Content-Type": "text/html; charset=utf-8" })
+    res.end(HTML_SUCCESS)
+  })
+  await new Promise<void>((resolve, reject) => {
+    oauthServer!.listen(OAUTH_PORT, resolve)
+    oauthServer!.on("error", reject)
+  })
+  return { redirectUri }
+}
+
+function stopOAuthServer(): void {
+  oauthServer?.close(() => {})
+  oauthServer = undefined
+}
+
+function waitForOAuthCallback(pkce: PkceCodes, state: string): Promise<TokenResponse> {
+  return new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      if (pendingOAuth) {
+        pendingOAuth = undefined
+        reject(new Error("OAuth callback timeout - authorization took too long"))
+      }
+    }, 5 * 60 * 1000)
+    pendingOAuth = {
+      pkce,
+      state,
+      resolve: (tokens) => {
+        clearTimeout(timeout)
+        resolve(tokens)
+      },
+      reject: (error) => {
+        clearTimeout(timeout)
+        reject(error)
+      },
+    }
+  })
+}
+
+// ---- Plugin --------------------------------------------------------------
+
+export const WeaveCodex: Plugin = async (input: PluginInput): Promise<Hooks> => {
+  return {
+    auth: {
+      provider: PROVIDER_ID,
+      async loader(getAuth) {
+        const auth = await getAuth()
+        if (auth.type !== "oauth") return {}
+
+        // Coalesce concurrent refreshes (opencode fires parallel turns).
+        let refreshPromise: Promise<{ access: string; accountId: string | undefined }> | undefined
+
+        return {
+          apiKey: DUMMY_KEY,
+          async fetch(requestInput: RequestInfo | URL, init?: RequestInit) {
+            const currentAuth = (await getAuth()) as {
+              type: string
+              access: string
+              refresh: string
+              expires: number
+              accountId?: string
+            }
+            if (currentAuth.type !== "oauth") return fetch(requestInput, init)
+
+            // Refresh the access token on (or just before) expiry and persist
+            // the rotated refresh token back into opencode's auth store.
+            if (!currentAuth.access || currentAuth.expires < Date.now()) {
+              if (!refreshPromise) {
+                refreshPromise = refreshAccessToken(currentAuth.refresh)
+                  .then(async (tokens) => {
+                    const accountId = extractAccountId(tokens) || currentAuth.accountId
+                    await input.client.auth.set({
+                      path: { id: PROVIDER_ID },
+                      body: {
+                        type: "oauth",
+                        refresh: tokens.refresh_token,
+                        access: tokens.access_token,
+                        expires: Date.now() + (tokens.expires_in ?? 3600) * 1000,
+                        ...(accountId && { accountId }),
+                      },
+                    })
+                    return { access: tokens.access_token, accountId }
+                  })
+                  .finally(() => {
+                    refreshPromise = undefined
+                  })
+              }
+              const refreshed = await refreshPromise
+              currentAuth.access = refreshed.access
+              currentAuth.accountId = refreshed.accountId
+            }
+
+            // Preserve the configured headers (X-Weave-Router-Key, X-App, ...
+            // from opencode.json options.headers), then overwrite Authorization
+            // with the caller's subscription bearer + the paired account id.
+            const headers = new Headers(init?.headers as HeadersInit | undefined)
+            headers.set("authorization", `Bearer ${currentAuth.access}`)
+            if (currentAuth.accountId) headers.set("ChatGPT-Account-Id", currentAuth.accountId)
+
+            // NOTE: unlike opencode's bundled codex plugin we deliberately do
+            // NOT rewrite the URL — the request stays on the Weave Router, which
+            // forwards it to the Codex backend on the caller's plan.
+            return fetch(requestInput, { ...init, headers })
+          },
+        }
+      },
+      methods: [
+        {
+          label: "ChatGPT Pro/Plus (browser)",
+          type: "oauth",
+          authorize: async () => {
+            const { redirectUri } = await startOAuthServer()
+            const pkce = await generatePKCE()
+            const state = base64UrlEncode(crypto.getRandomValues(new Uint8Array(32)).buffer)
+            const callbackPromise = waitForOAuthCallback(pkce, state)
+            return {
+              url: buildAuthorizeUrl(redirectUri, pkce, state),
+              instructions: "Complete authorization in your browser. This window will close automatically.",
+              method: "auto" as const,
+              callback: async () => {
+                const tokens = await callbackPromise
+                stopOAuthServer()
+                return {
+                  type: "success" as const,
+                  refresh: tokens.refresh_token,
+                  access: tokens.access_token,
+                  expires: Date.now() + (tokens.expires_in ?? 3600) * 1000,
+                  accountId: extractAccountId(tokens),
+                }
+              },
+            }
+          },
+        },
+        {
+          label: "ChatGPT Pro/Plus (headless device code)",
+          type: "oauth",
+          authorize: async () => {
+            const deviceResponse = await fetch(`${ISSUER}/api/accounts/deviceauth/usercode`, {
+              method: "POST",
+              headers: { "Content-Type": "application/json", "User-Agent": USER_AGENT },
+              body: JSON.stringify({ client_id: CLIENT_ID }),
+            })
+            if (!deviceResponse.ok) throw new Error("Failed to initiate device authorization")
+            const deviceData = (await deviceResponse.json()) as {
+              device_auth_id: string
+              user_code: string
+              interval: string
+            }
+            const interval = Math.max(parseInt(deviceData.interval) || 5, 1) * 1000
+            return {
+              url: `${ISSUER}/codex/device`,
+              instructions: `Enter code: ${deviceData.user_code}`,
+              method: "auto" as const,
+              async callback() {
+                const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms))
+                while (true) {
+                  const response = await fetch(`${ISSUER}/api/accounts/deviceauth/token`, {
+                    method: "POST",
+                    headers: { "Content-Type": "application/json", "User-Agent": USER_AGENT },
+                    body: JSON.stringify({
+                      device_auth_id: deviceData.device_auth_id,
+                      user_code: deviceData.user_code,
+                    }),
+                  })
+                  if (response.ok) {
+                    const data = (await response.json()) as { authorization_code: string; code_verifier: string }
+                    const tokenResponse = await fetch(`${ISSUER}/oauth/token`, {
+                      method: "POST",
+                      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+                      body: new URLSearchParams({
+                        grant_type: "authorization_code",
+                        code: data.authorization_code,
+                        redirect_uri: `${ISSUER}/deviceauth/callback`,
+                        client_id: CLIENT_ID,
+                        code_verifier: data.code_verifier,
+                      }).toString(),
+                    })
+                    if (!tokenResponse.ok) throw new Error(`Token exchange failed: ${tokenResponse.status}`)
+                    const tokens = (await tokenResponse.json()) as TokenResponse
+                    return {
+                      type: "success" as const,
+                      refresh: tokens.refresh_token,
+                      access: tokens.access_token,
+                      expires: Date.now() + (tokens.expires_in ?? 3600) * 1000,
+                      accountId: extractAccountId(tokens),
+                    }
+                  }
+                  if (response.status !== 403 && response.status !== 404) return { type: "failed" as const }
+                  await sleep(interval + OAUTH_POLLING_SAFETY_MARGIN_MS)
+                }
+              },
+            }
+          },
+        },
+      ],
+    },
+    // The Codex backend (which the router forwards to) keys session continuity
+    // off these headers; mirror opencode's bundled codex plugin. Scoped to our
+    // provider so other providers are untouched.
+    "chat.headers": async (hookInput, output) => {
+      if (hookInput.model.providerID !== PROVIDER_ID) return
+      output.headers["originator"] = "codex_cli_ts"
+      output.headers["session-id"] = hookInput.sessionID
+    },
+    "chat.params": async (hookInput, output) => {
+      if (hookInput.model.providerID !== PROVIDER_ID) return
+      // Match codex cli: the Codex backend rejects an explicit max output cap.
+      output.maxOutputTokens = undefined
+    },
+  }
+}
+
+export default WeaveCodex

--- a/install/opencode-weave/src/index.ts
+++ b/install/opencode-weave/src/index.ts
@@ -226,25 +226,36 @@ function stopOAuthServer(): void {
 }
 
 function waitForOAuthCallback(pkce: PkceCodes, state: string): Promise<TokenResponse> {
+  // A new login supersedes any in-flight one: reject the old promise so it
+  // can't hang or later clobber this flow's state.
+  pendingOAuth?.reject(new Error("OAuth flow superseded by a new login"))
   return new Promise((resolve, reject) => {
+    let entry: PendingOAuth | undefined
+    // Each handler clears the shared slot only if it still owns it, so a stale
+    // timer or callback never nulls out a newer flow's pendingOAuth.
+    const clearIfOwner = () => {
+      clearTimeout(timeout)
+      if (pendingOAuth === entry) pendingOAuth = undefined
+    }
     const timeout = setTimeout(() => {
-      if (pendingOAuth) {
+      if (pendingOAuth === entry) {
         pendingOAuth = undefined
         reject(new Error("OAuth callback timeout - authorization took too long"))
       }
     }, 5 * 60 * 1000)
-    pendingOAuth = {
+    entry = {
       pkce,
       state,
       resolve: (tokens) => {
-        clearTimeout(timeout)
+        clearIfOwner()
         resolve(tokens)
       },
       reject: (error) => {
-        clearTimeout(timeout)
+        clearIfOwner()
         reject(error)
       },
     }
+    pendingOAuth = entry
   })
 }
 

--- a/install/opencode-weave/src/index.ts
+++ b/install/opencode-weave/src/index.ts
@@ -55,10 +55,11 @@ function base64UrlEncode(buffer: ArrayBuffer): string {
 }
 
 async function generatePKCE(): Promise<PkceCodes> {
-  const chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~"
-  const verifier = Array.from(crypto.getRandomValues(new Uint8Array(43)))
-    .map((b) => chars[b % chars.length])
-    .join("")
+  // base64url of 32 random bytes → a 43-char verifier drawn uniformly from the
+  // PKCE unreserved set (RFC 7636 §4.1). Encoding the raw bytes avoids the
+  // modulo-on-a-CSPRNG bias that mapping bytes onto a 64-char alphabet would
+  // introduce (and that static analysis flags).
+  const verifier = base64UrlEncode(crypto.getRandomValues(new Uint8Array(32)).buffer)
   const challenge = base64UrlEncode(await crypto.subtle.digest("SHA-256", new TextEncoder().encode(verifier)))
   return { verifier, challenge }
 }

--- a/install/uninstall.sh
+++ b/install/uninstall.sh
@@ -155,13 +155,18 @@ if [ "$target" = "opencode" ]; then
   opencode_config_file="$opencode_dir/opencode.json"
   refuse_if_symlink "$opencode_config_file"
 
+  opencode_plugin="$opencode_dir/.weave/opencode-weave.ts"
   if [ -f "$opencode_config_file" ]; then
-    # Strip `provider.weave` and any router-pointing top-level model. Other
-    # providers, user-set models that don't reference the router, and any
-    # unrelated keys are preserved.
-    cleaned="$(jq '
+    # Strip both managed providers (`weave`, `weave-codex`), the managed plugin
+    # entry from the `plugin` array, and any router-pointing top-level model.
+    # Other providers, user-set models that don't reference the router, other
+    # plugins, and any unrelated keys are preserved.
+    cleaned="$(jq --arg plugin "$opencode_plugin" '
       (if .provider.weave then del(.provider.weave) else . end)
+      | (if .provider["weave-codex"] then del(.provider["weave-codex"]) else . end)
       | (if (.provider // {}) == {} then del(.provider) else . end)
+      | (if (.plugin | type) == "array" then .plugin -= [$plugin] else . end)
+      | (if (.plugin | type) == "array" and (.plugin | length) == 0 then del(.plugin) else . end)
       | (if (.model // "" | tostring | startswith("weave/")) then del(.model) else . end)
     ' "$opencode_config_file")"
     printf '%s\n' "$cleaned" >"$opencode_config_file"
@@ -177,6 +182,16 @@ if [ "$target" = "opencode" ]; then
     fi
   else
     info "No opencode config at $opencode_config_file (already uninstalled?)"
+  fi
+
+  # Drop the bundled Codex-subscription plugin (no secrets; the config holds the
+  # key, opencode's own auth store holds the ChatGPT tokens). Remove the .weave/
+  # dir only if it's left empty so we don't clobber an unrelated user dir.
+  if [ -f "$opencode_plugin" ]; then
+    refuse_if_symlink "$opencode_plugin"
+    rm -f "$opencode_plugin"
+    rmdir "$opencode_dir/.weave" 2>/dev/null || true
+    ok "Removed $opencode_plugin"
   fi
 
   # Drop the toggle parked sidecar (holds the parked router model when off).

--- a/install/uninstall.sh
+++ b/install/uninstall.sh
@@ -155,10 +155,19 @@ if [ "$target" = "opencode" ]; then
   opencode_config_file="$opencode_dir/opencode.json"
   refuse_if_symlink "$opencode_config_file"
 
-  opencode_plugin="$opencode_dir/.weave/opencode-weave.ts"
+  # Canonicalize the plugin path exactly as install.sh did (`cd … && pwd`) so
+  # the `plugin` array entry matches on removal — a raw "$opencode_dir/…" string
+  # can differ (symlinks, trailing slash) and leave the entry behind.
+  if [ -d "$opencode_dir" ]; then
+    opencode_plugin="$(cd "$opencode_dir" && pwd)/.weave/opencode-weave.ts"
+  else
+    opencode_plugin="$opencode_dir/.weave/opencode-weave.ts"
+  fi
   if [ -f "$opencode_config_file" ]; then
     # Strip both managed providers (`weave`, `weave-codex`), the managed plugin
-    # entry from the `plugin` array, and any router-pointing top-level model.
+    # entry from the `plugin` array, and any router-pointing top-level model
+    # (both the `weave/` and `weave-codex/` provider prefixes — otherwise a
+    # `weave-codex/...` default survives and points at the deleted provider).
     # Other providers, user-set models that don't reference the router, other
     # plugins, and any unrelated keys are preserved.
     cleaned="$(jq --arg plugin "$opencode_plugin" '
@@ -167,7 +176,7 @@ if [ "$target" = "opencode" ]; then
       | (if (.provider // {}) == {} then del(.provider) else . end)
       | (if (.plugin | type) == "array" then .plugin -= [$plugin] else . end)
       | (if (.plugin | type) == "array" and (.plugin | length) == 0 then del(.plugin) else . end)
-      | (if (.model // "" | tostring | startswith("weave/")) then del(.model) else . end)
+      | (if (.model // "" | tostring | (startswith("weave/") or startswith("weave-codex/"))) then del(.model) else . end)
     ' "$opencode_config_file")"
     printf '%s\n' "$cleaned" >"$opencode_config_file"
 


### PR DESCRIPTION
## What

Lets a developer pay for their **opencode** turns with their own **ChatGPT (Codex) subscription**, routed through the Weave Router — the opencode counterpart to the Codex-CLI passthrough.

The router side already detects an inbound ChatGPT bearer on `/v1/responses` (the Codex passthrough). The missing piece was getting opencode to *emit* that shape. This PR adds it.

## Why a plugin (not just config)

opencode removed built-in subscription auth in 1.3.0 and binds OAuth to its own first-party providers — its bundled `openai/codex.ts` hardcodes the upstream to `chatgpt.com` and binds provider `openai`, so a custom router provider can't reuse it. And a subscription bearer expires ~hourly, which a static `options.headers` string can't refresh.

So this adds a self-contained opencode plugin that re-implements the ChatGPT OAuth login + token refresh against a **custom `weave-codex` provider** and, crucially, **leaves the request URL on the Weave Router** instead of rewriting it to `chatgpt.com`.

## What's in it

- **`install/opencode-weave/`** — the plugin (TypeScript; typechecks `strict` against `@opencode-ai/plugin`). Browser PKCE + headless device-code login, background token refresh+rotation persisted to opencode's auth store, and a loader whose `fetch` injects the subscription `Authorization` + `ChatGPT-Account-Id` while preserving the configured `X-Weave-*` headers. Bundled into `@workweave/router` at prepack (mirrors `pi-router/`).
- **`install.sh` / `uninstall.sh`** — `--codex`/`--opencode` now writes a second `weave-codex` provider (OpenAI/Responses wire) alongside the existing Anthropic-shaped `weave` block, drops the plugin into `<opencode_dir>/.weave/`, and registers it via opencode.json's `plugin` array by absolute path (scope-independent). Idempotent; preserves the user's own providers/plugins on uninstall. The provider is **dormant until** the user runs `opencode auth login` → ChatGPT.

Division of responsibility: the **router key + identity** ride in config `options.headers` (as today); the **plugin** manages only the dynamic, refreshable subscription credential.

## Emitted wire shape

`POST {router}/v1/responses` (Responses format) · `Authorization: Bearer <ChatGPT JWT>` · `ChatGPT-Account-Id: <id>` · `X-Weave-Router-Key: rk_…` — exactly what the router's Codex passthrough detects, so the turn is served on the caller's plan.

## Verification

End-to-end against a local capture server with real opencode 1.17.9 + a real ChatGPT login:
- **Inject path** — forwards the real JWT + account-id in Responses format to `/v1/responses`.
- **Refresh path** — expired token → refresh against the issuer (mock, so no real token rotation) → rotate + persist → inject the refreshed bearer.
- **Installer** — verified the produced config + dropped plugin, idempotent re-install, and uninstall that strips both managed providers + the plugin while preserving user-owned entries.
- Plugin typechecks `strict` against `@opencode-ai/plugin@1.17.9`.

## Notes / follow-ups

- The backend installer template (`syncrouterinstall/install_template.sh`) is synced from `install.sh` at gitlink-bump time, per convention — not part of this router PR.
- To confirm against live traffic: that the router forwards `originator`/`session-id` to the Codex backend, and that the backend accepts `originator=codex_cli_ts` from a routed request.
- TOS caveat: ChatGPT/Anthropic restrict subscription tokens to official clients — a product call, and the OAuth path can break if they change it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)