### PR TITLE
fix(routing): calibrate quality dial against real mix crossovers

### DIFF
--- a/internal/router/cluster/distribution.go
+++ b/internal/router/cluster/distribution.go
@@ -54,7 +54,7 @@ const defaultDistributionGrid = 21
 // across a grid of gridN evenly spaced dial positions in [0, 1].
 //
 // Each cluster centroid is treated as one representative request, routed with
-// the SAME scoring path as live traffic (deriveClusterAlpha -> blendScoresV2 ->
+// the SAME scoring path as live traffic (dialToAlpha -> blendScoresV2 ->
 // argmax), and the winners are tallied with equal weight. This makes the
 // preview a faithful read of the routing math; what it is NOT is traffic
 // weighted — every cluster counts once regardless of how much real traffic
@@ -86,12 +86,9 @@ func (s *Scorer) RoutingDistribution(gridN int) ([]DistributionPoint, error) {
 		t := float64(g) / float64(gridN-1)
 
 		knobs := s.defaultActiveKnobs()
+		a := s.dialToAlpha(t)
 		for i := range knobs.Alpha {
-			rank := 0.5
-			if i < len(s.qualityDispersionRank) {
-				rank = s.qualityDispersionRank[i]
-			}
-			knobs.Alpha[i] = deriveClusterAlpha(t, rank, qualityBiasDispersionSpread)
+			knobs.Alpha[i] = a
 		}
 
 		counts := make(map[string]int, len(s.models))

--- a/internal/router/cluster/distribution_test.go
+++ b/internal/router/cluster/distribution_test.go
@@ -165,6 +165,7 @@ func TestRoutingDistribution_MidDialIsPricierThanLowDial(t *testing.T) {
 			mid = p
 		}
 	}
+	require.NotEmpty(t, low.Models, "dial position 0.2 must be present in the 21-point grid")
 	require.NotEmpty(t, mid.Models)
 	assert.Greater(t, mid.ProjectedCostPer1KInputUSD, low.ProjectedCostPer1KInputUSD*1.5,
 		"the 50%% dial must route a meaningfully pricier (higher-quality) mix than the 20%% dial")

--- a/internal/router/cluster/distribution_test.go
+++ b/internal/router/cluster/distribution_test.go
@@ -1,83 +1,65 @@
 package cluster
 
 import (
+	"fmt"
 	"math"
+	"sort"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-func TestDeriveClusterAlpha_EndpointsPinForEveryRank(t *testing.T) {
-	for _, rank := range []float64{0, 0.25, 0.5, 0.75, 1} {
-		assert.Equal(t, 0.0, deriveClusterAlpha(0, rank, qualityBiasDispersionSpread),
-			"t=0 must map to alpha 0 (all price) regardless of dispersion rank %v", rank)
-		assert.Equal(t, 1.0, deriveClusterAlpha(1, rank, qualityBiasDispersionSpread),
-			"t=1 must map to alpha 1 (all quality) regardless of dispersion rank %v", rank)
+func TestDialToAlpha_EndpointsPin(t *testing.T) {
+	// The slider's extremes stay honest regardless of calibration: 0 -> all
+	// cheapest, 1 -> best-per-cluster top quality.
+	for _, bp := range [][]float64{nil, {0, 1}, {0, 0.3, 0.55, 0.87, 1}} {
+		s := &Scorer{dialAlphaBreakpoints: bp}
+		assert.Equal(t, 0.0, s.dialToAlpha(0), "t=0 must map to alpha 0 (breakpoints %v)", bp)
+		assert.Equal(t, 1.0, s.dialToAlpha(1), "t=1 must map to alpha 1 (breakpoints %v)", bp)
+		assert.Equal(t, 0.0, s.dialToAlpha(-0.5), "t<0 clamps to 0")
+		assert.Equal(t, 1.0, s.dialToAlpha(1.5), "t>1 clamps to 1")
 	}
 }
 
-func TestDeriveClusterAlpha_MonotonicInDial(t *testing.T) {
-	for _, rank := range []float64{0, 0.5, 1} {
-		prev := -1.0
-		for g := 0; g <= 20; g++ {
-			a := deriveClusterAlpha(float64(g)/20, rank, qualityBiasDispersionSpread)
-			assert.GreaterOrEqual(t, a, prev, "alpha must be non-decreasing in the dial (rank %v)", rank)
-			prev = a
-		}
+func TestDialToAlpha_MonotonicAndInterpolates(t *testing.T) {
+	// Breakpoints placed at equal dial spacing: with 5 of them the dial quarters
+	// land exactly on a breakpoint, and interior positions interpolate linearly.
+	s := &Scorer{dialAlphaBreakpoints: []float64{0, 0.3, 0.55, 0.87, 1}}
+	assert.InDelta(t, 0.3, s.dialToAlpha(0.25), 1e-9, "quarter dial lands on the 2nd breakpoint")
+	assert.InDelta(t, 0.55, s.dialToAlpha(0.5), 1e-9, "mid dial lands on the 3rd breakpoint")
+	assert.InDelta(t, 0.425, s.dialToAlpha(0.375), 1e-9, "between breakpoints 2 and 3 it interpolates")
+
+	prev := -1.0
+	for g := 0; g <= 100; g++ {
+		a := s.dialToAlpha(float64(g) / 100)
+		assert.GreaterOrEqual(t, a, prev, "alpha must be non-decreasing in the dial")
+		prev = a
 	}
 }
 
-func TestDeriveClusterAlpha_HigherDispersionFavorsQualityEarlier(t *testing.T) {
-	// At a fixed mid-dial position, a higher-dispersion cluster (one whose
-	// strong models are much better than its cheap ones) should carry a higher
-	// quality weight than a low-dispersion cluster — that's what spreads the
-	// per-cluster crossovers into a gradient instead of a cliff.
-	for _, dial := range []float64{0.25, 0.5, 0.75} {
-		low := deriveClusterAlpha(dial, 0.0, qualityBiasDispersionSpread)
-		mid := deriveClusterAlpha(dial, 0.5, qualityBiasDispersionSpread)
-		high := deriveClusterAlpha(dial, 1.0, qualityBiasDispersionSpread)
-		assert.Less(t, low, mid, "dial=%v: low-dispersion alpha should trail median", dial)
-		assert.Less(t, mid, high, "dial=%v: median alpha should trail high-dispersion", dial)
+func TestDialToAlpha_NoCalibrationIsIdentity(t *testing.T) {
+	// A bundle with no mix separation (or a v1 bundle) leaves breakpoints nil;
+	// the dial then maps straight through so behavior is unchanged.
+	s := &Scorer{dialAlphaBreakpoints: nil}
+	for _, tt := range []float64{0.1, 0.4, 0.7, 0.9} {
+		assert.InDelta(t, tt, s.dialToAlpha(tt), 1e-9, "identity fallback at t=%v", tt)
 	}
 }
 
-func TestComputeQualityDispersionRank_OrdersBySpread(t *testing.T) {
-	models := []string{"a", "b"}
-	// cluster 0: spread 0 (both equal); cluster 1: spread 1; cluster 2: spread 4.
-	qm := Rankings{
-		0: {"a": 1, "b": 1},
-		1: {"a": 1, "b": 2},
-		2: {"a": 1, "b": 5},
+func TestComputeDialCalibration_AscendingPinnedEndpoints(t *testing.T) {
+	// On the real bundle the calibration must be a strictly ascending sequence
+	// pinned at 0 and 1, with several interior breakpoints (the bundle has many
+	// distinct routed mixes between the cheapest and the saturated end).
+	s := loadV0_67(t)
+	bp := s.dialAlphaBreakpoints
+	require.GreaterOrEqual(t, len(bp), 4, "expected several mix breakpoints on the real bundle")
+	assert.Equal(t, 0.0, bp[0], "first breakpoint pins the price extreme")
+	assert.Equal(t, 1.0, bp[len(bp)-1], "last breakpoint pins the quality extreme")
+	for i := 1; i < len(bp); i++ {
+		assert.Greater(t, bp[i], bp[i-1], "breakpoints must be strictly ascending")
 	}
-	ranks := computeQualityDispersionRank(qm, models, 3)
-	require.Len(t, ranks, 3)
-	assert.Equal(t, 0.0, ranks[0], "lowest-dispersion cluster ranks 0")
-	assert.Equal(t, 0.5, ranks[1], "middle-dispersion cluster ranks 0.5")
-	assert.Equal(t, 1.0, ranks[2], "highest-dispersion cluster ranks 1")
-}
-
-func TestComputeQualityDispersionRank_TiesShareMidRank(t *testing.T) {
-	models := []string{"a", "b"}
-	// clusters 0 and 1 have identical spread (1); cluster 2 has spread 4.
-	// The two tied clusters should get the SAME rank (mid-rank of positions
-	// 0,1 = 0.5 -> 0.25), independent of their order in the bundle.
-	qm := Rankings{
-		0: {"a": 1, "b": 2},
-		1: {"a": 5, "b": 6},
-		2: {"a": 1, "b": 5},
-	}
-	ranks := computeQualityDispersionRank(qm, models, 3)
-	require.Len(t, ranks, 3)
-	assert.Equal(t, ranks[0], ranks[1], "tied-dispersion clusters must share a rank")
-	assert.Equal(t, 0.25, ranks[0], "two tied clusters at positions 0,1 get mid-rank 0.5/(k-1)")
-	assert.Equal(t, 1.0, ranks[2], "the distinct top-dispersion cluster ranks 1")
-}
-
-func TestComputeQualityDispersionRank_SingleClusterNeutral(t *testing.T) {
-	ranks := computeQualityDispersionRank(Rankings{0: {"a": 1, "b": 9}}, []string{"a", "b"}, 1)
-	require.Len(t, ranks, 1)
-	assert.Equal(t, 0.5, ranks[0], "with no other cluster to rank against, rank is neutral 0.5")
 }
 
 // loadV0_67 loads the committed v0.67 bundle through a fake embedder (matching
@@ -142,4 +124,60 @@ func TestRoutingDistribution_DefaultGridAndV1Guard(t *testing.T) {
 	points, err := s.RoutingDistribution(0) // 0 -> default grid
 	require.NoError(t, err)
 	assert.Len(t, points, defaultDistributionGrid)
+}
+
+func TestRoutingDistribution_NoDeadZone(t *testing.T) {
+	// Regression guard for the reported bug: every adjacent pair of dial
+	// positions should differ in either the routed mix or its projected cost.
+	// A dead zone (a run of identical mixes) is exactly what made "50% look like
+	// 20%"; the calibration must keep all but a small number of steps live.
+	s := loadV0_67(t)
+	points, err := s.RoutingDistribution(21)
+	require.NoError(t, err)
+
+	identicalRuns := 0
+	for i := 1; i < len(points); i++ {
+		samMix := mixSignatureOf(points[i].Models) == mixSignatureOf(points[i-1].Models)
+		if samMix {
+			identicalRuns++
+		}
+	}
+	// A few coincidental repeats are fine (21 dial samples vs a finite set of
+	// distinct mixes); a dead zone would repeat across many steps in a row.
+	assert.LessOrEqual(t, identicalRuns, 3,
+		"too many adjacent dial positions route an identical mix (%d) — dial has a dead zone", identicalRuns)
+}
+
+func TestRoutingDistribution_MidDialIsPricierThanLowDial(t *testing.T) {
+	// The reported symptom in user terms: a mid dial (0.5) used to route the
+	// same all-cheapest mix as a low dial (0.2). After calibration the mid dial
+	// must route a meaningfully pricier (higher-quality) mix.
+	s := loadV0_67(t)
+	points, err := s.RoutingDistribution(21)
+	require.NoError(t, err)
+
+	var low, mid DistributionPoint
+	for _, p := range points {
+		if math.Abs(p.QualityBias-0.2) < 1e-9 {
+			low = p
+		}
+		if math.Abs(p.QualityBias-0.5) < 1e-9 {
+			mid = p
+		}
+	}
+	require.NotEmpty(t, mid.Models)
+	assert.Greater(t, mid.ProjectedCostPer1KInputUSD, low.ProjectedCostPer1KInputUSD*1.5,
+		"the 50%% dial must route a meaningfully pricier (higher-quality) mix than the 20%% dial")
+}
+
+// mixSignatureOf renders a DistributionPoint's model shares as a stable key for
+// comparing whether two dial positions route the same mix.
+func mixSignatureOf(models []ModelShare) string {
+	sorted := append([]ModelShare(nil), models...)
+	sort.Slice(sorted, func(i, j int) bool { return sorted[i].Model < sorted[j].Model })
+	var b strings.Builder
+	for _, m := range sorted {
+		fmt.Fprintf(&b, "%s:%.4f,", m.Model, m.Share)
+	}
+	return b.String()
 }

--- a/internal/router/cluster/scorer.go
+++ b/internal/router/cluster/scorer.go
@@ -264,7 +264,12 @@ func (s *Scorer) computeDialCalibration() []float64 {
 		for c := 0; c < k; c++ {
 			scores := s.blendScoresV2(centroidTopClusters[c], knobs, s.models)
 			winner, _ := argmax(scores, s.models)
-			counts[winner]++
+			// Mirror RoutingDistribution's accounting exactly: skip an empty
+			// winner so a cluster that flips between "" and a real model can't
+			// inject a phantom breakpoint the dashboard distribution never shows.
+			if winner != "" {
+				counts[winner]++
+			}
 		}
 		sig := mixSignature(counts)
 		if sig != prevSig {

--- a/internal/router/cluster/scorer.go
+++ b/internal/router/cluster/scorer.go
@@ -56,16 +56,15 @@ type Scorer struct {
 	qualityMeans    Rankings
 	modelAxes       map[string]ModelAxis
 	medianVerbosity float64
-	// qualityDispersionRank[k] is cluster k's quality dispersion expressed as a
-	// rank in [0, 1] (0 = lowest dispersion across all clusters, 1 = highest).
-	// Dispersion is the spread of raw quality_means across deployed models in
-	// the cluster: a high-dispersion cluster is one where the strong models are
-	// much better than the cheap ones (so it should keep quality models down to
-	// a low dial setting), a low-dispersion cluster is one where every model is
-	// about equally good (so it demotes to cheap early). Precomputed once at
-	// NewScorer over the full deployed set; drives deriveClusterAlpha for the
-	// QualityBias dial. Length K, v2 only (nil for v1 bundles).
-	qualityDispersionRank []float64
+	// dialAlphaBreakpoints calibrates the QualityBias dial against this bundle's
+	// actual routing behavior. It holds the ascending uniform-alpha values at
+	// which the routed model mix changes (one entry per distinct mix, first =
+	// 0, last = 1). dialToAlpha interpolates across them so equal dial travel
+	// produces an equal number of mix changes — which is what removes the dead
+	// zones (wide alpha ranges that route an identical mix) that otherwise make
+	// the slider's lower half feel inert. Computed once at NewScorer; nil for v1
+	// bundles, where dialToAlpha falls back to the identity t -> alpha.
+	dialAlphaBreakpoints []float64
 }
 
 // Version returns the artifact version (e.g. "v0.2").
@@ -194,132 +193,134 @@ func NewScorer(bundle *Bundle, cfg Config, embed Embedder, availableProviders ma
 		}
 	}
 
-	var qualityDispersionRank []float64
+	s := &Scorer{
+		version:         bundle.Version,
+		cfg:             cfg,
+		embed:           embed,
+		centroids:       bundle.Centroids,
+		rankings:        bundle.Rankings,
+		registry:        bundle.Registry,
+		candidates:      candidates,
+		models:          models,
+		metadata:        bundle.Metadata,
+		isV2:            bundle.IsV2,
+		qualityMeans:    bundle.QualityMeans,
+		modelAxes:       bundle.ModelAxes,
+		medianVerbosity: bundle.MedianVerbosity,
+	}
+	// The dial calibration replays the scorer across the alpha range, so it must
+	// be computed after the fields it reads (qualityMeans, modelAxes, models,
+	// centroids) are populated. v1 bundles have no quality_means and keep a nil
+	// calibration (dialToAlpha then falls back to identity).
 	if bundle.IsV2 {
-		qualityDispersionRank = computeQualityDispersionRank(bundle.QualityMeans, models, bundle.Centroids.K)
+		s.dialAlphaBreakpoints = s.computeDialCalibration()
 	}
-
-	return &Scorer{
-		version:               bundle.Version,
-		cfg:                   cfg,
-		embed:                 embed,
-		centroids:             bundle.Centroids,
-		rankings:              bundle.Rankings,
-		registry:              bundle.Registry,
-		candidates:            candidates,
-		models:                models,
-		metadata:              bundle.Metadata,
-		isV2:                  bundle.IsV2,
-		qualityMeans:          bundle.QualityMeans,
-		modelAxes:             bundle.ModelAxes,
-		medianVerbosity:       bundle.MedianVerbosity,
-		qualityDispersionRank: qualityDispersionRank,
-	}, nil
+	return s, nil
 }
 
-// computeQualityDispersionRank measures each cluster's quality dispersion — the
-// population standard deviation of its raw quality_means across the deployed
-// model set — and converts those into ranks in [0, 1] (0 = lowest-dispersion
-// cluster, 1 = highest). Dispersion is read from RAW quality_means, before the
-// per-cluster min-max normalization the scorer applies at request time: that
-// normalization deliberately flattens every cluster to the same [0, 1] range,
-// which is exactly what collapses the per-cluster crossovers into one cliff.
-// Ranking on the raw spread reintroduces the signal the dial needs.
+// qualityBiasCalibrationGrid is the uniform-alpha resolution swept at
+// scorer-build time to discover where the routed model mix changes. 401 points
+// = steps of 0.0025, fine enough to separate adjacent crossovers.
+const qualityBiasCalibrationGrid = 401
+
+// computeDialCalibration walks a uniform alpha from 0 to 1, scoring every
+// cluster centroid through the same blend as live routing, and records the
+// alpha at which the routed model mix (the multiset of per-cluster winners)
+// first changes. Those alphas — ascending, first forced to 0, last forced to 1
+// — are the dial breakpoints.
 //
-// Returns a slice of length K. With fewer than two clusters every rank is 0.5
-// (no spread to rank against), which makes deriveClusterAlpha fall back to a
-// plain t curve.
-func computeQualityDispersionRank(qualityMeans Rankings, models []string, k int) []float64 {
-	disp := make([]float64, k)
+// They exist to defeat the dead-zone problem. The cheapest models are far
+// cheaper than the rest while quality_means are tightly bunched, so the blend
+// routes an identical all-cheapest mix across a wide low-alpha range, an
+// identical saturated mix across a wide high-alpha range, and can sit on a
+// stable mid mix for a wide middle range too. A dial that maps linearly to
+// alpha spends most of its travel in those flat regions — the reported
+// "50% looks the same as 20%" bug. dialToAlpha instead interpolates across
+// these breakpoints, so equal dial travel crosses an equal number of mix
+// changes and every part of the slider does something.
+//
+// Forcing the first breakpoint to 0 keeps the price extreme at the single
+// cheapest model; forcing the last to 1 keeps the quality extreme at the pure
+// best-per-cluster mix. Returns nil when fewer than two distinct mixes exist
+// (no cost/quality separation), so dialToAlpha falls back to the identity.
+func (s *Scorer) computeDialCalibration() []float64 {
+	k := s.centroids.K
+	centroidTopClusters := make([][]int, k)
 	for c := 0; c < k; c++ {
-		row := qualityMeans[c]
-		if len(models) == 0 {
-			continue
-		}
-		var sum float64
-		for _, m := range models {
-			sum += float64(row[m])
-		}
-		mean := sum / float64(len(models))
-		var variance float64
-		for _, m := range models {
-			d := float64(row[m]) - mean
-			variance += d * d
-		}
-		disp[c] = math.Sqrt(variance / float64(len(models)))
+		centroidTopClusters[c] = topPNearest(s.centroids.Row(c), s.centroids, s.cfg.TopP)
 	}
 
-	// Rank by dispersion as a fraction in [0, 1], invariant to the absolute
-	// dispersion scale (which varies by bundle). order holds cluster indices
-	// sorted ascending by dispersion.
-	order := make([]int, k)
-	for i := range order {
-		order[i] = i
+	base := s.defaultActiveKnobs()
+	breakpoints := make([]float64, 0, 32)
+	prevSig := ""
+	for g := 0; g < qualityBiasCalibrationGrid; g++ {
+		a := float64(g) / float64(qualityBiasCalibrationGrid-1)
+		knobs := base
+		knobs.Alpha = make([]float64, k)
+		for i := range knobs.Alpha {
+			knobs.Alpha[i] = a
+		}
+		counts := make(map[string]int, len(s.models))
+		for c := 0; c < k; c++ {
+			scores := s.blendScoresV2(centroidTopClusters[c], knobs, s.models)
+			winner, _ := argmax(scores, s.models)
+			counts[winner]++
+		}
+		sig := mixSignature(counts)
+		if sig != prevSig {
+			breakpoints = append(breakpoints, a)
+			prevSig = sig
+		}
 	}
-	sort.SliceStable(order, func(a, b int) bool { return disp[order[a]] < disp[order[b]] })
 
-	ranks := make([]float64, k)
-	if k < 2 {
-		for i := range ranks {
-			ranks[i] = 0.5
-		}
-		return ranks
+	if len(breakpoints) < 2 {
+		return nil
 	}
-	// Assign mid-ranks: clusters with equal dispersion share the average of
-	// their positions, so tied clusters get identical alphas regardless of
-	// their arbitrary order in the bundle. Walk the sorted slice in equal-value
-	// groups.
-	for i := 0; i < k; {
-		j := i + 1
-		for j < k && disp[order[j]] == disp[order[i]] {
-			j++
-		}
-		midPos := float64(i+j-1) / 2 // average of positions i..j-1
-		rank := midPos / float64(k-1)
-		for p := i; p < j; p++ {
-			ranks[order[p]] = rank
-		}
-		i = j
-	}
-	return ranks
+	breakpoints[0] = 0
+	breakpoints[len(breakpoints)-1] = 1
+	return breakpoints
 }
 
-// deriveClusterAlpha maps the global QualityBias dial t in [0, 1] to a single
-// cluster's quality weight, bending the curve by that cluster's quality
-// dispersion rank. The mapping is alpha = t^gamma where gamma = spread^(1 -
-// 2*rank):
-//
-//   - high-dispersion clusters (rank -> 1) get gamma < 1, a concave curve that
-//     rises fast — they reach a quality-favoring alpha at a low dial setting
-//     and hold strong models the longest;
-//   - low-dispersion clusters (rank -> 0) get gamma > 1, a convex curve that
-//     stays near zero — they keep routing cheap until the dial is high;
-//   - the median cluster (rank = 0.5) gets gamma = 1, a straight line.
-//
-// Because t^gamma pins to 0 at t=0 and 1 at t=1 for every gamma > 0, the slider
-// endpoints always resolve to all-cheapest / all-top-quality regardless of
-// dispersion; only the midrange spreads. spread > 1 controls how far the
-// per-cluster crossovers fan out (1 collapses back to a uniform t).
-func deriveClusterAlpha(t, rank, spread float64) float64 {
+// mixSignature renders a winner-count map as a stable, order-independent key so
+// two dial positions that route the same model mix compare equal.
+func mixSignature(counts map[string]int) string {
+	models := make([]string, 0, len(counts))
+	for m := range counts {
+		models = append(models, m)
+	}
+	sort.Strings(models)
+	var b strings.Builder
+	for _, m := range models {
+		fmt.Fprintf(&b, "%s:%d,", m, counts[m])
+	}
+	return b.String()
+}
+
+// dialToAlpha maps the QualityBias dial t in [0, 1] to the uniform per-cluster
+// alpha the scorer should run at. It places the bundle's mix breakpoints at
+// equal dial spacing and interpolates between them, so the dial spends equal
+// travel on each distinct routed mix instead of wasting its lower half on a
+// dead zone. With no calibration (v1 bundles, or a bundle with no mix
+// separation) it is the identity. t outside [0, 1] is clamped.
+func (s *Scorer) dialToAlpha(t float64) float64 {
 	if t <= 0 {
 		return 0
 	}
 	if t >= 1 {
 		return 1
 	}
-	// For t in (0, 1) and gamma > 0 (guaranteed: spread > 0 so gamma =
-	// spread^(1-2*rank) is strictly positive), t^gamma is always in (0, 1) —
-	// no clamp needed.
-	gamma := math.Pow(spread, 1-2*rank)
-	return math.Pow(t, gamma)
+	bp := s.dialAlphaBreakpoints
+	if len(bp) < 2 {
+		return t
+	}
+	x := t * float64(len(bp)-1)
+	i := int(x)
+	if i >= len(bp)-1 {
+		return bp[len(bp)-1]
+	}
+	frac := x - float64(i)
+	return bp[i] + frac*(bp[i+1]-bp[i])
 }
-
-// qualityBiasDispersionSpread is the fan-out factor for deriveClusterAlpha. At
-// 3.0 the highest-dispersion cluster's crossover sits at roughly the cube root
-// of the lowest's, which spreads the 16 v0.67 clusters across the dial without
-// any single cluster dominating. Tunable; verified against the live bundle
-// centroids before promotion.
-const qualityBiasDispersionSpread = 3.0
 
 // resolveProviderFor walks the catalog's ordered ProviderBinding list for
 // modelID and returns the first binding whose Provider name is in
@@ -546,21 +547,19 @@ func (s *Scorer) Route(ctx context.Context, req router.Request) (router.Decision
 		if req.RoutingKnobs != nil {
 			switch {
 			case req.RoutingKnobs.QualityBias != nil:
-				// Dial path: derive a per-cluster alpha from the single dial
-				// position, bent by each cluster's quality dispersion. The
-				// endpoints still pin to all-cheapest / all-top-quality; only
-				// the midrange fans out into a real mix. Takes precedence over
-				// a co-set Alpha (the higher-level intent wins).
+				// Dial path: map the single dial position through this bundle's
+				// mix-change calibration to a uniform alpha, so the slider spends
+				// equal travel on each distinct routed mix (no dead zone) while
+				// the endpoints still pin to all-cheapest / best-per-cluster.
+				// Takes precedence over a co-set Alpha (the higher-level intent
+				// wins).
 				t := *req.RoutingKnobs.QualityBias
 				if math.IsNaN(t) || math.IsInf(t, 0) || t < 0 || t > 1 {
 					return router.Decision{}, fmt.Errorf("%w: quality_bias (%f) must be a finite value in [0, 1]", ErrInvalidRoutingKnobs, t)
 				}
+				a := s.dialToAlpha(t)
 				for i := range activeKnobs.Alpha {
-					rank := 0.5
-					if i < len(s.qualityDispersionRank) {
-						rank = s.qualityDispersionRank[i]
-					}
-					activeKnobs.Alpha[i] = deriveClusterAlpha(t, rank, qualityBiasDispersionSpread)
+					activeKnobs.Alpha[i] = a
 				}
 			case req.RoutingKnobs.Alpha != nil:
 				// Sledgehammer behavior: uniformly replace every alpha with the

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -10,15 +10,15 @@ type Overrides struct {
 	// quality dispersion so a bake-off can probe a single global alpha.
 	Alpha *float64
 	// QualityBias is the user-facing "quality vs price" dial in [0, 1] (0 =
-	// fully price, 1 = fully quality). Unlike Alpha, it is NOT applied
-	// uniformly: the scorer derives a per-cluster alpha from each cluster's
-	// quality dispersion (see deriveClusterAlpha), so the slider's midrange
-	// produces a real model mix instead of a cliff. The endpoints still pin to
-	// all-cheapest (0) and all-top-quality (1). Set by the per-installation
-	// routing-preference dial. routingKnobsForRequest returns either the header
-	// knobs or the installation knobs, never a merge, so Alpha and QualityBias
-	// do not normally coexist; if both are set, QualityBias wins (it is the
-	// higher-level intent).
+	// fully price, 1 = fully quality). Unlike Alpha, the scorer maps it through
+	// a per-bundle calibration (see dialToAlpha / computeDialCalibration) that
+	// places the dial's travel where the routed model mix actually changes, so
+	// the slider's midrange produces a real model mix instead of a dead zone.
+	// The endpoints still pin to all-cheapest (0) and best-per-cluster top
+	// quality (1). Set by the per-installation routing-preference dial.
+	// routingKnobsForRequest returns either the header knobs or the installation
+	// knobs, never a merge, so Alpha and QualityBias do not normally coexist; if
+	// both are set, QualityBias wins (it is the higher-level intent).
 	QualityBias          *float64
 	SpeedWeight          *float64
 	OutputCostRatio      *float64


### PR DESCRIPTION
## Problem

Reported by a user testing the quality-vs-price dial: **50/50 routes essentially the same mix as 20/80** — both land on the two cheapest models, with nothing in between, and the mix only "wakes up" near the top of the slider.

The dispersion-bend dial from #476 bent a per-cluster alpha by quality dispersion and remapped it onto a cost band. That trimmed the *outer* flat regions (the all-cheapest floor and the saturated ceiling) but **not interior ones**. On the deployed bundle the routed mix is identical across alpha ≈ 0.45–0.62, so the dial still showed one frozen mix from ~20% to ~55%. The bend is computed blind to where crossovers actually sit, so it structurally can't remove an interior dead zone.

## Fix

Calibrate the dial against the bundle's actual routing behavior. At scorer build, sweep a uniform alpha 0→1, score every cluster centroid through the **same blend as live routing**, and record the alpha at which the routed mix (the multiset of per-cluster winners) changes. Those breakpoints — ascending, first pinned to 0, last to 1 — are placed at equal dial spacing and interpolated by `dialToAlpha`. Equal dial travel then crosses an equal number of mix changes, so every part of the slider moves the mix.

This subsumes the dispersion bend (uniform alpha already routes high-dispersion clusters to quality earlier), so the per-cluster dispersion-rank + cost-band machinery is removed. The `Alpha` sledgehammer (eval/debug header) path is unchanged.

## Result (deployed v0.68, projected $/1k input)

| dial | before | after |
|------|--------|-------|
| 0%   | cheapest | 100% gemini-3.1-flash-lite ($0.10) |
| 20%  | all-cheapest | flash-lite + gemini-3.5-flash mix ($0.33) |
| 50%  | **same as 20%** | gemini-3.1-pro 38% dominant ($1.16) |
| 75%  | still mostly cheap | gemini-3.1-pro 100% ($2.00) |
| 100% | opus | best-per-cluster: 62% opus / 38% gemini-3.1-pro ($3.88) |

Cost now rises smoothly and monotonically across the whole slider; the endpoints stay honest (all-cheapest / best-per-cluster).

## Tests

- `dialToAlpha`: endpoints pin, monotone, interpolates between breakpoints, identity fallback with no calibration.
- `computeDialCalibration`: ascending, endpoint-pinned, multiple interior breakpoints on the real bundle.
- `RoutingDistribution`: no dead zone (no long run of identical adjacent mixes), and the 50% dial routes a materially pricier mix than the 20% dial (the reported symptom, as a regression guard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)