### PR TITLE
fix(install): don't restore a parked weave-codex model with no provider

### DIFF
--- a/install/install.sh
+++ b/install/install.sh
@@ -1588,6 +1588,17 @@ toggle_opencode() {
           | "weave/" + .
         ' "$f" 2>/dev/null || echo "weave/claude-sonnet-4-6")"
       fi
+      # Never restore a weave-codex model whose provider is no longer
+      # registered (e.g. a plugin-less re-install stripped it after `off`
+      # parked a weave-codex/… model). Fall back to the Anthropic weave default
+      # so `on` can't leave opencode pointing at a missing provider.
+      case "$restore_model" in
+        weave-codex/*)
+          if [ "$(jq -r '((.provider // {}) | has("weave-codex"))' "$f" 2>/dev/null || true)" != "true" ]; then
+            restore_model="weave/claude-sonnet-4-6"
+          fi
+          ;;
+      esac
       merged="$(jq --arg m "$restore_model" '.model = $m' "$f")"
       printf '%s\n' "$merged" >"$f"
       chmod 600 "$f"


### PR DESCRIPTION
Low-severity fast-follow to #481 (surfaced reviewing the WorkWeave bump).

`toggle_opencode on` could restore a parked `weave-codex/…` model whose provider was removed by a plugin-less re-install — chain: `npx` install → `off --opencode` (parks `weave-codex/gpt-5.5`) → plugin-less re-install (strips `provider.weave-codex`) → `on --opencode` restores the parked model → opencode points at a missing provider.

Fix: before restoring, if the model is `weave-codex/*` and that provider isn't registered in the config, fall back to `weave/claude-sonnet-4-6`.

Verified end-to-end against that exact chain: `on` restores the Anthropic default, not the dangling Codex model. `bash -n` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)