### PR TITLE
chore(install): bump @workweave/router to 0.2.3

### DIFF
--- a/install/npm/package.json
+++ b/install/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@workweave/router",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "One-command installer that points Claude Code, Codex, opencode, or pi at the Weave Router. For pi it also ships the routing extension, loaded via pi.extensions.",
   "bin": {
     "weave-router": "bin.js"


### PR DESCRIPTION
Bumps the npm package version so a publish (tag `router-v0.2.3`) ships the opencode Codex-subscription plugin (#477) and the curl|sh install hardening (#481/#482).

No code changes — `prepack` (scripts/copy-installer.js) already bundles `install/opencode-weave/` into the package; this just lets it go out. After merge I'll tag `router-v0.2.3` to trigger the OIDC publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)