### PR TITLE
feat: opencode subscription-credential routing

### DIFF
--- a/install/install.sh
+++ b/install/install.sh
@@ -533,20 +533,26 @@ TOML
   chmod 600 "$config_file"
 }
 
-# write_opencode_config merges TWO managed providers into opencode's
-# opencode.json plus the bundled Codex-subscription plugin:
-#   - provider.weave        : Anthropic-shaped (@ai-sdk/anthropic) — the router
-#                             speaks the Anthropic Messages API natively, so the
-#                             bundled provider works unmodified. The default.
-#   - provider.weave-codex  : OpenAI-shaped (@ai-sdk/openai, Responses wire) —
-#                             lets a caller's own ChatGPT (Codex) subscription
-#                             pay for their opencode turns. Dormant until the
-#                             user runs `opencode auth login` → ChatGPT and the
-#                             weave-codex plugin's loader injects the bearer.
+# write_opencode_config merges the managed Weave provider(s) into opencode's
+# opencode.json plus the bundled subscription plugin:
+#   - provider.weave        : OpenAI/Responses-shaped (@ai-sdk/openai → /v1/responses).
+#                             The single request provider. The router routes every
+#                             turn across all models the caller's subscriptions +
+#                             Weave key can pay for, and bills the plan matching the
+#                             model it served. The default.
+#   - provider.weave-claude : login-only storage for a Claude (Pro/Max) subscription
+#                             (no models, never serves requests). Written only when
+#                             the bundled plugin is present, since the Claude login
+#                             method lives in the plugin. The `weave` loader reads
+#                             this slot and attaches the Claude sub.
 # The plugin (src bundled at $script_dir/opencode-weave/src/index.ts) is dropped
 # into $opencode_dir/.weave/ and registered via opencode.json's `plugin` array
-# by absolute path — scope-independent (no reliance on an auto-load dir).
-# Re-running rewrites both blocks in-place via jq; uninstall strips them.
+# by absolute path — scope-independent (no reliance on an auto-load dir). It owns
+# both the ChatGPT (on `weave`) and Claude (on `weave-claude`) logins and attaches
+# whichever subscriptions are connected to every request via the router's
+# dedicated X-Weave-*-Subscription headers. Re-running rewrites the blocks
+# in-place via jq (and strips the legacy `weave-codex` provider); uninstall
+# strips them.
 #
 # Usage: write_opencode_config <config_file_path> <base_url> <api_key> [user_email] [user_name]
 write_opencode_config() {
@@ -573,61 +579,52 @@ write_opencode_config() {
 
   # Headline models we surface in opencode's picker. The router re-routes
   # each request anyway, so this list is mostly UX — what shows up when the
-  # user runs /models inside opencode. Keep it short and Anthropic-shaped
-  # so the bundled @ai-sdk/anthropic provider can request them.
+  # user runs /models inside opencode. We list a mix of GPT + Claude so the
+  # picker reflects that the router spans families; whichever model serves the
+  # turn, its matching subscription (if connected) pays.
   #
-  # apiKey is set to the router key as well as planted in headers. opencode's
-  # @ai-sdk/anthropic provider treats apiKey as required at config-parse time
-  # and otherwise falls back to ANTHROPIC_API_KEY from the environment;
-  # without this, a user who's never had an Anthropic key in their shell hits
-  # a startup error before the router ever sees a request. The router itself
-  # ignores the value (auth runs off X-Weave-Router-Key); apiKey here is just
-  # a placeholder that satisfies the SDK's "is auth configured" check.
-  # baseURL KEEPS its /v1 here — do NOT align it with the pi block, which is
-  # root. opencode's @ai-sdk/anthropic (Vercel) appends only /messages to
-  # baseURL (its default is api.anthropic.com/v1), so /v1 yields the correct
-  # /v1/messages. Dropping it would hit /messages and 404. (pi uses the official
-  # @anthropic-ai/sdk, which appends /v1/messages to a root baseURL — opposite
-  # convention.) Verified by install/pi-router/test/opencode_smoke.sh.
+  # npm is @ai-sdk/openai and baseURL KEEPS its /v1 here: opencode's
+  # @ai-sdk/openai provider appends /responses, yielding the router's
+  # /v1/responses surface (the canonical inbound — the router translates to
+  # Anthropic/OSS as it routes, and ships verbatim to the Codex backend for GPT
+  # turns). apiKey is the router key as a parse-time placeholder; the router
+  # authenticates off X-Weave-Router-Key (planted in headers) and the plugin's
+  # loader attaches subscriptions via the dedicated X-Weave-*-Subscription
+  # headers, so the apiKey value is never used upstream.
   local block
   block="$(jq -n \
     --arg url "$block_url/v1" \
     --arg key "$block_key" \
     --argjson headers "$headers_json" '
     {
-      npm: "@ai-sdk/anthropic",
+      npm: "@ai-sdk/openai",
       name: "Weave Router",
       options: { apiKey: $key, baseURL: $url, headers: $headers },
       models: {
-        "claude-fable-5":    { name: "Claude Fable 5 (via Weave Router)" },
-        "claude-opus-4-8":   { name: "Claude Opus 4.8 (via Weave Router)" },
-        "claude-opus-4-7":   { name: "Claude Opus 4.7 (via Weave Router)" },
         "claude-sonnet-4-6": { name: "Claude Sonnet 4.6 (via Weave Router)" },
-        "claude-haiku-4-5":  { name: "Claude Haiku 4.5 (via Weave Router)" }
+        "claude-opus-4-8":   { name: "Claude Opus 4.8 (via Weave Router)" },
+        "claude-haiku-4-5":  { name: "Claude Haiku 4.5 (via Weave Router)" },
+        "gpt-5.5":           { name: "GPT-5.5 (via Weave Router)" },
+        "gpt-5.4":           { name: "GPT-5.4 (via Weave Router)" }
       }
     }
   ')"
 
-  # The OpenAI-shaped Codex-subscription provider. Reuses the same X-Weave-*
-  # header triplet (router key + identity) — the plugin's loader adds only the
-  # dynamic subscription Authorization + ChatGPT-Account-Id on top. baseURL
-  # KEEPS /v1: opencode's @ai-sdk/openai provider appends /responses, yielding
-  # the router's /v1/responses Codex passthrough. apiKey is the router key as a
-  # parse-time placeholder (the loader overrides it once a subscription is
-  # linked), mirroring the weave block above.
-  local codex_block
-  codex_block="$(jq -n \
+  # Login-only storage provider for a Claude (Pro/Max) subscription. It serves
+  # no requests (no models), so its npm/baseURL are inert — opencode just needs
+  # it registered so the plugin's Claude login method has a home and `opencode
+  # auth login` lists it. The `weave` loader reads this slot off disk and
+  # attaches the Claude sub. Reuses the same router key + identity headers.
+  local claude_block
+  claude_block="$(jq -n \
     --arg url "$block_url/v1" \
     --arg key "$block_key" \
     --argjson headers "$headers_json" '
     {
       npm: "@ai-sdk/openai",
-      name: "Weave Router (Codex subscription)",
+      name: "Weave Router — Claude plan",
       options: { apiKey: $key, baseURL: $url, headers: $headers },
-      models: {
-        "gpt-5.5": { name: "GPT-5.5 — Codex subscription (via Weave Router)" },
-        "gpt-5.4": { name: "GPT-5.4 — Codex subscription (via Weave Router)" }
-      }
+      models: {}
     }
   ')"
 
@@ -653,7 +650,7 @@ write_opencode_config() {
     chmod 644 "$plugin_spec"
     plugin_arg="$plugin_spec"
   else
-    warn "opencode Codex plugin source not found at $plugin_src — skipping the weave-codex plugin registration. (Use a packaged 'npx @workweave/router' install.)"
+    warn "opencode subscription plugin source not found at $plugin_src — skipping the Claude login + subscription routing. (Use a packaged 'npx @workweave/router' install.)"
   fi
 
   # Merge into any existing opencode.json. We always overwrite provider.weave
@@ -661,21 +658,23 @@ write_opencode_config() {
   # file (other providers, mcp, agent settings) untouched. Top-level `model` is
   # only set when the user hasn't already picked one.
   #
-  # The weave-codex provider AND its plugin entry are written together only when
-  # the bundled plugin was present and copied ($plugin non-empty). Codex
-  # subscription auth depends on that plugin, so registering the provider
-  # without it (e.g. the `curl | sh` path, which carries no plugin source)
-  # would leave a non-working provider — instead we omit it (and strip any
-  # stale one from a prior install).
+  # The weave-claude login provider AND the plugin entry are written together
+  # only when the bundled plugin was present and copied ($plugin non-empty): the
+  # Claude login method lives in the plugin, so registering the provider without
+  # it (e.g. the `curl | sh` path, which carries no plugin source) would leave a
+  # non-working login — instead we omit it (and strip any stale one). The legacy
+  # `weave-codex` provider is always stripped: the single Responses `weave`
+  # provider supersedes it.
   local merged
   if [ -f "$config_file" ]; then
     merged="$(jq \
       --argjson block "$block" \
-      --argjson codex "$codex_block" \
+      --argjson claude "$claude_block" \
       --arg plugin "$plugin_arg" \
       --arg pluginspec "$plugin_spec" '
       .provider = ((.provider // {}) | .weave = $block)
-      | (if $plugin != "" then .provider["weave-codex"] = $codex else .provider |= del(."weave-codex") end)
+      | (.provider |= del(."weave-codex"))
+      | (if $plugin != "" then .provider["weave-claude"] = $claude else .provider |= del(."weave-claude") end)
       # Register the managed plugin path when we installed it; otherwise strip a
       # stale entry left by a prior install (the provider was just removed, so a
       # lingering plugin reference would be dead weight).
@@ -686,23 +685,24 @@ write_opencode_config() {
                    else . end)
          end)
       | (if (.model // "") == "" then .model = "weave/claude-sonnet-4-6" else . end)
-      # If we just stripped weave-codex (plugin-less re-install) but the default
-      # model still points at it, reset to the Anthropic weave model so opencode
-      # does not boot with a model whose provider no longer exists.
-      | (if $plugin == "" and (.model // "" | tostring | startswith("weave-codex/")) then .model = "weave/claude-sonnet-4-6" else . end)
+      # Reset the default model if it points at a provider we just removed: the
+      # retired weave-codex, or weave-claude on a plugin-less re-install (it has
+      # no models anyway). Otherwise opencode boots with a dangling model.
+      | (if (.model // "" | tostring | startswith("weave-codex/")) then .model = "weave/claude-sonnet-4-6" else . end)
+      | (if $plugin == "" and (.model // "" | tostring | startswith("weave-claude/")) then .model = "weave/claude-sonnet-4-6" else . end)
       | (.["$schema"] //= "https://opencode.ai/config.json")
     ' "$config_file")"
   else
     merged="$(jq -n \
       --argjson block "$block" \
-      --argjson codex "$codex_block" \
+      --argjson claude "$claude_block" \
       --arg plugin "$plugin_arg" '
       {
         "$schema": "https://opencode.ai/config.json",
         model: "weave/claude-sonnet-4-6",
         provider: { weave: $block }
       }
-      | (if $plugin != "" then .provider["weave-codex"] = $codex | .plugin = [$plugin] else . end)
+      | (if $plugin != "" then .provider["weave-claude"] = $claude | .plugin = [$plugin] else . end)
     ')"
   fi
   printf '%s\n' "$merged" >"$config_file"
@@ -1543,8 +1543,8 @@ toggle_opencode() {
     model="$(jq -r '.model // empty' "$f" 2>/dev/null || true)"
     if [ "$(jq -r '((.provider // {}) | has("weave"))' "$f" 2>/dev/null || true)" = "true" ]; then has_weave="true"; fi
   fi
-  # Either managed provider counts as router-on: the Anthropic-shaped `weave/…`
-  # default or a caller-selected `weave-codex/…` Codex-subscription model.
+  # A managed model counts as router-on: the Responses-shaped `weave/…` default,
+  # or a legacy `weave-codex/…` model parked by a pre-upgrade install.
   case "$model" in weave/* | weave-codex/*) on="true" ;; esac
 
   case "$mode" in
@@ -1588,10 +1588,10 @@ toggle_opencode() {
           | "weave/" + .
         ' "$f" 2>/dev/null || echo "weave/claude-sonnet-4-6")"
       fi
-      # Never restore a weave-codex model whose provider is no longer
-      # registered (e.g. a plugin-less re-install stripped it after `off`
-      # parked a weave-codex/… model). Fall back to the Anthropic weave default
-      # so `on` can't leave opencode pointing at a missing provider.
+      # Never restore a legacy weave-codex model whose provider is no longer
+      # registered (every current install strips weave-codex). Fall back to the
+      # `weave` default so `on` can't leave opencode pointing at a missing
+      # provider.
       case "$restore_model" in
         weave-codex/*)
           if [ "$(jq -r '((.provider // {}) | has("weave-codex"))' "$f" 2>/dev/null || true)" != "true" ]; then
@@ -1849,13 +1849,14 @@ if [ "$target" = "opencode" ]; then
   printf "\n"
   printf "%s✓%s %s%sWeave Router installed for opencode.%s\n" \
     "$C_GREEN" "$C_RESET" "$C_BOLD" "$C_BRAND" "$C_RESET"
-  # Surface the optional Codex-subscription path only when this run actually
-  # registered the weave-codex provider. Gate on the provider's presence in the
-  # written config (authoritative) rather than a plugin file on disk — a
-  # leftover plugin from a prior install can outlive a plugin-less re-install
-  # that stripped the provider, which would make these instructions misleading.
-  if jq -e '(.provider // {}) | has("weave-codex")' "$opencode_config_file" >/dev/null 2>&1; then
-    info "To pay for opencode turns with your own ChatGPT (Codex) subscription: run ${C_BOLD}opencode auth login${C_RESET} → ${C_BOLD}ChatGPT Pro/Plus${C_RESET}, then pick a ${C_BOLD}weave-codex${C_RESET} model."
+  # Surface the optional subscription-routing path only when this run actually
+  # registered the weave-claude login provider (which is written together with
+  # the plugin). Gate on its presence in the written config (authoritative)
+  # rather than a plugin file on disk — a leftover plugin from a prior install
+  # can outlive a plugin-less re-install that stripped the provider, which would
+  # make these instructions misleading.
+  if jq -e '(.provider // {}) | has("weave-claude")' "$opencode_config_file" >/dev/null 2>&1; then
+    info "Optional: connect your AI plans so they pay for the matching turns. Run ${C_BOLD}opencode auth login${C_RESET} → ${C_BOLD}Weave Router${C_RESET} for ${C_BOLD}ChatGPT Pro/Plus${C_RESET} (GPT/Codex turns) and/or ${C_BOLD}Weave Router — Claude plan${C_RESET} for ${C_BOLD}Claude Pro/Max${C_RESET} (Claude turns). The router still routes every turn; your Weave key pays for the rest."
   fi
   if [ -n "$install_dir" ]; then
     # --dir installs land outside opencode's discovery roots, so the caller

--- a/install/opencode-weave/README.md
+++ b/install/opencode-weave/README.md
@@ -1,59 +1,78 @@
-# opencode Weave Codex plugin
+# opencode Weave subscription plugin
 
-Lets a caller's own **ChatGPT (Codex) subscription** pay for their **opencode**
-turns, routed through the Weave Router. Bundled into `@workweave/router`; the
-installer (`--codex` / `--opencode`) drops `src/index.ts` into the user's
-opencode plugins dir and writes a matching `weave-codex` provider block into
-`opencode.json`.
+Lets a caller's own **AI subscriptions** pay for their **opencode** turns, routed
+through the Weave Router. A subscription is a **credential scoped to the model
+family it can pay for**, not a provider you pick: you connect your ChatGPT
+(Codex) and/or Claude (Pro/Max) plan once, the router routes every turn to the
+best model, and bills the plan that matches the model it served — ChatGPT pays
+for GPT/Codex turns, Claude pays for Claude turns, your Weave key pays for
+everything else.
+
+Bundled into `@workweave/router`; the installer (`--codex` / `--opencode`) drops
+`src/index.ts` into the user's opencode plugins dir and writes a single
+Responses-format `weave` provider (plus a login-only `weave-claude` provider)
+into `opencode.json`.
 
 ## Why a plugin (config alone can't do it)
 
 opencode removed built-in subscription auth in 1.3.0 and binds OAuth to its own
-first-party providers — its bundled `openai/codex.ts` plugin hardcodes the
-upstream to `chatgpt.com` and binds provider id `openai`, so a custom router
-provider can't reuse it. And a subscription needs the caller's OAuth token in
-`Authorization`, which expires hourly — a static `options.headers` string can't
-refresh it.
-
-This plugin re-implements the same ChatGPT OAuth + refresh against a **custom**
-provider id (`weave-codex`) and, crucially, **leaves the request URL on the
-Weave Router** instead of rewriting it to `chatgpt.com`.
+first-party providers, so a custom router provider can't reuse it. And
+subscription tokens expire hourly — a static `options.headers` string can't
+refresh them, nor carry two subscriptions whose tokens rotate independently.
 
 ## Wire shape it produces
 
-Matches the router's `/v1/responses` Codex passthrough:
+opencode talks to one Responses-format `weave` provider; the plugin's loader
+attaches whichever subscriptions are connected to **every** request via the
+router's dedicated headers:
 
 | | |
 |---|---|
 | `POST {router}/v1/responses` | Responses wire format (opencode's default for an `@ai-sdk/openai` provider) |
-| `Authorization: Bearer <ChatGPT JWT>` | the caller's subscription, refreshed on expiry |
-| `ChatGPT-Account-Id: <id>` | paired account id (required by the Codex backend) |
-| `X-Weave-Router-Key: rk_…` | from `opencode.json` `options.headers` — the router authenticates off this, leaving `Authorization` free for the JWT |
-| `originator`, `session-id` | from the plugin's `chat.headers` hook (Codex backend session continuity) |
+| `X-Weave-OpenAI-Subscription: <ChatGPT JWT>` | pays GPT/Codex turns, refreshed on expiry |
+| `X-Weave-OpenAI-Account-ID: <id>` | paired account id (required by the Codex backend) |
+| `X-Weave-Anthropic-Subscription: <sk-ant-oat token>` | pays Claude turns, refreshed on expiry |
+| `X-Weave-Router-Key: rk_…` | from `opencode.json` `options.headers` — the router authenticates off this |
 
-The router detects the inbound Codex bearer and serves the turn on the caller's
-own plan at the subscription fee.
+The router routes the turn across every model the caller's subs + key can pay
+for and resolves the subscription matching the chosen provider, so a sub is
+never billed for a turn outside its family.
 
-## Division of responsibility
+## Two storage slots, one request provider
 
-- **Installer** writes the router key + identity headers (`X-Weave-Router-Key`,
-  `X-App`, `X-Weave-User-Email`) into `opencode.json` `options.headers`.
-- **This plugin** manages only the dynamic, secret, refreshable subscription
-  credential (the `Authorization` bearer + `ChatGPT-Account-Id`) via the auth
-  `loader`, and the login flow via auth `methods` (browser PKCE + headless
-  device code). Tokens are stored in opencode's own auth store under the
-  `weave-codex` provider id.
+opencode stores one credential per provider id and the loader's `getAuth()` is
+scoped to its own provider, so the two logins live in two slots:
 
-## Env overrides
+- **`weave`** — the request provider. Owns the **ChatGPT** login and the loader
+  that attaches both subscriptions. Connecting ChatGPT activates sub-routing.
+- **`weave-claude`** — login-only (no models, serves no requests). Owns the
+  **Claude** login. Its token is read from opencode's on-disk auth store by the
+  `weave` loader (the SDK exposes no get-by-id).
 
-- `WEAVE_CODEX_OAUTH_ISSUER` — override the OpenAI auth issuer (self-hosted
-  OpenAI auth proxies; also used by the capture tests).
+With neither connected, `weave` is a plain router provider (your Weave key pays)
+— the loader simply doesn't run. Connecting ChatGPT is what turns on
+subscription routing; the Claude sub then rides along when present.
+
+## Login
+
+`opencode auth login` → **Weave Router** → *ChatGPT Pro/Plus* (browser or
+headless device code) and/or **Weave Router — Claude plan** → *Claude Pro/Max*
+(browser; paste the `code#state` shown after authorizing).
+
+## Env overrides (self-host + tests)
+
+- `WEAVE_CODEX_OAUTH_ISSUER` — OpenAI auth issuer.
+- `WEAVE_ANTHROPIC_OAUTH_AUTHORIZE` / `WEAVE_ANTHROPIC_OAUTH_TOKEN` — Anthropic
+  OAuth authorize host / token endpoint.
+- `WEAVE_OPENCODE_AUTH_FILE` — path to opencode's `auth.json` (the `weave`
+  loader reads the `weave-claude` slot from here; defaults to
+  `$XDG_DATA_HOME/opencode/auth.json`).
 
 ## Verification
 
-Capture-tested end-to-end against a local server standing in for the router
-(opencode 1.17.9, real ChatGPT login): the inject path forwards the real JWT +
-account-id in Responses format to `/v1/responses`, and the refresh path detects
-an expired token, refreshes against the issuer, rotates + persists the tokens,
-and injects the refreshed bearer. Typechecks under `strict` against
-`@opencode-ai/plugin`.
+`bun test test/` (run under bun, opencode's own runtime) covers: dual-sub
+injection via the dedicated headers with the router key preserved and
+`Authorization` left clean; ChatGPT-only graceful degradation; expired Claude
+token refresh + persist + rotated injection; the loader staying inert without
+oauth; and the Claude login hook's canonical OAuth flow + `code#state` exchange.
+Typechecks under `strict` against `@opencode-ai/plugin`.

--- a/install/opencode-weave/src/index.ts
+++ b/install/opencode-weave/src/index.ts
@@ -487,13 +487,18 @@ export const WeaveCodex: Plugin = async (input: PluginInput): Promise<Hooks> => 
             // model, so neither sub rides in Authorization.
             const headers = new Headers(init?.headers as HeadersInit | undefined)
 
-            const chatgpt = await resolveChatGPT()
+            // Resolve both subs independently and never let one failure (e.g. a
+            // failed ChatGPT token refresh) drop the other or fail the turn — a
+            // Claude-routed turn must still get its sub when the ChatGPT refresh
+            // is down, and vice-versa. Each resolver already persists rotations.
+            const [chatgpt, anthropic] = await Promise.all([
+              resolveChatGPT().catch(() => undefined),
+              resolveAnthropic().catch(() => undefined),
+            ])
             if (chatgpt?.access) {
               headers.set(HEADER_OPENAI_SUB, chatgpt.access)
               if (chatgpt.accountId) headers.set(HEADER_OPENAI_ACCOUNT_ID, chatgpt.accountId)
             }
-
-            const anthropic = await resolveAnthropic()
             if (anthropic) headers.set(HEADER_ANTHROPIC_SUB, anthropic)
 
             return fetch(requestInput, { ...init, headers })

--- a/install/opencode-weave/src/index.ts
+++ b/install/opencode-weave/src/index.ts
@@ -456,7 +456,12 @@ export const WeaveCodex: Plugin = async (input: PluginInput): Promise<Hooks> => 
           const current = await readStoredOAuth(ANTHROPIC_PROVIDER_ID)
           if (!current) return undefined
           if (current.access && (current.expires ?? 0) >= Date.now()) return current.access
-          if (!current.refresh) return current.access
+          // Access is expired/absent: only a refresh can produce a live token,
+          // so without a refresh token there's no usable credential to inject —
+          // returning the stale token would have the router treat a dead Claude
+          // sub as present instead of falling back to the Weave key. (Mirrors
+          // resolveChatGPT.)
+          if (!current.refresh) return undefined
           if (!anthropicRefresh) {
             anthropicRefresh = refreshAnthropicToken(current.refresh)
               .then(async (tokens) => {

--- a/install/opencode-weave/src/index.ts
+++ b/install/opencode-weave/src/index.ts
@@ -1,42 +1,80 @@
 /**
- * @workweave/router — use a caller's ChatGPT (Codex) subscription for their
- * opencode turns, routed through the Weave Router.
+ * @workweave/router — let a caller's own AI subscriptions pay for their opencode
+ * turns, routed through the Weave Router.
  *
- * opencode removed built-in subscription auth in 1.3.0 and binds OAuth to its
- * own first-party providers (the bundled `openai/codex.ts` plugin hardcodes the
- * upstream to chatgpt.com and binds provider "openai"), so a custom router
- * provider can't reuse it. This plugin re-implements the same ChatGPT OAuth +
- * refresh against a CUSTOM provider id (`weave-codex`) and, crucially, leaves
- * the request URL pointed at the Weave Router instead of chatgpt.com.
+ * Model: a subscription is a CREDENTIAL scoped to the model family it can pay
+ * for, not a provider you pick to force a model. You connect your ChatGPT
+ * (Codex) and/or Claude (Pro/Max) plan once; the Weave Router routes every turn
+ * to the best model and bills the plan that matches the model it served — and
+ * only that. ChatGPT plan pays for GPT/Codex turns, Claude plan pays for Claude
+ * turns, your Weave key pays for everything else. No manual provider-picking.
  *
- * Wire shape produced (matches the router's /v1/responses Codex passthrough):
- *   - POST {router}/v1/responses                       (Responses wire format)
- *   - Authorization: Bearer <ChatGPT JWT>              (the caller's subscription)
- *   - ChatGPT-Account-Id: <account id>                 (paired, required by Codex backend)
- *   - X-Weave-Router-Key: rk_...                       (from config options.headers)
+ * opencode talks to one Responses-format `weave` provider; this plugin attaches
+ * BOTH subscriptions to every request via the router's dedicated headers:
+ *   - POST {router}/v1/responses                          (Responses wire format)
+ *   - X-Weave-OpenAI-Subscription: <ChatGPT JWT>          (pays GPT/Codex turns)
+ *   - X-Weave-OpenAI-Account-ID:   <account id>           (paired, Codex backend)
+ *   - X-Weave-Anthropic-Subscription: <sk-ant-oat token>  (pays Claude turns)
+ *   - X-Weave-Router-Key: rk_...                          (from config options.headers)
  *
- * The router authenticates off X-Weave-Router-Key (so Authorization is free for
- * the subscription JWT), detects the inbound Codex bearer, and serves the turn
- * on the caller's own plan at the subscription fee. The router key + identity
- * headers (X-App, X-Weave-User-Email) live in opencode.json `options.headers`
- * written by the installer; this plugin manages only the dynamic, refreshable
- * subscription credential.
+ * The router authenticates off X-Weave-Router-Key, routes the turn across all
+ * models the caller's subs + key can pay for, and resolves the matching
+ * subscription per the chosen provider (so the ChatGPT plan can never be billed
+ * for a Claude/OSS turn, and vice-versa).
+ *
+ * opencode stores one credential per provider id and the loader's getAuth() is
+ * scoped to its own provider, so the two logins live in two slots:
+ *   - provider `weave`        : the request provider; owns the ChatGPT login and
+ *                               the loader that injects both subs.
+ *   - provider `weave-claude`  : login-only; owns the Claude login. Its token is
+ *                               read from opencode's on-disk auth store by the
+ *                               `weave` loader (the SDK has no get-by-id).
+ * Connecting ChatGPT activates sub-routing; the Claude sub then rides along when
+ * present. With neither connected, `weave` is a plain router provider (your
+ * Weave key pays) — the loader simply doesn't run.
  */
 
 import type { Hooks, Plugin, PluginInput } from "@opencode-ai/plugin"
+import { readFile } from "node:fs/promises"
+import { homedir } from "node:os"
+import { join } from "node:path"
 
-const CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann"
+// ---- ChatGPT (Codex) OAuth -------------------------------------------------
+const CHATGPT_CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann"
 // Overridable for self-hosted OpenAI auth proxies and for tests (mirrors the
 // bundled codex plugin's `options.issuer`).
-const ISSUER = process.env.WEAVE_CODEX_OAUTH_ISSUER ?? "https://auth.openai.com"
+const CHATGPT_ISSUER = process.env.WEAVE_CODEX_OAUTH_ISSUER ?? "https://auth.openai.com"
 const OAUTH_PORT = 1455
 const OAUTH_POLLING_SAFETY_MARGIN_MS = 3000
-// Provider id this plugin owns. Must match the provider block the installer
-// writes into opencode.json. Deliberately NOT "openai" — that id is claimed by
-// opencode's bundled codex plugin, which rewrites the upstream to chatgpt.com.
-const PROVIDER_ID = "weave-codex"
+
+// ---- Claude (Anthropic) OAuth ----------------------------------------------
+// Canonical Claude Pro/Max OAuth (the same flow Claude Code uses): a manual
+// code-paste browser flow. Authorize on claude.ai, exchange/refresh on the
+// console token endpoint. The access token is an sk-ant-oat… subscription
+// bearer; the router applies the Bearer + oauth beta header on the upstream leg.
+const ANTHROPIC_CLIENT_ID = "9d1c250a-e61b-44d9-88ed-5944d1962f5e"
+const ANTHROPIC_AUTHORIZE_BASE = process.env.WEAVE_ANTHROPIC_OAUTH_AUTHORIZE ?? "https://claude.ai"
+const ANTHROPIC_TOKEN_URL = process.env.WEAVE_ANTHROPIC_OAUTH_TOKEN ?? "https://console.anthropic.com/v1/oauth/token"
+const ANTHROPIC_REDIRECT_URI = "https://console.anthropic.com/oauth/code/callback"
+const ANTHROPIC_SCOPE = "org:create_api_key user:profile user:inference"
+
+// Provider ids this plugin owns. `weave` is the request provider the installer
+// writes into opencode.json; `weave-claude` is login-only storage for the Claude
+// subscription. Deliberately NOT "openai"/"anthropic" — those ids are claimed by
+// opencode's bundled provider plugins, which rewrite the upstream off the router.
+const PROVIDER_ID = "weave"
+const ANTHROPIC_PROVIDER_ID = "weave-claude"
+
+// Dedicated router subscription headers. Must match the constants in
+// internal/server/middleware/auth.go so the router stashes each sub and resolves
+// it per the routed provider.
+const HEADER_OPENAI_SUB = "X-Weave-OpenAI-Subscription"
+const HEADER_OPENAI_ACCOUNT_ID = "X-Weave-OpenAI-Account-ID"
+const HEADER_ANTHROPIC_SUB = "X-Weave-Anthropic-Subscription"
+
 // Placeholder so the @ai-sdk/openai provider considers auth configured; the
-// loader's fetch overwrites Authorization with the real subscription bearer.
+// loader's fetch carries the real subscriptions in the dedicated headers and the
+// router authenticates off X-Weave-Router-Key, so this value is never used.
 const DUMMY_KEY = "weave-router-oauth"
 const USER_AGENT = "weave-router-opencode"
 
@@ -111,7 +149,7 @@ interface TokenResponse {
 function buildAuthorizeUrl(redirectUri: string, pkce: PkceCodes, state: string): string {
   const params = new URLSearchParams({
     response_type: "code",
-    client_id: CLIENT_ID,
+    client_id: CHATGPT_CLIENT_ID,
     redirect_uri: redirectUri,
     scope: "openid profile email offline_access",
     code_challenge: pkce.challenge,
@@ -121,18 +159,18 @@ function buildAuthorizeUrl(redirectUri: string, pkce: PkceCodes, state: string):
     state,
     originator: "codex_cli_ts",
   })
-  return `${ISSUER}/oauth/authorize?${params.toString()}`
+  return `${CHATGPT_ISSUER}/oauth/authorize?${params.toString()}`
 }
 
 async function exchangeCodeForTokens(code: string, redirectUri: string, pkce: PkceCodes): Promise<TokenResponse> {
-  const response = await fetch(`${ISSUER}/oauth/token`, {
+  const response = await fetch(`${CHATGPT_ISSUER}/oauth/token`, {
     method: "POST",
     headers: { "Content-Type": "application/x-www-form-urlencoded" },
     body: new URLSearchParams({
       grant_type: "authorization_code",
       code,
       redirect_uri: redirectUri,
-      client_id: CLIENT_ID,
+      client_id: CHATGPT_CLIENT_ID,
       code_verifier: pkce.verifier,
     }).toString(),
   })
@@ -141,20 +179,115 @@ async function exchangeCodeForTokens(code: string, redirectUri: string, pkce: Pk
 }
 
 async function refreshAccessToken(refreshToken: string): Promise<TokenResponse> {
-  const response = await fetch(`${ISSUER}/oauth/token`, {
+  const response = await fetch(`${CHATGPT_ISSUER}/oauth/token`, {
     method: "POST",
     headers: { "Content-Type": "application/x-www-form-urlencoded" },
     body: new URLSearchParams({
       grant_type: "refresh_token",
       refresh_token: refreshToken,
-      client_id: CLIENT_ID,
+      client_id: CHATGPT_CLIENT_ID,
     }).toString(),
   })
   if (!response.ok) throw new Error(`Token refresh failed: ${response.status}`)
   return response.json() as Promise<TokenResponse>
 }
 
-// ---- Browser OAuth loopback server (PKCE) --------------------------------
+// ---- Claude (Anthropic) OAuth helpers --------------------------------------
+
+interface AnthropicTokens {
+  access: string
+  refresh: string
+  expires: number
+}
+
+function buildAnthropicAuthorizeUrl(pkce: PkceCodes): string {
+  const url = new URL(`${ANTHROPIC_AUTHORIZE_BASE}/oauth/authorize`)
+  url.searchParams.set("code", "true")
+  url.searchParams.set("client_id", ANTHROPIC_CLIENT_ID)
+  url.searchParams.set("response_type", "code")
+  url.searchParams.set("redirect_uri", ANTHROPIC_REDIRECT_URI)
+  url.searchParams.set("scope", ANTHROPIC_SCOPE)
+  url.searchParams.set("code_challenge", pkce.challenge)
+  url.searchParams.set("code_challenge_method", "S256")
+  // Claude Code reuses the PKCE verifier as the state value; the manual code is
+  // returned to the user as "<code>#<state>".
+  url.searchParams.set("state", pkce.verifier)
+  return url.toString()
+}
+
+async function exchangeAnthropicCode(code: string, verifier: string): Promise<AnthropicTokens> {
+  const [authCode, state] = code.trim().split("#")
+  const response = await fetch(ANTHROPIC_TOKEN_URL, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      grant_type: "authorization_code",
+      code: authCode,
+      state,
+      client_id: ANTHROPIC_CLIENT_ID,
+      redirect_uri: ANTHROPIC_REDIRECT_URI,
+      code_verifier: verifier,
+    }),
+  })
+  if (!response.ok) throw new Error(`Anthropic token exchange failed: ${response.status}`)
+  const json = (await response.json()) as { access_token: string; refresh_token: string; expires_in?: number }
+  return { access: json.access_token, refresh: json.refresh_token, expires: Date.now() + (json.expires_in ?? 3600) * 1000 }
+}
+
+async function refreshAnthropicToken(refreshToken: string): Promise<AnthropicTokens> {
+  const response = await fetch(ANTHROPIC_TOKEN_URL, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      grant_type: "refresh_token",
+      refresh_token: refreshToken,
+      client_id: ANTHROPIC_CLIENT_ID,
+    }),
+  })
+  if (!response.ok) throw new Error(`Anthropic token refresh failed: ${response.status}`)
+  const json = (await response.json()) as { access_token: string; refresh_token?: string; expires_in?: number }
+  return {
+    access: json.access_token,
+    // OAuth 2.0 lets the issuer omit a new refresh_token on refresh; keep the
+    // existing one in that case rather than clearing it.
+    refresh: json.refresh_token ?? refreshToken,
+    expires: Date.now() + (json.expires_in ?? 3600) * 1000,
+  }
+}
+
+// ---- opencode auth-store reader (cross-provider) ---------------------------
+// The `weave` loader's getAuth() is scoped to `weave`, and the SDK exposes no
+// get-by-id, so the Claude credential stored under `weave-claude` is read from
+// opencode's on-disk auth store directly. Path mirrors opencode's Global.Path
+// (XDG data home + /opencode/auth.json); overridable for tests.
+
+interface StoredOAuth {
+  type: string
+  access?: string
+  refresh?: string
+  expires?: number
+  accountId?: string
+}
+
+function opencodeAuthFile(): string {
+  const override = process.env.WEAVE_OPENCODE_AUTH_FILE
+  if (override) return override
+  const dataHome = process.env.XDG_DATA_HOME || join(homedir(), ".local", "share")
+  return join(dataHome, "opencode", "auth.json")
+}
+
+async function readStoredOAuth(providerID: string): Promise<StoredOAuth | undefined> {
+  try {
+    const raw = await readFile(opencodeAuthFile(), "utf8")
+    const entry = (JSON.parse(raw) as Record<string, StoredOAuth>)[providerID]
+    if (entry && entry.type === "oauth") return entry
+  } catch {
+    // No store yet / unreadable / not logged in — no Claude sub to attach.
+  }
+  return undefined
+}
+
+// ---- Browser OAuth loopback server (PKCE, ChatGPT) -------------------------
 
 function escapeHtml(s: string): string {
   return s.replace(/[&<>"']/g, (c) =>
@@ -162,12 +295,12 @@ function escapeHtml(s: string): string {
   )
 }
 
-const HTML_SUCCESS = `<!doctype html><html><head><title>Weave Router — Codex authorized</title></head>
+const HTML_SUCCESS = `<!doctype html><html><head><title>Weave Router — authorized</title></head>
 <body style="font-family:system-ui;background:#131010;color:#f1ecec;display:flex;justify-content:center;align-items:center;height:100vh;margin:0">
 <div style="text-align:center"><h1>Authorization successful</h1><p>You can close this window and return to opencode.</p>
 <script>setTimeout(()=>window.close(),2000)</script></div></body></html>`
 
-const renderOAuthError = (error: string) => `<!doctype html><html><head><title>Weave Router — Codex authorization failed</title></head>
+const renderOAuthError = (error: string) => `<!doctype html><html><head><title>Weave Router — authorization failed</title></head>
 <body style="font-family:system-ui;background:#131010;color:#f1ecec;display:flex;justify-content:center;align-items:center;height:100vh;margin:0">
 <div style="text-align:center"><h1 style="color:#fc533a">Authorization failed</h1>
 <div style="color:#ff917b;font-family:monospace;margin-top:1rem;padding:1rem;background:#3c140d;border-radius:.5rem">${escapeHtml(error)}</div></div></body></html>`
@@ -259,7 +392,7 @@ function waitForOAuthCallback(pkce: PkceCodes, state: string): Promise<TokenResp
   })
 }
 
-// ---- Plugin --------------------------------------------------------------
+// ---- Request provider: `weave` (Responses, both subs) ----------------------
 
 export const WeaveCodex: Plugin = async (input: PluginInput): Promise<Hooks> => {
   return {
@@ -269,69 +402,96 @@ export const WeaveCodex: Plugin = async (input: PluginInput): Promise<Hooks> => 
         const auth = await getAuth()
         if (auth.type !== "oauth") return {}
 
-        // Coalesce concurrent refreshes (opencode fires parallel turns).
-        let refreshPromise: Promise<{ access: string; accountId: string | undefined }> | undefined
+        // Coalesce concurrent refreshes (opencode fires parallel turns), one
+        // in-flight promise per subscription.
+        let chatgptRefresh: Promise<{ access: string; accountId: string | undefined }> | undefined
+        let anthropicRefresh: Promise<string | undefined> | undefined
+
+        // Resolve the ChatGPT (Codex) sub from this provider's own slot,
+        // refreshing + persisting the rotated token on (or just before) expiry.
+        async function resolveChatGPT(): Promise<{ access: string; accountId?: string } | undefined> {
+          const current = (await getAuth()) as StoredOAuth
+          if (current.type !== "oauth" || !current.refresh) return undefined
+          if (current.access && (current.expires ?? 0) >= Date.now()) {
+            return { access: current.access, accountId: current.accountId }
+          }
+          if (!chatgptRefresh) {
+            chatgptRefresh = refreshAccessToken(current.refresh)
+              .then(async (tokens) => {
+                const accountId = extractAccountId(tokens) || current.accountId
+                await input.client.auth.set({
+                  path: { id: PROVIDER_ID },
+                  body: {
+                    type: "oauth",
+                    refresh: tokens.refresh_token || current.refresh!,
+                    access: tokens.access_token,
+                    expires: Date.now() + (tokens.expires_in ?? 3600) * 1000,
+                    ...(accountId && { accountId }),
+                  },
+                })
+                return { access: tokens.access_token, accountId }
+              })
+              .finally(() => {
+                chatgptRefresh = undefined
+              })
+          }
+          return chatgptRefresh
+        }
+
+        // Resolve the Claude sub from the `weave-claude` slot (read off disk),
+        // refreshing + persisting the rotated token via the auth store. Returns
+        // undefined when Claude isn't connected.
+        async function resolveAnthropic(): Promise<string | undefined> {
+          const current = await readStoredOAuth(ANTHROPIC_PROVIDER_ID)
+          if (!current) return undefined
+          if (current.access && (current.expires ?? 0) >= Date.now()) return current.access
+          if (!current.refresh) return current.access
+          if (!anthropicRefresh) {
+            anthropicRefresh = refreshAnthropicToken(current.refresh)
+              .then(async (tokens) => {
+                await input.client.auth.set({
+                  path: { id: ANTHROPIC_PROVIDER_ID },
+                  body: { type: "oauth", refresh: tokens.refresh, access: tokens.access, expires: tokens.expires },
+                })
+                return tokens.access
+              })
+              // A failed Claude refresh must not fail the turn — fall back to the
+              // (possibly stale) token; an expired Claude turn the router can't
+              // bill to the plan falls through to the Weave key on its end.
+              .catch(() => current.access)
+              .finally(() => {
+                anthropicRefresh = undefined
+              })
+          }
+          return anthropicRefresh
+        }
 
         return {
           apiKey: DUMMY_KEY,
           async fetch(requestInput: RequestInfo | URL, init?: RequestInit) {
-            const currentAuth = (await getAuth()) as {
-              type: string
-              access: string
-              refresh: string
-              expires: number
-              accountId?: string
-            }
-            if (currentAuth.type !== "oauth") return fetch(requestInput, init)
-
-            // Refresh the access token on (or just before) expiry and persist
-            // the rotated refresh token back into opencode's auth store.
-            if (!currentAuth.access || currentAuth.expires < Date.now()) {
-              if (!refreshPromise) {
-                refreshPromise = refreshAccessToken(currentAuth.refresh)
-                  .then(async (tokens) => {
-                    const accountId = extractAccountId(tokens) || currentAuth.accountId
-                    await input.client.auth.set({
-                      path: { id: PROVIDER_ID },
-                      body: {
-                        type: "oauth",
-                        // OAuth 2.0 lets the issuer omit a new refresh_token on
-                        // refresh (the existing one stays valid). Keep the
-                        // stored one in that case rather than clearing it.
-                        refresh: tokens.refresh_token || currentAuth.refresh,
-                        access: tokens.access_token,
-                        expires: Date.now() + (tokens.expires_in ?? 3600) * 1000,
-                        ...(accountId && { accountId }),
-                      },
-                    })
-                    return { access: tokens.access_token, accountId }
-                  })
-                  .finally(() => {
-                    refreshPromise = undefined
-                  })
-              }
-              const refreshed = await refreshPromise
-              currentAuth.access = refreshed.access
-              currentAuth.accountId = refreshed.accountId
-            }
-
-            // Preserve the configured headers (X-Weave-Router-Key, X-App, ...
-            // from opencode.json options.headers), then overwrite Authorization
-            // with the caller's subscription bearer + the paired account id.
+            // Preserve the configured headers (X-Weave-Router-Key, X-App, …) and
+            // attach each connected subscription via its dedicated router header.
+            // Authorization is left as the @ai-sdk placeholder; the router authes
+            // off X-Weave-Router-Key and resolves the matching sub per the routed
+            // model, so neither sub rides in Authorization.
             const headers = new Headers(init?.headers as HeadersInit | undefined)
-            headers.set("authorization", `Bearer ${currentAuth.access}`)
-            if (currentAuth.accountId) headers.set("ChatGPT-Account-Id", currentAuth.accountId)
 
-            // NOTE: unlike opencode's bundled codex plugin we deliberately do
-            // NOT rewrite the URL — the request stays on the Weave Router, which
-            // forwards it to the Codex backend on the caller's plan.
+            const chatgpt = await resolveChatGPT()
+            if (chatgpt?.access) {
+              headers.set(HEADER_OPENAI_SUB, chatgpt.access)
+              if (chatgpt.accountId) headers.set(HEADER_OPENAI_ACCOUNT_ID, chatgpt.accountId)
+            }
+
+            const anthropic = await resolveAnthropic()
+            if (anthropic) headers.set(HEADER_ANTHROPIC_SUB, anthropic)
+
             return fetch(requestInput, { ...init, headers })
           },
         }
       },
       methods: [
         {
-          label: "ChatGPT Pro/Plus (browser)",
+          label: "ChatGPT Pro/Plus — pays for GPT/Codex turns (browser)",
           type: "oauth",
           authorize: async () => {
             const { redirectUri } = await startOAuthServer()
@@ -357,13 +517,13 @@ export const WeaveCodex: Plugin = async (input: PluginInput): Promise<Hooks> => 
           },
         },
         {
-          label: "ChatGPT Pro/Plus (headless device code)",
+          label: "ChatGPT Pro/Plus — pays for GPT/Codex turns (headless device code)",
           type: "oauth",
           authorize: async () => {
-            const deviceResponse = await fetch(`${ISSUER}/api/accounts/deviceauth/usercode`, {
+            const deviceResponse = await fetch(`${CHATGPT_ISSUER}/api/accounts/deviceauth/usercode`, {
               method: "POST",
               headers: { "Content-Type": "application/json", "User-Agent": USER_AGENT },
-              body: JSON.stringify({ client_id: CLIENT_ID }),
+              body: JSON.stringify({ client_id: CHATGPT_CLIENT_ID }),
             })
             if (!deviceResponse.ok) throw new Error("Failed to initiate device authorization")
             const deviceData = (await deviceResponse.json()) as {
@@ -373,13 +533,13 @@ export const WeaveCodex: Plugin = async (input: PluginInput): Promise<Hooks> => 
             }
             const interval = Math.max(parseInt(deviceData.interval) || 5, 1) * 1000
             return {
-              url: `${ISSUER}/codex/device`,
+              url: `${CHATGPT_ISSUER}/codex/device`,
               instructions: `Enter code: ${deviceData.user_code}`,
               method: "auto" as const,
               async callback() {
                 const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms))
                 while (true) {
-                  const response = await fetch(`${ISSUER}/api/accounts/deviceauth/token`, {
+                  const response = await fetch(`${CHATGPT_ISSUER}/api/accounts/deviceauth/token`, {
                     method: "POST",
                     headers: { "Content-Type": "application/json", "User-Agent": USER_AGENT },
                     body: JSON.stringify({
@@ -389,14 +549,14 @@ export const WeaveCodex: Plugin = async (input: PluginInput): Promise<Hooks> => 
                   })
                   if (response.ok) {
                     const data = (await response.json()) as { authorization_code: string; code_verifier: string }
-                    const tokenResponse = await fetch(`${ISSUER}/oauth/token`, {
+                    const tokenResponse = await fetch(`${CHATGPT_ISSUER}/oauth/token`, {
                       method: "POST",
                       headers: { "Content-Type": "application/x-www-form-urlencoded" },
                       body: new URLSearchParams({
                         grant_type: "authorization_code",
                         code: data.authorization_code,
-                        redirect_uri: `${ISSUER}/deviceauth/callback`,
-                        client_id: CLIENT_ID,
+                        redirect_uri: `${CHATGPT_ISSUER}/deviceauth/callback`,
+                        client_id: CHATGPT_CLIENT_ID,
                         code_verifier: data.code_verifier,
                       }).toString(),
                     })
@@ -419,9 +579,9 @@ export const WeaveCodex: Plugin = async (input: PluginInput): Promise<Hooks> => 
         },
       ],
     },
-    // The Codex backend (which the router forwards to) keys session continuity
-    // off these headers; mirror opencode's bundled codex plugin. Scoped to our
-    // provider so other providers are untouched.
+    // The Codex backend (which the router forwards GPT turns to) keys session
+    // continuity off these headers; mirror opencode's bundled codex plugin.
+    // Scoped to our provider so other providers are untouched.
     "chat.headers": async (hookInput, output) => {
       if (hookInput.model.providerID !== PROVIDER_ID) return
       output.headers["originator"] = "codex_cli_ts"
@@ -431,6 +591,42 @@ export const WeaveCodex: Plugin = async (input: PluginInput): Promise<Hooks> => 
       if (hookInput.model.providerID !== PROVIDER_ID) return
       // Match codex cli: the Codex backend rejects an explicit max output cap.
       output.maxOutputTokens = undefined
+    },
+  }
+}
+
+// ---- Login-only provider: `weave-claude` (Claude Pro/Max) ------------------
+// A second auth hook so the Claude subscription gets its own storage slot
+// (opencode keys credentials by provider id). It serves no requests — the
+// `weave` loader reads this slot and attaches the token — so it needs no loader.
+
+export const WeaveClaude: Plugin = async (_input: PluginInput): Promise<Hooks> => {
+  return {
+    auth: {
+      provider: ANTHROPIC_PROVIDER_ID,
+      methods: [
+        {
+          label: "Claude Pro/Max — pays for Claude turns (browser)",
+          type: "oauth",
+          authorize: async () => {
+            const pkce = await generatePKCE()
+            return {
+              url: buildAnthropicAuthorizeUrl(pkce),
+              instructions: "Sign in with your Claude account, then paste the code shown (looks like `code#state`).",
+              method: "code" as const,
+              callback: async (code: string) => {
+                const tokens = await exchangeAnthropicCode(code, pkce.verifier)
+                return {
+                  type: "success" as const,
+                  refresh: tokens.refresh,
+                  access: tokens.access,
+                  expires: tokens.expires,
+                }
+              },
+            }
+          },
+        },
+      ],
     },
   }
 }

--- a/install/opencode-weave/src/index.ts
+++ b/install/opencode-weave/src/index.ts
@@ -216,6 +216,11 @@ function buildAnthropicAuthorizeUrl(pkce: PkceCodes): string {
 }
 
 async function exchangeAnthropicCode(code: string, verifier: string): Promise<AnthropicTokens> {
+  // The manual flow returns "<code>#<state>"; without the separator the state
+  // would be undefined and the server would 4xx with an opaque error.
+  if (!code.includes("#")) {
+    throw new Error(`Expected the pasted code in "code#state" format; got: ${code.trim().slice(0, 24)}…`)
+  }
   const [authCode, state] = code.trim().split("#")
   const response = await fetch(ANTHROPIC_TOKEN_URL, {
     method: "POST",
@@ -411,10 +416,16 @@ export const WeaveCodex: Plugin = async (input: PluginInput): Promise<Hooks> => 
         // refreshing + persisting the rotated token on (or just before) expiry.
         async function resolveChatGPT(): Promise<{ access: string; accountId?: string } | undefined> {
           const current = (await getAuth()) as StoredOAuth
-          if (current.type !== "oauth" || !current.refresh) return undefined
+          if (current.type !== "oauth") return undefined
+          // Use a still-valid access token regardless of whether a refresh token
+          // is present (a partial store could lack it). Only an expired/absent
+          // access needs a refresh — and that needs the refresh token.
           if (current.access && (current.expires ?? 0) >= Date.now()) {
             return { access: current.access, accountId: current.accountId }
           }
+          // Access is expired/absent: a refresh is the only way forward, so
+          // without a refresh token there's no usable credential.
+          if (!current.refresh) return undefined
           if (!chatgptRefresh) {
             chatgptRefresh = refreshAccessToken(current.refresh)
               .then(async (tokens) => {

--- a/install/opencode-weave/test/capture.test.ts
+++ b/install/opencode-weave/test/capture.test.ts
@@ -81,7 +81,7 @@ async function runLoaderFetch(
   let captured: CapturedRequest | undefined
   globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
     const url = typeof input === "string" ? input : input.toString()
-    if (url.includes("/oauth/token")) {
+    if (new URL(url).pathname.endsWith("/oauth/token")) {
       const body = tokenResponder ? tokenResponder(url) : {}
       // A responder returning null/undefined for a token URL simulates a failed
       // refresh (non-2xx), so tests can exercise the resilience paths.
@@ -179,7 +179,7 @@ describe("weave loader — dual subscription injection", () => {
       accountId: CHATGPT_ACCOUNT,
     })
 
-    const req = await runLoaderFetch(getAuth, (url) => (url.startsWith(CHATGPT_ISSUER) ? undefined : {}))
+    const req = await runLoaderFetch(getAuth, (url) => (url === `${CHATGPT_ISSUER}/oauth/token` ? undefined : {}))
 
     // ChatGPT refresh failed → no OpenAI headers, but the turn still went out…
     expect(req.headers["x-weave-openai-subscription"]).toBeUndefined()
@@ -205,7 +205,7 @@ describe("weave loader — dual subscription injection", () => {
 
     const rotated = "sk-ant-oat01-rotated"
     const req = await runLoaderFetch(getAuth, (url) => {
-      if (url.startsWith(ANTHROPIC_TOKEN_URL)) {
+      if (url === ANTHROPIC_TOKEN_URL) {
         return { access_token: rotated, refresh_token: "claude-refresh-2", expires_in: 3600 }
       }
       return {}

--- a/install/opencode-weave/test/capture.test.ts
+++ b/install/opencode-weave/test/capture.test.ts
@@ -1,0 +1,249 @@
+/**
+ * Capture tests for the Weave opencode subscription plugin (run under bun, the
+ * runtime opencode itself uses): bun test install/opencode-weave/test
+ *
+ * These exercise the plugin's runtime contract without a live opencode:
+ *   1. the `weave` loader attaches BOTH subscriptions to a request via the
+ *      router's dedicated X-Weave-*-Subscription headers, preserves the
+ *      configured router-key/identity headers, and leaves Authorization alone;
+ *   2. an expired Claude token (read from the on-disk weave-claude slot) is
+ *      refreshed and the rotated token persisted + injected;
+ *   3. the `weave-claude` login hook builds the canonical Claude OAuth flow and
+ *      exchanges a pasted code.
+ *
+ * Type-only imports from @opencode-ai/plugin are erased at runtime, so no
+ * opencode package is needed to load the module.
+ */
+import { afterEach, beforeEach, describe, expect, test } from "bun:test"
+import { mkdtemp, writeFile, readFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+
+const ANTHROPIC_TOKEN_URL = "https://token.example.test/anthropic/oauth/token"
+const CHATGPT_ISSUER = "https://issuer.example.test"
+
+// Set the env overrides BEFORE importing the module (constants are read at load).
+process.env.WEAVE_ANTHROPIC_OAUTH_TOKEN = ANTHROPIC_TOKEN_URL
+process.env.WEAVE_CODEX_OAUTH_ISSUER = CHATGPT_ISSUER
+
+const ROUTER_KEY = "rk_capture_test"
+const CHATGPT_ACCESS = "eyJhbGciOiJChatGPTaccessJWT"
+const CHATGPT_ACCOUNT = "acct-1234-5678"
+const CLAUDE_ACCESS = "sk-ant-oat01-claude-access"
+const CLAUDE_REFRESH = "claude-refresh-token"
+
+const realFetch = globalThis.fetch
+let authFile: string
+let setCalls: Array<{ id: string; body: Record<string, unknown> }>
+
+interface CapturedRequest {
+  url: string
+  headers: Record<string, string>
+}
+
+// Build a PluginInput whose client.auth.set records the write (and, to mimic
+// persistence, rewrites the on-disk auth file the loader reads from).
+function fakeInput() {
+  return {
+    client: {
+      auth: {
+        async set(opts: { path: { id: string }; body: Record<string, unknown> }) {
+          setCalls.push({ id: opts.path.id, body: opts.body })
+          const raw = JSON.parse(await readFile(authFile, "utf8"))
+          raw[opts.path.id] = opts.body
+          await writeFile(authFile, JSON.stringify(raw))
+        },
+      },
+    },
+  } as unknown as import("@opencode-ai/plugin").PluginInput
+}
+
+beforeEach(async () => {
+  authFile = join(await mkdtemp(join(tmpdir(), "weave-auth-")), "auth.json")
+  process.env.WEAVE_OPENCODE_AUTH_FILE = authFile
+  setCalls = []
+})
+
+afterEach(() => {
+  globalThis.fetch = realFetch
+})
+
+// Drive the loader's fetch once and capture the upstream request. tokenResponder
+// answers any OAuth /oauth/token call (ChatGPT or Anthropic) so refreshes work.
+async function runLoaderFetch(
+  getAuth: () => Promise<Record<string, unknown>>,
+  tokenResponder?: (url: string) => unknown,
+): Promise<CapturedRequest> {
+  const { WeaveCodex } = await import("../src/index.ts")
+  const hooks = await WeaveCodex(fakeInput())
+  const loaded = await hooks.auth!.loader!(getAuth as never, {} as never)
+
+  let captured: CapturedRequest | undefined
+  globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = typeof input === "string" ? input : input.toString()
+    if (url.includes("/oauth/token")) {
+      return new Response(JSON.stringify(tokenResponder ? tokenResponder(url) : {}), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      })
+    }
+    const headers: Record<string, string> = {}
+    new Headers(init?.headers as HeadersInit).forEach((v, k) => (headers[k] = v))
+    captured = { url, headers }
+    return new Response("{}", { status: 200, headers: { "Content-Type": "application/json" } })
+  }) as typeof fetch
+
+  // opencode's @ai-sdk provider sends the configured headers + an Authorization
+  // bearer built from the (placeholder) apiKey.
+  await (loaded.fetch as typeof fetch)("https://router.example.test/v1/responses", {
+    method: "POST",
+    headers: {
+      "X-Weave-Router-Key": ROUTER_KEY,
+      "X-App": "opencode",
+      Authorization: "Bearer weave-router-oauth",
+    },
+  })
+  if (!captured) throw new Error("upstream request was not captured")
+  return captured
+}
+
+describe("weave loader — dual subscription injection", () => {
+  test("attaches both subs via dedicated headers, preserves router key, leaves Authorization", async () => {
+    // Claude slot present + unexpired on disk.
+    await writeFile(
+      authFile,
+      JSON.stringify({
+        "weave-claude": { type: "oauth", access: CLAUDE_ACCESS, refresh: CLAUDE_REFRESH, expires: Date.now() + 3_600_000 },
+      }),
+    )
+    // ChatGPT (own provider) auth: unexpired.
+    const getAuth = async () => ({
+      type: "oauth",
+      access: CHATGPT_ACCESS,
+      refresh: "cg-refresh",
+      expires: Date.now() + 3_600_000,
+      accountId: CHATGPT_ACCOUNT,
+    })
+
+    const req = await runLoaderFetch(getAuth)
+
+    expect(req.headers["x-weave-openai-subscription"]).toBe(CHATGPT_ACCESS)
+    expect(req.headers["x-weave-openai-account-id"]).toBe(CHATGPT_ACCOUNT)
+    expect(req.headers["x-weave-anthropic-subscription"]).toBe(CLAUDE_ACCESS)
+    // Configured headers survive.
+    expect(req.headers["x-weave-router-key"]).toBe(ROUTER_KEY)
+    expect(req.headers["x-app"]).toBe("opencode")
+    // Neither subscription leaks into Authorization (router resolves per model).
+    expect(req.headers["authorization"]).not.toContain(CHATGPT_ACCESS)
+    expect(req.headers["authorization"]).not.toContain(CLAUDE_ACCESS)
+    // No refresh happened (tokens were fresh).
+    expect(setCalls).toHaveLength(0)
+  })
+
+  test("ChatGPT-only (no Claude connected) attaches only the OpenAI sub", async () => {
+    await writeFile(authFile, JSON.stringify({})) // no weave-claude slot
+    const getAuth = async () => ({
+      type: "oauth",
+      access: CHATGPT_ACCESS,
+      refresh: "cg-refresh",
+      expires: Date.now() + 3_600_000,
+      accountId: CHATGPT_ACCOUNT,
+    })
+
+    const req = await runLoaderFetch(getAuth)
+
+    expect(req.headers["x-weave-openai-subscription"]).toBe(CHATGPT_ACCESS)
+    expect(req.headers["x-weave-anthropic-subscription"]).toBeUndefined()
+    expect(req.headers["x-weave-router-key"]).toBe(ROUTER_KEY)
+  })
+
+  test("refreshes an expired Claude token, persists it to weave-claude, and injects the rotated token", async () => {
+    await writeFile(
+      authFile,
+      JSON.stringify({
+        "weave-claude": { type: "oauth", access: "stale", refresh: CLAUDE_REFRESH, expires: Date.now() - 1000 },
+      }),
+    )
+    const getAuth = async () => ({
+      type: "oauth",
+      access: CHATGPT_ACCESS,
+      refresh: "cg-refresh",
+      expires: Date.now() + 3_600_000,
+      accountId: CHATGPT_ACCOUNT,
+    })
+
+    const rotated = "sk-ant-oat01-rotated"
+    const req = await runLoaderFetch(getAuth, (url) => {
+      if (url.startsWith(ANTHROPIC_TOKEN_URL)) {
+        return { access_token: rotated, refresh_token: "claude-refresh-2", expires_in: 3600 }
+      }
+      return {}
+    })
+
+    // Rotated token injected on the wire.
+    expect(req.headers["x-weave-anthropic-subscription"]).toBe(rotated)
+    // Persisted back to the weave-claude slot.
+    const claudeSet = setCalls.find((c) => c.id === "weave-claude")
+    expect(claudeSet).toBeDefined()
+    expect(claudeSet!.body.access).toBe(rotated)
+    expect(claudeSet!.body.refresh).toBe("claude-refresh-2")
+  })
+
+  test("loader is inert when the provider has no oauth (no subs attached)", async () => {
+    await writeFile(authFile, JSON.stringify({}))
+    const { WeaveCodex } = await import("../src/index.ts")
+    const hooks = await WeaveCodex(fakeInput())
+    const loaded = await hooks.auth!.loader!(
+      (async () => ({ type: "api", key: "x" })) as never,
+      {} as never,
+    )
+    expect(Object.keys(loaded)).toHaveLength(0) // {} — opencode falls back to static config
+  })
+})
+
+describe("weave-claude login hook", () => {
+  test("exposes the Claude login on its own provider with the canonical OAuth flow", async () => {
+    const { WeaveClaude } = await import("../src/index.ts")
+    const hooks = await WeaveClaude(fakeInput())
+    expect(hooks.auth!.provider).toBe("weave-claude")
+    const method = hooks.auth!.methods[0]
+    expect(method.type).toBe("oauth")
+    expect(method.label).toContain("Claude")
+
+    const result = await (method as { authorize: () => Promise<{ url: string; method: string }> }).authorize()
+    const url = new URL(result.url)
+    expect(url.origin).toBe("https://claude.ai")
+    expect(url.pathname).toBe("/oauth/authorize")
+    expect(url.searchParams.get("client_id")).toBe("9d1c250a-e61b-44d9-88ed-5944d1962f5e")
+    expect(url.searchParams.get("redirect_uri")).toBe("https://console.anthropic.com/oauth/code/callback")
+    expect(url.searchParams.get("code_challenge_method")).toBe("S256")
+    expect(result.method).toBe("code")
+  })
+
+  test("exchanges a pasted code#state for tokens", async () => {
+    const { WeaveClaude } = await import("../src/index.ts")
+    const hooks = await WeaveClaude(fakeInput())
+    const method = hooks.auth!.methods[0] as {
+      authorize: () => Promise<{ callback: (code: string) => Promise<Record<string, unknown>> }>
+    }
+    const flow = await method.authorize()
+
+    let exchangeBody: Record<string, unknown> | undefined
+    globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      exchangeBody = JSON.parse(String(init?.body))
+      return new Response(
+        JSON.stringify({ access_token: CLAUDE_ACCESS, refresh_token: CLAUDE_REFRESH, expires_in: 3600 }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      )
+    }) as typeof fetch
+
+    const out = await flow.callback("THECODE#THESTATE")
+    expect(out.type).toBe("success")
+    expect(out.access).toBe(CLAUDE_ACCESS)
+    expect(out.refresh).toBe(CLAUDE_REFRESH)
+    // Code/state split on the "#" the manual flow returns.
+    expect(exchangeBody!.code).toBe("THECODE")
+    expect(exchangeBody!.state).toBe("THESTATE")
+    expect(exchangeBody!.grant_type).toBe("authorization_code")
+  })
+})

--- a/install/opencode-weave/test/capture.test.ts
+++ b/install/opencode-weave/test/capture.test.ts
@@ -82,7 +82,13 @@ async function runLoaderFetch(
   globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
     const url = typeof input === "string" ? input : input.toString()
     if (url.includes("/oauth/token")) {
-      return new Response(JSON.stringify(tokenResponder ? tokenResponder(url) : {}), {
+      const body = tokenResponder ? tokenResponder(url) : {}
+      // A responder returning null/undefined for a token URL simulates a failed
+      // refresh (non-2xx), so tests can exercise the resilience paths.
+      if (body === null || body === undefined) {
+        return new Response("refresh failed", { status: 500 })
+      }
+      return new Response(JSON.stringify(body), {
         status: 200,
         headers: { "Content-Type": "application/json" },
       })
@@ -154,6 +160,31 @@ describe("weave loader — dual subscription injection", () => {
 
     expect(req.headers["x-weave-openai-subscription"]).toBe(CHATGPT_ACCESS)
     expect(req.headers["x-weave-anthropic-subscription"]).toBeUndefined()
+    expect(req.headers["x-weave-router-key"]).toBe(ROUTER_KEY)
+  })
+
+  test("a failed ChatGPT refresh still attaches the Claude sub (and doesn't fail the turn)", async () => {
+    await writeFile(
+      authFile,
+      JSON.stringify({
+        "weave-claude": { type: "oauth", access: CLAUDE_ACCESS, refresh: CLAUDE_REFRESH, expires: Date.now() + 3_600_000 },
+      }),
+    )
+    // ChatGPT token is expired → triggers a refresh; the issuer returns 500.
+    const getAuth = async () => ({
+      type: "oauth",
+      access: "stale",
+      refresh: "cg-refresh",
+      expires: Date.now() - 1000,
+      accountId: CHATGPT_ACCOUNT,
+    })
+
+    const req = await runLoaderFetch(getAuth, (url) => (url.startsWith(CHATGPT_ISSUER) ? undefined : {}))
+
+    // ChatGPT refresh failed → no OpenAI headers, but the turn still went out…
+    expect(req.headers["x-weave-openai-subscription"]).toBeUndefined()
+    // …with the (unaffected) Claude sub attached.
+    expect(req.headers["x-weave-anthropic-subscription"]).toBe(CLAUDE_ACCESS)
     expect(req.headers["x-weave-router-key"]).toBe(ROUTER_KEY)
   })
 

--- a/install/opencode-weave/test/capture.test.ts
+++ b/install/opencode-weave/test/capture.test.ts
@@ -188,6 +188,29 @@ describe("weave loader — dual subscription injection", () => {
     expect(req.headers["x-weave-router-key"]).toBe(ROUTER_KEY)
   })
 
+  test("does not inject an expired Claude token that has no refresh token", async () => {
+    await writeFile(
+      authFile,
+      JSON.stringify({
+        "weave-claude": { type: "oauth", access: "expired-claude", expires: Date.now() - 1000 },
+      }),
+    )
+    const getAuth = async () => ({
+      type: "oauth",
+      access: CHATGPT_ACCESS,
+      refresh: "cg-refresh",
+      expires: Date.now() + 3_600_000,
+      accountId: CHATGPT_ACCOUNT,
+    })
+
+    const req = await runLoaderFetch(getAuth)
+
+    // Dead Claude sub (expired, unrefreshable) is dropped so the router bills the
+    // Weave key rather than treating it as present.
+    expect(req.headers["x-weave-anthropic-subscription"]).toBeUndefined()
+    expect(req.headers["x-weave-openai-subscription"]).toBe(CHATGPT_ACCESS)
+  })
+
   test("refreshes an expired Claude token, persists it to weave-claude, and injects the rotated token", async () => {
     await writeFile(
       authFile,

--- a/install/opencode-weave/test/capture.test.ts
+++ b/install/opencode-weave/test/capture.test.ts
@@ -220,6 +220,16 @@ describe("weave-claude login hook", () => {
     expect(result.method).toBe("code")
   })
 
+  test("rejects a pasted code missing the #state separator with a clear error", async () => {
+    const { WeaveClaude } = await import("../src/index.ts")
+    const hooks = await WeaveClaude(fakeInput())
+    const method = hooks.auth!.methods[0] as {
+      authorize: () => Promise<{ callback: (code: string) => Promise<Record<string, unknown>> }>
+    }
+    const flow = await method.authorize()
+    await expect(flow.callback("JUSTACODE")).rejects.toThrow(/code#state/)
+  })
+
   test("exchanges a pasted code#state for tokens", async () => {
     const { WeaveClaude } = await import("../src/index.ts")
     const hooks = await WeaveClaude(fakeInput())
@@ -245,5 +255,37 @@ describe("weave-claude login hook", () => {
     expect(exchangeBody!.code).toBe("THECODE")
     expect(exchangeBody!.state).toBe("THESTATE")
     expect(exchangeBody!.grant_type).toBe("authorization_code")
+  })
+})
+
+describe("opencode plugin-loading contract", () => {
+  // opencode's loader (applyPlugin → readV1Plugin(mod, _, "server", "detect"))
+  // treats a module whose `default` is a plain OBJECT with id/server/tui as a V1
+  // module and loads ONLY `default.server`. Only when `default` is NOT such an
+  // object does it fall back to getLegacyPlugins → Object.values(mod), loading
+  // EVERY exported Plugin function. We rely on that fallback so BOTH WeaveCodex
+  // (provider `weave`) and WeaveClaude (provider `weave-claude`) register from one
+  // file. These assertions fail if someone converts the module to a `{ server }`
+  // default export (which would silently drop the named Claude-login plugin).
+  test("default export is a bare function (takes the all-exports legacy path)", async () => {
+    const mod = await import("../src/index.ts")
+    expect(typeof mod.default).toBe("function")
+    // A function is not a record, so readV1Plugin returns undefined in detect mode.
+    expect(mod.default).not.toBeNull()
+    expect(["id", "server", "tui"].some((k) => k in (mod.default as object))).toBe(false)
+  })
+
+  test("both Plugins are exported functions that opencode's Object.values loop will load", async () => {
+    const mod = (await import("../src/index.ts")) as unknown as Record<string, unknown>
+    const plugins = Object.values(mod).filter((v) => typeof v === "function")
+    // Dedup by reference (default === WeaveCodex), as opencode's loader does.
+    const unique = new Set(plugins)
+    const providers = new Set<string>()
+    for (const p of unique) {
+      const hooks = await (p as (i: unknown) => Promise<{ auth?: { provider: string } }>)(fakeInput())
+      if (hooks.auth) providers.add(hooks.auth.provider)
+    }
+    expect(providers.has("weave")).toBe(true)
+    expect(providers.has("weave-claude")).toBe(true)
   })
 })

--- a/install/uninstall.sh
+++ b/install/uninstall.sh
@@ -164,19 +164,21 @@ if [ "$target" = "opencode" ]; then
     opencode_plugin="$opencode_dir/.weave/opencode-weave.ts"
   fi
   if [ -f "$opencode_config_file" ]; then
-    # Strip both managed providers (`weave`, `weave-codex`), the managed plugin
+    # Strip every managed provider (`weave`, the login-only `weave-claude`, and
+    # the legacy `weave-codex` from pre-upgrade installs), the managed plugin
     # entry from the `plugin` array, and any router-pointing top-level model
-    # (both the `weave/` and `weave-codex/` provider prefixes — otherwise a
-    # `weave-codex/...` default survives and points at the deleted provider).
-    # Other providers, user-set models that don't reference the router, other
-    # plugins, and any unrelated keys are preserved.
+    # (the `weave/`, `weave-claude/`, and `weave-codex/` prefixes — otherwise a
+    # default survives and points at a deleted provider). Other providers,
+    # user-set models that don't reference the router, other plugins, and any
+    # unrelated keys are preserved.
     cleaned="$(jq --arg plugin "$opencode_plugin" '
       (if .provider.weave then del(.provider.weave) else . end)
+      | (if .provider["weave-claude"] then del(.provider["weave-claude"]) else . end)
       | (if .provider["weave-codex"] then del(.provider["weave-codex"]) else . end)
       | (if (.provider // {}) == {} then del(.provider) else . end)
       | (if (.plugin | type) == "array" then .plugin -= [$plugin] else . end)
       | (if (.plugin | type) == "array" and (.plugin | length) == 0 then del(.plugin) else . end)
-      | (if (.model // "" | tostring | (startswith("weave/") or startswith("weave-codex/"))) then del(.model) else . end)
+      | (if (.model // "" | tostring | (startswith("weave/") or startswith("weave-claude/") or startswith("weave-codex/"))) then del(.model) else . end)
     ' "$opencode_config_file")"
     printf '%s\n' "$cleaned" >"$opencode_config_file"
 
@@ -193,9 +195,9 @@ if [ "$target" = "opencode" ]; then
     info "No opencode config at $opencode_config_file (already uninstalled?)"
   fi
 
-  # Drop the bundled Codex-subscription plugin (no secrets; the config holds the
-  # key, opencode's own auth store holds the ChatGPT tokens). Remove the .weave/
-  # dir only if it's left empty so we don't clobber an unrelated user dir.
+  # Drop the bundled subscription plugin (no secrets; the config holds the key,
+  # opencode's own auth store holds the ChatGPT/Claude tokens). Remove the
+  # .weave/ dir only if it's left empty so we don't clobber an unrelated user dir.
   if [ -f "$opencode_plugin" ]; then
     refuse_if_symlink "$opencode_plugin"
     rm -f "$opencode_plugin"

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -3112,6 +3112,15 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 		// streams Responses SSE natively — forward it verbatim. A Codex-sub turn
 		// that routed elsewhere (Claude/OSS) leaves the writer in translate mode
 		// so its chat/Anthropic output is re-emitted as Responses.
+		//
+		// Set once here (before Prelude) rather than per-attempt because Prelude's
+		// response.created suppression depends on passthrough being engaged before
+		// the first write. Safe across the dispatch loop: passthrough engages only
+		// when decision.Provider == OpenAI, which in the catalog is always a
+		// single-binding GPT model — there is no cross-format fallback binding to
+		// fail over to, and single-binding retry re-hits OpenAI (still verbatim).
+		// The per-attempt body below is independently gated on d.Provider == OpenAI.
+		// If a GPT model ever gains a cross-format fallback, gate this per-attempt.
 		if codexPassthrough && decision.Provider == providers.ProviderOpenAI {
 			rw.SetPassthrough()
 		}

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -2942,15 +2942,22 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 	enabledProviders := s.enabledProvidersForRequest(ctx, providers.ProviderOpenAI, r.Header)
 
 	// Codex (ChatGPT) subscription passthrough: ProxyOpenAIResponses stashed the
-	// caller's original Responses body. Such turns dispatch to the Codex backend
-	// over the Responses API and stream Responses SSE straight back, so they
-	// constrain routing to OpenAI (the only provider the ChatGPT plan can pay
-	// for) and skip the chat-completions routing marker + semantic cache below.
+	// caller's original Responses body. Such turns skip the chat-completions
+	// routing marker + semantic cache below, and — when the routed decision is
+	// an OpenAI model — dispatch the verbatim Responses body to the Codex backend
+	// (see the codexPassthrough branch in the dispatch switch).
+	//
+	// We deliberately do NOT force OpenAI-only routing here. enabledProviders
+	// (from enabledProvidersForRequest) already scopes the request to providers
+	// it can pay for: a lone Codex sub yields {OpenAI} on its own, but a caller
+	// presenting both a Codex and a Claude subscription gets {OpenAI, Anthropic}
+	// and routes freely across them — GPT turns bill the ChatGPT plan via the
+	// Codex backend, Claude turns bill the Claude plan via the translated path.
+	// Subscriptions are credentials scoped to the routed model, not a provider
+	// you pin. (No current client sends multiple subs, so this is behavior-
+	// preserving today; it unlocks the unified-provider client.)
 	codexBody, _ := ctx.Value(codexResponsesBodyContextKey{}).([]byte)
 	codexPassthrough := len(codexBody) > 0
-	if codexPassthrough {
-		enabledProviders = map[string]struct{}{providers.ProviderOpenAI: {}}
-	}
 
 	// Pre-filter models whose context window cannot fit this request.
 	outputReserveOAI := contextWindowOutputReserve
@@ -3100,9 +3107,18 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 	// when single-binding so multi-binding requests stay failover-safe
 	// (Codex client sees response.created via ResponsesWriter's lazy
 	// emitCreated on the first upstream byte instead).
-	if rw, ok := w.(*translate.ResponsesWriter); ok && len(bindings) <= 1 {
-		if err := rw.Prelude(env.Stream()); err != nil {
-			log.Error("Responses prelude failed", "err", err)
+	if rw, ok := w.(*translate.ResponsesWriter); ok {
+		// A Codex-sub turn that routed to the Codex backend (decision == OpenAI)
+		// streams Responses SSE natively — forward it verbatim. A Codex-sub turn
+		// that routed elsewhere (Claude/OSS) leaves the writer in translate mode
+		// so its chat/Anthropic output is re-emitted as Responses.
+		if codexPassthrough && decision.Provider == providers.ProviderOpenAI {
+			rw.SetPassthrough()
+		}
+		if len(bindings) <= 1 {
+			if err := rw.Prelude(env.Stream()); err != nil {
+				log.Error("Responses prelude failed", "err", err)
+			}
 		}
 	}
 
@@ -3151,11 +3167,15 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 		// body must be re-emitted with TargetProvider = openrouter.
 		attempt = func(actx context.Context, d router.Decision, p providers.Client) error {
 			var prep providers.PreparedRequest
-			if codexPassthrough {
+			if codexPassthrough && d.Provider == providers.ProviderOpenAI {
 				// Dispatch the caller's ORIGINAL Responses body (untranslated)
 				// to the Codex backend, rewriting only the model to the routed
 				// pick. The OpenAI client switches to chatgpt.com/backend-api/
-				// codex when it sees the Codex subscription credential.
+				// codex when it sees the Codex subscription credential. Gated on
+				// d.Provider == OpenAI: a Codex-sub turn that routes to an OSS
+				// provider in this case (OpenRouter/Fireworks/…) must NOT ship a
+				// verbatim Responses body there — it gets the translated chat
+				// body below, like any other turn.
 				outBody, setErr := sjson.SetBytes(codexBody, "model", d.Model)
 				if setErr != nil {
 					log.Error("Failed to set routed model on Codex Responses body", "err", setErr, "decision_model", d.Model)
@@ -3458,16 +3478,19 @@ func (s *Service) ProxyOpenAIResponses(ctx context.Context, body []byte, w http.
 	if err != nil {
 		return fmt.Errorf("translate responses request: %w", err)
 	}
-	// Codex (ChatGPT) subscription: serve the turn on the caller's plan via the
-	// Codex backend (chatgpt.com/backend-api/codex), which speaks the Responses
-	// API natively. Stash the caller's ORIGINAL Responses body and write the
-	// upstream Responses SSE straight to w (no ResponsesWriter round-trip), so
-	// reasoning/tool/encrypted content is never lossily re-translated through
-	// chat completions. Routing, billing (5% subscription fee), and telemetry
-	// are reused via ProxyOpenAIChatCompletion (chatBody feeds routing only).
+	// Codex (ChatGPT) subscription: stash the caller's ORIGINAL Responses body.
+	// A turn that resolves a Codex sub AND routes to the Codex backend
+	// (decision == OpenAI) is dispatched verbatim and streamed back with the
+	// ResponsesWriter in passthrough mode (set post-routing in
+	// ProxyOpenAIChatCompletion), so reasoning/tool/encrypted content is never
+	// lossily re-translated. A Codex-sub turn that routes elsewhere
+	// (Claude/OSS — possible once both subs are presented) falls through to the
+	// normal chat->Responses translation, exactly like a non-sub Responses turn.
+	// Either way the writer is a ResponsesWriter; only the per-decision mode
+	// differs. Routing, billing (5% subscription fee), and telemetry are reused
+	// via ProxyOpenAIChatCompletion (chatBody feeds routing only).
 	if codexResponsesRequest(ctx, r.Header) {
 		ctx = context.WithValue(ctx, codexResponsesBodyContextKey{}, body)
-		return s.ProxyOpenAIChatCompletion(ctx, chatBody, w, r)
 	}
 	wrapper := translate.NewResponsesWriter(w, model)
 	// Defer the high-fidelity call-log emission until after Finalize: the

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -3216,11 +3216,16 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 			// the upstream error as an in-stream `data: {...}` frame
 			// instead of letting dispatch's flushErr append a corrupting
 			// JSON envelope. Pre-commit errors are handled by
-			// dispatchWithFallback (Discard + flushErr). Skipped for the Codex
-			// passthrough: the client speaks Responses, so a chat-completions
-			// error frame would corrupt the stream — the upstream's own
-			// Responses error event has already reached the client.
-			if err != nil && !codexPassthrough && env.Stream() && preludeBuf.Committed() {
+			// dispatchWithFallback (Discard + flushErr).
+			// Gate on THIS attempt being the verbatim Codex backend, not on
+			// codexPassthrough alone: post-Phase-1 that flag only means a Codex
+			// body was stashed, and a Codex-sub turn can route to Claude/OSS,
+			// which streams through the translating ResponsesWriter and still
+			// needs an error frame just like any non-sub Responses turn. Only the
+			// verbatim Codex attempt already delivered the upstream's own
+			// Responses error event, so only it skips the chat-completions frame.
+			verbatimCodex := codexPassthrough && d.Provider == providers.ProviderOpenAI
+			if err != nil && !verbatimCodex && env.Stream() && preludeBuf.Committed() {
 				err = emitOpenAISSEErrorEvent(sink, err)
 			}
 			return err

--- a/internal/proxy/service_test.go
+++ b/internal/proxy/service_test.go
@@ -506,6 +506,57 @@ func TestService_ProxyOpenAIChatCompletion_DispatchesDeepInfraAndBedrock(t *test
 	}
 }
 
+// TestService_CodexPassthrough_RoutesFreelyWithBothSubs guards the
+// subscription-credential routing flip: a /v1/responses turn that resolves a
+// Codex (ChatGPT) subscription must NOT force OpenAI-only routing when a Claude
+// subscription is also present. Both providers stay eligible so the scorer can
+// route freely and the sub matching the chosen model pays — GPT via the Codex
+// backend, Claude via the translated path. (Single-sub callers are unaffected:
+// enabledProvidersForRequest already yields {OpenAI} on a lone Codex sub.)
+func TestService_CodexPassthrough_RoutesFreelyWithBothSubs(t *testing.T) {
+	fr := &fakeRouter{decision: router.Decision{Provider: providers.ProviderAnthropic, Model: "claude-sonnet-4-6"}}
+	// The Anthropic upstream returns a normal Messages response; the proxy
+	// translates it back to the Responses wire format for the /v1/responses
+	// client (NOT the verbatim Codex-backend path, which only applies to an
+	// OpenAI decision).
+	anthropicResp := func(w http.ResponseWriter) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"id":"msg_1","type":"message","role":"assistant","model":"claude-sonnet-4-6","content":[{"type":"text","text":"hi"}],"stop_reason":"end_turn","usage":{"input_tokens":1,"output_tokens":1}}`))
+	}
+	providerMap := map[string]providers.Client{
+		providers.ProviderOpenAI:    &fakeProvider{},
+		providers.ProviderAnthropic: &fakeProvider{proxyResponse: anthropicResp},
+	}
+	svc := proxy.NewService(fr, providerMap, nil, false, nil, nil, false, providers.ProviderAnthropic, "claude-sonnet-4-6", nil).
+		WithByokOnly(true)
+
+	// Both subscriptions presented via the dedicated headers (stashed on ctx by
+	// the auth middleware): a Codex sub (token + account-id) and a Claude sub.
+	ctx := context.WithValue(context.Background(), proxy.OpenAISubscriptionContextKey{}, "eyJhbGciOiJSUzI1NiJ9.codex.sig")
+	ctx = context.WithValue(ctx, proxy.OpenAIAccountIDContextKey{}, "acct-123")
+	ctx = context.WithValue(ctx, proxy.AnthropicSubscriptionContextKey{}, "sk-ant-oat01-subscription-token")
+
+	body := []byte(`{"model":"gpt-5.5","input":[{"role":"user","content":[{"type":"input_text","text":"hi"}]}]}`)
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(""))
+	require.NoError(t, svc.ProxyOpenAIResponses(ctx, body, rec, req))
+
+	require.NotNil(t, fr.capturedReq)
+	assert.Contains(t, fr.capturedReq.EnabledProviders, providers.ProviderOpenAI,
+		"the Codex subscription must keep OpenAI eligible")
+	assert.Contains(t, fr.capturedReq.EnabledProviders, providers.ProviderAnthropic,
+		"Codex passthrough must NOT force OpenAI-only when a Claude subscription is also present")
+
+	// The Claude-routed turn comes back in Responses shape (translated), not
+	// chat-completions — proving a Codex-sub turn routed to Claude isn't sent
+	// through the verbatim Codex-backend path.
+	out := rec.Body.String()
+	assert.Contains(t, out, `"object":"response"`)
+	assert.Contains(t, out, `"output_text"`)
+	assert.NotContains(t, out, "chat.completion")
+}
+
 // TestService_WithByokOnly_FiltersUnauthedProvidersFromScorer: with
 // WithByokOnly(true), registered providers must not appear in EnabledProviders
 // without per-request credentials, or argmax routes to the platform key and 402s.

--- a/internal/translate/responses.go
+++ b/internal/translate/responses.go
@@ -272,6 +272,7 @@ type ResponsesWriter struct {
 	statusCode      int
 	streaming       bool
 	httpHeadersSent bool
+	passthrough     bool
 	buf             bytes.Buffer
 
 	seq int64
@@ -347,7 +348,31 @@ func (t *ResponsesWriter) WrapInner(fn func(http.ResponseWriter) http.ResponseWr
 
 func (t *ResponsesWriter) Header() http.Header { return t.inner.Header() }
 
+// SetPassthrough switches the writer to verbatim mode: upstream bytes are
+// forwarded to the client unchanged, the chat->Responses translation is
+// skipped, and the response.created prelude is suppressed. Use it when the
+// upstream already speaks the Responses wire format natively (the Codex
+// backend), so re-translating would corrupt the stream. A turn that resolves a
+// Codex subscription but routes to a non-OpenAI model leaves this off and gets
+// the normal chat->Responses translation. Must be called before the first
+// write (i.e. right after routing, before Prelude).
+func (t *ResponsesWriter) SetPassthrough() { t.passthrough = true }
+
 func (t *ResponsesWriter) WriteHeader(code int) {
+	if t.passthrough {
+		if t.httpHeadersSent {
+			return
+		}
+		t.statusCode = code
+		// Forward the upstream's own headers (the Codex backend already sets
+		// text/event-stream); only drop length/encoding which no longer apply
+		// once the proxy re-frames the stream.
+		t.inner.Header().Del("Content-Length")
+		t.inner.Header().Del("Content-Encoding")
+		t.inner.WriteHeader(code)
+		t.httpHeadersSent = true
+		return
+	}
 	// Always pick up the routed model when upstream calls WriteHeader, even if
 	// Prelude already committed the HTTP status. Prelude fires before routing
 	// completes, so the x-router-model header hasn't been stamped yet; the
@@ -374,6 +399,22 @@ func (t *ResponsesWriter) WriteHeader(code int) {
 }
 
 func (t *ResponsesWriter) Write(data []byte) (int, error) {
+	if t.passthrough {
+		// Forward verbatim. The upstream (Codex backend) emits Responses SSE
+		// natively, so there is nothing to translate.
+		if !t.httpHeadersSent {
+			t.inner.WriteHeader(http.StatusOK)
+			t.httpHeadersSent = true
+		}
+		written, err := t.bw.Write(data)
+		if err == nil {
+			err = t.bw.Flush()
+			if t.flusher != nil {
+				t.flusher.Flush()
+			}
+		}
+		return written, err
+	}
 	n := len(data)
 	t.buf.Write(data)
 	if !t.streaming {
@@ -394,6 +435,11 @@ func (t *ResponsesWriter) Write(data []byte) (int, error) {
 // Safe to call once; the headersEmitted guard prevents duplicate creation
 // when upstream Write later runs.
 func (t *ResponsesWriter) Prelude(streaming bool) error {
+	// In passthrough mode the upstream emits its own response.created; emitting
+	// ours too would duplicate it. Suppress the prelude entirely.
+	if t.passthrough {
+		return nil
+	}
 	if !streaming || t.headersEmitted {
 		return nil
 	}
@@ -420,6 +466,11 @@ func (t *ResponsesWriter) Flush() {
 
 // Finalize handles non-streaming bodies and end-of-stream completion events.
 func (t *ResponsesWriter) Finalize() error {
+	if t.passthrough {
+		// Verbatim mode: nothing to synthesize, just flush whatever's buffered.
+		// Non-streaming Codex-backend bodies were forwarded as-is in Write.
+		return t.bw.Flush()
+	}
 	if t.streaming {
 		// In the rare case the upstream produced no chunks at all, still
 		// emit a completed envelope so the client sees a clean termination.

--- a/internal/translate/responses_test.go
+++ b/internal/translate/responses_test.go
@@ -225,6 +225,34 @@ func TestResponsesWriter_StreamingText(t *testing.T) {
 	assert.EqualValues(t, 2, usage["output_tokens"])
 }
 
+// TestResponsesWriter_PassthroughForwardsVerbatim guards the Codex-backend
+// path: when the upstream already speaks Responses natively, the writer must
+// forward bytes unchanged and must NOT emit its own response.created prelude
+// (which would duplicate the upstream's).
+func TestResponsesWriter_PassthroughForwardsVerbatim(t *testing.T) {
+	rec := httptest.NewRecorder()
+	w := translate.NewResponsesWriter(rec, "gpt-5.5")
+	w.SetPassthrough()
+
+	// Prelude is a no-op in passthrough — the upstream emits response.created.
+	require.NoError(t, w.Prelude(true))
+
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.WriteHeader(200)
+
+	// Verbatim Responses SSE, as the Codex backend emits it.
+	native := "event: response.created\ndata: {\"type\":\"response.created\"}\n\n" +
+		"event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"delta\":\"ok\"}\n\n" +
+		"event: response.completed\ndata: {\"type\":\"response.completed\"}\n\n"
+	_, err := w.Write([]byte(native))
+	require.NoError(t, err)
+	require.NoError(t, w.Finalize())
+
+	// Output is exactly the upstream bytes: no chat->Responses translation, no
+	// synthesized or duplicated events.
+	assert.Equal(t, native, rec.Body.String())
+}
+
 func TestResponsesWriter_PrependsBadgeOnSwap(t *testing.T) {
 	rec := httptest.NewRecorder()
 	w := translate.NewResponsesWriter(rec, "gpt-5.5")


### PR DESCRIPTION
## What

Make a caller's AI subscription a **credential scoped to the model family it can pay for**, not a provider you pick to force a model. You connect your ChatGPT (Codex) and/or Claude (Pro/Max) plan once; the Weave Router routes every turn to the best model and bills the plan matching the model it served — ChatGPT pays for GPT/Codex turns, Claude pays for Claude turns, the Weave key pays for the rest. No manual provider-picking.

Closes the gap where opencode exposed the ChatGPT plan as a `weave-codex` provider you had to select (and which forced GPT-only routing).

## Router (Phase 1) — `internal/proxy`, `internal/translate`

- Drop the `codexPassthrough → enabledProviders = {OpenAI}` override. `enabledProvidersForRequest` already payable-scopes providers, so single-sub callers are unchanged (behavior-preserving) and dual-sub callers route freely.
- Apply the verbatim Codex-backend body **only when the decision is a GPT model** (`d.Provider == OpenAI`); other decisions fall through to the existing translated path, and `resolveAndInjectCredentials` resolves the matching sub (Claude, …).
- `ResponsesWriter` gains a passthrough mode; `ProxyOpenAIResponses` now always wraps the writer and the dispatch picks **verbatim passthrough for a Codex-backend dispatch, translate-to-Responses for any other**. (This per-decision writer handling — not the override removal — was the real work, sitting on the prelude-buffer/failover invariants.)

## opencode (Phases 2–3) — `install/`

Collapse to a single Responses-format `weave` provider; the plugin attaches **both** subs to every request via the dedicated `X-Weave-OpenAI-Subscription`/`-Account-ID` + `X-Weave-Anthropic-Subscription` headers. The router resolves the sub matching the routed provider, so a plan is never billed outside its family.

`install/opencode-weave/src/index.ts` exports two plugins:
- **`WeaveCodex`** (provider `weave`): ChatGPT login + the dual-inject loader. The Claude token is read from opencode's on-disk auth store (the SDK has no get-by-id, and `Auth.get()` strips undeclared fields, so the two logins need two standard Oauth slots). `Authorization` is left clean.
- **`WeaveClaude`** (login-only provider `weave-claude`): canonical Claude Pro/Max OAuth (manual `code#state` flow).

Installer writes one `weave` provider + a login-only `weave-claude` (empty models), retires the legacy `weave-codex` (provider, plugin entry, default-model prefix) on re-install, and reframes the wording. Uninstall strips all three.

### Limitation (accepted, ChatGPT-primary)
The dual-sub loader activates on the **ChatGPT** login (opencode runs a provider's loader only when it has stored auth). A Claude-only opencode user with no ChatGPT connected routes/bills via the Weave key, not their Claude plan.

## Testing

- `bun test install/opencode-weave/test` — dual-sub injection (router key preserved, Authorization clean), ChatGPT-only degrade, expired-Claude refresh + persist + rotated inject, loader inert without oauth, Claude login hook, `code#state` exchange.
- Strict `tsc` against `@opencode-ai/plugin`.
- `go build ./...` + full `go test ./...` green; new `TestService_CodexPassthrough_RoutesFreelyWithBothSubs` (dual-sub turn → Claude + bills Claude sub + Responses envelope) and `TestResponsesWriter_PassthroughForwardsVerbatim`.
- Installer run into a temp dir → correct config; legacy `weave-codex` migration + uninstall round-trip (user providers/plugins preserved).

Live prod E2E (real opencode → prod router → Codex/Claude backends) to follow after merge + gitlink bump + npm publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)