### PR TITLE
fix: reset loop detector on user text prompt

### DIFF
--- a/internal/translate/loop_detection.go
+++ b/internal/translate/loop_detection.go
@@ -41,7 +41,13 @@ func anthropicAssistantToolCallArgsPreview(body []byte, offset, maxLen int) []st
 		return nil
 	}
 	msgs.ForEach(func(_, msg gjson.Result) bool {
-		if msg.Get("role").String() != "assistant" {
+		role := msg.Get("role").String()
+		if role == "user" && anthropicUserMsgHasText(msg) {
+			out = nil
+			idx = 0
+			return true
+		}
+		if role != "assistant" {
 			return true
 		}
 		content := msg.Get("content")
@@ -79,7 +85,13 @@ func openAIAssistantToolCallArgsPreview(body []byte, offset, maxLen int) []strin
 		return nil
 	}
 	msgs.ForEach(func(_, msg gjson.Result) bool {
-		if msg.Get("role").String() != "assistant" {
+		role := msg.Get("role").String()
+		if role == "user" && anthropicUserMsgHasText(msg) {
+			out = nil
+			idx = 0
+			return true
+		}
+		if role != "assistant" {
 			return true
 		}
 		toolCalls := msg.Get("tool_calls")
@@ -138,7 +150,13 @@ func anthropicAssistantToolCallSigs(body []byte) []ToolCallSig {
 	}
 	var sigs []ToolCallSig
 	msgs.ForEach(func(_, msg gjson.Result) bool {
-		if msg.Get("role").String() != "assistant" {
+		role := msg.Get("role").String()
+		if role == "user" && anthropicUserMsgHasText(msg) {
+			sigs = nil
+
+			return true
+		}
+		if role != "assistant" {
 			return true
 		}
 		content := msg.Get("content")
@@ -188,7 +206,13 @@ func openAIAssistantToolCallSigs(body []byte) []ToolCallSig {
 	}
 	var sigs []ToolCallSig
 	msgs.ForEach(func(_, msg gjson.Result) bool {
-		if msg.Get("role").String() != "assistant" {
+		role := msg.Get("role").String()
+		if role == "user" && anthropicUserMsgHasText(msg) {
+			sigs = nil
+
+			return true
+		}
+		if role != "assistant" {
 			return true
 		}
 		toolCalls := msg.Get("tool_calls")
@@ -364,4 +388,23 @@ func hexDigit(n byte) byte {
 		return '0' + n
 	}
 	return 'a' + n - 10
+}
+
+func anthropicUserMsgHasText(msg gjson.Result) bool {
+	content := msg.Get("content")
+	if content.Type == gjson.String {
+		return content.String() != ""
+	}
+	if !content.IsArray() {
+		return false
+	}
+	hasText := false
+	content.ForEach(func(_, block gjson.Result) bool {
+		if block.Get("type").String() == "text" && block.Get("text").String() != "" {
+			hasText = true
+			return false
+		}
+		return true
+	})
+	return hasText
 }

--- a/internal/translate/loop_detection.go
+++ b/internal/translate/loop_detection.go
@@ -42,7 +42,7 @@ func anthropicAssistantToolCallArgsPreview(body []byte, offset, maxLen int) []st
 	}
 	msgs.ForEach(func(_, msg gjson.Result) bool {
 		role := msg.Get("role").String()
-		if role == "user" && anthropicUserMsgHasText(msg) {
+		if role == "user" && userPromptTextGJSON(msg.Get("content")) != "" {
 			out = nil
 			idx = 0
 			return true
@@ -86,7 +86,7 @@ func openAIAssistantToolCallArgsPreview(body []byte, offset, maxLen int) []strin
 	}
 	msgs.ForEach(func(_, msg gjson.Result) bool {
 		role := msg.Get("role").String()
-		if role == "user" && anthropicUserMsgHasText(msg) {
+		if role == "user" && userPromptTextGJSON(msg.Get("content")) != "" {
 			out = nil
 			idx = 0
 			return true
@@ -151,9 +151,13 @@ func anthropicAssistantToolCallSigs(body []byte) []ToolCallSig {
 	var sigs []ToolCallSig
 	msgs.ForEach(func(_, msg gjson.Result) bool {
 		role := msg.Get("role").String()
-		if role == "user" && anthropicUserMsgHasText(msg) {
+		// A genuine user-typed prompt breaks the loop: the human has
+		// intervened, so the calls before it are no longer part of any
+		// runaway cycle. userPromptTextGJSON returns "" for tool_result-only
+		// turns and for Claude Code's injected <system-reminder> /
+		// <command-*> wrapper blocks, so a normal tool round does NOT reset.
+		if role == "user" && userPromptTextGJSON(msg.Get("content")) != "" {
 			sigs = nil
-
 			return true
 		}
 		if role != "assistant" {
@@ -207,9 +211,10 @@ func openAIAssistantToolCallSigs(body []byte) []ToolCallSig {
 	var sigs []ToolCallSig
 	msgs.ForEach(func(_, msg gjson.Result) bool {
 		role := msg.Get("role").String()
-		if role == "user" && anthropicUserMsgHasText(msg) {
+		// See anthropicAssistantToolCallSigs: a genuine user-typed prompt
+		// resets the window; injected wrappers and tool_result turns do not.
+		if role == "user" && userPromptTextGJSON(msg.Get("content")) != "" {
 			sigs = nil
-
 			return true
 		}
 		if role != "assistant" {
@@ -388,23 +393,4 @@ func hexDigit(n byte) byte {
 		return '0' + n
 	}
 	return 'a' + n - 10
-}
-
-func anthropicUserMsgHasText(msg gjson.Result) bool {
-	content := msg.Get("content")
-	if content.Type == gjson.String {
-		return content.String() != ""
-	}
-	if !content.IsArray() {
-		return false
-	}
-	hasText := false
-	content.ForEach(func(_, block gjson.Result) bool {
-		if block.Get("type").String() == "text" && block.Get("text").String() != "" {
-			hasText = true
-			return false
-		}
-		return true
-	})
-	return hasText
 }

--- a/internal/translate/loop_detection_test.go
+++ b/internal/translate/loop_detection_test.go
@@ -270,3 +270,58 @@ func TestAssistantToolCallSignatures_UserTextResetsLoop(t *testing.T) {
 	require.Len(t, sigs, 1) // Only "read" is counted, because the "ls" was before the user text
 	assert.Equal(t, "read", sigs[0].Name)
 }
+
+func TestAssistantToolCallSignatures_InjectedTextDoesNotResetLoop(t *testing.T) {
+	// A normal tool round carries Claude Code's injected <system-reminder>
+	// text block alongside the tool_result. That is NOT a user intervention and
+	// must NOT reset the window — otherwise the loop detector could never reach
+	// its repeat threshold. Build a 6-deep identical-call loop with an injected
+	// reminder on every tool_result turn and assert all 6 sigs survive.
+	msgs := []any{
+		map[string]any{"role": "user", "content": "do stuff"},
+	}
+	for i := 0; i < 6; i++ {
+		msgs = append(msgs,
+			map[string]any{"role": "assistant", "content": []any{
+				map[string]any{"type": "tool_use", "id": "t", "name": "ls", "input": map[string]any{"path": "/tmp"}},
+			}},
+			map[string]any{"role": "user", "content": []any{
+				map[string]any{"type": "tool_result", "tool_use_id": "t", "content": "a"},
+				map[string]any{"type": "text", "text": "<system-reminder>be helpful</system-reminder>"},
+			}},
+		)
+	}
+	body := mustMarshalJSON(t, map[string]any{
+		"model": "claude-sonnet-4-6", "messages": msgs, "max_tokens": 256,
+	})
+	env, err := translate.ParseAnthropic(body)
+	require.NoError(t, err)
+
+	sigs := env.AssistantToolCallSignatures()
+	require.Len(t, sigs, 6, "injected reminder blocks must not reset the loop window")
+}
+
+func TestAssistantToolCallSignatures_UserTextResetsLoop_OpenAI(t *testing.T) {
+	// OpenAI-format parallel of the Anthropic reset test: a genuine user text
+	// message clears tool_calls accumulated before it.
+	body := mustMarshalJSON(t, map[string]any{
+		"model": "gpt-5.5",
+		"messages": []any{
+			map[string]any{"role": "user", "content": "do stuff"},
+			map[string]any{"role": "assistant", "tool_calls": []any{
+				map[string]any{"id": "1", "type": "function", "function": map[string]any{"name": "ls", "arguments": `{"path":"/tmp"}`}},
+			}},
+			map[string]any{"role": "tool", "tool_call_id": "1", "content": "a"},
+			map[string]any{"role": "user", "content": "continue please"}, // resets
+			map[string]any{"role": "assistant", "tool_calls": []any{
+				map[string]any{"id": "2", "type": "function", "function": map[string]any{"name": "read", "arguments": `{"path":"/etc/hosts"}`}},
+			}},
+		},
+	})
+	env, err := translate.ParseOpenAI(body)
+	require.NoError(t, err)
+
+	sigs := env.AssistantToolCallSignatures()
+	require.Len(t, sigs, 1)
+	assert.Equal(t, "read", sigs[0].Name)
+}

--- a/internal/translate/loop_detection_test.go
+++ b/internal/translate/loop_detection_test.go
@@ -242,3 +242,31 @@ func TestAssistantToolCallSignatures_SkipsRouterNudgeEntries(t *testing.T) {
 // mustMarshalJSON is shared with force_model_test.go; redeclared here would be
 // a compile error so the existing one is reused.
 var _ = json.Marshal
+
+func TestAssistantToolCallSignatures_UserTextResetsLoop(t *testing.T) {
+	// If the user explicitly sends a text message, it breaks the loop detector
+	// by resetting the tool call history.
+	body := mustMarshalJSON(t, map[string]any{
+		"model": "claude-sonnet-4-6",
+		"messages": []any{
+			map[string]any{"role": "user", "content": "do stuff"},
+			map[string]any{"role": "assistant", "content": []any{
+				map[string]any{"type": "tool_use", "id": "1", "name": "ls", "input": map[string]any{"path": "/tmp"}},
+			}},
+			map[string]any{"role": "user", "content": []any{
+				map[string]any{"type": "tool_result", "tool_use_id": "1", "content": "a"},
+				map[string]any{"type": "text", "text": "continue please"}, // This resets the loop
+			}},
+			map[string]any{"role": "assistant", "content": []any{
+				map[string]any{"type": "tool_use", "id": "2", "name": "read", "input": map[string]any{"path": "/etc/hosts"}},
+			}},
+		},
+		"max_tokens": 256,
+	})
+	env, err := translate.ParseAnthropic(body)
+	require.NoError(t, err)
+
+	sigs := env.AssistantToolCallSignatures()
+	require.Len(t, sigs, 1) // Only "read" is counted, because the "ls" was before the user text
+	assert.Equal(t, "read", sigs[0].Name)
+}


### PR DESCRIPTION
## Summary
- Resets the tool call history when a user message containing text is encountered.
- Resolves an issue where a user's explicit text intervention (like "continue please") failed to break the router's loop detection because prior tool calls were still retained in the loop-detection window.
- Fixes `detectToolCallLoop` and `detectCyclicToolCallLoop` to only consider the tool calls that occurred *since* the last user text prompt.
- Also zeroes out the tool call preview `AssistantToolCallArgsPreview` to keep the logs synchronized.

## Test plan
- Added `TestAssistantToolCallSignatures_UserTextResetsLoop` test to confirm that tool calls prior to a user text message are correctly discarded.
- `make test` passes successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)