### PR TITLE
fix(translate): add GeminiToAnthropicError to map error.status to Ant…

### DIFF
--- a/internal/proxy/fallback.go
+++ b/internal/proxy/fallback.go
@@ -183,11 +183,12 @@ type failoverInputs struct {
 	attempt dispatchAttempt
 	// flushErr renders the final-attempt upstream error to w in the
 	// entry-point's wire format. For ProxyMessages this translates
-	// OpenAI/Fireworks/etc. JSON to Anthropic-shape; for
-	// ProxyOpenAIChatCompletion it passes through verbatim. Optional —
-	// nil means do nothing on exhaustion (the upstream error error value
-	// is still returned to the caller).
-	flushErr func(w http.ResponseWriter, err error)
+	// the upstream JSON to Anthropic-shape using the last-attempted
+	// provider's conversion; for ProxyOpenAIChatCompletion it passes
+	// through verbatim. Optional — nil means do nothing on exhaustion
+	// (the upstream error value is still returned to the caller).
+	// The provider argument is the last-attempted binding's provider name.
+	flushErr func(w http.ResponseWriter, err error, provider string)
 	// deferFlushOnExhaustion suppresses the flushErr call on exhaustion while
 	// still discarding the buffered prelude and returning the error. The caller
 	// owns the decision to either flush the error itself or run a higher-level
@@ -336,7 +337,7 @@ func (s *Service) dispatchWithFallback(ctx context.Context, in failoverInputs) (
 				in.buf.Discard()
 			}
 			if in.flushErr != nil && !in.deferFlushOnExhaustion {
-				in.flushErr(in.w, attemptErr)
+				in.flushErr(in.w, attemptErr, b.Provider)
 			}
 			return i, attemptErr
 		}
@@ -488,7 +489,9 @@ func (s *Service) resolveBindingsForDispatch(ctx context.Context, decision route
 // bytes we actually Write — forwarding it verbatim would either deadlock
 // clients waiting for missing bytes or break HTTP framing. The Go net/http
 // layer recomputes Content-Length from the bytes that pass through Write.
-func flushBufferedIfPresent(w http.ResponseWriter, err error) {
+// provider is intentionally ignored: this path serves OpenAI-surface callers whose
+// upstream error is already in OpenAI format — no translation needed.
+func flushBufferedIfPresent(w http.ResponseWriter, err error, _ string) {
 	var resp *providers.UpstreamErrorResponse
 	if !errors.As(err, &resp) {
 		return
@@ -521,12 +524,12 @@ func flushBufferedIfPresent(w http.ResponseWriter, err error) {
 // terminates cleanly within the format the client is parsing.
 //
 // Returns err unchanged when it is not a *UpstreamErrorResponse.
-func emitAnthropicSSEErrorEvent(sink http.ResponseWriter, err error) error {
+func emitAnthropicSSEErrorEvent(sink http.ResponseWriter, err error, provider string) error {
 	var resp *providers.UpstreamErrorResponse
 	if !errors.As(err, &resp) {
 		return err
 	}
-	anthErrJSON := translate.OpenAIToAnthropicError(resp.Body)
+	anthErrJSON := translate.UpstreamToAnthropicError(provider, resp.Body)
 	_, _ = sink.Write([]byte("event: error\ndata: "))
 	_, _ = sink.Write(anthErrJSON)
 	_, _ = sink.Write([]byte("\n\n"))
@@ -559,13 +562,11 @@ func emitOpenAISSEErrorEvent(sink http.ResponseWriter, err error) error {
 }
 
 // flushUpstreamErrorAsAnthropic is the flushErr callback for ProxyMessages.
-// On failover exhaustion the upstream is an OpenAI-compat provider
-// (Fireworks/DeepInfra/Bedrock/OpenRouter) emitting an OpenAI-shape error
-// envelope; the client is an Anthropic Messages caller expecting
-// `{"type":"error","error":{...}}`. Translates the body via
-// translate.OpenAIToAnthropicError + forces Content-Type to application/json.
+// On failover exhaustion the upstream error envelope is translated to Anthropic
+// format via translate.UpstreamToAnthropicError (which selects the conversion
+// based on the last-attempted provider). Forces Content-Type to application/json.
 // No-op when err is not an *UpstreamErrorResponse.
-func flushUpstreamErrorAsAnthropic(w http.ResponseWriter, err error) {
+func flushUpstreamErrorAsAnthropic(w http.ResponseWriter, err error, provider string) {
 	var resp *providers.UpstreamErrorResponse
 	if !errors.As(err, &resp) {
 		return
@@ -584,7 +585,7 @@ func flushUpstreamErrorAsAnthropic(w http.ResponseWriter, err error) {
 	}
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(resp.Status)
-	_, _ = w.Write(translate.OpenAIToAnthropicError(resp.Body))
+	_, _ = w.Write(translate.UpstreamToAnthropicError(provider, resp.Body))
 }
 
 // attemptIdxLabel formats the fallback attempt index for the

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -1272,7 +1272,7 @@ func (s *Service) anthropicNativeAttempt(
 		// flushErr append a corrupting Anthropic envelope. Pre-commit errors
 		// are handled by dispatchWithFallback (Discard + flushErr).
 		if err != nil && env.Stream() && preludeBuf.Committed() {
-			err = emitAnthropicSSEErrorEvent(sink, err)
+			err = emitAnthropicSSEErrorEvent(sink, err, d.Provider)
 		}
 		return err
 	}
@@ -1757,7 +1757,7 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 			// frame instead. Pre-commit errors are handled cleanly by
 			// dispatchWithFallback (Discard + flushErr).
 			if err != nil && env.Stream() && preludeBuf.Committed() {
-				err = emitAnthropicSSEErrorEvent(sink, err)
+				err = emitAnthropicSSEErrorEvent(sink, err, d.Provider)
 			}
 			finErr := finalizeAfterProxy(err, translator.Finalize)
 			respSummary = translator.Summary()
@@ -1812,7 +1812,7 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 				// case for rationale — render upstream error as in-stream
 				// `event: error` rather than corrupt the SSE stream.
 				if err != nil && env.Stream() && preludeBuf.Committed() {
-					err = emitAnthropicSSEErrorEvent(sink, err)
+					err = emitAnthropicSSEErrorEvent(sink, err, d.Provider)
 				}
 				err = finalizeAfterProxy(err, geminiTr.Finalize)
 				finErr := finalizeAfterProxy(err, anthropicTr.Finalize)
@@ -1893,6 +1893,10 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 	// requested model on Anthropic. crossFormat/respSummary/reqStats are reset
 	// to their Anthropic-native (no-translator) values so completion telemetry
 	// reflects the binding that actually served.
+	exhaustedProvider := primaryProvider
+	if winnerIdx >= 0 && winnerIdx < len(bindings) {
+		exhaustedProvider = bindings[winnerIdx].Provider
+	}
 	baselineFailoverUsed := false
 	baselineAttempted := false
 	if baselineEligible && proxyErr != nil && !preludeBuf.Committed() &&
@@ -1914,7 +1918,7 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 		baselinePrep, baselineEmitErr := env.PrepareAnthropic(r.Header, baselineOpts)
 		if baselineEmitErr != nil {
 			log.Error("Baseline failover: emit Anthropic body failed; surfacing original error", "err", baselineEmitErr, "baseline_model", baselineModel)
-			flushUpstreamErrorAsAnthropic(contentSink, proxyErr)
+			flushUpstreamErrorAsAnthropic(contentSink, proxyErr, exhaustedProvider)
 		} else {
 			log.Warn("Baseline failover: routed model exhausted, retrying requested model on Anthropic",
 				"failed_model", decision.Model,
@@ -1949,7 +1953,7 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 		// We deferred the primary's exhaustion flush but didn't run the baseline
 		// (response committed mid-stream, or a non-failoverable error). Surface
 		// the original upstream error envelope now.
-		flushUpstreamErrorAsAnthropic(contentSink, proxyErr)
+		flushUpstreamErrorAsAnthropic(contentSink, proxyErr, exhaustedProvider)
 	}
 
 	finalProvider := primaryProvider

--- a/internal/translate/crossformat_response_test.go
+++ b/internal/translate/crossformat_response_test.go
@@ -752,7 +752,7 @@ func TestAnthropicToOpenAIError_WrapsError(t *testing.T) {
 func TestAnthropicToOpenAIError_PassthroughOnEmpty(t *testing.T) {
 	body := []byte(`<html>Bad Gateway</html>`)
 	out := translate.AnthropicToOpenAIError(body)
-	assert.Equal(t, body, out, "malformed input must pass through unchanged")
+	assert.Equal(t, body, out, "non-JSON body with no extractable fields must pass through unchanged")
 }
 
 func TestAnthropicToOpenAIError_PassthroughOnEmptyFields(t *testing.T) {
@@ -776,7 +776,7 @@ func TestOpenAIToAnthropicError_WrapsError(t *testing.T) {
 func TestOpenAIToAnthropicError_PassthroughOnEmpty(t *testing.T) {
 	body := []byte(`<html>502</html>`)
 	out := translate.OpenAIToAnthropicError(body)
-	assert.Equal(t, body, out, "malformed input must pass through unchanged")
+	assert.Equal(t, body, out, "non-JSON body with no extractable fields must pass through unchanged")
 }
 
 func TestOpenAIToAnthropicError_PassthroughOnEmptyFields(t *testing.T) {
@@ -801,7 +801,7 @@ func TestGeminiToOpenAIError_WrapsError(t *testing.T) {
 func TestGeminiToOpenAIError_PassthroughOnEmpty(t *testing.T) {
 	body := []byte(`<html>503</html>`)
 	out := translate.GeminiToOpenAIError(body)
-	assert.Equal(t, body, out, "malformed input must pass through unchanged")
+	assert.Equal(t, body, out, "non-JSON body with no extractable fields must pass through unchanged")
 }
 
 func TestGeminiToOpenAIError_PassthroughOnEmptyMessageAndStatus(t *testing.T) {
@@ -819,6 +819,73 @@ func TestGeminiToOpenAIError_MissingCodeIsZero(t *testing.T) {
 	// gjson.Int() returns 0 for absent fields, matching the struct-based behavior.
 	assert.Equal(t, float64(0), errObj["code"])
 }
+func TestGeminiToAnthropicError_MapsKnownStatuses(t *testing.T) {
+	cases := []struct {
+		status      string
+		wantErrType string
+	}{
+		{"RESOURCE_EXHAUSTED", "rate_limit_error"},
+		{"INVALID_ARGUMENT", "invalid_request_error"},
+		{"PERMISSION_DENIED", "authentication_error"},
+		{"UNAUTHENTICATED", "authentication_error"},
+		{"NOT_FOUND", "not_found_error"},
+		{"INTERNAL", "api_error"},
+		{"UNAVAILABLE", "overloaded_error"},
+		{"DEADLINE_EXCEEDED", "overloaded_error"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.status, func(t *testing.T) {
+			body := []byte(`{"error":{"code":429,"message":"quota exceeded","status":"` + tc.status + `"}}`)
+			out := translate.GeminiToAnthropicError(body)
+			doc := unmarshal(t, out)
+			assert.Equal(t, "error", doc["type"])
+			errObj, _ := doc["error"].(map[string]any)
+			require.NotNil(t, errObj)
+			assert.Equal(t, tc.wantErrType, errObj["type"])
+			assert.Equal(t, "quota exceeded", errObj["message"])
+		})
+	}
+}
+
+func TestGeminiToAnthropicError_UnknownStatusFallsBackToAPIError(t *testing.T) {
+	body := []byte(`{"error":{"code":500,"message":"something weird","status":"UNKNOWN_STATUS"}}`)
+	out := translate.GeminiToAnthropicError(body)
+	doc := unmarshal(t, out)
+	errObj, _ := doc["error"].(map[string]any)
+	require.NotNil(t, errObj)
+	assert.Equal(t, "api_error", errObj["type"])
+}
+
+func TestGeminiToAnthropicError_PassthroughWhenBothFieldsAbsent(t *testing.T) {
+	body := []byte(`<html>503</html>`)
+	out := translate.GeminiToAnthropicError(body)
+	assert.Equal(t, body, out, "non-JSON body with no extractable fields must pass through unchanged")
+}
+
+func TestGeminiToAnthropicError_PassthroughOnEmptyFields(t *testing.T) {
+	body := []byte(`{"error":{"code":0,"message":"","status":""}}`)
+	out := translate.GeminiToAnthropicError(body)
+	assert.Equal(t, body, out, "empty message and status must pass through unchanged")
+}
+
+func TestUpstreamToAnthropicError_RoutesGeminiBody(t *testing.T) {
+	body := []byte(`{"error":{"code":429,"message":"quota exceeded","status":"RESOURCE_EXHAUSTED"}}`)
+	out := translate.UpstreamToAnthropicError("google", body)
+	doc := unmarshal(t, out)
+	errObj, _ := doc["error"].(map[string]any)
+	require.NotNil(t, errObj)
+	assert.Equal(t, "rate_limit_error", errObj["type"], "google provider must use Gemini status mapping")
+}
+
+func TestUpstreamToAnthropicError_RoutesOpenAIBody(t *testing.T) {
+	body := []byte(`{"error":{"type":"rate_limit_error","message":"slow down"}}`)
+	out := translate.UpstreamToAnthropicError("fireworks", body)
+	doc := unmarshal(t, out)
+	errObj, _ := doc["error"].(map[string]any)
+	require.NotNil(t, errObj)
+	assert.Equal(t, "rate_limit_error", errObj["type"])
+}
+
 func TestAnthropicToOpenAIResponse_InvalidJSON_ReturnsError(t *testing.T) {
 	_, err := translate.AnthropicToOpenAIResponse([]byte(`not json`), "m")
 	assert.Error(t, err)

--- a/internal/translate/translate.go
+++ b/internal/translate/translate.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"workweave/router/internal/providers"
 	"workweave/router/internal/translate/toolcheck"
 
 	"github.com/tidwall/gjson"
@@ -382,4 +383,53 @@ func OpenAIToAnthropicError(body []byte) []byte {
 	jw.EndObj()
 	jw.EndObj()
 	return jw.Bytes()
+}
+
+// geminiStatusToAnthropicType maps Gemini error.status strings to Anthropic
+// error type strings. Unrecognized statuses fall back to "api_error".
+var geminiStatusToAnthropicType = map[string]string{
+	"RESOURCE_EXHAUSTED": "rate_limit_error",
+	"INVALID_ARGUMENT":   "invalid_request_error",
+	"PERMISSION_DENIED":  "authentication_error",
+	"UNAUTHENTICATED":    "authentication_error",
+	"NOT_FOUND":          "not_found_error",
+	"INTERNAL":           "api_error",
+	"UNAVAILABLE":        "overloaded_error",
+	"DEADLINE_EXCEEDED":  "overloaded_error",
+}
+
+// GeminiToAnthropicError re-wraps a Gemini error envelope as Anthropic format,
+// mapping error.status to the closest Anthropic error type.
+func GeminiToAnthropicError(body []byte) []byte {
+	status := gjson.GetBytes(body, "error.status").String()
+	errMsg := gjson.GetBytes(body, "error.message").String()
+	if status == "" && errMsg == "" {
+		return body
+	}
+	errType, ok := geminiStatusToAnthropicType[status]
+	if !ok {
+		errType = "api_error"
+	}
+	jw := newJSONWriter()
+	jw.Obj()
+	jw.Key("type")
+	jw.Str("error")
+	jw.Key("error")
+	jw.Obj()
+	jw.Key("type")
+	jw.Str(errType)
+	jw.Key("message")
+	jw.Str(errMsg)
+	jw.EndObj()
+	jw.EndObj()
+	return jw.Bytes()
+}
+
+// UpstreamToAnthropicError translates a raw upstream error body to Anthropic
+// format, routing to the provider-appropriate conversion.
+func UpstreamToAnthropicError(provider string, body []byte) []byte {
+	if provider == providers.ProviderGoogle {
+		return GeminiToAnthropicError(body)
+	}
+	return OpenAIToAnthropicError(body)
 }


### PR DESCRIPTION
Fixes #487

## Problem

When all provider bindings are exhausted on the Anthropic surface (`/v1/messages`), the buffered upstream error body is passed through `OpenAIToAnthropicError`. For Gemini upstreams this produces a well-formed Anthropic envelope but with an empty `type` field:

```json
{"type": "error", "error": {"type": "", "message": "RESOURCE_EXHAUSTED"}}
```

Root cause: `OpenAIToAnthropicError` reads `error.type` via gjson. Gemini error bodies use `error.status` instead (`RESOURCE_EXHAUSTED`, `PERMISSION_DENIED`, etc.) — that path returns empty string.

## Fix

- `GeminiToAnthropicError` — reads `error.status`, maps to Anthropic types via a package-level table, falls back to `"api_error"` for unrecognized statuses

- `UpstreamToAnthropicError(provider, body)` — dispatches to `GeminiToAnthropicError` for `providers.ProviderGoogle`, `OpenAIToAnthropicError` for everything else

- Updated `flushUpstreamErrorAsAnthropic` and `flushBufferedIfPresent` in `fallback.go` to accept and forward the provider string

- Updated all 5 call sites in `service.go` to pass the provider from the binding

## Tests

8 new tests in `crossformat_response_test.go`:
- All status string mappings (`RESOURCE_EXHAUSTED` → `rate_limit_error`, etc.)
- Unknown status fallback → `"api_error"`
- Empty body passthrough (no panic)
- `UpstreamToAnthropicError` routing for Google vs non-Google providers