### PR TITLE
chore(install): bump @workweave/router to 0.2.4

### DIFF
--- a/install/npm/package.json
+++ b/install/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@workweave/router",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "One-command installer that points Claude Code, Codex, opencode, or pi at the Weave Router. For pi it also ships the routing extension, loaded via pi.extensions.",
   "bin": {
     "weave-router": "bin.js"


### PR DESCRIPTION
Bumps the npm package to `0.2.4` so `npx @workweave/router --opencode` ships the dual-subscription plugin from #488 (single Responses `weave` provider + ChatGPT/Claude logins attaching both subs via the dedicated `X-Weave-*-Subscription` headers).

On merge, tag the merge commit `router-v0.2.4` to trigger `publish_npm.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)