### PR TITLE
fix(translate): stop dropping the Responses SSE stream when Codex sends `reasoning`

### DIFF
--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -3525,9 +3525,15 @@ func (s *Service) ProxyOpenAIResponses(ctx context.Context, body []byte, w http.
 	// commits.
 	proxyErr := s.ProxyOpenAIChatCompletion(ctx, chatBody, wrapper, r)
 	if proxyErr != nil {
-		// On error, let the handler write the error envelope unless we've
-		// already committed to streaming — in which case the chat-completions
-		// path will have surfaced a status error and we just propagate.
+		// If the Responses stream already committed (response.created is on the
+		// wire), the upstream error can no longer be rendered as a JSON error
+		// envelope — terminate the SSE stream with response.failed so the client
+		// (Codex) sees a clean failure instead of "stream closed before
+		// response.completed". A no-op before anything is streamed, so the
+		// handler still writes the JSON error envelope in that case.
+		if finErr := wrapper.FinalizeError(proxyErr); finErr != nil {
+			observability.FromContext(ctx).Error("Failed to finalize Responses error stream", "err", finErr)
+		}
 		deferredLog.run()
 		return proxyErr
 	}

--- a/internal/translate/responses.go
+++ b/internal/translate/responses.go
@@ -24,8 +24,21 @@ import (
 //
 // Only the subset of the Responses spec that Codex actually emits is handled:
 // instructions, input items (message / function_call / function_call_output),
-// tools (flat shape → nested function shape), tool_choice, reasoning.effort,
-// max_output_tokens, temperature, top_p, parallel_tool_calls, metadata.
+// tools (flat shape → nested function shape), tool_choice, max_output_tokens,
+// temperature, top_p, parallel_tool_calls, metadata.
+//
+// Codex's `reasoning` field is intentionally NOT propagated. This translation
+// runs before routing, so it can't know the served provider and can't map the
+// effort onto that provider's native thinking knob. Forwarding it as a Chat
+// Completions `reasoning_effort` broke every non-Gemini served model: Codex
+// always sends `reasoning` (even `effort:"none"`, which is not a valid
+// `reasoning_effort` value), and reasoning OpenAI models (gpt-5.x) reject
+// `reasoning_effort` alongside tools on /v1/chat/completions — both surface as
+// an upstream 400 after response.created, so the stream closes without
+// response.completed. Per-provider reasoning is still driven downstream from
+// the request's own signals (Gemini maps it natively, Anthropic via thinking);
+// dropping Codex's advisory effort here matches the "reasoning removed → works"
+// behavior and keeps every served model completing.
 func ResponsesToChatCompletions(body []byte) ([]byte, bool, string, error) {
 	if err := validateJSONObject(body); err != nil {
 		return nil, false, "", err
@@ -122,9 +135,6 @@ func ResponsesToChatCompletions(body []byte) ([]byte, bool, string, error) {
 	}
 	if max := root.Get("max_output_tokens"); max.Exists() {
 		out["max_completion_tokens"] = max.Int()
-	}
-	if effort := root.Get("reasoning.effort").Str; effort != "" {
-		out["reasoning_effort"] = effort
 	}
 	if md := root.Get("metadata"); md.IsObject() {
 		out["metadata"] = json.RawMessage(md.Raw)
@@ -511,6 +521,25 @@ func (t *ResponsesWriter) Finalize() error {
 	return err
 }
 
+// FinalizeError terminates a streaming Responses turn whose upstream failed
+// AFTER response.created was already emitted (the client is mid-stream). It
+// emits a response.failed terminal event so the client (Codex) sees a clean
+// failure instead of "stream closed before response.completed". It is a no-op
+// when nothing has been streamed yet (the caller still writes a JSON error
+// envelope in that case), in passthrough mode, or once a terminal event has
+// already been emitted. Returns nil when there was nothing to do.
+func (t *ResponsesWriter) FinalizeError(_ error) error {
+	if t.passthrough || !t.streaming || !t.headersEmitted || t.completedEmitted {
+		return nil
+	}
+	t.closeOpenItems()
+	if err := t.emitFailed(); err != nil {
+		return err
+	}
+	t.completedEmitted = true
+	return t.bw.Flush()
+}
+
 // processSSEBuffer drains complete chat.completion.chunk events.
 func (t *ResponsesWriter) processSSEBuffer() error {
 	for {
@@ -884,6 +913,22 @@ func (t *ResponsesWriter) emitCompleted() error {
 		}
 	}
 	return t.writeEvent("response.completed", map[string]any{
+		"response": env,
+	})
+}
+
+// emitFailed writes a response.failed terminal event carrying whatever output
+// was assembled before the upstream error, plus a generic error object (no
+// upstream internals leak through). Usage is omitted because a failed turn has
+// no trustworthy token accounting.
+func (t *ResponsesWriter) emitFailed() error {
+	env := t.responseEnvelope("failed")
+	env["output"] = t.assembleOutput()
+	env["error"] = map[string]any{
+		"code":    "upstream_error",
+		"message": "Upstream call failed.",
+	}
+	return t.writeEvent("response.failed", map[string]any{
 		"response": env,
 	})
 }

--- a/internal/translate/responses_test.go
+++ b/internal/translate/responses_test.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"encoding/json"
+	"errors"
 	"net/http/httptest"
 	"strings"
 	"testing"
@@ -151,7 +152,7 @@ func TestResponsesToChatCompletions_LeavesUserContentAlone(t *testing.T) {
 	assert.Contains(t, messages[0].Get("content").Str, "**WEAVE ROUTER**")
 }
 
-func TestResponsesToChatCompletions_ReasoningAndMaxOutput(t *testing.T) {
+func TestResponsesToChatCompletions_MaxOutputAndDropsReasoning(t *testing.T) {
 	body := []byte(`{
 		"model": "gpt-5",
 		"input": "hi",
@@ -163,7 +164,61 @@ func TestResponsesToChatCompletions_ReasoningAndMaxOutput(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, int64(4096), gjson.GetBytes(out, "max_completion_tokens").Int())
-	assert.Equal(t, "high", gjson.GetBytes(out, "reasoning_effort").Str)
+	// reasoning is intentionally dropped pre-routing: forwarding it as
+	// reasoning_effort broke every non-Gemini served model.
+	assert.False(t, gjson.GetBytes(out, "reasoning_effort").Exists(),
+		"reasoning_effort must not be propagated into the chat body")
+	assert.False(t, gjson.GetBytes(out, "reasoning").Exists())
+}
+
+// TestResponsesToChatCompletions_DropsReasoningEffort guards the Codex blocker:
+// Codex ALWAYS sends a `reasoning` field (including effort:"none", which is not
+// a valid Chat Completions reasoning_effort), and reasoning OpenAI models reject
+// reasoning_effort + tools — both 400 after response.created and close the
+// stream. None of these efforts may leak into the translated chat body.
+func TestResponsesToChatCompletions_DropsReasoningEffort(t *testing.T) {
+	for _, effort := range []string{"none", "minimal", "low", "medium", "high"} {
+		body := []byte(`{"model":"gpt-5.5","input":"hi","reasoning":{"effort":"` + effort + `"},"include":["reasoning.encrypted_content"]}`)
+		out, _, _, err := translate.ResponsesToChatCompletions(body)
+		require.NoError(t, err)
+		assert.Falsef(t, gjson.GetBytes(out, "reasoning_effort").Exists(),
+			"effort %q must not propagate", effort)
+	}
+}
+
+// TestResponsesWriter_FinalizeErrorEmitsFailed guards the stream-termination
+// half of the Codex fix: once response.created is on the wire, an upstream
+// error must close the stream with a response.failed terminal, never a bare
+// disconnect (which Codex reports as "stream closed before response.completed").
+func TestResponsesWriter_FinalizeErrorEmitsFailed(t *testing.T) {
+	rec := httptest.NewRecorder()
+	w := translate.NewResponsesWriter(rec, "")
+
+	require.NoError(t, w.Prelude(true)) // emits response.created
+	require.NoError(t, w.FinalizeError(errors.New("upstream 400")))
+
+	events := parseSSEEvents(t, rec.Body.Bytes())
+	types := eventTypes(events)
+	assert.Contains(t, types, "response.created")
+	assert.Contains(t, types, "response.failed")
+	assert.NotContains(t, types, "response.completed")
+
+	final := events[len(events)-1]
+	require.Equal(t, "response.failed", final["type"])
+	resp := final["response"].(map[string]any)
+	assert.Equal(t, "failed", resp["status"])
+	assert.NotNil(t, resp["error"])
+}
+
+// TestResponsesWriter_FinalizeErrorNoopBeforeCreated: when nothing has been
+// streamed yet, FinalizeError writes nothing so the handler can still emit a
+// JSON error envelope.
+func TestResponsesWriter_FinalizeErrorNoopBeforeCreated(t *testing.T) {
+	rec := httptest.NewRecorder()
+	w := translate.NewResponsesWriter(rec, "")
+
+	require.NoError(t, w.FinalizeError(errors.New("upstream 400")))
+	assert.Empty(t, rec.Body.Bytes())
 }
 
 func TestResponsesWriter_StreamingText(t *testing.T) {


### PR DESCRIPTION
## Problem

The router's `/v1/responses` path emits `response.created` and then **closes the SSE stream without `response.completed`** for every non-Gemini served model, so Codex CLI fails with:

```
stream disconnected before completion: stream closed before response.completed
```

Codex always sends a `reasoning` field (even with `model_reasoning_effort="none"`), and its `wire_api="chat"` is retired — so the Responses path is mandatory and Codex only completed on Gemini models.

Ref: `router-internal/docs/plans/ISSUE_codex_responses_reasoning_stream.md`.

## Root cause

`ResponsesToChatCompletions` forwarded `reasoning.effort` into the chat body as `reasoning_effort`. That value:
1. can be `"none"`, which is **not** a valid Chat Completions `reasoning_effort` (valid: minimal/low/medium/high), and
2. is rejected by reasoning OpenAI models (gpt-5.x) **alongside tools** on `/v1/chat/completions`.

Both surface as an upstream 400 *after* `response.created`, so the stream closes with no terminal event. Verified via a local pure-translation probe: with `reasoning` present, the chat→OpenAI body for `gpt-5.5` kept `reasoning_effort:"none"` (→ 400), while chat→Anthropic / chat→OSS bodies were clean.

## Fix

- **Translator** (`internal/translate/responses.go`): stop propagating Codex's `reasoning` into the chat body. The translation runs *before* routing, so it can't map the effort onto the served provider's native thinking knob. Per-provider reasoning is still driven downstream from the request's own signals (Gemini native, Anthropic via `thinking`). This matches the proven "reasoning removed → works" row from the issue.
- **Stream termination** (`internal/translate/responses.go` + `internal/proxy/service.go`): add `ResponsesWriter.FinalizeError` / `emitFailed`. When the upstream fails after `response.created` is already on the wire, emit a `response.failed` terminal so the client sees a clean failure instead of a bare disconnect. No-op before anything streams (the handler still writes the JSON error envelope).

## Tests

- Updated the stale `reasoning_effort=="high"` assertion → now asserts reasoning is dropped.
- Added `TestResponsesToChatCompletions_DropsReasoningEffort` (none/minimal/low/medium/high).
- Added `TestResponsesWriter_FinalizeErrorEmitsFailed` and `..._NoopBeforeCreated`.

`go build ./...`, `go vet`, `gofmt`, and `go test ./internal/translate/... ./internal/proxy/...` all pass on a clean `main` base.

## Not verified end-to-end

Couldn't run the live Codex forced-model repro: staging's deployed build ignores `x-weave-force-model` on `/v1/responses` (every forced request fell back to Gemini). Validated via the pure-translation probe + unit tests instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)