### PR TITLE
feat: subscription preference via headroom score-bonus (preserves Haiku-vs-Opus within a plan)

### DIFF
--- a/internal/proxy/subsidy.go
+++ b/internal/proxy/subsidy.go
@@ -142,6 +142,13 @@ func (s *Service) subsidyFactors(ctx context.Context, headers http.Header) map[s
 // (subsidyEpsilon) when none has been observed yet. The optimistic default is
 // what lets the covered models win the FIRST turn and thereby get a chance to
 // serve and record real headroom; without it the feature never bootstraps.
+//
+// The optimistic floor is safe here precisely because the observer keeps a
+// reading alive for the life of its binding quota window (usage.Observer.freshFor),
+// not a short TTL: a Snapshot miss therefore means the credential was genuinely
+// never observed, or its window has since reset — both states where assuming
+// slack is correct. A credential observed near its cap keeps returning that
+// near-1.0 factor (no optimistic re-subsidy) until its window actually resets.
 func (s *Service) observedOrOptimisticFactor(token string) float64 {
 	if snap, ok := s.usageObserver.Snapshot(s.usageObserver.Key([]byte(token))); ok {
 		return snap.CostFactor(s.subsidyEpsilon, s.subsidyGamma)

--- a/internal/proxy/subsidy.go
+++ b/internal/proxy/subsidy.go
@@ -102,12 +102,17 @@ func (s *Service) withUsageObserver(ctx context.Context, headers http.Header) co
 }
 
 // subsidyFactors computes the per-covered-model cost multiplier for this
-// request, from the present subscription(s)' observed rate-limit headroom.
-// Returns nil when the feature is off, no subscription is present, or no headroom
-// has been observed yet — in which case routing is unaffected (cold start = full
-// price until the first response populates the observer). Keyed identically to
-// withUsageObserver (via presentSubscriptionTokens) so record and read agree
-// across all three harnesses.
+// request from the present subscription(s). When headroom has been observed it
+// uses the real factor; when a subscription is present but NO headroom has been
+// observed yet, it OPTIMISTICALLY assumes slack (the epsilon floor) so the
+// covered models are favored from the very first turn. This bootstraps the
+// feature: otherwise the subscription would never serve a turn, so its headroom
+// would never be observed, so the discount would never engage — a chicken-and-
+// egg that pins routing to whatever wins at full price. The optimistic factor
+// self-corrects to the real headroom once the first subscription-served response
+// records it (including a 429's near-cap reading). Returns nil only when the
+// feature is off or no subscription is present. Keyed identically to
+// withUsageObserver so record and read agree across all three harnesses.
 func (s *Service) subsidyFactors(ctx context.Context, headers http.Header) map[string]float64 {
 	if s.usageObserver == nil {
 		return nil
@@ -115,23 +120,31 @@ func (s *Service) subsidyFactors(ctx context.Context, headers http.Header) map[s
 	codexTok, anthroTok := s.presentSubscriptionTokens(ctx, headers)
 	factors := make(map[string]float64)
 	if codexTok != "" {
-		if snap, ok := s.usageObserver.Snapshot(s.usageObserver.Key([]byte(codexTok))); ok {
-			f := snap.CostFactor(s.subsidyEpsilon, s.subsidyGamma)
-			for _, m := range codexCoveredModels {
-				factors[m] = f
-			}
+		f := s.observedOrOptimisticFactor(codexTok)
+		for _, m := range codexCoveredModels {
+			factors[m] = f
 		}
 	}
 	if anthroTok != "" {
-		if snap, ok := s.usageObserver.Snapshot(s.usageObserver.Key([]byte(anthroTok))); ok {
-			f := snap.CostFactor(s.subsidyEpsilon, s.subsidyGamma)
-			for _, m := range claudeCoveredModels() {
-				factors[m] = f
-			}
+		f := s.observedOrOptimisticFactor(anthroTok)
+		for _, m := range claudeCoveredModels() {
+			factors[m] = f
 		}
 	}
 	if len(factors) == 0 {
 		return nil
 	}
 	return factors
+}
+
+// observedOrOptimisticFactor returns the cost factor for a present subscription:
+// the real factor from observed headroom, or the optimistic slack floor
+// (subsidyEpsilon) when none has been observed yet. The optimistic default is
+// what lets the covered models win the FIRST turn and thereby get a chance to
+// serve and record real headroom; without it the feature never bootstraps.
+func (s *Service) observedOrOptimisticFactor(token string) float64 {
+	if snap, ok := s.usageObserver.Snapshot(s.usageObserver.Key([]byte(token))); ok {
+		return snap.CostFactor(s.subsidyEpsilon, s.subsidyGamma)
+	}
+	return s.subsidyEpsilon
 }

--- a/internal/proxy/subsidy_test.go
+++ b/internal/proxy/subsidy_test.go
@@ -84,3 +84,19 @@ func TestSubsidy_RecordReadKeyAgreement(t *testing.T) {
 	assert.Less(t, f, 1.0, "10%% used → discounted below full price")
 	assert.GreaterOrEqual(t, f, 0.05, "never below epsilon")
 }
+
+// Bootstrap: a present subscription with NO observed headroom yet must still
+// produce the optimistic (epsilon) discount, so the covered model can win the
+// first turn and thereby get a chance to serve and record real headroom.
+// Without this the feature never engages (the sub never serves → never observed).
+func TestSubsidyFactors_OptimisticColdStart(t *testing.T) {
+	s := (&Service{}).WithSubscriptionAwareRouting(
+		usage.NewObserver([]byte("salt"), time.Minute, time.Now), 0.05, 2.0)
+
+	// Claude Code sub in the inbound Authorization; observer is empty (cold).
+	h := http.Header{}
+	h.Set("Authorization", "Bearer sk-ant-oat01-cold")
+	factors := s.subsidyFactors(context.Background(), h)
+	require.NotNil(t, factors, "a present sub must produce factors even with no observed headroom")
+	assert.InDelta(t, 0.05, factors["claude-opus-4-8"], 1e-9, "cold start = optimistic epsilon (max bias)")
+}

--- a/internal/proxy/usage/usage.go
+++ b/internal/proxy/usage/usage.go
@@ -202,20 +202,28 @@ func (o *Observer) Sweep() {
 // rate-limit headers (primary = rolling/~5h, secondary = weekly). Reports false
 // if neither window is present. Used-percent headers are 0-100; we store [0,1].
 func ParseCodexHeaders(h http.Header) (Snapshot, bool) {
-	primary, pOK := parseCodexWindow(h, "primary")
-	secondary, sOK := parseCodexWindow(h, "secondary")
+	primary, pOK := parseCodexWindow(h, "primary", 5*60)
+	secondary, sOK := parseCodexWindow(h, "secondary", 7*24*60)
 	if !pOK && !sOK {
 		return Snapshot{}, false
 	}
 	return Snapshot{Primary: primary, Secondary: secondary}, true
 }
 
-func parseCodexWindow(h http.Header, which string) (Window, bool) {
+// parseCodexWindow reads one Codex window. defaultWindowMinutes is the known
+// window length (primary ~5h, secondary weekly) used when the upstream omits the
+// x-codex-*-window-minutes header — mirroring ParseAnthropicUnifiedHeaders, which
+// hardcodes its window lengths. This guarantees every observed reading carries a
+// window length, so freshFor never falls back to the short ttl floor for a real
+// subscription: a near-cap Codex reading keeps suppressing the subsidy for the
+// life of its window rather than aging out and re-applying the optimistic
+// epsilon to a still-capped credential.
+func parseCodexWindow(h http.Header, which string, defaultWindowMinutes int) (Window, bool) {
 	used, ok := parsePercent(h.Get("x-codex-" + which + "-used-percent"))
 	if !ok {
 		return Window{}, false
 	}
-	w := Window{UsedPercent: used}
+	w := Window{UsedPercent: used, WindowMinutes: defaultWindowMinutes}
 	if m, ok := parseInt(h.Get("x-codex-" + which + "-window-minutes")); ok {
 		w.WindowMinutes = m
 	}

--- a/internal/proxy/usage/usage.go
+++ b/internal/proxy/usage/usage.go
@@ -111,24 +111,39 @@ func NewObserver(salt []byte, ttl time.Duration, now func() time.Time) *Observer
 	return &Observer{salt: salt, ttl: ttl, now: now, data: make(map[CredentialKey]Snapshot)}
 }
 
+// windowConstrainedFraction is the utilization at/above which a window is a real
+// constraint whose full length must be waited out before its quota resets. Below
+// it a window is effectively slack — its CostFactor contribution is already near
+// epsilon — so it need not extend retention, and re-reading it as cold-start
+// slack costs nothing.
+const windowConstrainedFraction = 0.5
+
 // freshFor reports how long a snapshot stays authoritative. Quota is perishable
-// and refills only when its window resets, so a reading is meaningful until the
-// BINDING (more-utilized) window — the one that governs CostFactor — would reset,
-// NOT for a flat ttl far shorter than any quota window (5h / weekly). Without
-// this a near-cap reading ages out after the short ttl, Snapshot returns false,
-// and the cold-start path re-applies the optimistic epsilon to a credential that
-// is in fact still capped — routing back into it until a fresh response or 429
-// corrects it. Floored at ttl so a reading carrying no window length still
-// expires promptly. Once the binding window elapses the entry is evicted and the
-// credential reads as never-observed again — correct, its quota has by then reset.
+// and refills only when its window resets, so a reading is meaningful until every
+// window that is actually near cap would reset — NOT a flat ttl far shorter than
+// any quota window (5h / weekly). Without this a near-cap reading ages out after
+// the short ttl, Snapshot returns false, and the cold-start path re-applies the
+// optimistic epsilon to a credential that is in fact still capped — routing back
+// into it until a fresh response or 429 corrects it.
+//
+// The horizon is the LONGEST window among those at/above windowConstrainedFraction
+// (not just the binding/most-utilized one): when the 5h primary binds CostFactor
+// but the weekly window is also near cap, the entry must outlive the 5h window so
+// it does not reset to optimistic while weekly quota is still exhausted. A slack
+// window does not extend the horizon, so a 5h-capped + weekly-slack reading still
+// expires at ~5h rather than being stranded at full price for a week. Floored at
+// ttl so a reading carrying no constrained window still expires promptly; once
+// every constrained window has elapsed the entry is evicted and the credential
+// reads as never-observed again — correct, its quota has by then reset.
 func (o *Observer) freshFor(s Snapshot) time.Duration {
-	binding := s.Primary
-	if s.Secondary.UsedPercent >= s.Primary.UsedPercent {
-		binding = s.Secondary
-	}
-	horizon := time.Duration(binding.WindowMinutes) * time.Minute
-	if horizon < o.ttl {
-		return o.ttl
+	horizon := o.ttl
+	for _, w := range [...]Window{s.Primary, s.Secondary} {
+		if w.UsedPercent < windowConstrainedFraction {
+			continue
+		}
+		if d := time.Duration(w.WindowMinutes) * time.Minute; d > horizon {
+			horizon = d
+		}
 	}
 	return horizon
 }

--- a/internal/proxy/usage/usage.go
+++ b/internal/proxy/usage/usage.go
@@ -89,7 +89,9 @@ func (s Snapshot) CostFactor(epsilon, gamma float64) float64 {
 }
 
 // Observer stores the most recent Snapshot per credential. Concurrency-safe;
-// entries expire after TTL (stale headroom must not pin the cost signal).
+// each entry stays authoritative for the life of its binding quota window (see
+// freshFor) — stale headroom must not pin the cost signal, but a reading must not
+// age out faster than the window it describes.
 type Observer struct {
 	mu   sync.RWMutex
 	salt []byte
@@ -98,13 +100,37 @@ type Observer struct {
 	data map[CredentialKey]Snapshot
 }
 
-// NewObserver builds an Observer. salt keys credentials; ttl bounds staleness;
-// now is the injected clock (real time in prod, fake in tests).
+// NewObserver builds an Observer. salt keys credentials; ttl is the MINIMUM
+// freshness floor (for readings that carry no window length) — a reading that
+// does report a window stays fresh for that window, not just ttl; now is the
+// injected clock (real time in prod, fake in tests).
 func NewObserver(salt []byte, ttl time.Duration, now func() time.Time) *Observer {
 	if now == nil {
 		now = time.Now
 	}
 	return &Observer{salt: salt, ttl: ttl, now: now, data: make(map[CredentialKey]Snapshot)}
+}
+
+// freshFor reports how long a snapshot stays authoritative. Quota is perishable
+// and refills only when its window resets, so a reading is meaningful until the
+// BINDING (more-utilized) window — the one that governs CostFactor — would reset,
+// NOT for a flat ttl far shorter than any quota window (5h / weekly). Without
+// this a near-cap reading ages out after the short ttl, Snapshot returns false,
+// and the cold-start path re-applies the optimistic epsilon to a credential that
+// is in fact still capped — routing back into it until a fresh response or 429
+// corrects it. Floored at ttl so a reading carrying no window length still
+// expires promptly. Once the binding window elapses the entry is evicted and the
+// credential reads as never-observed again — correct, its quota has by then reset.
+func (o *Observer) freshFor(s Snapshot) time.Duration {
+	binding := s.Primary
+	if s.Secondary.UsedPercent >= s.Primary.UsedPercent {
+		binding = s.Secondary
+	}
+	horizon := time.Duration(binding.WindowMinutes) * time.Minute
+	if horizon < o.ttl {
+		return o.ttl
+	}
+	return horizon
 }
 
 // Key derives the CredentialKey for a token under this observer's salt.
@@ -125,7 +151,7 @@ func (o *Observer) Record(key CredentialKey, snap Snapshot) {
 	// and over-discounting until TTL. A genuinely reset window reports used≈0
 	// (still present), so it correctly overwrites; only an OMITTED window is
 	// preserved from the prior snapshot.
-	if prev, ok := o.data[key]; ok && o.now().Sub(prev.ObservedAt) <= o.ttl {
+	if prev, ok := o.data[key]; ok && o.now().Sub(prev.ObservedAt) <= o.freshFor(prev) {
 		if !snap.Primary.present() {
 			snap.Primary = prev.Primary
 		}
@@ -146,9 +172,9 @@ func (o *Observer) Snapshot(key CredentialKey) (Snapshot, bool) {
 	if !ok {
 		return Snapshot{}, false
 	}
-	if o.now().Sub(snap.ObservedAt) > o.ttl {
+	if o.now().Sub(snap.ObservedAt) > o.freshFor(snap) {
 		o.mu.Lock()
-		if cur, still := o.data[key]; still && o.now().Sub(cur.ObservedAt) > o.ttl {
+		if cur, still := o.data[key]; still && o.now().Sub(cur.ObservedAt) > o.freshFor(cur) {
 			delete(o.data, key)
 		}
 		o.mu.Unlock()
@@ -163,7 +189,7 @@ func (o *Observer) Sweep() {
 	cutoff := o.now()
 	o.mu.Lock()
 	for k, s := range o.data {
-		if cutoff.Sub(s.ObservedAt) > o.ttl {
+		if cutoff.Sub(s.ObservedAt) > o.freshFor(s) {
 			delete(o.data, k)
 		}
 	}

--- a/internal/proxy/usage/usage_test.go
+++ b/internal/proxy/usage/usage_test.go
@@ -48,6 +48,20 @@ func TestParseCodexHeaders_NoneReportsFalse(t *testing.T) {
 	assert.False(t, ok)
 }
 
+// When Codex reports used-percent but omits window-minutes, the parser must
+// still supply the known window length (primary ~5h, secondary weekly) so a
+// near-cap reading stays authoritative for the window's life instead of aging
+// out after the short ttl floor and re-subsidizing a still-capped credential.
+func TestParseCodexHeaders_DefaultsWindowWhenOmitted(t *testing.T) {
+	h := http.Header{}
+	h.Set("x-codex-primary-used-percent", "80")
+	h.Set("x-codex-secondary-used-percent", "97")
+	snap, ok := usage.ParseCodexHeaders(h)
+	require.True(t, ok)
+	assert.Equal(t, 300, snap.Primary.WindowMinutes, "primary defaults to ~5h")
+	assert.Equal(t, 10080, snap.Secondary.WindowMinutes, "secondary defaults to weekly")
+}
+
 func TestParseAnthropicUnified_FromRemainingLimit(t *testing.T) {
 	h := http.Header{}
 	h.Set("anthropic-ratelimit-unified-5h-limit", "1000")

--- a/internal/proxy/usage/usage_test.go
+++ b/internal/proxy/usage/usage_test.go
@@ -122,10 +122,44 @@ func TestObserver_RecordGetTTL(t *testing.T) {
 	require.True(t, ok)
 	assert.InDelta(t, 0.5, got.Primary.UsedPercent, 1e-9)
 
-	// Past TTL → expired, dropped.
+	// A short idle gap (past the 10-min floor) must NOT drop a reading whose
+	// quota window (5h) is still open — its headroom is still authoritative.
 	now = now.Add(11 * time.Minute)
 	_, ok = o.Snapshot(key)
+	assert.True(t, ok, "a 5h-window reading survives a short idle gap")
+
+	// Past the binding window → quota has reset → expired, dropped.
+	now = now.Add(300 * time.Minute)
+	_, ok = o.Snapshot(key)
 	assert.False(t, ok)
+}
+
+// TestObserver_NearCapDoesNotResetToOptimistic is the regression for the
+// reviewer-flagged bug: a credential observed near its cap must not age out after
+// a short idle gap and then read as cold-start slack (which would re-subsidize a
+// still-capped subscription). Its near-1.0 factor must persist for the life of
+// the binding window, and only after that window resets should the entry drop so
+// the cold-start path can legitimately treat it as never-observed again.
+func TestObserver_NearCapDoesNotResetToOptimistic(t *testing.T) {
+	const eps, gamma = 0.05, 2.0
+	now := time.Unix(2_000_000, 0)
+	clock := func() time.Time { return now }
+	o := usage.NewObserver([]byte("salt"), 10*time.Minute, clock)
+	key := o.Key([]byte("sk-ant-oat01-capped"))
+
+	// Weekly window nearly exhausted.
+	o.Record(key, usage.Snapshot{Secondary: usage.Window{UsedPercent: 0.98, WindowMinutes: 10080}})
+
+	// 11 minutes later (past the old flat TTL): still observed, still ~full price.
+	now = now.Add(11 * time.Minute)
+	snap, ok := o.Snapshot(key)
+	require.True(t, ok, "a near-cap reading must survive past the 10-min floor")
+	assert.Greater(t, snap.CostFactor(eps, gamma), 0.9, "still near full price, not optimistic epsilon")
+
+	// After the weekly window elapses, the quota has reset → drop → cold start.
+	now = now.Add(10080 * time.Minute)
+	_, ok = o.Snapshot(key)
+	assert.False(t, ok, "after the binding window resets, the reading is no longer authoritative")
 }
 
 func TestObserver_RecordMergesWindows(t *testing.T) {

--- a/internal/proxy/usage/usage_test.go
+++ b/internal/proxy/usage/usage_test.go
@@ -176,6 +176,47 @@ func TestObserver_NearCapDoesNotResetToOptimistic(t *testing.T) {
 	assert.False(t, ok, "after the binding window resets, the reading is no longer authoritative")
 }
 
+// TestObserver_LongWindowOutlivesShortBindingWindow guards the case where the 5h
+// primary window is the more-utilized (binding) one but the weekly window is also
+// near cap: the entry must survive past the 5h window so it does not reset to
+// optimistic epsilon while weekly quota is still exhausted.
+func TestObserver_LongWindowOutlivesShortBindingWindow(t *testing.T) {
+	now := time.Unix(3_000_000, 0)
+	clock := func() time.Time { return now }
+	o := usage.NewObserver([]byte("salt"), 10*time.Minute, clock)
+	key := o.Key([]byte("tok"))
+	o.Record(key, usage.Snapshot{
+		Primary:   usage.Window{UsedPercent: 0.99, WindowMinutes: 300},   // binds CostFactor
+		Secondary: usage.Window{UsedPercent: 0.90, WindowMinutes: 10080}, // also near cap
+	})
+
+	// 6h later: past the 5h primary window, but the weekly window still binds.
+	now = now.Add(6 * 60 * time.Minute)
+	_, ok := o.Snapshot(key)
+	assert.True(t, ok, "a near-cap weekly window keeps the entry alive past the 5h primary")
+}
+
+// TestObserver_SlackWindowDoesNotStrand is the converse: a 5h-capped reading whose
+// weekly window is slack must expire at ~5h, not be held at full price for the
+// (much longer) weekly window — otherwise a recovered primary quota would be
+// stranded on cash/OSS for a week.
+func TestObserver_SlackWindowDoesNotStrand(t *testing.T) {
+	now := time.Unix(4_000_000, 0)
+	clock := func() time.Time { return now }
+	o := usage.NewObserver([]byte("salt"), 10*time.Minute, clock)
+	key := o.Key([]byte("tok"))
+	o.Record(key, usage.Snapshot{
+		Primary:   usage.Window{UsedPercent: 0.99, WindowMinutes: 300},   // capped, 5h
+		Secondary: usage.Window{UsedPercent: 0.05, WindowMinutes: 10080}, // slack
+	})
+
+	// Just past the 5h primary window: the slack weekly window must not keep the
+	// stale primary-capped reading alive.
+	now = now.Add(301 * time.Minute)
+	_, ok := o.Snapshot(key)
+	assert.False(t, ok, "a slack long window must not strand a recovered short-window quota")
+}
+
 func TestObserver_RecordMergesWindows(t *testing.T) {
 	now := time.Unix(1_000_000, 0)
 	o := usage.NewObserver([]byte("salt"), 10*time.Minute, func() time.Time { return now })

--- a/internal/router/cluster/scorer.go
+++ b/internal/router/cluster/scorer.go
@@ -839,24 +839,32 @@ func clusterIDsString(ks []int) string {
 
 var _ router.Router = (*Scorer)(nil)
 
+// subsidyMaxBonus is the maximum per-cluster score lift a subscription-covered
+// model receives when its plan window is fully slack (headroom factor f≈epsilon).
+// It scales by (1−f), fading to 0 as the window binds so cash/OSS re-enter on
+// their merits (soft spill). Set to the per-cluster blend ceiling (1.0): a fully
+// slack plan is preferred over paying cash unless the covered model is near-worst
+// for the task — the prepaid "use-it-or-lose-it" preference — applied as an
+// additive bonus so it disturbs none of the quality/cost/speed blend weights.
+const subsidyMaxBonus float32 = 1.0
+
 // blendScoresV2 computes the v2 per-model blended scores for the given top-P
 // clusters under the effective knobs. Extracted from Route so the routing
 // distribution preview scores identically to live routing (single source of
 // truth for the cost/quality/speed blend). Caller owns knob validation and the
 // QualityBias->Alpha derivation; this method consumes the resolved alpha vector.
 func (s *Scorer) blendScoresV2(topClusters []int, activeKnobs DefaultRoutingKnobs, eligibleModels []string, subsidyFactors map[string]float64) map[string]float32 {
-	// Confine the subscription discount to eligible models. costs (and the
-	// cMin/cMax cost normalization) range over the full deployed set, so
-	// discounting an EXCLUDED covered model (context overflow, pin max-out,
-	// operator filter) could make it the artificial cost floor and weaken the
-	// cost axis for models that can actually win. An ineligible model can't be
-	// chosen, so subsidizing it serves no purpose.
-	eligibleSet := make(map[string]struct{}, len(eligibleModels))
-	for _, m := range eligibleModels {
-		eligibleSet[m] = struct{}{}
-	}
-
-	// 2. Effective per-model cost (knob-dependent)
+	// 2. Effective per-model cost (knob-dependent). Costs stay at FULL catalog
+	// scale for every model, INCLUDING subscription-covered ones. On a plan the
+	// dollar price is prepaid, but the catalog ratio still tracks how much plan
+	// quota each model burns (Anthropic's unified rate limit weights Opus far
+	// above Haiku), and that is exactly the intra-family signal we want the blend
+	// to weigh. Keeping covered models at full cost preserves the Haiku↔Opus
+	// spread, so the blend below still picks the cheap covered model for easy
+	// turns and the strong one for hard turns. The subscription PREFERENCE (use
+	// the prepaid plan over paying cash) is applied separately, as a uniform
+	// per-family score bonus in the blend loop — never by compressing the cost
+	// axis, which would wash Haiku and Opus together.
 	costs := make(map[string]float64, len(s.models))
 	for _, m := range s.models {
 		axis := s.modelAxes[m]
@@ -873,15 +881,6 @@ func (s *Scorer) blendScoresV2(topClusters []int, activeKnobs DefaultRoutingKnob
 			outputPer1K = *axis.OutputPer1KUSD
 		}
 		costs[m] = inputPer1K + activeKnobs.OutputCostRatio*outputPer1K*vFactor
-		// Subscription-aware discount: scale the cost term for models a caller's
-		// presented subscription covers, by the observed rate-limit headroom
-		// factor (~epsilon when slack, →1 as the window binds). Applied here so it
-		// rides the same per-cluster alpha/lambda blend as the base cost.
-		if f, ok := subsidyFactors[m]; ok {
-			if _, eligible := eligibleSet[m]; eligible {
-				costs[m] *= f
-			}
-		}
 	}
 
 	// 3. Effective per-model speed
@@ -1019,6 +1018,19 @@ func (s *Scorer) blendScoresV2(topClusters []int, activeKnobs DefaultRoutingKnob
 				} else {
 					scores[m] += qNorm
 				}
+			}
+
+			// Subscription preference: lift a covered model by the headroom bonus
+			// subsidyMaxBonus·(1−f) per cluster. f is the per-credential headroom
+			// factor (≈epsilon while the plan window is slack, →1 as it binds), so
+			// the bonus is near its max on a fresh plan and fades to 0 near the cap,
+			// letting cash/OSS re-enter on their own merits (soft spill). The bonus
+			// is UNIFORM across a covered family — every covered model shares its
+			// credential's f — so it only decides plan-vs-cash and never reorders
+			// models within the family; the full-catalog cost axis above still picks
+			// Haiku for easy turns and Opus for hard ones.
+			if f, ok := subsidyFactors[m]; ok {
+				scores[m] += subsidyMaxBonus * float32(1.0-f)
 			}
 		}
 	}

--- a/internal/router/cluster/scorer_test.go
+++ b/internal/router/cluster/scorer_test.go
@@ -165,13 +165,12 @@ func TestScorer_PicksClusterAlignedModel(t *testing.T) {
 	assert.Contains(t, got.Reason, "model=claude-opus-4-7")
 }
 
-// TestScorer_SubscriptionCostFactorNoop guards the feature-off path: a 1.0
-// factor (and nil) must leave routing byte-identical to no subsidy. The
-// directional cost effect of factors < 1 is unit-tested where the cost math
-// lives (internal/proxy/usage CostFactor) and validated end-to-end on
-// cost-weighted production traffic via the offline screen — this fixture's
-// default knobs give the cost axis zero weight, so a Route-level flip can't be
-// exercised here.
+// TestScorer_SubscriptionCostFactorNoop guards the feature-off path on the V1
+// fallback bundle (no model_axes → no cost axis), where the subscription signal
+// never applies: nil and a 1.0 factor must both leave routing byte-identical to
+// no subsidy. The directional V2 behavior — the headroom bonus flipping the pick
+// and the intra-family choice — is covered by TestScorer_SubscriptionPreference-
+// FlipsAndSpills and TestScorer_SubscriptionPicksCheapestSufficientWithinFamily.
 func TestScorer_SubscriptionCostFactorNoop(t *testing.T) {
 	emb := &fakeEmbedder{vec: makeOpusVec()}
 	s := newScorerForTest(t, emb, cfgForTest())
@@ -188,6 +187,75 @@ func TestScorer_SubscriptionCostFactorNoop(t *testing.T) {
 	assert.Equal(t, base.Model, noopRes.Model, "a 1.0 factor must not change the decision")
 	assert.InDelta(t, base.Metadata.ChosenScore, noopRes.Metadata.ChosenScore, 1e-9,
 		"a 1.0 factor must not change the score")
+}
+
+// subscriptionKnobs makes cluster 0 hard (quality-favored, alpha 0.9) and cluster
+// 1 easy (cost-favored, alpha 0.2), so the V2 blend has a real margin to flip.
+func subscriptionKnobs() *DefaultRoutingKnobs {
+	return &DefaultRoutingKnobs{
+		Alpha:                []float64{0.9, 0.2},
+		SpeedWeight:          0.0,
+		OutputCostRatio:      0.0,
+		ExpectedOutputTokens: 2000,
+	}
+}
+
+// TestScorer_SubscriptionPreferenceFlipsAndSpills exercises the plan-vs-cash half
+// of subscription-aware routing. In the hard cluster 0, opus is the quality-
+// favored pick with no subsidy. Treating haiku as the subscription-covered/plan
+// model and opus as the uncovered/cash alternative: a slack plan (f≈epsilon) adds
+// the headroom bonus and flips the pick to the covered model; a bound plan (f=1)
+// zeroes the bonus and the pick spills back to cash. The scorer is family-
+// agnostic — it applies the bonus to whatever subsidyFactors lists.
+func TestScorer_SubscriptionPreferenceFlipsAndSpills(t *testing.T) {
+	emb := &fakeEmbedder{vec: makeOpusVec()}
+	s := newV2BundleForTest(t, emb, v2BundleOpts{defaultKnobs: subscriptionKnobs()})
+	req := router.Request{PromptText: strings.Repeat("x", 100)}
+
+	base, err := s.Route(context.Background(), req)
+	require.NoError(t, err)
+	require.Equal(t, "claude-opus-4-7", base.Model, "no subsidy: quality-favored model wins the hard cluster")
+
+	slack := req
+	slack.SubsidizedModelCostFactor = map[string]float64{"claude-haiku-4-5": 0.05}
+	slackRes, err := s.Route(context.Background(), slack)
+	require.NoError(t, err)
+	assert.Equal(t, "claude-haiku-4-5", slackRes.Model,
+		"a slack plan (f≈epsilon) lifts the covered model above the otherwise-preferred one")
+
+	bound := req
+	bound.SubsidizedModelCostFactor = map[string]float64{"claude-haiku-4-5": 1.0}
+	boundRes, err := s.Route(context.Background(), bound)
+	require.NoError(t, err)
+	assert.Equal(t, "claude-opus-4-7", boundRes.Model,
+		"a bound plan (f=1) zeroes the bonus; routing spills back to the cash model")
+}
+
+// TestScorer_SubscriptionPicksCheapestSufficientWithinFamily is the headline
+// property: with BOTH covered models subsidized at the same slack factor, the
+// uniform bonus cannot reorder them, so the per-cluster quality/cost blend still
+// decides which covered model wins — the strong one on a hard (quality-favored)
+// cluster, the cheap one on an easy (cost-favored) cluster. This is exactly the
+// intra-family discrimination the old cost-multiply washed out (it compressed
+// Haiku and Opus together and over-picked Opus even for trivial turns).
+func TestScorer_SubscriptionPicksCheapestSufficientWithinFamily(t *testing.T) {
+	covered := map[string]float64{"claude-opus-4-7": 0.05, "claude-haiku-4-5": 0.05}
+
+	hard := newV2BundleForTest(t, &fakeEmbedder{vec: makeOpusVec()}, v2BundleOpts{defaultKnobs: subscriptionKnobs()})
+	hardRes, err := hard.Route(context.Background(), router.Request{
+		PromptText: strings.Repeat("x", 100), SubsidizedModelCostFactor: covered,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "claude-opus-4-7", hardRes.Model,
+		"hard cluster: a subscribed family still routes to the strong model")
+
+	easy := newV2BundleForTest(t, &fakeEmbedder{vec: makeHaikuVec()}, v2BundleOpts{defaultKnobs: subscriptionKnobs()})
+	easyRes, err := easy.Route(context.Background(), router.Request{
+		PromptText: strings.Repeat("y", 100), SubsidizedModelCostFactor: covered,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "claude-haiku-4-5", easyRes.Model,
+		"easy cluster: a subscribed family routes to the cheap sufficient model (Haiku, not Opus)")
 }
 
 // Removing any populated metadata field breaks routing telemetry rows.

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -41,12 +41,16 @@ type Request struct {
 	// If filtering empties eligible set, scorer returns ErrNoEligibleProvider.
 	ExcludedModels map[string]struct{}
 	RoutingKnobs   *Overrides // NEW: parsed dynamic knobs
-	// SubsidizedModelCostFactor scales a model's cost term in the scorer, in
-	// [epsilon, 1]. Set per-request for models a caller's presented subscription
-	// covers, derived from observed rate-limit headroom (see internal/proxy/usage):
-	// ~epsilon when the sub's window has slack (covered model ~free), rising to 1
-	// (full catalog price, no subsidy) as the window binds. Absent entry = no
-	// subsidy. nil/empty = today's behavior.
+	// SubsidizedModelCostFactor is the per-model rate-limit headroom factor in
+	// [epsilon, 1] for models a caller's presented subscription covers, derived
+	// from observed headroom (see internal/proxy/usage): ~epsilon when the sub's
+	// window has slack, rising to 1 as the window binds. Absent entry = no
+	// subsidy; nil/empty = today's behavior. The cluster scorer reads it as a
+	// PREFERENCE signal — it lifts a covered model's score by a uniform per-family
+	// bonus proportional to (1−factor), leaving the cost axis at full catalog so
+	// the intra-family Haiku↔Opus spread is preserved. (The planner, separately,
+	// still reads it as a literal cost multiplier for its dollar-EV cache-switch
+	// math, where a prepaid model's marginal price really is ~factor×catalog.)
 	SubsidizedModelCostFactor map[string]float64
 }
 


### PR DESCRIPTION
## What

Reworks subscription-aware routing so that, on a plan, the router picks the **cheapest covered model that clears the quality bar** (Haiku for a trivial turn, Opus for a hard one) instead of over-picking Opus — while still preferring the prepaid plan over paying cash, and easing back to cash as the rate-limit window binds.

Supersedes the narrow optimistic-bootstrap fix this branch started as (#497 scope) — the bootstrap is preserved inside the new mechanism.

## Why

The shipped subsidy multiplied a covered model's **cost term** by the headroom factor `f`. With slack headroom (small `f`), that compresses the entire covered family toward the cost-axis floor, so the scorer's min-max normalization against full-price OSS **washes out the Haiku↔Opus spread** — and the quality side of the 50/50 blend then over-picks Opus even for "hello"-class turns.

Dollars are the wrong unit on a plan: the price is prepaid. What actually differs between covered models is **how much plan quota each burns** — and Anthropic's unified rate limit weights Opus far above Haiku, which the catalog price ratio already tracks. So the intra-family signal we want is the *full* catalog spread, not a compressed one.

## How

Separate the two decisions a subscription implies:

- **Plan vs. cash (cross-family):** lift covered models by a **uniform per-family score bonus** `subsidyMaxBonus·(1−f)` — near its max on a slack plan, fading to 0 as the window binds, so OSS/cash re-enters on its own merits (**soft spill**).
- **Which model within the plan (intra-family):** leave **cost at full catalog scale**, so the existing quality/cost blend picks Haiku for easy turns and Opus for hard ones.

The bonus is *uniform across a family* (every covered model shares its credential's `f`), so it only moves plan-vs-cash and **never reorders within the family**. Cold start keeps the optimistic bootstrap behavior: `f=ε` → bonus ≈ max, so the plan wins (and seeds) the first turn.

The **planner** is intentionally unchanged: its dollar-EV cache-switch math still reads the factor as a literal cost multiplier, which is correct there (a prepaid model's marginal dollar price really is ~`f`×catalog).

## Guarantees / blast radius

- No new knobs.
- No-subscription traffic is **byte-identical** (an empty/nil factor map adds no bonus and leaves cost at catalog, exactly as today).
- Disturbs none of the quality/cost/speed blend weights — the bonus is purely additive, after the blend.

## Tests

- `TestScorer_SubscriptionPreferenceFlipsAndSpills` — a slack plan flips the pick to the covered model; a bound plan (`f=1`) zeroes the bonus and spills back.
- `TestScorer_SubscriptionPicksCheapestSufficientWithinFamily` — with the whole family subsidized, a hard cluster still routes to Opus and an easy cluster to Haiku (the intra-family discrimination the old cost-multiply washed out).
- `TestScorer_SubscriptionCostFactorNoop` — nil / `1.0` factor is byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)