### PR TITLE
feat(router): opt-in RL/DPO policy routing strategy via x-weave-router-strategy header

### DIFF
--- a/cmd/router/main.go
+++ b/cmd/router/main.go
@@ -594,7 +594,7 @@ func main() {
 	var rlRouter router.Router
 	if rlSidecarURL := config.GetOr("ROUTER_RL_SIDECAR_URL", ""); rlSidecarURL != "" {
 		rlTimeout := parseEnvDurationMs("ROUTER_RL_SIDECAR_TIMEOUT_MS", rl.DefaultTimeout)
-		rlRouter = rl.New(rl.NewHTTPDecider(rlSidecarURL, nil, rlTimeout), availableModels)
+		rlRouter = rl.New(rl.NewHTTPDecider(rlSidecarURL, nil, rlTimeout), availableModels, availableProviders)
 		logger.Info("RL policy router wired", "sidecar_url", rlSidecarURL, "timeout_ms", rlTimeout.Milliseconds(), "candidate_models", len(availableModels))
 	} else {
 		logger.Info("RL policy router disabled (ROUTER_RL_SIDECAR_URL unset); x-weave-router-strategy: rl will return 503")

--- a/cmd/router/main.go
+++ b/cmd/router/main.go
@@ -42,6 +42,7 @@ import (
 	"workweave/router/internal/router/cluster"
 	"workweave/router/internal/router/handover"
 	"workweave/router/internal/router/planner"
+	"workweave/router/internal/router/rl"
 	"workweave/router/internal/router/sessionpin"
 	"workweave/router/internal/server"
 	"workweave/router/internal/translate"
@@ -585,7 +586,22 @@ func main() {
 		logger.Info("Feedback link disabled (set ROUTER_FEEDBACK_LINK_SECRET and ROUTER_FEEDBACK_BASE_URL to enable)")
 	}
 
+	// Opt-in RL/DPO policy router. Wired only when ROUTER_RL_SIDECAR_URL points
+	// at a running policy sidecar; the x-weave-router-strategy: rl header then
+	// routes through it, selecting from the same deployed catalog candidates and
+	// dispatching via Weave's own providers. Left unset, the header fails closed
+	// with HTTP 503 rather than silently serving the cluster scorer.
+	var rlRouter router.Router
+	if rlSidecarURL := config.GetOr("ROUTER_RL_SIDECAR_URL", ""); rlSidecarURL != "" {
+		rlTimeout := parseEnvDurationMs("ROUTER_RL_SIDECAR_TIMEOUT_MS", rl.DefaultTimeout)
+		rlRouter = rl.New(rl.NewHTTPDecider(rlSidecarURL, nil, rlTimeout), availableModels)
+		logger.Info("RL policy router wired", "sidecar_url", rlSidecarURL, "timeout_ms", rlTimeout.Milliseconds(), "candidate_models", len(availableModels))
+	} else {
+		logger.Info("RL policy router disabled (ROUTER_RL_SIDECAR_URL unset); x-weave-router-strategy: rl will return 503")
+	}
+
 	proxySvc := proxy.NewService(routeEntry, providerMap, emitter, embedOnlyUser, semanticCache, pinStore, hardPinExplore, hardPinProvider, hardPinModel, repo.Telemetry).
+		WithRLRouter(rlRouter).
 		WithContentCapture(captureMode, captureMaxBytes, nil).
 		WithFeedback(repo.Feedback, feedbackSigner, feedbackBaseURL).
 		WithByokOnly(byokOnly).

--- a/internal/api/anthropic/messages.go
+++ b/internal/api/anthropic/messages.go
@@ -13,6 +13,7 @@ import (
 	"workweave/router/internal/providers"
 	"workweave/router/internal/proxy"
 	"workweave/router/internal/router/cluster"
+	"workweave/router/internal/router/rl"
 	"workweave/router/internal/server/middleware"
 	"workweave/router/internal/translate"
 
@@ -106,6 +107,12 @@ func MessagesHandler(svc *proxy.Service, authSvc *auth.Service) gin.HandlerFunc 
 			if errors.Is(err, cluster.ErrInvalidRoutingKnobs) {
 				log.Warn("Invalid routing knobs supplied", "err", err)
 				writeAnthropicError(c, http.StatusBadRequest, "invalid_request_error", "Invalid routing knobs supplied.")
+				return
+			}
+			if errors.Is(err, rl.ErrPolicyUnavailable) {
+				log.Error("RL routing unavailable", "err", err)
+				c.Header("Retry-After", "1")
+				writeAnthropicError(c, http.StatusServiceUnavailable, "api_error", "Router unavailable: RL policy router failed and no fallback is configured.")
 				return
 			}
 			if errors.Is(err, cluster.ErrClusterUnavailable) {

--- a/internal/api/gemini/generate_content.go
+++ b/internal/api/gemini/generate_content.go
@@ -13,6 +13,7 @@ import (
 	"workweave/router/internal/providers"
 	"workweave/router/internal/proxy"
 	"workweave/router/internal/router/cluster"
+	"workweave/router/internal/router/rl"
 	"workweave/router/internal/server/middleware"
 	"workweave/router/internal/translate"
 
@@ -102,6 +103,13 @@ func GenerateContentHandler(svc *proxy.Service, authSvc *auth.Service) gin.Handl
 			if errors.Is(err, cluster.ErrInvalidRoutingKnobs) {
 				log.Warn("Invalid routing knobs supplied", "err", err)
 				writeGeminiError(c, http.StatusBadRequest, "INVALID_ARGUMENT", err.Error())
+				return
+			}
+			if errors.Is(err, rl.ErrPolicyUnavailable) {
+				log.Error("RL routing unavailable", "err", err)
+				c.Header("Retry-After", "1")
+				writeGeminiError(c, http.StatusServiceUnavailable, "UNAVAILABLE",
+					"Router unavailable: RL policy router failed and no fallback is configured.")
 				return
 			}
 			if errors.Is(err, cluster.ErrClusterUnavailable) {

--- a/internal/api/openai/completions.go
+++ b/internal/api/openai/completions.go
@@ -12,6 +12,7 @@ import (
 	"workweave/router/internal/providers"
 	"workweave/router/internal/proxy"
 	"workweave/router/internal/router/cluster"
+	"workweave/router/internal/router/rl"
 	"workweave/router/internal/server/middleware"
 	"workweave/router/internal/translate"
 
@@ -72,6 +73,12 @@ func ChatCompletionHandler(svc *proxy.Service, authSvc *auth.Service) gin.Handle
 			if errors.Is(err, cluster.ErrInvalidRoutingKnobs) {
 				log.Warn("Invalid routing knobs supplied", "err", err)
 				writeOpenAIError(c, http.StatusBadRequest, "invalid_request_error", "Invalid routing knobs supplied.")
+				return
+			}
+			if errors.Is(err, rl.ErrPolicyUnavailable) {
+				log.Error("RL routing unavailable", "err", err)
+				c.Header("Retry-After", "1")
+				writeOpenAIError(c, http.StatusServiceUnavailable, "api_error", "Router unavailable: RL policy router failed and no fallback is configured.")
 				return
 			}
 			if errors.Is(err, cluster.ErrClusterUnavailable) {

--- a/internal/api/openai/responses.go
+++ b/internal/api/openai/responses.go
@@ -10,6 +10,7 @@ import (
 	"workweave/router/internal/providers"
 	"workweave/router/internal/proxy"
 	"workweave/router/internal/router/cluster"
+	"workweave/router/internal/router/rl"
 	"workweave/router/internal/server/middleware"
 	"workweave/router/internal/translate"
 
@@ -73,6 +74,12 @@ func ResponsesHandler(svc *proxy.Service, authSvc *auth.Service) gin.HandlerFunc
 			if errors.Is(err, cluster.ErrInvalidRoutingKnobs) {
 				log.Warn("Invalid routing knobs supplied", "err", err)
 				writeOpenAIError(c, http.StatusBadRequest, "invalid_request_error", "Invalid routing knobs supplied.")
+				return
+			}
+			if errors.Is(err, rl.ErrPolicyUnavailable) {
+				log.Error("RL routing unavailable", "err", err)
+				c.Header("Retry-After", "1")
+				writeOpenAIError(c, http.StatusServiceUnavailable, "api_error", "Router unavailable: RL policy router failed and no fallback is configured.")
 				return
 			}
 			if errors.Is(err, cluster.ErrClusterUnavailable) {

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -23,6 +23,7 @@ import (
 	"workweave/router/internal/router/catalog"
 	"workweave/router/internal/router/handover"
 	"workweave/router/internal/router/planner"
+	"workweave/router/internal/router/rl"
 	"workweave/router/internal/router/sessionpin"
 	"workweave/router/internal/router/turntype"
 	"workweave/router/internal/translate"
@@ -33,7 +34,12 @@ import (
 
 // Service orchestrates routing decisions and provider dispatch.
 type Service struct {
-	router               router.Router
+	router router.Router
+	// rlRouter is the opt-in RL/DPO policy router, selected per-request via the
+	// x-weave-router-strategy: rl header. Nil when no policy sidecar is wired
+	// (ROUTER_RL_SIDECAR_URL unset); the strategy header then 503s rather than
+	// silently serving the cluster scorer.
+	rlRouter             router.Router
 	providers            map[string]providers.Client
 	emitter              *otel.Emitter
 	embedOnlyUserMessage bool
@@ -1128,10 +1134,34 @@ func (s *Service) provider(name string) (providers.Client, error) {
 	return p, nil
 }
 
-// Route exposes the underlying router for callers that need a decision
-// without dispatching (e.g. admin endpoints).
-func (s *Service) Route(ctx context.Context, req router.Request) (router.Decision, error) {
+// WithRLRouter installs the opt-in RL/DPO policy router. nil leaves the
+// x-weave-router-strategy: rl header with no backing router, in which case
+// routeFor 503s for that header rather than silently serving the cluster
+// scorer.
+func (s *Service) WithRLRouter(r router.Router) *Service {
+	s.rlRouter = r
+	return s
+}
+
+// routeFor picks the active router for the request's strategy. The default
+// (and the cluster strategy) is the cluster scorer; the rl strategy uses the
+// RL policy router when wired, and otherwise fails closed with
+// ErrPolicyUnavailable (→ HTTP 503) — never a silent fallback that would mask
+// which strategy actually served the turn.
+func (s *Service) routeFor(ctx context.Context, req router.Request) (router.Decision, error) {
+	if router.StrategyFromContext(ctx) == router.StrategyRL {
+		if s.rlRouter == nil {
+			return router.Decision{}, fmt.Errorf("rl strategy requested but no policy sidecar configured: %w", rl.ErrPolicyUnavailable)
+		}
+		return s.rlRouter.Route(ctx, req)
+	}
 	return s.router.Route(ctx, req)
+}
+
+// Route exposes the underlying router for callers that need a decision
+// without dispatching (e.g. admin endpoints). Honors the per-request strategy.
+func (s *Service) Route(ctx context.Context, req router.Request) (router.Decision, error) {
+	return s.routeFor(ctx, req)
 }
 
 // PassthroughToProvider forwards a non-routing request to the default

--- a/internal/proxy/turnloop.go
+++ b/internal/proxy/turnloop.go
@@ -211,7 +211,7 @@ func (s *Service) runTurnLoop(
 
 	// Without a pin store, run the scorer and return its decision.
 	if s.pinStore == nil {
-		decision, err := s.router.Route(ctx, req)
+		decision, err := s.routeFor(ctx, req)
 		if err != nil {
 			return res, err
 		}
@@ -460,7 +460,7 @@ func (s *Service) runTurnLoop(
 		if constrained, ok := s.restrictToTier(req.ExcludedModels, forcedTierFloor); ok {
 			tierReq := req
 			tierReq.ExcludedModels = constrained
-			if dec, derr := s.router.Route(ctx, tierReq); derr == nil {
+			if dec, derr := s.routeFor(ctx, tierReq); derr == nil {
 				fresh, routed = dec, true
 				log.Info("user-forced model evicted; rerouted to next-best in same tier",
 					"forced_tier", forcedTierFloor.String(),
@@ -474,7 +474,7 @@ func (s *Service) runTurnLoop(
 		}
 	}
 	if !routed {
-		dec, err := s.router.Route(ctx, req)
+		dec, err := s.routeFor(ctx, req)
 		if err != nil {
 			log.Error("turnloop scorer failed", "err", err, "requested_model", req.RequestedModel)
 			return res, err

--- a/internal/router/rl/AGENTS.md
+++ b/internal/router/rl/AGENTS.md
@@ -1,0 +1,25 @@
+# internal/router/rl — CLAUDE
+
+> **Mirror notice.** Verbatim sync with [AGENTS.md](AGENTS.md). **Update both together** — divergence = bug.
+
+Opt-in `router.Router` that delegates model selection to a trained RL/DPO policy served by the out-of-process **router-rl-sidecar** Cloud Run service (`ml_dev/rl_router/router_policy_server.py`). Read [root CLAUDE.md](../../../CLAUDE.md) and [internal/router/CLAUDE.md](../CLAUDE.md) first.
+
+## What it does (and does not do)
+
+- **Does:** build the eligible candidate set from this router's own `catalog` (deployed models ∩ request's enabled providers, minus exclusions, minus `ToolUseLow` on tool turns), ask the policy to pick one, and map the choice back to a `router.Decision`.
+- **Does NOT:** dispatch, translate, embed, or talk to OpenRouter. Dispatch stays in `proxy.Service` over Weave's own providers; the sidecar only answers "which eligible model?". The prompt embedding the policy needs is computed inside the sidecar (against a Weave Google/Vertex key), never here.
+
+## Load-bearing invariants
+
+- **Opt-in only.** Reached solely via `x-weave-router-strategy: rl` (see `proxy.Service.routeFor`); the deployment default stays the cluster scorer.
+- **Fail closed.** Every failure path (sidecar unreachable/errored, no eligible candidate, unrecognized selection) returns `ErrPolicyUnavailable`, which the API layer maps to HTTP 503 — mirroring `cluster.ErrClusterUnavailable`. **Never** add a silent fallback to a default model or to the cluster scorer; that masks regressions exactly like the retired heuristic fallback.
+- **Adapters don't import adapters.** This package defines its own `ErrPolicyUnavailable` rather than importing `cluster`. Keep it that way.
+- **Roster mapping is best-effort.** `mapping.go` mirrors `ml_dev/agent_environment/roster.py`'s `OPENROUTER_MODEL_ALIASES`. The sidecar intersects candidates against its trained roster, so a model it doesn't know is simply dropped — but keep the two dotted-form Claude exceptions accurate.
+
+## Wiring
+
+`cmd/router/main.go` constructs `rl.New(rl.NewHTTPDecider(ROUTER_RL_SIDECAR_URL, …), availableModels)` and injects it via `proxy.Service.WithRLRouter`. Unset URL → `WithRLRouter(nil)` → the strategy header 503s.
+
+## Tests
+
+`Decider` is an interface so `rl_test.go` injects a fake and asserts candidate construction, roster↔catalog mapping, and the fail-closed paths — no network.

--- a/internal/router/rl/CLAUDE.md
+++ b/internal/router/rl/CLAUDE.md
@@ -1,0 +1,25 @@
+# internal/router/rl — CLAUDE
+
+> **Mirror notice.** Verbatim sync with [AGENTS.md](AGENTS.md). **Update both together** — divergence = bug.
+
+Opt-in `router.Router` that delegates model selection to a trained RL/DPO policy served by the out-of-process **router-rl-sidecar** Cloud Run service (`ml_dev/rl_router/router_policy_server.py`). Read [root CLAUDE.md](../../../CLAUDE.md) and [internal/router/CLAUDE.md](../CLAUDE.md) first.
+
+## What it does (and does not do)
+
+- **Does:** build the eligible candidate set from this router's own `catalog` (deployed models ∩ request's enabled providers, minus exclusions, minus `ToolUseLow` on tool turns), ask the policy to pick one, and map the choice back to a `router.Decision`.
+- **Does NOT:** dispatch, translate, embed, or talk to OpenRouter. Dispatch stays in `proxy.Service` over Weave's own providers; the sidecar only answers "which eligible model?". The prompt embedding the policy needs is computed inside the sidecar (against a Weave Google/Vertex key), never here.
+
+## Load-bearing invariants
+
+- **Opt-in only.** Reached solely via `x-weave-router-strategy: rl` (see `proxy.Service.routeFor`); the deployment default stays the cluster scorer.
+- **Fail closed.** Every failure path (sidecar unreachable/errored, no eligible candidate, unrecognized selection) returns `ErrPolicyUnavailable`, which the API layer maps to HTTP 503 — mirroring `cluster.ErrClusterUnavailable`. **Never** add a silent fallback to a default model or to the cluster scorer; that masks regressions exactly like the retired heuristic fallback.
+- **Adapters don't import adapters.** This package defines its own `ErrPolicyUnavailable` rather than importing `cluster`. Keep it that way.
+- **Roster mapping is best-effort.** `mapping.go` mirrors `ml_dev/agent_environment/roster.py`'s `OPENROUTER_MODEL_ALIASES`. The sidecar intersects candidates against its trained roster, so a model it doesn't know is simply dropped — but keep the two dotted-form Claude exceptions accurate.
+
+## Wiring
+
+`cmd/router/main.go` constructs `rl.New(rl.NewHTTPDecider(ROUTER_RL_SIDECAR_URL, …), availableModels)` and injects it via `proxy.Service.WithRLRouter`. Unset URL → `WithRLRouter(nil)` → the strategy header 503s.
+
+## Tests
+
+`Decider` is an interface so `rl_test.go` injects a fake and asserts candidate construction, roster↔catalog mapping, and the fail-closed paths — no network.

--- a/internal/router/rl/client.go
+++ b/internal/router/rl/client.go
@@ -1,0 +1,114 @@
+package rl
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// DefaultTimeout bounds a single policy decision. The sidecar embeds the
+// prompt (a network call to the embedding provider) before scoring, so the
+// budget is comparable to the cluster scorer's embed timeout.
+const DefaultTimeout = 2 * time.Second
+
+// HTTPDecider calls the policy sidecar's POST /route endpoint.
+type HTTPDecider struct {
+	baseURL string
+	client  *http.Client
+}
+
+// NewHTTPDecider builds a Decider that posts to baseURL/route. A nil client
+// uses a default client bounded by timeout; a non-nil client is used as-is.
+func NewHTTPDecider(baseURL string, client *http.Client, timeout time.Duration) *HTTPDecider {
+	if client == nil {
+		if timeout <= 0 {
+			timeout = DefaultTimeout
+		}
+		client = &http.Client{Timeout: timeout}
+	}
+	return &HTTPDecider{
+		baseURL: strings.TrimRight(baseURL, "/"),
+		client:  client,
+	}
+}
+
+type routeRequest struct {
+	PromptText         string            `json:"prompt_text"`
+	TurnIndex          int               `json:"turn_index"`
+	CandidateModels    []string          `json:"candidate_models"`
+	CandidateProviders map[string]string `json:"candidate_providers"`
+}
+
+type routeResponse struct {
+	Model      string  `json:"model"`
+	Score      float64 `json:"score"`
+	ScoreLabel string  `json:"score_label"`
+	Reason     string  `json:"reason"`
+	StateLabel string  `json:"state_label"`
+	Error      string  `json:"error"`
+}
+
+// Decide posts the candidate set to the sidecar and returns its selection.
+func (d *HTTPDecider) Decide(ctx context.Context, q Query) (Result, error) {
+	models := make([]string, 0, len(q.Candidates))
+	providers := make(map[string]string, len(q.Candidates))
+	for _, c := range q.Candidates {
+		models = append(models, c.RosterID)
+		providers[c.RosterID] = c.Provider
+	}
+	body, err := json.Marshal(routeRequest{
+		PromptText:         q.PromptText,
+		TurnIndex:          q.TurnIndex,
+		CandidateModels:    models,
+		CandidateProviders: providers,
+	})
+	if err != nil {
+		return Result{}, fmt.Errorf("marshal route request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, d.baseURL+"/route", bytes.NewReader(body))
+	if err != nil {
+		return Result{}, fmt.Errorf("build route request: %w", err)
+	}
+	req.Header.Set("content-type", "application/json")
+
+	resp, err := d.client.Do(req)
+	if err != nil {
+		return Result{}, fmt.Errorf("call policy sidecar: %w", err)
+	}
+	defer resp.Body.Close()
+
+	payload, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return Result{}, fmt.Errorf("read policy response: %w", err)
+	}
+
+	var parsed routeResponse
+	if err := json.Unmarshal(payload, &parsed); err != nil {
+		return Result{}, fmt.Errorf("decode policy response (status %d): %w", resp.StatusCode, err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		if parsed.Error != "" {
+			return Result{}, fmt.Errorf("policy sidecar status %d: %s", resp.StatusCode, parsed.Error)
+		}
+		return Result{}, fmt.Errorf("policy sidecar status %d", resp.StatusCode)
+	}
+	if parsed.Model == "" {
+		return Result{}, fmt.Errorf("policy sidecar returned empty model")
+	}
+
+	return Result{
+		Model:      parsed.Model,
+		Score:      parsed.Score,
+		ScoreLabel: parsed.ScoreLabel,
+		Reason:     parsed.Reason,
+		StateLabel: parsed.StateLabel,
+	}, nil
+}
+
+var _ Decider = (*HTTPDecider)(nil)

--- a/internal/router/rl/client_test.go
+++ b/internal/router/rl/client_test.go
@@ -1,0 +1,77 @@
+package rl_test
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"workweave/router/internal/providers"
+	"workweave/router/internal/router/rl"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHTTPDeciderPostsContractAndParsesResult(t *testing.T) {
+	var gotPath string
+	var gotBody map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		raw, _ := io.ReadAll(r.Body)
+		require.NoError(t, json.Unmarshal(raw, &gotBody))
+		// Mirror router_policy_server.py's success envelope.
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"model":       "anthropic/claude-opus-4-8",
+			"score":       1.875,
+			"score_label": "DPO score",
+			"reason":      "rl_policy artifact=main_q_dpo.pkl",
+			"state_label": "implementing a fix",
+		})
+	}))
+	defer server.Close()
+
+	d := rl.NewHTTPDecider(server.URL, nil, 0)
+	res, err := d.Decide(context.Background(), rl.Query{
+		PromptText: "fix the bug",
+		TurnIndex:  3,
+		Candidates: []rl.Candidate{
+			{RosterID: "anthropic/claude-opus-4-8", Provider: providers.ProviderAnthropic},
+			{RosterID: "deepseek/deepseek-v4-flash", Provider: providers.ProviderDeepInfra},
+		},
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, "/route", gotPath)
+	assert.Equal(t, "fix the bug", gotBody["prompt_text"])
+	assert.EqualValues(t, 3, gotBody["turn_index"])
+	assert.ElementsMatch(t,
+		[]any{"anthropic/claude-opus-4-8", "deepseek/deepseek-v4-flash"},
+		gotBody["candidate_models"])
+	providersMap, ok := gotBody["candidate_providers"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, providers.ProviderAnthropic, providersMap["anthropic/claude-opus-4-8"])
+
+	assert.Equal(t, "anthropic/claude-opus-4-8", res.Model)
+	assert.InDelta(t, 1.875, res.Score, 1e-9)
+	assert.Equal(t, "DPO score", res.ScoreLabel)
+	assert.Equal(t, "implementing a fix", res.StateLabel)
+}
+
+func TestHTTPDeciderSurfacesSidecarError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"error": "no request candidate model is present in the policy artifact roster",
+			"type":  "ValueError",
+		})
+	}))
+	defer server.Close()
+
+	d := rl.NewHTTPDecider(server.URL, nil, 0)
+	_, err := d.Decide(context.Background(), rl.Query{PromptText: "x"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "policy artifact roster")
+}

--- a/internal/router/rl/mapping.go
+++ b/internal/router/rl/mapping.go
@@ -1,0 +1,41 @@
+package rl
+
+import (
+	"strings"
+
+	"workweave/router/internal/providers"
+	"workweave/router/internal/router/catalog"
+)
+
+// rosterAliases maps a catalog model ID to the policy-artifact roster ID when
+// the vendor-prefix rule below would produce the wrong slug. The RL policy was
+// trained on OpenRouter-style slugs (ml_dev/agent_environment/roster.py's
+// OPENROUTER_MODEL_ALIASES); Opus 4.x uses dash-separated minor versions but
+// Sonnet/Haiku 4.x use dotted minor versions, so those two need an explicit
+// entry. Everything else is derived (slash-form is already a slug; bare
+// first-party IDs take their primary provider's vendor prefix).
+var rosterAliases = map[string]string{
+	"claude-sonnet-4-6": "anthropic/claude-sonnet-4.6",
+	"claude-haiku-4-5":  "anthropic/claude-haiku-4.5",
+}
+
+// rosterIDFor returns the policy-artifact roster ID for a catalog model. The
+// sidecar canonicalizes and intersects candidates against its own roster, so a
+// best-effort slug is safe: a model the policy doesn't know is simply dropped.
+func rosterIDFor(m catalog.Model) string {
+	if alias, ok := rosterAliases[m.ID]; ok {
+		return alias
+	}
+	if strings.Contains(m.ID, "/") {
+		return m.ID
+	}
+	switch m.PrimaryProvider() {
+	case providers.ProviderAnthropic:
+		return "anthropic/" + m.ID
+	case providers.ProviderOpenAI:
+		return "openai/" + m.ID
+	case providers.ProviderGoogle:
+		return "google/" + m.ID
+	}
+	return m.ID
+}

--- a/internal/router/rl/rl.go
+++ b/internal/router/rl/rl.go
@@ -66,21 +66,25 @@ type Decider interface {
 // Router selects a model via the RL policy and returns a router.Decision whose
 // provider is resolved from the catalog so dispatch uses Weave's own providers.
 type Router struct {
-	decider  Decider
-	deployed map[string]struct{}
-	toolLow  map[string]struct{}
-	imageLow map[string]struct{}
+	decider   Decider
+	deployed  map[string]struct{}
+	available map[string]struct{}
+	toolLow   map[string]struct{}
+	imageLow  map[string]struct{}
 }
 
 // New builds an RL Router. deployed is the set of deployable catalog model IDs
-// (the same source the planner's available-models set is drawn from); the
-// policy can only be offered models the deploy actually serves.
-func New(decider Decider, deployed map[string]struct{}) *Router {
+// (the same source the planner's available-models set is drawn from); available
+// is the deployment's keyed-provider set (the cluster scorer's
+// availableProviders), used to resolve a model's dispatch binding when the
+// request does not restrict providers.
+func New(decider Decider, deployed, available map[string]struct{}) *Router {
 	return &Router{
-		decider:  decider,
-		deployed: deployed,
-		toolLow:  catalog.ToolUseLowSet(),
-		imageLow: catalog.ImageUnsupportedSet(),
+		decider:   decider,
+		deployed:  deployed,
+		available: available,
+		toolLow:   catalog.ToolUseLowSet(),
+		imageLow:  catalog.ImageUnsupportedSet(),
 	}
 }
 
@@ -112,20 +116,19 @@ func (r *Router) eligible(req router.Request) ([]Candidate, map[string]candidate
 		if !ok {
 			continue
 		}
-		// nil EnabledProviders means unrestricted (router.Request contract);
-		// the cluster scorer only gates when the set is non-nil, so mirror that
-		// and fall back to the model's primary binding when unrestricted.
-		var provider string
-		if req.EnabledProviders == nil {
-			provider = model.PrimaryProvider()
-		} else {
-			binding, ok := catalog.ResolveBinding(id, req.EnabledProviders)
-			if !ok {
-				continue
-			}
-			provider = binding.Provider
+		// nil EnabledProviders means unrestricted (router.Request contract); the
+		// cluster scorer's unrestricted path resolves the binding against the
+		// deployment's keyed providers, not the catalog primary, so mirror that
+		// by resolving against r.available. A non-nil set gates per-request.
+		providerSet := req.EnabledProviders
+		if providerSet == nil {
+			providerSet = r.available
 		}
-		base = append(base, eligibleCand{catalogID: id, rosterID: rosterIDFor(model), provider: provider})
+		binding, ok := catalog.ResolveBinding(id, providerSet)
+		if !ok {
+			continue
+		}
+		base = append(base, eligibleCand{catalogID: id, rosterID: rosterIDFor(model), provider: binding.Provider})
 	}
 
 	base = r.softFilter(base, req.HasImages, r.imageLow)

--- a/internal/router/rl/rl.go
+++ b/internal/router/rl/rl.go
@@ -69,6 +69,7 @@ type Router struct {
 	decider  Decider
 	deployed map[string]struct{}
 	toolLow  map[string]struct{}
+	imageLow map[string]struct{}
 }
 
 // New builds an RL Router. deployed is the set of deployable catalog model IDs
@@ -79,18 +80,28 @@ func New(decider Decider, deployed map[string]struct{}) *Router {
 		decider:  decider,
 		deployed: deployed,
 		toolLow:  catalog.ToolUseLowSet(),
+		imageLow: catalog.ImageUnsupportedSet(),
 	}
+}
+
+// eligibleCand pairs the offered roster ID with the catalog model + dispatch
+// provider it maps back to.
+type eligibleCand struct {
+	catalogID string
+	rosterID  string
+	provider  string
 }
 
 // eligible builds the candidate list and a roster-ID → catalog model index for
 // mapping the policy's choice back. It mirrors the cluster scorer's
-// eligibility: deployed models with a binding in the request's enabled
-// providers, minus excluded models, and minus ToolUseLow models on tool turns
-// (relaxed only if the tool filter would empty the set).
+// eligibility: deployed models resolvable under the request's enabled providers
+// (nil = unrestricted), minus excluded models, minus image-unsupported models
+// on image turns, minus ToolUseLow models on tool turns — each soft filter
+// relaxed only if it would empty the pool. The index is built from the FINAL
+// returned slice so a soft-filtered model can never sneak back via the
+// response-mapping guard.
 func (r *Router) eligible(req router.Request) ([]Candidate, map[string]candidateBinding) {
-	withTool := make([]Candidate, 0, len(r.deployed))
-	withoutTool := make([]Candidate, 0, len(r.deployed))
-	idx := make(map[string]candidateBinding, len(r.deployed))
+	base := make([]eligibleCand, 0, len(r.deployed))
 	for id := range r.deployed {
 		if req.ExcludedModels != nil {
 			if _, excluded := req.ExcludedModels[id]; excluded {
@@ -101,23 +112,52 @@ func (r *Router) eligible(req router.Request) ([]Candidate, map[string]candidate
 		if !ok {
 			continue
 		}
-		binding, ok := catalog.ResolveBinding(id, req.EnabledProviders)
-		if !ok {
+		// nil EnabledProviders means unrestricted (router.Request contract);
+		// the cluster scorer only gates when the set is non-nil, so mirror that
+		// and fall back to the model's primary binding when unrestricted.
+		var provider string
+		if req.EnabledProviders == nil {
+			provider = model.PrimaryProvider()
+		} else {
+			binding, ok := catalog.ResolveBinding(id, req.EnabledProviders)
+			if !ok {
+				continue
+			}
+			provider = binding.Provider
+		}
+		base = append(base, eligibleCand{catalogID: id, rosterID: rosterIDFor(model), provider: provider})
+	}
+
+	base = r.softFilter(base, req.HasImages, r.imageLow)
+	base = r.softFilter(base, req.HasTools, r.toolLow)
+
+	candidates := make([]Candidate, 0, len(base))
+	idx := make(map[string]candidateBinding, len(base))
+	for _, c := range base {
+		candidates = append(candidates, Candidate{RosterID: c.rosterID, Provider: c.provider})
+		idx[c.rosterID] = candidateBinding{catalogID: c.catalogID, provider: c.provider}
+	}
+	return candidates, idx
+}
+
+// softFilter drops candidates whose catalog ID is in drop when active, but
+// keeps the unfiltered pool if the filter would empty it — the same empty-pool
+// fallback the cluster scorer uses for its tool-use and image filters.
+func (r *Router) softFilter(in []eligibleCand, active bool, drop map[string]struct{}) []eligibleCand {
+	if !active || len(drop) == 0 {
+		return in
+	}
+	kept := make([]eligibleCand, 0, len(in))
+	for _, c := range in {
+		if _, bad := drop[c.catalogID]; bad {
 			continue
 		}
-		rosterID := rosterIDFor(model)
-		cand := Candidate{RosterID: rosterID, Provider: binding.Provider}
-		idx[rosterID] = candidateBinding{catalogID: id, provider: binding.Provider}
-		withoutTool = append(withoutTool, cand)
-		if _, low := r.toolLow[id]; req.HasTools && low {
-			continue
-		}
-		withTool = append(withTool, cand)
+		kept = append(kept, c)
 	}
-	if req.HasTools && len(withTool) > 0 {
-		return withTool, idx
+	if len(kept) == 0 {
+		return in
 	}
-	return withoutTool, idx
+	return kept
 }
 
 type candidateBinding struct {
@@ -139,6 +179,11 @@ func (r *Router) Route(ctx context.Context, req router.Request) (router.Decision
 		return router.Decision{}, fmt.Errorf("rl: no eligible candidate: %w", ErrPolicyUnavailable)
 	}
 
+	// TurnIndex is always 0: router.Request carries no turn index (the proxy
+	// classifies turn TYPE but not depth), so we cannot populate it server-side
+	// without new plumbing. The policy's scoring is dominated by the prompt
+	// embedding; turn index is a minor feature. Threading a real index through
+	// router.Request is a deliberate follow-up, not done here.
 	res, err := r.decider.Decide(ctx, Query{
 		PromptText: req.PromptText,
 		TurnIndex:  0,

--- a/internal/router/rl/rl.go
+++ b/internal/router/rl/rl.go
@@ -1,0 +1,197 @@
+// Package rl is a router.Router implementation that delegates model selection
+// to a trained RL/DPO policy served by an out-of-process policy sidecar
+// (ml_dev/rl_router/router_policy_server.py, deployed as the router-rl-sidecar
+// Cloud Run service).
+//
+// The sidecar only answers "which eligible model should we route to?": this
+// package builds the candidate set from the router's own catalog (so dispatch
+// stays on Weave's providers, never OpenRouter), asks the policy to pick one,
+// and maps the choice back to a router.Decision. Auth, request translation,
+// provider dispatch, failover, and telemetry all stay in proxy.Service exactly
+// as for the cluster scorer.
+//
+// It is opt-in via the x-weave-router-strategy: rl header and is never a silent
+// fallback — every failure path returns ErrPolicyUnavailable so the API layer
+// maps it to HTTP 503 (the same contract as cluster.ErrClusterUnavailable),
+// rather than masking a regression by quietly serving a default model.
+package rl
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"workweave/router/internal/observability"
+	"workweave/router/internal/router"
+	"workweave/router/internal/router/catalog"
+)
+
+// ErrPolicyUnavailable signals the RL strategy could not produce a decision
+// (sidecar unreachable/errored, no eligible candidate, or an unrecognized
+// selection). API handlers map it to HTTP 503, mirroring the cluster scorer's
+// fail-closed contract — no silent fallback to a default model.
+var ErrPolicyUnavailable = errors.New("rl: policy router unavailable")
+
+// Candidate is one eligible model offered to the policy: the roster ID the
+// policy was trained on plus the provider the router would dispatch it to.
+type Candidate struct {
+	RosterID string
+	Provider string
+}
+
+// Query is the decision request handed to a Decider.
+type Query struct {
+	PromptText string
+	TurnIndex  int
+	Candidates []Candidate
+}
+
+// Result is the policy's selection. Model echoes one of the Query's
+// Candidate.RosterID values; the score/label/state fields are informational
+// and surface in the routing reason.
+type Result struct {
+	Model      string
+	Score      float64
+	ScoreLabel string
+	Reason     string
+	StateLabel string
+}
+
+// Decider asks the out-of-process policy which candidate to route to. The HTTP
+// implementation lives in client.go; tests inject a fake.
+type Decider interface {
+	Decide(ctx context.Context, q Query) (Result, error)
+}
+
+// Router selects a model via the RL policy and returns a router.Decision whose
+// provider is resolved from the catalog so dispatch uses Weave's own providers.
+type Router struct {
+	decider  Decider
+	deployed map[string]struct{}
+	toolLow  map[string]struct{}
+}
+
+// New builds an RL Router. deployed is the set of deployable catalog model IDs
+// (the same source the planner's available-models set is drawn from); the
+// policy can only be offered models the deploy actually serves.
+func New(decider Decider, deployed map[string]struct{}) *Router {
+	return &Router{
+		decider:  decider,
+		deployed: deployed,
+		toolLow:  catalog.ToolUseLowSet(),
+	}
+}
+
+// eligible builds the candidate list and a roster-ID → catalog model index for
+// mapping the policy's choice back. It mirrors the cluster scorer's
+// eligibility: deployed models with a binding in the request's enabled
+// providers, minus excluded models, and minus ToolUseLow models on tool turns
+// (relaxed only if the tool filter would empty the set).
+func (r *Router) eligible(req router.Request) ([]Candidate, map[string]candidateBinding) {
+	withTool := make([]Candidate, 0, len(r.deployed))
+	withoutTool := make([]Candidate, 0, len(r.deployed))
+	idx := make(map[string]candidateBinding, len(r.deployed))
+	for id := range r.deployed {
+		if req.ExcludedModels != nil {
+			if _, excluded := req.ExcludedModels[id]; excluded {
+				continue
+			}
+		}
+		model, ok := catalog.ByID(id)
+		if !ok {
+			continue
+		}
+		binding, ok := catalog.ResolveBinding(id, req.EnabledProviders)
+		if !ok {
+			continue
+		}
+		rosterID := rosterIDFor(model)
+		cand := Candidate{RosterID: rosterID, Provider: binding.Provider}
+		idx[rosterID] = candidateBinding{catalogID: id, provider: binding.Provider}
+		withoutTool = append(withoutTool, cand)
+		if _, low := r.toolLow[id]; req.HasTools && low {
+			continue
+		}
+		withTool = append(withTool, cand)
+	}
+	if req.HasTools && len(withTool) > 0 {
+		return withTool, idx
+	}
+	return withoutTool, idx
+}
+
+type candidateBinding struct {
+	catalogID string
+	provider  string
+}
+
+// Route asks the policy to choose among the eligible catalog candidates and
+// returns the choice as a router.Decision. Failure paths return
+// ErrPolicyUnavailable; the proxy never falls back to the cluster scorer.
+func (r *Router) Route(ctx context.Context, req router.Request) (router.Decision, error) {
+	log := observability.FromContext(ctx)
+	candidates, idx := r.eligible(req)
+	if len(candidates) == 0 {
+		log.Warn("RL router: no eligible candidate for request; returning ErrPolicyUnavailable",
+			"requested_model", req.RequestedModel,
+			"has_tools", req.HasTools,
+		)
+		return router.Decision{}, fmt.Errorf("rl: no eligible candidate: %w", ErrPolicyUnavailable)
+	}
+
+	res, err := r.decider.Decide(ctx, Query{
+		PromptText: req.PromptText,
+		TurnIndex:  0,
+		Candidates: candidates,
+	})
+	if err != nil {
+		log.Error("RL router: policy decide failed; returning ErrPolicyUnavailable", "err", err)
+		return router.Decision{}, fmt.Errorf("rl: policy decide: %w: %w", err, ErrPolicyUnavailable)
+	}
+
+	binding, ok := idx[res.Model]
+	if !ok {
+		log.Error("RL router: policy returned model not in candidate set; returning ErrPolicyUnavailable",
+			"returned_model", res.Model,
+		)
+		return router.Decision{}, fmt.Errorf("rl: policy returned unknown model %q: %w", res.Model, ErrPolicyUnavailable)
+	}
+
+	catalogIDs := make([]string, 0, len(idx))
+	for _, b := range idx {
+		catalogIDs = append(catalogIDs, b.catalogID)
+	}
+	log.Info("RL router decided",
+		"model", binding.catalogID,
+		"provider", binding.provider,
+		"roster_model", res.Model,
+		"score", res.Score,
+		"state", res.StateLabel,
+		"candidate_count", len(candidates),
+	)
+	return router.Decision{
+		Provider: binding.provider,
+		Model:    binding.catalogID,
+		Reason:   reasonFor(res),
+		Metadata: &router.RoutingMetadata{
+			CandidateModels: catalogIDs,
+			ChosenScore:     float32(res.Score),
+		},
+	}, nil
+}
+
+// reasonFor renders a compact routing reason from the policy result, e.g.
+// "rl_policy(DPO score=1.83; state=implementing a fix)".
+func reasonFor(res Result) string {
+	label := res.ScoreLabel
+	if label == "" {
+		label = "score"
+	}
+	reason := fmt.Sprintf("rl_policy(%s=%.3g", label, res.Score)
+	if res.StateLabel != "" {
+		reason += "; state=" + res.StateLabel
+	}
+	return reason + ")"
+}
+
+var _ router.Router = (*Router)(nil)

--- a/internal/router/rl/rl_test.go
+++ b/internal/router/rl/rl_test.go
@@ -121,6 +121,61 @@ func TestRouteDeciderErrorIsUnavailable(t *testing.T) {
 	assert.True(t, errors.Is(err, rl.ErrPolicyUnavailable))
 }
 
+func TestRouteNilEnabledProvidersIsUnrestricted(t *testing.T) {
+	// nil EnabledProviders means "unrestricted" (router.Request contract); the
+	// policy must still be offered the deployed models via their primary
+	// provider, not an empty set.
+	dec := &fakeDecider{result: rl.Result{Model: "anthropic/claude-opus-4-8"}}
+	r := rl.New(dec, deployed("claude-opus-4-8", "deepseek/deepseek-v4-flash"))
+
+	decision, err := r.Route(context.Background(), router.Request{
+		PromptText:       "hi",
+		EnabledProviders: nil,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "claude-opus-4-8", decision.Model)
+	assert.Equal(t, providers.ProviderAnthropic, decision.Provider)
+	assert.NotEmpty(t, dec.got.Candidates, "nil providers must not empty the candidate set")
+}
+
+func TestRouteToolTurnDropsToolUseLowFromCandidatesAndIndex(t *testing.T) {
+	// qwen/qwen3-235b-a22b-2507 is ToolUseLow. On a tool turn it must be absent
+	// from BOTH the offered candidates and the response-mapping index — a
+	// sidecar that names it anyway is rejected, not dispatched.
+	dec := &fakeDecider{result: rl.Result{Model: "qwen/qwen3-235b-a22b-2507"}}
+	r := rl.New(dec, deployed("claude-opus-4-8", "qwen/qwen3-235b-a22b-2507"))
+
+	_, err := r.Route(context.Background(), router.Request{
+		PromptText:       "use a tool",
+		HasTools:         true,
+		EnabledProviders: nil,
+	})
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, rl.ErrPolicyUnavailable))
+	for _, c := range dec.got.Candidates {
+		assert.NotEqual(t, "qwen/qwen3-235b-a22b-2507", c.RosterID,
+			"ToolUseLow model must not be offered on a tool turn")
+	}
+}
+
+func TestRouteImageTurnDropsImageUnsupported(t *testing.T) {
+	// deepseek/deepseek-v4-flash is image-unsupported; opus is vision-capable.
+	// An image turn must drop the text-only model when a capable one survives.
+	dec := &fakeDecider{result: rl.Result{Model: "anthropic/claude-opus-4-8"}}
+	r := rl.New(dec, deployed("claude-opus-4-8", "deepseek/deepseek-v4-flash"))
+
+	_, err := r.Route(context.Background(), router.Request{
+		PromptText:       "what is in this image",
+		HasImages:        true,
+		EnabledProviders: nil,
+	})
+	require.NoError(t, err)
+	for _, c := range dec.got.Candidates {
+		assert.NotEqual(t, "deepseek/deepseek-v4-flash", c.RosterID,
+			"image-unsupported model must not be offered on an image turn")
+	}
+}
+
 func TestRouteUnknownReturnedModelIsUnavailable(t *testing.T) {
 	dec := &fakeDecider{result: rl.Result{Model: "openai/gpt-5.5"}} // never offered
 	r := rl.New(dec, deployed("claude-opus-4-8"))

--- a/internal/router/rl/rl_test.go
+++ b/internal/router/rl/rl_test.go
@@ -41,11 +41,22 @@ func enabled(names ...string) map[string]struct{} {
 	return out
 }
 
+// allProviders is the deployment's keyed-provider set used to resolve dispatch
+// bindings on the unrestricted (nil EnabledProviders) path.
+var allProviders = enabled(
+	providers.ProviderAnthropic,
+	providers.ProviderOpenAI,
+	providers.ProviderGoogle,
+	providers.ProviderDeepInfra,
+	providers.ProviderFireworks,
+	providers.ProviderBedrock,
+)
+
 func TestRouteMapsRosterChoiceBackToCatalogModel(t *testing.T) {
 	// The policy picks by OpenRouter-style roster ID; the router must dispatch
 	// the corresponding catalog model via its own provider.
 	dec := &fakeDecider{result: rl.Result{Model: "anthropic/claude-opus-4-8", Score: 1.5, ScoreLabel: "DPO score", StateLabel: "implementing"}}
-	r := rl.New(dec, deployed("claude-opus-4-8", "deepseek/deepseek-v4-flash"))
+	r := rl.New(dec, deployed("claude-opus-4-8", "deepseek/deepseek-v4-flash"), allProviders)
 
 	decision, err := r.Route(context.Background(), router.Request{
 		PromptText:       "refactor the auth module",
@@ -69,7 +80,7 @@ func TestRouteMapsRosterChoiceBackToCatalogModel(t *testing.T) {
 
 func TestRouteOmitsModelsWithNoEnabledProvider(t *testing.T) {
 	dec := &fakeDecider{result: rl.Result{Model: "anthropic/claude-opus-4-8"}}
-	r := rl.New(dec, deployed("claude-opus-4-8", "deepseek/deepseek-v4-flash"))
+	r := rl.New(dec, deployed("claude-opus-4-8", "deepseek/deepseek-v4-flash"), allProviders)
 
 	_, err := r.Route(context.Background(), router.Request{
 		PromptText:       "hi",
@@ -84,7 +95,7 @@ func TestRouteOmitsModelsWithNoEnabledProvider(t *testing.T) {
 
 func TestRouteExcludesRequestedExclusions(t *testing.T) {
 	dec := &fakeDecider{result: rl.Result{Model: "deepseek/deepseek-v4-flash"}}
-	r := rl.New(dec, deployed("claude-opus-4-8", "deepseek/deepseek-v4-flash"))
+	r := rl.New(dec, deployed("claude-opus-4-8", "deepseek/deepseek-v4-flash"), allProviders)
 
 	_, err := r.Route(context.Background(), router.Request{
 		PromptText:       "hi",
@@ -99,7 +110,7 @@ func TestRouteExcludesRequestedExclusions(t *testing.T) {
 
 func TestRouteNoEligibleCandidatesIsUnavailable(t *testing.T) {
 	dec := &fakeDecider{result: rl.Result{Model: "anthropic/claude-opus-4-8"}}
-	r := rl.New(dec, deployed("claude-opus-4-8"))
+	r := rl.New(dec, deployed("claude-opus-4-8"), allProviders)
 
 	_, err := r.Route(context.Background(), router.Request{
 		PromptText:       "hi",
@@ -111,7 +122,7 @@ func TestRouteNoEligibleCandidatesIsUnavailable(t *testing.T) {
 
 func TestRouteDeciderErrorIsUnavailable(t *testing.T) {
 	dec := &fakeDecider{err: errors.New("sidecar down")}
-	r := rl.New(dec, deployed("claude-opus-4-8"))
+	r := rl.New(dec, deployed("claude-opus-4-8"), allProviders)
 
 	_, err := r.Route(context.Background(), router.Request{
 		PromptText:       "hi",
@@ -126,7 +137,7 @@ func TestRouteNilEnabledProvidersIsUnrestricted(t *testing.T) {
 	// policy must still be offered the deployed models via their primary
 	// provider, not an empty set.
 	dec := &fakeDecider{result: rl.Result{Model: "anthropic/claude-opus-4-8"}}
-	r := rl.New(dec, deployed("claude-opus-4-8", "deepseek/deepseek-v4-flash"))
+	r := rl.New(dec, deployed("claude-opus-4-8", "deepseek/deepseek-v4-flash"), allProviders)
 
 	decision, err := r.Route(context.Background(), router.Request{
 		PromptText:       "hi",
@@ -143,7 +154,7 @@ func TestRouteToolTurnDropsToolUseLowFromCandidatesAndIndex(t *testing.T) {
 	// from BOTH the offered candidates and the response-mapping index — a
 	// sidecar that names it anyway is rejected, not dispatched.
 	dec := &fakeDecider{result: rl.Result{Model: "qwen/qwen3-235b-a22b-2507"}}
-	r := rl.New(dec, deployed("claude-opus-4-8", "qwen/qwen3-235b-a22b-2507"))
+	r := rl.New(dec, deployed("claude-opus-4-8", "qwen/qwen3-235b-a22b-2507"), allProviders)
 
 	_, err := r.Route(context.Background(), router.Request{
 		PromptText:       "use a tool",
@@ -162,7 +173,7 @@ func TestRouteImageTurnDropsImageUnsupported(t *testing.T) {
 	// deepseek/deepseek-v4-flash is image-unsupported; opus is vision-capable.
 	// An image turn must drop the text-only model when a capable one survives.
 	dec := &fakeDecider{result: rl.Result{Model: "anthropic/claude-opus-4-8"}}
-	r := rl.New(dec, deployed("claude-opus-4-8", "deepseek/deepseek-v4-flash"))
+	r := rl.New(dec, deployed("claude-opus-4-8", "deepseek/deepseek-v4-flash"), allProviders)
 
 	_, err := r.Route(context.Background(), router.Request{
 		PromptText:       "what is in this image",
@@ -178,7 +189,7 @@ func TestRouteImageTurnDropsImageUnsupported(t *testing.T) {
 
 func TestRouteUnknownReturnedModelIsUnavailable(t *testing.T) {
 	dec := &fakeDecider{result: rl.Result{Model: "openai/gpt-5.5"}} // never offered
-	r := rl.New(dec, deployed("claude-opus-4-8"))
+	r := rl.New(dec, deployed("claude-opus-4-8"), allProviders)
 
 	_, err := r.Route(context.Background(), router.Request{
 		PromptText:       "hi",

--- a/internal/router/rl/rl_test.go
+++ b/internal/router/rl/rl_test.go
@@ -1,0 +1,134 @@
+package rl_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"workweave/router/internal/providers"
+	"workweave/router/internal/router"
+	"workweave/router/internal/router/rl"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeDecider records the query it received and returns a canned result/error.
+type fakeDecider struct {
+	got    rl.Query
+	result rl.Result
+	err    error
+}
+
+func (f *fakeDecider) Decide(_ context.Context, q rl.Query) (rl.Result, error) {
+	f.got = q
+	return f.result, f.err
+}
+
+func deployed(ids ...string) map[string]struct{} {
+	out := make(map[string]struct{}, len(ids))
+	for _, id := range ids {
+		out[id] = struct{}{}
+	}
+	return out
+}
+
+func enabled(names ...string) map[string]struct{} {
+	out := make(map[string]struct{}, len(names))
+	for _, n := range names {
+		out[n] = struct{}{}
+	}
+	return out
+}
+
+func TestRouteMapsRosterChoiceBackToCatalogModel(t *testing.T) {
+	// The policy picks by OpenRouter-style roster ID; the router must dispatch
+	// the corresponding catalog model via its own provider.
+	dec := &fakeDecider{result: rl.Result{Model: "anthropic/claude-opus-4-8", Score: 1.5, ScoreLabel: "DPO score", StateLabel: "implementing"}}
+	r := rl.New(dec, deployed("claude-opus-4-8", "deepseek/deepseek-v4-flash"))
+
+	decision, err := r.Route(context.Background(), router.Request{
+		PromptText:       "refactor the auth module",
+		EnabledProviders: enabled(providers.ProviderAnthropic, providers.ProviderDeepInfra),
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "claude-opus-4-8", decision.Model)
+	assert.Equal(t, providers.ProviderAnthropic, decision.Provider)
+	assert.Contains(t, decision.Reason, "DPO score")
+	assert.Contains(t, decision.Reason, "implementing")
+
+	// The deepseek slash-form id passes through unchanged; the dotted/dashed
+	// first-party slug is what the policy was offered for opus.
+	rosterIDs := make(map[string]string, len(dec.got.Candidates))
+	for _, c := range dec.got.Candidates {
+		rosterIDs[c.RosterID] = c.Provider
+	}
+	assert.Equal(t, providers.ProviderAnthropic, rosterIDs["anthropic/claude-opus-4-8"])
+	assert.Equal(t, providers.ProviderDeepInfra, rosterIDs["deepseek/deepseek-v4-flash"])
+}
+
+func TestRouteOmitsModelsWithNoEnabledProvider(t *testing.T) {
+	dec := &fakeDecider{result: rl.Result{Model: "anthropic/claude-opus-4-8"}}
+	r := rl.New(dec, deployed("claude-opus-4-8", "deepseek/deepseek-v4-flash"))
+
+	_, err := r.Route(context.Background(), router.Request{
+		PromptText:       "hi",
+		EnabledProviders: enabled(providers.ProviderAnthropic),
+	})
+	require.NoError(t, err)
+	for _, c := range dec.got.Candidates {
+		assert.NotEqual(t, "deepseek/deepseek-v4-flash", c.RosterID,
+			"deepinfra not enabled, so the deepseek model must not be offered")
+	}
+}
+
+func TestRouteExcludesRequestedExclusions(t *testing.T) {
+	dec := &fakeDecider{result: rl.Result{Model: "deepseek/deepseek-v4-flash"}}
+	r := rl.New(dec, deployed("claude-opus-4-8", "deepseek/deepseek-v4-flash"))
+
+	_, err := r.Route(context.Background(), router.Request{
+		PromptText:       "hi",
+		EnabledProviders: enabled(providers.ProviderAnthropic, providers.ProviderDeepInfra),
+		ExcludedModels:   map[string]struct{}{"claude-opus-4-8": {}},
+	})
+	require.NoError(t, err)
+	for _, c := range dec.got.Candidates {
+		assert.NotEqual(t, "anthropic/claude-opus-4-8", c.RosterID)
+	}
+}
+
+func TestRouteNoEligibleCandidatesIsUnavailable(t *testing.T) {
+	dec := &fakeDecider{result: rl.Result{Model: "anthropic/claude-opus-4-8"}}
+	r := rl.New(dec, deployed("claude-opus-4-8"))
+
+	_, err := r.Route(context.Background(), router.Request{
+		PromptText:       "hi",
+		EnabledProviders: enabled(providers.ProviderOpenAI), // no binding for opus
+	})
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, rl.ErrPolicyUnavailable))
+}
+
+func TestRouteDeciderErrorIsUnavailable(t *testing.T) {
+	dec := &fakeDecider{err: errors.New("sidecar down")}
+	r := rl.New(dec, deployed("claude-opus-4-8"))
+
+	_, err := r.Route(context.Background(), router.Request{
+		PromptText:       "hi",
+		EnabledProviders: enabled(providers.ProviderAnthropic),
+	})
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, rl.ErrPolicyUnavailable))
+}
+
+func TestRouteUnknownReturnedModelIsUnavailable(t *testing.T) {
+	dec := &fakeDecider{result: rl.Result{Model: "openai/gpt-5.5"}} // never offered
+	r := rl.New(dec, deployed("claude-opus-4-8"))
+
+	_, err := r.Route(context.Background(), router.Request{
+		PromptText:       "hi",
+		EnabledProviders: enabled(providers.ProviderAnthropic),
+	})
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, rl.ErrPolicyUnavailable))
+}

--- a/internal/router/strategy.go
+++ b/internal/router/strategy.go
@@ -1,0 +1,37 @@
+package router
+
+import "context"
+
+// Strategy names a routing strategy a request can opt into via the
+// x-weave-router-strategy header. The zero value ("") means the deployment
+// default (cluster).
+type Strategy string
+
+const (
+	// StrategyCluster is the default cluster-scorer strategy (AvengersPro).
+	StrategyCluster Strategy = "cluster"
+	// StrategyRL routes via the trained RL/DPO policy served by the
+	// out-of-process policy sidecar. Opt-in only; never the silent default.
+	StrategyRL Strategy = "rl"
+)
+
+type strategyContextKey struct{}
+
+// WithStrategy stashes a routing-strategy override on ctx. An empty strategy
+// leaves ctx unchanged so StrategyFromContext falls back to the default.
+func WithStrategy(ctx context.Context, s Strategy) context.Context {
+	if s == "" {
+		return ctx
+	}
+	return context.WithValue(ctx, strategyContextKey{}, s)
+}
+
+// StrategyFromContext returns the per-request strategy override, or
+// StrategyCluster when none was set.
+func StrategyFromContext(ctx context.Context) Strategy {
+	s, ok := ctx.Value(strategyContextKey{}).(Strategy)
+	if !ok || s == "" {
+		return StrategyCluster
+	}
+	return s
+}

--- a/internal/server/middleware/router_strategy_override.go
+++ b/internal/server/middleware/router_strategy_override.go
@@ -1,0 +1,54 @@
+package middleware
+
+import (
+	"strings"
+
+	"workweave/router/internal/observability"
+	"workweave/router/internal/router"
+
+	"github.com/gin-gonic/gin"
+)
+
+// RouterStrategyOverrideHeader selects the routing strategy for a request.
+// Accepted values are "cluster" (the default scorer) and "rl" (the trained
+// RL/DPO policy router). Absent or unrecognized values fall through to the
+// deployment default.
+const RouterStrategyOverrideHeader = "x-weave-router-strategy"
+
+// WithRouterStrategyOverride stashes the requested routing strategy on the
+// request context when the header is set to a recognized value. Like the
+// cluster-version override it gates on a resolved installation so anonymous
+// traffic can't flip strategies, and it never silently picks a model — the rl
+// strategy fails closed (HTTP 503) when no policy sidecar is wired.
+func WithRouterStrategyOverride() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		raw := strings.ToLower(strings.TrimSpace(c.GetHeader(RouterStrategyOverrideHeader)))
+		if raw == "" {
+			c.Next()
+			return
+		}
+		installation := InstallationFrom(c)
+		if installation == nil {
+			c.Next()
+			return
+		}
+		strategy := router.Strategy(raw)
+		if strategy != router.StrategyCluster && strategy != router.StrategyRL {
+			observability.FromGin(c).Warn(
+				"Router-strategy override ignored: unrecognized value",
+				"installation_id", installation.ID,
+				"requested_strategy", raw,
+			)
+			c.Next()
+			return
+		}
+		ctx := router.WithStrategy(c.Request.Context(), strategy)
+		c.Request = c.Request.WithContext(ctx)
+		observability.FromGin(c).Info(
+			"Router-strategy override applied",
+			"installation_id", installation.ID,
+			"requested_strategy", raw,
+		)
+		c.Next()
+	}
+}

--- a/internal/server/middleware/router_strategy_override_test.go
+++ b/internal/server/middleware/router_strategy_override_test.go
@@ -1,0 +1,67 @@
+package middleware_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"workweave/router/internal/auth"
+	"workweave/router/internal/router"
+	"workweave/router/internal/server/middleware"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+)
+
+// runStrategyOverride reports the strategy observed on the request context after WithRouterStrategyOverride runs.
+func runStrategyOverride(t *testing.T, installation *auth.Installation, header string) router.Strategy {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	engine := gin.New()
+	engine.Use(func(c *gin.Context) {
+		if installation != nil {
+			c.Set("router_installation", installation)
+		}
+		c.Next()
+	})
+	engine.Use(middleware.WithRouterStrategyOverride())
+
+	var observed router.Strategy
+	engine.GET("/probe", func(c *gin.Context) {
+		observed = router.StrategyFromContext(c.Request.Context())
+		c.Status(http.StatusOK)
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/probe", nil)
+	if header != "" {
+		req.Header.Set(middleware.RouterStrategyOverrideHeader, header)
+	}
+	rr := httptest.NewRecorder()
+	engine.ServeHTTP(rr, req)
+	return observed
+}
+
+func TestRouterStrategyOverride_AppliesRL(t *testing.T) {
+	got := runStrategyOverride(t, &auth.Installation{ID: "inst-eval"}, "rl")
+	assert.Equal(t, router.StrategyRL, got, "rl header must select the RL strategy")
+}
+
+func TestRouterStrategyOverride_CaseInsensitiveAndTrimmed(t *testing.T) {
+	got := runStrategyOverride(t, &auth.Installation{ID: "inst-eval"}, "  RL  ")
+	assert.Equal(t, router.StrategyRL, got, "value must be lowercased and trimmed before matching")
+}
+
+func TestRouterStrategyOverride_NoHeaderDefaultsToCluster(t *testing.T) {
+	got := runStrategyOverride(t, &auth.Installation{ID: "inst-eval"}, "")
+	assert.Equal(t, router.StrategyCluster, got, "absent header must leave the default cluster strategy")
+}
+
+func TestRouterStrategyOverride_UnknownValueIgnored(t *testing.T) {
+	got := runStrategyOverride(t, &auth.Installation{ID: "inst-eval"}, "bogus")
+	assert.Equal(t, router.StrategyCluster, got, "unrecognized strategy must fall through to the default")
+}
+
+func TestRouterStrategyOverride_NoOpsWhenInstallationMissing(t *testing.T) {
+	got := runStrategyOverride(t, nil, "rl")
+	assert.Equal(t, router.StrategyCluster, got, "missing installation (WithAuth bypassed) must not flip strategy")
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -141,6 +141,7 @@ func Register(engine *gin.Engine, authSvc *auth.Service, proxySvc *proxy.Service
 	messagesMiddleware = append(messagesMiddleware,
 		middleware.WithEmbedOnlyUserMessageOverride(),
 		middleware.WithClusterVersionOverride(),
+		middleware.WithRouterStrategyOverride(),
 		middleware.WithRoutingKnobsOverride(),
 	)
 	messagesGroup := engine.Group("", messagesMiddleware...)
@@ -157,6 +158,7 @@ func Register(engine *gin.Engine, authSvc *auth.Service, proxySvc *proxy.Service
 	chatCompletionMiddleware = append(chatCompletionMiddleware,
 		middleware.WithEmbedOnlyUserMessageOverride(),
 		middleware.WithClusterVersionOverride(),
+		middleware.WithRouterStrategyOverride(),
 		middleware.WithRoutingKnobsOverride(),
 	)
 	chatCompletionGroup := engine.Group("", chatCompletionMiddleware...)
@@ -190,6 +192,7 @@ func Register(engine *gin.Engine, authSvc *auth.Service, proxySvc *proxy.Service
 	routeMiddleware = append(routeMiddleware,
 		middleware.WithEmbedOnlyUserMessageOverride(),
 		middleware.WithClusterVersionOverride(),
+		middleware.WithRouterStrategyOverride(),
 		middleware.WithRoutingKnobsOverride(),
 	)
 	routeGroup := engine.Group("", routeMiddleware...)


### PR DESCRIPTION
## What

Adds a second routing **strategy**, selectable per-request with the header `x-weave-router-strategy: rl` (default stays `cluster`). It mirrors the existing `x-weave-cluster-version` override pattern — an explicit, installation-gated, opt-in switch for trying out a different router, **not** a silent A/B fallback.

The `rl` strategy delegates model selection to the trained RL/DPO policy served by the out-of-process **router-rl-sidecar** service (`ml_dev/rl_router/router_policy_server.py`). Crucially, the sidecar only answers *"which eligible model should we route to?"* — this router builds the candidate set from its **own catalog** and dispatches the chosen model through **Weave's own providers** (Anthropic/OpenAI/Google/Fireworks/DeepInfra/Bedrock), so **OpenRouter is not involved in dispatch**.

## How

- **`internal/router/rl`** — new `router.Router` implementation:
  - Builds eligible candidates from the catalog (deployed ∩ request's enabled providers, minus exclusions, minus `ToolUseLow` on tool turns) — same eligibility shape as the cluster scorer.
  - Maps catalog model IDs → the policy's OpenRouter-slug roster (`mapping.go`, mirroring `ml_dev/agent_environment/roster.py`), asks the sidecar to pick one, and maps the choice back to a catalog model + provider binding.
  - `HTTPDecider` posts `POST /route` matching the policy server's wire contract (`prompt_text`, `turn_index`, `candidate_models`, `candidate_providers`).
- **Fails closed.** Every failure path (sidecar unreachable/errored, no eligible candidate, unrecognized selection) returns `ErrPolicyUnavailable` → HTTP 503, mirroring `cluster.ErrClusterUnavailable`. No fallback to a default model or to the cluster scorer — consistent with the retired-heuristic policy.
- **`proxy.Service.routeFor`** selects cluster vs rl by `router.StrategyFromContext`. `WithRLRouter` wires the optional policy router; unset `ROUTER_RL_SIDECAR_URL` leaves the `rl` header to 503 rather than silently serving cluster.
- **`middleware.WithRouterStrategyOverride`** parses the header (installation-gated, lowercased/trimmed); the four API surfaces map the sentinel to 503.

## Config

- `ROUTER_RL_SIDECAR_URL` — base URL of the policy sidecar. Unset = RL disabled (header 503s).
- `ROUTER_RL_SIDECAR_TIMEOUT_MS` — per-decision timeout (default 2000ms).

## Tests

- `internal/router/rl`: roster↔catalog mapping, provider/exclusion/tool filtering, and all fail-closed paths (fake `Decider`); HTTP client contract + error surfacing against an `httptest` server.
- `internal/server/middleware`: header parsing (apply/case-insensitive/default/unknown/installation-gated).

Note: the embedding the policy needs is computed **inside the sidecar** against a Weave Google/Vertex key — that's handled in the WorkWeave-side sidecar service + terraform PR that bumps this gitlink.

🤖 Generated with [Claude Code](https://claude.com/claude-code)