### PR TITLE
Fix/responses assembleoutput noncontiguous tool index

### DIFF
--- a/internal/translate/responses.go
+++ b/internal/translate/responses.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 	"sync/atomic"
@@ -934,7 +935,7 @@ func (t *ResponsesWriter) emitFailed() error {
 }
 
 func (t *ResponsesWriter) assembleOutput() []any {
-	out := make([]any, 0, len(t.toolItems))
+	out := make([]any, 0, 1+len(t.toolItems))
 	if t.textItem != nil {
 		out = append(out, map[string]any{
 			"id":     t.textItem.itemID,
@@ -948,12 +949,16 @@ func (t *ResponsesWriter) assembleOutput() []any {
 			}},
 		})
 	}
-	// Tool items in original index order.
-	for i := 0; i < len(t.toolItems); i++ {
-		item, ok := t.toolItems[i]
-		if !ok {
-			continue
-		}
+	// Tool items in upstream index order. Use sort-and-iterate rather than a
+	// len-bounded loop so non-contiguous upstream indices (e.g. {0, 2}) don't
+	// cause entries past the first gap to be silently dropped.
+	indices := make([]int, 0, len(t.toolItems))
+	for idx := range t.toolItems {
+		indices = append(indices, idx)
+	}
+	sort.Ints(indices)
+	for _, idx := range indices {
+		item := t.toolItems[idx]
 		out = append(out, map[string]any{
 			"id":        item.itemID,
 			"type":      "function_call",

--- a/internal/translate/responses_test.go
+++ b/internal/translate/responses_test.go
@@ -459,6 +459,60 @@ func TestResponsesWriter_StreamingToolCall(t *testing.T) {
 	}
 }
 
+func TestResponsesWriter_NonContiguousToolCallIndices(t *testing.T) {
+	// Upstream sends two tool calls with indices 0 and 2 (gap at 1).
+	// assembleOutput must include BOTH in response.completed output.
+	// This test FAILS before the fix because the len-bounded loop in
+	// assembleOutput terminates at i=1 without ever reaching key 2.
+	rec := httptest.NewRecorder()
+	w := translate.NewResponsesWriter(rec, "gpt-5")
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.WriteHeader(200)
+
+	chunks := []string{
+		// Tool call at index=0 (search)
+		`data: {"choices":[{"index":0,"delta":{"role":"assistant","content":null,"tool_calls":[{"index":0,"id":"call_a","function":{"name":"search","arguments":""}}]},"finish_reason":null}]}` + "\n\n",
+		`data: {"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{\"q\":\"x\"}"}}]},"finish_reason":null}]}` + "\n\n",
+		// Tool call at index=2 (gap at 1 — simulates non-contiguous upstream)
+		`data: {"choices":[{"index":0,"delta":{"tool_calls":[{"index":2,"id":"call_b","function":{"name":"lookup","arguments":""}}]},"finish_reason":null}]}` + "\n\n",
+		`data: {"choices":[{"index":0,"delta":{"tool_calls":[{"index":2,"function":{"arguments":"{\"id\":1}"}}]},"finish_reason":null}]}` + "\n\n",
+		`data: {"choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}],"usage":{"prompt_tokens":10,"completion_tokens":5,"total_tokens":15}}` + "\n\n",
+		"data: [DONE]\n\n",
+	}
+	for _, c := range chunks {
+		_, err := w.Write([]byte(c))
+		require.NoError(t, err)
+	}
+	require.NoError(t, w.Finalize())
+
+	events := parseSSEEvents(t, rec.Body.Bytes())
+
+	// Find the response.completed event.
+	var completed map[string]any
+	for _, e := range events {
+		if e["type"] == "response.completed" {
+			completed = e
+			break
+		}
+	}
+	require.NotNil(t, completed, "response.completed event must be present")
+
+	response := completed["response"].(map[string]any)
+	output := response["output"].([]any)
+
+	// Both tool calls must appear in output — not just the first one.
+	require.Len(t, output, 2, "both tool calls must appear in output; got %d", len(output))
+
+	// Verify each tool call by name (order: index 0 then index 2).
+	first := output[0].(map[string]any)
+	assert.Equal(t, "search", first["name"], "first tool call must be 'search'")
+	assert.Equal(t, `{"q":"x"}`, first["arguments"])
+
+	second := output[1].(map[string]any)
+	assert.Equal(t, "lookup", second["name"], "second tool call must be 'lookup'")
+	assert.Equal(t, `{"id":1}`, second["arguments"])
+}
+
 func parseSSEEvents(t *testing.T, raw []byte) []map[string]any {
 	t.Helper()
 	var events []map[string]any


### PR DESCRIPTION
## What

`ResponsesWriter.assembleOutput()` (`internal/translate/responses.go`) iterated `toolItems` — a `map[int]*responsesToolItem` keyed by the upstream's raw `tool_calls[].index` — with a len-bounded `for i := 0; i < len(t.toolItems)` loop. With upstream indices `{0, 2}` (gap at 1), `len = 2` so the loop visited `i=0` (hit), `i=1` (miss → `continue`), and terminated — the entry at key `2` was never reached and that tool call was silently dropped from `response.completed` output.

The fix replaces the loop with collect-keys → `sort.Ints` → range so every map entry is visited regardless of index gaps. Also corrects the capacity hint from `len(t.toolItems)` to `1+len(t.toolItems)` to account for the optional text item.

## Why

`appendToolCall` stores entries at the raw upstream index with no remapping:

```go
idx := int(tc.Get("index").Int())
t.toolItems[idx] = item
```

The `SSETranslator` (Anthropic upstream) re-indexes sequentially via its own `t.toolIdx` counter — that path is unaffected. OpenAI-compat upstreams (OpenAI, OpenRouter, Fireworks, DeepInfra, Bedrock) forward raw SSE bytes, so their `tool_calls[].index` values key `toolItems` directly. The OpenAI spec does not enforce index contiguity; vLLM/SGLang-backed providers (GLM, Qwen,Kimi) are already documented in `stream.go:940` as emitting malformed tool-call deltas — a gap in index sequence is the same class of deviation.

The `!ok { continue }` guard existed defensively but was unreachable in all prior tests; `responses_test.go` exercised only `index=0` for all tool-call fixtures. `closeOpenItems()` uses `range t.toolItems` and is not affected.

## Tests

`TestResponsesWriter_NonContiguousToolCallIndices` (`internal/translate/responses_test.go`):

- Feeds a `ResponsesWriter` two streaming tool calls at upstream indices `0` and `2` (gap at `1`) via raw chat-completion chunks, then calls `Finalize()`

- Confirms **before the fix**: the test fails with `"both tool calls must appear in output; got 1"` — `call_b` (index=2) is
  silently dropped
  
- Confirms **after the fix**: `response.completed.response.output` contains both entries; asserts `name="search"` + `arguments={"q":"x"}` for the first and `name="lookup"` + `arguments={"id":1}` for the second, in index order

`make check` green.

Fixes #505.