### PR TITLE
feat(dashboard): add model distribution widget with provider pie char…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,6 +62,7 @@ docker-compose.override.yml
 node_modules/
 .next/
 tsconfig.tsbuildinfo
+out
 
 # Eval results (stored in GCS, not git)
 eval/results/

--- a/frontend/src/app/(app)/dashboard/page.tsx
+++ b/frontend/src/app/(app)/dashboard/page.tsx
@@ -4,6 +4,7 @@ import { Text } from "@/components/atoms/Text";
 import { ChartCard } from "@/components/ChartCard";
 import { CostBreakdownChart } from "@/components/charts/CostBreakdownChart";
 import { CumulativeSavingsChart } from "@/components/charts/CumulativeSavingsChart";
+import { ModelDistributionChart } from "@/components/charts/ModelDistributionChart";
 import { RouterCostSavingsChart } from "@/components/charts/RouterCostSavingsChart";
 import { SavingsRateChart } from "@/components/charts/SavingsRateChart";
 import {
@@ -15,7 +16,7 @@ import { Page } from "@/components/Page";
 import { PageHeader } from "@/components/PageHeader";
 import { ResponsiveGrid } from "@/components/ResponsiveGrid";
 import { Statistic } from "@/components/Statistic";
-import { api, type MetricsSummary, type TimeseriesBucket } from "@/lib/api";
+import { api, type MetricsDetailRow, type MetricsSummary, type TimeseriesBucket } from "@/lib/api";
 import { cn } from "@/lib/cn";
 import { LoadState } from "@/tools/LoadState";
 import { useEffect, useState } from "react";
@@ -38,11 +39,17 @@ export default function DashboardPage() {
 
   const [summary, setSummary] = useState<MetricsSummary | null>(null);
   const [buckets, setBuckets] = useState<TimeseriesBucket[]>([]);
+  const [detailRows, setDetailRows] = useState<MetricsDetailRow[]>([]);
+  const [detailRowsLoading, setDetailRowsLoading] = useState(true);
+  const [chartsLoading, setChartsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
     let cancelled = false;
     setError(null);
+    setSummary(null);
+    setBuckets([]);
+    setChartsLoading(true);
     Promise.all([
       api.metrics.summary(fromISO, toISO),
       api.metrics.timeseries(granularity, fromISO, toISO),
@@ -51,15 +58,36 @@ export default function DashboardPage() {
         if (cancelled) return;
         setSummary(s);
         setBuckets(ts.buckets ?? []);
+        setChartsLoading(false);
       })
       .catch((err: unknown) => {
         if (cancelled) return;
+        setChartsLoading(false);
         setError(err instanceof Error ? err.message : "Failed to load metrics.");
       });
     return () => {
       cancelled = true;
     };
   }, [fromISO, toISO, granularity]);
+
+  useEffect(() => {
+    let cancelled = false;
+    setDetailRows([]);
+    setDetailRowsLoading(true);
+    api.metrics.details(fromISO, toISO, 1000)
+      .then(d => {
+        if (cancelled) return;
+        setDetailRows(d.rows ?? []);
+        setDetailRowsLoading(false);
+      })
+      .catch(() => {
+        if (cancelled) return;
+        setDetailRowsLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [fromISO, toISO]);
 
   if (error) {
     return (
@@ -95,7 +123,12 @@ export default function DashboardPage() {
     summary == null || summary.request_count === 0
       ? 0
       : summary.total_tokens / summary.request_count;
-  const empty = buckets.length === 0;
+  const empty = !chartsLoading && buckets.length === 0;
+
+  const routedRows = detailRows.filter(r => r.decision_model !== "");
+  const substitutedRows = routedRows.filter(
+    r => r.decision_model !== r.requested_model,
+  );
 
   return (
     <Page
@@ -116,39 +149,56 @@ export default function DashboardPage() {
       <Page.Section>
         <DashboardPageFilters result={dashboardFilters} />
         <ResponsiveGrid>
-          <MetricCard
-            className={ResponsiveGrid.Small}
-            label="Cost saved"
-            value={summary == null ? "—" : formatUSD(Math.abs(summary.total_savings_usd))}
-            sub={
-              summary == null
-                ? undefined
-                : summary.total_savings_usd >= 0
-                  ? `${savingsRate.toFixed(1)}% of requested`
-                  : "Over requested cost"
-            }
-            accent={
-              summary == null
-                ? "default"
-                : summary.total_savings_usd >= 0
-                  ? "success"
-                  : "danger"
-            }
-          />
-          <MetricCard
-            className={ResponsiveGrid.Small}
-            label="Requests"
-            value={summary == null ? "—" : formatNumber(summary.request_count)}
-            sub={
-              summary == null ? undefined : `actual ${formatUSD(summary.total_actual_cost_usd)}`
-            }
-          />
-          <MetricCard
-            className={ResponsiveGrid.Small}
-            label="Tokens"
-            value={summary == null ? "—" : formatNumber(summary.total_tokens)}
-            sub={summary == null ? undefined : `${formatNumber(avgTokensPerReq)} avg / req`}
-          />
+          <div className={cn(ResponsiveGrid.Full, "grid grid-cols-2 gap-4 @xl:grid-cols-4")}>
+            <MetricCard
+              label="Cost saved"
+              value={summary == null ? "—" : formatUSD(Math.abs(summary.total_savings_usd))}
+              sub={
+                summary == null
+                  ? undefined
+                  : summary.total_savings_usd >= 0
+                    ? `${savingsRate.toFixed(1)}% of requested`
+                    : "Over requested cost"
+              }
+              accent={
+                summary == null
+                  ? "default"
+                  : summary.total_savings_usd >= 0
+                    ? "success"
+                    : "danger"
+              }
+            />
+            <MetricCard
+              label="Requests"
+              value={summary == null ? "—" : formatNumber(summary.request_count)}
+              sub={
+                summary == null ? undefined : `actual ${formatUSD(summary.total_actual_cost_usd)}`
+              }
+            />
+            <MetricCard
+              label="Tokens"
+              value={summary == null ? "—" : formatNumber(summary.total_tokens)}
+              sub={summary == null ? undefined : `${formatNumber(avgTokensPerReq)} avg / req`}
+            />
+            <MetricCard
+              label="Substitution rate"
+              value={
+                routedRows.length === 0
+                  ? "—"
+                  : detailRows.length === 1000
+                    ? `~${Math.round((substitutedRows.length / routedRows.length) * 100)}%`
+                    : `${Math.round((substitutedRows.length / routedRows.length) * 100)}%`
+              }
+              sub={
+                summary == null || routedRows.length === 0
+                  ? undefined
+                  : detailRows.length === 1000
+                    ? `${new Set(routedRows.map(r => r.decision_model)).size} models (sampled)`
+                    : `${new Set(routedRows.map(r => r.decision_model)).size} models served`
+              }
+              accent={substitutedRows.length > 0 ? "info" : "default"}
+            />
+          </div>
 
           <ChartCard
             className={ResponsiveGrid.Full}
@@ -175,6 +225,25 @@ export default function DashboardPage() {
               <RouterCostSavingsChart buckets={buckets} granularity={granularity} />
             )}
           </ChartCard>
+
+          <div className={cn(ResponsiveGrid.Full, "rounded-xl border bg-card shadow-sm")}>
+            <div className="border-b px-4 py-3 md:px-6">
+              <p className="text-sm font-semibold leading-tight text-foreground">
+                Model distribution
+              </p>
+              <p className="mt-0.5 text-xs text-muted-foreground">
+                Models and providers for requests served in the selected period.
+              </p>
+              {detailRows.length === 1000 && (
+                <p className="mt-0.5 text-xs text-muted-foreground/60">
+                  Showing first 1,000 requests — distribution may be a sample.
+                </p>
+              )}
+            </div>
+            <div className="p-4 md:p-6">
+              <ModelDistributionChart rows={detailRows} isLoading={detailRowsLoading} />
+            </div>
+          </div>
 
           <ChartCard
             className={ResponsiveGrid.Medium}

--- a/frontend/src/components/charts/ModelDistributionChart.tsx
+++ b/frontend/src/components/charts/ModelDistributionChart.tsx
@@ -1,0 +1,224 @@
+"use client";
+
+import { Text } from "@/components/atoms/Text";
+import { type MetricsDetailRow } from "@/lib/api";
+import { cn } from "@/lib/cn";
+import { Cell, Pie, PieChart, ResponsiveContainer, Tooltip } from "recharts";
+import { useMemo } from "react";
+
+interface Props {
+  rows: MetricsDetailRow[];
+  isLoading?: boolean;
+}
+
+// Explicit class names so Tailwind's scanner includes them in the bundle.
+const BAR_COLORS = [
+  "bg-primary",
+  "bg-primary/80",
+  "bg-primary/60",
+  "bg-primary/40",
+  "bg-primary/20",
+] as const;
+
+const PROVIDER_COLORS: Record<string, string> = {
+  anthropic:  "#CC785C",   // Anthropic brand terracotta
+  openai:     "#000000",   // OpenAI black
+  google:     "#4285F4",   // Google blue
+  openrouter: "#6366F1",   // OpenRouter indigo
+  fireworks:  "#FF6B35",   // Fireworks orange
+  deepinfra:  "#0EA5E9",   // DeepInfra sky blue
+  bedrock:    "#FF9900",   // AWS orange
+};
+const DEFAULT_PROVIDER_COLOR = "#94A3B8";
+
+function providerColor(provider: string): string {
+  return PROVIDER_COLORS[provider] ?? DEFAULT_PROVIDER_COLOR;
+}
+
+function capitalize(s: string): string {
+  return s.length === 0 ? s : s[0]!.toUpperCase() + s.slice(1);
+}
+
+const RADIAN = Math.PI / 180;
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function renderCustomLabel({ cx, cy, midAngle, innerRadius, outerRadius, percent, name }: any) {
+  if (percent < 0.15) return null;
+  const radius = innerRadius + (outerRadius - innerRadius) * 0.5;
+  const x = cx + radius * Math.cos(-midAngle * RADIAN);
+  const y = cy + radius * Math.sin(-midAngle * RADIAN);
+  return (
+    <text
+      x={x}
+      y={y}
+      fill="white"
+      textAnchor="middle"
+      dominantBaseline="central"
+      fontSize={11}
+      fontWeight={600}
+    >
+      {capitalize(name)}
+    </text>
+  );
+}
+
+export function ModelDistributionChart({ rows, isLoading = false }: Props) {
+  const { modelStats, providerData } = useMemo(() => {
+    const modelMap = new Map<string, { count: number; cost: number }>();
+    const providerMap = new Map<string, number>();
+
+    for (const row of rows) {
+      if (row.decision_model !== "") {
+        const prev = modelMap.get(row.decision_model) ?? { count: 0, cost: 0 };
+        modelMap.set(row.decision_model, {
+          count: prev.count + 1,
+          cost: prev.cost + row.actual_cost_usd,
+        });
+      }
+
+      if (row.decision_provider !== "") {
+        providerMap.set(
+          row.decision_provider,
+          (providerMap.get(row.decision_provider) ?? 0) + 1,
+        );
+      }
+    }
+
+    const modelStats = Array.from(modelMap.entries())
+      .map(([model, { count, cost }]) => ({ model, count, cost }))
+      .sort((a, b) => b.count - a.count);
+
+    const providerData = Array.from(providerMap.entries())
+      .map(([name, value]) => ({ name, value }))
+      .sort((a, b) => b.value - a.value);
+
+    return { modelStats, providerData };
+  }, [rows]);
+
+  if (isLoading) {
+    return (
+      <div className="flex flex-col gap-3 p-2">
+        {[0, 1, 2, 3].map(i => (
+          <div key={i} className="flex items-center gap-3">
+            <div className="h-3 w-32 animate-pulse rounded bg-muted" />
+            <div
+              className="h-3 animate-pulse rounded bg-muted"
+              style={{ width: `${80 - i * 15}%` }}
+            />
+          </div>
+        ))}
+      </div>
+    );
+  }
+
+  if (rows.length === 0 || (modelStats.length === 0 && providerData.length === 0)) {
+    return (
+      <div className="flex h-48 items-center justify-center text-sm text-muted-foreground">
+        No data for this period
+      </div>
+    );
+  }
+
+  const maxModelCount = modelStats[0]?.count ?? 1;
+  const totalRouted = modelStats.reduce((s, m) => s + m.count, 0);
+  const totalForPie = providerData.reduce((s, e) => s + e.value, 0);
+
+  return (
+    <div className="flex flex-col gap-4 p-2">
+      <div className="grid grid-cols-1 gap-6 @xl:grid-cols-2">
+        {/* LEFT: model bars */}
+        <div className="flex min-h-[280px] flex-col gap-3">
+          <Text className="text-2xs font-medium uppercase tracking-wider text-muted-foreground">
+            Models served
+          </Text>
+          <div className="flex flex-col gap-2">
+            {modelStats.map(({ model, count }, i) => {
+              const barPct = (count / maxModelCount) * 100;
+              const sharePct = (totalRouted > 0 ? (count / totalRouted) * 100 : 0).toFixed(1);
+              const colorClass = BAR_COLORS[Math.min(i, BAR_COLORS.length - 1)];
+              return (
+                <div key={model} className="flex w-full items-center gap-2">
+                  <span
+                    className="w-44 shrink-0 truncate font-mono text-2xs text-foreground"
+                    title={model}
+                  >
+                    {model}
+                  </span>
+                  <div className="relative h-4 min-w-0 flex-1 overflow-hidden rounded-sm bg-muted/30">
+                    <div
+                      className={cn("h-full rounded-sm transition-all", colorClass)}
+                      style={{ width: `${barPct}%` }}
+                    />
+                  </div>
+                  <span className="w-24 shrink-0 text-right text-2xs tabular-nums text-muted-foreground">
+                    {count} ({sharePct}%)
+                  </span>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+
+        {/* RIGHT: provider pie */}
+        <div className="flex flex-col gap-3">
+          <Text className="text-2xs font-medium uppercase tracking-wider text-muted-foreground">
+            Provider split
+          </Text>
+          {providerData.length === 0 ? (
+            <div className="flex h-48 items-center justify-center text-sm text-muted-foreground">
+              No provider data
+            </div>
+          ) : (
+            <>
+              <ResponsiveContainer width="100%" height={220}>
+                <PieChart>
+                  <Pie
+                    data={providerData}
+                    dataKey="value"
+                    cx="50%"
+                    cy="50%"
+                    outerRadius={90}
+                    paddingAngle={3}
+                    label={renderCustomLabel}
+                    labelLine={false}
+                  >
+                    {providerData.map((entry, index) => (
+                      <Cell
+                        key={`cell-${index}`}
+                        fill={providerColor(entry.name)}
+                        stroke="white"
+                        strokeWidth={2}
+                      />
+                    ))}
+                  </Pie>
+                  <Tooltip
+                    formatter={(value) => {
+                      const n = Number(value);
+                      const pct = totalForPie > 0 ? ((n / totalForPie) * 100).toFixed(1) : "0.0";
+                      return [`${n} requests (${pct}%)`, ""];
+                    }}
+                  />
+                </PieChart>
+              </ResponsiveContainer>
+
+              <div className="mt-3 flex flex-wrap justify-center gap-x-4 gap-y-1.5">
+                {providerData.map(entry => (
+                  <div key={entry.name} className="flex items-center gap-1.5">
+                    <div
+                      className="h-2.5 w-2.5 shrink-0 rounded-full"
+                      style={{ backgroundColor: providerColor(entry.name) }}
+                    />
+                    <span className="text-2xs capitalize text-muted-foreground">{entry.name}</span>
+                    <span className="text-2xs font-medium tabular-nums text-foreground">
+                      {((entry.value / totalForPie) * 100).toFixed(0)}%
+                    </span>
+                  </div>
+                ))}
+              </div>
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## What

Adds two new elements to the dashboard giving operators visibility into what the router actually decided — previously the dashboard only showed cost savings with no insight into which models were served or why.

`frontend/src/components/charts/ModelDistributionChart.tsx` (new): Two-column card with horizontal model bars on the left and a provider pie chart on the right. Derives entirely from the existing
`/metrics/details` endpoint — no new backend endpoints or DB changes.

`frontend/src/app/(app)/dashboard/page.tsx` (updated): two independent `useEffect` hooks, a Substitution rate stat card, and all four stat cards wrapped in a sub-grid so they share one row at all breakpoints.

## Why

The existing dashboard answers "how much did we save?" but gives no visibility into what the router actually decided. With 26 requests and $0.00 saved, an operator has no way to know whether the router served 6 distinct models, substituted 96% of requests, or routed 46% of traffic to Google. This widget makes those decisions concrete.

The widget uses only already-fetched data — `/metrics/details` is already called by the DrillDownModal on chart click. Fetching it upfront (limit=1000) adds one parallel request with no backend changes.

## Changes

**ModelDistributionChart:**
- Left column: horizontal bars per `decision_model`, sorted by request count descending, opacity-stepped `bg-primary` fill, percentages computed over routed rows only (blank `decision_model` excluded)
- Right column: recharts `PieChart` with `ResponsiveContainer`, brand colors per provider (Google `#4285F4`, Anthropic `#CC785C`, OpenRouter `#6366F1`, DeepInfra `#0EA5E9`, Fireworks `#FF6B35`), inline white labels on slices ≥ 15%, dot legend below
- Empty states: "No data for this period" and "No provider data" when all rows have blank decision fields
- Loading skeleton (`animate-pulse`) shown via `isLoading` prop
- All blank `decision_model` / `decision_provider` rows excluded from every map, percentage, and denominator

**Dashboard page:**
- Two independent `useEffect` hooks: `[fromISO, toISO, granularity]` for summary + timeseries; `[fromISO, toISO]` for details — granularity changes skip the details refetch entirely
- Both loading flags (`chartsLoading`, `detailRowsLoading`) initialize to `true` — no first-render empty state flash
- Details failure is non-fatal: widget shows empty, cost charts unaffected
- Substitution rate stat card: rate over routed rows only, shows `~N%` and `(sampled)` when `detailRows.length === 1000`
- Widget header footnote warns when distribution may be a sample
- All `cancelled` guards prevent `setState` after unmount across both effects
- `sharePct` denominator is `totalRouted` (blank-free), not `rows.length`
- `totalForPie` derived from `providerData.reduce()` for consistent pie labels

## Tests

`npm run build` — zero TypeScript errors, zero build errors.

Verified live against the Docker stack with real traffic data:

6 models served, 96% substitution rate, 4 providers.