### PR TITLE
fix: advertise /rf feedback verdicts in space form

### DIFF
--- a/internal/proxy/feedback.go
+++ b/internal/proxy/feedback.go
@@ -194,7 +194,7 @@ var terminalFeedbackClients = map[string]struct{}{
 // render identically across the TUI, print mode, and IDEs.
 // translate.feedbackFooterPattern matches this on ingress to strip it back out
 // of upstream context — keep the two in sync.
-const feedbackFooterText = "\n\n_Weave Router feedback:_ `/rf+` good experience · `/rf-` poor experience · note optional, e.g. `/rf- too slow`"
+const feedbackFooterText = "\n\n_Weave Router feedback:_ `/rf +` good experience · `/rf -` poor experience · note optional, e.g. `/rf - too slow`"
 
 // feedbackFooter returns the in-terminal rating hint appended to a streamed
 // response, or "" to stay fully transparent. Gated to terminal coding agents

--- a/internal/translate/anthropic_footer_test.go
+++ b/internal/translate/anthropic_footer_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/tidwall/gjson"
 )
 
-const testFooter = "\n\n_Weave Router feedback:_ `/rf+` good experience · `/rf-` poor experience · note optional, e.g. `/rf- too slow`"
+const testFooter = "\n\n_Weave Router feedback:_ `/rf +` good experience · `/rf -` poor experience · note optional, e.g. `/rf - too slow`"
 
 // anthropicAnswerStream is a minimal text answer (index 0) that ends naturally.
 func anthropicAnswerStream(stopReason string) string {

--- a/internal/translate/router_feedback_test.go
+++ b/internal/translate/router_feedback_test.go
@@ -60,6 +60,25 @@ func TestParseRouterFeedbackCommand(t *testing.T) {
 			wantFound:    true,
 		},
 		{
+			name:       "rf space plus promotes to thumbs up",
+			input:      "/rf +",
+			wantRating: "up",
+			wantFound:  true,
+		},
+		{
+			name:       "rf space minus promotes to thumbs down",
+			input:      "/rf -",
+			wantRating: "down",
+			wantFound:  true,
+		},
+		{
+			name:         "rf space minus carries a trailing note",
+			input:        "/rf - too slow",
+			wantRating:   "down",
+			wantFeedback: "too slow",
+			wantFound:    true,
+		},
+		{
 			name:         "note without a verdict keeps empty rating",
 			input:        "/rf the diff was incomplete",
 			wantFeedback: "the diff was incomplete",

--- a/internal/translate/strip_footer_test.go
+++ b/internal/translate/strip_footer_test.go
@@ -17,7 +17,7 @@ const footerSentinel = "_Weave Router feedback:_"
 // blank-line separator, the italic sentinel, the /rf± typed-command hints, and
 // the trailing optional-note example.
 func sampleFooter() string {
-	return "\n\n_Weave Router feedback:_ `/rf+` good experience · `/rf-` poor experience · note optional, e.g. `/rf- too slow`"
+	return "\n\n_Weave Router feedback:_ `/rf +` good experience · `/rf -` poor experience · note optional, e.g. `/rf - too slow`"
 }
 
 func TestStripFeedbackFooter_AppendedToAssistantBlock(t *testing.T) {


### PR DESCRIPTION
The feedback footer advertised `/rf+` and `/rf-` (no space), but the only
installed client slash command is `/rf <verdict>`. Clients that intercept
slash commands locally (Claude Code) reject the no-space forms as unknown
commands; only clients that forward raw slash text (Cursor) worked via the
router's literal parser. Reword the footer to `/rf +` / `/rf -` so it
matches the installed `/rf` command and works across clients. Add parser
regression tests covering the space form.