### PR TITLE
proxy: per-installation subscription usage-bypass gate

### DIFF
--- a/cmd/router/main.go
+++ b/cmd/router/main.go
@@ -674,6 +674,41 @@ func main() {
 	// AND have observed headroom (cold start / non-sub traffic = unchanged), so
 	// the blast radius is narrow. Set ROUTER_SUBSCRIPTION_AWARE_ROUTING=false to
 	// disable without a code change.
+	// The subscription usage observer is always wired: it feeds BOTH the
+	// subscription-aware cost discount (below, env-gated) AND the
+	// per-installation usage-bypass gate (DB-gated, so the env can't know
+	// whether any tenant enabled it). Recording is cheap and side-effect-free,
+	// so installing it unconditionally is what lets the bypass work regardless
+	// of the cost-discount flag.
+	subscriptionTTL := 10 * time.Minute
+	if v, err := time.ParseDuration(config.GetOr("ROUTER_SUBSCRIPTION_OBSERVATION_TTL", "10m")); err == nil {
+		subscriptionTTL = v
+	}
+	observerSalt := make([]byte, 16)
+	if _, err := rand.Read(observerSalt); err != nil {
+		logger.Error("Failed to seed subscription usage observer salt", "err", err)
+		panic(err)
+	}
+	usageObserver := usage.NewObserver(observerSalt, subscriptionTTL, time.Now)
+	// Bound memory: evict expired observations periodically (the usage package
+	// spawns no goroutines of its own).
+	go func() {
+		t := time.NewTicker(time.Minute)
+		defer t.Stop()
+		for range t.C {
+			usageObserver.Sweep()
+		}
+	}()
+	proxySvc = proxySvc.WithUsageObserver(usageObserver)
+
+	// ROUTER_SUBSCRIPTION_AWARE_ROUTING discounts a covered model's cost term by
+	// the caller's observed subscription rate-limit headroom (see
+	// internal/proxy/usage): ~epsilon when the window has slack, →1 (full price)
+	// as it binds. Defaults ON: the discount only affects turns that present a
+	// subscription AND have observed headroom (cold start / non-sub traffic =
+	// unchanged), so the blast radius is narrow. Set to false to disable the
+	// discount without a code change — the observer (and the usage-bypass gate)
+	// stay wired.
 	if config.GetOr("ROUTER_SUBSCRIPTION_AWARE_ROUTING", "true") == "true" {
 		epsilon := 0.05
 		if v, err := strconv.ParseFloat(config.GetOr("ROUTER_SUBSCRIPTION_COST_EPSILON", "0.05"), 64); err == nil {
@@ -683,27 +718,10 @@ func main() {
 		if v, err := strconv.ParseFloat(config.GetOr("ROUTER_SUBSCRIPTION_COST_GAMMA", "2"), 64); err == nil {
 			gamma = v
 		}
-		ttl := 10 * time.Minute
-		if v, err := time.ParseDuration(config.GetOr("ROUTER_SUBSCRIPTION_OBSERVATION_TTL", "10m")); err == nil {
-			ttl = v
-		}
-		salt := make([]byte, 16)
-		if _, err := rand.Read(salt); err != nil {
-			logger.Error("Failed to seed subscription usage observer salt", "err", err)
-			panic(err)
-		}
-		observer := usage.NewObserver(salt, ttl, time.Now)
-		// Bound memory: evict expired observations periodically (the usage package
-		// spawns no goroutines of its own).
-		go func() {
-			t := time.NewTicker(time.Minute)
-			defer t.Stop()
-			for range t.C {
-				observer.Sweep()
-			}
-		}()
-		proxySvc = proxySvc.WithSubscriptionAwareRouting(observer, epsilon, gamma)
-		logger.Info("Subscription-aware routing configured", "epsilon", epsilon, "gamma", gamma, "observation_ttl", ttl)
+		proxySvc = proxySvc.WithSubscriptionAwareRouting(usageObserver, epsilon, gamma)
+		logger.Info("Subscription-aware routing configured", "epsilon", epsilon, "gamma", gamma, "observation_ttl", subscriptionTTL)
+	} else {
+		logger.Info("Usage observer wired; subscription-aware cost discount disabled", "observation_ttl", subscriptionTTL)
 	}
 
 	// APM (SigNoz) — adds standard HTTP server spans and Go runtime metrics

--- a/db/migrations/0026_installation-usage-bypass.down.sql
+++ b/db/migrations/0026_installation-usage-bypass.down.sql
@@ -1,0 +1,7 @@
+BEGIN;
+
+ALTER TABLE router.model_router_installations
+  DROP COLUMN usage_bypass_enabled,
+  DROP COLUMN usage_bypass_threshold;
+
+COMMIT;

--- a/db/migrations/0026_installation-usage-bypass.up.sql
+++ b/db/migrations/0026_installation-usage-bypass.up.sql
@@ -12,8 +12,12 @@ BEGIN;
 -- turns it on. threshold is a normalized fraction in [0, 1] (e.g. 0.80 = "kick
 -- the router in once 80% of my plan is used"); NULL is treated as the default
 -- threshold at request time so the toggle can be on before a value is chosen.
+-- The CHECK guards the gate's core invariant at the storage layer (Go-side
+-- validation lands with the dashboard mutation): a threshold outside [0, 1]
+-- would make `utilization < threshold` always true, pinning the gate open and
+-- suppressing this installation's billing indefinitely.
 ALTER TABLE router.model_router_installations
   ADD COLUMN usage_bypass_enabled BOOLEAN NOT NULL DEFAULT FALSE,
-  ADD COLUMN usage_bypass_threshold DOUBLE PRECISION;
+  ADD COLUMN usage_bypass_threshold DOUBLE PRECISION CHECK (usage_bypass_threshold BETWEEN 0 AND 1);
 
 COMMIT;

--- a/db/migrations/0026_installation-usage-bypass.up.sql
+++ b/db/migrations/0026_installation-usage-bypass.up.sql
@@ -1,0 +1,19 @@
+BEGIN;
+
+-- Per-installation subscription usage-bypass gate. When enabled, requests that
+-- present a Claude/Codex subscription credential whose observed rate-limit
+-- utilization is still below usage_bypass_threshold are passed straight through
+-- to the requested model -- no cluster routing, no model substitution, and no
+-- billing debit (the turn is served on the customer's own subscription quota).
+-- Once observed utilization crosses the threshold, the gate disengages and the
+-- normal routing path (scorer + subscription-aware cost discounting) takes over.
+--
+-- enabled defaults FALSE: strict opt-in, no behavior change until a customer
+-- turns it on. threshold is a normalized fraction in [0, 1] (e.g. 0.80 = "kick
+-- the router in once 80% of my plan is used"); NULL is treated as the default
+-- threshold at request time so the toggle can be on before a value is chosen.
+ALTER TABLE router.model_router_installations
+  ADD COLUMN usage_bypass_enabled BOOLEAN NOT NULL DEFAULT FALSE,
+  ADD COLUMN usage_bypass_threshold DOUBLE PRECISION;
+
+COMMIT;

--- a/db/queries/model_router_installations.sql
+++ b/db/queries/model_router_installations.sql
@@ -66,3 +66,16 @@ SET routing_quality_weight = sqlc.narg('routing_quality_weight'),
 WHERE id = @id::uuid
   AND external_id = @external_id::varchar
   AND deleted_at IS NULL;
+
+-- Sets the subscription usage-bypass gate, scoped to an external_id to prevent
+-- cross-tenant updates. enabled toggles the gate; threshold is the [0, 1]
+-- utilization at/above which the gate disengages and normal routing takes over.
+-- A NULL threshold means "use the deployment default" at request time.
+-- name: UpdateModelRouterInstallationUsageBypass :exec
+UPDATE router.model_router_installations
+SET usage_bypass_enabled = @usage_bypass_enabled::boolean,
+    usage_bypass_threshold = sqlc.narg('usage_bypass_threshold'),
+    updated_at = NOW()
+WHERE id = @id::uuid
+  AND external_id = @external_id::varchar
+  AND deleted_at IS NULL;

--- a/internal/auth/installation.go
+++ b/internal/auth/installation.go
@@ -28,6 +28,16 @@ type Installation struct {
 	// remainder. nil means no preference -- the scorer keeps its tuned
 	// per-cluster defaults.
 	RoutingQualityWeight *float64
+	// UsageBypassEnabled toggles the per-installation subscription usage-bypass
+	// gate. When true, requests presenting a subscription credential whose
+	// observed rate-limit utilization is below UsageBypassThreshold pass
+	// straight through to the requested model (no routing, no billing debit).
+	// Defaults false -- strict opt-in.
+	UsageBypassEnabled bool
+	// UsageBypassThreshold is the [0, 1] utilization at/above which the bypass
+	// gate disengages and normal routing takes over. nil means "use the
+	// deployment default" so the toggle can be on before a value is chosen.
+	UsageBypassThreshold *float64
 }
 
 type CreateInstallationParams struct {
@@ -51,4 +61,8 @@ type InstallationRepository interface {
 	// fraction in [0, 1]). Passing nil clears the preference so the scorer
 	// reverts to its tuned per-cluster defaults.
 	UpdateRoutingPreference(ctx context.Context, externalID, id string, qualityWeight *float64) error
+	// UpdateUsageBypass sets the subscription usage-bypass gate. enabled toggles
+	// the gate; threshold is the [0, 1] utilization at/above which it disengages
+	// (nil = use the deployment default).
+	UpdateUsageBypass(ctx context.Context, externalID, id string, enabled bool, threshold *float64) error
 }

--- a/internal/auth/service_test.go
+++ b/internal/auth/service_test.go
@@ -99,6 +99,8 @@ type fakeInstallationRepository struct {
 	excludedProvidersByID         map[string][]string
 	excludedProvidersExternalByID map[string]string
 	routingQualityByID            map[string]*float64
+	usageBypassEnabledByID        map[string]bool
+	usageBypassThresholdByID      map[string]*float64
 }
 
 func (fakeInstallationRepository) Create(ctx context.Context, params auth.CreateInstallationParams) (*auth.Installation, error) {
@@ -140,6 +142,17 @@ func (f *fakeInstallationRepository) UpdateRoutingPreference(ctx context.Context
 		f.routingQualityByID = map[string]*float64{}
 	}
 	f.routingQualityByID[id] = qualityWeight
+	return nil
+}
+func (f *fakeInstallationRepository) UpdateUsageBypass(ctx context.Context, externalID, id string, enabled bool, threshold *float64) error {
+	if f.usageBypassEnabledByID == nil {
+		f.usageBypassEnabledByID = map[string]bool{}
+	}
+	if f.usageBypassThresholdByID == nil {
+		f.usageBypassThresholdByID = map[string]*float64{}
+	}
+	f.usageBypassEnabledByID[id] = enabled
+	f.usageBypassThresholdByID[id] = threshold
 	return nil
 }
 

--- a/internal/postgres/converters.go
+++ b/internal/postgres/converters.go
@@ -30,6 +30,8 @@ func toAuthInstallation(row sqlc.RouterModelRouterInstallation) *auth.Installati
 		ExcludedModels:       excluded,
 		ExcludedProviders:    excludedProviders,
 		RoutingQualityWeight: row.RoutingQualityWeight,
+		UsageBypassEnabled:   row.UsageBypassEnabled,
+		UsageBypassThreshold: row.UsageBypassThreshold,
 	}
 }
 

--- a/internal/postgres/repository.go
+++ b/internal/postgres/repository.go
@@ -135,6 +135,20 @@ func (r *installationRepo) UpdateRoutingPreference(ctx context.Context, external
 	})
 }
 
+func (r *installationRepo) UpdateUsageBypass(ctx context.Context, externalID, id string, enabled bool, threshold *float64) error {
+	parsed, err := uuid.Parse(id)
+	if err != nil {
+		return err
+	}
+	q := sqlc.New(r.tx)
+	return q.UpdateModelRouterInstallationUsageBypass(ctx, sqlc.UpdateModelRouterInstallationUsageBypassParams{
+		ID:                   parsed,
+		ExternalID:           externalID,
+		UsageBypassEnabled:   enabled,
+		UsageBypassThreshold: threshold,
+	})
+}
+
 type apiKeyRepo struct {
 	tx sqlc.DBTX
 }

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -258,6 +258,36 @@ type InstallationExcludedProvidersContextKey struct{}
 // routingKnobsForRequest.
 type InstallationRoutingKnobsContextKey struct{}
 
+// InstallationUsageBypassContextKey is the context key for the authed
+// installation's subscription usage-bypass gate config. Carried as
+// UsageBypassConfig. Absent when the installation hasn't enabled the gate.
+type InstallationUsageBypassContextKey struct{}
+
+// UsageBypassConfig is the per-installation subscription usage-bypass setting,
+// stashed on ctx by the auth middleware. Threshold is nil when the toggle is on
+// but no value has been chosen yet; the request path falls back to
+// defaultUsageBypassThreshold in that case.
+type UsageBypassConfig struct {
+	Enabled   bool
+	Threshold *float64
+}
+
+// defaultUsageBypassThreshold is the utilization at/above which the bypass gate
+// disengages when an installation has enabled the gate without choosing an
+// explicit threshold. Mirrors the conservative default of the legacy
+// ROUTER_USAGE_BYPASS_THRESHOLD knob.
+const defaultUsageBypassThreshold = 0.95
+
+// usageBypassFromContext returns the per-installation bypass config stashed on
+// ctx by the auth middleware, and whether one is present and enabled.
+func usageBypassFromContext(ctx context.Context) (UsageBypassConfig, bool) {
+	cfg, ok := ctx.Value(InstallationUsageBypassContextKey{}).(UsageBypassConfig)
+	if !ok || !cfg.Enabled {
+		return UsageBypassConfig{}, false
+	}
+	return cfg, true
+}
+
 // installationExcludedModelsFromContext returns the per-installation exclusion
 // list stashed on ctx by the auth middleware, or nil when none is present.
 
@@ -1503,6 +1533,17 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 	// tool_result blocks from env, which would zero out tool_result_bytes on a
 	// genuine tool_result turn read at telemetry time.
 	inboundLastUser := env.LastUserMessage()
+
+	// Subscription usage-bypass gate: while the caller's own Claude subscription
+	// has headroom (observed utilization below the installation's threshold, or
+	// cold start), serve the requested model straight from Anthropic — no
+	// routing, no substitution, no billing. The turn is paid for by the
+	// customer's plan; once they approach their cap the gate disengages and the
+	// normal routing path conserves the remainder. Excluded models still force
+	// routing so a tenant policy block can't be served via the bypass.
+	if _, blocked := s.excludedModelsForRequest(ctx)[feats.Model]; !blocked && s.usageBypassEngaged(ctx, r.Header, feats.Model) {
+		return s.bypassToAnthropic(ctx, env, feats, requestStart, requestID, externalID, r, w)
+	}
 
 	routeStart := time.Now()
 	routeRes, routeErr := s.runTurnLoop(ctx, env, feats, apiKeyID, installationID, "", r.Header, router.Request{

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -173,10 +173,15 @@ type Service struct {
 	// feedback-link header emission on proxied responses.
 	feedbackBaseURL string
 	// usageObserver records per-credential subscription rate-limit headroom from
-	// upstream response headers; subsidyFactors reads it to discount covered
-	// models' cost term. Nil disables subscription-aware routing entirely (the
-	// header observer is not installed and no factors are computed).
+	// upstream response headers. Two independent consumers read it: the
+	// subscription-aware cost discount (subsidyFactors, gated by subsidyEnabled)
+	// and the per-installation usage-bypass gate (usageBypassEngaged). It is
+	// wired whenever EITHER feature may be used; nil disables both.
 	usageObserver *usage.Observer
+	// subsidyEnabled gates the subscription-aware cost discount independently of
+	// the observer: the observer can be wired (so the usage-bypass gate works)
+	// without the discount being active (ROUTER_SUBSCRIPTION_AWARE_ROUTING=false).
+	subsidyEnabled bool
 	// subsidyEpsilon/subsidyGamma parameterize usage.Snapshot.CostFactor: the
 	// floor multiplier for a fully-slack covered model and the curvature that
 	// keeps the factor near epsilon until the window is genuinely near its cap.

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -1534,17 +1534,6 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 	// genuine tool_result turn read at telemetry time.
 	inboundLastUser := env.LastUserMessage()
 
-	// Subscription usage-bypass gate: while the caller's own Claude subscription
-	// has headroom (observed utilization below the installation's threshold, or
-	// cold start), serve the requested model straight from Anthropic — no
-	// routing, no substitution, no billing. The turn is paid for by the
-	// customer's plan; once they approach their cap the gate disengages and the
-	// normal routing path conserves the remainder. Excluded models still force
-	// routing so a tenant policy block can't be served via the bypass.
-	if _, blocked := s.excludedModelsForRequest(ctx)[feats.Model]; !blocked && s.usageBypassEngaged(ctx, r.Header, feats.Model) {
-		return s.bypassToAnthropic(ctx, env, feats, requestStart, requestID, externalID, r, w)
-	}
-
 	routeStart := time.Now()
 	routeRes, routeErr := s.runTurnLoop(ctx, env, feats, apiKeyID, installationID, "", r.Header, router.Request{
 		RequestedModel:       feats.Model,
@@ -1559,6 +1548,15 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 	if routeErr != nil {
 		log.Error("Routing failed", "err", routeErr, "route_ms", time.Since(routeStart).Milliseconds(), "requested_model", feats.Model, "total_input_tokens", feats.Tokens)
 		return routeErr
+	}
+
+	// Subscription usage-bypass: the gate engaged inside runTurnLoop (after the
+	// hard-pin, force-pin, and tool-result sticky branches, so those still win).
+	// The caller's own Claude subscription has headroom, so serve the requested
+	// model straight through to Anthropic with no model substitution and no
+	// billing debit — the turn is paid for by the customer's plan.
+	if routeRes.UsageBypass {
+		return s.bypassToAnthropic(ctx, env, feats, requestStart, requestID, externalID, r, w)
 	}
 	routeRes.SuggestionMode = r.Header.Get("x-weave-suggestion-mode") == "true"
 	decision := routeRes.Decision

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -1556,7 +1556,7 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 	// model straight through to Anthropic with no model substitution and no
 	// billing debit — the turn is paid for by the customer's plan.
 	if routeRes.UsageBypass {
-		return s.bypassToAnthropic(ctx, env, feats, requestStart, requestID, externalID, r, w)
+		return s.bypassToAnthropic(ctx, env, feats, routeRes.modelSwitched(), requestStart, requestID, externalID, r, w)
 	}
 	routeRes.SuggestionMode = r.Header.Get("x-weave-suggestion-mode") == "true"
 	decision := routeRes.Decision

--- a/internal/proxy/subsidy.go
+++ b/internal/proxy/subsidy.go
@@ -37,8 +37,18 @@ func claudeCoveredModels() []string {
 // computed, so routing is byte-for-byte today's behavior.
 func (s *Service) WithSubscriptionAwareRouting(obs *usage.Observer, epsilon, gamma float64) *Service {
 	s.usageObserver = obs
+	s.subsidyEnabled = true
 	s.subsidyEpsilon = epsilon
 	s.subsidyGamma = gamma
+	return s
+}
+
+// WithUsageObserver wires the subscription rate-limit observer WITHOUT enabling
+// the cost discount. The composition root calls this so the per-installation
+// usage-bypass gate works even when ROUTER_SUBSCRIPTION_AWARE_ROUTING is off;
+// WithSubscriptionAwareRouting additionally turns on the discount.
+func (s *Service) WithUsageObserver(obs *usage.Observer) *Service {
+	s.usageObserver = obs
 	return s
 }
 
@@ -114,7 +124,7 @@ func (s *Service) withUsageObserver(ctx context.Context, headers http.Header) co
 // feature is off or no subscription is present. Keyed identically to
 // withUsageObserver so record and read agree across all three harnesses.
 func (s *Service) subsidyFactors(ctx context.Context, headers http.Header) map[string]float64 {
-	if s.usageObserver == nil {
+	if s.usageObserver == nil || !s.subsidyEnabled {
 		return nil
 	}
 	codexTok, anthroTok := s.presentSubscriptionTokens(ctx, headers)

--- a/internal/proxy/turnloop.go
+++ b/internal/proxy/turnloop.go
@@ -53,8 +53,13 @@ type turnLoopResult struct {
 	TurnType   turntype.TurnType
 	StickyHit  bool
 	HardPinned bool
-	PinTier    string
-	PinAgeSec  int64
+	// UsageBypass is true when the subscription usage-bypass gate engaged for
+	// this turn: the caller's own subscription has headroom, so ProxyMessages
+	// must serve the requested model straight through to Anthropic with no
+	// billing debit rather than dispatching Decision through the normal path.
+	UsageBypass bool
+	PinTier     string
+	PinAgeSec   int64
 	// RequestedTier is the tier of the inbound requested model. Drives the
 	// session-pin role split (roleForTier) so a low-tier background turn and a
 	// high-tier main turn never share a pin.
@@ -209,8 +214,14 @@ func (s *Service) runTurnLoop(
 		return res, nil
 	}
 
-	// Without a pin store, run the scorer and return its decision.
+	// Without a pin store, run the scorer and return its decision. The usage
+	// bypass intercepts the fresh scorer decision here too (no pins to honor).
 	if s.pinStore == nil {
+		if dec, ok := s.usageBypassDecision(ctx, reqHeaders, req); ok {
+			res.Decision = dec
+			res.UsageBypass = true
+			return res, nil
+		}
 		decision, err := s.routeFor(ctx, req)
 		if err != nil {
 			return res, err
@@ -443,6 +454,17 @@ func (s *Service) runTurnLoop(
 		res.StickyHit = true
 		res.PinTier = "postgres"
 		s.refreshPin(ctx, installationID, res.SessionKey, pin, res.PinRole, decision)
+		return res, nil
+	}
+
+	// Subscription usage-bypass: while the caller's own Claude subscription has
+	// headroom, intercept the fresh scorer decision and serve the requested
+	// model straight through. Positioned after every higher-precedence path
+	// (hard-pin, user-forced pin, tool-result/planner-disabled stickies) so it
+	// only ever replaces a fresh scorer decision, never an explicit pin.
+	if dec, ok := s.usageBypassDecision(ctx, reqHeaders, req); ok {
+		res.Decision = dec
+		res.UsageBypass = true
 		return res, nil
 	}
 

--- a/internal/proxy/turnloop.go
+++ b/internal/proxy/turnloop.go
@@ -435,6 +435,22 @@ func (s *Service) runTurnLoop(
 		pin = sessionpin.Pin{}
 	}
 
+	// Subscription usage-bypass: while the caller's own Claude subscription has
+	// headroom, serve the requested model straight through. Positioned after the
+	// higher-precedence pins that must win (hard-pin and user-forced pin both
+	// returned above) but BEFORE the tool-result / planner-disabled stickies, so
+	// the WHOLE session bypasses consistently: a stale pin from a prior routed
+	// stretch can't make a tool_result continuation diverge from the bypassed
+	// tool_use turn. The stale pin is left untouched and is re-evaluated by
+	// normal routing once utilization crosses the threshold. res.PriorServedModel
+	// (loaded above) lets the emit path strip thinking signatures from a
+	// different prior model.
+	if dec, ok := s.usageBypassDecision(ctx, reqHeaders, req); ok {
+		res.Decision = dec
+		res.UsageBypass = true
+		return res, nil
+	}
+
 	// Tool-result turns are mid-turn continuations. Re-routing them on
 	// trailing tool_result embedding flips decisions to noisy candidates;
 	// reuse the pin verbatim when present and refresh the TTL.
@@ -454,17 +470,6 @@ func (s *Service) runTurnLoop(
 		res.StickyHit = true
 		res.PinTier = "postgres"
 		s.refreshPin(ctx, installationID, res.SessionKey, pin, res.PinRole, decision)
-		return res, nil
-	}
-
-	// Subscription usage-bypass: while the caller's own Claude subscription has
-	// headroom, intercept the fresh scorer decision and serve the requested
-	// model straight through. Positioned after every higher-precedence path
-	// (hard-pin, user-forced pin, tool-result/planner-disabled stickies) so it
-	// only ever replaces a fresh scorer decision, never an explicit pin.
-	if dec, ok := s.usageBypassDecision(ctx, reqHeaders, req); ok {
-		res.Decision = dec
-		res.UsageBypass = true
 		return res, nil
 	}
 

--- a/internal/proxy/usage/AGENTS.md
+++ b/internal/proxy/usage/AGENTS.md
@@ -2,21 +2,31 @@
 
 > **Mirror notice.** Verbatim sync with [CLAUDE.md](CLAUDE.md). **Update both together** — divergence = bug.
 
-Anthropic usage-bypass gate. Inner-ring, I/O-free. Read [root CLAUDE.md](../../../CLAUDE.md) first.
+Per-credential subscription rate-limit headroom observer. Inner-ring, I/O-free. Read [root CLAUDE.md](../../../CLAUDE.md) first.
 
 ## What it does
 
-Tracks the most recent Anthropic unified rate-limit utilization — the same data `claude /usage` CLI reads off `anthropic-ratelimit-unified-{5h,weekly}-*` response headers.
+Tracks the most recent rate-limit utilization each subscription backend reports on every response, keyed by a salted hash of the credential:
 
-When `ROUTER_USAGE_BYPASS_ENABLED=true`, requests whose recorded 5h + weekly utilization are both below `ROUTER_USAGE_BYPASS_THRESHOLD` (default `0.95`) pass straight through to Anthropic with the requested model — no cluster routing, no planner verdict. Once either window crosses threshold, the gate disengages for that credential + the cluster scorer takes over. Observations expire after `ROUTER_USAGE_OBSERVATION_TTL` (default 10 minutes); a torn-down key or long idle period falls back to "cold start = bypass" rather than pinning the gate open on a stale near-100% reading.
+- **Claude** (`api.anthropic.com`, OAuth) — `anthropic-ratelimit-unified-{5h,weekly}-*` (the `claude /usage` data), via `ParseAnthropicUnifiedHeaders`.
+- **Codex** (`chatgpt.com/backend-api/codex`) — `x-codex-{primary,secondary}-*`, via `ParseCodexHeaders`.
+
+`Snapshot.CostFactor(epsilon, gamma)` turns the binding (more-used) window's utilization into a multiplier on a covered model's catalog cost: ~epsilon when the window has slack, rising to 1.0 (full price) as it binds. Quota is perishable (resets each window), so unused headroom has zero salvage value — spend it, back off only as the cap nears.
+
+## Consumers (both in package `proxy`)
+
+- **Subscription-aware routing** ([`../subsidy.go`](../subsidy.go), `ROUTER_SUBSCRIPTION_AWARE_ROUTING`, default on): discounts covered models' cost term by `CostFactor` so they win routing while the plan has slack, fading to full price as it binds.
+- **Per-installation usage-bypass gate** ([`../usage_bypass.go`](../usage_bypass.go)): when an installation has `usage_bypass_enabled` and the caller's observed Claude utilization is below the installation's `usage_bypass_threshold` (or nothing has been observed yet — cold start), `ProxyMessages` passes the request straight through to the requested model on the customer's own subscription — no routing, no substitution, no billing debit. Once utilization crosses the threshold the gate disengages and normal routing (incl. the subsidy discount) takes over. Strict opt-in: off until the customer enables it in the dashboard.
 
 ## Why it exists
 
-Anthropic-plan customers (Claude Code's logged-in flow) want unused quota spent on Anthropic, not silently redirected to a cheaper substitute, until actually approaching cap.
+Subscription customers (Claude Code / Codex logged-in flows) want unused, perishable plan quota spent on their own subscription — not silently redirected to a cheaper substitute, and not billed by us — until they actually approach their cap.
 
 ## Invariants
 
 - **Pure in-memory state, no persistence.**
-- Entries keyed by `usage.CredentialKey` (salted hash of upstream API key bytes) so logs + metrics never see the raw token.
-- Periodic sweep bounds memory by evicting expired entries.
-- I/O-free per the inner-ring rule — observer is just structs + maps + a mutex.
+- Entries keyed by `usage.CredentialKey` (HMAC-SHA256 prefix of the token under a process-scoped salt) so logs + metrics never see the raw token.
+- A reading stays authoritative for the life of its binding quota window (`freshFor`), not a flat short TTL — a near-cap reading must not age out and re-read as optimistic slack while the window is still exhausted.
+- Per-window merge on `Record`: a response reporting only one window must not erase the other window's last-known utilization.
+- Periodic `Sweep` (driven by the composition root on a ticker) bounds memory; the package spawns no goroutines of its own.
+- I/O-free per the inner-ring rule — just structs, maps, a mutex, and an injected clock.

--- a/internal/proxy/usage/CLAUDE.md
+++ b/internal/proxy/usage/CLAUDE.md
@@ -2,21 +2,31 @@
 
 > **Mirror notice.** Verbatim sync with [AGENTS.md](AGENTS.md). **Update both together** — divergence = bug.
 
-Anthropic usage-bypass gate. Inner-ring, I/O-free. Read [root CLAUDE.md](../../../CLAUDE.md) first.
+Per-credential subscription rate-limit headroom observer. Inner-ring, I/O-free. Read [root CLAUDE.md](../../../CLAUDE.md) first.
 
 ## What it does
 
-Tracks the most recent Anthropic unified rate-limit utilization — the same data `claude /usage` CLI reads off `anthropic-ratelimit-unified-{5h,weekly}-*` response headers.
+Tracks the most recent rate-limit utilization each subscription backend reports on every response, keyed by a salted hash of the credential:
 
-When `ROUTER_USAGE_BYPASS_ENABLED=true`, requests whose recorded 5h + weekly utilization are both below `ROUTER_USAGE_BYPASS_THRESHOLD` (default `0.95`) pass straight through to Anthropic with the requested model — no cluster routing, no planner verdict. Once either window crosses threshold, the gate disengages for that credential + the cluster scorer takes over. Observations expire after `ROUTER_USAGE_OBSERVATION_TTL` (default 10 minutes); a torn-down key or long idle period falls back to "cold start = bypass" rather than pinning the gate open on a stale near-100% reading.
+- **Claude** (`api.anthropic.com`, OAuth) — `anthropic-ratelimit-unified-{5h,weekly}-*` (the `claude /usage` data), via `ParseAnthropicUnifiedHeaders`.
+- **Codex** (`chatgpt.com/backend-api/codex`) — `x-codex-{primary,secondary}-*`, via `ParseCodexHeaders`.
+
+`Snapshot.CostFactor(epsilon, gamma)` turns the binding (more-used) window's utilization into a multiplier on a covered model's catalog cost: ~epsilon when the window has slack, rising to 1.0 (full price) as it binds. Quota is perishable (resets each window), so unused headroom has zero salvage value — spend it, back off only as the cap nears.
+
+## Consumers (both in package `proxy`)
+
+- **Subscription-aware routing** ([`../subsidy.go`](../subsidy.go), `ROUTER_SUBSCRIPTION_AWARE_ROUTING`, default on): discounts covered models' cost term by `CostFactor` so they win routing while the plan has slack, fading to full price as it binds.
+- **Per-installation usage-bypass gate** ([`../usage_bypass.go`](../usage_bypass.go)): when an installation has `usage_bypass_enabled` and the caller's observed Claude utilization is below the installation's `usage_bypass_threshold` (or nothing has been observed yet — cold start), `ProxyMessages` passes the request straight through to the requested model on the customer's own subscription — no routing, no substitution, no billing debit. Once utilization crosses the threshold the gate disengages and normal routing (incl. the subsidy discount) takes over. Strict opt-in: off until the customer enables it in the dashboard.
 
 ## Why it exists
 
-Anthropic-plan customers (Claude Code's logged-in flow) want unused quota spent on Anthropic, not silently redirected to a cheaper substitute, until actually approaching cap.
+Subscription customers (Claude Code / Codex logged-in flows) want unused, perishable plan quota spent on their own subscription — not silently redirected to a cheaper substitute, and not billed by us — until they actually approach their cap.
 
 ## Invariants
 
 - **Pure in-memory state, no persistence.**
-- Entries keyed by `usage.CredentialKey` (salted hash of upstream API key bytes) so logs + metrics never see the raw token.
-- Periodic sweep bounds memory by evicting expired entries.
-- I/O-free per the inner-ring rule — observer is just structs + maps + a mutex.
+- Entries keyed by `usage.CredentialKey` (HMAC-SHA256 prefix of the token under a process-scoped salt) so logs + metrics never see the raw token.
+- A reading stays authoritative for the life of its binding quota window (`freshFor`), not a flat short TTL — a near-cap reading must not age out and re-read as optimistic slack while the window is still exhausted.
+- Per-window merge on `Record`: a response reporting only one window must not erase the other window's last-known utilization.
+- Periodic `Sweep` (driven by the composition root on a ticker) bounds memory; the package spawns no goroutines of its own.
+- I/O-free per the inner-ring rule — just structs, maps, a mutex, and an injected clock.

--- a/internal/proxy/usage_bypass.go
+++ b/internal/proxy/usage_bypass.go
@@ -2,6 +2,7 @@ package proxy
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"time"
@@ -147,6 +148,15 @@ func (s *Service) bypassToAnthropic(
 
 	proxyStart := time.Now()
 	proxyErr := p.Proxy(ctx, decision, prep, w, r)
+	// The Anthropic adapter returns a buffered *UpstreamErrorResponse on 4xx/5xx
+	// without writing to w (the routed path flushes it via dispatchWithFallback).
+	// Render it as the real upstream status+body so the caller sees e.g. a 429
+	// with its retry headers instead of a generic 502; treat the turn as served.
+	var upstreamErr *providers.UpstreamErrorResponse
+	if errors.As(proxyErr, &upstreamErr) {
+		flushUpstreamErrorAsAnthropic(w, proxyErr)
+		proxyErr = nil
+	}
 	otel.Record(ctx, otel.Span{
 		Name:  "router.usage_bypass",
 		Start: requestStart,

--- a/internal/proxy/usage_bypass.go
+++ b/internal/proxy/usage_bypass.go
@@ -97,6 +97,7 @@ func (s *Service) bypassToAnthropic(
 	ctx context.Context,
 	env *translate.RequestEnvelope,
 	feats translate.RoutingFeatures,
+	modelSwitched bool,
 	requestStart time.Time,
 	requestID, externalID string,
 	r *http.Request,
@@ -133,6 +134,10 @@ func (s *Service) bypassToAnthropic(
 		Capabilities:          router.Lookup(decision.Model),
 		IncludeStreamUsage:    s.usageRequired(),
 		EnableExtendedContext: shouldEnableExtendedContext(env.FullTokenEstimate(), outputReserve),
+		// When the session previously served a different model, strip thinking
+		// blocks whose signatures the requested model would reject (else
+		// Anthropic 400s on the stale signature).
+		ModelSwitched: modelSwitched,
 	}
 	prep, emitErr := env.PrepareAnthropic(r.Header, opts)
 	if emitErr != nil {

--- a/internal/proxy/usage_bypass.go
+++ b/internal/proxy/usage_bypass.go
@@ -1,0 +1,140 @@
+package proxy
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"time"
+
+	"workweave/router/internal/observability"
+	"workweave/router/internal/observability/otel"
+	"workweave/router/internal/providers"
+	"workweave/router/internal/router"
+	"workweave/router/internal/router/catalog"
+	"workweave/router/internal/translate"
+)
+
+// usageBypassEngaged reports whether this Anthropic-Messages request should skip
+// cluster routing entirely and pass straight through to the requested model on
+// the caller's own Claude subscription. It engages only when:
+//
+//   - the installation has turned the gate on (usageBypassFromContext),
+//   - the subscription usage observer is wired (it drives the threshold read),
+//   - the request presents a Claude subscription credential (the turn is paid
+//     for by the customer's own plan, so there's nothing for the router to save
+//     and nothing for us to bill),
+//   - the requested model is Anthropic-served (the only thing a Claude
+//     subscription can actually serve — a cross-vendor request can't bypass
+//     onto the subscription), and
+//   - observed utilization is still below the threshold, OR nothing has been
+//     observed yet (cold start: serve the first turn on the subscription so its
+//     response primes the observer, mirroring the subsidy bootstrap).
+//
+// Once observed utilization crosses the threshold the gate disengages and the
+// normal routing path (scorer + subscription-aware cost discounting) takes over,
+// so the caller starts conserving their remaining quota.
+func (s *Service) usageBypassEngaged(ctx context.Context, headers http.Header, requestedModel string) bool {
+	cfg, ok := usageBypassFromContext(ctx)
+	if !ok || s.usageObserver == nil {
+		return false
+	}
+	if m, found := catalog.ByID(requestedModel); !found || m.PrimaryProvider() != providers.ProviderAnthropic {
+		return false
+	}
+	_, anthroTok := s.presentSubscriptionTokens(ctx, headers)
+	if anthroTok == "" {
+		return false
+	}
+	threshold := defaultUsageBypassThreshold
+	if cfg.Threshold != nil {
+		threshold = *cfg.Threshold
+	}
+	snap, observed := s.usageObserver.Snapshot(s.usageObserver.Key([]byte(anthroTok)))
+	if !observed {
+		return true
+	}
+	util := max(snap.Primary.UsedPercent, snap.Secondary.UsedPercent)
+	return util < threshold
+}
+
+// bypassToAnthropic proxies an inbound Anthropic-Messages request straight to
+// the Anthropic provider with the caller-requested model. It deliberately skips
+// the cluster scorer, planner, session pin, semantic cache, AND billing: the
+// turn runs on the customer's own subscription quota, so there is no model
+// substitution to make and no usage to charge. The Anthropic adapter still
+// observes the response's rate-limit headers (via the ctx observer installed by
+// withUsageObserver), keeping the gate primed for the next request.
+func (s *Service) bypassToAnthropic(
+	ctx context.Context,
+	env *translate.RequestEnvelope,
+	feats translate.RoutingFeatures,
+	requestStart time.Time,
+	requestID, externalID string,
+	r *http.Request,
+	w http.ResponseWriter,
+) error {
+	log := observability.FromContext(ctx)
+	decision := router.Decision{
+		Provider: providers.ProviderAnthropic,
+		Model:    feats.Model,
+		Reason:   "usage_bypass",
+	}
+	w.Header().Set(HeaderRouterDecision, decision.Reason)
+	w.Header().Set(HeaderRouterProvider, decision.Provider)
+	w.Header().Set(HeaderRouterModel, decision.Model)
+
+	p, provErr := s.provider(providers.ProviderAnthropic)
+	if provErr != nil {
+		return provErr
+	}
+
+	// Resolve credentials onto ctx so the Anthropic adapter's setAuth picks up
+	// the subscription (or BYOK / client) credential exactly as a routed turn
+	// would, and so servedOnSubscription / the usage observer key off the same
+	// token the upstream call sends.
+	ctx = resolveAndInjectCredentials(ctx, decision.Provider, r.Header)
+
+	outputReserve := contextWindowOutputReserve
+	if feats.MaxTokens > outputReserve {
+		outputReserve = feats.MaxTokens
+	}
+	opts := translate.EmitOptions{
+		TargetModel:           decision.Model,
+		TargetProvider:        decision.Provider,
+		Capabilities:          router.Lookup(decision.Model),
+		IncludeStreamUsage:    s.usageRequired(),
+		EnableExtendedContext: shouldEnableExtendedContext(env.FullTokenEstimate(), outputReserve),
+	}
+	prep, emitErr := env.PrepareAnthropic(r.Header, opts)
+	if emitErr != nil {
+		log.Error("Failed to emit Anthropic body on usage-bypass path", "err", emitErr)
+		return fmt.Errorf("emit bypass body: %w", emitErr)
+	}
+
+	proxyStart := time.Now()
+	proxyErr := p.Proxy(ctx, decision, prep, w, r)
+	otel.Record(ctx, otel.Span{
+		Name:  "router.usage_bypass",
+		Start: requestStart,
+		End:   time.Now(),
+		Attrs: otel.NewAttrBuilder(6).
+			String("request_id", requestID).
+			String("external_id", externalID).
+			String("decision.model", decision.Model).
+			String("decision.provider", decision.Provider).
+			String("decision.reason", decision.Reason).
+			Bool("cost.subscription_served", servedOnSubscription(ctx)).
+			Build(),
+	})
+	otel.Flush(ctx)
+	log.Info("ProxyMessages usage-bypass complete",
+		"request_id", requestID,
+		"external_id", externalID,
+		"requested_model", feats.Model,
+		"decision_model", decision.Model,
+		"proxy_ms", time.Since(proxyStart).Milliseconds(),
+		"total_ms", time.Since(requestStart).Milliseconds(),
+		"proxy_err", proxyErr,
+	)
+	return proxyErr
+}

--- a/internal/proxy/usage_bypass.go
+++ b/internal/proxy/usage_bypass.go
@@ -14,18 +14,38 @@ import (
 	"workweave/router/internal/translate"
 )
 
-// usageBypassEngaged reports whether this Anthropic-Messages request should skip
-// cluster routing entirely and pass straight through to the requested model on
-// the caller's own Claude subscription. It engages only when:
+// usageBypassDecision returns the passthrough decision when the subscription
+// usage-bypass gate should engage for this turn, and false otherwise. It is
+// consulted inside runTurnLoop only at the point a FRESH scorer decision would
+// be made — after the hard-pin, user-forced-pin, and tool-result sticky
+// branches have already returned — so those higher-precedence paths are never
+// preempted by the bypass. The req-level exclusion sets (EnabledProviders,
+// ExcludedModels) it reads already carry installation provider/model denylists
+// and the per-request context-overflow filter, so a policy-blocked or
+// over-capacity model can't be served via the bypass.
+func (s *Service) usageBypassDecision(ctx context.Context, headers http.Header, req router.Request) (router.Decision, bool) {
+	if !s.usageBypassEngaged(ctx, headers, req) {
+		return router.Decision{}, false
+	}
+	return router.Decision{
+		Provider: providers.ProviderAnthropic,
+		Model:    req.RequestedModel,
+		Reason:   "usage_bypass",
+	}, true
+}
+
+// usageBypassEngaged reports whether the requested model should be served
+// straight through to the caller's own Claude subscription instead of routed.
+// It engages only when:
 //
 //   - the installation has turned the gate on (usageBypassFromContext),
 //   - the subscription usage observer is wired (it drives the threshold read),
-//   - the request presents a Claude subscription credential (the turn is paid
-//     for by the customer's own plan, so there's nothing for the router to save
-//     and nothing for us to bill),
 //   - the requested model is Anthropic-served (the only thing a Claude
-//     subscription can actually serve — a cross-vendor request can't bypass
-//     onto the subscription), and
+//     subscription can serve) and is neither provider- nor model-excluded for
+//     this request (denylist or context-overflow filter),
+//   - the request presents a Claude subscription credential (the turn is paid
+//     for by the customer's own plan — nothing for the router to save, nothing
+//     for us to bill), and
 //   - observed utilization is still below the threshold, OR nothing has been
 //     observed yet (cold start: serve the first turn on the subscription so its
 //     response primes the observer, mirroring the subsidy bootstrap).
@@ -33,12 +53,21 @@ import (
 // Once observed utilization crosses the threshold the gate disengages and the
 // normal routing path (scorer + subscription-aware cost discounting) takes over,
 // so the caller starts conserving their remaining quota.
-func (s *Service) usageBypassEngaged(ctx context.Context, headers http.Header, requestedModel string) bool {
+func (s *Service) usageBypassEngaged(ctx context.Context, headers http.Header, req router.Request) bool {
 	cfg, ok := usageBypassFromContext(ctx)
 	if !ok || s.usageObserver == nil {
 		return false
 	}
-	if m, found := catalog.ByID(requestedModel); !found || m.PrimaryProvider() != providers.ProviderAnthropic {
+	model := req.RequestedModel
+	if m, found := catalog.ByID(model); !found || m.PrimaryProvider() != providers.ProviderAnthropic {
+		return false
+	}
+	if req.EnabledProviders != nil {
+		if _, enabled := req.EnabledProviders[providers.ProviderAnthropic]; !enabled {
+			return false
+		}
+	}
+	if _, excluded := req.ExcludedModels[model]; excluded {
 		return false
 	}
 	_, anthroTok := s.presentSubscriptionTokens(ctx, headers)
@@ -47,7 +76,7 @@ func (s *Service) usageBypassEngaged(ctx context.Context, headers http.Header, r
 	}
 	threshold := defaultUsageBypassThreshold
 	if cfg.Threshold != nil {
-		threshold = *cfg.Threshold
+		threshold = min(1, max(0, *cfg.Threshold))
 	}
 	snap, observed := s.usageObserver.Snapshot(s.usageObserver.Key([]byte(anthroTok)))
 	if !observed {

--- a/internal/proxy/usage_bypass_test.go
+++ b/internal/proxy/usage_bypass_test.go
@@ -12,7 +12,9 @@ import (
 	"workweave/router/internal/proxy"
 	"workweave/router/internal/proxy/usage"
 	"workweave/router/internal/router"
+	"workweave/router/internal/router/sessionpin"
 
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -147,6 +149,45 @@ func TestUsageBypass_ExcludedModel_EngagesRouting(t *testing.T) {
 	require.NoError(t, svc.ProxyMessages(bypassCtx(0.80), body, rec, req))
 
 	assert.Equal(t, 1, fr.routeCalls, "an excluded requested model must force routing even under threshold")
+}
+
+// TestUsageBypass_ToolResult_BeatsStalePin: a session that previously routed
+// (leaving a pin) and is now under threshold must bypass CONSISTENTLY. A
+// tool_result continuation must serve the requested model via the bypass, not
+// short-circuit to the stale pinned model through the tool-result sticky —
+// otherwise the continuation hits a different model than the tool_use turn.
+func TestUsageBypass_ToolResult_BeatsStalePin(t *testing.T) {
+	store := newFakePinStore()
+	store.hasPin = true
+	store.pin = sessionpin.Pin{
+		Provider:      providers.ProviderAnthropic,
+		Model:         bypassScorerPickMdl, // stale pin from a prior routed stretch
+		Reason:        "cluster:v0.2",
+		PinnedUntil:   time.Now().Add(30 * time.Minute),
+		FirstPinnedAt: time.Now().Add(-5 * time.Minute),
+	}
+	fr := &fakeRouter{decision: router.Decision{Provider: providers.ProviderAnthropic, Model: bypassScorerPickMdl}}
+	obs := usage.NewObserver([]byte("salt"), 10*time.Minute, time.Now)
+	obs.Record(obs.Key([]byte(bypassSubToken)), usage.Snapshot{Primary: usage.Window{UsedPercent: 0.20, WindowMinutes: 300}})
+	svc := proxy.NewService(fr, map[string]providers.Client{providers.ProviderAnthropic: &fakeProvider{}}, nil, false, nil, store, false, providers.ProviderAnthropic, bypassScorerPickMdl, nil).
+		WithSubscriptionAwareRouting(obs, 0.05, 2.0)
+
+	ctx := context.WithValue(authedCtx(uuid.New().String()), proxy.AnthropicSubscriptionContextKey{}, bypassSubToken)
+	threshold := 0.80
+	ctx = context.WithValue(ctx, proxy.InstallationUsageBypassContextKey{}, proxy.UsageBypassConfig{Enabled: true, Threshold: &threshold})
+
+	toolResultBody := []byte(`{"model":"` + bypassRequestedMdl + `","messages":[` +
+		`{"role":"user","content":"do it"},` +
+		`{"role":"assistant","content":[{"type":"tool_use","id":"t1","name":"x","input":{}}]},` +
+		`{"role":"user","content":[{"type":"tool_result","tool_use_id":"t1","content":"ok"}]}]}`)
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(""))
+
+	require.NoError(t, svc.ProxyMessages(ctx, toolResultBody, rec, req))
+
+	assert.Equal(t, 0, fr.routeCalls, "bypass must preempt the tool-result sticky, not run the scorer")
+	assert.Equal(t, "usage_bypass", rec.Header().Get("x-router-decision"))
+	assert.Equal(t, bypassRequestedMdl, rec.Header().Get("x-router-model"), "continuation must serve the requested model, not the stale pin")
 }
 
 // TestUsageBypass_ExcludedProvider_EngagesRouting: when the installation has

--- a/internal/proxy/usage_bypass_test.go
+++ b/internal/proxy/usage_bypass_test.go
@@ -190,6 +190,25 @@ func TestUsageBypass_ToolResult_BeatsStalePin(t *testing.T) {
 	assert.Equal(t, bypassRequestedMdl, rec.Header().Get("x-router-model"), "continuation must serve the requested model, not the stale pin")
 }
 
+// TestUsageBypass_WorksWithoutSubsidyDiscount: the gate must engage when the
+// observer is wired via WithUsageObserver alone (ROUTER_SUBSCRIPTION_AWARE_ROUTING
+// off) — the bypass is opt-in per installation and must not depend on the
+// separate subscription-aware cost-discount flag.
+func TestUsageBypass_WorksWithoutSubsidyDiscount(t *testing.T) {
+	fr := &fakeRouter{decision: router.Decision{Provider: providers.ProviderAnthropic, Model: bypassScorerPickMdl}}
+	p := &fakeProvider{}
+	obs := usage.NewObserver([]byte("salt"), 10*time.Minute, time.Now)
+	obs.Record(obs.Key([]byte(bypassSubToken)), usage.Snapshot{Primary: usage.Window{UsedPercent: 0.20, WindowMinutes: 300}})
+	svc := proxy.NewService(fr, map[string]providers.Client{providers.ProviderAnthropic: p}, nil, false, nil, nil, false, providers.ProviderAnthropic, bypassScorerPickMdl, nil).
+		WithUsageObserver(obs) // observer only — subsidy discount NOT enabled
+
+	rec, req, body := bypassRequest(t)
+	require.NoError(t, svc.ProxyMessages(bypassCtx(0.80), body, rec, req))
+
+	assert.Equal(t, 0, fr.routeCalls, "bypass must engage on observer alone, without the subsidy flag")
+	assert.Equal(t, bypassRequestedMdl, rec.Header().Get("x-router-model"))
+}
+
 // TestUsageBypass_ExcludedProvider_EngagesRouting: when the installation has
 // excluded the Anthropic provider (e.g. data-residency policy), the bypass must
 // not dispatch to Anthropic even under threshold — routing runs so the

--- a/internal/proxy/usage_bypass_test.go
+++ b/internal/proxy/usage_bypass_test.go
@@ -1,0 +1,150 @@
+package proxy_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"workweave/router/internal/providers"
+	"workweave/router/internal/proxy"
+	"workweave/router/internal/proxy/usage"
+	"workweave/router/internal/router"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	bypassSubToken      = "sk-ant-oat01-subscription-token"
+	bypassRequestedMdl  = "claude-sonnet-4-6"
+	bypassScorerPickMdl = "claude-haiku-4-5"
+)
+
+// bypassFixture builds a service whose fake scorer would route to
+// bypassScorerPickMdl, with the subscription usage observer wired and a fake
+// Anthropic provider that returns a minimal valid Messages response so a routed
+// turn completes. seedUtil >= 0 pre-records an observation at that utilization
+// under the subscription token; seedUtil < 0 leaves the observer cold.
+func bypassFixture(t *testing.T, seedUtil float64) (*proxy.Service, *fakeRouter, *fakeProvider) {
+	t.Helper()
+	fr := &fakeRouter{decision: router.Decision{Provider: providers.ProviderAnthropic, Model: bypassScorerPickMdl}}
+	p := &fakeProvider{proxyResponse: func(w http.ResponseWriter) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"id":"msg_1","type":"message","role":"assistant","model":"` + bypassScorerPickMdl + `","content":[{"type":"text","text":"hi"}],"stop_reason":"end_turn","usage":{"input_tokens":1,"output_tokens":1}}`))
+	}}
+	obs := usage.NewObserver([]byte("salt"), 10*time.Minute, time.Now)
+	if seedUtil >= 0 {
+		obs.Record(obs.Key([]byte(bypassSubToken)), usage.Snapshot{
+			Primary: usage.Window{UsedPercent: seedUtil, WindowMinutes: 300},
+		})
+	}
+	svc := proxy.NewService(fr, map[string]providers.Client{providers.ProviderAnthropic: p}, nil, false, nil, nil, false, providers.ProviderAnthropic, bypassScorerPickMdl, nil).
+		WithSubscriptionAwareRouting(obs, 0.05, 2.0)
+	return svc, fr, p
+}
+
+// bypassCtx returns a ctx carrying a Claude subscription token plus a
+// per-installation usage-bypass config at the given threshold.
+func bypassCtx(threshold float64) context.Context {
+	ctx := context.WithValue(context.Background(), proxy.AnthropicSubscriptionContextKey{}, bypassSubToken)
+	return context.WithValue(ctx, proxy.InstallationUsageBypassContextKey{}, proxy.UsageBypassConfig{
+		Enabled:   true,
+		Threshold: &threshold,
+	})
+}
+
+func bypassRequest(t *testing.T) (*httptest.ResponseRecorder, *http.Request, []byte) {
+	t.Helper()
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(""))
+	body := []byte(`{"model":"` + bypassRequestedMdl + `","messages":[{"role":"user","content":"hi"}]}`)
+	return rec, req, body
+}
+
+// TestUsageBypass_BelowThreshold_SkipsScorer is the core contract: while the
+// caller's subscription utilization is below the installation threshold, the
+// scorer must NOT run and the requested model (not the scorer's pick) is served.
+func TestUsageBypass_BelowThreshold_SkipsScorer(t *testing.T) {
+	svc, fr, p := bypassFixture(t, 0.20)
+	rec, req, body := bypassRequest(t)
+
+	require.NoError(t, svc.ProxyMessages(bypassCtx(0.80), body, rec, req))
+
+	assert.Equal(t, 0, fr.routeCalls, "scorer must not run while subscription has headroom")
+	require.Len(t, p.proxyBodies, 1, "request must be dispatched to Anthropic exactly once")
+	assert.Contains(t, string(p.proxyBodies[0]), `"`+bypassRequestedMdl+`"`, "bypass must preserve the caller-requested model")
+	assert.Equal(t, "usage_bypass", rec.Header().Get("x-router-decision"))
+	assert.Equal(t, bypassRequestedMdl, rec.Header().Get("x-router-model"))
+}
+
+// TestUsageBypass_AtThreshold_EngagesRouting is the counterpart: once observed
+// utilization crosses the threshold, the scorer runs and substitutes its pick.
+func TestUsageBypass_AtThreshold_EngagesRouting(t *testing.T) {
+	svc, fr, _ := bypassFixture(t, 0.90)
+	rec, req, body := bypassRequest(t)
+
+	require.NoError(t, svc.ProxyMessages(bypassCtx(0.80), body, rec, req))
+
+	assert.Equal(t, 1, fr.routeCalls, "scorer must run once utilization crosses threshold")
+	assert.Equal(t, bypassScorerPickMdl, rec.Header().Get("x-router-model"), "scorer's pick replaces the requested model")
+}
+
+// TestUsageBypass_ColdStart_Bypasses: with the gate on and a subscription
+// present but no observation yet, the first turn serves on the subscription so
+// its response primes the observer (mirrors the subsidy bootstrap).
+func TestUsageBypass_ColdStart_Bypasses(t *testing.T) {
+	svc, fr, _ := bypassFixture(t, -1) // observer left cold
+	rec, req, body := bypassRequest(t)
+
+	require.NoError(t, svc.ProxyMessages(bypassCtx(0.80), body, rec, req))
+
+	assert.Equal(t, 0, fr.routeCalls, "cold start must bypass so the first turn primes the observer")
+	assert.Equal(t, bypassRequestedMdl, rec.Header().Get("x-router-model"))
+}
+
+// TestUsageBypass_GateDisabled_EngagesRouting: with no per-installation config
+// on ctx the gate is off, so routing runs even with headroom.
+func TestUsageBypass_GateDisabled_EngagesRouting(t *testing.T) {
+	svc, fr, _ := bypassFixture(t, 0.20)
+	rec, req, body := bypassRequest(t)
+	// Subscription present, but the installation never enabled the gate.
+	ctx := context.WithValue(context.Background(), proxy.AnthropicSubscriptionContextKey{}, bypassSubToken)
+
+	require.NoError(t, svc.ProxyMessages(ctx, body, rec, req))
+
+	assert.Equal(t, 1, fr.routeCalls, "scorer must run when the installation hasn't enabled the gate")
+}
+
+// TestUsageBypass_NoSubscription_EngagesRouting: the gate is on but the request
+// carries no subscription credential, so there's nothing to pass through onto —
+// routing runs.
+func TestUsageBypass_NoSubscription_EngagesRouting(t *testing.T) {
+	svc, fr, _ := bypassFixture(t, 0.20)
+	rec, req, body := bypassRequest(t)
+	threshold := 0.80
+	ctx := context.WithValue(context.Background(), proxy.InstallationUsageBypassContextKey{}, proxy.UsageBypassConfig{
+		Enabled:   true,
+		Threshold: &threshold,
+	})
+
+	require.NoError(t, svc.ProxyMessages(ctx, body, rec, req))
+
+	assert.Equal(t, 1, fr.routeCalls, "no subscription credential means nothing to bypass onto — scorer must run")
+}
+
+// TestUsageBypass_ExcludedModel_EngagesRouting: a model on the installation's
+// deny list must force routing even under threshold, so the bypass can't serve
+// a policy-blocked model.
+func TestUsageBypass_ExcludedModel_EngagesRouting(t *testing.T) {
+	svc, fr, _ := bypassFixture(t, 0.20)
+	svc = svc.WithExcludedModelsOverride([]string{bypassRequestedMdl})
+	rec, req, body := bypassRequest(t)
+
+	require.NoError(t, svc.ProxyMessages(bypassCtx(0.80), body, rec, req))
+
+	assert.Equal(t, 1, fr.routeCalls, "an excluded requested model must force routing even under threshold")
+}

--- a/internal/proxy/usage_bypass_test.go
+++ b/internal/proxy/usage_bypass_test.go
@@ -148,3 +148,17 @@ func TestUsageBypass_ExcludedModel_EngagesRouting(t *testing.T) {
 
 	assert.Equal(t, 1, fr.routeCalls, "an excluded requested model must force routing even under threshold")
 }
+
+// TestUsageBypass_ExcludedProvider_EngagesRouting: when the installation has
+// excluded the Anthropic provider (e.g. data-residency policy), the bypass must
+// not dispatch to Anthropic even under threshold — routing runs so the
+// exclusion is honored.
+func TestUsageBypass_ExcludedProvider_EngagesRouting(t *testing.T) {
+	svc, fr, _ := bypassFixture(t, 0.20)
+	rec, req, body := bypassRequest(t)
+	ctx := context.WithValue(bypassCtx(0.80), proxy.InstallationExcludedProvidersContextKey{}, []string{providers.ProviderAnthropic})
+
+	require.NoError(t, svc.ProxyMessages(ctx, body, rec, req))
+
+	assert.Equal(t, 1, fr.routeCalls, "an excluded Anthropic provider must force routing even under threshold")
+}

--- a/internal/server/middleware/auth.go
+++ b/internal/server/middleware/auth.go
@@ -130,6 +130,12 @@ func withAPIKey(svc *auth.Service, byokDisabled bool) gin.HandlerFunc {
 					QualityBias: installation.RoutingQualityWeight,
 				})
 			}
+			if installation.UsageBypassEnabled {
+				ctx = context.WithValue(ctx, proxy.InstallationUsageBypassContextKey{}, proxy.UsageBypassConfig{
+					Enabled:   true,
+					Threshold: installation.UsageBypassThreshold,
+				})
+			}
 		}
 		if externalKeys != nil && !byokDisabled {
 			ctx = context.WithValue(ctx, proxy.ExternalAPIKeysContextKey{}, externalKeys)

--- a/internal/server/middleware/auth_test.go
+++ b/internal/server/middleware/auth_test.go
@@ -110,6 +110,9 @@ func (fakeInstallationRepository) UpdateExcludedProviders(ctx context.Context, e
 func (fakeInstallationRepository) UpdateRoutingPreference(ctx context.Context, externalID, id string, qualityWeight *float64) error {
 	return errors.New("not used")
 }
+func (fakeInstallationRepository) UpdateUsageBypass(ctx context.Context, externalID, id string, enabled bool, threshold *float64) error {
+	return errors.New("not used")
+}
 
 func TestWithAuthPrefersRouterKeyHeader(t *testing.T) {
 	gin.SetMode(gin.TestMode)

--- a/internal/sqlc/model_router_api_keys.sql.go
+++ b/internal/sqlc/model_router_api_keys.sql.go
@@ -92,7 +92,7 @@ func (q *Queries) CreateModelRouterAPIKey(ctx context.Context, arg CreateModelRo
 }
 
 const getActiveModelRouterAPIKeyWithInstallationByHash = `-- name: GetActiveModelRouterAPIKeyWithInstallationByHash :one
-SELECT k.id, k.installation_id, k.external_id, k.name, k.key_prefix, k.key_hash, k.key_suffix, k.last_used_at, k.created_at, k.deleted_at, k.created_by, i.id, i.external_id, i.name, i.created_at, i.updated_at, i.deleted_at, i.created_by, i.excluded_models, i.excluded_providers, i.routing_quality_weight
+SELECT k.id, k.installation_id, k.external_id, k.name, k.key_prefix, k.key_hash, k.key_suffix, k.last_used_at, k.created_at, k.deleted_at, k.created_by, i.id, i.external_id, i.name, i.created_at, i.updated_at, i.deleted_at, i.created_by, i.excluded_models, i.excluded_providers, i.routing_quality_weight, i.usage_bypass_enabled, i.usage_bypass_threshold
 FROM router.model_router_api_keys k
 INNER JOIN router.model_router_installations i ON i.id = k.installation_id
 WHERE k.key_hash = $1::varchar
@@ -111,7 +111,7 @@ type GetActiveModelRouterAPIKeyWithInstallationByHashRow struct {
 // both sides so a soft-deleted installation invalidates all its keys without per-key
 // updates.
 //
-//	SELECT k.id, k.installation_id, k.external_id, k.name, k.key_prefix, k.key_hash, k.key_suffix, k.last_used_at, k.created_at, k.deleted_at, k.created_by, i.id, i.external_id, i.name, i.created_at, i.updated_at, i.deleted_at, i.created_by, i.excluded_models, i.excluded_providers, i.routing_quality_weight
+//	SELECT k.id, k.installation_id, k.external_id, k.name, k.key_prefix, k.key_hash, k.key_suffix, k.last_used_at, k.created_at, k.deleted_at, k.created_by, i.id, i.external_id, i.name, i.created_at, i.updated_at, i.deleted_at, i.created_by, i.excluded_models, i.excluded_providers, i.routing_quality_weight, i.usage_bypass_enabled, i.usage_bypass_threshold
 //	FROM router.model_router_api_keys k
 //	INNER JOIN router.model_router_installations i ON i.id = k.installation_id
 //	WHERE k.key_hash = $1::varchar
@@ -142,6 +142,8 @@ func (q *Queries) GetActiveModelRouterAPIKeyWithInstallationByHash(ctx context.C
 		&i.RouterModelRouterInstallation.ExcludedModels,
 		&i.RouterModelRouterInstallation.ExcludedProviders,
 		&i.RouterModelRouterInstallation.RoutingQualityWeight,
+		&i.RouterModelRouterInstallation.UsageBypassEnabled,
+		&i.RouterModelRouterInstallation.UsageBypassThreshold,
 	)
 	return i, err
 }

--- a/internal/sqlc/model_router_installations.sql.go
+++ b/internal/sqlc/model_router_installations.sql.go
@@ -22,7 +22,7 @@ VALUES (
     $2::varchar,
     $3
 )
-RETURNING id, external_id, name, created_at, updated_at, deleted_at, created_by, excluded_models, excluded_providers, routing_quality_weight
+RETURNING id, external_id, name, created_at, updated_at, deleted_at, created_by, excluded_models, excluded_providers, routing_quality_weight, usage_bypass_enabled, usage_bypass_threshold
 `
 
 type CreateModelRouterInstallationParams struct {
@@ -43,7 +43,7 @@ type CreateModelRouterInstallationParams struct {
 //	    $2::varchar,
 //	    $3
 //	)
-//	RETURNING id, external_id, name, created_at, updated_at, deleted_at, created_by, excluded_models, excluded_providers, routing_quality_weight
+//	RETURNING id, external_id, name, created_at, updated_at, deleted_at, created_by, excluded_models, excluded_providers, routing_quality_weight, usage_bypass_enabled, usage_bypass_threshold
 func (q *Queries) CreateModelRouterInstallation(ctx context.Context, arg CreateModelRouterInstallationParams) (RouterModelRouterInstallation, error) {
 	row := q.db.QueryRow(ctx, createModelRouterInstallation, arg.ExternalID, arg.Name, arg.CreatedBy)
 	var i RouterModelRouterInstallation
@@ -58,12 +58,14 @@ func (q *Queries) CreateModelRouterInstallation(ctx context.Context, arg CreateM
 		&i.ExcludedModels,
 		&i.ExcludedProviders,
 		&i.RoutingQualityWeight,
+		&i.UsageBypassEnabled,
+		&i.UsageBypassThreshold,
 	)
 	return i, err
 }
 
 const getModelRouterInstallation = `-- name: GetModelRouterInstallation :one
-SELECT id, external_id, name, created_at, updated_at, deleted_at, created_by, excluded_models, excluded_providers, routing_quality_weight
+SELECT id, external_id, name, created_at, updated_at, deleted_at, created_by, excluded_models, excluded_providers, routing_quality_weight, usage_bypass_enabled, usage_bypass_threshold
 FROM router.model_router_installations
 WHERE id = $1::uuid
   AND external_id = $2::varchar
@@ -77,7 +79,7 @@ type GetModelRouterInstallationParams struct {
 
 // Gets an installation by id, scoped to an external_id to prevent cross-tenant access.
 //
-//	SELECT id, external_id, name, created_at, updated_at, deleted_at, created_by, excluded_models, excluded_providers, routing_quality_weight
+//	SELECT id, external_id, name, created_at, updated_at, deleted_at, created_by, excluded_models, excluded_providers, routing_quality_weight, usage_bypass_enabled, usage_bypass_threshold
 //	FROM router.model_router_installations
 //	WHERE id = $1::uuid
 //	  AND external_id = $2::varchar
@@ -96,12 +98,14 @@ func (q *Queries) GetModelRouterInstallation(ctx context.Context, arg GetModelRo
 		&i.ExcludedModels,
 		&i.ExcludedProviders,
 		&i.RoutingQualityWeight,
+		&i.UsageBypassEnabled,
+		&i.UsageBypassThreshold,
 	)
 	return i, err
 }
 
 const listModelRouterInstallationsForExternalID = `-- name: ListModelRouterInstallationsForExternalID :many
-SELECT id, external_id, name, created_at, updated_at, deleted_at, created_by, excluded_models, excluded_providers, routing_quality_weight
+SELECT id, external_id, name, created_at, updated_at, deleted_at, created_by, excluded_models, excluded_providers, routing_quality_weight, usage_bypass_enabled, usage_bypass_threshold
 FROM router.model_router_installations
 WHERE external_id = $1::varchar
   AND deleted_at IS NULL
@@ -110,7 +114,7 @@ ORDER BY created_at DESC
 
 // ListModelRouterInstallationsForExternalID
 //
-//	SELECT id, external_id, name, created_at, updated_at, deleted_at, created_by, excluded_models, excluded_providers, routing_quality_weight
+//	SELECT id, external_id, name, created_at, updated_at, deleted_at, created_by, excluded_models, excluded_providers, routing_quality_weight, usage_bypass_enabled, usage_bypass_threshold
 //	FROM router.model_router_installations
 //	WHERE external_id = $1::varchar
 //	  AND deleted_at IS NULL
@@ -135,6 +139,8 @@ func (q *Queries) ListModelRouterInstallationsForExternalID(ctx context.Context,
 			&i.ExcludedModels,
 			&i.ExcludedProviders,
 			&i.RoutingQualityWeight,
+			&i.UsageBypassEnabled,
+			&i.UsageBypassThreshold,
 		); err != nil {
 			return nil, err
 		}
@@ -258,5 +264,44 @@ type UpdateModelRouterInstallationRoutingPreferenceParams struct {
 //	  AND deleted_at IS NULL
 func (q *Queries) UpdateModelRouterInstallationRoutingPreference(ctx context.Context, arg UpdateModelRouterInstallationRoutingPreferenceParams) error {
 	_, err := q.db.Exec(ctx, updateModelRouterInstallationRoutingPreference, arg.RoutingQualityWeight, arg.ID, arg.ExternalID)
+	return err
+}
+
+const updateModelRouterInstallationUsageBypass = `-- name: UpdateModelRouterInstallationUsageBypass :exec
+UPDATE router.model_router_installations
+SET usage_bypass_enabled = $1::boolean,
+    usage_bypass_threshold = $2,
+    updated_at = NOW()
+WHERE id = $3::uuid
+  AND external_id = $4::varchar
+  AND deleted_at IS NULL
+`
+
+type UpdateModelRouterInstallationUsageBypassParams struct {
+	UsageBypassEnabled   bool
+	UsageBypassThreshold *float64
+	ID                   uuid.UUID
+	ExternalID           string
+}
+
+// Sets the subscription usage-bypass gate, scoped to an external_id to prevent
+// cross-tenant updates. enabled toggles the gate; threshold is the [0, 1]
+// utilization at/above which the gate disengages and normal routing takes over.
+// A NULL threshold means "use the deployment default" at request time.
+//
+//	UPDATE router.model_router_installations
+//	SET usage_bypass_enabled = $1::boolean,
+//	    usage_bypass_threshold = $2,
+//	    updated_at = NOW()
+//	WHERE id = $3::uuid
+//	  AND external_id = $4::varchar
+//	  AND deleted_at IS NULL
+func (q *Queries) UpdateModelRouterInstallationUsageBypass(ctx context.Context, arg UpdateModelRouterInstallationUsageBypassParams) error {
+	_, err := q.db.Exec(ctx, updateModelRouterInstallationUsageBypass,
+		arg.UsageBypassEnabled,
+		arg.UsageBypassThreshold,
+		arg.ID,
+		arg.ExternalID,
+	)
 	return err
 }

--- a/internal/sqlc/models.go
+++ b/internal/sqlc/models.go
@@ -76,6 +76,8 @@ type RouterModelRouterInstallation struct {
 	ExcludedModels       []string
 	ExcludedProviders    []string
 	RoutingQualityWeight *float64
+	UsageBypassEnabled   bool
+	UsageBypassThreshold *float64
 }
 
 type RouterModelRouterRequestTelemetry struct {


### PR DESCRIPTION
## Summary

Lets a customer say *"keep serving my own subscription until N% of my plan is used, then let the router kick in."* While the caller's Claude subscription has headroom, the router passes their request **straight through to the model they asked for** — no cluster routing, no substitution, and **no billing debit** (the turn is paid for by the customer's own plan). Once observed utilization crosses the installation's threshold, the gate disengages and the normal routing path (scorer + the existing subscription-aware cost discount) conserves the remainder.

This supersedes the abandoned binary-bypass PR #108: it reuses the `usage.Observer` that subscription-aware routing already feeds (shared signal + credential key) instead of standing up a second header-observing mechanism, and it's per-installation + opt-in rather than a global env flag.

### Behavior

| Regime | Behavior | Billing |
|---|---|---|
| Under threshold (or cold start) | passthrough to the **requested** model on the caller's subscription | **no debit** |
| At/over threshold | normal routing (scorer + subsidy discount) | charged as today |

Gate engages only when **all** hold: installation has `usage_bypass_enabled`; a Claude subscription credential is present; the requested model is Anthropic-served; observed utilization `< threshold` (nil threshold → 0.95 default; no observation yet → bypass to prime the observer). Excluded models still force routing so a tenant policy block can't be served via the bypass.

### Changes
- **Migration 0026**: `usage_bypass_enabled bool NOT NULL DEFAULT false` + `usage_bypass_threshold double precision` on `model_router_installations`.
- `auth.Installation` fields + `UpdateUsageBypass` repo method + converter mapping; auth middleware injects `UsageBypassConfig` onto the request ctx alongside the routing-knobs dial.
- `internal/proxy/usage_bypass.go`: `usageBypassEngaged` gate + `bypassToAnthropic` dispatch (skips scorer/planner/pin/cache **and** `fireBilling`).
- `ProxyMessages` consults the gate before `runTurnLoop`.
- Refreshes `internal/proxy/usage` CLAUDE/AGENTS docs, which still described the old env-var bypass rather than the shipped subsidy observer.

### Test plan
- [x] `go build ./...`, `go vet ./...`, `gofmt` clean
- [x] New `usage_bypass_test.go`: below-threshold skips scorer + serves requested model; at-threshold engages routing; cold-start bypasses; gate-disabled / no-subscription / excluded-model all engage routing
- [x] `go test ./internal/proxy/... ./internal/auth/... ./internal/postgres/... ./internal/server/...` green
- [ ] Local smoke with `wv mr` after merge + gitlink bump

> Dashboard wiring (GraphQL query/mutation + the toggle + threshold slider in the router settings UI) lands as a follow-up in the WorkWeave repo after the gitlink bump — router owns the shared-schema column and deploys first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)