### PR TITLE
fix(billing): charge 0% on subscription-served turns (Anthropic + Codex)

### DIFF
--- a/internal/billing/service.go
+++ b/internal/billing/service.go
@@ -34,12 +34,6 @@ func HasOverrideFromContext(ctx context.Context) bool {
 // constraint on router.organization_credit_ledger.entry_type.
 const EntryTypeInference = "inference"
 
-// SubscriptionFeeRate is the fraction of notional upstream cost debited for a
-// turn served on the customer's own Anthropic subscription. The subscription
-// covers the underlying tokens, so Weave charges only this routing margin
-// rather than the full cost it charges for Weave-fronted (credit) usage.
-const SubscriptionFeeRate = 0.05
-
 // MinBalanceMicros: new requests 402 when balance <= this (USD micros).
 // 0 matches OpenAI/Anthropic prepaid semantics — block at zero, let
 // in-flight debits settle (post-request balance can dip by one req cost).
@@ -109,18 +103,18 @@ type DebitInferenceParams struct {
 	Pricing         catalog.Pricing
 	HasOverride     bool
 	// SubscriptionServed is true when the turn was served on the customer's own
-	// Anthropic subscription token. Such turns debit only SubscriptionFeeRate of
-	// the notional cost — their plan already covers the tokens.
+	// Anthropic or Codex subscription token. Weave charges nothing for these —
+	// the customer's plan already paid for the tokens.
 	SubscriptionServed bool
 }
 
 // DebitForInference computes the raw upstream cost and writes one ledger
 // row. For Weave-fronted usage there is no markup math — margin is collected
-// at top-up by the backend and the router debits at cost. The two exceptions
-// debit less than cost: an override pass-through debits 0, and a turn served
-// on the customer's own Anthropic subscription debits only SubscriptionFeeRate
-// of cost (their plan covers the tokens). NotionalCostMicros always records
-// the full would-be cost regardless.
+// at top-up by the backend and the router debits at cost. Two cases debit 0:
+// an override pass-through, and a turn served on the customer's own
+// subscription (Anthropic or Codex) — their plan already covers the tokens, so
+// Weave charges nothing for routing them. NotionalCostMicros always records
+// the full would-be cost regardless, as a shadow trail.
 //
 // Returns the post-debit balance (0 on override since balance is
 // unchanged but the ledger row was recorded with the current balance).
@@ -128,10 +122,11 @@ func (s *Service) DebitForInference(ctx context.Context, p DebitInferenceParams)
 	notional := computeNotionalMicros(p)
 	delta := -notional
 	switch {
-	case p.HasOverride:
+	case p.HasOverride, p.SubscriptionServed:
+		// Override pass-through, or a turn the customer's own subscription
+		// already paid for — debit nothing. The notional cost is still recorded
+		// below as a shadow billing trail.
 		delta = 0
-	case p.SubscriptionServed:
-		delta = -subscriptionFeeMicros(notional)
 	}
 	return s.repo.DebitInference(ctx, DebitParams{
 		OrganizationID:     p.OrganizationID,
@@ -141,12 +136,6 @@ func (s *Service) DebitForInference(ctx context.Context, p DebitInferenceParams)
 		RouterRequestID:    p.RouterRequestID,
 		RouterModel:        p.Model,
 	})
-}
-
-// subscriptionFeeMicros returns SubscriptionFeeRate of the notional cost in USD
-// micros, rounded — the amount debited for a subscription-served turn.
-func subscriptionFeeMicros(notional int64) int64 {
-	return int64(math.Round(float64(notional) * SubscriptionFeeRate))
 }
 
 // computeNotionalMicros returns the would-be charge in USD micros. Always

--- a/internal/billing/service_test.go
+++ b/internal/billing/service_test.go
@@ -3,7 +3,6 @@ package billing_test
 import (
 	"context"
 	"errors"
-	"math"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -144,10 +143,10 @@ func TestDebitForInference_OverrideWritesZeroDeltaWithNotional(t *testing.T) {
 	assert.Equal(t, int64(6_750_000), repo.ledgerCalls[0].NotionalCostMicros, "notional records would-be charge")
 }
 
-func TestDebitForInference_SubscriptionDebitsOnlyTheFee(t *testing.T) {
-	// Served on the customer's own Anthropic subscription: the plan covers the
-	// tokens, so the ledger debits only SubscriptionFeeRate of cost while the
-	// notional row still records the full would-be cost.
+func TestDebitForInference_SubscriptionDebitsNothing(t *testing.T) {
+	// Served on the customer's own subscription: their plan already covers the
+	// tokens, so Weave charges nothing — the ledger debits 0 while the notional
+	// row still records the full would-be cost as a shadow trail.
 	repo := &fakeRepo{balanceRowExists: true, balanceMicros: 10_000_000}
 	svc := billing.NewService(repo)
 	p := catalog.Pricing{InputUSDPer1M: 3.00, OutputUSDPer1M: 15.00, CacheReadMultiplier: 0.10}
@@ -163,12 +162,10 @@ func TestDebitForInference_SubscriptionDebitsOnlyTheFee(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	notional := int64(6_750_000)                                              // 3.00 + 3.75
-	fee := int64(math.Round(float64(notional) * billing.SubscriptionFeeRate)) // 337_500
-	assert.Equal(t, 10_000_000-fee, balance, "subscription turns debit only the fee")
+	assert.Equal(t, int64(10_000_000), balance, "subscription turns debit nothing")
 	require.Len(t, repo.ledgerCalls, 1)
-	assert.Equal(t, -fee, repo.ledgerCalls[0].DeltaUsdMicros, "delta is the negative subscription fee, not full cost")
-	assert.Equal(t, notional, repo.ledgerCalls[0].NotionalCostMicros, "notional still records the full would-be cost")
+	assert.Equal(t, int64(0), repo.ledgerCalls[0].DeltaUsdMicros, "delta is zero — the customer's plan covers the tokens")
+	assert.Equal(t, int64(6_750_000), repo.ledgerCalls[0].NotionalCostMicros, "notional still records the full would-be cost")
 }
 
 func TestDebitForInference_OverrideBeatsSubscription(t *testing.T) {


### PR DESCRIPTION
## What

Stop charging the 5% routing margin on turns served by the customer's **own Claude/Codex subscription** OAuth token. Those turns are paid for by the customer's own plan — Weave shouldn't skim a margin on tokens it never paid for.

`DebitForInference` now debits **0** for a subscription-served turn (same as an override pass-through). The full notional cost is still written to the ledger (`NotionalCostMicros`) as a shadow trail, so we keep visibility without billing. Removes the now-unused `SubscriptionFeeRate` const and `subscriptionFeeMicros` helper.

Non-subscription (Weave-fronted / BYOK-routed) turns are **unaffected** — still debited at cost.

## Why

`servedOnSubscription` is true when the resolved credential is a Claude **or** Codex OAuth subscription token (`creds.OAuth`), so this covers both. Charging a % of *notional* on a cost the customer's own plan already covers surprises customers and is out of step with how gateways price routing on customer-owned credentials (the norm is 0% on BYOK/subscription + a platform/seat fee).

## Note

Revenue corollary for product: with subscription turns at 0%, subscription-heavy customers generate ~$0 of inference revenue (only non-subscription routing draws down credits, at cost). Monetizing those customers will need a per-seat/platform fee — separate decision, not in this PR.

## Test

`go build ./...` clean; `go test ./internal/billing/...` passes. `TestDebitForInference_SubscriptionDebitsOnlyTheFee` renamed → `...DebitsNothing` and updated to assert a 0 debit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)