### PR TITLE
fix(routing): gate agentic pool to harness-capable models so the price dial can demote Opus

### DIFF
--- a/internal/router/catalog/catalog.go
+++ b/internal/router/catalog/catalog.go
@@ -96,6 +96,24 @@ const (
 	ToolUseLow
 )
 
+// AgenticUse marks whether a model can reliably DRIVE an agentic harness — the
+// multi-step skill/tool-orchestration loop (Claude Code, opencode, …) where the
+// model must read tool results, follow a skill/tool protocol, and sustain a plan
+// across turns. This is a STRICTER axis than ToolUseQuality: a model can emit
+// well-formed tool calls (so it is not ToolUseLow) yet still be unable to run the
+// harness — e.g. minimax-m3 grepped the filesystem for a skill instead of
+// invoking it. AgenticUnknown (the zero value) means "no concerns recorded";
+// AgenticLow flags models the cluster scorer drops from has_tools turns so a
+// price-leaning quality dial demotes Opus to a cheaper HARNESS-CAPABLE model
+// (Sonnet, GLM, DeepSeek-Pro) instead of stranding the turn on the cheapest model
+// in the pool.
+type AgenticUse int
+
+const (
+	AgenticUnknown AgenticUse = iota
+	AgenticLow
+)
+
 // ImageInput marks whether a model accepts image content parts. ImageInputUnknown
 // (the zero value) means "no restriction recorded" — first-party models (Anthropic,
 // OpenAI, Google) are all multimodal, so they keep the default. ImageInputUnsupported
@@ -126,6 +144,11 @@ type Model struct {
 	// value (ToolUseUnknown) is the default — set ToolUseLow to remove the
 	// model from agentic argmax pools.
 	ToolUseQuality ToolUseQuality
+	// AgenticUse marks whether the model can drive an agentic harness under
+	// has_tools turns. Zero value (AgenticUnknown) is the default — set
+	// AgenticLow to keep the model out of the price dial's agentic demotion
+	// ladder (see the scorer's has_tools filter).
+	AgenticUse AgenticUse
 	// ImageInput marks whether the model accepts image content parts. Zero
 	// value (ImageInputUnknown) is the default — set ImageInputUnsupported on
 	// text-only models so the scorer keeps image-bearing turns off them.
@@ -269,7 +292,7 @@ var Models = []Model{
 	}},
 
 	// --- Google Gemini 3.x ---
-	{ID: "gemini-3.1-flash-lite-preview", Tier: TierLow, ContextWindow: 1_048_576, Providers: []ProviderBinding{
+	{ID: "gemini-3.1-flash-lite-preview", Tier: TierLow, ContextWindow: 1_048_576, AgenticUse: AgenticLow, Providers: []ProviderBinding{
 		{Provider: providers.ProviderGoogle, Price: Pricing{InputUSDPer1M: 0.10, OutputUSDPer1M: 0.40, CacheReadMultiplier: 0.10}},
 	}},
 	{ID: "gemini-3-flash-preview", Tier: TierMid, ContextWindow: 1_048_576, Providers: []ProviderBinding{
@@ -324,7 +347,7 @@ var Models = []Model{
 			Price: Pricing{InputUSDPer1M: 0.500, OutputUSDPer1M: 1.200}},
 		{Provider: providers.ProviderOpenRouter, Price: Pricing{InputUSDPer1M: 0.070, OutputUSDPer1M: 0.300}},
 	}},
-	{ID: "qwen/qwen3-next-80b-a3b-instruct", Tier: TierMid, ContextWindow: 262_144, ImageInput: ImageInputUnsupported, Providers: []ProviderBinding{
+	{ID: "qwen/qwen3-next-80b-a3b-instruct", Tier: TierMid, ContextWindow: 262_144, ImageInput: ImageInputUnsupported, AgenticUse: AgenticLow, Providers: []ProviderBinding{
 		{Provider: providers.ProviderBedrock, UpstreamID: "qwen.qwen3-next-80b-a3b-instruct",
 			Price: Pricing{InputUSDPer1M: 0.150, OutputUSDPer1M: 1.200}},
 		{Provider: providers.ProviderOpenRouter, Price: Pricing{InputUSDPer1M: 0.090, OutputUSDPer1M: 1.100}},
@@ -333,7 +356,7 @@ var Models = []Model{
 	// DeepInfra (Flash primary) and Fireworks (Pro primary) both serve the full
 	// window. The 131_072 carried over from V3.2 was filtering these out of any
 	// request over ~128K tokens (see excludeContextOverflowModels in proxy/service.go).
-	{ID: "deepseek/deepseek-v4-flash", Tier: TierLow, ContextWindow: 1_048_576, ImageInput: ImageInputUnsupported, Providers: []ProviderBinding{
+	{ID: "deepseek/deepseek-v4-flash", Tier: TierLow, ContextWindow: 1_048_576, ImageInput: ImageInputUnsupported, AgenticUse: AgenticLow, Providers: []ProviderBinding{
 		{Provider: providers.ProviderDeepInfra, UpstreamID: "deepseek-ai/DeepSeek-V4-Flash",
 			Price: Pricing{InputUSDPer1M: 0.140, OutputUSDPer1M: 0.280, CacheReadMultiplier: 0.20}},
 		{Provider: providers.ProviderOpenRouter, Price: Pricing{InputUSDPer1M: 0.140, OutputUSDPer1M: 0.280, CacheReadMultiplier: 0.10}},
@@ -406,7 +429,7 @@ var Models = []Model{
 	// window (the model's headline 1M is not what the Fireworks endpoint
 	// exposes). Unlike m2.7 it accepts image parts, so ImageInput is left at the
 	// default (image-capable).
-	{ID: "minimax/minimax-m3", Tier: TierHigh, ContextWindow: 512_000, Providers: []ProviderBinding{
+	{ID: "minimax/minimax-m3", Tier: TierHigh, ContextWindow: 512_000, AgenticUse: AgenticLow, Providers: []ProviderBinding{
 		{Provider: providers.ProviderFireworks, UpstreamID: "accounts/fireworks/models/minimax-m3",
 			Price: Pricing{InputUSDPer1M: 0.300, OutputUSDPer1M: 1.200, CacheReadMultiplier: 0.20}},
 		{Provider: providers.ProviderOpenRouter, Price: Pricing{InputUSDPer1M: 0.300, OutputUSDPer1M: 1.200, CacheReadMultiplier: 0.10}},

--- a/internal/router/catalog/catalog_test.go
+++ b/internal/router/catalog/catalog_test.go
@@ -135,6 +135,51 @@ func TestModel_ToolUseQualityDefaultsToUnknown(t *testing.T) {
 	assert.Equal(t, ToolUseUnknown, m.ToolUseQuality)
 }
 
+func TestAgenticLowSet_IncludesHarnessIncapableModels(t *testing.T) {
+	// These models emit valid tool calls (so they are not ToolUseLow) but can't
+	// sustain an agentic harness loop, so they must be dropped from has_tools
+	// turns — otherwise a price-leaning dial demotes Opus straight onto one of
+	// them (minimax-m3 grepping for a skill instead of running it is the
+	// canonical failure). If this fires, a row was unflagged or renamed.
+	set := AgenticLowSet()
+	for _, id := range []string{
+		"minimax/minimax-m3",
+		"qwen/qwen3-next-80b-a3b-instruct",
+		"gemini-3.1-flash-lite-preview",
+		"deepseek/deepseek-v4-flash",
+	} {
+		_, found := set[id]
+		assert.Truef(t, found, "%s must be marked AgenticLow", id)
+	}
+}
+
+func TestAgenticLowSet_OmitsHarnessCapableModels(t *testing.T) {
+	// The harness-capable demotion ladder must stay eligible on has_tools turns:
+	// Opus -> Sonnet -> the cheaper capable coders. haiku stays eligible too (it
+	// is a legitimate cheap tool model), so it must NOT be flagged.
+	set := AgenticLowSet()
+	for _, id := range []string{
+		"claude-opus-4-8",
+		"claude-sonnet-4-6",
+		"z-ai/glm-5.2",
+		"deepseek/deepseek-v4-pro",
+		"moonshotai/kimi-k2.6",
+		"qwen/qwen3-coder-next",
+		"claude-haiku-4-5",
+	} {
+		_, found := set[id]
+		assert.Falsef(t, found, "%s must NOT be in the AgenticLow set", id)
+	}
+}
+
+func TestModel_AgenticUseDefaultsToUnknown(t *testing.T) {
+	// Zero-value safety: an unset AgenticUse must default to AgenticUnknown so
+	// the scorer treats the model as harness-capable until proven otherwise.
+	// Guards against a future iota reorder flipping every row to AgenticLow.
+	var m Model
+	assert.Equal(t, AgenticUnknown, m.AgenticUse)
+}
+
 func TestImageUnsupportedSet_IncludesTextOnlyModels(t *testing.T) {
 	// Text-only OSS models reject image content parts with a 4xx (DeepInfra
 	// 405 "does not accept image input" on GLM-5.1 is the canonical case).

--- a/internal/router/catalog/lookup.go
+++ b/internal/router/catalog/lookup.go
@@ -154,6 +154,23 @@ func ToolUseLowSet() map[string]struct{} {
 	return out
 }
 
+// AgenticLowSet returns the set of model IDs whose AgenticUse is AgenticLow —
+// models that emit valid tool calls but can't sustain an agentic harness loop.
+// The cluster scorer subtracts this set from the eligible pool when req.HasTools
+// is true (on top of the ToolUseLow subtraction), so the price/quality dial
+// demotes Opus to a cheaper harness-capable model rather than the cheapest model
+// in the pool. Falls back to the unfiltered pool when the subtraction would empty
+// the eligible set so a routing decision is always returned. Mirrors ToolUseLowSet.
+func AgenticLowSet() map[string]struct{} {
+	out := make(map[string]struct{}, len(Models))
+	for _, m := range Models {
+		if m.AgenticUse == AgenticLow {
+			out[m.ID] = struct{}{}
+		}
+	}
+	return out
+}
+
 // ImageUnsupportedSet returns the set of model IDs flagged
 // ImageInputUnsupported. The cluster scorer subtracts this set from the
 // eligible pool when the inbound request carries image content, falling back

--- a/internal/router/cluster/artifacts/v0.70/metadata.yaml
+++ b/internal/router/cluster/artifacts/v0.70/metadata.yaml
@@ -84,31 +84,42 @@ training:
     - 0.80  # c15 trivial-NL
     # Per-cluster floor the QualityBias dial may not pull alpha below — the
     # LOWEST quality weight tolerated at maximum price-sensitivity. The dial
-    # collapses the per-cluster alpha vector to one uniform value, so without a
-    # floor a price-leaning dial cheaps out EVERY cluster, stranding agentic
-    # main-loop turns on models that can't drive the harness (tool/skill
-    # protocol — observed: minimax-m3 grepped for a skill instead of running
-    # it). Coding/agentic clusters floor at 0.88 so they stay on premium models
-    # at any dial; conversational/NL clusters floor at 0.55 — still much
-    # cheaper than their 0.80 default, but not collapsed to the cheapest model,
-    # so price-sensitive turns get the best quality their budget allows.
-    # Verify shifts with `cmd/routing-report --quality-bias`.
+    # collapses the per-cluster alpha vector to one uniform value, so the floor
+    # is what keeps a price-leaning dial from cheaping out a cluster onto its
+    # worst model. The earlier rev floored agentic/coding at 0.88, which pinned
+    # them on Opus at EVERY dial position — the dial could not bias cheaper at
+    # all there. That over-corrected for the real failure (an agentic turn
+    # collapsing onto a model that can't drive the harness — minimax-m3 grepped
+    # for a skill instead of running it). That failure is now handled on the
+    # right axis: the scorer drops catalog AgenticLow models from the eligible
+    # pool on has_tools turns (see catalog.AgenticLowSet + the scorer's
+    # agentic-harness filter), so the agentic demotion ladder only ever contains
+    # harness-capable models. With incapable models gated out, the floor no
+    # longer has to pin agentic on premium models, so coding/agentic floor at
+    # 0.30 — low enough that a price-leaning dial walks the full capable ladder
+    # (observed on v0.70: Opus at the quality end -> gemini-3.1-pro at mid dial
+    # -> gpt-5.4-mini at the cost extreme), high enough that quality still
+    # carries the blend at mid dial. At this floor the gate is load-bearing:
+    # without it the cost extreme falls through to gemini-3.1-flash-lite (an
+    # incapable model). Conversational/NL clusters keep 0.55 (no harness
+    # constraint there, so no gate to lean on). Verify the per-dial mix with
+    # `cmd/routing-report --quality-bias` before promoting.
     alpha_floor:
-    - 0.88  # c0  agentic/coding catch-all
-    - 0.88  # c1
+    - 0.30  # c0  agentic/coding catch-all
+    - 0.30  # c1
     - 0.55  # c2  conversational
-    - 0.88  # c3
-    - 0.88  # c4
-    - 0.88  # c5  coding/agentic
-    - 0.88  # c6
-    - 0.88  # c7
-    - 0.88  # c8
+    - 0.30  # c3
+    - 0.30  # c4
+    - 0.30  # c5  coding/agentic
+    - 0.30  # c6
+    - 0.30  # c7
+    - 0.30  # c8
     - 0.55  # c9  conversational/NL
     - 0.55  # c10 conversational/NL (primary)
     - 0.55  # c11 trivial-NL
-    - 0.88  # c12
-    - 0.88  # c13 hard-code
-    - 0.88  # c14
+    - 0.30  # c12
+    - 0.30  # c13 hard-code
+    - 0.30  # c14
     - 0.55  # c15 trivial-NL
     speed_weight: 0.0
     output_cost_ratio: 0.0

--- a/internal/router/cluster/distribution_test.go
+++ b/internal/router/cluster/distribution_test.go
@@ -187,24 +187,6 @@ func loadV0_70(t *testing.T) *Scorer {
 	return s
 }
 
-// clusterWinnerAt scores the centroid of cluster c at the given dial position
-// through the exact production path (defaultActiveKnobs -> applyDialAlpha ->
-// blendScoresV2 -> argmax over the top-P union) and returns the winning model.
-// withFloor=false reproduces the OLD uniform-dial behavior (the bug) so a test
-// can assert the floor changed the realized routing.
-func clusterWinnerAt(s *Scorer, c int, t float64, withFloor bool) string {
-	knobs := s.defaultActiveKnobs()
-	floor := knobs.AlphaFloor
-	if !withFloor {
-		floor = nil // reproduce the old uniform dial (no alpha_floor)
-	}
-	s.applyDialAlpha(t, knobs.Alpha, floor)
-	top := topPNearest(s.centroids.Row(c), s.centroids, s.cfg.TopP)
-	scores := s.blendScoresV2(top, knobs, s.models, nil)
-	winner, _ := argmax(scores, s.models)
-	return winner
-}
-
 func TestApplyDialAlpha_HoldsEachClusterAtItsDeclaredFloor(t *testing.T) {
 	s := loadV0_70(t)
 	knobs := s.defaultActiveKnobs()
@@ -240,32 +222,47 @@ func TestApplyDialAlpha_NilFloorIsUniformDial(t *testing.T) {
 	}
 }
 
-func TestApplyDialAlpha_AgenticStaysOffCheapModelAtLowDial(t *testing.T) {
+func TestApplyDialAlpha_AgenticStaysOnCapableModelAtLowDial(t *testing.T) {
 	// The reported bug, end to end: under a price-leaning dial the agentic
-	// cluster routed to minimax-m3 (a model that can't drive the Claude Code
-	// skill/tool protocol). Cluster 0 is the agentic catch-all. Without the
-	// floor (old uniform dial) the centroid routes to a cheap OSS model; with
-	// the floor it stays on a frontier model.
+	// cluster routed to a model that can't drive the Claude Code skill/tool
+	// protocol (minimax-m3 grepping for a skill instead of running it). Cluster 0
+	// is the agentic catch-all. The fix moved the guard off the quality WEIGHT
+	// (the old 0.88 floor pinned Opus and killed the dial) and onto the candidate
+	// POOL: on has_tools turns the scorer drops catalog.AgenticLowSet, so a low
+	// dial demotes Opus to the cheapest HARNESS-CAPABLE model instead of
+	// stranding the turn on an incapable one. The low alpha_floor only sets how
+	// far down the capable ladder the dial may travel.
 	s := loadV0_70(t)
-	const lowDial = 0.2
 
-	without := clusterWinnerAt(s, 0, lowDial, false)
-	with := clusterWinnerAt(s, 0, lowDial, true)
+	// Realized agentic alpha at the price extreme = the declared floor.
+	knobs := s.defaultActiveKnobs()
+	s.applyDialAlpha(0.0, knobs.Alpha, knobs.AlphaFloor)
+	top := topPNearest(s.centroids.Row(0), s.centroids, s.cfg.TopP)
 
-	assert.NotEqual(t, with, without,
-		"the floor must change the agentic winner at a low dial (old=%s)", without)
-	// The fixed winner must be a genuine agentic-capable frontier model, not the
-	// cheap pack the uniform dial fell through to.
-	frontier := map[string]struct{}{
-		"claude-opus-4-8":          {},
-		"claude-opus-4-7":          {},
-		"claude-sonnet-4-6":        {},
-		"gemini-3.1-pro-preview":   {},
-		"gpt-5.5":                  {},
-		"deepseek/deepseek-v4-pro": {},
+	low := catalog.AgenticLowSet()
+
+	// Precondition: WITHOUT the gate (full pool) the price-extreme dial falls
+	// through to an agentic-incapable cheap model — the bug the gate exists to
+	// fix. If this stops holding, the floor got too high to exercise the gate.
+	full, _ := argmax(s.blendScoresV2(top, knobs, s.models, nil), s.models)
+	_, fullIncapable := low[full]
+	require.Truef(t, fullIncapable,
+		"precondition: without the gate the price-extreme dial must fall through to an AgenticLow model, got %s", full)
+
+	// WITH the gate the realized winner is harness-capable, and the gate changed
+	// the routed model.
+	gated := make([]string, 0, len(s.models))
+	for _, m := range s.models {
+		if _, drop := low[m]; drop {
+			continue
+		}
+		gated = append(gated, m)
 	}
-	_, isFrontier := frontier[with]
-	assert.True(t, isFrontier, "with the floor the agentic cluster must route to a frontier model, got %s", with)
+	with, _ := argmax(s.blendScoresV2(top, knobs, gated, nil), gated)
+	_, withIncapable := low[with]
+	assert.Falsef(t, withIncapable,
+		"with the agentic-harness gate the price-extreme winner must be harness-capable, got %s", with)
+	assert.NotEqual(t, full, with, "the gate must change the realized agentic winner at the price extreme")
 }
 
 func TestRoutingDistribution_ExcludedModelNeverAppears(t *testing.T) {

--- a/internal/router/cluster/scorer.go
+++ b/internal/router/cluster/scorer.go
@@ -586,6 +586,38 @@ func (s *Scorer) Route(ctx context.Context, req router.Request) (router.Decision
 		}
 	}
 
+	// Agentic-harness filter. A has_tools turn is an agentic/main-loop turn, so
+	// drop any model the catalog marks AgenticLow — models that emit valid tool
+	// calls (hence not ToolUseLow) but can't sustain the skill/tool
+	// orchestration loop (observed: minimax-m3 grepped the filesystem for a
+	// skill instead of invoking it). This is the gate that lets the price/quality
+	// dial demote Opus to a cheaper HARNESS-CAPABLE model (Sonnet, GLM,
+	// DeepSeek-Pro) as it leans toward cost, instead of stranding the turn on the
+	// cheapest model in the pool — so the per-cluster alpha_floor no longer has to
+	// pin agentic on premium models. Soft filter with the same empty-pool
+	// fallback as the tool-use filter so a decision is always returned.
+	if req.HasTools {
+		if blacklist := catalog.AgenticLowSet(); len(blacklist) > 0 {
+			filtered := eligibleModels[:0:0]
+			var dropped []string
+			for _, m := range eligibleModels {
+				if _, drop := blacklist[m]; drop {
+					dropped = append(dropped, m)
+					continue
+				}
+				filtered = append(filtered, m)
+			}
+			if len(filtered) > 0 && len(dropped) > 0 {
+				log.Debug(
+					"Cluster scorer: agentic-harness blacklist applied",
+					"dropped_models", dropped,
+					"requested_model", req.RequestedModel,
+				)
+				eligibleModels = filtered
+			}
+		}
+	}
+
 	// Image-input filter. When the inbound carries image content, drop every
 	// model the catalog has marked ImageInputUnsupported (text-only OSS models
 	// that 4xx on image parts). Soft filter with the same empty-pool fallback as

--- a/internal/router/cluster/scorer_test.go
+++ b/internal/router/cluster/scorer_test.go
@@ -953,6 +953,74 @@ func TestScorer_HasToolsExcludesToolUseLowFromArgmax(t *testing.T) {
 	assert.Equal(t, "claude-opus-4-7", got.Model, "has_tools=true must drop ToolUseLow models from argmax")
 }
 
+// has_tools=true must subtract catalog.AgenticLowSet from the argmax pool so a
+// model that emits valid tool calls but can't drive the agentic harness
+// (minimax-m3) cannot win an agentic turn — this is what lets a price-leaning
+// dial demote Opus to a cheaper HARNESS-CAPABLE model instead of collapsing onto
+// the cheapest model in the pool.
+func TestScorer_HasToolsExcludesAgenticLowFromArgmax(t *testing.T) {
+	dim := EmbedDim
+	c0 := make([]float32, dim)
+	c0[0] = 1
+	cb := buildCentroidsBlob(t, 1, dim, c0)
+	// Ranking puts minimax-m3 above claude-opus so without the filter it would
+	// win; the agentic-harness filter must demote it on has_tools=true.
+	rb := []byte(`{"rankings": {"0": {
+		"minimax/minimax-m3": 0.95,
+		"claude-opus-4-7": 0.10
+	}}}`)
+	regb := []byte(`{
+		"deployed_models": [
+			{"model": "minimax/minimax-m3", "provider": "fireworks", "bench_column": "routerarena_minimax/minimax-m3"},
+			{"model": "claude-opus-4-7", "provider": "anthropic", "bench_column": "gpt-5", "proxy": true}
+		]
+	}`)
+	cfg := cfgForTest()
+	cfg.TopP = 1
+	s, err := NewScorer(bundleFromBlobs(t, "v-test-agenticfilter", cb, rb, regb), cfg, &fakeEmbedder{vec: makeOpusVec()},
+		map[string]struct{}{"fireworks": {}, "anthropic": {}})
+	require.NoError(t, err)
+
+	// No tools: minimax-m3 wins (highest score).
+	got, err := s.Route(context.Background(), router.Request{PromptText: strings.Repeat("x", 100)})
+	require.NoError(t, err)
+	assert.Equal(t, "minimax/minimax-m3", got.Model, "without tools, minimax-m3 should win on score")
+
+	// With tools: filter drops minimax-m3 → claude-opus wins.
+	got, err = s.Route(context.Background(), router.Request{PromptText: strings.Repeat("x", 100), HasTools: true})
+	require.NoError(t, err)
+	assert.Equal(t, "claude-opus-4-7", got.Model, "has_tools=true must drop AgenticLow models from argmax")
+}
+
+// Soft-filter regression: if the AgenticLow filter would empty the eligible
+// pool, fall back to the unfiltered set rather than 4xx-ing — a decision is
+// always returned even on an OSS-only deploy.
+func TestScorer_HasToolsFallsBackWhenAgenticFilterEmptiesPool(t *testing.T) {
+	dim := EmbedDim
+	c0 := make([]float32, dim)
+	c0[0] = 1
+	cb := buildCentroidsBlob(t, 1, dim, c0)
+	rb := []byte(`{"rankings": {"0": {
+		"minimax/minimax-m3": 0.95
+	}}}`)
+	regb := []byte(`{
+		"deployed_models": [
+			{"model": "minimax/minimax-m3", "provider": "fireworks", "bench_column": "routerarena_minimax/minimax-m3"}
+		]
+	}`)
+	cfg := cfgForTest()
+	cfg.TopP = 1
+	s, err := NewScorer(bundleFromBlobs(t, "v-test-agenticfallback", cb, rb, regb), cfg, &fakeEmbedder{vec: makeOpusVec()},
+		map[string]struct{}{"fireworks": {}})
+	require.NoError(t, err)
+
+	// has_tools=true: filter would empty the pool, so we keep minimax-m3
+	// rather than returning an error.
+	got, err := s.Route(context.Background(), router.Request{PromptText: strings.Repeat("x", 100), HasTools: true})
+	require.NoError(t, err)
+	assert.Equal(t, "minimax/minimax-m3", got.Model, "filter must fall back when it would empty the pool")
+}
+
 // Soft-filter regression: if the ToolUseLow filter would empty the eligible
 // pool, fall back to the unfiltered set rather than 4xx-ing — this is a
 // quality preference, not a correctness gate.


### PR DESCRIPTION
## Problem

The QualityBias price/quality dial could not bias cheaper for the agentic/coding clusters — **Opus 4.8 stayed in rotation at every dial position.**

Root cause: the guard was on the wrong axis. `applyDialAlpha` floors the per-cluster quality *weight* (`alpha[i] = max(dialAlpha, floor[i])`) at `0.88` for agentic clusters. A single scalar weight can't express "cheaper *but still harness-capable*": the agentic quality band is compressed while cost spans the full deployed range, so alpha has only two regimes — high → Opus pinned, low → cheapest-incapable model wins (the original `minimax-m3` "grepped for a skill instead of running it" cliff). `0.88` (from #501) avoided the cliff by disabling the dial for agentic entirely.

## Fix — move the guard from the weight to the candidate pool

1. **Catalog: new `AgenticUse` capability axis (`AgenticLow`)** — stricter than `ToolUseLow`: a model emits valid tool calls but can't sustain the skill/tool orchestration loop. Flags `minimax-m3`, `gemini-3.1-flash-lite`, `deepseek-v4-flash`, `qwen3-next-80b-instruct`. `AgenticLowSet()` mirrors `ToolUseLowSet()`. (`mimo-pro` left eligible — the catalog's documented sweep says the pro variant is stable.)
2. **Scorer:** on `has_tools` turns, subtract `AgenticLowSet` from the eligible pool via the existing soft-filter seam (empty-pool fallback preserved, so a decision is always returned).
3. **v0.70 metadata:** relax agentic `alpha_floor` `0.88 → 0.30` (in place, matching #501's pattern) so the dial walks the full harness-capable ladder.

## Validated behavior (probed the real v0.70 bundle)

Agentic demotion ladder is now:

| dial | model |
|---|---|
| quality end | `claude-opus-4-8` |
| mid | `gemini-3.1-pro-preview` |
| cost end | `gpt-5.4-mini` |

The gate is **load-bearing at the cost end**: without it the pool falls through to `gemini-3.1-flash-lite` (incapable); with it the cheapest *capable* coder wins. Covered by `TestScorer_HasToolsExcludesAgenticLowFromArgmax`, the rewritten `TestApplyDialAlpha_AgenticStaysOnCapableModelAtLowDial`, and catalog set tests.

## Known follow-up

The dial preview (`RoutingDistribution`) has no `has_tools` signal, so it scores over the full pool and will under-represent the gate at low dial (shows `gemini-flash-lite` for agentic clusters where real tool turns get `gpt-5.4-mini`). Actual routing is correct. Fully unifying them means making the gate cluster-level in `blendScoresV2`.

## Notes

- v0.70 geometry (centroids / quality_means) is **unchanged** — only routing knobs + a pool gate. Deploys via the normal gitlink bump.
- Offline sign-off: `cmd/routing-report --quality-bias`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)