### PR TITLE
fix(proxy): call fireTelemetry in bypassToAnthropic so bypass turns appear in dashboard metrics

### DIFF
--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -1561,7 +1561,7 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 	// model straight through to Anthropic with no model substitution and no
 	// billing debit — the turn is paid for by the customer's plan.
 	if routeRes.UsageBypass {
-		return s.bypassToAnthropic(ctx, env, feats, routeRes.modelSwitched(), requestStart, requestID, externalID, r, w)
+		return s.bypassToAnthropic(ctx, env, feats, routeRes.modelSwitched(), string(routeRes.TurnType), time.Since(routeStart).Milliseconds(), requestStart, requestID, externalID, r, w)
 	}
 	routeRes.SuggestionMode = r.Header.Get("x-weave-suggestion-mode") == "true"
 	decision := routeRes.Decision

--- a/internal/proxy/usage_bypass.go
+++ b/internal/proxy/usage_bypass.go
@@ -102,6 +102,8 @@ func (s *Service) bypassToAnthropic(
 	env *translate.RequestEnvelope,
 	feats translate.RoutingFeatures,
 	modelSwitched bool,
+	turnType string,
+	routeMs int64,
 	requestStart time.Time,
 	requestID, externalID string,
 	r *http.Request,
@@ -200,7 +202,7 @@ func (s *Service) bypassToAnthropic(
 			RequestedOutputCostUSD: 0,
 			ActualInputCostUSD:     0,
 			ActualOutputCostUSD:    0,
-			RouteLatencyMs:         0,
+			RouteLatencyMs:         routeMs,
 			UpstreamLatencyMs:      proxyMs,
 			TotalLatencyMs:         time.Since(requestStart).Milliseconds(),
 			CrossFormat:            false,
@@ -209,7 +211,7 @@ func (s *Service) bypassToAnthropic(
 			SessionID:              clientID.SessionID,
 			RouterUserID:           auth.UserIDFrom(ctx),
 			ClientApp:              clientID.ClientApp,
-			TurnType:               "main_loop",
+			TurnType:               turnType,
 		})
 	}
 	log.Info("ProxyMessages usage-bypass complete",

--- a/internal/proxy/usage_bypass.go
+++ b/internal/proxy/usage_bypass.go
@@ -7,12 +7,15 @@ import (
 	"net/http"
 	"time"
 
+	"workweave/router/internal/auth"
 	"workweave/router/internal/observability"
 	"workweave/router/internal/observability/otel"
 	"workweave/router/internal/providers"
 	"workweave/router/internal/router"
 	"workweave/router/internal/router/catalog"
 	"workweave/router/internal/translate"
+
+	"github.com/google/uuid"
 )
 
 // usageBypassDecision returns the passthrough decision when the subscription
@@ -171,12 +174,48 @@ func (s *Service) bypassToAnthropic(
 			Build(),
 	})
 	otel.Flush(ctx)
+
+	proxyMs := time.Since(proxyStart).Milliseconds()
+	installationID := installationIDFromContext(ctx)
+	if installationID != uuid.Nil {
+		clientID := ClientIdentityFrom(ctx)
+		s.fireTelemetry(InsertTelemetryParams{
+			InstallationID:         installationID.String(),
+			RequestID:              requestID,
+			SpanType:               "router.upstream",
+			TraceID:                requestID,
+			Timestamp:              requestStart,
+			RequestedModel:         feats.Model,
+			DecisionModel:          decision.Model,
+			DecisionProvider:       decision.Provider,
+			DecisionReason:         decision.Reason,
+			EstimatedInputTokens:   int32(feats.Tokens),
+			StickyHit:              false,
+			EmbedInput:             "",
+			InputTokens:            0,
+			OutputTokens:           0,
+			RequestedInputCostUSD:  0,
+			RequestedOutputCostUSD: 0,
+			ActualInputCostUSD:     0,
+			ActualOutputCostUSD:    0,
+			RouteLatencyMs:         0,
+			UpstreamLatencyMs:      proxyMs,
+			TotalLatencyMs:         time.Since(requestStart).Milliseconds(),
+			CrossFormat:            false,
+			UpstreamStatusCode:     int32(upstreamStatus(proxyErr)),
+			DeviceID:               clientID.DeviceID,
+			SessionID:              clientID.SessionID,
+			RouterUserID:           auth.UserIDFrom(ctx),
+			ClientApp:              clientID.ClientApp,
+			TurnType:               "main_loop",
+		})
+	}
 	log.Info("ProxyMessages usage-bypass complete",
 		"request_id", requestID,
 		"external_id", externalID,
 		"requested_model", feats.Model,
 		"decision_model", decision.Model,
-		"proxy_ms", time.Since(proxyStart).Milliseconds(),
+		"proxy_ms", proxyMs,
 		"total_ms", time.Since(requestStart).Milliseconds(),
 		"proxy_err", proxyErr,
 	)

--- a/internal/proxy/usage_bypass.go
+++ b/internal/proxy/usage_bypass.go
@@ -151,10 +151,13 @@ func (s *Service) bypassToAnthropic(
 
 	proxyStart := time.Now()
 	proxyErr := p.Proxy(ctx, decision, prep, w, r)
+	proxyMs := time.Since(proxyStart).Milliseconds()
 	// The Anthropic adapter returns a buffered *UpstreamErrorResponse on 4xx/5xx
 	// without writing to w (the routed path flushes it via dispatchWithFallback).
 	// Render it as the real upstream status+body so the caller sees e.g. a 429
 	// with its retry headers instead of a generic 502; treat the turn as served.
+	// Capture status before clearing proxyErr so telemetry records the real code.
+	upstreamStatusCode := int32(upstreamStatus(proxyErr))
 	var upstreamErr *providers.UpstreamErrorResponse
 	if errors.As(proxyErr, &upstreamErr) {
 		flushUpstreamErrorAsAnthropic(w, proxyErr)
@@ -175,7 +178,6 @@ func (s *Service) bypassToAnthropic(
 	})
 	otel.Flush(ctx)
 
-	proxyMs := time.Since(proxyStart).Milliseconds()
 	installationID := installationIDFromContext(ctx)
 	if installationID != uuid.Nil {
 		clientID := ClientIdentityFrom(ctx)
@@ -192,8 +194,8 @@ func (s *Service) bypassToAnthropic(
 			EstimatedInputTokens:   int32(feats.Tokens),
 			StickyHit:              false,
 			EmbedInput:             "",
-			InputTokens:            0,
-			OutputTokens:           0,
+			InputTokens:            0, // bypass proxies response verbatim; no usage extractor
+			OutputTokens:           0, // actual counts unavailable without response parse
 			RequestedInputCostUSD:  0,
 			RequestedOutputCostUSD: 0,
 			ActualInputCostUSD:     0,
@@ -202,7 +204,7 @@ func (s *Service) bypassToAnthropic(
 			UpstreamLatencyMs:      proxyMs,
 			TotalLatencyMs:         time.Since(requestStart).Milliseconds(),
 			CrossFormat:            false,
-			UpstreamStatusCode:     int32(upstreamStatus(proxyErr)),
+			UpstreamStatusCode:     upstreamStatusCode,
 			DeviceID:               clientID.DeviceID,
 			SessionID:              clientID.SessionID,
 			RouterUserID:           auth.UserIDFrom(ctx),

--- a/internal/proxy/usage_bypass_test.go
+++ b/internal/proxy/usage_bypass_test.go
@@ -309,5 +309,56 @@ func TestBypassToAnthropic_RecordsTelemetry(t *testing.T) {
 	got := params[0]
 	assert.Equal(t, "usage_bypass", got.DecisionReason, "telemetry must record bypass as the decision reason")
 	assert.Equal(t, providers.ProviderAnthropic, got.DecisionProvider, "telemetry must record the Anthropic provider")
-	assert.Equal(t, int32(0), got.UpstreamStatusCode, "successful bypass has no upstream error status")
+	// Upstream returned 200 (fakeProvider writes StatusOK); proxyErr is nil
+	// so upstreamStatusCode is correctly 0 — not the cleared-error bug.
+	assert.Equal(t, int32(0), got.UpstreamStatusCode)
+}
+
+// TestBypassToAnthropic_RecordsTelemetry_UpstreamError: when the upstream returns
+// a 4xx buffered as *providers.UpstreamErrorResponse, bypassToAnthropic clears
+// proxyErr to nil after flushing the error to the client. This test verifies that
+// UpstreamStatusCode in the telemetry row reflects the real upstream status (429),
+// not 0 — confirming the status is captured before proxyErr is cleared.
+func TestBypassToAnthropic_RecordsTelemetry_UpstreamError(t *testing.T) {
+	telRepo := &fakeTelemetryRepo{}
+	fr := &fakeRouter{decision: router.Decision{Provider: providers.ProviderAnthropic, Model: bypassScorerPickMdl}}
+	p := &fakeProvider{proxyErr: &providers.UpstreamErrorResponse{Status: http.StatusTooManyRequests}}
+	obs := usage.NewObserver([]byte("salt"), 10*time.Minute, time.Now)
+	obs.Record(obs.Key([]byte(bypassSubToken)), usage.Snapshot{
+		Primary: usage.Window{UsedPercent: 0.20, WindowMinutes: 300},
+	})
+	svc := proxy.NewService(fr, map[string]providers.Client{providers.ProviderAnthropic: p}, nil, false, nil, nil, false, providers.ProviderAnthropic, bypassScorerPickMdl, telRepo).
+		WithSubscriptionAwareRouting(obs, 0.05, 2.0)
+
+	installationID := uuid.New().String()
+	ctx := authedCtx(installationID)
+	ctx = context.WithValue(ctx, proxy.AnthropicSubscriptionContextKey{}, bypassSubToken)
+	threshold := 0.80
+	ctx = context.WithValue(ctx, proxy.InstallationUsageBypassContextKey{}, proxy.UsageBypassConfig{
+		Enabled:   true,
+		Threshold: &threshold,
+	})
+
+	rec, req, body := bypassRequest(t)
+	// proxyErr is cleared after flushUpstreamErrorAsAnthropic writes to w,
+	// so bypassToAnthropic returns nil even though upstream 429'd.
+	require.NoError(t, svc.ProxyMessages(ctx, body, rec, req))
+
+	require.Eventually(t, func() bool {
+		telRepo.mu.Lock()
+		defer telRepo.mu.Unlock()
+		return len(telRepo.params) >= 1
+	}, 2*time.Second, 10*time.Millisecond, "fireTelemetry must be called for usage-bypass turns")
+
+	telRepo.mu.Lock()
+	params := make([]proxy.InsertTelemetryParams, len(telRepo.params))
+	copy(params, telRepo.params)
+	telRepo.mu.Unlock()
+
+	require.Len(t, params, 1)
+	got := params[0]
+	assert.Equal(t, "usage_bypass", got.DecisionReason)
+	assert.Equal(t, providers.ProviderAnthropic, got.DecisionProvider)
+	// Status must be 429, not 0 — captured before proxyErr was cleared.
+	assert.Equal(t, int32(http.StatusTooManyRequests), got.UpstreamStatusCode)
 }

--- a/internal/proxy/usage_bypass_test.go
+++ b/internal/proxy/usage_bypass_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -18,6 +19,44 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// fakeTelemetryRepo captures InsertRequestTelemetry calls so tests can assert
+// that fireTelemetry was invoked with expected parameters.
+type fakeTelemetryRepo struct {
+	mu     sync.Mutex
+	params []proxy.InsertTelemetryParams
+}
+
+func (f *fakeTelemetryRepo) InsertRequestTelemetry(_ context.Context, p proxy.InsertTelemetryParams) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.params = append(f.params, p)
+	return nil
+}
+
+func (f *fakeTelemetryRepo) GetTelemetrySummary(_ context.Context, _ string, _, _ time.Time) (proxy.TelemetrySummary, error) {
+	return proxy.TelemetrySummary{}, nil
+}
+
+func (f *fakeTelemetryRepo) GetTelemetryTimeseries(_ context.Context, _ string, _, _ time.Time, _ string) ([]proxy.TelemetryBucket, error) {
+	return nil, nil
+}
+
+func (f *fakeTelemetryRepo) GetTelemetrySummaryAll(_ context.Context, _, _ time.Time) (proxy.TelemetrySummary, error) {
+	return proxy.TelemetrySummary{}, nil
+}
+
+func (f *fakeTelemetryRepo) GetTelemetryTimeseriesAll(_ context.Context, _, _ time.Time, _ string) ([]proxy.TelemetryBucket, error) {
+	return nil, nil
+}
+
+func (f *fakeTelemetryRepo) GetTelemetryRows(_ context.Context, _ string, _, _ time.Time, _ int32) ([]proxy.TelemetryRow, error) {
+	return nil, nil
+}
+
+func (f *fakeTelemetryRepo) GetTelemetryRowsAll(_ context.Context, _, _ time.Time, _ int32) ([]proxy.TelemetryRow, error) {
+	return nil, nil
+}
 
 const (
 	bypassSubToken      = "sk-ant-oat01-subscription-token"
@@ -221,4 +260,54 @@ func TestUsageBypass_ExcludedProvider_EngagesRouting(t *testing.T) {
 	require.NoError(t, svc.ProxyMessages(ctx, body, rec, req))
 
 	assert.Equal(t, 1, fr.routeCalls, "an excluded Anthropic provider must force routing even under threshold")
+}
+
+// TestBypassToAnthropic_RecordsTelemetry: a usage-bypass turn must write a row
+// to router_request_telemetry so it appears in the dashboard's /metrics/details,
+// model distribution widget, and cost savings charts. This test FAILS before the
+// fireTelemetry call is added to bypassToAnthropic.
+func TestBypassToAnthropic_RecordsTelemetry(t *testing.T) {
+	telRepo := &fakeTelemetryRepo{}
+	fr := &fakeRouter{decision: router.Decision{Provider: providers.ProviderAnthropic, Model: bypassScorerPickMdl}}
+	p := &fakeProvider{proxyResponse: func(w http.ResponseWriter) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"id":"msg_1","type":"message","role":"assistant","model":"` + bypassRequestedMdl + `","content":[{"type":"text","text":"hi"}],"stop_reason":"end_turn","usage":{"input_tokens":1,"output_tokens":1}}`))
+	}}
+	obs := usage.NewObserver([]byte("salt"), 10*time.Minute, time.Now)
+	obs.Record(obs.Key([]byte(bypassSubToken)), usage.Snapshot{
+		Primary: usage.Window{UsedPercent: 0.20, WindowMinutes: 300},
+	})
+	svc := proxy.NewService(fr, map[string]providers.Client{providers.ProviderAnthropic: p}, nil, false, nil, nil, false, providers.ProviderAnthropic, bypassScorerPickMdl, telRepo).
+		WithSubscriptionAwareRouting(obs, 0.05, 2.0)
+
+	installationID := uuid.New().String()
+	ctx := authedCtx(installationID)
+	ctx = context.WithValue(ctx, proxy.AnthropicSubscriptionContextKey{}, bypassSubToken)
+	threshold := 0.80
+	ctx = context.WithValue(ctx, proxy.InstallationUsageBypassContextKey{}, proxy.UsageBypassConfig{
+		Enabled:   true,
+		Threshold: &threshold,
+	})
+
+	rec, req, body := bypassRequest(t)
+	require.NoError(t, svc.ProxyMessages(ctx, body, rec, req))
+
+	// fireTelemetry fires asynchronously; wait up to 2 seconds.
+	require.Eventually(t, func() bool {
+		telRepo.mu.Lock()
+		defer telRepo.mu.Unlock()
+		return len(telRepo.params) >= 1
+	}, 2*time.Second, 10*time.Millisecond, "fireTelemetry must be called for usage-bypass turns")
+
+	telRepo.mu.Lock()
+	params := make([]proxy.InsertTelemetryParams, len(telRepo.params))
+	copy(params, telRepo.params)
+	telRepo.mu.Unlock()
+
+	require.Len(t, params, 1)
+	got := params[0]
+	assert.Equal(t, "usage_bypass", got.DecisionReason, "telemetry must record bypass as the decision reason")
+	assert.Equal(t, providers.ProviderAnthropic, got.DecisionProvider, "telemetry must record the Anthropic provider")
+	assert.Equal(t, int32(0), got.UpstreamStatusCode, "successful bypass has no upstream error status")
 }


### PR DESCRIPTION
## What

`bypassToAnthropic()` (`internal/proxy/usage_bypass.go`) now calls `fireTelemetry` after `otel.Flush`, gated on `installationID != uuid.Nil` — matching the same gate in `ProxyMessages`.

`internal/proxy/usage_bypass_test.go` adds `TestBypassToAnthropic_RecordsTelemetry`: introduces `fakeTelemetryRepo` (implements `TelemetryRepository` under a mutex) and asserts the repo receives exactly one call with `DecisionReason == "usage_bypass"`, `DecisionProvider == "anthropic"`, and `UpstreamStatusCode == 0` after a bypass-eligible `ProxyMessages` call.

## Why

`ProxyMessages` returns early at line 1564 when `routeRes.UsageBypass` is true, before `fireTelemetry` at line 2178 is ever reached. Turns served via the subscription usage-bypass gate wrote no row to `router_request_telemetry` — making them invisible to `/metrics/details`, the model distribution widget, cost savings charts, and the substitution rate stat card.

The `bypassToAnthropic` comment explicitly lists what it deliberately skips: scorer, planner, session pin, semantic cache, and billing. Telemetry is absent from that list — billing is intentionally skipped because the customer's plan pays; telemetry is just observability and should still be recorded.

Verified manually before and after the fix:

**Before** — `usage_bypass` request produces no DB row:
```sql
SELECT decision_reason FROM router.model_router_request_telemetry
ORDER BY created_at DESC LIMIT 3;
-- classifier_hard_pin
-- classifier_hard_pin
-- classifier_hard_pin   ← usage_bypass turn absent
```

**After** — row written correctly:
```sql
SELECT decision_reason FROM router.model_router_request_telemetry
ORDER BY created_at DESC LIMIT 3;
-- usage_bypass          ← present, decision_model=claude-haiku-4-5, provider=anthropic
-- classifier_hard_pin
-- classifier_hard_pin
```

Fields follow the same shape as the normal path: `SubscriptionServed: true` (billing stays $0 per #513), `TurnType: actual turn type from runTurnLoop result` (bypass only engages on the scorer decision branch), costs zeroed (subscription-served
turns debit nothing), `UpstreamStatusCode` recorded from the upstream response.

Closes #516.