### PR TITLE
feat(router): per-installation model priority ranking (soft preference bonus)

### DIFF
--- a/db/migrations/0027_installation-preferred-models.down.sql
+++ b/db/migrations/0027_installation-preferred-models.down.sql
@@ -1,0 +1,6 @@
+BEGIN;
+
+ALTER TABLE router.model_router_installations
+  DROP COLUMN preferred_models;
+
+COMMIT;

--- a/db/migrations/0027_installation-preferred-models.up.sql
+++ b/db/migrations/0027_installation-preferred-models.up.sql
@@ -1,0 +1,13 @@
+BEGIN;
+
+-- Per-installation model priority list (the "preferred models" ranking). An
+-- ordered set of model IDs the org wants the router to lean toward: array
+-- position is the rank (index 0 = first preference). The scorer turns each
+-- entry into a small additive, rank-decaying score bonus (a soft "finger on the
+-- scale") layered on top of the quality/cost blend -- it tilts close calls
+-- toward a preferred model but never overrides a clearly-better model for the
+-- task. Empty array means "no preference" -- the scorer routes on its merits.
+ALTER TABLE router.model_router_installations
+  ADD COLUMN preferred_models TEXT[] NOT NULL DEFAULT '{}';
+
+COMMIT;

--- a/internal/auth/installation.go
+++ b/internal/auth/installation.go
@@ -21,6 +21,12 @@ type Installation struct {
 	// ExcludedProviders is the per-installation provider exclusion list.
 	// Empty means no exclusion.
 	ExcludedProviders []string
+	// PreferredModels is the per-installation model priority ranking, in
+	// descending preference (index 0 = first preference). The scorer lifts each
+	// preferred model's score by a small, rank-decaying additive bonus so a
+	// preferred model wins close calls without overriding a clearly-better
+	// model. Empty means no preference.
+	PreferredModels []string
 	// RoutingQualityWeight is the per-installation routing preference (the
 	// "quality vs price" dial), stored as the scorer's quality weight (Alpha)
 	// -- a normalized fraction in [0, 1] where 1.0 biases routing fully toward

--- a/internal/postgres/converters.go
+++ b/internal/postgres/converters.go
@@ -19,6 +19,10 @@ func toAuthInstallation(row sqlc.RouterModelRouterInstallation) *auth.Installati
 	if excludedProviders == nil {
 		excludedProviders = []string{}
 	}
+	preferred := row.PreferredModels
+	if preferred == nil {
+		preferred = []string{}
+	}
 	return &auth.Installation{
 		ID:                   row.ID.String(),
 		ExternalID:           row.ExternalID,
@@ -29,6 +33,7 @@ func toAuthInstallation(row sqlc.RouterModelRouterInstallation) *auth.Installati
 		CreatedBy:            row.CreatedBy,
 		ExcludedModels:       excluded,
 		ExcludedProviders:    excludedProviders,
+		PreferredModels:      preferred,
 		RoutingQualityWeight: row.RoutingQualityWeight,
 		UsageBypassEnabled:   row.UsageBypassEnabled,
 		UsageBypassThreshold: row.UsageBypassThreshold,

--- a/internal/proxy/gemini.go
+++ b/internal/proxy/gemini.go
@@ -94,6 +94,7 @@ func (s *Service) ProxyGeminiGenerateContent(ctx context.Context, body []byte, w
 		PromptText:           promptText,
 		EnabledProviders:     s.enabledProvidersForRequest(ctx, providers.ProviderGoogle, r.Header),
 		ExcludedModels:       s.excludedModelsForRequest(ctx),
+		PreferredModels:      s.preferredModelsForRequest(ctx),
 		RoutingKnobs:         router.RoutingKnobsFromContext(ctx),
 	})
 	routeMs := time.Since(routeStart).Milliseconds()

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -256,6 +256,11 @@ type InstallationExcludedModelsContextKey struct{}
 // installation's provider exclusion list. Carried as []string.
 type InstallationExcludedProvidersContextKey struct{}
 
+// InstallationPreferredModelsContextKey is the context key for the authed
+// installation's model priority ranking. Carried as []string in descending
+// preference (index 0 = first preference). See preferredModelsForRequest.
+type InstallationPreferredModelsContextKey struct{}
+
 // InstallationRoutingKnobsContextKey is the context key for the authed
 // installation's persisted routing preference (the "quality vs price" dial).
 // Carried as *router.Overrides with only Alpha (quality weight) set; the
@@ -466,6 +471,26 @@ func (s *Service) excludedProvidersForRequest(ctx context.Context) map[string]st
 		out[p] = struct{}{}
 	}
 	return out
+}
+
+// installationPreferredModelsFromContext returns the per-installation model
+// priority ranking stashed on ctx by the auth middleware, or nil when none is
+// present.
+func installationPreferredModelsFromContext(ctx context.Context) []string {
+	v := ctx.Value(InstallationPreferredModelsContextKey{})
+	if v == nil {
+		return nil
+	}
+	out, _ := v.([]string)
+	return out
+}
+
+// preferredModelsForRequest returns the request's ordered model priority
+// ranking (index 0 = first preference). The installation list flows through
+// unchanged; the scorer ignores entries not in the eligible pool. There is no
+// env override (priority is a per-installation product knob, not an eval lever).
+func (s *Service) preferredModelsForRequest(ctx context.Context) []string {
+	return installationPreferredModelsFromContext(ctx)
 }
 
 // contextWindowOverheadFactor scales the raw body-bytes token estimate to
@@ -1548,6 +1573,7 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 		PromptText:           promptText,
 		EnabledProviders:     enabledProviders,
 		ExcludedModels:       excluded,
+		PreferredModels:      s.preferredModelsForRequest(ctx),
 		RoutingKnobs:         routingKnobsForRequest(ctx),
 	})
 	if routeErr != nil {
@@ -3120,6 +3146,7 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 		PromptText:           promptText,
 		EnabledProviders:     enabledProviders,
 		ExcludedModels:       excludedOAI,
+		PreferredModels:      s.preferredModelsForRequest(ctx),
 		RoutingKnobs:         routingKnobsForRequest(ctx),
 	})
 	routeMs := time.Since(routeStart).Milliseconds()

--- a/internal/router/cluster/distribution.go
+++ b/internal/router/cluster/distribution.go
@@ -107,7 +107,7 @@ func (s *Scorer) RoutingDistribution(gridN int, excludedModels, excludedProvider
 
 		counts := make(map[string]int, len(eligible))
 		for c := 0; c < k; c++ {
-			scores := s.blendScoresV2(centroidTopClusters[c], knobs, eligible, nil)
+			scores := s.blendScoresV2(centroidTopClusters[c], knobs, eligible, nil, nil)
 			winner, _ := argmax(scores, eligible)
 			if winner != "" {
 				counts[winner]++

--- a/internal/router/cluster/distribution_test.go
+++ b/internal/router/cluster/distribution_test.go
@@ -244,7 +244,7 @@ func TestApplyDialAlpha_AgenticStaysOnCapableModelAtLowDial(t *testing.T) {
 	// Precondition: WITHOUT the gate (full pool) the price-extreme dial falls
 	// through to an agentic-incapable cheap model — the bug the gate exists to
 	// fix. If this stops holding, the floor got too high to exercise the gate.
-	full, _ := argmax(s.blendScoresV2(top, knobs, s.models, nil), s.models)
+	full, _ := argmax(s.blendScoresV2(top, knobs, s.models, nil, nil), s.models)
 	_, fullIncapable := low[full]
 	require.Truef(t, fullIncapable,
 		"precondition: without the gate the price-extreme dial must fall through to an AgenticLow model, got %s", full)
@@ -258,7 +258,7 @@ func TestApplyDialAlpha_AgenticStaysOnCapableModelAtLowDial(t *testing.T) {
 		}
 		gated = append(gated, m)
 	}
-	with, _ := argmax(s.blendScoresV2(top, knobs, gated, nil), gated)
+	with, _ := argmax(s.blendScoresV2(top, knobs, gated, nil, nil), gated)
 	_, withIncapable := low[with]
 	assert.Falsef(t, withIncapable,
 		"with the agentic-harness gate the price-extreme winner must be harness-capable, got %s", with)

--- a/internal/router/cluster/scorer.go
+++ b/internal/router/cluster/scorer.go
@@ -281,7 +281,7 @@ func (s *Scorer) computeDialCalibration() []float64 {
 		}
 		counts := make(map[string]int, len(s.models))
 		for c := 0; c < k; c++ {
-			scores := s.blendScoresV2(centroidTopClusters[c], knobs, s.models, nil)
+			scores := s.blendScoresV2(centroidTopClusters[c], knobs, s.models, nil, nil)
 			winner, _ := argmax(scores, s.models)
 			// Mirror RoutingDistribution's accounting exactly: skip an empty
 			// winner so a cluster that flips between "" and a real model can't
@@ -654,6 +654,32 @@ func (s *Scorer) Route(ctx context.Context, req router.Request) (router.Decision
 		}
 	}
 
+	// Per-installation model priority: turn the ranked preference list into a
+	// per-model additive bonus over the eligible pool. Rank is compacted over
+	// eligible entries — a preferred model that's excluded, undeployed, or
+	// filtered above is skipped, so the highest still-available preference gets
+	// the strongest nudge and a stale preference is a no-op. Built once here and
+	// applied per top-P cluster inside blendScoresV2.
+	var priorityBonus map[string]float32
+	if len(req.PreferredModels) > 0 {
+		eligible := make(map[string]struct{}, len(eligibleModels))
+		for _, m := range eligibleModels {
+			eligible[m] = struct{}{}
+		}
+		priorityBonus = make(map[string]float32, len(req.PreferredModels))
+		rank := 0
+		for _, m := range req.PreferredModels {
+			if _, ok := eligible[m]; !ok {
+				continue
+			}
+			if _, dup := priorityBonus[m]; dup {
+				continue
+			}
+			priorityBonus[m] = priorityBonusFor(rank)
+			rank++
+		}
+	}
+
 	scoreStart := time.Now()
 	topClusters := topPNearest(vec, s.centroids, s.cfg.TopP)
 
@@ -745,7 +771,7 @@ func (s *Scorer) Route(ctx context.Context, req router.Request) (router.Decision
 			activeKnobs.PerModelVerbosity,
 		)
 
-		scores = s.blendScoresV2(topClusters, activeKnobs, eligibleModels, req.SubsidizedModelCostFactor)
+		scores = s.blendScoresV2(topClusters, activeKnobs, eligibleModels, req.SubsidizedModelCostFactor, priorityBonus)
 	} else {
 		// Legacy v1 flow: static cluster rankings, no cost axis at all — so there
 		// is no cost term to discount and req.SubsidizedModelCostFactor does not
@@ -962,12 +988,37 @@ var _ router.Router = (*Scorer)(nil)
 // additive bonus so it disturbs none of the quality/cost/speed blend weights.
 const subsidyMaxBonus float32 = 1.0
 
+// preferredBonusBase is the rank-1 priority score bonus a per-installation
+// "preferred model" receives, in the same units as the per-cluster blend
+// (≈[0,1]). A preferred model wins a cluster's argmax when no peer leads it by
+// more than this in blended score — a soft "finger on the scale" that tilts
+// close calls toward the preference without overriding a clearly-better model
+// for the task. Applied as a per-cluster additive bonus, mirroring the
+// subscription preference, so it disturbs none of the quality/cost/speed blend
+// weights.
+const preferredBonusBase float32 = 0.15
+
+// preferredBonusDecay shrinks the bonus by rank so lower preferences press the
+// scale less hard: bonus(rank) = preferredBonusBase * decay^rank (rank 0-based).
+// 0.55 yields rank 0 ≈ 0.15, rank 1 ≈ 0.08, rank 2 ≈ 0.045.
+const preferredBonusDecay float64 = 0.55
+
+// priorityBonusFor returns the additive per-cluster score bonus for a model at
+// the given zero-based preference rank (0 = first preference). Later ranks decay
+// toward zero; a negative rank yields no bonus.
+func priorityBonusFor(rank int) float32 {
+	if rank < 0 {
+		return 0
+	}
+	return preferredBonusBase * float32(math.Pow(preferredBonusDecay, float64(rank)))
+}
+
 // blendScoresV2 computes the v2 per-model blended scores for the given top-P
 // clusters under the effective knobs. Extracted from Route so the routing
 // distribution preview scores identically to live routing (single source of
 // truth for the cost/quality/speed blend). Caller owns knob validation and the
 // QualityBias->Alpha derivation; this method consumes the resolved alpha vector.
-func (s *Scorer) blendScoresV2(topClusters []int, activeKnobs DefaultRoutingKnobs, eligibleModels []string, subsidyFactors map[string]float64) map[string]float32 {
+func (s *Scorer) blendScoresV2(topClusters []int, activeKnobs DefaultRoutingKnobs, eligibleModels []string, subsidyFactors map[string]float64, priorityBonus map[string]float32) map[string]float32 {
 	// 2. Effective per-model cost (knob-dependent). Costs stay at FULL catalog
 	// scale for every model, INCLUDING subscription-covered ones. On a plan the
 	// dollar price is prepaid, but the catalog ratio still tracks how much plan
@@ -1145,6 +1196,15 @@ func (s *Scorer) blendScoresV2(topClusters []int, activeKnobs DefaultRoutingKnob
 			// Haiku for easy turns and Opus for hard ones.
 			if f, ok := subsidyFactors[m]; ok {
 				scores[m] += subsidyMaxBonus * float32(1.0-f)
+			}
+
+			// Per-installation model-priority preference: lift a preferred model
+			// by its rank-decaying bonus, per cluster. Additive (like the subsidy
+			// above) so it disturbs none of the blend weights — it only decides
+			// close calls, leaving the quality/cost spread to keep a clearly-better
+			// model ahead on hard clusters. Absent entry = no preference.
+			if b, ok := priorityBonus[m]; ok {
+				scores[m] += b
 			}
 		}
 	}

--- a/internal/router/cluster/scorer_test.go
+++ b/internal/router/cluster/scorer_test.go
@@ -258,6 +258,49 @@ func TestScorer_SubscriptionPicksCheapestSufficientWithinFamily(t *testing.T) {
 		"easy cluster: a subscribed family routes to the cheap sufficient model (Haiku, not Opus)")
 }
 
+// TestScorer_PreferredModelSoftNudge exercises the per-installation model
+// priority bonus. It must behave as a soft "finger on the scale": a preferred
+// model wins a close call but never overrides a clearly-better model for the
+// cluster, and a stale/unknown preference is a no-op. makeOpusVec aligns with
+// cluster 0, where Opus is quality-favored; the alpha override sets the blend's
+// quality weight so the Opus↔Haiku margin is tunable.
+func TestScorer_PreferredModelSoftNudge(t *testing.T) {
+	emb := &fakeEmbedder{vec: makeOpusVec()}
+	s := newV2BundleForTest(t, emb, v2BundleOpts{})
+	ctx := context.Background()
+	prompt := strings.Repeat("x", 100)
+
+	alpha := func(a float64) *router.Overrides { return &router.Overrides{Alpha: &a} }
+
+	// Close call (alpha 0.55): Opus leads Haiku by only ~0.10 in blended score.
+	closeReq := router.Request{PromptText: prompt, RoutingKnobs: alpha(0.55)}
+	base, err := s.Route(ctx, closeReq)
+	require.NoError(t, err)
+	require.Equal(t, "claude-opus-4-7", base.Model, "no preference: quality-favored model wins the close call")
+
+	// Preferring the trailing model flips the close call — the rank-0 bonus
+	// (~0.15) exceeds the ~0.10 margin.
+	prefHaiku := closeReq
+	prefHaiku.PreferredModels = []string{"claude-haiku-4-5"}
+	flipped, err := s.Route(ctx, prefHaiku)
+	require.NoError(t, err)
+	assert.Equal(t, "claude-haiku-4-5", flipped.Model, "a preferred model wins a close call")
+
+	// Clear win (alpha 0.9): Opus leads by ~0.80. The same preference must NOT
+	// override a clearly-better model — the soft-nudge quality floor.
+	clearReq := router.Request{PromptText: prompt, RoutingKnobs: alpha(0.9), PreferredModels: []string{"claude-haiku-4-5"}}
+	clear, err := s.Route(ctx, clearReq)
+	require.NoError(t, err)
+	assert.Equal(t, "claude-opus-4-7", clear.Model, "preference must not override a clearly-better model")
+
+	// Stale / unknown preference is ignored: routes identically to no preference.
+	staleReq := closeReq
+	staleReq.PreferredModels = []string{"does-not-exist"}
+	stale, err := s.Route(ctx, staleReq)
+	require.NoError(t, err)
+	assert.Equal(t, base.Model, stale.Model, "an unknown preferred model is a no-op")
+}
+
 // Removing any populated metadata field breaks routing telemetry rows.
 func TestScorer_PopulatesRoutingMetadata(t *testing.T) {
 	emb := &fakeEmbedder{vec: makeOpusVec()}

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -40,7 +40,14 @@ type Request struct {
 	// Per-request model exclusion — nil or empty means no exclusion.
 	// If filtering empties eligible set, scorer returns ErrNoEligibleProvider.
 	ExcludedModels map[string]struct{}
-	RoutingKnobs   *Overrides // NEW: parsed dynamic knobs
+	// PreferredModels is the per-installation model priority ranking, in
+	// descending preference (index 0 = first preference). The scorer lifts each
+	// preferred model's blended score by a small, rank-decaying additive bonus
+	// (a soft "finger on the scale") so a preferred model wins close calls but
+	// never overrides a clearly-better model for the task. Entries not in the
+	// eligible pool are ignored. nil or empty means no preference.
+	PreferredModels []string
+	RoutingKnobs    *Overrides // NEW: parsed dynamic knobs
 	// SubsidizedModelCostFactor is the per-model rate-limit headroom factor in
 	// [epsilon, 1] for models a caller's presented subscription covers, derived
 	// from observed headroom (see internal/proxy/usage): ~epsilon when the sub's

--- a/internal/server/middleware/auth.go
+++ b/internal/server/middleware/auth.go
@@ -122,6 +122,9 @@ func withAPIKey(svc *auth.Service, byokDisabled bool) gin.HandlerFunc {
 			if len(installation.ExcludedProviders) > 0 {
 				ctx = context.WithValue(ctx, proxy.InstallationExcludedProvidersContextKey{}, installation.ExcludedProviders)
 			}
+			if len(installation.PreferredModels) > 0 {
+				ctx = context.WithValue(ctx, proxy.InstallationPreferredModelsContextKey{}, installation.PreferredModels)
+			}
 			if installation.RoutingQualityWeight != nil {
 				// The stored weight is the user-facing dial position, so it
 				// flows in as QualityBias (per-cluster, dispersion-aware), not

--- a/internal/sqlc/model_router_api_keys.sql.go
+++ b/internal/sqlc/model_router_api_keys.sql.go
@@ -92,7 +92,7 @@ func (q *Queries) CreateModelRouterAPIKey(ctx context.Context, arg CreateModelRo
 }
 
 const getActiveModelRouterAPIKeyWithInstallationByHash = `-- name: GetActiveModelRouterAPIKeyWithInstallationByHash :one
-SELECT k.id, k.installation_id, k.external_id, k.name, k.key_prefix, k.key_hash, k.key_suffix, k.last_used_at, k.created_at, k.deleted_at, k.created_by, i.id, i.external_id, i.name, i.created_at, i.updated_at, i.deleted_at, i.created_by, i.excluded_models, i.excluded_providers, i.routing_quality_weight, i.usage_bypass_enabled, i.usage_bypass_threshold
+SELECT k.id, k.installation_id, k.external_id, k.name, k.key_prefix, k.key_hash, k.key_suffix, k.last_used_at, k.created_at, k.deleted_at, k.created_by, i.id, i.external_id, i.name, i.created_at, i.updated_at, i.deleted_at, i.created_by, i.excluded_models, i.excluded_providers, i.routing_quality_weight, i.usage_bypass_enabled, i.usage_bypass_threshold, i.preferred_models
 FROM router.model_router_api_keys k
 INNER JOIN router.model_router_installations i ON i.id = k.installation_id
 WHERE k.key_hash = $1::varchar
@@ -111,7 +111,7 @@ type GetActiveModelRouterAPIKeyWithInstallationByHashRow struct {
 // both sides so a soft-deleted installation invalidates all its keys without per-key
 // updates.
 //
-//	SELECT k.id, k.installation_id, k.external_id, k.name, k.key_prefix, k.key_hash, k.key_suffix, k.last_used_at, k.created_at, k.deleted_at, k.created_by, i.id, i.external_id, i.name, i.created_at, i.updated_at, i.deleted_at, i.created_by, i.excluded_models, i.excluded_providers, i.routing_quality_weight, i.usage_bypass_enabled, i.usage_bypass_threshold
+//	SELECT k.id, k.installation_id, k.external_id, k.name, k.key_prefix, k.key_hash, k.key_suffix, k.last_used_at, k.created_at, k.deleted_at, k.created_by, i.id, i.external_id, i.name, i.created_at, i.updated_at, i.deleted_at, i.created_by, i.excluded_models, i.excluded_providers, i.routing_quality_weight, i.usage_bypass_enabled, i.usage_bypass_threshold, i.preferred_models
 //	FROM router.model_router_api_keys k
 //	INNER JOIN router.model_router_installations i ON i.id = k.installation_id
 //	WHERE k.key_hash = $1::varchar
@@ -144,6 +144,7 @@ func (q *Queries) GetActiveModelRouterAPIKeyWithInstallationByHash(ctx context.C
 		&i.RouterModelRouterInstallation.RoutingQualityWeight,
 		&i.RouterModelRouterInstallation.UsageBypassEnabled,
 		&i.RouterModelRouterInstallation.UsageBypassThreshold,
+		&i.RouterModelRouterInstallation.PreferredModels,
 	)
 	return i, err
 }

--- a/internal/sqlc/model_router_installations.sql.go
+++ b/internal/sqlc/model_router_installations.sql.go
@@ -22,7 +22,7 @@ VALUES (
     $2::varchar,
     $3
 )
-RETURNING id, external_id, name, created_at, updated_at, deleted_at, created_by, excluded_models, excluded_providers, routing_quality_weight, usage_bypass_enabled, usage_bypass_threshold
+RETURNING id, external_id, name, created_at, updated_at, deleted_at, created_by, excluded_models, excluded_providers, routing_quality_weight, usage_bypass_enabled, usage_bypass_threshold, preferred_models
 `
 
 type CreateModelRouterInstallationParams struct {
@@ -43,7 +43,7 @@ type CreateModelRouterInstallationParams struct {
 //	    $2::varchar,
 //	    $3
 //	)
-//	RETURNING id, external_id, name, created_at, updated_at, deleted_at, created_by, excluded_models, excluded_providers, routing_quality_weight, usage_bypass_enabled, usage_bypass_threshold
+//	RETURNING id, external_id, name, created_at, updated_at, deleted_at, created_by, excluded_models, excluded_providers, routing_quality_weight, usage_bypass_enabled, usage_bypass_threshold, preferred_models
 func (q *Queries) CreateModelRouterInstallation(ctx context.Context, arg CreateModelRouterInstallationParams) (RouterModelRouterInstallation, error) {
 	row := q.db.QueryRow(ctx, createModelRouterInstallation, arg.ExternalID, arg.Name, arg.CreatedBy)
 	var i RouterModelRouterInstallation
@@ -60,12 +60,13 @@ func (q *Queries) CreateModelRouterInstallation(ctx context.Context, arg CreateM
 		&i.RoutingQualityWeight,
 		&i.UsageBypassEnabled,
 		&i.UsageBypassThreshold,
+		&i.PreferredModels,
 	)
 	return i, err
 }
 
 const getModelRouterInstallation = `-- name: GetModelRouterInstallation :one
-SELECT id, external_id, name, created_at, updated_at, deleted_at, created_by, excluded_models, excluded_providers, routing_quality_weight, usage_bypass_enabled, usage_bypass_threshold
+SELECT id, external_id, name, created_at, updated_at, deleted_at, created_by, excluded_models, excluded_providers, routing_quality_weight, usage_bypass_enabled, usage_bypass_threshold, preferred_models
 FROM router.model_router_installations
 WHERE id = $1::uuid
   AND external_id = $2::varchar
@@ -79,7 +80,7 @@ type GetModelRouterInstallationParams struct {
 
 // Gets an installation by id, scoped to an external_id to prevent cross-tenant access.
 //
-//	SELECT id, external_id, name, created_at, updated_at, deleted_at, created_by, excluded_models, excluded_providers, routing_quality_weight, usage_bypass_enabled, usage_bypass_threshold
+//	SELECT id, external_id, name, created_at, updated_at, deleted_at, created_by, excluded_models, excluded_providers, routing_quality_weight, usage_bypass_enabled, usage_bypass_threshold, preferred_models
 //	FROM router.model_router_installations
 //	WHERE id = $1::uuid
 //	  AND external_id = $2::varchar
@@ -100,12 +101,13 @@ func (q *Queries) GetModelRouterInstallation(ctx context.Context, arg GetModelRo
 		&i.RoutingQualityWeight,
 		&i.UsageBypassEnabled,
 		&i.UsageBypassThreshold,
+		&i.PreferredModels,
 	)
 	return i, err
 }
 
 const listModelRouterInstallationsForExternalID = `-- name: ListModelRouterInstallationsForExternalID :many
-SELECT id, external_id, name, created_at, updated_at, deleted_at, created_by, excluded_models, excluded_providers, routing_quality_weight, usage_bypass_enabled, usage_bypass_threshold
+SELECT id, external_id, name, created_at, updated_at, deleted_at, created_by, excluded_models, excluded_providers, routing_quality_weight, usage_bypass_enabled, usage_bypass_threshold, preferred_models
 FROM router.model_router_installations
 WHERE external_id = $1::varchar
   AND deleted_at IS NULL
@@ -114,7 +116,7 @@ ORDER BY created_at DESC
 
 // ListModelRouterInstallationsForExternalID
 //
-//	SELECT id, external_id, name, created_at, updated_at, deleted_at, created_by, excluded_models, excluded_providers, routing_quality_weight, usage_bypass_enabled, usage_bypass_threshold
+//	SELECT id, external_id, name, created_at, updated_at, deleted_at, created_by, excluded_models, excluded_providers, routing_quality_weight, usage_bypass_enabled, usage_bypass_threshold, preferred_models
 //	FROM router.model_router_installations
 //	WHERE external_id = $1::varchar
 //	  AND deleted_at IS NULL
@@ -141,6 +143,7 @@ func (q *Queries) ListModelRouterInstallationsForExternalID(ctx context.Context,
 			&i.RoutingQualityWeight,
 			&i.UsageBypassEnabled,
 			&i.UsageBypassThreshold,
+			&i.PreferredModels,
 		); err != nil {
 			return nil, err
 		}

--- a/internal/sqlc/models.go
+++ b/internal/sqlc/models.go
@@ -78,6 +78,7 @@ type RouterModelRouterInstallation struct {
 	RoutingQualityWeight *float64
 	UsageBypassEnabled   bool
 	UsageBypassThreshold *float64
+	PreferredModels      []string
 }
 
 type RouterModelRouterRequestTelemetry struct {


### PR DESCRIPTION
## What

Adds a per-installation **model priority ranking** ("preferred models") that biases routing toward specific models — a customer ask (Redwood) to "put a finger on the scale" toward, e.g., GLM-5.2 first then Kimi-2.7 (both already live in v0.70, US-hosted via Fireworks).

## How

Each preferred model receives a small, **rank-decaying additive score bonus** in the cluster scorer's per-cluster blend — the same mechanism as the existing subscription-preference bonus, which "disturbs none of the quality/cost/speed blend weights":

- `priorityBonusFor(rank)` = `0.15 * 0.55^rank` → rank 0 ≈ **+0.15**, rank 1 ≈ **+0.08**, rank 2 ≈ **+0.045**.
- Applied per top-P cluster in `blendScoresV2`, so a preferred model wins a **close call** but never overrides a **clearly-better** model for the task (soft nudge, quality floor intact).
- The bonus map is built over the **eligible pool** — a preferred model that's excluded, undeployed, or filtered out (tools/images/provider) is a no-op, and rank is compacted so the highest still-available preference gets the strongest nudge.

## Plumbing (mirrors `excluded_models` / `routing_quality_weight`)

- **migration 0026**: `preferred_models TEXT[]` on `model_router_installations` (ordered; array index = rank). sqlc regenerated.
- `auth.Installation.PreferredModels` + converter mapping (read path).
- `proxy.InstallationPreferredModelsContextKey` + `preferredModelsForRequest`; middleware stashes the list; all three request-build sites (Anthropic / OpenAI / Gemini) set `router.Request.PreferredModels`.
- scorer `Route` builds the bonus map and passes it to `blendScoresV2`.

## Safety

The default routing path is **inert when no preference is set** — `priorityBonus` is `nil`, so `blendScoresV2` adds nothing and the blend is byte-identical. `computeDialCalibration` and the routing-distribution preview pass `nil`, so dial calibration and the preview are unchanged. Existing traffic is unaffected.

## Tests

- `TestScorer_PreferredModelSoftNudge`: a preferred model flips a close call (α 0.55, ~0.10 margin) but does **not** override a clear win (α 0.9, ~0.80 margin); a stale/unknown preference is a no-op.
- Full router suite + typecheck green (`wv mr test`, `wv mr tc`).

## Follow-up (separate WorkWeave PR)

Bump the WorkWeave gitlink to this commit and add the GraphQL surface + backend service/repo + the drag-to-rank "Preferred models" settings panel (writes the column directly via WorkWeave's own adapter; managed mode doesn't mount the router admin API).

🤖 Generated with [Claude Code](https://claude.com/claude-code)