### PR TITLE
feat(routing-report): add --per-prompt-json flag for replay scoring

### DIFF
--- a/cmd/routing-report/main.go
+++ b/cmd/routing-report/main.go
@@ -144,6 +144,7 @@ func main() {
 		topP         = flag.Int("top-p", 2, "top-P clusters blended per decision (prod runs 2)")
 		qualityBias  = flag.Float64("quality-bias", -1, "QualityBias dial position in [0,1] to route at; <0 uses the bundle's default knobs (no dial)")
 		outPath      = flag.String("out", "", "write markdown here instead of stdout")
+		perPromptOut = flag.String("per-prompt-json", "", "also dump [{id,model}] per probe (target chosen model, corpus order) here")
 	)
 	flag.Parse()
 
@@ -178,6 +179,23 @@ func main() {
 	tgt, err := routeCorpus(*artifactsDir, *target, probes, embedder, *topP, *qualityBias)
 	if err != nil {
 		fatal("route target %s: %v", *target, err)
+	}
+	if *perPromptOut != "" {
+		type pp struct {
+			ID    string `json:"id"`
+			Model string `json:"model"`
+		}
+		rows := make([]pp, len(probes))
+		for i, p := range probes {
+			rows[i] = pp{ID: p.ID, Model: tgt.chosen[i]}
+		}
+		buf, mErr := json.MarshalIndent(rows, "", "  ")
+		if mErr != nil {
+			fatal("marshal per-prompt: %v", mErr)
+		}
+		if wErr := os.WriteFile(*perPromptOut, buf, 0o644); wErr != nil {
+			fatal("write per-prompt-json: %v", wErr)
+		}
 	}
 	var base *routeResult
 	if *baseline != *target {


### PR DESCRIPTION
## What

Adds an additive `--per-prompt-json <path>` flag to `cmd/routing-report`. When set, it writes the target version's per-probe routed pick as `[{id, model}]` in corpus order to the given path, alongside the normal markdown report.

## Why

This is the local-only dev-tool patch the replay scorer (in the sibling `router-internal/eval/` harness) depends on. Committing it removes the dependency of a CI gate on an uncommitted local patch.

## Behavior

- Additive only — no change to the Scorer, the markdown output, or any existing flag.
- The dump only fires when `--per-prompt-json` is set, reusing the already-computed target route (`tgt.chosen[i]` per corpus prompt).
- Reuses the file's existing `fatal()` error helper and the already-imported `json` / `os` packages.

## Test

```
go build -tags no_onnx ./cmd/routing-report/...   # OK
go vet   -tags no_onnx ./cmd/routing-report/...   # OK
gofmt -l cmd/routing-report/main.go               # clean
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JnJ7bzxbMVgYNPkeqgMAmB