### PR TITLE
fix(admin): use static error messages in excluded models/providers handlers

### DIFF
--- a/internal/api/admin/excluded_models.go
+++ b/internal/api/admin/excluded_models.go
@@ -124,7 +124,7 @@ func UpdateExcludedModelsHandler(authSvc *auth.Service, models DeployedModelsSou
 		stored, err := authSvc.SetInstallationExcludedModels(c.Request.Context(), installation.ExternalID, installation.ID, req.Excluded, allowed)
 		if err != nil {
 			if errors.Is(err, auth.ErrUnknownModel) {
-				c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+				c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": "unknown model id in exclusion list"})
 				return
 			}
 			log.Error("Failed to update excluded models", "err", err, "installation_id", installation.ID)

--- a/internal/api/admin/excluded_providers.go
+++ b/internal/api/admin/excluded_providers.go
@@ -110,7 +110,7 @@ func UpdateExcludedProvidersHandler(authSvc *auth.Service, models DeployedModels
 		stored, err := authSvc.SetInstallationExcludedProviders(c.Request.Context(), installation.ExternalID, installation.ID, req.Excluded, allowed)
 		if err != nil {
 			if errors.Is(err, auth.ErrUnknownProvider) {
-				c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+				c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": "unknown provider in exclusion list"})
 				return
 			}
 			log.Error("Failed to update excluded providers", "err", err, "installation_id", installation.ID)


### PR DESCRIPTION
## Problem
 
`PUT /admin/v1/excluded-models` and `PUT /admin/v1/excluded-providers` call `err.Error()` directly when an unknown model or provider name is submitted, leaking the internal Go package name prefix to the client:
 
```json
{"error":"auth: unknown model id: \"some-model-name\""}
{"error":"auth: unknown provider: \"some-provider-name\""}
```
 
The `auth:` prefix comes from `ErrUnknownModel = errors.New("auth: unknown model id")` and `ErrUnknownProvider = errors.New("auth: unknown provider")` in `internal/auth/service.go`. These sentinel errors are internal bookkeeping — their `Error()` string was never intended to be user-facing.
 
Every other 400 response in the admin API uses a static string:
 
```go
gin.H{"error": "Failed to update excluded models."}
gin.H{"error": "Missing ID."}
gin.H{"error": "Failed to look up API key."}
```
 
These two handlers are the only ones in the admin layer that pass `err.Error()` through to the client on a validation failure.
 
## Fix
 
Replace the two `err.Error()` calls with static strings consistent with the rest of the admin API:
 
```go
// excluded_models.go
- c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+ c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": "unknown model id in exclusion list"})
 
// excluded_providers.go
- c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+ c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": "unknown provider in exclusion list"})
```
 
The underlying `errors.Is(err, auth.ErrUnknownModel)` / `errors.Is(err, auth.ErrUnknownProvider)` check is preserved — only the response body changes.
 
## Verification
 
Before the fix:
 
```
PUT /admin/v1/excluded-models    {"excluded":["not-a-real-model"]}
→ {"error":"auth: unknown model id: \"not-a-real-model\""}
 
PUT /admin/v1/excluded-providers {"excluded":["not-a-real-provider"]}
→ {"error":"auth: unknown provider: \"not-a-real-provider\""}
```
 
After the fix:
 
```
PUT /admin/v1/excluded-models    {"excluded":["not-a-real-model"]}
→ {"error":"unknown model id in exclusion list"}
 
PUT /admin/v1/excluded-providers {"excluded":["not-a-real-provider"]}
→ {"error":"unknown provider in exclusion list"}
```
 
`make check` — all 30 packages pass. fixes #535 
 