### PR TITLE
fix(auth): add installation_id predicate to SoftDeleteModelRouterAPIKey

### DIFF
--- a/db/queries/model_router_api_keys.sql
+++ b/db/queries/model_router_api_keys.sql
@@ -48,8 +48,10 @@ SET last_used_at = NOW()
 WHERE id = @id::uuid
   AND deleted_at IS NULL;
 
+-- Soft-deletes a router API key. Cross-tenant safe via installation_id predicate.
 -- name: SoftDeleteModelRouterAPIKey :exec
 UPDATE router.model_router_api_keys
 SET deleted_at = NOW()
 WHERE id = @id::uuid
+  AND installation_id = @installation_id::uuid
   AND deleted_at IS NULL;

--- a/internal/auth/api_key.go
+++ b/internal/auth/api_key.go
@@ -34,5 +34,5 @@ type APIKeyRepository interface {
 	GetActiveByHashWithInstallation(ctx context.Context, keyHash string) (*APIKey, *Installation, error)
 	ListForInstallation(ctx context.Context, installationID string) ([]*APIKey, error)
 	MarkUsed(ctx context.Context, id string) error
-	SoftDelete(ctx context.Context, id string) error
+	SoftDelete(ctx context.Context, installationID, id string) error
 }

--- a/internal/auth/service.go
+++ b/internal/auth/service.go
@@ -151,7 +151,7 @@ func (s *Service) RotateAPIKey(ctx context.Context, installationID, keyID string
 	if target == nil {
 		return nil, "", ErrAPIKeyNotFound
 	}
-	if err := s.apiKeys.SoftDelete(ctx, target.ID); err != nil {
+	if err := s.apiKeys.SoftDelete(ctx, installationID, target.ID); err != nil {
 		return nil, "", err
 	}
 	key, raw, err := s.IssueAPIKey(ctx, installationID, target.Name, createdBy)
@@ -168,7 +168,7 @@ func (s *Service) RotateAPIKey(ctx context.Context, installationID, keyID string
 // cache TTL (5 min) — the same window that RotateAPIKey closes via
 // invalidateInstallation.
 func (s *Service) DeleteAPIKey(ctx context.Context, installationID, id string) error {
-	if err := s.apiKeys.SoftDelete(ctx, id); err != nil {
+	if err := s.apiKeys.SoftDelete(ctx, installationID, id); err != nil {
 		return err
 	}
 	s.invalidateInstallation(installationID)

--- a/internal/auth/service_test.go
+++ b/internal/auth/service_test.go
@@ -61,7 +61,7 @@ func (f *fakeAPIKeyRepository) MarkUsed(ctx context.Context, id string) error {
 	return nil
 }
 
-func (f *fakeAPIKeyRepository) SoftDelete(ctx context.Context, id string) error {
+func (f *fakeAPIKeyRepository) SoftDelete(ctx context.Context, installationID, id string) error {
 	return f.override
 }
 

--- a/internal/postgres/repository.go
+++ b/internal/postgres/repository.go
@@ -209,11 +209,18 @@ func (r *apiKeyRepo) MarkUsed(ctx context.Context, id string) error {
 	return q.MarkModelRouterAPIKeyUsed(ctx, parsed)
 }
 
-func (r *apiKeyRepo) SoftDelete(ctx context.Context, id string) error {
+func (r *apiKeyRepo) SoftDelete(ctx context.Context, installationID, id string) error {
+	installationUUID, err := uuid.Parse(installationID)
+	if err != nil {
+		return err
+	}
 	parsed, err := uuid.Parse(id)
 	if err != nil {
 		return err
 	}
 	q := sqlc.New(r.tx)
-	return q.SoftDeleteModelRouterAPIKey(ctx, parsed)
+	return q.SoftDeleteModelRouterAPIKey(ctx, sqlc.SoftDeleteModelRouterAPIKeyParams{
+		ID:             parsed,
+		InstallationID: installationUUID,
+	})
 }

--- a/internal/server/middleware/auth_test.go
+++ b/internal/server/middleware/auth_test.go
@@ -77,7 +77,7 @@ func (f *fakeAPIKeyRepository) MarkUsed(ctx context.Context, id string) error {
 	return nil
 }
 
-func (f *fakeAPIKeyRepository) SoftDelete(ctx context.Context, id string) error {
+func (f *fakeAPIKeyRepository) SoftDelete(ctx context.Context, installationID, id string) error {
 	return errors.New("not used")
 }
 

--- a/internal/sqlc/model_router_api_keys.sql.go
+++ b/internal/sqlc/model_router_api_keys.sql.go
@@ -219,16 +219,23 @@ const softDeleteModelRouterAPIKey = `-- name: SoftDeleteModelRouterAPIKey :exec
 UPDATE router.model_router_api_keys
 SET deleted_at = NOW()
 WHERE id = $1::uuid
+  AND installation_id = $2::uuid
   AND deleted_at IS NULL
 `
 
-// SoftDeleteModelRouterAPIKey
+type SoftDeleteModelRouterAPIKeyParams struct {
+	ID             uuid.UUID
+	InstallationID uuid.UUID
+}
+
+// Soft-deletes a router API key. Cross-tenant safe via installation_id predicate.
 //
 //	UPDATE router.model_router_api_keys
 //	SET deleted_at = NOW()
 //	WHERE id = $1::uuid
+//	  AND installation_id = $2::uuid
 //	  AND deleted_at IS NULL
-func (q *Queries) SoftDeleteModelRouterAPIKey(ctx context.Context, id uuid.UUID) error {
-	_, err := q.db.Exec(ctx, softDeleteModelRouterAPIKey, id)
+func (q *Queries) SoftDeleteModelRouterAPIKey(ctx context.Context, arg SoftDeleteModelRouterAPIKeyParams) error {
+	_, err := q.db.Exec(ctx, softDeleteModelRouterAPIKey, arg.ID, arg.InstallationID)
 	return err
 }


### PR DESCRIPTION
## Problem
 
`SoftDeleteModelRouterAPIKey` was missing the `installation_id` ownership predicate present on every other soft-delete query in the codebase, leaving the SQL layer without tenant isolation on router API key deletion.
 
**Current query (no ownership filter):**
 
```sql
-- name: SoftDeleteModelRouterAPIKey :exec
UPDATE router.model_router_api_keys
SET deleted_at = NOW()
WHERE id = @id::uuid
  AND deleted_at IS NULL;
```
 
**Compare to `SoftDeleteExternalAPIKey` (correct pattern):**
 
```sql
-- Soft-deletes an external API key. Cross-tenant safe via installation_id predicate.
-- name: SoftDeleteExternalAPIKey :exec
UPDATE router.model_router_external_api_keys
SET deleted_at = CURRENT_TIMESTAMP, updated_at = CURRENT_TIMESTAMP
WHERE id = @id::uuid
  AND installation_id = @installation_id::uuid
  AND deleted_at IS NULL;
```
 
The only protection against cross-tenant deletion was an application-level list-then-check in `DeleteAPIKeyHandler` (`keys.go:132–146`): list all keys for the authed installation, find the requested ID in that list, reject with 404 if not found, then call `DeleteAPIKey`. Correct today, but a future refactor that skips the ownership check would silently permit deleting any key by UUID across all installations — with no SQL-layer backstop.
 
`installationID` was already accepted as a parameter by `Service.DeleteAPIKey` and `Service.RotateAPIKey` but was never threaded through to the SQL query.
 
## Fix
 
Add `AND installation_id = @installation_id::uuid` to `SoftDeleteModelRouterAPIKey` and thread `installationID` through all five touch points:
 
- `db/queries/model_router_api_keys.sql` — add the ownership predicate
- `internal/sqlc/model_router_api_keys.sql.go` — regenerated via `make generate`
- `internal/auth/api_key.go` — update `APIKeyRepository.SoftDelete` interface signature
- `internal/postgres/repository.go` — pass `installationID` to `SoftDeleteModelRouterAPIKeyParams`
- `internal/auth/service.go` — thread `installationID` through both call sites (`RotateAPIKey` and `DeleteAPIKey`)
## Verification
 
**Before the fix** — SQL deletes any key by ID with no ownership check:
 
```sql
UPDATE router.model_router_api_keys
SET deleted_at = NOW()
WHERE id = '17f22f80-d8cd-4a40-a97f-1ea5c27b91b9'
  AND deleted_at IS NULL;
-- UPDATE 1  ← key deleted regardless of installation ownership
```
 
**After the fix** — wrong `installation_id` correctly rejected:
 
```sql
UPDATE router.model_router_api_keys
SET deleted_at = NOW()
WHERE id = '17f22f80-d8cd-4a40-a97f-1ea5c27b91b9'
  AND installation_id = '00000000-0000-0000-0000-000000000000'
  AND deleted_at IS NULL;
-- UPDATE 0  ← key survives, deleted_at stays NULL
```
 
Verified live against the running local server before and after rebuild.
 
`make check` — all 30 packages pass.

Fixes #536
 