### PR TITLE
fix(feedback): enforce 2048-byte comment length cap in SubmitHandler

### DIFF
--- a/internal/api/feedback/feedback.go
+++ b/internal/api/feedback/feedback.go
@@ -102,6 +102,10 @@ func SubmitHandler(svc *proxy.Service) gin.HandlerFunc {
 			return
 		}
 
+		if req.Comment != nil && len(strings.TrimSpace(*req.Comment)) > maxCommentBytes {
+			c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": "comment too long"})
+			return
+		}
 		err = svc.SubmitFeedback(c.Request.Context(), proxy.SubmitFeedbackParams{
 			InstallationID: claims.InstallationID,
 			ExternalID:     claims.ExternalID,
@@ -181,6 +185,12 @@ func toContextResponse(f proxy.FeedbackContext) contextResponse {
 	}
 	return resp
 }
+
+// maxCommentBytes is the maximum allowed comment length after whitespace
+// trimming. The HTTP body reader caps total body size at 64KB, but a comment
+// close to that limit represents unnecessary DB storage amplification for a
+// rating widget. Submissions exceeding this limit are rejected with 400.
+const maxCommentBytes = 2048
 
 // normalizeComment trims whitespace and collapses an empty comment to nil so
 // "" and "no comment" are indistinguishable downstream.

--- a/internal/api/feedback/feedback_test.go
+++ b/internal/api/feedback/feedback_test.go
@@ -243,3 +243,32 @@ func TestRateHandler_ExpiredTokenReturns410(t *testing.T) {
 	assert.Equal(t, http.StatusGone, rec.Code)
 	assert.Empty(t, repo.upserts)
 }
+
+func TestSubmitHandler_RejectsOversizedComment(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	signer := token.NewSigner("secret", time.Hour)
+	repo := &fakeFeedbackRepo{}
+	engine := gin.New()
+	engine.POST("/v1/feedback/link", feedbackapi.SubmitHandler(newService(repo, signer)))
+	tok := signer.Mint("inst-1", "org-1", "req-99", "user-1")
+	longComment := strings.Repeat("a", 2049)
+	body := `{"token":"` + tok + `","rating":"up","comment":"` + longComment + `"}`
+	rec := httptest.NewRecorder()
+	engine.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/v1/feedback/link", strings.NewReader(body)))
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Contains(t, rec.Body.String(), "comment too long")
+}
+
+func TestSubmitHandler_AcceptsCommentAtLimit(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	signer := token.NewSigner("secret", time.Hour)
+	repo := &fakeFeedbackRepo{}
+	engine := gin.New()
+	engine.POST("/v1/feedback/link", feedbackapi.SubmitHandler(newService(repo, signer)))
+	tok := signer.Mint("inst-1", "org-1", "req-100", "user-1")
+	okComment := strings.Repeat("b", 2048)
+	body := `{"token":"` + tok + `","rating":"up","comment":"` + okComment + `"}`
+	rec := httptest.NewRecorder()
+	engine.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/v1/feedback/link", strings.NewReader(body)))
+	assert.Equal(t, http.StatusOK, rec.Code)
+}

--- a/internal/api/feedback/feedback_test.go
+++ b/internal/api/feedback/feedback_test.go
@@ -272,3 +272,36 @@ func TestSubmitHandler_AcceptsCommentAtLimit(t *testing.T) {
 	engine.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/v1/feedback/link", strings.NewReader(body)))
 	assert.Equal(t, http.StatusOK, rec.Code)
 }
+
+func TestSubmitHandler_WhitespaceOnlyCommentStoresNil(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	signer := token.NewSigner("secret", time.Hour)
+	repo := &fakeFeedbackRepo{}
+	engine := gin.New()
+	engine.POST("/v1/feedback/link", feedbackapi.SubmitHandler(newService(repo, signer)))
+	tok := signer.Mint("inst-1", "org-1", "req-101", "user-1")
+	body := `{"token":"` + tok + `","rating":"up","comment":"     "}`
+	rec := httptest.NewRecorder()
+	engine.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/v1/feedback/link", strings.NewReader(body)))
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Len(t, repo.upserts, 1)
+	assert.Nil(t, repo.upserts[0].Comment, "all-whitespace comment must normalize to nil")
+}
+
+func TestSubmitHandler_WhitespacePaddedCommentAtLimit(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	signer := token.NewSigner("secret", time.Hour)
+	repo := &fakeFeedbackRepo{}
+	engine := gin.New()
+	engine.POST("/v1/feedback/link", feedbackapi.SubmitHandler(newService(repo, signer)))
+	tok := signer.Mint("inst-1", "org-1", "req-102", "user-1")
+	// 2048 real bytes padded with spaces — trimmed length is exactly at the limit
+	paddedComment := "  " + strings.Repeat("c", 2048) + "  "
+	body := `{"token":"` + tok + `","rating":"up","comment":"` + paddedComment + `"}`
+	rec := httptest.NewRecorder()
+	engine.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/v1/feedback/link", strings.NewReader(body)))
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Len(t, repo.upserts, 1)
+	require.NotNil(t, repo.upserts[0].Comment)
+	assert.Equal(t, 2048, len(*repo.upserts[0].Comment), "whitespace padding must be stripped, real content stored")
+}


### PR DESCRIPTION
## Problem
 
`SubmitHandler` applied no per-field length limit on the comment field. The HTTP body reader caps total input at 64KB (`maxBodyBytes`), but after subtracting the token (~150 bytes) and JSON structure overhead, a comment close to **60KB** could be submitted and stored verbatim in the database. The `comment` column is `::text` in PostgreSQL — no size limit — so the full 60KB string is persisted.
 
For a rating widget, this represents unnecessary storage amplification with no product value.
 
## Fix
 
Add `maxCommentBytes = 2048` and reject oversized comments with **400** in `SubmitHandler` before submission proceeds:
 
```go
if req.Comment != nil && len(strings.TrimSpace(*req.Comment)) > maxCommentBytes {
        c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": "comment too long"})
        return
}
```
 
The limit applies to **trimmed content** (consistent with `normalizeComment`) so whitespace padding does not exhaust the cap — a comment of 2048 real characters surrounded by spaces is accepted and stored trimmed.
 
Rejection is explicit (`"comment too long"`) rather than silent truncation so the client knows the comment was not accepted.
 
## Verification
 
Four tests covering the boundary and edge cases:
 
| Test | Input | Expected |
|------|-------|----------|
| `RejectsOversizedComment` | 2049 bytes | 400 "comment too long" |
| `AcceptsCommentAtLimit` | exactly 2048 bytes | 200 OK |
| `WhitespaceOnlyCommentStoresNil` | `"     "` | 200 OK, `Comment = nil` stored |
| `WhitespacePaddedCommentAtLimit` | `"  " + 2048 chars + "  "` | 200 OK, 2048 bytes stored trimmed |
 
`make check` — all 30 packages pass. Fixes #537
 