### PR TITLE
feat(proxy): auto-discover upstream model naming conventions at boot

### DIFF
--- a/cmd/router/main.go
+++ b/cmd/router/main.go
@@ -9,11 +9,13 @@ import (
 	"crypto/rand"
 	"errors"
 	"fmt"
+	"io"
 	"log/slog"
 	"net/http"
 	"net/url"
 	"os"
 	"os/signal"
+	"sort"
 	"strconv"
 	"strings"
 	"syscall"
@@ -53,6 +55,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/tidwall/gjson"
 )
 
 func main() {
@@ -232,7 +235,18 @@ func main() {
 		if !byokOnly {
 			openRouterKey = config.GetOr("OPENROUTER_API_KEY", "")
 		}
-		providerMap[providers.ProviderOpenRouter] = openaiCompatProvider.NewClient(openRouterKey, openRouterBaseURL)
+		openRouterModelIDMap := bootUpstreamModelIDMap(openRouterBaseURL, openRouterKey, logger)
+		if len(openRouterModelIDMap) > 0 {
+			providerMap[providers.ProviderOpenRouter] = openaiCompatProvider.NewClientWithModelIDMap(openRouterKey, openRouterBaseURL, openRouterModelIDMap)
+			ids := make([]string, 0, len(openRouterModelIDMap))
+			for k, v := range openRouterModelIDMap {
+				ids = append(ids, k+"→"+v)
+			}
+			sort.Strings(ids)
+			logger.Info("Auto-discovered upstream model ID map", "remapped_count", len(ids), "remapped", ids)
+		} else {
+			providerMap[providers.ProviderOpenRouter] = openaiCompatProvider.NewClient(openRouterKey, openRouterBaseURL)
+		}
 		switch {
 		case byokOnly:
 			logger.Info("OpenRouter provider enabled (BYOK only)", "base_url", openRouterBaseURL)
@@ -1341,6 +1355,87 @@ func upstreamIDsForProvider(provider string) map[string]string {
 		for _, b := range m.Providers {
 			if b.Provider == provider && b.UpstreamID != "" {
 				out[m.ID] = b.UpstreamID
+			}
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// bootUpstreamModelIDMap calls the upstream's /v1/models endpoint at boot
+// and returns a modelIDMap that rewrites catalog model IDs to the upstream's
+// naming convention. For each catalog model:
+//   - If the upstream lists the exact catalog ID → no rewrite needed (real
+//     OpenRouter).
+//   - If the upstream lists only the bare name (after the last '/') → map the
+//     catalog ID to the bare name (custom proxies like OpenCode Go).
+//   - If neither matches → skip (model not available on this upstream).
+//
+// Returns nil on any failure, leaving model names unchanged (existing
+// behavior). The 5s timeout keeps boot-time impact bounded.
+func bootUpstreamModelIDMap(baseURL, apiKey string, logger *slog.Logger) map[string]string {
+	modelURL := strings.TrimRight(baseURL, "/") + "/models"
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, modelURL, nil)
+	if err != nil {
+		logger.Warn("Failed to build upstream /models request; skipping model ID discovery", "url", modelURL, "err", err)
+		return nil
+	}
+	if apiKey != "" {
+		req.Header.Set("Authorization", "Bearer "+apiKey)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		logger.Warn("Upstream /models call failed; skipping model ID discovery", "url", modelURL, "err", err)
+		return nil
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 400 {
+		logger.Warn("Upstream /models returned non-2xx; skipping model ID discovery", "url", modelURL, "status", resp.StatusCode)
+		return nil
+	}
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<19)) // 512KB
+	if err != nil {
+		logger.Warn("Failed to read upstream /models body; skipping model ID discovery", "url", modelURL, "err", err)
+		return nil
+	}
+
+	// OpenAI-compat /v1/models format: {"object":"list","data":[{"id":"..."},...]}
+	parsed := gjson.GetBytes(body, "data")
+	if !parsed.IsArray() {
+		logger.Warn("Upstream /models response missing 'data' array; skipping model ID discovery", "url", modelURL)
+		return nil
+	}
+
+	upstreamIDs := make(map[string]struct{}, len(parsed.Array()))
+	for _, item := range parsed.Array() {
+		id := item.Get("id").String()
+		if id != "" {
+			upstreamIDs[id] = struct{}{}
+		}
+	}
+	if len(upstreamIDs) == 0 {
+		return nil
+	}
+
+	out := make(map[string]string)
+	for _, m := range catalog.Models {
+		if _, ok := upstreamIDs[m.ID]; ok {
+			// Upstream uses the same name — no rewrite needed.
+			continue
+		}
+		// Check if the bare name (after the last '/') matches.
+		if idx := strings.LastIndexByte(m.ID, '/'); idx >= 0 {
+			bare := m.ID[idx+1:]
+			if _, ok := upstreamIDs[bare]; ok {
+				out[m.ID] = bare
 			}
 		}
 	}

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -25,7 +25,7 @@ Claude Code keep using the user's logged-in plan.
 | Variable              | Default                                                   | Effect |
 | --------------------- | --------------------------------------------------------- | ------ |
 | `OPENROUTER_API_KEY`  | *(none)*                                                  | **Recommended baseline.** Enables OpenRouter and the full OSS-model pool the cluster scorer is trained against. |
-| `OPENROUTER_BASE_URL` | `https://openrouter.ai/api/v1`                            | Override for OpenRouter or any OpenAI-compatible endpoint (vLLM, Together, Fireworks, self-hosted). |
+| `OPENROUTER_BASE_URL` | `https://openrouter.ai/api/v1`                            | Override for OpenRouter or any OpenAI-compatible endpoint (vLLM, Together, Fireworks, self-hosted). At boot the router calls this upstream's `/v1/models` to auto-discover model naming conventions and rewrite model IDs if needed. |
 | `ANTHROPIC_API_KEY`   | *(none — passthrough)*                                    | Router's own Anthropic key. When unset, client `Authorization` headers pass through. |
 | `OPENAI_API_KEY`      | *(none)*                                                  | Enables the OpenAI provider (Chat Completions API). |
 | `OPENAI_BASE_URL`     | `https://api.openai.com`                                  | Override for OpenAI (e.g. Azure OpenAI). |

--- a/internal/providers/openaicompat/client_test.go
+++ b/internal/providers/openaicompat/client_test.go
@@ -223,3 +223,96 @@ func TestProxy_4xxStillBuffered(t *testing.T) {
 	assert.False(t, providers.IsRetryableStatus(buffered.Status),
 		"sanity: 400 must classify as non-retryable")
 }
+
+func TestProxy_ModelIDMapRewritesBodyModelField(t *testing.T) {
+	var gotModel string
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body struct {
+			Model string `json:"model"`
+		}
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+		gotModel = body.Model
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"id":"chatcmpl-remapped","object":"chat.completion"}`))
+	}))
+	defer upstream.Close()
+
+	modelIDMap := map[string]string{
+		"deepseek/deepseek-v4-flash": "deepseek-v4-flash",
+		"deepseek/deepseek-v4-pro":   "deepseek-v4-pro",
+		"moonshotai/kimi-k2.6":       "kimi-k2.6",
+	}
+	c := openaicompat.NewClientWithModelIDMap("test-key", upstream.URL+"/api/v1", modelIDMap)
+
+	clientReq := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(""))
+	rec := httptest.NewRecorder()
+	body := []byte(`{"model":"deepseek/deepseek-v4-flash","messages":[{"role":"user","content":"hello"}]}`)
+	prep := providers.PreparedRequest{Body: body, Headers: make(http.Header)}
+	err := c.Proxy(context.Background(), router.Decision{Model: "deepseek/deepseek-v4-flash"}, prep, rec, clientReq)
+
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "deepseek-v4-flash", gotModel,
+		"body 'model' field must be rewritten per modelIDMap")
+}
+
+func TestProxy_ModelIDMapLeavesUnmappedModelsAlone(t *testing.T) {
+	var gotModel string
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body struct {
+			Model string `json:"model"`
+		}
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+		gotModel = body.Model
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"id":"chatcmpl-unmapped","object":"chat.completion"}`))
+	}))
+	defer upstream.Close()
+
+	modelIDMap := map[string]string{
+		"deepseek/deepseek-v4-flash": "deepseek-v4-flash",
+	}
+	c := openaicompat.NewClientWithModelIDMap("test-key", upstream.URL+"/api/v1", modelIDMap)
+
+	clientReq := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(""))
+	rec := httptest.NewRecorder()
+	body := []byte(`{"model":"claude-opus-4-8","messages":[{"role":"user","content":"hi"}]}`)
+	prep := providers.PreparedRequest{Body: body, Headers: make(http.Header)}
+	err := c.Proxy(context.Background(), router.Decision{Model: "claude-opus-4-8"}, prep, rec, clientReq)
+
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "claude-opus-4-8", gotModel,
+		"unmapped model must be forwarded unchanged")
+}
+
+func TestProxy_NilModelIDMapDoesNotRewrite(t *testing.T) {
+	var gotModel string
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body struct {
+			Model string `json:"model"`
+		}
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+		gotModel = body.Model
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"id":"chatcmpl-nomap","object":"chat.completion"}`))
+	}))
+	defer upstream.Close()
+
+	c := openaicompat.NewClient("test-key", upstream.URL+"/api/v1")
+
+	clientReq := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(""))
+	rec := httptest.NewRecorder()
+	body := []byte(`{"model":"deepseek/deepseek-v4-flash","messages":[]}`)
+	prep := providers.PreparedRequest{Body: body, Headers: make(http.Header)}
+	err := c.Proxy(context.Background(), router.Decision{Model: "deepseek/deepseek-v4-flash"}, prep, rec, clientReq)
+
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "deepseek/deepseek-v4-flash", gotModel,
+		"without modelIDMap the body must be forwarded unmodified")
+}


### PR DESCRIPTION
Fixes #526 · tested against #541

At boot the router queries the upstream `/v1/models` endpoint and compares returned IDs against the catalog. When the upstream uses bare model names (e.g. `deepseek-v4-flash` instead of `deepseek/deepseek-v4-flash`), the router strips the prefix automatically. Real OpenRouter is unaffected (exact match → no rewrite).

I took the liberty of fixing and testing this myself — verified end-to-end with OpenCode Go as the upstream and it works. Thank you for this project, this is something I've been wanting to build but couldn't figure out the right way to do it. This project seems like the right approach and I'll keep testing it.

Please review and merge as and when it fits — let me know if you need me to make any changes.