### PR TITLE
fix(admin): reject BYOK provider key when deployment env key is set

### DIFF
--- a/internal/api/admin/keys.go
+++ b/internal/api/admin/keys.go
@@ -6,6 +6,8 @@ import (
 	"time"
 
 	"workweave/router/internal/auth"
+	"workweave/router/internal/config"
+	"workweave/router/internal/providers"
 
 	"github.com/gin-gonic/gin"
 )
@@ -209,6 +211,16 @@ func UpsertExternalKeyHandler(authSvc *auth.Service) gin.HandlerFunc {
 		var req upsertExternalKeyRequest
 		if err := c.ShouldBindJSON(&req); err != nil {
 			c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": "Provider and key are required."})
+			return
+		}
+		// A provider configured via the deployment's env var (e.g. ANTHROPIC_API_KEY)
+		// must not be shadowed by a dashboard BYOK key — credential resolution
+		// prefers BYOK, so the stored key would silently win on every outbound call.
+		// The frontend grays out env-keyed providers, but that guard is derived from
+		// GET /admin/v1/config and fails open if that fetch errors; this is the only
+		// backend enforcement. Mirrors the env-key check in ConfigHandler.
+		if config.GetOr(providers.APIKeyEnvVar(req.Provider), "") != "" {
+			c.AbortWithStatusJSON(http.StatusConflict, gin.H{"error": "Provider already configured via deployment environment variable. Remove the env var before adding a dashboard key."})
 			return
 		}
 		key, err := authSvc.UpsertExternalAPIKey(c.Request.Context(), installation.ID, req.Provider, req.Key, req.Name, nil)

--- a/internal/api/admin/keys_test.go
+++ b/internal/api/admin/keys_test.go
@@ -1,0 +1,86 @@
+package admin_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"workweave/router/internal/api/admin"
+	"workweave/router/internal/auth"
+	"workweave/router/internal/providers"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeExternalAPIKeyRepo records whether a key was actually persisted, so a test
+// can distinguish "guard rejected the write" from "write went through".
+type fakeExternalAPIKeyRepo struct {
+	created int
+}
+
+func (f *fakeExternalAPIKeyRepo) Create(_ context.Context, params auth.CreateExternalAPIKeyParams) (*auth.ExternalAPIKey, error) {
+	f.created++
+	return &auth.ExternalAPIKey{ID: params.ExternalID, Provider: params.Provider}, nil
+}
+func (f *fakeExternalAPIKeyRepo) GetForInstallation(context.Context, string) ([]*auth.ExternalAPIKey, error) {
+	return nil, nil
+}
+func (f *fakeExternalAPIKeyRepo) SoftDeleteByProvider(context.Context, string, string) error {
+	return nil
+}
+func (f *fakeExternalAPIKeyRepo) SoftDelete(context.Context, string, string) error { return nil }
+func (f *fakeExternalAPIKeyRepo) MarkUsed(context.Context, string) error           { return nil }
+
+// upsertKeyEngine wires UpsertExternalKeyHandler behind a middleware that injects
+// an already-authed installation, so the handler reaches the env-shadow guard
+// without a real auth flow.
+func upsertKeyEngine(svc *auth.Service) *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	engine := gin.New()
+	engine.POST("/admin/v1/provider-keys", func(c *gin.Context) {
+		c.Set("router_installation", &auth.Installation{ID: "inst-1"})
+	}, admin.UpsertExternalKeyHandler(svc))
+	return engine
+}
+
+func postProviderKey(engine *gin.Engine, provider string) *httptest.ResponseRecorder {
+	body, _ := json.Marshal(map[string]string{"provider": provider, "key": "sk-test-key"})
+	req := httptest.NewRequest(http.MethodPost, "/admin/v1/provider-keys", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	engine.ServeHTTP(rec, req)
+	return rec
+}
+
+func TestUpsertExternalKeyHandler_RejectsEnvShadowedProvider(t *testing.T) {
+	t.Setenv(providers.APIKeyEnvVar(providers.ProviderAnthropic), "sk-ant-deployment-key")
+
+	repo := &fakeExternalAPIKeyRepo{}
+	svc := auth.NewService(nil, nil, repo, nil, auth.NoOpAPIKeyCache{}, nil, func() time.Time { return time.Unix(0, 0) })
+
+	rec := postProviderKey(upsertKeyEngine(svc), providers.ProviderAnthropic)
+
+	assert.Equal(t, http.StatusConflict, rec.Code,
+		"a provider with a deployment env key must not accept a dashboard BYOK key")
+	assert.Equal(t, 0, repo.created,
+		"the BYOK key must not be persisted when the env guard fires")
+}
+
+func TestUpsertExternalKeyHandler_AllowsProviderWithoutEnvKey(t *testing.T) {
+	// No env var set for the provider — the guard must let the write through.
+	t.Setenv(providers.APIKeyEnvVar(providers.ProviderAnthropic), "")
+
+	repo := &fakeExternalAPIKeyRepo{}
+	svc := auth.NewService(nil, nil, repo, nil, auth.NoOpAPIKeyCache{}, nil, func() time.Time { return time.Unix(0, 0) })
+
+	rec := postProviderKey(upsertKeyEngine(svc), providers.ProviderAnthropic)
+
+	require.Equal(t, http.StatusCreated, rec.Code)
+	assert.Equal(t, 1, repo.created, "the BYOK key must be persisted when no env key shadows it")
+}


### PR DESCRIPTION
## Problem (fixes #459)

`UpsertExternalKeyHandler` (`POST /admin/v1/provider-keys`) persists a dashboard BYOK key for **any** provider — including one already configured via the deployment env var (e.g. `ANTHROPIC_API_KEY`). Because `resolveAndInjectCredentials` resolves **BYOK before the deployment env key**, the stored key then silently becomes the credential used on every outbound call to that provider.

The only existing protection is a frontend gray-out, derived from a single `GET /admin/v1/config` call. That fetch **fails open**: if it errors for any ordinary reason (flaky network, momentary backend hiccup), the panel renders every env-keyed provider as freely editable, and the backend accepts the write with no check. #459 reproduced this live end-to-end — a fabricated canary key was presented to Anthropic's real API and rejected with a 401, proving the wrong credential was actually transmitted.

## Fix

Add the env-key guard to the **write** path — the same one-line check that already exists on the read path in `ConfigHandler`:

```go
if config.GetOr(providers.APIKeyEnvVar(req.Provider), "") != "" {
    c.AbortWithStatusJSON(http.StatusConflict, gin.H{"error": "Provider already configured via deployment environment variable. Remove the env var before adding a dashboard key."})
    return
}
```

This is a pure env read with no dependency on `/admin/v1/config` having succeeded, so it closes the hole regardless of frontend state or direct API/curl access.

- `APIKeyEnvVar` returns `""` for unknown providers → `GetOr("", "")` is `""` → the guard never falsely blocks a non-env provider.
- Inert in **managed** mode (env keys unset there; BYOK is the only credential source), and `/admin/v1/*` isn't even mounted in managed mode.

## Tests

`internal/api/admin/keys_test.go`:
- env key set → `POST` returns **409** and the key is **not** persisted
- no env key → `POST` returns **201** and the key **is** persisted

## Out of scope (follow-up)

Frontend fail-closed hardening for `ProviderKeysPanel` (surface an error state + keep the form disabled when `GET /admin/v1/config` errors, instead of treating every provider as unconfigured). That's defense-in-depth; the backend guard above is the change that actually closes the hole.

🤖 Generated with [Claude Code](https://claude.com/claude-code)