### PR TITLE
feat(providers): add Together AI as an inference provider

### DIFF
--- a/cmd/router/main.go
+++ b/cmd/router/main.go
@@ -307,6 +307,31 @@ func main() {
 	}
 
 	{
+		// Together AI OpenAI-compatible surface. Serves the OSS pool at the top
+		// of the artificialanalysis.ai throughput tables for several models we
+		// route (DeepSeek V4 Pro, GLM-5.1, MiniMax M2.7); primary binding for
+		// those, with the prior providers kept as ordered fallbacks. Together
+		// uses "Org/Model" model IDs while the router exposes slash-form slugs,
+		// so modelIDMap is derived from the catalog's per-binding UpstreamID at
+		// boot.
+		togetherBaseURL := config.GetOr("TOGETHER_BASE_URL", openaiCompatProvider.TogetherBaseURL)
+		togetherKey := ""
+		if !byokOnly {
+			togetherKey = config.GetOr("TOGETHER_API_KEY", "")
+		}
+		providerMap[providers.ProviderTogether] = openaiCompatProvider.NewClientWithModelIDMap(togetherKey, togetherBaseURL, upstreamIDsForProvider(providers.ProviderTogether))
+		switch {
+		case byokOnly:
+			logger.Info("Together provider enabled (BYOK only)", "base_url", togetherBaseURL)
+		case togetherKey != "":
+			envKeyedProviders[providers.ProviderTogether] = struct{}{}
+			logger.Info("Together provider enabled", "base_url", togetherBaseURL)
+		default:
+			logger.Info("Together provider registered (BYOK only — set TOGETHER_API_KEY for deployment-level use)", "base_url", togetherBaseURL)
+		}
+	}
+
+	{
 		// Bedrock via the OpenAI-compatible "bedrock-mantle" surface
 		// (https://bedrock-mantle.{region}.api.aws/v1). AWS recommends this
 		// over the model-native bedrock-runtime/InvokeModel surface; both

--- a/internal/providers/openaicompat/client.go
+++ b/internal/providers/openaicompat/client.go
@@ -34,6 +34,12 @@ const (
 	// with NewClientWithModelIDMap to rewrite the router's public slash-form
 	// slugs to Makora's upstream IDs on the wire.
 	MakoraBaseURL = "https://inference.makora.com/v1"
+	// TogetherBaseURL is Together AI's OpenAI-compatible surface. Together
+	// serves the OSS pool (DeepSeek, GLM, MiniMax, Qwen, Kimi, …) and is the
+	// fastest provider on artificialanalysis.ai for several of the models we
+	// route; pair with NewClientWithModelIDMap to rewrite the router's public
+	// slash-form slugs to Together's "Org/Model" upstream IDs on the wire.
+	TogetherBaseURL = "https://api.together.xyz/v1"
 )
 
 // BedrockMantleBaseURLTemplate is the OpenAI-compatible bedrock-mantle endpoint

--- a/internal/providers/provider.go
+++ b/internal/providers/provider.go
@@ -51,6 +51,7 @@ const (
 	ProviderDeepInfra  = "deepinfra"
 	ProviderBedrock    = "bedrock"
 	ProviderMakora     = "makora"
+	ProviderTogether   = "together"
 )
 
 // APIKeyEnvVars maps provider name to the env var providing its deployment-level upstream API key.
@@ -64,6 +65,7 @@ var APIKeyEnvVars = map[string]string{
 	ProviderDeepInfra:  "DEEPINFRA_API_KEY",
 	ProviderBedrock:    "AWS_BEARER_TOKEN_BEDROCK",
 	ProviderMakora:     "MAKORA_API_KEY",
+	ProviderTogether:   "TOGETHER_API_KEY",
 }
 
 // APIKeyEnvVar returns the env-var name for the given provider, or empty

--- a/internal/router/catalog/catalog.go
+++ b/internal/router/catalog/catalog.go
@@ -369,8 +369,15 @@ var Models = []Model{
 		{Provider: providers.ProviderOpenRouter, Price: Pricing{InputUSDPer1M: 0.140, OutputUSDPer1M: 0.280, CacheReadMultiplier: 0.10}},
 	}},
 	{ID: "deepseek/deepseek-v4-pro", Tier: TierHigh, ContextWindow: 1_048_576, ImageInput: ImageInputUnsupported, Providers: []ProviderBinding{
+		// Makora stays primary for cost ($1.318 / $2.636 vs Together's $1.74 / $3.48).
+		// Together is the #1 throughput provider for V4 Pro on artificialanalysis.ai
+		// (~209 t/s vs Fireworks ~120) at the same price as Fireworks, so it sits
+		// ahead of Fireworks as the fastest same-price fallback. Prices confirmed
+		// from the Together serverless catalog (cached $0.20).
 		{Provider: providers.ProviderMakora, UpstreamID: "deepseek-ai/DeepSeek-V4-Pro",
 			Price: Pricing{InputUSDPer1M: 1.3180, OutputUSDPer1M: 2.6361, CacheReadMultiplier: 0.10}},
+		{Provider: providers.ProviderTogether, UpstreamID: "deepseek-ai/DeepSeek-V4-Pro",
+			Price: Pricing{InputUSDPer1M: 1.740, OutputUSDPer1M: 3.480, CacheReadMultiplier: 0.20 / 1.740}},
 		{Provider: providers.ProviderFireworks, UpstreamID: "accounts/fireworks/models/deepseek-v4-pro",
 			Price: Pricing{InputUSDPer1M: 1.740, OutputUSDPer1M: 3.480, CacheReadMultiplier: 0.0862}},
 		{Provider: providers.ProviderOpenRouter, Price: Pricing{InputUSDPer1M: 0.435, OutputUSDPer1M: 0.870, CacheReadMultiplier: 0.10}},
@@ -430,6 +437,13 @@ var Models = []Model{
 	// MiniMax's "1M" marketing — do NOT raise without re-confirming the
 	// served cap, or requests over ~205K tokens will hard-400 (no failover).
 	{ID: "minimax/minimax-m2.7", Tier: TierHigh, ContextWindow: 204_800, ImageInput: ImageInputUnsupported, Providers: []ProviderBinding{
+		// Together dominates Fireworks on M2.7: AA clocks ~399 t/s (#1 latency too)
+		// vs Fireworks' ~95 t/s, at the identical $0.30 / $1.20 list price (cached
+		// $0.06) — confirmed from the Together serverless catalog ("MiniMax M2.7
+		// FP4"). Together leads the binding order; Fireworks/OpenRouter stay as
+		// ordered fallbacks.
+		{Provider: providers.ProviderTogether, UpstreamID: "MiniMaxAI/MiniMax-M2.7",
+			Price: Pricing{InputUSDPer1M: 0.300, OutputUSDPer1M: 1.200, CacheReadMultiplier: 0.06 / 0.300}},
 		{Provider: providers.ProviderFireworks, UpstreamID: "accounts/fireworks/models/minimax-m2p7",
 			Price: Pricing{InputUSDPer1M: 0.300, OutputUSDPer1M: 1.200}},
 		{Provider: providers.ProviderOpenRouter, Price: Pricing{InputUSDPer1M: 0.279, OutputUSDPer1M: 1.200, CacheReadMultiplier: 0.10}},
@@ -461,6 +475,12 @@ var Models = []Model{
 	// emit_openai layer injects tool_stream + disables thinking for this slug.
 	// Fireworks primary for the same speed reason as GLM-5 (cached input $0.26).
 	{ID: "z-ai/glm-5.1", Tier: TierHigh, ContextWindow: 202_752, ImageInput: ImageInputUnsupported, Providers: []ProviderBinding{
+		// Together edges out Fireworks on GLM-5.1: AA ranks it #1 in both throughput
+		// (~213 t/s vs Fireworks' ~180) and TTFT, so it leads the binding order.
+		// Same $1.40 / $4.40 list price as Fireworks, cached $0.26 — confirmed from
+		// the Together serverless catalog ("GLM 5.1 FP4").
+		{Provider: providers.ProviderTogether, UpstreamID: "zai-org/GLM-5.1",
+			Price: Pricing{InputUSDPer1M: 1.400, OutputUSDPer1M: 4.400, CacheReadMultiplier: 0.26 / 1.400}},
 		{Provider: providers.ProviderFireworks, UpstreamID: "accounts/fireworks/models/glm-5p1",
 			Price: Pricing{InputUSDPer1M: 1.400, OutputUSDPer1M: 4.400, CacheReadMultiplier: 0.26 / 1.40}},
 		{Provider: providers.ProviderDeepInfra, UpstreamID: "zai-org/GLM-5.1",
@@ -472,6 +492,11 @@ var Models = []Model{
 	// (overstating triggers hard 400s — cf. the minimax 1M->204800 incident);
 	// bump once the served window is verified.
 	{ID: "z-ai/glm-5.2", Tier: TierHigh, ContextWindow: 202_752, ImageInput: ImageInputUnsupported, Providers: []ProviderBinding{
+		// Together is #1 on artificialanalysis.ai for GLM-5.2 throughput (~382 t/s
+		// vs Fireworks ~347), so it leads the binding order. $1.40 / $4.40, cached
+		// $0.26 — confirmed from the Together serverless catalog ("GLM 5.2").
+		{Provider: providers.ProviderTogether, UpstreamID: "zai-org/GLM-5.2",
+			Price: Pricing{InputUSDPer1M: 1.400, OutputUSDPer1M: 4.400, CacheReadMultiplier: 0.26 / 1.400}},
 		{Provider: providers.ProviderFireworks, UpstreamID: "accounts/fireworks/models/glm-5p2",
 			Price: Pricing{InputUSDPer1M: 1.400, OutputUSDPer1M: 4.400, CacheReadMultiplier: 0.20}},
 	}},

--- a/internal/router/catalog/catalog_test.go
+++ b/internal/router/catalog/catalog_test.go
@@ -34,6 +34,7 @@ func TestCatalog_BindingsReferenceCanonicalProviders(t *testing.T) {
 		providers.ProviderDeepInfra:  {},
 		providers.ProviderBedrock:    {},
 		providers.ProviderMakora:     {},
+		providers.ProviderTogether:   {},
 	}
 	for _, m := range Models {
 		for i, b := range m.Providers {


### PR DESCRIPTION
## What

Wires up **Together AI** (`api.together.xyz`) as an OpenAI-compatible inference provider and makes it the **primary binding** for the OSS models where it is the fastest reachable provider on [artificialanalysis.ai](https://artificialanalysis.ai), keeping the prior providers as ordered fallbacks.

Same plumbing shape as the Makora provider (#529): a `ProviderTogether` constant + env mapping, a `TogetherBaseURL` in `openaicompat`, a registration block in `cmd/router/main.go`, and per-binding catalog entries. The cluster scorer's `resolveProviderFor` walks the catalog bindings, so routing shifts to Together whenever `TOGETHER_API_KEY` is set and falls through otherwise — **no cluster-artifact change or retrain needed**.

## Why these models

Checked every OSS model we serve against AA's per-provider throughput pages. Together leads on these, at a price at or matching the incumbent:

| Model | Together t/s | vs prior primary | Price (cached) |
|---|---|---|---|
| `minimax/minimax-m2.7` | ~399 (#2) | Fireworks ~95 (**4×**) | $0.30 / $1.20 ($0.06) |
| `z-ai/glm-5.2` | ~382 (#1) | Fireworks ~347 | $1.40 / $4.40 ($0.26) |
| `z-ai/glm-5.1` | ~213 (#1) | Fireworks ~180 | $1.40 / $4.40 ($0.26) |

**`deepseek/deepseek-v4-pro` keeps Makora primary for cost** ($1.318/$2.636 vs Together's $1.74/$3.48). Together is the #1 throughput provider (~209 t/s vs Fireworks ~120) at the same price as Fireworks, so it's inserted **ahead of Fireworks** as the fastest same-price fallback.

Skipped (Together not fastest / absent): `deepseek-v4-flash` (Makora), `kimi-k2.5/2.6`, `glm-5`, `minimax-m3`, `qwen3-coder`.

## ⚠️ Before merge / deploy

The per-binding `UpstreamID` values are **best-guess** and must be confirmed against `GET https://api.together.xyz/v1/models` — Together encodes quantization in some slugs (e.g. the catalog lists "GLM 5.1 **FP4**", "MiniMax M2.7 **FP4**"). If the real API string differs, the modelIDMap rewrite 404s. Holding as **draft** until those are confirmed.

## Validation

- `wv mr tc` ✅
- `go test ./internal/router/catalog/...` ✅
- `go run ./cmd/genprices` ✅ (no install-script diff — DeepSeek unchanged, others match prior primary's price)