### PR TITLE
feat(proxy): per-installation toggle to disable subscription-aware routing

### DIFF
--- a/db/migrations/0029_installation-subscription-routing-disabled.down.sql
+++ b/db/migrations/0029_installation-subscription-routing-disabled.down.sql
@@ -1,0 +1,6 @@
+BEGIN;
+
+ALTER TABLE router.model_router_installations
+  DROP COLUMN subscription_routing_disabled;
+
+COMMIT;

--- a/db/migrations/0029_installation-subscription-routing-disabled.up.sql
+++ b/db/migrations/0029_installation-subscription-routing-disabled.up.sql
@@ -1,0 +1,14 @@
+BEGIN;
+
+-- Per-installation toggle to disable subscription-AWARE ROUTING for this org.
+-- When true, the scorer's subscription subsidy bonus is suppressed, so routing
+-- decides purely on quality/cost/speed merits and non-Claude models (GLM, Kimi,
+-- DeepSeek, ...) compete fairly instead of always losing to the subsidized
+-- Claude family. This removes only the routing BIAS: a turn that still routes to
+-- Claude on its own merits is dispatched on the caller's subscription token
+-- exactly as before, so the prepaid billing path is unchanged. Default false
+-- preserves today's behavior for every existing installation.
+ALTER TABLE router.model_router_installations
+  ADD COLUMN subscription_routing_disabled BOOLEAN NOT NULL DEFAULT FALSE;
+
+COMMIT;

--- a/db/queries/model_router_installations.sql
+++ b/db/queries/model_router_installations.sql
@@ -79,3 +79,16 @@ SET usage_bypass_enabled = @usage_bypass_enabled::boolean,
 WHERE id = @id::uuid
   AND external_id = @external_id::varchar
   AND deleted_at IS NULL;
+
+-- Toggles subscription-aware routing for the installation, scoped to an
+-- external_id to prevent cross-tenant updates. When true, the scorer's
+-- subscription subsidy bonus is suppressed so routing decides on merits and
+-- non-Claude models compete fairly; the subscription credential is still
+-- forwarded for turns that route to Claude on their own merits.
+-- name: UpdateModelRouterInstallationSubscriptionRoutingDisabled :exec
+UPDATE router.model_router_installations
+SET subscription_routing_disabled = @subscription_routing_disabled::boolean,
+    updated_at = NOW()
+WHERE id = @id::uuid
+  AND external_id = @external_id::varchar
+  AND deleted_at IS NULL;

--- a/internal/auth/installation.go
+++ b/internal/auth/installation.go
@@ -44,6 +44,15 @@ type Installation struct {
 	// gate disengages and normal routing takes over. nil means "use the
 	// deployment default" so the toggle can be on before a value is chosen.
 	UsageBypassThreshold *float64
+	// SubscriptionRoutingDisabled turns off subscription-AWARE ROUTING for this
+	// installation. When true, the scorer's subscription subsidy bonus is
+	// suppressed, so routing decides purely on quality/cost/speed merits and
+	// non-Claude models compete fairly instead of always losing to the
+	// subsidized Claude family. It removes only the routing BIAS: a turn that
+	// still routes to Claude on its own merits is dispatched on the caller's
+	// subscription token exactly as before, so the prepaid billing path is
+	// unchanged. Defaults false -- preserves today's behavior.
+	SubscriptionRoutingDisabled bool
 }
 
 type CreateInstallationParams struct {
@@ -71,4 +80,8 @@ type InstallationRepository interface {
 	// the gate; threshold is the [0, 1] utilization at/above which it disengages
 	// (nil = use the deployment default).
 	UpdateUsageBypass(ctx context.Context, externalID, id string, enabled bool, threshold *float64) error
+	// UpdateSubscriptionRoutingDisabled toggles subscription-aware routing for
+	// the installation. When true, the scorer's subscription subsidy bonus is
+	// suppressed so routing decides on merits.
+	UpdateSubscriptionRoutingDisabled(ctx context.Context, externalID, id string, disabled bool) error
 }

--- a/internal/auth/service.go
+++ b/internal/auth/service.go
@@ -292,6 +292,19 @@ func (s *Service) SetInstallationRoutingPreference(ctx context.Context, external
 	return nil
 }
 
+// SetInstallationSubscriptionRoutingDisabled toggles subscription-aware routing
+// for the installation. When true, the scorer's subscription subsidy bonus is
+// suppressed so routing decides on merits and non-Claude models compete fairly.
+// Invalidates the API-key cache so the change takes effect on the next request
+// rather than after the cache TTL.
+func (s *Service) SetInstallationSubscriptionRoutingDisabled(ctx context.Context, externalID, installationID string, disabled bool) error {
+	if err := s.installations.UpdateSubscriptionRoutingDisabled(ctx, externalID, installationID, disabled); err != nil {
+		return err
+	}
+	s.invalidateInstallation(installationID)
+	return nil
+}
+
 // VerifyAPIKey authenticates a raw bearer token against the API key cache then Postgres.
 // Returns ErrInvalidPrefix/ErrInvalidToken for unauthenticated cases.
 // Returned ExternalAPIKey slice has Plaintext populated; nil when none exist.

--- a/internal/auth/service_test.go
+++ b/internal/auth/service_test.go
@@ -94,13 +94,14 @@ func (f *fakeExternalAPIKeyRepo) MarkUsed(ctx context.Context, id string) error 
 }
 
 type fakeInstallationRepository struct {
-	excludedModelsByID            map[string][]string
-	excludedModelsExternalByID    map[string]string
-	excludedProvidersByID         map[string][]string
-	excludedProvidersExternalByID map[string]string
-	routingQualityByID            map[string]*float64
-	usageBypassEnabledByID        map[string]bool
-	usageBypassThresholdByID      map[string]*float64
+	excludedModelsByID              map[string][]string
+	excludedModelsExternalByID      map[string]string
+	excludedProvidersByID           map[string][]string
+	excludedProvidersExternalByID   map[string]string
+	routingQualityByID              map[string]*float64
+	usageBypassEnabledByID          map[string]bool
+	usageBypassThresholdByID        map[string]*float64
+	subscriptionRoutingDisabledByID map[string]bool
 }
 
 func (fakeInstallationRepository) Create(ctx context.Context, params auth.CreateInstallationParams) (*auth.Installation, error) {
@@ -142,6 +143,13 @@ func (f *fakeInstallationRepository) UpdateRoutingPreference(ctx context.Context
 		f.routingQualityByID = map[string]*float64{}
 	}
 	f.routingQualityByID[id] = qualityWeight
+	return nil
+}
+func (f *fakeInstallationRepository) UpdateSubscriptionRoutingDisabled(ctx context.Context, externalID, id string, disabled bool) error {
+	if f.subscriptionRoutingDisabledByID == nil {
+		f.subscriptionRoutingDisabledByID = map[string]bool{}
+	}
+	f.subscriptionRoutingDisabledByID[id] = disabled
 	return nil
 }
 func (f *fakeInstallationRepository) UpdateUsageBypass(ctx context.Context, externalID, id string, enabled bool, threshold *float64) error {

--- a/internal/postgres/converters.go
+++ b/internal/postgres/converters.go
@@ -24,19 +24,20 @@ func toAuthInstallation(row sqlc.RouterModelRouterInstallation) *auth.Installati
 		preferred = []string{}
 	}
 	return &auth.Installation{
-		ID:                   row.ID.String(),
-		ExternalID:           row.ExternalID,
-		Name:                 row.Name,
-		CreatedAt:            timestampOrZero(row.CreatedAt),
-		UpdatedAt:            timestampOrZero(row.UpdatedAt),
-		DeletedAt:            timestampPtr(row.DeletedAt),
-		CreatedBy:            row.CreatedBy,
-		ExcludedModels:       excluded,
-		ExcludedProviders:    excludedProviders,
-		PreferredModels:      preferred,
-		RoutingQualityWeight: row.RoutingQualityWeight,
-		UsageBypassEnabled:   row.UsageBypassEnabled,
-		UsageBypassThreshold: row.UsageBypassThreshold,
+		ID:                          row.ID.String(),
+		ExternalID:                  row.ExternalID,
+		Name:                        row.Name,
+		CreatedAt:                   timestampOrZero(row.CreatedAt),
+		UpdatedAt:                   timestampOrZero(row.UpdatedAt),
+		DeletedAt:                   timestampPtr(row.DeletedAt),
+		CreatedBy:                   row.CreatedBy,
+		ExcludedModels:              excluded,
+		ExcludedProviders:           excludedProviders,
+		PreferredModels:             preferred,
+		RoutingQualityWeight:        row.RoutingQualityWeight,
+		UsageBypassEnabled:          row.UsageBypassEnabled,
+		UsageBypassThreshold:        row.UsageBypassThreshold,
+		SubscriptionRoutingDisabled: row.SubscriptionRoutingDisabled,
 	}
 }
 

--- a/internal/postgres/repository.go
+++ b/internal/postgres/repository.go
@@ -149,6 +149,19 @@ func (r *installationRepo) UpdateUsageBypass(ctx context.Context, externalID, id
 	})
 }
 
+func (r *installationRepo) UpdateSubscriptionRoutingDisabled(ctx context.Context, externalID, id string, disabled bool) error {
+	parsed, err := uuid.Parse(id)
+	if err != nil {
+		return err
+	}
+	q := sqlc.New(r.tx)
+	return q.UpdateModelRouterInstallationSubscriptionRoutingDisabled(ctx, sqlc.UpdateModelRouterInstallationSubscriptionRoutingDisabledParams{
+		ID:                          parsed,
+		ExternalID:                  externalID,
+		SubscriptionRoutingDisabled: disabled,
+	})
+}
+
 type apiKeyRepo struct {
 	tx sqlc.DBTX
 }

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -273,6 +273,13 @@ type InstallationRoutingKnobsContextKey struct{}
 // UsageBypassConfig. Absent when the installation hasn't enabled the gate.
 type InstallationUsageBypassContextKey struct{}
 
+// InstallationSubscriptionRoutingDisabledContextKey is the context key for the
+// authed installation's "disable subscription-aware routing" toggle. Carried as
+// bool; absent (== false) when the installation hasn't disabled it. When set,
+// subsidyFactors returns nil so the scorer adds no subscription bonus and
+// routing decides on merits. See subscriptionRoutingDisabledForRequest.
+type InstallationSubscriptionRoutingDisabledContextKey struct{}
+
 // UsageBypassConfig is the per-installation subscription usage-bypass setting,
 // stashed on ctx by the auth middleware. Threshold is nil when the toggle is on
 // but no value has been chosen yet; the request path falls back to
@@ -414,6 +421,14 @@ func installationExcludedModelsFromContext(ctx context.Context) []string {
 	}
 	out, _ := v.([]string)
 	return out
+}
+
+// subscriptionRoutingDisabledForRequest reports whether the authed installation
+// has turned off subscription-aware routing. When true, the subscription
+// subsidy bonus is suppressed for this request so routing decides on merits.
+func subscriptionRoutingDisabledForRequest(ctx context.Context) bool {
+	disabled, _ := ctx.Value(InstallationSubscriptionRoutingDisabledContextKey{}).(bool)
+	return disabled
 }
 
 // routingKnobsForRequest resolves the routing knobs for a request. The

--- a/internal/proxy/subsidy.go
+++ b/internal/proxy/subsidy.go
@@ -120,11 +120,22 @@ func (s *Service) withUsageObserver(ctx context.Context, headers http.Header) co
 // would never be observed, so the discount would never engage — a chicken-and-
 // egg that pins routing to whatever wins at full price. The optimistic factor
 // self-corrects to the real headroom once the first subscription-served response
-// records it (including a 429's near-cap reading). Returns nil only when the
-// feature is off or no subscription is present. Keyed identically to
-// withUsageObserver so record and read agree across all three harnesses.
+// records it (including a 429's near-cap reading). Returns nil when the feature
+// is off, no subscription is present, or the installation has disabled
+// subscription-aware routing. Keyed identically to withUsageObserver so record
+// and read agree across all three harnesses.
 func (s *Service) subsidyFactors(ctx context.Context, headers http.Header) map[string]float64 {
 	if s.usageObserver == nil || !s.subsidyEnabled {
+		return nil
+	}
+	// Per-installation opt-out: when the org has disabled subscription-aware
+	// routing, add no subscription bonus so the scorer decides on merits and
+	// non-Claude models (GLM, Kimi, DeepSeek, ...) compete fairly. The
+	// subscription credential is still forwarded downstream for turns that route
+	// to Claude on their own merits, so this removes only the routing bias, not
+	// the prepaid billing path. Keeping the usage observer installed (it is wired
+	// separately in withUsageObserver) preserves the usage-bypass gate.
+	if subscriptionRoutingDisabledForRequest(ctx) {
 		return nil
 	}
 	codexTok, anthroTok := s.presentSubscriptionTokens(ctx, headers)

--- a/internal/proxy/subsidy_test.go
+++ b/internal/proxy/subsidy_test.go
@@ -100,3 +100,26 @@ func TestSubsidyFactors_OptimisticColdStart(t *testing.T) {
 	require.NotNil(t, factors, "a present sub must produce factors even with no observed headroom")
 	assert.InDelta(t, 0.05, factors["claude-opus-4-8"], 1e-9, "cold start = optimistic epsilon (max bias)")
 }
+
+// Per-installation opt-out: when the org has disabled subscription-aware
+// routing, a present subscription must produce NO subsidy factors so the scorer
+// adds no Claude bonus and non-Claude models compete on merits. Mirrors the
+// cold-start case but with the disable flag stashed on ctx by the auth
+// middleware — the discount is otherwise non-nil there, so this asserts the
+// flag is what suppresses it.
+func TestSubsidyFactors_DisabledForInstallation(t *testing.T) {
+	s := (&Service{}).WithSubscriptionAwareRouting(
+		usage.NewObserver([]byte("salt"), time.Minute, time.Now), 0.05, 2.0)
+
+	h := http.Header{}
+	h.Set("Authorization", "Bearer sk-ant-oat01-cold")
+
+	// Sanity: without the flag the same request DOES subsidize (guards against a
+	// vacuous pass if the sub stopped being detected).
+	require.NotNil(t, s.subsidyFactors(context.Background(), h),
+		"baseline: a present sub subsidizes when routing is not disabled")
+
+	ctx := context.WithValue(context.Background(), InstallationSubscriptionRoutingDisabledContextKey{}, true)
+	assert.Nil(t, s.subsidyFactors(ctx, h),
+		"subscription routing disabled → no subsidy bonus, route on merits")
+}

--- a/internal/server/middleware/auth.go
+++ b/internal/server/middleware/auth.go
@@ -139,6 +139,9 @@ func withAPIKey(svc *auth.Service, byokDisabled bool) gin.HandlerFunc {
 					Threshold: installation.UsageBypassThreshold,
 				})
 			}
+			if installation.SubscriptionRoutingDisabled {
+				ctx = context.WithValue(ctx, proxy.InstallationSubscriptionRoutingDisabledContextKey{}, true)
+			}
 		}
 		if externalKeys != nil && !byokDisabled {
 			ctx = context.WithValue(ctx, proxy.ExternalAPIKeysContextKey{}, externalKeys)

--- a/internal/server/middleware/auth_test.go
+++ b/internal/server/middleware/auth_test.go
@@ -113,6 +113,9 @@ func (fakeInstallationRepository) UpdateRoutingPreference(ctx context.Context, e
 func (fakeInstallationRepository) UpdateUsageBypass(ctx context.Context, externalID, id string, enabled bool, threshold *float64) error {
 	return errors.New("not used")
 }
+func (fakeInstallationRepository) UpdateSubscriptionRoutingDisabled(ctx context.Context, externalID, id string, disabled bool) error {
+	return errors.New("not used")
+}
 
 func TestWithAuthPrefersRouterKeyHeader(t *testing.T) {
 	gin.SetMode(gin.TestMode)

--- a/internal/sqlc/model_router_api_keys.sql.go
+++ b/internal/sqlc/model_router_api_keys.sql.go
@@ -92,7 +92,7 @@ func (q *Queries) CreateModelRouterAPIKey(ctx context.Context, arg CreateModelRo
 }
 
 const getActiveModelRouterAPIKeyWithInstallationByHash = `-- name: GetActiveModelRouterAPIKeyWithInstallationByHash :one
-SELECT k.id, k.installation_id, k.external_id, k.name, k.key_prefix, k.key_hash, k.key_suffix, k.last_used_at, k.created_at, k.deleted_at, k.created_by, i.id, i.external_id, i.name, i.created_at, i.updated_at, i.deleted_at, i.created_by, i.excluded_models, i.excluded_providers, i.routing_quality_weight, i.usage_bypass_enabled, i.usage_bypass_threshold, i.preferred_models
+SELECT k.id, k.installation_id, k.external_id, k.name, k.key_prefix, k.key_hash, k.key_suffix, k.last_used_at, k.created_at, k.deleted_at, k.created_by, i.id, i.external_id, i.name, i.created_at, i.updated_at, i.deleted_at, i.created_by, i.excluded_models, i.excluded_providers, i.routing_quality_weight, i.usage_bypass_enabled, i.usage_bypass_threshold, i.preferred_models, i.subscription_routing_disabled
 FROM router.model_router_api_keys k
 INNER JOIN router.model_router_installations i ON i.id = k.installation_id
 WHERE k.key_hash = $1::varchar
@@ -111,7 +111,7 @@ type GetActiveModelRouterAPIKeyWithInstallationByHashRow struct {
 // both sides so a soft-deleted installation invalidates all its keys without per-key
 // updates.
 //
-//	SELECT k.id, k.installation_id, k.external_id, k.name, k.key_prefix, k.key_hash, k.key_suffix, k.last_used_at, k.created_at, k.deleted_at, k.created_by, i.id, i.external_id, i.name, i.created_at, i.updated_at, i.deleted_at, i.created_by, i.excluded_models, i.excluded_providers, i.routing_quality_weight, i.usage_bypass_enabled, i.usage_bypass_threshold, i.preferred_models
+//	SELECT k.id, k.installation_id, k.external_id, k.name, k.key_prefix, k.key_hash, k.key_suffix, k.last_used_at, k.created_at, k.deleted_at, k.created_by, i.id, i.external_id, i.name, i.created_at, i.updated_at, i.deleted_at, i.created_by, i.excluded_models, i.excluded_providers, i.routing_quality_weight, i.usage_bypass_enabled, i.usage_bypass_threshold, i.preferred_models, i.subscription_routing_disabled
 //	FROM router.model_router_api_keys k
 //	INNER JOIN router.model_router_installations i ON i.id = k.installation_id
 //	WHERE k.key_hash = $1::varchar
@@ -145,6 +145,7 @@ func (q *Queries) GetActiveModelRouterAPIKeyWithInstallationByHash(ctx context.C
 		&i.RouterModelRouterInstallation.UsageBypassEnabled,
 		&i.RouterModelRouterInstallation.UsageBypassThreshold,
 		&i.RouterModelRouterInstallation.PreferredModels,
+		&i.RouterModelRouterInstallation.SubscriptionRoutingDisabled,
 	)
 	return i, err
 }

--- a/internal/sqlc/model_router_installations.sql.go
+++ b/internal/sqlc/model_router_installations.sql.go
@@ -22,7 +22,7 @@ VALUES (
     $2::varchar,
     $3
 )
-RETURNING id, external_id, name, created_at, updated_at, deleted_at, created_by, excluded_models, excluded_providers, routing_quality_weight, usage_bypass_enabled, usage_bypass_threshold, preferred_models
+RETURNING id, external_id, name, created_at, updated_at, deleted_at, created_by, excluded_models, excluded_providers, routing_quality_weight, usage_bypass_enabled, usage_bypass_threshold, preferred_models, subscription_routing_disabled
 `
 
 type CreateModelRouterInstallationParams struct {
@@ -43,7 +43,7 @@ type CreateModelRouterInstallationParams struct {
 //	    $2::varchar,
 //	    $3
 //	)
-//	RETURNING id, external_id, name, created_at, updated_at, deleted_at, created_by, excluded_models, excluded_providers, routing_quality_weight, usage_bypass_enabled, usage_bypass_threshold, preferred_models
+//	RETURNING id, external_id, name, created_at, updated_at, deleted_at, created_by, excluded_models, excluded_providers, routing_quality_weight, usage_bypass_enabled, usage_bypass_threshold, preferred_models, subscription_routing_disabled
 func (q *Queries) CreateModelRouterInstallation(ctx context.Context, arg CreateModelRouterInstallationParams) (RouterModelRouterInstallation, error) {
 	row := q.db.QueryRow(ctx, createModelRouterInstallation, arg.ExternalID, arg.Name, arg.CreatedBy)
 	var i RouterModelRouterInstallation
@@ -61,12 +61,13 @@ func (q *Queries) CreateModelRouterInstallation(ctx context.Context, arg CreateM
 		&i.UsageBypassEnabled,
 		&i.UsageBypassThreshold,
 		&i.PreferredModels,
+		&i.SubscriptionRoutingDisabled,
 	)
 	return i, err
 }
 
 const getModelRouterInstallation = `-- name: GetModelRouterInstallation :one
-SELECT id, external_id, name, created_at, updated_at, deleted_at, created_by, excluded_models, excluded_providers, routing_quality_weight, usage_bypass_enabled, usage_bypass_threshold, preferred_models
+SELECT id, external_id, name, created_at, updated_at, deleted_at, created_by, excluded_models, excluded_providers, routing_quality_weight, usage_bypass_enabled, usage_bypass_threshold, preferred_models, subscription_routing_disabled
 FROM router.model_router_installations
 WHERE id = $1::uuid
   AND external_id = $2::varchar
@@ -80,7 +81,7 @@ type GetModelRouterInstallationParams struct {
 
 // Gets an installation by id, scoped to an external_id to prevent cross-tenant access.
 //
-//	SELECT id, external_id, name, created_at, updated_at, deleted_at, created_by, excluded_models, excluded_providers, routing_quality_weight, usage_bypass_enabled, usage_bypass_threshold, preferred_models
+//	SELECT id, external_id, name, created_at, updated_at, deleted_at, created_by, excluded_models, excluded_providers, routing_quality_weight, usage_bypass_enabled, usage_bypass_threshold, preferred_models, subscription_routing_disabled
 //	FROM router.model_router_installations
 //	WHERE id = $1::uuid
 //	  AND external_id = $2::varchar
@@ -102,12 +103,13 @@ func (q *Queries) GetModelRouterInstallation(ctx context.Context, arg GetModelRo
 		&i.UsageBypassEnabled,
 		&i.UsageBypassThreshold,
 		&i.PreferredModels,
+		&i.SubscriptionRoutingDisabled,
 	)
 	return i, err
 }
 
 const listModelRouterInstallationsForExternalID = `-- name: ListModelRouterInstallationsForExternalID :many
-SELECT id, external_id, name, created_at, updated_at, deleted_at, created_by, excluded_models, excluded_providers, routing_quality_weight, usage_bypass_enabled, usage_bypass_threshold, preferred_models
+SELECT id, external_id, name, created_at, updated_at, deleted_at, created_by, excluded_models, excluded_providers, routing_quality_weight, usage_bypass_enabled, usage_bypass_threshold, preferred_models, subscription_routing_disabled
 FROM router.model_router_installations
 WHERE external_id = $1::varchar
   AND deleted_at IS NULL
@@ -116,7 +118,7 @@ ORDER BY created_at DESC
 
 // ListModelRouterInstallationsForExternalID
 //
-//	SELECT id, external_id, name, created_at, updated_at, deleted_at, created_by, excluded_models, excluded_providers, routing_quality_weight, usage_bypass_enabled, usage_bypass_threshold, preferred_models
+//	SELECT id, external_id, name, created_at, updated_at, deleted_at, created_by, excluded_models, excluded_providers, routing_quality_weight, usage_bypass_enabled, usage_bypass_threshold, preferred_models, subscription_routing_disabled
 //	FROM router.model_router_installations
 //	WHERE external_id = $1::varchar
 //	  AND deleted_at IS NULL
@@ -144,6 +146,7 @@ func (q *Queries) ListModelRouterInstallationsForExternalID(ctx context.Context,
 			&i.UsageBypassEnabled,
 			&i.UsageBypassThreshold,
 			&i.PreferredModels,
+			&i.SubscriptionRoutingDisabled,
 		); err != nil {
 			return nil, err
 		}
@@ -267,6 +270,38 @@ type UpdateModelRouterInstallationRoutingPreferenceParams struct {
 //	  AND deleted_at IS NULL
 func (q *Queries) UpdateModelRouterInstallationRoutingPreference(ctx context.Context, arg UpdateModelRouterInstallationRoutingPreferenceParams) error {
 	_, err := q.db.Exec(ctx, updateModelRouterInstallationRoutingPreference, arg.RoutingQualityWeight, arg.ID, arg.ExternalID)
+	return err
+}
+
+const updateModelRouterInstallationSubscriptionRoutingDisabled = `-- name: UpdateModelRouterInstallationSubscriptionRoutingDisabled :exec
+UPDATE router.model_router_installations
+SET subscription_routing_disabled = $1::boolean,
+    updated_at = NOW()
+WHERE id = $2::uuid
+  AND external_id = $3::varchar
+  AND deleted_at IS NULL
+`
+
+type UpdateModelRouterInstallationSubscriptionRoutingDisabledParams struct {
+	SubscriptionRoutingDisabled bool
+	ID                          uuid.UUID
+	ExternalID                  string
+}
+
+// Toggles subscription-aware routing for the installation, scoped to an
+// external_id to prevent cross-tenant updates. When true, the scorer's
+// subscription subsidy bonus is suppressed so routing decides on merits and
+// non-Claude models compete fairly; the subscription credential is still
+// forwarded for turns that route to Claude on their own merits.
+//
+//	UPDATE router.model_router_installations
+//	SET subscription_routing_disabled = $1::boolean,
+//	    updated_at = NOW()
+//	WHERE id = $2::uuid
+//	  AND external_id = $3::varchar
+//	  AND deleted_at IS NULL
+func (q *Queries) UpdateModelRouterInstallationSubscriptionRoutingDisabled(ctx context.Context, arg UpdateModelRouterInstallationSubscriptionRoutingDisabledParams) error {
+	_, err := q.db.Exec(ctx, updateModelRouterInstallationSubscriptionRoutingDisabled, arg.SubscriptionRoutingDisabled, arg.ID, arg.ExternalID)
 	return err
 }
 

--- a/internal/sqlc/models.go
+++ b/internal/sqlc/models.go
@@ -66,19 +66,20 @@ type RouterModelRouterExternalAPIKey struct {
 
 // Customer router installations; owns API keys
 type RouterModelRouterInstallation struct {
-	ID                   uuid.UUID
-	ExternalID           string
-	Name                 string
-	CreatedAt            pgtype.Timestamp
-	UpdatedAt            pgtype.Timestamp
-	DeletedAt            pgtype.Timestamp
-	CreatedBy            *string
-	ExcludedModels       []string
-	ExcludedProviders    []string
-	RoutingQualityWeight *float64
-	UsageBypassEnabled   bool
-	UsageBypassThreshold *float64
-	PreferredModels      []string
+	ID                          uuid.UUID
+	ExternalID                  string
+	Name                        string
+	CreatedAt                   pgtype.Timestamp
+	UpdatedAt                   pgtype.Timestamp
+	DeletedAt                   pgtype.Timestamp
+	CreatedBy                   *string
+	ExcludedModels              []string
+	ExcludedProviders           []string
+	RoutingQualityWeight        *float64
+	UsageBypassEnabled          bool
+	UsageBypassThreshold        *float64
+	PreferredModels             []string
+	SubscriptionRoutingDisabled bool
 }
 
 type RouterModelRouterRequestTelemetry struct {


### PR DESCRIPTION
## What

Adds a per-installation `subscription_routing_disabled` flag on `model_router_installations`. When set, `subsidyFactors()` returns `nil`, so the cluster scorer adds **no subscription bonus** and routing decides purely on quality/cost/speed merits — non-Claude models (GLM, Kimi, DeepSeek, …) compete fairly instead of always losing to the subsidized Claude family.

## Why

Customer ask (Redwood): a Claude-team-subscription org seeing ~everything land on Opus/Sonnet and wanting traffic to reach Kimi-2.7 / GLM-5.2. Root cause is the subscription subsidy bonus, which uniformly lifts the whole Claude family above non-Claude options. This gives the org a switch to opt out of that bias.

## Scope: routing bias only, not billing

This removes **only the routing bias**. A turn that still routes to Claude on its own merits is dispatched on the caller's subscription token exactly as before — prepaid 5% margin unchanged. The usage observer stays installed (wired separately in `withUsageObserver`), so the usage-bypass gate is unaffected.

## How (mirrors `usage_bypass_enabled` end-to-end)

- migration `0029` (`BOOLEAN NOT NULL DEFAULT FALSE`)
- SQLC `UpdateModelRouterInstallationSubscriptionRoutingDisabled` query
- `postgres` repo method + `toAuthInstallation` mapping
- `auth.Installation.SubscriptionRoutingDisabled` + repo iface + cache-invalidating `Service.SetInstallationSubscriptionRoutingDisabled`
- `proxy` context key + `subscriptionRoutingDisabledForRequest` reader
- auth middleware stashes the flag on ctx
- **seam:** `subsidyFactors` early-returns `nil` when the flag is set

Default `false` preserves today's behavior for every existing installation.

## Tests

- `TestSubsidyFactors_DisabledForInstallation` — asserts a present subscription yields non-nil factors normally, but `nil` once the ctx flag is set (non-vacuous: checks the baseline first).
- Fakes updated; `internal/{auth,postgres,proxy,server/middleware}` packages green.

The WorkWeave side (weaverouter plumbing + GraphQL + a "route on merits" checkbox in the routing-priority panel) lands as a companion PR that bumps the gitlink to this PR's merge commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)