### PR TITLE
fix(postgres): surface zero-row installation updates as ErrInstallationNotFound

### DIFF
--- a/db/queries/model_router_installations.sql
+++ b/db/queries/model_router_installations.sql
@@ -37,7 +37,7 @@ WHERE id = @id::uuid
 -- Replaces the per-installation model exclusion list, scoped to an external_id
 -- to prevent cross-tenant updates. Empty array means "no exclusion". Bumps
 -- updated_at so dashboards see the change.
--- name: UpdateModelRouterInstallationExcludedModels :exec
+-- name: UpdateModelRouterInstallationExcludedModels :execrows
 UPDATE router.model_router_installations
 SET excluded_models = @excluded_models::text[],
     updated_at = NOW()
@@ -48,7 +48,7 @@ WHERE id = @id::uuid
 -- Replaces the per-installation provider exclusion list, scoped to an
 -- external_id to prevent cross-tenant updates. Empty array means "no
 -- exclusion". Bumps updated_at so dashboards see the change.
--- name: UpdateModelRouterInstallationExcludedProviders :exec
+-- name: UpdateModelRouterInstallationExcludedProviders :execrows
 UPDATE router.model_router_installations
 SET excluded_providers = @excluded_providers::text[],
     updated_at = NOW()
@@ -59,7 +59,7 @@ WHERE id = @id::uuid
 -- Sets the routing preference quality weight (a normalized fraction in [0, 1]),
 -- scoped to an external_id to prevent cross-tenant updates. NULL clears the
 -- preference so the scorer reverts to its tuned defaults.
--- name: UpdateModelRouterInstallationRoutingPreference :exec
+-- name: UpdateModelRouterInstallationRoutingPreference :execrows
 UPDATE router.model_router_installations
 SET routing_quality_weight = sqlc.narg('routing_quality_weight'),
     updated_at = NOW()
@@ -71,7 +71,7 @@ WHERE id = @id::uuid
 -- cross-tenant updates. enabled toggles the gate; threshold is the [0, 1]
 -- utilization at/above which the gate disengages and normal routing takes over.
 -- A NULL threshold means "use the deployment default" at request time.
--- name: UpdateModelRouterInstallationUsageBypass :exec
+-- name: UpdateModelRouterInstallationUsageBypass :execrows
 UPDATE router.model_router_installations
 SET usage_bypass_enabled = @usage_bypass_enabled::boolean,
     usage_bypass_threshold = sqlc.narg('usage_bypass_threshold'),
@@ -85,7 +85,7 @@ WHERE id = @id::uuid
 -- subscription subsidy bonus is suppressed so routing decides on merits and
 -- non-Claude models compete fairly; the subscription credential is still
 -- forwarded for turns that route to Claude on their own merits.
--- name: UpdateModelRouterInstallationSubscriptionRoutingDisabled :exec
+-- name: UpdateModelRouterInstallationSubscriptionRoutingDisabled :execrows
 UPDATE router.model_router_installations
 SET subscription_routing_disabled = @subscription_routing_disabled::boolean,
     updated_at = NOW()

--- a/internal/auth/errors.go
+++ b/internal/auth/errors.go
@@ -11,4 +11,10 @@ var (
 	// ErrAPIKeyNotFound is returned when a rotate/delete targets a key that is
 	// either missing or owned by a different installation.
 	ErrAPIKeyNotFound = errors.New("api key not found")
+
+	// ErrInstallationNotFound is returned when an installation update matches no
+	// row — a stale, soft-deleted, or cross-tenant id. Without it a zero-row
+	// UPDATE looks like success, so the caller would invalidate the cache and
+	// report the change as applied when nothing changed.
+	ErrInstallationNotFound = errors.New("installation not found")
 )

--- a/internal/auth/service_test.go
+++ b/internal/auth/service_test.go
@@ -121,6 +121,9 @@ func (fakeInstallationRepository) SoftDelete(ctx context.Context, externalID, id
 	return errors.New("not used")
 }
 func (f *fakeInstallationRepository) UpdateExcludedModels(ctx context.Context, externalID, id string, models []string) error {
+	if f.updateErr != nil {
+		return f.updateErr
+	}
 	if f.excludedModelsByID == nil {
 		f.excludedModelsByID = map[string][]string{}
 	}
@@ -132,6 +135,9 @@ func (f *fakeInstallationRepository) UpdateExcludedModels(ctx context.Context, e
 	return nil
 }
 func (f *fakeInstallationRepository) UpdateExcludedProviders(ctx context.Context, externalID, id string, providerNames []string) error {
+	if f.updateErr != nil {
+		return f.updateErr
+	}
 	if f.excludedProvidersByID == nil {
 		f.excludedProvidersByID = map[string][]string{}
 	}
@@ -153,6 +159,9 @@ func (f *fakeInstallationRepository) UpdateRoutingPreference(ctx context.Context
 	return nil
 }
 func (f *fakeInstallationRepository) UpdateSubscriptionRoutingDisabled(ctx context.Context, externalID, id string, disabled bool) error {
+	if f.updateErr != nil {
+		return f.updateErr
+	}
 	if f.subscriptionRoutingDisabledByID == nil {
 		f.subscriptionRoutingDisabledByID = map[string]bool{}
 	}
@@ -160,6 +169,9 @@ func (f *fakeInstallationRepository) UpdateSubscriptionRoutingDisabled(ctx conte
 	return nil
 }
 func (f *fakeInstallationRepository) UpdateUsageBypass(ctx context.Context, externalID, id string, enabled bool, threshold *float64) error {
+	if f.updateErr != nil {
+		return f.updateErr
+	}
 	if f.usageBypassEnabledByID == nil {
 		f.usageBypassEnabledByID = map[string]bool{}
 	}
@@ -727,20 +739,45 @@ func TestService_SetInstallationRoutingPreference(t *testing.T) {
 }
 
 // A zero-row update (stale / soft-deleted / cross-tenant id) surfaces from the
-// repo as ErrInstallationNotFound. The Service must propagate it AND must not
-// invalidate the cache — otherwise the write looks successful and the next
+// repo as ErrInstallationNotFound. Every Set* method must propagate it AND must
+// not invalidate the cache — otherwise the write looks successful and the next
 // requests would reload an unchanged row, the silent-no-op the rows-affected
-// guard exists to prevent.
-func TestService_SetInstallationRoutingPreference_NotFoundDoesNotInvalidate(t *testing.T) {
-	cache := newRecordingAPIKeyCache()
-	installRepo := &fakeInstallationRepository{updateErr: auth.ErrInstallationNotFound}
-	svc := auth.NewService(installRepo, &fakeAPIKeyRepository{byHash: map[string]fakeKeyRow{}}, nil, nil, cache, nil, frozenClock())
-
+// guard exists to prevent. Each method invalidates independently, so each is
+// asserted independently.
+func TestService_SetInstallation_NotFoundDoesNotInvalidate(t *testing.T) {
 	quality := 0.6
-	err := svc.SetInstallationRoutingPreference(context.Background(), "ext-1", "missing-inst", &quality)
-	require.ErrorIs(t, err, auth.ErrInstallationNotFound)
-	assert.Empty(t, cache.invalidationSnapshot(),
-		"a no-op update must not invalidate the cache — nothing changed to pick up")
+	cases := []struct {
+		name string
+		call func(context.Context, *auth.Service) error
+	}{
+		{"ExcludedModels", func(ctx context.Context, svc *auth.Service) error {
+			_, err := svc.SetInstallationExcludedModels(ctx, "ext-1", "missing-inst", []string{"opus"}, nil)
+			return err
+		}},
+		{"ExcludedProviders", func(ctx context.Context, svc *auth.Service) error {
+			_, err := svc.SetInstallationExcludedProviders(ctx, "ext-1", "missing-inst", []string{"openai"}, nil)
+			return err
+		}},
+		{"RoutingPreference", func(ctx context.Context, svc *auth.Service) error {
+			return svc.SetInstallationRoutingPreference(ctx, "ext-1", "missing-inst", &quality)
+		}},
+		{"SubscriptionRoutingDisabled", func(ctx context.Context, svc *auth.Service) error {
+			return svc.SetInstallationSubscriptionRoutingDisabled(ctx, "ext-1", "missing-inst", true)
+		}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cache := newRecordingAPIKeyCache()
+			installRepo := &fakeInstallationRepository{updateErr: auth.ErrInstallationNotFound}
+			svc := auth.NewService(installRepo, &fakeAPIKeyRepository{byHash: map[string]fakeKeyRow{}}, nil, nil, cache, nil, frozenClock())
+
+			err := tc.call(context.Background(), svc)
+			require.ErrorIs(t, err, auth.ErrInstallationNotFound)
+			assert.Empty(t, cache.invalidationSnapshot(),
+				"a no-op update must not invalidate the cache — nothing changed to pick up")
+		})
+	}
 }
 
 type recordingNotifier struct {

--- a/internal/auth/service_test.go
+++ b/internal/auth/service_test.go
@@ -102,6 +102,10 @@ type fakeInstallationRepository struct {
 	usageBypassEnabledByID          map[string]bool
 	usageBypassThresholdByID        map[string]*float64
 	subscriptionRoutingDisabledByID map[string]bool
+	// updateErr, when set, is returned by Update* methods instead of recording —
+	// simulates a zero-row update (stale/soft-deleted/cross-tenant id), which the
+	// real postgres repo surfaces as auth.ErrInstallationNotFound.
+	updateErr error
 }
 
 func (fakeInstallationRepository) Create(ctx context.Context, params auth.CreateInstallationParams) (*auth.Installation, error) {
@@ -139,6 +143,9 @@ func (f *fakeInstallationRepository) UpdateExcludedProviders(ctx context.Context
 	return nil
 }
 func (f *fakeInstallationRepository) UpdateRoutingPreference(ctx context.Context, externalID, id string, qualityWeight *float64) error {
+	if f.updateErr != nil {
+		return f.updateErr
+	}
 	if f.routingQualityByID == nil {
 		f.routingQualityByID = map[string]*float64{}
 	}
@@ -717,6 +724,23 @@ func TestService_SetInstallationRoutingPreference(t *testing.T) {
 		require.NoError(t, err)
 		assert.Nil(t, installRepo.routingQualityByID["inst-1"])
 	})
+}
+
+// A zero-row update (stale / soft-deleted / cross-tenant id) surfaces from the
+// repo as ErrInstallationNotFound. The Service must propagate it AND must not
+// invalidate the cache — otherwise the write looks successful and the next
+// requests would reload an unchanged row, the silent-no-op the rows-affected
+// guard exists to prevent.
+func TestService_SetInstallationRoutingPreference_NotFoundDoesNotInvalidate(t *testing.T) {
+	cache := newRecordingAPIKeyCache()
+	installRepo := &fakeInstallationRepository{updateErr: auth.ErrInstallationNotFound}
+	svc := auth.NewService(installRepo, &fakeAPIKeyRepository{byHash: map[string]fakeKeyRow{}}, nil, nil, cache, nil, frozenClock())
+
+	quality := 0.6
+	err := svc.SetInstallationRoutingPreference(context.Background(), "ext-1", "missing-inst", &quality)
+	require.ErrorIs(t, err, auth.ErrInstallationNotFound)
+	assert.Empty(t, cache.invalidationSnapshot(),
+		"a no-op update must not invalidate the cache — nothing changed to pick up")
 }
 
 type recordingNotifier struct {

--- a/internal/postgres/repository.go
+++ b/internal/postgres/repository.go
@@ -99,11 +99,18 @@ func (r *installationRepo) UpdateExcludedModels(ctx context.Context, externalID,
 		models = []string{}
 	}
 	q := sqlc.New(r.tx)
-	return q.UpdateModelRouterInstallationExcludedModels(ctx, sqlc.UpdateModelRouterInstallationExcludedModelsParams{
+	rows, err := q.UpdateModelRouterInstallationExcludedModels(ctx, sqlc.UpdateModelRouterInstallationExcludedModelsParams{
 		ID:             parsed,
 		ExternalID:     externalID,
 		ExcludedModels: models,
 	})
+	if err != nil {
+		return err
+	}
+	if rows == 0 {
+		return auth.ErrInstallationNotFound
+	}
+	return nil
 }
 
 func (r *installationRepo) UpdateExcludedProviders(ctx context.Context, externalID, id string, providerNames []string) error {
@@ -115,11 +122,18 @@ func (r *installationRepo) UpdateExcludedProviders(ctx context.Context, external
 		providerNames = []string{}
 	}
 	q := sqlc.New(r.tx)
-	return q.UpdateModelRouterInstallationExcludedProviders(ctx, sqlc.UpdateModelRouterInstallationExcludedProvidersParams{
+	rows, err := q.UpdateModelRouterInstallationExcludedProviders(ctx, sqlc.UpdateModelRouterInstallationExcludedProvidersParams{
 		ID:                parsed,
 		ExternalID:        externalID,
 		ExcludedProviders: providerNames,
 	})
+	if err != nil {
+		return err
+	}
+	if rows == 0 {
+		return auth.ErrInstallationNotFound
+	}
+	return nil
 }
 
 func (r *installationRepo) UpdateRoutingPreference(ctx context.Context, externalID, id string, qualityWeight *float64) error {
@@ -128,11 +142,18 @@ func (r *installationRepo) UpdateRoutingPreference(ctx context.Context, external
 		return err
 	}
 	q := sqlc.New(r.tx)
-	return q.UpdateModelRouterInstallationRoutingPreference(ctx, sqlc.UpdateModelRouterInstallationRoutingPreferenceParams{
+	rows, err := q.UpdateModelRouterInstallationRoutingPreference(ctx, sqlc.UpdateModelRouterInstallationRoutingPreferenceParams{
 		ID:                   parsed,
 		ExternalID:           externalID,
 		RoutingQualityWeight: qualityWeight,
 	})
+	if err != nil {
+		return err
+	}
+	if rows == 0 {
+		return auth.ErrInstallationNotFound
+	}
+	return nil
 }
 
 func (r *installationRepo) UpdateUsageBypass(ctx context.Context, externalID, id string, enabled bool, threshold *float64) error {
@@ -141,12 +162,19 @@ func (r *installationRepo) UpdateUsageBypass(ctx context.Context, externalID, id
 		return err
 	}
 	q := sqlc.New(r.tx)
-	return q.UpdateModelRouterInstallationUsageBypass(ctx, sqlc.UpdateModelRouterInstallationUsageBypassParams{
+	rows, err := q.UpdateModelRouterInstallationUsageBypass(ctx, sqlc.UpdateModelRouterInstallationUsageBypassParams{
 		ID:                   parsed,
 		ExternalID:           externalID,
 		UsageBypassEnabled:   enabled,
 		UsageBypassThreshold: threshold,
 	})
+	if err != nil {
+		return err
+	}
+	if rows == 0 {
+		return auth.ErrInstallationNotFound
+	}
+	return nil
 }
 
 func (r *installationRepo) UpdateSubscriptionRoutingDisabled(ctx context.Context, externalID, id string, disabled bool) error {
@@ -155,11 +183,18 @@ func (r *installationRepo) UpdateSubscriptionRoutingDisabled(ctx context.Context
 		return err
 	}
 	q := sqlc.New(r.tx)
-	return q.UpdateModelRouterInstallationSubscriptionRoutingDisabled(ctx, sqlc.UpdateModelRouterInstallationSubscriptionRoutingDisabledParams{
+	rows, err := q.UpdateModelRouterInstallationSubscriptionRoutingDisabled(ctx, sqlc.UpdateModelRouterInstallationSubscriptionRoutingDisabledParams{
 		ID:                          parsed,
 		ExternalID:                  externalID,
 		SubscriptionRoutingDisabled: disabled,
 	})
+	if err != nil {
+		return err
+	}
+	if rows == 0 {
+		return auth.ErrInstallationNotFound
+	}
+	return nil
 }
 
 type apiKeyRepo struct {

--- a/internal/sqlc/model_router_installations.sql.go
+++ b/internal/sqlc/model_router_installations.sql.go
@@ -183,7 +183,7 @@ func (q *Queries) SoftDeleteModelRouterInstallation(ctx context.Context, arg Sof
 	return err
 }
 
-const updateModelRouterInstallationExcludedModels = `-- name: UpdateModelRouterInstallationExcludedModels :exec
+const updateModelRouterInstallationExcludedModels = `-- name: UpdateModelRouterInstallationExcludedModels :execrows
 UPDATE router.model_router_installations
 SET excluded_models = $1::text[],
     updated_at = NOW()
@@ -208,12 +208,15 @@ type UpdateModelRouterInstallationExcludedModelsParams struct {
 //	WHERE id = $2::uuid
 //	  AND external_id = $3::varchar
 //	  AND deleted_at IS NULL
-func (q *Queries) UpdateModelRouterInstallationExcludedModels(ctx context.Context, arg UpdateModelRouterInstallationExcludedModelsParams) error {
-	_, err := q.db.Exec(ctx, updateModelRouterInstallationExcludedModels, arg.ExcludedModels, arg.ID, arg.ExternalID)
-	return err
+func (q *Queries) UpdateModelRouterInstallationExcludedModels(ctx context.Context, arg UpdateModelRouterInstallationExcludedModelsParams) (int64, error) {
+	result, err := q.db.Exec(ctx, updateModelRouterInstallationExcludedModels, arg.ExcludedModels, arg.ID, arg.ExternalID)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
 }
 
-const updateModelRouterInstallationExcludedProviders = `-- name: UpdateModelRouterInstallationExcludedProviders :exec
+const updateModelRouterInstallationExcludedProviders = `-- name: UpdateModelRouterInstallationExcludedProviders :execrows
 UPDATE router.model_router_installations
 SET excluded_providers = $1::text[],
     updated_at = NOW()
@@ -238,12 +241,15 @@ type UpdateModelRouterInstallationExcludedProvidersParams struct {
 //	WHERE id = $2::uuid
 //	  AND external_id = $3::varchar
 //	  AND deleted_at IS NULL
-func (q *Queries) UpdateModelRouterInstallationExcludedProviders(ctx context.Context, arg UpdateModelRouterInstallationExcludedProvidersParams) error {
-	_, err := q.db.Exec(ctx, updateModelRouterInstallationExcludedProviders, arg.ExcludedProviders, arg.ID, arg.ExternalID)
-	return err
+func (q *Queries) UpdateModelRouterInstallationExcludedProviders(ctx context.Context, arg UpdateModelRouterInstallationExcludedProvidersParams) (int64, error) {
+	result, err := q.db.Exec(ctx, updateModelRouterInstallationExcludedProviders, arg.ExcludedProviders, arg.ID, arg.ExternalID)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
 }
 
-const updateModelRouterInstallationRoutingPreference = `-- name: UpdateModelRouterInstallationRoutingPreference :exec
+const updateModelRouterInstallationRoutingPreference = `-- name: UpdateModelRouterInstallationRoutingPreference :execrows
 UPDATE router.model_router_installations
 SET routing_quality_weight = $1,
     updated_at = NOW()
@@ -268,12 +274,15 @@ type UpdateModelRouterInstallationRoutingPreferenceParams struct {
 //	WHERE id = $2::uuid
 //	  AND external_id = $3::varchar
 //	  AND deleted_at IS NULL
-func (q *Queries) UpdateModelRouterInstallationRoutingPreference(ctx context.Context, arg UpdateModelRouterInstallationRoutingPreferenceParams) error {
-	_, err := q.db.Exec(ctx, updateModelRouterInstallationRoutingPreference, arg.RoutingQualityWeight, arg.ID, arg.ExternalID)
-	return err
+func (q *Queries) UpdateModelRouterInstallationRoutingPreference(ctx context.Context, arg UpdateModelRouterInstallationRoutingPreferenceParams) (int64, error) {
+	result, err := q.db.Exec(ctx, updateModelRouterInstallationRoutingPreference, arg.RoutingQualityWeight, arg.ID, arg.ExternalID)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
 }
 
-const updateModelRouterInstallationSubscriptionRoutingDisabled = `-- name: UpdateModelRouterInstallationSubscriptionRoutingDisabled :exec
+const updateModelRouterInstallationSubscriptionRoutingDisabled = `-- name: UpdateModelRouterInstallationSubscriptionRoutingDisabled :execrows
 UPDATE router.model_router_installations
 SET subscription_routing_disabled = $1::boolean,
     updated_at = NOW()
@@ -300,12 +309,15 @@ type UpdateModelRouterInstallationSubscriptionRoutingDisabledParams struct {
 //	WHERE id = $2::uuid
 //	  AND external_id = $3::varchar
 //	  AND deleted_at IS NULL
-func (q *Queries) UpdateModelRouterInstallationSubscriptionRoutingDisabled(ctx context.Context, arg UpdateModelRouterInstallationSubscriptionRoutingDisabledParams) error {
-	_, err := q.db.Exec(ctx, updateModelRouterInstallationSubscriptionRoutingDisabled, arg.SubscriptionRoutingDisabled, arg.ID, arg.ExternalID)
-	return err
+func (q *Queries) UpdateModelRouterInstallationSubscriptionRoutingDisabled(ctx context.Context, arg UpdateModelRouterInstallationSubscriptionRoutingDisabledParams) (int64, error) {
+	result, err := q.db.Exec(ctx, updateModelRouterInstallationSubscriptionRoutingDisabled, arg.SubscriptionRoutingDisabled, arg.ID, arg.ExternalID)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
 }
 
-const updateModelRouterInstallationUsageBypass = `-- name: UpdateModelRouterInstallationUsageBypass :exec
+const updateModelRouterInstallationUsageBypass = `-- name: UpdateModelRouterInstallationUsageBypass :execrows
 UPDATE router.model_router_installations
 SET usage_bypass_enabled = $1::boolean,
     usage_bypass_threshold = $2,
@@ -334,12 +346,15 @@ type UpdateModelRouterInstallationUsageBypassParams struct {
 //	WHERE id = $3::uuid
 //	  AND external_id = $4::varchar
 //	  AND deleted_at IS NULL
-func (q *Queries) UpdateModelRouterInstallationUsageBypass(ctx context.Context, arg UpdateModelRouterInstallationUsageBypassParams) error {
-	_, err := q.db.Exec(ctx, updateModelRouterInstallationUsageBypass,
+func (q *Queries) UpdateModelRouterInstallationUsageBypass(ctx context.Context, arg UpdateModelRouterInstallationUsageBypassParams) (int64, error) {
+	result, err := q.db.Exec(ctx, updateModelRouterInstallationUsageBypass,
 		arg.UsageBypassEnabled,
 		arg.UsageBypassThreshold,
 		arg.ID,
 		arg.ExternalID,
 	)
-	return err
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
 }


### PR DESCRIPTION
## What

The five per-installation update methods — `excluded_models`, `excluded_providers`, `routing_preference`, `usage_bypass`, `subscription_routing_disabled` — ran their `UPDATE` as SQLC `:exec`, discarding the rows-affected count. A stale / soft-deleted / cross-tenant id matched **zero rows** but still returned `nil`, so the caller's `Set*` helper invalidated the cache and reported success even though nothing changed.

This switches all five to `:execrows` and returns a new `auth.ErrInstallationNotFound` sentinel when no row matched. Since `Set*` returns *before* invalidating, a no-op update now also leaves the cache untouched.

## Why

Follow-up to greptile's P2 on #547. The concern was real but applied to **every** sibling method, not just the new `subscription_routing_disabled` one — so fixing it consistently across all five (rather than one-off) keeps the pattern uniform.

## Scope / impact

- Happy path unchanged.
- The admin call sites resolve the installation from the verified request context before calling `Set*`, so the zero-row case only happens on a genuine concurrent-delete race. It currently surfaces as the handlers' existing generic 500 (a real failure) instead of a false 200 — I deliberately did **not** expand into per-handler 404 mapping for a near-impossible case; happy to if you'd prefer.
- `SoftDeleteModelRouterInstallation` left as `:exec` (out of scope; not a value-change update).

## Tests

`TestService_SetInstallationRoutingPreference_NotFoundDoesNotInvalidate` — asserts the sentinel propagates **and** the cache is not invalidated on a no-op update (the composition that makes the guard effective). The repo-level rows==0 path needs a DB, which `internal/` doesn't unit-test by convention. Build + `internal/{auth,postgres}` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)