### PR TITLE
chore(repo): agentic OSS maintenance — templates, automation, governance, skills

### DIFF
--- a/.claude/skills/add-provider/SKILL.md
+++ b/.claude/skills/add-provider/SKILL.md
@@ -1,0 +1,98 @@
+---
+name: add-provider
+description: Add a new upstream provider or model to the router — catalog entry, optional provider wiring, and the required tests. Use when a contributor wants to add a provider (Together, DeepInfra, Cerebras, a self-hosted vLLM/OpenAI-compatible endpoint, etc.) or make a new model routable. This is THE recipe for provider/model PRs; follow every step.
+---
+
+# Adding a provider or model to router
+
+Most "add my model" contributions are an **OpenAI-compatible upstream**, which needs **no new adapter package** — just a base-URL constant, a provider constant + env var, a registration block copied from an existing provider, and a catalog entry. Follow the steps in order. The definition of done is at the bottom; a PR that skips a step gets sent back here.
+
+Read first: [`internal/providers/CLAUDE.md`](../../../internal/providers/CLAUDE.md) and [`internal/router/catalog/CLAUDE.md`](../../../internal/router/catalog/CLAUDE.md).
+
+## Decide the shape
+
+- **New model on a provider already wired** (anthropic, openai, google, openrouter, fireworks, deepinfra, bedrock, makora) → you only need **Step 4 (catalog)**. Skip 1–3.
+- **New OpenAI-compatible upstream** (vLLM, Together, DeepInfra-likes, customer endpoint) → do **Steps 1–4**. No new adapter package.
+- **New non-OpenAI wire format** (a brand-new Anthropic/Gemini-shaped API) → this needs a real adapter package and is maintainer territory; open a [provider request issue](../../../.github/ISSUE_TEMPLATE/provider_request.yml) first instead of guessing.
+
+## Step 1 — Base URL constant
+
+Add a `*BaseURL` constant alongside the others in
+[`internal/providers/openaicompat/client.go`](../../../internal/providers/openaicompat/client.go)
+(see `DefaultBaseURL`, `FireworksBaseURL`, `DeepInfraBaseURL`, `MakoraBaseURL`):
+
+```go
+TogetherBaseURL = "https://api.together.xyz/v1"
+```
+
+## Step 2 — Provider constant + env var
+
+In [`internal/providers/provider.go`](../../../internal/providers/provider.go):
+
+1. Add a `Provider*` constant to the block (`ProviderTogether = "together"`).
+2. Add the matching entry to `APIKeyEnvVars` (`ProviderTogether: "TOGETHER_API_KEY"`).
+3. Add a cache-TTL entry to the TTL map if the provider streams (mirror the 5-minute entries).
+
+`APIKeyEnvVars` is the single source of truth the admin `/config` view reads — never wire a key without adding it here, or config drifts from reality.
+
+## Step 3 — Register in the composition root
+
+`cmd/router/main.go` is the **only** file that constructs concrete providers. **Copy the nearest existing block** (the DeepInfra block is the canonical template for an OpenAI-compatible upstream that needs model-ID mapping) and adapt the names:
+
+```go
+{
+    togetherBaseURL := config.GetOr("TOGETHER_BASE_URL", openaiCompatProvider.TogetherBaseURL)
+    togetherKey := ""
+    if !byokOnly {
+        togetherKey = config.GetOr("TOGETHER_API_KEY", "")
+    }
+    providerMap[providers.ProviderTogether] = openaiCompatProvider.NewClientWithModelIDMap(
+        togetherKey, togetherBaseURL, upstreamIDsForProvider(providers.ProviderTogether))
+    switch {
+    case byokOnly:
+        logger.Info("Together provider enabled (BYOK only)", "base_url", togetherBaseURL)
+    case togetherKey != "":
+        envKeyedProviders[providers.ProviderTogether] = struct{}{}
+        logger.Info("Together provider enabled", "base_url", togetherBaseURL)
+    default:
+        logger.Info("Together provider registered (BYOK only — set TOGETHER_API_KEY for deployment-level use)", "base_url", togetherBaseURL)
+    }
+}
+```
+
+Rules that this preserves (don't break them):
+- The provider goes into `providerMap` **regardless of mode** (so BYOK/passthrough works without a deployment key).
+- It joins `envKeyedProviders` **only** when a real deployment key is present (hard-pin resolution depends on this).
+- Use `NewClientWithModelIDMap` + `upstreamIDsForProvider(...)` if the upstream's model IDs differ from the router's slugs; plain `NewClient` otherwise.
+- Add the `*_BASE_URL` and `*_API_KEY` vars to [`.env.example`](../../../.env.example) and [`docs/CONFIGURATION.md`](../../../docs/CONFIGURATION.md).
+
+## Step 4 — Catalog entry (the source of truth for the model)
+
+Per-model data lives in [`internal/router/catalog/catalog.go`](../../../internal/router/catalog/catalog.go) — `Tier`, `ProviderBindings` (`Provider` + `UpstreamID` + `Pricing`), and capability flags. Add or extend the `Model`:
+
+- Set `Tier` (`TierLow` / `TierMid` / `TierHigh`) honestly.
+- Add a `ProviderBinding` with the `providers.Provider*` constant, the upstream's exact model ID as `UpstreamID`, and correct `Pricing` (input/output $/MTok). Wrong prices break cost-aware routing.
+- The binding order is load-bearing: the first binding whose provider is available in the deploy wins. Put the preferred/cheapest provider first.
+
+## What you can't do as a contributor (maintainer step)
+
+Making a model show up in the **cluster routing decision** requires a `bench_column` in
+`internal/router/cluster/artifacts/v<X.Y>/model_registry.json`, which only the training
+pipeline writes (hand-editing breaks the cluster geometry guarantee). Wiring the provider +
+catalog makes the model usable via **hard-pin and BYOK passthrough** immediately; cluster
+eligibility is a follow-up a maintainer runs through the model-onboarding pipeline. Note this
+in your PR so reviewers know what's left.
+
+## Step 5 — Tests
+
+- Add a table case to the openaicompat client tests if you touched routing/ID-mapping behavior.
+- Add a catalog test asserting the new model's tier + pricing + binding (see `catalog_test.go`).
+- Tests must be **non-tautological** — assert a value the code produced, not `x == x`.
+
+## Definition of done
+
+- [ ] No new adapter package (unless a genuinely new wire format — see "Decide the shape").
+- [ ] No magic strings — provider name used via the `providers.Provider*` constant everywhere.
+- [ ] `.env.example` + `docs/CONFIGURATION.md` document the new env vars.
+- [ ] `make check` is green (generate + build + test).
+- [ ] PR notes whether cluster-routing eligibility (bench column) is still pending.

--- a/.claude/skills/triage-issue/SKILL.md
+++ b/.claude/skills/triage-issue/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: triage-issue
+description: First-pass triage procedure for a new GitHub issue on workweave/router — dedupe search, docs check, label taxonomy, and a transparent first response. Used by the claude-issue-triage workflow and by maintainers triaging by hand. Use when triaging or labelling a router issue.
+---
+
+# Triaging a router issue
+
+Goal: give the reporter an instant, useful, honest first response and leave the
+issue correctly labelled — **without pretending to be a human and without
+claiming anything is fixed.** A maintainer follows up; you set them up.
+
+## 1. Read it
+
+Read the title and body. Identify the type (bug / feature / provider request /
+docs / question) and whether the essential info is present (for a bug: version,
+repro, expected-vs-actual).
+
+## 2. Dedupe
+
+Search existing issues before responding:
+
+```bash
+gh issue list --repo workweave/router --state all --limit 60 --search "<keywords>"
+```
+
+If there's a strong match, link it in your comment and apply the `duplicate`
+label. Don't close it yourself — leave that call to a maintainer.
+
+## 3. Check against the docs
+
+If it's answered by [`README.md`](../../../README.md) or
+[`docs/CONFIGURATION.md`](../../../docs/CONFIGURATION.md), point to the exact
+section. A large share of issues are configuration questions — resolving them
+with a precise pointer is the highest-value thing you can do.
+
+## 4. Label
+
+Apply labels with `gh issue edit`. Use **only** this set — do not invent labels:
+
+| Label | When |
+|---|---|
+| `bug` | Something is broken / misbehaving. |
+| `enhancement` | New capability or improvement. |
+| `provider-request` | Add a provider/model. Point them at the [`add-provider` skill](../add-provider/SKILL.md). |
+| `documentation` | Docs are wrong/missing. |
+| `question` | Usage question, not a defect. |
+| `needs-info` | Can't act without more detail (missing repro/version/logs). |
+| `duplicate` | Strong match to an existing issue (linked). |
+
+(`provider-request` and `needs-info` are router-specific; the rest are GitHub
+defaults. If a label doesn't exist yet, skip it rather than failing.)
+
+## 5. Respond — exactly one comment
+
+Post one comment that **opens with this transparency line verbatim**:
+
+> 🤖 _Automated first-pass triage — a maintainer will follow up. Reply with `@claude` if you need the agent again, or tag a maintainer if you need a human sooner._
+
+Then, briefly:
+- One line restating the problem as you understand it.
+- Any duplicate or docs links you found.
+- Only if essential info is missing: a short, specific list of what you need
+  (e.g. "router version + the exact request that failed").
+
+Tone: friendly coworker, not support bot. Hard rules:
+- **Never** say it's fixed or promise a timeline.
+- **Never** dump logs, internal implementation details, or speculation.
+- For a feature request, capture the **underlying goal**, not just the proposed
+  code change — the maintainer may solve it differently.
+- If you're genuinely unsure what it is, label `question` and say a maintainer
+  will take a look. Honest beats confident-and-wrong.

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,20 @@
+# Code owners are automatically requested for review on PRs that touch
+# matching paths. See https://docs.github.com/articles/about-code-owners
+#
+# TODO(maintainers): add co-maintainer handles as the team grows. The
+# load-bearing subsystems below should gain dedicated owners over time so
+# review isn't bottlenecked on one person.
+
+# Default owner for everything.
+*                                   @steventohme
+
+# Routing core + cluster artifacts — highest blast radius, review carefully.
+/internal/router/                   @steventohme
+/internal/proxy/                    @steventohme
+
+# Provider adapters — the long-tail contribution surface.
+/internal/providers/                @steventohme
+
+# CI, automation, and repo governance.
+/.github/                           @steventohme
+/.claude/                           @steventohme

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,72 @@
+name: 🐞 Bug report
+description: Something in the router is broken or behaving incorrectly.
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a bug. The more precise the repro, the faster we can fix it.
+        A maintainer (or our automated first-pass agent) will respond — please fill this out completely so we don't have to ask for the basics.
+
+  - type: checkboxes
+    id: prechecks
+    attributes:
+      label: Before you file
+      options:
+        - label: I searched [existing issues](https://github.com/workweave/router/issues?q=is%3Aissue) and this isn't a duplicate.
+          required: true
+        - label: I read the [README](https://github.com/workweave/router#readme) and [docs/CONFIGURATION.md](https://github.com/workweave/router/blob/main/docs/CONFIGURATION.md), and this isn't a configuration question.
+          required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: Router version / commit
+      description: Output of the running build, the npm package version, or the git commit SHA you're on.
+      placeholder: "e.g. router-v0.70.2, or commit c2bd4a3"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: deployment-mode
+    attributes:
+      label: Deployment mode
+      options:
+        - selfhosted
+        - managed
+        - not sure
+    validations:
+      required: true
+
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened
+      description: What did you observe? What did you expect instead?
+      placeholder: |
+        Expected: ...
+        Actual: ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      description: Exact, minimal steps. Include the request (curl is ideal — redact your API keys) and which model/provider was involved.
+      placeholder: |
+        1. Configure ...
+        2. Send `curl -X POST .../v1/messages -d '{...}'`
+        3. ...
+      render: shell
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs
+      description: Router logs around the failure. Redact API keys, bearer tokens, and any request bodies you can't share.
+      render: shell
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: false
+contact_links:
+  - name: 📖 Documentation
+    url: https://github.com/workweave/router#readme
+    about: Most setup, configuration, and routing questions are answered in the README and docs/CONFIGURATION.md. Please read these first.
+  - name: 💬 Contributors Slack
+    url: https://TODO-REPLACE-WITH-SLACK-INVITE
+    about: Questions, ideas, and "should I build this before I open a PR?" conversations happen here. Best place to reach a maintainer.
+  - name: 🔒 Report a security vulnerability
+    url: https://github.com/workweave/router/security/advisories/new
+    about: Do NOT open a public issue for security problems. Report privately here. See SECURITY.md.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,47 @@
+name: ✨ Feature request
+description: Suggest a capability or improvement.
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        We prioritize by the **problem** you're hitting, not a specific code change. Tell us what you're trying to do and why — we'll figure out the right shape with you. If you already have an implementation in mind, great, add it under "Possible solution", but lead with the use case.
+
+  - type: checkboxes
+    id: prechecks
+    attributes:
+      label: Before you file
+      options:
+        - label: I searched [existing issues](https://github.com/workweave/router/issues?q=is%3Aissue) and this isn't already requested.
+          required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: What are you trying to do?
+      description: The use case and the problem you're hitting today. What's blocked or painful without this?
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Possible solution (optional)
+      description: If you have an idea for how this could work, share it. We may take the goal and the implementation separately.
+    validations:
+      required: false
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives you've considered (optional)
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: contribution
+    attributes:
+      label: Contribution
+      options:
+        - label: I'm willing to open a PR for this (a maintainer can help scope it first in the Slack).
+          required: false

--- a/.github/ISSUE_TEMPLATE/provider_request.yml
+++ b/.github/ISSUE_TEMPLATE/provider_request.yml
@@ -1,0 +1,57 @@
+name: 🔌 Provider / model request
+description: Request (or offer to add) a new upstream provider or model.
+labels: ["enhancement", "provider-request"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Adding a provider or model is one of the most common contributions, and it follows a fixed recipe.
+        **If you plan to open the PR yourself, follow the [`add-provider` skill](https://github.com/workweave/router/blob/main/.claude/skills/add-provider/SKILL.md) to the letter** — it walks through the catalog entry, the env-var wiring, the composition-root registration, and the required tests. PRs that follow it are merged fast; ones that don't get sent back to it.
+
+  - type: checkboxes
+    id: prechecks
+    attributes:
+      label: Before you file
+      options:
+        - label: I checked the [model registry](https://github.com/workweave/router/blob/main/internal/router/cluster) and this provider/model isn't already wired.
+          required: true
+        - label: I read the [`add-provider` skill](https://github.com/workweave/router/blob/main/.claude/skills/add-provider/SKILL.md).
+          required: true
+
+  - type: input
+    id: provider
+    attributes:
+      label: Provider
+      placeholder: "e.g. Together, DeepInfra, Cerebras, a self-hosted vLLM endpoint"
+    validations:
+      required: true
+
+  - type: input
+    id: models
+    attributes:
+      label: Model(s)
+      description: Exact model slugs as the provider's API expects them.
+      placeholder: "e.g. deepseek-ai/DeepSeek-V4-Pro"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: api-shape
+    attributes:
+      label: API shape
+      description: Most new upstreams are OpenAI-compatible and need no new adapter package — just an openaicompat base URL.
+      options:
+        - OpenAI-compatible (/v1/chat/completions)
+        - Anthropic Messages
+        - Google Generative Language
+        - Other / not sure
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: contribution
+    attributes:
+      label: Contribution
+      options:
+        - label: I intend to open the PR myself following the add-provider skill.
+          required: false

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,39 @@
+version: 2
+updates:
+  # Go module (router server).
+  - package-ecosystem: gomod
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      go-minor-patch:
+        update-types: [minor, patch]
+
+  # GitHub Actions used in workflows.
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    groups:
+      actions:
+        patterns: ["*"]
+
+  # Dashboard frontend.
+  - package-ecosystem: npm
+    directory: "/frontend"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      npm-minor-patch:
+        update-types: [minor, patch]
+
+  # Published install CLI package.
+  - package-ecosystem: npm
+    directory: "/install/npm"
+    schedule:
+      interval: weekly
+    groups:
+      npm-minor-patch:
+        update-types: [minor, patch]

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,31 @@
+<!--
+Thanks for contributing to router! Fill this out so we can review quickly.
+PRs that skip the checklist or leave testing blank will be sent back — not because we're strict for its own sake, but because an untested change costs more to review than to write.
+-->
+
+## What & why
+
+<!-- What does this change, and what problem does it solve? Link the issue it closes: "Closes #123". -->
+
+## How it was tested
+
+<!-- Required. What did you actually run? Paste the command(s) and the result. "make check passes" is the floor, not the whole answer — if you fixed a bug, show the behavior before/after. -->
+
+## AI assistance
+
+<!--
+If you used an agent (Claude Code, Cursor, etc.) to write any of this, tell us how and paste the prompt(s) you used.
+This is not a gotcha — it genuinely helps us review faster and trust the change. Undisclosed slop is the thing we send back.
+-->
+
+- [ ] This PR was written or assisted by an AI agent. (If checked, the prompt(s) are above.)
+
+## Checklist
+
+- [ ] Commits are **DCO signed off** (`git commit -s`) — see [CONTRIBUTING](../CONTRIBUTING.md#developer-certificate-of-origin-dco).
+- [ ] `make check` passes locally (generate + build + test).
+- [ ] I followed the [layering / import rules](../AGENTS.md) — no cross-layer imports, no I/O in inner-ring packages.
+- [ ] No silent fallbacks — failures surface as errors/HTTP status, not a quiet default model.
+- [ ] No magic strings for provider/model names — used the `internal/providers` constants.
+- [ ] Generated code (`internal/sqlc/`) was **regenerated** via `make generate`, not hand-edited.
+- [ ] If adding a provider/model, I followed the [`add-provider` skill](../.claude/skills/add-provider/SKILL.md).

--- a/.github/workflows/claude-issue-triage.yml
+++ b/.github/workflows/claude-issue-triage.yml
@@ -1,0 +1,62 @@
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+# Automated first-pass triage on every new issue. Posts ONE transparent
+# agent reply (clearly labelled as a bot), checks the report against the
+# docs, looks for likely duplicates, and applies labels. A human maintainer
+# follows up — this just gives the reporter an instant, useful first response
+# and keeps the tracker organized. Requires the Claude GitHub App + secret.
+name: Claude issue triage
+
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  triage:
+    # Same-repo only (secret), and skip if the opener is already asking for a
+    # human via @claude — the on-demand workflow handles those.
+    if: |
+      github.repository == 'workweave/router' &&
+      !contains(github.event.issue.body, '@claude') &&
+      !contains(github.event.issue.title, '@claude')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+      id-token: write
+      actions: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Triage issue
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          track_progress: false
+          prompt: |
+            You are the first-pass triage agent for the workweave/router open-source repo.
+            A new issue (#${{ github.event.issue.number }}) was just opened. Triage it by
+            following the repo's triage procedure in .claude/skills/triage-issue/SKILL.md
+            EXACTLY. In short:
+
+            1. Read the issue title and body.
+            2. Search existing issues for likely duplicates:
+               `gh issue list --repo ${{ github.repository }} --state all --limit 60 --search "<keywords>"`.
+               If you find a strong match, link it.
+            3. Check the report against README.md and docs/CONFIGURATION.md — if it's a
+               configuration question already answered there, point to the exact section.
+            4. Apply labels with `gh issue edit` from THIS set only (do not invent labels):
+               bug, enhancement, documentation, question, provider-request, needs-info, duplicate.
+            5. Post exactly ONE comment via `gh issue comment`. It MUST open with this line
+               verbatim so the reporter knows it's automated:
+
+               > 🤖 _Automated first-pass triage — a maintainer will follow up. Reply with `@claude` if you need the agent again, or tag a maintainer if you need a human sooner._
+
+               Then: a one-line restatement of the problem, any duplicate/doc links you
+               found, and (only if essential info is missing) a short list of what you need.
+               Be concise and friendly. Do NOT claim anything is fixed, and do NOT promise a
+               timeline. If you're unsure, say a maintainer will take a look.
+          claude_args: |
+            --allowedTools "Bash(gh issue view:*),Bash(gh issue list:*),Bash(gh issue edit:*),Bash(gh issue comment:*),Bash(gh search:*)"

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,0 +1,68 @@
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+# Automated code review on every PR open / push. Reviews against the repo's
+# own layering rules (AGENTS.md) and the "what we won't accept" list in
+# CONTRIBUTING.md, then leaves review comments. It never merges.
+#
+# NOTE: PRs from forks do NOT receive secrets, so this auto-review only runs
+# for branches pushed to the canonical repo. For an external contributor's
+# fork PR, a maintainer triggers review by commenting "@claude review this"
+# (handled by claude.yml, which runs in the base-repo context). This avoids
+# pull_request_target, which would expose the API key to untrusted PR code.
+name: Claude review
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+jobs:
+  review:
+    if: github.repository == 'workweave/router'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      id-token: write
+      actions: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Review PR
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          track_progress: false
+          prompt: |
+            Review PR #${{ github.event.pull_request.number }} in workweave/router.
+            You are a maintainer-grade reviewer for a Go model-router. Be direct and
+            specific; cite file:line. Prefer a few high-signal comments over many nits.
+
+            Ground your review in the repo's own rules — read these first:
+              - AGENTS.md (layer model + import rules; the "Things to NEVER do" list)
+              - CONTRIBUTING.md ("What we won't accept")
+              - the CLAUDE.md inside any package the PR touches
+
+            Flag, in priority order:
+              1. Layering / import violations — inner-ring packages doing I/O; adapters
+                 importing each other; presentation importing internal/postgres or a
+                 concrete provider adapter; anything constructed outside cmd/router/main.go.
+              2. Silent fallbacks — any path that quietly degrades to a default model
+                 instead of surfacing an error / HTTP 503.
+              3. Magic strings for provider/model names instead of the internal/providers
+                 constants.
+              4. Hand-edited generated code under internal/sqlc/ (must be regenerated).
+              5. Tautological tests (assert nothing that breaks if prod code is deleted)
+                 and missing tests for new behavior.
+              6. Logging secrets / raw tokens / full request bodies; wrong log levels.
+              7. Missing DCO sign-off on commits.
+
+            If the diff only adds an OpenAI-compatible provider, check it against
+            .claude/skills/add-provider/SKILL.md and call out any skipped step.
+
+            Post your review with `gh pr review` (use --comment, not --approve and not
+            --request-changes — a human makes the merge call). If the PR looks clean,
+            say so briefly. Do not merge.
+          claude_args: |
+            --allowedTools "Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr review:*),Bash(gh pr comment:*)"

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,49 @@
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+# On-demand agent. Anyone can summon Claude by writing "@claude ..." in an
+# issue, a PR comment, or a review comment, and it will respond in-thread
+# (answer questions, explain code, or make a small fix on a branch).
+# Requires the Claude GitHub App installed + the ANTHROPIC_API_KEY secret.
+name: Claude
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  pull_request_review:
+    types: [submitted]
+  issues:
+    types: [opened, assigned]
+
+jobs:
+  claude:
+    # Only run on the canonical repo (forks don't have the secret) and only
+    # when someone actually mentions @claude.
+    if: |
+      github.repository == 'workweave/router' &&
+      (
+        (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+        (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+        (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+        (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      )
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+      id-token: write
+      actions: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          # Keep edits inside the repo; allow build/test so it can verify a fix.
+          claude_args: |
+            --allowedTools "Bash(make check),Bash(make build),Bash(make test),Bash(gofmt:*),Bash(go:*)"

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,46 @@
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+# Auto-close inactive issues/PRs. After 90 days with no activity an item is
+# marked stale; if nobody responds within 10 more days it's closed. Comment
+# to keep it open, or add the `keep-open` label to exempt it permanently.
+name: Stale
+
+on:
+  schedule:
+    - cron: "0 8 * * *" # daily, 08:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  stale:
+    if: github.repository == 'workweave/router'
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/stale@v9
+        with:
+          days-before-stale: 90
+          days-before-close: 10
+          stale-issue-label: stale
+          stale-pr-label: stale
+          exempt-issue-labels: "keep-open,pinned,security"
+          exempt-pr-labels: "keep-open,pinned,security"
+          exempt-all-milestones: true
+          stale-issue-message: >
+            This issue has been inactive for 90 days, so it's been marked stale.
+            If it's still relevant, just leave a comment and we'll keep it open —
+            otherwise it'll be closed in 10 days. Not a judgment on the issue, just
+            keeping the tracker honest.
+          stale-pr-message: >
+            This PR has been inactive for 90 days, so it's been marked stale.
+            Comment or push to keep it open; otherwise it'll be closed in 10 days.
+          close-issue-message: >
+            Closing this out after 10 more days of inactivity. Comment to reopen
+            anytime if it's still a problem — no hard feelings.
+          close-pr-message: >
+            Closing this out after 10 more days of inactivity. Reopen anytime
+            once you're ready to pick it back up.
+          ascending: true # touch the oldest items first

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,122 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity and
+orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+- The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+**conduct@workweave.ai**. All complaints will be reviewed and investigated
+promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. Violating
+these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. Violating these
+terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+<https://www.contributor-covenant.org/version/2/1/code_of_conduct.html>.
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][mozilla].
+
+[homepage]: https://www.contributor-covenant.org
+[mozilla]: https://github.com/mozilla/diversity
+
+For answers to common questions about this code of conduct, see the FAQ at
+<https://www.contributor-covenant.org/faq>. Translations are available at
+<https://www.contributor-covenant.org/translations>.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,6 +12,17 @@ conventions, and PR process.
 4. Make your changes on a topic branch.
 5. Open a PR.
 
+## Getting help & talking to maintainers
+
+The fastest way to reach us — and the right place to float an idea **before**
+you sink time into a big PR — is the contributors Slack:
+
+➡️ **[Join the contributors Slack](https://TODO-REPLACE-WITH-SLACK-INVITE)**
+
+For anything non-trivial, ask there first. We'd much rather help you scope it up
+front than send a finished PR back. Bug reports and feature requests go in
+[GitHub issues](https://github.com/workweave/router/issues/new/choose).
+
 ## Code of Conduct
 
 This project follows the [Contributor Covenant](CODE_OF_CONDUCT.md).
@@ -180,6 +191,26 @@ Common types: `feat`, `fix`, `refactor`, `docs`, `test`, `chore`, `ci`.
 3. Make sure CI is green (`make check` + the migration-timestamp check).
 4. A maintainer will review. Plan to iterate; reviews are usually 1-2
    rounds.
+
+## How we triage and review
+
+We lean on automation so humans can focus on the work that needs judgment.
+Knowing how it works will save you a round-trip:
+
+- **An automated agent takes a first pass.** New issues get an automated
+  first-pass reply (clearly labelled as a bot), and new PRs get an automated
+  review against the [layering rules](AGENTS.md) and the "What we won't accept"
+  list above. The agent never merges and never has the final say — a human does.
+  You can also summon it anytime by commenting `@claude` on an issue or PR.
+- **Tell us how you used AI.** If you wrote the change with an agent, say so in
+  the PR and paste the prompt. It's not a gotcha — disclosed, tested AI work is
+  welcome; undisclosed slop is what gets sent back.
+- **We prioritize honestly.** Not every issue gets fixed immediately, and we'd
+  rather tell you "we're not prioritizing this soon — ping us if it's blocking
+  you" than go quiet. A real answer beats a fake timeline.
+- **Adding a provider or model?** Follow the
+  [`add-provider` skill](.claude/skills/add-provider/SKILL.md) to the letter.
+  PRs that follow it merge fast.
 
 ## Adding documentation
 

--- a/README.md
+++ b/README.md
@@ -167,6 +167,18 @@ Settings → Models override above. See [install/README.md](install/README.md#sw
 - 🏗️ [**Architecture**](AGENTS.md): package layout, import contracts,
   recipes for adding endpoints / providers / strategies.
 
+## Contributing
+
+PRs welcome. Read [CONTRIBUTING.md](CONTRIBUTING.md) first — it covers the
+layering rules, the dev loop, and how we triage and review (an agent takes a
+first pass; a human makes the call). Adding a provider or model is the most
+common contribution and follows a fixed recipe:
+[`.claude/skills/add-provider/SKILL.md`](.claude/skills/add-provider/SKILL.md).
+
+Questions or want to scope a change before building it? Join the
+[**contributors Slack**](https://TODO-REPLACE-WITH-SLACK-INVITE). By
+participating you agree to our [Code of Conduct](CODE_OF_CONDUCT.md).
+
 ## Star history
 
 <a href="https://star-history.com/#workweave/router&Date">

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,52 @@
+# Security Policy
+
+The router sits on the request path between agents and model providers and
+handles provider API keys, BYOK secrets, and user traffic. We take security
+reports seriously.
+
+## Reporting a vulnerability
+
+**Please do not open a public issue for security vulnerabilities.**
+
+Report privately via GitHub Security Advisories:
+
+➡️ **[Open a private advisory](https://github.com/workweave/router/security/advisories/new)**
+
+If you can't use GitHub advisories, email **security@workweave.ai**.
+
+Please include:
+
+- A description of the vulnerability and its impact.
+- Steps to reproduce (a minimal proof-of-concept is ideal).
+- Affected version / commit, and your environment if relevant.
+
+## What to expect
+
+- We aim to acknowledge a report within **3 business days**.
+- We'll keep you updated as we investigate and work on a fix.
+- We'll coordinate disclosure with you and credit you in the release notes
+  unless you'd prefer to remain anonymous.
+
+## Scope
+
+In scope: the router server (`internal/`, `cmd/`), the install scripts under
+`install/`, and the dashboard frontend.
+
+Particularly interested in:
+
+- Leakage of API keys, BYOK secrets, or bearer tokens (in logs, errors, or
+  responses).
+- Auth bypass on `/admin/v1/*` or the dashboard.
+- SSRF / request smuggling through the proxy path.
+- Cross-format translation bugs that could exfiltrate one tenant's data to
+  another.
+
+Out of scope: vulnerabilities in upstream model providers themselves, and
+issues that require a pre-compromised host or a malicious deployment operator.
+
+## Handling of secrets
+
+The router never logs raw bearer tokens or full key hashes — only an 8-char
+prefix + 4-char suffix. BYOK secrets are encrypted at rest via AES-256-GCM
+(Tink) and held in plaintext only for a request's lifetime. If you find a code
+path that violates this, treat it as a security issue and report it privately.


### PR DESCRIPTION
Stands up the community + automation layer for the public repo now that issue/PR volume is climbing. Grounded in the call with **Nate Sesti (Continue founder)** + Continue's repo layout + Anthropic's [`claude-code-action`](https://github.com/anthropics/claude-code-action).

## What's in here

**1. Intake templates** (`.github/ISSUE_TEMPLATE/`, `pull_request_template.md`)
- Bug / feature / provider issue *forms* with required "I searched issues" + "I read the docs" checkboxes — gives us grounds to close low-effort submissions.
- PR template forces **how it was tested** and **"if AI-assisted, paste the prompt"** (Nate's core lever), plus a layering/DCO/no-silent-fallback checklist.

**2. Agentic automation** (`.github/workflows/`) — _requires setup below_
- `claude.yml` — `@claude` on-demand on issues/PRs/reviews.
- `claude-issue-triage.yml` — **auto first-pass on every new issue**, opens with a transparent "🤖 automated first-pass — a maintainer will follow up" line, dedupes, checks docs, labels.
- `claude-review.yml` — **auto-review every PR** against `AGENTS.md` layering rules + the "what we won't accept" list (silent fallbacks, magic strings, hand-edited generated code, tautological tests). Comments only; never merges.

**3. Governance** — `CODE_OF_CONDUCT.md` (fixes a **dead link** in CONTRIBUTING), `SECURITY.md` (private disclosure; the router handles keys), `CODEOWNERS`, `dependabot.yml` (gomod + actions + npm), and `stale.yml` (Nate's 90-day stale + 10-day close).

**4. Contributor skills** (`.claude/skills/`) — `add-provider` (codifies the long-tail provider/model recipe to the letter, per Nate's #1 advice) and `triage-issue` (the procedure the triage workflow follows).

**5. Docs** — CONTRIBUTING gains a "How we triage and review" norms section; README + CONTRIBUTING point at the contributors Slack.

## ⚠️ Setup only you can do (the agent workflows are inert until these are done)

1. **Install the Claude GitHub App** on `workweave/router` — run `/install-github-app` from Claude Code, or install via https://github.com/apps/claude.
2. **Add the `ANTHROPIC_API_KEY` repo secret** (Settings → Secrets and variables → Actions).
3. **Replace the Slack placeholder** `https://TODO-REPLACE-WITH-SLACK-INVITE` (appears in README, CONTRIBUTING, and `ISSUE_TEMPLATE/config.yml`) with the real invite.
4. **Create two labels** the triage agent uses: `provider-request` and `needs-info` (the rest are GitHub defaults; the skill skips missing labels gracefully).
5. **Confirm `CODEOWNERS` handles** — currently `@steventohme` everywhere; add co-maintainers as the team grows.
6. **Confirm the contact inboxes** `conduct@workweave.ai` (CoC) and `security@workweave.ai` (SECURITY) exist, or swap them.

## Design note: fork PRs

Auto-review runs on `pull_request` for branches in the canonical repo. Fork PRs (the external-contributor case) don't receive secrets, so they won't auto-review — instead a maintainer comments `@claude review this` and `claude.yml` handles it in the base-repo context. This intentionally avoids `pull_request_target`, which would expose the API key + write token to untrusted PR code — a real exfiltration risk for a repo that proxies provider keys. Say the word if you'd rather take that tradeoff for full fork auto-review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)