### PR TITLE
fix(router): enable prompt caching on cross-format OpenAI routes

### DIFF
--- a/internal/translate/emit_openai.go
+++ b/internal/translate/emit_openai.go
@@ -77,28 +77,67 @@ func (e *RequestEnvelope) PrepareOpenAI(in http.Header, opts EmitOptions) (provi
 // knob:
 //   - Fireworks / DeepInfra: x-session-affinity request header
 //   - OpenRouter: x-session-id request header (its sticky-routing key, ≤256 chars)
-//   - OpenAI: prompt_cache_key body field (combined with the prefix hash)
+//   - OpenAI: prompt_cache_key body field
+//
+// The serverless-affinity *headers* (Fireworks/DeepInfra/OpenRouter) are gated
+// on a real session key: collapsing every keyless request onto one synthetic
+// affinity bucket would herd unrelated conversations onto a single replica,
+// which is worse than letting them load-balance. OpenAI's prompt_cache_key is
+// different — it is a soft cache-routing hint, not a hard replica pin, so it is
+// always set on OpenAI-format cross-format routes (extended beyond the
+// session-affinity-only case): with a session key we use it directly, otherwise
+// we fall back to a stable hash of the request's cacheable prefix (system +
+// tools). Without prompt_cache_key, an Anthropic→OpenAI route carries no cache
+// hint at all and re-bills the full stable prefix every turn (NULL cache_read
+// in prod across all cross-format OpenAI traffic). OpenAI's automatic prompt
+// caching covers prompts >1024 tokens regardless, and the explicit key only
+// raises the hit rate.
 //
 // Bedrock (explicit cachePoint caching, centrally routed — no replica roulette)
-// and any unrecognized target get nothing. No-op when SessionAffinity is empty,
-// which also covers the handover summarizer's empty-TargetProvider calls.
+// and any unrecognized target get nothing.
 func applySessionAffinity(body []byte, headers http.Header, opts EmitOptions) ([]byte, error) {
-	if opts.SessionAffinity == "" {
-		return body, nil
-	}
 	switch opts.TargetProvider {
 	case providers.ProviderFireworks, providers.ProviderDeepInfra:
-		headers.Set("x-session-affinity", opts.SessionAffinity)
+		if opts.SessionAffinity != "" {
+			headers.Set("x-session-affinity", opts.SessionAffinity)
+		}
 	case providers.ProviderOpenRouter:
-		headers.Set("x-session-id", opts.SessionAffinity)
+		if opts.SessionAffinity != "" {
+			headers.Set("x-session-id", opts.SessionAffinity)
+		}
 	case providers.ProviderOpenAI:
-		out, err := sjson.SetBytes(body, "prompt_cache_key", opts.SessionAffinity)
+		cacheKey := opts.SessionAffinity
+		if cacheKey == "" {
+			cacheKey = stablePromptCacheKey(body)
+		}
+		out, err := sjson.SetBytes(body, "prompt_cache_key", cacheKey)
 		if err != nil {
 			return nil, fmt.Errorf("set prompt_cache_key: %w", err)
 		}
 		return out, nil
 	}
 	return body, nil
+}
+
+// stablePromptCacheKey derives a deterministic OpenAI prompt_cache_key from the
+// request's cacheable prefix — the system message(s) and tool definitions,
+// which are stable across the turns of a conversation while user/assistant
+// turns grow. Used as a fallback when no session key is available (e.g. the
+// handover summarizer, or requests with no derivable session) so the OpenAI
+// route still carries a consistent cache hint instead of none.
+func stablePromptCacheKey(body []byte) string {
+	h := sha1.New()
+	gjson.GetBytes(body, "messages").ForEach(func(_, msg gjson.Result) bool {
+		if msg.Get("role").String() == "system" {
+			h.Write([]byte(msg.Get("content").Raw))
+		}
+		return true
+	})
+	h.Write([]byte{0x00})
+	if tools := gjson.GetBytes(body, "tools"); tools.Exists() {
+		h.Write([]byte(tools.Raw))
+	}
+	return "wv_" + hex.EncodeToString(h.Sum(nil))
 }
 
 func (e *RequestEnvelope) buildOpenAIFromOpenAI(opts EmitOptions) ([]byte, error) {

--- a/internal/translate/emit_openai.go
+++ b/internal/translate/emit_openai.go
@@ -142,7 +142,7 @@ func applySessionAffinity(body []byte, headers http.Header, opts EmitOptions) ([
 // route still carries a consistent cache hint instead of none.
 //
 // Returns "" when the request has no cacheable prefix at all (no system
-// content and no tools). Hashing an empty prefix would yield one constant key
+// content and no non-empty tools array). Hashing an empty prefix would yield one constant key
 // shared by every prefix-less conversation, herding unrelated keyless requests
 // onto a single synthetic cache bucket; such requests are better left unhinted.
 func stablePromptCacheKey(body []byte) string {
@@ -158,8 +158,13 @@ func stablePromptCacheKey(body []byte) string {
 		return true
 	})
 	h.Write([]byte{0x00})
-	if tools := gjson.GetBytes(body, "tools"); tools.Exists() && tools.Raw != "" {
-		h.Write([]byte(tools.Raw))
+	// An empty tools array ("tools":[]) is not a cacheable prefix —
+	// gjson's .Exists() is true for it and .Raw is "[]" (non-empty), so
+	// gate on a non-empty array to avoid herding unrelated keyless,
+	// prefix-less requests (common with same-format OpenAI bodies that keep
+	// "tools":[]) onto one synthetic key.
+	if hasNonEmptyTools(body) {
+		h.Write([]byte(gjson.GetBytes(body, "tools").Raw))
 		hasPrefix = true
 	}
 	if !hasPrefix {

--- a/internal/translate/emit_openai.go
+++ b/internal/translate/emit_openai.go
@@ -85,9 +85,12 @@ func (e *RequestEnvelope) PrepareOpenAI(in http.Header, opts EmitOptions) (provi
 // which is worse than letting them load-balance. OpenAI's prompt_cache_key is
 // different — it is a soft cache-routing hint, not a hard replica pin, so it is
 // always set on OpenAI-format cross-format routes (extended beyond the
-// session-affinity-only case): with a session key we use it directly, otherwise
+// session-affinity-only case): with a session key we use it directly; otherwise
 // we fall back to a stable hash of the request's cacheable prefix (system +
-// tools). Without prompt_cache_key, an Anthropic→OpenAI route carries no cache
+// tools) — but only when the caller hasn't supplied its own prompt_cache_key
+// (which we preserve) and the request actually has a cacheable prefix (a
+// prefix-less request stays unhinted rather than collapsing onto one synthetic
+// key). Without prompt_cache_key, an Anthropic→OpenAI route carries no cache
 // hint at all and re-bills the full stable prefix every turn (NULL cache_read
 // in prod across all cross-format OpenAI traffic). OpenAI's automatic prompt
 // caching covers prompts >1024 tokens regardless, and the explicit key only
@@ -108,7 +111,19 @@ func applySessionAffinity(body []byte, headers http.Header, opts EmitOptions) ([
 	case providers.ProviderOpenAI:
 		cacheKey := opts.SessionAffinity
 		if cacheKey == "" {
+			// A same-format OpenAI caller may partition caching with its own
+			// prompt_cache_key; don't clobber it with our synthetic prefix hash.
+			if gjson.GetBytes(body, "prompt_cache_key").Exists() {
+				return body, nil
+			}
+			// Fall back to a prefix hash only when there's an actual cacheable
+			// prefix (system and/or tools). With neither, hashing the empty
+			// prefix would collapse every keyless, prefix-less conversation
+			// onto one synthetic key, so leave such requests unhinted.
 			cacheKey = stablePromptCacheKey(body)
+			if cacheKey == "" {
+				return body, nil
+			}
 		}
 		out, err := sjson.SetBytes(body, "prompt_cache_key", cacheKey)
 		if err != nil {
@@ -125,17 +140,30 @@ func applySessionAffinity(body []byte, headers http.Header, opts EmitOptions) ([
 // turns grow. Used as a fallback when no session key is available (e.g. the
 // handover summarizer, or requests with no derivable session) so the OpenAI
 // route still carries a consistent cache hint instead of none.
+//
+// Returns "" when the request has no cacheable prefix at all (no system
+// content and no tools). Hashing an empty prefix would yield one constant key
+// shared by every prefix-less conversation, herding unrelated keyless requests
+// onto a single synthetic cache bucket; such requests are better left unhinted.
 func stablePromptCacheKey(body []byte) string {
 	h := sha1.New()
+	var hasPrefix bool
 	gjson.GetBytes(body, "messages").ForEach(func(_, msg gjson.Result) bool {
 		if msg.Get("role").String() == "system" {
-			h.Write([]byte(msg.Get("content").Raw))
+			if content := msg.Get("content"); content.Raw != "" {
+				h.Write([]byte(content.Raw))
+				hasPrefix = true
+			}
 		}
 		return true
 	})
 	h.Write([]byte{0x00})
-	if tools := gjson.GetBytes(body, "tools"); tools.Exists() {
+	if tools := gjson.GetBytes(body, "tools"); tools.Exists() && tools.Raw != "" {
 		h.Write([]byte(tools.Raw))
+		hasPrefix = true
+	}
+	if !hasPrefix {
+		return ""
 	}
 	return "wv_" + hex.EncodeToString(h.Sum(nil))
 }

--- a/internal/translate/session_affinity_test.go
+++ b/internal/translate/session_affinity_test.go
@@ -205,3 +205,22 @@ func TestSessionAffinity_OpenAIEmptyPrefixStaysUnhinted(t *testing.T) {
 	_, ok := promptCacheKey(t, out.Body)
 	assert.False(t, ok, "a prefix-less keyless request must not carry a synthetic prompt_cache_key")
 }
+
+// An empty tools array ("tools":[]) is not a cacheable prefix: gjson's
+// .Exists() is true and .Raw is "[]" (non-empty), so a naive presence check
+// would herd every such keyless request onto one synthetic key. It must stay
+// unhinted just like a request with no tools field at all.
+func TestSessionAffinity_OpenAIEmptyToolsArrayStaysUnhinted(t *testing.T) {
+	src := []byte(`{"model":"gpt-5.5","messages":[{"role":"user","content":"hi"}],"tools":[]}`)
+	env, err := translate.ParseOpenAI(src)
+	require.NoError(t, err)
+
+	out, err := env.PrepareOpenAI(nil, translate.EmitOptions{
+		TargetModel:    "gpt-5.5",
+		TargetProvider: providers.ProviderOpenAI,
+	})
+	require.NoError(t, err)
+
+	_, ok := promptCacheKey(t, out.Body)
+	assert.False(t, ok, "an empty tools array must not count as a cacheable prefix")
+}

--- a/internal/translate/session_affinity_test.go
+++ b/internal/translate/session_affinity_test.go
@@ -167,3 +167,41 @@ func TestSessionAffinity_OpenAIFallbackKeyVariesByPrefix(t *testing.T) {
 	b := keyFor(t, `"prompt B"`)
 	assert.NotEqual(t, a, b, "different cacheable prefixes must map to different cache keys")
 }
+
+// A same-format OpenAI caller that partitions caching with its own
+// prompt_cache_key must keep it — the router's synthetic prefix hash must not
+// clobber a deliberate caller key on the keyless fallback path.
+func TestSessionAffinity_OpenAIPreservesCallerPromptCacheKey(t *testing.T) {
+	const callerKey = "caller-partition-key"
+	src := []byte(`{"model":"gpt-5.5","prompt_cache_key":"` + callerKey + `","messages":[{"role":"system","content":"sys"},{"role":"user","content":"hi"}]}`)
+	env, err := translate.ParseOpenAI(src)
+	require.NoError(t, err)
+
+	out, err := env.PrepareOpenAI(nil, translate.EmitOptions{
+		TargetModel:    "gpt-5.5",
+		TargetProvider: providers.ProviderOpenAI,
+	})
+	require.NoError(t, err)
+
+	v, ok := promptCacheKey(t, out.Body)
+	require.True(t, ok)
+	assert.Equal(t, callerKey, v, "caller-supplied prompt_cache_key must be preserved")
+}
+
+// A keyless request with no cacheable prefix (no system, no tools) must stay
+// unhinted: hashing the empty prefix would herd every such conversation onto
+// one synthetic cache key.
+func TestSessionAffinity_OpenAIEmptyPrefixStaysUnhinted(t *testing.T) {
+	src := []byte(`{"model":"gpt-5.5","messages":[{"role":"user","content":"hi"}]}`)
+	env, err := translate.ParseOpenAI(src)
+	require.NoError(t, err)
+
+	out, err := env.PrepareOpenAI(nil, translate.EmitOptions{
+		TargetModel:    "gpt-5.5",
+		TargetProvider: providers.ProviderOpenAI,
+	})
+	require.NoError(t, err)
+
+	_, ok := promptCacheKey(t, out.Body)
+	assert.False(t, ok, "a prefix-less keyless request must not carry a synthetic prompt_cache_key")
+}

--- a/internal/translate/session_affinity_test.go
+++ b/internal/translate/session_affinity_test.go
@@ -120,3 +120,50 @@ func TestSessionAffinity_EmptyIsNoOp(t *testing.T) {
 	_, hasBody := promptCacheKey(t, out.Body)
 	assert.False(t, hasBody)
 }
+
+// Without a session key, an OpenAI cross-format route still carries a
+// prompt_cache_key — a stable hash of the cacheable prefix — so OpenAI's
+// prompt caching engages instead of re-billing the full prefix every turn.
+func TestSessionAffinity_OpenAIFallsBackToStablePrefixKey(t *testing.T) {
+	src := []byte(`{"model":"claude-opus-4-7","system":"you are a helpful assistant","tools":[{"name":"read","input_schema":{"type":"object"}}],"messages":[{"role":"user","content":"hi"}],"max_tokens":256}`)
+
+	prepare := func(t *testing.T) string {
+		env, err := translate.ParseAnthropic(src)
+		require.NoError(t, err)
+		out, err := env.PrepareOpenAI(nil, translate.EmitOptions{
+			TargetModel:    "gpt-5.5",
+			TargetProvider: providers.ProviderOpenAI,
+		})
+		require.NoError(t, err)
+		v, ok := promptCacheKey(t, out.Body)
+		require.True(t, ok, "OpenAI must carry a prompt_cache_key even without a session key")
+		assert.NotEmpty(t, v)
+		return v
+	}
+
+	first := prepare(t)
+	second := prepare(t)
+	assert.Equal(t, first, second, "fallback prompt_cache_key must be stable for the same prefix")
+}
+
+// A different cacheable prefix (different system + tools) yields a different
+// fallback key, so unrelated conversations don't share one cache bucket.
+func TestSessionAffinity_OpenAIFallbackKeyVariesByPrefix(t *testing.T) {
+	keyFor := func(t *testing.T, system string) string {
+		src := []byte(`{"model":"claude-opus-4-7","system":` + system + `,"messages":[{"role":"user","content":"hi"}],"max_tokens":256}`)
+		env, err := translate.ParseAnthropic(src)
+		require.NoError(t, err)
+		out, err := env.PrepareOpenAI(nil, translate.EmitOptions{
+			TargetModel:    "gpt-5.5",
+			TargetProvider: providers.ProviderOpenAI,
+		})
+		require.NoError(t, err)
+		v, ok := promptCacheKey(t, out.Body)
+		require.True(t, ok)
+		return v
+	}
+
+	a := keyFor(t, `"prompt A"`)
+	b := keyFor(t, `"prompt B"`)
+	assert.NotEqual(t, a, b, "different cacheable prefixes must map to different cache keys")
+}


### PR DESCRIPTION
## Bug

Cross-format translation (Anthropic-format client request → OpenAI-format upstream) dropped prompt caching. The router only set OpenAI's `prompt_cache_key` under session affinity (`applySessionAffinity`, early-returns when the session key is empty), and never on the general cross-format path. With no cache hint, the stable prefix (tools + system + prior turns) is re-billed and re-prefilled every turn.

## Prod symptom

`cache_read_tokens` is NULL across all cross-format OpenAI traffic. Response-side cache-token mapping already works (`cache_usage_test.go` reads `prompt_tokens_details.cached_tokens`), so a NULL read means caching was never enabled on the **request** — not a response-parsing miss.

## Fix

Set `prompt_cache_key` for **all** OpenAI-format cross-format routes, extending beyond the session-affinity-only case:

- With a session key: use it directly (unchanged behavior).
- Without one (e.g. the handover summarizer, or requests with no derivable session): fall back to `stablePromptCacheKey(body)` — a SHA-1 over the cacheable prefix (system message(s) + tool definitions), which is stable across a conversation's turns.

`prompt_cache_key` is a *soft* cache-routing hint, not a hard replica pin, so a keyless fallback is safe and only raises the hit rate (OpenAI does automatic caching for >1024-token prompts regardless). The serverless-affinity **headers** (Fireworks/DeepInfra `x-session-affinity`, OpenRouter `x-session-id`) stay gated on a real session key — collapsing keyless requests onto one synthetic affinity bucket would herd unrelated conversations onto a single replica, which is worse than load-balancing.

Expected impact: cross-format OpenAI routes start registering `cache_read` instead of NULL, cutting the per-turn token burn / cost / TTFT from re-prefilling the stable prefix every turn.

## Gemini scope

**Out of scope.** Recent Gemini models do implicit prompt caching automatically; explicit cached-content creation is complex and not needed here. The router does nothing on the Gemini emit path that blocks implicit caching, so no change is required.

## Overlap with the existing cache branch

Checked `steven/anthropic-cache-injection` → that is **PR #442 (MERGED)**, which injects `cache_control` breakpoints on the **OpenAI → Anthropic** path (inbound OpenAI client, Anthropic upstream). This PR is the **opposite direction** (Anthropic client → OpenAI upstream) and touches a different function (`applySessionAffinity` in `emit_openai.go`, not `emit_anthropic.go`). Complementary, no conflict.

## Tests

- `go build ./...` — green.
- `go test ./internal/translate/...` and `./internal/proxy/...` — green. No golden regeneration needed (conformance/crossformat goldens unchanged).
- Added `TestSessionAffinity_OpenAIFallsBackToStablePrefixKey` (keyless OpenAI route now carries a stable `prompt_cache_key`) and `TestSessionAffinity_OpenAIFallbackKeyVariesByPrefix` (different prefixes → different keys, so unrelated conversations don't share a bucket). Existing `TestSessionAffinity_*` cases (Fireworks/DeepInfra/OpenRouter headers, OpenAI-with-key, Bedrock no-hint, Fireworks empty no-op) still pass unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013CbU9jmNQxJDGXJhnRMeYP