### PR TITLE
fix(router): apply excluded_models on hard-pin (title/classifier/probe) tier

### DIFF
--- a/cmd/router/main.go
+++ b/cmd/router/main.go
@@ -504,28 +504,44 @@ func main() {
 	}
 	logger.Info("Hard-pin model resolved", "provider", hardPinProvider, "model", hardPinModel, "byok_only", byokOnly)
 
-	// Per-request hard-pin resolver for byokOnly deployments. Loads the
-	// default cluster bundle once and closes over its metadata/registry; the
-	// resolver is then called from the proxy with the request's enabled-
-	// providers set so compaction lands on the cheapest model the request
-	// can actually authenticate to. Selfhosted mode leaves the resolver nil
-	// — its boot-time hardPin{Provider,Model} is already correct.
-	var hardPinResolver func(map[string]struct{}) (string, string, bool)
-	if byokOnly {
+	// Per-request hard-pin resolver. Loads the default cluster bundle once and
+	// closes over its metadata/registry; the resolver is then called from the
+	// proxy with the request's enabled-providers set and the installation's
+	// excluded_models deny set. It serves two purposes:
+	//   - byokOnly: the boot-time pin was computed over every registered
+	//     provider, but the request may only BYOK a subset; resolving per
+	//     request keeps the hard-pin on a provider the request can
+	//     authenticate to.
+	//   - all modes: the hard-pin tier bypasses the scorer, which is the only
+	//     component that applies excluded_models. Passing the deny set here
+	//     skips an excluded model on the title-gen/classifier/probe path, just
+	//     as the scorer does on the main-loop path.
+	// If the bundle fails to load the resolver stays nil and the proxy falls
+	// back to the boot-time hardPin{Provider,Model}.
+	//
+	// An explicit ROUTER_HARD_PIN_MODEL operator override is absolute by design
+	// (it also bypasses the tier ceiling downstream); we do NOT wire the
+	// resolver in that case so the operator's chosen model is never silently
+	// rewritten. excluded_models then can't redirect it, but an operator pin is
+	// a deliberate opt-in — the proxy logs if it collides with the exclude list.
+	var hardPinResolver func(enabled, denySet map[string]struct{}) (string, string, bool)
+	if config.GetOr("ROUTER_HARD_PIN_MODEL", "") == "" {
 		reqVersion := config.GetOr("ROUTER_CLUSTER_VERSION", cluster.LatestVersion)
 		if version, vErr := cluster.ResolveVersion(reqVersion); vErr == nil {
 			if bundle, bErr := cluster.LoadBundle(version); bErr == nil {
 				meta, registry := bundle.Metadata, bundle.Registry
-				hardPinResolver = func(enabled map[string]struct{}) (string, string, bool) {
-					return cluster.FastestModel(meta, registry, enabled)
+				hardPinResolver = func(enabled, denySet map[string]struct{}) (string, string, bool) {
+					return cluster.FastestModelInSet(meta, registry, enabled, denySet, nil)
 				}
-				logger.Info("Hard-pin resolver wired for byokOnly mode (per-request fastest model from cluster bundle)", "version", version)
+				logger.Info("Hard-pin resolver wired (per-request fastest model from cluster bundle, applies excluded_models)", "version", version, "byok_only", byokOnly)
 			} else {
-				logger.Warn("Hard-pin resolver disabled: cluster bundle failed to load; byokOnly hard-pin will fall back to boot-time defaults", "err", bErr, "version", version)
+				logger.Warn("Hard-pin resolver disabled: cluster bundle failed to load; hard-pin will fall back to boot-time defaults and cannot apply excluded_models", "err", bErr, "version", version)
 			}
 		} else {
-			logger.Warn("Hard-pin resolver disabled: could not resolve cluster version; byokOnly hard-pin will fall back to boot-time defaults", "err", vErr)
+			logger.Warn("Hard-pin resolver disabled: could not resolve cluster version; hard-pin will fall back to boot-time defaults and cannot apply excluded_models", "err", vErr)
 		}
+	} else {
+		logger.Info("Hard-pin resolver not wired: ROUTER_HARD_PIN_MODEL operator override is set and absolute by design", "model", hardPinModel)
 	}
 
 	// Default-eligible set for proxy.Service: env-keyed providers only.

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -63,10 +63,14 @@ type Service struct {
 	hardPinProvider string
 	hardPinModel    string
 	// hardPinResolver, when set, overrides boot-time hardPin{Provider,Model}
-	// per-request. Used in byokOnly deployments where the registered cheapest
-	// model is unsafe — the installation may only BYOK a subset of providers.
-	// Returns (provider, model, ok); ok=false signals no eligible provider.
-	hardPinResolver func(enabled map[string]struct{}) (provider, model string, ok bool)
+	// per-request. Used both to keep byokOnly deployments on a provider the
+	// request can authenticate to (the registered cheapest model is unsafe when
+	// the installation only BYOK'd a subset of providers) and to honor the
+	// installation's excluded_models on the hard-pin tier: denySet carries
+	// req.ExcludedModels so an excluded model is skipped here, just as the
+	// scorer skips it on the main-loop path. Returns (provider, model, ok);
+	// ok=false signals no eligible provider.
+	hardPinResolver func(enabled, denySet map[string]struct{}) (provider, model string, ok bool)
 	// telemetry is an optional repository for persisting per-request telemetry.
 	telemetry TelemetryRepository
 	// captureMode controls whether high-fidelity `router.call` OTLP log
@@ -952,7 +956,7 @@ func (s *Service) WithAvailableModels(models map[string]struct{}) *Service {
 // WithHardPinResolver installs a per-request hard-pin resolver. nil
 // preserves the boot-time hardPin{Provider,Model} for every request.
 // ok=false signals no eligible provider, surfacing ErrClusterUnavailable.
-func (s *Service) WithHardPinResolver(resolver func(enabled map[string]struct{}) (provider, model string, ok bool)) *Service {
+func (s *Service) WithHardPinResolver(resolver func(enabled, denySet map[string]struct{}) (provider, model string, ok bool)) *Service {
 	s.hardPinResolver = resolver
 	return s
 }

--- a/internal/proxy/service_session_pin_test.go
+++ b/internal/proxy/service_session_pin_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strconv"
@@ -329,7 +330,7 @@ func TestService_HardPin_Compaction_ByokOnly_UsesRequestResolver(t *testing.T) {
 	store := newFakePinStore()
 	fr := &fakeRouter{decision: router.Decision{Provider: "anthropic", Model: "claude-opus-4-7", Reason: "cluster"}}
 
-	resolver := func(enabled map[string]struct{}) (string, string, bool) {
+	resolver := func(enabled, _ map[string]struct{}) (string, string, bool) {
 		if _, ok := enabled[providers.ProviderAnthropic]; ok {
 			return providers.ProviderAnthropic, "claude-haiku-anthropic-byok", true
 		}
@@ -369,7 +370,7 @@ func TestService_HardPin_Compaction_ByokOnly_NoEligibleProviderErrors(t *testing
 	store := newFakePinStore()
 	fr := &fakeRouter{decision: router.Decision{Provider: "anthropic", Model: "claude-opus-4-7", Reason: "cluster"}}
 
-	resolver := func(enabled map[string]struct{}) (string, string, bool) {
+	resolver := func(enabled, _ map[string]struct{}) (string, string, bool) {
 		if _, ok := enabled[providers.ProviderAnthropic]; ok {
 			return providers.ProviderAnthropic, "claude-haiku", true
 		}
@@ -390,6 +391,65 @@ func TestService_HardPin_Compaction_ByokOnly_NoEligibleProviderErrors(t *testing
 	require.Error(t, err, "hard-pin with no eligible provider must surface an error, not silently dispatch")
 	assert.ErrorIs(t, err, cluster.ErrClusterUnavailable,
 		"error must be ErrClusterUnavailable so handlers map it to HTTP 503")
+}
+
+// classifierBody is a canonical Classifier-shaped turn: small max_tokens,
+// no tools, one short message. DetectFromEnvelope hard-pins this turn type,
+// bypassing the scorer (the only component that otherwise applies
+// excluded_models), so it exercises the exclusion-on-hard-pin path.
+const classifierBody = `{"model":"claude-haiku-4-5","max_tokens":5,"messages":[{"role":"user","content":"hello"}]}`
+
+// Regression guard: an installation's excluded_models must be honored on the
+// hard-pin (title-gen/classifier/probe) tier. Prod symptom: an installation
+// that excluded gemini-3.1-flash-lite-preview still had ALL its utility
+// traffic routed to it because the hard-pin path picked a model without
+// consulting req.ExcludedModels. The resolver now receives the deny set and
+// must skip the excluded model in favor of the next allowed candidate.
+func TestService_HardPin_Classifier_AppliesExcludedModels(t *testing.T) {
+	store := newFakePinStore()
+	fr := &fakeRouter{decision: router.Decision{Provider: "anthropic", Model: "claude-opus-4-7", Reason: "cluster"}}
+
+	const excludedModel = "gemini-3.1-flash-lite-preview"
+	const allowedFallback = "claude-haiku-4-5"
+
+	// Mimics the production-wired resolver (cluster.FastestModelInSet): the
+	// fastest candidate is the excluded gemini model, but when it lands in the
+	// deny set the resolver must fall through to the next allowed candidate.
+	resolver := func(enabled, denySet map[string]struct{}) (string, string, bool) {
+		if _, denied := denySet[excludedModel]; !denied {
+			return providers.ProviderGoogle, excludedModel, true
+		}
+		return providers.ProviderAnthropic, allowedFallback, true
+	}
+
+	// Both upstreams answer 200 so the served model reflects the hard-pin
+	// decision itself, not a failover away from an empty/erroring upstream.
+	okResp := func(w http.ResponseWriter) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, `{"id":"msg_1","type":"message","role":"assistant","content":[{"type":"text","text":"ok"}],"stop_reason":"end_turn"}`)
+	}
+	providerMap := map[string]providers.Client{
+		providers.ProviderAnthropic: &fakeProvider{proxyResponse: okResp},
+		providers.ProviderGoogle:    &fakeProvider{proxyResponse: okResp},
+	}
+	svc := proxy.NewService(
+		fr, providerMap, nil, false, nil, store, false,
+		providers.ProviderGoogle, excludedModel, // boot-time pin is the excluded model
+		nil,
+	).WithHardPinResolver(resolver)
+
+	ctx := context.WithValue(authedCtx(uuid.New().String()),
+		proxy.InstallationExcludedModelsContextKey{}, []string{excludedModel})
+	rec := httptest.NewRecorder()
+	httpReq := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(""))
+	require.NoError(t, svc.ProxyMessages(ctx, []byte(classifierBody), rec, httpReq))
+
+	assert.Equal(t, 0, fr.routeCalls, "classifier must bypass the cluster scorer")
+	assert.Equal(t, allowedFallback, rec.Header().Get(proxy.HeaderRouterModel),
+		"hard-pin must skip the excluded model and serve an allowed candidate")
+	assert.NotEqual(t, excludedModel, rec.Header().Get(proxy.HeaderRouterModel),
+		"excluded model must never be served on the hard-pin tier")
 }
 
 func TestService_HardPin_CompactionAlwaysRoutesToHaiku(t *testing.T) {

--- a/internal/proxy/turnloop.go
+++ b/internal/proxy/turnloop.go
@@ -183,9 +183,14 @@ func (s *Service) runTurnLoop(
 		// computed over every registered provider, but the request may
 		// only have BYOK credentials for a subset. Resolve per-request
 		// against the request's enabled-providers set so compaction
-		// stays on a provider the request can authenticate to.
+		// stays on a provider the request can authenticate to. The
+		// resolver also applies the installation's excluded_models
+		// (req.ExcludedModels) as a deny set — the hard-pin path bypasses
+		// the scorer, which is otherwise the only place exclusions are
+		// honored, so without this an excluded model would still serve
+		// all title-gen/classifier/probe traffic.
 		if s.hardPinResolver != nil {
-			p, m, ok := s.hardPinResolver(req.EnabledProviders)
+			p, m, ok := s.hardPinResolver(req.EnabledProviders, req.ExcludedModels)
 			if !ok {
 				log.Warn(
 					"Hard-pin: no eligible provider for request; returning ErrClusterUnavailable",
@@ -195,6 +200,17 @@ func (s *Service) runTurnLoop(
 				return res, fmt.Errorf("hard-pin: no eligible provider for %s: %w", res.TurnType, cluster.ErrClusterUnavailable)
 			}
 			provider, model = p, m
+		} else if _, excluded := req.ExcludedModels[model]; excluded {
+			// No resolver wired (bundle load failed at boot) but the
+			// static boot-time pin is on the installation's exclude
+			// list. We have no cluster bundle here to pick an allowed
+			// alternative, so preserve current behavior and serve the
+			// pin, but log so the misroute is visible in telemetry.
+			log.Warn(
+				"Hard-pin: boot-time pin is in excluded_models but no resolver is wired to pick an alternative; serving pin anyway",
+				"turn_type", string(res.TurnType),
+				"model", model,
+			)
 		}
 		// Operator hard-pins bypass the tier ceiling by design — the
 		// ROUTER_HARD_PIN_MODEL env var is an explicit operator opt-in


### PR DESCRIPTION
## Bug

The utility / hard-pin turn tier (`turn_type` **Probe / TitleGen / Classifier**, plus Explore when `hardPinExplore` is on) selected a model **without applying the installation's `excluded_models` list**.

The hard-pin branch in `runTurnLoop` (`internal/proxy/turnloop.go`) short-circuits for cost/latency and returns *before* the scorer — and the scorer (`cluster/scorer.go`) is the only component that applies `req.ExcludedModels`. Main-loop / tool_result turns are fine because they go through the scorer; the utility tier did not.

## Prod symptom

An installation that excluded `gemini-3.1-flash-lite-preview` still had **all** of its title-gen / classifier / probe traffic routed to that model (confirmed in prod telemetry).

## Fix

Thread `req.ExcludedModels` into the hard-pin model selection as a deny set:

- The per-request hard-pin resolver signature gains a `denySet` param and selects via `cluster.FastestModelInSet` (which already supports a denylist), so an excluded model is skipped in favor of the next allowed fastest candidate — mirroring the scorer's behavior on the main loop.
- `turnloop.go` passes `req.ExcludedModels` to the resolver.
- The resolver is now wired in **all** modes (previously `byokOnly` only), since the exclusion concern applies everywhere. An explicit `ROUTER_HARD_PIN_MODEL` operator override keeps the resolver off — that pin is absolute by design (it also bypasses the tier ceiling downstream).
- Edge case: if no resolver is wired (cluster bundle failed to load at boot) and the static boot-time pin is itself excluded, current behavior is preserved (serve the pin) but the misroute is logged so it's visible in telemetry.

## Files touched

- `internal/proxy/turnloop.go` — pass deny set to resolver; log excluded static pin
- `internal/proxy/service.go` — resolver field + `WithHardPinResolver` signature gain `denySet`
- `cmd/router/main.go` — wire resolver in all modes via `FastestModelInSet`; skip when operator override set
- `internal/proxy/service_session_pin_test.go` — new regression test + updated existing resolver signatures

## Testing

- New test `TestService_HardPin_Classifier_AppliesExcludedModels` drives a classifier turn where the excluded model is both the fastest candidate and the boot-time pin, and asserts the served model is the allowed fallback — **not** the excluded one. Verified it **fails** when the deny set is not threaded through (serves the excluded gemini model), proving it's a real regression guard.
- `go build ./...` and `go test ./internal/proxy/... ./internal/router/... ./cmd/router/...` all green; `gofmt` and `go vet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013CbU9jmNQxJDGXJhnRMeYP