### PR TITLE
fix(router): abort sub-throughput slow streams instead of hanging to 600s

### DIFF
--- a/internal/providers/httputil/httputil.go
+++ b/internal/providers/httputil/httputil.go
@@ -36,6 +36,12 @@ var ErrUpstreamIdleTimeout = providers.ErrUpstreamIdleTimeout
 // because the stream stayed byte-alive but produced no output-bearing content.
 var ErrUpstreamOutputStall = providers.ErrUpstreamOutputStall
 
+// ErrUpstreamSlowThroughput re-exports providers.ErrUpstreamSlowThroughput —
+// the cause set when the minimum-throughput watchdog (StartThroughputWatchdog)
+// trips because the stream IS producing output, but at a sustained rate below
+// the configured floor over the rolling window.
+var ErrUpstreamSlowThroughput = providers.ErrUpstreamSlowThroughput
+
 // DefaultSSEIdleTimeout is the per-read inactivity threshold for streaming
 // upstream responses. AWS NAT Gateway / NLB / VPC-endpoint reapers silently
 // drop idle TCP connections at 350s; a watchdog below that surfaces stalls
@@ -103,6 +109,79 @@ var DefaultResponsesOutputStallTimeout = idleTimeoutFromEnv("ROUTER_RESPONSES_OU
 //
 // Tunable via ROUTER_OUTPUT_STALL_TIMEOUT_SECONDS.
 var DefaultOutputStallTimeout = idleTimeoutFromEnv("ROUTER_OUTPUT_STALL_TIMEOUT_SECONDS", 240*time.Second)
+
+// Minimum-throughput watchdog defaults. The byte-idle (45s) and output-stall
+// (240s) watchdogs both catch a stream that STOPS producing — bytes or output
+// respectively. Neither catches a stream that keeps producing output but at a
+// crawl: a clean 200 that dribbles output-bearing deltas steadily enough to
+// reset both marks yet so slowly the turn takes minutes and the client appears
+// frozen, riding toward the 600s request cap with no failover.
+//
+// Prod incident 2026-06-25: a deepseek/deepseek-v4-flash stream emitted ~1774
+// output deltas over ~132s (~13 events/s) — a steadily-flowing 200 that tripped
+// none of the existing watchdogs and was never classified retryable. This
+// watchdog measures sustained OUTPUT-event throughput over a rolling window and,
+// once a warmup has passed, aborts with ErrUpstreamSlowThroughput (retryable)
+// when the rate stays below the floor.
+//
+// The mark is the SAME output-progress signal fed to the output-stall watchdog
+// (one mark per output-bearing delta: assistant text, streamed reasoning,
+// tool-call args, terminal finish — never keepalives/empty deltas). One delta
+// is a small chunk of tokens, so delta-rate is a usable proxy for token-rate
+// without threading byte counts through every translator.
+//
+// CONSERVATIVE BY DESIGN — these defaults err strongly on the side of NOT
+// aborting, so a legitimately slow "thinking" model is never killed:
+//
+//   - Floor (DefaultMinThroughputDeltasPerWindow / DefaultThroughputWindow):
+//     fewer than 8 output deltas in a 20s rolling window (~0.4 deltas/s) is the
+//     abort condition. The prod dribble ran ~13 deltas/s — over 30x this floor —
+//     so this would NOT have fired on it on rate alone; it targets the strictly
+//     worse "near-frozen but technically advancing" tail. A healthy generation
+//     streams many deltas per second, orders of magnitude above the floor.
+//   - Window (DefaultThroughputWindow): 20s rolling window. Long enough that a
+//     brief mid-stream pause (a slow tool-arg chunk, a reasoning gap) does not
+//     trip it; the rate is averaged over the window, not instantaneous.
+//   - Warmup (DefaultThroughputMinElapsed): the watchdog is INERT for the first
+//     90s of the stream. A large-context prefill, a long initial reasoning phase,
+//     or a slow-to-warm provider gets a full grace period before throughput is
+//     ever evaluated. Combined with the rolling window, an abort requires the
+//     stream to be both past warmup AND sustaining sub-floor output.
+//
+// All three are tunable via env so the floor can be relaxed (or the watchdog
+// disabled by setting the floor to 0) without a redeploy.
+var (
+	// DefaultThroughputWindow is the rolling window over which output-delta
+	// throughput is measured. Tunable via ROUTER_THROUGHPUT_WINDOW_SECONDS.
+	DefaultThroughputWindow = idleTimeoutFromEnv("ROUTER_THROUGHPUT_WINDOW_SECONDS", 20*time.Second)
+
+	// DefaultThroughputMinElapsed is the warmup period during which the
+	// throughput watchdog is inert (no abort), giving prefill/initial-reasoning
+	// a grace period. Tunable via ROUTER_THROUGHPUT_MIN_ELAPSED_SECONDS.
+	DefaultThroughputMinElapsed = idleTimeoutFromEnv("ROUTER_THROUGHPUT_MIN_ELAPSED_SECONDS", 90*time.Second)
+
+	// DefaultMinThroughputDeltasPerWindow is the minimum number of output-bearing
+	// deltas that must arrive within DefaultThroughputWindow once warmup has
+	// passed; below this the stream is aborted as ErrUpstreamSlowThroughput. A
+	// value <= 0 disables the watchdog entirely. Tunable via
+	// ROUTER_MIN_THROUGHPUT_DELTAS_PER_WINDOW.
+	DefaultMinThroughputDeltasPerWindow = intFromEnv("ROUTER_MIN_THROUGHPUT_DELTAS_PER_WINDOW", 8)
+)
+
+// intFromEnv reads a whole-number override from envVar, falling back to
+// fallback when unset or unparsable. Unlike idleTimeoutFromEnv it permits 0
+// (and negatives) through so an operator can disable a count-based guard.
+func intFromEnv(envVar string, fallback int) int {
+	v := os.Getenv(envVar)
+	if v == "" {
+		return fallback
+	}
+	n, err := strconv.Atoi(v)
+	if err != nil {
+		return fallback
+	}
+	return n
+}
 
 // idleTimeoutFromEnv reads a whole-seconds override from envVar, falling back
 // to fallback when unset, unparsable, or non-positive.
@@ -208,6 +287,83 @@ func StartIdleWatchdogCause(ctx context.Context, cancel context.CancelCauseFunc,
 		sync.OnceFunc(func() { close(done) })
 }
 
+// StartThroughputWatchdog starts a goroutine that cancels ctx with cause when
+// the upstream IS producing output but at a sustained rate below minDeltas per
+// window, once minElapsed has passed since the watchdog started. The returned
+// mark must be invoked on every output-bearing delta (the SAME signal fed to
+// the output-progress watchdog); the returned stop terminates the goroutine and
+// must be called via defer.
+//
+// Unlike the idle watchdogs (which measure time-since-last-event), this measures
+// the COUNT of marks within a rolling window: a stream that keeps marking but
+// too slowly is the failure mode here. The watchdog is inert until minElapsed
+// has elapsed, so prefill / initial reasoning is never penalized; thereafter, on
+// each tick it counts marks observed in the trailing window and trips if that
+// count is below minDeltas.
+//
+// minDeltas <= 0, window <= 0, or cancel == nil disables the watchdog
+// (no-op mark/stop). minElapsed <= 0 means evaluate as soon as a full window
+// of data exists.
+func StartThroughputWatchdog(ctx context.Context, cancel context.CancelCauseFunc, window, minElapsed time.Duration, minDeltas int, cause error) (mark func(), stop func()) {
+	if minDeltas <= 0 || window <= 0 || cancel == nil {
+		return func() {}, func() {}
+	}
+	var count atomic.Int64
+	start := time.Now()
+	// floorRate is the minimum marks-per-second the stream must sustain
+	// (minDeltas spread over one window). Evaluating a normalized RATE rather
+	// than a raw count over the exact window lets the watchdog tick at its own
+	// cadence without the tick interval distorting the measured throughput.
+	floorRate := float64(minDeltas) / window.Seconds()
+	done := make(chan struct{})
+	go func() {
+		// Tick several times per window so a sub-floor stretch is caught
+		// promptly; cap small so a short test window still evaluates within it,
+		// and floor so a large production window doesn't spin.
+		interval := min(max(window/4, 50*time.Millisecond), 5*time.Second)
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+		// windowStartCount / windowStart anchor the trailing measurement window.
+		// Marks-in-window = current - snapshot, over now-windowStart seconds.
+		var windowStartCount int64
+		windowStart := start
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-done:
+				return
+			case <-ticker.C:
+				now := time.Now()
+				if now.Sub(start) < minElapsed {
+					// Warmup: don't evaluate, and keep the window anchored at
+					// "now" so the first post-warmup evaluation reflects only
+					// post-warmup traffic, not the slow prefill.
+					windowStartCount = count.Load()
+					windowStart = now
+					continue
+				}
+				elapsed := now.Sub(windowStart)
+				if elapsed < window {
+					// Not yet a full window of post-warmup data to judge on.
+					continue
+				}
+				cur := count.Load()
+				rate := float64(cur-windowStartCount) / elapsed.Seconds()
+				if rate < floorRate {
+					cancel(cause)
+					return
+				}
+				// Slide the window forward.
+				windowStartCount = cur
+				windowStart = now
+			}
+		}
+	}()
+	return func() { count.Add(1) },
+		sync.OnceFunc(func() { close(done) })
+}
+
 // StreamBody reads r chunk-by-chunk into w, flushing after each write. Returns
 // UpstreamStatusError when status is non-2xx.
 //
@@ -246,7 +402,7 @@ func StreamBody(ctx context.Context, cancel context.CancelCauseFunc, idleTimeout
 			// share this ctx and cancel with a different cause; surface whichever
 			// sentinel tripped so the caller classifies it retryable instead of
 			// seeing a bare context.Canceled.
-			if cause := context.Cause(ctx); errors.Is(cause, ErrUpstreamIdleTimeout) || errors.Is(cause, ErrUpstreamOutputStall) {
+			if cause := context.Cause(ctx); errors.Is(cause, ErrUpstreamIdleTimeout) || errors.Is(cause, ErrUpstreamOutputStall) || errors.Is(cause, ErrUpstreamSlowThroughput) {
 				return cause
 			}
 			return readErr

--- a/internal/providers/httputil/httputil_test.go
+++ b/internal/providers/httputil/httputil_test.go
@@ -207,3 +207,86 @@ func TestErrUpstreamIdleTimeout_AliasIsRetryable(t *testing.T) {
 
 // Sanity guard: ensure the exported sentinel is actually used.
 var _ = errors.Is(ErrUpstreamIdleTimeout, ErrUpstreamIdleTimeout)
+
+func TestStartThroughputWatchdog_NoOpWhenDisabled(t *testing.T) {
+	ctx, cancel := context.WithCancelCause(context.Background())
+	defer cancel(nil)
+	// minDeltas <= 0 disables the watchdog (operator escape hatch).
+	mark, stop := StartThroughputWatchdog(ctx, cancel, 50*time.Millisecond, 0, 0, ErrUpstreamSlowThroughput)
+	mark()
+	stop()
+	assert.NoError(t, context.Cause(ctx))
+
+	// window <= 0 also disables.
+	mark2, stop2 := StartThroughputWatchdog(ctx, cancel, 0, 0, 5, ErrUpstreamSlowThroughput)
+	mark2()
+	stop2()
+	assert.NoError(t, context.Cause(ctx))
+}
+
+func TestStartThroughputWatchdog_InertDuringWarmup(t *testing.T) {
+	ctx, cancel := context.WithCancelCause(context.Background())
+	defer cancel(nil)
+	// Require 100 deltas/window but never mark: with a 300ms warmup the watchdog
+	// must NOT fire before warmup elapses even though throughput is zero.
+	_, stop := StartThroughputWatchdog(ctx, cancel, 50*time.Millisecond, 300*time.Millisecond, 100, ErrUpstreamSlowThroughput)
+	defer stop()
+
+	select {
+	case <-ctx.Done():
+		t.Fatalf("watchdog fired during warmup: %v", context.Cause(ctx))
+	case <-time.After(150 * time.Millisecond):
+	}
+	assert.NoError(t, context.Cause(ctx), "must stay inert through the warmup period")
+}
+
+func TestStartThroughputWatchdog_FiresOnSustainedSubFloor(t *testing.T) {
+	ctx, cancel := context.WithCancelCause(context.Background())
+	defer cancel(nil)
+	// After a tiny warmup, require >=5 deltas per 60ms window. Mark only once per
+	// ~40ms (well under the floor): the stream is "alive" but too slow, so the
+	// watchdog must trip with the slow-throughput cause.
+	mark, stop := StartThroughputWatchdog(ctx, cancel, 60*time.Millisecond, 30*time.Millisecond, 5, ErrUpstreamSlowThroughput)
+	defer stop()
+
+	go func() {
+		for i := 0; i < 50; i++ {
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(40 * time.Millisecond):
+				mark()
+			}
+		}
+	}()
+
+	deadline := time.NewTimer(2 * time.Second)
+	defer deadline.Stop()
+	select {
+	case <-ctx.Done():
+	case <-deadline.C:
+		t.Fatal("watchdog never fired on a sustained sub-floor stream")
+	}
+	assert.ErrorIs(t, context.Cause(ctx), ErrUpstreamSlowThroughput)
+}
+
+func TestStartThroughputWatchdog_DoesNotFireOnHealthyStream(t *testing.T) {
+	ctx, cancel := context.WithCancelCause(context.Background())
+	defer cancel(nil)
+	// Require >=3 deltas per 60ms window after a 30ms warmup; mark every ~5ms
+	// (~12 per window, well above the floor). Must NOT fire.
+	mark, stop := StartThroughputWatchdog(ctx, cancel, 60*time.Millisecond, 30*time.Millisecond, 3, ErrUpstreamSlowThroughput)
+	defer stop()
+
+	end := time.Now().Add(400 * time.Millisecond)
+	for time.Now().Before(end) {
+		mark()
+		time.Sleep(5 * time.Millisecond)
+	}
+	assert.NoError(t, context.Cause(ctx), "healthy throughput must not trip the watchdog")
+}
+
+func TestErrUpstreamSlowThroughput_AliasIsRetryable(t *testing.T) {
+	assert.True(t, errors.Is(ErrUpstreamSlowThroughput, providers.ErrUpstreamSlowThroughput))
+	assert.True(t, providers.IsRetryable(ErrUpstreamSlowThroughput))
+}

--- a/internal/providers/openaicompat/client.go
+++ b/internal/providers/openaicompat/client.go
@@ -75,6 +75,14 @@ type Client struct {
 	// inject a small value to drive the output-stall trip without waiting out the
 	// real budget.
 	outputStall time.Duration
+	// throughputWindow / throughputMinElapsed / throughputMinDeltas, when > 0
+	// (and >= 0 for the delta count), override the minimum-throughput watchdog
+	// budgets. Production uses the httputil defaults; tests inject small values
+	// to drive a slow-throughput trip without waiting out the real warmup.
+	throughputWindow     time.Duration
+	throughputMinElapsed time.Duration
+	throughputMinDeltas  int
+	throughputOverride   bool
 }
 
 func NewClient(apiKey, baseURL string) *Client {
@@ -123,6 +131,28 @@ func (c *Client) outputStallTimeout() time.Duration {
 		return c.outputStall
 	}
 	return httputil.DefaultOutputStallTimeout
+}
+
+// throughputParams returns the minimum-throughput watchdog budgets: the injected
+// test overrides when set, else the httputil defaults.
+func (c *Client) throughputParams() (window, minElapsed time.Duration, minDeltas int) {
+	if c.throughputOverride {
+		return c.throughputWindow, c.throughputMinElapsed, c.throughputMinDeltas
+	}
+	return httputil.DefaultThroughputWindow, httputil.DefaultThroughputMinElapsed, httputil.DefaultMinThroughputDeltasPerWindow
+}
+
+// NewClientWithThroughputGuard is NewClient with injected minimum-throughput
+// watchdog budgets, so a test can drive a slow-throughput trip with a tiny
+// warmup/window while keeping the idle and output-stall watchdogs large enough
+// that they aren't what fire.
+func NewClientWithThroughputGuard(apiKey, baseURL string, window, minElapsed time.Duration, minDeltas int) *Client {
+	c := NewClient(apiKey, baseURL)
+	c.throughputOverride = true
+	c.throughputWindow = window
+	c.throughputMinElapsed = minElapsed
+	c.throughputMinDeltas = minDeltas
+	return c
 }
 
 // rewriteModelField rewrites the body's top-level "model" field according to
@@ -225,17 +255,34 @@ func (c *Client) Proxy(ctx context.Context, decision router.Decision, prep provi
 	// keepalives, so it is wired via ArmOutputProgress; a non-streaming client
 	// (or a writer without the hook) returns armed=false and is byte-idle-guarded
 	// only.
+	// A third watchdog runs on the same output-progress mark: the
+	// minimum-throughput guard. The output-stall watchdog above only catches a
+	// stream that stops producing output entirely; it never trips on a clean 200
+	// that keeps dribbling output-bearing deltas (resetting outMark on each one)
+	// but at a crawl. The throughput watchdog measures the COUNT of those deltas
+	// over a rolling window and, once warmup has passed, aborts with
+	// ErrUpstreamSlowThroughput (retryable) when the rate stays below the floor
+	// (2026-06-25 deepseek-v4-flash ~132s dribble). Both are fed by the single
+	// ArmOutputProgress mark, so the installed mark fans out to both.
 	if arm, ok := w.(providers.OutputProgressArmer); ok {
 		outMark, outStop := httputil.StartIdleWatchdogCause(ctx, cancel, c.outputStallTimeout(), httputil.ErrUpstreamOutputStall)
-		if arm.ArmOutputProgress(outMark) {
+		tpWindow, tpMinElapsed, tpMinDeltas := c.throughputParams()
+		tpMark, tpStop := httputil.StartThroughputWatchdog(ctx, cancel, tpWindow, tpMinElapsed, tpMinDeltas, httputil.ErrUpstreamSlowThroughput)
+		combined := func() {
+			outMark()
+			tpMark()
+		}
+		if arm.ArmOutputProgress(combined) {
 			defer outStop()
+			defer tpStop()
 		} else {
 			outStop()
+			tpStop()
 		}
 	}
 
 	streamErr := httputil.StreamBody(ctx, cancel, c.idleTimeout(), resp.Body, resp.StatusCode, w, t)
-	if errors.Is(streamErr, httputil.ErrUpstreamIdleTimeout) || errors.Is(streamErr, httputil.ErrUpstreamOutputStall) {
+	if errors.Is(streamErr, httputil.ErrUpstreamIdleTimeout) || errors.Is(streamErr, httputil.ErrUpstreamOutputStall) || errors.Is(streamErr, httputil.ErrUpstreamSlowThroughput) {
 		logStreamStall(decision.Model, c.baseURL, streamErr)
 	}
 	return streamErr
@@ -249,8 +296,11 @@ func (c *Client) Proxy(ctx context.Context, decision router.Decision, prep provi
 // when nothing reached the client; this log is the per-model paper trail.
 func logStreamStall(model, baseURL string, cause error) {
 	stallKind := "byte_idle"
-	if errors.Is(cause, httputil.ErrUpstreamOutputStall) {
+	switch {
+	case errors.Is(cause, httputil.ErrUpstreamOutputStall):
 		stallKind = "output_idle"
+	case errors.Is(cause, httputil.ErrUpstreamSlowThroughput):
+		stallKind = "slow_throughput"
 	}
 	observability.Get().Error("Upstream OpenAI-compatible stream stalled mid-response; aborting for retry",
 		"model", model,

--- a/internal/providers/openaicompat/client_slow_throughput_test.go
+++ b/internal/providers/openaicompat/client_slow_throughput_test.go
@@ -1,0 +1,116 @@
+package openaicompat_test
+
+// Guards the MINIMUM-THROUGHPUT watchdog on the generic OpenAI-compatible
+// adapter. Prod incident 2026-06-25: a deepseek/deepseek-v4-flash stream emitted
+// ~1774 output deltas over ~132s (~13 events/s) — a clean, steadily-flowing 200
+// that reset BOTH the byte-idle (45s) and output-stall (240s) watchdogs on every
+// delta yet was so slow the turn rode toward the 600s request cap with the client
+// (Claude Code) frozen, and was never classified retryable. Only a watchdog that
+// measures the RATE of output deltas (not time-since-last-output) can catch it.
+// The translator reports each output-bearing delta via ArmOutputProgress; these
+// tests stand in a fake writer that marks on each relayed frame so the client
+// half is pinned independently of the translator: a stream marking far below the
+// floor aborts with a retryable ErrUpstreamSlowThroughput, while one marking
+// above the floor is never aborted.
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"workweave/router/internal/providers"
+	"workweave/router/internal/providers/httputil"
+	"workweave/router/internal/providers/openaicompat"
+	"workweave/router/internal/router"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// streamsContentForever commits 200 + SSE headers then emits one output-bearing
+// content frame every interval until the client disconnects. The fakeProgressWriter
+// (markOnWrite=true) marks output progress on each, so byte-idle and output-stall
+// both stay reset — only the throughput watchdog can end it.
+func streamsContentForever(interval time.Duration) *httptest.Server {
+	const frame = "data: {\"choices\":[{\"delta\":{\"content\":\"x\"}}]}\n\n"
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		f := w.(http.Flusher)
+		f.Flush()
+		for {
+			select {
+			case <-r.Context().Done():
+				return
+			case <-time.After(interval):
+			}
+			if _, err := io.WriteString(w, frame); err != nil {
+				return
+			}
+			f.Flush()
+		}
+	}))
+}
+
+func TestProxy_SlowThroughputAbortsRetryable(t *testing.T) {
+	// One delta every ~40ms = ~25/s. With a tiny warmup and a floor of 100
+	// deltas per 60ms window (~1666/s), the stream is steadily alive but far
+	// below the floor, so the throughput watchdog must trip — even though
+	// neither byte-idle nor output-stall ever would.
+	upstream := streamsContentForever(40 * time.Millisecond)
+	defer upstream.Close()
+
+	c := openaicompat.NewClientWithThroughputGuard("test-key", upstream.URL,
+		60*time.Millisecond /*window*/, 30*time.Millisecond /*minElapsed*/, 100 /*minDeltas*/)
+	w := &fakeProgressWriter{armReturns: true, markOnWrite: true}
+	clientReq := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(""))
+
+	start := time.Now()
+	err := c.Proxy(context.Background(), router.Decision{Model: "deepseek/deepseek-v4-flash"}, chatPrep(), w, clientReq)
+	elapsed := time.Since(start)
+
+	require.Error(t, err, "a sustained sub-throughput stream must surface an error, not hang")
+	assert.ErrorIs(t, err, httputil.ErrUpstreamSlowThroughput)
+	assert.True(t, providers.IsRetryable(err),
+		"the slow-throughput stall must classify retryable so dispatchWithFallback can re-attempt")
+	assert.Less(t, elapsed, 5*time.Second, "must abort promptly after warmup, not ride to the cap")
+	assert.Positive(t, w.bytesIn, "the upstream did keep the stream alive with output (precondition)")
+}
+
+func TestProxy_HealthyThroughputIsNotAborted(t *testing.T) {
+	// One delta every ~5ms = ~200/s, comfortably above a floor of 3 deltas per
+	// 60ms window (~50/s). The throughput watchdog must never trip; the stream
+	// ends on its own when the upstream closes.
+	const frame = "data: {\"choices\":[{\"delta\":{\"content\":\"x\"}}]}\n\n"
+	const frames = 80
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		f := w.(http.Flusher)
+		f.Flush()
+		for range frames {
+			select {
+			case <-r.Context().Done():
+				return
+			case <-time.After(5 * time.Millisecond):
+			}
+			_, _ = io.WriteString(w, frame)
+			f.Flush()
+		}
+	}))
+	defer upstream.Close()
+
+	c := openaicompat.NewClientWithThroughputGuard("test-key", upstream.URL,
+		60*time.Millisecond /*window*/, 30*time.Millisecond /*minElapsed*/, 3 /*minDeltas*/)
+	w := &fakeProgressWriter{armReturns: true, markOnWrite: true}
+	clientReq := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(""))
+
+	err := c.Proxy(context.Background(), router.Decision{Model: "deepseek/deepseek-v4-flash"}, chatPrep(), w, clientReq)
+
+	require.NoError(t, err, "a stream above the throughput floor must never trip the watchdog")
+	assert.Positive(t, w.bytesIn)
+}

--- a/internal/providers/provider.go
+++ b/internal/providers/provider.go
@@ -197,6 +197,20 @@ var ErrUpstreamIdleTimeout = errors.New("upstream sse idle timeout")
 // httputil re-exports it as httputil.ErrUpstreamOutputStall.
 var ErrUpstreamOutputStall = errors.New("upstream sse output stall")
 
+// ErrUpstreamSlowThroughput is the sentinel cause set when a provider adapter's
+// minimum-throughput watchdog fires: the upstream IS producing output (so
+// neither ErrUpstreamIdleTimeout nor ErrUpstreamOutputStall trips — the mark is
+// fed steadily), but at a sustained rate so low that the turn would dribble for
+// minutes and trip none of the other watchdogs while the client (Claude Code)
+// appears frozen. This is the 2026-06-25 failure mode: a deepseek/deepseek-v4-flash
+// stream emitted ~1774 output deltas over ~132s (~13 events/s) — a clean,
+// steadily-flowing 200 that no existing guard classified as retryable, riding
+// toward the 600s request cap. Like the other stall sentinels it is
+// upstream-owned and retryable. Defined here (not in httputil) so IsRetryable
+// can classify it without the import cycle; httputil re-exports it as
+// httputil.ErrUpstreamSlowThroughput.
+var ErrUpstreamSlowThroughput = errors.New("upstream sse slow throughput")
+
 // IsRetryableStatus reports whether an upstream HTTP status is worth
 // retrying on a different provider. Covers transient upstream-side faults
 // (5xx + 408 timeout + 429 rate-limit). 4xx ≠ 408/429 are the client's
@@ -237,6 +251,14 @@ func IsRetryable(err error) bool {
 	// the caller-cancellation guard for the same reason as ErrUpstreamIdleTimeout
 	// — the watchdog surfaces it via the request context's cancel cause.
 	if errors.Is(err, ErrUpstreamOutputStall) {
+		return true
+	}
+	// A sustained sub-throughput stall is upstream-owned: the stream produced
+	// output the whole time, just far too slowly to be usable. Classified
+	// before the caller-cancellation guard for the same reason as the other
+	// stall sentinels — the watchdog surfaces it via the request context's
+	// cancel cause, which may also chain context.Canceled.
+	if errors.Is(err, ErrUpstreamSlowThroughput) {
 		return true
 	}
 	// Client-side cancellation and per-request deadlines are owned by the


### PR DESCRIPTION
## Bug

A slow-but-steadily-flowing upstream stream hangs for minutes and trips **none** of the existing watchdogs, and there is no sub-600s total deadline short of the request cap. The existing guards all measure *time-since-last-event*, so a stream that keeps emitting output-bearing deltas — just very slowly — resets them on every delta and never trips:

- **30s header timeout** (`httputil.DefaultResponseHeaderTimeout`) — only bites *before* the first byte.
- **45s byte-idle watchdog** (`StartIdleWatchdog`, `DefaultSSEIdleTimeout`) — resets on every chunk with `n>0`; a dribbling stream keeps it alive.
- **240s output-stall watchdog** (`ErrUpstreamOutputStall`, `DefaultOutputStallTimeout`) — sees output *flowing*, so its mark keeps resetting; never trips.
- **600s request cap** (`messagesTimeout`) — the only hard ceiling.

A flowing 200 is not classified retryable, so failover never engages either.

## Prod symptom

2026-06-25: `deepseek/deepseek-v4-flash` produced ~1774 output deltas over **~132 seconds (~13 tok/s)** — a clean 200 that dribbles. The client (Claude Code) appeared frozen for 2+ minutes and the turn rode toward the 600s cap. No watchdog fired; failover never engaged.

## Fix — minimum-throughput watchdog

Added `httputil.StartThroughputWatchdog`, a third watchdog that runs alongside the byte-idle and output-stall guards on the **cross-format OpenAI-compatible (OSS) streaming path** — exactly where the output-stall watchdog already lives (`internal/providers/openaicompat/client.go`). It is fed by the **same** output-progress mark (`ArmOutputProgress`, one mark per output-bearing delta — assistant text, streamed reasoning, tool-call args, terminal finish; never keepalives/empty deltas). The single armed mark fans out to both the output-stall timer and the throughput counter.

Unlike the idle watchdogs (time-since-last-event), this measures the sustained **rate** of output deltas over a rolling window. Once warmup has passed, if the rate stays below the floor it cancels the request context with a new sentinel `ErrUpstreamSlowThroughput`, classified **retryable** by `providers.IsRetryable` (same family as `ErrUpstreamIdleTimeout` / `ErrUpstreamOutputStall`). `StreamBody` surfaces the cause directly so failover can engage when no bytes reached the client, or a clean retryable timeout surfaces instead of a 600s hang.

### Chosen thresholds (CONSERVATIVE — env-tunable)

| Constant | Default | Env override | Rationale |
|---|---|---|---|
| floor | **8 deltas / window** | `ROUTER_MIN_THROUGHPUT_DELTAS_PER_WINDOW` | ~0.4 deltas/s. The prod dribble ran ~13 deltas/s — over **30x** this floor — so it would NOT have fired on the prod case on rate alone; the floor targets the strictly-worse near-frozen tail. A value `<= 0` **disables** the watchdog (operator escape hatch). |
| window | **20s** | `ROUTER_THROUGHPUT_WINDOW_SECONDS` | Long enough that a brief mid-stream pause (slow tool-arg chunk, reasoning gap) doesn't trip it — rate is averaged over the window, not instantaneous. |
| warmup (min-elapsed) | **90s** | `ROUTER_THROUGHPUT_MIN_ELAPSED_SECONDS` | The watchdog is **inert** for the first 90s, so a large-context prefill / long initial reasoning / slow-to-warm provider gets a full grace period before throughput is ever evaluated. |

An abort requires the stream to be **both** past warmup **and** sustaining sub-floor output over a full rolling window.

### Tradeoff (explicit)

This is a behavior change to a production router serving real customers. The risk is **aborting a legitimately slow generation**. The defaults err strongly toward NOT aborting: the floor is ~30x below the already-pathological prod case, the warmup gives 90s of grace, and the rolling window absorbs transient pauses. A genuinely slow "thinking" model that streams reasoning at any reasonable cadence stays orders of magnitude above the floor. If a model surfaces that legitimately dribbles below the floor for >90s, the floor can be lowered (or the guard disabled, floor `0`) via env without a redeploy. The scorer's `speed_weight` was deliberately left untouched (0.0 in v0.70, no `tok_per_s` table) — this is a runtime guard, not a routing-config change.

## Tests

- `internal/providers/httputil/httputil_test.go` — unit tests: no-op when disabled, inert during warmup, fires on a sustained sub-floor stream, never fires on a healthy stream, retryable-alias guard.
- `internal/providers/openaicompat/client_slow_throughput_test.go` — client integration: a stream marking far below the floor aborts with retryable `ErrUpstreamSlowThroughput`; a stream above the floor is never aborted. Uses a new `NewClientWithThroughputGuard` test constructor (small warmup/window) so the idle/output-stall watchdogs aren't what fire.

`go build ./...`, `go vet ./internal/providers/...`, and `go test ./internal/providers/... ./internal/proxy/... ./internal/translate/...` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013CbU9jmNQxJDGXJhnRMeYP