### PR TITLE
fix(router): fail over on 429 / header-timeout on the subscription path

### DIFF
--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -2111,6 +2111,33 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 		baselineModel != decision.Model &&
 		baselineKnown && baselineCatalog.PrimaryProvider() == providers.ProviderAnthropic
 
+	// Subscription-credit failover eligibility. When a Claude turn is served on
+	// the caller's own subscription (sk-ant-oat) and the upstream returns a
+	// retryable 429 / header-timeout, the request is pinned to a single Anthropic
+	// binding (shouldFailover is false while a subscription credential rides on
+	// ctx) so dispatchWithFallback has nowhere to fail over to — the raw 429 /
+	// ~90s hang reaches the client. This is the gap behind the prod instability:
+	// the observer-driven exhaustion suppression (claudeSubscriptionExhausted ->
+	// withSuppressedClaudeSubscription, above) only fires when a PRIOR snapshot
+	// already read >= exhaustedFraction, but the binding 429 IS usually the first
+	// signal the window bound, so the stale snapshot still reads "slack" and the
+	// spent token is sent anyway.
+	//
+	// When a non-subscription Anthropic key is configured (per-request BYOK, or
+	// the deployment's own ANTHROPIC_API_KEY), retry the SAME requested model on
+	// that key exactly once. This is the deliberate product decision documented in
+	// the PR: a retryable 429 on a customer's subscription is treated as "serve
+	// this turn on the Weave key" (billed at full cost, not the subscription rate)
+	// rather than surface the throttle — the same fallback claudeSubscriptionExhausted
+	// already takes pre-emptively, just driven by the live error instead of a stale
+	// snapshot. Eligible only pre-commit (nothing on the wire), on a subscription-
+	// served Anthropic turn, with a fallback key available. Computed pre-dispatch
+	// so the primary dispatch defers its exhaustion flush to us. Mutually exclusive
+	// with baselineEligible (which requires a non-Anthropic routed provider).
+	subscriptionRetryEligible := decision.Provider == providers.ProviderAnthropic &&
+		servedOnSubscription(ctx) &&
+		s.anthropicFallbackKeyAvailable(ctx)
+
 	primaryProvider := decision.Provider
 	var winnerIdx int
 	winnerIdx, proxyErr = s.dispatchWithFallback(ctx, failoverInputs{
@@ -2122,7 +2149,7 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 		bindings:               bindings,
 		attempt:                attempt,
 		flushErr:               flushUpstreamErrorAsAnthropic,
-		deferFlushOnExhaustion: baselineEligible,
+		deferFlushOnExhaustion: baselineEligible || subscriptionRetryEligible,
 	})
 
 	// The routed model's bindings all failed with a fault a different model
@@ -2193,6 +2220,61 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 		flushUpstreamErrorAsAnthropic(contentSink, proxyErr)
 	}
 
+	// Subscription-credit failover: the requested Anthropic model was served on
+	// the caller's subscription and the upstream returned a retryable fault
+	// (429 weekly/5h-limit, or a ~90s header-timeout) before any byte reached
+	// the client. Suppress the subscription token and re-dispatch the SAME model
+	// once on the Weave / BYOK Anthropic key so the turn still completes instead
+	// of surfacing the throttle raw. Bounded to a single extra attempt (no loop),
+	// gated on pre-commit (!preludeBuf.Committed()) and on the error being
+	// genuinely retryable — a committed stream or a 4xx the client owns is never
+	// retried. Skipped when baseline failover already ran (mutually exclusive:
+	// baseline requires a non-Anthropic routed provider).
+	subscriptionFailoverUsed := false
+	subscriptionRetryRan := false
+	if subscriptionRetryEligible && !baselineAttempted && proxyErr != nil &&
+		!preludeBuf.Committed() && providers.IsRetryable(proxyErr) {
+		subscriptionRetryRan = true
+		subCtx := withSuppressedClaudeSubscription(ctx)
+		subCtx = resolveAndInjectCredentials(subCtx, providers.ProviderAnthropic, r.Header)
+		// Re-emit the body against the suppressed-subscription context. The model
+		// is unchanged, so opts/prep are identical to the primary attempt; rebuild
+		// the prep so the retry gets a pristine PreparedRequest.
+		subPrep, subEmitErr := env.PrepareAnthropic(r.Header, opts)
+		if subEmitErr != nil {
+			log.Error("Subscription failover: emit Anthropic body failed; surfacing original error", "err", subEmitErr, "model", decision.Model)
+			flushUpstreamErrorAsAnthropic(contentSink, proxyErr)
+		} else {
+			log.Warn("Subscription failover: subscription throttled/timed out, retrying requested model on Weave key",
+				"model", decision.Model,
+				"err", proxyErr,
+				"upstream_status", upstreamStatus(proxyErr))
+			subBindings := s.resolveBindingsForDispatch(subCtx, decision)
+			subAttempt := s.anthropicNativeAttempt(env, r, subPrep, sink, preludeBuf, marker, setExtractor)
+			crossFormat = false
+			respSummary = translate.ResponseSummary{}
+			reqStats = providers.RequestMutationStats{}
+			logUpstreamBody(log, routeRes.SessionKey, decision, feats, subPrep.Body)
+			winnerIdx, proxyErr = s.dispatchWithFallback(subCtx, failoverInputs{
+				w:               contentSink,
+				buf:             preludeBuf,
+				initialDecision: decision,
+				bindings:        subBindings,
+				attempt:         subAttempt,
+				flushErr:        flushUpstreamErrorAsAnthropic,
+			})
+			bindings = subBindings
+			subscriptionFailoverUsed = proxyErr == nil
+		}
+	}
+	// We deferred the primary's exhaustion flush for the subscription retry but
+	// the retry didn't run (response committed mid-stream, or a non-retryable
+	// error). Surface the original upstream error envelope now so a deferred
+	// flush is never silently dropped.
+	if subscriptionRetryEligible && !baselineAttempted && !subscriptionRetryRan && proxyErr != nil && !preludeBuf.Committed() {
+		flushUpstreamErrorAsAnthropic(contentSink, proxyErr)
+	}
+
 	finalProvider := primaryProvider
 	if winnerIdx >= 0 && winnerIdx < len(bindings) {
 		finalProvider = bindings[winnerIdx].Provider
@@ -2208,7 +2290,13 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 	// Re-resolve credentials for the binding that actually served the turn.
 	// During failover, each attempt gets its own per-attempt context with
 	// potentially different credentials. Update ctx so credentialKeyParts
-	// reads the correct key parts for telemetry.
+	// reads the correct key parts for telemetry. When the subscription failover
+	// served the turn on the Weave / BYOK key, carry the suppression forward so
+	// cost.subscription_served + the billing key reflect the key that actually
+	// paid (full cost), not the spent subscription that 429'd.
+	if subscriptionRetryRan {
+		ctx = withSuppressedClaudeSubscription(ctx)
+	}
 	ctx = resolveAndInjectCredentials(ctx, finalProvider, r.Header)
 
 	// Re-resolve actual pricing for the binding that actually served the
@@ -2269,8 +2357,9 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 		String("dispatch.primary_provider", primaryProvider).
 		String("dispatch.final_provider", finalProvider).
 		Int64("dispatch.fallback_attempts", int64(winnerIdx)).
-		Bool("dispatch.failover_used", finalProvider != primaryProvider).
-		Bool("dispatch.baseline_failover", baselineFailoverUsed)
+		Bool("dispatch.failover_used", finalProvider != primaryProvider || subscriptionFailoverUsed).
+		Bool("dispatch.baseline_failover", baselineFailoverUsed).
+		Bool("dispatch.subscription_failover", subscriptionFailoverUsed)
 	applyPlannerAttrs(upstreamBuilder, routeRes)
 	addTimingAttrs(ctx, upstreamBuilder)
 
@@ -2440,7 +2529,7 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 		)
 	}
 
-	log.Info("ProxyMessages complete", "requested_model", feats.Model, "baseline_model", s.baselineFor(feats.Model), "decision_model", decision.Model, "decision_provider", decision.Provider, "primary_provider", primaryProvider, "fallback_attempts", winnerIdx, "failover_used", finalProvider != primaryProvider, "decision_reason", decision.Reason, "requested_tier", routeRes.RequestedTier.String(), "decision_tier", catalog.TierFor(decision.Model).String(), "embedded_tokens", len(promptText)/4, "total_input_tokens", feats.Tokens, "has_tools", feats.HasTools, "message_count", feats.MessageCount, "last_kind", feats.LastKind, "last_preview", feats.LastPreview, "embed_input", embedInput, "cross_format", crossFormat, "sticky_hit", stickyHit, "route_ms", routeMs, "proxy_ms", proxyMs, "proxy_err", proxyErr, "upstream_status", upstreamStatus(proxyErr), "upstream_finish_reason", respSummary.UpstreamFinishReason, "resp_stop_reason", respSummary.StopReason, "stop_reason_promoted", respSummary.StopReasonPromoted, "tool_use_blocks", respSummary.ToolUseBlocks, "invalid_tool_args_blocks", respSummary.InvalidToolArgsBlocks, "text_only_turn_nudged", respSummary.TextOnlyTurnNudged, "stop_reason_demoted", respSummary.StopReasonDemoted, "suppressed_tool_calls", respSummary.SuppressedToolCalls, "tool_call_invalid_blocks", len(respSummary.ToolCallIssues), "cc_only_tools_stripped", reqStats.CCOnlyToolsStripped, "gemini_reminder_injected", reqStats.GeminiReminderInjected, "gemini_validated_tool_mode", reqStats.GeminiValidatedToolMode, "resp_output_tokens", respSummary.OutputTokens, "prelude_committed", preludeBuf.Committed())
+	log.Info("ProxyMessages complete", "requested_model", feats.Model, "baseline_model", s.baselineFor(feats.Model), "decision_model", decision.Model, "decision_provider", decision.Provider, "primary_provider", primaryProvider, "fallback_attempts", winnerIdx, "failover_used", finalProvider != primaryProvider || subscriptionFailoverUsed, "subscription_failover", subscriptionFailoverUsed, "decision_reason", decision.Reason, "requested_tier", routeRes.RequestedTier.String(), "decision_tier", catalog.TierFor(decision.Model).String(), "embedded_tokens", len(promptText)/4, "total_input_tokens", feats.Tokens, "has_tools", feats.HasTools, "message_count", feats.MessageCount, "last_kind", feats.LastKind, "last_preview", feats.LastPreview, "embed_input", embedInput, "cross_format", crossFormat, "sticky_hit", stickyHit, "route_ms", routeMs, "proxy_ms", proxyMs, "proxy_err", proxyErr, "upstream_status", upstreamStatus(proxyErr), "upstream_finish_reason", respSummary.UpstreamFinishReason, "resp_stop_reason", respSummary.StopReason, "stop_reason_promoted", respSummary.StopReasonPromoted, "tool_use_blocks", respSummary.ToolUseBlocks, "invalid_tool_args_blocks", respSummary.InvalidToolArgsBlocks, "text_only_turn_nudged", respSummary.TextOnlyTurnNudged, "stop_reason_demoted", respSummary.StopReasonDemoted, "suppressed_tool_calls", respSummary.SuppressedToolCalls, "tool_call_invalid_blocks", len(respSummary.ToolCallIssues), "cc_only_tools_stripped", reqStats.CCOnlyToolsStripped, "gemini_reminder_injected", reqStats.GeminiReminderInjected, "gemini_validated_tool_mode", reqStats.GeminiValidatedToolMode, "resp_output_tokens", respSummary.OutputTokens, "prelude_committed", preludeBuf.Committed())
 	return proxyErr
 }
 

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -2293,8 +2293,12 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 	// reads the correct key parts for telemetry. When the subscription failover
 	// served the turn on the Weave / BYOK key, carry the suppression forward so
 	// cost.subscription_served + the billing key reflect the key that actually
-	// paid (full cost), not the spent subscription that 429'd.
-	if subscriptionRetryRan {
+	// paid (full cost), not the spent subscription that 429'd. Gate on
+	// subscriptionFailoverUsed (the retry actually succeeded on the Weave key),
+	// NOT subscriptionRetryRan: if PrepareAnthropic failed or the Weave retry
+	// itself errored, no byte was billed to the Weave key, so the turn stays
+	// attributed to the subscription that was originally on ctx.
+	if subscriptionFailoverUsed {
 		ctx = withSuppressedClaudeSubscription(ctx)
 	}
 	ctx = resolveAndInjectCredentials(ctx, finalProvider, r.Header)
@@ -2380,7 +2384,11 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 
 	if installationID != uuid.Nil {
 		credentialKeyPrefix, credentialKeySuffix, credSource := s.credentialKeyParts(ctx)
-		failoverUsed := finalProvider != primaryProvider
+		// Same-provider Anthropic subscription -> Weave retries keep finalProvider
+		// == primaryProvider, so the bare provider diff misses them. OR in the
+		// subscription-failover flag so the Postgres FailoverUsed column matches
+		// the OTel span + completion log (both already OR it in).
+		failoverUsed := finalProvider != primaryProvider || subscriptionFailoverUsed
 		degShadow := proxyErr == nil && isDegenerateResponse(out, respSummary.ToolUseBlocks, respSummary.StopReason, respSummary.StopReasonDemoted)
 		if degShadow {
 			log.Info("router.degenerate_shadow",

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -2244,12 +2244,22 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 		if subEmitErr != nil {
 			log.Error("Subscription failover: emit Anthropic body failed; surfacing original error", "err", subEmitErr, "model", decision.Model)
 			flushUpstreamErrorAsAnthropic(contentSink, proxyErr)
+		} else if subBindings := s.resolveBindingsForDispatch(subCtx, decision); len(subBindings) == 0 {
+			// The suppressed context resolved to no usable Anthropic binding, so
+			// dispatchWithFallback would only return a synthetic 502 that masks the
+			// real rate-limit/timeout. Surface the original retryable error instead
+			// — the client should see the actual throttle, not a bad-gateway. No
+			// Weave key was attempted, so attribution stays on the subscription.
+			log.Warn("Subscription failover: no fallback Anthropic binding available; surfacing original error",
+				"model", decision.Model,
+				"err", proxyErr,
+				"upstream_status", upstreamStatus(proxyErr))
+			flushUpstreamErrorAsAnthropic(contentSink, proxyErr)
 		} else {
 			log.Warn("Subscription failover: subscription throttled/timed out, retrying requested model on Weave key",
 				"model", decision.Model,
 				"err", proxyErr,
 				"upstream_status", upstreamStatus(proxyErr))
-			subBindings := s.resolveBindingsForDispatch(subCtx, decision)
 			subAttempt := s.anthropicNativeAttempt(env, r, subPrep, sink, preludeBuf, marker, setExtractor)
 			crossFormat = false
 			respSummary = translate.ResponseSummary{}

--- a/internal/proxy/usage_bypass_internal_test.go
+++ b/internal/proxy/usage_bypass_internal_test.go
@@ -167,3 +167,45 @@ func TestBypass_LocalPrepError_PropagatesToClient(t *testing.T) {
 	require.Error(t, err, "provider-not-configured must surface as a real error")
 	assert.NotErrorIs(t, err, errBypassRetryable, "local prep errors must not trigger reroute — the client must see them")
 }
+
+// subscriptionCtx returns a ctx carrying a Claude subscription token (as the
+// auth middleware would stash it from X-Weave-Anthropic-Subscription) plus a
+// non-empty installation id so resolveAndInjectCredentials takes the
+// router-keyed subscription-first branch.
+func subscriptionCtx() context.Context {
+	ctx := context.WithValue(context.Background(), AnthropicSubscriptionContextKey{}, "sk-ant-oat01-test-subscription-token")
+	return context.WithValue(ctx, InstallationIDContextKey{}, "11111111-1111-1111-1111-111111111111")
+}
+
+// TestSubscriptionFailover_EligibilityAndSuppression covers the three
+// load-bearing predicates of the subscription-credit failover added for the
+// 429/header-timeout bug: a subscription-served Anthropic turn is detected as
+// such, a deployment Anthropic key counts as a fallback, and suppressing the
+// subscription flips credential resolution onto the deployment key.
+func TestSubscriptionFailover_EligibilityAndSuppression(t *testing.T) {
+	// A request whose Anthropic credential resolves to the caller's subscription.
+	ctx := resolveAndInjectCredentials(subscriptionCtx(), providers.ProviderAnthropic, http.Header{})
+	require.True(t, servedOnSubscription(ctx), "a resolved subscription token must report servedOnSubscription")
+
+	t.Run("no fallback key: not eligible", func(t *testing.T) {
+		s := &Service{} // no deployment Anthropic key, no BYOK
+		assert.False(t, s.anthropicFallbackKeyAvailable(ctx),
+			"without a Weave/BYOK Anthropic key there is nothing to fail over to")
+	})
+
+	t.Run("deployment Anthropic key present: eligible", func(t *testing.T) {
+		s := &Service{deploymentKeyedProviders: map[string]struct{}{providers.ProviderAnthropic: {}}}
+		assert.True(t, s.anthropicFallbackKeyAvailable(ctx),
+			"a deployment Anthropic key is a valid failover target for a throttled subscription")
+	})
+
+	t.Run("suppression flips resolution off the subscription", func(t *testing.T) {
+		// After withSuppressedClaudeSubscription, resolution must NOT pick the
+		// subscription token — so the retry dispatches on the deployment key and
+		// servedOnSubscription reports false (billed at full cost, not sub rate).
+		suppressed := withSuppressedClaudeSubscription(subscriptionCtx())
+		suppressed = resolveAndInjectCredentials(suppressed, providers.ProviderAnthropic, http.Header{})
+		assert.False(t, servedOnSubscription(suppressed),
+			"a suppressed subscription must not resolve back as the served credential")
+	})
+}


### PR DESCRIPTION
## Symptom

Prod telemetry for a heavy org shows `claude-sonnet-4-6` calls with `proxy_err=\"upstream returned status 429 (buffered)\"` and `proxy_err=\"http2: timeout awaiting response headers\"` (~90s), **every one** `failover_used=false`, `fallback_attempts=0`. The 429 / 90s hang reached Claude Code raw — a major instability complaint.

## Root cause (hypothesis **(a)** — credential-pinned single binding)

`providers.IsRetryable` is **not** the problem: it correctly classifies both the buffered 429 (`IsRetryableStatus` covers 429/408/5xx, `internal/providers/provider.go:204-211`) and the header-timeout (`isResponseHeaderTimeout`, `provider.go:263-269`).

The real gap is the **credential**, in `ProxyMessages`:

1. When a Claude turn is served on the caller's own subscription (sk-ant-oat), `resolveAndInjectCredentials` (`internal/proxy/service.go:2761-2788`) stamps the subscription credential onto ctx.
2. `shouldFailover` returns **false** whenever `CredentialsFromContext(ctx) != nil` (`internal/proxy/fallback.go:404-412`), so `resolveBindingsForDispatch` collapses to a **single Anthropic binding** (`fallback.go:418-420`). There is nothing to fail over *to*.
3. The only thing that would suppress the subscription token and retry on a router-paid key is `claudeSubscriptionExhausted` (`internal/proxy/usage_bypass.go:106-119`), which requires the **observer's last snapshot** to already read `Exhausted()` ≥ `exhaustedFraction` (0.999, `internal/proxy/usage/usage.go:83-94`). But the binding 429 is usually the *first* signal the window bound — the stale snapshot still reads "slack", so the spent token is sent anyway.
4. `dispatchWithFallback` then does at most a same-binding retry on the **same spent token** (`fallback.go:298`), all 429, and surfaces raw. `failover_used=false` because no cross-binding hop ever happened.

So the failover machinery was never the issue — the subscription credential pinned the request to one binding *and* the live throttle wasn't wired to trigger the existing token-suppression fallback.

(For completeness: hypothesis (b)/(d) — exhausted alternate pool — is a real but separate, already-handled case via the baseline failover at `service.go:2135`; (c) — surfaced before the classifier — is false, `bypassToAnthropic` at `usage_bypass.go:218` already routes buffered 429s through `IsRetryable`.)

## Fix

In `ProxyMessages`, after the primary dispatch on a **subscription-served Anthropic turn** returns a retryable 429 / header-timeout **pre-commit**, suppress the subscription token and re-dispatch the **same requested model exactly once** on the Weave / BYOK Anthropic key (reusing `anthropicFallbackKeyAvailable` + `withSuppressedClaudeSubscription`). This is the same fallback `claudeSubscriptionExhausted` already takes pre-emptively — now also driven by the **live error** instead of only a stale snapshot.

## Retry-storm guards

- **Single extra attempt, no loop**: one re-dispatch, gated by `subscriptionRetryRan`.
- **Pre-commit only**: `!preludeBuf.Committed()` — a stream already on the wire is never retried (mid-stream errors emit an in-stream `event: error` and return committed).
- **Retryable only**: `providers.IsRetryable(proxyErr)` — a 4xx the client owns is surfaced, not retried.
- **Fallback key required**: skipped entirely when no Weave/BYOK Anthropic key exists (would otherwise 400 — strictly worse than the 429).
- **Backoff preserved**: the inner `dispatchWithFallback` keeps its existing `sameBindingBackoff` / ctx-abortable sleep.
- **Mutually exclusive** with the existing baseline failover (which requires a non-Anthropic routed provider).

## Product decision + tradeoff (for human review)

**Decision implemented:** when a customer's subscription is throttled (429) or hangs mid-flight, the router **spends its own (Weave/BYOK) Anthropic credits to complete that one turn**, billed at full cost rather than the subscription rate.

- **Tradeoff:** this trades a small amount of router-paid spend for not freezing/failing the customer's session. It only triggers (a) when the subscription genuinely can't serve the turn, and (b) when a fallback key is actually configured — so deployments with no router Anthropic key are unaffected (they keep surfacing the 429, same as today). The credential switch is carried forward so cost telemetry (`cost.subscription_served`) and the billing key correctly attribute the turn to the Weave key, not the spent subscription.
- **Alternative considered (not chosen):** surface the 429 but with a clean Anthropic error envelope + Retry-After instead of a raw hang. Rejected because it still breaks the agentic loop; the defensible default for a heavy paying org is to keep them working. The behavior is conservative (single attempt, key-gated) and clearly documented inline — easy to flip to error-surface if product prefers.

## Telemetry

New `dispatch.subscription_failover` OTLP attr + `subscription_failover` log field; `failover_used` now also reflects a subscription-credit failover (same provider, different credential).

## Validation

- `go build ./...` green.
- `go test ./internal/proxy/... ./internal/providers/...` green.
- New `TestSubscriptionFailover_EligibilityAndSuppression` covers the three load-bearing predicates (subscription detected, deployment key counts as fallback, suppression flips resolution off the subscription).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013CbU9jmNQxJDGXJhnRMeYP