### PR TITLE
fix(providers): support OpenRouter model ID aliases

### DIFF
--- a/cmd/router/main.go
+++ b/cmd/router/main.go
@@ -232,7 +232,14 @@ func main() {
 		if !byokOnly {
 			openRouterKey = config.GetOr("OPENROUTER_API_KEY", "")
 		}
-		providerMap[providers.ProviderOpenRouter] = openaiCompatProvider.NewClient(openRouterKey, openRouterBaseURL)
+		openRouterModelIDMap, invalidOpenRouterModelIDMap := parseModelIDMap(config.GetOr(openRouterModelIDMapEnv, ""))
+		if len(invalidOpenRouterModelIDMap) > 0 {
+			logger.Warn("Invalid model ID map entries ignored", "env_var", openRouterModelIDMapEnv, "entries", invalidOpenRouterModelIDMap)
+		}
+		if len(openRouterModelIDMap) > 0 {
+			logger.Info("OpenRouter model ID aliases configured", "env_var", openRouterModelIDMapEnv, "count", len(openRouterModelIDMap))
+		}
+		providerMap[providers.ProviderOpenRouter] = openaiCompatProvider.NewClientWithModelIDMap(openRouterKey, openRouterBaseURL, openRouterModelIDMap)
 		switch {
 		case byokOnly:
 			logger.Info("OpenRouter provider enabled (BYOK only)", "base_url", openRouterBaseURL)
@@ -1312,6 +1319,35 @@ func resolveDefaultBaselineModel() string {
 		return "claude-sonnet-4-5"
 	}
 	return strings.TrimSpace(v)
+}
+
+const openRouterModelIDMapEnv = "OPENROUTER_MODEL_ID_MAP"
+
+// parseModelIDMap parses comma-separated "router=upstream" model ID aliases.
+func parseModelIDMap(raw string) (map[string]string, []string) {
+	if strings.TrimSpace(raw) == "" {
+		return nil, nil
+	}
+	out := make(map[string]string)
+	var invalid []string
+	for _, part := range strings.Split(raw, ",") {
+		entry := strings.TrimSpace(part)
+		if entry == "" {
+			continue
+		}
+		publicID, upstreamID, ok := strings.Cut(entry, "=")
+		publicID = strings.TrimSpace(publicID)
+		upstreamID = strings.TrimSpace(upstreamID)
+		if !ok || publicID == "" || upstreamID == "" {
+			invalid = append(invalid, entry)
+			continue
+		}
+		out[publicID] = upstreamID
+	}
+	if len(out) == 0 {
+		return nil, invalid
+	}
+	return out, invalid
 }
 
 // resolveHardPinModel returns the (provider, model) to use for compaction and

--- a/cmd/router/model_id_map_test.go
+++ b/cmd/router/model_id_map_test.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseModelIDMap(t *testing.T) {
+	t.Run("unset returns nil", func(t *testing.T) {
+		got, invalid := parseModelIDMap("")
+		assert.Nil(t, got)
+		assert.Empty(t, invalid)
+	})
+
+	t.Run("parses comma separated pairs", func(t *testing.T) {
+		got, invalid := parseModelIDMap("deepseek/deepseek-v4-flash=deepseek-v4-flash, moonshotai/kimi-k2.6 = kimi-k2.6")
+		assert.Empty(t, invalid)
+		assert.Equal(t, map[string]string{
+			"deepseek/deepseek-v4-flash": "deepseek-v4-flash",
+			"moonshotai/kimi-k2.6":       "kimi-k2.6",
+		}, got)
+	})
+
+	t.Run("keeps valid pairs and reports invalid entries", func(t *testing.T) {
+		got, invalid := parseModelIDMap("deepseek/deepseek-v4-pro=deepseek-v4-pro,missing_equals,=empty_source,z-ai/glm-5.2=")
+		assert.Equal(t, map[string]string{
+			"deepseek/deepseek-v4-pro": "deepseek-v4-pro",
+		}, got)
+		assert.Equal(t, []string{"missing_equals", "=empty_source", "z-ai/glm-5.2="}, invalid)
+	})
+}

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -22,15 +22,16 @@ the router still registers the provider but forwards Anthropic auth headers
 (`Authorization` / `x-api-key`) to `api.anthropic.com` directly. This lets
 Claude Code keep using the user's logged-in plan.
 
-| Variable              | Default                                                   | Effect |
-| --------------------- | --------------------------------------------------------- | ------ |
-| `OPENROUTER_API_KEY`  | *(none)*                                                  | **Recommended baseline.** Enables OpenRouter and the full OSS-model pool the cluster scorer is trained against. |
-| `OPENROUTER_BASE_URL` | `https://openrouter.ai/api/v1`                            | Override for OpenRouter or any OpenAI-compatible endpoint (vLLM, Together, Fireworks, self-hosted). |
-| `ANTHROPIC_API_KEY`   | *(none — passthrough)*                                    | Router's own Anthropic key. When unset, client `Authorization` headers pass through. |
-| `OPENAI_API_KEY`      | *(none)*                                                  | Enables the OpenAI provider (Chat Completions API). |
-| `OPENAI_BASE_URL`     | `https://api.openai.com`                                  | Override for OpenAI (e.g. Azure OpenAI). |
-| `GOOGLE_API_KEY`      | *(none)*                                                  | Enables Gemini via its OpenAI-compatible endpoint. |
-| `GOOGLE_BASE_URL`     | `https://generativelanguage.googleapis.com/v1beta/openai` | Override for Gemini. |
+| Variable                  | Default                                                   | Effect |
+| ------------------------- | --------------------------------------------------------- | ------ |
+| `OPENROUTER_API_KEY`      | *(none)*                                                  | **Recommended baseline.** Enables OpenRouter and the full OSS-model pool the cluster scorer is trained against. |
+| `OPENROUTER_BASE_URL`     | `https://openrouter.ai/api/v1`                            | Override for OpenRouter or any OpenAI-compatible endpoint (vLLM, Together, Fireworks, self-hosted). |
+| `OPENROUTER_MODEL_ID_MAP` | *(none)*                                                  | Comma-separated `router-model=upstream-model` aliases for `OPENROUTER_BASE_URL` overrides whose model IDs differ from the router catalog, e.g. `deepseek/deepseek-v4-flash=deepseek-v4-flash`. |
+| `ANTHROPIC_API_KEY`       | *(none — passthrough)*                                    | Router's own Anthropic key. When unset, client `Authorization` headers pass through. |
+| `OPENAI_API_KEY`          | *(none)*                                                  | Enables the OpenAI provider (Chat Completions API). |
+| `OPENAI_BASE_URL`         | `https://api.openai.com`                                  | Override for OpenAI (e.g. Azure OpenAI). |
+| `GOOGLE_API_KEY`          | *(none)*                                                  | Enables Gemini via its OpenAI-compatible endpoint. |
+| `GOOGLE_BASE_URL`         | `https://generativelanguage.googleapis.com/v1beta/openai` | Override for Gemini. |
 
 **BYOK (per-installation keys).** Instead of (or in addition to) the env vars
 above, each installation can supply its own provider keys via the dashboard.

--- a/internal/providers/openaicompat/client_test.go
+++ b/internal/providers/openaicompat/client_test.go
@@ -112,6 +112,35 @@ func TestProxy_DevModeEnvKeyUsedWhenNoCredentialsOnContext(t *testing.T) {
 		"when no credentials are on context (dev mode / no BYOK), the deployment env key must be sent to OpenRouter")
 }
 
+func TestProxy_RewritesModelWithModelIDMap(t *testing.T) {
+	var gotBody map[string]any
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		require.NoError(t, json.Unmarshal(body, &gotBody))
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"id":"chatcmpl-alias","object":"chat.completion"}`))
+	}))
+	defer upstream.Close()
+
+	c := openaicompat.NewClientWithModelIDMap("test-key", upstream.URL+"/api/v1", map[string]string{
+		"deepseek/deepseek-v4-flash": "deepseek-v4-flash",
+	})
+	rec := httptest.NewRecorder()
+	clientReq := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(""))
+	prep := providers.PreparedRequest{
+		Body:    []byte(`{"model":"deepseek/deepseek-v4-flash","messages":[{"role":"user","content":"hi"}]}`),
+		Headers: make(http.Header),
+	}
+
+	err := c.Proxy(context.Background(), router.Decision{Model: "deepseek/deepseek-v4-flash"}, prep, rec, clientReq)
+
+	require.NoError(t, err)
+	assert.Equal(t, "deepseek-v4-flash", gotBody["model"])
+	assert.Equal(t, http.StatusOK, rec.Code)
+}
+
 func TestPassthrough_StripsInboundV1Prefix(t *testing.T) {
 	var gotPath string
 


### PR DESCRIPTION
## Summary
- add `OPENROUTER_MODEL_ID_MAP` for OpenRouter-compatible base URL overrides whose upstream model IDs differ from router catalog IDs
- wire the parsed aliases into the existing OpenAI-compatible `modelIDMap` rewrite path
- document the env var and cover parsing plus request-body rewrite behavior with tests

## Why
Some self-hosters point `OPENROUTER_BASE_URL` at OpenAI-compatible upstreams like OpenCode Go. Those upstreams can advertise bare model IDs such as `deepseek-v4-flash`, while the router catalog exposes slash-form IDs such as `deepseek/deepseek-v4-flash`. Without a rewrite map, the request reaches the upstream with an unsupported model ID.

## Testing
- `go test ./cmd/router ./internal/providers/openaicompat`
- `PATH="$(go env GOPATH)/bin:$PATH" make check`
- `git diff --check upstream/main...HEAD`

Fixes #526
Fixes #541