### PR TITLE
hotfix(proxy): dispatch Makora/Together on Anthropic + OpenAI surfaces (fix 502 no-translation-path)

### DIFF
--- a/internal/proxy/credentials.go
+++ b/internal/proxy/credentials.go
@@ -107,7 +107,7 @@ func ExtractClientCredentials(provider string, headers http.Header) *Credentials
 				}
 			}
 		}
-	case providers.ProviderOpenAI, providers.ProviderGoogle, providers.ProviderOpenRouter, providers.ProviderFireworks, providers.ProviderDeepInfra, providers.ProviderBedrock:
+	case providers.ProviderOpenAI, providers.ProviderGoogle, providers.ProviderOpenRouter, providers.ProviderFireworks, providers.ProviderDeepInfra, providers.ProviderMakora, providers.ProviderTogether, providers.ProviderBedrock:
 		authHeader := headers.Get("Authorization")
 		if raw, found := strings.CutPrefix(authHeader, "Bearer "); found {
 			key := strings.TrimSpace(raw)

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -1932,7 +1932,7 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 		}
 		logUpstreamBody(log, routeRes.SessionKey, decision, feats, prep.Body)
 		attempt = s.anthropicNativeAttempt(env, r, prep, sink, preludeBuf, marker, setExtractor)
-	case providers.ProviderOpenAI, providers.ProviderOpenRouter, providers.ProviderFireworks, providers.ProviderDeepInfra, providers.ProviderBedrock:
+	case providers.ProviderOpenAI, providers.ProviderOpenRouter, providers.ProviderFireworks, providers.ProviderDeepInfra, providers.ProviderMakora, providers.ProviderTogether, providers.ProviderBedrock:
 		crossFormat = true
 		// Prep rebuilt per attempt: targetIsOpenRouter(opts) gates four
 		// OpenRouter-only body fields (provider hint, reasoning, system
@@ -2719,6 +2719,8 @@ func (s *Service) requestUsesNonDeploymentCreds(ctx context.Context, headers htt
 		providers.ProviderOpenRouter,
 		providers.ProviderFireworks,
 		providers.ProviderDeepInfra,
+		providers.ProviderMakora,
+		providers.ProviderTogether,
 		providers.ProviderBedrock,
 	} {
 		if ExtractClientCredentials(p, headers) != nil {
@@ -3592,7 +3594,7 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 
 	var attempt dispatchAttempt
 	switch decision.Provider {
-	case providers.ProviderOpenAI, providers.ProviderOpenRouter, providers.ProviderFireworks, providers.ProviderDeepInfra, providers.ProviderBedrock:
+	case providers.ProviderOpenAI, providers.ProviderOpenRouter, providers.ProviderFireworks, providers.ProviderDeepInfra, providers.ProviderMakora, providers.ProviderTogether, providers.ProviderBedrock:
 		// Prep rebuilt per attempt: targetIsOpenRouter(opts) gates four
 		// OpenRouter-only body fields (provider hint, reasoning, system
 		// reminder, tool-temp override) that the Fireworks/DeepInfra/

--- a/internal/proxy/service_test.go
+++ b/internal/proxy/service_test.go
@@ -441,11 +441,14 @@ func TestService_ProxyOpenAIChatCompletion_NativeOpenRouter(t *testing.T) {
 	assert.Contains(t, rec.Body.String(), `"chat.completion"`)
 }
 
-// SOC 2 isolation adds DeepInfra and Bedrock as direct providers
-// served by the openaicompat client. Both surfaces must route those
-// decisions through the OpenAI-emission case rather than the default
-// "no translation path" branch; otherwise the scorer's argmax silently
-// 502s for every prompt that lands on them.
+// DeepInfra, Bedrock, Makora, and Together are direct providers served by
+// the openaicompat client. Every surface must route those decisions through
+// the OpenAI-emission case rather than the default "no translation path"
+// branch; otherwise the scorer's argmax silently 502s for every prompt that
+// lands on them. Makora/Together are the DeepSeek-V4 primaries: they were
+// registered + made catalog-primary but omitted from this switch, so every
+// Claude Code turn routed to them 502'd with "no translation path defined
+// for inbound Anthropic Messages", then no-progress-looped back to Claude.
 func TestService_ProxyMessages_DispatchesDeepInfraAndBedrock(t *testing.T) {
 	cases := []struct {
 		name     string
@@ -454,6 +457,8 @@ func TestService_ProxyMessages_DispatchesDeepInfraAndBedrock(t *testing.T) {
 	}{
 		{"deepinfra", providers.ProviderDeepInfra, "deepseek/deepseek-v4-flash"},
 		{"bedrock", providers.ProviderBedrock, "moonshotai/kimi-k2.5"},
+		{"makora", providers.ProviderMakora, "deepseek/deepseek-v4-pro"},
+		{"together", providers.ProviderTogether, "deepseek/deepseek-v4-pro"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -488,6 +493,8 @@ func TestService_ProxyOpenAIChatCompletion_DispatchesDeepInfraAndBedrock(t *test
 	}{
 		{"deepinfra", providers.ProviderDeepInfra, "deepseek/deepseek-v4-flash"},
 		{"bedrock", providers.ProviderBedrock, "qwen/qwen3-coder-next"},
+		{"makora", providers.ProviderMakora, "deepseek/deepseek-v4-pro"},
+		{"together", providers.ProviderTogether, "deepseek/deepseek-v4-pro"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
## Hotfix — production-burning

Makora and Together were never able to serve a single Claude Code turn.

## The bug (confirmed in prod)

The router registers the `makora` and `together` providers (keys wired, "provider enabled" at boot) and the catalog makes them **primary** for DeepSeek V4 models. But the proxy's cross-format dispatch switches hardcode the list of OpenAI-compatible providers and **omit** `makora` and `together`.

So when an inbound **Anthropic Messages** request (`/v1/messages`, i.e. Claude Code) is routed to Makora/Together, the `switch decision.Provider` falls through to `default:` and returns:

```
provider not configured: makora (no translation path defined for inbound Anthropic Messages)
```

→ HTTP 502. Claude Code retries, gets empty turns, the no-progress detector breaks the turn and re-routes to Claude. **Net effect: Makora/Together have never successfully served a Claude Code request.**

## The fix

Add `providers.ProviderMakora` and `providers.ProviderTogether` to every hardcoded OpenAI-compat provider set so these decisions take the cross-format OpenAI translation path:

- `internal/proxy/service.go` — `ProxyMessages` cross-format dispatch switch (**the prod bug**)
- `internal/proxy/service.go` — `ProxyOpenAIChatCompletion` cross-format dispatch switch (same bug class on the OpenAI inbound surface)
- `internal/proxy/credentials.go` — `ExtractClientCredentials` (Bearer client/BYOK creds for these OpenAI-compat upstreams)
- `internal/proxy/service.go` — `requestUsesNonDeploymentCreds` (a client-supplied key for these providers must skip the summarizer)

Both providers are wired via `openaicompat.NewClientWithModelIDMap` in `cmd/router/main.go` and documented as OpenAI-compatible surfaces, so they belong in exactly the same sets as `deepinfra`/`fireworks`.

## Regression test

Extended the existing `DispatchesDeepInfraAndBedrock` table tests (both `ProxyMessages` and `ProxyOpenAIChatCompletion`) with `makora` and `together` cases. Verified the `ProxyMessages` case **reproduces the exact prod error and fails without the switch fix**:

```
--- FAIL: .../makora    provider not configured: makora (no translation path defined for inbound Anthropic Messages)
--- FAIL: .../together  provider not configured: together (no translation path defined for inbound Anthropic Messages)
```

and passes with it.

## Deliberately left unchanged

- `internal/translate/emit_openai.go` `applySessionAffinity` — the `x-session-affinity` header is a Fireworks/DeepInfra-specific caching optimization, not a dispatch/translation gate; the `default` (no header) is correct for other targets.
- `internal/api/admin/config.go` `configProviderOrder` — a curated self-hosted dashboard display list (already omits DeepInfra/Bedrock), not the cross-format provider set.

## Validation

```
go build ./...            # OK
go vet ./internal/proxy/... # OK
go test ./internal/proxy/... # ok (all pass)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)