### PR TITLE
fix(feedback): suppress /rf footer on subagent and machine turns

### DIFF
--- a/internal/proxy/feedback.go
+++ b/internal/proxy/feedback.go
@@ -9,6 +9,7 @@ import (
 
 	"workweave/router/internal/feedback"
 	"workweave/router/internal/observability/otel"
+	"workweave/router/internal/router/turntype"
 
 	"github.com/google/uuid"
 )
@@ -202,11 +203,22 @@ const feedbackFooterText = "\n\n_Weave Router feedback:_ `/rf +` good experience
 // surfaces, and to deployments with durable feedback storage so we never
 // advertise a rating command we can't record. The signed feedback link still
 // ships invisibly via the x-router-feedback-url header for rich GUI clients.
-func (s *Service) feedbackFooter(clientApp string) string {
+//
+// Also gated to the user's own conversation turns (MainLoop / ToolResult).
+// Subagent dispatches and machine turns (compaction, probe, title-gen,
+// classifier) render final text the user never directly initiated, so a
+// trailing /rf hint strands beneath it — e.g. under an Explore subagent's
+// result in the Claude Code TUI. The common final-answer turn arrives on a
+// ToolResult inbound (the assistant used tools first), so it must stay in the
+// allowlist or the footer would almost never fire.
+func (s *Service) feedbackFooter(clientApp string, tt turntype.TurnType) string {
 	if s.feedbackStore == nil {
 		return ""
 	}
 	if _, ok := terminalFeedbackClients[clientApp]; !ok {
+		return ""
+	}
+	if tt != turntype.MainLoop && tt != turntype.ToolResult {
 		return ""
 	}
 	return feedbackFooterText

--- a/internal/proxy/feedback_footer_internal_test.go
+++ b/internal/proxy/feedback_footer_internal_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"testing"
 
+	"workweave/router/internal/router/turntype"
+
 	"github.com/stretchr/testify/assert"
 )
 
@@ -16,7 +18,7 @@ func TestFeedbackFooter_ClientGating(t *testing.T) {
 
 	t.Run("terminal agents get the link-free rating hint", func(t *testing.T) {
 		for _, app := range []string{ClientAppClaudeCode, ClientAppCodex, ClientAppOpencode} {
-			footer := withStore.feedbackFooter(app)
+			footer := withStore.feedbackFooter(app, turntype.MainLoop)
 			assert.Equal(t, feedbackFooterText, footer, "expected hint for %q", app)
 			assert.NotContains(t, footer, "http", "footer must never embed a raw link")
 		}
@@ -24,11 +26,33 @@ func TestFeedbackFooter_ClientGating(t *testing.T) {
 
 	t.Run("ide and unknown clients are suppressed", func(t *testing.T) {
 		for _, app := range []string{ClientAppCursor, ClientAppGeminiCLI, "", "some-bot"} {
-			assert.Empty(t, withStore.feedbackFooter(app), "expected no footer for %q", app)
+			assert.Empty(t, withStore.feedbackFooter(app, turntype.MainLoop), "expected no footer for %q", app)
 		}
 	})
 
 	t.Run("no durable store suppresses the hint entirely", func(t *testing.T) {
-		assert.Empty(t, (&Service{}).feedbackFooter(ClientAppClaudeCode), "advertising a command we cannot record is misleading")
+		assert.Empty(t, (&Service{}).feedbackFooter(ClientAppClaudeCode, turntype.MainLoop), "advertising a command we cannot record is misleading")
+	})
+}
+
+func TestFeedbackFooter_TurnTypeGating(t *testing.T) {
+	withStore := (&Service{}).WithRouterFeedbackStore(footerFakeStore{})
+
+	t.Run("the user's own conversation turns get the hint", func(t *testing.T) {
+		for _, tt := range []turntype.TurnType{turntype.MainLoop, turntype.ToolResult} {
+			assert.Equal(t, feedbackFooterText, withStore.feedbackFooter(ClientAppClaudeCode, tt), "expected hint for %q", tt)
+		}
+	})
+
+	t.Run("subagent and machine turns are suppressed", func(t *testing.T) {
+		for _, tt := range []turntype.TurnType{
+			turntype.SubAgentDispatch,
+			turntype.Compaction,
+			turntype.Probe,
+			turntype.TitleGen,
+			turntype.Classifier,
+		} {
+			assert.Empty(t, withStore.feedbackFooter(ClientAppClaudeCode, tt), "expected no footer for %q — hint would strand under output the user never initiated", tt)
+		}
 	})
 }

--- a/internal/proxy/gemini.go
+++ b/internal/proxy/gemini.go
@@ -183,7 +183,7 @@ func (s *Service) ProxyGeminiGenerateContent(ctx context.Context, body []byte, w
 	// router user, matching the decision span and feedback header above.
 	clientSink := w
 	if env.Stream() {
-		if footer := s.feedbackFooter(ClientIdentityFrom(ctx).ClientApp); footer != "" {
+		if footer := s.feedbackFooter(ClientIdentityFrom(ctx).ClientApp, routeRes.TurnType); footer != "" {
 			clientSink = translate.NewGeminiRoutingFooterWriter(w, footer)
 		}
 	}

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -1884,7 +1884,7 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 	// responses and when feedback is unwired.
 	clientSink := w
 	if env.Stream() {
-		if footer := s.feedbackFooter(ClientIdentityFrom(ctx).ClientApp); footer != "" {
+		if footer := s.feedbackFooter(ClientIdentityFrom(ctx).ClientApp, routeRes.TurnType); footer != "" {
 			clientSink = translate.NewAnthropicRoutingFooterWriter(w, footer)
 		}
 	}
@@ -3506,7 +3506,7 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 	// footers are a follow-up.
 	clientSink := w
 	if _, isResponses := w.(*translate.ResponsesWriter); env.Stream() && !isResponses {
-		if footer := s.feedbackFooter(ClientIdentityFrom(ctx).ClientApp); footer != "" {
+		if footer := s.feedbackFooter(ClientIdentityFrom(ctx).ClientApp, routeRes.TurnType); footer != "" {
 			clientSink = translate.NewOpenAIRoutingFooterWriter(w, footer)
 		}
 	}


### PR DESCRIPTION
## Problem

The in-terminal `_Weave Router feedback:_ `/rf +` … `/rf -` …` hint was appearing **stranded beneath a subagent's result** in the Claude Code TUI (e.g. under an Explore/Task spawn), instead of only on the user's own answer.

`feedbackFooter` was gated on only:
1. streaming response,
2. terminal coding-agent client (Claude Code / Codex / opencode) + durable feedback store.

It was **never gated on turn type**. The translate layer already suppresses the footer when a response ends in `tool_use` (nothing to rate yet), but a subagent's *final text* turn is a normal text turn, so it collected the footer.

## Fix

Thread `routeRes.TurnType` into `feedbackFooter` and only emit the footer for the user's own conversation turns: `MainLoop` or `ToolResult`.

**Why `ToolResult` stays allowlisted:** in Claude Code the final answer of a turn almost always arrives on a `ToolResult` inbound (the assistant used tools first). Gating to `MainLoop`-only would suppress the footer on nearly every real answer. Allowlisting both fixes the reported subagent bug and the same latent glitch on `Compaction` / `Probe` / `TitleGen` / `Classifier` turns.

## Testing

- `wv mr tc` clean
- Full router suite green (`wv mr t`)
- New `TestFeedbackFooter_TurnTypeGating` asserts `MainLoop`/`ToolResult` get the hint and `SubAgentDispatch`/`Compaction`/`Probe`/`TitleGen`/`Classifier` are suppressed; existing `TestFeedbackFooter_ClientGating` updated for the new signature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)