### PR TITLE
feat: add opt-in bandit routing strategy via x-weave-router-strategy

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -76,6 +76,11 @@ ROUTER_DEPLOYMENT_MODE=selfhosted
 # deployments where the eval harness flips between versions.
 # ROUTER_CLUSTER_BUILD_ALL_VERSIONS=false
 
+# Opt-in routing strategies (selected per-request via x-weave-router-strategy).
+# Unset = strategy header returns HTTP 503 for that arm; default traffic uses cluster.
+# ROUTER_RL_SIDECAR_URL=          # rl strategy → router-rl-sidecar Cloud Run service
+# ROUTER_BANDIT_POSTERIOR_FILE=   # bandit strategy → ts_posterior.json from train_thompson_posterior.py
+
 # Per-request ONNX embed timeout. Increase on slower hosts.
 ROUTER_CLUSTER_EMBED_TIMEOUT_MS=200
 

--- a/cmd/router/main.go
+++ b/cmd/router/main.go
@@ -36,6 +36,7 @@ import (
 	"workweave/router/internal/proxy/usage"
 	routerpubsub "workweave/router/internal/pubsub"
 	"workweave/router/internal/router"
+	"workweave/router/internal/router/bandit"
 	"workweave/router/internal/router/banditexplore"
 	"workweave/router/internal/router/cache"
 	"workweave/router/internal/router/catalog"
@@ -600,8 +601,30 @@ func main() {
 		logger.Info("RL policy router disabled (ROUTER_RL_SIDECAR_URL unset); x-weave-router-strategy: rl will return 503")
 	}
 
+	// Opt-in Thompson-sampling bandit. Wired only when ROUTER_BANDIT_POSTERIOR_FILE
+	// points at a ts_posterior.json from train_thompson_posterior.py; the
+	// x-weave-router-strategy: bandit header then routes through it. Wraps the
+	// raw cluster scorer (not the explore wrapper). Unset path -> nil -> 503.
+	var banditRouter router.Router
+	if posteriorPath := strings.TrimSpace(config.GetOr("ROUTER_BANDIT_POSTERIOR_FILE", "")); posteriorPath != "" {
+		post, loadErr := bandit.LoadPosterior(posteriorPath)
+		if loadErr != nil {
+			logger.Error(
+				"Bandit posterior load failed; x-weave-router-strategy: bandit will return 503",
+				"path", posteriorPath,
+				"err", loadErr,
+			)
+		} else {
+			banditRouter = bandit.New(rtr, post)
+			logger.Info("Bandit strategy router wired", "posterior_file", posteriorPath)
+		}
+	} else {
+		logger.Info("Bandit strategy router disabled (ROUTER_BANDIT_POSTERIOR_FILE unset); x-weave-router-strategy: bandit will return 503")
+	}
+
 	proxySvc := proxy.NewService(routeEntry, providerMap, emitter, embedOnlyUser, semanticCache, pinStore, hardPinExplore, hardPinProvider, hardPinModel, repo.Telemetry).
 		WithRLRouter(rlRouter).
+		WithBanditRouter(banditRouter).
 		WithContentCapture(captureMode, captureMaxBytes, nil).
 		WithFeedback(repo.Feedback, feedbackSigner, feedbackBaseURL).
 		WithByokOnly(byokOnly).

--- a/internal/api/anthropic/messages.go
+++ b/internal/api/anthropic/messages.go
@@ -12,6 +12,7 @@ import (
 	"workweave/router/internal/observability"
 	"workweave/router/internal/providers"
 	"workweave/router/internal/proxy"
+	"workweave/router/internal/router/bandit"
 	"workweave/router/internal/router/cluster"
 	"workweave/router/internal/router/rl"
 	"workweave/router/internal/server/middleware"
@@ -113,6 +114,12 @@ func MessagesHandler(svc *proxy.Service, authSvc *auth.Service) gin.HandlerFunc 
 				log.Error("RL routing unavailable", "err", err)
 				c.Header("Retry-After", "1")
 				writeAnthropicError(c, http.StatusServiceUnavailable, "api_error", "Router unavailable: RL policy router failed and no fallback is configured.")
+				return
+			}
+			if errors.Is(err, bandit.ErrBanditUnavailable) {
+				log.Error("Bandit routing unavailable", "err", err)
+				c.Header("Retry-After", "1")
+				writeAnthropicError(c, http.StatusServiceUnavailable, "api_error", "Router unavailable: bandit router failed and no fallback is configured.")
 				return
 			}
 			if errors.Is(err, cluster.ErrClusterUnavailable) {

--- a/internal/api/gemini/generate_content.go
+++ b/internal/api/gemini/generate_content.go
@@ -12,6 +12,7 @@ import (
 	"workweave/router/internal/observability"
 	"workweave/router/internal/providers"
 	"workweave/router/internal/proxy"
+	"workweave/router/internal/router/bandit"
 	"workweave/router/internal/router/cluster"
 	"workweave/router/internal/router/rl"
 	"workweave/router/internal/server/middleware"
@@ -110,6 +111,13 @@ func GenerateContentHandler(svc *proxy.Service, authSvc *auth.Service) gin.Handl
 				c.Header("Retry-After", "1")
 				writeGeminiError(c, http.StatusServiceUnavailable, "UNAVAILABLE",
 					"Router unavailable: RL policy router failed and no fallback is configured.")
+				return
+			}
+			if errors.Is(err, bandit.ErrBanditUnavailable) {
+				log.Error("Bandit routing unavailable", "err", err)
+				c.Header("Retry-After", "1")
+				writeGeminiError(c, http.StatusServiceUnavailable, "UNAVAILABLE",
+					"Router unavailable: bandit router failed and no fallback is configured.")
 				return
 			}
 			if errors.Is(err, cluster.ErrClusterUnavailable) {

--- a/internal/api/openai/completions.go
+++ b/internal/api/openai/completions.go
@@ -11,6 +11,7 @@ import (
 	"workweave/router/internal/observability"
 	"workweave/router/internal/providers"
 	"workweave/router/internal/proxy"
+	"workweave/router/internal/router/bandit"
 	"workweave/router/internal/router/cluster"
 	"workweave/router/internal/router/rl"
 	"workweave/router/internal/server/middleware"
@@ -79,6 +80,12 @@ func ChatCompletionHandler(svc *proxy.Service, authSvc *auth.Service) gin.Handle
 				log.Error("RL routing unavailable", "err", err)
 				c.Header("Retry-After", "1")
 				writeOpenAIError(c, http.StatusServiceUnavailable, "api_error", "Router unavailable: RL policy router failed and no fallback is configured.")
+				return
+			}
+			if errors.Is(err, bandit.ErrBanditUnavailable) {
+				log.Error("Bandit routing unavailable", "err", err)
+				c.Header("Retry-After", "1")
+				writeOpenAIError(c, http.StatusServiceUnavailable, "api_error", "Router unavailable: bandit router failed and no fallback is configured.")
 				return
 			}
 			if errors.Is(err, cluster.ErrClusterUnavailable) {

--- a/internal/api/openai/responses.go
+++ b/internal/api/openai/responses.go
@@ -9,6 +9,7 @@ import (
 	"workweave/router/internal/observability"
 	"workweave/router/internal/providers"
 	"workweave/router/internal/proxy"
+	"workweave/router/internal/router/bandit"
 	"workweave/router/internal/router/cluster"
 	"workweave/router/internal/router/rl"
 	"workweave/router/internal/server/middleware"
@@ -80,6 +81,12 @@ func ResponsesHandler(svc *proxy.Service, authSvc *auth.Service) gin.HandlerFunc
 				log.Error("RL routing unavailable", "err", err)
 				c.Header("Retry-After", "1")
 				writeOpenAIError(c, http.StatusServiceUnavailable, "api_error", "Router unavailable: RL policy router failed and no fallback is configured.")
+				return
+			}
+			if errors.Is(err, bandit.ErrBanditUnavailable) {
+				log.Error("Bandit routing unavailable", "err", err)
+				c.Header("Retry-After", "1")
+				writeOpenAIError(c, http.StatusServiceUnavailable, "api_error", "Router unavailable: bandit router failed and no fallback is configured.")
 				return
 			}
 			if errors.Is(err, cluster.ErrClusterUnavailable) {

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -19,6 +19,7 @@ import (
 	"workweave/router/internal/providers"
 	"workweave/router/internal/proxy/usage"
 	"workweave/router/internal/router"
+	"workweave/router/internal/router/bandit"
 	"workweave/router/internal/router/cache"
 	"workweave/router/internal/router/catalog"
 	"workweave/router/internal/router/handover"
@@ -39,7 +40,11 @@ type Service struct {
 	// x-weave-router-strategy: rl header. Nil when no policy sidecar is wired
 	// (ROUTER_RL_SIDECAR_URL unset); the strategy header then 503s rather than
 	// silently serving the cluster scorer.
-	rlRouter             router.Router
+	rlRouter router.Router
+	// banditRouter is the opt-in Thompson-sampling router, selected per-request
+	// via x-weave-router-strategy: bandit. Nil when ROUTER_BANDIT_POSTERIOR_FILE
+	// is unset at boot; the strategy header then 503s.
+	banditRouter         router.Router
 	providers            map[string]providers.Client
 	emitter              *otel.Emitter
 	embedOnlyUserMessage bool
@@ -1178,19 +1183,34 @@ func (s *Service) WithRLRouter(r router.Router) *Service {
 	return s
 }
 
+// WithBanditRouter installs the opt-in Thompson-sampling bandit router. nil
+// leaves x-weave-router-strategy: bandit with no backing router, in which case
+// routeFor 503s rather than silently serving the cluster scorer.
+func (s *Service) WithBanditRouter(r router.Router) *Service {
+	s.banditRouter = r
+	return s
+}
+
 // routeFor picks the active router for the request's strategy. The default
 // (and the cluster strategy) is the cluster scorer; the rl strategy uses the
 // RL policy router when wired, and otherwise fails closed with
 // ErrPolicyUnavailable (→ HTTP 503) — never a silent fallback that would mask
 // which strategy actually served the turn.
 func (s *Service) routeFor(ctx context.Context, req router.Request) (router.Decision, error) {
-	if router.StrategyFromContext(ctx) == router.StrategyRL {
+	switch router.StrategyFromContext(ctx) {
+	case router.StrategyRL:
 		if s.rlRouter == nil {
 			return router.Decision{}, fmt.Errorf("rl strategy requested but no policy sidecar configured: %w", rl.ErrPolicyUnavailable)
 		}
 		return s.rlRouter.Route(ctx, req)
+	case router.StrategyBandit:
+		if s.banditRouter == nil {
+			return router.Decision{}, fmt.Errorf("bandit strategy requested but no posterior configured: %w", bandit.ErrBanditUnavailable)
+		}
+		return s.banditRouter.Route(ctx, req)
+	default:
+		return s.router.Route(ctx, req)
 	}
-	return s.router.Route(ctx, req)
 }
 
 // Route exposes the underlying router for callers that need a decision

--- a/internal/router/bandit/bandit.go
+++ b/internal/router/bandit/bandit.go
@@ -1,0 +1,149 @@
+// Package bandit is a router.Router that wraps the cluster scorer and
+// Thompson-samples a model from a frozen ts_posterior.json. Opt-in via the
+// x-weave-router-strategy: bandit header; OFF at boot unless
+// ROUTER_BANDIT_POSTERIOR_FILE is set.
+//
+// Every failure path returns ErrBanditUnavailable (HTTP 503) — no silent
+// fallback to the cluster argmax, mirroring the rl and cluster contracts.
+package bandit
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"hash/fnv"
+	"math/rand/v2"
+	"sort"
+
+	"workweave/router/internal/observability"
+	"workweave/router/internal/router"
+)
+
+// ErrBanditUnavailable signals the bandit strategy could not produce a
+// decision (posterior missing, inner scorer failed, or no servable candidate).
+var ErrBanditUnavailable = errors.New("bandit: router unavailable")
+
+// normFunc draws a standard normal variate. Injected for deterministic tests.
+type normFunc func() float64
+
+// Router wraps an inner cluster scorer and resamples its argmax via Thompson
+// sampling over (cluster, model) posterior arms.
+type Router struct {
+	inner router.Router
+	post  *Posterior
+	norm  normFunc
+}
+
+// New constructs a bandit Router. post must be non-nil.
+func New(inner router.Router, post *Posterior) *Router {
+	return &Router{
+		inner: inner,
+		post:  post,
+		norm:  rand.NormFloat64,
+	}
+}
+
+// Route delegates to the inner scorer, then Thompson-samples among eligible
+// candidates using the posterior keyed by the decision's cluster set.
+func (b *Router) Route(ctx context.Context, req router.Request) (router.Decision, error) {
+	if b == nil || b.inner == nil || b.post == nil {
+		return router.Decision{}, fmt.Errorf("bandit: not configured: %w", ErrBanditUnavailable)
+	}
+
+	dec, err := b.inner.Route(ctx, req)
+	if err != nil {
+		return dec, err
+	}
+	md := dec.Metadata
+	if md == nil || len(md.CandidateScores) < 2 {
+		return dec, nil
+	}
+
+	clusterIDs := md.ClusterIDs
+	if len(clusterIDs) == 0 {
+		observability.FromContext(ctx).Warn(
+			"Bandit router: decision missing cluster_ids; keeping cluster argmax",
+			"model", dec.Model,
+		)
+		return dec, nil
+	}
+
+	type candidate struct {
+		model    string
+		provider string
+		sample   float64
+	}
+	candidates := make([]candidate, 0, len(md.CandidateScores))
+	for model := range md.CandidateScores {
+		provider, ok := providerFor(dec, model)
+		if !ok {
+			continue
+		}
+		sample, ok := b.post.Sample(clusterIDs, model, b.norm)
+		if !ok {
+			// No posterior arm: fall back to the cluster scorer's blended score.
+			sample = float64(md.CandidateScores[model])
+		}
+		candidates = append(candidates, candidate{model: model, provider: provider, sample: sample})
+	}
+	if len(candidates) < 2 {
+		return dec, nil
+	}
+
+	sort.Slice(candidates, func(i, j int) bool {
+		if candidates[i].sample != candidates[j].sample {
+			return candidates[i].sample > candidates[j].sample
+		}
+		return candidates[i].model < candidates[j].model
+	})
+
+	argmaxModel := dec.Model
+	pick := candidates[0]
+	b.annotate(&dec, pick.model, pick.provider, len(candidates), pick.sample)
+	if pick.model != argmaxModel && md.EffectiveKnobsHash != 0 {
+		md.EffectiveKnobsHash = mixModel(md.EffectiveKnobsHash, pick.model)
+	}
+	return dec, nil
+}
+
+func providerFor(dec router.Decision, model string) (string, bool) {
+	if dec.Metadata != nil {
+		if p, ok := dec.Metadata.CandidateProviders[model]; ok && p != "" {
+			return p, true
+		}
+	}
+	if model == dec.Model && dec.Provider != "" {
+		return dec.Provider, true
+	}
+	return "", false
+}
+
+func (b *Router) annotate(dec *router.Decision, model, provider string, n int, sample float64) {
+	dec.Model = model
+	dec.Provider = provider
+	dec.Reason = fmt.Sprintf("bandit:ts n=%d sample=%.4g %s provider=%s base=[%s]", n, sample, model, provider, dec.Reason)
+	if dec.Metadata == nil {
+		return
+	}
+	if n >= 2 {
+		dec.Metadata.Propensity = 1.0 / float32(n)
+	} else {
+		dec.Metadata.Propensity = 1.0
+	}
+	if s, ok := dec.Metadata.CandidateScores[model]; ok {
+		dec.Metadata.ChosenScore = s
+	}
+}
+
+func mixModel(h uint64, model string) uint64 {
+	f := fnv.New64a()
+	var b [8]byte
+	for i := 0; i < 8; i++ {
+		b[i] = byte(h >> (8 * i))
+	}
+	_, _ = f.Write(b[:])
+	_, _ = f.Write([]byte(model))
+	return f.Sum64()
+}
+
+var _ router.Router = (*Router)(nil)

--- a/internal/router/bandit/bandit_test.go
+++ b/internal/router/bandit/bandit_test.go
@@ -1,0 +1,140 @@
+package bandit
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"workweave/router/internal/router"
+)
+
+type fakeInner struct {
+	dec router.Decision
+	err error
+}
+
+func (f *fakeInner) Route(context.Context, router.Request) (router.Decision, error) {
+	return f.dec, f.err
+}
+
+func clusterDecision(scores map[string]float32, clusterIDs []int, model, provider string) router.Decision {
+	providers := make(map[string]string, len(scores))
+	for m := range scores {
+		providers[m] = provider
+	}
+	return router.Decision{
+		Provider: provider,
+		Model:    model,
+		Reason:   "cluster:v-test",
+		Metadata: &router.RoutingMetadata{
+			ClusterIDs:         clusterIDs,
+			CandidateScores:    scores,
+			CandidateProviders: providers,
+			ChosenScore:        scores[model],
+			Propensity:         1.0,
+			EffectiveKnobsHash: 99,
+		},
+	}
+}
+
+func TestRoute_PropagatesInnerError(t *testing.T) {
+	sentinel := errors.New("boom")
+	post, err := LoadPosterior("testdata/ts_posterior.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	b := New(&fakeInner{err: sentinel}, post)
+	_, err = b.Route(context.Background(), router.Request{})
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("expected inner error, got %v", err)
+	}
+}
+
+func TestRoute_NotConfigured(t *testing.T) {
+	var b *Router
+	_, err := b.Route(context.Background(), router.Request{})
+	if !errors.Is(err, ErrBanditUnavailable) {
+		t.Fatalf("expected ErrBanditUnavailable, got %v", err)
+	}
+}
+
+func TestRoute_PassthroughWithoutMetadata(t *testing.T) {
+	post, err := LoadPosterior("testdata/ts_posterior.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	inner := router.Decision{Provider: "anthropic", Model: "haiku", Reason: "pin"}
+	b := New(&fakeInner{dec: inner}, post)
+	dec, err := b.Route(context.Background(), router.Request{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if dec.Model != "haiku" || dec.Metadata != nil {
+		t.Fatalf("expected passthrough, got %+v", dec)
+	}
+}
+
+func TestRoute_SamplesHigherPosteriorMean(t *testing.T) {
+	// haiku mean 0.8 > sonnet 0.75; zero noise -> pick haiku even if argmax was sonnet.
+	scores := map[string]float32{"claude-haiku-4-5": 0.5, "claude-sonnet-4-6": 0.9}
+	inner := clusterDecision(scores, []int{0}, "claude-sonnet-4-6", "anthropic")
+	post, err := LoadPosterior("testdata/ts_posterior.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	b := New(&fakeInner{dec: inner}, post)
+	b.norm = func() float64 { return 0 }
+	dec, err := b.Route(context.Background(), router.Request{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if dec.Model != "claude-haiku-4-5" {
+		t.Fatalf("expected Thompson pick haiku, got %q", dec.Model)
+	}
+	if dec.Metadata.Propensity != 0.5 {
+		t.Fatalf("expected propensity 0.5 for 2 candidates, got %v", dec.Metadata.Propensity)
+	}
+	if dec.Metadata.EffectiveKnobsHash == 99 {
+		t.Fatal("model switch must perturb cache key")
+	}
+}
+
+func TestRoute_KeepsArgmaxWhenSameModel(t *testing.T) {
+	scores := map[string]float32{"claude-haiku-4-5": 0.9, "claude-sonnet-4-6": 0.5}
+	inner := clusterDecision(scores, []int{0}, "claude-haiku-4-5", "anthropic")
+	post, err := LoadPosterior("testdata/ts_posterior.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	b := New(&fakeInner{dec: inner}, post)
+	b.norm = func() float64 { return 0 }
+	dec, err := b.Route(context.Background(), router.Request{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if dec.Model != "claude-haiku-4-5" {
+		t.Fatalf("expected haiku, got %q", dec.Model)
+	}
+	if dec.Metadata.EffectiveKnobsHash != 99 {
+		t.Fatal("keeping argmax must preserve cache key")
+	}
+}
+
+func TestRoute_UsesPerRequestProviderBinding(t *testing.T) {
+	scores := map[string]float32{"claude-haiku-4-5": 0.5, "claude-sonnet-4-6": 0.9}
+	inner := clusterDecision(scores, []int{0}, "claude-sonnet-4-6", "anthropic")
+	inner.Metadata.CandidateProviders["claude-haiku-4-5"] = "openrouter"
+	post, err := LoadPosterior("testdata/ts_posterior.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	b := New(&fakeInner{dec: inner}, post)
+	b.norm = func() float64 { return 0 }
+	dec, err := b.Route(context.Background(), router.Request{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if dec.Model != "claude-haiku-4-5" || dec.Provider != "openrouter" {
+		t.Fatalf("expected haiku via openrouter, got model=%q provider=%q", dec.Model, dec.Provider)
+	}
+}

--- a/internal/router/bandit/posterior.go
+++ b/internal/router/bandit/posterior.go
@@ -1,0 +1,91 @@
+package bandit
+
+import (
+	"encoding/json"
+	"fmt"
+	"math"
+	"os"
+	"strconv"
+)
+
+// Arm is the Gaussian posterior over reward for one (cluster, model) cell.
+type Arm struct {
+	Mean     float64
+	Variance float64
+}
+
+// Posterior holds per-cluster, per-model reward posteriors produced by
+// train_thompson_posterior.py (ts_posterior.json).
+type Posterior struct {
+	cells map[int]map[string]Arm
+}
+
+type posteriorFile struct {
+	Posterior map[string]map[string]armJSON `json:"posterior"`
+}
+
+type armJSON struct {
+	Mean     float64 `json:"mean"`
+	Variance float64 `json:"variance"`
+}
+
+// LoadPosterior reads ts_posterior.json from path.
+func LoadPosterior(path string) (*Posterior, error) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("bandit: read posterior %q: %w", path, err)
+	}
+	var file posteriorFile
+	if err := json.Unmarshal(raw, &file); err != nil {
+		return nil, fmt.Errorf("bandit: parse posterior %q: %w", path, err)
+	}
+	if len(file.Posterior) == 0 {
+		return nil, fmt.Errorf("bandit: posterior %q has no cells", path)
+	}
+
+	cells := make(map[int]map[string]Arm, len(file.Posterior))
+	for cidStr, arms := range file.Posterior {
+		cid, err := strconv.Atoi(cidStr)
+		if err != nil {
+			return nil, fmt.Errorf("bandit: posterior cluster id %q: %w", cidStr, err)
+		}
+		cell := make(map[string]Arm, len(arms))
+		for model, a := range arms {
+			if a.Variance < 0 {
+				return nil, fmt.Errorf("bandit: negative variance for cluster %d model %q", cid, model)
+			}
+			cell[model] = Arm{Mean: a.Mean, Variance: a.Variance}
+		}
+		cells[cid] = cell
+	}
+	return &Posterior{cells: cells}, nil
+}
+
+// Sample draws a Thompson sample for model across the given cluster ids.
+// When no arm exists in any cluster, ok is false.
+func (p *Posterior) Sample(clusterIDs []int, model string, norm func() float64) (sample float64, ok bool) {
+	if p == nil || len(clusterIDs) == 0 {
+		return 0, false
+	}
+	best := -1.0
+	found := false
+	for _, cid := range clusterIDs {
+		cell, okCell := p.cells[cid]
+		if !okCell {
+			continue
+		}
+		arm, okArm := cell[model]
+		if !okArm {
+			continue
+		}
+		draw := arm.Mean
+		if arm.Variance > 0 {
+			draw += norm() * math.Sqrt(arm.Variance)
+		}
+		if !found || draw > best {
+			best = draw
+			found = true
+		}
+	}
+	return best, found
+}

--- a/internal/router/bandit/posterior_test.go
+++ b/internal/router/bandit/posterior_test.go
@@ -1,0 +1,40 @@
+package bandit
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestLoadPosterior(t *testing.T) {
+	path := filepath.Join("testdata", "ts_posterior.json")
+	p, err := LoadPosterior(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sample, ok := p.Sample([]int{0}, "claude-haiku-4-5", func() float64 { return 0 })
+	if !ok {
+		t.Fatal("expected arm for cluster 0 haiku")
+	}
+	if sample != 0.8 {
+		t.Fatalf("zero-noise sample = mean, got %v", sample)
+	}
+	_, ok = p.Sample([]int{0}, "missing-model", func() float64 { return 0 })
+	if ok {
+		t.Fatal("missing arm must not ok")
+	}
+}
+
+func TestLoadPosterior_MissingFile(t *testing.T) {
+	_, err := LoadPosterior(filepath.Join("testdata", "nope.json"))
+	if err == nil {
+		t.Fatal("expected error for missing file")
+	}
+}
+
+func TestLoadPosterior_EmptyCells(t *testing.T) {
+	path := filepath.Join("testdata", "empty_posterior.json")
+	_, err := LoadPosterior(path)
+	if err == nil {
+		t.Fatal("expected error for empty posterior")
+	}
+}

--- a/internal/router/bandit/testdata/empty_posterior.json
+++ b/internal/router/bandit/testdata/empty_posterior.json
@@ -1,0 +1,1 @@
+{"meta": {}, "posterior": {}}

--- a/internal/router/bandit/testdata/ts_posterior.json
+++ b/internal/router/bandit/testdata/ts_posterior.json
@@ -1,0 +1,9 @@
+{
+  "meta": {"kappa0": 10.0},
+  "posterior": {
+    "0": {
+      "claude-haiku-4-5": {"mean": 0.8, "variance": 0.01, "kappa": 10.0, "prior_mean": 0.7, "n_obs": 0},
+      "claude-sonnet-4-6": {"mean": 0.75, "variance": 0.02, "kappa": 10.0, "prior_mean": 0.7, "n_obs": 0}
+    }
+  }
+}

--- a/internal/router/strategy.go
+++ b/internal/router/strategy.go
@@ -13,6 +13,10 @@ const (
 	// StrategyRL routes via the trained RL/DPO policy served by the
 	// out-of-process policy sidecar. Opt-in only; never the silent default.
 	StrategyRL Strategy = "rl"
+	// StrategyBandit routes via Thompson sampling over a frozen
+	// ts_posterior.json (cluster×model reward posterior). Opt-in only; wired
+	// when ROUTER_BANDIT_POSTERIOR_FILE is set at boot.
+	StrategyBandit Strategy = "bandit"
 )
 
 type strategyContextKey struct{}

--- a/internal/server/middleware/router_strategy_override.go
+++ b/internal/server/middleware/router_strategy_override.go
@@ -10,9 +10,10 @@ import (
 )
 
 // RouterStrategyOverrideHeader selects the routing strategy for a request.
-// Accepted values are "cluster" (the default scorer) and "rl" (the trained
-// RL/DPO policy router). Absent or unrecognized values fall through to the
-// deployment default.
+// Accepted values are "cluster" (the default scorer), "rl" (the trained
+// RL/DPO policy router), and "bandit" (Thompson sampling over a frozen
+// posterior). Absent or unrecognized values fall through to the deployment
+// default.
 const RouterStrategyOverrideHeader = "x-weave-router-strategy"
 
 // WithRouterStrategyOverride stashes the requested routing strategy on the
@@ -33,7 +34,7 @@ func WithRouterStrategyOverride() gin.HandlerFunc {
 			return
 		}
 		strategy := router.Strategy(raw)
-		if strategy != router.StrategyCluster && strategy != router.StrategyRL {
+		if strategy != router.StrategyCluster && strategy != router.StrategyRL && strategy != router.StrategyBandit {
 			observability.FromGin(c).Warn(
 				"Router-strategy override ignored: unrecognized value",
 				"installation_id", installation.ID,

--- a/internal/server/middleware/router_strategy_override_test.go
+++ b/internal/server/middleware/router_strategy_override_test.go
@@ -46,6 +46,11 @@ func TestRouterStrategyOverride_AppliesRL(t *testing.T) {
 	assert.Equal(t, router.StrategyRL, got, "rl header must select the RL strategy")
 }
 
+func TestRouterStrategyOverride_AppliesBandit(t *testing.T) {
+	got := runStrategyOverride(t, &auth.Installation{ID: "inst-eval"}, "bandit")
+	assert.Equal(t, router.StrategyBandit, got, "bandit header must select the bandit strategy")
+}
+
 func TestRouterStrategyOverride_CaseInsensitiveAndTrimmed(t *testing.T) {
 	got := runStrategyOverride(t, &auth.Installation{ID: "inst-eval"}, "  RL  ")
 	assert.Equal(t, router.StrategyRL, got, "value must be lowercased and trimmed before matching")


### PR DESCRIPTION
Wire a third routing arm (cluster / rl / bandit) that Thompson-samples
from ts_posterior.json when ROUTER_BANDIT_POSTERIOR_FILE is set at boot.
Unset in prod by default — header fails closed with HTTP 503.

Co-authored-by: Cursor <cursoragent@cursor.com>