### PR TITLE
Fix(Billing) :rotate preserve spend cap

### DIFF
--- a/db/queries/model_router_api_keys.sql
+++ b/db/queries/model_router_api_keys.sql
@@ -6,7 +6,8 @@ INSERT INTO router.model_router_api_keys (
     key_prefix,
     key_hash,
     key_suffix,
-    created_by
+    created_by,
+    spend_cap_usd_micros
 )
 VALUES (
     @installation_id::uuid,
@@ -15,7 +16,8 @@ VALUES (
     @key_prefix::varchar,
     @key_hash::varchar,
     @key_suffix::varchar,
-    @created_by
+    @created_by,
+    sqlc.narg('spend_cap_usd_micros')
 )
 RETURNING *;
 

--- a/internal/auth/api_key.go
+++ b/internal/auth/api_key.go
@@ -6,27 +6,29 @@ import (
 )
 
 type APIKey struct {
-	ID             string
-	InstallationID string
-	ExternalID     string
-	Name           *string
-	KeyPrefix      string
-	KeyHash        string
-	KeySuffix      string
-	LastUsedAt     *time.Time
-	CreatedAt      time.Time
-	DeletedAt      *time.Time
-	CreatedBy      *string
+	ID                string
+	InstallationID    string
+	ExternalID        string
+	Name              *string
+	KeyPrefix         string
+	KeyHash           string
+	KeySuffix         string
+	LastUsedAt        *time.Time
+	CreatedAt         time.Time
+	DeletedAt         *time.Time
+	CreatedBy         *string
+	SpendCapUsdMicros *int64
 }
 
 type CreateAPIKeyParams struct {
-	InstallationID string
-	ExternalID     string
-	Name           *string
-	KeyPrefix      string
-	KeyHash        string
-	KeySuffix      string
-	CreatedBy      *string
+	InstallationID    string
+	ExternalID        string
+	Name              *string
+	KeyPrefix         string
+	KeyHash           string
+	KeySuffix         string
+	CreatedBy         *string
+	SpendCapUsdMicros *int64
 }
 
 type APIKeyRepository interface {

--- a/internal/auth/rotate_spend_cap_test.go
+++ b/internal/auth/rotate_spend_cap_test.go
@@ -1,0 +1,120 @@
+package auth_test
+
+// TestRotateAPIKey_preservesSpendCap is a FAILING test that documents the bug:
+// RotateAPIKey issues the replacement key via IssueAPIKey, which calls Create
+// without forwarding spend_cap_usd_micros. The new key always gets a nil cap,
+// silently removing any budget limit that was set on the original key.
+//
+// Fix: propagate SpendCapUsdMicros through CreateAPIKeyParams so RotateAPIKey
+// can carry the old key's cap onto the new one.
+
+import (
+	"context"
+	"testing"
+
+	"workweave/router/internal/auth"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// rotateCapKeyRepo is a minimal APIKeyRepository that supports the Create and
+// ListForInstallation calls that RotateAPIKey drives. Create stores the new key
+// keyed by ID; ListForInstallation returns whichever keys belong to that
+// installation. SoftDelete marks a key deleted but leaves it visible only to
+// ListForInstallation (so RotateAPIKey can find the old key to copy from).
+type rotateCapKeyRepo struct {
+	keys []*auth.APIKey
+	next int
+}
+
+func (r *rotateCapKeyRepo) Create(_ context.Context, p auth.CreateAPIKeyParams) (*auth.APIKey, error) {
+	r.next++
+	key := &auth.APIKey{
+		ID:             auth.GenerateID("kid"),
+		InstallationID: p.InstallationID,
+		ExternalID:     p.ExternalID,
+		Name:           p.Name,
+		KeyPrefix:      p.KeyPrefix,
+		KeyHash:        p.KeyHash,
+		KeySuffix:      p.KeySuffix,
+		CreatedBy:      p.CreatedBy,
+		// SpendCapUsdMicros intentionally NOT set — this mirrors the real
+		// CreateModelRouterAPIKey SQL which has no spend_cap_usd_micros column
+		// in its INSERT, so new keys always start with a nil cap.
+		SpendCapUsdMicros: nil,
+	}
+	r.keys = append(r.keys, key)
+	return key, nil
+}
+
+func (r *rotateCapKeyRepo) GetActiveByHashWithInstallation(_ context.Context, _ string) (*auth.APIKey, *auth.Installation, error) {
+	return nil, nil, nil
+}
+
+func (r *rotateCapKeyRepo) ListForInstallation(_ context.Context, installationID string) ([]*auth.APIKey, error) {
+	var out []*auth.APIKey
+	for _, k := range r.keys {
+		if k.InstallationID == installationID && k.DeletedAt == nil {
+			out = append(out, k)
+		}
+	}
+	return out, nil
+}
+
+func (r *rotateCapKeyRepo) MarkUsed(_ context.Context, _ string) error { return nil }
+
+func (r *rotateCapKeyRepo) SoftDelete(_ context.Context, installationID, id string) error {
+	for _, k := range r.keys {
+		if k.InstallationID == installationID && k.ID == id {
+			now := frozenClock()()
+			k.DeletedAt = &now
+		}
+	}
+	return nil
+}
+
+func TestRotateAPIKey_preservesSpendCap(t *testing.T) {
+	const installationID = "00000000-0000-0000-0000-000000000001"
+	cap := int64(5_000_000) // $5.00 in micros
+
+	repo := &rotateCapKeyRepo{}
+	svc := auth.NewService(
+		&fakeInstallationRepository{},
+		repo,
+		nil, // externalKeys — unused
+		nil, // users — unused
+		auth.NoOpAPIKeyCache{},
+		nil, // userCache — unused
+		frozenClock(),
+	)
+
+	// Seed a key that already has a spend cap (simulates a cap set out-of-band
+	// by the control plane, e.g. direct DB write).
+	originalKeyID := auth.GenerateID("kid")
+	originalName := "budget-key"
+	original := &auth.APIKey{
+		ID:                originalKeyID,
+		InstallationID:    installationID,
+		ExternalID:        auth.GenerateID("ekid"),
+		Name:              &originalName,
+		KeyHash:           "hash-of-original",
+		KeyPrefix:         "rk_or",
+		KeySuffix:         "igin",
+		SpendCapUsdMicros: &cap,
+	}
+	repo.keys = append(repo.keys, original)
+
+	// Rotate the capped key.
+	newKey, _, err := svc.RotateAPIKey(context.Background(), installationID, originalKeyID, nil)
+	require.NoError(t, err)
+
+	// The replacement key MUST carry the same spend cap so the budget is not silently erased.
+	//
+	// This assertion FAILS with the current implementation because IssueAPIKey →
+	// Create is called without SpendCapUsdMicros, so the new key always gets nil.
+	require.NotNil(t, newKey.SpendCapUsdMicros,
+		"spend cap must be carried forward to the replacement key; got nil (cap was %d micros on old key)", cap)
+	assert.Equal(t, cap, *newKey.SpendCapUsdMicros,
+		"replacement key's spend cap must equal the original key's cap")
+}

--- a/internal/auth/rotate_spend_cap_test.go
+++ b/internal/auth/rotate_spend_cap_test.go
@@ -31,18 +31,15 @@ type rotateCapKeyRepo struct {
 func (r *rotateCapKeyRepo) Create(_ context.Context, p auth.CreateAPIKeyParams) (*auth.APIKey, error) {
 	r.next++
 	key := &auth.APIKey{
-		ID:             auth.GenerateID("kid"),
-		InstallationID: p.InstallationID,
-		ExternalID:     p.ExternalID,
-		Name:           p.Name,
-		KeyPrefix:      p.KeyPrefix,
-		KeyHash:        p.KeyHash,
-		KeySuffix:      p.KeySuffix,
-		CreatedBy:      p.CreatedBy,
-		// SpendCapUsdMicros intentionally NOT set — this mirrors the real
-		// CreateModelRouterAPIKey SQL which has no spend_cap_usd_micros column
-		// in its INSERT, so new keys always start with a nil cap.
-		SpendCapUsdMicros: nil,
+		ID:                auth.GenerateID("kid"),
+		InstallationID:    p.InstallationID,
+		ExternalID:        p.ExternalID,
+		Name:              p.Name,
+		KeyPrefix:         p.KeyPrefix,
+		KeyHash:           p.KeyHash,
+		KeySuffix:         p.KeySuffix,
+		CreatedBy:         p.CreatedBy,
+		SpendCapUsdMicros: p.SpendCapUsdMicros,
 	}
 	r.keys = append(r.keys, key)
 	return key, nil

--- a/internal/auth/service.go
+++ b/internal/auth/service.go
@@ -106,17 +106,24 @@ func (s *Service) invalidateInstallation(installationID string) {
 
 // IssueAPIKey creates a new router API key and returns the raw token.
 func (s *Service) IssueAPIKey(ctx context.Context, installationID string, name *string, createdBy *string) (*APIKey, string, error) {
+	return s.IssueAPIKeyWithCap(ctx, installationID, name, createdBy, nil)
+}
+
+// IssueAPIKeyWithCap creates a new router API key with an optional spend cap and returns the raw token.
+// Pass nil for spendCapUsdMicros to create an uncapped key.
+func (s *Service) IssueAPIKeyWithCap(ctx context.Context, installationID string, name *string, createdBy *string, spendCapUsdMicros *int64) (*APIKey, string, error) {
 	rawToken := GenerateID(APIKeyPrefix)
 	keyHash, keyPrefix, keySuffix := APITokenFingerprint(rawToken)
 	externalID := GenerateID("kid")
 	key, err := s.apiKeys.Create(ctx, CreateAPIKeyParams{
-		InstallationID: installationID,
-		ExternalID:     externalID,
-		Name:           name,
-		KeyPrefix:      keyPrefix,
-		KeyHash:        keyHash,
-		KeySuffix:      keySuffix,
-		CreatedBy:      createdBy,
+		InstallationID:    installationID,
+		ExternalID:        externalID,
+		Name:              name,
+		KeyPrefix:         keyPrefix,
+		KeyHash:           keyHash,
+		KeySuffix:         keySuffix,
+		CreatedBy:         createdBy,
+		SpendCapUsdMicros: spendCapUsdMicros,
 	})
 	if err != nil {
 		return nil, "", err
@@ -154,7 +161,7 @@ func (s *Service) RotateAPIKey(ctx context.Context, installationID, keyID string
 	if err := s.apiKeys.SoftDelete(ctx, installationID, target.ID); err != nil {
 		return nil, "", err
 	}
-	key, raw, err := s.IssueAPIKey(ctx, installationID, target.Name, createdBy)
+	key, raw, err := s.IssueAPIKeyWithCap(ctx, installationID, target.Name, createdBy, target.SpendCapUsdMicros)
 	if err != nil {
 		return nil, "", err
 	}

--- a/internal/postgres/converters.go
+++ b/internal/postgres/converters.go
@@ -43,17 +43,18 @@ func toAuthInstallation(row sqlc.RouterModelRouterInstallation) *auth.Installati
 
 func toAuthAPIKey(row sqlc.RouterModelRouterAPIKey) *auth.APIKey {
 	return &auth.APIKey{
-		ID:             row.ID.String(),
-		InstallationID: row.InstallationID.String(),
-		ExternalID:     row.ExternalID,
-		Name:           row.Name,
-		KeyPrefix:      row.KeyPrefix,
-		KeyHash:        row.KeyHash,
-		KeySuffix:      row.KeySuffix,
-		LastUsedAt:     timestampPtr(row.LastUsedAt),
-		CreatedAt:      timestampOrZero(row.CreatedAt),
-		DeletedAt:      timestampPtr(row.DeletedAt),
-		CreatedBy:      row.CreatedBy,
+		ID:                row.ID.String(),
+		InstallationID:    row.InstallationID.String(),
+		ExternalID:        row.ExternalID,
+		Name:              row.Name,
+		KeyPrefix:         row.KeyPrefix,
+		KeyHash:           row.KeyHash,
+		KeySuffix:         row.KeySuffix,
+		LastUsedAt:        timestampPtr(row.LastUsedAt),
+		CreatedAt:         timestampOrZero(row.CreatedAt),
+		DeletedAt:         timestampPtr(row.DeletedAt),
+		CreatedBy:         row.CreatedBy,
+		SpendCapUsdMicros: row.SpendCapUsdMicros,
 	}
 }
 

--- a/internal/postgres/repository.go
+++ b/internal/postgres/repository.go
@@ -208,13 +208,14 @@ func (r *apiKeyRepo) Create(ctx context.Context, params auth.CreateAPIKeyParams)
 	}
 	q := sqlc.New(r.tx)
 	row, err := q.CreateModelRouterAPIKey(ctx, sqlc.CreateModelRouterAPIKeyParams{
-		InstallationID: installationID,
-		ExternalID:     params.ExternalID,
-		Name:           params.Name,
-		KeyPrefix:      params.KeyPrefix,
-		KeyHash:        params.KeyHash,
-		KeySuffix:      params.KeySuffix,
-		CreatedBy:      params.CreatedBy,
+		InstallationID:    installationID,
+		ExternalID:        params.ExternalID,
+		Name:              params.Name,
+		KeyPrefix:         params.KeyPrefix,
+		KeyHash:           params.KeyHash,
+		KeySuffix:         params.KeySuffix,
+		CreatedBy:         params.CreatedBy,
+		SpendCapUsdMicros: params.SpendCapUsdMicros,
 	})
 	if err != nil {
 		return nil, err

--- a/internal/sqlc/model_router_api_keys.sql.go
+++ b/internal/sqlc/model_router_api_keys.sql.go
@@ -19,7 +19,8 @@ INSERT INTO router.model_router_api_keys (
     key_prefix,
     key_hash,
     key_suffix,
-    created_by
+    created_by,
+    spend_cap_usd_micros
 )
 VALUES (
     $1::uuid,
@@ -28,19 +29,21 @@ VALUES (
     $4::varchar,
     $5::varchar,
     $6::varchar,
-    $7
+    $7,
+    $8
 )
 RETURNING id, installation_id, external_id, name, key_prefix, key_hash, key_suffix, last_used_at, created_at, deleted_at, created_by, spend_cap_usd_micros, spent_usd_micros
 `
 
 type CreateModelRouterAPIKeyParams struct {
-	InstallationID uuid.UUID
-	ExternalID     string
-	Name           *string
-	KeyPrefix      string
-	KeyHash        string
-	KeySuffix      string
-	CreatedBy      *string
+	InstallationID    uuid.UUID
+	ExternalID        string
+	Name              *string
+	KeyPrefix         string
+	KeyHash           string
+	KeySuffix         string
+	CreatedBy         *string
+	SpendCapUsdMicros *int64
 }
 
 // CreateModelRouterAPIKey
@@ -52,7 +55,8 @@ type CreateModelRouterAPIKeyParams struct {
 //	    key_prefix,
 //	    key_hash,
 //	    key_suffix,
-//	    created_by
+//	    created_by,
+//	    spend_cap_usd_micros
 //	)
 //	VALUES (
 //	    $1::uuid,
@@ -61,7 +65,8 @@ type CreateModelRouterAPIKeyParams struct {
 //	    $4::varchar,
 //	    $5::varchar,
 //	    $6::varchar,
-//	    $7
+//	    $7,
+//	    $8
 //	)
 //	RETURNING id, installation_id, external_id, name, key_prefix, key_hash, key_suffix, last_used_at, created_at, deleted_at, created_by, spend_cap_usd_micros, spent_usd_micros
 func (q *Queries) CreateModelRouterAPIKey(ctx context.Context, arg CreateModelRouterAPIKeyParams) (RouterModelRouterAPIKey, error) {
@@ -73,6 +78,7 @@ func (q *Queries) CreateModelRouterAPIKey(ctx context.Context, arg CreateModelRo
 		arg.KeyHash,
 		arg.KeySuffix,
 		arg.CreatedBy,
+		arg.SpendCapUsdMicros,
 	)
 	var i RouterModelRouterAPIKey
 	err := row.Scan(


### PR DESCRIPTION
Fixes #564
 
## Problem
 
`RotateAPIKey` issues a replacement key via `IssueAPIKey`, which never carried forward `spend_cap_usd_micros`. Any capped key silently became uncapped on rotation, with no warning to the caller and no dashboard signal — the admin key list doesn't surface the cap field at all, before or after rotation.
 
Since there's no update/PATCH endpoint for keys, and no dashboard field for the cap, the only way to set — or restore — a cap is a direct database write. That makes a dropped cap permanent without out-of-band intervention: an admin doing routine key rotation for unrelated reasons (security hygiene, a leaked token) silently removes a customer's spend limit with zero indication anything beyond the token itself changed.
 
## Root cause
 
- `auth.APIKey` and `CreateAPIKeyParams` (`internal/auth/api_key.go`) had no `SpendCapUsdMicros` field
- `toAuthAPIKey` (`internal/postgres/converters.go`) dropped `row.SpendCapUsdMicros` when converting the DB row to the domain type
- `CreateModelRouterAPIKey`'s INSERT (`db/queries/model_router_api_keys.sql`) never wrote `spend_cap_usd_micros`
- `RotateAPIKey` (`internal/auth/service.go`) read the old key through this same blind spot before calling `IssueAPIKey`, so there was nothing to carry forward even in principle
Enforcement itself (`internal/server/middleware/api_key_spend_cap.go`) is correct and unaffected by this bug — it reads `spend_cap_usd_micros` / `spent_usd_micros` live from Postgres and hard-rejects with 402 at the cap. This is purely a gap in the create/rotate path.
 
## Fix
 
- Add `SpendCapUsdMicros *int64` to `APIKey` / `CreateAPIKeyParams` (nil = uncapped, preserves existing behavior for every current uncapped key)
- Propagate it in `toAuthAPIKey`
- Extend the `CreateModelRouterAPIKey` INSERT with `spend_cap_usd_micros` via `sqlc.narg(...)` so it stays nullable/optional; regenerated with sqlc v1.30.0
- Thread it through `apiKeyRepo.Create`
- Add `IssueAPIKeyWithCap`; `IssueAPIKey` now delegates to it with a nil cap, so every existing call site (fresh key creation via `POST /admin/v1/keys`) is unaffected. `RotateAPIKey` calls `IssueAPIKeyWithCap` with the old key's cap.
## Files changed
 
| File | Change |
|---|---|
| `internal/auth/api_key.go` | Added `SpendCapUsdMicros *int64` to `CreateAPIKeyParams` |
| `internal/postgres/converters.go` | `toAuthAPIKey` now propagates `SpendCapUsdMicros` from the DB row |
| `db/queries/model_router_api_keys.sql` | `CreateModelRouterAPIKey` INSERT extended with `spend_cap_usd_micros` via `sqlc.narg(...)` |
| `internal/sqlc/model_router_api_keys.sql.go` | Regenerated (sqlc v1.30.0) — `CreateModelRouterAPIKeyParams` gains `SpendCapUsdMicros *int64`, query gains one param |
| `internal/postgres/repository.go` | `apiKeyRepo.Create` passes `params.SpendCapUsdMicros` through to sqlc params |
| `internal/auth/service.go` | Added `IssueAPIKeyWithCap`; `IssueAPIKey` delegates with nil cap; `RotateAPIKey` calls it with `target.SpendCapUsdMicros` |
 
Two commits, test-then-fix:
 
- `9b50052` — `test(auth): assert RotateAPIKey preserves spend cap` (failing test only)
- `3725463` — `fix(auth): carry spend cap forward on RotateAPIKey`
## Testing
 
**New test, before the fix:**
 
```
--- FAIL: TestRotateAPIKey_preservesSpendCap (0.00s)
    rotate_spend_cap_test.go:116:
        Error: Expected value not to be nil.
        Messages: spend cap must be carried forward to the replacement key;
                  got nil (cap was 5000000 micros on old key)
```
 
**Same test, after the fix:**
 
```
--- PASS: TestRotateAPIKey_preservesSpendCap (0.00s)
```
 
**Full suite:** `go test ./... -race -count=1` — all packages green, race detector clean, all 20 pre-existing auth tests still pass.
 
`make check` — clean.
 
**Manual end-to-end verification** — rebuilt the local server image (`docker compose build server && docker compose up -d server`) and ran the full flow through the real running stack, not just the unit test, to confirm the fix works through the actual admin API and DB.
 
Capped key, before rotation:
 
| id | spend_cap_usd_micros |
|---|---|
| `0b60fab5-e82a-4220-bba2-07b369aca241` | `5000000` |
 
`POST /admin/v1/keys/0b60fab5-.../rotate` → `201`, returns new key `f4727177-6d57-4cc4-948d-bc557b6fe14d`
 
Both rows after rotation:
 
| external_id | spend_cap_usd_micros | created_at | |
|---|---|---|---|
| `kid_xgVBu9eH7N2GqZpwQfYo3rRL` | `5000000` | 2026-07-01 19:12:30 | new key, cap preserved |
| `kid_Kdts2E1HObZEm638KlQk4hwV` | `5000000` | 2026-07-01 19:11:40 | old key |
 
Regression check — uncapped key through the same rotate path, confirming the fix doesn't introduce a cap where none existed:
 
| external_id | spend_cap_usd_micros | |
|---|---|---|
| `kid_0CZuqdy4J5dAGq70Djf9Rfgg` | `null` | new key, still uncapped |
| `kid_329GSrWAUoWTfiLQdAPIZupq` | `null` | old key |
 
## Also verified via the dashboard UI
 
Reproduced the original bug and confirmed the fix through the actual "Rotate" button in the admin dashboard (not just curl), since that's the real-world trigger path. Screenshots in #564.
 