### PR TITLE
fix: route gpt-5.x tool turns via Responses API, strip stop param, surface upstream Responses errors

### DIFF
--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -1966,13 +1966,12 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 			attemptOpts := opts
 			attemptOpts.TargetProvider = d.Provider
 			respSummary = translate.ResponseSummary{}
-			// Reasoning OpenAI models (gpt-5.x) reject reasoning_effort + tools
-			// on /v1/chat/completions; an agentic Anthropic client that asks the
-			// model to reason must go through the Responses API instead. Scoped
-			// to the direct OpenAI provider (the only one with /v1/responses).
-			useResponses := d.Provider == providers.ProviderOpenAI &&
-				attemptOpts.Capabilities.Supports(router.CapReasoning) &&
-				feats.HasTools && env.ReasoningRequested()
+			// Reasoning OpenAI models (gpt-5.x) reject tools, stop, and
+			// reasoning_effort on /v1/chat/completions; any agentic turn with
+			// tools must go through the Responses API instead. Scoped to the
+			// direct OpenAI provider (the only one with /v1/responses).
+			useResponses := translate.UseOpenAIResponsesAPI(
+				d.Provider, attemptOpts.Capabilities, feats.HasTools)
 			var prep providers.PreparedRequest
 			var emitErr error
 			if useResponses {

--- a/internal/translate/crossformat_request_test.go
+++ b/internal/translate/crossformat_request_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"workweave/router/internal/router"
 	"workweave/router/internal/translate"
 
 	"github.com/stretchr/testify/assert"
@@ -1226,6 +1227,29 @@ func TestCrossFormat_AnthropicToOpenAI_ScalarFieldsCarriedThrough(t *testing.T) 
 	assert.Equal(t, float64(0.8), doc["top_p"])
 	stop := doc["stop"].([]any)
 	assert.Equal(t, []any{"STOP"}, stop)
+}
+
+func TestCrossFormat_AnthropicToOpenAI_ReasoningModelOmitsStop(t *testing.T) {
+	body := []byte(`{
+		"model": "claude-sonnet-5",
+		"stream": true,
+		"messages": [{"role": "user", "content": [{"type": "text", "text": "hi"}]}],
+		"stop_sequences": ["STOP"],
+		"tools": [{"name": "Bash", "description": "run", "input_schema": {"type": "object"}}]
+	}`)
+	env, err := translate.ParseAnthropic(body)
+	require.NoError(t, err)
+
+	prep, err := env.PrepareOpenAI(http.Header{}, translate.EmitOptions{
+		TargetModel:    "gpt-5.4-mini",
+		TargetProvider: "openai",
+		Capabilities:   router.Lookup("gpt-5.4-mini"),
+	})
+	require.NoError(t, err)
+
+	doc := unmarshalBody(t, prep.Body)
+	_, hasStop := doc["stop"]
+	assert.False(t, hasStop, "gpt-5.x rejects stop on chat/completions")
 }
 
 func TestCrossFormat_OpenAIToGemini_ScalarFieldsCarriedThrough(t *testing.T) {

--- a/internal/translate/emit_openai.go
+++ b/internal/translate/emit_openai.go
@@ -266,8 +266,10 @@ func (e *RequestEnvelope) buildOpenAIFromAnthropic(opts EmitOptions) ([]byte, pr
 	// System + Messages
 	writeOpenAISystemAndMessagesFromAnthropic(jw, body, opts)
 
-	// Stop sequences
-	if r := gjson.GetBytes(body, "stop_sequences"); r.Exists() {
+	// Stop sequences — reasoning OpenAI models (gpt-5.x) reject `stop` on
+	// /v1/chat/completions ("Unsupported parameter: 'stop' is not supported").
+	if r := gjson.GetBytes(body, "stop_sequences"); r.Exists() &&
+		!opts.Capabilities.Supports(router.CapReasoning) {
 		jw.Key("stop")
 		jw.Raw(r.Raw)
 	}

--- a/internal/translate/emit_openai_responses.go
+++ b/internal/translate/emit_openai_responses.go
@@ -59,6 +59,17 @@ func (e *RequestEnvelope) ReasoningRequested() bool {
 	return reasoningEffortFromAnthropic(e.body) != ""
 }
 
+// UseOpenAIResponsesAPI reports whether an Anthropic ingress dispatch to the
+// direct OpenAI provider should use POST /v1/responses instead of
+// /v1/chat/completions. Reasoning OpenAI models (gpt-5.x) reject tools,
+// stop, and reasoning_effort on chat/completions, so any agentic turn with
+// tools must go through the Responses API.
+func UseOpenAIResponsesAPI(provider string, caps router.ModelSpec, hasTools bool) bool {
+	return provider == providers.ProviderOpenAI &&
+		caps.Supports(router.CapReasoning) &&
+		hasTools
+}
+
 // reasoningEffortFromAnthropic resolves the Responses `reasoning.effort` from an
 // Anthropic body: the `thinking` budget (Claude Code) via effortForBudget, or an
 // explicit `reasoning_effort` if an OpenAI-format field rode along. "" = none.

--- a/internal/translate/responses_outbound_test.go
+++ b/internal/translate/responses_outbound_test.go
@@ -360,3 +360,11 @@ func TestPrepareGemini_ThinkingBudget_Legacy25(t *testing.T) {
 	_, hasLevel := tc["thinkingLevel"]
 	assert.False(t, hasLevel, "gemini-2.5 must NOT send thinkingLevel")
 }
+
+func TestUseOpenAIResponsesAPI(t *testing.T) {
+	caps := router.Lookup("gpt-5.4-mini")
+	assert.True(t, translate.UseOpenAIResponsesAPI(providers.ProviderOpenAI, caps, true))
+	assert.False(t, translate.UseOpenAIResponsesAPI(providers.ProviderOpenAI, caps, false))
+	assert.False(t, translate.UseOpenAIResponsesAPI(providers.ProviderFireworks, caps, true))
+	assert.False(t, translate.UseOpenAIResponsesAPI(providers.ProviderOpenAI, router.Lookup("gpt-4o"), true))
+}

--- a/internal/translate/responses_to_anthropic_writer.go
+++ b/internal/translate/responses_to_anthropic_writer.go
@@ -322,8 +322,9 @@ func (t *ResponsesToAnthropicWriter) translateResponsesEvent(raw []byte) error {
 		// response.failed is always an upstream failure — surface it as an error
 		// even when no error object rode along (responsesError fills a generic
 		// message), matching the buffered path's status:"failed" rejection.
-		e := gjson.GetBytes(data, "response.error")
-		return t.emitStreamErrorEvent(e.Get("code").String(), e.Get("message").String())
+		resp := gjson.GetBytes(data, "response")
+		errType, msg := responsesFailureFromResponse(resp)
+		return t.emitStreamErrorEvent(errType, msg)
 	case "response.completed", "response.incomplete":
 		// Terminal envelope: the turn is finishing, so this is progress (and a
 		// post-trip cancel would be moot anyway).
@@ -640,7 +641,13 @@ func (t *ResponsesToAnthropicWriter) finalizeBuffered() error {
 	// truncated response and is left to ResponsesToAnthropicResponse.
 	respErr := gjson.GetBytes(finalResp, "error")
 	if gjson.GetBytes(finalResp, "status").String() == "failed" || (respErr.Exists() && respErr.Type != gjson.Null) {
-		observability.Get().Error("ResponsesToAnthropic: upstream response failed", "request_model", t.requestModel)
+		errType, errMsg := responsesFailureFromResponse(gjson.ParseBytes(finalResp))
+		observability.Get().Error("ResponsesToAnthropic: upstream response failed",
+			"request_model", t.requestModel,
+			"upstream_status", gjson.GetBytes(finalResp, "status").String(),
+			"upstream_error_type", errType,
+			"upstream_error_message", errMsg,
+		)
 		return t.finalizeError()
 	}
 	anthropic, issues, err := responsesToAnthropicResponse(finalResp, t.requestModel, t.toolValidator)
@@ -727,13 +734,38 @@ func (t *ResponsesToAnthropicWriter) anthropicErrorFromBuffer() []byte {
 		switch gjson.GetBytes(data, "type").String() {
 		case "error":
 			return responsesError(gjson.GetBytes(data, "code").String(), gjson.GetBytes(data, "message").String())
-		case "response.failed", "response.incomplete":
-			if e := gjson.GetBytes(data, "response.error"); e.Exists() {
-				return responsesError(e.Get("code").String(), e.Get("message").String())
-			}
+		case "response.failed":
+			resp := gjson.GetBytes(data, "response")
+			errType, msg := responsesFailureFromResponse(resp)
+			return responsesError(errType, msg)
 		}
 	}
 	return responsesError("api_error", "upstream Responses stream ended without a terminal response event")
+}
+
+// responsesFailureFromResponse extracts an error type/message from a Responses
+// API `response` object on a response.failed terminal event.
+func responsesFailureFromResponse(resp gjson.Result) (errType, msg string) {
+	if !resp.Exists() {
+		return "", ""
+	}
+	if e := resp.Get("error"); e.Exists() && e.Type != gjson.Null {
+		errType = e.Get("code").String()
+		if errType == "" {
+			errType = e.Get("type").String()
+		}
+		msg = e.Get("message").String()
+		if msg != "" {
+			return errType, msg
+		}
+	}
+	if reason := resp.Get("incomplete_details.reason").String(); reason != "" {
+		return "api_error", "upstream Responses request incomplete: " + reason
+	}
+	if resp.Get("status").String() == "failed" {
+		return "api_error", "upstream Responses request failed (status: failed)"
+	}
+	return "", ""
 }
 
 // responsesError builds an Anthropic error envelope from a Responses-style

--- a/internal/translate/responses_to_anthropic_writer.go
+++ b/internal/translate/responses_to_anthropic_writer.go
@@ -754,7 +754,9 @@ func (t *ResponsesToAnthropicWriter) anthropicErrorFromBuffer() []byte {
 }
 
 // responsesFailureFromResponse extracts an error type/message from a Responses
-// API `response` object on a response.failed terminal event.
+// API `response` object on a response.failed terminal event. A parsed error
+// code/type is preserved even when the message is empty and a fallback message
+// is used (responsesError defaults an empty type to "api_error").
 func responsesFailureFromResponse(resp gjson.Result) (errType, msg string) {
 	if !resp.Exists() {
 		return "", ""
@@ -764,18 +766,17 @@ func responsesFailureFromResponse(resp gjson.Result) (errType, msg string) {
 		if errType == "" {
 			errType = e.Get("type").String()
 		}
-		msg = e.Get("message").String()
-		if msg != "" {
+		if msg = e.Get("message").String(); msg != "" {
 			return errType, msg
 		}
 	}
 	if reason := resp.Get("incomplete_details.reason").String(); reason != "" {
-		return "api_error", "upstream Responses request incomplete: " + reason
+		return errType, "upstream Responses request incomplete: " + reason
 	}
 	if resp.Get("status").String() == "failed" {
-		return "api_error", "upstream Responses request failed (status: failed)"
+		return errType, "upstream Responses request failed (status: failed)"
 	}
-	return "", ""
+	return errType, ""
 }
 
 // responsesError builds an Anthropic error envelope from a Responses-style

--- a/internal/translate/responses_to_anthropic_writer.go
+++ b/internal/translate/responses_to_anthropic_writer.go
@@ -738,6 +738,16 @@ func (t *ResponsesToAnthropicWriter) anthropicErrorFromBuffer() []byte {
 			resp := gjson.GetBytes(data, "response")
 			errType, msg := responsesFailureFromResponse(resp)
 			return responsesError(errType, msg)
+		case "response.incomplete":
+			// An incomplete terminal is only an error when it carries an error
+			// object (finalizeBuffered routes that case here); a plain
+			// max_output_tokens incomplete is a valid truncated response and
+			// must not short-circuit the scan.
+			resp := gjson.GetBytes(data, "response")
+			if e := resp.Get("error"); e.Exists() && e.Type != gjson.Null {
+				errType, msg := responsesFailureFromResponse(resp)
+				return responsesError(errType, msg)
+			}
 		}
 	}
 	return responsesError("api_error", "upstream Responses stream ended without a terminal response event")

--- a/internal/translate/responses_to_anthropic_writer_stream_test.go
+++ b/internal/translate/responses_to_anthropic_writer_stream_test.go
@@ -544,8 +544,8 @@ data: {"type":"response.failed","response":{"id":"r","status":"failed","error":{
 	assert.NotContains(t, body, "event: message_stop", "no success trailer after an error close")
 }
 
-// response.failed with no error object is still surfaced as an error (generic
-// message), not a normal success close.
+// response.failed with no error object is still surfaced as an error (status
+// detail in the message), not a normal success close.
 func TestResponsesToAnthropicWriter_StreamingFailedNoErrorObject(t *testing.T) {
 	const fixture = `event: response.failed
 data: {"type":"response.failed","response":{"id":"r","status":"failed","output":[]}}
@@ -560,6 +560,7 @@ data: {"type":"response.failed","response":{"id":"r","status":"failed","output":
 
 	body := rec.Body.String()
 	assert.Contains(t, body, "event: error")
+	assert.Contains(t, body, "status: failed")
 	assert.NotContains(t, body, "event: message_stop")
 }
 
@@ -607,6 +608,26 @@ data: {"type":"response.failed","response":{"id":"r","status":"failed","error":{
 	e, _ := msg["error"].(map[string]any)
 	require.NotNil(t, e)
 	assert.Contains(t, e["message"], "boom")
+}
+
+func TestResponsesToAnthropicWriter_NonStreamingFailedNoErrorObject(t *testing.T) {
+	const fixture = `event: response.failed
+data: {"type":"response.failed","response":{"id":"r","status":"failed","output":[]}}
+
+`
+	rec := httptest.NewRecorder()
+	w := translate.NewResponsesToAnthropicWriter(rec, "gpt-5.5", nil)
+	require.NoError(t, w.Prelude(false))
+	_, err := w.Write([]byte(fixture))
+	require.NoError(t, err)
+	require.NoError(t, w.Finalize())
+
+	var msg map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &msg))
+	assert.Equal(t, "error", msg["type"])
+	e, _ := msg["error"].(map[string]any)
+	require.NotNil(t, e)
+	assert.Contains(t, e["message"], "status: failed")
 }
 
 // A routing marker is emitted as content block 0; upstream content then starts

--- a/internal/translate/responses_to_anthropic_writer_stream_test.go
+++ b/internal/translate/responses_to_anthropic_writer_stream_test.go
@@ -633,6 +633,29 @@ data: {"type":"response.incomplete","response":{"id":"r","status":"incomplete","
 	assert.Contains(t, e["message"], "ran out of juice")
 }
 
+// An error object with a code but empty message keeps the upstream code in
+// the envelope (with a fallback message) instead of degrading to api_error.
+func TestResponsesToAnthropicWriter_NonStreamingFailedCodeNoMessage(t *testing.T) {
+	const fixture = `event: response.failed
+data: {"type":"response.failed","response":{"id":"r","status":"failed","error":{"code":"rate_limit_exceeded","message":""},"output":[]}}
+
+`
+	rec := httptest.NewRecorder()
+	w := translate.NewResponsesToAnthropicWriter(rec, "gpt-5.5", nil)
+	require.NoError(t, w.Prelude(false))
+	_, err := w.Write([]byte(fixture))
+	require.NoError(t, err)
+	require.NoError(t, w.Finalize())
+
+	var msg map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &msg))
+	assert.Equal(t, "error", msg["type"])
+	e, _ := msg["error"].(map[string]any)
+	require.NotNil(t, e)
+	assert.Equal(t, "rate_limit_exceeded", e["type"], "upstream error code preserved")
+	assert.Contains(t, e["message"], "status: failed")
+}
+
 func TestResponsesToAnthropicWriter_NonStreamingFailedNoErrorObject(t *testing.T) {
 	const fixture = `event: response.failed
 data: {"type":"response.failed","response":{"id":"r","status":"failed","output":[]}}

--- a/internal/translate/responses_to_anthropic_writer_stream_test.go
+++ b/internal/translate/responses_to_anthropic_writer_stream_test.go
@@ -610,6 +610,29 @@ data: {"type":"response.failed","response":{"id":"r","status":"failed","error":{
 	assert.Contains(t, e["message"], "boom")
 }
 
+// A response.incomplete terminal carrying an error object is a failure
+// (finalizeBuffered rejects it) and its error text must survive the buffer
+// scan — not fall through to the generic no-terminal message.
+func TestResponsesToAnthropicWriter_NonStreamingIncompleteWithError(t *testing.T) {
+	const fixture = `event: response.incomplete
+data: {"type":"response.incomplete","response":{"id":"r","status":"incomplete","error":{"code":"server_error","message":"ran out of juice"},"output":[]}}
+
+`
+	rec := httptest.NewRecorder()
+	w := translate.NewResponsesToAnthropicWriter(rec, "gpt-5.5", nil)
+	require.NoError(t, w.Prelude(false))
+	_, err := w.Write([]byte(fixture))
+	require.NoError(t, err)
+	require.NoError(t, w.Finalize())
+
+	var msg map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &msg))
+	assert.Equal(t, "error", msg["type"])
+	e, _ := msg["error"].(map[string]any)
+	require.NotNil(t, e)
+	assert.Contains(t, e["message"], "ran out of juice")
+}
+
 func TestResponsesToAnthropicWriter_NonStreamingFailedNoErrorObject(t *testing.T) {
 	const fixture = `event: response.failed
 data: {"type":"response.failed","response":{"id":"r","status":"failed","output":[]}}


### PR DESCRIPTION
Three fixes for cross-format Anthropic->OpenAI dispatch failures observed in
prod (Redwood org, 2026-07-01):

1. Widen the Responses-API gate: any agentic turn with tools on a
   reasoning-capable OpenAI model now uses /v1/responses, not just turns with
   thinking enabled. Chat-completions rejects tools+stop combos on gpt-5.x
   (18/24 requests returned 400 'Unsupported parameter: stop').

2. Strip stop_sequences -> stop mapping when the target model has
   CapReasoning (defense in depth for turns that still hit chat-completions).

3. Surface real upstream error details on response.failed: extract
   error.code/message (falling back to incomplete_details.reason or a
   status-failed marker) instead of the generic 'upstream Responses request
   failed', and log upstream_error_type/message on buffered failures.