### PR TITLE
fix(install): add claude-sonnet-5 to the pi /model picker list

### DIFF
--- a/install/install.sh
+++ b/install/install.sh
@@ -773,6 +773,7 @@ write_pi_models_config() {
         { id: "claude-fable-5",    name: "Claude Fable 5 (via Weave Router)",    reasoning: true, input: ["text","image"], contextWindow: 1000000, maxTokens: 128000 },
         { id: "claude-opus-4-8",   name: "Claude Opus 4.8 (via Weave Router)",   reasoning: true, input: ["text","image"], contextWindow: 200000, maxTokens: 64000 },
         { id: "claude-opus-4-7",   name: "Claude Opus 4.7 (via Weave Router)",   reasoning: true, input: ["text","image"], contextWindow: 200000, maxTokens: 64000 },
+        { id: "claude-sonnet-5",   name: "Claude Sonnet 5 (via Weave Router)",   reasoning: true, input: ["text","image"], contextWindow: 200000, maxTokens: 64000 },
         { id: "claude-sonnet-4-6", name: "Claude Sonnet 4.6 (via Weave Router)", reasoning: true, input: ["text","image"], contextWindow: 200000, maxTokens: 64000 },
         { id: "claude-haiku-4-5",  name: "Claude Haiku 4.5 (via Weave Router)",  reasoning: true, input: ["text","image"], contextWindow: 200000, maxTokens: 32000 }
       ]


### PR DESCRIPTION
Follow-up to #558. That PR added `claude-sonnet-5` to the opencode config + pricing tables but **missed the pi provider model list** (`write_pi_models_config`), so a `pi` install's `/model` picker hid Sonnet 5 even though the router serves/prices it. Adds it alongside the other Anthropic entries (200K ctx, 64K max, reasoning).

Found by greptile on WW#9679 (install_template.sh is a verbatim mirror of this file, so the correct fix is here — the mirror re-syncs on the next pin bump).

`bash -n install/install.sh` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)