### PR TITLE
feat(version): expose deployed commit via /v1/version + managed badge

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,6 +52,11 @@ ARG HF_MODEL_REPO
 ARG HF_MODEL_REVISION
 ARG HF_QWEN_REPO
 ARG HF_QWEN_REVISION
+# Build identity stamped into the binary via -ldflags (see the go build below)
+# and surfaced at GET /v1/version. Default to "unknown" so a plain
+# `docker build` with no --build-arg still produces a runnable image.
+ARG ROUTER_SHA=unknown
+ARG ROUTER_BUILD_TIME=unknown
 # TARGETARCH is set automatically by buildx (`amd64` or `arm64`) so we
 # can pull the matching native ONNX Runtime + libtokenizers tarball.
 # Without this, building on Apple Silicon / Graviton picks up x86_64
@@ -193,7 +198,9 @@ WORKDIR /app/cmd/router
 # main.go fail-opens to the heuristic. Don't drop the tag.
 RUN --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \
-    GOOS=linux go build -tags ORT -o /server
+    GOOS=linux go build -tags ORT \
+      -ldflags "-X workweave/router/internal/version.Commit=${ROUTER_SHA} -X workweave/router/internal/version.BuildTime=${ROUTER_BUILD_TIME}" \
+      -o /server
 
 
 FROM gcr.io/distroless/cc-debian12 AS build-release-stage

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ for *every* request: using a tiny on-box embedder, not a vibes-based prompt.
 [![Go](https://img.shields.io/badge/Go-1.25%2B-00ADD8?logo=go)](go.mod)
 [![Tests](https://github.com/workweave/router/actions/workflows/test.yml/badge.svg)](https://github.com/workweave/router/actions/workflows/test.yml)
 [![License: ELv2](https://img.shields.io/badge/License-ELv2-00BFB3.svg)](https://www.elastic.co/licensing/elastic-license)
+[![Managed deployment](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Frouter.workweave.ai%2Fv1%2Fversion&query=%24.commit_short&label=managed%20deployment&color=EC6341&cacheSeconds=1800)](https://router.workweave.ai/v1/version)
 
 *Built by [Weave](https://www.workweave.ai): The #1 engineering intelligence platform,
 loved by Robinhood, PostHog, Reducto, and hundreds of others.*

--- a/internal/api/admin/version.go
+++ b/internal/api/admin/version.go
@@ -1,0 +1,31 @@
+package admin
+
+import (
+	"net/http"
+
+	"workweave/router/internal/config"
+	"workweave/router/internal/version"
+
+	"github.com/gin-gonic/gin"
+)
+
+type versionResponse struct {
+	Commit         string `json:"commit"`
+	CommitShort    string `json:"commit_short"`
+	BuildTime      string `json:"build_time"`
+	ClusterVersion string `json:"cluster_version"`
+}
+
+// VersionHandler reports the running binary's build identity — the git commit
+// it was built from, the build timestamp, and the active cluster artifact — so
+// operators (and the managed-deployment badge in the README) can tell which
+// router commit is live. Unauthed and mounted in both deployment modes, like
+// /health; every field is public metadata with no leak risk.
+func VersionHandler(c *gin.Context) {
+	c.JSON(http.StatusOK, versionResponse{
+		Commit:         version.Commit,
+		CommitShort:    version.ShortCommit(),
+		BuildTime:      version.BuildTime,
+		ClusterVersion: config.GetOr("ROUTER_CLUSTER_VERSION", "artifacts/latest"),
+	})
+}

--- a/internal/api/admin/version_test.go
+++ b/internal/api/admin/version_test.go
@@ -1,0 +1,45 @@
+package admin_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"workweave/router/internal/api/admin"
+	"workweave/router/internal/version"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestVersionHandler(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	orig := version.Commit
+	t.Cleanup(func() { version.Commit = orig })
+	version.Commit = "0fb46ee9707c8db7d0ef69b7308a79a95d559e25"
+	t.Setenv("ROUTER_CLUSTER_VERSION", "v0.71")
+
+	engine := gin.New()
+	engine.GET("/v1/version", admin.VersionHandler)
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/version", nil)
+	rec := httptest.NewRecorder()
+	engine.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var body struct {
+		Commit         string `json:"commit"`
+		CommitShort    string `json:"commit_short"`
+		BuildTime      string `json:"build_time"`
+		ClusterVersion string `json:"cluster_version"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+
+	assert.Equal(t, "0fb46ee9707c8db7d0ef69b7308a79a95d559e25", body.Commit)
+	assert.Equal(t, "0fb46ee", body.CommitShort)
+	assert.Equal(t, "v0.71", body.ClusterVersion)
+}

--- a/internal/observability/apm/apm.go
+++ b/internal/observability/apm/apm.go
@@ -34,6 +34,7 @@ import (
 
 	"workweave/router/internal/config"
 	"workweave/router/internal/observability"
+	"workweave/router/internal/version"
 )
 
 // serviceName is the resource attribute the SigNoz UI groups spans + metrics
@@ -67,12 +68,11 @@ func initLocked() {
 
 	ctx := context.Background()
 	deployEnv := config.GetOr("ROUTER_DEPLOYMENT_ENV", config.GetOr("ENV", "dev"))
-	version := config.GetOr("ROUTER_VERSION", "unknown")
 
 	res, err := resource.New(ctx,
 		resource.WithAttributes(
 			semconv.ServiceName(serviceName),
-			semconv.ServiceVersion(version),
+			semconv.ServiceVersion(version.Commit),
 			semconv.DeploymentEnvironment(deployEnv),
 		),
 		resource.WithHost(),
@@ -133,7 +133,7 @@ func initLocked() {
 		"endpoint", endpoint,
 		"service", serviceName,
 		"deployment_env", deployEnv,
-		"version", version,
+		"version", version.Commit,
 		"insecure", insecure,
 	)
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -68,6 +68,12 @@ func Register(engine *gin.Engine, authSvc *auth.Service, proxySvc *proxy.Service
 
 	engine.GET("/health", middleware.WithTimeout(healthTimeout), admin.HealthHandler)
 
+	// /v1/version reports the running binary's git commit + build time (stamped
+	// via -ldflags) so operators and the README's managed-deployment badge can
+	// tell which router commit is live. Unauthed + mounted in both modes, like
+	// /health — the fields are public build metadata with no leak risk.
+	engine.GET("/v1/version", middleware.WithTimeout(healthTimeout), admin.VersionHandler)
+
 	// /v1/router/models surfaces the active artifact's deployed-models list so
 	// the Weave control plane can validate per-org exclusion submissions
 	// against the live universe instead of hand-copying it on every gitlink

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,0 +1,25 @@
+// Package version carries the router binary's build identity, stamped in at
+// link time via -ldflags. It imports nothing so any layer may read it, and its
+// defaults make an un-stamped build (e.g. `go run`, a local `go build`) report
+// "unknown" rather than an empty string.
+package version
+
+// shortLen is the git short-SHA length GitHub and the README badge display.
+const shortLen = 7
+
+var (
+	// Commit is the git SHA the binary was built from. Overridden at build
+	// time with `-ldflags "-X workweave/router/internal/version.Commit=<sha>"`.
+	Commit = "unknown"
+	// BuildTime is the RFC3339 UTC build timestamp, stamped the same way.
+	BuildTime = "unknown"
+)
+
+// ShortCommit returns the 7-character prefix of Commit, or Commit unchanged
+// when it is already shorter (e.g. the "unknown" default).
+func ShortCommit() string {
+	if len(Commit) <= shortLen {
+		return Commit
+	}
+	return Commit[:shortLen]
+}

--- a/internal/version/version_test.go
+++ b/internal/version/version_test.go
@@ -1,0 +1,30 @@
+package version_test
+
+import (
+	"testing"
+
+	"workweave/router/internal/version"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestShortCommit(t *testing.T) {
+	orig := version.Commit
+	t.Cleanup(func() { version.Commit = orig })
+
+	tests := map[string]struct {
+		commit string
+		want   string
+	}{
+		"full sha truncates to 7":   {commit: "0fb46ee9707c8db7d0ef69b7308a79a95d559e25", want: "0fb46ee"},
+		"unknown default unchanged": {commit: "unknown", want: "unknown"},
+		"exactly 7 unchanged":       {commit: "abcdef0", want: "abcdef0"},
+		"shorter than 7 unchanged":  {commit: "abc", want: "abc"},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			version.Commit = tc.commit
+			assert.Equal(t, tc.want, version.ShortCommit())
+		})
+	}
+}


### PR DESCRIPTION
## Why

Recurring confusion: nobody can tell *which router commit is running in Weave's managed deployment*. This adds a durable, self-updating indicator in the open-source repo.

## What

- **`internal/version`** — a dependency-free, build-stamped package (`Commit`, `BuildTime`, `ShortCommit()`); defaults to `"unknown"` for un-stamped local builds.
- **`GET /v1/version`** — unauthed, mounted in **both** deployment modes (like `/health`). Returns `commit`, `commit_short`, `build_time`, `cluster_version`. All public build metadata.
- **Dockerfile** — new `ROUTER_SHA` / `ROUTER_BUILD_TIME` build args injected into the binary via `-ldflags`. Default `unknown`, so a plain `docker build` still works.
- **README badge** — `managed deployment` shields.io badge reading the live `https://router.workweave.ai/v1/version` endpoint, so the repo homepage always shows the deployed short-SHA.
- **APM fix** — `service.version` previously read an unset `ROUTER_VERSION` env and always emitted `"unknown"`; now reports the stamped commit.

## How the SHA gets stamped

The managed image is built in WorkWeave's `deploy.yml`. A companion WorkWeave PR passes `--build-arg ROUTER_SHA=$(git rev-parse the pinned submodule HEAD)` and creates a GitHub Deployment on this repo on every prod deploy. Until that lands, `/v1/version` reports `unknown` — graceful, no breakage.

## Test

- `go test ./internal/version/... ./internal/api/admin/...` — pass (new tests for `ShortCommit()` truncation + the handler's JSON shape).
- Verified `-ldflags` stamping end-to-end (`Commit=deadbeef… → commit_short=deadbee`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)