### PR TITLE
fix(proxy): clear suppressed Claude subscription so failover uses the deployment key

### DIFF
--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -3086,6 +3086,19 @@ func resolveAndInjectCredentials(ctx context.Context, provider string, headers h
 	if creds != nil {
 		return context.WithValue(ctx, CredentialsContextKey{}, creds)
 	}
+	// A suppressed Claude subscription that resolved no replacement credential must
+	// have its credential EXPLICITLY cleared, not left as-is. On a router-keyed
+	// request (every managed customer) with no BYOK, none of the branches above
+	// resolve anything, so ctx still carries the subscription credential injected on
+	// the primary attempt — returning it re-sends the spent sk-ant-oat the
+	// suppression meant to drop (the exhaustion / 429 failover then re-hits the same
+	// 429 forever). The provider client only falls back to its deployment
+	// ANTHROPIC_API_KEY when ctx carries NO credential, so clear it. Safe because
+	// suppression is only ever set when a fallback key exists
+	// (anthropicFallbackKeyAvailable gates both callers).
+	if suppressClaudeSub && provider == providers.ProviderAnthropic {
+		return clearCredentials(ctx)
+	}
 	return ctx
 }
 

--- a/internal/proxy/subscription_suppression_credential_internal_test.go
+++ b/internal/proxy/subscription_suppression_credential_internal_test.go
@@ -1,0 +1,76 @@
+package proxy
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"workweave/router/internal/providers"
+)
+
+const routerKeyedInstallationID = "11111111-1111-1111-1111-111111111111"
+
+// routerKeyedCtx mimics an authenticated managed request: the auth middleware
+// stashed an installation ID, so installationIDFromContext != nil and
+// resolveAndInjectCredentials treats it as router-keyed.
+func routerKeyedCtx() context.Context {
+	return context.WithValue(context.Background(), InstallationIDContextKey{}, routerKeyedInstallationID)
+}
+
+// The exhaustion / 429 failover suppresses the Claude subscription and re-resolves
+// credentials so the retry serves on the deployment ANTHROPIC_API_KEY. On a
+// router-keyed request with no BYOK, none of the resolution branches match, and
+// the ctx still carries the subscription credential injected on the primary
+// attempt. resolveAndInjectCredentials MUST clear it — otherwise the retry
+// re-sends the spent sk-ant-oat and 429s forever (the provider client only falls
+// back to its deployment key when ctx carries no credential). This is the bug
+// that made #519 / #555 no-ops for every managed customer.
+func TestResolveAndInjectCredentials_SuppressedSubClearedOnRouterKeyedPath(t *testing.T) {
+	// Primary attempt injected the caller's subscription onto ctx.
+	spentSub := &Credentials{APIKey: []byte("sk-ant-oat01-spent"), Source: credSourceSubscription, OAuth: true}
+	ctx := context.WithValue(routerKeyedCtx(), CredentialsContextKey{}, spentSub)
+
+	// Failover suppresses the sub, then re-resolves for the retry. The spent
+	// sk-ant-oat also rides in the inbound Authorization on the router-key path.
+	ctx = withSuppressedClaudeSubscription(ctx)
+	headers := http.Header{}
+	headers.Set("Authorization", "Bearer sk-ant-oat01-spent")
+
+	out := resolveAndInjectCredentials(ctx, providers.ProviderAnthropic, headers)
+
+	assert.Nil(t, CredentialsFromContext(out),
+		"a suppressed subscription must be cleared so the client uses its deployment key, not the spent token")
+}
+
+// Regression guard: without suppression, the normal path still forwards the
+// caller's subscription so their Claude turns bill their own plan.
+func TestResolveAndInjectCredentials_UnsuppressedSubStillForwarded(t *testing.T) {
+	headers := http.Header{}
+	headers.Set("Authorization", "Bearer sk-ant-oat01-live")
+
+	out := resolveAndInjectCredentials(routerKeyedCtx(), providers.ProviderAnthropic, headers)
+
+	got := CredentialsFromContext(out)
+	require.NotNil(t, got, "a live subscription must resolve on the router-key path")
+	assert.Equal(t, credSourceSubscription, got.Source)
+	assert.True(t, got.OAuth)
+}
+
+// The clear must be scoped to Anthropic: a suppressed-Claude request that also
+// carries a Codex subscription for an OpenAI turn must still resolve the Codex
+// credential (its OpenAI turns bill the caller's ChatGPT plan, unaffected).
+func TestResolveAndInjectCredentials_SuppressionDoesNotClearCodexOpenAITurn(t *testing.T) {
+	ctx := withSuppressedClaudeSubscription(routerKeyedCtx())
+	headers := http.Header{}
+	headers.Set("Authorization", "Bearer eyJhbGciOi.codex.jwt")
+	headers.Set("ChatGPT-Account-ID", "acct-1")
+
+	out := resolveAndInjectCredentials(ctx, providers.ProviderOpenAI, headers)
+
+	got := CredentialsFromContext(out)
+	require.NotNil(t, got, "a Codex subscription must still resolve for its OpenAI turn")
+	assert.Equal(t, credSourceCodexSubscription, got.Source)
+}


### PR DESCRIPTION
## The bug: exhaustion/429 failover is a no-op for every managed customer

Both the subscription-exhaustion failover (#519) and the live-429/header-timeout failover (#555) suppress the caller's Claude subscription and re-resolve credentials, expecting the retry to serve on the deployment `ANTHROPIC_API_KEY`. **It never does on a router-keyed request** (i.e. every managed customer).

`resolveAndInjectCredentials` never *clears* the credential when it resolves nothing — it `return ctx`s as-is. Under suppression on a router-keyed request with no BYOK, none of the branches match:
- subscription-first block → skipped (suppressed)
- BYOK lookup → empty (managed)
- client extraction → gated behind `!routerKeyed` → skipped

…so the returned ctx still carries the **subscription credential the primary attempt injected** (`service.go:1913`). The provider client only falls back to its deployment key when ctx carries *no* credential, so the retry **re-sends the spent `sk-ant-oat`** and gets the same 429. The failover "fires" (logs `retrying on Weave key`) but re-hits the exact token it meant to drop.

This is why it was never caught: it only worked for BYOK / non-router-keyed callers, and we route away from Claude / don't hit our own sub limits.

## Evidence (prod, Everfit)

- Subscription-429s fire the failover but complete with `subscription_failover=false`, `upstream_status=429`.
- The 429 telemetry rows still show the credential as the subscription (`sk-ant-o…`), `failover_used=false`.
- **In 7 days the deployment key served zero Anthropic turns** — not a single non-subscription success row. If the retry ever used the Weave key, we'd see it.

## Fix

When the Claude subscription is suppressed on the Anthropic path and nothing else resolved, return `clearCredentials(ctx)` (explicit nil → client falls back to its deployment key) instead of the stale ctx. Safe because suppression is only set when a fallback key exists (`anthropicFallbackKeyAvailable` gates both callers). Scoped to Anthropic — a Codex sub on the same request still resolves for its OpenAI turn.

## Tests

`subscription_suppression_credential_internal_test.go`:
- suppressed sub on a router-keyed request → credential **cleared** (deployment-key fallback), not the spent token *(fails without this fix)*
- unsuppressed sub → still forwarded (billing regression guard)
- suppressed Claude + Codex sub on an OpenAI turn → Codex still resolves (scope guard)

`go vet` clean, full `internal/proxy` suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)