### PR TITLE
feat(version): surface the router PR number in /v1/version + badge

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -57,6 +57,7 @@ ARG HF_QWEN_REVISION
 # `docker build` with no --build-arg still produces a runnable image.
 ARG ROUTER_SHA=unknown
 ARG ROUTER_BUILD_TIME=unknown
+ARG ROUTER_PR=unknown
 # TARGETARCH is set automatically by buildx (`amd64` or `arm64`) so we
 # can pull the matching native ONNX Runtime + libtokenizers tarball.
 # Without this, building on Apple Silicon / Graviton picks up x86_64
@@ -199,7 +200,7 @@ WORKDIR /app/cmd/router
 RUN --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \
     GOOS=linux go build -tags ORT \
-      -ldflags "-X workweave/router/internal/version.Commit=${ROUTER_SHA} -X workweave/router/internal/version.BuildTime=${ROUTER_BUILD_TIME}" \
+      -ldflags "-X workweave/router/internal/version.Commit=${ROUTER_SHA} -X workweave/router/internal/version.BuildTime=${ROUTER_BUILD_TIME} -X workweave/router/internal/version.PR=${ROUTER_PR}" \
       -o /server
 
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ for *every* request: using a tiny on-box embedder, not a vibes-based prompt.
 [![Go](https://img.shields.io/badge/Go-1.25%2B-00ADD8?logo=go)](go.mod)
 [![Tests](https://github.com/workweave/router/actions/workflows/test.yml/badge.svg)](https://github.com/workweave/router/actions/workflows/test.yml)
 [![License: ELv2](https://img.shields.io/badge/License-ELv2-00BFB3.svg)](https://www.elastic.co/licensing/elastic-license)
-[![Managed deployment](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Frouter.workweave.ai%2Fv1%2Fversion&query=%24.commit_short&label=managed%20deployment&color=EC6341&cacheSeconds=1800)](https://router.workweave.ai/v1/version)
+[![Managed deployment](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Frouter.workweave.ai%2Fv1%2Fversion&query=%24.display&label=managed%20deployment&color=EC6341&cacheSeconds=1800)](https://github.com/workweave/router/deployments)
 
 *Built by [Weave](https://www.workweave.ai): The #1 engineering intelligence platform,
 loved by Robinhood, PostHog, Reducto, and hundreds of others.*

--- a/internal/api/admin/version.go
+++ b/internal/api/admin/version.go
@@ -12,6 +12,8 @@ import (
 type versionResponse struct {
 	Commit         string `json:"commit"`
 	CommitShort    string `json:"commit_short"`
+	PR             string `json:"pr"`
+	Display        string `json:"display"`
 	BuildTime      string `json:"build_time"`
 	ClusterVersion string `json:"cluster_version"`
 }
@@ -25,6 +27,8 @@ func VersionHandler(c *gin.Context) {
 	c.JSON(http.StatusOK, versionResponse{
 		Commit:         version.Commit,
 		CommitShort:    version.ShortCommit(),
+		PR:             version.PR,
+		Display:        version.Display(),
 		BuildTime:      version.BuildTime,
 		ClusterVersion: config.GetOr("ROUTER_CLUSTER_VERSION", "artifacts/latest"),
 	})

--- a/internal/api/admin/version_test.go
+++ b/internal/api/admin/version_test.go
@@ -17,9 +17,10 @@ import (
 func TestVersionHandler(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
-	orig := version.Commit
-	t.Cleanup(func() { version.Commit = orig })
+	origCommit, origPR := version.Commit, version.PR
+	t.Cleanup(func() { version.Commit, version.PR = origCommit, origPR })
 	version.Commit = "0fb46ee9707c8db7d0ef69b7308a79a95d559e25"
+	version.PR = "572"
 	t.Setenv("ROUTER_CLUSTER_VERSION", "v0.71")
 
 	engine := gin.New()
@@ -34,6 +35,8 @@ func TestVersionHandler(t *testing.T) {
 	var body struct {
 		Commit         string `json:"commit"`
 		CommitShort    string `json:"commit_short"`
+		PR             string `json:"pr"`
+		Display        string `json:"display"`
 		BuildTime      string `json:"build_time"`
 		ClusterVersion string `json:"cluster_version"`
 	}
@@ -41,5 +44,7 @@ func TestVersionHandler(t *testing.T) {
 
 	assert.Equal(t, "0fb46ee9707c8db7d0ef69b7308a79a95d559e25", body.Commit)
 	assert.Equal(t, "0fb46ee", body.CommitShort)
+	assert.Equal(t, "572", body.PR)
+	assert.Equal(t, "#572 (0fb46ee)", body.Display)
 	assert.Equal(t, "v0.71", body.ClusterVersion)
 }

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -13,6 +13,10 @@ var (
 	Commit = "unknown"
 	// BuildTime is the RFC3339 UTC build timestamp, stamped the same way.
 	BuildTime = "unknown"
+	// PR is the router pull-request number Commit was merged from (digits only,
+	// no leading "#"), stamped the same way. "unknown" when the commit has no
+	// associated PR (e.g. a direct push, or an un-stamped local build).
+	PR = "unknown"
 )
 
 // ShortCommit returns the 7-character prefix of Commit, or Commit unchanged
@@ -22,4 +26,14 @@ func ShortCommit() string {
 		return Commit
 	}
 	return Commit[:shortLen]
+}
+
+// Display is the human-facing build label for the managed-deployment badge:
+// the PR number plus short commit when the PR is known (e.g. "#572 (886d9df)"),
+// otherwise just the short commit.
+func Display() string {
+	if PR != "" && PR != "unknown" {
+		return "#" + PR + " (" + ShortCommit() + ")"
+	}
+	return ShortCommit()
 }

--- a/internal/version/version_test.go
+++ b/internal/version/version_test.go
@@ -28,3 +28,24 @@ func TestShortCommit(t *testing.T) {
 		})
 	}
 }
+
+func TestDisplay(t *testing.T) {
+	origCommit, origPR := version.Commit, version.PR
+	t.Cleanup(func() { version.Commit, version.PR = origCommit, origPR })
+	version.Commit = "886d9df40857f1fa0d0d0407100dd30127fb6c11"
+
+	tests := map[string]struct {
+		pr   string
+		want string
+	}{
+		"known PR shows number + commit":  {pr: "572", want: "#572 (886d9df)"},
+		"unknown PR falls back to commit": {pr: "unknown", want: "886d9df"},
+		"empty PR falls back to commit":   {pr: "", want: "886d9df"},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			version.PR = tc.pr
+			assert.Equal(t, tc.want, version.Display())
+		})
+	}
+}


### PR DESCRIPTION
Follow-up to #571. The managed-deployment badge showed only the commit SHA; this adds the **PR number** the deployed commit came from.

## What

- `internal/version`: new ldflag-stamped `PR` var + `Display()` → `"#572 (886d9df)"` when the PR is known, else the short commit.
- `GET /v1/version`: adds `pr` and `display` fields.
- `Dockerfile`: `ARG ROUTER_PR` injected via `-ldflags`.
- README badge: reads `$.display` (so it shows `#572 (886d9df)`) and links to the repo's deployments page.

The PR number is resolved at image-build time in WorkWeave's `deploy.yml` (companion PR) via `gh api repos/workweave/router/commits/<sha>/pulls` and passed as the `ROUTER_PR` build arg. Router is public, so it resolves with the default `GITHUB_TOKEN`.

## Test

- `go test ./internal/version/... ./internal/api/admin/...` — pass (new `Display()` cases + handler assertions).
- Verified stamping end-to-end: `ROUTER_PR=572 → "#572 (886d9df)"`; unstamped → falls back to short commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)