### PR TITLE
fix(router): stop using OpenRouter as a platform source in managed mode

### DIFF
--- a/cmd/router/main.go
+++ b/cmd/router/main.go
@@ -229,8 +229,17 @@ func main() {
 
 	{
 		openRouterBaseURL := config.GetOr("OPENROUTER_BASE_URL", openaiCompatProvider.DefaultBaseURL)
+		// Managed deploys don't use OpenRouter as a platform source by default:
+		// we don't read our own OPENROUTER_API_KEY, so it never lands in
+		// envKeyedProviders and the scorer + failover chain won't route platform
+		// traffic to it. A self-hoster running in managed mode can opt back in
+		// with ROUTER_OPENROUTER_PLATFORM_ENABLED=true; self-hosted mode reads the
+		// key unconditionally as before. Either way the provider stays registered
+		// so a caller's BYOK OpenRouter key still dispatches.
+		openRouterPlatformEnabled := deploymentMode == server.DeploymentModeSelfHosted ||
+			config.GetOr("ROUTER_OPENROUTER_PLATFORM_ENABLED", "false") == "true"
 		openRouterKey := ""
-		if !byokOnly {
+		if !byokOnly && openRouterPlatformEnabled {
 			openRouterKey = config.GetOr("OPENROUTER_API_KEY", "")
 		}
 		providerMap[providers.ProviderOpenRouter] = openaiCompatProvider.NewClient(openRouterKey, openRouterBaseURL)
@@ -240,6 +249,8 @@ func main() {
 		case openRouterKey != "":
 			envKeyedProviders[providers.ProviderOpenRouter] = struct{}{}
 			logger.Info("OpenRouter provider enabled", "base_url", openRouterBaseURL)
+		case !openRouterPlatformEnabled:
+			logger.Info("OpenRouter provider registered (BYOK only — managed deploys don't use OpenRouter as a platform source; set ROUTER_OPENROUTER_PLATFORM_ENABLED=true to opt in)", "base_url", openRouterBaseURL)
 		default:
 			logger.Info("OpenRouter provider registered (BYOK only — set OPENROUTER_API_KEY for deployment-level use)", "base_url", openRouterBaseURL)
 		}


### PR DESCRIPTION
## What

**Managed** deploys no longer use OpenRouter as one of *our* platform sources — by default. Self-hosters are unaffected. A self-hoster who runs in managed mode can opt OpenRouter back in with a single env var.

## Why

We want to stop routing Weave's own managed traffic through OpenRouter, while keeping OpenRouter fully available to self-hosters — including the (rare, advanced) case of a self-hoster running in `managed` mode with their own control plane, who can re-enable it explicitly.

## How

One gate at the composition root (`cmd/router/main.go`):

```go
openRouterPlatformEnabled := deploymentMode == server.DeploymentModeSelfHosted ||
    config.GetOr("ROUTER_OPENROUTER_PLATFORM_ENABLED", "false") == "true"
openRouterKey := ""
if !byokOnly && openRouterPlatformEnabled {
    openRouterKey = config.GetOr("OPENROUTER_API_KEY", "")
}
```

Behavior matrix:

| Mode | `ROUTER_OPENROUTER_PLATFORM_ENABLED` | OpenRouter as platform source |
|---|---|---|
| `selfhosted` (default) | — | ✅ read `OPENROUTER_API_KEY` (unchanged) |
| `managed` | unset / `false` | ❌ never (this is Weave's hosted deploy) |
| `managed` | `true` | ✅ opt back in |

When platform use is off in managed mode, OpenRouter never enters `envKeyedProviders` → never in `deploymentKeyedProviders`, so the cluster scorer won't treat it as a candidate and `resolveBindingsForDispatch` won't walk to it as a multi-binding fallback for OSS models (deepseek/qwen/moonshot) — those fail over across Fireworks/DeepInfra/Bedrock instead. The provider stays **registered** in all modes, so a caller's own BYOK OpenRouter key still dispatches.

### Why not `ROUTER_EXCLUDED_PROVIDERS=openrouter`?

That env override *replaces* per-installation DB provider exclusions (`excludedProvidersForRequest`), a live per-org feature in managed — setting it would clobber per-org exclusion state. Gating the key read at boot removes OpenRouter as *our* source without touching the per-installation exclusion path.

## Testing

- `go build ./cmd/router/` ✅
- `go vet ./cmd/router/` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)