### PR TITLE
chore(build): skip the 1 GB Qwen3 embedder pull by default

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,14 @@ ARG HF_MODEL_REVISION=516f4baf13dec4ddddda8631e019b5737c8bc250
 # pull; the runtime constructs embedders lazily, so deploys serving
 # only Jina bundles don't need the asset. Pin HF_QWEN_REVISION to the
 # upload commit SHA printed by the export script. Bump deliberately.
-ARG HF_QWEN_REPO=weave-eng/qwen3-embedding-0.6b-onnx-router
+#
+# Default is empty: the Qwen3 model.onnx is ~1 GB and pulls from HF at
+# ~6 MB/s (~3 min), which dominates the whole image build. No committed
+# bundle uses this embedder (every artifacts/v* declares
+# embedder_model: jina-v2-base-code-int8), so the runtime never loads
+# it. Re-set this to weave-eng/qwen3-embedding-0.6b-onnx-router if a
+# Qwen-embedder bundle is ever promoted to `latest`.
+ARG HF_QWEN_REPO=
 ARG HF_QWEN_REVISION=a43740ed1bb6436deaa4b79c9a132a3d98756ace
 
 # --- Stage 1: build the Next.js mini UI ---


### PR DESCRIPTION
## What

Default `ARG HF_QWEN_REPO=` to empty so the image build stops pulling the Qwen3 embedder from HuggingFace.

## Why

Profiling a router deploy build (Depot), one layer dominates everything else:

```
+ curl .../weave-eng/qwen3-embedding-0.6b-onnx-router/.../model.onnx
#22 1.852 → #22 184.9        ← 183 seconds
model.onnx  1,042,047,545 bytes   ← 1.04 GB
```

The Qwen3 `model.onnx` is ~1 GB and HF serves it at ~6 MB/s, so that single `curl` is ~183s — the entire difference between a ~70s cache-warm build and a ~290s cold one (the Jina model, 162 MB, pulls in <1s by comparison; the Go/CGO compile is cache-hit).

**Nothing uses this asset.** Every committed bundle (`artifacts/v0.53`–`v0.79`) declares `embedder_model: jina-v2-base-code-int8`, and `EmbedderSet.Get` (`embedder_onnx.go`) constructs a model lazily only for embedder IDs that *built* bundles reference. So the Qwen3 model is never loaded at runtime — not in prod (default bundle only) and not in staging (`BUILD_ALL_VERSIONS=true`, but still no bundle names it). It's pure dead weight in the image and re-downloaded on every uncached build.

## Impact

- Cold builds drop from ~250–290s to ~70–100s.
- ~1 GB off the image → faster registry push + faster Cloud Run cold-start pulls.
- **Zero behavior change** — no code path loads this embedder today.

The Dockerfile already documented this as the skip switch ("Set `HF_QWEN_REPO=` (empty) to skip the pull"); this just makes empty the default. Re-set the ARG to `weave-eng/qwen3-embedding-0.6b-onnx-router` if a Qwen-embedder bundle is ever promoted to `latest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)