### PR TITLE
Treat client history trims as free-switch windows and add cold-pin follow-fresh lever

### DIFF
--- a/cmd/router/main.go
+++ b/cmd/router/main.go
@@ -645,7 +645,12 @@ func main() {
 		ThresholdUSD:           parseEnvFloat("ROUTER_SWITCH_EV_THRESHOLD_USD", proxy.DefaultPlannerThresholdUSD),
 		ExpectedRemainingTurns: parseEnvInt("ROUTER_SWITCH_EXPECTED_REMAINING_TURNS", proxy.DefaultPlannerExpectedRemainingTurns),
 		TierUpgradeEnabled:     config.GetOr("ROUTER_SWITCH_TIER_UPGRADE_ENABLED", boolDefault(proxy.DefaultPlannerTierUpgradeEnabled)) == "true",
+		ColdPinFollowFresh:     config.GetOr("ROUTER_SWITCH_COLD_PIN_FOLLOW_FRESH", boolDefault(proxy.DefaultPlannerColdPinFollowFresh)) == "true",
 	}
+	// Prefix-trim free-switch: on a detected client history trim, price the
+	// pin's cache as cold and skip the switch handover. On by default (both
+	// effects are accuracy corrections); this is the kill switch.
+	prefixTrimFreeSwitch := config.GetOr("ROUTER_PREFIX_TRIM_FREE_SWITCH", "true") == "true"
 	handoverProviderName := config.GetOr("ROUTER_HANDOVER_PROVIDER", providers.ProviderAnthropic)
 	handoverModel := config.GetOr("ROUTER_HANDOVER_MODEL", proxy.DefaultHandoverModel)
 	handoverTimeout := parseEnvDurationMs("ROUTER_HANDOVER_TIMEOUT_MS", proxy.DefaultHandoverTimeout)
@@ -740,6 +745,7 @@ func main() {
 		WithPassthroughEligibleProviders(passthroughEligible).
 		WithHardPinResolver(hardPinResolver).
 		WithPlannerEnabled(plannerEnabled).
+		WithPrefixTrimFreeSwitch(prefixTrimFreeSwitch).
 		WithEffortEscalation(effortEscalation).
 		WithBandSwap(bandSwapEnabled).
 		WithLoopEscalationConfig(loopEscalationEnabled, loopEscalationHoldoutPct).
@@ -755,7 +761,7 @@ func main() {
 	logger.Info("Effort escalation configured", "enabled", effortEscalation)
 	logger.Info("Loop escalation configured", "enabled", loopEscalationEnabled, "holdout_pct", loopEscalationHoldoutPct)
 	logger.Info("Spiral shadow detector configured", "enabled", spiralShadowEnabled)
-	logger.Info("Planner configured", "enabled", plannerEnabled, "threshold_usd", plannerCfg.ThresholdUSD, "expected_remaining_turns", plannerCfg.ExpectedRemainingTurns, "tier_upgrade_enabled", plannerCfg.TierUpgradeEnabled, "available_models_count", len(availableModels))
+	logger.Info("Planner configured", "enabled", plannerEnabled, "threshold_usd", plannerCfg.ThresholdUSD, "expected_remaining_turns", plannerCfg.ExpectedRemainingTurns, "tier_upgrade_enabled", plannerCfg.TierUpgradeEnabled, "cold_pin_follow_fresh", plannerCfg.ColdPinFollowFresh, "prefix_trim_free_switch", prefixTrimFreeSwitch, "available_models_count", len(availableModels))
 
 	// Fail loud if a deployed model is missing from the tier table;
 	// TierUnknown would silently disable the guard for that pair.

--- a/cmd/router/main.go
+++ b/cmd/router/main.go
@@ -647,9 +647,6 @@ func main() {
 		TierUpgradeEnabled:     config.GetOr("ROUTER_SWITCH_TIER_UPGRADE_ENABLED", boolDefault(proxy.DefaultPlannerTierUpgradeEnabled)) == "true",
 		ColdPinFollowFresh:     config.GetOr("ROUTER_SWITCH_COLD_PIN_FOLLOW_FRESH", boolDefault(proxy.DefaultPlannerColdPinFollowFresh)) == "true",
 	}
-	// Prefix-trim free-switch: on a detected client history trim, price the
-	// pin's cache as cold and skip the switch handover. On by default (both
-	// effects are accuracy corrections); this is the kill switch.
 	prefixTrimFreeSwitch := config.GetOr("ROUTER_PREFIX_TRIM_FREE_SWITCH", "true") == "true"
 	handoverProviderName := config.GetOr("ROUTER_HANDOVER_PROVIDER", providers.ProviderAnthropic)
 	handoverModel := config.GetOr("ROUTER_HANDOVER_MODEL", proxy.DefaultHandoverModel)

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -63,11 +63,8 @@ type Service struct {
 	compaction *compactionTracker
 	// prefixTrimFreeSwitch treats a detected client history trim as a
 	// free-switch window: the planner prices the pin's cache as cold on that
-	// turn (the rewritten prefix makes the old cache unreachable regardless of
-	// TTL) and the switch handover is skipped (the client's own compaction
-	// summary already bounds the body). Kill switch:
-	// ROUTER_PREFIX_TRIM_FREE_SWITCH; defaults to true because both effects
-	// are accuracy corrections, not new policy.
+	// turn and the switch handover is skipped. Kill switch:
+	// ROUTER_PREFIX_TRIM_FREE_SWITCH.
 	prefixTrimFreeSwitch bool
 	// hardPinExplore gates the Explore sub-agent hard-pin.
 	hardPinExplore bool
@@ -832,9 +829,8 @@ const DefaultPlannerExpectedRemainingTurns = 3
 // turn can't pin a Low-tier model for the session.
 const DefaultPlannerTierUpgradeEnabled = true
 
-// DefaultPlannerColdPinFollowFresh ships the cold-pin follow-fresh lever off:
-// it flips lateral/downgrade switches on for cold pins, so it must first be
-// sized against the planner_* shadow telemetry before it's armed.
+// DefaultPlannerColdPinFollowFresh ships off: size it against the planner_*
+// shadow telemetry before arming.
 const DefaultPlannerColdPinFollowFresh = false
 
 func NewService(r router.Router, providerMap map[string]providers.Client, emitter *otel.Emitter, embedOnlyUserMessage bool, semanticCache *cache.Cache, pinStore sessionpin.Store, hardPinExplore bool, hardPinProvider, hardPinModel string, telemetry TelemetryRepository) *Service {
@@ -885,8 +881,7 @@ func (s *Service) WithPlannerEnabled(enabled bool) *Service {
 }
 
 // WithPrefixTrimFreeSwitch is the kill switch for the prefix-trim free-switch
-// window (cold cache pricing + handover skip on client history trims).
-// Detection and the post-routing compaction handover are unaffected.
+// window. Detection and the post-routing compaction handover are unaffected.
 func (s *Service) WithPrefixTrimFreeSwitch(enabled bool) *Service {
 	s.prefixTrimFreeSwitch = enabled
 	return s
@@ -1829,17 +1824,10 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 	// rewrite the envelope with a handover summary before dispatch.
 	compactionHandoverRan := false
 	var compactionHandoverOutcome handoverOutcome
-	// Detection (compaction.checkAndRecord) now runs inside runTurnLoop, before
-	// routing, so the planner can price the pin's cache as cold on the trim
-	// turn; routeRes.PrefixTrimmed carries the verdict here. Re-recording in
-	// this block would compare this turn's counts against themselves and never
-	// fire. Hard-pinned turn types never reach the turnloop's detection (their
-	// small bodies would mimic trims), so the HardPinned guard below is
-	// belt-and-suspenders — PrefixTrimmed is always false for them.
-	//
-	// Skip when the planner already ran a model-switch handover for this turn
-	// (routeRes.Handover.Invoked). Applying runCompactionHandover on top of an
-	// already-rewritten envelope would double-trim it.
+	// Detection runs pre-routing in runTurnLoop; routeRes.PrefixTrimmed carries
+	// the verdict (re-recording here would compare this turn's counts against
+	// themselves and never fire). Skip when a model-switch handover already
+	// rewrote the envelope this turn — a second rewrite would double-trim it.
 	if decision.Provider != providers.ProviderAnthropic && !routeRes.HardPinned && !routeRes.Handover.Invoked && routeRes.PrefixTrimmed {
 		log.Info("Context trimming detected on non-Anthropic route; rewriting context with handover summary",
 			"message_count", feats.MessageCount,

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -61,6 +61,14 @@ type Service struct {
 	// drops) so the router can rewrite non-Anthropic requests with a handover
 	// summary before the model loses awareness of prior completed work.
 	compaction *compactionTracker
+	// prefixTrimFreeSwitch treats a detected client history trim as a
+	// free-switch window: the planner prices the pin's cache as cold on that
+	// turn (the rewritten prefix makes the old cache unreachable regardless of
+	// TTL) and the switch handover is skipped (the client's own compaction
+	// summary already bounds the body). Kill switch:
+	// ROUTER_PREFIX_TRIM_FREE_SWITCH; defaults to true because both effects
+	// are accuracy corrections, not new policy.
+	prefixTrimFreeSwitch bool
 	// hardPinExplore gates the Explore sub-agent hard-pin.
 	hardPinExplore bool
 	// hardPinProvider/hardPinModel route compaction (and, when hardPinExplore is
@@ -824,6 +832,11 @@ const DefaultPlannerExpectedRemainingTurns = 3
 // turn can't pin a Low-tier model for the session.
 const DefaultPlannerTierUpgradeEnabled = true
 
+// DefaultPlannerColdPinFollowFresh ships the cold-pin follow-fresh lever off:
+// it flips lateral/downgrade switches on for cold pins, so it must first be
+// sized against the planner_* shadow telemetry before it's armed.
+const DefaultPlannerColdPinFollowFresh = false
+
 func NewService(r router.Router, providerMap map[string]providers.Client, emitter *otel.Emitter, embedOnlyUserMessage bool, semanticCache *cache.Cache, pinStore sessionpin.Store, hardPinExplore bool, hardPinProvider, hardPinModel string, telemetry TelemetryRepository) *Service {
 	return &Service{
 		router:               r,
@@ -834,6 +847,7 @@ func NewService(r router.Router, providerMap map[string]providers.Client, emitte
 		pinStore:             pinStore,
 		noProgress:           newNoProgressTracker(),
 		compaction:           newCompactionTracker(),
+		prefixTrimFreeSwitch: true,
 		spiralTracker:        newSpiralTracker(),
 		spiralShadowEnabled:  true,
 		hardPinExplore:       hardPinExplore,
@@ -859,6 +873,7 @@ func (s *Service) WithPlanner(cfg planner.EVConfig) *Service {
 		s.planner.ExpectedRemainingTurns = cfg.ExpectedRemainingTurns
 	}
 	s.planner.TierUpgradeEnabled = cfg.TierUpgradeEnabled
+	s.planner.ColdPinFollowFresh = cfg.ColdPinFollowFresh
 	return s
 }
 
@@ -866,6 +881,14 @@ func (s *Service) WithPlanner(cfg planner.EVConfig) *Service {
 // preserves first-decision-wins behavior.
 func (s *Service) WithPlannerEnabled(enabled bool) *Service {
 	s.plannerEnabled = enabled
+	return s
+}
+
+// WithPrefixTrimFreeSwitch is the kill switch for the prefix-trim free-switch
+// window (cold cache pricing + handover skip on client history trims).
+// Detection and the post-routing compaction handover are unaffected.
+func (s *Service) WithPrefixTrimFreeSwitch(enabled bool) *Service {
+	s.prefixTrimFreeSwitch = enabled
 	return s
 }
 
@@ -1806,29 +1829,26 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 	// rewrite the envelope with a handover summary before dispatch.
 	compactionHandoverRan := false
 	var compactionHandoverOutcome handoverOutcome
-	// Skip detection for all hard-pinned turn types (Compaction, Probe, TitleGen,
-	// Classifier, SubAgentDispatch with hardPinExplore). These turns carry far
-	// fewer messages than main-loop turns — a Probe or TitleGen after a long
-	// session would show a sharp count drop that mimics client history trimming
-	// and falsely trigger runCompactionHandover. Hard-pinned turns also do not
-	// model the conversational context the compaction handover is meant to
-	// preserve, so rewrites there would be both wrong and wasteful.
+	// Detection (compaction.checkAndRecord) now runs inside runTurnLoop, before
+	// routing, so the planner can price the pin's cache as cold on the trim
+	// turn; routeRes.PrefixTrimmed carries the verdict here. Re-recording in
+	// this block would compare this turn's counts against themselves and never
+	// fire. Hard-pinned turn types never reach the turnloop's detection (their
+	// small bodies would mimic trims), so the HardPinned guard below is
+	// belt-and-suspenders — PrefixTrimmed is always false for them.
 	//
-	// Also skip when the planner already ran a model-switch handover for this
-	// turn (routeRes.Handover.Invoked). Applying runCompactionHandover on top of
-	// an already-rewritten envelope would double-trim it.
-	if decision.Provider != providers.ProviderAnthropic && s.compaction != nil && !routeRes.HardPinned && !routeRes.Handover.Invoked {
-		role := roleForTier(catalog.TierFor(feats.Model))
-		if s.compaction.checkAndRecord(routeRes.SessionKey, installationID, role, feats.MessageCount, inboundToolCallCount) {
-			log.Info("Context trimming detected on non-Anthropic route; rewriting context with handover summary",
-				"message_count", feats.MessageCount,
-				"tool_call_count", inboundToolCallCount,
-				"decision_model", decision.Model,
-				"decision_provider", decision.Provider,
-			)
-			compactionHandoverOutcome = s.runCompactionHandover(ctx, env, r.Header, decision.Model)
-			compactionHandoverRan = true
-		}
+	// Skip when the planner already ran a model-switch handover for this turn
+	// (routeRes.Handover.Invoked). Applying runCompactionHandover on top of an
+	// already-rewritten envelope would double-trim it.
+	if decision.Provider != providers.ProviderAnthropic && !routeRes.HardPinned && !routeRes.Handover.Invoked && routeRes.PrefixTrimmed {
+		log.Info("Context trimming detected on non-Anthropic route; rewriting context with handover summary",
+			"message_count", feats.MessageCount,
+			"tool_call_count", inboundToolCallCount,
+			"decision_model", decision.Model,
+			"decision_provider", decision.Provider,
+		)
+		compactionHandoverOutcome = s.runCompactionHandover(ctx, env, r.Header, decision.Model)
+		compactionHandoverRan = true
 	}
 
 	// Semantic-cache eligibility: configured, non-streaming, decision has

--- a/internal/proxy/turnloop.go
+++ b/internal/proxy/turnloop.go
@@ -93,6 +93,14 @@ type turnLoopResult struct {
 	// x-weave-suggestion-mode header. The routing marker is suppressed so
 	// the badge does not appear in suggestion-overlay responses.
 	SuggestionMode bool
+	// PrefixTrimmed is true when the compaction tracker detected a client-side
+	// history trim on THIS turn (full compaction or rolling-window trimming)
+	// relative to the session's previous observation. Detected before routing
+	// so the planner can price the pin's now-unreachable cache as cold and the
+	// switch handover can be skipped (the client's own compaction summary is
+	// already in the body). ProxyMessages also reads it post-routing to run
+	// the non-Anthropic compaction handover without re-recording the tracker.
+	PrefixTrimmed bool
 	// EscalateEffort is true when the previous turn in this session looked like
 	// an observable failure (produced no output, or the pin carried a consecutive
 	// upstream error). The escalate-on-failure effort policy reads it to bump a
@@ -230,6 +238,40 @@ func (s *Service) runTurnLoop(
 		return res, nil
 	}
 
+	// sessionKey is local until the pin store is known to exist:
+	// res.SessionKey must stay zero in no-pin-store mode — downstream
+	// consumers (sessionAffinityHint, the spiral/telemetry join comment in
+	// ProxyMessages) rely on that invariant — but trim detection needs the
+	// key either way.
+	sessionKey := DeriveSessionKey(env, apiKeyID)
+
+	// Prefix-trim detection runs BEFORE routing (previously it ran after, and
+	// only on non-Anthropic decisions) so the planner can price the pin's
+	// cache as dead on the very turn the client broke the prompt prefix: a
+	// compaction or rolling-window trim rewrites the transcript head, so the
+	// upstream cache entries keyed on the old prefix are unreachable no matter
+	// how recently the pin served. Hard-pinned turn types never reach this
+	// point (their small bodies would poison the tracker's baselines, same
+	// rationale as the post-routing guard this detection used to live behind).
+	// env has not been rewritten yet, so the counts match what the client sent.
+	// ProxyMessages consumes res.PrefixTrimmed for the post-routing compaction
+	// handover instead of re-recording (a second checkAndRecord on the same
+	// turn would compare the counts against themselves and always miss).
+	res.PrefixTrimmed = s.compaction.checkAndRecord(
+		sessionKey, installationID, res.PinRole,
+		feats.MessageCount, len(env.AssistantToolCallSignatures()),
+	)
+	// prefixTrimFreeSwitch gates the ACTIONS on the signal (cold pricing +
+	// handover skip below); detection/recording itself is unconditional so the
+	// post-routing compaction handover keeps working when the lever is off.
+	prefixBroken := s.prefixTrimFreeSwitch && res.PrefixTrimmed
+	if res.PrefixTrimmed {
+		log.Info("turnloop detected client history trim",
+			"message_count", feats.MessageCount,
+			"free_switch_armed", prefixBroken,
+		)
+	}
+
 	// Without a pin store, run the scorer and return its decision. The usage
 	// bypass intercepts the fresh scorer decision here too (no pins to honor).
 	if s.pinStore == nil {
@@ -247,7 +289,7 @@ func (s *Service) runTurnLoop(
 		return res, nil
 	}
 
-	res.SessionKey = DeriveSessionKey(env, apiKeyID)
+	res.SessionKey = sessionKey
 
 	pin, pinFound := s.loadPin(ctx, res.SessionKey, res.PinRole)
 	res.PriorServedModel = pin.LastServedModel
@@ -622,7 +664,10 @@ func (s *Service) runTurnLoop(
 		Fresh:                fresh,
 		EstimatedInputTokens: feats.Tokens,
 		AvailableModels:      s.availableModels,
-		PinCacheCold:         pinFound && !cacheWarm(pin),
+		// A trimmed prefix kills the cache even inside the provider TTL: the
+		// upstream cache is keyed on the (now rewritten) prompt prefix, so a
+		// recent LastTurnEndedAt proves nothing about reuse on this turn.
+		PinCacheCold: pinFound && (!cacheWarm(pin) || prefixBroken),
 		// Price covered models at their subsidized marginal cost in the EV math
 		// too, so the discount takes effect on sticky (pinned) sessions, not just
 		// the fresh decision. nil when subscription-aware routing is off.
@@ -662,7 +707,21 @@ func (s *Service) runTurnLoop(
 	// Only when the request is BYOK/client-keyed AND no matching creds for
 	// the summarizer's provider were forwarded do we skip summarization and
 	// pass the full history through.
-	if pinFound {
+	if pinFound && prefixBroken {
+		// Free-switch window: the client just compacted/trimmed its own
+		// history, so the body already carries the client's summary of the
+		// elided turns and is as small as it will ever be. Running the switch
+		// summarizer here would summarize that summary — pure cost, no context
+		// preserved that the compacted body doesn't already have. Skip it and
+		// forward the compacted body unchanged. (For a non-Anthropic decision
+		// the post-routing compaction handover in ProxyMessages may still
+		// rewrite — exactly one rewrite either way.)
+		log.Info("Handover summarizer skipped: client history trim already bounded this switch turn",
+			"pin_model", pin.Model,
+			"fresh_model", fresh.Model,
+		)
+	}
+	if pinFound && !prefixBroken {
 		var (
 			sumProvider       string
 			sumCreds          *Credentials

--- a/internal/proxy/turnloop.go
+++ b/internal/proxy/turnloop.go
@@ -94,12 +94,9 @@ type turnLoopResult struct {
 	// the badge does not appear in suggestion-overlay responses.
 	SuggestionMode bool
 	// PrefixTrimmed is true when the compaction tracker detected a client-side
-	// history trim on THIS turn (full compaction or rolling-window trimming)
-	// relative to the session's previous observation. Detected before routing
-	// so the planner can price the pin's now-unreachable cache as cold and the
-	// switch handover can be skipped (the client's own compaction summary is
-	// already in the body). ProxyMessages also reads it post-routing to run
-	// the non-Anthropic compaction handover without re-recording the tracker.
+	// history trim on this turn. Detected before routing so the planner can
+	// price the pin's cache as cold; ProxyMessages also reads it post-routing
+	// for the compaction handover without re-recording the tracker.
 	PrefixTrimmed bool
 	// EscalateEffort is true when the previous turn in this session looked like
 	// an observable failure (produced no output, or the pin carried a consecutive
@@ -238,32 +235,20 @@ func (s *Service) runTurnLoop(
 		return res, nil
 	}
 
-	// sessionKey is local until the pin store is known to exist:
-	// res.SessionKey must stay zero in no-pin-store mode — downstream
-	// consumers (sessionAffinityHint, the spiral/telemetry join comment in
-	// ProxyMessages) rely on that invariant — but trim detection needs the
-	// key either way.
+	// res.SessionKey must stay zero in no-pin-store mode, but trim detection
+	// needs the key either way.
 	sessionKey := DeriveSessionKey(env, apiKeyID)
 
-	// Prefix-trim detection runs BEFORE routing (previously it ran after, and
-	// only on non-Anthropic decisions) so the planner can price the pin's
-	// cache as dead on the very turn the client broke the prompt prefix: a
-	// compaction or rolling-window trim rewrites the transcript head, so the
-	// upstream cache entries keyed on the old prefix are unreachable no matter
-	// how recently the pin served. Hard-pinned turn types never reach this
-	// point (their small bodies would poison the tracker's baselines, same
-	// rationale as the post-routing guard this detection used to live behind).
-	// env has not been rewritten yet, so the counts match what the client sent.
-	// ProxyMessages consumes res.PrefixTrimmed for the post-routing compaction
-	// handover instead of re-recording (a second checkAndRecord on the same
-	// turn would compare the counts against themselves and always miss).
+	// Trim detection runs before routing so the planner can price the pin's
+	// cache as dead on the turn the client rewrote the prompt prefix. env has
+	// not been rewritten yet, so the counts match what the client sent.
 	res.PrefixTrimmed = s.compaction.checkAndRecord(
 		sessionKey, installationID, res.PinRole,
 		feats.MessageCount, len(env.AssistantToolCallSignatures()),
 	)
-	// prefixTrimFreeSwitch gates the ACTIONS on the signal (cold pricing +
-	// handover skip below); detection/recording itself is unconditional so the
-	// post-routing compaction handover keeps working when the lever is off.
+	// prefixTrimFreeSwitch gates the actions only; detection stays
+	// unconditional so the post-routing compaction handover keeps working
+	// when the lever is off.
 	prefixBroken := s.prefixTrimFreeSwitch && res.PrefixTrimmed
 	if res.PrefixTrimmed {
 		log.Info("turnloop detected client history trim",
@@ -611,12 +596,9 @@ func (s *Service) runTurnLoop(
 	//   (g) this turn does NOT carry images if the prior model is text-only
 	//       (image guard mirrors the live-pin check above — re-anchoring a
 	//       text-only model on an image-bearing turn would immediately 4xx)
-	//   (h) the client did NOT trim its history this turn (prefix-trim
-	//       free-switch armed) — re-anchoring exists to avoid noise-driven
-	//       lateral switches, but a trim turn is a genuine free-switch
-	//       boundary: the prior model's cache is dead regardless of the pin's
-	//       expiry, so the scorer's fresh pick should win, mirroring the
-	//       cold-pricing the planner applies on the live-pin path below.
+	//   (h) the client did NOT trim its history this turn — a trim kills the
+	//       prior model's cache regardless of pin expiry, so the scorer's
+	//       fresh pick should win
 	// When re-anchoring, write a new pin so the next turn is a sticky hit.
 	if !pinFound && pin.Model != "" && !prefixBroken {
 		pinTier := catalog.TierFor(pin.Model)
@@ -670,9 +652,7 @@ func (s *Service) runTurnLoop(
 		Fresh:                fresh,
 		EstimatedInputTokens: feats.Tokens,
 		AvailableModels:      s.availableModels,
-		// A trimmed prefix kills the cache even inside the provider TTL: the
-		// upstream cache is keyed on the (now rewritten) prompt prefix, so a
-		// recent LastTurnEndedAt proves nothing about reuse on this turn.
+		// A trimmed prefix kills the cache even inside the provider TTL.
 		PinCacheCold: pinFound && (!cacheWarm(pin) || prefixBroken),
 		// Price covered models at their subsidized marginal cost in the EV math
 		// too, so the discount takes effect on sticky (pinned) sessions, not just
@@ -714,14 +694,9 @@ func (s *Service) runTurnLoop(
 	// the summarizer's provider were forwarded do we skip summarization and
 	// pass the full history through.
 	if pinFound && prefixBroken {
-		// Free-switch window: the client just compacted/trimmed its own
-		// history, so the body already carries the client's summary of the
-		// elided turns and is as small as it will ever be. Running the switch
-		// summarizer here would summarize that summary — pure cost, no context
-		// preserved that the compacted body doesn't already have. Skip it and
-		// forward the compacted body unchanged. (For a non-Anthropic decision
-		// the post-routing compaction handover in ProxyMessages may still
-		// rewrite — exactly one rewrite either way.)
+		// The client just trimmed its own history: the body already carries
+		// its compaction summary and is as small as it gets. Summarizing it
+		// again is pure cost, so forward it unchanged.
 		log.Info("Handover summarizer skipped: client history trim already bounded this switch turn",
 			"pin_model", pin.Model,
 			"fresh_model", fresh.Model,

--- a/internal/proxy/turnloop.go
+++ b/internal/proxy/turnloop.go
@@ -611,8 +611,14 @@ func (s *Service) runTurnLoop(
 	//   (g) this turn does NOT carry images if the prior model is text-only
 	//       (image guard mirrors the live-pin check above — re-anchoring a
 	//       text-only model on an image-bearing turn would immediately 4xx)
+	//   (h) the client did NOT trim its history this turn (prefix-trim
+	//       free-switch armed) — re-anchoring exists to avoid noise-driven
+	//       lateral switches, but a trim turn is a genuine free-switch
+	//       boundary: the prior model's cache is dead regardless of the pin's
+	//       expiry, so the scorer's fresh pick should win, mirroring the
+	//       cold-pricing the planner applies on the live-pin path below.
 	// When re-anchoring, write a new pin so the next turn is a sticky hit.
-	if !pinFound && pin.Model != "" {
+	if !pinFound && pin.Model != "" && !prefixBroken {
 		pinTier := catalog.TierFor(pin.Model)
 		freshTier := catalog.TierFor(fresh.Model)
 		if pinTier != catalog.TierUnknown && freshTier != catalog.TierUnknown && freshTier <= pinTier {

--- a/internal/proxy/turnloop_test.go
+++ b/internal/proxy/turnloop_test.go
@@ -492,9 +492,8 @@ func TestTurnLoop_UsageWritebackPersistsCacheStats(t *testing.T) {
 }
 
 // trimSessionTurn builds a main-loop Anthropic body with msgCount alternating
-// user/assistant text messages (msgCount must be odd so the turn trails with
-// user text, not a tool_result). The first user message is constant so every
-// turn derives the same session key — the compaction tracker's bucket.
+// user/assistant messages. The first user message is constant so every turn
+// derives the same session key (the compaction tracker's bucket).
 func trimSessionTurn(t *testing.T, msgCount int) []byte {
 	t.Helper()
 	require.True(t, msgCount%2 == 1, "odd msgCount keeps the trailing message a user turn")
@@ -506,17 +505,13 @@ func trimSessionTurn(t *testing.T, msgCount int) []byte {
 		}
 		msgs = append(msgs, `{"role":"`+role+`","content":"TRIM-SESSION turn `+itoa(i)+`"}`)
 	}
-	// messages.0 is identical across turns; only the tail varies.
 	msgs[0] = `{"role":"user","content":"TRIM-SESSION refactor the dispatch loop"}`
 	return []byte(`{"model":"claude-opus-4-7","system":"sys","messages":[` + strings.Join(msgs, ",") + `]}`)
 }
 
-// warmOpusPin is a pin whose prior turn billed ~1.5k input tokens and ended
-// seconds ago (warm). At that size an opus→haiku switch is EV-negative under
-// warm pricing (net ≈ $0.00081 < $0.001 threshold) but strongly EV-positive
-// under cold pricing (≈ $0.0189, eviction $0) — so the same session flips
-// verdicts purely on the warmth assumption, which is what the prefix-trim
-// tests need to observe.
+// warmOpusPin's prior turn billed 1.5k input tokens seconds ago. At that size
+// an opus→haiku switch is EV-negative under warm pricing but EV-positive under
+// cold pricing, so the verdict flips purely on the warmth assumption.
 func warmOpusPin() sessionpin.Pin {
 	return sessionpin.Pin{
 		Provider:        providers.ProviderAnthropic,
@@ -528,12 +523,9 @@ func warmOpusPin() sessionpin.Pin {
 	}
 }
 
-// TestTurnLoop_PrefixTrimPricesPinColdAndSkipsSummarizer is the free-switch
-// window end-to-end: a client history trim (9 → 3 messages on one session)
-// must make the planner price the warm pin's cache as dead — flipping an
-// otherwise EV-negative stay into a switch — and must NOT invoke the switch
-// summarizer, because the client's own compaction summary already bounds the
-// forwarded body.
+// A client history trim must make the planner price the warm pin's cache as
+// dead — flipping an otherwise EV-negative stay into a switch — without
+// invoking the switch summarizer.
 func TestTurnLoop_PrefixTrimPricesPinColdAndSkipsSummarizer(t *testing.T) {
 	store := newFakePinStore()
 	store.hasPin = true
@@ -543,16 +535,14 @@ func TestTurnLoop_PrefixTrimPricesPinColdAndSkipsSummarizer(t *testing.T) {
 	svc := newPinSvc(fr, store).WithSummarizer(sz)
 	ctx := authedCtx(uuid.New().String())
 
-	// Turn 1 (9 messages) records the compaction baseline. Warm pricing keeps
-	// the EV under threshold, so the planner stays on the opus pin.
+	// Turn 1 (9 messages) records the compaction baseline.
 	rec1 := httptest.NewRecorder()
 	req1 := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(""))
 	require.NoError(t, svc.ProxyMessages(ctx, trimSessionTurn(t, 9), rec1, req1))
 	require.Equal(t, "claude-opus-4-7", rec1.Header().Get(proxy.HeaderRouterModel),
 		"warm pin under the EV threshold must stay on turn 1")
 
-	// Turn 2 drops to 3 messages: a full-compaction trim. Cold pricing makes
-	// the switch strongly EV-positive.
+	// Turn 2 drops to 3 messages: a full-compaction trim.
 	rec2 := httptest.NewRecorder()
 	req2 := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(""))
 	require.NoError(t, svc.ProxyMessages(ctx, trimSessionTurn(t, 3), rec2, req2))
@@ -562,10 +552,8 @@ func TestTurnLoop_PrefixTrimPricesPinColdAndSkipsSummarizer(t *testing.T) {
 		"switch on a trim turn must skip the summarizer — the client's compaction summary already bounds the body")
 }
 
-// TestTurnLoop_PrefixTrimKillSwitchPreservesWarmStay proves
-// ROUTER_PREFIX_TRIM_FREE_SWITCH=false restores today's behavior: the trim is
-// still detected and recorded (the post-routing compaction handover depends on
-// that), but the planner keeps pricing the pin warm and stays.
+// With the kill switch off, the trim is still detected and recorded but the
+// planner keeps pricing the pin warm and stays.
 func TestTurnLoop_PrefixTrimKillSwitchPreservesWarmStay(t *testing.T) {
 	store := newFakePinStore()
 	store.hasPin = true
@@ -588,11 +576,8 @@ func TestTurnLoop_PrefixTrimKillSwitchPreservesWarmStay(t *testing.T) {
 	assert.Equal(t, int32(0), sz.calls.Load())
 }
 
-// TestTurnLoop_PrefixTrimSkipsExpiredPinReAnchor guards guard (h) on the
-// expired-pin re-anchor: re-anchoring exists to damp noise-driven lateral
-// switches on the one expiry turn, but a trim turn is a genuine free-switch
-// boundary — the prior model's cache is dead regardless of pin expiry — so the
-// scorer's fresh pick must win instead of the expired pin's model.
+// A trim turn must skip the expired-pin re-anchor (guard (h)): the prior
+// model's cache is dead regardless of pin expiry, so the fresh pick wins.
 func TestTurnLoop_PrefixTrimSkipsExpiredPinReAnchor(t *testing.T) {
 	store := newFakePinStore()
 	store.hasPin = true
@@ -606,17 +591,14 @@ func TestTurnLoop_PrefixTrimSkipsExpiredPinReAnchor(t *testing.T) {
 	})
 	ctx := authedCtx(uuid.New().String())
 
-	// Turn 1 (9 messages, no trim): the expired pin re-anchors — haiku is not
-	// a tier upgrade over opus, opus is routable — proving the re-anchor path
-	// is live in this harness before the trim turn bypasses it.
+	// Turn 1 (9 messages, no trim): the expired pin re-anchors, proving the
+	// re-anchor path is live before the trim turn bypasses it.
 	rec1 := httptest.NewRecorder()
 	req1 := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(""))
 	require.NoError(t, svc.ProxyMessages(ctx, trimSessionTurn(t, 9), rec1, req1))
 	require.Equal(t, "claude-opus-4-7", rec1.Header().Get(proxy.HeaderRouterModel),
 		"expired pin must re-anchor on a normal turn (guard baseline)")
 
-	// Turn 2 (3 messages): trim detected → re-anchor skipped → the scorer's
-	// fresh pick serves.
 	rec2 := httptest.NewRecorder()
 	req2 := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(""))
 	require.NoError(t, svc.ProxyMessages(ctx, trimSessionTurn(t, 3), rec2, req2))
@@ -624,11 +606,8 @@ func TestTurnLoop_PrefixTrimSkipsExpiredPinReAnchor(t *testing.T) {
 		"trim turn must skip the expired-pin re-anchor and follow the fresh pick")
 }
 
-// TestTurnLoop_SubAgentDoesNotInheritMainLoopTrimBaseline guards sub-agent
-// independence: a sub-agent's opening turn (small message count, distinct
-// first user message) derives its own session key, so it lands in its own
-// compaction bucket and must NOT read as a trim of the main loop's 9-message
-// baseline — which would falsely cold-price the sub-agent's pin.
+// A sub-agent's small opening turn derives its own session key and compaction
+// bucket, so it must not read as a trim of the main loop's baseline.
 func TestTurnLoop_SubAgentDoesNotInheritMainLoopTrimBaseline(t *testing.T) {
 	store := newFakePinStore()
 	store.hasPin = true
@@ -638,15 +617,11 @@ func TestTurnLoop_SubAgentDoesNotInheritMainLoopTrimBaseline(t *testing.T) {
 	svc := newPinSvc(fr, store).WithSummarizer(sz)
 	ctx := authedCtx(uuid.New().String())
 
-	// Main loop establishes a 9-message baseline in ITS bucket.
 	rec1 := httptest.NewRecorder()
 	req1 := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(""))
 	require.NoError(t, svc.ProxyMessages(ctx, trimSessionTurn(t, 9), rec1, req1))
 	require.Equal(t, "claude-opus-4-7", rec1.Header().Get(proxy.HeaderRouterModel))
 
-	// A sub-agent thread opens with 3 messages and a DIFFERENT first user
-	// message → different session key → first observation in a fresh bucket,
-	// not a drop. The warm EV stay must hold.
 	subAgentBody := []byte(`{"model":"claude-opus-4-7","system":"sys","messages":[
 		{"role":"user","content":"SUB-AGENT find every .go file under internal/"},
 		{"role":"assistant","content":"searching"},

--- a/internal/proxy/turnloop_test.go
+++ b/internal/proxy/turnloop_test.go
@@ -14,6 +14,7 @@ import (
 	"workweave/router/internal/proxy"
 	"workweave/router/internal/router"
 	"workweave/router/internal/router/handover"
+	"workweave/router/internal/router/planner"
 	"workweave/router/internal/router/sessionpin"
 	"workweave/router/internal/translate"
 
@@ -509,9 +510,9 @@ func trimSessionTurn(t *testing.T, msgCount int) []byte {
 	return []byte(`{"model":"claude-opus-4-7","system":"sys","messages":[` + strings.Join(msgs, ",") + `]}`)
 }
 
-// warmOpusPin's prior turn billed 1.5k input tokens seconds ago. At that size
-// an opus→haiku switch is EV-negative under warm pricing but EV-positive under
-// cold pricing, so the verdict flips purely on the warmth assumption.
+// warmOpusPin's prior turn billed 1.5k input tokens seconds ago (warm), so an
+// opus→haiku switch is an EV-negative stay unless something prices the cache
+// as cold.
 func warmOpusPin() sessionpin.Pin {
 	return sessionpin.Pin{
 		Provider:        providers.ProviderAnthropic,
@@ -524,15 +525,19 @@ func warmOpusPin() sessionpin.Pin {
 }
 
 // A client history trim must make the planner price the warm pin's cache as
-// dead — flipping an otherwise EV-negative stay into a switch — without
-// invoking the switch summarizer.
+// dead — letting the cold-pin follow-fresh lever switch — without invoking
+// the switch summarizer.
 func TestTurnLoop_PrefixTrimPricesPinColdAndSkipsSummarizer(t *testing.T) {
 	store := newFakePinStore()
 	store.hasPin = true
 	store.pin = warmOpusPin()
 	fr := &fakeRouter{decision: router.Decision{Provider: providers.ProviderAnthropic, Model: "claude-haiku-4-5", Reason: "cluster:v0.2"}}
 	sz := &fakeSummarizer{summary: "Prior conversation summary."}
-	svc := newPinSvc(fr, store).WithSummarizer(sz)
+	svc := newPinSvc(fr, store).WithSummarizer(sz).WithPlanner(planner.EVConfig{
+		ThresholdUSD:           0.001,
+		ExpectedRemainingTurns: 3,
+		ColdPinFollowFresh:     true,
+	})
 	ctx := authedCtx(uuid.New().String())
 
 	// Turn 1 (9 messages) records the compaction baseline.
@@ -540,7 +545,7 @@ func TestTurnLoop_PrefixTrimPricesPinColdAndSkipsSummarizer(t *testing.T) {
 	req1 := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(""))
 	require.NoError(t, svc.ProxyMessages(ctx, trimSessionTurn(t, 9), rec1, req1))
 	require.Equal(t, "claude-opus-4-7", rec1.Header().Get(proxy.HeaderRouterModel),
-		"warm pin under the EV threshold must stay on turn 1")
+		"warm pin must stay on turn 1 (cold lever must not fire on a warm cache)")
 
 	// Turn 2 drops to 3 messages: a full-compaction trim.
 	rec2 := httptest.NewRecorder()
@@ -553,14 +558,19 @@ func TestTurnLoop_PrefixTrimPricesPinColdAndSkipsSummarizer(t *testing.T) {
 }
 
 // With the kill switch off, the trim is still detected and recorded but the
-// planner keeps pricing the pin warm and stays.
+// planner keeps pricing the pin warm and stays — even with the cold-pin
+// follow-fresh lever armed.
 func TestTurnLoop_PrefixTrimKillSwitchPreservesWarmStay(t *testing.T) {
 	store := newFakePinStore()
 	store.hasPin = true
 	store.pin = warmOpusPin()
 	fr := &fakeRouter{decision: router.Decision{Provider: providers.ProviderAnthropic, Model: "claude-haiku-4-5", Reason: "cluster:v0.2"}}
 	sz := &fakeSummarizer{summary: "Prior conversation summary."}
-	svc := newPinSvc(fr, store).WithSummarizer(sz).WithPrefixTrimFreeSwitch(false)
+	svc := newPinSvc(fr, store).WithSummarizer(sz).WithPrefixTrimFreeSwitch(false).WithPlanner(planner.EVConfig{
+		ThresholdUSD:           0.001,
+		ExpectedRemainingTurns: 3,
+		ColdPinFollowFresh:     true,
+	})
 	ctx := authedCtx(uuid.New().String())
 
 	rec1 := httptest.NewRecorder()

--- a/internal/proxy/turnloop_test.go
+++ b/internal/proxy/turnloop_test.go
@@ -491,6 +491,139 @@ func TestTurnLoop_UsageWritebackPersistsCacheStats(t *testing.T) {
 	assert.Equal(t, 200, got.CachedWriteTokens)
 }
 
+// trimSessionTurn builds a main-loop Anthropic body with msgCount alternating
+// user/assistant text messages (msgCount must be odd so the turn trails with
+// user text, not a tool_result). The first user message is constant so every
+// turn derives the same session key — the compaction tracker's bucket.
+func trimSessionTurn(t *testing.T, msgCount int) []byte {
+	t.Helper()
+	require.True(t, msgCount%2 == 1, "odd msgCount keeps the trailing message a user turn")
+	msgs := make([]string, 0, msgCount)
+	for i := 0; i < msgCount; i++ {
+		role := "user"
+		if i%2 == 1 {
+			role = "assistant"
+		}
+		msgs = append(msgs, `{"role":"`+role+`","content":"TRIM-SESSION turn `+itoa(i)+`"}`)
+	}
+	// messages.0 is identical across turns; only the tail varies.
+	msgs[0] = `{"role":"user","content":"TRIM-SESSION refactor the dispatch loop"}`
+	return []byte(`{"model":"claude-opus-4-7","system":"sys","messages":[` + strings.Join(msgs, ",") + `]}`)
+}
+
+// warmOpusPin is a pin whose prior turn billed ~1.5k input tokens and ended
+// seconds ago (warm). At that size an opus→haiku switch is EV-negative under
+// warm pricing (net ≈ $0.00081 < $0.001 threshold) but strongly EV-positive
+// under cold pricing (≈ $0.0189, eviction $0) — so the same session flips
+// verdicts purely on the warmth assumption, which is what the prefix-trim
+// tests need to observe.
+func warmOpusPin() sessionpin.Pin {
+	return sessionpin.Pin{
+		Provider:        providers.ProviderAnthropic,
+		Model:           "claude-opus-4-7",
+		Reason:          "cluster:v0.2",
+		PinnedUntil:     time.Now().Add(time.Hour),
+		LastInputTokens: 1500,
+		LastTurnEndedAt: time.Now().Add(-30 * time.Second),
+	}
+}
+
+// TestTurnLoop_PrefixTrimPricesPinColdAndSkipsSummarizer is the free-switch
+// window end-to-end: a client history trim (9 → 3 messages on one session)
+// must make the planner price the warm pin's cache as dead — flipping an
+// otherwise EV-negative stay into a switch — and must NOT invoke the switch
+// summarizer, because the client's own compaction summary already bounds the
+// forwarded body.
+func TestTurnLoop_PrefixTrimPricesPinColdAndSkipsSummarizer(t *testing.T) {
+	store := newFakePinStore()
+	store.hasPin = true
+	store.pin = warmOpusPin()
+	fr := &fakeRouter{decision: router.Decision{Provider: providers.ProviderAnthropic, Model: "claude-haiku-4-5", Reason: "cluster:v0.2"}}
+	sz := &fakeSummarizer{summary: "Prior conversation summary."}
+	svc := newPinSvc(fr, store).WithSummarizer(sz)
+	ctx := authedCtx(uuid.New().String())
+
+	// Turn 1 (9 messages) records the compaction baseline. Warm pricing keeps
+	// the EV under threshold, so the planner stays on the opus pin.
+	rec1 := httptest.NewRecorder()
+	req1 := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(""))
+	require.NoError(t, svc.ProxyMessages(ctx, trimSessionTurn(t, 9), rec1, req1))
+	require.Equal(t, "claude-opus-4-7", rec1.Header().Get(proxy.HeaderRouterModel),
+		"warm pin under the EV threshold must stay on turn 1")
+
+	// Turn 2 drops to 3 messages: a full-compaction trim. Cold pricing makes
+	// the switch strongly EV-positive.
+	rec2 := httptest.NewRecorder()
+	req2 := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(""))
+	require.NoError(t, svc.ProxyMessages(ctx, trimSessionTurn(t, 3), rec2, req2))
+	assert.Equal(t, "claude-haiku-4-5", rec2.Header().Get(proxy.HeaderRouterModel),
+		"trim turn must price the pin cold and switch to the fresh pick")
+	assert.Equal(t, int32(0), sz.calls.Load(),
+		"switch on a trim turn must skip the summarizer — the client's compaction summary already bounds the body")
+}
+
+// TestTurnLoop_PrefixTrimKillSwitchPreservesWarmStay proves
+// ROUTER_PREFIX_TRIM_FREE_SWITCH=false restores today's behavior: the trim is
+// still detected and recorded (the post-routing compaction handover depends on
+// that), but the planner keeps pricing the pin warm and stays.
+func TestTurnLoop_PrefixTrimKillSwitchPreservesWarmStay(t *testing.T) {
+	store := newFakePinStore()
+	store.hasPin = true
+	store.pin = warmOpusPin()
+	fr := &fakeRouter{decision: router.Decision{Provider: providers.ProviderAnthropic, Model: "claude-haiku-4-5", Reason: "cluster:v0.2"}}
+	sz := &fakeSummarizer{summary: "Prior conversation summary."}
+	svc := newPinSvc(fr, store).WithSummarizer(sz).WithPrefixTrimFreeSwitch(false)
+	ctx := authedCtx(uuid.New().String())
+
+	rec1 := httptest.NewRecorder()
+	req1 := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(""))
+	require.NoError(t, svc.ProxyMessages(ctx, trimSessionTurn(t, 9), rec1, req1))
+	require.Equal(t, "claude-opus-4-7", rec1.Header().Get(proxy.HeaderRouterModel))
+
+	rec2 := httptest.NewRecorder()
+	req2 := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(""))
+	require.NoError(t, svc.ProxyMessages(ctx, trimSessionTurn(t, 3), rec2, req2))
+	assert.Equal(t, "claude-opus-4-7", rec2.Header().Get(proxy.HeaderRouterModel),
+		"kill switch off must preserve the warm-priced EV stay on the trim turn")
+	assert.Equal(t, int32(0), sz.calls.Load())
+}
+
+// TestTurnLoop_SubAgentDoesNotInheritMainLoopTrimBaseline guards sub-agent
+// independence: a sub-agent's opening turn (small message count, distinct
+// first user message) derives its own session key, so it lands in its own
+// compaction bucket and must NOT read as a trim of the main loop's 9-message
+// baseline — which would falsely cold-price the sub-agent's pin.
+func TestTurnLoop_SubAgentDoesNotInheritMainLoopTrimBaseline(t *testing.T) {
+	store := newFakePinStore()
+	store.hasPin = true
+	store.pin = warmOpusPin()
+	fr := &fakeRouter{decision: router.Decision{Provider: providers.ProviderAnthropic, Model: "claude-haiku-4-5", Reason: "cluster:v0.2"}}
+	sz := &fakeSummarizer{summary: "Prior conversation summary."}
+	svc := newPinSvc(fr, store).WithSummarizer(sz)
+	ctx := authedCtx(uuid.New().String())
+
+	// Main loop establishes a 9-message baseline in ITS bucket.
+	rec1 := httptest.NewRecorder()
+	req1 := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(""))
+	require.NoError(t, svc.ProxyMessages(ctx, trimSessionTurn(t, 9), rec1, req1))
+	require.Equal(t, "claude-opus-4-7", rec1.Header().Get(proxy.HeaderRouterModel))
+
+	// A sub-agent thread opens with 3 messages and a DIFFERENT first user
+	// message → different session key → first observation in a fresh bucket,
+	// not a drop. The warm EV stay must hold.
+	subAgentBody := []byte(`{"model":"claude-opus-4-7","system":"sys","messages":[
+		{"role":"user","content":"SUB-AGENT find every .go file under internal/"},
+		{"role":"assistant","content":"searching"},
+		{"role":"user","content":"narrow to the proxy package"}
+	]}`)
+	rec2 := httptest.NewRecorder()
+	req2 := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(""))
+	require.NoError(t, svc.ProxyMessages(ctx, subAgentBody, rec2, req2))
+	assert.Equal(t, "claude-opus-4-7", rec2.Header().Get(proxy.HeaderRouterModel),
+		"a sub-agent's small opening turn must not read as a trim of the main loop's baseline")
+	assert.Equal(t, int32(0), sz.calls.Load())
+}
+
 // TestTurnLoop_MaxedOutPinExcludedFromCandidates locks in the
 // runaway-tool-call escape hatch: when the previous turn saturated the
 // output cap (a hallmark of OSS-model parse-failure runaways), the pinned

--- a/internal/proxy/turnloop_test.go
+++ b/internal/proxy/turnloop_test.go
@@ -588,6 +588,42 @@ func TestTurnLoop_PrefixTrimKillSwitchPreservesWarmStay(t *testing.T) {
 	assert.Equal(t, int32(0), sz.calls.Load())
 }
 
+// TestTurnLoop_PrefixTrimSkipsExpiredPinReAnchor guards guard (h) on the
+// expired-pin re-anchor: re-anchoring exists to damp noise-driven lateral
+// switches on the one expiry turn, but a trim turn is a genuine free-switch
+// boundary — the prior model's cache is dead regardless of pin expiry — so the
+// scorer's fresh pick must win instead of the expired pin's model.
+func TestTurnLoop_PrefixTrimSkipsExpiredPinReAnchor(t *testing.T) {
+	store := newFakePinStore()
+	store.hasPin = true
+	expired := warmOpusPin()
+	expired.PinnedUntil = time.Now().Add(-time.Minute)
+	store.pin = expired
+	fr := &fakeRouter{decision: router.Decision{Provider: providers.ProviderAnthropic, Model: "claude-haiku-4-5", Reason: "cluster:v0.2"}}
+	svc := newPinSvc(fr, store).WithAvailableModels(map[string]struct{}{
+		"claude-opus-4-7":  {},
+		"claude-haiku-4-5": {},
+	})
+	ctx := authedCtx(uuid.New().String())
+
+	// Turn 1 (9 messages, no trim): the expired pin re-anchors — haiku is not
+	// a tier upgrade over opus, opus is routable — proving the re-anchor path
+	// is live in this harness before the trim turn bypasses it.
+	rec1 := httptest.NewRecorder()
+	req1 := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(""))
+	require.NoError(t, svc.ProxyMessages(ctx, trimSessionTurn(t, 9), rec1, req1))
+	require.Equal(t, "claude-opus-4-7", rec1.Header().Get(proxy.HeaderRouterModel),
+		"expired pin must re-anchor on a normal turn (guard baseline)")
+
+	// Turn 2 (3 messages): trim detected → re-anchor skipped → the scorer's
+	// fresh pick serves.
+	rec2 := httptest.NewRecorder()
+	req2 := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(""))
+	require.NoError(t, svc.ProxyMessages(ctx, trimSessionTurn(t, 3), rec2, req2))
+	assert.Equal(t, "claude-haiku-4-5", rec2.Header().Get(proxy.HeaderRouterModel),
+		"trim turn must skip the expired-pin re-anchor and follow the fresh pick")
+}
+
 // TestTurnLoop_SubAgentDoesNotInheritMainLoopTrimBaseline guards sub-agent
 // independence: a sub-agent's opening turn (small message count, distinct
 // first user message) derives its own session key, so it lands in its own

--- a/internal/router/planner/policy.go
+++ b/internal/router/planner/policy.go
@@ -60,6 +60,14 @@ type EVConfig struct {
 	// TierUpgradeEnabled overturns an EV stay when fresh is strictly higher
 	// tier than pin. Upgrade-only by design.
 	TierUpgradeEnabled bool
+	// ColdPinFollowFresh overturns an EV stay when the pin's cache is cold:
+	// with nothing warm to preserve, staying buys no cache reuse, so the
+	// scorer's fresh pick (its quality/cost argmax for this turn) wins even
+	// when the raw-price EV is below threshold — a cold cache is a free
+	// switch boundary. EV-positive and tier-upgrade still take precedence
+	// (same outcome, more specific reason). Off by default so the flip can
+	// be measured against the shadow EV telemetry before it's armed.
+	ColdPinFollowFresh bool
 }
 
 // Inputs is the full per-turn input to Decide.
@@ -93,6 +101,7 @@ const (
 	ReasonEVPositive      = "ev_positive"
 	ReasonEVNegative      = "ev_negative"
 	ReasonTierUpgrade     = "tier_upgrade"
+	ReasonColdPinFresh    = "cold_pin_follow_fresh"
 )
 
 // Decide returns the planner verdict for this turn.
@@ -162,6 +171,13 @@ func Decide(in Inputs, cfg EVConfig) Decision {
 	case cfg.TierUpgradeEnabled && tierUpgrade(in.Pin.Model, in.Fresh.Model):
 		d.Outcome = OutcomeSwitch
 		d.Reason = ReasonTierUpgrade
+	case cfg.ColdPinFollowFresh && in.PinCacheCold:
+		// Cold pin = free switch boundary: no warm cache to preserve, so the
+		// scorer's fresh argmax wins instead of first-decision inertia. Only
+		// reached when the raw-price EV was below threshold (an EV-positive
+		// cold switch already fired above).
+		d.Outcome = OutcomeSwitch
+		d.Reason = ReasonColdPinFresh
 	default:
 		d.Outcome = OutcomeStay
 		d.Reason = ReasonEVNegative

--- a/internal/router/planner/policy.go
+++ b/internal/router/planner/policy.go
@@ -61,12 +61,9 @@ type EVConfig struct {
 	// tier than pin. Upgrade-only by design.
 	TierUpgradeEnabled bool
 	// ColdPinFollowFresh overturns an EV stay when the pin's cache is cold:
-	// with nothing warm to preserve, staying buys no cache reuse, so the
-	// scorer's fresh pick (its quality/cost argmax for this turn) wins even
-	// when the raw-price EV is below threshold — a cold cache is a free
-	// switch boundary. EV-positive and tier-upgrade still take precedence
-	// (same outcome, more specific reason). Off by default so the flip can
-	// be measured against the shadow EV telemetry before it's armed.
+	// with nothing warm to preserve, the scorer's fresh pick wins. EV-positive
+	// and tier-upgrade take precedence (more specific reasons). Off by
+	// default; measure against shadow telemetry before arming.
 	ColdPinFollowFresh bool
 }
 
@@ -172,10 +169,6 @@ func Decide(in Inputs, cfg EVConfig) Decision {
 		d.Outcome = OutcomeSwitch
 		d.Reason = ReasonTierUpgrade
 	case cfg.ColdPinFollowFresh && in.PinCacheCold:
-		// Cold pin = free switch boundary: no warm cache to preserve, so the
-		// scorer's fresh argmax wins instead of first-decision inertia. Only
-		// reached when the raw-price EV was below threshold (an EV-positive
-		// cold switch already fired above).
 		d.Outcome = OutcomeSwitch
 		d.Reason = ReasonColdPinFresh
 	default:

--- a/internal/router/planner/policy_test.go
+++ b/internal/router/planner/policy_test.go
@@ -85,9 +85,8 @@ func TestDecide_SubscriptionDiscountFlipsSwitch(t *testing.T) {
 		"a 0.0 covered-model factor must still be treated as free (switch), not uncovered")
 }
 
-// A cold pin holds no warm cache worth preserving, so with ColdPinFollowFresh
-// enabled the scorer's fresh pick must win even when the raw-price EV is below
-// threshold — first-decision inertia only pays for itself through cache reuse.
+// With ColdPinFollowFresh enabled, a cold pin follows the scorer's fresh pick
+// even when the raw-price EV is below threshold.
 func TestDecide_ColdPinFollowFresh(t *testing.T) {
 	t.Parallel()
 	coldCfg := planner.EVConfig{
@@ -95,8 +94,8 @@ func TestDecide_ColdPinFollowFresh(t *testing.T) {
 		ExpectedRemainingTurns: 3,
 		ColdPinFollowFresh:     true,
 	}
-	// Cheap pin → expensive fresh: raw-price EV is strongly negative
-	// (savings ≈ −$0.63 at 50k tokens), so only the cold-pin lever can flip it.
+	// Cheap pin → expensive fresh: raw-price EV is strongly negative, so only
+	// the cold-pin lever can flip it.
 	base := planner.Inputs{
 		Pin:                  pinWithUsage(modelHaiku),
 		Fresh:                router.Decision{Model: modelOpus},
@@ -110,21 +109,18 @@ func TestDecide_ColdPinFollowFresh(t *testing.T) {
 	assert.Equal(t, planner.ReasonColdPinFresh, got.Reason)
 	assert.True(t, got.PinCacheCold, "decision must echo the cold pricing assumption")
 
-	// Lever off: the same cold, EV-negative inputs must preserve today's stay.
 	off := planner.Decide(base, defaultCfg)
 	assert.Equal(t, planner.OutcomeStay, off.Outcome, "lever off must preserve the EV-negative stay")
 	assert.Equal(t, planner.ReasonEVNegative, off.Reason)
 
-	// Warm pin: the lever must never fire — the warm cache is exactly the
-	// asset the EV math protects.
 	warm := base
 	warm.PinCacheCold = false
 	stay := planner.Decide(warm, coldCfg)
 	assert.Equal(t, planner.OutcomeStay, stay.Outcome, "warm pin must not follow fresh on the cold lever")
 	assert.Equal(t, planner.ReasonEVNegative, stay.Reason)
 
-	// Precedence: a cold pin whose switch is already EV-positive (expensive
-	// pin → cheap fresh) must keep the more specific ev_positive reason.
+	// A cold pin whose switch is already EV-positive keeps the more specific
+	// ev_positive reason.
 	evPositive := planner.Inputs{
 		Pin:                  pinWithUsage(modelOpus),
 		Fresh:                router.Decision{Model: modelHaiku},

--- a/internal/router/planner/policy_test.go
+++ b/internal/router/planner/policy_test.go
@@ -85,6 +85,58 @@ func TestDecide_SubscriptionDiscountFlipsSwitch(t *testing.T) {
 		"a 0.0 covered-model factor must still be treated as free (switch), not uncovered")
 }
 
+// A cold pin holds no warm cache worth preserving, so with ColdPinFollowFresh
+// enabled the scorer's fresh pick must win even when the raw-price EV is below
+// threshold — first-decision inertia only pays for itself through cache reuse.
+func TestDecide_ColdPinFollowFresh(t *testing.T) {
+	t.Parallel()
+	coldCfg := planner.EVConfig{
+		ThresholdUSD:           0.001,
+		ExpectedRemainingTurns: 3,
+		ColdPinFollowFresh:     true,
+	}
+	// Cheap pin → expensive fresh: raw-price EV is strongly negative
+	// (savings ≈ −$0.63 at 50k tokens), so only the cold-pin lever can flip it.
+	base := planner.Inputs{
+		Pin:                  pinWithUsage(modelHaiku),
+		Fresh:                router.Decision{Model: modelOpus},
+		EstimatedInputTokens: 50_000,
+		AvailableModels:      availableAll,
+		PinCacheCold:         true,
+	}
+
+	got := planner.Decide(base, coldCfg)
+	assert.Equal(t, planner.OutcomeSwitch, got.Outcome, "cold pin + lever on must follow the fresh pick")
+	assert.Equal(t, planner.ReasonColdPinFresh, got.Reason)
+	assert.True(t, got.PinCacheCold, "decision must echo the cold pricing assumption")
+
+	// Lever off: the same cold, EV-negative inputs must preserve today's stay.
+	off := planner.Decide(base, defaultCfg)
+	assert.Equal(t, planner.OutcomeStay, off.Outcome, "lever off must preserve the EV-negative stay")
+	assert.Equal(t, planner.ReasonEVNegative, off.Reason)
+
+	// Warm pin: the lever must never fire — the warm cache is exactly the
+	// asset the EV math protects.
+	warm := base
+	warm.PinCacheCold = false
+	stay := planner.Decide(warm, coldCfg)
+	assert.Equal(t, planner.OutcomeStay, stay.Outcome, "warm pin must not follow fresh on the cold lever")
+	assert.Equal(t, planner.ReasonEVNegative, stay.Reason)
+
+	// Precedence: a cold pin whose switch is already EV-positive (expensive
+	// pin → cheap fresh) must keep the more specific ev_positive reason.
+	evPositive := planner.Inputs{
+		Pin:                  pinWithUsage(modelOpus),
+		Fresh:                router.Decision{Model: modelHaiku},
+		EstimatedInputTokens: 50_000,
+		AvailableModels:      availableAll,
+		PinCacheCold:         true,
+	}
+	pos := planner.Decide(evPositive, coldCfg)
+	assert.Equal(t, planner.OutcomeSwitch, pos.Outcome)
+	assert.Equal(t, planner.ReasonEVPositive, pos.Reason, "EV-positive must take precedence over the cold-pin reason")
+}
+
 func TestDecide(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

Tier 1 of the inter-turn routing optimizations. Two changes:

**Prefix-trim free-switch** (on by default, kill switch `ROUTER_PREFIX_TRIM_FREE_SWITCH`):

- Compaction/trim detection (`compactionTracker.checkAndRecord`) moves from the post-routing block in `ProxyMessages` into `runTurnLoop`, before the pin/planner path, so the signal is available on the exact turn the client broke its prompt prefix.
- On a detected trim, the planner prices the pin's upstream cache as **cold** even inside the provider TTL — the client rewrote the transcript head, so cache entries keyed on the old prefix are unreachable no matter how recently the pin served. This flips "warm-cache inertia" stays into switches exactly when switching is free.
- The switch handover summarizer is skipped on trim turns: the body already carries the client's own compaction summary and is as small as it will ever be; summarizing it again is pure cost.
- The post-routing non-Anthropic compaction handover now consumes the turn loop's verdict (`routeRes.PrefixTrimmed`) instead of re-recording the tracker (re-recording would compare the turn's counts against themselves and never fire).

**Cold-pin follow-fresh** (off by default, `ROUTER_SWITCH_COLD_PIN_FOLLOW_FRESH`): a new planner lever that overturns an EV stay when the pin's cache is cold — with nothing warm to preserve, staying buys no cache reuse, so the scorer's fresh argmax wins. EV-positive and tier-upgrade keep precedence. 

## Test plan

- [x] `go build ./...`, `go vet ./...`, full `go test ./...` green
- [x] New planner unit test: cold+lever → switch (`cold_pin_follow_fresh`), lever-off → stay, warm → stay, EV-positive precedence
- [x] New turn-loop integration tests: trim turn flips a warm EV-negative stay into a switch with the summarizer skipped; `WithPrefixTrimFreeSwitch(false)` preserves the warm stay; a sub-agent's small opening turn does not inherit the main loop's trim baseline