### PR TITLE
fix(translate): sanitize tool_use.id in streamed Anthropic responses

### DIFF
--- a/internal/translate/stream.go
+++ b/internal/translate/stream.go
@@ -1483,7 +1483,7 @@ func (t *AnthropicSSETranslator) emitContentBlockStartTool(index int, id, name, 
 	t.bw.WriteString("event: content_block_start\ndata: {\"type\":\"content_block_start\",\"index\":")
 	sse.WriteJSONInt(t.bw, int64(index))
 	t.bw.WriteString(",\"content_block\":{\"type\":\"tool_use\",\"id\":")
-	sse.WriteJSONString(t.bw, embedSignatureInID(id, sig))
+	sse.WriteJSONString(t.bw, embedSignatureInID(sanitizeToolUseID(id), sig))
 	t.bw.WriteString(",\"name\":")
 	sse.WriteJSONString(t.bw, name)
 	t.bw.WriteString(",\"input\":{}}}\n\n")

--- a/internal/translate/stream_tool_use_id_test.go
+++ b/internal/translate/stream_tool_use_id_test.go
@@ -1,0 +1,51 @@
+package translate_test
+
+import (
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"workweave/router/internal/translate"
+
+	"github.com/tidwall/gjson"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Regression: Kimi-k2.x (and other OpenAI-compat upstreams) emit tool_call
+// ids like "functions.Read:0" containing dots/colons, which fail Anthropic's
+// required tool_use.id pattern (^[a-zA-Z0-9_-]+$). The non-streaming emit
+// path already sanitized these; the streaming SSE tool_use emitter did not,
+// letting the raw id reach the client and later get replayed straight to
+// Anthropic on `resume`, producing a 400.
+func TestAnthropicSSETranslator_SanitizesStreamedToolUseID(t *testing.T) {
+	rec := httptest.NewRecorder()
+	w := translate.NewAnthropicSSETranslator(rec, "moonshotai/kimi-k2.7", nil)
+	require.NoError(t, w.Prelude(true))
+
+	feedChat(t, w,
+		`{"choices":[{"delta":{"tool_calls":[{"index":0,"id":"functions.Read:0","function":{"name":"Read","arguments":""}}]},"finish_reason":null}]}`,
+		`{"choices":[{"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{}"}}]},"finish_reason":"tool_calls"}]}`,
+	)
+
+	out := rec.Body.String()
+	var sawToolUse bool
+	for _, line := range strings.Split(out, "\n") {
+		const p = "data: "
+		if !strings.HasPrefix(line, p) {
+			continue
+		}
+		data := line[len(p):]
+		block := gjson.Get(data, "content_block")
+		if block.Get("type").String() != "tool_use" {
+			continue
+		}
+		sawToolUse = true
+		id := block.Get("id").String()
+		assert.Regexp(t, `^[a-zA-Z0-9_-]+$`, id, "streamed tool_use.id must match Anthropic's required pattern")
+		assert.NotContains(t, id, ".")
+		assert.NotContains(t, id, ":")
+	}
+	assert.True(t, sawToolUse, "expected a tool_use content_block_start event")
+}


### PR DESCRIPTION
## Summary
- The streaming SSE tool_use emitter (`emitContentBlockStartTool` in `internal/translate/stream.go`) wrote OpenAI-compat `tool_calls[].id` straight through without sanitization, unlike the non-streaming path (`buildAnthropicAssistantMessage` in `emit_anthropic.go`), which already calls `sanitizeToolUseID`.
- Kimi-k2.x (and similar OpenAI-compat upstreams) emit ids like `functions.Read:0` containing `.`/`:`, which violate Anthropic's required `^[a-zA-Z0-9_-]+$` pattern for `tool_use.id`.
- Since Claude Code streams by default, the raw id got persisted into the client's local transcript and later replayed verbatim to Anthropic on `resume`, producing `400: messages.N.content.M.tool_use.id: String should match pattern '^[a-zA-Z0-9_-]+$'`.
- Found while investigating prod session `409d0313-5c5e-4dae-89f0-df84c5300641`, which was cross-format routed to `moonshotai/kimi-k2.7` (Fireworks) before a later `resume` hit this 400.

## Fix
Sanitize the id before it's embedded (and before any Gemini thought-signature suffix is appended), reusing the existing `sanitizeToolUseID` helper — same function already used on the non-streaming path and the request-replay path, so behavior is now consistent across all three.

## Test plan
- [x] Added `TestAnthropicSSETranslator_SanitizesStreamedToolUseID` reproducing the Kimi `functions.Read:0` id over the streaming path, asserting the emitted `content_block_start` id matches Anthropic's required pattern.
- [x] `go build ./...`
- [x] `go test ./...` (full suite green)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>