### PR TITLE
chore: shorten verbose comments, part 2 (next 25 files)

### DIFF
--- a/internal/billing/service.go
+++ b/internal/billing/service.go
@@ -8,15 +8,12 @@ import (
 	"workweave/router/internal/router/catalog"
 )
 
-// hasOverrideContextKeyT is the request-context type for the override
-// flag. Defined in the billing package so middleware (adapter) and
-// proxy (inner-ring) can both reference it without a layering
-// violation.
+// hasOverrideContextKeyT lives in billing (not middleware/proxy) so both
+// sides can reference it without a layering violation.
 type hasOverrideContextKeyT struct{}
 
-// HasOverrideContextKey is the request-context key used by
-// middleware.WithBalanceCheck to flag override-pass-through requests
-// for the proxy's debit hook. Bool value.
+// HasOverrideContextKey flags override-pass-through requests for the
+// proxy's debit hook. Set by middleware.WithBalanceCheck. Bool value.
 var HasOverrideContextKey = hasOverrideContextKeyT{}
 
 // HasOverrideFromContext returns true when WithBalanceCheck flagged the
@@ -30,14 +27,14 @@ func HasOverrideFromContext(ctx context.Context) bool {
 	return b
 }
 
-// EntryTypeInference is the canonical entry_type value for per-request
-// debits (and override pass-throughs). Keep in sync with the CHECK
-// constraint on router.organization_credit_ledger.entry_type.
+// EntryTypeInference is the canonical entry_type for per-request debits.
+// Keep in sync with the CHECK constraint on
+// router.organization_credit_ledger.entry_type.
 const EntryTypeInference = "inference"
 
-// MinBalanceMicros: new requests 402 when balance <= this (USD micros).
-// 0 matches OpenAI/Anthropic prepaid semantics — block at zero, let
-// in-flight debits settle (post-request balance can dip by one req cost).
+// MinBalanceMicros: requests 402 when balance <= this. 0 matches
+// OpenAI/Anthropic prepaid semantics — block at zero, let in-flight
+// debits settle.
 const MinBalanceMicros int64 = 0
 
 // Service orchestrates balance reads and debits. No I/O of its own — all
@@ -53,44 +50,41 @@ func NewService(repo Repo) *Service {
 	return &Service{repo: repo}
 }
 
-// AutopayNotifier signals the control plane that an org's balance just crossed
-// below its autopay threshold and a recharge should fire. Implemented by a
-// Pub/Sub adapter in internal/pubsub; left nil when autopay signalling isn't
-// wired (selfhosted, or the autopay topic env is unset), which disables the
-// crossing check entirely.
+// AutopayNotifier signals the control plane that an org's balance just
+// crossed below its autopay threshold. Implemented by a Pub/Sub adapter in
+// internal/pubsub; nil disables the crossing check (selfhosted, or topic
+// env unset).
 type AutopayNotifier interface {
 	NotifyRechargeNeeded(organizationID string)
 }
 
-// WithAutopayNotifier attaches the autopay recharge signaller and returns the
-// service for chaining. Wired only in managed mode when the autopay topic is
-// configured.
+// WithAutopayNotifier attaches the autopay recharge signaller and returns
+// the service for chaining. Wired only in managed mode.
 func (s *Service) WithAutopayNotifier(n AutopayNotifier) *Service {
 	s.autopay = n
 	return s
 }
 
-// CheckResult is the outcome of a preflight balance check. The middleware
-// uses HasOverride to skip the threshold comparison and to flag the request
-// context so the debit hook writes a delta=0 ledger row.
+// CheckResult is the outcome of a preflight balance check. HasOverride
+// tells the middleware to skip the threshold comparison and flag the
+// request context so the debit hook writes a delta=0 ledger row.
 type CheckResult struct {
 	HasOverride   bool
 	BalanceMicros int64
 }
 
-// APIKeySpendCapResult is the outcome of a preflight per-key spend-cap check.
-// Found is false when the key was deleted mid-request; CapMicros is nil for an
-// uncapped key. The middleware blocks when Found && CapMicros != nil &&
-// SpentMicros >= *CapMicros.
+// APIKeySpendCapResult is the outcome of a preflight per-key spend-cap
+// check. Found is false if the key was deleted mid-request; CapMicros is
+// nil for an uncapped key. Middleware blocks when Found && CapMicros !=
+// nil && SpentMicros >= *CapMicros.
 type APIKeySpendCapResult struct {
 	Found       bool
 	SpentMicros int64
 	CapMicros   *int64
 }
 
-// CheckAPIKeySpendCap reads the key's cap and spend-to-date fresh from the repo
-// (not the auth cache) so a hot cached key cannot overrun its cap within the
-// cache TTL. Returns Found=false when the key no longer exists.
+// CheckAPIKeySpendCap reads fresh from the repo (not the auth cache) so a
+// hot cached key can't overrun its cap within the cache TTL.
 func (s *Service) CheckAPIKeySpendCap(ctx context.Context, apiKeyID string) (APIKeySpendCapResult, error) {
 	spent, cap, found, err := s.repo.GetAPIKeySpend(ctx, apiKeyID)
 	if err != nil {
@@ -99,16 +93,12 @@ func (s *Service) CheckAPIKeySpendCap(ctx context.Context, apiKeyID string) (API
 	return APIKeySpendCapResult{Found: found, SpentMicros: spent, CapMicros: cap}, nil
 }
 
-// CheckBalance reads the override flag and balance row. Returns
-// HasOverride=true and short-circuits the balance read when an override is
-// active. Caller (middleware) compares BalanceMicros against the
-// configured minimum threshold.
+// CheckBalance short-circuits the balance read when an override is active
+// (returns HasOverride=true). Otherwise the caller compares BalanceMicros
+// against MinBalanceMicros.
 //
-// Errors:
-//   - ErrBalanceRowMissing: no balance row exists for the org. Middleware
-//     should treat this as 402 with a distinct log line; the org needs to
-//     be backfilled before any inference can succeed.
-//   - Other errors propagate from the Repo.
+// ErrBalanceRowMissing means no balance row exists for the org — treat as
+// 402; the org needs to be backfilled before inference can succeed.
 func (s *Service) CheckBalance(ctx context.Context, orgID string) (CheckResult, error) {
 	override, err := s.repo.HasActiveOverride(ctx, orgID)
 	if err != nil {
@@ -124,13 +114,10 @@ func (s *Service) CheckBalance(ctx context.Context, orgID string) (CheckResult, 
 	return CheckResult{BalanceMicros: balance}, nil
 }
 
-// DebitInferenceParams is the input to DebitForInference. Token counts and
-// the two pricing rows come from the proxy's usage extractor; orgID +
-// requestID + model + provider come from the request context.
-//
-// HasOverride is set by the caller (proxy) from the per-request context
-// flag that middleware stamped on. Plumbing it through here keeps the
-// override read out of the hot path — middleware already did it.
+// DebitInferenceParams is the input to DebitForInference. Token counts
+// and pricing come from the proxy's usage extractor; HasOverride is
+// carried from the context flag middleware already stamped, so the
+// override read doesn't happen twice.
 type DebitInferenceParams struct {
 	OrganizationID  string
 	RouterRequestID string
@@ -142,34 +129,27 @@ type DebitInferenceParams struct {
 	CacheRead       int
 	Pricing         catalog.Pricing
 	HasOverride     bool
-	// SubscriptionServed is true when the turn was served on the customer's own
-	// Anthropic or Codex subscription token. Weave charges nothing for these —
-	// the customer's plan already paid for the tokens.
+	// SubscriptionServed: turn ran on the customer's own Anthropic/Codex
+	// subscription token, so Weave charges nothing.
 	SubscriptionServed bool
-	// APIKeyID, when non-empty, attributes the debit to the api key that
-	// authenticated the request so its lifetime spend is tracked for cap
-	// enforcement. Empty leaves per-key spend untouched.
+	// APIKeyID attributes the debit to the authenticating key for
+	// spend-cap tracking; empty leaves per-key spend untouched.
 	APIKeyID string
 }
 
-// DebitForInference computes the raw upstream cost and writes one ledger
-// row. For Weave-fronted usage there is no markup math — margin is collected
-// at top-up by the backend and the router debits at cost. Two cases debit 0:
-// an override pass-through, and a turn served on the customer's own
-// subscription (Anthropic or Codex) — their plan already covers the tokens, so
-// Weave charges nothing for routing them. NotionalCostMicros always records
-// the full would-be cost regardless, as a shadow trail.
+// DebitForInference writes one ledger row at cost — no markup math here;
+// margin is collected at top-up by the backend. Debits 0 for an override
+// pass-through or subscription-served turn (already paid for), but always
+// records NotionalCostMicros as a shadow trail.
 //
-// Returns the post-debit balance (0 on override since balance is
-// unchanged but the ledger row was recorded with the current balance).
+// Returns the post-debit balance (0 on override, since balance doesn't
+// change).
 func (s *Service) DebitForInference(ctx context.Context, p DebitInferenceParams) (int64, error) {
 	notional := computeNotionalMicros(p)
 	delta := -notional
 	switch {
 	case p.HasOverride, p.SubscriptionServed:
-		// Override pass-through, or a turn the customer's own subscription
-		// already paid for — debit nothing. The notional cost is still recorded
-		// below as a shadow billing trail.
+		// Already paid for — debit nothing, but still record notional cost below.
 		delta = 0
 	}
 	balanceAfter, err := s.repo.DebitInference(ctx, DebitParams{
@@ -188,14 +168,11 @@ func (s *Service) DebitForInference(ctx context.Context, p DebitInferenceParams)
 	return balanceAfter, nil
 }
 
-// maybeSignalRecharge fires exactly one autopay recharge signal on the debit
-// that takes the org's balance from at-or-above its configured threshold to
-// below it — the single downward crossing. It no-ops when autopay signalling
-// isn't wired, the debit moved nothing (override or subscription-served), or
-// the org hasn't enabled autopay. The signal is the primary autopay trigger;
-// the control-plane reconciliation sweep backstops a dropped signal, so a
-// config read error is logged and dropped rather than failing the
-// already-served request.
+// maybeSignalRecharge fires once, on the debit that crosses the org's
+// balance from at-or-above its autopay threshold to below it. No-ops if
+// autopay isn't wired, the debit moved nothing, or autopay is disabled.
+// A config-read error is logged and dropped (not returned) since the
+// control-plane reconciliation sweep backstops a missed signal.
 func (s *Service) maybeSignalRecharge(ctx context.Context, orgID string, delta, balanceAfter int64) {
 	if s.autopay == nil || delta >= 0 {
 		return
@@ -216,9 +193,8 @@ func (s *Service) maybeSignalRecharge(ctx context.Context, orgID string, delta, 
 	}
 }
 
-// computeNotionalMicros returns the would-be charge in USD micros. Always
-// populated, regardless of override status, so the ledger preserves a
-// shadow billing trail.
+// computeNotionalMicros returns the would-be charge in USD micros,
+// regardless of override status, for the shadow billing trail.
 func computeNotionalMicros(p DebitInferenceParams) int64 {
 	inUSD := catalog.EffectiveInputCost(p.InputTokens, p.CacheCreation, p.CacheRead, p.Pricing.InputUSDPer1M, p.Pricing, p.Provider)
 	outUSD := catalog.EffectiveOutputCost(p.OutputTokens, p.Pricing.OutputUSDPer1M)

--- a/internal/observability/logger.go
+++ b/internal/observability/logger.go
@@ -16,14 +16,11 @@ import (
 
 const ginContextKey = "router_logger"
 
-// loggerContextKey is the private key used to stash a request-scoped
-// *slog.Logger on a context.Context. Private type prevents collisions with
-// other packages' context values.
+// loggerContextKey is a private type so context values don't collide with
+// other packages'.
 type loggerContextKey struct{}
 
-// WithLogger returns a new context that carries the given logger. Downstream
-// code reading the logger with FromContext sees this logger (with all its
-// pre-bound attributes) instead of the global default.
+// WithLogger attaches a logger to ctx for downstream FromContext calls.
 func WithLogger(ctx context.Context, log *slog.Logger) context.Context {
 	if log == nil {
 		return ctx
@@ -31,9 +28,8 @@ func WithLogger(ctx context.Context, log *slog.Logger) context.Context {
 	return context.WithValue(ctx, loggerContextKey{}, log)
 }
 
-// FromContext returns the request-scoped logger stashed by WithLogger, or the
-// global default logger if none is set. Always non-nil. Initializes the
-// LOG_LEVEL-honoring handler on first call, matching Get().
+// FromContext returns the logger stashed by WithLogger, or the global default
+// if none is set. Always non-nil.
 func FromContext(ctx context.Context) *slog.Logger {
 	initOnce.Do(initLogger)
 	if ctx != nil {
@@ -46,9 +42,8 @@ func FromContext(ctx context.Context) *slog.Logger {
 	return slog.Default()
 }
 
-// initOnce installs a slog handler honoring LOG_LEVEL on first Get(). Without
-// this, slog.Default() falls back to Go's stdlib handler at INFO, silently
-// dropping Debug lines emitted elsewhere in the codebase.
+// initOnce installs the LOG_LEVEL-honoring handler on first use; without it
+// slog.Default() defaults to INFO and silently drops Debug lines.
 var initOnce sync.Once
 
 func initLogger() {
@@ -64,10 +59,9 @@ func initLogger() {
 	slog.SetDefault(slog.New(newHandler(level)))
 }
 
-// newHandler builds the slog handler for the resolved format. JSON output maps
-// attributes to GCP Cloud Logging fields (severity/time/message) via
-// sloggcp.ReplaceAttr so lines render correctly when the router runs on Cloud
-// Run; tint gives a colorized human-readable stream for local dev.
+// newHandler builds the slog handler for the resolved format. JSON uses
+// sloggcp.ReplaceAttr so lines render correctly in GCP Cloud Logging; tint
+// gives colorized output for local dev.
 func newHandler(level slog.Level) slog.Handler {
 	switch logFormat() {
 	case "json":
@@ -80,9 +74,8 @@ func newHandler(level slog.Level) slog.Handler {
 	case "tint":
 		return tint.NewHandler(os.Stderr, &tint.Options{Level: level, TimeFormat: time.Kitchen})
 	}
-	// Auto: a TTY (local dev) gets human-readable output — colorized when color
-	// is enabled, plain text when NO_COLOR/LOG_COLOR disables it. Only non-TTY
-	// streams (Cloud Run, piped, redirected) get structured GCP JSON.
+	// Auto: TTY gets human-readable output (colorized unless disabled); non-TTY
+	// gets structured GCP JSON.
 	if useColor() {
 		return tint.NewHandler(os.Stderr, &tint.Options{Level: level, TimeFormat: time.Kitchen})
 	}
@@ -95,9 +88,8 @@ func newHandler(level slog.Level) slog.Handler {
 	})
 }
 
-// logFormat returns the explicitly requested handler format, or "" to let the
-// handler auto-detect based on whether stderr is a TTY. Honors
-// LOG_FORMAT={json,text,color,tint}.
+// logFormat returns the requested handler format from LOG_FORMAT
+// ({json,text,color,tint}), or "" to auto-detect.
 func logFormat() string {
 	switch strings.ToLower(strings.TrimSpace(os.Getenv("LOG_FORMAT"))) {
 	case "json":
@@ -110,10 +102,9 @@ func logFormat() string {
 	return ""
 }
 
-// useColor reports whether the auto format should pick tint's ANSI-colored
-// handler (vs structured JSON). Respects LOG_COLOR={1,true,yes,on} /
-// {0,false,no,off}; otherwise auto-detects based on whether stderr is a TTY and
-// NO_COLOR is unset (https://no-color.org).
+// useColor reports whether auto format should use tint's colorized handler.
+// Respects LOG_COLOR={1,true,yes,on}/{0,false,no,off}; otherwise auto-detects
+// via TTY + NO_COLOR (https://no-color.org).
 func useColor() bool {
 	switch strings.ToLower(strings.TrimSpace(os.Getenv("LOG_COLOR"))) {
 	case "1", "true", "yes", "on":
@@ -127,9 +118,8 @@ func useColor() bool {
 	return isTerminal()
 }
 
-// isTerminal reports whether stderr is an interactive terminal, independent of
-// any color preference. The auto format uses this to keep TTY output
-// human-readable (text) rather than JSON when color is disabled.
+// isTerminal reports whether stderr is an interactive terminal, independent
+// of color preference.
 func isTerminal() bool {
 	return isatty.IsTerminal(os.Stderr.Fd()) || isatty.IsCygwinTerminal(os.Stderr.Fd())
 }
@@ -160,9 +150,8 @@ func Middleware() gin.HandlerFunc {
 	}
 }
 
-// AccessLog logs one INFO line per request after handlers run. Without this,
-// a 401 from WithAuth produces zero output at LOG_LEVEL=info, making "no logs"
-// look like "the server isn't being hit" when it actually is.
+// AccessLog logs one INFO line per request after handlers run — without it, a
+// 401 from WithAuth produces zero output at LOG_LEVEL=info, masking traffic.
 func AccessLog() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		start := time.Now()

--- a/internal/providers/httputil/httputil.go
+++ b/internal/providers/httputil/httputil.go
@@ -20,136 +20,72 @@ import (
 // FlushChunk is the read buffer size used by all streaming provider adapters.
 const FlushChunk = 4 * 1024
 
-// ErrUpstreamIdleTimeout is the sentinel cause set on the request context when
-// the SSE inactivity watchdog fires. Provider adapters can check
-// errors.Is(err, httputil.ErrUpstreamIdleTimeout) (or context.Cause(ctx)) to
-// distinguish a real upstream stall from caller-initiated cancellation, and
-// the proxy's failover logic keys on this to retry against the next binding.
-//
-// Aliases providers.ErrUpstreamIdleTimeout — the sentinel lives there so
-// providers.IsRetryable can classify it explicitly without an import cycle
-// (this package imports providers). errors.Is matches against either name.
+// ErrUpstreamIdleTimeout is the cause set on the request context when the SSE
+// inactivity watchdog fires; the proxy's failover logic retries on it. Aliases
+// providers.ErrUpstreamIdleTimeout so providers.IsRetryable can classify it
+// without an import cycle — errors.Is matches either name.
 var ErrUpstreamIdleTimeout = providers.ErrUpstreamIdleTimeout
 
-// ErrUpstreamOutputStall re-exports providers.ErrUpstreamOutputStall — the
-// cause set when the output-progress watchdog (StartIdleWatchdogCause) trips
-// because the stream stayed byte-alive but produced no output-bearing content.
+// ErrUpstreamOutputStall re-exports providers.ErrUpstreamOutputStall: set when
+// the output-progress watchdog trips because the stream stayed byte-alive but
+// produced no output-bearing content.
 var ErrUpstreamOutputStall = providers.ErrUpstreamOutputStall
 
-// ErrUpstreamSlowThroughput re-exports providers.ErrUpstreamSlowThroughput —
-// the cause set when the minimum-throughput watchdog (StartThroughputWatchdog)
-// trips because the stream IS producing output, but at a sustained rate below
-// the configured floor over the rolling window.
+// ErrUpstreamSlowThroughput re-exports providers.ErrUpstreamSlowThroughput:
+// set when the minimum-throughput watchdog trips because output is flowing
+// but below the configured floor over the rolling window.
 var ErrUpstreamSlowThroughput = providers.ErrUpstreamSlowThroughput
 
 // DefaultSSEIdleTimeout is the per-read inactivity threshold for streaming
-// upstream responses. AWS NAT Gateway / NLB / VPC-endpoint reapers silently
-// drop idle TCP connections at 350s; a watchdog below that surfaces stalls
-// as a clean error within tens of seconds instead of letting the request
-// hang for the full overall deadline.
-//
-// Tunable via ROUTER_SSE_IDLE_TIMEOUT_SECONDS. Healthy generations stream a
-// chunk at least every few seconds, so 45s of silence is unambiguously a stall.
+// upstream responses. AWS NAT/NLB/VPC-endpoint reapers drop idle TCP
+// connections at 350s; a watchdog below that surfaces stalls quickly instead
+// of hanging for the full deadline. Tunable via ROUTER_SSE_IDLE_TIMEOUT_SECONDS.
 var DefaultSSEIdleTimeout = idleTimeoutFromEnv("ROUTER_SSE_IDLE_TIMEOUT_SECONDS", 45*time.Second)
 
 // DefaultResponsesSSEIdleTimeout is the idle-progress threshold for OpenAI
-// Responses API (/v1/responses) streams. More generous than
-// DefaultSSEIdleTimeout because a gpt-5.x reasoning turn can go tens of
-// seconds between SSE frames while the model thinks (reasoning-summary deltas
-// lag the actual reasoning). ANY received bytes count as progress — event
-// frames, reasoning deltas, keepalives — so only a zero-BYTE gap trips it.
-//
-// This catches the byte-silent stall (2026-06-09: two /v1/responses streams
-// produced no bytes at all until the 600s request cap). It does NOT catch a
-// byte-alive/output-silent stall — a stream that keeps dribbling non-output
-// frames (reasoning deltas, keepalives) while producing zero output tokens
-// (2026-06-16: gpt-5.5 sat at zero output for the full 600s, bytes flowing the
-// whole time). DefaultResponsesOutputStallTimeout guards that mode.
-//
+// Responses API streams. More generous than DefaultSSEIdleTimeout because a
+// gpt-5.x reasoning turn can go tens of seconds between SSE frames; any
+// received byte counts as progress, so only a zero-byte gap trips it. Catches
+// the byte-silent stall (2026-06-09 incident); does not catch a byte-alive but
+// output-silent stall — see DefaultResponsesOutputStallTimeout for that.
 // Tunable via ROUTER_RESPONSES_SSE_IDLE_TIMEOUT_SECONDS.
 var DefaultResponsesSSEIdleTimeout = idleTimeoutFromEnv("ROUTER_RESPONSES_SSE_IDLE_TIMEOUT_SECONDS", 90*time.Second)
 
 // DefaultResponsesOutputStallTimeout is the OUTPUT-progress threshold for
-// OpenAI Responses streams: the maximum time the upstream may stay byte-alive
-// (resetting DefaultResponsesSSEIdleTimeout) while producing zero
-// output-bearing content (assistant text, tool-call arguments, or a terminal
-// response envelope). It is deliberately far larger than the idle timeout so a
-// genuinely long reasoning phase that eventually emits output is never clipped
-// — only a turn that thinks/keepalives for minutes without ever producing
-// output is aborted. Set below the 600s request cap so the watchdog (not the
-// cap) surfaces the stall as a retryable error, while staying generous enough
-// to clear realistic worst-case reasoning. The OUTPUT-progress mark is fed by
-// the Responses→Anthropic translator, which alone can tell output frames from
-// reasoning/keepalive frames.
-//
-// Tunable via ROUTER_RESPONSES_OUTPUT_STALL_TIMEOUT_SECONDS.
+// OpenAI Responses streams: max time the upstream may stay byte-alive while
+// producing zero output-bearing content. Set well above the idle timeout so a
+// long-but-real reasoning phase is never clipped, and below the 600s request
+// cap so the watchdog surfaces the stall as retryable first. Fed by the
+// Responses→Anthropic translator, the only place that can tell output frames
+// from reasoning/keepalive frames. Tunable via
+// ROUTER_RESPONSES_OUTPUT_STALL_TIMEOUT_SECONDS.
 var DefaultResponsesOutputStallTimeout = idleTimeoutFromEnv("ROUTER_RESPONSES_OUTPUT_STALL_TIMEOUT_SECONDS", 240*time.Second)
 
-// DefaultOutputStallTimeout is the OUTPUT-progress threshold for the generic
-// OpenAI-compatible Chat Completions adapter (OpenRouter / Fireworks /
-// DeepInfra / Bedrock). It is the Chat-Completions analogue of
-// DefaultResponsesOutputStallTimeout: DefaultSSEIdleTimeout resets on ANY
-// upstream byte, so a provider that keeps the connection byte-alive with SSE
-// keepalive comments (": OPENROUTER PROCESSING") or empty/role-only delta
-// frames while producing zero output content rides to the 600s request cap.
-//
-// Prod incident 2026-06-19: a DeepInfra deepseek-v4-flash stream stayed
-// byte-alive but output-silent for ~10min until the request cap; the client
-// then retried and hit a model-not-found 404. The byte-idle watchdog (45s)
-// cannot catch a byte-alive stall — only a time-since-last-OUTPUT watchdog can.
-// The mark is fed by the OpenAI→Anthropic SSE translator on output-bearing
-// deltas (assistant text, streamed reasoning, tool-call arguments, terminal
-// finish) and never on keepalives or empty deltas. Unlike the Responses budget,
-// streamed reasoning_content DOES count here: OSS reasoning models emit it as
-// real tokens (rendered as a thinking block), not a sparse server-side summary.
-//
-// Set below the 600s request cap so the watchdog (not the cap) surfaces the
-// stall as a retryable error, while staying generous enough that a large-context
-// prefill emitting only keepalives before its first token is never clipped.
-//
-// Tunable via ROUTER_OUTPUT_STALL_TIMEOUT_SECONDS.
+// DefaultOutputStallTimeout is the Chat-Completions analogue of
+// DefaultResponsesOutputStallTimeout, for the generic OpenAI-compatible
+// adapter (OpenRouter/Fireworks/DeepInfra/Bedrock). DefaultSSEIdleTimeout
+// resets on any byte, so a provider that stays byte-alive via keepalive
+// comments or empty/role-only deltas while emitting zero output content would
+// otherwise ride to the request cap (prod incident 2026-06-19: a DeepInfra
+// stream did this for ~10min, then the client retry hit a 404). Fed by the
+// OpenAI→Anthropic SSE translator on output-bearing deltas only; unlike the
+// Responses budget, streamed reasoning_content counts here since OSS models
+// emit it as real rendered tokens. Tunable via ROUTER_OUTPUT_STALL_TIMEOUT_SECONDS.
 var DefaultOutputStallTimeout = idleTimeoutFromEnv("ROUTER_OUTPUT_STALL_TIMEOUT_SECONDS", 240*time.Second)
 
-// Minimum-throughput watchdog defaults. The byte-idle (45s) and output-stall
-// (240s) watchdogs both catch a stream that STOPS producing — bytes or output
-// respectively. Neither catches a stream that keeps producing output but at a
-// crawl: a clean 200 that dribbles output-bearing deltas steadily enough to
-// reset both marks yet so slowly the turn takes minutes and the client appears
-// frozen, riding toward the 600s request cap with no failover.
+// Minimum-throughput watchdog defaults. The byte-idle and output-stall
+// watchdogs catch a stream that STOPS producing; neither catches one that
+// keeps producing but at a crawl (prod incident 2026-06-25: a deepseek stream
+// dribbled ~13 events/s for ~132s, riding to the request cap without ever
+// being classified retryable). This watchdog measures OUTPUT-event throughput
+// over a rolling window, fed by the same mark as the output-stall watchdog,
+// and aborts with ErrUpstreamSlowThroughput once below-floor after warmup.
 //
-// Prod incident 2026-06-25: a deepseek/deepseek-v4-flash stream emitted ~1774
-// output deltas over ~132s (~13 events/s) — a steadily-flowing 200 that tripped
-// none of the existing watchdogs and was never classified retryable. This
-// watchdog measures sustained OUTPUT-event throughput over a rolling window and,
-// once a warmup has passed, aborts with ErrUpstreamSlowThroughput (retryable)
-// when the rate stays below the floor.
-//
-// The mark is the SAME output-progress signal fed to the output-stall watchdog
-// (one mark per output-bearing delta: assistant text, streamed reasoning,
-// tool-call args, terminal finish — never keepalives/empty deltas). One delta
-// is a small chunk of tokens, so delta-rate is a usable proxy for token-rate
-// without threading byte counts through every translator.
-//
-// CONSERVATIVE BY DESIGN — these defaults err strongly on the side of NOT
-// aborting, so a legitimately slow "thinking" model is never killed:
-//
-//   - Floor (DefaultMinThroughputDeltasPerWindow / DefaultThroughputWindow):
-//     fewer than 8 output deltas in a 20s rolling window (~0.4 deltas/s) is the
-//     abort condition. The prod dribble ran ~13 deltas/s — over 30x this floor —
-//     so this would NOT have fired on it on rate alone; it targets the strictly
-//     worse "near-frozen but technically advancing" tail. A healthy generation
-//     streams many deltas per second, orders of magnitude above the floor.
-//   - Window (DefaultThroughputWindow): 20s rolling window. Long enough that a
-//     brief mid-stream pause (a slow tool-arg chunk, a reasoning gap) does not
-//     trip it; the rate is averaged over the window, not instantaneous.
-//   - Warmup (DefaultThroughputMinElapsed): the watchdog is INERT for the first
-//     90s of the stream. A large-context prefill, a long initial reasoning phase,
-//     or a slow-to-warm provider gets a full grace period before throughput is
-//     ever evaluated. Combined with the rolling window, an abort requires the
-//     stream to be both past warmup AND sustaining sub-floor output.
-//
-// All three are tunable via env so the floor can be relaxed (or the watchdog
-// disabled by setting the floor to 0) without a redeploy.
+// Defaults are conservative so a legitimately slow "thinking" model is never
+// killed: floor is <8 deltas/20s (~0.4/s, >30x below the incident's rate, so
+// it targets only the near-frozen tail); the 20s window absorbs brief
+// mid-stream pauses; the 90s warmup exempts prefill/initial reasoning.
+// All three tunable via env (floor 0 disables the watchdog).
 var (
 	// DefaultThroughputWindow is the rolling window over which output-delta
 	// throughput is measured. Tunable via ROUTER_THROUGHPUT_WINDOW_SECONDS.
@@ -160,11 +96,10 @@ var (
 	// a grace period. Tunable via ROUTER_THROUGHPUT_MIN_ELAPSED_SECONDS.
 	DefaultThroughputMinElapsed = idleTimeoutFromEnv("ROUTER_THROUGHPUT_MIN_ELAPSED_SECONDS", 90*time.Second)
 
-	// DefaultMinThroughputDeltasPerWindow is the minimum number of output-bearing
-	// deltas that must arrive within DefaultThroughputWindow once warmup has
-	// passed; below this the stream is aborted as ErrUpstreamSlowThroughput. A
-	// value <= 0 disables the watchdog entirely. Tunable via
-	// ROUTER_MIN_THROUGHPUT_DELTAS_PER_WINDOW.
+	// DefaultMinThroughputDeltasPerWindow is the minimum output-bearing deltas
+	// required within DefaultThroughputWindow post-warmup, else the stream
+	// aborts as ErrUpstreamSlowThroughput. <= 0 disables the watchdog. Tunable
+	// via ROUTER_MIN_THROUGHPUT_DELTAS_PER_WINDOW.
 	DefaultMinThroughputDeltasPerWindow = intFromEnv("ROUTER_MIN_THROUGHPUT_DELTAS_PER_WINDOW", 8)
 )
 
@@ -204,23 +139,19 @@ const DefaultResponseHeaderTimeout = 30 * time.Second
 
 // NewTransport returns a pooled http.Transport sized for sustained traffic to a single upstream host.
 //
-// KeepAlive=30s is the critical setting against AWS NAT-GW / NLB / VPC-endpoint
-// reapers (350s fixed idle): the dialer's TCP keepalives keep the connection
-// live so the zero-byte-stall failure mode can't accumulate at the network layer.
-// ResponseHeaderTimeout only guards time-to-first-byte; per-read inactivity
-// during streaming is enforced by StreamBody's watchdog.
+// KeepAlive=30s guards against AWS NAT-GW/NLB/VPC-endpoint reapers (350s fixed
+// idle) by keeping the TCP connection live at the network layer.
+// ResponseHeaderTimeout only guards time-to-first-byte; per-read inactivity is
+// enforced separately by StreamBody's watchdog.
 func NewTransport(dialTimeout, tlsTimeout time.Duration) *http.Transport {
 	return NewTransportWithResponseHeaderTimeout(dialTimeout, tlsTimeout, DefaultResponseHeaderTimeout)
 }
 
 // NewTransportWithResponseHeaderTimeout is NewTransport with a caller-chosen
-// time-to-first-byte guard. Upstreams whose first byte can legitimately arrive
-// later than the 30s default pass a larger value: the OpenAI Responses API for
-// gpt-5.x high-effort reasoning can take well over 30s to emit its first SSE
-// event, so a 30s header timeout false-trips even when the model is healthy.
-// Per-read inactivity once the stream is flowing is still bounded by
-// StreamBody's idle watchdog (DefaultSSEIdleTimeout), so a generous header
-// timeout does not reintroduce an unbounded hang.
+// time-to-first-byte guard. Pass a larger value for upstreams whose first byte
+// can legitimately arrive later than 30s (e.g. gpt-5.x high-effort reasoning
+// via Responses API). Streaming inactivity is still bounded separately by
+// StreamBody's idle watchdog, so this can't reintroduce an unbounded hang.
 func NewTransportWithResponseHeaderTimeout(dialTimeout, tlsTimeout, responseHeaderTimeout time.Duration) *http.Transport {
 	return &http.Transport{
 		Proxy: http.ProxyFromEnvironment,
@@ -238,26 +169,18 @@ func NewTransportWithResponseHeaderTimeout(dialTimeout, tlsTimeout, responseHead
 	}
 }
 
-// StartIdleWatchdog starts a goroutine that cancels ctx with ErrUpstreamIdleTimeout
-// when more than idleTimeout has elapsed without a Mark call. The returned mark
-// function should be invoked on every successful upstream read (or other progress
-// signal). The returned stop function terminates the watchdog goroutine and must
-// be called via defer in the caller's scope.
-//
-// idleTimeout <= 0 or cancel == nil disables the watchdog (no-op mark/stop).
+// StartIdleWatchdog cancels ctx with ErrUpstreamIdleTimeout once idleTimeout
+// elapses without a mark() call. Call stop() via defer to terminate the
+// goroutine. idleTimeout <= 0 or cancel == nil disables the watchdog (no-op).
 func StartIdleWatchdog(ctx context.Context, cancel context.CancelCauseFunc, idleTimeout time.Duration) (mark func(), stop func()) {
 	return StartIdleWatchdogCause(ctx, cancel, idleTimeout, ErrUpstreamIdleTimeout)
 }
 
 // StartIdleWatchdogCause is StartIdleWatchdog with a caller-chosen cancel
-// cause. Use it to run a second, independent watchdog on the same request
-// context that measures a different progress signal — e.g. an output-progress
-// watchdog whose mark is fed only on output-bearing events (cause
-// ErrUpstreamOutputStall), running alongside the byte-idle watchdog (cause
-// ErrUpstreamIdleTimeout). Whichever watchdog trips first wins: context cancel
-// causes are set once, so a later cancel from the other watchdog is a no-op.
-//
-// idleTimeout <= 0 or cancel == nil disables the watchdog (no-op mark/stop).
+// cause, letting a second independent watchdog run on the same context for a
+// different progress signal. Whichever trips first wins — cancel causes are
+// set once, so a later cancel from the other watchdog is a no-op.
+// idleTimeout <= 0 or cancel == nil disables the watchdog (no-op).
 func StartIdleWatchdogCause(ctx context.Context, cancel context.CancelCauseFunc, idleTimeout time.Duration, cause error) (mark func(), stop func()) {
 	if idleTimeout <= 0 || cancel == nil {
 		return func() {}, func() {}
@@ -287,44 +210,28 @@ func StartIdleWatchdogCause(ctx context.Context, cancel context.CancelCauseFunc,
 		sync.OnceFunc(func() { close(done) })
 }
 
-// StartThroughputWatchdog starts a goroutine that cancels ctx with cause when
-// the upstream IS producing output but at a sustained rate below minDeltas per
-// window, once minElapsed has passed since the watchdog started. The returned
-// mark must be invoked on every output-bearing delta (the SAME signal fed to
-// the output-progress watchdog); the returned stop terminates the goroutine and
-// must be called via defer.
-//
-// Unlike the idle watchdogs (which measure time-since-last-event), this measures
-// the COUNT of marks within a rolling window: a stream that keeps marking but
-// too slowly is the failure mode here. The watchdog is inert until minElapsed
-// has elapsed, so prefill / initial reasoning is never penalized; thereafter, on
-// each tick it counts marks observed in the trailing window and trips if that
-// count is below minDeltas.
-//
-// minDeltas <= 0, window <= 0, or cancel == nil disables the watchdog
-// (no-op mark/stop). minElapsed <= 0 means evaluate as soon as a full window
-// of data exists.
+// StartThroughputWatchdog cancels ctx with cause when the upstream keeps
+// producing output but at a sustained rate below minDeltas per window (after
+// minElapsed warmup). Unlike the idle watchdogs, which measure time since the
+// last event, this measures the COUNT of mark() calls in a rolling window —
+// call mark() on every output-bearing delta, and stop() via defer.
+// minDeltas <= 0, window <= 0, or cancel == nil disables the watchdog (no-op).
+// minElapsed <= 0 evaluates as soon as a full window of data exists.
 func StartThroughputWatchdog(ctx context.Context, cancel context.CancelCauseFunc, window, minElapsed time.Duration, minDeltas int, cause error) (mark func(), stop func()) {
 	if minDeltas <= 0 || window <= 0 || cancel == nil {
 		return func() {}, func() {}
 	}
 	var count atomic.Int64
 	start := time.Now()
-	// floorRate is the minimum marks-per-second the stream must sustain
-	// (minDeltas spread over one window). Evaluating a normalized RATE rather
-	// than a raw count over the exact window lets the watchdog tick at its own
-	// cadence without the tick interval distorting the measured throughput.
+	// Normalized rate (not raw count) so the tick interval doesn't distort throughput.
 	floorRate := float64(minDeltas) / window.Seconds()
 	done := make(chan struct{})
 	go func() {
-		// Tick several times per window so a sub-floor stretch is caught
-		// promptly; cap small so a short test window still evaluates within it,
-		// and floor so a large production window doesn't spin.
+		// Tick several times per window to catch a sub-floor stretch promptly.
 		interval := min(max(window/4, 50*time.Millisecond), 5*time.Second)
 		ticker := time.NewTicker(interval)
 		defer ticker.Stop()
-		// windowStartCount / windowStart anchor the trailing measurement window.
-		// Marks-in-window = current - snapshot, over now-windowStart seconds.
+		// Anchors the trailing window: marks-in-window = current - snapshot.
 		var windowStartCount int64
 		windowStart := start
 		for {
@@ -364,14 +271,11 @@ func StartThroughputWatchdog(ctx context.Context, cancel context.CancelCauseFunc
 		sync.OnceFunc(func() { close(done) })
 }
 
-// StreamBody reads r chunk-by-chunk into w, flushing after each write. Returns
-// UpstreamStatusError when status is non-2xx.
-//
-// When idleTimeout > 0 a watchdog goroutine cancels ctx via cancel with
-// ErrUpstreamIdleTimeout if no upstream bytes arrive for idleTimeout. Callers
-// must pass a context wrapped via context.WithCancelCause so the cause survives
-// to the error site. On stall, returns ErrUpstreamIdleTimeout directly so the
-// caller does not need to inspect context.Cause itself.
+// StreamBody reads r chunk-by-chunk into w, flushing after each write.
+// Returns UpstreamStatusError when status is non-2xx. When idleTimeout > 0, a
+// watchdog cancels ctx with ErrUpstreamIdleTimeout on stall and StreamBody
+// returns that error directly; ctx must be wrapped via context.WithCancelCause
+// so the cause survives to the error site.
 func StreamBody(ctx context.Context, cancel context.CancelCauseFunc, idleTimeout time.Duration, r io.Reader, status int, w http.ResponseWriter, t *otel.Timing) error {
 	mark, stop := StartIdleWatchdog(ctx, cancel, idleTimeout)
 	defer stop()
@@ -398,10 +302,8 @@ func StreamBody(ctx context.Context, cancel context.CancelCauseFunc, idleTimeout
 			return nil
 		}
 		if readErr != nil {
-			// A second watchdog (e.g. the OpenAI output-progress watchdog) may
-			// share this ctx and cancel with a different cause; surface whichever
-			// sentinel tripped so the caller classifies it retryable instead of
-			// seeing a bare context.Canceled.
+			// A different watchdog sharing this ctx may have cancelled it; surface
+			// its sentinel so the caller can classify retryable instead of context.Canceled.
 			if cause := context.Cause(ctx); errors.Is(cause, ErrUpstreamIdleTimeout) || errors.Is(cause, ErrUpstreamOutputStall) || errors.Is(cause, ErrUpstreamSlowThroughput) {
 				return cause
 			}

--- a/internal/proxy/client_identity.go
+++ b/internal/proxy/client_identity.go
@@ -9,9 +9,8 @@ import (
 	"workweave/router/internal/observability"
 )
 
-// ClientIdentity holds per-request user identification signals. Email is the
-// cross-protocol identity persisted to router.model_router_users.email;
-// DisplayName is the optional free-form label persisted to display_name.
+// ClientIdentity holds per-request user identification signals, persisted to
+// router.model_router_users (Email, DisplayName).
 type ClientIdentity struct {
 	DeviceID    string
 	AccountID   string
@@ -20,9 +19,8 @@ type ClientIdentity struct {
 	DisplayName string
 	UserAgent   string
 	ClientApp   string
-	// RolloutID is the eval/training-harness correlation id from the
-	// x-weave-rollout-id header. Joins a sandbox rollout's graded reward
-	// onto every routing decision made inside it. Empty for normal traffic.
+	// RolloutID is the x-weave-rollout-id eval/training-harness correlation
+	// id; joins a sandbox rollout's graded reward to its routing decisions.
 	RolloutID string
 }
 
@@ -35,10 +33,10 @@ func ClientIdentityFrom(ctx context.Context) ClientIdentity {
 	return id
 }
 
-// ResolveUserFromContext pulls identity signals from ctx and hands them to
-// auth.Service.ResolveAndStashUser. No-op when deps are missing or both
-// email and account_uuid are empty. Claude CLI v2.1.x packs only
-// account_uuid (no email), so guarding on email alone would defeat that path.
+// ResolveUserFromContext dispatches identity signals from ctx to
+// auth.Service.ResolveAndStashUser. No-op if deps are missing or both email
+// and account_uuid are empty — Claude CLI v2.1.x sends account_uuid only, so
+// gating on email alone would break that path.
 func ResolveUserFromContext(ctx context.Context, authSvc *auth.Service, installation *auth.Installation) context.Context {
 	log := observability.Get()
 	if authSvc == nil || installation == nil {
@@ -92,12 +90,11 @@ func ParseClaudeCodeMetadata(raw string) ClaudeCodeMetadata {
 const MaxEmailLen = 254
 
 // MaxClientIdentifierLen bounds caller-controlled opaque identifiers.
-// Claude Code emits ~36-char UUIDs; 128 is overhead with flood-protection.
+// Claude Code emits ~36-char UUIDs; 128 leaves flood-protection headroom.
 const MaxClientIdentifierLen = 128
 
-// NormalizeClientIdentifier returns input unchanged when within bounds, else "".
-// Rejection (not truncation) keeps shape honest: a truncated identifier looks
-// valid but no longer correlates.
+// NormalizeClientIdentifier returns s unchanged if within bounds, else "".
+// Rejects rather than truncates: a truncated id looks valid but no longer correlates.
 func NormalizeClientIdentifier(s string) string {
 	if len(s) > MaxClientIdentifierLen {
 		return ""
@@ -109,13 +106,11 @@ func NormalizeClientIdentifier(s string) string {
 const RolloutIDHeader = "X-Weave-Rollout-Id"
 
 // MaxRolloutIDLen bounds the rollout correlation id. Harness ids compose
-// run_id/condition/seed/instance_id and can exceed the 128-byte client
-// identifier cap; 256 covers them with flood-protection headroom.
+// run_id/condition/seed/instance_id, exceeding the 128-byte client id cap.
 const MaxRolloutIDLen = 256
 
-// NormalizeRolloutID trims and bounds a rollout id. Rejection (not
-// truncation) for the same reason as NormalizeClientIdentifier: a truncated
-// id looks valid but no longer joins.
+// NormalizeRolloutID trims and bounds a rollout id, rejecting (not
+// truncating) oversized values — same reasoning as NormalizeClientIdentifier.
 func NormalizeRolloutID(s string) string {
 	s = strings.TrimSpace(s)
 	if len(s) > MaxRolloutIDLen {
@@ -124,11 +119,10 @@ func NormalizeRolloutID(s string) string {
 	return s
 }
 
-// NormalizeEmail trims, lower-cases, and structurally validates an email
-// to match the case-sensitive unique index on (installation_id, email).
-// Returns "" when empty, oversized, or malformed. Deliverability is not
-// checked: email is an opaque identifier, and the shape check is
-// flood-protection.
+// NormalizeEmail trims, lower-cases, and structurally validates an email to
+// match the case-sensitive unique index on (installation_id, email).
+// Returns "" when empty, oversized, or malformed. Deliverability isn't
+// checked — email is treated as an opaque identifier.
 func NormalizeEmail(s string) string {
 	s = strings.ToLower(strings.TrimSpace(s))
 	if s == "" || len(s) > MaxEmailLen {
@@ -163,14 +157,12 @@ var clientAppAliases = map[string]string{
 }
 
 // MaxClientAppLen bounds the X-App header. Canonical values are short
-// (claude-code, codex, cursor); longer values are header smuggling attempts.
+// (claude-code, codex, cursor); longer values suggest header smuggling.
 const MaxClientAppLen = 32
 
-// NormalizeClientApp returns the canonical client_app for a request. If the
-// caller sent an explicit X-App header within length bounds, we trust it
-// (lower-cased). Otherwise we fall back to a coarse User-Agent classifier so
-// older installs that don't yet send X-App still get attributed. Returns ""
-// when neither signal is recognized — telemetry leaves the column NULL.
+// NormalizeClientApp trusts an explicit, in-bounds X-App header (lower-cased);
+// otherwise falls back to a coarse User-Agent classifier for older installs
+// that don't send X-App. Returns "" when neither signal is recognized.
 func NormalizeClientApp(xApp, userAgent string) string {
 	xApp = strings.ToLower(strings.TrimSpace(xApp))
 	if xApp != "" && len(xApp) <= MaxClientAppLen {
@@ -197,15 +189,13 @@ func NormalizeClientApp(xApp, userAgent string) string {
 	return ""
 }
 
-// MaxDisplayNameLen bounds the free-form display name. 128 mirrors the
-// installer-side cap; longer values almost certainly indicate a header
-// smuggling attempt rather than a real name.
+// MaxDisplayNameLen bounds the free-form display name, mirroring the
+// installer-side cap; longer values suggest header smuggling, not a real name.
 const MaxDisplayNameLen = 128
 
-// NormalizeDisplayName trims and strips control characters from a free-form
-// display name. Returns "" when empty or oversized. We don't case-fold —
-// names are free-form, not lookup keys — but we do drop control bytes a
-// malicious header could carry so the value is safe to persist and render.
+// NormalizeDisplayName trims and strips control characters (so a malicious
+// header can't smuggle bytes) from a display name. Returns "" if empty or
+// oversized. Not case-folded — names are free-form, not lookup keys.
 func NormalizeDisplayName(s string) string {
 	s = strings.TrimSpace(s)
 	if s == "" || len(s) > MaxDisplayNameLen {

--- a/internal/proxy/credentials.go
+++ b/internal/proxy/credentials.go
@@ -9,15 +9,14 @@ import (
 	"workweave/router/internal/providers"
 )
 
-// subscriptionTokenPrefix marks a Claude subscription (Claude.ai OAuth) bearer.
-// Matches the "oat" (OAuth token) stem so it covers both the sk-ant-oat- and
-// the real-world sk-ant-oat01-… Claude Code subscription/access-token shapes.
+// subscriptionTokenPrefix marks a Claude subscription (Claude.ai OAuth)
+// bearer. Matches the "oat" stem to cover both sk-ant-oat- and the
+// real-world sk-ant-oat01-… shapes.
 const subscriptionTokenPrefix = "sk-ant-oat"
 
-// chatGPTAccountIDHeader is the inbound header Codex sends alongside a ChatGPT
-// subscription bearer (self-hosted/passthrough path). Its presence disambiguates
-// a Codex subscription JWT from a plain OpenAI client API key. http.Header.Get
-// canonicalizes the key, so casing variants resolve to the same value.
+// chatGPTAccountIDHeader is the header Codex sends alongside a ChatGPT
+// subscription bearer; its presence disambiguates that JWT from a plain
+// OpenAI API key.
 const chatGPTAccountIDHeader = "ChatGPT-Account-ID"
 
 // Credential sources, for logging and precedence reasoning. Never log the key
@@ -33,14 +32,12 @@ const (
 type Credentials struct {
 	APIKey []byte // never logged
 	Source string // credSourceBYOK | credSourceClient | credSourceSubscription | credSourceCodexSubscription
-	// OAuth marks a subscription bearer — a Claude subscription token
-	// (sk-ant-oat-, resolved only for Anthropic) or a Codex ChatGPT JWT
-	// (resolved only for OpenAI). It authenticates via Authorization: Bearer
-	// and never x-api-key. Zero value (false) = a normal API key.
+	// OAuth marks a subscription bearer (Claude sk-ant-oat- token, Anthropic
+	// only; or Codex ChatGPT JWT, OpenAI only). Authenticates via
+	// Authorization: Bearer, never x-api-key.
 	OAuth bool
 	// AccountID is the ChatGPT-Account-ID paired with a Codex subscription
-	// bearer; the Codex backend 401/403s without it. Set only for Codex
-	// subscription credentials, never logged, empty otherwise.
+	// bearer; the Codex backend 401/403s without it. Never logged.
 	AccountID []byte
 }
 
@@ -48,10 +45,9 @@ type Credentials struct {
 // stashed by the auth middleware.
 type ExternalAPIKeysContextKey struct{}
 
-// BuildCredentialsMap builds a map of provider -> Credentials from external
-// keys. Entries with empty plaintext are dropped: an empty-keyed row would
-// otherwise enroll the provider into the routing eligibility set and cause
-// the scorer to pick a model the upstream call would 401 on.
+// BuildCredentialsMap builds provider -> Credentials from external keys.
+// Empty-plaintext entries are dropped so the scorer doesn't route to a
+// provider whose upstream call would 401.
 func BuildCredentialsMap(keys []*auth.ExternalAPIKey) map[string]*Credentials {
 	if len(keys) == 0 {
 		return nil
@@ -72,35 +68,29 @@ func BuildCredentialsMap(keys []*auth.ExternalAPIKey) map[string]*Credentials {
 	return m
 }
 
-// ExtractClientCredentials extracts provider credentials from request headers.
-// Anthropic uses x-api-key; OpenAI and Google use Authorization: Bearer.
+// ExtractClientCredentials extracts provider credentials from request
+// headers. Anthropic uses x-api-key; OpenAI and Google use
+// Authorization: Bearer.
 //
-// Router-issued bearers (rk_...) authenticate the same headers via WithAuth,
-// so we reject any token carrying auth.APIKeyPrefix to prevent router
-// credentials from leaking upstream. TrimSpace matches the auth middleware's
-// normalization so embedded whitespace can't slip past the prefix guard.
+// Rejects any token with auth.APIKeyPrefix — router-issued bearers (rk_...)
+// use the same headers via WithAuth, and this stops them leaking upstream.
 func ExtractClientCredentials(provider string, headers http.Header) *Credentials {
-	// Anthropic is its own translation family and reads x-api-key / sk-ant-
-	// shapes, so it keeps a dedicated branch. Every other family (OpenAI-compat
-	// plus Gemini/Google, which shares the Authorization: Bearer shape) resolves
-	// via the shared Bearer branch — keyed off the family so a newly-added
-	// OpenAI-compat provider's client bearer is honored without editing a list.
+	// Anthropic reads x-api-key / sk-ant- shapes and keeps its own branch.
+	// Every other family shares the Authorization: Bearer branch, keyed off
+	// family so a new OpenAI-compat provider works without editing a list.
 	family := providers.FamilyFor(provider)
 	if family == providers.FamilyAnthropic {
-		// Real Anthropic API keys carry the sk-ant- prefix; requiring it here
-		// prevents a misplaced cross-provider key (e.g. an OpenAI `sk-…`
-		// passed in `x-api-key` by mistake) from being misclassified as
-		// Anthropic creds and routed through the summarizer / upstream call.
+		// Requiring the sk-ant- prefix here prevents a misplaced
+		// cross-provider key (e.g. an OpenAI key in x-api-key) from being
+		// misclassified as Anthropic creds.
 		if key := strings.TrimSpace(headers.Get("x-api-key")); key != "" &&
 			!auth.HasAPIKeyPrefix(key) && strings.HasPrefix(key, "sk-ant-") {
 			return &Credentials{APIKey: []byte(key), Source: credSourceClient}
 		}
-		// Authorization: Bearer with a real Anthropic API key (sk-ant-api-…) is
-		// legitimate client creds. OAuth bearers (sk-ant-oat-…) are Claude
-		// subscription (Claude.ai login) session tokens: they DO work against
-		// /v1/messages, but only with Authorization: Bearer + the oauth beta
-		// header and no x-api-key — the anthropic client applies both.
-		// We forward them so a caller's subscription pays for their Claude turns.
+		// sk-ant-api-… is a legitimate client key. sk-ant-oat-… is a Claude
+		// subscription (Claude.ai login) token — works against /v1/messages
+		// only via Bearer + oauth beta header, no x-api-key. Forwarded so
+		// the caller's subscription pays for their turns.
 		if raw, found := strings.CutPrefix(headers.Get("Authorization"), "Bearer "); found {
 			key := strings.TrimSpace(raw)
 			if !auth.HasAPIKeyPrefix(key) {
@@ -122,21 +112,16 @@ func ExtractClientCredentials(provider string, headers http.Header) *Credentials
 	authHeader := headers.Get("Authorization")
 	if raw, found := strings.CutPrefix(authHeader, "Bearer "); found {
 		key := strings.TrimSpace(raw)
-		// A Codex ChatGPT subscription bearer arrives on the OpenAI surface
-		// with a ChatGPT-Account-ID header; that pairing is the signal that
-		// distinguishes the subscription JWT from a plain client API key, so
-		// we resolve it before the client-key branch. OpenAI-only — the JWT
-		// can't authenticate any other Bearer-using upstream, and a caller's
-		// stray ChatGPT-Account-ID on a non-OpenAI route must not reclassify
-		// that route's bearer.
+		// A Codex ChatGPT subscription bearer pairs with a ChatGPT-Account-ID
+		// header; resolve it before the client-key branch. OpenAI-only, so a
+		// stray header on another route can't reclassify its bearer.
 		if provider == providers.ProviderOpenAI {
 			if sub := codexSubscriptionCreds(key, headers.Get(chatGPTAccountIDHeader)); sub != nil {
 				return sub
 			}
 		}
-		// Reject Anthropic-shaped tokens (API keys AND OAuth bearers)
-		// here so one Bearer header doesn't get misidentified as creds
-		// for every Bearer-using provider.
+		// Reject Anthropic-shaped tokens (keys and OAuth bearers) so one
+		// Bearer header isn't misidentified as creds for every provider.
 		if key != "" && !auth.HasAPIKeyPrefix(key) && !strings.HasPrefix(key, "sk-ant-") {
 			return &Credentials{APIKey: []byte(key), Source: credSourceClient}
 		}
@@ -144,11 +129,9 @@ func ExtractClientCredentials(provider string, headers http.Header) *Credentials
 	return nil
 }
 
-// ResolveCredentials returns the credentials to use for provider, in precedence
-// order: a caller's Claude subscription token (Anthropic only) first, then BYOK,
-// then any other client-supplied header credential. Subscription-first lets a
-// caller's own subscription pay for their Claude turns even when an
-// installation BYOK Anthropic key is also configured.
+// ResolveCredentials picks credentials for provider in precedence order:
+// caller's Claude subscription token first (so it pays even when BYOK
+// Anthropic is configured), then BYOK, then other client-header creds.
 func ResolveCredentials(provider string, byok map[string]*Credentials, headers http.Header) *Credentials {
 	client := ExtractClientCredentials(provider, headers)
 	if client != nil && client.OAuth {
@@ -160,10 +143,8 @@ func ResolveCredentials(provider string, byok map[string]*Credentials, headers h
 	return client
 }
 
-// subscriptionCredsFromToken returns subscription credentials for a bare token
-// (router-key prefix already excluded by the caller), or nil if it isn't a
-// Claude subscription bearer. Anthropic-only: the token authenticates only
-// against Anthropic's Messages API.
+// subscriptionCredsFromToken returns subscription credentials for a bare
+// token, or nil if it isn't a Claude subscription bearer. Anthropic-only.
 func subscriptionCredsFromToken(token string) *Credentials {
 	if !strings.HasPrefix(token, subscriptionTokenPrefix) {
 		return nil
@@ -171,13 +152,10 @@ func subscriptionCredsFromToken(token string) *Credentials {
 	return &Credentials{APIKey: []byte(token), Source: credSourceSubscription, OAuth: true}
 }
 
-// codexSubscriptionCreds returns Codex (ChatGPT) subscription credentials for a
-// bare OAuth access token paired with its ChatGPT account id, or nil if the
-// pair isn't a usable Codex subscription. The token is a ChatGPT-login JWT
-// (eyJ…); we reject router keys (rk_) and OpenAI API keys (sk-…), and require a
-// non-empty account id because the Codex backend (chatgpt.com/backend-api/codex)
-// 401/403s without the ChatGPT-Account-ID header. OpenAI-only: the JWT can't
-// authenticate any other upstream.
+// codexSubscriptionCreds returns Codex subscription credentials for a
+// ChatGPT-login JWT paired with its account id, or nil otherwise. Rejects
+// router keys and OpenAI API keys; requires a non-empty account id since
+// the Codex backend 401/403s without it. OpenAI-only.
 func codexSubscriptionCreds(token, accountID string) *Credentials {
 	token = strings.TrimSpace(token)
 	accountID = strings.TrimSpace(accountID)
@@ -195,10 +173,8 @@ func codexSubscriptionCreds(token, accountID string) *Credentials {
 	}
 }
 
-// subscriptionCredsFromHeaderValue resolves the dedicated
-// X-Weave-Anthropic-Subscription header value into subscription credentials.
-// Rejects empty, router-key-prefixed, and non-subscription values so token
-// shape knowledge stays in this file.
+// subscriptionCredsFromHeaderValue resolves the X-Weave-Anthropic-Subscription
+// header into subscription credentials, or nil if empty/router-keyed/invalid.
 func subscriptionCredsFromHeaderValue(sub string) *Credentials {
 	sub = strings.TrimSpace(sub)
 	if sub == "" || auth.HasAPIKeyPrefix(sub) {
@@ -207,11 +183,10 @@ func subscriptionCredsFromHeaderValue(sub string) *Credentials {
 	return subscriptionCredsFromToken(sub)
 }
 
-// clearCredentials returns a context whose resolved-credentials value is an
-// explicit nil, so CredentialsFromContext reports none and the provider client
-// falls back to its deployment key. Used to keep a caller's subscription/client
-// credential off the router's own synthetic upstream calls (e.g. the handover
-// summarizer), which lack the Claude Code identity a subscription token needs.
+// clearCredentials sets an explicit nil so CredentialsFromContext reports
+// none and the provider client falls back to its deployment key. Used to
+// keep a caller's subscription off synthetic upstream calls (e.g. the
+// handover summarizer), which lack the identity a subscription token needs.
 func clearCredentials(ctx context.Context) context.Context {
 	return context.WithValue(ctx, CredentialsContextKey{}, (*Credentials)(nil))
 }

--- a/internal/proxy/force_model.go
+++ b/internal/proxy/force_model.go
@@ -19,13 +19,11 @@ import (
 )
 
 // ForceModelHeader pins the session to a specific model, mirroring the
-// /force-model chat command. The header form exists so the directive is usable
-// from headless clients (the eval harness, CI smoke runs) where the slash
-// command is unreliable: Claude Code eats "/force-model …" as a client-side
-// slash command before it ever reaches the router, and a typed two-call pin
-// consumes a turn. A header rides on every request, so the pin is (re)written
-// and served on the same turn. Empty or unrecognized values are ignored and
-// routing proceeds automatically rather than failing the request.
+// /force-model chat command. Needed for headless clients (eval harness, CI
+// smoke runs): Claude Code eats "/force-model …" as a client-side slash
+// command before it reaches the router. The header rides on every request,
+// so the pin is (re)written and served on the same turn. Unrecognized values
+// are ignored; routing proceeds automatically rather than failing.
 const ForceModelHeader = "x-weave-force-model"
 
 var forceModelAliases = map[string]string{
@@ -73,9 +71,8 @@ var forceModelAliases = map[string]string{
 	"kimi":           "moonshotai/kimi-k2.7",
 	"kimi-k2.7":      "moonshotai/kimi-k2.7",
 	"kimi-k2.6":      "moonshotai/kimi-k2.6",
-	// Generic aliases stay on glm-5.1 (DeepInfra + OpenRouter) so they
-	// resolve on managed-prod deploys without a Fireworks key; glm-5.2 is
-	// Fireworks-only day-0. Pin glm-5.2 explicitly to opt into it.
+	// Generic glm/zai aliases stay on 5.1 (DeepInfra+OpenRouter, no Fireworks
+	// key needed); 5.2 is Fireworks-only day-0, so it requires an explicit pin.
 	"glm":          "z-ai/glm-5.1",
 	"zai":          "z-ai/glm-5.1",
 	"z-ai":         "z-ai/glm-5.1",
@@ -89,25 +86,17 @@ var forceModelAliases = map[string]string{
 }
 
 // resolveForceModel maps a user-typed model identifier to its canonical
-// catalog ID and primary provider binding. The catalog is the source of
-// truth — heuristics are only a best-effort provider guess for inputs that
-// are not in it.
+// catalog ID and primary provider. The catalog is the source of truth;
+// naming heuristics are only a best-effort provider guess for inputs not in
+// it. Resolution order: alias -> exact catalog.ByID match -> suffix match
+// (so bare names like `qwen3-235b-a22b-2507` resolve to their real binding,
+// e.g. `qwen/qwen3-235b-a22b-2507`, instead of misclassifying as Anthropic)
+// -> naming heuristic.
 //
-// Resolution order:
-//  1. Alias match for common user-facing shortcuts.
-//  2. Exact match against `catalog.ByID` (the input is already canonical).
-//  3. Suffix match: scan the catalog for any model whose ID ends with
-//     "/" + input. Lets users type bare names like `qwen3-235b-a22b-2507`
-//     and have the pin route to `qwen/qwen3-235b-a22b-2507` on its real
-//     binding (bedrock, in this case) instead of misclassifying it as
-//     Anthropic.
-//  4. Naming heuristic for IDs not in the catalog (provider guess only).
-//
-// The returned `known` flag is true only for catalog matches (1, 2, and 3). A
-// false `known` means the input has no catalog entry, so the router can't
-// confirm it names a real, servable model. Callers must reject the command
-// rather than pin an unservable directive. The heuristic provider is still
-// returned for logging.
+// `known` is true only for catalog matches. False means there's no catalog
+// entry to confirm this is a real, servable model — callers must reject the
+// command rather than pin it; the heuristic provider is still returned for
+// logging.
 func resolveForceModel(model string) (canonicalID, provider string, known bool) {
 	model = strings.ToLower(strings.TrimSpace(model))
 	if alias, ok := forceModelAliases[model]; ok {
@@ -146,11 +135,10 @@ func resolveForceModel(model string) (canonicalID, provider string, known bool) 
 	}
 }
 
-// setForceModelPin upserts an immutable user-forced session pin for the given
-// session/role. It preserves the prior pin's LastServedModel so the next turn
-// can still detect a mid-session model switch and strip stale Anthropic
-// thinking-block signatures. No-op when the pin store is unconfigured or
-// installationID is nil (pin rows require an installation_id).
+// setForceModelPin upserts an immutable user-forced session pin. It preserves
+// the prior pin's LastServedModel so the next turn can detect a mid-session
+// model switch and strip stale Anthropic thinking-block signatures. No-op if
+// the pin store is unconfigured or installationID is nil.
 func (s *Service) setForceModelPin(
 	ctx context.Context,
 	sessionKey [sessionpin.SessionKeyLen]byte,
@@ -180,18 +168,15 @@ func (s *Service) setForceModelPin(
 		PinnedUntil:     pinNeverExpires,
 		LastServedModel: lastServedModel,
 	}
-	// context.Background(): the request ctx may already be canceled by the time
-	// this runs (synthetic response written, or client disconnected). Upserting
-	// on a canceled context would leave Postgres holding the prior pin.
+	// context.Background(): ctx may already be canceled here (response written,
+	// client disconnected); a canceled ctx would leave the prior pin stuck.
 	return s.pinStore.Upsert(context.Background(), forced)
 }
 
-// applyForceModelHeader honors the x-weave-force-model request header by writing
-// a user-forced session pin, the same sticky the /force-model command writes.
-// The pin is (re)written on every request that carries the header, so the turn
-// loop's user-forced branch serves the requested model on this turn and stays on
-// it for the session. Unrecognized models are ignored (routing proceeds
-// automatically); the request is never failed on a bad header value.
+// applyForceModelHeader honors the x-weave-force-model request header,
+// writing the same session pin the /force-model command writes. It's
+// (re)written on every request carrying the header. Unrecognized models are
+// ignored (routing proceeds automatically) rather than failing the request.
 func (s *Service) applyForceModelHeader(
 	ctx context.Context,
 	r *http.Request,
@@ -229,11 +214,11 @@ func (s *Service) applyForceModelHeader(
 	)
 }
 
-// handleForceModelCommand processes a /force-model or /unforce-model directive.
-// It writes (or expires) the session pin and returns a synthetic Anthropic-format
-// acknowledgment response without dispatching to any upstream.
-// inputTokens should reflect the request's RoutingFeatures.Tokens to include the
-// actual turn input in the token counter (not just the synthetic response text).
+// handleForceModelCommand processes a /force-model or /unforce-model directive:
+// writes (or expires) the session pin and returns a synthetic acknowledgment
+// response without dispatching upstream. inputTokens should be the request's
+// RoutingFeatures.Tokens so the token counter reflects actual turn input, not
+// just the synthetic response text.
 func (s *Service) handleForceModelCommand(
 	ctx context.Context,
 	w http.ResponseWriter,
@@ -246,10 +231,9 @@ func (s *Service) handleForceModelCommand(
 	log := observability.FromContext(ctx)
 	role := roleForTier(catalog.TierFor(env.Model()))
 
-	// Acknowledgment text is formatted as a routing marker (✦ **Weave Router** → …\n\n)
-	// so the existing StripRoutingMarkerFromMessages ingress stripper removes it from
-	// subsequent inbound requests. Without this, the text persists in conversation
-	// history and leaks router internals to the upstream on every following turn.
+	// Formatted as a routing marker (✦ **Weave Router** → …\n\n) so
+	// StripRoutingMarkerFromMessages strips it from later inbound requests;
+	// otherwise it'd persist in history and leak router internals upstream.
 	var msg string
 	if cmd.Clear {
 		if s.pinStore != nil && installationID != uuid.Nil {
@@ -263,9 +247,8 @@ func (s *Service) handleForceModelCommand(
 				TurnCount:      1,
 				PinnedUntil:    time.Now().Add(-time.Second),
 			}
-			// context.Background(): the request ctx may be canceled by the
-			// time the synthetic response has been written. Upserting on a
-			// canceled context would leave Postgres holding the prior pin.
+			// context.Background(): ctx may be canceled by the time the
+			// synthetic response is written; a canceled ctx would strand the prior pin.
 			if err := s.pinStore.Upsert(context.Background(), expired); err != nil {
 				log.Error("/unforce-model: pin store upsert failed", "err", err)
 				return err
@@ -275,19 +258,14 @@ func (s *Service) handleForceModelCommand(
 		if env.SourceFormat() == translate.FormatOpenAI {
 			msg = "Weave Router: force-model cleared; resuming automatic model selection"
 		}
-		// Debug (not Info) per router logging rules: session_key_hex is a stable
-		// per-session identifier and this fires on every command use. The Info
-		// signal "a session pin was cleared" isn't a major business event worth
-		// emitting at default verbosity.
+		// Debug not Info: fires on every command use, not a major business event.
 		log.Debug("/unforce-model: session pin cleared",
 			"session_key_hex", fmt.Sprintf("%x", sessionKey),
 			"role", role,
 		)
 	} else if canonicalModel, provider, known := resolveForceModel(cmd.Model); !known {
-		// The model isn't in the catalog, so we can't confirm it names a real,
-		// servable model — e.g. a truncated "/force-model gpt-". Reject the
-		// directive rather than pin something we can't honor; the previous pin
-		// (if any) is left untouched.
+		// Not in the catalog (e.g. truncated "/force-model gpt-") — reject
+		// rather than pin something we can't honor; prior pin left untouched.
 		log.Info("/force-model: rejected unknown model",
 			"input_model", cmd.Model,
 			"session_key_hex", fmt.Sprintf("%x", sessionKey),
@@ -324,9 +302,8 @@ func (s *Service) handleForceModelCommand(
 }
 
 // writeSyntheticAnthropicResponse writes a minimal Anthropic Messages API
-// response without hitting an upstream. Handles both streaming and
-// non-streaming request shapes. inputTokens is the request's RoutingFeatures.Tokens
-// so the client's token counter reflects the actual turn input.
+// response without hitting an upstream, handling both streaming and
+// non-streaming shapes.
 func writeSyntheticAnthropicResponse(w http.ResponseWriter, env *translate.RequestEnvelope, text string, inputTokens int) error {
 	msgID := fmt.Sprintf("msg_router_cmd_%x", time.Now().UnixNano())
 	if env.Stream() {
@@ -408,9 +385,8 @@ func writeSyntheticAnthropicSSE(w http.ResponseWriter, msgID, text string, input
 }
 
 // writeSyntheticOpenAIResponse writes a minimal OpenAI Chat Completions
-// response without hitting an upstream. Handles both streaming and
-// non-streaming request shapes. inputTokens is the request's RoutingFeatures.Tokens
-// so the client's token counter reflects the actual turn input.
+// response without hitting an upstream, handling both streaming and
+// non-streaming shapes.
 func writeSyntheticOpenAIResponse(w http.ResponseWriter, env *translate.RequestEnvelope, text string, inputTokens int) error {
 	respID := fmt.Sprintf("chatcmpl_router_cmd_%x", time.Now().UnixNano())
 	if env.Stream() {

--- a/internal/proxy/handover.go
+++ b/internal/proxy/handover.go
@@ -21,29 +21,25 @@ import (
 	"workweave/router/internal/translate"
 )
 
-// DefaultHandoverModel is the Anthropic model used to summarize prior
-// conversation before a mid-session model switch. Haiku-class is intentional:
-// summarization is one of the cheapest workloads available.
+// DefaultHandoverModel summarizes prior conversation before a mid-session
+// model switch. Haiku-class is intentional: summarization is cheap.
 const DefaultHandoverModel = "claude-haiku-4-5"
 
-// DefaultHandoverTimeout bounds the summarizer call so a slow upstream
-// cannot block the request path. Tuned to allow haiku-class summarization
-// of ~20k-token sessions, which observed ~5-7s p95 on Anthropic.
+// DefaultHandoverTimeout bounds the summarizer call. Tuned for ~5-7s p95
+// observed for haiku-class summarization of ~20k-token sessions.
 const DefaultHandoverTimeout = 8 * time.Second
 
 // DefaultHandoverMaxTokens caps the synthesized summary length.
 const DefaultHandoverMaxTokens = 800
 
-// handoverInstruction is appended as a final user message to elicit the
-// summary. Kept explicit about what must be preserved so a routing switch
-// does not lose decisions, file paths, or the user's latest intent.
+// handoverInstruction elicits the summary as a final user message, explicit
+// about what must survive the switch (decisions, paths, latest intent).
 const handoverInstruction = "Summarize the conversation so far in <= 800 tokens. " +
 	"Preserve all decisions, file paths, code snippets, and the user's latest intent. " +
 	"Output only the summary text — no preamble, no closing remark."
 
-// ProviderSummarizer adapts a providers.Client to the handover.Summarizer
-// interface by building a small Anthropic Messages request from the inbound
-// envelope's prior conversation.
+// ProviderSummarizer adapts a providers.Client to handover.Summarizer by
+// building a small Anthropic Messages request from the prior conversation.
 type ProviderSummarizer struct {
 	client    providers.Client
 	model     string
@@ -86,11 +82,10 @@ func (s *ProviderSummarizer) Provider() string {
 // assistant text was extractable.
 var ErrEmptySummary = errors.New("handover: upstream returned no summary text")
 
-// Summarize implements handover.Summarizer. Builds an Anthropic Messages call,
-// dispatches through the configured client under a hard timeout. Returns the
-// summary text and the upstream usage breakdown so callers can debit the
-// summary as a separate ledger row. On failure returns ("", zero Usage, err)
-// so the caller can pass the full prior history through unchanged.
+// Summarize implements handover.Summarizer: builds and dispatches an
+// Anthropic Messages call under a hard timeout, returning summary text plus
+// usage for a separate ledger row. On failure returns ("", zero Usage, err)
+// so the caller falls back to the full prior history.
 func (s *ProviderSummarizer) Summarize(ctx context.Context, env *translate.RequestEnvelope) (string, handover.Usage, error) {
 	log := observability.FromContext(ctx)
 	if env == nil {
@@ -155,8 +150,7 @@ func (s *ProviderSummarizer) Summarize(ctx context.Context, env *translate.Reque
 }
 
 // extractAnthropicUsage pulls the usage block from an Anthropic non-streaming
-// Messages response. Missing fields are zero — the response shape is stable
-// enough that we don't bother distinguishing "absent" from "zero".
+// Messages response. Missing fields are zero; we don't distinguish "absent".
 func extractAnthropicUsage(body []byte) handover.Usage {
 	if !gjson.ValidBytes(body) {
 		return handover.Usage{}
@@ -173,9 +167,9 @@ func extractAnthropicUsage(body []byte) handover.Usage {
 	}
 }
 
-// buildHandoverRequestBody constructs a non-streaming Anthropic Messages
-// request from the inbound envelope's prior conversation, injecting a
-// summary instruction and overriding model/max_tokens/stream.
+// buildHandoverRequestBody builds a non-streaming Anthropic Messages request
+// from the envelope's prior conversation, injecting the summary instruction
+// and overriding model/max_tokens/stream.
 func buildHandoverRequestBody(env *translate.RequestEnvelope, model string, maxTokens int) ([]byte, error) {
 	prep, err := env.PrepareAnthropic(nil, translate.EmitOptions{TargetModel: model})
 	if err != nil {
@@ -254,18 +248,13 @@ func extractAnthropicAssistantText(body []byte) string {
 var _ handover.Summarizer = (*ProviderSummarizer)(nil)
 
 // runCompactionHandover rewrites env in-place with a handover summary when
-// Claude Code context compaction is detected on a non-Anthropic route. The
-// compaction already dropped old turns from the client's history; without this
-// step the non-Anthropic model has no awareness of edits or decisions that
-// lived only in those elided turns.
+// Claude Code context compaction is detected on a non-Anthropic route —
+// compaction already dropped old turns, so without this the non-Anthropic
+// model loses awareness of edits/decisions from those elided turns.
 //
-// Mirrors the model-switch handover in runTurnLoop: run the summarizer when
-// wired and credentials allow, and on any failure pass the compacted body
-// through unchanged rather than trimming it. Errors are logged but never
-// returned — a failed compaction rewrite is better than a failed request, and
-// passing the full compacted body keeps Claude Code's own compaction summary
-// intact (trimming to the last few turns would discard it).
-// Returns a handoverOutcome so the caller can bill the summary upstream call.
+// On any failure it logs and passes the compacted body through unchanged
+// (never trims it further, which would discard Claude Code's own compaction
+// summary). Returns a handoverOutcome so the caller can bill the summary call.
 func (s *Service) runCompactionHandover(ctx context.Context, env *translate.RequestEnvelope, reqHeaders http.Header, decisionModel string) handoverOutcome {
 	log := observability.FromContext(ctx)
 	var out handoverOutcome
@@ -295,9 +284,9 @@ func (s *Service) runCompactionHandover(ctx context.Context, env *translate.Requ
 		if sumCreds != nil {
 			summCtx = context.WithValue(ctx, CredentialsContextKey{}, sumCreds)
 		} else {
-			// Run on the deployment key: strip any request credential (notably a
-			// subscription OAuth token) the turn resolved, so this synthetic
-			// call doesn't inherit it from ctx and 401 / cross a tenant boundary.
+			// Strip any request credential (e.g. subscription OAuth token) so
+			// this synthetic call runs on the deployment key instead of
+			// inheriting one that could 401 or cross a tenant boundary.
 			summCtx = clearCredentials(ctx)
 		}
 		start := time.Now()

--- a/internal/proxy/no_progress.go
+++ b/internal/proxy/no_progress.go
@@ -21,18 +21,16 @@ import (
 
 // Cross-envelope tool-call loop detection.
 //
-// The within-envelope detector in loop_detection.go catches one assistant
-// looping inside a single request body. Claude Code's sub-agent failure
-// mode is different: the parent agent keeps spawning fresh sub-conversations
-// that each make one tool call, get back an identical empty result, and the
-// router only sees N independent envelope-1 requests. To the per-envelope
-// detector each envelope looks fine in isolation.
+// loop_detection.go catches loops within one request body. This catches a
+// different failure mode: Claude Code's parent agent spawning fresh
+// sub-agents that each make one tool call and get an identical empty
+// result — each envelope-1 request looks fine on its own, so the
+// per-envelope detector misses it.
 //
-// noProgressTracker keys an in-process LRU on the inbound session key and
-// holds a ring of recent dispatch fingerprints. When the same fingerprint
-// appears noProgressMatchThreshold times within noProgressTimeWindow the
-// session is declared stuck; the proxy emits a synthetic stop and expires
-// the pin so the next user turn re-routes fresh.
+// noProgressTracker keys an LRU on the session key and rings recent dispatch
+// fingerprints; noProgressMatchThreshold repeats within noProgressTimeWindow
+// mark the session stuck, so the proxy emits a synthetic stop and expires
+// the pin.
 
 const (
 	noProgressCacheSize      = 4096
@@ -43,21 +41,16 @@ const (
 	noProgressPromptPrefix   = 512
 )
 
-// noProgressFingerprint identifies one dispatch attempt by routed model,
-// provider, message count, tool-call progress, and a stable hash of the
-// prompt prefix.
+// noProgressFingerprint identifies one dispatch by model, provider, message
+// count, tool-call progress, and a hash of the prompt prefix.
 type noProgressFingerprint [32]byte
 
-// toolProgressMarker summarizes how far an agent's tool-call history has
-// advanced this turn: the count of meaningful assistant tool calls plus the
-// signature (name + canonical-arg hash) of the most recent one. Empty when the
-// envelope carries no assistant tool calls (e.g. a tool-free chat turn) or for
-// Gemini-format requests, which AssistantToolCallSignatures does not parse.
-//
-// Feeding this into the no-progress fingerprint is what lets the detector tell
-// a progressing tool-call loop (count climbs / last call changes each turn)
-// apart from a stuck one (count and last call constant) without relying on the
-// top-level message count, which Claude Code sub-agents hold flat.
+// toolProgressMarker summarizes tool-call progress this turn: count of
+// assistant tool calls plus the last call's signature (name + arg hash).
+// Empty for tool-free turns or Gemini requests (unparsed). Lets the
+// no-progress fingerprint tell a progressing loop (marker changes each turn)
+// from a stuck one (marker constant), without relying on top-level message
+// count, which Claude Code sub-agents hold flat.
 func toolProgressMarker(env *translate.RequestEnvelope) string {
 	if env == nil {
 		return ""
@@ -70,31 +63,17 @@ func toolProgressMarker(env *translate.RequestEnvelope) string {
 	return strconv.Itoa(len(sigs)) + "\x00" + last.Name + "\x00" + last.InputHash
 }
 
-// computeNoProgressFingerprint hashes the routed (model, provider), the
-// conversation's message count, a tool-call progress marker, and the prompt
-// prefix into a single fingerprint.
+// computeNoProgressFingerprint hashes routed (model, provider), message
+// count, a tool-call progress marker, and the prompt prefix.
 //
-// The prompt prefix alone is constant across a single agentic task: in the
-// default embed-only-user-message mode promptText is the user's typed task
-// (tool results are stripped), so every iteration of a healthy tool-call loop
-// shares the same prefix and the bare (model, provider, prefix) fingerprint
-// would collide on every dispatch — tripping the detector on any session that
-// fires >= noProgressMatchThreshold turns to one model within the window.
-//
-// progressMarker is the primary false-positive guard. A progressing agent
-// appends a new, distinct tool call each turn, so toolProgressMarker advances
-// (its count climbs and the last-call signature changes) and each dispatch
-// yields a distinct fingerprint that never accumulates to the threshold. A
-// genuinely stuck agent — a sub-agent spawn loop replaying independent
-// envelope-1 requests, or a model re-issuing one identical call — keeps the
-// marker constant, so the fingerprints still collide and the detector fires.
-//
-// messageCount is folded in as a secondary signal for tool-free loops, where a
-// growing transcript is the only progress signal available. It is NOT
-// sufficient on its own: Claude Code's Explore sub-agent holds the top-level
-// message count flat (tool_use blocks accrete inside a handful of messages)
-// while genuinely progressing, which the message-count guard alone mistook for
-// a loop.
+// The prompt prefix alone is constant across a healthy agentic task (it's
+// just the user's typed task, tool results stripped), so it can't be the
+// sole key — every dispatch would collide. progressMarker is the main
+// guard: it advances on real progress and stays constant when stuck, so
+// only stuck loops accumulate matching fingerprints. messageCount is a
+// secondary signal for tool-free loops, but not sufficient alone: Claude
+// Code's Explore sub-agent holds message count flat while genuinely
+// progressing.
 func computeNoProgressFingerprint(decision router.Decision, promptText string, messageCount int, progressMarker string) noProgressFingerprint {
 	p := promptText
 	if len(p) > noProgressPromptPrefix {
@@ -142,56 +121,36 @@ func newNoProgressTracker() *noProgressTracker {
 	}
 }
 
-// compactionState is what compactionTracker stores per session: the last-seen
-// top-level message count and the last-seen assistant tool-call count.
-// Both can independently signal that the client trimmed its history window.
+// compactionState is per-session state: last-seen message count and
+// assistant tool-call count. Either dropping can signal history trimming.
 type compactionState struct {
 	msgCount      int
 	toolCallCount int
 }
 
-// compactionMinHistoryMessages is the smallest conversation size for which a
-// count drop is read as real history trimming. Below it there is no substantial
-// history to lose, so a drop is some other (benign) shape:
-//   - A freshly spawned sub-agent opens its turn at messageCount=1, which looks
-//     like a sharp drop relative to the prior sub-agent that shared the same
-//     (session, role) bucket and left it at ~3.
-//   - Claude Code's Explore sub-agent holds a flat ~3-message window and varies
-//     its per-turn assistant tool-call count widely (e.g. 11→6→3); every such
-//     decrease would otherwise false-trip the rolling-window signal.
-//
-// Real full compaction comes from a large conversation (the client compacts on
-// token pressure, so the prior message count is in the dozens-plus), and real
-// rolling-window trimming keeps a correspondingly large flat window — both stay
-// well above this floor. Erring toward fewer fires is the safe bias: skipping
-// the handover passes the body (including Claude Code's own compaction summary)
-// through unchanged, whereas a false fire replaces live context with a lossy
-// summary and corrupts an in-flight sub-agent.
+// compactionMinHistoryMessages is the floor below which a count drop is
+// benign, not real trimming: fresh sub-agents open at messageCount=1 (looks
+// like a drop vs. a prior sub-agent in the same bucket), and Claude Code's
+// Explore sub-agent swings its tool-call count widely on a flat ~3-message
+// window. Real compaction/trimming only happens on large conversations,
+// well above this floor. Bias toward fewer fires: a missed detection just
+// passes the body through unchanged, but a false one corrupts an in-flight
+// sub-agent with a lossy summary.
 const compactionMinHistoryMessages = 8
 
-// compactionTracker detects Claude Code context window trimming by comparing
-// each turn's message count and assistant tool-call count against the last
-// seen values for the same session. Either count dropping is a signal that the
-// client elided old turns, which can leave a non-Anthropic model unaware of
-// completed work (edits, decisions) that were only visible in the now-elided
-// turns.
+// compactionTracker detects Claude Code context-window trimming by comparing
+// each turn's message count and tool-call count to the last seen values,
+// which can leave a non-Anthropic model unaware of work done in elided turns.
 //
-// Two independent signals are needed because Claude Code can trim history in
-// two distinct ways:
-//   - Full compaction: replaces all old messages with a summary block, so
-//     messageCount drops sharply (e.g. 20 → 3).
-//   - Rolling-window trimming: drops the oldest message pair each turn to
-//     keep a roughly fixed window, so messageCount stays flat while the
-//     assistant tool-call count shrinks by one per turn (the pattern
-//     observed in session 543151ce: 9 → 8 → 7 → 6 → 5).
+// Two independent signals catch two trimming shapes: full compaction (message
+// count drops sharply, e.g. 20→3) and rolling-window trimming (message count
+// stays flat while tool-call count shrinks by one per turn, e.g. 9→8→7→6→5).
+// Checking only message count misses the rolling-window case.
 //
-// Detecting only messageCount drops misses the rolling-window case.
+// Both signals are gated by compactionMinHistoryMessages (see that constant)
+// to avoid false-firing on sub-agent startup and Explore's flat window.
 //
-// Both signals are gated by compactionMinHistoryMessages so the small flat
-// windows of freshly spawned sub-agents and Claude Code's Explore sub-agent are
-// not mistaken for trimming (see that constant's doc).
-//
-// nil receivers are valid (no-op), matching noProgressTracker semantics.
+// nil receivers are valid (no-op), matching noProgressTracker.
 type compactionTracker struct {
 	cache *lru.LRU[string, compactionState]
 }
@@ -202,11 +161,9 @@ func newCompactionTracker() *compactionTracker {
 	}
 }
 
-// checkAndRecord records the session's current message count and tool-call
-// count, then reports whether either dropped versus the prior observation
-// (history-trimming event). Returns false on the first observation for a
-// session (no prior state to compare against) and when no bucket anchor is
-// available.
+// checkAndRecord records the session's current counts and reports whether
+// either dropped vs. the prior observation. Returns false on first
+// observation or when no bucket anchor is available.
 func (t *compactionTracker) checkAndRecord(sessionKey [sessionpin.SessionKeyLen]byte, installationID uuid.UUID, role string, messageCount, toolCallCount int) bool {
 	if t == nil || t.cache == nil {
 		return false
@@ -220,40 +177,30 @@ func (t *compactionTracker) checkAndRecord(sessionKey [sessionpin.SessionKeyLen]
 	if !found {
 		return false
 	}
-	// Full compaction: a messageCount drop from a substantial prior conversation.
-	// Gating on the prior size rejects the fresh-sub-agent case (a new dispatch
-	// opening at messageCount=1 against a prior sub-agent's small count in the
-	// shared bucket), which is not history loss.
+	// Full compaction: messageCount dropped from a substantial prior
+	// conversation (gated to reject the fresh-sub-agent-at-1 case).
 	if messageCount < last.msgCount && last.msgCount >= compactionMinHistoryMessages {
 		return true
 	}
-	// Rolling-window trimming: messageCount stays flat while the assistant
-	// tool-call count shrinks. Gating on a substantial current window rejects
-	// Claude Code's Explore sub-agent, which holds a flat ~3-message window and
-	// swings its per-turn tool-call count widely without any trimming.
+	// Rolling-window trimming: messageCount flat, tool-call count shrinks
+	// (gated to reject Explore's flat ~3-message window).
 	if toolCallCount < last.toolCallCount && messageCount >= compactionMinHistoryMessages {
 		return true
 	}
 	return false
 }
 
-// recordAndDetect records the fingerprint against a bucket keyed by
-// sessionKey (preferred) or installationID (fallback) and reports whether
-// the burst now exceeds the loop threshold. A nil tracker returns (false, 0)
-// so production-style construction can stay optional in tests and
-// selfhosted deploys.
+// recordAndDetect records the fingerprint in a bucket keyed by sessionKey
+// (preferred) or installationID (fallback), and reports whether the burst
+// exceeds the loop threshold. nil tracker returns (false, 0).
 //
 // Bucket selection:
-//   - non-zero sessionKey → per-session bucket (normal path)
-//   - zero sessionKey + non-nil installationID → per-installation bucket,
-//     used by hard-pin paths (Explore SubAgentDispatch under hardPinExplore)
-//     and routing with pinStore nil. Coarser than per-session but still
-//     keeps detection coverage; the fingerprint's (model, provider, prompt)
-//     tuple distinguishes unrelated work in the same installation from a
-//     real loop.
-//   - zero sessionKey + nil installationID → no anchor available; skipped
-//     to avoid one global zero-key bucket false-positive-tripping across
-//     unrelated unauthenticated traffic.
+//   - sessionKey set → per-session bucket
+//   - sessionKey zero, installationID set → per-installation bucket
+//     (hard-pin paths, pinStore nil); coarser, but the fingerprint tuple
+//     still distinguishes unrelated work
+//   - neither set → skipped, to avoid one global bucket false-tripping
+//     across unrelated traffic
 func (t *noProgressTracker) recordAndDetect(sessionKey [sessionpin.SessionKeyLen]byte, installationID uuid.UUID, role string, fp noProgressFingerprint, now time.Time) (looped bool, count int) {
 	if t == nil || t.cache == nil {
 		return false, 0
@@ -270,9 +217,8 @@ func (t *noProgressTracker) recordAndDetect(sessionKey [sessionpin.SessionKeyLen
 	return ring.recordAndDetect(fp, now)
 }
 
-// noProgressBucketKey picks the LRU bucket for a dispatch. Returns ok=false
-// when neither anchor is available — the caller must skip detection rather
-// than falling back to a global zero-keyed bucket.
+// noProgressBucketKey picks the LRU bucket key. ok=false means no anchor is
+// available and the caller must skip detection.
 func noProgressBucketKey(sessionKey [sessionpin.SessionKeyLen]byte, installationID uuid.UUID, role string) (string, bool) {
 	if sessionKey != ([sessionpin.SessionKeyLen]byte{}) {
 		return "session:" + hex.EncodeToString(sessionKey[:]) + ":" + role, true
@@ -283,14 +229,10 @@ func noProgressBucketKey(sessionKey [sessionpin.SessionKeyLen]byte, installation
 	return "", false
 }
 
-// shortSessionKey returns the first 16 hex chars (64 bits) of a session key
-// for use in Info-level logs. Mirrors the auth.APIKey "KeyPrefix" convention
-// (8-char prefix is considered safe) at a wider bit margin so an incident
-// triager can still correlate two log lines from the same break event,
-// while limiting long-window cross-request correlation across retained logs.
-//
-// "" for an all-zero key so logs visibly distinguish missing-anchor breaks
-// from real-session breaks.
+// shortSessionKey returns the first 8 bytes of a session key hex-encoded, for
+// safe use in logs (wider margin than auth.APIKey's 8-char KeyPrefix, still
+// short enough to limit cross-request correlation). Empty for an all-zero
+// key so logs distinguish missing-anchor breaks from real-session ones.
 func shortSessionKey(sessionKey [sessionpin.SessionKeyLen]byte) string {
 	if sessionKey == ([sessionpin.SessionKeyLen]byte{}) {
 		return ""
@@ -299,13 +241,9 @@ func shortSessionKey(sessionKey [sessionpin.SessionKeyLen]byte) string {
 }
 
 // handleNoProgressBreak writes a synthetic end_turn response, expires the
-// session pin, and returns a non-nil error so caller error-handling
-// (telemetry, billing skip) treats it as a failed dispatch.
-//
-// Mirrors handleToolCallLoopBreak's mechanics — same pin-expiry contract,
-// same synthetic-response writer paths — but the message explains the
-// cross-envelope nature so a human reading the chat history can tell the
-// two break modes apart.
+// session pin, and returns a non-nil error so callers treat it as a failed
+// dispatch (skips billing/telemetry). Mirrors handleToolCallLoopBreak's
+// mechanics but with a message that names the cross-envelope loop mode.
 func (s *Service) handleNoProgressBreak(
 	ctx context.Context,
 	w http.ResponseWriter,
@@ -341,10 +279,8 @@ func (s *Service) handleNoProgressBreak(
 		"role", role,
 	)
 
-	// Skip pin upsert when sessionKey is zero — writing a zero-keyed pin row
-	// would create a zombie entry shared by every zero-keyed session in the
-	// pin store. Hard-pin paths and selfhosted deploys without a pinStore
-	// hit this path and don't need persisted pin expiry anyway.
+	// Skip when sessionKey is zero: a zero-keyed pin row would be a zombie
+	// entry shared by every zero-keyed session.
 	if s.pinStore != nil && installationID != uuid.Nil && sessionKey != ([sessionpin.SessionKeyLen]byte{}) {
 		expired := sessionpin.Pin{
 			SessionKey:     sessionKey,

--- a/internal/proxy/no_progress_internal_test.go
+++ b/internal/proxy/no_progress_internal_test.go
@@ -49,9 +49,7 @@ func TestComputeNoProgressFingerprint_PromptPrefixOnly(t *testing.T) {
 
 func TestComputeNoProgressFingerprint_DistinguishesMessageCount(t *testing.T) {
 	d := router.Decision{Model: "gemini-3.1-pro-preview", Provider: "google"}
-	// Same model/provider/prompt-prefix/tool-progress, different message count:
-	// a tool-free loop grows its transcript each turn, so the fingerprints must
-	// diverge even though the user's typed task (the prompt prefix) is constant.
+	// A growing transcript must change the fingerprint even with a constant prompt prefix.
 	a := computeNoProgressFingerprint(d, "explore RSVP files", 10, "")
 	b := computeNoProgressFingerprint(d, "explore RSVP files", 12, "")
 	assert.NotEqual(t, a, b, "a growing message count must change the fingerprint")
@@ -59,23 +57,17 @@ func TestComputeNoProgressFingerprint_DistinguishesMessageCount(t *testing.T) {
 
 func TestComputeNoProgressFingerprint_DistinguishesToolProgress(t *testing.T) {
 	d := router.Decision{Model: "deepseek/deepseek-v4-flash", Provider: "deepinfra"}
-	// Everything constant except the tool-progress marker — the case Claude
-	// Code's Explore sub-agent hits, where model/provider/message_count and the
-	// user's task prompt are all flat but the tool-call history advances. The
-	// fingerprint must diverge so the detector does not mistake progress for a
-	// loop.
+	// Explore sub-agent case: message count and prompt stay flat but tool-call
+	// history advances — the fingerprint must still diverge.
 	a := computeNoProgressFingerprint(d, "investigate the bug", 5, "42\x00Read\x00hash-a")
 	b := computeNoProgressFingerprint(d, "investigate the bug", 5, "43\x00Read\x00hash-b")
 	assert.NotEqual(t, a, b, "an advancing tool-progress marker must change the fingerprint")
 }
 
 func TestNoProgressTracker_DoesNotTripWhenMessageCountGrows(t *testing.T) {
-	// Regression: a fast Claude Code tool-call loop fires well over the
-	// threshold of dispatches to one model within the window, all sharing the
-	// same routed (model, provider) and the same user-task prompt prefix
-	// (tool_result turns are stripped from promptText in embed-only mode). It
-	// must NOT trip, because the transcript grows by an assistant + tool_result
-	// turn each iteration.
+	// Regression: a fast tool-call loop can exceed the dispatch threshold for
+	// one (model, provider) while the prompt prefix stays constant, but must
+	// not trip since the transcript keeps growing each iteration.
 	tr := newNoProgressTracker()
 	key := sessionKeyFromString("session-healthy-loop")
 	install := uuid.New()
@@ -90,12 +82,9 @@ func TestNoProgressTracker_DoesNotTripWhenMessageCountGrows(t *testing.T) {
 }
 
 func TestNoProgressTracker_DoesNotTripWhenToolProgressGrows(t *testing.T) {
-	// Regression (Claude Code Explore sub-agent): the top-level message count
-	// stays flat across turns — tool_use blocks accrete inside a handful of
-	// messages — and tool_result turns are stripped from promptText in
-	// embed-only mode, so model/provider/message_count/prompt-prefix are all
-	// constant. It must NOT trip, because the agent appends a new, distinct tool
-	// call each turn, so the tool-progress marker advances.
+	// Regression (Explore sub-agent): message count/prompt/model/provider stay
+	// flat but each turn appends a distinct tool call, so the tool-progress
+	// marker advances and the detector must not trip.
 	tr := newNoProgressTracker()
 	key := sessionKeyFromString("session-explore")
 	install := uuid.New()
@@ -103,9 +92,7 @@ func TestNoProgressTracker_DoesNotTripWhenToolProgressGrows(t *testing.T) {
 	now := time.Now()
 
 	for i := 0; i < noProgressMatchThreshold*2; i++ {
-		// Flat message count (5) and constant task prompt, but a growing
-		// tool-call history: the count climbs and the last call differs (a Read
-		// of a different file) each turn.
+		// Flat message count, growing tool-call history (differs each turn).
 		progress := strconv.Itoa(40+i) + "\x00Read\x00hash-" + strconv.Itoa(i)
 		fp := computeNoProgressFingerprint(d, "investigate the stuck name", 5, progress)
 		looped, _ := tr.recordAndDetect(key, install, "low", fp, now)
@@ -114,11 +101,8 @@ func TestNoProgressTracker_DoesNotTripWhenToolProgressGrows(t *testing.T) {
 }
 
 func TestNoProgressTracker_TripsWhenMessageCountAndToolProgressFlat(t *testing.T) {
-	// A genuine stuck loop — a sub-agent spawn loop replaying independent
-	// envelope-1 requests, or a model re-issuing one identical tool call — never
-	// advances: the transcript stays flat and the same single tool call repeats,
-	// so both the message count and the tool-progress marker are constant. The
-	// detector must still fire.
+	// A genuine stuck loop (e.g. a model re-issuing one identical tool call)
+	// keeps message count and tool-progress marker both constant — must fire.
 	tr := newNoProgressTracker()
 	key := sessionKeyFromString("session-spawn-loop")
 	install := uuid.New()
@@ -134,9 +118,7 @@ func TestNoProgressTracker_TripsWhenMessageCountAndToolProgressFlat(t *testing.T
 }
 
 func TestToolProgressMarker_AdvancesWithToolCalls(t *testing.T) {
-	// Two consecutive turns of a healthy Explore-style loop: the second appends
-	// a new, distinct tool call (a Read of a different file). The marker must
-	// change so the no-progress fingerprint diverges between turns.
+	// Second turn appends a distinct tool call; the marker must change.
 	turn1 := []byte(`{"model":"claude-haiku-4-5","max_tokens":256,"messages":[` +
 		`{"role":"user","content":"find the bug"},` +
 		`{"role":"assistant","content":[{"type":"tool_use","id":"1","name":"Grep","input":{"pattern":"scim","path":"/a"}}]},` +
@@ -220,10 +202,8 @@ func TestNoProgressTracker_AgesOutOldEntries(t *testing.T) {
 }
 
 func TestNoProgressTracker_ZeroSessionKeyWithInstallationFallsBack(t *testing.T) {
-	// Hard-pin paths (Explore SubAgentDispatch when hardPinExplore is on)
-	// and routing with pinStore nil leave SessionKey at zero. The detector
-	// must still cover them — bucketing by installationID keeps the
-	// per-installation isolation while restoring detection coverage.
+	// Hard-pin/pinStore-nil paths leave SessionKey at zero; falling back to
+	// installationID must still detect loops while keeping isolation.
 	tr := newNoProgressTracker()
 	var zero [sessionpin.SessionKeyLen]byte
 	install := uuid.New()
@@ -241,9 +221,7 @@ func TestNoProgressTracker_ZeroSessionKeyWithInstallationFallsBack(t *testing.T)
 }
 
 func TestNoProgressTracker_ZeroSessionKeyAndZeroInstallationIsSkipped(t *testing.T) {
-	// Unauthenticated/test paths can have neither anchor — must skip rather
-	// than fall back to a global zero-keyed bucket that unrelated traffic
-	// would share.
+	// No anchor at all must skip rather than share a global zero-keyed bucket.
 	tr := newNoProgressTracker()
 	var zero [sessionpin.SessionKeyLen]byte
 	d := router.Decision{Model: "qwen/qwen3-235b-a22b-2507", Provider: "bedrock"}
@@ -359,10 +337,8 @@ func TestCompactionTracker_DetectsMessageCountDrop(t *testing.T) {
 }
 
 func TestCompactionTracker_DetectsRollingWindowTrimming(t *testing.T) {
-	// Rolling-window trimming (the pattern observed in session 543151ce):
-	// messageCount stays flat because old message pairs are swapped for new
-	// ones, but the assistant tool-call count shrinks by one per turn as the
-	// oldest tool call drops out of the visible window.
+	// Rolling-window trim: messageCount stays flat (old pairs swapped for new)
+	// but tool-call count shrinks as the oldest call drops out of view.
 	ct := newCompactionTracker()
 	key := sessionKeyFromString("session-rolling")
 	install := uuid.New()
@@ -376,11 +352,9 @@ func TestCompactionTracker_DetectsRollingWindowTrimming(t *testing.T) {
 }
 
 func TestCompactionTracker_NoFalsePositiveOnFreshSubAgentDispatch(t *testing.T) {
-	// A sub-agent shares the (session, role) bucket with the previous sub-agent
-	// of the same tier. When a new sub-agent is spawned its opening turn carries
-	// messageCount=1, which is a drop relative to the prior sub-agent's small
-	// count — but it is a fresh dispatch, not history trimming, so it must not
-	// fire (the prior conversation was too small to have lost anything).
+	// A new sub-agent shares the (session, role) bucket with the prior one, so
+	// its opening messageCount=1 looks like a drop — but it's a fresh dispatch,
+	// not trimming, and must not fire.
 	ct := newCompactionTracker()
 	key := sessionKeyFromString("session-subagent")
 	install := uuid.New()
@@ -394,10 +368,8 @@ func TestCompactionTracker_NoFalsePositiveOnFreshSubAgentDispatch(t *testing.T) 
 }
 
 func TestCompactionTracker_NoFalsePositiveOnExploreToolCallSwing(t *testing.T) {
-	// Claude Code's Explore sub-agent holds a flat ~3-message window and varies
-	// its per-turn assistant tool-call count widely. A decrease in that count is
-	// natural model behavior, not rolling-window trimming, and must not fire
-	// because the window is too small to be a real rolling window.
+	// Explore holds a flat ~3-message window with widely varying tool-call
+	// counts; a decrease here is natural, not trimming, and must not fire.
 	ct := newCompactionTracker()
 	key := sessionKeyFromString("session-explore")
 	install := uuid.New()

--- a/internal/proxy/pin_eviction_internal_test.go
+++ b/internal/proxy/pin_eviction_internal_test.go
@@ -17,10 +17,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// evictionStubPinStore records every call to IncrementUpstreamErrors /
-// ResetUpstreamErrors / Upsert so each two-strike branch can be
-// asserted independently. The increment counter is configurable to
-// drive the threshold path without re-running the whole turn loop.
+// evictionStubPinStore records calls so each two-strike branch can be
+// asserted independently; incrementNext drives the threshold directly.
 type evictionStubPinStore struct {
 	mu             sync.Mutex
 	incrementCalls int
@@ -87,12 +85,8 @@ func nonZeroSessionKey() [sessionpin.SessionKeyLen]byte {
 	return k
 }
 
-// TestMaybeEvictPin_FirstStrikeOnlyIncrements pins the two-strike
-// invariant: a SINGLE 400 must increment the counter but NOT expire
-// the pin. The eviction must wait for the second consecutive strike,
-// so an isolated bad request (a one-off malformed prompt, brief
-// upstream schema validation hiccup) doesn't flush an otherwise-warm
-// session's cache.
+// A single 400 must increment the counter but not evict — eviction waits for
+// a second consecutive strike so one-off bad requests don't flush a warm pin.
 func TestMaybeEvictPin_FirstStrikeOnlyIncrements(t *testing.T) {
 	store := &evictionStubPinStore{incrementNext: []int{1}}
 	svc := newEvictionTestService(store)
@@ -113,10 +107,7 @@ func TestMaybeEvictPin_FirstStrikeOnlyIncrements(t *testing.T) {
 	assert.Empty(t, store.upserts, "first strike must not expire the pin — eviction waits for strike #2")
 }
 
-// TestMaybeEvictPin_SecondStrikeExpires guards the actual eviction
-// path. The session 93e918bf wedge happened because there was NO
-// eviction path at all; this test fails the moment that regression
-// returns.
+// Guards against the session 93e918bf regression, where no eviction path existed.
 func TestMaybeEvictPin_SecondStrikeExpires(t *testing.T) {
 	store := &evictionStubPinStore{incrementNext: []int{pinEvictionStrikeThreshold}}
 	svc := newEvictionTestService(store)
@@ -147,11 +138,8 @@ func TestMaybeEvictPin_SecondStrikeExpires(t *testing.T) {
 		"eviction reason is the audit trail that distinguishes this path from force-model / loop-break")
 }
 
-// TestMaybeEvictPin_SuccessResets verifies that a successful turn
-// clears the counter so the strike count truly tracks CONSECUTIVE
-// failures (not lifetime failures). Without this, a session could
-// accumulate strikes across hours of healthy turns and trigger a
-// stale eviction on a single bad request.
+// A successful turn must clear the counter so strikes track consecutive
+// failures, not lifetime ones.
 func TestMaybeEvictPin_SuccessResets(t *testing.T) {
 	store := &evictionStubPinStore{}
 	svc := newEvictionTestService(store)
@@ -171,11 +159,8 @@ func TestMaybeEvictPin_SuccessResets(t *testing.T) {
 	assert.Empty(t, store.upserts)
 }
 
-// TestMaybeEvictPin_RetryableStatusIgnored guards the IsRetryableStatus
-// gate. 429 / 408 / 5xx are upstream-transient and handled by
-// dispatchWithFallback; they must not drain the strike counter, since
-// a rate-limited request says nothing about whether the model itself
-// is wedged.
+// 429/408/5xx are transient and handled by dispatchWithFallback; they must
+// not touch the strike counter since they say nothing about model health.
 func TestMaybeEvictPin_RetryableStatusIgnored(t *testing.T) {
 	for _, status := range []int{http.StatusRequestTimeout, http.StatusTooManyRequests, http.StatusInternalServerError, http.StatusBadGateway, http.StatusServiceUnavailable} {
 		store := &evictionStubPinStore{incrementNext: []int{99}}
@@ -196,11 +181,8 @@ func TestMaybeEvictPin_RetryableStatusIgnored(t *testing.T) {
 	}
 }
 
-// TestMaybeEvictPin_UserForcedSkipped pins the user-command override:
-// a force-model'd session is the user explicitly choosing this
-// provider/model, and auto-eviction would silently revert that
-// command on the next turn. /unforce-model remains the escape hatch.
-// Covers both the plain reason and the "+tier_clamp" suffix variant.
+// A force-model'd session must never auto-evict — that would silently revert
+// the user's explicit choice; /unforce-model is the intended escape hatch.
 func TestMaybeEvictPin_UserForcedSkipped(t *testing.T) {
 	for _, reason := range []string{translate.ReasonUserForceModel, translate.ReasonUserForceModel + "+tier_clamp"} {
 		store := &evictionStubPinStore{incrementNext: []int{pinEvictionStrikeThreshold}}
@@ -222,11 +204,8 @@ func TestMaybeEvictPin_UserForcedSkipped(t *testing.T) {
 	}
 }
 
-// TestMaybeEvictPin_NoStickyHitSkipped verifies the cheap fast-path:
-// when this turn freshly routed via the scorer (no sticky pin), there
-// is no prior decision to second-guess. The Upsert that just wrote
-// this turn's pin already resets the counter via the SQL CASE clause,
-// so any reset call here would be redundant work.
+// A freshly-scored turn (no sticky pin) has no prior decision to reconsider;
+// the Upsert already reset the counter via its SQL CASE clause.
 func TestMaybeEvictPin_NoStickyHitSkipped(t *testing.T) {
 	store := &evictionStubPinStore{incrementNext: []int{pinEvictionStrikeThreshold}}
 	svc := newEvictionTestService(store)
@@ -246,9 +225,8 @@ func TestMaybeEvictPin_NoStickyHitSkipped(t *testing.T) {
 	assert.Empty(t, store.upserts)
 }
 
-// TestMaybeEvictPin_ZeroSessionKeySkipped guards against a corrupted
-// pin row shared by every zero-keyed caller — mirrors the same guard
-// in no_progress.go.
+// Guards against a corrupted pin row shared by every zero-keyed caller —
+// mirrors the guard in no_progress.go.
 func TestMaybeEvictPin_ZeroSessionKeySkipped(t *testing.T) {
 	store := &evictionStubPinStore{incrementNext: []int{pinEvictionStrikeThreshold}}
 	svc := newEvictionTestService(store)
@@ -267,9 +245,7 @@ func TestMaybeEvictPin_ZeroSessionKeySkipped(t *testing.T) {
 	assert.Empty(t, store.upserts)
 }
 
-// TestMaybeEvictPin_NilInstallationSkipped covers the unauthenticated
-// path (no installation_id resolved). Selfhosted / fakes / dev
-// scenarios hit this; the eviction must no-op rather than write a
+// Unauthenticated path (no installation_id) must no-op rather than write a
 // uuid.Nil-installed row to Postgres.
 func TestMaybeEvictPin_NilInstallationSkipped(t *testing.T) {
 	store := &evictionStubPinStore{incrementNext: []int{pinEvictionStrikeThreshold}}
@@ -289,10 +265,8 @@ func TestMaybeEvictPin_NilInstallationSkipped(t *testing.T) {
 	assert.Empty(t, store.upserts)
 }
 
-// TestMaybeEvictPin_NonUpstreamErrorIgnored guards the upstreamStatus
-// gate: a generic transport / build / context-cancel error has no
-// upstream status and is not a model-quality signal, so the counter
-// must NOT advance.
+// A generic transport/build/context-cancel error has no upstream status and
+// is not a model-quality signal, so the counter must not advance.
 func TestMaybeEvictPin_NonUpstreamErrorIgnored(t *testing.T) {
 	store := &evictionStubPinStore{incrementNext: []int{pinEvictionStrikeThreshold}}
 	svc := newEvictionTestService(store)

--- a/internal/proxy/service_test.go
+++ b/internal/proxy/service_test.go
@@ -35,9 +35,8 @@ type fakeProvider struct {
 	proxyBodies   [][]byte
 	proxyResponse func(w http.ResponseWriter)
 	proxyErr      error
-	// proxyCreds records the resolved credential each dispatch saw, so a test can
-	// assert WHICH key served the turn (subscription vs deployment/BYOK). nil
-	// entries mean no credential was set (deployment-key fallback).
+	// proxyCreds records the resolved credential per dispatch; nil means
+	// deployment-key fallback (no credential set).
 	proxyCreds []*proxy.Credentials
 }
 
@@ -79,14 +78,11 @@ func TestService_ProxyMessages_PropagatesUpstreamStatusError(t *testing.T) {
 	assert.Equal(t, 400, got.Status)
 }
 
-// TestService_ProxyMessages_CrossFormatUpstreamErrorBodyReachesClient guards
-// against the regression where a cross-format upstream non-2xx (e.g. OpenRouter
-// 402 "out of credits") buffered the upstream body inside the
-// AnthropicSSETranslator but never flushed it, because Finalize was skipped on
-// any non-nil proxyErr. Claude Code would then see only the generic
-// "upstream call failed" envelope written by the handler. The translated body
-// must reach the client and the typed UpstreamStatusError must still surface
-// to the handler so telemetry records the upstream status.
+// TestService_ProxyMessages_CrossFormatUpstreamErrorBodyReachesClient guards a
+// regression: a cross-format upstream non-2xx (e.g. OpenRouter 402) buffered
+// the body inside AnthropicSSETranslator but never flushed it, because
+// Finalize was skipped on any non-nil proxyErr. Both the translated body and
+// the typed UpstreamStatusError must reach the client/handler.
 func TestService_ProxyMessages_CrossFormatUpstreamErrorBodyReachesClient(t *testing.T) {
 	const upstreamBody = `{"error":{"message":"OpenRouter: insufficient credits","code":402,"type":"invalid_request_error"}}`
 	provider := &fakeProvider{
@@ -119,12 +115,10 @@ func TestService_ProxyMessages_CrossFormatUpstreamErrorBodyReachesClient(t *test
 	assert.Contains(t, respBody, `"type":"error"`, "body must be in Anthropic error envelope shape")
 }
 
-// TestService_ProxyMessages_StripsRoutingMarkerFromInboundHistory guards the
-// hygiene fix at internal/proxy/service.go: the routing-marker text injected
-// on prior cross-format responses (✦ **Weave Router** → ...) must not survive
-// into the upstream body. Without the strip, the marker round-trips through
-// clients that preserve assistant content verbatim and pollutes context on
-// every subsequent turn.
+// TestService_ProxyMessages_StripsRoutingMarkerFromInboundHistory guards
+// service.go's hygiene fix: the routing-marker text injected on prior
+// cross-format responses (✦ **Weave Router** → ...) must not survive into the
+// upstream body, or it round-trips and pollutes context on every later turn.
 func TestService_ProxyMessages_StripsRoutingMarkerFromInboundHistory(t *testing.T) {
 	const markerSentinel = "Weave Router"
 	body := []byte(`{
@@ -161,10 +155,8 @@ func TestService_ProxyMessages_StripsRoutingMarkerFromInboundHistory(t *testing.
 func TestService_ProxyMessages_EmbedOnlyUserMessageFlag(t *testing.T) {
 	const firstUserPrompt = "Walk every Go file under router/internal/ and produce a one-paragraph summary of each."
 	const secondUserPrompt = "Now narrow it to handlers under internal/api/."
-	// CC-shaped body: system preamble + two user prompts separated by an
-	// assistant turn + trailing tool_result. embedOnlyUserMessage must keep
-	// both user prompts and drop the system text, the assistant tool_use, and
-	// the tool_result blocks.
+	// embedOnlyUserMessage must keep both user prompts, drop system text,
+	// assistant tool_use, and tool_result blocks.
 	body := []byte(`{
 		"model":"claude-opus-4-7",
 		"system":"You are Claude Code. CLAUDE.md says: do not use emojis...",
@@ -294,9 +286,8 @@ func TestService_ProxyMessages_EmbedOnlyUserMessageContextOverride(t *testing.T)
 
 func boolPtr(b bool) *bool { return &b }
 
-// TestService_ProxyMessages_NoPinStoreRunsScorerEveryTurn verifies the
-// pin-store-disabled path: without a pin store, every turn re-runs the
-// cluster scorer (no Tier-3 legacy LRU short-circuits routing anymore).
+// TestService_ProxyMessages_NoPinStoreRunsScorerEveryTurn verifies that
+// without a pin store, every turn re-runs the cluster scorer.
 func TestService_ProxyMessages_NoPinStoreRunsScorerEveryTurn(t *testing.T) {
 	body := []byte(`{"model":"claude-opus-4-7","messages":[{"role":"user","content":"hi"}]}`)
 	fr := &fakeRouter{decision: router.Decision{Provider: "anthropic", Model: "claude-haiku-4-5"}}
@@ -410,10 +401,9 @@ func TestService_ProxyOpenAIChatCompletion_NativeOpenAI(t *testing.T) {
 	assert.Contains(t, rec.Body.String(), `"chat.completion"`)
 }
 
-// OpenRouter speaks OpenAI Chat Completions natively: an OpenAI-format
+// OpenRouter speaks OpenAI Chat Completions natively, so an OpenAI-format
 // inbound landing on an OpenRouter decision must take the no-translation path.
-// Regression: eval harness v0.27 (OpenRouter OSS models) via mini-swe-agent's
-// OpenAI client hit "no translation path defined".
+// Regression: eval harness v0.27 hit "no translation path defined".
 func TestService_ProxyOpenAIChatCompletion_NativeOpenRouter(t *testing.T) {
 	provider := &fakeProvider{
 		proxyResponse: func(w http.ResponseWriter) {
@@ -441,15 +431,12 @@ func TestService_ProxyOpenAIChatCompletion_NativeOpenRouter(t *testing.T) {
 	assert.Contains(t, rec.Body.String(), `"chat.completion"`)
 }
 
-// DeepInfra, Bedrock, Makora, and Together are direct providers served by
-// the openaicompat client. Every surface must route those decisions through
-// the OpenAI-emission case rather than the default "no translation path"
-// branch; otherwise the scorer's argmax silently 502s for every prompt that
-// lands on them. Makora/Together are the DeepSeek-V4 primaries whose omission
-// from the old literal dispatch lists 502'd in prod ("no translation path
-// defined for inbound Anthropic Messages", then no-progress-looped back to
-// Claude); keying dispatch off the translation family covers every
-// OpenAI-compat provider, so they route here too.
+// DeepInfra, Bedrock, Makora, and Together are direct providers served by the
+// openaicompat client and must route through the OpenAI-emission case, not
+// the default "no translation path" branch. Regression: Makora/Together
+// (DeepSeek-V4 primaries) were missing from the old literal dispatch list and
+// 502'd in prod. Keying dispatch off the translation family fixes all of
+// them.
 func TestService_ProxyMessages_DispatchesDeepInfraAndBedrock(t *testing.T) {
 	cases := []struct {
 		name     string
@@ -474,9 +461,8 @@ func TestService_ProxyMessages_DispatchesDeepInfraAndBedrock(t *testing.T) {
 				router.Decision{Provider: tc.provider, Model: tc.model, Reason: "test"},
 				map[string]providers.Client{tc.provider: p},
 			)
-			// Tools present + opus requested keeps the turn out of the
-			// classifier-hard-pin path so the test exercises the
-			// switch we just widened, not the hard-pin fallback.
+			// Tools + opus keeps this out of the classifier-hard-pin path,
+			// so the test exercises the widened switch, not the fallback.
 			body := []byte(`{"model":"claude-opus-4-7","max_tokens":16,"tools":[{"name":"calc","description":"add","input_schema":{"type":"object","properties":{"a":{"type":"integer"},"b":{"type":"integer"}},"required":["a","b"]}}],"messages":[{"role":"user","content":"What is 7+5? Use calc."}]}`)
 			rec := httptest.NewRecorder()
 			req := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(string(body)))
@@ -519,19 +505,15 @@ func TestService_ProxyOpenAIChatCompletion_DispatchesDeepInfraAndBedrock(t *test
 	}
 }
 
-// TestService_CodexPassthrough_RoutesFreelyWithBothSubs guards the
-// subscription-credential routing flip: a /v1/responses turn that resolves a
-// Codex (ChatGPT) subscription must NOT force OpenAI-only routing when a Claude
-// subscription is also present. Both providers stay eligible so the scorer can
-// route freely and the sub matching the chosen model pays — GPT via the Codex
-// backend, Claude via the translated path. (Single-sub callers are unaffected:
-// enabledProvidersForRequest already yields {OpenAI} on a lone Codex sub.)
+// TestService_CodexPassthrough_RoutesFreelyWithBothSubs guards against a
+// Codex (ChatGPT) subscription forcing OpenAI-only routing when a Claude
+// subscription is also present. Both should stay eligible so the scorer can
+// route freely and the sub matching the chosen model pays. (Single-sub
+// callers are unaffected: a lone Codex sub still yields {OpenAI}.)
 func TestService_CodexPassthrough_RoutesFreelyWithBothSubs(t *testing.T) {
 	fr := &fakeRouter{decision: router.Decision{Provider: providers.ProviderAnthropic, Model: "claude-sonnet-4-6"}}
-	// The Anthropic upstream returns a normal Messages response; the proxy
-	// translates it back to the Responses wire format for the /v1/responses
-	// client (NOT the verbatim Codex-backend path, which only applies to an
-	// OpenAI decision).
+	// Anthropic upstream returns a normal Messages response; proxy translates
+	// it to Responses wire format (not the verbatim Codex-backend path).
 	anthropicResp := func(w http.ResponseWriter) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
@@ -561,18 +543,16 @@ func TestService_CodexPassthrough_RoutesFreelyWithBothSubs(t *testing.T) {
 	assert.Contains(t, fr.capturedReq.EnabledProviders, providers.ProviderAnthropic,
 		"Codex passthrough must NOT force OpenAI-only when a Claude subscription is also present")
 
-	// The Claude-routed turn comes back in Responses shape (translated), not
-	// chat-completions — proving a Codex-sub turn routed to Claude isn't sent
-	// through the verbatim Codex-backend path.
+	// Response must be in Responses shape, not chat-completions, proving this
+	// didn't go through the verbatim Codex-backend path.
 	out := rec.Body.String()
 	assert.Contains(t, out, `"object":"response"`)
 	assert.Contains(t, out, `"output_text"`)
 	assert.NotContains(t, out, "chat.completion")
 }
 
-// TestService_WithByokOnly_FiltersUnauthedProvidersFromScorer: with
-// WithByokOnly(true), registered providers must not appear in EnabledProviders
-// without per-request credentials, or argmax routes to the platform key and 402s.
+// TestService_WithByokOnly_FiltersUnauthedProvidersFromScorer: with BYOK-only,
+// providers without per-request creds must be excluded, or argmax 402s.
 func TestService_WithByokOnly_FiltersUnauthedProvidersFromScorer(t *testing.T) {
 	body := []byte(`{"model":"claude-opus-4-7","messages":[{"role":"user","content":"hi"}]}`)
 	providerMap := map[string]providers.Client{
@@ -607,11 +587,9 @@ func TestService_WithByokOnly_FiltersUnauthedProvidersFromScorer(t *testing.T) {
 	})
 
 	t.Run("byok-on Anthropic surface with x-api-key enables Anthropic only", func(t *testing.T) {
-		// On the Anthropic surface, a client x-api-key is the legitimate
-		// passthrough credential and enables Anthropic. It must NOT enable
-		// OpenRouter or any other OpenAI-compat upstream — those use a
-		// different inbound surface and reading the same header would be a
-		// cross-provider credential leak.
+		// A client x-api-key on the Anthropic surface is a legitimate passthrough
+		// credential and enables Anthropic, but must not leak into OpenRouter or
+		// other OpenAI-compat upstreams on a different inbound surface.
 		fr := &fakeRouter{decision: router.Decision{Provider: providers.ProviderAnthropic, Model: "claude-haiku-4-5"}}
 		svc := proxy.NewService(fr, providerMap, nil, false, nil, nil, false, providers.ProviderAnthropic, "claude-haiku-4-5", nil).
 			WithByokOnly(true)
@@ -629,15 +607,10 @@ func TestService_WithByokOnly_FiltersUnauthedProvidersFromScorer(t *testing.T) {
 	})
 
 	t.Run("byok-on Anthropic surface with inbound subscription Bearer enables Anthropic only", func(t *testing.T) {
-		// Claude Code passes a Claude subscription OAuth bearer (Authorization:
-		// Bearer sk-ant-oat…) on every request. It is legitimate Anthropic auth
-		// (forwarded as Bearer + the oauth beta header), so it enables Anthropic
-		// — the caller's subscription pays for their Claude turns.
-		//
-		// It must still NEVER enable OpenRouter or any other OpenAI-compat
-		// upstream. That cross-provider leak (treating the bearer as creds for
-		// every Bearer-using provider) was the 2026-05-13 prod incident:
-		// argmax picked OpenRouter and 401'd at dispatch with no OpenRouter key.
+		// A Claude subscription OAuth bearer is legitimate Anthropic auth and
+		// enables Anthropic, but must never enable OpenRouter or other
+		// OpenAI-compat upstreams — that cross-provider leak was the 2026-05-13
+		// prod incident (argmax picked OpenRouter, 401'd with no OpenRouter key).
 		fr := &fakeRouter{decision: router.Decision{Provider: providers.ProviderAnthropic, Model: "claude-haiku-4-5"}}
 		svc := proxy.NewService(fr, providerMap, nil, false, nil, nil, false, providers.ProviderAnthropic, "claude-haiku-4-5", nil).
 			WithByokOnly(true)

--- a/internal/proxy/spiral_detection.go
+++ b/internal/proxy/spiral_detection.go
@@ -14,57 +14,43 @@ import (
 	lru "github.com/hashicorp/golang-lru/v2/expirable"
 )
 
-// Shadow-mode spiral detector: per-turn signals that a session is
-// death-marching (error grind, same-file thrash, fuzzy action repetition,
-// monologue) on the model it is routed to. Shadow mode means LOG ONLY — the
-// detector records a durable event the first time each signal class fires
-// for a session and changes nothing about routing. The events are joined
-// offline by session_key against telemetry/session outcomes to measure fire
-// rates, precision, and lead time on real traffic before any escalation
-// action is armed (see docs/plans/ — the offline trajectory audit found
-// ~35% of failures have no behavioral tell, so live measurement, not
-// benchmarks, decides the operating point).
+// Shadow-mode spiral detector: flags sessions death-marching (error grind,
+// same-file thrash, fuzzy repetition, monologue) on their routed model.
+// LOG ONLY — records one durable event per signal class per session, no
+// routing change. Events are joined offline against outcomes to pick fire
+// rate/precision/lead-time before any escalation is armed (~35% of failures
+// have no behavioral tell per the offline trajectory audit, so live
+// measurement decides the operating point, not benchmarks).
 //
-// Signal provenance (offline audit of 186 full bake-off trajectories +
-// 8.5k outcome shards):
-//   - trailing tool_result error streak: AUC 0.73 pooled deep-session,
-//     0.86 on deepseek-v4-flash;
-//   - same-file edit thrash (>=5 edits to one path): present in 9 of the 20
-//     costliest death marches;
-//   - recent-window action repetition (repeat fraction >=~0.3 in the last 12
-//     calls at >=20 total): +8-11pp recall over a depth cap at matched FPR;
-//   - monologue: industry-convergent (OpenHands stuck detector), unmeasured
-//     on our traffic — shadow mode is how it gets measured.
+// Thresholds from an offline audit of 186 bake-off trajectories + 8.5k
+// outcome shards: err streak AUC 0.73 pooled (0.86 on deepseek-v4-flash);
+// same-file thrash (>=5 edits) present in 9/20 costliest death marches;
+// repeat-window fraction >=~0.3 over last 12 calls: +8-11pp recall over a
+// depth cap at matched FPR; monologue is industry-convergent (OpenHands)
+// but unmeasured here — shadow mode measures it.
 //
 // Unlike the cyclic-loop detector (exact-signature, no-edit windows), these
-// signals tolerate "rhyming" spirals: the same file edited with slightly
-// different args, test reruns with tiny variations.
+// tolerate "rhyming" spirals — same file, slightly different args.
 const (
-	// spiralMinToolCalls is the arming floor: no signal is evaluated before
-	// this many assistant tool calls exist in the history. Early-session
-	// intervention is the documented false-positive mode (the Explore
-	// sub-agent lesson generalizes).
+	// Arming floor: no signal evaluated before this many tool calls exist.
+	// Early-session intervention is the documented false-positive mode.
 	spiralMinToolCalls = 12
 	// spiralErrStreakThreshold: consecutive errored tool_results at the tail.
 	spiralErrStreakThreshold = 3
 	// spiralSameFileEditThreshold: edits targeting one file path.
 	spiralSameFileEditThreshold = 5
-	// spiralRepeatWindow / spiralRepeatMinCalls / spiralRepeatFracThreshold:
-	// fraction of the last spiralRepeatWindow tool-call signatures that are
-	// duplicates within that window, evaluated only once the session has
-	// spiralRepeatMinCalls total calls.
+	// Repetition: fraction of the last spiralRepeatWindow signatures that
+	// are duplicates, evaluated once spiralRepeatMinCalls is reached.
 	spiralRepeatWindow        = 12
 	spiralRepeatMinCalls      = 20
 	spiralRepeatFracThreshold = 0.34
-	// spiralMonologueThreshold: consecutive assistant messages with no real
-	// tool activity since the last real user input. Set above the text-only
-	// nudge machinery's territory so the two don't double-report.
+	// Consecutive assistant messages with no tool activity since the last
+	// real user input. Set above the text-only nudge threshold to avoid
+	// double-reporting.
 	spiralMonologueThreshold = 4
 )
 
-// Spiral signal-class taxonomy, recorded per event. One event per
-// (session, role, reason) — a session that error-grinds at turn 20 and
-// same-file-thrashes at turn 50 records two events.
+// Spiral signal-class taxonomy. One event per (session, role, reason).
 const (
 	spiralReasonErrStreak      = "err_streak"
 	spiralReasonSameFileThrash = "same_file_thrash"
@@ -72,17 +58,16 @@ const (
 	spiralReasonMonologue      = "monologue"
 )
 
-// SpiralShadowStore persists shadow-mode spiral detections durably (the
-// router.spiral_shadow_events table). The count query enforces the
-// once-per-(session, reason) budget across replicas.
+// SpiralShadowStore persists shadow spiral detections (router.spiral_shadow_events).
+// CountSpiralShadowEvents enforces the once-per-(session, reason) budget across replicas.
 type SpiralShadowStore interface {
 	InsertSpiralShadowEvent(ctx context.Context, p SpiralShadowEvent) error
 	CountSpiralShadowEvents(ctx context.Context, sessionKey []byte, role, reason string) (count int64, err error)
 }
 
 // SpiralShadowEvent mirrors one router.spiral_shadow_events row. All signal
-// values are recorded on every event regardless of which reason fired, so
-// thresholds can be re-tuned offline without re-running traffic.
+// values are recorded regardless of which reason fired, so thresholds can
+// be re-tuned offline without re-running traffic.
 type SpiralShadowEvent struct {
 	InstallationID   string
 	SessionKey       []byte
@@ -124,9 +109,8 @@ func computeSpiralSignals(env *translate.RequestEnvelope, messageCount int) spir
 		messageCount:  messageCount,
 	}
 
-	// Same-file edit thrash: max number of edit-class calls targeting one
-	// path. The path itself is recorded only as a hash — enough to confirm
-	// "the same file" offline without persisting customer file names.
+	// Path recorded as a hash only — confirms "same file" offline without
+	// persisting customer file names.
 	pathCounts := make(map[string]int)
 	for _, fp := range env.AssistantToolCallFilePaths() {
 		if _, isEdit := editToolNames[fp.Name]; !isEdit {
@@ -140,9 +124,8 @@ func computeSpiralSignals(env *translate.RequestEnvelope, messageCount int) spir
 		}
 	}
 
-	// Recent-window repetition: fraction of the last spiralRepeatWindow
-	// signatures that have a duplicate within that window. Catches rhyming
-	// re-grind that the exact tight-loop detector's 5-identical bar misses.
+	// Catches rhyming re-grind that the exact tight-loop detector's
+	// 5-identical bar misses.
 	if len(sigs) >= spiralRepeatWindow {
 		window := sigs[len(sigs)-spiralRepeatWindow:]
 		counts := make(map[string]int, len(window))
@@ -182,10 +165,9 @@ func spiralReasons(s spiralSignals) []string {
 	return reasons
 }
 
-// spiralFiredCache de-duplicates shadow fires per (session, role, reason) on
-// this replica, so the durable budget query only runs on the first crossing
-// each ~hour rather than on every turn of a stuck session. Cross-replica
-// duplicates are still possible in the gap before the durable count lands;
+// spiralFiredCache de-dupes shadow fires per (session, role, reason) per
+// replica so the durable budget query runs once per ~hour, not every turn.
+// Cross-replica dupes are still possible before the durable count lands;
 // offline analysis de-dupes by (session_key, reason).
 const (
 	spiralFiredCacheSize = 8192
@@ -206,11 +188,9 @@ func spiralFiredKey(sessionKey [sessionpin.SessionKeyLen]byte, role, reason stri
 	return string(sessionKey[:]) + "\x00" + role + "\x00" + reason
 }
 
-// handleSpiralShadow records shadow-mode spiral detections: one durable
-// event + one structured log line per (session, role, reason). It takes NO
-// routing action — that is the point of shadow mode. Gated upstream by
-// spiralShadowEnabled and the turn-type guard (main-loop/tool-result turns
-// only).
+// handleSpiralShadow records one durable event + one log line per
+// (session, role, reason). Takes no routing action. Gated upstream by
+// spiralShadowEnabled and the turn-type guard.
 func (s *Service) handleSpiralShadow(
 	ctx context.Context,
 	sig spiralSignals,
@@ -228,9 +208,8 @@ func (s *Service) handleSpiralShadow(
 			continue
 		}
 
-		// Durable once-per-(session, reason) budget, mirroring the
-		// loop-escalation budget pattern. Best-effort: a lookup failure
-		// proceeds (an extra row beats a lost one in shadow mode).
+		// Best-effort: a lookup failure proceeds — an extra row beats a
+		// lost one in shadow mode.
 		if s.spiralShadowStore != nil && installationID != uuid.Nil {
 			count, err := s.spiralShadowStore.CountSpiralShadowEvents(ctx, sessionKey[:], role, reason)
 			if err != nil {

--- a/internal/router/cluster/scorer_test.go
+++ b/internal/router/cluster/scorer_test.go
@@ -13,9 +13,8 @@ import (
 	"workweave/router/internal/router"
 )
 
-// fakeEmbedder returns a fixed vector or error; captures last text so
-// tests can assert tail-truncation happened upstream. Zero-value id/dim
-// default to the Jina identity so legacy-shaped fixtures keep working.
+// fakeEmbedder returns a fixed vector or error; captures last text for
+// tail-truncation assertions. Zero-value id/dim default to Jina.
 type fakeEmbedder struct {
 	vec      []float32
 	err      error
@@ -165,12 +164,8 @@ func TestScorer_PicksClusterAlignedModel(t *testing.T) {
 	assert.Contains(t, got.Reason, "model=claude-opus-4-7")
 }
 
-// TestScorer_SubscriptionCostFactorNoop guards the feature-off path on the V1
-// fallback bundle (no model_axes → no cost axis), where the subscription signal
-// never applies: nil and a 1.0 factor must both leave routing byte-identical to
-// no subsidy. The directional V2 behavior — the headroom bonus flipping the pick
-// and the intra-family choice — is covered by TestScorer_SubscriptionPreference-
-// FlipsAndSpills and TestScorer_SubscriptionPicksCheapestSufficientWithinFamily.
+// TestScorer_SubscriptionCostFactorNoop: on the V1 fallback bundle (no
+// model_axes), a 1.0 subsidy factor must be a no-op on routing and score.
 func TestScorer_SubscriptionCostFactorNoop(t *testing.T) {
 	emb := &fakeEmbedder{vec: makeOpusVec()}
 	s := newScorerForTest(t, emb, cfgForTest())
@@ -200,13 +195,10 @@ func subscriptionKnobs() *DefaultRoutingKnobs {
 	}
 }
 
-// TestScorer_SubscriptionPreferenceFlipsAndSpills exercises the plan-vs-cash half
-// of subscription-aware routing. In the hard cluster 0, opus is the quality-
-// favored pick with no subsidy. Treating haiku as the subscription-covered/plan
-// model and opus as the uncovered/cash alternative: a slack plan (f≈epsilon) adds
-// the headroom bonus and flips the pick to the covered model; a bound plan (f=1)
-// zeroes the bonus and the pick spills back to cash. The scorer is family-
-// agnostic — it applies the bonus to whatever subsidyFactors lists.
+// TestScorer_SubscriptionPreferenceFlipsAndSpills: in the hard cluster 0
+// (opus quality-favored), a slack plan factor (f≈epsilon) on haiku adds a
+// headroom bonus that flips the pick to haiku; a bound factor (f=1) zeroes
+// the bonus and it spills back to opus.
 func TestScorer_SubscriptionPreferenceFlipsAndSpills(t *testing.T) {
 	emb := &fakeEmbedder{vec: makeOpusVec()}
 	s := newV2BundleForTest(t, emb, v2BundleOpts{defaultKnobs: subscriptionKnobs()})
@@ -231,13 +223,10 @@ func TestScorer_SubscriptionPreferenceFlipsAndSpills(t *testing.T) {
 		"a bound plan (f=1) zeroes the bonus; routing spills back to the cash model")
 }
 
-// TestScorer_SubscriptionPicksCheapestSufficientWithinFamily is the headline
-// property: with BOTH covered models subsidized at the same slack factor, the
-// uniform bonus cannot reorder them, so the per-cluster quality/cost blend still
-// decides which covered model wins — the strong one on a hard (quality-favored)
-// cluster, the cheap one on an easy (cost-favored) cluster. This is exactly the
-// intra-family discrimination the old cost-multiply washed out (it compressed
-// Haiku and Opus together and over-picked Opus even for trivial turns).
+// TestScorer_SubscriptionPicksCheapestSufficientWithinFamily: with both
+// covered models subsidized at the same factor, the uniform bonus can't
+// reorder them, so the per-cluster quality/cost blend still picks the
+// strong model on a hard cluster and the cheap one on an easy cluster.
 func TestScorer_SubscriptionPicksCheapestSufficientWithinFamily(t *testing.T) {
 	covered := map[string]float64{"claude-opus-4-7": 0.05, "claude-haiku-4-5": 0.05}
 
@@ -258,12 +247,9 @@ func TestScorer_SubscriptionPicksCheapestSufficientWithinFamily(t *testing.T) {
 		"easy cluster: a subscribed family routes to the cheap sufficient model (Haiku, not Opus)")
 }
 
-// TestScorer_PreferredModelSoftNudge exercises the per-installation model
-// priority bonus. It must behave as a soft "finger on the scale": a preferred
-// model wins a close call but never overrides a clearly-better model for the
-// cluster, and a stale/unknown preference is a no-op. makeOpusVec aligns with
-// cluster 0, where Opus is quality-favored; the alpha override sets the blend's
-// quality weight so the Opus↔Haiku margin is tunable.
+// TestScorer_PreferredModelSoftNudge: a preferred model wins a close call
+// but never overrides a clearly-better model, and a stale/unknown
+// preference is a no-op.
 func TestScorer_PreferredModelSoftNudge(t *testing.T) {
 	emb := &fakeEmbedder{vec: makeOpusVec()}
 	s := newV2BundleForTest(t, emb, v2BundleOpts{})
@@ -319,10 +305,8 @@ func TestScorer_PopulatesRoutingMetadata(t *testing.T) {
 		"with cfgForTest TopP=1, only the closest cluster (Opus-aligned) is summed")
 }
 
-// Stage 1 band pair: the scorer must surface the runner-up (second-best
-// eligible model) alongside the chosen model so the turn loop can freeze the
-// {chosen, paired} pair into the session pin. On the Opus-aligned cluster 0
-// (opus 0.9 > haiku 0.1), chosen=opus and paired must be haiku, scored below.
+// The scorer must surface the runner-up alongside the chosen model so the
+// turn loop can freeze the {chosen, paired} pair into the session pin.
 func TestScorer_PopulatesBandPair(t *testing.T) {
 	emb := &fakeEmbedder{vec: makeOpusVec()}
 	s := newScorerForTest(t, emb, cfgForTest())
@@ -372,10 +356,8 @@ func TestScorer_PicksOtherClusterWhenAligned(t *testing.T) {
 	assert.Equal(t, "claude-haiku-4-5", got.Model)
 }
 
-// imageFilterArtifacts: K=1 fixture whose single cluster ranks the text-only
-// z-ai/glm-5.1 above the image-capable claude-opus-4-7. Without an image in the
-// request the scorer picks glm-5.1; with one it must drop glm-5.1 and fall to
-// opus.
+// imageFilterArtifacts: K=1 fixture ranking text-only glm-5.1 above
+// image-capable opus; an image in the request must drop glm-5.1.
 func imageFilterArtifacts(t *testing.T) (centroidsBlob, rankingsBlob, registryBlob []byte) {
 	t.Helper()
 	dim := EmbedDim
@@ -427,9 +409,8 @@ func TestScorer_KeepsTextOnlyPoolWhenNoImageCapableCandidate(t *testing.T) {
 	s, err := NewScorer(bundle, cfgForTest(), &fakeEmbedder{vec: makeOpusVec()}, map[string]struct{}{"deepinfra": {}})
 	require.NoError(t, err)
 
-	// Soft fallback: no image-capable candidate deployed, so the scorer still
-	// returns a decision rather than erroring — the upstream reports the
-	// rejection instead.
+	// No image-capable candidate deployed: the scorer still returns a
+	// decision rather than erroring; upstream reports the rejection.
 	got, err := s.Route(context.Background(), router.Request{PromptText: strings.Repeat("x", 100), HasImages: true})
 	require.NoError(t, err)
 	assert.Equal(t, "z-ai/glm-5.1", got.Model)
@@ -678,11 +659,9 @@ func TestScorer_FiltersOutUnregisteredProvider(t *testing.T) {
 	assert.Contains(t, got.Reason, "provider=openai")
 }
 
-// Multi-binding regression: kimi-k2.5 has catalog bindings [bedrock,
-// openrouter] (primary, fallback). A self-hoster wiring only OpenRouter
-// must still route to kimi-k2.5 — the scorer should resolve via the
-// trailing binding and emit Decision.Provider="openrouter", not drop the
-// row because the registry's Provider field says "bedrock".
+// kimi-k2.5's catalog bindings are [bedrock, openrouter]. A self-hoster
+// wiring only OpenRouter must still route to it via the trailing binding,
+// not drop it because the registry's Provider field says "bedrock".
 func TestScorer_MultiBindingResolvesFallbackProviderAtBoot(t *testing.T) {
 	dim := EmbedDim
 	c0 := make([]float32, dim)
@@ -714,9 +693,8 @@ func TestScorer_MultiBindingResolvesFallbackProviderAtBoot(t *testing.T) {
 	assert.Contains(t, got.Reason, "provider=openrouter")
 }
 
-// Multi-binding regression: when both primary and fallback are wired,
-// the primary (first in catalog order) wins. Verifies catalog's ordered
-// fallback list semantics.
+// When both primary and fallback bindings are wired, the primary (first
+// in catalog order) wins.
 func TestScorer_MultiBindingPrefersPrimaryWhenBothAvailable(t *testing.T) {
 	dim := EmbedDim
 	c0 := make([]float32, dim)
@@ -744,9 +722,8 @@ func TestScorer_MultiBindingPrefersPrimaryWhenBothAvailable(t *testing.T) {
 	assert.Equal(t, "bedrock", got.Provider, "with both providers wired, the primary binding wins")
 }
 
-// Per-request EnabledProviders re-resolves the binding: a deploy with
-// both bedrock + openrouter wired can still serve a per-request BYOK
-// constraint of openrouter-only by walking down the fallback list.
+// Per-request EnabledProviders re-resolves the binding: openrouter-only
+// walks down the fallback list even though bedrock is also wired.
 func TestScorer_MultiBindingPerRequestResolvesNarrowedSet(t *testing.T) {
 	dim := EmbedDim
 	c0 := make([]float32, dim)
@@ -882,9 +859,8 @@ func TestArgmax_TiebreakUsesOrderSlice(t *testing.T) {
 	assert.Equal(t, "B", gotB)
 }
 
-// twoProviderArtifacts: 2 clusters, one candidate per provider. OpenAI
-// outscores Anthropic on the aligned cluster — exercises per-request
-// EnabledProviders gating.
+// twoProviderArtifacts: 2 clusters, one candidate per provider; OpenAI
+// outscores Anthropic on the aligned cluster.
 func twoProviderArtifacts(t *testing.T) (centroidsBlob, rankingsBlob, registryBlob []byte) {
 	t.Helper()
 	dim := EmbedDim
@@ -1002,8 +978,7 @@ func TestScorer_ExcludedModelsEmptyingPoolReturnsErrNoEligibleProvider(t *testin
 }
 
 // has_tools=true must subtract catalog.ToolUseLowSet from the argmax pool
-// so qwen3-235b-Instruct (and other instruct-only weak tool callers) cannot
-// be picked for agentic workloads.
+// so weak tool-callers like qwen3-235b-Instruct aren't picked for agentic work.
 func TestScorer_HasToolsExcludesToolUseLowFromArgmax(t *testing.T) {
 	dim := EmbedDim
 	c0 := make([]float32, dim)
@@ -1038,11 +1013,10 @@ func TestScorer_HasToolsExcludesToolUseLowFromArgmax(t *testing.T) {
 	assert.Equal(t, "claude-opus-4-7", got.Model, "has_tools=true must drop ToolUseLow models from argmax")
 }
 
-// has_tools=true must subtract catalog.AgenticLowSet from the argmax pool so a
-// model that emits valid tool calls but can't drive the agentic harness
-// (minimax-m3) cannot win an agentic turn — this is what lets a price-leaning
-// dial demote Opus to a cheaper HARNESS-CAPABLE model instead of collapsing onto
-// the cheapest model in the pool.
+// has_tools=true must subtract catalog.AgenticLowSet from the argmax pool
+// so a model that emits valid tool calls but can't drive the agentic
+// harness (minimax-m3) can't win — a price-leaning dial should demote to
+// a cheaper harness-capable model, not the cheapest model overall.
 func TestScorer_HasToolsExcludesAgenticLowFromArgmax(t *testing.T) {
 	dim := EmbedDim
 	c0 := make([]float32, dim)
@@ -1077,9 +1051,8 @@ func TestScorer_HasToolsExcludesAgenticLowFromArgmax(t *testing.T) {
 	assert.Equal(t, "claude-opus-4-7", got.Model, "has_tools=true must drop AgenticLow models from argmax")
 }
 
-// Soft-filter regression: if the AgenticLow filter would empty the eligible
-// pool, fall back to the unfiltered set rather than 4xx-ing — a decision is
-// always returned even on an OSS-only deploy.
+// If the AgenticLow filter would empty the eligible pool, fall back to
+// the unfiltered set rather than 4xx-ing.
 func TestScorer_HasToolsFallsBackWhenAgenticFilterEmptiesPool(t *testing.T) {
 	dim := EmbedDim
 	c0 := make([]float32, dim)
@@ -1106,9 +1079,8 @@ func TestScorer_HasToolsFallsBackWhenAgenticFilterEmptiesPool(t *testing.T) {
 	assert.Equal(t, "minimax/minimax-m3", got.Model, "filter must fall back when it would empty the pool")
 }
 
-// Soft-filter regression: if the ToolUseLow filter would empty the eligible
-// pool, fall back to the unfiltered set rather than 4xx-ing — this is a
-// quality preference, not a correctness gate.
+// If the ToolUseLow filter would empty the eligible pool, fall back to
+// the unfiltered set — this is a quality preference, not a correctness gate.
 func TestScorer_HasToolsFallsBackWhenFilterEmptiesPool(t *testing.T) {
 	dim := EmbedDim
 	c0 := make([]float32, dim)
@@ -1292,10 +1264,8 @@ type v2BundleOpts struct {
 	defaultKnobs    *DefaultRoutingKnobs
 }
 
-// newV2BundleForTest builds a synthetic two-cluster v2 bundle that
-// matches twoClusterArtifacts (Opus + Haiku across clusters 0 and 1),
-// with per-axis overrides via opts. Returns a Scorer wired against
-// fakeEmbedder.
+// newV2BundleForTest builds a synthetic two-cluster v2 bundle (Opus +
+// Haiku across clusters 0/1) with per-axis overrides via opts.
 func newV2BundleForTest(t *testing.T, emb Embedder, opts v2BundleOpts) *Scorer {
 	t.Helper()
 	dim := EmbedDim
@@ -1393,9 +1363,8 @@ func newV2BundleForTest(t *testing.T, emb Embedder, opts v2BundleOpts) *Scorer {
 	return scorer
 }
 
-// TestDegenerateRangeFallthrough confirms that when every model ties on
-// quality in a cluster (q_range==0), the blend collapses to cost (+ speed
-// when enabled) only — matching the trainer's behavior at line 597/623.
+// When every model ties on quality (q_range==0), the blend must collapse
+// to cost (+ speed) only, matching the trainer's behavior.
 func TestDegenerateRangeFallthrough(t *testing.T) {
 	emb := &fakeEmbedder{vec: makeOpusVec()}
 	tied := Rankings{
@@ -1417,9 +1386,8 @@ func TestDegenerateRangeFallthrough(t *testing.T) {
 	assert.Equal(t, "claude-haiku-4-5", dec.Model, "tied quality should let cost decide")
 }
 
-// TestSpeedRangeZeroFallsBackToTwoAxis covers the case where exactly one
-// deployed model has AA timing data, so s_range==0. The blend must fall
-// back to (quality + cost) with w_s redistributed.
+// When exactly one deployed model has AA timing data (s_range==0), the
+// blend must fall back to (quality + cost) with w_s redistributed.
 func TestSpeedRangeZeroFallsBackToTwoAxis(t *testing.T) {
 	emb := &fakeEmbedder{vec: makeOpusVec()}
 	opusInputP := 0.015
@@ -1457,10 +1425,8 @@ func TestSpeedRangeZeroFallsBackToTwoAxis(t *testing.T) {
 	assert.Equal(t, "claude-opus-4-7", dec.Model, "s_range==0 must not crash; quality still decides")
 }
 
-// TestKnobOverrideOnlyReweights verifies that supplying explicit
-// overrides equal to the bundle defaults yields the same decision as
-// not supplying overrides — proves overrides reweight, they don't
-// silently change anything else.
+// Overrides equal to the bundle defaults must yield the same decision as
+// no overrides at all.
 func TestKnobOverrideOnlyReweights(t *testing.T) {
 	emb := &fakeEmbedder{vec: makeOpusVec()}
 	scorer := newV2BundleForTest(t, emb, v2BundleOpts{})
@@ -1489,10 +1455,8 @@ func TestKnobOverrideOnlyReweights(t *testing.T) {
 	assert.Equal(t, decDefault.Metadata.EffectiveKnobsHash, decOverride.Metadata.EffectiveKnobsHash, "matching knobs must hash identically")
 }
 
-// TestAlphaScalarReplacesVector confirms the sledgehammer behavior:
-// a scalar alpha override uniformly overwrites every per-cluster alpha,
-// discarding calibration. Set distinct per-cluster alphas and verify
-// they're gone after override.
+// A scalar alpha override uniformly overwrites every per-cluster alpha,
+// discarding calibration.
 func TestAlphaScalarReplacesVector(t *testing.T) {
 	emb := &fakeEmbedder{vec: makeOpusVec()}
 
@@ -1520,9 +1484,8 @@ func TestAlphaScalarReplacesVector(t *testing.T) {
 	assert.Equal(t, "claude-haiku-4-5", decOverride.Model, "scalar alpha=0 must overwrite per-cluster 0.9, letting cost decide")
 }
 
-// TestZeroAATimingFallback covers the case where w_s > 0 but no model
-// has AA timing data. The blend should fall to (quality + cost) across
-// the board with w_s proportionally redistributed.
+// When w_s > 0 but no model has AA timing data, the blend must fall back
+// to (quality + cost) with w_s redistributed.
 func TestZeroAATimingFallback(t *testing.T) {
 	emb := &fakeEmbedder{vec: makeOpusVec()}
 	opusInputP := 0.015
@@ -1555,10 +1518,8 @@ func TestZeroAATimingFallback(t *testing.T) {
 	assert.Equal(t, "claude-opus-4-7", dec.Model)
 }
 
-// TestPureSpeedMissingTimingFallsBackToQuality covers the extreme
-// configuration where alpha=0, w_s=1 (pure speed). For a model with no
-// AA timing, total = alpha + (1-alpha-w_s) = 0, so the fallback returns
-// the raw qNorm — preventing a NaN or panic.
+// With alpha=0, w_s=1 (pure speed) and no AA timing data, total weight
+// is 0; the fallback must return raw qNorm rather than NaN/panic.
 func TestPureSpeedMissingTimingFallsBackToQuality(t *testing.T) {
 	emb := &fakeEmbedder{vec: makeOpusVec()}
 	haikuInputP := 0.00025

--- a/internal/router/planner/policy_test.go
+++ b/internal/router/planner/policy_test.go
@@ -19,16 +19,14 @@ const (
 	modelUnknown = "fictional-foo-1.0" // intentionally absent from the pricing table
 )
 
-// defaultCfg matches the documented planner defaults (threshold $0.001,
-// horizon 3 turns) so the table below mirrors what production sees.
+// defaultCfg mirrors production defaults (threshold $0.001, horizon 3 turns).
 var defaultCfg = planner.EVConfig{
 	ThresholdUSD:           0.001,
 	ExpectedRemainingTurns: 3,
 }
 
-// availableAll covers every model the EV cases reference (Anthropic + the
-// cross-provider GPT-5 entry). Used everywhere except the pin_model_missing
-// case.
+// availableAll covers every model the EV cases reference; used everywhere
+// except pin_model_missing.
 var availableAll = map[string]struct{}{
 	modelOpus:   {},
 	modelSonnet: {},
@@ -58,17 +56,16 @@ func pinWithUsage(model string) sessionpin.Pin {
 func TestDecide_SubscriptionDiscountFlipsSwitch(t *testing.T) {
 	t.Parallel()
 	base := planner.Inputs{
-		Pin:                  pinWithUsage(modelHaiku),          // cheap pin ($0.80 in)
-		Fresh:                router.Decision{Model: modelOpus}, // expensive fresh ($5.00 in)
+		Pin:                  pinWithUsage(modelHaiku),
+		Fresh:                router.Decision{Model: modelOpus},
 		EstimatedInputTokens: 100_000,
 		AvailableModels:      availableAll,
 	}
 
-	// Full catalog economics: switching cheap→expensive is EV-negative → stay.
 	stay := planner.Decide(base, defaultCfg)
 	assert.Equal(t, planner.OutcomeStay, stay.Outcome, "no subsidy: keep the cheap pin")
 
-	// Subsidize the fresh (covered) model to ~free → switching now saves → switch.
+	// Subsidize the fresh model to ~free -> switching now saves.
 	sub := base
 	sub.SubsidizedCostFactor = map[string]float64{modelOpus: 0.01}
 	switched := planner.Decide(sub, defaultCfg)
@@ -76,8 +73,7 @@ func TestDecide_SubscriptionDiscountFlipsSwitch(t *testing.T) {
 		"subsidized covered model must win the stay-vs-switch EV")
 	assert.Equal(t, planner.ReasonEVPositive, switched.Reason)
 
-	// A 0.0 factor (epsilon=0) is a real "free" covered model, not "uncovered":
-	// membership in the map, not the sign, decides — matching the scorer.
+	// A 0.0 factor is still "covered" (map membership decides, not sign).
 	zeroFactor := base
 	zeroFactor.SubsidizedCostFactor = map[string]float64{modelOpus: 0.0}
 	zero := planner.Decide(zeroFactor, defaultCfg)
@@ -216,13 +212,9 @@ func TestDecide(t *testing.T) {
 			want: planner.Decision{Outcome: planner.OutcomeStay, Reason: planner.ReasonPricingMissing},
 		},
 		{
-			// EV math for switch from opus -> haiku, 50k input, 3 turns.
-			// Savings are multiplied by CacheReadMultiplier (0.1) because in
-			// steady state most input tokens come from cache on both models:
-			//   savingsPerTurn = (5.00 - 0.80) * 0.1 * 50000 / 1e6 = $0.021
-			//   evictionCost   = 0.80 * 50000 * 0.9 / 1e6          = $0.036
-			//   expectedSavings = 0.021 * 3 = $0.063
-			//   delta = 0.063 - 0.036 = $0.027 > $0.001 -> Switch.
+			// opus -> haiku, 50k tokens, 3 turns; cache-read multiplier 0.1 applies.
+			//   savingsPerTurn=$0.021 evictionCost=$0.036
+			//   expectedSavings=$0.063 -> delta=$0.027 -> Switch.
 			name: "ev_positive: opus -> haiku on a large prompt",
 			in: planner.Inputs{
 				Pin:                  pinWithUsage(modelOpus),
@@ -237,11 +229,8 @@ func TestDecide(t *testing.T) {
 			wantEvictionCostUSD:    0.036,
 		},
 		{
-			// Symmetric flip: pinning haiku, fresh recommends opus.
-			//   savingsPerTurn = (0.80 - 5.00) * 0.1 * 50000 / 1e6 = -$0.021
-			//   evictionCost   = 5.00 * 50000 * 0.9 / 1e6          = $0.225
-			//   expectedSavings = -0.021 * 3 = -$0.063
-			//   delta = -0.063 - 0.225 = -$0.288 < $0.001 -> Stay.
+			// Symmetric flip: haiku pin, opus fresh.
+			//   expectedSavings=-$0.063 evictionCost=$0.225 -> delta=-$0.288 -> Stay.
 			name: "ev_negative: haiku -> opus is a huge net loss",
 			in: planner.Inputs{
 				Pin:                  pinWithUsage(modelHaiku),
@@ -256,18 +245,8 @@ func TestDecide(t *testing.T) {
 			wantEvictionCostUSD:    0.225,
 		},
 		{
-			// Opus -> haiku, tuned to land just BELOW threshold under the
-			// corrected (cache-read-aware) EV math at the new $5/$25 opus
-			// pricing (was $15/$75; the old opus->sonnet boundary case no
-			// longer straddles — sonnet's $3 input dominates opus's $0.50
-			// cache-read at every horizon).
-			//   per-token net = (3 * 0.1 * (5.00 - 0.80) - 0.9 * 0.80) / 1e6
-			//                 = (1.26 - 0.72) / 1e6 = 0.54 / 1e6
-			//   at tokens = 1851: net = 0.54 * 1851 / 1e6 = $0.00099954
-			//   threshold = $0.001 -> net is 0.05% below.
-			//   expectedSavings = (5.00 - 0.80) * 0.1 * 1851 / 1e6 * 3 = $0.00233226
-			//   evictionCost    = 0.80 * 1851 * 0.9 / 1e6              = $0.00133272
-			//   delta = 0.00233226 - 0.00133272 = $0.00099954 -> Stay.
+			// opus -> haiku, tuned to land just below threshold (net $0.00099954
+			// at 1851 tokens vs $0.001 threshold, 0.05% below) -> Stay.
 			name: "ev_near_threshold: just below threshold stays stable",
 			in: planner.Inputs{
 				Pin:                  pinWithUsage(modelOpus),
@@ -282,12 +261,8 @@ func TestDecide(t *testing.T) {
 			wantEvictionCostUSD:    0.00133272,
 		},
 		{
-			// Same opus -> haiku math, two extra tokens nudge across:
-			//   at tokens = 1853: net = 0.54 * 1853 / 1e6 = $0.00100062
-			//   threshold = $0.001 -> net is 0.06% above.
-			//   expectedSavings = (5.00 - 0.80) * 0.1 * 1853 / 1e6 * 3 = $0.00233478
-			//   evictionCost    = 0.80 * 1853 * 0.9 / 1e6              = $0.00133416
-			//   delta = 0.00233478 - 0.00133416 = $0.00100062 -> Switch.
+			// Same math, two extra tokens (1853) nudges net to $0.00100062,
+			// 0.06% above threshold -> Switch.
 			name: "ev_near_threshold: just above threshold flips to switch",
 			in: planner.Inputs{
 				Pin:                  pinWithUsage(modelOpus),
@@ -302,21 +277,10 @@ func TestDecide(t *testing.T) {
 			wantEvictionCostUSD:    0.00133416,
 		},
 		{
-			// Cross-provider regression: opus (Anthropic, mult 0.10) ->
-			// gpt-5 (OpenAI, mult 0.10) on a 50k prompt at the new $5/$25
-			// opus pricing.
-			//   savingsPerTurn  = (5.00 * 0.10 - 2.50 * 0.10) * 50000 / 1e6
-			//                   = (0.50 - 0.25) * 0.05 = $0.0125
-			//   expectedSavings = 0.0125 * 3 = $0.0375
-			//   evictionCost    = 2.50 * 50000 * (1 - 0.10) / 1e6 = $0.1125
-			//   delta = 0.0375 - 0.1125 = -$0.075 -> Stay.
-			//
-			// In cache steady-state gpt-5 is actually cheaper per token than
-			// opus (half the nominal input price, same 0.10 cache-read
-			// multiplier), so the per-turn EV is positive. But abandoning
-			// opus's warm cache to refill gpt-5's cold cache costs more than
-			// the modest steady-state savings buy back over the horizon, so
-			// the planner stays on opus.
+			// Cross-provider: opus -> gpt-5, 50k prompt. gpt-5 is cheaper
+			// per-token in cache steady-state (expectedSavings=$0.0375), but
+			// evicting opus's warm cache to refill gpt-5's cold one costs more
+			// (evictionCost=$0.1125) -> Stay.
 			name: "ev_cross_provider: opus -> gpt-5 stays under per-model math",
 			in: planner.Inputs{
 				Pin:                  pinWithUsage(modelOpus),
@@ -347,8 +311,7 @@ func TestDecide(t *testing.T) {
 			wantEvictionCostUSD:    0.225,
 		},
 		{
-			// Same EV-loss as above; guard on flips it because opus is
-			// strictly higher tier than haiku. USD fields still populated.
+			// Same EV-loss as above; tier guard flips it since opus outranks haiku.
 			name: "tier_upgrade: low -> high flips stay into switch",
 			in: planner.Inputs{
 				Pin:                  pinWithUsage(modelHaiku),
@@ -375,21 +338,14 @@ func TestDecide(t *testing.T) {
 			cfg:          tierUpgradeCfg,
 			want:         planner.Decision{Outcome: planner.OutcomeStay, Reason: planner.ReasonEVNegative},
 			expectEVMath: true,
-			// savingsPerTurn = (3.00 - 0.80) * 0.1 * 1000 / 1e6 = $0.00022
-			// expectedSavings = 0.00022 * 3 = $0.00066
-			// evictionCost   = 0.80 * 1000 * 0.9 / 1e6 = $0.00072
+			// expectedSavings=$0.00066 evictionCost=$0.00072
 			wantExpectedSavingsUSD: 0.00066,
 			wantEvictionCostUSD:    0.00072,
 		},
 		{
-			// Cold pin: the provider's cache TTL lapsed, so neither the pin's
-			// cache-read discount nor the eviction cost applies — both sides are
-			// priced uncached. opus -> haiku still switches, but on raw input
-			// price rather than the cache-read delta.
-			//   savingsPerTurn  = (5.00 - 0.80) * 50000 / 1e6 = $0.21
-			//   expectedSavings = 0.21 * 3 = $0.63
-			//   evictionCost    = 0 (nothing warm to evict)
-			//   delta = 0.63 - 0 = $0.63 > $0.001 -> Switch.
+			// Cold pin: cache TTL lapsed, both sides price uncached, so this
+			// switches on raw input price rather than the cache-read delta.
+			// expectedSavings=$0.63 evictionCost=$0 (nothing warm to evict).
 			name: "cold_ev_positive: opus -> haiku prices uncached",
 			in: planner.Inputs{
 				Pin:                  pinWithUsage(modelOpus),
@@ -405,16 +361,8 @@ func TestDecide(t *testing.T) {
 			wantEvictionCostUSD:    0,
 		},
 		{
-			// Regression guard: the warm twin of this case (ev_cross_provider)
-			// STAYS because abandoning opus's warm cache to refill gpt-5's cold
-			// cache costs more than the steady-state savings buy back. Once the
-			// pin's cache is cold there is nothing warm to preserve, so the raw
-			// $2.50 vs $5.00 input price wins and the planner correctly switches
-			// instead of clinging to a stale pin.
-			//   savingsPerTurn  = (5.00 - 2.50) * 50000 / 1e6 = $0.125
-			//   expectedSavings = 0.125 * 3 = $0.375
-			//   evictionCost    = 0
-			//   delta = 0.375 > $0.001 -> Switch.
+			// Cold twin of ev_cross_provider (which STAYS): with no warm cache
+			// to preserve, raw $2.50 vs $5.00 input price wins and it switches.
 			name: "cold_cross_provider: opus -> gpt-5 switches once cache is cold",
 			in: planner.Inputs{
 				Pin:                  pinWithUsage(modelOpus),
@@ -430,12 +378,8 @@ func TestDecide(t *testing.T) {
 			wantEvictionCostUSD:    0,
 		},
 		{
-			// Cold pin but the pin is the cheaper model: no cache to preserve,
-			// yet switching to the pricier fresh model is a raw-price loss, so
-			// the planner stays. evictionCost is still zero.
-			//   savingsPerTurn  = (0.80 - 5.00) * 50000 / 1e6 = -$0.21
-			//   expectedSavings = -0.21 * 3 = -$0.63
-			//   delta = -0.63 < $0.001 -> Stay.
+			// Cold pin on the cheaper model: no cache to preserve, but switching
+			// to the pricier fresh model is still a raw-price loss -> Stay.
 			name: "cold_ev_negative: haiku -> opus stays on raw price",
 			in: planner.Inputs{
 				Pin:                  pinWithUsage(modelHaiku),
@@ -451,9 +395,8 @@ func TestDecide(t *testing.T) {
 			wantEvictionCostUSD:    0,
 		},
 		{
-			// Cold pin does not disable the tier-upgrade guard: haiku -> opus is
-			// a raw-price loss (would stay on EV alone) but opus is strictly
-			// higher tier, so the guard still flips it to switch.
+			// Cold pin does not disable the tier-upgrade guard: EV alone would
+			// stay, but opus outranks haiku so it still switches.
 			name: "cold_tier_upgrade: guard still fires when cache is cold",
 			in: planner.Inputs{
 				Pin:                  pinWithUsage(modelHaiku),

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -36,9 +36,8 @@ const (
 )
 
 // DeploymentMode gates whether the self-hoster admin dashboard and its
-// /admin/v1/* API are mounted. In Weave-managed (SaaS) deployments the
-// dashboard is redundant attack surface — keys, BYOK secrets, and config
-// are owned by the Weave control plane.
+// /admin/v1/* API are mounted. Managed (SaaS) deployments skip it since
+// keys, BYOK secrets, and config are owned by the Weave control plane.
 type DeploymentMode string
 
 const (
@@ -51,45 +50,33 @@ const (
 // Register wires routes onto the engine. In managed mode the dashboard +
 // /admin/v1/* routes are not registered at all.
 //
-// deployedModels is the source for the admin model-selection checklist. May
-// be nil in tests; required in selfhosted production so the dashboard can
-// render the universe of routable models.
+// deployedModels may be nil in tests; required in selfhosted prod so the
+// dashboard can render the universe of routable models.
 //
-// billingSvc is non-nil only in managed mode when the credit-billing tables
-// are present; when set, every inference route is gated on prepaid balance
-// via middleware.WithBalanceCheck. nil leaves inference routes open (BYOK
-// or platform key still controls upstream auth).
+// billingSvc is set only in managed mode when credit-billing is enabled; it
+// gates every inference route on prepaid balance via WithBalanceCheck. nil
+// leaves inference routes open (BYOK/platform key still controls upstream auth).
 func Register(engine *gin.Engine, authSvc *auth.Service, proxySvc *proxy.Service, deployedModels admin.DeployedModelsSource, mode DeploymentMode, billingSvc *billing.Service) {
-	// Managed mode bills via prepaid credits against the platform key; any
-	// BYOK row left over in router.model_router_external_api_keys would
-	// silently double-charge the customer (upstream provider + Weave credits).
-	// Drop BYOK at the middleware boundary so no downstream consumer can see it.
+	// Managed mode bills via platform-key credits; a leftover BYOK row would
+	// double-charge (upstream provider + Weave credits), so drop it here.
 	byokDisabled := mode == DeploymentModeManaged
 
 	engine.GET("/health", middleware.WithTimeout(healthTimeout), admin.HealthHandler)
 
-	// /v1/version reports the running binary's git commit + build time (stamped
-	// via -ldflags) so operators and the README's managed-deployment badge can
-	// tell which router commit is live. Unauthed + mounted in both modes, like
-	// /health — the fields are public build metadata with no leak risk.
+	// /v1/version reports the binary's git commit + build time (via -ldflags),
+	// used by the README's managed-deployment badge. Public build metadata, unauthed like /health.
 	engine.GET("/v1/version", middleware.WithTimeout(healthTimeout), admin.VersionHandler)
 
-	// /v1/router/models surfaces the active artifact's deployed-models list so
-	// the Weave control plane can validate per-org exclusion submissions
-	// against the live universe instead of hand-copying it on every gitlink
-	// bump. Read-only metadata — unauthed so managed mode (no admin keys
-	// issuable on-router) can call it; the list is published publicly on the
-	// RouterArena leaderboard so there is no leak risk. nil source skips the
-	// route in tests that don't wire a cluster scorer.
+	// /v1/router/models lets the Weave control plane validate per-org exclusion
+	// submissions against the live deployed-models universe instead of
+	// hand-copying it per gitlink bump. Unauthed: read-only, and the list is
+	// already public on the RouterArena leaderboard.
 	if deployedModels != nil {
 		engine.GET("/v1/router/models", middleware.WithTimeout(healthTimeout), admin.CatalogModelsHandler(deployedModels))
 
-		// /v1/router/routing-distribution projects the per-installation "quality
-		// vs price" dial's model mix across a grid of dial positions, so the
-		// dashboard can render the live distribution preview and calibrate the
-		// slider. Same read-only/unauthed rationale as /v1/router/models. The
-		// source is the same *cluster.Multiversion; the assertion skips the
-		// route for a deployedModels source that can't project a distribution.
+		// Projects the quality-vs-price dial's model mix across dial positions
+		// for the dashboard's distribution preview. Same unauthed rationale as
+		// /v1/router/models; the assertion skips sources that can't project one.
 		if dist, ok := deployedModels.(admin.RoutingDistributionSource); ok {
 			engine.GET("/v1/router/routing-distribution", middleware.WithTimeout(healthTimeout), admin.RoutingDistributionHandler(dist))
 		}
@@ -175,11 +162,9 @@ func Register(engine *gin.Engine, authSvc *auth.Service, proxySvc *proxy.Service
 	// Action suffix (:generateContent or :streamGenerateContent) lives inside modelAction because Gin treats `:` outside the leading position as a literal.
 	chatCompletionGroup.POST("/v1beta/models/:modelAction", geminiapi.GenerateContentHandler(proxySvc, authSvc))
 
-	// Passthrough endpoints (count_tokens, model list) do not consume
-	// upstream tokens beyond a metadata lookup, so we leave them open
-	// even when billing is enabled. count_tokens in particular is the
-	// SDK's first call before /v1/messages — gating it on balance would
-	// make clients fail to negotiate before any inference happens.
+	// Passthrough endpoints cost no upstream tokens, so they stay open even
+	// with billing enabled — count_tokens is the SDK's pre-flight call before
+	// /v1/messages, and gating it would break client negotiation.
 	passthroughGroup := engine.Group("",
 		middleware.WithTimeout(passthroughTimeout),
 		middleware.WithAuth(authSvc, byokDisabled),
@@ -204,10 +189,9 @@ func Register(engine *gin.Engine, authSvc *auth.Service, proxySvc *proxy.Service
 	routeGroup := engine.Group("", routeMiddleware...)
 	routeGroup.POST("/v1/route", anthropicapi.RouteHandler(proxySvc))
 
-	// No-login feedback link (product surface, both modes). The signed HMAC
-	// token in the URL / body is the sole credential, so these routes carry no
-	// auth middleware. Mounted only when a feedback signer is configured
-	// (ROUTER_FEEDBACK_LINK_SECRET set); otherwise the surface stays absent.
+	// No-login feedback link: the signed HMAC token in the URL/body is the
+	// sole credential, so no auth middleware. Mounted only when
+	// ROUTER_FEEDBACK_LINK_SECRET is configured.
 	if proxySvc.FeedbackEnabled() {
 		feedbackGroup := engine.Group("/v1/feedback", middleware.WithTimeout(feedbackTimeout))
 		feedbackGroup.GET("/link/:token", feedbackapi.GetContextHandler(proxySvc))
@@ -220,23 +204,18 @@ func Register(engine *gin.Engine, authSvc *auth.Service, proxySvc *proxy.Service
 }
 
 // registerUIStatic mounts the exported Next.js dashboard at /ui with
-// clean-URL semantics (no trailing slash, no .html extension visible).
+// clean-URL semantics (no trailing slash, no .html extension).
 //
-// Next is configured with trailingSlash:false, so its static export writes
-// files as `settings.html` rather than `settings/index.html`. We can't use
-// gin.Static / http.FileServer directly: FileServer would either 404 on
-// `/ui/settings` or redirect `/ui/settings` → `/ui/settings/` (when
-// `settings/index.html` exists), neither of which is what we want here.
-//
-// Resolution order for a request to `/ui/<path>`:
-//  1. If <path> ends with `/`, redirect to the slashless form (308).
-//  2. If <path> is empty or `index`, serve `index.html`.
-//  3. If `<path>` exists as a regular file under assets/ui, serve it.
-//  4. If `<path>.html` exists, serve that.
+// Next's static export (trailingSlash:false) writes `settings.html`, not
+// `settings/index.html`, so plain gin.Static/http.FileServer would 404 or
+// redirect wrong on `/ui/settings`. Resolution order for `/ui/<path>`:
+//  1. Trailing slash -> redirect to slashless form (308).
+//  2. Empty or `index` -> serve index.html.
+//  3. `<path>` exists as a file -> serve it.
+//  4. `<path>.html` exists -> serve that.
 //  5. Otherwise 404.
 //
-// All resolved paths are clamped under `root` via filepath.Clean to block
-// `..` traversal regardless of what gin's wildcard captures.
+// Resolved paths are clamped under `root` via filepath.Clean against `..` traversal.
 func registerUIStatic(engine *gin.Engine, root string) {
 	absRoot, err := filepath.Abs(root)
 	if err != nil {

--- a/internal/translate/crossformat_request_test.go
+++ b/internal/translate/crossformat_request_test.go
@@ -85,9 +85,8 @@ var openAIAssistantTextAndToolCalls = []byte(`{
 }`)
 
 // openAIAssistantArrayContentAndToolCalls mirrors openAIAssistantTextAndToolCalls
-// but carries assistant content as an OpenAI parts array (the shape Cursor sends)
-// rather than a plain string. The array form must flatten to the inner text, not
-// be serialized verbatim into the Anthropic text block.
+// but with assistant content as an OpenAI parts array (Cursor's shape); it must
+// flatten to inner text, not serialize verbatim.
 var openAIAssistantArrayContentAndToolCalls = []byte(`{
 	"model": "gpt-4",
 	"messages": [
@@ -356,11 +355,9 @@ var openAICacheInjectionConversation = []byte(`{
 
 var ephemeral = map[string]any{"type": "ephemeral"}
 
-// TestCrossFormat_OpenAIToAnthropic_CacheControlInjection pins the prompt-cache
-// breakpoint injection on the OpenAI->Anthropic path: clients like Cursor send
-// no cache_control, so the router marks the last system block (caches the
-// tools+system floor) and the last block of the final message (caches the
-// conversation prefix) — and nothing else.
+// TestCrossFormat_OpenAIToAnthropic_CacheControlInjection pins prompt-cache
+// breakpoint injection: for clients that send no cache_control, the router
+// marks only the last system block and the last block of the final message.
 func TestCrossFormat_OpenAIToAnthropic_CacheControlInjection(t *testing.T) {
 	env, err := translate.ParseOpenAI(openAICacheInjectionConversation)
 	require.NoError(t, err)
@@ -493,12 +490,10 @@ func TestCrossFormat_OpenAIToAnthropic_AssistantTextAndToolCalls(t *testing.T) {
 	assert.Equal(t, "search_prs", toolBlock["name"])
 }
 
-// TestCrossFormat_OpenAIToAnthropic_AssistantArrayContentAndToolCalls guards the
-// regression where an assistant message carrying tool_calls plus parts-array
-// content (the shape Cursor sends) had its content array serialized verbatim into
-// the Anthropic text block via gjson .String(). That produced a stringified
-// {"type":"text",...} block that the model echoed and compounded one level per
-// agentic turn, yielding deeply nested garbage on the client.
+// TestCrossFormat_OpenAIToAnthropic_AssistantArrayContentAndToolCalls guards a
+// regression: an assistant message with tool_calls plus parts-array content
+// (Cursor's shape) got serialized verbatim via gjson .String(), producing a
+// stringified block that compounded into nested garbage each agentic turn.
 func TestCrossFormat_OpenAIToAnthropic_AssistantArrayContentAndToolCalls(t *testing.T) {
 	env, err := translate.ParseOpenAI(openAIAssistantArrayContentAndToolCalls)
 	require.NoError(t, err)
@@ -643,12 +638,9 @@ func TestCrossFormat_OpenAIToGemini_ToolConversation(t *testing.T) {
 	assert.Equal(t, "package main\n\nfunc main() {}", result["result"])
 }
 
-// TestCrossFormat_OpenAIToGemini_DropsSigLessToolsForGemini3x covers the
-// mirror of the Anthropic→Gemini guard for the OpenAI surface. An OpenAI
-// client whose assistant history was produced by a non-Gemini provider
-// carries `tool_calls` without `thought_signature`. Routed to a Gemini 3.x
-// preview model, the upstream rejects the request with 400 on missing
-// thoughtSignature. The translator must drop the sig-less tool history.
+// TestCrossFormat_OpenAIToGemini_DropsSigLessToolsForGemini3x mirrors the
+// Anthropic→Gemini guard: tool_calls without thought_signature 400 on Gemini
+// 3.x preview models, so the translator must drop sig-less tool history.
 func TestCrossFormat_OpenAIToGemini_DropsSigLessToolsForGemini3x(t *testing.T) {
 	env, err := translate.ParseOpenAI(openAIToolConversation)
 	require.NoError(t, err)
@@ -678,11 +670,9 @@ func TestCrossFormat_OpenAIToGemini_DropsSigLessToolsForGemini3x(t *testing.T) {
 	}
 }
 
-// Multi-tool turns produce one `role:"tool"` message per tool_call_id. When
-// the sig-less drop guard fires, each tool message would naively emit its
-// own user placeholder, producing consecutive `user` entries that Gemini
-// 400s on. Verify a run of consecutive tool messages coalesces into a single
-// placeholder so role alternation is preserved.
+// When the sig-less drop guard fires on multi-tool turns, consecutive
+// `role:"tool"` messages must coalesce into a single user placeholder —
+// otherwise Gemini 400s on non-alternating roles.
 func TestCrossFormat_OpenAIToGemini_MultiToolDropCoalescesPlaceholders(t *testing.T) {
 	body := []byte(`{
 		"model":"gpt-5",
@@ -900,9 +890,8 @@ func TestCrossFormat_AnthropicToOpenAI_ToolConversation(t *testing.T) {
 }
 
 func TestCrossFormat_AnthropicToOpenAI_OverlongToolUseIDClampedAndPaired(t *testing.T) {
-	// OpenAI rejects tool_calls[].id over 64 chars (400 "string too long").
-	// Cross-format round-trips can produce such IDs; the emit must clamp them,
-	// and the tool_use id must stay paired with its tool_result tool_call_id.
+	// OpenAI rejects tool_calls[].id over 64 chars; emit must clamp round-trip
+	// IDs while keeping tool_use paired with its tool_result tool_call_id.
 	longID := "toolu_" + strings.Repeat("a", 1411)
 	body := []byte(`{
 		"model": "claude-opus-4-8",
@@ -1796,9 +1785,9 @@ func TestCrossFormat_OpenAIToAnthropic_ToolMissingFunctionName(t *testing.T) {
 	require.NoError(t, json.Unmarshal(prep.Body, &doc), "output must be valid JSON; got: %s", string(prep.Body))
 }
 
-// TestSanitizeToolUseIDs_OpenAIToAnthropic checks that tool call IDs containing
-// dots or colons (e.g. Kimi-k2.6's "functions.Read:0") are sanitized before
-// forwarding to Anthropic, which rejects them with pattern ^[a-zA-Z0-9_-]+$.
+// TestSanitizeToolUseIDs_OpenAIToAnthropic checks tool call IDs with dots or
+// colons (e.g. Kimi-k2.6's "functions.Read:0") are sanitized before forwarding
+// to Anthropic, which requires pattern ^[a-zA-Z0-9_-]+$.
 func TestSanitizeToolUseIDs_OpenAIToAnthropic(t *testing.T) {
 	body := []byte(`{
 		"model": "gpt-4",
@@ -1865,12 +1854,10 @@ func TestSanitizeToolUseIDs_AnthropicToAnthropic(t *testing.T) {
 	assert.Equal(t, "functions_Grep_11", result["tool_use_id"], "tool_use_id must be sanitized in same-format path")
 }
 
-// TestStripToolUseThoughtSignature_AnthropicToAnthropic checks that a Gemini
-// thought_signature carried on a tool_use block in Anthropic-format history is
-// stripped before forwarding to Anthropic, which rejects the unknown field with
-// a 400 ("tool_use.thought_signature: Extra inputs are not permitted"). The
-// rest of the block — including the id that smuggles the signature for a later
-// switch back to Gemini — must survive untouched.
+// TestStripToolUseThoughtSignature_AnthropicToAnthropic checks a Gemini
+// thought_signature on a tool_use block is stripped before forwarding to
+// Anthropic (which 400s on the unknown field), while the id — which smuggles
+// the signature for a later switch back to Gemini — survives untouched.
 func TestStripToolUseThoughtSignature_AnthropicToAnthropic(t *testing.T) {
 	body := []byte(`{
 		"model": "claude-opus-4-8",

--- a/internal/translate/emit_anthropic.go
+++ b/internal/translate/emit_anthropic.go
@@ -50,9 +50,8 @@ func deriveAnthropicHeaders(in http.Header, opts EmitOptions) http.Header {
 	return h
 }
 
-// context1MBeta is the Anthropic beta that unlocks the 1M-token context window
-// for CapExtendedContext models (Opus 4.6+, Sonnet 4.6). Native-1M models
-// (Fable 5) accept it as a harmless no-op.
+// context1MBeta unlocks the 1M-token context window for CapExtendedContext
+// models; native-1M models (Fable 5) accept it as a no-op.
 const context1MBeta = "context-1m-2025-08-07"
 
 // ensureBetaToken appends token to a comma-separated anthropic-beta list when
@@ -138,9 +137,8 @@ func (e *RequestEnvelope) buildAnthropicFromOpenAI(opts EmitOptions) ([]byte, er
 	return jw.Bytes(), nil
 }
 
-// writeAnthropicSystemAndMessages walks the OpenAI messages array, extracts
-// system-role messages into the Anthropic "system" field, and writes the
-// remaining messages as Anthropic-formatted content.
+// writeAnthropicSystemAndMessages extracts system-role messages into the
+// Anthropic "system" field and writes the rest as Anthropic content.
 func writeAnthropicSystemAndMessages(jw *jsonWriter, body []byte) {
 	messages := gjson.GetBytes(body, "messages")
 	if !messages.Exists() {
@@ -251,9 +249,7 @@ func writeAnthropicSystemAndMessages(jw *jsonWriter, body []byte) {
 		jw.Key("messages")
 		jw.Arr()
 		for i, m := range msgParts {
-			// Cache the conversation prefix up to this turn by marking the
-			// last block of the final message; on the next turn that block is
-			// a stable prefix and reads from cache.
+			// Mark the last block so the prefix reads from cache next turn.
 			if i == len(msgParts)-1 {
 				m = cacheControlOnLastBlock(m)
 			}
@@ -263,18 +259,16 @@ func writeAnthropicSystemAndMessages(jw *jsonWriter, body []byte) {
 	}
 }
 
-// cacheControlMember is the Anthropic prompt-cache breakpoint, serialized as a
-// JSON object member. OpenAI and Gemini clients never send cache_control, so on
-// the OpenAI->Anthropic path the router injects it: without breakpoints, clients
-// like Cursor re-bill the entire stable prefix (tools + system + prior turns) on
-// every turn at 0% cache hit, because Anthropic has no implicit prompt caching.
-// Below the model's minimum cacheable prefix the marker is a silent no-op, so it
-// is always safe to add.
+// cacheControlMember is the Anthropic prompt-cache breakpoint. OpenAI/Gemini
+// clients never send cache_control, and Anthropic has no implicit caching, so
+// the OpenAI->Anthropic path injects it or clients like Cursor re-bill the
+// whole stable prefix every turn. It's a no-op below the model's minimum
+// cacheable prefix, so always safe to add.
 const cacheControlMember = `"cache_control":{"type":"ephemeral"}`
 
 // appendCacheControl inserts the cache_control marker into a raw JSON content
-// block. The block is one we constructed, so its final byte is the closing brace
-// of the outer object; the guard keeps it fail-open on anything unexpected.
+// block we constructed (final byte is the closing brace); guard fails open on
+// anything unexpected.
 func appendCacheControl(block string) string {
 	if len(block) < 2 || block[len(block)-1] != '}' || !strings.Contains(block, ":") {
 		return block
@@ -282,11 +276,9 @@ func appendCacheControl(block string) string {
 	return block[:len(block)-1] + "," + cacheControlMember + "}"
 }
 
-// cacheControlOnLastBlock returns a raw Anthropic message object with a
-// cache_control breakpoint on its final content block. String content is
-// promoted to a single text block to carry the marker (Anthropic treats "x" and
-// [{"type":"text","text":"x"}] identically). Messages built on this path only
-// ever carry "role" and "content", so rebuilding from those two is lossless.
+// cacheControlOnLastBlock adds a cache_control breakpoint to a message's final
+// content block, promoting string content to a text block to carry it
+// (Anthropic treats "x" and [{"type":"text","text":"x"}] identically).
 func cacheControlOnLastBlock(msg string) string {
 	content := gjson.Get(msg, "content")
 	role := gjson.Get(msg, "role").String()
@@ -419,11 +411,9 @@ func buildAnthropicAssistantMessage(msg gjson.Result) string {
 		return string(jw.Bytes())
 	}
 
-	// Has tool calls: build content array with optional text prefix + tool_use blocks.
-	// Content may be a plain string or an OpenAI parts array ([{"type":"text",...}]);
-	// openAIContentTextGJSON flattens both. Using gjson's .String() here would
-	// serialize a parts array into the text field verbatim, wrapping it in a
-	// stringified {"type":"text",...} block that compounds on every agentic turn.
+	// openAIContentTextGJSON flattens string or parts-array content; gjson's
+	// .String() would instead serialize a parts array verbatim into the text
+	// field, compounding a stringified block on every agentic turn.
 	jw.Key("content")
 	jw.Arr()
 	if text := openAIContentTextGJSON(msg.Get("content")); text != "" {
@@ -474,8 +464,7 @@ func buildAnthropicUserMessage(role string, content gjson.Result) string {
 	return string(jw.Bytes())
 }
 
-// writeAnthropicContentValue writes a content value (string or array) in
-// Anthropic format. String content passes through verbatim; array content has
+// writeAnthropicContentValue writes string content verbatim; array content has
 // image_url parts converted to Anthropic image blocks.
 func writeAnthropicContentValue(jw *jsonWriter, content gjson.Result) {
 	if content.Type == gjson.String {
@@ -652,14 +641,11 @@ func (e *RequestEnvelope) buildAnthropicFromAnthropic(opts EmitOptions) ([]byte,
 	return applyOverrides(body, ov)
 }
 
-// hoistAnthropicSystemMessages moves any role:"system" entries out of the
-// "messages" array and merges their text into the top-level "system" field.
-// Anthropic's Messages API rejects a system role inside messages (400
-// "role 'system' must precede an 'assistant' message or end the array"); a
-// system-bearing body can reach this same-format emit path on a mid-session
-// switch back to an Anthropic model. The OpenAI->Anthropic emit path already
-// hoists in writeAnthropicSystemAndMessages; this is the same guarantee for the
-// same-format path. No-op when no system message is present.
+// hoistAnthropicSystemMessages moves role:"system" entries out of "messages"
+// into the top-level "system" field. Anthropic's Messages API 400s on a system
+// role inside messages, which can happen on a mid-session switch back to an
+// Anthropic model; this mirrors the hoisting writeAnthropicSystemAndMessages
+// already does on the OpenAI->Anthropic path. No-op if none present.
 func hoistAnthropicSystemMessages(body []byte) ([]byte, error) {
 	msgs := gjson.GetBytes(body, "messages")
 	if !msgs.IsArray() {
@@ -743,15 +729,12 @@ func writeAnthropicTextBlock(jw *jsonWriter, text string) {
 	jw.EndObj()
 }
 
-// sanitizeToolUseID replaces characters that Anthropic rejects in tool_use.id
-// (required pattern: ^[a-zA-Z0-9_-]+$). Non-Anthropic upstreams (e.g.
-// Kimi-k2.6) emit IDs like "functions.Read:0" containing dots and colons; when
-// the router switches a session back to Anthropic those IDs cause a 400.
-//
-// Length is NOT clamped here: this helper is shared by the Anthropic and Gemini
-// emit paths, where a Gemini thoughtSignature smuggled into the id by
-// embedSignatureInID makes the id intentionally longer than 64 bytes. OpenAI's
-// 64-char limit is enforced separately in clampOpenAIToolCallID.
+// sanitizeToolUseID replaces characters Anthropic rejects in tool_use.id
+// (must match ^[a-zA-Z0-9_-]+$). Non-Anthropic upstreams (e.g. Kimi-k2.6) emit
+// IDs with dots/colons that 400 if a session switches back to Anthropic.
+// Length is not clamped: this is shared with the Gemini emit path, where
+// embedSignatureInID intentionally pushes ids past 64 bytes; OpenAI's 64-char
+// limit is enforced separately in clampOpenAIToolCallID.
 func sanitizeToolUseID(id string) string {
 	if id == "" {
 		return id

--- a/internal/translate/emit_openai.go
+++ b/internal/translate/emit_openai.go
@@ -15,17 +15,13 @@ import (
 	"github.com/tidwall/sjson"
 )
 
-// maxToolCallIDLen is OpenAI's limit on a tool-call id — tool_calls[].id on
-// Chat Completions and call_id on Responses; both reject longer ids with a 400
-// ("string too long").
+// maxToolCallIDLen is OpenAI's limit on a tool-call id (tool_calls[].id,
+// call_id) — longer ids get a 400 ("string too long").
 const maxToolCallIDLen = 64
 
-// clampOpenAIToolCallID makes a tool-call id safe for the OpenAI wire format.
-// Any Gemini thoughtSignature smuggled into the id (embedSignatureInID) is
-// dropped first — OpenAI cannot use it, and the bare id is usually within the
-// limit. An id still over 64 chars is replaced with a deterministic hash of the
-// original id, so a tool_use block and its matching tool_result (same original
-// id) map to the same value and stay paired.
+// clampOpenAIToolCallID makes a tool-call id safe for the OpenAI wire format:
+// strips any smuggled Gemini thoughtSignature, then hashes ids still over 64
+// chars so a tool_use block and its tool_result stay paired on the same id.
 func clampOpenAIToolCallID(id string) string {
 	if id == "" {
 		return id
@@ -69,41 +65,24 @@ func (e *RequestEnvelope) PrepareOpenAI(in http.Header, opts EmitOptions) (provi
 }
 
 // applySessionAffinity attaches an upstream-specific prompt-cache routing hint
-// derived from opts.SessionAffinity (a stable per-conversation identifier).
-// Serverless upstreams fan a session's turns across replicas and hold the
-// prefix KV-cache per replica; without a stickiness hint, a turn can land on a
-// cold replica and pay a full prefill (the deepseek-v4-pro/Fireworks incident:
-// 60k-token turn, zero cache read, 26s TTFT). Each upstream exposes a different
-// knob:
-//   - Serverless OpenAI-compat (Fireworks / DeepInfra / Makora / Together / …):
-//     x-session-affinity request header (the default for OpenAI-compat)
-//   - OpenRouter: x-session-id request header (its sticky-routing key, ≤256 chars)
-//   - OpenAI: prompt_cache_key body field
+// from opts.SessionAffinity. Serverless upstreams fan a session across
+// replicas and hold prefix KV-cache per replica; without a stickiness hint a
+// turn can land on a cold replica and pay a full prefill (the
+// deepseek-v4-pro/Fireworks incident: 60k-token turn, zero cache read, 26s
+// TTFT). Each upstream takes a different knob: OpenAI-compat serverless
+// (Fireworks/DeepInfra/Makora/Together/…) gets x-session-affinity (the
+// default for any OpenAI-compat target, so new upstreams need no edit here),
+// OpenRouter gets x-session-id, OpenAI gets the prompt_cache_key body field.
+// Bedrock's explicit cachePoint caching is centrally routed, so it gets nothing.
 //
-// The serverless-affinity *headers* (OpenAI-compat default / OpenRouter) are gated
-// on a real session key: collapsing every keyless request onto one synthetic
-// affinity bucket would herd unrelated conversations onto a single replica,
-// which is worse than letting them load-balance. OpenAI's prompt_cache_key is
-// different — it is a soft cache-routing hint, not a hard replica pin, so it is
-// always set on OpenAI-format cross-format routes (extended beyond the
-// session-affinity-only case): with a session key we use it directly; otherwise
-// we fall back to a stable hash of the request's cacheable prefix (system +
-// tools) — but only when the caller hasn't supplied its own prompt_cache_key
-// (which we preserve) and the request actually has a cacheable prefix (a
-// prefix-less request stays unhinted rather than collapsing onto one synthetic
-// key). Without prompt_cache_key, an Anthropic→OpenAI route carries no cache
-// hint at all and re-bills the full stable prefix every turn (NULL cache_read
-// in prod across all cross-format OpenAI traffic). OpenAI's automatic prompt
-// caching covers prompts >1024 tokens regardless, and the explicit key only
-// raises the hit rate.
-//
-// Bedrock (explicit cachePoint caching, centrally routed — no replica roulette)
-// and any non-OpenAI-compat target get nothing. The x-session-affinity header
-// branch is the DEFAULT for OpenAI-compat providers rather than an enumerated
-// list, so a newly-added serverless OpenAI-compat upstream (Makora, Together, …)
-// gets replica stickiness without editing this switch. OpenRouter and OpenAI are
-// special-cased above it because they expose a different knob (x-session-id and
-// the prompt_cache_key body field, respectively).
+// The header-based hints are gated on a real session key — collapsing keyless
+// requests onto one synthetic bucket would herd unrelated conversations onto
+// a single replica. OpenAI's prompt_cache_key is a soft hint rather than a
+// hard pin, so it's always set on OpenAI-format cross-format routes: a
+// session key is used directly, otherwise we fall back to a hash of the
+// cacheable prefix (system + tools), preserving any caller-supplied key and
+// leaving prefix-less requests unhinted. Without this, an Anthropic→OpenAI
+// route re-bills the full prefix every turn (NULL cache_read in prod).
 func applySessionAffinity(body []byte, headers http.Header, opts EmitOptions) ([]byte, error) {
 	switch opts.TargetProvider {
 	case providers.ProviderOpenRouter:
@@ -119,10 +98,8 @@ func applySessionAffinity(body []byte, headers http.Header, opts EmitOptions) ([
 			if gjson.GetBytes(body, "prompt_cache_key").Exists() {
 				return body, nil
 			}
-			// Fall back to a prefix hash only when there's an actual cacheable
-			// prefix (system and/or tools). With neither, hashing the empty
-			// prefix would collapse every keyless, prefix-less conversation
-			// onto one synthetic key, so leave such requests unhinted.
+			// Only hash if there's an actual prefix; hashing nothing would
+			// collapse every keyless conversation onto one synthetic key.
 			cacheKey = stablePromptCacheKey(body)
 			if cacheKey == "" {
 				return body, nil
@@ -137,27 +114,19 @@ func applySessionAffinity(body []byte, headers http.Header, opts EmitOptions) ([
 		// Explicit cachePoint caching, centrally routed — no replica roulette.
 		return body, nil
 	}
-	// Every other OpenAI-compat serverless upstream (Fireworks, DeepInfra,
-	// Makora, Together, …) exposes the x-session-affinity replica-stickiness
-	// header. Gated on a real session key: collapsing keyless requests onto one
-	// synthetic bucket would herd unrelated conversations onto a single replica.
+	// Other OpenAI-compat serverless upstreams get x-session-affinity, gated
+	// on a real session key (see doc comment above).
 	if providers.IsOpenAICompat(opts.TargetProvider) && opts.SessionAffinity != "" {
 		headers.Set("x-session-affinity", opts.SessionAffinity)
 	}
 	return body, nil
 }
 
-// stablePromptCacheKey derives a deterministic OpenAI prompt_cache_key from the
-// request's cacheable prefix — the system message(s) and tool definitions,
-// which are stable across the turns of a conversation while user/assistant
-// turns grow. Used as a fallback when no session key is available (e.g. the
-// handover summarizer, or requests with no derivable session) so the OpenAI
-// route still carries a consistent cache hint instead of none.
-//
-// Returns "" when the request has no cacheable prefix at all (no system
-// content and no non-empty tools array). Hashing an empty prefix would yield one constant key
-// shared by every prefix-less conversation, herding unrelated keyless requests
-// onto a single synthetic cache bucket; such requests are better left unhinted.
+// stablePromptCacheKey hashes the request's cacheable prefix (system message
+// + tool definitions) into a deterministic prompt_cache_key, used as a
+// fallback when no session key is available. Returns "" when there's no
+// cacheable prefix, so prefix-less requests stay unhinted rather than all
+// hashing to the same synthetic key.
 func stablePromptCacheKey(body []byte) string {
 	h := sha1.New()
 	var hasPrefix bool
@@ -171,11 +140,8 @@ func stablePromptCacheKey(body []byte) string {
 		return true
 	})
 	h.Write([]byte{0x00})
-	// An empty tools array ("tools":[]) is not a cacheable prefix —
-	// gjson's .Exists() is true for it and .Raw is "[]" (non-empty), so
-	// gate on a non-empty array to avoid herding unrelated keyless,
-	// prefix-less requests (common with same-format OpenAI bodies that keep
-	// "tools":[]) onto one synthetic key.
+	// An empty "tools":[] still has .Exists()==true, so gate on non-empty
+	// to avoid treating it as a cacheable prefix.
 	if hasNonEmptyTools(body) {
 		h.Write([]byte(gjson.GetBytes(body, "tools").Raw))
 		hasPrefix = true
@@ -231,13 +197,10 @@ func (e *RequestEnvelope) buildOpenAIFromOpenAI(opts EmitOptions) ([]byte, error
 	return body, nil
 }
 
-// targetIsOpenRouter reports whether the emit target is the OpenRouter
-// upstream. OpenRouter-specific body fields (`provider`, `reasoning`),
-// system reminders, and tool-turn temperature overrides only belong on
-// the OpenRouter wire; direct upstreams (Fireworks/DeepInfra/Bedrock)
-// reject them. Empty TargetProvider falls back to the model-slug match
-// so the historical single-binding behavior keeps working for callers
-// that haven't been plumbed through yet (the handover summarizer).
+// targetIsOpenRouter reports whether the emit target is OpenRouter — direct
+// upstreams (Fireworks/DeepInfra/Bedrock) reject OpenRouter-only fields like
+// `provider`/`reasoning`. Empty TargetProvider falls back to the model-slug
+// match for callers not yet plumbed through (the handover summarizer).
 func targetIsOpenRouter(opts EmitOptions) bool {
 	if opts.TargetProvider != "" {
 		return opts.TargetProvider == providers.ProviderOpenRouter
@@ -340,24 +303,14 @@ func (e *RequestEnvelope) buildOpenAIFromAnthropic(opts EmitOptions) ([]byte, pr
 	return body, stats, nil
 }
 
-// applyGLM51FlagsIfNeeded sets the request-body knobs GLM-5.1 needs to behave
-// correctly on tool-heavy turns. Two knobs, both gated on isGLM51:
-//
-//  1. tool_stream=true — opt-in flag per Z.AI docs that switches GLM-5.1 from
-//     "emit tool envelope, send args as one late chunk (or never)" to proper
-//     incremental argument streaming. Without it, GLM-5.1 reproduces the
-//     GLM-5 empty-input loop documented in
-//     docs/investigations/2026-05-26-glm5-empty-tool-loop.md.
-//
-//  2. chat_template_kwargs.enable_thinking=false — DeepInfra serves GLM-5.1
-//     on vLLM, which honors the Jinja template kwarg to disable thinking
-//     mode. Default is on; we don't want reasoning blocks leaking into the
-//     response stream. OpenRouter routes the same disable through its native
-//     reasoning={enabled:false} hint (see openRouterReasoningHint), so the
-//     chat_template_kwargs path only fires for non-OpenRouter targets.
-//
-// Both knobs respect client-set values so a caller forcing thinking-on or
-// tool_stream-off still wins.
+// applyGLM51FlagsIfNeeded sets two GLM-5.1 knobs, both gated on isGLM51 and
+// both leaving client-set values alone:
+//   - tool_stream=true — without it GLM-5.1 reproduces the GLM-5 empty-input
+//     loop (docs/investigations/2026-05-26-glm5-empty-tool-loop.md).
+//   - chat_template_kwargs.enable_thinking=false — disables vLLM/DeepInfra's
+//     default-on thinking mode so reasoning doesn't leak into the response
+//     stream. Skipped for OpenRouter, which disables thinking via its own
+//     reasoning={enabled:false} hint instead.
 func applyGLM51FlagsIfNeeded(body []byte, opts EmitOptions) ([]byte, error) {
 	if !isGLM51(opts.TargetModel) {
 		return body, nil
@@ -379,12 +332,10 @@ func applyGLM51FlagsIfNeeded(body []byte, opts EmitOptions) ([]byte, error) {
 	return body, nil
 }
 
-// applyQwen3SamplersIfNeeded layers the Qwen3 model-card sampling defaults onto
-// the outbound body when the target is a qwen3-family model and the client did
-// not set them. Applied across all OpenAI-compat providers (OpenRouter, Bedrock,
-// DeepInfra, Fireworks) — the recommendation is model-keyed, not provider-keyed,
-// and Qwen3 only routes to OpenAI-compat backends so unknown-field rejection
-// (e.g. OpenAI native strict mode) is not in scope.
+// applyQwen3SamplersIfNeeded layers the Qwen3 model-card sampling defaults
+// onto the body for qwen3-family models, unless the client already set them.
+// The recommendation is model-keyed, not provider-keyed, so it's applied
+// across all OpenAI-compat providers.
 func applyQwen3SamplersIfNeeded(body []byte, model string) ([]byte, error) {
 	if !isQwen3Family(model) {
 		return body, nil
@@ -807,22 +758,12 @@ func writeOpenAIMaxTokensFromAnthropic(jw *jsonWriter, body []byte, opts EmitOpt
 }
 
 // inlineSchemaDefs replaces "$ref" pointers to "#/$defs/<name>" or
-// "#/definitions/<name>" with a deep copy of the referenced definition, then
-// strips the defs maps from the schema. Some OpenAI-compatible upstreams
-// (notably Fireworks) do not dereference $ref themselves and return a 400
-// ("Error resolving schema reference '#/$defs/X': AttributeError('NoneType'
-// object has no attribute 'lookup')") on tool schemas that use $defs. Inlining
-// before forwarding keeps the schema self-contained so it works on every
-// OpenAI-compat backend regardless of how its validator handles $ref.
-//
-// A $ref with sibling keys (e.g. {"$ref": "#/$defs/X", "description": "..."},
-// emitted by Pydantic v2 / OpenAPI 3.1 / many MCP servers including Intuit
-// QuickBooks) is resolved the same way: per JSON Schema Draft 7, siblings to
-// $ref are ignored, so dropping them on substitution is spec-compliant and
-// keeps the upstream from seeing an unresolvable ref after $defs is stripped.
-//
-// Cyclic refs are left intact (no infinite recursion); unresolvable refs are
-// left intact so the upstream can surface its own clearer error.
+// "#/definitions/<name>" with a deep copy of the referenced definition and
+// strips the defs maps. Some upstreams (notably Fireworks) don't dereference
+// $ref themselves and 400 on tool schemas that use $defs, so inlining keeps
+// the schema self-contained. Sibling keys on a $ref (common from Pydantic
+// v2/OpenAPI 3.1/MCP servers) are dropped on substitution — per JSON Schema
+// Draft 7 they're ignored anyway. Cyclic and unresolvable refs are left intact.
 func inlineSchemaDefs(node any) any {
 	root, ok := node.(map[string]any)
 	if !ok {

--- a/internal/translate/emit_openai_responses.go
+++ b/internal/translate/emit_openai_responses.go
@@ -14,16 +14,12 @@ import (
 )
 
 // PrepareOpenAIResponses builds an OpenAI Responses API (`POST /v1/responses`)
-// request from an Anthropic Messages envelope. Reasoning-capable OpenAI models
-// (gpt-5.x) reject `reasoning_effort` + tools on `/v1/chat/completions`, so an
-// agentic Anthropic client (Claude Code) that wants the model to reason must go
-// through the Responses API instead. The upstream call streams (`stream:true`):
-// a non-streaming Responses call buffers the entire reasoning+output before
-// emitting any response headers, which for gpt-5.x at high effort routinely
-// exceeds the transport's response-header timeout and fails the turn with
-// "http2: timeout awaiting response headers". Streaming returns headers + the
-// first event immediately; ResponsesToAnthropicWriter translates the event
-// stream into Anthropic SSE on the fly.
+// request from an Anthropic Messages envelope. Reasoning gpt-5.x models reject
+// `reasoning_effort` + tools on /v1/chat/completions, so agentic clients must
+// use Responses instead. We always stream: a non-streaming Responses call
+// buffers all reasoning+output before headers, which at high effort routinely
+// exceeds the header timeout ("http2: timeout awaiting response headers").
+
 func (e *RequestEnvelope) PrepareOpenAIResponses(in http.Header, opts EmitOptions) (providers.PreparedRequest, error) {
 	if e.format != FormatAnthropic {
 		return providers.PreparedRequest{}, fmt.Errorf("PrepareOpenAIResponses: only Anthropic ingress is supported, got format %d", e.format)
@@ -36,10 +32,8 @@ func (e *RequestEnvelope) PrepareOpenAIResponses(in http.Header, opts EmitOption
 }
 
 // ResponseTranslator is the common surface the proxy's cross-format OpenAI
-// dispatch drives: an http.ResponseWriter the provider writes the upstream
-// response into, plus the Prelude/Finalize/Summary lifecycle. Both
-// AnthropicSSETranslator (chat/completions) and ResponsesToAnthropicWriter
-// (Responses API) implement it, so the dispatch closure can pick either.
+// dispatch drives. AnthropicSSETranslator (chat/completions) and
+// ResponsesToAnthropicWriter (Responses API) both implement it.
 type ResponseTranslator interface {
 	http.ResponseWriter
 	Prelude(streaming bool) error
@@ -61,18 +55,16 @@ func (e *RequestEnvelope) ReasoningRequested() bool {
 
 // UseOpenAIResponsesAPI reports whether an Anthropic ingress dispatch to the
 // direct OpenAI provider should use POST /v1/responses instead of
-// /v1/chat/completions. Reasoning OpenAI models (gpt-5.x) reject tools,
-// stop, and reasoning_effort on chat/completions, so any agentic turn with
-// tools must go through the Responses API.
+// /v1/chat/completions: reasoning gpt-5.x models reject tools/stop/
+// reasoning_effort on chat/completions.
 func UseOpenAIResponsesAPI(provider string, caps router.ModelSpec, hasTools bool) bool {
 	return provider == providers.ProviderOpenAI &&
 		caps.Supports(router.CapReasoning) &&
 		hasTools
 }
 
-// reasoningEffortFromAnthropic resolves the Responses `reasoning.effort` from an
-// Anthropic body: the `thinking` budget (Claude Code) via effortForBudget, or an
-// explicit `reasoning_effort` if an OpenAI-format field rode along. "" = none.
+// reasoningEffortFromAnthropic resolves the Responses `reasoning.effort` from
+// the `thinking` budget or an explicit `reasoning_effort` field. "" = none.
 func reasoningEffortFromAnthropic(body []byte) string {
 	if t := gjson.GetBytes(body, "thinking"); t.Exists() && t.Get("type").String() != "disabled" {
 		return effortForBudget(t.Get("budget_tokens").Int())
@@ -83,12 +75,9 @@ func reasoningEffortFromAnthropic(body []byte) string {
 	return ""
 }
 
-// responsesReasoningEffort applies model-specific effort policy on top of the
-// budget-derived effort. gpt-5.x has a measured "medium" dead-zone on hard
-// agentic coding (SWE-bench Pro: low 16%, medium 0%, high 41% ≈ opus) — medium
-// is strictly dominated by both neighbors, so never serve it to a gpt-5.x
-// reasoning model; promote to high. Small budgets still resolve to low via
-// effortForBudget, so easy traffic is untouched. Other models pass through.
+// responsesReasoningEffort promotes "medium" to "high" for gpt-5.x: measured
+// SWE-bench Pro scores (low 16%, medium 0%, high 41%) show medium is strictly
+// dominated, so never serve it to a gpt-5.x reasoning model.
 func responsesReasoningEffort(eff, model string) string {
 	if eff == "medium" && strings.HasPrefix(model, "gpt-5") {
 		return "high"
@@ -110,10 +99,8 @@ func (e *RequestEnvelope) buildResponsesFromAnthropic(opts EmitOptions) ([]byte,
 	jw.Str(opts.TargetModel)
 	jw.Key("stream")
 	jw.Bool(true)
-	// Stateless: we send the full history each turn and don't rely on
-	// server-side state. Prior OpenAI reasoning items are round-tripped through
-	// signed Anthropic thinking blocks and replayed below when the client echoes
-	// them back.
+	// Stateless: prior reasoning items round-trip through signed Anthropic
+	// thinking blocks and are replayed below when the client echoes them back.
 	jw.Key("store")
 	jw.Bool(false)
 
@@ -161,10 +148,8 @@ func (e *RequestEnvelope) buildResponsesFromAnthropic(opts EmitOptions) ([]byte,
 	return jw.Bytes(), stats, nil
 }
 
-// writeResponsesInputFromAnthropic emits the `input` array: Anthropic messages
-// become Responses input items — user/assistant text as typed messages,
-// signed OpenAI thinking as reasoning, tool_use as function_call, tool_result as
-// function_call_output.
+// writeResponsesInputFromAnthropic converts Anthropic messages into Responses
+// input items (text messages, reasoning, function_call, function_call_output).
 func writeResponsesInputFromAnthropic(jw *jsonWriter, body []byte) {
 	jw.Key("input")
 	jw.Arr()
@@ -206,9 +191,8 @@ func writeResponsesInputFromAnthropic(jw *jsonWriter, body []byte) {
 					writeResponsesTextMessage(jw, role, joinNonEmpty(textParts))
 					textParts = nil
 				}
-				// Replay the reasoning item carried on the tool id (the
-				// Claude Code round-trip drops the thinking block but keeps the
-				// tool_use id) when it wasn't already emitted from a thinking block.
+				// Claude Code's round-trip drops the thinking block but keeps
+				// the tool_use id, so replay the reasoning item carried on it.
 				if sig != "" {
 					if _, emitted := emittedReasoningSignatures[sig]; !emitted && emitResponsesReasoningItem(jw, sig) {
 						emittedReasoningSignatures[sig] = struct{}{}
@@ -327,18 +311,15 @@ func flattenAnthropicToolResultContent(content gjson.Result) string {
 	}
 }
 
-// writeResponsesToolsFromAnthropic emits the Responses flat function-tool shape
-// (`{type:"function", name, description, parameters}` — no nested wrapper).
+// writeResponsesToolsFromAnthropic emits the Responses flat function-tool
+// shape (`{type:"function", name, description, parameters}`, no wrapper).
 //
-// Each tool whose schema survives strictifyOpenAISchema is emitted with
-// `strict:true` + the strictified parameters, turning on grammar-constrained
-// decoding so gpt-5.x cannot emit out-of-schema arguments at all (the
-// prevention layer in front of toolcheck's detect/repair). Tools whose
-// schemas can't be faithfully strictified fall back to non-strict emission of
-// the original schema — never fail the request over strictness. Note the
-// proxy-side validator (toolcheck) still checks against the ORIGINAL schema:
-// strict mode makes optionals nullable, and the explicit nulls gpt-5.x then
-// emits are dropped by toolcheck's normalize pass before reaching the client.
+// Tools whose schema survives strictifyOpenAISchema get `strict:true`, which
+// turns on grammar-constrained decoding so gpt-5.x can't emit out-of-schema
+// args. Schemas that can't be strictified fall back to non-strict emission
+// rather than failing the request. toolcheck still validates against the
+// ORIGINAL schema downstream — strict mode's nullable optionals produce
+// explicit nulls that toolcheck's normalize pass strips before the client sees them.
 func writeResponsesToolsFromAnthropic(jw *jsonWriter, body []byte) {
 	tools := gjson.GetBytes(body, "tools")
 	if !tools.Exists() || !tools.IsArray() || tools.Get("#").Int() == 0 {

--- a/internal/translate/force_model.go
+++ b/internal/translate/force_model.go
@@ -8,17 +8,13 @@ import (
 	"github.com/tidwall/sjson"
 )
 
-// ReasonUserForceModel is the decision_reason stored in the session pin when a
-// user has forced a specific model via /force-model. The turn loop treats this
-// as an immutable sticky: scorer and planner are bypassed for the session's
-// lifetime until /unforce-model clears it.
+// ReasonUserForceModel marks a session pin from /force-model. It's an
+// immutable sticky: scorer/planner are bypassed until /unforce-model clears it.
 const ReasonUserForceModel = "user_forced"
 
-// ReasonLoopEscalation is the decision_reason stored in the session pin when the
-// router detects a cyclic tool-call loop on a cheap/mid model and escalates the
-// session to opus. The turn loop treats it as an immutable sticky (same as
-// ReasonUserForceModel) so the rescued session stays on the strong model for the
-// rest of its life rather than re-routing back into the loop.
+// ReasonLoopEscalation marks a session pin created when the router detects a
+// tool-call loop and escalates to opus. Immutable sticky like
+// ReasonUserForceModel, so the session doesn't re-route back into the loop.
 const ReasonLoopEscalation = "loop_escalation"
 
 // ForceModelResult holds the parsed outcome of a force-model command.
@@ -30,9 +26,8 @@ type ForceModelResult struct {
 }
 
 // ExtractForceModelCommand scans the last user-role message in env for a
-// /force-model <model> or /unforce-model directive. When found, it strips the
-// command line from env.body and returns the parsed result.
-// Returns (zero, false) when no command is present.
+// /force-model <model> or /unforce-model directive, stripping it from
+// env.body. Returns (zero, false) when no command is present.
 func (env *RequestEnvelope) ExtractForceModelCommand() (ForceModelResult, bool) {
 	var res ForceModelResult
 	found := env.extractLeadingCommand(func(text string) (bool, string) {
@@ -45,11 +40,10 @@ func (env *RequestEnvelope) ExtractForceModelCommand() (ForceModelResult, bool) 
 	return res, found
 }
 
-// extractLeadingCommand scans the last user-role message for a router
-// directive recognized by parse, which receives each candidate text and
-// returns (found, strippedText). On a match the matched content (string body
-// or text block) is replaced in env.body with the stripped remainder. Only
-// Anthropic / OpenAI message shapes are scanned.
+// extractLeadingCommand scans the last user-role message (Anthropic/OpenAI
+// shapes only) for a directive recognized by parse, which receives candidate
+// text and returns (found, strippedText). On a match, the matched content is
+// replaced in env.body with the stripped remainder.
 func (env *RequestEnvelope) extractLeadingCommand(parse func(text string) (found bool, stripped string)) bool {
 	switch env.format {
 	case FormatAnthropic, FormatOpenAI:
@@ -88,11 +82,9 @@ func (env *RequestEnvelope) extractLeadingCommand(parse func(text string) (found
 		return true
 
 	case lastContent.Type == gjson.JSON && lastContent.IsArray():
-		// Scan every text block in order. Claude Code clients sometimes split
-		// the user turn into multiple text parts (one carrying injected
-		// <command-name>/<command-args> tags, another carrying the typed
-		// directive), so inspecting only the first block silently lets
-		// the directive fall through to upstream routing.
+		// Scan every text block: Claude Code sometimes splits the user turn
+		// into multiple parts (injected tags in one, typed directive in
+		// another), so checking only the first block could miss it.
 		type textBlock struct {
 			idx  int
 			text string
@@ -124,18 +116,15 @@ func (env *RequestEnvelope) extractLeadingCommand(parse func(text string) (found
 
 // parseForceModelCommand scans text for a /force-model (alias /fm) or
 // /unforce-model (alias /ufm) directive on the first non-empty line.
-// Restricting to the leading line is a deliberate guard: pasted content
-// (snippets, transcripts) frequently contains strings starting with "/" that
-// would otherwise silently rewrite session routing without explicit user
-// intent. The short aliases exist for clients without local slash-command
-// expansion (pi, opencode, raw API callers) — Claude Code and Codex installs
-// ship alias .md files that expand to the canonical form client-side, so the
-// router-side aliases are the fallback path, not the primary one.
+// Restricted to the leading line so pasted content (snippets, transcripts)
+// starting with "/" can't silently rewrite session routing. The short
+// aliases are a fallback for clients without local slash-command expansion
+// (pi, opencode, raw API); Claude Code/Codex expand to the canonical form
+// client-side.
 //
-// Complete leading <tag>...</tag> blocks (Claude Code injects <system-reminder>,
-// <command-name>, <local-command-stdout>, etc. ahead of the user's typed text)
-// are skipped before the leading-line check is applied. Skipped blocks are
-// preserved in the stripped output so downstream prompt context is intact.
+// Leading <tag>...</tag> blocks (e.g. <system-reminder>, <command-name>
+// injected by Claude Code) are skipped before the leading-line check, and
+// preserved in the stripped output.
 func parseForceModelCommand(text string) (res ForceModelResult, found bool, stripped string) {
 	prefixEnd := leadingInjectedPrefixEnd(text)
 	prefix := text[:prefixEnd]
@@ -192,11 +181,10 @@ func cutAnyPrefix(text string, prefixes ...string) (after string, ok bool) {
 	return text, false
 }
 
-// leadingInjectedPrefixEnd returns the byte offset in text after any leading
-// whitespace and complete <tag>...</tag> blocks. Only simple tag names (letters,
-// digits, '-', '_') with no attributes are recognized so that arbitrary pasted
-// XML/HTML — which may contain a stray /force-model line — does not satisfy the
-// guard. Unclosed or attribute-bearing tags terminate the prefix scan.
+// leadingInjectedPrefixEnd returns the byte offset after leading whitespace
+// and complete <tag>...</tag> blocks. Only simple attribute-free tag names are
+// recognized, so pasted XML/HTML containing a stray /force-model line can't
+// satisfy the guard; unclosed or attribute-bearing tags stop the scan.
 func leadingInjectedPrefixEnd(text string) int {
 	i := 0
 	for i < len(text) {

--- a/internal/translate/gemini_test.go
+++ b/internal/translate/gemini_test.go
@@ -61,9 +61,8 @@ func TestPrepareGemini_MultipleSystemMessagesConcatenated(t *testing.T) {
 }
 
 func TestPrepareGemini_AssistantToolCallsRoundTripsThoughtSignature(t *testing.T) {
-	// Load-bearing test: thought_signature on a prior assistant tool_call must
-	// land as thoughtSignature on the Gemini functionCall part. This is the
-	// whole reason the native adapter exists.
+	// Load-bearing: thought_signature on a prior assistant tool_call must land
+	// as thoughtSignature on the Gemini functionCall part.
 	body := []byte(`{
 		"messages": [
 			{"role": "user", "content": "list /tmp"},
@@ -163,8 +162,8 @@ func TestPrepareGemini_ReasoningEffortMapsToThinkingBudget(t *testing.T) {
 }
 
 func TestPrepareGemini_ReasoningEffortMapsToThinkingLevel_Gemini3x(t *testing.T) {
-	// OpenAI-format ingress (reasoning_effort) → gemini-3.x: string thinkingLevel,
-	// no legacy thinkingBudget. "none" is omitted (3.x cannot disable thinking).
+	// gemini-3.x uses string thinkingLevel, not thinkingBudget. "none" is
+	// omitted — 3.x can't disable thinking.
 	for _, effort := range []string{"low", "medium", "high"} {
 		body := []byte(`{"messages":[{"role":"user","content":"x"}],"reasoning_effort":"` + effort + `"}`)
 		env, _ := translate.ParseOpenAI(body)
@@ -313,8 +312,7 @@ func TestGeminiToOpenAIResponse_TextOnly(t *testing.T) {
 }
 
 func TestGeminiToOpenAIResponse_ToolCallPreservesThoughtSignature(t *testing.T) {
-	// Load-bearing: the response-side signature is smuggled into the tool-call
-	// id (the single SDK-safe carrier), not emitted as an off-spec field.
+	// Signature is smuggled into the tool-call id, not emitted as an off-spec field.
 	body := []byte(`{
 		"candidates":[{"content":{"role":"model","parts":[
 			{"functionCall":{"name":"bash","args":{"command":"ls /tmp"}},
@@ -371,19 +369,16 @@ func TestGeminiToAnthropicResponse_ToolUsePreservesThoughtSignature(t *testing.T
 	assert.Equal(t, "tool_use", tu["type"])
 	assert.NotContains(t, tu, "thought_signature", "off-spec field must not be emitted")
 	assert.Equal(t, "bash", tu["name"])
-	// The id is the sole carrier: a typed string that every client SDK (incl.
-	// Claude Code, which drops unknown content-block fields) round-trips.
+	// The id is a typed string that every client SDK round-trips, incl.
+	// Claude Code, which drops unknown content-block fields.
 	assert.Contains(t, tu["id"].(string), "__thought__")
 }
 
-// TestPrepareGemini_FromAnthropic_ToolUseSignatureSurvivesUnknownFieldStripping
-// is the load-bearing regression test for Gemini 3.x multi-turn tool use
-// when the client (Claude Code) drops the off-spec thought_signature field
-// from a tool_use content block on deserialization. The signature must still
-// be smuggled back to Gemini via the id channel.
+// Load-bearing regression: Gemini 3.x multi-turn tool use when the client
+// drops the off-spec thought_signature field on deserialization — the
+// signature must still be smuggled back via the id channel.
 func TestPrepareGemini_FromAnthropic_ToolUseSignatureSurvivesUnknownFieldStripping(t *testing.T) {
-	// Turn 1: Gemini → Anthropic response embeds the signature into the
-	// synthesized tool_use.id.
+	// Turn 1: embed the signature into the synthesized tool_use.id.
 	geminiResp := []byte(`{
 		"candidates":[{"content":{"role":"model","parts":[
 			{"functionCall":{"name":"bash","args":{"command":"ls"}},
@@ -562,9 +557,8 @@ func must(t *testing.T, m map[string]any, k string) any {
 }
 
 func TestPrepareGemini_StripsJSONSchemaFieldsGoogleRejects(t *testing.T) {
-	// Regression: Claude Code tool definitions include JSON Schema fields
-	// ($schema, additionalProperties, propertyNames) that Google rejects with
-	// 400. Hit production on every tools-bearing Gemini request.
+	// Regression: Claude Code tool defs include JSON Schema fields (`$schema`,
+	// `additionalProperties`, `propertyNames`) Google rejects with 400.
 	body := []byte(`{
 		"messages": [{"role":"user","content":"hi"}],
 		"tools": [{
@@ -621,10 +615,8 @@ func TestPrepareGemini_StripsJSONSchemaFieldsGoogleRejects(t *testing.T) {
 }
 
 func TestPrepareGemini_PrunesDanglingRequired(t *testing.T) {
-	// Regression: Gemini's strict function-calling validator 400s
-	// ("Request contains an invalid argument") when "required" names a
-	// property that isn't in "properties". Well-formed JSON Schema permits
-	// it, so an inbound MCP tool schema can carry one; prune it.
+	// Regression: Gemini 400s when "required" names a property not in
+	// "properties" — valid JSON Schema, so MCP tool schemas can carry it; prune it.
 	body := []byte(`{
 		"messages": [{"role":"user","content":"hi"}],
 		"tools": [{
@@ -663,10 +655,8 @@ func TestPrepareGemini_PrunesDanglingRequired(t *testing.T) {
 }
 
 func TestPrepareGemini_PreservesPropertyNamedRequired(t *testing.T) {
-	// Pruning must run only in schema-node context: inside a "properties"
-	// map the keys are user-defined parameter names, so a parameter literally
-	// named "required" is a property schema, not the "required" keyword, and
-	// must survive untouched (incl. its own nested "required" keyword).
+	// A parameter literally named "required" is a property schema, not the
+	// "required" keyword, and must survive pruning untouched.
 	body := []byte(`{
 		"messages": [{"role":"user","content":"hi"}],
 		"tools": [{
@@ -705,11 +695,9 @@ func TestPrepareGemini_PreservesPropertyNamedRequired(t *testing.T) {
 }
 
 func TestPrepareGemini_StripsVendorExtensionAndDollarPrefixedKeys(t *testing.T) {
-	// Regression: MCP tool schemas derived from Google APIs (and friends)
-	// embed vendor extensions like `x-google-enum-descriptions` at every
-	// nesting level. Gemini's proto validator rejects any unknown field
-	// with 400 "Cannot find field". Strip anything with an "x-" or "$"
-	// prefix instead of maintaining a moving allowlist.
+	// Regression: MCP schemas derived from Google APIs embed vendor extensions
+	// (`x-google-*`) at every level; Gemini 400s on unknown fields. Strip any
+	// "x-" or "$" prefixed key instead of maintaining an allowlist.
 	body := []byte(`{
 		"messages": [{"role":"user","content":"hi"}],
 		"tools": [{
@@ -795,13 +783,10 @@ func TestSanitizeSchemaForGemini_PreservesSupportedFields(t *testing.T) {
 }
 
 func TestPrepareGemini_DropsUnsupportedFormatValues(t *testing.T) {
-	// Regression: Gemini's function-calling Schema accepts "format" only with a
-	// narrow value set (strings: enum, date-time; numbers: float/double/int32/
-	// int64). Tool schemas from MCP servers and SDKs routinely carry "uri",
-	// "email", "uuid" etc., which Google rejects with a generic 400
-	// INVALID_ARGUMENT — observed on every tools-bearing Gemini request from
-	// tool-heavy clients. The sanitizer must drop unsupported format values
-	// while keeping supported ones and the rest of the property schema intact.
+	// Regression: Gemini's Schema only accepts a narrow "format" set (strings:
+	// enum, date-time; numbers: float/double/int32/int64). MCP schemas routinely
+	// carry "uri"/"email"/"uuid" etc., which Gemini 400s on; drop unsupported
+	// values but keep the rest of the property schema intact.
 	body := []byte(`{
 		"messages": [{"role":"user","content":"hi"}],
 		"tools": [{
@@ -837,9 +822,8 @@ func TestPrepareGemini_DropsUnsupportedFormatValues(t *testing.T) {
 }
 
 func TestPrepareGemini_CollapsesItemsBool(t *testing.T) {
-	// Regression: MCP tool schemas (e.g. SigNoz) use `"items": true` (JSON Schema:
-	// any items allowed). Gemini's proto Schema.items is optional Schema and
-	// rejects boolean values with "Invalid value at ... (Schema), true".
+	// Regression: MCP schemas (e.g. SigNoz) use `"items": true` (JSON Schema:
+	// any items allowed); Gemini's proto Schema.items rejects boolean values.
 	body := []byte(`{
 		"messages": [{"role":"user","content":"hi"}],
 		"tools": [{
@@ -887,10 +871,8 @@ func TestPrepareGemini_CollapsesItemsBool(t *testing.T) {
 }
 
 func TestPrepareGemini_CollapsesArrayTypeField(t *testing.T) {
-	// Regression: MCP tool schemas (e.g. Pylon) use JSON Schema array-typed
-	// "type" like ["array","null"]. Gemini's proto Schema expects type to be a
-	// single enum value with a separate "nullable" boolean. Without collapsing,
-	// Gemini rejects with "Proto field is not repeating, cannot start list."
+	// Regression: MCP schemas (e.g. Pylon) use array-typed "type" like
+	// ["array","null"]; Gemini expects a single type plus a "nullable" bool.
 	body := []byte(`{
 		"messages": [{"role":"user","content":"hi"}],
 		"tools": [{
@@ -931,11 +913,8 @@ func TestPrepareGemini_CollapsesArrayTypeField(t *testing.T) {
 }
 
 func TestPrepareGemini_RepairsArrayMissingItems(t *testing.T) {
-	// Regression: production Claude Code traffic includes MCP tools whose schemas
-	// declare `{"type":"array"}` with no `items` field (valid JSON Schema, invalid
-	// Gemini function-call schema). Gemini rejected the whole request with
-	// "GenerateContentRequest.tools[0].function_declarations[N].parameters.
-	// properties[X].items: missing field". Inject a permissive default instead.
+	// Regression: MCP tools declare `{"type":"array"}` with no `items` field
+	// (valid JSON Schema, invalid for Gemini); inject a permissive default.
 	body := []byte(`{
 		"messages": [{"role":"user","content":"hi"}],
 		"tools": [{
@@ -975,10 +954,9 @@ func TestPrepareGemini_RepairsArrayMissingItems(t *testing.T) {
 }
 
 func TestPrepareGemini_DropsEmptyStringEnumEntries(t *testing.T) {
-	// Regression: MCP tool schemas occasionally include `""` as an enum value
-	// (e.g. an "operator" field that allows "no filter"). Gemini rejects with
-	// "function_declarations[N].parameters.properties[X].enum[0]: cannot be
-	// empty". Drop empty strings; drop the enum entirely when nothing remains.
+	// Regression: MCP schemas sometimes include `""` as an enum value (e.g. an
+	// "operator" allowing "no filter"), which Gemini rejects; drop empty
+	// strings, and the enum entirely if nothing remains.
 	body := []byte(`{
 		"messages": [{"role":"user","content":"hi"}],
 		"tools": [{

--- a/internal/translate/loop_detection.go
+++ b/internal/translate/loop_detection.go
@@ -16,12 +16,10 @@ type ToolCallSig struct {
 	InputHash string
 }
 
-// AssistantToolCallArgsPreview returns short string previews of the raw
-// argument JSON for each assistant tool call, in order, starting at offset.
-// Used by the proxy's loop detector to log what was actually in the window
-// when a loop trips, so a real loop (5 identical args) can be told apart
-// from a false positive (5 distinct args sharing a canonicalize hash) at a
-// glance in the logs. Names are included so multi-tool windows are readable.
+// AssistantToolCallArgsPreview returns short previews of the raw argument
+// JSON for each assistant tool call, in order, starting at offset. Used to
+// log the window when a loop trips, so real loops (identical args) can be
+// told apart from false positives (distinct args, colliding hash).
 func (e *RequestEnvelope) AssistantToolCallArgsPreview(offset, maxLen int) []string {
 	switch e.format {
 	case FormatAnthropic:
@@ -121,17 +119,12 @@ func openAIAssistantToolCallArgsPreview(body []byte, offset, maxLen int) []strin
 	return out
 }
 
-// AssistantToolCallSignatures returns the ordered list of tool invocations
-// emitted by assistant messages in the request body. Order matches message
-// order, and within a message, content-block order.
-//
-// Used by the proxy's loop detector to identify runaway tool-call cycles. An
-// OSS model (notably qwen3 variants) that fails to recognize when a task is
-// complete will alternate or repeat the same tool calls indefinitely; counting
-// signature occurrences in a recent window catches both patterns.
-//
-// Returns nil for Gemini-format requests (not currently supported) and for
-// requests with no assistant tool calls.
+// AssistantToolCallSignatures returns the ordered list of tool invocations in
+// the request body (message order, then content-block order). Used by the
+// loop detector: some OSS models (notably qwen3) fail to recognize task
+// completion and alternate/repeat calls indefinitely, which counting
+// signature occurrences in a recent window catches. Returns nil for
+// Gemini-format requests (unsupported) or no assistant tool calls.
 func (e *RequestEnvelope) AssistantToolCallSignatures() []ToolCallSig {
 	switch e.format {
 	case FormatAnthropic:
@@ -151,11 +144,10 @@ func anthropicAssistantToolCallSigs(body []byte) []ToolCallSig {
 	var sigs []ToolCallSig
 	msgs.ForEach(func(_, msg gjson.Result) bool {
 		role := msg.Get("role").String()
-		// A genuine user-typed prompt breaks the loop: the human has
-		// intervened, so the calls before it are no longer part of any
-		// runaway cycle. userPromptTextGJSON returns "" for tool_result-only
-		// turns and for Claude Code's injected <system-reminder> /
-		// <command-*> wrapper blocks, so a normal tool round does NOT reset.
+		// A genuine user-typed prompt breaks the loop (human intervened).
+		// userPromptTextGJSON returns "" for tool_result-only turns and
+		// Claude Code's injected wrapper blocks, so normal tool rounds
+		// don't reset the window.
 		if role == "user" && userPromptTextGJSON(msg.Get("content")) != "" {
 			sigs = nil
 			return true
@@ -175,13 +167,10 @@ func anthropicAssistantToolCallSigs(body []byte) []ToolCallSig {
 			if name == "" {
 				return true
 			}
-			// Skip entries with empty input. Cross-format translation of a
-			// stream-incomplete tool call (OpenAI/openaicompat upstream →
-			// Anthropic inbound) can emit `input:{}` to satisfy the schema.
-			// Claude Code echoes those back in the assistant history; with no
-			// real args every empty-input call collides to the same hash and
-			// 5 of them in a window false-positive trip the loop detector.
-			// Real tool calls always carry at least one argument.
+			// Skip empty input: cross-format translation of a stream-incomplete
+			// tool call can emit `input:{}`, and Claude Code echoes those back,
+			// so several would collide to the same hash and false-positive trip
+			// the loop detector. Real tool calls always carry an argument.
 			input := block.Get("input")
 			if !isMeaningfulInput(input) {
 				return true
@@ -223,10 +212,9 @@ func openAIAssistantToolCallSigs(body []byte) []ToolCallSig {
 			if name == "" {
 				return true
 			}
-			// OpenAI delivers arguments as a JSON-encoded string. Skip
-			// empty/object-empty values for the same reason the Anthropic
-			// path does — stream-incomplete tool_calls produce hash
-			// collisions that aren't real loops.
+			// Skip empty/object-empty args (JSON-encoded string here) for the
+			// same reason as the Anthropic path: stream-incomplete tool_calls
+			// produce hash collisions that aren't real loops.
 			argsRaw := tc.Get("function.arguments").String()
 			if !isMeaningfulInputRaw(argsRaw) {
 				return true
@@ -239,10 +227,9 @@ func openAIAssistantToolCallSigs(body []byte) []ToolCallSig {
 	return sigs
 }
 
-// isMeaningfulInput reports whether a tool_use input field carries any real
-// arguments. Missing, null, empty-string, and empty-object inputs are
-// rejected — they're artifacts of stream-incomplete tool calls bouncing
-// through cross-format translation, not real model invocations.
+// isMeaningfulInput reports whether a tool_use input carries real arguments.
+// Missing, null, empty-string, and empty-object inputs are artifacts of
+// stream-incomplete tool calls, not real model invocations.
 func isMeaningfulInput(r gjson.Result) bool {
 	if !r.Exists() {
 		return false
@@ -278,11 +265,9 @@ func isMeaningfulInputRaw(raw string) bool {
 	return !empty
 }
 
-// hashCanonicalJSON returns a stable hex sha256 of the canonical form of a
-// JSON document. Whitespace and key order are normalized via gjson's parsed
-// representation so equivalent JSON values produce identical hashes. Invalid
-// JSON is hashed verbatim — same-string inputs still collide, which is the
-// property the loop detector relies on.
+// hashCanonicalJSON returns a stable hex sha256 of a JSON document with
+// whitespace/key-order normalized, so equivalent values hash identically.
+// Invalid JSON is hashed verbatim; same-string inputs still collide.
 func hashCanonicalJSON(raw string) string {
 	if raw == "" {
 		h := sha256.Sum256(nil)

--- a/internal/translate/responses_to_anthropic_writer_stream_test.go
+++ b/internal/translate/responses_to_anthropic_writer_stream_test.go
@@ -30,10 +30,8 @@ func firstSignatureDelta(t *testing.T, body string) string {
 	return ""
 }
 
-// responsesStreamFixture is a representative OpenAI Responses streaming SSE
-// sequence: a reasoning summary, an output_text message, and one function_call
-// whose arguments arrive split across two deltas, terminated by
-// response.completed carrying usage + status.
+// responsesStreamFixture: reasoning summary + output_text message + one
+// function_call with args split across two deltas, then response.completed.
 const responsesStreamFixture = `event: response.created
 data: {"type":"response.created","response":{"id":"resp_abc","status":"in_progress","model":"gpt-5.5","output":[]}}
 
@@ -78,9 +76,8 @@ data: {"type":"response.completed","response":{"id":"resp_abc","status":"complet
 
 `
 
-// A streaming client gets the Responses event stream translated to Anthropic SSE
-// incrementally: thinking → text → tool_use blocks in order, then a
-// message_delta carrying stop_reason=tool_use and the upstream usage.
+// Streaming: thinking → text → tool_use blocks in order, then message_delta
+// with stop_reason=tool_use and upstream usage.
 func TestResponsesToAnthropicWriter_StreamingClient(t *testing.T) {
 	rec := httptest.NewRecorder()
 	w := translate.NewResponsesToAnthropicWriter(rec, "gpt-5.5", nil)
@@ -140,10 +137,8 @@ func TestResponsesToAnthropicWriter_StreamingClient(t *testing.T) {
 	assert.Contains(t, body, `"content_block_start","index":2`)
 }
 
-// message_start ids must be unique per response. Clients (notably ccusage)
-// dedupe usage records by message id, so the old constant "msg_responses" id
-// collapsed every turn of a session into one record and massively undercounted
-// tokens/cost. The "msg_responses_" prefix is kept as a route marker.
+// message_start ids must be unique per response: clients (e.g. ccusage)
+// dedupe usage by message id, so a constant id undercounted tokens/cost.
 func TestResponsesToAnthropicWriter_MessageStartIDUniquePerResponse(t *testing.T) {
 	startID := func() string {
 		rec := httptest.NewRecorder()
@@ -173,8 +168,7 @@ func TestResponsesToAnthropicWriter_MessageStartIDUniquePerResponse(t *testing.T
 	assert.NotEqual(t, first, second, "message ids must differ across responses")
 }
 
-// A non-streaming client gets a one-shot Anthropic JSON body reconstructed from
-// the terminal response.completed event in the (still-streamed) upstream.
+// Non-streaming: one-shot Anthropic JSON reconstructed from response.completed.
 func TestResponsesToAnthropicWriter_NonStreamingClient(t *testing.T) {
 	rec := httptest.NewRecorder()
 	w := translate.NewResponsesToAnthropicWriter(rec, "gpt-5.5", nil)
@@ -221,9 +215,7 @@ data: {"type":"response.completed","response":{"id":"r","status":"completed","mo
 	assert.Equal(t, 800, got.CacheReadTokens)
 }
 
-// A function_call that streams no argument deltas still delivers its real
-// arguments: the translator falls back to the authoritative item.arguments on
-// the terminal output_item.done rather than emitting {}.
+// No delta events: falls back to item.arguments on output_item.done, not {}.
 func TestResponsesToAnthropicWriter_ToolArgsFromDoneEvent(t *testing.T) {
 	const fixture = `event: response.output_item.added
 data: {"type":"response.output_item.added","output_index":0,"item":{"id":"fc_1","type":"function_call","call_id":"call_a","name":"Read","arguments":"","status":"in_progress"}}
@@ -267,11 +259,9 @@ func writeToolValidator(t *testing.T) *toolcheck.Validator {
 	return v
 }
 
-// gpt-5.x reasoning models emit optional string params (e.g. Read.pages) as ""
-// rather than omitting them, which fails the client's tool validation and loops
-// the model. With the tool's schema validator installed, the writer strips the
-// empty optional arg so the client receives a valid call; the required file_path
-// is preserved.
+// gpt-5.x emits optional string params (e.g. Read.pages) as "" instead of
+// omitting them, which fails client tool validation. With a schema validator
+// installed, the writer strips the empty optional arg.
 func TestResponsesToAnthropicWriter_StripsEmptyOptionalArg(t *testing.T) {
 	const fixture = `event: response.output_item.added
 data: {"type":"response.output_item.added","output_index":0,"item":{"id":"fc_1","type":"function_call","call_id":"call_a","name":"Read","arguments":"","status":"in_progress"}}
@@ -398,9 +388,8 @@ data: {"type":"response.output_item.done","output_index":0,"item":{"id":"fc_1","
 		"schema for a different tool must not authorize stripping this tool's args")
 }
 
-// A stream truncated before response.completed still reconciles to
-// stop_reason=tool_use (a tool block was emitted) and flushes the partial
-// tool args, rather than defaulting to end_turn with a dropped input_json_delta.
+// Truncated before response.completed: still reconciles to stop_reason=tool_use
+// and flushes the partial tool args.
 func TestResponsesToAnthropicWriter_TruncatedToolStream(t *testing.T) {
 	const fixture = `event: response.output_item.added
 data: {"type":"response.output_item.added","output_index":0,"item":{"id":"fc_1","type":"function_call","call_id":"call_a","name":"Bash","arguments":"","status":"in_progress"}}
@@ -427,9 +416,8 @@ data: {"type":"response.function_call_arguments.delta","item_id":"fc_1","output_
 	assert.Contains(t, body, "event: message_stop")
 }
 
-// An upstream that delivers a reasoning summary and message text only on
-// output_item.done (no *.delta events) still produces visible thinking + text
-// blocks on the streaming path, rather than an empty assistant turn.
+// Content delivered only on output_item.done (no *.delta) still produces
+// visible thinking + text blocks.
 func TestResponsesToAnthropicWriter_DoneOnlyContent(t *testing.T) {
 	const fixture = `event: response.output_item.added
 data: {"type":"response.output_item.added","output_index":0,"item":{"id":"rs_1","type":"reasoning","encrypted_content":"enc_stream","summary":[],"status":"in_progress"}}
@@ -462,9 +450,8 @@ data: {"type":"response.completed","response":{"id":"r","status":"completed","ou
 	assert.Contains(t, body, `"stop_reason":"end_turn"`)
 }
 
-// A function_call with no name is dropped (never opened as a tool_use block),
-// so the client can't be sent on an invoke-"" loop; the turn demotes to
-// end_turn since no tool_use block survives.
+// A function_call with no name is dropped, never opened as a tool_use block;
+// the turn demotes to end_turn.
 func TestResponsesToAnthropicWriter_NamelessToolDropped(t *testing.T) {
 	const fixture = `event: response.output_item.added
 data: {"type":"response.output_item.added","output_index":0,"item":{"id":"fc_x","type":"function_call","call_id":"call_x","name":"","arguments":"","status":"in_progress"}}
@@ -493,9 +480,8 @@ data: {"type":"response.completed","response":{"id":"r","status":"completed","ou
 	assert.Contains(t, body, "event: message_stop")
 }
 
-// On the non-streaming path, an upstream stream that ends without a terminal
-// response event but carries an `error` event yields a real Anthropic error
-// envelope — not an empty 502 from feeding raw SSE to the JSON error mapper.
+// Non-streaming: an `error` event with no terminal response event still
+// yields a real Anthropic error envelope, not an empty 502.
 func TestResponsesToAnthropicWriter_NonStreamingErrorFromStream(t *testing.T) {
 	const fixture = `event: error
 data: {"type":"error","code":"server_error","message":"upstream exploded"}
@@ -587,9 +573,8 @@ data: {"type":"response.completed","response":{"id":"r","status":"completed","ou
 	assert.Contains(t, body, `"stop_reason":"tool_use"`)
 }
 
-// A non-streaming client also gets an error envelope (not empty success JSON)
-// when the buffered stream ends in response.failed — symmetric with the
-// streaming path's event: error.
+// Non-streaming also gets an error envelope, not empty success JSON, when
+// the buffered stream ends in response.failed.
 func TestResponsesToAnthropicWriter_NonStreamingFailedResponse(t *testing.T) {
 	const fixture = `event: response.failed
 data: {"type":"response.failed","response":{"id":"r","status":"failed","error":{"code":"server_error","message":"boom"},"output":[]}}
@@ -610,9 +595,8 @@ data: {"type":"response.failed","response":{"id":"r","status":"failed","error":{
 	assert.Contains(t, e["message"], "boom")
 }
 
-// A response.incomplete terminal carrying an error object is a failure
-// (finalizeBuffered rejects it) and its error text must survive the buffer
-// scan — not fall through to the generic no-terminal message.
+// response.incomplete with an error object is a failure; its error text
+// must survive the buffer scan.
 func TestResponsesToAnthropicWriter_NonStreamingIncompleteWithError(t *testing.T) {
 	const fixture = `event: response.incomplete
 data: {"type":"response.incomplete","response":{"id":"r","status":"incomplete","error":{"code":"server_error","message":"ran out of juice"},"output":[]}}

--- a/internal/translate/spiral_signals.go
+++ b/internal/translate/spiral_signals.go
@@ -6,24 +6,17 @@ import (
 	"github.com/tidwall/gjson"
 )
 
-// Spiral-signal extraction: cheap, per-request scans of the message history
-// that feed the proxy's shadow-mode spiral detector (see
-// internal/proxy/spiral_detection.go). Like the loop-detection extractors in
-// this package, everything here is a pure function of the request body — the
-// full history arrives on every turn, so no cross-turn state is needed.
+// Spiral-signal extraction: cheap per-request scans of message history feeding
+// the proxy's shadow-mode spiral detector (internal/proxy/spiral_detection.go).
+// Pure functions of the request body — no cross-turn state needed.
 
-// toolResultErrorScanLimit caps how many bytes of a tool_result's string
-// content are scanned for error markers. Tool results can be hundreds of KB
-// (full test logs); errors announce themselves early.
+// toolResultErrorScanLimit caps bytes of tool_result content scanned for error
+// markers; results can be hundreds of KB but errors show up early.
 const toolResultErrorScanLimit = 2048
 
-// toolResultErrorMarkers are substrings in a tool_result's content that mark
-// the result as errored even when the client did not set is_error. Claude
-// Code sets is_error for tool-level failures (bad Edit old_string, command
-// not found) but a Bash tool call that ran a test suite to a red result is a
-// successful tool call carrying a failure payload — the marker scan catches
-// those. Kept deliberately short and high-precision; the offline trajectory
-// audit graded the combined flag+marker signal at AUC 0.73-0.86.
+// toolResultErrorMarkers catch errored tool_results where is_error wasn't set
+// (e.g. a test suite that ran fine but returned red). Kept short/high-precision;
+// offline audit graded the combined flag+marker signal at AUC 0.73-0.86.
 var toolResultErrorMarkers = []string{
 	"Traceback (most recent call last)",
 	"FAILED",
@@ -31,10 +24,9 @@ var toolResultErrorMarkers = []string{
 	"error:",
 }
 
-// ToolResultErrorStats summarizes tool_result error evidence in the message
-// history. TrailingErrStreak counts consecutive errored results from the end
-// of the history backwards — the "agent keeps trying things that fail" shape;
-// one healthy result resets it.
+// ToolResultErrorStats summarizes tool_result error evidence. TrailingErrStreak
+// counts consecutive errored results from the end of history; one healthy
+// result resets it.
 type ToolResultErrorStats struct {
 	Total             int
 	Errored           int
@@ -42,10 +34,8 @@ type ToolResultErrorStats struct {
 }
 
 // ToolResultErrors scans user-role tool_result blocks (Anthropic format) for
-// error evidence: the is_error flag, or a high-precision error marker within
-// the first toolResultErrorScanLimit bytes of string content. Returns zero
-// stats for non-Anthropic formats — OpenAI tool-role messages carry no error
-// flag and the Claude Code traffic this detector targets is Anthropic-format.
+// error evidence: the is_error flag, or an error marker in the first
+// toolResultErrorScanLimit bytes. Returns zero stats for non-Anthropic formats.
 func (e *RequestEnvelope) ToolResultErrors() ToolResultErrorStats {
 	if e.format != FormatAnthropic {
 		return ToolResultErrorStats{}
@@ -81,10 +71,8 @@ func (e *RequestEnvelope) ToolResultErrors() ToolResultErrorStats {
 	return stats
 }
 
-// toolResultIsErrored reports whether a single tool_result block carries
-// error evidence: the is_error flag, or an error marker early in its string
-// content. Content can be a plain string or an array of text blocks; only
-// the first toolResultErrorScanLimit bytes are scanned either way.
+// toolResultIsErrored checks the is_error flag or an early error marker.
+// Content may be a plain string or an array of text blocks.
 func toolResultIsErrored(block gjson.Result) bool {
 	if block.Get("is_error").Bool() {
 		return true
@@ -124,10 +112,9 @@ type ToolCallFilePath struct {
 	Path string
 }
 
-// AssistantToolCallFilePaths returns, in message order, every assistant
-// tool_use invocation that carries a file_path or notebook_path argument.
-// The proxy's spiral detector counts repeat edits to the same path (the
-// same-file-thrash death-march shape). Anthropic format only.
+// AssistantToolCallFilePaths returns, in order, every assistant tool_use call
+// carrying a file_path or notebook_path arg. Used to detect same-file-thrash.
+// Anthropic format only.
 func (e *RequestEnvelope) AssistantToolCallFilePaths() []ToolCallFilePath {
 	if e.format != FormatAnthropic {
 		return nil
@@ -168,12 +155,10 @@ func (e *RequestEnvelope) AssistantToolCallFilePaths() []ToolCallFilePath {
 	return out
 }
 
-// TrailingAssistantMonologue counts consecutive assistant messages at the
-// tail of the history that carry no tool_use block. The walk stops at the first
-// assistant message WITH a tool call (including router-synthesized nudges) or
-// the first user message carrying non-tool_result content — i.e. it measures
-// "assistant turns since the last real progress or real user input", the
-// OpenHands monologue shape.
+// TrailingAssistantMonologue counts consecutive tool-less assistant messages
+// at the tail of history — "turns since the last real progress or user input"
+// (the OpenHands monologue shape). Stops at an assistant tool call (including
+// router-synthesized nudges) or a user message with non-tool_result content.
 func (e *RequestEnvelope) TrailingAssistantMonologue() int {
 	if e.format != FormatAnthropic {
 		return 0
@@ -201,9 +186,8 @@ func (e *RequestEnvelope) TrailingAssistantMonologue() int {
 	return streak
 }
 
-// assistantHasRealToolUse reports whether an assistant message carries at
-// least one tool_use block. Router-synthesized nudges now count as tool
-// activity since they are included in loop detection.
+// assistantHasRealToolUse reports whether msg carries a tool_use block.
+// Router-synthesized nudges count as tool activity too.
 func assistantHasRealToolUse(msg gjson.Result) bool {
 	content := msg.Get("content")
 	if !content.IsArray() {
@@ -220,9 +204,8 @@ func assistantHasRealToolUse(msg gjson.Result) bool {
 	return has
 }
 
-// userHasNonToolResultContent reports whether a user message carries real
-// user input (anything other than tool_result blocks). A plain-string user
-// message is always real input.
+// userHasNonToolResultContent reports whether msg carries real user input
+// (anything besides tool_result blocks).
 func userHasNonToolResultContent(msg gjson.Result) bool {
 	content := msg.Get("content")
 	if content.Type == gjson.String {

--- a/internal/translate/toolcheck/toolcheck.go
+++ b/internal/translate/toolcheck/toolcheck.go
@@ -1,22 +1,16 @@
 // Package toolcheck validates model-emitted tool_use blocks against the
-// tool JSON Schemas carried on the inbound Anthropic request
-// (tools[].input_schema), and deterministically repairs the failure modes
-// that are safe to fix without changing the call's meaning.
+// tools[].input_schema on the inbound request and deterministically repairs
+// safe failure modes, replacing prior per-failure patches (#284, #293,
+// #327/#333, #339) with one layered pipeline:
 //
-// It replaces the accreted per-failure patches (#284 nudge, #293 degenerate
-// demote, #327/#333 tool-id fixes, #339 empty-optional strip) with one
-// layered pipeline:
+//  1. normalize — drop empty-string/null OPTIONAL params (gpt-5.x Responses
+//     failure mode; required params untouched)
+//  2. parse     — minimal repair for malformed argument JSON
+//  3. validate  — Draft-7 validation against the original schema
+//  4. repair    — validation-error-driven safe coercions, re-validated
 //
-//  1. normalize  — drop empty-string / null OPTIONAL params (the gpt-5.x
-//     Responses failure mode; required params are never touched)
-//  2. parse      — minimal JSON repair for truncated/malformed argument JSON
-//  3. validate   — Draft-7 schema validation against the ORIGINAL schema
-//  4. repair     — validation-error-driven safe coercions, re-validated
-//
-// Everything is fail-open: a schema that won't compile, a panic in the
-// validator, or a nil *Validator must never break a request — the block is
-// forwarded as-is and the failure is only reported via the returned Issue
-// so the proxy can log it (router.tool_call_invalid).
+// Fail-open throughout: an uncompilable schema, validator panic, or nil
+// *Validator forwards the block as-is and reports via the returned Issue.
 package toolcheck
 
 import (
@@ -56,9 +50,8 @@ const maxDetailBytes = 300
 // compiled and the tool is treated as uncheckable.
 const maxSchemaBytes = 256 * 1024
 
-// maxArgsBytes bounds how much argument JSON the repair pipeline will touch.
-// Larger payloads (e.g. a Write call carrying a huge file) are validated but
-// never run through jsonfix.
+// maxArgsBytes bounds how much argument JSON the repair pipeline touches;
+// larger payloads (e.g. a huge Write) are validated but not repaired.
 const maxArgsBytes = 4 * 1024 * 1024
 
 // Issue describes one offending tool_use block. It is carried on the
@@ -78,13 +71,11 @@ type Issue struct {
 
 // Verdict is the outcome of checking one tool_use block.
 type Verdict struct {
-	// OK is true when the block was valid exactly as the model emitted it
-	// (normalize-only cleanups do not clear OK=true; they preserve the #339
-	// silent-strip semantics).
+	// OK is true when the block was valid as emitted; normalize-only
+	// cleanups do not clear it (preserves #339 silent-strip semantics).
 	OK bool
-	// Args is the argument JSON to forward: repaired when repair succeeded,
-	// otherwise the normalized original. "{}" is the last resort for
-	// unparseable JSON only — never for a schema mismatch.
+	// Args is the JSON to forward: repaired on success, else the normalized
+	// original. "{}" is the last resort for unparseable JSON only.
 	Args string
 	// Issue is nil when OK.
 	Issue *Issue
@@ -102,15 +93,14 @@ type toolSchema struct {
 
 // Validator holds compiled schemas for one request's tool set. A nil
 // *Validator is valid and checks nothing. Safe for concurrent use after
-// Compile (compiled schemas and sets are read-only).
+// Compile — schemas and sets are read-only.
 type Validator struct {
 	tools map[string]*toolSchema
 }
 
-// Compile parses an Anthropic `tools` array (the raw JSON of the request's
-// "tools" field) into a Validator. It never returns an error: any per-tool
-// compile failure marks that tool uncheckable and is logged once at WARN.
-// Returns nil when toolsRaw carries no usable tools.
+// Compile parses an Anthropic `tools` array into a Validator. It never
+// returns an error: a per-tool compile failure marks that tool uncheckable
+// (logged at WARN). Returns nil when toolsRaw carries no usable tools.
 func Compile(toolsRaw []byte) *Validator {
 	parsed := gjson.ParseBytes(toolsRaw)
 	if !parsed.IsArray() {
@@ -139,8 +129,8 @@ func Compile(toolsRaw []byte) *Validator {
 }
 
 // compileSchema compiles one tool's input_schema, returning nil (uncheckable)
-// on any failure or panic. Anthropic input_schemas rarely declare $schema, so
-// Draft-7 is the default dialect.
+// on failure or panic. Draft-7 is the default dialect since Anthropic
+// input_schemas rarely declare $schema.
 func compileSchema(name string, schema gjson.Result) (compiled *jsonschema.Schema) {
 	if !schema.IsObject() || len(schema.Raw) > maxSchemaBytes {
 		return nil
@@ -181,11 +171,9 @@ func (v *Validator) KnownTool(name string) bool {
 	return ok
 }
 
-// Check validates argsJSON for the named tool, attempting deterministic
-// repair on failure and re-validating the result. A nil receiver still runs
-// the parse tier — malformed JSON is invalid regardless of schema, and the
-// translators previously syntax-checked unconditionally — but skips the
-// schema-aware tiers.
+// Check validates argsJSON for the named tool, repairing on failure and
+// re-validating. A nil receiver still runs the parse tier (malformed JSON
+// is invalid regardless of schema) but skips the schema-aware tiers.
 func (v *Validator) Check(name, argsJSON string) Verdict {
 	// Models commonly emit no argument payload for zero-param tools.
 	if strings.TrimSpace(argsJSON) == "" {
@@ -195,9 +183,8 @@ func (v *Validator) Check(name, argsJSON string) Verdict {
 	args := argsJSON
 	var actions []string
 
-	// Parse tier: unparseable JSON gets one minimal-repair attempt; if that
-	// fails too, "{}" is the last resort (the pre-existing translator
-	// behavior — now bucketed and reported instead of silent).
+	// Unparseable JSON gets one minimal-repair attempt; "{}" is the last
+	// resort (matches prior translator behavior, now reported not silent).
 	if !gjson.Valid(args) {
 		fixed, fixActions := repairJSON(args)
 		actions = append(actions, fixActions...)
@@ -222,9 +209,8 @@ func (v *Validator) Check(name, argsJSON string) Verdict {
 
 	ts, known := v.tools[name]
 	if !known {
-		// The name is typically already committed to the wire when this runs
-		// (streaming emits it at content_block_start), so unknown_tool is
-		// telemetry-only: forward and report.
+		// Streaming already emits the name at content_block_start, so
+		// unknown_tool is telemetry-only: forward and report.
 		return Verdict{
 			Args: args,
 			Issue: &Issue{
@@ -237,9 +223,8 @@ func (v *Validator) Check(name, argsJSON string) Verdict {
 		}
 	}
 
-	// Normalize tier: runs even when the args are schema-valid, because the
-	// client's own tool validation is stricter than JSON Schema (e.g. Read
-	// rejects pages:"" which a {type:string} schema accepts).
+	// Runs even when schema-valid: the client's own tool validation is
+	// stricter than JSON Schema (e.g. Read rejects pages:"" that {type:string} accepts).
 	args, normActions := normalizeArgs(args, ts.required)
 	actions = append(actions, normActions...)
 
@@ -254,9 +239,8 @@ func (v *Validator) Check(name, argsJSON string) Verdict {
 		return verdictAfterValidation(name, args, jsonRepaired, actions, nil)
 	}
 
-	// Repair tier: drive safe coercions off the validation errors, then
-	// re-validate. On failure forward the normalized ORIGINAL args — a
-	// half-repaired payload is worse than the model's own.
+	// Drive safe coercions off the validation errors, then re-validate. On
+	// failure forward the normalized original — half-repaired is worse.
 	repaired, repairActions := repairArgs(ts.compiled, args, verr)
 	if len(repairActions) > 0 {
 		if rerr := validate(ts.compiled, repaired); rerr == nil {
@@ -285,8 +269,7 @@ func (v *Validator) Check(name, argsJSON string) Verdict {
 }
 
 // verdictAfterValidation builds the verdict for args that pass (or skip)
-// schema validation: clean unless an earlier JSON repair already made this
-// block report-worthy.
+// validation: clean unless an earlier JSON repair made it report-worthy.
 func verdictAfterValidation(name, args string, jsonRepaired bool, actions []string, _ error) Verdict {
 	if !jsonRepaired {
 		return Verdict{OK: true, Args: args}
@@ -304,8 +287,8 @@ func verdictAfterValidation(name, args string, jsonRepaired bool, actions []stri
 }
 
 // validate runs the compiled schema over args, recovering from validator
-// panics (fail-open). The instance is decoded with jsonschema.UnmarshalJSON
-// so large integers don't false-fail float comparisons.
+// panics (fail-open). Decoded via jsonschema.UnmarshalJSON so large
+// integers don't false-fail float comparisons.
 func validate(schema *jsonschema.Schema, args string) (verr error) {
 	defer func() {
 		if r := recover(); r != nil {
@@ -324,10 +307,9 @@ func validate(schema *jsonschema.Schema, args string) (verr error) {
 
 // normalizeArgs drops top-level OPTIONAL params whose value is "" or null.
 // Empty-string optionals are the gpt-5.x /chat-era failure mode (#339);
-// null optionals are the strict-mode artifact (strictified schemas force
-// every param to be present, so the model emits explicit nulls). Required
-// params are never touched: a genuinely-missing required arg must surface
-// its error downstream.
+// null optionals come from strictified schemas that force every param
+// present. Required params are never touched, so a genuinely-missing one
+// still surfaces downstream.
 func normalizeArgs(args string, required map[string]struct{}) (out string, actions []string) {
 	parsed := gjson.Parse(args)
 	if !parsed.IsObject() {


### PR DESCRIPTION
## Summary
- Part 2 of the comment-length cleanup (part 1: #583). Sweeps the next tier of highest-offending files (25 files, ~280 blocks) — same rule as part 1: keep genuinely non-obvious "why" explanations (hidden constraints, bug workarounds, security/precision rationale, prod-incident context), cut restated/narrated filler.
- Comment-only changes, no logic touched. Skipped SQLC-generated files entirely (per repo convention).
- Independent of #583 (disjoint file sets, both branched off main) — can merge in either order.

## Test plan
- [x] `go build ./...` clean
- [x] `gofmt -l .` clean
- [x] `go vet ./...` clean
- [x] `go test ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)