### PR TITLE
fix(ci): skip comment-length review when ANTHROPIC_API_KEY is unset

### DIFF
--- a/.github/workflows/comment_length_review.yml
+++ b/.github/workflows/comment_length_review.yml
@@ -23,6 +23,10 @@ concurrency:
 jobs:
   review:
     runs-on: ubuntu-latest
+    # Skip cleanly (not a failure) until ANTHROPIC_API_KEY is added to this
+    # repo's secrets -- it currently only exists on the main workweave/weave
+    # repo, not here.
+    if: ${{ secrets.ANTHROPIC_API_KEY != '' }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
`ANTHROPIC_API_KEY` isn't configured as a secret on this repo (only `WORKWEAVE_PIN_BUMP_PAT` exists — checked via `gh secret list`), so the new comment-length review workflow from #583 fails on every PR with "Environment variable validation failed". Gate the job on the secret being present so it skips cleanly instead of showing a failing check.

To actually get the reviews running, someone with admin access needs to add `ANTHROPIC_API_KEY` under Settings → Secrets and variables → Actions on `workweave/router`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)