### PR TITLE
chore: shorten verbose comments, part 3 (next 30 files)

### DIFF
--- a/cmd/routing-report/main.go
+++ b/cmd/routing-report/main.go
@@ -1,20 +1,16 @@
-// Command routing-report renders the register-routing report for a cluster
-// artifact: it routes a labeled probe corpus (testdata/register_probes.jsonl)
-// through the REAL cluster Scorer and reports, per register, which models get
-// chosen — plus an auto-derived label for each cluster (the register mix that
-// lands in it) and a diff vs the currently-deployed `latest` artifact.
+// Command routing-report routes a labeled probe corpus
+// (testdata/register_probes.jsonl) through the REAL cluster Scorer for a
+// given artifact and reports, per register, which models get chosen — plus
+// an auto-derived label per cluster and a diff vs the deployed `latest`
+// artifact. Lets a PR reviewer see where conversational/trivial turns route
+// before shipping a clustering change, instead of finding out post-deploy
+// that everything went to Opus.
 //
-// It exists so a human reviewing a PR that changes the deployed clustering
-// model can SEE where conversational / trivial turns route before it ships,
-// rather than discovering post-deploy that everything went to Opus.
-//
-// No ONNX at runtime: probe embeddings are precomputed and committed
-// (testdata/register_probes.emb), so this builds and runs under
-// `-tags no_onnx`. The Scorer is fed a static embedder that returns the
-// cached vector per probe, so the blend, normalization, and all eligibility
-// filters are the exact production code path. Regenerate the cache with
-// scripts/embed_register_probes.py whenever the corpus or embedder changes; a
-// corpus-hash mismatch fails this tool loudly.
+// Runs under `-tags no_onnx`: probe embeddings are precomputed
+// (testdata/register_probes.emb) and fed to the Scorer via a static
+// embedder, so the blend/normalization/eligibility path is exact production
+// code. Regenerate the cache with scripts/embed_register_probes.py when the
+// corpus or embedder changes — a hash mismatch fails loudly.
 //
 // Usage:
 //
@@ -48,8 +44,7 @@ var registers = []string{
 }
 
 // opusModels and premiumModels classify the deployed pool for the summary
-// percentages. Premium = the four most expensive tiers a chit-chat turn has no
-// business reaching.
+// percentages; premium = tiers a chit-chat turn has no business reaching.
 var opusModels = map[string]struct{}{
 	"claude-opus-4-8": {}, "claude-opus-4-7": {},
 }
@@ -74,14 +69,12 @@ type embHeader struct {
 	Comment      string `json:"comment"`
 }
 
-// maxPromptChars mirrors the Scorer's Config.MaxPromptChars: the Scorer
-// tail-truncates the prompt to this many bytes before calling Embed, so the
-// cache must be keyed by the same truncation.
+// maxPromptChars mirrors Scorer's Config.MaxPromptChars; the cache must be
+// keyed by the same tail-truncation the Scorer applies before Embed.
 const maxPromptChars = 1024
 
-// staticEmbedder satisfies cluster.Embedder from precomputed vectors keyed by
-// the tail-truncated probe text — the exact string the Scorer passes to
-// Embed — so a probe longer than maxPromptChars still resolves.
+// staticEmbedder satisfies cluster.Embedder from vectors keyed by the
+// tail-truncated probe text, matching what the Scorer passes to Embed.
 type staticEmbedder struct {
 	id     string
 	dim    int
@@ -107,9 +100,8 @@ func (s *staticEmbedder) Embed(_ context.Context, text string) ([]float32, error
 func (s *staticEmbedder) ID() string { return s.id }
 func (s *staticEmbedder) Dim() int   { return s.dim }
 
-// tailTruncate keeps the last maxChars bytes of s, advancing off any partial
-// UTF-8 continuation byte. Byte-for-byte identical to the Scorer's helper, so
-// the cache key matches the string the Scorer embeds.
+// tailTruncate keeps the last maxChars bytes of s, skipping any partial UTF-8
+// continuation byte. Must match the Scorer's helper byte-for-byte.
 func tailTruncate(s string, maxChars int) string {
 	if len(s) <= maxChars {
 		return s
@@ -129,9 +121,8 @@ func truncForErr(s string) string {
 }
 
 func main() {
-	// The Scorer warns on every alpha>0.9 cluster, which floods stderr with
-	// ~20 lines per probe under the deployed config. Quiet it unless the
-	// caller asked for more. Must precede the first observability.Get().
+	// Scorer warns on every alpha>0.9 cluster (~20 lines/probe under deployed
+	// config); quiet unless caller overrides. Must precede first observability.Get().
 	if os.Getenv("LOG_LEVEL") == "" {
 		os.Setenv("LOG_LEVEL", "error")
 	}

--- a/internal/feedback/token.go
+++ b/internal/feedback/token.go
@@ -1,12 +1,8 @@
-// Package feedback defines the signed, no-login token that authorizes a single
-// router request's feedback link (`/f/<token>`). The token is the sole
-// credential for the public feedback page: it is minted by the router when a
-// request is routed and verified by the router when the feedback page loads or
-// a rating is submitted. The Weave backend never sees the secret.
-//
-// The package is pure (HMAC + base64 only, no I/O) so it can be shared by the
-// proxy (mint), the API handlers (verify), and the composition root (Signer
-// construction) without violating the layering rules.
+// Package feedback defines the signed, no-login token that authorizes a
+// single router request's feedback link (`/f/<token>`). It's the sole
+// credential for the public feedback page — minted at routing time, verified
+// on page load/rating submit — and the Weave backend never sees the secret.
+// Pure (HMAC + base64, no I/O) so it can be shared across layers.
 package feedback
 
 import (
@@ -28,10 +24,9 @@ var ErrInvalidToken = errors.New("feedback: invalid token")
 // expiry has passed. Handlers map this to HTTP 410 (the link is stale).
 var ErrExpiredToken = errors.New("feedback: expired token")
 
-// Claims is the verified payload carried by a feedback-link token. All fields
-// are opaque to this package; the router uses InstallationID + RequestID to
-// look up routing context and ExternalID + RouterUserID to attribute the
-// emitted router.feedback span to a Weave organization and user.
+// Claims is the verified payload of a feedback-link token. InstallationID +
+// RequestID look up routing context; ExternalID + RouterUserID attribute the
+// emitted router.feedback span to a Weave org and user.
 type Claims struct {
 	InstallationID string `json:"iid"`
 	ExternalID     string `json:"eid"`
@@ -43,18 +38,17 @@ type Claims struct {
 
 // Signer mints and verifies feedback-link tokens with a single HMAC-SHA256
 // secret. A nil *Signer means the feature is disabled: Mint returns "" and
-// Verify returns ErrInvalidToken, so callers can treat "no signer" and "bad
-// token" identically. Safe for concurrent use.
+// Verify returns ErrInvalidToken, so "no signer" and "bad token" are
+// indistinguishable to callers. Safe for concurrent use.
 type Signer struct {
 	secret []byte
 	ttl    time.Duration
 	now    func() time.Time
 }
 
-// NewSigner returns a Signer over the given secret with the given link TTL.
-// Returns nil when secret is empty so the composition root can leave the
-// feature unwired without a sentinel. A non-positive ttl mints tokens that
-// never expire.
+// NewSigner returns a Signer over the given secret and link TTL. Returns nil
+// when secret is empty, letting the composition root leave the feature
+// unwired without a sentinel. Non-positive ttl mints tokens that never expire.
 func NewSigner(secret string, ttl time.Duration) *Signer {
 	if secret == "" {
 		return nil
@@ -62,9 +56,9 @@ func NewSigner(secret string, ttl time.Duration) *Signer {
 	return &Signer{secret: []byte(secret), ttl: ttl, now: time.Now}
 }
 
-// Mint returns a signed, URL-safe token encoding the claims for one request.
-// The expiry is computed from the Signer's TTL at mint time. Nil receiver
-// returns "" so disabled deployments simply omit the feedback link.
+// Mint returns a signed, URL-safe token encoding the claims for one request,
+// with expiry computed from the Signer's TTL. Nil receiver returns "" so
+// disabled deployments simply omit the feedback link.
 func (s *Signer) Mint(installationID, externalID, requestID, routerUserID string) string {
 	if s == nil {
 		return ""
@@ -82,9 +76,8 @@ func (s *Signer) Mint(installationID, externalID, requestID, routerUserID string
 	}
 	payload, err := json.Marshal(claims)
 	if err != nil {
-		// Claims is a fixed struct of strings/int — marshaling cannot fail in
-		// practice. Returning "" degrades to "no link" rather than panicking
-		// on the request path.
+		// Marshaling a fixed string/int struct can't practically fail; degrade
+		// to "no link" rather than panic on the request path.
 		return ""
 	}
 	body := base64.RawURLEncoding.EncodeToString(payload)

--- a/internal/observability/apm/apm.go
+++ b/internal/observability/apm/apm.go
@@ -1,17 +1,10 @@
 // Package apm wires the OpenTelemetry SDK against an OTLP/gRPC collector so
-// HTTP request spans and Go runtime metrics show up in the shared SigNoz
-// instance at apm.app.workweave.ai alongside the rest of the Weave services.
+// HTTP spans and Go runtime metrics show up in the shared SigNoz instance
+// alongside the rest of Weave's services. It's independent of the router's
+// own custom OTLP/HTTP emitter (internal/observability/otel), which keeps
+// publishing high-cardinality per-decision spans separately.
 //
-// This sits alongside the router's own custom OTLP/HTTP emitter (which keeps
-// emitting the per-decision spans defined in internal/observability/otel).
-// The two pipelines are independent and can both be enabled — the custom
-// emitter publishes high-cardinality routing spans; this package publishes
-// the standard gin HTTP spans + runtime metrics that the rest of Weave's
-// services already publish in the same shape.
-//
-// Enable by setting WV_APM_OTLP_ENDPOINT to the SigNoz OTLP/gRPC host:port.
-// Unset = no-op (same convention as the custom emitter on
-// OTEL_EXPORTER_OTLP_ENDPOINT).
+// Enable via WV_APM_OTLP_ENDPOINT (SigNoz OTLP/gRPC host:port); unset = no-op.
 package apm
 
 import (
@@ -47,12 +40,10 @@ var (
 	meterProvider  *sdkmetric.MeterProvider
 )
 
-// Init wires the OTel SDK against the SigNoz collector. Reads
+// Init wires the OTel SDK against the SigNoz collector using
 // WV_APM_OTLP_ENDPOINT (host:port for OTLP/gRPC). Empty = no-op. Idempotent.
-//
-// Mirrors backend/internal/app/telemetry/otel.go's init() in shape so the
-// router shows up in apm.app.workweave.ai with the same resource attributes
-// as the rest of Weave.
+// Mirrors backend/internal/app/telemetry/otel.go's init() so the router
+// reports the same resource attribute shape as the rest of Weave.
 func Init() {
 	initOnce.Do(initLocked)
 }
@@ -83,12 +74,10 @@ func initLocked() {
 		return
 	}
 
-	// TLS by default. The router runs outside the cluster the SigNoz
-	// collector is on for some deployments, so silently shipping spans over
-	// plaintext gRPC would leak whatever's in attributes (api_key_id, model
-	// names, decision reasons) to anyone on-path. Operators opt into insecure
-	// transport explicitly via WV_APM_OTLP_INSECURE=true when the collector
-	// is reachable only over a trusted internal network.
+	// TLS by default: some deployments run the router outside the SigNoz
+	// collector's cluster, and plaintext gRPC would leak span attributes
+	// (api_key_id, model names, decision reasons) on-path. Opt into insecure
+	// transport explicitly via WV_APM_OTLP_INSECURE=true on trusted networks.
 	insecure := config.GetOr("WV_APM_OTLP_INSECURE", "false") == "true"
 
 	traceExporter, err := newTraceExporter(ctx, endpoint, insecure)
@@ -121,10 +110,8 @@ func initLocked() {
 	)
 	otel.SetMeterProvider(meterProvider)
 
-	// Without this the MeterProvider has no instruments registered against
-	// it and the only metric SigNoz receives is the empty resource heartbeat.
-	// otelruntime.Start hooks runtime/metrics (goroutines, heap, GC pauses,
-	// cgo calls) into the global MeterProvider just set above.
+	// Hooks runtime/metrics (goroutines, heap, GC, cgo calls) into the
+	// MeterProvider just set above — without it SigNoz gets no metrics at all.
 	if err := otelruntime.Start(otelruntime.WithMinimumReadMemStatsInterval(15 * time.Second)); err != nil {
 		log.Warn("APM init: runtime instrumentation failed; SDK traces still active", "err", err)
 	}
@@ -154,10 +141,9 @@ func metricGRPCOpts(endpoint string, insecure bool) []otlpmetricgrpc.Option {
 	return opts
 }
 
-// Middleware returns a gin middleware that wraps each request in an HTTP
-// server span tagged with method/route/status. Routes /health and /validate
-// are excluded — they're polled by infra and would swamp the trace volume.
-// No-op when Init was never called or the SDK is disabled.
+// Middleware wraps each request in an HTTP server span tagged with
+// method/route/status, excluding /health and /validate (infra polling would
+// swamp trace volume). No-op when Init was never called.
 func Middleware() gin.HandlerFunc {
 	return otelgin.Middleware(
 		serviceName,
@@ -169,19 +155,16 @@ func Middleware() gin.HandlerFunc {
 }
 
 // Shutdown flushes the trace + metric pipelines with a 5s default budget.
-// Safe to call multiple times and safe when Init was never called.
-//
-// Most callers should prefer ShutdownWithContext so the parent process can
-// budget the flush against its own SIGTERM window.
+// Safe to call multiple times or when Init was never called. Prefer
+// ShutdownWithContext when the caller has its own SIGTERM budget to enforce.
 func Shutdown() {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 	ShutdownWithContext(ctx)
 }
 
-// ShutdownWithContext flushes the trace + metric pipelines under the caller's
-// deadline. Use this from a process-level shutdown handler that's already
-// budgeting its remaining SIGTERM time across multiple flush stages.
+// ShutdownWithContext flushes the trace + metric pipelines under the
+// caller's deadline.
 func ShutdownWithContext(ctx context.Context) {
 	if tracerProvider != nil {
 		_ = tracerProvider.Shutdown(ctx)

--- a/internal/observability/otel/usage.go
+++ b/internal/observability/otel/usage.go
@@ -9,19 +9,16 @@ import (
 	"workweave/router/internal/sse"
 )
 
-// Local mirrors of the providers.Provider* constants. This package is a leaf
-// utility (must not import internal/providers), so we duplicate the short
-// strings rather than introduce a circular import. Keep in sync with
-// internal/providers/provider.go.
+// Mirrors providers.Provider* constants; duplicated (not imported) to avoid a
+// circular import since this is a leaf package. Keep in sync with internal/providers/provider.go.
 const (
 	providerAnthropic = "anthropic"
 	providerOpenAI    = "openai"
 	providerGoogle    = "google"
 )
 
-// UsageSink receives extracted token usage. Translators call RecordUsage /
-// RecordCacheUsage when they encounter usage data in already-parsed events,
-// eliminating the need for a separate parse pass.
+// UsageSink receives extracted token usage. Translators call it directly when
+// they've already parsed usage from an event, skipping a separate parse pass.
 type UsageSink interface {
 	RecordUsage(inputTokens, outputTokens int)
 	RecordCacheUsage(cacheCreationTokens, cacheReadTokens int)
@@ -33,10 +30,8 @@ var (
 	_ UsageSink           = (*UsageExtractor)(nil)
 )
 
-// UsageExtractor wraps an http.ResponseWriter and sniffs token usage from
-// upstream responses (SSE and JSON) as bytes flow through. Only the unconsumed
-// tail of the most recent Write is retained; complete SSE events are parsed
-// and discarded immediately.
+// UsageExtractor wraps an http.ResponseWriter and sniffs token usage (SSE or
+// JSON) as bytes flow through. Only the unconsumed tail is retained between writes.
 type UsageExtractor struct {
 	inner    http.ResponseWriter
 	provider string
@@ -49,10 +44,9 @@ type UsageExtractor struct {
 	leftover []byte
 }
 
-// NewUsageExtractor creates a usage-extracting writer. Provider determines the
-// response format to parse. When inner is nil the extractor operates in sink-only
-// mode: only RecordUsage and Tokens are valid; the ResponseWriter methods must
-// not be called.
+// NewUsageExtractor creates a usage-extracting writer for the given provider's
+// response format. If inner is nil, only RecordUsage/Tokens are valid — the
+// ResponseWriter methods must not be called.
 func NewUsageExtractor(inner http.ResponseWriter, provider string) *UsageExtractor {
 	return &UsageExtractor{
 		inner:    inner,
@@ -93,13 +87,9 @@ func (u *UsageExtractor) Flush() {
 	}
 }
 
-// ArmOutputProgress forwards the output-progress watchdog mark to the inner
-// writer when it supports it. UsageExtractor sniffs usage but cannot itself tell
-// an output-bearing frame from a keepalive; the wrapped marker writer (or
-// translator) can. Without this forward, wrapping the marker writer in a
-// UsageExtractor would hide ArmOutputProgress from the provider client and leave
-// the OpenAI→openaicompat passthrough byte-idle-guarded only. Returns false when
-// inner is nil (sink-only mode) or doesn't implement the hook.
+// ArmOutputProgress forwards the watchdog arm call to inner if it supports it.
+// UsageExtractor can't itself distinguish an output frame from a keepalive, so
+// this must pass through or wrapping would hide the hook from the provider client.
 func (u *UsageExtractor) ArmOutputProgress(mark func()) (armed bool) {
 	if u.inner == nil {
 		return false
@@ -122,9 +112,8 @@ func (u *UsageExtractor) RecordUsage(inputTokens, outputTokens int) {
 	}
 }
 
-// RecordCacheUsage sets cache token counts directly. OpenAI has no creation
-// concept, so it passes cacheCreationTokens=0 with prompt_tokens_details.cached_tokens
-// as cacheReadTokens.
+// RecordCacheUsage sets cache token counts directly. OpenAI has no cache-creation
+// concept, so callers pass 0 for cacheCreationTokens.
 func (u *UsageExtractor) RecordCacheUsage(cacheCreationTokens, cacheReadTokens int) {
 	if cacheCreationTokens > 0 {
 		u.cacheCreation = cacheCreationTokens
@@ -142,9 +131,8 @@ func (u *UsageExtractor) Tokens() (input, output int) {
 	return u.input, u.output
 }
 
-// CacheTokens returns the extracted cache creation and cache read token counts.
-// Zero values indicate the provider does not emit cache tokens (Google) or the
-// response had no cache hits.
+// CacheTokens returns the extracted cache creation/read counts. Zero means the
+// provider doesn't emit cache tokens (Google) or there were no cache hits.
 func (u *UsageExtractor) CacheTokens() (creation, read int) {
 	if u == nil {
 		return 0, 0
@@ -260,11 +248,10 @@ func (u *UsageExtractor) tryExtractFromJSON() {
 	}
 }
 
-// extractUsageGJSON probes for token usage fields using gjson, avoiding
-// json.Unmarshal and map[string]any allocations entirely. OpenAI has no
-// cache-creation concept (cacheRead maps to prompt_tokens_details.cached_tokens).
-// Google's native :generateContent surface uses usageMetadata with
-// cachedContentTokenCount; the OpenAI-compat surface uses the OpenAI shape.
+// extractUsageGJSON probes usage fields via gjson (no json.Unmarshal/map allocs).
+// OpenAI has no cache-creation field; cacheRead maps from cached_tokens.
+// Google's native :generateContent uses usageMetadata; its OpenAI-compat surface
+// uses the OpenAI shape instead.
 func extractUsageGJSON(data []byte, provider string) (input, output, cacheCreation, cacheRead int, found bool) {
 	if provider == providerGoogle {
 		if meta := gjson.GetBytes(data, "usageMetadata"); meta.Exists() {
@@ -295,10 +282,8 @@ func extractUsageGJSON(data []byte, provider string) (input, output, cacheCreati
 		cacheCreation = int(usage.Get("cache_creation_input_tokens").Int())
 		cacheRead = int(usage.Get("cache_read_input_tokens").Int())
 	case providerOpenAI, providerGoogle:
-		// Chat Completions uses prompt_tokens/completion_tokens; the Responses
-		// API (Codex backend passthrough) uses input_tokens/output_tokens with
-		// input_tokens_details.cached_tokens. Probe both so one extractor serves
-		// both OpenAI surfaces.
+		// Chat Completions uses prompt_tokens/completion_tokens; Responses API
+		// (Codex passthrough) uses input_tokens/output_tokens. Probe both.
 		if pt := usage.Get("prompt_tokens"); pt.Exists() {
 			input = int(pt.Int())
 			output = int(usage.Get("completion_tokens").Int())

--- a/internal/providers/openaicompat/client.go
+++ b/internal/providers/openaicompat/client.go
@@ -24,21 +24,16 @@ import (
 const (
 	DefaultBaseURL   = "https://openrouter.ai/api/v1"
 	FireworksBaseURL = "https://api.fireworks.ai/inference/v1"
-	// DeepInfraBaseURL is DeepInfra's OpenAI-compatible surface. DeepInfra uses
-	// HuggingFace-form model IDs; pair with NewClientWithModelIDMap to rewrite
-	// the router's public slash-form slugs on the wire.
+	// DeepInfraBaseURL uses HuggingFace-form model IDs; pair with
+	// NewClientWithModelIDMap to rewrite the router's slash-form slugs.
 	DeepInfraBaseURL = "https://api.deepinfra.com/v1/openai"
-	// MakoraBaseURL is Makora's OpenAI-compatible surface. Makora is an
-	// agent-optimized inference platform serving DeepSeek V4 (and other OSS
-	// models) at notably higher throughput than the commodity providers; pair
-	// with NewClientWithModelIDMap to rewrite the router's public slash-form
-	// slugs to Makora's upstream IDs on the wire.
+	// MakoraBaseURL serves DeepSeek V4 (and other OSS models) at higher
+	// throughput than commodity providers; pair with NewClientWithModelIDMap
+	// to rewrite slugs to Makora's upstream IDs.
 	MakoraBaseURL = "https://inference.makora.com/v1"
-	// TogetherBaseURL is Together AI's OpenAI-compatible surface. Together
-	// serves the OSS pool (DeepSeek, GLM, MiniMax, Qwen, Kimi, …) and is the
-	// fastest provider on artificialanalysis.ai for several of the models we
-	// route; pair with NewClientWithModelIDMap to rewrite the router's public
-	// slash-form slugs to Together's "Org/Model" upstream IDs on the wire.
+	// TogetherBaseURL serves the OSS pool (DeepSeek, GLM, MiniMax, Qwen, Kimi)
+	// and is fastest on artificialanalysis.ai for several routed models; pair
+	// with NewClientWithModelIDMap to rewrite slugs to Together's "Org/Model" IDs.
 	TogetherBaseURL = "https://api.together.xyz/v1"
 )
 
@@ -60,25 +55,19 @@ type Client struct {
 	apiKey  string
 	baseURL string
 	http    *http.Client
-	// modelIDMap rewrites the request body's "model" field before sending.
-	// Empty map (or nil) = no rewrite. Used when the router's public slash-form
-	// slug differs from the upstream's canonical ID (Bedrock dot-form,
-	// DeepInfra HuggingFace-form).
+	// modelIDMap rewrites the request body's "model" field before sending, when
+	// the router's public slug differs from the upstream's canonical ID
+	// (Bedrock dot-form, DeepInfra HuggingFace-form). Nil/empty = no rewrite.
 	modelIDMap map[string]string
-	// sseIdleTimeout, when > 0, overrides httputil.DefaultSSEIdleTimeout for the
-	// byte-idle watchdog. Production uses the default; tests inject a small value
-	// so the output-stall watchdog can be exercised without the byte-idle one
-	// firing first.
+	// sseIdleTimeout overrides httputil.DefaultSSEIdleTimeout when > 0; tests
+	// set it small so the output-stall watchdog fires before this one.
 	sseIdleTimeout time.Duration
-	// outputStall, when > 0, overrides httputil.DefaultOutputStallTimeout for the
-	// output-progress watchdog. Production uses the default via NewClient; tests
-	// inject a small value to drive the output-stall trip without waiting out the
-	// real budget.
+	// outputStall overrides httputil.DefaultOutputStallTimeout when > 0; used
+	// by tests to trip output-stall without waiting out the real budget.
 	outputStall time.Duration
-	// throughputWindow / throughputMinElapsed / throughputMinDeltas, when > 0
-	// (and >= 0 for the delta count), override the minimum-throughput watchdog
-	// budgets. Production uses the httputil defaults; tests inject small values
-	// to drive a slow-throughput trip without waiting out the real warmup.
+	// throughputWindow/MinElapsed/MinDeltas override the minimum-throughput
+	// watchdog budgets when set; used by tests to trip slow-throughput without
+	// waiting out the real warmup.
 	throughputWindow     time.Duration
 	throughputMinElapsed time.Duration
 	throughputMinDeltas  int
@@ -213,9 +202,8 @@ func (c *Client) Proxy(ctx context.Context, decision router.Decision, prep provi
 	t.StampUpstreamHeaders()
 
 	if resp.StatusCode >= 400 {
-		// Buffer the upstream error response — do NOT touch w. The proxy's
-		// failover loop decides whether to retry on the next binding or
-		// flush this buffer to the client.
+		// Buffer the error — do NOT touch w; the failover loop decides whether
+		// to retry or flush this buffer to the client.
 		bufBody, totalRead, drainErr := readCapped(resp.Body, providers.MaxBufferedErrorBytes)
 		if len(bufBody) > 0 {
 			t.StampUpstreamFirstByte()
@@ -243,27 +231,17 @@ func (c *Client) Proxy(ctx context.Context, decision router.Decision, prep provi
 	providers.CopyUpstreamHeaders(w, resp)
 	w.WriteHeader(resp.StatusCode)
 
-	// Output-progress watchdog. StreamBody's byte-idle watchdog below resets on
-	// ANY upstream byte, so a stream that stays byte-alive with SSE keepalive
-	// comments or empty/role-only delta frames while producing zero output rides
-	// to the 600s request cap (2026-06-19 DeepInfra incident). This second
-	// watchdog measures time-since-last-OUTPUT: its mark is fed by the
-	// OpenAI→Anthropic SSE translator only on output-bearing deltas (text,
-	// reasoning, tool-call args, terminal finish). On trip it cancels ctx with
-	// ErrUpstreamOutputStall (retryable; fails over while the preludeBuffer is
-	// still uncommitted). Only the translator can tell output frames from
-	// keepalives, so it is wired via ArmOutputProgress; a non-streaming client
-	// (or a writer without the hook) returns armed=false and is byte-idle-guarded
-	// only.
-	// A third watchdog runs on the same output-progress mark: the
-	// minimum-throughput guard. The output-stall watchdog above only catches a
-	// stream that stops producing output entirely; it never trips on a clean 200
-	// that keeps dribbling output-bearing deltas (resetting outMark on each one)
-	// but at a crawl. The throughput watchdog measures the COUNT of those deltas
-	// over a rolling window and, once warmup has passed, aborts with
-	// ErrUpstreamSlowThroughput (retryable) when the rate stays below the floor
-	// (2026-06-25 deepseek-v4-flash ~132s dribble). Both are fed by the single
-	// ArmOutputProgress mark, so the installed mark fans out to both.
+	// Output-progress watchdog: StreamBody's byte-idle watchdog resets on ANY
+	// byte, so keepalive/empty-delta frames with zero real output ride to the
+	// request cap (2026-06-19 DeepInfra incident). This one is marked only on
+	// output-bearing deltas by the SSE translator (via ArmOutputProgress) and
+	// trips ErrUpstreamOutputStall (retryable). Non-streaming/no-hook writers
+	// stay byte-idle-guarded only.
+	//
+	// A second watchdog shares the same mark: minimum-throughput. It catches a
+	// clean 200 that keeps dribbling output at a crawl (2026-06-25
+	// deepseek-v4-flash ~132s dribble) by counting deltas over a rolling window
+	// and tripping ErrUpstreamSlowThroughput once warmup passes.
 	if arm, ok := w.(providers.OutputProgressArmer); ok {
 		outMark, outStop := httputil.StartIdleWatchdogCause(ctx, cancel, c.outputStallTimeout(), httputil.ErrUpstreamOutputStall)
 		tpWindow, tpMinElapsed, tpMinDeltas := c.throughputParams()
@@ -288,12 +266,9 @@ func (c *Client) Proxy(ctx context.Context, decision router.Decision, prep provi
 	return streamErr
 }
 
-// logStreamStall reports a watchdog trip at ERROR: the upstream returned 200 +
-// headers, then stalled for the full budget. byte_idle = zero bytes for the
-// idle budget; output_idle = stream stayed byte-alive on keepalive/empty frames
-// but produced zero output content for the output-stall budget (the 2026-06-19
-// DeepInfra mode). Both classify retryable, so dispatchWithFallback re-attempts
-// when nothing reached the client; this log is the per-model paper trail.
+// logStreamStall reports a watchdog trip at ERROR after upstream returned
+// 200 + headers then stalled for the full budget. Both stall kinds are
+// retryable (dispatchWithFallback re-attempts); this is the paper trail.
 func logStreamStall(model, baseURL string, cause error) {
 	stallKind := "byte_idle"
 	switch {
@@ -309,12 +284,9 @@ func logStreamStall(model, baseURL string, cause error) {
 	)
 }
 
-// readCapped reads up to limit bytes from r into a buffer, then drains the
-// rest without retention up to maxDrain to bound failover latency on a
-// slow upstream returning a large error body. The connection is closed by
-// the caller's defer regardless, so the unread tail is discarded by Close.
-// Returns the buffered prefix, total bytes read, and any read error
-// (io.EOF mapped to nil).
+// readCapped buffers up to limit bytes from r, then drains (without retaining)
+// up to maxDrain more to bound failover latency on a large error body. Returns
+// the buffered prefix, total bytes read, and any read error (io.EOF -> nil).
 func readCapped(r io.Reader, limit int) ([]byte, int64, error) {
 	prefix, err := io.ReadAll(io.LimitReader(r, int64(limit)))
 	totalRead := int64(len(prefix))

--- a/internal/providers/openaicompat/client_test.go
+++ b/internal/providers/openaicompat/client_test.go
@@ -51,10 +51,8 @@ func TestProxy_ForwardsToChatCompletionsUnderVersionedBaseURL(t *testing.T) {
 	assert.Equal(t, http.StatusOK, rec.Code)
 }
 
-// TestProxy_BYOKCredentialsOverrideEnvKey covers the case where a BYOK key is
-// stashed on context (e.g. a managed installation that brings its own
-// OpenRouter key). The context credential must win over the deployment-level
-// env key.
+// TestProxy_BYOKCredentialsOverrideEnvKey: a BYOK key on context (e.g. a
+// managed installation's own OpenRouter key) must win over the deployment env key.
 func TestProxy_BYOKCredentialsOverrideEnvKey(t *testing.T) {
 	var gotAuth string
 
@@ -80,11 +78,9 @@ func TestProxy_BYOKCredentialsOverrideEnvKey(t *testing.T) {
 		"BYOK credentials on context must override the deployment-level env key")
 }
 
-// TestProxy_DevModeEnvKeyUsedWhenNoCredentialsOnContext covers the dev-mode /
-// non-BYOK path: no credentials are stashed on context (WithAuth middleware
-// is skipped), so setAuth must fall back to the deployment-level env key.
-// This is the primary path for self-hosters and local dev with OPENROUTER_API_KEY
-// set in .env.local.
+// TestProxy_DevModeEnvKeyUsedWhenNoCredentialsOnContext: with no context
+// credentials (WithAuth skipped, e.g. ROUTER_DEV_MODE), setAuth must fall
+// back to the deployment env key — the path self-hosters/local dev rely on.
 func TestProxy_DevModeEnvKeyUsedWhenNoCredentialsOnContext(t *testing.T) {
 	var gotAuth string
 
@@ -134,11 +130,9 @@ func TestPassthrough_StripsInboundV1Prefix(t *testing.T) {
 	assert.Equal(t, http.StatusOK, rec.Code)
 }
 
-// TestProxy_BuffersErrorBodyAndDoesNotTouchWriter is the core failover
-// precondition: when the upstream returns >=400, openaicompat MUST NOT
-// write headers or status to the client writer. Instead it returns
-// *UpstreamErrorResponse carrying the buffered body, leaving the
-// dispatcher free to retry on another binding.
+// TestProxy_BuffersErrorBodyAndDoesNotTouchWriter: on upstream >=400,
+// openaicompat must not touch the client writer — it returns
+// *UpstreamErrorResponse so the dispatcher can retry on another binding.
 func TestProxy_BuffersErrorBodyAndDoesNotTouchWriter(t *testing.T) {
 	const errBody = `{"error":{"message":"fireworks is having a moment","type":"service_unavailable"}}`
 
@@ -163,17 +157,14 @@ func TestProxy_BuffersErrorBodyAndDoesNotTouchWriter(t *testing.T) {
 	assert.Equal(t, errBody, string(buffered.Body))
 	assert.Equal(t, "application/json", buffered.Headers.Get("Content-Type"))
 
-	// The writer must remain pristine — no headers, no body, no status.
-	// httptest.ResponseRecorder defaults to 200 and reports it via Code
-	// even before WriteHeader is called, so we check that nothing was
-	// actually written instead.
+	// ResponseRecorder reports Code=200 by default even without WriteHeader,
+	// so check that nothing was actually written instead.
 	assert.Equal(t, 0, rec.Body.Len(), "writer must not be touched on retryable upstream error")
 	assert.False(t, rec.HeaderMap.Get("Content-Type") != "", "writer headers must not be set on retryable upstream error")
 }
 
-// TestProxy_BuffersErrorBodyTruncatedAtCap ensures that a chatty upstream
-// can't OOM us via a huge error body. Beyond MaxBufferedErrorBytes the
-// remainder is drained and discarded.
+// TestProxy_BuffersErrorBodyTruncatedAtCap: a chatty upstream can't OOM us —
+// beyond MaxBufferedErrorBytes the remainder is drained and discarded.
 func TestProxy_BuffersErrorBodyTruncatedAtCap(t *testing.T) {
 	// 256KB body, well over the 64KB cap.
 	largeBody := strings.Repeat("x", 256*1024)
@@ -199,10 +190,8 @@ func TestProxy_BuffersErrorBodyTruncatedAtCap(t *testing.T) {
 		"body must be truncated at MaxBufferedErrorBytes")
 }
 
-// TestProxy_4xxStillBuffered confirms that non-retryable 4xx is also
-// buffered — the classifier (providers.IsRetryable) decides retry
-// eligibility, not the adapter. Adapter just stops bytes from leaking
-// to the client until the dispatcher decides whether to flush or retry.
+// TestProxy_4xxStillBuffered: non-retryable 4xx is buffered too — the
+// adapter just withholds bytes; providers.IsRetryable decides eligibility.
 func TestProxy_4xxStillBuffered(t *testing.T) {
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusBadRequest)

--- a/internal/proxy/conformance_golden_test.go
+++ b/internal/proxy/conformance_golden_test.go
@@ -1,13 +1,9 @@
 package proxy_test
 
-// Golden-file helpers for the translation-conformance suite. The router writes
-// translated responses with a fixed key order (hand-written JSON buffers, not
-// Go maps), and every input here is fixture-driven, so output is deterministic.
-// normalizeResponse re-canonicalizes anyway — it parses the response, redacts
-// the handful of volatile values (generated message ids, timestamps), and
-// re-serializes with sorted keys — so a golden never flakes on key order and a
-// diff pinpoints a real translation change. Run `go test -update` to (re)write
-// goldens, then review the diff before committing.
+// Golden-file helpers for the translation-conformance suite. Output is
+// deterministic (fixture-driven), but normalizeResponse still redacts
+// volatile values (ids, timestamps) and sorts keys so a diff always
+// reflects a real translation change. Run `go test -update` to regenerate.
 
 import (
 	"bytes"
@@ -67,9 +63,8 @@ type normalizedFrame struct {
 	Data  map[string]interface{} `json:"data"`
 }
 
-// normalizeResponse canonicalizes a client-facing Anthropic response (SSE stream
-// or one-shot JSON) into stable, diffable bytes: volatile values redacted, JSON
-// keys sorted. SSE vs JSON is detected from the recorded body.
+// normalizeResponse canonicalizes an Anthropic response (SSE or one-shot JSON)
+// into stable, diffable bytes: volatile values redacted, keys sorted.
 func normalizeResponse(t *testing.T, contentType string, raw []byte) []byte {
 	t.Helper()
 	trimmed := bytes.TrimSpace(raw)
@@ -106,9 +101,8 @@ func normalizeJSON(t *testing.T, raw []byte) []byte {
 	return marshalCanonical(t, normalizedFrame{Data: redactJSON(t, bytes.TrimSpace(raw))})
 }
 
-// marshalCanonical renders v as indented JSON with sorted map keys (encoding/json
-// sorts map keys) and HTML escaping off, so goldens stay readable (`<id>`, not
-// the <id> escape) and any < > & in model text isn't mangled.
+// marshalCanonical renders v as indented JSON with sorted keys and HTML
+// escaping off, so `<id>` etc. stay readable in the golden.
 func marshalCanonical(t *testing.T, v interface{}) []byte {
 	t.Helper()
 	var buf bytes.Buffer
@@ -119,12 +113,9 @@ func marshalCanonical(t *testing.T, v interface{}) []byte {
 	return buf.Bytes()
 }
 
-// redactJSON unmarshals one JSON object and replaces values that the translator
-// generates fresh (so they vary even with a fixed fixture) with stable
-// placeholders: a message's generated id and any wire timestamp. Everything that
-// flows deterministically from the fixture (text, tool args, tool_use ids that
-// echo the upstream call id, usage, stop_reason) is left intact so the golden
-// asserts real translation behavior.
+// redactJSON unmarshals one JSON object and replaces the translator's
+// freshly-generated values (message id, timestamp) with stable placeholders;
+// everything fixture-derived is left intact.
 func redactJSON(t *testing.T, data []byte) map[string]interface{} {
 	t.Helper()
 	var m map[string]interface{}
@@ -133,17 +124,13 @@ func redactJSON(t *testing.T, data []byte) map[string]interface{} {
 	return m
 }
 
-// synthToolID matches a tool-call id the translator generates from scratch
-// (Gemini has no native call id: gemini_response.go uses "call_"+randomHex(4) =
-// 8 hex chars). Upstream-echoed ids in fixtures ("call_abc", "call_x") don't
-// match, so they stay in the golden and assert the echo behavior; only the
-// random ones get neutralized.
+// synthToolID matches tool-call ids the translator invents (Gemini has no
+// native call id: gemini_response.go uses "call_"+randomHex(4)). Upstream-
+// echoed ids like "call_abc" don't match this pattern and stay in the golden.
 var synthToolID = regexp.MustCompile(`^call_[0-9a-f]{8}$`)
 
-// redactVolatile walks a decoded response frame and replaces the values the
-// translator generates fresh — a message's id and any synthesized tool-call id —
-// with stable placeholders, and drops wire timestamps. Everything fixture-driven
-// stays intact so the golden still asserts real translation behavior.
+// redactVolatile walks a decoded frame, replacing message ids and synthesized
+// tool-call ids with placeholders and dropping wire timestamps.
 func redactVolatile(v interface{}) {
 	switch x := v.(type) {
 	case map[string]interface{}:

--- a/internal/proxy/enabled_providers_internal_test.go
+++ b/internal/proxy/enabled_providers_internal_test.go
@@ -10,12 +10,10 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// TestEnabledProvidersForRequest_PassthroughIsSurfaceScoped guards the fix for
-// PR #159's cross-provider credential-leak review: a passthrough-eligible
-// provider must join the eligible set only when the inbound surface matches
-// its own. Without this, an Anthropic-surface request could route to OpenAI
-// in a passthrough deployment and forward the inbound `x-api-key` (an
-// Anthropic token) to api.openai.com.
+// TestEnabledProvidersForRequest_PassthroughIsSurfaceScoped guards PR #159's
+// credential-leak fix: a passthrough-eligible provider is only eligible when
+// the inbound surface matches its own, or e.g. an Anthropic x-api-key could
+// leak to api.openai.com.
 func TestEnabledProvidersForRequest_PassthroughIsSurfaceScoped(t *testing.T) {
 	s := &Service{
 		// Mimic selfhosted with no env keys, both passthrough-eligible.
@@ -53,10 +51,8 @@ func TestEnabledProvidersForRequest_PassthroughIsSurfaceScoped(t *testing.T) {
 }
 
 // TestEnabledProvidersForRequest_ExcludedProvidersSubtracted confirms the
-// per-installation provider exclusion list removes providers from the
-// eligible set even when their credentials are wired — the single seam
-// through which the scorer, hard pins, session pins, and tier clamp all
-// inherit the exclusion.
+// per-installation exclusion list removes providers even when credentials
+// are wired — the single seam scorer, pins, and tier clamp all inherit from.
 func TestEnabledProvidersForRequest_ExcludedProvidersSubtracted(t *testing.T) {
 	makeService := func() *Service {
 		return &Service{
@@ -100,11 +96,9 @@ func TestEnabledProvidersForRequest_ExcludedProvidersSubtracted(t *testing.T) {
 }
 
 // TestEnabledProvidersForRequest_SubscriptionEnrollsAnthropic guards the
-// managed-mode primary path: a router-keyed (installation set) byokOnly request
-// carrying only the dedicated subscription header — no BYOK, no deployment key —
-// must enroll Anthropic so the scorer can pick a Claude model. Without it the
-// enabled set is empty and the scorer fails with ErrNoEligibleProvider before
-// any Claude turn runs.
+// managed-mode path: a router-keyed byokOnly request carrying only the
+// subscription header must enroll Anthropic, or the scorer fails with
+// ErrNoEligibleProvider before any Claude turn runs.
 func TestEnabledProvidersForRequest_SubscriptionEnrollsAnthropic(t *testing.T) {
 	makeService := func() *Service {
 		return &Service{
@@ -131,10 +125,8 @@ func TestEnabledProvidersForRequest_SubscriptionEnrollsAnthropic(t *testing.T) {
 	})
 
 	t.Run("inbound Authorization subscription bearer enrolls anthropic on a router-keyed request", func(t *testing.T) {
-		// The managed Claude Code path: router key in X-Weave-Router-Key
-		// (installation set), the subscription OAuth token left in Authorization.
-		// Anthropic must be enrolled off the inbound bearer so the scorer can
-		// route a Claude turn the subscription will pay for.
+		// Managed Claude Code path: router key in X-Weave-Router-Key, OAuth
+		// token in Authorization — Anthropic must enroll off the inbound bearer.
 		headers := http.Header{"Authorization": []string{"Bearer sk-ant-oat01-subscription-token"}}
 		got := makeService().enabledProvidersForRequest(routerKeyed(), providers.ProviderAnthropic, headers)
 		assert.Contains(t, got, providers.ProviderAnthropic,
@@ -144,9 +136,7 @@ func TestEnabledProvidersForRequest_SubscriptionEnrollsAnthropic(t *testing.T) {
 	})
 
 	t.Run("inbound API-key bearer does NOT enroll anthropic on a router-keyed request", func(t *testing.T) {
-		// Only the sk-ant-oat OAuth subset enrolls off the inbound bearer; a real
-		// client API key must not, mirroring resolveAndInjectCredentials and
-		// preserving the cross-provider-leak guard.
+		// Only the sk-ant-oat OAuth subset enrolls off the bearer; a real API key must not.
 		headers := http.Header{"Authorization": []string{"Bearer sk-ant-api-real-client-key"}}
 		got := makeService().enabledProvidersForRequest(routerKeyed(), providers.ProviderAnthropic, headers)
 		assert.NotContains(t, got, providers.ProviderAnthropic,
@@ -170,10 +160,8 @@ func TestEnabledProvidersForRequest_SubscriptionEnrollsAnthropic(t *testing.T) {
 }
 
 // TestEnabledProvidersForRequest_CodexSubscriptionEnrollsOpenAI mirrors the
-// Anthropic enrollment for the Codex (ChatGPT) subscription: a router-keyed
-// byokOnly request carrying the dedicated Codex header pair — no BYOK, no
-// deployment key — must enroll OpenAI (and only OpenAI) so the scorer can pick
-// a Codex-eligible model. Enrollment requires BOTH token and account-id.
+// Anthropic subscription test for Codex: enrolling OpenAI requires BOTH the
+// JWT and account-id.
 func TestEnabledProvidersForRequest_CodexSubscriptionEnrollsOpenAI(t *testing.T) {
 	const codexJWT = "eyJhbGciOiJSUzI1NiJ9.codex.sig"
 	makeService := func() *Service {
@@ -202,9 +190,8 @@ func TestEnabledProvidersForRequest_CodexSubscriptionEnrollsOpenAI(t *testing.T)
 	})
 
 	t.Run("inbound Authorization Codex bearer enrolls openai on a router-keyed request", func(t *testing.T) {
-		// The managed Codex CLI path: router key in X-Weave-Router-Key, the
-		// ChatGPT JWT + account-id left in Authorization. OpenAI must be enrolled
-		// off the inbound bearer so the scorer can route a Codex turn.
+		// Managed Codex CLI path: router key in X-Weave-Router-Key, JWT+account-id
+		// in Authorization — OpenAI must enroll off the inbound bearer.
 		headers := http.Header{
 			"Authorization":      []string{"Bearer " + codexJWT},
 			"Chatgpt-Account-Id": []string{"acct-123"},
@@ -244,8 +231,7 @@ func TestEnabledProvidersForRequest_CodexSubscriptionEnrollsOpenAI(t *testing.T)
 }
 
 // TestEnabledProvidersForRequest_DeploymentKeyedStillCrossSurface confirms
-// that env-keyed providers stay eligible regardless of surface (their keys
-// are trusted and don't depend on inbound headers).
+// env-keyed providers stay eligible regardless of surface.
 func TestEnabledProvidersForRequest_DeploymentKeyedStillCrossSurface(t *testing.T) {
 	s := &Service{
 		providers: map[string]providers.Client{

--- a/internal/proxy/feedback.go
+++ b/internal/proxy/feedback.go
@@ -14,9 +14,8 @@ import (
 	"github.com/google/uuid"
 )
 
-// HeaderRouterFeedbackURL carries the no-login feedback page URL for the request
-// the response served, so clients can surface a "rate this routing decision"
-// affordance. Omitted when the feedback-link feature is unwired.
+// HeaderRouterFeedbackURL carries the no-login feedback page URL for the
+// served request. Omitted when the feedback-link feature is unwired.
 const HeaderRouterFeedbackURL = "x-router-feedback-url"
 
 // routerFeedbackSpanName is the OTLP span the router emits on each submission so
@@ -71,9 +70,9 @@ type FeedbackRepository interface {
 	GetContext(ctx context.Context, installationID, requestID string) (FeedbackContext, error)
 }
 
-// WithFeedback wires the feedback repository, the signed-link signer, and the
-// public base URL of the feedback page. Any of them being nil/empty disables
-// the corresponding capability (DB access, token verification, link emission).
+// WithFeedback wires the feedback repository, signed-link signer, and public
+// base URL of the feedback page. Any left nil/empty disables that capability
+// (DB access, token verification, link emission respectively).
 func (s *Service) WithFeedback(repo FeedbackRepository, signer *feedback.Signer, baseURL string) *Service {
 	s.feedbackRepo = repo
 	s.feedbackSigner = signer
@@ -81,17 +80,16 @@ func (s *Service) WithFeedback(repo FeedbackRepository, signer *feedback.Signer,
 	return s
 }
 
-// FeedbackEnabled reports whether the signed feedback-link endpoints should be
-// mounted. True when a signer is configured (ROUTER_FEEDBACK_LINK_SECRET set);
-// the repository can still be nil in tests, so handlers guard independently.
+// FeedbackEnabled reports whether the signed feedback-link endpoints should
+// be mounted (i.e. ROUTER_FEEDBACK_LINK_SECRET is set). The repository can
+// still be nil in tests, so handlers guard independently.
 func (s *Service) FeedbackEnabled() bool {
 	return s != nil && s.feedbackSigner != nil
 }
 
-// VerifyFeedbackToken verifies a feedback-link token and returns its claims,
-// without leaking the signer to the presentation layer. Returns
-// feedback.ErrInvalidToken / feedback.ErrExpiredToken for the handler to map to
-// HTTP 404 / 410.
+// VerifyFeedbackToken verifies a feedback-link token without leaking the
+// signer to the presentation layer. Returns feedback.ErrInvalidToken /
+// ErrExpiredToken for the handler to map to HTTP 404 / 410.
 func (s *Service) VerifyFeedbackToken(token string) (feedback.Claims, error) {
 	return s.feedbackSigner.Verify(token)
 }
@@ -105,10 +103,9 @@ func (s *Service) GetFeedbackContext(ctx context.Context, installationID, reques
 	return s.feedbackRepo.GetContext(ctx, installationID, requestID)
 }
 
-// SubmitFeedback persists feedback to the router's own source-of-truth table
-// and emits a router.feedback OTLP span so the Weave backend mirrors it. The
-// DB write is authoritative for the feedback page; the span is best-effort
-// (dropped silently if the exporter queue is full).
+// SubmitFeedback persists feedback to the router's source-of-truth table and
+// emits a router.feedback OTLP span so Weave mirrors it. The DB write is
+// authoritative; the span is best-effort (dropped if the exporter queue is full).
 func (s *Service) SubmitFeedback(ctx context.Context, p SubmitFeedbackParams) error {
 	if s.feedbackRepo == nil {
 		return ErrFeedbackUnavailable
@@ -152,9 +149,9 @@ func (s *Service) emitFeedbackSpan(p SubmitFeedbackParams) {
 	buf.Flush()
 }
 
-// mintFeedbackToken signs a feedback-link token for one request, or returns ""
-// when the feature is unwired or any required id is missing (e.g. anonymous /
-// no-external-id deployments). Callers treat "" as "feedback disabled".
+// mintFeedbackToken signs a feedback-link token, or returns "" when the
+// feature is unwired or any required id is missing. Callers treat "" as
+// "feedback disabled".
 func (s *Service) mintFeedbackToken(installationID uuid.UUID, externalID, requestID, routerUserID string) string {
 	if s.feedbackSigner == nil || s.feedbackBaseURL == "" {
 		return ""
@@ -165,9 +162,8 @@ func (s *Service) mintFeedbackToken(installationID uuid.UUID, externalID, reques
 	return s.feedbackSigner.Mint(installationID.String(), externalID, requestID, routerUserID)
 }
 
-// setFeedbackLinkHeader mints a signed feedback link for the request and sets
-// it on the response. No-op when the feature is unwired or any required id is
-// missing (e.g. anonymous / no-external-id deployments).
+// setFeedbackLinkHeader mints a signed feedback link and sets it on the
+// response. No-op when the feature is unwired or any required id is missing.
 func (s *Service) setFeedbackLinkHeader(w http.ResponseWriter, installationID uuid.UUID, externalID, requestID, routerUserID string) {
 	token := s.mintFeedbackToken(installationID, externalID, requestID, routerUserID)
 	if token == "" {
@@ -176,41 +172,33 @@ func (s *Service) setFeedbackLinkHeader(w http.ResponseWriter, installationID uu
 	w.Header().Set(HeaderRouterFeedbackURL, s.feedbackBaseURL+"/f/"+token)
 }
 
-// terminalFeedbackClients are the coding agents whose entire streamed response
-// is user-facing chat, so a trailing rating hint renders cleanly and the user
-// can reply with /rf+ or /rf-. IDEs (cursor) and unknown clients are excluded:
-// they reuse the same endpoint for inline edits, applied diffs, and commit
-// messages, where an appended footer contaminates non-chat output.
+// terminalFeedbackClients are agents whose entire streamed response is
+// user-facing chat, so a trailing /rf rating hint renders cleanly. IDEs
+// (cursor) and unknown clients are excluded: they reuse the endpoint for
+// inline edits, applied diffs, and commit messages, where a footer would
+// contaminate non-chat output.
 var terminalFeedbackClients = map[string]struct{}{
 	ClientAppClaudeCode: {},
 	ClientAppCodex:      {},
 	ClientAppOpencode:   {},
 }
 
-// feedbackFooterText is the trailing rating hint appended to streamed answers
-// for terminal coding agents. It is deliberately link-free: Claude Code's
-// markdown renderer prints a [label](url) link as "label (url)" rather than
-// hiding the URL, so embedding the signed rate link dumps the entire token
-// inline. The typed /rf+ /rf- commands keep feedback one keystroke away and
-// render identically across the TUI, print mode, and IDEs.
-// translate.feedbackFooterPattern matches this on ingress to strip it back out
-// of upstream context — keep the two in sync.
+// feedbackFooterText is deliberately link-free: Claude Code's markdown
+// renderer prints "[label](url)" as "label (url)", so embedding the signed
+// feedback link would dump the whole token inline. /rf+ and /rf- render
+// identically across TUI, print mode, and IDEs.
+// Keep in sync with translate.feedbackFooterPattern, which strips this back
+// out of upstream context on ingress.
 const feedbackFooterText = "\n\n_Weave Router feedback:_ `/rf +` good experience · `/rf -` poor experience · note optional, e.g. `/rf - too slow`"
 
-// feedbackFooter returns the in-terminal rating hint appended to a streamed
-// response, or "" to stay fully transparent. Gated to terminal coding agents
-// (terminalFeedbackClients) so IDEs never get chat text injected into non-chat
-// surfaces, and to deployments with durable feedback storage so we never
-// advertise a rating command we can't record. The signed feedback link still
-// ships invisibly via the x-router-feedback-url header for rich GUI clients.
-//
-// Also gated to the user's own conversation turns (MainLoop / ToolResult).
-// Subagent dispatches and machine turns (compaction, probe, title-gen,
-// classifier) render final text the user never directly initiated, so a
-// trailing /rf hint strands beneath it — e.g. under an Explore subagent's
-// result in the Claude Code TUI. The common final-answer turn arrives on a
-// ToolResult inbound (the assistant used tools first), so it must stay in the
-// allowlist or the footer would almost never fire.
+// feedbackFooter returns the in-terminal rating hint for a streamed response,
+// or "" to stay transparent. Gated to terminalFeedbackClients (avoid
+// contaminating non-chat surfaces), to deployments with durable feedback
+// storage (never advertise a command we can't record — the header-based link
+// still ships for GUI clients), and to MainLoop/ToolResult turns: subagent
+// dispatches and machine turns (compaction, probe, title-gen, classifier)
+// render final text the user didn't directly initiate, where a trailing /rf
+// hint would strand beneath it (e.g. under an Explore subagent's result).
 func (s *Service) feedbackFooter(clientApp string, tt turntype.TurnType) string {
 	if s.feedbackStore == nil {
 		return ""

--- a/internal/proxy/log_io.go
+++ b/internal/proxy/log_io.go
@@ -7,9 +7,8 @@ import (
 	"workweave/router/internal/translate"
 )
 
-// preview returns the first n runes of s with an ellipsis suffix when
-// truncated. Empty in, empty out. Used everywhere we want a log-safe excerpt
-// of free-text payloads — full bodies stay behind LOG_LEVEL=debug.
+// preview returns a log-safe excerpt of s, truncated to n bytes with an
+// ellipsis suffix. Full bodies stay behind LOG_LEVEL=debug.
 func preview(s string, n int) string {
 	if s == "" || n <= 0 {
 		return ""
@@ -25,14 +24,10 @@ func preview(s string, n int) string {
 	return cut + "…"
 }
 
-// logInboundToolTraffic emits a Debug log line summarising the tool-use blocks
-// the model is about to see on this turn. Keeps payload small (just names +
-// short arg previews of the last few assistant calls) so we can correlate a
-// broken turn back to the prior tool_use / tool_result shape without dumping
-// the entire body.
-//
-// Gemini envelopes are skipped — the underlying preview helper only knows
-// Anthropic + OpenAI shapes today.
+// logInboundToolTraffic logs names + short arg previews of the last few
+// assistant tool_use calls, to correlate a broken turn without dumping the
+// full body. Gemini envelopes are skipped — preview only knows Anthropic +
+// OpenAI shapes today.
 func logInboundToolTraffic(log *slog.Logger, env *translate.RequestEnvelope) {
 	if env == nil {
 		return
@@ -64,13 +59,9 @@ func logInboundRequestDiagnostics(log *slog.Logger, env *translate.RequestEnvelo
 	logInboundSystemTail(log, env)
 }
 
-// logInboundConversationTail emits a structured summary of the last few
-// inbound messages, with role + per-block type/name/preview. Pairs with
-// logInboundToolTraffic: the tool-call view shows what the model previously
-// invoked, this view shows the visible prose context (assistant text, last
-// user prompt, last tool_result) the model is about to react to. Used to
-// diagnose stuck conversations where bytes change but the model keeps
-// emitting the same prefix.
+// logInboundConversationTail logs role + per-block type/name/preview for the
+// last few inbound messages — the visible prose context the model is about
+// to react to, complementing logInboundToolTraffic's view of prior tool calls.
 func logInboundConversationTail(log *slog.Logger, env *translate.RequestEnvelope) {
 	if env == nil {
 		return
@@ -110,10 +101,9 @@ func logInboundConversationTail(log *slog.Logger, env *translate.RequestEnvelope
 	)
 }
 
-// logInboundSystemTail emits the system-prompt length plus head/tail
-// excerpts. The static Claude Code system prompt dwarfs any per-turn
-// system_reminder injections; logging head + tail makes those injections
-// visible without paying to log the whole prompt every turn.
+// logInboundSystemTail logs system-prompt length plus head/tail excerpts,
+// surfacing per-turn system_reminder injections without logging the whole
+// prompt (which the static Claude Code prompt otherwise dwarfs).
 func logInboundSystemTail(log *slog.Logger, env *translate.RequestEnvelope) {
 	if env == nil {
 		return
@@ -130,12 +120,9 @@ func logInboundSystemTail(log *slog.Logger, env *translate.RequestEnvelope) {
 	)
 }
 
-// logAssistantOutputSummary emits a Debug summary of the assistant blocks the
-// upstream produced this turn: counts of text / tool_use / thinking blocks and
-// short previews of each tool_use call. Streaming providers should call this
-// once the response stream has closed and the buffered text/tool blocks are
-// known; for non-streaming responses it can be invoked directly on the parsed
-// body.
+// logAssistantOutputSummary logs counts of text/tool_use/thinking blocks and
+// tool_use previews for the assistant's turn. Streaming providers call it
+// once the stream closes; non-streaming callers pass the parsed body directly.
 func logAssistantOutputSummary(
 	log *slog.Logger,
 	textBlocks, thinkingBlocks int,
@@ -160,10 +147,8 @@ func logAssistantOutputSummary(
 	)
 }
 
-// ToolCallPreview is a log-friendly snapshot of one assistant tool_use block.
-// Kept in this package to avoid coupling translate or providers to a logging
-// type; populated by the streaming/non-streaming response parsers when they
-// can cheaply observe the block.
+// ToolCallPreview is a log-friendly snapshot of one assistant tool_use block,
+// kept here to avoid coupling translate/providers to a logging type.
 type ToolCallPreview struct {
 	Name     string
 	ArgsJSON string

--- a/internal/proxy/observation.go
+++ b/internal/proxy/observation.go
@@ -24,37 +24,30 @@ type observationContext struct {
 	// TTFTMs is the upstream-request-to-first-byte delta in ms. Pointer because
 	// zero is a legitimate sub-millisecond measurement.
 	TTFTMs *int64
-	// CandidateScores is the pre-argmax score vector marshaled to JSON for the
-	// jsonb column. nil when the router exposes no score vector. Off-policy
-	// substrate only — never read back on the request path.
+	// CandidateScores is the pre-argmax score vector, JSON-marshaled for the
+	// jsonb column (nil if none). Off-policy substrate only — never read on the request path.
 	CandidateScores []byte
 	// Propensity is the probability the chosen model was selected under the
-	// acting policy. Pointer so 0.0 stays distinct from "not a cluster
-	// decision". 1.0 for deterministic argmax.
+	// acting policy (1.0 for deterministic argmax). Pointer distinguishes 0.0 from unset.
 	Propensity *float64
-	// FreshDecisionModel is the scorer's fresh pick this turn, captured even
-	// when the planner returned STAY (decision_model then names the pinned model
-	// served). Empty when the scorer did not run. Shadow-mode instrumentation
-	// for the hysteresis downgrade lever.
+	// FreshDecisionModel is the scorer's fresh pick this turn, captured even on
+	// STAY (decision_model then names the pinned model served instead). Empty if
+	// the scorer didn't run. Shadow instrumentation for the hysteresis downgrade lever.
 	FreshDecisionModel string
-	// FreshCandidateScores is the fresh scorer's pre-argmax score vector
-	// marshaled to JSON, captured even on STAY. Distinct from CandidateScores,
-	// which mirrors the FINAL decision and is NULL on STAY. nil when the scorer
-	// did not run / exposed no vector.
+	// FreshCandidateScores is the fresh scorer's score vector, JSON-marshaled,
+	// captured even on STAY — unlike CandidateScores, which mirrors the final
+	// decision and is NULL on STAY. nil if the scorer didn't run or exposed none.
 	FreshCandidateScores []byte
 }
 
 // buildObservationContext derives the observation bundle from the routing
-// decision and request context. Nil-safe: returns a zero value when sources
-// are absent. fresh is the scorer's recommendation this turn (which equals
-// decision on a SWITCH/fresh-pin write, but differs on a STAY where decision
-// rehydrates from the pin); its score vector is captured separately so the
-// hysteresis downgrade opportunity is measurable on STAY turns.
+// decision and request context. Nil-safe. fresh is the scorer's recommendation
+// this turn, which differs from decision on STAY (decision rehydrates from the
+// pin); fresh's scores are captured separately to measure the hysteresis downgrade lever.
 func buildObservationContext(ctx context.Context, decision, fresh router.Decision) observationContext {
 	obs := observationContext{}
-	// Fresh scorer recommendation, captured independently of the final decision
-	// so STAY turns (decision == pin, no metadata) still record what a re-score
-	// would have picked.
+	// Captured independently of the final decision so STAY turns (decision ==
+	// pin, no metadata) still record what a re-score would have picked.
 	if fresh.Model != "" {
 		obs.FreshDecisionModel = fresh.Model
 	}
@@ -80,9 +73,8 @@ func buildObservationContext(ctx context.Context, decision, fresh router.Decisio
 		score := float64(md.ChosenScore)
 		obs.ChosenScore = &score
 		obs.ClusterRouterVersion = md.ClusterRouterVersion
-		// Propensity is meaningful only alongside a score vector (the scorer
-		// sets both together); gate on CandidateScores so a non-scoring router
-		// leaves the column NULL instead of logging the Go zero 0.0.
+		// Propensity is meaningful only alongside a score vector; gate on
+		// CandidateScores so a non-scoring router leaves NULL, not a false 0.0.
 		if len(md.CandidateScores) > 0 {
 			prop := float64(md.Propensity)
 			obs.Propensity = &prop

--- a/internal/proxy/pin_eviction.go
+++ b/internal/proxy/pin_eviction.go
@@ -13,31 +13,20 @@ import (
 	"github.com/google/uuid"
 )
 
-// pinEvictionStrikeThreshold is the consecutive-non-retryable-4xx count
-// that trips a sticky pin to expire. Two strikes (not one) tolerates a
-// single transient 400 — e.g. a malformed prompt or a brief upstream
-// schema-validation hiccup — without flushing a working pin's prompt
-// cache. Hit two in a row and the model is wedged for this session;
-// re-route via the cluster scorer rather than wait for the user to
-// notice and manually /force-model out.
+// pinEvictionStrikeThreshold is the consecutive-non-retryable-4xx count that
+// expires a sticky pin. Two (not one) tolerates a single transient 400
+// without flushing a working pin's prompt cache.
 const pinEvictionStrikeThreshold = 2
 
-// evictPinAfterDegenerateResponse expires the session pin immediately
-// after a degenerate response (end_turn with no tool calls and fewer
-// than degenerateOutputThreshold output tokens). The current turn has
-// already been streamed to the client and cannot be retried, but
-// evicting the pin ensures the NEXT turn re-scores rather than
-// continuing to serve the same misbehaving model.
+// evictPinAfterDegenerateResponse expires the session pin after a degenerate
+// response (end_turn, no tool calls, too few output tokens). The current
+// turn already streamed and can't be retried, but evicting ensures the next
+// turn re-scores instead of repeating the same misbehaving model.
 //
-// Skipped paths:
-//   - !stickyHit: the pin row was just written this turn; no decision
-//     history to evict yet.
-//   - Zero session_key / installation_id: no addressable pin row.
-//   - User-forced pins: the user explicitly chose this model; auto-eviction
-//     would silently override an explicit command.
-//
-// Errors from the upsert path are logged and swallowed — eviction is a
-// recovery optimization; failing it must not change the client outcome.
+// No-ops when there's no decision history yet (!stickyHit), no addressable
+// pin row (zero session_key/installation_id), or the pin was user-forced
+// (auto-eviction shouldn't override an explicit /force-model). Upsert errors
+// are logged and swallowed since eviction is best-effort.
 func (s *Service) evictPinAfterDegenerateResponse(
 	ctx context.Context,
 	stickyHit bool,
@@ -77,33 +66,18 @@ func (s *Service) evictPinAfterDegenerateResponse(
 	)
 }
 
-// maybeEvictPinAfterUpstreamErr applies the two-strike pin-eviction
-// policy on every turn that ran against a sticky session pin:
+// maybeEvictPinAfterUpstreamErr applies the two-strike eviction policy for a
+// turn run against a sticky pin: a successful turn resets the strike counter,
+// a non-retryable upstream 4xx increments it, and hitting
+// pinEvictionStrikeThreshold expires the pin so the next turn re-routes via
+// the cluster scorer.
 //
-//   - Successful turn → reset the counter to 0 (any prior strikes are
-//     forgiven the moment the model serves a real response).
-//   - Non-retryable upstream 4xx → atomically increment the counter
-//     on the existing pin row and, when the new count reaches
-//     pinEvictionStrikeThreshold, expire the pin so the NEXT turn
-//     re-routes via the cluster scorer.
-//
-// Skipped paths:
-//   - !stickyHit: the pin row was just written this turn with
-//     counter=0 (writeNewPin) or doesn't exist; no decision-history
-//     yet.
-//   - Zero session_key / installation_id: no addressable pin row.
-//   - User-forced pins (ReasonUserForceModel or its tier_clamp
-//     variant): user explicitly chose this model; auto-eviction would
-//     silently override an explicit command. The user retains
-//     /unforce-model as the escape hatch.
-//   - Retryable upstream status (408 / 429 / 5xx): handled by
-//     dispatchWithFallback's retry loop OR represent transient
-//     upstream conditions that don't indict the model choice.
-//
-// Errors from the increment/reset/upsert paths are logged and
-// swallowed — eviction is a recovery optimization on a turn that
-// already succeeded or failed; failing it must not change the
-// client-visible outcome.
+// No-ops when there's no decision history yet (!stickyHit), no addressable
+// pin row (zero session_key/installation_id), the pin was user-forced (user
+// keeps /unforce-model as the escape hatch), or the status is retryable
+// (408/429/5xx — handled by dispatchWithFallback's retry loop). Errors from
+// the increment/reset/upsert are logged and swallowed since eviction is
+// best-effort and must not change the client-visible outcome.
 func (s *Service) maybeEvictPinAfterUpstreamErr(
 	ctx context.Context,
 	stickyHit bool,
@@ -119,10 +93,7 @@ func (s *Service) maybeEvictPinAfterUpstreamErr(
 	if sessionKey == ([sessionpin.SessionKeyLen]byte{}) {
 		return
 	}
-	// Force-model pins are user commands; the router does not auto-evict
-	// them. ReasonUserForceModel + the "+tier_clamp" suffix are both
-	// surfaced verbatim in decision_reason; cover both with a prefix
-	// check.
+	// Prefix check covers both ReasonUserForceModel and its tier_clamp suffix.
 	if strings.HasPrefix(decisionReason, translate.ReasonUserForceModel) {
 		return
 	}
@@ -130,10 +101,8 @@ func (s *Service) maybeEvictPinAfterUpstreamErr(
 	log := observability.FromContext(ctx)
 
 	if proxyErr == nil {
-		// Background ctx: the request ctx is canceled by the time the
-		// response has finished streaming, but the success-reset is a
-		// best-effort no-op on a missing pin so we don't want it
-		// silently dropped by ctx cancellation.
+		// context.Background(): the request ctx is already canceled by the
+		// time streaming finishes, but this reset must still go through.
 		if err := s.pinStore.ResetUpstreamErrors(context.Background(), sessionKey, role); err != nil {
 			log.Error("pin error-counter reset failed", "err", err, "role", role)
 		}
@@ -165,10 +134,8 @@ func (s *Service) maybeEvictPinAfterUpstreamErr(
 		return
 	}
 
-	// Threshold reached. Expire the pin so the NEXT turn re-routes via
-	// the cluster scorer. Mirrors the loop-break / no-progress / force
-	// -model "expired pin" pattern: upsert a row with PinnedUntil in
-	// the past so loadPin discards it.
+	// Expire via a PinnedUntil in the past, same pattern as loop-break /
+	// no-progress / force-model, so loadPin discards it next turn.
 	expired := sessionpin.Pin{
 		SessionKey:     sessionKey,
 		Role:           role,

--- a/internal/proxy/service_observation_test.go
+++ b/internal/proxy/service_observation_test.go
@@ -79,9 +79,8 @@ func (c *captureTelemetry) firstRow(t *testing.T) proxy.InsertTelemetryParams {
 	return c.rows[0]
 }
 
-// TestProxyMessages_RecordsClusterObservation asserts cluster-routed
-// decisions surface every routing-brain field into the telemetry row.
-// W-1339 / W-1335 depend on the writer populating them.
+// TestProxyMessages_RecordsClusterObservation asserts cluster-routed decisions
+// surface every routing-brain field into the telemetry row (W-1339/W-1335).
 func TestProxyMessages_RecordsClusterObservation(t *testing.T) {
 	const installID = "11111111-1111-1111-1111-111111111111"
 	decision := router.Decision{
@@ -124,9 +123,8 @@ func TestProxyMessages_RecordsClusterObservation(t *testing.T) {
 	require.NotNil(t, row.ChosenScore)
 	assert.InDelta(t, 0.85, *row.ChosenScore, 1e-6)
 	assert.Equal(t, "v-test", row.ClusterRouterVersion)
-	// Propensity is &1.0 for the deterministic argmax scorer; candidate_scores
-	// carries the full pre-argmax vector as jsonb. These are the off-policy
-	// logging substrate — a nil here means the writer dropped them.
+	// Propensity=&1.0 for the deterministic argmax scorer; candidate_scores is
+	// the pre-argmax vector — off-policy logging substrate.
 	require.NotNil(t, row.Propensity)
 	assert.InDelta(t, 1.0, *row.Propensity, 1e-6)
 	require.NotNil(t, row.CandidateScores)
@@ -134,18 +132,15 @@ func TestProxyMessages_RecordsClusterObservation(t *testing.T) {
 	require.NoError(t, json.Unmarshal(row.CandidateScores, &gotScores))
 	assert.InDelta(t, 0.85, gotScores["claude-opus-4-7"], 1e-6)
 	assert.InDelta(t, 0.42, gotScores["claude-haiku-4-5"], 1e-6)
-	// AlphaBreakdown is a W-1335 forward-compat slot; nil here.
-	// Cache* are nil because the fake provider returns no body, so the
-	// usage extractor reports 0 and cacheTokenPtr returns nil.
+	// AlphaBreakdown is a W-1335 forward-compat slot; Cache* are nil since the
+	// fake provider returns no body.
 	assert.Nil(t, row.AlphaBreakdown)
 	assert.Nil(t, row.CacheCreationTokens)
 	assert.Nil(t, row.CacheReadTokens)
 }
 
-// TestProxyMessages_PersistsCacheTokens covers the inverse of the above:
-// when the upstream actually reports cache_creation_input_tokens and
-// cache_read_input_tokens, those values must land on the telemetry row.
-// Regression guard against the W-1309 fields being declared but never wired.
+// TestProxyMessages_PersistsCacheTokens: cache_creation/read_input_tokens
+// reported upstream must land on the telemetry row (W-1309 regression guard).
 func TestProxyMessages_PersistsCacheTokens(t *testing.T) {
 	const installID = "44444444-4444-4444-4444-444444444444"
 	decision := router.Decision{
@@ -181,9 +176,8 @@ func TestProxyMessages_PersistsCacheTokens(t *testing.T) {
 	assert.Equal(t, int32(2048), *row.CacheReadTokens)
 }
 
-// TestProxyMessages_ChosenScoreZeroIsPersisted pins the *float64 semantics:
-// nil = not a cluster decision, &0 = legitimate zero. Regression guard
-// against a `!= 0` simplification that silently drops zero scores.
+// TestProxyMessages_ChosenScoreZeroIsPersisted: nil = not a cluster decision,
+// &0 = legitimate zero. Guards against a `!= 0` simplification dropping zero scores.
 func TestProxyMessages_ChosenScoreZeroIsPersisted(t *testing.T) {
 	const installID = "33333333-3333-3333-3333-333333333333"
 	decision := router.Decision{
@@ -259,10 +253,8 @@ func TestProxyMessages_NoMetadataOmitsClusterFields(t *testing.T) {
 	assert.Nil(t, row.Propensity)
 }
 
-// TestProxyMessages_PersistsTurnType asserts the turntype classification
-// lands on the telemetry row, so dashboard/analytics queries can separate
-// automated turns (probe, title_gen, compaction, classifier) from user
-// traffic when computing per-model shares.
+// TestProxyMessages_PersistsTurnType asserts turntype classification lands on
+// the telemetry row, so analytics can separate automated turns from user traffic.
 func TestProxyMessages_PersistsTurnType(t *testing.T) {
 	const installID = "55555555-5555-5555-5555-555555555555"
 	decision := router.Decision{
@@ -309,10 +301,8 @@ func TestProxyMessages_PersistsTurnType(t *testing.T) {
 	}
 }
 
-// TestProxyMessages_PersistsRolloutID asserts the eval/training-harness
-// rollout correlation id flows from ClientIdentity to the telemetry row —
-// the join key for bandit-loop reward attribution. Empty stays empty (NULL
-// column) for normal traffic.
+// TestProxyMessages_PersistsRolloutID asserts the rollout correlation id
+// flows from ClientIdentity to the telemetry row (bandit-loop reward join key).
 func TestProxyMessages_PersistsRolloutID(t *testing.T) {
 	const installID = "66666666-6666-6666-6666-666666666666"
 	const rolloutID = "swerebench-cc-r1/router-v0.65/0/owner__repo-123"
@@ -341,13 +331,10 @@ func TestProxyMessages_PersistsRolloutID(t *testing.T) {
 	assert.Equal(t, rolloutID, row.RolloutID)
 }
 
-// TestProxyMessages_PersistsSessionKeyAndRole asserts the offline join key to
-// router.spiral_shadow_events / session_pins lands on the telemetry row.
-// session_key must be the 16-byte digest (never empty for a real request), and
-// role must be roleForTier(TierFor(requestedModel)) — the exact value spiral
-// shadow events are keyed on, so the join matches byte-for-byte. The requested
-// model here is claude-opus-4-7 (TierHigh) → "default_high", regardless of the
-// cheaper decision model the router picked.
+// TestProxyMessages_PersistsSessionKeyAndRole: session_key/role are the join
+// key to router.spiral_shadow_events, so they must match spiral's encoding
+// byte-for-byte. role is keyed off the *requested* model (opus-4-7 ->
+// "default_high"), not the cheaper model the router actually picked.
 func TestProxyMessages_PersistsSessionKeyAndRole(t *testing.T) {
 	const installID = "77777777-7777-7777-7777-777777777777"
 	decision := router.Decision{

--- a/internal/proxy/session_key.go
+++ b/internal/proxy/session_key.go
@@ -11,9 +11,8 @@ import (
 	"workweave/router/internal/translate"
 )
 
-// shortKey returns the first 16 hex chars (64 bits) of a session key for
-// log-friendly correlation. Empty for zero keys so log lines on the pre-derive
-// path don't show a misleading prefix.
+// shortKey returns the first 16 hex chars of a session key for log
+// correlation. Empty for the zero key to avoid a misleading prefix.
 func shortKey(key [sessionpin.SessionKeyLen]byte) string {
 	var zero [sessionpin.SessionKeyLen]byte
 	if key == zero {
@@ -22,10 +21,9 @@ func shortKey(key [sessionpin.SessionKeyLen]byte) string {
 	return hex.EncodeToString(key[:8])
 }
 
-// sessionAffinityHint returns the full hex session key for use as an upstream
-// prompt-cache stickiness hint (translate.EmitOptions.SessionAffinity), or ""
-// for the zero key so requests with no derivable session don't all collapse
-// onto one synthetic affinity bucket.
+// sessionAffinityHint returns the full hex session key as an upstream
+// prompt-cache stickiness hint, or "" for the zero key so sessionless
+// requests don't all collapse onto one affinity bucket.
 func sessionAffinityHint(key [sessionpin.SessionKeyLen]byte) string {
 	var zero [sessionpin.SessionKeyLen]byte
 	if key == zero {
@@ -34,14 +32,10 @@ func sessionAffinityHint(key [sessionpin.SessionKeyLen]byte) string {
 	return hex.EncodeToString(key[:])
 }
 
-// bindRequestLogger derives the session key and returns a new context carrying
-// a request-scoped logger pre-bound with session_key, request_id, api_key_id,
-// and ingress. Downstream code reading via observability.FromContext gets these
-// attributes on every line for free, so a single session's path through the
-// router can be filtered in Cloud Logging by session_key alone.
-//
-// Returns the derived session key so callers don't re-derive it for force-model
-// or loop-detection paths that already needed it.
+// bindRequestLogger derives the session key and returns a context carrying a
+// logger pre-bound with session_key, request_id, api_key_id, and ingress, so
+// a session's path can be filtered in Cloud Logging by session_key alone. It
+// also returns the key so callers don't have to re-derive it.
 func bindRequestLogger(
 	ctx context.Context,
 	env *translate.RequestEnvelope,
@@ -54,9 +48,8 @@ func bindRequestLogger(
 		"api_key_id", apiKeyID,
 		"ingress", ingress,
 	)
-	// client_session_id is the calling client's own session id (e.g. Claude
-	// Code's /status UUID). Bound when the client surfaces one so operators
-	// can grep logs by the id the user actually sees.
+	// The client's own session id (e.g. Claude Code's /status UUID), bound
+	// when present so operators can grep by the id the user actually sees.
 	if env != nil {
 		if cs := env.ClientSessionID(); cs != "" {
 			log = log.With("client_session_id", cs)
@@ -65,28 +58,21 @@ func bindRequestLogger(
 	return observability.WithLogger(ctx, log), log, key
 }
 
-// DeriveSessionKey produces a 16-byte session digest from metadata.user_id
-// (when present) AND the first user message, plus apiKeyID to prevent
-// cross-key collisions.
+// DeriveSessionKey produces a 16-byte session digest from apiKeyID,
+// metadata.user_id (when present), and the first user message.
 //
-// The first user message is load-bearing, not decoration: Claude Code packs
-// only its device+account+session bundle into metadata.user_id — NOT sub-agent
-// identity — so the main loop and every Task/Explore sub-agent of one session
-// share an identical user_id. Keying on user_id alone collapsed them onto a
-// single pin slot that concurrent threads then thrashed (one writes haiku, a
-// sibling reuses it, a third overwrites qwen…), producing the cross-model
-// bouncing operators saw. A thread's first user message is stable across its
-// turns and distinct per sub-agent (each carries its own dispatch prompt), so
-// it separates the threads while keeping each one's pin (and prompt cache)
-// stable.
+// The first user message is load-bearing: Claude Code's metadata.user_id
+// identifies only device+account+session, not the sub-agent, so a main loop
+// and all its Task/Explore sub-agents share one user_id. Keying on user_id
+// alone collapsed them onto a single pin slot that concurrent threads then
+// thrashed (writes/overwrites racing across models). Each thread's first
+// user message is stable across turns but distinct per sub-agent, so it
+// separates them while keeping each pin (and prompt cache) stable.
 //
-// System text is deliberately excluded for the common (Anthropic) path: Claude
-// Code mutates the system prompt every turn (verified in repro — a fresh hash
-// each request), so folding it in would re-key every turn and evict the prompt
-// cache it exists to preserve. It is used only as a fallback for OpenAI-format
-// bodies, whose system lives inside messages[] and leaves the first user
-// message empty — without the fallback such conversations would collapse onto
-// one pin.
+// System text is excluded on the common Anthropic path because Claude Code
+// mutates it every turn, which would re-key (and evict the prompt cache) on
+// every request. It's used only as a fallback for OpenAI-format bodies,
+// where system lives in messages[] and the first user message is empty.
 func DeriveSessionKey(env *translate.RequestEnvelope, apiKeyID string) [sessionpin.SessionKeyLen]byte {
 	h := sha256.New()
 	h.Write([]byte(apiKeyID))
@@ -99,12 +85,8 @@ func DeriveSessionKey(env *translate.RequestEnvelope, apiKeyID string) [sessionp
 			h.Write([]byte(uid))
 			h.Write([]byte{0x00})
 		}
-		// OpenAI-format bodies carry `system` inside messages[], so their first
-		// message is often a system role and FirstUserMessageText is empty.
-		// Fall back to system text there so unrelated conversations that share
-		// an API key (and lack metadata.user_id) don't collapse onto one pin.
-		// Anthropic (Claude Code) keeps system out of messages[], so the first
-		// user message is populated and the volatile system prompt stays out.
+		// Fallback for OpenAI-format bodies (see doc comment above): without
+		// this, unrelated conversations sharing an API key would collapse.
 		disc := env.FirstUserMessageText()
 		if disc == "" {
 			disc = env.SystemText()

--- a/internal/proxy/subscription_internal_test.go
+++ b/internal/proxy/subscription_internal_test.go
@@ -41,10 +41,8 @@ func TestSubscriptionCredsFromHeaderValue(t *testing.T) {
 }
 
 func TestResolveAndInjectCredentials_SubscriptionHeaderBeatsBYOK(t *testing.T) {
-	// Router-keyed request (non-nil installation) carrying both a BYOK Anthropic
-	// key and the dedicated subscription header. The subscription must win, and
-	// it must be read past the router-key guard that normally skips inbound
-	// header extraction.
+	// Router-keyed request with both a BYOK key and the dedicated subscription
+	// header: subscription must win, read past the router-key guard.
 	ctx := context.Background()
 	ctx = context.WithValue(ctx, InstallationIDContextKey{}, testInstallationID)
 	ctx = context.WithValue(ctx, ExternalAPIKeysContextKey{}, []*auth.ExternalAPIKey{
@@ -79,10 +77,8 @@ func TestResolveAndInjectCredentials_SubscriptionHeaderIgnoredForNonAnthropic(t 
 }
 
 func TestResolveAndInjectCredentials_InboundSubscriptionBeatsBYOK(t *testing.T) {
-	// Self-hosted (no router key): an inbound Authorization subscription bearer
-	// must beat a present BYOK key so the turn bills at the 5% subscription fee,
-	// honoring the subscription -> BYOK -> deployment precedence explicitly
-	// rather than by coincidence of BYOK being absent off the router-key path.
+	// Self-hosted: inbound subscription bearer must beat BYOK (subscription ->
+	// BYOK -> deployment precedence), not just because BYOK happens to be absent.
 	ctx := context.WithValue(context.Background(), ExternalAPIKeysContextKey{}, []*auth.ExternalAPIKey{
 		{Provider: providers.ProviderAnthropic, Plaintext: []byte("sk-ant-api-byok")},
 	})
@@ -107,11 +103,9 @@ func TestResolveAndInjectCredentials_SelfHostedInboundSubscription(t *testing.T)
 }
 
 func TestResolveAndInjectCredentials_RouterKeyedInboundSubscription(t *testing.T) {
-	// Claude Code routed through the Weave Router: the router key authenticates
-	// via X-Weave-Router-Key (installation set), while CC leaves its own
-	// subscription OAuth token in Authorization. No dedicated header, no BYOK.
-	// The inbound bearer must resolve as the subscription credential so the turn
-	// bills at the 5% fee — the managed-CC case this path exists for.
+	// Managed CC: router key auth via X-Weave-Router-Key, CC's own subscription
+	// OAuth token in Authorization, no dedicated header, no BYOK. Inbound bearer
+	// must still resolve as the subscription credential.
 	ctx := context.WithValue(context.Background(), InstallationIDContextKey{}, testInstallationID)
 	headers := http.Header{"Authorization": []string{"Bearer sk-ant-oat01-subscription-token"}}
 	out := resolveAndInjectCredentials(ctx, providers.ProviderAnthropic, headers)
@@ -124,11 +118,8 @@ func TestResolveAndInjectCredentials_RouterKeyedInboundSubscription(t *testing.T
 }
 
 func TestResolveAndInjectCredentials_RouterKeyedInboundApiKeyNotForwarded(t *testing.T) {
-	// The router-key path still must NOT forward a general inbound API key: only
-	// the sk-ant-oat OAuth subset is honored. A real client API key in
-	// Authorization must resolve to no credential, so the deployment key (not the
-	// client's key) is the upstream fallback — preserving the cross-provider-leak
-	// guard the OAuth carve-out is careful not to widen.
+	// Router-key path must not forward a general inbound API key, only the
+	// sk-ant-oat OAuth subset — otherwise it'd widen the cross-provider-leak guard.
 	ctx := context.WithValue(context.Background(), InstallationIDContextKey{}, testInstallationID)
 	headers := http.Header{"Authorization": []string{"Bearer sk-ant-api-real-client-key"}}
 	out := resolveAndInjectCredentials(ctx, providers.ProviderAnthropic, headers)
@@ -139,9 +130,8 @@ func TestResolveAndInjectCredentials_RouterKeyedInboundApiKeyNotForwarded(t *tes
 const codexTestJWT = "eyJhbGciOiJSUzI1NiJ9.codex-access.signature"
 
 func TestResolveAndInjectCredentials_CodexDedicatedHeadersBeatBYOK(t *testing.T) {
-	// Router-keyed request with a BYOK OpenAI key and the dedicated Codex
-	// subscription headers. The subscription must win and be read past the
-	// router-key guard, mirroring the Anthropic dedicated-header path.
+	// Dedicated Codex headers must win over BYOK, read past the router-key
+	// guard — mirrors the Anthropic dedicated-header path.
 	ctx := context.WithValue(context.Background(), InstallationIDContextKey{}, testInstallationID)
 	ctx = context.WithValue(ctx, ExternalAPIKeysContextKey{}, []*auth.ExternalAPIKey{
 		{Provider: providers.ProviderOpenAI, Plaintext: []byte("sk-oai-byok")},
@@ -177,11 +167,9 @@ func TestResolveAndInjectCredentials_CodexInboundBeatsBYOK(t *testing.T) {
 }
 
 func TestResolveAndInjectCredentials_RouterKeyedInboundCodexSubscription(t *testing.T) {
-	// Codex CLI routed through the Weave Router: the router key authenticates via
-	// X-Weave-Router-Key (installation set), while Codex leaves its own ChatGPT
-	// auth in Authorization + ChatGPT-Account-ID. No dedicated header, no BYOK.
-	// The inbound bearer must resolve as the Codex subscription credential so the
-	// turn bills at the 5% fee — the managed-Codex case mirroring #460.
+	// Managed Codex: router key auth via X-Weave-Router-Key, Codex's own ChatGPT
+	// auth in Authorization + ChatGPT-Account-ID, no dedicated header, no BYOK.
+	// Inbound bearer must still resolve as Codex subscription (mirrors #460).
 	ctx := context.WithValue(context.Background(), InstallationIDContextKey{}, testInstallationID)
 	headers := http.Header{
 		"Authorization":      []string{"Bearer " + codexTestJWT},
@@ -197,10 +185,8 @@ func TestResolveAndInjectCredentials_RouterKeyedInboundCodexSubscription(t *test
 }
 
 func TestResolveAndInjectCredentials_RouterKeyedInboundOpenAIApiKeyNotForwarded(t *testing.T) {
-	// The router-key path still must NOT forward a general inbound OpenAI API key:
-	// only the Codex OAuth subset (JWT + ChatGPT-Account-ID) is honored. A plain
-	// client key in Authorization, with no account-id, must resolve to no
-	// credential so the deployment key is the upstream fallback.
+	// Router-key path must not forward a general inbound OpenAI key — only the
+	// Codex OAuth subset (JWT + ChatGPT-Account-ID) is honored.
 	ctx := context.WithValue(context.Background(), InstallationIDContextKey{}, testInstallationID)
 	headers := http.Header{"Authorization": []string{"Bearer sk-proj-real-client-key"}}
 	out := resolveAndInjectCredentials(ctx, providers.ProviderOpenAI, headers)
@@ -241,11 +227,8 @@ func TestCodexResponsesRequest(t *testing.T) {
 		assert.True(t, codexResponsesRequest(context.Background(), headers))
 	})
 	t.Run("inbound bearer + account-id on a router-keyed request", func(t *testing.T) {
-		// Managed Codex: the router key authenticates via X-Weave-Router-Key
-		// (installation set) while Codex CLI leaves its ChatGPT auth in
-		// Authorization, with no dedicated header. resolveAndInjectCredentials
-		// resolves this as the Codex subscription, so detection must agree and
-		// route to the Codex backend — not be gated on the installation's absence.
+		// Detection must agree with resolveAndInjectCredentials here: not
+		// gated on the installation's absence.
 		ctx := context.WithValue(context.Background(), InstallationIDContextKey{}, testInstallationID)
 		headers := http.Header{
 			"Authorization":      []string{"Bearer " + codexTestJWT},

--- a/internal/router/banditexplore/explorer.go
+++ b/internal/router/banditexplore/explorer.go
@@ -1,22 +1,13 @@
-// Package banditexplore wraps a content-aware router.Router with bounded
-// exploration over the quality-tie band, for collecting the propensity-logged
-// trajectories an off-policy estimator (and, later, a contextual bandit)
-// needs. It is OFF by default and ships behind an env flag — prod keeps
-// serving the wrapped router's deterministic argmax until a bake-off proves
-// exploration helps.
+// Package banditexplore wraps a router.Router with bounded exploration over
+// the quality-tie band, collecting the propensity-logged trajectories an
+// off-policy estimator needs. OFF by default behind an env flag until a
+// bake-off proves it helps.
 //
-// The exploration rule is deliberately the lowest-risk one: among the models
-// whose blended score is within `bandWidth` of the argmax (the "quality-tie
-// band" — models the scorer considers near-equivalent), pick uniformly at
-// random. Models clearly below the band are never touched, so a hard query is
-// never gambled on an inferior model. The probability the chosen model was
-// selected (1/|band|) is recorded as the decision's Propensity, which is the
-// importance weight Phase 2's IPS / doubly-robust estimator requires.
-//
-// This package depends only on the inner `router` interface and a provider
-// resolver injected at construction — it knows nothing about clustering,
-// artifacts, or the proxy. The wrapped router is unchanged; this is pure
-// composition.
+// Exploration only picks uniformly among models within `bandWidth` of the
+// argmax score (near-equivalent per the scorer); models clearly below the
+// band are never gambled on. The chosen model's selection probability
+// (1/|band|) is recorded as Propensity, the importance weight the IPS /
+// doubly-robust estimator requires.
 package banditexplore
 
 import (
@@ -31,8 +22,7 @@ import (
 )
 
 // ProviderForModel is a boot-time fallback resolver for a model's provider,
-// used only when the decision metadata carries no per-request binding. ok is
-// false when the model has no known deployment binding.
+// used when decision metadata carries no per-request binding.
 type ProviderForModel func(model string) (provider string, ok bool)
 
 // bandEntry is an in-band model paired with the provider that serves it.
@@ -45,19 +35,17 @@ type bandEntry struct {
 type Explorer struct {
 	inner       router.Router
 	providerFor ProviderForModel
-	// bandWidth is the score-unit half-width of the quality-tie band. A model
-	// is in-band iff score >= maxScore - bandWidth. <= 0 disables exploration.
+	// bandWidth: a model is in-band iff score >= maxScore - bandWidth. <= 0 disables exploration.
 	bandWidth float32
-	// intn returns a pseudo-random int in [0, n). Injected for deterministic
-	// tests; defaults to the concurrency-safe top-level rand/v2 generator.
+	// intn returns a pseudo-random int in [0, n); injected for deterministic tests.
 	intn func(n int) int
 }
 
 var _ router.Router = (*Explorer)(nil)
 
-// New constructs an Explorer. A non-positive bandWidth makes the explorer a
-// pure pass-through. providerFor is an optional boot-time fallback: when nil,
-// the explorer relies solely on the per-request bindings in decision metadata.
+// New constructs an Explorer. A non-positive bandWidth makes it a pure
+// pass-through. providerFor is optional; when nil, only per-request bindings
+// in decision metadata are used.
 func New(inner router.Router, providerFor ProviderForModel, bandWidth float32) *Explorer {
 	return &Explorer{
 		inner:       inner,
@@ -67,10 +55,9 @@ func New(inner router.Router, providerFor ProviderForModel, bandWidth float32) *
 	}
 }
 
-// Route delegates to the inner router, then — when exploration is enabled and
-// the decision exposes a multi-model score vector — may substitute an in-band
-// peer of the argmax pick. Any condition that makes exploration unsafe or
-// undefined returns the inner decision verbatim.
+// Route delegates to the inner router, then may substitute an in-band peer of
+// the argmax pick when exploration is enabled and safe. Otherwise returns the
+// inner decision verbatim.
 func (e *Explorer) Route(ctx context.Context, req router.Request) (router.Decision, error) {
 	dec, err := e.inner.Route(ctx, req)
 	if err != nil {
@@ -80,9 +67,8 @@ func (e *Explorer) Route(ctx context.Context, req router.Request) (router.Decisi
 		return dec, nil
 	}
 
-	// Restrict the band to servable peers before sampling so the logged
-	// propensity (1/|band|) is exact and a peer is only ever served via a
-	// request-valid provider binding. A singleton band has no peer to explore.
+	// Restrict to servable peers first so the logged propensity (1/|band|) is
+	// exact and every peer has a request-valid provider binding.
 	band := e.servableBand(dec)
 	if len(band) < 2 {
 		return dec, nil
@@ -91,17 +77,13 @@ func (e *Explorer) Route(ctx context.Context, req router.Request) (router.Decisi
 	argmaxModel := dec.Model
 	pick := band[e.intn(len(band))]
 	e.annotate(&dec, pick.model, pick.provider, len(band))
-	// When exploration changes the served model, isolate the semantic-cache
-	// key so a hit can't return another model's cached body. The cache keys on
-	// EffectiveKnobsHash (among embedding/cluster/version); mixing the model in
-	// only on a real switch keeps argmax-cache reuse intact when we draw it.
+	// On a real model switch, mix the model into the semantic-cache key so a
+	// hit can't return another model's cached body (leave it untouched when we
+	// draw the argmax, to preserve argmax-cache reuse).
 	if pick.model != argmaxModel && dec.Metadata != nil {
 		dec.Metadata.EffectiveKnobsHash = mixModel(dec.Metadata.EffectiveKnobsHash, pick.model)
-		// Only a real switch can collapse the band pair: the scorer's runner-up
-		// was computed against the argmax, so it may equal the now-served peer.
-		// Recompute it against the served model. When we draw the argmax the
-		// scorer's pair is already distinct, so leave its metadata untouched
-		// rather than overwrite it with our own tie-break.
+		// The scorer's runner-up was computed against the argmax and may now
+		// equal the served peer; recompute it against the served model.
 		e.repairBandPair(&dec.Metadata.PairedModel, &dec.Metadata.PairedProvider, &dec.Metadata.PairedScore, dec, pick.model)
 	}
 	return dec, nil
@@ -129,9 +111,9 @@ func (e *Explorer) shouldExplore(dec router.Decision) bool {
 	return md != nil && len(md.CandidateScores) >= 2
 }
 
-// servableBand returns in-band models (score >= max - bandWidth) paired with a
-// request-valid provider, sorted by name for reproducible sampling. The argmax
-// is always included; peers only when their provider resolves.
+// servableBand returns in-band models paired with a request-valid provider,
+// sorted by name for reproducible sampling. The argmax is always included;
+// peers only when their provider resolves.
 func (e *Explorer) servableBand(dec router.Decision) []bandEntry {
 	scores := dec.Metadata.CandidateScores
 	maxScore, ok := maxScore(scores)
@@ -194,8 +176,8 @@ func maxScore(scores map[string]float32) (float32, bool) {
 }
 
 // annotate rewrites the served model/provider and records the exploration
-// propensity (1/bandSize) and the chosen model's score on the metadata. The
-// scorer allocates Metadata fresh per call, so in-place mutation is safe.
+// propensity (1/bandSize) and chosen score on the metadata (safe to mutate
+// in place: the scorer allocates Metadata fresh per call).
 func (e *Explorer) annotate(dec *router.Decision, model, provider string, bandSize int) {
 	dec.Model = model
 	dec.Provider = provider
@@ -208,11 +190,10 @@ func (e *Explorer) annotate(dec *router.Decision, model, provider string, bandSi
 	}
 }
 
-// repairBandPair recomputes the band pair's runner-up after exploration has
-// rewritten the served model, writing it back through the metadata pointers.
-// It picks the highest-scoring servable peer other than served (tie-broken by
-// name for reproducibility), and clears the pair when no other model has a
-// resolvable provider — never leaving a runner-up equal to the served model.
+// repairBandPair recomputes the band pair's runner-up against the served
+// model, writing it back through the metadata pointers. Picks the
+// highest-scoring servable peer other than served (ties broken by name);
+// clears the pair if none has a resolvable provider.
 func (e *Explorer) repairBandPair(outModel, outProvider *string, outScore *float32, dec router.Decision, served string) {
 	scores := dec.Metadata.CandidateScores
 	models := make([]string, 0, len(scores))

--- a/internal/router/cache/cache.go
+++ b/internal/router/cache/cache.go
@@ -1,7 +1,6 @@
-// Package cache implements a semantic response cache. Short-circuits
-// near-duplicate non-streaming requests by cosine similarity on prompt
-// embedding; per-(installation, inbound-format) isolation. Entries expire
-// lazily on Lookup once they exceed the configured TTL.
+// Package cache short-circuits near-duplicate non-streaming requests by cosine
+// similarity on prompt embedding, isolated per (installation, inbound-format).
+// Entries expire lazily on Lookup once past the configured TTL.
 package cache
 
 import (
@@ -29,15 +28,13 @@ type Config struct {
 	// BucketSize caps each per-(installation, format, clusterID, clusterVersion,
 	// knobsHash) LRU.
 	BucketSize int
-	// MaxBucketsPerInstallation caps the number of distinct buckets each
-	// installation may hold. Bucket identity includes attacker-influenceable
-	// inputs (cluster version, knobs hash), so without a per-installation cap
-	// one tenant could vary x-weave-routing-* headers to evict other tenants'
-	// buckets out of a shared global LRU.
+	// MaxBucketsPerInstallation caps buckets per installation. Bucket identity
+	// includes attacker-influenceable inputs (cluster version, knobs hash), so
+	// without this cap one tenant could vary x-weave-routing-* headers to evict
+	// other tenants' buckets from a shared global LRU.
 	MaxBucketsPerInstallation int
-	// MaxInstallations caps the number of distinct installations tracked.
-	// Installations come from authenticated bearer tokens, not request
-	// headers, so this is defense in depth.
+	// MaxInstallations caps tracked installations. Defense in depth since
+	// installations come from bearer tokens, not request headers.
 	MaxInstallations int
 	TTL              time.Duration
 	MaxBodyBytes     int
@@ -57,11 +54,9 @@ func DefaultConfig() Config {
 
 // Cache is the in-memory semantic cache. Concurrent-safe.
 //
-// Per-bucket TTL is implemented with `storedAt` on each entry checked
-// lazily by Lookup, not via a background goroutine. expirable.LRU was
-// the obvious fit but its v2.0.7 cleanup goroutine has no public
-// shutdown — using it for inner buckets would leak one goroutine per
-// evicted bucket whenever an installation churned past
+// TTL is enforced lazily via `storedAt` on Lookup, not a background goroutine:
+// expirable.LRU's v2.0.7 cleanup goroutine has no public shutdown, so using it
+// for inner buckets would leak one goroutine per bucket evicted past
 // MaxBucketsPerInstallation.
 type Cache struct {
 	cfg           Config
@@ -142,9 +137,8 @@ func (c *Cache) thresholdFor(clusterID int) float32 {
 	return c.cfg.DefaultThreshold
 }
 
-// Lookup walks buckets for (installation, format, clusterIDs) and
-// returns the first entry whose cosine clears the threshold.
-// embedding must be L2-normalized; clusterIDs order is irrelevant.
+// Lookup walks buckets for (installation, format, clusterIDs) and returns the
+// first entry whose cosine clears the threshold. embedding must be L2-normalized.
 func (c *Cache) Lookup(installationID string, format Format, embedding []float32, clusterIDs []int, clusterVersion string, knobsHash uint64) (CachedResponse, bool) {
 	if c == nil || len(embedding) == 0 || len(clusterIDs) == 0 {
 		return CachedResponse{}, false
@@ -198,10 +192,8 @@ func (c *Cache) Store(installationID string, format Format, embedding []float32,
 	})
 }
 
-// bucket returns the LRU for a key. create=false returns nil for missing
-// buckets (lookup path); create=true allocates lazily, capping per-
-// installation so one tenant cannot churn knob hashes to evict another's
-// buckets.
+// bucket returns the LRU for a key. create=false returns nil if missing
+// (lookup path); create=true allocates lazily, capped per-installation.
 func (c *Cache) bucket(installationID string, format Format, clusterID int, clusterVersion string, knobsHash uint64, create bool) *lru.Cache[entryKey, *entry] {
 	key := bucketKey{
 		format:         format,

--- a/internal/router/catalog/catalog_test.go
+++ b/internal/router/catalog/catalog_test.go
@@ -79,9 +79,7 @@ func TestPriceFor_KnownPair(t *testing.T) {
 }
 
 func TestResolveBinding_PicksFirstAvailable(t *testing.T) {
-	// Hypothetical: build a synthetic model with ordered fallback to
-	// verify the resolver respects ordering. Use a real one: claude-opus-4-7
-	// only has anthropic — should only resolve when anthropic is available.
+	// claude-opus-4-7 is anthropic-only, so it should resolve only when anthropic is available.
 	avail := map[string]struct{}{providers.ProviderAnthropic: {}}
 	b, ok := ResolveBinding("claude-opus-4-7", avail)
 	require.True(t, ok)
@@ -110,11 +108,8 @@ func TestAllowedAtOrBelow_FiltersOutUnknownTier(t *testing.T) {
 }
 
 func TestToolUseLowSet_IncludesQwen3_235BInstruct(t *testing.T) {
-	// Production traffic on 2026-05-23 saw Instruct-2507 emit narrative
-	// "I edited the file" without tool_use blocks — flagged ToolUseLow so
-	// the cluster scorer excludes it from agentic argmax. If this assertion
-	// fires, either the entry was downgraded back to ToolUseUnknown or the
-	// catalog row was renamed.
+	// Instruct-2507 emits narrative text instead of tool_use blocks (seen in prod
+	// 2026-05-23), so it's flagged ToolUseLow to exclude it from agentic argmax.
 	set := ToolUseLowSet()
 	_, found := set["qwen/qwen3-235b-a22b-2507"]
 	assert.True(t, found, "qwen/qwen3-235b-a22b-2507 must be marked ToolUseLow")
@@ -129,20 +124,16 @@ func TestToolUseLowSet_OmitsHealthyModels(t *testing.T) {
 }
 
 func TestModel_ToolUseQualityDefaultsToUnknown(t *testing.T) {
-	// Zero-value safety: an unset ToolUseQuality must default to
-	// ToolUseUnknown so the scorer treats the model as healthy until
-	// proven otherwise. Guards against a future iota reorder that would
-	// silently flip every catalog row to ToolUseLow.
+	// Zero-value must default to ToolUseUnknown (healthy) so a future iota
+	// reorder can't silently flip every catalog row to ToolUseLow.
 	var m Model
 	assert.Equal(t, ToolUseUnknown, m.ToolUseQuality)
 }
 
 func TestAgenticLowSet_IncludesHarnessIncapableModels(t *testing.T) {
-	// These models emit valid tool calls (so they are not ToolUseLow) but can't
-	// sustain an agentic harness loop, so they must be dropped from has_tools
-	// turns — otherwise a price-leaning dial demotes Opus straight onto one of
-	// them (minimax-m3 grepping for a skill instead of running it is the
-	// canonical failure). If this fires, a row was unflagged or renamed.
+	// These models emit valid tool calls but can't sustain an agentic harness
+	// loop, so they're dropped from has_tools turns (minimax-m3 grepping for a
+	// skill instead of running it is the canonical failure).
 	set := AgenticLowSet()
 	for _, id := range []string{
 		"minimax/minimax-m3",
@@ -156,9 +147,8 @@ func TestAgenticLowSet_IncludesHarnessIncapableModels(t *testing.T) {
 }
 
 func TestAgenticLowSet_OmitsHarnessCapableModels(t *testing.T) {
-	// The harness-capable demotion ladder must stay eligible on has_tools turns:
-	// Opus -> Sonnet -> the cheaper capable coders. haiku stays eligible too (it
-	// is a legitimate cheap tool model), so it must NOT be flagged.
+	// Demotion ladder (Opus -> Sonnet -> cheaper capable coders) plus haiku, a
+	// legitimate cheap tool model, must all stay eligible on has_tools turns.
 	set := AgenticLowSet()
 	for _, id := range []string{
 		"claude-opus-4-8",
@@ -175,17 +165,15 @@ func TestAgenticLowSet_OmitsHarnessCapableModels(t *testing.T) {
 }
 
 func TestModel_AgenticUseDefaultsToUnknown(t *testing.T) {
-	// Zero-value safety: an unset AgenticUse must default to AgenticUnknown so
-	// the scorer treats the model as harness-capable until proven otherwise.
-	// Guards against a future iota reorder flipping every row to AgenticLow.
+	// Zero-value must default to AgenticUnknown (harness-capable) so a future
+	// iota reorder can't silently flip every row to AgenticLow.
 	var m Model
 	assert.Equal(t, AgenticUnknown, m.AgenticUse)
 }
 
 func TestImageUnsupportedSet_IncludesTextOnlyModels(t *testing.T) {
-	// Text-only OSS models reject image content parts with a 4xx (DeepInfra
-	// 405 "does not accept image input" on GLM-5.1 is the canonical case).
-	// They must be flagged so the scorer keeps image-bearing turns off them.
+	// Text-only OSS models reject image parts with a 4xx (DeepInfra 405 on
+	// GLM-5.1 is the canonical case), so they must be flagged.
 	set := ImageUnsupportedSet()
 	for _, id := range []string{"z-ai/glm-5.1", "z-ai/glm-5", "deepseek/deepseek-v4-pro", "moonshotai/kimi-k2.6", "qwen/qwen3-coder"} {
 		_, found := set[id]
@@ -194,9 +182,8 @@ func TestImageUnsupportedSet_IncludesTextOnlyModels(t *testing.T) {
 }
 
 func TestImageUnsupportedSet_OmitsMultimodalModels(t *testing.T) {
-	// First-party models (Anthropic / OpenAI / Google) are all multimodal and
-	// must keep the default. mistral-small-2603 is a multimodal OSS row and is
-	// deliberately left unflagged.
+	// First-party models are all multimodal; mistral-small-2603 is a
+	// multimodal OSS row and is deliberately left unflagged too.
 	set := ImageUnsupportedSet()
 	for _, id := range []string{"claude-opus-4-7", "gpt-5.5", "gemini-3.1-pro-preview", "mistralai/mistral-small-2603"} {
 		_, found := set[id]
@@ -213,9 +200,8 @@ func TestAcceptsImages(t *testing.T) {
 }
 
 func TestModel_ImageInputDefaultsToUnknown(t *testing.T) {
-	// Zero-value safety: an unset ImageInput must default to ImageInputUnknown
-	// (treated as image-capable) so a new first-party model is never silently
-	// excluded from image turns.
+	// Zero-value must default to ImageInputUnknown (image-capable) so a new
+	// first-party model is never silently excluded from image turns.
 	var m Model
 	assert.Equal(t, ImageInputUnknown, m.ImageInput)
 }

--- a/internal/router/catalog/lookup.go
+++ b/internal/router/catalog/lookup.go
@@ -30,9 +30,8 @@ func ByID(id string) (Model, bool) {
 	return Model{}, false
 }
 
-// ResolveBinding returns the first ProviderBinding whose Provider name is
-// in `available`. Used at boot by the cluster scorer to pick which
-// upstream serves each routable model.
+// ResolveBinding returns the first ProviderBinding whose Provider is in
+// `available`. Used at boot to pick each routable model's upstream.
 func ResolveBinding(id string, available map[string]struct{}) (ProviderBinding, bool) {
 	m, ok := ByID(id)
 	if !ok {
@@ -46,11 +45,9 @@ func ResolveBinding(id string, available map[string]struct{}) (ProviderBinding, 
 	return ProviderBinding{}, false
 }
 
-// AvailableBindings returns every ProviderBinding for the model whose
-// Provider name is in `available`, in catalog order. Used by the proxy's
-// per-request failover loop: index 0 is the primary, indexes >0 are
-// ordered fallbacks. Empty result means the model has no binding under
-// the available set.
+// AvailableBindings returns every ProviderBinding for the model whose Provider
+// is in `available`, in catalog order. Used by the proxy's failover loop:
+// index 0 is primary, indexes >0 are ordered fallbacks.
 func AvailableBindings(id string, available map[string]struct{}) []ProviderBinding {
 	m, ok := ByID(id)
 	if !ok {
@@ -65,8 +62,7 @@ func AvailableBindings(id string, available map[string]struct{}) []ProviderBindi
 	return out
 }
 
-// PriceFor returns the per-(provider, model) pricing. Used by the planner
-// when both pin and fresh have a resolved provider.
+// PriceFor returns the per-(provider, model) pricing.
 func PriceFor(provider, id string) (Pricing, bool) {
 	m, ok := ByID(id)
 	if !ok {
@@ -80,9 +76,8 @@ func PriceFor(provider, id string) (Pricing, bool) {
 	return Pricing{}, false
 }
 
-// PrimaryPriceFor returns the pricing of the first (primary) binding for
-// the given model. Used by call sites (OTel emitter, billing debit hook,
-// install-script generation) that don't yet thread provider through.
+// PrimaryPriceFor returns the pricing of the model's first (primary) binding,
+// for call sites that don't thread a specific provider through.
 func PrimaryPriceFor(id string) (Pricing, bool) {
 	m, ok := ByID(id)
 	if !ok {
@@ -104,8 +99,8 @@ func TierFor(id string) Tier {
 }
 
 // ThinkTagReasoningFor reports whether the model streams chain-of-thought as
-// inline <think>…</think> in the content channel (so the Anthropic translator
-// should reroute it into thinking). Unknown models return false.
+// inline <think>…</think> in content (the Anthropic translator reroutes it
+// into thinking). Unknown models return false.
 func ThinkTagReasoningFor(id string) bool {
 	m, ok := ByID(id)
 	if !ok {
@@ -150,11 +145,9 @@ func ContextWindowFor(id string) int {
 	return m.ContextWindow
 }
 
-// ToolUseLowSet returns the set of model IDs whose ToolUseQuality is
-// ToolUseLow. The cluster scorer subtracts this set from the eligible pool
-// when req.HasTools is true; falls back to the unfiltered pool when the
-// subtraction would empty the eligible set so a routing decision is always
-// returned.
+// ToolUseLowSet returns model IDs with ToolUseLow quality. The cluster scorer
+// excludes these when req.HasTools, falling back to the unfiltered pool if
+// that would empty the eligible set.
 func ToolUseLowSet() map[string]struct{} {
 	out := make(map[string]struct{}, len(Models))
 	for _, m := range Models {
@@ -165,13 +158,10 @@ func ToolUseLowSet() map[string]struct{} {
 	return out
 }
 
-// AgenticLowSet returns the set of model IDs whose AgenticUse is AgenticLow —
-// models that emit valid tool calls but can't sustain an agentic harness loop.
-// The cluster scorer subtracts this set from the eligible pool when req.HasTools
-// is true (on top of the ToolUseLow subtraction), so the price/quality dial
-// demotes Opus to a cheaper harness-capable model rather than the cheapest model
-// in the pool. Falls back to the unfiltered pool when the subtraction would empty
-// the eligible set so a routing decision is always returned. Mirrors ToolUseLowSet.
+// AgenticLowSet returns model IDs whose AgenticUse is AgenticLow — models that
+// emit valid tool calls but can't sustain an agentic harness loop. Excluded
+// alongside ToolUseLowSet so a cost demotion lands on a harness-capable model,
+// not just the cheapest one. Mirrors ToolUseLowSet's fallback behavior.
 func AgenticLowSet() map[string]struct{} {
 	out := make(map[string]struct{}, len(Models))
 	for _, m := range Models {
@@ -182,11 +172,9 @@ func AgenticLowSet() map[string]struct{} {
 	return out
 }
 
-// ImageUnsupportedSet returns the set of model IDs flagged
-// ImageInputUnsupported. The cluster scorer subtracts this set from the
-// eligible pool when the inbound request carries image content, falling back
-// to the unfiltered pool when the subtraction would empty the eligible set so
-// a routing decision is always returned. Mirrors ToolUseLowSet.
+// ImageUnsupportedSet returns model IDs flagged ImageInputUnsupported,
+// excluded when the request carries image content. Mirrors ToolUseLowSet's
+// fallback behavior.
 func ImageUnsupportedSet() map[string]struct{} {
 	out := make(map[string]struct{}, len(Models))
 	for _, m := range Models {
@@ -197,10 +185,9 @@ func ImageUnsupportedSet() map[string]struct{} {
 	return out
 }
 
-// AcceptsImages reports whether the model accepts image content parts. Unknown
-// models and models with no ImageInput flag are treated as image-capable — only
-// an explicit ImageInputUnsupported flag returns false. Used by the turn loop to
-// evict a text-only session pin when the current turn carries an image.
+// AcceptsImages reports whether the model accepts image content. Unknown
+// models default to true; only an explicit ImageInputUnsupported flag
+// returns false.
 func AcceptsImages(id string) bool {
 	m, ok := ByID(id)
 	if !ok {
@@ -209,9 +196,8 @@ func AcceptsImages(id string) bool {
 	return m.ImageInput != ImageInputUnsupported
 }
 
-// AllPrimaryPricing returns a copy of the primary-binding pricing for
-// every known model, keyed by model ID. Used by the OTel emitter and the
-// genprices install-script generator.
+// AllPrimaryPricing returns primary-binding pricing for every known model,
+// keyed by model ID.
 func AllPrimaryPricing() map[string]Pricing {
 	out := make(map[string]Pricing, len(Models))
 	for _, m := range Models {
@@ -223,9 +209,8 @@ func AllPrimaryPricing() map[string]Pricing {
 	return out
 }
 
-// ValidateDeployed returns an error naming any deployed model missing
-// from the catalog or lacking a tier. Called once at boot against the
-// cluster scorer's deployed-model set.
+// ValidateDeployed returns an error naming any deployed model missing from
+// the catalog or lacking a tier.
 func ValidateDeployed(deployed []string) error {
 	var missing []string
 	for _, id := range deployed {

--- a/internal/router/cluster/embedder_onnx.go
+++ b/internal/router/cluster/embedder_onnx.go
@@ -14,18 +14,16 @@ import (
 	"github.com/knights-analytics/hugot/pipelines"
 )
 
-// Each embedder's model.onnx and tokenizer.json live under
-// <assetsRoot>/<EmbedderSpec.AssetSubdir>/. Override the root with
-// ROUTER_ONNX_ASSETS_DIR for local dev.
+// Model files live under <assetsRoot>/<EmbedderSpec.AssetSubdir>/; override
+// the root with ROUTER_ONNX_ASSETS_DIR for local dev.
 const defaultAssetsDir = "/opt/router/assets"
 
 // minModelSizeBytes catches unpopulated HF downloads or placeholders.
 // Real INT8-quantized embedders are >100 MB.
 const minModelSizeBytes = 1 << 20
 
-// onnxEmbedder is the production Embedder for one EmbedderSpec. The
-// pipeline is goroutine-safe so one instance serves all requests; the
-// hugot session is owned by the EmbedderSet, not the embedder.
+// onnxEmbedder is the production Embedder for one EmbedderSpec. The pipeline
+// is goroutine-safe (one instance serves all requests); EmbedderSet owns the hugot session.
 type onnxEmbedder struct {
 	spec     EmbedderSpec
 	pipeline *pipelines.FeatureExtractionPipeline
@@ -39,9 +37,8 @@ func resolveAssetsDir() string {
 	return defaultAssetsDir
 }
 
-// assetsDirForSpec resolves the model directory for a spec. The Jina
-// embedder falls back to the flat legacy layout (<root>/model.onnx)
-// when its subdir is absent, so existing local-dev setups keep working.
+// assetsDirForSpec resolves the model directory for a spec. Jina falls back
+// to the flat legacy layout (<root>/model.onnx) if its subdir is absent.
 func assetsDirForSpec(spec EmbedderSpec) string {
 	root := resolveAssetsDir()
 	dir := filepath.Join(root, spec.AssetSubdir)
@@ -56,13 +53,12 @@ func assetsDirForSpec(spec EmbedderSpec) string {
 	return dir
 }
 
-// newONNXEmbedder builds the feature-extraction pipeline for one spec on
-// a shared hugot session.
+// newONNXEmbedder builds the feature-extraction pipeline for one spec on a
+// shared hugot session.
 //
-// Pooling contract: the Jina export emits token-level (3D) outputs which
-// hugot mean-pools; the Qwen3 export bakes last-token pooling into the
-// graph and emits a pooled (2D) output which hugot returns as-is. Both
-// are L2-normalized via WithNormalization.
+// Pooling: Jina emits token-level (3D) output that hugot mean-pools; Qwen3
+// bakes last-token pooling into the graph and emits pooled (2D) output as-is.
+// Both are L2-normalized via WithNormalization.
 func newONNXEmbedder(session *hugot.Session, spec EmbedderSpec) (*onnxEmbedder, error) {
 	assetsDir := assetsDirForSpec(spec)
 	modelPath := filepath.Join(assetsDir, "model.onnx")
@@ -93,9 +89,8 @@ func newONNXEmbedder(session *hugot.Session, spec EmbedderSpec) (*onnxEmbedder, 
 	return &onnxEmbedder{spec: spec, pipeline: pipeline}, nil
 }
 
-// Embed runs the pipeline on a single text. ctx is ignored because hugot
-// v0.7.0's RunPipeline doesn't accept one; scorer.Route races this call
-// against context.WithTimeout in a goroutine instead.
+// Embed runs the pipeline on a single text. ctx is ignored — hugot v0.7.0's
+// RunPipeline has no ctx param; scorer.Route races this call in a goroutine instead.
 func (e *onnxEmbedder) Embed(_ context.Context, text string) ([]float32, error) {
 	out, err := e.pipeline.RunPipeline([]string{text})
 	if err != nil {
@@ -119,10 +114,9 @@ func (e *onnxEmbedder) Dim() int { return e.spec.Dim }
 
 var _ Embedder = (*onnxEmbedder)(nil)
 
-// EmbedderSet lazily constructs and caches one Embedder per registered
-// spec, all sharing a single ORT session. Construct in the composition
-// root; Get only the IDs the built artifact versions require so prod
-// (single default version) loads exactly one model into memory.
+// EmbedderSet lazily constructs and caches one Embedder per registered spec,
+// sharing a single ORT session. Get only the IDs the built artifact versions
+// require, so prod (single default version) loads exactly one model.
 type EmbedderSet struct {
 	mu        sync.Mutex
 	session   *hugot.Session
@@ -203,9 +197,8 @@ type StandaloneEmbedder struct {
 // Close releases the underlying ORT session. Idempotent.
 func (s *StandaloneEmbedder) Close() error { return s.set.Close() }
 
-// NewEmbedder constructs a standalone Jina v2 embedder with its own
-// session. Retained for the parity integration tests; the composition
-// root uses NewEmbedderSet directly.
+// NewEmbedder constructs a standalone Jina v2 embedder with its own session.
+// Retained for parity integration tests; the composition root uses NewEmbedderSet directly.
 func NewEmbedder() (*StandaloneEmbedder, error) {
 	set, err := NewEmbedderSet()
 	if err != nil {

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -4,21 +4,18 @@ package router
 import "context"
 
 type Overrides struct {
-	// Alpha is the raw per-cluster quality weight, applied UNIFORMLY across
-	// every cluster (the "sledgehammer"). This is the eval/debug lever set by
-	// the x-weave-routing-alpha header; it deliberately ignores per-cluster
-	// quality dispersion so a bake-off can probe a single global alpha.
+	// Alpha is the raw per-cluster quality weight applied UNIFORMLY across every
+	// cluster (the eval/debug "sledgehammer" set via x-weave-routing-alpha), so
+	// a bake-off can probe a single global alpha regardless of per-cluster
+	// quality dispersion.
 	Alpha *float64
-	// QualityBias is the user-facing "quality vs price" dial in [0, 1] (0 =
-	// fully price, 1 = fully quality). Unlike Alpha, the scorer maps it through
-	// a per-bundle calibration (see dialToAlpha / computeDialCalibration) that
-	// places the dial's travel where the routed model mix actually changes, so
-	// the slider's midrange produces a real model mix instead of a dead zone.
-	// The endpoints still pin to all-cheapest (0) and best-per-cluster top
-	// quality (1). Set by the per-installation routing-preference dial.
-	// routingKnobsForRequest returns either the header knobs or the installation
-	// knobs, never a merge, so Alpha and QualityBias do not normally coexist; if
-	// both are set, QualityBias wins (it is the higher-level intent).
+	// QualityBias is the user-facing "quality vs price" dial in [0, 1]. Unlike
+	// Alpha, it's mapped through a per-bundle calibration (dialToAlpha /
+	// computeDialCalibration) so the slider's midrange moves the routed model
+	// mix instead of hitting a dead zone; endpoints still pin to all-cheapest
+	// (0) and best-per-cluster quality (1). routingKnobsForRequest returns
+	// either header or installation knobs, never a merge, so if both Alpha and
+	// QualityBias are set, QualityBias wins.
 	QualityBias          *float64
 	SpeedWeight          *float64
 	OutputCostRatio      *float64
@@ -30,9 +27,8 @@ type Request struct {
 	RequestedModel       string
 	EstimatedInputTokens int
 	HasTools             bool
-	// HasImages is true when the request carries image content. The scorer
-	// drops text-only models from the eligible pool; the turn loop evicts a
-	// text-only session pin.
+	// HasImages: scorer drops text-only models from the eligible pool; turn
+	// loop evicts a text-only session pin.
 	HasImages  bool
 	PromptText string
 	// Per-request provider gating — nil means unrestricted.
@@ -40,24 +36,19 @@ type Request struct {
 	// Per-request model exclusion — nil or empty means no exclusion.
 	// If filtering empties eligible set, scorer returns ErrNoEligibleProvider.
 	ExcludedModels map[string]struct{}
-	// PreferredModels is the per-installation model priority ranking, in
-	// descending preference (index 0 = first preference). The scorer lifts each
-	// preferred model's blended score by a small, rank-decaying additive bonus
-	// (a soft "finger on the scale") so a preferred model wins close calls but
-	// never overrides a clearly-better model for the task. Entries not in the
-	// eligible pool are ignored. nil or empty means no preference.
+	// PreferredModels is the per-installation priority ranking (index 0 =
+	// first). The scorer adds a small rank-decaying bonus to each preferred
+	// model's score — enough to win close calls, not to override a clearly
+	// better model. Entries not in the eligible pool are ignored.
 	PreferredModels []string
 	RoutingKnobs    *Overrides // NEW: parsed dynamic knobs
 	// SubsidizedModelCostFactor is the per-model rate-limit headroom factor in
-	// [epsilon, 1] for models a caller's presented subscription covers, derived
-	// from observed headroom (see internal/proxy/usage): ~epsilon when the sub's
-	// window has slack, rising to 1 as the window binds. Absent entry = no
-	// subsidy; nil/empty = today's behavior. The cluster scorer reads it as a
-	// PREFERENCE signal — it lifts a covered model's score by a uniform per-family
-	// bonus proportional to (1−factor), leaving the cost axis at full catalog so
-	// the intra-family Haiku↔Opus spread is preserved. (The planner, separately,
-	// still reads it as a literal cost multiplier for its dollar-EV cache-switch
-	// math, where a prepaid model's marginal price really is ~factor×catalog.)
+	// [epsilon, 1] for models the caller's subscription covers (see
+	// internal/proxy/usage): ~epsilon when the window has slack, rising to 1 as
+	// it binds. Absent = no subsidy. The cluster scorer treats it as a
+	// preference signal (score bonus proportional to 1−factor, cost axis left
+	// at full catalog so Haiku↔Opus spread is preserved); the planner instead
+	// treats it as a literal cost multiplier for dollar-EV cache-switch math.
 	SubsidizedModelCostFactor map[string]float64
 }
 
@@ -78,27 +69,22 @@ type RoutingMetadata struct {
 	ChosenScore          float32
 	ClusterRouterVersion string
 	EffectiveKnobsHash   uint64 // NEW: canonical knobs hash for response-cache isolation
-	// CandidateScores is the full pre-argmax blended score per eligible model.
-	// Surfaced for off-policy analysis (the substrate a contextual bandit needs);
-	// nil for routers that don't compute a score vector. Does not affect routing.
+	// CandidateScores: full pre-argmax blended score per eligible model, for
+	// off-policy analysis (contextual bandit substrate). Doesn't affect routing.
 	CandidateScores map[string]float32
-	// CandidateProviders is the per-request resolved provider for each eligible
-	// model, so an exploration policy can switch to an in-band peer using this
-	// request's binding (correct under BYOK) instead of a boot-time default.
-	// nil for routers that don't resolve providers. Does not affect routing.
+	// CandidateProviders: per-request resolved provider per eligible model, so
+	// an exploration policy can switch to an in-band peer using this request's
+	// binding (correct under BYOK) rather than a boot-time default.
 	CandidateProviders map[string]string
 	// Propensity is the probability the chosen model was selected under the
-	// acting policy. 1.0 for a deterministic argmax; <1.0 only when an
-	// exploration policy randomizes. Logged so logged decisions carry the
-	// importance weight an off-policy estimator requires.
+	// acting policy: 1.0 for deterministic argmax, <1.0 under exploration.
+	// Logged as the importance weight an off-policy estimator needs.
 	Propensity float32
-	// PairedModel is the runner-up — the second-highest-scoring eligible model
-	// for this request, the other half of the {Model, PairedModel} band pair
-	// Stage 1 freezes into the session pin so a later per-turn policy can swap
-	// between the two without re-running the scorer. Empty when only one model
-	// is eligible. PairedProvider is its per-request resolved provider binding;
-	// PairedScore is its blended score (same scale as ChosenScore). These are
-	// informational — they do not affect this request's routing.
+	// PairedModel is the runner-up model — the other half of the {Model,
+	// PairedModel} band pair Stage 1 freezes into the session pin so a later
+	// per-turn policy can swap without re-running the scorer. Empty when only
+	// one model is eligible. PairedProvider/PairedScore are informational and
+	// don't affect this request's routing.
 	PairedModel    string
 	PairedProvider string
 	PairedScore    float32

--- a/internal/router/turntype/detect.go
+++ b/internal/router/turntype/detect.go
@@ -1,6 +1,5 @@
-// Package turntype classifies inbound conversation requests by role,
-// independent of wire format. Pure, I/O-free helper used by the proxy
-// service for role-conditioned routing.
+// Package turntype classifies inbound conversation turns by role, independent
+// of wire format, for role-conditioned routing.
 package turntype
 
 import (
@@ -31,9 +30,8 @@ const (
 
 const probeMaxTokensThreshold = 4
 
-// classifier thresholds bound the Classifier type to short-form calls.
-// Claude Code's security monitor uses max_tokens=64, message_count=2;
-// headroom for similar classifiers without catching real main-loop turns.
+// Bounds for short-form classifier calls (e.g. Claude Code's security monitor:
+// max_tokens=64, message_count=2). Headroom for similar calls without catching main-loop turns.
 const (
 	classifierMaxTokensThreshold = 256
 	classifierMaxMessageCount    = 3
@@ -42,9 +40,8 @@ const (
 // DetectFromEnvelope classifies an inbound request. subAgentHint is the
 // optional x-weave-subagent-type header value.
 //
-// Conservative: false negatives (returning MainLoop) are safe — the
-// cluster scorer runs normally. False positives are the real risk; each
-// heuristic is intentionally tight.
+// Conservative by design: false negatives (MainLoop) are safe, false
+// positives aren't, so each heuristic below is intentionally tight.
 func DetectFromEnvelope(env *translate.RequestEnvelope, feats translate.RoutingFeatures, subAgentHint string) TurnType {
 	if env == nil {
 		return MainLoop
@@ -57,10 +54,9 @@ func DetectFromEnvelope(env *translate.RequestEnvelope, feats translate.RoutingF
 		return TitleGen
 	}
 	systemText := env.SystemText()
-	// Compaction is a Claude-Code-only signal and Claude Code always talks
-	// Anthropic wire format. Gating on format keeps Codex / OpenAI clients —
-	// whose system prompts can incidentally mention "compact" and
-	// "conversation" — out of the hard pin.
+	// Compaction is Claude-Code-only, and Claude Code always talks Anthropic
+	// format. Gating on format keeps Codex/OpenAI clients — whose prompts can
+	// incidentally mention "compact" — out of the hard pin.
 	if env.SourceFormat() == translate.FormatAnthropic && isCompaction(systemText) {
 		return Compaction
 	}
@@ -80,14 +76,10 @@ func isProbe(feats translate.RoutingFeatures) bool {
 	return feats.MaxTokens > 0 && feats.MaxTokens <= probeMaxTokensThreshold
 }
 
-// isClassifier reports whether a request is a short-form classifier call.
-// Three structural signals, all required:
-//  1. No tools — real Claude Code turns always carry the tool registry.
-//  2. max_tokens within classifierMaxTokensThreshold.
-//  3. message_count within classifierMaxMessageCount.
-//
-// Probe (max_tokens<=4) is checked first and wins. False negatives are
-// safe; false positives would hard-pin a real conversation — hence tight.
+// isClassifier reports whether a request is a short-form classifier call:
+// no tools (real Claude Code turns always carry the tool registry), plus
+// max_tokens/message_count within their thresholds. Checked after Probe.
+// Tight on purpose — a false positive would hard-pin a real conversation.
 func isClassifier(feats translate.RoutingFeatures) bool {
 	if feats.HasTools {
 		return false
@@ -101,12 +93,8 @@ func isClassifier(feats translate.RoutingFeatures) bool {
 	return true
 }
 
-// isTitleGen reports whether a request is Claude Code's sidebar-title
-// generation call. Two structural signals:
-//  1. Declares a JSON-schema response format with top-level "title" string
-//     property — asking the model to emit {"title": "..."}.
-//  2. tools is empty — a real conversation with structured output still
-//     carries the tool registry.
+// isTitleGen reports whether a request is Claude Code's sidebar-title call:
+// no tools, plus a JSON-schema response format asking for {"title": "..."}.
 func isTitleGen(env *translate.RequestEnvelope, hasTools bool) bool {
 	if hasTools {
 		return false
@@ -121,19 +109,13 @@ func isCompaction(systemText string) bool {
 	return strings.Contains(lower, "your task is to create a detailed summary")
 }
 
-// isSubAgentDispatch reports whether the request originates from a
-// sub-agent. Three independent signals:
-//  1. x-weave-subagent-type header.
-//  2. metadata.user_id starting with "subagent:".
-//  3. First user message wrapped in "<transcript>...</transcript>"
-//     (Claude Code's Agent tool convention).
-//
-// "<transcript>" lives in the user-message body, not the system prompt —
-// earlier attempt matching "subagent_type" in system text false-positived
-// on every main-loop turn exposing the Agent tool description.
-//
-// Sniff bounded prefix so a stray "<transcript>" deep in content can't
-// trigger on long main-loop turns.
+// isSubAgentDispatch reports whether the request originates from a sub-agent:
+// the x-weave-subagent-type header, a "subagent:" metadata.user_id prefix, or
+// a "<transcript>" tag (Claude Code's Agent tool convention) near the start
+// of the first user message. Matching in the user-message body rather than
+// the system prompt avoids false-positiving on the Agent tool's own
+// description, which appears in every main-loop turn's system prompt. The
+// prefix is bounded so a stray "<transcript>" deep in a long turn can't trigger.
 func isSubAgentDispatch(metadataUserID, firstUserText, subAgentHint string) bool {
 	if subAgentHint != "" {
 		return true

--- a/internal/server/middleware/auth.go
+++ b/internal/server/middleware/auth.go
@@ -23,19 +23,15 @@ const (
 // RouterKeyHeader carries the Weave Router key when clients need to preserve Authorization / x-api-key for the upstream provider.
 const RouterKeyHeader = "X-Weave-Router-Key"
 
-// AnthropicSubscriptionHeader carries a caller's Claude subscription OAuth token
-// (sk-ant-oat-) on router-keyed requests, where Authorization already holds the
-// rk_ router key. The proxy forwards it to Anthropic for Claude-model turns so
-// the caller's own subscription pays, instead of the deployment API key.
+// AnthropicSubscriptionHeader carries a caller's Claude subscription OAuth
+// token (sk-ant-oat-) alongside an rk_ router key, so the proxy can bill
+// Claude-model turns to the caller's subscription instead of the deployment key.
 const AnthropicSubscriptionHeader = "X-Weave-Anthropic-Subscription"
 
-// OpenAISubscriptionHeader and OpenAIAccountIDHeader carry a caller's Codex
-// (ChatGPT) subscription on router-keyed requests, where Authorization already
-// holds the rk_ router key. The subscription header holds the ChatGPT OAuth JWT
-// and the account-id header holds the paired ChatGPT-Account-ID; both are
-// required because the Codex backend 401/403s on a token without its account id.
-// The proxy forwards them to OpenAI's Codex backend for OpenAI-model turns so
-// the caller's own ChatGPT plan pays, instead of the deployment API key.
+// OpenAISubscriptionHeader/OpenAIAccountIDHeader carry a caller's Codex
+// (ChatGPT) OAuth JWT and its paired ChatGPT-Account-ID alongside an rk_
+// router key, so Codex turns bill to the caller's ChatGPT plan. Both are
+// required — the Codex backend 401/403s on a token without its account id.
 const (
 	OpenAISubscriptionHeader = "X-Weave-OpenAI-Subscription"
 	OpenAIAccountIDHeader    = "X-Weave-OpenAI-Account-ID"
@@ -43,22 +39,18 @@ const (
 
 // WithAuth validates the inbound request via a bearer rk_ token only. Used on data-plane routes (`/v1/*`). On failure, short-circuits 401.
 //
-// byokDisabled drops any BYOK (customer-owned provider) keys at the middleware
-// boundary so downstream proxy code can't see them. Managed-mode deployments
-// pass true: they bill via prepaid credits against the platform key and must
-// never honor a leftover row in router.model_router_external_api_keys, or the
-// customer would be charged twice (once upstream, once via credits).
-// Self-hosted passes false; BYOK is the only credentialing path there.
+// byokDisabled strips BYOK (customer-owned provider) keys before downstream
+// proxy code sees them. Managed-mode deployments pass true: they bill via
+// prepaid credits, so honoring a leftover BYOK row would double-charge the
+// customer. Self-hosted passes false; BYOK is the only credentialing path there.
 func WithAuth(svc *auth.Service, byokDisabled bool) gin.HandlerFunc {
 	return withAPIKey(svc, byokDisabled)
 }
 
 // WithAdminOrAuth accepts either a signed admin session cookie OR a bearer rk_ token.
-//
-// Do not use on `/v1/*` data-plane routes — a dashboard cookie must not call provider proxy endpoints.
-// Do not use on control-plane mutations — a leaked rk_ must not mint fresh keys or rotate provider credentials; use WithAdminOnly instead.
-//
-// See WithAuth for the byokDisabled semantics.
+// Don't use on `/v1/*` data-plane routes (a cookie shouldn't call provider proxy endpoints)
+// or on control-plane mutations (a leaked rk_ shouldn't mint keys or rotate credentials —
+// use WithAdminOnly there). See WithAuth for byokDisabled.
 func WithAdminOrAuth(svc *auth.Service, byokDisabled bool) gin.HandlerFunc {
 	apiKeyMW := withAPIKey(svc, byokDisabled)
 	return func(c *gin.Context) {
@@ -90,11 +82,10 @@ func WithAdminOnly(svc *auth.Service) gin.HandlerFunc {
 
 // withAPIKey is the bearer-only auth path shared by WithAuth and the fall-through branch of WithAdminOrAuth.
 //
-// When byokDisabled is true, BYOK rows returned by svc.VerifyAPIKey are
-// dropped before reaching the request context. Every downstream consumer of
-// the BYOK ctx value (proxy credential resolution, provider gating, usage
-// bookkeeping) reads from that single key, so gating it here makes the entire
-// code path BYOK-blind without further surgery.
+// When byokDisabled is true, BYOK rows from svc.VerifyAPIKey are dropped
+// before reaching the request context. Every downstream BYOK consumer
+// (credential resolution, provider gating, usage bookkeeping) reads that
+// single ctx key, so gating it here makes the whole path BYOK-blind.
 func withAPIKey(svc *auth.Service, byokDisabled bool) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		token := extractToken(c)
@@ -126,9 +117,8 @@ func withAPIKey(svc *auth.Service, byokDisabled bool) gin.HandlerFunc {
 				ctx = context.WithValue(ctx, proxy.InstallationPreferredModelsContextKey{}, installation.PreferredModels)
 			}
 			if installation.RoutingQualityWeight != nil {
-				// The stored weight is the user-facing dial position, so it
-				// flows in as QualityBias (per-cluster, dispersion-aware), not
-				// the uniform Alpha sledgehammer. See router.Overrides.
+				// User-facing dial position flows in as QualityBias (per-cluster,
+				// dispersion-aware), not the uniform Alpha. See router.Overrides.
 				ctx = context.WithValue(ctx, proxy.InstallationRoutingKnobsContextKey{}, &router.Overrides{
 					QualityBias: installation.RoutingQualityWeight,
 				})
@@ -154,9 +144,7 @@ func withAPIKey(svc *auth.Service, byokDisabled bool) gin.HandlerFunc {
 		if sub := strings.TrimSpace(c.GetHeader(AnthropicSubscriptionHeader)); sub != "" {
 			ctx = context.WithValue(ctx, proxy.AnthropicSubscriptionContextKey{}, sub)
 		}
-		// Codex (ChatGPT) subscription, router-keyed path: stash the OAuth JWT
-		// and its paired ChatGPT-Account-ID raw; the proxy validates shape and
-		// decides precedence. Never logged.
+		// Codex (ChatGPT) subscription: stash JWT + account ID raw for the proxy. Never logged.
 		if sub := strings.TrimSpace(c.GetHeader(OpenAISubscriptionHeader)); sub != "" {
 			ctx = context.WithValue(ctx, proxy.OpenAISubscriptionContextKey{}, sub)
 		}

--- a/internal/translate/emit_same_format_test.go
+++ b/internal/translate/emit_same_format_test.go
@@ -68,13 +68,9 @@ func TestOpenAISameFormat_UnknownFieldsPreserved(t *testing.T) {
 	assert.Equal(t, "val", meta["key"])
 }
 
-// A Gemini turn earlier in the session left an off-spec thought_signature field
-// on content blocks (the router smuggles it to passthrough clients on text
-// blocks, and pre-id-embed sessions also carried it on tool_use blocks, which
-// Claude Code echoes back). Forwarding that field to an Anthropic upstream 400s
-// ("...tool_use.thought_signature: Extra inputs are not permitted"), so the
-// same-format Anthropic emit must drop it from every block. On tool_use the
-// signature still round-trips via the id; on text it is simply dropped.
+// An off-spec thought_signature field (smuggled from a Gemini turn) 400s an
+// Anthropic upstream, so same-format emit must strip it from every block. On
+// tool_use the signature still round-trips via the id; on text it's just dropped.
 func TestAnthropicSameFormat_StripsThoughtSignature(t *testing.T) {
 	body := []byte(`{"model":"claude-opus-4-8","max_tokens":1024,"messages":[
 		{"role":"assistant","content":[
@@ -348,11 +344,9 @@ func TestAnthropicSameFormat_ThinkingBlocksKeptForCapableModel(t *testing.T) {
 	require.Len(t, content, 2, "thinking blocks should be preserved for capable models")
 }
 
-// Pi and other legacy Anthropic clients still send the pre-rollout
-// thinking.type=enabled shape. claude-opus-4-6+ rejects that with HTTP 400, so
-// the router must upconvert to thinking.type=adaptive and inject
-// output_config.effort derived from budget_tokens. Production session
-// 019e89de-f555-755b-a98b-d00cbef7a299 hit this on 2026-06-02.
+// Legacy clients still send thinking.type=enabled, which claude-opus-4-6+
+// rejects (400). The router must upconvert to type=adaptive and derive
+// output_config.effort from budget_tokens (prod incident 2026-06-02).
 func TestAnthropicSameFormat_EnabledThinkingUpconvertedToAdaptive(t *testing.T) {
 	tests := []struct {
 		name         string
@@ -390,9 +384,7 @@ func TestAnthropicSameFormat_EnabledThinkingUpconvertedToAdaptive(t *testing.T) 
 	}
 }
 
-// Inbound clients that already specify output_config.effort should win over
-// the budget-derived default — the router only fills in a default when the
-// caller said nothing.
+// An explicit output_config.effort wins over the budget-derived default.
 func TestAnthropicSameFormat_EnabledThinkingPreservesExplicitEffort(t *testing.T) {
 	body := []byte(`{"model":"claude-opus-4-7","messages":[{"role":"user","content":"hi"}],"max_tokens":1024,"thinking":{"type":"enabled","budget_tokens":8192},"output_config":{"effort":"high"}}`)
 	opts := translate.EmitOptions{
@@ -406,11 +398,8 @@ func TestAnthropicSameFormat_EnabledThinkingPreservesExplicitEffort(t *testing.T
 }
 
 func TestAnthropicSameFormat_ThinkingBlocksStrippedOnModelSwitch(t *testing.T) {
-	// A capable model would normally keep historical thinking blocks, but on a
-	// mid-session model switch their `signature`s were issued by the previous
-	// model and Anthropic rejects them with `Invalid signature in thinking
-	// block` (400). ModelSwitched forces the strip so the stale signature never
-	// reaches the upstream, while the text block survives.
+	// On a model switch, prior thinking blocks carry signatures from the old
+	// model; Anthropic 400s on those. ModelSwitched forces the strip.
 	body := []byte(`{"model":"claude-opus-4-7","messages":[{"role":"user","content":"hi"},{"role":"assistant","content":[{"type":"thinking","thinking":"thought","signature":"sig-from-other-model"},{"type":"text","text":"reply"}]}],"max_tokens":1024,"thinking":{"type":"adaptive"}}`)
 	opts := translate.EmitOptions{
 		TargetModel:   "claude-opus-4-7",
@@ -428,9 +417,8 @@ func TestAnthropicSameFormat_ThinkingBlocksStrippedOnModelSwitch(t *testing.T) {
 }
 
 func TestAnthropicSameFormat_ThinkingBlocksKeptWhenNoModelSwitch(t *testing.T) {
-	// Same capable model with ModelSwitched=false (the steady-state, same-model
-	// turn): thinking blocks and their valid signatures must be preserved so
-	// prompt-cache hits and reasoning continuity are not needlessly destroyed.
+	// Same-model turn (ModelSwitched=false): valid thinking blocks must survive
+	// to keep prompt-cache hits and reasoning continuity intact.
 	body := []byte(`{"model":"claude-opus-4-7","messages":[{"role":"user","content":"hi"},{"role":"assistant","content":[{"type":"thinking","thinking":"thought","signature":"valid-sig"},{"type":"text","text":"reply"}]}],"max_tokens":1024,"thinking":{"type":"adaptive"}}`)
 	opts := translate.EmitOptions{
 		TargetModel:   "claude-opus-4-7",
@@ -652,13 +640,10 @@ func TestAnthropicSameFormat_BodyIsImmutable(t *testing.T) {
 	assert.Equal(t, original, body, "original body bytes must not be modified")
 }
 
-// Prod repro (2026-06-09 customer benchmark): a session running with
-// output_config.effort="xhigh" (valid for the requested opus) was re-routed
-// mid-session to claude-sonnet-4-6, whose effort menu tops out at "max".
-// The body went through with only the model swapped and Anthropic rejected it
-// with a non-retryable 400 ("This model does not support effort level
-// 'xhigh'"), killing the session. The emit layer must clamp xhigh to max for
-// adaptive targets without CapXhighEffort.
+// Prod repro (2026-06-09): a session using effort="xhigh" was re-routed
+// mid-session to claude-sonnet-4-6 (tops out at "max"), and Anthropic
+// 400'd on the unsupported level, killing the session. Emit must clamp
+// xhigh to max for adaptive targets without CapXhighEffort.
 func TestAnthropicSameFormat_XhighEffortClampedOnReroute(t *testing.T) {
 	body := []byte(`{"model":"claude-opus-4-7","messages":[{"role":"user","content":"hi"}],"max_tokens":1024,"thinking":{"type":"adaptive"},"output_config":{"effort":"xhigh"}}`)
 	opts := translate.EmitOptions{
@@ -695,14 +680,9 @@ func TestAnthropicSameFormat_XhighEffortPreservedForCapableModel(t *testing.T) {
 	assert.Equal(t, "xhigh", outputConfig["effort"], "xhigh must pass through to models with CapXhighEffort")
 }
 
-// Exhaustive backstop for the 2026-06-09 production incident (see
-// TestAnthropicSameFormat_XhighEffortClampedOnReroute). The per-model clamp keys
-// on router.CapXhighEffort, so a newly added or re-tagged Anthropic model could
-// silently reintroduce the non-retryable 400. Rather than trust two hardcoded
-// pairs, walk every Anthropic model in the catalog and assert the wire-level
-// guarantee directly: effort "xhigh" survives emit only when the target advertises
-// CapXhighEffort. A model that lacks the capability but isn't clamped fails here
-// before it can reach a customer session.
+// Exhaustive backstop for the 2026-06-09 incident: a newly added or re-tagged
+// Anthropic model could silently reintroduce the 400. Walk every catalog model
+// and assert xhigh survives emit only when CapXhighEffort is advertised.
 func TestAnthropicSameFormat_XhighEffortNeverReachesIncapableModel(t *testing.T) {
 	var anthropicModels, capableModels int
 	for _, m := range catalog.Models {

--- a/internal/translate/gemini_stream.go
+++ b/internal/translate/gemini_stream.go
@@ -15,8 +15,8 @@ import (
 )
 
 // GeminiToOpenAISSETranslator translates Gemini :streamGenerateContent SSE into
-// OpenAI chat.completion.chunk on the fly. For Anthropic-inbound, it chains with
-// an inner AnthropicSSETranslator.
+// OpenAI chat.completion.chunk on the fly, chaining with an inner AnthropicSSETranslator
+// for Anthropic-inbound requests.
 type GeminiToOpenAISSETranslator struct {
 	inner   http.ResponseWriter
 	flusher http.Flusher
@@ -39,11 +39,9 @@ type GeminiToOpenAISSETranslator struct {
 
 	usageSink otel.UsageSink
 
-	// onOutputProgress, when set via ArmOutputProgress, is invoked on every
-	// parsed output-bearing Gemini event (text delta, tool-call chunk, or
-	// terminal finish) and never on keepalives or empty/role-only frames. It
-	// feeds the openaicompat client's output-progress watchdog through the
-	// Gemini→OpenAI SSE translator chain. nil disables it.
+	// onOutputProgress, set via ArmOutputProgress, fires on output-bearing events
+	// (text delta, tool-call chunk, finish) to feed the output-progress watchdog.
+	// nil disables it.
 	onOutputProgress func()
 }
 
@@ -61,13 +59,10 @@ func NewGeminiToOpenAISSETranslator(w http.ResponseWriter, model string, sink ot
 	}
 }
 
-// ArmOutputProgress installs the output-progress watchdog mark. The translator
-// invokes mark whenever it writes an output-bearing upstream event — text delta,
-// tool-call chunk, or terminal finish — and never on role-only first chunks,
-// usage-only chunks, or [DONE]. It returns false (and installs nothing) when the
-// client is not streaming: the buffered path translates only at Finalize, so an
-// output-progress watchdog would have nothing to mark and would false-trip.
-// Call after WriteHeader, which sets the streaming flag.
+// ArmOutputProgress installs mark to fire on output-bearing events (not on
+// role-only, usage-only, or [DONE] frames). Returns false if not streaming,
+// since the buffered path only translates at Finalize and would false-trip a
+// watchdog. Call after WriteHeader, which sets the streaming flag.
 func (t *GeminiToOpenAISSETranslator) ArmOutputProgress(mark func()) (armed bool) {
 	if !t.streaming {
 		return false
@@ -208,10 +203,9 @@ func (t *GeminiToOpenAISSETranslator) translateEvent(raw []byte) error {
 				if sig == "" && t.pendingSig != "" {
 					sig = t.pendingSig
 				} else if sig != "" {
-					// Latch any newly-seen sig so later functionCalls in the
-					// same turn can inherit it. Gemini 3.x rejects next-turn
-					// requests with missing thoughtSignature on ANY functionCall
-					// part; only the first part in a turn carries one.
+					// Latch it: Gemini 3.x rejects next-turn requests missing a
+					// thoughtSignature on any functionCall, but only the first
+					// part in a turn carries one.
 					t.pendingSig = sig
 				}
 				if err := t.emitToolCallChunk(t.toolIdx, name, argsRaw, sig); err != nil {
@@ -248,9 +242,7 @@ func (t *GeminiToOpenAISSETranslator) translateEvent(raw []byte) error {
 		return t.emitDone()
 	}
 	if usage != nil {
-		// Gemini sometimes sends usage in a trailing chunk without a
-		// finishReason; emit a usage-only chunk so downstream consumers
-		// see it before [DONE].
+		// Gemini can send usage in a trailing chunk with no finishReason.
 		if err := t.emitUsageOnlyChunk(usage); err != nil {
 			return err
 		}
@@ -295,11 +287,10 @@ func (t *GeminiToOpenAISSETranslator) emitTextDelta(text string) error {
 	return t.flushEvent()
 }
 
-// emitToolCallChunk emits an OpenAI tool_calls delta with a full arguments JSON
-// in one chunk. A Gemini thoughtSignature is smuggled into the tool-call id
-// (embedSignatureInID) — a typed string every client SDK round-trips — so the
-// next request can replay it without relying on an off-spec field that typed
-// SDKs drop and Anthropic upstreams reject.
+// emitToolCallChunk emits an OpenAI tool_calls delta with the full arguments
+// JSON in one chunk. The Gemini thoughtSignature is smuggled into the tool-call
+// id (embedSignatureInID) so it replays on the next request without an
+// off-spec field that typed SDKs drop and Anthropic upstreams reject.
 func (t *GeminiToOpenAISSETranslator) emitToolCallChunk(idx int, name, argsRaw, sig string) error {
 	t.markOutputProgress()
 	id := embedSignatureInID(generateToolCallID(), sig)
@@ -341,9 +332,8 @@ func (t *GeminiToOpenAISSETranslator) emitUsageOnlyChunk(usage map[string]int) e
 	return t.flushEvent()
 }
 
-// writeUsageJSON serializes an OpenAI-shape usage object onto t.bw, including
-// cached_tokens when present. The nested shape matches what AnthropicSSETranslator
-// reads, so cache numbers propagate through the chain.
+// writeUsageJSON serializes an OpenAI-shape usage object, matching the nested
+// shape AnthropicSSETranslator reads so cache numbers propagate through.
 func (t *GeminiToOpenAISSETranslator) writeUsageJSON(usage map[string]int) {
 	t.bw.WriteString(`,"usage":{"prompt_tokens":`)
 	sse.WriteJSONInt(t.bw, int64(usage["prompt_tokens"]))

--- a/internal/translate/provider_hint.go
+++ b/internal/translate/provider_hint.go
@@ -2,10 +2,9 @@ package translate
 
 import "strings"
 
-// openRouterProviderHint returns the OpenRouter `provider` field for model slugs
-// that need pinning to caching-capable backends. Without a hint, OpenRouter
-// load-balances by price and picks hosts without prefix caching, which breaks
-// agentic workloads re-sending large transcripts each turn.
+// openRouterProviderHint pins model slugs to caching-capable backends.
+// Without it, OpenRouter load-balances by price onto hosts without prefix
+// caching, which breaks agentic workloads re-sending large transcripts.
 func openRouterProviderHint(model string) map[string]any {
 	switch {
 	case strings.HasPrefix(model, "deepseek/"):
@@ -24,16 +23,12 @@ func openRouterProviderHint(model string) map[string]any {
 	return nil
 }
 
-// openRouterReasoningHint returns the OpenRouter `reasoning` field to disable
-// reasoning on models that burn the entire max_tokens budget on hidden thinking.
-// Native DeepSeek serving defaults to reasoning-on and ignores effort=minimal.
-//
-// Extended to moonshotai/* (Kimi K2.x) and xiaomi/* (MiMo) because on
-// tool-calling turns these models otherwise emit native tool-call tokens
-// (<|tool_call_begin|>, Hermes <tool_call> XML) inside an unbounded reasoning
-// segment that OpenRouter's tool-call parser misses, leaving structured
-// tool_calls empty and generation running to the output cap.
-// (hermes-agent #24534, vllm #39056).
+// openRouterReasoningHint disables reasoning on models that burn the whole
+// max_tokens budget on hidden thinking. Native DeepSeek ignores effort=minimal
+// and defaults reasoning-on. moonshotai/* (Kimi) and xiaomi/* (MiMo) are
+// included because on tool calls they emit native tool-call tokens inside an
+// unbounded reasoning segment that OpenRouter's parser misses, leaving
+// tool_calls empty (hermes-agent #24534, vllm #39056).
 func openRouterReasoningHint(model string) map[string]any {
 	switch {
 	case strings.HasPrefix(model, "deepseek/"),
@@ -45,41 +40,34 @@ func openRouterReasoningHint(model string) map[string]any {
 	return nil
 }
 
-// openRouterForcesToolTemperatureZero reports whether tool-calling turns for
-// this model should default to temperature 0. Reserved for models whose
-// sampling jitter measurably degrades tool-arg fidelity (whitespace, unicode)
-// — DeepSeek's reasoning-disabled tool turns are the documented case.
-// Callers still skip the override when the client set temperature explicitly.
+// openRouterForcesToolTemperatureZero reports whether tool-calling turns
+// should default to temperature 0, for models whose sampling jitter degrades
+// tool-arg fidelity (DeepSeek's reasoning-disabled tool turns). Callers still
+// skip this when the client set temperature explicitly.
 func openRouterForcesToolTemperatureZero(model string) bool {
 	return strings.HasPrefix(model, "deepseek/")
 }
 
-// isGLM51 reports whether the model id is z-ai/glm-5.1. GLM-5.1 shipped the
-// streaming tool-call fix behind an opt-in flag (tool_stream=true per Z.AI
-// docs https://docs.z.ai/guides/capabilities/stream-tool); without it the
-// model reverts to the GLM-5 behavior where tool_call envelopes arrive with
-// empty arguments. We also disable thinking-mode on the DeepInfra path
-// (chat_template_kwargs.enable_thinking=false) so reasoning blocks don't leak
-// into the response stream; OpenRouter handles the same via openRouterReasoningHint.
+// isGLM51 reports whether the model id is z-ai/glm-5.1. GLM-5.1's streaming
+// tool-call fix is opt-in (tool_stream=true, docs.z.ai/guides/capabilities/stream-tool);
+// without it tool_call envelopes arrive with empty arguments like GLM-5. We
+// also disable thinking-mode on the DeepInfra path so reasoning doesn't leak
+// into the stream; OpenRouter's case is handled by openRouterReasoningHint.
 func isGLM51(model string) bool {
 	return model == "z-ai/glm-5.1"
 }
 
 // isQwen3Family reports whether the model id belongs to the qwen3.x family.
-// Qwen3 variants (instruct, coder, qwen3-next, qwen3.6-*) are documented to
-// drift into tool-call / thinking loops without the recommended sampling
-// defaults; the Qwen3 model card publishes a tuned set of params for
-// agentic/code workloads which we layer in when the client did not set them.
+// These variants drift into tool-call/thinking loops without the model
+// card's recommended sampling defaults, which we layer in when unset.
 func isQwen3Family(model string) bool {
 	return strings.HasPrefix(model, "qwen/qwen3")
 }
 
-// Qwen3 sampling defaults from the official model card and Unsloth runbook
-// (huggingface.co/Qwen/Qwen3-235B-A22B-Instruct-2507 — "Sampling Parameters").
-// Applied only when the client has not set the corresponding field, so callers
-// with their own tuning still win. presence_penalty=1.5 specifically suppresses
-// the "same tool, same args, N times in a row" loop the Instruct variant is
-// prone to without CoT.
+// Qwen3 sampling defaults from the official model card
+// (huggingface.co/Qwen/Qwen3-235B-A22B-Instruct-2507), applied only when the
+// client hasn't set the field. presence_penalty=1.5 suppresses the
+// "same tool, same args, N times" loop the Instruct variant is prone to.
 const (
 	qwen3Temperature       = 0.7
 	qwen3TopP              = 0.8

--- a/internal/translate/responses_outbound_test.go
+++ b/internal/translate/responses_outbound_test.go
@@ -41,9 +41,8 @@ func decodeOpenAIReasoningTestSignature(t *testing.T, sig string) map[string]any
 	return out
 }
 
-// Anthropic (Claude Code) → OpenAI Responses request: the thinking budget must
-// become reasoning.effort, messages must become typed input items, tool_use →
-// function_call, tool_result → function_call_output, tools the flat shape.
+// Anthropic → OpenAI Responses request shape: thinking budget, typed input
+// items, tool_use/tool_result mapping, flat tools.
 func TestPrepareOpenAIResponses_RequestShape(t *testing.T) {
 	body := []byte(`{
       "model":"claude-opus-4-8","max_tokens":4096,
@@ -122,12 +121,10 @@ func TestPrepareOpenAIResponses_RequestShape(t *testing.T) {
 	assert.Equal(t, providers.EndpointResponses, prep.Endpoint)
 }
 
-// A session that ran on Gemini accumulates tool_use ids with a base64
-// thoughtSignature smuggled in (call_xxx__thought__<sig>, often >1KB). When a
-// later turn re-routes to a gpt-5.x Responses model, the call_id must be
-// stripped of the signature and clamped to OpenAI's 64-char limit, or the
-// upstream 400s ("input[N].call_id: string too long, max 64"). The tool_use
-// and its tool_result must still map to the same clamped call_id so they pair.
+// Gemini sessions smuggle a thoughtSignature into tool_use ids
+// (call_xxx__thought__<sig>, often >1KB). On re-route to a gpt-5.x Responses
+// model, call_id must be stripped and clamped to 64 chars or the upstream
+// 400s; tool_use and tool_result must still share the clamped call_id.
 func TestPrepareOpenAIResponses_ClampsGeminiThoughtSignatureCallID(t *testing.T) {
 	longSig := strings.Repeat("A", 1300) // valid base64url, > 64 chars
 	id := "call_abc123__thought__" + longSig
@@ -242,9 +239,8 @@ func TestPrepareOpenAIResponses_ReplaysSignedReasoningAfterModelSwitch(t *testin
 
 // budget→effort ladder.
 func TestPrepareOpenAIResponses_EffortLadder(t *testing.T) {
-	// gpt-5.x has a measured "medium" dead-zone on hard agentic coding (Pro:
-	// low 16%, medium 0%, high 41%), so the medium band (budget ≤16384) is
-	// promoted to high. Small budgets still resolve to low — easy stays cheap.
+	// gpt-5.x has a measured "medium" dead-zone on hard agentic coding, so the
+	// medium band (budget ≤16384) is promoted to high; small budgets stay low.
 	for _, tc := range []struct {
 		budget int
 		want   string
@@ -296,9 +292,8 @@ func TestResponsesToAnthropicResponse(t *testing.T) {
 	assert.Equal(t, "here is the fix", b1["text"])
 	b2, _ := content[2].(map[string]any)
 	assert.Equal(t, "tool_use", b2["type"])
-	// The preceding reasoning item's signature is also carried on the tool_use id
-	// (the Claude Code round-trip drops the thinking block but preserves the id),
-	// so the id is the call_id plus an opaque reasoning-signature suffix.
+	// The tool_use id also carries the preceding reasoning item's signature,
+	// since Claude Code drops the thinking block on round-trip but keeps the id.
 	toolID, _ := b2["id"].(string)
 	assert.True(t, strings.HasPrefix(toolID, "call_9"), "tool id keeps the call_id prefix, got %q", toolID)
 	assert.Contains(t, toolID, "__openai_reasoning__", "tool id carries the reasoning signature for replay")
@@ -324,9 +319,8 @@ func TestResponsesToAnthropicResponse_StopReasons(t *testing.T) {
 	assert.Equal(t, "end_turn", gjsonStopReason(out))
 }
 
-// gemini-3.x (native) must receive a thinkingConfig derived from the Anthropic
-// thinking budget so it reasons. Gemini 3.x uses the string `thinkingLevel`;
-// the legacy numeric `thinkingBudget` is suboptimal for 3.x and mixing both 400s.
+// gemini-3.x uses string `thinkingLevel`, not the legacy numeric `thinkingBudget`
+// (sending both 400s).
 func TestPrepareGemini_ThinkingBudgetToThinkingConfig(t *testing.T) {
 	body := []byte(`{"model":"claude-opus-4-8","max_tokens":1024,"messages":[{"role":"user","content":"hi"}],"thinking":{"type":"enabled","budget_tokens":31999}}`)
 	env, err := translate.ParseAnthropic(body)

--- a/internal/translate/responses_test.go
+++ b/internal/translate/responses_test.go
@@ -95,9 +95,8 @@ func TestResponsesToChatCompletions_ToolsFlatToNested(t *testing.T) {
 }
 
 func TestResponsesToChatCompletions_StripsRoutingBadgeFromAssistantHistory(t *testing.T) {
-	// Codex re-sends every prior assistant turn in the input array. The badge
-	// we prepend on egress must not survive ingress, or the upstream sees
-	// per-turn router-injected bytes that break prompt-cache reuse.
+	// The egress badge must not survive ingress, or repeated turns leak
+	// router bytes that break prompt-cache reuse.
 	body := []byte(`{
 		"model": "gpt-5",
 		"input": [
@@ -171,11 +170,9 @@ func TestResponsesToChatCompletions_MaxOutputAndDropsReasoning(t *testing.T) {
 	assert.False(t, gjson.GetBytes(out, "reasoning").Exists())
 }
 
-// TestResponsesToChatCompletions_DropsReasoningEffort guards the Codex blocker:
-// Codex ALWAYS sends a `reasoning` field (including effort:"none", which is not
-// a valid Chat Completions reasoning_effort), and reasoning OpenAI models reject
-// reasoning_effort + tools — both 400 after response.created and close the
-// stream. None of these efforts may leak into the translated chat body.
+// Codex always sends a `reasoning` field, including effort:"none" (invalid as
+// reasoning_effort); reasoning OpenAI models also 400 on reasoning_effort+tools.
+// No effort value may leak into the translated chat body.
 func TestResponsesToChatCompletions_DropsReasoningEffort(t *testing.T) {
 	for _, effort := range []string{"none", "minimal", "low", "medium", "high"} {
 		body := []byte(`{"model":"gpt-5.5","input":"hi","reasoning":{"effort":"` + effort + `"},"include":["reasoning.encrypted_content"]}`)
@@ -186,10 +183,9 @@ func TestResponsesToChatCompletions_DropsReasoningEffort(t *testing.T) {
 	}
 }
 
-// TestResponsesWriter_FinalizeErrorEmitsFailed guards the stream-termination
-// half of the Codex fix: once response.created is on the wire, an upstream
-// error must close the stream with a response.failed terminal, never a bare
-// disconnect (which Codex reports as "stream closed before response.completed").
+// Once response.created is on the wire, an upstream error must terminate with
+// response.failed, never a bare disconnect (Codex reports that as "stream
+// closed before response.completed").
 func TestResponsesWriter_FinalizeErrorEmitsFailed(t *testing.T) {
 	rec := httptest.NewRecorder()
 	w := translate.NewResponsesWriter(rec, "")
@@ -210,9 +206,8 @@ func TestResponsesWriter_FinalizeErrorEmitsFailed(t *testing.T) {
 	assert.NotNil(t, resp["error"])
 }
 
-// TestResponsesWriter_FinalizeErrorNoopBeforeCreated: when nothing has been
-// streamed yet, FinalizeError writes nothing so the handler can still emit a
-// JSON error envelope.
+// Before anything streams, FinalizeError writes nothing so the handler can
+// still emit a JSON error envelope.
 func TestResponsesWriter_FinalizeErrorNoopBeforeCreated(t *testing.T) {
 	rec := httptest.NewRecorder()
 	w := translate.NewResponsesWriter(rec, "")
@@ -223,9 +218,8 @@ func TestResponsesWriter_FinalizeErrorNoopBeforeCreated(t *testing.T) {
 
 func TestResponsesWriter_StreamingText(t *testing.T) {
 	rec := httptest.NewRecorder()
-	// Empty initial model + no x-router-model header means the badge can't
-	// resolve a routed pick and stays silent — lets this test focus on the
-	// chunk translation contract.
+	// No model / x-router-model header, so the badge stays silent and the
+	// test can focus on chunk translation.
 	w := translate.NewResponsesWriter(rec, "")
 
 	w.Header().Set("Content-Type", "text/event-stream")
@@ -256,9 +250,8 @@ func TestResponsesWriter_StreamingText(t *testing.T) {
 	assert.Contains(t, types, "response.output_item.done")
 	assert.Contains(t, types, "response.completed")
 
-	// Concatenated text deltas, skipping the routing badge prefix that the
-	// writer prepends on the first delta whenever a routed model is known.
-	// Chunks here carry model="gpt-5" so the badge resolves and fires.
+	// Skip the badge prefix the writer prepends on the first delta (model
+	// "gpt-5" resolves here so the badge fires).
 	var combined strings.Builder
 	for _, e := range events {
 		if e["type"] != "response.output_text.delta" {
@@ -280,10 +273,8 @@ func TestResponsesWriter_StreamingText(t *testing.T) {
 	assert.EqualValues(t, 2, usage["output_tokens"])
 }
 
-// TestResponsesWriter_PassthroughForwardsVerbatim guards the Codex-backend
-// path: when the upstream already speaks Responses natively, the writer must
-// forward bytes unchanged and must NOT emit its own response.created prelude
-// (which would duplicate the upstream's).
+// When upstream already speaks Responses natively, the writer must forward
+// bytes unchanged and skip its own response.created prelude.
 func TestResponsesWriter_PassthroughForwardsVerbatim(t *testing.T) {
 	rec := httptest.NewRecorder()
 	w := translate.NewResponsesWriter(rec, "gpt-5.5")

--- a/internal/translate/translate.go
+++ b/internal/translate/translate.go
@@ -1,6 +1,5 @@
-// Package translate converts request and response bodies between OpenAI and
-// Anthropic wire formats. Request translation uses RequestEnvelope; this file
-// handles non-streaming response helpers.
+// Package translate converts request/response bodies between OpenAI and
+// Anthropic wire formats. This file handles non-streaming responses.
 package translate
 
 import (
@@ -171,9 +170,8 @@ func OpenAIToAnthropicResponse(body []byte, requestModel string) ([]byte, error)
 }
 
 // openAIToAnthropicResponse is the validator-aware variant: tool_use inputs
-// are checked (and safely repaired) against the request's tool schemas via
-// toolValidator, with one toolcheck.Issue returned per offending block. A nil
-// validator degrades to syntax-check-only.
+// are checked/repaired against the request's tool schemas, returning one
+// toolcheck.Issue per offending block. A nil validator is syntax-check-only.
 func openAIToAnthropicResponse(body []byte, requestModel string, toolValidator *toolcheck.Validator, thinkTagReasoning bool) ([]byte, []toolcheck.Issue, error) {
 	if !gjson.ValidBytes(body) {
 		return nil, nil, fmt.Errorf("unmarshal openai response: invalid JSON")
@@ -192,16 +190,12 @@ func openAIToAnthropicResponse(body []byte, requestModel string, toolValidator *
 	firstChoice := gjson.GetBytes(body, "choices.0")
 	message := firstChoice.Get("message")
 	finishReason := firstChoice.Get("finish_reason").String()
-	// Anthropic invariant: a tool_use stop_reason holds iff at least one
-	// tool_use block exists. Some OpenAI-compat upstreams (GLM-5.1 on
-	// DeepInfra, vLLM Qwen/MiMo serves) violate it in both directions, so we
-	// correct both — mirroring the streaming path in emitMessageDelta:
-	//   - Promote: a named tool call is present but the turn closed with
-	//     finish_reason="stop" instead of "tool_calls".
-	//   - Demote: finish_reason="tool_calls" but every call was nameless and
-	//     dropped by writeAnthropicContentFromOpenAI (or the call leaked into
-	//     text). Left as tool_use it would ship a tool_use stop_reason with
-	//     zero tool_use blocks and dead-end the client.
+	// Anthropic invariant: tool_use stop_reason iff a tool_use block exists.
+	// Some OpenAI-compat upstreams (GLM-5.1/DeepInfra, vLLM Qwen/MiMo) violate
+	// it both ways, so we correct both, mirroring emitMessageDelta:
+	//   - Promote: named tool call present but finish_reason="stop".
+	//   - Demote: finish_reason="tool_calls" but every call was nameless
+	//     (dropped below) — else we'd ship tool_use with zero blocks.
 	if anyNamedToolCall(message.Get("tool_calls")) {
 		finishReason = "tool_calls"
 	} else if finishReason == "tool_calls" {
@@ -259,10 +253,8 @@ func writeAnthropicContentFromOpenAI(jw *jsonWriter, message gjson.Result, toolV
 				prose.WriteString(seg.text)
 			}
 		}
-		// Fold tag-derived reasoning into the same thinking block as
-		// reasoning_content/reasoning, matching the streaming translator
-		// (appendThinking reuses an open thinking block) so a payload with both
-		// channels shapes identically for stream:false clients.
+		// Fold into the same thinking block as reasoning_content/reasoning,
+		// matching the streaming translator so both channels shape identically.
 		reasoning += think.String()
 		text = prose.String()
 	}
@@ -296,9 +288,8 @@ func writeAnthropicContentFromOpenAI(jw *jsonWriter, message gjson.Result, toolV
 				}
 			}
 		}
-		// Validate (and safely repair) the args against the request's tool
-		// schema; with a nil validator this degrades to the historic
-		// syntax-check + `{}` substitution.
+		// Validate (and safely repair) args against the request's tool schema;
+		// nil validator degrades to syntax-check + `{}` substitution.
 		verdict := toolValidator.Check(name, argsStr)
 		if verdict.Issue != nil {
 			issues = append(issues, *verdict.Issue)
@@ -321,13 +312,11 @@ func writeAnthropicContentFromOpenAI(jw *jsonWriter, message gjson.Result, toolV
 	return issues
 }
 
-// anyNamedToolCall reports whether the OpenAI tool_calls array contains at
-// least one call with a non-empty function name. A nameless tool_call is
-// malformed: OpenAI-compat upstreams (GLM, Qwen, Kimi, gpt-oss on
-// vLLM/SGLang/DeepInfra) intermittently emit one, often alongside
-// finish_reason="stop". Forwarding it as an Anthropic tool_use block makes the
-// client invoke tool "" -> "No such tool available" -> retry -> infinite loop,
-// so such calls are dropped and must not drive the stop_reason promotion.
+// anyNamedToolCall reports whether tool_calls has a call with a non-empty
+// function name. Nameless tool_calls (seen intermittently from GLM/Qwen/Kimi/
+// gpt-oss on vLLM/SGLang/DeepInfra) are malformed: forwarded as-is they make
+// the client invoke tool "" and infinite-loop retrying, so they're dropped
+// and must not drive stop_reason promotion.
 func anyNamedToolCall(toolCalls gjson.Result) bool {
 	found := false
 	toolCalls.ForEach(func(_, tc gjson.Result) bool {

--- a/internal/translate/translate_test.go
+++ b/internal/translate/translate_test.go
@@ -494,11 +494,10 @@ func messageStartID(t *testing.T, body string) string {
 	return ""
 }
 
-// On the eager-Prelude path (the normal streaming dispatch), message_start
-// fires before any upstream chunk carries an id, so the translator generates
-// the message id itself. It must be unique per response — clients (notably
-// ccusage) dedupe usage records by message id, so a constant placeholder
-// collapses every turn of a session into one record and undercounts cost.
+// On the eager-Prelude path, message_start fires before any upstream chunk
+// carries an id, so the translator generates one itself. It must be unique per
+// response: clients (e.g. ccusage) dedupe usage records by message id, so a
+// constant placeholder would collapse a session's turns into one record.
 func TestAnthropicSSETranslator_EagerPreludeMessageIDUniquePerResponse(t *testing.T) {
 	startID := func() string {
 		rec := httptest.NewRecorder()
@@ -556,14 +555,11 @@ func TestAnthropicSSETranslator_StreamingToolUse(t *testing.T) {
 	assert.Contains(t, body, "event: message_stop")
 }
 
-// Anthropic invariant: any response containing tool_use blocks MUST report
-// stop_reason="tool_use", regardless of what the OpenAI-compat upstream sent
-// as finish_reason. GLM-5.1 on DeepInfra (vLLM, tool_stream=true) and other
-// OpenAI-compat serves have been observed closing tool-emitting turns with
-// finish_reason="stop" or "" instead of "tool_calls"; without this promotion
-// the client receives tool_use blocks alongside stop_reason="end_turn" and
-// Claude Code executes the (often partial-arg) tool_use anyway, looping on
-// the identical result.
+// Any response with tool_use blocks must report stop_reason="tool_use" even if
+// the upstream finish_reason says otherwise. Some OpenAI-compat serves (e.g.
+// GLM-5.1 on DeepInfra) close tool-emitting turns with "stop" or "", which
+// without this promotion leaves Claude Code executing the tool_use anyway
+// under stop_reason="end_turn" and looping.
 func TestAnthropicSSETranslator_PromotesStopReasonWhenToolUseEmitted(t *testing.T) {
 	rec := httptest.NewRecorder()
 	translator := translate.NewAnthropicSSETranslator(rec, "z-ai/glm-5.1", nil)
@@ -592,10 +588,9 @@ func TestAnthropicSSETranslator_PromotesStopReasonWhenToolUseEmitted(t *testing.
 		"end_turn alongside emitted tool_use violates Anthropic spec and triggers client loops")
 }
 
-// Summary must expose, post-stream, the signals needed to diagnose the
-// GLM-5.1/DeepInfra tool loop from logs alone: the raw upstream finish_reason,
-// the promoted stop_reason, the fact that promotion fired, the tool_use block
-// count, and the upstream completion-token count.
+// Summary must expose the raw finish_reason, promoted stop_reason, whether
+// promotion fired, tool_use count, and completion tokens — enough to diagnose
+// the GLM-5.1/DeepInfra tool loop from logs alone.
 func TestAnthropicSSETranslator_SummaryReportsPromotionAndToolUse(t *testing.T) {
 	rec := httptest.NewRecorder()
 	translator := translate.NewAnthropicSSETranslator(rec, "z-ai/glm-5.1", nil)
@@ -654,12 +649,10 @@ func TestAnthropicSSETranslator_SummaryNoPromotionOnPlainStop(t *testing.T) {
 	assert.Equal(t, 0, got.ToolUseBlocks)
 }
 
-// Load-bearing: Gemini 3.x requires the opaque thoughtSignature round-tripped
-// on the next turn's functionCall part. When an upstream emits it as
-// function.thought_signature with a plain tool-call id (a Gemini model behind an
-// OpenAI-compatible gateway), AnthropicSSE must smuggle it into the tool_use id
-// — the single SDK-safe carrier — so every client echoes it back, instead of an
-// off-spec block field that typed SDKs drop and Anthropic upstreams reject.
+// Gemini 3.x requires the opaque thoughtSignature round-tripped on the next
+// turn's functionCall. When it arrives as function.thought_signature (Gemini
+// behind an OpenAI-compat gateway), we must smuggle it into the tool_use id —
+// the only field typed SDKs preserve and Anthropic upstreams won't reject.
 func TestAnthropicSSETranslator_StreamingToolUsePreservesThoughtSignature(t *testing.T) {
 	rec := httptest.NewRecorder()
 	translator := translate.NewAnthropicSSETranslator(rec, "gemini-x", nil)
@@ -711,10 +704,8 @@ func TestAnthropicSSETranslator_NonStreamingResponse(t *testing.T) {
 	assert.Equal(t, "Hello!", block["text"])
 }
 
-// Qwen via OpenRouter (and DeepSeek native) emit reasoning traces in
-// `reasoning` / `reasoning_content` deltas. Without translation these either
-// vanished or — when the model embedded the reasoning inline — leaked into the
-// visible text channel.
+// Qwen (via OpenRouter) and DeepSeek emit reasoning in `reasoning`/`reasoning_content`
+// deltas; without translation these vanish or leak into the visible text channel.
 func TestAnthropicSSETranslator_StreamingReasoningEmitsThinkingBlock(t *testing.T) {
 	rec := httptest.NewRecorder()
 	translator := translate.NewAnthropicSSETranslator(rec, "qwen/qwen3-coder-next", nil)
@@ -780,11 +771,10 @@ func TestAnthropicSSETranslator_StreamingReasoningContentField(t *testing.T) {
 	assert.Contains(t, body, `"text":"answer"`)
 }
 
-// DeepSeek-v4 on Fireworks emits a whitespace-only "\n\n" content delta
-// between its reasoning_content and its tool_calls. Opening a text block for it
-// renders as an empty assistant block wedged between the thinking block and the
-// tool_use. The translator must buffer whitespace-only leading content and drop
-// it when the turn ends on a tool_use rather than real text.
+// DeepSeek-v4/Fireworks emits a whitespace-only "\n\n" content delta between
+// reasoning_content and tool_calls. Opening a text block for it would wedge an
+// empty block between thinking and tool_use, so the translator must buffer and
+// drop whitespace-only leading content when the turn ends on tool_use.
 func TestAnthropicSSETranslator_WhitespaceOnlyContentBeforeToolCallSuppressed(t *testing.T) {
 	rec := httptest.NewRecorder()
 	translator := translate.NewAnthropicSSETranslator(rec, "deepseek/deepseek-v4-pro", nil)
@@ -813,9 +803,8 @@ func TestAnthropicSSETranslator_WhitespaceOnlyContentBeforeToolCallSuppressed(t 
 	assert.NotContains(t, body, `"type":"text_delta"`)
 }
 
-// When real text follows the whitespace-only delta, the buffered whitespace is
-// flushed as the text block's leading content so the model's formatting is
-// preserved (only the trailing-before-tool_use case is dropped).
+// When real text follows the whitespace-only delta, it's flushed as leading
+// content instead of dropped (only the trailing-before-tool_use case drops it).
 func TestAnthropicSSETranslator_WhitespaceFlushedWhenRealTextFollows(t *testing.T) {
 	rec := httptest.NewRecorder()
 	translator := translate.NewAnthropicSSETranslator(rec, "deepseek/deepseek-v4-pro", nil)


### PR DESCRIPTION
## Summary
- Part 3 of the comment-length cleanup (part 1: #583, part 2: #584). Sweeps the next tier of files (30 files, this tier much flatter — max ~8 blocks/file vs 157 in part 1).
- Same rule as prior parts: keep genuinely non-obvious "why" explanations (hidden constraints, bug workarounds, security/precision rationale, prod-incident context), cut restated/narrated filler.
- Comment-only changes, no logic touched. Skipped SQLC-generated files.
- Independent of #583/#584 (disjoint file sets, all branched off main) — can merge in any order.

## Test plan
- [x] `go build ./...` clean
- [x] `gofmt -l .` clean
- [x] `go vet ./...` clean
- [x] `go test ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)