### PR TITLE
chore: shorten verbose comments, part 4 (next 37 files)

### DIFF
--- a/cmd/genprices/main.go
+++ b/cmd/genprices/main.go
@@ -1,7 +1,6 @@
-// Command genprices rewrites the BEGIN_GENERATED_PRICES block in both
-// install/cc-statusline.sh and install/install.sh (the heredoc copy) from
-// pricingTable in internal/observability/otel/pricing.go.
-// Run via `make generate` or `go generate ./internal/observability/otel/`.
+// Command genprices rewrites the BEGIN_GENERATED_PRICES block in
+// install/cc-statusline.sh and install/install.sh from pricingTable in
+// internal/observability/otel/pricing.go. Run via `make generate`.
 package main
 
 import (
@@ -20,9 +19,9 @@ const (
 	endMarker   = "# END_GENERATED_PRICES"
 )
 
-// scriptPaths lists every file that contains a BEGIN/END_GENERATED_PRICES
-// block. install.sh carries the block inside a heredoc so the installer writes
-// cc-statusline.sh from its own content — no URL fetch required.
+// scriptPaths lists files containing a BEGIN/END_GENERATED_PRICES block.
+// install.sh carries it in a heredoc, letting the installer write
+// cc-statusline.sh without a URL fetch.
 var scriptPaths = []string{
 	"install/cc-statusline.sh",
 	"install/install.sh",
@@ -51,9 +50,8 @@ func spliceFile(path, block string) error {
 	return os.WriteFile(path, []byte(updated), 0o755)
 }
 
-// buildBlock produces the shell prices='{...}' assignment from the pricing table.
-// Values are in USD/1k (= USD/1M ÷ 1000) to match what the jq math in
-// cc-statusline.sh expects.
+// buildBlock produces the shell prices='{...}' assignment from the pricing
+// table, in USD/1k (= USD/1M ÷ 1000) to match cc-statusline.sh's jq math.
 func buildBlock(table map[string]otel.Pricing) string {
 	models := make([]string, 0, len(table))
 	for m := range table {
@@ -110,12 +108,9 @@ func maxLen(models []string) int {
 	return n
 }
 
-// fmtPrice formats a USD/1k price for the jq math in cc-statusline.sh.
-// Rounds to 6 significant figures before formatting so the generated block
-// doesn't carry IEEE 754 representation artifacts (e.g. 0.071/1000 would
-// otherwise render as 0.00007099999999999999). 6 sig figs gives ~10×
-// headroom over the smallest input we ever serialize (~6.5e-5 USD/k) and
-// stays well within the precision the downstream jq calculation needs.
+// fmtPrice formats a USD/1k price for cc-statusline.sh's jq math. Rounds to
+// 6 sig figs first so IEEE 754 artifacts (e.g. 0.071/1000 rendering as
+// 0.00007099999999999999) don't leak into the generated block.
 func fmtPrice(v float64) string {
 	if v == 0 {
 		return "0"

--- a/internal/api/admin/excluded_models.go
+++ b/internal/api/admin/excluded_models.go
@@ -13,17 +13,14 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
-// DeployedModelsSource exposes the universe of routable models the cluster
-// scorer knows about. The admin endpoint surfaces this so the UI can render
-// a checkbox per model. Implemented by *cluster.Multiversion in production;
-// callers can pass a fake in tests.
+// DeployedModelsSource exposes the routable models the cluster scorer knows
+// about. Implemented by *cluster.Multiversion; tests can pass a fake.
 type DeployedModelsSource interface {
 	DefaultDeployedModels() []cluster.DeployedEntry
 }
 
-// ExclusionOverrideSource reports whether ROUTER_EXCLUDED_MODELS (or an
-// equivalent deployment-wide override) is in effect, and what its contents
-// are. Implemented by *proxy.Service.
+// ExclusionOverrideSource reports the deployment-wide ROUTER_EXCLUDED_MODELS
+// override, if active. Implemented by *proxy.Service.
 type ExclusionOverrideSource interface {
 	HasExcludedModelsOverride() bool
 	ExcludedModelsOverride() []string
@@ -61,9 +58,8 @@ func deployedModelsDTO(models DeployedModelsSource) []deployedModelDTO {
 	return out
 }
 
-// GetExcludedModelsHandler returns deployed models and the installation's exclusion list.
-// When a deployment-wide env override is active, `env_override_active` is true and the
-// UI must render the checklist read-only.
+// GetExcludedModelsHandler returns deployed models and the installation's
+// exclusion list. `env_override_active` tells the UI to render read-only.
 func GetExcludedModelsHandler(authSvc *auth.Service, models DeployedModelsSource, override ExclusionOverrideSource) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		installation, ok := resolveInstallation(c, authSvc)
@@ -94,8 +90,7 @@ func GetExcludedModelsHandler(authSvc *auth.Service, models DeployedModelsSource
 }
 
 // UpdateExcludedModelsHandler replaces the installation's exclusion list.
-// Rejects unknown model IDs with 400. Returns 403 when the env override is
-// active so the UI never silently loses a save.
+// 400 on unknown model IDs; 403 if the env override is active.
 func UpdateExcludedModelsHandler(authSvc *auth.Service, models DeployedModelsSource, override ExclusionOverrideSource) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		log := observability.FromGin(c)

--- a/internal/api/admin/excluded_providers.go
+++ b/internal/api/admin/excluded_providers.go
@@ -12,9 +12,8 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
-// ProviderExclusionOverrideSource reports whether ROUTER_EXCLUDED_PROVIDERS
-// (or an equivalent deployment-wide override) is in effect, and what its
-// contents are. Implemented by *proxy.Service.
+// ProviderExclusionOverrideSource reports the deployment-wide ROUTER_EXCLUDED_PROVIDERS
+// override, if active. Implemented by *proxy.Service.
 type ProviderExclusionOverrideSource interface {
 	HasExcludedProvidersOverride() bool
 	ExcludedProvidersOverride() []string
@@ -30,9 +29,8 @@ type updateExcludedProvidersRequest struct {
 	Excluded []string `json:"excluded"`
 }
 
-// deployedProvidersDTO returns the distinct provider names behind the
-// deployed-models registry, sorted. Centralized so the GET and PUT responses
-// cannot drift apart.
+// deployedProvidersDTO returns distinct provider names from the deployed-models
+// registry, sorted, so GET and PUT responses can't drift apart.
 func deployedProvidersDTO(models DeployedModelsSource) []string {
 	seen := make(map[string]struct{})
 	out := make([]string, 0)
@@ -47,10 +45,8 @@ func deployedProvidersDTO(models DeployedModelsSource) []string {
 	return out
 }
 
-// GetExcludedProvidersHandler returns the deployed provider names and the
-// installation's provider exclusion list. When a deployment-wide env override
-// is active, `env_override_active` is true and the UI must render the
-// checklist read-only.
+// GetExcludedProvidersHandler returns deployed providers and the installation's
+// exclusion list. `env_override_active` tells the UI to render read-only.
 func GetExcludedProvidersHandler(authSvc *auth.Service, models DeployedModelsSource, override ProviderExclusionOverrideSource) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		installation, ok := resolveInstallation(c, authSvc)
@@ -78,9 +74,8 @@ func GetExcludedProvidersHandler(authSvc *auth.Service, models DeployedModelsSou
 	}
 }
 
-// UpdateExcludedProvidersHandler replaces the installation's provider
-// exclusion list. Rejects unknown provider names with 400. Returns 403 when
-// the env override is active so the UI never silently loses a save.
+// UpdateExcludedProvidersHandler replaces the installation's exclusion list.
+// 400 on unknown providers; 403 if the env override is active.
 func UpdateExcludedProvidersHandler(authSvc *auth.Service, models DeployedModelsSource, override ProviderExclusionOverrideSource) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		log := observability.FromGin(c)

--- a/internal/auth/apikey_cache_test.go
+++ b/internal/auth/apikey_cache_test.go
@@ -75,12 +75,9 @@ func TestLRUAPIKeyCache_InvalidateInstallationDoesNotTouchNegativeEntries(t *tes
 }
 
 func TestLRUAPIKeyCache_NaturalEvictionKeepsSecondaryIndexConsistent(t *testing.T) {
-	// Capacity of 1 forces the second insert to evict the first via the LRU
-	// callback. If the secondary index still held the evicted hash, a later
-	// invalidate of installation A would try to remove a hash that's already
-	// gone (harmless) — but if the second insert *re-used* installation A,
-	// the invalidate must still drop the surviving entry. This guards the
-	// onEvict bookkeeping that ties the two together.
+	// Capacity 1 forces eviction on the second insert. Guards that onEvict
+	// bookkeeping still lets InvalidateInstallation drop the surviving entry
+	// when the second insert reuses the same installation.
 	cache := auth.NewLRUAPIKeyCache(1, 1, time.Hour, time.Hour)
 
 	cache.Set("h-old", auth.CachedKey{
@@ -99,16 +96,12 @@ func TestLRUAPIKeyCache_NaturalEvictionKeepsSecondaryIndexConsistent(t *testing.
 		"after an LRU eviction-then-reinsert under the same installation, InvalidateInstallation must still drop the surviving entry")
 }
 
-// TestLRUAPIKeyCache_InvalidationDuringSetEvictsOrphan models the
-// concurrency window where Set has indexed its keyHash under
-// byInstallation but has not yet completed positive.Add when
-// InvalidateInstallation runs. Without the generation-counter
-// recheck in Set, the entry would land in the positive LRU after
-// the invalidate already cleared the index — orphaning it until
-// TTL and silently surviving a policy change. Driving the race
-// directly is flaky; instead we drive the same logical sequence
-// step-by-step from a single goroutine, exercising the exact
-// state transitions Set traverses.
+// TestLRUAPIKeyCache_InvalidationDuringSetEvictsOrphan covers the race where
+// Set indexes byInstallation before positive.Add completes while
+// InvalidateInstallation runs concurrently. Without the generation-counter
+// recheck in Set, the entry would land in the LRU after the index was
+// already cleared, orphaning it until TTL. The true race is flaky to
+// trigger, so this drives the same interleaving deterministically.
 func TestLRUAPIKeyCache_InvalidationDuringSetEvictsOrphan(t *testing.T) {
 	cache := auth.NewLRUAPIKeyCache(8, 8, time.Hour, time.Hour)
 
@@ -118,11 +111,8 @@ func TestLRUAPIKeyCache_InvalidationDuringSetEvictsOrphan(t *testing.T) {
 		Installation: &auth.Installation{ID: "inst-A"},
 	})
 
-	// Invalidate concurrently from another goroutine while we race a
-	// Set. The test passes deterministically because of the recheck:
-	// regardless of interleaving, every invalidation that fires after
-	// the Set begins must result in a cache that does NOT serve the
-	// new entry on Get.
+	// Race Invalidate against Set from another goroutine; the recheck
+	// guarantees no invalidation-after-Set-start leaves h-race visible.
 	done := make(chan struct{})
 	go func() {
 		for range 50 {
@@ -135,9 +125,7 @@ func TestLRUAPIKeyCache_InvalidationDuringSetEvictsOrphan(t *testing.T) {
 			APIKey:       &auth.APIKey{ID: "k-race"},
 			Installation: &auth.Installation{ID: "inst-A"},
 		})
-		// After every Set/Invalidate pair, follow with a final
-		// invalidate so the post-state is unambiguous: nothing for
-		// inst-A may survive.
+		// Final invalidate ensures nothing for inst-A survives.
 		cache.InvalidateInstallation("inst-A")
 	}
 	<-done
@@ -145,9 +133,8 @@ func TestLRUAPIKeyCache_InvalidationDuringSetEvictsOrphan(t *testing.T) {
 	_, ok := cache.Get("h-race")
 	assert.False(t, ok, "no entry for inst-A may survive the final invalidation, even when Set and Invalidate interleave")
 
-	// And follow-up: a fresh Set after the final invalidate must
-	// land in the cache (proving generation tracking didn't pin
-	// the installation out permanently).
+	// A fresh Set after the final invalidate must still land (generation
+	// tracking isn't a permanent pin).
 	cache.Set("h-post", auth.CachedKey{
 		APIKey:       &auth.APIKey{ID: "k-post"},
 		Installation: &auth.Installation{ID: "inst-A"},

--- a/internal/auth/service.go
+++ b/internal/auth/service.go
@@ -130,12 +130,10 @@ func (s *Service) ListAPIKeys(ctx context.Context, installationID string) ([]*AP
 }
 
 // RotateAPIKey soft-deletes the named key and issues a replacement under the
-// same installation, carrying forward the previous key's name. Returns
-// ErrAPIKeyNotFound when keyID does not match an active key owned by the
-// installation, so a tenant who learns a foreign key UUID cannot rotate it.
-//
-// Not wrapped in a tx: a brief "no active key" window is acceptable because
-// rotation's purpose is to invalidate the old token anyway.
+// same installation, carrying forward its name. Returns ErrAPIKeyNotFound if
+// keyID isn't an active key owned by installationID, so a foreign key UUID
+// can't be rotated. Not transactional: the brief "no active key" gap is fine
+// since rotation's whole point is invalidating the old token anyway.
 func (s *Service) RotateAPIKey(ctx context.Context, installationID, keyID string, createdBy *string) (*APIKey, string, error) {
 	existing, err := s.apiKeys.ListForInstallation(ctx, installationID)
 	if err != nil {
@@ -162,11 +160,9 @@ func (s *Service) RotateAPIKey(ctx context.Context, installationID, keyID string
 	return key, raw, nil
 }
 
-// DeleteAPIKey soft-deletes an API key and immediately invalidates the
-// installation's cache entry on this replica and all peers. Without the
-// invalidation the deleted key would remain usable for up to the positive
-// cache TTL (5 min) — the same window that RotateAPIKey closes via
-// invalidateInstallation.
+// DeleteAPIKey soft-deletes an API key and invalidates the installation's
+// cache entry on this replica and all peers, so the key doesn't stay usable
+// for the remainder of the positive cache TTL (5 min).
 func (s *Service) DeleteAPIKey(ctx context.Context, installationID, id string) error {
 	if err := s.apiKeys.SoftDelete(ctx, installationID, id); err != nil {
 		return err
@@ -280,10 +276,9 @@ func (s *Service) SetInstallationExcludedProviders(ctx context.Context, external
 }
 
 // SetInstallationRoutingPreference persists the routing quality weight (a
-// normalized fraction in [0, 1]) on the installation. Passing nil clears the
-// preference so the scorer reverts to its tuned per-cluster defaults.
-// Invalidates the API-key cache so the change takes effect on the next request
-// rather than after the cache TTL.
+// normalized fraction in [0, 1]). Passing nil clears it so the scorer reverts
+// to its tuned per-cluster defaults. Invalidates the cache so the change
+// applies on the next request instead of waiting out the TTL.
 func (s *Service) SetInstallationRoutingPreference(ctx context.Context, externalID, installationID string, qualityWeight *float64) error {
 	if err := s.installations.UpdateRoutingPreference(ctx, externalID, installationID, qualityWeight); err != nil {
 		return err
@@ -292,11 +287,10 @@ func (s *Service) SetInstallationRoutingPreference(ctx context.Context, external
 	return nil
 }
 
-// SetInstallationSubscriptionRoutingDisabled toggles subscription-aware routing
-// for the installation. When true, the scorer's subscription subsidy bonus is
-// suppressed so routing decides on merits and non-Claude models compete fairly.
-// Invalidates the API-key cache so the change takes effect on the next request
-// rather than after the cache TTL.
+// SetInstallationSubscriptionRoutingDisabled toggles subscription-aware
+// routing. When true, the scorer's subscription subsidy bonus is suppressed
+// so non-Claude models compete fairly. Invalidates the cache so the change
+// applies on the next request instead of waiting out the TTL.
 func (s *Service) SetInstallationSubscriptionRoutingDisabled(ctx context.Context, externalID, installationID string, disabled bool) error {
 	if err := s.installations.UpdateSubscriptionRoutingDisabled(ctx, externalID, installationID, disabled); err != nil {
 		return err
@@ -305,9 +299,9 @@ func (s *Service) SetInstallationSubscriptionRoutingDisabled(ctx context.Context
 	return nil
 }
 
-// VerifyAPIKey authenticates a raw bearer token against the API key cache then Postgres.
-// Returns ErrInvalidPrefix/ErrInvalidToken for unauthenticated cases.
-// Returned ExternalAPIKey slice has Plaintext populated; nil when none exist.
+// VerifyAPIKey authenticates a raw bearer token against the cache then Postgres,
+// returning ErrInvalidPrefix/ErrInvalidToken on failure. The returned
+// ExternalAPIKey slice has Plaintext populated, or nil if none exist.
 func (s *Service) VerifyAPIKey(ctx context.Context, rawToken string) (*Installation, *APIKey, []*ExternalAPIKey, error) {
 	if !HasAPIKeyPrefix(rawToken) {
 		return nil, nil, nil, ErrInvalidPrefix
@@ -349,11 +343,11 @@ func (s *Service) VerifyAPIKey(ctx context.Context, rawToken string) (*Installat
 	return installation, apiKey, externalKeys, nil
 }
 
-// ResolveAndStashUser upserts a router user and stashes the ID on ctx.
-// Email takes precedence as the lookup key. When only claudeAccountUUID is present,
-// the row is keyed on account_uuid with NULL email. displayName is best-effort
-// metadata persisted alongside the identity; empty = leave existing value.
-// Best-effort: returns ctx unchanged on failure — must never fail an authenticated request.
+// ResolveAndStashUser upserts a router user and stashes the ID on ctx. Email
+// takes precedence as the lookup key; with only claudeAccountUUID, the row is
+// keyed on account_uuid with NULL email. displayName is best-effort (empty
+// leaves the existing value). Never fails an authenticated request — returns
+// ctx unchanged on error.
 func (s *Service) ResolveAndStashUser(ctx context.Context, installationID, email, claudeAccountUUID, displayName string) context.Context {
 	log := observability.Get()
 	if s.users == nil || installationID == "" {

--- a/internal/billing/repo.go
+++ b/internal/billing/repo.go
@@ -5,41 +5,32 @@ import "context"
 // Repo is the adapter-boundary contract for credit billing reads and writes.
 // Implementations live in internal/postgres/billing_repo.go.
 type Repo interface {
-	// GetBalance returns the org's current balance in USD micros. If no
-	// balance row exists for the org, returns ErrBalanceRowMissing — callers
-	// distinguish "row missing" from "balance == 0" at the boundary so the
-	// log line is unambiguous.
+	// GetBalance returns the org's balance in USD micros, or
+	// ErrBalanceRowMissing if no row exists (distinct from balance == 0).
 	GetBalance(ctx context.Context, orgID string) (balanceMicros int64, err error)
 
-	// HasActiveOverride reports whether the org currently has an unexpired
-	// billing override. Used by middleware to short-circuit balance checks
-	// and by the debit hook to pick the delta=0 path.
+	// HasActiveOverride reports whether the org has an unexpired billing
+	// override, used to short-circuit balance checks and pick the delta=0
+	// debit path.
 	HasActiveOverride(ctx context.Context, orgID string) (bool, error)
 
-	// DebitInference performs an atomic UPDATE + INSERT in a single
-	// statement: decrement the balance row and append the matching ledger
-	// row. When override is active, delta is 0 and the ledger row still
-	// records notional_cost_micros for the shadow billing trail. Returns
-	// the post-debit balance.
+	// DebitInference atomically decrements the balance and appends the
+	// ledger row. Under an active override, delta is 0 but the ledger row
+	// still records notional_cost_micros for the shadow billing trail.
 	DebitInference(ctx context.Context, p DebitParams) (balanceAfterMicros int64, err error)
 
-	// GetAPIKeySpend reads a key's lifetime spend cap and spend-to-date fresh
-	// from Postgres (bypassing the auth cache) so the spend-cap gate cannot be
-	// overrun by a hot cached key. found is false when no active key matches the
-	// id (deleted mid-request); callers treat that as "no cap to enforce".
+	// GetAPIKeySpend reads a key's spend cap and spend-to-date fresh from
+	// Postgres, bypassing the auth cache. found is false if the key was
+	// deleted mid-request, treated as "no cap to enforce".
 	GetAPIKeySpend(ctx context.Context, apiKeyID string) (spentMicros int64, capMicros *int64, found bool, err error)
 
-	// GetAutopayConfig reports whether the org has autopay enabled and its
-	// recharge threshold (USD micros), read by the debit hook to detect a
-	// balance crossing below the threshold. A missing config row (org never
-	// configured autopay) returns enabled=false with a nil error — callers
-	// treat that as "autopay off" and skip the crossing check.
+	// GetAutopayConfig reports the org's autopay state and recharge
+	// threshold. A missing config row returns enabled=false, nil error
+	// ("autopay off"), not an error.
 	GetAutopayConfig(ctx context.Context, orgID string) (enabled bool, thresholdMicros int64, err error)
 
-	// BillingTablesExist is a boot-time health check: returns true when
-	// all three billing tables exist in the router schema. A missing
-	// table means the migration hasn't run; the composition root then
-	// disables billing rather than 500ing on every request.
+	// BillingTablesExist is a boot-time check for the three billing tables.
+	// A missing table means the migration hasn't run yet.
 	BillingTablesExist(ctx context.Context) (bool, error)
 }
 
@@ -51,8 +42,7 @@ type DebitParams struct {
 	EntryType          string // 'inference', 'adjustment', etc.
 	RouterRequestID    string // upstream call id; suffix ('_summary','_main') used for handover rows
 	RouterModel        string
-	// APIKeyID, when non-empty, attributes this debit to the api key so its
-	// lifetime spent_usd_micros is bumped in the same transaction. Empty on
-	// paths with no key on context.
+	// APIKeyID, if non-empty, attributes the debit to that key, bumping its
+	// lifetime spent_usd_micros in the same transaction.
 	APIKeyID string
 }

--- a/internal/billing/service_test.go
+++ b/internal/billing/service_test.go
@@ -101,8 +101,7 @@ func TestCheckBalance_Override(t *testing.T) {
 	res, err := svc.CheckBalance(context.Background(), "org_x")
 	require.NoError(t, err)
 	assert.True(t, res.HasOverride)
-	// When override is active the service must not bother reading the
-	// balance — the middleware doesn't need it and the row may be missing.
+	// Override path skips the balance read entirely; the row may be missing.
 	assert.Equal(t, int64(0), res.BalanceMicros, "balance must be skipped on override path")
 }
 
@@ -123,10 +122,8 @@ func TestCheckBalance_MissingRowPropagates(t *testing.T) {
 }
 
 func TestDebitForInference_MatchesExportedCostMath(t *testing.T) {
-	// The debit hook must compute the same notional cost as the OTel
-	// emitter and telemetry writer — they all go through the exported
-	// pricing functions now. If this drifts the customer sees a billed
-	// amount different from the dashboard cost.
+	// Debit cost must match the OTel emitter/telemetry writer (same pricing
+	// funcs) — drift means the billed amount diverges from the dashboard.
 	repo := &fakeRepo{balanceRowExists: true, balanceMicros: 10_000_000}
 	svc := billing.NewService(repo)
 	p := catalog.Pricing{InputUSDPer1M: 3.00, OutputUSDPer1M: 15.00, CacheReadMultiplier: 0.10}
@@ -153,9 +150,8 @@ func TestDebitForInference_MatchesExportedCostMath(t *testing.T) {
 }
 
 func TestDebitForInference_OverrideWritesZeroDeltaWithNotional(t *testing.T) {
-	// Override path: ledger row must record the would-be charge in
-	// notional_cost_micros while leaving the balance untouched. This is
-	// the shadow billing trail the plan requires for capacity planning.
+	// Override: ledger records the would-be charge in notional_cost_micros
+	// but leaves balance untouched — the shadow trail for capacity planning.
 	repo := &fakeRepo{balanceRowExists: true, balanceMicros: 0}
 	svc := billing.NewService(repo)
 	p := catalog.Pricing{InputUSDPer1M: 3.00, OutputUSDPer1M: 15.00, CacheReadMultiplier: 0.10}
@@ -176,9 +172,8 @@ func TestDebitForInference_OverrideWritesZeroDeltaWithNotional(t *testing.T) {
 }
 
 func TestDebitForInference_SubscriptionDebitsNothing(t *testing.T) {
-	// Served on the customer's own subscription: their plan already covers the
-	// tokens, so Weave charges nothing — the ledger debits 0 while the notional
-	// row still records the full would-be cost as a shadow trail.
+	// Subscription-served: the customer's plan covers the tokens, so the debit
+	// is 0 while notional still records the full would-be cost as a shadow trail.
 	repo := &fakeRepo{balanceRowExists: true, balanceMicros: 10_000_000}
 	svc := billing.NewService(repo)
 	p := catalog.Pricing{InputUSDPer1M: 3.00, OutputUSDPer1M: 15.00, CacheReadMultiplier: 0.10}
@@ -224,10 +219,8 @@ func TestDebitForInference_OverrideBeatsSubscription(t *testing.T) {
 }
 
 func TestDebitForInference_BalanceCanGoNegative(t *testing.T) {
-	// Concurrent-debit semantics: when two requests pass preflight with a
-	// thin balance and both debit, the second goes negative. The Service
-	// must accept this — no balance>=amount guard. The middleware's
-	// min-balance threshold bounds the typical dip.
+	// Two concurrent debits against a thin balance: the Service has no
+	// balance>=amount guard, so the second goes negative by design.
 	repo := &fakeRepo{balanceRowExists: true, balanceMicros: 500_000} // $0.50
 	svc := billing.NewService(repo)
 	p := catalog.Pricing{InputUSDPer1M: 3.00, OutputUSDPer1M: 15.00, CacheReadMultiplier: 0.10}
@@ -249,10 +242,8 @@ func TestDebitForInference_BalanceCanGoNegative(t *testing.T) {
 }
 
 func TestDebitForInference_ZeroTokensYieldsZeroCharge(t *testing.T) {
-	// A real failure mode: upstream returns 0-token usage (timeouts, 5xx
-	// before any tokens were produced). Notional must be 0 and balance
-	// unchanged — billing the customer for "0 tokens worth of cost" would
-	// be confusing.
+	// 0-token usage (timeout/5xx before generation) must yield 0 notional
+	// cost and leave the balance unchanged.
 	repo := &fakeRepo{balanceRowExists: true, balanceMicros: 5_000_000}
 	svc := billing.NewService(repo)
 	p := catalog.Pricing{InputUSDPer1M: 3.00, OutputUSDPer1M: 15.00, CacheReadMultiplier: 0.10}
@@ -278,9 +269,8 @@ func TestDebitForInference_RepoErrorPropagates(t *testing.T) {
 }
 
 func TestDebitForInference_AttributesAPIKey(t *testing.T) {
-	// The api_key_id and the negative delta both flow to the repo so the CTE
-	// can bump the key's lifetime spent counter by the debit magnitude. On a
-	// real debit spent should grow by exactly the notional charge (= -delta).
+	// api_key_id and delta flow to the repo's CTE, which bumps the key's
+	// lifetime spend by the debit magnitude (-delta).
 	repo := &fakeRepo{balanceRowExists: true, balanceMicros: 10_000_000}
 	svc := billing.NewService(repo)
 	p := catalog.Pricing{InputUSDPer1M: 3.00, OutputUSDPer1M: 15.00, CacheReadMultiplier: 0.10}

--- a/internal/postgres/session_pin_repo.go
+++ b/internal/postgres/session_pin_repo.go
@@ -55,13 +55,9 @@ func (r *SessionPinRepo) Upsert(ctx context.Context, p sessionpin.Pin) error {
 	})
 }
 
-// UpdateUsage records the previous turn's upstream token usage on the
-// existing pin row. The UPDATE matches by (session_key, role); a
-// missing pin (evicted, never created, or already swept) affects zero
-// rows and surfaces as a successful no-op so callers off the request
-// path don't have to special-case it. A zero-valued EndedAt is
-// defensively stamped with time.Now so the column is always populated
-// once a turn has produced usage.
+// UpdateUsage records the previous turn's usage on the pin row. A missing
+// pin (evicted/swept/never created) is a no-op, not an error. A zero
+// EndedAt is stamped with time.Now so the column is always populated.
 func (r *SessionPinRepo) UpdateUsage(ctx context.Context, sessionKey [sessionpin.SessionKeyLen]byte, role string, usage sessionpin.Usage) error {
 	endedAt := usage.EndedAt
 	if endedAt.IsZero() {
@@ -80,11 +76,9 @@ func (r *SessionPinRepo) UpdateUsage(ctx context.Context, sessionKey [sessionpin
 	})
 }
 
-// IncrementUpstreamErrors atomically bumps the consecutive-error
-// counter and returns the new value. A missing pin (already evicted
-// by force-model or loop-break, or never created) surfaces as
-// (0, nil) so the turn loop's two-strike check treats it as a no-op
-// — the relevant signal is gone and there's no row left to evict.
+// IncrementUpstreamErrors atomically bumps the consecutive-error counter.
+// A missing pin (already evicted or never created) returns (0, nil): the
+// two-strike check treats it as a no-op since there's no row left to evict.
 func (r *SessionPinRepo) IncrementUpstreamErrors(ctx context.Context, sessionKey [sessionpin.SessionKeyLen]byte, role string) (int, error) {
 	q := sqlc.New(r.tx)
 	count, err := q.IncrementSessionPinUpstreamErrors(ctx, sqlc.IncrementSessionPinUpstreamErrorsParams{
@@ -101,8 +95,7 @@ func (r *SessionPinRepo) IncrementUpstreamErrors(ctx context.Context, sessionKey
 }
 
 // ResetUpstreamErrors clears the consecutive-error counter after a
-// successful turn. Missing pin = successful no-op (mirrors
-// UpdateUsage's semantics).
+// successful turn. Missing pin is a no-op, same as UpdateUsage.
 func (r *SessionPinRepo) ResetUpstreamErrors(ctx context.Context, sessionKey [sessionpin.SessionKeyLen]byte, role string) error {
 	q := sqlc.New(r.tx)
 	return q.ResetSessionPinUpstreamErrors(ctx, sqlc.ResetSessionPinUpstreamErrorsParams{
@@ -143,9 +136,8 @@ func toSessionPin(row sqlc.RouterSessionPin) sessionpin.Pin {
 	return pin
 }
 
-// timestamptzOrZero mirrors timestampOrZero for TIMESTAMPTZ columns;
-// NULL on the wire is surfaced as the time.Time zero value so callers
-// can branch on IsZero() rather than threading a pointer through.
+// timestamptzOrZero mirrors timestampOrZero for TIMESTAMPTZ columns:
+// NULL becomes the zero value instead of a pointer.
 func timestamptzOrZero(t pgtype.Timestamptz) time.Time {
 	if !t.Valid {
 		return time.Time{}

--- a/internal/providers/openai/client_output_stall_test.go
+++ b/internal/providers/openai/client_output_stall_test.go
@@ -1,16 +1,13 @@
 package openai_test
 
-// Guards the OUTPUT-progress watchdog — the second half of the gpt-5.x stall
-// protection, distinct from the byte-idle watchdog in client_stall_test.go.
-// Prod incident 2026-06-16: a /v1/responses stream stayed byte-alive (reasoning
-// deltas / keepalives kept the byte-idle watchdog reset) yet produced ZERO
-// output tokens until the router's 600s cap. The byte-idle watchdog cannot
-// catch that — only a watchdog that measures time-since-last-OUTPUT can. The
-// translator reports output progress via ArmOutputProgress; these tests stand
-// in a fake writer for it so the client half is pinned independently: a
-// byte-alive/output-silent stream aborts at the output-stall budget with a
-// retryable ErrUpstreamOutputStall, while a stream whose writer keeps marking
-// output progress is never aborted.
+// Guards the OUTPUT-progress watchdog, the second half of gpt-5.x stall
+// protection (distinct from the byte-idle watchdog in client_stall_test.go).
+// Prod incident 2026-06-16: a stream stayed byte-alive (keepalives reset the
+// byte-idle watchdog) yet produced ZERO output tokens until the 600s cap —
+// only a time-since-last-OUTPUT watchdog catches that. A fake writer stands
+// in for the translator's ArmOutputProgress so the client half is pinned
+// independently: byte-alive/output-silent aborts retryable; output-flowing
+// never aborts.
 
 import (
 	"context"
@@ -31,9 +28,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// fakeProgressWriter stands in for the Responses→Anthropic translator: it
-// exposes ArmOutputProgress so the client wires its output-progress watchdog,
-// and optionally calls the mark on each Write to simulate output flowing.
+// fakeProgressWriter stands in for the translator: it exposes
+// ArmOutputProgress and optionally marks progress on each Write.
 type fakeProgressWriter struct {
 	mu          sync.Mutex
 	hdr         http.Header
@@ -74,10 +70,9 @@ func (f *fakeProgressWriter) ArmOutputProgress(mark func()) bool {
 	return f.armReturns
 }
 
-// streamsNonOutputFramesForever returns an upstream that commits 200 + SSE
-// headers, then emits a non-output frame every interval until the client
-// disconnects. Bytes keep flowing (the byte-idle watchdog never trips); none of
-// them is output-bearing, so only the output-progress watchdog can end it.
+// streamsNonOutputFramesForever emits a non-output SSE frame every interval
+// until disconnect: bytes keep flowing (byte-idle never trips) but none is
+// output-bearing, so only the output-progress watchdog can end it.
 func streamsNonOutputFramesForever(interval time.Duration) *httptest.Server {
 	const frame = "event: response.in_progress\ndata: {\"type\":\"response.in_progress\"}\n\n"
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -103,9 +98,8 @@ func TestProxy_OutputStallAbortsRetryable_ByteAliveNoOutput(t *testing.T) {
 	upstream := streamsNonOutputFramesForever(15 * time.Millisecond)
 	defer upstream.Close()
 
-	// Byte-idle far longer than the frame interval (so it never fires);
-	// output-stall short (so it fires). This is the 2026-06-16 separation:
-	// bytes flowing, output silent.
+	// byteIdle >> frame interval (never fires); outputStall short (fires) —
+	// the 2026-06-16 separation of bytes-flowing vs. output-silent.
 	const byteIdle = 5 * time.Second
 	const outputStall = 120 * time.Millisecond
 	c := openai.NewClientWithStallTimeouts("test-key", upstream.URL, stallTestHeaderTimeout, byteIdle, outputStall)
@@ -128,8 +122,7 @@ func TestProxy_OutputStallAbortsRetryable_ByteAliveNoOutput(t *testing.T) {
 }
 
 func TestProxy_OutputFlowingStreamIsNotOutputStalled(t *testing.T) {
-	// Same frame cadence, but the writer marks output progress on every relayed
-	// frame (simulating real output). The output-stall watchdog must keep
+	// Writer marks output progress on every frame; the watchdog must keep
 	// resetting and never trip, even though total duration exceeds its budget.
 	const frame = "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"delta\":\"x\"}\n\n"
 	const frames = 6

--- a/internal/providers/openai/client_stall_test.go
+++ b/internal/providers/openai/client_stall_test.go
@@ -1,18 +1,12 @@
 package openai_test
 
-// Guards the mid-stream half of the gpt-5.x stall protection (the
-// time-to-first-byte half lives in client_timeout_test.go). Prod incident
-// 2026-06-09 (customer benchmark org): two /v1/responses streams returned
-// headers and then produced ZERO output tokens until the router's 600s cap
-// (proxy_ms 599,991 and 599,880, both resp_output_tokens=0). The
-// ResponseHeaderTimeout cannot fire once headers have arrived, so the only
-// guard against a post-header stall is the idle-progress watchdog. These
-// tests pin its contract: a zero-progress stall aborts at the idle threshold,
-// the error is retryable (so dispatchWithFallback re-attempts), and no
-// response bytes reach the client writer; a slow-but-flowing stream — long
-// reasoning turns emit SSE event frames even while "thinking", and ANY bytes
-// count as progress — is never aborted; and a stalled >=400 error body cannot
-// hang the buffered-error read.
+// Guards the mid-stream half of gpt-5.x stall protection (TTFB half is in
+// client_timeout_test.go). Prod incident 2026-06-09: /v1/responses streams
+// returned headers then produced ZERO output tokens until the 600s cap.
+// ResponseHeaderTimeout can't fire post-header, so the idle-progress
+// watchdog is the only guard. Pins: zero-progress stalls abort + retryable +
+// no bytes written; flowing streams (any bytes = progress) are never
+// aborted; a stalled error body can't hang the buffered-error read.
 
 import (
 	"context"
@@ -43,10 +37,8 @@ func responsesPrep() providers.PreparedRequest {
 }
 
 func TestProxy_MidStreamStallAbortsRetryableNothingWritten(t *testing.T) {
-	// The upstream commits 200 + SSE headers, then goes silent forever. The
-	// only timer in play is the injected tiny idle threshold; release is
-	// closed (defer, LIFO) before upstream.Close() so the handler unblocks
-	// even if the watchdog's cancel didn't already end its request context.
+	// Upstream sends headers then goes silent forever. release closes
+	// (defer, LIFO) before upstream.Close() so the handler always unblocks.
 	release := make(chan struct{})
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/event-stream")
@@ -76,17 +68,15 @@ func TestProxy_MidStreamStallAbortsRetryableNothingWritten(t *testing.T) {
 	assert.GreaterOrEqual(t, elapsed, idleTimeout, "must not abort before the idle threshold")
 	assert.Less(t, elapsed, stallTestHeaderTimeout,
 		"must abort at the idle threshold — a regression here re-opens the 600s zero-token hang")
-	// In the dispatch path the per-attempt writer is the preludeBuffer chain,
-	// and failover is only legal while it holds zero committed bytes. A stall
-	// with no upstream bytes must therefore leave the writer body empty.
+	// Failover is only legal while the preludeBuffer chain holds zero
+	// committed bytes, so a zero-byte stall must leave the writer empty.
 	assert.Zero(t, rec.Body.Len(), "no response bytes may reach the client writer on a zero-byte stall")
 }
 
 func TestProxy_SlowButFlowingStreamIsNotAborted(t *testing.T) {
-	// Frames arrive slower than a fast stream but well inside the idle
-	// budget; the stream's TOTAL duration exceeds the idle budget several
-	// times over. Only a zero-progress gap may trip the watchdog — total
-	// duration never does (long thinking turns with progress must survive).
+	// Frames arrive slower than a fast stream but each gap is inside the
+	// idle budget, even though total duration exceeds it — only a
+	// zero-progress gap may trip the watchdog, never total duration.
 	const frame = "event: response.in_progress\ndata: {}\n\n"
 	const frames = 5
 	const frameInterval = 60 * time.Millisecond
@@ -120,10 +110,9 @@ func TestProxy_SlowButFlowingStreamIsNotAborted(t *testing.T) {
 }
 
 func TestProxy_StalledErrorBodyDoesNotHang(t *testing.T) {
-	// The upstream returns 500 headers, promises a body, and never sends it.
-	// The buffered-error read must abort on the idle watchdog and still
-	// surface the status-classified *UpstreamErrorResponse so the dispatch
-	// loop's status-based retry logic applies.
+	// Upstream sends 500 headers, promises a body, never sends it. The
+	// buffered-error read must abort on the idle watchdog yet still surface
+	// *UpstreamErrorResponse for the dispatch loop's status-based retry.
 	release := make(chan struct{})
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")

--- a/internal/proxy/baseline_failover_integration_test.go
+++ b/internal/proxy/baseline_failover_integration_test.go
@@ -29,12 +29,10 @@ const anthropicMessageSSE = "event: message_start\ndata: {\"type\":\"message_sta
 	"event: message_delta\ndata: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\"},\"usage\":{\"output_tokens\":1}}\n\n" +
 	"event: message_stop\ndata: {\"type\":\"message_stop\"}\n\n"
 
-// TestProxyMessages_OSSOutageFailsOverToBaselineAnthropic wires the real
-// dispatch path against stub upstreams and asserts the in-turn baseline
-// failover: when the router cost-routes a `claude-opus-4-8` request to an OSS
-// model (deepseek/deepseek-v4-pro) and every OSS binding fails (the Redwood
-// demo's Fireworks-503 → OpenRouter-down double outage), the turn re-dispatches
-// the requested model on Anthropic instead of surfacing "model may not exist".
+// TestProxyMessages_OSSOutageFailsOverToBaselineAnthropic: when a cost-routed
+// OSS model (deepseek/deepseek-v4-pro) fails on every binding, the turn
+// re-dispatches the requested model (claude-opus-4-8) on Anthropic instead of
+// surfacing "model may not exist" (the Redwood demo double outage).
 func TestProxyMessages_OSSOutageFailsOverToBaselineAnthropic(t *testing.T) {
 	var (
 		mu                     sync.Mutex
@@ -125,10 +123,9 @@ func TestProxyMessages_OSSOutageFailsOverToBaselineAnthropic(t *testing.T) {
 	assert.Equal(t, "claude-opus-4-8", store.usages[len(store.usages)-1].ServedModel, "pin usage records the served baseline model")
 }
 
-// TestProxyMessages_OSSOutageNoBaselineWhenRequestedModelIsOSS asserts the
-// guard: when the caller themselves requested the OSS model (so the baseline
-// equals the routed model), exhaustion surfaces the upstream error envelope —
-// baseline failover does NOT fire and does not mask the real failure.
+// TestProxyMessages_OSSOutageNoBaselineWhenRequestedModelIsOSS: when the caller
+// requested the OSS model directly (baseline == routed model), exhaustion
+// surfaces the real upstream error instead of masking it via failover.
 func TestProxyMessages_OSSOutageNoBaselineWhenRequestedModelIsOSS(t *testing.T) {
 	var anthropicCount int
 	anthropicUpstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -168,10 +165,9 @@ func TestProxyMessages_OSSOutageNoBaselineWhenRequestedModelIsOSS(t *testing.T) 
 	assert.Equal(t, 0, anthropicCount, "baseline failover must not fire when the caller requested the OSS model")
 }
 
-// TestProxyMessages_OSSOutageNoBaselineWhenAnthropicExcluded asserts the
-// provider-exclusion contract: when the installation excludes Anthropic,
-// baseline failover must NOT defer the OSS error to an Anthropic retry it can
-// never run — the original upstream error surfaces and Anthropic is never hit.
+// TestProxyMessages_OSSOutageNoBaselineWhenAnthropicExcluded: when Anthropic is
+// excluded, baseline failover must not retry against it — the original
+// upstream error surfaces instead.
 func TestProxyMessages_OSSOutageNoBaselineWhenAnthropicExcluded(t *testing.T) {
 	var anthropicCount int
 	anthropicUpstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -211,10 +207,9 @@ func TestProxyMessages_OSSOutageNoBaselineWhenAnthropicExcluded(t *testing.T) {
 	assert.NotEqual(t, providers.ProviderAnthropic, rec.Header().Get(proxy.HeaderRouterProvider), "served provider must not be the excluded Anthropic")
 }
 
-// TestProxyMessages_FailedBaselineReportsAnthropicProvider asserts that when
-// both the OSS bindings AND the Anthropic baseline retry fail, the telemetry
-// row pairs the baseline (Anthropic) model with the Anthropic provider — not
-// the OSS primary that never served that model.
+// TestProxyMessages_FailedBaselineReportsAnthropicProvider: when both the OSS
+// bindings and the Anthropic baseline retry fail, telemetry must pair the
+// baseline model with the Anthropic provider, not the OSS primary.
 func TestProxyMessages_FailedBaselineReportsAnthropicProvider(t *testing.T) {
 	fail := func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")

--- a/internal/proxy/conformance_openai_test.go
+++ b/internal/proxy/conformance_openai_test.go
@@ -1,8 +1,7 @@
 package proxy_test
 
-// OpenAI /v1/chat/completions conformance cases (the format every OpenAI-compat
-// upstream shares: OpenAI, OpenRouter, Fireworks, DeepInfra, Bedrock). Each
-// pins a known translation behavior or past regression.
+// OpenAI /v1/chat/completions conformance cases, shared by every OpenAI-compat
+// upstream. Each pins a known translation behavior or past regression.
 
 import (
 	"net/http"
@@ -22,9 +21,8 @@ func openRouterClient(baseURL string) providers.Client {
 
 const weatherTool = `[{"name":"get_weather","description":"Get the weather","input_schema":{"type":"object","properties":{"city":{"type":"string"}},"required":["city"]}}]`
 
-// readTool mirrors the Claude Code Read tool shape: a required param, an
-// optional string, an integer, and a closed schema — enough surface for the
-// toolcheck validate/repair conformance cases.
+// readTool mirrors the Claude Code Read tool shape: required param, optional
+// string, integer, closed schema — for toolcheck validate/repair cases.
 const readTool = `[{"name":"Read","description":"Read a file","input_schema":{"type":"object","properties":{"file_path":{"type":"string"},"pages":{"type":"string"},"limit":{"type":"integer"}},"required":["file_path"],"additionalProperties":false}}]`
 
 func TestConformance_OpenAIChat(t *testing.T) {
@@ -69,9 +67,8 @@ func TestConformance_OpenAIChat(t *testing.T) {
 			},
 		},
 		{
-			// Guards router #293: an upstream that closes finish_reason="tool_calls"
-			// but emits no usable (named) tool_use block must demote stop_reason to
-			// end_turn, not strand the agent waiting for a tool call that never comes.
+			// Guards #293: finish_reason="tool_calls" with no usable tool_use
+			// block must demote stop_reason to end_turn, not strand the agent.
 			name:            "openai_chat/degenerate_toolcall_demotes",
 			provider:        providers.ProviderOpenRouter,
 			model:           "deepseek/deepseek-v4-pro",
@@ -81,9 +78,9 @@ func TestConformance_OpenAIChat(t *testing.T) {
 			upstreamFixture: "openai_chat/degenerate_toolcall.upstream.sse",
 		},
 		{
-			// Guards the OpenRouter-only request gates: deepseek/* must carry the
-			// provider-pin hint and reasoning:{enabled:false} so OpenRouter pins a
-			// prefix-caching host and doesn't burn max_tokens on hidden thinking.
+			// deepseek/* must carry the provider-pin hint and
+			// reasoning:{enabled:false} to pin a caching host and avoid
+			// burning max_tokens on hidden thinking.
 			name:            "openai_chat/openrouter_gates",
 			provider:        providers.ProviderOpenRouter,
 			model:           "deepseek/deepseek-v4-pro",
@@ -110,10 +107,8 @@ func TestConformance_OpenAIChat(t *testing.T) {
 			},
 		},
 		{
-			// toolcheck unrepairable tier: a mismatched closer can't be fixed
-			// deterministically, so the args degrade to `{}` (never the raw
-			// malformed bytes) and the tool_use block stays dispatchable. The
-			// golden pins the `{}` substitution.
+			// Unrepairable args degrade to `{}` (never raw malformed bytes)
+			// so the tool_use block stays dispatchable.
 			name:            "openai_chat/invalid_toolcall_args",
 			provider:        providers.ProviderOpenRouter,
 			model:           "deepseek/deepseek-v4-pro",
@@ -123,10 +118,8 @@ func TestConformance_OpenAIChat(t *testing.T) {
 			upstreamFixture: "openai_chat/invalid_toolcall_args.upstream.sse",
 		},
 		{
-			// toolcheck normalize+repair tier on one call: empty-string optional
-			// dropped (#339 semantics), hallucinated param dropped (schema closes
-			// additionalProperties), "5"-for-integer losslessly coerced. The
-			// golden pins the cleaned input reaching the client.
+			// Normalize+repair: empty-string optional dropped (#339),
+			// hallucinated param dropped, "5"-for-integer coerced.
 			name:            "openai_chat/toolcall_repaired_args",
 			provider:        providers.ProviderOpenRouter,
 			model:           "deepseek/deepseek-v4-pro",

--- a/internal/proxy/conformance_responses_test.go
+++ b/internal/proxy/conformance_responses_test.go
@@ -1,9 +1,8 @@
 package proxy_test
 
-// OpenAI Responses API (/v1/responses) conformance cases. Reasoning gpt-5.x with
-// tools routes here instead of /v1/chat/completions. These guard router #331
-// (the request MUST stream upstream, or the header-timeout hang returns) and the
-// Responses-SSE -> Anthropic translation, plus the #328 medium-effort promotion.
+// OpenAI Responses API conformance: reasoning gpt-5.x + tools routes here
+// instead of chat/completions. Guards #331 (must stream upstream) and #328
+// (medium-effort promotion).
 
 import (
 	"net/http"
@@ -26,9 +25,7 @@ func TestConformance_OpenAIResponses(t *testing.T) {
 
 	cases := []conformanceCase{
 		{
-			// Streaming client: full Responses-SSE -> Anthropic translation
-			// (reasoning->thinking, output_text->text, function_call->tool_use)
-			// plus the load-bearing stream:true guard.
+			// Full Responses-SSE -> Anthropic translation plus the load-bearing stream:true guard.
 			name:            "responses/toolcall_stream",
 			provider:        providers.ProviderOpenAI,
 			model:           "gpt-5.5",
@@ -74,10 +71,8 @@ func TestConformance_OpenAIResponses(t *testing.T) {
 			},
 		},
 		{
-			// Strict-decode prevention layer: every strictifiable tool schema
-			// must go out with strict:true + the strictified parameters
-			// (additionalProperties:false, all-required, optionals nullable),
-			// so gpt-5.x grammar-constrains tool arguments at decode time.
+			// Strictifiable schemas must go out strict:true, additionalProperties:false,
+			// all-required, optionals as null unions.
 			name:            "responses/strict_tools",
 			provider:        providers.ProviderOpenAI,
 			model:           "gpt-5.5",
@@ -102,10 +97,8 @@ func TestConformance_OpenAIResponses(t *testing.T) {
 			},
 		},
 		{
-			// toolcheck on the Responses path: a truncated function_call
-			// arguments payload (missing closing brace in both the deltas and
-			// the terminal item) is deterministically repaired before reaching
-			// the client. The golden pins the closed, valid input.
+			// toolcheck must repair a truncated function_call arguments payload
+			// (missing closing brace) before it reaches the client.
 			name:            "responses/invalid_toolcall",
 			provider:        providers.ProviderOpenAI,
 			model:           "gpt-5.5",

--- a/internal/proxy/credentials_test.go
+++ b/internal/proxy/credentials_test.go
@@ -35,10 +35,8 @@ func TestBuildCredentialsMap_IndexesByProvider(t *testing.T) {
 }
 
 func TestBuildCredentialsMap_DropsEmptyPlaintext(t *testing.T) {
-	// An empty Plaintext indicates a stale or malformed BYOK row (insertion
-	// bug, or decryption that produced no bytes). Such an entry must not
-	// enroll the provider into the routing eligibility set: argmax would
-	// pick it and the upstream call would 401 with no auth header.
+	// An empty Plaintext means a stale/malformed BYOK row; it must not enroll
+	// the provider, or argmax would pick it and the upstream call would 401.
 	keys := []*auth.ExternalAPIKey{
 		{Provider: "openrouter", Plaintext: []byte{}},
 		{Provider: "anthropic", Plaintext: []byte("sk-ant-byok")},
@@ -84,9 +82,8 @@ func TestExtractClientCredentials_Google(t *testing.T) {
 	assert.Equal(t, []byte("goog-client-key"), creds.APIKey)
 }
 
-// Makora and Together are OpenAI-compat providers that were missing from the
-// old literal Bearer-branch list, so a client-supplied key for them was dropped
-// (never forwarded as BYOK). Keying off the translation family fixes that.
+// Makora/Together were missing from the old literal Bearer-branch list, so a
+// client-supplied key was dropped; keying off the translation family fixes it.
 func TestExtractClientCredentials_OpenAICompatBearer(t *testing.T) {
 	for _, provider := range []string{"makora", "together"} {
 		t.Run(provider, func(t *testing.T) {
@@ -150,9 +147,8 @@ func TestExtractClientCredentials_RejectsRouterBearerForFireworks(t *testing.T) 
 }
 
 func TestExtractClientCredentials_OpenRouterNoAuthHeader(t *testing.T) {
-	// Anthropic-format clients (Claude Code with x-api-key) have no Authorization
-	// header. ExtractClientCredentials must return nil so the caller falls back to
-	// the deployment-level env key rather than injecting empty credentials.
+	// Anthropic-format clients have no Authorization header; must return nil
+	// so the caller falls back to the deployment-level env key.
 	headers := http.Header{"X-Api-Key": []string{"rk_router_key"}}
 	creds := proxy.ExtractClientCredentials("openrouter", headers)
 	assert.Nil(t, creds,
@@ -283,10 +279,8 @@ func TestResolveCredentials_SubscriptionBeatsBYOK(t *testing.T) {
 const codexJWT = "eyJhbGciOiJSUzI1NiJ9.codex-access-token.signature"
 
 func TestExtractClientCredentials_CodexSubscription(t *testing.T) {
-	// A Codex (ChatGPT) subscription arrives on the OpenAI surface as an OAuth
-	// JWT bearer paired with a ChatGPT-Account-ID header. The pairing is what
-	// distinguishes it from a plain client API key, and both pieces are carried
-	// so the OpenAI client can reach the Codex backend.
+	// A Codex subscription is an OAuth JWT bearer paired with a
+	// ChatGPT-Account-Id header, distinguishing it from a plain API key.
 	headers := http.Header{
 		"Authorization":      []string{"Bearer " + codexJWT},
 		"Chatgpt-Account-Id": []string{"acct-12345"},
@@ -324,9 +318,8 @@ func TestExtractClientCredentials_OpenAIKeyWithAccountIDIsNotSubscription(t *tes
 }
 
 func TestExtractClientCredentials_CodexSubscriptionIsOpenAIOnly(t *testing.T) {
-	// The Codex JWT authenticates only the OpenAI Codex backend; a ChatGPT
-	// account-id header on another vendor's surface must not produce an OAuth
-	// credential for that vendor.
+	// The Codex JWT is OpenAI-only; an account-id header on another vendor's
+	// surface must not produce an OAuth credential there.
 	headers := http.Header{
 		"Authorization":      []string{"Bearer " + codexJWT},
 		"Chatgpt-Account-Id": []string{"acct-12345"},

--- a/internal/proxy/force_model_tier_fallback_internal_test.go
+++ b/internal/proxy/force_model_tier_fallback_internal_test.go
@@ -17,12 +17,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// tierProbeRouter mimics the production-observed collapse that motivated the
-// fix: among the eligible candidates (available models minus ExcludedModels) it
-// returns the CHEAPEST one (lowest tier). Without a tier constraint a dropped
-// high-tier force-model would therefore route to the low-tier default; with the
-// constraint the low-tier candidates are excluded, so it must return a same-tier
-// model. It records every request so the constraint itself can be asserted.
+// tierProbeRouter reproduces the production collapse: it returns the cheapest
+// eligible candidate, so an unconstrained fallback would pick the low-tier
+// default. It records every request so the tier constraint can be asserted.
 type tierProbeRouter struct {
 	available map[string]struct{}
 	captured  []router.Request
@@ -69,12 +66,9 @@ func (s *forcedPinStore) ResetUpstreamErrors(context.Context, [sessionpin.Sessio
 }
 func (s *forcedPinStore) SweepExpired(context.Context) error { return nil }
 
-// TestRunTurnLoop_ForcedModelContextOverflow_StaysInTier is the regression for
-// the debug-session bug: a user force-pinned deepseek-v4-pro (TierHigh) was
-// evicted by the context-window pre-filter and the turn collapsed all the way
-// to haiku (TierLow) instead of the next-best same-tier model. The fix
-// constrains the fresh decision to the forced model's tier, so the evicted
-// high-tier pin reroutes to a high-tier model (here, Opus).
+// Regression: a force-pinned high-tier model evicted by the context-window
+// pre-filter used to collapse all the way to the low-tier default instead of
+// the next-best same-tier model.
 func TestRunTurnLoop_ForcedModelContextOverflow_StaysInTier(t *testing.T) {
 	const forced = "deepseek/deepseek-v4-pro"
 	require.Equal(t, catalog.TierHigh, catalog.TierFor(forced), "test premise: forced model is high-tier")
@@ -123,10 +117,8 @@ func TestRunTurnLoop_ForcedModelContextOverflow_StaysInTier(t *testing.T) {
 	assert.False(t, opusExcluded, "the same-tier replacement must remain eligible")
 }
 
-// TestRestrictToTier_FallsBackWhenNoInTierCandidate guards the empty-pool
-// escape hatch: when no in-tier model would survive the constraint, the helper
-// returns the original denylist and ok=false so the caller leaves routing
-// unconstrained rather than handing the scorer an empty pool.
+// Guards the empty-pool escape hatch: with no in-tier candidate, the helper
+// must return ok=false rather than hand the scorer an empty pool.
 func TestRestrictToTier_FallsBackWhenNoInTierCandidate(t *testing.T) {
 	svc := NewService(nil, nil, nil, false, nil, nil, false,
 		providers.ProviderAnthropic, "claude-haiku-4-5", nil).
@@ -138,9 +130,8 @@ func TestRestrictToTier_FallsBackWhenNoInTierCandidate(t *testing.T) {
 	assert.Equal(t, excluded, out, "the original denylist is returned unchanged on fallback")
 }
 
-// TestRestrictToTier_ExcludesOtherTiers verifies the constraint set: every
-// available model outside the target tier is added to the denylist while
-// in-tier models stay eligible.
+// Every available model outside the target tier gets excluded; in-tier
+// models stay eligible.
 func TestRestrictToTier_ExcludesOtherTiers(t *testing.T) {
 	svc := NewService(nil, nil, nil, false, nil, nil, false,
 		providers.ProviderAnthropic, "claude-haiku-4-5", nil).

--- a/internal/proxy/router_feedback.go
+++ b/internal/proxy/router_feedback.go
@@ -32,22 +32,17 @@ type RouterFeedbackEvent struct {
 	SessionID      string
 	RequestedModel string
 	ServedModel    string
-	// Rating is the thumbs verdict ("up", "down", or "" for a note-only
-	// submission), parsed from the /rf+ /rf- shortcuts or a leading verdict
-	// token in the note.
+	// Rating is the thumbs verdict ("up", "down", or "" for note-only),
+	// parsed from /rf+ /rf- or a leading verdict token in the note.
 	Rating string
-	// Feedback is the human-readable submission persisted to
-	// router.router_feedback. When the user gave only a verdict, it carries a
-	// compact label ("👍" / "👎") so the column is never empty and stays
-	// self-describing without a dedicated rating column.
+	// Feedback is the persisted submission text; verdict-only submissions
+	// get a compact emoji so the column is never empty.
 	Feedback string
 }
 
-// handleRouterFeedbackCommand processes a /router-feedback directive: it
-// persists the feedback to router.router_feedback, emits a router.feedback
-// telemetry span (the same OTel pipeline the per-request decision/upstream
-// spans ride, so the WorkWeave backend ingests it like any other event), and
-// returns a synthetic acknowledgment without dispatching to any upstream.
+// handleRouterFeedbackCommand persists a /router-feedback submission, emits a
+// router.feedback span on the standard OTel pipeline, and returns a synthetic
+// acknowledgment without dispatching to any upstream.
 func (s *Service) handleRouterFeedbackCommand(
 	ctx context.Context,
 	w http.ResponseWriter,
@@ -63,10 +58,8 @@ func (s *Service) handleRouterFeedbackCommand(
 	feedback := strings.TrimSpace(cmd.Feedback)
 	rating := cmd.Rating
 	if rating == "" && feedback == "" {
-		// Nothing actionable: no verdict and no note. Acknowledgment text is
-		// formatted as a routing marker so the existing
-		// StripRoutingMarkerFromMessages ingress stripper removes it from
-		// subsequent inbound requests (see handleForceModelCommand).
+		// No verdict and no note. Message is formatted as a routing marker so
+		// StripRoutingMarkerFromMessages strips it from later requests.
 		msg := "✦ **Weave Router** → Router-feedback needs a verdict or a note, e.g. /rf+ or /rf- too slow.\n\n"
 		if env.SourceFormat() == translate.FormatOpenAI {
 			msg = "Weave Router: router-feedback needs a verdict or a note, e.g. /rf+ or /rf- too slow."
@@ -105,9 +98,8 @@ func (s *Service) handleRouterFeedbackCommand(
 			Rating:         rating,
 			Feedback:       persistedFeedbackText(rating, feedback),
 		}
-		// context.Background(): the request ctx may already be canceled by the
-		// time this runs (client disconnected mid-command). Feedback the user
-		// explicitly typed must not be dropped on a canceled context.
+		// context.Background(): ctx may already be canceled (client disconnected
+		// mid-command); don't drop feedback the user explicitly typed.
 		if err := s.feedbackStore.InsertRouterFeedback(context.Background(), event); err != nil {
 			log.Error("/router-feedback: feedback insert failed", "err", err)
 			return err
@@ -146,10 +138,9 @@ func (s *Service) handleRouterFeedbackCommand(
 	return writeSyntheticCommandResponse(w, env, routerFeedbackAck(env.SourceFormat(), rating), inputTokens)
 }
 
-// routerFeedbackAck renders the synthetic acknowledgment for a recorded
-// submission, echoing the verdict so the user sees their rating landed. The
-// Anthropic-format ack is wrapped as a routing marker so the existing ingress
-// stripper removes it from subsequent turns.
+// routerFeedbackAck renders the acknowledgment, echoing the verdict. The
+// Anthropic-format ack is wrapped as a routing marker so it gets stripped
+// from subsequent turns.
 func routerFeedbackAck(format translate.Format, rating string) string {
 	verdict := ""
 	switch rating {
@@ -165,8 +156,7 @@ func routerFeedbackAck(format translate.Format, rating string) string {
 }
 
 // persistedFeedbackText is the value written to router.router_feedback.feedback.
-// A verdict-only submission stores a compact emoji so the NOT NULL column is
-// never empty and stays self-describing.
+// Verdict-only submissions get a compact emoji so the NOT NULL column is never empty.
 func persistedFeedbackText(rating, feedback string) string {
 	if feedback != "" {
 		return feedback
@@ -181,9 +171,7 @@ func persistedFeedbackText(rating, feedback string) string {
 }
 
 // writeSyntheticCommandResponse writes a router-command acknowledgment in the
-// inbound wire format without dispatching upstream. inputTokens is the
-// request's RoutingFeatures.Tokens so the client's token counter reflects the
-// actual turn input.
+// inbound wire format without dispatching upstream.
 func writeSyntheticCommandResponse(w http.ResponseWriter, env *translate.RequestEnvelope, msg string, inputTokens int) error {
 	switch env.SourceFormat() {
 	case translate.FormatOpenAI:

--- a/internal/proxy/session_key_test.go
+++ b/internal/proxy/session_key_test.go
@@ -19,9 +19,8 @@ func anthropicEnv(t *testing.T, body string) *translate.RequestEnvelope {
 }
 
 func TestDeriveSessionKey_StableAcrossTurns(t *testing.T) {
-	// Claude Code mutates the system prompt every turn, so turn2 carries a
-	// different system block. The key must still be stable: it keys on the
-	// (unchanging) first user message, not the volatile system text.
+	// System prompt mutates every turn; key must stay stable on the
+	// unchanging first user message instead.
 	turn1 := anthropicEnv(t, `{
 		"model": "claude-sonnet-4-6",
 		"system": "You are a careful coding assistant. <reminder>cwd=/a</reminder>",
@@ -59,9 +58,7 @@ func TestDeriveSessionKey_DiffersAcrossAPIKeys(t *testing.T) {
 }
 
 func TestDeriveSessionKey_IgnoresSystemPrompt(t *testing.T) {
-	// System text is volatile (Claude Code rewrites it every turn), so it must
-	// NOT move the key. Two requests that differ only in system prompt — same
-	// first user message — collide.
+	// System text is volatile and must not move the key.
 	envA := anthropicEnv(t, `{
 		"system": "You are agent A.",
 		"messages": [{"role": "user", "content": "go"}]
@@ -78,10 +75,9 @@ func TestDeriveSessionKey_IgnoresSystemPrompt(t *testing.T) {
 }
 
 func TestDeriveSessionKey_SeparatesSubAgentsSharingUserID(t *testing.T) {
-	// The fix: Claude Code sends ONE metadata.user_id for the main loop and all
-	// of a session's sub-agents. Keying on user_id alone funneled them onto a
-	// single pin that concurrent threads thrashed. The first user message (each
-	// sub-agent's distinct dispatch prompt) must split them into separate pins.
+	// Claude Code sends ONE metadata.user_id for the main loop and all
+	// sub-agents; keying on user_id alone thrashed a shared pin. The distinct
+	// first user message must split them apart.
 	mainLoop := anthropicEnv(t, `{
 		"metadata": {"user_id": "device=abc;account=u1;session=42"},
 		"system": "main loop system",
@@ -100,8 +96,8 @@ func TestDeriveSessionKey_SeparatesSubAgentsSharingUserID(t *testing.T) {
 }
 
 func TestDeriveSessionKey_SameUserIDAndFirstMessageCollide(t *testing.T) {
-	// Stability counterpart: same user_id AND same first user message — across
-	// a thread's turns, even as the system prompt mutates — stay on one pin.
+	// Stability counterpart: same user_id + same first message stay on one
+	// pin across turns, even as the system prompt mutates.
 	turn1 := anthropicEnv(t, `{
 		"metadata": {"user_id": "device=abc;session=42"},
 		"system": "system v1",
@@ -124,9 +120,8 @@ func TestDeriveSessionKey_SameUserIDAndFirstMessageCollide(t *testing.T) {
 }
 
 func TestDeriveSessionKey_DistinctMetadataUserIDsDoNotCollide(t *testing.T) {
-	// Claude Code packs {device_id, account_uuid, session_id} into
-	// metadata.user_id, so different sessions for the same human produce
-	// different keys — that's the whole point of a *session* pin.
+	// metadata.user_id packs {device_id, account_uuid, session_id}, so
+	// different sessions for the same human must get different keys.
 	envA := anthropicEnv(t, `{
 		"metadata": {"user_id": "device=abc;session=1"},
 		"messages": [{"role": "user", "content": "x"}]
@@ -143,8 +138,8 @@ func TestDeriveSessionKey_DistinctMetadataUserIDsDoNotCollide(t *testing.T) {
 }
 
 func TestDeriveSessionKey_MetadataTierDoesNotCollideWithPromptTier(t *testing.T) {
-	// Domain separation: metadata-tier and prompt-prefix-tier must not
-	// collide even when metadata.user_id matches the prompt-prefix shape.
+	// Metadata-tier and prompt-prefix-tier keys must not collide even when
+	// the values look alike.
 	envWithMeta := anthropicEnv(t, `{
 		"metadata": {"user_id": "user_id:fake"},
 		"messages": [{"role": "user", "content": "x"}]
@@ -175,11 +170,9 @@ func openAIEnv(t *testing.T, body string) *translate.RequestEnvelope {
 }
 
 func TestDeriveSessionKey_OpenAILeadingSystemDoesNotCollapse(t *testing.T) {
-	// OpenAI-format bodies carry `system` inside messages[], so messages.0 is a
-	// system role and FirstUserMessageText is empty. Without metadata.user_id,
-	// distinct conversations must still get distinct pins — DeriveSessionKey
-	// falls back to system text rather than collapsing every OpenAI session on
-	// one API key onto a single pin.
+	// OpenAI bodies carry `system` inside messages[], so FirstUserMessageText
+	// is empty; DeriveSessionKey must fall back to system text instead of
+	// collapsing every session on one API key onto a single pin.
 	convoA := openAIEnv(t, `{
 		"messages": [
 			{"role": "system", "content": "You are assistant A."},

--- a/internal/proxy/turn_logs.go
+++ b/internal/proxy/turn_logs.go
@@ -71,16 +71,11 @@ func (m ContentCaptureMode) String() string {
 }
 
 // maybeCaptureResponse wraps w with a content-capturing writer when capture is
-// enabled. The returned captureWriter (nil when off) mirrors the exact bytes
-// delivered to the client, so the captured response is in the client's native
-// wire format regardless of which upstream served it.
+// enabled, mirroring the exact bytes sent to the client (nil when off).
 //
-// The /v1/responses surface hands us a *translate.ResponsesWriter that performs
-// its own surface translation and emits an eager prelude straight to its inner
-// writer. Wrapping it externally would capture the pre-translation event stream
-// and miss the prelude, so for that case we splice the capture writer in at the
-// ResponsesWriter's true client boundary instead — yielding the exact Responses
-// wire, prelude included — and return the ResponsesWriter unchanged as the sink.
+// ResponsesWriter translates and emits an eager prelude to its inner writer, so
+// wrapping it externally would miss the prelude and capture pre-translation
+// bytes; instead we splice the capture writer at its true client boundary.
 func (s *Service) maybeCaptureResponse(w http.ResponseWriter) (http.ResponseWriter, *captureWriter) {
 	if s.captureMode == CaptureOff {
 		return w, nil
@@ -110,19 +105,15 @@ func capturedResponse(c *captureWriter) (body []byte, truncated bool) {
 	return b, false
 }
 
-// deferredCallLog lets a wrapping handler run the call-log emission after the
-// response body is fully written. The /v1/responses surface wraps the client
-// in a translate.ResponsesWriter and calls Finalize only after
-// ProxyOpenAIChatCompletion returns; reading the captured body before Finalize
-// would yield empty/partial content. When a holder is present on the context,
-// ProxyOpenAIChatCompletion stores its emit closure here instead of running it
-// inline, and the wrapper invokes run() post-Finalize.
+// deferredCallLog lets a wrapping handler run call-log emission after the
+// response body is fully written, since /v1/responses' ResponsesWriter only
+// calls Finalize after ProxyOpenAIChatCompletion returns (reading the
+// captured body earlier would yield empty/partial content).
 type deferredCallLog struct {
 	fn func()
-	// requestBody, when set, overrides the captured request body for the call
-	// log. ProxyOpenAIResponses sets it to the client's original Responses JSON
-	// so io.request_body matches the Responses-format response body, rather than
-	// the translated Chat Completions payload ProxyOpenAIChatCompletion sees.
+	// requestBody overrides the captured request body: ProxyOpenAIResponses
+	// sets it to the client's original Responses JSON so io.request_body
+	// matches, instead of the translated Chat Completions payload.
 	requestBody []byte
 }
 
@@ -159,13 +150,9 @@ func sha256Hex(b []byte) string {
 }
 
 // recordCallLog emits a high-fidelity `router.call` OTLP log record for one
-// upstream call. It reuses the upstream span's already-built attributes as the
-// metadata base (decision, tokens, cost, latency, cluster scoring) and appends
-// content attributes per the capture mode. No-op when capture is off, when the
-// emitter is disabled (RecordLog finds no buffer), so callers need not guard.
-//
-// base is the slice returned by the upstream span's AttrBuilder.Build(); it is
-// cloned before appending so the span's attributes are never mutated.
+// upstream call, reusing the upstream span's attributes as the metadata base
+// and appending content attributes per capture mode. No-op when capture is
+// off. base is cloned before appending so the span's attributes aren't mutated.
 func (s *Service) recordCallLog(ctx context.Context, base []*commonv1.KeyValue, isErr bool, reqBody, respBody []byte, respTruncated bool) {
 	if s.captureMode == CaptureOff {
 		return

--- a/internal/proxy/turnloop_internal_test.go
+++ b/internal/proxy/turnloop_internal_test.go
@@ -14,8 +14,7 @@ import (
 )
 
 // stubPinStore is a minimal sessionpin.Store for testing recordTurnUsage.
-// getPin/getFound configure the Get response; both default to a miss so
-// existing tests that rely on "no Postgres row" keep working unchanged.
+// getPin/getFound configure Get's response and default to a miss.
 type stubPinStore struct {
 	mu        sync.Mutex
 	lastUsage sessionpin.Usage
@@ -65,9 +64,8 @@ func (s *stubPinStore) ResetUpstreamErrors(context.Context, [sessionpin.SessionK
 func (s *stubPinStore) SweepExpired(context.Context) error { return nil }
 
 // TestRecordTurnUsage_WritesToStore guards the synchronous UpdateUsage write:
-// recordTurnUsage must persist Last* fields to Postgres in-line on the request
-// path so the planner has prior-turn evidence by the time the next turn loads
-// the pin.
+// recordTurnUsage must persist Last* fields in-line so the planner has
+// prior-turn evidence by the next turn.
 func TestRecordTurnUsage_WritesToStore(t *testing.T) {
 	store := newStubPinStore()
 	svc := NewService(
@@ -105,10 +103,9 @@ func TestRecordTurnUsage_WritesToStore(t *testing.T) {
 	assert.False(t, store.lastUsage.EndedAt.IsZero(), "EndedAt must be stamped — the planner uses IsZero() as its no-prior-usage gate")
 }
 
-// TestLoadPin_DoesNotServeExpiredPostgresPinButKeepsEmitHistory guards the
-// expiry filter: expired rows must be routing misses, but their
-// has_ever_switched / last_served_model history still protects Anthropic emit
-// from poisoned thinking blocks that remain in the client transcript.
+// TestLoadPin_DoesNotServeExpiredPostgresPinButKeepsEmitHistory: expired rows
+// are routing misses, but has_ever_switched/last_served_model must survive so
+// Anthropic emit still strips poisoned thinking blocks.
 func TestLoadPin_DoesNotServeExpiredPostgresPinButKeepsEmitHistory(t *testing.T) {
 	store := newStubPinStore()
 	svc := NewService(
@@ -193,11 +190,9 @@ func TestLoadPin_ServesFreshPostgresPin(t *testing.T) {
 	assert.Equal(t, "anthropic", pin.Provider)
 }
 
-// TestModelSwitched covers the switch → stay → stay lifecycle that motivated
-// the has_ever_switched latch. The transition turn alone is not enough: once a
-// session has served two models, the stale-signed thinking blocks persist in
-// the client transcript, so every subsequent same-model turn must keep
-// stripping or Anthropic 400s.
+// TestModelSwitched covers switch → stay → stay: once a session has served
+// two models, every later same-model turn must keep stripping stale-signed
+// thinking blocks or Anthropic 400s — the has_ever_switched latch.
 func TestModelSwitched(t *testing.T) {
 	tests := []struct {
 		name             string

--- a/internal/pubsub/invalidation.go
+++ b/internal/pubsub/invalidation.go
@@ -19,10 +19,8 @@ import (
 // stall the request that triggered the settings change.
 const notifyTimeout = 2 * time.Second
 
-// replicaSubscriptionTTL is the expiration policy applied to per-replica
-// subscriptions. If a replica crashes without running its deferred cleanup,
-// the subscription is reclaimed by GCP after this idle window so leaked
-// subscriptions can't accumulate forever.
+// replicaSubscriptionTTL reclaims subscriptions leaked by replicas that
+// crash before running their deferred cleanup.
 const replicaSubscriptionTTL = 24 * time.Hour
 
 // subscriptionDeleteTimeout bounds the cleanup call during shutdown so a slow
@@ -40,8 +38,7 @@ func NewInvalidationNotifier(publisher *gcppubsub.Publisher) *InvalidationNotifi
 }
 
 // NotifyInstallationChanged publishes installationID on the invalidation topic.
-// Fire-and-forget: errors are logged and dropped because the write has already
-// committed and TTL is the cross-replica safety net.
+// Fire-and-forget: the write already committed, so failures just log and rely on cache TTL.
 func (n *InvalidationNotifier) NotifyInstallationChanged(installationID string) {
 	if installationID == "" {
 		return
@@ -60,16 +57,14 @@ func (n *InvalidationNotifier) NotifyInstallationChanged(installationID string) 
 	}()
 }
 
-// Stop flushes any buffered messages and shuts the publisher's background
-// goroutines down. Must be called during graceful shutdown — Client.Close()
-// does not stop publishers.
+// Stop flushes buffered messages and shuts the publisher down. Must be
+// called on graceful shutdown — Client.Close() does not stop publishers.
 func (n *InvalidationNotifier) Stop() {
 	n.publisher.Stop()
 }
 
 // InvalidationListener subscribes to the invalidation topic and forwards every
-// payload to the local cache. Pub/Sub's built-in retry handles transient failures;
-// under a sustained outage the cache TTL acts as the safety net.
+// payload to the local cache; cache TTL is the fallback under sustained outages.
 type InvalidationListener struct {
 	subscriber *gcppubsub.Subscriber
 	cache      auth.APIKeyCache
@@ -107,17 +102,10 @@ func (l *InvalidationListener) Run(ctx context.Context) {
 func (l *InvalidationListener) Wait() { <-l.done }
 
 // CreateReplicaSubscription provisions a per-replica subscription on topicID so
-// every replica receives every invalidation message. A shared subscription
-// would load-balance — only one replica would see each message — defeating
-// the cross-fleet broadcast we need for cache invalidation.
-//
-// The subscription name is "<prefix>-<uuid>" so concurrent replicas don't
-// collide. An expiration policy is set so subscriptions leaked by crashed
-// replicas are reclaimed automatically.
-//
-// Returns the fully-qualified subscription name and a cleanup func that
-// deletes the subscription. Cleanup uses context.Background() internally so
-// shutdown completes even when the parent context is already canceled.
+// every replica sees every invalidation message — a shared subscription would
+// load-balance and defeat the broadcast. Returns the subscription name and a
+// cleanup func; cleanup uses context.Background() so it still runs if the
+// caller's context is already canceled at shutdown.
 func CreateReplicaSubscription(
 	ctx context.Context,
 	client *gcppubsub.Client,

--- a/internal/router/cluster/artifacts_test.go
+++ b/internal/router/cluster/artifacts_test.go
@@ -197,9 +197,8 @@ func TestLoadRegistry_MissingBenchColumn(t *testing.T) {
 	assert.Contains(t, err.Error(), "missing bench_column")
 }
 
-// Catches in CI the "ship one bad bundle, lose the cluster scorer
-// entirely" footgun — production refuses to boot on any malformed
-// committed version.
+// Guards against shipping one bad bundle that boots production with no
+// cluster scorer at all.
 func TestEmbeddedArtifacts_AllVersionsLoadable(t *testing.T) {
 	versions, err := ListVersions()
 	require.NoError(t, err)
@@ -251,9 +250,7 @@ func TestListVersions_FlattensLegacyAndOmitsPseudoName(t *testing.T) {
 	assert.Contains(t, versions, "v0.21", "legacy v0.21 must remain reachable after the move")
 }
 
-// Confirms bundleDirForVersion resolves legacy bundles transparently —
-// callers don't have to know whether a version lives at the root or
-// under legacy/.
+// bundleDirForVersion must resolve legacy bundles transparently.
 func TestResolveVersion_LegacyBundleIsReachable(t *testing.T) {
 	resolved, err := ResolveVersion("v0.21")
 	require.NoError(t, err)
@@ -352,11 +349,7 @@ func TestCheapestModelInSet(t *testing.T) {
 	})
 
 	t.Run("denySet excludes models even when allowed by allowSet", func(t *testing.T) {
-		// allowSet permits model-b and model-c (both google, both in
-		// the registry); denySet excludes the cheapest of the two —
-		// model-c — forcing the resolver to fall back to model-b.
-		// Guards the PR #100 issue where tier clamping bypassed the
-		// request's ExcludedModels denylist.
+		// Guards PR #100: tier clamping bypassed the request's denylist.
 		allow := map[string]struct{}{"model-b": {}, "model-c": {}}
 		deny := map[string]struct{}{"model-c": {}}
 		p, m, ok := CheapestModelInSet(meta, registry, available, deny, allow)
@@ -450,9 +443,7 @@ func TestFastestModelInSet(t *testing.T) {
 	available := map[string]struct{}{"google": {}, "deepinfra": {}}
 
 	t.Run("low-tier clamp prefers fast flash-lite over cheap v4-flash", func(t *testing.T) {
-		// Mirrors the real haiku-tier clamp: both models are in-ceiling;
-		// cost-only picks v4-flash (the slow one), FastestModel picks
-		// flash-lite.
+		// Mirrors the real haiku-tier clamp, where cost-only picks the slow v4-flash.
 		allow := map[string]struct{}{"flash-lite": {}, "v4-flash": {}}
 		p, m, ok := FastestModelInSet(meta, registry, available, nil, allow)
 		require.True(t, ok)
@@ -485,11 +476,8 @@ func TestFastestModelInSet(t *testing.T) {
 	})
 }
 
-// Integration guard against the real shipped bundle: the low-tier clamp
-// (the path that funneled production traffic onto the slowest provider)
-// must now resolve to the fastest annotated low-tier model rather than the
-// cheapest. Pins the actual symptom this change fixes; will fail loudly if
-// a future bundle drops the flash-lite speed annotation or its tier.
+// Pins the fix on the real bundle: low-tier clamp must pick the fastest
+// annotated model, not the cheapest slow incumbent.
 func TestFastestModel_RealLatestBundle_LowTierPrefersFastFlash(t *testing.T) {
 	version, err := ResolveVersion(LatestVersion)
 	require.NoError(t, err)

--- a/internal/router/cluster/diff_v2_test.go
+++ b/internal/router/cluster/diff_v2_test.go
@@ -11,32 +11,21 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// diffV2PromptsSHA pins the SHA-256 of testdata/diff_v2_prompts.jsonl.
-// Any unintended drift (hand edit, corpus regenerated without updating
-// this constant) fails CI before TestV2MatchesV1 even runs.
-//
-// Regenerating the fixture:
-//
-//	cd router-internal/scripts
-//	poetry run python regen_diff_corpus.py --n 1000 --seed 42 --routerarena-only
-//
-// The script prints the new SHA; replace this constant in the same
-// commit that ships the new file.
+// diffV2PromptsSHA pins the SHA-256 of testdata/diff_v2_prompts.jsonl so
+// unnoticed corpus drift fails CI before TestV2MatchesV1 runs. Regenerate via
+// `poetry run python regen_diff_corpus.py --n 1000 --seed 42 --routerarena-only`
+// (from router-internal/scripts) and update this constant in the same commit.
 const diffV2PromptsSHA = "7f72e9a4b217242e56417d2933b9b9f31c5f319ae0222115a7958b49b97aa20f"
 
-// diffV2FixturePath is the on-disk path to the committed fixture
-// relative to this package. The diff test driver script may override
-// it via DIFF_V2_FIXTURE_PATH.
+// diffV2FixturePath is the committed fixture path; the driver script may
+// override it via DIFF_V2_FIXTURE_PATH.
 var diffV2FixturePath = filepath.Join("testdata", "diff_v2_prompts.jsonl")
 
-// TestDiffV2PromptsFixtureSHA gates v2 release: catches accidental
-// drift in the committed diff fixture before the release-gate
-// integration test (TestV2MatchesV1) is run.
+// TestDiffV2PromptsFixtureSHA gates v2 release by catching fixture drift
+// before TestV2MatchesV1 runs.
 func TestDiffV2PromptsFixtureSHA(t *testing.T) {
 	if env := os.Getenv("DIFF_V2_FIXTURE_PATH"); env != "" {
-		// Override is for the driver script; under `go test`-only runs
-		// we always check the committed fixture so the constant stays
-		// honest.
+		// Driver-script override; go-test-only runs always check the committed fixture.
 		t.Skip("DIFF_V2_FIXTURE_PATH set; skipping committed-fixture SHA check.")
 	}
 	raw, err := os.ReadFile(diffV2FixturePath)

--- a/internal/router/cluster/distribution.go
+++ b/internal/router/cluster/distribution.go
@@ -11,21 +11,19 @@ type ModelShare struct {
 	Share float64 `json:"share"` // fraction in [0, 1]
 }
 
-// DistributionPoint is the projected model mix at one dial position. Share
-// values sum to 1 (modulo rounding). ProjectedCostPer1KInputUSD is the
-// share-weighted input price, the basis for the dashboard's "spend vs all-Opus"
-// readout.
+// DistributionPoint is the projected model mix at one dial position (shares
+// sum to 1, modulo rounding); ProjectedCostPer1KInputUSD is the share-weighted
+// input price for the dashboard's "spend vs all-Opus" readout.
 type DistributionPoint struct {
 	QualityBias                float64      `json:"quality_bias"`
 	Models                     []ModelShare `json:"models"`
 	ProjectedCostPer1KInputUSD float64      `json:"projected_cost_per_1k_input_usd"`
 }
 
-// defaultActiveKnobs returns a fresh copy of the bundle's default routing knobs
-// (Alpha slice cloned so callers can mutate per request without leaking into
-// the shared bundle defaults). When the bundle ships no defaults it falls back
-// to a neutral alpha of 0.53 on every cluster. Single source of truth for both
-// Route and RoutingDistribution.
+// defaultActiveKnobs returns a fresh copy of the bundle's default routing
+// knobs (Alpha/AlphaFloor cloned so callers can mutate without leaking into
+// shared defaults), falling back to alpha 0.53 on every cluster if the bundle
+// ships none. Shared by Route and RoutingDistribution.
 func (s *Scorer) defaultActiveKnobs() DefaultRoutingKnobs {
 	if s.metadata != nil && s.metadata.Training.DefaultRoutingKnobs != nil {
 		knobs := *s.metadata.Training.DefaultRoutingKnobs
@@ -46,32 +44,23 @@ func (s *Scorer) defaultActiveKnobs() DefaultRoutingKnobs {
 	return knobs
 }
 
-// defaultDistributionGrid is the dial-position count used when a caller does
-// not request a specific grid size: 21 points = steps of 0.05, fine enough for
-// the dashboard to render a smooth curve and seat the slider handle.
+// defaultDistributionGrid is the default dial-position count: 21 points = 0.05
+// steps, fine enough for a smooth dashboard curve.
 const defaultDistributionGrid = 21
 
-// RoutingDistribution projects the model mix the QualityBias dial would produce
-// across a grid of gridN evenly spaced dial positions in [0, 1].
+// RoutingDistribution projects the model mix the QualityBias dial would
+// produce across gridN evenly spaced dial positions in [0, 1].
 //
-// Each cluster centroid is treated as one representative request, routed with
-// the SAME scoring path as live traffic (dialToAlpha -> blendScoresV2 ->
-// argmax), and the winners are tallied with equal weight. This makes the
-// preview a faithful read of the routing math; what it is NOT is traffic
-// weighted — every cluster counts once regardless of how much real traffic
-// lands there, so the dashboard should frame it as the mix "across request
-// types," not "your traffic."
+// Each cluster centroid is routed once via the same scoring path as live
+// traffic (dialToAlpha -> blendScoresV2 -> argmax) and tallied with equal
+// weight, so the result is a mix "across request types," NOT traffic-weighted.
 //
-// excludedModels / excludedProviders mirror the caller's per-installation
-// exclusion lists: the preview routes over the SAME eligible pool Route would
-// (a model is dropped when it is named in excludedModels or when every one of
-// its provider bindings is excluded), so an excluded model never appears in the
-// dial preview and the cluster it would have won falls through to the next-best
-// eligible model rather than vanishing from the mix. Nil/empty sets leave the
-// full deployed roster eligible.
+// excludedModels/excludedProviders apply the same eligibility filter as
+// Route: an excluded model never appears, and its clusters fall through to
+// the next-best eligible model instead of vanishing from the mix.
 //
-// gridN < 2 falls back to defaultDistributionGrid. Returns an error for v1
-// bundles, which have no quality_means to disperse over.
+// gridN < 2 falls back to defaultDistributionGrid. Errors on v1 bundles
+// (no quality_means to disperse over).
 func (s *Scorer) RoutingDistribution(gridN int, excludedModels, excludedProviders map[string]struct{}) ([]DistributionPoint, error) {
 	if !s.isV2 {
 		return nil, fmt.Errorf("%w: routing distribution requires a v2 bundle", ErrClusterUnavailable)
@@ -82,10 +71,7 @@ func (s *Scorer) RoutingDistribution(gridN int, excludedModels, excludedProvider
 
 	k := s.centroids.K
 
-	// Eligibility is dial-independent, so resolve the exclusion-filtered pool
-	// once and reuse it across every grid step. An exclusion set that empties
-	// the pool is rejected the same way Route rejects it, rather than returning
-	// points whose shares sum to 0.
+	// Eligibility is dial-independent: resolve once and reuse per grid step.
 	eligible := s.eligibleForDistribution(excludedModels, excludedProviders)
 	if len(eligible) == 0 {
 		return nil, fmt.Errorf("exclusions leave no eligible candidates: %w", ErrNoEligibleProvider)

--- a/internal/router/cluster/distribution_test.go
+++ b/internal/router/cluster/distribution_test.go
@@ -51,9 +51,7 @@ func TestDialToAlpha_NoCalibrationIsIdentity(t *testing.T) {
 }
 
 func TestComputeDialCalibration_AscendingPinnedEndpoints(t *testing.T) {
-	// On the real bundle the calibration must be a strictly ascending sequence
-	// pinned at 0 and 1, with several interior breakpoints (the bundle has many
-	// distinct routed mixes between the cheapest and the saturated end).
+	// Real bundle: breakpoints must be strictly ascending, pinned at 0 and 1.
 	s := loadV0_67(t)
 	bp := s.dialAlphaBreakpoints
 	require.GreaterOrEqual(t, len(bp), 4, "expected several mix breakpoints on the real bundle")
@@ -64,9 +62,9 @@ func TestComputeDialCalibration_AscendingPinnedEndpoints(t *testing.T) {
 	}
 }
 
-// loadV0_67 loads the committed v0.67 bundle through a fake embedder (matching
-// its jina-v2 id / 768 dim). RoutingDistribution never embeds, so no ONNX
-// runtime is needed; this keeps the test hermetic and in the default matrix.
+// loadV0_67 loads the committed v0.67 bundle via a fake embedder (matching
+// its jina-v2 id/dim) — RoutingDistribution never embeds, so no ONNX runtime
+// is needed and the test stays hermetic.
 func loadV0_67(t *testing.T) *Scorer {
 	t.Helper()
 	bundle, err := LoadBundle("v0.67")
@@ -107,9 +105,8 @@ func TestRoutingDistribution_EndpointsAndGradient(t *testing.T) {
 	assert.Equal(t, maxCost, points[len(points)-1].ProjectedCostPer1KInputUSD, "quality end should be the priciest point")
 	assert.Greater(t, maxCost, minCost, "the dial must actually move projected cost")
 
-	// Gradient, not cliff: several interior dial positions land strictly
-	// between the two cost extremes (a cliff would jump from min to max with
-	// nothing in between).
+	// Gradient, not cliff: several interior positions must land strictly
+	// between the cost extremes.
 	span := maxCost - minCost
 	interiorBetween := 0
 	for _, p := range points[1 : len(points)-1] {
@@ -129,10 +126,8 @@ func TestRoutingDistribution_DefaultGridAndV1Guard(t *testing.T) {
 }
 
 func TestRoutingDistribution_NoDeadZone(t *testing.T) {
-	// Regression guard for the reported bug: every adjacent pair of dial
-	// positions should differ in either the routed mix or its projected cost.
-	// A dead zone (a run of identical mixes) is exactly what made "50% look like
-	// 20%"; the calibration must keep all but a small number of steps live.
+	// Regression guard: a run of identical mixes across adjacent dial steps is
+	// what made "50% look like 20%" — the calibration must keep steps live.
 	s := loadV0_67(t)
 	points, err := s.RoutingDistribution(21, nil, nil)
 	require.NoError(t, err)
@@ -144,16 +139,14 @@ func TestRoutingDistribution_NoDeadZone(t *testing.T) {
 			identicalRuns++
 		}
 	}
-	// A few coincidental repeats are fine (21 dial samples vs a finite set of
-	// distinct mixes); a dead zone would repeat across many steps in a row.
+	// A few coincidental repeats are fine; a dead zone repeats many in a row.
 	assert.LessOrEqual(t, identicalRuns, 3,
 		"too many adjacent dial positions route an identical mix (%d) — dial has a dead zone", identicalRuns)
 }
 
 func TestRoutingDistribution_MidDialIsPricierThanLowDial(t *testing.T) {
-	// The reported symptom in user terms: a mid dial (0.5) used to route the
-	// same all-cheapest mix as a low dial (0.2). After calibration the mid dial
-	// must route a meaningfully pricier (higher-quality) mix.
+	// Reported bug: mid dial (0.5) used to route the same all-cheapest mix as
+	// low dial (0.2); it must now route a meaningfully pricier mix.
 	s := loadV0_67(t)
 	points, err := s.RoutingDistribution(21, nil, nil)
 	require.NoError(t, err)
@@ -173,10 +166,8 @@ func TestRoutingDistribution_MidDialIsPricierThanLowDial(t *testing.T) {
 		"the 50%% dial must route a meaningfully pricier (higher-quality) mix than the 20%% dial")
 }
 
-// loadV0_70 loads the committed v0.70 bundle (the first shaped bundle whose
-// default alpha protects agentic/code clusters at 0.96 and lets conversational
-// clusters cheapen at 0.8). Like loadV0_67 it uses a fake embedder; the dial
-// tests below never embed a prompt — they score cluster centroids directly.
+// loadV0_70 loads the committed v0.70 bundle (default alpha protects
+// agentic/code clusters at 0.96, lets conversational cheapen at 0.8).
 func loadV0_70(t *testing.T) *Scorer {
 	t.Helper()
 	bundle, err := LoadBundle("v0.70")
@@ -223,15 +214,12 @@ func TestApplyDialAlpha_NilFloorIsUniformDial(t *testing.T) {
 }
 
 func TestApplyDialAlpha_AgenticStaysOnCapableModelAtLowDial(t *testing.T) {
-	// The reported bug, end to end: under a price-leaning dial the agentic
-	// cluster routed to a model that can't drive the Claude Code skill/tool
-	// protocol (minimax-m3 grepping for a skill instead of running it). Cluster 0
-	// is the agentic catch-all. The fix moved the guard off the quality WEIGHT
-	// (the old 0.88 floor pinned Opus and killed the dial) and onto the candidate
-	// POOL: on has_tools turns the scorer drops catalog.AgenticLowSet, so a low
-	// dial demotes Opus to the cheapest HARNESS-CAPABLE model instead of
-	// stranding the turn on an incapable one. The low alpha_floor only sets how
-	// far down the capable ladder the dial may travel.
+	// Reported bug: a price-leaning dial routed the agentic cluster (0) to a
+	// model that can't drive the Claude Code tool protocol (minimax-m3 grepping
+	// for a skill instead of running it). Fix moved the guard off the quality
+	// weight (old 0.88 floor pinned Opus, killing the dial) and onto the
+	// candidate pool: has_tools turns drop catalog.AgenticLowSet, so a low dial
+	// demotes to the cheapest harness-capable model instead of an incapable one.
 	s := loadV0_70(t)
 
 	// Realized agentic alpha at the price extreme = the declared floor.
@@ -241,9 +229,8 @@ func TestApplyDialAlpha_AgenticStaysOnCapableModelAtLowDial(t *testing.T) {
 
 	low := catalog.AgenticLowSet()
 
-	// Precondition: WITHOUT the gate (full pool) the price-extreme dial falls
-	// through to an agentic-incapable cheap model — the bug the gate exists to
-	// fix. If this stops holding, the floor got too high to exercise the gate.
+	// Precondition: without the gate, the price extreme falls through to an
+	// agentic-incapable model — the bug the gate exists to fix.
 	full, _ := argmax(s.blendScoresV2(top, knobs, s.models, nil, nil), s.models)
 	_, fullIncapable := low[full]
 	require.Truef(t, fullIncapable,
@@ -266,10 +253,9 @@ func TestApplyDialAlpha_AgenticStaysOnCapableModelAtLowDial(t *testing.T) {
 }
 
 func TestRoutingDistribution_ExcludedModelNeverAppears(t *testing.T) {
-	// The dial preview must agree with what Route would actually do: an excluded
-	// model never shows up in the mix, and the clusters it would have won fall
-	// through to the next-best eligible model rather than vanishing (shares still
-	// sum to 1). Excluding the quality-extreme winner is the load-bearing case.
+	// Preview must agree with Route: an excluded model never appears, and its
+	// clusters fall through to the next-best eligible model (shares still sum
+	// to 1). Excludes the quality-extreme winner as the load-bearing case.
 	s := loadV0_70(t)
 
 	full, err := s.RoutingDistribution(21, nil, nil)
@@ -304,9 +290,8 @@ func TestRoutingDistribution_ExcludedModelNeverAppears(t *testing.T) {
 }
 
 func TestRoutingDistribution_EmptyPoolErrors(t *testing.T) {
-	// Excluding every deployed model empties the eligible pool. Route returns
-	// ErrNoEligibleProvider in that case, so the preview must too rather than
-	// emit points whose shares sum to 0.
+	// Excluding every deployed model empties the pool; the preview must return
+	// ErrNoEligibleProvider like Route does, not points summing to 0.
 	s := loadV0_70(t)
 	all := make(map[string]struct{}, len(s.models))
 	for _, m := range s.models {
@@ -320,8 +305,7 @@ func TestRoutingDistribution_EmptyPoolErrors(t *testing.T) {
 
 func TestRoutingDistribution_ExcludedProviderDropsSingleBindingModels(t *testing.T) {
 	// Excluding a provider must drop every model whose only binding is that
-	// provider, mirroring Route's EnabledProviders gate. Pick a single-binding
-	// model that appears in the mix so the assertion is unambiguous.
+	// provider, mirroring Route's EnabledProviders gate.
 	s := loadV0_70(t)
 
 	full, err := s.RoutingDistribution(21, nil, nil)

--- a/internal/router/handover/summarizer.go
+++ b/internal/router/handover/summarizer.go
@@ -1,12 +1,10 @@
-// Package handover defines the contract for bounded-cost context handover
-// when the planner switches models mid-session. The provider-backed
-// implementation lives in internal/proxy; this package only declares the
-// interface and envelope-rewrite helpers so inner-ring code can describe
-// the operation without an I/O dependency.
+// Package handover declares the interface and envelope-rewrite helpers for
+// bounded-cost context handover when the planner switches models mid-session
+// (provider-backed implementation lives in internal/proxy).
 //
-// Why: switching mid-session forces a prompt-cache miss on the full prior
-// context. Summarizing and replacing history with [summary, latestUser]
-// bounds switch-turn input cost regardless of session length.
+// Switching mid-session forces a prompt-cache miss on the full prior context;
+// replacing history with [summary, latestUser] bounds switch-turn input cost
+// regardless of session length.
 package handover
 
 import (
@@ -15,10 +13,9 @@ import (
 	"workweave/router/internal/translate"
 )
 
-// Usage captures the upstream token counts of a Summarize call so callers
-// can record a separate billing ledger row for the summary turn alongside
-// the main inference debit. Zero values mean no usage was reported (e.g.
-// fallback path or implementation that doesn't track tokens).
+// Usage captures the upstream token counts of a Summarize call so callers can
+// bill the summary turn separately from the main inference debit. Zero
+// values mean usage wasn't reported.
 type Usage struct {
 	InputTokens   int
 	OutputTokens  int
@@ -30,18 +27,15 @@ type Usage struct {
 	Provider string
 }
 
-// Summarizer produces a prose summary of the prior conversation for
-// seeding a new model's context after a router switch.
+// Summarizer produces a prose summary of the prior conversation for seeding
+// a new model's context after a router switch.
 //
-// Implementations SHOULD respect the context deadline. On timeout or
-// error, callers pass the full prior history through unchanged rather than
-// dropping it. Usage is reported on success; on error it is the zero value.
+// Implementations SHOULD respect the context deadline; on timeout or error,
+// callers keep the full prior history unchanged instead of dropping it.
 //
-// Provider returns the upstream provider this summarizer dispatches to
-// (e.g. "anthropic"). The orchestrator uses this to plumb matching
-// client/BYOK creds through so summarization can run on the caller's
-// own account when the request is BYOK or carries client-supplied keys,
-// avoiding tenant data crossing the deployment key boundary.
+// Provider identifies the upstream this summarizer dispatches to (e.g.
+// "anthropic"), so the orchestrator can plumb matching BYOK creds through
+// and keep tenant data from crossing the deployment key boundary.
 type Summarizer interface {
 	Summarize(ctx context.Context, env *translate.RequestEnvelope) (summary string, usage Usage, err error)
 	Provider() string
@@ -49,9 +43,7 @@ type Summarizer interface {
 
 // RewriteEnvelope mutates env in-place: keeps system blocks, replaces
 // messages with [assistantSummary, latestUser]. Returns the number of
-// original messages elided.
-//
-// Pure: no I/O. Returns 0 when env is nil or the message array is missing/empty.
+// messages elided (0 if env is nil or has no messages).
 func RewriteEnvelope(env *translate.RequestEnvelope, summary string) int {
 	if env == nil {
 		return 0
@@ -59,18 +51,12 @@ func RewriteEnvelope(env *translate.RequestEnvelope, summary string) int {
 	return env.RewriteForHandover(summary)
 }
 
-// TrimLastN is a bounded-trim primitive that keeps the most recent n
-// non-system messages plus system blocks; n <= 0 is treated as 3. Returns
-// the number of messages elided.
+// TrimLastN keeps the most recent n non-system messages plus system blocks
+// (n <= 0 treated as 3) and returns the number elided; 0 if env is nil.
 //
-// NOTE: this is no longer the handover failure path — on summarizer failure
-// the orchestrator keeps the full prior history rather than trimming, because
-// silently dropping the conversation a switched-to model needs is worse than a
-// pricier switch turn. Retained as a primitive for a future context-window
-// overflow guard (trim only when full history would exceed the target model's
-// context window).
-//
-// Pure: no I/O. Returns 0 when env is nil.
+// No longer used on the handover failure path — summarizer failure now keeps
+// full history instead of trimming. Retained for a future context-window
+// overflow guard.
 func TrimLastN(env *translate.RequestEnvelope, n int) int {
 	if env == nil {
 		return 0

--- a/internal/router/handover/summarizer_test.go
+++ b/internal/router/handover/summarizer_test.go
@@ -14,11 +14,8 @@ import (
 	"workweave/router/internal/translate"
 )
 
-// anthropicConversation is a representative 6-message conversation:
-// top-level system, two user turns, two assistant turns, and a trailing
-// user tool_result follow-up. RewriteEnvelope must preserve system on
-// the separate top-level field and collapse messages to
-// [summary, lastUser].
+// anthropicConversation: system + 2 user + 2 assistant turns + trailing
+// tool_result. RewriteEnvelope must collapse messages to [summary, lastUser].
 const anthropicConversation = `{
   "model": "claude-opus-4-7",
   "system": "You are a careful assistant.",
@@ -137,9 +134,7 @@ func TestRewriteEnvelope_OpenAIPreservesLeadingSystemMessages(t *testing.T) {
 func TestTrimLastN_KeepsLastNMessagesAndSystem(t *testing.T) {
 	t.Parallel()
 
-	// Anthropic-shape conversation with 10 messages; system on the
-	// top-level field stays untouched. TrimLastN(3) keeps the last 3,
-	// eliding 7.
+	// 10 messages; TrimLastN(3) keeps the last 3, eliding 7.
 	const tenMessageBody = `{
   "model": "claude-opus-4-7",
   "system": "sys",
@@ -208,9 +203,8 @@ func TestTrimLastN_NilEnvelopeReturnsZero(t *testing.T) {
 func TestTrimLastN_StripsOrphanedAnthropicToolResults(t *testing.T) {
 	t.Parallel()
 
-	// 5 messages: user text, assistant with tool_use, user with tool_result,
-	// assistant text, user text. TrimLastN(3) keeps the last 3, which starts
-	// with the user tool_result whose matching tool_use was trimmed.
+	// TrimLastN(3) keeps the last 3, starting with a tool_result whose
+	// matching tool_use gets trimmed away.
 	const body = `{
   "model": "claude-opus-4-7",
   "messages": [
@@ -333,15 +327,13 @@ func TestRewriteEnvelope_StripsToolResultsFromLatestUser(t *testing.T) {
 	assert.Equal(t, "assistant", msgs[0].Get("role").String())
 }
 
-// Regression test for the exact failure path observed in production:
-// mid-session model switch triggers TrimLastN → orphaned tool_result blocks
-// survive into the Anthropic→Gemini translation → empty function_response.name
-// → Gemini 400.
+// Regression: mid-session model switch + TrimLastN can orphan tool_result
+// blocks, which the Anthropic→Gemini translation turned into an empty
+// functionResponse.name (Gemini 400).
 func TestTrimLastN_ThenPrepareGemini_NoEmptyFunctionResponseName(t *testing.T) {
 	t.Parallel()
 
-	// Simulates a Conductor/Claude-Code session with multiple tool-use rounds
-	// followed by a text turn. TrimLastN(3) orphans the tool_result in msg[4].
+	// TrimLastN(3) orphans the tool_result in msg[4].
 	const body = `{
   "model": "claude-opus-4-7",
   "system": "You are a helpful assistant.",

--- a/internal/router/model.go
+++ b/internal/router/model.go
@@ -10,11 +10,8 @@ const (
 	CapExtendedThinking ModelCapability = "extended_thinking"
 	CapReasoning        ModelCapability = "reasoning"
 	CapExtendedContext  ModelCapability = "extended_context"
-	// CapXhighEffort marks Anthropic adaptive models whose output_config.effort
-	// menu includes "xhigh". All adaptive models accept low/medium/high/max;
-	// xhigh is opus-4-7+ only — claude-sonnet-4-6 rejects it with 400 "This
-	// model does not support effort level 'xhigh'". Emit clamps xhigh to "max"
-	// when the target lacks this capability.
+	// CapXhighEffort marks models supporting effort "xhigh" (opus-4-7+ only;
+	// sonnet-4-6 400s on it). Emit clamps to "max" when unsupported.
 	CapXhighEffort ModelCapability = "xhigh_effort"
 )
 
@@ -56,11 +53,9 @@ func Lookup(model string) ModelSpec {
 }
 
 var (
-	// claude-opus-4-6+ and claude-sonnet-4-6+ only accept thinking.type=adaptive;
-	// the legacy thinking.type=enabled shape returns 400 from Anthropic since the
-	// rollout of output_config.effort.
-	// Opus 4.6+, Opus 4.7+, Opus 4.8, and Sonnet 4.6 support 1M context via
-	// context-1m-2025-08-07 beta; Haiku 4.5 and Sonnet 4.5 are limited to 200K.
+	// Opus/Sonnet 4.6+ only accept thinking.type=adaptive (legacy "enabled" 400s
+	// since output_config.effort rollout) and support 1M context via the
+	// context-1m-2025-08-07 beta; Haiku 4.5 and Sonnet 4.5 top out at 200K.
 	anthropicAdaptive = NewSpec(CapAdaptiveThinking, CapExtendedContext)
 	// Opus 4.7+ (and fable) additionally accept effort level "xhigh"; the
 	// older adaptive models (opus-4-6, sonnet-4-6) top out at "max".
@@ -80,22 +75,19 @@ var googleBase = NewSpec()
 var openAICompatBase = NewSpec()
 
 var registry = map[string]ModelSpec{
-	// claude-fable-5: adaptive thinking is always on (thinking.type=disabled
-	// is rejected); 1M context is native, so CapExtendedContext only makes the
-	// context-1m beta header a harmless no-op.
+	// claude-fable-5 has adaptive thinking always on (disabled is rejected);
+	// 1M context is native, so CapExtendedContext's beta header is a no-op.
 	"claude-fable-5":  anthropicAdaptiveXhigh,
 	"claude-opus-4-8": anthropicAdaptiveXhigh,
 	"claude-opus-4-7": anthropicAdaptiveXhigh,
-	// claude-sonnet-5: adaptive-only, 1M context behind the beta header. Mirrors
-	// sonnet-4-6 (no xhigh — the Sonnet line tops out at effort "max"; marking
-	// xhigh unsupported clamps it to max rather than 400ing a mid-session switch).
+	// claude-sonnet-5 mirrors sonnet-4-6: no xhigh, since Sonnet tops out at
+	// effort "max" and marking xhigh unsupported clamps rather than 400s.
 	"claude-sonnet-5":   anthropicAdaptive,
 	"claude-sonnet-4-6": anthropicAdaptive,
 	"claude-opus-4-6":   anthropicAdaptive,
 
-	// claude-haiku-4-5 returns 400 "adaptive thinking is not supported on
-	// this model" when a Claude Code body with thinking.type=adaptive is
-	// forwarded through the router after a downgrade from opus.
+	// claude-haiku-4-5 400s on thinking.type=adaptive, which Claude Code
+	// bodies carry after a downgrade from opus.
 	"claude-haiku-4-5": anthropicExtended,
 	"claude-opus-4-5":  anthropicExtended,
 	"claude-opus-4-1":  anthropicExtended,

--- a/internal/router/sessionpin/store.go
+++ b/internal/router/sessionpin/store.go
@@ -1,6 +1,5 @@
 // Package sessionpin defines the inner-ring contract for session-sticky
-// routing pins. Pure types + interface; the Postgres adapter lives in
-// internal/postgres.
+// routing pins (pure types + interface); the Postgres adapter lives in internal/postgres.
 package sessionpin
 
 import (
@@ -18,38 +17,29 @@ const SessionKeyLen = 16
 // turn-type detector can land non-breakingly.
 const DefaultRole = "default"
 
-// Pin is one row in the session-pin table. Mirrors a routing decision
-// so a hit can rehydrate router.Decision without re-running the scorer.
+// Pin is one row in the session-pin table, mirroring a routing decision so a
+// hit can rehydrate router.Decision without re-running the scorer.
 //
-// Last*Tokens / LastTurnEndedAt record the previous turn's upstream usage
-// and are written by Store.UpdateUsage after a turn completes. They are
-// deliberately left untouched by Upsert so an at-start-of-turn refresh
-// cannot clobber them with zeros.
+// Last*Tokens / LastTurnEndedAt hold the previous turn's usage, written by
+// Store.UpdateUsage; Upsert leaves them untouched so a start-of-turn refresh
+// can't clobber them with zeros.
 //
-// ConsecutiveUpstreamErrors counts consecutive turns ending in a
-// non-retryable upstream error (4xx other than 408/429). The turn loop
-// increments via Store.IncrementUpstreamErrors after a sticky-pinned
-// turn fails and evicts the pin once the count hits the two-strike
-// threshold; Store.ResetUpstreamErrors clears it on any successful
-// turn. Upsert preserves it on a same-model refresh and resets it on
-// a switch (different model).
+// ConsecutiveUpstreamErrors counts consecutive non-retryable upstream errors
+// (4xx other than 408/429); IncrementUpstreamErrors bumps it and the turn loop
+// evicts at the two-strike threshold. Upsert preserves it on a same-model
+// refresh, resets it on a model switch.
 type Pin struct {
 	SessionKey     [SessionKeyLen]byte
 	Role           string
 	InstallationID uuid.UUID
 	Provider       string
 	Model          string
-	// PairedProvider / PairedModel are the other half of the band pair the
-	// scorer picks (the runner-up model and its provider). Upsert refreshes them
-	// on a genuine scorer re-run (first turn, switch, expired-pin re-route),
-	// preserves them on a same-model sticky refresh or re-anchor (which pass an
-	// empty pair), and clears them when the pinned model changes without a fresh
-	// pair (force-model, loop-break, eviction) — so the stored pair always
-	// matches the live routing decision and never collapses onto Model.
-	// PairedModel is empty for pins created outside the scorer path (force-model,
-	// loop-break) or when only one model was eligible. A later per-turn policy
-	// reads them to swap between {Model, PairedModel} without re-running the
-	// scorer.
+	// PairedProvider/PairedModel are the scorer's runner-up pick, refreshed by
+	// Upsert on a genuine scorer re-run, preserved on a same-model refresh, and
+	// cleared on a model change without a fresh pair (force-model, loop-break,
+	// eviction) so the stored pair never goes stale. Empty for non-scorer pins
+	// or single-candidate routing; a later per-turn policy swaps between the
+	// pair without re-scoring.
 	PairedProvider            string
 	PairedModel               string
 	Reason                    string
@@ -63,19 +53,16 @@ type Pin struct {
 	LastOutputTokens          int
 	LastTurnEndedAt           time.Time
 	ConsecutiveUpstreamErrors int
-	// LastServedModel is the model that actually served the previous turn,
-	// written by Store.UpdateUsage (post-turn) and left untouched by Upsert.
-	// A /force-model pin overwrites Model via Upsert but not this field, so
-	// the next turn can compare it against the new target model to detect a
-	// mid-session model switch (and strip Anthropic thinking-block signatures
-	// the new model would otherwise reject with a 400).
+	// LastServedModel is the model that served the previous turn (written by
+	// UpdateUsage, untouched by Upsert). Comparing it to the new target model
+	// detects a mid-session switch, so stale Anthropic thinking-block
+	// signatures that would 400 on the new model get stripped.
 	LastServedModel string
-	// HasEverSwitched latches true the first time this session served a model
-	// different from the prior LastServedModel. It stays set for the life of
-	// the pin and is flipped atomically inside Store.UpdateUsage. The emit
-	// path ORs it into ModelSwitched so the stale-signed thinking blocks an
-	// earlier cross-model excursion left in the client transcript are stripped
-	// on every subsequent turn, not just the single switch-back turn.
+	// HasEverSwitched latches true (in UpdateUsage) the first time the session
+	// serves a model different from LastServedModel, and stays set for the
+	// pin's life. The emit path ORs it into ModelSwitched so stale-signed
+	// thinking blocks from an earlier cross-model excursion are stripped on
+	// every later turn, not just the one the switch happened on.
 	HasEverSwitched bool
 }
 
@@ -91,15 +78,12 @@ type Usage struct {
 }
 
 // Store is the I/O surface for session pins. Get returns (zero, false, nil)
-// when no row exists. UpdateUsage, IncrementUpstreamErrors, and
-// ResetUpstreamErrors are no-ops when the pin has been evicted or never
-// existed.
+// when no row exists; UpdateUsage/IncrementUpstreamErrors/ResetUpstreamErrors
+// are no-ops on an evicted or missing pin.
 //
-// IncrementUpstreamErrors atomically increments the consecutive-error
-// counter on the existing pin and returns the new count, so the turn
-// loop can apply a two-strike eviction without a read-modify-write race
-// across pods. Returns (0, nil) for a missing pin — the caller treats
-// that as "pin already evicted" rather than an error.
+// IncrementUpstreamErrors atomically bumps the error counter and returns the
+// new count so the turn loop can two-strike-evict without a cross-pod
+// read-modify-write race; it returns (0, nil) for a missing pin.
 type Store interface {
 	Get(ctx context.Context, sessionKey [SessionKeyLen]byte, role string) (Pin, bool, error)
 	Upsert(ctx context.Context, p Pin) error

--- a/internal/translate/anthropic_marker.go
+++ b/internal/translate/anthropic_marker.go
@@ -12,10 +12,8 @@ import (
 	"github.com/tidwall/sjson"
 )
 
-// AnthropicRoutingMarkerWriter wraps an http.ResponseWriter and injects a
-// routing-marker text block at index 0 of an Anthropic-format SSE stream.
-// Upstream content_block_* indices are shifted by +1 to accommodate the
-// injected block. Non-streaming responses pass through unmodified.
+// AnthropicRoutingMarkerWriter injects a routing-marker text block at index 0
+// of an Anthropic SSE stream, shifting upstream content_block_* indices by +1.
 type AnthropicRoutingMarkerWriter struct {
 	inner   http.ResponseWriter
 	flusher http.Flusher
@@ -31,9 +29,8 @@ type AnthropicRoutingMarkerWriter struct {
 	markerEmitted  bool
 }
 
-// NewAnthropicRoutingMarkerWriter creates a writer that injects marker as a
-// standalone text block at index 0 before any upstream data. If marker is
-// empty, all writes pass through unchanged.
+// NewAnthropicRoutingMarkerWriter injects marker as a text block at index 0.
+// If marker is empty, writes pass through unchanged.
 func NewAnthropicRoutingMarkerWriter(w http.ResponseWriter, model, marker string) *AnthropicRoutingMarkerWriter {
 	flusher, _ := w.(http.Flusher)
 	return &AnthropicRoutingMarkerWriter{
@@ -81,12 +78,10 @@ func (w *AnthropicRoutingMarkerWriter) Write(data []byte) (int, error) {
 	return n, nil
 }
 
-// Prelude commits headers and emits the routing marker immediately, before the
-// upstream provider has returned a single byte. Call this right after the
-// routing decision is made when the client requested streaming (streaming=true)
-// so first-byte latency drops to ~routing time rather than upstream prefill +
-// first decode. Safe to call once; subsequent Write/WriteHeader calls are
-// idempotent. No-op when streaming is false or marker is empty.
+// Prelude commits headers and emits the marker before upstream responds, so
+// first-byte latency is ~routing time instead of upstream prefill+decode. Call
+// once right after the routing decision; later Write/WriteHeader calls are
+// idempotent. No-op if streaming is false or marker is empty.
 func (w *AnthropicRoutingMarkerWriter) Prelude(streaming bool) error {
 	if !streaming || w.markerEmitted {
 		return nil
@@ -149,12 +144,10 @@ func (w *AnthropicRoutingMarkerWriter) emitPreludeEvents() error {
 }
 
 // processUpstream parses upstream SSE events, drops message_start, and shifts
-// content_block_* indices by +1. Non-indexed events (message_delta,
-// message_stop, ping, error) pass through unchanged.
+// content_block_* indices by +1; other events pass through unchanged.
 func (w *AnthropicRoutingMarkerWriter) processUpstream(data []byte) (int, error) {
-	// Accumulate into a persistent buffer so an SSE event split across two
-	// Write calls is held until its terminating blank line arrives, rather
-	// than being parsed as a truncated (and silently dropped) event.
+	// Buffer across Write calls so an SSE event split mid-stream isn't parsed
+	// as truncated (and silently dropped) before its terminating blank line.
 	w.buf.Write(data)
 	for {
 		event, n := sse.SplitNext(w.buf.Bytes())

--- a/internal/translate/cache_usage_test.go
+++ b/internal/translate/cache_usage_test.go
@@ -75,10 +75,9 @@ func TestAnthropicSSETranslator_ForwardsOpenAICachedTokens(t *testing.T) {
 	assert.Equal(t, 64, sink.cacheRead)
 }
 
-// Cross-format upstreams (OpenAI, Gemini) only learn the real input_tokens
-// at the end of the stream, but Claude Code's subagent counter reads off
-// message_start.usage.input_tokens. Without WithEstimatedInputTokens the
-// counter shows zero tokens for every subagent turn.
+// Cross-format upstreams only learn real input_tokens at stream end, but
+// Claude Code's subagent counter reads message_start.usage.input_tokens.
+// Without WithEstimatedInputTokens it shows zero for every subagent turn.
 func TestAnthropicSSETranslator_MessageStartCarriesEstimatedInputTokens(t *testing.T) {
 	rec := httptest.NewRecorder()
 	translator := translate.NewAnthropicSSETranslator(rec, "gpt-4o", nil).
@@ -105,10 +104,8 @@ func TestAnthropicSSETranslator_MessageStartCarriesEstimatedInputTokens(t *testi
 	assert.Contains(t, startSegment, `"usage":{"input_tokens":1234,"output_tokens":0}`)
 }
 
-// Catches the Gemini cachedContentTokenCount field being dropped on its way
-// to the usage sink. Gemini implicit caching is the only signal we have that
-// caching is working at all on the Gemini path, so this number must reach
-// recordTurnUsage → session_pins / telemetry.
+// Gemini implicit caching is the only signal we have that caching works on
+// the Gemini path, so cachedContentTokenCount must reach the usage sink.
 func TestGeminiSSETranslator_ForwardsCachedContentTokenCount(t *testing.T) {
 	rec := httptest.NewRecorder()
 	sink := &fakeUsageSink{}
@@ -132,9 +129,8 @@ func TestGeminiSSETranslator_ForwardsCachedContentTokenCount(t *testing.T) {
 	assert.Equal(t, 0, sink.cacheCreation, "Gemini reports only cache reads, not creation")
 	assert.Equal(t, 1900, sink.cacheRead)
 
-	// The serialized OpenAI chunk must carry prompt_tokens_details.cached_tokens
-	// so the downstream AnthropicSSETranslator picks it up via gjson at the
-	// path it already reads (stream.go:604).
+	// Must carry prompt_tokens_details.cached_tokens for the downstream
+	// AnthropicSSETranslator to pick up (stream.go:604).
 	body := rec.Body.String()
 	assert.Contains(t, body, `"prompt_tokens_details":{"cached_tokens":1900}`)
 }
@@ -159,12 +155,9 @@ func TestGeminiSSETranslator_NonStreamingForwardsCachedContentTokenCount(t *test
 	assert.Equal(t, 1200, sink.cacheRead)
 }
 
-// Catches the missing inputTokens field on SSETranslator: Anthropic splits
-// token counts across two events — message_start carries input_tokens,
-// message_delta carries output_tokens with no input_tokens field. Without
-// persisting the value from message_start, handleMessageDelta re-reads
-// input_tokens from the event body via gjson and gets 0, so the final
-// OpenAI chunk emitted to the client always has prompt_tokens:0.
+// Anthropic splits token counts across two events: message_start carries
+// input_tokens, message_delta carries only output_tokens. Without persisting
+// input_tokens from message_start, the final chunk's prompt_tokens is always 0.
 func TestSSETranslator_FinalChunkCarriesPromptTokensFromMessageStart(t *testing.T) {
 	rec := httptest.NewRecorder()
 	sink := &fakeUsageSink{}
@@ -188,8 +181,7 @@ func TestSSETranslator_FinalChunkCarriesPromptTokensFromMessageStart(t *testing.
 
 	body := rec.Body.String()
 
-	// Locate the final chunk — emitted by handleMessageDelta, identified by
-	// finish_reason. This is what OpenAI SDK clients read for cost attribution.
+	// Final chunk carries finish_reason; OpenAI SDK clients read it for cost attribution.
 	chunks := strings.Split(body, "\n\n")
 	var finalChunk string
 	for _, chunk := range chunks {
@@ -204,10 +196,9 @@ func TestSSETranslator_FinalChunkCarriesPromptTokensFromMessageStart(t *testing.
 	assert.Contains(t, finalChunk, `"total_tokens":59`)
 }
 
-// Catches the sink accumulation across the full message_start → message_delta
-// sequence. The UsageExtractor guards RecordUsage with if value > 0, so
-// input tokens recorded in handleMessageStart must not be overwritten by the
-// zero value re-read in handleMessageDelta.
+// UsageExtractor guards RecordUsage with if value > 0, so input tokens from
+// handleMessageStart must not be overwritten by the zero re-read in
+// handleMessageDelta.
 func TestSSETranslator_SinkAccumulatesInputAndOutputAcrossStream(t *testing.T) {
 	rec := httptest.NewRecorder()
 	sink := &fakeUsageSink{}

--- a/internal/translate/degenerate_tool_call_test.go
+++ b/internal/translate/degenerate_tool_call_test.go
@@ -9,23 +9,18 @@ import (
 	"workweave/router/internal/translate"
 )
 
-// The degenerate tool-call turn: an OpenAI-compat upstream (GLM-5.1 on
-// DeepInfra is the repeat offender) closes with finish_reason="tool_calls" but
-// no usable tool_use block ever materializes — every call was nameless and
-// dropped, or the call leaked into plain text the parser never structured.
-// finish_reason="tool_calls" maps to stop_reason="tool_use", so without a
-// demote the client receives stop_reason="tool_use" alongside zero tool_use
-// blocks. Agent clients (Claude Code, pi) then wait for a tool call that never
-// arrives and the turn dead-ends, which surfaces to the user as the agent
-// "stopping instead of going". The translators must demote to end_turn.
+// Degenerate tool-call turn: an OpenAI-compat upstream (GLM-5.1 on DeepInfra
+// is the repeat offender) closes finish_reason="tool_calls" with no surviving
+// tool_use block (nameless/dropped call, or leaked into plain text). Without
+// a demote to end_turn, agent clients wait forever for a tool call that never
+// arrives.
 
 // driveAnthropicSSEWithTools (declared in tool_args_validation_test.go) feeds
 // OpenAI chunks through the translator and returns the body plus the summary.
 
 func TestAnthropicSSETranslator_DemotesToolCallsFinishWithNamelessCall(t *testing.T) {
-	// finish_reason="tool_calls" + a nameless (dropped) call. requestHadTools
-	// is false so the text-only nudge cannot mask the demote: this is the
-	// no-tools path the nudge deliberately skips.
+	// Nameless (dropped) call; requestHadTools=false so the text-only nudge
+	// can't mask the demote.
 	body, summary := driveAnthropicSSEWithTools(t, "z-ai/glm-5.1", false, []string{
 		`data: {"id":"c1","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"role":"assistant","content":"Let me run that for you."},"finish_reason":null}]}` + "\n\n",
 		`data: {"id":"c1","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_x","type":"function","function":{"name":"","arguments":"{}"}}]},"finish_reason":null}]}` + "\n\n",
@@ -45,14 +40,10 @@ func TestAnthropicSSETranslator_DemotesToolCallsFinishWithNamelessCall(t *testin
 }
 
 func TestAnthropicSSETranslator_SuppressedToolCallFinishDoesNotNudge(t *testing.T) {
-	// The prod loop (session 081e0a3d, model z-ai/glm-5.1 on DeepInfra): the
-	// upstream closes finish_reason="tool_calls" with a nameless call that gets
-	// dropped, AND the request HAD tools available. Without the suppressed-call
-	// guard, synthesizeTextOnlyTurnNudge fires (its switch has no "tool_calls"
-	// case), stapling a synthetic Bash call onto every such turn. Because the
-	// degenerate shape recurs each turn, the nudge loops to the turn ceiling.
-	// The model already emitted a (malformed) tool call; the drop handled it, so
-	// the nudge must stay silent.
+	// Prod loop (session 081e0a3d, glm-5.1/DeepInfra): nameless call dropped,
+	// but request HAD tools. Without the suppressed-call guard,
+	// synthesizeTextOnlyTurnNudge fires and staples a synthetic Bash call onto
+	// every turn, looping to the turn ceiling since the shape recurs each turn.
 	body, summary := driveAnthropicSSEWithTools(t, "z-ai/glm-5.1", true, []string{
 		`data: {"id":"c1","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"role":"assistant"},"finish_reason":null}]}` + "\n\n",
 		`data: {"id":"c1","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_x","type":"function","function":{"name":"","arguments":"{}"}}]},"finish_reason":null}]}` + "\n\n",
@@ -87,9 +78,8 @@ func TestAnthropicSSETranslator_DemotesToolCallsFinishWithNoStructuredCall(t *te
 }
 
 func TestAnthropicSSETranslator_NamedToolCallWithToolCallsFinishStillToolUse(t *testing.T) {
-	// Regression guard: a legitimate named tool_call closing with
-	// finish_reason="tool_calls" must keep stop_reason="tool_use" and never
-	// demote.
+	// Regression guard: a real named tool_call must keep stop_reason="tool_use"
+	// and never demote.
 	body, summary := driveAnthropicSSEWithTools(t, "z-ai/glm-5.1", true, []string{
 		`data: {"id":"c1","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_ok","type":"function","function":{"name":"Bash","arguments":"{\"command\":\"git status\"}"}}]},"finish_reason":null}]}` + "\n\n",
 		`data: {"id":"c1","choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}],"usage":{"prompt_tokens":20,"completion_tokens":7}}` + "\n\n",
@@ -105,14 +95,11 @@ func TestAnthropicSSETranslator_NamedToolCallWithToolCallsFinishStillToolUse(t *
 }
 
 func TestAnthropicSSETranslator_NullToolCallsOnTextDeltasDoNotSuppressRealCall(t *testing.T) {
-	// Prod loop (session ba584c9d, z-ai/glm-5.1 on DeepInfra): GLM-5.1 streams
-	// `"tool_calls": null` on every plain-text delta, THEN emits the real named
-	// tool_call in a later frame. gjson's ForEach over a JSON null yields one
-	// zero-value iteration (index=0, name=""), which used to trip the
-	// nameless-call guard and latch suppressedTools[0]; the real Bash call (also
-	// index 0) was then dropped as a "fragment of a suppressed call", so the
-	// client got an empty end_turn and the agent idled. The real call must
-	// survive as a tool_use block.
+	// Prod loop (session ba584c9d, glm-5.1/DeepInfra): GLM-5.1 streams
+	// `"tool_calls": null` on text deltas, then emits the real named call later.
+	// gjson's ForEach over a JSON null yields one zero-value iteration
+	// (index=0, name=""), which used to trip the nameless-call guard and drop
+	// the real Bash call (same index) as a suppressed-call fragment.
 	body, summary := driveAnthropicSSEWithTools(t, "z-ai/glm-5.1", true, []string{
 		`data: {"id":"c1","choices":[{"index":0,"delta":{"role":"assistant","content":"I'll run that.","tool_calls":null},"finish_reason":null}]}` + "\n\n",
 		`data: {"id":"c1","choices":[{"index":0,"delta":{"role":"assistant","content":" One sec.","tool_calls":null},"finish_reason":null}]}` + "\n\n",

--- a/internal/translate/escape_normalize.go
+++ b/internal/translate/escape_normalize.go
@@ -2,47 +2,32 @@ package translate
 
 import "strings"
 
-// EnableEditEscapeNormalize gates the escape-sequence repair pass on file-edit
-// tool-call arguments. Set once at startup from the composition root. When
-// false, normalizeEditEscapes is a no-op for every call. Off by default
-// because the transform can corrupt legitimate code containing literal `\n` /
-// `\t` sequences in source (e.g. a Python string `"\\n"`).
+// EnableEditEscapeNormalize gates the escape-repair pass on file-edit tool
+// args. Off by default: the transform can corrupt legitimate source
+// containing literal `\n`/`\t` (e.g. a Python string `"\\n"`).
 var EnableEditEscapeNormalize bool
 
-// editToolNames is the set of tool names whose string arguments may carry
-// file content that must round-trip whitespace exactly. Comparison is
-// case-insensitive against incoming tool names so client-defined casing
-// variants are caught.
+// editToolNames is the set of tools whose args carry file content needing
+// exact whitespace round-tripping. Matched case-insensitively.
 var editToolNames = map[string]struct{}{
 	"edit":      {},
 	"write":     {},
 	"multiedit": {},
 }
 
-// editEscapableFields is the per-tool allowlist of string fields where
-// backslash-letter escapes should be unescaped. `file_path` is deliberately
-// excluded — paths shouldn't contain newlines, and rewriting one risks
-// corrupting an otherwise-valid path containing a literal backslash.
+// editEscapableFields is the allowlist of fields to unescape. `file_path` is
+// excluded — paths can contain a literal backslash that rewriting would corrupt.
 var editEscapableFields = map[string]struct{}{
 	"old_string": {},
 	"new_string": {},
 	"content":    {},
 }
 
-// normalizeEditEscapes repairs `\n` / `\t` / `\r` literal sequences that
-// upstream models occasionally emit in file-edit tool arguments where a real
-// newline / tab / carriage return was intended. Mutates `input` in place.
-// No-op when EnableEditEscapeNormalize is false, when `toolName` is not a
-// file-edit tool, or when `input` is not a JSON object.
-//
-// JSON decoding has already converted real escape sequences ("\n" in the wire
-// JSON) to actual newlines by the time we see `input`, so any remaining
-// backslash-letter sequence here is the broken case: the model emitted
-// double-escaped JSON ("\\n" on the wire) and our decoder produced literal
-// backslash-n.
-//
-// MultiEdit nests per-edit `old_string`/`new_string` inside an `edits` array,
-// so each entry there is also walked.
+// normalizeEditEscapes repairs literal `\n`/`\t`/`\r` sequences that upstream
+// models occasionally double-escape (`\\n` on the wire) in file-edit tool
+// args. Mutates `input` in place; no-op unless enabled, toolName is a
+// file-edit tool, and input is a JSON object. MultiEdit's nested `edits`
+// array entries are walked too.
 func normalizeEditEscapes(toolName string, input any) {
 	if !EnableEditEscapeNormalize {
 		return
@@ -81,9 +66,8 @@ func rewriteAllowlistedFields(m map[string]any) {
 	}
 }
 
-// unescapeBackslashLiterals rewrites the literal two-character sequences
-// `\n` / `\t` / `\r` (a real backslash followed by a real letter) to their
-// single-character escape values. Other escape sequences are left alone.
+// unescapeBackslashLiterals rewrites literal `\n`/`\t`/`\r` two-character
+// sequences to their single-character values; other escapes are untouched.
 func unescapeBackslashLiterals(s string) string {
 	if !strings.ContainsRune(s, '\\') {
 		return s

--- a/internal/translate/features.go
+++ b/internal/translate/features.go
@@ -9,14 +9,11 @@ import (
 
 const previewMaxChars = 120
 
-// contentBytesPerToken is the byte-to-token ratio for the dense JSON + code +
-// tool-result content that dominates a Claude Code request body, measured
-// against real upstream token counts (~4.2 bytes/token). Used by
-// ContextOverflowTokenEstimate. Deliberately lower than FullTokenEstimate's ÷6:
-// that divisor is tuned so base64 thought-signatures don't over-count and evict
-// the 1M Anthropic models; the overflow estimate instead subtracts the
-// signature bytes explicitly, so the remaining content divides at its true
-// ratio.
+// contentBytesPerToken is the measured bytes/token ratio (~4.2) for dense
+// Claude Code request bodies, used by ContextOverflowTokenEstimate. Lower
+// than FullTokenEstimate's ÷6 because that divisor is tuned to avoid
+// over-counting base64 thought-signatures; here we subtract signature bytes
+// explicitly instead, so the rest can divide at its true ratio.
 const contentBytesPerToken = 4
 
 // signatureFieldMarker precedes a base64 thought-signature payload in an
@@ -42,39 +39,30 @@ type RoutingFeatures struct {
 	OnlyUserMessageText string
 }
 
-// FullTokenEstimate returns a conservative token estimate for the entire
-// request body, including tool definitions, tool calls, and tool results
-// that the text-only RoutingFeatures.Tokens estimate misses. Divides raw
-// body bytes by 6 to account for JSON overhead and base64 thought-signature
-// relative to actual tokens. Used only for context-window pre-filtering;
-// RoutingFeatures.Tokens remains the routing signal.
+// FullTokenEstimate estimates tokens for the whole request body — including
+// tool defs/calls/results that RoutingFeatures.Tokens (text-only) misses.
+// Used only for context-window pre-filtering, not routing.
 func (e *RequestEnvelope) FullTokenEstimate() int {
-	// Base64 thought signatures heavily inflate the byte length, often leading
-	// to false context-window evictions for Opus. Divide by 6 to account for this.
+	// ÷6, not ÷4: base64 thought signatures otherwise inflate byte length and
+	// falsely evict Opus for exceeding its context window.
 	return len(e.body) / 6
 }
 
-// ContextOverflowTokenEstimate estimates the token count of the full body for
-// context-window overflow pre-filtering — the count a signature-KEEPING target
-// (an Anthropic-family upstream) receives. Divides raw body bytes by
-// contentBytesPerToken (~4.2 real bytes/token on dense Claude Code bodies),
-// deliberately lower than FullTokenEstimate's ÷6 so a genuinely large,
-// signature-light body is no longer undercounted onto a too-small window (the
-// bug: a ~263K prompt estimated ~175K under ÷6 and 400'd on a 256K OSS model).
-// FullTokenEstimate stays ÷6 so the extended-context beta trigger keeps its
-// existing calibration. Signature-STRIPPING targets subtract
-// SignatureTokenSavings from this figure — see excludeContextOverflowModels.
+// ContextOverflowTokenEstimate estimates tokens for context-window overflow
+// pre-filtering, for a signature-KEEPING (Anthropic-family) target. Uses
+// contentBytesPerToken rather than FullTokenEstimate's ÷6: ÷6 undercounted a
+// genuinely large, signature-light ~263K-token body to ~175K and 400'd on a
+// 256K OSS model. FullTokenEstimate stays ÷6 for its own (extended-context
+// beta) calibration. Signature-STRIPPING targets subtract
+// SignatureTokenSavings from this — see excludeContextOverflowModels.
 func (e *RequestEnvelope) ContextOverflowTokenEstimate() int {
 	return len(e.body) / contentBytesPerToken
 }
 
 // SignatureTokenSavings returns the tokens a signature-STRIPPING target saves
-// versus ContextOverflowTokenEstimate: the translator drops base64
-// thought-signature blocks before dispatch to any non-Anthropic model, so those
-// bytes never occupy that target's window. Zero for non-Anthropic inbound
-// formats — they carry no Anthropic thought-signatures, so a stray "signature"
-// field there is caller data, not a block to strip (which would falsely
-// undercount an OpenAI/Gemini request).
+// vs ContextOverflowTokenEstimate, since we drop thought-signature blocks
+// before dispatch to non-Anthropic models. Zero for non-Anthropic inbound
+// formats: a stray "signature" field there is caller data, not ours to strip.
 func (e *RequestEnvelope) SignatureTokenSavings() int {
 	if e.format != FormatAnthropic {
 		return 0
@@ -83,11 +71,8 @@ func (e *RequestEnvelope) SignatureTokenSavings() int {
 }
 
 // base64SignatureBytes sums the byte length of every base64 thought-signature
-// payload in body. Signatures are pure base64 ([A-Za-z0-9+/=], no quotes or
-// backslashes), so each payload runs from its field marker to the next double
-// quote. These bytes inflate the raw body length far out of proportion to their
-// token cost and are stripped before dispatch to any non-Anthropic model, so
-// the overflow estimate excludes them.
+// payload in body. Signatures contain no quotes/backslashes, so each payload
+// runs from its field marker to the next double quote.
 func base64SignatureBytes(body []byte) int {
 	total := 0
 	for i := 0; ; {
@@ -399,13 +384,11 @@ func contentTextGJSON(v gjson.Result) string {
 	return b.String()
 }
 
-// classifyLastMessageGJSON maps an Anthropic message's role + content to the
-// shared LastKind enum. Any user message carrying at least one tool_result
-// block is a continuation of an in-flight tool flow, even when the client
-// wraps the result with accompanying text (Claude Code emits <system-reminder>
-// text blocks alongside tool_results). Switching models on these turns would
-// hand the new model a tool_result destined for the previous model's tool_use,
-// so they must short-circuit to the session pin.
+// classifyLastMessageGJSON maps an Anthropic message to the shared LastKind
+// enum. Any user message with a tool_result block classifies as "tool_result"
+// even alongside other text (e.g. Claude Code's <system-reminder> blocks) —
+// switching models mid tool-flow would hand the new model a tool_result meant
+// for the old model's tool_use, so these must stay pinned to the session.
 func classifyLastMessageGJSON(role string, content gjson.Result) string {
 	if role == "assistant" {
 		return "assistant"
@@ -463,8 +446,7 @@ func userPromptTextGJSON(content gjson.Result) string {
 }
 
 // claudeCodeInjectedBlockPrefixes are wrapper tags Claude Code injects into
-// user-message content arrays. They carry no routing signal and dwarf the
-// user's typed text, so we skip them when building the embed input.
+// user messages; skipped since they dwarf the user's typed text and add no signal.
 var claudeCodeInjectedBlockPrefixes = []string{
 	"<system-reminder>",
 	"<command-name>",
@@ -523,9 +505,8 @@ func appendText(b *strings.Builder, s string) {
 	b.WriteString(s)
 }
 
-// anthropicHasImages reports whether any message content block is an "image"
-// block. Anthropic carries images as {"type":"image","source":{...}} entries in
-// a message's content array; string content never has an image.
+// anthropicHasImages reports whether any content block is
+// {"type":"image",...}. String content never has an image.
 func anthropicHasImages(body []byte) bool {
 	found := false
 	gjson.GetBytes(body, "messages").ForEach(func(_, msg gjson.Result) bool {
@@ -545,9 +526,8 @@ func anthropicHasImages(body []byte) bool {
 	return found
 }
 
-// openAIHasImages reports whether any message content part is an "image_url"
-// part. OpenAI carries images as {"type":"image_url","image_url":{...}} entries
-// in a message's content array; string content never has an image.
+// openAIHasImages reports whether any content part is
+// {"type":"image_url",...}. String content never has an image.
 func openAIHasImages(body []byte) bool {
 	found := false
 	gjson.GetBytes(body, "messages").ForEach(func(_, msg gjson.Result) bool {

--- a/internal/translate/force_model_test.go
+++ b/internal/translate/force_model_test.go
@@ -55,10 +55,8 @@ func TestParseForceModelCommand_ForceModel(t *testing.T) {
 			wantFound: false,
 		},
 		{
-			// Security guard: a /force-model anywhere other than the leading
-			// non-empty line is ignored. Pasted content (snippets, transcripts,
-			// log dumps) frequently contains lines starting with "/" and must
-			// not silently rewrite session routing.
+			// Only a leading /force-model triggers; pasted content often has
+			// lines starting with "/" and must not rewrite session routing.
 			name:      "command after leading text is ignored",
 			input:     "Please help me.\n/force-model gemini-2.5-pro",
 			wantFound: false,
@@ -88,9 +86,8 @@ func TestParseForceModelCommand_ForceModel(t *testing.T) {
 			wantStripped: "",
 		},
 		{
-			// Claude Code injects <system-reminder> blocks ahead of the user's
-			// typed text. The command must still be recognized; injected blocks
-			// must be preserved in the stripped output.
+			// Injected <system-reminder> blocks must not block recognition
+			// and must be preserved in the stripped output.
 			name:         "leading system-reminder before command",
 			input:        "<system-reminder>be helpful</system-reminder>\n/force-model gpt-5",
 			wantModel:    "gpt-5",
@@ -119,9 +116,8 @@ func TestParseForceModelCommand_ForceModel(t *testing.T) {
 			wantFound: false,
 		},
 		{
-			// Tags with attributes are not part of Claude Code's injection set
-			// and must not unlock the guard — they may originate from pasted
-			// HTML/XML content.
+			// Attributed tags aren't part of Claude Code's injection set and
+			// may be pasted HTML/XML, so they must not unlock the guard.
 			name:      "tag with attributes does not unlock leading-line guard",
 			input:     "<div class=\"x\">hi</div>\n/force-model gpt-5",
 			wantFound: false,
@@ -204,10 +200,8 @@ func TestExtractForceModelCommand_ArrayContent(t *testing.T) {
 }
 
 func TestExtractForceModelCommand_ArrayContentMultipleTextBlocks(t *testing.T) {
-	// Claude Code clients sometimes split a slash-command turn into multiple
-	// text blocks: one carries the injected <command-name>/<command-args>
-	// tags, and the typed directive lands in a separate block. The parser
-	// must scan every text block, not just the first.
+	// The directive can land in a non-first text block (e.g. after an
+	// injected <command-name> block), so the parser must scan all of them.
 	body := mustMarshalJSON(t, map[string]any{
 		"model": "claude-sonnet-4-6",
 		"messages": []any{

--- a/internal/translate/handover.go
+++ b/internal/translate/handover.go
@@ -8,14 +8,13 @@ import (
 	"github.com/tidwall/sjson"
 )
 
-// HandoverSummaryTag prefixes the synthesized assistant message inserted by
-// RewriteForHandover so a reader can tell the bounded-cost handover summary
-// apart from real assistant output.
+// HandoverSummaryTag prefixes the synthesized summary message inserted by
+// RewriteForHandover so it's distinguishable from real assistant output.
 const HandoverSummaryTag = "[handover summary] "
 
-// RewriteForHandover replaces all non-system messages with [assistantSummary, latestUserMessage].
-// Returns the count of elided messages. No-ops when the envelope has no messages.
-// Used to bound input-token cost on mid-session model switches.
+// RewriteForHandover replaces all non-system messages with [assistantSummary,
+// latestUserMessage] to bound input-token cost on mid-session model switches.
+// Returns the count of elided messages; no-ops if there are none.
 func (e *RequestEnvelope) RewriteForHandover(summary string) int {
 	if e == nil {
 		return 0
@@ -317,10 +316,9 @@ func (e *RequestEnvelope) trimGeminiLastN(n int) int {
 	return len(all) - len(keep)
 }
 
-// stripOrphanedAnthropicToolResults removes tool_result content blocks from
-// Anthropic-format user messages when the referenced tool_use_id has no
-// matching tool_use block in any assistant message in the set. User messages
-// left with no content blocks after stripping are omitted entirely.
+// stripOrphanedAnthropicToolResults drops tool_result blocks whose tool_use_id
+// has no matching tool_use among the set's assistant messages; user messages
+// left empty afterward are omitted entirely.
 func stripOrphanedAnthropicToolResults(msgs []gjson.Result) []string {
 	knownIDs := collectAnthropicToolUseIDs(msgs)
 	result := make([]string, 0, len(msgs))
@@ -357,9 +355,8 @@ func collectAnthropicToolUseIDs(msgs []gjson.Result) map[string]struct{} {
 	return ids
 }
 
-// stripAnthropicToolResultMsg removes tool_result blocks from a user message
-// whose tool_use_id is not in knownIDs. A nil knownIDs strips all
-// tool_results. Returns "" if the message is left with no content.
+// stripAnthropicToolResultMsg removes tool_result blocks not in knownIDs (nil
+// strips all). Returns "" if the message is left with no content.
 func stripAnthropicToolResultMsg(msg gjson.Result, knownIDs map[string]struct{}) string {
 	content := msg.Get("content")
 	if !content.IsArray() {

--- a/internal/translate/strictify_openai.go
+++ b/internal/translate/strictify_openai.go
@@ -20,33 +20,25 @@ var strictifyBailKeywords = []string{
 	"dependentSchemas", "unevaluatedProperties", "unevaluatedItems", "prefixItems",
 }
 
-// strictifyDropKeywords are constraint keywords strict mode rejects; they are
-// stripped from the node and appended to its description so the model still
-// sees the constraint as guidance. Order fixes the appended-text order.
+// strictifyDropKeywords are constraints strict mode rejects; they're stripped
+// from the node and appended to its description as guidance instead.
 var strictifyDropKeywords = []string{
 	"format", "pattern", "default", "examples",
 	"minimum", "maximum", "exclusiveMinimum", "exclusiveMaximum", "multipleOf",
 	"minLength", "maxLength", "minItems", "maxItems", "uniqueItems",
 	"minProperties", "maxProperties",
-	// Key/membership constraints strict mode rejects outright. propertyNames
-	// in particular rode through untouched and 400'd the whole request
-	// ("'propertyNames' is not permitted") for any session carrying the
+	// propertyNames rode through untouched and 400'd requests carrying the
 	// playwright MCP tools (browser_drop) on the gpt-5.x Responses path.
 	"propertyNames", "contains", "minContains", "maxContains", "dependentRequired",
 }
 
-// strictifyOpenAISchema converts a tool input_schema (already $ref-inlined by
-// inlineSchemaDefs) into the subset OpenAI structured outputs requires for
-// `strict:true` function tools: additionalProperties:false on every object,
-// every property required, and originally-optional properties made nullable
-// (type union with "null") so the call can still omit them semantically.
-// Constraint keywords strict mode rejects are moved into descriptions.
+// strictifyOpenAISchema converts a $ref-inlined tool input_schema into the
+// subset OpenAI strict mode requires: additionalProperties:false everywhere,
+// all properties required (optional ones made nullable instead), and rejected
+// constraint keywords moved into descriptions.
 //
-// Returns ok=false when the schema cannot be faithfully strictified (root is
-// not an object schema, bail keywords like oneOf / unresolved $ref are
-// present, or size limits are exceeded); the caller then emits the original
-// schema without strict. The input is never mutated — the result is a deep
-// transform over a copy.
+// Returns ok=false if the schema can't be strictified (non-object root, bail
+// keywords, unresolved $ref, or size limits exceeded). Input is never mutated.
 func strictifyOpenAISchema(schema any) (out any, ok bool) {
 	root, isMap := schema.(map[string]any)
 	if !isMap {
@@ -184,9 +176,8 @@ func strictifyNode(node map[string]any, depth int, propCount *int) (out map[stri
 	return res, true
 }
 
-// makeNullable rewrites a property schema so null is an accepted value:
-// strict mode requires every property listed in `required`, so optionality is
-// expressed as a null union instead of omission.
+// makeNullable adds null as an accepted type: strict mode requires every
+// property in `required`, so optionality is expressed via null union instead.
 func makeNullable(node map[string]any) map[string]any {
 	switch t := node["type"].(type) {
 	case string:

--- a/internal/translate/toolcheck/jsonfix.go
+++ b/internal/translate/toolcheck/jsonfix.go
@@ -2,14 +2,11 @@ package toolcheck
 
 import "strings"
 
-// repairJSON attempts a minimal, conservative repair of malformed tool
-// argument JSON. It handles the observed model failure modes — markdown
-// fences around the payload, trailing commas, and truncation mid-stream —
-// and nothing speculative. Returns "" when no repair applied (caller falls
-// back to "{}").
+// repairJSON conservatively repairs malformed tool-argument JSON: markdown
+// fences, trailing commas, and mid-stream truncation. Returns "" if no
+// repair applied (caller falls back to "{}").
 //
-// A full LLM-output JSON repairer (e.g. kaptinlin/jsonrepair) is the upgrade
-// path once the module toolchain moves to go 1.26.
+// TODO: switch to a full repairer (kaptinlin/jsonrepair) once go 1.26 lands.
 func repairJSON(raw string) (out string, actions []string) {
 	if len(raw) > maxArgsBytes {
 		return "", nil
@@ -47,19 +44,15 @@ func stripMarkdownFence(s string) (out string, ok bool) {
 	return body, true
 }
 
-// balanceJSON walks the input tracking string/escape state, drops trailing
-// commas, truncates anything after the top-level value closes, and closes
-// whatever a truncation left open (string, then brackets/braces). A dangling
-// partial member like `,"key":` is stripped back to the last complete value
-// before closing.
+// balanceJSON tracks string/escape state to drop trailing commas, truncate
+// content after the top-level value closes, and close whatever truncation
+// left open — stripping a dangling partial member like `,"key":` first.
 func balanceJSON(s string) (out string, actions []string) {
 	var stack []byte
 	inString := false
 	escaped := false
-	// expectKey tracks whether a string at the current position would be an
-	// object KEY rather than a value — a closing quote on a key must not
-	// count as "last complete value" or a dangling `"key":` would survive
-	// the cut.
+	// expectKey marks whether the next string is an object KEY, not a value:
+	// a key's closing quote must not count as "last complete value".
 	expectKey := false
 	stringIsKey := false
 	lastComplete := -1 // index AFTER the last byte that ends a complete value
@@ -136,9 +129,8 @@ func balanceJSON(s string) (out string, actions []string) {
 		return "", nil // already balanced; the syntax error is something else
 	}
 
-	// Truncated input: close an open VALUE string, cut back to the last
-	// complete value (dropping any dangling partial member), then close the
-	// open scopes in reverse order.
+	// Truncated input: close an open value string, cut back to the last
+	// complete value, then close remaining open scopes in reverse order.
 	out = b.String()
 	if inString && !stringIsKey {
 		out += `"`


### PR DESCRIPTION
## Summary
- Part 4 of the comment-length cleanup (parts 1-3: #583, #584, #586). Sweeps the long tail (37 files, max ~5 blocks/file).
- Same rule as prior parts: keep genuinely non-obvious "why" explanations (hidden constraints, bug workarounds, security/precision rationale, prod-incident context), cut restated/narrated filler.
- Comment-only changes, no logic touched. Skipped SQLC-generated files.
- Independent of #583/#584/#586 (disjoint file sets, all branched off main) — can merge in any order.

## Test plan
- [x] `go build ./...` clean
- [x] `gofmt -l .` clean
- [x] `go vet ./...` clean
- [x] `go test ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)