### PR TITLE
fix(proxy): fail over subscription OAuth 401/403 to the Weave key

### DIFF
--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -2145,16 +2145,18 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 	}
 
 	// Subscription-credit failover: a subscription-served Anthropic turn got a
-	// retryable fault (429 weekly/5h-limit, or ~90s timeout) pre-commit.
-	// Suppress the subscription token and retry the SAME model once on the
-	// Weave/BYOK key so the turn completes instead of surfacing the throttle
-	// raw. Bounded to one extra attempt, pre-commit only, genuinely retryable
-	// only. Skipped when baseline failover already ran (mutually exclusive:
-	// that requires a non-Anthropic routed provider).
+	// retryable fault (429 weekly/5h-limit, or ~90s timeout) OR had its OAuth
+	// token refused (401 authentication_error / 403 permission_error — expired
+	// token, or an org that disabled OAuth) pre-commit. Suppress the subscription
+	// token and retry the SAME model once on the Weave/BYOK key so the turn
+	// completes instead of surfacing the throttle/rejection raw. Bounded to one
+	// extra attempt, pre-commit only. Skipped when baseline failover already ran
+	// (mutually exclusive: that requires a non-Anthropic routed provider).
 	subscriptionFailoverUsed := false
 	subscriptionRetryRan := false
 	if subscriptionRetryEligible && !baselineAttempted && proxyErr != nil &&
-		!preludeBuf.Committed() && providers.IsRetryable(proxyErr) {
+		!preludeBuf.Committed() &&
+		(providers.IsRetryable(proxyErr) || anthropicOAuthCredentialRejected(proxyErr)) {
 		subscriptionRetryRan = true
 		subCtx := withSuppressedClaudeSubscription(ctx)
 		subCtx = resolveAndInjectCredentials(subCtx, providers.ProviderAnthropic, r.Header)

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -2144,14 +2144,10 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 		flushUpstreamErrorAsAnthropic(contentSink, proxyErr)
 	}
 
-	// Subscription-credit failover: a subscription-served Anthropic turn got a
-	// retryable fault (429 weekly/5h-limit, or ~90s timeout) OR had its OAuth
-	// token refused (401 authentication_error / 403 permission_error — expired
-	// token, or an org that disabled OAuth) pre-commit. Suppress the subscription
-	// token and retry the SAME model once on the Weave/BYOK key so the turn
-	// completes instead of surfacing the throttle/rejection raw. Bounded to one
-	// extra attempt, pre-commit only. Skipped when baseline failover already ran
-	// (mutually exclusive: that requires a non-Anthropic routed provider).
+	// Subscription-credit failover: suppress the OAuth token and retry the SAME
+	// model once on the Weave/BYOK key when a subscription-served Anthropic turn
+	// hit a transient fault (429/timeout) or an OAuth rejection (401/403),
+	// pre-commit. Skipped when baseline failover already ran (non-Anthropic).
 	subscriptionFailoverUsed := false
 	subscriptionRetryRan := false
 	if subscriptionRetryEligible && !baselineAttempted && proxyErr != nil &&

--- a/internal/proxy/subscription_oauth_reject_internal_test.go
+++ b/internal/proxy/subscription_oauth_reject_internal_test.go
@@ -1,0 +1,83 @@
+package proxy
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+
+	"workweave/router/internal/providers"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAnthropicOAuthCredentialRejected(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "403 permission_error (org disabled OAuth) is rejected",
+			err: &providers.UpstreamErrorResponse{
+				Status: http.StatusForbidden,
+				Body:   []byte(`{"type":"error","error":{"type":"permission_error","message":"OAuth authentication is currently not allowed for this organization."}}`),
+			},
+			want: true,
+		},
+		{
+			name: "401 authentication_error (expired/invalid token) is rejected",
+			err: &providers.UpstreamErrorResponse{
+				Status: http.StatusUnauthorized,
+				Body:   []byte(`{"type":"error","error":{"type":"authentication_error","message":"Invalid authentication credentials"}}`),
+			},
+			want: true,
+		},
+		{
+			name: "403 with an unrelated error type stays terminal",
+			err: &providers.UpstreamErrorResponse{
+				Status: http.StatusForbidden,
+				Body:   []byte(`{"type":"error","error":{"type":"invalid_request_error","message":"content policy"}}`),
+			},
+			want: false,
+		},
+		{
+			name: "429 rate-limit is not an OAuth rejection (handled by IsRetryable)",
+			err: &providers.UpstreamErrorResponse{
+				Status: http.StatusTooManyRequests,
+				Body:   []byte(`{"type":"error","error":{"type":"rate_limit_error","message":"slow down"}}`),
+			},
+			want: false,
+		},
+		{
+			name: "400 authentication_error (wrong status) stays terminal",
+			err: &providers.UpstreamErrorResponse{
+				Status: http.StatusBadRequest,
+				Body:   []byte(`{"type":"error","error":{"type":"authentication_error"}}`),
+			},
+			want: false,
+		},
+		{
+			name: "unparseable body stays terminal",
+			err: &providers.UpstreamErrorResponse{
+				Status: http.StatusForbidden,
+				Body:   []byte(`not json`),
+			},
+			want: false,
+		},
+		{
+			name: "non-upstream error stays terminal",
+			err:  errors.New("dial tcp: connection refused"),
+			want: false,
+		},
+		{
+			name: "nil is not a rejection",
+			err:  nil,
+			want: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, anthropicOAuthCredentialRejected(tc.err))
+		})
+	}
+}

--- a/internal/proxy/usage_bypass.go
+++ b/internal/proxy/usage_bypass.go
@@ -141,10 +141,8 @@ func (s *Service) anthropicFallbackKeyAvailable(ctx context.Context) bool {
 
 // anthropicOAuthCredentialRejected reports whether err is a buffered Anthropic
 // 401 authentication_error or 403 permission_error — a rejected subscription
-// OAuth token (expired, or an org with OAuth sign-in disabled). On a
-// subscription-served turn these are the credential's fault, so they gate the
-// failover onto the BYOK/deployment key. Deliberately narrow so an unrelated 403
-// (e.g. content policy) stays terminal.
+// OAuth token that gates the failover onto the BYOK/deployment key. Narrow by
+// design so an unrelated 403 (e.g. content policy) stays terminal.
 func anthropicOAuthCredentialRejected(err error) bool {
 	var buffered *providers.UpstreamErrorResponse
 	if !errors.As(err, &buffered) {

--- a/internal/proxy/usage_bypass.go
+++ b/internal/proxy/usage_bypass.go
@@ -2,6 +2,7 @@ package proxy
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
@@ -136,6 +137,35 @@ func (s *Service) anthropicFallbackKeyAvailable(ctx context.Context) bool {
 		}
 	}
 	return false
+}
+
+// anthropicOAuthCredentialRejected reports whether err is a buffered Anthropic
+// 401/403 that means the caller's subscription OAuth token was refused — an
+// expired/invalid token (401 authentication_error) or an org that has disabled
+// OAuth sign-in (403 permission_error, "OAuth authentication is currently not
+// allowed for this organization"). On a subscription-served turn these are the
+// credential's fault, not the client's, and a retry on the deployment/BYOK
+// Anthropic key serves the turn — so they gate the subscription-credit failover
+// alongside the transient faults IsRetryable already covers. Deliberately narrow:
+// only the two error types actually produced by a rejected OAuth token, so an
+// unrelated 403 (e.g. content policy) is left terminal.
+func anthropicOAuthCredentialRejected(err error) bool {
+	var buffered *providers.UpstreamErrorResponse
+	if !errors.As(err, &buffered) {
+		return false
+	}
+	if buffered.Status != http.StatusUnauthorized && buffered.Status != http.StatusForbidden {
+		return false
+	}
+	var env struct {
+		Error struct {
+			Type string `json:"type"`
+		} `json:"error"`
+	}
+	if jsonErr := json.Unmarshal(buffered.Body, &env); jsonErr != nil {
+		return false
+	}
+	return env.Error.Type == "authentication_error" || env.Error.Type == "permission_error"
 }
 
 // errBypassRetryable is returned by bypassToAnthropic when the bypass attempt

--- a/internal/proxy/usage_bypass.go
+++ b/internal/proxy/usage_bypass.go
@@ -140,15 +140,11 @@ func (s *Service) anthropicFallbackKeyAvailable(ctx context.Context) bool {
 }
 
 // anthropicOAuthCredentialRejected reports whether err is a buffered Anthropic
-// 401/403 that means the caller's subscription OAuth token was refused — an
-// expired/invalid token (401 authentication_error) or an org that has disabled
-// OAuth sign-in (403 permission_error, "OAuth authentication is currently not
-// allowed for this organization"). On a subscription-served turn these are the
-// credential's fault, not the client's, and a retry on the deployment/BYOK
-// Anthropic key serves the turn — so they gate the subscription-credit failover
-// alongside the transient faults IsRetryable already covers. Deliberately narrow:
-// only the two error types actually produced by a rejected OAuth token, so an
-// unrelated 403 (e.g. content policy) is left terminal.
+// 401 authentication_error or 403 permission_error — a rejected subscription
+// OAuth token (expired, or an org with OAuth sign-in disabled). On a
+// subscription-served turn these are the credential's fault, so they gate the
+// failover onto the BYOK/deployment key. Deliberately narrow so an unrelated 403
+// (e.g. content policy) stays terminal.
 func anthropicOAuthCredentialRejected(err error) bool {
 	var buffered *providers.UpstreamErrorResponse
 	if !errors.As(err, &buffered) {


### PR DESCRIPTION
## What

A subscription-served Anthropic turn whose OAuth token is refused was surfaced **raw to the client with no failover**, even when a deployment/BYOK Anthropic key was available to serve it. Two variants, both terminal today:

- **403** `permission_error` — `"OAuth authentication is currently not allowed for this organization."` (the customer's Anthropic org disabled OAuth sign-in)
- **401** `authentication_error` — `"Invalid authentication credentials"` (expired / invalid `sk-ant-oat` token)

Found in a prod router-calls sweep: one org accounted for ~100 terminal errors of exactly these two shapes over 7 days, all on `claude-code` → `claude-opus-4-8`, none of which failed over.

## Fix

Extend the existing **subscription-credit failover** (already handles 429 weekly/5h-limit + ~90s timeout) to also treat these OAuth rejections as failover-eligible: suppress the subscription token and retry the **same model once** on the Weave/BYOK Anthropic key. Reuses the existing suppression + re-resolve machinery — no new dispatch path.

- Bounded to one extra attempt, pre-commit only (`!preludeBuf.Committed()`).
- Gated on a fallback Anthropic key being available (`subscriptionRetryEligible`); with none, the original error is surfaced as before.
- New classifier `anthropicOAuthCredentialRejected` is deliberately narrow — only the two error types a rejected OAuth token actually produces, so an unrelated 403 (e.g. content policy) stays terminal.

## Test

`TestAnthropicOAuthCredentialRejected` — table test over 401/403 credential bodies, unrelated 403, 429, wrong-status, unparseable body, non-upstream error, and nil.

🤖 Generated with [Claude Code](https://claude.com/claude-code)