### PR TITLE
fix(translate): floor Responses max_output_tokens so reasoning turns don't 400

### DIFF
--- a/internal/translate/emit_openai_responses.go
+++ b/internal/translate/emit_openai_responses.go
@@ -85,6 +85,20 @@ func responsesReasoningEffort(eff, model string) string {
 	return eff
 }
 
+// minResponsesOutputTokens floors max_output_tokens on the Responses API. This
+// path is reasoning-models-only (UseOpenAIResponsesAPI requires CapReasoning), and
+// a reasoning model spends its output budget on hidden reasoning before it can emit
+// a single visible token. Claude Code sends a tiny max_tokens for its auxiliary
+// turns (1 for a quota/auth probe, 64 for topic/title generation); mapped straight
+// to max_output_tokens the reasoning phase exhausts it and the turn 400s with
+// "Could not finish the message because max_tokens or model output limit was
+// reached." max_output_tokens is a CEILING, not an allocation — the model still
+// bills only what it generates — so flooring a small request costs nothing on turns
+// that finish quickly; it only prevents the premature truncation. Real agentic
+// turns request far more than this (Claude Code caps main-loop turns at ~32k), so
+// the floor only ever lifts the small auxiliary turns.
+const minResponsesOutputTokens = 16000
+
 func (e *RequestEnvelope) buildResponsesFromAnthropic(opts EmitOptions) ([]byte, providers.RequestMutationStats, error) {
 	var stats providers.RequestMutationStats
 	body, removed, err := filterClaudeCodeOnlyToolsFromAnthropicBody(e.body)
@@ -139,7 +153,7 @@ func (e *RequestEnvelope) buildResponsesFromAnthropic(opts EmitOptions) ([]byte,
 
 	if mt := gjson.GetBytes(body, "max_tokens"); mt.Exists() && mt.Type == gjson.Number {
 		jw.Key("max_output_tokens")
-		jw.Int(clampToModelOutputCap(mt.Int(), opts.TargetModel))
+		jw.Int(clampToModelOutputCap(max(mt.Int(), minResponsesOutputTokens), opts.TargetModel))
 	}
 	// NB: reasoning models reject temperature != 1 on the Responses API, so we
 	// deliberately omit temperature/top_p here.

--- a/internal/translate/responses_outbound_test.go
+++ b/internal/translate/responses_outbound_test.go
@@ -3,6 +3,7 @@ package translate_test
 import (
 	"encoding/base64"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"strconv"
 	"strings"
@@ -77,7 +78,10 @@ func TestPrepareOpenAIResponses_RequestShape(t *testing.T) {
 	reasoning, _ := out["reasoning"].(map[string]any)
 	require.NotNil(t, reasoning, "reasoning must be set from thinking budget")
 	assert.Equal(t, "high", reasoning["effort"], "31999 budget -> high")
-	assert.EqualValues(t, 4096, out["max_output_tokens"])
+	// max_tokens 4096 is floored to minResponsesOutputTokens (16000): a reasoning
+	// model needs output-budget headroom for hidden reasoning before any visible
+	// token, so the requested 4096 is lifted to the reasoning floor.
+	assert.EqualValues(t, 16000, out["max_output_tokens"])
 	assert.Equal(t, "auto", out["tool_choice"])
 
 	// tools: FLAT function shape (no nested "function" wrapper)
@@ -119,6 +123,43 @@ func TestPrepareOpenAIResponses_RequestShape(t *testing.T) {
 	assert.Equal(t, "file.go", fco["output"])
 
 	assert.Equal(t, providers.EndpointResponses, prep.Endpoint)
+}
+
+// A tiny client max_tokens (Claude Code sends 1 for a probe, 64 for a
+// title/topic turn) must be floored to the reasoning output budget: a reasoning
+// model burns the budget on hidden reasoning before any visible token, so the
+// raw tiny value 400s ("max_tokens or model output limit was reached"). A budget
+// already above the floor is passed through unchanged (clamped only to the cap).
+func TestPrepareOpenAIResponses_FloorsMaxOutputTokensForReasoning(t *testing.T) {
+	cases := []struct {
+		name       string
+		maxTokens  int
+		wantMaxOut int64
+	}{
+		{name: "probe max_tokens=1 floored", maxTokens: 1, wantMaxOut: 16000},
+		{name: "title-turn max_tokens=64 floored", maxTokens: 64, wantMaxOut: 16000},
+		{name: "at floor unchanged", maxTokens: 16000, wantMaxOut: 16000},
+		{name: "large budget passes through", maxTokens: 32000, wantMaxOut: 32000},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			body := []byte(fmt.Sprintf(`{
+				"model":"claude-opus-4-8","max_tokens":%d,
+				"tools":[{"name":"bash","description":"run","input_schema":{"type":"object","properties":{"command":{"type":"string"}},"required":["command"]}}],
+				"messages":[{"role":"user","content":"hi"}]
+			}`, tc.maxTokens))
+			env, err := translate.ParseAnthropic(body)
+			require.NoError(t, err)
+			prep, err := env.PrepareOpenAIResponses(http.Header{}, translate.EmitOptions{
+				TargetModel:  "gpt-5.4-mini",
+				Capabilities: router.Lookup("gpt-5.4-mini"),
+			})
+			require.NoError(t, err)
+			var out map[string]any
+			require.NoError(t, json.Unmarshal(prep.Body, &out))
+			assert.EqualValues(t, tc.wantMaxOut, out["max_output_tokens"])
+		})
+	}
 }
 
 // Gemini sessions smuggle a thoughtSignature into tool_use ids


### PR DESCRIPTION
## What

Small auxiliary turns routed to a gpt-5.x reasoning model were 400ing upstream:

```
{"type":"invalid_request_error","message":"Could not finish the message because
max_tokens or model output limit was reached. Please try again with higher max_tokens."}
```

Seen in a prod router-calls sweep on `gpt-5.4-mini`. The inbound `max_tokens` on the failing turns was **1 or 64** — Claude Code's quota/auth probe (`max_tokens:1`) and its title/topic turns (`max_tokens:64`).

## Root cause

The Anthropic→OpenAI **Responses** path is reasoning-models-only (`UseOpenAIResponsesAPI` requires `CapReasoning`). A reasoning model spends its output budget on **hidden reasoning before it can emit a single visible token**. The client's tiny `max_tokens` maps straight to `max_output_tokens`, so the reasoning phase alone exhausts it → the model can never produce output → 400.

## Fix

Floor `max_output_tokens` to **16000** on this path.

`max_output_tokens` is a **ceiling, not an allocation** — the model still bills only what it actually generates — so flooring a small request costs nothing on turns that finish quickly; it only prevents the premature truncation. Real agentic turns request far more (Claude Code caps main-loop turns at ~32k), so the floor only ever lifts the small auxiliary turns. The value is still clamped to the model's output cap.

## Test

`TestPrepareOpenAIResponses_FloorsMaxOutputTokensForReasoning` — `max_tokens` 1 and 64 floored to 16000, 16000 unchanged, 32000 passed through. Updated `TestPrepareOpenAIResponses_RequestShape` (4096 → floored to 16000).

🤖 Generated with [Claude Code](https://claude.com/claude-code)