### PR TITLE
fix(cost): stop crediting savings for model-switch cache prefills

### DIFF
--- a/internal/proxy/gemini.go
+++ b/internal/proxy/gemini.go
@@ -224,7 +224,7 @@ func (s *Service) ProxyGeminiGenerateContent(ctx context.Context, body []byte, w
 		Int64("usage.output_tokens", int64(out)).
 		Int64("usage.cache_creation_input_tokens", int64(cacheCreation)).
 		Int64("usage.cache_read_input_tokens", int64(cacheRead)).
-		Float64("cost.requested_input_usd", catalog.EffectiveInputCost(in, cacheCreation, cacheRead, reqPricing.InputUSDPer1M, reqPricing, decision.Provider)).
+		Float64("cost.requested_input_usd", catalog.CounterfactualInputCost(in, cacheCreation, cacheRead, reqPricing.InputUSDPer1M, reqPricing, decision.Provider, routeRes.switchPrefillPaid())).
 		Float64("cost.requested_output_usd", catalog.EffectiveOutputCost(out, reqPricing.OutputUSDPer1M)).
 		Float64("cost.actual_input_usd", catalog.EffectiveInputCost(in, cacheCreation, cacheRead, actPricing.InputUSDPer1M, actPricing, decision.Provider)).
 		Float64("cost.actual_output_usd", catalog.EffectiveOutputCost(out, actPricing.OutputUSDPer1M)).

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -2443,7 +2443,7 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 		Int64("usage.output_tokens", int64(out)).
 		Int64("usage.cache_creation_input_tokens", int64(cacheCreation)).
 		Int64("usage.cache_read_input_tokens", int64(cacheRead)).
-		Float64("cost.requested_input_usd", catalog.EffectiveInputCost(in, cacheCreation, cacheRead, reqPricing.InputUSDPer1M, reqPricing, decision.Provider)).
+		Float64("cost.requested_input_usd", catalog.CounterfactualInputCost(in, cacheCreation, cacheRead, reqPricing.InputUSDPer1M, reqPricing, decision.Provider, routeRes.switchPrefillPaid())).
 		Float64("cost.requested_output_usd", catalog.EffectiveOutputCost(out, reqPricing.OutputUSDPer1M)).
 		Float64("cost.actual_input_usd", catalog.EffectiveInputCost(in, cacheCreation, cacheRead, actPricing.InputUSDPer1M, actPricing, decision.Provider)).
 		Float64("cost.actual_output_usd", catalog.EffectiveOutputCost(out, actPricing.OutputUSDPer1M)).
@@ -2516,7 +2516,7 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 			EmbedInput:             embedInput,
 			InputTokens:            int32(in),
 			OutputTokens:           int32(out),
-			RequestedInputCostUSD:  catalog.EffectiveInputCost(in, cacheCreation, cacheRead, reqPricing.InputUSDPer1M, reqPricing, decision.Provider),
+			RequestedInputCostUSD:  catalog.CounterfactualInputCost(in, cacheCreation, cacheRead, reqPricing.InputUSDPer1M, reqPricing, decision.Provider, routeRes.switchPrefillPaid()),
 			RequestedOutputCostUSD: catalog.EffectiveOutputCost(out, reqPricing.OutputUSDPer1M),
 			ActualInputCostUSD:     catalog.EffectiveInputCost(in, cacheCreation, cacheRead, actPricing.InputUSDPer1M, actPricing, decision.Provider),
 			ActualOutputCostUSD:    catalog.EffectiveOutputCost(out, actPricing.OutputUSDPer1M),
@@ -3990,7 +3990,7 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 		Int64("usage.output_tokens", int64(out)).
 		Int64("usage.cache_creation_input_tokens", int64(cacheCreation)).
 		Int64("usage.cache_read_input_tokens", int64(cacheRead)).
-		Float64("cost.requested_input_usd", catalog.EffectiveInputCost(in, cacheCreation, cacheRead, reqPricing.InputUSDPer1M, reqPricing, decision.Provider)).
+		Float64("cost.requested_input_usd", catalog.CounterfactualInputCost(in, cacheCreation, cacheRead, reqPricing.InputUSDPer1M, reqPricing, decision.Provider, routeRes.switchPrefillPaid())).
 		Float64("cost.requested_output_usd", catalog.EffectiveOutputCost(out, reqPricing.OutputUSDPer1M)).
 		Float64("cost.actual_input_usd", catalog.EffectiveInputCost(in, cacheCreation, cacheRead, actPricing.InputUSDPer1M, actPricing, decision.Provider)).
 		Float64("cost.actual_output_usd", catalog.EffectiveOutputCost(out, actPricing.OutputUSDPer1M)).
@@ -4063,7 +4063,7 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 			EmbedInput:             embedInput,
 			InputTokens:            int32(in),
 			OutputTokens:           int32(out),
-			RequestedInputCostUSD:  catalog.EffectiveInputCost(in, cacheCreation, cacheRead, reqPricing.InputUSDPer1M, reqPricing, decision.Provider),
+			RequestedInputCostUSD:  catalog.CounterfactualInputCost(in, cacheCreation, cacheRead, reqPricing.InputUSDPer1M, reqPricing, decision.Provider, routeRes.switchPrefillPaid()),
 			RequestedOutputCostUSD: catalog.EffectiveOutputCost(out, reqPricing.OutputUSDPer1M),
 			ActualInputCostUSD:     catalog.EffectiveInputCost(in, cacheCreation, cacheRead, actPricing.InputUSDPer1M, actPricing, decision.Provider),
 			ActualOutputCostUSD:    catalog.EffectiveOutputCost(out, actPricing.OutputUSDPer1M),

--- a/internal/proxy/turnloop.go
+++ b/internal/proxy/turnloop.go
@@ -120,6 +120,16 @@ func (r turnLoopResult) modelSwitched() bool {
 	return transition || r.SessionEverSwitched
 }
 
+// switchPrefillPaid reports whether this turn actually paid a cold-cache prefill
+// from a mid-session switch — the single transition turn, unlike modelSwitched's
+// session-lifetime latch. Excludes the first turn and client-trim windows
+// (PrefixTrimmed): a no-switch baseline pays a prefill there too, so there is
+// nothing to correct. Gates the savings counterfactual (CounterfactualInputCost).
+func (r turnLoopResult) switchPrefillPaid() bool {
+	transition := r.PriorServedModel != "" && r.PriorServedModel != r.Decision.Model
+	return transition && !r.PrefixTrimmed
+}
+
 // handoverOutcome describes the synchronous handover step.
 type handoverOutcome struct {
 	Invoked       bool

--- a/internal/router/catalog/cost.go
+++ b/internal/router/catalog/cost.go
@@ -28,3 +28,17 @@ func EffectiveInputCost(inputTokens, cacheCreation, cacheRead int, pricePer1M fl
 func EffectiveOutputCost(outputTokens int, pricePer1M float64) float64 {
 	return float64(outputTokens) / 1_000_000 * pricePer1M
 }
+
+// CounterfactualInputCost is EffectiveInputCost for the savings baseline, except
+// on a model-switch turn (switchPrefillPaid) it reprices the served model's
+// cold-cache prefill as a cache read: a session that never switched would have
+// kept that context warm, so charging the baseline the prefill overstates
+// savings. Off the switch turn it is identical to EffectiveInputCost.
+func CounterfactualInputCost(inputTokens, cacheCreation, cacheRead int, pricePer1M float64, p Pricing, upstreamProvider string, switchPrefillPaid bool) float64 {
+	if !switchPrefillPaid {
+		return EffectiveInputCost(inputTokens, cacheCreation, cacheRead, pricePer1M, p, upstreamProvider)
+	}
+	// New tokens for a single turn are negligible against the carried context, so
+	// fold the whole prefill into cache reads rather than splitting new-vs-carried.
+	return EffectiveInputCost(inputTokens, 0, cacheCreation+cacheRead, pricePer1M, p, upstreamProvider)
+}

--- a/internal/router/catalog/cost_test.go
+++ b/internal/router/catalog/cost_test.go
@@ -1,0 +1,59 @@
+package catalog_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"workweave/router/internal/providers"
+	"workweave/router/internal/router/catalog"
+)
+
+// opusPricing mirrors the catalog's Claude 4.8 binding: $5/1M input with a 0.10
+// cache-read multiplier — the case Andrew's switch-cost example turns on.
+var opusPricing = catalog.Pricing{InputUSDPer1M: 5.00, OutputUSDPer1M: 25.00, CacheReadMultiplier: 0.10}
+
+func TestCounterfactualInputCost_NonSwitchEqualsEffective(t *testing.T) {
+	// Off a switch turn the counterfactual must be byte-identical to the plain
+	// effective cost — the correction only ever applies to the transition turn.
+	for _, prov := range []string{providers.ProviderAnthropic, providers.ProviderOpenAI} {
+		in, cc, cr := 102_000, 100_000, 1_000
+		want := catalog.EffectiveInputCost(in, cc, cr, opusPricing.InputUSDPer1M, opusPricing, prov)
+		got := catalog.CounterfactualInputCost(in, cc, cr, opusPricing.InputUSDPer1M, opusPricing, prov, false)
+		assert.Equal(t, want, got, "provider %s", prov)
+	}
+}
+
+func TestCounterfactualInputCost_SwitchRepricesPrefillAsCacheRead(t *testing.T) {
+	// Anthropic reports input_tokens as fresh-only, so cacheCreation is separate.
+	// A cold switch turn: 100k prefill + 2k genuinely-new fresh tokens.
+	freshOnly, cc, cr := 2_000, 100_000, 0
+
+	// Actual (cold): fresh + prefill at 1.25x.
+	cold := catalog.EffectiveInputCost(freshOnly, cc, cr, opusPricing.InputUSDPer1M, opusPricing, providers.ProviderAnthropic)
+	assert.InDelta(t, 0.635, cold, 1e-9)
+
+	// Counterfactual (baseline stayed warm): prefill repriced at the 0.10 read
+	// multiplier, so the savings baseline no longer eats the router's switch cost.
+	warm := catalog.CounterfactualInputCost(freshOnly, cc, cr, opusPricing.InputUSDPer1M, opusPricing, providers.ProviderAnthropic, true)
+	assert.InDelta(t, 0.060, warm, 1e-9)
+	assert.Less(t, warm, cold, "counterfactual must fall below the cold-served cost on a switch turn")
+}
+
+func TestCounterfactualInputCost_SwitchOpenAIProviderMatchesAnthropic(t *testing.T) {
+	// OpenAI/Gemini fold cached tokens into input_tokens; EffectiveInputCost
+	// subtracts them back out. Repricing the prefill must land on the same number
+	// regardless of which token-accounting shape the served provider used.
+	anthropic := catalog.CounterfactualInputCost(2_000, 100_000, 0, opusPricing.InputUSDPer1M, opusPricing, providers.ProviderAnthropic, true)
+	openai := catalog.CounterfactualInputCost(102_000, 100_000, 0, opusPricing.InputUSDPer1M, opusPricing, providers.ProviderOpenAI, true)
+	assert.InDelta(t, anthropic, openai, 1e-9)
+}
+
+func TestCounterfactualInputCost_SwitchWithNoPrefillIsNoOp(t *testing.T) {
+	// A transition turn that happened to carry no cacheCreation (e.g. cache still
+	// warm on switch-back) has nothing to reprice — equals the effective cost.
+	in, cc, cr := 3_000, 0, 50_000
+	want := catalog.EffectiveInputCost(in, cc, cr, opusPricing.InputUSDPer1M, opusPricing, providers.ProviderAnthropic)
+	got := catalog.CounterfactualInputCost(in, cc, cr, opusPricing.InputUSDPer1M, opusPricing, providers.ProviderAnthropic, true)
+	assert.Equal(t, want, got)
+}


### PR DESCRIPTION
## Problem

The router's savings report computes a **counterfactual** `requested_cost` — it takes this turn's *realized* token counts and reprices them at the **requested** model's rates, then reports `savings = requested_cost − actual_cost`.

On a **model-switch turn**, the switched-to model serves with a cold cache and pays a one-time prefill (reported as `cacheCreation` at 1.25×). But the counterfactual priced that *same* prefill on the baseline side too, so the switch cost appeared on both sides and netted to ≈zero. A session that had **never switched** would have kept that context warm and paid only the cache-read rate (e.g. 0.10× on Opus). So the router was effectively getting the switch for free in the metric, and **reported savings were overstated**.

Concretely (Opus, $5/1M, 0.10 read mult; 100k carried context):
- Cold switch turn actual: `100k × 1.25 × $5/M ≈ $0.625`
- Old counterfactual: same `$0.625` → savings on this turn = **$0** ❌
- A no-switch baseline (warm): `100k × 0.10 × $5/M ≈ $0.05` → savings should be **−$0.575** for this turn ✓

This was raised as the top concern from a Hacker News commenter on the router repo.

## Fix

- **`catalog.CounterfactualInputCost`** (pure, unit-tested) — identical to `EffectiveInputCost` off a switch turn; on a switch turn it reprices the prefill (`cacheCreation`) as a warm cache read, which is what a no-switch baseline would have paid.
- **`turnLoopResult.switchPrefillPaid()`** gates it to the *single transition turn* where a cold prefill was actually incurred. Unlike `modelSwitched()` (which stays true for the life of a session that ever switched), this is:
  - `PriorServedModel != ""` — excludes the session's first turn (any baseline pays the first prefill)
  - `PriorServedModel != Decision.Model` — the served model actually changed this turn
  - `!PrefixTrimmed` — excludes client-side history trims, where a no-switch baseline would also have re-primed its cache
- Wired into all three surfaces (Anthropic / OpenAI / Gemini), for both the OTel `cost.requested_input_usd` attribute and the persisted `requested_input_cost_usd`.

**Actual cost and billing are untouched** — this only corrects the savings baseline. No migration (the value is recomputed at write time from signals already in scope).

## Modeling note

The whole switch-turn `cacheCreation` is treated as a warm read. The genuinely-new tokens of a single turn are negligible against the carried context that dominates a cold prefill, so no new-vs-carried split is attempted — the same approximation Andrew's algebra used.

## Test plan

- `go test ./internal/router/catalog/ ./internal/proxy/` ✓
- `wv mr tc` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)