### PR TITLE
fix(anthropic): output-stall + throughput watchdogs on the native path

### DIFF
--- a/internal/providers/anthropic/client.go
+++ b/internal/providers/anthropic/client.go
@@ -49,9 +49,8 @@ func NewClient(apiKey, baseURL string) *Client {
 }
 
 // NewClientWithStallTimeouts is NewClient with injected byte-idle and
-// output-stall watchdog budgets, so a test can drive the output-progress
-// watchdog with a small budget while keeping the byte-idle watchdog large enough
-// that it isn't what fires.
+// output-stall watchdog budgets so a test can trip the output-stall watchdog
+// without waiting out the real budgets.
 func NewClientWithStallTimeouts(apiKey, baseURL string, sseIdleTimeout, outputStall time.Duration) *Client {
 	c := NewClient(apiKey, baseURL)
 	c.sseIdleTimeout = sseIdleTimeout
@@ -216,15 +215,12 @@ func (c *Client) Proxy(ctx context.Context, decision router.Decision, prep provi
 	providers.CopyUpstreamHeaders(w, resp)
 	w.WriteHeader(resp.StatusCode)
 
-	// Output-progress + throughput watchdogs. StreamBody's byte-idle watchdog
-	// resets on ANY byte, and Anthropic streams `ping` keepalives every few
-	// seconds, so a stream that pings but produces zero output tokens (prod:
-	// sonnet-5 turns stuck at output_tokens=0, ttft unset, riding to the request
-	// cap with no failover) never trips it. These are marked only on
-	// output-bearing content_block_delta frames by the routing-marker writer (via
-	// ArmOutputProgress) and trip ErrUpstreamOutputStall / ErrUpstreamSlowThroughput
-	// (both retryable). Writers without the hook (marker-suppressed passthrough)
-	// stay byte-idle-guarded only.
+	// Output-progress + throughput watchdogs. Anthropic streams `ping` keepalives
+	// that reset StreamBody's byte-idle watchdog, so a ping-alive/zero-output
+	// stream (prod: sonnet-5 stuck at output_tokens=0, no failover) needs an
+	// output-only watchdog to abort with ErrUpstreamOutputStall /
+	// ErrUpstreamSlowThroughput (retryable). Marker-suppressed passthrough (no
+	// ArmOutputProgress hook) stays byte-idle-guarded only.
 	if arm, ok := w.(providers.OutputProgressArmer); ok {
 		outMark, outStop := httputil.StartIdleWatchdogCause(ctx, cancel, c.outputStallTimeout(), httputil.ErrUpstreamOutputStall)
 		tpWindow, tpMinElapsed, tpMinDeltas := c.throughputParams()

--- a/internal/providers/anthropic/client.go
+++ b/internal/providers/anthropic/client.go
@@ -48,9 +48,7 @@ func NewClient(apiKey, baseURL string) *Client {
 	}
 }
 
-// NewClientWithStallTimeouts is NewClient with injected byte-idle and
-// output-stall watchdog budgets so a test can trip the output-stall watchdog
-// without waiting out the real budgets.
+// NewClientWithStallTimeouts is NewClient with watchdog budgets injected for testing.
 func NewClientWithStallTimeouts(apiKey, baseURL string, sseIdleTimeout, outputStall time.Duration) *Client {
 	c := NewClient(apiKey, baseURL)
 	c.sseIdleTimeout = sseIdleTimeout
@@ -215,12 +213,9 @@ func (c *Client) Proxy(ctx context.Context, decision router.Decision, prep provi
 	providers.CopyUpstreamHeaders(w, resp)
 	w.WriteHeader(resp.StatusCode)
 
-	// Output-progress + throughput watchdogs. Anthropic streams `ping` keepalives
-	// that reset StreamBody's byte-idle watchdog, so a ping-alive/zero-output
-	// stream (prod: sonnet-5 stuck at output_tokens=0, no failover) needs an
-	// output-only watchdog to abort with ErrUpstreamOutputStall /
-	// ErrUpstreamSlowThroughput (retryable). Marker-suppressed passthrough (no
-	// ArmOutputProgress hook) stays byte-idle-guarded only.
+	// Anthropic ping keepalives reset the byte-idle watchdog, so also arm
+	// output-progress + throughput watchdogs — a ping-alive/zero-output stream
+	// (prod: sonnet-5 stuck at 0 output, no failover) otherwise never aborts.
 	if arm, ok := w.(providers.OutputProgressArmer); ok {
 		outMark, outStop := httputil.StartIdleWatchdogCause(ctx, cancel, c.outputStallTimeout(), httputil.ErrUpstreamOutputStall)
 		tpWindow, tpMinElapsed, tpMinDeltas := c.throughputParams()

--- a/internal/providers/anthropic/client.go
+++ b/internal/providers/anthropic/client.go
@@ -24,6 +24,17 @@ type Client struct {
 	apiKey  string
 	baseURL string
 	http    *http.Client
+	// sseIdleTimeout overrides httputil.DefaultSSEIdleTimeout when > 0; tests set
+	// it small so the output-stall watchdog fires before this one.
+	sseIdleTimeout time.Duration
+	// outputStall overrides httputil.DefaultOutputStallTimeout when > 0; used by
+	// tests to trip output-stall without waiting out the real budget.
+	outputStall time.Duration
+	// throughput* override the minimum-throughput watchdog budgets when set.
+	throughputWindow     time.Duration
+	throughputMinElapsed time.Duration
+	throughputMinDeltas  int
+	throughputOverride   bool
 }
 
 func NewClient(apiKey, baseURL string) *Client {
@@ -35,6 +46,44 @@ func NewClient(apiKey, baseURL string) *Client {
 		baseURL: baseURL,
 		http:    &http.Client{Transport: httputil.NewTransport(10*time.Second, 10*time.Second)},
 	}
+}
+
+// NewClientWithStallTimeouts is NewClient with injected byte-idle and
+// output-stall watchdog budgets, so a test can drive the output-progress
+// watchdog with a small budget while keeping the byte-idle watchdog large enough
+// that it isn't what fires.
+func NewClientWithStallTimeouts(apiKey, baseURL string, sseIdleTimeout, outputStall time.Duration) *Client {
+	c := NewClient(apiKey, baseURL)
+	c.sseIdleTimeout = sseIdleTimeout
+	c.outputStall = outputStall
+	return c
+}
+
+// idleTimeout returns the byte-idle watchdog budget: the injected test override
+// when set, else httputil.DefaultSSEIdleTimeout.
+func (c *Client) idleTimeout() time.Duration {
+	if c.sseIdleTimeout > 0 {
+		return c.sseIdleTimeout
+	}
+	return httputil.DefaultSSEIdleTimeout
+}
+
+// outputStallTimeout returns the output-progress watchdog budget: the injected
+// test override when set, else httputil.DefaultOutputStallTimeout.
+func (c *Client) outputStallTimeout() time.Duration {
+	if c.outputStall > 0 {
+		return c.outputStall
+	}
+	return httputil.DefaultOutputStallTimeout
+}
+
+// throughputParams returns the minimum-throughput watchdog budgets: the injected
+// test overrides when set, else the httputil defaults.
+func (c *Client) throughputParams() (window, minElapsed time.Duration, minDeltas int) {
+	if c.throughputOverride {
+		return c.throughputWindow, c.throughputMinElapsed, c.throughputMinDeltas
+	}
+	return httputil.DefaultThroughputWindow, httputil.DefaultThroughputMinElapsed, httputil.DefaultMinThroughputDeltasPerWindow
 }
 
 // oauthBetaToken is the anthropic-beta flag Anthropic requires for Claude
@@ -166,7 +215,34 @@ func (c *Client) Proxy(ctx context.Context, decision router.Decision, prep provi
 
 	providers.CopyUpstreamHeaders(w, resp)
 	w.WriteHeader(resp.StatusCode)
-	return httputil.StreamBody(ctx, cancel, httputil.DefaultSSEIdleTimeout, resp.Body, resp.StatusCode, w, t)
+
+	// Output-progress + throughput watchdogs. StreamBody's byte-idle watchdog
+	// resets on ANY byte, and Anthropic streams `ping` keepalives every few
+	// seconds, so a stream that pings but produces zero output tokens (prod:
+	// sonnet-5 turns stuck at output_tokens=0, ttft unset, riding to the request
+	// cap with no failover) never trips it. These are marked only on
+	// output-bearing content_block_delta frames by the routing-marker writer (via
+	// ArmOutputProgress) and trip ErrUpstreamOutputStall / ErrUpstreamSlowThroughput
+	// (both retryable). Writers without the hook (marker-suppressed passthrough)
+	// stay byte-idle-guarded only.
+	if arm, ok := w.(providers.OutputProgressArmer); ok {
+		outMark, outStop := httputil.StartIdleWatchdogCause(ctx, cancel, c.outputStallTimeout(), httputil.ErrUpstreamOutputStall)
+		tpWindow, tpMinElapsed, tpMinDeltas := c.throughputParams()
+		tpMark, tpStop := httputil.StartThroughputWatchdog(ctx, cancel, tpWindow, tpMinElapsed, tpMinDeltas, httputil.ErrUpstreamSlowThroughput)
+		combined := func() {
+			outMark()
+			tpMark()
+		}
+		if arm.ArmOutputProgress(combined) {
+			defer outStop()
+			defer tpStop()
+		} else {
+			outStop()
+			tpStop()
+		}
+	}
+
+	return httputil.StreamBody(ctx, cancel, c.idleTimeout(), resp.Body, resp.StatusCode, w, t)
 }
 
 func (c *Client) Passthrough(ctx context.Context, prep providers.PreparedRequest, w http.ResponseWriter, r *http.Request) error {

--- a/internal/providers/anthropic/client_output_stall_test.go
+++ b/internal/providers/anthropic/client_output_stall_test.go
@@ -1,0 +1,170 @@
+package anthropic_test
+
+// Guards the OUTPUT-progress watchdog on the native Anthropic adapter. Prod
+// sweep (2026-07): claude-sonnet-5 turns sat at output_tokens=0 with ttft unset
+// for ~200s and returned nothing, with no failover. Anthropic streams `ping`
+// keepalives every few seconds, so the byte-idle watchdog (which resets on ANY
+// byte) never fires; only a watchdog that measures time-since-last-OUTPUT can end
+// it. The routing-marker writer reports output progress via ArmOutputProgress,
+// marking only on content_block_delta frames (not pings). These tests drive the
+// real writer against fake upstreams: a ping-only stream aborts at the
+// output-stall budget with a retryable ErrUpstreamOutputStall, a stream emitting
+// content deltas is never aborted, and a writer without the hook stays byte-idle
+// guarded.
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"workweave/router/internal/providers"
+	"workweave/router/internal/providers/anthropic"
+	"workweave/router/internal/providers/httputil"
+	"workweave/router/internal/router"
+	"workweave/router/internal/translate"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// flushRecorder is a minimal streaming ResponseWriter. It does NOT implement
+// ArmOutputProgress, so wrapping it in the routing-marker writer is what exposes
+// the hook; passed bare, it exercises the not-armed degradation path.
+type flushRecorder struct {
+	hdr http.Header
+	n   int
+}
+
+func (r *flushRecorder) Header() http.Header {
+	if r.hdr == nil {
+		r.hdr = make(http.Header)
+	}
+	return r.hdr
+}
+func (r *flushRecorder) Write(p []byte) (int, error) { r.n += len(p); return len(p), nil }
+func (r *flushRecorder) WriteHeader(int)             {}
+func (r *flushRecorder) Flush()                      {}
+
+// streamsFramesForever commits 200 + SSE headers then emits frame every interval
+// until the client disconnects. Bytes keep flowing so the byte-idle watchdog
+// never trips.
+func streamsFramesForever(frame string, interval time.Duration) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		f := w.(http.Flusher)
+		f.Flush()
+		for {
+			select {
+			case <-r.Context().Done():
+				return
+			case <-time.After(interval):
+			}
+			if _, err := io.WriteString(w, frame); err != nil {
+				return
+			}
+			f.Flush()
+		}
+	}))
+}
+
+func messagesPrep() providers.PreparedRequest {
+	return providers.PreparedRequest{
+		Body:    []byte(`{"model":"claude-sonnet-5","messages":[{"role":"user","content":"hi"}],"stream":true}`),
+		Headers: make(http.Header),
+	}
+}
+
+const pingFrame = "event: ping\ndata: {\"type\":\"ping\"}\n\n"
+const textDeltaFrame = "event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"x\"}}\n\n"
+
+func TestProxy_OutputStallAbortsOnPingOnlyStream(t *testing.T) {
+	upstream := streamsFramesForever(pingFrame, 15*time.Millisecond)
+	defer upstream.Close()
+
+	// Byte-idle far longer than the ping interval (so it never fires); output-stall
+	// short (so it fires): pings flowing, zero output.
+	const byteIdle = 5 * time.Second
+	const outputStall = 120 * time.Millisecond
+	c := anthropic.NewClientWithStallTimeouts("test-key", upstream.URL, byteIdle, outputStall)
+	w := translate.NewAnthropicRoutingMarkerWriter(&flushRecorder{}, "claude-sonnet-5", "[routed]")
+	clientReq := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(""))
+
+	start := time.Now()
+	err := c.Proxy(context.Background(), router.Decision{Model: "claude-sonnet-5"}, messagesPrep(), w, clientReq)
+	elapsed := time.Since(start)
+
+	require.Error(t, err, "a ping-alive/output-silent stream must surface an error, not hang")
+	assert.ErrorIs(t, err, httputil.ErrUpstreamOutputStall)
+	assert.NotErrorIs(t, err, httputil.ErrUpstreamIdleTimeout,
+		"the byte-idle watchdog must not be what fired — ping bytes were flowing the whole time")
+	assert.True(t, providers.IsRetryable(err),
+		"the output stall must classify retryable so dispatchWithFallback can re-attempt")
+	assert.GreaterOrEqual(t, elapsed, outputStall, "must not abort before the output-stall budget")
+	assert.Less(t, elapsed, byteIdle, "must abort at the output-stall budget, not ride to the byte-idle/cap")
+}
+
+func TestProxy_ContentDeltasResetOutputStall(t *testing.T) {
+	// content_block_delta frames carry real output; the marker writer marks each,
+	// so the output-stall watchdog keeps resetting and never trips even though the
+	// stream outlives its budget.
+	const frames = 6
+	const frameInterval = 20 * time.Millisecond
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		f := w.(http.Flusher)
+		f.Flush()
+		for range frames {
+			select {
+			case <-r.Context().Done():
+				return
+			case <-time.After(frameInterval):
+			}
+			_, _ = io.WriteString(w, textDeltaFrame)
+			f.Flush()
+		}
+	}))
+	defer upstream.Close()
+
+	const byteIdle = 5 * time.Second
+	const outputStall = 60 * time.Millisecond // < frames*frameInterval, so total duration exceeds it
+	c := anthropic.NewClientWithStallTimeouts("test-key", upstream.URL, byteIdle, outputStall)
+	w := translate.NewAnthropicRoutingMarkerWriter(&flushRecorder{}, "claude-sonnet-5", "[routed]")
+	clientReq := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(""))
+
+	err := c.Proxy(context.Background(), router.Decision{Model: "claude-sonnet-5"}, messagesPrep(), w, clientReq)
+	require.NoError(t, err, "a stream producing content_block_delta output must never trip the output-stall watchdog")
+}
+
+// A bare writer (no ArmOutputProgress, e.g. marker-suppressed passthrough) is
+// still protected by the byte-idle watchdog: a fully byte-silent stream trips it
+// even though no output-progress watchdog was wired.
+func TestProxy_NotArmedWriterStillByteIdleGuarded(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		w.(http.Flusher).Flush()
+		<-r.Context().Done() // headers sent, then zero bytes forever
+	}))
+	defer upstream.Close()
+
+	const byteIdle = 80 * time.Millisecond
+	const outputStall = 5 * time.Second
+	c := anthropic.NewClientWithStallTimeouts("test-key", upstream.URL, byteIdle, outputStall)
+	w := &flushRecorder{} // no ArmOutputProgress hook
+	clientReq := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(""))
+
+	start := time.Now()
+	err := c.Proxy(context.Background(), router.Decision{Model: "claude-sonnet-5"}, messagesPrep(), w, clientReq)
+	elapsed := time.Since(start)
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, httputil.ErrUpstreamIdleTimeout)
+	assert.GreaterOrEqual(t, elapsed, byteIdle)
+	assert.Less(t, elapsed, outputStall, "byte-idle must fire well before the output-stall budget")
+}

--- a/internal/providers/anthropic/client_output_stall_test.go
+++ b/internal/providers/anthropic/client_output_stall_test.go
@@ -1,9 +1,8 @@
 package anthropic_test
 
-// Guards the output-progress watchdog on the native Anthropic adapter. Anthropic
+// Guards the output-progress watchdog on the native Anthropic adapter: Anthropic
 // ping keepalives reset the byte-idle watchdog, so only an output-bearing
-// watchdog ends a ping-alive/zero-output stream (prod 2026-07: sonnet-5 stuck at
-// output_tokens=0, ~200s, no failover). Drives the real routing-marker writer.
+// watchdog ends a ping-alive/zero-output stream.
 
 import (
 	"context"
@@ -24,9 +23,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// flushRecorder is a minimal streaming ResponseWriter. It does NOT implement
-// ArmOutputProgress, so wrapping it in the routing-marker writer is what exposes
-// the hook; passed bare, it exercises the not-armed degradation path.
+// flushRecorder is a minimal streaming ResponseWriter without ArmOutputProgress.
 type flushRecorder struct {
 	hdr http.Header
 	n   int
@@ -101,9 +98,7 @@ func TestProxy_OutputStallAbortsOnPingOnlyStream(t *testing.T) {
 }
 
 func TestProxy_ContentDeltasResetOutputStall(t *testing.T) {
-	// content_block_delta frames carry real output; the marker writer marks each,
-	// so the output-stall watchdog keeps resetting and never trips even though the
-	// stream outlives its budget.
+	// content_block_delta marks each reset; the stream outlives the budget.
 	const frames = 6
 	const frameInterval = 20 * time.Millisecond
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/providers/anthropic/client_output_stall_test.go
+++ b/internal/providers/anthropic/client_output_stall_test.go
@@ -1,16 +1,9 @@
 package anthropic_test
 
-// Guards the OUTPUT-progress watchdog on the native Anthropic adapter. Prod
-// sweep (2026-07): claude-sonnet-5 turns sat at output_tokens=0 with ttft unset
-// for ~200s and returned nothing, with no failover. Anthropic streams `ping`
-// keepalives every few seconds, so the byte-idle watchdog (which resets on ANY
-// byte) never fires; only a watchdog that measures time-since-last-OUTPUT can end
-// it. The routing-marker writer reports output progress via ArmOutputProgress,
-// marking only on content_block_delta frames (not pings). These tests drive the
-// real writer against fake upstreams: a ping-only stream aborts at the
-// output-stall budget with a retryable ErrUpstreamOutputStall, a stream emitting
-// content deltas is never aborted, and a writer without the hook stays byte-idle
-// guarded.
+// Guards the output-progress watchdog on the native Anthropic adapter. Anthropic
+// ping keepalives reset the byte-idle watchdog, so only an output-bearing
+// watchdog ends a ping-alive/zero-output stream (prod 2026-07: sonnet-5 stuck at
+// output_tokens=0, ~200s, no failover). Drives the real routing-marker writer.
 
 import (
 	"context"
@@ -49,9 +42,8 @@ func (r *flushRecorder) Write(p []byte) (int, error) { r.n += len(p); return len
 func (r *flushRecorder) WriteHeader(int)             {}
 func (r *flushRecorder) Flush()                      {}
 
-// streamsFramesForever commits 200 + SSE headers then emits frame every interval
-// until the client disconnects. Bytes keep flowing so the byte-idle watchdog
-// never trips.
+// streamsFramesForever emits frame every interval until the client disconnects,
+// keeping the stream byte-alive so the byte-idle watchdog never trips.
 func streamsFramesForever(frame string, interval time.Duration) *httptest.Server {
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/event-stream")

--- a/internal/translate/anthropic_marker.go
+++ b/internal/translate/anthropic_marker.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"strings"
 
+	"workweave/router/internal/providers"
 	"workweave/router/internal/sse"
 
 	"github.com/tidwall/gjson"
@@ -27,6 +28,8 @@ type AnthropicRoutingMarkerWriter struct {
 	streaming      bool
 	headersEmitted bool
 	markerEmitted  bool
+
+	onOutputProgress func()
 }
 
 // NewAnthropicRoutingMarkerWriter injects marker as a text block at index 0.
@@ -172,6 +175,14 @@ func (w *AnthropicRoutingMarkerWriter) processUpstream(data []byte) (int, error)
 			continue
 
 		case "content_block_start", "content_block_delta", "content_block_stop":
+			// A content_block_delta carries real output (text / thinking /
+			// tool-call args); mark output progress so the output-stall watchdog
+			// tracks time-since-last-output. Anthropic ping keepalives reset the
+			// byte-idle watchdog, so a zero-output stream trips nothing without
+			// this. content_block_start/stop are structural, not output.
+			if string(eventType) == "content_block_delta" && w.onOutputProgress != nil {
+				w.onOutputProgress()
+			}
 			// Rewrite the index field: shift by +1.
 			currentIdx := gjson.GetBytes(eventData, "index").Int()
 			rewritten, err := sjson.SetBytes(eventData, "index", currentIdx+1)
@@ -204,5 +215,23 @@ func (w *AnthropicRoutingMarkerWriter) processUpstream(data []byte) (int, error)
 	return len(data), nil
 }
 
+// ArmOutputProgress installs mark to fire on output-bearing upstream deltas
+// (content_block_delta: text, thinking, tool-call args), never on the injected
+// marker or keepalive frames — so the output-stall watchdog tracks
+// time-since-last-output rather than time-since-last-byte. The native Anthropic
+// path needs this because Anthropic streams ping keepalives that reset
+// StreamBody's byte-idle watchdog, so a byte-alive/zero-output stream would
+// otherwise ride to the request cap with no failover. Returns false when not
+// streaming or when no marker is configured (the transparent-passthrough path
+// never parses frames, so it can't mark). Call after WriteHeader/Prelude.
+func (w *AnthropicRoutingMarkerWriter) ArmOutputProgress(mark func()) (armed bool) {
+	if !w.streaming || w.marker == "" {
+		return false
+	}
+	w.onOutputProgress = mark
+	return true
+}
+
 var _ http.ResponseWriter = (*AnthropicRoutingMarkerWriter)(nil)
 var _ http.Flusher = (*AnthropicRoutingMarkerWriter)(nil)
+var _ providers.OutputProgressArmer = (*AnthropicRoutingMarkerWriter)(nil)

--- a/internal/translate/anthropic_marker.go
+++ b/internal/translate/anthropic_marker.go
@@ -175,9 +175,7 @@ func (w *AnthropicRoutingMarkerWriter) processUpstream(data []byte) (int, error)
 			continue
 
 		case "content_block_start", "content_block_delta", "content_block_stop":
-			// content_block_delta carries real output (text / thinking / tool
-			// args); mark it so the output-stall watchdog tracks
-			// time-since-last-output. start/stop are structural, not output.
+			// Mark on output-bearing content_block_delta only; start/stop are structural.
 			if string(eventType) == "content_block_delta" && w.onOutputProgress != nil {
 				w.onOutputProgress()
 			}
@@ -213,12 +211,9 @@ func (w *AnthropicRoutingMarkerWriter) processUpstream(data []byte) (int, error)
 	return len(data), nil
 }
 
-// ArmOutputProgress installs mark to fire on output-bearing content_block_delta
-// frames only — never the injected marker, pings, or structural frames — so the
-// native Anthropic output-stall watchdog tracks time-since-last-output, not
-// last-byte (Anthropic pings reset the byte-idle watchdog). Returns false when
-// not streaming or without a marker (the transparent-passthrough path never
-// parses frames). Call after WriteHeader/Prelude.
+// ArmOutputProgress fires mark on output-bearing content_block_delta frames only
+// (not pings or structural frames) so the native output-stall watchdog tracks
+// time-since-last-output. Returns false when not streaming or without a marker.
 func (w *AnthropicRoutingMarkerWriter) ArmOutputProgress(mark func()) (armed bool) {
 	if !w.streaming || w.marker == "" {
 		return false

--- a/internal/translate/anthropic_marker.go
+++ b/internal/translate/anthropic_marker.go
@@ -175,11 +175,9 @@ func (w *AnthropicRoutingMarkerWriter) processUpstream(data []byte) (int, error)
 			continue
 
 		case "content_block_start", "content_block_delta", "content_block_stop":
-			// A content_block_delta carries real output (text / thinking /
-			// tool-call args); mark output progress so the output-stall watchdog
-			// tracks time-since-last-output. Anthropic ping keepalives reset the
-			// byte-idle watchdog, so a zero-output stream trips nothing without
-			// this. content_block_start/stop are structural, not output.
+			// content_block_delta carries real output (text / thinking / tool
+			// args); mark it so the output-stall watchdog tracks
+			// time-since-last-output. start/stop are structural, not output.
 			if string(eventType) == "content_block_delta" && w.onOutputProgress != nil {
 				w.onOutputProgress()
 			}
@@ -215,15 +213,12 @@ func (w *AnthropicRoutingMarkerWriter) processUpstream(data []byte) (int, error)
 	return len(data), nil
 }
 
-// ArmOutputProgress installs mark to fire on output-bearing upstream deltas
-// (content_block_delta: text, thinking, tool-call args), never on the injected
-// marker or keepalive frames — so the output-stall watchdog tracks
-// time-since-last-output rather than time-since-last-byte. The native Anthropic
-// path needs this because Anthropic streams ping keepalives that reset
-// StreamBody's byte-idle watchdog, so a byte-alive/zero-output stream would
-// otherwise ride to the request cap with no failover. Returns false when not
-// streaming or when no marker is configured (the transparent-passthrough path
-// never parses frames, so it can't mark). Call after WriteHeader/Prelude.
+// ArmOutputProgress installs mark to fire on output-bearing content_block_delta
+// frames only — never the injected marker, pings, or structural frames — so the
+// native Anthropic output-stall watchdog tracks time-since-last-output, not
+// last-byte (Anthropic pings reset the byte-idle watchdog). Returns false when
+// not streaming or without a marker (the transparent-passthrough path never
+// parses frames). Call after WriteHeader/Prelude.
 func (w *AnthropicRoutingMarkerWriter) ArmOutputProgress(mark func()) (armed bool) {
 	if !w.streaming || w.marker == "" {
 		return false

--- a/internal/translate/anthropic_marker_output_progress_test.go
+++ b/internal/translate/anthropic_marker_output_progress_test.go
@@ -1,0 +1,73 @@
+package translate_test
+
+import (
+	"net/http/httptest"
+	"testing"
+
+	"workweave/router/internal/translate"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// These tests pin the OUTPUT-progress classification the native Anthropic
+// output-stall watchdog depends on (see anthropic.Client.Proxy). The
+// routing-marker writer is the only layer on the native path that parses the
+// upstream Anthropic SSE, so it owns the mark: a content_block_delta (text /
+// thinking / tool-call args) is output and must count; ping keepalives and
+// structural frames (message_start, content_block_start/stop) must NOT — else a
+// ping-alive/output-silent Anthropic stream would keep resetting the watchdog.
+
+func newAnthropicMarkerStreamingWriter(t *testing.T) (*translate.AnthropicRoutingMarkerWriter, *int) {
+	t.Helper()
+	w := translate.NewAnthropicRoutingMarkerWriter(httptest.NewRecorder(), "claude-sonnet-5", "[routed]")
+	require.NoError(t, w.Prelude(true))
+	count := 0
+	require.True(t, w.ArmOutputProgress(func() { count++ }),
+		"ArmOutputProgress must report armed for a streaming client with a marker")
+	return w, &count
+}
+
+func TestAnthropicMarkerOutputProgress_ContentDeltaCounts(t *testing.T) {
+	w, count := newAnthropicMarkerStreamingWriter(t)
+	_, err := w.Write([]byte("event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"hi\"}}\n\n"))
+	require.NoError(t, err)
+	assert.Positive(t, *count, "a content_block_delta must mark output progress")
+}
+
+func TestAnthropicMarkerOutputProgress_PingDoesNotCount(t *testing.T) {
+	w, count := newAnthropicMarkerStreamingWriter(t)
+	_, err := w.Write([]byte("event: ping\ndata: {\"type\":\"ping\"}\n\n"))
+	require.NoError(t, err)
+	assert.Zero(t, *count, "a ping keepalive must not mark output progress")
+}
+
+func TestAnthropicMarkerOutputProgress_StructuralFramesDoNotCount(t *testing.T) {
+	w, count := newAnthropicMarkerStreamingWriter(t)
+	frames := []string{
+		"event: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"id\":\"m\",\"content\":[]}}\n\n",
+		"event: content_block_start\ndata: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"text\",\"text\":\"\"}}\n\n",
+		"event: content_block_stop\ndata: {\"type\":\"content_block_stop\",\"index\":0}\n\n",
+	}
+	for _, f := range frames {
+		_, err := w.Write([]byte(f))
+		require.NoError(t, err)
+	}
+	assert.Zero(t, *count, "message_start / content_block_start / content_block_stop are structural, not output")
+}
+
+func TestAnthropicMarkerOutputProgress_NotArmedWhenNotStreaming(t *testing.T) {
+	w := translate.NewAnthropicRoutingMarkerWriter(httptest.NewRecorder(), "claude-sonnet-5", "[routed]")
+	require.NoError(t, w.Prelude(false))
+	assert.False(t, w.ArmOutputProgress(func() {}),
+		"ArmOutputProgress must report not-armed for a non-streaming client")
+}
+
+func TestAnthropicMarkerOutputProgress_NotArmedWithoutMarker(t *testing.T) {
+	// With no marker the writer is a transparent passthrough — it never parses
+	// frames, so it cannot mark and must decline arming.
+	w := translate.NewAnthropicRoutingMarkerWriter(httptest.NewRecorder(), "claude-sonnet-5", "")
+	require.NoError(t, w.Prelude(true))
+	assert.False(t, w.ArmOutputProgress(func() {}),
+		"ArmOutputProgress must report not-armed when no marker is configured")
+}

--- a/internal/translate/anthropic_marker_output_progress_test.go
+++ b/internal/translate/anthropic_marker_output_progress_test.go
@@ -10,13 +10,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// These tests pin the OUTPUT-progress classification the native Anthropic
-// output-stall watchdog depends on (see anthropic.Client.Proxy). The
-// routing-marker writer is the only layer on the native path that parses the
-// upstream Anthropic SSE, so it owns the mark: a content_block_delta (text /
-// thinking / tool-call args) is output and must count; ping keepalives and
-// structural frames (message_start, content_block_start/stop) must NOT — else a
-// ping-alive/output-silent Anthropic stream would keep resetting the watchdog.
+// Pins the output-progress classification the native Anthropic output-stall
+// watchdog depends on: content_block_delta counts as output; pings and
+// structural frames (message_start, content_block_start/stop) must not.
 
 func newAnthropicMarkerStreamingWriter(t *testing.T) (*translate.AnthropicRoutingMarkerWriter, *int) {
 	t.Helper()

--- a/internal/translate/anthropic_marker_output_progress_test.go
+++ b/internal/translate/anthropic_marker_output_progress_test.go
@@ -10,9 +10,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// Pins the output-progress classification the native Anthropic output-stall
-// watchdog depends on: content_block_delta counts as output; pings and
-// structural frames (message_start, content_block_start/stop) must not.
+// Pins the output-progress classification the output-stall watchdog depends on:
+// content_block_delta counts; pings and structural frames must not.
 
 func newAnthropicMarkerStreamingWriter(t *testing.T) (*translate.AnthropicRoutingMarkerWriter, *int) {
 	t.Helper()


### PR DESCRIPTION
## What

Native Anthropic (opus/sonnet) turns could stall at **zero output tokens** and return nothing to the client, with **no failover**. Prod router-calls sweep (2026-07): `claude-sonnet-5` turns stuck at `output_tokens=0`, `ttft` unset, ~200s each, terminal — one session retried the same 459KB request 7× in an hour, every attempt dead.

## Root cause

The native Anthropic adapter armed **only** `StreamBody`'s byte-idle watchdog (45s), which resets on **any** upstream byte. Anthropic streams `ping` keepalives every few seconds, so a stream that pings but produces zero output tokens never trips it — it rides to the 600s request cap and the terminal error is non-retryable, so no failover fires.

Every **other** provider adapter (openaicompat, openai, google) already arms the **output-progress** and **minimum-throughput** watchdogs, which measure time-since-last-*output* rather than time-since-last-*byte*. Anthropic native was the only one missing them.

## Fix

Arm the output-progress + throughput watchdogs on the native path, mirroring the other adapters:

- `AnthropicRoutingMarkerWriter` (the one layer on the native path that parses upstream Anthropic SSE) now implements `ArmOutputProgress`, marking **only** on output-bearing `content_block_delta` frames — never on pings or structural frames (`message_start`, `content_block_start`/`stop`).
- `anthropic.Client.Proxy` arms `ErrUpstreamOutputStall` + `ErrUpstreamSlowThroughput` (both retryable) after `WriteHeader`. A byte-alive/output-silent stream now aborts at the output-stall budget so `dispatchWithFallback` re-attempts, instead of dead-ending.
- `UsageExtractor` already forwards `ArmOutputProgress`, so the wrapped native writer is reached. Marker-suppressed passthrough (no hook) stays byte-idle-guarded as before.

## Test

- `internal/providers/anthropic/client_output_stall_test.go` — end-to-end with the real marker writer: ping-only stream → `ErrUpstreamOutputStall` (retryable, byte-alive, before byte-idle); content_block_delta stream → never stalled; unhooked writer → byte-idle still guards.
- `internal/translate/anthropic_marker_output_progress_test.go` — marking semantics: content_block_delta counts; ping + structural frames don't; not armed when non-streaming or marker-less.

🤖 Generated with [Claude Code](https://claude.com/claude-code)