### PR TITLE
fix(cluster): recover from panics in embed goroutine instead of crashing the process

### DIFF
--- a/internal/router/cluster/scorer.go
+++ b/internal/router/cluster/scorer.go
@@ -445,6 +445,12 @@ func (s *Scorer) Route(ctx context.Context, req router.Request) (router.Decision
 	}
 	resCh := make(chan embedResult, 1)
 	go func() {
+		defer func() {
+			if r := recover(); r != nil {
+				log.Error("Cluster scorer: embed panic; returning ErrClusterUnavailable", "panic", fmt.Sprint(r))
+				resCh <- embedResult{err: fmt.Errorf("embed panic: %v", r)}
+			}
+		}()
 		v, e := s.embed.Embed(embedCtx, text)
 		resCh <- embedResult{vec: v, err: e}
 	}()

--- a/internal/router/cluster/scorer_test.go
+++ b/internal/router/cluster/scorer_test.go
@@ -425,6 +425,27 @@ func TestScorer_ReturnsErrOnEmbedderError(t *testing.T) {
 	assert.True(t, errors.Is(err, ErrClusterUnavailable))
 }
 
+// panicEmbedder panics inside Embed to simulate a crash in the native
+// ONNX/hugot pipeline, exercising the goroutine's recover().
+type panicEmbedder struct{}
+
+func (panicEmbedder) Embed(_ context.Context, _ string) ([]float32, error) {
+	panic("simulated onnx/hugot panic")
+}
+
+func (panicEmbedder) ID() string { return EmbedderJinaV2 }
+
+func (panicEmbedder) Dim() int { return EmbedDim }
+
+func TestScorer_RecoversFromEmbedPanic(t *testing.T) {
+	s := newScorerForTest(t, panicEmbedder{}, cfgForTest())
+
+	_, err := s.Route(context.Background(), router.Request{PromptText: strings.Repeat("x", 100)})
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrClusterUnavailable))
+	assert.Contains(t, err.Error(), "embed panic")
+}
+
 func TestScorer_ReturnsErrOnDimMismatch(t *testing.T) {
 	emb := &fakeEmbedder{vec: make([]float32, 7)} // wrong size
 	s := newScorerForTest(t, emb, cfgForTest())


### PR DESCRIPTION
## Summary

Fixes critical audit finding **[112]** (duplicate report **[39]** describes the same underlying site — confirmed there is only one unrecovered goroutine in `cluster/scorer.go`, no second instance).

`Scorer.Route` races the ONNX/hugot embed call against `EmbedTimeout` in a per-request goroutine (`internal/router/cluster/scorer.go`). That goroutine had no `recover()`, so any panic inside the native embedding pipeline (malformed input, ORT/hugot internal panic, etc.) crashed the entire router process — reachable on essentially every routing decision.

- Wrapped the goroutine body in a `recover()` matching the existing pattern used in `internal/translate/toolcheck/toolcheck.go` (`compileSchema`/`validate`).
- Per the audit's own risk note — *"a recover() that swallows the error without logging at Error level turns a visible crash into a silent, undetected failure mode — every recovery point must still surface loudly to on-call"* — the recovered panic is logged at **Error** level (not Warn) before being sent on the result channel, in addition to the existing Error-level log in `Route`'s embed-failure branch. So a panic now produces two loud Error logs instead of a process crash.
- The recovered panic surfaces as an `embedResult{err: ...}`, which `Route`'s existing error handling already wraps into `ErrClusterUnavailable` → HTTP 503 — no changes needed there.

Out of scope: `internal/proxy/service.go:2689`'s `fireTelemetry` goroutine (finding [16], handled separately).

## Test plan

- [x] Added `TestScorer_RecoversFromEmbedPanic` in `internal/router/cluster/scorer_test.go` using a `panicEmbedder` test double that panics inside `Embed`; asserts the panic is recovered, surfaces as an error, and `errors.Is(err, ErrClusterUnavailable)`.
- [x] `go build ./...`
- [x] `go test ./internal/router/cluster/... ./internal/translate/toolcheck/...` — all pass
- [x] `go vet ./...` clean
- [x] Manually verified via `-v` test run that both Error-level log lines fire on panic (recovery site + `Route`'s embed-failure handler)

🤖 Generated with [Claude Code](https://claude.com/claude-code)