### PR TITLE
fix(api/anthropic): stop logging full unredacted request body at Debug level

### DIFF
--- a/internal/api/anthropic/messages.go
+++ b/internal/api/anthropic/messages.go
@@ -71,7 +71,6 @@ func MessagesHandler(svc *proxy.Service, authSvc *auth.Service) gin.HandlerFunc 
 			"model", gjson.GetBytes(body, "model").String(),
 			"max_tokens", gjson.GetBytes(body, "max_tokens").Int(),
 			"session_id", c.Request.Header.Get("X-Claude-Code-Session-Id"),
-			"body", string(body),
 		)
 
 		ctx := stashClientIdentity(c.Request.Context(), c.Request.Header, body)


### PR DESCRIPTION
## Summary
- Addresses a **critical privacy finding ([52])** from an internal code-quality audit.
- `MessagesHandler` in `internal/api/anthropic/messages.go` logged the complete, unredacted `/v1/messages` request body unconditionally at Debug level — this can contain source code, credentials, or PII.
- Removed the `body` field from the log call. The remaining fields (`body_bytes`, `message_count`, `system_chars`, `model`, `max_tokens`, `session_id`) already provide equivalent debugging signal.

## Scope note
Checked `internal/api/openai/*.go` and `internal/api/gemini/*.go` for the same anti-pattern (unconditional Debug-level raw body logging) since the audit noted duplication between these handlers. Did not find the same pattern there — their Debug logs only cover body-read failures, not successful-read body dumps — so no changes were made outside the anthropic handler.

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/api/anthropic/... ./internal/api/openai/... ./internal/api/gemini/...`