### PR TITLE
fix(proxy): stop logging full upstream request bodies at Info level

### DIFF
--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -1348,52 +1348,20 @@ func (s *Service) PassthroughToNamedProvider(ctx context.Context, providerName s
 	return proxyErr
 }
 
-// upstreamBodyLogHead and upstreamBodyLogTail bound the bytes attached to
-// each "upstream prepared body" log entry. Claude Code turns routinely hit
-// 50-400KB; logging whole at Info would blow up GCP ingest cost and hit the
-// 256KB per-entry cap. Head (4KB) shows request shape (envelope, sampling
-// params, tool defs); tail (4KB) shows what the model just saw (end of
-// messages, last tool_result/turn). Middle is dropped with a
-// "…<n bytes omitted>…" marker; bodies that fit go through whole.
-const (
-	upstreamBodyLogHead = 4 * 1024
-	upstreamBodyLogTail = 4 * 1024
-)
-
-// logUpstreamBody emits the prepared upstream request body at Info so it
-// shows up in GCP without flipping LOG_LEVEL, for per-turn investigation of
-// "what did we actually send". Bodies over the head+tail limit are truncated;
-// body_truncated + body_omitted_bytes make the cut obvious.
+// logUpstreamBody emits per-attempt dispatch metadata at Info so it shows up
+// in GCP without flipping LOG_LEVEL. It intentionally does NOT include the
+// raw request body — that would violate the "never log full request bodies"
+// rule regardless of truncation, and duplicates the purpose-built, opt-in,
+// redactable captureMode/Redactor pipeline (see turn_logs.go / recordCallLog)
+// which already exists for "what did we actually send" debugging.
 func logUpstreamBody(log *slog.Logger, sessionKey [sessionpin.SessionKeyLen]byte, decision router.Decision, feats translate.RoutingFeatures, body []byte) {
-	bodyStr, truncated, omitted := truncateBodyForLog(body, upstreamBodyLogHead, upstreamBodyLogTail)
-	log.Info("upstream prepared body",
+	log.Info("upstream prepared request",
 		"session_key", hex.EncodeToString(sessionKey[:8]),
 		"decision_model", decision.Model,
 		"decision_provider", decision.Provider,
 		"message_count", feats.MessageCount,
 		"body_len", len(body),
-		"body_truncated", truncated,
-		"body_omitted_bytes", omitted,
-		"body_head_limit", upstreamBodyLogHead,
-		"body_tail_limit", upstreamBodyLogTail,
-		"body", bodyStr,
 	)
-}
-
-// truncateBodyForLog returns the body unchanged when it fits in head+tail,
-// otherwise concatenates the first `head` bytes, an "…<n omitted>…" marker,
-// and the last `tail` bytes. Returns (output, wasTruncated, omittedBytes).
-func truncateBodyForLog(body []byte, head, tail int) (string, bool, int) {
-	if len(body) <= head+tail {
-		return string(body), false, 0
-	}
-	omitted := len(body) - head - tail
-	var b strings.Builder
-	b.Grow(head + tail + 32)
-	b.Write(body[:head])
-	fmt.Fprintf(&b, "\n…<%d bytes omitted>…\n", omitted)
-	b.Write(body[len(body)-tail:])
-	return b.String(), true, omitted
 }
 
 // ProxyMessages routes a raw Anthropic-Messages request body and streams the

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -1348,12 +1348,9 @@ func (s *Service) PassthroughToNamedProvider(ctx context.Context, providerName s
 	return proxyErr
 }
 
-// logUpstreamBody emits per-attempt dispatch metadata at Info so it shows up
-// in GCP without flipping LOG_LEVEL. It intentionally does NOT include the
-// raw request body — that would violate the "never log full request bodies"
-// rule regardless of truncation, and duplicates the purpose-built, opt-in,
-// redactable captureMode/Redactor pipeline (see turn_logs.go / recordCallLog)
-// which already exists for "what did we actually send" debugging.
+// logUpstreamBody emits per-attempt dispatch metadata at Info. Body is
+// intentionally omitted — use captureMode/Redactor (turn_logs.go) for
+// per-attempt body capture.
 func logUpstreamBody(log *slog.Logger, sessionKey [sessionpin.SessionKeyLen]byte, decision router.Decision, feats translate.RoutingFeatures, body []byte) {
 	log.Info("upstream prepared request",
 		"session_key", hex.EncodeToString(sessionKey[:8]),


### PR DESCRIPTION
## Summary

Addresses a **critical** privacy/logging finding ([15]) from an internal code-quality audit.

`logUpstreamBody` (`internal/proxy/service.go`) logged the complete raw upstream request body (head+tail truncated to 8KB) at **Info** level, unconditionally, on every dispatch attempt — called from 6 sites inside `ProxyMessages` (primary attempt, failover attempt, auto-retry, baseline failover, sub-agent dispatch). This is on by default (no `LOG_LEVEL` flip required) and directly violates the repo's own "never log full request bodies" rule, and duplicates the purpose-built `captureMode`/`Redactor` pipeline in `internal/proxy/turn_logs.go`.

## Fix

Removed the raw `body` field (and the now-unused `truncateBodyForLog` helper + head/tail constants) from `logUpstreamBody`'s Info-level log call. Kept the other fields — `session_key` (8-byte prefix only), `decision_model`, `decision_provider`, `message_count`, `body_len` — at Info, since they carry no request content and are legitimately useful for routing/dispatch debugging without flipping log level.

No Error-level logs elsewhere in `service.go` were touched — this change is scoped exactly to the unconditional full-body Info log described in the finding.

## Verified: existing capture/redactor pipeline coverage

Confirmed `s.recordCallLog` (`internal/proxy/turn_logs.go`) already provides opt-in (`captureMode` off by default), redactable (`Redactor` hook) capture of **both** request and response bodies (`io.request_body` / `io.response_body` under `CaptureFull`, or `io.request_sha256` / `io.response_sha256` under `CaptureHashed`) as OTLP `router.call` log records — this is the intended mechanism for "what did we actually send" debugging going forward.

**Gap noted (not fixed here, flagging for awareness):** `recordCallLog` is invoked once per `ProxyMessages` call with the *original client request body* (the `body` parameter), not the *per-attempt prepared/translated* body (`prep.Body`/`autoPrep.Body`/`baselinePrep.Body`/`subPrep.Body`) that `logUpstreamBody` was logging at each of its 6 call sites. For requests that involve cross-format translation, baseline failover, or sub-agent dispatch, the capture pipeline today shows what the *client* sent, not necessarily the exact bytes sent to *each specific upstream* on *each attempt*. This is an existing gap independent of this fix (the raw-body Info log wasn't a safe substitute for it either, since it was unredacted and unconditional) — worth a follow-up if per-attempt prepared-body visibility is needed for debugging cross-format/failover issues.

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/proxy/...` — passes (`internal/proxy`, `internal/proxy/usage`)
- [x] `go vet ./internal/proxy/...` — clean
- [x] Confirmed no other Error-level logs in `service.go`/`turn_logs.go` were modified