### PR TITLE
fix(providers): scrub router API keys from inbound Authorization header in Anthropic adapter

### DIFF
--- a/internal/providers/anthropic/client.go
+++ b/internal/providers/anthropic/client.go
@@ -50,11 +50,8 @@ const subscriptionTokenPrefix = "sk-ant-oat"
 // headers. A subscription OAuth credential authenticates via Authorization:
 // Bearer and must NOT send x-api-key; everything else uses x-api-key.
 //
-// The passthrough tier scrubs `Authorization: Bearer rk_...` via
-// httputil.SanitizeInboundAuthHeader — the router auth middleware accepts the
-// same header shape for router-key auth, so we must not relay a router
-// credential to Anthropic. Mirrors the openai adapter's guard so the two
-// client-passthrough fallbacks can't drift.
+// The passthrough tier scrubs router-issued Bearer tokens via
+// httputil.SanitizeInboundAuthHeader before relaying inbound auth upstream.
 func (c *Client) setAuth(ctx context.Context, upstream *http.Request, inbound *http.Request) {
 	if creds := proxy.CredentialsFromContext(ctx); creds != nil {
 		if creds.OAuth {

--- a/internal/providers/anthropic/client.go
+++ b/internal/providers/anthropic/client.go
@@ -49,6 +49,12 @@ const subscriptionTokenPrefix = "sk-ant-oat"
 // credential (subscription/BYOK/client), deployment key, then client-sent auth
 // headers. A subscription OAuth credential authenticates via Authorization:
 // Bearer and must NOT send x-api-key; everything else uses x-api-key.
+//
+// The passthrough tier scrubs `Authorization: Bearer rk_...` via
+// httputil.SanitizeInboundAuthHeader — the router auth middleware accepts the
+// same header shape for router-key auth, so we must not relay a router
+// credential to Anthropic. Mirrors the openai adapter's guard so the two
+// client-passthrough fallbacks can't drift.
 func (c *Client) setAuth(ctx context.Context, upstream *http.Request, inbound *http.Request) {
 	if creds := proxy.CredentialsFromContext(ctx); creds != nil {
 		if creds.OAuth {
@@ -62,7 +68,7 @@ func (c *Client) setAuth(ctx context.Context, upstream *http.Request, inbound *h
 		upstream.Header.Set("x-api-key", c.apiKey)
 		return
 	}
-	if v := inbound.Header.Get("authorization"); v != "" {
+	if v := httputil.SanitizeInboundAuthHeader(inbound.Header.Get("authorization")); v != "" {
 		upstream.Header.Set("authorization", v)
 	}
 	if v := inbound.Header.Get("x-api-key"); v != "" {

--- a/internal/providers/anthropic/client_test.go
+++ b/internal/providers/anthropic/client_test.go
@@ -94,6 +94,61 @@ func TestProxy_PassesThroughAnthropicAuthWithoutRouterKey(t *testing.T) {
 	assert.Empty(t, gotRouterKey, "router auth must not be forwarded to Anthropic")
 }
 
+func TestProxy_ScrubsRouterKeyFromInboundAuthorizationHeader(t *testing.T) {
+	var gotAuth string
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"id":"msg_1"}`))
+	}))
+	defer upstream.Close()
+
+	// No deployment-level key configured, so setAuth falls through to the
+	// client-passthrough tier. A client authenticating to the router itself
+	// via `Authorization: Bearer rk_...` must never have that credential
+	// relayed to Anthropic.
+	c := anthropic.NewClient("", upstream.URL)
+	rec := httptest.NewRecorder()
+	clientReq := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(""))
+	clientReq.Header.Set("Authorization", "Bearer rk_abcdefghijklmnopqrstuvwx")
+
+	prep := providers.PreparedRequest{
+		Body:    []byte(`{"model":"claude-opus-4-7","messages":[{"role":"user","content":"hi"}]}`),
+		Headers: make(http.Header),
+	}
+	err := c.Proxy(context.Background(), router.Decision{Model: "claude-haiku-4-5"}, prep, rec, clientReq)
+
+	require.NoError(t, err)
+	assert.Empty(t, gotAuth, "router-issued key must not be forwarded to Anthropic")
+}
+
+func TestProxy_ScrubsRouterKeyFromInboundAuthorizationHeaderCaseInsensitive(t *testing.T) {
+	var gotAuth string
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"id":"msg_1"}`))
+	}))
+	defer upstream.Close()
+
+	c := anthropic.NewClient("", upstream.URL)
+	rec := httptest.NewRecorder()
+	clientReq := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(""))
+	// Lowercased "bearer" prefix must not bypass the scrub guard.
+	clientReq.Header.Set("Authorization", "bearer rk_abcdefghijklmnopqrstuvwx")
+
+	prep := providers.PreparedRequest{
+		Body:    []byte(`{"model":"claude-opus-4-7","messages":[{"role":"user","content":"hi"}]}`),
+		Headers: make(http.Header),
+	}
+	err := c.Proxy(context.Background(), router.Decision{Model: "claude-haiku-4-5"}, prep, rec, clientReq)
+
+	require.NoError(t, err)
+	assert.Empty(t, gotAuth, "router-issued key must not be forwarded to Anthropic regardless of Bearer casing")
+}
+
 func TestProxy_RouterKeyDoesNotOverrideConfiguredAnthropicKey(t *testing.T) {
 	var (
 		gotAuth   string

--- a/internal/providers/anthropic/client_test.go
+++ b/internal/providers/anthropic/client_test.go
@@ -104,10 +104,7 @@ func TestProxy_ScrubsRouterKeyFromInboundAuthorizationHeader(t *testing.T) {
 	}))
 	defer upstream.Close()
 
-	// No deployment-level key configured, so setAuth falls through to the
-	// client-passthrough tier. A client authenticating to the router itself
-	// via `Authorization: Bearer rk_...` must never have that credential
-	// relayed to Anthropic.
+	// No deployment key -> passthrough tier; router key must not leak to Anthropic.
 	c := anthropic.NewClient("", upstream.URL)
 	rec := httptest.NewRecorder()
 	clientReq := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(""))

--- a/internal/providers/httputil/httputil.go
+++ b/internal/providers/httputil/httputil.go
@@ -9,10 +9,12 @@ import (
 	"net/http"
 	"os"
 	"strconv"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
 
+	"workweave/router/internal/auth"
 	"workweave/router/internal/observability/otel"
 	"workweave/router/internal/providers"
 )
@@ -136,6 +138,33 @@ func idleTimeoutFromEnv(envVar string, fallback time.Duration) time.Duration {
 // NewTransport. Streaming upstreams return headers immediately, so 30s is ample
 // for them; it only bites a non-streaming upstream that buffers a slow response.
 const DefaultResponseHeaderTimeout = 30 * time.Second
+
+// SanitizeInboundAuthHeader returns v unchanged unless it carries a
+// router-issued key as a Bearer token, in which case it returns "" so the
+// caller skips forwarding it upstream.
+//
+// Client-passthrough fallback tiers (used when neither a resolved BYOK/
+// subscription credential nor a deployment-level key is configured) must run
+// the client's raw inbound `Authorization` header through this before
+// relaying it upstream — the router auth middleware accepts the same header
+// shape (`Authorization: Bearer rk_...`) for router-key auth, so without this
+// guard a client authenticating to the router would have its router API key
+// relayed verbatim to the upstream provider. Any other Bearer value (e.g. a
+// BYOK provider key, or a Claude subscription `sk-ant-oat` token) is left
+// untouched and forwarded as-is; the upstream 401s on invalid credentials.
+//
+// Prefix match is case-insensitive to mirror extractBearer — otherwise a
+// lowercased `authorization: bearer rk_...` bypasses this guard and leaks the
+// router key upstream.
+func SanitizeInboundAuthHeader(v string) string {
+	const bearerPrefix = "Bearer "
+	if len(v) > len(bearerPrefix) && strings.EqualFold(v[:len(bearerPrefix)], bearerPrefix) {
+		if auth.HasAPIKeyPrefix(strings.TrimSpace(v[len(bearerPrefix):])) {
+			return ""
+		}
+	}
+	return v
+}
 
 // NewTransport returns a pooled http.Transport sized for sustained traffic to a single upstream host.
 //

--- a/internal/providers/httputil/httputil.go
+++ b/internal/providers/httputil/httputil.go
@@ -141,21 +141,8 @@ const DefaultResponseHeaderTimeout = 30 * time.Second
 
 // SanitizeInboundAuthHeader returns v unchanged unless it carries a
 // router-issued key as a Bearer token, in which case it returns "" so the
-// caller skips forwarding it upstream.
-//
-// Client-passthrough fallback tiers (used when neither a resolved BYOK/
-// subscription credential nor a deployment-level key is configured) must run
-// the client's raw inbound `Authorization` header through this before
-// relaying it upstream — the router auth middleware accepts the same header
-// shape (`Authorization: Bearer rk_...`) for router-key auth, so without this
-// guard a client authenticating to the router would have its router API key
-// relayed verbatim to the upstream provider. Any other Bearer value (e.g. a
-// BYOK provider key, or a Claude subscription `sk-ant-oat` token) is left
-// untouched and forwarded as-is; the upstream 401s on invalid credentials.
-//
-// Prefix match is case-insensitive to mirror extractBearer — otherwise a
-// lowercased `authorization: bearer rk_...` bypasses this guard and leaks the
-// router key upstream.
+// caller skips forwarding it upstream. Prefix match is case-insensitive to
+// guard against `bearer rk_...` bypassing the scrub.
 func SanitizeInboundAuthHeader(v string) string {
 	const bearerPrefix = "Bearer "
 	if len(v) > len(bearerPrefix) && strings.EqualFold(v[:len(bearerPrefix)], bearerPrefix) {

--- a/internal/providers/httputil/httputil_test.go
+++ b/internal/providers/httputil/httputil_test.go
@@ -290,3 +290,58 @@ func TestErrUpstreamSlowThroughput_AliasIsRetryable(t *testing.T) {
 	assert.True(t, errors.Is(ErrUpstreamSlowThroughput, providers.ErrUpstreamSlowThroughput))
 	assert.True(t, providers.IsRetryable(ErrUpstreamSlowThroughput))
 }
+
+func TestSanitizeInboundAuthHeader(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "empty header passes through unchanged",
+			in:   "",
+			want: "",
+		},
+		{
+			name: "router key bearer is scrubbed",
+			in:   "Bearer rk_abcdefghijklmnopqrstuvwx",
+			want: "",
+		},
+		{
+			name: "router key bearer is scrubbed case-insensitively",
+			in:   "bearer rk_abcdefghijklmnopqrstuvwx",
+			want: "",
+		},
+		{
+			name: "router key bearer with mixed-case prefix is scrubbed",
+			in:   "BEARER rk_abcdefghijklmnopqrstuvwx",
+			want: "",
+		},
+		{
+			name: "BYOK anthropic subscription bearer is forwarded",
+			in:   "Bearer sk-ant-oat01-abcdefg",
+			want: "Bearer sk-ant-oat01-abcdefg",
+		},
+		{
+			name: "BYOK openai-shaped bearer is forwarded",
+			in:   "Bearer sk-proj-abcdefg",
+			want: "Bearer sk-proj-abcdefg",
+		},
+		{
+			name: "non-bearer auth scheme is forwarded untouched",
+			in:   "Basic dXNlcjpwYXNz",
+			want: "Basic dXNlcjpwYXNz",
+		},
+		{
+			name: "bearer with only rk-like substring (not prefixed) is forwarded",
+			in:   "Bearer sk-rk_notarealrouterkey",
+			want: "Bearer sk-rk_notarealrouterkey",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, SanitizeInboundAuthHeader(tt.in))
+		})
+	}
+}

--- a/internal/providers/openai/client.go
+++ b/internal/providers/openai/client.go
@@ -9,10 +9,8 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
-	"strings"
 	"time"
 
-	"workweave/router/internal/auth"
 	"workweave/router/internal/observability"
 	"workweave/router/internal/observability/otel"
 	"workweave/router/internal/providers"
@@ -160,15 +158,10 @@ func (c *Client) setAuth(ctx context.Context, upstream *http.Request, inbound *h
 		return
 	}
 	// Skip forwarding only if the Bearer token is a router-issued key; any
-	// other shape is forwarded as-is (upstream 401s on invalid creds). Prefix
-	// match is case-insensitive to mirror extractBearer — otherwise a
-	// lowercased `authorization: bearer rk_...` bypasses this guard and leaks
-	// the router key to OpenAI.
-	const bearerPrefix = "Bearer "
-	if len(v) > len(bearerPrefix) && strings.EqualFold(v[:len(bearerPrefix)], bearerPrefix) {
-		if auth.HasAPIKeyPrefix(strings.TrimSpace(v[len(bearerPrefix):])) {
-			return
-		}
+	// other shape is forwarded as-is (upstream 401s on invalid creds). See
+	// httputil.SanitizeInboundAuthHeader for the shared scrub guard.
+	if v = httputil.SanitizeInboundAuthHeader(v); v == "" {
+		return
 	}
 	upstream.Header.Set("Authorization", v)
 }


### PR DESCRIPTION
## Security finding [107] — critical

**Internal code-quality audit finding [107] (router API key leak).**

`internal/providers/anthropic/client.go`'s `setAuth` forwarded a client's inbound `Authorization` header to `api.anthropic.com` verbatim on the client-passthrough fallback tier (no BYOK/deployment Anthropic key resolved for the request). The OpenAI adapter's `setAuth` already scrubbed this case — stripping a case-insensitive `Bearer ` prefix and checking `auth.HasAPIKeyPrefix` — but that guard was hand-duplicated per-adapter instead of shared, and the Anthropic adapter's copy was missing it entirely.

**Impact:** a client that authenticates to the router with `Authorization: Bearer rk_...` (instead of `x-api-key`) would have that same router-issued API key forwarded upstream to Anthropic whenever no BYOK/deployment Anthropic key was configured for the request.

## Fix

- Extracted the existing openai-adapter scrub logic into `httputil.SanitizeInboundAuthHeader(v string) string`, which strips a case-insensitive `Bearer ` prefix and returns `""` when the remaining token is a router-issued key (`auth.HasAPIKeyPrefix`). Any other value (BYOK key, Claude subscription `sk-ant-oat` token, non-Bearer scheme, etc.) is returned unchanged.
- Updated `internal/providers/openai/client.go`'s `setAuth` to call the shared helper instead of its inline logic.
- Updated `internal/providers/anthropic/client.go`'s `setAuth` to call the same shared helper on its inbound-passthrough branch, closing the leak. The `x-api-key` passthrough branch is untouched — the router's own auth middleware only recognizes `Authorization: Bearer rk_...` for router-key auth, so `x-api-key` was never a viable leak vector.
- Both adapters now share one scrub implementation, so the two client-passthrough fallbacks can't drift again. `openaicompat`/`google` don't yet have a client-passthrough fallback tier, but should call `httputil.SanitizeInboundAuthHeader` if/when they add one.

## Test plan

- [x] `internal/providers/httputil/httputil_test.go`: new table-driven `TestSanitizeInboundAuthHeader` covering router-key scrub (incl. case-insensitive `Bearer`/`bearer`/`BEARER`), legitimate BYOK/subscription bearer passthrough, non-Bearer schemes, and a near-miss substring case.
- [x] `internal/providers/anthropic/client_test.go`: new `TestProxy_ScrubsRouterKeyFromInboundAuthorizationHeader` and `TestProxy_ScrubsRouterKeyFromInboundAuthorizationHeaderCaseInsensitive`, proving a `Bearer rk_...` inbound header is never forwarded to Anthropic. Existing `TestProxy_PassesThroughAnthropicAuthWithoutRouterKey` continues to pass, proving legitimate inbound bearer tokens are still forwarded.
- [x] `go build ./...`
- [x] `go test ./internal/providers/...` — all pass
- [x] `go test ./...` (full suite) — all pass