### PR TITLE
fix(proxy): depend on TelemetryEmitter interface, not concrete *otel.Emitter

### DIFF
--- a/cmd/router/main.go
+++ b/cmd/router/main.go
@@ -450,10 +450,9 @@ func main() {
 		logger.Error("Failed to create OTel emitter", "err", err)
 		panic(err)
 	}
-	// telemetryEmitter is proxy.NewService's interface-typed parameter. Left as
-	// a true nil interface (not a nil-valued *otel.Emitter wrapped in an
-	// interface) when OTel is disabled, so proxy's `s.emitter == nil` checks
-	// keep working correctly.
+	// Keep as a true nil interface, not a nil *otel.Emitter wrapped in an
+	// interface (which would be non-nil), so proxy's s.emitter == nil checks
+	// work correctly.
 	var telemetryEmitter proxy.TelemetryEmitter
 	if emitter != nil {
 		telemetryEmitter = emitter

--- a/cmd/router/main.go
+++ b/cmd/router/main.go
@@ -450,6 +450,14 @@ func main() {
 		logger.Error("Failed to create OTel emitter", "err", err)
 		panic(err)
 	}
+	// telemetryEmitter is proxy.NewService's interface-typed parameter. Left as
+	// a true nil interface (not a nil-valued *otel.Emitter wrapped in an
+	// interface) when OTel is disabled, so proxy's `s.emitter == nil` checks
+	// keep working correctly.
+	var telemetryEmitter proxy.TelemetryEmitter
+	if emitter != nil {
+		telemetryEmitter = emitter
+	}
 
 	semanticCache := buildSemanticCache(rtr)
 
@@ -627,7 +635,7 @@ func main() {
 		logger.Info("Bandit strategy router disabled (ROUTER_BANDIT_POSTERIOR_FILE unset); x-weave-router-strategy: bandit will return 503")
 	}
 
-	proxySvc := proxy.NewService(routeEntry, providerMap, emitter, embedOnlyUser, semanticCache, pinStore, hardPinExplore, hardPinProvider, hardPinModel, repo.Telemetry).
+	proxySvc := proxy.NewService(routeEntry, providerMap, telemetryEmitter, embedOnlyUser, semanticCache, pinStore, hardPinExplore, hardPinProvider, hardPinModel, repo.Telemetry).
 		WithRLRouter(rlRouter).
 		WithBanditRouter(banditRouter).
 		WithContentCapture(captureMode, captureMaxBytes, nil).

--- a/internal/observability/otel/emitter.go
+++ b/internal/observability/otel/emitter.go
@@ -103,8 +103,7 @@ func NewEmitter(cfg EmitterConfig) (*Emitter, error) {
 }
 
 // NewBuffer returns a request-scoped span/log buffer wrapping e, or nil when e
-// is nil (OTel disabled). Satisfies proxy.TelemetryEmitter so callers can
-// depend on that narrow interface instead of the concrete *Emitter type.
+// is nil (OTel disabled).
 func (e *Emitter) NewBuffer() *Buffer {
 	return NewBuffer(e)
 }

--- a/internal/observability/otel/emitter.go
+++ b/internal/observability/otel/emitter.go
@@ -102,6 +102,13 @@ func NewEmitter(cfg EmitterConfig) (*Emitter, error) {
 	return e, nil
 }
 
+// NewBuffer returns a request-scoped span/log buffer wrapping e, or nil when e
+// is nil (OTel disabled). Satisfies proxy.TelemetryEmitter so callers can
+// depend on that narrow interface instead of the concrete *Emitter type.
+func (e *Emitter) NewBuffer() *Buffer {
+	return NewBuffer(e)
+}
+
 // Enqueue submits a span to the export queue. Non-blocking: drops on queue-full
 // or post-shutdown. Nil receiver is a no-op.
 func (e *Emitter) Enqueue(s *tracev1.Span) {

--- a/internal/proxy/feedback.go
+++ b/internal/proxy/feedback.go
@@ -144,7 +144,7 @@ func (s *Service) emitFeedbackSpan(p SubmitFeedbackParams) {
 	if p.RouterUserID != "" {
 		b = b.String("router_user_id", p.RouterUserID)
 	}
-	buf := otel.NewBuffer(s.emitter)
+	buf := s.newTelemetryBuffer()
 	buf.Record(otel.Span{Name: routerFeedbackSpanName, Start: now, End: now, Attrs: b.Build()})
 	buf.Flush()
 }

--- a/internal/proxy/gemini.go
+++ b/internal/proxy/gemini.go
@@ -33,7 +33,7 @@ func (s *Service) ProxyGeminiGenerateContent(ctx context.Context, body []byte, w
 	log := observability.FromContext(ctx)
 	requestStart := time.Now()
 	requestID := uuid.New().String()
-	buf := otel.NewBuffer(s.emitter)
+	buf := s.newTelemetryBuffer()
 	ctx = buf.WithContext(ctx)
 
 	apiKeyID, _ := ctx.Value(APIKeyIDContextKey{}).(string)

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -34,12 +34,8 @@ import (
 	"github.com/tidwall/sjson"
 )
 
-// TelemetryEmitter is the narrow inner-ring interface proxy needs from the
-// OTel observability adapter: a request-scoped span/log buffer. Implemented
-// by *otel.Emitter (internal/observability/otel) and injected from
-// cmd/router/main.go, mirroring the sessionpin.Store / handover.Summarizer /
-// billing.Repo pattern so proxy depends on an interface it owns rather than
-// the adapter's concrete type.
+// TelemetryEmitter is the narrow interface proxy owns for OTel: a
+// request-scoped span/log buffer. Implemented by *otel.Emitter.
 type TelemetryEmitter interface {
 	// NewBuffer returns a request-scoped span/log buffer, or nil when the
 	// emitter itself is disabled.
@@ -1079,10 +1075,8 @@ func (s *Service) usageRequired() bool {
 	return s.emitter != nil || s.telemetry != nil || s.billing != nil
 }
 
-// newTelemetryBuffer returns a request-scoped span/log buffer, or nil when no
-// TelemetryEmitter is wired (OTel disabled). Callers invoke this instead of
-// calling s.emitter.NewBuffer() directly so a nil emitter interface never
-// causes a nil-interface method-call panic.
+// newTelemetryBuffer returns a request-scoped buffer, or nil when OTel is
+// disabled — guards against a nil-interface method-call panic.
 func (s *Service) newTelemetryBuffer() *otel.Buffer {
 	if s.emitter == nil {
 		return nil

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -34,6 +34,18 @@ import (
 	"github.com/tidwall/sjson"
 )
 
+// TelemetryEmitter is the narrow inner-ring interface proxy needs from the
+// OTel observability adapter: a request-scoped span/log buffer. Implemented
+// by *otel.Emitter (internal/observability/otel) and injected from
+// cmd/router/main.go, mirroring the sessionpin.Store / handover.Summarizer /
+// billing.Repo pattern so proxy depends on an interface it owns rather than
+// the adapter's concrete type.
+type TelemetryEmitter interface {
+	// NewBuffer returns a request-scoped span/log buffer, or nil when the
+	// emitter itself is disabled.
+	NewBuffer() *otel.Buffer
+}
+
 // Service orchestrates routing decisions and provider dispatch.
 type Service struct {
 	router router.Router
@@ -47,7 +59,7 @@ type Service struct {
 	// is unset at boot; the strategy header then 503s.
 	banditRouter         router.Router
 	providers            map[string]providers.Client
-	emitter              *otel.Emitter
+	emitter              TelemetryEmitter
 	embedOnlyUserMessage bool
 	semanticCache        *cache.Cache
 	// pinStore persists session-sticky routing decisions. Nil when the feature
@@ -776,7 +788,7 @@ const DefaultPlannerTierUpgradeEnabled = true
 // shadow telemetry before arming.
 const DefaultPlannerColdPinFollowFresh = false
 
-func NewService(r router.Router, providerMap map[string]providers.Client, emitter *otel.Emitter, embedOnlyUserMessage bool, semanticCache *cache.Cache, pinStore sessionpin.Store, hardPinExplore bool, hardPinProvider, hardPinModel string, telemetry TelemetryRepository) *Service {
+func NewService(r router.Router, providerMap map[string]providers.Client, emitter TelemetryEmitter, embedOnlyUserMessage bool, semanticCache *cache.Cache, pinStore sessionpin.Store, hardPinExplore bool, hardPinProvider, hardPinModel string, telemetry TelemetryRepository) *Service {
 	return &Service{
 		router:               r,
 		providers:            providerMap,
@@ -1065,6 +1077,17 @@ func (s *Service) ExcludedProvidersOverride() []string {
 // OTel export, DB telemetry persistence, and credit billing all need it.
 func (s *Service) usageRequired() bool {
 	return s.emitter != nil || s.telemetry != nil || s.billing != nil
+}
+
+// newTelemetryBuffer returns a request-scoped span/log buffer, or nil when no
+// TelemetryEmitter is wired (OTel disabled). Callers invoke this instead of
+// calling s.emitter.NewBuffer() directly so a nil emitter interface never
+// causes a nil-interface method-call panic.
+func (s *Service) newTelemetryBuffer() *otel.Buffer {
+	if s.emitter == nil {
+		return nil
+	}
+	return s.emitter.NewBuffer()
 }
 
 // WithBillingService installs the credit-billing service. Nil disables the
@@ -1442,7 +1465,7 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 	log := observability.FromContext(ctx)
 	requestStart := time.Now()
 	requestID := uuid.New().String()
-	buf := otel.NewBuffer(s.emitter)
+	buf := s.newTelemetryBuffer()
 	ctx = buf.WithContext(ctx)
 
 	// Strip the routing marker prior responses injected as assistant text —
@@ -3156,7 +3179,7 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 	log := observability.FromContext(ctx)
 	requestStart := time.Now()
 	requestID := uuid.New().String()
-	buf := otel.NewBuffer(s.emitter)
+	buf := s.newTelemetryBuffer()
 	ctx = buf.WithContext(ctx)
 
 	apiKeyID, _ := ctx.Value(APIKeyIDContextKey{}).(string)


### PR DESCRIPTION
## Summary

Internal code-quality audit flagged (critical, [100]) that `internal/proxy/service.go:37` held a hard compile-time dependency on the concrete adapter type `*otel.Emitter`, calling the adapter package's functions directly across the whole turn loop — inverting the "adapters depend on inner ring, never the reverse" rule documented in the root CLAUDE.md.

- Defines `proxy.TelemetryEmitter`, a narrow inner-ring interface covering the one stateful operation the turn loop actually needs from OTel (a request-scoped span/log buffer), mirroring the existing `sessionpin.Store` / `handover.Summarizer` / `billing.Repo` pattern of interfaces owned by the inner ring and implemented by adapters.
- `*otel.Emitter` implements it via a new `NewBuffer()` method that just wraps the existing `otel.NewBuffer(e)` constructor.
- `proxy.Service`'s `emitter` field and `NewService` constructor now take `TelemetryEmitter` instead of `*otel.Emitter`.
- `cmd/router/main.go` injects the interface, carefully preserving nil semantics: a disabled emitter (`OTEL_EXPORTER_OTLP_ENDPOINT` unset) stays a *true* nil interface rather than a nil `*otel.Emitter` pointer wrapped in a non-nil interface (the classic Go nil-interface trap), so `s.emitter == nil` checks throughout proxy keep working correctly.
- Added a small `s.newTelemetryBuffer()` helper so the four call sites that unconditionally called `.NewBuffer()` can't panic on a nil interface.

Scope intentionally narrow: package-level `otel.Record`/`otel.Flush`/`otel.Lookup`/data types (`otel.Span`, `otel.AttrBuilder`, etc.) used elsewhere in proxy are unaffected — they're stateless functions/DTOs from a leaf package, not the concrete-service dependency the finding was about.

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/proxy/... ./internal/observability/... ./cmd/router/...` — all pass
- [x] `go test ./...` (full suite) — all pass
- [x] `gofmt -l .` — clean