### PR TITLE
test(api/anthropic): add handler tests for /v1/messages and /v1/route

### DIFF
--- a/internal/api/anthropic/messages_test.go
+++ b/internal/api/anthropic/messages_test.go
@@ -62,17 +62,10 @@ func (f *fakeProviderClient) Passthrough(_ context.Context, _ providers.Prepared
 	return nil
 }
 
-// max_tokens is kept above turntype's classifier/probe thresholds (4 and 256
-// respectively) so DetectFromEnvelope classifies this as a normal MainLoop
-// turn and runs the scorer via routeFor, rather than short-circuiting through
-// the hard-pin path used for probes/title-gen/classifier calls.
+// max_tokens > 256 so DetectFromEnvelope treats this as a MainLoop turn, not a probe/classifier.
 const validAnthropicBody = `{"model":"claude-sonnet-4-5","messages":[{"role":"user","content":"hi"}],"max_tokens":4096}`
 
-// newTestService builds a proxy.Service wired with a fake router and, when
-// clientName/client are non-empty/non-nil, a single fake provider — enough to
-// drive MessagesHandler/RouteHandler/PassthroughHandler end to end without any
-// real dependency (DB, HTTP upstream, etc), mirroring the fake-repo pattern in
-// internal/api/feedback/feedback_test.go.
+// newTestService wires a proxy.Service with a fake router and optional fake provider, no real I/O.
 func newTestService(r router.Router, clientName string, client providers.Client) *proxy.Service {
 	providerMap := map[string]providers.Client{}
 	if clientName != "" && client != nil {
@@ -164,9 +157,7 @@ func TestMessagesHandler_ClusterUnavailableReturns503WithRetryAfter(t *testing.T
 }
 
 func TestMessagesHandler_RLPolicyUnavailableReturns503(t *testing.T) {
-	// No RL router wired (WithRLRouter never called), so opting into the rl
-	// strategy fails closed rather than silently falling back to the cluster
-	// scorer.
+	// No RL router wired — strategy fails closed rather than falling back to cluster scorer.
 	svc := newTestService(&fakeRouter{decision: router.Decision{Provider: providers.ProviderAnthropic, Model: "claude-sonnet-4-5"}}, "", nil)
 	engine := messagesEngine(svc)
 

--- a/internal/api/anthropic/messages_test.go
+++ b/internal/api/anthropic/messages_test.go
@@ -1,0 +1,352 @@
+package anthropic_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	anthropicapi "workweave/router/internal/api/anthropic"
+	"workweave/router/internal/providers"
+	"workweave/router/internal/proxy"
+	"workweave/router/internal/router"
+	"workweave/router/internal/router/cluster"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeRouter lets tests control exactly what routing decision (or error) the
+// proxy.Service's scorer step returns, without needing a real cluster router.
+type fakeRouter struct {
+	decision router.Decision
+	err      error
+}
+
+func (f *fakeRouter) Route(_ context.Context, _ router.Request) (router.Decision, error) {
+	return f.decision, f.err
+}
+
+// fakeProviderClient is a minimal providers.Client double: Proxy/Passthrough
+// return whatever the test wants, optionally writing a response first.
+type fakeProviderClient struct {
+	proxyErr       error
+	proxyStatus    int
+	proxyBody      string
+	passthroughErr error
+}
+
+func (f *fakeProviderClient) Proxy(_ context.Context, _ router.Decision, _ providers.PreparedRequest, w http.ResponseWriter, _ *http.Request) error {
+	if f.proxyErr != nil {
+		return f.proxyErr
+	}
+	status := f.proxyStatus
+	if status == 0 {
+		status = http.StatusOK
+	}
+	w.WriteHeader(status)
+	_, _ = w.Write([]byte(f.proxyBody))
+	return nil
+}
+
+func (f *fakeProviderClient) Passthrough(_ context.Context, _ providers.PreparedRequest, w http.ResponseWriter, _ *http.Request) error {
+	if f.passthroughErr != nil {
+		return f.passthroughErr
+	}
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write([]byte(f.proxyBody))
+	return nil
+}
+
+// max_tokens is kept above turntype's classifier/probe thresholds (4 and 256
+// respectively) so DetectFromEnvelope classifies this as a normal MainLoop
+// turn and runs the scorer via routeFor, rather than short-circuiting through
+// the hard-pin path used for probes/title-gen/classifier calls.
+const validAnthropicBody = `{"model":"claude-sonnet-4-5","messages":[{"role":"user","content":"hi"}],"max_tokens":4096}`
+
+// newTestService builds a proxy.Service wired with a fake router and, when
+// clientName/client are non-empty/non-nil, a single fake provider — enough to
+// drive MessagesHandler/RouteHandler/PassthroughHandler end to end without any
+// real dependency (DB, HTTP upstream, etc), mirroring the fake-repo pattern in
+// internal/api/feedback/feedback_test.go.
+func newTestService(r router.Router, clientName string, client providers.Client) *proxy.Service {
+	providerMap := map[string]providers.Client{}
+	if clientName != "" && client != nil {
+		providerMap[clientName] = client
+	}
+	return proxy.NewService(r, providerMap, nil, false, nil, nil, false, "", "", nil)
+}
+
+func errorEnvelope(t *testing.T, body []byte) map[string]any {
+	t.Helper()
+	var got map[string]any
+	require.NoError(t, json.Unmarshal(body, &got))
+	assert.Equal(t, "error", got["type"])
+	errObj, ok := got["error"].(map[string]any)
+	require.True(t, ok, "expected error envelope to carry an \"error\" object")
+	return errObj
+}
+
+func messagesEngine(svc *proxy.Service) *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	engine := gin.New()
+	engine.POST("/v1/messages", anthropicapi.MessagesHandler(svc, nil))
+	return engine
+}
+
+func postMessages(engine *gin.Engine, body []byte) *httptest.ResponseRecorder {
+	rec := httptest.NewRecorder()
+	engine.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/v1/messages", bytes.NewReader(body)))
+	return rec
+}
+
+func TestMessagesHandler_RequestTooLarge(t *testing.T) {
+	svc := newTestService(&fakeRouter{}, "", nil)
+	engine := messagesEngine(svc)
+
+	oversized := bytes.Repeat([]byte("a"), 10*1024*1024+1)
+	rec := postMessages(engine, oversized)
+
+	require.Equal(t, http.StatusRequestEntityTooLarge, rec.Code)
+	errObj := errorEnvelope(t, rec.Body.Bytes())
+	assert.Equal(t, "invalid_request_error", errObj["type"])
+}
+
+func TestMessagesHandler_MalformedBodyReturns400(t *testing.T) {
+	svc := newTestService(&fakeRouter{}, "", nil)
+	engine := messagesEngine(svc)
+
+	// A JSON array is valid JSON but not a JSON object, so ParseAnthropic
+	// returns translate.ErrNotJSONObject.
+	rec := postMessages(engine, []byte(`[]`))
+
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+	errObj := errorEnvelope(t, rec.Body.Bytes())
+	assert.Equal(t, "invalid_request_error", errObj["type"])
+}
+
+func TestMessagesHandler_NoEligibleProviderReturns400(t *testing.T) {
+	svc := newTestService(&fakeRouter{err: cluster.ErrNoEligibleProvider}, "", nil)
+	engine := messagesEngine(svc)
+
+	rec := postMessages(engine, []byte(validAnthropicBody))
+
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+	errObj := errorEnvelope(t, rec.Body.Bytes())
+	assert.Equal(t, "invalid_request_error", errObj["type"])
+}
+
+func TestMessagesHandler_InvalidRoutingKnobsReturns400(t *testing.T) {
+	svc := newTestService(&fakeRouter{err: cluster.ErrInvalidRoutingKnobs}, "", nil)
+	engine := messagesEngine(svc)
+
+	rec := postMessages(engine, []byte(validAnthropicBody))
+
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+	errObj := errorEnvelope(t, rec.Body.Bytes())
+	assert.Equal(t, "invalid_request_error", errObj["type"])
+}
+
+func TestMessagesHandler_ClusterUnavailableReturns503WithRetryAfter(t *testing.T) {
+	svc := newTestService(&fakeRouter{err: cluster.ErrClusterUnavailable}, "", nil)
+	engine := messagesEngine(svc)
+
+	rec := postMessages(engine, []byte(validAnthropicBody))
+
+	require.Equal(t, http.StatusServiceUnavailable, rec.Code)
+	assert.Equal(t, "1", rec.Header().Get("Retry-After"))
+	errObj := errorEnvelope(t, rec.Body.Bytes())
+	assert.Equal(t, "api_error", errObj["type"])
+}
+
+func TestMessagesHandler_RLPolicyUnavailableReturns503(t *testing.T) {
+	// No RL router wired (WithRLRouter never called), so opting into the rl
+	// strategy fails closed rather than silently falling back to the cluster
+	// scorer.
+	svc := newTestService(&fakeRouter{decision: router.Decision{Provider: providers.ProviderAnthropic, Model: "claude-sonnet-4-5"}}, "", nil)
+	engine := messagesEngine(svc)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/messages", bytes.NewReader([]byte(validAnthropicBody)))
+	req = req.WithContext(router.WithStrategy(req.Context(), router.StrategyRL))
+	engine.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusServiceUnavailable, rec.Code)
+	assert.Equal(t, "1", rec.Header().Get("Retry-After"))
+	errObj := errorEnvelope(t, rec.Body.Bytes())
+	assert.Equal(t, "api_error", errObj["type"])
+	assert.Contains(t, errObj["message"], "RL policy router")
+}
+
+func TestMessagesHandler_BanditUnavailableReturns503(t *testing.T) {
+	// No bandit router wired, mirroring the RL case above.
+	svc := newTestService(&fakeRouter{decision: router.Decision{Provider: providers.ProviderAnthropic, Model: "claude-sonnet-4-5"}}, "", nil)
+	engine := messagesEngine(svc)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/messages", bytes.NewReader([]byte(validAnthropicBody)))
+	req = req.WithContext(router.WithStrategy(req.Context(), router.StrategyBandit))
+	engine.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusServiceUnavailable, rec.Code)
+	assert.Equal(t, "1", rec.Header().Get("Retry-After"))
+	errObj := errorEnvelope(t, rec.Body.Bytes())
+	assert.Equal(t, "api_error", errObj["type"])
+	assert.Contains(t, errObj["message"], "bandit router")
+}
+
+func TestMessagesHandler_UpstreamStatusErrorPassesThroughStatus(t *testing.T) {
+	client := &fakeProviderClient{proxyErr: &providers.UpstreamStatusError{Status: http.StatusTooManyRequests}}
+	svc := newTestService(
+		&fakeRouter{decision: router.Decision{Provider: providers.ProviderAnthropic, Model: "claude-sonnet-4-5", Reason: "test"}},
+		providers.ProviderAnthropic, client,
+	)
+	engine := messagesEngine(svc)
+
+	rec := postMessages(engine, []byte(validAnthropicBody))
+
+	require.Equal(t, http.StatusTooManyRequests, rec.Code)
+	errObj := errorEnvelope(t, rec.Body.Bytes())
+	assert.Equal(t, "api_error", errObj["type"])
+}
+
+func TestMessagesHandler_UnknownErrorReturns502(t *testing.T) {
+	client := &fakeProviderClient{proxyErr: errors.New("boom: transport exploded")}
+	svc := newTestService(
+		&fakeRouter{decision: router.Decision{Provider: providers.ProviderAnthropic, Model: "claude-sonnet-4-5", Reason: "test"}},
+		providers.ProviderAnthropic, client,
+	)
+	engine := messagesEngine(svc)
+
+	rec := postMessages(engine, []byte(validAnthropicBody))
+
+	require.Equal(t, http.StatusBadGateway, rec.Code)
+	errObj := errorEnvelope(t, rec.Body.Bytes())
+	assert.Equal(t, "api_error", errObj["type"])
+}
+
+func TestMessagesHandler_HappyPathServesUpstreamResponse(t *testing.T) {
+	client := &fakeProviderClient{proxyStatus: http.StatusOK, proxyBody: `{"id":"msg_1","type":"message"}`}
+	svc := newTestService(
+		&fakeRouter{decision: router.Decision{Provider: providers.ProviderAnthropic, Model: "claude-sonnet-4-5", Reason: "test_reason"}},
+		providers.ProviderAnthropic, client,
+	)
+	engine := messagesEngine(svc)
+
+	rec := postMessages(engine, []byte(validAnthropicBody))
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, `{"id":"msg_1","type":"message"}`, rec.Body.String())
+	assert.Equal(t, "claude-sonnet-4-5", rec.Header().Get("x-router-model"))
+	assert.Equal(t, providers.ProviderAnthropic, rec.Header().Get("x-router-provider"))
+	assert.Equal(t, "test_reason", rec.Header().Get("x-router-decision"))
+}
+
+// --- RouteHandler (/v1/route) ---
+
+func routeEngine(svc *proxy.Service) *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	engine := gin.New()
+	engine.POST("/v1/route", anthropicapi.RouteHandler(svc))
+	return engine
+}
+
+func TestRouteHandler_InvalidRoutingKnobsReturns400(t *testing.T) {
+	svc := newTestService(&fakeRouter{err: cluster.ErrInvalidRoutingKnobs}, "", nil)
+	engine := routeEngine(svc)
+
+	rec := httptest.NewRecorder()
+	engine.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/v1/route", bytes.NewReader([]byte(validAnthropicBody))))
+
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+	errObj := errorEnvelope(t, rec.Body.Bytes())
+	assert.Equal(t, "invalid_request_error", errObj["type"])
+}
+
+func TestRouteHandler_GenericRoutingErrorReturns502(t *testing.T) {
+	svc := newTestService(&fakeRouter{err: errors.New("scorer exploded")}, "", nil)
+	engine := routeEngine(svc)
+
+	rec := httptest.NewRecorder()
+	engine.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/v1/route", bytes.NewReader([]byte(validAnthropicBody))))
+
+	require.Equal(t, http.StatusBadGateway, rec.Code)
+	errObj := errorEnvelope(t, rec.Body.Bytes())
+	assert.Equal(t, "api_error", errObj["type"])
+}
+
+func TestRouteHandler_RequestTooLarge(t *testing.T) {
+	svc := newTestService(&fakeRouter{}, "", nil)
+	engine := routeEngine(svc)
+
+	oversized := bytes.Repeat([]byte("a"), 10*1024*1024+1)
+	rec := httptest.NewRecorder()
+	engine.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/v1/route", bytes.NewReader(oversized)))
+
+	require.Equal(t, http.StatusRequestEntityTooLarge, rec.Code)
+}
+
+func TestRouteHandler_HappyPathReturnsDecision(t *testing.T) {
+	decision := router.Decision{Provider: providers.ProviderAnthropic, Model: "claude-haiku-4-5", Reason: "cheap_and_cheerful"}
+	svc := newTestService(&fakeRouter{decision: decision}, "", nil)
+	engine := routeEngine(svc)
+
+	rec := httptest.NewRecorder()
+	engine.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/v1/route", bytes.NewReader([]byte(validAnthropicBody))))
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	var got map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
+	assert.Equal(t, "claude-haiku-4-5", got["model"])
+	assert.Equal(t, providers.ProviderAnthropic, got["provider"])
+	assert.Equal(t, "cheap_and_cheerful", got["reason"])
+}
+
+// --- PassthroughHandler ---
+
+func passthroughEngine(svc *proxy.Service) *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	engine := gin.New()
+	engine.POST("/v1/messages/count_tokens", anthropicapi.PassthroughHandler(svc))
+	return engine
+}
+
+func TestPassthroughHandler_NotImplementedReturns501(t *testing.T) {
+	client := &fakeProviderClient{passthroughErr: providers.ErrNotImplemented}
+	svc := newTestService(&fakeRouter{}, providers.ProviderAnthropic, client)
+	engine := passthroughEngine(svc)
+
+	rec := httptest.NewRecorder()
+	engine.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/v1/messages/count_tokens", bytes.NewReader([]byte(validAnthropicBody))))
+
+	require.Equal(t, http.StatusNotImplemented, rec.Code)
+	errObj := errorEnvelope(t, rec.Body.Bytes())
+	assert.Equal(t, "api_error", errObj["type"])
+}
+
+func TestPassthroughHandler_RequestTooLarge(t *testing.T) {
+	svc := newTestService(&fakeRouter{}, "", nil)
+	engine := passthroughEngine(svc)
+
+	oversized := bytes.Repeat([]byte("a"), 10*1024*1024+1)
+	rec := httptest.NewRecorder()
+	engine.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/v1/messages/count_tokens", bytes.NewReader(oversized)))
+
+	require.Equal(t, http.StatusRequestEntityTooLarge, rec.Code)
+}
+
+func TestPassthroughHandler_HappyPath(t *testing.T) {
+	client := &fakeProviderClient{proxyBody: `{"input_tokens":42}`}
+	svc := newTestService(&fakeRouter{}, providers.ProviderAnthropic, client)
+	engine := passthroughEngine(svc)
+
+	rec := httptest.NewRecorder()
+	engine.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/v1/messages/count_tokens", bytes.NewReader([]byte(validAnthropicBody))))
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, `{"input_tokens":42}`, rec.Body.String())
+}


### PR DESCRIPTION
## Summary

Addresses a critical test-coverage finding ([117]) from an internal code-quality audit: the entire `internal/api/anthropic` package (`MessagesHandler` for `/v1/messages`, `RouteHandler` for `/v1/route`, `PassthroughHandler`) had zero test files, leaving the primary customer-facing HTTP entry point's error-to-status mapping completely unverified.

Adds `internal/api/anthropic/messages_test.go` as an external `anthropic_test` package, following the fake-repo + httptest pattern documented in `internal/api/CLAUDE.md` step 7 and modeled on `internal/api/feedback/feedback_test.go`. Builds a `proxy.Service` via `proxy.NewService` wired with a fake `router.Router` and fake `providers.Client`, so the full request path (routing decision → dispatch → response) runs without any real dependency (DB, HTTP upstream, etc).

Coverage:
- **MessagesHandler**: request-too-large (413), malformed body / not-a-JSON-object (400), `cluster.ErrNoEligibleProvider` (400), `cluster.ErrInvalidRoutingKnobs` (400), `cluster.ErrClusterUnavailable` (503 + `Retry-After`), `rl.ErrPolicyUnavailable` via the `x-weave-router-strategy: rl` override with no sidecar wired (503), `bandit.ErrBanditUnavailable` likewise (503), `providers.UpstreamStatusError` passthrough status, unknown/generic upstream error (502 default), and a happy-path response with `x-router-*` headers.
- **RouteHandler**: invalid-routing-knobs (400), generic routing error (502), request-too-large (413), happy-path decision JSON.
- **PassthroughHandler**: `providers.ErrNotImplemented` (501), request-too-large (413), happy-path passthrough.

## Deviations from the original ask

- `rl.ErrPolicyUnavailable` / `bandit.ErrBanditUnavailable` aren't triggered via the real `WithRouterStrategyOverride` gin middleware (which requires a resolved installation) — instead the test injects the strategy directly via `router.WithStrategy(ctx, ...)` on the request context before calling `ServeHTTP`, since that's exactly what the middleware would have stashed. No production code changes were needed; the constructor and `router.Router`/`providers.Client` interfaces already have exactly the seams needed (as used internally by `internal/proxy/fallback_test.go`).
- One test (`TestMessagesHandler_UnknownErrorReturns502`) takes ~0.75s because a non-`UpstreamStatusError` error is classified as retryable by `providers.IsRetryable` and triggers the real same-binding backoff sleep in `dispatchWithFallback` (`retrySleep` is an unexported field only overridable from within `package proxy`, not from this external test package). All other tests are fast.
- Also added coverage for `PassthroughHandler`, which was in scope per the finding's description of the package even though not explicitly itemized in the task bullets — it shares the same zero-coverage problem and was trivial to cover once the fake provider existed.

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/api/anthropic/... -v` — 17/17 pass
- [x] `go test ./internal/proxy/... ./internal/api/...` — all packages pass (no regressions)
- [x] `gofmt -l` / `go vet` clean on the new file