### PR TITLE
ci(cluster-routing): post + gate routing-review comment as weave-bot

### DIFF
--- a/.github/workflows/cluster_routing_ack.yml
+++ b/.github/workflows/cluster_routing_ack.yml
@@ -27,8 +27,8 @@ jobs:
     name: Routing review acknowledge
     if: >-
       github.event.issue.pull_request != null &&
-      github.event.sender.type != 'Bot' &&
-      github.event.comment.user.login == 'github-actions[bot]' &&
+      github.event.sender.login != 'weave-bot' &&
+      github.event.comment.user.login == 'weave-bot' &&
       contains(github.event.comment.body, '<!-- cluster-routing-report:')
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/publish_cluster_routing.yml
+++ b/.github/workflows/publish_cluster_routing.yml
@@ -41,7 +41,7 @@ concurrency:
 env:
   CHECK_CONTEXT: cluster-routing/acknowledged
   COMMENT_MARKER_PREFIX: "<!-- cluster-routing-report:"
-  BOT_LOGIN: "github-actions[bot]"
+  BOT_LOGIN: "weave-bot"
   LATEST_PATH: internal/router/cluster/artifacts/latest
 
 jobs:
@@ -72,6 +72,10 @@ jobs:
       - name: Upsert comment and set status
         uses: actions/github-script@v7
         with:
+          # PAT so the sticky comment is authored by weave-bot (cluster_routing_ack
+          # keys the acknowledgment gate off this author login). Needs issues:write,
+          # pull-requests:read, statuses:write on this repo.
+          github-token: ${{ secrets.WEAVE_BOT_TOKEN }}
           script: |
             const fs = require('fs');
             const crypto = require('crypto');


### PR DESCRIPTION
Author the cluster-routing review comment as the **weave-bot** machine user instead of `github-actions[bot]`, so those gate comments come from a real, attributable account.

The poster (`publish_cluster_routing.yml`) and the ack watcher (`cluster_routing_ack.yml`) are coupled through the comment author login — the watcher only fires when a maintainer edits a comment authored by the bot — so both change together:

- **publish**: `BOT_LOGIN` -> `weave-bot`, and the upsert `github-script` step now runs under the `WEAVE_BOT_TOKEN` PAT so the sticky comment is authored by weave-bot. Artifact download stays on `GITHUB_TOKEN`.
- **ack**: match comments authored by `weave-bot`, and swap the self-trigger guard from `sender.type != Bot` to `sender.login != weave-bot` — a machine-user PAT authors as a User, not a Bot, so the old check would let the bot own comment re-trigger the ack.

### Required before/after merge
- [x] Add a `WEAVE_BOT_TOKEN` secret to this repo (or org-level) — scopes: **issues:write, pull-requests:read, statuses:write, contents:read**.
- [x] `weave-bot` has **write** access to this repo (also what enforces the gate: only writers can edit another user comment).

### Transition note
In-flight PRs with an existing `github-actions[bot]` routing comment will get a fresh `weave-bot` comment; reviewers must tick the **new** one. Self-heals as PRs merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)