### PR TITLE
fix(otel): don't panic on crypto/rand failure when generating trace/span IDs

### DIFF
--- a/internal/observability/otel/spans.go
+++ b/internal/observability/otel/spans.go
@@ -2,12 +2,18 @@ package otel
 
 import (
 	"crypto/rand"
+	mathrand "math/rand/v2"
 	"time"
 
 	commonv1 "go.opentelemetry.io/proto/otlp/common/v1"
 	resourcev1 "go.opentelemetry.io/proto/otlp/resource/v1"
 	tracev1 "go.opentelemetry.io/proto/otlp/trace/v1"
+
+	"workweave/router/internal/observability"
 )
+
+// cryptoRandRead is a seam for tests to simulate crypto/rand.Read failures.
+var cryptoRandRead = rand.Read
 
 // Span is a lightweight telemetry record converted to OTLP protobuf at flush time.
 type Span struct {
@@ -17,20 +23,37 @@ type Span struct {
 	Attrs []*commonv1.KeyValue
 }
 
+// generateTraceID returns a random 16-byte trace ID. Trace/span IDs need
+// uniqueness, not cryptographic unpredictability, so a crypto/rand.Read
+// failure falls back to math/rand/v2 instead of panicking: this runs on the
+// request path for every proxied turn, and telemetry ID generation must
+// never crash the request.
 func generateTraceID() [16]byte {
 	var id [16]byte
-	if _, err := rand.Read(id[:]); err != nil {
-		panic("OTel: crypto/rand failed: " + err.Error())
+	if _, err := cryptoRandRead(id[:]); err != nil {
+		observability.Get().Warn("OTel: crypto/rand failed generating trace ID; falling back to math/rand/v2", "err", err)
+		fillMathRand(id[:])
 	}
 	return id
 }
 
+// generateSpanID returns a random 8-byte span ID. See generateTraceID for why
+// a crypto/rand.Read failure falls back to math/rand/v2 rather than panicking.
 func generateSpanID() [8]byte {
 	var id [8]byte
-	if _, err := rand.Read(id[:]); err != nil {
-		panic("OTel: crypto/rand failed: " + err.Error())
+	if _, err := cryptoRandRead(id[:]); err != nil {
+		observability.Get().Warn("OTel: crypto/rand failed generating span ID; falling back to math/rand/v2", "err", err)
+		fillMathRand(id[:])
 	}
 	return id
+}
+
+// fillMathRand fills buf with non-cryptographic random bytes as a best-effort
+// fallback when crypto/rand is unavailable.
+func fillMathRand(buf []byte) {
+	for i := range buf {
+		buf[i] = byte(mathrand.IntN(256))
+	}
 }
 
 // AttrBuilder constructs OTLP KeyValue attributes directly without intermediate

--- a/internal/observability/otel/spans_internal_test.go
+++ b/internal/observability/otel/spans_internal_test.go
@@ -1,0 +1,47 @@
+package otel
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// failingRandRead simulates a crypto/rand.Read failure so tests can exercise
+// the math/rand/v2 fallback path in generateTraceID/generateSpanID without
+// panicking.
+func failingRandRead(_ []byte) (int, error) {
+	return 0, errors.New("simulated crypto/rand failure")
+}
+
+func TestGenerateTraceID_FallsBackOnCryptoRandFailure(t *testing.T) {
+	orig := cryptoRandRead
+	cryptoRandRead = failingRandRead
+	defer func() { cryptoRandRead = orig }()
+
+	assert.NotPanics(t, func() {
+		id := generateTraceID()
+		assert.Len(t, id, 16)
+	})
+}
+
+func TestGenerateSpanID_FallsBackOnCryptoRandFailure(t *testing.T) {
+	orig := cryptoRandRead
+	cryptoRandRead = failingRandRead
+	defer func() { cryptoRandRead = orig }()
+
+	assert.NotPanics(t, func() {
+		id := generateSpanID()
+		assert.Len(t, id, 8)
+	})
+}
+
+func TestGenerateTraceID_SucceedsWithRealCryptoRand(t *testing.T) {
+	id := generateTraceID()
+	assert.Len(t, id, 16)
+}
+
+func TestGenerateSpanID_SucceedsWithRealCryptoRand(t *testing.T) {
+	id := generateSpanID()
+	assert.Len(t, id, 8)
+}


### PR DESCRIPTION
## Summary
- Addresses finding [67] from an internal code-quality audit: `generateTraceID` and `generateSpanID` in `internal/observability/otel/spans.go` panicked when `crypto/rand.Read` failed, and both run on the request path for every proxied turn — violating the repo's "never panic on request path" rule.
- Trace/span IDs need uniqueness, not cryptographic unpredictability, so on a `crypto/rand.Read` failure the code now logs a warning via `observability.Get().Warn(...)` (same best-effort style as `emitter.go`'s `post()`) and falls back to `math/rand/v2` instead of crashing.
- Added an unexported `cryptoRandRead` seam so tests can inject a failing reader and exercise the fallback path without a real crypto/rand failure.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/observability/...` — new tests assert no panic and a valid ID is still returned when `crypto/rand.Read` fails, plus existing-path coverage with the real reader