### PR TITLE
fix(translate): stop importing the otel adapter directly

### DIFF
--- a/internal/translate/gemini_stream.go
+++ b/internal/translate/gemini_stream.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"time"
 
-	"workweave/router/internal/observability/otel"
 	"workweave/router/internal/providers"
 	"workweave/router/internal/sse"
 
@@ -37,7 +36,7 @@ type GeminiToOpenAISSETranslator struct {
 	// sibling, held for the next tool_call chunk.
 	pendingSig string
 
-	usageSink otel.UsageSink
+	usageSink UsageSink
 
 	// onOutputProgress, set via ArmOutputProgress, fires on output-bearing events
 	// (text delta, tool-call chunk, finish) to feed the output-progress watchdog.
@@ -46,7 +45,7 @@ type GeminiToOpenAISSETranslator struct {
 }
 
 // NewGeminiToOpenAISSETranslator wraps w. Call Finalize after upstream returns.
-func NewGeminiToOpenAISSETranslator(w http.ResponseWriter, model string, sink otel.UsageSink) *GeminiToOpenAISSETranslator {
+func NewGeminiToOpenAISSETranslator(w http.ResponseWriter, model string, sink UsageSink) *GeminiToOpenAISSETranslator {
 	flusher, _ := w.(http.Flusher)
 	return &GeminiToOpenAISSETranslator{
 		inner:     w,

--- a/internal/translate/responses_to_anthropic_writer.go
+++ b/internal/translate/responses_to_anthropic_writer.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 
 	"workweave/router/internal/observability"
-	"workweave/router/internal/observability/otel"
 	"workweave/router/internal/providers"
 	"workweave/router/internal/sse"
 	"workweave/router/internal/translate/toolcheck"
@@ -29,7 +28,7 @@ type ResponsesToAnthropicWriter struct {
 	flusher      http.Flusher
 	bw           *bufio.Writer
 	requestModel string
-	usageSink    otel.UsageSink
+	usageSink    UsageSink
 	// messageID: generated fresh per response since Prelude fires message_start
 	// before upstream produces a `resp_...` id (no passthrough possible). Must
 	// be unique — clients like ccusage dedupe usage records by message id, so a
@@ -96,7 +95,7 @@ type ResponsesToAnthropicWriter struct {
 
 // NewResponsesToAnthropicWriter wraps w to translate a streaming Responses
 // upstream into Anthropic for the client.
-func NewResponsesToAnthropicWriter(w http.ResponseWriter, requestModel string, sink otel.UsageSink) *ResponsesToAnthropicWriter {
+func NewResponsesToAnthropicWriter(w http.ResponseWriter, requestModel string, sink UsageSink) *ResponsesToAnthropicWriter {
 	flusher, _ := w.(http.Flusher)
 	return &ResponsesToAnthropicWriter{
 		inner:               w,

--- a/internal/translate/stream.go
+++ b/internal/translate/stream.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"workweave/router/internal/observability"
-	"workweave/router/internal/observability/otel"
 	"workweave/router/internal/providers"
 	"workweave/router/internal/sse"
 	"workweave/router/internal/translate/toolcheck"
@@ -38,12 +37,12 @@ type SSETranslator struct {
 	toolIdx       int
 	currentIsTool bool
 
-	usageSink   otel.UsageSink
+	usageSink   UsageSink
 	inputTokens int // persists input token count from message_start for use in handleMessageDelta
 }
 
 // NewSSETranslator wraps w. Call Finalize after upstream returns.
-func NewSSETranslator(w http.ResponseWriter, model string, sink otel.UsageSink) *SSETranslator {
+func NewSSETranslator(w http.ResponseWriter, model string, sink UsageSink) *SSETranslator {
 	flusher, _ := w.(http.Flusher)
 	return &SSETranslator{
 		inner:     w,
@@ -398,7 +397,7 @@ type AnthropicSSETranslator struct {
 	messageID                string
 	modelFromUpstream        string
 
-	usageSink otel.UsageSink
+	usageSink UsageSink
 
 	// onOutputProgress fires on every output-bearing delta (text, reasoning,
 	// tool-call args, terminal finish), never on keepalives/empty deltas. Feeds
@@ -463,7 +462,7 @@ type AnthropicSSETranslator struct {
 const upstreamErrorBodyCap = 8 << 10
 
 // NewAnthropicSSETranslator wraps w. Call Finalize after upstream returns.
-func NewAnthropicSSETranslator(w http.ResponseWriter, requestModel string, sink otel.UsageSink) *AnthropicSSETranslator {
+func NewAnthropicSSETranslator(w http.ResponseWriter, requestModel string, sink UsageSink) *AnthropicSSETranslator {
 	flusher, _ := w.(http.Flusher)
 	return &AnthropicSSETranslator{
 		inner:           w,

--- a/internal/translate/usage_sink.go
+++ b/internal/translate/usage_sink.go
@@ -1,0 +1,12 @@
+package translate
+
+// UsageSink receives extracted token usage. Translators call it directly when
+// they've already parsed usage from an event, skipping a separate parse pass.
+// Declared here (not in internal/observability/otel) because translate is an
+// I/O-free inner-ring package and must not import the otel adapter; otel's
+// UsageExtractor satisfies this interface structurally, with no otel-side
+// changes needed since Go interfaces are structurally typed.
+type UsageSink interface {
+	RecordUsage(inputTokens, outputTokens int)
+	RecordCacheUsage(cacheCreationTokens, cacheReadTokens int)
+}


### PR DESCRIPTION
## Summary

- `internal/translate` is documented as an I/O-free inner-ring package in the root `CLAUDE.md`, but `internal/translate/stream.go` imported `internal/observability/otel` — an adapter package that does real OTLP HTTP export — purely to reference its `UsageSink` interface. Inner-ring packages must not import adapter packages.
- Moved the `UsageSink` interface declaration into `internal/translate` (new `internal/translate/usage_sink.go`), per the root doc's documented escape hatch ("surface as interface in appropriate inner-ring package and implement in adapter subpackage").
- `otel.UsageExtractor` already satisfies the two-method interface structurally (Go interfaces are structurally typed), so no changes were needed in `internal/observability/otel` or in `internal/proxy` (which still declares `otel.UsageSink`-typed locals and passes them into `translate`'s constructors — those remain assignable since the method sets are identical).
- Updated `internal/translate/stream.go`, `gemini_stream.go`, and `responses_to_anthropic_writer.go` (all three referenced `otel.UsageSink` the same way) to use the local `translate.UsageSink` instead, and dropped their now-unused `internal/observability/otel` imports.

Addresses finding [8] (high severity) from an internal code-quality audit: layering violation, inner-ring package importing an adapter package.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/translate/... ./internal/observability/...`
- [x] `go test ./...` (full repo suite, all green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)