### PR TITLE
fix(catalog): strip OpenAI dashed date suffixes in model ID lookup

### DIFF
--- a/internal/router/catalog/catalog_test.go
+++ b/internal/router/catalog/catalog_test.go
@@ -60,6 +60,22 @@ func TestByID_DateStrippedFallback(t *testing.T) {
 	assert.Equal(t, "claude-opus-4-7", m.ID)
 }
 
+func TestByID_OpenAIDashedDateStrippedFallback(t *testing.T) {
+	// gpt-4o-2024-08-06 is an exact dated OpenAI model ID (dashed
+	// YYYY-MM-DD suffix); it should resolve to the base "gpt-4o" catalog
+	// entry the same way router.Lookup already resolves it for capability
+	// checks. Regression test for a bug where catalog's stripper only
+	// handled Anthropic's compact 8-digit suffix and missed this shape,
+	// causing ByID/PriceFor/TierFor to report not-found for dated OpenAI IDs.
+	m, ok := ByID("gpt-4o-2024-08-06")
+	require.True(t, ok)
+	assert.Equal(t, "gpt-4o", m.ID)
+
+	p, ok := PriceFor(providers.ProviderOpenAI, "gpt-4o-2024-08-06")
+	require.True(t, ok)
+	assert.Greater(t, p.InputUSDPer1M, 0.0)
+}
+
 func TestByID_UnknownReturnsFalse(t *testing.T) {
 	_, ok := ByID("definitely-not-a-model")
 	assert.False(t, ok)

--- a/internal/router/catalog/catalog_test.go
+++ b/internal/router/catalog/catalog_test.go
@@ -61,12 +61,8 @@ func TestByID_DateStrippedFallback(t *testing.T) {
 }
 
 func TestByID_OpenAIDashedDateStrippedFallback(t *testing.T) {
-	// gpt-4o-2024-08-06 is an exact dated OpenAI model ID (dashed
-	// YYYY-MM-DD suffix); it should resolve to the base "gpt-4o" catalog
-	// entry the same way router.Lookup already resolves it for capability
-	// checks. Regression test for a bug where catalog's stripper only
-	// handled Anthropic's compact 8-digit suffix and missed this shape,
-	// causing ByID/PriceFor/TierFor to report not-found for dated OpenAI IDs.
+	// Regression: catalog's stripper previously only handled Anthropic's compact
+	// 8-digit suffix and missed OpenAI's dashed YYYY-MM-DD shape.
 	m, ok := ByID("gpt-4o-2024-08-06")
 	require.True(t, ok)
 	assert.Equal(t, "gpt-4o", m.ID)

--- a/internal/router/catalog/lookup.go
+++ b/internal/router/catalog/lookup.go
@@ -19,10 +19,7 @@ func init() {
 }
 
 // ByID returns the model with the given ID. If the exact ID isn't found,
-// retries after stripping a trailing date suffix — either Anthropic's compact
-// form (e.g. "-20251001") or OpenAI's dashed form (e.g. "-2024-08-06") — using
-// the same stripper router.Lookup uses, so capability and pricing/tier
-// lookups normalize dated model IDs identically.
+// retries after stripping a trailing Anthropic (-20251001) or OpenAI (-2024-08-06) date suffix.
 func ByID(id string) (Model, bool) {
 	if m, ok := byID[id]; ok {
 		return m, true

--- a/internal/router/catalog/lookup.go
+++ b/internal/router/catalog/lookup.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+
+	"workweave/router/internal/router"
 )
 
 // byID is built once at init from Models so accessors are O(1).
@@ -17,12 +19,15 @@ func init() {
 }
 
 // ByID returns the model with the given ID. If the exact ID isn't found,
-// retries after stripping a trailing date suffix (e.g. "-20251001").
+// retries after stripping a trailing date suffix — either Anthropic's compact
+// form (e.g. "-20251001") or OpenAI's dashed form (e.g. "-2024-08-06") — using
+// the same stripper router.Lookup uses, so capability and pricing/tier
+// lookups normalize dated model IDs identically.
 func ByID(id string) (Model, bool) {
 	if m, ok := byID[id]; ok {
 		return m, true
 	}
-	if base := stripDateSuffix(id); base != id {
+	if base := router.StripDateSuffix(id); base != id {
 		if m, ok := byID[base]; ok {
 			return m, true
 		}
@@ -228,21 +233,4 @@ func ValidateDeployed(deployed []string) error {
 	}
 	sort.Strings(missing)
 	return fmt.Errorf("catalog: deployed models missing or unconfigured — add or fix them in internal/router/catalog/catalog.go: %s", strings.Join(missing, ", "))
-}
-
-// stripDateSuffix removes a trailing "-XXXXXXXX" (hyphen + 8 digits).
-func stripDateSuffix(model string) string {
-	if len(model) < 10 {
-		return model
-	}
-	tail := model[len(model)-9:]
-	if tail[0] != '-' {
-		return model
-	}
-	for _, c := range tail[1:] {
-		if c < '0' || c > '9' {
-			return model
-		}
-	}
-	return model[:len(model)-9]
 }

--- a/internal/router/model.go
+++ b/internal/router/model.go
@@ -38,13 +38,22 @@ func NewSpec(caps ...ModelCapability) ModelSpec {
 // dateSuffix matches Anthropic (-20251001) and OpenAI (-2024-08-06) trailing date stamps.
 var dateSuffix = regexp.MustCompile(`-\d{4}-?\d{2}-?\d{2}$`)
 
+// StripDateSuffix removes a trailing Anthropic-style compact date stamp
+// (-20251001) or OpenAI-style dashed date stamp (-2024-08-06) from a model
+// ID, if present. Returns the input unchanged when no such suffix matches.
+// Shared by Lookup and catalog.ByID so both capability and pricing/tier
+// lookups normalize dated model IDs identically.
+func StripDateSuffix(model string) string {
+	return dateSuffix.ReplaceAllString(model, "")
+}
+
 // Lookup returns the spec for a known model ID. Dated variants (e.g.
 // "-20251001") fall back to the base model; unknown models get zero-value.
 func Lookup(model string) ModelSpec {
 	if s, ok := registry[model]; ok {
 		return s
 	}
-	if base := dateSuffix.ReplaceAllString(model, ""); base != model {
+	if base := StripDateSuffix(model); base != model {
 		if s, ok := registry[base]; ok {
 			return s
 		}

--- a/internal/router/model.go
+++ b/internal/router/model.go
@@ -38,11 +38,8 @@ func NewSpec(caps ...ModelCapability) ModelSpec {
 // dateSuffix matches Anthropic (-20251001) and OpenAI (-2024-08-06) trailing date stamps.
 var dateSuffix = regexp.MustCompile(`-\d{4}-?\d{2}-?\d{2}$`)
 
-// StripDateSuffix removes a trailing Anthropic-style compact date stamp
-// (-20251001) or OpenAI-style dashed date stamp (-2024-08-06) from a model
-// ID, if present. Returns the input unchanged when no such suffix matches.
-// Shared by Lookup and catalog.ByID so both capability and pricing/tier
-// lookups normalize dated model IDs identically.
+// StripDateSuffix removes a trailing Anthropic-style (-20251001) or OpenAI-style
+// (-2024-08-06) date stamp from a model ID. Returns the input unchanged when no suffix matches.
 func StripDateSuffix(model string) string {
 	return dateSuffix.ReplaceAllString(model, "")
 }


### PR DESCRIPTION
## Summary

Addresses finding **[31]** (high) from an internal code-quality audit — this is a real pricing/tier-lookup correctness bug, not just a style nit.

`catalog.stripDateSuffix` (in `internal/router/catalog/lookup.go`) only stripped Anthropic's compact 8-digit date tag (e.g. `-20251001`). It silently failed to strip OpenAI's dashed date-suffix shape (e.g. `-2024-08-06`) that `internal/router/model.go`'s regex-based stripper (`dateSuffix = regexp.MustCompile(`-\d{4}-?\d{2}-?\d{2}$`)`, used by `router.Lookup`) already handles.

Net effect: `router.Lookup` correctly resolved capabilities for exact dated OpenAI model IDs like `gpt-4o-2024-08-06`, but `catalog.ByID` / `PriceFor` / `TierFor` / `ContextWindowFor` returned not-found for the exact same IDs — meaning affected dated OpenAI model IDs could get missing/zero pricing and tier data even though the router considered them valid, known models.

## Fix

- Exported the shared stripper as `router.StripDateSuffix` in `internal/router/model.go` (same regex, `Lookup` now calls it too).
- `catalog.ByID` now imports `workweave/router/internal/router` and calls `router.StripDateSuffix` instead of its own hand-rolled 8-digit-only stripper, which is deleted.
- No import cycle: `internal/router` does not import `internal/router/catalog` anywhere, so `catalog` importing its parent package is safe.

## Test plan

- Added `TestByID_OpenAIDashedDateStrippedFallback` in `internal/router/catalog/catalog_test.go`: asserts `ByID("gpt-4o-2024-08-06")` now resolves to the base `gpt-4o` catalog entry (previously returned `ok=false`), and `PriceFor(openai, "gpt-4o-2024-08-06")` now resolves non-zero pricing.
- Existing `TestByID_DateStrippedFallback` (Anthropic compact-date shape) still passes, confirming no regression on the original behavior.
- `go build ./...`, `go vet ./...`, `go test ./internal/router/...` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)