### PR TITLE
fix(api): stop importing internal/translate directly for sentinel checks

### DIFF
--- a/internal/api/anthropic/messages.go
+++ b/internal/api/anthropic/messages.go
@@ -16,7 +16,6 @@ import (
 	"workweave/router/internal/router/cluster"
 	"workweave/router/internal/router/rl"
 	"workweave/router/internal/server/middleware"
-	"workweave/router/internal/translate"
 
 	"github.com/gin-gonic/gin"
 	"github.com/tidwall/gjson"
@@ -95,7 +94,7 @@ func MessagesHandler(svc *proxy.Service, authSvc *auth.Service) gin.HandlerFunc 
 				writeAnthropicError(c, http.StatusNotImplemented, "api_error", "Provider not implemented.")
 				return
 			}
-			if errors.Is(err, translate.ErrNotJSONObject) {
+			if errors.Is(err, proxy.ErrRequestNotJSONObject) {
 				writeAnthropicError(c, http.StatusBadRequest, "invalid_request_error", "Request body must be a JSON object.")
 				return
 			}

--- a/internal/api/gemini/generate_content.go
+++ b/internal/api/gemini/generate_content.go
@@ -16,7 +16,6 @@ import (
 	"workweave/router/internal/router/cluster"
 	"workweave/router/internal/router/rl"
 	"workweave/router/internal/server/middleware"
-	"workweave/router/internal/translate"
 
 	"github.com/gin-gonic/gin"
 	"github.com/tidwall/sjson"
@@ -91,7 +90,7 @@ func GenerateContentHandler(svc *proxy.Service, authSvc *auth.Service) gin.Handl
 				writeGeminiError(c, http.StatusBadGateway, "FAILED_PRECONDITION", "Provider not configured.")
 				return
 			}
-			if errors.Is(err, translate.ErrNotJSONObject) {
+			if errors.Is(err, proxy.ErrRequestNotJSONObject) {
 				writeGeminiError(c, http.StatusBadRequest, "INVALID_ARGUMENT", "Request body must be a JSON object.")
 				return
 			}

--- a/internal/api/openai/completions.go
+++ b/internal/api/openai/completions.go
@@ -15,7 +15,6 @@ import (
 	"workweave/router/internal/router/cluster"
 	"workweave/router/internal/router/rl"
 	"workweave/router/internal/server/middleware"
-	"workweave/router/internal/translate"
 
 	"github.com/gin-gonic/gin"
 )
@@ -62,7 +61,7 @@ func ChatCompletionHandler(svc *proxy.Service, authSvc *auth.Service) gin.Handle
 				writeOpenAIError(c, http.StatusBadGateway, "api_error", "Provider not configured.")
 				return
 			}
-			if errors.Is(err, translate.ErrNotJSONObject) {
+			if errors.Is(err, proxy.ErrRequestNotJSONObject) {
 				writeOpenAIError(c, http.StatusBadRequest, "invalid_request_error", "request body must be a JSON object")
 				return
 			}

--- a/internal/api/openai/responses.go
+++ b/internal/api/openai/responses.go
@@ -13,7 +13,6 @@ import (
 	"workweave/router/internal/router/cluster"
 	"workweave/router/internal/router/rl"
 	"workweave/router/internal/server/middleware"
-	"workweave/router/internal/translate"
 
 	"github.com/gin-gonic/gin"
 )
@@ -63,7 +62,7 @@ func ResponsesHandler(svc *proxy.Service, authSvc *auth.Service) gin.HandlerFunc
 				writeOpenAIError(c, http.StatusBadGateway, "api_error", "Provider not configured.")
 				return
 			}
-			if errors.Is(err, translate.ErrNotJSONObject) {
+			if errors.Is(err, proxy.ErrRequestNotJSONObject) {
 				writeOpenAIError(c, http.StatusBadRequest, "invalid_request_error", "request body must be a JSON object")
 				return
 			}

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -1180,6 +1180,11 @@ func (s *Service) MetricsRowsAll(ctx context.Context, from, to time.Time, limit 
 // provider that is not present in the registry.
 var ErrProviderNotConfigured = errors.New("provider not configured")
 
+// ErrRequestNotJSONObject re-exports translate.ErrNotJSONObject so that
+// internal/api/* handlers can check request-body-shape errors without
+// importing internal/translate directly (see root CLAUDE.md layering rules).
+var ErrRequestNotJSONObject = translate.ErrNotJSONObject
+
 // semanticCacheMaxBodyBytes caps how large a response the cache will store;
 // larger bodies stream through but skip the Store call to bound peak memory.
 const semanticCacheMaxBodyBytes = 1 << 20

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -1180,9 +1180,8 @@ func (s *Service) MetricsRowsAll(ctx context.Context, from, to time.Time, limit 
 // provider that is not present in the registry.
 var ErrProviderNotConfigured = errors.New("provider not configured")
 
-// ErrRequestNotJSONObject re-exports translate.ErrNotJSONObject so that
-// internal/api/* handlers can check request-body-shape errors without
-// importing internal/translate directly (see root CLAUDE.md layering rules).
+// ErrRequestNotJSONObject re-exports translate.ErrNotJSONObject so api/* handlers
+// avoid importing internal/translate directly (layering rule, root CLAUDE.md).
 var ErrRequestNotJSONObject = translate.ErrNotJSONObject
 
 // semanticCacheMaxBodyBytes caps how large a response the cache will store;


### PR DESCRIPTION
## Summary
- The `anthropic`, `openai`, and `gemini` handler packages each imported `internal/translate` solely to check `translate.ErrNotJSONObject`, repeating the "`internal/api/* must not import internal/translate directly`" layering violation documented in the root `CLAUDE.md`.
- Re-exported the sentinel as `proxy.ErrRequestNotJSONObject` (following the existing `proxy.ErrProviderNotConfigured` re-export convention) and updated all 4 call sites (`internal/api/anthropic/messages.go`, `internal/api/openai/completions.go`, `internal/api/openai/responses.go`, `internal/api/gemini/generate_content.go`) to check `errors.Is(err, proxy.ErrRequestNotJSONObject)` instead, removing the now-unused `translate` import from each.

Addresses finding [54] from an internal code-quality audit.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/api/... ./internal/proxy/...`
- [x] `go test ./...` (full suite)

🤖 Generated with [Claude Code](https://claude.com/claude-code)