### PR TITLE
fix(proxy): disambiguate router.feedback span name across two pipelines

### DIFF
--- a/internal/proxy/feedback_span_names_test.go
+++ b/internal/proxy/feedback_span_names_test.go
@@ -86,12 +86,9 @@ func newTestEmitter(t *testing.T, endpoint string) *otel.Emitter {
 	return em
 }
 
-// TestFeedbackSpans_UseDistinctNamesAndSchemas guards against the two
-// independent feedback pipelines colliding on the OTLP span name
-// "router.feedback" (finding [28]): the signed-link pipeline
-// (Service.SubmitFeedback) owns that name as a documented contract the Weave
-// backend's buildFeedbackRow reads, while the /router-feedback slash-command
-// pipeline must emit under its own distinct name with its own schema.
+// TestFeedbackSpans_UseDistinctNamesAndSchemas guards against the two feedback
+// pipelines colliding on "router.feedback": the signed-link pipeline owns that
+// name as a downstream contract; the /router-feedback command must use its own.
 func TestFeedbackSpans_UseDistinctNamesAndSchemas(t *testing.T) {
 	collector := newSpanCollector(t)
 	emitter := newTestEmitter(t, collector.srv.URL)

--- a/internal/proxy/feedback_span_names_test.go
+++ b/internal/proxy/feedback_span_names_test.go
@@ -1,0 +1,181 @@
+package proxy_test
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	feedbacktoken "workweave/router/internal/feedback"
+	"workweave/router/internal/observability/otel"
+	"workweave/router/internal/providers"
+	"workweave/router/internal/proxy"
+	"workweave/router/internal/router"
+	"workweave/router/internal/router/sessionpin"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+
+	coltracepb "go.opentelemetry.io/proto/otlp/collector/trace/v1"
+	commonv1 "go.opentelemetry.io/proto/otlp/common/v1"
+	tracev1 "go.opentelemetry.io/proto/otlp/trace/v1"
+)
+
+// spanCollector runs an httptest server that decodes OTLP/HTTP trace export
+// requests and records every span it receives, keyed by name.
+type spanCollector struct {
+	srv *httptest.Server
+	mu  sync.Mutex
+	byName map[string][]*tracev1.Span
+}
+
+func newSpanCollector(t *testing.T) *spanCollector {
+	t.Helper()
+	c := &spanCollector{byName: make(map[string][]*tracev1.Span)}
+	c.srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		var req coltracepb.ExportTraceServiceRequest
+		require.NoError(t, proto.Unmarshal(body, &req))
+		c.mu.Lock()
+		for _, rs := range req.ResourceSpans {
+			for _, ss := range rs.ScopeSpans {
+				for _, sp := range ss.Spans {
+					c.byName[sp.Name] = append(c.byName[sp.Name], sp)
+				}
+			}
+		}
+		c.mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(c.srv.Close)
+	return c
+}
+
+// attrString returns the string value of the named attribute on the span, or
+// "" (and false) if it isn't present.
+func attrString(sp *tracev1.Span, key string) (string, bool) {
+	for _, kv := range sp.Attributes {
+		if kv.Key != key {
+			continue
+		}
+		if sv, ok := kv.Value.Value.(*commonv1.AnyValue_StringValue); ok {
+			return sv.StringValue, true
+		}
+	}
+	return "", false
+}
+
+func newTestEmitter(t *testing.T, endpoint string) *otel.Emitter {
+	t.Helper()
+	em, err := otel.NewEmitter(otel.EmitterConfig{
+		Endpoint:      endpoint,
+		Workers:       1,
+		QueueSize:     100,
+		BatchSize:     1,
+		FlushInterval: 10 * time.Millisecond,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = em.Shutdown(context.Background()) })
+	return em
+}
+
+// TestFeedbackSpans_UseDistinctNamesAndSchemas guards against the two
+// independent feedback pipelines colliding on the OTLP span name
+// "router.feedback" (finding [28]): the signed-link pipeline
+// (Service.SubmitFeedback) owns that name as a documented contract the Weave
+// backend's buildFeedbackRow reads, while the /router-feedback slash-command
+// pipeline must emit under its own distinct name with its own schema.
+func TestFeedbackSpans_UseDistinctNamesAndSchemas(t *testing.T) {
+	collector := newSpanCollector(t)
+	emitter := newTestEmitter(t, collector.srv.URL)
+
+	// --- Pipeline A: signed feedback-link submission ---
+	repo := &fakeFeedbackRepoForSpanTest{}
+	signer := feedbacktoken.NewSigner("secret", time.Hour)
+	linkSvc := proxy.NewService(nil, nil, emitter, false, nil, nil, false, "", "", nil).
+		WithFeedback(repo, signer, "https://router.example.com")
+
+	err := linkSvc.SubmitFeedback(context.Background(), proxy.SubmitFeedbackParams{
+		InstallationID: "inst-1",
+		ExternalID:     "org-1",
+		RequestID:      "req-1",
+		RouterUserID:   "user-1",
+		Rating:         "down",
+	})
+	require.NoError(t, err)
+
+	// --- Pipeline B: /router-feedback slash command ---
+	store := newFakePinStore()
+	store.hasPin = true
+	store.pin = sessionpin.Pin{Provider: providers.ProviderAnthropic, Model: "claude-haiku-4-5", LastServedModel: "claude-haiku-4-5"}
+	feedbackStore := &fakeFeedbackStore{}
+	fr := &fakeRouter{decision: router.Decision{Provider: providers.ProviderAnthropic, Model: "claude-sonnet-4-6", Reason: "cluster"}}
+	cmdSvc := proxy.NewService(
+		fr,
+		map[string]providers.Client{providers.ProviderAnthropic: &fakeProvider{}},
+		emitter,
+		false,
+		nil,
+		store,
+		false,
+		providers.ProviderAnthropic,
+		"claude-haiku-4-5",
+		nil,
+	).WithRouterFeedbackStore(feedbackStore)
+
+	const body = `{
+		"model":"claude-sonnet-4-6",
+		"max_tokens":1024,
+		"messages":[
+			{"role":"user","content":"/router-feedback got stuck on Haiku for too long"}
+		]
+	}`
+	ctx := context.WithValue(context.Background(), proxy.APIKeyIDContextKey{}, "key-1")
+	ctx = context.WithValue(ctx, proxy.InstallationIDContextKey{}, uuid.New().String())
+	rec := httptest.NewRecorder()
+	httpReq := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(""))
+	require.NoError(t, cmdSvc.ProxyMessages(ctx, []byte(body), rec, httpReq))
+
+	// Force both buffers to flush and the emitter to export before asserting.
+	require.NoError(t, emitter.Shutdown(context.Background()))
+
+	collector.mu.Lock()
+	defer collector.mu.Unlock()
+
+	linkSpans := collector.byName["router.feedback"]
+	cmdSpans := collector.byName["router.feedback.command"]
+	require.Len(t, linkSpans, 1, "signed-link pipeline must emit exactly one router.feedback span")
+	require.Len(t, cmdSpans, 1, "/router-feedback command must emit exactly one router.feedback.command span")
+
+	// The documented-contract span (router.feedback) always carries a rating.
+	rating, ok := attrString(linkSpans[0], "feedback.rating")
+	assert.True(t, ok, "router.feedback span must carry feedback.rating (Weave contract)")
+	assert.Equal(t, "down", rating)
+
+	// The two pipelines must not collide under the same span name.
+	assert.NotEqual(t, linkSpans[0].Name, cmdSpans[0].Name)
+
+	// The command pipeline's span has its own, unrelated schema (e.g. carries
+	// client.app, which the link pipeline's contract never emits).
+	_, cmdHasClientApp := attrString(cmdSpans[0], "client.app")
+	assert.True(t, cmdHasClientApp, "router.feedback.command span should carry client.app")
+	_, linkHasClientApp := attrString(linkSpans[0], "client.app")
+	assert.False(t, linkHasClientApp, "router.feedback span schema must stay untouched by the command pipeline's fields")
+}
+
+type fakeFeedbackRepoForSpanTest struct{}
+
+func (f *fakeFeedbackRepoForSpanTest) Upsert(_ context.Context, _ proxy.UpsertFeedbackParams) error {
+	return nil
+}
+
+func (f *fakeFeedbackRepoForSpanTest) GetContext(_ context.Context, _, _ string) (proxy.FeedbackContext, error) {
+	return proxy.FeedbackContext{}, nil
+}

--- a/internal/proxy/feedback_span_names_test.go
+++ b/internal/proxy/feedback_span_names_test.go
@@ -30,8 +30,8 @@ import (
 // spanCollector runs an httptest server that decodes OTLP/HTTP trace export
 // requests and records every span it receives, keyed by name.
 type spanCollector struct {
-	srv *httptest.Server
-	mu  sync.Mutex
+	srv    *httptest.Server
+	mu     sync.Mutex
 	byName map[string][]*tracev1.Span
 }
 

--- a/internal/proxy/router_feedback.go
+++ b/internal/proxy/router_feedback.go
@@ -16,15 +16,10 @@ import (
 	"github.com/google/uuid"
 )
 
-// routerFeedbackCommandSpanName is the OTLP span the /router-feedback (aka
-// /rf) slash command emits. This is a distinct span from routerFeedbackSpanName
-// ("router.feedback", defined in feedback.go): that name is the documented
-// contract the Weave backend's buildFeedbackRow reads to populate
-// router.request_feedback, and it always carries a feedback.rating attribute.
-// This command path persists into the separate router.router_feedback table
-// (DB write is authoritative; this span is best-effort mirroring/observability
-// only) and has its own, incompatible attribute schema — do not reuse
-// "router.feedback" here, and do not change routerFeedbackSpanName's schema.
+// routerFeedbackCommandSpanName is the OTLP span for the /router-feedback (/rf)
+// slash command. Distinct from routerFeedbackSpanName ("router.feedback" in
+// feedback.go), which is a downstream contract (buildFeedbackRow); do not reuse
+// that name or alter its schema.
 const routerFeedbackCommandSpanName = "router.feedback.command"
 
 // RouterFeedbackStore persists /router-feedback submissions durably

--- a/internal/proxy/router_feedback.go
+++ b/internal/proxy/router_feedback.go
@@ -16,6 +16,17 @@ import (
 	"github.com/google/uuid"
 )
 
+// routerFeedbackCommandSpanName is the OTLP span the /router-feedback (aka
+// /rf) slash command emits. This is a distinct span from routerFeedbackSpanName
+// ("router.feedback", defined in feedback.go): that name is the documented
+// contract the Weave backend's buildFeedbackRow reads to populate
+// router.request_feedback, and it always carries a feedback.rating attribute.
+// This command path persists into the separate router.router_feedback table
+// (DB write is authoritative; this span is best-effort mirroring/observability
+// only) and has its own, incompatible attribute schema — do not reuse
+// "router.feedback" here, and do not change routerFeedbackSpanName's schema.
+const routerFeedbackCommandSpanName = "router.feedback.command"
+
 // RouterFeedbackStore persists /router-feedback submissions durably
 // (router.router_feedback). Nil degrades to span + log only.
 type RouterFeedbackStore interface {
@@ -41,8 +52,8 @@ type RouterFeedbackEvent struct {
 }
 
 // handleRouterFeedbackCommand persists a /router-feedback submission, emits a
-// router.feedback span on the standard OTel pipeline, and returns a synthetic
-// acknowledgment without dispatching to any upstream.
+// router.feedback.command span on the standard OTel pipeline, and returns a
+// synthetic acknowledgment without dispatching to any upstream.
 func (s *Service) handleRouterFeedbackCommand(
 	ctx context.Context,
 	w http.ResponseWriter,
@@ -108,7 +119,7 @@ func (s *Service) handleRouterFeedbackCommand(
 
 	now := time.Now()
 	otel.Record(ctx, otel.Span{
-		Name:  "router.feedback",
+		Name:  routerFeedbackCommandSpanName,
 		Start: now,
 		End:   now,
 		Attrs: otel.NewAttrBuilder(11).
@@ -127,7 +138,7 @@ func (s *Service) handleRouterFeedbackCommand(
 	})
 	otel.Flush(ctx)
 
-	log.Info("router.feedback",
+	log.Info("router.feedback.command",
 		"rating", rating,
 		"feedback", feedback,
 		"served_model", servedModel,


### PR DESCRIPTION
## Summary

Fixes finding **[28]** (high, observability data integrity) from an internal code-quality audit: `internal/proxy/router_feedback.go:108` and `internal/proxy/feedback.go:148` were two independent feedback pipelines both emitting OTLP spans under the identical literal name `"router.feedback"`, with non-overlapping, incompatible attribute schemas.

- `internal/proxy/feedback.go` (`Service.SubmitFeedback` → `emitFeedbackSpan`), triggered by the signed no-login feedback-link flow (`/v1/feedback/link`). Its doc comment states explicitly: *"The attribute keys are the contract the Weave backend's buildFeedbackRow reads."* This span backs `router.request_feedback` (see migration `0024_request-feedback.up.sql`, whose column comment references this exact span). **Left unchanged.**
- `internal/proxy/router_feedback.go` (`handleRouterFeedbackCommand`), triggered by the `/router-feedback` (alias `/rf`) slash command. It persists to the separate `router.router_feedback` table (DB write authoritative; span is "best-effort mirroring" per the existing comment in `service.go`: *"Nil degrades to span + log only"*). Its schema (client.app, client.session_id, requested.model, feedback.served_model, feedback.role, feedback.text, …) has no doc comment claiming it's a downstream contract. **Renamed** its span (and the companion log line) from `router.feedback` → `router.feedback.command`, matching this repo's existing flat `router.<noun>` / `router.<noun>_<noun>` span-naming convention (`router.cache_hit`, `router.usage_bypass`, `router.upstream`, `router.decision`, `router.call`).

### Confidence / review flag

**High confidence** that `internal/proxy/feedback.go`'s span is the authoritative/documented one and `router_feedback.go`'s is the one that drifted:
- Only `feedback.go` has explicit "this is the contract a downstream reader parses" language in its doc comment.
- `db/migrations/0024_request-feedback.up.sql` independently documents `router.request_feedback` as populated from "the router.feedback OTLP span" — matching the link-based flow's target table, not the command's.
- `router_feedback.go`'s own comments describe its span as best-effort/degraded, not as a contract.

I could **not** verify from this repo alone how the downstream Weave-monorepo consumer (`buildFeedbackRow`) is implemented — that code isn't in this repository. **Flagging for extra review scrutiny** given this affects a downstream data pipeline; if anyone knows the consumer also read `router.feedback` spans looking for the command-pipeline's fields (e.g. `client.app`, `requested.model`), that would change the picture, but nothing in this repo suggests that.

## Changes

- `internal/proxy/router_feedback.go`: new `routerFeedbackCommandSpanName = "router.feedback.command"` constant (with a doc comment cross-referencing `routerFeedbackSpanName` in `feedback.go` and explaining why the two must stay separate); span emission and log line updated to use the new name.
- `internal/proxy/feedback_span_names_test.go` (new): end-to-end regression test that spins up a real `otel.Emitter` against an `httptest.Server` OTLP collector, drives both pipelines (`Service.SubmitFeedback` and the `/router-feedback` command via `ProxyMessages`), and asserts each emits exactly one span under its own name with its own schema — `router.feedback` always carries `feedback.rating` and never `client.app`; `router.feedback.command` carries `client.app` and is a distinct span name.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/proxy/...` — all pass, including new `TestFeedbackSpans_UseDistinctNamesAndSchemas`