### PR TITLE
fix(cluster): stop warning on the bundle's own baked-in alpha defaults

### DIFF
--- a/internal/router/cluster/scorer.go
+++ b/internal/router/cluster/scorer.go
@@ -646,6 +646,14 @@ func (s *Scorer) Route(ctx context.Context, req router.Request) (router.Decision
 
 	if s.isV2 {
 		// 1. Resolve Knobs and Validate
+		//
+		// defaultKnobs is kept alongside activeKnobs (both fresh clones from
+		// defaultActiveKnobs) so the extreme-value check below can tell a
+		// request-level override apart from the bundle's own baked-in
+		// defaults -- a bundle is allowed to ship an alpha > 0.9 on some
+		// clusters by design, and that's not something an operator can act
+		// on, so it must never WARN.
+		defaultKnobs := s.defaultActiveKnobs()
 		activeKnobs := s.defaultActiveKnobs()
 
 		if req.RoutingKnobs != nil {
@@ -692,6 +700,14 @@ func (s *Scorer) Route(ctx context.Context, req router.Request) (router.Decision
 		if activeKnobs.SpeedWeight < 0 || activeKnobs.SpeedWeight > 1 {
 			return router.Decision{}, fmt.Errorf("%w: speed_weight (%f) must be in [0, 1]", ErrInvalidRoutingKnobs, activeKnobs.SpeedWeight)
 		}
+		// speedWeightOverridden is request-scoped (SpeedWeight is a single
+		// scalar, not per-cluster), so it's resolved once outside the loop.
+		speedWeightOverridden := activeKnobs.SpeedWeight != defaultKnobs.SpeedWeight
+
+		var extremeAlphaClusters []int
+		var extremeAlphaValues []float64
+		var extremeAlphaSpeedClusters []int
+		var extremeAlphaSpeedValues []float64
 		for i, a := range activeKnobs.Alpha {
 			if a < 0 || a > 1 {
 				return router.Decision{}, fmt.Errorf("%w: alpha[%d] (%f) must be in [0, 1]", ErrInvalidRoutingKnobs, i, a)
@@ -699,12 +715,37 @@ func (s *Scorer) Route(ctx context.Context, req router.Request) (router.Decision
 			if a+activeKnobs.SpeedWeight > 1.0+1e-9 {
 				return router.Decision{}, fmt.Errorf("%w: alpha[%d] (%f) + speed_weight (%f) must be <= 1.0", ErrInvalidRoutingKnobs, i, a, activeKnobs.SpeedWeight)
 			}
-			if a > 0.9 {
-				log.Warn("Extreme routing knob: alpha > 0.9", "cluster", i, "alpha", a)
+			// Only flag a cluster as "extreme" if the request actually moved
+			// it away from the bundle's own default -- otherwise this fires
+			// on every request for a bundle that simply ships a high alpha
+			// on some clusters by design, drowning out genuinely actionable
+			// WARNs. Aggregated below into a single log line per bundle.
+			alphaOverridden := a != defaultKnobs.Alpha[i]
+			if alphaOverridden && a > 0.9 {
+				extremeAlphaClusters = append(extremeAlphaClusters, i)
+				extremeAlphaValues = append(extremeAlphaValues, a)
 			}
-			if a+activeKnobs.SpeedWeight > 0.95 {
-				log.Warn("Extreme routing knob: alpha + speed_weight > 0.95", "cluster", i, "alpha", a, "speed_weight", activeKnobs.SpeedWeight)
+			if (alphaOverridden || speedWeightOverridden) && a+activeKnobs.SpeedWeight > 0.95 {
+				extremeAlphaSpeedClusters = append(extremeAlphaSpeedClusters, i)
+				extremeAlphaSpeedValues = append(extremeAlphaSpeedValues, a)
 			}
+		}
+		if len(extremeAlphaClusters) > 0 {
+			log.Warn(
+				"Extreme routing knob override: alpha > 0.9",
+				"clusters", extremeAlphaClusters,
+				"alphas", extremeAlphaValues,
+				"count", len(extremeAlphaClusters),
+			)
+		}
+		if len(extremeAlphaSpeedClusters) > 0 {
+			log.Warn(
+				"Extreme routing knob override: alpha + speed_weight > 0.95",
+				"clusters", extremeAlphaSpeedClusters,
+				"alphas", extremeAlphaSpeedValues,
+				"speed_weight", activeKnobs.SpeedWeight,
+				"count", len(extremeAlphaSpeedClusters),
+			)
 		}
 		if activeKnobs.OutputCostRatio < 0 || activeKnobs.OutputCostRatio > 10 {
 			return router.Decision{}, fmt.Errorf("%w: output_cost_ratio (%f) must be in [0, 10]", ErrInvalidRoutingKnobs, activeKnobs.OutputCostRatio)

--- a/internal/router/cluster/scorer_test.go
+++ b/internal/router/cluster/scorer_test.go
@@ -3,7 +3,9 @@ package cluster
 import (
 	"context"
 	"errors"
+	"log/slog"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -1630,4 +1632,103 @@ func TestInvalidEffectiveKnobs(t *testing.T) {
 			assert.ErrorIs(t, err, ErrInvalidRoutingKnobs, "%s must return ErrInvalidRoutingKnobs", tc.name)
 		})
 	}
+}
+
+// capturingHandler is a minimal slog.Handler that records every emitted
+// record so tests can assert on WARN volume without parsing stderr.
+type capturingHandler struct {
+	mu      sync.Mutex
+	records []slog.Record
+}
+
+func (h *capturingHandler) Enabled(context.Context, slog.Level) bool { return true }
+
+func (h *capturingHandler) Handle(_ context.Context, r slog.Record) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.records = append(h.records, r)
+	return nil
+}
+
+func (h *capturingHandler) WithAttrs(_ []slog.Attr) slog.Handler { return h }
+func (h *capturingHandler) WithGroup(_ string) slog.Handler      { return h }
+
+func (h *capturingHandler) warnRecords() []slog.Record {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	var out []slog.Record
+	for _, r := range h.records {
+		if r.Level == slog.LevelWarn {
+			out = append(out, r)
+		}
+	}
+	return out
+}
+
+// withCapturedLogs swaps in a capturingHandler as the slog default for the
+// duration of the test (observability.Get() reads slog.Default()) and
+// restores the previous default on cleanup.
+func withCapturedLogs(t *testing.T) *capturingHandler {
+	t.Helper()
+	h := &capturingHandler{}
+	prev := slog.Default()
+	slog.SetDefault(slog.New(h))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+	return h
+}
+
+// TestExtremeRoutingKnobWarnOnlyOnOverride is the regression test for the
+// "extreme routing knob" WARN spam finding: a bundle is allowed to ship an
+// alpha > 0.9 on some clusters by design (e.g. v0.70), and that must never
+// WARN on a default request -- only a request that actually overrides a
+// value into extreme territory should.
+func TestExtremeRoutingKnobWarnOnlyOnOverride(t *testing.T) {
+	// Bundle default alpha is already > 0.9 on both clusters, mirroring the
+	// deployed v0.70 bundle shape that triggered the original spam.
+	extremeDefaults := &DefaultRoutingKnobs{
+		Alpha:                []float64{0.95, 0.95},
+		SpeedWeight:          0.0,
+		OutputCostRatio:      0.0,
+		ExpectedOutputTokens: 2000,
+		PerModelVerbosity:    false,
+	}
+
+	t.Run("bundle's own extreme defaults never warn", func(t *testing.T) {
+		emb := &fakeEmbedder{vec: makeOpusVec()}
+		scorer := newV2BundleForTest(t, emb, v2BundleOpts{defaultKnobs: extremeDefaults})
+		handler := withCapturedLogs(t)
+
+		_, err := scorer.Route(context.Background(), router.Request{PromptText: "test"})
+		require.NoError(t, err)
+
+		assert.Empty(t, handler.warnRecords(), "bundle's own baked-in defaults must not produce an extreme-knob WARN")
+	})
+
+	t.Run("request override into extreme territory still warns, aggregated", func(t *testing.T) {
+		emb := &fakeEmbedder{vec: makeOpusVec()}
+		// Start from a non-extreme default so the override is unambiguously
+		// the thing that pushes both clusters over the threshold.
+		scorer := newV2BundleForTest(t, emb, v2BundleOpts{})
+		handler := withCapturedLogs(t)
+
+		alphaVal := 0.99
+		_, err := scorer.Route(context.Background(), router.Request{
+			PromptText: "test",
+			RoutingKnobs: &router.Overrides{
+				Alpha: &alphaVal,
+			},
+		})
+		require.NoError(t, err)
+
+		// alpha=0.99 trips both the alpha>0.9 check and the
+		// alpha+speed_weight>0.95 check, but each check aggregates across
+		// clusters into a single line -- so 2 clusters overridden into
+		// extreme territory produces exactly 2 WARN lines (one per check),
+		// not 4 (one per cluster per check).
+		warns := handler.warnRecords()
+		require.Len(t, warns, 2, "each extreme-knob check must aggregate across clusters into a single WARN line")
+		for _, w := range warns {
+			assert.Contains(t, w.Message, "Extreme routing knob override")
+		}
+	})
 }


### PR DESCRIPTION
## Summary

Fixes finding **[38]** (high, internal code-quality audit) in `internal/router/cluster/scorer.go`.

The "extreme routing knob" WARN check iterated the *full* effective alpha vector — including the bundle's own baked-in defaults, not just request-level overrides. On the deployed v0.70 bundle, 11 of 16 clusters ship a default alpha of 0.96 (by design — see `metadata.yaml`'s `default_routing_knobs.alpha` comments), which trips both the `alpha > 0.9` check and the `alpha + speed_weight > 0.95` check. That's **22 WARN lines fired on every single default request**, describing the bundle's own intended configuration as an anomaly and drowning out genuinely actionable WARNs.

## Fix

- Keep a fresh clone of the bundle's default knobs (`defaultKnobs`) alongside the resolved `activeKnobs`.
- Only flag a cluster as "extreme" when the *effective* value actually differs from the bundle's own default for that cluster (i.e. the request overrode it) **and** the effective value is extreme.
- Aggregate all affected clusters into a single structured WARN line per check (clusters + values + count) instead of one WARN per cluster.
- No routing/scoring logic touched — only the logging path. Thresholds (`0.9`, `0.95`) and validation errors are unchanged.

## Verification

Loaded the real `v0.70` bundle artifact (`internal/router/cluster/artifacts/v0.70`) and routed a plain default request (no `RoutingKnobs`):

| | WARN lines |
|---|---|
| Before | 22 |
| After | 0 |

A request that actually overrides alpha into extreme territory (e.g. `Alpha: 0.99`) still produces WARNs — aggregated into 2 lines (one per check) instead of up to 32 (one per cluster per check on a K=16 bundle).

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` (all packages pass)
- [x] New test `TestExtremeRoutingKnobWarnOnlyOnOverride` in `internal/router/cluster/scorer_test.go`:
  - bundle defaults with alpha=0.95 on every cluster → 0 WARNs
  - request override to alpha=0.99 → exactly 2 aggregated WARNs (not one per cluster)
- [x] Manually verified 22→0 WARN reduction against the real v0.70 bundle (scratch test, not committed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)