### PR TITLE
fix(reliability): recover from panics in remaining fire-and-forget goroutines

### DIFF
--- a/cmd/router/main.go
+++ b/cmd/router/main.go
@@ -424,7 +424,7 @@ func main() {
 		listenerCancel()
 		listener.Wait()
 	}()
-	go listener.Run(listenerCtx)
+	safeGo(logger, "invalidation-listener", func() { listener.Run(listenerCtx) })
 
 	// Managed mode doesn't mount the dashboard, so this only matters selfhosted.
 	if deploymentMode == server.DeploymentModeSelfHosted {
@@ -467,7 +467,7 @@ func main() {
 	var pinStore sessionpin.Store
 	if config.GetOr("ROUTER_SESSION_PIN_ENABLED", "true") == "true" {
 		pinStore = postgres.NewSessionPinRepo(pool)
-		go runSessionPinSweep(context.Background(), pinStore)
+		safeGo(logger, "session-pin-sweep", func() { runSessionPinSweep(context.Background(), pinStore) })
 		logger.Info("Session pin store enabled (sliding 1h TTL, hourly sweep)")
 	}
 
@@ -1202,6 +1202,20 @@ func buildSemanticCache(rtr router.Router) *cache.Cache {
 		"version", multi.Default,
 	)
 	return cache.New(cfg)
+}
+
+// safeGo launches fn in a goroutine with panic recovery so a bug in a
+// long-running background task (Pub/Sub listener, sweep loop, etc.) logs and
+// dies quietly instead of crashing the whole process.
+func safeGo(logger *slog.Logger, name string, fn func()) {
+	go func() {
+		defer func() {
+			if r := recover(); r != nil {
+				logger.Error("Background goroutine panicked", "goroutine", name, "panic", r)
+			}
+		}()
+		fn()
+	}()
 }
 
 // runSessionPinSweep deletes pins expired >24h on an hourly cadence. Uses

--- a/internal/auth/service.go
+++ b/internal/auth/service.go
@@ -415,6 +415,11 @@ func userIdentityKey(email, claudeAccountUUID string) string {
 // the parent ctx is often canceled (response written) before the UPDATE completes.
 func (s *Service) fireMarkUsed(apiKeyID string) {
 	go func() {
+		defer func() {
+			if r := recover(); r != nil {
+				observability.Get().Error("panic in fireMarkUsed", "panic", r, "api_key_id", apiKeyID)
+			}
+		}()
 		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 		defer cancel()
 		if err := s.apiKeys.MarkUsed(ctx, apiKeyID); err != nil {

--- a/internal/auth/service_test.go
+++ b/internal/auth/service_test.go
@@ -22,9 +22,7 @@ type fakeAPIKeyRepository struct {
 	byHash   map[string]fakeKeyRow
 	override error
 
-	// markUsedPanic simulates a bug in the underlying MarkUsed implementation
-	// so tests can assert the async fireMarkUsed goroutine recovers instead
-	// of crashing the process.
+	// markUsedPanic, when true, causes MarkUsed to panic so fireMarkUsed recovery can be exercised.
 	markUsedPanic bool
 
 	mu       sync.Mutex
@@ -429,10 +427,8 @@ func TestService_VerifyAPIKey_RecoversFromMarkUsedPanic(t *testing.T) {
 	svc, apiKeys := makeService(t, fakeKeyRow{apiKey: wantKey, installation: wantInstall})
 	apiKeys.markUsedPanic = true
 
-	// Force observability's lazy sync.Once init to run before we override the
-	// default logger below — otherwise the first-ever Get() call (which may
-	// happen inside the async fireMarkUsed goroutine) races our SetDefault
-	// and clobbers it back to the production handler.
+	// Prime observability's sync.Once before overriding slog.Default; otherwise the goroutine's
+	// first Get() call races SetDefault and resets the handler.
 	observability.Get()
 
 	var buf bytes.Buffer

--- a/internal/auth/service_test.go
+++ b/internal/auth/service_test.go
@@ -1,14 +1,18 @@
 package auth_test
 
 import (
+	"bytes"
 	"context"
 	"database/sql"
 	"errors"
+	"log/slog"
+	"strings"
 	"sync"
 	"testing"
 	"time"
 
 	"workweave/router/internal/auth"
+	"workweave/router/internal/observability"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -17,6 +21,11 @@ import (
 type fakeAPIKeyRepository struct {
 	byHash   map[string]fakeKeyRow
 	override error
+
+	// markUsedPanic simulates a bug in the underlying MarkUsed implementation
+	// so tests can assert the async fireMarkUsed goroutine recovers instead
+	// of crashing the process.
+	markUsedPanic bool
 
 	mu       sync.Mutex
 	markUsed []string
@@ -55,6 +64,9 @@ func (f *fakeAPIKeyRepository) ListForInstallation(ctx context.Context, installa
 }
 
 func (f *fakeAPIKeyRepository) MarkUsed(ctx context.Context, id string) error {
+	if f.markUsedPanic {
+		panic("boom: mark used")
+	}
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.markUsed = append(f.markUsed, id)
@@ -391,6 +403,54 @@ func TestService_VerifyAPIKey_HappyPathReturnsInstallationAndKey(t *testing.T) {
 		return len(snap) == 1 && snap[0] == "key_xyz"
 	}, 500*time.Millisecond, 10*time.Millisecond,
 		"VerifyAPIKey must asynchronously call MarkUsed with the matched key id")
+}
+
+func TestService_VerifyAPIKey_RecoversFromMarkUsedPanic(t *testing.T) {
+	rawToken := "rk_panic_token_for_test_only"
+	keyHash := auth.HashAPIKeySHA256(rawToken)
+
+	wantInstall := &auth.Installation{
+		ID:         "install_panic",
+		ExternalID: "org_panic",
+		Name:       "panic-api",
+		CreatedAt:  time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+		UpdatedAt:  time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+	}
+	wantKey := &auth.APIKey{
+		ID:             "key_panic",
+		InstallationID: wantInstall.ID,
+		ExternalID:     wantInstall.ExternalID,
+		KeyPrefix:      "rk_",
+		KeyHash:        keyHash,
+		KeySuffix:      "only",
+		CreatedAt:      time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+	}
+
+	svc, apiKeys := makeService(t, fakeKeyRow{apiKey: wantKey, installation: wantInstall})
+	apiKeys.markUsedPanic = true
+
+	// Force observability's lazy sync.Once init to run before we override the
+	// default logger below — otherwise the first-ever Get() call (which may
+	// happen inside the async fireMarkUsed goroutine) races our SetDefault
+	// and clobbers it back to the production handler.
+	observability.Get()
+
+	var buf bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, nil)))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+
+	require.NotPanics(t, func() {
+		gotInstall, gotKey, _, err := svc.VerifyAPIKey(context.Background(), rawToken)
+		require.NoError(t, err)
+		require.NotNil(t, gotInstall)
+		require.NotNil(t, gotKey)
+	}, "a panicking MarkUsed must not crash the request path")
+
+	require.Eventually(t, func() bool {
+		return strings.Contains(buf.String(), "panic in fireMarkUsed")
+	}, 500*time.Millisecond, 10*time.Millisecond,
+		"the async fireMarkUsed goroutine must recover and log the panic")
 }
 
 func makeServiceWithCacheAndCounter(t *testing.T, cache auth.APIKeyCache, rows ...fakeKeyRow) (*auth.Service, *repoCallCounter) {

--- a/internal/proxy/fire_telemetry_panic_internal_test.go
+++ b/internal/proxy/fire_telemetry_panic_internal_test.go
@@ -48,10 +48,8 @@ func (panicTelemetryRepo) GetTelemetryRowsAll(ctx context.Context, from, to time
 // TestFireTelemetryRecoversFromPanic proves a panic inside the async
 // telemetry insert is caught and logged instead of crashing the process.
 func TestFireTelemetryRecoversFromPanic(t *testing.T) {
-	// Force observability's lazy sync.Once init to run before we override the
-	// default logger below — otherwise the first-ever Get() call (which may
-	// happen inside the async fireTelemetry goroutine) races our SetDefault
-	// and clobbers it back to the production handler.
+	// Prime observability's sync.Once before overriding slog.Default; otherwise the goroutine's
+	// first Get() call races SetDefault and resets the handler.
 	observability.Get()
 
 	var buf bytes.Buffer

--- a/internal/proxy/fire_telemetry_panic_internal_test.go
+++ b/internal/proxy/fire_telemetry_panic_internal_test.go
@@ -1,0 +1,77 @@
+package proxy
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+
+	"workweave/router/internal/observability"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// panicTelemetryRepo is a TelemetryRepository whose InsertRequestTelemetry
+// always panics, simulating a bug in the telemetry sink.
+type panicTelemetryRepo struct{}
+
+func (panicTelemetryRepo) InsertRequestTelemetry(ctx context.Context, p InsertTelemetryParams) error {
+	panic("boom: telemetry insert")
+}
+
+func (panicTelemetryRepo) GetTelemetrySummary(ctx context.Context, installationID string, from, to time.Time) (TelemetrySummary, error) {
+	return TelemetrySummary{}, nil
+}
+
+func (panicTelemetryRepo) GetTelemetryTimeseries(ctx context.Context, installationID string, from, to time.Time, granularity string) ([]TelemetryBucket, error) {
+	return nil, nil
+}
+
+func (panicTelemetryRepo) GetTelemetrySummaryAll(ctx context.Context, from, to time.Time) (TelemetrySummary, error) {
+	return TelemetrySummary{}, nil
+}
+
+func (panicTelemetryRepo) GetTelemetryTimeseriesAll(ctx context.Context, from, to time.Time, granularity string) ([]TelemetryBucket, error) {
+	return nil, nil
+}
+
+func (panicTelemetryRepo) GetTelemetryRows(ctx context.Context, installationID string, from, to time.Time, limit int32) ([]TelemetryRow, error) {
+	return nil, nil
+}
+
+func (panicTelemetryRepo) GetTelemetryRowsAll(ctx context.Context, from, to time.Time, limit int32) ([]TelemetryRow, error) {
+	return nil, nil
+}
+
+// TestFireTelemetryRecoversFromPanic proves a panic inside the async
+// telemetry insert is caught and logged instead of crashing the process.
+func TestFireTelemetryRecoversFromPanic(t *testing.T) {
+	// Force observability's lazy sync.Once init to run before we override the
+	// default logger below — otherwise the first-ever Get() call (which may
+	// happen inside the async fireTelemetry goroutine) races our SetDefault
+	// and clobbers it back to the production handler.
+	observability.Get()
+
+	var buf bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, nil)))
+	defer slog.SetDefault(prev)
+
+	s := &Service{telemetry: panicTelemetryRepo{}}
+
+	assert.NotPanics(t, func() {
+		s.fireTelemetry(InsertTelemetryParams{RequestID: "req-1"})
+		// fireTelemetry launches a goroutine; give it a moment to run and recover.
+		deadline := time.Now().Add(2 * time.Second)
+		for time.Now().Before(deadline) {
+			if strings.Contains(buf.String(), "telemetry insert panicked") {
+				break
+			}
+			time.Sleep(10 * time.Millisecond)
+		}
+	})
+
+	assert.Contains(t, buf.String(), "telemetry insert panicked")
+}

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -2989,6 +2989,11 @@ func (s *Service) fireTelemetry(p InsertTelemetryParams) {
 		return
 	}
 	go func() {
+		defer func() {
+			if r := recover(); r != nil {
+				observability.Get().Error("telemetry insert panicked", "panic", r)
+			}
+		}()
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
 		if err := s.telemetry.InsertRequestTelemetry(ctx, p); err != nil {

--- a/internal/pubsub/invalidation.go
+++ b/internal/pubsub/invalidation.go
@@ -91,7 +91,10 @@ func NewInvalidationListener(subscriber *gcppubsub.Subscriber, cache auth.APIKey
 }
 
 // Run blocks until ctx is canceled, forwarding invalidation messages to cache.
+// done is closed via defer so Wait() can't hang if a caller wraps Run with
+// panic recovery (e.g. safeGo) — the defer still fires as the panic unwinds.
 func (l *InvalidationListener) Run(ctx context.Context) {
+	defer close(l.done)
 	log := observability.Get()
 	log.Info("Invalidation listener active", "subscription", l.subscriber.String())
 	err := l.subscriber.Receive(ctx, func(_ context.Context, msg *gcppubsub.Message) {
@@ -104,7 +107,6 @@ func (l *InvalidationListener) Run(ctx context.Context) {
 	if err != nil && ctx.Err() == nil {
 		log.Warn("Invalidation listener receive loop ended unexpectedly", "err", err)
 	}
-	close(l.done)
 }
 
 // Wait blocks until Run has returned. Intended for shutdown coordination.

--- a/internal/pubsub/invalidation.go
+++ b/internal/pubsub/invalidation.go
@@ -44,6 +44,15 @@ func (n *InvalidationNotifier) NotifyInstallationChanged(installationID string) 
 		return
 	}
 	go func() {
+		defer func() {
+			if r := recover(); r != nil {
+				observability.Get().Error(
+					"Panic publishing installation invalidation",
+					"installation_id", installationID,
+					"panic", r,
+				)
+			}
+		}()
 		ctx, cancel := context.WithTimeout(context.Background(), notifyTimeout)
 		defer cancel()
 		result := n.publisher.Publish(ctx, &gcppubsub.Message{Data: []byte(installationID)})


### PR DESCRIPTION
## Summary
- Adds `recover()`-and-log wrappers to the fire-and-forget goroutines that were missing them, matching the pattern already shipped for the ONNX embed goroutine in `internal/router/cluster/scorer.go` (#593).
- Covers: `fireTelemetry` (`internal/proxy/service.go`), `fireMarkUsed` (`internal/auth/service.go`), the Pub/Sub invalidation publish (`internal/pubsub/invalidation.go`), and the two boot-time background loops in `cmd/router/main.go` (the invalidation listener and the session-pin sweep), via a new `safeGo` helper.
- Addresses high-severity findings [16], [74], [91], [115] from the internal code-quality audit: a panic in any of these best-effort background paths could previously crash the entire router process.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` (full suite, all packages green)
- [x] New tests: `TestFireTelemetryRecoversFromPanic` (internal/proxy) and `TestService_VerifyAPIKey_RecoversFromMarkUsedPanic` (internal/auth) — both drive a panicking dependency through the real async path and assert the process doesn't crash and the panic is logged.
- Not independently unit-tested: the Pub/Sub invalidation publish (`internal/pubsub/invalidation.go`) takes a concrete `*gcppubsub.Publisher`, not an interface, so there's no seam to inject a panicking fake without a larger refactor — covered by code review instead. Same for the two `cmd/router/main.go` boot-time goroutines (invalidation listener, session-pin sweep), which are wired directly in `main()`.