### PR TITLE
fix: route anthropic requests through proxy.Service instead of importing translate directly

### DIFF
--- a/internal/api/anthropic/route.go
+++ b/internal/api/anthropic/route.go
@@ -7,9 +7,7 @@ import (
 
 	"workweave/router/internal/observability"
 	"workweave/router/internal/proxy"
-	"workweave/router/internal/router"
 	"workweave/router/internal/router/cluster"
-	"workweave/router/internal/translate"
 
 	"github.com/gin-gonic/gin"
 )
@@ -29,27 +27,13 @@ func RouteHandler(svc *proxy.Service) gin.HandlerFunc {
 			return
 		}
 
-		env, parseErr := translate.ParseAnthropic(body)
-		if parseErr != nil {
-			writeAnthropicError(c, http.StatusBadRequest, "invalid_request_error", "Request body must be a JSON object.")
-			return
-		}
-
 		ctx := c.Request.Context()
-		embedFlag := svc.ResolveEmbedOnlyUserMessage(ctx)
-		feats := env.RoutingFeatures(embedFlag)
-		promptText := feats.PromptText
-		if embedFlag && feats.OnlyUserMessageText != "" {
-			promptText = feats.OnlyUserMessageText
-		}
-		decision, routeErr := svc.Route(ctx, router.Request{
-			RequestedModel:       feats.Model,
-			EstimatedInputTokens: feats.Tokens,
-			HasTools:             feats.HasTools,
-			PromptText:           promptText,
-			RoutingKnobs:         router.RoutingKnobsFromContext(ctx),
-		})
+		decision, routeErr := svc.RouteAnthropicRequest(ctx, body)
 		if routeErr != nil {
+			if errors.Is(routeErr, proxy.ErrRequestNotJSONObject) {
+				writeAnthropicError(c, http.StatusBadRequest, "invalid_request_error", "Request body must be a JSON object.")
+				return
+			}
 			if errors.Is(routeErr, cluster.ErrInvalidRoutingKnobs) {
 				log.Warn("Invalid routing knobs supplied on route", "err", routeErr)
 				writeAnthropicError(c, http.StatusBadRequest, "invalid_request_error", "Invalid routing knobs supplied.")

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -1317,6 +1317,35 @@ func (s *Service) Route(ctx context.Context, req router.Request) (router.Decisio
 	return s.routeFor(ctx, req)
 }
 
+// RouteAnthropicRequest parses a raw Anthropic-Messages body and returns the
+// routing decision without dispatching (e.g. the /v1/route dry-run endpoint).
+// Owns translate.ParseAnthropic + RoutingFeatures extraction internally so
+// callers in internal/api/* never import internal/translate directly,
+// matching ProxyMessages.
+func (s *Service) RouteAnthropicRequest(ctx context.Context, body []byte) (decision router.Decision, err error) {
+	env, parseErr := translate.ParseAnthropic(body)
+	if parseErr != nil {
+		err = fmt.Errorf("parse request: %w", parseErr)
+		return decision, err
+	}
+
+	embedFlag := s.ResolveEmbedOnlyUserMessage(ctx)
+	feats := env.RoutingFeatures(embedFlag)
+	promptText := feats.PromptText
+	if embedFlag && feats.OnlyUserMessageText != "" {
+		promptText = feats.OnlyUserMessageText
+	}
+
+	decision, err = s.Route(ctx, router.Request{
+		RequestedModel:       feats.Model,
+		EstimatedInputTokens: feats.Tokens,
+		HasTools:             feats.HasTools,
+		PromptText:           promptText,
+		RoutingKnobs:         router.RoutingKnobsFromContext(ctx),
+	})
+	return decision, err
+}
+
 // PassthroughToProvider forwards a non-routing request to the default
 // (Anthropic) provider for metadata endpoints (count_tokens, models).
 func (s *Service) PassthroughToProvider(ctx context.Context, body []byte, w http.ResponseWriter, r *http.Request) error {


### PR DESCRIPTION
## Summary

Fixes finding **[53]** from the code quality audit: `internal/api/anthropic/route.go` imported `internal/translate` directly and called `translate.ParseAnthropic` + `RoutingFeatures` from the presentation layer, violating the documented `internal/api/*` import rule ("must not import `internal/translate` directly" — see root `CLAUDE.md` and `internal/api/CLAUDE.md`).

- Added `proxy.Service.RouteAnthropicRequest(ctx, body) (router.Decision, error)`, which owns `translate.ParseAnthropic` + `RoutingFeatures` extraction internally — mirroring how `ProxyMessages` already parses internally without leaking `translate` types to callers.
- Updated `RouteHandler` (`/v1/route`) to call only `svc.RouteAnthropicRequest`, removing its `internal/translate` and `internal/router` imports.
- Parse failures now surface as `proxy.ErrRequestNotJSONObject` (the existing re-export of `translate.ErrNotJSONObject` already used by `messages.go`, `completions.go`, `responses.go`, and `generate_content.go`), so `RouteHandler`'s error handling follows the same `errors.Is` pattern as the rest of `internal/api/anthropic`.

## Test plan

- [x] `go build ./...`
- [x] `go test ./...` (all packages pass)
- [x] `gofmt -l .` clean, `go vet ./...` clean