### PR TITLE
refactor: extract shared SSE writer base to internal/sse

### DIFF
--- a/internal/sse/chunked_writer.go
+++ b/internal/sse/chunked_writer.go
@@ -1,0 +1,77 @@
+package sse
+
+import (
+	"bufio"
+	"net/http"
+	"strings"
+)
+
+// ChunkedWriter is an embeddable base for http.ResponseWriter wrappers that
+// prepend synthetic content (e.g. a routing marker) to a live SSE stream
+// before upstream bytes arrive. It owns the header/streaming-detection and
+// flush bookkeeping shared by every such wrapper; embedders add their own
+// format-specific Write and emit* methods.
+type ChunkedWriter struct {
+	Inner   http.ResponseWriter
+	Flusher http.Flusher
+	BW      *bufio.Writer
+
+	Streaming      bool
+	HeadersEmitted bool
+}
+
+// NewChunkedWriter wraps w, buffering emitted bytes through a bufio.Writer of
+// bufSize bytes.
+func NewChunkedWriter(w http.ResponseWriter, bufSize int) ChunkedWriter {
+	flusher, _ := w.(http.Flusher)
+	return ChunkedWriter{
+		Inner:   w,
+		Flusher: flusher,
+		BW:      bufio.NewWriterSize(w, bufSize),
+	}
+}
+
+// Header implements http.ResponseWriter.
+func (c *ChunkedWriter) Header() http.Header {
+	return c.Inner.Header()
+}
+
+// WriteHeader implements http.ResponseWriter. It latches Streaming based on
+// whether the upstream response is a non-error SSE stream, and is idempotent
+// — a call after the first is a no-op.
+func (c *ChunkedWriter) WriteHeader(code int) {
+	if c.HeadersEmitted {
+		return
+	}
+	ct := c.Inner.Header().Get("Content-Type")
+	c.Streaming = strings.Contains(ct, "text/event-stream") && code < 400
+	c.HeadersEmitted = true
+	c.Inner.WriteHeader(code)
+}
+
+// Flush implements http.Flusher.
+func (c *ChunkedWriter) Flush() {
+	if c.Flusher != nil {
+		c.Flusher.Flush()
+	}
+}
+
+// FlushEvent flushes the buffered writer, then the underlying http.Flusher —
+// the sequence every emit* method needs after writing one SSE event.
+func (c *ChunkedWriter) FlushEvent() error {
+	return FlushWriter(c.BW, c.Flusher)
+}
+
+// FlushWriter flushes bw, then f if non-nil. Shared by writers that keep
+// their own bufio.Writer/http.Flusher pair instead of embedding ChunkedWriter
+// (e.g. because they also need bespoke WriteHeader/streaming-detection logic
+// that ChunkedWriter's can't safely stand in for).
+func FlushWriter(bw *bufio.Writer, f http.Flusher) error {
+	if err := bw.Flush(); err != nil {
+		return err
+	}
+	if f != nil {
+		f.Flush()
+	}
+	return nil
+}

--- a/internal/sse/chunked_writer_test.go
+++ b/internal/sse/chunked_writer_test.go
@@ -1,0 +1,130 @@
+package sse_test
+
+import (
+	"bufio"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"workweave/router/internal/sse"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// flushRecorder wraps httptest.ResponseRecorder to also implement http.Flusher
+// and count Flush calls, so tests can assert FlushEvent/Flush actually reach
+// the underlying flusher.
+type flushRecorder struct {
+	*httptest.ResponseRecorder
+	flushes int
+}
+
+func (f *flushRecorder) Flush() { f.flushes++ }
+
+func TestChunkedWriter_WriteHeaderDetectsStreaming(t *testing.T) {
+	rec := httptest.NewRecorder()
+	rec.Header().Set("Content-Type", "text/event-stream")
+	c := sse.NewChunkedWriter(rec, 4096)
+
+	c.WriteHeader(http.StatusOK)
+
+	assert.True(t, c.Streaming)
+	assert.True(t, c.HeadersEmitted)
+	assert.Equal(t, http.StatusOK, rec.Code)
+}
+
+func TestChunkedWriter_WriteHeaderNonSSENotStreaming(t *testing.T) {
+	rec := httptest.NewRecorder()
+	rec.Header().Set("Content-Type", "application/json")
+	c := sse.NewChunkedWriter(rec, 4096)
+
+	c.WriteHeader(http.StatusOK)
+
+	assert.False(t, c.Streaming)
+}
+
+func TestChunkedWriter_WriteHeaderErrorStatusNotStreaming(t *testing.T) {
+	rec := httptest.NewRecorder()
+	rec.Header().Set("Content-Type", "text/event-stream")
+	c := sse.NewChunkedWriter(rec, 4096)
+
+	c.WriteHeader(http.StatusInternalServerError)
+
+	assert.False(t, c.Streaming, "a >=400 status must not be treated as a streaming SSE response")
+}
+
+func TestChunkedWriter_WriteHeaderIdempotent(t *testing.T) {
+	rec := httptest.NewRecorder()
+	rec.Header().Set("Content-Type", "text/event-stream")
+	c := sse.NewChunkedWriter(rec, 4096)
+
+	c.WriteHeader(http.StatusOK)
+	c.WriteHeader(http.StatusInternalServerError)
+
+	assert.Equal(t, http.StatusOK, rec.Code, "second WriteHeader call must be a no-op")
+	assert.True(t, c.Streaming, "state from the first call must not be overwritten by the no-op second call")
+}
+
+func TestChunkedWriter_HeaderReturnsInnerHeader(t *testing.T) {
+	rec := httptest.NewRecorder()
+	c := sse.NewChunkedWriter(rec, 4096)
+
+	c.Header().Set("X-Test", "1")
+
+	assert.Equal(t, "1", rec.Header().Get("X-Test"))
+}
+
+func TestChunkedWriter_FlushForwardsToUnderlyingFlusher(t *testing.T) {
+	rec := &flushRecorder{ResponseRecorder: httptest.NewRecorder()}
+	c := sse.NewChunkedWriter(rec, 4096)
+
+	c.Flush()
+
+	assert.Equal(t, 1, rec.flushes)
+}
+
+func TestChunkedWriter_FlushNilFlusherNoPanic(t *testing.T) {
+	// httptest.ResponseRecorder implements http.Flusher, so wrap a writer that
+	// deliberately doesn't, to exercise the nil-flusher branch.
+	w := struct{ http.ResponseWriter }{httptest.NewRecorder()}
+	c := sse.NewChunkedWriter(w, 4096)
+
+	require.Nil(t, c.Flusher)
+	assert.NotPanics(t, func() { c.Flush() })
+}
+
+func TestChunkedWriter_FlushEventFlushesBufferThenFlusher(t *testing.T) {
+	rec := &flushRecorder{ResponseRecorder: httptest.NewRecorder()}
+	c := sse.NewChunkedWriter(rec, 4096)
+
+	c.BW.WriteString("hello")
+	err := c.FlushEvent()
+
+	require.NoError(t, err)
+	assert.Equal(t, "hello", rec.Body.String(), "FlushEvent must flush the buffered bytes to the inner writer")
+	assert.Equal(t, 1, rec.flushes, "FlushEvent must also flush the underlying http.Flusher")
+}
+
+func TestFlushWriter_FlushesBufferThenFlusher(t *testing.T) {
+	rec := &flushRecorder{ResponseRecorder: httptest.NewRecorder()}
+	bw := bufio.NewWriterSize(rec, 4096)
+	bw.WriteString("world")
+
+	err := sse.FlushWriter(bw, rec)
+
+	require.NoError(t, err)
+	assert.Equal(t, "world", rec.Body.String())
+	assert.Equal(t, 1, rec.flushes)
+}
+
+func TestFlushWriter_NilFlusherNoPanic(t *testing.T) {
+	rec := httptest.NewRecorder()
+	bw := bufio.NewWriterSize(rec, 4096)
+	bw.WriteString("ok")
+
+	err := sse.FlushWriter(bw, nil)
+
+	require.NoError(t, err)
+	assert.Equal(t, "ok", rec.Body.String())
+}

--- a/internal/translate/AGENTS.md
+++ b/internal/translate/AGENTS.md
@@ -15,7 +15,7 @@ Covers all three directions: Anthropic ⇄ OpenAI and Gemini ⇄ {Anthropic, Ope
 When a new inbound format needs to talk to an existing upstream provider with a different wire format:
 
 1. **Add conversion functions to this package.** Pure functions only — no I/O, no provider knowledge, no domain types.
-2. **If response streaming, adapt [`stream.go`](stream.go) / [`gemini_stream.go`](gemini_stream.go)** or add a sibling decorator. Decorators wrap `http.ResponseWriter` and translate on the fly so we never buffer entire responses. Use [`../sse`](../sse) for zero-alloc SSE framing.
+2. **If response streaming, adapt [`stream.go`](stream.go) / [`gemini_stream.go`](gemini_stream.go)** or add a sibling decorator. Decorators wrap `http.ResponseWriter` and translate on the fly so we never buffer entire responses. Use [`../sse`](../sse) for zero-alloc SSE framing. A decorator that only prepends synthetic content to a stream (like the `*RoutingMarkerWriter` types) should embed `sse.ChunkedWriter` for the shared `Header`/`WriteHeader`/`Flush`/`FlushEvent` + streaming-detection bookkeeping, and add only its format-specific `Write`/`emit*` methods. A full response translator (buffers to translate one wire format into another, e.g. `AnthropicSSETranslator`) has enough divergent `WriteHeader`/streaming logic that it should NOT embed `ChunkedWriter` — reuse only `sse.FlushWriter(bw, flusher)` for its `flushEvent` helper.
 3. **Compose the new translation in `proxy.Service.Proxy*`.** Proxy is the only caller of `translate`.
 
 ## Anthropic-specific stripping (load-bearing)

--- a/internal/translate/CLAUDE.md
+++ b/internal/translate/CLAUDE.md
@@ -15,7 +15,7 @@ Covers all three directions: Anthropic ⇄ OpenAI and Gemini ⇄ {Anthropic, Ope
 When a new inbound format needs to talk to an existing upstream provider with a different wire format:
 
 1. **Add conversion functions to this package.** Pure functions only — no I/O, no provider knowledge, no domain types.
-2. **If response streaming, adapt [`stream.go`](stream.go) / [`gemini_stream.go`](gemini_stream.go)** or add a sibling decorator. Decorators wrap `http.ResponseWriter` and translate on the fly so we never buffer entire responses. Use [`../sse`](../sse) for zero-alloc SSE framing.
+2. **If response streaming, adapt [`stream.go`](stream.go) / [`gemini_stream.go`](gemini_stream.go)** or add a sibling decorator. Decorators wrap `http.ResponseWriter` and translate on the fly so we never buffer entire responses. Use [`../sse`](../sse) for zero-alloc SSE framing. A decorator that only prepends synthetic content to a stream (like the `*RoutingMarkerWriter` types) should embed `sse.ChunkedWriter` for the shared `Header`/`WriteHeader`/`Flush`/`FlushEvent` + streaming-detection bookkeeping, and add only its format-specific `Write`/`emit*` methods. A full response translator (buffers to translate one wire format into another, e.g. `AnthropicSSETranslator`) has enough divergent `WriteHeader`/streaming logic that it should NOT embed `ChunkedWriter` — reuse only `sse.FlushWriter(bw, flusher)` for its `flushEvent` helper.
 3. **Compose the new translation in `proxy.Service.Proxy*`.** Proxy is the only caller of `translate`.
 
 ## Anthropic-specific stripping (load-bearing)

--- a/internal/translate/anthropic_marker.go
+++ b/internal/translate/anthropic_marker.go
@@ -1,10 +1,8 @@
 package translate
 
 import (
-	"bufio"
 	"bytes"
 	"net/http"
-	"strings"
 
 	"workweave/router/internal/providers"
 	"workweave/router/internal/sse"
@@ -16,18 +14,14 @@ import (
 // AnthropicRoutingMarkerWriter injects a routing-marker text block at index 0
 // of an Anthropic SSE stream, shifting upstream content_block_* indices by +1.
 type AnthropicRoutingMarkerWriter struct {
-	inner   http.ResponseWriter
-	flusher http.Flusher
-	bw      *bufio.Writer
+	sse.ChunkedWriter
 
 	marker string
 	model  string
 
 	buf bytes.Buffer
 
-	streaming      bool
-	headersEmitted bool
-	markerEmitted  bool
+	markerEmitted bool
 
 	onOutputProgress func()
 }
@@ -35,32 +29,15 @@ type AnthropicRoutingMarkerWriter struct {
 // NewAnthropicRoutingMarkerWriter injects marker as a text block at index 0.
 // If marker is empty, writes pass through unchanged.
 func NewAnthropicRoutingMarkerWriter(w http.ResponseWriter, model, marker string) *AnthropicRoutingMarkerWriter {
-	flusher, _ := w.(http.Flusher)
 	return &AnthropicRoutingMarkerWriter{
-		inner:   w,
-		flusher: flusher,
-		bw:      bufio.NewWriterSize(w, 4096),
-		marker:  marker,
-		model:   model,
+		ChunkedWriter: sse.NewChunkedWriter(w, 4096),
+		marker:        marker,
+		model:         model,
 	}
-}
-
-func (w *AnthropicRoutingMarkerWriter) Header() http.Header {
-	return w.inner.Header()
-}
-
-func (w *AnthropicRoutingMarkerWriter) WriteHeader(code int) {
-	if w.headersEmitted {
-		return
-	}
-	ct := w.inner.Header().Get("Content-Type")
-	w.streaming = strings.Contains(ct, "text/event-stream") && code < 400
-	w.headersEmitted = true
-	w.inner.WriteHeader(code)
 }
 
 func (w *AnthropicRoutingMarkerWriter) Write(data []byte) (int, error) {
-	if w.streaming && !w.markerEmitted {
+	if w.Streaming && !w.markerEmitted {
 		w.markerEmitted = true
 		if w.marker != "" {
 			if err := w.emitPreludeEvents(); err != nil {
@@ -68,9 +45,9 @@ func (w *AnthropicRoutingMarkerWriter) Write(data []byte) (int, error) {
 			}
 		}
 	}
-	if !w.streaming || w.marker == "" {
+	if !w.Streaming || w.marker == "" {
 		// Non-streaming or empty marker: fully transparent passthrough.
-		return w.inner.Write(data)
+		return w.Inner.Write(data)
 	}
 	// Streaming with a configured marker: parse upstream SSE, drop message_start,
 	// shift content_block_* indices, pass everything else through.
@@ -89,61 +66,42 @@ func (w *AnthropicRoutingMarkerWriter) Prelude(streaming bool) error {
 	if !streaming || w.markerEmitted {
 		return nil
 	}
-	w.inner.Header().Set("Content-Type", "text/event-stream")
-	w.streaming = true
-	if !w.headersEmitted {
-		w.headersEmitted = true
-		w.inner.WriteHeader(http.StatusOK)
+	w.Inner.Header().Set("Content-Type", "text/event-stream")
+	w.Streaming = true
+	if !w.HeadersEmitted {
+		w.HeadersEmitted = true
+		w.Inner.WriteHeader(http.StatusOK)
 	}
 	w.markerEmitted = true
 	if w.marker == "" {
-		w.bw.WriteString(": routing complete\n\n")
-		if err := w.bw.Flush(); err != nil {
-			return err
-		}
-		if w.flusher != nil {
-			w.flusher.Flush()
-		}
-		return nil
+		w.BW.WriteString(": routing complete\n\n")
+		return w.FlushEvent()
 	}
 	return w.emitPreludeEvents()
-}
-
-// Flush implements http.Flusher.
-func (w *AnthropicRoutingMarkerWriter) Flush() {
-	if w.flusher != nil {
-		w.flusher.Flush()
-	}
 }
 
 // emitPreludeEvents writes message_start followed by the routing marker as a
 // text content block at index 0.
 func (w *AnthropicRoutingMarkerWriter) emitPreludeEvents() error {
 	// message_start — mirrors the envelope shape from AnthropicSSETranslator.
-	w.bw.WriteString("event: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"id\":")
-	sse.WriteJSONString(w.bw, generateAnthropicMsgID())
-	w.bw.WriteString(",\"type\":\"message\",\"role\":\"assistant\",\"content\":[],\"model\":")
-	sse.WriteJSONString(w.bw, w.model)
-	w.bw.WriteString(",\"stop_reason\":null,\"stop_sequence\":null,\"usage\":{\"input_tokens\":0,\"output_tokens\":0}}}\n\n")
+	w.BW.WriteString("event: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"id\":")
+	sse.WriteJSONString(w.BW, generateAnthropicMsgID())
+	w.BW.WriteString(",\"type\":\"message\",\"role\":\"assistant\",\"content\":[],\"model\":")
+	sse.WriteJSONString(w.BW, w.model)
+	w.BW.WriteString(",\"stop_reason\":null,\"stop_sequence\":null,\"usage\":{\"input_tokens\":0,\"output_tokens\":0}}}\n\n")
 
 	// content_block_start at index 0 (text block).
-	w.bw.WriteString("event: content_block_start\ndata: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"text\",\"text\":\"\"}}\n\n")
+	w.BW.WriteString("event: content_block_start\ndata: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"text\",\"text\":\"\"}}\n\n")
 
 	// content_block_delta (text_delta) at index 0.
-	w.bw.WriteString("event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":")
-	sse.WriteJSONString(w.bw, w.marker)
-	w.bw.WriteString("}}\n\n")
+	w.BW.WriteString("event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":")
+	sse.WriteJSONString(w.BW, w.marker)
+	w.BW.WriteString("}}\n\n")
 
 	// content_block_stop at index 0.
-	w.bw.WriteString("event: content_block_stop\ndata: {\"type\":\"content_block_stop\",\"index\":0}\n\n")
+	w.BW.WriteString("event: content_block_stop\ndata: {\"type\":\"content_block_stop\",\"index\":0}\n\n")
 
-	if err := w.bw.Flush(); err != nil {
-		return err
-	}
-	if w.flusher != nil {
-		w.flusher.Flush()
-	}
-	return nil
+	return w.FlushEvent()
 }
 
 // processUpstream parses upstream SSE events, drops message_start, and shifts
@@ -161,7 +119,7 @@ func (w *AnthropicRoutingMarkerWriter) processUpstream(data []byte) (int, error)
 
 		if len(eventType) == 0 && len(eventData) == 0 {
 			// Comment or empty — pass through as-is.
-			if _, err := w.inner.Write(event[:n]); err != nil {
+			if _, err := w.Inner.Write(event[:n]); err != nil {
 				return 0, err
 			}
 			w.buf.Next(n)
@@ -184,25 +142,25 @@ func (w *AnthropicRoutingMarkerWriter) processUpstream(data []byte) (int, error)
 			rewritten, err := sjson.SetBytes(eventData, "index", currentIdx+1)
 			if err != nil {
 				// Fall through: emit original event if rewrite fails.
-				if _, err := w.inner.Write(event[:n]); err != nil {
+				if _, err := w.Inner.Write(event[:n]); err != nil {
 					return 0, err
 				}
 				w.buf.Next(n)
 				continue
 			}
-			w.bw.WriteString("event: ")
-			w.bw.Write(eventType)
-			w.bw.WriteString("\ndata: ")
-			w.bw.Write(rewritten)
-			w.bw.WriteString("\n\n")
-			if err := w.bw.Flush(); err != nil {
+			w.BW.WriteString("event: ")
+			w.BW.Write(eventType)
+			w.BW.WriteString("\ndata: ")
+			w.BW.Write(rewritten)
+			w.BW.WriteString("\n\n")
+			if err := w.BW.Flush(); err != nil {
 				return 0, err
 			}
 			w.buf.Next(n)
 
 		default:
 			// message_delta, message_stop, ping, error, etc. — pass through untouched.
-			if _, err := w.inner.Write(event[:n]); err != nil {
+			if _, err := w.Inner.Write(event[:n]); err != nil {
 				return 0, err
 			}
 			w.buf.Next(n)
@@ -215,7 +173,7 @@ func (w *AnthropicRoutingMarkerWriter) processUpstream(data []byte) (int, error)
 // (not pings or structural frames) so the native output-stall watchdog tracks
 // time-since-last-output. Returns false when not streaming or without a marker.
 func (w *AnthropicRoutingMarkerWriter) ArmOutputProgress(mark func()) (armed bool) {
-	if !w.streaming || w.marker == "" {
+	if !w.Streaming || w.marker == "" {
 		return false
 	}
 	w.onOutputProgress = mark

--- a/internal/translate/gemini_marker.go
+++ b/internal/translate/gemini_marker.go
@@ -1,9 +1,7 @@
 package translate
 
 import (
-	"bufio"
 	"net/http"
-	"strings"
 
 	"workweave/router/internal/sse"
 )
@@ -12,46 +10,25 @@ import (
 // routing-marker chunk at the start of a Gemini-format SSE stream.
 // Non-streaming responses pass through unmodified.
 type GeminiRoutingMarkerWriter struct {
-	inner   http.ResponseWriter
-	flusher http.Flusher
-	bw      *bufio.Writer
+	sse.ChunkedWriter
 
 	marker string
 
-	streaming      bool
-	headersEmitted bool
-	markerEmitted  bool
+	markerEmitted bool
 }
 
 // NewGeminiRoutingMarkerWriter creates a writer that emits marker as the first
 // Gemini SSE candidate before any upstream data. If marker is empty, all
 // writes pass through unchanged.
 func NewGeminiRoutingMarkerWriter(w http.ResponseWriter, marker string) *GeminiRoutingMarkerWriter {
-	flusher, _ := w.(http.Flusher)
 	return &GeminiRoutingMarkerWriter{
-		inner:   w,
-		flusher: flusher,
-		bw:      bufio.NewWriterSize(w, 4096),
-		marker:  marker,
+		ChunkedWriter: sse.NewChunkedWriter(w, 4096),
+		marker:        marker,
 	}
-}
-
-func (w *GeminiRoutingMarkerWriter) Header() http.Header {
-	return w.inner.Header()
-}
-
-func (w *GeminiRoutingMarkerWriter) WriteHeader(code int) {
-	if w.headersEmitted {
-		return
-	}
-	ct := w.inner.Header().Get("Content-Type")
-	w.streaming = strings.Contains(ct, "text/event-stream") && code < 400
-	w.headersEmitted = true
-	w.inner.WriteHeader(code)
 }
 
 func (w *GeminiRoutingMarkerWriter) Write(data []byte) (int, error) {
-	if w.streaming && !w.markerEmitted {
+	if w.Streaming && !w.markerEmitted {
 		w.markerEmitted = true
 		if w.marker != "" {
 			if err := w.emitMarkerChunk(); err != nil {
@@ -59,7 +36,7 @@ func (w *GeminiRoutingMarkerWriter) Write(data []byte) (int, error) {
 			}
 		}
 	}
-	return w.inner.Write(data)
+	return w.Inner.Write(data)
 }
 
 // Prelude commits headers and emits the routing marker immediately, before the
@@ -68,45 +45,26 @@ func (w *GeminiRoutingMarkerWriter) Prelude(streaming bool) error {
 	if !streaming || w.markerEmitted {
 		return nil
 	}
-	w.inner.Header().Set("Content-Type", "text/event-stream")
-	w.streaming = true
-	if !w.headersEmitted {
-		w.headersEmitted = true
-		w.inner.WriteHeader(http.StatusOK)
+	w.Inner.Header().Set("Content-Type", "text/event-stream")
+	w.Streaming = true
+	if !w.HeadersEmitted {
+		w.HeadersEmitted = true
+		w.Inner.WriteHeader(http.StatusOK)
 	}
 	w.markerEmitted = true
 	if w.marker == "" {
-		w.bw.WriteString(": routing complete\n\n")
-		if err := w.bw.Flush(); err != nil {
-			return err
-		}
-		if w.flusher != nil {
-			w.flusher.Flush()
-		}
-		return nil
+		w.BW.WriteString(": routing complete\n\n")
+		return w.FlushEvent()
 	}
 	return w.emitMarkerChunk()
 }
 
-// Flush implements http.Flusher.
-func (w *GeminiRoutingMarkerWriter) Flush() {
-	if w.flusher != nil {
-		w.flusher.Flush()
-	}
-}
-
 func (w *GeminiRoutingMarkerWriter) emitMarkerChunk() error {
-	w.bw.WriteString(`data: {"candidates":[{"content":{"parts":[{"text":`)
-	sse.WriteJSONString(w.bw, w.marker)
-	w.bw.WriteString(`}],"role":"model"},"index":0}]}`)
-	w.bw.WriteString("\n\n")
-	if err := w.bw.Flush(); err != nil {
-		return err
-	}
-	if w.flusher != nil {
-		w.flusher.Flush()
-	}
-	return nil
+	w.BW.WriteString(`data: {"candidates":[{"content":{"parts":[{"text":`)
+	sse.WriteJSONString(w.BW, w.marker)
+	w.BW.WriteString(`}],"role":"model"},"index":0}]}`)
+	w.BW.WriteString("\n\n")
+	return w.FlushEvent()
 }
 
 var _ http.ResponseWriter = (*GeminiRoutingMarkerWriter)(nil)

--- a/internal/translate/gemini_stream.go
+++ b/internal/translate/gemini_stream.go
@@ -375,13 +375,7 @@ func (t *GeminiToOpenAISSETranslator) writeChunkHeader() {
 }
 
 func (t *GeminiToOpenAISSETranslator) flushEvent() error {
-	if err := t.bw.Flush(); err != nil {
-		return err
-	}
-	if t.flusher != nil {
-		t.flusher.Flush()
-	}
-	return nil
+	return sse.FlushWriter(t.bw, t.flusher)
 }
 
 var _ http.ResponseWriter = (*GeminiToOpenAISSETranslator)(nil)

--- a/internal/translate/openai_marker.go
+++ b/internal/translate/openai_marker.go
@@ -1,9 +1,7 @@
 package translate
 
 import (
-	"bufio"
 	"net/http"
-	"strings"
 	"time"
 
 	"workweave/router/internal/providers"
@@ -16,16 +14,12 @@ import (
 // routing-marker chunk at the start of an OpenAI-format SSE stream.
 // Non-streaming responses pass through unmodified.
 type OpenAIRoutingMarkerWriter struct {
-	inner   http.ResponseWriter
-	flusher http.Flusher
-	bw      *bufio.Writer
+	sse.ChunkedWriter
 
 	marker string
 	model  string
 
-	streaming      bool
-	headersEmitted bool
-	markerEmitted  bool
+	markerEmitted bool
 
 	// onOutputProgress, when set via ArmOutputProgress, is invoked whenever a
 	// written upstream chunk carries an output-bearing delta (content,
@@ -46,32 +40,15 @@ type OpenAIRoutingMarkerWriter struct {
 // chat.completion.chunk before any upstream data. If marker is empty, all
 // writes pass through unchanged.
 func NewOpenAIRoutingMarkerWriter(w http.ResponseWriter, model, marker string) *OpenAIRoutingMarkerWriter {
-	flusher, _ := w.(http.Flusher)
 	return &OpenAIRoutingMarkerWriter{
-		inner:   w,
-		flusher: flusher,
-		bw:      bufio.NewWriterSize(w, 4096),
-		marker:  marker,
-		model:   model,
+		ChunkedWriter: sse.NewChunkedWriter(w, 4096),
+		marker:        marker,
+		model:         model,
 	}
-}
-
-func (w *OpenAIRoutingMarkerWriter) Header() http.Header {
-	return w.inner.Header()
-}
-
-func (w *OpenAIRoutingMarkerWriter) WriteHeader(code int) {
-	if w.headersEmitted {
-		return
-	}
-	ct := w.inner.Header().Get("Content-Type")
-	w.streaming = strings.Contains(ct, "text/event-stream") && code < 400
-	w.headersEmitted = true
-	w.inner.WriteHeader(code)
 }
 
 func (w *OpenAIRoutingMarkerWriter) Write(data []byte) (int, error) {
-	if w.streaming && !w.markerEmitted {
+	if w.Streaming && !w.markerEmitted {
 		w.markerEmitted = true
 		if w.marker != "" {
 			if err := w.emitMarkerChunk(); err != nil {
@@ -79,10 +56,10 @@ func (w *OpenAIRoutingMarkerWriter) Write(data []byte) (int, error) {
 			}
 		}
 	}
-	if w.streaming && w.onOutputProgress != nil {
+	if w.Streaming && w.onOutputProgress != nil {
 		w.scanOutputProgress(data)
 	}
-	return w.inner.Write(data)
+	return w.Inner.Write(data)
 }
 
 // ArmOutputProgress installs the output-progress watchdog mark. The writer
@@ -93,7 +70,7 @@ func (w *OpenAIRoutingMarkerWriter) Write(data []byte) (int, error) {
 // streaming: a non-streaming passthrough has nothing to mark mid-stream. Call
 // after WriteHeader / Prelude, which set the streaming flag.
 func (w *OpenAIRoutingMarkerWriter) ArmOutputProgress(mark func()) (armed bool) {
-	if !w.streaming {
+	if !w.Streaming {
 		return false
 	}
 	w.onOutputProgress = mark
@@ -165,52 +142,33 @@ func (w *OpenAIRoutingMarkerWriter) Prelude(streaming bool) error {
 	if !streaming || w.markerEmitted {
 		return nil
 	}
-	w.inner.Header().Set("Content-Type", "text/event-stream")
-	w.streaming = true
-	if !w.headersEmitted {
-		w.headersEmitted = true
-		w.inner.WriteHeader(http.StatusOK)
+	w.Inner.Header().Set("Content-Type", "text/event-stream")
+	w.Streaming = true
+	if !w.HeadersEmitted {
+		w.HeadersEmitted = true
+		w.Inner.WriteHeader(http.StatusOK)
 	}
 	w.markerEmitted = true
 	if w.marker == "" {
 		// Still flush a comment so TCP gets a packet — TTFB is what we're optimizing for.
-		w.bw.WriteString(": routing complete\n\n")
-		if err := w.bw.Flush(); err != nil {
-			return err
-		}
-		if w.flusher != nil {
-			w.flusher.Flush()
-		}
-		return nil
+		w.BW.WriteString(": routing complete\n\n")
+		return w.FlushEvent()
 	}
 	return w.emitMarkerChunk()
 }
 
-// Flush implements http.Flusher.
-func (w *OpenAIRoutingMarkerWriter) Flush() {
-	if w.flusher != nil {
-		w.flusher.Flush()
-	}
-}
-
 func (w *OpenAIRoutingMarkerWriter) emitMarkerChunk() error {
-	w.bw.WriteString(`data: {"id":`)
-	sse.WriteJSONString(w.bw, generateChatCmplID())
-	w.bw.WriteString(`,"object":"chat.completion.chunk","created":`)
-	sse.WriteJSONInt(w.bw, time.Now().Unix())
-	w.bw.WriteString(`,"model":`)
-	sse.WriteJSONString(w.bw, w.model)
-	w.bw.WriteString(`,"choices":[{"index":0,"delta":{"role":"assistant","content":`)
-	sse.WriteJSONString(w.bw, w.marker)
-	w.bw.WriteString(`},"finish_reason":null}]}`)
-	w.bw.WriteString("\n\n")
-	if err := w.bw.Flush(); err != nil {
-		return err
-	}
-	if w.flusher != nil {
-		w.flusher.Flush()
-	}
-	return nil
+	w.BW.WriteString(`data: {"id":`)
+	sse.WriteJSONString(w.BW, generateChatCmplID())
+	w.BW.WriteString(`,"object":"chat.completion.chunk","created":`)
+	sse.WriteJSONInt(w.BW, time.Now().Unix())
+	w.BW.WriteString(`,"model":`)
+	sse.WriteJSONString(w.BW, w.model)
+	w.BW.WriteString(`,"choices":[{"index":0,"delta":{"role":"assistant","content":`)
+	sse.WriteJSONString(w.BW, w.marker)
+	w.BW.WriteString(`},"finish_reason":null}]}`)
+	w.BW.WriteString("\n\n")
+	return w.FlushEvent()
 }
 
 var _ http.ResponseWriter = (*OpenAIRoutingMarkerWriter)(nil)

--- a/internal/translate/responses_to_anthropic_writer.go
+++ b/internal/translate/responses_to_anthropic_writer.go
@@ -981,13 +981,7 @@ func (t *ResponsesToAnthropicWriter) emitStreamErrorEvent(errType, msg string) e
 }
 
 func (t *ResponsesToAnthropicWriter) flushEvent() error {
-	if err := t.bw.Flush(); err != nil {
-		return err
-	}
-	if t.flusher != nil {
-		t.flusher.Flush()
-	}
-	return nil
+	return sse.FlushWriter(t.bw, t.flusher)
 }
 
 var _ http.ResponseWriter = (*ResponsesToAnthropicWriter)(nil)

--- a/internal/translate/stream.go
+++ b/internal/translate/stream.go
@@ -316,13 +316,7 @@ func (t *SSETranslator) emitDone() error {
 }
 
 func (t *SSETranslator) flushEvent() error {
-	if err := t.bw.Flush(); err != nil {
-		return err
-	}
-	if t.flusher != nil {
-		t.flusher.Flush()
-	}
-	return nil
+	return sse.FlushWriter(t.bw, t.flusher)
 }
 
 var _ http.ResponseWriter = (*SSETranslator)(nil)
@@ -1450,13 +1444,7 @@ func (t *AnthropicSSETranslator) emitMessageStop() error {
 }
 
 func (t *AnthropicSSETranslator) flushEvent() error {
-	if err := t.bw.Flush(); err != nil {
-		return err
-	}
-	if t.flusher != nil {
-		t.flusher.Flush()
-	}
-	return nil
+	return sse.FlushWriter(t.bw, t.flusher)
 }
 
 func openAIFinishToAnthropic(reason string) string {


### PR DESCRIPTION
## Summary

Addresses finding [9] of the router code-quality audit: `internal/translate/anthropic_marker.go:52` and related files had six SSE writer/translator types with duplicated `bufio`+flusher+streaming-detection skeletons.

- **Fully unified (byte-identical before this change):** `AnthropicRoutingMarkerWriter`, `OpenAIRoutingMarkerWriter`, `GeminiRoutingMarkerWriter` — their `Header()`/`WriteHeader()`/`Flush()` bodies and `streaming`/`headersEmitted` bookkeeping were byte-for-byte identical. Extracted `sse.ChunkedWriter`, an embeddable base type in `internal/sse` (already the designated home for "zero-alloc SSE framing helpers" per root `CLAUDE.md`) exposing `Header()`/`WriteHeader()`/`Flush()`/`FlushEvent()` plus the bookkeeping fields (`Streaming`, `HeadersEmitted`, `Inner`, `Flusher`, `BW`). All three writers now embed it and keep only their format-specific `Write`/`emit*` methods.
- **Deliberately left out — scoped down:** the four buffered response translators (`SSETranslator`, `AnthropicSSETranslator` in `stream.go`, `GeminiToOpenAISSETranslator` in `gemini_stream.go`, `ResponsesToAnthropicWriter`). On close reading their `WriteHeader`/streaming logic is **not** actually identical:
  - `AnthropicSSETranslator.WriteHeader` additionally captures an upstream error status and logs via `observability`.
  - All four (except the marker writers) strip `Content-Length`/`Content-Encoding` headers before re-encoding — the marker writers don't, since they pass upstream bytes through unmodified.
  - `ResponsesToAnthropicWriter.WriteHeader` doesn't set `Streaming` at all — the client's streaming choice is decided in `Prelude`, not from the upstream response.

  Forcing these onto a shared `WriteHeader`/streaming base would risk a real behavior change in production SSE streaming code, so I left them as-is rather than force a risky unification (per the audit's own guidance to be conservative here). Their one truly identical piece — the `bufio.Writer.Flush()` then `http.Flusher.Flush()` two-liner every `flushEvent`/`emitMarkerChunk` method ended with — is deduped into a new `sse.FlushWriter(bw, flusher) error` helper. This is a pure mechanical substitution (same two calls, same order, same params) with zero behavior change, used by all seven of the original duplicated flush call sites (3 marker writers, via `ChunkedWriter.FlushEvent`, + 4 translators, via `sse.FlushWriter` directly).

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` — full suite passes, including existing black-box tests in `internal/translate` that exercise the marker writers' `Header`/`WriteHeader`/`Prelude`/`Flush` behavior end-to-end (`anthropic_marker_test.go`, `openai_marker_test.go`, `gemini_marker_test.go`, `*_output_progress_test.go`)
- [x] `gofmt -l .` — clean
- [x] Added `internal/sse/chunked_writer_test.go` — direct unit coverage for the new `ChunkedWriter`/`FlushWriter` (streaming detection on/off, error-status non-streaming, `WriteHeader` idempotency, `Header()` passthrough, `Flush`/`FlushEvent` reaching the underlying `http.Flusher`, nil-flusher no-panic)
- [x] Updated `internal/translate/CLAUDE.md` + mirrored `AGENTS.md` with guidance on when to embed `sse.ChunkedWriter` vs. only reuse `sse.FlushWriter`

## Confidence

High for the three marker-writer types — their pre-change code was byte-identical, and the diff is a mechanical field/method rename plus struct embedding (`w.streaming` → `w.Streaming`, `w.inner` → `w.Inner`, etc.), verified against the existing test suite plus new direct unit tests on the base type. Lower-risk on the four translators since I deliberately did *not* touch their `WriteHeader`/streaming logic — only their `flushEvent` bodies changed, which is a straight extraction of an already-identical two-line sequence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)