### PR TITLE
fix: address catalog pricing coverage gap for unlisted model IDs

### DIFF
--- a/install/cc-statusline.sh
+++ b/install/cc-statusline.sh
@@ -131,6 +131,9 @@ prices='{
   "input": {
     "claude-fable-5":                   0.01,
     "claude-haiku-4-5":                 0.0008,
+    "claude-opus-4-0":                  0.015,
+    "claude-opus-4-1":                  0.015,
+    "claude-opus-4-5":                  0.005,
     "claude-opus-4-6":                  0.005,
     "claude-opus-4-7":                  0.005,
     "claude-opus-4-8":                  0.005,
@@ -188,6 +191,9 @@ prices='{
   "output": {
     "claude-fable-5":                   0.05,
     "claude-haiku-4-5":                 0.004,
+    "claude-opus-4-0":                  0.075,
+    "claude-opus-4-1":                  0.075,
+    "claude-opus-4-5":                  0.025,
     "claude-opus-4-6":                  0.025,
     "claude-opus-4-7":                  0.025,
     "claude-opus-4-8":                  0.025,

--- a/install/install.sh
+++ b/install/install.sh
@@ -2072,6 +2072,9 @@ prices='{
   "input": {
     "claude-fable-5":                   0.01,
     "claude-haiku-4-5":                 0.0008,
+    "claude-opus-4-0":                  0.015,
+    "claude-opus-4-1":                  0.015,
+    "claude-opus-4-5":                  0.005,
     "claude-opus-4-6":                  0.005,
     "claude-opus-4-7":                  0.005,
     "claude-opus-4-8":                  0.005,
@@ -2129,6 +2132,9 @@ prices='{
   "output": {
     "claude-fable-5":                   0.05,
     "claude-haiku-4-5":                 0.004,
+    "claude-opus-4-0":                  0.075,
+    "claude-opus-4-1":                  0.075,
+    "claude-opus-4-5":                  0.025,
     "claude-opus-4-6":                  0.025,
     "claude-opus-4-7":                  0.025,
     "claude-opus-4-8":                  0.025,

--- a/internal/billing/service.go
+++ b/internal/billing/service.go
@@ -206,7 +206,7 @@ func warnOnUnknownPricing(p DebitInferenceParams) {
 	if p.Pricing.InputUSDPer1M != 0 || p.Pricing.OutputUSDPer1M != 0 {
 		return
 	}
-	if p.InputTokens == 0 && p.OutputTokens == 0 {
+	if p.InputTokens == 0 && p.OutputTokens == 0 && p.CacheCreation == 0 && p.CacheRead == 0 {
 		return
 	}
 	observability.Get().Error("Billing debit resolved zero-value catalog pricing for a real turn — add the model to internal/router/catalog/catalog.go's Models table",
@@ -216,6 +216,8 @@ func warnOnUnknownPricing(p DebitInferenceParams) {
 		"router_request_id", p.RouterRequestID,
 		"input_tokens", p.InputTokens,
 		"output_tokens", p.OutputTokens,
+		"cache_creation_tokens", p.CacheCreation,
+		"cache_read_tokens", p.CacheRead,
 	)
 }
 

--- a/internal/billing/service.go
+++ b/internal/billing/service.go
@@ -145,6 +145,7 @@ type DebitInferenceParams struct {
 // Returns the post-debit balance (0 on override, since balance doesn't
 // change).
 func (s *Service) DebitForInference(ctx context.Context, p DebitInferenceParams) (int64, error) {
+	warnOnUnknownPricing(p)
 	notional := computeNotionalMicros(p)
 	delta := -notional
 	switch {
@@ -191,6 +192,31 @@ func (s *Service) maybeSignalRecharge(ctx context.Context, orgID string, delta, 
 	if balanceBefore >= threshold && balanceAfter < threshold {
 		s.autopay.NotifyRechargeNeeded(orgID)
 	}
+}
+
+// warnOnUnknownPricing logs when a billable turn resolves to zero-value
+// catalog pricing — the model ID has no internal/router/catalog.Models
+// entry, so PrimaryPriceFor/PriceFor returned a zero Pricing and this turn
+// is about to debit $0 for real usage. Override/subscription-served turns
+// are exempt: those are intentionally free, not a pricing gap.
+func warnOnUnknownPricing(p DebitInferenceParams) {
+	if p.HasOverride || p.SubscriptionServed {
+		return
+	}
+	if p.Pricing.InputUSDPer1M != 0 || p.Pricing.OutputUSDPer1M != 0 {
+		return
+	}
+	if p.InputTokens == 0 && p.OutputTokens == 0 {
+		return
+	}
+	observability.Get().Error("Billing debit resolved zero-value catalog pricing for a real turn — add the model to internal/router/catalog/catalog.go's Models table",
+		"model", p.Model,
+		"provider", p.Provider,
+		"organization_id", p.OrganizationID,
+		"router_request_id", p.RouterRequestID,
+		"input_tokens", p.InputTokens,
+		"output_tokens", p.OutputTokens,
+	)
 }
 
 // computeNotionalMicros returns the would-be charge in USD micros,

--- a/internal/billing/service_test.go
+++ b/internal/billing/service_test.go
@@ -1,19 +1,39 @@
 package billing_test
 
 import (
+	"bytes"
 	"context"
 	"errors"
+	"log/slog"
 	"sync"
 	"sync/atomic"
 	"testing"
 
 	"workweave/router/internal/billing"
+	"workweave/router/internal/observability"
 	"workweave/router/internal/providers"
 	"workweave/router/internal/router/catalog"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// captureLogs swaps slog's default logger for one writing text lines into
+// the returned buffer, restoring the previous default on test cleanup.
+//
+// observability.Get() lazily installs its own default handler exactly once
+// (sync.Once) the first time any test calls it; if that happens after we've
+// installed our buffer handler, it clobbers it. Force that one-time init
+// first so our SetDefault below is the one that sticks.
+func captureLogs(t *testing.T) *bytes.Buffer {
+	t.Helper()
+	observability.Get()
+	var buf bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+	return &buf
+}
 
 // fakeRepo is an in-memory billing.Repo for testing the Service without
 // hitting Postgres. Atomic fields keep the concurrent-debit test honest.
@@ -147,6 +167,82 @@ func TestDebitForInference_MatchesExportedCostMath(t *testing.T) {
 	assert.Equal(t, billing.EntryTypeInference, repo.ledgerCalls[0].EntryType)
 	assert.Equal(t, "req_abc", repo.ledgerCalls[0].RouterRequestID)
 	assert.Equal(t, "claude-sonnet-4-5", repo.ledgerCalls[0].RouterModel)
+}
+
+func TestDebitForInference_WarnsOnZeroPricingForRealUsage(t *testing.T) {
+	// A model ID with no catalog.Models entry resolves to a zero-value
+	// Pricing (see catalog.PrimaryPriceFor). Debiting real token usage at
+	// that price silently charges $0 — this must surface as an Error log so
+	// the gap gets noticed instead of masked (finding [30]).
+	buf := captureLogs(t)
+	repo := &fakeRepo{balanceRowExists: true, balanceMicros: 10_000_000}
+	svc := billing.NewService(repo)
+	balance, err := svc.DebitForInference(context.Background(), billing.DebitInferenceParams{
+		OrganizationID:  "org_x",
+		RouterRequestID: "req_unknown",
+		Model:           "gpt-5.2",
+		Provider:        providers.ProviderOpenAI,
+		InputTokens:     1_000_000,
+		OutputTokens:    250_000,
+		Pricing:         catalog.Pricing{}, // zero value: model not in catalog
+	})
+	require.NoError(t, err)
+	assert.Equal(t, int64(10_000_000), balance, "zero pricing charges nothing even though real tokens were used")
+	assert.Contains(t, buf.String(), "level=ERROR")
+	assert.Contains(t, buf.String(), "zero-value catalog pricing")
+	assert.Contains(t, buf.String(), "gpt-5.2")
+}
+
+func TestDebitForInference_NoWarnOnKnownPricing(t *testing.T) {
+	buf := captureLogs(t)
+	repo := &fakeRepo{balanceRowExists: true, balanceMicros: 10_000_000}
+	svc := billing.NewService(repo)
+	p := catalog.Pricing{InputUSDPer1M: 3.00, OutputUSDPer1M: 15.00, CacheReadMultiplier: 0.10}
+	_, err := svc.DebitForInference(context.Background(), billing.DebitInferenceParams{
+		OrganizationID: "org_x",
+		Model:          "claude-sonnet-4-5",
+		Provider:       providers.ProviderAnthropic,
+		InputTokens:    1_000_000,
+		OutputTokens:   250_000,
+		Pricing:        p,
+	})
+	require.NoError(t, err)
+	assert.NotContains(t, buf.String(), "zero-value catalog pricing", "a priced model must not trip the unknown-pricing warning")
+}
+
+func TestDebitForInference_NoWarnOnZeroPricingOverride(t *testing.T) {
+	// Override/subscription-served turns are intentionally free — a $0 debit
+	// there is expected behavior, not a pricing gap.
+	buf := captureLogs(t)
+	repo := &fakeRepo{balanceRowExists: true, balanceMicros: 0}
+	svc := billing.NewService(repo)
+	_, err := svc.DebitForInference(context.Background(), billing.DebitInferenceParams{
+		OrganizationID: "org_internal",
+		Model:          "gpt-5.2",
+		Provider:       providers.ProviderOpenAI,
+		InputTokens:    1_000_000,
+		OutputTokens:   250_000,
+		Pricing:        catalog.Pricing{},
+		HasOverride:    true,
+	})
+	require.NoError(t, err)
+	assert.NotContains(t, buf.String(), "zero-value catalog pricing", "override turns are exempt from the unknown-pricing warning")
+}
+
+func TestDebitForInference_NoWarnOnZeroTokenUsage(t *testing.T) {
+	// 0-token usage (e.g. a failed request before generation) has zero
+	// pricing AND zero tokens — nothing was actually billed, so no warning.
+	buf := captureLogs(t)
+	repo := &fakeRepo{balanceRowExists: true, balanceMicros: 5_000_000}
+	svc := billing.NewService(repo)
+	_, err := svc.DebitForInference(context.Background(), billing.DebitInferenceParams{
+		OrganizationID: "org_x",
+		Model:          "gpt-5.2",
+		Provider:       providers.ProviderOpenAI,
+		Pricing:        catalog.Pricing{},
+	})
+	require.NoError(t, err)
+	assert.NotContains(t, buf.String(), "zero-value catalog pricing")
 }
 
 func TestDebitForInference_OverrideWritesZeroDeltaWithNotional(t *testing.T) {

--- a/internal/billing/service_test.go
+++ b/internal/billing/service_test.go
@@ -193,6 +193,26 @@ func TestDebitForInference_WarnsOnZeroPricingForRealUsage(t *testing.T) {
 	assert.Contains(t, buf.String(), "gpt-5.2")
 }
 
+func TestDebitForInference_WarnsOnZeroPricingForCacheOnlyUsage(t *testing.T) {
+	// A turn can be all cache reads/writes with zero fresh InputTokens/
+	// OutputTokens (e.g. a fully cache-hit prompt) — that's still real,
+	// billable usage and must not be treated as "nothing happened."
+	buf := captureLogs(t)
+	repo := &fakeRepo{balanceRowExists: true, balanceMicros: 10_000_000}
+	svc := billing.NewService(repo)
+	_, err := svc.DebitForInference(context.Background(), billing.DebitInferenceParams{
+		OrganizationID:  "org_x",
+		RouterRequestID: "req_cache_only",
+		Model:           "gpt-5.2",
+		Provider:        providers.ProviderOpenAI,
+		CacheRead:       500_000,
+		Pricing:         catalog.Pricing{}, // zero value: model not in catalog
+	})
+	require.NoError(t, err)
+	assert.Contains(t, buf.String(), "level=ERROR")
+	assert.Contains(t, buf.String(), "zero-value catalog pricing", "cache-only usage must still trip the unknown-pricing warning")
+}
+
 func TestDebitForInference_NoWarnOnKnownPricing(t *testing.T) {
 	buf := captureLogs(t)
 	repo := &fakeRepo{balanceRowExists: true, balanceMicros: 10_000_000}

--- a/internal/router/catalog/catalog.go
+++ b/internal/router/catalog/catalog.go
@@ -175,6 +175,20 @@ var Models = []Model{
 	{ID: "claude-sonnet-5", Tier: TierMid, ContextWindow: 200_000, Providers: []ProviderBinding{
 		{Provider: providers.ProviderAnthropic, Price: Pricing{InputUSDPer1M: 3.00, OutputUSDPer1M: 15.00, CacheReadMultiplier: 0.10}},
 	}},
+	// Legacy Opus IDs kept passthrough-priced (no Tier — not a routing
+	// target; see gpt-4o below for the same pattern) so BYOK/direct-model
+	// requests billing-debit at real cost instead of catalog.PrimaryPriceFor
+	// silently returning $0. Prices per the opus-4-6 comment below: 4.1 and
+	// earlier were $15/$75; 4.5 is the first $5/$25 release.
+	{ID: "claude-opus-4-0", ContextWindow: 200_000, Providers: []ProviderBinding{
+		{Provider: providers.ProviderAnthropic, Price: Pricing{InputUSDPer1M: 15.00, OutputUSDPer1M: 75.00, CacheReadMultiplier: 0.10}},
+	}},
+	{ID: "claude-opus-4-1", ContextWindow: 200_000, Providers: []ProviderBinding{
+		{Provider: providers.ProviderAnthropic, Price: Pricing{InputUSDPer1M: 15.00, OutputUSDPer1M: 75.00, CacheReadMultiplier: 0.10}},
+	}},
+	{ID: "claude-opus-4-5", ContextWindow: 200_000, Providers: []ProviderBinding{
+		{Provider: providers.ProviderAnthropic, Price: Pricing{InputUSDPer1M: 5.00, OutputUSDPer1M: 25.00, CacheReadMultiplier: 0.10}},
+	}},
 	// Opus 4.5+ is $5/$25 per MTok (down from $15/$75 on 4.1 and earlier).
 	// 4.6+/4.7+/4.8 support 1M context via the context-1m-2025-08-07 beta; the
 	// catalog reports 200K and the pre-filter expands to 1M when the beta

--- a/internal/router/catalog/catalog_test.go
+++ b/internal/router/catalog/catalog_test.go
@@ -90,6 +90,29 @@ func TestPriceFor_KnownPair(t *testing.T) {
 	assert.Equal(t, 0.10, p.CacheReadMultiplier)
 }
 
+func TestPrimaryPriceFor_LegacyOpusIDsResolve(t *testing.T) {
+	// claude-opus-4-0/4-1/4-5 are legacy passthrough IDs (finding [30]):
+	// registered as capability specs in internal/router/model.go but were
+	// missing from catalog.Models, so PrimaryPriceFor silently returned a
+	// zero Pricing and billing debited $0 for real usage. Prices per the
+	// opus-4-6 comment in catalog.go: 4.1-and-earlier = $15/$75, 4.5 = $5/$25.
+	cases := []struct {
+		id             string
+		inputUSDPer1M  float64
+		outputUSDPer1M float64
+	}{
+		{"claude-opus-4-0", 15.00, 75.00},
+		{"claude-opus-4-1", 15.00, 75.00},
+		{"claude-opus-4-5", 5.00, 25.00},
+	}
+	for _, tc := range cases {
+		p, ok := PrimaryPriceFor(tc.id)
+		require.True(t, ok, "%s must resolve to a catalog entry", tc.id)
+		assert.Equal(t, tc.inputUSDPer1M, p.InputUSDPer1M, "%s input price", tc.id)
+		assert.Equal(t, tc.outputUSDPer1M, p.OutputUSDPer1M, "%s output price", tc.id)
+	}
+}
+
 func TestResolveBinding_PicksFirstAvailable(t *testing.T) {
 	// claude-opus-4-7 is anthropic-only, so it should resolve only when anthropic is available.
 	avail := map[string]struct{}{providers.ProviderAnthropic: {}}


### PR DESCRIPTION
## Summary

Addresses finding **[30]**: `internal/router/catalog/catalog.go` — 18 model IDs carry real capability specs wired in `internal/router/model.go`'s `registry` map, but have zero corresponding entry in `catalog.Models`. Every price/tier accessor (`PrimaryPriceFor`, `PriceFor`, `TierFor`) silently returns a zero value for these IDs, and the billing debit path (`billing.DebitForInference`, fed by `otel.Lookup`/`catalog.PrimaryPriceFor`) turns that into a **$0.00 charge with no log** — so a passthrough/BYOK turn on any of these 18 models is billed as free today, silently.

**This touches billing-sensitive pricing data. No pricing numbers were fabricated** — the 3 catalog entries added here are copied verbatim from an existing in-repo comment; every other ID is left uncovered by real pricing and instead gets a loud Error log at the debit site.

## How the 18 were found

Diffed the model-ID keys in `internal/router/model.go`'s `registry` against `catalog.Models`' `ID`s. All 18 registry entries turned out to still be **live, supported passthrough model IDs** — not dead code — confirmed by cross-references elsewhere in the repo (`internal/translate/envelope.go`'s per-model max-tokens table, `internal/proxy/force_model.go`'s reasoning-model allowlist, `internal/translate/default_max_tokens_test.go`). None showed any deprecation/retirement signal in git history or comments, so **none were deleted**.

## Per-ID disposition

| Model ID | Disposition | Reasoning | Confidence |
|---|---|---|---|
| `claude-opus-4-5` | **Priced** | catalog.go's own comment on the opus-4-6 entry states "Opus 4.5+ is $5/$25 per MTok" — this is that exact release. Added `$5.00/$25.00`, no Tier (passthrough-only, matching the `gpt-4o` pattern). | High — direct quote from an existing sourced comment in this file |
| `claude-opus-4-1` | **Priced** | Same comment: "down from $15/$75 on 4.1 and earlier." Added `$15.00/$75.00`. | High — direct quote |
| `claude-opus-4-0` | **Priced** | Same comment's "4.1 and earlier" — Opus 4.0 predates 4.1 chronologically, so it's covered by the same "$15/$75" statement. Added `$15.00/$75.00`. | Medium-high — inferred from "and earlier" rather than an explicit "4.0" mention |
| `claude-sonnet-4-0` | **Warn-only (uncertain)** | Every Sonnet entry in the catalog (4-5, 4-6, 5) is priced $3/$15, suggesting the same for 4-0, but no comment or source explicitly states Sonnet 4.0's price. Declined to extrapolate a billing number from a pattern alone. | Left to a human with an authoritative Anthropic pricing source |
| `gpt-4` | **Warn-only (uncertain)** | Legacy OpenAI model, still in the max-tokens table (`envelope.go`) and capability registry, but no price is referenced anywhere in this repo or the sibling `eval/pricing.py`. | Needs OpenAI pricing docs to close |
| `gpt-4-turbo` | **Warn-only (uncertain)** | Same as above — actively referenced (`envelope.go` has an explicit 4096-token cap test for it) but unpriced anywhere in-repo. | Needs OpenAI pricing docs to close |
| `gpt-5-pro` | **Warn-only (uncertain)** | Sits between `gpt-5`/`gpt-5-chat` (priced) and `gpt-5.4-pro`/`gpt-5.5-pro` (priced) in the catalog's numbering, but has no entry of its own and no in-repo price reference. | Needs OpenAI pricing docs to close |
| `gpt-5.1` | **Warn-only (uncertain)** | Catalog jumps straight from `gpt-5` to `gpt-5.4`; `5.1`/`5.2`/`5.3` are referenced in `envelope.go`'s token-limit table but never priced. | Needs OpenAI pricing docs to close |
| `gpt-5.2` | **Warn-only (uncertain)** | Same gap as `gpt-5.1`. | Needs OpenAI pricing docs to close |
| `gpt-5.2-pro` | **Warn-only (uncertain)** | Same gap. | Needs OpenAI pricing docs to close |
| `gpt-5.3` | **Warn-only (uncertain)** | Same gap. | Needs OpenAI pricing docs to close |
| `o1` | **Warn-only (uncertain)** | OpenAI o-series reasoning model, still in `envelope.go`'s max-tokens table and `openaiReasoning` capability spec, but the catalog has never carried any o-series pricing (not just missing — absent from the whole table), and no price is referenced in-repo. | Needs OpenAI pricing docs to close |
| `o1-pro` | **Warn-only (uncertain)** | Same as `o1`. | Needs OpenAI pricing docs to close |
| `o1-mini` | **Warn-only (uncertain)** | Same as `o1`. | Needs OpenAI pricing docs to close |
| `o3` | **Warn-only (uncertain)** | Same as `o1`; also directly exercised in `default_max_tokens_test.go` via `router.Lookup("o3")`. | Needs OpenAI pricing docs to close |
| `o3-pro` | **Warn-only (uncertain)** | Same as `o1`. | Needs OpenAI pricing docs to close |
| `o3-mini` | **Warn-only (uncertain)** | Same as `o1`. | Needs OpenAI pricing docs to close |
| `o4-mini` | **Warn-only (uncertain)** | Same as `o1`. | Needs OpenAI pricing docs to close |

**Deleted: 0.** All 18 IDs show live usage elsewhere in the codebase (capability tables, allowlists, tests) with no deprecation signal, so treating any of them as dead code would itself be a guess.

## What changed

1. **`internal/router/catalog/catalog.go`** — added 3 `Model{}` entries (`claude-opus-4-0`, `claude-opus-4-1`, `claude-opus-4-5`), each with a comment citing the existing opus-4-6 pricing note as the source. No `Tier` set (passthrough-only, matching the `gpt-4o` family's existing pattern).
2. **`internal/billing/service.go`** — added `warnOnUnknownPricing`, called at the top of `DebitForInference`. Logs `observability.Get().Error(...)` naming the model/provider/org/request whenever a non-override, non-subscription turn with real token usage resolves to a zero-value `Pricing`. This is the safety net for the remaining 15 unresolved IDs (and any future model ID that slips through the same gap).
3. **`install/install.sh` + `install/cc-statusline.sh`** — regenerated via `go run ./cmd/genprices` to pick up the 3 new catalog prices, per `internal/router/catalog/CLAUDE.md`.
4. Tests:
   - `internal/router/catalog/catalog_test.go`: `TestPrimaryPriceFor_LegacyOpusIDsResolve` asserts the 3 new entries resolve to the correct prices.
   - `internal/billing/service_test.go`: 4 new tests around `warnOnUnknownPricing` — fires on zero-pricing + real usage, silent on known pricing, silent on override/subscription turns, silent on zero-token usage.

## Validation

- `go build ./...` — passes
- `go test ./...` — passes (full suite, including the new tests)
- `gofmt -l .` / `go vet ./...` — clean

## Flag for reviewer

**15 of the 18 IDs remain unpriced** (`claude-sonnet-4-0` + all 14 OpenAI legacy/o-series IDs) — they're covered only by the new warn-on-miss log, not a real catalog price. If any of them see live traffic, that traffic is still billed at $0 until someone adds a sourced price. The Error log should make that visible in on-call/alerting instead of silent. Recommend following up with authoritative OpenAI (and Anthropic, for `sonnet-4-0`) pricing before merge or shortly after, if these IDs are expected to see real traffic.