### PR TITLE
fix: don't panic on lru.New error in Cache.bucket (request path)

### DIFF
--- a/internal/router/cache/cache.go
+++ b/internal/router/cache/cache.go
@@ -12,6 +12,8 @@ import (
 	"time"
 
 	lru "github.com/hashicorp/golang-lru/v2"
+
+	"workweave/router/internal/observability"
 )
 
 // CachedResponse captures the upstream response in the inbound wire format.
@@ -210,7 +212,8 @@ func (c *Cache) bucket(installationID string, format Format, clusterID int, clus
 		}
 		buckets, err := lru.New[bucketKey, *lru.Cache[entryKey, *entry]](c.cfg.MaxBucketsPerInstallation)
 		if err != nil {
-			panic(err)
+			observability.Get().Error("cache: failed to allocate installation bucket LRU; treating as cache miss", "err", err)
+			return nil
 		}
 		ic = &installationCache{buckets: buckets}
 		c.installations.Add(installationID, ic)
@@ -222,7 +225,8 @@ func (c *Cache) bucket(installationID string, format Format, clusterID int, clus
 		}
 		b, err := lru.New[entryKey, *entry](c.cfg.BucketSize)
 		if err != nil {
-			panic(err)
+			observability.Get().Error("cache: failed to allocate entry LRU; treating as cache miss", "err", err)
+			return nil
 		}
 		ic.buckets.Add(key, b)
 		return b

--- a/internal/router/cache/cache_internal_test.go
+++ b/internal/router/cache/cache_internal_test.go
@@ -1,0 +1,72 @@
+package cache
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	lru "github.com/hashicorp/golang-lru/v2"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newBrokenCache builds a Cache bypassing New()'s validation, so cfg fields
+// that would make lru.New fail (size <= 0) survive into bucket().
+func newBrokenCache(t *testing.T, cfg Config) *Cache {
+	t.Helper()
+	installations, err := lru.New[string, *installationCache](1)
+	require.NoError(t, err)
+	return &Cache{
+		cfg:           cfg,
+		now:           time.Now,
+		installations: installations,
+	}
+}
+
+// TestBucket_InvalidMaxBucketsPerInstallationNoOpsInsteadOfPanic pins finding
+// [32]: a size <= 0 passed to lru.New for a never-seen installation must be
+// treated as a cache-miss/no-op, not a request-path panic.
+func TestBucket_InvalidMaxBucketsPerInstallationNoOpsInsteadOfPanic(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.MaxBucketsPerInstallation = 0 // lru.New rejects size <= 0
+	c := newBrokenCache(t, cfg)
+
+	assert.NotPanics(t, func() {
+		b := c.bucket("inst-1", FormatAnthropic, 0, "v1", 0, true)
+		assert.Nil(t, b, "bucket allocation failure must surface as nil, not panic")
+	})
+}
+
+// TestBucket_InvalidBucketSizeNoOpsInsteadOfPanic pins the second lru.New
+// call site (per-bucket entry LRU) under the same rule.
+func TestBucket_InvalidBucketSizeNoOpsInsteadOfPanic(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.BucketSize = 0 // lru.New rejects size <= 0
+	c := newBrokenCache(t, cfg)
+
+	assert.NotPanics(t, func() {
+		b := c.bucket("inst-1", FormatAnthropic, 0, "v1", 0, true)
+		assert.Nil(t, b, "bucket allocation failure must surface as nil, not panic")
+	})
+}
+
+// TestLookupAndStore_SurviveBrokenBucketAllocation exercises the actual
+// request-path entry points (Lookup/Store), not just bucket() directly, to
+// prove callers never observe a panic when lru.New fails.
+func TestLookupAndStore_SurviveBrokenBucketAllocation(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.MaxBucketsPerInstallation = 0
+	c := newBrokenCache(t, cfg)
+	emb := []float32{1, 0, 0, 0}
+
+	assert.NotPanics(t, func() {
+		c.Store("inst-1", FormatAnthropic, emb, 0, CachedResponse{StatusCode: http.StatusOK}, "v1", 0)
+	})
+
+	var hit bool
+	assert.NotPanics(t, func() {
+		_, hit = c.Lookup("inst-1", FormatAnthropic, emb, []int{0}, "v1", 0)
+	})
+	assert.False(t, hit, "broken bucket allocation must degrade to a cache miss")
+}


### PR DESCRIPTION
## Summary

Fixes finding [32]: `Cache.bucket`, called from the request-path `Lookup` and `Store` methods, contained two `panic(err)` calls around `lru.New`, violating the repo's "never panic on request path" hard rule — even though the panic is currently unreachable in practice (`New()` already validates/defaults the relevant `Config` fields before construction).

`bucket()` now treats an `lru.New` error as a cache-miss/no-op: it logs via `observability.Get().Error(...)` and returns `nil`, mirroring how `Lookup`/`Store` already treat a nil `Cache` or empty embedding as a safe no-op. `panic` is still used in `New()` for the one-time construction-time validation, per the "reserve panic for startup-time fail-fast" rule.

## Test plan

- [x] Added `internal/router/cache/cache_internal_test.go` (in-package test, needed to reach the unexported `bucket()` and to construct a `Cache` that bypasses `New()`'s validation) proving:
  - `bucket()` returns `nil` instead of panicking when `MaxBucketsPerInstallation <= 0` (first `lru.New` call site — brand new installation).
  - `bucket()` returns `nil` instead of panicking when `BucketSize <= 0` (second `lru.New` call site — new bucket key).
  - `Lookup`/`Store` (the actual request-path entry points) don't panic and degrade to a miss/no-op when bucket allocation fails.
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .` (clean)
- [x] `go test ./...` (all packages pass)