### PR TITLE
fix: correct log levels to match documented conventions (4 sites)

### DIFF
--- a/internal/observability/otel/emitter.go
+++ b/internal/observability/otel/emitter.go
@@ -3,7 +3,6 @@ package otel
 import (
 	"bytes"
 	"context"
-	"log/slog"
 	"net/http"
 	"strings"
 	"sync"
@@ -18,6 +17,8 @@ import (
 	logsv1 "go.opentelemetry.io/proto/otlp/logs/v1"
 	resourcev1 "go.opentelemetry.io/proto/otlp/resource/v1"
 	tracev1 "go.opentelemetry.io/proto/otlp/trace/v1"
+
+	"workweave/router/internal/observability"
 )
 
 // EmitterConfig controls the emitter's async export pipeline.
@@ -175,7 +176,7 @@ func (e *Emitter) Shutdown(c context.Context) error {
 	}
 
 	if n := e.dropped.Load(); n > 0 {
-		slog.Warn("Dropped spans during emitter lifetime", "count", n)
+		observability.Get().Warn("Dropped spans during emitter lifetime", "count", n)
 	}
 
 	return nil
@@ -263,7 +264,7 @@ func (e *Emitter) exportBatch(spans []*tracev1.Span) {
 
 	body, err := proto.Marshal(req)
 	if err != nil {
-		slog.Warn("Failed to marshal OTLP export request", "err", err)
+		observability.Get().Warn("Failed to marshal OTLP export request", "err", err)
 		return
 	}
 	e.post(e.endpoint, body)
@@ -282,7 +283,7 @@ func (e *Emitter) exportLogBatch(records []*logsv1.LogRecord) {
 
 	body, err := proto.Marshal(req)
 	if err != nil {
-		slog.Warn("Failed to marshal OTLP log export request", "err", err)
+		observability.Get().Warn("Failed to marshal OTLP log export request", "err", err)
 		return
 	}
 	e.post(e.logEndpoint, body)
@@ -293,7 +294,7 @@ func (e *Emitter) exportLogBatch(records []*logsv1.LogRecord) {
 func (e *Emitter) post(endpoint string, body []byte) {
 	httpReq, err := http.NewRequest(http.MethodPost, endpoint, bytes.NewReader(body))
 	if err != nil {
-		slog.Warn("Failed to create OTLP export HTTP request", "err", err)
+		observability.Get().Warn("Failed to create OTLP export HTTP request", "err", err)
 		return
 	}
 	httpReq.Header.Set("Content-Type", "application/x-protobuf")
@@ -303,12 +304,12 @@ func (e *Emitter) post(endpoint string, body []byte) {
 
 	resp, err := e.client.Do(httpReq)
 	if err != nil {
-		slog.Warn("OTLP export request failed", "err", err)
+		observability.Get().Warn("OTLP export request failed", "err", err)
 		return
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		slog.Warn("OTLP export returned non-2xx status", "status", resp.StatusCode)
+		observability.Get().Warn("OTLP export returned non-2xx status", "status", resp.StatusCode)
 	}
 }

--- a/internal/proxy/log_io.go
+++ b/internal/proxy/log_io.go
@@ -46,7 +46,7 @@ func logInboundToolTraffic(log *slog.Logger, env *translate.RequestEnvelope) {
 	for _, s := range sigs {
 		names = append(names, s.Name)
 	}
-	log.Info("inbound tool_use history",
+	log.Debug("inbound tool_use history",
 		"total_tool_calls", len(sigs),
 		"tool_names", names,
 		"tail_window_args", args,
@@ -136,7 +136,7 @@ func logAssistantOutputSummary(
 		names = append(names, tc.Name)
 		args = append(args, preview(tc.ArgsJSON, 160))
 	}
-	log.Info("assistant output summary",
+	log.Debug("assistant output summary",
 		"text_blocks", textBlocks,
 		"thinking_blocks", thinkingBlocks,
 		"tool_use_count", len(toolCalls),

--- a/internal/server/middleware/auth.go
+++ b/internal/server/middleware/auth.go
@@ -199,9 +199,9 @@ func handleAuthError(c *gin.Context, err error) {
 	logger := observability.FromGin(c)
 	switch {
 	case errors.Is(err, auth.ErrInvalidPrefix):
-		logger.Info("Auth rejected: invalid bearer prefix (expected rk_...)")
+		logger.Debug("Auth rejected: invalid bearer prefix (expected rk_...)")
 	case errors.Is(err, auth.ErrInvalidToken):
-		logger.Info("Auth rejected: bearer token did not match an active key")
+		logger.Debug("Auth rejected: bearer token did not match an active key")
 	default:
 		// Infra failure (DB unreachable, etc.). Still 401 to the caller; logged as Error for on-call.
 		logger.Error("Auth check errored", "err", err)

--- a/internal/translate/responses_to_anthropic_writer.go
+++ b/internal/translate/responses_to_anthropic_writer.go
@@ -318,7 +318,7 @@ func (t *ResponsesToAnthropicWriter) handleOutputItemAdded(data []byte) error {
 		// reconciledStopReason demotes a terminal tool_use claim with no
 		// surviving block to end_turn.
 		t.suppressed[oi] = struct{}{}
-		observability.Get().Error(
+		observability.Get().Warn(
 			"ResponsesToAnthropic dropping nameless function_call",
 			"request_model", t.requestModel,
 			"call_id", item.Get("call_id").String(),
@@ -912,7 +912,7 @@ func (t *ResponsesToAnthropicWriter) emitValidatedToolArgsDelta(oi, index int, f
 			if len(preview) > previewMax {
 				preview = preview[:previewMax]
 			}
-			observability.Get().Error(
+			observability.Get().Warn(
 				"ResponsesToAnthropic tool_use args failed JSON validation — substituting empty args",
 				"block_index", index,
 				"request_model", t.requestModel,


### PR DESCRIPTION
## Summary

Four isolated logging-level/channel fixes, each matching the repo's documented Info/Debug/Warn/Error conventions.

- **[19]** `internal/proxy/log_io.go:36` — `logInboundToolTraffic` and `logAssistantOutputSummary` logged at Info despite their own docstrings' intent to keep full-body/per-request diagnostics behind Debug; `logInboundToolTraffic` runs on every single request. Both now log at `log.Debug`.
- **[61]** `internal/server/middleware/auth.go:201` — `handleAuthError` logged routine 401 rejections (invalid prefix / invalid token) at Info on every authenticated request, the highest-volume path, contradicting the documented "auth-401 is Debug, not Error" rule. Both branches now log at Debug; the infra-failure default branch stays at Error.
- **[69]** `internal/observability/otel/emitter.go:172` — 6 call sites logged via raw `log/slog` instead of the documented `observability.Get()` entry point, bypassing LOG_LEVEL/format-aware handling. All 6 now go through `observability.Get().Warn(...)`; the now-unused `log/slog` import was dropped.
- **[6]** `internal/translate/responses_to_anthropic_writer.go:350` — A documented, expected, fail-open upstream quirk (nameless `function_call`, unparseable tool-args JSON) was logged at Error, inconsistent with the sibling `toolcheck` package's Warn for equivalent fail-open anomalies. Both call sites downgraded to Warn.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .` (clean)
- [x] `go test ./...` (all packages pass)
- [x] Confirmed no existing test asserts on log level/content for the four touched call sites