### PR TITLE
refactor: extract shared metricsScope helper in admin metrics handlers

### DIFF
--- a/internal/api/admin/metrics.go
+++ b/internal/api/admin/metrics.go
@@ -29,23 +29,38 @@ type metricsTimeseriesResponse struct {
 	Buckets []timeseriesBucket `json:"buckets"`
 }
 
+// metricsScope resolves whether the caller may see metrics across all installations
+// (admin cookie) or must be scoped to their own installation (bearer auth). When
+// neither applies, it aborts the request with 401 and returns ok=false.
+func metricsScope(c *gin.Context) (allInstallations bool, installationID string, ok bool) {
+	if admin := middleware.AdminPrincipalFrom(c); admin != nil {
+		return true, "", true
+	}
+	installation := middleware.InstallationFrom(c)
+	if installation == nil {
+		c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "invalid_key"})
+		return false, "", false
+	}
+	return false, installation.ID, true
+}
+
 func MetricsSummaryHandler(proxySvc *proxy.Service) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		from, to := parseTimeWindow(c)
+
+		allInstallations, installationID, ok := metricsScope(c)
+		if !ok {
+			return
+		}
 
 		var (
 			summary proxy.TelemetrySummary
 			err     error
 		)
-		if admin := middleware.AdminPrincipalFrom(c); admin != nil {
+		if allInstallations {
 			summary, err = proxySvc.MetricsSummaryAll(c.Request.Context(), from, to)
 		} else {
-			installation := middleware.InstallationFrom(c)
-			if installation == nil {
-				c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "invalid_key"})
-				return
-			}
-			summary, err = proxySvc.MetricsSummary(c.Request.Context(), installation.ID, from, to)
+			summary, err = proxySvc.MetricsSummary(c.Request.Context(), installationID, from, to)
 		}
 		if err != nil {
 			c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"error": "Failed to fetch metrics."})
@@ -70,19 +85,19 @@ func MetricsTimeseriesHandler(proxySvc *proxy.Service) gin.HandlerFunc {
 		}
 		from, to := parseTimeWindow(c)
 
+		allInstallations, installationID, ok := metricsScope(c)
+		if !ok {
+			return
+		}
+
 		var (
 			buckets []proxy.TelemetryBucket
 			err     error
 		)
-		if admin := middleware.AdminPrincipalFrom(c); admin != nil {
+		if allInstallations {
 			buckets, err = proxySvc.MetricsTimeseriesAll(c.Request.Context(), from, to, granularity)
 		} else {
-			installation := middleware.InstallationFrom(c)
-			if installation == nil {
-				c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "invalid_key"})
-				return
-			}
-			buckets, err = proxySvc.MetricsTimeseries(c.Request.Context(), installation.ID, from, to, granularity)
+			buckets, err = proxySvc.MetricsTimeseries(c.Request.Context(), installationID, from, to, granularity)
 		}
 		if err != nil {
 			c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"error": "Failed to fetch timeseries."})
@@ -143,19 +158,19 @@ func MetricsDetailsHandler(proxySvc *proxy.Service) gin.HandlerFunc {
 			}
 		}
 
+		allInstallations, installationID, ok := metricsScope(c)
+		if !ok {
+			return
+		}
+
 		var (
 			rows []proxy.TelemetryRow
 			err  error
 		)
-		if admin := middleware.AdminPrincipalFrom(c); admin != nil {
+		if allInstallations {
 			rows, err = proxySvc.MetricsRowsAll(c.Request.Context(), from, to, limit)
 		} else {
-			installation := middleware.InstallationFrom(c)
-			if installation == nil {
-				c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "invalid_key"})
-				return
-			}
-			rows, err = proxySvc.MetricsRows(c.Request.Context(), installation.ID, from, to, limit)
+			rows, err = proxySvc.MetricsRows(c.Request.Context(), installationID, from, to, limit)
 		}
 		if err != nil {
 			c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"error": "Failed to fetch details."})


### PR DESCRIPTION
## Summary
- The admin-cookie-vs-installation branching used to pick which `proxy.Service` method to call was copy-pasted verbatim across `MetricsSummaryHandler`, `MetricsTimeseriesHandler`, and `MetricsDetailsHandler` in `internal/api/admin/metrics.go`.
- Extracted a `metricsScope(c *gin.Context) (allInstallations bool, installationID string, ok bool)` helper. Each handler now calls it once, then branches only on which `proxy.Service` method variant (`*All` vs scoped) to invoke.
- Behavior-preserving: same 401 on missing admin/installation, same method selection per scope.

Fixes [60].

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .` (clean)
- [x] `go test ./...` (all packages pass, including `internal/api/admin`)