### PR TITLE
refactor: dedup TelemetryRepo per-installation/admin-wide method pairs

### DIFF
--- a/internal/postgres/telemetry.go
+++ b/internal/postgres/telemetry.go
@@ -226,63 +226,44 @@ func (r *TelemetryRepo) GetTelemetryTimeseries(ctx context.Context, installation
 		return nil, err
 	}
 	q := sqlc.New(r.tx)
+	fromTs := pgtype.Timestamptz{Time: from, Valid: true}
+	toTs := pgtype.Timestamptz{Time: to, Valid: true}
 
-	switch granularity {
-	case "week":
-		rows, err := q.GetTelemetryTimeseriesWeekly(ctx, sqlc.GetTelemetryTimeseriesWeeklyParams{
-			InstallationID: id,
-			FromTime:       pgtype.Timestamptz{Time: from, Valid: true},
-			ToTime:         pgtype.Timestamptz{Time: to, Valid: true},
-		})
-		if err != nil {
-			return nil, err
-		}
-		out := make([]proxy.TelemetryBucket, 0, len(rows))
-		for _, row := range rows {
-			out = append(out, proxy.TelemetryBucket{
-				Bucket:           row.Bucket.Time,
-				RequestedCostUSD: microsToUSD(row.RequestedCostUsd),
-				ActualCostUSD:    microsToUSD(row.ActualCostUsd),
+	return selectTimeseriesGranularity(granularity,
+		func() ([]proxy.TelemetryBucket, error) {
+			rows, err := q.GetTelemetryTimeseriesWeekly(ctx, sqlc.GetTelemetryTimeseriesWeeklyParams{
+				InstallationID: id,
+				FromTime:       fromTs,
+				ToTime:         toTs,
 			})
-		}
-		return out, nil
-	case "day":
-		rows, err := q.GetTelemetryTimeseriesDaily(ctx, sqlc.GetTelemetryTimeseriesDailyParams{
-			InstallationID: id,
-			FromTime:       pgtype.Timestamptz{Time: from, Valid: true},
-			ToTime:         pgtype.Timestamptz{Time: to, Valid: true},
-		})
-		if err != nil {
-			return nil, err
-		}
-		out := make([]proxy.TelemetryBucket, 0, len(rows))
-		for _, row := range rows {
-			out = append(out, proxy.TelemetryBucket{
-				Bucket:           row.Bucket.Time,
-				RequestedCostUSD: microsToUSD(row.RequestedCostUsd),
-				ActualCostUSD:    microsToUSD(row.ActualCostUsd),
+			if err != nil {
+				return nil, err
+			}
+			return mapRows(rows, telemetryBucketFromWeeklyRow), nil
+		},
+		func() ([]proxy.TelemetryBucket, error) {
+			rows, err := q.GetTelemetryTimeseriesDaily(ctx, sqlc.GetTelemetryTimeseriesDailyParams{
+				InstallationID: id,
+				FromTime:       fromTs,
+				ToTime:         toTs,
 			})
-		}
-		return out, nil
-	}
-
-	rows, err := q.GetTelemetryTimeseriesHourly(ctx, sqlc.GetTelemetryTimeseriesHourlyParams{
-		InstallationID: id,
-		FromTime:       pgtype.Timestamptz{Time: from, Valid: true},
-		ToTime:         pgtype.Timestamptz{Time: to, Valid: true},
-	})
-	if err != nil {
-		return nil, err
-	}
-	out := make([]proxy.TelemetryBucket, 0, len(rows))
-	for _, row := range rows {
-		out = append(out, proxy.TelemetryBucket{
-			Bucket:           row.Bucket.Time,
-			RequestedCostUSD: microsToUSD(row.RequestedCostUsd),
-			ActualCostUSD:    microsToUSD(row.ActualCostUsd),
-		})
-	}
-	return out, nil
+			if err != nil {
+				return nil, err
+			}
+			return mapRows(rows, telemetryBucketFromDailyRow), nil
+		},
+		func() ([]proxy.TelemetryBucket, error) {
+			rows, err := q.GetTelemetryTimeseriesHourly(ctx, sqlc.GetTelemetryTimeseriesHourlyParams{
+				InstallationID: id,
+				FromTime:       fromTs,
+				ToTime:         toTs,
+			})
+			if err != nil {
+				return nil, err
+			}
+			return mapRows(rows, telemetryBucketFromHourlyRow), nil
+		},
+	)
 }
 
 // GetTelemetrySummaryAll aggregates across every installation for the admin dashboard.
@@ -307,60 +288,115 @@ func (r *TelemetryRepo) GetTelemetrySummaryAll(ctx context.Context, from, to tim
 // GetTelemetryTimeseriesAll is the admin-only counterpart to GetTelemetryTimeseries.
 func (r *TelemetryRepo) GetTelemetryTimeseriesAll(ctx context.Context, from, to time.Time, granularity string) ([]proxy.TelemetryBucket, error) {
 	q := sqlc.New(r.tx)
+	fromTs := pgtype.Timestamptz{Time: from, Valid: true}
+	toTs := pgtype.Timestamptz{Time: to, Valid: true}
 
+	return selectTimeseriesGranularity(granularity,
+		func() ([]proxy.TelemetryBucket, error) {
+			rows, err := q.GetTelemetryTimeseriesWeeklyAll(ctx, sqlc.GetTelemetryTimeseriesWeeklyAllParams{
+				FromTime: fromTs,
+				ToTime:   toTs,
+			})
+			if err != nil {
+				return nil, err
+			}
+			return mapRows(rows, telemetryBucketFromWeeklyAllRow), nil
+		},
+		func() ([]proxy.TelemetryBucket, error) {
+			rows, err := q.GetTelemetryTimeseriesDailyAll(ctx, sqlc.GetTelemetryTimeseriesDailyAllParams{
+				FromTime: fromTs,
+				ToTime:   toTs,
+			})
+			if err != nil {
+				return nil, err
+			}
+			return mapRows(rows, telemetryBucketFromDailyAllRow), nil
+		},
+		func() ([]proxy.TelemetryBucket, error) {
+			rows, err := q.GetTelemetryTimeseriesHourlyAll(ctx, sqlc.GetTelemetryTimeseriesHourlyAllParams{
+				FromTime: fromTs,
+				ToTime:   toTs,
+			})
+			if err != nil {
+				return nil, err
+			}
+			return mapRows(rows, telemetryBucketFromHourlyAllRow), nil
+		},
+	)
+}
+
+// selectTimeseriesGranularity dispatches to the query closure matching
+// granularity, defaulting to hourly — the shared switch behind both
+// GetTelemetryTimeseries and GetTelemetryTimeseriesAll.
+func selectTimeseriesGranularity(
+	granularity string,
+	weekly, daily, hourly func() ([]proxy.TelemetryBucket, error),
+) ([]proxy.TelemetryBucket, error) {
 	switch granularity {
 	case "week":
-		rows, err := q.GetTelemetryTimeseriesWeeklyAll(ctx, sqlc.GetTelemetryTimeseriesWeeklyAllParams{
-			FromTime: pgtype.Timestamptz{Time: from, Valid: true},
-			ToTime:   pgtype.Timestamptz{Time: to, Valid: true},
-		})
-		if err != nil {
-			return nil, err
-		}
-		out := make([]proxy.TelemetryBucket, 0, len(rows))
-		for _, row := range rows {
-			out = append(out, proxy.TelemetryBucket{
-				Bucket:           row.Bucket.Time,
-				RequestedCostUSD: microsToUSD(row.RequestedCostUsd),
-				ActualCostUSD:    microsToUSD(row.ActualCostUsd),
-			})
-		}
-		return out, nil
+		return weekly()
 	case "day":
-		rows, err := q.GetTelemetryTimeseriesDailyAll(ctx, sqlc.GetTelemetryTimeseriesDailyAllParams{
-			FromTime: pgtype.Timestamptz{Time: from, Valid: true},
-			ToTime:   pgtype.Timestamptz{Time: to, Valid: true},
-		})
-		if err != nil {
-			return nil, err
-		}
-		out := make([]proxy.TelemetryBucket, 0, len(rows))
-		for _, row := range rows {
-			out = append(out, proxy.TelemetryBucket{
-				Bucket:           row.Bucket.Time,
-				RequestedCostUSD: microsToUSD(row.RequestedCostUsd),
-				ActualCostUSD:    microsToUSD(row.ActualCostUsd),
-			})
-		}
-		return out, nil
+		return daily()
+	default:
+		return hourly()
 	}
+}
 
-	rows, err := q.GetTelemetryTimeseriesHourlyAll(ctx, sqlc.GetTelemetryTimeseriesHourlyAllParams{
-		FromTime: pgtype.Timestamptz{Time: from, Valid: true},
-		ToTime:   pgtype.Timestamptz{Time: to, Valid: true},
-	})
-	if err != nil {
-		return nil, err
-	}
-	out := make([]proxy.TelemetryBucket, 0, len(rows))
+// mapRows converts a slice of SQLC rows to a slice of domain values via convert.
+func mapRows[T, U any](rows []T, convert func(T) U) []U {
+	out := make([]U, 0, len(rows))
 	for _, row := range rows {
-		out = append(out, proxy.TelemetryBucket{
-			Bucket:           row.Bucket.Time,
-			RequestedCostUSD: microsToUSD(row.RequestedCostUsd),
-			ActualCostUSD:    microsToUSD(row.ActualCostUsd),
-		})
+		out = append(out, convert(row))
 	}
-	return out, nil
+	return out
+}
+
+func telemetryBucketFromWeeklyRow(row sqlc.GetTelemetryTimeseriesWeeklyRow) proxy.TelemetryBucket {
+	return proxy.TelemetryBucket{
+		Bucket:           row.Bucket.Time,
+		RequestedCostUSD: microsToUSD(row.RequestedCostUsd),
+		ActualCostUSD:    microsToUSD(row.ActualCostUsd),
+	}
+}
+
+func telemetryBucketFromDailyRow(row sqlc.GetTelemetryTimeseriesDailyRow) proxy.TelemetryBucket {
+	return proxy.TelemetryBucket{
+		Bucket:           row.Bucket.Time,
+		RequestedCostUSD: microsToUSD(row.RequestedCostUsd),
+		ActualCostUSD:    microsToUSD(row.ActualCostUsd),
+	}
+}
+
+func telemetryBucketFromHourlyRow(row sqlc.GetTelemetryTimeseriesHourlyRow) proxy.TelemetryBucket {
+	return proxy.TelemetryBucket{
+		Bucket:           row.Bucket.Time,
+		RequestedCostUSD: microsToUSD(row.RequestedCostUsd),
+		ActualCostUSD:    microsToUSD(row.ActualCostUsd),
+	}
+}
+
+func telemetryBucketFromWeeklyAllRow(row sqlc.GetTelemetryTimeseriesWeeklyAllRow) proxy.TelemetryBucket {
+	return proxy.TelemetryBucket{
+		Bucket:           row.Bucket.Time,
+		RequestedCostUSD: microsToUSD(row.RequestedCostUsd),
+		ActualCostUSD:    microsToUSD(row.ActualCostUsd),
+	}
+}
+
+func telemetryBucketFromDailyAllRow(row sqlc.GetTelemetryTimeseriesDailyAllRow) proxy.TelemetryBucket {
+	return proxy.TelemetryBucket{
+		Bucket:           row.Bucket.Time,
+		RequestedCostUSD: microsToUSD(row.RequestedCostUsd),
+		ActualCostUSD:    microsToUSD(row.ActualCostUsd),
+	}
+}
+
+func telemetryBucketFromHourlyAllRow(row sqlc.GetTelemetryTimeseriesHourlyAllRow) proxy.TelemetryBucket {
+	return proxy.TelemetryBucket{
+		Bucket:           row.Bucket.Time,
+		RequestedCostUSD: microsToUSD(row.RequestedCostUsd),
+		ActualCostUSD:    microsToUSD(row.ActualCostUsd),
+	}
 }
 
 // GetTelemetryRows returns individual telemetry rows for an installation in [from, to) for the drill-down modal.
@@ -379,30 +415,7 @@ func (r *TelemetryRepo) GetTelemetryRows(ctx context.Context, installationID str
 	if err != nil {
 		return nil, err
 	}
-	out := make([]proxy.TelemetryRow, 0, len(rows))
-	for _, row := range rows {
-		out = append(out, telemetryRowFromRow(
-			row.Timestamp.Time,
-			row.RequestID,
-			row.RequestedModel,
-			row.DecisionModel,
-			row.DecisionProvider,
-			row.DecisionReason,
-			row.StickyHit,
-			row.InputTokens,
-			row.OutputTokens,
-			row.CacheCreationTokens,
-			row.CacheReadTokens,
-			row.RequestedCostUsd,
-			row.ActualCostUsd,
-			row.TotalLatencyMs,
-			row.UpstreamStatusCode,
-			uuidString(row.RouterUserID),
-			row.ClientApp,
-			row.TurnType,
-			row.UserEmail,
-		))
-	}
+	out := mapRows(rows, telemetryRowFromRowsRow)
 	return out, nil
 }
 
@@ -417,30 +430,7 @@ func (r *TelemetryRepo) GetTelemetryRowsAll(ctx context.Context, from, to time.T
 	if err != nil {
 		return nil, err
 	}
-	out := make([]proxy.TelemetryRow, 0, len(rows))
-	for _, row := range rows {
-		out = append(out, telemetryRowFromRow(
-			row.Timestamp.Time,
-			row.RequestID,
-			row.RequestedModel,
-			row.DecisionModel,
-			row.DecisionProvider,
-			row.DecisionReason,
-			row.StickyHit,
-			row.InputTokens,
-			row.OutputTokens,
-			row.CacheCreationTokens,
-			row.CacheReadTokens,
-			row.RequestedCostUsd,
-			row.ActualCostUsd,
-			row.TotalLatencyMs,
-			row.UpstreamStatusCode,
-			uuidString(row.RouterUserID),
-			row.ClientApp,
-			row.TurnType,
-			row.UserEmail,
-		))
-	}
+	out := mapRows(rows, telemetryRowFromRowsAllRow)
 	return out, nil
 }
 
@@ -507,4 +497,52 @@ func telemetryRowFromRow(
 		TurnType:            turnType,
 		UserEmail:           deref(userEmail),
 	}
+}
+
+func telemetryRowFromRowsRow(row sqlc.GetTelemetryRowsRow) proxy.TelemetryRow {
+	return telemetryRowFromRow(
+		row.Timestamp.Time,
+		row.RequestID,
+		row.RequestedModel,
+		row.DecisionModel,
+		row.DecisionProvider,
+		row.DecisionReason,
+		row.StickyHit,
+		row.InputTokens,
+		row.OutputTokens,
+		row.CacheCreationTokens,
+		row.CacheReadTokens,
+		row.RequestedCostUsd,
+		row.ActualCostUsd,
+		row.TotalLatencyMs,
+		row.UpstreamStatusCode,
+		uuidString(row.RouterUserID),
+		row.ClientApp,
+		row.TurnType,
+		row.UserEmail,
+	)
+}
+
+func telemetryRowFromRowsAllRow(row sqlc.GetTelemetryRowsAllRow) proxy.TelemetryRow {
+	return telemetryRowFromRow(
+		row.Timestamp.Time,
+		row.RequestID,
+		row.RequestedModel,
+		row.DecisionModel,
+		row.DecisionProvider,
+		row.DecisionReason,
+		row.StickyHit,
+		row.InputTokens,
+		row.OutputTokens,
+		row.CacheCreationTokens,
+		row.CacheReadTokens,
+		row.RequestedCostUsd,
+		row.ActualCostUsd,
+		row.TotalLatencyMs,
+		row.UpstreamStatusCode,
+		uuidString(row.RouterUserID),
+		row.ClientApp,
+		row.TurnType,
+		row.UserEmail,
+	)
 }


### PR DESCRIPTION
## Summary

`TelemetryRepo` had three near-identical per-installation/admin-wide method pairs (`GetTelemetrySummary`/`All`, `GetTelemetryTimeseries`/`All`, `GetTelemetryRows`/`All`) whose bodies differed only in the SQLC call and the presence of an installation filter [75].

- Extracted a generic `mapRows[T, U any](rows []T, convert func(T) U) []U` helper and used it at all 8 call sites (3 granularities x 2 variants for timeseries, plus the 2 row-listing methods), replacing the repeated `make + for + append` boilerplate.
- Extracted `selectTimeseriesGranularity` — a single granularity-switch dispatcher parameterized by three per-granularity query closures — called once from each of `GetTelemetryTimeseries` and `GetTelemetryTimeseriesAll`.
- Added small named row->bucket / row->row adapter functions (`telemetryBucketFromWeeklyRow`, etc.) since Go generics can't unify the six structurally-identical-but-distinctly-named SQLC row types directly.
- `GetTelemetrySummary`/`GetTelemetrySummaryAll` were left as-is — their bodies are just one query call + one literal struct, no real duplication to extract there.
- No SQL or SQLC-generated files touched; this is a pure Go-side refactor of the hand-written wrapper methods in `internal/postgres/telemetry.go`.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .` (clean)
- [x] `go test ./...` (all packages pass, including `internal/postgres`)
- [x] Manually diffed old vs new behavior per method — output shape/values unchanged