### PR TITLE
refactor: extract shared expireSessionPin helper (5 call sites)

### DIFF
--- a/internal/proxy/force_model.go
+++ b/internal/proxy/force_model.go
@@ -237,19 +237,7 @@ func (s *Service) handleForceModelCommand(
 	var msg string
 	if cmd.Clear {
 		if s.pinStore != nil && installationID != uuid.Nil {
-			expired := sessionpin.Pin{
-				SessionKey:     sessionKey,
-				Role:           role,
-				InstallationID: installationID,
-				Provider:       "",
-				Model:          "",
-				Reason:         "user_unforced",
-				TurnCount:      1,
-				PinnedUntil:    time.Now().Add(-time.Second),
-			}
-			// context.Background(): ctx may be canceled by the time the
-			// synthetic response is written; a canceled ctx would strand the prior pin.
-			if err := s.pinStore.Upsert(context.Background(), expired); err != nil {
+			if err := s.expireSessionPin(ctx, installationID, sessionKey, role, "user_unforced"); err != nil {
 				log.Error("/unforce-model: pin store upsert failed", "err", err)
 				return err
 			}

--- a/internal/proxy/loop_detection.go
+++ b/internal/proxy/loop_detection.go
@@ -351,19 +351,7 @@ func (s *Service) handleToolCallLoopBreak(
 	// Expire the pin in Postgres (not just the in-proc cache) so a racing
 	// reader on another pod can't repopulate the LRU from the stale row.
 	if s.pinStore != nil && installationID != uuid.Nil {
-		expired := sessionpin.Pin{
-			SessionKey:     sessionKey,
-			Role:           role,
-			InstallationID: installationID,
-			Provider:       "",
-			Model:          "",
-			Reason:         "tool_call_loop_break",
-			TurnCount:      1,
-			PinnedUntil:    time.Now().Add(-time.Second),
-		}
-		// context.Background(): request ctx may already be canceled (client
-		// drops slow turns); upserting on it would silently fail, leaving the bad pin.
-		if err := s.pinStore.Upsert(context.Background(), expired); err != nil {
+		if err := s.expireSessionPin(ctx, installationID, sessionKey, role, "tool_call_loop_break"); err != nil {
 			log.Error("loop-break: pin store upsert failed", "err", err)
 		}
 	}

--- a/internal/proxy/no_progress.go
+++ b/internal/proxy/no_progress.go
@@ -282,17 +282,7 @@ func (s *Service) handleNoProgressBreak(
 	// Skip when sessionKey is zero: a zero-keyed pin row would be a zombie
 	// entry shared by every zero-keyed session.
 	if s.pinStore != nil && installationID != uuid.Nil && sessionKey != ([sessionpin.SessionKeyLen]byte{}) {
-		expired := sessionpin.Pin{
-			SessionKey:     sessionKey,
-			Role:           role,
-			InstallationID: installationID,
-			Provider:       "",
-			Model:          "",
-			Reason:         "no_progress_loop_break",
-			TurnCount:      1,
-			PinnedUntil:    time.Now().Add(-time.Second),
-		}
-		if err := s.pinStore.Upsert(context.Background(), expired); err != nil {
+		if err := s.expireSessionPin(ctx, installationID, sessionKey, role, "no_progress_loop_break"); err != nil {
 			log.Error("no-progress-break: pin store upsert failed", "err", err)
 		}
 	}

--- a/internal/proxy/pin_eviction.go
+++ b/internal/proxy/pin_eviction.go
@@ -18,6 +18,36 @@ import (
 // without flushing a working pin's prompt cache.
 const pinEvictionStrikeThreshold = 2
 
+// expireSessionPin writes an already-expired sessionpin.Pin so the next
+// turn's loadPin discards it and the session re-routes via the cluster
+// scorer. Shared by force-model clear, loop-break/no-progress/
+// degenerate-response eviction, and the upstream-error strike threshold —
+// call sites differ only in the Reason string recorded for observability.
+//
+// context.Background(): callers invoke this once the response has already
+// streamed or is about to be written, so the request ctx may already be
+// canceled; the eviction write must still land or the next turn inherits
+// the stale pin.
+func (s *Service) expireSessionPin(
+	ctx context.Context,
+	installationID uuid.UUID,
+	sessionKey [sessionpin.SessionKeyLen]byte,
+	role string,
+	reason string,
+) error {
+	expired := sessionpin.Pin{
+		SessionKey:     sessionKey,
+		Role:           role,
+		InstallationID: installationID,
+		Provider:       "",
+		Model:          "",
+		Reason:         reason,
+		TurnCount:      1,
+		PinnedUntil:    time.Now().Add(-time.Second),
+	}
+	return s.pinStore.Upsert(context.Background(), expired)
+}
+
 // evictPinAfterDegenerateResponse expires the session pin after a degenerate
 // response (end_turn, no tool calls, too few output tokens). The current
 // turn already streamed and can't be retried, but evicting ensures the next
@@ -47,17 +77,7 @@ func (s *Service) evictPinAfterDegenerateResponse(
 
 	log := observability.FromContext(ctx)
 
-	expired := sessionpin.Pin{
-		SessionKey:     sessionKey,
-		Role:           role,
-		InstallationID: installationID,
-		Provider:       "",
-		Model:          "",
-		Reason:         "degenerate_response",
-		TurnCount:      1,
-		PinnedUntil:    time.Now().Add(-time.Second),
-	}
-	if err := s.pinStore.Upsert(context.Background(), expired); err != nil {
+	if err := s.expireSessionPin(ctx, installationID, sessionKey, role, "degenerate_response"); err != nil {
 		log.Error("pin eviction after degenerate response failed", "err", err, "role", role)
 		return
 	}
@@ -136,17 +156,7 @@ func (s *Service) maybeEvictPinAfterUpstreamErr(
 
 	// Expire via a PinnedUntil in the past, same pattern as loop-break /
 	// no-progress / force-model, so loadPin discards it next turn.
-	expired := sessionpin.Pin{
-		SessionKey:     sessionKey,
-		Role:           role,
-		InstallationID: installationID,
-		Provider:       "",
-		Model:          "",
-		Reason:         "upstream_error_strike_threshold",
-		TurnCount:      1,
-		PinnedUntil:    time.Now().Add(-time.Second),
-	}
-	if err := s.pinStore.Upsert(context.Background(), expired); err != nil {
+	if err := s.expireSessionPin(ctx, installationID, sessionKey, role, "upstream_error_strike_threshold"); err != nil {
 		log.Error("pin eviction upsert failed", "err", err, "role", role)
 		return
 	}


### PR DESCRIPTION
## Summary

Fix finding [26]: the "write an already-expired `sessionpin.Pin` then `Upsert` on `context.Background()`" idiom was copy-pasted verbatim (differing only in the `Reason` string) across five call sites in `internal/proxy`, violating DRY.

Extracted a single package-private helper in `pin_eviction.go`:

```go
func (s *Service) expireSessionPin(
	ctx context.Context,
	installationID uuid.UUID,
	sessionKey [sessionpin.SessionKeyLen]byte,
	role string,
	reason string,
) error
```

It builds the expired `Pin` and upserts on `context.Background()` (matching the repo's documented "finish/cleanup DB writes in deferred code must use `context.Background()`, never the parent `ctx`" invariant), returning the error for the caller to log with call-site-specific context.

Called from all five sites:
- `pin_eviction.go`: `evictPinAfterDegenerateResponse` (`degenerate_response`)
- `pin_eviction.go`: `maybeEvictPinAfterUpstreamErr` (`upstream_error_strike_threshold`)
- `no_progress.go`: `handleNoProgressLoopBreak` (`no_progress_loop_break`)
- `loop_detection.go`: `handleToolCallLoopBreak` (`tool_call_loop_break`)
- `force_model.go`: `handleForceModelCommand` clear branch (`user_unforced`)

Pre-existing call sites that write a *non-expired* pin (`setForceModelPin`, loop-escalation's opus pin) were left untouched — they don't match the idiom (different `Provider`/`Model`/`PinnedUntil` semantics).

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .` (clean)
- [x] `go test ./...` (all packages pass, including `internal/proxy`)