### PR TITLE
refactor: extract shared ClientIdentityFromHeaders constructor

### DIFF
--- a/internal/api/anthropic/messages.go
+++ b/internal/api/anthropic/messages.go
@@ -103,24 +103,20 @@ func MessagesHandler(svc *proxy.Service, authSvc *auth.Service) gin.HandlerFunc 
 func stashClientIdentity(ctx context.Context, h http.Header, body []byte) context.Context {
 	metaRaw := gjson.GetBytes(body, "metadata.user_id").String()
 	meta := proxy.ParseClaudeCodeMetadata(metaRaw)
-	sessionID := meta.SessionID
-	if sessionID == "" {
-		sessionID = h.Get("X-Claude-Code-Session-Id")
+
+	// Start from the header-only identity, then overlay the body-derived
+	// fields Claude Code's metadata.user_id carries that no other surface
+	// sends: DeviceID/AccountID always win; SessionID/Email only override
+	// when the body actually has a value, else the header-derived one from
+	// ClientIdentityFromHeaders stands.
+	id := proxy.ClientIdentityFromHeaders(h)
+	id.DeviceID = proxy.NormalizeClientIdentifier(meta.DeviceID)
+	id.AccountID = proxy.NormalizeClientIdentifier(meta.AccountID)
+	if meta.SessionID != "" {
+		id.SessionID = proxy.NormalizeClientIdentifier(meta.SessionID)
 	}
-	email := proxy.NormalizeEmail(meta.Email)
-	if email == "" {
-		email = proxy.NormalizeEmail(h.Get("X-Weave-User-Email"))
-	}
-	displayName := proxy.NormalizeDisplayName(h.Get("X-Weave-User-Name"))
-	id := proxy.ClientIdentity{
-		DeviceID:    proxy.NormalizeClientIdentifier(meta.DeviceID),
-		AccountID:   proxy.NormalizeClientIdentifier(meta.AccountID),
-		SessionID:   proxy.NormalizeClientIdentifier(sessionID),
-		Email:       email,
-		DisplayName: displayName,
-		UserAgent:   h.Get("User-Agent"),
-		ClientApp:   proxy.NormalizeClientApp(h.Get("X-App"), h.Get("User-Agent")),
-		RolloutID:   proxy.NormalizeRolloutID(h.Get(proxy.RolloutIDHeader)),
+	if metaEmail := proxy.NormalizeEmail(meta.Email); metaEmail != "" {
+		id.Email = metaEmail
 	}
 	observability.Get().Debug("anthropic stashClientIdentity",
 		"meta_raw_len", len(metaRaw),

--- a/internal/api/gemini/generate_content.go
+++ b/internal/api/gemini/generate_content.go
@@ -57,7 +57,7 @@ func GenerateContentHandler(svc *proxy.Service, authSvc *auth.Service) gin.Handl
 			return
 		}
 
-		ctx := stashClientIdentity(c.Request.Context(), c.Request.Header)
+		ctx := context.WithValue(c.Request.Context(), proxy.ClientIdentityContextKey{}, proxy.ClientIdentityFromHeaders(c.Request.Header))
 		ctx = proxy.ResolveUserFromContext(ctx, authSvc, middleware.InstallationFrom(c))
 		c.Request = c.Request.WithContext(ctx)
 
@@ -118,18 +118,6 @@ func injectModelAndStream(body []byte, model string, stream bool) ([]byte, error
 		return nil, err
 	}
 	return out, nil
-}
-
-func stashClientIdentity(ctx context.Context, h http.Header) context.Context {
-	id := proxy.ClientIdentity{
-		SessionID:   proxy.NormalizeClientIdentifier(h.Get("X-Claude-Code-Session-Id")),
-		Email:       proxy.NormalizeEmail(h.Get("X-Weave-User-Email")),
-		DisplayName: proxy.NormalizeDisplayName(h.Get("X-Weave-User-Name")),
-		UserAgent:   h.Get("User-Agent"),
-		ClientApp:   proxy.NormalizeClientApp(h.Get("X-App"), h.Get("User-Agent")),
-		RolloutID:   proxy.NormalizeRolloutID(h.Get(proxy.RolloutIDHeader)),
-	}
-	return context.WithValue(ctx, proxy.ClientIdentityContextKey{}, id)
 }
 
 // geminiErrorStatus maps a classified dispatch error to the Gemini native

--- a/internal/api/openai/completions.go
+++ b/internal/api/openai/completions.go
@@ -31,7 +31,7 @@ func ChatCompletionHandler(svc *proxy.Service, authSvc *auth.Service) gin.Handle
 			return
 		}
 
-		ctx := stashClientIdentity(c.Request.Context(), c.Request.Header)
+		ctx := context.WithValue(c.Request.Context(), proxy.ClientIdentityContextKey{}, proxy.ClientIdentityFromHeaders(c.Request.Header))
 		ctx = proxy.ResolveUserFromContext(ctx, authSvc, middleware.InstallationFrom(c))
 		c.Request = c.Request.WithContext(ctx)
 
@@ -61,18 +61,6 @@ func ChatCompletionHandler(svc *proxy.Service, authSvc *auth.Service) gin.Handle
 			return
 		}
 	}
-}
-
-func stashClientIdentity(ctx context.Context, h http.Header) context.Context {
-	id := proxy.ClientIdentity{
-		SessionID:   proxy.NormalizeClientIdentifier(h.Get("X-Claude-Code-Session-Id")),
-		Email:       proxy.NormalizeEmail(h.Get("X-Weave-User-Email")),
-		DisplayName: proxy.NormalizeDisplayName(h.Get("X-Weave-User-Name")),
-		UserAgent:   h.Get("User-Agent"),
-		ClientApp:   proxy.NormalizeClientApp(h.Get("X-App"), h.Get("User-Agent")),
-		RolloutID:   proxy.NormalizeRolloutID(h.Get(proxy.RolloutIDHeader)),
-	}
-	return context.WithValue(ctx, proxy.ClientIdentityContextKey{}, id)
 }
 
 // openAIErrorType maps a classified dispatch error to the OpenAI Chat

--- a/internal/api/openai/responses.go
+++ b/internal/api/openai/responses.go
@@ -1,6 +1,7 @@
 package openai
 
 import (
+	"context"
 	"io"
 	"net/http"
 
@@ -32,7 +33,7 @@ func ResponsesHandler(svc *proxy.Service, authSvc *auth.Service) gin.HandlerFunc
 			return
 		}
 
-		ctx := stashClientIdentity(c.Request.Context(), c.Request.Header)
+		ctx := context.WithValue(c.Request.Context(), proxy.ClientIdentityContextKey{}, proxy.ClientIdentityFromHeaders(c.Request.Header))
 		ctx = proxy.ResolveUserFromContext(ctx, authSvc, middleware.InstallationFrom(c))
 		c.Request = c.Request.WithContext(ctx)
 

--- a/internal/proxy/client_identity.go
+++ b/internal/proxy/client_identity.go
@@ -3,6 +3,7 @@ package proxy
 import (
 	"context"
 	"encoding/json"
+	"net/http"
 	"strings"
 
 	"workweave/router/internal/auth"
@@ -31,6 +32,22 @@ type ClientIdentityContextKey struct{}
 func ClientIdentityFrom(ctx context.Context) ClientIdentity {
 	id, _ := ctx.Value(ClientIdentityContextKey{}).(ClientIdentity)
 	return id
+}
+
+// ClientIdentityFromHeaders builds a ClientIdentity from the headers common
+// to every surface (OpenAI, Gemini, and the Anthropic header-only fields).
+// DeviceID and AccountID are left zero — only Claude Code's
+// metadata.user_id body field carries them; callers with a body (see
+// anthropic.stashClientIdentity) overlay those after calling this.
+func ClientIdentityFromHeaders(h http.Header) ClientIdentity {
+	return ClientIdentity{
+		SessionID:   NormalizeClientIdentifier(h.Get("X-Claude-Code-Session-Id")),
+		Email:       NormalizeEmail(h.Get("X-Weave-User-Email")),
+		DisplayName: NormalizeDisplayName(h.Get("X-Weave-User-Name")),
+		UserAgent:   h.Get("User-Agent"),
+		ClientApp:   NormalizeClientApp(h.Get("X-App"), h.Get("User-Agent")),
+		RolloutID:   NormalizeRolloutID(h.Get(RolloutIDHeader)),
+	}
 }
 
 // ResolveUserFromContext dispatches identity signals from ctx to


### PR DESCRIPTION
## Summary

- `stashClientIdentity(ctx, h http.Header)` was defined with an identical body in `internal/api/openai/completions.go` and `internal/api/gemini/generate_content.go`, duplicating header-parsing logic that already composes entirely from `proxy.ClientIdentity`'s `Normalize*` helpers.
- Adds `proxy.ClientIdentityFromHeaders(h http.Header) ClientIdentity` to `internal/proxy/client_identity.go` — the file that already owns `ClientIdentity` and every `Normalize*` helper it uses.
- openai (`completions.go`, `responses.go`) and gemini (`generate_content.go`) now call `context.WithValue(ctx, proxy.ClientIdentityContextKey{}, proxy.ClientIdentityFromHeaders(h))` directly instead of each keeping its own copy of the constructor.
- anthropic's `messages.go` now builds on `ClientIdentityFromHeaders` too, overlaying only the `metadata.user_id` body-derived overrides (DeviceID, AccountID, and the SessionID/Email fallback logic) instead of re-deriving all six fields from headers by hand.

Addresses finding [110].

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .` (clean)
- [x] `go test ./...` (all packages pass, including `internal/api/anthropic`, `internal/api/gemini`, `internal/proxy`)