### PR TITLE
fix: routing-report uses cluster.DefaultConfig() and real TailTruncate

### DIFF
--- a/cmd/routing-report/main.go
+++ b/cmd/routing-report/main.go
@@ -31,7 +31,6 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
-	"time"
 
 	"workweave/router/internal/router"
 	"workweave/router/internal/router/cluster"
@@ -85,7 +84,7 @@ type staticEmbedder struct {
 func buildEmbedder(hdr embHeader, probes []probe, vecs [][]float32) *staticEmbedder {
 	byText := make(map[string][]float32, len(probes))
 	for i, p := range probes {
-		byText[tailTruncate(p.Text, maxPromptChars)] = vecs[i]
+		byText[cluster.TailTruncate(p.Text, maxPromptChars)] = vecs[i]
 	}
 	return &staticEmbedder{id: hdr.EmbedderID, dim: hdr.EmbedDim, byText: byText}
 }
@@ -99,19 +98,6 @@ func (s *staticEmbedder) Embed(_ context.Context, text string) ([]float32, error
 }
 func (s *staticEmbedder) ID() string { return s.id }
 func (s *staticEmbedder) Dim() int   { return s.dim }
-
-// tailTruncate keeps the last maxChars bytes of s, skipping any partial UTF-8
-// continuation byte. Must match the Scorer's helper byte-for-byte.
-func tailTruncate(s string, maxChars int) string {
-	if len(s) <= maxChars {
-		return s
-	}
-	cut := len(s) - maxChars
-	for cut < len(s) && (s[cut]&0xC0) == 0x80 {
-		cut++
-	}
-	return s[cut:]
-}
 
 func truncForErr(s string) string {
 	if len(s) > 60 {
@@ -227,7 +213,8 @@ func routeCorpus(artifactsDir, version string, probes []probe, embedder *staticE
 			bundle.EmbedderID(), embedder.id)
 	}
 	providers := availableProviders(bundle)
-	cfg := cluster.Config{TopP: topP, MaxPromptChars: 1024, EmbedTimeout: 5 * time.Second}
+	cfg := cluster.DefaultConfig()
+	cfg.TopP = topP
 	scorer, err := cluster.NewScorer(bundle, cfg, embedder, providers)
 	if err != nil {
 		return nil, fmt.Errorf("new scorer: %w", err)

--- a/internal/router/cluster/scorer.go
+++ b/internal/router/cluster/scorer.go
@@ -431,7 +431,7 @@ func (s *Scorer) Route(ctx context.Context, req router.Request) (router.Decision
 	start := time.Now()
 	log := observability.Get()
 
-	text := tailTruncate(req.PromptText, s.cfg.MaxPromptChars)
+	text := TailTruncate(req.PromptText, s.cfg.MaxPromptChars)
 	truncated := len(req.PromptText) > s.cfg.MaxPromptChars
 
 	embedCtx, cancel := context.WithTimeout(ctx, s.cfg.EmbedTimeout)
@@ -982,8 +982,8 @@ func runnerUp(scores map[string]float32, order []string, exclude string) (string
 	return bestModel, bestScore
 }
 
-// tailTruncate keeps the last maxChars bytes, snapping to a UTF-8 boundary.
-func tailTruncate(s string, maxChars int) string {
+// TailTruncate keeps the last maxChars bytes, snapping to a UTF-8 boundary.
+func TailTruncate(s string, maxChars int) string {
 	if len(s) <= maxChars {
 		return s
 	}

--- a/internal/router/cluster/scorer_test.go
+++ b/internal/router/cluster/scorer_test.go
@@ -844,13 +844,13 @@ func (s *slowEmbedder) ID() string { return EmbedderJinaV2 }
 func (s *slowEmbedder) Dim() int { return EmbedDim }
 
 func TestTailTruncate(t *testing.T) {
-	got := tailTruncate("abcdef", 3)
+	got := TailTruncate("abcdef", 3)
 	assert.Equal(t, "def", got)
 
-	assert.Equal(t, "ab", tailTruncate("ab", 5))
+	assert.Equal(t, "ab", TailTruncate("ab", 5))
 
 	in := "héllo"
-	got = tailTruncate(in, 4)
+	got = TailTruncate(in, 4)
 	assert.True(t, len(got) <= 4)
 	assert.True(t, strings.HasSuffix(in, got))
 	for _, r := range got {


### PR DESCRIPTION
## Summary

Two related drift-risk findings in `cmd/routing-report/main.go`, both stemming from the tool hand-copying instead of importing production code — undermining its own claim of exercising "the exact production code path":

- **[94]** `routeCorpus` hand-rolled a `cluster.Config{...}` literal. Its `EmbedTimeout` (`5 * time.Second`) had already silently drifted from the real `cluster.DefaultConfig()` production default (`1500ms`). Fixed by calling `cluster.DefaultConfig()` and overriding only `TopP` (the one knob the CLI flag is meant to control), so `MaxPromptChars` and `EmbedTimeout` can never silently diverge again.
- **[96]** `tailTruncate` was a byte-for-byte copy of the unexported `cluster.tailTruncate` helper, kept in sync only by convention/comment ("Must match the Scorer's helper byte-for-byte"). Exported it as `cluster.TailTruncate` and updated routing-report to import it directly, eliminating the copy.

## Output change

None. `MaxPromptChars` was already hardcoded to `1024`, matching `DefaultConfig()`'s value. `EmbedTimeout` only bounds the synchronous, in-memory static test embedder routing-report uses (precomputed probe vectors, no real I/O), so shrinking the bound from 5s to 1500ms has no observable effect on report output — verified via `go test -tags no_onnx ./cmd/routing-report/... ./internal/router/cluster/...`, all green.

## Test plan

- [x] `go build ./...` and `go build -tags no_onnx ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .` (clean)
- [x] `go test ./...` (full suite, all packages)
- [x] `go test -tags no_onnx ./cmd/routing-report/... ./internal/router/cluster/...` (routing-report's own tests, including `TestReportRunsOnLatest`)