### PR TITLE
fix: align filtered indices between AssistantToolCallArgsPreview and AssistantToolCallSignatures

### DIFF
--- a/internal/translate/loop_detection.go
+++ b/internal/translate/loop_detection.go
@@ -19,103 +19,34 @@ type ToolCallSig struct {
 // AssistantToolCallArgsPreview returns short previews of the raw argument
 // JSON for each assistant tool call, in order, starting at offset. Used to
 // log the window when a loop trips, so real loops (identical args) can be
-// told apart from false positives (distinct args, colliding hash).
+// told apart from false positives (distinct args, colliding hash). offset is
+// an index into the same filtered sequence AssistantToolCallSignatures
+// produces (see assistantToolCallEntry) — the two must never filter
+// differently, or an offset computed against one is meaningless against the
+// other.
 func (e *RequestEnvelope) AssistantToolCallArgsPreview(offset, maxLen int) []string {
 	switch e.format {
 	case FormatAnthropic:
-		return anthropicAssistantToolCallArgsPreview(e.body, offset, maxLen)
+		return assistantToolCallArgsPreview(anthropicAssistantToolCallEntries(e.body), offset, maxLen)
 	case FormatOpenAI:
-		return openAIAssistantToolCallArgsPreview(e.body, offset, maxLen)
+		return assistantToolCallArgsPreview(openAIAssistantToolCallEntries(e.body), offset, maxLen)
 	default:
 		return nil
 	}
 }
 
-func anthropicAssistantToolCallArgsPreview(body []byte, offset, maxLen int) []string {
+func assistantToolCallArgsPreview(entries []assistantToolCallEntry, offset, maxLen int) []string {
 	var out []string
-	idx := 0
-	msgs := gjson.GetBytes(body, "messages")
-	if !msgs.IsArray() {
-		return nil
+	for i, entry := range entries {
+		if i < offset {
+			continue
+		}
+		preview := entry.InputRaw
+		if len(preview) > maxLen {
+			preview = preview[:maxLen] + "…"
+		}
+		out = append(out, entry.Name+":"+preview)
 	}
-	msgs.ForEach(func(_, msg gjson.Result) bool {
-		role := msg.Get("role").String()
-		if role == "user" && userPromptTextGJSON(msg.Get("content")) != "" {
-			out = nil
-			idx = 0
-			return true
-		}
-		if role != "assistant" {
-			return true
-		}
-		content := msg.Get("content")
-		if !content.IsArray() {
-			return true
-		}
-		content.ForEach(func(_, block gjson.Result) bool {
-			if block.Get("type").String() != "tool_use" {
-				return true
-			}
-			name := block.Get("name").String()
-			if name == "" {
-				return true
-			}
-			if idx >= offset {
-				preview := block.Get("input").Raw
-				if len(preview) > maxLen {
-					preview = preview[:maxLen] + "…"
-				}
-				out = append(out, name+":"+preview)
-			}
-			idx++
-			return true
-		})
-		return true
-	})
-	return out
-}
-
-func openAIAssistantToolCallArgsPreview(body []byte, offset, maxLen int) []string {
-	var out []string
-	idx := 0
-	msgs := gjson.GetBytes(body, "messages")
-	if !msgs.IsArray() {
-		return nil
-	}
-	msgs.ForEach(func(_, msg gjson.Result) bool {
-		role := msg.Get("role").String()
-		if role == "user" && userPromptTextGJSON(msg.Get("content")) != "" {
-			out = nil
-			idx = 0
-			return true
-		}
-		if role != "assistant" {
-			return true
-		}
-		toolCalls := msg.Get("tool_calls")
-		if !toolCalls.IsArray() {
-			return true
-		}
-		toolCalls.ForEach(func(_, tc gjson.Result) bool {
-			if tc.Get("type").String() != "function" {
-				return true
-			}
-			name := tc.Get("function.name").String()
-			if name == "" {
-				return true
-			}
-			if idx >= offset {
-				preview := tc.Get("function.arguments").String()
-				if len(preview) > maxLen {
-					preview = preview[:maxLen] + "…"
-				}
-				out = append(out, name+":"+preview)
-			}
-			idx++
-			return true
-		})
-		return true
-	})
 	return out
 }
 
@@ -136,12 +67,23 @@ func (e *RequestEnvelope) AssistantToolCallSignatures() []ToolCallSig {
 	}
 }
 
-func anthropicAssistantToolCallSigs(body []byte) []ToolCallSig {
+// assistantToolCallEntry is one filtered assistant tool invocation: a callee
+// name plus its raw argument JSON. AssistantToolCallSignatures and
+// AssistantToolCallArgsPreview both derive from the same
+// {anthropic,openAI}AssistantToolCallEntries walk, so they can never diverge
+// on which entries survive filtering — an index into one is always valid
+// against the other.
+type assistantToolCallEntry struct {
+	Name     string
+	InputRaw string
+}
+
+func anthropicAssistantToolCallEntries(body []byte) []assistantToolCallEntry {
 	msgs := gjson.GetBytes(body, "messages")
 	if !msgs.IsArray() {
 		return nil
 	}
-	var sigs []ToolCallSig
+	var entries []assistantToolCallEntry
 	msgs.ForEach(func(_, msg gjson.Result) bool {
 		role := msg.Get("role").String()
 		// A genuine user-typed prompt breaks the loop (human intervened).
@@ -149,7 +91,7 @@ func anthropicAssistantToolCallSigs(body []byte) []ToolCallSig {
 		// Claude Code's injected wrapper blocks, so normal tool rounds
 		// don't reset the window.
 		if role == "user" && userPromptTextGJSON(msg.Get("content")) != "" {
-			sigs = nil
+			entries = nil
 			return true
 		}
 		if role != "assistant" {
@@ -175,26 +117,26 @@ func anthropicAssistantToolCallSigs(body []byte) []ToolCallSig {
 			if !isMeaningfulInput(input) {
 				return true
 			}
-			sigs = append(sigs, ToolCallSig{Name: name, InputHash: hashCanonicalJSON(input.Raw)})
+			entries = append(entries, assistantToolCallEntry{Name: name, InputRaw: input.Raw})
 			return true
 		})
 		return true
 	})
-	return sigs
+	return entries
 }
 
-func openAIAssistantToolCallSigs(body []byte) []ToolCallSig {
+func openAIAssistantToolCallEntries(body []byte) []assistantToolCallEntry {
 	msgs := gjson.GetBytes(body, "messages")
 	if !msgs.IsArray() {
 		return nil
 	}
-	var sigs []ToolCallSig
+	var entries []assistantToolCallEntry
 	msgs.ForEach(func(_, msg gjson.Result) bool {
 		role := msg.Get("role").String()
-		// See anthropicAssistantToolCallSigs: a genuine user-typed prompt
+		// See anthropicAssistantToolCallEntries: a genuine user-typed prompt
 		// resets the window; injected wrappers and tool_result turns do not.
 		if role == "user" && userPromptTextGJSON(msg.Get("content")) != "" {
-			sigs = nil
+			entries = nil
 			return true
 		}
 		if role != "assistant" {
@@ -219,11 +161,30 @@ func openAIAssistantToolCallSigs(body []byte) []ToolCallSig {
 			if !isMeaningfulInputRaw(argsRaw) {
 				return true
 			}
-			sigs = append(sigs, ToolCallSig{Name: name, InputHash: hashCanonicalJSON(argsRaw)})
+			entries = append(entries, assistantToolCallEntry{Name: name, InputRaw: argsRaw})
 			return true
 		})
 		return true
 	})
+	return entries
+}
+
+func anthropicAssistantToolCallSigs(body []byte) []ToolCallSig {
+	return sigsFromEntries(anthropicAssistantToolCallEntries(body))
+}
+
+func openAIAssistantToolCallSigs(body []byte) []ToolCallSig {
+	return sigsFromEntries(openAIAssistantToolCallEntries(body))
+}
+
+func sigsFromEntries(entries []assistantToolCallEntry) []ToolCallSig {
+	if entries == nil {
+		return nil
+	}
+	sigs := make([]ToolCallSig, len(entries))
+	for i, entry := range entries {
+		sigs[i] = ToolCallSig{Name: entry.Name, InputHash: hashCanonicalJSON(entry.InputRaw)}
+	}
 	return sigs
 }
 

--- a/internal/translate/loop_detection_test.go
+++ b/internal/translate/loop_detection_test.go
@@ -2,6 +2,8 @@ package translate_test
 
 import (
 	"encoding/json"
+	"fmt"
+	"strings"
 	"testing"
 
 	"workweave/router/internal/translate"
@@ -237,6 +239,98 @@ func TestAssistantToolCallSignatures_IncludesRouterNudgeEntries(t *testing.T) {
 	assert.Equal(t, "Bash", sigs[1].Name)
 	assert.Equal(t, "Read", sigs[2].Name)
 	assert.Equal(t, sigs[0].InputHash, sigs[1].InputHash, "identical nudge args produce identical hash")
+}
+
+// TestAssistantToolCallArgsPreview_AlignsWithSignatures_Anthropic reproduces
+// proxy.detectToolCallLoop's exact usage: window the trailing N entries of
+// AssistantToolCallSignatures(), find the offending index within that window,
+// then fetch AssistantToolCallArgsPreview(start, ...) — start expressed as an
+// index into the SAME sequence AssistantToolCallSignatures walked — and check
+// the preview entries line up name-for-name with sigs[start:]. The body
+// interleaves empty-input tool_use blocks (filtered out of the signature
+// sequence) among the real ones. Before the fix, ArgsPreview only skipped
+// nameless blocks (not empty-input ones), so it walked a longer, differently
+// filtered sequence: an offset valid against sigs pointed at the wrong
+// entries in the preview.
+func TestAssistantToolCallArgsPreview_AlignsWithSignatures_Anthropic(t *testing.T) {
+	const windowSize = 10
+	const maxRepeats = 5
+
+	var content []any
+	id := 0
+	nextID := func() string {
+		id++
+		return fmt.Sprintf("%d", id)
+	}
+	// 3 "Setup" calls with distinct args, then 5 identical "Loop" calls — each
+	// immediately followed by an empty-input tool_use, which Signatures
+	// filters out but the pre-fix ArgsPreview did not.
+	for i := 0; i < 3; i++ {
+		content = append(content,
+			map[string]any{"type": "tool_use", "id": nextID(), "name": "Setup", "input": map[string]any{"step": i}},
+			map[string]any{"type": "tool_use", "id": nextID(), "name": "Read", "input": map[string]any{}},
+		)
+	}
+	for i := 0; i < 5; i++ {
+		content = append(content,
+			map[string]any{"type": "tool_use", "id": nextID(), "name": "Loop", "input": map[string]any{"n": 1}},
+			map[string]any{"type": "tool_use", "id": nextID(), "name": "Read", "input": map[string]any{}},
+		)
+	}
+	body := mustMarshalJSON(t, map[string]any{
+		"model":      "claude-sonnet-4-6",
+		"messages":   []any{map[string]any{"role": "assistant", "content": content}},
+		"max_tokens": 256,
+	})
+	env, err := translate.ParseAnthropic(body)
+	require.NoError(t, err)
+
+	sigs := env.AssistantToolCallSignatures()
+	require.Len(t, sigs, 8, "the 8 empty-input Read blocks must be filtered out of the signature sequence")
+
+	// Mirror proxy.detectToolCallLoop's windowing exactly.
+	start := 0
+	if len(sigs) > windowSize {
+		start = len(sigs) - windowSize
+	}
+	require.Equal(t, 0, start, "8 sigs fits within the 10-wide window, so detectToolCallLoop windows from the start")
+	window := sigs[start:]
+	counts := make(map[string]int, len(window))
+	offendingIdx := -1
+	for i, s := range window {
+		key := s.Name + "\x00" + s.InputHash
+		counts[key]++
+		if counts[key] >= maxRepeats {
+			offendingIdx = i
+			break
+		}
+	}
+	require.NotEqual(t, -1, offendingIdx, "the 5 identical Loop calls must trip the repeat threshold")
+	require.Equal(t, "Loop", window[offendingIdx].Name)
+
+	// detectToolCallLoop passes `start` (not offendingIdx) as the offset — it
+	// wants the whole window dumped, not just the tail from the trip point.
+	preview := env.AssistantToolCallArgsPreview(start, 200)
+	require.Len(t, preview, len(sigs)-start,
+		"preview window must contain exactly as many entries as the aligned signature window")
+	for i, s := range sigs[start:] {
+		require.True(t, strings.HasPrefix(preview[i], s.Name+":"),
+			"preview[%d] = %q must describe the same tool call as sigs[%d] = %q (index alignment)", i, preview[i], start+i, s.Name)
+	}
+	// Pin down the exact entries the loop-detector log line cares about: 3
+	// distinct Setup previews followed by 5 identical Loop previews, in
+	// order — proving the empty-input Read blocks did not shift ArgsPreview's
+	// output relative to Signatures'.
+	require.Equal(t, []string{
+		`Setup:{"step":0}`,
+		`Setup:{"step":1}`,
+		`Setup:{"step":2}`,
+		`Loop:{"n":1}`,
+		`Loop:{"n":1}`,
+		`Loop:{"n":1}`,
+		`Loop:{"n":1}`,
+		`Loop:{"n":1}`,
+	}, preview)
 }
 
 // mustMarshalJSON is shared with force_model_test.go; redeclared here would be


### PR DESCRIPTION
## Finding [10]

**Location:** `internal/translate/loop_detection.go`

**Bug:** `AssistantToolCallArgsPreview` only filtered out nameless `tool_use`/`tool_calls` entries, while the parallel `AssistantToolCallSignatures` walker also filters out empty-input entries (`isMeaningfulInput` / `isMeaningfulInputRaw` — stream-incomplete tool calls that cross-format translation echoes back as `input:{}`). The two functions therefore iterated **different filtered sequences** over the same request body.

`proxy.detectToolCallLoop` computes `start` (a window offset) against `env.AssistantToolCallSignatures()`, then passes that same `start` into `env.AssistantToolCallArgsPreview(start, 200)` for the diagnostic "loop detector window dump" log line when a real loop trips (`internal/proxy/loop_detection.go:104`). Because the two functions filtered differently, an offset valid in the `Signatures` index space could point at the wrong entries once interpreted against `ArgsPreview`'s (longer, unfiltered-for-empty-input) sequence — misaligning the exact diagnostic the log line exists to produce (telling a real loop apart from a hash-collision false positive).

Note: the fix suggestion also mentioned a "nudge-ID filter" divergence. That filter (`toolu_router_nudge_` id prefix) was removed from `AssistantToolCallSignatures` entirely in #531 — router-synthesized nudges are now deliberately *counted* toward loop detection (see `TestAssistantToolCallSignatures_IncludesRouterNudgeEntries`). So there's no nudge-ID filter left in either function to align; the real, still-present divergence is the empty-input filter.

## Fix

Extracted a shared `assistantToolCallEntry` walk-and-filter helper (`anthropicAssistantToolCallEntries` / `openAIAssistantToolCallEntries`) that both `AssistantToolCallSignatures` and `AssistantToolCallArgsPreview` now derive from. Both functions apply the identical name + `isMeaningfulInput`/`isMeaningfulInputRaw` filters and the identical user-prompt reset logic, so they can never diverge on which entries survive — an offset computed against one is guaranteed valid against the other.

## Test

Added `TestAssistantToolCallArgsPreview_AlignsWithSignatures_Anthropic`, which reproduces `proxy.detectToolCallLoop`'s exact usage pattern: build a signature window, locate the offending repeat index, and pass that same offset into `AssistantToolCallArgsPreview`. The body interleaves empty-input `tool_use` blocks (filtered out of `Signatures`) among real `Setup`/`Loop` calls; before the fix, `ArgsPreview` did not filter those out, so it would have walked a longer sequence and shifted the preview relative to the signatures it's meant to describe. The test asserts the preview lines up name-for-name (and exact-string) with the signature window.

`go build ./...`, `go vet ./...`, `gofmt -l .`, `go test ./...` all clean.