### PR TITLE
fix: remove translate package-global mutation + eager per-request stack trace

### DIFF
--- a/cmd/router/main.go
+++ b/cmd/router/main.go
@@ -46,7 +46,6 @@ import (
 	"workweave/router/internal/router/rl"
 	"workweave/router/internal/router/sessionpin"
 	"workweave/router/internal/server"
-	"workweave/router/internal/translate"
 
 	_ "time/tzdata"
 
@@ -442,8 +441,8 @@ func main() {
 	} else {
 		logger.Info("Cluster scorer embedding concatenated stream (ROUTER_EMBED_ONLY_USER_MESSAGE=false)")
 	}
-	if config.GetOr("ROUTER_DEEPSEEK_ESCAPE_NORMALIZE", "false") == "true" {
-		translate.EnableEditEscapeNormalize = true
+	escapeNormalize := config.GetOr("ROUTER_DEEPSEEK_ESCAPE_NORMALIZE", "false") == "true"
+	if escapeNormalize {
 		logger.Info("Edit-tool escape-sequence repair enabled (ROUTER_DEEPSEEK_ESCAPE_NORMALIZE=true)")
 	}
 	emitter, err := buildOtelEmitter(string(deploymentMode))
@@ -658,6 +657,7 @@ func main() {
 		WithHardPinResolver(hardPinResolver).
 		WithPlannerEnabled(plannerEnabled).
 		WithPrefixTrimFreeSwitch(prefixTrimFreeSwitch).
+		WithEscapeNormalize(escapeNormalize).
 		WithEffortEscalation(effortEscalation).
 		WithBandSwap(bandSwapEnabled).
 		WithLoopEscalationConfig(loopEscalationEnabled, loopEscalationHoldoutPct).

--- a/internal/api/anthropic/messages.go
+++ b/internal/api/anthropic/messages.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"io"
 	"net/http"
-	"runtime/debug"
 
 	"workweave/router/internal/auth"
 	"workweave/router/internal/observability"
@@ -15,30 +14,6 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/tidwall/gjson"
 )
-
-type tracingWriter struct {
-	gin.ResponseWriter
-}
-
-func (t *tracingWriter) WriteHeader(code int) {
-	observability.Get().Debug("ResponseWriter WriteHeader called",
-		"code", code,
-		"already_written", t.ResponseWriter.Written(),
-		"current_status", t.ResponseWriter.Status(),
-		"stack", string(debug.Stack()),
-	)
-	t.ResponseWriter.WriteHeader(code)
-}
-
-func (t *tracingWriter) Write(b []byte) (int, error) {
-	if !t.ResponseWriter.Written() {
-		observability.Get().Debug("ResponseWriter implicit-200 via Write",
-			"bytes", len(b),
-			"stack", string(debug.Stack()),
-		)
-	}
-	return t.ResponseWriter.Write(b)
-}
 
 const maxBodyBytes = 10 * 1024 * 1024
 
@@ -71,8 +46,7 @@ func MessagesHandler(svc *proxy.Service, authSvc *auth.Service) gin.HandlerFunc 
 		ctx = proxy.ResolveUserFromContext(ctx, authSvc, middleware.InstallationFrom(c))
 		c.Request = c.Request.WithContext(ctx)
 
-		w := &tracingWriter{ResponseWriter: c.Writer}
-		if err := svc.ProxyMessages(c.Request.Context(), body, w, c.Request); err != nil {
+		if err := svc.ProxyMessages(c.Request.Context(), body, c.Writer, c.Request); err != nil {
 			cls, ok := proxy.ClassifyDispatchError(err)
 			if ok && cls.Kind == proxy.DispatchErrorUpstreamStatus {
 				if c.Writer.Written() {

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -79,6 +79,10 @@ type Service struct {
 	// turn and the switch handover is skipped. Kill switch:
 	// ROUTER_PREFIX_TRIM_FREE_SWITCH.
 	prefixTrimFreeSwitch bool
+	// escapeNormalize enables the escape-repair pass on file-edit tool
+	// (Edit/Write/MultiEdit) args for cross-format OpenAI-upstream responses.
+	// Off by default. Kill switch: ROUTER_DEEPSEEK_ESCAPE_NORMALIZE.
+	escapeNormalize bool
 	// hardPinExplore gates the Explore sub-agent hard-pin.
 	hardPinExplore bool
 	// hardPinProvider/hardPinModel route compaction (and, when hardPinExplore is
@@ -881,6 +885,14 @@ func (s *Service) WithPlannerEnabled(enabled bool) *Service {
 // window. Detection and the post-routing compaction handover are unaffected.
 func (s *Service) WithPrefixTrimFreeSwitch(enabled bool) *Service {
 	s.prefixTrimFreeSwitch = enabled
+	return s
+}
+
+// WithEscapeNormalize is the kill switch for the file-edit tool escape-repair
+// pass on cross-format OpenAI-upstream responses (see
+// translate.AnthropicSSETranslator.WithEscapeNormalize).
+func (s *Service) WithEscapeNormalize(enabled bool) *Service {
+	s.escapeNormalize = enabled
 	return s
 }
 
@@ -2007,6 +2019,7 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 					WithEstimatedInputTokens(feats.Tokens).
 					WithRequestHadTools(feats.HasTools).
 					WithThinkTagReasoning(catalog.ThinkTagReasoningFor(d.Model)).
+					WithEscapeNormalize(s.escapeNormalize).
 					WithToolValidator(toolValidator)
 			}
 			if err := translator.Prelude(env.Stream()); err != nil {
@@ -2058,6 +2071,7 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 				WithRoutingMarker(suppressMarkerIfRequested(r.Header, routingMarkerFor(routeRes))).
 				WithEstimatedInputTokens(feats.Tokens).
 				WithRequestHadTools(feats.HasTools).
+				WithEscapeNormalize(s.escapeNormalize).
 				WithToolValidator(toolValidator)
 			if err := anthropicTr.Prelude(env.Stream()); err != nil {
 				log.Error("Anthropic SSE prelude failed (Gemini upstream)", "err", err)

--- a/internal/translate/escape_normalize.go
+++ b/internal/translate/escape_normalize.go
@@ -2,11 +2,6 @@ package translate
 
 import "strings"
 
-// EnableEditEscapeNormalize gates the escape-repair pass on file-edit tool
-// args. Off by default: the transform can corrupt legitimate source
-// containing literal `\n`/`\t` (e.g. a Python string `"\\n"`).
-var EnableEditEscapeNormalize bool
-
 // editToolNames is the set of tools whose args carry file content needing
 // exact whitespace round-tripping. Matched case-insensitively.
 var editToolNames = map[string]struct{}{
@@ -27,9 +22,11 @@ var editEscapableFields = map[string]struct{}{
 // models occasionally double-escape (`\\n` on the wire) in file-edit tool
 // args. Mutates `input` in place; no-op unless enabled, toolName is a
 // file-edit tool, and input is a JSON object. MultiEdit's nested `edits`
-// array entries are walked too.
-func normalizeEditEscapes(toolName string, input any) {
-	if !EnableEditEscapeNormalize {
+// array entries are walked too. The transform can corrupt legitimate source
+// containing literal `\n`/`\t` (e.g. a Python string `"\\n"`), so callers
+// must gate `enabled` behind an explicit opt-in.
+func normalizeEditEscapes(enabled bool, toolName string, input any) {
+	if !enabled {
 		return
 	}
 	if _, ok := editToolNames[strings.ToLower(toolName)]; !ok {

--- a/internal/translate/escape_normalize_test.go
+++ b/internal/translate/escape_normalize_test.go
@@ -2,6 +2,8 @@ package translate_test
 
 import (
 	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"workweave/router/internal/translate"
@@ -10,15 +12,21 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// withEscapeNormalize toggles the package-level flag for the duration of one
-// subtest and restores it after.
-func withEscapeNormalize(t *testing.T, enabled bool) {
+// translateWithEscapeNormalize routes resp through the buffered
+// (non-streaming) path of AnthropicSSETranslator with escape normalization
+// set to enabled, mirroring how proxy.Service threads the flag down instead
+// of a package-level global.
+func translateWithEscapeNormalize(t *testing.T, resp []byte, enabled bool) []byte {
 	t.Helper()
-	prior := translate.EnableEditEscapeNormalize
-	translate.EnableEditEscapeNormalize = enabled
-	t.Cleanup(func() {
-		translate.EnableEditEscapeNormalize = prior
-	})
+	rec := httptest.NewRecorder()
+	w := translate.NewAnthropicSSETranslator(rec, "deepseek/deepseek-v4-pro", nil).
+		WithEscapeNormalize(enabled)
+	require.NoError(t, w.Prelude(false)) // buffered path
+	w.WriteHeader(http.StatusOK)
+	_, err := w.Write(resp)
+	require.NoError(t, err)
+	require.NoError(t, w.Finalize())
+	return rec.Body.Bytes()
 }
 
 // editToolUseResponse builds a non-streaming OpenAI response with one tool_call
@@ -74,23 +82,19 @@ func firstToolUseInput(t *testing.T, body []byte) map[string]any {
 }
 
 func TestEscapeNormalize_FlagOff_DoesNothing(t *testing.T) {
-	withEscapeNormalize(t, false)
 	// JSON-encoded `\\n` lands as literal backslash-n after json.Unmarshal.
 	resp := editToolUseResponse(t, "Edit", `{"file_path":"a.go","old_string":"foo\\nbar","new_string":"baz"}`)
 
-	out, err := translate.OpenAIToAnthropicResponse(resp, "deepseek/deepseek-v4-pro")
-	require.NoError(t, err)
+	out := translateWithEscapeNormalize(t, resp, false)
 
 	input := firstToolUseInput(t, out)
 	assert.Equal(t, `foo\nbar`, input["old_string"], "flag off must leave literal backslash-n untouched")
 }
 
 func TestEscapeNormalize_FlagOn_RewritesEditArgs(t *testing.T) {
-	withEscapeNormalize(t, true)
 	resp := editToolUseResponse(t, "Edit", `{"file_path":"a.go","old_string":"foo\\nbar","new_string":"baz\\tqux"}`)
 
-	out, err := translate.OpenAIToAnthropicResponse(resp, "deepseek/deepseek-v4-pro")
-	require.NoError(t, err)
+	out := translateWithEscapeNormalize(t, resp, true)
 
 	input := firstToolUseInput(t, out)
 	assert.Equal(t, "foo\nbar", input["old_string"], "literal backslash-n must become real newline")
@@ -98,25 +102,21 @@ func TestEscapeNormalize_FlagOn_RewritesEditArgs(t *testing.T) {
 }
 
 func TestEscapeNormalize_FlagOn_LeavesRealNewlinesAlone(t *testing.T) {
-	withEscapeNormalize(t, true)
 	// `\n` in JSON decodes to a real newline before our code sees it; nothing to do.
 	resp := editToolUseResponse(t, "Edit", `{"old_string":"foo\nbar","new_string":"baz"}`)
 
-	out, err := translate.OpenAIToAnthropicResponse(resp, "deepseek/deepseek-v4-pro")
-	require.NoError(t, err)
+	out := translateWithEscapeNormalize(t, resp, true)
 
 	input := firstToolUseInput(t, out)
 	assert.Equal(t, "foo\nbar", input["old_string"], "already-correct newlines pass through unchanged")
 }
 
 func TestEscapeNormalize_FlagOn_SkipsNonEditTools(t *testing.T) {
-	withEscapeNormalize(t, true)
 	cases := []string{"Read", "Bash", "Grep"}
 	for _, name := range cases {
 		t.Run(name, func(t *testing.T) {
 			resp := editToolUseResponse(t, name, `{"command":"echo foo\\nbar"}`)
-			out, err := translate.OpenAIToAnthropicResponse(resp, "deepseek/deepseek-v4-pro")
-			require.NoError(t, err)
+			out := translateWithEscapeNormalize(t, resp, true)
 			input := firstToolUseInput(t, out)
 			assert.Equal(t, `echo foo\nbar`, input["command"], "non-edit tools must not be rewritten")
 		})
@@ -124,11 +124,9 @@ func TestEscapeNormalize_FlagOn_SkipsNonEditTools(t *testing.T) {
 }
 
 func TestEscapeNormalize_FlagOn_SkipsFilePath(t *testing.T) {
-	withEscapeNormalize(t, true)
 	resp := editToolUseResponse(t, "Edit", `{"file_path":"weird\\npath.go","old_string":"foo\\nbar"}`)
 
-	out, err := translate.OpenAIToAnthropicResponse(resp, "deepseek/deepseek-v4-pro")
-	require.NoError(t, err)
+	out := translateWithEscapeNormalize(t, resp, true)
 
 	input := firstToolUseInput(t, out)
 	assert.Equal(t, `weird\npath.go`, input["file_path"], "file_path is excluded — paths can have backslashes legitimately")
@@ -139,7 +137,6 @@ func TestEscapeNormalize_FlagOn_RewritesMultiEditNestedEdits(t *testing.T) {
 	// MultiEdit's real shape nests per-edit fields inside an `edits` array.
 	// A flat-only walk would silently skip the strings that actually need
 	// repairing.
-	withEscapeNormalize(t, true)
 	args := `{
 		"file_path":"a.go",
 		"edits":[
@@ -149,8 +146,7 @@ func TestEscapeNormalize_FlagOn_RewritesMultiEditNestedEdits(t *testing.T) {
 	}`
 	resp := editToolUseResponse(t, "MultiEdit", args)
 
-	out, err := translate.OpenAIToAnthropicResponse(resp, "deepseek/deepseek-v4-pro")
-	require.NoError(t, err)
+	out := translateWithEscapeNormalize(t, resp, true)
 
 	input := firstToolUseInput(t, out)
 	assert.Equal(t, "a.go", input["file_path"])
@@ -168,12 +164,10 @@ func TestEscapeNormalize_FlagOn_RewritesMultiEditNestedEdits(t *testing.T) {
 }
 
 func TestEscapeNormalize_FlagOn_CaseInsensitiveToolName(t *testing.T) {
-	withEscapeNormalize(t, true)
 	for _, name := range []string{"edit", "EDIT", "Write", "MultiEdit"} {
 		t.Run(name, func(t *testing.T) {
 			resp := editToolUseResponse(t, name, `{"old_string":"x\\nx","content":"y\\ny"}`)
-			out, err := translate.OpenAIToAnthropicResponse(resp, "deepseek/deepseek-v4-pro")
-			require.NoError(t, err)
+			out := translateWithEscapeNormalize(t, resp, true)
 			input := firstToolUseInput(t, out)
 			if v, ok := input["old_string"]; ok {
 				assert.Equal(t, "x\nx", v)

--- a/internal/translate/stream.go
+++ b/internal/translate/stream.go
@@ -420,6 +420,13 @@ type AnthropicSSETranslator struct {
 	thinkTagReasoning bool
 	splitter          thinkTagSplitter
 
+	// escapeNormalize repairs literal `\n`/`\t`/`\r` sequences that upstream
+	// models occasionally double-escape (`\\n` on the wire) in file-edit tool
+	// args (Edit/Write/MultiEdit). Off by default: the transform can corrupt
+	// legitimate source containing literal `\n`/`\t` (e.g. a Python string
+	// `"\\n"`).
+	escapeNormalize bool
+
 	// nudgeEmitted latches when finishStream emits the text-only recovery
 	// nudge, surfaced via Summary.
 	nudgeEmitted bool
@@ -509,6 +516,13 @@ func (t *AnthropicSSETranslator) WithRequestHadTools(hadTools bool) *AnthropicSS
 // chain-of-thought as inline content tags rather than reasoning_content.
 func (t *AnthropicSSETranslator) WithThinkTagReasoning(on bool) *AnthropicSSETranslator {
 	t.thinkTagReasoning = on
+	return t
+}
+
+// WithEscapeNormalize enables the escape-repair pass on file-edit tool
+// (Edit/Write/MultiEdit) args for the buffered non-streaming response path.
+func (t *AnthropicSSETranslator) WithEscapeNormalize(on bool) *AnthropicSSETranslator {
+	t.escapeNormalize = on
 	return t
 }
 
@@ -722,7 +736,7 @@ func (t *AnthropicSSETranslator) Finalize() error {
 		}
 	}
 
-	translated, issues, err := openAIToAnthropicResponse(body, t.requestModel, t.toolValidator, t.thinkTagReasoning)
+	translated, issues, err := openAIToAnthropicResponse(body, t.requestModel, t.toolValidator, t.thinkTagReasoning, t.escapeNormalize)
 	t.toolCallIssues = append(t.toolCallIssues, issues...)
 	if err != nil {
 		t.inner.Header().Set("Content-Type", "application/json")

--- a/internal/translate/translate.go
+++ b/internal/translate/translate.go
@@ -165,14 +165,14 @@ func AnthropicToOpenAIError(body []byte) []byte {
 // OpenAIToAnthropicResponse converts a non-streaming OpenAI response to
 // Anthropic Messages format.
 func OpenAIToAnthropicResponse(body []byte, requestModel string) ([]byte, error) {
-	out, _, err := openAIToAnthropicResponse(body, requestModel, nil, false)
+	out, _, err := openAIToAnthropicResponse(body, requestModel, nil, false, false)
 	return out, err
 }
 
 // openAIToAnthropicResponse is the validator-aware variant: tool_use inputs
 // are checked/repaired against the request's tool schemas, returning one
 // toolcheck.Issue per offending block. A nil validator is syntax-check-only.
-func openAIToAnthropicResponse(body []byte, requestModel string, toolValidator *toolcheck.Validator, thinkTagReasoning bool) ([]byte, []toolcheck.Issue, error) {
+func openAIToAnthropicResponse(body []byte, requestModel string, toolValidator *toolcheck.Validator, thinkTagReasoning, escapeNormalize bool) ([]byte, []toolcheck.Issue, error) {
 	if !gjson.ValidBytes(body) {
 		return nil, nil, fmt.Errorf("unmarshal openai response: invalid JSON")
 	}
@@ -213,7 +213,7 @@ func openAIToAnthropicResponse(body []byte, requestModel string, toolValidator *
 	jw.Key("model")
 	jw.Str(model)
 	jw.Key("content")
-	issues := writeAnthropicContentFromOpenAI(jw, message, toolValidator, thinkTagReasoning)
+	issues := writeAnthropicContentFromOpenAI(jw, message, toolValidator, thinkTagReasoning, escapeNormalize)
 	jw.Key("stop_reason")
 	jw.Str(openAIFinishToAnthropicStopReason(finishReason))
 	jw.Key("stop_sequence")
@@ -233,7 +233,7 @@ func writeAnthropicThinkingBlock(jw *jsonWriter, thinking string) {
 	jw.EndObj()
 }
 
-func writeAnthropicContentFromOpenAI(jw *jsonWriter, message gjson.Result, toolValidator *toolcheck.Validator, thinkTagReasoning bool) (issues []toolcheck.Issue) {
+func writeAnthropicContentFromOpenAI(jw *jsonWriter, message gjson.Result, toolValidator *toolcheck.Validator, thinkTagReasoning, escapeNormalize bool) (issues []toolcheck.Issue) {
 	jw.Arr()
 	reasoning := message.Get("reasoning_content").String()
 	if reasoning == "" {
@@ -279,10 +279,10 @@ func writeAnthropicContentFromOpenAI(jw *jsonWriter, message gjson.Result, toolV
 		}
 		argsStr := tc.Get("function.arguments").String()
 
-		if EnableEditEscapeNormalize && isEditToolName(name) {
+		if escapeNormalize && isEditToolName(name) {
 			var inputMap map[string]any
 			if json.Unmarshal([]byte(argsStr), &inputMap) == nil {
-				normalizeEditEscapes(name, inputMap)
+				normalizeEditEscapes(escapeNormalize, name, inputMap)
 				if b, err := json.Marshal(inputMap); err == nil {
 					argsStr = string(b)
 				}


### PR DESCRIPTION
## Summary

Two small, unrelated bug fixes.

**[92] `internal/translate` I/O-free-package invariant violation**

`cmd/router/main.go` mutated `translate.EnableEditEscapeNormalize`, an exported package-level bool, making the supposedly pure/I/O-free `internal/translate` package a process-wide singleton with no constructor-injection or reset path.

Fix: added `proxy.Service.WithEscapeNormalize(bool)`, matching the established `With*` kill-switch pattern already in `internal/proxy/service.go` (e.g. `WithPrefixTrimFreeSwitch`). Added the matching `translate.AnthropicSSETranslator.WithEscapeNormalize(bool)` builder, matching the existing `WithThinkTagReasoning` pattern. The flag is now threaded down as a plain parameter through `openAIToAnthropicResponse` → `writeAnthropicContentFromOpenAI` → `normalizeEditEscapes`, replacing the global. `cmd/router/main.go` now reads `ROUTER_DEEPSEEK_ESCAPE_NORMALIZE` into a local `bool` and passes it into the `proxy.NewService(...).WithEscapeNormalize(...)` builder chain instead of assigning a package global.

Both proxy call sites that build an `AnthropicSSETranslator` for OpenAI-family and Gemini-family upstreams now call `.WithEscapeNormalize(s.escapeNormalize)`, preserving the prior (global) behavior of applying uniformly across both paths.

Updated `internal/translate/escape_normalize_test.go` to exercise the flag through `AnthropicSSETranslator.WithEscapeNormalize` (the buffered non-streaming path), the same seam `stream_think_test.go` already uses for `WithThinkTagReasoning`, instead of mutating a package global.

**[62] Eager stack-trace build on every request**

`tracingWriter` in `internal/api/anthropic/messages.go` unconditionally called `debug.Stack()` on every `WriteHeader`/`Write` invocation on `/v1/messages` — the hottest path in the router. Since Go evaluates function arguments eagerly, this ran on every request/chunk regardless of the configured log level (the calls were `observability.Get().Debug(...)`, but the stack string was built before the level check).

Checked `git log -p` — `tracingWriter` was present since the initial commit (`9bf0317`, "Initial version of model router (#1)") and has never been touched since; nothing else in the codebase references it. It reads as forgotten debug scaffolding rather than an actively-used workflow, so removed it entirely: `svc.ProxyMessages` now receives `c.Writer` directly (already satisfies `http.ResponseWriter`).

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .` (clean)
- [x] `go test ./...` (all packages pass)