### PR TITLE
fix: derive configProviderOrder from APIKeyEnvVars, propagate strip errors in OpenAI path

### DIFF
--- a/internal/api/admin/config_test.go
+++ b/internal/api/admin/config_test.go
@@ -1,0 +1,46 @@
+package admin_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"workweave/router/internal/api/admin"
+	"workweave/router/internal/auth"
+	"workweave/router/internal/providers"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+)
+
+// TestConfigHandler_EnvProviderKeys_IncludesEveryDeployedProvider guards
+// [114]: ConfigHandler used to derive its display list from a hand-maintained
+// literal that silently omitted deepinfra and bedrock even though both are
+// wired into providerMap, so an operator who set the env var still saw the
+// key reported as absent. ConfigHandler must now report every provider
+// whose env var is actually set, regardless of when the provider was added
+// to internal/providers.
+func TestConfigHandler_EnvProviderKeys_IncludesEveryDeployedProvider(t *testing.T) {
+	t.Setenv(providers.APIKeyEnvVar(providers.ProviderDeepInfra), "dummy-key")
+	t.Setenv(providers.APIKeyEnvVar(providers.ProviderBedrock), "dummy-key")
+
+	gin.SetMode(gin.TestMode)
+	engine := gin.New()
+	engine.GET("/admin/v1/config", func(c *gin.Context) {
+		c.Set("router_installation", &auth.Installation{ID: "inst-1"})
+	}, admin.ConfigHandler)
+
+	req := httptest.NewRequest(http.MethodGet, "/admin/v1/config", nil)
+	rec := httptest.NewRecorder()
+	engine.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var body struct {
+		EnvProviderKeys []string `json:"env_provider_keys"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+	require.Contains(t, body.EnvProviderKeys, providers.ProviderDeepInfra)
+	require.Contains(t, body.EnvProviderKeys, providers.ProviderBedrock)
+}

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -1230,6 +1230,11 @@ var ErrProviderNotConfigured = errors.New("provider not configured")
 // avoid importing internal/translate directly (layering rule, root CLAUDE.md).
 var ErrRequestNotJSONObject = translate.ErrNotJSONObject
 
+// stripRoutingMarkerFromMessages is a seam over translate.StripRoutingMarkerFromMessages
+// so tests can force a strip failure without depending on a real reproducer;
+// prod code never overrides it.
+var stripRoutingMarkerFromMessages = translate.StripRoutingMarkerFromMessages
+
 // semanticCacheMaxBodyBytes caps how large a response the cache will store;
 // larger bodies stream through but skip the Store call to bound peak memory.
 const semanticCacheMaxBodyBytes = 1 << 20
@@ -1527,7 +1532,7 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 	// Strip the routing marker prior responses injected as assistant text —
 	// clients echo it back verbatim, so left in place it accumulates in
 	// upstream context every turn.
-	body, stripErr := translate.StripRoutingMarkerFromMessages(body)
+	body, stripErr := stripRoutingMarkerFromMessages(body)
 	if stripErr != nil {
 		log.Error("Failed to strip routing marker from inbound messages", "err", stripErr)
 		return fmt.Errorf("strip routing marker: %w", stripErr)
@@ -3297,14 +3302,17 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 	installationID := installationIDFromContext(ctx)
 	clientID := ClientIdentityFrom(ctx)
 
-	// Keep original bytes on strip failure: strippers return a nil body
-	// alongside the error, and this path logs-and-continues rather than aborts.
-	strippedBody, stripErr := translate.StripRoutingMarkerFromMessages(body)
+	strippedBody, stripErr := stripRoutingMarkerFromMessages(body)
 	if stripErr != nil {
 		log.Error("Failed to strip routing marker from OpenAI messages", "err", stripErr)
-	} else {
-		body = strippedBody
+		return fmt.Errorf("strip routing marker: %w", stripErr)
 	}
+	body = strippedBody
+
+	// Same for the one-click thumbs footer (and its signed rate URLs), which
+	// would otherwise shift assistant prefixes off the prompt cache.
+	// Best-effort: log-and-continue on failure rather than abort over cosmetic
+	// cleanup, matching the Anthropic Messages path.
 	strippedBody, stripErr = translate.StripFeedbackFooterFromMessages(body)
 	if stripErr != nil {
 		log.Error("Failed to strip feedback footer from OpenAI messages", "err", stripErr)

--- a/internal/proxy/strip_error_propagation_internal_test.go
+++ b/internal/proxy/strip_error_propagation_internal_test.go
@@ -1,0 +1,92 @@
+package proxy
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"workweave/router/internal/providers"
+	"workweave/router/internal/router"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// stripFailureRouter never gets called: the strip failure must abort the
+// turn before routing runs.
+type stripFailureRouter struct {
+	routeCalls int
+}
+
+func (r *stripFailureRouter) Route(context.Context, router.Request) (router.Decision, error) {
+	r.routeCalls++
+	return router.Decision{Provider: providers.ProviderAnthropic, Model: "claude-haiku-4-5"}, nil
+}
+
+// stripFailureProvider never gets called either, for the same reason.
+type stripFailureProvider struct {
+	proxyCalls int
+}
+
+func (p *stripFailureProvider) Proxy(context.Context, router.Decision, providers.PreparedRequest, http.ResponseWriter, *http.Request) error {
+	p.proxyCalls++
+	return nil
+}
+
+func (p *stripFailureProvider) Passthrough(context.Context, providers.PreparedRequest, http.ResponseWriter, *http.Request) error {
+	return nil
+}
+
+// TestProxyOpenAIChatCompletion_StripRoutingMarkerFailure_ReturnsError guards
+// [23]: ProxyOpenAIChatCompletion used to log a strip failure and proceed
+// with the unstripped body instead of aborting, unlike ProxyMessages. Force
+// the seam to fail and assert the OpenAI path now returns the error (and
+// never dispatches upstream) just like the Anthropic path.
+func TestProxyOpenAIChatCompletion_StripRoutingMarkerFailure_ReturnsError(t *testing.T) {
+	wantErr := errors.New("boom: strip failed")
+	prevStrip := stripRoutingMarkerFromMessages
+	stripRoutingMarkerFromMessages = func(body []byte) ([]byte, error) { return nil, wantErr }
+	defer func() { stripRoutingMarkerFromMessages = prevStrip }()
+
+	fr := &stripFailureRouter{}
+	fp := &stripFailureProvider{}
+	svc := NewService(fr, map[string]providers.Client{providers.ProviderAnthropic: fp}, nil, false, nil, nil, false,
+		providers.ProviderAnthropic, "claude-haiku-4-5", nil)
+
+	body := `{"model":"gpt-4o","messages":[{"role":"user","content":"hi"}]}`
+	rec := httptest.NewRecorder()
+	httpReq := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(body))
+
+	err := svc.ProxyOpenAIChatCompletion(context.Background(), []byte(body), rec, httpReq)
+
+	require.ErrorIs(t, err, wantErr, "strip failure must propagate instead of being swallowed")
+	assert.Zero(t, fr.routeCalls, "must abort before routing runs on strip failure")
+	assert.Zero(t, fp.proxyCalls, "must abort before dispatching upstream on strip failure")
+}
+
+// TestProxyMessages_StripRoutingMarkerFailure_ReturnsError is the existing
+// Anthropic-path behavior [23] fixes ProxyOpenAIChatCompletion to match.
+func TestProxyMessages_StripRoutingMarkerFailure_ReturnsError(t *testing.T) {
+	wantErr := errors.New("boom: strip failed")
+	prevStrip := stripRoutingMarkerFromMessages
+	stripRoutingMarkerFromMessages = func(body []byte) ([]byte, error) { return nil, wantErr }
+	defer func() { stripRoutingMarkerFromMessages = prevStrip }()
+
+	fr := &stripFailureRouter{}
+	fp := &stripFailureProvider{}
+	svc := NewService(fr, map[string]providers.Client{providers.ProviderAnthropic: fp}, nil, false, nil, nil, false,
+		providers.ProviderAnthropic, "claude-haiku-4-5", nil)
+
+	body := `{"model":"claude-opus-4-7","messages":[{"role":"user","content":"hi"}]}`
+	rec := httptest.NewRecorder()
+	httpReq := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(body))
+
+	err := svc.ProxyMessages(context.Background(), []byte(body), rec, httpReq)
+
+	require.ErrorIs(t, err, wantErr, "strip failure must propagate")
+	assert.Zero(t, fr.routeCalls, "must abort before routing runs on strip failure")
+	assert.Zero(t, fp.proxyCalls, "must abort before dispatching upstream on strip failure")
+}


### PR DESCRIPTION
## Summary

- **[114] `configProviderOrder` is stale, misleads operators.** Investigated the current `internal/api/admin/config.go` on `main`: this was already fixed — `ConfigHandler` derives `env_provider_keys` from `providers.AllProviders()` (sorted, includes `deepinfra`/`bedrock`) instead of a hand-maintained literal. Added `TestConfigHandler_EnvProviderKeys_IncludesEveryDeployedProvider` to `internal/api/admin/config_test.go` as an end-to-end regression guard (on top of the existing `providers.TestEveryProviderHasFamilyAndEnvVar`) so a future hand-maintained list can't silently regress this again.
- **[23] Inconsistent error handling between `ProxyMessages` and `ProxyOpenAIChatCompletion`.** `ProxyOpenAIChatCompletion` logged a `StripRoutingMarkerFromMessages` failure and proceeded with the unstripped body; `ProxyMessages` correctly returned the error. Fixed `ProxyOpenAIChatCompletion` in `internal/proxy/service.go` to return the error, matching `ProxyMessages`. Verified both HTTP callers (`internal/api/openai/completions.go`, `internal/api/anthropic/messages.go`) handle a returned error identically via `ClassifyDispatchError`/`log.Error` + `502 api_error` fallback, so no caller-side behavior changes.

## Testing

`StripRoutingMarkerFromMessages` can't currently fail on any reachable input (json.Marshal on a string never errors, sjson tolerates malformed trailing bytes), so I added a small test seam — a package-level `stripRoutingMarkerFromMessages` var in `internal/proxy/service.go` that tests override, mirroring the existing `retrySleep` seam pattern used for `dispatchWithFallback`. New tests in `internal/proxy/strip_error_propagation_internal_test.go`:

- `TestProxyOpenAIChatCompletion_StripRoutingMarkerFailure_ReturnsError` — forces the seam to fail; asserts the OpenAI path now returns the error and never reaches routing/dispatch.
- `TestProxyMessages_StripRoutingMarkerFailure_ReturnsError` — same assertion for the (already-correct) Anthropic path, to lock in parity.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .` (clean)
- [x] `go test ./...` (all packages pass)