### PR TITLE
fix: recover panics in remaining fire-and-forget goroutines (auth/proxy/pubsub)

### DIFF
--- a/internal/auth/service.go
+++ b/internal/auth/service.go
@@ -414,20 +414,10 @@ func userIdentityKey(email, claudeAccountUUID string) string {
 // fireMarkUsed runs the last_used_at update off the request path. Uses context.Background because
 // the parent ctx is often canceled (response written) before the UPDATE completes.
 func (s *Service) fireMarkUsed(apiKeyID string) {
-	go func() {
-		defer func() {
-			if r := recover(); r != nil {
-				observability.Get().Error("panic in fireMarkUsed", "panic", r, "api_key_id", apiKeyID)
-			}
-		}()
-		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-		defer cancel()
+	log := observability.Get().With("api_key_id", apiKeyID)
+	observability.SafeGo(log, 2*time.Second, "fireMarkUsed", func(ctx context.Context) {
 		if err := s.apiKeys.MarkUsed(ctx, apiKeyID); err != nil {
-			observability.Get().Warn(
-				"Failed to mark router api key used",
-				"api_key_id", apiKeyID,
-				"err", err,
-			)
+			log.Warn("Failed to mark router api key used", "err", err)
 		}
-	}()
+	})
 }

--- a/internal/auth/service_test.go
+++ b/internal/auth/service_test.go
@@ -444,7 +444,8 @@ func TestService_VerifyAPIKey_RecoversFromMarkUsedPanic(t *testing.T) {
 	}, "a panicking MarkUsed must not crash the request path")
 
 	require.Eventually(t, func() bool {
-		return strings.Contains(buf.String(), "panic in fireMarkUsed")
+		return strings.Contains(buf.String(), "Background goroutine panicked") &&
+			strings.Contains(buf.String(), "fireMarkUsed")
 	}, 500*time.Millisecond, 10*time.Millisecond,
 		"the async fireMarkUsed goroutine must recover and log the panic")
 }

--- a/internal/observability/safego.go
+++ b/internal/observability/safego.go
@@ -1,0 +1,33 @@
+package observability
+
+import (
+	"context"
+	"log/slog"
+	"time"
+)
+
+// SafeGo runs fn in a background goroutine bounded by timeout, recovering
+// any panic so a bug in a best-effort side effect (telemetry insert, cache
+// invalidation fanout, billing signal) drops the operation instead of taking
+// down the process. fn receives a fresh context.Background()-derived
+// context rather than a caller-supplied one, since these operations must
+// outlive the request that triggered them (response already written,
+// caller's ctx may already be canceled). fn is responsible for logging its
+// own failure with whatever level/fields fit that operation; SafeGo only
+// guards the goroutine boundary.
+//
+// Counterpart for boot-time, long-running goroutines (Pub/Sub listeners,
+// sweep loops) that must run until the parent ctx cancels rather than a
+// bounded timeout: cmd/router/main.go's safeGo.
+func SafeGo(log *slog.Logger, timeout time.Duration, name string, fn func(ctx context.Context)) {
+	go func() {
+		defer func() {
+			if r := recover(); r != nil {
+				log.Error("Background goroutine panicked", "goroutine", name, "panic", r)
+			}
+		}()
+		ctx, cancel := context.WithTimeout(context.Background(), timeout)
+		defer cancel()
+		fn(ctx)
+	}()
+}

--- a/internal/observability/safego_test.go
+++ b/internal/observability/safego_test.go
@@ -1,0 +1,66 @@
+package observability
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestSafeGoRecoversFromPanic proves a panic inside the wrapped fn is
+// recovered and logged rather than propagating out of the goroutine (which
+// would crash the process).
+func TestSafeGoRecoversFromPanic(t *testing.T) {
+	var buf bytes.Buffer
+	log := slog.New(slog.NewTextHandler(&buf, nil))
+
+	assert.NotPanics(t, func() {
+		SafeGo(log, time.Second, "test-goroutine", func(ctx context.Context) {
+			panic("boom")
+		})
+		waitForLog(t, &buf, "Background goroutine panicked")
+	})
+
+	assert.Contains(t, buf.String(), "Background goroutine panicked")
+	assert.Contains(t, buf.String(), "test-goroutine")
+	assert.Contains(t, buf.String(), "boom")
+}
+
+// TestSafeGoRunsFnToCompletion proves a non-panicking fn runs normally with
+// a bounded context derived from context.Background(), independent of any
+// caller-supplied ctx.
+func TestSafeGoRunsFnToCompletion(t *testing.T) {
+	var buf bytes.Buffer
+	log := slog.New(slog.NewTextHandler(&buf, nil))
+	done := make(chan struct{})
+
+	SafeGo(log, time.Second, "test-goroutine", func(ctx context.Context) {
+		defer close(done)
+		assert.NoError(t, ctx.Err())
+	})
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("fn did not run within timeout")
+	}
+	assert.Empty(t, buf.String())
+}
+
+// waitForLog polls buf until it contains substr or fails the test after a
+// bounded wait, since the goroutine under test runs concurrently.
+func waitForLog(t *testing.T, buf *bytes.Buffer, substr string) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if strings.Contains(buf.String(), substr) {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("expected log containing %q, got: %s", substr, buf.String())
+}

--- a/internal/proxy/fire_telemetry_panic_internal_test.go
+++ b/internal/proxy/fire_telemetry_panic_internal_test.go
@@ -64,12 +64,13 @@ func TestFireTelemetryRecoversFromPanic(t *testing.T) {
 		// fireTelemetry launches a goroutine; give it a moment to run and recover.
 		deadline := time.Now().Add(2 * time.Second)
 		for time.Now().Before(deadline) {
-			if strings.Contains(buf.String(), "telemetry insert panicked") {
+			if strings.Contains(buf.String(), "Background goroutine panicked") {
 				break
 			}
 			time.Sleep(10 * time.Millisecond)
 		}
 	})
 
-	assert.Contains(t, buf.String(), "telemetry insert panicked")
+	assert.Contains(t, buf.String(), "Background goroutine panicked")
+	assert.Contains(t, buf.String(), "fireTelemetry")
 }

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -2654,19 +2654,16 @@ func (s *Service) reportHMMOutcome(ctx context.Context, res turnLoopResult, deci
 	if proxyErr != nil {
 		payload["error"] = proxyErr.Error()
 	}
-	log := observability.FromContext(ctx)
+	log := observability.FromContext(ctx).With("route_id", routeMetadata.RouteID)
 	if err := ctx.Err(); err != nil {
-		log.Debug("Skipping HMM outcome report for canceled request", "err", err, "route_id", routeMetadata.RouteID)
+		log.Debug("Skipping HMM outcome report for canceled request", "err", err)
 		return
 	}
-	routeID := routeMetadata.RouteID
-	go func() {
-		reportCtx, cancel := context.WithTimeout(context.Background(), hmmOutcomeReportTimeout)
-		defer cancel()
+	observability.SafeGo(log, hmmOutcomeReportTimeout, "reportHMMOutcome", func(reportCtx context.Context) {
 		if err := s.hmmOutcomeReporter.ReportOutcome(reportCtx, payload); err != nil {
-			log.Error("HMM outcome report failed", "err", err, "route_id", routeID)
+			log.Error("HMM outcome report failed", "err", err)
 		}
-	}()
+	})
 }
 
 // pinDecision rehydrates a router.Decision from a stored pin. Metadata is nil
@@ -3134,18 +3131,12 @@ func (s *Service) fireTelemetry(p InsertTelemetryParams) {
 	if s.telemetry == nil {
 		return
 	}
-	go func() {
-		defer func() {
-			if r := recover(); r != nil {
-				observability.Get().Error("telemetry insert panicked", "panic", r)
-			}
-		}()
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-		defer cancel()
+	log := observability.Get().With("request_id", p.RequestID)
+	observability.SafeGo(log, 5*time.Second, "fireTelemetry", func(ctx context.Context) {
 		if err := s.telemetry.InsertRequestTelemetry(ctx, p); err != nil {
-			observability.Get().Debug("Telemetry insert failed", "err", err, "request_id", p.RequestID)
+			log.Debug("Telemetry insert failed", "err", err)
 		}
-	}()
+	})
 }
 
 // emitBilling debits the customer for one upstream call and, on switch turns

--- a/internal/pubsub/autopay.go
+++ b/internal/pubsub/autopay.go
@@ -29,18 +29,13 @@ func (n *AutopayNotifier) NotifyRechargeNeeded(organizationID string) {
 	if organizationID == "" {
 		return
 	}
-	go func() {
-		ctx, cancel := context.WithTimeout(context.Background(), notifyTimeout)
-		defer cancel()
+	log := observability.Get().With("organization_id", organizationID)
+	observability.SafeGo(log, notifyTimeout, "NotifyRechargeNeeded", func(ctx context.Context) {
 		result := n.publisher.Publish(ctx, &gcppubsub.Message{Data: []byte(organizationID)})
 		if _, err := result.Get(ctx); err != nil {
-			observability.Get().Warn(
-				"Failed to publish autopay recharge signal",
-				"organization_id", organizationID,
-				"err", err,
-			)
+			log.Warn("Failed to publish autopay recharge signal", "err", err)
 		}
-	}()
+	})
 }
 
 // Stop flushes buffered messages and shuts the publisher's background

--- a/internal/pubsub/invalidation.go
+++ b/internal/pubsub/invalidation.go
@@ -43,27 +43,13 @@ func (n *InvalidationNotifier) NotifyInstallationChanged(installationID string) 
 	if installationID == "" {
 		return
 	}
-	go func() {
-		defer func() {
-			if r := recover(); r != nil {
-				observability.Get().Error(
-					"Panic publishing installation invalidation",
-					"installation_id", installationID,
-					"panic", r,
-				)
-			}
-		}()
-		ctx, cancel := context.WithTimeout(context.Background(), notifyTimeout)
-		defer cancel()
+	log := observability.Get().With("installation_id", installationID)
+	observability.SafeGo(log, notifyTimeout, "NotifyInstallationChanged", func(ctx context.Context) {
 		result := n.publisher.Publish(ctx, &gcppubsub.Message{Data: []byte(installationID)})
 		if _, err := result.Get(ctx); err != nil {
-			observability.Get().Warn(
-				"Failed to publish installation invalidation",
-				"installation_id", installationID,
-				"err", err,
-			)
+			log.Warn("Failed to publish installation invalidation", "err", err)
 		}
-	}()
+	})
 }
 
 // Stop flushes buffered messages and shuts the publisher down. Must be


### PR DESCRIPTION
## Summary

Round 3 of the panic-recovery cleanup started in #593 (cluster embed goroutine) and continued in #609 (fireTelemetry/fireMarkUsed/boot goroutines).

Findings [105] and [82]: three packages (`auth`, `proxy`, `pubsub`) each spawn fire-and-forget `go func()` goroutines for best-effort side effects, duplicating the identical goroutine+recover+timeout idiom. Two of the five call sites had **no** panic recovery at all — a bug in either would crash the whole process instead of just dropping the best-effort write:

- `internal/proxy/service.go` `reportHMMOutcome` (HMM outcome telemetry) — unrecovered
- `internal/pubsub/autopay.go` `NotifyRechargeNeeded` (autopay recharge signal) — unrecovered
- `internal/auth/service.go` `fireMarkUsed` — already recovered inline (from #609)
- `internal/proxy/service.go` `fireTelemetry` — already recovered inline (from #609)
- `internal/pubsub/invalidation.go` `NotifyInstallationChanged` — already recovered inline (from #609)

Since three packages now need the identical idiom, extracted `observability.SafeGo(log *slog.Logger, timeout time.Duration, name string, fn func(ctx context.Context))` in the leaf `internal/observability` package and switched all five call sites to it. `SafeGo` owns the goroutine spawn, panic recovery + generic log, and the `context.Background()`-derived bounded timeout context; each `fn` keeps its own operation-specific error logging (level/fields vary per call site — Warn vs Debug vs Error — so that stays with the caller). Callers pre-scope their logger via `.With(...)` so panic logs retain call-site context (`api_key_id`, `request_id`, `route_id`, `installation_id`, `organization_id`).

This is a distinct helper from `cmd/router/main.go`'s existing `safeGo` (added in #609), which wraps *boot-time*, long-running goroutines (Pub/Sub listeners, sweep loops) that run until the parent ctx cancels — no bounded timeout. The two don't overlap in shape, so both are kept; `SafeGo`'s doc comment cross-references the boot-time counterpart to avoid confusion.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .` (clean)
- [x] `go test ./...` (all pass)
- [x] New `internal/observability/safego_test.go`: `TestSafeGoRecoversFromPanic` proves a panic inside the wrapped `fn` is recovered and logged instead of propagating; `TestSafeGoRunsFnToCompletion` proves the non-panic path runs normally.
- [x] Updated existing panic-recovery tests (`TestFireTelemetryRecoversFromPanic`, `TestService_VerifyAPIKey_RecoversFromMarkUsedPanic`) to assert on the new shared log message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)