### PR TITLE
fix: resolve middleware/httputil otel layering violation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,6 +75,8 @@ Three concentric layers. Imports flow inward only.
 |  |  |                      conversion: OpenAI <-> Anthropic |  |  |
 |  |  |                      <-> Gemini; pure, no I/O)        |  |  |
 |  |  |  internal/sse       (zero-alloc SSE framing helpers)  |  |  |
+|  |  |  internal/timing    (Timing value type: per-request   |  |  |
+|  |  |                      latency stamps, no otel dep)     |  |  |
 |  |  +-------------------------------------------------------+  |  |
 |  +-------------------------------------------------------------+  |
 |                                                                   |
@@ -87,8 +89,8 @@ Three concentric layers. Imports flow inward only.
 
 - **Layering is load-bearing.** Imports flow inward only. Inner-ring packages must not import adapter or presentation packages; adapters never import each other; only `cmd/router/main.go` constructs concrete things. Inner-ring packages may import each other (e.g. `proxy.Service.Route` returns `router.Decision`; `proxy.Service` calls `translate`, `sessionpin`, `planner`, `handover`, `cache`, `pricing`, `capability`, `turntype`, `usage` to compose a turn).
 - **Small utility third-party libs allowed at every layer.** Layering = about *where I/O and behavior live*, not banning go.mod entries. Reach for vetted small lib (`golang-lru`, `uuid`, error helpers) before rolling own. Reject heavyweight frameworks (DI containers, ORMs, metaprogramming kits).
-- **Inner-ring packages are I/O-free.** `internal/router`, `internal/providers`, `internal/translate`, `internal/sse`, `internal/router/{cache,capability,handover,planner,pricing,sessionpin,turntype}`, `internal/proxy/usage` define interfaces, value types, pure functions only. Adding I/O method (HTTP, DB, queue, FS) = layering violation; put on `auth.Service` / `proxy.Service` or adapter subpackage. Pure-Go utility libs fine.
-- **Adapters depend only on inner ring.** `internal/postgres` may also import `internal/sqlc`. Adapters never import each other — `internal/postgres` doesn't know `internal/api/admin` etc. Note: provider adapters (`internal/providers/<name>/`) import `internal/proxy` for `OnUpstreamMeta` callback so streaming responses record usage/headers back to proxy — one of few inward-pointing adapter→inner-ring imports, intentional.
+- **Inner-ring packages are I/O-free.** `internal/router`, `internal/providers`, `internal/translate`, `internal/sse`, `internal/timing`, `internal/router/{cache,capability,handover,planner,pricing,sessionpin,turntype}`, `internal/proxy/usage` define interfaces, value types, pure functions only. Adding I/O method (HTTP, DB, queue, FS) = layering violation; put on `auth.Service` / `proxy.Service` or adapter subpackage. Pure-Go utility libs fine.
+- **Adapters depend only on inner ring.** `internal/postgres` may also import `internal/sqlc`. Adapters never import each other — `internal/postgres` doesn't know `internal/api/admin` etc. Note: provider adapters (`internal/providers/<name>/`) import `internal/proxy` for `OnUpstreamMeta` callback so streaming responses record usage/headers back to proxy — one of few inward-pointing adapter→inner-ring imports, intentional. `internal/server/middleware` and `internal/providers/httputil` (both adapters) stamp/read request latency via `internal/timing`'s `Timing` value type instead of importing `internal/observability/otel` directly — `Timing` used to live in `otel` and was pulled out specifically so these adapters (and `internal/providers/{anthropic,openai,google,openaicompat}`) don't need a concrete dependency on the OTel exporter adapter just to stamp a timestamp. `internal/proxy` also imports `internal/timing` (an inner-ring package importing another inner-ring package, which is allowed) to read timing back into span attributes.
 - **`internal/api/*` and `internal/server`** depend on `internal/auth` (Service handle + middleware-context types) and `internal/proxy` (routing/dispatch service handle). May import `internal/observability` for logging, `internal/providers` for shared sentinel errors, `internal/router/cluster` for `ErrClusterUnavailable` sentinel + `DeployedModelsSource` interface (API handlers map sentinel → HTTP 503). Must not import `internal/postgres`, any concrete `internal/providers/*` adapter, or `internal/translate` directly. Concrete instances reach presentation only via constructor params from composition root.
 - **`internal/config` and `internal/observability` are leaf utilities** — must not import any other package under `internal/`. Third-party utility deps fine; today pull only stdlib + gin (request-scoped logger middleware). `internal/observability/otel` subpackage *is* an adapter (builds real OTLP exporter) and can import other internal packages; parent `internal/observability` stays a leaf.
 - **Composition happens in `cmd/router/main.go`.** Only file that constructs concrete adapters + injects them. No other place wires things. See [`cmd/CLAUDE.md`](cmd/CLAUDE.md).
@@ -113,7 +115,7 @@ Pick by responsibility, then read that package's `CLAUDE.md`:
 | New column / SQL query | `db/queries/` + `internal/postgres/` | [db/CLAUDE.md](db/CLAUDE.md), [internal/postgres/CLAUDE.md](internal/postgres/CLAUDE.md) |
 | Doc under `docs/` | `docs/` | [docs/CONFIGURATION.md](docs/CONFIGURATION.md) |
 
-**Default rule:** put logic in the package that uses it. Only promote to a shared home (`auth`, `proxy`, `translate`, `config`, `observability`, `sse`) when 3+ packages need the same logic.
+**Default rule:** put logic in the package that uses it. Only promote to a shared home (`auth`, `proxy`, `translate`, `config`, `observability`, `sse`, `timing`) when 3+ packages need the same logic.
 
 ## Adding a new helper
 
@@ -123,6 +125,7 @@ Don't, unless same logic needed in 3+ places and no plausible existing home. Can
 - **Env parsing** → [`internal/config`](internal/config).
 - **Logging / tracing** → [`internal/observability`](internal/observability) (OTel exporter in `otel` subpackage).
 - **SSE framing** → [`internal/sse`](internal/sse).
+- **Per-request latency stamps** → [`internal/timing`](internal/timing) — pure value type shared by adapters (`server/middleware`, `providers/*`) and `proxy.Service`; deliberately has zero otel dependency so those adapters don't need one just to stamp a timestamp.
 
 If new helper doesn't fit, justify new package in code comment before creating.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,6 +75,8 @@ Three concentric layers. Imports flow inward only.
 |  |  |                      conversion: OpenAI <-> Anthropic |  |  |
 |  |  |                      <-> Gemini; pure, no I/O)        |  |  |
 |  |  |  internal/sse       (zero-alloc SSE framing helpers)  |  |  |
+|  |  |  internal/timing    (Timing value type: per-request   |  |  |
+|  |  |                      latency stamps, no otel dep)     |  |  |
 |  |  +-------------------------------------------------------+  |  |
 |  +-------------------------------------------------------------+  |
 |                                                                   |
@@ -87,8 +89,8 @@ Three concentric layers. Imports flow inward only.
 
 - **Layering is load-bearing.** Imports flow inward only. Inner-ring packages must not import adapter or presentation packages; adapters never import each other; only `cmd/router/main.go` constructs concrete things. Inner-ring packages may import each other (e.g. `proxy.Service.Route` returns `router.Decision`; `proxy.Service` calls `translate`, `sessionpin`, `planner`, `handover`, `cache`, `pricing`, `capability`, `turntype`, `usage` to compose a turn).
 - **Small utility third-party libs allowed at every layer.** Layering = about *where I/O and behavior live*, not banning go.mod entries. Reach for vetted small lib (`golang-lru`, `uuid`, error helpers) before rolling own. Reject heavyweight frameworks (DI containers, ORMs, metaprogramming kits).
-- **Inner-ring packages are I/O-free.** `internal/router`, `internal/providers`, `internal/translate`, `internal/sse`, `internal/router/{cache,capability,handover,planner,pricing,sessionpin,turntype}`, `internal/proxy/usage` define interfaces, value types, pure functions only. Adding I/O method (HTTP, DB, queue, FS) = layering violation; put on `auth.Service` / `proxy.Service` or adapter subpackage. Pure-Go utility libs fine.
-- **Adapters depend only on inner ring.** `internal/postgres` may also import `internal/sqlc`. Adapters never import each other — `internal/postgres` doesn't know `internal/api/admin` etc. Note: provider adapters (`internal/providers/<name>/`) import `internal/proxy` for `OnUpstreamMeta` callback so streaming responses record usage/headers back to proxy — one of few inward-pointing adapter→inner-ring imports, intentional.
+- **Inner-ring packages are I/O-free.** `internal/router`, `internal/providers`, `internal/translate`, `internal/sse`, `internal/timing`, `internal/router/{cache,capability,handover,planner,pricing,sessionpin,turntype}`, `internal/proxy/usage` define interfaces, value types, pure functions only. Adding I/O method (HTTP, DB, queue, FS) = layering violation; put on `auth.Service` / `proxy.Service` or adapter subpackage. Pure-Go utility libs fine.
+- **Adapters depend only on inner ring.** `internal/postgres` may also import `internal/sqlc`. Adapters never import each other — `internal/postgres` doesn't know `internal/api/admin` etc. Note: provider adapters (`internal/providers/<name>/`) import `internal/proxy` for `OnUpstreamMeta` callback so streaming responses record usage/headers back to proxy — one of few inward-pointing adapter→inner-ring imports, intentional. `internal/server/middleware` and `internal/providers/httputil` (both adapters) stamp/read request latency via `internal/timing`'s `Timing` value type instead of importing `internal/observability/otel` directly — `Timing` used to live in `otel` and was pulled out specifically so these adapters (and `internal/providers/{anthropic,openai,google,openaicompat}`) don't need a concrete dependency on the OTel exporter adapter just to stamp a timestamp. `internal/proxy` also imports `internal/timing` (an inner-ring package importing another inner-ring package, which is allowed) to read timing back into span attributes.
 - **`internal/api/*` and `internal/server`** depend on `internal/auth` (Service handle + middleware-context types) and `internal/proxy` (routing/dispatch service handle). May import `internal/observability` for logging, `internal/providers` for shared sentinel errors, `internal/router/cluster` for `ErrClusterUnavailable` sentinel + `DeployedModelsSource` interface (API handlers map sentinel → HTTP 503). Must not import `internal/postgres`, any concrete `internal/providers/*` adapter, or `internal/translate` directly. Concrete instances reach presentation only via constructor params from composition root.
 - **`internal/config` and `internal/observability` are leaf utilities** — must not import any other package under `internal/`. Third-party utility deps fine; today pull only stdlib + gin (request-scoped logger middleware). `internal/observability/otel` subpackage *is* an adapter (builds real OTLP exporter) and can import other internal packages; parent `internal/observability` stays a leaf.
 - **Composition happens in `cmd/router/main.go`.** Only file that constructs concrete adapters + injects them. No other place wires things. See [`cmd/CLAUDE.md`](cmd/CLAUDE.md).
@@ -113,7 +115,7 @@ Pick by responsibility, then read that package's `CLAUDE.md`:
 | New column / SQL query | `db/queries/` + `internal/postgres/` | [db/CLAUDE.md](db/CLAUDE.md), [internal/postgres/CLAUDE.md](internal/postgres/CLAUDE.md) |
 | Doc under `docs/` | `docs/` | [docs/CONFIGURATION.md](docs/CONFIGURATION.md) |
 
-**Default rule:** put logic in the package that uses it. Only promote to a shared home (`auth`, `proxy`, `translate`, `config`, `observability`, `sse`) when 3+ packages need the same logic.
+**Default rule:** put logic in the package that uses it. Only promote to a shared home (`auth`, `proxy`, `translate`, `config`, `observability`, `sse`, `timing`) when 3+ packages need the same logic.
 
 ## Adding a new helper
 
@@ -123,6 +125,7 @@ Don't, unless same logic needed in 3+ places and no plausible existing home. Can
 - **Env parsing** → [`internal/config`](internal/config).
 - **Logging / tracing** → [`internal/observability`](internal/observability) (OTel exporter in `otel` subpackage).
 - **SSE framing** → [`internal/sse`](internal/sse).
+- **Per-request latency stamps** → [`internal/timing`](internal/timing) — pure value type shared by adapters (`server/middleware`, `providers/*`) and `proxy.Service`; deliberately has zero otel dependency so those adapters don't need one just to stamp a timestamp.
 
 If new helper doesn't fit, justify new package in code comment before creating.
 

--- a/internal/providers/anthropic/client.go
+++ b/internal/providers/anthropic/client.go
@@ -11,11 +11,11 @@ import (
 	"time"
 
 	"workweave/router/internal/observability"
-	"workweave/router/internal/observability/otel"
 	"workweave/router/internal/providers"
 	"workweave/router/internal/providers/httputil"
 	"workweave/router/internal/proxy"
 	"workweave/router/internal/router"
+	"workweave/router/internal/timing"
 )
 
 const DefaultBaseURL = "https://api.anthropic.com"
@@ -176,7 +176,7 @@ func (c *Client) Proxy(ctx context.Context, decision router.Decision, prep provi
 		upstream.Header.Set("accept", v)
 	}
 
-	t := otel.TimingFrom(ctx)
+	t := timing.TimingFrom(ctx)
 	t.StampUpstreamRequest()
 	resp, err := c.http.Do(upstream)
 	if err != nil {

--- a/internal/providers/anthropic/client_test.go
+++ b/internal/providers/anthropic/client_test.go
@@ -9,11 +9,11 @@ import (
 	"strings"
 	"testing"
 
-	"workweave/router/internal/observability/otel"
 	"workweave/router/internal/providers"
 	"workweave/router/internal/providers/anthropic"
 	"workweave/router/internal/proxy"
 	"workweave/router/internal/router"
+	"workweave/router/internal/timing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -385,7 +385,7 @@ func TestProxy_StampsTimingMilestones(t *testing.T) {
 	defer upstream.Close()
 
 	c := anthropic.NewClient("k", upstream.URL)
-	ctx, tm := otel.WithTiming(context.Background())
+	ctx, tm := timing.WithTiming(context.Background())
 	rec := httptest.NewRecorder()
 	clientReq := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(""))
 
@@ -410,7 +410,7 @@ func TestProxy_StampsTimingOnError(t *testing.T) {
 	defer upstream.Close()
 
 	c := anthropic.NewClient("k", upstream.URL)
-	ctx, tm := otel.WithTiming(context.Background())
+	ctx, tm := timing.WithTiming(context.Background())
 	rec := httptest.NewRecorder()
 	clientReq := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(""))
 

--- a/internal/providers/google/client.go
+++ b/internal/providers/google/client.go
@@ -10,11 +10,11 @@ import (
 	"strings"
 	"time"
 
-	"workweave/router/internal/observability/otel"
 	"workweave/router/internal/providers"
 	"workweave/router/internal/providers/httputil"
 	"workweave/router/internal/proxy"
 	"workweave/router/internal/router"
+	"workweave/router/internal/timing"
 )
 
 // DefaultBaseURL is the public OpenAI-compatible endpoint for Gemini.
@@ -96,7 +96,7 @@ func (c *Client) Proxy(ctx context.Context, decision router.Decision, prep provi
 		upstream.Header.Set("Accept", v)
 	}
 
-	t := otel.TimingFrom(ctx)
+	t := timing.TimingFrom(ctx)
 	t.StampUpstreamRequest()
 	resp, err := c.http.Do(upstream)
 	if err != nil {

--- a/internal/providers/google/client_test.go
+++ b/internal/providers/google/client_test.go
@@ -9,10 +9,10 @@ import (
 	"strings"
 	"testing"
 
-	"workweave/router/internal/observability/otel"
 	"workweave/router/internal/providers"
 	"workweave/router/internal/providers/google"
 	"workweave/router/internal/router"
+	"workweave/router/internal/timing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -62,7 +62,7 @@ func TestProxy_StampsTimingMilestones(t *testing.T) {
 	defer upstream.Close()
 
 	c := google.NewClient("k", upstream.URL)
-	ctx, tm := otel.WithTiming(context.Background())
+	ctx, tm := timing.WithTiming(context.Background())
 	rec := httptest.NewRecorder()
 	clientReq := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(""))
 

--- a/internal/providers/google/native_client.go
+++ b/internal/providers/google/native_client.go
@@ -10,11 +10,11 @@ import (
 	"time"
 
 	"workweave/router/internal/observability"
-	"workweave/router/internal/observability/otel"
 	"workweave/router/internal/providers"
 	"workweave/router/internal/providers/httputil"
 	"workweave/router/internal/proxy"
 	"workweave/router/internal/router"
+	"workweave/router/internal/timing"
 	"workweave/router/internal/translate"
 )
 
@@ -108,7 +108,7 @@ func (c *NativeClient) Proxy(ctx context.Context, decision router.Decision, prep
 		upstream.Header.Set("Accept", "text/event-stream")
 	}
 
-	t := otel.TimingFrom(ctx)
+	t := timing.TimingFrom(ctx)
 	t.StampUpstreamRequest()
 	resp, err := c.http.Do(upstream)
 	if err != nil {

--- a/internal/providers/httputil/httputil.go
+++ b/internal/providers/httputil/httputil.go
@@ -15,8 +15,8 @@ import (
 	"time"
 
 	"workweave/router/internal/auth"
-	"workweave/router/internal/observability/otel"
 	"workweave/router/internal/providers"
+	"workweave/router/internal/timing"
 )
 
 // FlushChunk is the read buffer size used by all streaming provider adapters.
@@ -292,7 +292,7 @@ func StartThroughputWatchdog(ctx context.Context, cancel context.CancelCauseFunc
 // watchdog cancels ctx with ErrUpstreamIdleTimeout on stall and StreamBody
 // returns that error directly; ctx must be wrapped via context.WithCancelCause
 // so the cause survives to the error site.
-func StreamBody(ctx context.Context, cancel context.CancelCauseFunc, idleTimeout time.Duration, r io.Reader, status int, w http.ResponseWriter, t *otel.Timing) error {
+func StreamBody(ctx context.Context, cancel context.CancelCauseFunc, idleTimeout time.Duration, r io.Reader, status int, w http.ResponseWriter, t *timing.Timing) error {
 	mark, stop := StartIdleWatchdog(ctx, cancel, idleTimeout)
 	defer stop()
 

--- a/internal/providers/httputil/httputil_test.go
+++ b/internal/providers/httputil/httputil_test.go
@@ -10,8 +10,8 @@ import (
 	"testing"
 	"time"
 
-	"workweave/router/internal/observability/otel"
 	"workweave/router/internal/providers"
+	"workweave/router/internal/timing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -59,7 +59,7 @@ func TestStreamBody_NoWatchdogPath(t *testing.T) {
 	}
 	w := httptest.NewRecorder()
 
-	err := StreamBody(ctx, nil, 0, r, 200, w, &otel.Timing{})
+	err := StreamBody(ctx, nil, 0, r, 200, w, &timing.Timing{})
 	require.NoError(t, err)
 	assert.Equal(t, "hello world", w.Body.String())
 }
@@ -74,7 +74,7 @@ func TestStreamBody_WatchdogDoesNotFireOnLivelyStream(t *testing.T) {
 	}
 	w := httptest.NewRecorder()
 
-	err := StreamBody(ctx, cancel, 200*time.Millisecond, r, 200, w, &otel.Timing{})
+	err := StreamBody(ctx, cancel, 200*time.Millisecond, r, 200, w, &timing.Timing{})
 	require.NoError(t, err)
 	assert.Equal(t, "abcd", w.Body.String())
 }
@@ -93,7 +93,7 @@ func TestStreamBody_WatchdogFiresOnStall(t *testing.T) {
 	w := httptest.NewRecorder()
 
 	start := time.Now()
-	err := StreamBody(ctx, cancel, 150*time.Millisecond, r, 200, w, &otel.Timing{})
+	err := StreamBody(ctx, cancel, 150*time.Millisecond, r, 200, w, &timing.Timing{})
 	elapsed := time.Since(start)
 
 	require.Error(t, err)
@@ -114,7 +114,7 @@ func TestStreamBody_WatchdogFiresWithZeroPriorBytes(t *testing.T) {
 	}
 	w := httptest.NewRecorder()
 
-	err := StreamBody(ctx, cancel, 100*time.Millisecond, r, 200, w, &otel.Timing{})
+	err := StreamBody(ctx, cancel, 100*time.Millisecond, r, 200, w, &timing.Timing{})
 	require.Error(t, err)
 	assert.ErrorIs(t, err, ErrUpstreamIdleTimeout)
 }
@@ -125,7 +125,7 @@ func TestStreamBody_NonStreamingStatus(t *testing.T) {
 	ctx, cancel := context.WithCancelCause(context.Background())
 	defer cancel(nil)
 
-	err := StreamBody(ctx, cancel, 200*time.Millisecond, r, 500, w, &otel.Timing{})
+	err := StreamBody(ctx, cancel, 200*time.Millisecond, r, 500, w, &timing.Timing{})
 	var statusErr *providers.UpstreamStatusError
 	require.ErrorAs(t, err, &statusErr)
 	assert.Equal(t, 500, statusErr.Status)

--- a/internal/providers/openai/client.go
+++ b/internal/providers/openai/client.go
@@ -12,11 +12,11 @@ import (
 	"time"
 
 	"workweave/router/internal/observability"
-	"workweave/router/internal/observability/otel"
 	"workweave/router/internal/providers"
 	"workweave/router/internal/providers/httputil"
 	"workweave/router/internal/proxy"
 	"workweave/router/internal/router"
+	"workweave/router/internal/timing"
 )
 
 const DefaultBaseURL = "https://api.openai.com"
@@ -204,7 +204,7 @@ func (c *Client) Proxy(ctx context.Context, decision router.Decision, prep provi
 		upstream.Header.Set(codexUserAgentHeader, codexUserAgentValue)
 	}
 
-	t := otel.TimingFrom(ctx)
+	t := timing.TimingFrom(ctx)
 	t.StampUpstreamRequest()
 	resp, err := c.http.Do(upstream)
 	if err != nil {

--- a/internal/providers/openai/client_test.go
+++ b/internal/providers/openai/client_test.go
@@ -9,10 +9,10 @@ import (
 	"strings"
 	"testing"
 
-	"workweave/router/internal/observability/otel"
 	"workweave/router/internal/providers"
 	"workweave/router/internal/providers/openai"
 	"workweave/router/internal/router"
+	"workweave/router/internal/timing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -116,7 +116,7 @@ func TestProxy_StampsTimingMilestones(t *testing.T) {
 	defer upstream.Close()
 
 	c := openai.NewClient("k", upstream.URL)
-	ctx, tm := otel.WithTiming(context.Background())
+	ctx, tm := timing.WithTiming(context.Background())
 	rec := httptest.NewRecorder()
 	clientReq := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(""))
 

--- a/internal/providers/openaicompat/client.go
+++ b/internal/providers/openaicompat/client.go
@@ -14,11 +14,11 @@ import (
 	"github.com/tidwall/gjson"
 	"github.com/tidwall/sjson"
 	"workweave/router/internal/observability"
-	"workweave/router/internal/observability/otel"
 	"workweave/router/internal/providers"
 	"workweave/router/internal/providers/httputil"
 	"workweave/router/internal/proxy"
 	"workweave/router/internal/router"
+	"workweave/router/internal/timing"
 )
 
 const (
@@ -192,7 +192,7 @@ func (c *Client) Proxy(ctx context.Context, decision router.Decision, prep provi
 		upstream.Header.Set("Accept", v)
 	}
 
-	t := otel.TimingFrom(ctx)
+	t := timing.TimingFrom(ctx)
 	t.StampUpstreamRequest()
 	resp, err := c.http.Do(upstream)
 	if err != nil {

--- a/internal/proxy/observation.go
+++ b/internal/proxy/observation.go
@@ -7,6 +7,7 @@ import (
 	"workweave/router/internal/observability"
 	"workweave/router/internal/observability/otel"
 	"workweave/router/internal/router"
+	"workweave/router/internal/timing"
 )
 
 // observationContext bundles per-request routing values shared by the OTel
@@ -87,7 +88,7 @@ func buildObservationContext(ctx context.Context, decision, fresh router.Decisio
 			}
 		}
 	}
-	if t := otel.TimingFrom(ctx); t != nil {
+	if t := timing.TimingFrom(ctx); t != nil {
 		if ms := t.Ms(&t.UpstreamRequestNanos, &t.UpstreamFirstByteNanos); ms > 0 {
 			obs.TTFTMs = &ms
 		}

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -29,6 +29,7 @@ import (
 	"workweave/router/internal/router/rl"
 	"workweave/router/internal/router/sessionpin"
 	"workweave/router/internal/router/turntype"
+	"workweave/router/internal/timing"
 	"workweave/router/internal/translate"
 
 	"github.com/google/uuid"
@@ -3017,7 +3018,7 @@ func resolveAndInjectCredentials(ctx context.Context, provider string, headers h
 
 // addTimingAttrs appends derived latency attributes from the request Timing.
 func addTimingAttrs(ctx context.Context, b *otel.AttrBuilder) {
-	t := otel.TimingFrom(ctx)
+	t := timing.TimingFrom(ctx)
 	if t == nil {
 		return
 	}

--- a/internal/server/middleware/observability_timing.go
+++ b/internal/server/middleware/observability_timing.go
@@ -1,17 +1,17 @@
 package middleware
 
 import (
-	"workweave/router/internal/observability/otel"
+	"workweave/router/internal/timing"
 
 	"github.com/gin-gonic/gin"
 )
 
-// WithTimingEntry creates an otel.Timing, stamps EntryNanos, and attaches it to the request context for downstream readers (provider adapters, proxy.Service) via otel.TimingFrom.
+// WithTimingEntry creates a timing.Timing, stamps EntryNanos, and attaches it to the request context for downstream readers (provider adapters, proxy.Service) via timing.TimingFrom.
 //
 // Must be registered before WithTimeout so the entry stamp reflects the true gin-entry instant, not the post-deadline-setup instant.
 func WithTimingEntry() gin.HandlerFunc {
 	return func(c *gin.Context) {
-		ctx, t := otel.WithTiming(c.Request.Context())
+		ctx, t := timing.WithTiming(c.Request.Context())
 		t.StampEntry()
 		c.Request = c.Request.WithContext(ctx)
 		c.Next()

--- a/internal/timing/timing.go
+++ b/internal/timing/timing.go
@@ -1,4 +1,10 @@
-package otel
+// Package timing carries per-request latency timestamps stamped by
+// middleware and provider adapters and read back by proxy.Service. It is a
+// pure value-type package (no I/O, no otel SDK dependency) so it can be
+// imported by adapters (internal/server/middleware, internal/providers/*)
+// without those adapters reaching into the internal/observability/otel
+// exporter adapter for a concrete type.
+package timing
 
 import (
 	"context"

--- a/internal/timing/timing_test.go
+++ b/internal/timing/timing_test.go
@@ -1,10 +1,10 @@
-package otel_test
+package timing_test
 
 import (
 	"context"
 	"testing"
 
-	"workweave/router/internal/observability/otel"
+	"workweave/router/internal/timing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -12,20 +12,20 @@ import (
 
 func TestTimingRoundTripViaContext(t *testing.T) {
 	ctx := context.Background()
-	ctx, tm := otel.WithTiming(ctx)
+	ctx, tm := timing.WithTiming(ctx)
 	require.NotNil(t, tm)
 
-	got := otel.TimingFrom(ctx)
+	got := timing.TimingFrom(ctx)
 	assert.Equal(t, tm, got)
 }
 
 func TestTimingFromEmptyContext(t *testing.T) {
-	got := otel.TimingFrom(context.Background())
+	got := timing.TimingFrom(context.Background())
 	assert.Nil(t, got)
 }
 
 func TestStampIsIdempotent(t *testing.T) {
-	tm := &otel.Timing{}
+	tm := &timing.Timing{}
 	tm.StampEntry()
 	first := tm.EntryNanos.Load()
 	require.NotZero(t, first)
@@ -35,7 +35,7 @@ func TestStampIsIdempotent(t *testing.T) {
 }
 
 func TestStampNilReceiver(t *testing.T) {
-	var tm *otel.Timing
+	var tm *timing.Timing
 	assert.NotPanics(t, func() { tm.StampEntry() })
 	assert.NotPanics(t, func() { tm.StampUpstreamRequest() })
 	assert.NotPanics(t, func() { tm.StampUpstreamHeaders() })
@@ -44,31 +44,31 @@ func TestStampNilReceiver(t *testing.T) {
 }
 
 func TestMsReturnsZeroWhenUnstamped(t *testing.T) {
-	tm := &otel.Timing{}
+	tm := &timing.Timing{}
 	tm.StampEntry()
 	assert.Zero(t, tm.Ms(&tm.EntryNanos, &tm.UpstreamRequestNanos), "unstamped 'to' field should yield 0")
 	assert.Zero(t, tm.Ms(&tm.UpstreamRequestNanos, &tm.EntryNanos), "unstamped 'from' field should yield 0")
 }
 
 func TestMsNilReceiver(t *testing.T) {
-	var tm *otel.Timing
-	dummy := &otel.Timing{}
+	var tm *timing.Timing
+	dummy := &timing.Timing{}
 	assert.Zero(t, tm.Ms(&dummy.EntryNanos, &dummy.UpstreamRequestNanos))
 }
 
 func TestMsSinceNilReceiver(t *testing.T) {
-	var tm *otel.Timing
-	dummy := &otel.Timing{}
+	var tm *timing.Timing
+	dummy := &timing.Timing{}
 	assert.Zero(t, tm.MsSince(&dummy.EntryNanos))
 }
 
 func TestMsSinceReturnsZeroWhenUnstamped(t *testing.T) {
-	tm := &otel.Timing{}
+	tm := &timing.Timing{}
 	assert.Zero(t, tm.MsSince(&tm.EntryNanos))
 }
 
 func TestMsBetweenStampedFields(t *testing.T) {
-	tm := &otel.Timing{}
+	tm := &timing.Timing{}
 	tm.EntryNanos.Store(1_000_000_000)
 	tm.UpstreamRequestNanos.Store(1_050_000_000)
 


### PR DESCRIPTION
## Finding
[103] `internal/server/middleware` and `internal/providers/httputil` (both adapter-ring packages per the root diagram) imported `internal/observability/otel` directly for the concrete `Timing` type — an undocumented adapter-to-adapter edge distinct from the one documented exception (`providers/<name>` → `proxy.OnUpstreamMeta`).

## Fix chosen: (a) move the type

Read `Timing`'s definition first — it's a pure value type (`sync/atomic` timestamps + nil-safe `Stamp*`/`Ms`/`MsSince` methods, no otel SDK/HTTP export machinery). Moving it out was the low-risk, architecturally-correct option, so that's what I did rather than documenting a new exception.

- Moved `Timing`/`WithTiming`/`TimingFrom` from `internal/observability/otel` into a new leaf inner-ring package, `internal/timing` (no internal imports, stdlib only).
- Updated every consumer to import `internal/timing` instead of reaching into `internal/observability/otel` for this type:
  - `internal/server/middleware/observability_timing.go` — otel import dropped entirely.
  - `internal/providers/httputil/httputil.go` (+ test) — otel import dropped entirely.
  - `internal/providers/{anthropic,openai,google,openaicompat}/client.go` (+ tests) — otel import dropped entirely (these only ever used `otel.TimingFrom`).
  - `internal/proxy/service.go` and `internal/proxy/observation.go` — added `internal/timing` import alongside the still-legitimate `internal/observability/otel` import (proxy uses otel for `Span`/`AttrBuilder`/`UsageExtractor`/pricing lookups elsewhere; only the `TimingFrom` call sites moved). `internal/proxy` importing `internal/timing` is inner-ring→inner-ring, which the layer model already allows.
- Documented the new package in root `CLAUDE.md` (kept `AGENTS.md` byte-identical per the mirror notice): added it to the layer diagram, the inner-ring I/O-free list, the "Adding a new helper" canonical-homes list, and a note next to the existing `OnUpstreamMeta` exception explaining why this one isn't a violation.

## Validation
- `go build ./...` — clean
- `go vet ./...` — clean
- `gofmt -l .` — clean
- `go test ./...` — all packages pass, including the relocated `internal/timing` tests