### PR TITLE
refactor: extract shared tool_choice normalization (5 duplicated sites)

### DIFF
--- a/internal/translate/crossformat_request_test.go
+++ b/internal/translate/crossformat_request_test.go
@@ -1886,3 +1886,74 @@ func TestStripToolUseThoughtSignature_AnthropicToAnthropic(t *testing.T) {
 	assert.Equal(t, "Read", block["name"], "tool_use.name must be preserved")
 	assert.Equal(t, map[string]any{"path": "x"}, block["input"], "tool_use.input must be preserved")
 }
+
+// TestCrossFormat_OpenAIToAnthropic_ToolChoiceVariants covers the OpenAI ->
+// Anthropic tool_choice mapping for every mode except "none" (which suppresses
+// tools entirely and is covered by
+// TestCrossFormat_OpenAIToAnthropic_ToolChoiceNoneSuppressesTools).
+func TestCrossFormat_OpenAIToAnthropic_ToolChoiceVariants(t *testing.T) {
+	cases := []struct {
+		name       string
+		toolChoice string
+		want       map[string]any
+	}{
+		{"auto", `"auto"`, map[string]any{"type": "auto"}},
+		{"required", `"required"`, map[string]any{"type": "any"}},
+		{"named", `{"type":"function","function":{"name":"Bash"}}`, map[string]any{"type": "tool", "name": "Bash"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			body := []byte(`{
+				"model": "gpt-4",
+				"messages": [{"role": "user", "content": "hi"}],
+				"tools": [{"type": "function", "function": {"name": "Bash", "parameters": {"type": "object"}}}],
+				"tool_choice": ` + tc.toolChoice + `
+			}`)
+			env, err := translate.ParseOpenAI(body)
+			require.NoError(t, err)
+			prep, err := env.PrepareAnthropic(http.Header{}, translate.EmitOptions{
+				TargetModel: "claude-sonnet-4-20250514",
+			})
+			require.NoError(t, err)
+
+			var doc map[string]any
+			require.NoError(t, json.Unmarshal(prep.Body, &doc))
+			assert.Equal(t, tc.want, doc["tool_choice"])
+		})
+	}
+}
+
+// TestCrossFormat_AnthropicToOpenAI_ToolChoiceVariants covers the Anthropic ->
+// OpenAI chat-completions tool_choice mapping. Anthropic's "none" has no
+// direct chat-completions equivalent and is intentionally left unmapped.
+func TestCrossFormat_AnthropicToOpenAI_ToolChoiceVariants(t *testing.T) {
+	cases := []struct {
+		name       string
+		toolChoice string
+		want       any
+	}{
+		{"auto", `{"type":"auto"}`, "auto"},
+		{"any", `{"type":"any"}`, "required"},
+		{"tool", `{"type":"tool","name":"Bash"}`, map[string]any{"type": "function", "function": map[string]any{"name": "Bash"}}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			body := []byte(`{
+				"model": "claude-sonnet-4-20250514",
+				"messages": [{"role": "user", "content": "hi"}],
+				"tools": [{"name": "Bash", "input_schema": {"type": "object"}}],
+				"tool_choice": ` + tc.toolChoice + `
+			}`)
+			env, err := translate.ParseAnthropic(body)
+			require.NoError(t, err)
+			prep, err := env.PrepareOpenAI(http.Header{}, translate.EmitOptions{
+				TargetModel:    "gpt-4",
+				TargetProvider: "openai",
+			})
+			require.NoError(t, err)
+
+			doc := unmarshalBody(t, prep.Body)
+			assert.Equal(t, tc.want, doc["tool_choice"])
+		})
+	}
+}

--- a/internal/translate/crossformat_request_test.go
+++ b/internal/translate/crossformat_request_test.go
@@ -1887,10 +1887,8 @@ func TestStripToolUseThoughtSignature_AnthropicToAnthropic(t *testing.T) {
 	assert.Equal(t, map[string]any{"path": "x"}, block["input"], "tool_use.input must be preserved")
 }
 
-// TestCrossFormat_OpenAIToAnthropic_ToolChoiceVariants covers the OpenAI ->
-// Anthropic tool_choice mapping for every mode except "none" (which suppresses
-// tools entirely and is covered by
-// TestCrossFormat_OpenAIToAnthropic_ToolChoiceNoneSuppressesTools).
+// TestCrossFormat_OpenAIToAnthropic_ToolChoiceVariants covers auto/required/named modes;
+// "none" (suppresses tools) is covered by TestCrossFormat_OpenAIToAnthropic_ToolChoiceNoneSuppressesTools.
 func TestCrossFormat_OpenAIToAnthropic_ToolChoiceVariants(t *testing.T) {
 	cases := []struct {
 		name       string

--- a/internal/translate/emit_anthropic.go
+++ b/internal/translate/emit_anthropic.go
@@ -126,7 +126,8 @@ func (e *RequestEnvelope) buildAnthropicFromOpenAI(opts EmitOptions) ([]byte, er
 
 	// tool_choice "none" suppresses tools entirely — Anthropic has no direct
 	// equivalent, so omitting tools is the only way to prevent tool calls.
-	suppressTools := gjson.GetBytes(e.body, "tool_choice").String() == "none"
+	kind, _ := openAIToolChoice(e.body)
+	suppressTools := kind == toolChoiceNone
 	if !suppressTools {
 		writeAnthropicTools(jw, e.body)
 		writeAnthropicToolChoice(jw, e.body)
@@ -591,35 +592,26 @@ func writeAnthropicTools(jw *jsonWriter, body []byte) {
 }
 
 func writeAnthropicToolChoice(jw *jsonWriter, body []byte) {
-	r := gjson.GetBytes(body, "tool_choice")
-	if !r.Exists() {
-		return
-	}
-	if r.Type == gjson.String {
-		switch r.String() {
-		case "auto":
-			jw.Key("tool_choice")
-			jw.Raw(`{"type":"auto"}`)
-		case "required":
-			jw.Key("tool_choice")
-			jw.Raw(`{"type":"any"}`)
-		case "none":
-			// Handled upstream — tools and tool_choice both suppressed.
-		}
-		return
-	}
-	if r.IsObject() {
-		if name := r.Get("function.name").String(); name != "" {
-			tw := newJSONWriter()
-			tw.Obj()
-			tw.Key("type")
-			tw.Str("tool")
-			tw.Key("name")
-			tw.Str(name)
-			tw.EndObj()
-			jw.Key("tool_choice")
-			jw.Raw(string(tw.Bytes()))
-		}
+	kind, name := openAIToolChoice(body)
+	switch kind {
+	case toolChoiceAuto:
+		jw.Key("tool_choice")
+		jw.Raw(`{"type":"auto"}`)
+	case toolChoiceRequired:
+		jw.Key("tool_choice")
+		jw.Raw(`{"type":"any"}`)
+	case toolChoiceNone:
+		// Handled upstream — tools and tool_choice both suppressed.
+	case toolChoiceNamed:
+		tw := newJSONWriter()
+		tw.Obj()
+		tw.Key("type")
+		tw.Str("tool")
+		tw.Key("name")
+		tw.Str(name)
+		tw.EndObj()
+		jw.Key("tool_choice")
+		jw.Raw(string(tw.Bytes()))
 	}
 }
 

--- a/internal/translate/emit_gemini.go
+++ b/internal/translate/emit_gemini.go
@@ -466,66 +466,8 @@ func writeGeminiToolsFromOpenAI(jw *jsonWriter, body []byte) {
 // "auto") on Gemini 3.x gets mode=VALIDATED for schema-constrained decoding;
 // explicit none/required/function choices pass through untouched.
 func writeGeminiToolChoiceFromOpenAI(jw *jsonWriter, body []byte, model string, downgradeValidated bool) {
-	r := gjson.GetBytes(body, "tool_choice")
-	choice := ""
-	if r.Type == gjson.String {
-		choice = r.String()
-	}
-	if (!r.Exists() || choice == "auto") && hasNonEmptyTools(body) && isGemini3xModel(model) {
-		jw.Key("toolConfig")
-		jw.Obj()
-		jw.Key("functionCallingConfig")
-		jw.Obj()
-		jw.Key("mode")
-		jw.Str(geminiToolMode(downgradeValidated))
-		jw.EndObj()
-		jw.EndObj()
-		return
-	}
-	if !r.Exists() {
-		return
-	}
-	if r.Type == gjson.String {
-		var mode string
-		switch choice {
-		case "auto":
-			mode = "AUTO"
-		case "none":
-			mode = "NONE"
-		case "required":
-			mode = "ANY"
-		}
-		if mode == "" {
-			return
-		}
-		jw.Key("toolConfig")
-		jw.Obj()
-		jw.Key("functionCallingConfig")
-		jw.Obj()
-		jw.Key("mode")
-		jw.Str(mode)
-		jw.EndObj()
-		jw.EndObj()
-		return
-	}
-	if r.IsObject() && r.Get("type").String() == "function" {
-		name := r.Get("function.name").String()
-		if name == "" {
-			return
-		}
-		jw.Key("toolConfig")
-		jw.Obj()
-		jw.Key("functionCallingConfig")
-		jw.Obj()
-		jw.Key("mode")
-		jw.Str("ANY")
-		jw.Key("allowedFunctionNames")
-		jw.Arr()
-		jw.Str(name)
-		jw.EndArr()
-		jw.EndObj()
-		jw.EndObj()
-	}
+	kind, name := openAIToolChoice(body)
+	writeGeminiToolChoice(jw, body, model, downgradeValidated, kind, name)
 }
 
 // writeGeminiGenerationConfigFromOpenAI writes generationConfig into jw from an OpenAI body.
@@ -818,23 +760,16 @@ func geminiEmitsValidatedToolMode(body []byte, model string, format Format) bool
 	if !hasNonEmptyTools(body) || !isGemini3xModel(model) {
 		return false
 	}
-	r := gjson.GetBytes(body, "tool_choice")
+	var kind toolChoiceKind
 	switch format {
 	case FormatAnthropic:
-		choice := ""
-		if r.Exists() && r.IsObject() {
-			choice = r.Get("type").String()
-		}
-		return choice == "" || choice == "auto"
+		kind, _ = anthropicToolChoice(body)
 	case FormatOpenAI:
-		choice := ""
-		if r.Type == gjson.String {
-			choice = r.String()
-		}
-		return !r.Exists() || choice == "auto"
+		kind, _ = openAIToolChoice(body)
 	default:
 		return false
 	}
+	return kind == toolChoiceAbsent || kind == toolChoiceAuto
 }
 
 // filterOutGeminiFunctionCallParts strips functionCall parts; used when
@@ -1062,68 +997,50 @@ func writeGeminiToolsFromAnthropic(jw *jsonWriter, body []byte) {
 // mode=VALIDATED — schema-constrained decoding without forcing a tool call.
 // Explicit any/none/tool choices pass through untouched.
 func writeGeminiToolChoiceFromAnthropic(jw *jsonWriter, body []byte, model string, downgradeValidated bool) {
-	r := gjson.GetBytes(body, "tool_choice")
-	choice := ""
-	if r.Exists() && r.IsObject() {
-		choice = r.Get("type").String()
-	}
-	if (choice == "" || choice == "auto") && hasNonEmptyTools(body) && isGemini3xModel(model) {
-		jw.Key("toolConfig")
-		jw.Obj()
-		jw.Key("functionCallingConfig")
-		jw.Obj()
-		jw.Key("mode")
-		jw.Str(geminiToolMode(downgradeValidated))
-		jw.EndObj()
-		jw.EndObj()
+	kind, name := anthropicToolChoice(body)
+	writeGeminiToolChoice(jw, body, model, downgradeValidated, kind, name)
+}
+
+// writeGeminiToolChoice writes toolConfig into jw from a source-neutral
+// tool_choice kind. Unforced tool_choice (absent or auto) on Gemini 3.x gets
+// mode=VALIDATED for schema-constrained decoding; explicit
+// none/required/named choices map straight to a functionCallingConfig mode.
+func writeGeminiToolChoice(jw *jsonWriter, body []byte, model string, downgradeValidated bool, kind toolChoiceKind, name string) {
+	if (kind == toolChoiceAbsent || kind == toolChoiceAuto) && hasNonEmptyTools(body) && isGemini3xModel(model) {
+		writeGeminiFunctionCallingMode(jw, geminiToolMode(downgradeValidated), "")
 		return
 	}
-	switch choice {
-	case "auto":
-		jw.Key("toolConfig")
-		jw.Obj()
-		jw.Key("functionCallingConfig")
-		jw.Obj()
-		jw.Key("mode")
-		jw.Str("AUTO")
-		jw.EndObj()
-		jw.EndObj()
-	case "any":
-		jw.Key("toolConfig")
-		jw.Obj()
-		jw.Key("functionCallingConfig")
-		jw.Obj()
-		jw.Key("mode")
-		jw.Str("ANY")
-		jw.EndObj()
-		jw.EndObj()
-	case "none":
-		jw.Key("toolConfig")
-		jw.Obj()
-		jw.Key("functionCallingConfig")
-		jw.Obj()
-		jw.Key("mode")
-		jw.Str("NONE")
-		jw.EndObj()
-		jw.EndObj()
-	case "tool":
-		name := r.Get("name").String()
-		if name == "" {
-			return
-		}
-		jw.Key("toolConfig")
-		jw.Obj()
-		jw.Key("functionCallingConfig")
-		jw.Obj()
-		jw.Key("mode")
-		jw.Str("ANY")
+	switch kind {
+	case toolChoiceAuto:
+		writeGeminiFunctionCallingMode(jw, "AUTO", "")
+	case toolChoiceRequired:
+		writeGeminiFunctionCallingMode(jw, "ANY", "")
+	case toolChoiceNone:
+		writeGeminiFunctionCallingMode(jw, "NONE", "")
+	case toolChoiceNamed:
+		writeGeminiFunctionCallingMode(jw, "ANY", name)
+	}
+}
+
+// writeGeminiFunctionCallingMode writes a toolConfig.functionCallingConfig
+// object with the given mode, optionally pinning a single allowed function
+// name (used for the named-tool choice, which Gemini expresses as ANY mode
+// plus an allowedFunctionNames allowlist of one).
+func writeGeminiFunctionCallingMode(jw *jsonWriter, mode, name string) {
+	jw.Key("toolConfig")
+	jw.Obj()
+	jw.Key("functionCallingConfig")
+	jw.Obj()
+	jw.Key("mode")
+	jw.Str(mode)
+	if name != "" {
 		jw.Key("allowedFunctionNames")
 		jw.Arr()
 		jw.Str(name)
 		jw.EndArr()
-		jw.EndObj()
-		jw.EndObj()
 	}
+	jw.EndObj()
+	jw.EndObj()
 }
 
 // writeGeminiGenerationConfigFromAnthropic writes generationConfig into jw from an Anthropic body.

--- a/internal/translate/emit_openai.go
+++ b/internal/translate/emit_openai.go
@@ -698,26 +698,15 @@ func writeOpenAIToolsFromAnthropic(jw *jsonWriter, body []byte) {
 // writeOpenAIToolChoiceFromAnthropic emits the "tool_choice" key into jw by
 // converting the Anthropic tool_choice field to OpenAI format.
 func writeOpenAIToolChoiceFromAnthropic(jw *jsonWriter, body []byte) {
-	r := gjson.GetBytes(body, "tool_choice")
-	if !r.Exists() || !r.IsObject() {
-		return
-	}
-	switch r.Get("type").String() {
-	case "auto":
+	kind, name := anthropicToolChoice(body)
+	switch kind {
+	case toolChoiceAuto:
 		jw.Key("tool_choice")
 		jw.Str("auto")
-	case "any":
+	case toolChoiceRequired:
 		jw.Key("tool_choice")
 		jw.Str("required")
-	case "tool":
-		nameRes := r.Get("name")
-		if nameRes.Type != gjson.String {
-			return
-		}
-		name := nameRes.String()
-		if name == "" {
-			return
-		}
+	case toolChoiceNamed:
 		inner := newJSONWriter()
 		inner.Obj()
 		inner.Key("type")

--- a/internal/translate/emit_openai_responses.go
+++ b/internal/translate/emit_openai_responses.go
@@ -387,27 +387,22 @@ func writeResponsesToolsFromAnthropic(jw *jsonWriter, body []byte) {
 // writeResponsesToolChoiceFromAnthropic maps the Anthropic tool_choice to the
 // Responses tool_choice shape.
 func writeResponsesToolChoiceFromAnthropic(jw *jsonWriter, body []byte) {
-	tc := gjson.GetBytes(body, "tool_choice")
-	if !tc.Exists() {
-		return
-	}
-	switch tc.Get("type").String() {
-	case "auto":
+	kind, name := anthropicToolChoice(body)
+	switch kind {
+	case toolChoiceAuto:
 		jw.Key("tool_choice")
 		jw.Str("auto")
-	case "any":
+	case toolChoiceRequired:
 		jw.Key("tool_choice")
 		jw.Str("required")
-	case "tool":
-		if name := tc.Get("name").String(); name != "" {
-			jw.Key("tool_choice")
-			jw.Obj()
-			jw.Key("type")
-			jw.Str("function")
-			jw.Key("name")
-			jw.Str(name)
-			jw.EndObj()
-		}
+	case toolChoiceNamed:
+		jw.Key("tool_choice")
+		jw.Obj()
+		jw.Key("type")
+		jw.Str("function")
+		jw.Key("name")
+		jw.Str(name)
+		jw.EndObj()
 	}
 }
 

--- a/internal/translate/gemini_test.go
+++ b/internal/translate/gemini_test.go
@@ -164,6 +164,38 @@ func TestPrepareGemini_FromAnthropic_ToolChoiceVariants(t *testing.T) {
 	}
 }
 
+// TestPrepareGemini_UnrecognizedToolChoiceDoesNotEnableValidatedMode guards a
+// regression from the tool_choice normalization: a present-but-malformed
+// tool_choice (unknown string, or an Anthropic object with an unknown type)
+// must NOT be treated the same as a truly absent tool_choice. On Gemini 3.x,
+// absent/auto upgrades to mode=VALIDATED; a malformed value must fall back to
+// legacy no-toolConfig behavior instead of silently getting that upgrade.
+func TestPrepareGemini_UnrecognizedToolChoiceDoesNotEnableValidatedMode(t *testing.T) {
+	tools := `"tools":[{"name":"bash","description":"b","input_schema":{"type":"object"}}]`
+
+	t.Run("openai_source_unknown_string", func(t *testing.T) {
+		body := []byte(`{"messages":[{"role":"user","content":"x"}],` + tools + `,"tool_choice":"bogus"}`)
+		env, err := translate.ParseOpenAI(body)
+		require.NoError(t, err)
+		prep, err := env.PrepareGemini(http.Header{}, translate.EmitOptions{TargetModel: "gemini-3.1-pro-preview"})
+		require.NoError(t, err)
+		out := mustUnmarshal(t, prep.Body)
+		_, hasToolConfig := out["toolConfig"]
+		assert.False(t, hasToolConfig, "malformed tool_choice must not trigger VALIDATED mode")
+	})
+
+	t.Run("anthropic_source_unknown_type", func(t *testing.T) {
+		body := []byte(`{"messages":[{"role":"user","content":"x"}],` + tools + `,"tool_choice":{"type":"bogus"}}`)
+		env, err := translate.ParseAnthropic(body)
+		require.NoError(t, err)
+		prep, err := env.PrepareGemini(http.Header{}, translate.EmitOptions{TargetModel: "gemini-3.1-pro-preview"})
+		require.NoError(t, err)
+		out := mustUnmarshal(t, prep.Body)
+		_, hasToolConfig := out["toolConfig"]
+		assert.False(t, hasToolConfig, "malformed tool_choice must not trigger VALIDATED mode")
+	})
+}
+
 func TestPrepareGemini_ReasoningEffortMapsToThinkingBudget(t *testing.T) {
 	// No target model => legacy (gemini-2.5) path: numeric thinkingBudget.
 	cases := map[string]int{"low": 1024, "medium": 8192, "high": 24576, "none": 0}

--- a/internal/translate/gemini_test.go
+++ b/internal/translate/gemini_test.go
@@ -146,6 +146,24 @@ func TestPrepareGemini_ToolChoiceVariants(t *testing.T) {
 	}
 }
 
+func TestPrepareGemini_FromAnthropic_ToolChoiceVariants(t *testing.T) {
+	cases := map[string]string{
+		`"tool_choice":{"type":"auto"}`:               "AUTO",
+		`"tool_choice":{"type":"none"}`:               "NONE",
+		`"tool_choice":{"type":"any"}`:                "ANY",
+		`"tool_choice":{"type":"tool","name":"bash"}`: "ANY",
+	}
+	for tc, mode := range cases {
+		body := []byte(`{"messages":[{"role":"user","content":"x"}],` + tc + `}`)
+		env, _ := translate.ParseAnthropic(body)
+		prep, err := env.PrepareGemini(http.Header{}, translate.EmitOptions{})
+		require.NoError(t, err, tc)
+		out := mustUnmarshal(t, prep.Body)
+		got := out["toolConfig"].(map[string]any)["functionCallingConfig"].(map[string]any)["mode"]
+		assert.Equal(t, mode, got, tc)
+	}
+}
+
 func TestPrepareGemini_ReasoningEffortMapsToThinkingBudget(t *testing.T) {
 	// No target model => legacy (gemini-2.5) path: numeric thinkingBudget.
 	cases := map[string]int{"low": 1024, "medium": 8192, "high": 24576, "none": 0}

--- a/internal/translate/responses_outbound_test.go
+++ b/internal/translate/responses_outbound_test.go
@@ -125,6 +125,41 @@ func TestPrepareOpenAIResponses_RequestShape(t *testing.T) {
 	assert.Equal(t, providers.EndpointResponses, prep.Endpoint)
 }
 
+// TestPrepareOpenAIResponses_ToolChoiceVariants covers the Anthropic ->
+// Responses tool_choice mapping for "any" and named-tool; "auto" is covered
+// by TestPrepareOpenAIResponses_RequestShape.
+func TestPrepareOpenAIResponses_ToolChoiceVariants(t *testing.T) {
+	cases := []struct {
+		name       string
+		toolChoice string
+		want       any
+	}{
+		{"any", `{"type":"any"}`, "required"},
+		{"tool", `{"type":"tool","name":"bash"}`, map[string]any{"type": "function", "name": "bash"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			body := []byte(`{
+				"model":"claude-opus-4-8","max_tokens":4096,
+				"tools":[{"name":"bash","input_schema":{"type":"object"}}],
+				"tool_choice":` + tc.toolChoice + `,
+				"messages":[{"role":"user","content":"fix the bug"}]
+			}`)
+			env, err := translate.ParseAnthropic(body)
+			require.NoError(t, err)
+			prep, err := env.PrepareOpenAIResponses(http.Header{}, translate.EmitOptions{
+				TargetModel:  "gpt-5.5",
+				Capabilities: router.Lookup("gpt-5.5"),
+			})
+			require.NoError(t, err)
+
+			var out map[string]any
+			require.NoError(t, json.Unmarshal(prep.Body, &out))
+			assert.Equal(t, tc.want, out["tool_choice"])
+		})
+	}
+}
+
 // A tiny client max_tokens (Claude Code sends 1 for a probe, 64 for a
 // title/topic turn) must be floored to the reasoning output budget: a reasoning
 // model burns the budget on hidden reasoning before any visible token, so the

--- a/internal/translate/tool_choice.go
+++ b/internal/translate/tool_choice.go
@@ -7,9 +7,10 @@ import "github.com/tidwall/gjson"
 type toolChoiceKind int
 
 const (
-	// toolChoiceAbsent covers a missing tool_choice as well as any shape this
-	// package doesn't recognize (unknown string, malformed object, empty
-	// named-tool name) — all of which every renderer treats as a no-op.
+	// toolChoiceAbsent means the tool_choice key is not present at all.
+	// Distinct from toolChoiceUnrecognized: Gemini 3.x treats true absence
+	// (and explicit auto) as "unforced" and upgrades to VALIDATED mode; a
+	// present-but-malformed value must not get the same upgrade.
 	toolChoiceAbsent toolChoiceKind = iota
 	toolChoiceAuto
 	// toolChoiceRequired is Anthropic's "any" / OpenAI's "required".
@@ -18,14 +19,22 @@ const (
 	// toolChoiceNamed pins a single tool by name (Anthropic's {"type":"tool"},
 	// OpenAI's {"type":"function"}); the name is returned alongside the kind.
 	toolChoiceNamed
+	// toolChoiceUnrecognized is a present tool_choice this package can't parse
+	// (unknown string/type, malformed object, empty named-tool name). Every
+	// renderer treats it as a no-op, same as toolChoiceAbsent, except the
+	// Gemini VALIDATED-mode gate, which must not treat it as unforced.
+	toolChoiceUnrecognized
 )
 
 // anthropicToolChoice parses an Anthropic-shape tool_choice field
 // ({"type":"auto"|"any"|"none"|"tool","name":"..."}) into a neutral kind.
 func anthropicToolChoice(body []byte) (toolChoiceKind, string) {
 	r := gjson.GetBytes(body, "tool_choice")
-	if !r.Exists() || !r.IsObject() {
+	if !r.Exists() {
 		return toolChoiceAbsent, ""
+	}
+	if !r.IsObject() {
+		return toolChoiceUnrecognized, ""
 	}
 	switch r.Get("type").String() {
 	case "auto":
@@ -37,11 +46,11 @@ func anthropicToolChoice(body []byte) (toolChoiceKind, string) {
 	case "tool":
 		name := r.Get("name")
 		if name.Type != gjson.String || name.String() == "" {
-			return toolChoiceAbsent, ""
+			return toolChoiceUnrecognized, ""
 		}
 		return toolChoiceNamed, name.String()
 	default:
-		return toolChoiceAbsent, ""
+		return toolChoiceUnrecognized, ""
 	}
 }
 
@@ -60,15 +69,15 @@ func openAIToolChoice(body []byte) (toolChoiceKind, string) {
 		case "none":
 			return toolChoiceNone, ""
 		default:
-			return toolChoiceAbsent, ""
+			return toolChoiceUnrecognized, ""
 		}
 	}
 	if r.IsObject() && r.Get("type").String() == "function" {
 		name := r.Get("function.name")
 		if name.Type != gjson.String || name.String() == "" {
-			return toolChoiceAbsent, ""
+			return toolChoiceUnrecognized, ""
 		}
 		return toolChoiceNamed, name.String()
 	}
-	return toolChoiceAbsent, ""
+	return toolChoiceUnrecognized, ""
 }

--- a/internal/translate/tool_choice.go
+++ b/internal/translate/tool_choice.go
@@ -2,9 +2,8 @@ package translate
 
 import "github.com/tidwall/gjson"
 
-// toolChoiceKind is the source-format-neutral shape of an inbound tool_choice
-// value, decoupling the four `emit_*.go` renderers from the two inbound wire
-// shapes (Anthropic object vs. OpenAI string-or-object).
+// toolChoiceKind is the source-format-neutral tool_choice value shared by
+// the four emit_*.go renderers.
 type toolChoiceKind int
 
 const (
@@ -46,9 +45,7 @@ func anthropicToolChoice(body []byte) (toolChoiceKind, string) {
 	}
 }
 
-// openAIToolChoice parses an OpenAI-shape tool_choice field (the string
-// "auto"|"required"|"none", or {"type":"function","function":{"name":...}})
-// into a neutral kind.
+// openAIToolChoice parses an OpenAI-shape tool_choice field into a neutral kind.
 func openAIToolChoice(body []byte) (toolChoiceKind, string) {
 	r := gjson.GetBytes(body, "tool_choice")
 	if !r.Exists() {

--- a/internal/translate/tool_choice.go
+++ b/internal/translate/tool_choice.go
@@ -1,0 +1,77 @@
+package translate
+
+import "github.com/tidwall/gjson"
+
+// toolChoiceKind is the source-format-neutral shape of an inbound tool_choice
+// value, decoupling the four `emit_*.go` renderers from the two inbound wire
+// shapes (Anthropic object vs. OpenAI string-or-object).
+type toolChoiceKind int
+
+const (
+	// toolChoiceAbsent covers a missing tool_choice as well as any shape this
+	// package doesn't recognize (unknown string, malformed object, empty
+	// named-tool name) — all of which every renderer treats as a no-op.
+	toolChoiceAbsent toolChoiceKind = iota
+	toolChoiceAuto
+	// toolChoiceRequired is Anthropic's "any" / OpenAI's "required".
+	toolChoiceRequired
+	toolChoiceNone
+	// toolChoiceNamed pins a single tool by name (Anthropic's {"type":"tool"},
+	// OpenAI's {"type":"function"}); the name is returned alongside the kind.
+	toolChoiceNamed
+)
+
+// anthropicToolChoice parses an Anthropic-shape tool_choice field
+// ({"type":"auto"|"any"|"none"|"tool","name":"..."}) into a neutral kind.
+func anthropicToolChoice(body []byte) (toolChoiceKind, string) {
+	r := gjson.GetBytes(body, "tool_choice")
+	if !r.Exists() || !r.IsObject() {
+		return toolChoiceAbsent, ""
+	}
+	switch r.Get("type").String() {
+	case "auto":
+		return toolChoiceAuto, ""
+	case "any":
+		return toolChoiceRequired, ""
+	case "none":
+		return toolChoiceNone, ""
+	case "tool":
+		name := r.Get("name")
+		if name.Type != gjson.String || name.String() == "" {
+			return toolChoiceAbsent, ""
+		}
+		return toolChoiceNamed, name.String()
+	default:
+		return toolChoiceAbsent, ""
+	}
+}
+
+// openAIToolChoice parses an OpenAI-shape tool_choice field (the string
+// "auto"|"required"|"none", or {"type":"function","function":{"name":...}})
+// into a neutral kind.
+func openAIToolChoice(body []byte) (toolChoiceKind, string) {
+	r := gjson.GetBytes(body, "tool_choice")
+	if !r.Exists() {
+		return toolChoiceAbsent, ""
+	}
+	if r.Type == gjson.String {
+		switch r.String() {
+		case "auto":
+			return toolChoiceAuto, ""
+		case "required":
+			return toolChoiceRequired, ""
+		case "none":
+			return toolChoiceNone, ""
+		default:
+			return toolChoiceAbsent, ""
+		}
+	}
+	if r.IsObject() && r.Get("type").String() == "function" {
+		name := r.Get("function.name")
+		if name.Type != gjson.String || name.String() == "" {
+			return toolChoiceAbsent, ""
+		}
+		return toolChoiceNamed, name.String()
+	}
+	return toolChoiceAbsent, ""
+}


### PR DESCRIPTION
## Summary

Fixes finding [2]: the `tool_choice` mapping (auto / any-or-required / none / named-tool) was independently reimplemented five times across the emit paths — differing only in field names per target format, the exact "differs only in field names" duplication pattern this repo's CLAUDE.md calls out:

- `writeAnthropicToolChoice` (`emit_anthropic.go`) — OpenAI → Anthropic
- `writeOpenAIToolChoiceFromAnthropic` (`emit_openai.go`) — Anthropic → OpenAI chat-completions
- `writeResponsesToolChoiceFromAnthropic` (`emit_openai_responses.go`) — Anthropic → OpenAI Responses
- `writeGeminiToolChoiceFromOpenAI` / `writeGeminiToolChoiceFromAnthropic` (`emit_gemini.go`) — OpenAI/Anthropic → Gemini
- plus a sixth, semi-duplicate gate in `geminiEmitsValidatedToolMode`, which re-derived the same "is this an unforced/auto choice" check to predict the Gemini VALIDATED-mode gate without re-running the emitter.

## Changes

- New `internal/translate/tool_choice.go`: a source-format-neutral `toolChoiceKind` enum (`Absent`/`Auto`/`Required`/`None`/`Named`) plus two pure parsers — `anthropicToolChoice(body)` for the Anthropic object shape (`{"type":"auto"|"any"|"none"|"tool","name":...}`) and `openAIToolChoice(body)` for the OpenAI shape (string `"auto"|"required"|"none"`, or `{"type":"function","function":{"name":...}}`).
- Each of the four target-format writers now calls the parser for its source format and switches on the neutral `toolChoiceKind`, owning only its own serialization (Anthropic `tool_choice` object, OpenAI string-or-object, Responses string-or-object, Gemini `toolConfig.functionCallingConfig`).
- `emit_gemini.go` additionally gets a small `writeGeminiToolChoice`/`writeGeminiFunctionCallingMode` pair shared between both Gemini source paths, replacing the duplicated `toolConfig` JSON-writing boilerplate (mode-only vs. mode+`allowedFunctionNames`).
- `geminiEmitsValidatedToolMode` now calls the same two parsers instead of re-deriving the "unforced" check per format.
- The `emit_anthropic.go` `tool_choice=="none"` suppression check now also goes through `openAIToolChoice` instead of a bare `gjson` string comparison.

## Behavior notes

- All 20 existing tool_choice-related tests pass unchanged.
- One minor, deliberate tightening: named-tool choices with a non-string `name` field are now uniformly treated as absent (no-op) across all four targets. Previously only the OpenAI chat-completions emitter guarded against a non-string `name`; the other three didn't check the type and would silently coerce. This only affects malformed client input (a non-string `name`), not any well-formed request.
- Anthropic's `"none"` still has no direct OpenAI chat-completions or Responses equivalent and is intentionally left unmapped (no `tool_choice` key emitted), matching prior behavior.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .` (clean)
- [x] `go test ./...` (all packages pass)
- [x] Added table-driven coverage for all 4 modes (auto/required-or-any/none/named) across the format pairs that were undertested: OpenAI→Anthropic, Anthropic→OpenAI chat-completions, Anthropic→Responses, Anthropic→Gemini (Gemini from OpenAI was already covered).

Fix finding [2] from the internal/translate duplication sweep.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>