### PR TITLE
refactor: consolidate duplicated adapter transport helpers into httputil

### DIFF
--- a/internal/providers/anthropic/client.go
+++ b/internal/providers/anthropic/client.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 	"time"
 
-	"workweave/router/internal/observability"
 	"workweave/router/internal/providers"
 	"workweave/router/internal/providers/httputil"
 	"workweave/router/internal/proxy"
@@ -190,22 +189,22 @@ func (c *Client) Proxy(ctx context.Context, decision router.Decision, prep provi
 	providers.ObserveUpstreamHeaders(ctx, resp.Header)
 
 	if resp.StatusCode >= 400 {
-		bufBody, totalRead, drainErr := readCapped(resp.Body, providers.MaxBufferedErrorBytes)
+		bufBody, totalRead, drainErr := httputil.ReadCapped(resp.Body, providers.MaxBufferedErrorBytes)
 		if len(bufBody) > 0 {
 			t.StampUpstreamFirstByte()
 		}
 		if drainErr == nil {
 			t.StampUpstreamEOF()
 		}
-		logUpstreamStatus(
+		httputil.LogUpstreamStatus(
 			"Upstream Anthropic returned error status",
 			resp.StatusCode,
 			"routed_model", decision.Model,
-			"body_preview", previewBytes(bufBody),
+			"body_preview", httputil.PreviewBytes(bufBody),
 			"body_total_bytes", totalRead,
 		)
 		errHeaders := http.Header{}
-		providers.CopyUpstreamHeaders(headerCapture{errHeaders}, resp)
+		providers.CopyUpstreamHeaders(httputil.HeaderCapture{H: errHeaders}, resp)
 		return &providers.UpstreamErrorResponse{
 			Status:  resp.StatusCode,
 			Headers: errHeaders,
@@ -270,62 +269,10 @@ func (c *Client) Passthrough(ctx context.Context, prep providers.PreparedRequest
 	providers.CopyUpstreamHeaders(w, resp)
 	w.WriteHeader(resp.StatusCode)
 	if resp.StatusCode >= 400 {
-		var snip [1024]byte
-		n, _ := io.ReadFull(resp.Body, snip[:])
-		_, snipWriteErr := w.Write(snip[:n])
-		rest, copyErr := io.Copy(w, resp.Body)
-		logUpstreamStatus(
-			"Upstream Anthropic returned error status (passthrough)",
-			resp.StatusCode,
-			"path", r.URL.Path,
-			"body_preview", string(snip[:n]),
-			"body_total_bytes", int64(n)+rest,
-		)
-		if snipWriteErr != nil {
-			return snipWriteErr
-		}
-		if copyErr != nil {
-			return copyErr
-		}
-		return &providers.UpstreamStatusError{Status: resp.StatusCode}
+		return httputil.WritePassthroughError(w, resp, nil, nil, "Upstream Anthropic returned error status (passthrough)", "path", r.URL.Path)
 	}
 	_, err = io.Copy(w, resp.Body)
 	return err
 }
-
-func logUpstreamStatus(msg string, status int, attrs ...any) {
-	merged := append([]any{"status", status}, attrs...)
-	if status >= 500 || (status >= 400 && status != http.StatusTooManyRequests) {
-		observability.Get().Error(msg, merged...)
-		return
-	}
-	observability.Get().Warn(msg, merged...)
-}
-
-func readCapped(r io.Reader, limit int) ([]byte, int64, error) {
-	prefix, err := io.ReadAll(io.LimitReader(r, int64(limit)))
-	totalRead := int64(len(prefix))
-	if err != nil {
-		return prefix, totalRead, err
-	}
-	const maxDrain = 1 << 20 // 1 MiB
-	rest, drainErr := io.Copy(io.Discard, io.LimitReader(r, maxDrain))
-	totalRead += rest
-	return prefix, totalRead, drainErr
-}
-
-func previewBytes(body []byte) string {
-	const previewLimit = 1024
-	if len(body) > previewLimit {
-		return string(body[:previewLimit])
-	}
-	return string(body)
-}
-
-type headerCapture struct{ h http.Header }
-
-func (c headerCapture) Header() http.Header       { return c.h }
-func (c headerCapture) Write([]byte) (int, error) { return 0, nil }
-func (c headerCapture) WriteHeader(int)           {}
 
 var _ providers.Client = (*Client)(nil)

--- a/internal/providers/google/native_client.go
+++ b/internal/providers/google/native_client.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 	"time"
 
-	"workweave/router/internal/observability"
 	"workweave/router/internal/providers"
 	"workweave/router/internal/providers/httputil"
 	"workweave/router/internal/proxy"
@@ -121,31 +120,8 @@ func (c *NativeClient) Proxy(ctx context.Context, decision router.Decision, prep
 	w.WriteHeader(resp.StatusCode)
 
 	if resp.StatusCode >= 400 {
-		var snip [1024]byte
-		n, _ := io.ReadFull(resp.Body, snip[:])
-		if n > 0 {
-			t.StampUpstreamFirstByte()
-		}
-		_, snipWriteErr := w.Write(snip[:n])
-		rest, copyErr := io.Copy(w, resp.Body)
-		if copyErr == nil {
-			t.StampUpstreamEOF()
-		}
-		logUpstreamStatus(
-			"Upstream Google returned error status",
-			resp.StatusCode,
-			"routed_model", decision.Model,
-			"streaming", stream,
-			"body_preview", string(snip[:n]),
-			"body_total_bytes", int64(n)+rest,
-		)
-		if snipWriteErr != nil {
-			return snipWriteErr
-		}
-		if copyErr != nil {
-			return copyErr
-		}
-		return &providers.UpstreamStatusError{Status: resp.StatusCode}
+		return httputil.WritePassthroughError(w, resp, t.StampUpstreamFirstByte, t.StampUpstreamEOF,
+			"Upstream Google returned error status", "routed_model", decision.Model, "streaming", stream)
 	}
 
 	// Output-progress watchdog: StreamBody's byte-idle watchdog resets on ANY
@@ -207,37 +183,10 @@ func (c *NativeClient) Passthrough(ctx context.Context, prep providers.PreparedR
 	providers.CopyUpstreamHeaders(w, resp)
 	w.WriteHeader(resp.StatusCode)
 	if resp.StatusCode >= 400 {
-		var snip [1024]byte
-		n, _ := io.ReadFull(resp.Body, snip[:])
-		_, snipWriteErr := w.Write(snip[:n])
-		rest, copyErr := io.Copy(w, resp.Body)
-		logUpstreamStatus(
-			"Upstream Google returned error status (passthrough)",
-			resp.StatusCode,
-			"path", r.URL.Path,
-			"body_preview", string(snip[:n]),
-			"body_total_bytes", int64(n)+rest,
-		)
-		if snipWriteErr != nil {
-			return snipWriteErr
-		}
-		if copyErr != nil {
-			return copyErr
-		}
-		return &providers.UpstreamStatusError{Status: resp.StatusCode}
+		return httputil.WritePassthroughError(w, resp, nil, nil, "Upstream Google returned error status (passthrough)", "path", r.URL.Path)
 	}
 	_, err = io.Copy(w, resp.Body)
 	return err
-}
-
-// logUpstreamStatus logs non-2xx upstream responses with a body preview.
-func logUpstreamStatus(msg string, status int, attrs ...any) {
-	merged := append([]any{"status", status}, attrs...)
-	if status >= 500 || (status >= 400 && status != http.StatusTooManyRequests) {
-		observability.Get().Error(msg, merged...)
-		return
-	}
-	observability.Get().Warn(msg, merged...)
 }
 
 // applyAPIKey sets x-goog-api-key, preferring BYOK credentials over the deployment-level key.

--- a/internal/providers/httputil/errors.go
+++ b/internal/providers/httputil/errors.go
@@ -1,0 +1,85 @@
+package httputil
+
+import (
+	"io"
+	"net/http"
+
+	"workweave/router/internal/observability"
+	"workweave/router/internal/providers"
+)
+
+// ReadCapped buffers up to limit bytes from r, then drains (without retaining)
+// up to maxDrain more to bound failover latency on a large error body. Returns
+// the buffered prefix, total bytes read, and any read error (io.EOF -> nil).
+func ReadCapped(r io.Reader, limit int) ([]byte, int64, error) {
+	prefix, err := io.ReadAll(io.LimitReader(r, int64(limit)))
+	totalRead := int64(len(prefix))
+	if err != nil {
+		return prefix, totalRead, err
+	}
+	const maxDrain = 1 << 20 // 1 MiB
+	rest, drainErr := io.Copy(io.Discard, io.LimitReader(r, maxDrain))
+	totalRead += rest
+	return prefix, totalRead, drainErr
+}
+
+// PreviewBytes returns the first 1KB of body as a string for logging.
+func PreviewBytes(body []byte) string {
+	const previewLimit = 1024
+	if len(body) > previewLimit {
+		return string(body[:previewLimit])
+	}
+	return string(body)
+}
+
+// HeaderCapture is a minimal http.ResponseWriter that captures headers only,
+// used to reuse providers.CopyUpstreamHeaders against an http.Header we own.
+// Write/WriteHeader are no-ops.
+type HeaderCapture struct{ H http.Header }
+
+// Header returns the captured header set.
+func (c HeaderCapture) Header() http.Header { return c.H }
+
+// Write is a no-op; HeaderCapture only captures headers.
+func (c HeaderCapture) Write([]byte) (int, error) { return 0, nil }
+
+// WriteHeader is a no-op; HeaderCapture only captures headers.
+func (c HeaderCapture) WriteHeader(int) {}
+
+// LogUpstreamStatus logs non-2xx upstream responses with a body preview, at
+// ERROR except 429 (routine rate-limit signal handled via failover), which
+// logs at WARN.
+func LogUpstreamStatus(msg string, status int, attrs ...any) {
+	merged := append([]any{"status", status}, attrs...)
+	if status >= 500 || (status >= 400 && status != http.StatusTooManyRequests) {
+		observability.Get().Error(msg, merged...)
+		return
+	}
+	observability.Get().Warn(msg, merged...)
+}
+
+// WritePassthroughError streams up to 1KB of resp.Body to w, logs via
+// LogUpstreamStatus (body_preview/body_total_bytes appended automatically),
+// and returns UpstreamStatusError. onFirstByte/onEOF are nil-safe OTel
+// timing hooks; pass nil, nil on paths that don't stamp upstream timing.
+func WritePassthroughError(w http.ResponseWriter, resp *http.Response, onFirstByte, onEOF func(), msg string, attrs ...any) error {
+	var snip [1024]byte
+	n, _ := io.ReadFull(resp.Body, snip[:])
+	if n > 0 && onFirstByte != nil {
+		onFirstByte()
+	}
+	_, snipWriteErr := w.Write(snip[:n])
+	rest, copyErr := io.Copy(w, resp.Body)
+	if copyErr == nil && onEOF != nil {
+		onEOF()
+	}
+	merged := append(append([]any{}, attrs...), "body_preview", string(snip[:n]), "body_total_bytes", int64(n)+rest)
+	LogUpstreamStatus(msg, resp.StatusCode, merged...)
+	if snipWriteErr != nil {
+		return snipWriteErr
+	}
+	if copyErr != nil {
+		return copyErr
+	}
+	return &providers.UpstreamStatusError{Status: resp.StatusCode}
+}

--- a/internal/providers/httputil/errors_test.go
+++ b/internal/providers/httputil/errors_test.go
@@ -1,0 +1,72 @@
+package httputil
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"workweave/router/internal/providers"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReadCapped_TruncatesAndDrainsRest(t *testing.T) {
+	body := strings.Repeat("a", 10) + strings.Repeat("b", 10)
+	prefix, total, err := ReadCapped(strings.NewReader(body), 10)
+	require.NoError(t, err)
+	assert.Equal(t, strings.Repeat("a", 10), string(prefix))
+	assert.EqualValues(t, 20, total)
+}
+
+func TestPreviewBytes_CapsAt1KB(t *testing.T) {
+	body := []byte(strings.Repeat("x", 2000))
+	preview := PreviewBytes(body)
+	assert.Len(t, preview, 1024)
+
+	small := []byte("short body")
+	assert.Equal(t, "short body", PreviewBytes(small))
+}
+
+func TestHeaderCapture_CapturesHeaderWithoutWriting(t *testing.T) {
+	h := http.Header{}
+	hc := HeaderCapture{H: h}
+	hc.Header().Set("X-Test", "value")
+	n, err := hc.Write([]byte("ignored"))
+	require.NoError(t, err)
+	assert.Equal(t, 0, n)
+	assert.Equal(t, "value", h.Get("X-Test"))
+}
+
+func TestWritePassthroughError_WritesBodyLogsAndReturnsStatusError(t *testing.T) {
+	upstreamBody := "upstream failure detail"
+	resp := &http.Response{
+		StatusCode: http.StatusBadGateway,
+		Body:       http.NoBody,
+	}
+	resp.Body = io.NopCloser(strings.NewReader(upstreamBody))
+
+	rec := httptest.NewRecorder()
+	var firstByteCalls, eofCalls int
+	err := WritePassthroughError(rec, resp, func() { firstByteCalls++ }, func() { eofCalls++ }, "upstream failed", "path", "/v1/messages")
+
+	var statusErr *providers.UpstreamStatusError
+	require.ErrorAs(t, err, &statusErr)
+	assert.Equal(t, http.StatusBadGateway, statusErr.Status)
+	assert.Equal(t, upstreamBody, rec.Body.String())
+	assert.Equal(t, 1, firstByteCalls)
+	assert.Equal(t, 1, eofCalls)
+}
+
+func TestWritePassthroughError_NilHooksAreSafe(t *testing.T) {
+	resp := &http.Response{
+		StatusCode: http.StatusInternalServerError,
+		Body:       io.NopCloser(strings.NewReader("boom")),
+	}
+	rec := httptest.NewRecorder()
+	err := WritePassthroughError(rec, resp, nil, nil, "upstream failed")
+	require.Error(t, err)
+	assert.Equal(t, "boom", rec.Body.String())
+}

--- a/internal/providers/openai/client.go
+++ b/internal/providers/openai/client.go
@@ -235,7 +235,7 @@ func (c *Client) Proxy(ctx context.Context, decision router.Decision, prep provi
 		// headers then stalls the body (header timeout no longer applies).
 		mark, stop := httputil.StartIdleWatchdog(ctx, cancel, idleTimeout)
 		body := &progressReader{r: resp.Body, mark: mark}
-		bufBody, totalRead, drainErr := readCapped(body, providers.MaxBufferedErrorBytes)
+		bufBody, totalRead, drainErr := httputil.ReadCapped(body, providers.MaxBufferedErrorBytes)
 		stop()
 		if errors.Is(context.Cause(ctx), httputil.ErrUpstreamIdleTimeout) {
 			logStreamStall(decision.Model, path, idleTimeout, totalRead, httputil.ErrUpstreamIdleTimeout)
@@ -246,16 +246,16 @@ func (c *Client) Proxy(ctx context.Context, decision router.Decision, prep provi
 		if drainErr == nil {
 			t.StampUpstreamEOF()
 		}
-		logUpstreamStatus(
+		httputil.LogUpstreamStatus(
 			"Upstream OpenAI returned error status",
 			resp.StatusCode,
 			"base_url", c.baseURL,
 			"routed_model", decision.Model,
-			"body_preview", previewBytes(bufBody),
+			"body_preview", httputil.PreviewBytes(bufBody),
 			"body_total_bytes", totalRead,
 		)
 		errHeaders := http.Header{}
-		providers.CopyUpstreamHeaders(headerCapture{errHeaders}, resp)
+		providers.CopyUpstreamHeaders(httputil.HeaderCapture{H: errHeaders}, resp)
 		return &providers.UpstreamErrorResponse{
 			Status:  resp.StatusCode,
 			Headers: errHeaders,
@@ -419,70 +419,10 @@ func (c *Client) Passthrough(ctx context.Context, prep providers.PreparedRequest
 	providers.CopyUpstreamHeaders(w, resp)
 	w.WriteHeader(resp.StatusCode)
 	if resp.StatusCode >= 400 {
-		var snip [1024]byte
-		n, _ := io.ReadFull(resp.Body, snip[:])
-		_, snipWriteErr := w.Write(snip[:n])
-		rest, copyErr := io.Copy(w, resp.Body)
-		logUpstreamStatus(
-			"Upstream OpenAI returned error status (passthrough)",
-			resp.StatusCode,
-			"base_url", c.baseURL,
-			"path", r.URL.Path,
-			"body_preview", string(snip[:n]),
-			"body_total_bytes", int64(n)+rest,
-		)
-		if snipWriteErr != nil {
-			return snipWriteErr
-		}
-		if copyErr != nil {
-			return copyErr
-		}
-		return &providers.UpstreamStatusError{Status: resp.StatusCode}
+		return httputil.WritePassthroughError(w, resp, nil, nil, "Upstream OpenAI returned error status (passthrough)", "base_url", c.baseURL, "path", r.URL.Path)
 	}
 	_, err = io.Copy(w, resp.Body)
 	return err
-}
-
-// readCapped reads up to limit bytes into a buffer, then drains the rest
-// (up to maxDrain, discarded) to bound failover latency on a large error body.
-func readCapped(r io.Reader, limit int) ([]byte, int64, error) {
-	prefix, err := io.ReadAll(io.LimitReader(r, int64(limit)))
-	totalRead := int64(len(prefix))
-	if err != nil {
-		return prefix, totalRead, err
-	}
-	const maxDrain = 1 << 20 // 1 MiB
-	rest, drainErr := io.Copy(io.Discard, io.LimitReader(r, maxDrain))
-	totalRead += rest
-	return prefix, totalRead, drainErr
-}
-
-// previewBytes returns the first 1KB of body as a string for logging.
-func previewBytes(body []byte) string {
-	const previewLimit = 1024
-	if len(body) > previewLimit {
-		return string(body[:previewLimit])
-	}
-	return string(body)
-}
-
-// headerCapture is a minimal http.ResponseWriter used to reuse
-// providers.CopyUpstreamHeaders against an http.Header we own.
-type headerCapture struct{ h http.Header }
-
-func (c headerCapture) Header() http.Header       { return c.h }
-func (c headerCapture) Write([]byte) (int, error) { return 0, nil }
-func (c headerCapture) WriteHeader(int)           {}
-
-// logUpstreamStatus logs non-2xx responses at ERROR, except 429 (routine
-// rate-limit signal handled via failover), logged at WARN.
-func logUpstreamStatus(msg string, status int, attrs ...any) {
-	merged := append([]any{"status", status}, attrs...)
-	if status >= 500 || (status >= 400 && status != http.StatusTooManyRequests) {
-		observability.Get().Error(msg, merged...)
-		return
-	}
-	observability.Get().Warn(msg, merged...)
 }
 
 var _ providers.Client = (*Client)(nil)

--- a/internal/providers/openaicompat/client.go
+++ b/internal/providers/openaicompat/client.go
@@ -204,23 +204,23 @@ func (c *Client) Proxy(ctx context.Context, decision router.Decision, prep provi
 	if resp.StatusCode >= 400 {
 		// Buffer the error — do NOT touch w; the failover loop decides whether
 		// to retry or flush this buffer to the client.
-		bufBody, totalRead, drainErr := readCapped(resp.Body, providers.MaxBufferedErrorBytes)
+		bufBody, totalRead, drainErr := httputil.ReadCapped(resp.Body, providers.MaxBufferedErrorBytes)
 		if len(bufBody) > 0 {
 			t.StampUpstreamFirstByte()
 		}
 		if drainErr == nil {
 			t.StampUpstreamEOF()
 		}
-		logUpstreamStatus(
+		httputil.LogUpstreamStatus(
 			"Upstream OpenAI-compatible provider returned error status",
 			resp.StatusCode,
 			"base_url", c.baseURL,
 			"routed_model", decision.Model,
-			"body_preview", previewBytes(bufBody),
+			"body_preview", httputil.PreviewBytes(bufBody),
 			"body_total_bytes", totalRead,
 		)
 		errHeaders := http.Header{}
-		providers.CopyUpstreamHeaders(headerCapture{errHeaders}, resp)
+		providers.CopyUpstreamHeaders(httputil.HeaderCapture{H: errHeaders}, resp)
 		return &providers.UpstreamErrorResponse{
 			Status:  resp.StatusCode,
 			Headers: errHeaders,
@@ -284,39 +284,6 @@ func logStreamStall(model, baseURL string, cause error) {
 	)
 }
 
-// readCapped buffers up to limit bytes from r, then drains (without retaining)
-// up to maxDrain more to bound failover latency on a large error body. Returns
-// the buffered prefix, total bytes read, and any read error (io.EOF -> nil).
-func readCapped(r io.Reader, limit int) ([]byte, int64, error) {
-	prefix, err := io.ReadAll(io.LimitReader(r, int64(limit)))
-	totalRead := int64(len(prefix))
-	if err != nil {
-		return prefix, totalRead, err
-	}
-	const maxDrain = 1 << 20 // 1 MiB
-	rest, drainErr := io.Copy(io.Discard, io.LimitReader(r, maxDrain))
-	totalRead += rest
-	return prefix, totalRead, drainErr
-}
-
-// previewBytes returns the first 1KB of body as a string for logging.
-func previewBytes(body []byte) string {
-	const previewLimit = 1024
-	if len(body) > previewLimit {
-		return string(body[:previewLimit])
-	}
-	return string(body)
-}
-
-// headerCapture is a minimal http.ResponseWriter that captures headers
-// only, used to reuse providers.CopyUpstreamHeaders against an http.Header
-// we own. Write/WriteHeader are no-ops.
-type headerCapture struct{ h http.Header }
-
-func (c headerCapture) Header() http.Header       { return c.h }
-func (c headerCapture) Write([]byte) (int, error) { return 0, nil }
-func (c headerCapture) WriteHeader(int)           {}
-
 // Passthrough strips the inbound /v1 prefix to avoid double-prefixing with the configured baseURL.
 func (c *Client) Passthrough(ctx context.Context, prep providers.PreparedRequest, w http.ResponseWriter, r *http.Request) error {
 	suffix := strings.TrimPrefix(r.URL.Path, "/v1")
@@ -349,38 +316,10 @@ func (c *Client) Passthrough(ctx context.Context, prep providers.PreparedRequest
 	providers.CopyUpstreamHeaders(w, resp)
 	w.WriteHeader(resp.StatusCode)
 	if resp.StatusCode >= 400 {
-		var snip [1024]byte
-		n, _ := io.ReadFull(resp.Body, snip[:])
-		_, snipWriteErr := w.Write(snip[:n])
-		rest, copyErr := io.Copy(w, resp.Body)
-		logUpstreamStatus(
-			"Upstream OpenAI-compatible provider returned error status (passthrough)",
-			resp.StatusCode,
-			"base_url", c.baseURL,
-			"path", r.URL.Path,
-			"body_preview", string(snip[:n]),
-			"body_total_bytes", int64(n)+rest,
-		)
-		if snipWriteErr != nil {
-			return snipWriteErr
-		}
-		if copyErr != nil {
-			return copyErr
-		}
-		return &providers.UpstreamStatusError{Status: resp.StatusCode}
+		return httputil.WritePassthroughError(w, resp, nil, nil, "Upstream OpenAI-compatible provider returned error status (passthrough)", "base_url", c.baseURL, "path", r.URL.Path)
 	}
 	_, err = io.Copy(w, resp.Body)
 	return err
-}
-
-// logUpstreamStatus logs non-2xx upstream responses with a body preview.
-func logUpstreamStatus(msg string, status int, attrs ...any) {
-	merged := append([]any{"status", status}, attrs...)
-	if status >= 500 || (status >= 400 && status != http.StatusTooManyRequests) {
-		observability.Get().Error(msg, merged...)
-		return
-	}
-	observability.Get().Warn(msg, merged...)
 }
 
 var _ providers.Client = (*Client)(nil)


### PR DESCRIPTION
## Summary

- `readCapped`, `previewBytes`, and `headerCapture` were copy-pasted byte-for-byte across `internal/providers/anthropic`, `internal/providers/openai`, and `internal/providers/openaicompat`. Moved into `internal/providers/httputil` as `ReadCapped`, `PreviewBytes`, and `HeaderCapture` (exported `H http.Header` field so it can be constructed from outside the package), and deleted every duplicate.
- `logUpstreamStatus` plus the "buffer 1KB snippet + copy rest + log + return `UpstreamStatusError`" passthrough-error block were duplicated near-identically across all four adapter files (`anthropic`, `openai`, `openaicompat`, `google/native_client.go`). Added `httputil.LogUpstreamStatus` and `httputil.WritePassthroughError`, and deleted every duplicate.
- `WritePassthroughError` takes optional `onFirstByte`/`onEOF` hooks (nil-safe) because `google.NativeClient.Proxy`'s error path stamps OTel upstream timing (`t.StampUpstreamFirstByte`/`t.StampUpstreamEOF`) inline with the snippet read/copy — the only call site that does this. Every other call site (all three `Passthrough` methods plus `google.NativeClient.Passthrough`) passes `nil, nil`, preserving existing behavior exactly.
- Confirmed `google/client.go` (the OpenAI-compat-flavored Gemini client) has none of these helpers and doesn't need them — it doesn't buffer/log upstream errors at all, so it's correctly excluded from this dedup.
- Added `internal/providers/httputil/errors_test.go` covering the five new exported helpers.

Fixes [46], [47], [108].

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .` (clean)
- [x] `go test ./...` (all packages pass, including new httputil tests)