### PR TITLE
test: add coverage for pubsub, sse, and apm packages

### DIFF
--- a/internal/observability/apm/apm_test.go
+++ b/internal/observability/apm/apm_test.go
@@ -1,0 +1,61 @@
+package apm_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"workweave/router/internal/observability/apm"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// Init is guarded by a sync.Once, so only one of these tests can ever
+// observe the "never initialized" no-op path in a given process. We rely on
+// WV_APM_OTLP_ENDPOINT being unset in the test environment and run the
+// no-op-path assertions first in this file; go test executes tests within a
+// file in source order, and package-level state is process-wide.
+
+func TestInit_NoEndpointIsNoOp(t *testing.T) {
+	t.Setenv("WV_APM_OTLP_ENDPOINT", "")
+
+	assert.NotPanics(t, func() {
+		apm.Init()
+	}, "Init must not panic when WV_APM_OTLP_ENDPOINT is unset")
+}
+
+func TestShutdownWithContext_SafeWhenInitNeverCalled(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	assert.NotPanics(t, func() {
+		apm.ShutdownWithContext(ctx)
+	}, "ShutdownWithContext must be safe to call even if the SDK was never wired up")
+}
+
+func TestShutdown_IdempotentAcrossRepeatedCalls(t *testing.T) {
+	assert.NotPanics(t, func() {
+		apm.Shutdown()
+		apm.Shutdown()
+		apm.Shutdown()
+	}, "Shutdown must be safe to call repeatedly")
+}
+
+func TestShutdownWithContext_IdempotentAcrossRepeatedCalls(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	assert.NotPanics(t, func() {
+		apm.ShutdownWithContext(ctx)
+		apm.ShutdownWithContext(ctx)
+	}, "ShutdownWithContext must be safe to call repeatedly")
+}
+
+func TestMiddleware_ReturnsNonNilHandler(t *testing.T) {
+	// Middleware wraps otelgin regardless of whether Init has run; it should
+	// always return a usable gin.HandlerFunc, never nil, since callers wire
+	// it into the router unconditionally at startup.
+	handler := apm.Middleware()
+
+	assert.NotNil(t, handler)
+}

--- a/internal/pubsub/invalidation.go
+++ b/internal/pubsub/invalidation.go
@@ -27,14 +27,39 @@ const replicaSubscriptionTTL = 24 * time.Hour
 // Pub/Sub admin API can't hold up termination indefinitely.
 const subscriptionDeleteTimeout = 10 * time.Second
 
+// publisher is the narrow seam NotifyInstallationChanged needs from a GCP
+// Pub/Sub Publisher: publish installationID and synchronously wait for the
+// result. Abstracting it behind an interface (rather than the concrete
+// *gcppubsub.Publisher, whose Publish returns a SDK-internal PublishResult
+// future) lets tests exercise the guard/retry logic with an in-memory fake
+// instead of a real Pub/Sub connection.
+type publisher interface {
+	Publish(ctx context.Context, installationID string) error
+}
+
+// gcpPublisher adapts a real *gcppubsub.Publisher to the publisher interface.
+type gcpPublisher struct {
+	inner *gcppubsub.Publisher
+}
+
+func (p gcpPublisher) Publish(ctx context.Context, installationID string) error {
+	result := p.inner.Publish(ctx, &gcppubsub.Message{Data: []byte(installationID)})
+	_, err := result.Get(ctx)
+	return err
+}
+
 // InvalidationNotifier publishes installation invalidation events over GCP Pub/Sub.
 type InvalidationNotifier struct {
-	publisher *gcppubsub.Publisher
+	publisher publisher
+	stop      func()
 }
 
 // NewInvalidationNotifier constructs a notifier backed by the supplied Publisher.
-func NewInvalidationNotifier(publisher *gcppubsub.Publisher) *InvalidationNotifier {
-	return &InvalidationNotifier{publisher: publisher}
+func NewInvalidationNotifier(publisherClient *gcppubsub.Publisher) *InvalidationNotifier {
+	return &InvalidationNotifier{
+		publisher: gcpPublisher{inner: publisherClient},
+		stop:      publisherClient.Stop,
+	}
 }
 
 // NotifyInstallationChanged publishes installationID on the invalidation topic.
@@ -45,8 +70,7 @@ func (n *InvalidationNotifier) NotifyInstallationChanged(installationID string) 
 	}
 	log := observability.Get().With("installation_id", installationID)
 	observability.SafeGo(log, notifyTimeout, "NotifyInstallationChanged", func(ctx context.Context) {
-		result := n.publisher.Publish(ctx, &gcppubsub.Message{Data: []byte(installationID)})
-		if _, err := result.Get(ctx); err != nil {
+		if err := n.publisher.Publish(ctx, installationID); err != nil {
 			log.Warn("Failed to publish installation invalidation", "err", err)
 		}
 	})
@@ -55,13 +79,22 @@ func (n *InvalidationNotifier) NotifyInstallationChanged(installationID string) 
 // Stop flushes buffered messages and shuts the publisher down. Must be
 // called on graceful shutdown — Client.Close() does not stop publishers.
 func (n *InvalidationNotifier) Stop() {
-	n.publisher.Stop()
+	n.stop()
+}
+
+// subscriberReceiver is the narrow seam Run needs from a GCP Pub/Sub
+// Subscriber. *gcppubsub.Subscriber already implements this directly, so no
+// adapter is required in production; the interface exists purely so tests can
+// substitute an in-memory fake for Run's message-handling logic.
+type subscriberReceiver interface {
+	Receive(ctx context.Context, f func(context.Context, *gcppubsub.Message)) error
+	String() string
 }
 
 // InvalidationListener subscribes to the invalidation topic and forwards every
 // payload to the local cache; cache TTL is the fallback under sustained outages.
 type InvalidationListener struct {
-	subscriber *gcppubsub.Subscriber
+	subscriber subscriberReceiver
 	cache      auth.APIKeyCache
 	done       chan struct{}
 }

--- a/internal/pubsub/invalidation_internal_test.go
+++ b/internal/pubsub/invalidation_internal_test.go
@@ -1,0 +1,188 @@
+package pubsub
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"workweave/router/internal/auth"
+
+	gcppubsub "cloud.google.com/go/pubsub/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakePublisher is an in-memory stand-in for the publisher interface, letting
+// tests exercise NotifyInstallationChanged's guard/goroutine logic without a
+// real Pub/Sub connection.
+type fakePublisher struct {
+	mu        sync.Mutex
+	published []string
+	err       error
+	done      chan struct{}
+}
+
+func newFakePublisher() *fakePublisher {
+	return &fakePublisher{done: make(chan struct{}, 8)}
+}
+
+func (f *fakePublisher) Publish(_ context.Context, installationID string) error {
+	f.mu.Lock()
+	f.published = append(f.published, installationID)
+	err := f.err
+	f.mu.Unlock()
+	f.done <- struct{}{}
+	return err
+}
+
+func (f *fakePublisher) Published() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([]string, len(f.published))
+	copy(out, f.published)
+	return out
+}
+
+func (f *fakePublisher) waitForPublish(t *testing.T) {
+	t.Helper()
+	select {
+	case <-f.done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for Publish to be called")
+	}
+}
+
+func TestNotifyInstallationChanged_EmptyIDNeverPublishes(t *testing.T) {
+	fp := newFakePublisher()
+	n := &InvalidationNotifier{publisher: fp, stop: func() {}}
+
+	n.NotifyInstallationChanged("")
+
+	select {
+	case <-fp.done:
+		t.Fatal("Publish must not be called for an empty installation ID")
+	case <-time.After(50 * time.Millisecond):
+	}
+	assert.Empty(t, fp.Published())
+}
+
+func TestNotifyInstallationChanged_PublishesInstallationID(t *testing.T) {
+	fp := newFakePublisher()
+	n := &InvalidationNotifier{publisher: fp, stop: func() {}}
+
+	n.NotifyInstallationChanged("install-123")
+
+	fp.waitForPublish(t)
+	assert.Equal(t, []string{"install-123"}, fp.Published())
+}
+
+func TestNotifyInstallationChanged_PublishErrorDoesNotPanic(t *testing.T) {
+	fp := newFakePublisher()
+	fp.err = errors.New("boom")
+	n := &InvalidationNotifier{publisher: fp, stop: func() {}}
+
+	assert.NotPanics(t, func() {
+		n.NotifyInstallationChanged("install-456")
+		fp.waitForPublish(t)
+	})
+	assert.Equal(t, []string{"install-456"}, fp.Published())
+}
+
+func TestInvalidationNotifier_StopCallsUnderlyingStop(t *testing.T) {
+	called := false
+	n := &InvalidationNotifier{publisher: newFakePublisher(), stop: func() { called = true }}
+
+	n.Stop()
+
+	assert.True(t, called, "Stop must delegate to the wrapped Publisher.Stop")
+}
+
+// fakeSubscriber is an in-memory stand-in for subscriberReceiver, letting
+// tests drive Run's message-handling loop without a real subscription.
+type fakeSubscriber struct {
+	messages []*gcppubsub.Message
+}
+
+func (f *fakeSubscriber) String() string { return "fake-subscription" }
+
+func (f *fakeSubscriber) Receive(ctx context.Context, handler func(context.Context, *gcppubsub.Message)) error {
+	for _, msg := range f.messages {
+		handler(ctx, msg)
+	}
+	<-ctx.Done()
+	return ctx.Err()
+}
+
+// fakeAPIKeyCache records InvalidateInstallation calls.
+type fakeAPIKeyCache struct {
+	auth.NoOpAPIKeyCache
+	mu          sync.Mutex
+	invalidated []string
+}
+
+func (f *fakeAPIKeyCache) InvalidateInstallation(installationID string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.invalidated = append(f.invalidated, installationID)
+}
+
+func (f *fakeAPIKeyCache) Invalidated() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([]string, len(f.invalidated))
+	copy(out, f.invalidated)
+	return out
+}
+
+func TestInvalidationListener_RunForwardsNonEmptyMessagesToCache(t *testing.T) {
+	sub := &fakeSubscriber{messages: []*gcppubsub.Message{
+		{Data: []byte("install-1")},
+		{Data: []byte("")},
+		{Data: []byte("install-2")},
+	}}
+	cache := &fakeAPIKeyCache{}
+	l := NewInvalidationListener(nil, cache)
+	l.subscriber = sub
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go l.Run(ctx)
+
+	require.Eventually(t, func() bool {
+		return len(cache.Invalidated()) == 2
+	}, time.Second, 5*time.Millisecond, "Run must invalidate the cache for every non-empty message")
+	assert.Equal(t, []string{"install-1", "install-2"}, cache.Invalidated())
+
+	cancel()
+	l.Wait()
+}
+
+func TestInvalidationListener_WaitBlocksUntilRunReturns(t *testing.T) {
+	sub := &fakeSubscriber{}
+	l := NewInvalidationListener(nil, &fakeAPIKeyCache{})
+	l.subscriber = sub
+
+	ctx, cancel := context.WithCancel(context.Background())
+	waitReturned := make(chan struct{})
+	go func() {
+		l.Wait()
+		close(waitReturned)
+	}()
+
+	go l.Run(ctx)
+
+	select {
+	case <-waitReturned:
+		t.Fatal("Wait must not return before Run has completed")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	cancel()
+
+	select {
+	case <-waitReturned:
+	case <-time.After(time.Second):
+		t.Fatal("Wait must return once Run has returned")
+	}
+}

--- a/internal/sse/json_test.go
+++ b/internal/sse/json_test.go
@@ -1,0 +1,107 @@
+package sse_test
+
+import (
+	"bufio"
+	"bytes"
+	"math"
+	"testing"
+
+	"workweave/router/internal/sse"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWriteJSONString_PlainStringIsQuoted(t *testing.T) {
+	var buf bytes.Buffer
+	w := bufio.NewWriter(&buf)
+
+	sse.WriteJSONString(w, "hello")
+	require.NoError(t, w.Flush())
+
+	assert.Equal(t, `"hello"`, buf.String())
+}
+
+func TestWriteJSONString_EscapesQuotesAndBackslashes(t *testing.T) {
+	var buf bytes.Buffer
+	w := bufio.NewWriter(&buf)
+
+	sse.WriteJSONString(w, `say "hi"\now`)
+	require.NoError(t, w.Flush())
+
+	assert.Equal(t, `"say \"hi\"\\now"`, buf.String())
+}
+
+func TestWriteJSONString_EscapesControlCharacters(t *testing.T) {
+	var buf bytes.Buffer
+	w := bufio.NewWriter(&buf)
+
+	sse.WriteJSONString(w, "a\nb\tc")
+	require.NoError(t, w.Flush())
+
+	assert.Equal(t, "\"a\\u000ab\\u0009c\"", buf.String())
+}
+
+// TestWriteJSONString_EscapesLineSeparators covers U+2028/U+2029, which are
+// valid inside a JSON string but illegal as literal characters inside a
+// JavaScript string; escaping them keeps output safe for any consumer that
+// naively eval's or line-splits the payload.
+func TestWriteJSONString_EscapesLineSeparators(t *testing.T) {
+	var buf bytes.Buffer
+	w := bufio.NewWriter(&buf)
+
+	sse.WriteJSONString(w, "before\u2028middle\u2029after")
+	require.NoError(t, w.Flush())
+
+	assert.Equal(t, "\"before\\u2028middle\\u2029after\"", buf.String())
+}
+
+func TestWriteJSONString_EmptyStringWritesEmptyQuotes(t *testing.T) {
+	var buf bytes.Buffer
+	w := bufio.NewWriter(&buf)
+
+	sse.WriteJSONString(w, "")
+	require.NoError(t, w.Flush())
+
+	assert.Equal(t, `""`, buf.String())
+}
+
+func TestWriteJSONString_PassesThroughMultiByteRunes(t *testing.T) {
+	var buf bytes.Buffer
+	w := bufio.NewWriter(&buf)
+
+	sse.WriteJSONString(w, "café 中文")
+	require.NoError(t, w.Flush())
+
+	assert.Equal(t, "\"café 中文\"", buf.String())
+}
+
+func TestWriteJSONInt_Zero(t *testing.T) {
+	var buf bytes.Buffer
+	w := bufio.NewWriter(&buf)
+
+	sse.WriteJSONInt(w, 0)
+	require.NoError(t, w.Flush())
+
+	assert.Equal(t, "0", buf.String())
+}
+
+func TestWriteJSONInt_Negative(t *testing.T) {
+	var buf bytes.Buffer
+	w := bufio.NewWriter(&buf)
+
+	sse.WriteJSONInt(w, -42)
+	require.NoError(t, w.Flush())
+
+	assert.Equal(t, "-42", buf.String())
+}
+
+func TestWriteJSONInt_LargeValue(t *testing.T) {
+	var buf bytes.Buffer
+	w := bufio.NewWriter(&buf)
+
+	sse.WriteJSONInt(w, math.MaxInt64)
+	require.NoError(t, w.Flush())
+
+	assert.Equal(t, "9223372036854775807", buf.String())
+}

--- a/internal/sse/parse_test.go
+++ b/internal/sse/parse_test.go
@@ -1,0 +1,100 @@
+package sse_test
+
+import (
+	"testing"
+
+	"workweave/router/internal/sse"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSplitNext_LFBoundary(t *testing.T) {
+	event, n := sse.SplitNext([]byte("event: message\ndata: {}\n\nrest"))
+
+	assert.Equal(t, "event: message\ndata: {}", string(event))
+	assert.Equal(t, len("event: message\ndata: {}\n\n"), n)
+}
+
+func TestSplitNext_CRLFBoundary(t *testing.T) {
+	event, n := sse.SplitNext([]byte("event: message\r\ndata: {}\r\n\r\nrest"))
+
+	assert.Equal(t, "event: message\r\ndata: {}", string(event))
+	assert.Equal(t, len("event: message\r\ndata: {}\r\n\r\n"), n)
+}
+
+func TestSplitNext_IncompleteBufferReturnsZero(t *testing.T) {
+	event, n := sse.SplitNext([]byte("event: message\ndata: {}"))
+
+	assert.Nil(t, event)
+	assert.Equal(t, 0, n)
+}
+
+func TestSplitNext_EmptyBufferReturnsZero(t *testing.T) {
+	event, n := sse.SplitNext(nil)
+
+	assert.Nil(t, event)
+	assert.Equal(t, 0, n)
+}
+
+// TestSplitNext_CRLFPrecedenceWhenBothBoundariesPresent covers the case where
+// an earlier LF-only boundary and a later CRLF boundary both appear in the
+// buffer; SplitNext must prefer whichever boundary starts first, not always
+// CRLF, so this pins down the crpf < lf tie-break in the switch.
+func TestSplitNext_EarlierLFBoundaryWinsOverLaterCRLF(t *testing.T) {
+	buf := []byte("a\n\nb\r\n\r\nc")
+
+	event, n := sse.SplitNext(buf)
+
+	assert.Equal(t, "a", string(event))
+	assert.Equal(t, 3, n)
+}
+
+func TestSplitNext_EarlierCRLFBoundaryWinsOverLaterLF(t *testing.T) {
+	buf := []byte("a\r\n\r\nb\n\nc")
+
+	event, n := sse.SplitNext(buf)
+
+	assert.Equal(t, "a", string(event))
+	assert.Equal(t, 5, n)
+}
+
+func TestParseEvent_ExtractsEventTypeAndData(t *testing.T) {
+	eventType, data := sse.ParseEvent([]byte("event: content_block_delta\ndata: {\"type\":\"text\"}"))
+
+	assert.Equal(t, "content_block_delta", string(eventType))
+	assert.Equal(t, `{"type":"text"}`, string(data))
+}
+
+func TestParseEvent_NoEventLineLeavesEventTypeEmpty(t *testing.T) {
+	eventType, data := sse.ParseEvent([]byte("data: {\"ok\":true}"))
+
+	assert.Empty(t, eventType)
+	assert.Equal(t, `{"ok":true}`, string(data))
+}
+
+// TestParseEvent_MultiLineDataReturnsOnlyFirstLine pins down the documented
+// behavior: for a multi-line `data:` field, only the first line is returned.
+// This holds regardless of which provider emitted the event — Anthropic,
+// OpenAI, and Gemini (via internal/translate/gemini_stream.go) all call
+// ParseEvent and all only ever emit single-line JSON payloads, so returning
+// just the first `data:` line is safe for all three.
+func TestParseEvent_MultiLineDataReturnsOnlyFirstLine(t *testing.T) {
+	eventType, data := sse.ParseEvent([]byte("event: message\ndata: first-line\ndata: second-line"))
+
+	assert.Equal(t, "message", string(eventType))
+	assert.Equal(t, "first-line", string(data))
+}
+
+func TestParseEvent_IgnoresCarriageReturnAtLineEnd(t *testing.T) {
+	eventType, data := sse.ParseEvent([]byte("event: message\r\ndata: {}\r"))
+
+	assert.Equal(t, "message", string(eventType))
+	assert.Equal(t, "{}", string(data))
+}
+
+func TestParseEvent_EmptyEventReturnsEmptyValues(t *testing.T) {
+	eventType, data := sse.ParseEvent(nil)
+
+	assert.Empty(t, eventType)
+	assert.Nil(t, data)
+}


### PR DESCRIPTION
## Summary

Adds unit test coverage for three previously untested packages, each independent and non-overlapping:

- **internal/pubsub** ([88]): `InvalidationNotifier`/`InvalidationListener` were built directly around concrete `*gcppubsub.Publisher`/`*gcppubsub.Subscriber` SDK types. Introduces narrow interface seams (`publisher`, `subscriberReceiver`) so `NotifyInstallationChanged`'s guard logic and `Run`'s message-handling loop can be tested with in-memory fakes instead of a real Pub/Sub connection. `CreateReplicaSubscription`'s admin-client plumbing is left untested as a thin one-time boot-path wrapper, per repo convention (no DB-backed/SDK integration tests in internal/).
- **internal/sse** ([85]): Adds `parse_test.go` (SplitNext LF vs CRLF boundary precedence + the n=0 incomplete-buffer case; ParseEvent's documented first-line-only behavior on multi-line `data:` fields, confirmed to also hold for Gemini's usage in `internal/translate/gemini_stream.go`) and `json_test.go` (WriteJSONString's escape paths for quotes/backslashes/control chars/U+2028/U+2029, plus WriteJSONInt across negative/zero/large values).
- **internal/observability/apm** ([72]): Adds `apm_test.go` covering the no-op path when `WV_APM_OTLP_ENDPOINT` is unset, and idempotent `Shutdown`/`ShutdownWithContext` (including when `Init` was never called).

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .` (clean)
- [x] `go test ./...` (all packages pass)