### PR TITLE
test: add coverage for spiral_signals, Gemini handover, crossformat repair fallbacks

### DIFF
--- a/internal/router/handover/summarizer_test.go
+++ b/internal/router/handover/summarizer_test.go
@@ -327,6 +327,122 @@ func TestRewriteEnvelope_StripsToolResultsFromLatestUser(t *testing.T) {
 	assert.Equal(t, "assistant", msgs[0].Get("role").String())
 }
 
+func TestRewriteEnvelope_GeminiCollapsesToSummaryPlusLastUser(t *testing.T) {
+	t.Parallel()
+
+	const geminiConversation = `{
+  "contents": [
+    {"role": "user", "parts": [{"text": "Plan a refactor of pkg/foo."}]},
+    {"role": "model", "parts": [{"text": "Sure — I will start with renames."}]},
+    {"role": "user", "parts": [{"text": "Now apply step 1."}]},
+    {"role": "model", "parts": [{"functionCall": {"name": "edit", "args": {}}}]},
+    {"role": "user", "parts": [{"functionResponse": {"name": "edit", "response": {"result": "edit applied"}}}]},
+    {"role": "user", "parts": [{"text": "Continue with step 2."}]}
+  ]
+}`
+	env, err := translate.ParseGemini([]byte(geminiConversation))
+	require.NoError(t, err)
+
+	elided := handover.RewriteEnvelope(env, "Refactor of pkg/foo in progress; step 1 applied.")
+
+	// 6 original entries, only the trailing user is preserved → 5 elided.
+	assert.Equal(t, 5, elided)
+
+	prep, err := env.PrepareGemini(http.Header{}, translate.EmitOptions{TargetModel: "gemini-3.1-pro"})
+	require.NoError(t, err)
+
+	contents := gjson.GetBytes(prep.Body, "contents").Array()
+	require.Len(t, contents, 2, "expect [summary, lastUser]")
+
+	assert.Equal(t, "model", contents[0].Get("role").String())
+	summaryText := contents[0].Get("parts.0.text").String()
+	assert.True(t, strings.HasPrefix(summaryText, translate.HandoverSummaryTag), "summary must carry the tag prefix; got %q", summaryText)
+	assert.Contains(t, summaryText, "Refactor of pkg/foo")
+
+	assert.Equal(t, "user", contents[1].Get("role").String())
+	assert.Equal(t, "Continue with step 2.", contents[1].Get("parts.0.text").String())
+}
+
+func TestRewriteEnvelope_GeminiNoUserMessagesYieldsSummaryOnlyContents(t *testing.T) {
+	t.Parallel()
+
+	const body = `{
+  "contents": [
+    {"role": "model", "parts": [{"text": "hello"}]},
+    {"role": "model", "parts": [{"text": "still talking to myself"}]}
+  ]
+}`
+	env, err := translate.ParseGemini([]byte(body))
+	require.NoError(t, err)
+
+	elided := handover.RewriteEnvelope(env, "Brief recap.")
+
+	// Both original model turns dropped; no user turn to keep.
+	assert.Equal(t, 2, elided)
+
+	prep, err := env.PrepareGemini(http.Header{}, translate.EmitOptions{TargetModel: "gemini-3.1-pro"})
+	require.NoError(t, err)
+	contents := gjson.GetBytes(prep.Body, "contents").Array()
+	require.Len(t, contents, 1, "expect summary-only contents when no user turn is present")
+	assert.Equal(t, "model", contents[0].Get("role").String())
+}
+
+func TestTrimLastN_GeminiKeepsLastNAndSystemInstruction(t *testing.T) {
+	t.Parallel()
+
+	const tenEntryBody = `{
+  "systemInstruction": {"parts": [{"text": "sys"}]},
+  "contents": [
+    {"role": "user", "parts": [{"text": "m1"}]},
+    {"role": "model", "parts": [{"text": "m2"}]},
+    {"role": "user", "parts": [{"text": "m3"}]},
+    {"role": "model", "parts": [{"text": "m4"}]},
+    {"role": "user", "parts": [{"text": "m5"}]},
+    {"role": "model", "parts": [{"text": "m6"}]},
+    {"role": "user", "parts": [{"text": "m7"}]},
+    {"role": "model", "parts": [{"text": "m8"}]},
+    {"role": "user", "parts": [{"text": "m9"}]},
+    {"role": "model", "parts": [{"text": "m10"}]}
+  ]
+}`
+	env, err := translate.ParseGemini([]byte(tenEntryBody))
+	require.NoError(t, err)
+
+	elided := handover.TrimLastN(env, 3)
+	assert.Equal(t, 7, elided)
+
+	prep, err := env.PrepareGemini(http.Header{}, translate.EmitOptions{TargetModel: "gemini-3.1-pro"})
+	require.NoError(t, err)
+	assert.Equal(t, "sys", gjson.GetBytes(prep.Body, "systemInstruction.parts.0.text").String(),
+		"systemInstruction is untouched by TrimLastN on the Gemini path")
+	contents := gjson.GetBytes(prep.Body, "contents").Array()
+	require.Len(t, contents, 3)
+	assert.Equal(t, "m8", contents[0].Get("parts.0.text").String())
+	assert.Equal(t, "m9", contents[1].Get("parts.0.text").String())
+	assert.Equal(t, "m10", contents[2].Get("parts.0.text").String())
+}
+
+func TestTrimLastN_GeminiNoOpWhenUnderLimit(t *testing.T) {
+	t.Parallel()
+
+	const body = `{
+  "contents": [
+    {"role": "user", "parts": [{"text": "m1"}]},
+    {"role": "model", "parts": [{"text": "m2"}]}
+  ]
+}`
+	env, err := translate.ParseGemini([]byte(body))
+	require.NoError(t, err)
+
+	elided := handover.TrimLastN(env, 5)
+	assert.Equal(t, 0, elided, "fewer entries than n must elide nothing")
+
+	prep, err := env.PrepareGemini(http.Header{}, translate.EmitOptions{TargetModel: "gemini-3.1-pro"})
+	require.NoError(t, err)
+	contents := gjson.GetBytes(prep.Body, "contents").Array()
+	require.Len(t, contents, 2)
+}
+
 // Regression: mid-session model switch + TrimLastN can orphan tool_result
 // blocks, which the Anthropic→Gemini translation turned into an empty
 // functionResponse.name (Gemini 400).

--- a/internal/translate/crossformat_request_test.go
+++ b/internal/translate/crossformat_request_test.go
@@ -1659,6 +1659,19 @@ func TestCrossFormat_AnthropicToOpenAI_ToolUseWithMissingName(t *testing.T) {
 
 	var doc map[string]any
 	require.NoError(t, json.Unmarshal(prep.Body, &doc), "output must be valid JSON; got: %s", string(prep.Body))
+
+	msgs := getArray(t, doc, "messages")
+	require.Len(t, msgs, 2)
+	assistant := msgs[1].(map[string]any)
+	toolCalls, ok := assistant["tool_calls"].([]any)
+	require.True(t, ok, "assistant message must still carry tool_calls; got: %s", string(prep.Body))
+	require.Len(t, toolCalls, 1, "the tool call must not be silently dropped")
+
+	call := toolCalls[0].(map[string]any)
+	assert.Equal(t, "toolu_123", call["id"], "the original tool_use id must be preserved, not replaced with a garbage id")
+	fn := call["function"].(map[string]any)
+	assert.Equal(t, "", fn["name"], "a missing name must pass through as empty, not a fabricated placeholder name")
+	assert.JSONEq(t, `{"x":1}`, fn["arguments"].(string), "arguments must survive untouched")
 }
 
 func TestCrossFormat_AnthropicToOpenAI_ToolResultMissingToolUseID(t *testing.T) {
@@ -1678,6 +1691,13 @@ func TestCrossFormat_AnthropicToOpenAI_ToolResultMissingToolUseID(t *testing.T) 
 
 	var doc map[string]any
 	require.NoError(t, json.Unmarshal(prep.Body, &doc), "output must be valid JSON; got: %s", string(prep.Body))
+
+	msgs := getArray(t, doc, "messages")
+	require.Len(t, msgs, 1, "the tool_result message must not be silently dropped")
+	toolMsg := msgs[0].(map[string]any)
+	assert.Equal(t, "tool", toolMsg["role"])
+	assert.Equal(t, "", toolMsg["tool_call_id"], "a missing tool_use_id must pass through as empty, not a fabricated id")
+	assert.Equal(t, "done", toolMsg["content"])
 }
 
 func TestCrossFormat_OpenAIToGemini_SchemaRefsInlined(t *testing.T) {

--- a/internal/translate/spiral_signals_test.go
+++ b/internal/translate/spiral_signals_test.go
@@ -1,0 +1,311 @@
+package translate_test
+
+import (
+	"testing"
+
+	"workweave/router/internal/translate"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestToolResultErrors_FlagsIsErrorAndCountsStreak(t *testing.T) {
+	body := mustMarshalJSON(t, map[string]any{
+		"model": "claude-sonnet-4-6",
+		"messages": []any{
+			map[string]any{"role": "assistant", "content": []any{
+				map[string]any{"type": "tool_use", "id": "1", "name": "Bash", "input": map[string]any{"command": "run"}},
+			}},
+			map[string]any{"role": "user", "content": []any{
+				map[string]any{"type": "tool_result", "tool_use_id": "1", "content": "ok", "is_error": false},
+			}},
+			map[string]any{"role": "assistant", "content": []any{
+				map[string]any{"type": "tool_use", "id": "2", "name": "Bash", "input": map[string]any{"command": "run"}},
+			}},
+			map[string]any{"role": "user", "content": []any{
+				map[string]any{"type": "tool_result", "tool_use_id": "2", "content": "boom", "is_error": true},
+			}},
+		},
+		"max_tokens": 256,
+	})
+	env, err := translate.ParseAnthropic(body)
+	require.NoError(t, err)
+
+	stats := env.ToolResultErrors()
+	assert.Equal(t, 2, stats.Total)
+	assert.Equal(t, 1, stats.Errored)
+	assert.Equal(t, 1, stats.TrailingErrStreak)
+}
+
+func TestToolResultErrors_DetectsMarkerTextWithoutIsErrorFlag(t *testing.T) {
+	// A test suite can exit non-zero without the client setting is_error;
+	// the marker-text scan is the fallback.
+	body := mustMarshalJSON(t, map[string]any{
+		"model": "claude-sonnet-4-6",
+		"messages": []any{
+			map[string]any{"role": "user", "content": []any{
+				map[string]any{"type": "tool_result", "tool_use_id": "1", "content": "Traceback (most recent call last):\n  boom"},
+			}},
+		},
+		"max_tokens": 256,
+	})
+	env, err := translate.ParseAnthropic(body)
+	require.NoError(t, err)
+
+	stats := env.ToolResultErrors()
+	assert.Equal(t, 1, stats.Total)
+	assert.Equal(t, 1, stats.Errored, "marker text must be detected even without is_error set")
+	assert.Equal(t, 1, stats.TrailingErrStreak)
+}
+
+func TestToolResultErrors_MarkerTextInArrayContent(t *testing.T) {
+	// tool_result content can be an array of text blocks rather than a plain
+	// string; the marker scan must walk into it.
+	body := mustMarshalJSON(t, map[string]any{
+		"model": "claude-sonnet-4-6",
+		"messages": []any{
+			map[string]any{"role": "user", "content": []any{
+				map[string]any{"type": "tool_result", "tool_use_id": "1", "content": []any{
+					map[string]any{"type": "text", "text": "running tests...\nFAILED test_foo"},
+				}},
+			}},
+		},
+		"max_tokens": 256,
+	})
+	env, err := translate.ParseAnthropic(body)
+	require.NoError(t, err)
+
+	stats := env.ToolResultErrors()
+	assert.Equal(t, 1, stats.Errored, "marker in array-form content must be detected")
+}
+
+func TestToolResultErrors_TrailingStreakResetsOnSuccess(t *testing.T) {
+	body := mustMarshalJSON(t, map[string]any{
+		"model": "claude-sonnet-4-6",
+		"messages": []any{
+			map[string]any{"role": "user", "content": []any{
+				map[string]any{"type": "tool_result", "tool_use_id": "1", "content": "boom", "is_error": true},
+			}},
+			map[string]any{"role": "user", "content": []any{
+				map[string]any{"type": "tool_result", "tool_use_id": "2", "content": "boom again", "is_error": true},
+			}},
+			map[string]any{"role": "user", "content": []any{
+				map[string]any{"type": "tool_result", "tool_use_id": "3", "content": "ok now", "is_error": false},
+			}},
+		},
+		"max_tokens": 256,
+	})
+	env, err := translate.ParseAnthropic(body)
+	require.NoError(t, err)
+
+	stats := env.ToolResultErrors()
+	assert.Equal(t, 3, stats.Total)
+	assert.Equal(t, 2, stats.Errored)
+	assert.Equal(t, 0, stats.TrailingErrStreak, "a healthy result at the tail must reset the streak")
+}
+
+func TestToolResultErrors_ScanLimitCapsMarkerSearch(t *testing.T) {
+	// The marker text sits well past the 2048-byte scan limit; it must not
+	// be found, proving the cap is enforced rather than scanning the whole body.
+	padding := make([]byte, 3000)
+	for i := range padding {
+		padding[i] = 'a'
+	}
+	content := string(padding) + "Traceback (most recent call last):"
+	body := mustMarshalJSON(t, map[string]any{
+		"model": "claude-sonnet-4-6",
+		"messages": []any{
+			map[string]any{"role": "user", "content": []any{
+				map[string]any{"type": "tool_result", "tool_use_id": "1", "content": content},
+			}},
+		},
+		"max_tokens": 256,
+	})
+	env, err := translate.ParseAnthropic(body)
+	require.NoError(t, err)
+
+	stats := env.ToolResultErrors()
+	assert.Equal(t, 0, stats.Errored, "marker past the scan limit must not be detected")
+}
+
+func TestToolResultErrors_NonAnthropicFormatReturnsZeroStats(t *testing.T) {
+	body := mustMarshalJSON(t, map[string]any{
+		"model": "gpt-4o",
+		"messages": []any{
+			map[string]any{"role": "tool", "tool_call_id": "1", "content": "Traceback (most recent call last):"},
+		},
+	})
+	env, err := translate.ParseOpenAI(body)
+	require.NoError(t, err)
+
+	stats := env.ToolResultErrors()
+	assert.Equal(t, translate.ToolResultErrorStats{}, stats)
+}
+
+func TestAssistantToolCallFilePaths_ExtractsFilePathAndNotebookPath(t *testing.T) {
+	body := mustMarshalJSON(t, map[string]any{
+		"model": "claude-sonnet-4-6",
+		"messages": []any{
+			map[string]any{"role": "assistant", "content": []any{
+				map[string]any{"type": "tool_use", "id": "1", "name": "Read", "input": map[string]any{"file_path": "/foo.go"}},
+				map[string]any{"type": "tool_use", "id": "2", "name": "NotebookEdit", "input": map[string]any{"notebook_path": "/nb.ipynb"}},
+			}},
+		},
+		"max_tokens": 256,
+	})
+	env, err := translate.ParseAnthropic(body)
+	require.NoError(t, err)
+
+	paths := env.AssistantToolCallFilePaths()
+	require.Len(t, paths, 2)
+	assert.Equal(t, translate.ToolCallFilePath{Name: "Read", Path: "/foo.go"}, paths[0])
+	assert.Equal(t, translate.ToolCallFilePath{Name: "NotebookEdit", Path: "/nb.ipynb"}, paths[1])
+}
+
+func TestAssistantToolCallFilePaths_SkipsNudgeAndPathlessCalls(t *testing.T) {
+	// Router-synthesized recovery nudges (id prefix toolu_router_nudge_) carry
+	// command/description args, never file_path/notebook_path, so they must
+	// never surface as a file touch in the same-file-thrash detector.
+	body := mustMarshalJSON(t, map[string]any{
+		"model": "claude-sonnet-4-6",
+		"messages": []any{
+			map[string]any{"role": "assistant", "content": []any{
+				map[string]any{"type": "tool_use", "id": "toolu_router_nudge_msg1", "name": "Bash", "input": map[string]any{
+					"command":     "echo nudge",
+					"description": "router recovery nudge: previous turn had no tool_use",
+				}},
+				map[string]any{"type": "tool_use", "id": "2", "name": "Grep", "input": map[string]any{"pattern": "foo"}},
+				map[string]any{"type": "tool_use", "id": "3", "name": "Read", "input": map[string]any{"file_path": "/bar.go"}},
+			}},
+		},
+		"max_tokens": 256,
+	})
+	env, err := translate.ParseAnthropic(body)
+	require.NoError(t, err)
+
+	paths := env.AssistantToolCallFilePaths()
+	require.Len(t, paths, 1, "nudge and Grep (no file_path/notebook_path) must be filtered")
+	assert.Equal(t, translate.ToolCallFilePath{Name: "Read", Path: "/bar.go"}, paths[0])
+}
+
+func TestAssistantToolCallFilePaths_NonAnthropicFormatReturnsNil(t *testing.T) {
+	body := mustMarshalJSON(t, map[string]any{
+		"model": "gpt-4o",
+		"messages": []any{
+			map[string]any{"role": "assistant", "tool_calls": []any{
+				map[string]any{"id": "1", "type": "function", "function": map[string]any{"name": "Read", "arguments": `{"file_path":"/foo.go"}`}},
+			}},
+		},
+	})
+	env, err := translate.ParseOpenAI(body)
+	require.NoError(t, err)
+	assert.Nil(t, env.AssistantToolCallFilePaths())
+}
+
+func TestTrailingAssistantMonologue_StopsAtRealToolUse(t *testing.T) {
+	body := mustMarshalJSON(t, map[string]any{
+		"model": "claude-sonnet-4-6",
+		"messages": []any{
+			map[string]any{"role": "assistant", "content": []any{
+				map[string]any{"type": "tool_use", "id": "1", "name": "Bash", "input": map[string]any{"command": "ls"}},
+			}},
+			map[string]any{"role": "user", "content": []any{
+				map[string]any{"type": "tool_result", "tool_use_id": "1", "content": "ok"},
+			}},
+			map[string]any{"role": "assistant", "content": []any{
+				map[string]any{"type": "text", "text": "thinking out loud"},
+			}},
+			map[string]any{"role": "assistant", "content": []any{
+				map[string]any{"type": "text", "text": "still thinking"},
+			}},
+		},
+		"max_tokens": 256,
+	})
+	env, err := translate.ParseAnthropic(body)
+	require.NoError(t, err)
+
+	assert.Equal(t, 2, env.TrailingAssistantMonologue(), "two tool-less assistant turns since the last real tool_use")
+}
+
+func TestTrailingAssistantMonologue_StopsAtUserRealContent(t *testing.T) {
+	body := mustMarshalJSON(t, map[string]any{
+		"model": "claude-sonnet-4-6",
+		"messages": []any{
+			map[string]any{"role": "user", "content": "keep going"},
+			map[string]any{"role": "assistant", "content": []any{
+				map[string]any{"type": "text", "text": "prose only"},
+			}},
+			map[string]any{"role": "assistant", "content": []any{
+				map[string]any{"type": "text", "text": "still prose"},
+			}},
+			map[string]any{"role": "assistant", "content": []any{
+				map[string]any{"type": "text", "text": "more prose"},
+			}},
+		},
+		"max_tokens": 256,
+	})
+	env, err := translate.ParseAnthropic(body)
+	require.NoError(t, err)
+
+	assert.Equal(t, 3, env.TrailingAssistantMonologue(), "three trailing tool-less assistant turns, stopping at the real user message")
+}
+
+func TestTrailingAssistantMonologue_ToolResultOnlyUserDoesNotStopStreak(t *testing.T) {
+	// A user turn carrying only a tool_result (no real content) must NOT
+	// count as "real input" that stops the monologue streak.
+	body := mustMarshalJSON(t, map[string]any{
+		"model": "claude-sonnet-4-6",
+		"messages": []any{
+			map[string]any{"role": "assistant", "content": []any{
+				map[string]any{"type": "tool_use", "id": "1", "name": "Bash", "input": map[string]any{"command": "ls"}},
+			}},
+			map[string]any{"role": "user", "content": []any{
+				map[string]any{"type": "tool_result", "tool_use_id": "1", "content": "ok"},
+			}},
+			map[string]any{"role": "assistant", "content": []any{
+				map[string]any{"type": "text", "text": "prose only"},
+			}},
+		},
+		"max_tokens": 256,
+	})
+	env, err := translate.ParseAnthropic(body)
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, env.TrailingAssistantMonologue())
+}
+
+func TestTrailingAssistantMonologue_NudgeCountsAsRealToolUse(t *testing.T) {
+	// A router-synthesized nudge tool_use still counts as tool activity, per
+	// assistantHasRealToolUse's contract, so it must stop the streak too.
+	body := mustMarshalJSON(t, map[string]any{
+		"model": "claude-sonnet-4-6",
+		"messages": []any{
+			map[string]any{"role": "assistant", "content": []any{
+				map[string]any{"type": "text", "text": "prose before nudge"},
+			}},
+			map[string]any{"role": "assistant", "content": []any{
+				map[string]any{"type": "tool_use", "id": "toolu_router_nudge_1", "name": "Bash", "input": map[string]any{
+					"command":     "echo nudge",
+					"description": "router recovery nudge: previous turn had no tool_use",
+				}},
+			}},
+		},
+		"max_tokens": 256,
+	})
+	env, err := translate.ParseAnthropic(body)
+	require.NoError(t, err)
+
+	assert.Equal(t, 0, env.TrailingAssistantMonologue(), "the trailing message is a nudge tool_use, which stops the streak at 0")
+}
+
+func TestTrailingAssistantMonologue_NonAnthropicFormatReturnsZero(t *testing.T) {
+	body := mustMarshalJSON(t, map[string]any{
+		"model": "gpt-4o",
+		"messages": []any{
+			map[string]any{"role": "assistant", "content": "prose only"},
+		},
+	})
+	env, err := translate.ParseOpenAI(body)
+	require.NoError(t, err)
+	assert.Equal(t, 0, env.TrailingAssistantMonologue())
+}


### PR DESCRIPTION
## Summary
- **[13]** `internal/translate/spiral_signals.go` had zero test coverage anywhere in the repo, despite feeding the production shadow-mode spiral detector, unlike its structurally-identical sibling `loop_detection.go`. Adds `spiral_signals_test.go` covering `ToolResultErrors` (is_error flag, marker-text detection in both string and array content, `TrailingErrStreak` reset-on-success, the `toolResultErrorScanLimit` cap), `AssistantToolCallFilePaths` (file_path vs notebook_path, nudge-ID / pathless-call skip), and `TrailingAssistantMonologue` (stop at real tool_use including router nudges, stop at real user content, tool_result-only user turns don't reset the streak).
- **[121]** The Gemini branch of `internal/translate/handover.go` was the only wire format with zero coverage in `RewriteEnvelope`/`TrimLastN`, while Anthropic and OpenAI were thoroughly tested. Adds `TestRewriteEnvelope_Gemini*`/`TestTrimLastN_Gemini*` cases to `summarizer_test.go`, built off `translate.ParseGemini`, mirroring the existing Anthropic/OpenAI cases (summary+lastUser collapse, summary-only when no user turn, systemInstruction left untouched by trim, no-op under the limit).
- **[122]** `TestCrossFormat_AnthropicToOpenAI_ToolUseWithMissingName` and `...ToolResultMissingToolUseID` only asserted the output was syntactically valid JSON, so a regression that silently dropped the tool call/result or emitted a garbage id would still pass. Both now assert the tool call/result actually survives translation, with the id/name/tool_call_id preserved as the documented empty-string passthrough (no fabricated placeholder).

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .` (clean)
- [x] `go test ./...` (all packages pass)
- New tests are non-tautological — each asserts a value derived from the input that a broken/deleted implementation would get wrong (not just "no panic" or "valid JSON").