### PR TITLE
fix: small consolidation/cleanup fixes in translate package (6 findings)

### DIFF
--- a/internal/observability/otel/usage.go
+++ b/internal/observability/otel/usage.go
@@ -6,15 +6,8 @@ import (
 
 	"github.com/tidwall/gjson"
 
+	"workweave/router/internal/providers"
 	"workweave/router/internal/sse"
-)
-
-// Mirrors providers.Provider* constants; duplicated (not imported) to avoid a
-// circular import since this is a leaf package. Keep in sync with internal/providers/provider.go.
-const (
-	providerAnthropic = "anthropic"
-	providerOpenAI    = "openai"
-	providerGoogle    = "google"
 )
 
 // UsageSink receives extracted token usage. Translators call it directly when
@@ -168,9 +161,9 @@ func (u *UsageExtractor) scanBuffer() {
 
 func (u *UsageExtractor) extractFromSSEEvent(eventType []byte, data []byte) {
 	switch u.provider {
-	case providerAnthropic:
+	case providers.ProviderAnthropic:
 		u.extractAnthropicSSE(eventType, data)
-	case providerOpenAI, providerGoogle:
+	case providers.ProviderOpenAI, providers.ProviderGoogle:
 		u.extractOpenAISSE(data)
 	}
 }
@@ -181,7 +174,7 @@ func (u *UsageExtractor) extractAnthropicSSE(eventType []byte, data []byte) {
 		return
 	}
 
-	input, output, cacheCreation, cacheRead, found := extractUsageGJSON(data, providerAnthropic)
+	input, output, cacheCreation, cacheRead, found := extractUsageGJSON(data, providers.ProviderAnthropic)
 	if !found {
 		return
 	}
@@ -253,7 +246,7 @@ func (u *UsageExtractor) tryExtractFromJSON() {
 // Google's native :generateContent uses usageMetadata; its OpenAI-compat surface
 // uses the OpenAI shape instead.
 func extractUsageGJSON(data []byte, provider string) (input, output, cacheCreation, cacheRead int, found bool) {
-	if provider == providerGoogle {
+	if provider == providers.ProviderGoogle {
 		if meta := gjson.GetBytes(data, "usageMetadata"); meta.Exists() {
 			input = int(meta.Get("promptTokenCount").Int())
 			output = int(meta.Get("candidatesTokenCount").Int())
@@ -263,12 +256,12 @@ func extractUsageGJSON(data []byte, provider string) (input, output, cacheCreati
 	}
 
 	usage := gjson.GetBytes(data, "usage")
-	if !usage.Exists() && provider == providerAnthropic {
+	if !usage.Exists() && provider == providers.ProviderAnthropic {
 		usage = gjson.GetBytes(data, "message.usage")
 	}
 	// OpenAI Responses streaming nests usage under the terminal response event
 	// (response.completed); the non-streaming body carries it at the top level.
-	if !usage.Exists() && provider == providerOpenAI {
+	if !usage.Exists() && provider == providers.ProviderOpenAI {
 		usage = gjson.GetBytes(data, "response.usage")
 	}
 	if !usage.Exists() {
@@ -276,12 +269,12 @@ func extractUsageGJSON(data []byte, provider string) (input, output, cacheCreati
 	}
 
 	switch provider {
-	case providerAnthropic:
+	case providers.ProviderAnthropic:
 		input = int(usage.Get("input_tokens").Int())
 		output = int(usage.Get("output_tokens").Int())
 		cacheCreation = int(usage.Get("cache_creation_input_tokens").Int())
 		cacheRead = int(usage.Get("cache_read_input_tokens").Int())
-	case providerOpenAI, providerGoogle:
+	case providers.ProviderOpenAI, providers.ProviderGoogle:
 		// Chat Completions uses prompt_tokens/completion_tokens; Responses API
 		// (Codex passthrough) uses input_tokens/output_tokens. Probe both.
 		if pt := usage.Get("prompt_tokens"); pt.Exists() {

--- a/internal/translate/emit_gemini.go
+++ b/internal/translate/emit_gemini.go
@@ -1097,12 +1097,12 @@ func writeGeminiGenerationConfigFromAnthropic(jw *jsonWriter, body []byte, model
 
 // clampToModelOutputCap caps v to the model's max output token limit.
 func clampToModelOutputCap(v int64, model string) int64 {
-	cap := modelMaxOutputTokens[model]
-	if cap == 0 {
-		cap = defaultMaxOutputTokenCap
+	outputCap := modelMaxOutputTokens[model]
+	if outputCap == 0 {
+		outputCap = defaultMaxOutputTokenCap
 	}
-	if v > int64(cap) {
-		return int64(cap)
+	if v > int64(outputCap) {
+		return int64(outputCap)
 	}
 	return v
 }

--- a/internal/translate/emit_openai.go
+++ b/internal/translate/emit_openai.go
@@ -731,13 +731,7 @@ func writeOpenAIMaxTokensFromAnthropic(jw *jsonWriter, body []byte, opts EmitOpt
 	if r.Exists() {
 		val = r.Int()
 	}
-	cap := modelMaxOutputTokens[opts.TargetModel]
-	if cap == 0 {
-		cap = defaultMaxOutputTokenCap
-	}
-	if val > int64(cap) {
-		val = int64(cap)
-	}
+	val = clampToModelOutputCap(val, opts.TargetModel)
 	if opts.Capabilities.Supports(router.CapReasoning) {
 		jw.Key("max_completion_tokens")
 	} else {

--- a/internal/translate/envelope.go
+++ b/internal/translate/envelope.go
@@ -888,17 +888,17 @@ func resolveOpenAIOverrides(body []byte, opts EmitOptions) EmitOverrides {
 		ov.DeleteKeys = append(ov.DeleteKeys, "max_tokens")
 	}
 
-	cap := modelMaxOutputTokens[opts.TargetModel]
-	if cap == 0 {
-		cap = defaultMaxOutputTokenCap
+	tokenCap := modelMaxOutputTokens[opts.TargetModel]
+	if tokenCap == 0 {
+		tokenCap = defaultMaxOutputTokenCap
 	}
 	maxTokensDeleted := hasMaxTokens && supportsReasoning
 	if hasMaxTokens && !maxTokensDeleted {
 		ov.ClampMaxTokensKey = "max_tokens"
-		ov.ClampMaxTokensValue = int64(cap)
+		ov.ClampMaxTokensValue = int64(tokenCap)
 	}
 	if hasMaxComp || ov.SetMaxCompletionTokens != nil {
-		ov.ClampMaxCompTokensValue = int64(cap)
+		ov.ClampMaxCompTokensValue = int64(tokenCap)
 	}
 
 	if !hasMaxTokens && !hasMaxComp {
@@ -1048,8 +1048,8 @@ const defaultMaxOutputTokenCap = 8192
 // defaultOutputTokens returns the default max output tokens for a model,
 // floored by the model's own cap and globally at defaultMaxOutputTokenCap.
 func defaultOutputTokens(model string) int64 {
-	if cap, ok := modelMaxOutputTokens[model]; ok && cap < defaultMaxOutputTokenCap {
-		return int64(cap)
+	if tokenCap, ok := modelMaxOutputTokens[model]; ok && tokenCap < defaultMaxOutputTokenCap {
+		return int64(tokenCap)
 	}
 	return defaultMaxOutputTokenCap
 }

--- a/internal/translate/escape_normalize.go
+++ b/internal/translate/escape_normalize.go
@@ -2,9 +2,9 @@ package translate
 
 import "strings"
 
-// editToolNames is the set of tools whose args carry file content needing
-// exact whitespace round-tripping. Matched case-insensitively.
-var editToolNames = map[string]struct{}{
+// escapeNormalizeToolNames is the set of tools whose args carry file content
+// needing exact whitespace round-tripping. Matched case-insensitively.
+var escapeNormalizeToolNames = map[string]struct{}{
 	"edit":      {},
 	"write":     {},
 	"multiedit": {},
@@ -29,7 +29,7 @@ func normalizeEditEscapes(enabled bool, toolName string, input any) {
 	if !enabled {
 		return
 	}
-	if _, ok := editToolNames[strings.ToLower(toolName)]; !ok {
+	if _, ok := escapeNormalizeToolNames[strings.ToLower(toolName)]; !ok {
 		return
 	}
 	m, ok := input.(map[string]any)

--- a/internal/translate/openai_reasoning_signature.go
+++ b/internal/translate/openai_reasoning_signature.go
@@ -4,6 +4,8 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"strings"
+
+	"workweave/router/internal/providers"
 )
 
 type openAIReasoningSignatureEnvelope struct {
@@ -19,7 +21,7 @@ func encodeOpenAIReasoningSignature(id, enc string) string {
 	}
 	b, err := json.Marshal(openAIReasoningSignatureEnvelope{
 		Version:  1,
-		Provider: "openai",
+		Provider: providers.ProviderOpenAI,
 		ID:       id,
 		Enc:      enc,
 	})
@@ -41,7 +43,7 @@ func decodeOpenAIReasoningSignature(sig string) (id, enc string, ok bool) {
 	if err := json.Unmarshal(b, &env); err != nil {
 		return "", "", false
 	}
-	if env.Version != 1 || env.Provider != "openai" || env.ID == "" || env.Enc == "" {
+	if env.Version != 1 || env.Provider != providers.ProviderOpenAI || env.ID == "" || env.Enc == "" {
 		return "", "", false
 	}
 	return env.ID, env.Enc, true

--- a/internal/translate/translate.go
+++ b/internal/translate/translate.go
@@ -331,7 +331,7 @@ func anyNamedToolCall(toolCalls gjson.Result) bool {
 
 // isEditToolName reports whether name is a file-edit tool subject to escape normalization.
 func isEditToolName(name string) bool {
-	_, ok := editToolNames[strings.ToLower(name)]
+	_, ok := escapeNormalizeToolNames[strings.ToLower(name)]
 	return ok
 }
 


### PR DESCRIPTION
Small mechanical cleanups in `internal/translate` + `internal/observability/otel`, bundled as one PR since none is individually PR-worthy.

## [3] Duplicated clamp arithmetic
`writeOpenAIMaxTokensFromAnthropic` (emit_openai.go) duplicated the exact clamp arithmetic already factored out into `clampToModelOutputCap` (emit_gemini.go). Changed it to call `clampToModelOutputCap` so output-cap policy has one source of truth.

## [4] Two stale doc comments
Already fixed by #583 (merged 2026-07-03) — verified via `git log -p -L` on the relevant lines. Nothing left to do here.

## [7] Variable shadows builtin
Renamed the three `cap` locals that shadowed the builtin `cap()` (two in envelope.go, one in emit_gemini.go's `clampToModelOutputCap`) to `tokenCap`/`outputCap`.

## [14] Name collision trap between packages
Renamed `translate.editToolNames` to `escapeNormalizeToolNames` to disambiguate from the unrelated `proxy.editToolNames` (progress detection). Left the proxy package untouched — out of scope for this bundle.

## [11] Hardcoded string instead of constant
`openai_reasoning_signature.go` hardcoded `"openai"` in two places instead of `providers.ProviderOpenAI`. Imported `internal/providers` and replaced both literals.

## [68+102] Hardcoded provider constants, false import-cycle justification
`usage.go` locally duplicated `providerAnthropic`/`providerOpenAI`/`providerGoogle` string constants with a comment claiming an import cycle. Verified the claim is false — `otel` already transitively imports `providers` via `pricing.go` -> `catalog` -> `providers`, and a direct import builds clean. Deleted the local constants, imported `providers.Provider*` directly.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .` (clean)
- [x] `go test ./...` (all packages pass)
- [x] Ran translate package tests after each of the clamp/cap changes ([3], [7]) individually, not just at the end