### PR TITLE
feat(proxy): proactively compact over-window sessions instead of failing

### DIFF
--- a/cmd/router/main.go
+++ b/cmd/router/main.go
@@ -515,12 +515,19 @@ func main() {
 	// Kept as the interface type: a typed-nil *ProviderSummarizer would defeat
 	// the orchestrator's `!= nil` check.
 	var summarizer handover.Summarizer
+	// compactionSz stays a true-nil interface unless the summarizer provider is
+	// registered, so the Service's nil-check disables Tier-3 correctly (a
+	// typed-nil concrete pointer would defeat it).
+	var compactionSz proxy.CompactionSummarizer
 	if client, ok := providerMap[handoverProviderName]; ok {
-		summarizer = proxy.NewProviderSummarizer(client, handoverModel, handoverTimeout)
+		ps := proxy.NewProviderSummarizer(client, handoverModel, handoverTimeout)
+		summarizer = ps
+		compactionSz = ps
 		logger.Info("Handover summarizer wired", "provider", handoverProviderName, "model", handoverModel, "timeout_ms", handoverTimeout.Milliseconds())
 	} else {
 		logger.Info("Handover summarizer disabled (provider not registered); switch turns will preserve full history instead", "requested_provider", handoverProviderName)
 	}
+	compactionPct := parseEnvFloat("ROUTER_COMPACTION_PCT", proxy.DefaultCompactionTriggerPct)
 
 	// Lets the planner force a switch when a pinned model's provider is
 	// removed. nil on a missing/unloadable bundle treats every pin as routable.
@@ -614,6 +621,7 @@ func main() {
 		WithRouterFeedbackStore(repo.Telemetry).
 		WithPlanner(plannerCfg).
 		WithSummarizer(summarizer).
+		WithCompaction(compactionSz, compactionPct).
 		WithAvailableModels(availableModels).
 		WithDefaultBaselineModel(resolveDefaultBaselineModel()).
 		WithBillingService(billingSvc)

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -71,6 +71,7 @@ Set `DATABASE_URL` directly, or compose it from the individual vars:
 | `ROUTER_SESSION_PIN_ENABLED`      | `true`                       | Pin a session to its first-routed model so multi-turn conversations stay coherent. |
 | `ROUTER_HARD_PIN_MODEL`           | *(none)*                     | Force every request to a specific model, bypassing the cluster scorer. Debugging only. |
 | `ROUTER_HARD_PIN_PROVIDER`        | *(none)*                     | Pair with `ROUTER_HARD_PIN_MODEL`. |
+| `ROUTER_COMPACTION_PCT`           | `0.85`                       | Fraction of the largest eligible model's context window at which the proactive compaction cascade engages (clear old tool results → structured summary → trim). Range `(0,1]`; `0` disables compaction (over-window requests then 413). Mirrors Claude Code's ~0.85 auto-compact trigger. |
 | `ROUTER_ONNX_ASSETS_DIR`          | `/opt/router/assets`         | Directory containing `model.onnx` + `tokenizer.json`. |
 | `ROUTER_ONNX_LIBRARY_DIR`         | *(system default)*           | Path to `libonnxruntime` (e.g. `/opt/homebrew/lib` on Apple Silicon). |
 

--- a/internal/proxy/AGENTS.md
+++ b/internal/proxy/AGENTS.md
@@ -37,6 +37,10 @@ The per-turn flow is more than "scorer → dispatch". Pinned session, planner ve
 
 The provider-backed `Summarizer` implementation for handover lives in [`handover.go`](handover.go); the inner-ring `handover` package only defines the contract. On summarizer timeout or error, proxy keeps the full prior history unchanged (it does **not** trim) — a pricier switch turn beats silently dropping the conversation the switched-to model needs.
 
+## Proactive context-window compaction
+
+`ProxyMessages` / `ProxyOpenAIChatCompletion` call [`maybeCompact`](compaction.go) **before** routing so an over-long session is compacted rather than dead-ending in the scorer with no eligible provider. It engages when the estimate reaches `ROUTER_COMPACTION_PCT` (default 0.85) of the largest eligible model's window and runs Claude Code's tiered cascade: (1) `ClearOldToolResults` — local, clears stale tool results; (2) structured 9-section summary via a **window-aware** Anthropic-family summarizer (`SummarizeForCompaction`; haiku when the history fits, `claude-fable-5` for larger) rewritten with `RewriteForCompaction(summary, recentTurns)`; (3) progressive `TrimLastNMessages` rescue. If even the trimmed floor overflows, it returns `ErrContextWindowExceeded` → HTTP 413 (distinct from the "no provider keys" `ErrNoEligibleProvider`). The summary call is billed as a `_precompaction_summary` ledger row. Trigger below the window (not at overflow) is load-bearing: a summarizer can only ingest a history that still fits *some* model.
+
 ## Translation
 
 `proxy.Service` is the **only caller of [`../translate`](../translate)**. Keep providers ignorant of cross-format concerns. See [translate/CLAUDE.md](../translate/CLAUDE.md) for the recipe.

--- a/internal/proxy/CLAUDE.md
+++ b/internal/proxy/CLAUDE.md
@@ -37,6 +37,10 @@ The per-turn flow is more than "scorer → dispatch". Pinned session, planner ve
 
 The provider-backed `Summarizer` implementation for handover lives in [`handover.go`](handover.go); the inner-ring `handover` package only defines the contract. On summarizer timeout or error, proxy keeps the full prior history unchanged (it does **not** trim) — a pricier switch turn beats silently dropping the conversation the switched-to model needs.
 
+## Proactive context-window compaction
+
+`ProxyMessages` / `ProxyOpenAIChatCompletion` call [`maybeCompact`](compaction.go) **before** routing so an over-long session is compacted rather than dead-ending in the scorer with no eligible provider. It engages when the estimate reaches `ROUTER_COMPACTION_PCT` (default 0.85) of the largest eligible model's window and runs Claude Code's tiered cascade: (1) `ClearOldToolResults` — local, clears stale tool results; (2) structured 9-section summary via a **window-aware** Anthropic-family summarizer (`SummarizeForCompaction`; haiku when the history fits, `claude-fable-5` for larger) rewritten with `RewriteForCompaction(summary, recentTurns)`; (3) progressive `TrimLastNMessages` rescue. If even the trimmed floor overflows, it returns `ErrContextWindowExceeded` → HTTP 413 (distinct from the "no provider keys" `ErrNoEligibleProvider`). The summary call is billed as a `_precompaction_summary` ledger row. Trigger below the window (not at overflow) is load-bearing: a summarizer can only ingest a history that still fits *some* model.
+
 ## Translation
 
 `proxy.Service` is the **only caller of [`../translate`](../translate)**. Keep providers ignorant of cross-format concerns. See [translate/CLAUDE.md](../translate/CLAUDE.md) for the recipe.

--- a/internal/proxy/compaction.go
+++ b/internal/proxy/compaction.go
@@ -1,0 +1,233 @@
+package proxy
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+
+	"workweave/router/internal/billing"
+	"workweave/router/internal/observability"
+	"workweave/router/internal/router/catalog"
+	"workweave/router/internal/router/handover"
+	"workweave/router/internal/translate"
+)
+
+// ErrContextWindowExceeded is returned when a request's estimated context —
+// even after the full compaction cascade (tool-result cleanup, structured
+// summarization, and recent-turn trimming) — still exceeds the largest context
+// window any eligible model offers. It maps to HTTP 413, distinguishing a
+// genuinely-too-large request from the "no provider keys" flavor of
+// ErrNoEligibleProvider.
+var ErrContextWindowExceeded = errors.New("proxy: request context exceeds every eligible model's window")
+
+const (
+	// DefaultCompactionTriggerPct is the fraction of the largest eligible
+	// model's window at which the cascade engages. Mirrors Claude Code's own
+	// ~0.85 auto-compact trigger: compacting below the window (not at overflow)
+	// keeps the pre-summary history small enough for a summarizer to ingest.
+	DefaultCompactionTriggerPct = 0.85
+	// compactionRecentTurns is how many trailing non-system messages survive a
+	// summarization rewrite, so the model keeps immediate working context.
+	compactionRecentTurns = 12
+	// compactionToolResultKeep is how many trailing tool results Tier-1 cleanup
+	// leaves intact; older ones are replaced with a placeholder.
+	compactionToolResultKeep = 5
+	// compactionSummaryOutputReserve is headroom (summary output + margin) the
+	// selected summarizer model needs above the history it must ingest.
+	compactionSummaryOutputReserve = DefaultCompactionMaxTokens + 8_000
+	// largeWindowSummarizerModel is the big-context Anthropic-family model used
+	// to summarize histories too large for the cheap default summarizer. It is
+	// Anthropic-family so the Anthropic-only ProviderSummarizer can target it
+	// with no cross-format translation.
+	largeWindowSummarizerModel = "claude-fable-5"
+)
+
+// compactionSummarizerModels are the Anthropic-family models the cascade may
+// summarize with, ordered cheapest-first. The selector picks the first whose
+// context window can ingest the (post-Tier-1) history plus summary headroom.
+var compactionSummarizerModels = []string{DefaultHandoverModel, largeWindowSummarizerModel}
+
+// CompactionSummarizer summarizes prior conversation with the structured
+// compaction prompt against an explicit model. Implemented by
+// *ProviderSummarizer; declared here so the Service depends on the behavior,
+// not the concrete type.
+type CompactionSummarizer interface {
+	SummarizeForCompaction(ctx context.Context, env *translate.RequestEnvelope, model string, maxTokens int) (string, handover.Usage, error)
+	Provider() string
+}
+
+// compactionResult records what the cascade did, for logging and billing.
+type compactionResult struct {
+	Applied            bool
+	ToolResultsCleared int
+	Summarized         bool
+	SummaryModel       string
+	SummaryUsage       handover.Usage
+	TrimmedToRecent    int
+	FinalEstimate      int
+}
+
+// maxEligibleContextWindow returns the largest effective context window among
+// available routing models that are not policy-excluded. Zero when none are
+// known (availableModels unset), which disables compaction.
+func (s *Service) maxEligibleContextWindow(policyExcluded map[string]struct{}) int {
+	maxWindow := 0
+	for model := range s.availableModels {
+		if _, excluded := policyExcluded[model]; excluded {
+			continue
+		}
+		if w := contextWindowForRequest(model); w > maxWindow {
+			maxWindow = w
+		}
+	}
+	return maxWindow
+}
+
+// selectCompactionSummarizer returns the cheapest configured summarizer model
+// whose context window can ingest historyTokens plus summary headroom, or ""
+// when none can (caller falls back to trimming).
+func (s *Service) selectCompactionSummarizer(historyTokens int) string {
+	need := historyTokens + compactionSummaryOutputReserve
+	for _, m := range compactionSummarizerModels {
+		if catalog.ContextWindowFor(m) >= need {
+			return m
+		}
+	}
+	return ""
+}
+
+// maybeCompact runs the proactive compaction cascade when the request is at or
+// over compactionTriggerPct of maxWindow (the largest eligible model's window).
+// It mutates env in place — the caller MUST recompute feats/estimates when
+// res.Applied is true. Mirrors Claude Code's tiered cascade: (1) clear old tool
+// results, (2) structured summarization with a window-aware model, (3) trim
+// recent turns. Returns ErrContextWindowExceeded when even a maximally-trimmed
+// request cannot fit maxWindow. A nil/zero-threshold Service, or a request
+// already comfortably under threshold, is a no-op returning res.Applied=false.
+func (s *Service) maybeCompact(ctx context.Context, env *translate.RequestEnvelope, outputReserve, maxWindow int, reqHeaders http.Header) (compactionResult, error) {
+	log := observability.FromContext(ctx)
+	var res compactionResult
+	if s.compactionTriggerPct <= 0 || maxWindow <= 0 || env == nil {
+		return res, nil
+	}
+
+	needed := func() int { return env.ContextOverflowTokenEstimate() + outputReserve }
+	fits := func() bool { return needed() <= maxWindow }
+	trigger := int(float64(maxWindow) * s.compactionTriggerPct)
+	if needed() < trigger {
+		return res, nil
+	}
+	log.Info("Compaction cascade engaged",
+		"needed", needed(),
+		"trigger", trigger,
+		"max_window", maxWindow,
+	)
+
+	// Tier 1: clear stale tool results (cheap, local, no model call).
+	if n := env.ClearOldToolResults(compactionToolResultKeep); n > 0 {
+		res.Applied = true
+		res.ToolResultsCleared = n
+		log.Info("Compaction Tier-1: cleared old tool results", "cleared", n, "needed_after", needed())
+	}
+	if fits() {
+		res.FinalEstimate = needed()
+		return res, nil
+	}
+
+	// Tier 3: structured summarization with a window-aware model.
+	if s.compactionSummarizer != nil {
+		if summary, usage, model, ok := s.runCompactionSummary(ctx, env, reqHeaders); ok {
+			env.RewriteForCompaction(summary, compactionRecentTurns)
+			res.Applied = true
+			res.Summarized = true
+			res.SummaryModel = model
+			res.SummaryUsage = usage
+			log.Info("Compaction Tier-3: history summarized", "summary_model", model, "needed_after", needed())
+		}
+	}
+	if fits() {
+		res.FinalEstimate = needed()
+		return res, nil
+	}
+
+	// Rescue: trim recent turns progressively until the request fits.
+	for _, n := range []int{compactionRecentTurns, 6, 3, 1} {
+		if env.TrimLastNMessages(n) > 0 {
+			res.Applied = true
+			res.TrimmedToRecent = n
+		}
+		if fits() {
+			res.FinalEstimate = needed()
+			log.Info("Compaction rescue: trimmed to recent turns", "kept_recent", n, "needed_after", needed())
+			return res, nil
+		}
+	}
+
+	// Floor: even the last user turn overflows the largest window.
+	res.FinalEstimate = needed()
+	return res, fmt.Errorf("context ~%d tokens over largest window %d: %w", res.FinalEstimate, maxWindow, ErrContextWindowExceeded)
+}
+
+// billCompactionSummary debits the compaction summary call as its own ledger
+// row (mirrors the switch-handover summary billing). No-ops when billing is
+// unwired or the usage carries no tokens.
+func (s *Service) billCompactionSummary(ctx context.Context, requestID, externalID string, usage handover.Usage) {
+	if usage.Model == "" || (usage.InputTokens == 0 && usage.OutputTokens == 0) {
+		return
+	}
+	sumPricing, _ := catalog.PrimaryPriceFor(usage.Model)
+	apiKeyID, _ := ctx.Value(APIKeyIDContextKey{}).(string)
+	s.fireBilling(ctx, billing.DebitInferenceParams{
+		OrganizationID:  externalID,
+		RouterRequestID: requestID + "_precompaction_summary",
+		Model:           usage.Model,
+		Provider:        usage.Provider,
+		InputTokens:     usage.InputTokens,
+		OutputTokens:    usage.OutputTokens,
+		CacheCreation:   usage.CacheCreation,
+		CacheRead:       usage.CacheRead,
+		Pricing:         sumPricing,
+		HasOverride:     billing.HasOverrideFromContext(ctx),
+		APIKeyID:        apiKeyID,
+	})
+}
+
+// runCompactionSummary picks a window-aware summarizer model and dispatches the
+// structured summary call, honoring the tenant-boundary credential rules used
+// by the switch-handover path. Returns ok=false (and logs) when no summarizer
+// fits the history, the tenant boundary forbids the call, or the call fails —
+// in every such case the caller falls through to trimming.
+func (s *Service) runCompactionSummary(ctx context.Context, env *translate.RequestEnvelope, reqHeaders http.Header) (string, handover.Usage, string, bool) {
+	log := observability.FromContext(ctx)
+
+	model := s.selectCompactionSummarizer(env.ContextOverflowTokenEstimate())
+	if model == "" {
+		log.Info("Compaction Tier-3 skipped: history exceeds every summarizer window", "history", env.ContextOverflowTokenEstimate())
+		return "", handover.Usage{}, "", false
+	}
+
+	sumProvider := s.compactionSummarizer.Provider()
+	sumCreds := resolveSummarizerCreds(ctx, sumProvider, reqHeaders)
+	if sumCreds == nil && s.requestUsesNonDeploymentCreds(ctx, reqHeaders) {
+		log.Info("Compaction Tier-3 skipped: would cross tenant boundary", "sum_provider", sumProvider)
+		return "", handover.Usage{}, "", false
+	}
+	summCtx := ctx
+	if sumCreds != nil {
+		summCtx = context.WithValue(ctx, CredentialsContextKey{}, sumCreds)
+	} else {
+		summCtx = clearCredentials(ctx)
+	}
+
+	summary, usage, err := s.compactionSummarizer.SummarizeForCompaction(summCtx, env, model, DefaultCompactionMaxTokens)
+	if err != nil {
+		log.Warn("Compaction summarizer failed; falling back to trim", "err", err, "model", model)
+		return "", handover.Usage{}, "", false
+	}
+	if summary == "" {
+		log.Warn("Compaction summarizer returned empty; falling back to trim", "model", model)
+		return "", handover.Usage{}, "", false
+	}
+	return summary, usage, model, true
+}

--- a/internal/proxy/compaction.go
+++ b/internal/proxy/compaction.go
@@ -10,15 +10,13 @@ import (
 	"workweave/router/internal/observability"
 	"workweave/router/internal/router/catalog"
 	"workweave/router/internal/router/handover"
+	"workweave/router/internal/router/turntype"
 	"workweave/router/internal/translate"
 )
 
-// ErrContextWindowExceeded is returned when a request's estimated context —
-// even after the full compaction cascade (tool-result cleanup, structured
-// summarization, and recent-turn trimming) — still exceeds the largest context
-// window any eligible model offers. It maps to HTTP 413, distinguishing a
-// genuinely-too-large request from the "no provider keys" flavor of
-// ErrNoEligibleProvider.
+// ErrContextWindowExceeded is returned after the full compaction cascade
+// (tool-result cleanup, summarization, trim) still can't fit any eligible
+// model's window. Maps to HTTP 413, distinct from ErrNoEligibleProvider.
 var ErrContextWindowExceeded = errors.New("proxy: request context exceeds every eligible model's window")
 
 const (
@@ -97,18 +95,17 @@ func (s *Service) selectCompactionSummarizer(historyTokens int) string {
 	return ""
 }
 
-// maybeCompact runs the proactive compaction cascade when the request is at or
-// over compactionTriggerPct of maxWindow (the largest eligible model's window).
-// It mutates env in place — the caller MUST recompute feats/estimates when
-// res.Applied is true. Mirrors Claude Code's tiered cascade: (1) clear old tool
-// results, (2) structured summarization with a window-aware model, (3) trim
-// recent turns. Returns ErrContextWindowExceeded when even a maximally-trimmed
-// request cannot fit maxWindow. A nil/zero-threshold Service, or a request
-// already comfortably under threshold, is a no-op returning res.Applied=false.
-func (s *Service) maybeCompact(ctx context.Context, env *translate.RequestEnvelope, outputReserve, maxWindow int, reqHeaders http.Header) (compactionResult, error) {
+// maybeCompact runs the compaction cascade when needed ≥ compactionTriggerPct
+// of maxWindow: (1) clear old tool results, (2) summarize with a window-aware
+// model, (3) progressive trim. Mutates env in place — caller MUST recompute
+// estimates when res.Applied is true. Returns ErrContextWindowExceeded if the
+// history overflows even after all tiers; no-ops when pct is zero/unset, below
+// threshold, or the turn is hard-pinned (Claude Code's own compaction turn must
+// not be rewritten, and probe/title-gen/classifier turns bypass the scorer).
+func (s *Service) maybeCompact(ctx context.Context, env *translate.RequestEnvelope, tt turntype.TurnType, outputReserve, maxWindow int, reqHeaders http.Header) (compactionResult, error) {
 	log := observability.FromContext(ctx)
 	var res compactionResult
-	if s.compactionTriggerPct <= 0 || maxWindow <= 0 || env == nil {
+	if s.compactionTriggerPct <= 0 || maxWindow <= 0 || env == nil || s.isHardPinnedTurn(tt) {
 		return res, nil
 	}
 

--- a/internal/proxy/compaction.go
+++ b/internal/proxy/compaction.go
@@ -67,15 +67,24 @@ type compactionResult struct {
 }
 
 // maxEligibleContextWindow returns the largest effective context window among
-// available routing models that are not policy-excluded. Zero when none are
-// known (availableModels unset), which disables compaction.
-func (s *Service) maxEligibleContextWindow(policyExcluded map[string]struct{}) int {
+// available routing models that are not policy-excluded. A signature-stripping
+// (non-Anthropic) target gets sigSavings added to its window: the translator
+// drops base64 thought-signature blocks before dispatch, so that model can
+// serve sigSavings more of this request's estimated tokens — mirroring the
+// per-model discount in excludeContextOverflowModels, so a signature-heavy
+// session isn't falsely 413'd when a stripping model would still fit. Zero when
+// none are known (availableModels unset), which disables compaction.
+func (s *Service) maxEligibleContextWindow(policyExcluded map[string]struct{}, sigSavings int) int {
 	maxWindow := 0
 	for model := range s.availableModels {
 		if _, excluded := policyExcluded[model]; excluded {
 			continue
 		}
-		if w := contextWindowForRequest(model); w > maxWindow {
+		w := contextWindowForRequest(model)
+		if sigSavings > 0 && modelStripsAnthropicSignatures(model) {
+			w += sigSavings
+		}
+		if w > maxWindow {
 			maxWindow = w
 		}
 	}

--- a/internal/proxy/compaction_test.go
+++ b/internal/proxy/compaction_test.go
@@ -1,0 +1,157 @@
+package proxy
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+
+	"workweave/router/internal/providers"
+	"workweave/router/internal/router/handover"
+	"workweave/router/internal/translate"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeCompactionSummarizer struct {
+	summary   string
+	usage     handover.Usage
+	err       error
+	calls     int
+	lastModel string
+}
+
+func (f *fakeCompactionSummarizer) SummarizeForCompaction(_ context.Context, _ *translate.RequestEnvelope, model string, _ int) (string, handover.Usage, error) {
+	f.calls++
+	f.lastModel = model
+	return f.summary, f.usage, f.err
+}
+
+func (f *fakeCompactionSummarizer) Provider() string { return providers.ProviderAnthropic }
+
+// alternatingAnthropicBody builds an Anthropic body of nMsgs user/assistant
+// messages (starting with user), each padded to ~perMsgPad content bytes.
+func alternatingAnthropicBody(nMsgs, perMsgPad int) []byte {
+	pad := strings.Repeat("x", perMsgPad)
+	var sb strings.Builder
+	sb.WriteString(`{"model":"claude-opus-4-8","system":"sys","messages":[`)
+	for i := range nMsgs {
+		if i > 0 {
+			sb.WriteString(",")
+		}
+		role := "user"
+		if i%2 == 1 {
+			role = "assistant"
+		}
+		sb.WriteString(`{"role":"` + role + `","content":"` + pad + `"}`)
+	}
+	sb.WriteString(`]}`)
+	return []byte(sb.String())
+}
+
+// toolHeavyAnthropicBody builds nPairs of (assistant tool_use, user tool_result)
+// with each tool_result carrying contentBytes of payload.
+func toolHeavyAnthropicBody(nPairs, contentBytes int) []byte {
+	pad := strings.Repeat("y", contentBytes)
+	var sb strings.Builder
+	sb.WriteString(`{"model":"claude-opus-4-8","messages":[`)
+	for i := range nPairs {
+		if i > 0 {
+			sb.WriteString(",")
+		}
+		id := fmt.Sprintf("t%d", i)
+		sb.WriteString(`{"role":"assistant","content":[{"type":"tool_use","id":"` + id + `","name":"read","input":{}}]},`)
+		sb.WriteString(`{"role":"user","content":[{"type":"tool_result","tool_use_id":"` + id + `","content":"` + pad + `"}]}`)
+	}
+	sb.WriteString(`]}`)
+	return []byte(sb.String())
+}
+
+func TestMaybeCompact_UnderThresholdIsNoop(t *testing.T) {
+	s := &Service{compactionTriggerPct: DefaultCompactionTriggerPct, compactionSummarizer: &fakeCompactionSummarizer{}}
+	env, err := translate.ParseAnthropic(alternatingAnthropicBody(2, 20))
+	require.NoError(t, err)
+	before := env.ContextOverflowTokenEstimate()
+
+	res, err := s.maybeCompact(context.Background(), env, 0, 1_000_000, http.Header{})
+	require.NoError(t, err)
+	assert.False(t, res.Applied, "a small request must not be compacted")
+	assert.Equal(t, before, env.ContextOverflowTokenEstimate(), "env must be untouched below threshold")
+}
+
+func TestMaybeCompact_DisabledWhenPctZero(t *testing.T) {
+	s := &Service{} // compactionTriggerPct == 0 disables the cascade
+	env, err := translate.ParseAnthropic(alternatingAnthropicBody(20, 200))
+	require.NoError(t, err)
+	res, err := s.maybeCompact(context.Background(), env, 0, 500, http.Header{})
+	require.NoError(t, err)
+	assert.False(t, res.Applied)
+}
+
+func TestMaybeCompact_Tier1ClearsToolResults(t *testing.T) {
+	s := &Service{compactionTriggerPct: DefaultCompactionTriggerPct} // nil summarizer
+	env, err := translate.ParseAnthropic(toolHeavyAnthropicBody(20, 300))
+	require.NoError(t, err)
+	before := env.ContextOverflowTokenEstimate()
+	// maxWindow between post-Tier-1 and pre-Tier-1 estimates so Tier-1 alone fits.
+	maxWindow := before * 3 / 4
+
+	res, err := s.maybeCompact(context.Background(), env, 0, maxWindow, http.Header{})
+	require.NoError(t, err)
+	assert.True(t, res.Applied)
+	assert.Positive(t, res.ToolResultsCleared, "old tool results should be cleared")
+	assert.False(t, res.Summarized, "nil summarizer must not summarize")
+	assert.LessOrEqual(t, env.ContextOverflowTokenEstimate(), maxWindow, "must fit after Tier-1")
+}
+
+func TestMaybeCompact_Tier3Summarizes(t *testing.T) {
+	fake := &fakeCompactionSummarizer{summary: "SHORT STRUCTURED SUMMARY"}
+	s := &Service{compactionTriggerPct: DefaultCompactionTriggerPct, compactionSummarizer: fake}
+	env, err := translate.ParseAnthropic(alternatingAnthropicBody(20, 200))
+	require.NoError(t, err)
+
+	// Window that Tier-1 (no tool results here) can't satisfy but a
+	// summarize + recent-12 rewrite can.
+	res, err := s.maybeCompact(context.Background(), env, 0, 900, http.Header{})
+	require.NoError(t, err)
+	assert.True(t, res.Applied)
+	assert.True(t, res.Summarized)
+	assert.Equal(t, DefaultHandoverModel, res.SummaryModel, "small history summarizes with the cheap model")
+	assert.Equal(t, 1, fake.calls)
+	assert.Equal(t, DefaultHandoverModel, fake.lastModel)
+}
+
+func TestMaybeCompact_ExceedsFloorReturnsSentinel(t *testing.T) {
+	s := &Service{compactionTriggerPct: DefaultCompactionTriggerPct} // nil summarizer
+	env, err := translate.ParseAnthropic(alternatingAnthropicBody(4, 400))
+	require.NoError(t, err)
+
+	// A window so small that even trimming to a single (large) message overflows.
+	_, err = s.maybeCompact(context.Background(), env, 0, 30, http.Header{})
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrContextWindowExceeded))
+}
+
+func TestSelectCompactionSummarizer_WindowAware(t *testing.T) {
+	s := &Service{}
+	assert.Equal(t, DefaultHandoverModel, s.selectCompactionSummarizer(1_000), "small history → cheap model")
+	assert.Equal(t, largeWindowSummarizerModel, s.selectCompactionSummarizer(300_000), "history over the cheap model's window → large-window model")
+	assert.Equal(t, "", s.selectCompactionSummarizer(5_000_000), "history over every window → none")
+}
+
+func TestMaxEligibleContextWindow(t *testing.T) {
+	s := &Service{availableModels: map[string]struct{}{"claude-haiku-4-5": {}}}
+	assert.Equal(t, 200_000, s.maxEligibleContextWindow(nil))
+	assert.Equal(t, 0, s.maxEligibleContextWindow(map[string]struct{}{"claude-haiku-4-5": {}}), "policy-excluding the only model leaves no window")
+}
+
+func TestClassifyDispatchError_ContextWindowExceeded(t *testing.T) {
+	cls, ok := ClassifyDispatchError(fmt.Errorf("wrapped: %w", ErrContextWindowExceeded))
+	require.True(t, ok)
+	assert.Equal(t, http.StatusRequestEntityTooLarge, cls.Status)
+	assert.Equal(t, DispatchErrorContextWindowExceeded, cls.Kind)
+	assert.True(t, cls.Kind.IsClientError())
+}

--- a/internal/proxy/compaction_test.go
+++ b/internal/proxy/compaction_test.go
@@ -10,6 +10,7 @@ import (
 
 	"workweave/router/internal/providers"
 	"workweave/router/internal/router/handover"
+	"workweave/router/internal/router/turntype"
 	"workweave/router/internal/translate"
 
 	"github.com/stretchr/testify/assert"
@@ -76,7 +77,7 @@ func TestMaybeCompact_UnderThresholdIsNoop(t *testing.T) {
 	require.NoError(t, err)
 	before := env.ContextOverflowTokenEstimate()
 
-	res, err := s.maybeCompact(context.Background(), env, 0, 1_000_000, http.Header{})
+	res, err := s.maybeCompact(context.Background(), env, turntype.MainLoop, 0, 1_000_000, http.Header{})
 	require.NoError(t, err)
 	assert.False(t, res.Applied, "a small request must not be compacted")
 	assert.Equal(t, before, env.ContextOverflowTokenEstimate(), "env must be untouched below threshold")
@@ -86,7 +87,7 @@ func TestMaybeCompact_DisabledWhenPctZero(t *testing.T) {
 	s := &Service{} // compactionTriggerPct == 0 disables the cascade
 	env, err := translate.ParseAnthropic(alternatingAnthropicBody(20, 200))
 	require.NoError(t, err)
-	res, err := s.maybeCompact(context.Background(), env, 0, 500, http.Header{})
+	res, err := s.maybeCompact(context.Background(), env, turntype.MainLoop, 0, 500, http.Header{})
 	require.NoError(t, err)
 	assert.False(t, res.Applied)
 }
@@ -99,7 +100,7 @@ func TestMaybeCompact_Tier1ClearsToolResults(t *testing.T) {
 	// maxWindow between post-Tier-1 and pre-Tier-1 estimates so Tier-1 alone fits.
 	maxWindow := before * 3 / 4
 
-	res, err := s.maybeCompact(context.Background(), env, 0, maxWindow, http.Header{})
+	res, err := s.maybeCompact(context.Background(), env, turntype.MainLoop, 0, maxWindow, http.Header{})
 	require.NoError(t, err)
 	assert.True(t, res.Applied)
 	assert.Positive(t, res.ToolResultsCleared, "old tool results should be cleared")
@@ -115,7 +116,7 @@ func TestMaybeCompact_Tier3Summarizes(t *testing.T) {
 
 	// Window that Tier-1 (no tool results here) can't satisfy but a
 	// summarize + recent-12 rewrite can.
-	res, err := s.maybeCompact(context.Background(), env, 0, 900, http.Header{})
+	res, err := s.maybeCompact(context.Background(), env, turntype.MainLoop, 0, 900, http.Header{})
 	require.NoError(t, err)
 	assert.True(t, res.Applied)
 	assert.True(t, res.Summarized)
@@ -130,9 +131,36 @@ func TestMaybeCompact_ExceedsFloorReturnsSentinel(t *testing.T) {
 	require.NoError(t, err)
 
 	// A window so small that even trimming to a single (large) message overflows.
-	_, err = s.maybeCompact(context.Background(), env, 0, 30, http.Header{})
+	_, err = s.maybeCompact(context.Background(), env, turntype.MainLoop, 0, 30, http.Header{})
 	require.Error(t, err)
 	assert.True(t, errors.Is(err, ErrContextWindowExceeded))
+}
+
+func TestMaybeCompact_SkipsHardPinnedTurns(t *testing.T) {
+	fake := &fakeCompactionSummarizer{summary: "x"}
+	s := &Service{compactionTriggerPct: DefaultCompactionTriggerPct, compactionSummarizer: fake}
+	env, err := translate.ParseAnthropic(alternatingAnthropicBody(20, 200))
+	require.NoError(t, err)
+	before := env.ContextOverflowTokenEstimate()
+
+	// A Compaction turn is Claude Code's own compaction request — the router
+	// must not rewrite it, even when it's over threshold.
+	res, err := s.maybeCompact(context.Background(), env, turntype.Compaction, 0, 900, http.Header{})
+	require.NoError(t, err)
+	assert.False(t, res.Applied, "hard-pinned turns must skip compaction")
+	assert.Equal(t, 0, fake.calls, "summarizer must not be called for a Compaction turn")
+	assert.Equal(t, before, env.ContextOverflowTokenEstimate(), "env must be untouched")
+}
+
+func TestWithCompaction_ZeroPctDisables(t *testing.T) {
+	// ROUTER_COMPACTION_PCT=0 must disable, not fall back to the default.
+	s := (&Service{}).WithCompaction(nil, 0)
+	assert.Equal(t, 0.0, s.compactionTriggerPct)
+	// A negative/out-of-range value falls back to the default.
+	s = (&Service{}).WithCompaction(nil, -1)
+	assert.Equal(t, DefaultCompactionTriggerPct, s.compactionTriggerPct)
+	s = (&Service{}).WithCompaction(nil, 2)
+	assert.Equal(t, DefaultCompactionTriggerPct, s.compactionTriggerPct)
 }
 
 func TestSelectCompactionSummarizer_WindowAware(t *testing.T) {

--- a/internal/proxy/compaction_test.go
+++ b/internal/proxy/compaction_test.go
@@ -172,8 +172,15 @@ func TestSelectCompactionSummarizer_WindowAware(t *testing.T) {
 
 func TestMaxEligibleContextWindow(t *testing.T) {
 	s := &Service{availableModels: map[string]struct{}{"claude-haiku-4-5": {}}}
-	assert.Equal(t, 200_000, s.maxEligibleContextWindow(nil))
-	assert.Equal(t, 0, s.maxEligibleContextWindow(map[string]struct{}{"claude-haiku-4-5": {}}), "policy-excluding the only model leaves no window")
+	assert.Equal(t, 200_000, s.maxEligibleContextWindow(nil, 0))
+	assert.Equal(t, 200_000, s.maxEligibleContextWindow(nil, 5_000), "Anthropic (signature-keeping) models ignore signature savings")
+	assert.Equal(t, 0, s.maxEligibleContextWindow(map[string]struct{}{"claude-haiku-4-5": {}}, 0), "policy-excluding the only model leaves no window")
+
+	// A signature-stripping (non-Anthropic) model gets sigSavings added to its
+	// effective window, matching the context-overflow pre-filter's discount.
+	sStrip := &Service{availableModels: map[string]struct{}{"gpt-5.5": {}}}
+	assert.Equal(t, 1_050_000, sStrip.maxEligibleContextWindow(nil, 0))
+	assert.Equal(t, 1_050_000+5_000, sStrip.maxEligibleContextWindow(nil, 5_000), "stripping model gains signature savings as headroom")
 }
 
 func TestClassifyDispatchError_ContextWindowExceeded(t *testing.T) {

--- a/internal/proxy/dispatch_error.go
+++ b/internal/proxy/dispatch_error.go
@@ -28,6 +28,7 @@ const (
 	DispatchErrorProviderNotConfigured
 	DispatchErrorRequestNotJSONObject
 	DispatchErrorNoEligibleProvider
+	DispatchErrorContextWindowExceeded
 	DispatchErrorInvalidRoutingKnobs
 	DispatchErrorRLPolicyUnavailable
 	DispatchErrorBanditUnavailable
@@ -97,6 +98,14 @@ func ClassifyDispatchError(err error) (DispatchErrorClass, bool) {
 			LogLevel:   "warn",
 			LogMessage: "No eligible provider for request",
 		}, true
+	case errors.Is(err, ErrContextWindowExceeded):
+		return DispatchErrorClass{
+			Kind:       DispatchErrorContextWindowExceeded,
+			Status:     http.StatusRequestEntityTooLarge,
+			Message:    "Request context exceeds the largest available model's context window even after compaction. Reduce the conversation (e.g. /compact or start a new session).",
+			LogLevel:   "warn",
+			LogMessage: "Request context exceeds every eligible model's window after compaction",
+		}, true
 	case errors.Is(err, cluster.ErrInvalidRoutingKnobs):
 		return DispatchErrorClass{
 			Kind:       DispatchErrorInvalidRoutingKnobs,
@@ -152,7 +161,7 @@ func ClassifyDispatchError(err error) (DispatchErrorClass, bool) {
 // rather than "api_error".
 func (k DispatchErrorKind) IsClientError() bool {
 	switch k {
-	case DispatchErrorRequestNotJSONObject, DispatchErrorNoEligibleProvider, DispatchErrorInvalidRoutingKnobs:
+	case DispatchErrorRequestNotJSONObject, DispatchErrorNoEligibleProvider, DispatchErrorContextWindowExceeded, DispatchErrorInvalidRoutingKnobs:
 		return true
 	default:
 		return false

--- a/internal/proxy/handover.go
+++ b/internal/proxy/handover.go
@@ -38,6 +38,31 @@ const handoverInstruction = "Summarize the conversation so far in <= 800 tokens.
 	"Preserve all decisions, file paths, code snippets, and the user's latest intent. " +
 	"Output only the summary text — no preamble, no closing remark."
 
+// DefaultCompactionMaxTokens caps the structured compaction summary. Larger
+// than the switch handover cap because the compaction summary is the ONLY
+// record of the elided history the model keeps — it must carry task state, not
+// just a gist.
+const DefaultCompactionMaxTokens = 4000
+
+// compactionInstruction elicits Claude Code's 9-section structured summary used
+// when a long session is compacted to fit a context window. Unlike the terse
+// switch-handover instruction, this preserves enough task state (pending work,
+// current file, next step) that the model can continue seamlessly, and quotes
+// user-stated constraints verbatim so they keep applying after the elision.
+const compactionInstruction = "The conversation is being compacted to fit the model's context window. " +
+	"Produce a detailed structured summary of everything above under these numbered sections, " +
+	"prioritizing technical accuracy and completeness:\n" +
+	"1. Primary Request and Intent — every explicit user request, in detail.\n" +
+	"2. Key Technical Concepts — technologies, frameworks, and patterns in play.\n" +
+	"3. Files and Code Sections — files examined/modified, with key snippets and why they matter.\n" +
+	"4. Errors and Fixes — problems hit, fixes applied, and user feedback received.\n" +
+	"5. Problem Solving — approaches tried and reasoning, not just outcomes.\n" +
+	"6. All User Messages (verbatim) — quote every non-tool user message exactly, especially any stated constraints or policies; do not paraphrase.\n" +
+	"7. Pending Tasks — requested work not yet completed.\n" +
+	"8. Current Work — precisely what was being done just before this summary, with filenames and state.\n" +
+	"9. Next Step — the immediate next action, aligned to the user's most recent request.\n" +
+	"Output only the summary text — no preamble, no closing remark."
+
 // ProviderSummarizer adapts a providers.Client to handover.Summarizer by
 // building a small Anthropic Messages request from the prior conversation.
 type ProviderSummarizer struct {
@@ -87,6 +112,29 @@ var ErrEmptySummary = errors.New("handover: upstream returned no summary text")
 // usage for a separate ledger row. On failure returns ("", zero Usage, err)
 // so the caller falls back to the full prior history.
 func (s *ProviderSummarizer) Summarize(ctx context.Context, env *translate.RequestEnvelope) (string, handover.Usage, error) {
+	return s.summarize(ctx, env, s.model, handoverInstruction, s.maxTokens, "handover")
+}
+
+// SummarizeForCompaction summarizes env with the structured 9-section
+// compaction prompt, targeting an explicit model (the window-aware selection
+// happens in the caller) and a larger output cap. Used by the context-window
+// compaction cascade, not the switch-handover path. Same failure contract as
+// Summarize.
+func (s *ProviderSummarizer) SummarizeForCompaction(ctx context.Context, env *translate.RequestEnvelope, model string, maxTokens int) (string, handover.Usage, error) {
+	if model == "" {
+		model = s.model
+	}
+	if maxTokens <= 0 {
+		maxTokens = DefaultCompactionMaxTokens
+	}
+	return s.summarize(ctx, env, model, compactionInstruction, maxTokens, "compaction")
+}
+
+// summarize builds an Anthropic Messages call from env with the given
+// instruction/model/cap and dispatches it under a hard timeout. kind is a log
+// label ("handover" or "compaction"). On any failure returns ("", zero, err)
+// so callers fall back to the full history.
+func (s *ProviderSummarizer) summarize(ctx context.Context, env *translate.RequestEnvelope, model, instruction string, maxTokens int, kind string) (string, handover.Usage, error) {
 	log := observability.FromContext(ctx)
 	if env == nil {
 		return "", handover.Usage{}, errors.New("handover: nil envelope")
@@ -95,9 +143,9 @@ func (s *ProviderSummarizer) Summarize(ctx context.Context, env *translate.Reque
 		return "", handover.Usage{}, errors.New("handover: nil provider client")
 	}
 
-	body, err := buildHandoverRequestBody(env, s.model, s.maxTokens)
+	body, err := buildSummaryRequestBody(env, model, instruction, maxTokens)
 	if err != nil {
-		return "", handover.Usage{}, fmt.Errorf("build handover request: %w", err)
+		return "", handover.Usage{}, fmt.Errorf("build %s request: %w", kind, err)
 	}
 
 	callCtx, cancel := context.WithTimeout(ctx, s.timeout)
@@ -115,36 +163,36 @@ func (s *ProviderSummarizer) Summarize(ctx context.Context, env *translate.Reque
 
 	decision := router.Decision{
 		Provider: providers.ProviderAnthropic,
-		Model:    s.model,
-		Reason:   "handover_summary",
+		Model:    model,
+		Reason:   kind + "_summary",
 	}
 
 	proxyErr := s.client.Proxy(callCtx, decision, prep, rec, req)
 	if proxyErr != nil {
-		log.Warn("Handover summarizer upstream call failed", "err", proxyErr, "model", s.model)
+		log.Warn("Summarizer upstream call failed", "kind", kind, "err", proxyErr, "model", model)
 		return "", handover.Usage{}, proxyErr
 	}
 	if callCtx.Err() != nil {
-		log.Warn("Handover summarizer timed out", "err", callCtx.Err(), "model", s.model)
+		log.Warn("Summarizer timed out", "kind", kind, "err", callCtx.Err(), "model", model)
 		return "", handover.Usage{}, callCtx.Err()
 	}
 	if rec.Code >= 400 {
 		err := fmt.Errorf("handover: upstream status %d", rec.Code)
-		log.Warn("Handover summarizer non-2xx", "status", rec.Code, "model", s.model)
+		log.Warn("Summarizer non-2xx", "kind", kind, "status", rec.Code, "model", model)
 		return "", handover.Usage{}, err
 	}
 
 	respBody, err := io.ReadAll(rec.Body)
 	if err != nil {
-		return "", handover.Usage{}, fmt.Errorf("read handover response: %w", err)
+		return "", handover.Usage{}, fmt.Errorf("read %s response: %w", kind, err)
 	}
 	text := extractAnthropicAssistantText(respBody)
 	if text == "" {
-		log.Warn("Handover summarizer extracted no text", "model", s.model, "body_bytes", len(respBody))
+		log.Warn("Summarizer extracted no text", "kind", kind, "model", model, "body_bytes", len(respBody))
 		return "", handover.Usage{}, ErrEmptySummary
 	}
 	usage := extractAnthropicUsage(respBody)
-	usage.Model = s.model
+	usage.Model = model
 	usage.Provider = providers.ProviderAnthropic
 	return text, usage, nil
 }
@@ -167,10 +215,10 @@ func extractAnthropicUsage(body []byte) handover.Usage {
 	}
 }
 
-// buildHandoverRequestBody builds a non-streaming Anthropic Messages request
-// from the envelope's prior conversation, injecting the summary instruction
-// and overriding model/max_tokens/stream.
-func buildHandoverRequestBody(env *translate.RequestEnvelope, model string, maxTokens int) ([]byte, error) {
+// buildSummaryRequestBody builds a non-streaming Anthropic Messages request
+// from the envelope's prior conversation, injecting the given summary
+// instruction and overriding model/max_tokens/stream.
+func buildSummaryRequestBody(env *translate.RequestEnvelope, model, instruction string, maxTokens int) ([]byte, error) {
 	prep, err := env.PrepareAnthropic(nil, translate.EmitOptions{TargetModel: model})
 	if err != nil {
 		return nil, fmt.Errorf("prepare anthropic body: %w", err)
@@ -190,7 +238,7 @@ func buildHandoverRequestBody(env *translate.RequestEnvelope, model string, maxT
 		return nil, fmt.Errorf("set max_tokens: %w", err)
 	}
 
-	body, err = appendUserInstruction(body, handoverInstruction)
+	body, err = appendUserInstruction(body, instruction)
 	if err != nil {
 		return nil, fmt.Errorf("append instruction: %w", err)
 	}

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -1706,7 +1706,7 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 	// fit the largest eligible model BEFORE routing, so a genuinely huge
 	// session is compacted (à la Claude Code) instead of dead-ending in the
 	// scorer with no eligible provider. Mutates env; feats is recomputed after.
-	maxEligibleWindow := s.maxEligibleContextWindow(baseExcluded)
+	maxEligibleWindow := s.maxEligibleContextWindow(baseExcluded, env.SignatureTokenSavings())
 	compRes, compErr := s.maybeCompact(ctx, env, turntype.DetectFromEnvelope(env, feats, ""), outputReserve, maxEligibleWindow, r.Header)
 	if compErr != nil {
 		log.Warn("Compaction could not fit request to any eligible model",
@@ -3471,7 +3471,7 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 	// Codex passthrough bodies, which are forwarded verbatim.
 	var compResOAI compactionResult
 	if !codexPassthrough {
-		maxEligibleWindowOAI := s.maxEligibleContextWindow(baseExcludedOAI)
+		maxEligibleWindowOAI := s.maxEligibleContextWindow(baseExcludedOAI, env.SignatureTokenSavings())
 		var compErrOAI error
 		compResOAI, compErrOAI = s.maybeCompact(ctx, env, turntype.DetectFromEnvelope(env, feats, subAgentHint), outputReserveOAI, maxEligibleWindowOAI, r.Header)
 		if compErrOAI != nil {

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -170,6 +170,14 @@ type Service struct {
 	// summarizer produces a bounded-cost handover summary on switch turns.
 	// nil passes the full prior history through unchanged.
 	summarizer handover.Summarizer
+	// compactionSummarizer produces the structured summary for the proactive
+	// context-window compaction cascade (maybeCompact). nil disables Tier-3
+	// summarization (the cascade still runs Tier-1 cleanup + trim rescue).
+	compactionSummarizer CompactionSummarizer
+	// compactionTriggerPct is the fraction of the largest eligible model's
+	// context window at which the compaction cascade engages. Zero disables
+	// compaction entirely.
+	compactionTriggerPct float64
 	// availableModels is the boot-time set of model names whose providers are
 	// registered. Read by the planner to decide whether a pin's model is still
 	// routable.
@@ -1013,6 +1021,19 @@ func (s *Service) WithSummarizer(sz handover.Summarizer) *Service {
 	return s
 }
 
+// WithCompaction installs the summarizer and trigger threshold for the
+// proactive context-window compaction cascade (maybeCompact). A zero or
+// out-of-range pct falls back to compactionTriggerPctDefault; a nil summarizer
+// leaves Tier-3 summarization off (Tier-1 cleanup + trim rescue still run).
+func (s *Service) WithCompaction(cs CompactionSummarizer, pct float64) *Service {
+	s.compactionSummarizer = cs
+	if pct <= 0 || pct > 1 {
+		pct = DefaultCompactionTriggerPct
+	}
+	s.compactionTriggerPct = pct
+	return s
+}
+
 // WithAvailableModels installs the boot-time set of routable model names.
 // The planner consults this set so a pin whose model is no longer
 // available forces a switch. nil treats every model as available.
@@ -1667,6 +1688,40 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 		outputReserve = feats.MaxTokens
 	}
 	baseExcluded := s.excludedModelsForRequest(ctx)
+
+	// Snapshot inbound (client-sent) state BEFORE any env rewrite. The
+	// compaction tracker, spiral scan, and tool-output telemetry must compare
+	// what the client actually sent, not a router-shortened body — either the
+	// proactive compaction just below or runTurnLoop's switch-handover rewrite.
+	inboundToolCallCount := len(env.AssistantToolCallSignatures())
+	var inboundSpiralSignals spiralSignals
+	if s.spiralShadowEnabled {
+		inboundSpiralSignals = computeSpiralSignals(env, feats.MessageCount)
+	}
+	inboundLastUser := env.LastUserMessage()
+
+	// Proactive context-window compaction: shrink an over-long conversation to
+	// fit the largest eligible model BEFORE routing, so a genuinely huge
+	// session is compacted (à la Claude Code) instead of dead-ending in the
+	// scorer with no eligible provider. Mutates env; feats is recomputed after.
+	maxEligibleWindow := s.maxEligibleContextWindow(baseExcluded)
+	compRes, compErr := s.maybeCompact(ctx, env, outputReserve, maxEligibleWindow, r.Header)
+	if compErr != nil {
+		log.Warn("Compaction could not fit request to any eligible model",
+			"err", compErr, "final_estimate", compRes.FinalEstimate, "max_window", maxEligibleWindow, "requested_model", feats.Model)
+		return compErr
+	}
+	if compRes.Applied {
+		feats = env.RoutingFeatures(embedFlag)
+		log.Info("Proactive compaction applied",
+			"tool_results_cleared", compRes.ToolResultsCleared,
+			"summarized", compRes.Summarized,
+			"summary_model", compRes.SummaryModel,
+			"trimmed_to_recent", compRes.TrimmedToRecent,
+			"final_estimate", compRes.FinalEstimate,
+		)
+	}
+
 	overflowEstimate := env.ContextOverflowTokenEstimate()
 	excluded, ctxOverflowed := excludeContextOverflowModels(overflowEstimate, env.SignatureTokenSavings(), outputReserve, baseExcluded, s.availableModels)
 	if len(ctxOverflowed) > 0 {
@@ -1683,25 +1738,6 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 			"excluded_models", strings.Join(geminiUnsigned, ","),
 		)
 	}
-
-	// Snapshot inbound tool-call count before runTurnLoop, which may mutate env
-	// via a model-switch handover's RewriteForHandover. The compaction tracker
-	// must compare what the client actually sent, not the post-rewrite count,
-	// to avoid false-positives when the router itself shortened the window.
-	inboundToolCallCount := len(env.AssistantToolCallSignatures())
-
-	// Same reasoning for spiral signals: a handover-rewritten history would
-	// wipe error streaks / thrash / repetition on exactly the turns that cross
-	// threshold.
-	var inboundSpiralSignals spiralSignals
-	if s.spiralShadowEnabled {
-		inboundSpiralSignals = computeSpiralSignals(env, feats.MessageCount)
-	}
-
-	// Same reasoning for tool-output size: a handover rewrite strips
-	// tool_result blocks from env, which would zero out tool_result_bytes for
-	// a genuine tool_result turn at telemetry time.
-	inboundLastUser := env.LastUserMessage()
 
 	routeStart := time.Now()
 	req := router.Request{
@@ -2497,6 +2533,9 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 	// upstream call since the cache-hit branch above already returned.
 	if proxyErr == nil {
 		s.emitBilling(ctx, requestID, externalID, decision, actPricing, routeRes, in, out, cacheCreation, cacheRead)
+		if compRes.Summarized {
+			s.billCompactionSummary(ctx, requestID, externalID, compRes.SummaryUsage)
+		}
 		if compactionHandoverOutcome.Invoked && !compactionHandoverOutcome.FallbackToFullHistory {
 			sumUsage := compactionHandoverOutcome.SummaryUsage
 			if sumUsage.Model != "" && (sumUsage.InputTokens > 0 || sumUsage.OutputTokens > 0) {
@@ -3421,6 +3460,35 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 		outputReserveOAI = feats.MaxTokens
 	}
 	baseExcludedOAI := s.excludedModelsForRequest(ctx)
+
+	// Snapshot the inbound tool-output size before any env rewrite (proactive
+	// compaction below, or runTurnLoop's switch handover); see toolResultBytesPtr.
+	inboundLastUser := env.LastUserMessage()
+
+	// Proactive context-window compaction, as in ProxyMessages. Skipped for
+	// Codex passthrough bodies, which are forwarded verbatim.
+	var compResOAI compactionResult
+	if !codexPassthrough {
+		maxEligibleWindowOAI := s.maxEligibleContextWindow(baseExcludedOAI)
+		var compErrOAI error
+		compResOAI, compErrOAI = s.maybeCompact(ctx, env, outputReserveOAI, maxEligibleWindowOAI, r.Header)
+		if compErrOAI != nil {
+			log.Warn("Compaction could not fit request to any eligible model",
+				"err", compErrOAI, "final_estimate", compResOAI.FinalEstimate, "max_window", maxEligibleWindowOAI, "requested_model", feats.Model)
+			return compErrOAI
+		}
+		if compResOAI.Applied {
+			feats = env.RoutingFeatures(embedFlag)
+			log.Info("Proactive compaction applied",
+				"tool_results_cleared", compResOAI.ToolResultsCleared,
+				"summarized", compResOAI.Summarized,
+				"summary_model", compResOAI.SummaryModel,
+				"trimmed_to_recent", compResOAI.TrimmedToRecent,
+				"final_estimate", compResOAI.FinalEstimate,
+			)
+		}
+	}
+
 	overflowEstimateOAI := env.ContextOverflowTokenEstimate()
 	excludedOAI, ctxOverflowedOAI := excludeContextOverflowModels(overflowEstimateOAI, env.SignatureTokenSavings(), outputReserveOAI, baseExcludedOAI, s.availableModels)
 	if len(ctxOverflowedOAI) > 0 {
@@ -3437,10 +3505,6 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 			"excluded_models", strings.Join(geminiUnsignedOAI, ","),
 		)
 	}
-
-	// Snapshot the inbound tool-output size before runTurnLoop (which may rewrite
-	// env via switch handover); see toolResultBytesPtr.
-	inboundLastUser := env.LastUserMessage()
 
 	routeStart := time.Now()
 	routeRes, err := s.runTurnLoop(ctx, env, feats, apiKeyID, installationID, subAgentHint, r.Header, router.Request{
@@ -3881,6 +3945,9 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 
 	if proxyErr == nil {
 		s.emitBilling(ctx, requestID, externalID, decision, actPricing, routeRes, in, out, cacheCreation, cacheRead)
+		if compResOAI.Summarized {
+			s.billCompactionSummary(ctx, requestID, externalID, compResOAI.SummaryUsage)
+		}
 	}
 
 	// See ProxyMessages for the two-strike eviction rationale.

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -1850,8 +1850,12 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 	var compactionHandoverOutcome handoverOutcome
 	// Detection runs pre-routing in runTurnLoop; routeRes.PrefixTrimmed carries
 	// the verdict. Skip if a model-switch handover already rewrote env this
-	// turn — a second rewrite would double-trim it.
-	if decision.Provider != providers.ProviderAnthropic && !routeRes.HardPinned && !routeRes.Handover.Invoked && routeRes.PrefixTrimmed {
+	// turn — a second rewrite would double-trim it. Also skip when the proactive
+	// compaction cascade already ran this turn: it shrank env (which trips the
+	// client-trim detector as a false positive), so a compaction handover here
+	// would be a redundant summarizer call that also discards the recent-turn
+	// tail maybeCompact deliberately kept.
+	if decision.Provider != providers.ProviderAnthropic && !routeRes.HardPinned && !routeRes.Handover.Invoked && !compRes.Applied && routeRes.PrefixTrimmed {
 		log.Info("Context trimming detected on non-Anthropic route; rewriting context with handover summary",
 			"message_count", feats.MessageCount,
 			"tool_call_count", inboundToolCallCount,

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -1022,12 +1022,14 @@ func (s *Service) WithSummarizer(sz handover.Summarizer) *Service {
 }
 
 // WithCompaction installs the summarizer and trigger threshold for the
-// proactive context-window compaction cascade (maybeCompact). A zero or
-// out-of-range pct falls back to compactionTriggerPctDefault; a nil summarizer
-// leaves Tier-3 summarization off (Tier-1 cleanup + trim rescue still run).
+// proactive context-window compaction cascade (maybeCompact). pct == 0
+// disables compaction (operators set ROUTER_COMPACTION_PCT=0 to turn the
+// cascade off); an out-of-range pct (negative or > 1) falls back to
+// DefaultCompactionTriggerPct. A nil summarizer leaves Tier-3 summarization off
+// (Tier-1 cleanup + trim rescue still run).
 func (s *Service) WithCompaction(cs CompactionSummarizer, pct float64) *Service {
 	s.compactionSummarizer = cs
-	if pct <= 0 || pct > 1 {
+	if pct < 0 || pct > 1 {
 		pct = DefaultCompactionTriggerPct
 	}
 	s.compactionTriggerPct = pct
@@ -1705,7 +1707,7 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 	// session is compacted (à la Claude Code) instead of dead-ending in the
 	// scorer with no eligible provider. Mutates env; feats is recomputed after.
 	maxEligibleWindow := s.maxEligibleContextWindow(baseExcluded)
-	compRes, compErr := s.maybeCompact(ctx, env, outputReserve, maxEligibleWindow, r.Header)
+	compRes, compErr := s.maybeCompact(ctx, env, turntype.DetectFromEnvelope(env, feats, ""), outputReserve, maxEligibleWindow, r.Header)
 	if compErr != nil {
 		log.Warn("Compaction could not fit request to any eligible model",
 			"err", compErr, "final_estimate", compRes.FinalEstimate, "max_window", maxEligibleWindow, "requested_model", feats.Model)
@@ -3471,7 +3473,7 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 	if !codexPassthrough {
 		maxEligibleWindowOAI := s.maxEligibleContextWindow(baseExcludedOAI)
 		var compErrOAI error
-		compResOAI, compErrOAI = s.maybeCompact(ctx, env, outputReserveOAI, maxEligibleWindowOAI, r.Header)
+		compResOAI, compErrOAI = s.maybeCompact(ctx, env, turntype.DetectFromEnvelope(env, feats, subAgentHint), outputReserveOAI, maxEligibleWindowOAI, r.Header)
 		if compErrOAI != nil {
 			log.Warn("Compaction could not fit request to any eligible model",
 				"err", compErrOAI, "final_estimate", compResOAI.FinalEstimate, "max_window", maxEligibleWindowOAI, "requested_model", feats.Model)

--- a/internal/proxy/turnloop.go
+++ b/internal/proxy/turnloop.go
@@ -124,6 +124,22 @@ type handoverOutcome struct {
 	SummaryUsage handover.Usage
 }
 
+// isHardPinnedTurn reports whether a turn type bypasses pin lookup/write,
+// planner, and scorer entirely via the boot-time hard pin. These turns are
+// also skipped by proactive compaction: they are either tiny (probe/title-gen/
+// classifier) or carry their own dedicated flow (Claude Code's compaction turn,
+// whose request the router must not rewrite).
+func (s *Service) isHardPinnedTurn(tt turntype.TurnType) bool {
+	switch tt {
+	case turntype.Compaction, turntype.Probe, turntype.TitleGen, turntype.Classifier:
+		return true
+	case turntype.SubAgentDispatch:
+		return s.hardPinExplore
+	default:
+		return false
+	}
+}
+
 // runTurnLoop is the format-agnostic routing orchestrator: detect turn type,
 // short-circuit hard pins, load pin, run scorer, hand to planner, and on
 // switch attempt bounded-cost handover.
@@ -163,11 +179,7 @@ func (s *Service) runTurnLoop(
 	// probes before the first real turn, and Claude Code fires title-gen
 	// ~25ms before the real-conv call — an anchored pin would leak the
 	// cheap-model decision into the conversation that follows.
-	if res.TurnType == turntype.Compaction ||
-		res.TurnType == turntype.Probe ||
-		res.TurnType == turntype.TitleGen ||
-		res.TurnType == turntype.Classifier ||
-		(res.TurnType == turntype.SubAgentDispatch && s.hardPinExplore) {
+	if s.isHardPinnedTurn(res.TurnType) {
 		provider, model := s.hardPinProvider, s.hardPinModel
 		// The boot-time hard-pin was computed over every registered provider,
 		// but a BYOK request may only authenticate to a subset. Resolve

--- a/internal/translate/compaction.go
+++ b/internal/translate/compaction.go
@@ -1,0 +1,367 @@
+package translate
+
+import (
+	"encoding/json"
+	"strings"
+
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
+)
+
+// ClearedToolResultPlaceholder replaces the body of an old tool result during
+// Tier-1 compaction cleanup. Mirrors Claude Code's own placeholder so a reader
+// (human or model) recognizes that the content was elided, not lost.
+const ClearedToolResultPlaceholder = "[Old tool result content cleared]"
+
+// ClearOldToolResults replaces the content of every tool result EXCEPT the most
+// recent keepRecent with ClearedToolResultPlaceholder, leaving message and
+// tool-call structure intact. This is the cheap, model-free first tier of
+// compaction: tool results (file reads, command output) dominate an agentic
+// session's tokens, so clearing stale ones alone often brings a request back
+// under a model's window without summarizing. Returns the number of tool
+// results cleared. No-ops (returns 0) when there are at most keepRecent.
+//
+// Pure: no I/O. keepRecent < 0 is treated as 0.
+func (e *RequestEnvelope) ClearOldToolResults(keepRecent int) int {
+	if e == nil {
+		return 0
+	}
+	keepRecent = max(keepRecent, 0)
+	switch e.format {
+	case FormatAnthropic:
+		return e.clearOldToolResultsAnthropic(keepRecent)
+	case FormatOpenAI:
+		return e.clearOldToolResultsOpenAI(keepRecent)
+	case FormatGemini:
+		return e.clearOldToolResultsGemini(keepRecent)
+	default:
+		return 0
+	}
+}
+
+// RewriteForCompaction keeps system context + a synthesized summary + the most
+// recent keepRecentTurns non-system messages, eliding everything older. Unlike
+// RewriteForHandover (which keeps only the latest user message), this preserves
+// a tail of recent turns so the model retains immediate working context, which
+// is what Claude Code's own compaction does. Tool results orphaned by the trim
+// (their tool_use fell in the elided region) are stripped so the request stays
+// wire-valid. The recent window is aligned to begin on a user message so the
+// [summary, ...recent] sequence alternates roles correctly. Returns the number
+// of original messages elided.
+//
+// Pure: no I/O. keepRecentTurns <= 0 is treated as 1 (summary + latest user).
+func (e *RequestEnvelope) RewriteForCompaction(summary string, keepRecentTurns int) int {
+	if e == nil {
+		return 0
+	}
+	keepRecentTurns = max(keepRecentTurns, 1)
+	switch e.format {
+	case FormatAnthropic:
+		return e.rewriteAnthropicForCompaction(summary, keepRecentTurns)
+	case FormatOpenAI:
+		return e.rewriteOpenAIForCompaction(summary, keepRecentTurns)
+	case FormatGemini:
+		return e.rewriteGeminiForCompaction(summary, keepRecentTurns)
+	default:
+		return 0
+	}
+}
+
+// userAlignedStart returns the index at which to begin a recent-message window
+// of size keepRecent drawn from msgs, advanced forward to the first user
+// message so the window starts on a user turn. Falls back to the last user
+// message's index when the window contains none.
+func userAlignedStart(msgs []gjson.Result, keepRecent int) int {
+	start := len(msgs) - keepRecent
+	if start < 0 {
+		start = 0
+	}
+	for start < len(msgs) && msgs[start].Get("role").String() != "user" {
+		start++
+	}
+	if start >= len(msgs) {
+		for i := len(msgs) - 1; i >= 0; i-- {
+			if msgs[i].Get("role").String() == "user" {
+				return i
+			}
+		}
+		return len(msgs)
+	}
+	return start
+}
+
+func (e *RequestEnvelope) clearOldToolResultsAnthropic(keepRecent int) int {
+	msgs := gjson.GetBytes(e.body, "messages")
+	if !msgs.IsArray() {
+		return 0
+	}
+	all := msgs.Array()
+
+	total := 0
+	for _, m := range all {
+		if m.Get("role").String() != "user" {
+			continue
+		}
+		m.Get("content").ForEach(func(_, b gjson.Result) bool {
+			if b.Get("type").String() == "tool_result" {
+				total++
+			}
+			return true
+		})
+	}
+	cutoff := total - keepRecent
+	if cutoff <= 0 {
+		return 0
+	}
+
+	seen, cleared := 0, 0
+	rebuilt := make([]string, 0, len(all))
+	for _, m := range all {
+		content := m.Get("content")
+		if m.Get("role").String() != "user" || !content.IsArray() {
+			rebuilt = append(rebuilt, m.Raw)
+			continue
+		}
+		newBlocks := make([]string, 0, len(content.Array()))
+		changed := false
+		content.ForEach(func(_, b gjson.Result) bool {
+			if b.Get("type").String() == "tool_result" {
+				seen++
+				if seen <= cutoff {
+					nb, err := sjson.SetBytes([]byte(b.Raw), "content", ClearedToolResultPlaceholder)
+					if err == nil {
+						newBlocks = append(newBlocks, string(nb))
+						cleared++
+						changed = true
+						return true
+					}
+				}
+			}
+			newBlocks = append(newBlocks, b.Raw)
+			return true
+		})
+		if !changed {
+			rebuilt = append(rebuilt, m.Raw)
+			continue
+		}
+		newContent := "[" + strings.Join(newBlocks, ",") + "]"
+		nm, err := sjson.SetRawBytes([]byte(m.Raw), "content", []byte(newContent))
+		if err != nil {
+			rebuilt = append(rebuilt, m.Raw)
+			continue
+		}
+		rebuilt = append(rebuilt, string(nm))
+	}
+	if cleared == 0 {
+		return 0
+	}
+	return e.setMessages(rebuilt, cleared)
+}
+
+func (e *RequestEnvelope) clearOldToolResultsOpenAI(keepRecent int) int {
+	msgs := gjson.GetBytes(e.body, "messages")
+	if !msgs.IsArray() {
+		return 0
+	}
+	all := msgs.Array()
+
+	total := 0
+	for _, m := range all {
+		if m.Get("role").String() == "tool" {
+			total++
+		}
+	}
+	cutoff := total - keepRecent
+	if cutoff <= 0 {
+		return 0
+	}
+
+	seen, cleared := 0, 0
+	rebuilt := make([]string, 0, len(all))
+	for _, m := range all {
+		if m.Get("role").String() != "tool" {
+			rebuilt = append(rebuilt, m.Raw)
+			continue
+		}
+		seen++
+		if seen <= cutoff {
+			nm, err := sjson.SetBytes([]byte(m.Raw), "content", ClearedToolResultPlaceholder)
+			if err == nil {
+				rebuilt = append(rebuilt, string(nm))
+				cleared++
+				continue
+			}
+		}
+		rebuilt = append(rebuilt, m.Raw)
+	}
+	if cleared == 0 {
+		return 0
+	}
+	return e.setMessages(rebuilt, cleared)
+}
+
+func (e *RequestEnvelope) clearOldToolResultsGemini(keepRecent int) int {
+	contents := gjson.GetBytes(e.body, "contents")
+	if !contents.IsArray() {
+		return 0
+	}
+	all := contents.Array()
+
+	total := 0
+	for _, c := range all {
+		c.Get("parts").ForEach(func(_, p gjson.Result) bool {
+			if p.Get("functionResponse").Exists() {
+				total++
+			}
+			return true
+		})
+	}
+	cutoff := total - keepRecent
+	if cutoff <= 0 {
+		return 0
+	}
+
+	seen, cleared := 0, 0
+	rebuilt := make([]string, 0, len(all))
+	for _, c := range all {
+		parts := c.Get("parts")
+		if !parts.IsArray() {
+			rebuilt = append(rebuilt, c.Raw)
+			continue
+		}
+		newParts := make([]string, 0, len(parts.Array()))
+		changed := false
+		parts.ForEach(func(_, p gjson.Result) bool {
+			if p.Get("functionResponse").Exists() {
+				seen++
+				if seen <= cutoff {
+					np, err := sjson.SetBytes([]byte(p.Raw), "functionResponse.response", map[string]any{"result": ClearedToolResultPlaceholder})
+					if err == nil {
+						newParts = append(newParts, string(np))
+						cleared++
+						changed = true
+						return true
+					}
+				}
+			}
+			newParts = append(newParts, p.Raw)
+			return true
+		})
+		if !changed {
+			rebuilt = append(rebuilt, c.Raw)
+			continue
+		}
+		newPartsRaw := "[" + strings.Join(newParts, ",") + "]"
+		nc, err := sjson.SetRawBytes([]byte(c.Raw), "parts", []byte(newPartsRaw))
+		if err != nil {
+			rebuilt = append(rebuilt, c.Raw)
+			continue
+		}
+		rebuilt = append(rebuilt, string(nc))
+	}
+	if cleared == 0 {
+		return 0
+	}
+	out, err := sjson.SetRawBytes(e.body, "contents", []byte("["+strings.Join(rebuilt, ",")+"]"))
+	if err != nil {
+		return 0
+	}
+	e.body = out
+	return cleared
+}
+
+// setMessages writes rebuilt back to the "messages" array and returns ret on
+// success, 0 on marshal failure. Shared by the Anthropic/OpenAI message-array
+// rewriters.
+func (e *RequestEnvelope) setMessages(rebuilt []string, ret int) int {
+	out, err := sjson.SetRawBytes(e.body, "messages", []byte("["+strings.Join(rebuilt, ",")+"]"))
+	if err != nil {
+		return 0
+	}
+	e.body = out
+	return ret
+}
+
+func (e *RequestEnvelope) rewriteAnthropicForCompaction(summary string, keepRecent int) int {
+	msgs := gjson.GetBytes(e.body, "messages")
+	if !msgs.IsArray() {
+		return 0
+	}
+	all := msgs.Array()
+	if len(all) == 0 {
+		return 0
+	}
+	start := userAlignedStart(all, keepRecent)
+	cleaned := stripOrphanedAnthropicToolResults(all[start:])
+	rebuilt := append([]string{anthropicAssistantSummaryBlock(summary)}, cleaned...)
+	elided := max(len(all)-len(cleaned), 0)
+	return e.setMessages(rebuilt, elided)
+}
+
+func (e *RequestEnvelope) rewriteOpenAIForCompaction(summary string, keepRecent int) int {
+	msgs := gjson.GetBytes(e.body, "messages")
+	if !msgs.IsArray() {
+		return 0
+	}
+	all := msgs.Array()
+	if len(all) == 0 {
+		return 0
+	}
+	systems := make([]string, 0)
+	others := make([]gjson.Result, 0, len(all))
+	for _, m := range all {
+		if m.Get("role").String() == "system" {
+			systems = append(systems, m.Raw)
+			continue
+		}
+		others = append(others, m)
+	}
+	if len(others) == 0 {
+		return 0
+	}
+	start := userAlignedStart(others, keepRecent)
+	keptRaw := make([]string, 0, len(others)-start)
+	for _, m := range others[start:] {
+		keptRaw = append(keptRaw, m.Raw)
+	}
+	cleaned := stripOrphanedOpenAIToolMessages(keptRaw)
+	rebuilt := make([]string, 0, len(systems)+1+len(cleaned))
+	rebuilt = append(rebuilt, systems...)
+	rebuilt = append(rebuilt, openAIAssistantSummaryMessage(summary))
+	rebuilt = append(rebuilt, cleaned...)
+	elided := max(len(others)-len(cleaned), 0)
+	return e.setMessages(rebuilt, elided)
+}
+
+func (e *RequestEnvelope) rewriteGeminiForCompaction(summary string, keepRecent int) int {
+	contents := gjson.GetBytes(e.body, "contents")
+	if !contents.IsArray() {
+		return 0
+	}
+	all := contents.Array()
+	if len(all) == 0 {
+		return 0
+	}
+	start := userAlignedStart(all, keepRecent)
+	kept := all[start:]
+
+	tagged := HandoverSummaryTag + summary
+	summaryEntry := map[string]any{
+		"role":  "model",
+		"parts": []any{map[string]any{"text": tagged}},
+	}
+	summaryRaw, _ := json.Marshal(summaryEntry)
+
+	rebuilt := make([]string, 0, len(kept)+1)
+	rebuilt = append(rebuilt, string(summaryRaw))
+	for _, m := range kept {
+		rebuilt = append(rebuilt, m.Raw)
+	}
+	elided := max(len(all)-len(kept), 0)
+	out, err := sjson.SetRawBytes(e.body, "contents", []byte("["+strings.Join(rebuilt, ",")+"]"))
+	if err != nil {
+		return 0
+	}
+	e.body = out
+	return elided
+}

--- a/internal/translate/compaction.go
+++ b/internal/translate/compaction.go
@@ -13,15 +13,11 @@ import (
 // (human or model) recognizes that the content was elided, not lost.
 const ClearedToolResultPlaceholder = "[Old tool result content cleared]"
 
-// ClearOldToolResults replaces the content of every tool result EXCEPT the most
-// recent keepRecent with ClearedToolResultPlaceholder, leaving message and
-// tool-call structure intact. This is the cheap, model-free first tier of
-// compaction: tool results (file reads, command output) dominate an agentic
-// session's tokens, so clearing stale ones alone often brings a request back
-// under a model's window without summarizing. Returns the number of tool
-// results cleared. No-ops (returns 0) when there are at most keepRecent.
-//
-// Pure: no I/O. keepRecent < 0 is treated as 0.
+// ClearOldToolResults replaces every tool result except the most recent
+// keepRecent with ClearedToolResultPlaceholder, leaving structure intact and
+// returning the number cleared. Tool results dominate agentic-session tokens;
+// clearing stale ones is the cheap, model-free Tier-1 step that often avoids a
+// full summarization. Pure: no I/O. keepRecent < 0 is treated as 0.
 func (e *RequestEnvelope) ClearOldToolResults(keepRecent int) int {
 	if e == nil {
 		return 0
@@ -39,17 +35,12 @@ func (e *RequestEnvelope) ClearOldToolResults(keepRecent int) int {
 	}
 }
 
-// RewriteForCompaction keeps system context + a synthesized summary + the most
-// recent keepRecentTurns non-system messages, eliding everything older. Unlike
-// RewriteForHandover (which keeps only the latest user message), this preserves
-// a tail of recent turns so the model retains immediate working context, which
-// is what Claude Code's own compaction does. Tool results orphaned by the trim
-// (their tool_use fell in the elided region) are stripped so the request stays
-// wire-valid. The recent window is aligned to begin on a user message so the
-// [summary, ...recent] sequence alternates roles correctly. Returns the number
-// of original messages elided.
-//
-// Pure: no I/O. keepRecentTurns <= 0 is treated as 1 (summary + latest user).
+// RewriteForCompaction rewrites history to [summary + recent keepRecentTurns
+// non-system messages], aligned to begin on a user turn so roles alternate.
+// Orphaned tool results (whose tool_use was elided) are stripped to keep the
+// request wire-valid. Unlike RewriteForHandover, a tail is kept so the model
+// retains immediate working context. Returns the number of messages elided.
+// Pure: no I/O. keepRecentTurns <= 0 is treated as 1.
 func (e *RequestEnvelope) RewriteForCompaction(summary string, keepRecentTurns int) int {
 	if e == nil {
 		return 0
@@ -72,10 +63,7 @@ func (e *RequestEnvelope) RewriteForCompaction(summary string, keepRecentTurns i
 // message so the window starts on a user turn. Falls back to the last user
 // message's index when the window contains none.
 func userAlignedStart(msgs []gjson.Result, keepRecent int) int {
-	start := len(msgs) - keepRecent
-	if start < 0 {
-		start = 0
-	}
+	start := max(len(msgs)-keepRecent, 0)
 	for start < len(msgs) && msgs[start].Get("role").String() != "user" {
 		start++
 	}

--- a/internal/translate/compaction_test.go
+++ b/internal/translate/compaction_test.go
@@ -1,0 +1,164 @@
+package translate
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+)
+
+// anthropicToolTurn builds a user message carrying a single tool_result whose
+// body is the given text, for the given tool_use_id.
+func anthropicToolResultMsg(id, text string) string {
+	return `{"role":"user","content":[{"type":"tool_result","tool_use_id":"` + id + `","content":"` + text + `"}]}`
+}
+
+func anthropicAssistantToolUse(id string) string {
+	return `{"role":"assistant","content":[{"type":"tool_use","id":"` + id + `","name":"read","input":{}}]}`
+}
+
+func TestClearOldToolResults_Anthropic(t *testing.T) {
+	body := `{"model":"claude-opus-4-8","system":"sys","messages":[` +
+		anthropicAssistantToolUse("t1") + `,` + anthropicToolResultMsg("t1", "OLD_ONE") + `,` +
+		anthropicAssistantToolUse("t2") + `,` + anthropicToolResultMsg("t2", "OLD_TWO") + `,` +
+		anthropicAssistantToolUse("t3") + `,` + anthropicToolResultMsg("t3", "RECENT") +
+		`]}`
+	e, err := ParseAnthropic([]byte(body))
+	require.NoError(t, err)
+
+	cleared := e.ClearOldToolResults(1)
+	assert.Equal(t, 2, cleared, "two of three tool results should be cleared")
+
+	got := string(e.body)
+	assert.Contains(t, got, ClearedToolResultPlaceholder)
+	assert.NotContains(t, got, "OLD_ONE")
+	assert.NotContains(t, got, "OLD_TWO")
+	assert.Contains(t, got, "RECENT", "the most recent tool result must be preserved verbatim")
+
+	// Structure intact: still 6 messages, tool_use blocks untouched.
+	msgs := gjson.GetBytes(e.body, "messages").Array()
+	assert.Len(t, msgs, 6)
+	assert.Equal(t, 2, strings.Count(got, ClearedToolResultPlaceholder))
+}
+
+func TestClearOldToolResults_NoOpWhenWithinKeep(t *testing.T) {
+	body := `{"messages":[` + anthropicAssistantToolUse("t1") + `,` + anthropicToolResultMsg("t1", "ONLY") + `]}`
+	e, err := ParseAnthropic([]byte(body))
+	require.NoError(t, err)
+	before := string(e.body)
+	assert.Equal(t, 0, e.ClearOldToolResults(5))
+	assert.Equal(t, before, string(e.body), "body must be unchanged when nothing is cleared")
+}
+
+func TestClearOldToolResults_OpenAI(t *testing.T) {
+	body := `{"messages":[` +
+		`{"role":"assistant","tool_calls":[{"id":"c1","type":"function","function":{"name":"f","arguments":"{}"}}]},` +
+		`{"role":"tool","tool_call_id":"c1","content":"OLD_OUTPUT"},` +
+		`{"role":"assistant","tool_calls":[{"id":"c2","type":"function","function":{"name":"f","arguments":"{}"}}]},` +
+		`{"role":"tool","tool_call_id":"c2","content":"RECENT_OUTPUT"}` +
+		`]}`
+	e, err := ParseOpenAI([]byte(body))
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, e.ClearOldToolResults(1))
+	got := string(e.body)
+	assert.NotContains(t, got, "OLD_OUTPUT")
+	assert.Contains(t, got, "RECENT_OUTPUT")
+	assert.Contains(t, got, ClearedToolResultPlaceholder)
+}
+
+func TestRewriteForCompaction_Anthropic_KeepsSummaryAndRecent(t *testing.T) {
+	// 8 alternating messages; keep recent 3 turns.
+	var b strings.Builder
+	b.WriteString(`{"model":"claude-opus-4-8","system":"sys","messages":[`)
+	parts := []string{
+		`{"role":"user","content":"u1 old"}`,
+		`{"role":"assistant","content":"a1 old"}`,
+		`{"role":"user","content":"u2 old"}`,
+		`{"role":"assistant","content":"a2 old"}`,
+		`{"role":"user","content":"u3 keep"}`,
+		`{"role":"assistant","content":"a3 keep"}`,
+		`{"role":"user","content":"u4 latest"}`,
+	}
+	b.WriteString(strings.Join(parts, ","))
+	b.WriteString(`]}`)
+	e, err := ParseAnthropic([]byte(b.String()))
+	require.NoError(t, err)
+
+	elided := e.RewriteForCompaction("THE SUMMARY", 3)
+	assert.Positive(t, elided)
+
+	msgs := gjson.GetBytes(e.body, "messages").Array()
+	require.GreaterOrEqual(t, len(msgs), 2)
+	// First message is the tagged assistant summary.
+	assert.Equal(t, "assistant", msgs[0].Get("role").String())
+	assert.Contains(t, msgs[0].Get("content").Array()[0].Get("text").String(), HandoverSummaryTag)
+	assert.Contains(t, msgs[0].Get("content").Array()[0].Get("text").String(), "THE SUMMARY")
+	// The message after the summary must be a user turn (valid alternation).
+	assert.Equal(t, "user", msgs[1].Get("role").String())
+	// Latest user turn preserved; oldest elided.
+	got := string(e.body)
+	assert.Contains(t, got, "u4 latest")
+	assert.NotContains(t, got, "u1 old")
+	// System field untouched.
+	assert.Equal(t, "sys", gjson.GetBytes(e.body, "system").String())
+}
+
+func TestRewriteForCompaction_Anthropic_StripsOrphanedToolResult(t *testing.T) {
+	// The recent window begins on a tool_result whose tool_use is elided.
+	body := `{"messages":[` +
+		anthropicAssistantToolUse("t1") + `,` +
+		anthropicToolResultMsg("t1", "orphan-after-trim") + `,` +
+		`{"role":"assistant","content":"a"},` +
+		`{"role":"user","content":"latest"}` +
+		`]}`
+	e, err := ParseAnthropic([]byte(body))
+	require.NoError(t, err)
+
+	e.RewriteForCompaction("S", 2)
+	got := string(e.body)
+	// The orphaned tool_result (its tool_use t1 was elided) must not survive.
+	assert.NotContains(t, got, "orphan-after-trim")
+	assert.Contains(t, got, "latest")
+}
+
+func TestRewriteForCompaction_OpenAI_PreservesSystem(t *testing.T) {
+	body := `{"messages":[` +
+		`{"role":"system","content":"SYS"},` +
+		`{"role":"user","content":"u1 old"},` +
+		`{"role":"assistant","content":"a1"},` +
+		`{"role":"user","content":"u2 latest"}` +
+		`]}`
+	e, err := ParseOpenAI([]byte(body))
+	require.NoError(t, err)
+
+	e.RewriteForCompaction("SUM", 1)
+	msgs := gjson.GetBytes(e.body, "messages").Array()
+	require.NotEmpty(t, msgs)
+	assert.Equal(t, "system", msgs[0].Get("role").String())
+	assert.Equal(t, "SYS", msgs[0].Get("content").String())
+	got := string(e.body)
+	assert.Contains(t, got, "u2 latest")
+	assert.NotContains(t, got, "u1 old")
+	assert.Contains(t, got, "SUM")
+}
+
+func TestRewriteForCompaction_Gemini_KeepsSummaryModelTurn(t *testing.T) {
+	body := `{"contents":[` +
+		`{"role":"user","parts":[{"text":"u1 old"}]},` +
+		`{"role":"model","parts":[{"text":"m1"}]},` +
+		`{"role":"user","parts":[{"text":"u2 latest"}]}` +
+		`]}`
+	e, err := ParseGemini([]byte(body))
+	require.NoError(t, err)
+
+	e.RewriteForCompaction("GSUM", 1)
+	contents := gjson.GetBytes(e.body, "contents").Array()
+	require.GreaterOrEqual(t, len(contents), 2)
+	assert.Equal(t, "model", contents[0].Get("role").String())
+	assert.Contains(t, contents[0].Get("parts").Array()[0].Get("text").String(), "GSUM")
+	assert.Equal(t, "user", contents[1].Get("role").String())
+	assert.Contains(t, string(e.body), "u2 latest")
+}


### PR DESCRIPTION
## Problem

Router session `e0f9de9f-eb02-4f3f-86c8-3a88cbd99a53` (prod) failed **every** request with `cluster: no eligible provider for request`. It's a Claude Code CLI session that grew to a **~1M-token context**. Chain:

1. The context-window pre-filter computed `needed = est(~988k) + output_reserve(64k) ≈ 1.05M`, exceeding even `gpt-5.5`'s 1.05M window → it excluded all large-window models (including the pinned `gpt-5.5`).
2. Combined with the org's excluded-models list, **all 20 models were excluded** → scorer returned `ErrNoEligibleProvider`.
3. That mapped to a **misleading 400**: *"No provider keys available… register a BYOK key…"* — useless advice for a too-large context.

Root cause: the router only reacted **at** overflow (>100% of every window) — too late for any model to ingest the history and summarize it. Claude Code avoids this by auto-compacting at **~85%** of the window, *below* the limit, while the history still fits a model.

## Fix

Mirror Claude Code's compaction. `maybeCompact` runs **before** routing (in `ProxyMessages` + `ProxyOpenAIChatCompletion`), engaging when the estimate reaches `ROUTER_COMPACTION_PCT` (default **0.85**) of the largest eligible model's window:

1. **Tier 1 — `ClearOldToolResults`**: local, clears all but the most recent tool results (tool output dominates agentic-session tokens). Often enough alone.
2. **Tier 3 — structured summary**: the 9-section Claude-Code-style prompt via a **window-aware** Anthropic-family summarizer (`claude-haiku-4-5` when the history fits its window, `claude-fable-5` (1M) for larger), rewriting history to `[summary + recent 12 turns]` with tool_use/tool_result pairing preserved.
3. **Rescue — progressive trim** until it fits.

If even the trimmed floor overflows the largest eligible window, return a new **`ErrContextWindowExceeded` → HTTP 413** with an actionable message, replacing the misleading `ErrNoEligibleProvider` mapping for the overflow case. The summary call is billed as a `_precompaction_summary` ledger row.

Trigger *below* the window is load-bearing: a summarizer can only ingest a history that still fits *some* model.

## Config

`ROUTER_COMPACTION_PCT` (default `0.85`, range `(0,1]`; `0` disables → over-window requests 413).

## Changes

- `internal/translate/compaction.go` — pure `ClearOldToolResults` + `RewriteForCompaction` (Anthropic/OpenAI/Gemini), reusing existing orphaned-tool-result stripping.
- `internal/proxy/compaction.go` — cascade orchestration, window-aware summarizer selection, `ErrContextWindowExceeded`, summary billing.
- `internal/proxy/handover.go` — parametric summary builder + `SummarizeForCompaction` (9-section prompt, larger cap).
- `internal/proxy/dispatch_error.go` — classify `ErrContextWindowExceeded` → 413.
- `internal/proxy/service.go` — wire cascade into both entry points; snapshots taken pre-rewrite.
- `cmd/router/main.go` — `WithCompaction`, `ROUTER_COMPACTION_PCT`.
- Tests for both new packages; docs updated.

## Testing

`go build`, `go vet`, and full `go test` (`-tags no_onnx`) pass. New unit tests cover the cascade tiers, window-aware selection, the 413 floor, and the error classification. Tool_use/tool_result pairing is asserted preserved across rewrites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)