### PR TITLE
fix: compress review comments to concise form (bot feedback)

### DIFF
--- a/.claude/skills/fix-pr-reviews/SKILL.md
+++ b/.claude/skills/fix-pr-reviews/SKILL.md
@@ -150,6 +150,7 @@ For each thread where `isResolved: false` AND `isOutdated: false`, classify into
 | Fix | Code style/convention | Apply consistently |
 | Fix | Refactoring suggestion (clear, single obvious approach) | Implement if clear |
 | Fix | Nitpicks | Fix if straightforward |
+| Fix | Bot comments about comment length / doc brevity | Apply as-is — the bot's suggested replacement text is authoritative; these are objective conciseness improvements, not subjective style calls |
 | Decline | False positive / incorrect suggestion | Reply with explanation, don't change code |
 | Decline | Already handled elsewhere | Reply pointing to where it's handled |
 | Decline | Would make code worse | Reply explaining the trade-off |

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -132,15 +132,10 @@ type Service struct {
 	// plannerEnabled is the kill switch. When false, the orchestrator falls
 	// back to first-decision-wins behavior.
 	plannerEnabled bool
-	// scoreToolResultTurns controls whether ToolResult turns with an existing
-	// pin run the cluster scorer + planner (MainLoop parity) or reuse the pin
-	// verbatim (the legacy #82 behavior). When true, the fresh cluster decision
-	// is computed and logged on every ToolResult turn and the planner may switch
-	// on EV grounds, exactly as on MainLoop; when false, ToolResult turns
-	// short-circuit to the pin with no scorer call. Defaults to true; set from
-	// ROUTER_SCORE_TOOL_RESULT_TURNS as the kill switch. Note this runs the
-	// embedder on ToolResult traffic (the majority of turns), so a deploy that
-	// disables it reverts to the cheaper verbatim-reuse hot path.
+	// scoreToolResultTurns is the kill switch (ROUTER_SCORE_TOOL_RESULT_TURNS).
+	// When true (default), ToolResult turns run the cluster scorer + planner
+	// for MainLoop parity; when false, the pin is reused verbatim (#82 path).
+	// Runs the embedder on ToolResult traffic (majority of turns).
 	scoreToolResultTurns bool
 	// effortEscalation enables the escalate-on-failure reasoning-effort policy:
 	// gpt-5.x serves low effort by default and high after an observed
@@ -902,10 +897,7 @@ func (s *Service) WithPlannerEnabled(enabled bool) *Service {
 	return s
 }
 
-// WithScoreToolResultTurns toggles whether pinned ToolResult turns run the
-// scorer + planner (MainLoop parity, the default) or reuse the pin verbatim
-// with no scorer call (the legacy #82 hot path). Set from
-// ROUTER_SCORE_TOOL_RESULT_TURNS.
+// WithScoreToolResultTurns sets ROUTER_SCORE_TOOL_RESULT_TURNS; see scoreToolResultTurns.
 func (s *Service) WithScoreToolResultTurns(enabled bool) *Service {
 	s.scoreToolResultTurns = enabled
 	return s

--- a/internal/proxy/service_session_pin_test.go
+++ b/internal/proxy/service_session_pin_test.go
@@ -654,10 +654,8 @@ func TestService_SessionPin_OpenAI_ForceModelCommandStreamShape(t *testing.T) {
 }
 
 func TestService_SessionPin_OpenAI_ToolResultShortCircuit(t *testing.T) {
-	// Trailing role=="tool" → turntype.ToolResult. With the tool-result scoring
-	// kill switch OFF, a pinned tool_result turn short-circuits the scorer and
-	// reuses the pin verbatim (the legacy #82 hot path). The default (scorer
-	// runs, MainLoop parity) is covered by the turnloop_test.go cases.
+	// Kill switch OFF: pinned tool_result reuses the pin verbatim (legacy #82 path).
+	// Default (scorer runs) is covered by turnloop_test.go.
 	const toolResultBody = `{
 		"model":"gpt-4o",
 		"messages":[

--- a/internal/proxy/turnloop.go
+++ b/internal/proxy/turnloop.go
@@ -448,17 +448,11 @@ func (s *Service) runTurnLoop(
 		return res, nil
 	}
 
-	// Tool-result turns are mid-turn continuations. By default they now run the
-	// scorer + planner exactly like MainLoop (fall through below), so the fresh
-	// cluster decision is computed and logged on every tool_result turn and the
-	// planner may switch on EV grounds. The legacy behavior — reuse the pin
-	// verbatim with no scorer call — is preserved behind the scoreToolResultTurns
-	// kill switch. That skip was originally chosen (#82) because re-routing on a
-	// trailing tool_result embedding could flip to noisy candidates; but under the
-	// prod only_user_message embed mode the tool_result blocks are stripped from
-	// the embed input (see translate.userPromptTextGJSON), so the embedding is the
-	// stable user instruction, not the tool output. Switches still degrade safely:
-	// handover.RewriteEnvelope strips orphaned tool_results on the switch turn.
+	// Tool-result turns: by default, fall through to the scorer + planner for
+	// MainLoop parity. Kill switch preserves the legacy #82 verbatim-reuse path.
+	// The #82 noisy-embedding concern is stale under only_user_message embed mode:
+	// translate.userPromptTextGJSON strips tool_result blocks from the embed input.
+	// Switches degrade safely — handover.RewriteEnvelope strips orphaned tool_results.
 	if !s.scoreToolResultTurns && res.TurnType == turntype.ToolResult && pinFound {
 		decision := pinDecision(pin)
 		res.Decision = decision

--- a/internal/proxy/turnloop_test.go
+++ b/internal/proxy/turnloop_test.go
@@ -180,11 +180,8 @@ func TestTurnLoop_ToolResultScoringDisabledSkipsScorer(t *testing.T) {
 	assert.Equal(t, "claude-haiku-4-5", rec.Header().Get(proxy.HeaderRouterModel))
 }
 
-// TestTurnLoop_ToolResultScoringEnabledRunsScorerAndStays verifies the default
-// (WithScoreToolResultTurns(true)): a pinned tool_result turn now runs the
-// scorer for MainLoop parity — the fresh decision is computed (and logged) —
-// but when the planner agrees it STAYs on the pinned model, so the served
-// model is unchanged from the verbatim-reuse behavior.
+// TestTurnLoop_ToolResultScoringEnabledRunsScorerAndStays verifies the default path:
+// scorer runs (routeCalls==1) but planner STAYs, so the served model is unchanged.
 func TestTurnLoop_ToolResultScoringEnabledRunsScorerAndStays(t *testing.T) {
 	store := newFakePinStore()
 	store.hasPin = true
@@ -208,12 +205,8 @@ func TestTurnLoop_ToolResultScoringEnabledRunsScorerAndStays(t *testing.T) {
 	assert.Equal(t, "claude-haiku-4-5", rec.Header().Get(proxy.HeaderRouterModel), "planner agreement STAYs on the pinned model")
 }
 
-// TestTurnLoop_ToolResultScoringEnabledSwitchesSafely exercises the genuinely
-// new path: a positive-EV switch triggered ON a tool_result turn. The planner
-// switches off the pinned opus model and the handover rewrite must strip the
-// orphaned tool_result (the summary carries no matching tool_use), so the body
-// forwarded to the switched-to model is well-formed rather than a 400-inducing
-// tool_result-without-tool_use sequence.
+// TestTurnLoop_ToolResultScoringEnabledSwitchesSafely verifies a positive-EV switch
+// on a tool_result turn: handover strips the orphaned tool_result from the forwarded body.
 func TestTurnLoop_ToolResultScoringEnabledSwitchesSafely(t *testing.T) {
 	chunk := strings.Repeat("aaaa ", 4000) // ~5k tokens each, positive EV
 	toolResultLargeBody := []byte(`{
@@ -256,13 +249,8 @@ func TestTurnLoop_ToolResultScoringEnabledSwitchesSafely(t *testing.T) {
 		"handover must strip the orphaned tool_result on a mid-tool-use switch")
 }
 
-// TestTurnLoop_ToolResultPinOnExcludedProviderFallsThroughToScorer guards the
-// provider-eligibility pin guard: a session pinned to a provider that has
-// since been excluded (installation list, env override, or BYOK narrowing)
-// must NOT be served through the sticky branches — the turn falls through to
-// the scorer, which routes within the remaining enabled set. Without the
-// guard, ordinary stickies (unlike user-forced pins) kept hitting the
-// excluded provider until the pin expired.
+// TestTurnLoop_ToolResultPinOnExcludedProviderFallsThroughToScorer verifies that a pin
+// on an excluded provider falls through to the scorer rather than being served sticky.
 func TestTurnLoop_ToolResultPinOnExcludedProviderFallsThroughToScorer(t *testing.T) {
 	const toolResultBody = `{
 		"model":"claude-opus-4-7",


### PR DESCRIPTION
## Summary

Applies workweave-bot's suggested comment-length fixes across 4 files, compressing 46 lines → 18. Also updates the fix-pr-reviews skill to classify bot comment-length nits as a Fix category (they're objective conciseness improvements, not subjective style calls).

## Changes

- **service.go**: compress scoreToolResultTurns field comment (9→4 lines) + WithScoreToolResultTurns doc (4→1 line)
- **turnloop.go**: compress tool_result turn comment (11→5 lines)
- **turnloop_test.go**: compress 3 test doc comments (5→2, 6→2, 7→2 lines)
- **service_session_pin_test.go**: compress short-circuit test comment (4→2 lines)
- **SKILL.md**: add Fix category for bot comment-length nits