### PR TITLE
feat(routing): re-pin session off a cyber-refusing model (defensive, kill-switch gated)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -124,6 +124,16 @@ ROUTER_STICKY_DECISION_TTL_MS=0
 # reuse the pin verbatim with no scorer call (the cheaper legacy hot path).
 # ROUTER_SCORE_TOOL_RESULT_TURNS=true
 
+# Defensive backstop for Anthropic's cyber safety classifier. When true, a
+# safety refusal observed on the response stream (opus's cyber classifier
+# declines ~45% of security-adjacent coding; sonnet 0%) re-pins the session off
+# the refusing model to a non-refusing one, so the rest of the session routes
+# around it. Detection is observe-only (forwarded bytes are never modified).
+# Default off; enable on the defensive deploy.
+# ROUTER_CYBER_REFUSAL_REPIN=false
+# Re-pin target when the session pin carries no runner-up (PairedModel).
+# ROUTER_CYBER_REFUSAL_FALLBACK_MODEL=claude-sonnet-5
+
 # Minimum positive expected value (USD, over the remaining-turn horizon)
 # required to evict a pinned model. Lower = more switches, higher = stickier.
 # ROUTER_SWITCH_EV_THRESHOLD_USD=0.001

--- a/cmd/router/main.go
+++ b/cmd/router/main.go
@@ -481,6 +481,11 @@ func main() {
 	// below can be overridden per deployment.
 	plannerEnabled := config.GetOr("ROUTER_PLANNER_ENABLED", "true") == "true"
 	scoreToolResultTurns := config.GetOr("ROUTER_SCORE_TOOL_RESULT_TURNS", "true") == "true"
+	// Defensive backstop for Anthropic's cyber safety classifier: re-pin a
+	// session off a model that returned a safety refusal. Default off; enabled
+	// on the defensive deploy. Fallback target when the pin has no runner-up.
+	cyberRefusalRepin := config.GetOr("ROUTER_CYBER_REFUSAL_REPIN", "false") == "true"
+	cyberRefusalFallbackModel := config.GetOr("ROUTER_CYBER_REFUSAL_FALLBACK_MODEL", "claude-sonnet-5")
 	effortEscalation := config.GetOr("ROUTER_EFFORT_ESCALATION", "false") == "true"
 	// Per-turn large-vs-small action-classifier swap. Off by default until the
 	// Layer-2 extrinsic validation clears it; enabling loads the compiled-in head.
@@ -612,6 +617,8 @@ func main() {
 		WithHardPinResolver(hardPinResolver).
 		WithPlannerEnabled(plannerEnabled).
 		WithScoreToolResultTurns(scoreToolResultTurns).
+		WithCyberRefusalRepin(cyberRefusalRepin).
+		WithCyberRefusalFallbackModel(cyberRefusalFallbackModel).
 		WithPrefixTrimFreeSwitch(prefixTrimFreeSwitch).
 		WithEscapeNormalize(escapeNormalize).
 		WithEffortEscalation(effortEscalation).

--- a/internal/proxy/cyber_refusal_internal_test.go
+++ b/internal/proxy/cyber_refusal_internal_test.go
@@ -1,0 +1,199 @@
+package proxy
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"workweave/router/internal/router"
+	"workweave/router/internal/router/sessionpin"
+)
+
+// repinFakeStore is a minimal sessionpin.Store for the re-pin unit tests.
+type repinFakeStore struct {
+	getPin  sessionpin.Pin
+	hasPin  bool
+	upserts []sessionpin.Pin
+}
+
+func (f *repinFakeStore) Get(_ context.Context, key [sessionpin.SessionKeyLen]byte, role string) (sessionpin.Pin, bool, error) {
+	if !f.hasPin {
+		return sessionpin.Pin{}, false, nil
+	}
+	p := f.getPin
+	p.SessionKey = key
+	p.Role = role
+	return p, true, nil
+}
+func (f *repinFakeStore) Upsert(_ context.Context, p sessionpin.Pin) error {
+	f.upserts = append(f.upserts, p)
+	return nil
+}
+func (f *repinFakeStore) UpdateUsage(context.Context, [sessionpin.SessionKeyLen]byte, string, sessionpin.Usage) error {
+	return nil
+}
+func (f *repinFakeStore) IncrementUpstreamErrors(context.Context, [sessionpin.SessionKeyLen]byte, string) (int, error) {
+	return 0, nil
+}
+func (f *repinFakeStore) ResetUpstreamErrors(context.Context, [sessionpin.SessionKeyLen]byte, string) error {
+	return nil
+}
+func (f *repinFakeStore) SweepExpired(context.Context) error { return nil }
+
+// A realistic Anthropic-native refusal SSE (the router-visible wire shape:
+// stop_reason "refusal" on HTTP 200; see catalog.go). The real opus cyber
+// refusal also carries api_refusal_category "cyber" / "safeguards flagged".
+const refusalSSE = `event: message_start
+data: {"type":"message_start","message":{"id":"msg_1","model":"claude-opus-4-8","stop_reason":null}}
+
+event: message_delta
+data: {"type":"message_delta","delta":{"stop_reason":"refusal","stop_sequence":null},"usage":{"output_tokens":5}}
+
+event: message_stop
+data: {"type":"message_stop"}
+`
+
+const normalSSE = `event: message_start
+data: {"type":"message_start","message":{"id":"msg_2","model":"claude-opus-4-8"}}
+
+event: message_delta
+data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null}}
+`
+
+func TestDetectRefusalSignal(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want bool
+	}{
+		{"stop_reason refusal", `"stop_reason":"refusal"`, true},
+		{"refusal content block", `{"type":"refusal","text":"..."}`, true},
+		{"api_refusal_category", `"api_refusal_category":"cyber"`, true},
+		{"safeguard text mixed case", "This request triggered cyber-related SAFEGUARDS FLAGGED for review", true},
+		{"normal end_turn", `"stop_reason":"end_turn"`, false},
+		{"benign cybersecurity mention", "here is a summary of cybersecurity best practices", false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := detectRefusalSignal([]byte(c.in)); got != c.want {
+				t.Fatalf("detectRefusalSignal(%q) = %v, want %v", c.in, got, c.want)
+			}
+		})
+	}
+}
+
+func TestRefusalObserver_ForwardsUnchangedAndDetects(t *testing.T) {
+	// Signal split across two Write calls must still be caught, and every byte
+	// must be forwarded to inner unchanged (observe-only).
+	rec := httptest.NewRecorder()
+	obs := newRefusalObserver(rec)
+	half := len(refusalSSE) / 2
+	if _, err := obs.Write([]byte(refusalSSE[:half])); err != nil {
+		t.Fatalf("write 1: %v", err)
+	}
+	if _, err := obs.Write([]byte(refusalSSE[half:])); err != nil {
+		t.Fatalf("write 2: %v", err)
+	}
+	if !obs.refused {
+		t.Fatal("observer did not detect the refusal split across writes")
+	}
+	if got := rec.Body.String(); got != refusalSSE {
+		t.Fatalf("observer altered forwarded bytes:\n got=%q\nwant=%q", got, refusalSSE)
+	}
+
+	rec2 := httptest.NewRecorder()
+	obs2 := newRefusalObserver(rec2)
+	if _, err := obs2.Write([]byte(normalSSE)); err != nil {
+		t.Fatalf("write normal: %v", err)
+	}
+	if obs2.refused {
+		t.Fatal("observer false-positived on a normal end_turn response")
+	}
+	if rec2.Body.String() != normalSSE {
+		t.Fatal("observer altered a normal response")
+	}
+}
+
+func repinCtx() context.Context {
+	return context.WithValue(context.Background(), InstallationIDContextKey{}, uuid.New().String())
+}
+
+func TestMaybeRepinOnRefusal_RepinsToFallbackModel(t *testing.T) {
+	store := &repinFakeStore{} // no existing pin -> no PairedModel
+	s := &Service{pinStore: store, cyberRefusalFallbackModel: "claude-sonnet-5"}
+	obs := &refusalObserver{refused: true}
+	served := router.Decision{Provider: "anthropic", Model: "claude-opus-4-8"}
+
+	s.maybeRepinOnRefusal(repinCtx(), obs, [sessionpin.SessionKeyLen]byte{1, 2, 3}, "main_loop", served)
+
+	if len(store.upserts) != 1 {
+		t.Fatalf("expected exactly 1 re-pin upsert, got %d", len(store.upserts))
+	}
+	got := store.upserts[0]
+	if got.Model != "claude-sonnet-5" {
+		t.Fatalf("re-pinned to %q, want claude-sonnet-5", got.Model)
+	}
+	if got.Provider == "" {
+		t.Fatal("re-pin has no provider (catalog resolution failed)")
+	}
+	if got.Reason != "cyber-refusal-repin" {
+		t.Fatalf("re-pin reason = %q, want cyber-refusal-repin", got.Reason)
+	}
+}
+
+func TestMaybeRepinOnRefusal_PrefersPairedModel(t *testing.T) {
+	store := &repinFakeStore{
+		hasPin: true,
+		getPin: sessionpin.Pin{PairedModel: "claude-haiku-4-5", PairedProvider: "anthropic"},
+	}
+	s := &Service{pinStore: store, cyberRefusalFallbackModel: "claude-sonnet-5"}
+	obs := &refusalObserver{refused: true}
+	served := router.Decision{Provider: "anthropic", Model: "claude-opus-4-8"}
+
+	s.maybeRepinOnRefusal(repinCtx(), obs, [sessionpin.SessionKeyLen]byte{4, 5, 6}, "main_loop", served)
+
+	if len(store.upserts) != 1 {
+		t.Fatalf("expected 1 upsert, got %d", len(store.upserts))
+	}
+	if got := store.upserts[0].Model; got != "claude-haiku-4-5" {
+		t.Fatalf("re-pinned to %q, want the pin's PairedModel claude-haiku-4-5", got)
+	}
+	if got := store.upserts[0].Provider; got != "anthropic" {
+		t.Fatalf("re-pin provider = %q, want anthropic (from PairedProvider)", got)
+	}
+}
+
+func TestMaybeRepinOnRefusal_NoOpCases(t *testing.T) {
+	served := router.Decision{Provider: "anthropic", Model: "claude-opus-4-8"}
+	key := [sessionpin.SessionKeyLen]byte{7}
+
+	t.Run("nil observer (flag off)", func(t *testing.T) {
+		store := &repinFakeStore{}
+		s := &Service{pinStore: store, cyberRefusalFallbackModel: "claude-sonnet-5"}
+		s.maybeRepinOnRefusal(repinCtx(), nil, key, "main_loop", served)
+		if len(store.upserts) != 0 {
+			t.Fatalf("nil observer should not re-pin, got %d upserts", len(store.upserts))
+		}
+	})
+
+	t.Run("no refusal observed", func(t *testing.T) {
+		store := &repinFakeStore{}
+		s := &Service{pinStore: store, cyberRefusalFallbackModel: "claude-sonnet-5"}
+		s.maybeRepinOnRefusal(repinCtx(), &refusalObserver{refused: false}, key, "main_loop", served)
+		if len(store.upserts) != 0 {
+			t.Fatalf("no refusal should not re-pin, got %d upserts", len(store.upserts))
+		}
+	})
+
+	t.Run("served model already the fallback", func(t *testing.T) {
+		store := &repinFakeStore{}
+		s := &Service{pinStore: store, cyberRefusalFallbackModel: "claude-sonnet-5"}
+		alreadyFallback := router.Decision{Provider: "anthropic", Model: "claude-sonnet-5"}
+		s.maybeRepinOnRefusal(repinCtx(), &refusalObserver{refused: true}, key, "main_loop", alreadyFallback)
+		if len(store.upserts) != 0 {
+			t.Fatalf("re-pin to the same model should be skipped, got %d upserts", len(store.upserts))
+		}
+	})
+}

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -1690,9 +1690,8 @@ func (s *Service) maybeRepinOnRefusal(ctx context.Context, obs *refusalObserver,
 		return
 	}
 	log := observability.FromContext(ctx)
-	// Prefer the scorer's runner-up (PairedModel) as the re-pin target; else the
-	// configured fallback, resolving its provider from the catalog. context.Background():
-	// the request ctx may already be canceled here (response written, client gone).
+	// Prefer the scorer's runner-up (PairedModel); use context.Background() because
+	// the request ctx may already be canceled when the response has been written.
 	fbModel, fbProvider := s.cyberRefusalFallbackModel, ""
 	if existing, found, err := s.pinStore.Get(context.Background(), sessionKey, role); err == nil && found && existing.PairedModel != "" {
 		fbModel, fbProvider = existing.PairedModel, existing.PairedProvider

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -139,9 +139,8 @@ type Service struct {
 	// Runs the embedder on ToolResult traffic (majority of turns).
 	scoreToolResultTurns bool
 	// cyberRefusalRepin is the kill switch (ROUTER_CYBER_REFUSAL_REPIN, default
-	// false). When true, a refusal on the anthropic-native path (opus's cyber
-	// classifier declines ~45% of security coding; sonnet 0%) re-pins the session
-	// off the refusing model. Observe-only — bytes are never modified.
+	// false). When true, a safety refusal on the anthropic-native path re-pins
+	// the session off the refusing model (opus ~45% refusal rate; sonnet 0%).
 	cyberRefusalRepin bool
 	// cyberRefusalFallbackModel is the model to re-pin to on a cyber refusal
 	// when the session pin carries no runner-up (PairedModel). Set from

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -2163,9 +2163,7 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 		captureW = newCaptureWriter(rootSink, semanticCacheMaxBodyBytes)
 		sink = captureW
 	}
-	// Cyber-refusal backstop (ROUTER_CYBER_REFUSAL_REPIN, default off): wrap
-	// sink to detect a refusal on the native path (no translator Summary here)
-	// and re-pin the session off the refusing model after the turn.
+	// Wrap sink to observe refusals on the native path (no translator Summary here).
 	var refusalObs *refusalObserver
 	if s.cyberRefusalRepin {
 		refusalObs = newRefusalObserver(sink)

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -1627,9 +1627,7 @@ func (o *refusalObserver) Header() http.Header { return o.inner.Header() }
 func (o *refusalObserver) WriteHeader(status int) { o.inner.WriteHeader(status) }
 
 func (o *refusalObserver) Write(p []byte) (int, error) {
-	// Accumulate a bounded prefix (so a signal split across SSE chunks is still
-	// caught) and re-scan until the signal is found or the cap is reached. Never
-	// alters the bytes forwarded to the client.
+	// Accumulate up to refusalScanCap so signals split across SSE chunks are caught.
 	if !o.refused && len(o.buf) < refusalScanCap {
 		prevLen := len(o.buf)
 		room := refusalScanCap - len(o.buf)

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -139,11 +139,9 @@ type Service struct {
 	// Runs the embedder on ToolResult traffic (majority of turns).
 	scoreToolResultTurns bool
 	// cyberRefusalRepin is the kill switch (ROUTER_CYBER_REFUSAL_REPIN, default
-	// false). When true, a detected safety refusal on the anthropic-native path
-	// (opus's cyber classifier declines ~45% of security-adjacent coding;
-	// sonnet 0%) re-pins the session off the refusing model to a non-refusing
-	// one so the rest of the session routes around it. Observe-only detection —
-	// the forwarded response bytes are never modified.
+	// false). When true, a refusal on the anthropic-native path (opus's cyber
+	// classifier declines ~45% of security coding; sonnet 0%) re-pins the session
+	// off the refusing model. Observe-only — bytes are never modified.
 	cyberRefusalRepin bool
 	// cyberRefusalFallbackModel is the model to re-pin to on a cyber refusal
 	// when the session pin carries no runner-up (PairedModel). Set from
@@ -1605,12 +1603,16 @@ func (s *Service) anthropicNativeAttempt(
 // events, so a small window catches it without buffering a whole response.
 const refusalScanCap = 64 * 1024
 
-// refusalObserver tees the anthropic-native passthrough response to inner
-// UNCHANGED while scanning a bounded prefix for a safety-refusal signal. It is
-// observe-only: it never modifies, drops, or delays forwarded bytes, so it
-// stays entirely off the risky path (the client always receives the raw
-// upstream stream). The native passthrough has no translator Summary to read,
-// so this is how a refusal is detected there. See detectRefusalSignal.
+// refusalScanOverlap is the trailing window each Write re-scans so a signal
+// split across two chunks is still caught, without re-scanning (and re-lowering)
+// the whole accumulated buffer every write. Must exceed the longest signal in
+// detectRefusalSignal (`"stop_reason":"refusal"`, 23 bytes).
+const refusalScanOverlap = 32
+
+// refusalObserver tees the anthropic-native passthrough to inner unchanged
+// while scanning a bounded prefix for a safety-refusal signal. Observe-only
+// because the native path has no translator Summary to read from.
+// See detectRefusalSignal.
 type refusalObserver struct {
 	inner   http.ResponseWriter
 	buf     []byte
@@ -1630,12 +1632,20 @@ func (o *refusalObserver) Write(p []byte) (int, error) {
 	// caught) and re-scan until the signal is found or the cap is reached. Never
 	// alters the bytes forwarded to the client.
 	if !o.refused && len(o.buf) < refusalScanCap {
+		prevLen := len(o.buf)
 		room := refusalScanCap - len(o.buf)
 		if room > len(p) {
 			room = len(p)
 		}
 		o.buf = append(o.buf, p[:room]...)
-		if detectRefusalSignal(o.buf) {
+		// Scan only the newly appended bytes plus a short overlap; re-scanning the
+		// whole accumulated buffer every write is O(n^2) (and ToLower re-allocates
+		// it each time). A signal split across two writes is still caught.
+		scanFrom := prevLen - refusalScanOverlap
+		if scanFrom < 0 {
+			scanFrom = 0
+		}
+		if detectRefusalSignal(o.buf[scanFrom:]) {
 			o.refused = true
 		}
 	}
@@ -1648,10 +1658,8 @@ func (o *refusalObserver) Flush() {
 	}
 }
 
-// detectRefusalSignal is a multi-signal (over-detecting-is-safe) check for an
-// Anthropic safety refusal, robust to the exact wire shape: the documented
-// stop_reason "refusal" (HTTP 200), a refusal content block, the
-// api_refusal_category field, or the safeguard text signature.
+// detectRefusalSignal returns true on any Anthropic safety-refusal signal.
+// Over-detecting is safe — re-pin to sonnet is always valid.
 func detectRefusalSignal(b []byte) bool {
 	if bytes.Contains(b, []byte(`"stop_reason":"refusal"`)) ||
 		bytes.Contains(b, []byte(`"type":"refusal"`)) ||
@@ -1661,24 +1669,33 @@ func detectRefusalSignal(b []byte) bool {
 	return bytes.Contains(bytes.ToLower(b), []byte("safeguards flagged"))
 }
 
-// maybeRepinOnRefusal re-pins the session off a cyber-refusing model after the
-// turn completes, so subsequent turns route to a non-refusing model instead of
-// hitting the refusal again. Post-turn + observe-only: it never touches the
-// forwarded response. No-op when the flag is off, no refusal was observed, or
-// no distinct fallback model can be resolved.
+// maybeRepinOnRefusal re-pins the session off the refusing model post-turn
+// so subsequent turns route to a non-refusing model. No-op when the flag is
+// off, no refusal was observed, or no fallback model can be resolved.
 func (s *Service) maybeRepinOnRefusal(ctx context.Context, obs *refusalObserver, sessionKey [sessionpin.SessionKeyLen]byte, role string, served router.Decision) {
 	if obs == nil || !obs.refused || s.pinStore == nil {
 		return
 	}
-	log := observability.FromContext(ctx)
 	installationID := installationIDFromContext(ctx)
 	if installationID == uuid.Nil {
 		return
 	}
+	// Hard-pinned turns (probe, compaction, title-gen) leave SessionKey zero and
+	// skip normal pin read/write — never persist a pin under an empty key.
+	if sessionKey == ([sessionpin.SessionKeyLen]byte{}) {
+		return
+	}
+	// A /force-model pin is the user's explicit choice; a refusal must not silently
+	// overwrite it. Prefix check covers ReasonUserForceModel and its tier_clamp suffix.
+	if strings.HasPrefix(served.Reason, translate.ReasonUserForceModel) {
+		return
+	}
+	log := observability.FromContext(ctx)
 	// Prefer the scorer's runner-up (PairedModel) as the re-pin target; else the
-	// configured fallback, resolving its provider from the catalog.
+	// configured fallback, resolving its provider from the catalog. context.Background():
+	// the request ctx may already be canceled here (response written, client gone).
 	fbModel, fbProvider := s.cyberRefusalFallbackModel, ""
-	if existing, found, err := s.pinStore.Get(ctx, sessionKey, role); err == nil && found && existing.PairedModel != "" {
+	if existing, found, err := s.pinStore.Get(context.Background(), sessionKey, role); err == nil && found && existing.PairedModel != "" {
 		fbModel, fbProvider = existing.PairedModel, existing.PairedProvider
 	}
 	if fbProvider == "" {
@@ -2147,11 +2164,9 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 		captureW = newCaptureWriter(rootSink, semanticCacheMaxBodyBytes)
 		sink = captureW
 	}
-	// Cyber-refusal backstop (ROUTER_CYBER_REFUSAL_REPIN, default off): observe
-	// the response stream for a safety refusal so a refused session is re-pinned
-	// off the refusing model post-turn (opus's cyber classifier declines ~45% of
-	// security-adjacent coding; sonnet 0%). Observe-only — forwarded bytes are
-	// never modified. Detection is here because the native path has no Summary.
+	// Cyber-refusal backstop (ROUTER_CYBER_REFUSAL_REPIN, default off): wrap
+	// sink to detect a refusal on the native path (no translator Summary here)
+	// and re-pin the session off the refusing model after the turn.
 	var refusalObs *refusalObserver
 	if s.cyberRefusalRepin {
 		refusalObs = newRefusalObserver(sink)
@@ -2736,9 +2751,7 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 	// persistent counter hits threshold; successful turns reset it.
 	s.maybeEvictPinAfterUpstreamErr(ctx, stickyHit, proxyErr, decision.Reason, installationID, routeRes.SessionKey, routeRes.PinRole)
 
-	// Cyber-refusal backstop: if the observer saw a safety refusal on this turn,
-	// re-pin the session off the refusing model so subsequent turns route around
-	// it. No-op when the flag is off (refusalObs is nil) or no refusal was seen.
+	// Re-pin the session off the refusing model if a cyber refusal was observed.
 	s.maybeRepinOnRefusal(ctx, refusalObs, routeRes.SessionKey, routeRes.PinRole, decision)
 
 	// One event per tool_use block that failed toolcheck validation, including

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -1,6 +1,7 @@
 package proxy
 
 import (
+	"bytes"
 	"context"
 	"encoding/hex"
 	"errors"
@@ -137,6 +138,17 @@ type Service struct {
 	// for MainLoop parity; when false, the pin is reused verbatim (#82 path).
 	// Runs the embedder on ToolResult traffic (majority of turns).
 	scoreToolResultTurns bool
+	// cyberRefusalRepin is the kill switch (ROUTER_CYBER_REFUSAL_REPIN, default
+	// false). When true, a detected safety refusal on the anthropic-native path
+	// (opus's cyber classifier declines ~45% of security-adjacent coding;
+	// sonnet 0%) re-pins the session off the refusing model to a non-refusing
+	// one so the rest of the session routes around it. Observe-only detection —
+	// the forwarded response bytes are never modified.
+	cyberRefusalRepin bool
+	// cyberRefusalFallbackModel is the model to re-pin to on a cyber refusal
+	// when the session pin carries no runner-up (PairedModel). Set from
+	// ROUTER_CYBER_REFUSAL_FALLBACK_MODEL; defaults to claude-sonnet-5.
+	cyberRefusalFallbackModel string
 	// effortEscalation enables the escalate-on-failure reasoning-effort policy:
 	// gpt-5.x serves low effort by default and high after an observed
 	// failed/no-progress turn; gemini is pinned low. Off by default (set from
@@ -871,9 +883,11 @@ func NewService(r router.Router, providerMap map[string]providers.Client, emitte
 			ExpectedRemainingTurns: DefaultPlannerExpectedRemainingTurns,
 			TierUpgradeEnabled:     DefaultPlannerTierUpgradeEnabled,
 		},
-		plannerEnabled:        true,
-		scoreToolResultTurns:  true,
-		loopEscalationEnabled: true,
+		plannerEnabled:            true,
+		scoreToolResultTurns:      true,
+		loopEscalationEnabled:     true,
+		cyberRefusalRepin:         false,
+		cyberRefusalFallbackModel: "claude-sonnet-5",
 	}
 }
 
@@ -900,6 +914,22 @@ func (s *Service) WithPlannerEnabled(enabled bool) *Service {
 // WithScoreToolResultTurns sets ROUTER_SCORE_TOOL_RESULT_TURNS; see scoreToolResultTurns.
 func (s *Service) WithScoreToolResultTurns(enabled bool) *Service {
 	s.scoreToolResultTurns = enabled
+	return s
+}
+
+// WithCyberRefusalRepin is the kill switch for the cyber-refusal re-pin backstop
+// (ROUTER_CYBER_REFUSAL_REPIN); see cyberRefusalRepin.
+func (s *Service) WithCyberRefusalRepin(enabled bool) *Service {
+	s.cyberRefusalRepin = enabled
+	return s
+}
+
+// WithCyberRefusalFallbackModel sets the re-pin target used when the session pin
+// carries no runner-up (ROUTER_CYBER_REFUSAL_FALLBACK_MODEL). Empty is ignored.
+func (s *Service) WithCyberRefusalFallbackModel(model string) *Service {
+	if strings.TrimSpace(model) != "" {
+		s.cyberRefusalFallbackModel = strings.TrimSpace(model)
+	}
 	return s
 }
 
@@ -1570,6 +1600,120 @@ func (s *Service) anthropicNativeAttempt(
 	}
 }
 
+// refusalScanCap bounds how many response bytes a refusalObserver accumulates
+// while scanning for a safety-refusal signal. A refusal surfaces in the opening
+// events, so a small window catches it without buffering a whole response.
+const refusalScanCap = 64 * 1024
+
+// refusalObserver tees the anthropic-native passthrough response to inner
+// UNCHANGED while scanning a bounded prefix for a safety-refusal signal. It is
+// observe-only: it never modifies, drops, or delays forwarded bytes, so it
+// stays entirely off the risky path (the client always receives the raw
+// upstream stream). The native passthrough has no translator Summary to read,
+// so this is how a refusal is detected there. See detectRefusalSignal.
+type refusalObserver struct {
+	inner   http.ResponseWriter
+	buf     []byte
+	refused bool
+}
+
+func newRefusalObserver(inner http.ResponseWriter) *refusalObserver {
+	return &refusalObserver{inner: inner}
+}
+
+func (o *refusalObserver) Header() http.Header { return o.inner.Header() }
+
+func (o *refusalObserver) WriteHeader(status int) { o.inner.WriteHeader(status) }
+
+func (o *refusalObserver) Write(p []byte) (int, error) {
+	// Accumulate a bounded prefix (so a signal split across SSE chunks is still
+	// caught) and re-scan until the signal is found or the cap is reached. Never
+	// alters the bytes forwarded to the client.
+	if !o.refused && len(o.buf) < refusalScanCap {
+		room := refusalScanCap - len(o.buf)
+		if room > len(p) {
+			room = len(p)
+		}
+		o.buf = append(o.buf, p[:room]...)
+		if detectRefusalSignal(o.buf) {
+			o.refused = true
+		}
+	}
+	return o.inner.Write(p)
+}
+
+func (o *refusalObserver) Flush() {
+	if f, ok := o.inner.(http.Flusher); ok {
+		f.Flush()
+	}
+}
+
+// detectRefusalSignal is a multi-signal (over-detecting-is-safe) check for an
+// Anthropic safety refusal, robust to the exact wire shape: the documented
+// stop_reason "refusal" (HTTP 200), a refusal content block, the
+// api_refusal_category field, or the safeguard text signature.
+func detectRefusalSignal(b []byte) bool {
+	if bytes.Contains(b, []byte(`"stop_reason":"refusal"`)) ||
+		bytes.Contains(b, []byte(`"type":"refusal"`)) ||
+		bytes.Contains(b, []byte("api_refusal_category")) {
+		return true
+	}
+	return bytes.Contains(bytes.ToLower(b), []byte("safeguards flagged"))
+}
+
+// maybeRepinOnRefusal re-pins the session off a cyber-refusing model after the
+// turn completes, so subsequent turns route to a non-refusing model instead of
+// hitting the refusal again. Post-turn + observe-only: it never touches the
+// forwarded response. No-op when the flag is off, no refusal was observed, or
+// no distinct fallback model can be resolved.
+func (s *Service) maybeRepinOnRefusal(ctx context.Context, obs *refusalObserver, sessionKey [sessionpin.SessionKeyLen]byte, role string, served router.Decision) {
+	if obs == nil || !obs.refused || s.pinStore == nil {
+		return
+	}
+	log := observability.FromContext(ctx)
+	installationID := installationIDFromContext(ctx)
+	if installationID == uuid.Nil {
+		return
+	}
+	// Prefer the scorer's runner-up (PairedModel) as the re-pin target; else the
+	// configured fallback, resolving its provider from the catalog.
+	fbModel, fbProvider := s.cyberRefusalFallbackModel, ""
+	if existing, found, err := s.pinStore.Get(ctx, sessionKey, role); err == nil && found && existing.PairedModel != "" {
+		fbModel, fbProvider = existing.PairedModel, existing.PairedProvider
+	}
+	if fbProvider == "" {
+		if m, ok := catalog.ByID(fbModel); ok && len(m.Providers) > 0 {
+			fbProvider = m.Providers[0].Provider
+		}
+	}
+	if fbModel == "" || fbProvider == "" || fbModel == served.Model {
+		log.Warn("cyber refusal observed but no distinct fallback model available; not re-pinning",
+			"from_model", served.Model, "fallback_model", fbModel)
+		return
+	}
+	pin := sessionpin.Pin{
+		SessionKey:     sessionKey,
+		Role:           role,
+		InstallationID: installationID,
+		Provider:       fbProvider,
+		Model:          fbModel,
+		Reason:         "cyber-refusal-repin",
+		TurnCount:      1,
+		PinnedUntil:    pinExpiry("cyber-refusal-repin"),
+	}
+	// context.Background(): ctx may already be canceled here (response written,
+	// client disconnected); a canceled ctx would drop the re-pin write.
+	if err := s.pinStore.Upsert(context.Background(), pin); err != nil {
+		log.Error("cyber-refusal re-pin: pin upsert failed", "err", err, "from_model", served.Model, "to_model", fbModel)
+		return
+	}
+	log.Info("cyber refusal — re-pinned session off refusing model",
+		"session_key", shortSessionKey(sessionKey),
+		"from_model", served.Model,
+		"to_model", fbModel,
+		"to_provider", fbProvider)
+}
+
 func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.ResponseWriter, r *http.Request) error {
 	ctx = s.withUsageObserver(ctx, r.Header)
 	log := observability.FromContext(ctx)
@@ -2002,6 +2146,16 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 	if cacheEligible {
 		captureW = newCaptureWriter(rootSink, semanticCacheMaxBodyBytes)
 		sink = captureW
+	}
+	// Cyber-refusal backstop (ROUTER_CYBER_REFUSAL_REPIN, default off): observe
+	// the response stream for a safety refusal so a refused session is re-pinned
+	// off the refusing model post-turn (opus's cyber classifier declines ~45% of
+	// security-adjacent coding; sonnet 0%). Observe-only — forwarded bytes are
+	// never modified. Detection is here because the native path has no Summary.
+	var refusalObs *refusalObserver
+	if s.cyberRefusalRepin {
+		refusalObs = newRefusalObserver(sink)
+		sink = refusalObs
 	}
 
 	proxyStart := time.Now()
@@ -2581,6 +2735,11 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 	// 4xx wedges until manually /force-model'd out. Expires the pin after a
 	// persistent counter hits threshold; successful turns reset it.
 	s.maybeEvictPinAfterUpstreamErr(ctx, stickyHit, proxyErr, decision.Reason, installationID, routeRes.SessionKey, routeRes.PinRole)
+
+	// Cyber-refusal backstop: if the observer saw a safety refusal on this turn,
+	// re-pin the session off the refusing model so subsequent turns route around
+	// it. No-op when the flag is off (refusalObs is nil) or no refusal was seen.
+	s.maybeRepinOnRefusal(ctx, refusalObs, routeRes.SessionKey, routeRes.PinRole, decision)
 
 	// One event per tool_use block that failed toolcheck validation, including
 	// repaired ones — doubles as a per-model×provider tool-calling-quality signal.

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -1667,8 +1667,7 @@ func detectRefusalSignal(b []byte) bool {
 }
 
 // maybeRepinOnRefusal re-pins the session off the refusing model post-turn
-// so subsequent turns route to a non-refusing model. No-op when the flag is
-// off, no refusal was observed, or no fallback model can be resolved.
+// so subsequent turns route to a non-refusing model.
 func (s *Service) maybeRepinOnRefusal(ctx context.Context, obs *refusalObserver, sessionKey [sessionpin.SessionKeyLen]byte, role string, served router.Decision) {
 	if obs == nil || !obs.refused || s.pinStore == nil {
 		return


### PR DESCRIPTION
## What

Anthropic's cyber safety classifier declines **~45% of security-adjacent coding turns on `claude-opus-4-8`** (`stop_reason:"refusal"` on HTTP 200; `sonnet` 0%). In-harness these surface as empty patches / failed turns. The Cyber Verification Program exemption is applied for but pending — **this is the defensive backstop.**

On a detected refusal, re-pin the session off the refusing model to a non-refusing one, so the rest of the session routes around it.

## How (safe by construction)

- **Observe-only detector** (`refusalObserver`) wraps the response sink and tees bytes to the client **unchanged** while scanning a bounded prefix. It never modifies, drops, or delays forwarded bytes — so it stays off the streaming hot path.
- Needed because the **anthropic-native path is a raw passthrough** (`anthropicNativeAttempt`) with no translator `Summary()`, so `respSummary.StopReason` is never populated there — the refusal signal has to be observed off the stream.
- **Multi-signal detection** (over-detecting is safe here — re-pin to sonnet is always valid), robust to the exact wire shape: `"stop_reason":"refusal"`, a `"type":"refusal"` content block, `api_refusal_category`, or the case-insensitive `"safeguards flagged"` text.
- **Post-turn re-pin:** prefer the pin's runner-up (`PairedModel`/`PairedProvider`), else `ROUTER_CYBER_REFUSAL_FALLBACK_MODEL` (default `claude-sonnet-5`, provider resolved from the catalog). Written via `pinStore.Upsert(context.Background(), ...)` with reason `cyber-refusal-repin`. Structured `log.Info` (session key, from/to model) as the telemetry signal.

## Flag

`ROUTER_CYBER_REFUSAL_REPIN`, **default false** (mirrors the `ROUTER_SCORE_TOOL_RESULT_TURNS` #580 pattern: service field + `cmd/router/main.go` env + `.env.example` + `WithX` option). Enabled on the defensive deploy; shadow-able.

## Scope / follow-up

- Does **not** modify forwarded bytes or touch the streaming hot path — the refused *current* turn is still lost; only subsequent turns re-route. Transparently retrying the refused turn mid-stream would require holding/retracting the stream and is a documented follow-up.
- No real refusal fixture was capturable locally (no Anthropic key reachable); the test uses a synthetic Anthropic-native refusal SSE built to the documented shape, and the multi-signal design covers whichever signal the live stream carries.

## Tests

`internal/proxy/cyber_refusal_internal_test.go`: `detectRefusalSignal` (all 4 signals + two negatives incl. a benign "cybersecurity" mention), `refusalObserver` (signal split across writes is caught; bytes forwarded unchanged; no false-positive on `end_turn`), and `maybeRepinOnRefusal` (re-pin to fallback, prefer `PairedModel`, and no-op when flag off / no refusal / served == fallback).

`go build ./...` clean; `go test ./internal/proxy/ -count=1` green.

🤖 Generated with Claude Code
