### PR TITLE
feat(proxy): emit usage + cost on router.usage_bypass span

### DIFF
--- a/internal/proxy/usage_bypass.go
+++ b/internal/proxy/usage_bypass.go
@@ -229,8 +229,7 @@ func (s *Service) bypassToAnthropic(
 	}
 
 	// Tap the response stream so the bypass span carries token usage for
-	// Weave's router cost-savings metric — subscription-served turns would
-	// otherwise be invisible to it.
+	// Weave's router cost-savings metric — subscription turns are otherwise invisible.
 	var extractor *otel.UsageExtractor
 	if s.usageRequired() {
 		extractor = otel.NewUsageExtractor(w, decision.Provider)

--- a/internal/proxy/usage_bypass.go
+++ b/internal/proxy/usage_bypass.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"time"
 
+	"workweave/router/internal/auth"
 	"workweave/router/internal/observability"
 	"workweave/router/internal/observability/otel"
 	"workweave/router/internal/providers"
@@ -227,6 +228,18 @@ func (s *Service) bypassToAnthropic(
 		return fmt.Errorf("emit bypass body: %w", emitErr)
 	}
 
+	// Tap the response stream for token usage. The bypass path skips billing
+	// (the customer's own subscription pays), but Weave's router cost-savings
+	// metric still needs the would-have-cost of this turn — otherwise every
+	// subscription-served request is invisible to it. The extractor forwards
+	// bytes to the real writer untouched and yields (0,0) when usage isn't
+	// streamed, matching the routed path's Anthropic-native attempt.
+	var extractor *otel.UsageExtractor
+	if s.usageRequired() {
+		extractor = otel.NewUsageExtractor(w, decision.Provider)
+		w = extractor
+	}
+
 	proxyStart := time.Now()
 	proxyErr := p.Proxy(ctx, decision, prep, w, r)
 	// The Anthropic adapter returns a buffered *UpstreamErrorResponse on 4xx/5xx
@@ -246,17 +259,46 @@ func (s *Service) bypassToAnthropic(
 		flushUpstreamErrorAsAnthropic(w, proxyErr)
 		proxyErr = nil
 	}
+	// Bypass never substitutes the model, so requested == actual cost: both are
+	// the API cost of running feats.Model directly. Weave credits actual to $0
+	// downstream when cost.subscription_served is set, turning that cost into
+	// the savings the subscription delivered.
+	in, out := extractor.Tokens()
+	cacheCreation, cacheRead := extractor.CacheTokens()
+	pricing, _ := catalog.PriceFor(decision.Provider, decision.Model)
+	inputCost := catalog.EffectiveInputCost(in, cacheCreation, cacheRead, pricing.InputUSDPer1M, pricing, decision.Provider)
+	outputCost := catalog.EffectiveOutputCost(out, pricing.OutputUSDPer1M)
+
+	// Same identity block the routed upstream span carries, so Weave's savings
+	// drilldown groups bypass turns by user / session / tool instead of folding
+	// them into an anonymous "Unknown session" bucket.
+	clientID := ClientIdentityFrom(ctx)
 	otel.Record(ctx, otel.Span{
 		Name:  "router.usage_bypass",
 		Start: requestStart,
 		End:   time.Now(),
-		Attrs: otel.NewAttrBuilder(6).
+		Attrs: otel.NewAttrBuilder(18).
 			String("request_id", requestID).
 			String("external_id", externalID).
+			String("router_user_id", auth.UserIDFrom(ctx)).
+			String("client.app", clientID.ClientApp).
+			String("client.session_id", clientID.SessionID).
+			// Bypass never substitutes, so the requested model IS the served
+			// model; emit it so the savings drilldown's requested/decision
+			// columns match the routed path's shape.
+			String("requested.model", decision.Model).
 			String("decision.model", decision.Model).
 			String("decision.provider", decision.Provider).
 			String("decision.reason", decision.Reason).
 			Bool("cost.subscription_served", servedOnSubscription(ctx)).
+			Int64("usage.input_tokens", int64(in)).
+			Int64("usage.output_tokens", int64(out)).
+			Int64("usage.cache_creation_input_tokens", int64(cacheCreation)).
+			Int64("usage.cache_read_input_tokens", int64(cacheRead)).
+			Float64("cost.requested_input_usd", inputCost).
+			Float64("cost.requested_output_usd", outputCost).
+			Float64("cost.actual_input_usd", inputCost).
+			Float64("cost.actual_output_usd", outputCost).
 			Build(),
 	})
 	otel.Flush(ctx)

--- a/internal/proxy/usage_bypass.go
+++ b/internal/proxy/usage_bypass.go
@@ -228,12 +228,9 @@ func (s *Service) bypassToAnthropic(
 		return fmt.Errorf("emit bypass body: %w", emitErr)
 	}
 
-	// Tap the response stream for token usage. The bypass path skips billing
-	// (the customer's own subscription pays), but Weave's router cost-savings
-	// metric still needs the would-have-cost of this turn — otherwise every
-	// subscription-served request is invisible to it. The extractor forwards
-	// bytes to the real writer untouched and yields (0,0) when usage isn't
-	// streamed, matching the routed path's Anthropic-native attempt.
+	// Tap the response stream so the bypass span carries token usage for
+	// Weave's router cost-savings metric — subscription-served turns would
+	// otherwise be invisible to it.
 	var extractor *otel.UsageExtractor
 	if s.usageRequired() {
 		extractor = otel.NewUsageExtractor(w, decision.Provider)
@@ -259,10 +256,8 @@ func (s *Service) bypassToAnthropic(
 		flushUpstreamErrorAsAnthropic(w, proxyErr)
 		proxyErr = nil
 	}
-	// Bypass never substitutes the model, so requested == actual cost: both are
-	// the API cost of running feats.Model directly. Weave credits actual to $0
-	// downstream when cost.subscription_served is set, turning that cost into
-	// the savings the subscription delivered.
+	// Bypass never substitutes the model, so requested == actual; Weave credits
+	// actual to $0 downstream when cost.subscription_served is set.
 	in, out := extractor.Tokens()
 	cacheCreation, cacheRead := extractor.CacheTokens()
 	pricing, _ := catalog.PriceFor(decision.Provider, decision.Model)
@@ -283,9 +278,7 @@ func (s *Service) bypassToAnthropic(
 			String("router_user_id", auth.UserIDFrom(ctx)).
 			String("client.app", clientID.ClientApp).
 			String("client.session_id", clientID.SessionID).
-			// Bypass never substitutes, so the requested model IS the served
-			// model; emit it so the savings drilldown's requested/decision
-			// columns match the routed path's shape.
+			// Bypass never substitutes, so requested model IS the served model.
 			String("requested.model", decision.Model).
 			String("decision.model", decision.Model).
 			String("decision.provider", decision.Provider).

--- a/internal/proxy/usage_bypass.go
+++ b/internal/proxy/usage_bypass.go
@@ -264,9 +264,7 @@ func (s *Service) bypassToAnthropic(
 	inputCost := catalog.EffectiveInputCost(in, cacheCreation, cacheRead, pricing.InputUSDPer1M, pricing, decision.Provider)
 	outputCost := catalog.EffectiveOutputCost(out, pricing.OutputUSDPer1M)
 
-	// Same identity block the routed upstream span carries, so Weave's savings
-	// drilldown groups bypass turns by user / session / tool instead of folding
-	// them into an anonymous "Unknown session" bucket.
+	// Same identity block as the routed upstream span so Weave groups bypass turns by user/session.
 	clientID := ClientIdentityFrom(ctx)
 	otel.Record(ctx, otel.Span{
 		Name:  "router.usage_bypass",

--- a/internal/proxy/usage_bypass_internal_test.go
+++ b/internal/proxy/usage_bypass_internal_test.go
@@ -307,12 +307,9 @@ func spanBool(t *testing.T, sp *tracev1.Span, key string) bool {
 	return false
 }
 
-// TestBypass_EmitsUsageAndCost is the regression guard for the router
-// cost-savings metric: the subscription bypass path skips billing, so unless it
-// emits token usage + the would-have-cost on its span, every subscription-served
-// turn is invisible to Weave's savings drilldown. A fake upstream streams a
-// known Anthropic usage envelope; the span must carry those tokens and the
-// catalog-priced cost of running the model directly.
+// TestBypass_EmitsUsageAndCost guards that the bypass span carries token usage
+// + catalog-priced cost — subscription turns are invisible to the savings metric
+// without it.
 func TestBypass_EmitsUsageAndCost(t *testing.T) {
 	const (
 		inputTokens  = 1200

--- a/internal/proxy/usage_bypass_internal_test.go
+++ b/internal/proxy/usage_bypass_internal_test.go
@@ -306,8 +306,7 @@ func spanBool(t *testing.T, sp *tracev1.Span, key string) bool {
 }
 
 // TestBypass_EmitsUsageAndCost guards that the bypass span carries token usage
-// + catalog-priced cost — subscription turns are invisible to the savings metric
-// without it.
+// + catalog-priced cost — subscription turns are invisible to the savings metric without it.
 func TestBypass_EmitsUsageAndCost(t *testing.T) {
 	const (
 		inputTokens  = 1200

--- a/internal/proxy/usage_bypass_internal_test.go
+++ b/internal/proxy/usage_bypass_internal_test.go
@@ -3,18 +3,27 @@ package proxy
 import (
 	"context"
 	"errors"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
+	"workweave/router/internal/observability/otel"
 	"workweave/router/internal/providers"
 	"workweave/router/internal/router"
+	"workweave/router/internal/router/catalog"
 	"workweave/router/internal/translate"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+
+	coltracepb "go.opentelemetry.io/proto/otlp/collector/trace/v1"
+	commonv1 "go.opentelemetry.io/proto/otlp/common/v1"
+	tracev1 "go.opentelemetry.io/proto/otlp/trace/v1"
 )
 
 // bypassFakeProvider is an internal-package fake providers.Client for
@@ -22,6 +31,7 @@ import (
 // test can assert no bytes were committed on a retryable error.
 type bypassFakeProvider struct {
 	proxyErr     error
+	respBody     string
 	dispatches   int
 	capturedW    http.ResponseWriter
 	capturedBody []byte
@@ -37,6 +47,9 @@ func (f *bypassFakeProvider) Proxy(ctx context.Context, decision router.Decision
 	f.capturedW = w
 	f.capturedR = r
 	f.capturedBody = append([]byte(nil), prep.Body...)
+	if f.respBody != "" {
+		_, _ = io.WriteString(w, f.respBody)
+	}
 	return f.proxyErr
 }
 
@@ -208,4 +221,163 @@ func TestSubscriptionFailover_EligibilityAndSuppression(t *testing.T) {
 		assert.False(t, servedOnSubscription(suppressed),
 			"a suppressed subscription must not resolve back as the served credential")
 	})
+}
+
+// bypassSpanCollector runs an httptest OTLP endpoint and records every exported
+// span keyed by name, so a test can assert the attributes emitted on the
+// router.usage_bypass span.
+type bypassSpanCollector struct {
+	srv    *httptest.Server
+	mu     sync.Mutex
+	byName map[string][]*tracev1.Span
+}
+
+func newBypassSpanCollector(t *testing.T) *bypassSpanCollector {
+	t.Helper()
+	c := &bypassSpanCollector{byName: make(map[string][]*tracev1.Span)}
+	c.srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		var req coltracepb.ExportTraceServiceRequest
+		require.NoError(t, proto.Unmarshal(body, &req))
+		c.mu.Lock()
+		for _, rs := range req.ResourceSpans {
+			for _, ss := range rs.ScopeSpans {
+				for _, sp := range ss.Spans {
+					c.byName[sp.Name] = append(c.byName[sp.Name], sp)
+				}
+			}
+		}
+		c.mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(c.srv.Close)
+	return c
+}
+
+func spanStr(t *testing.T, sp *tracev1.Span, key string) string {
+	t.Helper()
+	for _, kv := range sp.Attributes {
+		if kv.Key == key {
+			sv, ok := kv.Value.Value.(*commonv1.AnyValue_StringValue)
+			require.True(t, ok, "attr %q must be a string", key)
+			return sv.StringValue
+		}
+	}
+	t.Fatalf("attr %q not present on span", key)
+	return ""
+}
+
+func spanInt(t *testing.T, sp *tracev1.Span, key string) int64 {
+	t.Helper()
+	for _, kv := range sp.Attributes {
+		if kv.Key == key {
+			iv, ok := kv.Value.Value.(*commonv1.AnyValue_IntValue)
+			require.True(t, ok, "attr %q must be an int", key)
+			return iv.IntValue
+		}
+	}
+	t.Fatalf("attr %q not present on span", key)
+	return 0
+}
+
+func spanFloat(t *testing.T, sp *tracev1.Span, key string) float64 {
+	t.Helper()
+	for _, kv := range sp.Attributes {
+		if kv.Key == key {
+			dv, ok := kv.Value.Value.(*commonv1.AnyValue_DoubleValue)
+			require.True(t, ok, "attr %q must be a double", key)
+			return dv.DoubleValue
+		}
+	}
+	t.Fatalf("attr %q not present on span", key)
+	return 0
+}
+
+func spanBool(t *testing.T, sp *tracev1.Span, key string) bool {
+	t.Helper()
+	for _, kv := range sp.Attributes {
+		if kv.Key == key {
+			bv, ok := kv.Value.Value.(*commonv1.AnyValue_BoolValue)
+			require.True(t, ok, "attr %q must be a bool", key)
+			return bv.BoolValue
+		}
+	}
+	t.Fatalf("attr %q not present on span", key)
+	return false
+}
+
+// TestBypass_EmitsUsageAndCost is the regression guard for the router
+// cost-savings metric: the subscription bypass path skips billing, so unless it
+// emits token usage + the would-have-cost on its span, every subscription-served
+// turn is invisible to Weave's savings drilldown. A fake upstream streams a
+// known Anthropic usage envelope; the span must carry those tokens and the
+// catalog-priced cost of running the model directly.
+func TestBypass_EmitsUsageAndCost(t *testing.T) {
+	const (
+		inputTokens  = 1200
+		outputTokens = 340
+		model        = "claude-sonnet-4-6"
+	)
+	sse := "event: message_start\n" +
+		`data: {"type":"message_start","message":{"usage":{"input_tokens":1200,"output_tokens":1}}}` + "\n\n" +
+		"event: message_delta\n" +
+		`data: {"type":"message_delta","usage":{"output_tokens":340}}` + "\n\n"
+
+	collector := newBypassSpanCollector(t)
+	emitter, err := otel.NewEmitter(otel.EmitterConfig{
+		Endpoint:      collector.srv.URL,
+		Workers:       1,
+		QueueSize:     100,
+		BatchSize:     1,
+		FlushInterval: 10 * time.Millisecond,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = emitter.Shutdown(context.Background()) })
+
+	upstream := &bypassFakeProvider{respBody: sse}
+	svc := newBypassService(upstream)
+	svc.emitter = emitter // makes usageRequired() true so the extractor runs
+
+	env := bypassAnthropicEnvelope(t)
+	feats := env.RoutingFeatures(false)
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(""))
+
+	buf := otel.NewBuffer(emitter)
+	ctx := buf.WithContext(context.Background())
+	err = svc.bypassToAnthropic(ctx, env, feats, false, time.Now(), "req-1", "ext-1", req, rec)
+	require.NoError(t, err)
+	buf.Flush()
+
+	require.Eventually(t, func() bool {
+		collector.mu.Lock()
+		defer collector.mu.Unlock()
+		return len(collector.byName["router.usage_bypass"]) == 1
+	}, time.Second, 5*time.Millisecond, "the bypass span must be exported")
+
+	collector.mu.Lock()
+	sp := collector.byName["router.usage_bypass"][0]
+	collector.mu.Unlock()
+
+	assert.Equal(t, model, spanStr(t, sp, "requested.model"), "bypass requested model IS the served model")
+	assert.Equal(t, model, spanStr(t, sp, "decision.model"))
+	assert.Equal(t, int64(inputTokens), spanInt(t, sp, "usage.input_tokens"))
+	assert.Equal(t, int64(outputTokens), spanInt(t, sp, "usage.output_tokens"))
+	// No OAuth credential in this unit context, so the turn is not
+	// subscription-served — but the flag must still be emitted (spanBool fatals
+	// if the attribute is absent, guarding the contract Weave ingests).
+	assert.False(t, spanBool(t, sp, "cost.subscription_served"))
+
+	pricing, ok := catalog.PriceFor(providers.ProviderAnthropic, model)
+	require.True(t, ok, "test model must have catalog pricing")
+	wantOut := catalog.EffectiveOutputCost(outputTokens, pricing.OutputUSDPer1M)
+	wantIn := catalog.EffectiveInputCost(inputTokens, 0, 0, pricing.InputUSDPer1M, pricing, providers.ProviderAnthropic)
+
+	// Bypass never substitutes the model, so requested == actual on the span;
+	// Weave zeroes actual downstream when subscription_served is set.
+	assert.InDelta(t, wantOut, spanFloat(t, sp, "cost.actual_output_usd"), 1e-9)
+	assert.InDelta(t, wantIn, spanFloat(t, sp, "cost.actual_input_usd"), 1e-9)
+	assert.InDelta(t, wantOut, spanFloat(t, sp, "cost.requested_output_usd"), 1e-9)
+	assert.InDelta(t, wantIn, spanFloat(t, sp, "cost.requested_input_usd"), 1e-9)
 }

--- a/internal/proxy/usage_bypass_internal_test.go
+++ b/internal/proxy/usage_bypass_internal_test.go
@@ -223,9 +223,7 @@ func TestSubscriptionFailover_EligibilityAndSuppression(t *testing.T) {
 	})
 }
 
-// bypassSpanCollector runs an httptest OTLP endpoint and records every exported
-// span keyed by name, so a test can assert the attributes emitted on the
-// router.usage_bypass span.
+// bypassSpanCollector is an in-process OTLP endpoint that records spans by name for assertion.
 type bypassSpanCollector struct {
 	srv    *httptest.Server
 	mu     sync.Mutex
@@ -361,9 +359,7 @@ func TestBypass_EmitsUsageAndCost(t *testing.T) {
 	assert.Equal(t, model, spanStr(t, sp, "decision.model"))
 	assert.Equal(t, int64(inputTokens), spanInt(t, sp, "usage.input_tokens"))
 	assert.Equal(t, int64(outputTokens), spanInt(t, sp, "usage.output_tokens"))
-	// No OAuth credential in this unit context, so the turn is not
-	// subscription-served — but the flag must still be emitted (spanBool fatals
-	// if the attribute is absent, guarding the contract Weave ingests).
+	// No subscription credential here, but spanBool fatals if the attribute is absent — guards the emitted contract.
 	assert.False(t, spanBool(t, sp, "cost.subscription_served"))
 
 	pricing, ok := catalog.PriceFor(providers.ProviderAnthropic, model)


### PR DESCRIPTION
## Why

Subscription **usage-bypass** turns serve straight to Anthropic on the customer's own plan and deliberately skip billing, so the `router.usage_bypass` span carried no token or cost data — just the decision + `cost.subscription_served` flag.

That made every subscription-served request **invisible** to Weave's router cost-savings metric. Weave's savings pipeline inner-joins `router.decision` ↔ `router.upstream` spans, and the bypass path returns early *before* those spans are ever emitted (`service.go` engages the bypass inside `runTurnLoop` and `return`s). So the biggest chunk of subscription traffic — pure savings, since the customer pays $0 — never shows up in the drilldown at all.

## What

Wrap the client writer with `otel.UsageExtractor` before `p.Proxy` — exactly as the routed Anthropic-native attempt does — so the bypass span now carries:

- `usage.{input,output,cache_creation_input,cache_read_input}_tokens`
- `cost.{requested,actual}_{input,output}_usd` — the catalog-priced cost of running the model directly

Bypass never substitutes the model, so `requested == actual` on the span. Weave zeroes `actual` downstream when `cost.subscription_served` is set, turning that cost into the savings the subscription delivered.

The extractor is nil-safe and yields `(0,0)` when usage isn't streamed, matching the routed path's behavior on error.

## Downstream

Paired with a WorkWeave PR that ingests the `router.usage_bypass` span type + `cost.subscription_served`, credits `$0` actual for subscription turns in the savings pipeline, and surfaces a "Served via" column in the router cost-savings drilldown. The WorkWeave gitlink bump waits until this merges + deploys.

## Test

`TestBypass_EmitsUsageAndCost` streams a known Anthropic usage envelope through a fake upstream and asserts the exported span carries the expected tokens and the catalog-priced cost (input + output, requested + actual). Full `internal/proxy` suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)