### PR TITLE
feat(router): add CI gate enforcing one deployed model per family

### DIFF
--- a/internal/router/catalog/family.go
+++ b/internal/router/catalog/family.go
@@ -1,0 +1,100 @@
+package catalog
+
+import (
+	"fmt"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// familyVersionPattern matches "<family><major>[.-<minor>][-<suffix>]" —
+// e.g. claude-sonnet-4-6, gpt-5.4-mini, kimi-k2.7. IDs with no generation
+// number (gpt-4o) don't match and are treated as singleton families.
+var familyVersionPattern = regexp.MustCompile(`^(.+?)(\d+)(?:[.-](\d+))?(-[a-z][a-z0-9\-]*)?$`)
+
+// FamilyAndVersion parses id into a family key (generation stripped, suffix
+// kept, e.g. "gpt-5.4-mini" → family "gpt-mini") and a (major, minor) version
+// tuple. ok=false means id has no generation number; treat as singleton family.
+func FamilyAndVersion(id string) (family string, version [2]int, ok bool) {
+	m := familyVersionPattern.FindStringSubmatch(id)
+	if m == nil {
+		return "", [2]int{}, false
+	}
+	major, err := strconv.Atoi(m[2])
+	if err != nil {
+		return "", [2]int{}, false
+	}
+	minor := 0
+	if m[3] != "" {
+		minor, err = strconv.Atoi(m[3])
+		if err != nil {
+			return "", [2]int{}, false
+		}
+	}
+	return strings.TrimSuffix(m[1], "-") + m[4], [2]int{major, minor}, true
+}
+
+// versionLess reports whether a is an earlier generation than b.
+func versionLess(a, b [2]int) bool {
+	if a[0] != b[0] {
+		return a[0] < b[0]
+	}
+	return a[1] < b[1]
+}
+
+// FamilyDuplicates returns, for each family with 2+ members, the non-newest
+// ids paired with the newest superseder. IDs with ok=false are exempt.
+func FamilyDuplicates(ids []string) []Duplicate {
+	type member struct {
+		id      string
+		version [2]int
+	}
+	byFamily := make(map[string][]member)
+	for _, id := range ids {
+		family, version, ok := FamilyAndVersion(id)
+		if !ok {
+			continue
+		}
+		byFamily[family] = append(byFamily[family], member{id: id, version: version})
+	}
+
+	var out []Duplicate
+	for family, members := range byFamily {
+		if len(members) < 2 {
+			continue
+		}
+		newest := members[0]
+		for _, m := range members[1:] {
+			if versionLess(newest.version, m.version) {
+				newest = m
+			}
+		}
+		for _, m := range members {
+			if m.id == newest.id {
+				continue
+			}
+			out = append(out, Duplicate{Family: family, Superseded: m.id, SupersededBy: newest.id})
+		}
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Family != out[j].Family {
+			return out[i].Family < out[j].Family
+		}
+		return out[i].Superseded < out[j].Superseded
+	})
+	return out
+}
+
+// Duplicate is one FamilyDuplicates finding: Superseded should be dropped in
+// favor of the already-present, strictly newer SupersededBy.
+type Duplicate struct {
+	Family       string
+	Superseded   string
+	SupersededBy string
+}
+
+// String renders a human-readable line for test failure output.
+func (d Duplicate) String() string {
+	return fmt.Sprintf("family %q: %q is superseded by %q (already deployed) — drop it from deployed_models", d.Family, d.Superseded, d.SupersededBy)
+}

--- a/internal/router/catalog/family_test.go
+++ b/internal/router/catalog/family_test.go
@@ -1,0 +1,115 @@
+package catalog
+
+import "testing"
+
+func TestFamilyAndVersion(t *testing.T) {
+	tests := []struct {
+		id      string
+		family  string
+		version [2]int
+		ok      bool
+	}{
+		{"claude-sonnet-4-5", "claude-sonnet", [2]int{4, 5}, true},
+		{"claude-sonnet-4-6", "claude-sonnet", [2]int{4, 6}, true},
+		{"claude-sonnet-5", "claude-sonnet", [2]int{5, 0}, true},
+		{"claude-opus-4-6", "claude-opus", [2]int{4, 6}, true},
+		{"claude-opus-4-7", "claude-opus", [2]int{4, 7}, true},
+		{"claude-opus-4-8", "claude-opus", [2]int{4, 8}, true},
+		{"claude-haiku-4-5", "claude-haiku", [2]int{4, 5}, true},
+		{"claude-fable-5", "claude-fable", [2]int{5, 0}, true},
+		{"gpt-4.1", "gpt", [2]int{4, 1}, true},
+		{"gpt-4.1-mini", "gpt-mini", [2]int{4, 1}, true},
+		{"gpt-4.1-nano", "gpt-nano", [2]int{4, 1}, true},
+		{"gpt-5", "gpt", [2]int{5, 0}, true},
+		{"gpt-5-mini", "gpt-mini", [2]int{5, 0}, true},
+		{"gpt-5-nano", "gpt-nano", [2]int{5, 0}, true},
+		{"gpt-5-chat", "gpt-chat", [2]int{5, 0}, true},
+		{"gpt-5.4", "gpt", [2]int{5, 4}, true},
+		{"gpt-5.4-mini", "gpt-mini", [2]int{5, 4}, true},
+		{"gpt-5.4-pro", "gpt-pro", [2]int{5, 4}, true},
+		{"gpt-5.5", "gpt", [2]int{5, 5}, true},
+		{"gpt-5.5-mini", "gpt-mini", [2]int{5, 5}, true},
+		{"gpt-5.5-pro", "gpt-pro", [2]int{5, 5}, true},
+		{"gpt-4o", "", [2]int{}, false},
+		{"gpt-4o-mini", "", [2]int{}, false},
+		{"gemini-2.0-flash", "gemini-flash", [2]int{2, 0}, true},
+		{"gemini-2.5-flash", "gemini-flash", [2]int{2, 5}, true},
+		{"gemini-3.5-flash", "gemini-flash", [2]int{3, 5}, true},
+		{"gemini-3-pro-preview", "gemini-pro-preview", [2]int{3, 0}, true},
+		{"gemini-3.1-pro-preview", "gemini-pro-preview", [2]int{3, 1}, true},
+		{"z-ai/glm-5", "z-ai/glm", [2]int{5, 0}, true},
+		{"z-ai/glm-5.1", "z-ai/glm", [2]int{5, 1}, true},
+		{"z-ai/glm-5.2", "z-ai/glm", [2]int{5, 2}, true},
+		{"moonshotai/kimi-k2.5", "moonshotai/kimi-k", [2]int{2, 5}, true},
+		{"moonshotai/kimi-k2.6", "moonshotai/kimi-k", [2]int{2, 6}, true},
+		{"moonshotai/kimi-k2.7", "moonshotai/kimi-k", [2]int{2, 7}, true},
+		{"minimax/minimax-m2.7", "minimax/minimax-m", [2]int{2, 7}, true},
+		{"minimax/minimax-m3", "minimax/minimax-m", [2]int{3, 0}, true},
+		{"deepseek/deepseek-v4-pro", "deepseek/deepseek-v-pro", [2]int{4, 0}, true},
+		{"deepseek/deepseek-v4-flash", "deepseek/deepseek-v-flash", [2]int{4, 0}, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.id, func(t *testing.T) {
+			family, version, ok := FamilyAndVersion(tt.id)
+			if ok != tt.ok {
+				t.Fatalf("FamilyAndVersion(%q) ok = %v, want %v", tt.id, ok, tt.ok)
+			}
+			if !ok {
+				return
+			}
+			if family != tt.family {
+				t.Errorf("FamilyAndVersion(%q) family = %q, want %q", tt.id, family, tt.family)
+			}
+			if version != tt.version {
+				t.Errorf("FamilyAndVersion(%q) version = %v, want %v", tt.id, version, tt.version)
+			}
+		})
+	}
+}
+
+func TestFamilyDuplicates(t *testing.T) {
+	ids := []string{
+		"claude-haiku-4-5",
+		"claude-sonnet-4-6",
+		"claude-sonnet-5",
+		"claude-opus-4-7",
+		"claude-opus-4-8",
+		"moonshotai/kimi-k2.6",
+		"moonshotai/kimi-k2.7",
+		"gpt-5.5",
+	}
+	dups := FamilyDuplicates(ids)
+	got := make(map[string]string, len(dups))
+	for _, d := range dups {
+		got[d.Superseded] = d.SupersededBy
+	}
+	want := map[string]string{
+		"claude-sonnet-4-6":    "claude-sonnet-5",
+		"claude-opus-4-7":      "claude-opus-4-8",
+		"moonshotai/kimi-k2.6": "moonshotai/kimi-k2.7",
+	}
+	if len(got) != len(want) {
+		t.Fatalf("FamilyDuplicates(%v) = %v, want %v", ids, dups, want)
+	}
+	for supersededID, wantBy := range want {
+		gotBy, ok := got[supersededID]
+		if !ok {
+			t.Errorf("expected %q to be flagged as superseded, was not", supersededID)
+			continue
+		}
+		if gotBy != wantBy {
+			t.Errorf("FamilyDuplicates: %q superseded by %q, want %q", supersededID, gotBy, wantBy)
+		}
+	}
+}
+
+func TestFamilyDuplicates_NoFalsePositiveOnDistinctSizes(t *testing.T) {
+	ids := []string{
+		"deepseek/deepseek-v4-flash",
+		"deepseek/deepseek-v4-pro",
+		"gpt-5.5-mini",
+	}
+	if dups := FamilyDuplicates(ids); len(dups) != 0 {
+		t.Errorf("FamilyDuplicates(%v) = %v, want no duplicates", ids, dups)
+	}
+}

--- a/internal/router/cluster/artifacts_test.go
+++ b/internal/router/cluster/artifacts_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/binary"
 	"encoding/json"
+	"fmt"
 	"math"
 	"testing"
 
@@ -219,6 +220,25 @@ func TestEmbeddedArtifacts_AllVersionsLoadable(t *testing.T) {
 			assert.NotEmpty(t, bundle.Registry.DeployedModels)
 		})
 	}
+}
+
+// Enforces one deployed model per family on the latest bundle only; frozen
+// historical bundles intentionally retain predecessors (BYOK, /force-model).
+func TestLatestBundle_OneDeployedModelPerFamily(t *testing.T) {
+	version, err := ResolveVersion(LatestVersion)
+	require.NoError(t, err)
+	bundle, err := LoadBundle(version)
+	require.NoError(t, err)
+
+	dups := catalog.FamilyDuplicates(bundle.Registry.Models())
+	if len(dups) == 0 {
+		return
+	}
+	msg := fmt.Sprintf("latest bundle %s deploys more than one model per family — see docs/plans/ROUTER_MODEL_LIFECYCLE.md and the add-router-model skill for how to retire a superseded model from deployed_models:", version)
+	for _, d := range dups {
+		msg += "\n  - " + d.String()
+	}
+	t.Error(msg)
 }
 
 // Catches a typo'd latest pointer.


### PR DESCRIPTION
catalog.FamilyAndVersion/FamilyDuplicates derives a model's family and
generation straight from its ID (claude-sonnet-4-6 -> family
claude-sonnet, gen 4.6), so there's no hand-maintained "latest model"
list to keep in sync as new generations ship.

Adds a cluster test that fails the moment the served bundle's
deployed_models carries two generations of the same family. It
currently fails against v0.72 (the sonnet-4-6/opus-4-7/kimi-k2.6
duplicates already fixed by v0.73 in #656) until v0.73 clears an
offline screen + live bake-off and `latest` is flipped, per
docs/plans/ROUTER_MODEL_LIFECYCLE.md.