### PR TITLE
fix(ci): correct cluster-routing bot login from weave-bot to workweave-bot

### DIFF
--- a/.github/workflows/cluster_routing_ack.yml
+++ b/.github/workflows/cluster_routing_ack.yml
@@ -27,8 +27,8 @@ jobs:
     name: Routing review acknowledge
     if: >-
       github.event.issue.pull_request != null &&
-      github.event.sender.login != 'weave-bot' &&
-      github.event.comment.user.login == 'weave-bot' &&
+      github.event.sender.login != 'workweave-bot' &&
+      github.event.comment.user.login == 'workweave-bot' &&
       contains(github.event.comment.body, '<!-- cluster-routing-report:')
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/publish_cluster_routing.yml
+++ b/.github/workflows/publish_cluster_routing.yml
@@ -41,7 +41,7 @@ concurrency:
 env:
   CHECK_CONTEXT: cluster-routing/acknowledged
   COMMENT_MARKER_PREFIX: "<!-- cluster-routing-report:"
-  BOT_LOGIN: "weave-bot"
+  BOT_LOGIN: "workweave-bot"
   LATEST_PATH: internal/router/cluster/artifacts/latest
 
 jobs:
@@ -72,7 +72,7 @@ jobs:
       - name: Upsert comment and set status
         uses: actions/github-script@v7
         with:
-          # PAT so the sticky comment is authored by weave-bot (cluster_routing_ack
+          # PAT so the sticky comment is authored by workweave-bot (cluster_routing_ack
           # keys the acknowledgment gate off this author login). Needs issues:write,
           # pull-requests:read, statuses:write on this repo.
           github-token: ${{ secrets.WEAVE_BOT_TOKEN }}


### PR DESCRIPTION
## Why

\`WEAVE_BOT_TOKEN\` authenticates as \`workweave-bot\` (see the comment in
\`comment_length_review.yml\`), but \`publish_cluster_routing.yml\` and
\`cluster_routing_ack.yml\` both hardcoded the stale login \`weave-bot\`. That
mismatch means:

- \`publish_cluster_routing.yml\`'s existing-comment lookup
  (\`comments.find(c => c.user.login === BOT ...)\`) never matches, so every
  run treats the sticky comment as missing and can never see a ticked
  checkbox as ticked.
- \`cluster_routing_ack.yml\`'s \`issue_comment\` trigger condition
  (\`comment.user.login == 'weave-bot'\`) never matches either.

Net effect: **\`cluster-routing/acknowledged\` can never turn green for any PR
that changes \`artifacts/latest\`** — discovered while trying to land
[#661](https://github.com/workweave/router/pull/661) (promote \`v0.73\` to
\`latest\`).

This PR itself doesn't change \`latest\`, so the gate takes the "not gating"
path (always success) and isn't blocked by the bug it's fixing.

Note: \`workflow_run\`/\`issue_comment\`-triggered workflows always run the
version of the workflow file committed to the *default* branch, not the PR
branch — so this fix only takes effect once merged to \`main\`, which is why
it has to land ahead of #661 rather than as part of it.