### PR TITLE
feat(catalog): add Together fallback binding to kimi-k2.7

### DIFF
--- a/internal/router/catalog/catalog.go
+++ b/internal/router/catalog/catalog.go
@@ -370,9 +370,13 @@ var Models = []Model{
 		{Provider: providers.ProviderOpenRouter, Price: Pricing{InputUSDPer1M: 0.950, OutputUSDPer1M: 4.000, CacheReadMultiplier: 0.10}},
 	}},
 	// kimi-k2.7 "Code" variant: same rates as k2.6, ~30% less thinking-token
-	// usage. Fireworks-only — not yet on OpenRouter, so no fallback binding.
+	// usage. Fireworks primary; Together added as a cross-provider fallback
+	// (identical $0.95/$4.00 list price) so a Fireworks outage fails over
+	// instead of hard-killing the turn — the binding previously stood alone.
 	{ID: "moonshotai/kimi-k2.7", Tier: TierHigh, ContextWindow: 262_144, ImageInput: ImageInputUnsupported, Providers: []ProviderBinding{
 		{Provider: providers.ProviderFireworks, UpstreamID: "accounts/fireworks/models/kimi-k2p7-code",
+			Price: Pricing{InputUSDPer1M: 0.950, OutputUSDPer1M: 4.000, CacheReadMultiplier: 0.20}},
+		{Provider: providers.ProviderTogether, UpstreamID: "moonshotai/Kimi-K2.7-Code",
 			Price: Pricing{InputUSDPer1M: 0.950, OutputUSDPer1M: 4.000, CacheReadMultiplier: 0.20}},
 	}},
 	// AA top-performer additions (2026-05-18): ranked by composite of quality


### PR DESCRIPTION
## What

Adds a **Together** binding (`moonshotai/Kimi-K2.7-Code`) to `moonshotai/kimi-k2.7`, as the trailing/fallback provider after Fireworks.

## Why

`kimi-k2.7` carried a **single Fireworks binding** — the only high-tier model with no fallback (k2.6 already has OpenRouter). A Fireworks 5xx/timeout/404 therefore hard-kills the turn with nowhere to fail over. Together serves the same "Code" variant at an **identical $0.95/$4.00** list price, so adding it as the second binding lets `dispatchWithFallback` walk to it on a Fireworks failure at no cost delta.

Surfaced while investigating a Redwood (`org_5Ao…`) incident where a `kimi-k2.7` session looped; the missing fallback was the second half of "why didn't it fail over." (The loop itself — a model-behavior issue independent of provider — is addressed separately in the `text_repetition` detector PR.)

## Notes

- **Fireworks stays primary** — no change to the default serving path. Flip ordering later if Together shows better throughput for Kimi, as we did for `glm-5.2`.
- `go run ./cmd/genprices` produced no install-script diff (Together price matches Fireworks).
- Cache-read multiplier mirrors the Fireworks binding (0.20) pending confirmation of Together's Kimi cache pricing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)