### PR TITLE
feat(proxy): enforcing text-repetition loop break

### DIFF
--- a/cmd/router/main.go
+++ b/cmd/router/main.go
@@ -508,6 +508,9 @@ func main() {
 	// Shadow mode is log-only, so it ships enabled; the switch just sheds the
 	// per-turn signal-scan cost if it misbehaves.
 	spiralShadowEnabled := config.GetOr("ROUTER_SPIRAL_SHADOW_ENABLED", "true") == "true"
+	// Enforcing text-repetition break ships enabled; the switch is the kill
+	// switch if it ever false-positives on legit repeated narration.
+	textRepetitionBreakEnabled := config.GetOr("ROUTER_TEXT_REPETITION_BREAK_ENABLED", "true") == "true"
 	plannerCfg := planner.EVConfig{
 		ThresholdUSD:           parseEnvFloat("ROUTER_SWITCH_EV_THRESHOLD_USD", proxy.DefaultPlannerThresholdUSD),
 		ExpectedRemainingTurns: parseEnvInt("ROUTER_SWITCH_EXPECTED_REMAINING_TURNS", proxy.DefaultPlannerExpectedRemainingTurns),
@@ -627,6 +630,7 @@ func main() {
 		WithLoopEscalationStore(repo.Telemetry).
 		WithSpiralShadowConfig(spiralShadowEnabled).
 		WithSpiralShadowStore(repo.Telemetry).
+		WithTextRepetitionBreak(textRepetitionBreakEnabled).
 		WithRouterFeedbackStore(repo.Telemetry).
 		WithPlanner(plannerCfg).
 		WithSummarizer(summarizer).
@@ -637,6 +641,7 @@ func main() {
 	logger.Info("Effort escalation configured", "enabled", effortEscalation)
 	logger.Info("Loop escalation configured", "enabled", loopEscalationEnabled, "holdout_pct", loopEscalationHoldoutPct)
 	logger.Info("Spiral shadow detector configured", "enabled", spiralShadowEnabled)
+	logger.Info("Text-repetition break configured", "enabled", textRepetitionBreakEnabled)
 	logger.Info("Planner configured", "enabled", plannerEnabled, "threshold_usd", plannerCfg.ThresholdUSD, "expected_remaining_turns", plannerCfg.ExpectedRemainingTurns, "tier_upgrade_enabled", plannerCfg.TierUpgradeEnabled, "cold_pin_follow_fresh", plannerCfg.ColdPinFollowFresh, "prefix_trim_free_switch", prefixTrimFreeSwitch, "available_models_count", len(availableModels))
 	logger.Info("Tool-result scoring configured", "enabled", scoreToolResultTurns)
 

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -2020,7 +2020,6 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 
 	// Text-repetition break: fresh tool calls each turn defeat the no-progress
 	// fingerprint; repeated narration is the durable tell. See text_repetition.go.
-	// Main-loop / tool-result turns only, matching the spiral turn-type guard.
 	if s.textRepetitionBreakEnabled && (tt == turntype.MainLoop || tt == turntype.ToolResult) {
 		if looped, count, sampleHash := detectTextRepetition(env); looped {
 			role := roleForTier(catalog.TierFor(feats.Model))

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -172,6 +172,10 @@ type Service struct {
 	// death-march signals; see spiral_detection.go). Defaults true — shadow mode
 	// changes no routing behavior.
 	spiralShadowEnabled bool
+	// textRepetitionBreakEnabled gates the enforcing assistant-text repetition
+	// detector (see text_repetition.go). Defaults true; kill switch is
+	// ROUTER_TEXT_REPETITION_BREAK_ENABLED.
+	textRepetitionBreakEnabled bool
 	// spiralTracker de-duplicates shadow fires per (session, role, reason) on
 	// this replica.
 	spiralTracker *spiralTracker
@@ -866,21 +870,22 @@ const DefaultPlannerColdPinFollowFresh = false
 
 func NewService(r router.Router, providerMap map[string]providers.Client, emitter TelemetryEmitter, embedOnlyUserMessage bool, semanticCache *cache.Cache, pinStore sessionpin.Store, hardPinExplore bool, hardPinProvider, hardPinModel string, telemetry TelemetryRepository) *Service {
 	return &Service{
-		router:               r,
-		providers:            providerMap,
-		emitter:              emitter,
-		embedOnlyUserMessage: embedOnlyUserMessage,
-		semanticCache:        semanticCache,
-		pinStore:             pinStore,
-		noProgress:           newNoProgressTracker(),
-		compaction:           newCompactionTracker(),
-		prefixTrimFreeSwitch: true,
-		spiralTracker:        newSpiralTracker(),
-		spiralShadowEnabled:  true,
-		hardPinExplore:       hardPinExplore,
-		hardPinProvider:      hardPinProvider,
-		hardPinModel:         hardPinModel,
-		telemetry:            telemetry,
+		router:                     r,
+		providers:                  providerMap,
+		emitter:                    emitter,
+		embedOnlyUserMessage:       embedOnlyUserMessage,
+		semanticCache:              semanticCache,
+		pinStore:                   pinStore,
+		noProgress:                 newNoProgressTracker(),
+		compaction:                 newCompactionTracker(),
+		prefixTrimFreeSwitch:       true,
+		spiralTracker:              newSpiralTracker(),
+		spiralShadowEnabled:        true,
+		textRepetitionBreakEnabled: true,
+		hardPinExplore:             hardPinExplore,
+		hardPinProvider:            hardPinProvider,
+		hardPinModel:               hardPinModel,
+		telemetry:                  telemetry,
 		planner: planner.EVConfig{
 			ThresholdUSD:           DefaultPlannerThresholdUSD,
 			ExpectedRemainingTurns: DefaultPlannerExpectedRemainingTurns,
@@ -1006,6 +1011,14 @@ func (s *Service) WithLoopEscalationStore(store LoopEscalationStore) *Service {
 // cost if it ever misbehaves.
 func (s *Service) WithSpiralShadowConfig(enabled bool) *Service {
 	s.spiralShadowEnabled = enabled
+	return s
+}
+
+// WithTextRepetitionBreak sets the enforcing text-repetition detector kill
+// switch (default on). enabled=false skips the per-turn scan entirely. See
+// text_repetition.go.
+func (s *Service) WithTextRepetitionBreak(enabled bool) *Service {
+	s.textRepetitionBreakEnabled = enabled
 	return s
 }
 
@@ -2002,6 +2015,19 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 		role := roleForTier(catalog.TierFor(feats.Model))
 		if looped, count := s.noProgress.recordAndDetect(routeRes.SessionKey, installationID, role, fp, time.Now()); looped {
 			return s.handleNoProgressBreak(ctx, w, env, count, installationID, routeRes.SessionKey, role, decision.Model, decision.Provider, feats.Tokens)
+		}
+	}
+
+	// Enforcing text-repetition break: a model can keep issuing fresh tool
+	// calls each turn — defeating the no-progress fingerprint's tool-progress
+	// marker — while repeating the same narration verbatim and never
+	// converging. Catch that specific loop by the repeated text and re-route.
+	// Main-loop / tool-result turns only, matching the spiral detector's
+	// turn-type guard (hard-pinned turn types carry mimicking history shapes).
+	if s.textRepetitionBreakEnabled && (tt == turntype.MainLoop || tt == turntype.ToolResult) {
+		if looped, count, sampleHash := detectTextRepetition(env); looped {
+			role := roleForTier(catalog.TierFor(feats.Model))
+			return s.handleTextRepetitionBreak(ctx, w, env, count, sampleHash, installationID, routeRes.SessionKey, role, decision.Model, decision.Provider, feats.Tokens)
 		}
 	}
 

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -2018,12 +2018,9 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 		}
 	}
 
-	// Enforcing text-repetition break: a model can keep issuing fresh tool
-	// calls each turn — defeating the no-progress fingerprint's tool-progress
-	// marker — while repeating the same narration verbatim and never
-	// converging. Catch that specific loop by the repeated text and re-route.
-	// Main-loop / tool-result turns only, matching the spiral detector's
-	// turn-type guard (hard-pinned turn types carry mimicking history shapes).
+	// Text-repetition break: fresh tool calls each turn defeat the no-progress
+	// fingerprint; repeated narration is the durable tell. See text_repetition.go.
+	// Main-loop / tool-result turns only, matching the spiral turn-type guard.
 	if s.textRepetitionBreakEnabled && (tt == turntype.MainLoop || tt == turntype.ToolResult) {
 		if looped, count, sampleHash := detectTextRepetition(env); looped {
 			role := roleForTier(catalog.TierFor(feats.Model))

--- a/internal/proxy/text_repetition.go
+++ b/internal/proxy/text_repetition.go
@@ -1,0 +1,149 @@
+package proxy
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"workweave/router/internal/observability"
+	"workweave/router/internal/router/sessionpin"
+	"workweave/router/internal/translate"
+
+	"github.com/google/uuid"
+)
+
+// Enforcing assistant-text repetition detector.
+//
+// The tool-call loop, no-progress, and shadow-spiral detectors all key on
+// stagnation evidence — identical tool signatures, errored results, no tool
+// activity, same-file thrash. A distinct failure mode slips under all of them:
+// the model keeps issuing fresh, mostly-succeeding tool calls (so the
+// tool-call count grows and the no-progress fingerprint's tool-progress marker
+// advances every turn) while narrating the *same intent* verbatim — "I'll read
+// the test file and then implement the fix", "Now sending to the channel and
+// then the follow-up messages" — never converging. The repeated narration is
+// the only durable tell.
+//
+// This scans the inbound history (present in full on every turn, so no
+// cross-turn state) and fires when one normalized assistant text of
+// non-trivial length recurs textRepetitionThreshold+ times within the last
+// textRepetitionWindow assistant messages. On a fire it breaks the turn and
+// clears the pin, so the next message re-routes off the stuck model — the same
+// remedy as handleNoProgressBreak. Gated by the ROUTER_TEXT_REPETITION_BREAK_ENABLED
+// kill switch.
+const (
+	// textRepetitionWindow bounds the scan to the most recent assistant texts,
+	// so an early duplicate that the agent already recovered from doesn't
+	// count against it.
+	textRepetitionWindow = 12
+	// textRepetitionThreshold: verbatim recurrences of one line that trip the
+	// break. Three identical substantive turns is a loop, not a coincidence.
+	textRepetitionThreshold = 3
+	// textRepetitionMinLen: ignore short lines ("Done.", "OK") whose repetition
+	// is benign; only count narration long enough to be a real intent restatement.
+	textRepetitionMinLen = 40
+)
+
+// normalizeAssistantText lower-cases and collapses runs of whitespace so
+// cosmetic drift (a trailing newline, soft re-wrap) doesn't defeat the
+// exact-match count.
+func normalizeAssistantText(s string) string {
+	return strings.ToLower(strings.Join(strings.Fields(s), " "))
+}
+
+// detectTextRepetition reports whether a single normalized assistant text of at
+// least textRepetitionMinLen chars recurs textRepetitionThreshold+ times within
+// the last textRepetitionWindow assistant messages. Returns the recurrence
+// count and an 8-byte hash of the offending text (safe for logs — never the
+// customer's prose).
+func detectTextRepetition(env *translate.RequestEnvelope) (looped bool, count int, sampleHash string) {
+	texts := env.AssistantTextMessages()
+	if len(texts) < textRepetitionThreshold {
+		return false, 0, ""
+	}
+	start := 0
+	if len(texts) > textRepetitionWindow {
+		start = len(texts) - textRepetitionWindow
+	}
+	window := texts[start:]
+
+	counts := make(map[string]int, len(window))
+	topKey := ""
+	for _, t := range window {
+		n := normalizeAssistantText(t)
+		if len(n) < textRepetitionMinLen {
+			continue
+		}
+		counts[n]++
+		if counts[n] > count {
+			count = counts[n]
+			topKey = n
+		}
+	}
+	if count < textRepetitionThreshold {
+		return false, count, ""
+	}
+	h := sha256.Sum256([]byte(topKey))
+	return true, count, hex.EncodeToString(h[:8])
+}
+
+// handleTextRepetitionBreak writes a synthetic end_turn response and expires
+// the session pin so the next turn re-routes off the stuck model instead of
+// re-anchoring on it. Mirrors handleNoProgressBreak's mechanics; pin expiry is
+// best-effort.
+func (s *Service) handleTextRepetitionBreak(
+	ctx context.Context,
+	w http.ResponseWriter,
+	env *translate.RequestEnvelope,
+	count int,
+	sampleHash string,
+	installationID uuid.UUID,
+	sessionKey [sessionpin.SessionKeyLen]byte,
+	role string,
+	decisionModel string,
+	decisionProvider string,
+	inputTokens int,
+) error {
+	log := observability.FromContext(ctx)
+
+	msg := fmt.Sprintf(
+		"✦ **Weave Router** → Repetition loop detected: `%s` (`%s`) repeated the same response %d times without making progress. Stopping this turn and clearing the session pin so the next message re-routes to a fresh model.\n\nIf the task is genuinely incomplete, send a follow-up message describing what's still needed; the router will pick a different model.\n\n",
+		decisionModel, decisionProvider, count,
+	)
+	if env.SourceFormat() == translate.FormatOpenAI {
+		msg = fmt.Sprintf(
+			"Weave Router: repetition loop detected (%s/%s repeated the same response %d times). Stopping and clearing the session pin; send a follow-up to resume on a different model.",
+			decisionModel, decisionProvider, count,
+		)
+	}
+
+	log.Info("Text-repetition loop detected; breaking turn",
+		"repeat_count", count,
+		"window_size", textRepetitionWindow,
+		"text_sample_hash", sampleHash,
+		"decision_model", decisionModel,
+		"decision_provider", decisionProvider,
+		"session_key_prefix", shortSessionKey(sessionKey),
+		"role", role,
+	)
+
+	// Expire the pin in Postgres (not just the in-proc cache) so a racing
+	// reader on another pod can't repopulate the LRU from the stale row.
+	// Skip a zero session key: a zero-keyed pin row is a zombie shared by every
+	// zero-keyed session.
+	if s.pinStore != nil && installationID != uuid.Nil && sessionKey != ([sessionpin.SessionKeyLen]byte{}) {
+		if err := s.expireSessionPin(ctx, installationID, sessionKey, role, "text_repetition_break"); err != nil {
+			log.Error("text-repetition-break: pin store upsert failed", "err", err)
+		}
+	}
+
+	switch env.SourceFormat() {
+	case translate.FormatOpenAI:
+		return writeSyntheticOpenAIResponse(w, env, msg, inputTokens)
+	default:
+		return writeSyntheticAnthropicResponse(w, env, msg, inputTokens)
+	}
+}

--- a/internal/proxy/text_repetition.go
+++ b/internal/proxy/text_repetition.go
@@ -29,9 +29,8 @@ import (
 // last textRepetitionWindow messages. Breaks the turn and clears the pin —
 // same remedy as handleNoProgressBreak. Gated by ROUTER_TEXT_REPETITION_BREAK_ENABLED.
 const (
-	// textRepetitionWindow bounds the scan to the most recent assistant texts,
-	// so an early duplicate that the agent already recovered from doesn't
-	// count against it.
+	// textRepetitionWindow bounds the scan to recent messages so an early
+	// duplicate the agent recovered from doesn't count against it.
 	textRepetitionWindow = 12
 	// textRepetitionThreshold: verbatim recurrences of one line that trip the
 	// break. Three identical substantive turns is a loop, not a coincidence.

--- a/internal/proxy/text_repetition.go
+++ b/internal/proxy/text_repetition.go
@@ -17,17 +17,14 @@ import (
 
 // Enforcing assistant-text repetition detector.
 //
-// Other detectors key on stagnation evidence (identical tool signatures,
-// errored results, no tool activity). A distinct failure mode slips under all
-// of them: fresh tool calls each turn advance the no-progress fingerprint
-// while the assistant narrates the same intent verbatim — the repeated text is
-// the only durable tell.
+// Existing detectors key on stagnation evidence (identical tool signatures,
+// errored results, no tool activity). Fresh tool calls each turn advance the
+// no-progress fingerprint while the assistant narrates the same intent
+// verbatim — the repeated text is the only durable tell.
 //
-// Scans assistant narration since the last user turn (so a re-route after a
-// break starts clean) and fires when a normalized text of at least
-// textRepetitionMinLen chars recurs textRepetitionThreshold+ times within the
-// last textRepetitionWindow messages. Breaks the turn and clears the pin —
-// same remedy as handleNoProgressBreak. Gated by ROUTER_TEXT_REPETITION_BREAK_ENABLED.
+// Scans narration since the last real user turn; fires when a normalized text
+// of ≥textRepetitionMinLen chars recurs ≥textRepetitionThreshold times within
+// textRepetitionWindow messages. Gated by ROUTER_TEXT_REPETITION_BREAK_ENABLED.
 const (
 	// textRepetitionWindow bounds the scan to recent messages so an early
 	// duplicate the agent recovered from doesn't count against it.
@@ -46,11 +43,9 @@ func normalizeAssistantText(s string) string {
 	return strings.ToLower(strings.Join(strings.Fields(s), " "))
 }
 
-// detectTextRepetition reports whether a single normalized assistant text of at
-// least textRepetitionMinLen chars recurs textRepetitionThreshold+ times within
-// the last textRepetitionWindow assistant messages of the current turn. Returns
-// the recurrence count and an 8-byte hash of the offending text (safe for logs
-// — never the customer's prose).
+// detectTextRepetition reports whether a normalized assistant text recurs
+// textRepetitionThreshold+ times within textRepetitionWindow messages. Returns
+// count and an 8-byte hash of the offending text (safe for logs).
 func detectTextRepetition(env *translate.RequestEnvelope) (looped bool, count int, sampleHash string) {
 	texts := env.TrailingAssistantTexts()
 	if len(texts) < textRepetitionThreshold {

--- a/internal/proxy/text_repetition.go
+++ b/internal/proxy/text_repetition.go
@@ -17,23 +17,17 @@ import (
 
 // Enforcing assistant-text repetition detector.
 //
-// The tool-call loop, no-progress, and shadow-spiral detectors all key on
-// stagnation evidence — identical tool signatures, errored results, no tool
-// activity, same-file thrash. A distinct failure mode slips under all of them:
-// the model keeps issuing fresh, mostly-succeeding tool calls (so the
-// tool-call count grows and the no-progress fingerprint's tool-progress marker
-// advances every turn) while narrating the *same intent* verbatim — "I'll read
-// the test file and then implement the fix", "Now sending to the channel and
-// then the follow-up messages" — never converging. The repeated narration is
+// Other detectors key on stagnation evidence (identical tool signatures,
+// errored results, no tool activity). A distinct failure mode slips under all
+// of them: fresh tool calls each turn advance the no-progress fingerprint
+// while the assistant narrates the same intent verbatim — the repeated text is
 // the only durable tell.
 //
-// This scans the inbound history (present in full on every turn, so no
-// cross-turn state) and fires when one normalized assistant text of
-// non-trivial length recurs textRepetitionThreshold+ times within the last
-// textRepetitionWindow assistant messages. On a fire it breaks the turn and
-// clears the pin, so the next message re-routes off the stuck model — the same
-// remedy as handleNoProgressBreak. Gated by the ROUTER_TEXT_REPETITION_BREAK_ENABLED
-// kill switch.
+// Scans assistant narration since the last user turn (so a re-route after a
+// break starts clean) and fires when a normalized text of at least
+// textRepetitionMinLen chars recurs textRepetitionThreshold+ times within the
+// last textRepetitionWindow messages. Breaks the turn and clears the pin —
+// same remedy as handleNoProgressBreak. Gated by ROUTER_TEXT_REPETITION_BREAK_ENABLED.
 const (
 	// textRepetitionWindow bounds the scan to the most recent assistant texts,
 	// so an early duplicate that the agent already recovered from doesn't
@@ -47,20 +41,19 @@ const (
 	textRepetitionMinLen = 40
 )
 
-// normalizeAssistantText lower-cases and collapses runs of whitespace so
-// cosmetic drift (a trailing newline, soft re-wrap) doesn't defeat the
-// exact-match count.
+// normalizeAssistantText lowercases and collapses whitespace so cosmetic
+// drift (re-wrap, trailing newline) doesn't defeat the exact-match count.
 func normalizeAssistantText(s string) string {
 	return strings.ToLower(strings.Join(strings.Fields(s), " "))
 }
 
 // detectTextRepetition reports whether a single normalized assistant text of at
 // least textRepetitionMinLen chars recurs textRepetitionThreshold+ times within
-// the last textRepetitionWindow assistant messages. Returns the recurrence
-// count and an 8-byte hash of the offending text (safe for logs — never the
-// customer's prose).
+// the last textRepetitionWindow assistant messages of the current turn. Returns
+// the recurrence count and an 8-byte hash of the offending text (safe for logs
+// — never the customer's prose).
 func detectTextRepetition(env *translate.RequestEnvelope) (looped bool, count int, sampleHash string) {
-	texts := env.AssistantTextMessages()
+	texts := env.TrailingAssistantTexts()
 	if len(texts) < textRepetitionThreshold {
 		return false, 0, ""
 	}

--- a/internal/proxy/text_repetition_internal_test.go
+++ b/internal/proxy/text_repetition_internal_test.go
@@ -61,6 +61,24 @@ func TestDetectTextRepetition_BelowThresholdDoesNotFire(t *testing.T) {
 	}
 }
 
+func TestDetectTextRepetition_RealUserTurnResetsWindow(t *testing.T) {
+	// After a break clears the pin, the stale loop narration is still in the
+	// body. Once the user sends a real follow-up, that narration is before the
+	// turn boundary and must not re-trip the break before the fresh model runs
+	// (Cursor Bugbot #665). Three restatements, then a real user turn.
+	turns := []string{
+		"text:" + loopNarration, `call:Read:{"file_path":"/src/x.go"}`, "result:ok",
+		"text:" + loopNarration, `call:Read:{"file_path":"/src/y.go"}`, "result:ok",
+		"text:" + loopNarration, `call:Read:{"file_path":"/src/z.go"}`, "result:ok",
+		"user:please try a different approach",
+	}
+	env := parseSpiralEnv(t, turns)
+
+	if looped, count, _ := detectTextRepetition(env); looped {
+		t.Fatalf("a real user turn must reset the repetition window; count=%d", count)
+	}
+}
+
 func TestDetectTextRepetition_IgnoresShortLines(t *testing.T) {
 	// "Done." style acknowledgements repeat benignly and must not count.
 	turns := []string{

--- a/internal/proxy/text_repetition_internal_test.go
+++ b/internal/proxy/text_repetition_internal_test.go
@@ -1,0 +1,92 @@
+package proxy
+
+import "testing"
+
+// A substantive narration line (>= textRepetitionMinLen) that a stuck model
+// restates verbatim each turn while still issuing fresh tool calls.
+const loopNarration = "I'll read the test file and then implement the fix."
+
+func TestDetectTextRepetition_FiresOnRepeatedNarrationDespiteFreshToolCalls(t *testing.T) {
+	// The loop shape that defeats every other detector: a NEW tool call every
+	// turn (tool-call count grows, no-progress fingerprint advances) but the
+	// same narration repeated. Three restatements trips the break.
+	var turns []string
+	for i := 0; i < 3; i++ {
+		turns = append(turns,
+			"text:"+loopNarration,
+			`call:Read:{"file_path":"/src/thing.go"}`, // a tool call every turn: the detector must fire on the text, not tool-call stagnation
+			"result:ok",
+		)
+	}
+	env := parseSpiralEnv(t, turns)
+
+	looped, count, sample := detectTextRepetition(env)
+	if !looped {
+		t.Fatalf("expected repetition loop to be detected; count=%d", count)
+	}
+	if count != 3 {
+		t.Fatalf("expected recurrence count 3, got %d", count)
+	}
+	if sample == "" {
+		t.Fatal("expected a non-empty text sample hash for logs")
+	}
+}
+
+func TestDetectTextRepetition_IgnoresDistinctNarration(t *testing.T) {
+	turns := []string{
+		"text:First I will inspect the failing assertion in the parser suite.",
+		`call:Read:{"file_path":"/src/a.go"}`, "result:ok",
+		"text:Now I understand the bug; the offset is computed before the guard.",
+		`call:Edit:{"file_path":"/src/a.go"}`, "result:ok",
+		"text:Verifying the fix by re-running only the previously failing case.",
+		`call:Bash:{"command":"go test ./..."}`, "result:ok",
+	}
+	env := parseSpiralEnv(t, turns)
+
+	if looped, count, _ := detectTextRepetition(env); looped {
+		t.Fatalf("healthy distinct narration must not trip the break; count=%d", count)
+	}
+}
+
+func TestDetectTextRepetition_BelowThresholdDoesNotFire(t *testing.T) {
+	// Two identical restatements is a retry, not a loop.
+	turns := []string{
+		"text:" + loopNarration, `call:Read:{"file_path":"/src/x.go"}`, "result:ok",
+		"text:" + loopNarration, `call:Read:{"file_path":"/src/y.go"}`, "result:ok",
+	}
+	env := parseSpiralEnv(t, turns)
+
+	if looped, count, _ := detectTextRepetition(env); looped {
+		t.Fatalf("two restatements must not trip the break; count=%d", count)
+	}
+}
+
+func TestDetectTextRepetition_IgnoresShortLines(t *testing.T) {
+	// "Done." style acknowledgements repeat benignly and must not count.
+	turns := []string{
+		"text:Done.", `call:Read:{"file_path":"/src/x.go"}`, "result:ok",
+		"text:Done.", `call:Read:{"file_path":"/src/y.go"}`, "result:ok",
+		"text:Done.", `call:Read:{"file_path":"/src/z.go"}`, "result:ok",
+	}
+	env := parseSpiralEnv(t, turns)
+
+	if looped, count, _ := detectTextRepetition(env); looped {
+		t.Fatalf("short repeated lines must not trip the break; count=%d", count)
+	}
+}
+
+func TestDetectTextRepetition_NormalizesCaseAndWhitespace(t *testing.T) {
+	// Cosmetic drift (case, re-wrapping) between otherwise-identical narration
+	// must still be counted as the same line.
+	turns := []string{
+		"text:" + loopNarration,
+		"text:i'll read the test file    and then implement the fix.",
+		"text:I'LL READ THE TEST FILE AND THEN IMPLEMENT THE FIX.",
+	}
+	env := parseSpiralEnv(t, turns)
+
+	looped, count, _ := detectTextRepetition(env)
+	if !looped || count != 3 {
+		t.Fatalf("case/whitespace-variant restatements must all count; looped=%v count=%d", looped, count)
+	}
+}

--- a/internal/proxy/text_repetition_internal_test.go
+++ b/internal/proxy/text_repetition_internal_test.go
@@ -1,6 +1,11 @@
 package proxy
 
-import "testing"
+import (
+	"encoding/json"
+	"testing"
+
+	"workweave/router/internal/translate"
+)
 
 // A substantive narration line (>= textRepetitionMinLen) that a stuck model
 // restates verbatim each turn while still issuing fresh tool calls.
@@ -58,6 +63,39 @@ func TestDetectTextRepetition_BelowThresholdDoesNotFire(t *testing.T) {
 
 	if looped, count, _ := detectTextRepetition(env); looped {
 		t.Fatalf("two restatements must not trip the break; count=%d", count)
+	}
+}
+
+func TestDetectTextRepetition_FiresThroughSystemReminderToolResults(t *testing.T) {
+	// Production shape (Redwood): Claude Code appends a <system-reminder> text
+	// block on the same user turn as the tool_result every iteration. Those
+	// turns must NOT count as human boundaries, or the backward scan collects
+	// nothing on exactly the turns this detector guards. The loop must fire.
+	var msgs []map[string]any
+	for i := 0; i < 4; i++ {
+		msgs = append(msgs,
+			map[string]any{"role": "assistant", "content": []map[string]any{
+				{"type": "text", "text": loopNarration},
+				{"type": "tool_use", "id": "t", "name": "Read", "input": map[string]any{"file_path": "/src/x.go"}},
+			}},
+			map[string]any{"role": "user", "content": []map[string]any{
+				{"type": "tool_result", "tool_use_id": "t", "content": "ok"},
+				{"type": "text", "text": "<system-reminder>The task tools haven't been used recently.</system-reminder>"},
+			}},
+		)
+	}
+	body, err := json.Marshal(map[string]any{"model": "claude-sonnet-4-6", "messages": msgs, "max_tokens": 256})
+	if err != nil {
+		t.Fatal(err)
+	}
+	env, err := translate.ParseAnthropic(body)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	looped, count, _ := detectTextRepetition(env)
+	if !looped {
+		t.Fatalf("loop through reminder-bearing tool_result turns must fire; count=%d", count)
 	}
 }
 

--- a/internal/translate/text_repetition.go
+++ b/internal/translate/text_repetition.go
@@ -6,12 +6,12 @@ import (
 	"github.com/tidwall/gjson"
 )
 
-// TrailingAssistantTexts returns the visible narration of each assistant
-// message since the last real human turn, in order — the concatenation of a
+// TrailingAssistantTexts returns, in order, the narration text of each
+// assistant message since the last real human turn — the concatenation of a
 // message's `text` blocks, with `thinking` and `tool_use` ignored and empty
-// messages dropped. A genuine human user turn (see userIsHumanTurn) bounds the
-// run: repetition before it belongs to a prior task, so a re-route after a
-// break starts from a clean window. Anthropic format only; others return nil.
+// messages dropped. Tool-result turns with CC `<system-reminder>` injections
+// are not treated as human boundaries (see userIsHumanTurn). Anthropic only;
+// others return nil.
 func (e *RequestEnvelope) TrailingAssistantTexts() []string {
 	if e.format != FormatAnthropic {
 		return nil
@@ -45,12 +45,9 @@ loop:
 }
 
 // userIsHumanTurn reports whether a user message carries genuine human input:
-// text that is neither a tool_result nor one of Claude Code's injected
-// <system-reminder> blocks. CC appends those reminders on the same user turn as
-// tool_result payloads every iteration, so treating any non-tool_result content
-// as a boundary (as userHasNonToolResultContent does) would stop the backward
-// scan on exactly the tool-result turns this detector guards, collecting no
-// narration. Only real human text resets the repetition window.
+// text that is neither a tool_result nor a CC-injected <system-reminder> block.
+// Those reminder-bearing turns must not reset the repetition window or the
+// backward scan collects nothing on the tool-result turns it guards.
 func userIsHumanTurn(msg gjson.Result) bool {
 	content := msg.Get("content")
 	if content.Type == gjson.String {

--- a/internal/translate/text_repetition.go
+++ b/internal/translate/text_repetition.go
@@ -6,20 +6,13 @@ import (
 	"github.com/tidwall/gjson"
 )
 
-// AssistantTextMessages returns, in order, the visible narration text of each
-// assistant message — the concatenation of its `text` blocks, with `thinking`
-// and `tool_use` blocks ignored. Messages with no text contribute an empty
-// string so callers can reason about position if they need to; empties are
-// skipped here to keep the slice to real narration. Anthropic format only
-// (Claude Code's wire format); other formats return nil.
-//
-// Feeds the proxy's enforcing text-repetition detector
-// (internal/proxy/text_repetition.go): a model can defeat the tool-call and
-// no-progress detectors by issuing a fresh tool call every turn while
-// repeating the same narration verbatim, and that repeated text is the only
-// durable tell. Pure function of the request body — the full history arrives
-// on every turn, so no cross-turn state is needed.
-func (e *RequestEnvelope) AssistantTextMessages() []string {
+// TrailingAssistantTexts returns the visible narration of each assistant
+// message since the last real user turn, in order — the concatenation of a
+// message's `text` blocks, with `thinking` and `tool_use` ignored and empty
+// messages dropped. A user message with any non-tool_result content bounds the
+// run: repetition before it belongs to a prior task, so a re-route after a
+// break starts from a clean window. Anthropic format only; others return nil.
+func (e *RequestEnvelope) TrailingAssistantTexts() []string {
 	if e.format != FormatAnthropic {
 		return nil
 	}
@@ -27,37 +20,50 @@ func (e *RequestEnvelope) AssistantTextMessages() []string {
 	if !msgs.IsArray() {
 		return nil
 	}
-	var out []string
-	msgs.ForEach(func(_, msg gjson.Result) bool {
-		if msg.Get("role").String() != "assistant" {
+	all := msgs.Array()
+	var rev []string
+loop:
+	for i := len(all) - 1; i >= 0; i-- {
+		msg := all[i]
+		switch msg.Get("role").String() {
+		case "user":
+			if userHasNonToolResultContent(msg) {
+				break loop
+			}
+		case "assistant":
+			if s := assistantMessageText(msg); s != "" {
+				rev = append(rev, s)
+			}
+		}
+	}
+	// Collected tail-first; reverse to chronological order so callers can take
+	// the most-recent window off the end.
+	for l, r := 0, len(rev)-1; l < r; l, r = l+1, r-1 {
+		rev[l], rev[r] = rev[r], rev[l]
+	}
+	return rev
+}
+
+// assistantMessageText joins the text blocks of one assistant message,
+// skipping thinking/tool_use. A plain-string content is the text itself.
+func assistantMessageText(msg gjson.Result) string {
+	content := msg.Get("content")
+	if content.Type == gjson.String {
+		return content.String()
+	}
+	if !content.IsArray() {
+		return ""
+	}
+	var b strings.Builder
+	content.ForEach(func(_, block gjson.Result) bool {
+		if block.Get("type").String() != "text" {
 			return true
 		}
-		content := msg.Get("content")
-		// A plain-string assistant message is itself the text.
-		if content.Type == gjson.String {
-			if s := content.String(); s != "" {
-				out = append(out, s)
-			}
-			return true
-		}
-		if !content.IsArray() {
-			return true
-		}
-		var b strings.Builder
-		content.ForEach(func(_, block gjson.Result) bool {
-			if block.Get("type").String() != "text" {
-				return true
-			}
-			if b.Len() > 0 {
-				b.WriteByte('\n')
-			}
-			b.WriteString(block.Get("text").String())
-			return true
-		})
 		if b.Len() > 0 {
-			out = append(out, b.String())
+			b.WriteByte('\n')
 		}
+		b.WriteString(block.Get("text").String())
 		return true
 	})
-	return out
+	return b.String()
 }

--- a/internal/translate/text_repetition.go
+++ b/internal/translate/text_repetition.go
@@ -1,0 +1,63 @@
+package translate
+
+import (
+	"strings"
+
+	"github.com/tidwall/gjson"
+)
+
+// AssistantTextMessages returns, in order, the visible narration text of each
+// assistant message — the concatenation of its `text` blocks, with `thinking`
+// and `tool_use` blocks ignored. Messages with no text contribute an empty
+// string so callers can reason about position if they need to; empties are
+// skipped here to keep the slice to real narration. Anthropic format only
+// (Claude Code's wire format); other formats return nil.
+//
+// Feeds the proxy's enforcing text-repetition detector
+// (internal/proxy/text_repetition.go): a model can defeat the tool-call and
+// no-progress detectors by issuing a fresh tool call every turn while
+// repeating the same narration verbatim, and that repeated text is the only
+// durable tell. Pure function of the request body — the full history arrives
+// on every turn, so no cross-turn state is needed.
+func (e *RequestEnvelope) AssistantTextMessages() []string {
+	if e.format != FormatAnthropic {
+		return nil
+	}
+	msgs := gjson.GetBytes(e.body, "messages")
+	if !msgs.IsArray() {
+		return nil
+	}
+	var out []string
+	msgs.ForEach(func(_, msg gjson.Result) bool {
+		if msg.Get("role").String() != "assistant" {
+			return true
+		}
+		content := msg.Get("content")
+		// A plain-string assistant message is itself the text.
+		if content.Type == gjson.String {
+			if s := content.String(); s != "" {
+				out = append(out, s)
+			}
+			return true
+		}
+		if !content.IsArray() {
+			return true
+		}
+		var b strings.Builder
+		content.ForEach(func(_, block gjson.Result) bool {
+			if block.Get("type").String() != "text" {
+				return true
+			}
+			if b.Len() > 0 {
+				b.WriteByte('\n')
+			}
+			b.WriteString(block.Get("text").String())
+			return true
+		})
+		if b.Len() > 0 {
+			out = append(out, b.String())
+		}
+		return true
+	})
+	return out
+}

--- a/internal/translate/text_repetition.go
+++ b/internal/translate/text_repetition.go
@@ -7,9 +7,9 @@ import (
 )
 
 // TrailingAssistantTexts returns the visible narration of each assistant
-// message since the last real user turn, in order — the concatenation of a
+// message since the last real human turn, in order — the concatenation of a
 // message's `text` blocks, with `thinking` and `tool_use` ignored and empty
-// messages dropped. A user message with any non-tool_result content bounds the
+// messages dropped. A genuine human user turn (see userIsHumanTurn) bounds the
 // run: repetition before it belongs to a prior task, so a re-route after a
 // break starts from a clean window. Anthropic format only; others return nil.
 func (e *RequestEnvelope) TrailingAssistantTexts() []string {
@@ -27,7 +27,7 @@ loop:
 		msg := all[i]
 		switch msg.Get("role").String() {
 		case "user":
-			if userHasNonToolResultContent(msg) {
+			if userIsHumanTurn(msg) {
 				break loop
 			}
 		case "assistant":
@@ -42,6 +42,42 @@ loop:
 		rev[l], rev[r] = rev[r], rev[l]
 	}
 	return rev
+}
+
+// userIsHumanTurn reports whether a user message carries genuine human input:
+// text that is neither a tool_result nor one of Claude Code's injected
+// <system-reminder> blocks. CC appends those reminders on the same user turn as
+// tool_result payloads every iteration, so treating any non-tool_result content
+// as a boundary (as userHasNonToolResultContent does) would stop the backward
+// scan on exactly the tool-result turns this detector guards, collecting no
+// narration. Only real human text resets the repetition window.
+func userIsHumanTurn(msg gjson.Result) bool {
+	content := msg.Get("content")
+	if content.Type == gjson.String {
+		return isHumanText(content.String())
+	}
+	if !content.IsArray() {
+		return false
+	}
+	found := false
+	content.ForEach(func(_, block gjson.Result) bool {
+		if block.Get("type").String() != "text" {
+			return true // tool_result / image / etc. are not human input
+		}
+		if isHumanText(block.Get("text").String()) {
+			found = true
+			return false
+		}
+		return true
+	})
+	return found
+}
+
+// isHumanText reports whether s is real human input rather than empty text or a
+// Claude Code injected <system-reminder> block.
+func isHumanText(s string) bool {
+	s = strings.TrimSpace(s)
+	return s != "" && !strings.HasPrefix(s, "<system-reminder")
 }
 
 // assistantMessageText joins the text blocks of one assistant message,

--- a/internal/translate/text_repetition_test.go
+++ b/internal/translate/text_repetition_test.go
@@ -1,0 +1,71 @@
+package translate_test
+
+import (
+	"testing"
+
+	"workweave/router/internal/translate"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAssistantTextMessages_ExtractsNarrationInOrder(t *testing.T) {
+	body := mustMarshalJSON(t, map[string]any{
+		"model": "claude-sonnet-4-6",
+		"messages": []any{
+			map[string]any{"role": "user", "content": "do stuff"},
+			// text + tool_use in one message: only the text is narration.
+			map[string]any{"role": "assistant", "content": []any{
+				map[string]any{"type": "text", "text": "first"},
+				map[string]any{"type": "tool_use", "id": "1", "name": "ls", "input": map[string]any{}},
+			}},
+			map[string]any{"role": "user", "content": []any{
+				map[string]any{"type": "tool_result", "tool_use_id": "1", "content": "ok"},
+			}},
+			// multiple text blocks concatenate; thinking is ignored.
+			map[string]any{"role": "assistant", "content": []any{
+				map[string]any{"type": "thinking", "thinking": "hidden reasoning"},
+				map[string]any{"type": "text", "text": "second"},
+				map[string]any{"type": "text", "text": "third"},
+			}},
+			// tool-only assistant message contributes nothing.
+			map[string]any{"role": "assistant", "content": []any{
+				map[string]any{"type": "tool_use", "id": "2", "name": "read", "input": map[string]any{}},
+			}},
+		},
+		"max_tokens": 256,
+	})
+	env, err := translate.ParseAnthropic(body)
+	require.NoError(t, err)
+
+	got := env.AssistantTextMessages()
+	require.Equal(t, []string{"first", "second\nthird"}, got)
+}
+
+func TestAssistantTextMessages_PlainStringContent(t *testing.T) {
+	body := mustMarshalJSON(t, map[string]any{
+		"model": "claude-sonnet-4-6",
+		"messages": []any{
+			map[string]any{"role": "assistant", "content": "a plain string reply"},
+			map[string]any{"role": "assistant", "content": ""},
+		},
+		"max_tokens": 256,
+	})
+	env, err := translate.ParseAnthropic(body)
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{"a plain string reply"}, env.AssistantTextMessages(), "empty content is skipped")
+}
+
+func TestAssistantTextMessages_NonAnthropicReturnsNil(t *testing.T) {
+	body := mustMarshalJSON(t, map[string]any{
+		"model": "gpt-5.5",
+		"messages": []any{
+			map[string]any{"role": "assistant", "content": "hi"},
+		},
+	})
+	env, err := translate.ParseOpenAI(body)
+	require.NoError(t, err)
+
+	assert.Nil(t, env.AssistantTextMessages())
+}

--- a/internal/translate/text_repetition_test.go
+++ b/internal/translate/text_repetition_test.go
@@ -63,6 +63,29 @@ func TestTrailingAssistantTexts_ResetsAtLastRealUserTurn(t *testing.T) {
 		"only narration since the last real user turn is in scope")
 }
 
+func TestTrailingAssistantTexts_SystemReminderToolResultTurnIsNotABoundary(t *testing.T) {
+	// Claude Code appends a <system-reminder> text block alongside tool_result
+	// payloads. That turn must NOT reset the window (else the scan collects
+	// nothing on tool-result turns) — only genuine human text is a boundary.
+	body := mustMarshalJSON(t, map[string]any{
+		"model": "claude-sonnet-4-6",
+		"messages": []any{
+			map[string]any{"role": "assistant", "content": "narration one from the loop"},
+			map[string]any{"role": "user", "content": []any{
+				map[string]any{"type": "tool_result", "tool_use_id": "1", "content": "ok"},
+				map[string]any{"type": "text", "text": "<system-reminder>reminder text</system-reminder>"},
+			}},
+			map[string]any{"role": "assistant", "content": "narration two from the loop"},
+		},
+		"max_tokens": 256,
+	})
+	env, err := translate.ParseAnthropic(body)
+	require.NoError(t, err)
+
+	require.Equal(t, []string{"narration one from the loop", "narration two from the loop"},
+		env.TrailingAssistantTexts(), "a reminder-bearing tool_result turn must not reset the window")
+}
+
 func TestTrailingAssistantTexts_PlainStringContent(t *testing.T) {
 	body := mustMarshalJSON(t, map[string]any{
 		"model": "claude-sonnet-4-6",

--- a/internal/translate/text_repetition_test.go
+++ b/internal/translate/text_repetition_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestAssistantTextMessages_ExtractsNarrationInOrder(t *testing.T) {
+func TestTrailingAssistantTexts_ExtractsNarrationInOrder(t *testing.T) {
 	body := mustMarshalJSON(t, map[string]any{
 		"model": "claude-sonnet-4-6",
 		"messages": []any{
@@ -19,6 +19,7 @@ func TestAssistantTextMessages_ExtractsNarrationInOrder(t *testing.T) {
 				map[string]any{"type": "text", "text": "first"},
 				map[string]any{"type": "tool_use", "id": "1", "name": "ls", "input": map[string]any{}},
 			}},
+			// tool_result is not a real user turn, so the run continues through it.
 			map[string]any{"role": "user", "content": []any{
 				map[string]any{"type": "tool_result", "tool_use_id": "1", "content": "ok"},
 			}},
@@ -38,11 +39,31 @@ func TestAssistantTextMessages_ExtractsNarrationInOrder(t *testing.T) {
 	env, err := translate.ParseAnthropic(body)
 	require.NoError(t, err)
 
-	got := env.AssistantTextMessages()
-	require.Equal(t, []string{"first", "second\nthird"}, got)
+	require.Equal(t, []string{"first", "second\nthird"}, env.TrailingAssistantTexts())
 }
 
-func TestAssistantTextMessages_PlainStringContent(t *testing.T) {
+func TestTrailingAssistantTexts_ResetsAtLastRealUserTurn(t *testing.T) {
+	// Narration before a real user message belongs to a prior task: after a
+	// break clears the pin and the user sends a follow-up, the stale loop
+	// narration must NOT count against the fresh model (Cursor Bugbot #665).
+	body := mustMarshalJSON(t, map[string]any{
+		"model": "claude-sonnet-4-6",
+		"messages": []any{
+			map[string]any{"role": "assistant", "content": "stale narration from the looping model"},
+			map[string]any{"role": "assistant", "content": "more stale narration from the loop"},
+			map[string]any{"role": "user", "content": "please try again"}, // real user turn = boundary
+			map[string]any{"role": "assistant", "content": "fresh model, first real step"},
+		},
+		"max_tokens": 256,
+	})
+	env, err := translate.ParseAnthropic(body)
+	require.NoError(t, err)
+
+	require.Equal(t, []string{"fresh model, first real step"}, env.TrailingAssistantTexts(),
+		"only narration since the last real user turn is in scope")
+}
+
+func TestTrailingAssistantTexts_PlainStringContent(t *testing.T) {
 	body := mustMarshalJSON(t, map[string]any{
 		"model": "claude-sonnet-4-6",
 		"messages": []any{
@@ -54,10 +75,10 @@ func TestAssistantTextMessages_PlainStringContent(t *testing.T) {
 	env, err := translate.ParseAnthropic(body)
 	require.NoError(t, err)
 
-	assert.Equal(t, []string{"a plain string reply"}, env.AssistantTextMessages(), "empty content is skipped")
+	assert.Equal(t, []string{"a plain string reply"}, env.TrailingAssistantTexts(), "empty content is skipped")
 }
 
-func TestAssistantTextMessages_NonAnthropicReturnsNil(t *testing.T) {
+func TestTrailingAssistantTexts_NonAnthropicReturnsNil(t *testing.T) {
 	body := mustMarshalJSON(t, map[string]any{
 		"model": "gpt-5.5",
 		"messages": []any{
@@ -67,5 +88,5 @@ func TestAssistantTextMessages_NonAnthropicReturnsNil(t *testing.T) {
 	env, err := translate.ParseOpenAI(body)
 	require.NoError(t, err)
 
-	assert.Nil(t, env.AssistantTextMessages())
+	assert.Nil(t, env.TrailingAssistantTexts())
 }


### PR DESCRIPTION
## Problem

A `kimi-k2.7` session looped for ~26 turns re-attempting. It **never failed over**. A second reported Redwood loop ("I'll read the test file and then implement the fix") is the same shape on a different task.

The loop slips under **all six** existing detection paths because every one keys on *stagnation evidence*:
- tool-call loop / cyclic loop → needs identical repeated tool signatures
- no-progress fingerprint → its tool-progress marker **advances** because a new tool call is appended each turn (reads as progress)
- shadow spiral (`err_streak`, `same_file_thrash`, `repetition`, `monologue`) → calls succeed, args vary, tools are present, no edits

The one durable tell across both loops is the **repeated assistant narration** — and nothing looked at it.

## Fix

New enforcing `text_repetition` detector:
- **Pure scan** of the inbound history (present in full every turn → no cross-turn state). `translate.AssistantTextMessages()` extracts per-message narration (text blocks; skips `thinking`/`tool_use`).
- **Fires** when one normalized (`lowercase` + collapsed-whitespace) assistant text of **≥40 chars** recurs **≥3 times** within the last **12** assistant messages.
- **Action:** break the turn (synthetic `end_turn`) + expire the session pin so the next message re-routes off the stuck model — reuses `handleNoProgressBreak` mechanics.
- **Scope:** wired next to `no_progress` in the Anthropic path; main-loop / tool-result turns only (matches the spiral turn-type guard).
- **Kill switch:** `ROUTER_TEXT_REPETITION_BREAK_ENABLED` (default on), mirroring `ROUTER_SPIRAL_SHADOW_ENABLED` / `ROUTER_LOOP_ESCALATION_ENABLED`.

Thresholds are deliberately conservative (3 verbatim ≥40-char restatements) to keep false positives low on legit repeated confirmations; the kill switch is the escape hatch if it ever mis-fires.

## Design decisions (confirmed with @steventohme)

- **Break + re-route** rather than escalate-to-Opus — gets off the loop at re-route cost, not a forced Opus pin.
- **Armed now behind a kill switch** rather than shadow-first — Redwood is actively affected and burning balance.

## Tests

- `text_repetition_internal_test.go`: fires on repeated narration despite fresh tool calls; ignores distinct narration; below-threshold (2×) doesn't fire; short lines ignored; case/whitespace variants still count.
- `text_repetition_test.go` (translate): extraction order, multi-block concat, thinking/tool-only skipped, plain-string content, non-Anthropic → nil.
- Full `internal/proxy` + `internal/translate` suites green; `go vet` clean.

Companion: catalog PR #664 (Together fallback binding for `kimi-k2.7`) covers the provider-redundancy half of the same incident.

🤖 Generated with [Claude Code](https://claude.com/claude-code)