### PR TITLE
fix(translate): reuse isClaudeCodeInjectedBlock for text-repetition human-turn boundary

### DIFF
--- a/internal/translate/text_repetition.go
+++ b/internal/translate/text_repetition.go
@@ -45,10 +45,8 @@ loop:
 }
 
 // userIsHumanTurn reports whether a user message carries genuine human input:
-// text that is neither a tool_result nor a CC-injected wrapper block (reminder,
-// command, local-command output). Those injected turns must not reset the
-// repetition window or the backward scan collects nothing on the tool-result
-// turns it guards.
+// text that is neither a tool_result nor a CC-injected wrapper block.
+// Injected turns must not reset the window or the backward scan collects nothing.
 func userIsHumanTurn(msg gjson.Result) bool {
 	content := msg.Get("content")
 	if content.Type == gjson.String {

--- a/internal/translate/text_repetition.go
+++ b/internal/translate/text_repetition.go
@@ -45,9 +45,10 @@ loop:
 }
 
 // userIsHumanTurn reports whether a user message carries genuine human input:
-// text that is neither a tool_result nor a CC-injected <system-reminder> block.
-// Those reminder-bearing turns must not reset the repetition window or the
-// backward scan collects nothing on the tool-result turns it guards.
+// text that is neither a tool_result nor a CC-injected wrapper block (reminder,
+// command, local-command output). Those injected turns must not reset the
+// repetition window or the backward scan collects nothing on the tool-result
+// turns it guards.
 func userIsHumanTurn(msg gjson.Result) bool {
 	content := msg.Get("content")
 	if content.Type == gjson.String {
@@ -70,11 +71,12 @@ func userIsHumanTurn(msg gjson.Result) bool {
 	return found
 }
 
-// isHumanText reports whether s is real human input rather than empty text or a
-// Claude Code injected <system-reminder> block.
+// isHumanText reports whether s is real human input rather than empty text or
+// one of Claude Code's injected wrapper blocks (<system-reminder>,
+// <command-name>, <local-command-*>, …). Reuses isClaudeCodeInjectedBlock so
+// this stays in sync with how the rest of translate classifies user text.
 func isHumanText(s string) bool {
-	s = strings.TrimSpace(s)
-	return s != "" && !strings.HasPrefix(s, "<system-reminder")
+	return strings.TrimSpace(s) != "" && !isClaudeCodeInjectedBlock(s)
 }
 
 // assistantMessageText joins the text blocks of one assistant message,

--- a/internal/translate/text_repetition.go
+++ b/internal/translate/text_repetition.go
@@ -72,9 +72,7 @@ func userIsHumanTurn(msg gjson.Result) bool {
 }
 
 // isHumanText reports whether s is real human input rather than empty text or
-// one of Claude Code's injected wrapper blocks (<system-reminder>,
-// <command-name>, <local-command-*>, …). Reuses isClaudeCodeInjectedBlock so
-// this stays in sync with how the rest of translate classifies user text.
+// one of Claude Code's injected wrapper blocks (<system-reminder>, <command-name>, <local-command-*>, …).
 func isHumanText(s string) bool {
 	return strings.TrimSpace(s) != "" && !isClaudeCodeInjectedBlock(s)
 }

--- a/internal/translate/text_repetition_test.go
+++ b/internal/translate/text_repetition_test.go
@@ -86,6 +86,28 @@ func TestTrailingAssistantTexts_SystemReminderToolResultTurnIsNotABoundary(t *te
 		env.TrailingAssistantTexts(), "a reminder-bearing tool_result turn must not reset the window")
 }
 
+func TestTrailingAssistantTexts_CommandInjectionIsNotABoundary(t *testing.T) {
+	// CC injects other wrapper blocks besides <system-reminder> (e.g.
+	// <command-name>). A turn carrying only an injected block must not reset the
+	// window, matching isClaudeCodeInjectedBlock's classification elsewhere.
+	body := mustMarshalJSON(t, map[string]any{
+		"model": "claude-sonnet-4-6",
+		"messages": []any{
+			map[string]any{"role": "assistant", "content": "narration one from the loop"},
+			map[string]any{"role": "user", "content": []any{
+				map[string]any{"type": "text", "text": "<command-name>/status</command-name>"},
+			}},
+			map[string]any{"role": "assistant", "content": "narration two from the loop"},
+		},
+		"max_tokens": 256,
+	})
+	env, err := translate.ParseAnthropic(body)
+	require.NoError(t, err)
+
+	require.Equal(t, []string{"narration one from the loop", "narration two from the loop"},
+		env.TrailingAssistantTexts(), "a command-injection-only turn must not reset the window")
+}
+
 func TestTrailingAssistantTexts_PlainStringContent(t *testing.T) {
 	body := mustMarshalJSON(t, map[string]any{
 		"model": "claude-sonnet-4-6",

--- a/internal/translate/text_repetition_test.go
+++ b/internal/translate/text_repetition_test.go
@@ -87,9 +87,8 @@ func TestTrailingAssistantTexts_SystemReminderToolResultTurnIsNotABoundary(t *te
 }
 
 func TestTrailingAssistantTexts_CommandInjectionIsNotABoundary(t *testing.T) {
-	// CC injects other wrapper blocks besides <system-reminder> (e.g.
-	// <command-name>). A turn carrying only an injected block must not reset the
-	// window, matching isClaudeCodeInjectedBlock's classification elsewhere.
+	// CC injects wrapper blocks beyond <system-reminder> (e.g. <command-name>);
+	// those turns must not reset the repetition window.
 	body := mustMarshalJSON(t, map[string]any{
 		"model": "claude-sonnet-4-6",
 		"messages": []any{


### PR DESCRIPTION
Follow-up to #665, which merged before this last review comment could land.

Cursor Bugbot (medium) flagged that `isHumanText` — the human-turn boundary for the text-repetition detector's `TrailingAssistantTexts` scan — only skipped `<system-reminder>`, while the rest of `translate` classifies several Claude Code wrapper tags as non-human via `isClaudeCodeInjectedBlock` (`<command-name>`, `<local-command-*>`, …). A tool-result turn carrying only, e.g., a `<command-name>` block could be misread as a real user boundary, shrinking the narration window and letting a repetition loop slip through.

Fix: `isHumanText` now delegates to `isClaudeCodeInjectedBlock`, so the boundary stays in sync with how the rest of the package classifies user text. Added a `<command-name>` regression test alongside the existing `<system-reminder>` one.

No behavior change beyond the widened injected-tag set; full `internal/translate` + `internal/proxy` suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)