### PR TITLE
docs: forbid customer/private identifiers in this public repo

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -189,6 +189,7 @@ If new helper doesn't fit, justify new package in code comment before creating.
 
 ## Things to NEVER do
 
+- **Never put customer/company/org names or private identifiers in anything committed here.** This repo is public — commit messages, branch names, PR titles/descriptions, code comments, tests, and fixtures are world-readable. This holds even when a change is motivated by one customer's investigation (e.g. a loop-break or spiral fix found from a specific org's agentic session): describe the trigger generically ("a customer", "a large agentic session", "an org's monorepo"). No org names, org IDs, account emails, internal ticket/Linear links, or verbatim private Slack/support excerpts — those stay in the private WorkWeave repo + Linear.
 - **Never import code from outside this subproject.** Router is standalone Go module (`module workweave/router`) with no cross-project deps. If need utility from elsewhere in monorepo, copy into appropriate `internal/` package with own godoc.
 - **Never write raw SQL outside `db/queries/`** or call `pgx.Pool` directly from anywhere except `internal/postgres/`. SQLC is only data mapper.
 - **Never reach across layers.** Handler in `internal/api/` calling `*sqlc.Queries` directly = layering violation; surface Service method instead. Repo calling another repo = layering violation; put orchestration in `auth.Service` / `proxy.Service`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -189,6 +189,7 @@ If new helper doesn't fit, justify new package in code comment before creating.
 
 ## Things to NEVER do
 
+- **Never put customer/company/org names or private identifiers in anything committed here.** This repo is public — commit messages, branch names, PR titles/descriptions, code comments, tests, and fixtures are world-readable. This holds even when a change is motivated by one customer's investigation (e.g. a loop-break or spiral fix found from a specific org's agentic session): describe the trigger generically ("a customer", "a large agentic session", "an org's monorepo"). No org names, org IDs, account emails, internal ticket/Linear links, or verbatim private Slack/support excerpts — those stay in the private WorkWeave repo + Linear.
 - **Never import code from outside this subproject.** Router is standalone Go module (`module workweave/router`) with no cross-project deps. If need utility from elsewhere in monorepo, copy into appropriate `internal/` package with own godoc.
 - **Never write raw SQL outside `db/queries/`** or call `pgx.Pool` directly from anywhere except `internal/postgres/`. SQLC is only data mapper.
 - **Never reach across layers.** Handler in `internal/api/` calling `*sqlc.Queries` directly = layering violation; surface Service method instead. Repo calling another repo = layering violation; put orchestration in `auth.Service` / `proxy.Service`.


### PR DESCRIPTION
## Why

This repo is public. Customer/company names and other private identifiers have leaked into router PRs before (e.g. an org name in a loop-fix PR title/description). We want a standing rule that agents and humans see up front.

## What

Adds one bullet to the top of the **"Things to NEVER do"** section, mirrored verbatim in both `AGENTS.md` and `CLAUDE.md` (per the files' mirror notice):

> **Never put customer/company/org names or private identifiers in anything committed here.** This repo is public — commit messages, branch names, PR titles/descriptions, code comments, tests, and fixtures are world-readable. This holds even when a change is motivated by one customer's investigation … describe the trigger generically ("a customer", "a large agentic session", "an org's monorepo"). No org names, org IDs, account emails, internal ticket/Linear links, or verbatim private Slack/support excerpts — those stay in the private WorkWeave repo + Linear.

Instruction-layer guardrail only — it loads into any agent working in a router checkout. A mechanical backstop (pre-push/CI grep against a private denylist) can follow if we want a hard block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)