### PR TITLE
feat(proxy): honor "use my subscription first" toggle by fully bypassing subscription when off

### DIFF
--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -3247,10 +3247,7 @@ func (s *Service) enabledProvidersForRequest(ctx context.Context, surfaceProvide
 // env key is the correct fallback there.
 func resolveAndInjectCredentials(ctx context.Context, provider string, headers http.Header) context.Context {
 	routerKeyed := installationIDFromContext(ctx) != (uuid.UUID{})
-	// Skip the caller's subscription OAuth token (fall through to BYOK / the
-	// deployment key) when it's exhausted (Anthropic-only, a 429 would just
-	// repeat) or the installation turned off "use my subscription first"
-	// (provider-wide, so Codex is suppressed too).
+	// Skip subscription OAuth (fall through to BYOK / deployment key): exhausted (Anthropic-only, avoid re-429) or toggle off (provider-wide).
 	subDisabled := subscriptionRoutingDisabledForRequest(ctx)
 	suppressClaudeSub := claudeSubscriptionSuppressed(ctx) || subDisabled
 	suppressCodexSub := subDisabled

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -3306,11 +3306,8 @@ func resolveAndInjectCredentials(ctx context.Context, provider string, headers h
 	if creds != nil {
 		return context.WithValue(ctx, CredentialsContextKey{}, creds)
 	}
-	// Clear explicitly: on a router-keyed / no-BYOK request ctx still carries the
-	// subscription credential from an earlier attempt, and the provider client
-	// only falls back to its deployment key when ctx carries NO credential. For
-	// the disabled-toggle case the deployment / prepaid key is the intended path
-	// (the balance gate governs spend).
+	// Clear explicitly: router-keyed / no-BYOK ctx still carries the subscription credential from an earlier attempt;
+	// provider client only falls back to the deployment key when ctx carries NO credential.
 	if (suppressClaudeSub && provider == providers.ProviderAnthropic) ||
 		(suppressCodexSub && provider == providers.ProviderOpenAI) {
 		return clearCredentials(ctx)

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -842,9 +842,8 @@ func codexSubscriptionFromContext(ctx context.Context) *Credentials {
 // even on router-keyed requests (Codex CLI keeps its auth in Authorization
 // while the router key rides in X-Weave-Router-Key).
 func codexResponsesRequest(ctx context.Context, headers http.Header) bool {
-	// Subscription routing disabled suppresses the Codex credential, so the turn
-	// must not take the verbatim passthrough path — route it through normal
-	// chat->Responses translation and bill prepaid on the deployment key.
+	// Subscription routing disabled: skip verbatim passthrough — route through
+	// normal chat->Responses translation and bill prepaid.
 	if subscriptionRoutingDisabledForRequest(ctx) {
 		return false
 	}

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -3247,15 +3247,10 @@ func (s *Service) enabledProvidersForRequest(ctx context.Context, surfaceProvide
 // env key is the correct fallback there.
 func resolveAndInjectCredentials(ctx context.Context, provider string, headers http.Header) context.Context {
 	routerKeyed := installationIDFromContext(ctx) != (uuid.UUID{})
-	// Two independent reasons to skip a caller's subscription OAuth token and let
-	// resolution fall through to BYOK / the deployment key (prepaid billing):
-	//   1. claudeSubscriptionSuppressed — the Claude subscription is observed-
-	//      exhausted, so re-hitting it would just 429. Anthropic only; a Codex
-	//      subscription on the same request still pays for its OpenAI turns.
-	//   2. subscriptionRoutingDisabledForRequest — the installation turned off
-	//      "use my subscription first", opting to ignore its subscription and
-	//      bill every turn through prepaid. Provider-wide, so it suppresses the
-	//      Codex subscription too.
+	// Skip the caller's subscription OAuth token (fall through to BYOK / the
+	// deployment key) when it's exhausted (Anthropic-only, a 429 would just
+	// repeat) or the installation turned off "use my subscription first"
+	// (provider-wide, so Codex is suppressed too).
 	subDisabled := subscriptionRoutingDisabledForRequest(ctx)
 	suppressClaudeSub := claudeSubscriptionSuppressed(ctx) || subDisabled
 	suppressCodexSub := subDisabled
@@ -3302,10 +3297,8 @@ func resolveAndInjectCredentials(ctx context.Context, provider string, headers h
 	}
 	if creds == nil && !routerKeyed {
 		client := ExtractClientCredentials(provider, headers)
-		// A suppressed subscription must not slip back in here: off the router-key
-		// path the caller's OAuth bearer would otherwise re-resolve as the
-		// subscription, undoing the skip above. Scoped to the OAuth bearer of the
-		// provider whose subscription is suppressed.
+		// A suppressed subscription must not slip back in as the inbound OAuth
+		// bearer off the router-key path, undoing the skip above.
 		if client != nil && client.OAuth &&
 			((provider == providers.ProviderAnthropic && suppressClaudeSub) ||
 				(provider == providers.ProviderOpenAI && suppressCodexSub)) {
@@ -3316,13 +3309,11 @@ func resolveAndInjectCredentials(ctx context.Context, provider string, headers h
 	if creds != nil {
 		return context.WithValue(ctx, CredentialsContextKey{}, creds)
 	}
-	// Explicitly clear rather than leave as-is: on a router-keyed request with
-	// no BYOK, none of the branches above resolve anything, so ctx would still
-	// carry the primary attempt's subscription credential — re-sending the token
-	// the suppression meant to drop. The provider client only falls back to its
-	// deployment key when ctx carries NO credential. For the exhaustion case a
-	// fallback key always exists; for the disabled-toggle case the deployment /
-	// prepaid key is the intended path (and the balance gate governs spend).
+	// Clear explicitly: on a router-keyed / no-BYOK request ctx still carries the
+	// subscription credential from an earlier attempt, and the provider client
+	// only falls back to its deployment key when ctx carries NO credential. For
+	// the disabled-toggle case the deployment / prepaid key is the intended path
+	// (the balance gate governs spend).
 	if (suppressClaudeSub && provider == providers.ProviderAnthropic) ||
 		(suppressCodexSub && provider == providers.ProviderOpenAI) {
 		return clearCredentials(ctx)

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -3247,11 +3247,18 @@ func (s *Service) enabledProvidersForRequest(ctx context.Context, surfaceProvide
 // env key is the correct fallback there.
 func resolveAndInjectCredentials(ctx context.Context, provider string, headers http.Header) context.Context {
 	routerKeyed := installationIDFromContext(ctx) != (uuid.UUID{})
-	// When the caller's Claude subscription is observed-exhausted, skip its OAuth
-	// token so resolution falls through to BYOK / the deployment key instead of
-	// re-hitting a token that will just 429. Anthropic only — a Codex
-	// subscription on the same request still pays for its OpenAI turns.
-	suppressClaudeSub := claudeSubscriptionSuppressed(ctx)
+	// Two independent reasons to skip a caller's subscription OAuth token and let
+	// resolution fall through to BYOK / the deployment key (prepaid billing):
+	//   1. claudeSubscriptionSuppressed — the Claude subscription is observed-
+	//      exhausted, so re-hitting it would just 429. Anthropic only; a Codex
+	//      subscription on the same request still pays for its OpenAI turns.
+	//   2. subscriptionRoutingDisabledForRequest — the installation turned off
+	//      "use my subscription first", opting to ignore its subscription and
+	//      bill every turn through prepaid. Provider-wide, so it suppresses the
+	//      Codex subscription too.
+	subDisabled := subscriptionRoutingDisabledForRequest(ctx)
+	suppressClaudeSub := claudeSubscriptionSuppressed(ctx) || subDisabled
+	suppressCodexSub := subDisabled
 	if provider == providers.ProviderAnthropic && !suppressClaudeSub {
 		// Subscription-first (subscription -> BYOK -> deployment), resolved here
 		// explicitly rather than relying on BYOK being absent off the router-key
@@ -3272,7 +3279,7 @@ func resolveAndInjectCredentials(ctx context.Context, provider string, headers h
 			return context.WithValue(ctx, CredentialsContextKey{}, inbound)
 		}
 	}
-	if provider == providers.ProviderOpenAI {
+	if provider == providers.ProviderOpenAI && !suppressCodexSub {
 		// Codex (ChatGPT) subscription-first, mirroring the Anthropic block above.
 		if sub := codexSubscriptionFromContext(ctx); sub != nil {
 			observability.FromContext(ctx).Debug("Resolved Codex subscription credential for OpenAI turn", "credential_source", sub.Source)
@@ -3295,11 +3302,13 @@ func resolveAndInjectCredentials(ctx context.Context, provider string, headers h
 	}
 	if creds == nil && !routerKeyed {
 		client := ExtractClientCredentials(provider, headers)
-		// A suppressed Claude subscription must not slip back in here: off the
-		// router-key path the spent sk-ant-oat bearer would otherwise re-resolve
-		// as the subscription, undoing the skip above. Scoped to the Anthropic
-		// OAuth bearer only.
-		if suppressClaudeSub && provider == providers.ProviderAnthropic && client != nil && client.OAuth {
+		// A suppressed subscription must not slip back in here: off the router-key
+		// path the caller's OAuth bearer would otherwise re-resolve as the
+		// subscription, undoing the skip above. Scoped to the OAuth bearer of the
+		// provider whose subscription is suppressed.
+		if client != nil && client.OAuth &&
+			((provider == providers.ProviderAnthropic && suppressClaudeSub) ||
+				(provider == providers.ProviderOpenAI && suppressCodexSub)) {
 			client = nil
 		}
 		creds = client
@@ -3309,11 +3318,13 @@ func resolveAndInjectCredentials(ctx context.Context, provider string, headers h
 	}
 	// Explicitly clear rather than leave as-is: on a router-keyed request with
 	// no BYOK, none of the branches above resolve anything, so ctx would still
-	// carry the primary attempt's subscription credential — re-sending the
-	// spent sk-ant-oat the suppression meant to drop. The provider client only
-	// falls back to its deployment key when ctx carries NO credential. Safe
-	// because suppression is only ever set when a fallback key exists.
-	if suppressClaudeSub && provider == providers.ProviderAnthropic {
+	// carry the primary attempt's subscription credential — re-sending the token
+	// the suppression meant to drop. The provider client only falls back to its
+	// deployment key when ctx carries NO credential. For the exhaustion case a
+	// fallback key always exists; for the disabled-toggle case the deployment /
+	// prepaid key is the intended path (and the balance gate governs spend).
+	if (suppressClaudeSub && provider == providers.ProviderAnthropic) ||
+		(suppressCodexSub && provider == providers.ProviderOpenAI) {
 		return clearCredentials(ctx)
 	}
 	return ctx

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -842,6 +842,12 @@ func codexSubscriptionFromContext(ctx context.Context) *Credentials {
 // even on router-keyed requests (Codex CLI keeps its auth in Authorization
 // while the router key rides in X-Weave-Router-Key).
 func codexResponsesRequest(ctx context.Context, headers http.Header) bool {
+	// Subscription routing disabled suppresses the Codex credential, so the turn
+	// must not take the verbatim passthrough path — route it through normal
+	// chat->Responses translation and bill prepaid on the deployment key.
+	if subscriptionRoutingDisabledForRequest(ctx) {
+		return false
+	}
 	if codexSubscriptionFromContext(ctx) != nil {
 		return true
 	}

--- a/internal/proxy/subscription_suppression_credential_internal_test.go
+++ b/internal/proxy/subscription_suppression_credential_internal_test.go
@@ -105,6 +105,19 @@ func TestResolveAndInjectCredentials_DisabledSuppressesCodexSubscription(t *test
 		"toggle off must suppress the Codex subscription so the turn bills prepaid")
 }
 
+// Toggle off must also drop the Codex /v1/responses verbatim-passthrough path,
+// so the turn takes normal chat->Responses translation and bills prepaid.
+func TestCodexResponsesRequest_DisabledDropsPassthrough(t *testing.T) {
+	headers := http.Header{}
+	headers.Set("Authorization", "Bearer eyJhbGciOi.codex.jwt")
+	headers.Set("ChatGPT-Account-ID", "acct-1")
+
+	assert.True(t, codexResponsesRequest(routerKeyedCtx(), headers),
+		"a Codex sub normally takes the passthrough path")
+	assert.False(t, codexResponsesRequest(subscriptionDisabledCtx(), headers),
+		"toggle off must drop the Codex passthrough path")
+}
+
 // Regression guard: an inbound Codex subscription bearer on the router-key path
 // must not slip back in via the client-credential branch when the toggle is off.
 func TestResolveAndInjectCredentials_DisabledCodexNotReResolvedFromContext(t *testing.T) {

--- a/internal/proxy/subscription_suppression_credential_internal_test.go
+++ b/internal/proxy/subscription_suppression_credential_internal_test.go
@@ -75,17 +75,13 @@ func TestResolveAndInjectCredentials_SuppressionDoesNotClearCodexOpenAITurn(t *t
 	assert.Equal(t, credSourceCodexSubscription, got.Source)
 }
 
-// subscriptionDisabledCtx mimics a router-keyed request whose installation has
-// turned off "use my subscription first" (stored inverted as
-// subscription_routing_disabled), stashed on ctx by the auth middleware.
+// subscriptionDisabledCtx returns a router-keyed ctx with subscription routing
+// disabled (the "use my subscription first" toggle off).
 func subscriptionDisabledCtx() context.Context {
 	return context.WithValue(routerKeyedCtx(), InstallationSubscriptionRoutingDisabledContextKey{}, true)
 }
 
-// With the toggle off, the installation opted to ignore its subscription and
-// bill through prepaid, so an inbound Claude subscription bearer must be
-// suppressed and cleared just like the exhaustion case — the turn serves on the
-// deployment key and debits prepaid credits.
+// Toggle off must suppress the Claude subscription so the turn bills prepaid.
 func TestResolveAndInjectCredentials_DisabledSuppressesClaudeSubscription(t *testing.T) {
 	headers := http.Header{}
 	headers.Set("Authorization", "Bearer sk-ant-oat01-live")
@@ -96,9 +92,8 @@ func TestResolveAndInjectCredentials_DisabledSuppressesClaudeSubscription(t *tes
 		"toggle off must suppress the Claude subscription so the turn bills prepaid")
 }
 
-// Unlike exhaustion (Anthropic-only), the toggle is provider-wide: with it off
-// a Codex subscription must ALSO be suppressed so OpenAI turns bill prepaid
-// rather than the caller's ChatGPT plan.
+// Unlike exhaustion (Anthropic-only), the disabled toggle is provider-wide and
+// must suppress Codex too.
 func TestResolveAndInjectCredentials_DisabledSuppressesCodexSubscription(t *testing.T) {
 	headers := http.Header{}
 	headers.Set("Authorization", "Bearer eyJhbGciOi.codex.jwt")

--- a/internal/proxy/subscription_suppression_credential_internal_test.go
+++ b/internal/proxy/subscription_suppression_credential_internal_test.go
@@ -74,3 +74,53 @@ func TestResolveAndInjectCredentials_SuppressionDoesNotClearCodexOpenAITurn(t *t
 	require.NotNil(t, got, "a Codex subscription must still resolve for its OpenAI turn")
 	assert.Equal(t, credSourceCodexSubscription, got.Source)
 }
+
+// subscriptionDisabledCtx mimics a router-keyed request whose installation has
+// turned off "use my subscription first" (stored inverted as
+// subscription_routing_disabled), stashed on ctx by the auth middleware.
+func subscriptionDisabledCtx() context.Context {
+	return context.WithValue(routerKeyedCtx(), InstallationSubscriptionRoutingDisabledContextKey{}, true)
+}
+
+// With the toggle off, the installation opted to ignore its subscription and
+// bill through prepaid, so an inbound Claude subscription bearer must be
+// suppressed and cleared just like the exhaustion case — the turn serves on the
+// deployment key and debits prepaid credits.
+func TestResolveAndInjectCredentials_DisabledSuppressesClaudeSubscription(t *testing.T) {
+	headers := http.Header{}
+	headers.Set("Authorization", "Bearer sk-ant-oat01-live")
+
+	out := resolveAndInjectCredentials(subscriptionDisabledCtx(), providers.ProviderAnthropic, headers)
+
+	assert.Nil(t, CredentialsFromContext(out),
+		"toggle off must suppress the Claude subscription so the turn bills prepaid")
+}
+
+// Unlike exhaustion (Anthropic-only), the toggle is provider-wide: with it off
+// a Codex subscription must ALSO be suppressed so OpenAI turns bill prepaid
+// rather than the caller's ChatGPT plan.
+func TestResolveAndInjectCredentials_DisabledSuppressesCodexSubscription(t *testing.T) {
+	headers := http.Header{}
+	headers.Set("Authorization", "Bearer eyJhbGciOi.codex.jwt")
+	headers.Set("ChatGPT-Account-ID", "acct-1")
+
+	out := resolveAndInjectCredentials(subscriptionDisabledCtx(), providers.ProviderOpenAI, headers)
+
+	assert.Nil(t, CredentialsFromContext(out),
+		"toggle off must suppress the Codex subscription so the turn bills prepaid")
+}
+
+// Regression guard: an inbound Codex subscription bearer on the router-key path
+// must not slip back in via the client-credential branch when the toggle is off.
+func TestResolveAndInjectCredentials_DisabledCodexNotReResolvedFromContext(t *testing.T) {
+	spentCodex := &Credentials{APIKey: []byte("eyJhbGciOi.codex.jwt"), AccountID: []byte("acct-1"), Source: credSourceCodexSubscription, OAuth: true}
+	ctx := context.WithValue(subscriptionDisabledCtx(), CredentialsContextKey{}, spentCodex)
+	headers := http.Header{}
+	headers.Set("Authorization", "Bearer eyJhbGciOi.codex.jwt")
+	headers.Set("ChatGPT-Account-ID", "acct-1")
+
+	out := resolveAndInjectCredentials(ctx, providers.ProviderOpenAI, headers)
+
+	assert.Nil(t, CredentialsFromContext(out),
+		"a disabled Codex subscription carried on ctx must be cleared, not re-resolved")
+}

--- a/internal/proxy/subsidy.go
+++ b/internal/proxy/subsidy.go
@@ -75,11 +75,9 @@ func (s *Service) WithUsageObserver(obs *usage.Observer) *Service {
 // the prepaid balance gate (server/middleware) has no Service handle but must
 // agree with this path on what counts as "a subscription is present".
 func presentSubscriptionTokens(ctx context.Context, headers http.Header) (codex, anthropic string) {
-	// "Use my subscription first" off: the installation opted out of its
-	// subscription entirely, so report none. Every subscription-keyed path then
-	// agrees — no subsidy, no usage-bypass, no balance-gate exemption, no usage
-	// observer — matching resolveAndInjectCredentials, which suppresses the actual
-	// credential so the turn bills prepaid on the deployment key.
+	// Subscription routing disabled: report none so every keyed path (subsidy,
+	// usage-bypass, balance gate) agrees the turn is prepaid, matching the
+	// credential suppression in resolveAndInjectCredentials.
 	if subscriptionRoutingDisabledForRequest(ctx) {
 		return "", ""
 	}

--- a/internal/proxy/subsidy.go
+++ b/internal/proxy/subsidy.go
@@ -75,9 +75,8 @@ func (s *Service) WithUsageObserver(obs *usage.Observer) *Service {
 // the prepaid balance gate (server/middleware) has no Service handle but must
 // agree with this path on what counts as "a subscription is present".
 func presentSubscriptionTokens(ctx context.Context, headers http.Header) (codex, anthropic string) {
-	// Subscription routing disabled: report none so every keyed path (subsidy,
-	// usage-bypass, balance gate) agrees the turn is prepaid, matching the
-	// credential suppression in resolveAndInjectCredentials.
+	// Subscription routing disabled: treat as absent so subsidy, usage-bypass, and
+	// balance gate all agree the turn is prepaid.
 	if subscriptionRoutingDisabledForRequest(ctx) {
 		return "", ""
 	}

--- a/internal/proxy/subsidy.go
+++ b/internal/proxy/subsidy.go
@@ -75,6 +75,14 @@ func (s *Service) WithUsageObserver(obs *usage.Observer) *Service {
 // the prepaid balance gate (server/middleware) has no Service handle but must
 // agree with this path on what counts as "a subscription is present".
 func presentSubscriptionTokens(ctx context.Context, headers http.Header) (codex, anthropic string) {
+	// "Use my subscription first" off: the installation opted out of its
+	// subscription entirely, so report none. Every subscription-keyed path then
+	// agrees — no subsidy, no usage-bypass, no balance-gate exemption, no usage
+	// observer — matching resolveAndInjectCredentials, which suppresses the actual
+	// credential so the turn bills prepaid on the deployment key.
+	if subscriptionRoutingDisabledForRequest(ctx) {
+		return "", ""
+	}
 	if codexSubscriptionFromContext(ctx) != nil {
 		codex = openaiSubscriptionFromContext(ctx)
 	} else if c := ExtractClientCredentials(providers.ProviderOpenAI, headers); c != nil && c.OAuth {

--- a/internal/proxy/subsidy_test.go
+++ b/internal/proxy/subsidy_test.go
@@ -49,11 +49,8 @@ func TestPresentSubscriptionTokens_InboundBearerHarnesses(t *testing.T) {
 	})
 }
 
-// With "use my subscription first" off, a present Claude sub must NOT count as
-// present anywhere: resolveAndInjectCredentials suppresses the credential and
-// bills prepaid, so the usage-bypass gate and the balance-gate exemption (both
-// keyed on presentSubscriptionTokens / RequestPresentsCoveringSubscription) must
-// agree the turn is prepaid — otherwise it runs free on the deployment key.
+// Toggle off: presentSubscriptionTokens must report none so the usage-bypass and
+// balance-gate paths agree the turn is prepaid, not free on the deployment key.
 func TestPresentSubscriptionTokens_DisabledReportsNone(t *testing.T) {
 	h := http.Header{}
 	h.Set("Authorization", "Bearer sk-ant-oat01-live-token")

--- a/internal/proxy/subsidy_test.go
+++ b/internal/proxy/subsidy_test.go
@@ -49,6 +49,27 @@ func TestPresentSubscriptionTokens_InboundBearerHarnesses(t *testing.T) {
 	})
 }
 
+// With "use my subscription first" off, a present Claude sub must NOT count as
+// present anywhere: resolveAndInjectCredentials suppresses the credential and
+// bills prepaid, so the usage-bypass gate and the balance-gate exemption (both
+// keyed on presentSubscriptionTokens / RequestPresentsCoveringSubscription) must
+// agree the turn is prepaid — otherwise it runs free on the deployment key.
+func TestPresentSubscriptionTokens_DisabledReportsNone(t *testing.T) {
+	h := http.Header{}
+	h.Set("Authorization", "Bearer sk-ant-oat01-live-token")
+	ctx := context.WithValue(context.Background(), InstallationSubscriptionRoutingDisabledContextKey{}, true)
+
+	codex, anthro := presentSubscriptionTokens(ctx, h)
+	assert.Empty(t, anthro, "toggle off must report no Claude sub so billing paths gate prepaid")
+	assert.Empty(t, codex)
+
+	assert.False(t, RequestPresentsCoveringSubscription(ctx, h, routePathMessages),
+		"toggle off must not exempt the balance gate")
+
+	// Sanity: the same request WITH the toggle on does present the sub.
+	assert.True(t, RequestPresentsCoveringSubscription(context.Background(), h, routePathMessages))
+}
+
 // End-to-end: the key withUsageObserver records under must equal the key
 // subsidyFactors reads, or the discount never materializes. Drives the real
 // observer closure (as a provider would) with a resolved Codex credential and an


### PR DESCRIPTION
## What

Makes the per-installation `subscription_routing_disabled` flag (the inverted form of the dashboard's "use my subscription first" toggle) actually stop using the caller's subscription when off, instead of only dropping the routing subsidy bonus.

`resolveAndInjectCredentials` now folds `subscriptionRoutingDisabledForRequest(ctx)` into credential suppression:

- **Claude**: `suppressClaudeSub` now includes the disabled flag (previously only the observed-exhaustion case).
- **Codex**: a new `suppressCodexSub` skips the ChatGPT-subscription resolution branch and clears any Codex credential carried on ctx, so OpenAI turns fall through too.
- Both providers now clear credentials on the router-keyed / no-BYOK path so resolution lands on the deployment key and the turn bills through prepaid credits.

## Why

Previously the flag only zeroed `subsidyFactors` — it removed the Claude routing *bias* but still forwarded the subscription credential whenever a Claude/Codex model won on merit. So subscription usage never went to zero, and the dashboard toggle didn't mean what it said. Customers who turned it off (or, more commonly, misread the old double-negative label) kept billing their subscription.

With this change, off = "ignore my subscription, bill everything through prepaid credits like a normal API key."

## Billing note

When off and the org has no funded prepaid balance / autopay, the existing balance gate returns 402 — which is correct (no subscription, no credits = can't serve). The WorkWeave dashboard PR adds a client-side guard that blocks turning the toggle off unless the org is prepaid-ready, and the org with a stuck negative balance is being reverted to on before this deploys.

## Tests

Added to `subscription_suppression_credential_internal_test.go`:
- disabled → Claude subscription suppressed/cleared
- disabled → Codex subscription suppressed (unlike exhaustion, which is Anthropic-only)
- disabled → Codex carried on ctx is cleared, not re-resolved

`go build ./...` and the full `internal/proxy` suite pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)