### PR TITLE
fix(translate): bail strictify on typeless anyOf branches

### DIFF
--- a/internal/translate/strictify_openai.go
+++ b/internal/translate/strictify_openai.go
@@ -104,12 +104,8 @@ func strictifyNode(node map[string]any, depth int, propCount *int) (out map[stri
 			if !sok {
 				return nil, false
 			}
-			// OpenAI strict mode requires every anyOf branch to carry a
-			// concrete type; a typeless branch — e.g. an "any"/`{}` member of a
-			// Union (respan's bulk_create_dataset_logs `expected_output`) — is
-			// not expressible strictly. Bail to the non-strict fallback rather
-			// than emit a branch OpenAI 400s with
-			// "In context=(...anyOf...), schema must have a 'type' key".
+			// OpenAI strict mode: every anyOf branch needs a concrete type; bail
+			// rather than emit a typeless branch that 400s.
 			if !schemaHasStrictType(sb) {
 				return nil, false
 			}

--- a/internal/translate/strictify_openai.go
+++ b/internal/translate/strictify_openai.go
@@ -216,11 +216,8 @@ func makeNullable(node map[string]any) map[string]any {
 	return map[string]any{"anyOf": []any{node, map[string]any{"type": "null"}}}
 }
 
-// schemaHasStrictType reports whether a strictified node carries a type OpenAI
-// strict mode can consume: an explicit "type", a nested "anyOf" (whose branches
-// were themselves strictified and type-checked), or an "enum" (strict mode
-// infers the type from the enum values). A node with none of these — e.g. a
-// bare "any"/`{}` schema — is not expressible in strict mode.
+// schemaHasStrictType reports whether node carries a type OpenAI strict mode
+// can consume: an explicit "type", a nested "anyOf", or an "enum".
 func schemaHasStrictType(node map[string]any) bool {
 	if _, ok := node["type"]; ok {
 		return true

--- a/internal/translate/strictify_openai.go
+++ b/internal/translate/strictify_openai.go
@@ -104,6 +104,15 @@ func strictifyNode(node map[string]any, depth int, propCount *int) (out map[stri
 			if !sok {
 				return nil, false
 			}
+			// OpenAI strict mode requires every anyOf branch to carry a
+			// concrete type; a typeless branch — e.g. an "any"/`{}` member of a
+			// Union (respan's bulk_create_dataset_logs `expected_output`) — is
+			// not expressible strictly. Bail to the non-strict fallback rather
+			// than emit a branch OpenAI 400s with
+			// "In context=(...anyOf...), schema must have a 'type' key".
+			if !schemaHasStrictType(sb) {
+				return nil, false
+			}
 			outBranches = append(outBranches, sb)
 		}
 		res["anyOf"] = outBranches
@@ -135,7 +144,11 @@ func strictifyNode(node map[string]any, depth int, propCount *int) (out map[stri
 	}
 
 	// Object node: additionalProperties:false, all properties required,
-	// originally-optional properties become nullable.
+	// originally-optional properties become nullable. Stamp an explicit
+	// type:"object" — a node OpenAI must read as an object (it has properties)
+	// but that omitted its own type would otherwise emit typeless and 400 when
+	// it sits inside an anyOf branch.
+	res["type"] = "object"
 	res["additionalProperties"] = false
 	originallyRequired := make(map[string]struct{})
 	if reqList, present := res["required"].([]any); present {
@@ -201,6 +214,24 @@ func makeNullable(node map[string]any) map[string]any {
 	}
 	// No type and no anyOf (e.g. bare enum): wrap the node itself.
 	return map[string]any{"anyOf": []any{node, map[string]any{"type": "null"}}}
+}
+
+// schemaHasStrictType reports whether a strictified node carries a type OpenAI
+// strict mode can consume: an explicit "type", a nested "anyOf" (whose branches
+// were themselves strictified and type-checked), or an "enum" (strict mode
+// infers the type from the enum values). A node with none of these — e.g. a
+// bare "any"/`{}` schema — is not expressible in strict mode.
+func schemaHasStrictType(node map[string]any) bool {
+	if _, ok := node["type"]; ok {
+		return true
+	}
+	if _, ok := node["anyOf"]; ok {
+		return true
+	}
+	if _, ok := node["enum"]; ok {
+		return true
+	}
+	return false
 }
 
 // compactJSONValue renders a dropped constraint value for a description note.

--- a/internal/translate/strictify_openai.go
+++ b/internal/translate/strictify_openai.go
@@ -140,10 +140,8 @@ func strictifyNode(node map[string]any, depth int, propCount *int) (out map[stri
 	}
 
 	// Object node: additionalProperties:false, all properties required,
-	// originally-optional properties become nullable. Stamp an explicit
-	// type:"object" — a node OpenAI must read as an object (it has properties)
-	// but that omitted its own type would otherwise emit typeless and 400 when
-	// it sits inside an anyOf branch.
+	// originally-optional properties become nullable. Stamp type:"object" so
+	// a properties-only node inside anyOf carries an explicit type.
 	res["type"] = "object"
 	res["additionalProperties"] = false
 	originallyRequired := make(map[string]struct{})

--- a/internal/translate/strictify_openai_test.go
+++ b/internal/translate/strictify_openai_test.go
@@ -180,6 +180,56 @@ func TestStrictify_PropertyNamesDroppedToDescription(t *testing.T) {
 	assert.Contains(t, desc, "propertyNames", "dropped constraint must survive as description guidance")
 }
 
+// Prod repro (2026-07-07): the respan MCP server's bulk_create_dataset_logs
+// tool types `expected_output` as a Union whose first anyOf branch is a typeless
+// "any"/`{}` schema. Pre-fix strictify emitted strict:true carrying that
+// typeless branch and OpenAI 400'd the whole request with
+// "In context=('properties','logs','items','properties','expected_output','anyOf','0'),
+// schema must have a 'type' key" — killing the session on the first call.
+func TestStrictify_TypelessAnyOfBranchBails(t *testing.T) {
+	_, ok := strictifyFromJSON(t, `{
+		"type":"object",
+		"properties":{
+			"logs":{
+				"type":"array",
+				"items":{
+					"type":"object",
+					"properties":{
+						"expected_output":{"anyOf":[{},{"type":"null"}]}
+					},
+					"required":["expected_output"]
+				}
+			}
+		},
+		"required":["logs"]
+	}`)
+	require.False(t, ok, "typeless anyOf branch must fall back to non-strict emission")
+}
+
+// An object branch inside an anyOf that omits its own type (relying on its
+// properties to imply object) must be stamped type:"object" so strict mode
+// accepts it rather than 400'ing on the missing type key.
+func TestStrictify_ObjectBranchGetsExplicitType(t *testing.T) {
+	out, ok := strictifyFromJSON(t, `{
+		"type":"object",
+		"properties":{
+			"payload":{"anyOf":[
+				{"properties":{"id":{"type":"string"}},"required":["id"]},
+				{"type":"null"}
+			]}
+		},
+		"required":["payload"]
+	}`)
+	require.True(t, ok)
+
+	payload := out["properties"].(map[string]any)["payload"].(map[string]any)
+	branches := payload["anyOf"].([]any)
+	objBranch := branches[0].(map[string]any)
+	assert.Equal(t, "object", objBranch["type"],
+		"an object-by-properties branch must be stamped type:object for strict mode")
+	assert.Equal(t, false, objBranch["additionalProperties"])
+}
+
 // Schema-defining keywords strict mode cannot express must bail to the
 // non-strict fallback rather than emit a lossy strict schema.
 func TestStrictify_UnevaluatedPropertiesBails(t *testing.T) {

--- a/internal/translate/strictify_openai_test.go
+++ b/internal/translate/strictify_openai_test.go
@@ -180,12 +180,8 @@ func TestStrictify_PropertyNamesDroppedToDescription(t *testing.T) {
 	assert.Contains(t, desc, "propertyNames", "dropped constraint must survive as description guidance")
 }
 
-// Prod repro (2026-07-07): the respan MCP server's bulk_create_dataset_logs
-// tool types `expected_output` as a Union whose first anyOf branch is a typeless
-// "any"/`{}` schema. Pre-fix strictify emitted strict:true carrying that
-// typeless branch and OpenAI 400'd the whole request with
-// "In context=('properties','logs','items','properties','expected_output','anyOf','0'),
-// schema must have a 'type' key" — killing the session on the first call.
+// A typeless anyOf branch (e.g. "any"/`{}`) cannot be expressed in strict
+// mode; strictify must bail rather than emit a schema OpenAI 400s on.
 func TestStrictify_TypelessAnyOfBranchBails(t *testing.T) {
 	_, ok := strictifyFromJSON(t, `{
 		"type":"object",

--- a/internal/translate/strictify_openai_test.go
+++ b/internal/translate/strictify_openai_test.go
@@ -202,9 +202,7 @@ func TestStrictify_TypelessAnyOfBranchBails(t *testing.T) {
 	require.False(t, ok, "typeless anyOf branch must fall back to non-strict emission")
 }
 
-// An object branch inside an anyOf that omits its own type (relying on its
-// properties to imply object) must be stamped type:"object" so strict mode
-// accepts it rather than 400'ing on the missing type key.
+// An object-by-properties anyOf branch without an explicit type must be stamped type:"object".
 func TestStrictify_ObjectBranchGetsExplicitType(t *testing.T) {
 	out, ok := strictifyFromJSON(t, `{
 		"type":"object",


### PR DESCRIPTION
## Problem

A Claude Code session (router session `2d3d4001-c838-4c42-b841-5ea8060eade2`) hit:

```
400 Invalid schema for function 'mcp__respan__bulk_create_dataset_logs':
In context=('properties','logs','items','properties','expected_output','anyOf','0'),
schema must have a 'type' key.
```

## Root cause

On the Responses API path (gpt-5.x), `writeResponsesToolsFromAnthropic` runs `strictifyOpenAISchema` and, on success, emits the tool with `strict:true`. OpenAI's strict-mode grammar compiler requires **every** `anyOf` branch to carry a concrete `type`.

respan's `bulk_create_dataset_logs` types `expected_output` as a Union whose first `anyOf` branch is a typeless "any"/`{}` schema. `strictifyNode` recursed into `anyOf` branches but passed them through unchanged, so the typeless branch rode into a `strict:true` schema and OpenAI rejected the whole request — killing the session on the first call.

## Fix

- **Bail on typeless `anyOf` branches.** A bare "any"/`{}` branch is not expressible in strict mode, so fall back to the existing non-strict emission path (same behavior as the `oneOf`/`allOf` bail keywords). New helper `schemaHasStrictType` treats a node as strict-expressible if it has a `type`, a nested `anyOf`, or an `enum` (strict mode infers type from enum values — matches the existing enum-optional handling).
- **Stamp `type:"object"` on object-by-properties nodes** so a legitimate object branch that omitted its own `type` (relying on `properties` to imply object) survives strictification with a valid type key instead of also 400'ing inside an `anyOf`.

## Tests

- `TestStrictify_TypelessAnyOfBranchBails` — exact respan repro; asserts the schema bails to non-strict.
- `TestStrictify_ObjectBranchGetsExplicitType` — object-by-properties `anyOf` branch is stamped `type:"object"`.
- Full `internal/translate` suite passes with no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)