### PR TITLE
feat(install): default ENABLE_TOOL_SEARCH=auto for Claude Code

### DIFF
--- a/install/README.md
+++ b/install/README.md
@@ -89,7 +89,7 @@ the target flag:
 
 | Path                                  | Purpose                                                       |
 | ------------------------------------- | ------------------------------------------------------------- |
-| `~/.claude/settings.json`             | Sets `env.ANTHROPIC_BASE_URL`, `env.ANTHROPIC_CUSTOM_HEADERS` with `X-Weave-Router-Key`, and `statusLine`. Other keys preserved. |
+| `~/.claude/settings.json`             | Sets `env.ANTHROPIC_BASE_URL`, `env.ANTHROPIC_CUSTOM_HEADERS` with `X-Weave-Router-Key`, `env.ENABLE_TOOL_SEARCH=auto` (a custom base URL otherwise disables Claude Code's MCP tool-search deferral), and `statusLine`. Other keys preserved. |
 | `~/.weave/cc-statusline.sh`           | The status line script. Reads the router's decisions log + the CC transcript to show routed-model + savings. |
 
 **Project scope (`--scope project`):**

--- a/install/install.sh
+++ b/install/install.sh
@@ -1403,9 +1403,9 @@ toggle_claude() {
       else
         # Park just the router-owned env keys, then strip them so Claude Code
         # falls back to its own Anthropic login.
-        jq '{env: ((.env // {}) | {ANTHROPIC_BASE_URL, ANTHROPIC_CUSTOM_HEADERS} | with_entries(select(.value != null)))}' "$settings_file" >"$parked"
+        jq '{env: ((.env // {}) | {ANTHROPIC_BASE_URL, ANTHROPIC_CUSTOM_HEADERS, ENABLE_TOOL_SEARCH} | with_entries(select(.value != null)))}' "$settings_file" >"$parked"
         chmod 600 "$parked"
-        merged="$(jq '(.env // {}) |= del(.ANTHROPIC_BASE_URL, .ANTHROPIC_CUSTOM_HEADERS)
+        merged="$(jq '(.env // {}) |= del(.ANTHROPIC_BASE_URL, .ANTHROPIC_CUSTOM_HEADERS, .ENABLE_TOOL_SEARCH)
                       | (if (.env // {} | length) == 0 then del(.env) else . end)' "$settings_file")"
         printf '%s\n' "$merged" >"$settings_file"
       fi
@@ -2431,14 +2431,19 @@ if [ -n "$user_name" ]; then
 fi
 custom_headers="$custom_headers"$'\n'"X-App: claude-code"
 
+# Setting ANTHROPIC_BASE_URL makes Claude Code treat us as non-first-party and
+# disable MCP tool-search deferral, inlining every tool schema into every request
+# — a large uncompactable prefix that can push a session into an autocompact
+# thrash loop. ENABLE_TOOL_SEARCH=auto restores on-demand loading (Claude Code's
+# own first-party default).
 if [ "$scope" = "project" ] && [ -z "$install_dir" ]; then
   jq -n --arg url "$base_url" --arg sl "$statusline_path_for_settings" '{
-    env: { ANTHROPIC_BASE_URL: $url },
+    env: { ANTHROPIC_BASE_URL: $url, ENABLE_TOOL_SEARCH: "auto" },
     statusLine: { type: "command", command: $sl }
   }' >"$tmp_patch"
 else
   jq -n --arg url "$base_url" --arg header "$custom_headers" --arg sl "$statusline_path_for_settings" '{
-    env: { ANTHROPIC_BASE_URL: $url, ANTHROPIC_CUSTOM_HEADERS: $header },
+    env: { ANTHROPIC_BASE_URL: $url, ANTHROPIC_CUSTOM_HEADERS: $header, ENABLE_TOOL_SEARCH: "auto" },
     statusLine: { type: "command", command: $sl }
   }' >"$tmp_patch"
 fi

--- a/install/uninstall.sh
+++ b/install/uninstall.sh
@@ -475,13 +475,13 @@ else
 fi
 
 if [ -f "$settings_file" ]; then
-  # Only remove keys we actually installed: scrub our two env vars, and only
+  # Only remove keys we actually installed: scrub our env vars, and only
   # delete `statusLine` / `apiKeyHelper` when they point at scripts this
   # installer used in older versions. Otherwise an unrelated user-configured
   # statusLine or apiKeyHelper would be silently clobbered.
   cleaned="$(jq '
     if .env then
-      .env |= (del(.ANTHROPIC_BASE_URL, .ANTHROPIC_AUTH_TOKEN, .ANTHROPIC_CUSTOM_HEADERS))
+      .env |= (del(.ANTHROPIC_BASE_URL, .ANTHROPIC_AUTH_TOKEN, .ANTHROPIC_CUSTOM_HEADERS, .ENABLE_TOOL_SEARCH))
       | (if (.env | length) == 0 then del(.env) else . end)
     else . end
     | (if (.statusLine.command // "" | tostring | endswith("cc-statusline.sh"))
@@ -501,7 +501,7 @@ if [ -n "$local_settings_file" ] && [ -f "$local_settings_file" ]; then
   # uninstall fully reverts a toggled-off install.
   cleaned="$(jq '
     if .env then
-      .env |= (del(.ANTHROPIC_BASE_URL, .ANTHROPIC_AUTH_TOKEN, .ANTHROPIC_CUSTOM_HEADERS))
+      .env |= (del(.ANTHROPIC_BASE_URL, .ANTHROPIC_AUTH_TOKEN, .ANTHROPIC_CUSTOM_HEADERS, .ENABLE_TOOL_SEARCH))
       | (if (.env | length) == 0 then del(.env) else . end)
     else . end
     | del(.apiKeyHelper)


### PR DESCRIPTION
## Problem

Pointing Claude Code at the router sets a non-first-party `ANTHROPIC_BASE_URL`, which makes Claude Code **disable its MCP tool-search deferral**. Every MCP tool schema is then inlined into every request. With a large MCP tool set that fixed prefix measured **~89% of a ~465 KB request body (~118k tokens)** in one investigated session — and it's **uncompactable**, because compaction only rewrites the conversation, never the tool definitions.

The result: the context window sits permanently near-full, so any sizeable tool output tips it over → compact → the prefix instantly refills → Claude Code's autocompact **thrash circuit breaker** fires. It's dramatically worse on smaller-context routes (e.g. a forced 131k-window model), where the prefix alone eats most of the window.

This never reproduces on vanilla Claude Code hitting the first-party API, because there tool search stays on and the prefix collapses to a few hundred tokens of tool *names*.

## Fix

Set `env.ENABLE_TOOL_SEARCH=auto` in the Claude Code `settings.json` the installer writes. `auto` mirrors Claude Code's own first-party default: defer schemas only when the tool block is large, inline otherwise — so small setups are unaffected. The installer that creates the condition (setting `ANTHROPIC_BASE_URL`) now also restores the mitigation.

Mirrored through the off-toggle park/strip and `uninstall.sh` so the on/off round-trip and uninstall stay symmetric (verified: parks/strips/cleans all three env keys, preserves unrelated env).

## Verification

Reproduced locally with the same Claude Code version + a mock non-first-party endpoint + a fat MCP server (40 tools, ~203 KB of schemas):

| | baseline | `ENABLE_TOOL_SEARCH=auto` |
|---|---|---|
| tool-schema bytes | 291,997 | **40,480 (−86%)** |
| MCP tools inlined | 40/40 | **0/40 (all deferred)** |
| total request body | 348,828 | **106,291 (−69%)** |

Deferred tools are replaced by a `ToolSearch` tool + `advanced-tool-use` beta.

`bash -n` clean on both scripts; jq blocks validated to emit correct JSON.

## Follow-up (not in this PR)

Tool-search resolution is an Anthropic-server feature. On **cross-vendor routes** (Anthropic→OpenAI/Gemini translation) deferred MCP tools may not be retrievable. The vast majority of Claude-Code-through-router traffic is Anthropic-family, so shipping the default now is the right call; a follow-up should confirm/handle the cross-vendor path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)