### PR TITLE
chore(install): bump @workweave/router to 0.2.5

### DIFF
--- a/install/npm/package.json
+++ b/install/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@workweave/router",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "One-command installer that points Claude Code, Codex, opencode, or pi at the Weave Router. For pi it also ships the routing extension, loaded via pi.extensions.",
   "bin": {
     "weave-router": "bin.js"


### PR DESCRIPTION
Bumps the npm package version so the `ENABLE_TOOL_SEARCH=auto` installer default from #671 actually reaches `npx @workweave/router` users.

## Why
#671 merged the installer change (a custom base URL makes Claude Code treat the router as non-first-party and disable MCP tool-search deferral → all tool schemas inlined into every request → autocompact thrash + inflated token usage). But `npx @workweave/router` runs the **published** npm package, which is stamped from a `router-v*` tag — merging to main does not republish.

## What ships this
1. This PR bumps `install/npm/package.json` 0.2.4 → 0.2.5.
2. After merge, push tag `router-v0.2.5` (must be reachable from main; `publish_npm.yml` asserts tag version == package.json version) to trigger the OIDC npm publish.

No code changes — version string only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)