### PR TITLE
Stop pinning HMM route decisions for tool calls, add Price decision for down/upgrade classification clusters

### DIFF
--- a/cmd/router/main.go
+++ b/cmd/router/main.go
@@ -518,6 +518,7 @@ func main() {
 		ColdPinFollowFresh:     config.GetOr("ROUTER_SWITCH_COLD_PIN_FOLLOW_FRESH", boolDefault(proxy.DefaultPlannerColdPinFollowFresh)) == "true",
 	}
 	prefixTrimFreeSwitch := config.GetOr("ROUTER_PREFIX_TRIM_FREE_SWITCH", "true") == "true"
+	hmmUpgradeConfidence := parseEnvFloat("ROUTER_HMM_UPGRADE_CONFIDENCE_THRESHOLD", 0.85)
 	handoverProviderName := config.GetOr("ROUTER_HANDOVER_PROVIDER", providers.ProviderAnthropic)
 	handoverModel := config.GetOr("ROUTER_HANDOVER_MODEL", proxy.DefaultHandoverModel)
 	handoverTimeout := parseEnvDurationMs("ROUTER_HANDOVER_TIMEOUT_MS", proxy.DefaultHandoverTimeout)
@@ -623,6 +624,7 @@ func main() {
 		WithCyberRefusalRepin(cyberRefusalRepin).
 		WithCyberRefusalFallbackModel(cyberRefusalFallbackModel).
 		WithPrefixTrimFreeSwitch(prefixTrimFreeSwitch).
+		WithHMMUpgradeConfidenceThreshold(hmmUpgradeConfidence).
 		WithEscapeNormalize(escapeNormalize).
 		WithEffortEscalation(effortEscalation).
 		WithBandSwap(bandSwapEnabled).

--- a/internal/proxy/gemini.go
+++ b/internal/proxy/gemini.go
@@ -255,7 +255,7 @@ func (s *Service) ProxyGeminiGenerateContent(ctx context.Context, body []byte, w
 		s.emitBilling(ctx, requestID, externalID, decision, actPricing, routeRes, in, out, cacheCreation, cacheRead)
 	}
 
-	log.Info("ProxyGeminiGenerateContent complete", "requested_model", feats.Model, "baseline_model", s.baselineFor(feats.Model), "decision_model", decision.Model, "decision_provider", decision.Provider, "decision_reason", decision.Reason, "embedded_tokens", len(promptText)/4, "total_input_tokens", feats.Tokens, "has_tools", feats.HasTools, "embed_input", embedInput, "sticky_hit", stickyHit, "pin_tier", pinTier, "turn_type", string(tt), "route_ms", routeMs, "proxy_ms", proxyMs, "proxy_err", proxyErr, "upstream_status", upstreamStatus(proxyErr))
+	log.Info("ProxyGeminiGenerateContent complete", append([]any{"requested_model", feats.Model, "baseline_model", s.baselineFor(feats.Model), "decision_model", decision.Model, "decision_provider", decision.Provider, "decision_reason", decision.Reason, "embedded_tokens", len(promptText) / 4, "total_input_tokens", feats.Tokens, "has_tools", feats.HasTools, "embed_input", embedInput, "sticky_hit", stickyHit, "pin_tier", pinTier, "turn_type", string(tt), "route_ms", routeMs, "proxy_ms", proxyMs, "proxy_err", proxyErr, "upstream_status", upstreamStatus(proxyErr)}, plannerLogFields(routeRes)...)...)
 	s.reportHMMOutcome(ctx, routeRes, decision, decision.Provider, feats.Tokens, in, out, cacheCreation, cacheRead, routeMs, proxyMs, proxyErr, nil)
 	return proxyErr
 }

--- a/internal/proxy/gemini.go
+++ b/internal/proxy/gemini.go
@@ -249,7 +249,7 @@ func (s *Service) ProxyGeminiGenerateContent(ctx context.Context, body []byte, w
 
 	// Persist last-turn usage to the pin row so the next turn's planner
 	// has cache-hit evidence. Off the request path; drops on saturation.
-	s.recordTurnUsage(routeRes, decision.Model, in, out, cacheCreation, cacheRead)
+	s.recordTurnUsage(routeRes, decision.Provider, decision.Model, in, out, cacheCreation, cacheRead)
 
 	if proxyErr == nil {
 		s.emitBilling(ctx, requestID, externalID, decision, actPricing, routeRes, in, out, cacheCreation, cacheRead)

--- a/internal/proxy/loop_detection.go
+++ b/internal/proxy/loop_detection.go
@@ -321,8 +321,8 @@ func (s *Service) handleToolCallLoopBreak(
 	installationID uuid.UUID,
 	sessionKey [sessionpin.SessionKeyLen]byte,
 	role string,
-	decisionModel string,
-	decisionProvider string,
+	loopingModel string,
+	loopingProvider string,
 	inputTokens int,
 ) error {
 	log := observability.FromContext(ctx)
@@ -342,8 +342,9 @@ func (s *Service) handleToolCallLoopBreak(
 		"tool_name", sig.Name,
 		"repeat_count", count,
 		"window_size", loopDetectionWindowSize,
-		"decision_model", decisionModel,
-		"decision_provider", decisionProvider,
+		"decision_source", "synthetic_tool_call_loop_break",
+		"looping_model", loopingModel,
+		"looping_provider", loopingProvider,
 		"session_key_prefix", shortSessionKey(sessionKey),
 		"role", role,
 	)

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -2650,7 +2650,7 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 	s.recordCallLog(ctx, upstreamBuilder.Build(), proxyErr != nil, body, respBody, respTrunc)
 	otel.Flush(ctx)
 
-	s.recordTurnUsage(routeRes, decision.Model, in, out, cacheCreation, cacheRead)
+	s.recordTurnUsage(routeRes, finalProvider, decision.Model, in, out, cacheCreation, cacheRead)
 
 	if installationID != uuid.Nil {
 		credentialKeyPrefix, credentialKeySuffix, credSource := s.credentialKeyParts(ctx)
@@ -2886,8 +2886,13 @@ func (s *Service) logPlannerOutcome(ctx context.Context, res turnLoopResult) {
 		)
 		return
 	}
-	log.Info("router stayed on pinned model",
+	message := "router stayed on pinned model"
+	if isHMMDecision(res.Fresh) {
+		message = "router stayed on previous HMM model"
+	}
+	log.Info(message,
 		"model", res.Decision.Model,
+		"pin_model", res.PinModel,
 		"reason", res.PlannerDecision.Reason,
 		"expected_savings_usd", res.PlannerDecision.ExpectedSavingsUSD,
 		"eviction_cost_usd", res.PlannerDecision.EvictionCostUSD,
@@ -2896,12 +2901,12 @@ func (s *Service) logPlannerOutcome(ctx context.Context, res turnLoopResult) {
 	)
 }
 
-func (s *Service) recordTurnUsage(res turnLoopResult, servedModel string, in, out, cacheCreation, cacheRead int) {
+func (s *Service) recordTurnUsage(res turnLoopResult, servedProvider, servedModel string, in, out, cacheCreation, cacheRead int) {
 	if s.pinStore == nil || res.HardPinned {
 		return
 	}
 	if isHMMDecision(res.Decision) {
-		s.recordHMMTurnHistory(res, servedModel)
+		s.recordHMMTurnHistory(res, servedProvider, servedModel)
 		return
 	}
 	var zeroKey [sessionpin.SessionKeyLen]byte
@@ -2928,7 +2933,7 @@ func (s *Service) recordTurnUsage(res turnLoopResult, servedModel string, in, ou
 	}
 }
 
-func (s *Service) recordHMMTurnHistory(res turnLoopResult, servedModel string) {
+func (s *Service) recordHMMTurnHistory(res turnLoopResult, servedProvider, servedModel string) {
 	if servedModel == "" || res.InstallationID == uuid.Nil {
 		return
 	}
@@ -2941,6 +2946,7 @@ func (s *Service) recordHMMTurnHistory(res turnLoopResult, servedModel string) {
 		SessionKey:     res.SessionKey,
 		Role:           role,
 		InstallationID: res.InstallationID,
+		Provider:       servedProvider,
 		Reason:         hmmHistoryReason,
 		TurnCount:      1,
 		PinnedUntil:    pinExpiry(hmmHistoryReason),
@@ -4250,7 +4256,7 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 		emitCallLog()
 	}
 
-	s.recordTurnUsage(routeRes, decision.Model, in, out, cacheCreation, cacheRead)
+	s.recordTurnUsage(routeRes, finalProvider, decision.Model, in, out, cacheCreation, cacheRead)
 
 	if proxyErr == nil {
 		s.emitBilling(ctx, requestID, externalID, decision, actPricing, routeRes, in, out, cacheCreation, cacheRead)

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -2905,8 +2905,8 @@ func (s *Service) recordTurnUsage(res turnLoopResult, servedProvider, servedMode
 	if s.pinStore == nil || res.HardPinned {
 		return
 	}
-	if isHMMDecision(res.Decision) {
-		s.recordHMMTurnHistory(res, servedProvider, servedModel)
+	if isHMMTurn(res) {
+		s.recordHMMTurnHistory(res, servedProvider, servedModel, in, out, cacheCreation, cacheRead)
 		return
 	}
 	var zeroKey [sessionpin.SessionKeyLen]byte
@@ -2933,7 +2933,11 @@ func (s *Service) recordTurnUsage(res turnLoopResult, servedProvider, servedMode
 	}
 }
 
-func (s *Service) recordHMMTurnHistory(res turnLoopResult, servedProvider, servedModel string) {
+func isHMMTurn(res turnLoopResult) bool {
+	return isHMMDecision(res.Decision) || isHMMDecision(res.Fresh)
+}
+
+func (s *Service) recordHMMTurnHistory(res turnLoopResult, servedProvider, servedModel string, in, out, cacheCreation, cacheRead int) {
 	if servedModel == "" || res.InstallationID == uuid.Nil {
 		return
 	}
@@ -2962,8 +2966,12 @@ func (s *Service) recordHMMTurnHistory(res turnLoopResult, servedProvider, serve
 		}
 	}
 	if err := s.pinStore.UpdateUsage(context.Background(), res.SessionKey, role, sessionpin.Usage{
-		EndedAt:     now,
-		ServedModel: servedModel,
+		InputTokens:       in,
+		CachedReadTokens:  cacheRead,
+		CachedWriteTokens: cacheCreation,
+		OutputTokens:      out,
+		EndedAt:           now,
+		ServedModel:       servedModel,
 	}); err != nil {
 		observability.Get().Error("HMM switch-history writeback failed", "err", err)
 	}

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -1970,17 +1970,16 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 		// discounts Anthropic correctly on reroute.
 		req.SubsidizedModelCostFactor = s.subsidyFactors(ctx, r.Header)
 
-		// Bypass returns early without loading the pin, so load it now for
+		// Bypass returns early without loading pin history, so load it now for
 		// modelSwitched() to correctly detect a switch away from it.
 		var priorServedModel string
 		var sessionEverSwitched bool
 		if s.pinStore != nil {
 			sessionKey := DeriveSessionKey(env, apiKeyID)
-			pin, pinFound := s.loadPin(ctx, sessionKey, roleForTier(catalog.TierFor(feats.Model)))
-			if pinFound {
-				priorServedModel = pin.LastServedModel
-				sessionEverSwitched = pin.HasEverSwitched
-			}
+			role := roleForTier(catalog.TierFor(feats.Model))
+			pin, _ := s.loadPin(ctx, sessionKey, role)
+			hmmHistory := s.loadHMMHistory(ctx, sessionKey, role)
+			priorServedModel, sessionEverSwitched = switchHistoryFromPins(pin, hmmHistory)
 		}
 
 		log.Info("usage-bypass pre-commit failure, rerouting via scorer",
@@ -2902,6 +2901,7 @@ func (s *Service) recordTurnUsage(res turnLoopResult, servedModel string, in, ou
 		return
 	}
 	if isHMMDecision(res.Decision) {
+		s.recordHMMTurnHistory(res, servedModel)
 		return
 	}
 	var zeroKey [sessionpin.SessionKeyLen]byte
@@ -2925,6 +2925,41 @@ func (s *Service) recordTurnUsage(res turnLoopResult, servedModel string, in, ou
 	}
 	if err := s.pinStore.UpdateUsage(context.Background(), res.SessionKey, role, usage); err != nil {
 		observability.Get().Error("session pin usage writeback failed", "err", err)
+	}
+}
+
+func (s *Service) recordHMMTurnHistory(res turnLoopResult, servedModel string) {
+	if servedModel == "" || res.InstallationID == uuid.Nil {
+		return
+	}
+	var zeroKey [sessionpin.SessionKeyLen]byte
+	if res.SessionKey == zeroKey {
+		return
+	}
+	role := hmmHistoryRole(res.PinRole)
+	s.upsertPin(context.Background(), sessionpin.Pin{
+		SessionKey:     res.SessionKey,
+		Role:           role,
+		InstallationID: res.InstallationID,
+		Reason:         hmmHistoryReason,
+		TurnCount:      1,
+		PinnedUntil:    pinExpiry(hmmHistoryReason),
+	})
+	now := time.Now()
+	if res.PriorServedModel != "" && res.PriorServedModel != servedModel {
+		if err := s.pinStore.UpdateUsage(context.Background(), res.SessionKey, role, sessionpin.Usage{
+			EndedAt:     now,
+			ServedModel: res.PriorServedModel,
+		}); err != nil {
+			observability.Get().Error("HMM switch-history prior writeback failed", "err", err)
+			return
+		}
+	}
+	if err := s.pinStore.UpdateUsage(context.Background(), res.SessionKey, role, sessionpin.Usage{
+		EndedAt:     now,
+		ServedModel: servedModel,
+	}); err != nil {
+		observability.Get().Error("HMM switch-history writeback failed", "err", err)
 	}
 }
 

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -2802,7 +2802,7 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 		)
 	}
 
-	log.Info("ProxyMessages complete", "requested_model", feats.Model, "baseline_model", s.baselineFor(feats.Model), "decision_model", decision.Model, "decision_provider", decision.Provider, "primary_provider", primaryProvider, "fallback_attempts", winnerIdx, "failover_used", finalProvider != primaryProvider || subscriptionFailoverUsed, "subscription_failover", subscriptionFailoverUsed, "decision_reason", decision.Reason, "requested_tier", routeRes.RequestedTier.String(), "decision_tier", catalog.TierFor(decision.Model).String(), "embedded_tokens", len(promptText)/4, "total_input_tokens", feats.Tokens, "has_tools", feats.HasTools, "message_count", feats.MessageCount, "last_kind", feats.LastKind, "last_preview", feats.LastPreview, "embed_input", embedInput, "cross_format", crossFormat, "sticky_hit", stickyHit, "route_ms", routeMs, "proxy_ms", proxyMs, "proxy_err", proxyErr, "upstream_status", upstreamStatus(proxyErr), "upstream_finish_reason", respSummary.UpstreamFinishReason, "resp_stop_reason", respSummary.StopReason, "stop_reason_promoted", respSummary.StopReasonPromoted, "tool_use_blocks", respSummary.ToolUseBlocks, "invalid_tool_args_blocks", respSummary.InvalidToolArgsBlocks, "text_only_turn_nudged", respSummary.TextOnlyTurnNudged, "stop_reason_demoted", respSummary.StopReasonDemoted, "suppressed_tool_calls", respSummary.SuppressedToolCalls, "tool_call_invalid_blocks", len(respSummary.ToolCallIssues), "cc_only_tools_stripped", reqStats.CCOnlyToolsStripped, "gemini_reminder_injected", reqStats.GeminiReminderInjected, "gemini_validated_tool_mode", reqStats.GeminiValidatedToolMode, "resp_output_tokens", respSummary.OutputTokens, "prelude_committed", preludeBuf.Committed())
+	log.Info("ProxyMessages complete", append([]any{"requested_model", feats.Model, "baseline_model", s.baselineFor(feats.Model), "decision_model", decision.Model, "decision_provider", decision.Provider, "primary_provider", primaryProvider, "fallback_attempts", winnerIdx, "failover_used", finalProvider != primaryProvider || subscriptionFailoverUsed, "subscription_failover", subscriptionFailoverUsed, "decision_reason", decision.Reason, "requested_tier", routeRes.RequestedTier.String(), "decision_tier", catalog.TierFor(decision.Model).String(), "embedded_tokens", len(promptText) / 4, "total_input_tokens", feats.Tokens, "has_tools", feats.HasTools, "message_count", feats.MessageCount, "last_kind", feats.LastKind, "last_preview", feats.LastPreview, "embed_input", embedInput, "cross_format", crossFormat, "sticky_hit", stickyHit, "route_ms", routeMs, "proxy_ms", proxyMs, "proxy_err", proxyErr, "upstream_status", upstreamStatus(proxyErr), "upstream_finish_reason", respSummary.UpstreamFinishReason, "resp_stop_reason", respSummary.StopReason, "stop_reason_promoted", respSummary.StopReasonPromoted, "tool_use_blocks", respSummary.ToolUseBlocks, "invalid_tool_args_blocks", respSummary.InvalidToolArgsBlocks, "text_only_turn_nudged", respSummary.TextOnlyTurnNudged, "stop_reason_demoted", respSummary.StopReasonDemoted, "suppressed_tool_calls", respSummary.SuppressedToolCalls, "tool_call_invalid_blocks", len(respSummary.ToolCallIssues), "cc_only_tools_stripped", reqStats.CCOnlyToolsStripped, "gemini_reminder_injected", reqStats.GeminiReminderInjected, "gemini_validated_tool_mode", reqStats.GeminiValidatedToolMode, "resp_output_tokens", respSummary.OutputTokens, "prelude_committed", preludeBuf.Committed()}, plannerLogFields(routeRes)...)...)
 	hmmRespBody, hmmRespTrunc := capturedResponse(hmmOutcomeCap)
 	var hmmResp *hmmOutcomeResponse
 	if hmmOutcomeCap != nil {
@@ -2847,6 +2847,24 @@ func plannerOutcomeAttr(res turnLoopResult) string {
 	}
 }
 
+func plannerLogFields(res turnLoopResult) []any {
+	var pinCacheWarm any
+	if res.PlannerDecision.Reason != "" {
+		pinCacheWarm = !res.PlannerDecision.PinCacheCold
+	}
+	return []any{
+		"planner_outcome", plannerOutcomeAttr(res),
+		"planner_reason", res.PlannerDecision.Reason,
+		"planner_expected_savings_usd", res.PlannerDecision.ExpectedSavingsUSD,
+		"planner_eviction_cost_usd", res.PlannerDecision.EvictionCostUSD,
+		"planner_threshold_usd", res.PlannerDecision.ThresholdUSD,
+		"planner_pin_model", res.PinModel,
+		"planner_fresh_model", res.Fresh.Model,
+		"planner_chosen_model", res.Decision.Model,
+		"planner_pin_cache_warm", pinCacheWarm,
+	}
+}
+
 // logPlannerOutcome emits a structured log line for the planner's verdict.
 // Switch turns are Info; stay turns are Debug.
 func (s *Service) logPlannerOutcome(ctx context.Context, res turnLoopResult) {
@@ -2881,6 +2899,9 @@ func (s *Service) logPlannerOutcome(ctx context.Context, res turnLoopResult) {
 
 func (s *Service) recordTurnUsage(res turnLoopResult, servedModel string, in, out, cacheCreation, cacheRead int) {
 	if s.pinStore == nil || res.HardPinned {
+		return
+	}
+	if isHMMDecision(res.Decision) {
 		return
 	}
 	var zeroKey [sessionpin.SessionKeyLen]byte
@@ -4269,7 +4290,7 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 		})
 	}
 
-	log.Info("ProxyOpenAIChatCompletion complete", "requested_model", feats.Model, "baseline_model", s.baselineFor(feats.Model), "decision_model", decision.Model, "decision_provider", decision.Provider, "primary_provider", primaryProvider, "fallback_attempts", winnerIdx, "failover_used", finalProvider != primaryProvider, "decision_reason", decision.Reason, "requested_tier", routeRes.RequestedTier.String(), "decision_tier", catalog.TierFor(decision.Model).String(), "embedded_tokens", len(promptText)/4, "total_input_tokens", feats.Tokens, "has_tools", feats.HasTools, "embed_input", embedInput, "cross_format", crossFormat, "sticky_hit", stickyHit, "pin_tier", pinTier, "turn_type", string(tt), "route_ms", routeMs, "proxy_ms", proxyMs, "proxy_err", proxyErr, "upstream_status", upstreamStatus(proxyErr))
+	log.Info("ProxyOpenAIChatCompletion complete", append([]any{"requested_model", feats.Model, "baseline_model", s.baselineFor(feats.Model), "decision_model", decision.Model, "decision_provider", decision.Provider, "primary_provider", primaryProvider, "fallback_attempts", winnerIdx, "failover_used", finalProvider != primaryProvider, "decision_reason", decision.Reason, "requested_tier", routeRes.RequestedTier.String(), "decision_tier", catalog.TierFor(decision.Model).String(), "embedded_tokens", len(promptText) / 4, "total_input_tokens", feats.Tokens, "has_tools", feats.HasTools, "embed_input", embedInput, "cross_format", crossFormat, "sticky_hit", stickyHit, "pin_tier", pinTier, "turn_type", string(tt), "route_ms", routeMs, "proxy_ms", proxyMs, "proxy_err", proxyErr, "upstream_status", upstreamStatus(proxyErr)}, plannerLogFields(routeRes)...)...)
 	s.reportHMMOutcome(ctx, routeRes, decision, finalProvider, feats.Tokens, in, out, cacheCreation, cacheRead, routeMs, proxyMs, proxyErr, nil)
 	return proxyErr
 }

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -2973,11 +2973,8 @@ func (s *Service) recordHMMTurnHistory(res turnLoopResult, servedProvider, serve
 		TurnCount:      1,
 		PinnedUntil:    pinExpiry(hmmHistoryReason),
 	})
-	// Mirror recordTurnUsage's zero-usage guard for the UpdateUsage writebacks:
-	// a failed/empty upstream turn carries no tokens, and writing it would
-	// overwrite the history row's prior token counts and last_turn_ended_at —
-	// making the next turn's EV-stay and cache-warm checks read a warm session
-	// as cold or usage-less. The TTL-refreshing upsert above still ran.
+	// Zero tokens means a failed/empty upstream turn — don't clobber prior
+	// usage counters; the TTL-refreshing upsert above already ran.
 	if in == 0 && out == 0 && cacheCreation == 0 && cacheRead == 0 {
 		return
 	}

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -146,6 +146,14 @@ type Service struct {
 	// when the session pin carries no runner-up (PairedModel). Set from
 	// ROUTER_CYBER_REFUSAL_FALLBACK_MODEL; defaults to claude-sonnet-5.
 	cyberRefusalFallbackModel string
+	// hmmUpgradeConfidenceThreshold is the minimum fresh-decision ChosenScore on
+	// the HMM strategy that overrides an EV stay for a *more expensive* fresh
+	// model. Below it the stay-pin holds even if the sidecar prefers an
+	// upgrade — protects against the sidecar occasionally returning a low-
+	// confidence "upgrade" suggestion that would otherwise thrash the prompt
+	// cache. Set via ROUTER_HMM_UPGRADE_CONFIDENCE_THRESHOLD. Out-of-range
+	// values are rejected by the setter and the default sticks.
+	hmmUpgradeConfidenceThreshold float64
 	// effortEscalation enables the escalate-on-failure reasoning-effort policy:
 	// gpt-5.x serves low effort by default and high after an observed
 	// failed/no-progress turn; gemini is pinned low. Off by default (set from
@@ -896,11 +904,12 @@ func NewService(r router.Router, providerMap map[string]providers.Client, emitte
 			ExpectedRemainingTurns: DefaultPlannerExpectedRemainingTurns,
 			TierUpgradeEnabled:     DefaultPlannerTierUpgradeEnabled,
 		},
-		plannerEnabled:            true,
-		scoreToolResultTurns:      true,
-		loopEscalationEnabled:     true,
-		cyberRefusalRepin:         false,
-		cyberRefusalFallbackModel: "claude-sonnet-5",
+		plannerEnabled:                true,
+		scoreToolResultTurns:          true,
+		loopEscalationEnabled:         true,
+		cyberRefusalRepin:             false,
+		cyberRefusalFallbackModel:     "claude-sonnet-5",
+		hmmUpgradeConfidenceThreshold: defaultHMMUpgradeConfidenceThreshold,
 	}
 }
 
@@ -943,6 +952,22 @@ func (s *Service) WithCyberRefusalFallbackModel(model string) *Service {
 	if strings.TrimSpace(model) != "" {
 		s.cyberRefusalFallbackModel = strings.TrimSpace(model)
 	}
+	return s
+}
+
+// WithHMMUpgradeConfidenceThreshold sets the minimum ChosenScore from the HMM
+// sidecar that lets a fresh "upgrade to a more expensive model" decision beat
+// the planner's EV stay on the cheaper pinned model. Below this threshold an
+// EV stay holds even if the sidecar prefers an upgrade — protects against
+// occasional low-confidence "upgrade" suggestions that would thrash the prompt
+// cache for no real benefit. Out-of-range values (not in [0,1]) are rejected
+// and the existing threshold stays. Wired from
+// ROUTER_HMM_UPGRADE_CONFIDENCE_THRESHOLD.
+func (s *Service) WithHMMUpgradeConfidenceThreshold(v float64) *Service {
+	if v < 0 || v > 1 {
+		return s
+	}
+	s.hmmUpgradeConfidenceThreshold = v
 	return s
 }
 

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -146,13 +146,9 @@ type Service struct {
 	// when the session pin carries no runner-up (PairedModel). Set from
 	// ROUTER_CYBER_REFUSAL_FALLBACK_MODEL; defaults to claude-sonnet-5.
 	cyberRefusalFallbackModel string
-	// hmmUpgradeConfidenceThreshold is the minimum fresh-decision ChosenScore on
-	// the HMM strategy that overrides an EV stay for a *more expensive* fresh
-	// model. Below it the stay-pin holds even if the sidecar prefers an
-	// upgrade — protects against the sidecar occasionally returning a low-
-	// confidence "upgrade" suggestion that would otherwise thrash the prompt
-	// cache. Set via ROUTER_HMM_UPGRADE_CONFIDENCE_THRESHOLD. Out-of-range
-	// values are rejected by the setter and the default sticks.
+	// hmmUpgradeConfidenceThreshold is the minimum HMM sidecar ChosenScore that
+	// lets a fresh upgrade to a more expensive model beat an EV stay. Protects
+	// against low-confidence thrash. Set via ROUTER_HMM_UPGRADE_CONFIDENCE_THRESHOLD.
 	hmmUpgradeConfidenceThreshold float64
 	// effortEscalation enables the escalate-on-failure reasoning-effort policy:
 	// gpt-5.x serves low effort by default and high after an observed
@@ -955,14 +951,9 @@ func (s *Service) WithCyberRefusalFallbackModel(model string) *Service {
 	return s
 }
 
-// WithHMMUpgradeConfidenceThreshold sets the minimum ChosenScore from the HMM
-// sidecar that lets a fresh "upgrade to a more expensive model" decision beat
-// the planner's EV stay on the cheaper pinned model. Below this threshold an
-// EV stay holds even if the sidecar prefers an upgrade — protects against
-// occasional low-confidence "upgrade" suggestions that would thrash the prompt
-// cache for no real benefit. Out-of-range values (not in [0,1]) are rejected
-// and the existing threshold stays. Wired from
-// ROUTER_HMM_UPGRADE_CONFIDENCE_THRESHOLD.
+// WithHMMUpgradeConfidenceThreshold sets the minimum HMM sidecar ChosenScore
+// for a fresh upgrade to beat an EV stay on the cheaper pinned model. Out-of-range
+// values ([0,1] only) are rejected silently. Wired from ROUTER_HMM_UPGRADE_CONFIDENCE_THRESHOLD.
 func (s *Service) WithHMMUpgradeConfidenceThreshold(v float64) *Service {
 	if v < 0 || v > 1 {
 		return s
@@ -2971,6 +2962,8 @@ func (s *Service) recordHMMTurnHistory(res turnLoopResult, servedProvider, serve
 		return
 	}
 	role := hmmHistoryRole(res.PinRole)
+	// The upsert only refreshes the row's TTL/turn_count/provider (ON CONFLICT
+	// leaves the usage columns untouched), so it is always safe to run.
 	s.upsertPin(context.Background(), sessionpin.Pin{
 		SessionKey:     res.SessionKey,
 		Role:           role,
@@ -2980,6 +2973,14 @@ func (s *Service) recordHMMTurnHistory(res turnLoopResult, servedProvider, serve
 		TurnCount:      1,
 		PinnedUntil:    pinExpiry(hmmHistoryReason),
 	})
+	// Mirror recordTurnUsage's zero-usage guard for the UpdateUsage writebacks:
+	// a failed/empty upstream turn carries no tokens, and writing it would
+	// overwrite the history row's prior token counts and last_turn_ended_at —
+	// making the next turn's EV-stay and cache-warm checks read a warm session
+	// as cold or usage-less. The TTL-refreshing upsert above still ran.
+	if in == 0 && out == 0 && cacheCreation == 0 && cacheRead == 0 {
+		return
+	}
 	now := time.Now()
 	if res.PriorServedModel != "" && res.PriorServedModel != servedModel {
 		if err := s.pinStore.UpdateUsage(context.Background(), res.SessionKey, role, sessionpin.Usage{

--- a/internal/proxy/service_session_pin_test.go
+++ b/internal/proxy/service_session_pin_test.go
@@ -30,6 +30,8 @@ type fakePinStore struct {
 	mu               sync.Mutex
 	pin              sessionpin.Pin
 	hasPin           bool
+	hmmHistory       sessionpin.Pin
+	hasHMMHistory    bool
 	getErr           error
 	getCalls         int
 	upserts          []sessionpin.Pin
@@ -56,7 +58,13 @@ func (f *fakePinStore) Get(ctx context.Context, key [sessionpin.SessionKeyLen]by
 		return sessionpin.Pin{}, false, f.getErr
 	}
 	if strings.HasSuffix(role, "_hmm_history") {
-		return sessionpin.Pin{}, false, nil
+		if !f.hasHMMHistory {
+			return sessionpin.Pin{}, false, nil
+		}
+		pin := f.hmmHistory
+		pin.SessionKey = key
+		pin.Role = role
+		return pin, true, nil
 	}
 	if !f.hasPin {
 		return sessionpin.Pin{}, false, nil

--- a/internal/proxy/service_session_pin_test.go
+++ b/internal/proxy/service_session_pin_test.go
@@ -123,7 +123,7 @@ func assertOnlyHMMHistoryUpserts(t *testing.T, store *fakePinStore) {
 	for _, p := range store.upserts {
 		assert.True(t, strings.HasSuffix(p.Role, "_hmm_history"), "HMM must not write the active routing pin role")
 		assert.Equal(t, "hmm_history", p.Reason)
-		assert.Empty(t, p.Provider, "HMM history rows must not be routable")
+		assert.NotEmpty(t, p.Provider, "HMM history rows retain provider for cache TTL math")
 		assert.Empty(t, p.Model, "HMM history rows must not be routable")
 	}
 }

--- a/internal/proxy/service_session_pin_test.go
+++ b/internal/proxy/service_session_pin_test.go
@@ -55,6 +55,9 @@ func (f *fakePinStore) Get(ctx context.Context, key [sessionpin.SessionKeyLen]by
 	if f.getErr != nil {
 		return sessionpin.Pin{}, false, f.getErr
 	}
+	if strings.HasSuffix(role, "_hmm_history") {
+		return sessionpin.Pin{}, false, nil
+	}
 	if !f.hasPin {
 		return sessionpin.Pin{}, false, nil
 	}
@@ -111,6 +114,17 @@ func waitForUpsert(t *testing.T, store *fakePinStore) {
 	case <-store.upsertCh:
 	case <-time.After(2 * time.Second):
 		t.Fatal("expected an async pin upsert within 2s; none observed")
+	}
+}
+
+func assertOnlyHMMHistoryUpserts(t *testing.T, store *fakePinStore) {
+	t.Helper()
+	require.NotEmpty(t, store.upserts, "HMM turns should persist switch history")
+	for _, p := range store.upserts {
+		assert.True(t, strings.HasSuffix(p.Role, "_hmm_history"), "HMM must not write the active routing pin role")
+		assert.Equal(t, "hmm_history", p.Reason)
+		assert.Empty(t, p.Provider, "HMM history rows must not be routable")
+		assert.Empty(t, p.Model, "HMM history rows must not be routable")
 	}
 }
 
@@ -229,13 +243,13 @@ func TestService_SessionPin_EveryTurnReadsPostgres(t *testing.T) {
 	httpReq1 := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(""))
 	require.NoError(t, svc.ProxyMessages(ctx, []byte(pinTestBody), rec1, httpReq1))
 	require.Equal(t, 1, fr.routeCalls)
-	require.Equal(t, 1, store.getCalls, "first turn must read the pin store")
+	require.Equal(t, 2, store.getCalls, "first turn must read the active pin and HMM history roles")
 
 	rec2 := httptest.NewRecorder()
 	httpReq2 := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(""))
 	require.NoError(t, svc.ProxyMessages(ctx, []byte(pinTestBody), rec2, httpReq2))
 	assert.Equal(t, 2, fr.routeCalls, "planner re-evaluates every MainLoop turn")
-	assert.Equal(t, 2, store.getCalls, "second turn must also read Postgres — there is no in-process cache")
+	assert.Equal(t, 4, store.getCalls, "second turn must also read Postgres — there is no in-process cache")
 }
 
 func TestService_SessionPin_StoreErrorFallsThroughToFreshRoute(t *testing.T) {
@@ -288,7 +302,7 @@ func TestService_SessionPin_EvalOverrideHeaderKeepsSessionKeyPinning(t *testing.
 
 	// Scorer still runs, but the pin wins under ReasonNoPriorUsage.
 	assert.Equal(t, 1, fr.routeCalls, "scorer runs every MainLoop turn under the planner")
-	assert.Equal(t, 1, store.getCalls)
+	assert.Equal(t, 2, store.getCalls)
 	assert.Equal(t, "claude-haiku-4-5", rec.Header().Get(proxy.HeaderRouterModel))
 }
 
@@ -533,7 +547,7 @@ func TestService_HMMSubAgentUsesFreshDecision(t *testing.T) {
 	assert.Equal(t, "claude-opus-4-7", rec.Header().Get(proxy.HeaderRouterModel),
 		"an HMM Explore subagent must follow the fresh sidecar decision instead of an existing execution pin")
 	store.mu.Lock()
-	assert.Empty(t, store.upserts, "fresh HMM decisions must not write session pins")
+	assertOnlyHMMHistoryUpserts(t, store)
 	store.mu.Unlock()
 }
 

--- a/internal/proxy/service_session_pin_test.go
+++ b/internal/proxy/service_session_pin_test.go
@@ -507,7 +507,7 @@ func TestService_HardPin_HMMExploreBypassesBootHardPin(t *testing.T) {
 	assert.Equal(t, "claude-opus-4-7", rec.Header().Get(proxy.HeaderRouterModel))
 }
 
-func TestService_HMMSubAgentKeepsExecutionPin(t *testing.T) {
+func TestService_HMMSubAgentUsesFreshDecision(t *testing.T) {
 	store := newFakePinStore()
 	store.hasPin = true
 	store.pin = sessionpin.Pin{
@@ -530,8 +530,11 @@ func TestService_HMMSubAgentKeepsExecutionPin(t *testing.T) {
 	require.NoError(t, svc.ProxyMessages(ctx, []byte(exploreBody), rec, httpReq))
 
 	assert.Equal(t, 1, fr.routeCalls, "subagent HMM turns may still score for diagnostics")
-	assert.Equal(t, "claude-haiku-4-5", rec.Header().Get(proxy.HeaderRouterModel),
-		"an HMM Explore subagent must keep its selected execution model for the subagent session")
+	assert.Equal(t, "claude-opus-4-7", rec.Header().Get(proxy.HeaderRouterModel),
+		"an HMM Explore subagent must follow the fresh sidecar decision instead of an existing execution pin")
+	store.mu.Lock()
+	assert.Empty(t, store.upserts, "fresh HMM decisions must not write session pins")
+	store.mu.Unlock()
 }
 
 func TestService_HardPin_ExploreFallsThroughWhenFlagOff(t *testing.T) {

--- a/internal/proxy/turnloop.go
+++ b/internal/proxy/turnloop.go
@@ -377,10 +377,8 @@ func (s *Service) runTurnLoop(
 		pin = sessionpin.Pin{}
 	}
 	if maxedModel := maxedOutServedModel(hmmHistory); maxedModel != "" {
-		// No expiry gate: a model that saturated its output cap must be excluded
-		// even after the history row's TTL lapses, matching the active-pin maxed
-		// path above — otherwise the degenerate auto-continue loop can re-select
-		// it on the very next turn.
+		// No expiry gate: match the active-pin maxed path so the degenerate
+		// auto-continue loop cannot re-select a saturated model after TTL lapses.
 		log.Info("HMM history maxed out on previous turn; excluding for this turn",
 			"history_provider", hmmHistory.Provider,
 			"maxed_model", maxedModel,
@@ -792,10 +790,8 @@ func (s *Service) hmmStayPin(req router.Request, activePin sessionpin.Pin, hmmHi
 		best sessionpin.Pin
 		ok   bool
 	)
-	// The active routing pin is only an HMM stay candidate when it was itself
-	// written by an HMM turn. A cluster/planner pin from a prior non-HMM stretch
-	// (e.g. the session's strategy header changed mid-flight) must not win an
-	// HMM turn's EV stay — the _hmm_history row is the authoritative source.
+	// Only HMM-written pins are stay candidates; a cluster/planner pin from a
+	// prior non-HMM stretch must not steer an HMM EV stay.
 	if !isHMMPinReason(activePin.Reason) {
 		activePin = sessionpin.Pin{}
 	}

--- a/internal/proxy/turnloop.go
+++ b/internal/proxy/turnloop.go
@@ -118,28 +118,6 @@ func isHMMDecision(dec router.Decision) bool {
 	return strings.HasPrefix(strings.TrimSpace(dec.Reason), "hmm_policy")
 }
 
-func isHMMToolExecutionReason(reason string) bool {
-	return strings.HasPrefix(strings.TrimSpace(reason), "hmm_policy:tool_execution")
-}
-
-func shouldServeFreshHMMToolResult(turnType turntype.TurnType, subAgentHint string, pin sessionpin.Pin, fresh router.Decision) bool {
-	if subAgentHint != "" || turnType != turntype.ToolResult {
-		return false
-	}
-	return isHMMToolExecutionReason(pin.Reason) && isHMMDecision(fresh) && !isHMMToolExecutionReason(fresh.Reason)
-}
-
-func shouldServeFreshHMMToolExecution(pin sessionpin.Pin, fresh router.Decision) bool {
-	return isHMMDecision(fresh) && isHMMToolExecutionReason(fresh.Reason) && !isHMMToolExecutionReason(pin.Reason)
-}
-
-func isHMMSubAgentExecutionLock(turnType turntype.TurnType, subAgentHint string, pin sessionpin.Pin, fresh router.Decision) bool {
-	if !isHMMDecision(fresh) || !isHMMToolExecutionReason(pin.Reason) {
-		return false
-	}
-	return turnType == turntype.SubAgentDispatch || subAgentHint != ""
-}
-
 // handoverOutcome describes the synchronous handover step.
 type handoverOutcome struct {
 	Invoked       bool
@@ -542,37 +520,11 @@ func (s *Service) runTurnLoop(
 		"fresh_reason", fresh.Reason,
 	)
 	res.Fresh = fresh
-	hmmToolExecutionFresh := pinFound && shouldServeFreshHMMToolExecution(pin, fresh)
-	hmmToolResultFresh := pinFound && shouldServeFreshHMMToolResult(res.TurnType, subAgentHint, pin, fresh)
-	hmmToolExecutionContinue := pinFound && isHMMToolExecutionReason(pin.Reason) && isHMMToolExecutionReason(fresh.Reason)
-	if hmmToolExecutionContinue || (pinFound && isHMMSubAgentExecutionLock(res.TurnType, subAgentHint, pin, fresh)) {
-		decision := pinDecision(pin)
-		res.Decision = decision
-		res.StickyHit = true
-		if hmmToolExecutionContinue {
-			res.PinTier = "hmm_tool_execution_lock"
-		} else {
-			res.PinTier = "hmm_subagent_execution_lock"
-		}
-		s.refreshPin(ctx, installationID, res.SessionKey, pin, res.PinRole, decision)
-		return res, nil
-	}
-	if (hmmToolExecutionFresh || hmmToolResultFresh) && fresh.Provider == pin.Provider && fresh.Model == pin.Model {
-		res.Decision = fresh
-		if hmmToolExecutionFresh {
-			res.PinTier = "hmm_tool_execution_fresh_same_model"
-		} else {
-			res.PinTier = "hmm_tool_result_fresh_same_model"
-		}
-		s.writeNewPin(ctx, installationID, res.SessionKey, res.PinRole, fresh)
-		return res, nil
-	}
 	if isHMMDecision(fresh) {
 		res.Decision = fresh
 		if pinFound {
-			res.PinTier = "hmm_fresh"
+			res.PinTier = "hmm_fresh_unpinned"
 		}
-		s.writeNewPin(ctx, installationID, res.SessionKey, res.PinRole, fresh)
 		return res, nil
 	}
 
@@ -648,11 +600,6 @@ func (s *Service) runTurnLoop(
 		plannerIn.Pin = sessionpin.Pin{}
 	}
 	decision := planner.Decide(plannerIn, s.planner)
-	if hmmToolExecutionFresh && decision.Outcome == planner.OutcomeStay {
-		decision = planner.Decision{Outcome: planner.OutcomeSwitch, Reason: "tool_execution_fresh"}
-	} else if hmmToolResultFresh && decision.Outcome == planner.OutcomeStay {
-		decision = planner.Decision{Outcome: planner.OutcomeSwitch, Reason: "tool_result_fresh"}
-	}
 	res.PlannerDecision = decision
 
 	if decision.Outcome == planner.OutcomeStay && pinFound {

--- a/internal/proxy/turnloop.go
+++ b/internal/proxy/turnloop.go
@@ -359,10 +359,7 @@ func (s *Service) runTurnLoop(
 		// model can be the paired member, so pin.Model could name the wrong
 		// (healthy) model and leave the broken one eligible. Fall back to
 		// pin.Model for older rows written before LastServedModel existed.
-		maxedModel := pin.LastServedModel
-		if maxedModel == "" {
-			maxedModel = pin.Model
-		}
+		maxedModel := maxedOutServedModel(pin)
 		log.Info("Session pin maxed out on previous turn; excluding for this turn",
 			"pin_model", pin.Model,
 			"pin_provider", pin.Provider,
@@ -378,6 +375,20 @@ func (s *Service) runTurnLoop(
 		req.ExcludedModels = excluded
 		pinFound = false
 		pin = sessionpin.Pin{}
+	}
+	if maxedModel := maxedOutServedModel(hmmHistory); maxedModel != "" &&
+		(hmmHistory.PinnedUntil.IsZero() || hmmHistory.PinnedUntil.After(time.Now())) {
+		log.Info("HMM history maxed out on previous turn; excluding for this turn",
+			"history_provider", hmmHistory.Provider,
+			"maxed_model", maxedModel,
+			"last_output_tokens", hmmHistory.LastOutputTokens,
+		)
+		excluded := make(map[string]struct{}, len(req.ExcludedModels)+1)
+		for k := range req.ExcludedModels {
+			excluded[k] = struct{}{}
+		}
+		excluded[maxedModel] = struct{}{}
+		req.ExcludedModels = excluded
 	}
 
 	// If the pre-filter excluded the pinned model for context overflow,
@@ -538,9 +549,13 @@ func (s *Service) runTurnLoop(
 	)
 	res.Fresh = fresh
 	if isHMMDecision(fresh) {
+		activePin := sessionpin.Pin{}
+		if pinFound {
+			activePin = pin
+		}
 		hmmDecision, hmmPlannerDecision, hmmSticky, hmmStayModel := s.hmmCostGatedDecision(
 			req,
-			pin,
+			activePin,
 			hmmHistory,
 			fresh,
 			feats.Tokens,
@@ -797,6 +812,12 @@ func (s *Service) normalizeHMMStayPin(req router.Request, p sessionpin.Pin) (ses
 	if p.LastTurnEndedAt.IsZero() {
 		return sessionpin.Pin{}, false
 	}
+	if !p.PinnedUntil.IsZero() && !p.PinnedUntil.After(time.Now()) {
+		return sessionpin.Pin{}, false
+	}
+	if p.LastOutputTokens >= prevTurnMaxedOutThreshold {
+		return sessionpin.Pin{}, false
+	}
 	if req.ExcludedModels != nil {
 		if _, excluded := req.ExcludedModels[model]; excluded {
 			return sessionpin.Pin{}, false
@@ -862,6 +883,17 @@ func hmmEffectiveInputUSDPer1M(model string, factors map[string]float64) (float6
 		value *= factor
 	}
 	return value, true
+}
+
+func maxedOutServedModel(pin sessionpin.Pin) string {
+	if pin.LastOutputTokens < prevTurnMaxedOutThreshold {
+		return ""
+	}
+	model := pin.LastServedModel
+	if model == "" {
+		model = pin.Model
+	}
+	return model
 }
 
 // roleForTier maps a requested-model tier to its session-pin role. Each tier

--- a/internal/proxy/turnloop.go
+++ b/internal/proxy/turnloop.go
@@ -120,7 +120,7 @@ func isHMMDecision(dec router.Decision) bool {
 }
 
 const hmmHistoryReason = "hmm_history"
-const hmmUpgradeConfidenceThreshold = 0.85
+const defaultHMMUpgradeConfidenceThreshold = 0.85
 
 const (
 	hmmReasonConfidentUpgrade     = "hmm_confident_upgrade"
@@ -768,7 +768,11 @@ func (s *Service) hmmCostGatedDecision(
 
 	if hmmFreshIsMoreExpensive(stayPin.Model, fresh.Model, req.SubsidizedModelCostFactor) {
 		confidence, ok := hmmDecisionConfidence(fresh)
-		if ok && confidence >= hmmUpgradeConfidenceThreshold {
+		// Threshold configurable per-deploy via ROUTER_HMM_UPGRADE_CONFIDENCE_THRESHOLD
+		// (turnloop.go-bound to Package proxy.Service via WithHMMUpgradeConfidenceThreshold).
+		// Default 0.85 — calibrated assumes the sidecar's ChosenScore is a [0,1]
+		// posterior probability; lower if the sidecar returns scores on a wider range.
+		if ok && confidence >= s.hmmUpgradeConfidenceThreshold {
 			base.Outcome = planner.OutcomeSwitch
 			base.Reason = hmmReasonConfidentUpgrade
 		} else {

--- a/internal/proxy/turnloop.go
+++ b/internal/proxy/turnloop.go
@@ -120,6 +120,12 @@ func isHMMDecision(dec router.Decision) bool {
 }
 
 const hmmHistoryReason = "hmm_history"
+const hmmUpgradeConfidenceThreshold = 0.85
+
+const (
+	hmmReasonConfidentUpgrade     = "hmm_confident_upgrade"
+	hmmReasonUpgradeConfidenceLow = "hmm_upgrade_confidence_low"
+)
 
 func hmmHistoryRole(role string) string {
 	if role == "" {
@@ -532,9 +538,29 @@ func (s *Service) runTurnLoop(
 	)
 	res.Fresh = fresh
 	if isHMMDecision(fresh) {
-		res.Decision = fresh
-		if pinFound {
+		hmmDecision, hmmPlannerDecision, hmmSticky, hmmStayModel := s.hmmCostGatedDecision(
+			req,
+			pin,
+			hmmHistory,
+			fresh,
+			feats.Tokens,
+			prefixBroken,
+		)
+		res.Decision = hmmDecision
+		res.PlannerDecision = hmmPlannerDecision
+		if hmmStayModel != "" {
+			res.PinModel = hmmStayModel
+		}
+		if hmmSticky {
+			res.StickyHit = true
+			res.PinTier = "hmm_ev_stay_" + hmmPlannerDecision.Reason
+		} else {
 			res.PinTier = "hmm_fresh_unpinned"
+			if hmmPlannerDecision.Outcome == planner.OutcomeStay && hmmPlannerDecision.Reason != "" {
+				res.PinTier = "hmm_ev_same_" + hmmPlannerDecision.Reason
+			} else if hmmPlannerDecision.Reason != "" && hmmPlannerDecision.Reason != planner.ReasonNoPin {
+				res.PinTier = "hmm_ev_switch_" + hmmPlannerDecision.Reason
+			}
 		}
 		return res, nil
 	}
@@ -697,6 +723,145 @@ func (s *Service) runTurnLoop(
 	}
 	s.writeNewPin(ctx, installationID, res.SessionKey, res.PinRole, fresh)
 	return res, nil
+}
+
+func (s *Service) hmmCostGatedDecision(
+	req router.Request,
+	activePin sessionpin.Pin,
+	hmmHistory sessionpin.Pin,
+	fresh router.Decision,
+	estimatedInputTokens int,
+	prefixBroken bool,
+) (router.Decision, planner.Decision, bool, string) {
+	stayPin, ok := s.hmmStayPin(req, activePin, hmmHistory)
+	if !ok {
+		return fresh, planner.Decision{Outcome: planner.OutcomeSwitch, Reason: planner.ReasonNoPin}, false, ""
+	}
+
+	cfg := s.planner
+	// HMM owns semantic upgrades. The generic planner tier guard is too coarse
+	// here because HMM clusters and router catalog tiers are not the same axis.
+	cfg.TierUpgradeEnabled = false
+	base := planner.Decide(planner.Inputs{
+		Pin:                  stayPin,
+		Fresh:                fresh,
+		EstimatedInputTokens: estimatedInputTokens,
+		AvailableModels:      s.availableModels,
+		PinCacheCold:         !cacheWarm(stayPin) || prefixBroken,
+		SubsidizedCostFactor: req.SubsidizedModelCostFactor,
+	}, cfg)
+
+	if hmmFreshIsMoreExpensive(stayPin.Model, fresh.Model, req.SubsidizedModelCostFactor) {
+		confidence, ok := hmmDecisionConfidence(fresh)
+		if ok && confidence >= hmmUpgradeConfidenceThreshold {
+			base.Outcome = planner.OutcomeSwitch
+			base.Reason = hmmReasonConfidentUpgrade
+		} else {
+			base.Outcome = planner.OutcomeStay
+			base.Reason = hmmReasonUpgradeConfidenceLow
+		}
+	}
+
+	if base.Outcome == planner.OutcomeStay && stayPin.Model != fresh.Model {
+		return pinDecision(stayPin), base, true, stayPin.Model
+	}
+	return fresh, base, false, stayPin.Model
+}
+
+func (s *Service) hmmStayPin(req router.Request, activePin sessionpin.Pin, hmmHistory sessionpin.Pin) (sessionpin.Pin, bool) {
+	var (
+		best sessionpin.Pin
+		ok   bool
+	)
+	for _, candidate := range []sessionpin.Pin{activePin, hmmHistory} {
+		normalized, candidateOK := s.normalizeHMMStayPin(req, candidate)
+		if !candidateOK {
+			continue
+		}
+		if !ok || normalized.LastTurnEndedAt.After(best.LastTurnEndedAt) {
+			best = normalized
+			ok = true
+		}
+	}
+	return best, ok
+}
+
+func (s *Service) normalizeHMMStayPin(req router.Request, p sessionpin.Pin) (sessionpin.Pin, bool) {
+	model := p.LastServedModel
+	if model == "" {
+		model = p.Model
+	}
+	if model == "" {
+		return sessionpin.Pin{}, false
+	}
+	if p.LastTurnEndedAt.IsZero() {
+		return sessionpin.Pin{}, false
+	}
+	if req.ExcludedModels != nil {
+		if _, excluded := req.ExcludedModels[model]; excluded {
+			return sessionpin.Pin{}, false
+		}
+	}
+	if s.availableModels != nil {
+		if _, available := s.availableModels[model]; !available {
+			return sessionpin.Pin{}, false
+		}
+	}
+	if req.HasImages && !catalog.AcceptsImages(model) {
+		return sessionpin.Pin{}, false
+	}
+	p.Model = model
+	if p.Provider != "" {
+		if req.EnabledProviders == nil {
+			return p, true
+		}
+		if _, ok := req.EnabledProviders[p.Provider]; ok {
+			return p, true
+		}
+		return sessionpin.Pin{}, false
+	}
+	providerSet := req.EnabledProviders
+	if providerSet == nil {
+		providerSet = make(map[string]struct{}, len(s.providers))
+		for provider := range s.providers {
+			providerSet[provider] = struct{}{}
+		}
+	}
+	binding, ok := catalog.ResolveBinding(model, providerSet)
+	if !ok {
+		return sessionpin.Pin{}, false
+	}
+	p.Provider = binding.Provider
+	return p, true
+}
+
+func hmmDecisionConfidence(dec router.Decision) (float64, bool) {
+	if dec.Metadata == nil {
+		return 0, false
+	}
+	confidence := float64(dec.Metadata.ChosenScore)
+	if confidence <= 0 {
+		return 0, false
+	}
+	return confidence, true
+}
+
+func hmmFreshIsMoreExpensive(stayModel, freshModel string, factors map[string]float64) bool {
+	stay, okStay := hmmEffectiveInputUSDPer1M(stayModel, factors)
+	fresh, okFresh := hmmEffectiveInputUSDPer1M(freshModel, factors)
+	return okStay && okFresh && fresh > stay
+}
+
+func hmmEffectiveInputUSDPer1M(model string, factors map[string]float64) (float64, bool) {
+	price, ok := catalog.PrimaryPriceFor(model)
+	if !ok {
+		return 0, false
+	}
+	value := price.InputUSDPer1M
+	if factor, covered := factors[model]; covered {
+		value *= factor
+	}
+	return value, true
 }
 
 // roleForTier maps a requested-model tier to its session-pin role. Each tier

--- a/internal/proxy/turnloop.go
+++ b/internal/proxy/turnloop.go
@@ -48,11 +48,12 @@ func cacheWarm(pin sessionpin.Pin) bool {
 
 // turnLoopResult bundles the routing decision and pin/planner state.
 type turnLoopResult struct {
-	Decision   router.Decision
-	SessionKey [sessionpin.SessionKeyLen]byte
-	TurnType   turntype.TurnType
-	StickyHit  bool
-	HardPinned bool
+	Decision       router.Decision
+	SessionKey     [sessionpin.SessionKeyLen]byte
+	InstallationID uuid.UUID
+	TurnType       turntype.TurnType
+	StickyHit      bool
+	HardPinned     bool
 	// UsageBypass is true when the caller's own subscription has headroom:
 	// ProxyMessages must serve the requested model straight through with no
 	// billing debit, bypassing Decision's normal dispatch.
@@ -118,6 +119,15 @@ func isHMMDecision(dec router.Decision) bool {
 	return strings.HasPrefix(strings.TrimSpace(dec.Reason), "hmm_policy")
 }
 
+const hmmHistoryReason = "hmm_history"
+
+func hmmHistoryRole(role string) string {
+	if role == "" {
+		role = sessionpin.DefaultRole
+	}
+	return role + "_hmm_history"
+}
+
 // handoverOutcome describes the synchronous handover step.
 type handoverOutcome struct {
 	Invoked       bool
@@ -169,9 +179,10 @@ func (s *Service) runTurnLoop(
 ) (turnLoopResult, error) {
 	log := observability.FromContext(ctx)
 	res := turnLoopResult{
-		TurnType:      turntype.DetectFromEnvelope(env, feats, subAgentHint),
-		PinTier:       "miss",
-		RequestedTier: catalog.TierFor(feats.Model),
+		InstallationID: installationID,
+		TurnType:       turntype.DetectFromEnvelope(env, feats, subAgentHint),
+		PinTier:        "miss",
+		RequestedTier:  catalog.TierFor(feats.Model),
 	}
 	res.PinRole = roleForTier(res.RequestedTier)
 	log.Info("turnloop classified",
@@ -272,8 +283,8 @@ func (s *Service) runTurnLoop(
 	res.SessionKey = sessionKey
 
 	pin, pinFound := s.loadPin(ctx, res.SessionKey, res.PinRole)
-	res.PriorServedModel = pin.LastServedModel
-	res.SessionEverSwitched = pin.HasEverSwitched
+	hmmHistory := s.loadHMMHistory(ctx, res.SessionKey, res.PinRole)
+	res.PriorServedModel, res.SessionEverSwitched = switchHistoryFromPins(pin, hmmHistory)
 	// Computed before any same-turn pin-drop guards below so it reflects the
 	// prior turn's outcome; Service.effortEscalation gates whether it's acted on.
 	res.EscalateEffort = pinFound && !pin.LastTurnEndedAt.IsZero() &&
@@ -722,6 +733,34 @@ func (s *Service) loadPin(ctx context.Context, sessionKey [sessionpin.SessionKey
 		return pin, false
 	}
 	return pin, true
+}
+
+func (s *Service) loadHMMHistory(ctx context.Context, sessionKey [sessionpin.SessionKeyLen]byte, role string) sessionpin.Pin {
+	log := observability.FromContext(ctx)
+	pin, found, err := s.pinStore.Get(ctx, sessionKey, hmmHistoryRole(role))
+	if err != nil {
+		log.Error("HMM switch-history store unavailable", "err", err)
+		return sessionpin.Pin{}
+	}
+	if !found {
+		return sessionpin.Pin{}
+	}
+	return pin
+}
+
+func switchHistoryFromPins(activePin, hmmHistory sessionpin.Pin) (string, bool) {
+	priorServedModel := activePin.LastServedModel
+	sessionEverSwitched := activePin.HasEverSwitched || hmmHistory.HasEverSwitched
+	if hmmHistory.LastServedModel != "" &&
+		(priorServedModel == "" || hmmHistory.LastTurnEndedAt.After(activePin.LastTurnEndedAt)) {
+		priorServedModel = hmmHistory.LastServedModel
+	}
+	if activePin.LastServedModel != "" &&
+		hmmHistory.LastServedModel != "" &&
+		activePin.LastServedModel != hmmHistory.LastServedModel {
+		sessionEverSwitched = true
+	}
+	return priorServedModel, sessionEverSwitched
 }
 
 // refreshPin extends the TTL on an existing pin. Carries the existing pin's

--- a/internal/proxy/turnloop.go
+++ b/internal/proxy/turnloop.go
@@ -376,8 +376,11 @@ func (s *Service) runTurnLoop(
 		pinFound = false
 		pin = sessionpin.Pin{}
 	}
-	if maxedModel := maxedOutServedModel(hmmHistory); maxedModel != "" &&
-		(hmmHistory.PinnedUntil.IsZero() || hmmHistory.PinnedUntil.After(time.Now())) {
+	if maxedModel := maxedOutServedModel(hmmHistory); maxedModel != "" {
+		// No expiry gate: a model that saturated its output cap must be excluded
+		// even after the history row's TTL lapses, matching the active-pin maxed
+		// path above — otherwise the degenerate auto-continue loop can re-select
+		// it on the very next turn.
 		log.Info("HMM history maxed out on previous turn; excluding for this turn",
 			"history_provider", hmmHistory.Provider,
 			"maxed_model", maxedModel,
@@ -768,10 +771,7 @@ func (s *Service) hmmCostGatedDecision(
 
 	if hmmFreshIsMoreExpensive(stayPin.Model, fresh.Model, req.SubsidizedModelCostFactor) {
 		confidence, ok := hmmDecisionConfidence(fresh)
-		// Threshold configurable per-deploy via ROUTER_HMM_UPGRADE_CONFIDENCE_THRESHOLD
-		// (turnloop.go-bound to Package proxy.Service via WithHMMUpgradeConfidenceThreshold).
-		// Default 0.85 — calibrated assumes the sidecar's ChosenScore is a [0,1]
-		// posterior probability; lower if the sidecar returns scores on a wider range.
+		// Configurable via ROUTER_HMM_UPGRADE_CONFIDENCE_THRESHOLD; lower if sidecar scores exceed [0,1].
 		if ok && confidence >= s.hmmUpgradeConfidenceThreshold {
 			base.Outcome = planner.OutcomeSwitch
 			base.Reason = hmmReasonConfidentUpgrade
@@ -792,6 +792,13 @@ func (s *Service) hmmStayPin(req router.Request, activePin sessionpin.Pin, hmmHi
 		best sessionpin.Pin
 		ok   bool
 	)
+	// The active routing pin is only an HMM stay candidate when it was itself
+	// written by an HMM turn. A cluster/planner pin from a prior non-HMM stretch
+	// (e.g. the session's strategy header changed mid-flight) must not win an
+	// HMM turn's EV stay — the _hmm_history row is the authoritative source.
+	if !isHMMPinReason(activePin.Reason) {
+		activePin = sessionpin.Pin{}
+	}
 	for _, candidate := range []sessionpin.Pin{activePin, hmmHistory} {
 		normalized, candidateOK := s.normalizeHMMStayPin(req, candidate)
 		if !candidateOK {
@@ -803,6 +810,14 @@ func (s *Service) hmmStayPin(req router.Request, activePin sessionpin.Pin, hmmHi
 		}
 	}
 	return best, ok
+}
+
+// isHMMPinReason reports whether a stored pin's Reason marks it as HMM-written
+// (either the hmm_history sentinel or an hmm_policy* sidecar reason). Used to
+// keep a stale cluster/planner pin from steering an HMM turn's EV stay.
+func isHMMPinReason(reason string) bool {
+	return reason == hmmHistoryReason ||
+		strings.HasPrefix(strings.TrimSpace(reason), "hmm_policy")
 }
 
 func (s *Service) normalizeHMMStayPin(req router.Request, p sessionpin.Pin) (sessionpin.Pin, bool) {

--- a/internal/proxy/turnloop_internal_test.go
+++ b/internal/proxy/turnloop_internal_test.go
@@ -10,7 +10,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"workweave/router/internal/providers"
 	"workweave/router/internal/router"
+	"workweave/router/internal/router/planner"
 	"workweave/router/internal/router/sessionpin"
 )
 
@@ -93,7 +95,7 @@ func TestRecordTurnUsage_WritesToStore(t *testing.T) {
 		SessionKey: sessionKey,
 		PinRole:    sessionpin.DefaultRole,
 	}
-	svc.recordTurnUsage(res, res.Decision.Model, 1200, 80, 200, 900)
+	svc.recordTurnUsage(res, res.Decision.Provider, res.Decision.Model, 1200, 80, 200, 900)
 
 	store.mu.Lock()
 	defer store.mu.Unlock()
@@ -143,13 +145,14 @@ func TestRecordTurnUsage_HMMDecisionWritesHistoryOnly(t *testing.T) {
 		// latch has_ever_switched without mutating the active routing role.
 		PriorServedModel: "claude-haiku-4-5",
 	}
-	svc.recordTurnUsage(res, res.Decision.Model, 1200, 80, 200, 900)
+	svc.recordTurnUsage(res, res.Decision.Provider, res.Decision.Model, 1200, 80, 200, 900)
 
 	store.mu.Lock()
 	defer store.mu.Unlock()
 	require.Len(t, store.upserts, 1)
 	assert.Equal(t, hmmHistoryRole(sessionpin.DefaultRole), store.upserts[0].Role)
 	assert.Equal(t, hmmHistoryReason, store.upserts[0].Reason)
+	assert.Equal(t, providers.ProviderAnthropic, store.upserts[0].Provider)
 	assert.Empty(t, store.upserts[0].Model, "HMM history rows must not be routable pins")
 	assert.Equal(t, []string{
 		hmmHistoryRole(sessionpin.DefaultRole),
@@ -157,6 +160,155 @@ func TestRecordTurnUsage_HMMDecisionWritesHistoryOnly(t *testing.T) {
 	}, store.usageRoles)
 	assert.NotContains(t, store.usageRoles, sessionpin.DefaultRole, "HMM turns must not mutate the active routing pin role")
 	assert.Equal(t, "claude-sonnet-5", store.lastUsage.ServedModel)
+}
+
+func TestHMMCostGate_StaysOnWarmCacheWhenCheaperFreshDoesNotClearEV(t *testing.T) {
+	svc := NewService(
+		nil,
+		map[string]providers.Client{providers.ProviderAnthropic: nil, providers.ProviderMakora: nil},
+		nil,
+		false,
+		nil,
+		nil,
+		false,
+		"anthropic", "claude-haiku-4-5",
+		nil,
+	)
+	history := sessionpin.Pin{
+		Provider:        providers.ProviderAnthropic,
+		LastServedModel: "claude-sonnet-5",
+		LastTurnEndedAt: time.Now().Add(-30 * time.Second),
+	}
+	fresh := router.Decision{
+		Provider: providers.ProviderMakora,
+		Model:    "deepseek/deepseek-v4-flash",
+		Reason:   "hmm_policy(classifier 'Simple Tool Call Request')",
+		Metadata: &router.RoutingMetadata{
+			Strategy:    string(router.StrategyHMM),
+			RouteID:     "route-1",
+			ChosenScore: 0.70,
+		},
+	}
+
+	decision, plan, sticky, stayModel := svc.hmmCostGatedDecision(
+		router.Request{},
+		sessionpin.Pin{},
+		history,
+		fresh,
+		100,
+		false,
+	)
+
+	assert.True(t, sticky)
+	assert.Equal(t, "claude-sonnet-5", decision.Model)
+	assert.Equal(t, providers.ProviderAnthropic, decision.Provider)
+	assert.Equal(t, "claude-sonnet-5", stayModel)
+	assert.Equal(t, planner.OutcomeStay, plan.Outcome)
+	assert.Equal(t, planner.ReasonEVNegative, plan.Reason)
+}
+
+func TestHMMCostGate_SwitchesCheaperFreshWhenEVPositive(t *testing.T) {
+	svc := NewService(
+		nil,
+		map[string]providers.Client{providers.ProviderAnthropic: nil, providers.ProviderMakora: nil},
+		nil,
+		false,
+		nil,
+		nil,
+		false,
+		"anthropic", "claude-haiku-4-5",
+		nil,
+	)
+	history := sessionpin.Pin{
+		Provider:        providers.ProviderAnthropic,
+		LastServedModel: "claude-sonnet-5",
+		LastTurnEndedAt: time.Now().Add(-30 * time.Second),
+	}
+	fresh := router.Decision{
+		Provider: providers.ProviderMakora,
+		Model:    "deepseek/deepseek-v4-flash",
+		Reason:   "hmm_policy(classifier 'Simple Tool Call Request')",
+		Metadata: &router.RoutingMetadata{
+			Strategy:    string(router.StrategyHMM),
+			RouteID:     "route-1",
+			ChosenScore: 0.70,
+		},
+	}
+
+	decision, plan, sticky, stayModel := svc.hmmCostGatedDecision(
+		router.Request{},
+		sessionpin.Pin{},
+		history,
+		fresh,
+		10_000,
+		false,
+	)
+
+	assert.False(t, sticky)
+	assert.Equal(t, "deepseek/deepseek-v4-flash", decision.Model)
+	assert.Equal(t, "claude-sonnet-5", stayModel)
+	assert.Equal(t, planner.OutcomeSwitch, plan.Outcome)
+	assert.Equal(t, planner.ReasonEVPositive, plan.Reason)
+}
+
+func TestHMMCostGate_ExpensiveUpgradeRequiresHighConfidence(t *testing.T) {
+	svc := NewService(
+		nil,
+		map[string]providers.Client{providers.ProviderAnthropic: nil, providers.ProviderFireworks: nil},
+		nil,
+		false,
+		nil,
+		nil,
+		false,
+		"anthropic", "claude-haiku-4-5",
+		nil,
+	)
+	history := sessionpin.Pin{
+		Provider:        providers.ProviderFireworks,
+		LastServedModel: "moonshotai/kimi-k2.7",
+		LastTurnEndedAt: time.Now().Add(-30 * time.Second),
+	}
+	fresh := router.Decision{
+		Provider: providers.ProviderAnthropic,
+		Model:    "claude-sonnet-5",
+		Reason:   "hmm_policy(classifier 'Complex Followup')",
+		Metadata: &router.RoutingMetadata{
+			Strategy:    string(router.StrategyHMM),
+			RouteID:     "route-1",
+			ChosenScore: 0.84,
+		},
+	}
+
+	decision, plan, sticky, stayModel := svc.hmmCostGatedDecision(
+		router.Request{},
+		sessionpin.Pin{},
+		history,
+		fresh,
+		10_000,
+		false,
+	)
+
+	assert.True(t, sticky)
+	assert.Equal(t, "moonshotai/kimi-k2.7", decision.Model)
+	assert.Equal(t, "moonshotai/kimi-k2.7", stayModel)
+	assert.Equal(t, planner.OutcomeStay, plan.Outcome)
+	assert.Equal(t, hmmReasonUpgradeConfidenceLow, plan.Reason)
+
+	fresh.Metadata.ChosenScore = 0.85
+	decision, plan, sticky, stayModel = svc.hmmCostGatedDecision(
+		router.Request{},
+		sessionpin.Pin{},
+		history,
+		fresh,
+		10_000,
+		false,
+	)
+
+	assert.False(t, sticky)
+	assert.Equal(t, "claude-sonnet-5", decision.Model)
+	assert.Equal(t, "moonshotai/kimi-k2.7", stayModel)
+	assert.Equal(t, planner.OutcomeSwitch, plan.Outcome)
+	assert.Equal(t, hmmReasonConfidentUpgrade, plan.Reason)
 }
 
 // TestLoadPin_DoesNotServeExpiredPostgresPinButKeepsEmitHistory: expired rows

--- a/internal/proxy/turnloop_internal_test.go
+++ b/internal/proxy/turnloop_internal_test.go
@@ -616,3 +616,103 @@ func TestModelSwitched(t *testing.T) {
 		})
 	}
 }
+
+// TestService_NewService_HMMUpgradeConfidenceDefaults: the HMM "upgrade to
+// more expensive model" ChosenScore threshold must default to 0.85 so a fresh
+// deploy behaves like the previous hardcoded behavior. Without a default the
+// floor becomes 0 and every fresh HMM "upgrade" picks would beat an EV stay.
+func TestService_NewService_HMMUpgradeConfidenceDefaults(t *testing.T) {
+	svc := NewService(
+		nil,
+		map[string]providers.Client{providers.ProviderAnthropic: nil},
+		nil,
+		false,
+		nil,
+		nil,
+		false,
+		"anthropic", "claude-haiku-4-5",
+		nil,
+	)
+	assert.Equal(t, defaultHMMUpgradeConfidenceThreshold, svc.hmmUpgradeConfidenceThreshold,
+		"new deploys must default to the documented 0.85 threshold")
+}
+
+// TestService_WithHMMUpgradeConfidenceThreshold: setter accepts in-range and
+// rejects out-of-range. Out-of-range values must not the existing threshold —
+// failing silently on bad input would let a single typo disable upgrade
+// gating permanently.
+func TestService_WithHMMUpgradeConfidenceThreshold(t *testing.T) {
+	svc := NewService(
+		nil,
+		map[string]providers.Client{providers.ProviderAnthropic: nil},
+		nil,
+		false,
+		nil,
+		nil,
+		false,
+		"anthropic", "claude-haiku-4-5",
+		nil,
+	)
+	svc.WithHMMUpgradeConfidenceThreshold(0.50)
+	assert.Equal(t, 0.50, svc.hmmUpgradeConfidenceThreshold,
+		"in-range threshold must be applied")
+
+	svc.WithHMMUpgradeConfidenceThreshold(-0.10)
+	assert.Equal(t, 0.50, svc.hmmUpgradeConfidenceThreshold,
+		"negative threshold must be rejected")
+
+	svc.WithHMMUpgradeConfidenceThreshold(1.50)
+	assert.Equal(t, 0.50, svc.hmmUpgradeConfidenceThreshold,
+		"threshold above 1.0 must be rejected")
+
+	svc.WithHMMUpgradeConfidenceThreshold(0.0)
+	assert.Equal(t, 0.0, svc.hmmUpgradeConfidenceThreshold,
+		"zero is a legitimate value, not an error")
+}
+
+// TestHMMCostGate_UpgradeThresholdConfigurable: lower the threshold so a
+// ChosenScore that the default 0.85 rejects is accepted. Verifies the wiring
+// between withHMMUpgradeConfidenceThreshold and the cost-gate switch path.
+func TestHMMCostGate_UpgradeThresholdConfigurable(t *testing.T) {
+	svc := NewService(
+		nil,
+		map[string]providers.Client{providers.ProviderAnthropic: nil, providers.ProviderFireworks: nil},
+		nil,
+		false,
+		nil,
+		nil,
+		false,
+		"anthropic", "claude-haiku-4-5",
+		nil,
+	)
+	svc.WithHMMUpgradeConfidenceThreshold(0.20)
+	history := sessionpin.Pin{
+		Provider:        providers.ProviderFireworks,
+		LastServedModel: "moonshotai/kimi-k2.7",
+		LastTurnEndedAt: time.Now().Add(-30 * time.Second),
+	}
+	fresh := router.Decision{
+		Provider: providers.ProviderAnthropic,
+		Model:    "claude-sonnet-5",
+		Reason:   "hmm_policy(classifier 'Complex Followup')",
+		Metadata: &router.RoutingMetadata{
+			Strategy:    string(router.StrategyHMM),
+			RouteID:     "route-1",
+			ChosenScore: 0.30,
+		},
+	}
+
+	decision, plan, sticky, stayModel := svc.hmmCostGatedDecision(
+		router.Request{},
+		sessionpin.Pin{},
+		history,
+		fresh,
+		10_000,
+		false,
+	)
+	assert.False(t, sticky, "0.30 must clear 0.20 threshold")
+	assert.Equal(t, "claude-sonnet-5", decision.Model)
+	assert.Equal(t, planner.OutcomeSwitch, plan.Outcome)
+	assert.Equal(t, hmmReasonConfidentUpgrade, plan.Reason)
+	assert.Equal(t, "moonshotai/kimi-k2.7", stayModel)
+}

--- a/internal/proxy/turnloop_internal_test.go
+++ b/internal/proxy/turnloop_internal_test.go
@@ -103,6 +103,46 @@ func TestRecordTurnUsage_WritesToStore(t *testing.T) {
 	assert.False(t, store.lastUsage.EndedAt.IsZero(), "EndedAt must be stamped — the planner uses IsZero() as its no-prior-usage gate")
 }
 
+func TestRecordTurnUsage_SkipsHMMDecision(t *testing.T) {
+	store := newStubPinStore()
+	svc := NewService(
+		nil,
+		nil,
+		nil,
+		false,
+		nil,
+		store,
+		false,
+		"anthropic", "claude-haiku-4-5",
+		nil,
+	)
+
+	var sessionKey [sessionpin.SessionKeyLen]byte
+	for i := range sessionKey {
+		sessionKey[i] = byte(i + 1)
+	}
+
+	res := turnLoopResult{
+		Decision: router.Decision{
+			Provider: "anthropic",
+			Model:    "claude-sonnet-5",
+			Reason:   "hmm_policy(label=Complex Followup)",
+			Metadata: &router.RoutingMetadata{
+				Strategy: string(router.StrategyHMM),
+				RouteID:  "route-1",
+			},
+		},
+		SessionKey: sessionKey,
+		PinRole:    sessionpin.DefaultRole,
+		PinTier:    "hmm_fresh_unpinned",
+	}
+	svc.recordTurnUsage(res, res.Decision.Model, 1200, 80, 200, 900)
+
+	store.mu.Lock()
+	defer store.mu.Unlock()
+	assert.Equal(t, 0, store.usageHits, "HMM turns do not own session pins and must not mutate stale pin usage")
+}
+
 // TestLoadPin_DoesNotServeExpiredPostgresPinButKeepsEmitHistory: expired rows
 // are routing misses, but has_ever_switched/last_served_model must survive so
 // Anthropic emit still strips poisoned thinking blocks.

--- a/internal/proxy/turnloop_internal_test.go
+++ b/internal/proxy/turnloop_internal_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -16,13 +17,14 @@ import (
 // stubPinStore is a minimal sessionpin.Store for testing recordTurnUsage.
 // getPin/getFound configure Get's response and default to a miss.
 type stubPinStore struct {
-	mu        sync.Mutex
-	lastUsage sessionpin.Usage
-	usageHits int
-	getPin    sessionpin.Pin
-	getFound  bool
-	upserts   []sessionpin.Pin
-	upsertErr error
+	mu         sync.Mutex
+	lastUsage  sessionpin.Usage
+	usageHits  int
+	usageRoles []string
+	getPin     sessionpin.Pin
+	getFound   bool
+	upserts    []sessionpin.Pin
+	upsertErr  error
 }
 
 func newStubPinStore() *stubPinStore {
@@ -45,11 +47,12 @@ func (s *stubPinStore) Upsert(_ context.Context, p sessionpin.Pin) error {
 	return nil
 }
 
-func (s *stubPinStore) UpdateUsage(_ context.Context, _ [sessionpin.SessionKeyLen]byte, _ string, u sessionpin.Usage) error {
+func (s *stubPinStore) UpdateUsage(_ context.Context, _ [sessionpin.SessionKeyLen]byte, role string, u sessionpin.Usage) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.lastUsage = u
 	s.usageHits++
+	s.usageRoles = append(s.usageRoles, role)
 	return nil
 }
 
@@ -103,7 +106,7 @@ func TestRecordTurnUsage_WritesToStore(t *testing.T) {
 	assert.False(t, store.lastUsage.EndedAt.IsZero(), "EndedAt must be stamped — the planner uses IsZero() as its no-prior-usage gate")
 }
 
-func TestRecordTurnUsage_SkipsHMMDecision(t *testing.T) {
+func TestRecordTurnUsage_HMMDecisionWritesHistoryOnly(t *testing.T) {
 	store := newStubPinStore()
 	svc := NewService(
 		nil,
@@ -123,6 +126,7 @@ func TestRecordTurnUsage_SkipsHMMDecision(t *testing.T) {
 	}
 
 	res := turnLoopResult{
+		InstallationID: uuid.New(),
 		Decision: router.Decision{
 			Provider: "anthropic",
 			Model:    "claude-sonnet-5",
@@ -135,12 +139,24 @@ func TestRecordTurnUsage_SkipsHMMDecision(t *testing.T) {
 		SessionKey: sessionKey,
 		PinRole:    sessionpin.DefaultRole,
 		PinTier:    "hmm_fresh_unpinned",
+		// Simulate a prior HMM/default-route model so the history role can
+		// latch has_ever_switched without mutating the active routing role.
+		PriorServedModel: "claude-haiku-4-5",
 	}
 	svc.recordTurnUsage(res, res.Decision.Model, 1200, 80, 200, 900)
 
 	store.mu.Lock()
 	defer store.mu.Unlock()
-	assert.Equal(t, 0, store.usageHits, "HMM turns do not own session pins and must not mutate stale pin usage")
+	require.Len(t, store.upserts, 1)
+	assert.Equal(t, hmmHistoryRole(sessionpin.DefaultRole), store.upserts[0].Role)
+	assert.Equal(t, hmmHistoryReason, store.upserts[0].Reason)
+	assert.Empty(t, store.upserts[0].Model, "HMM history rows must not be routable pins")
+	assert.Equal(t, []string{
+		hmmHistoryRole(sessionpin.DefaultRole),
+		hmmHistoryRole(sessionpin.DefaultRole),
+	}, store.usageRoles)
+	assert.NotContains(t, store.usageRoles, sessionpin.DefaultRole, "HMM turns must not mutate the active routing pin role")
+	assert.Equal(t, "claude-sonnet-5", store.lastUsage.ServedModel)
 }
 
 // TestLoadPin_DoesNotServeExpiredPostgresPinButKeepsEmitHistory: expired rows
@@ -228,6 +244,23 @@ func TestLoadPin_ServesFreshPostgresPin(t *testing.T) {
 	require.True(t, found, "non-expired Postgres row must be returned")
 	assert.Equal(t, "claude-opus-4-7", pin.Model)
 	assert.Equal(t, "anthropic", pin.Provider)
+}
+
+func TestSwitchHistoryFromPins_UsesHMMHistory(t *testing.T) {
+	now := time.Now()
+	active := sessionpin.Pin{
+		LastServedModel: "claude-haiku-4-5",
+		LastTurnEndedAt: now.Add(-time.Minute),
+	}
+	hmmHistory := sessionpin.Pin{
+		LastServedModel: "claude-sonnet-5",
+		LastTurnEndedAt: now,
+	}
+
+	prior, everSwitched := switchHistoryFromPins(active, hmmHistory)
+
+	assert.Equal(t, "claude-sonnet-5", prior)
+	assert.True(t, everSwitched, "different active/history models must preserve thinking-block stripping")
 }
 
 // TestModelSwitched covers switch → stay → stay: once a session has served

--- a/internal/proxy/turnloop_internal_test.go
+++ b/internal/proxy/turnloop_internal_test.go
@@ -159,6 +159,61 @@ func TestRecordTurnUsage_HMMDecisionWritesHistoryOnly(t *testing.T) {
 		hmmHistoryRole(sessionpin.DefaultRole),
 	}, store.usageRoles)
 	assert.NotContains(t, store.usageRoles, sessionpin.DefaultRole, "HMM turns must not mutate the active routing pin role")
+	assert.Equal(t, 1200, store.lastUsage.InputTokens)
+	assert.Equal(t, 900, store.lastUsage.CachedReadTokens)
+	assert.Equal(t, 200, store.lastUsage.CachedWriteTokens)
+	assert.Equal(t, 80, store.lastUsage.OutputTokens)
+	assert.Equal(t, "claude-sonnet-5", store.lastUsage.ServedModel)
+}
+
+func TestRecordTurnUsage_HMMEVStayWritesHistoryOnly(t *testing.T) {
+	store := newStubPinStore()
+	svc := NewService(
+		nil,
+		nil,
+		nil,
+		false,
+		nil,
+		store,
+		false,
+		"anthropic", "claude-haiku-4-5",
+		nil,
+	)
+
+	var sessionKey [sessionpin.SessionKeyLen]byte
+	for i := range sessionKey {
+		sessionKey[i] = byte(i + 1)
+	}
+
+	res := turnLoopResult{
+		InstallationID: uuid.New(),
+		Decision: router.Decision{
+			Provider: providers.ProviderAnthropic,
+			Model:    "claude-sonnet-5",
+			Reason:   hmmHistoryReason,
+		},
+		Fresh: router.Decision{
+			Provider: providers.ProviderMakora,
+			Model:    "deepseek/deepseek-v4-flash",
+			Reason:   "hmm_policy(classifier 'Simple Tool Call Request')",
+			Metadata: &router.RoutingMetadata{
+				Strategy: string(router.StrategyHMM),
+				RouteID:  "route-1",
+			},
+		},
+		SessionKey: sessionKey,
+		PinRole:    sessionpin.DefaultRole,
+		PinTier:    "hmm_ev_stay_ev_negative",
+	}
+	svc.recordTurnUsage(res, res.Decision.Provider, res.Decision.Model, 1200, 80, 200, 900)
+
+	store.mu.Lock()
+	defer store.mu.Unlock()
+	require.Len(t, store.upserts, 1)
+	assert.Equal(t, hmmHistoryRole(sessionpin.DefaultRole), store.upserts[0].Role)
+	assert.Empty(t, store.upserts[0].Model, "HMM history rows must not be routable pins")
+	assert.Equal(t, []string{hmmHistoryRole(sessionpin.DefaultRole)}, store.usageRoles)
+	assert.Equal(t, 80, store.lastUsage.OutputTokens)
 	assert.Equal(t, "claude-sonnet-5", store.lastUsage.ServedModel)
 }
 
@@ -309,6 +364,98 @@ func TestHMMCostGate_ExpensiveUpgradeRequiresHighConfidence(t *testing.T) {
 	assert.Equal(t, "moonshotai/kimi-k2.7", stayModel)
 	assert.Equal(t, planner.OutcomeSwitch, plan.Outcome)
 	assert.Equal(t, hmmReasonConfidentUpgrade, plan.Reason)
+}
+
+func TestHMMCostGate_IgnoresExpiredActivePin(t *testing.T) {
+	svc := NewService(
+		nil,
+		map[string]providers.Client{providers.ProviderAnthropic: nil, providers.ProviderMakora: nil},
+		nil,
+		false,
+		nil,
+		nil,
+		false,
+		"anthropic", "claude-haiku-4-5",
+		nil,
+	)
+	expired := sessionpin.Pin{
+		Provider:        providers.ProviderAnthropic,
+		Model:           "claude-sonnet-5",
+		LastServedModel: "claude-sonnet-5",
+		LastTurnEndedAt: time.Now().Add(-30 * time.Second),
+		PinnedUntil:     time.Now().Add(-time.Minute),
+	}
+	fresh := router.Decision{
+		Provider: providers.ProviderMakora,
+		Model:    "deepseek/deepseek-v4-flash",
+		Reason:   "hmm_policy(classifier 'Simple Tool Call Request')",
+		Metadata: &router.RoutingMetadata{
+			Strategy:    string(router.StrategyHMM),
+			RouteID:     "route-1",
+			ChosenScore: 0.70,
+		},
+	}
+
+	decision, plan, sticky, stayModel := svc.hmmCostGatedDecision(
+		router.Request{},
+		expired,
+		sessionpin.Pin{},
+		fresh,
+		100,
+		false,
+	)
+
+	assert.False(t, sticky)
+	assert.Equal(t, "deepseek/deepseek-v4-flash", decision.Model)
+	assert.Empty(t, stayModel)
+	assert.Equal(t, planner.OutcomeSwitch, plan.Outcome)
+	assert.Equal(t, planner.ReasonNoPin, plan.Reason)
+}
+
+func TestHMMCostGate_IgnoresMaxedHistory(t *testing.T) {
+	svc := NewService(
+		nil,
+		map[string]providers.Client{providers.ProviderAnthropic: nil, providers.ProviderMakora: nil},
+		nil,
+		false,
+		nil,
+		nil,
+		false,
+		"anthropic", "claude-haiku-4-5",
+		nil,
+	)
+	history := sessionpin.Pin{
+		Provider:         providers.ProviderAnthropic,
+		LastServedModel:  "claude-sonnet-5",
+		LastOutputTokens: prevTurnMaxedOutThreshold,
+		LastTurnEndedAt:  time.Now().Add(-30 * time.Second),
+		PinnedUntil:      time.Now().Add(time.Hour),
+	}
+	fresh := router.Decision{
+		Provider: providers.ProviderMakora,
+		Model:    "deepseek/deepseek-v4-flash",
+		Reason:   "hmm_policy(classifier 'Simple Tool Call Request')",
+		Metadata: &router.RoutingMetadata{
+			Strategy:    string(router.StrategyHMM),
+			RouteID:     "route-1",
+			ChosenScore: 0.70,
+		},
+	}
+
+	decision, plan, sticky, stayModel := svc.hmmCostGatedDecision(
+		router.Request{},
+		sessionpin.Pin{},
+		history,
+		fresh,
+		100,
+		false,
+	)
+
+	assert.False(t, sticky)
+	assert.Equal(t, "deepseek/deepseek-v4-flash", decision.Model)
+	assert.Empty(t, stayModel)
+	assert.Equal(t, planner.OutcomeSwitch, plan.Outcome)
+	assert.Equal(t, planner.ReasonNoPin, plan.Reason)
 }
 
 // TestLoadPin_DoesNotServeExpiredPostgresPinButKeepsEmitHistory: expired rows

--- a/internal/proxy/turnloop_internal_test.go
+++ b/internal/proxy/turnloop_internal_test.go
@@ -166,6 +166,50 @@ func TestRecordTurnUsage_HMMDecisionWritesHistoryOnly(t *testing.T) {
 	assert.Equal(t, "claude-sonnet-5", store.lastUsage.ServedModel)
 }
 
+func TestRecordHMMTurnHistory_ZeroUsageRefreshesTTLButSkipsUsageWriteback(t *testing.T) {
+	store := newStubPinStore()
+	svc := NewService(
+		nil,
+		nil,
+		nil,
+		false,
+		nil,
+		store,
+		false,
+		"anthropic", "claude-haiku-4-5",
+		nil,
+	)
+
+	var sessionKey [sessionpin.SessionKeyLen]byte
+	for i := range sessionKey {
+		sessionKey[i] = byte(i + 1)
+	}
+
+	res := turnLoopResult{
+		InstallationID: uuid.New(),
+		Decision: router.Decision{
+			Provider: providers.ProviderAnthropic,
+			Model:    "claude-sonnet-5",
+			Reason:   "hmm_policy(label=Complex Followup)",
+			Metadata: &router.RoutingMetadata{
+				Strategy: string(router.StrategyHMM),
+				RouteID:  "route-1",
+			},
+		},
+		SessionKey: sessionKey,
+		PinRole:    sessionpin.DefaultRole,
+	}
+	// A failed/empty upstream turn: all usage counts zero.
+	svc.recordTurnUsage(res, res.Decision.Provider, res.Decision.Model, 0, 0, 0, 0)
+
+	store.mu.Lock()
+	defer store.mu.Unlock()
+	require.Len(t, store.upserts, 1, "TTL-refreshing upsert must still run on a zero-usage turn")
+	assert.Equal(t, hmmHistoryRole(sessionpin.DefaultRole), store.upserts[0].Role)
+	assert.Empty(t, store.usageRoles, "zero-usage turn must not clobber the history row's usage columns")
+	assert.Equal(t, 0, store.usageHits)
+}
+
 func TestRecordTurnUsage_HMMEVStayWritesHistoryOnly(t *testing.T) {
 	store := newStubPinStore()
 	svc := NewService(
@@ -412,6 +456,104 @@ func TestHMMCostGate_IgnoresExpiredActivePin(t *testing.T) {
 	assert.Equal(t, planner.ReasonNoPin, plan.Reason)
 }
 
+func TestHMMCostGate_IgnoresNonHMMActivePin(t *testing.T) {
+	svc := NewService(
+		nil,
+		map[string]providers.Client{providers.ProviderAnthropic: nil, providers.ProviderMakora: nil},
+		nil,
+		false,
+		nil,
+		nil,
+		false,
+		"anthropic", "claude-haiku-4-5",
+		nil,
+	)
+	// A warm cluster/planner pin (non-HMM reason) must NOT steer an HMM turn's
+	// EV stay — otherwise HMM turns silently reuse ordinary session pins.
+	clusterPin := sessionpin.Pin{
+		Provider:        providers.ProviderAnthropic,
+		Model:           "claude-sonnet-5",
+		LastServedModel: "claude-sonnet-5",
+		Reason:          "cluster:v0.2",
+		LastTurnEndedAt: time.Now().Add(-30 * time.Second),
+		PinnedUntil:     time.Now().Add(time.Hour),
+	}
+	fresh := router.Decision{
+		Provider: providers.ProviderMakora,
+		Model:    "deepseek/deepseek-v4-flash",
+		Reason:   "hmm_policy(classifier 'Simple Tool Call Request')",
+		Metadata: &router.RoutingMetadata{
+			Strategy:    string(router.StrategyHMM),
+			RouteID:     "route-1",
+			ChosenScore: 0.70,
+		},
+	}
+
+	decision, plan, sticky, stayModel := svc.hmmCostGatedDecision(
+		router.Request{},
+		clusterPin,
+		sessionpin.Pin{},
+		fresh,
+		100,
+		false,
+	)
+
+	assert.False(t, sticky, "a non-HMM cluster pin must not win an HMM EV stay")
+	assert.Equal(t, "deepseek/deepseek-v4-flash", decision.Model)
+	assert.Empty(t, stayModel)
+	assert.Equal(t, planner.OutcomeSwitch, plan.Outcome)
+	assert.Equal(t, planner.ReasonNoPin, plan.Reason)
+}
+
+func TestHMMCostGate_HonorsHMMReasonedActivePin(t *testing.T) {
+	svc := NewService(
+		nil,
+		map[string]providers.Client{providers.ProviderAnthropic: nil, providers.ProviderMakora: nil},
+		nil,
+		false,
+		nil,
+		nil,
+		false,
+		"anthropic", "claude-haiku-4-5",
+		nil,
+	)
+	// The active pin IS HMM-reasoned, so it remains a valid stay candidate: a
+	// cheaper fresh pick that doesn't clear EV must stay on it.
+	hmmPin := sessionpin.Pin{
+		Provider:        providers.ProviderAnthropic,
+		Model:           "claude-sonnet-5",
+		LastServedModel: "claude-sonnet-5",
+		Reason:          "hmm_policy(label=Complex Followup)",
+		LastTurnEndedAt: time.Now().Add(-30 * time.Second),
+		PinnedUntil:     time.Now().Add(time.Hour),
+	}
+	fresh := router.Decision{
+		Provider: providers.ProviderMakora,
+		Model:    "deepseek/deepseek-v4-flash",
+		Reason:   "hmm_policy(classifier 'Simple Tool Call Request')",
+		Metadata: &router.RoutingMetadata{
+			Strategy:    string(router.StrategyHMM),
+			RouteID:     "route-1",
+			ChosenScore: 0.70,
+		},
+	}
+
+	decision, plan, sticky, stayModel := svc.hmmCostGatedDecision(
+		router.Request{},
+		hmmPin,
+		sessionpin.Pin{},
+		fresh,
+		100,
+		false,
+	)
+
+	assert.True(t, sticky, "an HMM-reasoned active pin remains a valid stay candidate")
+	assert.Equal(t, "claude-sonnet-5", decision.Model)
+	assert.Equal(t, "claude-sonnet-5", stayModel)
+	assert.Equal(t, planner.OutcomeStay, plan.Outcome)
+	assert.Equal(t, planner.ReasonEVNegative, plan.Reason)
+}
+
 func TestHMMCostGate_IgnoresMaxedHistory(t *testing.T) {
 	svc := NewService(
 		nil,
@@ -617,10 +759,8 @@ func TestModelSwitched(t *testing.T) {
 	}
 }
 
-// TestService_NewService_HMMUpgradeConfidenceDefaults: the HMM "upgrade to
-// more expensive model" ChosenScore threshold must default to 0.85 so a fresh
-// deploy behaves like the previous hardcoded behavior. Without a default the
-// floor becomes 0 and every fresh HMM "upgrade" picks would beat an EV stay.
+// TestService_NewService_HMMUpgradeConfidenceDefaults: must default to 0.85;
+// a zero default would let every HMM upgrade beat an EV stay.
 func TestService_NewService_HMMUpgradeConfidenceDefaults(t *testing.T) {
 	svc := NewService(
 		nil,
@@ -637,10 +777,8 @@ func TestService_NewService_HMMUpgradeConfidenceDefaults(t *testing.T) {
 		"new deploys must default to the documented 0.85 threshold")
 }
 
-// TestService_WithHMMUpgradeConfidenceThreshold: setter accepts in-range and
-// rejects out-of-range. Out-of-range values must not the existing threshold —
-// failing silently on bad input would let a single typo disable upgrade
-// gating permanently.
+// TestService_WithHMMUpgradeConfidenceThreshold: accepts in-range, rejects
+// out-of-range silently (a typo must not disable upgrade gating permanently).
 func TestService_WithHMMUpgradeConfidenceThreshold(t *testing.T) {
 	svc := NewService(
 		nil,
@@ -671,8 +809,7 @@ func TestService_WithHMMUpgradeConfidenceThreshold(t *testing.T) {
 }
 
 // TestHMMCostGate_UpgradeThresholdConfigurable: lower the threshold so a
-// ChosenScore that the default 0.85 rejects is accepted. Verifies the wiring
-// between withHMMUpgradeConfidenceThreshold and the cost-gate switch path.
+// ChosenScore that the default 0.85 rejects is accepted.
 func TestHMMCostGate_UpgradeThresholdConfigurable(t *testing.T) {
 	svc := NewService(
 		nil,

--- a/internal/proxy/turnloop_test.go
+++ b/internal/proxy/turnloop_test.go
@@ -277,7 +277,7 @@ func TestTurnLoop_HMMToolResultCommunicationFollowsFreshDecision(t *testing.T) {
 	assert.Equal(t, "claude-sonnet-4-5", rec.Header().Get(proxy.HeaderRouterModel),
 		"a completed tool result must not stay pinned to the tool-execution model")
 	store.mu.Lock()
-	assert.Empty(t, store.upserts, "fresh HMM decisions must not write session pins")
+	assertOnlyHMMHistoryUpserts(t, store)
 	store.mu.Unlock()
 }
 
@@ -310,7 +310,7 @@ func TestTurnLoop_HMMToolResultToolExecutionUsesFreshDecision(t *testing.T) {
 	assert.Equal(t, "claude-sonnet-4-5", rec.Header().Get(proxy.HeaderRouterModel),
 		"HMM tool execution must follow the fresh sidecar decision instead of an existing session pin")
 	store.mu.Lock()
-	assert.Empty(t, store.upserts, "fresh HMM decisions must not write session pins")
+	assertOnlyHMMHistoryUpserts(t, store)
 	store.mu.Unlock()
 }
 
@@ -345,7 +345,7 @@ func TestTurnLoop_HMMToolExecutionDoesNotServeExistingPin(t *testing.T) {
 	assert.Equal(t, "claude-haiku-4-5", rec.Header().Get(proxy.HeaderRouterModel),
 		"HMM tool execution must not keep an existing session pin")
 	store.mu.Lock()
-	assert.Empty(t, store.upserts, "fresh HMM decisions must not write session pins")
+	assertOnlyHMMHistoryUpserts(t, store)
 	store.mu.Unlock()
 }
 
@@ -380,7 +380,7 @@ func TestTurnLoop_HMMConversationFollowsFreshDecision(t *testing.T) {
 	assert.Equal(t, "claude-sonnet-5", rec.Header().Get(proxy.HeaderRouterModel),
 		"HMM normal conversation routing must follow the fresh sidecar decision instead of EV-staying on the old pin")
 	store.mu.Lock()
-	assert.Empty(t, store.upserts, "fresh HMM decisions must not write session pins")
+	assertOnlyHMMHistoryUpserts(t, store)
 	store.mu.Unlock()
 }
 
@@ -416,7 +416,7 @@ func TestTurnLoop_HMMToolExecutionBreaksConversationalPin(t *testing.T) {
 		"a fresh HMM tool/explore execution decision must break a conversational pin")
 
 	store.mu.Lock()
-	assert.Empty(t, store.upserts, "fresh HMM decisions must not write session pins")
+	assertOnlyHMMHistoryUpserts(t, store)
 	store.mu.Unlock()
 }
 
@@ -451,7 +451,7 @@ func TestTurnLoop_HMMToolExecutionSameModelDoesNotRewritePin(t *testing.T) {
 	assert.Equal(t, "claude-sonnet-4-5", rec.Header().Get(proxy.HeaderRouterModel))
 
 	store.mu.Lock()
-	assert.Empty(t, store.upserts, "fresh HMM decisions must not write session pins")
+	assertOnlyHMMHistoryUpserts(t, store)
 	store.mu.Unlock()
 }
 

--- a/internal/proxy/turnloop_test.go
+++ b/internal/proxy/turnloop_test.go
@@ -314,7 +314,7 @@ func TestTurnLoop_HMMToolResultToolExecutionUsesFreshDecision(t *testing.T) {
 	store.mu.Unlock()
 }
 
-func TestTurnLoop_HMMToolExecutionDoesNotServeExistingPin(t *testing.T) {
+func TestTurnLoop_HMMToolExecutionStaysWhenWarmCacheEVBeatsCheapFresh(t *testing.T) {
 	store := newFakePinStore()
 	store.hasPin = true
 	store.pin = sessionpin.Pin{
@@ -342,8 +342,8 @@ func TestTurnLoop_HMMToolExecutionDoesNotServeExistingPin(t *testing.T) {
 	require.NoError(t, svc.ProxyMessages(ctx, []byte(pinTestBody), rec, httpReq))
 
 	assert.Equal(t, 1, fr.routeCalls, "ongoing HMM execution still scores to see if execution continues")
-	assert.Equal(t, "claude-haiku-4-5", rec.Header().Get(proxy.HeaderRouterModel),
-		"HMM tool execution must not keep an existing session pin")
+	assert.Equal(t, "claude-sonnet-5", rec.Header().Get(proxy.HeaderRouterModel),
+		"HMM should stay when switching to a cheaper tool model would not beat warm-cache eviction cost")
 	store.mu.Lock()
 	assertOnlyHMMHistoryUpserts(t, store)
 	store.mu.Unlock()
@@ -365,8 +365,9 @@ func TestTurnLoop_HMMConversationFollowsFreshDecision(t *testing.T) {
 		Model:    "claude-sonnet-5",
 		Reason:   "hmm_policy(label=Complex Design)",
 		Metadata: &router.RoutingMetadata{
-			Strategy: string(router.StrategyHMM),
-			RouteID:  "route-1",
+			Strategy:    string(router.StrategyHMM),
+			RouteID:     "route-1",
+			ChosenScore: 0.90,
 		},
 	}}
 	svc := newPinSvc(fr, store)
@@ -384,7 +385,7 @@ func TestTurnLoop_HMMConversationFollowsFreshDecision(t *testing.T) {
 	store.mu.Unlock()
 }
 
-func TestTurnLoop_HMMToolExecutionBreaksConversationalPin(t *testing.T) {
+func TestTurnLoop_HMMToolExecutionStaysOnLateralWarmCacheWhenEVNegative(t *testing.T) {
 	store := newFakePinStore()
 	store.hasPin = true
 	store.pin = sessionpin.Pin{
@@ -412,8 +413,8 @@ func TestTurnLoop_HMMToolExecutionBreaksConversationalPin(t *testing.T) {
 	require.NoError(t, svc.ProxyMessages(ctx, []byte(pinTestBody), rec, httpReq))
 
 	assert.Equal(t, 1, fr.routeCalls, "main-loop HMM turn must ask for a fresh decision")
-	assert.Equal(t, "claude-sonnet-5", rec.Header().Get(proxy.HeaderRouterModel),
-		"a fresh HMM tool/explore execution decision must break a conversational pin")
+	assert.Equal(t, "claude-sonnet-4-5", rec.Header().Get(proxy.HeaderRouterModel),
+		"lateral HMM tool/explore decisions should not break a warm cache when EV is negative")
 
 	store.mu.Lock()
 	assertOnlyHMMHistoryUpserts(t, store)

--- a/internal/proxy/turnloop_test.go
+++ b/internal/proxy/turnloop_test.go
@@ -384,6 +384,42 @@ func TestTurnLoop_HMMHistoryMaxedOutExcludesServedModelBeforeRouting(t *testing.
 	store.mu.Unlock()
 }
 
+func TestTurnLoop_HMMExpiredHistoryMaxedOutStillExcludesServedModel(t *testing.T) {
+	store := newFakePinStore()
+	store.hasHMMHistory = true
+	// Expired history row (PinnedUntil in the past) that maxed out its output
+	// cap: the maxed model must still be excluded, matching the active-pin path.
+	store.hmmHistory = sessionpin.Pin{
+		Provider:         providers.ProviderAnthropic,
+		LastServedModel:  "claude-sonnet-5",
+		LastOutputTokens: 8192,
+		LastTurnEndedAt:  time.Now().Add(-time.Hour),
+		PinnedUntil:      time.Now().Add(-time.Minute),
+	}
+	fr := &fakeRouter{decision: router.Decision{
+		Provider: providers.ProviderAnthropic,
+		Model:    "claude-haiku-4-5",
+		Reason:   "hmm_policy(classifier 'Simple Tool Call Request')",
+		Metadata: &router.RoutingMetadata{
+			Strategy: string(router.StrategyHMM),
+			RouteID:  "route-1",
+		},
+	}}
+	svc := newPinSvc(fr, store)
+
+	ctx := authedCtx(uuid.New().String())
+	rec := httptest.NewRecorder()
+	httpReq := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(""))
+	require.NoError(t, svc.ProxyMessages(ctx, []byte(pinTestBody), rec, httpReq))
+
+	require.NotNil(t, fr.capturedReq)
+	assert.Contains(t, fr.capturedReq.ExcludedModels, "claude-sonnet-5",
+		"a maxed-out model must stay excluded even after the history row's TTL lapses")
+	store.mu.Lock()
+	assertOnlyHMMHistoryUpserts(t, store)
+	store.mu.Unlock()
+}
+
 func TestTurnLoop_HMMConversationFollowsFreshDecision(t *testing.T) {
 	store := newFakePinStore()
 	store.hasPin = true

--- a/internal/proxy/turnloop_test.go
+++ b/internal/proxy/turnloop_test.go
@@ -276,9 +276,12 @@ func TestTurnLoop_HMMToolResultCommunicationFollowsFreshDecision(t *testing.T) {
 	assert.Equal(t, 1, fr.routeCalls, "tool_result must ask HMM for a fresh communication decision")
 	assert.Equal(t, "claude-sonnet-4-5", rec.Header().Get(proxy.HeaderRouterModel),
 		"a completed tool result must not stay pinned to the tool-execution model")
+	store.mu.Lock()
+	assert.Empty(t, store.upserts, "fresh HMM decisions must not write session pins")
+	store.mu.Unlock()
 }
 
-func TestTurnLoop_HMMToolResultContinuesToolExecutionPin(t *testing.T) {
+func TestTurnLoop_HMMToolResultToolExecutionUsesFreshDecision(t *testing.T) {
 	store := newFakePinStore()
 	store.hasPin = true
 	store.pin = sessionpin.Pin{
@@ -304,11 +307,14 @@ func TestTurnLoop_HMMToolResultContinuesToolExecutionPin(t *testing.T) {
 	require.NoError(t, svc.ProxyMessages(ctx, []byte(toolResultPinnedBody), rec, httpReq))
 
 	assert.Equal(t, 1, fr.routeCalls, "tool_result still scores so HMM can decide whether execution continues")
-	assert.Equal(t, "claude-haiku-4-5", rec.Header().Get(proxy.HeaderRouterModel),
-		"ongoing tool execution keeps the existing execution pin")
+	assert.Equal(t, "claude-sonnet-4-5", rec.Header().Get(proxy.HeaderRouterModel),
+		"HMM tool execution must follow the fresh sidecar decision instead of an existing session pin")
+	store.mu.Lock()
+	assert.Empty(t, store.upserts, "fresh HMM decisions must not write session pins")
+	store.mu.Unlock()
 }
 
-func TestTurnLoop_HMMToolExecutionLockBeatsPlannerSwitch(t *testing.T) {
+func TestTurnLoop_HMMToolExecutionDoesNotServeExistingPin(t *testing.T) {
 	store := newFakePinStore()
 	store.hasPin = true
 	store.pin = sessionpin.Pin{
@@ -336,8 +342,11 @@ func TestTurnLoop_HMMToolExecutionLockBeatsPlannerSwitch(t *testing.T) {
 	require.NoError(t, svc.ProxyMessages(ctx, []byte(pinTestBody), rec, httpReq))
 
 	assert.Equal(t, 1, fr.routeCalls, "ongoing HMM execution still scores to see if execution continues")
-	assert.Equal(t, "claude-sonnet-5", rec.Header().Get(proxy.HeaderRouterModel),
-		"ongoing tool execution must keep its selected model instead of planner-switching mid-execution")
+	assert.Equal(t, "claude-haiku-4-5", rec.Header().Get(proxy.HeaderRouterModel),
+		"HMM tool execution must not keep an existing session pin")
+	store.mu.Lock()
+	assert.Empty(t, store.upserts, "fresh HMM decisions must not write session pins")
+	store.mu.Unlock()
 }
 
 func TestTurnLoop_HMMConversationFollowsFreshDecision(t *testing.T) {
@@ -370,6 +379,9 @@ func TestTurnLoop_HMMConversationFollowsFreshDecision(t *testing.T) {
 	assert.Equal(t, 1, fr.routeCalls, "HMM conversation turns must score fresh")
 	assert.Equal(t, "claude-sonnet-5", rec.Header().Get(proxy.HeaderRouterModel),
 		"HMM normal conversation routing must follow the fresh sidecar decision instead of EV-staying on the old pin")
+	store.mu.Lock()
+	assert.Empty(t, store.upserts, "fresh HMM decisions must not write session pins")
+	store.mu.Unlock()
 }
 
 func TestTurnLoop_HMMToolExecutionBreaksConversationalPin(t *testing.T) {
@@ -403,15 +415,12 @@ func TestTurnLoop_HMMToolExecutionBreaksConversationalPin(t *testing.T) {
 	assert.Equal(t, "claude-sonnet-5", rec.Header().Get(proxy.HeaderRouterModel),
 		"a fresh HMM tool/explore execution decision must break a conversational pin")
 
-	waitForUpsert(t, store)
-	require.NotEmpty(t, store.upserts)
-	last := store.upserts[len(store.upserts)-1]
-	assert.Equal(t, "claude-sonnet-5", last.Model)
-	assert.True(t, strings.HasPrefix(last.Reason, "hmm_policy:tool_execution"),
-		"the execution phase must be persisted so later tool-result routing can detect it")
+	store.mu.Lock()
+	assert.Empty(t, store.upserts, "fresh HMM decisions must not write session pins")
+	store.mu.Unlock()
 }
 
-func TestTurnLoop_HMMToolExecutionSameModelUpdatesPinReason(t *testing.T) {
+func TestTurnLoop_HMMToolExecutionSameModelDoesNotRewritePin(t *testing.T) {
 	store := newFakePinStore()
 	store.hasPin = true
 	store.pin = sessionpin.Pin{
@@ -441,12 +450,9 @@ func TestTurnLoop_HMMToolExecutionSameModelUpdatesPinReason(t *testing.T) {
 	assert.Equal(t, 1, fr.routeCalls, "main-loop HMM turn must ask for a fresh decision")
 	assert.Equal(t, "claude-sonnet-4-5", rec.Header().Get(proxy.HeaderRouterModel))
 
-	waitForUpsert(t, store)
-	require.NotEmpty(t, store.upserts)
-	last := store.upserts[len(store.upserts)-1]
-	assert.Equal(t, "claude-sonnet-4-5", last.Model)
-	assert.True(t, strings.HasPrefix(last.Reason, "hmm_policy:tool_execution"),
-		"same-model fresh execution decisions must still rewrite the pin phase")
+	store.mu.Lock()
+	assert.Empty(t, store.upserts, "fresh HMM decisions must not write session pins")
+	store.mu.Unlock()
 }
 
 // TestTurnLoop_ToolResultPinOnExcludedProviderFallsThroughToScorer verifies that a pin

--- a/internal/proxy/turnloop_test.go
+++ b/internal/proxy/turnloop_test.go
@@ -349,6 +349,41 @@ func TestTurnLoop_HMMToolExecutionStaysWhenWarmCacheEVBeatsCheapFresh(t *testing
 	store.mu.Unlock()
 }
 
+func TestTurnLoop_HMMHistoryMaxedOutExcludesServedModelBeforeRouting(t *testing.T) {
+	store := newFakePinStore()
+	store.hasHMMHistory = true
+	store.hmmHistory = sessionpin.Pin{
+		Provider:         providers.ProviderAnthropic,
+		LastServedModel:  "claude-sonnet-5",
+		LastOutputTokens: 8192,
+		LastTurnEndedAt:  time.Now().Add(-30 * time.Second),
+		PinnedUntil:      time.Now().Add(time.Hour),
+	}
+	fr := &fakeRouter{decision: router.Decision{
+		Provider: providers.ProviderAnthropic,
+		Model:    "claude-haiku-4-5",
+		Reason:   "hmm_policy(classifier 'Simple Tool Call Request')",
+		Metadata: &router.RoutingMetadata{
+			Strategy: string(router.StrategyHMM),
+			RouteID:  "route-1",
+		},
+	}}
+	svc := newPinSvc(fr, store)
+
+	ctx := authedCtx(uuid.New().String())
+	rec := httptest.NewRecorder()
+	httpReq := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(""))
+	require.NoError(t, svc.ProxyMessages(ctx, []byte(pinTestBody), rec, httpReq))
+
+	require.NotNil(t, fr.capturedReq)
+	assert.Contains(t, fr.capturedReq.ExcludedModels, "claude-sonnet-5",
+		"HMM history saturation must exclude the prior served model before sidecar routing")
+	assert.Equal(t, "claude-haiku-4-5", rec.Header().Get(proxy.HeaderRouterModel))
+	store.mu.Lock()
+	assertOnlyHMMHistoryUpserts(t, store)
+	store.mu.Unlock()
+}
+
 func TestTurnLoop_HMMConversationFollowsFreshDecision(t *testing.T) {
 	store := newFakePinStore()
 	store.hasPin = true


### PR DESCRIPTION
Stops HMM router decisions from writing or reusing active session pins, while preserving lightweight HMM history for switch detection and cache-aware stay decisions. Fresh HMM sidecar decisions now pass through the EV/cache cost gate before switching, explicit force-model pins remain unchanged, and the HMM expensive-upgrade confidence threshold is tunable via ROUTER_HMM_UPGRADE_CONFIDENCE_THRESHOLD.