### PR TITLE
fix: unique per-response tool_use ids (Kimi churn loop) + no-progress marker fix

### DIFF
--- a/internal/proxy/conformance_golden_test.go
+++ b/internal/proxy/conformance_golden_test.go
@@ -132,8 +132,11 @@ var synthToolID = regexp.MustCompile(`^call_[0-9a-f]{8}$`)
 // nonceSuffixedToolID matches an upstream-echoed tool-call id that
 // uniqueToolUseIDWithNonce suffixed with a per-response 12-hex-char nonce
 // (functions_Bash_0_<nonce>). The nonce is volatile per response, so redact
-// only the suffix and keep the readable upstream prefix in the golden.
-var nonceSuffixedToolID = regexp.MustCompile(`^(.*)_[0-9a-f]{12}$`)
+// only the suffix and keep the readable upstream prefix in the golden. The
+// prefix is anchored to a tool-call id shape (call_/toolu_/functions_/tc_…) so
+// an unrelated stable id that merely ends in _<12hex> is left untouched and its
+// real changes still show in the golden diff.
+var nonceSuffixedToolID = regexp.MustCompile(`^((?:call_|toolu_|tc_|functions?[._]).*)_[0-9a-f]{12}$`)
 
 // redactVolatile walks a decoded frame, replacing message ids and synthesized
 // tool-call ids with placeholders and dropping wire timestamps.

--- a/internal/proxy/conformance_golden_test.go
+++ b/internal/proxy/conformance_golden_test.go
@@ -129,6 +129,12 @@ func redactJSON(t *testing.T, data []byte) map[string]interface{} {
 // echoed ids like "call_abc" don't match this pattern and stay in the golden.
 var synthToolID = regexp.MustCompile(`^call_[0-9a-f]{8}$`)
 
+// nonceSuffixedToolID matches an upstream-echoed tool-call id that
+// uniqueToolUseIDWithNonce suffixed with a per-response 12-hex-char nonce
+// (functions_Bash_0_<nonce>). The nonce is volatile per response, so redact
+// only the suffix and keep the readable upstream prefix in the golden.
+var nonceSuffixedToolID = regexp.MustCompile(`^(.*)_[0-9a-f]{12}$`)
+
 // redactVolatile walks a decoded frame, replacing message ids and synthesized
 // tool-call ids with placeholders and dropping wire timestamps.
 func redactVolatile(v interface{}) {
@@ -146,9 +152,25 @@ func redactVolatile(v interface{}) {
 		}
 		delete(x, "created")
 		for k, val := range x {
-			if s, ok := val.(string); ok && synthToolID.MatchString(s) {
-				x[k] = "<tool_id>"
-				continue
+			if s, ok := val.(string); ok {
+				// Tool-use ids and their paired tool_use_id carry a per-response
+				// nonce suffix (uniqueToolUseIDWithNonce). Strip the volatile
+				// suffix first, then redact the prefix: a fully-synthetic prefix
+				// (Gemini's "call_<8hex>") is itself volatile and collapses to
+				// <tool_id>; an upstream-echoed prefix stays readable.
+				prefix := s
+				hasNonce := false
+				if m := nonceSuffixedToolID.FindStringSubmatch(s); m != nil {
+					prefix, hasNonce = m[1], true
+				}
+				if synthToolID.MatchString(prefix) {
+					x[k] = "<tool_id>"
+					continue
+				}
+				if hasNonce && (k == "id" || k == "tool_use_id") {
+					x[k] = prefix + "_<nonce>"
+					continue
+				}
 			}
 			redactVolatile(val)
 		}

--- a/internal/proxy/conformance_golden_test.go
+++ b/internal/proxy/conformance_golden_test.go
@@ -130,12 +130,9 @@ func redactJSON(t *testing.T, data []byte) map[string]interface{} {
 var synthToolID = regexp.MustCompile(`^call_[0-9a-f]{8}$`)
 
 // nonceSuffixedToolID matches an upstream-echoed tool-call id that
-// uniqueToolUseIDWithNonce suffixed with a per-response 12-hex-char nonce
-// (functions_Bash_0_<nonce>). The nonce is volatile per response, so redact
-// only the suffix and keep the readable upstream prefix in the golden. The
-// prefix is anchored to a tool-call id shape (call_/toolu_/functions_/tc_…) so
-// an unrelated stable id that merely ends in _<12hex> is left untouched and its
-// real changes still show in the golden diff.
+// uniqueToolUseIDWithNonce suffixed with a per-response 12-hex-char nonce.
+// Prefix is anchored to tool-call id shapes (call_/toolu_/functions_/tc_…) so
+// an unrelated stable id ending in _<12hex> is left untouched in goldens.
 var nonceSuffixedToolID = regexp.MustCompile(`^((?:call_|toolu_|tc_|functions?[._]).*)_[0-9a-f]{12}$`)
 
 // redactVolatile walks a decoded frame, replacing message ids and synthesized
@@ -156,11 +153,8 @@ func redactVolatile(v interface{}) {
 		delete(x, "created")
 		for k, val := range x {
 			if s, ok := val.(string); ok {
-				// Tool-use ids and their paired tool_use_id carry a per-response
-				// nonce suffix (uniqueToolUseIDWithNonce). Strip the volatile
-				// suffix first, then redact the prefix: a fully-synthetic prefix
-				// (Gemini's "call_<8hex>") is itself volatile and collapses to
-				// <tool_id>; an upstream-echoed prefix stays readable.
+				// Nonce suffix (uniqueToolUseIDWithNonce) is volatile; strip it,
+				// then redact a synthetic prefix or keep an upstream-echoed one.
 				prefix := s
 				hasNonce := false
 				if m := nonceSuffixedToolID.FindStringSubmatch(s); m != nil {

--- a/internal/proxy/no_progress.go
+++ b/internal/proxy/no_progress.go
@@ -67,24 +67,11 @@ func toolProgressMarker(env *translate.RequestEnvelope) string {
 // progress marker, the prompt prefix, and — only when there is no progress
 // marker — the message count.
 //
-// The prompt prefix alone is constant across a healthy agentic task (it's
-// just the user's typed task, tool results stripped), so it can't be the
-// sole key — every dispatch would collide. progressMarker is the main
-// guard: it advances on real progress and stays constant when stuck, so
-// only stuck loops accumulate matching fingerprints.
-//
-// messageCount is deliberately EXCLUDED whenever progressMarker is non-empty.
-// A stuck agentic session still appends real assistant/user messages each turn
-// (retries, router markers, empty-body continuations), so messageCount climbs
-// even while no tool progress is made — folding it into the hash makes every
-// turn's fingerprint distinct and silently defeats the detector. This was the
-// failure mode behind a Kimi-k2.x churn loop: the model re-issued the same
-// tool calls for 20+ turns with a frozen tool-progress marker, but the rising
-// messageCount kept the fingerprints unique so the loop was never caught. When
-// there IS a marker, it fully captures progress; messageCount adds only noise.
-// It stays in the hash for the tool-free case (empty marker), where it is the
-// sole fallback signal — Claude Code's Explore sub-agent holds it flat while
-// genuinely progressing, so the tool-free path still tolerates false matches.
+// progressMarker is the primary stuck signal; it stays frozen while the same
+// tool call re-issues, so matching fingerprints accumulate. messageCount is
+// excluded when a marker is present because retries/continuations still append
+// messages even when stuck — folding it in defeats detection. For the tool-free
+// case (empty marker) it remains the sole fallback signal.
 func computeNoProgressFingerprint(decision router.Decision, promptText string, messageCount int, progressMarker string) noProgressFingerprint {
 	p := promptText
 	if len(p) > noProgressPromptPrefix {

--- a/internal/proxy/no_progress.go
+++ b/internal/proxy/no_progress.go
@@ -63,23 +63,38 @@ func toolProgressMarker(env *translate.RequestEnvelope) string {
 	return strconv.Itoa(len(sigs)) + "\x00" + last.Name + "\x00" + last.InputHash
 }
 
-// computeNoProgressFingerprint hashes routed (model, provider), message
-// count, a tool-call progress marker, and the prompt prefix.
+// computeNoProgressFingerprint hashes routed (model, provider), a tool-call
+// progress marker, the prompt prefix, and — only when there is no progress
+// marker — the message count.
 //
 // The prompt prefix alone is constant across a healthy agentic task (it's
 // just the user's typed task, tool results stripped), so it can't be the
 // sole key — every dispatch would collide. progressMarker is the main
 // guard: it advances on real progress and stays constant when stuck, so
-// only stuck loops accumulate matching fingerprints. messageCount is a
-// secondary signal for tool-free loops, but not sufficient alone: Claude
-// Code's Explore sub-agent holds message count flat while genuinely
-// progressing.
+// only stuck loops accumulate matching fingerprints.
+//
+// messageCount is deliberately EXCLUDED whenever progressMarker is non-empty.
+// A stuck agentic session still appends real assistant/user messages each turn
+// (retries, router markers, empty-body continuations), so messageCount climbs
+// even while no tool progress is made — folding it into the hash makes every
+// turn's fingerprint distinct and silently defeats the detector. This was the
+// failure mode behind a Kimi-k2.x churn loop: the model re-issued the same
+// tool calls for 20+ turns with a frozen tool-progress marker, but the rising
+// messageCount kept the fingerprints unique so the loop was never caught. When
+// there IS a marker, it fully captures progress; messageCount adds only noise.
+// It stays in the hash for the tool-free case (empty marker), where it is the
+// sole fallback signal — Claude Code's Explore sub-agent holds it flat while
+// genuinely progressing, so the tool-free path still tolerates false matches.
 func computeNoProgressFingerprint(decision router.Decision, promptText string, messageCount int, progressMarker string) noProgressFingerprint {
 	p := promptText
 	if len(p) > noProgressPromptPrefix {
 		p = p[:noProgressPromptPrefix]
 	}
-	return sha256.Sum256([]byte(decision.Model + "\x00" + decision.Provider + "\x00" + strconv.Itoa(messageCount) + "\x00" + progressMarker + "\x00" + p))
+	countPart := ""
+	if progressMarker == "" {
+		countPart = strconv.Itoa(messageCount)
+	}
+	return sha256.Sum256([]byte(decision.Model + "\x00" + decision.Provider + "\x00" + countPart + "\x00" + progressMarker + "\x00" + p))
 }
 
 type fingerprintEntry struct {

--- a/internal/proxy/no_progress_internal_test.go
+++ b/internal/proxy/no_progress_internal_test.go
@@ -64,6 +64,52 @@ func TestComputeNoProgressFingerprint_DistinguishesToolProgress(t *testing.T) {
 	assert.NotEqual(t, a, b, "an advancing tool-progress marker must change the fingerprint")
 }
 
+func TestComputeNoProgressFingerprint_IgnoresMessageCountWhenMarkerPresent(t *testing.T) {
+	// Regression (Kimi-k2.x churn loop): when Claude Code drops the upstream's
+	// repeated tool calls, they never enter history, so the tool-progress marker
+	// FREEZES — the correct "stuck" signal. But the session still appends real
+	// assistant/user/router messages each turn, so message_count keeps rising.
+	// Folding message_count into the hash while a marker exists made every turn's
+	// fingerprint unique and silently defeated the detector. With a frozen marker
+	// the fingerprint must be identical regardless of message_count.
+	d := router.Decision{Model: "moonshotai/kimi-k2.7", Provider: "fireworks"}
+	marker := "57\x00Bash\x00frozen-hash"
+	a := computeNoProgressFingerprint(d, "create a PR from staging to prod", 90, marker)
+	b := computeNoProgressFingerprint(d, "create a PR from staging to prod", 109, marker)
+	assert.Equal(t, a, b, "a frozen tool-progress marker must collide regardless of rising message count")
+}
+
+func TestComputeNoProgressFingerprint_MessageCountStillCountsWithoutMarker(t *testing.T) {
+	// The tool-free path keeps message_count as its only fallback signal, so a
+	// growing transcript with no marker must still change the fingerprint.
+	d := router.Decision{Model: "gemini-3.1-pro-preview", Provider: "google"}
+	a := computeNoProgressFingerprint(d, "explore RSVP files", 10, "")
+	b := computeNoProgressFingerprint(d, "explore RSVP files", 12, "")
+	assert.NotEqual(t, a, b, "without a marker, message_count must still distinguish turns")
+}
+
+func TestNoProgressTracker_TripsOnFrozenMarkerDespiteRisingMessageCount(t *testing.T) {
+	// End-to-end: the Kimi churn loop. Frozen tool-progress marker (dropped
+	// duplicate-id calls never advance it) plus a message_count that climbs each
+	// turn must now trip the detector at the threshold, where before the rising
+	// count kept every fingerprint unique and it never fired.
+	tr := newNoProgressTracker()
+	key := sessionKeyFromString("session-kimi-churn")
+	install := uuid.New()
+	d := router.Decision{Model: "moonshotai/kimi-k2.7", Provider: "fireworks"}
+	now := time.Now()
+	marker := "57\x00Bash\x00frozen-hash"
+
+	var looped bool
+	var count int
+	for i := 0; i < noProgressMatchThreshold; i++ {
+		fp := computeNoProgressFingerprint(d, "create a PR from staging to prod", 90+3*i, marker)
+		looped, count = tr.recordAndDetect(key, install, "high", fp, now)
+	}
+	assert.True(t, looped, "a frozen-marker loop with rising message count must trip the detector")
+	assert.Equal(t, noProgressMatchThreshold, count)
+}
+
 func TestNoProgressTracker_DoesNotTripWhenMessageCountGrows(t *testing.T) {
 	// Regression: a fast tool-call loop can exceed the dispatch threshold for
 	// one (model, provider) while the prompt prefix stays constant, but must

--- a/internal/proxy/no_progress_internal_test.go
+++ b/internal/proxy/no_progress_internal_test.go
@@ -65,13 +65,9 @@ func TestComputeNoProgressFingerprint_DistinguishesToolProgress(t *testing.T) {
 }
 
 func TestComputeNoProgressFingerprint_IgnoresMessageCountWhenMarkerPresent(t *testing.T) {
-	// Regression (Kimi-k2.x churn loop): when Claude Code drops the upstream's
-	// repeated tool calls, they never enter history, so the tool-progress marker
-	// FREEZES — the correct "stuck" signal. But the session still appends real
-	// assistant/user/router messages each turn, so message_count keeps rising.
-	// Folding message_count into the hash while a marker exists made every turn's
-	// fingerprint unique and silently defeated the detector. With a frozen marker
-	// the fingerprint must be identical regardless of message_count.
+	// Regression: a frozen tool-progress marker combined with a rising
+	// message_count must produce identical fingerprints (marker excluded from
+	// hash when present, so count noise doesn't defeat detection).
 	d := router.Decision{Model: "moonshotai/kimi-k2.7", Provider: "fireworks"}
 	marker := "57\x00Bash\x00frozen-hash"
 	a := computeNoProgressFingerprint(d, "create a PR from staging to prod", 90, marker)

--- a/internal/proxy/no_progress_internal_test.go
+++ b/internal/proxy/no_progress_internal_test.go
@@ -104,12 +104,8 @@ func TestNoProgressTracker_TripsOnFrozenMarkerDespiteRisingMessageCount(t *testi
 	assert.Equal(t, noProgressMatchThreshold, count)
 }
 
-// The no-progress detector is gated to tool-bearing turns (a tool_use in
-// history or a tool_result this turn). A run of healthy text-only assistant
-// turns in a long session freezes both the marker and the (capped) prompt
-// prefix, so without this gate they would collide and falsely trip the break.
-// This mirrors the ProxyMessages gate: toolBearingTurn = inboundToolCallCount
-// > 0 || inboundLastUser.HasToolResult.
+// Gate: the no-progress detector only runs on tool-bearing turns so a
+// frozen marker + frozen prompt prefix can't trip it on healthy text-only turns.
 func TestNoProgressGate_TextOnlyTurnIsNotToolBearing(t *testing.T) {
 	textOnly := []byte(`{"model":"kimi","messages":[` +
 		`{"role":"user","content":"explain the design"},` +

--- a/internal/proxy/no_progress_internal_test.go
+++ b/internal/proxy/no_progress_internal_test.go
@@ -85,10 +85,8 @@ func TestComputeNoProgressFingerprint_MessageCountStillCountsWithoutMarker(t *te
 }
 
 func TestNoProgressTracker_TripsOnFrozenMarkerDespiteRisingMessageCount(t *testing.T) {
-	// End-to-end: the Kimi churn loop. Frozen tool-progress marker (dropped
-	// duplicate-id calls never advance it) plus a message_count that climbs each
-	// turn must now trip the detector at the threshold, where before the rising
-	// count kept every fingerprint unique and it never fired.
+	// Regression: frozen tool-progress marker + rising message_count must
+	// still trip the detector (count excluded from hash when marker present).
 	tr := newNoProgressTracker()
 	key := sessionKeyFromString("session-kimi-churn")
 	install := uuid.New()

--- a/internal/proxy/no_progress_internal_test.go
+++ b/internal/proxy/no_progress_internal_test.go
@@ -104,6 +104,46 @@ func TestNoProgressTracker_TripsOnFrozenMarkerDespiteRisingMessageCount(t *testi
 	assert.Equal(t, noProgressMatchThreshold, count)
 }
 
+// The no-progress detector is gated to tool-bearing turns (a tool_use in
+// history or a tool_result this turn). A run of healthy text-only assistant
+// turns in a long session freezes both the marker and the (capped) prompt
+// prefix, so without this gate they would collide and falsely trip the break.
+// This mirrors the ProxyMessages gate: toolBearingTurn = inboundToolCallCount
+// > 0 || inboundLastUser.HasToolResult.
+func TestNoProgressGate_TextOnlyTurnIsNotToolBearing(t *testing.T) {
+	textOnly := []byte(`{"model":"kimi","messages":[` +
+		`{"role":"user","content":"explain the design"},` +
+		`{"role":"assistant","content":[{"type":"text","text":"Here is the design ..."}]}` +
+		`]}`)
+	env, err := translate.ParseAnthropic(textOnly)
+	require.NoError(t, err)
+	toolBearing := len(env.AssistantToolCallSignatures()) > 0 || env.LastUserMessage().HasToolResult
+	assert.False(t, toolBearing, "a text-only turn must not feed the no-progress detector")
+}
+
+func TestNoProgressGate_ToolTurnsAreToolBearing(t *testing.T) {
+	// tool_use in history (the frozen-marker Kimi case).
+	withToolUse := []byte(`{"model":"kimi","messages":[` +
+		`{"role":"user","content":"create a PR"},` +
+		`{"role":"assistant","content":[{"type":"tool_use","id":"1","name":"Bash","input":{"command":"gh pr create"}}]}` +
+		`]}`)
+	env1, err := translate.ParseAnthropic(withToolUse)
+	require.NoError(t, err)
+	assert.True(t, len(env1.AssistantToolCallSignatures()) > 0 || env1.LastUserMessage().HasToolResult,
+		"a turn with a tool_use in history must feed the detector")
+
+	// tool_result this turn (agent just ran a tool).
+	withToolResult := []byte(`{"model":"kimi","messages":[` +
+		`{"role":"user","content":"create a PR"},` +
+		`{"role":"assistant","content":[{"type":"tool_use","id":"1","name":"Bash","input":{"command":"gh pr create"}}]},` +
+		`{"role":"user","content":[{"type":"tool_result","tool_use_id":"1","content":"done"}]}` +
+		`]}`)
+	env2, err := translate.ParseAnthropic(withToolResult)
+	require.NoError(t, err)
+	assert.True(t, len(env2.AssistantToolCallSignatures()) > 0 || env2.LastUserMessage().HasToolResult,
+		"a tool_result turn must feed the detector")
+}
+
 func TestNoProgressTracker_DoesNotTripWhenMessageCountGrows(t *testing.T) {
 	// Regression: a fast tool-call loop can exceed the dispatch threshold for
 	// one (model, provider) while the prompt prefix stays constant, but must

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -2009,21 +2009,14 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 	routeMs := time.Since(routeStart).Milliseconds()
 	s.logPlannerOutcome(ctx, routeRes)
 
-	// Cross-envelope no-progress detector: if this session dispatches the same
-	// (decision, tool-progress, prompt-prefix) fingerprint repeatedly within a
-	// window, the agent is stuck (sub-agent spawn loop, or a re-issued identical
-	// call) — break the pin and emit a synthetic stop. The tool-progress marker
-	// is the key guard: a genuinely progressing agent appends a new tool call
-	// each turn, so it never false-positives even when top-level message count
-	// stays flat (as with Explore sub-agents).
+	// Cross-envelope no-progress detector: repeated identical dispatch
+	// fingerprints within a window mean the agent is stuck (sub-agent spawn
+	// loop, or a re-issued identical call) — break the pin and emit a synthetic
+	// stop.
 	//
-	// Gated to turns that carry tool activity — a tool_use in history
-	// (inboundToolCallCount > 0) or a tool_result this turn. The fingerprint
-	// drops message_count when a marker is present, so in a long session
-	// (transcript past the prompt-prefix cap) a frozen marker + frozen prefix
-	// would otherwise let a run of healthy TEXT-ONLY assistant turns collide and
-	// falsely trip the break. Tool-bearing turns are the only ones a stuck
-	// re-issue loop produces, so gating here costs no real detection.
+	// Gated to tool-bearing turns (tool_use in history or tool_result this turn)
+	// because a frozen marker + frozen prompt prefix collide on healthy text-only
+	// turns, causing false trips; only re-issue loops produce tool-bearing turns.
 	toolBearingTurn := inboundToolCallCount > 0 || inboundLastUser.HasToolResult
 	if toolBearingTurn && s.noProgress != nil {
 		fp := computeNoProgressFingerprint(decision, promptText, feats.MessageCount, toolProgressMarker(env))

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -2009,14 +2009,10 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 	routeMs := time.Since(routeStart).Milliseconds()
 	s.logPlannerOutcome(ctx, routeRes)
 
-	// Cross-envelope no-progress detector: repeated identical dispatch
-	// fingerprints within a window mean the agent is stuck (sub-agent spawn
-	// loop, or a re-issued identical call) — break the pin and emit a synthetic
-	// stop.
-	//
-	// Gated to tool-bearing turns (tool_use in history or tool_result this turn)
-	// because a frozen marker + frozen prompt prefix collide on healthy text-only
-	// turns, causing false trips; only re-issue loops produce tool-bearing turns.
+	// Cross-envelope no-progress detector: repeated identical fingerprints in a
+	// window mean the agent is stuck — break the pin and emit a synthetic stop.
+	// Gated to tool-bearing turns so a frozen marker + frozen prompt prefix
+	// can't collide on healthy text-only turns.
 	toolBearingTurn := inboundToolCallCount > 0 || inboundLastUser.HasToolResult
 	if toolBearingTurn && s.noProgress != nil {
 		fp := computeNoProgressFingerprint(decision, promptText, feats.MessageCount, toolProgressMarker(env))

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -2010,13 +2010,23 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 	s.logPlannerOutcome(ctx, routeRes)
 
 	// Cross-envelope no-progress detector: if this session dispatches the same
-	// (decision, message_count, tool-progress, prompt-prefix) fingerprint
-	// repeatedly within a window, the agent is stuck (sub-agent spawn loop, or
-	// a re-issued identical call) — break the pin and emit a synthetic stop.
-	// The tool-progress marker is the key guard: a genuinely progressing agent
-	// appends a new tool call each turn, so it never false-positives even when
-	// top-level message count stays flat (as with Explore sub-agents).
-	if fp := computeNoProgressFingerprint(decision, promptText, feats.MessageCount, toolProgressMarker(env)); s.noProgress != nil {
+	// (decision, tool-progress, prompt-prefix) fingerprint repeatedly within a
+	// window, the agent is stuck (sub-agent spawn loop, or a re-issued identical
+	// call) — break the pin and emit a synthetic stop. The tool-progress marker
+	// is the key guard: a genuinely progressing agent appends a new tool call
+	// each turn, so it never false-positives even when top-level message count
+	// stays flat (as with Explore sub-agents).
+	//
+	// Gated to turns that carry tool activity — a tool_use in history
+	// (inboundToolCallCount > 0) or a tool_result this turn. The fingerprint
+	// drops message_count when a marker is present, so in a long session
+	// (transcript past the prompt-prefix cap) a frozen marker + frozen prefix
+	// would otherwise let a run of healthy TEXT-ONLY assistant turns collide and
+	// falsely trip the break. Tool-bearing turns are the only ones a stuck
+	// re-issue loop produces, so gating here costs no real detection.
+	toolBearingTurn := inboundToolCallCount > 0 || inboundLastUser.HasToolResult
+	if toolBearingTurn && s.noProgress != nil {
+		fp := computeNoProgressFingerprint(decision, promptText, feats.MessageCount, toolProgressMarker(env))
 		role := roleForTier(catalog.TierFor(feats.Model))
 		if looped, count := s.noProgress.recordAndDetect(routeRes.SessionKey, installationID, role, fp, time.Now()); looped {
 			return s.handleNoProgressBreak(ctx, w, env, count, installationID, routeRes.SessionKey, role, decision.Model, decision.Provider, feats.Tokens)

--- a/internal/proxy/testdata/conformance/openai_chat/invalid_toolcall_args.golden
+++ b/internal/proxy/testdata/conformance/openai_chat/invalid_toolcall_args.golden
@@ -22,7 +22,7 @@
     "event": "content_block_start",
     "data": {
       "content_block": {
-        "id": "call_bad",
+        "id": "call_bad_<nonce>",
         "input": {},
         "name": "Read",
         "type": "tool_use"

--- a/internal/proxy/testdata/conformance/openai_chat/toolcall.golden
+++ b/internal/proxy/testdata/conformance/openai_chat/toolcall.golden
@@ -22,7 +22,7 @@
     "event": "content_block_start",
     "data": {
       "content_block": {
-        "id": "call_abc",
+        "id": "call_abc_<nonce>",
         "input": {},
         "name": "get_weather",
         "type": "tool_use"

--- a/internal/proxy/testdata/conformance/openai_chat/toolcall_repaired_args.golden
+++ b/internal/proxy/testdata/conformance/openai_chat/toolcall_repaired_args.golden
@@ -22,7 +22,7 @@
     "event": "content_block_start",
     "data": {
       "content_block": {
-        "id": "call_fix",
+        "id": "call_fix_<nonce>",
         "input": {},
         "name": "Read",
         "type": "tool_use"

--- a/internal/translate/crossformat_response_test.go
+++ b/internal/translate/crossformat_response_test.go
@@ -350,9 +350,7 @@ func TestOpenAIToAnthropicResponse_ToolUse(t *testing.T) {
 	require.Len(t, blocks, 1)
 	blk, _ := blocks[0].(map[string]any)
 	assert.Equal(t, "tool_use", blk["type"])
-	// The upstream id is suffixed with a per-response nonce so deterministic
-	// upstream ids (Kimi's "functions.Bash:0") don't repeat across turns and
-	// get dropped by Claude Code's id dedupe. See uniqueToolUseIDWithNonce.
+	// Upstream id gets a per-response nonce suffix (uniqueToolUseIDWithNonce).
 	id, _ := blk["id"].(string)
 	assert.Regexp(t, `^call_r1_[0-9a-f]{12}$`, id, "tool_use id must be the upstream id plus a per-response nonce")
 	assert.Equal(t, "Read", blk["name"])

--- a/internal/translate/crossformat_response_test.go
+++ b/internal/translate/crossformat_response_test.go
@@ -350,7 +350,11 @@ func TestOpenAIToAnthropicResponse_ToolUse(t *testing.T) {
 	require.Len(t, blocks, 1)
 	blk, _ := blocks[0].(map[string]any)
 	assert.Equal(t, "tool_use", blk["type"])
-	assert.Equal(t, "call_r1", blk["id"])
+	// The upstream id is suffixed with a per-response nonce so deterministic
+	// upstream ids (Kimi's "functions.Bash:0") don't repeat across turns and
+	// get dropped by Claude Code's id dedupe. See uniqueToolUseIDWithNonce.
+	id, _ := blk["id"].(string)
+	assert.Regexp(t, `^call_r1_[0-9a-f]{12}$`, id, "tool_use id must be the upstream id plus a per-response nonce")
 	assert.Equal(t, "Read", blk["name"])
 
 	input, _ := blk["input"].(map[string]any)
@@ -392,7 +396,8 @@ func TestOpenAIToAnthropicResponse_MixedTextAndToolCalls(t *testing.T) {
 
 	toolBlk, _ := blocks[1].(map[string]any)
 	assert.Equal(t, "tool_use", toolBlk["type"])
-	assert.Equal(t, "call_m1", toolBlk["id"])
+	id, _ := toolBlk["id"].(string)
+	assert.Regexp(t, `^call_m1_[0-9a-f]{12}$`, id, "tool_use id must be the upstream id plus a per-response nonce")
 }
 
 func TestOpenAIToAnthropicResponse_StopReasonMapping(t *testing.T) {

--- a/internal/translate/emit_anthropic.go
+++ b/internal/translate/emit_anthropic.go
@@ -813,16 +813,11 @@ func sanitizeToolUseID(id string) string {
 	return string(b)
 }
 
-// uniqueToolUseIDWithNonce sanitizes id and appends a per-response nonce so the
-// resulting tool_use.id is unique across turns. Deterministic OpenAI-compat
-// upstreams (Kimi-k2.x on Fireworks, some vLLM/SGLang hosts) emit a stable id
-// like "functions.Bash:0" on every turn; sanitizeToolUseID normalizes the
-// characters but not the value, so the id repeats. Claude Code dedupes tool_use
-// blocks by id and silently drops a repeat, so the model's call is never
-// executed and the session churns re-issuing it. The nonce is generated once
-// per translated response and shared by every block in it, so ids stay stable
-// within a turn but differ between turns. Idempotent for a value already
-// carrying this nonce. Empty ids get a synthetic router-owned id.
+// uniqueToolUseIDWithNonce sanitizes id and appends a per-response nonce so
+// tool_use.id is unique across turns. Deterministic upstreams (Kimi-k2.x,
+// some vLLM/SGLang hosts) reuse a stable id every turn; Claude Code dedupes
+// by id and silently drops repeats, stalling the session. Nonce shared per
+// response so ids pair within a turn. Idempotent; empty id gets synthetic one.
 func uniqueToolUseIDWithNonce(id, nonce string) string {
 	if nonce == "" {
 		return sanitizeToolUseID(id)

--- a/internal/translate/emit_anthropic.go
+++ b/internal/translate/emit_anthropic.go
@@ -812,3 +812,27 @@ func sanitizeToolUseID(id string) string {
 	}
 	return string(b)
 }
+
+// uniqueToolUseIDWithNonce sanitizes id and appends a per-response nonce so the
+// resulting tool_use.id is unique across turns. Deterministic OpenAI-compat
+// upstreams (Kimi-k2.x on Fireworks, some vLLM/SGLang hosts) emit a stable id
+// like "functions.Bash:0" on every turn; sanitizeToolUseID normalizes the
+// characters but not the value, so the id repeats. Claude Code dedupes tool_use
+// blocks by id and silently drops a repeat, so the model's call is never
+// executed and the session churns re-issuing it. The nonce is generated once
+// per translated response and shared by every block in it, so ids stay stable
+// within a turn but differ between turns. Idempotent for a value already
+// carrying this nonce. Empty ids get a synthetic router-owned id.
+func uniqueToolUseIDWithNonce(id, nonce string) string {
+	if nonce == "" {
+		return sanitizeToolUseID(id)
+	}
+	clean := sanitizeToolUseID(id)
+	if clean == "" {
+		return "toolu_router_" + nonce
+	}
+	if strings.HasSuffix(clean, "_"+nonce) {
+		return clean
+	}
+	return clean + "_" + nonce
+}

--- a/internal/translate/stream.go
+++ b/internal/translate/stream.go
@@ -456,6 +456,17 @@ type AnthropicSSETranslator struct {
 	// Anthropic `error` event instead.
 	upstreamErrorStatus int
 	upstreamErrorBody   strings.Builder
+
+	// toolIDNonce is a per-response suffix appended to every translated
+	// tool_use.id (see uniqueToolUseID). Deterministic upstreams (Kimi-k2.x on
+	// Fireworks, some vLLM/SGLang hosts) emit stable ids like "functions.Bash:0"
+	// on every turn; sanitizeToolUseID normalizes the characters but not the
+	// value, so the id repeats across turns. Claude Code dedupes tool_use blocks
+	// by id and silently drops a repeat, so the model's call is never executed,
+	// its result never returns, and the session churns re-issuing the same call.
+	// A nonce unique to this response makes each turn's ids collision-free.
+	// Lazily seeded on first use so it shares message_start's randomness budget.
+	toolIDNonce string
 }
 
 // upstreamErrorBodyCap bounds how much of an upstream error body is retained
@@ -1354,11 +1365,25 @@ func (t *AnthropicSSETranslator) emitContentBlockStartTool(index int, id, name, 
 	t.bw.WriteString("event: content_block_start\ndata: {\"type\":\"content_block_start\",\"index\":")
 	sse.WriteJSONInt(t.bw, int64(index))
 	t.bw.WriteString(",\"content_block\":{\"type\":\"tool_use\",\"id\":")
-	sse.WriteJSONString(t.bw, embedSignatureInID(sanitizeToolUseID(id), sig))
+	sse.WriteJSONString(t.bw, embedSignatureInID(t.uniqueToolUseID(id), sig))
 	t.bw.WriteString(",\"name\":")
 	sse.WriteJSONString(t.bw, name)
 	t.bw.WriteString(",\"input\":{}}}\n\n")
 	return t.flushEvent()
+}
+
+// uniqueToolUseID sanitizes id and appends this response's nonce so the
+// resulting tool_use.id is unique across turns (see uniqueToolUseIDWithNonce
+// and the toolIDNonce field for the full rationale). The nonce is a short
+// per-response random suffix, seeded once on first use and reused for every
+// block in the response so ids stay stable within the turn. Kept short (12 hex
+// chars) so a re-route to OpenAI rarely trips clampOpenAIToolCallID's 64-char
+// hash fallback.
+func (t *AnthropicSSETranslator) uniqueToolUseID(id string) string {
+	if t.toolIDNonce == "" {
+		t.toolIDNonce = randomHex(6)
+	}
+	return uniqueToolUseIDWithNonce(id, t.toolIDNonce)
 }
 
 func (t *AnthropicSSETranslator) emitContentBlockStartThinking(index int) error {

--- a/internal/translate/stream.go
+++ b/internal/translate/stream.go
@@ -458,14 +458,8 @@ type AnthropicSSETranslator struct {
 	upstreamErrorBody   strings.Builder
 
 	// toolIDNonce is a per-response suffix appended to every translated
-	// tool_use.id (see uniqueToolUseID). Deterministic upstreams (Kimi-k2.x on
-	// Fireworks, some vLLM/SGLang hosts) emit stable ids like "functions.Bash:0"
-	// on every turn; sanitizeToolUseID normalizes the characters but not the
-	// value, so the id repeats across turns. Claude Code dedupes tool_use blocks
-	// by id and silently drops a repeat, so the model's call is never executed,
-	// its result never returns, and the session churns re-issuing the same call.
-	// A nonce unique to this response makes each turn's ids collision-free.
-	// Lazily seeded on first use so it shares message_start's randomness budget.
+	// tool_use.id so deterministic upstreams don't repeat ids across turns
+	// (see uniqueToolUseIDWithNonce). Lazily seeded on first use.
 	toolIDNonce string
 }
 
@@ -1372,13 +1366,9 @@ func (t *AnthropicSSETranslator) emitContentBlockStartTool(index int, id, name, 
 	return t.flushEvent()
 }
 
-// uniqueToolUseID sanitizes id and appends this response's nonce so the
-// resulting tool_use.id is unique across turns (see uniqueToolUseIDWithNonce
-// and the toolIDNonce field for the full rationale). The nonce is a short
-// per-response random suffix, seeded once on first use and reused for every
-// block in the response so ids stay stable within the turn. Kept short (12 hex
-// chars) so a re-route to OpenAI rarely trips clampOpenAIToolCallID's 64-char
-// hash fallback.
+// uniqueToolUseID wraps uniqueToolUseIDWithNonce with this response's nonce,
+// seeding it once on first use so all blocks in the response share one nonce.
+// Kept short (12 hex chars) to stay under clampOpenAIToolCallID's 64-char limit.
 func (t *AnthropicSSETranslator) uniqueToolUseID(id string) string {
 	if t.toolIDNonce == "" {
 		t.toolIDNonce = randomHex(6)

--- a/internal/translate/stream_tool_use_id_test.go
+++ b/internal/translate/stream_tool_use_id_test.go
@@ -66,10 +66,8 @@ func streamedToolUseIDs(out string) []string {
 	return ids
 }
 
-// Regression: deterministic upstreams (Kimi-k2.x on Fireworks) emit the same
-// tool_call id every turn; after sanitization the id repeated. Claude Code
-// dedupes by id and drops repeats, stalling the session. Each translated
-// response must yield a distinct tool_use.id even for byte-identical upstream ids.
+// Regression: deterministic upstreams reuse a stable tool_call id every turn;
+// each translated response must yield a distinct tool_use.id.
 func TestAnthropicSSETranslator_StreamedToolUseIDUniqueAcrossResponses(t *testing.T) {
 	feedOnce := func() string {
 		rec := httptest.NewRecorder()

--- a/internal/translate/stream_tool_use_id_test.go
+++ b/internal/translate/stream_tool_use_id_test.go
@@ -49,3 +49,74 @@ func TestAnthropicSSETranslator_SanitizesStreamedToolUseID(t *testing.T) {
 	}
 	assert.True(t, sawToolUse, "expected a tool_use content_block_start event")
 }
+
+// streamedToolUseIDs returns every tool_use.id from an Anthropic SSE body.
+func streamedToolUseIDs(out string) []string {
+	var ids []string
+	for _, line := range strings.Split(out, "\n") {
+		const p = "data: "
+		if !strings.HasPrefix(line, p) {
+			continue
+		}
+		block := gjson.Get(line[len(p):], "content_block")
+		if block.Get("type").String() == "tool_use" {
+			ids = append(ids, block.Get("id").String())
+		}
+	}
+	return ids
+}
+
+// Regression (Kimi-k2.x churn loop): deterministic OpenAI-compat upstreams
+// (Kimi on Fireworks) emit the SAME tool_call id — e.g. "functions.Bash:0" —
+// on every turn. sanitizeToolUseID normalizes the characters but not the value,
+// so the id "functions_Bash_0" repeated across turns. Claude Code dedupes
+// tool_use blocks by id and silently drops a repeat, so the model's call is
+// never executed, its result never returns, and the session churns re-issuing
+// the same call (58 Kimi turns, ~$3, no progress in one observed session).
+// Each translated response must therefore yield a distinct tool_use.id even
+// when the upstream id is byte-identical.
+func TestAnthropicSSETranslator_StreamedToolUseIDUniqueAcrossResponses(t *testing.T) {
+	feedOnce := func() string {
+		rec := httptest.NewRecorder()
+		w := translate.NewAnthropicSSETranslator(rec, "moonshotai/kimi-k2.7", nil)
+		require.NoError(t, w.Prelude(true))
+		feedChat(t, w,
+			`{"choices":[{"delta":{"tool_calls":[{"index":0,"id":"functions.Bash:0","function":{"name":"Bash","arguments":""}}]},"finish_reason":null}]}`,
+			`{"choices":[{"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{}"}}]},"finish_reason":"tool_calls"}]}`,
+		)
+		ids := streamedToolUseIDs(rec.Body.String())
+		require.Len(t, ids, 1)
+		return ids[0]
+	}
+
+	first := feedOnce()
+	second := feedOnce()
+
+	// Both must be sanitized (no dots/colons) and both must derive from the
+	// upstream id, but the per-response nonce must make them differ.
+	assert.Regexp(t, `^functions_Bash_0_[0-9a-f]{12}$`, first)
+	assert.Regexp(t, `^functions_Bash_0_[0-9a-f]{12}$`, second)
+	assert.NotEqual(t, first, second, "identical upstream ids must translate to distinct tool_use ids across responses")
+}
+
+// Within a single response, all blocks share one nonce so a tool_use.id and
+// its later tool_result.tool_use_id (which the client echoes back) still pair,
+// and distinct upstream ids stay distinct.
+func TestAnthropicSSETranslator_StreamedToolUseIDStableWithinResponse(t *testing.T) {
+	rec := httptest.NewRecorder()
+	w := translate.NewAnthropicSSETranslator(rec, "moonshotai/kimi-k2.7", nil)
+	require.NoError(t, w.Prelude(true))
+	feedChat(t, w,
+		`{"choices":[{"delta":{"tool_calls":[{"index":0,"id":"functions.Bash:0","function":{"name":"Bash","arguments":"{}"}}]},"finish_reason":null}]}`,
+		`{"choices":[{"delta":{"tool_calls":[{"index":1,"id":"functions.Read:1","function":{"name":"Read","arguments":"{}"}}]},"finish_reason":null}]}`,
+		`{"choices":[{"delta":{},"finish_reason":"tool_calls"}]}`,
+	)
+	ids := streamedToolUseIDs(rec.Body.String())
+	require.Len(t, ids, 2)
+	assert.Regexp(t, `^functions_Bash_0_[0-9a-f]{12}$`, ids[0])
+	assert.Regexp(t, `^functions_Read_1_[0-9a-f]{12}$`, ids[1])
+	// Same response → same nonce suffix on both.
+	suffix := func(id string) string { return id[strings.LastIndex(id, "_")+1:] }
+	assert.Equal(t, suffix(ids[0]), suffix(ids[1]), "all tool_use ids in one response share the response nonce")
+	assert.NotEqual(t, ids[0], ids[1], "distinct upstream ids stay distinct")
+}

--- a/internal/translate/stream_tool_use_id_test.go
+++ b/internal/translate/stream_tool_use_id_test.go
@@ -66,15 +66,10 @@ func streamedToolUseIDs(out string) []string {
 	return ids
 }
 
-// Regression (Kimi-k2.x churn loop): deterministic OpenAI-compat upstreams
-// (Kimi on Fireworks) emit the SAME tool_call id — e.g. "functions.Bash:0" —
-// on every turn. sanitizeToolUseID normalizes the characters but not the value,
-// so the id "functions_Bash_0" repeated across turns. Claude Code dedupes
-// tool_use blocks by id and silently drops a repeat, so the model's call is
-// never executed, its result never returns, and the session churns re-issuing
-// the same call (58 Kimi turns, ~$3, no progress in one observed session).
-// Each translated response must therefore yield a distinct tool_use.id even
-// when the upstream id is byte-identical.
+// Regression: deterministic upstreams (Kimi-k2.x on Fireworks) emit the same
+// tool_call id every turn; after sanitization the id repeated. Claude Code
+// dedupes by id and drops repeats, stalling the session. Each translated
+// response must yield a distinct tool_use.id even for byte-identical upstream ids.
 func TestAnthropicSSETranslator_StreamedToolUseIDUniqueAcrossResponses(t *testing.T) {
 	feedOnce := func() string {
 		rec := httptest.NewRecorder()

--- a/internal/translate/translate.go
+++ b/internal/translate/translate.go
@@ -182,6 +182,11 @@ func openAIToAnthropicResponse(body []byte, requestModel string, toolValidator *
 		// by message id, so a constant placeholder undercounts tokens/cost.
 		id = "msg_translated_" + randomHex(8)
 	}
+	// Per-response nonce appended to every tool_use.id (see uniqueToolUseID on
+	// the streaming translator for the full rationale): deterministic upstreams
+	// (Kimi-k2.x on Fireworks) reuse a stable id like "functions.Bash:0" every
+	// turn, which Claude Code dedupes and drops, stalling the session.
+	toolIDNonce := randomHex(6)
 	model := gjson.GetBytes(body, "model").String()
 	if model == "" {
 		model = requestModel
@@ -213,7 +218,7 @@ func openAIToAnthropicResponse(body []byte, requestModel string, toolValidator *
 	jw.Key("model")
 	jw.Str(model)
 	jw.Key("content")
-	issues := writeAnthropicContentFromOpenAI(jw, message, toolValidator, thinkTagReasoning, escapeNormalize)
+	issues := writeAnthropicContentFromOpenAI(jw, message, toolValidator, thinkTagReasoning, escapeNormalize, toolIDNonce)
 	jw.Key("stop_reason")
 	jw.Str(openAIFinishToAnthropicStopReason(finishReason))
 	jw.Key("stop_sequence")
@@ -233,7 +238,7 @@ func writeAnthropicThinkingBlock(jw *jsonWriter, thinking string) {
 	jw.EndObj()
 }
 
-func writeAnthropicContentFromOpenAI(jw *jsonWriter, message gjson.Result, toolValidator *toolcheck.Validator, thinkTagReasoning, escapeNormalize bool) (issues []toolcheck.Issue) {
+func writeAnthropicContentFromOpenAI(jw *jsonWriter, message gjson.Result, toolValidator *toolcheck.Validator, thinkTagReasoning, escapeNormalize bool, toolIDNonce string) (issues []toolcheck.Issue) {
 	jw.Arr()
 	reasoning := message.Get("reasoning_content").String()
 	if reasoning == "" {
@@ -300,7 +305,7 @@ func writeAnthropicContentFromOpenAI(jw *jsonWriter, message gjson.Result, toolV
 		jw.Key("type")
 		jw.Str("tool_use")
 		jw.Key("id")
-		jw.Str(id)
+		jw.Str(uniqueToolUseIDWithNonce(id, toolIDNonce))
 		jw.Key("name")
 		jw.Str(name)
 		jw.Key("input")

--- a/internal/translate/translate.go
+++ b/internal/translate/translate.go
@@ -182,10 +182,8 @@ func openAIToAnthropicResponse(body []byte, requestModel string, toolValidator *
 		// by message id, so a constant placeholder undercounts tokens/cost.
 		id = "msg_translated_" + randomHex(8)
 	}
-	// Per-response nonce appended to every tool_use.id (see uniqueToolUseID on
-	// the streaming translator for the full rationale): deterministic upstreams
-	// (Kimi-k2.x on Fireworks) reuse a stable id like "functions.Bash:0" every
-	// turn, which Claude Code dedupes and drops, stalling the session.
+	// Per-response nonce so deterministic upstream ids don't repeat across turns
+	// (see uniqueToolUseIDWithNonce for full rationale).
 	toolIDNonce := randomHex(6)
 	model := gjson.GetBytes(body, "model").String()
 	if model == "" {

--- a/internal/translate/translate_test.go
+++ b/internal/translate/translate_test.go
@@ -548,9 +548,7 @@ func TestAnthropicSSETranslator_StreamingToolUse(t *testing.T) {
 	body := rec.Body.String()
 	assert.Contains(t, body, "event: message_start")
 	assert.Contains(t, body, `"type":"tool_use"`)
-	// The upstream id "call_1" is suffixed with a per-response nonce so a
-	// deterministic upstream id doesn't repeat across turns (Claude Code drops
-	// duplicate tool_use ids). See uniqueToolUseID / the toolIDNonce field.
+	// Upstream id carries a per-response nonce (uniqueToolUseIDWithNonce).
 	assert.Regexp(t, `"id":"call_1_[0-9a-f]{12}"`, body, "streamed tool_use id must carry the per-response nonce")
 	assert.Contains(t, body, `"get_weather"`)
 	assert.Contains(t, body, `"type":"input_json_delta"`)
@@ -678,9 +676,7 @@ func TestAnthropicSSETranslator_StreamingToolUsePreservesThoughtSignature(t *tes
 	assert.Contains(t, body, `"type":"tool_use"`)
 	assert.NotContains(t, body, `"thought_signature"`, "off-spec field must not be emitted")
 	encoded := base64.RawURLEncoding.EncodeToString([]byte("OPAQUE_SIG"))
-	// The upstream id "call_x" now carries a per-response nonce before the
-	// signature is embedded (uniqueToolUseID), so the wire form is
-	// call_x_<nonce>__thought__<sig>. The signature must still survive intact.
+	// Nonce precedes the signature: call_x_<nonce>__thought__<sig>.
 	assert.Regexp(t, `call_x_[0-9a-f]{12}__thought__`+encoded, body, "upstream id (plus nonce) is embedded with the signature")
 }
 

--- a/internal/translate/translate_test.go
+++ b/internal/translate/translate_test.go
@@ -548,7 +548,10 @@ func TestAnthropicSSETranslator_StreamingToolUse(t *testing.T) {
 	body := rec.Body.String()
 	assert.Contains(t, body, "event: message_start")
 	assert.Contains(t, body, `"type":"tool_use"`)
-	assert.Contains(t, body, `"call_1"`)
+	// The upstream id "call_1" is suffixed with a per-response nonce so a
+	// deterministic upstream id doesn't repeat across turns (Claude Code drops
+	// duplicate tool_use ids). See uniqueToolUseID / the toolIDNonce field.
+	assert.Regexp(t, `"id":"call_1_[0-9a-f]{12}"`, body, "streamed tool_use id must carry the per-response nonce")
 	assert.Contains(t, body, `"get_weather"`)
 	assert.Contains(t, body, `"type":"input_json_delta"`)
 	assert.Contains(t, body, `"stop_reason":"tool_use"`)
@@ -675,7 +678,10 @@ func TestAnthropicSSETranslator_StreamingToolUsePreservesThoughtSignature(t *tes
 	assert.Contains(t, body, `"type":"tool_use"`)
 	assert.NotContains(t, body, `"thought_signature"`, "off-spec field must not be emitted")
 	encoded := base64.RawURLEncoding.EncodeToString([]byte("OPAQUE_SIG"))
-	assert.Contains(t, body, "call_x__thought__"+encoded, "plain upstream id is embedded with the signature")
+	// The upstream id "call_x" now carries a per-response nonce before the
+	// signature is embedded (uniqueToolUseID), so the wire form is
+	// call_x_<nonce>__thought__<sig>. The signature must still survive intact.
+	assert.Regexp(t, `call_x_[0-9a-f]{12}__thought__`+encoded, body, "upstream id (plus nonce) is embedded with the signature")
 }
 
 func TestAnthropicSSETranslator_NonStreamingResponse(t *testing.T) {


### PR DESCRIPTION
## Problem

Kimi-k2.x (on Fireworks) and other deterministic OpenAI-compat upstreams emit a **stable** tool_call id — e.g. `functions.Bash:0` — on *every* turn. `sanitizeToolUseID` normalized the characters (`functions_Bash_0`) but not the value, so the id repeated across turns.

Claude Code dedupes `tool_use` blocks by id and **silently drops a repeat**, so the model's tool call is never executed, its result never comes back, and the session churns re-issuing the same call. In one observed session this burned **58 Kimi turns / ~\$3** looping on a plain "create a PR" request with zero progress — matching the earlier Kimi 2.7 churn report.

The existing cross-envelope no-progress detector *should* have caught this but didn't: its fingerprint folded in `message_count`, which keeps climbing from retry/marker/continuation noise even while the tool-progress marker is frozen (the real "stuck" signal). Rising count → unique fingerprint every turn → detector never accumulates a match.

## Fix

**1. Unique per-response `tool_use.id` (`internal/translate`)**
Append a short (12 hex) per-response nonce to every translated `tool_use.id`, in both the streaming and non-streaming OpenAI→Anthropic paths. The nonce is generated once per response and shared by all blocks in it:
- ids stay **stable within a turn** — a `tool_use.id` and the `tool_result.tool_use_id` the client echoes back still pair, and clamp identically on the request path back to the upstream;
- ids **differ between turns**, so a byte-identical upstream id no longer collides and gets dropped.

Kept short so a re-route to OpenAI rarely trips `clampOpenAIToolCallID`'s 64-char hash fallback. The load-bearing Gemini 3.x `thoughtSignature` id-carrier round-trip is preserved (verified by the existing signature round-trip tests).

**2. No-progress detector marker fix (`internal/proxy`)**
Exclude `message_count` from the fingerprint whenever a tool-progress marker is present — the marker already fully captures progress, and `message_count` only adds noise that defeats detection. `message_count` is retained for the tool-free fallback case (empty marker), where it's the only signal.

## Tests
- `internal/translate`: cross-turn id uniqueness (the actual Kimi loop), within-response id stability + nonce sharing, existing sanitize/signature/pairing/clamp tests still green.
- `internal/proxy`: fingerprint ignores rising `message_count` under a frozen marker; still distinguishes turns in the tool-free case; end-to-end frozen-marker + rising-count loop now trips the detector at threshold.
- Conformance goldens updated; redaction strips the volatile nonce suffix and keeps the readable upstream prefix.
- Full `go test ./...` + `go vet ./...` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)