### PR TITLE
Fix HMM router state isolation

### DIFF
--- a/internal/proxy/gemini.go
+++ b/internal/proxy/gemini.go
@@ -249,13 +249,13 @@ func (s *Service) ProxyGeminiGenerateContent(ctx context.Context, body []byte, w
 
 	// Persist last-turn usage to the pin row so the next turn's planner
 	// has cache-hit evidence. Off the request path; drops on saturation.
-	s.recordTurnUsage(routeRes, decision.Model, in, out, cacheCreation, cacheRead)
+	s.recordTurnUsage(routeRes, decision.Provider, decision.Model, in, out, cacheCreation, cacheRead)
 
 	if proxyErr == nil {
 		s.emitBilling(ctx, requestID, externalID, decision, actPricing, routeRes, in, out, cacheCreation, cacheRead)
 	}
 
-	log.Info("ProxyGeminiGenerateContent complete", "requested_model", feats.Model, "baseline_model", s.baselineFor(feats.Model), "decision_model", decision.Model, "decision_provider", decision.Provider, "decision_reason", decision.Reason, "embedded_tokens", len(promptText)/4, "total_input_tokens", feats.Tokens, "has_tools", feats.HasTools, "embed_input", embedInput, "sticky_hit", stickyHit, "pin_tier", pinTier, "turn_type", string(tt), "route_ms", routeMs, "proxy_ms", proxyMs, "proxy_err", proxyErr, "upstream_status", upstreamStatus(proxyErr))
+	log.Info("ProxyGeminiGenerateContent complete", append([]any{"requested_model", feats.Model, "baseline_model", s.baselineFor(feats.Model), "decision_model", decision.Model, "decision_provider", decision.Provider, "decision_reason", decision.Reason, "embedded_tokens", len(promptText) / 4, "total_input_tokens", feats.Tokens, "has_tools", feats.HasTools, "embed_input", embedInput, "sticky_hit", stickyHit, "pin_tier", pinTier, "turn_type", string(tt), "route_ms", routeMs, "proxy_ms", proxyMs, "proxy_err", proxyErr, "upstream_status", upstreamStatus(proxyErr)}, plannerLogFields(routeRes)...)...)
 	s.reportHMMOutcome(ctx, routeRes, decision, decision.Provider, feats.Tokens, in, out, cacheCreation, cacheRead, routeMs, proxyMs, proxyErr, nil)
 	return proxyErr
 }

--- a/internal/proxy/loop_detection.go
+++ b/internal/proxy/loop_detection.go
@@ -352,7 +352,7 @@ func (s *Service) handleToolCallLoopBreak(
 	// Expire the pin in Postgres (not just the in-proc cache) so a racing
 	// reader on another pod can't repopulate the LRU from the stale row.
 	if s.pinStore != nil && installationID != uuid.Nil {
-		if err := s.expireSessionPin(ctx, installationID, sessionKey, role, "tool_call_loop_break"); err != nil {
+		if err := s.expireSessionPinAndHMMHistory(ctx, installationID, sessionKey, role, "tool_call_loop_break"); err != nil {
 			log.Error("loop-break: pin store upsert failed", "err", err)
 		}
 	}

--- a/internal/proxy/loop_detection.go
+++ b/internal/proxy/loop_detection.go
@@ -321,8 +321,8 @@ func (s *Service) handleToolCallLoopBreak(
 	installationID uuid.UUID,
 	sessionKey [sessionpin.SessionKeyLen]byte,
 	role string,
-	decisionModel string,
-	decisionProvider string,
+	loopingModel string,
+	loopingProvider string,
 	inputTokens int,
 ) error {
 	log := observability.FromContext(ctx)
@@ -342,8 +342,9 @@ func (s *Service) handleToolCallLoopBreak(
 		"tool_name", sig.Name,
 		"repeat_count", count,
 		"window_size", loopDetectionWindowSize,
-		"decision_model", decisionModel,
-		"decision_provider", decisionProvider,
+		"decision_source", "synthetic_tool_call_loop_break",
+		"looping_model", loopingModel,
+		"looping_provider", loopingProvider,
 		"session_key_prefix", shortSessionKey(sessionKey),
 		"role", role,
 	)

--- a/internal/proxy/no_progress.go
+++ b/internal/proxy/no_progress.go
@@ -284,7 +284,7 @@ func (s *Service) handleNoProgressBreak(
 	// Skip when sessionKey is zero: a zero-keyed pin row would be a zombie
 	// entry shared by every zero-keyed session.
 	if s.pinStore != nil && installationID != uuid.Nil && sessionKey != ([sessionpin.SessionKeyLen]byte{}) {
-		if err := s.expireSessionPin(ctx, installationID, sessionKey, role, "no_progress_loop_break"); err != nil {
+		if err := s.expireSessionPinAndHMMHistory(ctx, installationID, sessionKey, role, "no_progress_loop_break"); err != nil {
 			log.Error("no-progress-break: pin store upsert failed", "err", err)
 		}
 	}

--- a/internal/proxy/pin_eviction.go
+++ b/internal/proxy/pin_eviction.go
@@ -48,6 +48,23 @@ func (s *Service) expireSessionPin(
 	return s.pinStore.Upsert(context.Background(), expired)
 }
 
+func (s *Service) expireSessionPinAndHMMHistory(
+	ctx context.Context,
+	installationID uuid.UUID,
+	sessionKey [sessionpin.SessionKeyLen]byte,
+	role string,
+	reason string,
+) error {
+	if err := s.expireSessionPin(ctx, installationID, sessionKey, role, reason); err != nil {
+		return err
+	}
+	historyRole := hmmHistoryRole(role)
+	if historyRole == role {
+		return nil
+	}
+	return s.expireSessionPin(ctx, installationID, sessionKey, historyRole, reason)
+}
+
 // evictPinAfterDegenerateResponse expires the session pin after a degenerate
 // response (end_turn, no tool calls, too few output tokens). The current
 // turn already streamed and can't be retried, but evicting ensures the next

--- a/internal/proxy/pin_eviction_internal_test.go
+++ b/internal/proxy/pin_eviction_internal_test.go
@@ -138,6 +138,33 @@ func TestMaybeEvictPin_SecondStrikeExpires(t *testing.T) {
 		"eviction reason is the audit trail that distinguishes this path from force-model / loop-break")
 }
 
+func TestExpireSessionPinAndHMMHistoryExpiresBothRoles(t *testing.T) {
+	store := &evictionStubPinStore{}
+	svc := newEvictionTestService(store)
+	installationID := uuid.New()
+	sessionKey := nonZeroSessionKey()
+
+	err := svc.expireSessionPinAndHMMHistory(
+		context.Background(),
+		installationID,
+		sessionKey,
+		sessionpin.DefaultRole,
+		"tool_call_loop_break",
+	)
+
+	require.NoError(t, err)
+	require.Len(t, store.upserts, 2)
+	assert.Equal(t, sessionpin.DefaultRole, store.upserts[0].Role)
+	assert.Equal(t, hmmHistoryRole(sessionpin.DefaultRole), store.upserts[1].Role)
+	for _, expired := range store.upserts {
+		assert.Equal(t, installationID, expired.InstallationID)
+		assert.Empty(t, expired.Provider)
+		assert.Empty(t, expired.Model)
+		assert.Equal(t, "tool_call_loop_break", expired.Reason)
+		assert.True(t, expired.PinnedUntil.Before(time.Now()))
+	}
+}
+
 // A successful turn must clear the counter so strikes track consecutive
 // failures, not lifetime ones.
 func TestMaybeEvictPin_SuccessResets(t *testing.T) {

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -1970,17 +1970,16 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 		// discounts Anthropic correctly on reroute.
 		req.SubsidizedModelCostFactor = s.subsidyFactors(ctx, r.Header)
 
-		// Bypass returns early without loading the pin, so load it now for
+		// Bypass returns early without loading pin history, so load it now for
 		// modelSwitched() to correctly detect a switch away from it.
 		var priorServedModel string
 		var sessionEverSwitched bool
 		if s.pinStore != nil {
 			sessionKey := DeriveSessionKey(env, apiKeyID)
-			pin, pinFound := s.loadPin(ctx, sessionKey, roleForTier(catalog.TierFor(feats.Model)))
-			if pinFound {
-				priorServedModel = pin.LastServedModel
-				sessionEverSwitched = pin.HasEverSwitched
-			}
+			role := roleForTier(catalog.TierFor(feats.Model))
+			pin, _ := s.loadPin(ctx, sessionKey, role)
+			hmmHistory := s.loadHMMHistory(ctx, sessionKey, role)
+			priorServedModel, sessionEverSwitched = switchHistoryFromPins(pin, hmmHistory)
 		}
 
 		log.Info("usage-bypass pre-commit failure, rerouting via scorer",
@@ -2650,7 +2649,7 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 	s.recordCallLog(ctx, upstreamBuilder.Build(), proxyErr != nil, body, respBody, respTrunc)
 	otel.Flush(ctx)
 
-	s.recordTurnUsage(routeRes, decision.Model, in, out, cacheCreation, cacheRead)
+	s.recordTurnUsage(routeRes, finalProvider, decision.Model, in, out, cacheCreation, cacheRead)
 
 	if installationID != uuid.Nil {
 		credentialKeyPrefix, credentialKeySuffix, credSource := s.credentialKeyParts(ctx)
@@ -2801,7 +2800,7 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 		)
 	}
 
-	log.Info("ProxyMessages complete", "requested_model", feats.Model, "baseline_model", s.baselineFor(feats.Model), "decision_model", decision.Model, "decision_provider", decision.Provider, "primary_provider", primaryProvider, "fallback_attempts", winnerIdx, "failover_used", finalProvider != primaryProvider || subscriptionFailoverUsed, "subscription_failover", subscriptionFailoverUsed, "decision_reason", decision.Reason, "requested_tier", routeRes.RequestedTier.String(), "decision_tier", catalog.TierFor(decision.Model).String(), "embedded_tokens", len(promptText)/4, "total_input_tokens", feats.Tokens, "has_tools", feats.HasTools, "message_count", feats.MessageCount, "last_kind", feats.LastKind, "last_preview", feats.LastPreview, "embed_input", embedInput, "cross_format", crossFormat, "sticky_hit", stickyHit, "route_ms", routeMs, "proxy_ms", proxyMs, "proxy_err", proxyErr, "upstream_status", upstreamStatus(proxyErr), "upstream_finish_reason", respSummary.UpstreamFinishReason, "resp_stop_reason", respSummary.StopReason, "stop_reason_promoted", respSummary.StopReasonPromoted, "tool_use_blocks", respSummary.ToolUseBlocks, "invalid_tool_args_blocks", respSummary.InvalidToolArgsBlocks, "text_only_turn_nudged", respSummary.TextOnlyTurnNudged, "stop_reason_demoted", respSummary.StopReasonDemoted, "suppressed_tool_calls", respSummary.SuppressedToolCalls, "tool_call_invalid_blocks", len(respSummary.ToolCallIssues), "cc_only_tools_stripped", reqStats.CCOnlyToolsStripped, "gemini_reminder_injected", reqStats.GeminiReminderInjected, "gemini_validated_tool_mode", reqStats.GeminiValidatedToolMode, "resp_output_tokens", respSummary.OutputTokens, "prelude_committed", preludeBuf.Committed())
+	log.Info("ProxyMessages complete", append([]any{"requested_model", feats.Model, "baseline_model", s.baselineFor(feats.Model), "decision_model", decision.Model, "decision_provider", decision.Provider, "primary_provider", primaryProvider, "fallback_attempts", winnerIdx, "failover_used", finalProvider != primaryProvider || subscriptionFailoverUsed, "subscription_failover", subscriptionFailoverUsed, "decision_reason", decision.Reason, "requested_tier", routeRes.RequestedTier.String(), "decision_tier", catalog.TierFor(decision.Model).String(), "embedded_tokens", len(promptText) / 4, "total_input_tokens", feats.Tokens, "has_tools", feats.HasTools, "message_count", feats.MessageCount, "last_kind", feats.LastKind, "last_preview", feats.LastPreview, "embed_input", embedInput, "cross_format", crossFormat, "sticky_hit", stickyHit, "route_ms", routeMs, "proxy_ms", proxyMs, "proxy_err", proxyErr, "upstream_status", upstreamStatus(proxyErr), "upstream_finish_reason", respSummary.UpstreamFinishReason, "resp_stop_reason", respSummary.StopReason, "stop_reason_promoted", respSummary.StopReasonPromoted, "tool_use_blocks", respSummary.ToolUseBlocks, "invalid_tool_args_blocks", respSummary.InvalidToolArgsBlocks, "text_only_turn_nudged", respSummary.TextOnlyTurnNudged, "stop_reason_demoted", respSummary.StopReasonDemoted, "suppressed_tool_calls", respSummary.SuppressedToolCalls, "tool_call_invalid_blocks", len(respSummary.ToolCallIssues), "cc_only_tools_stripped", reqStats.CCOnlyToolsStripped, "gemini_reminder_injected", reqStats.GeminiReminderInjected, "gemini_validated_tool_mode", reqStats.GeminiValidatedToolMode, "resp_output_tokens", respSummary.OutputTokens, "prelude_committed", preludeBuf.Committed()}, plannerLogFields(routeRes)...)...)
 	hmmRespBody, hmmRespTrunc := capturedResponse(hmmOutcomeCap)
 	var hmmResp *hmmOutcomeResponse
 	if hmmOutcomeCap != nil {
@@ -2846,6 +2845,24 @@ func plannerOutcomeAttr(res turnLoopResult) string {
 	}
 }
 
+func plannerLogFields(res turnLoopResult) []any {
+	var pinCacheWarm any
+	if res.PlannerDecision.Reason != "" {
+		pinCacheWarm = !res.PlannerDecision.PinCacheCold
+	}
+	return []any{
+		"planner_outcome", plannerOutcomeAttr(res),
+		"planner_reason", res.PlannerDecision.Reason,
+		"planner_expected_savings_usd", res.PlannerDecision.ExpectedSavingsUSD,
+		"planner_eviction_cost_usd", res.PlannerDecision.EvictionCostUSD,
+		"planner_threshold_usd", res.PlannerDecision.ThresholdUSD,
+		"planner_pin_model", res.PinModel,
+		"planner_fresh_model", res.Fresh.Model,
+		"planner_chosen_model", res.Decision.Model,
+		"planner_pin_cache_warm", pinCacheWarm,
+	}
+}
+
 // logPlannerOutcome emits a structured log line for the planner's verdict.
 // Switch turns are Info; stay turns are Debug.
 func (s *Service) logPlannerOutcome(ctx context.Context, res turnLoopResult) {
@@ -2868,8 +2885,13 @@ func (s *Service) logPlannerOutcome(ctx context.Context, res turnLoopResult) {
 		)
 		return
 	}
-	log.Info("router stayed on pinned model",
+	message := "router stayed on pinned model"
+	if isHMMDecision(res.Fresh) {
+		message = "router stayed on previous HMM model"
+	}
+	log.Info(message,
 		"model", res.Decision.Model,
+		"pin_model", res.PinModel,
 		"reason", res.PlannerDecision.Reason,
 		"expected_savings_usd", res.PlannerDecision.ExpectedSavingsUSD,
 		"eviction_cost_usd", res.PlannerDecision.EvictionCostUSD,
@@ -2878,8 +2900,12 @@ func (s *Service) logPlannerOutcome(ctx context.Context, res turnLoopResult) {
 	)
 }
 
-func (s *Service) recordTurnUsage(res turnLoopResult, servedModel string, in, out, cacheCreation, cacheRead int) {
+func (s *Service) recordTurnUsage(res turnLoopResult, servedProvider, servedModel string, in, out, cacheCreation, cacheRead int) {
 	if s.pinStore == nil || res.HardPinned {
+		return
+	}
+	if isHMMTurn(res) {
+		s.recordHMMTurnHistory(res, servedProvider, servedModel, in, out, cacheCreation, cacheRead)
 		return
 	}
 	var zeroKey [sessionpin.SessionKeyLen]byte
@@ -2903,6 +2929,57 @@ func (s *Service) recordTurnUsage(res turnLoopResult, servedModel string, in, ou
 	}
 	if err := s.pinStore.UpdateUsage(context.Background(), res.SessionKey, role, usage); err != nil {
 		observability.Get().Error("session pin usage writeback failed", "err", err)
+	}
+}
+
+func isHMMTurn(res turnLoopResult) bool {
+	return isHMMDecision(res.Decision) || isHMMDecision(res.Fresh)
+}
+
+func (s *Service) recordHMMTurnHistory(res turnLoopResult, servedProvider, servedModel string, in, out, cacheCreation, cacheRead int) {
+	if servedModel == "" || res.InstallationID == uuid.Nil {
+		return
+	}
+	var zeroKey [sessionpin.SessionKeyLen]byte
+	if res.SessionKey == zeroKey {
+		return
+	}
+	role := hmmHistoryRole(res.PinRole)
+	// The upsert only refreshes the row's TTL/turn_count/provider (ON CONFLICT
+	// leaves the usage columns untouched), so it is always safe to run.
+	s.upsertPin(context.Background(), sessionpin.Pin{
+		SessionKey:     res.SessionKey,
+		Role:           role,
+		InstallationID: res.InstallationID,
+		Provider:       servedProvider,
+		Reason:         hmmHistoryReason,
+		TurnCount:      1,
+		PinnedUntil:    pinExpiry(hmmHistoryReason),
+	})
+	// Zero tokens means a failed/empty upstream turn — don't clobber prior
+	// usage counters; the TTL-refreshing upsert above already ran.
+	if in == 0 && out == 0 && cacheCreation == 0 && cacheRead == 0 {
+		return
+	}
+	now := time.Now()
+	if res.PriorServedModel != "" && res.PriorServedModel != servedModel {
+		if err := s.pinStore.UpdateUsage(context.Background(), res.SessionKey, role, sessionpin.Usage{
+			EndedAt:     now,
+			ServedModel: res.PriorServedModel,
+		}); err != nil {
+			observability.Get().Error("HMM switch-history prior writeback failed", "err", err)
+			return
+		}
+	}
+	if err := s.pinStore.UpdateUsage(context.Background(), res.SessionKey, role, sessionpin.Usage{
+		InputTokens:       in,
+		CachedReadTokens:  cacheRead,
+		CachedWriteTokens: cacheCreation,
+		OutputTokens:      out,
+		EndedAt:           now,
+		ServedModel:       servedModel,
+	}); err != nil {
+		observability.Get().Error("HMM switch-history writeback failed", "err", err)
 	}
 }
 
@@ -4193,7 +4270,7 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 		emitCallLog()
 	}
 
-	s.recordTurnUsage(routeRes, decision.Model, in, out, cacheCreation, cacheRead)
+	s.recordTurnUsage(routeRes, finalProvider, decision.Model, in, out, cacheCreation, cacheRead)
 
 	if proxyErr == nil {
 		s.emitBilling(ctx, requestID, externalID, decision, actPricing, routeRes, in, out, cacheCreation, cacheRead)
@@ -4268,7 +4345,7 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 		})
 	}
 
-	log.Info("ProxyOpenAIChatCompletion complete", "requested_model", feats.Model, "baseline_model", s.baselineFor(feats.Model), "decision_model", decision.Model, "decision_provider", decision.Provider, "primary_provider", primaryProvider, "fallback_attempts", winnerIdx, "failover_used", finalProvider != primaryProvider, "decision_reason", decision.Reason, "requested_tier", routeRes.RequestedTier.String(), "decision_tier", catalog.TierFor(decision.Model).String(), "embedded_tokens", len(promptText)/4, "total_input_tokens", feats.Tokens, "has_tools", feats.HasTools, "embed_input", embedInput, "cross_format", crossFormat, "sticky_hit", stickyHit, "pin_tier", pinTier, "turn_type", string(tt), "route_ms", routeMs, "proxy_ms", proxyMs, "proxy_err", proxyErr, "upstream_status", upstreamStatus(proxyErr))
+	log.Info("ProxyOpenAIChatCompletion complete", append([]any{"requested_model", feats.Model, "baseline_model", s.baselineFor(feats.Model), "decision_model", decision.Model, "decision_provider", decision.Provider, "primary_provider", primaryProvider, "fallback_attempts", winnerIdx, "failover_used", finalProvider != primaryProvider, "decision_reason", decision.Reason, "requested_tier", routeRes.RequestedTier.String(), "decision_tier", catalog.TierFor(decision.Model).String(), "embedded_tokens", len(promptText) / 4, "total_input_tokens", feats.Tokens, "has_tools", feats.HasTools, "embed_input", embedInput, "cross_format", crossFormat, "sticky_hit", stickyHit, "pin_tier", pinTier, "turn_type", string(tt), "route_ms", routeMs, "proxy_ms", proxyMs, "proxy_err", proxyErr, "upstream_status", upstreamStatus(proxyErr)}, plannerLogFields(routeRes)...)...)
 	s.reportHMMOutcome(ctx, routeRes, decision, finalProvider, feats.Tokens, in, out, cacheCreation, cacheRead, routeMs, proxyMs, proxyErr, nil)
 	return proxyErr
 }

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -2670,7 +2670,7 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 			)
 			// Evict the pin so the next turn re-scores instead of repeating the
 			// same misbehaving model — this turn already streamed and can't retry.
-			s.evictPinAfterDegenerateResponse(ctx, stickyHit, decision.Reason, installationID, routeRes.SessionKey, routeRes.PinRole)
+			s.evictPinAfterDegenerateResponse(ctx, stickyHit, decision.Reason, installationID, routeRes.SessionKey, stickyStateRole(routeRes))
 		}
 		s.fireTelemetry(InsertTelemetryParams{
 			InstallationID:         installationID.String(),
@@ -2780,7 +2780,7 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 	// Two-strike eviction: a session pinned to a model returning non-retryable
 	// 4xx wedges until manually /force-model'd out. Expires the pin after a
 	// persistent counter hits threshold; successful turns reset it.
-	s.maybeEvictPinAfterUpstreamErr(ctx, stickyHit, proxyErr, decision.Reason, installationID, routeRes.SessionKey, routeRes.PinRole)
+	s.maybeEvictPinAfterUpstreamErr(ctx, stickyHit, proxyErr, decision.Reason, installationID, routeRes.SessionKey, stickyStateRole(routeRes))
 
 	// Re-pin the session off the refusing model if a cyber refusal was observed.
 	s.maybeRepinOnRefusal(ctx, refusalObs, routeRes.SessionKey, routeRes.PinRole, decision)
@@ -2861,6 +2861,13 @@ func plannerLogFields(res turnLoopResult) []any {
 		"planner_chosen_model", res.Decision.Model,
 		"planner_pin_cache_warm", pinCacheWarm,
 	}
+}
+
+func stickyStateRole(res turnLoopResult) string {
+	if res.StickyHit && res.StickyRole != "" {
+		return res.StickyRole
+	}
+	return res.PinRole
 }
 
 // logPlannerOutcome emits a structured log line for the planner's verdict.
@@ -4280,7 +4287,7 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 	}
 
 	// See ProxyMessages for the two-strike eviction rationale.
-	s.maybeEvictPinAfterUpstreamErr(ctx, stickyHit, proxyErr, decision.Reason, installationIDFromContext(ctx), routeRes.SessionKey, routeRes.PinRole)
+	s.maybeEvictPinAfterUpstreamErr(ctx, stickyHit, proxyErr, decision.Reason, installationIDFromContext(ctx), routeRes.SessionKey, stickyStateRole(routeRes))
 
 	installationIDOAI, _ := ctx.Value(InstallationIDContextKey{}).(string)
 	if installationIDOAI != "" {

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -2783,7 +2783,7 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 	s.maybeEvictPinAfterUpstreamErr(ctx, stickyHit, proxyErr, decision.Reason, installationID, routeRes.SessionKey, stickyStateRole(routeRes))
 
 	// Re-pin the session off the refusing model if a cyber refusal was observed.
-	s.maybeRepinOnRefusal(ctx, refusalObs, routeRes.SessionKey, routeRes.PinRole, decision)
+	s.maybeRepinOnRefusal(ctx, refusalObs, routeRes.SessionKey, stickyStateRole(routeRes), decision)
 
 	// One event per tool_use block that failed toolcheck validation, including
 	// repaired ones — doubles as a per-model×provider tool-calling-quality signal.
@@ -2959,7 +2959,7 @@ func (s *Service) recordHMMTurnHistory(res turnLoopResult, servedProvider, serve
 		Role:           role,
 		InstallationID: res.InstallationID,
 		Provider:       servedProvider,
-		Reason:         hmmHistoryReason,
+		Reason:         hmmHistoryStoredReason(res),
 		TurnCount:      1,
 		PinnedUntil:    pinExpiry(hmmHistoryReason),
 	})
@@ -2975,7 +2975,6 @@ func (s *Service) recordHMMTurnHistory(res turnLoopResult, servedProvider, serve
 			ServedModel: res.PriorServedModel,
 		}); err != nil {
 			observability.Get().Error("HMM switch-history prior writeback failed", "err", err)
-			return
 		}
 	}
 	if err := s.pinStore.UpdateUsage(context.Background(), res.SessionKey, role, sessionpin.Usage{
@@ -2988,6 +2987,16 @@ func (s *Service) recordHMMTurnHistory(res turnLoopResult, servedProvider, serve
 	}); err != nil {
 		observability.Get().Error("HMM switch-history writeback failed", "err", err)
 	}
+}
+
+func hmmHistoryStoredReason(res turnLoopResult) string {
+	if isHMMDecision(res.Fresh) {
+		return res.Fresh.Reason
+	}
+	if isHMMDecision(res.Decision) {
+		return res.Decision.Reason
+	}
+	return hmmHistoryReason
 }
 
 func hmmOutcomeRoute(res turnLoopResult, decision router.Decision) (router.Decision, *router.RoutingMetadata, bool) {

--- a/internal/proxy/service_session_pin_test.go
+++ b/internal/proxy/service_session_pin_test.go
@@ -130,7 +130,7 @@ func assertOnlyHMMHistoryUpserts(t *testing.T, store *fakePinStore) {
 	require.NotEmpty(t, store.upserts, "HMM turns should persist switch history")
 	for _, p := range store.upserts {
 		assert.True(t, strings.HasSuffix(p.Role, "_hmm_history"), "HMM must not write the active routing pin role")
-		assert.Equal(t, "hmm_history", p.Reason)
+		assert.True(t, p.Reason == "hmm_history" || strings.HasPrefix(strings.TrimSpace(p.Reason), "hmm_policy"), "HMM history must retain an HMM marker")
 		assert.NotEmpty(t, p.Provider, "HMM history rows retain provider for cache TTL math")
 		assert.Empty(t, p.Model, "HMM history rows must not be routable")
 	}

--- a/internal/proxy/service_session_pin_test.go
+++ b/internal/proxy/service_session_pin_test.go
@@ -30,6 +30,8 @@ type fakePinStore struct {
 	mu               sync.Mutex
 	pin              sessionpin.Pin
 	hasPin           bool
+	hmmHistory       sessionpin.Pin
+	hasHMMHistory    bool
 	getErr           error
 	getCalls         int
 	upserts          []sessionpin.Pin
@@ -54,6 +56,15 @@ func (f *fakePinStore) Get(ctx context.Context, key [sessionpin.SessionKeyLen]by
 	f.getCalls++
 	if f.getErr != nil {
 		return sessionpin.Pin{}, false, f.getErr
+	}
+	if strings.HasSuffix(role, "_hmm_history") {
+		if !f.hasHMMHistory {
+			return sessionpin.Pin{}, false, nil
+		}
+		pin := f.hmmHistory
+		pin.SessionKey = key
+		pin.Role = role
+		return pin, true, nil
 	}
 	if !f.hasPin {
 		return sessionpin.Pin{}, false, nil
@@ -111,6 +122,17 @@ func waitForUpsert(t *testing.T, store *fakePinStore) {
 	case <-store.upsertCh:
 	case <-time.After(2 * time.Second):
 		t.Fatal("expected an async pin upsert within 2s; none observed")
+	}
+}
+
+func assertOnlyHMMHistoryUpserts(t *testing.T, store *fakePinStore) {
+	t.Helper()
+	require.NotEmpty(t, store.upserts, "HMM turns should persist switch history")
+	for _, p := range store.upserts {
+		assert.True(t, strings.HasSuffix(p.Role, "_hmm_history"), "HMM must not write the active routing pin role")
+		assert.Equal(t, "hmm_history", p.Reason)
+		assert.NotEmpty(t, p.Provider, "HMM history rows retain provider for cache TTL math")
+		assert.Empty(t, p.Model, "HMM history rows must not be routable")
 	}
 }
 
@@ -229,13 +251,13 @@ func TestService_SessionPin_EveryTurnReadsPostgres(t *testing.T) {
 	httpReq1 := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(""))
 	require.NoError(t, svc.ProxyMessages(ctx, []byte(pinTestBody), rec1, httpReq1))
 	require.Equal(t, 1, fr.routeCalls)
-	require.Equal(t, 1, store.getCalls, "first turn must read the pin store")
+	require.Equal(t, 2, store.getCalls, "first turn must read the active pin and HMM history roles")
 
 	rec2 := httptest.NewRecorder()
 	httpReq2 := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(""))
 	require.NoError(t, svc.ProxyMessages(ctx, []byte(pinTestBody), rec2, httpReq2))
 	assert.Equal(t, 2, fr.routeCalls, "planner re-evaluates every MainLoop turn")
-	assert.Equal(t, 2, store.getCalls, "second turn must also read Postgres — there is no in-process cache")
+	assert.Equal(t, 4, store.getCalls, "second turn must also read Postgres — there is no in-process cache")
 }
 
 func TestService_SessionPin_StoreErrorFallsThroughToFreshRoute(t *testing.T) {
@@ -288,7 +310,7 @@ func TestService_SessionPin_EvalOverrideHeaderKeepsSessionKeyPinning(t *testing.
 
 	// Scorer still runs, but the pin wins under ReasonNoPriorUsage.
 	assert.Equal(t, 1, fr.routeCalls, "scorer runs every MainLoop turn under the planner")
-	assert.Equal(t, 1, store.getCalls)
+	assert.Equal(t, 2, store.getCalls)
 	assert.Equal(t, "claude-haiku-4-5", rec.Header().Get(proxy.HeaderRouterModel))
 }
 
@@ -507,7 +529,7 @@ func TestService_HardPin_HMMExploreBypassesBootHardPin(t *testing.T) {
 	assert.Equal(t, "claude-opus-4-7", rec.Header().Get(proxy.HeaderRouterModel))
 }
 
-func TestService_HMMSubAgentKeepsExecutionPin(t *testing.T) {
+func TestService_HMMSubAgentUsesFreshDecision(t *testing.T) {
 	store := newFakePinStore()
 	store.hasPin = true
 	store.pin = sessionpin.Pin{
@@ -530,8 +552,11 @@ func TestService_HMMSubAgentKeepsExecutionPin(t *testing.T) {
 	require.NoError(t, svc.ProxyMessages(ctx, []byte(exploreBody), rec, httpReq))
 
 	assert.Equal(t, 1, fr.routeCalls, "subagent HMM turns may still score for diagnostics")
-	assert.Equal(t, "claude-haiku-4-5", rec.Header().Get(proxy.HeaderRouterModel),
-		"an HMM Explore subagent must keep its selected execution model for the subagent session")
+	assert.Equal(t, "claude-opus-4-7", rec.Header().Get(proxy.HeaderRouterModel),
+		"an HMM Explore subagent must follow the fresh sidecar decision instead of an existing execution pin")
+	store.mu.Lock()
+	assertOnlyHMMHistoryUpserts(t, store)
+	store.mu.Unlock()
 }
 
 func TestService_HardPin_ExploreFallsThroughWhenFlagOff(t *testing.T) {

--- a/internal/proxy/text_repetition.go
+++ b/internal/proxy/text_repetition.go
@@ -122,7 +122,7 @@ func (s *Service) handleTextRepetitionBreak(
 	// Skip a zero session key: a zero-keyed pin row is a zombie shared by every
 	// zero-keyed session.
 	if s.pinStore != nil && installationID != uuid.Nil && sessionKey != ([sessionpin.SessionKeyLen]byte{}) {
-		if err := s.expireSessionPin(ctx, installationID, sessionKey, role, "text_repetition_break"); err != nil {
+		if err := s.expireSessionPinAndHMMHistory(ctx, installationID, sessionKey, role, "text_repetition_break"); err != nil {
 			log.Error("text-repetition-break: pin store upsert failed", "err", err)
 		}
 	}

--- a/internal/proxy/turnloop.go
+++ b/internal/proxy/turnloop.go
@@ -66,6 +66,9 @@ type turnLoopResult struct {
 	// PinRole is the session-pin role used for this turn, preventing a
 	// low-tier background turn and a high-tier main turn from sharing a pin.
 	PinRole string
+	// StickyRole is the stored state role that backed a sticky decision. It is
+	// PinRole for active pins and _hmm_history for HMM EV stays.
+	StickyRole string
 	// Fresh is the scorer's recommendation for this turn when the scorer ran.
 	Fresh router.Decision
 	// PlannerDecision holds the planner's verdict and EV math when the planner ran.
@@ -570,6 +573,7 @@ func (s *Service) runTurnLoop(
 		if hmmSticky {
 			res.StickyHit = true
 			res.PinTier = "hmm_ev_stay_" + hmmPlannerDecision.Reason
+			res.StickyRole = hmmHistoryRole(res.PinRole)
 		} else {
 			res.PinTier = "hmm_fresh_unpinned"
 			if hmmPlannerDecision.Outcome == planner.OutcomeStay && hmmPlannerDecision.Reason != "" {
@@ -807,9 +811,8 @@ func (s *Service) hmmStayPin(req router.Request, activePin sessionpin.Pin, hmmHi
 	return best, ok
 }
 
-// isHMMPinReason reports whether a stored pin's Reason marks it as HMM-written
-// (either the hmm_history sentinel or an hmm_policy* sidecar reason). Used to
-// keep a stale cluster/planner pin from steering an HMM turn's EV stay.
+// isHMMPinReason reports whether reason is HMM-written (hmm_history or hmm_policy*);
+// guards against a stale cluster/planner pin steering an HMM turn's EV stay.
 func isHMMPinReason(reason string) bool {
 	return reason == hmmHistoryReason ||
 		strings.HasPrefix(strings.TrimSpace(reason), "hmm_policy")

--- a/internal/proxy/turnloop.go
+++ b/internal/proxy/turnloop.go
@@ -48,11 +48,12 @@ func cacheWarm(pin sessionpin.Pin) bool {
 
 // turnLoopResult bundles the routing decision and pin/planner state.
 type turnLoopResult struct {
-	Decision   router.Decision
-	SessionKey [sessionpin.SessionKeyLen]byte
-	TurnType   turntype.TurnType
-	StickyHit  bool
-	HardPinned bool
+	Decision       router.Decision
+	SessionKey     [sessionpin.SessionKeyLen]byte
+	InstallationID uuid.UUID
+	TurnType       turntype.TurnType
+	StickyHit      bool
+	HardPinned     bool
 	// UsageBypass is true when the caller's own subscription has headroom:
 	// ProxyMessages must serve the requested model straight through with no
 	// billing debit, bypassing Decision's normal dispatch.
@@ -118,26 +119,19 @@ func isHMMDecision(dec router.Decision) bool {
 	return strings.HasPrefix(strings.TrimSpace(dec.Reason), "hmm_policy")
 }
 
-func isHMMToolExecutionReason(reason string) bool {
-	return strings.HasPrefix(strings.TrimSpace(reason), "hmm_policy:tool_execution")
-}
+const hmmHistoryReason = "hmm_history"
+const hmmUpgradeConfidenceThreshold = 0.85
 
-func shouldServeFreshHMMToolResult(turnType turntype.TurnType, subAgentHint string, pin sessionpin.Pin, fresh router.Decision) bool {
-	if subAgentHint != "" || turnType != turntype.ToolResult {
-		return false
+const (
+	hmmReasonConfidentUpgrade     = "hmm_confident_upgrade"
+	hmmReasonUpgradeConfidenceLow = "hmm_upgrade_confidence_low"
+)
+
+func hmmHistoryRole(role string) string {
+	if role == "" {
+		role = sessionpin.DefaultRole
 	}
-	return isHMMToolExecutionReason(pin.Reason) && isHMMDecision(fresh) && !isHMMToolExecutionReason(fresh.Reason)
-}
-
-func shouldServeFreshHMMToolExecution(pin sessionpin.Pin, fresh router.Decision) bool {
-	return isHMMDecision(fresh) && isHMMToolExecutionReason(fresh.Reason) && !isHMMToolExecutionReason(pin.Reason)
-}
-
-func isHMMSubAgentExecutionLock(turnType turntype.TurnType, subAgentHint string, pin sessionpin.Pin, fresh router.Decision) bool {
-	if !isHMMDecision(fresh) || !isHMMToolExecutionReason(pin.Reason) {
-		return false
-	}
-	return turnType == turntype.SubAgentDispatch || subAgentHint != ""
+	return role + "_hmm_history"
 }
 
 // handoverOutcome describes the synchronous handover step.
@@ -191,9 +185,10 @@ func (s *Service) runTurnLoop(
 ) (turnLoopResult, error) {
 	log := observability.FromContext(ctx)
 	res := turnLoopResult{
-		TurnType:      turntype.DetectFromEnvelope(env, feats, subAgentHint),
-		PinTier:       "miss",
-		RequestedTier: catalog.TierFor(feats.Model),
+		InstallationID: installationID,
+		TurnType:       turntype.DetectFromEnvelope(env, feats, subAgentHint),
+		PinTier:        "miss",
+		RequestedTier:  catalog.TierFor(feats.Model),
 	}
 	res.PinRole = roleForTier(res.RequestedTier)
 	log.Info("turnloop classified",
@@ -294,8 +289,8 @@ func (s *Service) runTurnLoop(
 	res.SessionKey = sessionKey
 
 	pin, pinFound := s.loadPin(ctx, res.SessionKey, res.PinRole)
-	res.PriorServedModel = pin.LastServedModel
-	res.SessionEverSwitched = pin.HasEverSwitched
+	hmmHistory := s.loadHMMHistory(ctx, res.SessionKey, res.PinRole)
+	res.PriorServedModel, res.SessionEverSwitched = switchHistoryFromPins(pin, hmmHistory)
 	// Computed before any same-turn pin-drop guards below so it reflects the
 	// prior turn's outcome; Service.effortEscalation gates whether it's acted on.
 	res.EscalateEffort = pinFound && !pin.LastTurnEndedAt.IsZero() &&
@@ -364,10 +359,7 @@ func (s *Service) runTurnLoop(
 		// model can be the paired member, so pin.Model could name the wrong
 		// (healthy) model and leave the broken one eligible. Fall back to
 		// pin.Model for older rows written before LastServedModel existed.
-		maxedModel := pin.LastServedModel
-		if maxedModel == "" {
-			maxedModel = pin.Model
-		}
+		maxedModel := maxedOutServedModel(pin)
 		log.Info("Session pin maxed out on previous turn; excluding for this turn",
 			"pin_model", pin.Model,
 			"pin_provider", pin.Provider,
@@ -383,6 +375,21 @@ func (s *Service) runTurnLoop(
 		req.ExcludedModels = excluded
 		pinFound = false
 		pin = sessionpin.Pin{}
+	}
+	if maxedModel := maxedOutServedModel(hmmHistory); maxedModel != "" {
+		// No expiry gate: match the active-pin maxed path so the degenerate
+		// auto-continue loop cannot re-select a saturated model after TTL lapses.
+		log.Info("HMM history maxed out on previous turn; excluding for this turn",
+			"history_provider", hmmHistory.Provider,
+			"maxed_model", maxedModel,
+			"last_output_tokens", hmmHistory.LastOutputTokens,
+		)
+		excluded := make(map[string]struct{}, len(req.ExcludedModels)+1)
+		for k := range req.ExcludedModels {
+			excluded[k] = struct{}{}
+		}
+		excluded[maxedModel] = struct{}{}
+		req.ExcludedModels = excluded
 	}
 
 	// If the pre-filter excluded the pinned model for context overflow,
@@ -542,37 +549,35 @@ func (s *Service) runTurnLoop(
 		"fresh_reason", fresh.Reason,
 	)
 	res.Fresh = fresh
-	hmmToolExecutionFresh := pinFound && shouldServeFreshHMMToolExecution(pin, fresh)
-	hmmToolResultFresh := pinFound && shouldServeFreshHMMToolResult(res.TurnType, subAgentHint, pin, fresh)
-	hmmToolExecutionContinue := pinFound && isHMMToolExecutionReason(pin.Reason) && isHMMToolExecutionReason(fresh.Reason)
-	if hmmToolExecutionContinue || (pinFound && isHMMSubAgentExecutionLock(res.TurnType, subAgentHint, pin, fresh)) {
-		decision := pinDecision(pin)
-		res.Decision = decision
-		res.StickyHit = true
-		if hmmToolExecutionContinue {
-			res.PinTier = "hmm_tool_execution_lock"
-		} else {
-			res.PinTier = "hmm_subagent_execution_lock"
-		}
-		s.refreshPin(ctx, installationID, res.SessionKey, pin, res.PinRole, decision)
-		return res, nil
-	}
-	if (hmmToolExecutionFresh || hmmToolResultFresh) && fresh.Provider == pin.Provider && fresh.Model == pin.Model {
-		res.Decision = fresh
-		if hmmToolExecutionFresh {
-			res.PinTier = "hmm_tool_execution_fresh_same_model"
-		} else {
-			res.PinTier = "hmm_tool_result_fresh_same_model"
-		}
-		s.writeNewPin(ctx, installationID, res.SessionKey, res.PinRole, fresh)
-		return res, nil
-	}
 	if isHMMDecision(fresh) {
-		res.Decision = fresh
+		activePin := sessionpin.Pin{}
 		if pinFound {
-			res.PinTier = "hmm_fresh"
+			activePin = pin
 		}
-		s.writeNewPin(ctx, installationID, res.SessionKey, res.PinRole, fresh)
+		hmmDecision, hmmPlannerDecision, hmmSticky, hmmStayModel := s.hmmCostGatedDecision(
+			req,
+			activePin,
+			hmmHistory,
+			fresh,
+			feats.Tokens,
+			prefixBroken,
+		)
+		res.Decision = hmmDecision
+		res.PlannerDecision = hmmPlannerDecision
+		if hmmStayModel != "" {
+			res.PinModel = hmmStayModel
+		}
+		if hmmSticky {
+			res.StickyHit = true
+			res.PinTier = "hmm_ev_stay_" + hmmPlannerDecision.Reason
+		} else {
+			res.PinTier = "hmm_fresh_unpinned"
+			if hmmPlannerDecision.Outcome == planner.OutcomeStay && hmmPlannerDecision.Reason != "" {
+				res.PinTier = "hmm_ev_same_" + hmmPlannerDecision.Reason
+			} else if hmmPlannerDecision.Reason != "" && hmmPlannerDecision.Reason != planner.ReasonNoPin {
+				res.PinTier = "hmm_ev_switch_" + hmmPlannerDecision.Reason
+			}
+		}
 		return res, nil
 	}
 
@@ -648,11 +653,6 @@ func (s *Service) runTurnLoop(
 		plannerIn.Pin = sessionpin.Pin{}
 	}
 	decision := planner.Decide(plannerIn, s.planner)
-	if hmmToolExecutionFresh && decision.Outcome == planner.OutcomeStay {
-		decision = planner.Decision{Outcome: planner.OutcomeSwitch, Reason: "tool_execution_fresh"}
-	} else if hmmToolResultFresh && decision.Outcome == planner.OutcomeStay {
-		decision = planner.Decision{Outcome: planner.OutcomeSwitch, Reason: "tool_result_fresh"}
-	}
 	res.PlannerDecision = decision
 
 	if decision.Outcome == planner.OutcomeStay && pinFound {
@@ -741,6 +741,175 @@ func (s *Service) runTurnLoop(
 	return res, nil
 }
 
+func (s *Service) hmmCostGatedDecision(
+	req router.Request,
+	activePin sessionpin.Pin,
+	hmmHistory sessionpin.Pin,
+	fresh router.Decision,
+	estimatedInputTokens int,
+	prefixBroken bool,
+) (router.Decision, planner.Decision, bool, string) {
+	stayPin, ok := s.hmmStayPin(req, activePin, hmmHistory)
+	if !ok {
+		return fresh, planner.Decision{Outcome: planner.OutcomeSwitch, Reason: planner.ReasonNoPin}, false, ""
+	}
+
+	cfg := s.planner
+	// HMM owns semantic upgrades. The generic planner tier guard is too coarse
+	// here because HMM clusters and router catalog tiers are not the same axis.
+	cfg.TierUpgradeEnabled = false
+	base := planner.Decide(planner.Inputs{
+		Pin:                  stayPin,
+		Fresh:                fresh,
+		EstimatedInputTokens: estimatedInputTokens,
+		AvailableModels:      s.availableModels,
+		PinCacheCold:         !cacheWarm(stayPin) || prefixBroken,
+		SubsidizedCostFactor: req.SubsidizedModelCostFactor,
+	}, cfg)
+
+	if hmmFreshIsMoreExpensive(stayPin.Model, fresh.Model, req.SubsidizedModelCostFactor) {
+		confidence, ok := hmmDecisionConfidence(fresh)
+		if ok && confidence >= hmmUpgradeConfidenceThreshold {
+			base.Outcome = planner.OutcomeSwitch
+			base.Reason = hmmReasonConfidentUpgrade
+		} else {
+			base.Outcome = planner.OutcomeStay
+			base.Reason = hmmReasonUpgradeConfidenceLow
+		}
+	}
+
+	if base.Outcome == planner.OutcomeStay && stayPin.Model != fresh.Model {
+		return pinDecision(stayPin), base, true, stayPin.Model
+	}
+	return fresh, base, false, stayPin.Model
+}
+
+func (s *Service) hmmStayPin(req router.Request, activePin sessionpin.Pin, hmmHistory sessionpin.Pin) (sessionpin.Pin, bool) {
+	var (
+		best sessionpin.Pin
+		ok   bool
+	)
+	// Only HMM-written pins are stay candidates; a cluster/planner pin from a
+	// prior non-HMM stretch must not steer an HMM EV stay.
+	if !isHMMPinReason(activePin.Reason) {
+		activePin = sessionpin.Pin{}
+	}
+	for _, candidate := range []sessionpin.Pin{activePin, hmmHistory} {
+		normalized, candidateOK := s.normalizeHMMStayPin(req, candidate)
+		if !candidateOK {
+			continue
+		}
+		if !ok || normalized.LastTurnEndedAt.After(best.LastTurnEndedAt) {
+			best = normalized
+			ok = true
+		}
+	}
+	return best, ok
+}
+
+// isHMMPinReason reports whether a stored pin's Reason marks it as HMM-written
+// (either the hmm_history sentinel or an hmm_policy* sidecar reason). Used to
+// keep a stale cluster/planner pin from steering an HMM turn's EV stay.
+func isHMMPinReason(reason string) bool {
+	return reason == hmmHistoryReason ||
+		strings.HasPrefix(strings.TrimSpace(reason), "hmm_policy")
+}
+
+func (s *Service) normalizeHMMStayPin(req router.Request, p sessionpin.Pin) (sessionpin.Pin, bool) {
+	model := p.LastServedModel
+	if model == "" {
+		model = p.Model
+	}
+	if model == "" {
+		return sessionpin.Pin{}, false
+	}
+	if p.LastTurnEndedAt.IsZero() {
+		return sessionpin.Pin{}, false
+	}
+	if !p.PinnedUntil.IsZero() && !p.PinnedUntil.After(time.Now()) {
+		return sessionpin.Pin{}, false
+	}
+	if p.LastOutputTokens >= prevTurnMaxedOutThreshold {
+		return sessionpin.Pin{}, false
+	}
+	if req.ExcludedModels != nil {
+		if _, excluded := req.ExcludedModels[model]; excluded {
+			return sessionpin.Pin{}, false
+		}
+	}
+	if s.availableModels != nil {
+		if _, available := s.availableModels[model]; !available {
+			return sessionpin.Pin{}, false
+		}
+	}
+	if req.HasImages && !catalog.AcceptsImages(model) {
+		return sessionpin.Pin{}, false
+	}
+	p.Model = model
+	if p.Provider != "" {
+		if req.EnabledProviders == nil {
+			return p, true
+		}
+		if _, ok := req.EnabledProviders[p.Provider]; ok {
+			return p, true
+		}
+		return sessionpin.Pin{}, false
+	}
+	providerSet := req.EnabledProviders
+	if providerSet == nil {
+		providerSet = make(map[string]struct{}, len(s.providers))
+		for provider := range s.providers {
+			providerSet[provider] = struct{}{}
+		}
+	}
+	binding, ok := catalog.ResolveBinding(model, providerSet)
+	if !ok {
+		return sessionpin.Pin{}, false
+	}
+	p.Provider = binding.Provider
+	return p, true
+}
+
+func hmmDecisionConfidence(dec router.Decision) (float64, bool) {
+	if dec.Metadata == nil {
+		return 0, false
+	}
+	confidence := float64(dec.Metadata.ChosenScore)
+	if confidence <= 0 {
+		return 0, false
+	}
+	return confidence, true
+}
+
+func hmmFreshIsMoreExpensive(stayModel, freshModel string, factors map[string]float64) bool {
+	stay, okStay := hmmEffectiveInputUSDPer1M(stayModel, factors)
+	fresh, okFresh := hmmEffectiveInputUSDPer1M(freshModel, factors)
+	return okStay && okFresh && fresh > stay
+}
+
+func hmmEffectiveInputUSDPer1M(model string, factors map[string]float64) (float64, bool) {
+	price, ok := catalog.PrimaryPriceFor(model)
+	if !ok {
+		return 0, false
+	}
+	value := price.InputUSDPer1M
+	if factor, covered := factors[model]; covered {
+		value *= factor
+	}
+	return value, true
+}
+
+func maxedOutServedModel(pin sessionpin.Pin) string {
+	if pin.LastOutputTokens < prevTurnMaxedOutThreshold {
+		return ""
+	}
+	model := pin.LastServedModel
+	if model == "" {
+		model = pin.Model
+	}
+	return model
+}
+
 // roleForTier maps a requested-model tier to its session-pin role. Each tier
 // gets its own row so separate-tier turns never share a pin. TierUnknown
 // falls back to DefaultRole.
@@ -775,6 +944,34 @@ func (s *Service) loadPin(ctx context.Context, sessionKey [sessionpin.SessionKey
 		return pin, false
 	}
 	return pin, true
+}
+
+func (s *Service) loadHMMHistory(ctx context.Context, sessionKey [sessionpin.SessionKeyLen]byte, role string) sessionpin.Pin {
+	log := observability.FromContext(ctx)
+	pin, found, err := s.pinStore.Get(ctx, sessionKey, hmmHistoryRole(role))
+	if err != nil {
+		log.Error("HMM switch-history store unavailable", "err", err)
+		return sessionpin.Pin{}
+	}
+	if !found {
+		return sessionpin.Pin{}
+	}
+	return pin
+}
+
+func switchHistoryFromPins(activePin, hmmHistory sessionpin.Pin) (string, bool) {
+	priorServedModel := activePin.LastServedModel
+	sessionEverSwitched := activePin.HasEverSwitched || hmmHistory.HasEverSwitched
+	if hmmHistory.LastServedModel != "" &&
+		(priorServedModel == "" || hmmHistory.LastTurnEndedAt.After(activePin.LastTurnEndedAt)) {
+		priorServedModel = hmmHistory.LastServedModel
+	}
+	if activePin.LastServedModel != "" &&
+		hmmHistory.LastServedModel != "" &&
+		activePin.LastServedModel != hmmHistory.LastServedModel {
+		sessionEverSwitched = true
+	}
+	return priorServedModel, sessionEverSwitched
 }
 
 // refreshPin extends the TTL on an existing pin. Carries the existing pin's

--- a/internal/proxy/turnloop.go
+++ b/internal/proxy/turnloop.go
@@ -128,6 +128,7 @@ const hmmUpgradeConfidenceThreshold = 0.85
 const (
 	hmmReasonConfidentUpgrade     = "hmm_confident_upgrade"
 	hmmReasonUpgradeConfidenceLow = "hmm_upgrade_confidence_low"
+	hmmReasonPhaseChange          = "hmm_phase_change"
 )
 
 func hmmHistoryRole(role string) string {
@@ -757,6 +758,9 @@ func (s *Service) hmmCostGatedDecision(
 	if !ok {
 		return fresh, planner.Decision{Outcome: planner.OutcomeSwitch, Reason: planner.ReasonNoPin}, false, ""
 	}
+	if hmmToolExecutionPhaseChanged(stayPin.Reason, fresh.Reason) {
+		return fresh, planner.Decision{Outcome: planner.OutcomeSwitch, Reason: hmmReasonPhaseChange}, false, stayPin.Model
+	}
 
 	cfg := s.planner
 	// HMM owns semantic upgrades. The generic planner tier guard is too coarse
@@ -776,7 +780,7 @@ func (s *Service) hmmCostGatedDecision(
 		if ok && confidence >= hmmUpgradeConfidenceThreshold {
 			base.Outcome = planner.OutcomeSwitch
 			base.Reason = hmmReasonConfidentUpgrade
-		} else {
+		} else if base.Outcome != planner.OutcomeSwitch {
 			base.Outcome = planner.OutcomeStay
 			base.Reason = hmmReasonUpgradeConfidenceLow
 		}
@@ -816,6 +820,14 @@ func (s *Service) hmmStayPin(req router.Request, activePin sessionpin.Pin, hmmHi
 func isHMMPinReason(reason string) bool {
 	return reason == hmmHistoryReason ||
 		strings.HasPrefix(strings.TrimSpace(reason), "hmm_policy")
+}
+
+func isHMMToolExecutionReason(reason string) bool {
+	return strings.HasPrefix(strings.TrimSpace(reason), "hmm_policy:tool_execution")
+}
+
+func hmmToolExecutionPhaseChanged(stayReason, freshReason string) bool {
+	return isHMMToolExecutionReason(stayReason) != isHMMToolExecutionReason(freshReason)
 }
 
 func (s *Service) normalizeHMMStayPin(req router.Request, p sessionpin.Pin) (sessionpin.Pin, bool) {

--- a/internal/proxy/turnloop_internal_test.go
+++ b/internal/proxy/turnloop_internal_test.go
@@ -6,23 +6,27 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"workweave/router/internal/providers"
 	"workweave/router/internal/router"
+	"workweave/router/internal/router/planner"
 	"workweave/router/internal/router/sessionpin"
 )
 
 // stubPinStore is a minimal sessionpin.Store for testing recordTurnUsage.
 // getPin/getFound configure Get's response and default to a miss.
 type stubPinStore struct {
-	mu        sync.Mutex
-	lastUsage sessionpin.Usage
-	usageHits int
-	getPin    sessionpin.Pin
-	getFound  bool
-	upserts   []sessionpin.Pin
-	upsertErr error
+	mu         sync.Mutex
+	lastUsage  sessionpin.Usage
+	usageHits  int
+	usageRoles []string
+	getPin     sessionpin.Pin
+	getFound   bool
+	upserts    []sessionpin.Pin
+	upsertErr  error
 }
 
 func newStubPinStore() *stubPinStore {
@@ -45,11 +49,12 @@ func (s *stubPinStore) Upsert(_ context.Context, p sessionpin.Pin) error {
 	return nil
 }
 
-func (s *stubPinStore) UpdateUsage(_ context.Context, _ [sessionpin.SessionKeyLen]byte, _ string, u sessionpin.Usage) error {
+func (s *stubPinStore) UpdateUsage(_ context.Context, _ [sessionpin.SessionKeyLen]byte, role string, u sessionpin.Usage) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.lastUsage = u
 	s.usageHits++
+	s.usageRoles = append(s.usageRoles, role)
 	return nil
 }
 
@@ -90,7 +95,7 @@ func TestRecordTurnUsage_WritesToStore(t *testing.T) {
 		SessionKey: sessionKey,
 		PinRole:    sessionpin.DefaultRole,
 	}
-	svc.recordTurnUsage(res, res.Decision.Model, 1200, 80, 200, 900)
+	svc.recordTurnUsage(res, res.Decision.Provider, res.Decision.Model, 1200, 80, 200, 900)
 
 	store.mu.Lock()
 	defer store.mu.Unlock()
@@ -101,6 +106,498 @@ func TestRecordTurnUsage_WritesToStore(t *testing.T) {
 	assert.Equal(t, 80, store.lastUsage.OutputTokens)
 	assert.Equal(t, "claude-opus-4-7", store.lastUsage.ServedModel)
 	assert.False(t, store.lastUsage.EndedAt.IsZero(), "EndedAt must be stamped — the planner uses IsZero() as its no-prior-usage gate")
+}
+
+func TestRecordTurnUsage_HMMDecisionWritesHistoryOnly(t *testing.T) {
+	store := newStubPinStore()
+	svc := NewService(
+		nil,
+		nil,
+		nil,
+		false,
+		nil,
+		store,
+		false,
+		"anthropic", "claude-haiku-4-5",
+		nil,
+	)
+
+	var sessionKey [sessionpin.SessionKeyLen]byte
+	for i := range sessionKey {
+		sessionKey[i] = byte(i + 1)
+	}
+
+	res := turnLoopResult{
+		InstallationID: uuid.New(),
+		Decision: router.Decision{
+			Provider: "anthropic",
+			Model:    "claude-sonnet-5",
+			Reason:   "hmm_policy(label=Complex Followup)",
+			Metadata: &router.RoutingMetadata{
+				Strategy: string(router.StrategyHMM),
+				RouteID:  "route-1",
+			},
+		},
+		SessionKey: sessionKey,
+		PinRole:    sessionpin.DefaultRole,
+		PinTier:    "hmm_fresh_unpinned",
+		// Simulate a prior HMM/default-route model so the history role can
+		// latch has_ever_switched without mutating the active routing role.
+		PriorServedModel: "claude-haiku-4-5",
+	}
+	svc.recordTurnUsage(res, res.Decision.Provider, res.Decision.Model, 1200, 80, 200, 900)
+
+	store.mu.Lock()
+	defer store.mu.Unlock()
+	require.Len(t, store.upserts, 1)
+	assert.Equal(t, hmmHistoryRole(sessionpin.DefaultRole), store.upserts[0].Role)
+	assert.Equal(t, hmmHistoryReason, store.upserts[0].Reason)
+	assert.Equal(t, providers.ProviderAnthropic, store.upserts[0].Provider)
+	assert.Empty(t, store.upserts[0].Model, "HMM history rows must not be routable pins")
+	assert.Equal(t, []string{
+		hmmHistoryRole(sessionpin.DefaultRole),
+		hmmHistoryRole(sessionpin.DefaultRole),
+	}, store.usageRoles)
+	assert.NotContains(t, store.usageRoles, sessionpin.DefaultRole, "HMM turns must not mutate the active routing pin role")
+	assert.Equal(t, 1200, store.lastUsage.InputTokens)
+	assert.Equal(t, 900, store.lastUsage.CachedReadTokens)
+	assert.Equal(t, 200, store.lastUsage.CachedWriteTokens)
+	assert.Equal(t, 80, store.lastUsage.OutputTokens)
+	assert.Equal(t, "claude-sonnet-5", store.lastUsage.ServedModel)
+}
+
+func TestRecordHMMTurnHistory_ZeroUsageRefreshesTTLButSkipsUsageWriteback(t *testing.T) {
+	store := newStubPinStore()
+	svc := NewService(
+		nil,
+		nil,
+		nil,
+		false,
+		nil,
+		store,
+		false,
+		"anthropic", "claude-haiku-4-5",
+		nil,
+	)
+
+	var sessionKey [sessionpin.SessionKeyLen]byte
+	for i := range sessionKey {
+		sessionKey[i] = byte(i + 1)
+	}
+
+	res := turnLoopResult{
+		InstallationID: uuid.New(),
+		Decision: router.Decision{
+			Provider: providers.ProviderAnthropic,
+			Model:    "claude-sonnet-5",
+			Reason:   "hmm_policy(label=Complex Followup)",
+			Metadata: &router.RoutingMetadata{
+				Strategy: string(router.StrategyHMM),
+				RouteID:  "route-1",
+			},
+		},
+		SessionKey: sessionKey,
+		PinRole:    sessionpin.DefaultRole,
+	}
+	// A failed/empty upstream turn: all usage counts zero.
+	svc.recordTurnUsage(res, res.Decision.Provider, res.Decision.Model, 0, 0, 0, 0)
+
+	store.mu.Lock()
+	defer store.mu.Unlock()
+	require.Len(t, store.upserts, 1, "TTL-refreshing upsert must still run on a zero-usage turn")
+	assert.Equal(t, hmmHistoryRole(sessionpin.DefaultRole), store.upserts[0].Role)
+	assert.Empty(t, store.usageRoles, "zero-usage turn must not clobber the history row's usage columns")
+	assert.Equal(t, 0, store.usageHits)
+}
+
+func TestRecordTurnUsage_HMMEVStayWritesHistoryOnly(t *testing.T) {
+	store := newStubPinStore()
+	svc := NewService(
+		nil,
+		nil,
+		nil,
+		false,
+		nil,
+		store,
+		false,
+		"anthropic", "claude-haiku-4-5",
+		nil,
+	)
+
+	var sessionKey [sessionpin.SessionKeyLen]byte
+	for i := range sessionKey {
+		sessionKey[i] = byte(i + 1)
+	}
+
+	res := turnLoopResult{
+		InstallationID: uuid.New(),
+		Decision: router.Decision{
+			Provider: providers.ProviderAnthropic,
+			Model:    "claude-sonnet-5",
+			Reason:   hmmHistoryReason,
+		},
+		Fresh: router.Decision{
+			Provider: providers.ProviderMakora,
+			Model:    "deepseek/deepseek-v4-flash",
+			Reason:   "hmm_policy(classifier 'Simple Tool Call Request')",
+			Metadata: &router.RoutingMetadata{
+				Strategy: string(router.StrategyHMM),
+				RouteID:  "route-1",
+			},
+		},
+		SessionKey: sessionKey,
+		PinRole:    sessionpin.DefaultRole,
+		PinTier:    "hmm_ev_stay_ev_negative",
+	}
+	svc.recordTurnUsage(res, res.Decision.Provider, res.Decision.Model, 1200, 80, 200, 900)
+
+	store.mu.Lock()
+	defer store.mu.Unlock()
+	require.Len(t, store.upserts, 1)
+	assert.Equal(t, hmmHistoryRole(sessionpin.DefaultRole), store.upserts[0].Role)
+	assert.Empty(t, store.upserts[0].Model, "HMM history rows must not be routable pins")
+	assert.Equal(t, []string{hmmHistoryRole(sessionpin.DefaultRole)}, store.usageRoles)
+	assert.Equal(t, 80, store.lastUsage.OutputTokens)
+	assert.Equal(t, "claude-sonnet-5", store.lastUsage.ServedModel)
+}
+
+func TestHMMCostGate_StaysOnWarmCacheWhenCheaperFreshDoesNotClearEV(t *testing.T) {
+	svc := NewService(
+		nil,
+		map[string]providers.Client{providers.ProviderAnthropic: nil, providers.ProviderMakora: nil},
+		nil,
+		false,
+		nil,
+		nil,
+		false,
+		"anthropic", "claude-haiku-4-5",
+		nil,
+	)
+	history := sessionpin.Pin{
+		Provider:        providers.ProviderAnthropic,
+		LastServedModel: "claude-sonnet-5",
+		LastTurnEndedAt: time.Now().Add(-30 * time.Second),
+	}
+	fresh := router.Decision{
+		Provider: providers.ProviderMakora,
+		Model:    "deepseek/deepseek-v4-flash",
+		Reason:   "hmm_policy(classifier 'Simple Tool Call Request')",
+		Metadata: &router.RoutingMetadata{
+			Strategy:    string(router.StrategyHMM),
+			RouteID:     "route-1",
+			ChosenScore: 0.70,
+		},
+	}
+
+	decision, plan, sticky, stayModel := svc.hmmCostGatedDecision(
+		router.Request{},
+		sessionpin.Pin{},
+		history,
+		fresh,
+		100,
+		false,
+	)
+
+	assert.True(t, sticky)
+	assert.Equal(t, "claude-sonnet-5", decision.Model)
+	assert.Equal(t, providers.ProviderAnthropic, decision.Provider)
+	assert.Equal(t, "claude-sonnet-5", stayModel)
+	assert.Equal(t, planner.OutcomeStay, plan.Outcome)
+	assert.Equal(t, planner.ReasonEVNegative, plan.Reason)
+}
+
+func TestHMMCostGate_SwitchesCheaperFreshWhenEVPositive(t *testing.T) {
+	svc := NewService(
+		nil,
+		map[string]providers.Client{providers.ProviderAnthropic: nil, providers.ProviderMakora: nil},
+		nil,
+		false,
+		nil,
+		nil,
+		false,
+		"anthropic", "claude-haiku-4-5",
+		nil,
+	)
+	history := sessionpin.Pin{
+		Provider:        providers.ProviderAnthropic,
+		LastServedModel: "claude-sonnet-5",
+		LastTurnEndedAt: time.Now().Add(-30 * time.Second),
+	}
+	fresh := router.Decision{
+		Provider: providers.ProviderMakora,
+		Model:    "deepseek/deepseek-v4-flash",
+		Reason:   "hmm_policy(classifier 'Simple Tool Call Request')",
+		Metadata: &router.RoutingMetadata{
+			Strategy:    string(router.StrategyHMM),
+			RouteID:     "route-1",
+			ChosenScore: 0.70,
+		},
+	}
+
+	decision, plan, sticky, stayModel := svc.hmmCostGatedDecision(
+		router.Request{},
+		sessionpin.Pin{},
+		history,
+		fresh,
+		10_000,
+		false,
+	)
+
+	assert.False(t, sticky)
+	assert.Equal(t, "deepseek/deepseek-v4-flash", decision.Model)
+	assert.Equal(t, "claude-sonnet-5", stayModel)
+	assert.Equal(t, planner.OutcomeSwitch, plan.Outcome)
+	assert.Equal(t, planner.ReasonEVPositive, plan.Reason)
+}
+
+func TestHMMCostGate_ExpensiveUpgradeRequiresHighConfidence(t *testing.T) {
+	svc := NewService(
+		nil,
+		map[string]providers.Client{providers.ProviderAnthropic: nil, providers.ProviderFireworks: nil},
+		nil,
+		false,
+		nil,
+		nil,
+		false,
+		"anthropic", "claude-haiku-4-5",
+		nil,
+	)
+	history := sessionpin.Pin{
+		Provider:        providers.ProviderFireworks,
+		LastServedModel: "moonshotai/kimi-k2.7",
+		LastTurnEndedAt: time.Now().Add(-30 * time.Second),
+	}
+	fresh := router.Decision{
+		Provider: providers.ProviderAnthropic,
+		Model:    "claude-sonnet-5",
+		Reason:   "hmm_policy(classifier 'Complex Followup')",
+		Metadata: &router.RoutingMetadata{
+			Strategy:    string(router.StrategyHMM),
+			RouteID:     "route-1",
+			ChosenScore: 0.84,
+		},
+	}
+
+	decision, plan, sticky, stayModel := svc.hmmCostGatedDecision(
+		router.Request{},
+		sessionpin.Pin{},
+		history,
+		fresh,
+		10_000,
+		false,
+	)
+
+	assert.True(t, sticky)
+	assert.Equal(t, "moonshotai/kimi-k2.7", decision.Model)
+	assert.Equal(t, "moonshotai/kimi-k2.7", stayModel)
+	assert.Equal(t, planner.OutcomeStay, plan.Outcome)
+	assert.Equal(t, hmmReasonUpgradeConfidenceLow, plan.Reason)
+
+	fresh.Metadata.ChosenScore = 0.85
+	decision, plan, sticky, stayModel = svc.hmmCostGatedDecision(
+		router.Request{},
+		sessionpin.Pin{},
+		history,
+		fresh,
+		10_000,
+		false,
+	)
+
+	assert.False(t, sticky)
+	assert.Equal(t, "claude-sonnet-5", decision.Model)
+	assert.Equal(t, "moonshotai/kimi-k2.7", stayModel)
+	assert.Equal(t, planner.OutcomeSwitch, plan.Outcome)
+	assert.Equal(t, hmmReasonConfidentUpgrade, plan.Reason)
+}
+
+func TestHMMCostGate_IgnoresExpiredActivePin(t *testing.T) {
+	svc := NewService(
+		nil,
+		map[string]providers.Client{providers.ProviderAnthropic: nil, providers.ProviderMakora: nil},
+		nil,
+		false,
+		nil,
+		nil,
+		false,
+		"anthropic", "claude-haiku-4-5",
+		nil,
+	)
+	expired := sessionpin.Pin{
+		Provider:        providers.ProviderAnthropic,
+		Model:           "claude-sonnet-5",
+		LastServedModel: "claude-sonnet-5",
+		LastTurnEndedAt: time.Now().Add(-30 * time.Second),
+		PinnedUntil:     time.Now().Add(-time.Minute),
+	}
+	fresh := router.Decision{
+		Provider: providers.ProviderMakora,
+		Model:    "deepseek/deepseek-v4-flash",
+		Reason:   "hmm_policy(classifier 'Simple Tool Call Request')",
+		Metadata: &router.RoutingMetadata{
+			Strategy:    string(router.StrategyHMM),
+			RouteID:     "route-1",
+			ChosenScore: 0.70,
+		},
+	}
+
+	decision, plan, sticky, stayModel := svc.hmmCostGatedDecision(
+		router.Request{},
+		expired,
+		sessionpin.Pin{},
+		fresh,
+		100,
+		false,
+	)
+
+	assert.False(t, sticky)
+	assert.Equal(t, "deepseek/deepseek-v4-flash", decision.Model)
+	assert.Empty(t, stayModel)
+	assert.Equal(t, planner.OutcomeSwitch, plan.Outcome)
+	assert.Equal(t, planner.ReasonNoPin, plan.Reason)
+}
+
+func TestHMMCostGate_IgnoresNonHMMActivePin(t *testing.T) {
+	svc := NewService(
+		nil,
+		map[string]providers.Client{providers.ProviderAnthropic: nil, providers.ProviderMakora: nil},
+		nil,
+		false,
+		nil,
+		nil,
+		false,
+		"anthropic", "claude-haiku-4-5",
+		nil,
+	)
+	// A warm cluster/planner pin (non-HMM reason) must NOT steer an HMM turn's
+	// EV stay — otherwise HMM turns silently reuse ordinary session pins.
+	clusterPin := sessionpin.Pin{
+		Provider:        providers.ProviderAnthropic,
+		Model:           "claude-sonnet-5",
+		LastServedModel: "claude-sonnet-5",
+		Reason:          "cluster:v0.2",
+		LastTurnEndedAt: time.Now().Add(-30 * time.Second),
+		PinnedUntil:     time.Now().Add(time.Hour),
+	}
+	fresh := router.Decision{
+		Provider: providers.ProviderMakora,
+		Model:    "deepseek/deepseek-v4-flash",
+		Reason:   "hmm_policy(classifier 'Simple Tool Call Request')",
+		Metadata: &router.RoutingMetadata{
+			Strategy:    string(router.StrategyHMM),
+			RouteID:     "route-1",
+			ChosenScore: 0.70,
+		},
+	}
+
+	decision, plan, sticky, stayModel := svc.hmmCostGatedDecision(
+		router.Request{},
+		clusterPin,
+		sessionpin.Pin{},
+		fresh,
+		100,
+		false,
+	)
+
+	assert.False(t, sticky, "a non-HMM cluster pin must not win an HMM EV stay")
+	assert.Equal(t, "deepseek/deepseek-v4-flash", decision.Model)
+	assert.Empty(t, stayModel)
+	assert.Equal(t, planner.OutcomeSwitch, plan.Outcome)
+	assert.Equal(t, planner.ReasonNoPin, plan.Reason)
+}
+
+func TestHMMCostGate_HonorsHMMReasonedActivePin(t *testing.T) {
+	svc := NewService(
+		nil,
+		map[string]providers.Client{providers.ProviderAnthropic: nil, providers.ProviderMakora: nil},
+		nil,
+		false,
+		nil,
+		nil,
+		false,
+		"anthropic", "claude-haiku-4-5",
+		nil,
+	)
+	// The active pin IS HMM-reasoned, so it remains a valid stay candidate: a
+	// cheaper fresh pick that doesn't clear EV must stay on it.
+	hmmPin := sessionpin.Pin{
+		Provider:        providers.ProviderAnthropic,
+		Model:           "claude-sonnet-5",
+		LastServedModel: "claude-sonnet-5",
+		Reason:          "hmm_policy(label=Complex Followup)",
+		LastTurnEndedAt: time.Now().Add(-30 * time.Second),
+		PinnedUntil:     time.Now().Add(time.Hour),
+	}
+	fresh := router.Decision{
+		Provider: providers.ProviderMakora,
+		Model:    "deepseek/deepseek-v4-flash",
+		Reason:   "hmm_policy(classifier 'Simple Tool Call Request')",
+		Metadata: &router.RoutingMetadata{
+			Strategy:    string(router.StrategyHMM),
+			RouteID:     "route-1",
+			ChosenScore: 0.70,
+		},
+	}
+
+	decision, plan, sticky, stayModel := svc.hmmCostGatedDecision(
+		router.Request{},
+		hmmPin,
+		sessionpin.Pin{},
+		fresh,
+		100,
+		false,
+	)
+
+	assert.True(t, sticky, "an HMM-reasoned active pin remains a valid stay candidate")
+	assert.Equal(t, "claude-sonnet-5", decision.Model)
+	assert.Equal(t, "claude-sonnet-5", stayModel)
+	assert.Equal(t, planner.OutcomeStay, plan.Outcome)
+	assert.Equal(t, planner.ReasonEVNegative, plan.Reason)
+}
+
+func TestHMMCostGate_IgnoresMaxedHistory(t *testing.T) {
+	svc := NewService(
+		nil,
+		map[string]providers.Client{providers.ProviderAnthropic: nil, providers.ProviderMakora: nil},
+		nil,
+		false,
+		nil,
+		nil,
+		false,
+		"anthropic", "claude-haiku-4-5",
+		nil,
+	)
+	history := sessionpin.Pin{
+		Provider:         providers.ProviderAnthropic,
+		LastServedModel:  "claude-sonnet-5",
+		LastOutputTokens: prevTurnMaxedOutThreshold,
+		LastTurnEndedAt:  time.Now().Add(-30 * time.Second),
+		PinnedUntil:      time.Now().Add(time.Hour),
+	}
+	fresh := router.Decision{
+		Provider: providers.ProviderMakora,
+		Model:    "deepseek/deepseek-v4-flash",
+		Reason:   "hmm_policy(classifier 'Simple Tool Call Request')",
+		Metadata: &router.RoutingMetadata{
+			Strategy:    string(router.StrategyHMM),
+			RouteID:     "route-1",
+			ChosenScore: 0.70,
+		},
+	}
+
+	decision, plan, sticky, stayModel := svc.hmmCostGatedDecision(
+		router.Request{},
+		sessionpin.Pin{},
+		history,
+		fresh,
+		100,
+		false,
+	)
+
+	assert.False(t, sticky)
+	assert.Equal(t, "deepseek/deepseek-v4-flash", decision.Model)
+	assert.Empty(t, stayModel)
+	assert.Equal(t, planner.OutcomeSwitch, plan.Outcome)
+	assert.Equal(t, planner.ReasonNoPin, plan.Reason)
 }
 
 // TestLoadPin_DoesNotServeExpiredPostgresPinButKeepsEmitHistory: expired rows
@@ -188,6 +685,23 @@ func TestLoadPin_ServesFreshPostgresPin(t *testing.T) {
 	require.True(t, found, "non-expired Postgres row must be returned")
 	assert.Equal(t, "claude-opus-4-7", pin.Model)
 	assert.Equal(t, "anthropic", pin.Provider)
+}
+
+func TestSwitchHistoryFromPins_UsesHMMHistory(t *testing.T) {
+	now := time.Now()
+	active := sessionpin.Pin{
+		LastServedModel: "claude-haiku-4-5",
+		LastTurnEndedAt: now.Add(-time.Minute),
+	}
+	hmmHistory := sessionpin.Pin{
+		LastServedModel: "claude-sonnet-5",
+		LastTurnEndedAt: now,
+	}
+
+	prior, everSwitched := switchHistoryFromPins(active, hmmHistory)
+
+	assert.Equal(t, "claude-sonnet-5", prior)
+	assert.True(t, everSwitched, "different active/history models must preserve thinking-block stripping")
 }
 
 // TestModelSwitched covers switch → stay → stay: once a session has served

--- a/internal/proxy/turnloop_internal_test.go
+++ b/internal/proxy/turnloop_internal_test.go
@@ -261,6 +261,23 @@ func TestRecordTurnUsage_HMMEVStayWritesHistoryOnly(t *testing.T) {
 	assert.Equal(t, "claude-sonnet-5", store.lastUsage.ServedModel)
 }
 
+func TestStickyStateRole_HMMEVStayTargetsHistory(t *testing.T) {
+	res := turnLoopResult{
+		StickyHit:  true,
+		PinRole:    sessionpin.DefaultRole,
+		StickyRole: hmmHistoryRole(sessionpin.DefaultRole),
+	}
+	assert.Equal(t, hmmHistoryRole(sessionpin.DefaultRole), stickyStateRole(res))
+}
+
+func TestStickyStateRole_DefaultsToActivePinRole(t *testing.T) {
+	res := turnLoopResult{
+		StickyHit: true,
+		PinRole:   sessionpin.DefaultRole,
+	}
+	assert.Equal(t, sessionpin.DefaultRole, stickyStateRole(res))
+}
+
 func TestHMMCostGate_StaysOnWarmCacheWhenCheaperFreshDoesNotClearEV(t *testing.T) {
 	svc := NewService(
 		nil,

--- a/internal/proxy/turnloop_internal_test.go
+++ b/internal/proxy/turnloop_internal_test.go
@@ -2,6 +2,7 @@ package proxy
 
 import (
 	"context"
+	"errors"
 	"sync"
 	"testing"
 	"time"
@@ -27,6 +28,7 @@ type stubPinStore struct {
 	getFound   bool
 	upserts    []sessionpin.Pin
 	upsertErr  error
+	usageErrs  []error
 }
 
 func newStubPinStore() *stubPinStore {
@@ -55,6 +57,13 @@ func (s *stubPinStore) UpdateUsage(_ context.Context, _ [sessionpin.SessionKeyLe
 	s.lastUsage = u
 	s.usageHits++
 	s.usageRoles = append(s.usageRoles, role)
+	if len(s.usageErrs) > 0 {
+		err := s.usageErrs[0]
+		s.usageErrs = s.usageErrs[1:]
+		if err != nil {
+			return err
+		}
+	}
 	return nil
 }
 
@@ -151,7 +160,7 @@ func TestRecordTurnUsage_HMMDecisionWritesHistoryOnly(t *testing.T) {
 	defer store.mu.Unlock()
 	require.Len(t, store.upserts, 1)
 	assert.Equal(t, hmmHistoryRole(sessionpin.DefaultRole), store.upserts[0].Role)
-	assert.Equal(t, hmmHistoryReason, store.upserts[0].Reason)
+	assert.Equal(t, "hmm_policy(label=Complex Followup)", store.upserts[0].Reason)
 	assert.Equal(t, providers.ProviderAnthropic, store.upserts[0].Provider)
 	assert.Empty(t, store.upserts[0].Model, "HMM history rows must not be routable pins")
 	assert.Equal(t, []string{
@@ -162,6 +171,56 @@ func TestRecordTurnUsage_HMMDecisionWritesHistoryOnly(t *testing.T) {
 	assert.Equal(t, 1200, store.lastUsage.InputTokens)
 	assert.Equal(t, 900, store.lastUsage.CachedReadTokens)
 	assert.Equal(t, 200, store.lastUsage.CachedWriteTokens)
+	assert.Equal(t, 80, store.lastUsage.OutputTokens)
+	assert.Equal(t, "claude-sonnet-5", store.lastUsage.ServedModel)
+}
+
+func TestRecordTurnUsage_HMMPriorWritebackErrorStillWritesCurrentUsage(t *testing.T) {
+	store := newStubPinStore()
+	store.usageErrs = []error{errors.New("transient writeback failure")}
+	svc := NewService(
+		nil,
+		nil,
+		nil,
+		false,
+		nil,
+		store,
+		false,
+		"anthropic", "claude-haiku-4-5",
+		nil,
+	)
+
+	var sessionKey [sessionpin.SessionKeyLen]byte
+	for i := range sessionKey {
+		sessionKey[i] = byte(i + 1)
+	}
+
+	res := turnLoopResult{
+		InstallationID: uuid.New(),
+		Decision: router.Decision{
+			Provider: providers.ProviderAnthropic,
+			Model:    "claude-sonnet-5",
+			Reason:   "hmm_policy(label=Complex Followup)",
+			Metadata: &router.RoutingMetadata{
+				Strategy: string(router.StrategyHMM),
+				RouteID:  "route-1",
+			},
+		},
+		SessionKey:       sessionKey,
+		PinRole:          sessionpin.DefaultRole,
+		PinTier:          "hmm_fresh_unpinned",
+		PriorServedModel: "claude-haiku-4-5",
+	}
+	svc.recordTurnUsage(res, res.Decision.Provider, res.Decision.Model, 1200, 80, 200, 900)
+
+	store.mu.Lock()
+	defer store.mu.Unlock()
+	assert.Equal(t, 2, store.usageHits)
+	assert.Equal(t, []string{
+		hmmHistoryRole(sessionpin.DefaultRole),
+		hmmHistoryRole(sessionpin.DefaultRole),
+	}, store.usageRoles)
+	assert.Equal(t, 1200, store.lastUsage.InputTokens)
 	assert.Equal(t, 80, store.lastUsage.OutputTokens)
 	assert.Equal(t, "claude-sonnet-5", store.lastUsage.ServedModel)
 }
@@ -367,6 +426,99 @@ func TestHMMCostGate_SwitchesCheaperFreshWhenEVPositive(t *testing.T) {
 	assert.Equal(t, planner.ReasonEVPositive, plan.Reason)
 }
 
+func TestHMMCostGate_PhaseChangeFollowsFreshDecision(t *testing.T) {
+	svc := NewService(
+		nil,
+		map[string]providers.Client{providers.ProviderAnthropic: nil, providers.ProviderMakora: nil},
+		nil,
+		false,
+		nil,
+		nil,
+		false,
+		"anthropic", "claude-haiku-4-5",
+		nil,
+	)
+	activePin := sessionpin.Pin{
+		Provider:        providers.ProviderAnthropic,
+		Model:           "claude-sonnet-5",
+		LastServedModel: "claude-sonnet-5",
+		Reason:          "hmm_policy:tool_execution(label=SPAWN_EXPLORE)",
+		LastTurnEndedAt: time.Now().Add(-30 * time.Second),
+		PinnedUntil:     time.Now().Add(time.Hour),
+	}
+	fresh := router.Decision{
+		Provider: providers.ProviderMakora,
+		Model:    "deepseek/deepseek-v4-flash",
+		Reason:   "hmm_policy(classifier 'Simple Followup')",
+		Metadata: &router.RoutingMetadata{
+			Strategy:    string(router.StrategyHMM),
+			RouteID:     "route-1",
+			ChosenScore: 0.70,
+		},
+	}
+
+	decision, plan, sticky, stayModel := svc.hmmCostGatedDecision(
+		router.Request{},
+		activePin,
+		sessionpin.Pin{},
+		fresh,
+		100,
+		false,
+	)
+
+	assert.False(t, sticky)
+	assert.Equal(t, "deepseek/deepseek-v4-flash", decision.Model)
+	assert.Equal(t, "claude-sonnet-5", stayModel)
+	assert.Equal(t, planner.OutcomeSwitch, plan.Outcome)
+	assert.Equal(t, hmmReasonPhaseChange, plan.Reason)
+}
+
+func TestHMMCostGate_HistoryPhaseChangeFollowsFreshDecision(t *testing.T) {
+	svc := NewService(
+		nil,
+		map[string]providers.Client{providers.ProviderAnthropic: nil, providers.ProviderMakora: nil},
+		nil,
+		false,
+		nil,
+		nil,
+		false,
+		"anthropic", "claude-haiku-4-5",
+		nil,
+	)
+	history := sessionpin.Pin{
+		Provider:        providers.ProviderAnthropic,
+		LastServedModel: "claude-sonnet-5",
+		Reason:          "hmm_policy:tool_execution(label=SPAWN_EXPLORE)",
+		LastTurnEndedAt: time.Now().Add(-30 * time.Second),
+		PinnedUntil:     time.Now().Add(time.Hour),
+	}
+	fresh := router.Decision{
+		Provider: providers.ProviderMakora,
+		Model:    "deepseek/deepseek-v4-flash",
+		Reason:   "hmm_policy(classifier 'Simple Followup')",
+		Metadata: &router.RoutingMetadata{
+			Strategy:    string(router.StrategyHMM),
+			RouteID:     "route-1",
+			ChosenScore: 0.70,
+		},
+	}
+
+	decision, plan, sticky, stayModel := svc.hmmCostGatedDecision(
+		router.Request{},
+		sessionpin.Pin{},
+		history,
+		fresh,
+		100,
+		false,
+	)
+
+	assert.False(t, sticky)
+	assert.Equal(t, "deepseek/deepseek-v4-flash", decision.Model)
+	assert.Equal(t, "claude-sonnet-5", stayModel)
+	assert.Equal(t, planner.OutcomeSwitch, plan.Outcome)
+	assert.Equal(t, hmmReasonPhaseChange, plan.Reason)
+}
+
 func TestHMMCostGate_ExpensiveUpgradeRequiresHighConfidence(t *testing.T) {
 	svc := NewService(
 		nil,
@@ -425,6 +577,55 @@ func TestHMMCostGate_ExpensiveUpgradeRequiresHighConfidence(t *testing.T) {
 	assert.Equal(t, "moonshotai/kimi-k2.7", stayModel)
 	assert.Equal(t, planner.OutcomeSwitch, plan.Outcome)
 	assert.Equal(t, hmmReasonConfidentUpgrade, plan.Reason)
+}
+
+func TestHMMCostGate_LowConfidenceUpgradeKeepsIndependentPlannerSwitch(t *testing.T) {
+	svc := NewService(
+		nil,
+		map[string]providers.Client{providers.ProviderAnthropic: nil, providers.ProviderFireworks: nil},
+		nil,
+		false,
+		nil,
+		nil,
+		false,
+		"anthropic", "claude-haiku-4-5",
+		nil,
+	).WithPlanner(planner.EVConfig{
+		ThresholdUSD:           DefaultPlannerThresholdUSD,
+		ExpectedRemainingTurns: DefaultPlannerExpectedRemainingTurns,
+		TierUpgradeEnabled:     false,
+		ColdPinFollowFresh:     true,
+	})
+	history := sessionpin.Pin{
+		Provider:        providers.ProviderFireworks,
+		LastServedModel: "moonshotai/kimi-k2.7",
+		LastTurnEndedAt: time.Now().Add(-30 * time.Second),
+	}
+	fresh := router.Decision{
+		Provider: providers.ProviderAnthropic,
+		Model:    "claude-sonnet-5",
+		Reason:   "hmm_policy(classifier 'Complex Followup')",
+		Metadata: &router.RoutingMetadata{
+			Strategy:    string(router.StrategyHMM),
+			RouteID:     "route-1",
+			ChosenScore: 0.84,
+		},
+	}
+
+	decision, plan, sticky, stayModel := svc.hmmCostGatedDecision(
+		router.Request{},
+		sessionpin.Pin{},
+		history,
+		fresh,
+		10_000,
+		true,
+	)
+
+	assert.False(t, sticky)
+	assert.Equal(t, "claude-sonnet-5", decision.Model)
+	assert.Equal(t, "moonshotai/kimi-k2.7", stayModel)
+	assert.Equal(t, planner.OutcomeSwitch, plan.Outcome)
+	assert.Equal(t, planner.ReasonColdPinFresh, plan.Reason)
 }
 
 func TestHMMCostGate_IgnoresExpiredActivePin(t *testing.T) {

--- a/internal/proxy/turnloop_test.go
+++ b/internal/proxy/turnloop_test.go
@@ -276,9 +276,12 @@ func TestTurnLoop_HMMToolResultCommunicationFollowsFreshDecision(t *testing.T) {
 	assert.Equal(t, 1, fr.routeCalls, "tool_result must ask HMM for a fresh communication decision")
 	assert.Equal(t, "claude-sonnet-4-5", rec.Header().Get(proxy.HeaderRouterModel),
 		"a completed tool result must not stay pinned to the tool-execution model")
+	store.mu.Lock()
+	assertOnlyHMMHistoryUpserts(t, store)
+	store.mu.Unlock()
 }
 
-func TestTurnLoop_HMMToolResultContinuesToolExecutionPin(t *testing.T) {
+func TestTurnLoop_HMMToolResultToolExecutionUsesFreshDecision(t *testing.T) {
 	store := newFakePinStore()
 	store.hasPin = true
 	store.pin = sessionpin.Pin{
@@ -304,11 +307,14 @@ func TestTurnLoop_HMMToolResultContinuesToolExecutionPin(t *testing.T) {
 	require.NoError(t, svc.ProxyMessages(ctx, []byte(toolResultPinnedBody), rec, httpReq))
 
 	assert.Equal(t, 1, fr.routeCalls, "tool_result still scores so HMM can decide whether execution continues")
-	assert.Equal(t, "claude-haiku-4-5", rec.Header().Get(proxy.HeaderRouterModel),
-		"ongoing tool execution keeps the existing execution pin")
+	assert.Equal(t, "claude-sonnet-4-5", rec.Header().Get(proxy.HeaderRouterModel),
+		"HMM tool execution must follow the fresh sidecar decision instead of an existing session pin")
+	store.mu.Lock()
+	assertOnlyHMMHistoryUpserts(t, store)
+	store.mu.Unlock()
 }
 
-func TestTurnLoop_HMMToolExecutionLockBeatsPlannerSwitch(t *testing.T) {
+func TestTurnLoop_HMMToolExecutionStaysWhenWarmCacheEVBeatsCheapFresh(t *testing.T) {
 	store := newFakePinStore()
 	store.hasPin = true
 	store.pin = sessionpin.Pin{
@@ -337,7 +343,81 @@ func TestTurnLoop_HMMToolExecutionLockBeatsPlannerSwitch(t *testing.T) {
 
 	assert.Equal(t, 1, fr.routeCalls, "ongoing HMM execution still scores to see if execution continues")
 	assert.Equal(t, "claude-sonnet-5", rec.Header().Get(proxy.HeaderRouterModel),
-		"ongoing tool execution must keep its selected model instead of planner-switching mid-execution")
+		"HMM should stay when switching to a cheaper tool model would not beat warm-cache eviction cost")
+	store.mu.Lock()
+	assertOnlyHMMHistoryUpserts(t, store)
+	store.mu.Unlock()
+}
+
+func TestTurnLoop_HMMHistoryMaxedOutExcludesServedModelBeforeRouting(t *testing.T) {
+	store := newFakePinStore()
+	store.hasHMMHistory = true
+	store.hmmHistory = sessionpin.Pin{
+		Provider:         providers.ProviderAnthropic,
+		LastServedModel:  "claude-sonnet-5",
+		LastOutputTokens: 8192,
+		LastTurnEndedAt:  time.Now().Add(-30 * time.Second),
+		PinnedUntil:      time.Now().Add(time.Hour),
+	}
+	fr := &fakeRouter{decision: router.Decision{
+		Provider: providers.ProviderAnthropic,
+		Model:    "claude-haiku-4-5",
+		Reason:   "hmm_policy(classifier 'Simple Tool Call Request')",
+		Metadata: &router.RoutingMetadata{
+			Strategy: string(router.StrategyHMM),
+			RouteID:  "route-1",
+		},
+	}}
+	svc := newPinSvc(fr, store)
+
+	ctx := authedCtx(uuid.New().String())
+	rec := httptest.NewRecorder()
+	httpReq := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(""))
+	require.NoError(t, svc.ProxyMessages(ctx, []byte(pinTestBody), rec, httpReq))
+
+	require.NotNil(t, fr.capturedReq)
+	assert.Contains(t, fr.capturedReq.ExcludedModels, "claude-sonnet-5",
+		"HMM history saturation must exclude the prior served model before sidecar routing")
+	assert.Equal(t, "claude-haiku-4-5", rec.Header().Get(proxy.HeaderRouterModel))
+	store.mu.Lock()
+	assertOnlyHMMHistoryUpserts(t, store)
+	store.mu.Unlock()
+}
+
+func TestTurnLoop_HMMExpiredHistoryMaxedOutStillExcludesServedModel(t *testing.T) {
+	store := newFakePinStore()
+	store.hasHMMHistory = true
+	// Expired history row (PinnedUntil in the past) that maxed out its output
+	// cap: the maxed model must still be excluded, matching the active-pin path.
+	store.hmmHistory = sessionpin.Pin{
+		Provider:         providers.ProviderAnthropic,
+		LastServedModel:  "claude-sonnet-5",
+		LastOutputTokens: 8192,
+		LastTurnEndedAt:  time.Now().Add(-time.Hour),
+		PinnedUntil:      time.Now().Add(-time.Minute),
+	}
+	fr := &fakeRouter{decision: router.Decision{
+		Provider: providers.ProviderAnthropic,
+		Model:    "claude-haiku-4-5",
+		Reason:   "hmm_policy(classifier 'Simple Tool Call Request')",
+		Metadata: &router.RoutingMetadata{
+			Strategy: string(router.StrategyHMM),
+			RouteID:  "route-1",
+		},
+	}}
+	svc := newPinSvc(fr, store)
+
+	ctx := authedCtx(uuid.New().String())
+	rec := httptest.NewRecorder()
+	httpReq := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(""))
+	require.NoError(t, svc.ProxyMessages(ctx, []byte(pinTestBody), rec, httpReq))
+
+	require.NotNil(t, fr.capturedReq)
+	assert.Contains(t, fr.capturedReq.ExcludedModels, "claude-sonnet-5",
+		"a maxed-out model must stay excluded even after the history row's TTL lapses")
+	store.mu.Lock()
+	assertOnlyHMMHistoryUpserts(t, store)
+	store.mu.Unlock()
 }
 
 func TestTurnLoop_HMMConversationFollowsFreshDecision(t *testing.T) {
@@ -356,8 +436,9 @@ func TestTurnLoop_HMMConversationFollowsFreshDecision(t *testing.T) {
 		Model:    "claude-sonnet-5",
 		Reason:   "hmm_policy(label=Complex Design)",
 		Metadata: &router.RoutingMetadata{
-			Strategy: string(router.StrategyHMM),
-			RouteID:  "route-1",
+			Strategy:    string(router.StrategyHMM),
+			RouteID:     "route-1",
+			ChosenScore: 0.90,
 		},
 	}}
 	svc := newPinSvc(fr, store)
@@ -370,9 +451,12 @@ func TestTurnLoop_HMMConversationFollowsFreshDecision(t *testing.T) {
 	assert.Equal(t, 1, fr.routeCalls, "HMM conversation turns must score fresh")
 	assert.Equal(t, "claude-sonnet-5", rec.Header().Get(proxy.HeaderRouterModel),
 		"HMM normal conversation routing must follow the fresh sidecar decision instead of EV-staying on the old pin")
+	store.mu.Lock()
+	assertOnlyHMMHistoryUpserts(t, store)
+	store.mu.Unlock()
 }
 
-func TestTurnLoop_HMMToolExecutionBreaksConversationalPin(t *testing.T) {
+func TestTurnLoop_HMMToolExecutionStaysOnLateralWarmCacheWhenEVNegative(t *testing.T) {
 	store := newFakePinStore()
 	store.hasPin = true
 	store.pin = sessionpin.Pin{
@@ -400,18 +484,15 @@ func TestTurnLoop_HMMToolExecutionBreaksConversationalPin(t *testing.T) {
 	require.NoError(t, svc.ProxyMessages(ctx, []byte(pinTestBody), rec, httpReq))
 
 	assert.Equal(t, 1, fr.routeCalls, "main-loop HMM turn must ask for a fresh decision")
-	assert.Equal(t, "claude-sonnet-5", rec.Header().Get(proxy.HeaderRouterModel),
-		"a fresh HMM tool/explore execution decision must break a conversational pin")
+	assert.Equal(t, "claude-sonnet-4-5", rec.Header().Get(proxy.HeaderRouterModel),
+		"lateral HMM tool/explore decisions should not break a warm cache when EV is negative")
 
-	waitForUpsert(t, store)
-	require.NotEmpty(t, store.upserts)
-	last := store.upserts[len(store.upserts)-1]
-	assert.Equal(t, "claude-sonnet-5", last.Model)
-	assert.True(t, strings.HasPrefix(last.Reason, "hmm_policy:tool_execution"),
-		"the execution phase must be persisted so later tool-result routing can detect it")
+	store.mu.Lock()
+	assertOnlyHMMHistoryUpserts(t, store)
+	store.mu.Unlock()
 }
 
-func TestTurnLoop_HMMToolExecutionSameModelUpdatesPinReason(t *testing.T) {
+func TestTurnLoop_HMMToolExecutionSameModelDoesNotRewritePin(t *testing.T) {
 	store := newFakePinStore()
 	store.hasPin = true
 	store.pin = sessionpin.Pin{
@@ -441,12 +522,9 @@ func TestTurnLoop_HMMToolExecutionSameModelUpdatesPinReason(t *testing.T) {
 	assert.Equal(t, 1, fr.routeCalls, "main-loop HMM turn must ask for a fresh decision")
 	assert.Equal(t, "claude-sonnet-4-5", rec.Header().Get(proxy.HeaderRouterModel))
 
-	waitForUpsert(t, store)
-	require.NotEmpty(t, store.upserts)
-	last := store.upserts[len(store.upserts)-1]
-	assert.Equal(t, "claude-sonnet-4-5", last.Model)
-	assert.True(t, strings.HasPrefix(last.Reason, "hmm_policy:tool_execution"),
-		"same-model fresh execution decisions must still rewrite the pin phase")
+	store.mu.Lock()
+	assertOnlyHMMHistoryUpserts(t, store)
+	store.mu.Unlock()
 }
 
 // TestTurnLoop_ToolResultPinOnExcludedProviderFallsThroughToScorer verifies that a pin

--- a/internal/proxy/turnloop_test.go
+++ b/internal/proxy/turnloop_test.go
@@ -456,7 +456,7 @@ func TestTurnLoop_HMMConversationFollowsFreshDecision(t *testing.T) {
 	store.mu.Unlock()
 }
 
-func TestTurnLoop_HMMToolExecutionStaysOnLateralWarmCacheWhenEVNegative(t *testing.T) {
+func TestTurnLoop_HMMToolExecutionPhaseChangeUsesFreshDecision(t *testing.T) {
 	store := newFakePinStore()
 	store.hasPin = true
 	store.pin = sessionpin.Pin{
@@ -484,8 +484,8 @@ func TestTurnLoop_HMMToolExecutionStaysOnLateralWarmCacheWhenEVNegative(t *testi
 	require.NoError(t, svc.ProxyMessages(ctx, []byte(pinTestBody), rec, httpReq))
 
 	assert.Equal(t, 1, fr.routeCalls, "main-loop HMM turn must ask for a fresh decision")
-	assert.Equal(t, "claude-sonnet-4-5", rec.Header().Get(proxy.HeaderRouterModel),
-		"lateral HMM tool/explore decisions should not break a warm cache when EV is negative")
+	assert.Equal(t, "claude-sonnet-5", rec.Header().Get(proxy.HeaderRouterModel),
+		"HMM tool/explore phase changes should follow the fresh sidecar decision")
 
 	store.mu.Lock()
 	assertOnlyHMMHistoryUpserts(t, store)


### PR DESCRIPTION
## Summary
- stop HMM turns from writing/reusing ordinary active session pins for routing state
- persist HMM-owned history for switch/cache decisions without making it a routable pin
- preserve prior HMM usage on failed/empty turns and keep saturated HMM history excluded before routing

This keeps the price-aware HMM policy intent from #673, but avoids the stale-pin, saturated-model reselection, and history-clobber failure modes.

## Tests
- go test ./internal/proxy
- wv mr tc
- wv mr t