### PR TITLE
feat: forward HMM routing preferences

### DIFF
--- a/internal/proxy/gemini.go
+++ b/internal/proxy/gemini.go
@@ -88,7 +88,7 @@ func (s *Service) ProxyGeminiGenerateContent(ctx context.Context, body []byte, w
 	routeStart := time.Now()
 	routeRes, err := s.runTurnLoop(ctx, env, feats, apiKeyID, installationID, subAgentHint, r.Header, router.Request{
 		RequestedModel:       feats.Model,
-		Harness:              router.HarnessAPI,
+		Harness:              clientIdentityHarnessForRequest(ctx),
 		EstimatedInputTokens: feats.Tokens,
 		HasTools:             feats.HasTools,
 		HasImages:            feats.HasImages,

--- a/internal/proxy/gemini.go
+++ b/internal/proxy/gemini.go
@@ -88,6 +88,7 @@ func (s *Service) ProxyGeminiGenerateContent(ctx context.Context, body []byte, w
 	routeStart := time.Now()
 	routeRes, err := s.runTurnLoop(ctx, env, feats, apiKeyID, installationID, subAgentHint, r.Header, router.Request{
 		RequestedModel:       feats.Model,
+		Harness:              router.HarnessAPI,
 		EstimatedInputTokens: feats.Tokens,
 		HasTools:             feats.HasTools,
 		HasImages:            feats.HasImages,

--- a/internal/proxy/gemini_test.go
+++ b/internal/proxy/gemini_test.go
@@ -1,6 +1,7 @@
 package proxy_test
 
 import (
+	"context"
 	"errors"
 	"net/http"
 	"net/http/httptest"
@@ -40,10 +41,15 @@ func TestProxyGeminiGenerateContent_RoutesToGoogleProvider(t *testing.T) {
 	)
 
 	ctx := authedCtx("00000000-0000-0000-0000-000000000001")
+	ctx = context.WithValue(ctx, proxy.ClientIdentityContextKey{}, proxy.ClientIdentity{
+		ClientApp: proxy.ClientAppCodex,
+	})
 	rec := httptest.NewRecorder()
 	httpReq := httptest.NewRequest(http.MethodPost, "/v1beta/models/gemini-1.5-pro:generateContent", strings.NewReader(""))
 	require.NoError(t, svc.ProxyGeminiGenerateContent(ctx, []byte(geminiInjectedBody), rec, httpReq))
 
+	require.NotNil(t, fr.capturedReq)
+	assert.Equal(t, router.HarnessCodex, fr.capturedReq.Harness)
 	assert.Equal(t, "gemini-2.5-pro", rec.Header().Get(proxy.HeaderRouterModel))
 	assert.Equal(t, providers.ProviderGoogle, rec.Header().Get(proxy.HeaderRouterProvider))
 	require.Len(t, googleProv.proxyBodies, 1, "the upstream Google client must be invoked once")

--- a/internal/proxy/harness_internal_test.go
+++ b/internal/proxy/harness_internal_test.go
@@ -31,6 +31,27 @@ func TestOpenAIHarnessForRequestRequiresUsableCodexSubscription(t *testing.T) {
 			want: router.HarnessAPI,
 		},
 		{
+			name: "codex client identity",
+			ctx: context.WithValue(context.Background(), ClientIdentityContextKey{}, ClientIdentity{
+				ClientApp: ClientAppCodex,
+			}),
+			want: router.HarnessCodex,
+		},
+		{
+			name: "cursor client identity",
+			ctx: context.WithValue(context.Background(), ClientIdentityContextKey{}, ClientIdentity{
+				ClientApp: ClientAppCursor,
+			}),
+			want: router.HarnessCursor,
+		},
+		{
+			name: "claude code client identity",
+			ctx: context.WithValue(context.Background(), ClientIdentityContextKey{}, ClientIdentity{
+				ClientApp: ClientAppClaudeCode,
+			}),
+			want: router.HarnessClaudeCode,
+		},
+		{
 			name: "complete codex subscription",
 			ctx: func() context.Context {
 				ctx := context.WithValue(context.Background(), OpenAISubscriptionContextKey{}, codexTestJWT)

--- a/internal/proxy/harness_internal_test.go
+++ b/internal/proxy/harness_internal_test.go
@@ -1,0 +1,46 @@
+package proxy
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"workweave/router/internal/router"
+)
+
+func TestOpenAIHarnessForRequestRequiresUsableCodexSubscription(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		ctx  context.Context
+		want router.Harness
+	}{
+		{
+			name: "no subscription",
+			ctx:  context.Background(),
+			want: router.HarnessAPI,
+		},
+		{
+			name: "responses body without subscription",
+			ctx:  context.WithValue(context.Background(), codexResponsesBodyContextKey{}, []byte(`{"model":"gpt-5.5"}`)),
+			want: router.HarnessAPI,
+		},
+		{
+			name: "token without account id",
+			ctx:  context.WithValue(context.Background(), OpenAISubscriptionContextKey{}, codexTestJWT),
+			want: router.HarnessAPI,
+		},
+		{
+			name: "complete codex subscription",
+			ctx: func() context.Context {
+				ctx := context.WithValue(context.Background(), OpenAISubscriptionContextKey{}, codexTestJWT)
+				return context.WithValue(ctx, OpenAIAccountIDContextKey{}, "acct-1")
+			}(),
+			want: router.HarnessCodex,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, openAIHarnessForRequest(tc.ctx))
+		})
+	}
+}

--- a/internal/proxy/harness_internal_test.go
+++ b/internal/proxy/harness_internal_test.go
@@ -2,6 +2,7 @@ package proxy
 
 import (
 	"context"
+	"net/http"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -13,6 +14,7 @@ func TestOpenAIHarnessForRequestRequiresUsableCodexSubscription(t *testing.T) {
 	for _, tc := range []struct {
 		name string
 		ctx  context.Context
+		hdr  http.Header
 		want router.Harness
 	}{
 		{
@@ -29,6 +31,21 @@ func TestOpenAIHarnessForRequestRequiresUsableCodexSubscription(t *testing.T) {
 			name: "token without account id",
 			ctx:  context.WithValue(context.Background(), OpenAISubscriptionContextKey{}, codexTestJWT),
 			want: router.HarnessAPI,
+		},
+		{
+			name: "plain OpenAI bearer",
+			hdr: http.Header{
+				"Authorization": []string{"Bearer sk-oai-client-key"},
+			},
+			want: router.HarnessAPI,
+		},
+		{
+			name: "codex bearer subscription",
+			hdr: http.Header{
+				"Authorization":      []string{"Bearer " + codexTestJWT},
+				"Chatgpt-Account-Id": []string{"acct-1"},
+			},
+			want: router.HarnessCodex,
 		},
 		{
 			name: "codex client identity",
@@ -61,7 +78,11 @@ func TestOpenAIHarnessForRequestRequiresUsableCodexSubscription(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			assert.Equal(t, tc.want, openAIHarnessForRequest(tc.ctx))
+			ctx := tc.ctx
+			if ctx == nil {
+				ctx = context.Background()
+			}
+			assert.Equal(t, tc.want, openAIHarnessForRequest(ctx, tc.hdr))
 		})
 	}
 }

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -558,8 +558,11 @@ func clientIdentityHarnessForRequest(ctx context.Context) router.Harness {
 	}
 }
 
-func openAIHarnessForRequest(ctx context.Context) router.Harness {
+func openAIHarnessForRequest(ctx context.Context, headers http.Header) router.Harness {
 	if codexSubscriptionFromContext(ctx) != nil {
+		return router.HarnessCodex
+	}
+	if c := ExtractClientCredentials(providers.ProviderOpenAI, headers); c != nil && c.OAuth {
 		return router.HarnessCodex
 	}
 	return clientIdentityHarnessForRequest(ctx)
@@ -3886,7 +3889,7 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 	routeStart := time.Now()
 	routeRes, err := s.runTurnLoop(ctx, env, feats, apiKeyID, installationID, subAgentHint, r.Header, router.Request{
 		RequestedModel:       feats.Model,
-		Harness:              openAIHarnessForRequest(ctx),
+		Harness:              openAIHarnessForRequest(ctx, r.Header),
 		EstimatedInputTokens: feats.Tokens,
 		HasTools:             feats.HasTools,
 		HasImages:            feats.HasImages,

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -555,10 +555,7 @@ func anthropicHarnessForRequest(ctx context.Context) router.Harness {
 }
 
 func openAIHarnessForRequest(ctx context.Context) router.Harness {
-	if body, ok := ctx.Value(codexResponsesBodyContextKey{}).([]byte); ok && len(body) > 0 {
-		return router.HarnessCodex
-	}
-	if openaiSubscriptionFromContext(ctx) != "" {
+	if codexSubscriptionFromContext(ctx) != nil {
 		return router.HarnessCodex
 	}
 	return router.HarnessAPI

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -558,6 +558,15 @@ func openAIHarnessForRequest(ctx context.Context) router.Harness {
 	if codexSubscriptionFromContext(ctx) != nil {
 		return router.HarnessCodex
 	}
+	identity := ClientIdentityFrom(ctx)
+	switch identity.ClientApp {
+	case ClientAppClaudeCode:
+		return router.HarnessClaudeCode
+	case ClientAppCodex:
+		return router.HarnessCodex
+	case ClientAppCursor:
+		return router.HarnessCursor
+	}
 	return router.HarnessAPI
 }
 

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -541,8 +541,17 @@ func routingKnobsForRequest(ctx context.Context) *router.Overrides {
 	return nil
 }
 
-func anthropicHarnessForRequest(context.Context) router.Harness {
-	return router.HarnessClaudeCode
+func anthropicHarnessForRequest(ctx context.Context) router.Harness {
+	switch ClientIdentityFrom(ctx).ClientApp {
+	case ClientAppClaudeCode:
+		return router.HarnessClaudeCode
+	case ClientAppCodex:
+		return router.HarnessCodex
+	case ClientAppCursor:
+		return router.HarnessCursor
+	default:
+		return router.HarnessAPI
+	}
 }
 
 func openAIHarnessForRequest(ctx context.Context) router.Harness {

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -542,6 +542,10 @@ func routingKnobsForRequest(ctx context.Context) *router.Overrides {
 }
 
 func anthropicHarnessForRequest(ctx context.Context) router.Harness {
+	return clientIdentityHarnessForRequest(ctx)
+}
+
+func clientIdentityHarnessForRequest(ctx context.Context) router.Harness {
 	switch ClientIdentityFrom(ctx).ClientApp {
 	case ClientAppClaudeCode:
 		return router.HarnessClaudeCode
@@ -558,16 +562,7 @@ func openAIHarnessForRequest(ctx context.Context) router.Harness {
 	if codexSubscriptionFromContext(ctx) != nil {
 		return router.HarnessCodex
 	}
-	identity := ClientIdentityFrom(ctx)
-	switch identity.ClientApp {
-	case ClientAppClaudeCode:
-		return router.HarnessClaudeCode
-	case ClientAppCodex:
-		return router.HarnessCodex
-	case ClientAppCursor:
-		return router.HarnessCursor
-	}
-	return router.HarnessAPI
+	return clientIdentityHarnessForRequest(ctx)
 }
 
 // excludedModelsForRequest returns the request's model exclusion set.

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -541,6 +541,20 @@ func routingKnobsForRequest(ctx context.Context) *router.Overrides {
 	return nil
 }
 
+func anthropicHarnessForRequest(context.Context) router.Harness {
+	return router.HarnessClaudeCode
+}
+
+func openAIHarnessForRequest(ctx context.Context) router.Harness {
+	if body, ok := ctx.Value(codexResponsesBodyContextKey{}).([]byte); ok && len(body) > 0 {
+		return router.HarnessCodex
+	}
+	if openaiSubscriptionFromContext(ctx) != "" {
+		return router.HarnessCodex
+	}
+	return router.HarnessAPI
+}
+
 // excludedModelsForRequest returns the request's model exclusion set.
 // Env override wins; otherwise the installation list is converted to a set.
 func (s *Service) excludedModelsForRequest(ctx context.Context) map[string]struct{} {
@@ -1522,6 +1536,7 @@ func (s *Service) RouteAnthropicRequest(ctx context.Context, body []byte) (decis
 
 	decision, err = s.Route(ctx, router.Request{
 		RequestedModel:       feats.Model,
+		Harness:              anthropicHarnessForRequest(ctx),
 		EstimatedInputTokens: feats.Tokens,
 		HasTools:             feats.HasTools,
 		PromptText:           promptText,
@@ -1954,6 +1969,7 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 	routeStart := time.Now()
 	req := router.Request{
 		RequestedModel:       feats.Model,
+		Harness:              anthropicHarnessForRequest(ctx),
 		EstimatedInputTokens: feats.Tokens,
 		HasTools:             feats.HasTools,
 		HasImages:            feats.HasImages,
@@ -3860,6 +3876,7 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 	routeStart := time.Now()
 	routeRes, err := s.runTurnLoop(ctx, env, feats, apiKeyID, installationID, subAgentHint, r.Header, router.Request{
 		RequestedModel:       feats.Model,
+		Harness:              openAIHarnessForRequest(ctx),
 		EstimatedInputTokens: feats.Tokens,
 		HasTools:             feats.HasTools,
 		HasImages:            feats.HasImages,

--- a/internal/proxy/service_test.go
+++ b/internal/proxy/service_test.go
@@ -31,6 +31,52 @@ func (f *fakeRouter) Route(ctx context.Context, req router.Request) (router.Deci
 	return f.decision, f.err
 }
 
+func TestService_RouteAnthropicRequestSetsHarnessFromClientIdentity(t *testing.T) {
+	body := []byte(`{
+		"model":"claude-3-5-sonnet-20241022",
+		"messages":[{"role":"user","content":"hello"}]
+	}`)
+	for _, tc := range []struct {
+		name      string
+		clientApp string
+		want      router.Harness
+	}{
+		{name: "generic_api", want: router.HarnessAPI},
+		{name: "claude_code", clientApp: proxy.ClientAppClaudeCode, want: router.HarnessClaudeCode},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			fr := &fakeRouter{
+				decision: router.Decision{
+					Provider: providers.ProviderAnthropic,
+					Model:    "claude-haiku-4-5",
+				},
+			}
+			svc := proxy.NewService(fr,
+				map[string]providers.Client{providers.ProviderAnthropic: &fakeProvider{}},
+				nil,
+				false,
+				nil,
+				nil,
+				false,
+				providers.ProviderAnthropic, "claude-haiku-4-5",
+				nil,
+			)
+			ctx := context.Background()
+			if tc.clientApp != "" {
+				ctx = context.WithValue(ctx, proxy.ClientIdentityContextKey{}, proxy.ClientIdentity{
+					ClientApp: tc.clientApp,
+				})
+			}
+
+			_, err := svc.RouteAnthropicRequest(ctx, body)
+
+			require.NoError(t, err)
+			require.NotNil(t, fr.capturedReq)
+			assert.Equal(t, tc.want, fr.capturedReq.Harness)
+		})
+	}
+}
+
 type fakeProvider struct {
 	proxyBodies   [][]byte
 	proxyResponse func(w http.ResponseWriter)

--- a/internal/router/hmm/client.go
+++ b/internal/router/hmm/client.go
@@ -76,17 +76,19 @@ func (d *HTTPDecider) ReportOutcome(ctx context.Context, payload map[string]inte
 }
 
 type routeRequest struct {
-	RouteID              string            `json:"route_id"`
-	PromptText           string            `json:"prompt_text"`
-	LatestUserText       string            `json:"latest_user_text,omitempty"`
-	TurnIndex            int               `json:"turn_index"`
-	ConversationMessages []routeMessage    `json:"conversation_messages,omitempty"`
-	AvailableTools       []string          `json:"available_tools,omitempty"`
-	EstimatedInputTokens int               `json:"estimated_input_tokens"`
-	HasTools             bool              `json:"has_tools"`
-	HasImages            bool              `json:"has_images"`
-	CandidateModels      []string          `json:"candidate_models"`
-	CandidateProviders   map[string]string `json:"candidate_providers"`
+	RouteID              string              `json:"route_id"`
+	PromptText           string              `json:"prompt_text"`
+	LatestUserText       string              `json:"latest_user_text,omitempty"`
+	TurnIndex            int                 `json:"turn_index"`
+	Harness              string              `json:"harness,omitempty"`
+	ConversationMessages []routeMessage      `json:"conversation_messages,omitempty"`
+	AvailableTools       []string            `json:"available_tools,omitempty"`
+	EstimatedInputTokens int                 `json:"estimated_input_tokens"`
+	HasTools             bool                `json:"has_tools"`
+	HasImages            bool                `json:"has_images"`
+	CandidateModels      []string            `json:"candidate_models"`
+	CandidateProviders   map[string]string   `json:"candidate_providers"`
+	RoutingPreferences   *RoutingPreferences `json:"routing_preferences,omitempty"`
 }
 
 type routeMessage struct {
@@ -142,6 +144,7 @@ func (d *HTTPDecider) Decide(ctx context.Context, q Query) (Result, error) {
 		PromptText:           q.PromptText,
 		LatestUserText:       latestUserText(messages),
 		TurnIndex:            turnIndex(messages),
+		Harness:              string(q.Harness),
 		ConversationMessages: messages,
 		AvailableTools:       clipRouteValues(q.AvailableTools, maxRouteToolCallInputKeys, maxRouteToolCallInputChars),
 		EstimatedInputTokens: q.EstimatedInputTokens,
@@ -149,6 +152,7 @@ func (d *HTTPDecider) Decide(ctx context.Context, q Query) (Result, error) {
 		HasImages:            q.HasImages,
 		CandidateModels:      models,
 		CandidateProviders:   providers,
+		RoutingPreferences:   q.RoutingPreferences,
 	})
 	if err != nil {
 		return Result{}, fmt.Errorf("marshal route request: %w", err)

--- a/internal/router/hmm/client_test.go
+++ b/internal/router/hmm/client_test.go
@@ -36,9 +36,11 @@ func TestHTTPDeciderPostsRouteAndParsesDisplayMetadata(t *testing.T) {
 	defer server.Close()
 
 	decider := NewHTTPDecider(server.URL, server.Client(), 0)
+	alpha := 0.7
 	result, err := decider.Decide(context.Background(), Query{
 		RouteID:    "route-1",
 		PromptText: "hello",
+		Harness:    router.HarnessClaudeCode,
 		ConversationMessages: []router.ConversationMessage{
 			{Role: "user", Text: "please explore the repo"},
 			{Role: "assistant", Text: "done"},
@@ -63,6 +65,12 @@ func TestHTTPDeciderPostsRouteAndParsesDisplayMetadata(t *testing.T) {
 			RosterID: "moonshotai/kimi-k2.7-code",
 			Provider: "openrouter",
 		}},
+		RoutingPreferences: &RoutingPreferences{
+			Alpha:                     &alpha,
+			PreferredModels:           []string{"moonshotai/kimi-k2.7-code"},
+			ExcludedModels:            []string{"openai/gpt-5.5"},
+			SubsidizedModelCostFactor: map[string]float64{"moonshotai/kimi-k2.7-code": 0.2},
+		},
 	})
 
 	require.NoError(t, err)
@@ -85,6 +93,13 @@ func TestHTTPDeciderPostsRouteAndParsesDisplayMetadata(t *testing.T) {
 	assert.True(t, got.HasTools)
 	assert.Equal(t, []string{"Read", "Grep"}, got.AvailableTools)
 	assert.Equal(t, []string{"moonshotai/kimi-k2.7-code"}, got.CandidateModels)
+	assert.Equal(t, "claude_code", got.Harness)
+	require.NotNil(t, got.RoutingPreferences)
+	require.NotNil(t, got.RoutingPreferences.Alpha)
+	assert.Equal(t, 0.7, *got.RoutingPreferences.Alpha)
+	assert.Equal(t, []string{"moonshotai/kimi-k2.7-code"}, got.RoutingPreferences.PreferredModels)
+	assert.Equal(t, []string{"openai/gpt-5.5"}, got.RoutingPreferences.ExcludedModels)
+	assert.Equal(t, map[string]float64{"moonshotai/kimi-k2.7-code": 0.2}, got.RoutingPreferences.SubsidizedModelCostFactor)
 	assert.Equal(t, "moonshotai/kimi-k2.7-code", result.Model)
 	assert.Equal(t, "classifier_confidence", result.ScoreKind)
 	assert.Equal(t, "medium", result.PolicyGroup)

--- a/internal/router/hmm/hmm.go
+++ b/internal/router/hmm/hmm.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/google/uuid"
@@ -311,6 +312,7 @@ func rosterIDsForCatalogIDSet(ids map[string]struct{}) []string {
 		seen[rosterID] = struct{}{}
 		out = append(out, rosterID)
 	}
+	sort.Strings(out)
 	return out
 }
 

--- a/internal/router/hmm/hmm.go
+++ b/internal/router/hmm/hmm.go
@@ -27,12 +27,22 @@ type Candidate struct {
 type Query struct {
 	RouteID              string
 	PromptText           string
+	Harness              router.Harness
 	ConversationMessages []router.ConversationMessage
 	AvailableTools       []string
 	EstimatedInputTokens int
 	HasTools             bool
 	HasImages            bool
 	Candidates           []Candidate
+	RoutingPreferences   *RoutingPreferences
+}
+
+type RoutingPreferences struct {
+	Alpha                     *float64           `json:"alpha,omitempty"`
+	QualityBias               *float64           `json:"quality_bias,omitempty"`
+	PreferredModels           []string           `json:"preferred_models,omitempty"`
+	ExcludedModels            []string           `json:"excluded_models,omitempty"`
+	SubsidizedModelCostFactor map[string]float64 `json:"subsidized_model_cost_factor,omitempty"`
 }
 
 type Result struct {
@@ -163,12 +173,14 @@ func (r *Router) Route(ctx context.Context, req router.Request) (router.Decision
 	res, err := r.decider.Decide(ctx, Query{
 		RouteID:              requestRouteID,
 		PromptText:           req.PromptText,
+		Harness:              req.Harness,
 		ConversationMessages: req.ConversationMessages,
 		AvailableTools:       req.AvailableTools,
 		EstimatedInputTokens: req.EstimatedInputTokens,
 		HasTools:             req.HasTools,
 		HasImages:            req.HasImages,
 		Candidates:           candidates,
+		RoutingPreferences:   routingPreferencesFromRequest(req),
 	})
 	if err != nil {
 		log.Error("HMM router: sidecar decide failed; returning ErrHMMUnavailable", "err", err)
@@ -242,3 +254,84 @@ func isToolExecutionResult(res Result) bool {
 
 var _ router.Router = (*Router)(nil)
 var _ OutcomeReporter = (*Router)(nil)
+
+func routingPreferencesFromRequest(req router.Request) *RoutingPreferences {
+	prefs := RoutingPreferences{}
+	if req.RoutingKnobs != nil {
+		prefs.Alpha = req.RoutingKnobs.Alpha
+		prefs.QualityBias = req.RoutingKnobs.QualityBias
+	}
+	prefs.PreferredModels = rosterIDsForCatalogIDs(req.PreferredModels)
+	prefs.ExcludedModels = rosterIDsForCatalogIDSet(req.ExcludedModels)
+	prefs.SubsidizedModelCostFactor = rosterSubsidyFactors(req.SubsidizedModelCostFactor)
+	if prefs.Alpha == nil &&
+		prefs.QualityBias == nil &&
+		len(prefs.PreferredModels) == 0 &&
+		len(prefs.ExcludedModels) == 0 &&
+		len(prefs.SubsidizedModelCostFactor) == 0 {
+		return nil
+	}
+	return &prefs
+}
+
+func rosterIDsForCatalogIDs(ids []string) []string {
+	if len(ids) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(ids))
+	seen := map[string]struct{}{}
+	for _, id := range ids {
+		rosterID := rosterIDForModelID(id)
+		if rosterID == "" {
+			continue
+		}
+		if _, ok := seen[rosterID]; ok {
+			continue
+		}
+		seen[rosterID] = struct{}{}
+		out = append(out, rosterID)
+	}
+	return out
+}
+
+func rosterIDsForCatalogIDSet(ids map[string]struct{}) []string {
+	if len(ids) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(ids))
+	seen := map[string]struct{}{}
+	for id := range ids {
+		rosterID := rosterIDForModelID(id)
+		if rosterID == "" {
+			continue
+		}
+		if _, ok := seen[rosterID]; ok {
+			continue
+		}
+		seen[rosterID] = struct{}{}
+		out = append(out, rosterID)
+	}
+	return out
+}
+
+func rosterSubsidyFactors(factors map[string]float64) map[string]float64 {
+	if len(factors) == 0 {
+		return nil
+	}
+	out := make(map[string]float64, len(factors))
+	for id, factor := range factors {
+		rosterID := rosterIDForModelID(id)
+		if rosterID == "" {
+			continue
+		}
+		out[rosterID] = factor
+	}
+	return out
+}
+
+func rosterIDForModelID(id string) string {
+	if model, ok := catalog.ByID(id); ok {
+		return rosterIDFor(model)
+	}
+	return id
+}

--- a/internal/router/hmm/hmm_test.go
+++ b/internal/router/hmm/hmm_test.go
@@ -117,6 +117,20 @@ func TestRouterForwardsHarnessAndPreferenceSignals(t *testing.T) {
 	assert.Equal(t, map[string]float64{"moonshotai/kimi-k2.7-code": 0.15}, decider.query.RoutingPreferences.SubsidizedModelCostFactor)
 }
 
+func TestRosterIDsForCatalogIDSetIsDeterministic(t *testing.T) {
+	ids := map[string]struct{}{
+		"moonshotai/kimi-k2.7": {},
+		"claude-sonnet-5":      {},
+	}
+
+	for range 10 {
+		assert.Equal(t,
+			[]string{"anthropic/claude-sonnet-5", "moonshotai/kimi-k2.7-code"},
+			rosterIDsForCatalogIDSet(ids),
+		)
+	}
+}
+
 func TestRouterFailsClosedOnUnknownReturnedModel(t *testing.T) {
 	decider := &fakeDecider{res: Result{Model: "unknown/model"}}
 	r := New(decider, map[string]struct{}{"moonshotai/kimi-k2.7": {}}, map[string]struct{}{"fireworks": {}})

--- a/internal/router/hmm/hmm_test.go
+++ b/internal/router/hmm/hmm_test.go
@@ -73,6 +73,50 @@ func TestRouterKeepsGeneratedRouteIDWhenSidecarOmitsIt(t *testing.T) {
 	assert.Equal(t, decider.query.RouteID, decision.Metadata.RouteID)
 }
 
+func TestRouterForwardsHarnessAndPreferenceSignals(t *testing.T) {
+	decider := &fakeDecider{res: Result{Model: "moonshotai/kimi-k2.7-code"}}
+	r := New(
+		decider,
+		map[string]struct{}{
+			"moonshotai/kimi-k2.7": {},
+			"claude-sonnet-5":      {},
+		},
+		map[string]struct{}{
+			providers.ProviderFireworks: {},
+			providers.ProviderAnthropic: {},
+		},
+	)
+	alpha := 0.25
+	qualityBias := 0.9
+
+	_, err := r.Route(context.Background(), router.Request{
+		PromptText:      "hello",
+		Harness:         router.HarnessClaudeCode,
+		PreferredModels: []string{"moonshotai/kimi-k2.7"},
+		ExcludedModels: map[string]struct{}{
+			"claude-sonnet-5": {},
+		},
+		RoutingKnobs: &router.Overrides{
+			Alpha:       &alpha,
+			QualityBias: &qualityBias,
+		},
+		SubsidizedModelCostFactor: map[string]float64{
+			"moonshotai/kimi-k2.7": 0.15,
+		},
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, router.HarnessClaudeCode, decider.query.Harness)
+	require.NotNil(t, decider.query.RoutingPreferences)
+	require.NotNil(t, decider.query.RoutingPreferences.Alpha)
+	require.NotNil(t, decider.query.RoutingPreferences.QualityBias)
+	assert.Equal(t, alpha, *decider.query.RoutingPreferences.Alpha)
+	assert.Equal(t, qualityBias, *decider.query.RoutingPreferences.QualityBias)
+	assert.Equal(t, []string{"moonshotai/kimi-k2.7-code"}, decider.query.RoutingPreferences.PreferredModels)
+	assert.Equal(t, []string{"anthropic/claude-sonnet-5"}, decider.query.RoutingPreferences.ExcludedModels)
+	assert.Equal(t, map[string]float64{"moonshotai/kimi-k2.7-code": 0.15}, decider.query.RoutingPreferences.SubsidizedModelCostFactor)
+}
+
 func TestRouterFailsClosedOnUnknownReturnedModel(t *testing.T) {
 	decider := &fakeDecider{res: Result{Model: "unknown/model"}}
 	r := New(decider, map[string]struct{}{"moonshotai/kimi-k2.7": {}}, map[string]struct{}{"fireworks": {}})

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -3,6 +3,16 @@ package router
 
 import "context"
 
+type Harness string
+
+const (
+	HarnessClaudeCode Harness = "claude_code"
+	HarnessCodex      Harness = "codex"
+	HarnessCursor     Harness = "cursor"
+	HarnessAPI        Harness = "api"
+	HarnessUnknown    Harness = "unknown"
+)
+
 type Overrides struct {
 	// Alpha is the raw per-cluster quality weight applied UNIFORMLY across every
 	// cluster (the eval/debug "sledgehammer" set via x-weave-routing-alpha), so
@@ -25,6 +35,7 @@ type Overrides struct {
 
 type Request struct {
 	RequestedModel       string
+	Harness              Harness
 	EstimatedInputTokens int
 	HasTools             bool
 	// HasImages: scorer drops text-only models from the eligible pool; turn


### PR DESCRIPTION
## Summary
- add router harness context to HMM route requests
- forward alpha/quality bias, preferred/excluded models, and subscription subsidy factors to the HMM sidecar
- tag proxy requests as claude_code, codex, or api before HMM routing

## Tests
- go test ./internal/router/hmm ./internal/proxy