### PR TITLE
Add opt-in switch to force Anthropic deployment credentials

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -27,6 +27,7 @@ Claude Code keep using the user's logged-in plan.
 | `OPENROUTER_API_KEY`  | *(none)*                                                  | **Recommended baseline.** Enables OpenRouter and the full OSS-model pool the cluster scorer is trained against. |
 | `OPENROUTER_BASE_URL` | `https://openrouter.ai/api/v1`                            | Override for OpenRouter or any OpenAI-compatible endpoint (vLLM, Together, Fireworks, self-hosted). |
 | `ANTHROPIC_API_KEY`   | *(none — passthrough)*                                    | Router's own Anthropic key. When unset, client `Authorization` headers pass through. |
+| `ROUTER_FORCE_ANTHROPIC_DEPLOYMENT_CREDENTIALS` | `false`                                | When `true`, router-keyed Anthropic requests ignore subscription OAuth tokens (`sk-ant-oat...`) and fall through to BYOK / deployment `ANTHROPIC_API_KEY`. |
 | `OPENAI_API_KEY`      | *(none)*                                                  | Enables the OpenAI provider (Chat Completions API). |
 | `OPENAI_BASE_URL`     | `https://api.openai.com`                                  | Override for OpenAI (e.g. Azure OpenAI). |
 | `GOOGLE_API_KEY`      | *(none)*                                                  | Enables Gemini via its OpenAI-compatible endpoint. |

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -335,6 +335,12 @@ type InstallationUsageBypassContextKey struct{}
 // routing decides on merits. See subscriptionRoutingDisabledForRequest.
 type InstallationSubscriptionRoutingDisabledContextKey struct{}
 
+// ForceAnthropicDeploymentCredentialsContextKey is the context key for a
+// deployment-wide policy that suppresses Anthropic subscription OAuth on
+// router-keyed requests so credential resolution falls through to BYOK /
+// deployment ANTHROPIC_API_KEY. Carried as bool; absent == false.
+type ForceAnthropicDeploymentCredentialsContextKey struct{}
+
 // UsageBypassConfig is the per-installation subscription usage-bypass setting,
 // stashed on ctx by the auth middleware. Threshold is nil when the toggle is on
 // but no value has been chosen yet; the request path falls back to
@@ -525,6 +531,11 @@ func installationExcludedModelsFromContext(ctx context.Context) []string {
 func subscriptionRoutingDisabledForRequest(ctx context.Context) bool {
 	disabled, _ := ctx.Value(InstallationSubscriptionRoutingDisabledContextKey{}).(bool)
 	return disabled
+}
+
+func forceAnthropicDeploymentCredentialsForRequest(ctx context.Context) bool {
+	force, _ := ctx.Value(ForceAnthropicDeploymentCredentialsContextKey{}).(bool)
+	return force
 }
 
 // routingKnobsForRequest resolves the routing knobs for a request. The
@@ -3356,7 +3367,9 @@ func resolveAndInjectCredentials(ctx context.Context, provider string, headers h
 	routerKeyed := installationIDFromContext(ctx) != (uuid.UUID{})
 	// Skip subscription OAuth (fall through to BYOK / deployment key): exhausted (Anthropic-only, avoid re-429) or toggle off (provider-wide).
 	subDisabled := subscriptionRoutingDisabledForRequest(ctx)
-	suppressClaudeSub := claudeSubscriptionSuppressed(ctx) || subDisabled
+	forceAnthropicDeploymentCreds := provider == providers.ProviderAnthropic &&
+		routerKeyed && forceAnthropicDeploymentCredentialsForRequest(ctx)
+	suppressClaudeSub := claudeSubscriptionSuppressed(ctx) || subDisabled || forceAnthropicDeploymentCreds
 	suppressCodexSub := subDisabled
 	if provider == providers.ProviderAnthropic && !suppressClaudeSub {
 		// Subscription-first (subscription -> BYOK -> deployment), resolved here

--- a/internal/proxy/subscription_suppression_credential_internal_test.go
+++ b/internal/proxy/subscription_suppression_credential_internal_test.go
@@ -59,6 +59,20 @@ func TestResolveAndInjectCredentials_UnsuppressedSubStillForwarded(t *testing.T)
 	assert.True(t, got.OAuth)
 }
 
+// Deployment policy can force router-keyed Anthropic turns onto BYOK /
+// deployment credentials (ANTHROPIC_API_KEY), even when a subscription bearer
+// is present in Authorization.
+func TestResolveAndInjectCredentials_ForceAnthropicDeploymentCredentials(t *testing.T) {
+	ctx := context.WithValue(routerKeyedCtx(), ForceAnthropicDeploymentCredentialsContextKey{}, true)
+	headers := http.Header{}
+	headers.Set("Authorization", "Bearer sk-ant-oat01-live")
+
+	out := resolveAndInjectCredentials(ctx, providers.ProviderAnthropic, headers)
+
+	assert.Nil(t, CredentialsFromContext(out),
+		"forced deployment credentials must suppress Anthropic subscription resolution")
+}
+
 // The clear must be scoped to Anthropic: a suppressed-Claude request that also
 // carries a Codex subscription for an OpenAI turn must still resolve the Codex
 // credential (its OpenAI turns bill the caller's ChatGPT plan, unaffected).

--- a/internal/server/middleware/auth.go
+++ b/internal/server/middleware/auth.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"workweave/router/internal/auth"
+	"workweave/router/internal/config"
 	"workweave/router/internal/observability"
 	"workweave/router/internal/proxy"
 	"workweave/router/internal/router"
@@ -19,6 +20,8 @@ const (
 	ctxKeyAPIKey         = "router_api_key"
 	ctxKeyAdminPrincipal = "router_admin_principal"
 )
+
+var forceAnthropicDeploymentCredentials = config.GetOr("ROUTER_FORCE_ANTHROPIC_DEPLOYMENT_CREDENTIALS", "false") == "true"
 
 // RouterKeyHeader carries the Weave Router key when clients need to preserve Authorization / x-api-key for the upstream provider.
 const RouterKeyHeader = "X-Weave-Router-Key"
@@ -138,6 +141,9 @@ func withAPIKey(svc *auth.Service, byokDisabled bool) gin.HandlerFunc {
 		}
 		if installation != nil && installation.ID != "" {
 			ctx = context.WithValue(ctx, proxy.InstallationIDContextKey{}, installation.ID)
+		}
+		if forceAnthropicDeploymentCredentials {
+			ctx = context.WithValue(ctx, proxy.ForceAnthropicDeploymentCredentialsContextKey{}, true)
 		}
 		// Stash the dedicated subscription header (router-keyed path) raw; the
 		// proxy validates its shape and decides precedence. Never logged.


### PR DESCRIPTION
## Summary
- add a deployment toggle (ROUTER_FORCE_ANTHROPIC_DEPLOYMENT_CREDENTIALS) that suppresses Anthropic subscription OAuth on router-keyed requests
- when enabled, router-keyed Anthropic turns fall through to BYOK / deployment ANTHROPIC_API_KEY instead of sk-ant-oat subscription bearer
- document the new env var in docs/CONFIGURATION.md

## Why
Some deployments want router-owned/provider credentials for Anthropic traffic even when clients carry subscription OAuth tokens in Authorization.

## Validation
- added unit test: TestResolveAndInjectCredentials_ForceAnthropicDeploymentCredentials
- unable to run Go tests in this environment (go command not found)