### PR TITLE
fix: cap subscription overdraft at five dollars

### DIFF
--- a/internal/billing/service.go
+++ b/internal/billing/service.go
@@ -43,8 +43,8 @@ const MinBalanceMicros int64 = 0
 // is rate-limit exhausted, or the scorer routes to a non-covered model). Rather
 // than 402 free subscription traffic at zero balance, allow the balance to run
 // negative to this floor, then gate — staying optimistic while bounding the
-// unbilled-failover window. -$20.
-const SubscriptionOverdraftFloorMicros int64 = -20_000_000
+// unbilled-failover window. -$5.
+const SubscriptionOverdraftFloorMicros int64 = -5_000_000
 
 // Service orchestrates balance reads and debits. No I/O of its own — all
 // persistence flows through the Repo interface.

--- a/internal/server/middleware/balance_check_test.go
+++ b/internal/server/middleware/balance_check_test.go
@@ -388,6 +388,8 @@ func TestWithBalanceCheck_402sCodexSubscriptionOnAnthropicRoute(t *testing.T) {
 }
 
 func TestWithBalanceCheck_SubscriptionOverdraftAllowsNegativeBalance(t *testing.T) {
+	assert.Equal(t, int64(-5_000_000), billing.SubscriptionOverdraftFloorMicros)
+
 	// A subscription-covered request stays optimistic: a small negative balance
 	// (e.g. paid failover) within the overdraft floor still passes.
 	repo := &stubBillingRepo{balance: billing.SubscriptionOverdraftFloorMicros / 2}


### PR DESCRIPTION
## Summary
- lower the subscription-covered overdraft floor from - to -
- add a test assertion that locks the overdraft policy to -

## Test Plan
- go test ./internal/billing ./internal/server/middleware

Graphite submit was attempted first, but this repo is not synced with Graphite for the current account.