### PR TITLE
fix(proxy): expire hmm_history and guard cyber-refusal repin from HMM override

### DIFF
--- a/internal/proxy/cyber_refusal_internal_test.go
+++ b/internal/proxy/cyber_refusal_internal_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 
@@ -41,6 +42,15 @@ func (f *repinFakeStore) ResetUpstreamErrors(context.Context, [sessionpin.Sessio
 	return nil
 }
 func (f *repinFakeStore) SweepExpired(context.Context) error { return nil }
+
+func activeCyberRefusalUpsert(upserts []sessionpin.Pin) (sessionpin.Pin, bool) {
+	for _, u := range upserts {
+		if u.Reason == "cyber-refusal-repin" && u.PinnedUntil.After(time.Now()) {
+			return u, true
+		}
+	}
+	return sessionpin.Pin{}, false
+}
 
 // A realistic Anthropic-native refusal SSE (the router-visible wire shape:
 // stop_reason "refusal" on HTTP 200; see catalog.go). The real opus cyber
@@ -128,10 +138,10 @@ func TestMaybeRepinOnRefusal_RepinsToFallbackModel(t *testing.T) {
 
 	s.maybeRepinOnRefusal(repinCtx(), obs, [sessionpin.SessionKeyLen]byte{1, 2, 3}, "main_loop", served)
 
-	if len(store.upserts) != 1 {
-		t.Fatalf("expected exactly 1 re-pin upsert, got %d", len(store.upserts))
+	got, ok := activeCyberRefusalUpsert(store.upserts)
+	if !ok {
+		t.Fatalf("expected cyber-refusal-repin upsert, got %d upserts", len(store.upserts))
 	}
-	got := store.upserts[0]
 	if got.Model != "claude-sonnet-5" {
 		t.Fatalf("re-pinned to %q, want claude-sonnet-5", got.Model)
 	}
@@ -154,14 +164,37 @@ func TestMaybeRepinOnRefusal_PrefersPairedModel(t *testing.T) {
 
 	s.maybeRepinOnRefusal(repinCtx(), obs, [sessionpin.SessionKeyLen]byte{4, 5, 6}, "main_loop", served)
 
-	if len(store.upserts) != 1 {
-		t.Fatalf("expected 1 upsert, got %d", len(store.upserts))
+	got, ok := activeCyberRefusalUpsert(store.upserts)
+	if !ok {
+		t.Fatalf("expected cyber-refusal-repin upsert, got %d upserts", len(store.upserts))
 	}
-	if got := store.upserts[0].Model; got != "claude-haiku-4-5" {
-		t.Fatalf("re-pinned to %q, want the pin's PairedModel claude-haiku-4-5", got)
+	if got.Model != "claude-haiku-4-5" {
+		t.Fatalf("re-pinned to %q, want the pin's PairedModel claude-haiku-4-5", got.Model)
 	}
-	if got := store.upserts[0].Provider; got != "anthropic" {
-		t.Fatalf("re-pin provider = %q, want anthropic (from PairedProvider)", got)
+	if got.Provider != "anthropic" {
+		t.Fatalf("re-pin provider = %q, want anthropic (from PairedProvider)", got.Provider)
+	}
+}
+
+func TestMaybeRepinOnRefusal_ExpiresHMMHistory(t *testing.T) {
+	store := &repinFakeStore{}
+	s := &Service{pinStore: store, cyberRefusalFallbackModel: "claude-sonnet-5"}
+	obs := &refusalObserver{refused: true}
+	served := router.Decision{Provider: "anthropic", Model: "claude-opus-4-8"}
+
+	s.maybeRepinOnRefusal(repinCtx(), obs, [sessionpin.SessionKeyLen]byte{8, 9}, "main_loop", served)
+
+	var historyExpired bool
+	for _, u := range store.upserts {
+		if u.Role == hmmHistoryRole("main_loop") && u.PinnedUntil.Before(time.Now()) {
+			historyExpired = true
+		}
+	}
+	if !historyExpired {
+		t.Fatalf("expected expired hmm_history upsert, got upserts: %+v", store.upserts)
+	}
+	if _, ok := activeCyberRefusalUpsert(store.upserts); !ok {
+		t.Fatal("expected active cyber-refusal-repin upsert alongside hmm_history expiry")
 	}
 }
 

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -1760,6 +1760,9 @@ func (s *Service) maybeRepinOnRefusal(ctx context.Context, obs *refusalObserver,
 		log.Error("cyber-refusal re-pin: pin upsert failed", "err", err, "from_model", served.Model, "to_model", fbModel)
 		return
 	}
+	if err := s.expireSessionPin(context.Background(), installationID, sessionKey, hmmHistoryRole(role), "cyber-refusal-repin"); err != nil {
+		log.Error("cyber-refusal re-pin: hmm_history expiry failed", "err", err, "session_key", shortSessionKey(sessionKey))
+	}
 	log.Info("cyber refusal — re-pinned session off refusing model",
 		"session_key", shortSessionKey(sessionKey),
 		"from_model", served.Model,

--- a/internal/proxy/turnloop.go
+++ b/internal/proxy/turnloop.go
@@ -801,6 +801,8 @@ func (s *Service) hmmStayPin(req router.Request, activePin sessionpin.Pin, hmmHi
 	// prior non-HMM stretch must not steer an HMM EV stay.
 	if !isHMMPinReason(activePin.Reason) {
 		activePin = sessionpin.Pin{}
+	} else if activePin.Reason == "cyber-refusal-repin" {
+		hmmHistory = sessionpin.Pin{}
 	}
 	for _, candidate := range []sessionpin.Pin{activePin, hmmHistory} {
 		normalized, candidateOK := s.normalizeHMMStayPin(req, candidate)
@@ -819,6 +821,7 @@ func (s *Service) hmmStayPin(req router.Request, activePin sessionpin.Pin, hmmHi
 // guards against a stale cluster/planner pin steering an HMM turn's EV stay.
 func isHMMPinReason(reason string) bool {
 	return reason == hmmHistoryReason ||
+		reason == "cyber-refusal-repin" ||
 		strings.HasPrefix(strings.TrimSpace(reason), "hmm_policy")
 }
 

--- a/internal/proxy/turnloop.go
+++ b/internal/proxy/turnloop.go
@@ -775,7 +775,7 @@ func (s *Service) hmmCostGatedDecision(
 		SubsidizedCostFactor: req.SubsidizedModelCostFactor,
 	}, cfg)
 
-	if hmmFreshIsMoreExpensive(stayPin.Model, fresh.Model, req.SubsidizedModelCostFactor) {
+	if stayPin.Reason != "cyber-refusal-repin" && hmmFreshIsMoreExpensive(stayPin.Model, fresh.Model, req.SubsidizedModelCostFactor) {
 		confidence, ok := hmmDecisionConfidence(fresh)
 		if ok && confidence >= s.hmmUpgradeConfidenceThreshold {
 			base.Outcome = planner.OutcomeSwitch
@@ -841,7 +841,7 @@ func (s *Service) normalizeHMMStayPin(req router.Request, p sessionpin.Pin) (ses
 	if model == "" {
 		return sessionpin.Pin{}, false
 	}
-	if p.LastTurnEndedAt.IsZero() {
+	if p.LastTurnEndedAt.IsZero() && p.Reason != "cyber-refusal-repin" {
 		return sessionpin.Pin{}, false
 	}
 	if !p.PinnedUntil.IsZero() && !p.PinnedUntil.After(time.Now()) {

--- a/internal/proxy/turnloop_internal_test.go
+++ b/internal/proxy/turnloop_internal_test.go
@@ -739,9 +739,9 @@ func TestHMMEVStay_RespectsCyberRefusalRepin(t *testing.T) {
 		PinnedUntil:     now.Add(time.Hour),
 	}
 	fresh := router.Decision{
-		Provider: providers.ProviderAnthropic,
-		Model:    "claude-opus-4-8",
-		Reason:   "hmm_policy(classifier 'Complex Followup')",
+		Provider: providers.ProviderMakora,
+		Model:    "deepseek/deepseek-v4-flash",
+		Reason:   "hmm_policy(classifier 'Simple Tool Call Request')",
 		Metadata: &router.RoutingMetadata{
 			Strategy:    string(router.StrategyHMM),
 			RouteID:     "route-1",

--- a/internal/proxy/turnloop_internal_test.go
+++ b/internal/proxy/turnloop_internal_test.go
@@ -709,6 +709,62 @@ func TestHMMCostGate_IgnoresNonHMMActivePin(t *testing.T) {
 	assert.Equal(t, planner.ReasonNoPin, plan.Reason)
 }
 
+func TestHMMEVStay_RespectsCyberRefusalRepin(t *testing.T) {
+	t.Parallel()
+	svc := NewService(
+		nil,
+		map[string]providers.Client{providers.ProviderAnthropic: nil, providers.ProviderMakora: nil},
+		nil,
+		false,
+		nil,
+		nil,
+		false,
+		"anthropic", "claude-haiku-4-5",
+		nil,
+	)
+	now := time.Now()
+	activePin := sessionpin.Pin{
+		Provider:        providers.ProviderAnthropic,
+		Model:           "claude-sonnet-5",
+		LastServedModel: "claude-sonnet-5",
+		Reason:          "cyber-refusal-repin",
+		LastTurnEndedAt: now.Add(-5 * time.Second),
+		PinnedUntil:     now.Add(time.Hour),
+	}
+	history := sessionpin.Pin{
+		Provider:        providers.ProviderAnthropic,
+		LastServedModel: "claude-opus-4-8",
+		Reason:          hmmHistoryReason,
+		LastTurnEndedAt: now.Add(-3 * time.Second),
+		PinnedUntil:     now.Add(time.Hour),
+	}
+	fresh := router.Decision{
+		Provider: providers.ProviderAnthropic,
+		Model:    "claude-opus-4-8",
+		Reason:   "hmm_policy(classifier 'Complex Followup')",
+		Metadata: &router.RoutingMetadata{
+			Strategy:    string(router.StrategyHMM),
+			RouteID:     "route-1",
+			ChosenScore: 0.70,
+		},
+	}
+
+	decision, plan, sticky, stayModel := svc.hmmCostGatedDecision(
+		router.Request{},
+		activePin,
+		history,
+		fresh,
+		100,
+		false,
+	)
+
+	assert.True(t, sticky, "cyber-refusal-repin fallback must not lose to stale hmm_history")
+	assert.Equal(t, "claude-sonnet-5", decision.Model)
+	assert.Equal(t, "claude-sonnet-5", stayModel)
+	assert.Equal(t, planner.OutcomeStay, plan.Outcome)
+	assert.Equal(t, planner.ReasonEVNegative, plan.Reason)
+}
+
 func TestHMMCostGate_HonorsHMMReasonedActivePin(t *testing.T) {
 	svc := NewService(
 		nil,

--- a/internal/proxy/turnloop_internal_test.go
+++ b/internal/proxy/turnloop_internal_test.go
@@ -765,6 +765,53 @@ func TestHMMEVStay_RespectsCyberRefusalRepin(t *testing.T) {
 	assert.Equal(t, planner.ReasonEVNegative, plan.Reason)
 }
 
+func TestHMMEVStay_CyberRefusalRepinBlocksConfidentUpgrade(t *testing.T) {
+	t.Parallel()
+	svc := NewService(
+		nil,
+		map[string]providers.Client{providers.ProviderAnthropic: nil, providers.ProviderMakora: nil},
+		nil,
+		false,
+		nil,
+		nil,
+		false,
+		"anthropic", "claude-haiku-4-5",
+		nil,
+	)
+	activePin := sessionpin.Pin{
+		Provider:        providers.ProviderAnthropic,
+		Model:           "claude-sonnet-5",
+		LastServedModel: "claude-sonnet-5",
+		Reason:          "cyber-refusal-repin",
+		PinnedUntil:     time.Now().Add(time.Hour),
+	}
+	fresh := router.Decision{
+		Provider: providers.ProviderAnthropic,
+		Model:    "claude-opus-4-8",
+		Reason:   "hmm_policy(mock_hmm_sidecar)",
+		Metadata: &router.RoutingMetadata{
+			Strategy:    string(router.StrategyHMM),
+			RouteID:     "route-1",
+			ChosenScore: 0.99,
+		},
+	}
+
+	decision, plan, sticky, stayModel := svc.hmmCostGatedDecision(
+		router.Request{},
+		activePin,
+		sessionpin.Pin{},
+		fresh,
+		100,
+		false,
+	)
+
+	assert.True(t, sticky)
+	assert.Equal(t, "claude-sonnet-5", decision.Model)
+	assert.Equal(t, "claude-sonnet-5", stayModel)
+	assert.Equal(t, planner.OutcomeStay, plan.Outcome)
+	assert.NotEqual(t, hmmReasonConfidentUpgrade, plan.Reason)
+}
+
 func TestHMMCostGate_HonorsHMMReasonedActivePin(t *testing.T) {
 	svc := NewService(
 		nil,


### PR DESCRIPTION
## Summary
 
Fixes a session-routing bug where a cyber-refusal fallback pin is silently
undone on the very next HMM turn.
 
1. **Expire `{role}_hmm_history` on cyber-refusal repin** — closes the gap
   Bugbot flagged on #675 ("Refusal repin ignores sticky role"). #675 fixed
   the call site to use `stickyStateRole(routeRes)`, but `maybeRepinOnRefusal`
   never expired `hmm_history`, so it kept pointing at the refusing model.
2. **Treat `cyber-refusal-repin` as a valid HMM stay candidate** (via
   `isHMMPinReason`) so the fallback pin itself can actually win EV-stay,
   instead of being discarded as a non-HMM pin.
3. **Block `hmm_confident_upgrade` while a `cyber-refusal-repin` pin is
   active** — found via live e2e repro, not speculative. The mock HMM
   sidecar returned a high-confidence pick for the refusing model, which
   would have silently defeated commits 1+2 in production. Scoped to the
   pin's *reason*, not the specific model (see tradeoff below).
## Root cause
 
`recordHMMTurnHistory` writes the refusing model into `{role}_hmm_history`
before `maybeRepinOnRefusal` runs. `isHMMPinReason` excludes
`cyber-refusal-repin`, so on the next HMM turn `hmmStayPin` discards the
active fallback pin and falls back to `hmm_history` — which still points at
the refusing model with a live TTL. HMM EV-stay re-selects the refusing
model, undoing the re-pin.
 
Unaffected by #677 (confirmed — its diff touches `PriorServedModel`/
confidence-threshold plumbing only, not `maybeRepinOnRefusal`, `hmmStayPin`,
or history expiry).
 
## Live verification
 
End-to-end on a rebuilt container from this branch (mock HMM sidecar,
`ROUTER_CYBER_REFUSAL_REPIN=true`):
 
- **Turn 1** (HMM session, refusal triggered): `claude-opus-4-8` refuses.
  Server re-pins to fallback.
```
  session_pins:
    default_mid              → claude-sonnet-5   (cyber-refusal-repin, active)
    default_mid_hmm_history  → claude-opus-4-8    (expired)
```
 
- **Turn 2** (same session):
```
  X-Router-Decision: cyber-refusal-repin
  X-Router-Model: claude-sonnet-5
```
 
  `decision_reason: cyber-refusal-repin`, `sticky_hit: true` — fallback holds.
 
Prior to commit 3, the same repro showed turn 2 reverting to `claude-opus-4-8`
via `hmm_confident_upgrade` even after commits 1–2.
 
## Tradeoff
 
The confident-upgrade block in commit 3 is scoped to the active pin's
*reason*, not to the specific refusing model — the refusing model isn't
persisted on the active pin row (`UpsertSessionPin` omits `last_served_model`),
so narrowing this further would require a schema/field addition. Net effect:
no confident upgrade to *any* model (including a genuinely better third
option) while the repin is active. Acceptable tradeoff for short-term
stability after a refusal; the pin expires on its normal TTL.
 
## Test plan
 
- [x] `TestHMMEVStay_RespectsCyberRefusalRepin` — fails on `main`, passes here
- [x] `TestHMMEVStay_CyberRefusalRepinBlocksConfidentUpgrade`
- [x] `TestHMMCostGate_IgnoresNonHMMActivePin` — unchanged, still passes
      (confirms the carve-out is scoped to `cyber-refusal-repin` only, not a
      general relaxation of the non-HMM pin gate)
- [x] `make check`
- [x] `go test ./... -race -count=1` — 3 pre-existing failures
      (`TestFireTelemetryRecoversFromPanic`, `TestSafeGoRecoversFromPanic`,
      `TestService_VerifyAPIKey_RecoversFromMarkUsedPanic`), confirmed
      reproducing identically on `main`, unrelated to this change
- [x] Live e2e repro (see above)
