### PR TITLE
Add HMM router feedback forwarding

### DIFF
--- a/internal/proxy/router_feedback.go
+++ b/internal/proxy/router_feedback.go
@@ -178,9 +178,12 @@ func (s *Service) reportRouterFeedback(
 	if installationID != uuid.Nil {
 		payload["installation_id"] = installationID.String()
 	}
-	if err := s.hmmFeedbackReporter.ReportFeedback(context.Background(), payload); err != nil {
-		observability.FromContext(ctx).Error("/router-feedback: sidecar feedback report failed", "err", err)
-	}
+	log := observability.FromContext(ctx)
+	observability.SafeGo(log, hmmFeedbackReportTimeout, "reportHMMFeedback", func(reportCtx context.Context) {
+		if err := s.hmmFeedbackReporter.ReportFeedback(reportCtx, payload); err != nil {
+			log.Error("/router-feedback: sidecar feedback report failed", "err", err)
+		}
+	})
 }
 
 // routerFeedbackAck renders the acknowledgment, echoing the verdict. The

--- a/internal/proxy/router_feedback.go
+++ b/internal/proxy/router_feedback.go
@@ -2,6 +2,7 @@ package proxy
 
 import (
 	"context"
+	"encoding/hex"
 	"net/http"
 	"strings"
 	"time"
@@ -9,6 +10,7 @@ import (
 	"workweave/router/internal/auth"
 	"workweave/router/internal/observability"
 	"workweave/router/internal/observability/otel"
+	"workweave/router/internal/router"
 	"workweave/router/internal/router/catalog"
 	"workweave/router/internal/router/sessionpin"
 	"workweave/router/internal/translate"
@@ -111,6 +113,9 @@ func (s *Service) handleRouterFeedbackCommand(
 			return err
 		}
 	}
+	if router.StrategyFromContext(ctx) == router.StrategyHMM {
+		s.reportRouterFeedback(ctx, installationID, sessionKey, role, routerUserID, clientID, env.Model(), servedModel, rating, feedback)
+	}
 
 	now := time.Now()
 	otel.Record(ctx, otel.Span{
@@ -142,6 +147,40 @@ func (s *Service) handleRouterFeedbackCommand(
 	)
 
 	return writeSyntheticCommandResponse(w, env, routerFeedbackAck(env.SourceFormat(), rating), inputTokens)
+}
+
+func (s *Service) reportRouterFeedback(
+	ctx context.Context,
+	installationID uuid.UUID,
+	sessionKey [sessionpin.SessionKeyLen]byte,
+	role string,
+	routerUserID string,
+	clientID ClientIdentity,
+	requestedModel string,
+	servedModel string,
+	rating string,
+	feedback string,
+) {
+	if s.hmmFeedbackReporter == nil {
+		return
+	}
+	payload := map[string]interface{}{
+		"feedback_key":      hex.EncodeToString(sessionKey[:]),
+		"feedback_role":     role,
+		"rating":            rating,
+		"feedback":          feedback,
+		"requested_model":   requestedModel,
+		"served_model":      servedModel,
+		"router_user_id":    routerUserID,
+		"client_app":        clientID.ClientApp,
+		"client_session_id": clientID.SessionID,
+	}
+	if installationID != uuid.Nil {
+		payload["installation_id"] = installationID.String()
+	}
+	if err := s.hmmFeedbackReporter.ReportFeedback(context.Background(), payload); err != nil {
+		observability.FromContext(ctx).Error("/router-feedback: sidecar feedback report failed", "err", err)
+	}
 }
 
 // routerFeedbackAck renders the acknowledgment, echoing the verdict. The

--- a/internal/proxy/router_feedback_proxy_test.go
+++ b/internal/proxy/router_feedback_proxy_test.go
@@ -31,6 +31,22 @@ func (f *fakeFeedbackStore) InsertRouterFeedback(ctx context.Context, p proxy.Ro
 	return nil
 }
 
+type fakePolicyFeedbackRouter struct {
+	mu       sync.Mutex
+	payloads []map[string]interface{}
+}
+
+func (f *fakePolicyFeedbackRouter) Route(ctx context.Context, req router.Request) (router.Decision, error) {
+	return router.Decision{}, nil
+}
+
+func (f *fakePolicyFeedbackRouter) ReportFeedback(ctx context.Context, payload map[string]interface{}) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.payloads = append(f.payloads, payload)
+	return nil
+}
+
 func TestService_RouterFeedbackCommand_PersistsAndAcks(t *testing.T) {
 	const body = `{
 		"model":"claude-sonnet-4-6",
@@ -70,6 +86,63 @@ func TestService_RouterFeedbackCommand_PersistsAndAcks(t *testing.T) {
 	first, _ := blocks[0].(map[string]any)
 	text, _ := first["text"].(string)
 	assert.Contains(t, text, "Feedback recorded")
+}
+
+func TestService_RouterFeedbackCommand_ForwardsPolicyFeedback(t *testing.T) {
+	const body = `{
+		"model":"claude-sonnet-4-6",
+		"max_tokens":1024,
+		"messages":[
+			{"role":"user","content":"/rf- label=\"Complex Followup\" model=\"anthropic/claude-sonnet-5\" should have used the deeper route"}
+		]
+	}`
+	store := newFakePinStore()
+	store.hasPin = true
+	store.pin = sessionpin.Pin{Provider: providers.ProviderAnthropic, Model: "claude-haiku-4-5", LastServedModel: "claude-haiku-4-5"}
+	feedback := &fakeFeedbackStore{}
+	policyFeedback := &fakePolicyFeedbackRouter{}
+	fr := &fakeRouter{decision: router.Decision{Provider: providers.ProviderAnthropic, Model: "claude-sonnet-4-6", Reason: "cluster"}}
+	svc := newPinSvc(fr, store).
+		WithRouterFeedbackStore(feedback).
+		WithHMMRouter(policyFeedback)
+
+	installationID := uuid.New().String()
+	ctx := router.WithStrategy(authedCtx(installationID), router.StrategyHMM)
+	rec := httptest.NewRecorder()
+	httpReq := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(""))
+	require.NoError(t, svc.ProxyMessages(ctx, []byte(body), rec, httpReq))
+
+	assert.Equal(t, 0, fr.routeCalls)
+	require.Len(t, feedback.events, 1)
+	require.Len(t, policyFeedback.payloads, 1)
+	payload := policyFeedback.payloads[0]
+	assert.Equal(t, "down", payload["rating"])
+	assert.Equal(t, "label=\"Complex Followup\" model=\"anthropic/claude-sonnet-5\" should have used the deeper route", payload["feedback"])
+	assert.Equal(t, "claude-sonnet-4-6", payload["requested_model"])
+	assert.Equal(t, "claude-haiku-4-5", payload["served_model"])
+	assert.Equal(t, installationID, payload["installation_id"])
+	assert.NotEmpty(t, payload["feedback_key"])
+	assert.NotEmpty(t, payload["feedback_role"])
+}
+
+func TestService_RouterFeedbackCommand_DoesNotForwardPolicyFeedbackOutsideHMM(t *testing.T) {
+	const body = `{
+		"model":"claude-sonnet-4-6",
+		"max_tokens":1024,
+		"messages":[
+			{"role":"user","content":"/rf+"}
+		]
+	}`
+	store := newFakePinStore()
+	policyFeedback := &fakePolicyFeedbackRouter{}
+	fr := &fakeRouter{decision: router.Decision{Provider: providers.ProviderAnthropic, Model: "claude-sonnet-4-6", Reason: "cluster"}}
+	svc := newPinSvc(fr, store).WithHMMRouter(policyFeedback)
+
+	rec := httptest.NewRecorder()
+	httpReq := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(""))
+	require.NoError(t, svc.ProxyMessages(authedCtx(uuid.NewString()), []byte(body), rec, httpReq))
+
+	assert.Empty(t, policyFeedback.payloads)
 }
 
 func TestService_RouterFeedbackCommand_OpenAIIngress(t *testing.T) {

--- a/internal/proxy/router_feedback_proxy_test.go
+++ b/internal/proxy/router_feedback_proxy_test.go
@@ -2,17 +2,20 @@ package proxy_test
 
 import (
 	"context"
+	"encoding/hex"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"workweave/router/internal/providers"
 	"workweave/router/internal/proxy"
 	"workweave/router/internal/router"
 	"workweave/router/internal/router/sessionpin"
+	"workweave/router/internal/translate"
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
@@ -33,11 +36,16 @@ func (f *fakeFeedbackStore) InsertRouterFeedback(ctx context.Context, p proxy.Ro
 
 type fakePolicyFeedbackRouter struct {
 	mu       sync.Mutex
+	decision router.Decision
+	requests []router.Request
 	payloads []map[string]interface{}
 }
 
 func (f *fakePolicyFeedbackRouter) Route(ctx context.Context, req router.Request) (router.Decision, error) {
-	return router.Decision{}, nil
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.requests = append(f.requests, req)
+	return f.decision, nil
 }
 
 func (f *fakePolicyFeedbackRouter) ReportFeedback(ctx context.Context, payload map[string]interface{}) error {
@@ -45,6 +53,41 @@ func (f *fakePolicyFeedbackRouter) ReportFeedback(ctx context.Context, payload m
 	defer f.mu.Unlock()
 	f.payloads = append(f.payloads, payload)
 	return nil
+}
+
+func (f *fakePolicyFeedbackRouter) Payloads() []map[string]interface{} {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]map[string]interface{}(nil), f.payloads...)
+}
+
+func (f *fakePolicyFeedbackRouter) Requests() []router.Request {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]router.Request(nil), f.requests...)
+}
+
+type blockingPolicyFeedbackRouter struct {
+	started chan bool
+	release chan struct{}
+}
+
+func (f *blockingPolicyFeedbackRouter) Route(ctx context.Context, req router.Request) (router.Decision, error) {
+	return router.Decision{}, nil
+}
+
+func (f *blockingPolicyFeedbackRouter) ReportFeedback(ctx context.Context, payload map[string]interface{}) error {
+	_, hasDeadline := ctx.Deadline()
+	select {
+	case f.started <- hasDeadline:
+	default:
+	}
+	select {
+	case <-f.release:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
 }
 
 func TestService_RouterFeedbackCommand_PersistsAndAcks(t *testing.T) {
@@ -114,8 +157,12 @@ func TestService_RouterFeedbackCommand_ForwardsPolicyFeedback(t *testing.T) {
 
 	assert.Equal(t, 0, fr.routeCalls)
 	require.Len(t, feedback.events, 1)
-	require.Len(t, policyFeedback.payloads, 1)
-	payload := policyFeedback.payloads[0]
+	require.Eventually(t, func() bool {
+		return len(policyFeedback.Payloads()) == 1
+	}, time.Second, 10*time.Millisecond)
+	payloads := policyFeedback.Payloads()
+	require.Len(t, payloads, 1)
+	payload := payloads[0]
 	assert.Equal(t, "down", payload["rating"])
 	assert.Equal(t, "label=\"Complex Followup\" model=\"anthropic/claude-sonnet-5\" should have used the deeper route", payload["feedback"])
 	assert.Equal(t, "claude-sonnet-4-6", payload["requested_model"])
@@ -123,6 +170,109 @@ func TestService_RouterFeedbackCommand_ForwardsPolicyFeedback(t *testing.T) {
 	assert.Equal(t, installationID, payload["installation_id"])
 	assert.NotEmpty(t, payload["feedback_key"])
 	assert.NotEmpty(t, payload["feedback_role"])
+}
+
+func TestService_RouterFeedbackCommand_AcksBeforePolicyFeedbackCompletes(t *testing.T) {
+	const body = `{
+		"model":"claude-sonnet-4-6",
+		"max_tokens":1024,
+		"messages":[
+			{"role":"user","content":"/rf+"}
+		]
+	}`
+	store := newFakePinStore()
+	fr := &fakeRouter{decision: router.Decision{Provider: providers.ProviderAnthropic, Model: "claude-sonnet-4-6", Reason: "cluster"}}
+	policyFeedback := &blockingPolicyFeedbackRouter{
+		started: make(chan bool, 1),
+		release: make(chan struct{}),
+	}
+	defer close(policyFeedback.release)
+	svc := newPinSvc(fr, store).WithHMMRouter(policyFeedback)
+
+	ctx := router.WithStrategy(authedCtx(uuid.NewString()), router.StrategyHMM)
+	rec := httptest.NewRecorder()
+	httpReq := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(""))
+	done := make(chan error, 1)
+	go func() {
+		done <- svc.ProxyMessages(ctx, []byte(body), rec, httpReq)
+	}()
+
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("router-feedback acknowledgment waited for policy feedback")
+	}
+	select {
+	case hasDeadline := <-policyFeedback.started:
+		assert.True(t, hasDeadline, "background policy feedback must have a bounded context")
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for policy feedback dispatch")
+	}
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	blocks, ok := resp["content"].([]any)
+	require.True(t, ok)
+	require.NotEmpty(t, blocks)
+	first, _ := blocks[0].(map[string]any)
+	assert.Contains(t, first["text"], "Feedback recorded")
+}
+
+func TestService_RouterFeedbackCommand_CorrelatesCompactedHMMRoute(t *testing.T) {
+	routeBody := []byte(`{
+		"model":"claude-haiku-4-5",
+		"max_tokens":195000,
+		"messages":[
+			{"role":"user","content":"` + strings.Repeat("x", 30_000) + `"},
+			{"role":"assistant","content":"working"},
+			{"role":"user","content":"latest request"}
+		]
+	}`)
+	routeEnv, err := translate.ParseAnthropic(routeBody)
+	require.NoError(t, err)
+	rawSessionKey := proxy.DeriveSessionKey(routeEnv, "key-1")
+	rawFeedbackKey := hex.EncodeToString(rawSessionKey[:])
+
+	store := newFakePinStore()
+	policyFeedback := &fakePolicyFeedbackRouter{decision: router.Decision{
+		Provider: providers.ProviderAnthropic,
+		Model:    "claude-haiku-4-5",
+		Reason:   "hmm_policy(label=Simple Followup)",
+		Metadata: &router.RoutingMetadata{Strategy: string(router.StrategyHMM)},
+	}}
+	fr := &fakeRouter{decision: router.Decision{Provider: providers.ProviderAnthropic, Model: "claude-haiku-4-5", Reason: "cluster"}}
+	svc := newPinSvc(fr, store).
+		WithHMMRouter(policyFeedback).
+		WithAvailableModels(map[string]struct{}{"claude-haiku-4-5": {}}).
+		WithCompaction(nil, proxy.DefaultCompactionTriggerPct)
+	ctx := router.WithStrategy(authedCtx(uuid.NewString()), router.StrategyHMM)
+	httpReq := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(""))
+	require.NoError(t, svc.ProxyMessages(ctx, routeBody, httptest.NewRecorder(), httpReq))
+
+	requests := policyFeedback.Requests()
+	require.Len(t, requests, 1)
+	assert.Equal(t, rawFeedbackKey, requests[0].FeedbackKey)
+
+	feedbackBody := []byte(`{
+		"model":"claude-haiku-4-5",
+		"max_tokens":1024,
+		"messages":[
+			{"role":"user","content":"` + strings.Repeat("x", 30_000) + `"},
+			{"role":"assistant","content":"working"},
+			{"role":"user","content":"latest request"},
+			{"role":"assistant","content":"done"},
+			{"role":"user","content":"/rf+"}
+		]
+	}`)
+	require.NoError(t, svc.ProxyMessages(ctx, feedbackBody, httptest.NewRecorder(), httpReq))
+	require.Eventually(t, func() bool {
+		return len(policyFeedback.Payloads()) == 1
+	}, time.Second, 10*time.Millisecond)
+	payloads := policyFeedback.Payloads()
+	require.Len(t, payloads, 1)
+	assert.Equal(t, requests[0].FeedbackKey, payloads[0]["feedback_key"])
+	assert.Equal(t, requests[0].FeedbackRole, payloads[0]["feedback_role"])
 }
 
 func TestService_RouterFeedbackCommand_DoesNotForwardPolicyFeedbackOutsideHMM(t *testing.T) {
@@ -142,7 +292,7 @@ func TestService_RouterFeedbackCommand_DoesNotForwardPolicyFeedbackOutsideHMM(t 
 	httpReq := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(""))
 	require.NoError(t, svc.ProxyMessages(authedCtx(uuid.NewString()), []byte(body), rec, httpReq))
 
-	assert.Empty(t, policyFeedback.payloads)
+	assert.Empty(t, policyFeedback.Payloads())
 }
 
 func TestService_RouterFeedbackCommand_OpenAIIngress(t *testing.T) {

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -369,6 +369,7 @@ const routingMarkerHeader = "X-Weave-Routing-Marker"
 const routingMarkerPrefix = "✦ **Weave Router** → "
 const maxSidecarDisplayMarkerRunes = 512
 const hmmOutcomeReportTimeout = 2 * time.Second
+const hmmFeedbackReportTimeout = 2 * time.Second
 const hmmOutcomeResponseMaxBytes = 256 * 1024
 
 type hmmOutcomeResponse struct {
@@ -1958,7 +1959,6 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 	}
 
 	routeStart := time.Now()
-	routingSessionKey := DeriveSessionKey(env, apiKeyID)
 	req := router.Request{
 		RequestedModel:       feats.Model,
 		EstimatedInputTokens: feats.Tokens,
@@ -1967,12 +1967,14 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 		PromptText:           promptText,
 		ConversationMessages: conversationMessagesForRouting(env),
 		AvailableTools:       availableToolsForRouting(env),
-		FeedbackKey:          hex.EncodeToString(routingSessionKey[:]),
-		FeedbackRole:         roleForTier(catalog.TierFor(feats.Model)),
-		EnabledProviders:     enabledProviders,
-		ExcludedModels:       excluded,
-		PreferredModels:      s.preferredModelsForRequest(ctx),
-		RoutingKnobs:         routingKnobsForRequest(ctx),
+		// Keep this tied to client-visible history so a later feedback command
+		// can correlate with the route even if local compaction rewrites env.
+		FeedbackKey:      hex.EncodeToString(sessionKey[:]),
+		FeedbackRole:     roleForTier(catalog.TierFor(feats.Model)),
+		EnabledProviders: enabledProviders,
+		ExcludedModels:   excluded,
+		PreferredModels:  s.preferredModelsForRequest(ctx),
+		RoutingKnobs:     routingKnobsForRequest(ctx),
 	}
 	routeRes, routeErr := s.runTurnLoop(ctx, env, feats, apiKeyID, installationID, "", r.Header, req)
 	if routeErr != nil {
@@ -3867,7 +3869,6 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 	}
 
 	routeStart := time.Now()
-	routingSessionKey := DeriveSessionKey(env, apiKeyID)
 	routeRes, err := s.runTurnLoop(ctx, env, feats, apiKeyID, installationID, subAgentHint, r.Header, router.Request{
 		RequestedModel:       feats.Model,
 		EstimatedInputTokens: feats.Tokens,
@@ -3876,12 +3877,14 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 		PromptText:           promptText,
 		ConversationMessages: conversationMessagesForRouting(env),
 		AvailableTools:       availableToolsForRouting(env),
-		FeedbackKey:          hex.EncodeToString(routingSessionKey[:]),
-		FeedbackRole:         roleForTier(catalog.TierFor(feats.Model)),
-		EnabledProviders:     enabledProviders,
-		ExcludedModels:       excludedOAI,
-		PreferredModels:      s.preferredModelsForRequest(ctx),
-		RoutingKnobs:         routingKnobsForRequest(ctx),
+		// Keep this tied to client-visible history so a later feedback command
+		// can correlate with the route even if local compaction rewrites env.
+		FeedbackKey:      hex.EncodeToString(sessionKey[:]),
+		FeedbackRole:     roleForTier(catalog.TierFor(feats.Model)),
+		EnabledProviders: enabledProviders,
+		ExcludedModels:   excludedOAI,
+		PreferredModels:  s.preferredModelsForRequest(ctx),
+		RoutingKnobs:     routingKnobsForRequest(ctx),
 	})
 	routeMs := time.Since(routeStart).Milliseconds()
 	if err != nil {

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -55,8 +55,9 @@ type Service struct {
 	rlRouter router.Router
 	// hmmRouter is the opt-in policy router selected per-request via
 	// x-weave-router-strategy: hmm.
-	hmmRouter          router.Router
-	hmmOutcomeReporter hmm.OutcomeReporter
+	hmmRouter           router.Router
+	hmmOutcomeReporter  hmm.OutcomeReporter
+	hmmFeedbackReporter hmm.FeedbackReporter
 	// banditRouter is the opt-in Thompson-sampling router, selected per-request
 	// via x-weave-router-strategy: bandit. Nil when ROUTER_BANDIT_POSTERIOR_FILE
 	// is unset at boot; the strategy header then 503s.
@@ -1457,6 +1458,11 @@ func (s *Service) WithHMMRouter(r router.Router) *Service {
 	} else {
 		s.hmmOutcomeReporter = nil
 	}
+	if reporter, ok := r.(hmm.FeedbackReporter); ok {
+		s.hmmFeedbackReporter = reporter
+	} else {
+		s.hmmFeedbackReporter = nil
+	}
 	return s
 }
 
@@ -1960,6 +1966,8 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 		PromptText:           promptText,
 		ConversationMessages: conversationMessagesForRouting(env),
 		AvailableTools:       availableToolsForRouting(env),
+		FeedbackKey:          hex.EncodeToString(sessionKey[:]),
+		FeedbackRole:         roleForTier(catalog.TierFor(feats.Model)),
 		EnabledProviders:     enabledProviders,
 		ExcludedModels:       excluded,
 		PreferredModels:      s.preferredModelsForRequest(ctx),
@@ -3866,6 +3874,8 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 		PromptText:           promptText,
 		ConversationMessages: conversationMessagesForRouting(env),
 		AvailableTools:       availableToolsForRouting(env),
+		FeedbackKey:          hex.EncodeToString(sessionKey[:]),
+		FeedbackRole:         roleForTier(catalog.TierFor(feats.Model)),
 		EnabledProviders:     enabledProviders,
 		ExcludedModels:       excludedOAI,
 		PreferredModels:      s.preferredModelsForRequest(ctx),

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -1958,6 +1958,7 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 	}
 
 	routeStart := time.Now()
+	routingSessionKey := DeriveSessionKey(env, apiKeyID)
 	req := router.Request{
 		RequestedModel:       feats.Model,
 		EstimatedInputTokens: feats.Tokens,
@@ -1966,7 +1967,7 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 		PromptText:           promptText,
 		ConversationMessages: conversationMessagesForRouting(env),
 		AvailableTools:       availableToolsForRouting(env),
-		FeedbackKey:          hex.EncodeToString(sessionKey[:]),
+		FeedbackKey:          hex.EncodeToString(routingSessionKey[:]),
 		FeedbackRole:         roleForTier(catalog.TierFor(feats.Model)),
 		EnabledProviders:     enabledProviders,
 		ExcludedModels:       excluded,
@@ -3866,6 +3867,7 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 	}
 
 	routeStart := time.Now()
+	routingSessionKey := DeriveSessionKey(env, apiKeyID)
 	routeRes, err := s.runTurnLoop(ctx, env, feats, apiKeyID, installationID, subAgentHint, r.Header, router.Request{
 		RequestedModel:       feats.Model,
 		EstimatedInputTokens: feats.Tokens,
@@ -3874,7 +3876,7 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 		PromptText:           promptText,
 		ConversationMessages: conversationMessagesForRouting(env),
 		AvailableTools:       availableToolsForRouting(env),
-		FeedbackKey:          hex.EncodeToString(sessionKey[:]),
+		FeedbackKey:          hex.EncodeToString(routingSessionKey[:]),
 		FeedbackRole:         roleForTier(catalog.TierFor(feats.Model)),
 		EnabledProviders:     enabledProviders,
 		ExcludedModels:       excludedOAI,

--- a/internal/proxy/service_session_pin_test.go
+++ b/internal/proxy/service_session_pin_test.go
@@ -2,6 +2,7 @@ package proxy_test
 
 import (
 	"context"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"io"
@@ -557,6 +558,94 @@ func TestService_HMMSubAgentUsesFreshDecision(t *testing.T) {
 	store.mu.Lock()
 	assertOnlyHMMHistoryUpserts(t, store)
 	store.mu.Unlock()
+}
+
+func TestService_HMMFeedbackKeyUsesPostCompactionSession(t *testing.T) {
+	body := []byte(`{
+		"model":"claude-haiku-4-5",
+		"max_tokens":195000,
+		"messages":[
+			{"role":"user","content":"` + strings.Repeat("x", 30_000) + `"},
+			{"role":"assistant","content":"working"},
+			{"role":"user","content":"latest request"}
+		]
+	}`)
+
+	before, err := translate.ParseAnthropic(body)
+	require.NoError(t, err)
+	after, err := translate.ParseAnthropic(body)
+	require.NoError(t, err)
+	require.Positive(t, after.TrimLastNMessages(1))
+	beforeSessionKey := proxy.DeriveSessionKey(before, "key-1")
+	afterSessionKey := proxy.DeriveSessionKey(after, "key-1")
+	beforeKey := hex.EncodeToString(beforeSessionKey[:])
+	afterKey := hex.EncodeToString(afterSessionKey[:])
+	require.NotEqual(t, beforeKey, afterKey)
+
+	store := newFakePinStore()
+	fr := &fakeRouter{decision: router.Decision{
+		Provider: providers.ProviderAnthropic,
+		Model:    "claude-haiku-4-5",
+		Reason:   "hmm_policy(label=Simple Followup)",
+		Metadata: &router.RoutingMetadata{Strategy: string(router.StrategyHMM)},
+	}}
+	svc := newPinSvc(fr, store).
+		WithHMMRouter(fr).
+		WithAvailableModels(map[string]struct{}{"claude-haiku-4-5": {}}).
+		WithCompaction(nil, proxy.DefaultCompactionTriggerPct)
+
+	ctx := router.WithStrategy(authedCtx(uuid.NewString()), router.StrategyHMM)
+	rec := httptest.NewRecorder()
+	httpReq := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(""))
+	require.NoError(t, svc.ProxyMessages(ctx, body, rec, httpReq))
+
+	require.NotNil(t, fr.capturedReq)
+	assert.Equal(t, afterKey, fr.capturedReq.FeedbackKey)
+	assert.Equal(t, "latest request", fr.capturedReq.ConversationMessages[0].Text)
+}
+
+func TestService_HMMFeedbackKeyOpenAIUsesPostCompactionSession(t *testing.T) {
+	body := []byte(`{
+		"model":"gpt-4o",
+		"max_tokens":123000,
+		"messages":[
+			{"role":"user","content":"` + strings.Repeat("x", 30_000) + `"},
+			{"role":"assistant","content":"working"},
+			{"role":"user","content":"latest request"}
+		]
+	}`)
+
+	before, err := translate.ParseOpenAI(body)
+	require.NoError(t, err)
+	after, err := translate.ParseOpenAI(body)
+	require.NoError(t, err)
+	require.Positive(t, after.TrimLastNMessages(1))
+	beforeSessionKey := proxy.DeriveSessionKey(before, "key-1")
+	afterSessionKey := proxy.DeriveSessionKey(after, "key-1")
+	beforeKey := hex.EncodeToString(beforeSessionKey[:])
+	afterKey := hex.EncodeToString(afterSessionKey[:])
+	require.NotEqual(t, beforeKey, afterKey)
+
+	store := newFakePinStore()
+	fr := &fakeRouter{decision: router.Decision{
+		Provider: providers.ProviderOpenAI,
+		Model:    "gpt-4o",
+		Reason:   "hmm_policy(label=Simple Followup)",
+		Metadata: &router.RoutingMetadata{Strategy: string(router.StrategyHMM)},
+	}}
+	svc := newOpenAIPinSvc(fr, store).
+		WithHMMRouter(fr).
+		WithAvailableModels(map[string]struct{}{"gpt-4o": {}}).
+		WithCompaction(nil, proxy.DefaultCompactionTriggerPct)
+
+	ctx := router.WithStrategy(authedCtx(uuid.NewString()), router.StrategyHMM)
+	rec := httptest.NewRecorder()
+	httpReq := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(""))
+	require.NoError(t, svc.ProxyOpenAIChatCompletion(ctx, body, rec, httpReq))
+
+	require.NotNil(t, fr.capturedReq)
+	assert.Equal(t, afterKey, fr.capturedReq.FeedbackKey)
+	assert.Equal(t, "latest request", fr.capturedReq.ConversationMessages[0].Text)
 }
 
 func TestService_HardPin_ExploreFallsThroughWhenFlagOff(t *testing.T) {

--- a/internal/proxy/service_session_pin_test.go
+++ b/internal/proxy/service_session_pin_test.go
@@ -560,7 +560,7 @@ func TestService_HMMSubAgentUsesFreshDecision(t *testing.T) {
 	store.mu.Unlock()
 }
 
-func TestService_HMMFeedbackKeyUsesPostCompactionSession(t *testing.T) {
+func TestService_HMMFeedbackKeyUsesClientSessionBeforeCompaction(t *testing.T) {
 	body := []byte(`{
 		"model":"claude-haiku-4-5",
 		"max_tokens":195000,
@@ -600,11 +600,12 @@ func TestService_HMMFeedbackKeyUsesPostCompactionSession(t *testing.T) {
 	require.NoError(t, svc.ProxyMessages(ctx, body, rec, httpReq))
 
 	require.NotNil(t, fr.capturedReq)
-	assert.Equal(t, afterKey, fr.capturedReq.FeedbackKey)
+	assert.Equal(t, beforeKey, fr.capturedReq.FeedbackKey)
+	assert.NotEqual(t, afterKey, fr.capturedReq.FeedbackKey)
 	assert.Equal(t, "latest request", fr.capturedReq.ConversationMessages[0].Text)
 }
 
-func TestService_HMMFeedbackKeyOpenAIUsesPostCompactionSession(t *testing.T) {
+func TestService_HMMFeedbackKeyOpenAIUsesClientSessionBeforeCompaction(t *testing.T) {
 	body := []byte(`{
 		"model":"gpt-4o",
 		"max_tokens":123000,
@@ -644,7 +645,8 @@ func TestService_HMMFeedbackKeyOpenAIUsesPostCompactionSession(t *testing.T) {
 	require.NoError(t, svc.ProxyOpenAIChatCompletion(ctx, body, rec, httpReq))
 
 	require.NotNil(t, fr.capturedReq)
-	assert.Equal(t, afterKey, fr.capturedReq.FeedbackKey)
+	assert.Equal(t, beforeKey, fr.capturedReq.FeedbackKey)
+	assert.NotEqual(t, afterKey, fr.capturedReq.FeedbackKey)
 	assert.Equal(t, "latest request", fr.capturedReq.ConversationMessages[0].Text)
 }
 

--- a/internal/router/hmm/client.go
+++ b/internal/router/hmm/client.go
@@ -44,23 +44,31 @@ func NewHTTPDecider(baseURL string, client *http.Client, timeout time.Duration) 
 
 // ReportOutcome posts final dispatch usage/status back to the policy sidecar.
 func (d *HTTPDecider) ReportOutcome(ctx context.Context, payload map[string]interface{}) error {
+	return d.post(ctx, "/outcome", payload, "outcome")
+}
+
+func (d *HTTPDecider) ReportFeedback(ctx context.Context, payload map[string]interface{}) error {
+	return d.post(ctx, "/feedback", payload, "feedback")
+}
+
+func (d *HTTPDecider) post(ctx context.Context, path string, payload map[string]interface{}, label string) error {
 	body, err := json.Marshal(payload)
 	if err != nil {
-		return fmt.Errorf("marshal outcome request: %w", err)
+		return fmt.Errorf("marshal %s request: %w", label, err)
 	}
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, d.baseURL+"/outcome", bytes.NewReader(body))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, d.baseURL+path, bytes.NewReader(body))
 	if err != nil {
-		return fmt.Errorf("build outcome request: %w", err)
+		return fmt.Errorf("build %s request: %w", label, err)
 	}
 	req.Header.Set("content-type", "application/json")
 	resp, err := d.client.Do(req)
 	if err != nil {
-		return fmt.Errorf("call HMM outcome endpoint: %w", err)
+		return fmt.Errorf("call HMM %s endpoint: %w", label, err)
 	}
 	defer resp.Body.Close()
 	payloadBytes, readErr := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
 	if readErr != nil {
-		return fmt.Errorf("read HMM outcome response: %w", readErr)
+		return fmt.Errorf("read HMM %s response: %w", label, readErr)
 	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		var parsed struct {
@@ -68,9 +76,9 @@ func (d *HTTPDecider) ReportOutcome(ctx context.Context, payload map[string]inte
 		}
 		_ = json.Unmarshal(payloadBytes, &parsed)
 		if parsed.Error != "" {
-			return fmt.Errorf("HMM outcome status %d: %s", resp.StatusCode, parsed.Error)
+			return fmt.Errorf("HMM %s status %d: %s", label, resp.StatusCode, parsed.Error)
 		}
-		return fmt.Errorf("HMM outcome status %d", resp.StatusCode)
+		return fmt.Errorf("HMM %s status %d", label, resp.StatusCode)
 	}
 	return nil
 }
@@ -82,6 +90,8 @@ type routeRequest struct {
 	TurnIndex            int               `json:"turn_index"`
 	ConversationMessages []routeMessage    `json:"conversation_messages,omitempty"`
 	AvailableTools       []string          `json:"available_tools,omitempty"`
+	FeedbackKey          string            `json:"feedback_key,omitempty"`
+	FeedbackRole         string            `json:"feedback_role,omitempty"`
 	EstimatedInputTokens int               `json:"estimated_input_tokens"`
 	HasTools             bool              `json:"has_tools"`
 	HasImages            bool              `json:"has_images"`
@@ -144,6 +154,8 @@ func (d *HTTPDecider) Decide(ctx context.Context, q Query) (Result, error) {
 		TurnIndex:            turnIndex(messages),
 		ConversationMessages: messages,
 		AvailableTools:       clipRouteValues(q.AvailableTools, maxRouteToolCallInputKeys, maxRouteToolCallInputChars),
+		FeedbackKey:          q.FeedbackKey,
+		FeedbackRole:         q.FeedbackRole,
 		EstimatedInputTokens: q.EstimatedInputTokens,
 		HasTools:             q.HasTools,
 		HasImages:            q.HasImages,

--- a/internal/router/hmm/client_test.go
+++ b/internal/router/hmm/client_test.go
@@ -37,8 +37,10 @@ func TestHTTPDeciderPostsRouteAndParsesDisplayMetadata(t *testing.T) {
 
 	decider := NewHTTPDecider(server.URL, server.Client(), 0)
 	result, err := decider.Decide(context.Background(), Query{
-		RouteID:    "route-1",
-		PromptText: "hello",
+		RouteID:      "route-1",
+		PromptText:   "hello",
+		FeedbackKey:  "feedback-session",
+		FeedbackRole: "default",
 		ConversationMessages: []router.ConversationMessage{
 			{Role: "user", Text: "please explore the repo"},
 			{Role: "assistant", Text: "done"},
@@ -84,6 +86,8 @@ func TestHTTPDeciderPostsRouteAndParsesDisplayMetadata(t *testing.T) {
 	assert.Equal(t, []string{"file_path"}, got.ConversationMessages[3].ToolCalls[0].InputKeys)
 	assert.True(t, got.HasTools)
 	assert.Equal(t, []string{"Read", "Grep"}, got.AvailableTools)
+	assert.Equal(t, "feedback-session", got.FeedbackKey)
+	assert.Equal(t, "default", got.FeedbackRole)
 	assert.Equal(t, []string{"moonshotai/kimi-k2.7-code"}, got.CandidateModels)
 	assert.Equal(t, "moonshotai/kimi-k2.7-code", result.Model)
 	assert.Equal(t, "classifier_confidence", result.ScoreKind)
@@ -150,4 +154,27 @@ func TestHTTPDeciderReportsOutcome(t *testing.T) {
 
 	require.NoError(t, err)
 	assert.Equal(t, "route-1", got["route_id"])
+}
+
+func TestHTTPDeciderReportsFeedback(t *testing.T) {
+	var got map[string]interface{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/feedback", r.URL.Path)
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&got))
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{"ok": true})
+	}))
+	defer server.Close()
+
+	decider := NewHTTPDecider(server.URL, server.Client(), 0)
+	err := decider.ReportFeedback(context.Background(), map[string]interface{}{
+		"feedback_key":  "feedback-session",
+		"feedback_role": "default",
+		"rating":        "down",
+		"feedback":      "label=Complex Followup",
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, "feedback-session", got["feedback_key"])
+	assert.Equal(t, "default", got["feedback_role"])
+	assert.Equal(t, "down", got["rating"])
 }

--- a/internal/router/hmm/hmm.go
+++ b/internal/router/hmm/hmm.go
@@ -29,6 +29,8 @@ type Query struct {
 	PromptText           string
 	ConversationMessages []router.ConversationMessage
 	AvailableTools       []string
+	FeedbackKey          string
+	FeedbackRole         string
 	EstimatedInputTokens int
 	HasTools             bool
 	HasImages            bool
@@ -59,24 +61,31 @@ type OutcomeReporter interface {
 	ReportOutcome(ctx context.Context, payload map[string]interface{}) error
 }
 
+type FeedbackReporter interface {
+	ReportFeedback(ctx context.Context, payload map[string]interface{}) error
+}
+
 type Router struct {
-	decider   Decider
-	reporter  OutcomeReporter
-	deployed  map[string]struct{}
-	available map[string]struct{}
-	toolLow   map[string]struct{}
-	imageLow  map[string]struct{}
+	decider          Decider
+	reporter         OutcomeReporter
+	feedbackReporter FeedbackReporter
+	deployed         map[string]struct{}
+	available        map[string]struct{}
+	toolLow          map[string]struct{}
+	imageLow         map[string]struct{}
 }
 
 func New(decider Decider, deployed, available map[string]struct{}) *Router {
 	reporter, _ := decider.(OutcomeReporter)
+	feedbackReporter, _ := decider.(FeedbackReporter)
 	return &Router{
-		decider:   decider,
-		reporter:  reporter,
-		deployed:  deployed,
-		available: available,
-		toolLow:   catalog.ToolUseLowSet(),
-		imageLow:  catalog.ImageUnsupportedSet(),
+		decider:          decider,
+		reporter:         reporter,
+		feedbackReporter: feedbackReporter,
+		deployed:         deployed,
+		available:        available,
+		toolLow:          catalog.ToolUseLowSet(),
+		imageLow:         catalog.ImageUnsupportedSet(),
 	}
 }
 
@@ -85,6 +94,13 @@ func (r *Router) ReportOutcome(ctx context.Context, payload map[string]interface
 		return nil
 	}
 	return r.reporter.ReportOutcome(ctx, payload)
+}
+
+func (r *Router) ReportFeedback(ctx context.Context, payload map[string]interface{}) error {
+	if r.feedbackReporter == nil {
+		return nil
+	}
+	return r.feedbackReporter.ReportFeedback(ctx, payload)
 }
 
 type eligibleCand struct {
@@ -165,6 +181,8 @@ func (r *Router) Route(ctx context.Context, req router.Request) (router.Decision
 		PromptText:           req.PromptText,
 		ConversationMessages: req.ConversationMessages,
 		AvailableTools:       req.AvailableTools,
+		FeedbackKey:          req.FeedbackKey,
+		FeedbackRole:         req.FeedbackRole,
 		EstimatedInputTokens: req.EstimatedInputTokens,
 		HasTools:             req.HasTools,
 		HasImages:            req.HasImages,

--- a/internal/router/hmm/hmm_test.go
+++ b/internal/router/hmm/hmm_test.go
@@ -45,6 +45,8 @@ func TestRouterMapsSidecarRosterModelBackToCatalogDecision(t *testing.T) {
 			Text: "latest hello",
 		}},
 		EstimatedInputTokens: 10,
+		FeedbackKey:          "feedback-session",
+		FeedbackRole:         "default",
 	})
 
 	require.NoError(t, err)
@@ -55,6 +57,8 @@ func TestRouterMapsSidecarRosterModelBackToCatalogDecision(t *testing.T) {
 	assert.Equal(t, "hmm", decision.Metadata.Strategy)
 	assert.Equal(t, float32(0.9), decision.Metadata.Propensity)
 	assert.Equal(t, "hello", decider.query.PromptText)
+	assert.Equal(t, "feedback-session", decider.query.FeedbackKey)
+	assert.Equal(t, "default", decider.query.FeedbackRole)
 	assert.Equal(t, []router.ConversationMessage{{Role: "user", Text: "latest hello"}}, decider.query.ConversationMessages)
 	assert.Equal(t, []Candidate{{RosterID: "moonshotai/kimi-k2.7-code", Provider: "fireworks"}}, decider.query.Candidates)
 }

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -36,6 +36,10 @@ type Request struct {
 	ConversationMessages []ConversationMessage
 	// AvailableTools is a bounded list of tool names declared on this request.
 	AvailableTools []string
+	// FeedbackKey/FeedbackRole are optional opaque correlation fields for
+	// sidecar routers that accept per-session feedback.
+	FeedbackKey  string
+	FeedbackRole string
 	// Per-request provider gating — nil means unrestricted.
 	EnabledProviders map[string]struct{}
 	// Per-request model exclusion — nil or empty means no exclusion.


### PR DESCRIPTION
Forward opaque feedback correlation to policy sidecars. HMM-specific interpretation remains outside router-internal. Tests: go test ./internal/router/hmm ./internal/proxy -count=1.