### PR TITLE
Strip router feedback artifacts from prompt history

### DIFF
--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -1817,6 +1817,9 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 		log.Error("Failed to parse Anthropic request", "err", parseErr)
 		return fmt.Errorf("parse request: %w", parseErr)
 	}
+	if removed := env.StripRouterFeedbackArtifacts(); removed > 0 {
+		log.Info("Stripped router-feedback artifacts from Anthropic history", "removed_messages", removed)
+	}
 
 	embedFlag := s.embedOnlyUserMessage
 	if v, ok := embedOnlyUserMessageOverride(ctx); ok {
@@ -3730,6 +3733,9 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 	if parseErr != nil {
 		log.Error("Failed to parse OpenAI request", "err", parseErr)
 		return fmt.Errorf("parse request: %w", parseErr)
+	}
+	if removed := env.StripRouterFeedbackArtifacts(); removed > 0 {
+		log.Info("Stripped router-feedback artifacts from OpenAI history", "removed_messages", removed)
 	}
 	embedFlag := s.embedOnlyUserMessage
 	if v, ok := embedOnlyUserMessageOverride(ctx); ok {

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -1817,6 +1817,18 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 		log.Error("Failed to parse Anthropic request", "err", parseErr)
 		return fmt.Errorf("parse request: %w", parseErr)
 	}
+
+	apiKeyID, _ := ctx.Value(APIKeyIDContextKey{}).(string)
+	externalID, _ := ctx.Value(ExternalIDContextKey{}).(string)
+	installationID := installationIDFromContext(ctx)
+	clientID := ClientIdentityFrom(ctx)
+	bypassEval := hasEvalOverrideHeader(r)
+
+	// Bind session_key/request_id/api_key_id/ingress onto a ctx-scoped logger
+	// before stripping router-only history. The derived key is reused below to
+	// avoid a second hash + divergent key if env.body mutates mid-flow.
+	var sessionKey [sessionpin.SessionKeyLen]byte
+	ctx, log, sessionKey = bindRequestLogger(ctx, env, apiKeyID, requestID, "anthropic_messages")
 	if removed := env.StripRouterFeedbackArtifacts(); removed > 0 {
 		log.Info("Stripped router-feedback artifacts from Anthropic history", "removed_messages", removed)
 	}
@@ -1833,17 +1845,6 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 		embedInput = "only_user_message"
 	}
 
-	apiKeyID, _ := ctx.Value(APIKeyIDContextKey{}).(string)
-	externalID, _ := ctx.Value(ExternalIDContextKey{}).(string)
-	installationID := installationIDFromContext(ctx)
-	clientID := ClientIdentityFrom(ctx)
-	bypassEval := hasEvalOverrideHeader(r)
-
-	// Bind session_key/request_id/api_key_id/ingress onto a ctx-scoped logger.
-	// The derived key is reused below to avoid a second hash + a divergent key
-	// if env.body mutates mid-flow.
-	var sessionKey [sessionpin.SessionKeyLen]byte
-	ctx, log, sessionKey = bindRequestLogger(ctx, env, apiKeyID, requestID, "anthropic_messages")
 	log.Info("ProxyMessages start",
 		"requested_model", feats.Model,
 		"stream", env.Stream(),
@@ -3734,6 +3735,11 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 		log.Error("Failed to parse OpenAI request", "err", parseErr)
 		return fmt.Errorf("parse request: %w", parseErr)
 	}
+
+	// Bind session-scoped logger before stripping router-only history; see the
+	// matching Anthropic block for why the raw client session shape owns pins.
+	var sessionKey [sessionpin.SessionKeyLen]byte
+	ctx, log, sessionKey = bindRequestLogger(ctx, env, apiKeyID, requestID, "openai_chat_completions")
 	if removed := env.StripRouterFeedbackArtifacts(); removed > 0 {
 		log.Info("Stripped router-feedback artifacts from OpenAI history", "removed_messages", removed)
 	}
@@ -3751,10 +3757,6 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 
 	bypassEval := hasEvalOverrideHeader(r)
 
-	// Bind session-scoped logger; see the matching block in ProxyMessages for
-	// the rationale around deriving the key once and reusing it.
-	var sessionKey [sessionpin.SessionKeyLen]byte
-	ctx, log, sessionKey = bindRequestLogger(ctx, env, apiKeyID, requestID, "openai_chat_completions")
 	log.Info("ProxyOpenAIChatCompletion start",
 		"requested_model", feats.Model,
 		"stream", env.Stream(),

--- a/internal/translate/router_feedback.go
+++ b/internal/translate/router_feedback.go
@@ -2,6 +2,8 @@ package translate
 
 import (
 	"strings"
+
+	"github.com/tidwall/gjson"
 )
 
 // RouterFeedbackResult holds the parsed outcome of a /router-feedback command.
@@ -41,6 +43,51 @@ func (env *RequestEnvelope) ExtractRouterFeedbackCommand() (RouterFeedbackResult
 	return res, found
 }
 
+// StripRouterFeedbackArtifacts removes prior router-feedback command turns and
+// synthetic ack turns from model-visible history. The current trailing user
+// command is preserved so ExtractRouterFeedbackCommand can still record it.
+func (env *RequestEnvelope) StripRouterFeedbackArtifacts() int {
+	switch env.format {
+	case FormatAnthropic, FormatOpenAI:
+	default:
+		return 0
+	}
+	msgs := gjson.GetBytes(env.body, "messages")
+	if !msgs.IsArray() {
+		return 0
+	}
+
+	lastUserIdx := -1
+	msgs.ForEach(func(key, msg gjson.Result) bool {
+		if msg.Get("role").String() == "user" {
+			lastUserIdx = int(key.Int())
+		}
+		return true
+	})
+
+	removed := 0
+	rebuilt := make([]string, 0, len(msgs.Array()))
+	msgs.ForEach(func(key, msg gjson.Result) bool {
+		idx := int(key.Int())
+		role := msg.Get("role").String()
+		content := msg.Get("content")
+		if role == "user" && idx != lastUserIdx && isRouterFeedbackCommandOnlyContent(content) {
+			removed++
+			return true
+		}
+		if role == "assistant" && isRouterFeedbackAckOnlyContent(content) {
+			removed++
+			return true
+		}
+		rebuilt = append(rebuilt, msg.Raw)
+		return true
+	})
+	if removed == 0 {
+		return 0
+	}
+	return env.setMessages(rebuilt, removed)
+}
+
 // parseRouterFeedbackCommand scans text for a /router-feedback (alias /rf)
 // directive on the first non-empty line, applying the same leading-line +
 // injected-prefix guards as parseForceModelCommand (see that function for the
@@ -75,6 +122,79 @@ func parseRouterFeedbackCommand(text string) (res RouterFeedbackResult, found bo
 		rating, feedback = splitLeadingRating(feedback)
 	}
 	return RouterFeedbackResult{Rating: rating, Feedback: feedback}, true, strings.TrimSpace(prefix)
+}
+
+func isRouterFeedbackCommandOnlyContent(content gjson.Result) bool {
+	switch {
+	case content.Type == gjson.String:
+		_, found, stripped := parseRouterFeedbackCommand(content.String())
+		return found && isOnlyInjectedCommandText(stripped)
+	case content.Type == gjson.JSON && content.IsArray():
+		seenCommand := false
+		allSynthetic := true
+		content.ForEach(func(_, block gjson.Result) bool {
+			if block.Get("type").String() != "text" {
+				allSynthetic = false
+				return false
+			}
+			text := block.Get("text").String()
+			if strings.TrimSpace(text) == "" || isClaudeCodeInjectedBlock(text) {
+				return true
+			}
+			_, found, stripped := parseRouterFeedbackCommand(text)
+			if found && isOnlyInjectedCommandText(stripped) {
+				seenCommand = true
+				return true
+			}
+			allSynthetic = false
+			return false
+		})
+		return seenCommand && allSynthetic
+	default:
+		return false
+	}
+}
+
+func isOnlyInjectedCommandText(text string) bool {
+	trimmed := strings.TrimSpace(text)
+	return trimmed == "" || leadingInjectedPrefixEnd(trimmed) == len(trimmed)
+}
+
+func isRouterFeedbackAckOnlyContent(content gjson.Result) bool {
+	switch {
+	case content.Type == gjson.String:
+		return isRouterFeedbackAckText(content.String())
+	case content.Type == gjson.JSON && content.IsArray():
+		seenAck := false
+		allSynthetic := true
+		content.ForEach(func(_, block gjson.Result) bool {
+			if block.Get("type").String() != "text" {
+				allSynthetic = false
+				return false
+			}
+			text := block.Get("text").String()
+			if strings.TrimSpace(text) == "" {
+				return true
+			}
+			if isRouterFeedbackAckText(text) {
+				seenAck = true
+				return true
+			}
+			allSynthetic = false
+			return false
+		})
+		return seenAck && allSynthetic
+	default:
+		return false
+	}
+}
+
+func isRouterFeedbackAckText(text string) bool {
+	trimmed := strings.TrimSpace(text)
+	return strings.HasPrefix(trimmed, "Weave Router: Feedback recorded") ||
+		strings.HasPrefix(trimmed, "Weave Router: router-feedback needs a verdict") ||
+		strings.HasPrefix(trimmed, "✦ **Weave Router** → Feedback recorded") ||
+		strings.HasPrefix(trimmed, "✦ **Weave Router** → Router-feedback needs a verdict")
 }
 
 // matchRouterFeedbackCommand recognizes the command token at the start of the


### PR DESCRIPTION
Prevents historical /rf commands and synthetic feedback acknowledgements from being included in later routing features or upstream model-visible context.