### PR TITLE
feat(router): add per-API-key default routing strategy

### DIFF
--- a/db/migrations/0034_api-key-default-strategy.down.sql
+++ b/db/migrations/0034_api-key-default-strategy.down.sql
@@ -1,0 +1,6 @@
+BEGIN;
+
+ALTER TABLE router.model_router_api_keys
+    DROP COLUMN default_strategy;
+
+COMMIT;

--- a/db/migrations/0034_api-key-default-strategy.up.sql
+++ b/db/migrations/0034_api-key-default-strategy.up.sql
@@ -1,0 +1,15 @@
+BEGIN;
+
+-- Per-key routing strategy default. Lets a client that cannot send the
+-- x-weave-router-strategy header (e.g. Cursor's Override Base URL, which has
+-- no custom-header field) opt into a non-cluster strategy by using a
+-- dedicated key instead. NULL means "no key default" -- the deployment
+-- default (cluster) applies. The x-weave-router-strategy header, when
+-- present and recognized, always takes precedence over this column; see
+-- WithRouterStrategyOverride. Allowed values (enforced in the app layer, not
+-- a CHECK constraint, to match the header's own validation path):
+-- cluster | rl | hmm | bandit.
+ALTER TABLE router.model_router_api_keys
+    ADD COLUMN default_strategy TEXT;
+
+COMMIT;

--- a/db/queries/model_router_api_keys.sql
+++ b/db/queries/model_router_api_keys.sql
@@ -6,6 +6,7 @@ INSERT INTO router.model_router_api_keys (
     key_prefix,
     key_hash,
     key_suffix,
+    default_strategy,
     created_by
 )
 VALUES (
@@ -15,6 +16,7 @@ VALUES (
     @key_prefix::varchar,
     @key_hash::varchar,
     @key_suffix::varchar,
+    @default_strategy,
     @created_by
 )
 RETURNING *;
@@ -63,6 +65,18 @@ WHERE id = @id::uuid
 -- name: SoftDeleteModelRouterAPIKey :exec
 UPDATE router.model_router_api_keys
 SET deleted_at = NOW()
+WHERE id = @id::uuid
+  AND installation_id = @installation_id::uuid
+  AND deleted_at IS NULL;
+
+-- Sets the per-key routing-strategy default, scoped to installation_id to
+-- prevent cross-tenant updates. NULL clears it so the key falls back to the
+-- deployment default (cluster) absent an x-weave-router-strategy header. The
+-- header always wins over this column when both are present; see
+-- WithRouterStrategyOverride.
+-- name: UpdateModelRouterAPIKeyDefaultStrategy :execrows
+UPDATE router.model_router_api_keys
+SET default_strategy = sqlc.narg('default_strategy')
 WHERE id = @id::uuid
   AND installation_id = @installation_id::uuid
   AND deleted_at IS NULL;

--- a/install/README.md
+++ b/install/README.md
@@ -211,6 +211,14 @@ What each `off` does (and `on` reverses byte-for-byte):
 settings UI. To toggle it, open **Settings → Models → Override OpenAI Base
 URL** and turn the override (`<base-url>/v1`) on or off there.
 
+Cursor also can't send custom headers, so it can't select a routing strategy
+via `x-weave-router-strategy` the way Claude Code / evals do. To opt a Cursor
+key into HMM (or another non-default strategy), mint it with
+`wv mr seed-key --default-strategy hmm` and paste that token into the OpenAI
+API key field — the key's stored default applies whenever no header is
+present. A header still overrides the key default when both are set, so the
+same key works unmodified for Claude Code / eval traffic that does send one.
+
 ## Verifying
 
 **Claude Code:**

--- a/internal/api/admin/keys.go
+++ b/internal/api/admin/keys.go
@@ -13,16 +13,22 @@ import (
 )
 
 type apiKeyResponse struct {
-	ID         string     `json:"id"`
-	Name       *string    `json:"name"`
-	KeyPrefix  string     `json:"key_prefix"`
-	KeySuffix  string     `json:"key_suffix"`
-	LastUsedAt *time.Time `json:"last_used_at"`
-	CreatedAt  time.Time  `json:"created_at"`
+	ID              string     `json:"id"`
+	Name            *string    `json:"name"`
+	KeyPrefix       string     `json:"key_prefix"`
+	KeySuffix       string     `json:"key_suffix"`
+	LastUsedAt      *time.Time `json:"last_used_at"`
+	CreatedAt       time.Time  `json:"created_at"`
+	DefaultStrategy string     `json:"default_strategy"`
 }
 
 type issueAPIKeyRequest struct {
 	Name string `json:"name"`
+	// DefaultStrategy is the per-key routing-strategy default; see
+	// auth.APIKey.DefaultStrategy. Empty (the common case) means no key
+	// default -- the deployment default (cluster) applies unless the caller
+	// sends x-weave-router-strategy.
+	DefaultStrategy string `json:"default_strategy"`
 }
 
 type issueAPIKeyResponse struct {
@@ -30,15 +36,35 @@ type issueAPIKeyResponse struct {
 	Token string         `json:"token"`
 }
 
+type updateAPIKeyDefaultStrategyRequest struct {
+	DefaultStrategy string `json:"default_strategy"`
+}
+
 func toAPIKeyResponse(k *auth.APIKey) apiKeyResponse {
 	return apiKeyResponse{
-		ID:         k.ID,
-		Name:       k.Name,
-		KeyPrefix:  k.KeyPrefix,
-		KeySuffix:  k.KeySuffix,
-		LastUsedAt: k.LastUsedAt,
-		CreatedAt:  k.CreatedAt,
+		ID:              k.ID,
+		Name:            k.Name,
+		KeyPrefix:       k.KeyPrefix,
+		KeySuffix:       k.KeySuffix,
+		LastUsedAt:      k.LastUsedAt,
+		CreatedAt:       k.CreatedAt,
+		DefaultStrategy: k.DefaultStrategy,
 	}
+}
+
+// writeAPIKeyServiceError maps IssueAPIKey/RotateAPIKey/SetAPIKeyDefaultStrategy
+// errors to HTTP responses. Callers pass the "action" fallback message (e.g.
+// "issue", "rotate") used when the error isn't one of the recognized sentinels.
+func writeAPIKeyServiceError(c *gin.Context, err error, action string) {
+	if errors.Is(err, auth.ErrUnknownStrategy) {
+		c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": "Unknown default_strategy. Must be one of: cluster, rl, hmm, bandit."})
+		return
+	}
+	if errors.Is(err, auth.ErrAPIKeyNotFound) {
+		c.AbortWithStatusJSON(http.StatusNotFound, gin.H{"error": "API key not found."})
+		return
+	}
+	c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"error": "Failed to " + action + " API key."})
 }
 
 func ListAPIKeysHandler(authSvc *auth.Service) gin.HandlerFunc {
@@ -75,9 +101,9 @@ func IssueAPIKeyHandler(authSvc *auth.Service) gin.HandlerFunc {
 		if req.Name != "" {
 			name = &req.Name
 		}
-		key, rawToken, err := authSvc.IssueAPIKey(c.Request.Context(), installation.ID, name, nil)
+		key, rawToken, err := authSvc.IssueAPIKey(c.Request.Context(), installation.ID, name, req.DefaultStrategy, nil)
 		if err != nil {
-			c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"error": "Failed to issue API key."})
+			writeAPIKeyServiceError(c, err, "issue")
 			return
 		}
 		c.JSON(http.StatusCreated, issueAPIKeyResponse{
@@ -88,8 +114,9 @@ func IssueAPIKeyHandler(authSvc *auth.Service) gin.HandlerFunc {
 }
 
 // RotateAPIKeyHandler soft-deletes the specified key and issues a replacement
-// against the same installation, carrying forward the previous key's name.
-// 404 when the id is not owned by the caller's installation.
+// against the same installation, carrying forward the previous key's name
+// and default_strategy. 404 when the id is not owned by the caller's
+// installation.
 func RotateAPIKeyHandler(authSvc *auth.Service) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		installation, ok := resolveInstallation(c, authSvc)
@@ -103,17 +130,41 @@ func RotateAPIKeyHandler(authSvc *auth.Service) gin.HandlerFunc {
 		}
 		key, rawToken, err := authSvc.RotateAPIKey(c.Request.Context(), installation.ID, id, nil)
 		if err != nil {
-			if errors.Is(err, auth.ErrAPIKeyNotFound) {
-				c.AbortWithStatusJSON(http.StatusNotFound, gin.H{"error": "API key not found."})
-				return
-			}
-			c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"error": "Failed to rotate API key."})
+			writeAPIKeyServiceError(c, err, "rotate")
 			return
 		}
 		c.JSON(http.StatusCreated, issueAPIKeyResponse{
 			Key:   toAPIKeyResponse(key),
 			Token: rawToken,
 		})
+	}
+}
+
+// UpdateAPIKeyDefaultStrategyHandler flips a key's default_strategy without
+// rotating (invalidating) the token itself -- the Cursor path: mint a key
+// once, then flip its default strategy as needed. 404 when the id is not
+// owned by the caller's installation; 400 for an unrecognized strategy.
+func UpdateAPIKeyDefaultStrategyHandler(authSvc *auth.Service) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		installation, ok := resolveInstallation(c, authSvc)
+		if !ok {
+			return
+		}
+		id := c.Param("id")
+		if id == "" {
+			c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": "Missing ID."})
+			return
+		}
+		var req updateAPIKeyDefaultStrategyRequest
+		if err := c.ShouldBindJSON(&req); err != nil {
+			c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": "Invalid request body."})
+			return
+		}
+		if err := authSvc.SetAPIKeyDefaultStrategy(c.Request.Context(), installation.ID, id, req.DefaultStrategy); err != nil {
+			writeAPIKeyServiceError(c, err, "update")
+			return
+		}
+		c.Status(http.StatusNoContent)
 	}
 }
 

--- a/internal/api/admin/keys_test.go
+++ b/internal/api/admin/keys_test.go
@@ -33,15 +33,16 @@ func (f *fakeAPIKeyRepository) Create(_ context.Context, params auth.CreateAPIKe
 	defer f.mu.Unlock()
 	f.nextID++
 	key := &auth.APIKey{
-		ID:             fmt.Sprintf("key-%d", f.nextID),
-		InstallationID: params.InstallationID,
-		ExternalID:     params.ExternalID,
-		Name:           params.Name,
-		KeyPrefix:      params.KeyPrefix,
-		KeyHash:        params.KeyHash,
-		KeySuffix:      params.KeySuffix,
-		CreatedBy:      params.CreatedBy,
-		CreatedAt:      time.Now(),
+		ID:              fmt.Sprintf("key-%d", f.nextID),
+		InstallationID:  params.InstallationID,
+		ExternalID:      params.ExternalID,
+		Name:            params.Name,
+		KeyPrefix:       params.KeyPrefix,
+		KeyHash:         params.KeyHash,
+		KeySuffix:       params.KeySuffix,
+		DefaultStrategy: params.DefaultStrategy,
+		CreatedBy:       params.CreatedBy,
+		CreatedAt:       time.Now(),
 	}
 	f.keys = append(f.keys, key)
 	return key, nil
@@ -78,6 +79,18 @@ func (f *fakeAPIKeyRepository) SoftDelete(_ context.Context, installationID, id 
 	return nil
 }
 
+func (f *fakeAPIKeyRepository) UpdateDefaultStrategy(_ context.Context, installationID, id, defaultStrategy string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	for _, k := range f.keys {
+		if k.ID == id && k.InstallationID == installationID && k.DeletedAt == nil {
+			k.DefaultStrategy = defaultStrategy
+			return nil
+		}
+	}
+	return auth.ErrAPIKeyNotFound
+}
+
 func (f *fakeAPIKeyRepository) softDeletedSnapshot() []string {
 	f.mu.Lock()
 	defer f.mu.Unlock()
@@ -102,6 +115,7 @@ func apiKeysEngine(svc *auth.Service) *gin.Engine {
 	engine.GET("/admin/v1/keys", inject, admin.ListAPIKeysHandler(svc))
 	engine.POST("/admin/v1/keys", inject, admin.IssueAPIKeyHandler(svc))
 	engine.POST("/admin/v1/keys/:id/rotate", inject, admin.RotateAPIKeyHandler(svc))
+	engine.PUT("/admin/v1/keys/:id/default-strategy", inject, admin.UpdateAPIKeyDefaultStrategyHandler(svc))
 	engine.GET("/admin/v1/provider-keys", inject, admin.ListExternalKeysHandler(svc))
 	return engine
 }
@@ -113,10 +127,10 @@ func newAuthServiceForKeyTests(apiKeys auth.APIKeyRepository, externalKeys auth.
 func TestListAPIKeysHandler_ReturnsKeysForInstallation(t *testing.T) {
 	repo := &fakeAPIKeyRepository{}
 	svc := newAuthServiceForKeyTests(repo, nil)
-	_, _, err := svc.IssueAPIKey(context.Background(), testInstallationID, nil, nil)
+	_, _, err := svc.IssueAPIKey(context.Background(), testInstallationID, nil, "", nil)
 	require.NoError(t, err)
 	// A key on a different installation must not leak into this installation's list.
-	_, _, err = svc.IssueAPIKey(context.Background(), "other-inst", nil, nil)
+	_, _, err = svc.IssueAPIKey(context.Background(), "other-inst", nil, "", nil)
 	require.NoError(t, err)
 
 	rec := httptest.NewRecorder()
@@ -170,7 +184,7 @@ func TestIssueAPIKeyHandler_ReturnsTokenMatchingFingerprint(t *testing.T) {
 func TestRotateAPIKeyHandler_SoftDeletesOldKeyAndIssuesNew(t *testing.T) {
 	repo := &fakeAPIKeyRepository{}
 	svc := newAuthServiceForKeyTests(repo, nil)
-	oldKey, _, err := svc.IssueAPIKey(context.Background(), testInstallationID, nil, nil)
+	oldKey, _, err := svc.IssueAPIKey(context.Background(), testInstallationID, nil, "", nil)
 	require.NoError(t, err)
 
 	req := httptest.NewRequest(http.MethodPost, "/admin/v1/keys/"+oldKey.ID+"/rotate", nil)
@@ -195,7 +209,7 @@ func TestRotateAPIKeyHandler_ForeignKeyIDReturnsNotFound(t *testing.T) {
 	repo := &fakeAPIKeyRepository{}
 	svc := newAuthServiceForKeyTests(repo, nil)
 	// Key belongs to a different installation than the one injected by apiKeysEngine.
-	foreignKey, _, err := svc.IssueAPIKey(context.Background(), "other-inst", nil, nil)
+	foreignKey, _, err := svc.IssueAPIKey(context.Background(), "other-inst", nil, "", nil)
 	require.NoError(t, err)
 
 	req := httptest.NewRequest(http.MethodPost, "/admin/v1/keys/"+foreignKey.ID+"/rotate", nil)
@@ -206,6 +220,111 @@ func TestRotateAPIKeyHandler_ForeignKeyIDReturnsNotFound(t *testing.T) {
 		"rotating a key id owned by a foreign installation must map auth.ErrAPIKeyNotFound to 404")
 	assert.Empty(t, repo.softDeletedSnapshot(),
 		"a rejected rotation must not soft-delete the foreign key")
+}
+
+func TestRotateAPIKeyHandler_CarriesForwardDefaultStrategy(t *testing.T) {
+	repo := &fakeAPIKeyRepository{}
+	svc := newAuthServiceForKeyTests(repo, nil)
+	oldKey, _, err := svc.IssueAPIKey(context.Background(), testInstallationID, nil, "hmm", nil)
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodPost, "/admin/v1/keys/"+oldKey.ID+"/rotate", nil)
+	rec := httptest.NewRecorder()
+	apiKeysEngine(svc).ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusCreated, rec.Code)
+	var resp struct {
+		Key struct {
+			DefaultStrategy string `json:"default_strategy"`
+		} `json:"key"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Equal(t, "hmm", resp.Key.DefaultStrategy,
+		"rotation must carry forward the old key's default_strategy")
+}
+
+func TestIssueAPIKeyHandler_PersistsDefaultStrategy(t *testing.T) {
+	repo := &fakeAPIKeyRepository{}
+	svc := newAuthServiceForKeyTests(repo, nil)
+
+	body, _ := json.Marshal(map[string]string{"name": "cursor-hmm", "default_strategy": "hmm"})
+	req := httptest.NewRequest(http.MethodPost, "/admin/v1/keys", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	apiKeysEngine(svc).ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusCreated, rec.Code)
+	var resp struct {
+		Key struct {
+			DefaultStrategy string `json:"default_strategy"`
+		} `json:"key"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Equal(t, "hmm", resp.Key.DefaultStrategy)
+}
+
+func TestIssueAPIKeyHandler_RejectsUnknownDefaultStrategy(t *testing.T) {
+	repo := &fakeAPIKeyRepository{}
+	svc := newAuthServiceForKeyTests(repo, nil)
+
+	body, _ := json.Marshal(map[string]string{"default_strategy": "not-a-strategy"})
+	req := httptest.NewRequest(http.MethodPost, "/admin/v1/keys", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	apiKeysEngine(svc).ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Empty(t, repo.keys, "an invalid default_strategy must not persist a key")
+}
+
+func TestUpdateAPIKeyDefaultStrategyHandler_FlipsWithoutRotating(t *testing.T) {
+	repo := &fakeAPIKeyRepository{}
+	svc := newAuthServiceForKeyTests(repo, nil)
+	key, _, err := svc.IssueAPIKey(context.Background(), testInstallationID, nil, "", nil)
+	require.NoError(t, err)
+
+	body, _ := json.Marshal(map[string]string{"default_strategy": "hmm"})
+	req := httptest.NewRequest(http.MethodPut, "/admin/v1/keys/"+key.ID+"/default-strategy", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	apiKeysEngine(svc).ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusNoContent, rec.Code)
+	keys, err := svc.ListAPIKeys(context.Background(), testInstallationID)
+	require.NoError(t, err)
+	require.Len(t, keys, 1)
+	assert.Equal(t, key.ID, keys[0].ID, "the token itself must be unchanged — this is a flip, not a rotate")
+	assert.Equal(t, "hmm", keys[0].DefaultStrategy)
+}
+
+func TestUpdateAPIKeyDefaultStrategyHandler_ForeignKeyIDReturnsNotFound(t *testing.T) {
+	repo := &fakeAPIKeyRepository{}
+	svc := newAuthServiceForKeyTests(repo, nil)
+	foreignKey, _, err := svc.IssueAPIKey(context.Background(), "other-inst", nil, "", nil)
+	require.NoError(t, err)
+
+	body, _ := json.Marshal(map[string]string{"default_strategy": "hmm"})
+	req := httptest.NewRequest(http.MethodPut, "/admin/v1/keys/"+foreignKey.ID+"/default-strategy", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	apiKeysEngine(svc).ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+}
+
+func TestUpdateAPIKeyDefaultStrategyHandler_RejectsUnknownValue(t *testing.T) {
+	repo := &fakeAPIKeyRepository{}
+	svc := newAuthServiceForKeyTests(repo, nil)
+	key, _, err := svc.IssueAPIKey(context.Background(), testInstallationID, nil, "", nil)
+	require.NoError(t, err)
+
+	body, _ := json.Marshal(map[string]string{"default_strategy": "not-a-strategy"})
+	req := httptest.NewRequest(http.MethodPut, "/admin/v1/keys/"+key.ID+"/default-strategy", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	apiKeysEngine(svc).ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
 }
 
 func TestListExternalKeysHandler_ReturnsProviderKeysForInstallation(t *testing.T) {

--- a/internal/auth/api_key.go
+++ b/internal/auth/api_key.go
@@ -17,16 +17,23 @@ type APIKey struct {
 	CreatedAt      time.Time
 	DeletedAt      *time.Time
 	CreatedBy      *string
+	// DefaultStrategy is the per-key routing-strategy default, used when the
+	// caller can't send x-weave-router-strategy (e.g. Cursor's Override Base
+	// URL, which has no custom-header field). Empty means no key default --
+	// the deployment default (cluster) applies. The header always wins over
+	// this value when present; see WithRouterStrategyOverride.
+	DefaultStrategy string
 }
 
 type CreateAPIKeyParams struct {
-	InstallationID string
-	ExternalID     string
-	Name           *string
-	KeyPrefix      string
-	KeyHash        string
-	KeySuffix      string
-	CreatedBy      *string
+	InstallationID  string
+	ExternalID      string
+	Name            *string
+	KeyPrefix       string
+	KeyHash         string
+	KeySuffix       string
+	DefaultStrategy string
+	CreatedBy       *string
 }
 
 type APIKeyRepository interface {
@@ -35,4 +42,9 @@ type APIKeyRepository interface {
 	ListForInstallation(ctx context.Context, installationID string) ([]*APIKey, error)
 	MarkUsed(ctx context.Context, id string) error
 	SoftDelete(ctx context.Context, installationID, id string) error
+	// UpdateDefaultStrategy sets the per-key default_strategy, scoped to
+	// installationID for cross-tenant safety. Empty defaultStrategy clears it
+	// (stored as NULL). Returns ErrAPIKeyNotFound if id isn't an active key
+	// owned by installationID.
+	UpdateDefaultStrategy(ctx context.Context, installationID, id, defaultStrategy string) error
 }

--- a/internal/auth/errors.go
+++ b/internal/auth/errors.go
@@ -17,4 +17,11 @@ var (
 	// UPDATE looks like success, so the caller would invalidate the cache and
 	// report the change as applied when nothing changed.
 	ErrInstallationNotFound = errors.New("installation not found")
+
+	// ErrUnknownStrategy is returned when an API key's default_strategy is set
+	// to a value outside the recognized router.Strategy set (or empty, which
+	// clears it). Mirrors the header path's own validation in
+	// WithRouterStrategyOverride so a key default can't smuggle in a value the
+	// header would reject.
+	ErrUnknownStrategy = errors.New("unknown router strategy")
 )

--- a/internal/auth/service.go
+++ b/internal/auth/service.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"workweave/router/internal/observability"
+	"workweave/router/internal/router"
 
 	"github.com/hashicorp/golang-lru/v2/expirable"
 )
@@ -104,19 +105,39 @@ func (s *Service) invalidateInstallation(installationID string) {
 	s.notifier.NotifyInstallationChanged(installationID)
 }
 
+// validAPIKeyDefaultStrategy reports whether s is empty (no key default) or a
+// recognized router.Strategy value. Mirrors the header's own recognized set
+// in WithRouterStrategyOverride so a key default can't smuggle in a value the
+// header path would reject.
+func validAPIKeyDefaultStrategy(s string) bool {
+	switch router.Strategy(s) {
+	case "", router.StrategyCluster, router.StrategyRL, router.StrategyHMM, router.StrategyBandit:
+		return true
+	default:
+		return false
+	}
+}
+
 // IssueAPIKey creates a new router API key and returns the raw token.
-func (s *Service) IssueAPIKey(ctx context.Context, installationID string, name *string, createdBy *string) (*APIKey, string, error) {
+// defaultStrategy is the per-key routing-strategy default (empty for none);
+// see APIKey.DefaultStrategy. Returns ErrUnknownStrategy for an unrecognized
+// value.
+func (s *Service) IssueAPIKey(ctx context.Context, installationID string, name *string, defaultStrategy string, createdBy *string) (*APIKey, string, error) {
+	if !validAPIKeyDefaultStrategy(defaultStrategy) {
+		return nil, "", fmt.Errorf("%w: %q", ErrUnknownStrategy, defaultStrategy)
+	}
 	rawToken := GenerateID(APIKeyPrefix)
 	keyHash, keyPrefix, keySuffix := APITokenFingerprint(rawToken)
 	externalID := GenerateID("kid")
 	key, err := s.apiKeys.Create(ctx, CreateAPIKeyParams{
-		InstallationID: installationID,
-		ExternalID:     externalID,
-		Name:           name,
-		KeyPrefix:      keyPrefix,
-		KeyHash:        keyHash,
-		KeySuffix:      keySuffix,
-		CreatedBy:      createdBy,
+		InstallationID:  installationID,
+		ExternalID:      externalID,
+		Name:            name,
+		KeyPrefix:       keyPrefix,
+		KeyHash:         keyHash,
+		KeySuffix:       keySuffix,
+		DefaultStrategy: defaultStrategy,
+		CreatedBy:       createdBy,
 	})
 	if err != nil {
 		return nil, "", err
@@ -130,10 +151,11 @@ func (s *Service) ListAPIKeys(ctx context.Context, installationID string) ([]*AP
 }
 
 // RotateAPIKey soft-deletes the named key and issues a replacement under the
-// same installation, carrying forward its name. Returns ErrAPIKeyNotFound if
-// keyID isn't an active key owned by installationID, so a foreign key UUID
-// can't be rotated. Not transactional: the brief "no active key" gap is fine
-// since rotation's whole point is invalidating the old token anyway.
+// same installation, carrying forward its name and default_strategy. Returns
+// ErrAPIKeyNotFound if keyID isn't an active key owned by installationID, so
+// a foreign key UUID can't be rotated. Not transactional: the brief "no
+// active key" gap is fine since rotation's whole point is invalidating the
+// old token anyway.
 func (s *Service) RotateAPIKey(ctx context.Context, installationID, keyID string, createdBy *string) (*APIKey, string, error) {
 	existing, err := s.apiKeys.ListForInstallation(ctx, installationID)
 	if err != nil {
@@ -152,12 +174,31 @@ func (s *Service) RotateAPIKey(ctx context.Context, installationID, keyID string
 	if err := s.apiKeys.SoftDelete(ctx, installationID, target.ID); err != nil {
 		return nil, "", err
 	}
-	key, raw, err := s.IssueAPIKey(ctx, installationID, target.Name, createdBy)
+	key, raw, err := s.IssueAPIKey(ctx, installationID, target.Name, target.DefaultStrategy, createdBy)
 	if err != nil {
 		return nil, "", err
 	}
 	s.invalidateInstallation(installationID)
 	return key, raw, nil
+}
+
+// SetAPIKeyDefaultStrategy sets the per-key routing-strategy default used
+// when the caller can't send x-weave-router-strategy (e.g. Cursor's Override
+// Base URL has no custom-header field). The header always wins over this
+// value when present; see WithRouterStrategyOverride. Empty clears the
+// default so the key falls back to the deployment default (cluster). Returns
+// ErrUnknownStrategy for an unrecognized value, or ErrAPIKeyNotFound if keyID
+// isn't an active key owned by installationID. Invalidates the cache so the
+// change applies on the next request instead of waiting out the TTL.
+func (s *Service) SetAPIKeyDefaultStrategy(ctx context.Context, installationID, keyID, defaultStrategy string) error {
+	if !validAPIKeyDefaultStrategy(defaultStrategy) {
+		return fmt.Errorf("%w: %q", ErrUnknownStrategy, defaultStrategy)
+	}
+	if err := s.apiKeys.UpdateDefaultStrategy(ctx, installationID, keyID, defaultStrategy); err != nil {
+		return err
+	}
+	s.invalidateInstallation(installationID)
+	return nil
 }
 
 // DeleteAPIKey soft-deletes an API key and invalidates the installation's

--- a/internal/auth/service_test.go
+++ b/internal/auth/service_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"fmt"
 	"log/slog"
 	"strings"
 	"sync"
@@ -73,6 +74,82 @@ func (f *fakeAPIKeyRepository) MarkUsed(ctx context.Context, id string) error {
 
 func (f *fakeAPIKeyRepository) SoftDelete(ctx context.Context, installationID, id string) error {
 	return f.override
+}
+
+func (f *fakeAPIKeyRepository) UpdateDefaultStrategy(ctx context.Context, installationID, id, defaultStrategy string) error {
+	return errors.New("not used by these tests")
+}
+
+// fakeIssueAPIKeyRepository is a minimal in-memory auth.APIKeyRepository
+// backing IssueAPIKey/RotateAPIKey/SetAPIKeyDefaultStrategy tests. Distinct
+// from fakeAPIKeyRepository above (which is keyed by hash for VerifyAPIKey
+// tests and deliberately errors on Create/List/SoftDelete/UpdateDefaultStrategy).
+type fakeIssueAPIKeyRepository struct {
+	mu     sync.Mutex
+	keys   []*auth.APIKey
+	nextID int
+}
+
+func (f *fakeIssueAPIKeyRepository) Create(_ context.Context, params auth.CreateAPIKeyParams) (*auth.APIKey, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.nextID++
+	key := &auth.APIKey{
+		ID:              fmt.Sprintf("key-%d", f.nextID),
+		InstallationID:  params.InstallationID,
+		ExternalID:      params.ExternalID,
+		Name:            params.Name,
+		KeyPrefix:       params.KeyPrefix,
+		KeyHash:         params.KeyHash,
+		KeySuffix:       params.KeySuffix,
+		DefaultStrategy: params.DefaultStrategy,
+		CreatedBy:       params.CreatedBy,
+	}
+	f.keys = append(f.keys, key)
+	return key, nil
+}
+
+func (f *fakeIssueAPIKeyRepository) GetActiveByHashWithInstallation(context.Context, string) (*auth.APIKey, *auth.Installation, error) {
+	return nil, nil, errors.New("not used by these tests")
+}
+
+func (f *fakeIssueAPIKeyRepository) ListForInstallation(_ context.Context, installationID string) ([]*auth.APIKey, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([]*auth.APIKey, 0, len(f.keys))
+	for _, k := range f.keys {
+		if k.InstallationID == installationID && k.DeletedAt == nil {
+			out = append(out, k)
+		}
+	}
+	return out, nil
+}
+
+func (f *fakeIssueAPIKeyRepository) MarkUsed(context.Context, string) error { return nil }
+
+func (f *fakeIssueAPIKeyRepository) SoftDelete(_ context.Context, installationID, id string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	for _, k := range f.keys {
+		if k.ID == id && k.InstallationID == installationID && k.DeletedAt == nil {
+			now := time.Now()
+			k.DeletedAt = &now
+			return nil
+		}
+	}
+	return nil
+}
+
+func (f *fakeIssueAPIKeyRepository) UpdateDefaultStrategy(_ context.Context, installationID, id, defaultStrategy string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	for _, k := range f.keys {
+		if k.ID == id && k.InstallationID == installationID && k.DeletedAt == nil {
+			k.DefaultStrategy = defaultStrategy
+			return nil
+		}
+	}
+	return auth.ErrAPIKeyNotFound
 }
 
 type fakeExternalAPIKeyRepo struct {
@@ -835,6 +912,88 @@ func TestService_SetInstallation_NotFoundDoesNotInvalidate(t *testing.T) {
 				"a no-op update must not invalidate the cache — nothing changed to pick up")
 		})
 	}
+}
+
+// TestService_IssueAPIKey_RejectsUnknownDefaultStrategy verifies IssueAPIKey
+// validates default_strategy against the same recognized set the header path
+// enforces (WithRouterStrategyOverride) -- a key default can't smuggle in a
+// value the header would reject.
+func TestService_IssueAPIKey_RejectsUnknownDefaultStrategy(t *testing.T) {
+	svc := auth.NewService(&fakeInstallationRepository{}, &fakeIssueAPIKeyRepository{}, nil, nil, auth.NoOpAPIKeyCache{}, nil, frozenClock())
+
+	_, _, err := svc.IssueAPIKey(context.Background(), "inst-1", nil, "not-a-strategy", nil)
+
+	require.ErrorIs(t, err, auth.ErrUnknownStrategy)
+}
+
+func TestService_IssueAPIKey_PersistsDefaultStrategy(t *testing.T) {
+	repo := &fakeIssueAPIKeyRepository{}
+	svc := auth.NewService(&fakeInstallationRepository{}, repo, nil, nil, auth.NoOpAPIKeyCache{}, nil, frozenClock())
+
+	key, _, err := svc.IssueAPIKey(context.Background(), "inst-1", nil, "hmm", nil)
+
+	require.NoError(t, err)
+	assert.Equal(t, "hmm", key.DefaultStrategy)
+}
+
+// TestService_RotateAPIKey_CarriesForwardNameAndDefaultStrategy is the
+// Cursor-key lifecycle case: rotating a key that was minted with
+// --default-strategy hmm must not silently drop back to the deployment
+// default on the replacement token.
+func TestService_RotateAPIKey_CarriesForwardNameAndDefaultStrategy(t *testing.T) {
+	repo := &fakeIssueAPIKeyRepository{}
+	svc := auth.NewService(&fakeInstallationRepository{}, repo, nil, nil, auth.NoOpAPIKeyCache{}, nil, frozenClock())
+	name := "cursor-hmm"
+	old, _, err := svc.IssueAPIKey(context.Background(), "inst-1", &name, "hmm", nil)
+	require.NoError(t, err)
+
+	rotated, _, err := svc.RotateAPIKey(context.Background(), "inst-1", old.ID, nil)
+
+	require.NoError(t, err)
+	assert.NotEqual(t, old.ID, rotated.ID, "rotation must issue a new key id")
+	require.NotNil(t, rotated.Name)
+	assert.Equal(t, name, *rotated.Name, "rotation must carry forward the old key's name")
+	assert.Equal(t, "hmm", rotated.DefaultStrategy, "rotation must carry forward the old key's default_strategy")
+}
+
+func TestService_SetAPIKeyDefaultStrategy_RejectsUnknownValue(t *testing.T) {
+	repo := &fakeIssueAPIKeyRepository{}
+	svc := auth.NewService(&fakeInstallationRepository{}, repo, nil, nil, auth.NoOpAPIKeyCache{}, nil, frozenClock())
+	key, _, err := svc.IssueAPIKey(context.Background(), "inst-1", nil, "", nil)
+	require.NoError(t, err)
+
+	err = svc.SetAPIKeyDefaultStrategy(context.Background(), "inst-1", key.ID, "not-a-strategy")
+
+	require.ErrorIs(t, err, auth.ErrUnknownStrategy)
+}
+
+// TestService_SetAPIKeyDefaultStrategy_NotFoundDoesNotInvalidate mirrors
+// TestService_SetInstallation_NotFoundDoesNotInvalidate's guard: a zero-row
+// update (stale/cross-tenant id) must not invalidate the cache, or the write
+// looks successful when nothing changed.
+func TestService_SetAPIKeyDefaultStrategy_NotFoundDoesNotInvalidate(t *testing.T) {
+	cache := newRecordingAPIKeyCache()
+	repo := &fakeIssueAPIKeyRepository{}
+	svc := auth.NewService(&fakeInstallationRepository{}, repo, nil, nil, cache, nil, frozenClock())
+
+	err := svc.SetAPIKeyDefaultStrategy(context.Background(), "inst-1", "missing-key", "hmm")
+
+	require.ErrorIs(t, err, auth.ErrAPIKeyNotFound)
+	assert.Empty(t, cache.invalidationSnapshot(),
+		"a no-op update must not invalidate the cache — nothing changed to pick up")
+}
+
+func TestService_SetAPIKeyDefaultStrategy_InvalidatesCache(t *testing.T) {
+	cache := newRecordingAPIKeyCache()
+	repo := &fakeIssueAPIKeyRepository{}
+	svc := auth.NewService(&fakeInstallationRepository{}, repo, nil, nil, cache, nil, frozenClock())
+	key, _, err := svc.IssueAPIKey(context.Background(), "inst-1", nil, "", nil)
+	require.NoError(t, err)
+
+	err = svc.SetAPIKeyDefaultStrategy(context.Background(), "inst-1", key.ID, "hmm")
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{"inst-1"}, cache.invalidationSnapshot())
 }
 
 type recordingNotifier struct {

--- a/internal/postgres/converters.go
+++ b/internal/postgres/converters.go
@@ -42,18 +42,23 @@ func toAuthInstallation(row sqlc.RouterModelRouterInstallation) *auth.Installati
 }
 
 func toAuthAPIKey(row sqlc.RouterModelRouterAPIKey) *auth.APIKey {
+	var defaultStrategy string
+	if row.DefaultStrategy != nil {
+		defaultStrategy = *row.DefaultStrategy
+	}
 	return &auth.APIKey{
-		ID:             row.ID.String(),
-		InstallationID: row.InstallationID.String(),
-		ExternalID:     row.ExternalID,
-		Name:           row.Name,
-		KeyPrefix:      row.KeyPrefix,
-		KeyHash:        row.KeyHash,
-		KeySuffix:      row.KeySuffix,
-		LastUsedAt:     timestampPtr(row.LastUsedAt),
-		CreatedAt:      timestampOrZero(row.CreatedAt),
-		DeletedAt:      timestampPtr(row.DeletedAt),
-		CreatedBy:      row.CreatedBy,
+		ID:              row.ID.String(),
+		InstallationID:  row.InstallationID.String(),
+		ExternalID:      row.ExternalID,
+		Name:            row.Name,
+		KeyPrefix:       row.KeyPrefix,
+		KeyHash:         row.KeyHash,
+		KeySuffix:       row.KeySuffix,
+		LastUsedAt:      timestampPtr(row.LastUsedAt),
+		CreatedAt:       timestampOrZero(row.CreatedAt),
+		DeletedAt:       timestampPtr(row.DeletedAt),
+		CreatedBy:       row.CreatedBy,
+		DefaultStrategy: defaultStrategy,
 	}
 }
 

--- a/internal/postgres/converters_test.go
+++ b/internal/postgres/converters_test.go
@@ -30,3 +30,26 @@ func TestToAuthInstallationRoutingQualityWeight(t *testing.T) {
 		assert.Nil(t, inst.RoutingQualityWeight)
 	})
 }
+
+func TestToAuthAPIKeyDefaultStrategy(t *testing.T) {
+	t.Run("set strategy maps to string", func(t *testing.T) {
+		strategy := "hmm"
+		key := toAuthAPIKey(sqlc.RouterModelRouterAPIKey{
+			ID:              uuid.New(),
+			InstallationID:  uuid.New(),
+			ExternalID:      "kid-1",
+			DefaultStrategy: &strategy,
+		})
+		assert.Equal(t, "hmm", key.DefaultStrategy)
+	})
+
+	t.Run("null strategy maps to empty string", func(t *testing.T) {
+		key := toAuthAPIKey(sqlc.RouterModelRouterAPIKey{
+			ID:             uuid.New(),
+			InstallationID: uuid.New(),
+			ExternalID:     "kid-2",
+		})
+		assert.Equal(t, "", key.DefaultStrategy,
+			"a NULL default_strategy column must map to the empty-string sentinel (no key default)")
+	})
+}

--- a/internal/postgres/repository.go
+++ b/internal/postgres/repository.go
@@ -208,13 +208,14 @@ func (r *apiKeyRepo) Create(ctx context.Context, params auth.CreateAPIKeyParams)
 	}
 	q := sqlc.New(r.tx)
 	row, err := q.CreateModelRouterAPIKey(ctx, sqlc.CreateModelRouterAPIKeyParams{
-		InstallationID: installationID,
-		ExternalID:     params.ExternalID,
-		Name:           params.Name,
-		KeyPrefix:      params.KeyPrefix,
-		KeyHash:        params.KeyHash,
-		KeySuffix:      params.KeySuffix,
-		CreatedBy:      params.CreatedBy,
+		InstallationID:  installationID,
+		ExternalID:      params.ExternalID,
+		Name:            params.Name,
+		KeyPrefix:       params.KeyPrefix,
+		KeyHash:         params.KeyHash,
+		KeySuffix:       params.KeySuffix,
+		DefaultStrategy: stringPtrOrNil(params.DefaultStrategy),
+		CreatedBy:       params.CreatedBy,
 	})
 	if err != nil {
 		return nil, err
@@ -271,4 +272,28 @@ func (r *apiKeyRepo) SoftDelete(ctx context.Context, installationID, id string) 
 		ID:             parsed,
 		InstallationID: installationUUID,
 	})
+}
+
+func (r *apiKeyRepo) UpdateDefaultStrategy(ctx context.Context, installationID, id, defaultStrategy string) error {
+	installationUUID, err := uuid.Parse(installationID)
+	if err != nil {
+		return err
+	}
+	parsed, err := uuid.Parse(id)
+	if err != nil {
+		return err
+	}
+	q := sqlc.New(r.tx)
+	rows, err := q.UpdateModelRouterAPIKeyDefaultStrategy(ctx, sqlc.UpdateModelRouterAPIKeyDefaultStrategyParams{
+		ID:              parsed,
+		InstallationID:  installationUUID,
+		DefaultStrategy: stringPtrOrNil(defaultStrategy),
+	})
+	if err != nil {
+		return err
+	}
+	if rows == 0 {
+		return auth.ErrAPIKeyNotFound
+	}
+	return nil
 }

--- a/internal/server/middleware/auth_test.go
+++ b/internal/server/middleware/auth_test.go
@@ -81,6 +81,10 @@ func (f *fakeAPIKeyRepository) SoftDelete(ctx context.Context, installationID, i
 	return errors.New("not used")
 }
 
+func (f *fakeAPIKeyRepository) UpdateDefaultStrategy(ctx context.Context, installationID, id, defaultStrategy string) error {
+	return errors.New("not used")
+}
+
 type fakeInstallationRepository struct{}
 
 func (fakeInstallationRepository) Create(ctx context.Context, params auth.CreateInstallationParams) (*auth.Installation, error) {

--- a/internal/server/middleware/router_strategy_override.go
+++ b/internal/server/middleware/router_strategy_override.go
@@ -12,44 +12,78 @@ import (
 // RouterStrategyOverrideHeader selects the routing strategy for a request.
 // Accepted values are "cluster" (the default scorer), "rl" (the trained
 // RL/DPO policy router), and "bandit" (Thompson sampling over a frozen
-// posterior). Absent or unrecognized values fall through to the deployment
-// default.
+// posterior). Absent or unrecognized values fall through to the resolved
+// API key's default_strategy (see auth.APIKey.DefaultStrategy), and from
+// there to the deployment default.
 const RouterStrategyOverrideHeader = "x-weave-router-strategy"
 
-// WithRouterStrategyOverride stashes the requested routing strategy on the
-// request context when the header is set to a recognized value. Like the
-// cluster-version override it gates on a resolved installation so anonymous
-// traffic can't flip strategies, and it never silently picks a model — the rl
-// and hmm strategies fail closed (HTTP 503) when no policy sidecar is wired.
+// WithRouterStrategyOverride stashes the request's routing strategy on the
+// request context. The header, when present and recognized, always wins —
+// this is the only path clients like Claude Code or an eval harness use.
+// Absent or unrecognized header values fall back to the authed API key's
+// default_strategy, which exists for clients that can't send custom headers
+// (e.g. Cursor's Override Base URL). Like the cluster-version override this
+// gates on a resolved installation so anonymous traffic can't flip
+// strategies, and it never silently picks a model — the rl and hmm
+// strategies fail closed (HTTP 503) when no policy sidecar is wired.
 func WithRouterStrategyOverride() gin.HandlerFunc {
 	return func(c *gin.Context) {
-		raw := strings.ToLower(strings.TrimSpace(c.GetHeader(RouterStrategyOverrideHeader)))
-		if raw == "" {
-			c.Next()
-			return
-		}
 		installation := InstallationFrom(c)
 		if installation == nil {
 			c.Next()
 			return
 		}
-		strategy := router.Strategy(raw)
-		if strategy != router.StrategyCluster && strategy != router.StrategyRL && strategy != router.StrategyHMM && strategy != router.StrategyBandit {
+
+		raw := strings.ToLower(strings.TrimSpace(c.GetHeader(RouterStrategyOverrideHeader)))
+		if raw != "" {
+			if strategy, ok := parseRouterStrategy(raw); ok {
+				applyRouterStrategy(c, installation.ID, strategy, "header")
+				c.Next()
+				return
+			}
 			observability.FromGin(c).Warn(
-				"Router-strategy override ignored: unrecognized value",
+				"Router-strategy override header ignored: unrecognized value",
 				"installation_id", installation.ID,
 				"requested_strategy", raw,
 			)
-			c.Next()
-			return
 		}
-		ctx := router.WithStrategy(c.Request.Context(), strategy)
-		c.Request = c.Request.WithContext(ctx)
-		observability.FromGin(c).Info(
-			"Router-strategy override applied",
-			"installation_id", installation.ID,
-			"requested_strategy", raw,
-		)
+
+		if apiKey := APIKeyFrom(c); apiKey != nil && apiKey.DefaultStrategy != "" {
+			if strategy, ok := parseRouterStrategy(apiKey.DefaultStrategy); ok {
+				applyRouterStrategy(c, installation.ID, strategy, "api_key_default")
+			} else {
+				observability.FromGin(c).Warn(
+					"API key default_strategy ignored: unrecognized value",
+					"installation_id", installation.ID,
+					"api_key_id", apiKey.ID,
+					"default_strategy", apiKey.DefaultStrategy,
+				)
+			}
+		}
 		c.Next()
 	}
+}
+
+// parseRouterStrategy reports whether raw is a recognized router.Strategy value.
+func parseRouterStrategy(raw string) (router.Strategy, bool) {
+	strategy := router.Strategy(raw)
+	switch strategy {
+	case router.StrategyCluster, router.StrategyRL, router.StrategyHMM, router.StrategyBandit:
+		return strategy, true
+	default:
+		return "", false
+	}
+}
+
+// applyRouterStrategy stashes strategy on the request context and logs which
+// source (header vs. api_key_default) supplied it.
+func applyRouterStrategy(c *gin.Context, installationID string, strategy router.Strategy, source string) {
+	ctx := router.WithStrategy(c.Request.Context(), strategy)
+	c.Request = c.Request.WithContext(ctx)
+	observability.FromGin(c).Info(
+		"Router-strategy override applied",
+		"installation_id", installationID,
+		"strategy", string(strategy),
+		"source", source,
+	)
 }

--- a/internal/server/middleware/router_strategy_override_test.go
+++ b/internal/server/middleware/router_strategy_override_test.go
@@ -16,11 +16,21 @@ import (
 // runStrategyOverride reports the strategy observed on the request context after WithRouterStrategyOverride runs.
 func runStrategyOverride(t *testing.T, installation *auth.Installation, header string) router.Strategy {
 	t.Helper()
+	return runStrategyOverrideWithKey(t, installation, nil, header)
+}
+
+// runStrategyOverrideWithKey is runStrategyOverride plus an authed API key, so
+// tests can exercise the key-default fallback (APIKeyFrom(c)).
+func runStrategyOverrideWithKey(t *testing.T, installation *auth.Installation, apiKey *auth.APIKey, header string) router.Strategy {
+	t.Helper()
 	gin.SetMode(gin.TestMode)
 	engine := gin.New()
 	engine.Use(func(c *gin.Context) {
 		if installation != nil {
 			c.Set("router_installation", installation)
+		}
+		if apiKey != nil {
+			c.Set("router_api_key", apiKey)
 		}
 		c.Next()
 	})
@@ -74,4 +84,34 @@ func TestRouterStrategyOverride_UnknownValueIgnored(t *testing.T) {
 func TestRouterStrategyOverride_NoOpsWhenInstallationMissing(t *testing.T) {
 	got := runStrategyOverride(t, nil, "rl")
 	assert.Equal(t, router.StrategyCluster, got, "missing installation (WithAuth bypassed) must not flip strategy")
+}
+
+func TestRouterStrategyOverride_HeaderAbsentFallsBackToKeyDefault(t *testing.T) {
+	apiKey := &auth.APIKey{ID: "key-1", DefaultStrategy: "hmm"}
+	got := runStrategyOverrideWithKey(t, &auth.Installation{ID: "inst-eval"}, apiKey, "")
+	assert.Equal(t, router.StrategyHMM, got, "absent header must fall back to the key's default_strategy (the Cursor path)")
+}
+
+func TestRouterStrategyOverride_HeaderWinsOverKeyDefault(t *testing.T) {
+	apiKey := &auth.APIKey{ID: "key-1", DefaultStrategy: "hmm"}
+	got := runStrategyOverrideWithKey(t, &auth.Installation{ID: "inst-eval"}, apiKey, "cluster")
+	assert.Equal(t, router.StrategyCluster, got, "an explicit header must win over the key's default_strategy")
+}
+
+func TestRouterStrategyOverride_UnrecognizedHeaderFallsBackToKeyDefault(t *testing.T) {
+	apiKey := &auth.APIKey{ID: "key-1", DefaultStrategy: "hmm"}
+	got := runStrategyOverrideWithKey(t, &auth.Installation{ID: "inst-eval"}, apiKey, "bogus")
+	assert.Equal(t, router.StrategyHMM, got, "an unrecognized header must fall through to the key's default_strategy, not straight to cluster")
+}
+
+func TestRouterStrategyOverride_UnknownKeyDefaultIgnored(t *testing.T) {
+	apiKey := &auth.APIKey{ID: "key-1", DefaultStrategy: "not-a-real-strategy"}
+	got := runStrategyOverrideWithKey(t, &auth.Installation{ID: "inst-eval"}, apiKey, "")
+	assert.Equal(t, router.StrategyCluster, got, "an unrecognized stored default_strategy must fall through to cluster, not error")
+}
+
+func TestRouterStrategyOverride_EmptyKeyDefaultLeavesCluster(t *testing.T) {
+	apiKey := &auth.APIKey{ID: "key-1", DefaultStrategy: ""}
+	got := runStrategyOverrideWithKey(t, &auth.Installation{ID: "inst-eval"}, apiKey, "")
+	assert.Equal(t, router.StrategyCluster, got, "a key with no default_strategy set must leave the deployment default")
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -108,6 +108,7 @@ func Register(engine *gin.Engine, authSvc *auth.Service, proxySvc *proxy.Service
 		mgmt.GET("/keys", admin.ListAPIKeysHandler(authSvc))
 		mgmt.POST("/keys", admin.IssueAPIKeyHandler(authSvc))
 		mgmt.POST("/keys/:id/rotate", admin.RotateAPIKeyHandler(authSvc))
+		mgmt.PUT("/keys/:id/default-strategy", admin.UpdateAPIKeyDefaultStrategyHandler(authSvc))
 		mgmt.DELETE("/keys/:id", admin.DeleteAPIKeyHandler(authSvc))
 		mgmt.GET("/provider-keys", admin.ListExternalKeysHandler(authSvc))
 		mgmt.POST("/provider-keys", admin.UpsertExternalKeyHandler(authSvc))

--- a/internal/sqlc/model_router_api_keys.sql.go
+++ b/internal/sqlc/model_router_api_keys.sql.go
@@ -19,6 +19,7 @@ INSERT INTO router.model_router_api_keys (
     key_prefix,
     key_hash,
     key_suffix,
+    default_strategy,
     created_by
 )
 VALUES (
@@ -28,19 +29,21 @@ VALUES (
     $4::varchar,
     $5::varchar,
     $6::varchar,
-    $7
+    $7,
+    $8
 )
-RETURNING id, installation_id, external_id, name, key_prefix, key_hash, key_suffix, last_used_at, created_at, deleted_at, created_by, spend_cap_usd_micros, spent_usd_micros
+RETURNING id, installation_id, external_id, name, key_prefix, key_hash, key_suffix, last_used_at, created_at, deleted_at, created_by, spend_cap_usd_micros, spent_usd_micros, default_strategy
 `
 
 type CreateModelRouterAPIKeyParams struct {
-	InstallationID uuid.UUID
-	ExternalID     string
-	Name           *string
-	KeyPrefix      string
-	KeyHash        string
-	KeySuffix      string
-	CreatedBy      *string
+	InstallationID  uuid.UUID
+	ExternalID      string
+	Name            *string
+	KeyPrefix       string
+	KeyHash         string
+	KeySuffix       string
+	DefaultStrategy *string
+	CreatedBy       *string
 }
 
 // CreateModelRouterAPIKey
@@ -52,6 +55,7 @@ type CreateModelRouterAPIKeyParams struct {
 //	    key_prefix,
 //	    key_hash,
 //	    key_suffix,
+//	    default_strategy,
 //	    created_by
 //	)
 //	VALUES (
@@ -61,9 +65,10 @@ type CreateModelRouterAPIKeyParams struct {
 //	    $4::varchar,
 //	    $5::varchar,
 //	    $6::varchar,
-//	    $7
+//	    $7,
+//	    $8
 //	)
-//	RETURNING id, installation_id, external_id, name, key_prefix, key_hash, key_suffix, last_used_at, created_at, deleted_at, created_by, spend_cap_usd_micros, spent_usd_micros
+//	RETURNING id, installation_id, external_id, name, key_prefix, key_hash, key_suffix, last_used_at, created_at, deleted_at, created_by, spend_cap_usd_micros, spent_usd_micros, default_strategy
 func (q *Queries) CreateModelRouterAPIKey(ctx context.Context, arg CreateModelRouterAPIKeyParams) (RouterModelRouterAPIKey, error) {
 	row := q.db.QueryRow(ctx, createModelRouterAPIKey,
 		arg.InstallationID,
@@ -72,6 +77,7 @@ func (q *Queries) CreateModelRouterAPIKey(ctx context.Context, arg CreateModelRo
 		arg.KeyPrefix,
 		arg.KeyHash,
 		arg.KeySuffix,
+		arg.DefaultStrategy,
 		arg.CreatedBy,
 	)
 	var i RouterModelRouterAPIKey
@@ -89,12 +95,13 @@ func (q *Queries) CreateModelRouterAPIKey(ctx context.Context, arg CreateModelRo
 		&i.CreatedBy,
 		&i.SpendCapUsdMicros,
 		&i.SpentUsdMicros,
+		&i.DefaultStrategy,
 	)
 	return i, err
 }
 
 const getActiveModelRouterAPIKeyWithInstallationByHash = `-- name: GetActiveModelRouterAPIKeyWithInstallationByHash :one
-SELECT k.id, k.installation_id, k.external_id, k.name, k.key_prefix, k.key_hash, k.key_suffix, k.last_used_at, k.created_at, k.deleted_at, k.created_by, k.spend_cap_usd_micros, k.spent_usd_micros, i.id, i.external_id, i.name, i.created_at, i.updated_at, i.deleted_at, i.created_by, i.excluded_models, i.excluded_providers, i.routing_quality_weight, i.usage_bypass_enabled, i.usage_bypass_threshold, i.preferred_models, i.subscription_routing_disabled
+SELECT k.id, k.installation_id, k.external_id, k.name, k.key_prefix, k.key_hash, k.key_suffix, k.last_used_at, k.created_at, k.deleted_at, k.created_by, k.spend_cap_usd_micros, k.spent_usd_micros, k.default_strategy, i.id, i.external_id, i.name, i.created_at, i.updated_at, i.deleted_at, i.created_by, i.excluded_models, i.excluded_providers, i.routing_quality_weight, i.usage_bypass_enabled, i.usage_bypass_threshold, i.preferred_models, i.subscription_routing_disabled
 FROM router.model_router_api_keys k
 INNER JOIN router.model_router_installations i ON i.id = k.installation_id
 WHERE k.key_hash = $1::varchar
@@ -113,7 +120,7 @@ type GetActiveModelRouterAPIKeyWithInstallationByHashRow struct {
 // both sides so a soft-deleted installation invalidates all its keys without per-key
 // updates.
 //
-//	SELECT k.id, k.installation_id, k.external_id, k.name, k.key_prefix, k.key_hash, k.key_suffix, k.last_used_at, k.created_at, k.deleted_at, k.created_by, k.spend_cap_usd_micros, k.spent_usd_micros, i.id, i.external_id, i.name, i.created_at, i.updated_at, i.deleted_at, i.created_by, i.excluded_models, i.excluded_providers, i.routing_quality_weight, i.usage_bypass_enabled, i.usage_bypass_threshold, i.preferred_models, i.subscription_routing_disabled
+//	SELECT k.id, k.installation_id, k.external_id, k.name, k.key_prefix, k.key_hash, k.key_suffix, k.last_used_at, k.created_at, k.deleted_at, k.created_by, k.spend_cap_usd_micros, k.spent_usd_micros, k.default_strategy, i.id, i.external_id, i.name, i.created_at, i.updated_at, i.deleted_at, i.created_by, i.excluded_models, i.excluded_providers, i.routing_quality_weight, i.usage_bypass_enabled, i.usage_bypass_threshold, i.preferred_models, i.subscription_routing_disabled
 //	FROM router.model_router_api_keys k
 //	INNER JOIN router.model_router_installations i ON i.id = k.installation_id
 //	WHERE k.key_hash = $1::varchar
@@ -136,6 +143,7 @@ func (q *Queries) GetActiveModelRouterAPIKeyWithInstallationByHash(ctx context.C
 		&i.RouterModelRouterAPIKey.CreatedBy,
 		&i.RouterModelRouterAPIKey.SpendCapUsdMicros,
 		&i.RouterModelRouterAPIKey.SpentUsdMicros,
+		&i.RouterModelRouterAPIKey.DefaultStrategy,
 		&i.RouterModelRouterInstallation.ID,
 		&i.RouterModelRouterInstallation.ExternalID,
 		&i.RouterModelRouterInstallation.Name,
@@ -184,7 +192,7 @@ func (q *Queries) GetModelRouterAPIKeySpend(ctx context.Context, id uuid.UUID) (
 }
 
 const listModelRouterAPIKeysForInstallation = `-- name: ListModelRouterAPIKeysForInstallation :many
-SELECT id, installation_id, external_id, name, key_prefix, key_hash, key_suffix, last_used_at, created_at, deleted_at, created_by, spend_cap_usd_micros, spent_usd_micros
+SELECT id, installation_id, external_id, name, key_prefix, key_hash, key_suffix, last_used_at, created_at, deleted_at, created_by, spend_cap_usd_micros, spent_usd_micros, default_strategy
 FROM router.model_router_api_keys
 WHERE installation_id = $1::uuid
   AND deleted_at IS NULL
@@ -193,7 +201,7 @@ ORDER BY created_at DESC
 
 // Lists active keys for an installation (dashboard / CRUD; not on the request path).
 //
-//	SELECT id, installation_id, external_id, name, key_prefix, key_hash, key_suffix, last_used_at, created_at, deleted_at, created_by, spend_cap_usd_micros, spent_usd_micros
+//	SELECT id, installation_id, external_id, name, key_prefix, key_hash, key_suffix, last_used_at, created_at, deleted_at, created_by, spend_cap_usd_micros, spent_usd_micros, default_strategy
 //	FROM router.model_router_api_keys
 //	WHERE installation_id = $1::uuid
 //	  AND deleted_at IS NULL
@@ -221,6 +229,7 @@ func (q *Queries) ListModelRouterAPIKeysForInstallation(ctx context.Context, ins
 			&i.CreatedBy,
 			&i.SpendCapUsdMicros,
 			&i.SpentUsdMicros,
+			&i.DefaultStrategy,
 		); err != nil {
 			return nil, err
 		}
@@ -274,4 +283,37 @@ type SoftDeleteModelRouterAPIKeyParams struct {
 func (q *Queries) SoftDeleteModelRouterAPIKey(ctx context.Context, arg SoftDeleteModelRouterAPIKeyParams) error {
 	_, err := q.db.Exec(ctx, softDeleteModelRouterAPIKey, arg.ID, arg.InstallationID)
 	return err
+}
+
+const updateModelRouterAPIKeyDefaultStrategy = `-- name: UpdateModelRouterAPIKeyDefaultStrategy :execrows
+UPDATE router.model_router_api_keys
+SET default_strategy = $1
+WHERE id = $2::uuid
+  AND installation_id = $3::uuid
+  AND deleted_at IS NULL
+`
+
+type UpdateModelRouterAPIKeyDefaultStrategyParams struct {
+	DefaultStrategy *string
+	ID              uuid.UUID
+	InstallationID  uuid.UUID
+}
+
+// Sets the per-key routing-strategy default, scoped to installation_id to
+// prevent cross-tenant updates. NULL clears it so the key falls back to the
+// deployment default (cluster) absent an x-weave-router-strategy header. The
+// header always wins over this column when both are present; see
+// WithRouterStrategyOverride.
+//
+//	UPDATE router.model_router_api_keys
+//	SET default_strategy = $1
+//	WHERE id = $2::uuid
+//	  AND installation_id = $3::uuid
+//	  AND deleted_at IS NULL
+func (q *Queries) UpdateModelRouterAPIKeyDefaultStrategy(ctx context.Context, arg UpdateModelRouterAPIKeyDefaultStrategyParams) (int64, error) {
+	result, err := q.db.Exec(ctx, updateModelRouterAPIKeyDefaultStrategy, arg.DefaultStrategy, arg.ID, arg.InstallationID)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
 }

--- a/internal/sqlc/models.go
+++ b/internal/sqlc/models.go
@@ -44,6 +44,7 @@ type RouterModelRouterAPIKey struct {
 	CreatedBy         *string
 	SpendCapUsdMicros *int64
 	SpentUsdMicros    int64
+	DefaultStrategy   *string
 }
 
 // Customer-owned provider API keys for BYOK routing


### PR DESCRIPTION
Adds a default_strategy column on router.model_router_api_keys so
clients that can't send X-Weave-Router-Strategy (e.g. Cursor's
Override Base URL, which has no custom-header field) can still opt
into a non-default strategy like hmm. An explicit header always wins
over the key's default; the key's default wins over the deployment
default (cluster).

- Migration 0034 adds the nullable default_strategy column
- auth.APIKey/CreateAPIKeyParams carry DefaultStrategy; IssueAPIKey
  validates it, RotateAPIKey carries it forward
- New auth.Service.SetAPIKeyDefaultStrategy + admin PUT
  /admin/v1/keys/:id/default-strategy to flip it without rotating
- WithRouterStrategyOverride middleware falls back to the key's
  default_strategy when no header is present
- wv mr seed-key --default-strategy plus a Cursor setup blurb