### PR TITLE
feat(settings): sort and search router API keys

### DIFF
--- a/frontend/src/app/(app)/settings/page.tsx
+++ b/frontend/src/app/(app)/settings/page.tsx
@@ -184,10 +184,14 @@ function RouterKeysPanel() {
   const hasKey = keys.length > 0;
   const showSearch = keys.length >= KEY_SEARCH_THRESHOLD;
   const normalizedQuery = query.trim().toLowerCase();
+  // Only filter while the search box is actually shown; otherwise a stale query
+  // from before the list shrank below the threshold would hide keys with no
+  // visible input to clear it.
+  const activeQuery = showSearch ? normalizedQuery : "";
   const visibleKeys = keys
     .slice()
     .sort(compareKeysByName)
-    .filter(k => keyMatchesQuery(k, normalizedQuery));
+    .filter(k => keyMatchesQuery(k, activeQuery));
 
   function load() {
     api.keys

--- a/frontend/src/app/(app)/settings/page.tsx
+++ b/frontend/src/app/(app)/settings/page.tsx
@@ -153,6 +153,10 @@ export default function SettingsPage() {
 // gets tedious; for a couple of keys a search bar is just noise.
 const KEY_SEARCH_THRESHOLD = 5;
 
+// Shown in place of a name for keys created without one; kept in one place so the
+// list row and the search haystack stay in sync.
+const UNNAMED_KEY_LABEL = "Unnamed key";
+
 // Alphabetical by name, with unnamed keys pushed to the bottom.
 function compareKeysByName(a: APIKey, b: APIKey): number {
   if (a.name == null && b.name == null) return 0;
@@ -161,11 +165,15 @@ function compareKeysByName(a: APIKey, b: APIKey): number {
   return a.name.localeCompare(b.name);
 }
 
-// Case-insensitive substring match over the name and the visible key fragments,
-// so pasting the last few characters of a token also finds it.
+// Case-insensitive substring match over what the row actually shows: the label
+// ("Unnamed key" when there's no name), the raw prefix/suffix (so the last few
+// characters of a token match), and the exact "prefix…suffix" fingerprint that's
+// rendered, so pasting the visible fingerprint verbatim also finds it.
 function keyMatchesQuery(k: APIKey, query: string): boolean {
   if (query === "") return true;
-  const haystack = `${k.name ?? ""} ${k.key_prefix} ${k.key_suffix}`.toLowerCase();
+  const label = k.name ?? UNNAMED_KEY_LABEL;
+  const haystack =
+    `${label} ${k.key_prefix} ${k.key_suffix} ${k.key_prefix}…${k.key_suffix}`.toLowerCase();
   return haystack.includes(query);
 }
 
@@ -354,7 +362,7 @@ function RouterKeysPanel() {
                 <li key={k.id} className="flex items-center justify-between gap-3 px-5 py-3">
                   <div className="min-w-0 flex-1">
                     <div className="text-xs font-medium text-foreground">
-                      {k.name ?? "Unnamed key"}
+                      {k.name ?? UNNAMED_KEY_LABEL}
                     </div>
                     <p className="mt-0.5 truncate font-mono text-2xs text-muted-foreground">
                       {k.key_prefix}…{k.key_suffix}

--- a/frontend/src/app/(app)/settings/page.tsx
+++ b/frontend/src/app/(app)/settings/page.tsx
@@ -16,7 +16,7 @@ import {
   type ExternalKey,
   type RouterConfig,
 } from "@/lib/api";
-import { ChevronDown, Copy, Filter, KeyRound, Network, Plug, RotateCw, Settings as SettingsIcon, SlidersHorizontal, Trash2 } from "lucide-react";
+import { ChevronDown, Copy, Filter, KeyRound, Network, Plug, RotateCw, Search, Settings as SettingsIcon, SlidersHorizontal, Trash2 } from "lucide-react";
 import { useEffect, useState } from "react";
 
 export default function SettingsPage() {
@@ -149,8 +149,29 @@ export default function SettingsPage() {
 }
 
 
+// Show the search box only once the list is long enough that scanning it by eye
+// gets tedious; for a couple of keys a search bar is just noise.
+const KEY_SEARCH_THRESHOLD = 5;
+
+// Alphabetical by name, with unnamed keys pushed to the bottom.
+function compareKeysByName(a: APIKey, b: APIKey): number {
+  if (a.name == null && b.name == null) return 0;
+  if (a.name == null) return 1;
+  if (b.name == null) return -1;
+  return a.name.localeCompare(b.name);
+}
+
+// Case-insensitive substring match over the name and the visible key fragments,
+// so pasting the last few characters of a token also finds it.
+function keyMatchesQuery(k: APIKey, query: string): boolean {
+  if (query === "") return true;
+  const haystack = `${k.name ?? ""} ${k.key_prefix} ${k.key_suffix}`.toLowerCase();
+  return haystack.includes(query);
+}
+
 function RouterKeysPanel() {
   const [keys, setKeys] = useState<APIKey[]>([]);
+  const [query, setQuery] = useState("");
   const [loaded, setLoaded] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [name, setName] = useState("");
@@ -161,6 +182,12 @@ function RouterKeysPanel() {
   const [copied, setCopied] = useState(false);
 
   const hasKey = keys.length > 0;
+  const showSearch = keys.length >= KEY_SEARCH_THRESHOLD;
+  const normalizedQuery = query.trim().toLowerCase();
+  const visibleKeys = keys
+    .slice()
+    .sort(compareKeysByName)
+    .filter(k => keyMatchesQuery(k, normalizedQuery));
 
   function load() {
     api.keys
@@ -296,12 +323,30 @@ function RouterKeysPanel() {
 
       {hasKey ? (
         <Card className="p-0">
-          <Card.Header className="border-b border-border px-5 py-3">
+          <Card.Header className="flex-row items-center justify-between gap-3 border-b border-border px-5 py-3">
             <Card.Title variant="h4">Active router keys</Card.Title>
+            {showSearch && (
+              <div className="relative w-48">
+                <Search className="pointer-events-none absolute left-2.5 top-1/2 size-3.5 -translate-y-1/2 text-muted-foreground" />
+                <Input
+                  type="search"
+                  aria-label="Search router keys"
+                  placeholder="Search keys"
+                  className="h-8 pl-8 text-xs"
+                  value={query}
+                  onChange={e => setQuery(e.target.value)}
+                />
+              </div>
+            )}
           </Card.Header>
           <Card.Content>
+            {visibleKeys.length === 0 ? (
+              <div className="px-5 py-8 text-center text-2xs text-muted-foreground">
+                No keys match “{query.trim()}”.
+              </div>
+            ) : (
             <ul className="divide-y divide-border">
-              {keys.map(k => (
+              {visibleKeys.map(k => (
                 <li key={k.id} className="flex items-center justify-between gap-3 px-5 py-3">
                   <div className="min-w-0 flex-1">
                     <div className="text-xs font-medium text-foreground">
@@ -339,6 +384,7 @@ function RouterKeysPanel() {
                 </li>
               ))}
             </ul>
+            )}
           </Card.Content>
         </Card>
       ) : loaded ? (


### PR DESCRIPTION
## What

On the router dashboard Settings page, the **Router API keys** list was rendered in server order (`created_at DESC`) with no way to find a specific key. This adds:

- **Alphabetical default sort** by key name (unnamed keys sort to the bottom).
- **A search box** that filters the list as you type, shown only when an installation has **5 or more** keys (below that a search bar is just noise). Matching is case-insensitive against the key name and its visible `prefix…suffix` fragments, so pasting the last few characters of a token also finds it.

Scoped to the **Router API keys** panel only. Provider API keys, model/provider selection, etc. are untouched.

## Implementation notes

- Purely client-side — the per-installation key list is small, so no backend/SQL change. `ListModelRouterAPIKeysForInstallation` still returns `created_at DESC`; the panel re-sorts and filters in the component.
- One file: `frontend/src/app/(app)/settings/page.tsx`. Reuses the existing `Input` component and the `Search` lucide icon; no new dependencies.
- Empty-state message shown when a query matches nothing.

## Testing

- `npx tsc --noEmit` — clean
- `npm run build` (includes type-check) — passes; `/settings` route compiles

🤖 Generated with [Claude Code](https://claude.com/claude-code)