### PR TITLE
fix(middleware): fail closed on unregistered persisted routing strategy

### DIFF
--- a/internal/server/middleware/router_strategy_override.go
+++ b/internal/server/middleware/router_strategy_override.go
@@ -1,9 +1,12 @@
 package middleware
 
 import (
+	"fmt"
+	"net/http"
 	"strings"
 
 	"workweave/router/internal/observability"
+	"workweave/router/internal/proxy"
 	"workweave/router/internal/router"
 
 	"github.com/gin-gonic/gin"
@@ -45,14 +48,6 @@ func WithRouterStrategyDefault(defaultStrategy router.Strategy, available ...rou
 		if strategy == "" {
 			strategy = defaultStrategy
 		}
-		if _, ok := allowed[strategy]; !ok {
-			observability.FromGin(c).Warn(
-				"Persisted router strategy is not registered; using cluster",
-				"installation_id", installation.ID,
-				"persisted_strategy", strategy,
-			)
-			strategy = router.StrategyCluster
-		}
 
 		raw := strings.ToLower(strings.TrimSpace(c.GetHeader(RouterStrategyOverrideHeader)))
 		if raw != "" {
@@ -66,6 +61,25 @@ func WithRouterStrategyDefault(defaultStrategy router.Strategy, available ...rou
 				strategy = requested
 				observability.FromGin(c).Info("Router-strategy override applied", "installation_id", installation.ID, "requested_strategy", raw)
 			}
+		}
+
+		if _, ok := allowed[strategy]; !ok {
+			log := observability.FromGin(c).With(
+				"installation_id", installation.ID,
+				"persisted_strategy", strategy,
+			)
+			err := fmt.Errorf("strategy %q requested but no router configured: %w", strategy, router.ErrStrategyUnavailable)
+			cls, ok := proxy.ClassifyDispatchError(err)
+			if !ok {
+				c.AbortWithStatus(http.StatusServiceUnavailable)
+				return
+			}
+			proxy.LogDispatchErrorClass(log, cls, err)
+			if cls.RetryAfter {
+				c.Header("Retry-After", "1")
+			}
+			abortStrategyUnavailable(c, cls.Status, cls.Message)
+			return
 		}
 
 		ctx := router.WithStrategy(c.Request.Context(), strategy)
@@ -97,4 +111,36 @@ func strategyAllowed(strategy router.Strategy, allowed map[router.Strategy]struc
 	}
 	_, ok := allowed[strategy]
 	return ok
+}
+
+// abortStrategyUnavailable writes a 503 with the error envelope matching the
+// route's API format — same detectAPIFormat branching as abortInvalidKnob.
+func abortStrategyUnavailable(c *gin.Context, status int, message string) {
+	switch detectAPIFormat(c.Request.URL.Path) {
+	case apiFormatAnthropic:
+		c.AbortWithStatusJSON(status, gin.H{
+			"type": "error",
+			"error": gin.H{
+				"type":    "api_error",
+				"message": message,
+			},
+		})
+	case apiFormatGemini:
+		c.AbortWithStatusJSON(status, gin.H{
+			"error": gin.H{
+				"code":    status,
+				"message": message,
+				"status":  "UNAVAILABLE",
+			},
+		})
+	default:
+		c.AbortWithStatusJSON(status, gin.H{
+			"error": gin.H{
+				"type":    "api_error",
+				"message": message,
+				"param":   nil,
+				"code":    nil,
+			},
+		})
+	}
 }

--- a/internal/server/middleware/router_strategy_override_test.go
+++ b/internal/server/middleware/router_strategy_override_test.go
@@ -1,6 +1,7 @@
 package middleware_test
 
 import (
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -11,16 +12,25 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // runStrategyOverride reports the strategy observed on the request context after WithRouterStrategyOverride runs.
 func runStrategyOverride(t *testing.T, installation *auth.Installation, header string, available ...router.Strategy) router.Strategy {
 	t.Helper()
-	_, observed := runStrategyOverrideResult(t, installation, header, available...)
+	_, observed, _ := runStrategyOverrideAt(t, "/probe", installation, header, available...)
 	return observed
 }
 
 func runStrategyOverrideResult(t *testing.T, installation *auth.Installation, header string, available ...router.Strategy) (int, router.Strategy) {
+	t.Helper()
+	status, observed, _ := runStrategyOverrideAt(t, "/v1/route", installation, header, available...)
+	return status, observed
+}
+
+// runStrategyOverrideAt drives WithRouterStrategyOverride against path so
+// detectAPIFormat can pick the correct error envelope on fail-closed aborts.
+func runStrategyOverrideAt(t *testing.T, path string, installation *auth.Installation, header string, available ...router.Strategy) (int, router.Strategy, *httptest.ResponseRecorder) {
 	t.Helper()
 	gin.SetMode(gin.TestMode)
 	engine := gin.New()
@@ -33,18 +43,18 @@ func runStrategyOverrideResult(t *testing.T, installation *auth.Installation, he
 	engine.Use(middleware.WithRouterStrategyOverride(available...))
 
 	var observed router.Strategy
-	engine.GET("/probe", func(c *gin.Context) {
+	engine.Any("/*any", func(c *gin.Context) {
 		observed = router.StrategyFromContext(c.Request.Context())
 		c.Status(http.StatusOK)
 	})
 
-	req := httptest.NewRequest(http.MethodGet, "/probe", nil)
+	req := httptest.NewRequest(http.MethodGet, path, nil)
 	if header != "" {
 		req.Header.Set(middleware.RouterStrategyOverrideHeader, header)
 	}
 	rr := httptest.NewRecorder()
 	engine.ServeHTTP(rr, req)
-	return rr.Code, observed
+	return rr.Code, observed, rr
 }
 
 func TestRouterStrategyOverride_AppliesRL(t *testing.T) {
@@ -154,12 +164,103 @@ func TestRouterStrategyOverride_AcceptsFutureRegisteredStrategy(t *testing.T) {
 
 func TestRouterStrategyOverride_RejectsUnregisteredPersistedStrategy(t *testing.T) {
 	unregistered := router.Strategy("quality-v2")
-	status, got := runStrategyOverrideResult(t, &auth.Installation{
+	status, got, rr := runStrategyOverrideAt(t, "/v1/route", &auth.Installation{
 		ID:              "inst-custom",
 		RoutingStrategy: unregistered,
 	}, "")
 	assert.Equal(t, http.StatusServiceUnavailable, status)
+	assert.Equal(t, "1", rr.Header().Get("Retry-After"))
 	assert.NotEqual(t, router.StrategyCluster, got, "must not silently rewrite to cluster")
+	assertAnthropicUnavailableEnvelope(t, rr.Body.Bytes())
+}
+
+func TestRouterStrategyOverride_UnregisteredPersisted_HeaderDisabledReturns503(t *testing.T) {
+	status, got, rr := runStrategyOverrideAt(t, "/v1/route", &auth.Installation{
+		ID:                           "inst-custom",
+		RoutingStrategy:              router.Strategy("quality-v2"),
+		PolicyHeaderOverridesEnabled: false,
+	}, "cluster")
+	assert.Equal(t, http.StatusServiceUnavailable, status)
+	assert.Equal(t, "1", rr.Header().Get("Retry-After"))
+	assert.NotEqual(t, router.StrategyCluster, got, "disabled header must not rescue an unregistered persisted strategy")
+	assertAnthropicUnavailableEnvelope(t, rr.Body.Bytes())
+}
+
+func TestRouterStrategyOverride_UnregisteredPersisted_ValidHeaderOverrideWins(t *testing.T) {
+	status, got := runStrategyOverrideResult(t, &auth.Installation{
+		ID:                           "inst-custom",
+		RoutingStrategy:              router.Strategy("quality-v2"),
+		PolicyHeaderOverridesEnabled: true,
+	}, "cluster")
+	assert.Equal(t, http.StatusOK, status)
+	assert.Equal(t, router.StrategyCluster, got, "authorized valid header must override an unregistered persisted strategy")
+}
+
+func TestRouterStrategyOverride_UnregisteredPersisted_InvalidHeaderStill503(t *testing.T) {
+	status, got, rr := runStrategyOverrideAt(t, "/v1/route", &auth.Installation{
+		ID:                           "inst-custom",
+		RoutingStrategy:              router.Strategy("quality-v2"),
+		PolicyHeaderOverridesEnabled: true,
+	}, "bogus")
+	assert.Equal(t, http.StatusServiceUnavailable, status)
+	assert.Equal(t, "1", rr.Header().Get("Retry-After"))
+	assert.NotEqual(t, router.StrategyCluster, got, "invalid header must not silently rewrite to cluster")
+	assertAnthropicUnavailableEnvelope(t, rr.Body.Bytes())
+}
+
+func TestRouterStrategyOverride_FailClosedEnvelopeOpenAI(t *testing.T) {
+	for _, path := range []string{"/v1/chat/completions", "/v1/responses"} {
+		t.Run(path, func(t *testing.T) {
+			status, _, rr := runStrategyOverrideAt(t, path, &auth.Installation{
+				ID:              "inst-custom",
+				RoutingStrategy: router.Strategy("quality-v2"),
+			}, "")
+			assert.Equal(t, http.StatusServiceUnavailable, status)
+			assert.Equal(t, "1", rr.Header().Get("Retry-After"))
+
+			body := parseJSONBody(t, rr.Body.Bytes())
+			errObj, ok := body["error"].(map[string]any)
+			require.True(t, ok, "OpenAI envelope must have top-level 'error' object")
+			assert.Equal(t, "api_error", errObj["type"])
+			assert.Contains(t, errObj["message"], "selected policy router is not configured")
+			_, hasParam := errObj["param"]
+			_, hasCode := errObj["code"]
+			assert.True(t, hasParam, "OpenAI envelope must include 'param' field")
+			assert.True(t, hasCode, "OpenAI envelope must include 'code' field")
+			_, hasOuterType := body["type"]
+			assert.False(t, hasOuterType, "OpenAI envelope must not include outer 'type' (that's the Anthropic shape)")
+		})
+	}
+}
+
+func TestRouterStrategyOverride_FailClosedEnvelopeAnthropic(t *testing.T) {
+	for _, path := range []string{"/v1/messages", "/v1/route"} {
+		t.Run(path, func(t *testing.T) {
+			status, _, rr := runStrategyOverrideAt(t, path, &auth.Installation{
+				ID:              "inst-custom",
+				RoutingStrategy: router.Strategy("quality-v2"),
+			}, "")
+			assert.Equal(t, http.StatusServiceUnavailable, status)
+			assert.Equal(t, "1", rr.Header().Get("Retry-After"))
+			assertAnthropicUnavailableEnvelope(t, rr.Body.Bytes())
+		})
+	}
+}
+
+func TestRouterStrategyOverride_FailClosedEnvelopeGemini(t *testing.T) {
+	status, _, rr := runStrategyOverrideAt(t, "/v1beta/models/gemini-2.5-pro:generateContent", &auth.Installation{
+		ID:              "inst-custom",
+		RoutingStrategy: router.Strategy("quality-v2"),
+	}, "")
+	assert.Equal(t, http.StatusServiceUnavailable, status)
+	assert.Equal(t, "1", rr.Header().Get("Retry-After"))
+
+	body := parseJSONBody(t, rr.Body.Bytes())
+	errObj, ok := body["error"].(map[string]any)
+	require.True(t, ok, "Gemini envelope must have nested 'error' object")
+	assert.EqualValues(t, http.StatusServiceUnavailable, errObj["code"], "Gemini envelope echoes HTTP status as numeric 'code'")
+	assert.Equal(t, "UNAVAILABLE", errObj["status"], "Gemini envelope must include machine-readable 'status'")
+	assert.Contains(t, errObj["message"], "selected policy router is not configured")
 }
 
 func TestRouterStrategyOverride_NoOpsWhenInstallationMissing(t *testing.T) {
@@ -169,4 +270,21 @@ func TestRouterStrategyOverride_NoOpsWhenInstallationMissing(t *testing.T) {
 
 func overrideEnabledInstallation() *auth.Installation {
 	return &auth.Installation{ID: "inst-eval", PolicyHeaderOverridesEnabled: true}
+}
+
+func parseJSONBody(t *testing.T, raw []byte) map[string]any {
+	t.Helper()
+	var body map[string]any
+	require.NoError(t, json.Unmarshal(raw, &body), "response body must be JSON")
+	return body
+}
+
+func assertAnthropicUnavailableEnvelope(t *testing.T, raw []byte) {
+	t.Helper()
+	body := parseJSONBody(t, raw)
+	assert.Equal(t, "error", body["type"], "Anthropic envelope must have top-level 'type': 'error'")
+	errObj, ok := body["error"].(map[string]any)
+	require.True(t, ok, "Anthropic envelope must have nested 'error' object")
+	assert.Equal(t, "api_error", errObj["type"])
+	assert.Contains(t, errObj["message"], "selected policy router is not configured")
 }

--- a/internal/server/middleware/router_strategy_override_test.go
+++ b/internal/server/middleware/router_strategy_override_test.go
@@ -16,6 +16,12 @@ import (
 // runStrategyOverride reports the strategy observed on the request context after WithRouterStrategyOverride runs.
 func runStrategyOverride(t *testing.T, installation *auth.Installation, header string, available ...router.Strategy) router.Strategy {
 	t.Helper()
+	_, observed := runStrategyOverrideResult(t, installation, header, available...)
+	return observed
+}
+
+func runStrategyOverrideResult(t *testing.T, installation *auth.Installation, header string, available ...router.Strategy) (int, router.Strategy) {
+	t.Helper()
 	gin.SetMode(gin.TestMode)
 	engine := gin.New()
 	engine.Use(func(c *gin.Context) {
@@ -38,7 +44,7 @@ func runStrategyOverride(t *testing.T, installation *auth.Installation, header s
 	}
 	rr := httptest.NewRecorder()
 	engine.ServeHTTP(rr, req)
-	return observed
+	return rr.Code, observed
 }
 
 func TestRouterStrategyOverride_AppliesRL(t *testing.T) {
@@ -144,6 +150,16 @@ func TestRouterStrategyOverride_AcceptsFutureRegisteredStrategy(t *testing.T) {
 	installation := overrideEnabledInstallation()
 	got := runStrategyOverride(t, installation, string(future), future)
 	assert.Equal(t, future, got)
+}
+
+func TestRouterStrategyOverride_RejectsUnregisteredPersistedStrategy(t *testing.T) {
+	unregistered := router.Strategy("quality-v2")
+	status, got := runStrategyOverrideResult(t, &auth.Installation{
+		ID:              "inst-custom",
+		RoutingStrategy: unregistered,
+	}, "")
+	assert.Equal(t, http.StatusServiceUnavailable, status)
+	assert.NotEqual(t, router.StrategyCluster, got, "must not silently rewrite to cluster")
 }
 
 func TestRouterStrategyOverride_NoOpsWhenInstallationMissing(t *testing.T) {


### PR DESCRIPTION
## Summary

Fixes #705  — `router_strategy_override.go` silently rewrote an
installation's persisted `routing_strategy` to `cluster` when that strategy
wasn't registered via `ROUTER_POLICY_SIDECARS`, returning HTTP 200 instead
of failing closed. This contradicts documented project policy
(`CONTRIBUTING.md:59-62`, `docs/POLICY_ROUTER_HARNESS.md:26-27`) and is
inconsistent with every other unrecognized-strategy case in the routing
path, where unwired/unknown strategies already fail closed with 503.

Introduced in #689, untested and undocumented as intentional.

## Fix

Replaces the warn-and-rewrite-to-cluster path with the same
`ErrStrategyUnavailable` → `ClassifyDispatchError` → 503 flow already used
elsewhere in the proxy layer — no new error format, just applying the
existing fail-closed convention to this one remaining outlier.

## Note

While verifying this fix, two additional issues were found and fixed in the
same branch:

1. **Header-override regression** — the fail-closed check initially ran
   before the header-override logic, so a valid `X-Weave-Router-Strategy`
   header could no longer override a bad persisted strategy even with
   `policy_header_overrides_enabled=true`, defeating the intended escape
   hatch. Reordered so the header override is evaluated first; added test
   coverage for all three cases (overrides disabled, valid override,
   invalid override).

2. **Error envelope format** — this middleware is mounted across Anthropic
   (`/v1/messages`, `/v1/route`), OpenAI (`/v1/chat/completions`,
   `/v1/responses`), and Gemini (`/v1beta/...`) routes, but the initial fix
   always returned an Anthropic-shaped error body. Now branches via
   `detectAPIFormat` (matching `abortInvalidKnob`'s existing pattern) so
   each client gets its native error shape. Live-verified all three.

Both are covered by new test cases in the same commit.

## Test plan

- [x] `TestRouterStrategyOverride_RejectsUnregisteredPersistedStrategy` —
      fails on `main`, passes here
- [x] Header-override precedence: overrides disabled → 503; overrides
      enabled + valid header → 200; overrides enabled + invalid header → 503
- [x] Per-format envelope assertions (Anthropic / OpenAI / Gemini), including
      `Retry-After` header
- [x] `make check`
- [x] `go test ./internal/server/middleware/... -race -count=1`
- [x] `go test ./... -race -count=1` — only the same pre-existing unrelated
      `internal/proxy` panic/race harness failures, nothing new
- [x] Live verify across all three formats: `routing_strategy='quality-v2'`
      → 503 with correct native envelope on `/v1/route`,
      `/v1/chat/completions`, and `/v1beta/...:generateContent`; reverted to
      `NULL` → 200 confirms normal routing unaffected