### PR TITLE
fix(auth): export invalidation hook for externally-written installation columns

### DIFF
--- a/docs/POLICY_ROUTER_HARNESS.md
+++ b/docs/POLICY_ROUTER_HARNESS.md
@@ -29,6 +29,53 @@ selection after bounded transient retries, the client receives HTTP 503.
 Availability comes from healthy replicas, readiness gates, immutable artifacts,
 and staged rollout rather than a second hidden policy.
 
+## Installation policy-rollout cache invalidation
+
+Migration `0034_installation-policy-routing` added installation columns that
+the router loads into the auth cache on every API-key lookup:
+
+- `routing_strategy`
+- `policy_shadow_strategy`
+- `policy_debug_enabled`
+- `policy_header_overrides_enabled`
+- `routing_rollout_id`
+- `ai_training_allowed`
+- `policy_routing_intent`
+
+These columns are written by the Weave control plane (direct SQL / its own
+data plane), not through this repo's admin API or SQLC update queries. The
+router only reads them.
+
+After committing a change to any of those columns, the external writer
+**must** publish the installation's UUID as the message body on
+`PUBSUB_TOPIC_ROUTER_INVALIDATION`. That is the same fanout
+`auth.Service.invalidateInstallation` already uses for every in-repo write
+that changes what `VerifyAPIKey` returns: API key rotation and deletion;
+BYOK external key upsert/delete; excluded models and excluded providers;
+routing preference; and subscription-routing-disabled. Each router
+replica's invalidation listener drops the installation from its positive
+auth cache so the next request reloads from Postgres.
+
+The positive auth-cache TTL (5 minutes) is a **fallback safety net**, not
+steady-state behavior. Relying on TTL alone means rollout flips, shadow
+toggles, and training-eligibility changes can serve stale values for up to
+five minutes after the control-plane write.
+
+This repo deliberately does **not** expose an HTTP invalidate endpoint.
+Unauthed control-plane routes in the router today (`/v1/router/models`,
+`/v1/router/policies`, …) are read-only and already-public data; an
+unauthed mutation endpoint would be a new security surface with no existing
+auth precedent to protect it. Authenticated inbound service-to-service auth
+also does not exist here yet (only outbound, e.g. `ROUTER_HMM_SIDECAR_AUTH`
+for sidecar calls). If an HTTP-based invalidation option becomes necessary,
+it needs an explicit auth design decision first — not silent adoption of
+the unauthed read-endpoint pattern.
+
+In-process callers can use `auth.Service.InvalidateInstallationCache`, which
+performs the same local eviction + Pub/Sub publish as the private write
+hooks. Publishing to the topic directly from the control plane is the
+production path for managed deployments.
+
 ## Required HTTP surface
 
 Every sidecar exposes:

--- a/internal/auth/service.go
+++ b/internal/auth/service.go
@@ -94,6 +94,19 @@ func (s *Service) WithInstallationChangeNotifier(n InstallationChangeNotifier) *
 	return s
 }
 
+// InvalidateInstallationCache evicts this replica's auth cache for
+// installationID and fans out to peer replicas via the configured notifier.
+// Use after an external writer (e.g. the Weave control plane) updates
+// installation columns that are loaded into the auth cache — there is no
+// HTTP write path in this repo for those columns, so the writer must trigger
+// invalidation explicitly. Set* methods on this service already call
+// invalidateInstallation as part of their own write path — do not pair this
+// with an in-repo write; it exists for callers outside this repo's write path.
+// Empty IDs are a no-op.
+func (s *Service) InvalidateInstallationCache(installationID string) {
+	s.invalidateInstallation(installationID)
+}
+
 // invalidateInstallation evicts the local cache and fans out to peer replicas.
 // Always called after a successful DB commit so listeners observe the new state.
 func (s *Service) invalidateInstallation(installationID string) {

--- a/internal/auth/service_test.go
+++ b/internal/auth/service_test.go
@@ -856,6 +856,47 @@ func (n *recordingNotifier) snapshot() []string {
 	return out
 }
 
+func TestService_InvalidateInstallationCache(t *testing.T) {
+	// External writers of installation columns (policy rollout, preferred
+	// models, etc.) have no SQLC/admin write path in this repo, so they must
+	// trigger the same local+pubsub eviction the in-repo write hooks use.
+	// This method must not touch the DB — it only clears cache.
+	const installID = "inst-A"
+
+	cache := newRecordingAPIKeyCache()
+	cache.Set("hash-A", auth.CachedKey{
+		APIKey:       &auth.APIKey{ID: "k1"},
+		Installation: &auth.Installation{ID: installID},
+	})
+	nf := &recordingNotifier{}
+	installRepo := &fakeInstallationRepository{}
+	svc := auth.NewService(installRepo, &fakeAPIKeyRepository{byHash: map[string]fakeKeyRow{}}, nil, nil, cache, nil, frozenClock()).
+		WithInstallationChangeNotifier(nf)
+
+	svc.InvalidateInstallationCache(installID)
+
+	assert.Equal(t, []string{installID}, cache.invalidationSnapshot(),
+		"InvalidateInstallationCache must drop cached keys for the installation")
+	assert.Equal(t, []string{installID}, nf.snapshot(),
+		"InvalidateInstallationCache must publish NOTIFY so peer replicas drop their cache too")
+	assert.Empty(t, installRepo.excludedModelsByID,
+		"InvalidateInstallationCache must not write excluded_models")
+	assert.Empty(t, installRepo.excludedProvidersByID,
+		"InvalidateInstallationCache must not write excluded_providers")
+	assert.Empty(t, installRepo.routingQualityByID,
+		"InvalidateInstallationCache must not write routing_quality_weight")
+	assert.Empty(t, installRepo.subscriptionRoutingDisabledByID,
+		"InvalidateInstallationCache must not write subscription_routing_disabled")
+	assert.Empty(t, installRepo.usageBypassEnabledByID,
+		"InvalidateInstallationCache must not write usage_bypass_*")
+
+	svc.InvalidateInstallationCache("")
+	assert.Equal(t, []string{installID}, cache.invalidationSnapshot(),
+		"empty installation ID must be a no-op")
+	assert.Equal(t, []string{installID}, nf.snapshot(),
+		"empty installation ID must not publish NOTIFY")
+}
+
 func TestService_WriteHooksInvalidateAndNotify(t *testing.T) {
 	// Each per-installation write must drop the cached entries for that
 	// installation AND publish a NOTIFY so peer replicas do the same. The


### PR DESCRIPTION
## Summary
 
Fixes #707 — policy-rollout columns added in migration 0034
(`routing_strategy`, `policy_shadow_strategy`, `policy_debug_enabled`,
`policy_header_overrides_enabled`, `routing_rollout_id`,
`ai_training_allowed`, `policy_routing_intent`) are written externally by
the Weave control plane with no way to trigger auth-cache invalidation, so
changes to any of them can serve stale for up to the 5-minute positive TTL,
per replica.
 
## What this PR does
 
Exports `auth.Service.InvalidateInstallationCache(installationID string)`
— a thin, tested wrapper around the existing private `invalidateInstallation`
helper, which does exactly what every in-repo write already does: evicts
the local LRU cache entry for that installation, and publishes to
`PUBSUB_TOPIC_ROUTER_INVALIDATION` so every other replica's subscriber
evicts too.
 
This gives the codebase a clean, documented, tested entry point for
triggering the same invalidation an external writer needs, without
inventing a new mechanism — it's the same fan-out every other mutable
field already relies on.
 
## What this PR deliberately does not do
 
**No HTTP endpoint.** Every unauthed control-plane route this repo
currently exposes (`/v1/router/models`, `/v1/router/policies`) is
read-only, serving data that's already public. An unauthed *mutation*
endpoint would be new attack surface with no existing precedent to protect
it, and this repo has no inbound service-to-service auth scheme today —
only outbound (e.g. `ROUTER_HMM_SIDECAR_AUTH` for router→sidecar calls).
Adding inbound auth is a real security design decision that shouldn't be
made silently as a side effect of a bugfix PR. If an HTTP-based
invalidation path becomes necessary later, it needs its own explicit design
discussion — this PR intentionally stops short of that.
 
**No fix for production staleness by itself.** This PR only takes effect
once the control plane either calls this method in-process (if it's ever
merged into this codebase) or — in its current form as a separate service —
publishes the installation ID to `PUBSUB_TOPIC_ROUTER_INVALIDATION`
directly, which it's able to do today without any code from this PR, since
that topic and its fan-out mechanism already exist and are already
consumed by every replica. What this PR actually adds is: a clean in-repo
entry point (useful for any future in-repo caller), full test coverage of
its exact eviction/fan-out behavior, and — maybe most importantly — a
written-down contract in `docs/POLICY_ROUTER_HARNESS.md` so this isn't
tribal knowledge.
 
## Docs
 
New section in `docs/POLICY_ROUTER_HARNESS.md`:
- Lists the affected columns and confirms they're control-plane-owned.
- States the required contract: publish the installation ID to
  `PUBSUB_TOPIC_ROUTER_INVALIDATION` after committing any of these columns.
- States explicitly that the 5-minute TTL is a fallback safety net, not
  steady-state behavior (matching existing test comment language).
- Explains, plainly, why there's no HTTP endpoint and what would need to
  happen before one gets added.
- Points to `auth.Service.InvalidateInstallationCache` and its test as the
  concrete in-process reference for the exact behavior this triggers.
## Test plan
 
- [x] `TestService_InvalidateInstallationCache` — asserts local cache
      eviction and notifier publish both fire, confirms no DB interaction
      occurs, and confirms an empty installation ID is a no-op
- [x] `make check`
- [x] `go test ./internal/auth/... -race -count=1`
- [x] `go test ./... -race -count=1` — same 3 pre-existing, unrelated
      panic-recovery race flakes seen on `main` and in prior PRs
      (`TestService_VerifyAPIKey_RecoversFromMarkUsedPanic`,
      `TestSafeGoRecoversFromPanic`, `TestFireTelemetryRecoversFromPanic`),
      nothing new introduced by this change
- [x] **Live verify, hand-driven, no restarts during the actual proof:**
  1. Confirmed baseline request succeeds (200).
  2. Wrote `routing_strategy='hmm'` directly via SQL (simulating an
     external control-plane write) — no server restart.
  3. Re-sent the identical request — still 200, confirming the cache is
     stale and hasn't picked up the change.
  4. Restarted the server to force a fresh read, confirming `hmm` really
     does produce different behavior (502, unwired locally) once the cache
     isn't stale — ruling out coincidence.
  5. Reset to a clean baseline (`routing_strategy=NULL`), reconfirmed 200.
  6. Reproduced the stale-cache condition again (wrote `hmm`, confirmed
     200 with no restart).
  7. Called `InvalidateInstallationCache` via a standalone script — no
     server restart.
  8. Re-sent the identical request immediately — now 502, proving the
     cache was evicted and the next request read fresh state, entirely
     without a restart or waiting out the TTL.
## Related
 
- Introduced (as a read path with no write/invalidation path) in #689.
- Same class of gap as `preferred_models`, `usage_bypass_*`, and
  `subscription_routing_disabled` — see linked issue for details. This is
  the fourth instance, with the highest blast radius since it affects
  routing strategy and privacy/training gates.
 