### PR TITLE
feat(hmm): forward client session id and outcome cost_usd

### DIFF
--- a/internal/policyclient/client.go
+++ b/internal/policyclient/client.go
@@ -139,6 +139,7 @@ type routeRequest struct {
 	AvailableTools            []string           `json:"available_tools,omitempty"`
 	FeedbackKey               string             `json:"feedback_key,omitempty"`
 	FeedbackRole              string             `json:"feedback_role,omitempty"`
+	ClientSessionID           string             `json:"client_session_id,omitempty"`
 	EstimatedInputTokens      int                `json:"estimated_input_tokens"`
 	HasTools                  bool               `json:"has_tools"`
 	HasImages                 bool               `json:"has_images"`
@@ -248,6 +249,7 @@ func (c *Client) Decide(ctx context.Context, query policy.Query) (policy.Result,
 		AvailableTools:            clipRouteValues(query.AvailableTools, maxRouteToolCallInputKeys, maxRouteToolCallInputChars),
 		FeedbackKey:               query.FeedbackKey,
 		FeedbackRole:              query.FeedbackRole,
+		ClientSessionID:           query.ClientSessionID,
 		EstimatedInputTokens:      query.EstimatedInputTokens,
 		HasTools:                  query.HasTools,
 		HasImages:                 query.HasImages,

--- a/internal/policyclient/client_test.go
+++ b/internal/policyclient/client_test.go
@@ -68,6 +68,9 @@ func TestClientPostsVersionedRouteAndParsesPolicyMetadata(t *testing.T) {
 			{Role: "user", Text: "latest hello", ToolCalls: []router.ConversationToolCall{{Name: "Read", InputKeys: []string{"file_path"}, InputJSON: `{"file_path":"README.md"}`}}},
 		},
 		AvailableTools:  []string{"Read", "Grep", "Read", ""},
+		FeedbackKey:     "feedback-session",
+		FeedbackRole:    "default",
+		ClientSessionID: "client-session-abc",
 		TrainingAllowed: true,
 		Candidates: []policy.Candidate{{
 			RosterID:       "moonshotai/kimi-k2.7-code",
@@ -96,6 +99,9 @@ func TestClientPostsVersionedRouteAndParsesPolicyMetadata(t *testing.T) {
 	assert.Equal(t, "latest hello", got.LatestUserText)
 	assert.Equal(t, 1, got.TurnIndex)
 	assert.Equal(t, []string{"Read", "Grep"}, got.AvailableTools)
+	assert.Equal(t, "feedback-session", got.FeedbackKey)
+	assert.Equal(t, "default", got.FeedbackRole)
+	assert.Equal(t, "client-session-abc", got.ClientSessionID)
 	require.Len(t, got.TrainingConversationDelta, 3)
 	assert.Equal(t, "assistant", got.TrainingConversationDelta[0].Role)
 	require.Len(t, got.TrainingConversationDelta[1].ToolResults, 1)

--- a/internal/proxy/gemini.go
+++ b/internal/proxy/gemini.go
@@ -93,6 +93,7 @@ func (s *Service) ProxyGeminiGenerateContent(ctx context.Context, body []byte, w
 		PromptText:           promptText,
 		ConversationMessages: conversationMessagesForRouting(env),
 		AvailableTools:       availableToolsForRouting(env),
+		ClientSessionID:      env.ClientSessionID(),
 		EnabledProviders:     s.enabledProvidersForRequest(ctx, providers.ProviderGoogle, r.Header),
 		ExcludedModels:       s.excludedModelsForRequest(ctx),
 		PreferredModels:      s.preferredModelsForRequest(ctx),

--- a/internal/proxy/hmm_outcome_internal_test.go
+++ b/internal/proxy/hmm_outcome_internal_test.go
@@ -10,6 +10,7 @@ import (
 
 	"workweave/router/internal/providers"
 	"workweave/router/internal/router"
+	"workweave/router/internal/router/catalog"
 	"workweave/router/internal/router/policy"
 )
 
@@ -56,10 +57,19 @@ func TestReportPolicyOutcome_UsesFreshMetadataForStickyServedDecision(t *testing
 	ctx = context.WithValue(ctx, ExternalIDContextKey{}, "org-1")
 	ctx = context.WithValue(ctx, InstallationIDContextKey{}, "installation-1")
 	ctx = context.WithValue(ctx, ClientIdentityContextKey{}, ClientIdentity{ClientApp: ClientAppCodex, RolloutID: "rollout-1"})
-	s.reportPolicyOutcome(ctx, routeRes, served, providers.ProviderAnthropic, 100, 90, 10, 0, 0, 12, 34, nil, &policyOutcomeResponse{
+	const (
+		inputTokens  = 90
+		outputTokens = 10
+	)
+	s.reportPolicyOutcome(ctx, routeRes, served, providers.ProviderAnthropic, 100, inputTokens, outputTokens, 0, 0, 12, 34, nil, &policyOutcomeResponse{
 		Body:      []byte(`{"content":[{"type":"text","text":"done"}]}`),
 		Truncated: false,
 	})
+
+	price, ok := catalog.PriceFor(providers.ProviderAnthropic, "claude-haiku-4-5")
+	require.True(t, ok)
+	wantCost := catalog.EffectiveInputCost(inputTokens, 0, 0, price.InputUSDPer1M, price, providers.ProviderAnthropic) +
+		catalog.EffectiveOutputCost(outputTokens, price.OutputUSDPer1M)
 
 	select {
 	case payload := <-reporter.ch:
@@ -79,6 +89,7 @@ func TestReportPolicyOutcome_UsesFreshMetadataForStickyServedDecision(t *testing
 		assert.Equal(t, `{"content":[{"type":"text","text":"done"}]}`, payload["response_body"])
 		assert.Equal(t, "client_anthropic", payload["response_body_format"])
 		assert.Equal(t, false, payload["response_body_truncated"])
+		assert.Equal(t, wantCost, payload["cost_usd"])
 	case <-time.After(time.Second):
 		t.Fatal("timed out waiting for HMM outcome payload")
 	}

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -1651,6 +1651,7 @@ func (s *Service) RouteAnthropicRequest(ctx context.Context, body []byte) (decis
 		AvailableTools:       availableToolsForRouting(env),
 		OrganizationID:       organizationID,
 		InstallationID:       installationID,
+		ClientSessionID:      env.ClientSessionID(),
 		RoutingKnobs:         router.RoutingKnobsFromContext(ctx),
 	})
 	return decision, err
@@ -2093,6 +2094,7 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 		// can correlate with the route even if local compaction rewrites env.
 		FeedbackKey:      hex.EncodeToString(sessionKey[:]),
 		FeedbackRole:     roleForTier(catalog.TierFor(feats.Model)),
+		ClientSessionID:  env.ClientSessionID(),
 		EnabledProviders: enabledProviders,
 		ExcludedModels:   excluded,
 		PreferredModels:  s.preferredModelsForRequest(ctx),
@@ -3229,6 +3231,15 @@ func (s *Service) reportPolicyOutcome(ctx context.Context, res turnLoopResult, d
 	if proxyErr != nil {
 		payload["error"] = proxyErr.Error()
 	}
+	price, ok := catalog.PriceFor(finalProvider, decision.Model)
+	if !ok {
+		price, ok = catalog.PrimaryPriceFor(decision.Model)
+	}
+	if ok {
+		inputCost := catalog.EffectiveInputCost(inputTokens, cacheCreation, cacheRead, price.InputUSDPer1M, price, finalProvider)
+		outputCost := catalog.EffectiveOutputCost(outputTokens, price.OutputUSDPer1M)
+		payload["cost_usd"] = inputCost + outputCost
+	}
 	log := observability.FromContext(ctx).With("route_id", routeMetadata.RouteID)
 	if err := ctx.Err(); err != nil {
 		log.Debug("Skipping policy outcome report for canceled request", "err", err)
@@ -4034,6 +4045,7 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 		// can correlate with the route even if local compaction rewrites env.
 		FeedbackKey:      hex.EncodeToString(sessionKey[:]),
 		FeedbackRole:     roleForTier(catalog.TierFor(feats.Model)),
+		ClientSessionID:  env.ClientSessionID(),
 		EnabledProviders: enabledProviders,
 		ExcludedModels:   excludedOAI,
 		PreferredModels:  s.preferredModelsForRequest(ctx),

--- a/internal/router/hmm/hmm_test.go
+++ b/internal/router/hmm/hmm_test.go
@@ -62,6 +62,7 @@ func TestRouterMapsSidecarRosterModelBackToCatalogDecision(t *testing.T) {
 		DebugEnabled:         true,
 		FeedbackKey:          "feedback-session",
 		FeedbackRole:         "default",
+		ClientSessionID:      "client-session-abc",
 	})
 
 	require.NoError(t, err)
@@ -86,6 +87,7 @@ func TestRouterMapsSidecarRosterModelBackToCatalogDecision(t *testing.T) {
 	assert.Equal(t, "rollout-1", decider.query.RolloutID)
 	assert.Equal(t, "feedback-session", decider.query.FeedbackKey)
 	assert.Equal(t, "default", decider.query.FeedbackRole)
+	assert.Equal(t, "client-session-abc", decider.query.ClientSessionID)
 	assert.Equal(t, []router.ConversationMessage{{Role: "user", Text: "latest hello"}}, decider.query.ConversationMessages)
 	require.Len(t, decider.query.Candidates, 1)
 	candidate := decider.query.Candidates[0]

--- a/internal/router/policy/contract.go
+++ b/internal/router/policy/contract.go
@@ -50,6 +50,7 @@ type Query struct {
 	AvailableTools       []string
 	FeedbackKey          string
 	FeedbackRole         string
+	ClientSessionID      string
 	EstimatedInputTokens int
 	HasTools             bool
 	HasImages            bool

--- a/internal/router/policy/sidecar_router.go
+++ b/internal/router/policy/sidecar_router.go
@@ -108,6 +108,7 @@ func (r *SidecarRouter) Route(ctx context.Context, req router.Request) (router.D
 		AvailableTools:       req.AvailableTools,
 		FeedbackKey:          req.FeedbackKey,
 		FeedbackRole:         req.FeedbackRole,
+		ClientSessionID:      req.ClientSessionID,
 		EstimatedInputTokens: req.EstimatedInputTokens,
 		HasTools:             req.HasTools,
 		HasImages:            req.HasImages,

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -49,6 +49,9 @@ type Request struct {
 	// sidecar routers that accept per-session feedback.
 	FeedbackKey  string
 	FeedbackRole string
+	// ClientSessionID is the calling client's own session id (e.g. Claude
+	// Code metadata.user_id), when present on the inbound envelope.
+	ClientSessionID string
 	// Per-request provider gating — nil means unrestricted.
 	EnabledProviders map[string]struct{}
 	// Per-request model exclusion — nil or empty means no exclusion.


### PR DESCRIPTION
Wire ClientSessionID through Request → policy Query → /route JSON, and estimate cost_usd on policy outcome reports so the HMM sidecar can emit cost deltas and session-scoped learning signals.