### PR TITLE
fix(policy): use effective context window for extended-context models in resolver

### DIFF
--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -646,10 +646,7 @@ func shouldEnableExtendedContext(est, outputReserve int) bool {
 // client's beta header or the token estimate instead would let a large
 // request slip onto 200K and overflow on the first turn.
 func contextWindowForRequest(modelID string) int {
-	if router.Lookup(modelID).Supports(router.CapExtendedContext) {
-		return 1_000_000
-	}
-	return catalog.ContextWindowFor(modelID)
+	return catalog.EffectiveContextWindowFor(modelID)
 }
 
 // modelStripsAnthropicSignatures reports whether dispatching to model drops

--- a/internal/router/catalog/catalog.go
+++ b/internal/router/catalog/catalog.go
@@ -193,8 +193,8 @@ var Models = []Model{
 	}},
 	// Opus 4.5+ is $5/$25 per MTok (down from $15/$75 on 4.1 and earlier).
 	// 4.6+/4.7+/4.8 support 1M context via the context-1m-2025-08-07 beta; the
-	// catalog reports 200K and the pre-filter expands to 1M when the beta
-	// header is present (contextWindowForRequest in proxy/service.go).
+	// catalog reports 200K and EffectiveContextWindowFor expands to 1M for
+	// CapExtendedContext models (proxy pre-filter + policy candidate filter).
 	{ID: "claude-opus-4-6", Tier: TierHigh, ContextWindow: 200_000, Providers: []ProviderBinding{
 		{Provider: providers.ProviderAnthropic, Price: Pricing{InputUSDPer1M: 5.00, OutputUSDPer1M: 25.00, CacheReadMultiplier: 0.10}},
 	}},

--- a/internal/router/catalog/catalog_test.go
+++ b/internal/router/catalog/catalog_test.go
@@ -249,8 +249,8 @@ func TestModel_ImageInputDefaultsToUnknown(t *testing.T) {
 }
 
 func TestContextWindowFor_KnownModels(t *testing.T) {
-	// Anthropic models report 200K in the catalog; they support 1M via context-1m-2025-08-07
-	// beta when explicitly requested by the client (see contextWindowForRequest in proxy/service.go).
+	// Anthropic models report 200K in the catalog; CapExtendedContext models
+	// expand to 1M via EffectiveContextWindowFor (not this accessor).
 	assert.Equal(t, 200_000, ContextWindowFor("claude-opus-4-8"))
 	assert.Equal(t, 200_000, ContextWindowFor("claude-sonnet-4-6"))
 	assert.Equal(t, 200_000, ContextWindowFor("claude-haiku-4-5"))
@@ -272,6 +272,22 @@ func TestContextWindowFor_KnownModels(t *testing.T) {
 	assert.Equal(t, 204_800, ContextWindowFor("minimax/minimax-m2.7"))
 	// Unknown model falls back to DefaultContextWindow.
 	assert.Equal(t, DefaultContextWindow, ContextWindowFor("not-a-real-model"))
+}
+
+// TestEffectiveContextWindowFor_ExtendedContextModelsReport1M is the catalog-side
+// contract for CapExtendedContext models: catalog.ContextWindowFor stays at the
+// base 200K row, but EffectiveContextWindowFor must report 1M because dispatch
+// unconditionally injects the context-1m beta for those models.
+func TestEffectiveContextWindowFor_ExtendedContextModelsReport1M(t *testing.T) {
+	assert.Equal(t, 200_000, ContextWindowFor("claude-opus-4-8"), "base catalog window must stay 200K")
+	assert.Equal(t, 1_000_000, EffectiveContextWindowFor("claude-opus-4-8"))
+	assert.Equal(t, 1_000_000, EffectiveContextWindowFor("claude-sonnet-5"))
+	assert.Equal(t, 1_000_000, EffectiveContextWindowFor("claude-sonnet-4-6"))
+	assert.Equal(t, 1_000_000, EffectiveContextWindowFor("claude-opus-4-6"))
+	// fable-5 is CapExtendedContext but already 1M in the catalog.
+	assert.Equal(t, 1_000_000, EffectiveContextWindowFor("claude-fable-5"))
+	// Non-extended models keep their catalog window.
+	assert.Equal(t, 200_000, EffectiveContextWindowFor("claude-haiku-4-5"))
 }
 
 func TestValidateDeployed_FlagsMissingAndUntiered(t *testing.T) {

--- a/internal/router/catalog/lookup.go
+++ b/internal/router/catalog/lookup.go
@@ -147,6 +147,24 @@ func ContextWindowFor(id string) int {
 	return m.ContextWindow
 }
 
+// EffectiveContextWindowFor returns the dispatch-eligible context window for a
+// model. CapExtendedContext models (Opus 4.6+, Sonnet 4.6+) always report 1M
+// because the proxy unconditionally injects the context-1m beta when dispatching
+// them — gating on the client's beta header or the token estimate instead would
+// let a large request slip onto the catalog's 200K row and overflow on the first
+// turn. Non-extended models keep their catalog window via ContextWindowFor.
+//
+// Use this for eligibility / overflow decisions (policy candidate filtering,
+// proxy pre-filter). Prefer ContextWindowFor when the base catalog row is what
+// you need (pricing docs, install scripts, summarizer rosters that already list
+// native-1M models).
+func EffectiveContextWindowFor(id string) int {
+	if router.Lookup(id).Supports(router.CapExtendedContext) {
+		return 1_000_000
+	}
+	return ContextWindowFor(id)
+}
+
 // ToolUseLowSet returns model IDs with ToolUseLow quality. The cluster scorer
 // excludes these when req.HasTools, falling back to the unfiltered pool if
 // that would empty the eligible set.

--- a/internal/router/policy/resolver.go
+++ b/internal/router/policy/resolver.go
@@ -183,7 +183,7 @@ func (r *Resolver) Resolve(req router.Request) ResolvedCandidates {
 			diagnostics = append(diagnostics, Diagnostic{CatalogID: id, Reason: ExclusionUnmappedRoster})
 			continue
 		}
-		contextWindow := catalog.ContextWindowFor(id)
+		contextWindow := catalog.EffectiveContextWindowFor(id)
 		if requiredContextTokens(req) > contextWindow {
 			diagnostics = append(diagnostics, Diagnostic{CatalogID: id, RosterID: rosterID, Reason: ExclusionContextWindow})
 			continue

--- a/internal/router/policy/resolver_test.go
+++ b/internal/router/policy/resolver_test.go
@@ -103,7 +103,25 @@ func TestResolverRejectsAmbiguousRosterMappings(t *testing.T) {
 	assert.Len(t, resolved.Diagnostics, 2)
 }
 
-func TestResolverRejectsCandidatesThatCannotFitEstimatedInput(t *testing.T) {
+func TestResolverRejectsNonExtendedModelAboveCatalogWindow(t *testing.T) {
+	resolver := policy.NewResolver(
+		set("claude-haiku-4-5"),
+		set(providers.ProviderAnthropic),
+		catalogRosterID,
+		policy.ManagedProviderPolicy(),
+	)
+
+	resolved := resolver.Resolve(router.Request{EstimatedInputTokens: catalog.ContextWindowFor("claude-haiku-4-5") + 1})
+
+	assert.Empty(t, resolved.Candidates)
+	assert.Contains(t, resolved.Diagnostics, policy.Diagnostic{
+		CatalogID: "claude-haiku-4-5",
+		RosterID:  "claude-haiku-4-5",
+		Reason:    policy.ExclusionContextWindow,
+	})
+}
+
+func TestResolverRejectsExtendedContextModelAboveEffectiveWindow(t *testing.T) {
 	resolver := policy.NewResolver(
 		set("claude-opus-4-8"),
 		set(providers.ProviderAnthropic),
@@ -111,7 +129,9 @@ func TestResolverRejectsCandidatesThatCannotFitEstimatedInput(t *testing.T) {
 		policy.ManagedProviderPolicy(),
 	)
 
-	resolved := resolver.Resolve(router.Request{EstimatedInputTokens: catalog.ContextWindowFor("claude-opus-4-8") + 1})
+	// CapExtendedContext expands eligibility to 1M; above that the model must
+	// still be excluded so the fix does not invent infinite headroom.
+	resolved := resolver.Resolve(router.Request{EstimatedInputTokens: 1_000_001})
 
 	assert.Empty(t, resolved.Candidates)
 	assert.Contains(t, resolved.Diagnostics, policy.Diagnostic{
@@ -119,6 +139,31 @@ func TestResolverRejectsCandidatesThatCannotFitEstimatedInput(t *testing.T) {
 		RosterID:  "claude-opus-4-8",
 		Reason:    policy.ExclusionContextWindow,
 	})
+}
+
+// TestResolverKeepsExtendedContextModelAboveCatalogWindow is the live-bug
+// regression: CapExtendedContext models (catalog 200K, dispatch 1M) must remain
+// candidates when requiredContextTokens is catalogCW+1 (200_001). Filtering on
+// catalog.ContextWindowFor alone wrongly excludes them.
+func TestResolverKeepsExtendedContextModelAboveCatalogWindow(t *testing.T) {
+	resolver := policy.NewResolver(
+		set("claude-opus-4-8"),
+		set(providers.ProviderAnthropic),
+		catalogRosterID,
+		policy.ManagedProviderPolicy(),
+	)
+
+	resolved := resolver.Resolve(router.Request{
+		EstimatedInputTokens: catalog.ContextWindowFor("claude-opus-4-8") + 1,
+	})
+
+	assert.Equal(t, []string{"claude-opus-4-8"}, resolved.CandidateModels(),
+		"opus-4-8 must stay eligible at catalogCW+1 (serves at 1M via CapExtendedContext)")
+	assert.Empty(t, resolved.Diagnostics)
+	if assert.Len(t, resolved.Candidates, 1) {
+		assert.Equal(t, 1_000_000, resolved.Candidates[0].Capabilities.ContextWindow,
+			"candidate capabilities must advertise the effective 1M window, not catalog 200K")
+	}
 }
 
 func TestResolverAllowsExactContextFit(t *testing.T) {
@@ -137,7 +182,7 @@ func TestResolverAllowsExactContextFit(t *testing.T) {
 
 func TestResolverIncludesExpectedOutputInContextBudget(t *testing.T) {
 	resolver := policy.NewResolver(
-		set("claude-opus-4-8"),
+		set("claude-haiku-4-5"),
 		set(providers.ProviderAnthropic),
 		catalogRosterID,
 		policy.ManagedProviderPolicy(),
@@ -145,14 +190,14 @@ func TestResolverIncludesExpectedOutputInContextBudget(t *testing.T) {
 	expectedOutputTokens := 2_000
 
 	resolved := resolver.Resolve(router.Request{
-		EstimatedInputTokens: catalog.ContextWindowFor("claude-opus-4-8") - 1_000,
+		EstimatedInputTokens: catalog.ContextWindowFor("claude-haiku-4-5") - 1_000,
 		RoutingKnobs:         &router.Overrides{ExpectedOutputTokens: &expectedOutputTokens},
 	})
 
 	assert.Empty(t, resolved.Candidates)
 	assert.Contains(t, resolved.Diagnostics, policy.Diagnostic{
-		CatalogID: "claude-opus-4-8",
-		RosterID:  "claude-opus-4-8",
+		CatalogID: "claude-haiku-4-5",
+		RosterID:  "claude-haiku-4-5",
 		Reason:    policy.ExclusionContextWindow,
 	})
 }


### PR DESCRIPTION
## Summary
 
Fixes #710 — the policy resolver excluded `claude-opus-4-8` and
`claude-sonnet-5` from sidecar candidate sets for any request estimating
more than 200,000 input tokens, because it filtered on the raw catalog
window instead of the effective 1M window these `CapExtendedContext`
models actually serve at via the `context-1m` beta. This caused
customer-visible 502/503 failures whenever a policy sidecar selected one
of these models for a legitimately large — but entirely serviceable —
request. This is a known Bugbot finding from #691, left unaddressed while
two sibling findings on the same file were fixed in that same review
cycle.
 
## Fix
 
Two commits, following the extraction pattern already established in this
codebase (#642 — pull shared logic into `catalog`, thin wrapper at each
call site):
 
**1. `refactor(catalog): extract EffectiveContextWindowFor`**
Moves the "does this model actually serve at 1M via the context-1m beta"
logic out of `proxy.contextWindowForRequest` and into
`catalog.EffectiveContextWindowFor`, a single shared source of truth both
`proxy` and `policy` can call. This location was chosen deliberately:
`policy` cannot import `proxy` (proxy already imports policy — the reverse
would be a cycle), and `catalog` already imports `router` for the
`Lookup`/`Supports` calls this logic needs. `proxy.contextWindowForRequest`
becomes a one-line wrapper around the new function. This commit is
behavior-preserving — no functional change, confirmed by the full existing
test suite staying green.
 
**2. `fix(policy): use effective context window in resolver`**
Switches the resolver's candidate-filtering line from
`catalog.ContextWindowFor(id)` to `catalog.EffectiveContextWindowFor(id)`
— the actual bug fix. Also updates the advertised
`Capabilities.ContextWindow` sent to the sidecar to reflect the effective
window, so the sidecar's own cost/capability reasoning about these
candidates is accurate too, not just the resolver's pass/fail filter.
 
This approach directly eliminates the underlying bug *class* — two
independent implementations of "what's this model's real context window"
able to silently drift apart — rather than only patching the resolver's
check in isolation. A local-only fix would have left the next caller (a
future policy path, a planner, anything else that needs this same
eligibility check) free to reintroduce the identical bug. This is the same
shape of gap #706 addressed for per-format error envelopes: fix the
divergence at its root, not just the symptom.
 
## Known, deliberately unaddressed scope
 
`selectCompactionSummarizer` (`internal/proxy/compaction.go`) still uses
raw `catalog.ContextWindowFor` for its two current candidate models
(`claude-haiku-4-5`, `claude-fable-5`). Neither is a `CapExtendedContext`
model with a 200K catalog window today — `claude-haiku-4-5` isn't
`CapExtendedContext` at all, and `claude-fable-5`'s catalog window is
already 1M — so this call site is not a live instance of the bug and is
deliberately left untouched in this PR. Flagging explicitly for future
reference: if a `CapExtendedContext` model with a 200K catalog window is
ever added to `compactionSummarizerModels`, that selector should switch to
`EffectiveContextWindowFor` too.
 
## Test plan
 
- [x] `TestEffectiveContextWindowFor_ExtendedContextModelsReport1M` (new,
      `catalog` package) — asserts `EffectiveContextWindowFor` returns 1M
      for `claude-opus-4-8`, `claude-sonnet-5`, `claude-sonnet-4-6`,
      `claude-opus-4-6`, and confirms `claude-fable-5` and
      `claude-haiku-4-5` behave correctly at their own boundaries; asserts
      `ContextWindowFor` (the base catalog accessor) is untouched and still
      returns 200K for these models
- [x] `TestResolverKeepsExtendedContextModelAboveCatalogWindow` (new,
      `policy` package) — the direct live-bug regression test: asserts
      `claude-opus-4-8` remains a candidate at exactly `catalogWindow + 1`
      (200,001) tokens, with zero diagnostics, and that its advertised
      `Capabilities.ContextWindow` is 1M, not 200K. **Fails on `main`,
      passes here.**
- [x] Existing exclusion coverage preserved and split into two explicit,
      correctly-scoped cases (the old single test conflated both and
      happened to only exercise the buggy path):
  - `TestResolverRejectsNonExtendedModelAboveCatalogWindow` — a
    non-`CapExtendedContext` model (`claude-haiku-4-5`) is still correctly
    excluded at its own catalog window + 1
  - `TestResolverRejectsExtendedContextModelAboveEffectiveWindow` — a
    `CapExtendedContext` model is still correctly excluded above the true
    1M ceiling (tested at 1,000,001) — confirms the fix extends eligibility
    to 1M without removing the ceiling entirely
- [x] `TestResolverIncludesExpectedOutputInContextBudget` retargeted to a
      non-extended model (`claude-haiku-4-5`) so it continues to test what
      it was meant to test (output-budget inclusion) without incidentally
      depending on the now-fixed extended-context behavior
- [x] `go build ./...`, `go vet ./...`, `make check` — all pass
- [x] `go test ./... -race -count=1` — the only failure is the
      pre-existing `TestFireTelemetryRecoversFromPanic` (`internal/proxy`),
      confirmed reproducible in isolation (3/3 runs under `-run`, `-race`)
      on this branch's own tip — this is a known, `-race`-detector-only
      timing flake in the panic-recovery test harness itself, unrelated to
      this change; `catalog` and `policy` packages are fully clean under
      `-race`; identical failure signature to prior PRs in this repo
      (#706, #708)
- [x] **Live verify, hand-driven, exact token boundaries** against a fresh
      rebuild of this branch:
  - 199,999 / 200,000 / 200,001 tokens → `claude-opus-4-8` and
    `claude-sonnet-5` present in sidecar candidates at all three sizes
    (broken at 200,001 before this fix)
  - Counterfactual: `/v1/messages` pre-filter log confirms these models
    were never excluded by the actual serving path — the resolver was the
    sole source of the gap
  - Forced-selection failure case at 200,001 tokens:
    `/v1/route` 502 → 200; `/v1/messages` 503 → (progresses past routing
    entirely, only hits a pre-existing, unrelated upstream billing error)
    — the customer-facing bug is resolved
  - Regression check at 1,000,001 and 1,200,000 tokens: `claude-opus-4-8`,
    `claude-sonnet-5`, and `claude-fable-5` are all correctly still
    excluded — confirms the fix extends the window to 1M without removing
    the ceiling, i.e. no overcorrection
 