### PR TITLE
feat: emit exact HMM transition telemetry

### DIFF
--- a/internal/proxy/gemini.go
+++ b/internal/proxy/gemini.go
@@ -12,6 +12,7 @@ import (
 	"workweave/router/internal/providers"
 	"workweave/router/internal/router"
 	"workweave/router/internal/router/catalog"
+	"workweave/router/internal/router/sessionpin"
 	"workweave/router/internal/translate"
 
 	"github.com/google/uuid"
@@ -71,7 +72,8 @@ func (s *Service) ProxyGeminiGenerateContent(ctx context.Context, body []byte, w
 		embedInput = "only_user_message"
 	}
 
-	ctx, log, _ = bindRequestLogger(ctx, env, apiKeyID, requestID, "gemini_generate_content")
+	var sessionKey [sessionpin.SessionKeyLen]byte
+	ctx, log, sessionKey = bindRequestLogger(ctx, env, apiKeyID, requestID, "gemini_generate_content")
 	log.Info("ProxyGeminiGenerateContent start",
 		"requested_model", feats.Model,
 		"stream", env.Stream(),
@@ -154,7 +156,7 @@ func (s *Service) ProxyGeminiGenerateContent(ctx context.Context, body []byte, w
 		Float64("catalog.actual_output_per_1m", actPricing.OutputUSDPer1M).
 		Int64("latency.route_ms", routeMs)
 	applyPlannerAttrs(geminiDecisionBuilder, routeRes)
-	applyRoutingStateAttrs(geminiDecisionBuilder, routeRes, decision.Model)
+	applyRoutingStateAttrs(geminiDecisionBuilder, routeRes, decision.Model, sessionKey)
 	otel.Record(ctx, otel.Span{
 		Name:  "router.decision",
 		Start: requestStart,
@@ -240,7 +242,7 @@ func (s *Service) ProxyGeminiGenerateContent(ctx context.Context, body []byte, w
 		Int64("upstream.status_code", int64(upstreamStatus(proxyErr))).
 		Bool("routing.cross_format", false)
 	applyPlannerAttrs(geminiUpstreamBuilder, routeRes)
-	applyRoutingStateAttrs(geminiUpstreamBuilder, routeRes, decision.Model)
+	applyRoutingStateAttrs(geminiUpstreamBuilder, routeRes, decision.Model, sessionKey)
 	addTimingAttrs(ctx, geminiUpstreamBuilder)
 	otel.Record(ctx, otel.Span{
 		Name:  "router.upstream",

--- a/internal/proxy/gemini.go
+++ b/internal/proxy/gemini.go
@@ -154,6 +154,7 @@ func (s *Service) ProxyGeminiGenerateContent(ctx context.Context, body []byte, w
 		Float64("catalog.actual_output_per_1m", actPricing.OutputUSDPer1M).
 		Int64("latency.route_ms", routeMs)
 	applyPlannerAttrs(geminiDecisionBuilder, routeRes)
+	applyRoutingStateAttrs(geminiDecisionBuilder, routeRes, decision.Model)
 	otel.Record(ctx, otel.Span{
 		Name:  "router.decision",
 		Start: requestStart,
@@ -239,6 +240,7 @@ func (s *Service) ProxyGeminiGenerateContent(ctx context.Context, body []byte, w
 		Int64("upstream.status_code", int64(upstreamStatus(proxyErr))).
 		Bool("routing.cross_format", false)
 	applyPlannerAttrs(geminiUpstreamBuilder, routeRes)
+	applyRoutingStateAttrs(geminiUpstreamBuilder, routeRes, decision.Model)
 	addTimingAttrs(ctx, geminiUpstreamBuilder)
 	otel.Record(ctx, otel.Span{
 		Name:  "router.upstream",

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -2297,6 +2297,7 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 		Float64("catalog.actual_output_per_1m", actPricing.OutputUSDPer1M).
 		Int64("latency.route_ms", routeMs)
 	applyPlannerAttrs(decisionBuilder, routeRes)
+	applyRoutingStateAttrs(decisionBuilder, routeRes, decision.Model)
 	otel.Record(ctx, otel.Span{
 		Name:  "router.decision",
 		Start: requestStart,
@@ -2794,6 +2795,7 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 		Bool("dispatch.baseline_failover", baselineFailoverUsed).
 		Bool("dispatch.subscription_failover", subscriptionFailoverUsed)
 	applyPlannerAttrs(upstreamBuilder, routeRes)
+	applyRoutingStateAttrs(upstreamBuilder, routeRes, decision.Model)
 	addTimingAttrs(ctx, upstreamBuilder)
 
 	obs := buildObservationContext(ctx, decision, routeRes.Fresh, s.captureMode)
@@ -2979,23 +2981,35 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 }
 
 // applyPlannerAttrs stamps planner and handover attributes onto a span
-// attribute builder. Safe when the planner didn't run (uses "skipped" outcome).
+// attribute builder. Planner details are omitted when the planner did not run
+// so downstream nullable columns do not turn zero values into false evidence.
 func applyPlannerAttrs(b *otel.AttrBuilder, res turnLoopResult) *otel.AttrBuilder {
-	outcome := plannerOutcomeAttr(res)
-	b.String("planner.outcome", outcome).
-		String("planner.reason", res.PlannerDecision.Reason).
-		Float64("planner.expected_savings_usd", res.PlannerDecision.ExpectedSavingsUSD).
-		Float64("planner.eviction_cost_usd", res.PlannerDecision.EvictionCostUSD).
-		Float64("planner.threshold_usd", res.PlannerDecision.ThresholdUSD).
-		String("planner.pin_model", res.PinModel).
-		String("planner.fresh_model", res.Fresh.Model).
-		String("planner.chosen_model", res.Decision.Model).
-		Bool("planner.pin_cache_warm", !res.PlannerDecision.PinCacheCold).
-		Bool("handover.invoked", res.Handover.Invoked).
+	if res.PlannerDecision.Reason != "" {
+		b.String("planner.outcome", plannerOutcomeAttr(res)).
+			String("planner.reason", res.PlannerDecision.Reason).
+			Float64("planner.expected_savings_usd", res.PlannerDecision.ExpectedSavingsUSD).
+			Float64("planner.eviction_cost_usd", res.PlannerDecision.EvictionCostUSD).
+			Float64("planner.threshold_usd", res.PlannerDecision.ThresholdUSD).
+			String("planner.pin_model", res.PinModel).
+			String("planner.fresh_model", res.Fresh.Model).
+			String("planner.chosen_model", res.Decision.Model).
+			Bool("planner.pin_cache_warm", !res.PlannerDecision.PinCacheCold)
+	}
+	b.Bool("handover.invoked", res.Handover.Invoked).
 		Int64("handover.latency_ms", res.Handover.LatencyMS).
 		Int64("handover.summary_tokens", int64(res.Handover.SummaryTokens)).
 		Bool("handover.fallback_to_full_history", res.Handover.FallbackToFullHistory)
 	return b
+}
+
+// applyRoutingStateAttrs emits the privacy-safe, exact thread/transition
+// identity used to distinguish real model changes from first-turn selection
+// and interleaved sub-agent calls.
+func applyRoutingStateAttrs(b *otel.AttrBuilder, res turnLoopResult, servedModel string) *otel.AttrBuilder {
+	return b.String("routing.session_key", sessionKeyHex(res.SessionKey)).
+		String("routing.pin_role", res.PinRole).
+		String("routing.prior_served_model", res.PriorServedModel).
+		Bool("routing.model_changed", res.PriorServedModel != "" && res.PriorServedModel != servedModel)
 }
 
 // plannerOutcomeAttr maps the planner's typed outcome to an OTel string.
@@ -4136,6 +4150,7 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 		Float64("catalog.actual_output_per_1m", actPricing.OutputUSDPer1M).
 		Int64("latency.route_ms", routeMs)
 	applyPlannerAttrs(openaiDecisionBuilder, routeRes)
+	applyRoutingStateAttrs(openaiDecisionBuilder, routeRes, decision.Model)
 	otel.Record(ctx, otel.Span{
 		Name:  "router.decision",
 		Start: requestStart,
@@ -4451,6 +4466,7 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 		Int64("dispatch.fallback_attempts", int64(winnerIdx)).
 		Bool("dispatch.failover_used", finalProvider != primaryProvider)
 	applyPlannerAttrs(openaiUpstreamBuilder, routeRes)
+	applyRoutingStateAttrs(openaiUpstreamBuilder, routeRes, decision.Model)
 	addTimingAttrs(ctx, openaiUpstreamBuilder)
 
 	openaiObs := buildObservationContext(ctx, decision, routeRes.Fresh, s.captureMode)

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -2297,7 +2297,7 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 		Float64("catalog.actual_output_per_1m", actPricing.OutputUSDPer1M).
 		Int64("latency.route_ms", routeMs)
 	applyPlannerAttrs(decisionBuilder, routeRes)
-	applyRoutingStateAttrs(decisionBuilder, routeRes, decision.Model)
+	applyRoutingStateAttrs(decisionBuilder, routeRes, decision.Model, sessionKey)
 	otel.Record(ctx, otel.Span{
 		Name:  "router.decision",
 		Start: requestStart,
@@ -2795,7 +2795,7 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 		Bool("dispatch.baseline_failover", baselineFailoverUsed).
 		Bool("dispatch.subscription_failover", subscriptionFailoverUsed)
 	applyPlannerAttrs(upstreamBuilder, routeRes)
-	applyRoutingStateAttrs(upstreamBuilder, routeRes, decision.Model)
+	applyRoutingStateAttrs(upstreamBuilder, routeRes, decision.Model, sessionKey)
 	addTimingAttrs(ctx, upstreamBuilder)
 
 	obs := buildObservationContext(ctx, decision, routeRes.Fresh, s.captureMode)
@@ -3002,11 +3002,15 @@ func applyPlannerAttrs(b *otel.AttrBuilder, res turnLoopResult) *otel.AttrBuilde
 	return b
 }
 
-// applyRoutingStateAttrs emits the privacy-safe, exact thread/transition
-// identity used to distinguish real model changes from first-turn selection
-// and interleaved sub-agent calls.
-func applyRoutingStateAttrs(b *otel.AttrBuilder, res turnLoopResult, servedModel string) *otel.AttrBuilder {
-	return b.String("routing.session_key", sessionKeyHex(res.SessionKey)).
+// applyRoutingStateAttrs stamps thread identity and transition attrs; it
+// distinguishes real model changes from first selection and sub-agent calls.
+func applyRoutingStateAttrs(
+	b *otel.AttrBuilder,
+	res turnLoopResult,
+	servedModel string,
+	sessionKey [sessionpin.SessionKeyLen]byte,
+) *otel.AttrBuilder {
+	return b.String("routing.session_key", sessionKeyHex(sessionKey)).
 		String("routing.pin_role", res.PinRole).
 		String("routing.prior_served_model", res.PriorServedModel).
 		Bool("routing.model_changed", res.PriorServedModel != "" && res.PriorServedModel != servedModel)
@@ -4150,7 +4154,7 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 		Float64("catalog.actual_output_per_1m", actPricing.OutputUSDPer1M).
 		Int64("latency.route_ms", routeMs)
 	applyPlannerAttrs(openaiDecisionBuilder, routeRes)
-	applyRoutingStateAttrs(openaiDecisionBuilder, routeRes, decision.Model)
+	applyRoutingStateAttrs(openaiDecisionBuilder, routeRes, decision.Model, sessionKey)
 	otel.Record(ctx, otel.Span{
 		Name:  "router.decision",
 		Start: requestStart,
@@ -4466,7 +4470,7 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 		Int64("dispatch.fallback_attempts", int64(winnerIdx)).
 		Bool("dispatch.failover_used", finalProvider != primaryProvider)
 	applyPlannerAttrs(openaiUpstreamBuilder, routeRes)
-	applyRoutingStateAttrs(openaiUpstreamBuilder, routeRes, decision.Model)
+	applyRoutingStateAttrs(openaiUpstreamBuilder, routeRes, decision.Model, sessionKey)
 	addTimingAttrs(ctx, openaiUpstreamBuilder)
 
 	openaiObs := buildObservationContext(ctx, decision, routeRes.Fresh, s.captureMode)

--- a/internal/proxy/session_key.go
+++ b/internal/proxy/session_key.go
@@ -21,15 +21,22 @@ func shortKey(key [sessionpin.SessionKeyLen]byte) string {
 	return hex.EncodeToString(key[:8])
 }
 
-// sessionAffinityHint returns the full hex session key as an upstream
-// prompt-cache stickiness hint, or "" for the zero key so sessionless
-// requests don't all collapse onto one affinity bucket.
-func sessionAffinityHint(key [sessionpin.SessionKeyLen]byte) string {
+// sessionKeyHex returns the complete one-way session digest for durable
+// telemetry joins. Unlike shortKey (operator-facing log correlation), this
+// must retain all 16 bytes so parallel threads cannot collapse together.
+func sessionKeyHex(key [sessionpin.SessionKeyLen]byte) string {
 	var zero [sessionpin.SessionKeyLen]byte
 	if key == zero {
 		return ""
 	}
 	return hex.EncodeToString(key[:])
+}
+
+// sessionAffinityHint returns the full hex session key as an upstream
+// prompt-cache stickiness hint, or "" for the zero key so sessionless
+// requests don't all collapse onto one affinity bucket.
+func sessionAffinityHint(key [sessionpin.SessionKeyLen]byte) string {
+	return sessionKeyHex(key)
 }
 
 // bindRequestLogger derives the session key and returns a context carrying a

--- a/internal/proxy/session_key.go
+++ b/internal/proxy/session_key.go
@@ -21,9 +21,8 @@ func shortKey(key [sessionpin.SessionKeyLen]byte) string {
 	return hex.EncodeToString(key[:8])
 }
 
-// sessionKeyHex returns the complete one-way session digest for durable
-// telemetry joins. Unlike shortKey (operator-facing log correlation), this
-// must retain all 16 bytes so parallel threads cannot collapse together.
+// sessionKeyHex returns the full 32-hex session digest for telemetry joins;
+// unlike shortKey, it retains all 16 bytes so parallel threads don't collapse.
 func sessionKeyHex(key [sessionpin.SessionKeyLen]byte) string {
 	var zero [sessionpin.SessionKeyLen]byte
 	if key == zero {
@@ -32,9 +31,8 @@ func sessionKeyHex(key [sessionpin.SessionKeyLen]byte) string {
 	return hex.EncodeToString(key[:])
 }
 
-// sessionAffinityHint returns the full hex session key as an upstream
-// prompt-cache stickiness hint, or "" for the zero key so sessionless
-// requests don't all collapse onto one affinity bucket.
+// sessionAffinityHint returns the session key hex for upstream prompt-cache
+// stickiness, or "" for the zero key so sessionless requests stay unbucketed.
 func sessionAffinityHint(key [sessionpin.SessionKeyLen]byte) string {
 	return sessionKeyHex(key)
 }

--- a/internal/proxy/turn_logs_internal_test.go
+++ b/internal/proxy/turn_logs_internal_test.go
@@ -17,7 +17,20 @@ import (
 	collogspb "go.opentelemetry.io/proto/otlp/collector/logs/v1"
 
 	"workweave/router/internal/observability/otel"
+	"workweave/router/internal/router"
+	"workweave/router/internal/router/planner"
+	"workweave/router/internal/router/sessionpin"
+
+	commonv1 "go.opentelemetry.io/proto/otlp/common/v1"
 )
+
+func attrsByKey(attrs []*commonv1.KeyValue) map[string]*commonv1.AnyValue {
+	out := make(map[string]*commonv1.AnyValue, len(attrs))
+	for _, attr := range attrs {
+		out[attr.Key] = attr.Value
+	}
+	return out
+}
 
 func TestParseCaptureMode(t *testing.T) {
 	assert.Equal(t, CaptureOff, ParseCaptureMode(""))
@@ -247,4 +260,68 @@ func TestRecordCallLog_RedactorApplied(t *testing.T) {
 	a := coll.attrs(t)
 	assert.Equal(t, "REDACTED-REQ", a["io.request_body"])
 	assert.Equal(t, "REDACTED-RESP", a["io.response_body"])
+}
+
+func TestApplyRoutingStateAttrs_EmitsExactThreadAndTransition(t *testing.T) {
+	var key [sessionpin.SessionKeyLen]byte
+	for i := range key {
+		key[i] = byte(i + 1)
+	}
+	res := turnLoopResult{
+		SessionKey:       key,
+		PinRole:          "default_high",
+		PriorServedModel: "claude-haiku-4-5",
+	}
+	b := otel.NewAttrBuilder(4)
+	applyRoutingStateAttrs(b, res, "claude-opus-4-7")
+	attrs := attrsByKey(b.Build())
+
+	assert.Equal(t, "0102030405060708090a0b0c0d0e0f10", attrs["routing.session_key"].GetStringValue())
+	assert.Equal(t, "default_high", attrs["routing.pin_role"].GetStringValue())
+	assert.Equal(t, "claude-haiku-4-5", attrs["routing.prior_served_model"].GetStringValue())
+	assert.True(t, attrs["routing.model_changed"].GetBoolValue())
+}
+
+func TestApplyRoutingStateAttrs_FirstSelectionIsNotAChange(t *testing.T) {
+	b := otel.NewAttrBuilder(4)
+	applyRoutingStateAttrs(b, turnLoopResult{PinRole: sessionpin.DefaultRole}, "claude-haiku-4-5")
+	attrs := attrsByKey(b.Build())
+
+	assert.Empty(t, attrs["routing.session_key"].GetStringValue())
+	assert.Empty(t, attrs["routing.prior_served_model"].GetStringValue())
+	assert.False(t, attrs["routing.model_changed"].GetBoolValue())
+}
+
+func TestApplyPlannerAttrs_OmitsDetailsWhenSkipped(t *testing.T) {
+	b := otel.NewAttrBuilder(8)
+	applyPlannerAttrs(b, turnLoopResult{})
+	attrs := attrsByKey(b.Build())
+
+	assert.NotContains(t, attrs, "planner.outcome")
+	assert.NotContains(t, attrs, "planner.pin_cache_warm")
+	assert.Contains(t, attrs, "handover.invoked")
+}
+
+func TestApplyPlannerAttrs_EmitsDetailsWhenEvaluated(t *testing.T) {
+	res := turnLoopResult{
+		Decision: router.Decision{Model: "claude-haiku-4-5"},
+		Fresh:    router.Decision{Model: "claude-opus-4-7"},
+		PinModel: "claude-haiku-4-5",
+		PlannerDecision: planner.Decision{
+			Outcome:            planner.OutcomeStay,
+			Reason:             planner.ReasonEVNegative,
+			ExpectedSavingsUSD: 0.002,
+			EvictionCostUSD:    0.003,
+			ThresholdUSD:       0.001,
+			PinCacheCold:       false,
+		},
+	}
+	b := otel.NewAttrBuilder(16)
+	applyPlannerAttrs(b, res)
+	attrs := attrsByKey(b.Build())
+
+	assert.Equal(t, "stay", attrs["planner.outcome"].GetStringValue())
+	assert.Equal(t, planner.ReasonEVNegative, attrs["planner.reason"].GetStringValue())
+	assert.True(t, attrs["planner.pin_cache_warm"].GetBoolValue())
+	assert.InDelta(t, 0.003, attrs["planner.eviction_cost_usd"].GetDoubleValue(), 1e-12)
 }

--- a/internal/proxy/turn_logs_internal_test.go
+++ b/internal/proxy/turn_logs_internal_test.go
@@ -273,7 +273,7 @@ func TestApplyRoutingStateAttrs_EmitsExactThreadAndTransition(t *testing.T) {
 		PriorServedModel: "claude-haiku-4-5",
 	}
 	b := otel.NewAttrBuilder(4)
-	applyRoutingStateAttrs(b, res, "claude-opus-4-7")
+	applyRoutingStateAttrs(b, res, "claude-opus-4-7", key)
 	attrs := attrsByKey(b.Build())
 
 	assert.Equal(t, "0102030405060708090a0b0c0d0e0f10", attrs["routing.session_key"].GetStringValue())
@@ -284,12 +284,21 @@ func TestApplyRoutingStateAttrs_EmitsExactThreadAndTransition(t *testing.T) {
 
 func TestApplyRoutingStateAttrs_FirstSelectionIsNotAChange(t *testing.T) {
 	b := otel.NewAttrBuilder(4)
-	applyRoutingStateAttrs(b, turnLoopResult{PinRole: sessionpin.DefaultRole}, "claude-haiku-4-5")
+	applyRoutingStateAttrs(b, turnLoopResult{PinRole: sessionpin.DefaultRole}, "claude-haiku-4-5", [sessionpin.SessionKeyLen]byte{})
 	attrs := attrsByKey(b.Build())
 
 	assert.Empty(t, attrs["routing.session_key"].GetStringValue())
 	assert.Empty(t, attrs["routing.prior_served_model"].GetStringValue())
 	assert.False(t, attrs["routing.model_changed"].GetBoolValue())
+}
+
+func TestApplyRoutingStateAttrs_UsesRequestKeyWhenRoutingKeyIsEmpty(t *testing.T) {
+	key := [sessionpin.SessionKeyLen]byte{1, 2, 3}
+	b := otel.NewAttrBuilder(4)
+	applyRoutingStateAttrs(b, turnLoopResult{}, "claude-haiku-4-5", key)
+	attrs := attrsByKey(b.Build())
+
+	assert.Equal(t, "01020300000000000000000000000000", attrs["routing.session_key"].GetStringValue())
 }
 
 func TestApplyPlannerAttrs_OmitsDetailsWhenSkipped(t *testing.T) {


### PR DESCRIPTION
Emits the full privacy-safe session digest, pin role, prior served model, and exact per-call model transition on Anthropic, OpenAI, and Gemini decision/upstream records.

Omits planner detail attributes when the planner did not run while preserving handover telemetry.

Adds focused coverage for exact transitions, first selections, and evaluated versus skipped planner decisions.

Validation: `wv mr tc` and `wv mr t`.
