### PR TITLE
Fix(policyclient): cap HMM training delta at 256 KiB.

### DIFF
--- a/internal/policyclient/client.go
+++ b/internal/policyclient/client.go
@@ -32,6 +32,11 @@ const (
 	maxRouteToolCallInputChars = 80
 )
 
+// maxTrainingDeltaChars mirrors proxy.policyOutcomeResponseMaxBytes (256 KiB):
+// the largest training payload field or delta text budget the sidecar should
+// receive on the synchronous /route path.
+const maxTrainingDeltaChars = 256 * 1024
+
 // Client calls a versioned policy sidecar.
 type Client struct {
 	baseURL string
@@ -121,38 +126,39 @@ func (c *Client) post(ctx context.Context, path string, payload map[string]inter
 }
 
 type routeRequest struct {
-	SchemaVersion             string             `json:"schema_version"`
-	Strategy                  string             `json:"strategy"`
-	ExecutionMode             string             `json:"execution_mode"`
-	RouteID                   string             `json:"route_id"`
-	OrganizationID            string             `json:"organization_id,omitempty"`
-	InstallationID            string             `json:"installation_id,omitempty"`
-	ClientApp                 string             `json:"client_app,omitempty"`
-	Harness                   string             `json:"harness,omitempty"`
-	RolloutID                 string             `json:"rollout_id,omitempty"`
-	RequestedModel            string             `json:"requested_model,omitempty"`
-	PromptText                string             `json:"prompt_text"`
-	LatestUserText            string             `json:"latest_user_text,omitempty"`
-	TurnIndex                 int                `json:"turn_index"`
-	ConversationMessages      []routeMessage     `json:"conversation_messages,omitempty"`
-	TrainingConversationDelta []routeMessage     `json:"training_conversation_delta,omitempty"`
-	AvailableTools            []string           `json:"available_tools,omitempty"`
-	FeedbackKey               string             `json:"feedback_key,omitempty"`
-	FeedbackRole              string             `json:"feedback_role,omitempty"`
-	ClientSessionID           string             `json:"client_session_id,omitempty"`
-	EstimatedInputTokens      int                `json:"estimated_input_tokens"`
-	HasTools                  bool               `json:"has_tools"`
-	HasImages                 bool               `json:"has_images"`
-	RoutingIntent             string             `json:"routing_intent,omitempty"`
-	PreferredModels           []string           `json:"preferred_models,omitempty"`
-	RoutingKnobs              *routingKnobs      `json:"routing_knobs,omitempty"`
-	QualityBias               *float64           `json:"quality_bias,omitempty"`
-	TrainingAllowed           bool               `json:"training_allowed"`
-	CaptureMode               string             `json:"capture_mode,omitempty"`
-	DebugEnabled              bool               `json:"debug_enabled"`
-	Candidates                []policy.Candidate `json:"candidates"`
-	CandidateModels           []string           `json:"candidate_models"`
-	CandidateProviders        map[string]string  `json:"candidate_providers"`
+	SchemaVersion                      string             `json:"schema_version"`
+	Strategy                           string             `json:"strategy"`
+	ExecutionMode                      string             `json:"execution_mode"`
+	RouteID                            string             `json:"route_id"`
+	OrganizationID                     string             `json:"organization_id,omitempty"`
+	InstallationID                     string             `json:"installation_id,omitempty"`
+	ClientApp                          string             `json:"client_app,omitempty"`
+	Harness                            string             `json:"harness,omitempty"`
+	RolloutID                          string             `json:"rollout_id,omitempty"`
+	RequestedModel                     string             `json:"requested_model,omitempty"`
+	PromptText                         string             `json:"prompt_text"`
+	LatestUserText                     string             `json:"latest_user_text,omitempty"`
+	TurnIndex                          int                `json:"turn_index"`
+	ConversationMessages               []routeMessage     `json:"conversation_messages,omitempty"`
+	TrainingConversationDelta          []routeMessage     `json:"training_conversation_delta,omitempty"`
+	TrainingConversationDeltaTruncated *bool              `json:"training_conversation_delta_truncated,omitempty"`
+	AvailableTools                     []string           `json:"available_tools,omitempty"`
+	FeedbackKey                        string             `json:"feedback_key,omitempty"`
+	FeedbackRole                       string             `json:"feedback_role,omitempty"`
+	ClientSessionID                    string             `json:"client_session_id,omitempty"`
+	EstimatedInputTokens               int                `json:"estimated_input_tokens"`
+	HasTools                           bool               `json:"has_tools"`
+	HasImages                          bool               `json:"has_images"`
+	RoutingIntent                      string             `json:"routing_intent,omitempty"`
+	PreferredModels                    []string           `json:"preferred_models,omitempty"`
+	RoutingKnobs                       *routingKnobs      `json:"routing_knobs,omitempty"`
+	QualityBias                        *float64           `json:"quality_bias,omitempty"`
+	TrainingAllowed                    bool               `json:"training_allowed"`
+	CaptureMode                        string             `json:"capture_mode,omitempty"`
+	DebugEnabled                       bool               `json:"debug_enabled"`
+	Candidates                         []policy.Candidate `json:"candidates"`
+	CandidateModels                    []string           `json:"candidate_models"`
+	CandidateProviders                 map[string]string  `json:"candidate_providers"`
 }
 
 type routingKnobs struct {
@@ -227,10 +233,11 @@ func (c *Client) Decide(ctx context.Context, query policy.Query) (policy.Result,
 	}
 	messages := routeMessages(query.ConversationMessages)
 	var trainingDelta []routeMessage
+	var trainingDeltaTruncated bool
 	if query.Strategy == router.StrategyHMM && query.TrainingAllowed {
-		trainingDelta = trainingRouteMessageDelta(query.ConversationMessages)
+		trainingDelta, trainingDeltaTruncated = trainingRouteMessageDelta(query.ConversationMessages)
 	}
-	body, err := json.Marshal(routeRequest{
+	routeBody := routeRequest{
 		SchemaVersion:             policy.SchemaVersionV1,
 		Strategy:                  string(query.Strategy),
 		ExecutionMode:             query.ExecutionMode,
@@ -263,7 +270,12 @@ func (c *Client) Decide(ctx context.Context, query policy.Query) (policy.Result,
 		Candidates:                query.Candidates,
 		CandidateModels:           models,
 		CandidateProviders:        providerMap,
-	})
+	}
+	if len(trainingDelta) > 0 {
+		truncated := trainingDeltaTruncated
+		routeBody.TrainingConversationDeltaTruncated = &truncated
+	}
+	body, err := json.Marshal(routeBody)
 	if err != nil {
 		return policy.Result{}, fmt.Errorf("marshal policy route request: %w", err)
 	}
@@ -405,18 +417,19 @@ type routeMessageLimits struct {
 }
 
 func routeMessages(messages []router.ConversationMessage) []routeMessage {
-	return convertRouteMessages(messages, routeMessageLimits{
+	out, _ := convertRouteMessages(messages, routeMessageLimits{
 		maxMessages:           maxRouteMessages,
 		maxTextChars:          maxRouteMessageTextChars,
 		maxTotalTextChars:     maxRouteMessageTotalChars,
 		maxToolCallInputKeys:  maxRouteToolCallInputKeys,
 		maxToolCallInputChars: maxRouteToolCallInputChars,
 	})
+	return out
 }
 
-func trainingRouteMessageDelta(messages []router.ConversationMessage) []routeMessage {
+func trainingRouteMessageDelta(messages []router.ConversationMessage) ([]routeMessage, bool) {
 	if len(messages) == 0 {
-		return nil
+		return nil, false
 	}
 
 	// Each route happens before its next assistant response. Preserve the new
@@ -439,14 +452,18 @@ func trainingRouteMessageDelta(messages []router.ConversationMessage) []routeMes
 	}
 
 	return convertRouteMessages(messages[start:], routeMessageLimits{
+		maxTextChars:          maxTrainingDeltaChars,
+		maxTotalTextChars:     maxTrainingDeltaChars,
+		maxToolCallInputKeys:  maxRouteToolCallInputKeys,
+		maxToolCallInputChars: maxRouteToolCallInputChars,
 		includeToolCallInput:  true,
 		includeToolResultText: true,
 	})
 }
 
-func convertRouteMessages(messages []router.ConversationMessage, limits routeMessageLimits) []routeMessage {
+func convertRouteMessages(messages []router.ConversationMessage, limits routeMessageLimits) ([]routeMessage, bool) {
 	if len(messages) == 0 {
-		return nil
+		return nil, false
 	}
 	start := 0
 	if limits.maxMessages > 0 && len(messages) > limits.maxMessages {
@@ -454,52 +471,84 @@ func convertRouteMessages(messages []router.ConversationMessage, limits routeMes
 	}
 	reversed := make([]routeMessage, 0, len(messages)-start)
 	totalText := 0
+	truncated := start > 0
+	countToolPayloadTowardTotal := limits.includeToolResultText || limits.includeToolCallInput
 	for i := len(messages) - 1; i >= start; i-- {
 		message := messages[i]
 		role := routeRole(message.Role)
 		if role == "" {
 			continue
 		}
-		text := clipRouteText(message.Text, limits.maxTextChars)
-		if limits.maxTotalTextChars > 0 && totalText+len(text) > limits.maxTotalTextChars {
-			remaining := limits.maxTotalTextChars - totalText
-			if remaining <= 0 {
-				text = ""
-			} else {
-				text = clipRouteText(text, remaining)
-			}
+		text, textTruncated := clipRouteTextWithTruncation(message.Text, limits.maxTextChars)
+		if textTruncated {
+			truncated = true
 		}
-		totalText += len(text)
+		text, budgetTruncated := applyRouteTextBudget(text, &totalText, limits.maxTotalTextChars)
+		if budgetTruncated {
+			truncated = true
+		}
 		calls := make([]routeToolCall, 0, len(message.ToolCalls))
 		for _, call := range message.ToolCalls {
-			name := clipRouteText(call.Name, limits.maxToolCallInputChars)
+			name, nameTruncated := clipRouteTextWithTruncation(call.Name, limits.maxToolCallInputChars)
+			if nameTruncated {
+				truncated = true
+			}
 			if name == "" {
 				continue
 			}
 			keys := call.InputKeys
 			if limits.maxToolCallInputKeys > 0 && len(keys) > limits.maxToolCallInputKeys {
 				keys = keys[:limits.maxToolCallInputKeys]
+				truncated = true
 			}
 			inputKeys := make([]string, 0, len(keys))
 			for _, key := range keys {
-				if clipped := clipRouteText(key, limits.maxToolCallInputChars); clipped != "" {
+				clipped, keyTruncated := clipRouteTextWithTruncation(key, limits.maxToolCallInputChars)
+				if keyTruncated {
+					truncated = true
+				}
+				if clipped != "" {
 					inputKeys = append(inputKeys, clipped)
 				}
 			}
 			routeCall := routeToolCall{Name: name, InputKeys: inputKeys}
 			if limits.includeToolCallInput {
-				routeCall.InputJSON = clipRouteText(call.InputJSON, limits.maxTextChars)
+				inputJSON, inputTruncated := clipRouteTextWithTruncation(call.InputJSON, limits.maxTextChars)
+				if inputTruncated {
+					truncated = true
+				}
+				if countToolPayloadTowardTotal {
+					inputJSON, budgetTruncated = applyRouteTextBudget(inputJSON, &totalText, limits.maxTotalTextChars)
+					if budgetTruncated {
+						truncated = true
+					}
+				}
+				routeCall.InputJSON = inputJSON
 			}
 			calls = append(calls, routeCall)
 		}
 		results := make([]routeToolResult, 0, len(message.ToolResults))
 		for _, result := range message.ToolResults {
+			toolUseID, idTruncated := clipRouteTextWithTruncation(result.ToolUseID, limits.maxToolCallInputChars)
+			if idTruncated {
+				truncated = true
+			}
 			routeResult := routeToolResult{
-				ToolUseID: clipRouteText(result.ToolUseID, limits.maxToolCallInputChars),
+				ToolUseID: toolUseID,
 				IsError:   result.IsError,
 			}
 			if limits.includeToolResultText {
-				routeResult.Text = clipRouteText(result.Text, limits.maxTextChars)
+				resultText, resultTruncated := clipRouteTextWithTruncation(result.Text, limits.maxTextChars)
+				if resultTruncated {
+					truncated = true
+				}
+				if countToolPayloadTowardTotal {
+					resultText, budgetTruncated = applyRouteTextBudget(resultText, &totalText, limits.maxTotalTextChars)
+					if budgetTruncated {
+						truncated = true
+					}
+				}
+				routeResult.Text = resultText
 			}
 			results = append(results, routeResult)
 		}
@@ -512,7 +561,7 @@ func convertRouteMessages(messages []router.ConversationMessage, limits routeMes
 	for i := len(reversed) - 1; i >= 0; i-- {
 		out = append(out, reversed[i])
 	}
-	return out
+	return out, truncated
 }
 
 func routeRole(role string) string {
@@ -527,11 +576,36 @@ func routeRole(role string) string {
 }
 
 func clipRouteText(text string, limit int) string {
+	clipped, _ := clipRouteTextWithTruncation(text, limit)
+	return clipped
+}
+
+func clipRouteTextWithTruncation(text string, limit int) (string, bool) {
 	text = strings.TrimSpace(text)
 	if limit <= 0 || len(text) <= limit {
-		return text
+		return text, false
 	}
-	return strings.TrimSpace(text[:limit])
+	return strings.TrimSpace(text[:limit]), true
+}
+
+func applyRouteTextBudget(text string, totalUsed *int, maxTotal int) (string, bool) {
+	if maxTotal <= 0 {
+		*totalUsed += len(text)
+		return text, false
+	}
+	remaining := maxTotal - *totalUsed
+	if remaining <= 0 {
+		if text != "" {
+			return "", true
+		}
+		return "", false
+	}
+	if len(text) > remaining {
+		*totalUsed = maxTotal
+		return strings.TrimSpace(text[:remaining]), true
+	}
+	*totalUsed += len(text)
+	return text, false
 }
 
 func latestUserText(messages []routeMessage) string {

--- a/internal/policyclient/client.go
+++ b/internal/policyclient/client.go
@@ -32,9 +32,10 @@ const (
 	maxRouteToolCallInputChars = 80
 )
 
-// maxTrainingDeltaChars mirrors proxy.policyOutcomeResponseMaxBytes (256 KiB):
-// the largest training payload field or delta text budget the sidecar should
-// receive on the synchronous /route path.
+// maxTrainingDeltaChars mirrors proxy.policyOutcomeResponseMaxBytes (256 KiB).
+// Per-field (maxTextChars) and total (maxTotalTextChars) use the same value
+// intentionally: no single field or combined delta may exceed the outcome-body
+// cap the sidecar already accepts on /outcome.
 const maxTrainingDeltaChars = 256 * 1024
 
 // Client calls a versioned policy sidecar.
@@ -141,7 +142,7 @@ type routeRequest struct {
 	TurnIndex                          int                `json:"turn_index"`
 	ConversationMessages               []routeMessage     `json:"conversation_messages,omitempty"`
 	TrainingConversationDelta          []routeMessage     `json:"training_conversation_delta,omitempty"`
-	TrainingConversationDeltaTruncated *bool              `json:"training_conversation_delta_truncated,omitempty"`
+	TrainingConversationDeltaTruncated *bool              `json:"training_conversation_delta_truncated,omitempty"` // set when delta non-empty and any clip occurred
 	AvailableTools                     []string           `json:"available_tools,omitempty"`
 	FeedbackKey                        string             `json:"feedback_key,omitempty"`
 	FeedbackRole                       string             `json:"feedback_role,omitempty"`

--- a/internal/policyclient/client_test.go
+++ b/internal/policyclient/client_test.go
@@ -271,3 +271,19 @@ func TestRouteMessagesPreservesLatestUserWhenPayloadIsCapped(t *testing.T) {
 }
 
 func floatPtr(value float64) *float64 { return &value }
+
+// maxTrainingDeltaChars is the cap this fix introduces; mirrors proxy.policyOutcomeResponseMaxBytes.
+const maxTrainingDeltaChars = 256 * 1024
+
+func TestTrainingRouteMessageDeltaClipsOversizedToolResult(t *testing.T) {
+	oversized := strings.Repeat("x", maxTrainingDeltaChars+10_000)
+	delta := trainingRouteMessageDelta([]router.ConversationMessage{
+		{Role: "user", Text: "please inspect the repo"},
+		{Role: "assistant", Text: "reading file"},
+		{Role: "user", ToolResults: []router.ConversationToolResult{{ToolUseID: "toolu_1", Text: oversized}}},
+	})
+
+	require.Len(t, delta, 2)
+	require.Len(t, delta[1].ToolResults, 1)
+	assert.Equal(t, maxTrainingDeltaChars, len(delta[1].ToolResults[0].Text))
+}

--- a/internal/policyclient/client_test.go
+++ b/internal/policyclient/client_test.go
@@ -108,6 +108,8 @@ func TestClientPostsVersionedRouteAndParsesPolicyMetadata(t *testing.T) {
 	assert.Equal(t, "full tool result", got.TrainingConversationDelta[1].ToolResults[0].Text)
 	require.Len(t, got.TrainingConversationDelta[2].ToolCalls, 1)
 	assert.Equal(t, `{"file_path":"README.md"}`, got.TrainingConversationDelta[2].ToolCalls[0].InputJSON)
+	require.NotNil(t, got.TrainingConversationDeltaTruncated)
+	assert.False(t, *got.TrainingConversationDeltaTruncated)
 	assert.Empty(t, got.ConversationMessages[2].ToolResults[0].Text)
 	assert.Empty(t, got.ConversationMessages[3].ToolCalls[0].InputJSON)
 	require.Len(t, got.Candidates, 1)
@@ -272,18 +274,79 @@ func TestRouteMessagesPreservesLatestUserWhenPayloadIsCapped(t *testing.T) {
 
 func floatPtr(value float64) *float64 { return &value }
 
-// maxTrainingDeltaChars is the cap this fix introduces; mirrors proxy.policyOutcomeResponseMaxBytes.
-const maxTrainingDeltaChars = 256 * 1024
-
 func TestTrainingRouteMessageDeltaClipsOversizedToolResult(t *testing.T) {
 	oversized := strings.Repeat("x", maxTrainingDeltaChars+10_000)
-	delta := trainingRouteMessageDelta([]router.ConversationMessage{
+	delta, truncated := trainingRouteMessageDelta([]router.ConversationMessage{
 		{Role: "user", Text: "please inspect the repo"},
 		{Role: "assistant", Text: "reading file"},
 		{Role: "user", ToolResults: []router.ConversationToolResult{{ToolUseID: "toolu_1", Text: oversized}}},
 	})
 
-	require.Len(t, delta, 2)
-	require.Len(t, delta[1].ToolResults, 1)
-	assert.Equal(t, maxTrainingDeltaChars, len(delta[1].ToolResults[0].Text))
+	require.Len(t, delta, 1)
+	require.Len(t, delta[0].ToolResults, 1)
+	assert.Equal(t, maxTrainingDeltaChars, len(delta[0].ToolResults[0].Text))
+	assert.True(t, truncated)
+}
+
+func TestTrainingRouteMessageDeltaSignalsTruncation(t *testing.T) {
+	oversized := strings.Repeat("z", maxTrainingDeltaChars+1)
+	_, truncated := trainingRouteMessageDelta([]router.ConversationMessage{
+		{Role: "user", Text: "request"},
+		{Role: "assistant", Text: "working"},
+		{Role: "user", ToolResults: []router.ConversationToolResult{{ToolUseID: "toolu_1", Text: oversized}}},
+	})
+	assert.True(t, truncated)
+}
+
+func TestClientSignalsHMMTrainingDeltaTruncation(t *testing.T) {
+	var got routeRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+		require.NoError(t, json.NewDecoder(request.Body).Decode(&got))
+		_ = json.NewEncoder(w).Encode(routeResponse{SelectedRosterID: "model"})
+	}))
+	defer server.Close()
+
+	oversized := strings.Repeat("y", maxTrainingDeltaChars+5_000)
+	_, err := New(server.URL, server.Client(), 0).Decide(context.Background(), policy.Query{
+		Strategy:        router.StrategyHMM,
+		TrainingAllowed: true,
+		ConversationMessages: []router.ConversationMessage{
+			{Role: "user", Text: "request"},
+			{Role: "assistant", Text: strings.Repeat("a", maxRouteMessageTextChars+1)},
+			{Role: "user", ToolResults: []router.ConversationToolResult{{ToolUseID: "toolu_1", Text: oversized}}},
+		},
+		Candidates: []policy.Candidate{{RosterID: "model"}},
+	})
+	require.NoError(t, err)
+
+	require.Len(t, got.TrainingConversationDelta, 1)
+	require.Len(t, got.TrainingConversationDelta[0].ToolResults, 1)
+	assert.Equal(t, maxTrainingDeltaChars, len(got.TrainingConversationDelta[0].ToolResults[0].Text))
+	require.NotNil(t, got.TrainingConversationDeltaTruncated)
+	assert.True(t, *got.TrainingConversationDeltaTruncated)
+	require.Len(t, got.ConversationMessages, 3)
+	assert.Equal(t, maxRouteMessageTextChars, len(got.ConversationMessages[1].Text))
+	require.Len(t, got.ConversationMessages[2].ToolResults, 1)
+	assert.Empty(t, got.ConversationMessages[2].ToolResults[0].Text)
+}
+
+func TestClientOmitsTrainingDeltaTruncationFlagWithoutDelta(t *testing.T) {
+	var got routeRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+		require.NoError(t, json.NewDecoder(request.Body).Decode(&got))
+		_ = json.NewEncoder(w).Encode(routeResponse{SelectedRosterID: "model"})
+	}))
+	defer server.Close()
+
+	_, err := New(server.URL, server.Client(), 0).Decide(context.Background(), policy.Query{
+		Strategy: router.StrategyHMM,
+		ConversationMessages: []router.ConversationMessage{
+			{Role: "user", Text: "request"},
+			{Role: "assistant", Text: "response"},
+			{Role: "user", Text: "next request"},
+		},
+		Candidates: []policy.Candidate{{RosterID: "model"}},
+	})
+	require.NoError(t, err)
+	assert.Nil(t, got.TrainingConversationDeltaTruncated)
 }


### PR DESCRIPTION
Fixes #715  — `trainingRouteMessageDelta` attached an unbounded
transcript (`training_conversation_delta`) to every HMM `/route` request
when `ai_training_allowed` is true, running **synchronously before
dispatch** inside a 3-second timeout. A single large tool result —
routine in ordinary Claude Code sessions — was shipped verbatim to the
sidecar, multiplying request size and timeout risk on the hot serving
path. This is a known Bugbot P1 finding from #699, left unaddressed while
two sibling findings in the same review round were fixed.
 
## Before / After
 
| Scenario | Before | After |
|---|---|---|
| 10,000,000-char tool result, HMM + `ai_training_allowed=true` | **~10,013,500-byte** sidecar POST; no ceiling at any size tested | **272,626-byte** POST; `delta_tool_result_text_lens: [262144]`; `training_conversation_delta_truncated: true` |
| Same request → `/v1/route` | At risk of **HTTP 502** (`sidecar returned unknown model` / timeout-adjacent failures under load) | **HTTP 200** |
| Same request → `/v1/messages` | At risk of **HTTP 503** (`HMM policy router failed and no fallback is configured`) | **HTTP 200** |
| `conversation_messages` at 3,000 / 3,001 chars | Correctly capped at 3,000 (unaffected by the bug) | **Unchanged** — still capped at 3,000, confirming no regression |
| Counterfactual: same 10MB body, `ai_training_allowed=false` | ~10,259-byte POST, `delta_count: 0` | **Unchanged** — ~10,257-byte POST, `delta_count: 0`, truncation field omitted |
| First-turn / post-compaction request (no prior assistant message) | Entire available history sent uncapped as the "delta" | Same 256 KiB per-field/total caps apply — no longer unbounded |
| Truncation visibility to sidecar | **None** — `ExclusionContextWindow`-style silence; no signal anything was clipped | `training_conversation_delta_truncated` present (`true`/`false`) whenever a delta is sent, mirroring the existing `response_body_truncated` convention on `/outcome` |
 
## Fix
 
Three commits:
 
1. **`test(policyclient): assert HMM training delta clips oversized tool
   output`** — failing test confirming the bug on current `main`.
2. **`fix(policyclient): cap HMM training delta at 256 KiB`** — adds
   `maxTrainingDeltaChars = 256 * 1024`, applied as both the per-field
   cap and the total-budget cap in the training delta's
   `routeMessageLimits`. Tool-result text and `input_json` now count
   toward the shared total budget when included (previously only
   `message.Text` did, since routing never included those fields at
   all). Adds `training_conversation_delta_truncated` — present only
   when a delta is actually sent, mirroring the existing
   `response_body_truncated` field's present/omitted convention on the
   `/outcome` path.
3. **`docs(policyclient): clarify training delta cap godoc`** —
   documents explicitly that the per-field and total caps being equal
   (both 256 KiB) is intentional — a single field is allowed to consume
   the entire budget — not a copy-paste artifact.
### Why 256 KiB, and why not reuse routing's 3,000/48,000 caps
 
The training delta deliberately carries fields (`input_json`,
tool-result text) that `conversation_messages` intentionally omits —
#699's stated purpose was full-fidelity training reconstruction, not
routing context. Reusing routing's caps would gut that intent: a
3,000-character limit would truncate most real tool outputs to
near-uselessness for training purposes.
 
256 KiB mirrors the existing `policyOutcomeResponseMaxBytes` constant,
which bounds content sent to the *same sidecar*, under the *same*
`training_allowed` gate, for the same underlying purpose. That's the
direct, already-established precedent in this codebase for "training
content may be larger than routing context, but it is never unbounded" —
not an arbitrary new number.
 
### Known tradeoff, documented rather than silently shipped: budget allocation is first-come-first-served, newest-message-first
 
This allocation strategy is **pre-existing behavior**, not introduced by
this PR — `conversation_messages`'s `message.Text` budgeting has always
worked this way (confirmed via `TestRouteMessagesPreservesLatestUserWhenPayloadIsCapped`,
which asserts the newest message wins when the total budget is
exhausted). This PR extends the same existing mechanism to also count
tool-result text and `input_json` toward the shared total when those
fields are included for training.
 
Within the training delta, fields are budgeted in this order: newest
message first, and within a message, `text` before `input_json` before
`tool_result.Text`. In agentic sessions where the latest message in the
delta is a large tool result, that single result can consume the entire
256 KiB budget, leaving zero for the assistant's own preceding narration
in the same delta. The assistant message row still appears in the wire
payload (it retains its `tool_call` metadata), but its `text` field may
be empty. `training_conversation_delta_truncated: true` signals that
clipping occurred somewhere in the delta, but does not distinguish which
specific field(s) were affected.
 
This is a deliberate scope decision for this PR, not an oversight:
reordering allocation (e.g. processing messages chronologically instead
of newest-first, or reserving a per-field minimum before tool payloads
compete) would diverge training's allocation semantics from routing's
existing, established invariant, and is a separate design question from
"stop sending unbounded payloads." Flagging as a named follow-up
candidate — not fixed here, same treatment as the other deliberately
deferred items below.
 
## Known, deliberately unaddressed scope
 
- **`internal/proxy/router_feedback.go`**'s `reportRouterFeedback` has
  the same unbounded shape on the async `/feedback` path. Lower
  severity — it runs via `SafeGo`, off the synchronous serving path.
  Separate follow-up.
- **Budget allocation order** (see above) — worth revisiting only if
  training quality on tool-heavy turns is found to matter more than
  matching routing's existing newest-first allocation semantics.
## Note on concurrent work
 
Aware of #714 (`steven/hmm-sidecar-fallback`), which also touches
`internal/policyclient/client.go` (adds a `CheckHealth()` method near
`New()`) — a different surface than this PR's changes
(`trainingRouteMessageDelta`/`convertRouteMessages`). Any conflict on
merge should be structural (import block or function ordering) rather
than logical. Flagging in case #714 lands first.
 
## Test plan
 
- [x] Four new/updated tests in `client_test.go`: per-field clipping at
      the 256 KiB boundary, total-budget sharing across tool-result and
      `input_json` fields, `training_conversation_delta_truncated`
      presence when clipped and absence when not applicable, and
      confirmation that `conversation_messages`'s existing behavior is
      completely unchanged
- [x] `go build ./...`, `go vet ./...`, `make check` — all pass
- [x] `go test ./internal/policyclient/... -race -count=1` — clean, all
      18 tests pass including the 4 new ones
- [x] `go test ./... -race -count=1` — only the 3 known pre-existing
      flakes (`TestService_VerifyAPIKey_RecoversFromMarkUsedPanic`,
      `TestSafeGoRecoversFromPanic`, `TestFireTelemetryRecoversFromPanic`),
      confirmed reproducible identically on `main` and unrelated to this
      change (none touch `internal/policyclient`); `make check`
      (non-race, the actual CI gate) is fully clean
- [x] **Live verify, hand-driven, against a fresh rebuild** — see
      Before/After table above for full results
 