### PR TITLE
fix(proxy): cap router-feedback training delta at 256 KiB. 

### DIFF
--- a/internal/proxy/router_feedback.go
+++ b/internal/proxy/router_feedback.go
@@ -118,10 +118,11 @@ func (s *Service) handleRouterFeedbackCommand(
 	if registered, ok := s.strategies[strategy]; ok && registered.feedback != nil {
 		trainingAllowed, _ := ctx.Value(PolicyTrainingAllowedContextKey{}).(bool)
 		var trainingDelta []router.ConversationMessage
+		var trainingDeltaTruncated bool
 		if strategy == router.StrategyHMM && trainingAllowed {
-			trainingDelta = routerFeedbackTrainingDelta(env)
+			trainingDelta, trainingDeltaTruncated = clipFeedbackTrainingDelta(routerFeedbackTrainingDelta(env))
 		}
-		s.reportRouterFeedback(ctx, registered.feedback, strategy, externalID, installationID, sessionKey, role, routerUserID, clientID, env.Model(), servedModel, rating, feedback, trainingDelta)
+		s.reportRouterFeedback(ctx, registered.feedback, strategy, externalID, installationID, sessionKey, role, routerUserID, clientID, env.Model(), servedModel, rating, feedback, trainingDelta, trainingDeltaTruncated)
 	}
 
 	now := time.Now()
@@ -171,6 +172,7 @@ func (s *Service) reportRouterFeedback(
 	rating string,
 	feedback string,
 	trainingDelta []router.ConversationMessage,
+	trainingDeltaTruncated bool,
 ) {
 	payload := map[string]interface{}{
 		"strategy":          string(strategy),
@@ -199,6 +201,7 @@ func (s *Service) reportRouterFeedback(
 	}
 	if strategy == router.StrategyHMM && trainingAllowed && len(trainingDelta) > 0 {
 		payload["training_conversation_delta"] = trainingDelta
+		payload["training_conversation_delta_truncated"] = trainingDeltaTruncated
 	}
 	log := observability.FromContext(ctx)
 	observability.SafeGo(log, policyFeedbackReportTimeout, "reportPolicyFeedback", func(reportCtx context.Context) {
@@ -236,6 +239,101 @@ func routerFeedbackTrainingDelta(env *translate.RequestEnvelope) []router.Conver
 		}
 	}
 	return append([]router.ConversationMessage(nil), messages[start:ratedAssistant+1]...)
+}
+
+// maxFeedbackDeltaChars mirrors policyOutcomeResponseMaxBytes (256 KiB): the
+// established ceiling for training content sent to the same sidecar under the
+// same training_allowed gate. Defined locally because #716's
+// policyclient.maxTrainingDeltaChars is not on main yet; reconcile into a
+// shared helper once that lands and the clip is promoted out of the adapter.
+const maxFeedbackDeltaChars = 256 * 1024
+
+// clipFeedbackTrainingDelta applies the #716-style per-field + total budget
+// cap to an already-selected feedback exchange. Newest message first; within a
+// message, Text then input_json then tool_result.Text share the total budget.
+func clipFeedbackTrainingDelta(messages []router.ConversationMessage) ([]router.ConversationMessage, bool) {
+	if len(messages) == 0 {
+		return nil, false
+	}
+	out := make([]router.ConversationMessage, len(messages))
+	copy(out, messages)
+	totalUsed := 0
+	truncated := false
+	for i := len(out) - 1; i >= 0; i-- {
+		msg := &out[i]
+		text, textTruncated := clipFeedbackText(msg.Text, maxFeedbackDeltaChars)
+		if textTruncated {
+			truncated = true
+		}
+		text, budgetTruncated := applyFeedbackTextBudget(text, &totalUsed, maxFeedbackDeltaChars)
+		if budgetTruncated {
+			truncated = true
+		}
+		msg.Text = text
+
+		if len(msg.ToolCalls) > 0 {
+			calls := make([]router.ConversationToolCall, len(msg.ToolCalls))
+			copy(calls, msg.ToolCalls)
+			for j := range calls {
+				inputJSON, inputTruncated := clipFeedbackText(calls[j].InputJSON, maxFeedbackDeltaChars)
+				if inputTruncated {
+					truncated = true
+				}
+				inputJSON, budgetTruncated = applyFeedbackTextBudget(inputJSON, &totalUsed, maxFeedbackDeltaChars)
+				if budgetTruncated {
+					truncated = true
+				}
+				calls[j].InputJSON = inputJSON
+			}
+			msg.ToolCalls = calls
+		}
+
+		if len(msg.ToolResults) > 0 {
+			results := make([]router.ConversationToolResult, len(msg.ToolResults))
+			copy(results, msg.ToolResults)
+			for j := range results {
+				resultText, resultTruncated := clipFeedbackText(results[j].Text, maxFeedbackDeltaChars)
+				if resultTruncated {
+					truncated = true
+				}
+				resultText, budgetTruncated = applyFeedbackTextBudget(resultText, &totalUsed, maxFeedbackDeltaChars)
+				if budgetTruncated {
+					truncated = true
+				}
+				results[j].Text = resultText
+			}
+			msg.ToolResults = results
+		}
+	}
+	return out, truncated
+}
+
+func clipFeedbackText(text string, limit int) (string, bool) {
+	text = strings.TrimSpace(text)
+	if limit <= 0 || len(text) <= limit {
+		return text, false
+	}
+	return strings.TrimSpace(text[:limit]), true
+}
+
+func applyFeedbackTextBudget(text string, totalUsed *int, maxTotal int) (string, bool) {
+	if maxTotal <= 0 {
+		*totalUsed += len(text)
+		return text, false
+	}
+	remaining := maxTotal - *totalUsed
+	if remaining <= 0 {
+		if text != "" {
+			return "", true
+		}
+		return "", false
+	}
+	if len(text) > remaining {
+		*totalUsed = maxTotal
+		return strings.TrimSpace(text[:remaining]), true
+	}
+	*totalUsed += len(text)
+	return text, false
 }
 
 // routerFeedbackAck renders the acknowledgment, echoing the verdict. The

--- a/internal/proxy/router_feedback_clip_internal_test.go
+++ b/internal/proxy/router_feedback_clip_internal_test.go
@@ -1,0 +1,38 @@
+package proxy
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"workweave/router/internal/router"
+)
+
+func TestClipFeedbackTrainingDelta_ClipsAt256KiBBoundary(t *testing.T) {
+	oversized := strings.Repeat("x", maxFeedbackDeltaChars+1)
+	clipped, truncated := clipFeedbackTrainingDelta([]router.ConversationMessage{{
+		Role: "user",
+		ToolResults: []router.ConversationToolResult{{
+			ToolUseID: "toolu_1",
+			Text:      oversized,
+		}},
+	}})
+	require.Len(t, clipped, 1)
+	require.Len(t, clipped[0].ToolResults, 1)
+	assert.Equal(t, maxFeedbackDeltaChars, len(clipped[0].ToolResults[0].Text))
+	assert.True(t, truncated)
+
+	exact := strings.Repeat("y", maxFeedbackDeltaChars)
+	clipped, truncated = clipFeedbackTrainingDelta([]router.ConversationMessage{{
+		Role: "user",
+		ToolResults: []router.ConversationToolResult{{
+			ToolUseID: "toolu_2",
+			Text:      exact,
+		}},
+	}})
+	require.Len(t, clipped, 1)
+	assert.Equal(t, maxFeedbackDeltaChars, len(clipped[0].ToolResults[0].Text))
+	assert.False(t, truncated)
+}

--- a/internal/proxy/router_feedback_proxy_test.go
+++ b/internal/proxy/router_feedback_proxy_test.go
@@ -245,6 +245,113 @@ func TestService_RouterFeedbackCommand_OmitsTrainingTranscriptWithoutPermission(
 	payload := policyFeedback.Payloads()[0]
 	assert.Equal(t, false, payload["training_allowed"])
 	assert.NotContains(t, payload, "training_conversation_delta")
+	assert.NotContains(t, payload, "training_conversation_delta_truncated")
+}
+
+// TestService_RouterFeedbackCommand_CapsOversizedTrainingDelta locks the
+// class-4 feedback bug: a routine multi-100KB tool result in the rated
+// exchange must not be marshaled verbatim into ReportFeedback. Cap matches
+// policyOutcomeResponseMaxBytes (256 KiB); truncated flag must be present.
+func TestService_RouterFeedbackCommand_CapsOversizedTrainingDelta(t *testing.T) {
+	const maxFeedbackDeltaChars = 256 * 1024
+	oversized := strings.Repeat("H", maxFeedbackDeltaChars+10_000)
+	body, err := json.Marshal(map[string]any{
+		"model":      "claude-haiku-4-5",
+		"max_tokens": 1024,
+		"messages": []any{
+			map[string]any{"role": "user", "content": "Please read the large file."},
+			map[string]any{"role": "assistant", "content": []any{
+				map[string]any{"type": "tool_use", "id": "toolu_audit1", "name": "Read", "input": map[string]any{"file_path": "/tmp/big.txt"}},
+			}},
+			map[string]any{"role": "user", "content": []any{
+				map[string]any{"type": "tool_result", "tool_use_id": "toolu_audit1", "content": oversized},
+			}},
+			map[string]any{"role": "assistant", "content": "Done reading."},
+			map[string]any{"role": "user", "content": "/rf+"},
+		},
+	})
+	require.NoError(t, err)
+
+	store := newFakePinStore()
+	fr := &fakeRouter{decision: router.Decision{Provider: providers.ProviderAnthropic, Model: "claude-haiku-4-5", Reason: "cluster"}}
+	policyFeedback := &fakePolicyFeedbackRouter{}
+	svc := newPinSvc(fr, store).WithHMMRouter(policyFeedback)
+
+	ctx := router.WithStrategy(authedCtx(uuid.NewString()), router.StrategyHMM)
+	ctx = context.WithValue(ctx, proxy.PolicyTrainingAllowedContextKey{}, true)
+	require.NoError(t, svc.ProxyMessages(ctx, body, httptest.NewRecorder(), httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(""))))
+	require.Eventually(t, func() bool {
+		return len(policyFeedback.Payloads()) == 1
+	}, time.Second, 10*time.Millisecond)
+
+	payload := policyFeedback.Payloads()[0]
+	assert.Equal(t, true, payload["training_allowed"])
+	delta, ok := payload["training_conversation_delta"].([]router.ConversationMessage)
+	require.True(t, ok)
+	require.Len(t, delta, 2)
+	require.Len(t, delta[0].ToolResults, 1)
+	// Newest-first budgeting (#716 mirror): assistant text is charged first, so
+	// the tool_result gets the remainder of the shared 256 KiB total — never
+	// the raw oversized input.
+	assert.LessOrEqual(t, len(delta[0].ToolResults[0].Text), maxFeedbackDeltaChars)
+	assert.Equal(t, maxFeedbackDeltaChars-len(delta[1].Text), len(delta[0].ToolResults[0].Text),
+		"tool_result must consume the remaining shared budget after newer fields")
+	assert.Equal(t, "Done reading.", delta[1].Text)
+	assert.Less(t, len(delta[0].ToolResults[0].Text), len(oversized),
+		"oversized tool_result must not ship verbatim")
+	truncated, ok := payload["training_conversation_delta_truncated"].(bool)
+	require.True(t, ok, "truncated flag must be present whenever a delta is sent")
+	assert.True(t, truncated)
+}
+
+// TestService_RouterFeedbackCommand_PreservesSmallTrainingDelta is the
+// complementary case to CapsOversized: a routine small tool_result must ship
+// verbatim with training_conversation_delta_truncated explicitly false (present
+// as bool false — not omitted, not null).
+func TestService_RouterFeedbackCommand_PreservesSmallTrainingDelta(t *testing.T) {
+	const toolChars = 500
+	small := strings.Repeat("s", toolChars)
+	body, err := json.Marshal(map[string]any{
+		"model":      "claude-haiku-4-5",
+		"max_tokens": 1024,
+		"messages": []any{
+			map[string]any{"role": "user", "content": "Please read the small file."},
+			map[string]any{"role": "assistant", "content": []any{
+				map[string]any{"type": "tool_use", "id": "toolu_small1", "name": "Read", "input": map[string]any{"file_path": "/tmp/small.txt"}},
+			}},
+			map[string]any{"role": "user", "content": []any{
+				map[string]any{"type": "tool_result", "tool_use_id": "toolu_small1", "content": small},
+			}},
+			map[string]any{"role": "assistant", "content": "Done reading."},
+			map[string]any{"role": "user", "content": "/rf+"},
+		},
+	})
+	require.NoError(t, err)
+
+	store := newFakePinStore()
+	fr := &fakeRouter{decision: router.Decision{Provider: providers.ProviderAnthropic, Model: "claude-haiku-4-5", Reason: "cluster"}}
+	policyFeedback := &fakePolicyFeedbackRouter{}
+	svc := newPinSvc(fr, store).WithHMMRouter(policyFeedback)
+
+	ctx := router.WithStrategy(authedCtx(uuid.NewString()), router.StrategyHMM)
+	ctx = context.WithValue(ctx, proxy.PolicyTrainingAllowedContextKey{}, true)
+	require.NoError(t, svc.ProxyMessages(ctx, body, httptest.NewRecorder(), httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(""))))
+	require.Eventually(t, func() bool {
+		return len(policyFeedback.Payloads()) == 1
+	}, time.Second, 10*time.Millisecond)
+
+	payload := policyFeedback.Payloads()[0]
+	assert.Equal(t, true, payload["training_allowed"])
+	delta, ok := payload["training_conversation_delta"].([]router.ConversationMessage)
+	require.True(t, ok, "delta must be present when training is allowed")
+	require.Len(t, delta, 2)
+	require.Len(t, delta[0].ToolResults, 1)
+	assert.Equal(t, toolChars, len(delta[0].ToolResults[0].Text))
+	assert.Equal(t, small, delta[0].ToolResults[0].Text)
+	assert.Equal(t, "Done reading.", delta[1].Text)
+	truncated, ok := payload["training_conversation_delta_truncated"].(bool)
+	require.True(t, ok, "truncated flag must be present whenever a delta is sent")
+	assert.False(t, truncated)
 }
 
 func TestService_RouterFeedbackCommand_CorrelatesCompactedHMMRoute(t *testing.T) {
@@ -315,6 +422,9 @@ func TestService_RouterFeedbackCommand_CorrelatesCompactedHMMRoute(t *testing.T)
 	assert.Equal(t, "latest request", delta[0].Text)
 	assert.Equal(t, "assistant", delta[1].Role)
 	assert.Equal(t, "done", delta[1].Text)
+	truncated, ok := payloads[0]["training_conversation_delta_truncated"].(bool)
+	require.True(t, ok, "truncated flag must be present whenever a delta is sent")
+	assert.False(t, truncated)
 }
 
 func TestService_RouterFeedbackCommand_DoesNotForwardPolicyFeedbackOutsideHMM(t *testing.T) {


### PR DESCRIPTION
## Summary
 
Fixes #719  — `routerFeedbackTrainingDelta` attached an
unbounded `training_conversation_delta` to every HMM `/feedback` request
(triggered by `/rf+`-style rating commands) when `ai_training_allowed` is
true. A single large tool result from the rated exchange was shipped
verbatim to the sidecar with no size limit — the same bug class #716
fixed on the synchronous `/route` path, but on the async `/feedback` path,
and explicitly named as deferred scope in #716's own PR description.
 
## Before / After
 
| Scenario | Before | After |
|---|---|---|
| `ai_training_allowed=true`, 500,000-char tool result in rated exchange | `training_conversation_delta` sent uncapped: 500,000-char tool result, ~500,524-byte POST | Capped: **262,131**-char tool result (256 KiB budget minus 13 chars for "Done reading."), **272,xxx-byte** POST, `training_conversation_delta_truncated: true` |
| Same session, `ai_training_allowed=false` | No delta sent (`has_delta: false`), ~375-byte POST | **Unchanged** — no delta, `training_conversation_delta`/`training_conversation_delta_truncated` keys entirely absent from payload |
| Boundary: 262,144 vs. 262,145 chars | Both uncapped, 1:1 with input | 262,144 → `truncated: false`; 262,145 → clips to 262,144, `truncated: true` |
| Small tool result (500 chars), training on | Passed through untouched | **Unchanged** — passed through untouched; `truncated` explicitly `false` (present, not omitted), confirming this is distinct from the "no delta at all" case |
 
## Fix
 
Two commits:
 
1. **`test(proxy): assert router-feedback training delta clips oversized
   tool output`** — failing test confirming the bug on current `main`.
2. **`fix(proxy): cap router-feedback training delta at 256 KiB`** —
   adds a local `maxFeedbackDeltaChars = 256 * 1024` constant in
   `router_feedback.go`, applies per-field and total-budget clipping to
   `routerFeedbackTrainingDelta`'s output before it's placed on the
   `/feedback` payload, and adds `training_conversation_delta_truncated`
   (present only when a delta is sent), mirroring #716's exact
   present/omitted convention on the same field name.
### Why a local constant, not a shared helper with #716
 
Considered and deliberately ruled out for this PR:
 
- **Different selection semantics.** `trainingRouteMessageDelta` (#716,
  `/route` path) anchors on the *latest user message* and walks back to
  the prior assistant. `routerFeedbackTrainingDelta` (`/feedback` path)
  anchors on the *last rated assistant message* and excludes the
  trailing `/rf+` command entirely. Calling one from the other would
  silently select the wrong exchange — verified directly: running the
  `/route` path's selection logic over a `/feedback`-shaped conversation
  would have dropped the actual oversized tool result from the delta
  entirely, hiding the bug rather than fixing it.
- **Wrong layering direction.** `trainingRouteMessageDelta` is
  unexported `policyclient`-internal logic returning an unexported wire
  type. `internal/proxy` calling into `internal/policyclient` would
  invert this codebase's adapter/inner-ring dependency rule (`AGENTS.md`)
  — `policyclient` is the HTTP sidecar adapter; `proxy` is inner-ring
  orchestration.
A local mirror of #716's approach — same 256 KiB precedent
(`policyOutcomeResponseMaxBytes`), same clip-in-place-keep-prefix
strategy, same truncation-flag convention — is the correct scope. The
constant is documented as needing reconciliation with `policyclient`'s
`maxTrainingDeltaChars` if/when a shared helper is promoted after #716
lands; #716 has not yet merged as of this PR.
 
### Allocation order (same pre-existing FCFS behavior as #716, not new here either)
 
Same newest-first, first-come-first-served budget allocation as #716 —
confirmed live: in the 500,000-char test case, the assistant's trailing
"Done reading." (13 chars, processed first as the newest text) consumes
13 chars of the 262,144 budget, leaving exactly 262,131 for the tool
result. This is consistent with #716's documented tradeoff, not a new
one introduced here.
 
## Known, deliberately unaddressed scope
 
- **Shared-helper consolidation** between this fix and #716's
  `trainingRouteMessageDelta` — worth revisiting once #716 merges, if a
  single clip implementation used by both paths is judged worth the
  cross-package refactor. Not done here; see reasoning above.
- Reconciling the two now-separate 256 KiB constants
  (`maxFeedbackDeltaChars` here, `maxTrainingDeltaChars` in #716) if
  they ever need to diverge or if a shared constant is promoted later.
## Test plan
 
- [x] Two new tests: `TestService_RouterFeedbackCommand_CapsOversizedTrainingDelta`
      (clips a 500KB tool result, asserts `truncated: true`) and
      `TestService_RouterFeedbackCommand_PreservesSmallTrainingDelta`
      (500-char tool result passes through byte-identical, asserts
      `truncated: false` explicitly, not omitted), plus a unit-level
      `TestClipFeedbackTrainingDelta_ClipsAt256KiBBoundary` confirming
      the exact 262,144/262,145 boundary
- [x] `go build ./...`, `go vet ./...`, `make check` — all pass
- [x] `go test ./internal/proxy/... -race -count=1` — clean
- [x] `go test ./... -race -count=1` — only the 3 known pre-existing
      flakes (`TestService_VerifyAPIKey_RecoversFromMarkUsedPanic`,
      `TestSafeGoRecoversFromPanic`, `TestFireTelemetryRecoversFromPanic`),
      confirmed identical to `main` and unrelated to this change
- [x] **Live verify, hand-driven, both directions:**
  - Fixed session: sent a turn with a 500,000-char tool result, then an
    `/rf+` feedback command rating that exchange, with
    `ai_training_allowed=true` — confirmed capped delta
    (`tool_result_chars: 262131`, `truncated: true`) in the actual
    `/feedback` POST received by a mock sidecar
  - Repeated the identical session and tool result with
    `ai_training_allowed=false` — confirmed no delta sent at all,
    `training_conversation_delta` and `training_conversation_delta_truncated`
    keys both entirely absent from the payload, isolating the fix to the
    training-enabled path only
  - Confirmed no rebase needed / no overlapping PR touching
    `internal/proxy/router_feedback.go` before pushing
## Note on concurrent work
 
No overlapping open PR found touching `router_feedback.go` at time of
filing (checked via `gh pr list` search and a direct `git log
main..origin/main -- internal/proxy/` diff, which was empty).
 