### PR TITLE
feat(rl): Modal proxy auth headers for policy sidecar

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -81,7 +81,10 @@ ROUTER_DEPLOYMENT_MODE=selfhosted
 
 # Opt-in routing strategies (selected per-request via x-weave-router-strategy).
 # Unset = strategy header returns HTTP 503 for that arm; default traffic uses cluster.
-# ROUTER_RL_SIDECAR_URL=          # rl strategy → router-rl-sidecar Cloud Run service
+# ROUTER_RL_SIDECAR_URL=          # rl strategy → router-rl-sidecar Cloud Run or Modal band serve
+# ROUTER_RL_SIDECAR_TIMEOUT_MS=10000
+# ROUTER_RL_SIDECAR_MODAL_KEY=    # Modal-Key when URL is a requires_proxy_auth ASGI app
+# ROUTER_RL_SIDECAR_MODAL_SECRET=
 # ROUTER_HMM_SIDECAR_URL=         # set automatically by `make up-hmm`
 # ROUTER_BANDIT_POSTERIOR_FILE=   # bandit strategy → ts_posterior.json from train_thompson_posterior.py
 

--- a/cmd/router/main.go
+++ b/cmd/router/main.go
@@ -1192,12 +1192,23 @@ func boolDefault(b bool) string {
 	return "false"
 }
 
-// rlSidecarHeadersFromEnv builds Modal-Key / Modal-Secret headers when the
+// rlSidecarHeadersFromEnv builds Modal-Key / Modal-Secret headers when both
 // env vars are set — needed for Modal ASGI apps with requires_proxy_auth=True.
+// A partial pair (only one set) logs an error and returns nil so misconfig
+// surfaces at startup instead of as opaque 401/503s from the sidecar.
 func rlSidecarHeadersFromEnv() map[string]string {
 	key := strings.TrimSpace(config.GetOr("ROUTER_RL_SIDECAR_MODAL_KEY", ""))
 	secret := strings.TrimSpace(config.GetOr("ROUTER_RL_SIDECAR_MODAL_SECRET", ""))
+	if key == "" && secret == "" {
+		return nil
+	}
 	if key == "" || secret == "" {
+		observability.Get().Error(
+			"Partial Modal RL sidecar proxy auth config; omitting headers",
+			"has_key", key != "",
+			"has_secret", secret != "",
+			"hint", "set both ROUTER_RL_SIDECAR_MODAL_KEY and ROUTER_RL_SIDECAR_MODAL_SECRET",
+		)
 		return nil
 	}
 	return map[string]string{

--- a/cmd/router/main.go
+++ b/cmd/router/main.go
@@ -573,8 +573,19 @@ func main() {
 	var rlRouter router.Router
 	if rlSidecarURL := config.GetOr("ROUTER_RL_SIDECAR_URL", ""); rlSidecarURL != "" {
 		rlTimeout := parseEnvDurationMs("ROUTER_RL_SIDECAR_TIMEOUT_MS", rl.DefaultTimeout)
-		rlRouter = rl.New(rl.NewHTTPDecider(rlSidecarURL, nil, rlTimeout), availableModels, availableProviders)
-		logger.Info("RL policy router wired", "sidecar_url", rlSidecarURL, "timeout_ms", rlTimeout.Milliseconds(), "candidate_models", len(availableModels))
+		rlHeaders := rlSidecarHeadersFromEnv()
+		rlRouter = rl.New(
+			rl.NewHTTPDeciderWithHeaders(rlSidecarURL, nil, rlTimeout, rlHeaders),
+			availableModels,
+			availableProviders,
+		)
+		logger.Info(
+			"RL policy router wired",
+			"sidecar_url", rlSidecarURL,
+			"timeout_ms", rlTimeout.Milliseconds(),
+			"candidate_models", len(availableModels),
+			"modal_proxy_auth", len(rlHeaders) > 0,
+		)
 	} else {
 		logger.Info("RL policy router disabled (ROUTER_RL_SIDECAR_URL unset); x-weave-router-strategy: rl will return 503")
 	}
@@ -1179,6 +1190,22 @@ func boolDefault(b bool) string {
 		return "true"
 	}
 	return "false"
+}
+
+// rlSidecarHeadersFromEnv returns static headers for the RL sidecar HTTP
+// client. When ROUTER_RL_SIDECAR_MODAL_KEY + ROUTER_RL_SIDECAR_MODAL_SECRET
+// are set, they are sent as Modal-Key / Modal-Secret for Modal ASGI apps
+// deployed with requires_proxy_auth=True (staging band serve).
+func rlSidecarHeadersFromEnv() map[string]string {
+	key := strings.TrimSpace(config.GetOr("ROUTER_RL_SIDECAR_MODAL_KEY", ""))
+	secret := strings.TrimSpace(config.GetOr("ROUTER_RL_SIDECAR_MODAL_SECRET", ""))
+	if key == "" || secret == "" {
+		return nil
+	}
+	return map[string]string{
+		"Modal-Key":    key,
+		"Modal-Secret": secret,
+	}
 }
 
 // parseEnvDurationMs reads an env var as a millisecond integer and returns

--- a/cmd/router/main.go
+++ b/cmd/router/main.go
@@ -1192,10 +1192,9 @@ func boolDefault(b bool) string {
 	return "false"
 }
 
-// rlSidecarHeadersFromEnv builds Modal-Key / Modal-Secret headers when both
-// env vars are set — needed for Modal ASGI apps with requires_proxy_auth=True.
-// A partial pair (only one set) logs an error and returns nil so misconfig
-// surfaces at startup instead of as opaque 401/503s from the sidecar.
+// rlSidecarHeadersFromEnv builds Modal-Key / Modal-Secret headers when
+// both env vars are set (Modal ASGI requires_proxy_auth=True). A partial
+// pair logs an error and returns nil so misconfig surfaces at startup.
 func rlSidecarHeadersFromEnv() map[string]string {
 	key := strings.TrimSpace(config.GetOr("ROUTER_RL_SIDECAR_MODAL_KEY", ""))
 	secret := strings.TrimSpace(config.GetOr("ROUTER_RL_SIDECAR_MODAL_SECRET", ""))

--- a/cmd/router/main.go
+++ b/cmd/router/main.go
@@ -1192,10 +1192,8 @@ func boolDefault(b bool) string {
 	return "false"
 }
 
-// rlSidecarHeadersFromEnv returns static headers for the RL sidecar HTTP
-// client. When ROUTER_RL_SIDECAR_MODAL_KEY + ROUTER_RL_SIDECAR_MODAL_SECRET
-// are set, they are sent as Modal-Key / Modal-Secret for Modal ASGI apps
-// deployed with requires_proxy_auth=True (staging band serve).
+// rlSidecarHeadersFromEnv builds Modal-Key / Modal-Secret headers when the
+// env vars are set — needed for Modal ASGI apps with requires_proxy_auth=True.
 func rlSidecarHeadersFromEnv() map[string]string {
 	key := strings.TrimSpace(config.GetOr("ROUTER_RL_SIDECAR_MODAL_KEY", ""))
 	secret := strings.TrimSpace(config.GetOr("ROUTER_RL_SIDECAR_MODAL_SECRET", ""))

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -97,6 +97,8 @@ privacy context, and telemetry.
 | `ROUTER_HMM_SIDECAR_AUTH`          | `none`  | Authentication for the HMM sidecar. Use `google-id-token` for managed Cloud Run; the exact sidecar origin is used as the token audience. |
 | `ROUTER_RL_SIDECAR_URL`            | *(none)* | Legacy built-in RL registration. Prefer the generic map for new strategies. |
 | `ROUTER_RL_SIDECAR_TIMEOUT_MS`     | `3000`  | Total RL decision timeout. |
+| `ROUTER_RL_SIDECAR_MODAL_KEY`      | *(none)* | Optional Modal proxy token id (`Modal-Key`) when the RL sidecar is a Modal ASGI app with `requires_proxy_auth`. |
+| `ROUTER_RL_SIDECAR_MODAL_SECRET`   | *(none)* | Optional Modal proxy token secret (`Modal-Secret`); required when `ROUTER_RL_SIDECAR_MODAL_KEY` is set. |
 
 `GET /capabilities` is queried at router startup. A failed probe does not
 silently remove the strategy: serving stays registered and fails closed if

--- a/internal/router/rl/AGENTS.md
+++ b/internal/router/rl/AGENTS.md
@@ -18,7 +18,7 @@ Opt-in `router.Router` that delegates model selection to a trained RL/DPO policy
 
 ## Wiring
 
-`cmd/router/main.go` constructs `rl.New(rl.NewHTTPDecider(ROUTER_RL_SIDECAR_URL, …), availableModels)` and injects it via `proxy.Service.WithRLRouter`. Unset URL → `WithRLRouter(nil)` → the strategy header 503s.
+`cmd/router/main.go` constructs `rl.New(rl.NewHTTPDeciderWithHeaders(ROUTER_RL_SIDECAR_URL, …, rlSidecarHeadersFromEnv()), availableModels)` and injects it via `proxy.Service.WithRLRouter`. Unset URL → `WithRLRouter(nil)` → the strategy header 503s. Optional `ROUTER_RL_SIDECAR_MODAL_KEY` / `ROUTER_RL_SIDECAR_MODAL_SECRET` attach Modal proxy-auth headers for staging Modal band serve.
 
 ## Tests
 

--- a/internal/router/rl/CLAUDE.md
+++ b/internal/router/rl/CLAUDE.md
@@ -18,7 +18,7 @@ Opt-in `router.Router` that delegates model selection to a trained RL/DPO policy
 
 ## Wiring
 
-`cmd/router/main.go` constructs `rl.New(rl.NewHTTPDecider(ROUTER_RL_SIDECAR_URL, …), availableModels)` and injects it via `proxy.Service.WithRLRouter`. Unset URL → `WithRLRouter(nil)` → the strategy header 503s.
+`cmd/router/main.go` constructs `rl.New(rl.NewHTTPDeciderWithHeaders(ROUTER_RL_SIDECAR_URL, …, rlSidecarHeadersFromEnv()), availableModels)` and injects it via `proxy.Service.WithRLRouter`. Unset URL → `WithRLRouter(nil)` → the strategy header 503s. Optional `ROUTER_RL_SIDECAR_MODAL_KEY` / `ROUTER_RL_SIDECAR_MODAL_SECRET` attach Modal proxy-auth headers for staging Modal band serve.
 
 ## Tests
 

--- a/internal/router/rl/client.go
+++ b/internal/router/rl/client.go
@@ -14,9 +14,6 @@ import (
 // DefaultTimeout bounds a single policy decision. The sidecar embeds the
 // prompt (a network call to the embedding provider) before scoring, so the
 // budget is comparable to the cluster scorer's embed timeout.
-//
-// Band/Modal GPU serves are usually well under this; raise via
-// ROUTER_RL_SIDECAR_TIMEOUT_MS when pointing at a cold or CPU sidecar.
 const DefaultTimeout = 2 * time.Second
 
 // HTTPDecider calls the policy sidecar's POST /route endpoint.

--- a/internal/router/rl/client.go
+++ b/internal/router/rl/client.go
@@ -14,26 +14,44 @@ import (
 // DefaultTimeout bounds a single policy decision. The sidecar embeds the
 // prompt (a network call to the embedding provider) before scoring, so the
 // budget is comparable to the cluster scorer's embed timeout.
+//
+// Band/Modal GPU serves are usually well under this; raise via
+// ROUTER_RL_SIDECAR_TIMEOUT_MS when pointing at a cold or CPU sidecar.
 const DefaultTimeout = 2 * time.Second
 
 // HTTPDecider calls the policy sidecar's POST /route endpoint.
 type HTTPDecider struct {
 	baseURL string
 	client  *http.Client
+	headers map[string]string
 }
 
 // NewHTTPDecider builds a Decider that posts to baseURL/route. A nil client
 // uses a default client bounded by timeout; a non-nil client is used as-is.
 func NewHTTPDecider(baseURL string, client *http.Client, timeout time.Duration) *HTTPDecider {
+	return NewHTTPDeciderWithHeaders(baseURL, client, timeout, nil)
+}
+
+// NewHTTPDeciderWithHeaders is NewHTTPDecider plus static request headers
+// (e.g. Modal-Key / Modal-Secret for requires_proxy_auth ASGI apps).
+func NewHTTPDeciderWithHeaders(baseURL string, client *http.Client, timeout time.Duration, headers map[string]string) *HTTPDecider {
 	if client == nil {
 		if timeout <= 0 {
 			timeout = DefaultTimeout
 		}
 		client = &http.Client{Timeout: timeout}
 	}
+	copied := map[string]string{}
+	for k, v := range headers {
+		if strings.TrimSpace(k) == "" || v == "" {
+			continue
+		}
+		copied[k] = v
+	}
 	return &HTTPDecider{
 		baseURL: strings.TrimRight(baseURL, "/"),
 		client:  client,
+		headers: copied,
 	}
 }
 
@@ -76,6 +94,9 @@ func (d *HTTPDecider) Decide(ctx context.Context, q Query) (Result, error) {
 		return Result{}, fmt.Errorf("build route request: %w", err)
 	}
 	req.Header.Set("content-type", "application/json")
+	for k, v := range d.headers {
+		req.Header.Set(k, v)
+	}
 
 	resp, err := d.client.Do(req)
 	if err != nil {

--- a/internal/router/rl/client_test.go
+++ b/internal/router/rl/client_test.go
@@ -60,6 +60,33 @@ func TestHTTPDeciderPostsContractAndParsesResult(t *testing.T) {
 	assert.Equal(t, "implementing a fix", res.StateLabel)
 }
 
+func TestHTTPDeciderAttachesStaticHeaders(t *testing.T) {
+	var gotKey, gotSecret string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotKey = r.Header.Get("Modal-Key")
+		gotSecret = r.Header.Get("Modal-Secret")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"model": "anthropic/claude-opus-4-8",
+			"score": 1.0,
+		})
+	}))
+	defer server.Close()
+
+	d := rl.NewHTTPDeciderWithHeaders(server.URL, nil, 0, map[string]string{
+		"Modal-Key":    "mk_test",
+		"Modal-Secret": "ms_test",
+	})
+	_, err := d.Decide(context.Background(), rl.Query{
+		PromptText: "x",
+		Candidates: []rl.Candidate{
+			{RosterID: "anthropic/claude-opus-4-8", Provider: providers.ProviderAnthropic},
+		},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "mk_test", gotKey)
+	assert.Equal(t, "ms_test", gotSecret)
+}
+
 func TestHTTPDeciderSurfacesSidecarError(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusBadRequest)


### PR DESCRIPTION
## Summary
- Add `NewHTTPDeciderWithHeaders` so the RL sidecar client can attach static headers on every `/route` call
- Wire `ROUTER_RL_SIDECAR_MODAL_KEY` / `ROUTER_RL_SIDECAR_MODAL_SECRET` → `Modal-Key` / `Modal-Secret` for Modal ASGI apps with `requires_proxy_auth`
- Document the env vars in CONFIGURATION.md / `.env.example`

Needed so staging can point `ROUTER_RL_SIDECAR_URL` at the tip_k3 Modal L4 band serve (WorkWeave bake-off infra) without Cloud Run CPU capacity failures.

## Test plan
- [x] `go test ./internal/router/rl/ ./cmd/router/ -count=1`
- [ ] Staging: set Modal URL + key/secret; `curl`/`x-weave-router-strategy: rl` succeeds against Modal `/route`

Made with [Cursor](https://cursor.com)