### PR TITLE
fix(proxy): wire force-model header and pin eviction into Gemini surface  

### DIFF
--- a/internal/proxy/gemini.go
+++ b/internal/proxy/gemini.go
@@ -85,6 +85,11 @@ func (s *Service) ProxyGeminiGenerateContent(ctx context.Context, body []byte, w
 
 	logInboundRequestDiagnostics(log, env)
 
+	// Honor the x-weave-force-model header (headless equivalent of /force-model).
+	// Writes the user-forced pin and falls through to normal routing, which picks
+	// the pin up and serves the requested model on this same turn.
+	s.applyForceModelHeader(ctx, r, env, installationID, sessionKey)
+
 	subAgentHint := r.Header.Get("x-weave-subagent-type")
 
 	routeRequest := router.Request{
@@ -261,6 +266,11 @@ func (s *Service) ProxyGeminiGenerateContent(ctx context.Context, body []byte, w
 	if proxyErr == nil {
 		s.emitBilling(ctx, requestID, externalID, decision, actPricing, routeRes, in, out, cacheCreation, cacheRead)
 	}
+
+	// Two-strike eviction: a session pinned to a model returning non-retryable
+	// 4xx wedges until manually /force-model'd out. Expires the pin after a
+	// persistent counter hits threshold; successful turns reset it.
+	s.maybeEvictPinAfterUpstreamErr(ctx, stickyHit, proxyErr, decision.Reason, installationID, routeRes.SessionKey, stickyStateRole(routeRes))
 
 	log.Info("ProxyGeminiGenerateContent complete", append([]any{"requested_model", feats.Model, "baseline_model", s.baselineFor(feats.Model), "decision_model", decision.Model, "decision_provider", decision.Provider, "decision_reason", decision.Reason, "embedded_tokens", len(promptText) / 4, "total_input_tokens", feats.Tokens, "has_tools", feats.HasTools, "embed_input", embedInput, "sticky_hit", stickyHit, "pin_tier", pinTier, "turn_type", string(tt), "route_ms", routeMs, "proxy_ms", proxyMs, "proxy_err", proxyErr, "upstream_status", upstreamStatus(proxyErr)}, plannerLogFields(routeRes)...)...)
 	s.reportPolicyOutcome(ctx, routeRes, decision, decision.Provider, feats.Tokens, in, out, cacheCreation, cacheRead, routeMs, proxyMs, proxyErr, nil)

--- a/internal/proxy/gemini_sticky_hooks_test.go
+++ b/internal/proxy/gemini_sticky_hooks_test.go
@@ -1,0 +1,111 @@
+package proxy_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"workweave/router/internal/providers"
+	"workweave/router/internal/proxy"
+	"workweave/router/internal/router"
+	"workweave/router/internal/router/sessionpin"
+	"workweave/router/internal/translate"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// geminiPinTestBody is a minimal, valid Gemini-native request body used by
+// both tests below.
+const geminiPinTestBody = `{
+	"contents":[{"role":"user","parts":[{"text":"hello"}]}]
+}`
+
+func newGeminiPinSvc(fr *fakeRouter, store *fakePinStore) *proxy.Service {
+	return proxy.NewService(
+		fr,
+		map[string]providers.Client{providers.ProviderGoogle: &fakeProvider{}},
+		nil,
+		false,
+		nil,
+		store,
+		false,
+		providers.ProviderGoogle,
+		"gemini-2.5-flash",
+		nil,
+	)
+}
+
+// TestProxyGeminiGenerateContent_ForceModelHeader_WritesUserForcedPin proves
+// bug #730 finding 1: x-weave-force-model is a documented escape hatch for
+// headless clients (see ForceModelHeader doc comment in force_model.go) and
+// is honored on /v1/messages (see
+// TestService_ForceModelHeader_WritesUserForcedPin in
+// service_session_pin_test.go), but ProxyGeminiGenerateContent never calls
+// applyForceModelHeader, so the header is silently ignored on the Gemini
+// surface. This test currently FAILS: no store.upserts entry has
+// Reason == translate.ReasonUserForceModel, because the call site is
+// missing in gemini.go.
+func TestProxyGeminiGenerateContent_ForceModelHeader_WritesUserForcedPin(t *testing.T) {
+	store := newFakePinStore()
+	fr := &fakeRouter{decision: router.Decision{Provider: providers.ProviderGoogle, Model: "gemini-2.5-pro", Reason: "fresh"}}
+	svc := newGeminiPinSvc(fr, store)
+
+	ctx := authedCtx(uuid.New().String())
+	rec := httptest.NewRecorder()
+	httpReq := httptest.NewRequest(http.MethodPost, "/v1beta/models/gemini-2.5-flash:generateContent", strings.NewReader(""))
+	httpReq.Header.Set(proxy.ForceModelHeader, "gemini-2.5-flash")
+	require.NoError(t, svc.ProxyGeminiGenerateContent(ctx, []byte(geminiPinTestBody), rec, httpReq))
+
+	store.mu.Lock()
+	defer store.mu.Unlock()
+	var forced *sessionpin.Pin
+	for i := range store.upserts {
+		if store.upserts[i].Reason == translate.ReasonUserForceModel {
+			forced = &store.upserts[i]
+			break
+		}
+	}
+	require.NotNil(t, forced, "x-weave-force-model header must write a user_forced pin upsert on the Gemini surface, same as it does on /v1/messages and /v1/chat/completions")
+	assert.Equal(t, "gemini-2.5-flash", forced.Model)
+	assert.Equal(t, providers.ProviderGoogle, forced.Provider)
+}
+
+// TestProxyGeminiGenerateContent_MaybeEvictPinAfterUpstreamErr_Called proves
+// bug #730 finding 2: maybeEvictPinAfterUpstreamErr (the two-strike pin
+// eviction policy) is called by both ProxyMessages and
+// ProxyOpenAIChatCompletion after every dispatch, but never by
+// ProxyGeminiGenerateContent. We can't observe the increment/reset counters
+// directly (unexported), but we CAN observe that fakePinStore.IncrementUpstreamErrors
+// is never invoked by asserting on the exported-via-test-helper call count.
+// This test currently FAILS to show any eviction-path activity: incrementCalls
+// stays at 0 regardless of the upstream error, because the call site is
+// missing in gemini.go.
+func TestProxyGeminiGenerateContent_MaybeEvictPinAfterUpstreamErr_Called(t *testing.T) {
+	store := newFakePinStore()
+	store.hasPin = true
+	store.pin = sessionpin.Pin{Provider: providers.ProviderGoogle, Model: "gemini-2.5-pro", PinnedUntil: time.Now().Add(time.Hour)}
+	failingProv := &fakeProvider{proxyErr: &providers.UpstreamErrorResponse{Status: http.StatusBadRequest}}
+	fr := &fakeRouter{decision: router.Decision{Provider: providers.ProviderGoogle, Model: "gemini-2.5-pro", Reason: "sticky"}}
+	svc := proxy.NewService(
+		fr,
+		map[string]providers.Client{providers.ProviderGoogle: failingProv},
+		nil, false, nil,
+		store,
+		false, providers.ProviderGoogle, "gemini-2.5-flash",
+		nil,
+	)
+
+	ctx := authedCtx(uuid.New().String())
+	rec := httptest.NewRecorder()
+	httpReq := httptest.NewRequest(http.MethodPost, "/v1beta/models/gemini-2.5-flash:generateContent", strings.NewReader(""))
+	_ = svc.ProxyGeminiGenerateContent(ctx, []byte(geminiPinTestBody), rec, httpReq)
+
+	store.mu.Lock()
+	defer store.mu.Unlock()
+	assert.Greater(t, store.incrementCalls, 0,
+		"a non-retryable upstream 4xx on a sticky Gemini pin must call maybeEvictPinAfterUpstreamErr (IncrementUpstreamErrors), same as it does on /v1/messages and /v1/chat/completions")
+}


### PR DESCRIPTION
## Summary
 
`ProxyGeminiGenerateContent` (`internal/proxy/gemini.go`) computes and uses
the same `sessionKey` / sticky-pin machinery as `ProxyMessages` (Anthropic
surface) and `ProxyOpenAIChatCompletion` (OpenAI surface), but never called
two lifecycle hooks that both of those functions call on every request:
 
1. `applyForceModelHeader` — reads `x-weave-force-model` and writes a
   forced session pin.
2. `maybeEvictPinAfterUpstreamErr` — applies the two-strike eviction
   policy after consecutive non-retryable upstream errors.
This PR adds both calls to `ProxyGeminiGenerateContent`, at the same
relative position they occupy in `ProxyMessages`. **No other changes to
`gemini.go`** — this is intentionally the minimal diff that closes the gap,
not a broader refactor.
 
---
 
## Root cause
 
`ProxyGeminiGenerateContent` appears to have been built as an
independently-maintained third implementation of the proxy request
lifecycle, rather than sharing the pre/post-request hook sequence that
`ProxyMessages` and `ProxyOpenAIChatCompletion` both run through. This
isn't a one-off — PR #543 already fixed the same *class* of gap on this
same function (`fireTelemetry` was missing). Full static evidence
(call-site greps, call-set diff across all three proxy functions) and live
reproduction of both bugs is documented in #730.
 
---
 
## The diff
 
```diff
--- a/internal/proxy/gemini.go
+++ b/internal/proxy/gemini.go
@@ -85,6 +85,11 @@ func (s *Service) ProxyGeminiGenerateContent(ctx context.Context, body []byte,
 	logInboundRequestDiagnostics(log, env)
 
+	// Honor the x-weave-force-model header (headless equivalent of /force-model).
+	// Writes the user-forced pin and falls through to normal routing, which picks
+	// the pin up and serves the requested model on this same turn.
+	s.applyForceModelHeader(ctx, r, env, installationID, sessionKey)
+
 	subAgentHint := r.Header.Get("x-weave-subagent-type")
 	...
@@ -262,6 +267,11 @@ func (s *Service) ProxyGeminiGenerateContent(ctx context.Context, body []byte,
 		s.emitBilling(...)
 	}
 
+	// Two-strike eviction: a session pinned to a model returning non-retryable
+	// 4xx wedges until manually /force-model'd out. Expires the pin after a
+	// persistent counter hits threshold; successful turns reset it.
+	s.maybeEvictPinAfterUpstreamErr(ctx, stickyHit, proxyErr, decision.Reason, installationID, routeRes.SessionKey, stickyStateRole(routeRes))
+
 	log.Info("ProxyGeminiGenerateContent complete", ...)
```
 
Both call signatures are copied verbatim from their `ProxyMessages` call
sites (`service.go:1998` and `service.go:2953` respectively) — only the
variable names were adjusted to match what's actually in scope in
`gemini.go` at each insertion point. Neither hook required any
Gemini-specific translation work; both operate on format-agnostic inputs
(`sessionKey`, `installationID`, HTTP status classification via
`providers.IsRetryableStatus`).
 
---
 
## Testing
 
### New unit tests (committed as a failing-test-first commit, before the fix)
 
`internal/proxy/gemini_sticky_hooks_test.go`:
 
- **`TestProxyGeminiGenerateContent_ForceModelHeader_WritesUserForcedPin`**
  — sends `x-weave-force-model: gemini-2.5-flash` against a Gemini request
  and asserts a `sessionpin.Pin` upsert exists with
  `Reason == translate.ReasonUserForceModel`, `Model == "gemini-2.5-flash"`,
  `Provider == providers.ProviderGoogle`.
- **`TestProxyGeminiGenerateContent_MaybeEvictPinAfterUpstreamErr_Called`**
  — sets up a sticky pin fixture (`hasPin=true`, `PinnedUntil` in the
  future) with a failing upstream provider stub (`400`, non-retryable),
  asserts `store.incrementCalls > 0`.
Both commands, run on `main` before this fix was applied, to confirm they
fail without it:
 
```
go test -run "TestProxyGeminiGenerateContent_ForceModelHeader_WritesUserForcedPin|TestProxyGeminiGenerateContent_MaybeEvictPinAfterUpstreamErr_Called" ./internal/proxy/... -v -count=1
```
 
Result on `main` (pre-fix): both **FAIL**.
- Force-model test: `Expected value not to be nil` — no `user_forced`
  pin was written; log showed `fresh_reason:"fresh"` (the fixture's
  unforced decision reason) rather than `user_forced`.
- Eviction test: `"0" is not greater than "0"` — despite a genuine
  `upstream returned status 400 (buffered)` in the completion log
  (proving the failing-provider stub worked), `incrementCalls` never
  moved.
Same commands on this branch (post-fix): both **PASS**.
 
### Edge cases (verified locally, not part of the committed diff — see below)
 
Four additional temporary test functions were written, run, and then
deleted (not part of this PR's test file — noted here for reviewer
confidence that the fix doesn't overshoot or undershoot):
 
| Case | What it checks | Result |
|---|---|---|
| Unknown `x-weave-force-model` value | Must be silently ignored, not error/crash — mirrors existing `TestService_ForceModelHeader_UnknownModelIgnored` behavior for `/v1/messages` | **PASS** — logged `"x-weave-force-model: ignoring unrecognized model; routing automatically"`, no `user_forced` upsert, routing completed normally |
| Retryable `503` on a sticky Gemini pin | Must **NOT** increment `consecutive_upstream_errors` — 5xx retry is `dispatchWithFallback`'s job, not the eviction counter's | **PASS** — `incrementCalls == 0` with sticky hit + 503 |
| Successful turn on existing sticky pin | Must call `ResetUpstreamErrors`, not `IncrementUpstreamErrors` | **PASS** — `resetCalls > 0`, `incrementCalls == 0` |
| Streaming Gemini request | New hooks must not break the streaming response writer | **PASS** — `"stream":true` body completed normally; force-model upsert still written; provider invoked exactly once |
 
### Full suite
 
```
go build ./...                              PASS
go vet ./...                                 PASS
go test ./internal/proxy/... -count=1        PASS
go test ./... -count=1                       PASS
go test -race ./internal/proxy/... -count=1  1 unrelated pre-existing failure (see below)
make check                                   PASS
```
 
**On the race failure:** `TestFireTelemetryRecoversFromPanic`
(`fire_telemetry_panic_internal_test.go`) fails under `-race` — a race
between `fireTelemetry`'s background goroutine writing to a shared
`bytes.Buffer` via `slog` and the test's own `buf.String()` read of that
same buffer. This is **not introduced by this PR**: reproduced with
identical stack traces on a clean checkout of `main` with none of this
branch's changes present. This PR's diff doesn't touch `fireTelemetry`,
`safego.go`, or that test file. Flagging here for visibility, not fixing
as part of this PR since it's out of scope — happy to file a separate
issue if useful.
 
---
 
## Live verification
 
Rebuilt the router and ran both scenarios against the local stack with a
real Google API key fixture inserted (fake key, so upstream calls return
genuine Google-side rejections rather than router-side short-circuits).
 
### Force-model (Finding 1)
 
Request forced to `gemini-2.5-flash` via `x-weave-force-model`:
 
**Response headers:**
```
X-Router-Decision: user_forced
X-Router-Model: gemini-2.5-flash
X-Router-Provider: google
```
 
**Log:**
```
"x-weave-force-model applied"
"decision_model":"gemini-2.5-flash", "decision_reason":"user_forced", "sticky_hit":true
```
 
**Postgres (`router.session_pins`):**
```
pinned_model=gemini-2.5-flash
pinned_provider=google
decision_reason=user_forced
pinned_until=9999-01-01   (immutable user-forced pin, per setForceModelPin)
```
 
Before this fix, the identical request (documented in #730) resulted in
the scorer's normal top pick (`claude-opus-4-8`) being served instead,
with no trace of the header anywhere in the logs.
 
### Eviction (Finding 2)
 
Same session (same API key + same first-message text, so `DeriveSessionKey`
hashes identically) hit three times in a row: turn 1 establishes the
sticky pin, turns 2 and 3 both return genuine non-retryable `404` from the
fake Google key.
 
**Turn 1:** `sticky_hit:true` (pin established), upstream `404`.
**Turn 2:** log line `"session pin evicted after consecutive upstream
errors"` with `consecutive_errors:2`, `strike_threshold:2`.
 
**Postgres after eviction:**
```
sk=6c5618ce8f791b73f1419a98641271f3   role=default_low
pinned_model=''   pinned_provider=''
consecutive_upstream_errors=0        (cleared by the expire upsert)
pinned_until=2026-07-15 19:24:40     expired=t
decision_reason=upstream_error_strike_threshold
```
 
Before this fix, `maybeEvictPinAfterUpstreamErr` was never called on this
surface at all — `consecutive_upstream_errors` would never move off `0`
under any circumstance, and a wedged Gemini pin had no auto-recovery path
(documented statically in #730; this session adds the live confirmation).
 
**Environment note:** the Google BYOK test fixture and the resulting
expired/completed test pins were left in place in the local Postgres
instance after verification — they're inert historical rows and don't
affect future local testing. A temporary `excluded_providers` override
used to isolate the Google routing decision was reverted before pushing
this branch.
 
---
 
## What this PR deliberately does NOT do
 
- **Does not touch loop detection.** A related but architecturally
  separate gap — tool-call loop detection is entirely absent on the
  Gemini surface, at three independent layers (no call sites, detector
  structurally blind to Gemini's wire format, response writers can't
  safely serve a Gemini-native break) — is filed separately as **#731**
  and is out of scope here. It requires translate-layer work and a new
  synthetic-response path; bundling it into this PR would make a small,
  easily-reviewable fix much larger for no benefit.
- **Does not refactor `gemini.go` further**, even though a systematic
  call-set diff across all three proxy functions surfaced several more
  hooks present in both `ProxyMessages`/`ProxyOpenAIChatCompletion` but
  absent from Gemini's. Most of those are architecturally intentional
  (Gemini's single-binding dispatch has no need for
  `dispatchWithFallback`; no consumer subscription on `/v1beta/*` so
  `withUsageObserver`/`subsidyFactors` correctly don't apply; etc.) — see
  #730 for the full triage. Only the two hooks in this diff were
  confirmed as genuine, in-scope gaps.
 