### PR TITLE
feat(proxy): wire tool-call loop detection into the Gemini surface 

### DIFF
--- a/internal/proxy/force_model.go
+++ b/internal/proxy/force_model.go
@@ -385,6 +385,88 @@ func writeSyntheticAnthropicSSE(w http.ResponseWriter, msgID, text string, input
 	return nil
 }
 
+// writeSyntheticGeminiResponse writes a minimal Gemini generateContent
+// response without hitting an upstream, handling both streaming and
+// non-streaming shapes.
+func writeSyntheticGeminiResponse(w http.ResponseWriter, env *translate.RequestEnvelope, text string, inputTokens int) error {
+	if env.Stream() {
+		return writeSyntheticGeminiSSE(w, text, inputTokens)
+	}
+	return writeSyntheticGeminiJSON(w, text, inputTokens)
+}
+
+func writeSyntheticGeminiJSON(w http.ResponseWriter, text string, inputTokens int) error {
+	outTokens := len(text) / 4
+	resp := map[string]any{
+		"candidates": []any{
+			map[string]any{
+				"content": map[string]any{
+					"role":  "model",
+					"parts": []any{map[string]any{"text": text}},
+				},
+				"finishReason": "STOP",
+				"index":        0,
+			},
+		},
+		"usageMetadata": map[string]any{
+			"promptTokenCount":     inputTokens,
+			"candidatesTokenCount": outTokens,
+			"totalTokenCount":      inputTokens + outTokens,
+		},
+	}
+	body, err := json.Marshal(resp)
+	if err != nil {
+		return fmt.Errorf("marshal synthetic gemini response: %w", err)
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_, writeErr := w.Write(body)
+	return writeErr
+}
+
+func writeSyntheticGeminiSSE(w http.ResponseWriter, text string, inputTokens int) error {
+	w.Header().Set("Content-Type", "text/event-stream")
+	flusher, _ := w.(http.Flusher)
+	bw := bufio.NewWriterSize(w, 4096)
+	outTokens := len(text) / 4
+	chunkContent := mustMarshalJSON(map[string]any{
+		"candidates": []any{
+			map[string]any{
+				"content": map[string]any{
+					"role":  "model",
+					"parts": []any{map[string]any{"text": text}},
+				},
+				"index": 0,
+			},
+		},
+	})
+	chunkStop := mustMarshalJSON(map[string]any{
+		"candidates": []any{
+			map[string]any{
+				"content": map[string]any{
+					"parts": []any{},
+				},
+				"finishReason": "STOP",
+				"index":        0,
+			},
+		},
+		"usageMetadata": map[string]any{
+			"promptTokenCount":     inputTokens,
+			"candidatesTokenCount": outTokens,
+			"totalTokenCount":      inputTokens + outTokens,
+		},
+	})
+	for _, ev := range []string{openAISSEData(chunkContent), openAISSEData(chunkStop)} {
+		bw.WriteString(ev)
+	}
+	if err := bw.Flush(); err != nil {
+		return err
+	}
+	if flusher != nil {
+		flusher.Flush()
+	}
+	return nil
+}
+
 // writeSyntheticOpenAIResponse writes a minimal OpenAI Chat Completions
 // response without hitting an upstream, handling both streaming and
 // non-streaming shapes.

--- a/internal/proxy/gemini.go
+++ b/internal/proxy/gemini.go
@@ -83,6 +83,25 @@ func (s *Service) ProxyGeminiGenerateContent(ctx context.Context, body []byte, w
 		"prompt_preview", observability.Preview(promptText, 200),
 	)
 
+	// Wide cyclic re-read loop → escalate to geminiEscalateModel (same-format
+	// Google target). Tight identical-args loop → synthetic break. Mirrors
+	// ProxyMessages; see detectCyclicToolCallLoop / handleLoopEscalationTo.
+	escalatedLoop := false
+	if cyc, csig, ccount, cratio, cwin := detectCyclicToolCallLoop(env); cyc {
+		loopRole := roleForTier(catalog.TierFor(feats.Model))
+		s.handleLoopEscalationTo(ctx, csig, ccount, cratio, cwin, installationID, sessionKey, loopRole, feats.Model,
+			providers.ProviderGoogle, geminiEscalateModel)
+		escalatedLoop = true
+	}
+	if !escalatedLoop {
+		if loop, sig, count := detectToolCallLoop(env); loop {
+			loopRole := roleForTier(catalog.TierFor(feats.Model))
+			log.Info("ProxyGeminiGenerateContent tool-call loop detected", "tool_sig", sig, "repeat_count", count, "role", loopRole)
+			return s.handleToolCallLoopBreak(ctx, w, env, sig, count, installationID, sessionKey, loopRole,
+				feats.Model, providers.ProviderGoogle, feats.Tokens)
+		}
+	}
+
 	logInboundRequestDiagnostics(log, env)
 
 	subAgentHint := r.Header.Get("x-weave-subagent-type")

--- a/internal/proxy/gemini_loop_detection_test.go
+++ b/internal/proxy/gemini_loop_detection_test.go
@@ -1,0 +1,225 @@
+package proxy_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+
+	"workweave/router/internal/providers"
+	"workweave/router/internal/proxy"
+	"workweave/router/internal/router"
+	"workweave/router/internal/router/sessionpin"
+	"workweave/router/internal/translate"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+)
+
+// geminiLoopEscalateModel mirrors proxy.geminiEscalateModel (unexported).
+const geminiLoopEscalateModel = "gemini-3.1-pro-preview"
+
+func newGeminiLoopSvc(fr *fakeRouter, store *fakePinStore, googleProv *fakeProvider) *proxy.Service {
+	return proxy.NewService(
+		fr,
+		map[string]providers.Client{providers.ProviderGoogle: googleProv},
+		nil,
+		false,
+		nil,
+		store,
+		false,
+		providers.ProviderGoogle,
+		"gemini-2.5-flash",
+		nil,
+	)
+}
+
+// buildGeminiTightLoopBody builds 5 identical bash {command: ls /tmp}
+// functionCall/functionResponse pairs — enough to trip detectToolCallLoop
+// (loopDetectionMaxRepeats == 5) without tripping the cyclic detector
+// (needs ≥24 calls). Ends on a functionResponse turn so no genuine user
+// text resets the window.
+func buildGeminiTightLoopBody(t *testing.T) []byte {
+	t.Helper()
+	contents := []any{
+		map[string]any{"role": "user", "parts": []any{
+			map[string]any{"text": "LOOP_DETECT_TIGHT"},
+		}},
+	}
+	for i := 0; i < 5; i++ {
+		contents = append(contents,
+			map[string]any{"role": "model", "parts": []any{
+				map[string]any{"functionCall": map[string]any{
+					"name": "bash",
+					"args": map[string]any{"command": "ls /tmp"},
+				}},
+			}},
+			map[string]any{"role": "user", "parts": []any{
+				map[string]any{"functionResponse": map[string]any{
+					"name": "bash", "response": map[string]any{"result": "file1 file2"},
+				}},
+			}},
+		)
+	}
+	body, err := json.Marshal(map[string]any{
+		"model":    "gemini-2.5-flash",
+		"stream":   false,
+		"contents": contents,
+	})
+	require.NoError(t, err)
+	return body
+}
+
+// buildGeminiCyclicLoopBody builds a wide re-read cycle (same few files
+// re-Read, no edits) — enough to trip detectCyclicToolCallLoop without
+// tripping the tight identical-args detector (each path appears at most
+// twice in any 10-call window).
+func buildGeminiCyclicLoopBody(t *testing.T, nFiles, total int) []byte {
+	t.Helper()
+	contents := []any{
+		map[string]any{"role": "user", "parts": []any{
+			map[string]any{"text": "LOOP_DETECT_CYCLIC"},
+		}},
+	}
+	for i := 0; i < total; i++ {
+		path := "/app/f" + strconv.Itoa(i%nFiles) + ".go"
+		contents = append(contents,
+			map[string]any{"role": "model", "parts": []any{
+				map[string]any{"functionCall": map[string]any{
+					"name": "Read",
+					"args": map[string]any{"file_path": path},
+				}},
+			}},
+			map[string]any{"role": "user", "parts": []any{
+				map[string]any{"functionResponse": map[string]any{
+					"name": "Read", "response": map[string]any{"result": "x"},
+				}},
+			}},
+		)
+	}
+	body, err := json.Marshal(map[string]any{
+		"model":    "gemini-2.5-flash",
+		"stream":   false,
+		"contents": contents,
+	})
+	require.NoError(t, err)
+	return body
+}
+
+// TestProxyGeminiGenerateContent_ToolCallLoopBreak_Fires proves Layer 1 of
+// #731: 5 identical Gemini functionCalls must short-circuit before upstream
+// dispatch with a synthetic Gemini-format break response. Currently FAILS —
+// ProxyGeminiGenerateContent has no detectToolCallLoop call site, so the
+// fake provider is invoked (proxyBodies == 1) and no candidates[] body is
+// written.
+func TestProxyGeminiGenerateContent_ToolCallLoopBreak_Fires(t *testing.T) {
+	store := newFakePinStore()
+	googleProv := &fakeProvider{}
+	fr := &fakeRouter{decision: router.Decision{
+		Provider: providers.ProviderGoogle,
+		Model:    "gemini-2.5-pro",
+		Reason:   "cluster",
+	}}
+	svc := newGeminiLoopSvc(fr, store, googleProv)
+
+	ctx := authedCtx(uuid.New().String())
+	rec := httptest.NewRecorder()
+	httpReq := httptest.NewRequest(http.MethodPost, "/v1beta/models/gemini-2.5-flash:generateContent", strings.NewReader(""))
+	require.NoError(t, svc.ProxyGeminiGenerateContent(ctx, buildGeminiTightLoopBody(t), rec, httpReq))
+
+	assert.Len(t, googleProv.proxyBodies, 0,
+		"tight tool-call loop must short-circuit before upstream Proxy — Layer 1 call site missing in gemini.go today")
+
+	assert.Equal(t, "application/json", rec.Header().Get("Content-Type"))
+	resp := rec.Body.Bytes()
+	require.True(t, gjson.GetBytes(resp, "candidates").Exists(),
+		"loop break must write a Gemini-native synthetic body; got %s", rec.Body.String())
+	assert.Equal(t, "STOP", gjson.GetBytes(resp, "candidates.0.finishReason").String())
+	assert.Equal(t, "model", gjson.GetBytes(resp, "candidates.0.content.role").String())
+	text := gjson.GetBytes(resp, "candidates.0.content.parts.0.text").String()
+	assert.Contains(t, text, "bash")
+	assert.Contains(t, text, "5")
+}
+
+// TestProxyGeminiGenerateContent_CyclicLoopEscalation_PinsGoogleModel proves
+// Layer 1 of #731 for the wide cyclic path: detectCyclicToolCallLoop must
+// pin Provider=Google + gemini-3.1-pro-preview then fall through to normal
+// routing (provider IS called — escalation rescues, it does not stop).
+// Currently FAILS — no loop_escalation pin is written because gemini.go
+// never calls handleLoopEscalationTo.
+func TestProxyGeminiGenerateContent_CyclicLoopEscalation_PinsGoogleModel(t *testing.T) {
+	store := newFakePinStore()
+	googleProv := &fakeProvider{}
+	fr := &fakeRouter{decision: router.Decision{
+		Provider: providers.ProviderGoogle,
+		Model:    "gemini-2.5-pro",
+		Reason:   "cluster",
+	}}
+	svc := newGeminiLoopSvc(fr, store, googleProv)
+
+	ctx := authedCtx(uuid.New().String())
+	rec := httptest.NewRecorder()
+	httpReq := httptest.NewRequest(http.MethodPost, "/v1beta/models/gemini-2.5-flash:generateContent", strings.NewReader(""))
+	// 30 Reads over 5 files → distinct ratio 5/30 ≈ 0.17 < 0.4, ≥24 calls,
+	// no Edit — trips cyclicLoop; each path appears ≤2× in any 10-wide
+	// window so the tight detector does not also fire.
+	require.NoError(t, svc.ProxyGeminiGenerateContent(ctx, buildGeminiCyclicLoopBody(t, 5, 30), rec, httpReq))
+
+	store.mu.Lock()
+	defer store.mu.Unlock()
+	var escalated *sessionpin.Pin
+	for i := range store.upserts {
+		if store.upserts[i].Reason == translate.ReasonLoopEscalation {
+			escalated = &store.upserts[i]
+			break
+		}
+	}
+	require.NotNil(t, escalated,
+		"cyclic Gemini loop must write a loop_escalation pin via handleLoopEscalationTo — Layer 1 call site missing in gemini.go today")
+	assert.Equal(t, providers.ProviderGoogle, escalated.Provider)
+	assert.Equal(t, geminiLoopEscalateModel, escalated.Model)
+
+	assert.Len(t, googleProv.proxyBodies, 1,
+		"cyclic escalation pins then continues the turn — upstream must still be invoked")
+}
+
+// TestProxyGeminiGenerateContent_NoLoop_RoutesNormally is the Layer-1
+// regression guard: a normal Gemini request with no repeated tool calls
+// must route to the Google provider exactly once and must not write a
+// loop_escalation pin. Expected to PASS against current (pre-call-site)
+// code — baseline before Layer 1 lands.
+func TestProxyGeminiGenerateContent_NoLoop_RoutesNormally(t *testing.T) {
+	store := newFakePinStore()
+	googleProv := &fakeProvider{}
+	fr := &fakeRouter{decision: router.Decision{
+		Provider: providers.ProviderGoogle,
+		Model:    "gemini-2.5-pro",
+		Reason:   "cluster",
+	}}
+	svc := newGeminiLoopSvc(fr, store, googleProv)
+
+	body := []byte(`{
+		"model":"gemini-2.5-flash",
+		"stream":false,
+		"contents":[{"role":"user","parts":[{"text":"hello"}]}]
+	}`)
+	ctx := authedCtx(uuid.New().String())
+	rec := httptest.NewRecorder()
+	httpReq := httptest.NewRequest(http.MethodPost, "/v1beta/models/gemini-2.5-flash:generateContent", strings.NewReader(""))
+	require.NoError(t, svc.ProxyGeminiGenerateContent(ctx, body, rec, httpReq))
+
+	require.Len(t, googleProv.proxyBodies, 1, "non-looping Gemini request must dispatch upstream once")
+	assert.Equal(t, "gemini-2.5-pro", rec.Header().Get(proxy.HeaderRouterModel))
+	assert.Equal(t, providers.ProviderGoogle, rec.Header().Get(proxy.HeaderRouterProvider))
+
+	store.mu.Lock()
+	defer store.mu.Unlock()
+	for _, p := range store.upserts {
+		assert.NotEqual(t, translate.ReasonLoopEscalation, p.Reason,
+			"non-looping request must not write a loop_escalation pin")
+	}
+}

--- a/internal/proxy/loop_detection.go
+++ b/internal/proxy/loop_detection.go
@@ -18,6 +18,10 @@ import (
 // escalateModel is the strong model a looping cheap/mid session is rescued onto.
 const escalateModel = "claude-opus-4-8"
 
+// geminiEscalateModel is the same-format TierHigh Google rescue target for
+// Gemini-source cyclic loops (Anthropic/OpenAI keep escalateModel).
+const geminiEscalateModel = "gemini-3.1-pro-preview"
+
 // LoopEscalationStore persists cyclic-loop detections (one row per
 // session+role); CountLoopEscalationEvents enforces the once-per-session budget.
 type LoopEscalationStore interface {
@@ -183,6 +187,27 @@ func (s *Service) handleLoopEscalation(
 	role string,
 	routedModel string,
 ) {
+	s.handleLoopEscalationTo(ctx, top, topCount, distinctRatio, window, installationID, sessionKey, role, routedModel,
+		providers.ProviderAnthropic, escalateModel)
+}
+
+// handleLoopEscalationTo is the provider/model-parameterized core used by
+// handleLoopEscalation (Anthropic/opus) and Gemini-source callers (Google /
+// geminiEscalateModel). Behavior matches the former hard-coded path when
+// targetProvider/targetModel are ProviderAnthropic + escalateModel.
+func (s *Service) handleLoopEscalationTo(
+	ctx context.Context,
+	top translate.ToolCallSig,
+	topCount int,
+	distinctRatio float64,
+	window int,
+	installationID uuid.UUID,
+	sessionKey [sessionpin.SessionKeyLen]byte,
+	role string,
+	routedModel string,
+	targetProvider string,
+	targetModel string,
+) {
 	log := observability.FromContext(ctx)
 
 	loopingModel := routedModel
@@ -229,7 +254,7 @@ func (s *Service) handleLoopEscalation(
 		action = loopActionDisabled
 	case userForced:
 		action = loopActionUserForced
-	case loopingModel == escalateModel:
+	case loopingModel == targetModel:
 		action = loopActionAlreadyStrong
 	case holdout:
 		action = loopActionHoldout
@@ -243,7 +268,7 @@ func (s *Service) handleLoopEscalation(
 		"action", action,
 		"escalated", willEscalate,
 		"user_forced", userForced,
-		"escalation_target", escalateModel,
+		"escalation_target", targetModel,
 		"loop_tool", top.Name,
 		"loop_input_hash", top.InputHash,
 		"repeat_count", topCount,
@@ -257,8 +282,8 @@ func (s *Service) handleLoopEscalation(
 	// budget, so recording before the pin lands would permanently block retry
 	// on a failed rescue. On upsert failure, return without a row so the loop re-detects next turn.
 	if willEscalate {
-		// Pin opus for the rest of the session (immutable sticky via
-		// ReasonLoopEscalation).
+		// Pin the escalation target for the rest of the session (immutable
+		// sticky via ReasonLoopEscalation).
 		if s.pinStore == nil || installationID == uuid.Nil {
 			return
 		}
@@ -270,8 +295,8 @@ func (s *Service) handleLoopEscalation(
 			SessionKey:      sessionKey,
 			Role:            role,
 			InstallationID:  installationID,
-			Provider:        providers.ProviderAnthropic,
-			Model:           escalateModel,
+			Provider:        targetProvider,
+			Model:           targetModel,
 			Reason:          translate.ReasonLoopEscalation,
 			TurnCount:       1,
 			PinnedUntil:     time.Now().Add(pinSessionTTL),
@@ -295,7 +320,7 @@ func (s *Service) handleLoopEscalation(
 			Role:             role,
 			LoopingModel:     loopingModel,
 			Action:           action,
-			EscalationTarget: escalateModel,
+			EscalationTarget: targetModel,
 			LoopTool:         top.Name,
 			LoopInputHash:    top.InputHash,
 			RepeatCount:      int32(topCount),
@@ -360,6 +385,8 @@ func (s *Service) handleToolCallLoopBreak(
 	switch env.SourceFormat() {
 	case translate.FormatOpenAI:
 		return writeSyntheticOpenAIResponse(w, env, msg, inputTokens)
+	case translate.FormatGemini:
+		return writeSyntheticGeminiResponse(w, env, msg, inputTokens)
 	default:
 		return writeSyntheticAnthropicResponse(w, env, msg, inputTokens)
 	}

--- a/internal/proxy/loop_detection_internal_test.go
+++ b/internal/proxy/loop_detection_internal_test.go
@@ -5,15 +5,19 @@ import (
 	"crypto/sha256"
 	"encoding/json"
 	"errors"
+	"net/http/httptest"
+	"strings"
 	"sync"
 	"testing"
 
+	"workweave/router/internal/providers"
 	"workweave/router/internal/router/sessionpin"
 	"workweave/router/internal/translate"
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
 )
 
 func TestDetectToolCallLoop_TripsAtMaxRepeats(t *testing.T) {
@@ -400,4 +404,158 @@ func TestHandleLoopEscalation_NilInstallationSkipsHoldout(t *testing.T) {
 
 	assert.Empty(t, events.events, "nil installation cannot record an event row")
 	assert.Empty(t, pins.upserts, "nil installation cannot pin either — but it must not be counted as holdout")
+}
+
+// TestHandleLoopEscalation_AnthropicUnchanged is the Layer-3 regression guard:
+// the existing handleLoopEscalation entrypoint must keep pinning to
+// ProviderAnthropic + escalateModel. Written before the handleLoopEscalationTo
+// extract so a bad refactor surfaces here immediately.
+func TestHandleLoopEscalation_AnthropicUnchanged(t *testing.T) {
+	pins := newStubPinStore()
+	events := &recordingLoopStore{}
+	svc := newLoopEscalationSvc(pins, events)
+
+	svc.handleLoopEscalation(context.Background(), loopTestSig, 12, 0.2, 30, uuid.New(), loopTestKey(12), "default", "claude-haiku-4-5")
+
+	require.Len(t, pins.upserts, 1)
+	assert.Equal(t, providers.ProviderAnthropic, pins.upserts[0].Provider,
+		"handleLoopEscalation must keep pinning Anthropic — Gemini escalation uses handleLoopEscalationTo")
+	assert.Equal(t, escalateModel, pins.upserts[0].Model)
+	assert.Equal(t, translate.ReasonLoopEscalation, pins.upserts[0].Reason)
+
+	require.Len(t, events.events, 1)
+	assert.Equal(t, escalateModel, events.events[0].EscalationTarget)
+	assert.Equal(t, loopActionEscalated, events.events[0].Action)
+}
+
+func TestWriteSyntheticGeminiResponse_NonStreaming(t *testing.T) {
+	const text = "loop break message"
+	const inputTokens = 42
+	env, err := translate.ParseGemini([]byte(`{"contents":[{"role":"user","parts":[{"text":"hi"}]}],"stream":false}`))
+	require.NoError(t, err)
+
+	rec := httptest.NewRecorder()
+	require.NoError(t, writeSyntheticGeminiResponse(rec, env, text, inputTokens))
+
+	assert.Equal(t, "application/json", rec.Header().Get("Content-Type"))
+	body := rec.Body.Bytes()
+	assert.Equal(t, text, gjson.GetBytes(body, "candidates.0.content.parts.0.text").String())
+	assert.Equal(t, "model", gjson.GetBytes(body, "candidates.0.content.role").String())
+	assert.Equal(t, "STOP", gjson.GetBytes(body, "candidates.0.finishReason").String())
+	outTokens := len(text) / 4
+	assert.Equal(t, int64(inputTokens), gjson.GetBytes(body, "usageMetadata.promptTokenCount").Int())
+	assert.Equal(t, int64(outTokens), gjson.GetBytes(body, "usageMetadata.candidatesTokenCount").Int())
+	assert.Equal(t, int64(inputTokens+outTokens), gjson.GetBytes(body, "usageMetadata.totalTokenCount").Int())
+}
+
+func TestWriteSyntheticGeminiResponse_Streaming(t *testing.T) {
+	const text = "stream loop break"
+	const inputTokens = 17
+	env, err := translate.ParseGemini([]byte(`{"contents":[{"role":"user","parts":[{"text":"hi"}]}],"stream":true}`))
+	require.NoError(t, err)
+
+	rec := httptest.NewRecorder()
+	require.NoError(t, writeSyntheticGeminiResponse(rec, env, text, inputTokens))
+
+	assert.Equal(t, "text/event-stream", rec.Header().Get("Content-Type"))
+	frames := geminiSSEDataFrames(t, rec.Body.String())
+	require.Len(t, frames, 2, "streaming synthetic Gemini response must be exactly two SSE data frames")
+
+	assert.Equal(t, text, gjson.Get(frames[0], "candidates.0.content.parts.0.text").String())
+	assert.Equal(t, "model", gjson.Get(frames[0], "candidates.0.content.role").String())
+	assert.Equal(t, "", gjson.Get(frames[0], "candidates.0.finishReason").String(),
+		"first frame is content-only; finishReason belongs on the second frame")
+
+	assert.Equal(t, "STOP", gjson.Get(frames[1], "candidates.0.finishReason").String())
+	parts := gjson.Get(frames[1], "candidates.0.content.parts")
+	require.True(t, parts.Exists() && parts.IsArray())
+	assert.Equal(t, 0, len(parts.Array()), "second frame must carry empty parts")
+	outTokens := len(text) / 4
+	assert.Equal(t, int64(inputTokens), gjson.Get(frames[1], "usageMetadata.promptTokenCount").Int())
+	assert.Equal(t, int64(outTokens), gjson.Get(frames[1], "usageMetadata.candidatesTokenCount").Int())
+	assert.Equal(t, int64(inputTokens+outTokens), gjson.Get(frames[1], "usageMetadata.totalTokenCount").Int())
+}
+
+func TestHandleToolCallLoopBreak_Gemini(t *testing.T) {
+	// Today handleToolCallLoopBreak falls through to the Anthropic writer for
+	// any non-OpenAI format. After Layer 3 it must emit a Gemini-native body.
+	body, err := json.Marshal(map[string]any{
+		"contents": []any{
+			map[string]any{"role": "user", "parts": []any{
+				map[string]any{"text": "do stuff"},
+			}},
+		},
+		"stream": false,
+	})
+	require.NoError(t, err)
+	env, err := translate.ParseGemini(body)
+	require.NoError(t, err)
+
+	pins := newStubPinStore()
+	svc := newLoopEscalationSvc(pins, nil)
+	rec := httptest.NewRecorder()
+	err = svc.handleToolCallLoopBreak(
+		context.Background(), rec, env, loopTestSig, 5,
+		uuid.New(), loopTestKey(13), "default",
+		"gemini-2.5-flash", providers.ProviderGoogle, 99,
+	)
+	require.NoError(t, err)
+
+	assert.Equal(t, "application/json", rec.Header().Get("Content-Type"),
+		"Gemini loop break must not use the Anthropic/OpenAI content type")
+	resp := rec.Body.Bytes()
+	require.True(t, gjson.GetBytes(resp, "candidates").Exists(),
+		"Gemini loop break must write candidates[], not an Anthropic message envelope; got %s", rec.Body.String())
+	assert.Equal(t, "STOP", gjson.GetBytes(resp, "candidates.0.finishReason").String())
+	assert.Equal(t, "model", gjson.GetBytes(resp, "candidates.0.content.role").String())
+	text := gjson.GetBytes(resp, "candidates.0.content.parts.0.text").String()
+	assert.Contains(t, text, "Read", "break message should name the looping tool")
+	assert.Contains(t, text, "5", "break message should include the repeat count")
+	assert.False(t, gjson.GetBytes(resp, "type").Exists(),
+		"must not be an Anthropic synthetic message (type=message)")
+	assert.False(t, gjson.GetBytes(resp, "choices").Exists(),
+		"must not be an OpenAI synthetic chat.completion")
+}
+
+func TestHandleLoopEscalationTo_PinsGoogleModel(t *testing.T) {
+	pins := newStubPinStore()
+	events := &recordingLoopStore{}
+	svc := newLoopEscalationSvc(pins, events)
+
+	svc.handleLoopEscalationTo(
+		context.Background(), loopTestSig, 12, 0.2, 30,
+		uuid.New(), loopTestKey(14), "default", "gemini-2.5-flash",
+		providers.ProviderGoogle, geminiEscalateModel,
+	)
+
+	require.Len(t, pins.upserts, 1, "Gemini escalation must write a pin")
+	assert.Equal(t, providers.ProviderGoogle, pins.upserts[0].Provider)
+	assert.Equal(t, geminiEscalateModel, pins.upserts[0].Model)
+	assert.Equal(t, "gemini-3.1-pro-preview", pins.upserts[0].Model)
+	assert.Equal(t, translate.ReasonLoopEscalation, pins.upserts[0].Reason)
+
+	require.Len(t, events.events, 1)
+	assert.Equal(t, loopActionEscalated, events.events[0].Action)
+	assert.Equal(t, geminiEscalateModel, events.events[0].EscalationTarget)
+	assert.Equal(t, "gemini-2.5-flash", events.events[0].LoopingModel)
+}
+
+// geminiSSEDataFrames splits an SSE body into the JSON payloads of each
+// `data:` frame (blank-line delimited), skipping comment/event-only frames.
+func geminiSSEDataFrames(t *testing.T, body string) []string {
+	t.Helper()
+	var frames []string
+	for _, block := range strings.Split(body, "\n\n") {
+		block = strings.TrimSpace(block)
+		if block == "" {
+			continue
+		}
+		for _, line := range strings.Split(block, "\n") {
+			if strings.HasPrefix(line, "data: ") {
+				frames = append(frames, strings.TrimPrefix(line, "data: "))
+				break
+			}
+		}
+	}
+	return frames
 }

--- a/internal/translate/loop_detection.go
+++ b/internal/translate/loop_detection.go
@@ -30,6 +30,8 @@ func (e *RequestEnvelope) AssistantToolCallArgsPreview(offset, maxLen int) []str
 		return assistantToolCallArgsPreview(anthropicAssistantToolCallEntries(e.body), offset, maxLen)
 	case FormatOpenAI:
 		return assistantToolCallArgsPreview(openAIAssistantToolCallEntries(e.body), offset, maxLen)
+	case FormatGemini:
+		return assistantToolCallArgsPreview(geminiAssistantToolCallEntries(e.body), offset, maxLen)
 	default:
 		return nil
 	}
@@ -54,14 +56,16 @@ func assistantToolCallArgsPreview(entries []assistantToolCallEntry, offset, maxL
 // the request body (message order, then content-block order). Used by the
 // loop detector: some OSS models (notably qwen3) fail to recognize task
 // completion and alternate/repeat calls indefinitely, which counting
-// signature occurrences in a recent window catches. Returns nil for
-// Gemini-format requests (unsupported) or no assistant tool calls.
+// signature occurrences in a recent window catches. Returns nil when the
+// body has no assistant tool calls.
 func (e *RequestEnvelope) AssistantToolCallSignatures() []ToolCallSig {
 	switch e.format {
 	case FormatAnthropic:
 		return anthropicAssistantToolCallSigs(e.body)
 	case FormatOpenAI:
 		return openAIAssistantToolCallSigs(e.body)
+	case FormatGemini:
+		return geminiAssistantToolCallSigs(e.body)
 	default:
 		return nil
 	}
@@ -70,9 +74,9 @@ func (e *RequestEnvelope) AssistantToolCallSignatures() []ToolCallSig {
 // assistantToolCallEntry is one filtered assistant tool invocation: a callee
 // name plus its raw argument JSON. AssistantToolCallSignatures and
 // AssistantToolCallArgsPreview both derive from the same
-// {anthropic,openAI}AssistantToolCallEntries walk, so they can never diverge
-// on which entries survive filtering — an index into one is always valid
-// against the other.
+// {anthropic,openAI,gemini}AssistantToolCallEntries walk, so they can never
+// diverge on which entries survive filtering — an index into one is always
+// valid against the other.
 type assistantToolCallEntry struct {
 	Name     string
 	InputRaw string
@@ -175,6 +179,81 @@ func anthropicAssistantToolCallSigs(body []byte) []ToolCallSig {
 
 func openAIAssistantToolCallSigs(body []byte) []ToolCallSig {
 	return sigsFromEntries(openAIAssistantToolCallEntries(body))
+}
+
+func geminiAssistantToolCallEntries(body []byte) []assistantToolCallEntry {
+	contents := gjson.GetBytes(body, "contents")
+	if !contents.IsArray() {
+		return nil
+	}
+	var entries []assistantToolCallEntry
+	contents.ForEach(func(_, msg gjson.Result) bool {
+		role := msg.Get("role").String()
+		// See anthropicAssistantToolCallEntries: a genuine user-typed prompt
+		// resets the window; functionResponse-only turns and Claude Code
+		// injected wrappers do not.
+		if role == "user" && geminiUserPromptTextForLoop(msg.Get("parts")) != "" {
+			entries = nil
+			return true
+		}
+		if role != "model" {
+			return true
+		}
+		parts := msg.Get("parts")
+		if !parts.IsArray() {
+			return true
+		}
+		parts.ForEach(func(_, part gjson.Result) bool {
+			call := part.Get("functionCall")
+			if !call.Exists() {
+				call = part.Get("function_call")
+			}
+			if !call.Exists() {
+				return true
+			}
+			name := call.Get("name").String()
+			if name == "" {
+				return true
+			}
+			args := call.Get("args")
+			if !args.Exists() {
+				args = call.Get("arguments")
+			}
+			if !isMeaningfulInput(args) {
+				return true
+			}
+			entries = append(entries, assistantToolCallEntry{Name: name, InputRaw: args.Raw})
+			return true
+		})
+		return true
+	})
+	return entries
+}
+
+// geminiUserPromptTextForLoop returns concatenated non-injected text parts from
+// a Gemini contents[] entry. functionResponse-only turns and Claude Code
+// wrapper tags yield "" so they do not reset the loop-detection window.
+func geminiUserPromptTextForLoop(parts gjson.Result) string {
+	if !parts.IsArray() {
+		return ""
+	}
+	var b strings.Builder
+	parts.ForEach(func(_, part gjson.Result) bool {
+		text := part.Get("text").String()
+		if text == "" || isClaudeCodeInjectedBlock(text) {
+			return true
+		}
+		if b.Len() > 0 {
+			b.WriteByte('\n')
+		}
+		b.WriteString(text)
+		return true
+	})
+	return b.String()
+}
+
+func geminiAssistantToolCallSigs(body []byte) []ToolCallSig {
+	return sigsFromEntries(geminiAssistantToolCallEntries(body))
 }
 
 func sigsFromEntries(entries []assistantToolCallEntry) []ToolCallSig {

--- a/internal/translate/loop_detection_test.go
+++ b/internal/translate/loop_detection_test.go
@@ -419,3 +419,246 @@ func TestAssistantToolCallSignatures_UserTextResetsLoop_OpenAI(t *testing.T) {
 	require.Len(t, sigs, 1)
 	assert.Equal(t, "read", sigs[0].Name)
 }
+
+func TestAssistantToolCallSignatures_Gemini(t *testing.T) {
+	body := mustMarshalJSON(t, map[string]any{
+		"contents": []any{
+			map[string]any{"role": "user", "parts": []any{
+				map[string]any{"text": "do stuff"},
+			}},
+			map[string]any{"role": "model", "parts": []any{
+				map[string]any{"functionCall": map[string]any{
+					"name": "ls",
+					"args": map[string]any{"path": "/tmp"},
+				}},
+			}},
+			map[string]any{"role": "user", "parts": []any{
+				map[string]any{"functionResponse": map[string]any{
+					"name": "ls", "response": map[string]any{"result": "a"},
+				}},
+			}},
+			map[string]any{"role": "model", "parts": []any{
+				map[string]any{"functionCall": map[string]any{
+					"name": "ls",
+					"args": map[string]any{"path": "/tmp"},
+				}},
+				map[string]any{"text": "ignore me"},
+				map[string]any{"functionCall": map[string]any{
+					"name": "read",
+					"args": map[string]any{"path": "/etc/hosts"},
+				}},
+			}},
+		},
+	})
+	env, err := translate.ParseGemini(body)
+	require.NoError(t, err)
+
+	sigs := env.AssistantToolCallSignatures()
+	require.Len(t, sigs, 3)
+	assert.Equal(t, "ls", sigs[0].Name)
+	assert.Equal(t, "ls", sigs[1].Name)
+	assert.Equal(t, "read", sigs[2].Name)
+	assert.Equal(t, sigs[0].InputHash, sigs[1].InputHash, "identical args must produce identical hash")
+	assert.NotEqual(t, sigs[1].InputHash, sigs[2].InputHash, "different tool args must produce different hash")
+}
+
+func TestAssistantToolCallSignatures_Gemini_UserTextResetsLoop(t *testing.T) {
+	// Genuine user text (not functionResponse-only) resets the window, same as
+	// Anthropic/OpenAI. Signatures before the reset are excluded.
+	body := mustMarshalJSON(t, map[string]any{
+		"contents": []any{
+			map[string]any{"role": "user", "parts": []any{
+				map[string]any{"text": "do stuff"},
+			}},
+			map[string]any{"role": "model", "parts": []any{
+				map[string]any{"functionCall": map[string]any{
+					"name": "ls",
+					"args": map[string]any{"path": "/tmp"},
+				}},
+			}},
+			map[string]any{"role": "user", "parts": []any{
+				map[string]any{"functionResponse": map[string]any{
+					"name": "ls", "response": map[string]any{"result": "a"},
+				}},
+				map[string]any{"text": "continue please"}, // resets
+			}},
+			map[string]any{"role": "model", "parts": []any{
+				map[string]any{"functionCall": map[string]any{
+					"name": "read",
+					"args": map[string]any{"path": "/etc/hosts"},
+				}},
+			}},
+		},
+	})
+	env, err := translate.ParseGemini(body)
+	require.NoError(t, err)
+
+	sigs := env.AssistantToolCallSignatures()
+	require.Len(t, sigs, 1) // Only "read"; "ls" was before the user text
+	assert.Equal(t, "read", sigs[0].Name)
+}
+
+func TestAssistantToolCallSignatures_Gemini_InjectedTextDoesNotResetLoop(t *testing.T) {
+	// Claude Code's <system-reminder> (and siblings matched by
+	// isClaudeCodeInjectedBlock) must NOT reset the Gemini window — same
+	// parity as Anthropic. Six identical calls with an injected reminder on
+	// every functionResponse turn should all survive.
+	contents := []any{
+		map[string]any{"role": "user", "parts": []any{
+			map[string]any{"text": "do stuff"},
+		}},
+	}
+	for i := 0; i < 6; i++ {
+		contents = append(contents,
+			map[string]any{"role": "model", "parts": []any{
+				map[string]any{"functionCall": map[string]any{
+					"name": "ls",
+					"args": map[string]any{"path": "/tmp"},
+				}},
+			}},
+			map[string]any{"role": "user", "parts": []any{
+				map[string]any{"functionResponse": map[string]any{
+					"name": "ls", "response": map[string]any{"result": "a"},
+				}},
+				map[string]any{"text": "<system-reminder>be helpful</system-reminder>"},
+			}},
+		)
+	}
+	body := mustMarshalJSON(t, map[string]any{"contents": contents})
+	env, err := translate.ParseGemini(body)
+	require.NoError(t, err)
+
+	sigs := env.AssistantToolCallSignatures()
+	require.Len(t, sigs, 6, "injected reminder blocks must not reset the loop window")
+}
+
+func TestAssistantToolCallSignatures_Gemini_SkipsEmptyInputEntries(t *testing.T) {
+	// Mirror TestAssistantToolCallSignatures_SkipsEmptyInputEntries: empty
+	// args objects and null args are stream-incomplete artifacts and must
+	// not count toward loop detection.
+	body := mustMarshalJSON(t, map[string]any{
+		"contents": []any{
+			map[string]any{"role": "model", "parts": []any{
+				map[string]any{"functionCall": map[string]any{
+					"name": "Read",
+					"args": map[string]any{"file_path": "/a"},
+				}},
+				map[string]any{"functionCall": map[string]any{
+					"name": "Read",
+					"args": map[string]any{},
+				}},
+				map[string]any{"functionCall": map[string]any{
+					"name": "Read",
+					"args": map[string]any{"file_path": "/b"},
+				}},
+				map[string]any{"functionCall": map[string]any{
+					"name": "Read",
+					"args": nil,
+				}},
+				map[string]any{"functionCall": map[string]any{
+					"name": "Read",
+					"args": map[string]any{"file_path": "/c"},
+				}},
+				map[string]any{"functionCall": map[string]any{
+					"name": "Read",
+					"args": map[string]any{},
+				}},
+				map[string]any{"functionCall": map[string]any{
+					"name": "Read",
+					// missing args entirely
+				}},
+			}},
+		},
+	})
+	env, err := translate.ParseGemini(body)
+	require.NoError(t, err)
+
+	sigs := env.AssistantToolCallSignatures()
+	require.Len(t, sigs, 3, "empty/null/missing-args functionCall entries must be filtered")
+	assert.NotEqual(t, sigs[0].InputHash, sigs[1].InputHash)
+	assert.NotEqual(t, sigs[1].InputHash, sigs[2].InputHash)
+}
+
+func TestAssistantToolCallSignatures_Gemini_CamelAndSnakeCase(t *testing.T) {
+	// geminiToolCalls accepts both spellings; signature extraction must too,
+	// and produce identical Name + InputHash for equivalent payloads.
+	camel := mustMarshalJSON(t, map[string]any{
+		"contents": []any{
+			map[string]any{"role": "model", "parts": []any{
+				map[string]any{"functionCall": map[string]any{
+					"name": "bash",
+					"args": map[string]any{"command": "ls /tmp"},
+				}},
+			}},
+		},
+	})
+	snake := mustMarshalJSON(t, map[string]any{
+		"contents": []any{
+			map[string]any{"role": "model", "parts": []any{
+				map[string]any{"function_call": map[string]any{
+					"name":      "bash",
+					"arguments": map[string]any{"command": "ls /tmp"},
+				}},
+			}},
+		},
+	})
+
+	envCamel, err := translate.ParseGemini(camel)
+	require.NoError(t, err)
+	envSnake, err := translate.ParseGemini(snake)
+	require.NoError(t, err)
+
+	sigsCamel := envCamel.AssistantToolCallSignatures()
+	sigsSnake := envSnake.AssistantToolCallSignatures()
+	require.Len(t, sigsCamel, 1)
+	require.Len(t, sigsSnake, 1)
+	assert.Equal(t, sigsCamel[0].Name, sigsSnake[0].Name)
+	assert.Equal(t, sigsCamel[0].InputHash, sigsSnake[0].InputHash,
+		"camelCase functionCall/args and snake_case function_call/arguments must hash identically")
+}
+
+func TestAssistantToolCallArgsPreview_Gemini(t *testing.T) {
+	// Window-dump preview must follow the same Name:rawJSON shape as
+	// Anthropic/OpenAI, filtered identically to AssistantToolCallSignatures
+	// (empty args dropped; offset indexes the filtered sequence).
+	body := mustMarshalJSON(t, map[string]any{
+		"contents": []any{
+			map[string]any{"role": "model", "parts": []any{
+				map[string]any{"functionCall": map[string]any{
+					"name": "Setup",
+					"args": map[string]any{"step": 0},
+				}},
+				map[string]any{"functionCall": map[string]any{
+					"name": "Read",
+					"args": map[string]any{},
+				}},
+				map[string]any{"functionCall": map[string]any{
+					"name": "Loop",
+					"args": map[string]any{"n": 1},
+				}},
+				map[string]any{"functionCall": map[string]any{
+					"name": "Loop",
+					"args": map[string]any{"n": 1},
+				}},
+			}},
+		},
+	})
+	env, err := translate.ParseGemini(body)
+	require.NoError(t, err)
+
+	sigs := env.AssistantToolCallSignatures()
+	require.Len(t, sigs, 3, "empty-args Read must be filtered from the signature sequence")
+
+	preview := env.AssistantToolCallArgsPreview(0, 200)
+	require.Len(t, preview, len(sigs),
+		"preview must contain exactly as many entries as the aligned signature sequence")
+	for i, s := range sigs {
+		require.True(t, strings.HasPrefix(preview[i], s.Name+":"),
+			"preview[%d] = %q must describe the same tool call as sigs[%d] = %q", i, preview[i], i, s.Name)
+	}
+	require.Equal(t, []string{
+		`Setup:{"step":0}`,
+		`Loop:{"n":1}`,
+		`Loop:{"n":1}`,
+	}, preview)
+}


### PR DESCRIPTION
**Fixes #731**
 
**Note on branch base:** this branch was cut from `main` before PR #732
(Gemini sticky-pin hooks — force-model header, two-strike eviction) merged.
`gemini.go` here does not yet include those hooks. This branch will need a
rebase onto `main` once #732 merges, before this is ready to merge itself.
Opening now rather than blocking finished, verified work on an unrelated
PR's review timeline.
 
---
 
## Summary
 
Tool-call loop detection — the mechanism that protects Anthropic and OpenAI
sessions from a model repeatedly issuing the same tool call, or cycling
through a small set of calls without progress — was completely absent on
the Gemini surface, at three independent layers:
 
1. **No call sites.** `ProxyGeminiGenerateContent` never called
   `detectToolCallLoop`, `detectCyclicToolCallLoop`, `handleLoopEscalation`,
   or `handleToolCallLoopBreak`.
2. **The detector was structurally blind to Gemini's wire format.**
   `AssistantToolCallSignatures()` returned `nil` for `FormatGemini` — even
   with call sites added, there was nothing to count.
3. **The response-writing layer couldn't safely serve a Gemini-native
   break.** `handleToolCallLoopBreak` only wrote Anthropic/OpenAI synthetic
   responses, and `handleLoopEscalation` hard-pinned escalation to
   `claude-opus-4-8` — which would immediately 501 the next turn on a
   Gemini-source session (`gemini.go:170` rejects any non-Google decision
   for a Gemini-source request).
This PR closes all three layers. Full static + live evidence of the
original gap is documented in #731.
 
---
 
## Why three layers, four commits
 
A partial fix at any single layer doesn't work:
 
- Adding call sites (Layer 1) without signature extraction (Layer 2) would
  call the detector, but it would always see zero tool calls and never
  fire.
- Adding Layers 1+2 without provider-aware escalation (Layer 3) would
  correctly detect a cyclic loop, then hard-pin the session to
  `claude-opus-4-8` — 501-ing the very next Gemini-source turn.
So this landed as four commits, each independently reviewed and tested
before the next began:
 
| # | Commit | Layer | What |
|---|---|---|---|
| 1 | `test(translate): add failing tests for Gemini tool-call signature extraction` | 2 (tests) | 6 failing tests for signature extraction |
| 2 | `feat(translate): extract tool-call signatures from Gemini requests` | 2 (impl) | `geminiAssistantToolCallEntries`/`Sigs`, wired into both `AssistantToolCallSignatures` and `AssistantToolCallArgsPreview` |
| 3 | `feat(proxy): add Gemini synthetic loop-break response and provider-aware escalation` | 3 (tests + impl) | `writeSyntheticGeminiResponse`, `handleLoopEscalationTo` extraction, `geminiEscalateModel` |
| 4 | `feat(proxy): wire loop detection into Gemini surface` | 1 (tests + impl) | The actual call sites in `gemini.go` |
 
Layer 2 alone got a full test-then-implement split because the fixture
design (Claude-Code-injected-block parity, camelCase/snake_case
equivalence) had enough surface area to warrant it. Layers 3 and 4 bundled
tests+implementation per commit rather than splitting further — the tests
were still written and confirmed failing before implementation began in
both cases, just landed together.
 
---
 
## Layer 2 — Gemini tool-call signature extraction
 
`internal/translate/loop_detection.go`
 
Added `geminiAssistantToolCallEntries` / `geminiAssistantToolCallSigs`,
mirroring `anthropicAssistantToolCallEntries`'s structure:
 
- Walks `contents[]` in order.
- A genuine user-typed text part (checked via a new
  `geminiUserPromptTextForLoop` helper) resets the detection window —
  same semantics as Anthropic/OpenAI.
- **Design decision, confirmed in review before implementation:**
  Claude-Code-injected wrapper tags (`<system-reminder>`,
  `<command-name>`, etc., via the existing `isClaudeCodeInjectedBlock`)
  do **not** reset the window, for parity with Anthropic/OpenAI. A
  `functionResponse`-only turn also does not reset.
- `functionCall`/`function_call` dual-key resolution, `args`/`arguments`
  dual-key resolution, empty/meaningless input filtered via the existing
  shared `isMeaningfulInput` check (same helper Anthropic/OpenAI use — no
  new filtering logic invented).
- Wired into both `AssistantToolCallSignatures` and
  `AssistantToolCallArgsPreview`'s format switches as a `FormatGemini` case.
**Known, accepted, intentional side effect:** any *existing* Gemini call
site of `AssistantToolCallSignatures()` — turnloop prefix-trim counts,
`logInboundToolTraffic` diagnostics — now receives real signatures instead
of `nil`. Confirmed via full repo test suite that nothing hard-asserted
the previous empty/nil behavior.
 
**Explicitly out of scope, flagged for follow-up, not fixed here:**
`editToolNames` (used by the cyclic detector to recognize genuine
progress) still only contains Claude Code's Anthropic-surface tool names
(`Edit`, `Write`, etc.). Gemini agents may use different tool names for
equivalent operations, which could make cyclic-loop false-negative
avoidance weaker on Gemini until that map is generalized. Not blocking
this PR; noted as a known limitation.
 
### Tests (`internal/translate/loop_detection_test.go`, 6 new, existing untouched)
 
| Test | Covers |
|---|---|
| `TestAssistantToolCallSignatures_Gemini` | Basic extraction: 3 `functionCall`s, name + hash equality/inequality |
| `..._Gemini_UserTextResetsLoop` | Genuine user text clears prior signatures |
| `..._Gemini_InjectedTextDoesNotResetLoop` | 6 identical calls survive a `<system-reminder>` on every turn — confirmed the fixture text matches the real `claudeCodeInjectedBlockPrefixes` list, not a plausible-looking guess |
| `..._Gemini_SkipsEmptyInputEntries` | `{}` / `null` / missing `args` filtered |
| `..._Gemini_CamelAndSnakeCase` | `functionCall`/`args` vs `function_call`/`arguments` produce identical hashes |
| `TestAssistantToolCallArgsPreview_Gemini` | Window-dump preview format matches Anthropic/OpenAI shape |
 
All 6 failed with empty results before implementation (`"[]" should have
N item(s), but has 0`), confirmed passing after.
 
---
 
## Layer 3 — Gemini synthetic response + provider-aware escalation
 
`internal/proxy/force_model.go`, `internal/proxy/loop_detection.go`
 
### Synthetic Gemini response writer
 
New `writeSyntheticGeminiResponse` (+ `writeSyntheticGeminiJSON` /
`writeSyntheticGeminiSSE` helpers), alongside the existing Anthropic/OpenAI
synthetic writers:
 
- **Non-streaming:** `candidates[0].content.{role:"model", parts:[{text}]}`,
  `finishReason:"STOP"`, `usageMetadata` with prompt/candidates/total token
  counts. `Content-Type: application/json`.
- **Streaming:** two SSE `data:` frames — first carries content with no
  `finishReason` (matches how a real Gemini stream separates content chunks
  from the terminal chunk), second carries empty `parts`, `finishReason:"STOP"`,
  and `usageMetadata`. `Content-Type: text/event-stream`. Reuses the
  existing `openAISSEData` frame-wrapping helper (SSE wire framing itself
  isn't format-specific; only the JSON payload inside each frame is).
`handleToolCallLoopBreak` gained an additive `case FormatGemini` calling
the new writer. `case FormatOpenAI` and the Anthropic `default` case are
byte-for-byte unchanged.
 
### Provider-aware escalation
 
Extracted `handleLoopEscalationTo(ctx, ..., targetProvider, targetModel string)`
as the parameterized core of what was previously `handleLoopEscalation`'s
hard-coded body. `handleLoopEscalation` is now a one-line wrapper:
 
```go
func (s *Service) handleLoopEscalation(ctx, top, topCount, distinctRatio, window, installationID, sessionKey, role, routedModel) {
    s.handleLoopEscalationTo(ctx, top, topCount, distinctRatio, window, installationID, sessionKey, role, routedModel,
        providers.ProviderAnthropic, escalateModel)
}
```
 
**Its signature and every existing caller in `service.go` are unchanged.**
Every hard-coded `escalateModel`/`providers.ProviderAnthropic` reference
inside the extracted core became a parameter — no other logic in the
function changed (the `willEscalate`/`action` branching, the
holdout/userForced checks, the pin-write-before-event-record ordering are
all untouched).
 
New constant: `geminiEscalateModel = "gemini-3.1-pro-preview"`.
 
**Design decision, confirmed in review before implementation:** the
Gemini escalation target is the newest TierHigh Google model in the
catalog, mirroring the intent of hard-pinning to `claude-opus-4-8` on the
other two surfaces — "rescue onto the strongest current same-family
model." The same-format guard at `gemini.go:170` requires the target to be
Google regardless.
 
### Tests (`internal/proxy/loop_detection_internal_test.go`, 5 new)
 
| Test | Covers |
|---|---|
| `TestWriteSyntheticGeminiResponse_NonStreaming` | JSON shape, Content-Type |
| `TestWriteSyntheticGeminiResponse_Streaming` | Two-frame SSE shape, Content-Type |
| `TestHandleToolCallLoopBreak_Gemini` | Gemini env routes to the new writer, not Anthropic/OpenAI's |
| `TestHandleLoopEscalationTo_PinsGoogleModel` | Escalation with `targetProvider=Google` pins `gemini-3.1-pro-preview` correctly |
| `TestHandleLoopEscalation_AnthropicUnchanged` | **Regression guard**, written and confirmed passing *before* the extraction refactor touched any shared logic, as a trustworthy baseline — confirms `handleLoopEscalation`'s existing Anthropic/`claude-opus-4-8` behavior is byte-for-byte unchanged after the refactor |
 
All passed after implementation, including the regression guard both
before (baseline) and after (confirms no drift) the refactor.
 
---
 
## Layer 1 — call sites in `ProxyGeminiGenerateContent`
 
`internal/proxy/gemini.go`
 
Added the pre-routing loop checks, inserted after `sessionKey` binding and
before `logInboundRequestDiagnostics`, mirroring their placement in
`ProxyMessages` (`service.go:2007-2017`) exactly:
 
```go
escalatedLoop := false
if cyc, csig, ccount, cratio, cwin := detectCyclicToolCallLoop(env); cyc {
    loopRole := roleForTier(catalog.TierFor(feats.Model))
    s.handleLoopEscalationTo(ctx, csig, ccount, cratio, cwin, installationID, sessionKey, loopRole, feats.Model,
        providers.ProviderGoogle, geminiEscalateModel)
    escalatedLoop = true
}
if !escalatedLoop {
    if loop, sig, count := detectToolCallLoop(env); loop {
        loopRole := roleForTier(catalog.TierFor(feats.Model))
        return s.handleToolCallLoopBreak(ctx, w, env, sig, count, installationID, sessionKey, loopRole,
            feats.Model, providers.ProviderGoogle, feats.Tokens)
    }
}
```
 
Cyclic escalation pins and **falls through** to normal routing (the pinned
model serves the current turn). Tight-loop break **returns early** with
the synthetic response, before any upstream dispatch — same control flow
as the Anthropic/OpenAI surfaces.
 
This is the only change to `gemini.go` in this commit.
 
### Tests (`internal/proxy/gemini_loop_detection_test.go`, 3 new)
 
| Test | Covers |
|---|---|
| `TestProxyGeminiGenerateContent_ToolCallLoopBreak_Fires` | 5 identical `bash`/`ls /tmp` pairs → synthetic response returned, fake upstream provider never called (`proxyBodies` empty) |
| `TestProxyGeminiGenerateContent_CyclicLoopEscalation_PinsGoogleModel` | 30 `Read`s over 5 distinct files (ratio ≈0.17, no `Edit`) → pin written with `Provider=Google, Model=geminiEscalateModel`, AND the fake provider **was** called (escalation continues the turn, doesn't short-circuit it) |
| `TestProxyGeminiGenerateContent_NoLoop_RoutesNormally` | **Regression guard**, confirmed passing *before* Layer 1 landed (baseline) and after (no drift) — normal traffic routes with exactly one upstream call, no escalation pin |
 
The cyclic fixture (30 reads / 5 files, no edits) was deliberately
constructed so that no path repeats more than twice within any 10-wide
window — high enough to trip the cyclic detector's distinct-ratio
threshold without also accidentally satisfying the tight-loop detector's
repeat-count threshold first. This ensures the test exercises the cyclic
path specifically, not an ambiguous overlap of both.
 
All three failed appropriately before Layer 1 landed (tests 1–2: no
call sites, upstream ran / no pin written; test 3: passed as baseline)
and all three pass now.
 
---
 
## Full suite (after all four commits)
 
```
go build ./...                              PASS
go vet ./...                                 PASS
go test ./internal/translate/... -count=1    PASS
go test ./internal/proxy/... -count=1        PASS
go test ./... -count=1                       PASS
go test -race ./internal/proxy/... -count=1  1 unrelated pre-existing failure (see below)
make check                                   PASS
```
 
**On the race failure:** `TestFireTelemetryRecoversFromPanic` fails under
`-race` — the same pre-existing, unrelated race already documented and
confirmed present on a clean `main` (independent of this branch's changes)
in PR #732. Not touched by, or related to, this PR's diff.
 
---
 
## Live verification
 
Rebuilt and ran against the local stack with a real Google API key
fixture (fake key — upstream calls return genuine Google-side rejections,
not router-side short-circuits).
 
### Tight loop — two variants, deliberately
 
**3a. Verbatim original bug-confirmation repro** (5 identical
`bash`/`ls /tmp` pairs + a trailing `"ls again"` user message — the exact
body used to originally *prove* the bug in #731):
 
Result: **does not break.** Full lifecycle completes normally,
`X-Router-Decision: cluster:...`, real upstream `404`.
 
This is correct, not a regression: the trailing `"ls again"` is genuine
user text, which resets the detection window per Layer 2's design (same
behavior Anthropic/OpenAI have always had — a user actively typing
something new means the session isn't stuck, regardless of what came
before). The original unit-test fixtures end on a `functionResponse`, not
user text, which is why they correctly do trigger the break.
 
**3b. Same pattern, no trailing user text** (matches the unit test
fixture shape exactly):
 
Result: **breaks correctly.** HTTP 200, synthetic Gemini JSON body
(`candidates[0].content.parts[0].text`: *"Tool-call loop detected: `bash`
was called 5 times..."*, `finishReason: STOP`). Log:
`"ProxyGeminiGenerateContent tool-call loop detected"` →
`"Tool-call loop detected; breaking turn"`,
`decision_source:synthetic_tool_call_loop_break`. No upstream dispatch —
no `ProxyGeminiGenerateContent complete` with a real `upstream_status`.
 
### Cyclic loop — never exercised live before this session, only unit-tested
 
30 `Read` calls over 5 distinct file paths (same shape as the committed
test fixture), sent as a real request:
 
- `X-Router-Decision: loop_escalation`, `X-Router-Model: gemini-3.1-pro-preview`,
  `X-Router-Provider: google`
- Log: `router.loop_escalation` with `action:escalated`,
  `escalation_target:gemini-3.1-pro-preview`, `loop_tool:Read`,
  `distinct_ratio:0.166...`, `window_size:30` → `turnloop pin lookup hit`
  → `ProxyGeminiGenerateContent complete` with `decision_reason:loop_escalation`,
  `sticky_hit:true`, real `upstream_status:404` (confirms the turn
  **continued** to a genuine upstream call after pinning, per design —
  not a hard break)
- Postgres `router.session_pins`: real row with `pinned_provider=google`,
  `pinned_model=gemini-3.1-pro-preview`, `decision_reason=loop_escalation`
- Postgres `router.loop_escalation_events`: 1 row, `action=escalated`,
  `escalation_target=gemini-3.1-pro-preview`, `loop_tool=Read`
### Regression check
 
One ordinary Gemini request (no repeated tool calls) through the same
mechanics: normal cluster routing, real upstream `404`, zero loop or
escalation log activity, `pin_tier:miss` — confirms the fix doesn't
over-fire on legitimate traffic.
 
### Environment left as-is
 
Google BYOK fixture, the resulting escalation/tight-break/normal pin
rows, and captured logs under `/tmp/loop_fix_verify_*` are left in place —
inert historical state, consistent with prior sessions' convention.
 
---
 
## What this PR deliberately does not do
 
- Does not generalize `editToolNames` for Gemini-specific tool naming
  conventions (see Layer 2 section above) — flagged as a known limitation,
  not blocking.
- Does not add the same `FormatGemini` handling to
  `handleNoProgressBreak`, `handleTextRepetitionBreak`, or command-ack
  writers — `writeSyntheticGeminiResponse` is a shared primitive that
  could support these later, but wiring them is out of scope here.
- Does not touch anything from #730 (force-model header, two-strike pin
  eviction) — that's a separate, already-open PR (#732) based on the same
  pre-#732 `main`. This branch will be rebased onto `main` after #732
  merges.
 