### PR TITLE
fix(translate): reprice base64 images in token estimators

### DIFF
--- a/internal/translate/features.go
+++ b/internal/translate/features.go
@@ -18,6 +18,18 @@ const previewMaxChars = 120
 // explicitly instead, so the rest can divide at its true ratio.
 const contentBytesPerToken = 4
 
+// fullBytesPerToken is FullTokenEstimate's looser bytes/token divisor, tuned so
+// base64 thought-signatures don't falsely evict extended-context models.
+const fullBytesPerToken = 6
+
+// imageTokenEstimate approximates one inline image's real token cost. Providers
+// tokenize images by pixel dimensions (Anthropic ≈ (w·h)/750, capped near 1600
+// for its 1568px max edge), NOT by base64 transport size. Both byte-based
+// estimators subtract base64 image payloads and add this back per image:
+// counting a page-sized image's base64 at the content ratio over-counts it ~40×,
+// which spuriously tripped context-window compaction on multi-page PDF reads.
+const imageTokenEstimate = 1600
+
 // signatureFieldMarker precedes a base64 thought-signature payload in an
 // Anthropic request body.
 var signatureFieldMarker = []byte(`"signature":"`)
@@ -46,8 +58,11 @@ type RoutingFeatures struct {
 // Used only for context-window pre-filtering, not routing.
 func (e *RequestEnvelope) FullTokenEstimate() int {
 	// ÷6, not ÷4: base64 thought signatures otherwise inflate byte length and
-	// falsely evict Opus for exceeding its context window.
-	return len(e.body) / 6
+	// falsely evict Opus for exceeding its context window. Base64 image payloads
+	// are repriced separately — the ÷6 blunt instrument still over-counts a
+	// multi-page PDF read (each page a ~250KB base64 image) by hundreds of K.
+	imgBytes, imgCount := e.base64ImageStats()
+	return (len(e.body)-imgBytes)/fullBytesPerToken + imgCount*imageTokenEstimate
 }
 
 // ContextOverflowTokenEstimate estimates tokens for context-window overflow
@@ -58,7 +73,12 @@ func (e *RequestEnvelope) FullTokenEstimate() int {
 // beta) calibration. Signature-STRIPPING targets subtract
 // SignatureTokenSavings from this — see excludeContextOverflowModels.
 func (e *RequestEnvelope) ContextOverflowTokenEstimate() int {
-	return len(e.body) / contentBytesPerToken
+	// Base64 image payloads are transport, not tokens: subtract their bytes and
+	// add a per-image estimate back, so a multi-page PDF read (each page a
+	// ~250KB base64 image) doesn't read as ~1.3M phantom tokens and force a
+	// spurious context-window compaction.
+	imgBytes, imgCount := e.base64ImageStats()
+	return (len(e.body)-imgBytes)/contentBytesPerToken + imgCount*imageTokenEstimate
 }
 
 // SignatureTokenSavings returns the tokens a signature-STRIPPING target saves

--- a/internal/translate/features.go
+++ b/internal/translate/features.go
@@ -24,8 +24,7 @@ const fullBytesPerToken = 6
 
 // imageTokenEstimate is a conservative per-image token cost. Providers
 // tokenize images by pixel dimensions (Anthropic ≈ (w·h)/750, capped ~1600),
-// not by base64 transport size; counting base64 bytes at the content ratio
-// over-estimates a typical image ~40×.
+// not by base64 transport size.
 const imageTokenEstimate = 1600
 
 // signatureFieldMarker precedes a base64 thought-signature payload in an

--- a/internal/translate/features.go
+++ b/internal/translate/features.go
@@ -22,12 +22,10 @@ const contentBytesPerToken = 4
 // base64 thought-signatures don't falsely evict extended-context models.
 const fullBytesPerToken = 6
 
-// imageTokenEstimate approximates one inline image's real token cost. Providers
-// tokenize images by pixel dimensions (Anthropic ≈ (w·h)/750, capped near 1600
-// for its 1568px max edge), NOT by base64 transport size. Both byte-based
-// estimators subtract base64 image payloads and add this back per image:
-// counting a page-sized image's base64 at the content ratio over-counts it ~40×,
-// which spuriously tripped context-window compaction on multi-page PDF reads.
+// imageTokenEstimate is a conservative per-image token cost. Providers
+// tokenize images by pixel dimensions (Anthropic ≈ (w·h)/750, capped ~1600),
+// not by base64 transport size; counting base64 bytes at the content ratio
+// over-estimates a typical image ~40×.
 const imageTokenEstimate = 1600
 
 // signatureFieldMarker precedes a base64 thought-signature payload in an
@@ -59,8 +57,7 @@ type RoutingFeatures struct {
 func (e *RequestEnvelope) FullTokenEstimate() int {
 	// ÷6, not ÷4: base64 thought signatures otherwise inflate byte length and
 	// falsely evict Opus for exceeding its context window. Base64 image payloads
-	// are repriced separately — the ÷6 blunt instrument still over-counts a
-	// multi-page PDF read (each page a ~250KB base64 image) by hundreds of K.
+	// are repriced separately (÷6 still over-counts them).
 	imgBytes, imgCount := e.base64ImageStats()
 	return (len(e.body)-imgBytes)/fullBytesPerToken + imgCount*imageTokenEstimate
 }
@@ -73,10 +70,8 @@ func (e *RequestEnvelope) FullTokenEstimate() int {
 // beta) calibration. Signature-STRIPPING targets subtract
 // SignatureTokenSavings from this — see excludeContextOverflowModels.
 func (e *RequestEnvelope) ContextOverflowTokenEstimate() int {
-	// Base64 image payloads are transport, not tokens: subtract their bytes and
-	// add a per-image estimate back, so a multi-page PDF read (each page a
-	// ~250KB base64 image) doesn't read as ~1.3M phantom tokens and force a
-	// spurious context-window compaction.
+	// Base64 image bytes are transport, not tokens; subtract them and reprice
+	// per image to avoid phantom token inflation on multi-page PDF reads.
 	imgBytes, imgCount := e.base64ImageStats()
 	return (len(e.body)-imgBytes)/contentBytesPerToken + imgCount*imageTokenEstimate
 }

--- a/internal/translate/features_images.go
+++ b/internal/translate/features_images.go
@@ -1,0 +1,114 @@
+package translate
+
+import (
+	"strings"
+
+	"github.com/tidwall/gjson"
+)
+
+// dataURLBase64Marker precedes an OpenAI data-URL's base64 payload.
+const dataURLBase64Marker = ";base64,"
+
+// base64ImageStats returns the total base64 byte length and count of inline
+// image payloads in the body, dispatched by inbound format. Both byte-based
+// token estimators subtract these bytes and add imageTokenEstimate per image,
+// because base64 image transport size bears no relation to the model's
+// dimension-based image token cost. Referenced media (http image URLs, Gemini
+// fileData URIs) carry no in-body payload and are ignored.
+func (e *RequestEnvelope) base64ImageStats() (bytes, count int) {
+	switch e.format {
+	case FormatAnthropic:
+		return anthropicImageBytes(e.body)
+	case FormatOpenAI:
+		return openAIImageBytes(e.body)
+	case FormatGemini:
+		return geminiImageBytes(e.body)
+	default:
+		return 0, 0
+	}
+}
+
+// jsonStringBytes returns a JSON string value's byte length without
+// materializing it. Base64 payloads contain no JSON escapes, so the raw quoted
+// length minus the two surrounding quotes is exact.
+func jsonStringBytes(v gjson.Result) int {
+	if n := len(v.Raw); n >= 2 {
+		return n - 2
+	}
+	return 0
+}
+
+// anthropicImageBytes sums base64 image payloads in an Anthropic body, covering
+// both top-level image blocks and images nested inside tool_result content —
+// the shape the Read tool emits for a rendered PDF (one image block per page).
+func anthropicImageBytes(body []byte) (total, count int) {
+	addImage := func(block gjson.Result) {
+		if data := block.Get("source.data"); data.Exists() {
+			total += jsonStringBytes(data)
+			count++
+		}
+	}
+	gjson.GetBytes(body, "messages").ForEach(func(_, msg gjson.Result) bool {
+		msg.Get("content").ForEach(func(_, block gjson.Result) bool {
+			switch block.Get("type").String() {
+			case "image":
+				addImage(block)
+			case "tool_result":
+				block.Get("content").ForEach(func(_, inner gjson.Result) bool {
+					if inner.Get("type").String() == "image" {
+						addImage(inner)
+					}
+					return true
+				})
+			}
+			return true
+		})
+		return true
+	})
+	return total, count
+}
+
+// openAIImageBytes sums base64 payloads carried in OpenAI image_url data URLs.
+// http(s) image URLs carry no in-body bytes and are skipped.
+func openAIImageBytes(body []byte) (total, count int) {
+	gjson.GetBytes(body, "messages").ForEach(func(_, msg gjson.Result) bool {
+		msg.Get("content").ForEach(func(_, part gjson.Result) bool {
+			if part.Get("type").String() != "image_url" {
+				return true
+			}
+			raw := part.Get("image_url.url").Raw
+			i := strings.Index(raw, dataURLBase64Marker)
+			if i < 0 {
+				return true
+			}
+			// From just after the marker to the closing quote.
+			if n := len(raw) - i - len(dataURLBase64Marker) - 1; n > 0 {
+				total += n
+				count++
+			}
+			return true
+		})
+		return true
+	})
+	return total, count
+}
+
+// geminiImageBytes sums base64 payloads in Gemini inlineData parts (camelCase
+// and snake_case). fileData URIs carry no in-body payload and are skipped.
+func geminiImageBytes(body []byte) (total, count int) {
+	gjson.GetBytes(body, "contents").ForEach(func(_, content gjson.Result) bool {
+		content.Get("parts").ForEach(func(_, part gjson.Result) bool {
+			data := part.Get("inlineData.data")
+			if !data.Exists() {
+				data = part.Get("inline_data.data")
+			}
+			if data.Exists() {
+				total += jsonStringBytes(data)
+				count++
+			}
+			return true
+		})
+		return true
+	})
+	return total, count
+}

--- a/internal/translate/features_images.go
+++ b/internal/translate/features_images.go
@@ -35,9 +35,8 @@ func jsonStringBytes(v gjson.Result) int {
 	return 0
 }
 
-// anthropicImageBytes sums base64 image payloads in an Anthropic body, covering
-// both top-level image blocks and images nested inside tool_result content —
-// the shape the Read tool emits for a rendered PDF (one image block per page).
+// anthropicImageBytes sums base64 image payloads in an Anthropic body,
+// including images nested inside tool_result content blocks.
 func anthropicImageBytes(body []byte) (total, count int) {
 	addImage := func(block gjson.Result) {
 		if data := block.Get("source.data"); data.Exists() {

--- a/internal/translate/features_images.go
+++ b/internal/translate/features_images.go
@@ -9,12 +9,9 @@ import (
 // dataURLBase64Marker precedes an OpenAI data-URL's base64 payload.
 const dataURLBase64Marker = ";base64,"
 
-// base64ImageStats returns the total base64 byte length and count of inline
-// image payloads in the body, dispatched by inbound format. Both byte-based
-// token estimators subtract these bytes and add imageTokenEstimate per image,
-// because base64 image transport size bears no relation to the model's
-// dimension-based image token cost. Referenced media (http image URLs, Gemini
-// fileData URIs) carry no in-body payload and are ignored.
+// base64ImageStats returns the total base64 payload byte length and image
+// count, dispatched by inbound format. Referenced media (http URLs, Gemini
+// fileData URIs) carry no in-body bytes and are skipped.
 func (e *RequestEnvelope) base64ImageStats() (bytes, count int) {
 	switch e.format {
 	case FormatAnthropic:

--- a/internal/translate/features_internal_test.go
+++ b/internal/translate/features_internal_test.go
@@ -55,3 +55,58 @@ func TestContextOverflowTokenEstimate_TicketRegression(t *testing.T) {
 	assert.Greater(t, e.ContextOverflowTokenEstimate(), kimiWindow, "dense ~263K-token body must estimate above a 256K window")
 	assert.Less(t, e.FullTokenEstimate(), kimiWindow, "the old ÷6 estimate undercounted below the window — the bug this fixes")
 }
+
+// TestBase64ImageStats sums inline base64 image payloads per inbound format,
+// covering top-level and tool_result-nested Anthropic images, OpenAI data URLs
+// (http URLs skipped), and Gemini inlineData (camelCase + snake_case).
+func TestBase64ImageStats(t *testing.T) {
+	anthropic := []byte(`{"messages":[{"role":"user","content":[` +
+		`{"type":"image","source":{"type":"base64","data":"AAAA"}},` +
+		`{"type":"tool_result","content":[{"type":"image","source":{"data":"BBBBBB"}}]}]}]}`)
+	b, c := (&RequestEnvelope{body: anthropic, format: FormatAnthropic}).base64ImageStats()
+	assert.Equal(t, 10, b, "top-level (4) + tool_result-nested (6) image bytes")
+	assert.Equal(t, 2, c, "counts both images")
+
+	openai := []byte(`{"messages":[{"role":"user","content":[` +
+		`{"type":"image_url","image_url":{"url":"data:image/png;base64,ABCDEFGH"}},` +
+		`{"type":"image_url","image_url":{"url":"https://example.com/y.png"}}]}]}`)
+	b, c = (&RequestEnvelope{body: openai, format: FormatOpenAI}).base64ImageStats()
+	assert.Equal(t, 8, b, "only the data-URL base64 payload counts")
+	assert.Equal(t, 1, c, "http image URL is not an in-body payload")
+
+	gemini := []byte(`{"contents":[{"parts":[` +
+		`{"inlineData":{"mimeType":"image/png","data":"AAAA"}},` +
+		`{"inline_data":{"data":"BB"}}]}]}`)
+	b, c = (&RequestEnvelope{body: gemini, format: FormatGemini}).base64ImageStats()
+	assert.Equal(t, 6, b, "camelCase (4) + snake_case (2) inlineData bytes")
+	assert.Equal(t, 2, c, "counts both inline parts")
+}
+
+// TestContextOverflowTokenEstimate_ImagesRepriced is the regression for the
+// multi-page-PDF compaction incident: Claude Code renders a PDF to one base64
+// image per page, so a 20-page read carries ~5MB of base64. Counting that at
+// the content ratio read as ~1.3M phantom tokens and force-compacted a session
+// whose real size was ~120K, which then trimmed to a single turn (the model
+// "forgot" the task). Images must be repriced to their dimension-based cost so
+// a handful of page images never trips context-window compaction.
+func TestContextOverflowTokenEstimate_ImagesRepriced(t *testing.T) {
+	const pages = 20
+	const pageBytes = 250_000 // ~250KB base64 per rendered page
+	page := strings.Repeat("A", pageBytes)
+	blocks := make([]string, pages)
+	for i := range blocks {
+		blocks[i] = `{"type":"image","source":{"type":"base64","media_type":"image/jpeg","data":"` + page + `"}}`
+	}
+	body := []byte(`{"messages":[{"role":"user","content":[` + strings.Join(blocks, ",") +
+		`,{"type":"text","text":"summarize this paper"}]}]}`)
+	e := &RequestEnvelope{body: body, format: FormatAnthropic}
+
+	imgBytes, imgCount := e.base64ImageStats()
+	assert.Equal(t, pages, imgCount, "counts one image per page")
+	assert.Equal(t, pages*pageBytes, imgBytes, "sums each page's base64 bytes")
+
+	// The naive len/4 estimate is a phantom >1M-token overflow (the bug).
+	assert.Greater(t, len(body)/contentBytesPerToken, 1_000_000, "raw body ÷4 falsely overflows")
+	// Repriced, the same body is well below any compaction trigger.
+	assert.Less(t, e.ContextOverflowTokenEstimate(), 100_000, "repriced estimate stays far below the window")
+}

--- a/internal/translate/features_internal_test.go
+++ b/internal/translate/features_internal_test.go
@@ -82,13 +82,9 @@ func TestBase64ImageStats(t *testing.T) {
 	assert.Equal(t, 2, c, "counts both inline parts")
 }
 
-// TestContextOverflowTokenEstimate_ImagesRepriced is the regression for the
-// multi-page-PDF compaction incident: Claude Code renders a PDF to one base64
-// image per page, so a 20-page read carries ~5MB of base64. Counting that at
-// the content ratio read as ~1.3M phantom tokens and force-compacted a session
-// whose real size was ~120K, which then trimmed to a single turn (the model
-// "forgot" the task). Images must be repriced to their dimension-based cost so
-// a handful of page images never trips context-window compaction.
+// TestContextOverflowTokenEstimate_ImagesRepriced is the regression for
+// phantom token inflation on multi-page PDF reads: base64 transport size
+// must not be counted at the content byte ratio.
 func TestContextOverflowTokenEstimate_ImagesRepriced(t *testing.T) {
 	const pages = 20
 	const pageBytes = 250_000 // ~250KB base64 per rendered page


### PR DESCRIPTION
## Problem

Both byte-based token estimators in `internal/translate/features.go` — `ContextOverflowTokenEstimate` (÷4) and `FullTokenEstimate` (÷6) — count the **entire raw request body**, including base64 image payloads, at the content byte ratio. But providers tokenize images by **pixel dimensions** (Anthropic ≈ (w·h)/750, capped ~1600 for a full page), not by base64 transport size. So one page-sized image (~250KB base64) reads as ~62k phantom tokens.

When Claude Code's `Read` tool renders a **multi-page PDF**, it emits one base64 image block per page. A 20-page read carries ~5MB of base64 → the estimator reported a **>1M-token** history for a session whose real footprint was **~120k** (confirmed by upstream cache+input token accounting).

That phantom over-window estimate tripped proactive context-window compaction. Because the (phantom) history exceeded every summarizer's window, the cascade couldn't summarize and fell through to its rescue trim — dropping the conversation to a **single recent turn with no summary** (`summarized=false`, `kept_recent=1`). The next turn's model had no task context and greeted the user fresh ("Hi — what would you like me to work on?"). Observed on a large agentic session reading a paper.

## Fix

Subtract base64 image bytes from both estimators and add back a conservative per-image estimate (`imageTokenEstimate = 1600`, Anthropic's per-image cap — a safe upper bound that won't let a genuine overflow slip through). Covered across all three inbound formats:

- **Anthropic** `source.data` — top-level image blocks **and** images nested in `tool_result` content (the `Read` tool shape)
- **OpenAI** `image_url` data URLs (http URLs carry no in-body bytes, skipped)
- **Gemini** `inlineData` (camelCase + snake_case; `fileData` URIs skipped)

With the fix, the incident body estimates ~70k → compaction never engages.

## Tests

- `TestBase64ImageStats` — per-format byte/count summing (incl. tool_result-nested Anthropic, http-URL skip, snake/camel Gemini)
- `TestContextOverflowTokenEstimate_ImagesRepriced` — 20-image body: naive ÷4 is >1M (the bug); repriced estimate <100k
- Existing estimator regressions (`_FullBody`, `_TicketRegression`, signature tests) unchanged — image-free bodies keep identical behavior

`go build ./...`, `go vet ./...`, and `go test ./internal/translate/... ./internal/proxy/...` all pass.

## Follow-up (not in this PR)

Defense-in-depth for genuinely-over-window histories: when history exceeds every summarizer window, drop/placeholder the oversized *recent* media before summarizing rather than silently trimming to one turn with no summary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)