### PR TITLE
fix(force-model): write session-wide pin so sub-agents inherit forced model

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -456,12 +456,15 @@ with nowhere to go (HTTP 503 from the scorer), so exclude deliberately.
 
 ## Forcing a model or a routing cluster
 
-`/force-model <model>` (alias `/fm`) pins the session to one model. The name is
-matched **exactly** — it must be a canonical catalog ID (`qwen/qwen3.8-max`),
-that model's bare name without the vendor prefix (`qwen3.8-max`), or an alias
-(`opus`, `qwen-max`), optionally with a `:level` effort suffix (`opus:high`).
-There is no prefix, substring, or nearest-match fallback: a name the router
-doesn't recognize is refused, never approximated.
+`/force-model <model>` (alias `/fm`) pins the client session to one model. The
+pin applies to parent and child agent threads that share the same client-session
+identity, regardless of their first prompt or active routing strategy. Clients
+that send no session identity can only be pinned at the current thread scope.
+The name is matched **exactly** — it must be a canonical catalog ID
+(`qwen/qwen3.8-max`), that model's bare name without the vendor prefix
+(`qwen3.8-max`), or an alias (`opus`, `qwen-max`), optionally with a `:level`
+effort suffix (`opus:high`). There is no prefix, substring, or nearest-match
+fallback: a name the router doesn't recognize is refused, never approximated.
 
 That strictness is the point. Approximate matching served a model the caller
 never named — `/fm qwen 3.8` resolved through the bare `qwen` alias to

--- a/internal/proxy/force_model.go
+++ b/internal/proxy/force_model.go
@@ -274,6 +274,28 @@ func forceModelHistoryRole(role string) string {
 	return role + forceModelHistoryRoleSuffix
 }
 
+func (s *Service) preserveForceModelControlHistory(
+	ctx context.Context,
+	sessionKey [sessionpin.SessionKeyLen]byte,
+	nextModel string,
+) error {
+	existing, found, err := s.pinStore.Get(ctx, sessionKey, forceModelSessionRole)
+	if err != nil {
+		return err
+	}
+	if !found || !isUserForcedReason(existing.Reason) || existing.Model == "" || existing.Model == nextModel {
+		return nil
+	}
+	return s.pinStore.UpdateUsage(context.Background(), sessionKey, forceModelSessionRole, sessionpin.Usage{
+		Strategy:            existing.Strategy,
+		EndedAt:             time.Now(),
+		ServedModel:         existing.Model,
+		ServedProvider:      existing.Provider,
+		PriorServedModel:    existing.LastServedModel,
+		SessionEverSwitched: existing.HasEverSwitched,
+	})
+}
+
 // setForceModelSessionPin writes the session-wide control row. Ordinary turns
 // never refresh this row; only another force or an explicit clear changes it.
 func (s *Service) setForceModelSessionPin(
@@ -284,6 +306,9 @@ func (s *Service) setForceModelSessionPin(
 ) error {
 	if s.pinStore == nil || installationID == uuid.Nil {
 		return nil
+	}
+	if err := s.preserveForceModelControlHistory(ctx, sessionKey, canonicalModel); err != nil {
+		return fmt.Errorf("preserve force-model control history: %w", err)
 	}
 	forced := sessionpin.Pin{
 		SessionKey:     sessionKey,
@@ -311,7 +336,7 @@ func (s *Service) loadForceModelSessionPin(
 		return sessionpin.Pin{}, false, false
 	}
 	if found && pin.Reason == userUnforcedReason {
-		return sessionpin.Pin{}, false, true
+		return pin, false, true
 	}
 	if !found || !pin.PinnedUntil.After(time.Now()) || !isUserForcedReason(pin.Reason) || pin.Model == "" || pin.Provider == "" {
 		return sessionpin.Pin{}, false, false
@@ -394,12 +419,15 @@ func (s *Service) clearLegacyForceModelPins(
 }
 
 func (s *Service) clearForceModelSessionPin(
-	_ context.Context,
+	ctx context.Context,
 	installationID uuid.UUID,
 	sessionKey [sessionpin.SessionKeyLen]byte,
 ) error {
 	if s.pinStore == nil || installationID == uuid.Nil {
 		return nil
+	}
+	if err := s.preserveForceModelControlHistory(ctx, sessionKey, ""); err != nil {
+		return fmt.Errorf("preserve force-model control history before clear: %w", err)
 	}
 	// Keep a durable tombstone so a pre-session-scope user_forced row on any
 	// child thread cannot revive after /unforce-model.

--- a/internal/proxy/force_model.go
+++ b/internal/proxy/force_model.go
@@ -260,43 +260,158 @@ func looksLikeEffortAlias(tail string) bool {
 	}
 }
 
-// setForceModelPin upserts an immutable user-forced session pin. It preserves
-// the prior pin's LastServedModel so the next turn can detect a mid-session
-// model switch and strip stale Anthropic thinking-block signatures. No-op if
-// the pin store is unconfigured or installationID is nil.
-func (s *Service) setForceModelPin(
+const (
+	forceModelSessionRole       = "force_model"
+	forceModelHistoryRoleSuffix = "_force_hist"
+	forceModelHistoryReason     = "force_model_history"
+	userUnforcedReason          = "user_unforced"
+)
+
+func forceModelHistoryRole(role string) string {
+	if role == "" {
+		role = sessionpin.DefaultRole
+	}
+	return role + forceModelHistoryRoleSuffix
+}
+
+// setForceModelSessionPin writes the session-wide control row. Ordinary turns
+// never refresh this row; only another force or an explicit clear changes it.
+func (s *Service) setForceModelSessionPin(
 	ctx context.Context,
 	sessionKey [sessionpin.SessionKeyLen]byte,
-	role string,
 	installationID uuid.UUID,
 	canonicalModel, provider string,
 ) error {
 	if s.pinStore == nil || installationID == uuid.Nil {
 		return nil
 	}
-	log := observability.FromContext(ctx)
-	var lastServedModel string
-	existing, found, err := s.pinStore.Get(ctx, sessionKey, role)
-	if err != nil {
-		log.Error("force-model: prior pin lookup failed", "err", err)
-	} else if found && pinMatchesEffectiveStrategy(ctx, existing) {
-		lastServedModel = existing.LastServedModel
-	}
 	forced := sessionpin.Pin{
-		SessionKey:      sessionKey,
-		Role:            role,
-		InstallationID:  installationID,
-		Provider:        provider,
-		Model:           canonicalModel,
-		Reason:          translate.ReasonUserForceModel,
-		Strategy:        router.StrategyFromContext(ctx),
-		TurnCount:       1,
-		PinnedUntil:     pinNeverExpires,
-		LastServedModel: lastServedModel,
+		SessionKey:     sessionKey,
+		Role:           forceModelSessionRole,
+		InstallationID: installationID,
+		Provider:       provider,
+		Model:          canonicalModel,
+		Reason:         translate.ReasonUserForceModel,
+		TurnCount:      1,
+		PinnedUntil:    pinNeverExpires,
 	}
-	// context.Background(): ctx may already be canceled here (response written,
-	// client disconnected); a canceled ctx would leave the prior pin stuck.
 	return s.pinStore.Upsert(context.Background(), forced)
+}
+
+func (s *Service) loadForceModelSessionPin(
+	ctx context.Context,
+	sessionKey [sessionpin.SessionKeyLen]byte,
+) (sessionpin.Pin, bool, bool) {
+	if s.pinStore == nil {
+		return sessionpin.Pin{}, false, false
+	}
+	pin, found, err := s.pinStore.Get(ctx, sessionKey, forceModelSessionRole)
+	if err != nil {
+		observability.FromContext(ctx).Error("force-model session pin lookup failed", "err", err)
+		return sessionpin.Pin{}, false, false
+	}
+	if found && pin.Reason == userUnforcedReason {
+		return sessionpin.Pin{}, false, true
+	}
+	if !found || !pin.PinnedUntil.After(time.Now()) || !isUserForcedReason(pin.Reason) || pin.Model == "" || pin.Provider == "" {
+		return sessionpin.Pin{}, false, false
+	}
+	return pin, true, false
+}
+
+func (s *Service) loadForceModelHistory(
+	ctx context.Context,
+	sessionKey [sessionpin.SessionKeyLen]byte,
+	role string,
+) sessionpin.Pin {
+	if s.pinStore == nil {
+		return sessionpin.Pin{}
+	}
+	pin, found, err := s.pinStore.Get(ctx, sessionKey, forceModelHistoryRole(role))
+	if err != nil {
+		observability.FromContext(ctx).Error("force-model history lookup failed", "err", err)
+		return sessionpin.Pin{}
+	}
+	if !found || !pin.PinnedUntil.After(time.Now()) {
+		return sessionpin.Pin{}
+	}
+	return pin
+}
+
+func (s *Service) anchorForceModelHistory(
+	ctx context.Context,
+	installationID uuid.UUID,
+	sessionKey [sessionpin.SessionKeyLen]byte,
+	role string,
+	forcedPin sessionpin.Pin,
+) {
+	if s.pinStore == nil || installationID == uuid.Nil {
+		return
+	}
+	s.upsertPin(ctx, sessionpin.Pin{
+		SessionKey:     sessionKey,
+		Role:           forceModelHistoryRole(role),
+		InstallationID: installationID,
+		Provider:       forcedPin.Provider,
+		Model:          forcedPin.Model,
+		Reason:         forceModelHistoryReason,
+		Strategy:       router.StrategyFromContext(ctx),
+		TurnCount:      1,
+		PinnedUntil:    time.Now().Add(pinSessionTTL),
+	})
+}
+
+func forceModelClearRoles() []string {
+	return []string{
+		roleForTier(catalog.TierUnknown),
+		roleForTier(catalog.TierLow),
+		roleForTier(catalog.TierMid),
+		roleForTier(catalog.TierHigh),
+	}
+}
+
+func (s *Service) clearLegacyForceModelPins(
+	ctx context.Context,
+	installationID uuid.UUID,
+	sessionKey [sessionpin.SessionKeyLen]byte,
+) error {
+	if s.pinStore == nil || installationID == uuid.Nil {
+		return nil
+	}
+	for _, role := range forceModelClearRoles() {
+		pin, found, err := s.pinStore.Get(ctx, sessionKey, role)
+		if err != nil {
+			return fmt.Errorf("load legacy force-model pin for role %q: %w", role, err)
+		}
+		if !found || !isUserForcedReason(pin.Reason) {
+			continue
+		}
+		if err := s.expireSessionPin(ctx, installationID, sessionKey, role, userUnforcedReason); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *Service) clearForceModelSessionPin(
+	_ context.Context,
+	installationID uuid.UUID,
+	sessionKey [sessionpin.SessionKeyLen]byte,
+) error {
+	if s.pinStore == nil || installationID == uuid.Nil {
+		return nil
+	}
+	// Keep a durable tombstone so a pre-session-scope user_forced row on any
+	// child thread cannot revive after /unforce-model.
+	cleared := sessionpin.Pin{
+		SessionKey:     sessionKey,
+		Role:           forceModelSessionRole,
+		InstallationID: installationID,
+		Reason:         userUnforcedReason,
+		TurnCount:      1,
+		PinnedUntil:    pinNeverExpires,
+	}
+	return s.pinStore.Upsert(context.Background(), cleared)
 }
 
 // applyForceModelHeader honors the x-weave-force-model request header,
@@ -310,9 +425,8 @@ func (s *Service) setForceModelPin(
 func (s *Service) applyForceModelHeader(
 	ctx context.Context,
 	r *http.Request,
-	env *translate.RequestEnvelope,
 	installationID uuid.UUID,
-	sessionKey [sessionpin.SessionKeyLen]byte,
+	forceModelSessionKey [sessionpin.SessionKeyLen]byte,
 ) (string, error) {
 	raw := strings.TrimSpace(r.Header.Get(ForceModelHeader))
 	if raw == "" {
@@ -338,7 +452,7 @@ func (s *Service) applyForceModelHeader(
 	if !known {
 		log.Warn("x-weave-force-model: rejected unrecognized model",
 			"input_model", raw,
-			"session_key_hex", fmt.Sprintf("%x", sessionKey),
+			"force_model_session_key_hex", fmt.Sprintf("%x", forceModelSessionKey),
 		)
 		return "", &ForcedModelUnknownError{Model: raw}
 	}
@@ -353,12 +467,8 @@ func (s *Service) applyForceModelHeader(
 		return "", &ForcedModelExcludedError{Model: canonicalModel, Reason: reason}
 	}
 	provider = binding
-	if s.pinStore == nil {
-		return canonicalModel, nil
-	}
-	role := roleForTier(catalog.TierFor(env.Model()))
-	if err := s.setForceModelPin(ctx, sessionKey, role, installationID, canonicalModel, provider); err != nil {
-		log.Error("x-weave-force-model: pin store upsert failed", "err", err)
+	if err := s.setForceModelSessionPin(ctx, forceModelSessionKey, installationID, canonicalModel, provider); err != nil {
+		log.Error("x-weave-force-model: session pin upsert failed", "err", err)
 		return canonicalModel, nil
 	}
 	log.Info("x-weave-force-model applied",
@@ -366,8 +476,8 @@ func (s *Service) applyForceModelHeader(
 		"canonical_model", canonicalModel,
 		"provider", provider,
 		"effort", effortLevel,
-		"session_key_hex", fmt.Sprintf("%x", sessionKey),
-		"role", role,
+		"force_model_session_key_hex", fmt.Sprintf("%x", forceModelSessionKey),
+		"role", forceModelSessionRole,
 	)
 	return canonicalModel, nil
 }
@@ -381,10 +491,10 @@ func (s *Service) handleForceModelCommand(
 	env *translate.RequestEnvelope,
 	cmd translate.ForceModelResult,
 	installationID uuid.UUID,
-	sessionKey [sessionpin.SessionKeyLen]byte,
+	threadSessionKey, forceModelSessionKey [sessionpin.SessionKeyLen]byte,
 	inputTokens int,
 ) error {
-	_, msg, err := s.applyForceModelCommand(ctx, env, cmd, installationID, sessionKey)
+	_, msg, err := s.applyForceModelCommand(ctx, env, cmd, installationID, threadSessionKey, forceModelSessionKey)
 	if err != nil {
 		return err
 	}
@@ -404,29 +514,30 @@ func (s *Service) applyForceModelCommand(
 	env *translate.RequestEnvelope,
 	cmd translate.ForceModelResult,
 	installationID uuid.UUID,
-	sessionKey [sessionpin.SessionKeyLen]byte,
+	threadSessionKey, forceModelSessionKey [sessionpin.SessionKeyLen]byte,
 ) (string, string, error) {
 	log := observability.FromContext(ctx)
-	role := roleForTier(catalog.TierFor(env.Model()))
 
 	// Formatted as a routing marker (✦ **Weave Router** → …\n\n) so
 	// StripRoutingMarkerFromMessages strips it from later inbound requests;
 	// otherwise it'd persist in history and leak router internals upstream.
 	var msg string
 	if cmd.Clear {
-		if s.pinStore != nil && installationID != uuid.Nil {
-			if err := s.expireSessionPin(ctx, installationID, sessionKey, role, "user_unforced"); err != nil {
-				log.Error("/unforce-model: pin store upsert failed", "err", err)
-				return "", "", err
-			}
+		if err := s.clearLegacyForceModelPins(ctx, installationID, threadSessionKey); err != nil {
+			log.Error("/unforce-model: legacy pin cleanup failed", "err", err)
+			return "", "", err
+		}
+		if err := s.clearForceModelSessionPin(ctx, installationID, forceModelSessionKey); err != nil {
+			log.Error("/unforce-model: session pin clear failed", "err", err)
+			return "", "", err
 		}
 		msg = "✦ **Weave Router** → force-model cleared · resuming automatic model selection\n\n"
 		if env.SourceFormat() == translate.FormatOpenAI {
 			msg = "Weave Router: force-model cleared; resuming automatic model selection"
 		}
 		log.Debug("/unforce-model: session pin cleared",
-			"session_key_hex", fmt.Sprintf("%x", sessionKey),
-			"role", role,
+			"force_model_session_key_hex", fmt.Sprintf("%x", forceModelSessionKey),
+			"role", forceModelSessionRole,
 		)
 		return "", msg, nil
 	}
@@ -435,8 +546,8 @@ func (s *Service) applyForceModelCommand(
 	if !known {
 		log.Info("/force-model: rejected unknown model",
 			"input_model", cmd.Model,
-			"session_key_hex", fmt.Sprintf("%x", sessionKey),
-			"role", role,
+			"force_model_session_key_hex", fmt.Sprintf("%x", forceModelSessionKey),
+			"role", forceModelSessionRole,
 		)
 		msg = fmt.Sprintf("✦ **Weave Router** → force-model: %q isn't a recognized model · keeping automatic routing. Use a full model ID, e.g. claude-opus-5, gpt-5.5, or gemini-3-pro-preview.\n\n", cmd.Model)
 		if env.SourceFormat() == translate.FormatOpenAI {
@@ -452,8 +563,8 @@ func (s *Service) applyForceModelCommand(
 			"canonical_model", canonicalModel,
 			"provider", provider,
 			"reason", reason,
-			"session_key_hex", fmt.Sprintf("%x", sessionKey),
-			"role", role,
+			"force_model_session_key_hex", fmt.Sprintf("%x", forceModelSessionKey),
+			"role", forceModelSessionRole,
 		)
 		msg = fmt.Sprintf("✦ **Weave Router** → force-model rejected: %s · keeping automatic routing. Ask an admin to allow the provider, or force a model from one that is permitted.\n\n", reason)
 		if env.SourceFormat() == translate.FormatOpenAI {
@@ -462,8 +573,12 @@ func (s *Service) applyForceModelCommand(
 		return "", msg, nil
 	}
 
-	if err := s.setForceModelPin(ctx, sessionKey, role, installationID, canonicalModel, binding); err != nil {
-		log.Error("/force-model: pin store upsert failed", "err", err)
+	if err := s.clearLegacyForceModelPins(ctx, installationID, threadSessionKey); err != nil {
+		log.Error("/force-model: legacy pin cleanup failed", "err", err)
+		return "", "", err
+	}
+	if err := s.setForceModelSessionPin(ctx, forceModelSessionKey, installationID, canonicalModel, binding); err != nil {
+		log.Error("/force-model: session pin upsert failed", "err", err)
 		return "", "", err
 	}
 	msg = fmt.Sprintf("✦ **Weave Router** → force-model applied: %s (%s) · Use /unforce-model to clear\n\n", canonicalModel, binding)
@@ -474,8 +589,8 @@ func (s *Service) applyForceModelCommand(
 		"input_model", cmd.Model,
 		"canonical_model", canonicalModel,
 		"provider", binding,
-		"session_key_hex", fmt.Sprintf("%x", sessionKey),
-		"role", role,
+		"force_model_session_key_hex", fmt.Sprintf("%x", forceModelSessionKey),
+		"role", forceModelSessionRole,
 	)
 	return canonicalModel, msg, nil
 }

--- a/internal/proxy/force_model.go
+++ b/internal/proxy/force_model.go
@@ -382,7 +382,7 @@ func (s *Service) anchorForceModelHistory(
 		Reason:         forceModelHistoryReason,
 		Strategy:       router.StrategyFromContext(ctx),
 		TurnCount:      1,
-		PinnedUntil:    time.Now().Add(pinSessionTTL),
+		PinnedUntil:    pinNeverExpires,
 	})
 }
 

--- a/internal/proxy/force_model_exclusions_internal_test.go
+++ b/internal/proxy/force_model_exclusions_internal_test.go
@@ -60,7 +60,7 @@ func TestForceModelCommand_RejectsSoleProviderExcluded(t *testing.T) {
 	require.NoError(t, svc.handleForceModelCommand(
 		excludedProvidersCtx(providers.ProviderAnthropic), rec, env,
 		translate.ForceModelResult{Model: "opus"},
-		uuid.New(), DeriveSessionKey(env, "key-1"), 10))
+		uuid.New(), DeriveSessionKey(env, "key-1"), DeriveSessionKey(env, "key-1"), 10))
 
 	assert.Empty(t, store.upserts, "a refused force must not write a pin")
 	assert.Contains(t, rec.Body.String(), "force-model rejected")
@@ -82,7 +82,7 @@ func TestForceModelCommand_RejectsExcludedModel(t *testing.T) {
 	rec := httptest.NewRecorder()
 	require.NoError(t, svc.handleForceModelCommand(ctx, rec, env,
 		translate.ForceModelResult{Model: "opus"},
-		uuid.New(), DeriveSessionKey(env, "key-1"), 10))
+		uuid.New(), DeriveSessionKey(env, "key-1"), DeriveSessionKey(env, "key-1"), 10))
 
 	assert.Empty(t, store.upserts, "an excluded model must not be pinned")
 	assert.Contains(t, rec.Body.String(), "force-model rejected")
@@ -101,7 +101,7 @@ func TestForceModelCommand_AllowsWhenOneBindingSurvives(t *testing.T) {
 	require.NoError(t, svc.handleForceModelCommand(
 		excludedProvidersCtx(providers.ProviderOpenRouter), rec, env,
 		translate.ForceModelResult{Model: multiBindingModel},
-		uuid.New(), DeriveSessionKey(env, "key-1"), 10))
+		uuid.New(), DeriveSessionKey(env, "key-1"), DeriveSessionKey(env, "key-1"), 10))
 
 	require.Len(t, store.upserts, 1, "one excluded binding must not refuse the force")
 	assert.Equal(t, multiBindingModel, store.upserts[0].Model)
@@ -121,7 +121,7 @@ func TestForceModelCommand_RejectsWhenEveryBindingExcluded(t *testing.T) {
 	require.NoError(t, svc.handleForceModelCommand(
 		excludedProvidersCtx(providers.ProviderBedrock, providers.ProviderOpenRouter),
 		rec, env, translate.ForceModelResult{Model: multiBindingModel},
-		uuid.New(), DeriveSessionKey(env, "key-1"), 10))
+		uuid.New(), DeriveSessionKey(env, "key-1"), DeriveSessionKey(env, "key-1"), 10))
 
 	assert.Empty(t, store.upserts)
 	assert.Contains(t, rec.Body.String(), "force-model rejected")
@@ -141,7 +141,7 @@ func TestForceModelCommand_SessionStrikeOutDoesNotReject(t *testing.T) {
 	rec := httptest.NewRecorder()
 	require.NoError(t, svc.handleForceModelCommand(ctx, rec, env,
 		translate.ForceModelResult{Model: "opus"},
-		uuid.New(), DeriveSessionKey(env, "key-1"), 10))
+		uuid.New(), DeriveSessionKey(env, "key-1"), DeriveSessionKey(env, "key-1"), 10))
 
 	require.Len(t, store.upserts, 1,
 		"a provider struck out for overload is not an exclusion")
@@ -161,7 +161,7 @@ func TestForceModelHeader_RejectsExcludedModel(t *testing.T) {
 	req.Header.Set(ForceModelHeader, "opus")
 
 	model, forceErr := svc.applyForceModelHeader(
-		excludedProvidersCtx(providers.ProviderAnthropic), req, env,
+		excludedProvidersCtx(providers.ProviderAnthropic), req,
 		uuid.New(), DeriveSessionKey(env, "key-1"))
 
 	require.Error(t, forceErr)
@@ -183,7 +183,7 @@ func TestForceModelHeader_UnfencedInstallationUnaffected(t *testing.T) {
 	req.Header.Set(ForceModelHeader, "opus")
 
 	model, forceErr := svc.applyForceModelHeader(
-		context.Background(), req, env, uuid.New(), DeriveSessionKey(env, "key-1"))
+		context.Background(), req, uuid.New(), DeriveSessionKey(env, "key-1"))
 
 	require.NoError(t, forceErr)
 	assert.Equal(t, "claude-opus-5", model)
@@ -255,7 +255,7 @@ func TestForceModelCommand_AllowsWhenAnotherKeyedBindingServes(t *testing.T) {
 	require.NoError(t, svc.handleForceModelCommand(
 		excludedProvidersCtx(providers.ProviderAnthropic), rec, env,
 		translate.ForceModelResult{Model: "opus"},
-		uuid.New(), DeriveSessionKey(env, "key-1"), 10))
+		uuid.New(), DeriveSessionKey(env, "key-1"), DeriveSessionKey(env, "key-1"), 10))
 
 	require.Len(t, store.upserts, 1)
 	assert.Contains(t, rec.Body.String(), "force-model applied")
@@ -278,7 +278,7 @@ func TestForceModelCommand_RejectsDeploymentExcludedModel(t *testing.T) {
 	rec := httptest.NewRecorder()
 	require.NoError(t, svc.handleForceModelCommand(context.Background(), rec, env,
 		translate.ForceModelResult{Model: "opus"},
-		uuid.New(), DeriveSessionKey(env, "key-1"), 10))
+		uuid.New(), DeriveSessionKey(env, "key-1"), DeriveSessionKey(env, "key-1"), 10))
 
 	assert.Empty(t, store.upserts, "an env-excluded model must not be pinned")
 	assert.Contains(t, rec.Body.String(), "force-model rejected")

--- a/internal/proxy/force_model_pin_ttl_internal_test.go
+++ b/internal/proxy/force_model_pin_ttl_internal_test.go
@@ -74,32 +74,33 @@ func TestPinExpiry_UserForcedNeverExpires(t *testing.T) {
 // TestSetForceModelPin_WritesNeverExpiresSentinel guards the write path: the
 // /force-model upsert must persist the never-expires PinnedUntil so an idle gap
 // can never silently drop the user's directive.
-func TestSetForceModelPin_WritesNeverExpiresSentinel(t *testing.T) {
+func TestSetForceModelSessionPin_WritesNeverExpiresSentinel(t *testing.T) {
 	store := &recordingPinStore{}
 	svc := NewService(nil, nil, nil, false, nil, store, false,
 		providers.ProviderAnthropic, "claude-haiku-4-5", nil)
 
 	var key [sessionpin.SessionKeyLen]byte
-	require.NoError(t, svc.setForceModelPin(
-		context.Background(), key, roleForTier(0), uuid.New(),
+	require.NoError(t, svc.setForceModelSessionPin(
+		context.Background(), key, uuid.New(),
 		"claude-opus-4-8", providers.ProviderAnthropic))
 
 	require.Len(t, store.upserts, 1)
+	assert.Equal(t, forceModelSessionRole, store.upserts[0].Role)
 	assert.Equal(t, translate.ReasonUserForceModel, store.upserts[0].Reason)
 	assert.Equal(t, pinNeverExpires, store.upserts[0].PinnedUntil,
 		"a /force-model pin must be written with the never-expires sentinel")
 }
 
-func TestSetForceModelPin_WritesEffectiveStrategy(t *testing.T) {
+func TestSetForceModelSessionPin_IsStrategyIndependent(t *testing.T) {
 	store := &recordingPinStore{}
 	svc := NewService(nil, nil, nil, false, nil, store, false,
 		providers.ProviderAnthropic, "claude-haiku-4-5", nil)
 
 	ctx := router.WithStrategy(context.Background(), router.StrategyHMMBeta)
-	require.NoError(t, svc.setForceModelPin(
-		ctx, [sessionpin.SessionKeyLen]byte{}, sessionpin.DefaultRole, uuid.New(),
+	require.NoError(t, svc.setForceModelSessionPin(
+		ctx, [sessionpin.SessionKeyLen]byte{}, uuid.New(),
 		"claude-opus-4-8", providers.ProviderAnthropic))
 
 	require.Len(t, store.upserts, 1)
-	assert.Equal(t, router.StrategyHMMBeta, store.upserts[0].Strategy)
+	assert.Empty(t, store.upserts[0].Strategy)
 }

--- a/internal/proxy/force_model_session_internal_test.go
+++ b/internal/proxy/force_model_session_internal_test.go
@@ -55,7 +55,16 @@ func (s *forceModelMapStore) Consume(_ context.Context, sessionKey [sessionpin.S
 func (s *forceModelMapStore) Upsert(_ context.Context, pin sessionpin.Pin) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	s.pins[forceModelMapKey(pin.SessionKey, pin.Role)] = pin
+	key := forceModelMapKey(pin.SessionKey, pin.Role)
+	existing, found := s.pins[key]
+	if found && existing.Strategy == pin.Strategy {
+		pin.LastServedModel = existing.LastServedModel
+		pin.LastTurnEndedAt = existing.LastTurnEndedAt
+		pin.LastInputTokens = existing.LastInputTokens
+		pin.LastOutputTokens = existing.LastOutputTokens
+		pin.HasEverSwitched = existing.HasEverSwitched
+	}
+	s.pins[key] = pin
 	return nil
 }
 
@@ -73,6 +82,8 @@ func (s *forceModelMapStore) UpdateUsage(_ context.Context, sessionKey [sessionp
 	pin.LastTurnEndedAt = usage.EndedAt
 	pin.LastInputTokens = usage.InputTokens
 	pin.LastOutputTokens = usage.OutputTokens
+	pin.HasEverSwitched = usage.SessionEverSwitched ||
+		(usage.PriorServedModel != "" && usage.PriorServedModel != usage.ServedModel)
 	s.pins[key] = pin
 	return nil
 }
@@ -322,6 +333,14 @@ func TestApplyForceModelCommand_WritesAndClearsSessionControl(t *testing.T) {
 		assert.False(t, threadForceFound, "new force state must have only one authoritative row")
 	}
 
+	nextModel, _, err := svc.applyForceModelCommand(ctx, env, translate.ForceModelResult{Model: "sonnet"}, installationID, threadKey, forceKey)
+	require.NoError(t, err)
+	assert.Equal(t, "claude-sonnet-5", nextModel)
+	switched, found, err := store.Get(ctx, forceKey, forceModelSessionRole)
+	require.NoError(t, err)
+	require.True(t, found)
+	assert.Equal(t, "claude-opus-5", switched.LastServedModel)
+
 	_, _, err = svc.applyForceModelCommand(ctx, env, translate.ForceModelResult{Clear: true}, installationID, threadKey, forceKey)
 	require.NoError(t, err)
 	cleared, found, err := store.Get(ctx, forceKey, forceModelSessionRole)
@@ -329,6 +348,8 @@ func TestApplyForceModelCommand_WritesAndClearsSessionControl(t *testing.T) {
 	require.True(t, found)
 	assert.Equal(t, pinNeverExpires, cleared.PinnedUntil, "the clear tombstone prevents legacy child pins from reviving")
 	assert.Empty(t, cleared.Model)
+	assert.Equal(t, "claude-sonnet-5", cleared.LastServedModel)
+	assert.True(t, cleared.HasEverSwitched)
 	assert.Equal(t, userUnforcedReason, cleared.Reason)
 }
 

--- a/internal/proxy/force_model_session_internal_test.go
+++ b/internal/proxy/force_model_session_internal_test.go
@@ -1,0 +1,369 @@
+package proxy
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"workweave/router/internal/providers"
+	"workweave/router/internal/router"
+	"workweave/router/internal/router/catalog"
+	"workweave/router/internal/router/sessionpin"
+	"workweave/router/internal/translate"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type forceModelMapStore struct {
+	mu         sync.Mutex
+	pins       map[string]sessionpin.Pin
+	usageRoles []string
+	usageKeys  [][sessionpin.SessionKeyLen]byte
+}
+
+func newForceModelMapStore() *forceModelMapStore {
+	return &forceModelMapStore{pins: make(map[string]sessionpin.Pin)}
+}
+
+func forceModelMapKey(sessionKey [sessionpin.SessionKeyLen]byte, role string) string {
+	return fmt.Sprintf("%x:%s", sessionKey, role)
+}
+
+func (s *forceModelMapStore) Get(_ context.Context, sessionKey [sessionpin.SessionKeyLen]byte, role string) (sessionpin.Pin, bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	pin, found := s.pins[forceModelMapKey(sessionKey, role)]
+	return pin, found, nil
+}
+
+func (s *forceModelMapStore) Consume(_ context.Context, sessionKey [sessionpin.SessionKeyLen]byte, role string, expected router.Strategy) (sessionpin.Pin, bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	key := forceModelMapKey(sessionKey, role)
+	pin, found := s.pins[key]
+	if !found || !pin.PinnedUntil.After(time.Now()) || (pin.Strategy != expected && !(pin.Strategy == "" && expected != router.StrategyHMMBeta)) {
+		return sessionpin.Pin{}, false, nil
+	}
+	delete(s.pins, key)
+	return pin, true, nil
+}
+
+func (s *forceModelMapStore) Upsert(_ context.Context, pin sessionpin.Pin) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.pins[forceModelMapKey(pin.SessionKey, pin.Role)] = pin
+	return nil
+}
+
+func (s *forceModelMapStore) UpdateUsage(_ context.Context, sessionKey [sessionpin.SessionKeyLen]byte, role string, usage sessionpin.Usage) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	key := forceModelMapKey(sessionKey, role)
+	pin, found := s.pins[key]
+	if !found || (pin.Strategy != usage.Strategy && !(pin.Strategy == "" && usage.Strategy != router.StrategyHMMBeta)) {
+		return nil
+	}
+	s.usageKeys = append(s.usageKeys, sessionKey)
+	s.usageRoles = append(s.usageRoles, role)
+	pin.LastServedModel = usage.ServedModel
+	pin.LastTurnEndedAt = usage.EndedAt
+	pin.LastInputTokens = usage.InputTokens
+	pin.LastOutputTokens = usage.OutputTokens
+	s.pins[key] = pin
+	return nil
+}
+
+func (*forceModelMapStore) IncrementUpstreamErrors(context.Context, [sessionpin.SessionKeyLen]byte, string, router.Strategy) (int, error) {
+	return 0, nil
+}
+func (*forceModelMapStore) ResetUpstreamErrors(context.Context, [sessionpin.SessionKeyLen]byte, string, router.Strategy) error {
+	return nil
+}
+func (*forceModelMapStore) IncrementOverloadErrors(context.Context, [sessionpin.SessionKeyLen]byte, string, router.Strategy) (int, error) {
+	return 0, nil
+}
+func (*forceModelMapStore) ResetOverloadErrors(context.Context, [sessionpin.SessionKeyLen]byte, string, router.Strategy) error {
+	return nil
+}
+func (*forceModelMapStore) DisableProvider(context.Context, [sessionpin.SessionKeyLen]byte, string, string, router.Strategy) error {
+	return nil
+}
+func (*forceModelMapStore) SweepExpired(context.Context) error { return nil }
+
+func TestRunTurnLoop_ForceModelSessionPinAppliesAcrossChildThreads(t *testing.T) {
+	const (
+		apiKeyID      = "api-key"
+		clientSession = "client-session"
+		forcedModel   = "claude-opus-5"
+	)
+	installationID := uuid.New()
+	ctx := context.WithValue(context.Background(), ClientIdentityContextKey{}, ClientIdentity{SessionID: clientSession})
+	parent, err := translate.ParseAnthropic([]byte(`{
+		"model":"claude-opus-4-8",
+		"messages":[{"role":"user","content":"parent task"}]
+	}`))
+	require.NoError(t, err)
+	child, err := translate.ParseAnthropic([]byte(`{
+		"model":"claude-opus-4-8",
+		"messages":[{"role":"user","content":"different child task"}]
+	}`))
+	require.NoError(t, err)
+
+	parentThreadKey := deriveSessionKeyForRequest(ctx, parent, apiKeyID)
+	childThreadKey := deriveSessionKeyForRequest(ctx, child, apiKeyID)
+	forceSessionKey := deriveForceModelSessionKeyForRequest(ctx, parent, apiKeyID, parentThreadKey)
+	require.NotEqual(t, parentThreadKey, childThreadKey)
+	require.Equal(t, forceSessionKey, deriveForceModelSessionKeyForRequest(ctx, child, apiKeyID, childThreadKey))
+
+	store := newForceModelMapStore()
+	store.pins[forceModelMapKey(forceSessionKey, forceModelSessionRole)] = sessionpin.Pin{
+		SessionKey:     forceSessionKey,
+		Role:           forceModelSessionRole,
+		InstallationID: installationID,
+		Provider:       providers.ProviderAnthropic,
+		Model:          forcedModel,
+		Reason:         translate.ReasonUserForceModel,
+		Strategy:       router.StrategyCluster,
+		PinnedUntil:    pinNeverExpires,
+	}
+	freshRouter := &tierProbeRouter{available: map[string]struct{}{"claude-haiku-4-5": {}}}
+	svc := NewService(freshRouter, nil, nil, false, nil, store, false,
+		providers.ProviderAnthropic, "claude-haiku-4-5", nil)
+	features := child.RoutingFeatures(false)
+
+	ctx = router.WithStrategy(ctx, router.StrategyHMMBeta)
+	result, err := svc.runTurnLoop(ctx, child, features, apiKeyID, installationID, "", nil, router.Request{
+		RequestedModel: features.Model,
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, forcedModel, result.Decision.Model)
+	assert.Equal(t, translate.ReasonUserForceModel, result.Decision.Reason)
+	assert.True(t, result.StickyHit)
+	assert.False(t, result.HardPinned)
+	assert.Equal(t, childThreadKey, result.SessionKey, "routing state must remain scoped to the child thread")
+	assert.Equal(t, roleForTier(result.RequestedTier), result.PinRole)
+	assert.Empty(t, freshRouter.captured, "session force must bypass the scorer")
+
+	store.mu.Lock()
+	defer store.mu.Unlock()
+	_, controlStillPresent := store.pins[forceModelMapKey(forceSessionKey, forceModelSessionRole)]
+	_, historyPresent := store.pins[forceModelMapKey(childThreadKey, forceModelHistoryRole(result.PinRole))]
+	assert.True(t, controlStillPresent)
+	assert.True(t, historyPresent)
+}
+
+func TestRunTurnLoop_DroppedSessionForcePreservesThreadPin(t *testing.T) {
+	const apiKeyID = "api-key"
+	installationID := uuid.New()
+	ctx := context.WithValue(context.Background(), ClientIdentityContextKey{}, ClientIdentity{SessionID: "client-session"})
+	env, err := translate.ParseAnthropic([]byte(`{
+		"model":"claude-opus-4-8",
+		"messages":[{"role":"user","content":"task"}]
+	}`))
+	require.NoError(t, err)
+	features := env.RoutingFeatures(false)
+	threadKey := deriveSessionKeyForRequest(ctx, env, apiKeyID)
+	forceKey := deriveForceModelSessionKeyForRequest(ctx, env, apiKeyID, threadKey)
+	role := roleForTier(catalog.TierFor(features.Model))
+	store := newForceModelMapStore()
+	store.pins[forceModelMapKey(forceKey, forceModelSessionRole)] = sessionpin.Pin{
+		SessionKey:     forceKey,
+		Role:           forceModelSessionRole,
+		InstallationID: installationID,
+		Provider:       providers.ProviderAnthropic,
+		Model:          "claude-opus-5",
+		Reason:         translate.ReasonUserForceModel,
+		PinnedUntil:    pinNeverExpires,
+	}
+	store.pins[forceModelMapKey(threadKey, role)] = sessionpin.Pin{
+		SessionKey:     threadKey,
+		Role:           role,
+		InstallationID: installationID,
+		Provider:       providers.ProviderOpenAI,
+		Model:          "gpt-5.5",
+		Reason:         "cluster:existing",
+		Strategy:       router.StrategyCluster,
+		PinnedUntil:    time.Now().Add(time.Hour),
+	}
+	freshRouter := &tierProbeRouter{available: map[string]struct{}{"claude-haiku-4-5": {}}}
+	svc := NewService(freshRouter, nil, nil, false, nil, store, false,
+		providers.ProviderAnthropic, "claude-haiku-4-5", nil)
+	ctx = router.WithStrategy(ctx, router.StrategyCluster)
+
+	result, err := svc.runTurnLoop(ctx, env, features, apiKeyID, installationID, "", nil, router.Request{
+		RequestedModel: features.Model,
+		EnabledProviders: map[string]struct{}{
+			providers.ProviderOpenAI: {},
+		},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "gpt-5.5", result.Decision.Model)
+	assert.True(t, result.StickyHit)
+	assert.True(t, result.ForcedPinDropped)
+	assert.Equal(t, "provider_not_enabled", result.ForcedPinDropReason)
+}
+
+func TestRunTurnLoop_ClearTombstoneBlocksLegacyForce(t *testing.T) {
+	const apiKeyID = "api-key"
+	installationID := uuid.New()
+	ctx := context.WithValue(context.Background(), ClientIdentityContextKey{}, ClientIdentity{SessionID: "client-session"})
+	ctx = router.WithStrategy(ctx, router.StrategyCluster)
+	env, err := translate.ParseAnthropic([]byte(`{
+		"model":"claude-opus-4-8",
+		"messages":[{"role":"user","content":"task after unforce"}]
+	}`))
+	require.NoError(t, err)
+	features := env.RoutingFeatures(false)
+	threadKey := deriveSessionKeyForRequest(ctx, env, apiKeyID)
+	forceKey := deriveForceModelSessionKeyForRequest(ctx, env, apiKeyID, threadKey)
+	role := roleForTier(catalog.TierFor(features.Model))
+	store := newForceModelMapStore()
+	store.pins[forceModelMapKey(forceKey, forceModelSessionRole)] = sessionpin.Pin{
+		SessionKey:     forceKey,
+		Role:           forceModelSessionRole,
+		InstallationID: installationID,
+		Reason:         userUnforcedReason,
+		PinnedUntil:    pinNeverExpires,
+	}
+	store.pins[forceModelMapKey(threadKey, role)] = sessionpin.Pin{
+		SessionKey:     threadKey,
+		Role:           role,
+		InstallationID: installationID,
+		Provider:       providers.ProviderAnthropic,
+		Model:          "claude-opus-5",
+		Reason:         translate.ReasonUserForceModel,
+		Strategy:       router.StrategyCluster,
+		PinnedUntil:    pinNeverExpires,
+	}
+	freshRouter := &tierProbeRouter{
+		available: map[string]struct{}{"claude-haiku-4-5": {}},
+	}
+	svc := NewService(freshRouter, nil, nil, false, nil, store, false,
+		providers.ProviderAnthropic, "claude-haiku-4-5", nil)
+
+	result, err := svc.runTurnLoop(ctx, env, features, apiKeyID, installationID, "", nil, router.Request{
+		RequestedModel: features.Model,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "claude-haiku-4-5", result.Decision.Model)
+	assert.NotEqual(t, translate.ReasonUserForceModel, result.Decision.Reason)
+	assert.NotEmpty(t, freshRouter.captured)
+}
+
+func TestRunTurnLoop_SessionForceOverridesAuxiliaryHardPin(t *testing.T) {
+	const apiKeyID = "api-key"
+	installationID := uuid.New()
+	ctx := context.WithValue(context.Background(), ClientIdentityContextKey{}, ClientIdentity{SessionID: "client-session"})
+	env, err := translate.ParseAnthropic([]byte(`{
+		"model":"claude-opus-4-8",
+		"system":"Your task is to create a detailed summary of the conversation so far.",
+		"messages":[{"role":"user","content":"summarize"}]
+	}`))
+	require.NoError(t, err)
+	threadKey := deriveSessionKeyForRequest(ctx, env, apiKeyID)
+	forceKey := deriveForceModelSessionKeyForRequest(ctx, env, apiKeyID, threadKey)
+	store := newForceModelMapStore()
+	store.pins[forceModelMapKey(forceKey, forceModelSessionRole)] = sessionpin.Pin{
+		SessionKey:     forceKey,
+		Role:           forceModelSessionRole,
+		InstallationID: installationID,
+		Provider:       providers.ProviderAnthropic,
+		Model:          "claude-opus-5",
+		Reason:         translate.ReasonUserForceModel,
+		PinnedUntil:    pinNeverExpires,
+	}
+	freshRouter := &tierProbeRouter{available: map[string]struct{}{"claude-haiku-4-5": {}}}
+	svc := NewService(freshRouter, nil, nil, false, nil, store, false,
+		providers.ProviderAnthropic, "claude-haiku-4-5", nil)
+	features := env.RoutingFeatures(false)
+
+	result, err := svc.runTurnLoop(ctx, env, features, apiKeyID, installationID, "", nil, router.Request{
+		RequestedModel: features.Model,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "claude-opus-5", result.Decision.Model)
+	assert.Equal(t, translate.ReasonUserForceModel, result.Decision.Reason)
+	assert.False(t, result.HardPinned)
+	assert.Equal(t, threadKey, result.SessionKey)
+	assert.Empty(t, freshRouter.captured)
+}
+
+func TestApplyForceModelCommand_WritesAndClearsSessionControl(t *testing.T) {
+	const apiKeyID = "api-key"
+	installationID := uuid.New()
+	ctx := context.WithValue(context.Background(), ClientIdentityContextKey{}, ClientIdentity{SessionID: "client-session"})
+	env, err := translate.ParseAnthropic([]byte(`{
+		"model":"claude-opus-4-8",
+		"messages":[{"role":"user","content":"task"}]
+	}`))
+	require.NoError(t, err)
+	threadKey := deriveSessionKeyForRequest(ctx, env, apiKeyID)
+	forceKey := deriveForceModelSessionKeyForRequest(ctx, env, apiKeyID, threadKey)
+	store := newForceModelMapStore()
+	svc := NewService(nil, nil, nil, false, nil, store, false,
+		providers.ProviderAnthropic, "claude-haiku-4-5", nil)
+
+	forcedModel, _, err := svc.applyForceModelCommand(ctx, env, translate.ForceModelResult{Model: "opus"}, installationID, threadKey, forceKey)
+	require.NoError(t, err)
+	assert.Equal(t, "claude-opus-5", forcedModel)
+	pin, found, err := store.Get(ctx, forceKey, forceModelSessionRole)
+	require.NoError(t, err)
+	require.True(t, found)
+	assert.Equal(t, translate.ReasonUserForceModel, pin.Reason)
+	assert.Equal(t, pinNeverExpires, pin.PinnedUntil)
+	for _, role := range forceModelClearRoles() {
+		_, threadForceFound, getErr := store.Get(ctx, threadKey, role)
+		require.NoError(t, getErr)
+		assert.False(t, threadForceFound, "new force state must have only one authoritative row")
+	}
+
+	_, _, err = svc.applyForceModelCommand(ctx, env, translate.ForceModelResult{Clear: true}, installationID, threadKey, forceKey)
+	require.NoError(t, err)
+	cleared, found, err := store.Get(ctx, forceKey, forceModelSessionRole)
+	require.NoError(t, err)
+	require.True(t, found)
+	assert.Equal(t, pinNeverExpires, cleared.PinnedUntil, "the clear tombstone prevents legacy child pins from reviving")
+	assert.Empty(t, cleared.Model)
+	assert.Equal(t, userUnforcedReason, cleared.Reason)
+}
+
+func TestRecordTurnUsage_ForcedDecisionWritesThreadHistoryOnly(t *testing.T) {
+	store := newForceModelMapStore()
+	svc := NewService(nil, nil, nil, false, nil, store, false,
+		providers.ProviderAnthropic, "claude-haiku-4-5", nil)
+	threadKey := [sessionpin.SessionKeyLen]byte{1}
+	controlKey := [sessionpin.SessionKeyLen]byte{2}
+	role := roleForTier(catalog.TierFor("claude-opus-5"))
+	store.pins[forceModelMapKey(controlKey, forceModelSessionRole)] = sessionpin.Pin{
+		SessionKey: controlKey,
+		Role:       forceModelSessionRole,
+		Provider:   providers.ProviderAnthropic,
+		Model:      "claude-opus-5",
+		Reason:     translate.ReasonUserForceModel,
+	}
+	store.pins[forceModelMapKey(threadKey, forceModelHistoryRole(role))] = sessionpin.Pin{
+		SessionKey: threadKey,
+		Role:       forceModelHistoryRole(role),
+	}
+
+	svc.recordTurnUsage(turnLoopResult{
+		SessionKey: threadKey,
+		PinRole:    role,
+		Decision: router.Decision{
+			Provider: providers.ProviderAnthropic,
+			Model:    "claude-opus-5",
+			Reason:   translate.ReasonUserForceModel,
+		},
+	}, providers.ProviderAnthropic, "claude-opus-5", 100, 10, 0, 0)
+
+	store.mu.Lock()
+	defer store.mu.Unlock()
+	require.Equal(t, []string{forceModelHistoryRole(role)}, store.usageRoles)
+	require.Equal(t, [][sessionpin.SessionKeyLen]byte{threadKey}, store.usageKeys)
+	assert.Empty(t, store.pins[forceModelMapKey(controlKey, forceModelSessionRole)].LastServedModel)
+}

--- a/internal/proxy/force_model_session_internal_test.go
+++ b/internal/proxy/force_model_session_internal_test.go
@@ -242,15 +242,12 @@ func TestRunTurnLoop_ClearTombstoneBlocksLegacyForce(t *testing.T) {
 		Reason:         userUnforcedReason,
 		PinnedUntil:    pinNeverExpires,
 	}
-	store.pins[forceModelMapKey(threadKey, role)] = sessionpin.Pin{
-		SessionKey:     threadKey,
-		Role:           role,
-		InstallationID: installationID,
-		Provider:       providers.ProviderAnthropic,
-		Model:          "claude-opus-5",
-		Reason:         translate.ReasonUserForceModel,
-		Strategy:       router.StrategyCluster,
-		PinnedUntil:    pinNeverExpires,
+	store.pins[forceModelMapKey(threadKey, forceModelHistoryRole(role))] = sessionpin.Pin{
+		SessionKey:      threadKey,
+		Role:            forceModelHistoryRole(role),
+		LastServedModel: "claude-opus-5",
+		LastTurnEndedAt: time.Now(),
+		PinnedUntil:     pinNeverExpires,
 	}
 	freshRouter := &tierProbeRouter{
 		available: map[string]struct{}{"claude-haiku-4-5": {}},
@@ -264,6 +261,7 @@ func TestRunTurnLoop_ClearTombstoneBlocksLegacyForce(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "claude-haiku-4-5", result.Decision.Model)
 	assert.NotEqual(t, translate.ReasonUserForceModel, result.Decision.Reason)
+	assert.Equal(t, "claude-opus-5", result.PriorServedModel)
 	assert.NotEmpty(t, freshRouter.captured)
 }
 

--- a/internal/proxy/force_model_session_internal_test.go
+++ b/internal/proxy/force_model_session_internal_test.go
@@ -166,6 +166,7 @@ func TestRunTurnLoop_ForceModelSessionPinAppliesAcrossChildThreads(t *testing.T)
 	_, historyPresent := store.pins[forceModelMapKey(childThreadKey, forceModelHistoryRole(result.PinRole))]
 	assert.True(t, controlStillPresent)
 	assert.True(t, historyPresent)
+	assert.Equal(t, pinNeverExpires, store.pins[forceModelMapKey(childThreadKey, forceModelHistoryRole(result.PinRole))].PinnedUntil)
 }
 
 func TestRunTurnLoop_DroppedSessionForcePreservesThreadPin(t *testing.T) {

--- a/internal/proxy/force_model_tier_fallback_internal_test.go
+++ b/internal/proxy/force_model_tier_fallback_internal_test.go
@@ -292,7 +292,7 @@ func TestForceModelHeader_OverridesHardPin(t *testing.T) {
 	headerReq, err := http.NewRequest(http.MethodPost, "/v1/messages", nil)
 	require.NoError(t, err)
 	headerReq.Header.Set(ForceModelHeader, "opus")
-	_, forceErr := svc.applyForceModelHeader(context.Background(), headerReq, env, uuid.New(), key)
+	_, forceErr := svc.applyForceModelHeader(context.Background(), headerReq, uuid.New(), key)
 	require.NoError(t, forceErr)
 
 	feats := env.RoutingFeatures(false)

--- a/internal/proxy/loop_detection.go
+++ b/internal/proxy/loop_detection.go
@@ -138,6 +138,7 @@ func (s *Service) handleLoopEscalation(
 	sessionKey [sessionpin.SessionKeyLen]byte,
 	role string,
 	routedModel string,
+	forceModelSessionKeys ...[sessionpin.SessionKeyLen]byte,
 ) {
 	log := observability.FromContext(ctx)
 
@@ -159,6 +160,13 @@ func (s *Service) handleLoopEscalation(
 			if existing.Model != "" {
 				loopingModel = existing.Model
 			}
+		}
+	}
+	if len(forceModelSessionKeys) > 0 {
+		forcePin, active, _ := s.loadForceModelSessionPin(ctx, forceModelSessionKeys[0])
+		if active {
+			userForced = true
+			loopingModel = forcePin.Model
 		}
 	}
 

--- a/internal/proxy/no_progress.go
+++ b/internal/proxy/no_progress.go
@@ -275,10 +275,11 @@ func (s *Service) handleNoProgressBreak(
 	decisionModel string,
 	decisionProvider string,
 	inputTokens int,
+	decisionReason ...string,
 ) error {
 	log := observability.FromContext(ctx)
-	preserveForcedPin := false
-	if s.pinStore != nil && installationID != uuid.Nil && sessionKey != ([sessionpin.SessionKeyLen]byte{}) {
+	preserveForcedPin := len(decisionReason) > 0 && isUserForcedReason(decisionReason[0])
+	if !preserveForcedPin && s.pinStore != nil && installationID != uuid.Nil && sessionKey != ([sessionpin.SessionKeyLen]byte{}) {
 		pin, found := s.loadPin(ctx, sessionKey, role)
 		preserveForcedPin = found && isUserForcedReason(pin.Reason)
 	}

--- a/internal/proxy/pin_strategy.go
+++ b/internal/proxy/pin_strategy.go
@@ -8,9 +8,12 @@ import (
 )
 
 // pinMatchesEffectiveStrategy reports whether a stored pin belongs to the
-// strategy serving this request. Legacy (empty Strategy) rows remain eligible
-// for non-beta strategies during rollout; beta never inherits a legacy pin.
+// strategy serving this request. An explicit user force is policy-independent;
+// legacy empty-strategy rows remain eligible outside beta during rollout.
 func pinMatchesEffectiveStrategy(ctx context.Context, pin sessionpin.Pin) bool {
+	if isUserForcedReason(pin.Reason) {
+		return true
+	}
 	expected := router.StrategyFromContext(ctx)
 	if pin.Strategy == expected {
 		return true

--- a/internal/proxy/pin_strategy_internal_test.go
+++ b/internal/proxy/pin_strategy_internal_test.go
@@ -6,6 +6,7 @@ import (
 
 	"workweave/router/internal/router"
 	"workweave/router/internal/router/sessionpin"
+	"workweave/router/internal/translate"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -35,4 +36,10 @@ func TestPinMatchesEffectiveStrategy(t *testing.T) {
 			assert.Equal(t, tt.expected, pinMatchesEffectiveStrategy(ctx, sessionpin.Pin{Strategy: tt.stored}))
 		})
 	}
+
+	betaContext := router.WithStrategy(context.Background(), router.StrategyHMMBeta)
+	assert.True(t, pinMatchesEffectiveStrategy(betaContext, sessionpin.Pin{
+		Reason:   translate.ReasonUserForceModel,
+		Strategy: router.StrategyCluster,
+	}), "an explicit force must survive routing-strategy changes")
 }

--- a/internal/proxy/router_feedback.go
+++ b/internal/proxy/router_feedback.go
@@ -131,13 +131,16 @@ func (s *Service) handleRouterFeedbackCommand(
 		}
 	}
 	if servedModel == "" && s.pinStore != nil {
-		if pin, found, err := s.pinStore.Get(ctx, sessionKey, role); err != nil {
+		pin := sessionpin.Pin{}
+		if storedPin, found, err := s.pinStore.Get(ctx, sessionKey, role); err != nil {
 			log.Error("/router-feedback: pin lookup failed", "err", err)
-		} else if found && pinMatchesEffectiveStrategy(ctx, pin) {
-			servedModel = pin.LastServedModel
-			if servedModel == "" {
-				servedModel = pin.Model
-			}
+		} else if found && pinMatchesEffectiveStrategy(ctx, storedPin) {
+			pin = storedPin
+		}
+		forceHistory := s.loadForceModelHistory(ctx, sessionKey, role)
+		servedModel, _ = switchHistoryFromPins(pin, forceHistory)
+		if servedModel == "" {
+			servedModel = pin.Model
 		}
 	}
 

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -574,15 +574,8 @@ func routingMarkerFor(res turnLoopResult) string {
 	if res.SuggestionMode {
 		return ""
 	}
-	// Hard pins (compaction / sub-agent) return before the pin is loaded, so
-	// PriorServedModel is always empty there — suppress explicitly rather than
-	// letting it read as a first turn.
-	if res.HardPinned {
-		return ""
-	}
 	// A dropped force-model pin contradicts an ack the user already saw, so it
-	// prints even when the model did not change — the same-model gate below would
-	// otherwise hide exactly the turns where the pin stopped applying.
+	// prints even when the automatic fallback is a normally hidden hard pin.
 	if res.ForcedPinDropped {
 		parts := []string{"✦ **Weave Router** → " + decision.Model, markerReasonForcedPinDropped}
 		if res.ForcedPinModel != "" {
@@ -592,6 +585,12 @@ func routingMarkerFor(res turnLoopResult) string {
 			}
 		}
 		return strings.Join(parts, " · ") + "\n\n"
+	}
+	// Hard pins (compaction / sub-agent) return before the pin is loaded, so
+	// PriorServedModel is always empty there — suppress explicitly rather than
+	// letting it read as a first turn.
+	if res.HardPinned {
+		return ""
 	}
 	// Same model as last turn: the user already knows. Empty prior model means
 	// the first turn of this session (or role), which still shows. Applies to
@@ -2895,6 +2894,7 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 		}
 		*r = *r.WithContext(ctx)
 	}
+	forceModelSessionKey := deriveForceModelSessionKeyForRequest(ctx, env, apiKeyID, sessionKey)
 
 	// Handle /force-model and /unforce-model before routing (stripped from
 	// env.body so the upstream never sees it). Session key is derived before
@@ -2907,13 +2907,13 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 			log.Info("ProxyMessages force-model command", "force_model_cmd", cmd)
 			if cmd.FromToolResult {
 				var err error
-				agentForceModel, _, err = s.applyForceModelCommand(ctx, env, cmd, installationID, sessionKey)
+				agentForceModel, _, err = s.applyForceModelCommand(ctx, env, cmd, installationID, sessionKey, forceModelSessionKey)
 				if err != nil {
 					return err
 				}
 				requestBodyChanged = true
 			} else {
-				if err := s.handleForceModelCommand(ctx, w, env, cmd, installationID, sessionKey, feats.Tokens); err != nil {
+				if err := s.handleForceModelCommand(ctx, w, env, cmd, installationID, sessionKey, forceModelSessionKey, feats.Tokens); err != nil {
 					return err
 				}
 				s.grantPostCommandContinuation(ctx, installationID, sessionKey, roleForTier(catalog.TierFor(feats.Model)))
@@ -2958,7 +2958,7 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 	forceModel := agentForceModel
 	forceCluster := ""
 	if !agentShadowMode {
-		headerForceModel, forceErr := s.applyForceModelHeader(ctx, r, env, installationID, sessionKey)
+		headerForceModel, forceErr := s.applyForceModelHeader(ctx, r, installationID, forceModelSessionKey)
 		if forceErr != nil {
 			return forceErr
 		}
@@ -2976,7 +2976,7 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 	if !agentShadowMode {
 		if cyc, csig, ccount, cratio, cwin := detectCyclicToolCallLoop(env); cyc {
 			loopRole := roleForTier(catalog.TierFor(feats.Model))
-			s.handleLoopEscalation(ctx, csig, ccount, cratio, cwin, installationID, sessionKey, loopRole, feats.Model)
+			s.handleLoopEscalation(ctx, csig, ccount, cratio, cwin, installationID, sessionKey, loopRole, feats.Model, forceModelSessionKey)
 		}
 	}
 
@@ -2996,7 +2996,7 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 	// dispatches the sideways target on the same turn.
 	if !agentShadowMode && s.ResolveStruggleEscalationEnabled(ctx) && (turntype.DetectFromEnvelope(env, feats, "") == turntype.MainLoop || turntype.DetectFromEnvelope(env, feats, "") == turntype.ToolResult) {
 		struggleRole := roleForTier(catalog.TierFor(feats.Model))
-		s.handleStruggleEscalation(ctx, installationID, sessionKey, struggleRole, inboundSpiralReasons)
+		s.handleStruggleEscalation(ctx, installationID, sessionKey, struggleRole, inboundSpiralReasons, forceModelSessionKey)
 	}
 	// Surface inbound tool_use / tool_result blocks the model is about to see.
 	// Lets us audit whether a misbehaving turn was provoked by a malformed prior
@@ -3166,8 +3166,9 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 			role := roleForTier(catalog.TierFor(feats.Model))
 			pin, _ := s.loadPin(ctx, sessionKey, role)
 			hmmHistory := s.loadHMMHistory(ctx, sessionKey, role)
+			forceHistory := s.loadForceModelHistory(ctx, sessionKey, role)
 			routeRes.SessionKey = sessionKey
-			routeRes.PriorServedModel, routeRes.SessionEverSwitched = switchHistoryFromPins(pin, hmmHistory)
+			routeRes.PriorServedModel, routeRes.SessionEverSwitched = switchHistoryFromPins(pin, hmmHistory, forceHistory)
 		}
 
 		routeRes.UsageBypass = false
@@ -3201,7 +3202,7 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 		fp := computeNoProgressFingerprint(decision, promptText, feats.MessageCount, toolProgressMarker(env))
 		role := roleForTier(catalog.TierFor(feats.Model))
 		if looped, count := s.noProgress.recordAndDetect(routeRes.SessionKey, installationID, role, fp, time.Now()); looped {
-			return s.handleNoProgressBreak(ctx, w, env, count, installationID, routeRes.SessionKey, role, decision.Model, decision.Provider, feats.Tokens)
+			return s.handleNoProgressBreak(ctx, w, env, count, installationID, routeRes.SessionKey, role, decision.Model, decision.Provider, feats.Tokens, routeRes.Decision.Reason)
 		}
 	}
 
@@ -4548,6 +4549,9 @@ func (s *Service) recordTurnUsage(res turnLoopResult, servedProvider, servedMode
 		SessionEverSwitched: res.SessionEverSwitched,
 	}
 	role := res.PinRole
+	if isUserForcedReason(res.Decision.Reason) {
+		role = forceModelHistoryRole(role)
+	}
 	if role == "" {
 		role = sessionpin.DefaultRole
 	}
@@ -5541,6 +5545,7 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 		return err
 	}
 	*r = *r.WithContext(ctx)
+	forceModelSessionKey := deriveForceModelSessionKeyForRequest(ctx, env, apiKeyID, sessionKey)
 
 	// Handle /force-model and /unforce-model before routing (stripped from
 	// env.body so the upstream never sees it). Session key is derived before
@@ -5553,13 +5558,13 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 			log.Info("ProxyOpenAIChatCompletion force-model command", "force_model_cmd", cmd)
 			if cmd.FromToolResult {
 				var err error
-				agentForceModel, _, err = s.applyForceModelCommand(ctx, env, cmd, installationID, sessionKey)
+				agentForceModel, _, err = s.applyForceModelCommand(ctx, env, cmd, installationID, sessionKey, forceModelSessionKey)
 				if err != nil {
 					return err
 				}
 				requestBodyChanged = true
 			} else {
-				if err := s.handleForceModelCommand(ctx, w, env, cmd, installationID, sessionKey, feats.Tokens); err != nil {
+				if err := s.handleForceModelCommand(ctx, w, env, cmd, installationID, sessionKey, forceModelSessionKey, feats.Tokens); err != nil {
 					return err
 				}
 				s.grantPostCommandContinuation(ctx, installationID, sessionKey, roleForTier(catalog.TierFor(feats.Model)))
@@ -5600,7 +5605,7 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 	// Writes the user-forced pin and falls through to normal routing, which picks
 	// the pin up and serves the requested model on this same turn.
 	forceModel := agentForceModel
-	headerForceModel, forceErr := s.applyForceModelHeader(ctx, r, env, installationID, sessionKey)
+	headerForceModel, forceErr := s.applyForceModelHeader(ctx, r, installationID, forceModelSessionKey)
 	if forceErr != nil {
 		return forceErr
 	}
@@ -5616,7 +5621,7 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 	// ingress). See detectCyclicToolCallLoop / handleLoopEscalation.
 	if cyc, csig, ccount, cratio, cwin := detectCyclicToolCallLoop(env); cyc {
 		loopRole := roleForTier(catalog.TierFor(feats.Model))
-		s.handleLoopEscalation(ctx, csig, ccount, cratio, cwin, installationID, sessionKey, loopRole, feats.Model)
+		s.handleLoopEscalation(ctx, csig, ccount, cratio, cwin, installationID, sessionKey, loopRole, feats.Model, forceModelSessionKey)
 	}
 
 	logInboundRequestDiagnostics(log, env)

--- a/internal/proxy/service_session_pin_test.go
+++ b/internal/proxy/service_session_pin_test.go
@@ -341,13 +341,13 @@ func TestService_SessionPin_EveryTurnReadsPostgres(t *testing.T) {
 	httpReq1 := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(""))
 	require.NoError(t, svc.ProxyMessages(ctx, []byte(pinTestBody), rec1, httpReq1))
 	require.Equal(t, 1, fr.routeCalls)
-	require.Equal(t, 2, store.getCalls, "first turn must read the active pin and HMM history roles")
+	require.Equal(t, 3, store.getCalls, "first turn reads force control, active pin, and HMM history")
 
 	rec2 := httptest.NewRecorder()
 	httpReq2 := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(""))
 	require.NoError(t, svc.ProxyMessages(ctx, []byte(pinTestBody), rec2, httpReq2))
 	assert.Equal(t, 2, fr.routeCalls, "planner re-evaluates every MainLoop turn")
-	assert.Equal(t, 4, store.getCalls, "second turn must also read Postgres — there is no in-process cache")
+	assert.Equal(t, 6, store.getCalls, "second turn must also read Postgres — there is no in-process cache")
 }
 
 func TestService_SessionPin_StoreErrorFallsThroughToFreshRoute(t *testing.T) {
@@ -400,7 +400,7 @@ func TestService_SessionPin_EvalOverrideHeaderKeepsSessionKeyPinning(t *testing.
 
 	// Scorer still runs, but the pin wins under ReasonNoPriorUsage.
 	assert.Equal(t, 1, fr.routeCalls, "scorer runs every MainLoop turn under the planner")
-	assert.Equal(t, 2, store.getCalls)
+	assert.Equal(t, 3, store.getCalls, "force control, thread pin, and HMM history are read independently")
 	assert.Equal(t, "claude-haiku-4-5", rec.Header().Get(proxy.HeaderRouterModel))
 }
 
@@ -549,7 +549,7 @@ func TestService_HardPin_CompactionAlwaysRoutesToHaiku(t *testing.T) {
 
 	assert.Equal(t, 0, fr.routeCalls, "compaction must bypass the cluster scorer")
 	assert.Equal(t, "claude-haiku-4-5", rec.Header().Get(proxy.HeaderRouterModel))
-	assert.Equal(t, 1, store.getCalls, "compaction must check for an explicit user-forced pin before the hard-pin fast path")
+	assert.Equal(t, 2, store.getCalls, "compaction checks session and legacy thread force state before hard-pinning")
 
 	select {
 	case <-store.upsertCh:
@@ -1509,8 +1509,8 @@ func TestService_ForceModelHeader_WritesUserForcedPin(t *testing.T) {
 	require.NotNil(t, forced, "header must write a user_forced pin upsert")
 	assert.Equal(t, "claude-opus-5", forced.Model, "alias 'opus' resolves to the canonical id")
 	assert.Equal(t, providers.ProviderAnthropic, forced.Provider)
-	require.NotNil(t, fr.capturedReq)
-	assert.Equal(t, "claude-opus-5", fr.capturedReq.ForceModel, "valid force-model header must bypass router decorators")
+	assert.Equal(t, 0, fr.routeCalls, "a valid force bypasses automatic routing")
+	assert.Equal(t, "claude-opus-5", rec.Header().Get(proxy.HeaderRouterModel))
 }
 
 // An unrecognized x-weave-force-model value fails the request: routing on

--- a/internal/proxy/session_key.go
+++ b/internal/proxy/session_key.go
@@ -2,6 +2,7 @@ package proxy
 
 import (
 	"context"
+	"crypto/hmac"
 	"crypto/sha256"
 	"encoding/hex"
 	"log/slog"
@@ -117,6 +118,33 @@ func DeriveSessionKey(env *translate.RequestEnvelope, apiKeyID string) [sessionp
 
 func deriveSessionKeyForRequest(ctx context.Context, env *translate.RequestEnvelope, apiKeyID string) [sessionpin.SessionKeyLen]byte {
 	return deriveSessionKey(env, apiKeyID, clientSessionIDForRequest(ctx, env))
+}
+
+// deriveForceModelSessionKeyForRequest omits the first-message discriminator
+// so an explicit force applies to every thread in one client session.
+func deriveForceModelSessionKeyForRequest(
+	ctx context.Context,
+	env *translate.RequestEnvelope,
+	apiKeyID string,
+	threadSessionKey [sessionpin.SessionKeyLen]byte,
+) [sessionpin.SessionKeyLen]byte {
+	h := hmac.New(sha256.New, []byte(apiKeyID))
+	h.Write([]byte("force_model_session:"))
+	h.Write([]byte{0x00})
+
+	if clientSessionID := clientSessionIDForRequest(ctx, env); clientSessionID != "" {
+		h.Write([]byte("client_session_id:"))
+		h.Write([]byte(clientSessionID))
+	} else {
+		// Without a client session identifier there is no safe parent scope.
+		h.Write([]byte("thread_key:"))
+		h.Write(threadSessionKey[:])
+	}
+
+	sum := h.Sum(nil)
+	var key [sessionpin.SessionKeyLen]byte
+	copy(key[:], sum[:sessionpin.SessionKeyLen])
+	return key
 }
 
 func clientSessionIDForRequest(ctx context.Context, env *translate.RequestEnvelope) string {

--- a/internal/proxy/session_key_internal_test.go
+++ b/internal/proxy/session_key_internal_test.go
@@ -43,3 +43,59 @@ func TestClientSessionIDForRequest_PrefersHeaderOverBody(t *testing.T) {
 	assert.Equal(t, "header-session", clientSessionIDForRequest(ctx, env))
 	assert.Equal(t, "body-session", clientSessionIDForRequest(context.Background(), env))
 }
+
+func TestDeriveForceModelSessionKeyForRequest_SharedAcrossThreads(t *testing.T) {
+	ctx := context.WithValue(context.Background(), ClientIdentityContextKey{}, ClientIdentity{SessionID: "shared-session"})
+	parent, err := translate.ParseAnthropic([]byte(`{
+		"messages": [{"role": "user", "content": "parent task"}]
+	}`))
+	require.NoError(t, err)
+	child, err := translate.ParseAnthropic([]byte(`{
+		"messages": [{"role": "user", "content": "different child task"}]
+	}`))
+	require.NoError(t, err)
+
+	parentThread := deriveSessionKeyForRequest(ctx, parent, "api-key")
+	childThread := deriveSessionKeyForRequest(ctx, child, "api-key")
+	parentForce := deriveForceModelSessionKeyForRequest(ctx, parent, "api-key", parentThread)
+	childForce := deriveForceModelSessionKeyForRequest(ctx, child, "api-key", childThread)
+
+	assert.NotEqual(t, parentThread, childThread)
+	assert.Equal(t, parentForce, childForce)
+}
+
+func TestDeriveForceModelSessionKeyForRequest_IsolatesSessionsAndAPIKeys(t *testing.T) {
+	env, err := translate.ParseAnthropic([]byte(`{
+		"messages": [{"role": "user", "content": "task"}]
+	}`))
+	require.NoError(t, err)
+	ctxA := context.WithValue(context.Background(), ClientIdentityContextKey{}, ClientIdentity{SessionID: "session-a"})
+	ctxB := context.WithValue(context.Background(), ClientIdentityContextKey{}, ClientIdentity{SessionID: "session-b"})
+	threadA := deriveSessionKeyForRequest(ctxA, env, "api-key-a")
+	threadB := deriveSessionKeyForRequest(ctxB, env, "api-key-a")
+
+	keyA := deriveForceModelSessionKeyForRequest(ctxA, env, "api-key-a", threadA)
+	keyB := deriveForceModelSessionKeyForRequest(ctxB, env, "api-key-a", threadB)
+	otherAPIKey := deriveForceModelSessionKeyForRequest(ctxA, env, "api-key-b", threadA)
+
+	assert.NotEqual(t, keyA, keyB)
+	assert.NotEqual(t, keyA, otherAPIKey)
+}
+
+func TestDeriveForceModelSessionKeyForRequest_FallsBackToThreadScope(t *testing.T) {
+	parent, err := translate.ParseAnthropic([]byte(`{
+		"messages": [{"role": "user", "content": "parent task"}]
+	}`))
+	require.NoError(t, err)
+	child, err := translate.ParseAnthropic([]byte(`{
+		"messages": [{"role": "user", "content": "child task"}]
+	}`))
+	require.NoError(t, err)
+
+	parentThread := deriveSessionKeyForRequest(context.Background(), parent, "api-key")
+	childThread := deriveSessionKeyForRequest(context.Background(), child, "api-key")
+	parentForce := deriveForceModelSessionKeyForRequest(context.Background(), parent, "api-key", parentThread)
+	childForce := deriveForceModelSessionKeyForRequest(context.Background(), child, "api-key", childThread)
+
+	assert.NotEqual(t, parentForce, childForce, "clients without a session id must remain thread-scoped")
+}

--- a/internal/proxy/struggle_escalation.go
+++ b/internal/proxy/struggle_escalation.go
@@ -75,6 +75,7 @@ func (s *Service) handleStruggleEscalation(
 	sessionKey [sessionpin.SessionKeyLen]byte,
 	role string,
 	evidence []spiralReason,
+	forceModelSessionKeys ...[sessionpin.SessionKeyLen]byte,
 ) {
 	log := observability.FromContext(ctx)
 
@@ -121,6 +122,10 @@ func (s *Service) handleStruggleEscalation(
 
 	if !timerArmed && !evidenceArmed {
 		return // not yet struggling, or only "late" (not armed)
+	}
+	if len(forceModelSessionKeys) > 0 {
+		_, active, _ := s.loadForceModelSessionPin(ctx, forceModelSessionKeys[0])
+		userForced = userForced || active
 	}
 	armingMode := struggleArmingTurnWall
 	if evidenceArmed {

--- a/internal/proxy/turnloop.go
+++ b/internal/proxy/turnloop.go
@@ -738,7 +738,7 @@ func (s *Service) runTurnLoop(
 	}
 	hmmHistory := s.loadHMMHistory(ctx, res.SessionKey, res.PinRole)
 	forceHistory := sessionpin.Pin{}
-	if forceModelFound {
+	if forceModelFound || forceModelCleared {
 		forceHistory = s.loadForceModelHistory(ctx, res.SessionKey, res.PinRole)
 	}
 	if !forceModelFound && !forceModelCleared && pinFound && isUserForcedReason(pin.Reason) {

--- a/internal/proxy/turnloop.go
+++ b/internal/proxy/turnloop.go
@@ -444,6 +444,18 @@ func forcedPinEligible(pin sessionpin.Pin, req router.Request) bool {
 	return pinEligible(pin, req)
 }
 
+func forcedPinIneligibilityReason(pin sessionpin.Pin, req router.Request) string {
+	if req.EnabledProviders != nil {
+		if _, enabled := req.EnabledProviders[pin.Provider]; !enabled {
+			return "provider_not_enabled"
+		}
+	}
+	if !pinServesImages(pin, req) {
+		return "not_image_capable"
+	}
+	return "excluded"
+}
+
 // runTurnLoop is the format-agnostic routing orchestrator: detect turn type,
 // short-circuit hard pins, load pin, run scorer, hand to planner, and on
 // switch attempt bounded-cost handover.
@@ -518,36 +530,87 @@ func (s *Service) runTurnLoop(
 		"sub_agent_hint", subAgentHint,
 	)
 
+	// Explicit force state is scoped to the client session rather than one
+	// first-message-derived thread. A force carried by this request wins over a
+	// concurrently persisted value; future requests observe the last write.
+	forceModelSessionKey := deriveForceModelSessionKeyForRequest(ctx, env, apiKeyID, threadSessionKey)
+	forceModelPin := sessionpin.Pin{}
+	forceModelFound := false
+	forceModelCleared := false
+	if req.ForceModel != "" {
+		canonicalModel, provider, known := resolveForceModel(req.ForceModel)
+		if !known {
+			return res, &ForcedModelUnknownError{Model: req.ForceModel}
+		}
+		forceModelPin = sessionpin.Pin{
+			SessionKey:     forceModelSessionKey,
+			Role:           forceModelSessionRole,
+			InstallationID: installationID,
+			Provider:       provider,
+			Model:          canonicalModel,
+			Reason:         translate.ReasonUserForceModel,
+			PinnedUntil:    pinNeverExpires,
+		}
+		forceModelFound = true
+	}
+	if !forceModelFound {
+		forceModelPin, forceModelFound, forceModelCleared = s.loadForceModelSessionPin(ctx, forceModelSessionKey)
+	}
+	if forceModelFound {
+		binding, reason := s.forcedModelBinding(ctx, forceModelPin.Model, forceModelPin.Provider)
+		if reason != "" {
+			return res, &ForcedModelExcludedError{Model: forceModelPin.Model, Reason: reason}
+		}
+		forceModelPin.Provider = binding
+	}
+	sessionForceControlFound := forceModelFound
+
 	// Discounts covered models' cost term by the caller's observed subscription
 	// headroom. nil (feature off / no headroom yet) leaves scoring unchanged.
 	req.SubsidizedModelCostFactor = s.subsidyFactors(ctx, reqHeaders)
 
-	// Explicit user-forced pins outrank every automatic fast path, including
-	// the turn-type hard pin; only check here so ordinary turns use the normal flow.
+	// Explicit user force outranks every automatic fast path, including hard
+	// pins. Legacy thread-scoped forces keep their original thread boundary.
 	hardPinnedTurn := s.isHardPinnedTurn(ctx, res.TurnType)
-	if s.pinStore != nil && hardPinnedTurn {
-		forcedPin, found := s.loadPin(ctx, threadSessionKey, res.PinRole)
-		permitted := found && isUserForcedReason(forcedPin.Reason)
-		// Same binding remap as the main path: excluded primary whose fallback
-		// is permitted stays forced; excluded outright, hard pin wins quietly.
-		if permitted {
-			binding, reason := s.forcedModelBinding(ctx, forcedPin.Model, forcedPin.Provider)
-			forcedPin.Provider = binding
-			permitted = reason == ""
+	if s.pinStore != nil && hardPinnedTurn && !forceModelFound && !forceModelCleared {
+		legacyPin, found := s.loadPin(ctx, threadSessionKey, res.PinRole)
+		if found && isUserForcedReason(legacyPin.Reason) {
+			binding, reason := s.forcedModelBinding(ctx, legacyPin.Model, legacyPin.Provider)
+			if reason != "" {
+				return res, &ForcedModelExcludedError{Model: legacyPin.Model, Reason: reason}
+			}
+			legacyPin.Provider = binding
+			forceModelPin, forceModelFound = legacyPin, true
 		}
-		if permitted && forcedPinEligible(forcedPin, req) {
+	}
+	if forceModelFound && hardPinnedTurn {
+		if forcedPinEligible(forceModelPin, req) {
+			threadPin, _ := s.loadPin(ctx, threadSessionKey, res.PinRole)
+			hmmHistory := s.loadHMMHistory(ctx, threadSessionKey, res.PinRole)
+			forceHistory := s.loadForceModelHistory(ctx, threadSessionKey, res.PinRole)
 			res.SessionKey = threadSessionKey
-			res.PinModel = forcedPin.Model
-			res.PinAgeSec = pinAge(forcedPin)
-			res.PriorServedModel, res.SessionEverSwitched = switchHistoryFromPins(forcedPin, sessionpin.Pin{})
-			res.EscalateEffort = !forcedPin.LastTurnEndedAt.IsZero() &&
-				(forcedPin.LastOutputTokens == 0 || forcedPin.ConsecutiveUpstreamErrors > 0)
-			res.Decision = pinDecision(forcedPin)
+			res.PinModel = forceModelPin.Model
+			res.PinAgeSec = pinAge(forceModelPin)
+			res.PriorServedModel, res.SessionEverSwitched = switchHistoryFromPins(threadPin, hmmHistory, forceHistory)
+			res.EscalateEffort = !forceHistory.LastTurnEndedAt.IsZero() &&
+				(forceHistory.LastOutputTokens == 0 || forceHistory.ConsecutiveUpstreamErrors > 0)
+			res.Decision = pinDecision(forceModelPin)
+			res.Decision.Reason = translate.ReasonUserForceModel
 			res.StickyHit = true
-			res.PinTier = forcedPin.Reason
-			s.refreshPin(ctx, installationID, res.SessionKey, forcedPin, res.PinRole, res.Decision)
+			res.PinTier = translate.ReasonUserForceModel
+			s.anchorForceModelHistory(ctx, installationID, threadSessionKey, res.PinRole, forceModelPin)
 			return res, nil
 		}
+		res.SessionKey = threadSessionKey
+		res.ForcedPinDropped = true
+		res.ForcedPinModel = forceModelPin.Model
+		res.ForcedPinDropReason = forcedPinIneligibilityReason(forceModelPin, req)
+		log.Info("Forced session pin dropped for hard-pinned turn",
+			"pin_model", forceModelPin.Model,
+			"pin_provider", forceModelPin.Provider,
+			"drop_reason", res.ForcedPinDropReason,
+			"role", res.PinRole,
+		)
 	}
 
 	// Automatic hard pins bypass pin lookup/write, planner, and scorer entirely.
@@ -639,6 +702,13 @@ func (s *Service) runTurnLoop(
 	// Without a pin store, run the scorer and return its decision. The usage
 	// bypass intercepts the fresh scorer decision here too (no pins to honor).
 	if s.pinStore == nil {
+		if forceModelFound && forcedPinEligible(forceModelPin, req) {
+			res.Decision = pinDecision(forceModelPin)
+			res.Decision.Reason = translate.ReasonUserForceModel
+			res.StickyHit = true
+			res.PinTier = translate.ReasonUserForceModel
+			return res, nil
+		}
 		req.PolicyTurnContext = buildPolicyTurnContext(req, res, sessionpin.Pin{}, sessionpin.Pin{})
 		if dec, ok := s.usageBypassDecision(ctx, reqHeaders, req); ok {
 			res.Decision = dec
@@ -666,6 +736,22 @@ func (s *Service) runTurnLoop(
 		clearedPinReason = pin.Reason
 	}
 	hmmHistory := s.loadHMMHistory(ctx, res.SessionKey, res.PinRole)
+	forceHistory := sessionpin.Pin{}
+	if forceModelFound || forceModelCleared {
+		forceHistory = s.loadForceModelHistory(ctx, res.SessionKey, res.PinRole)
+	}
+	if !forceModelFound && !forceModelCleared && pinFound && isUserForcedReason(pin.Reason) {
+		binding, reason := s.forcedModelBinding(ctx, pin.Model, pin.Provider)
+		if reason != "" {
+			return res, &ForcedModelExcludedError{Model: pin.Model, Reason: reason}
+		}
+		pin.Provider = binding
+		forceModelPin, forceModelFound = pin, true
+	}
+	if forceModelCleared && pinFound && isUserForcedReason(pin.Reason) {
+		pinFound = false
+		pin = sessionpin.Pin{}
+	}
 	commandContinuation := sessionpin.Pin{}
 	commandContinuationFound := false
 	if res.TurnType == turntype.MainLoop {
@@ -692,13 +778,18 @@ func (s *Service) runTurnLoop(
 		pin.Provider = binding
 	}
 	disabledProviders := mergeDisabledProviders(pin.DisabledProviders, hmmHistory.DisabledProviders)
-	// User-forced pin exempts its own provider: an explicit /force-model
-	// must not be silently reverted by the session-level breaker.
-	if pinFound && pin.Provider != "" && isUserForcedReason(pin.Reason) {
+	// Explicit force exempts its own provider from session-level breaker state.
+	forcedProvider := ""
+	if forceModelFound {
+		forcedProvider = forceModelPin.Provider
+	} else if pinFound && isUserForcedReason(pin.Reason) {
+		forcedProvider = pin.Provider
+	}
+	if forcedProvider != "" {
 		filtered := make([]string, 0, len(disabledProviders))
-		for _, p := range disabledProviders {
-			if p != pin.Provider {
-				filtered = append(filtered, p)
+		for _, provider := range disabledProviders {
+			if provider != forcedProvider {
+				filtered = append(filtered, provider)
 			}
 		}
 		disabledProviders = filtered
@@ -718,7 +809,7 @@ func (s *Service) runTurnLoop(
 			req.EnabledProviders = filtered
 		}
 	}
-	res.PriorServedModel, res.SessionEverSwitched = switchHistoryFromPins(pin, hmmHistory)
+	res.PriorServedModel, res.SessionEverSwitched = switchHistoryFromPins(pin, hmmHistory, forceHistory)
 	req.PolicyTurnContext = buildPolicyTurnContext(req, res, pin, hmmHistory)
 	// Computed before any same-turn pin-drop guards below so it reflects the
 	// prior turn's outcome; Service.effortEscalation gates whether it's acted on.
@@ -758,6 +849,43 @@ func (s *Service) runTurnLoop(
 	// the scorer call further down constrains the fresh decision to this tier
 	// instead of collapsing to the cheap tier-default. TierUnknown = no constraint.
 	forcedTierFloor := catalog.TierUnknown
+	if forceModelFound {
+		_, excluded := req.ExcludedModels[forceModelPin.Model]
+		_, providerEnabled := req.EnabledProviders[forceModelPin.Provider]
+		providerEligible := req.EnabledProviders == nil || providerEnabled
+		imageCapable := pinServesImages(forceModelPin, req)
+		if !excluded && providerEligible && imageCapable {
+			res.PinModel = forceModelPin.Model
+			res.PinAgeSec = pinAge(forceModelPin)
+			res.EscalateEffort = !forceHistory.LastTurnEndedAt.IsZero() &&
+				(forceHistory.LastOutputTokens == 0 || forceHistory.ConsecutiveUpstreamErrors > 0)
+			res.Decision = pinDecision(forceModelPin)
+			res.Decision.Reason = translate.ReasonUserForceModel
+			res.StickyHit = true
+			res.PinTier = translate.ReasonUserForceModel
+			s.anchorForceModelHistory(ctx, installationID, res.SessionKey, res.PinRole, forceModelPin)
+			return res, nil
+		}
+		res.ForcedPinDropped = true
+		res.ForcedPinDropReason = forcedPinIneligibilityReason(forceModelPin, req)
+		res.ForcedPinModel = forceModelPin.Model
+		log.Info("Forced session pin dropped for this turn",
+			"pin_model", forceModelPin.Model,
+			"pin_provider", forceModelPin.Provider,
+			"drop_reason", res.ForcedPinDropReason,
+			"role", res.PinRole,
+		)
+		if excluded || !imageCapable {
+			forcedTierFloor = catalog.TierFor(forceModelPin.Model)
+		}
+		if !imageCapable {
+			req.ExcludedModels = excludingModel(req.ExcludedModels, forceModelPin.Model)
+		}
+		if !sessionForceControlFound || isUserForcedReason(pin.Reason) {
+			pinFound = false
+			pin = sessionpin.Pin{}
+		}
+	}
 	if pinFound && (isUserForcedReason(pin.Reason) || pin.Reason == translate.ReasonLoopEscalation || pin.Reason == translate.ReasonStruggleEscalation) {
 		_, excluded := req.ExcludedModels[pin.Model]
 		_, providerEnabled := req.EnabledProviders[pin.Provider]
@@ -974,7 +1102,7 @@ func (s *Service) runTurnLoop(
 		res.PinTier = "post_command_continuation"
 		res.PinModel = commandContinuation.Model
 		res.PinAgeSec = pinAge(commandContinuation)
-		res.PriorServedModel, res.SessionEverSwitched = switchHistoryFromPins(commandContinuation, hmmHistory)
+		res.PriorServedModel, res.SessionEverSwitched = switchHistoryFromPins(commandContinuation, hmmHistory, forceHistory)
 		res.EscalateEffort = !commandContinuation.LastTurnEndedAt.IsZero() &&
 			(commandContinuation.LastOutputTokens == 0 || commandContinuation.ConsecutiveUpstreamErrors > 0)
 		log.Info("turnloop used one-shot post-command continuation",
@@ -1777,19 +1905,24 @@ func (s *Service) loadHMMHistory(ctx context.Context, sessionKey [sessionpin.Ses
 	return pin
 }
 
-func switchHistoryFromPins(activePin, hmmHistory sessionpin.Pin) (string, bool) {
-	priorServedModel := activePin.LastServedModel
-	sessionEverSwitched := activePin.HasEverSwitched || hmmHistory.HasEverSwitched
-	if hmmHistory.LastServedModel != "" &&
-		(priorServedModel == "" || hmmHistory.LastTurnEndedAt.After(activePin.LastTurnEndedAt)) {
-		priorServedModel = hmmHistory.LastServedModel
+func switchHistoryFromPins(pins ...sessionpin.Pin) (string, bool) {
+	var latest sessionpin.Pin
+	sessionEverSwitched := false
+	seenModel := ""
+	for _, pin := range pins {
+		sessionEverSwitched = sessionEverSwitched || pin.HasEverSwitched
+		if pin.LastServedModel == "" {
+			continue
+		}
+		if seenModel != "" && seenModel != pin.LastServedModel {
+			sessionEverSwitched = true
+		}
+		seenModel = pin.LastServedModel
+		if latest.LastServedModel == "" || pin.LastTurnEndedAt.After(latest.LastTurnEndedAt) {
+			latest = pin
+		}
 	}
-	if activePin.LastServedModel != "" &&
-		hmmHistory.LastServedModel != "" &&
-		activePin.LastServedModel != hmmHistory.LastServedModel {
-		sessionEverSwitched = true
-	}
-	return priorServedModel, sessionEverSwitched
+	return latest.LastServedModel, sessionEverSwitched
 }
 
 func buildPolicyTurnContext(

--- a/internal/proxy/turnloop.go
+++ b/internal/proxy/turnloop.go
@@ -530,9 +530,7 @@ func (s *Service) runTurnLoop(
 		"sub_agent_hint", subAgentHint,
 	)
 
-	// Explicit force state is scoped to the client session rather than one
-	// first-message-derived thread. A force carried by this request wins over a
-	// concurrently persisted value; future requests observe the last write.
+	// Force state is session-scoped so sub-agents inherit the parent choice.
 	forceModelSessionKey := deriveForceModelSessionKeyForRequest(ctx, env, apiKeyID, threadSessionKey)
 	forceModelPin := sessionpin.Pin{}
 	forceModelFound := false
@@ -585,13 +583,16 @@ func (s *Service) runTurnLoop(
 	}
 	if forceModelFound && hardPinnedTurn {
 		if forcedPinEligible(forceModelPin, req) {
-			threadPin, _ := s.loadPin(ctx, threadSessionKey, res.PinRole)
-			hmmHistory := s.loadHMMHistory(ctx, threadSessionKey, res.PinRole)
-			forceHistory := s.loadForceModelHistory(ctx, threadSessionKey, res.PinRole)
+			threadPin, hmmHistory, forceHistory := sessionpin.Pin{}, sessionpin.Pin{}, sessionpin.Pin{}
+			if s.pinStore != nil {
+				threadPin, _ = s.loadPin(ctx, threadSessionKey, res.PinRole)
+				hmmHistory = s.loadHMMHistory(ctx, threadSessionKey, res.PinRole)
+				forceHistory = s.loadForceModelHistory(ctx, threadSessionKey, res.PinRole)
+			}
 			res.SessionKey = threadSessionKey
 			res.PinModel = forceModelPin.Model
 			res.PinAgeSec = pinAge(forceModelPin)
-			res.PriorServedModel, res.SessionEverSwitched = switchHistoryFromPins(threadPin, hmmHistory, forceHistory)
+			res.PriorServedModel, res.SessionEverSwitched = switchHistoryFromPins(threadPin, hmmHistory, forceHistory, forceModelPin)
 			res.EscalateEffort = !forceHistory.LastTurnEndedAt.IsZero() &&
 				(forceHistory.LastOutputTokens == 0 || forceHistory.ConsecutiveUpstreamErrors > 0)
 			res.Decision = pinDecision(forceModelPin)
@@ -809,7 +810,7 @@ func (s *Service) runTurnLoop(
 			req.EnabledProviders = filtered
 		}
 	}
-	res.PriorServedModel, res.SessionEverSwitched = switchHistoryFromPins(pin, hmmHistory, forceHistory)
+	res.PriorServedModel, res.SessionEverSwitched = switchHistoryFromPins(pin, hmmHistory, forceHistory, forceModelPin)
 	req.PolicyTurnContext = buildPolicyTurnContext(req, res, pin, hmmHistory)
 	// Computed before any same-turn pin-drop guards below so it reflects the
 	// prior turn's outcome; Service.effortEscalation gates whether it's acted on.
@@ -1102,7 +1103,7 @@ func (s *Service) runTurnLoop(
 		res.PinTier = "post_command_continuation"
 		res.PinModel = commandContinuation.Model
 		res.PinAgeSec = pinAge(commandContinuation)
-		res.PriorServedModel, res.SessionEverSwitched = switchHistoryFromPins(commandContinuation, hmmHistory, forceHistory)
+		res.PriorServedModel, res.SessionEverSwitched = switchHistoryFromPins(commandContinuation, hmmHistory, forceHistory, forceModelPin)
 		res.EscalateEffort = !commandContinuation.LastTurnEndedAt.IsZero() &&
 			(commandContinuation.LastOutputTokens == 0 || commandContinuation.ConsecutiveUpstreamErrors > 0)
 		log.Info("turnloop used one-shot post-command continuation",

--- a/internal/proxy/turnloop.go
+++ b/internal/proxy/turnloop.go
@@ -592,7 +592,7 @@ func (s *Service) runTurnLoop(
 			res.SessionKey = threadSessionKey
 			res.PinModel = forceModelPin.Model
 			res.PinAgeSec = pinAge(forceModelPin)
-			res.PriorServedModel, res.SessionEverSwitched = switchHistoryFromPins(threadPin, hmmHistory, forceHistory, forceModelPin)
+			res.PriorServedModel, res.SessionEverSwitched = switchHistoryFromPins(threadPin, hmmHistory, forceHistory)
 			res.EscalateEffort = !forceHistory.LastTurnEndedAt.IsZero() &&
 				(forceHistory.LastOutputTokens == 0 || forceHistory.ConsecutiveUpstreamErrors > 0)
 			res.Decision = pinDecision(forceModelPin)
@@ -738,7 +738,7 @@ func (s *Service) runTurnLoop(
 	}
 	hmmHistory := s.loadHMMHistory(ctx, res.SessionKey, res.PinRole)
 	forceHistory := sessionpin.Pin{}
-	if forceModelFound || forceModelCleared {
+	if forceModelFound {
 		forceHistory = s.loadForceModelHistory(ctx, res.SessionKey, res.PinRole)
 	}
 	if !forceModelFound && !forceModelCleared && pinFound && isUserForcedReason(pin.Reason) {
@@ -810,7 +810,7 @@ func (s *Service) runTurnLoop(
 			req.EnabledProviders = filtered
 		}
 	}
-	res.PriorServedModel, res.SessionEverSwitched = switchHistoryFromPins(pin, hmmHistory, forceHistory, forceModelPin)
+	res.PriorServedModel, res.SessionEverSwitched = switchHistoryFromPins(pin, hmmHistory, forceHistory)
 	req.PolicyTurnContext = buildPolicyTurnContext(req, res, pin, hmmHistory)
 	// Computed before any same-turn pin-drop guards below so it reflects the
 	// prior turn's outcome; Service.effortEscalation gates whether it's acted on.
@@ -1103,7 +1103,11 @@ func (s *Service) runTurnLoop(
 		res.PinTier = "post_command_continuation"
 		res.PinModel = commandContinuation.Model
 		res.PinAgeSec = pinAge(commandContinuation)
-		res.PriorServedModel, res.SessionEverSwitched = switchHistoryFromPins(commandContinuation, hmmHistory, forceHistory, forceModelPin)
+		if forceModelCleared {
+			res.PriorServedModel, res.SessionEverSwitched = switchHistoryFromPins(commandContinuation, hmmHistory, forceHistory, forceModelPin)
+		} else {
+			res.PriorServedModel, res.SessionEverSwitched = switchHistoryFromPins(commandContinuation, hmmHistory, forceHistory)
+		}
 		res.EscalateEffort = !commandContinuation.LastTurnEndedAt.IsZero() &&
 			(commandContinuation.LastOutputTokens == 0 || commandContinuation.ConsecutiveUpstreamErrors > 0)
 		log.Info("turnloop used one-shot post-command continuation",


### PR DESCRIPTION
## Summary

- derive an API-key-scoped force-model control key from the client session ID, without the first-message discriminator that intentionally separates child agent threads
- consult that control before hard pins and automatic routing on every turn type, while keeping compaction, pin usage, and switch history on each ordinary thread key
- make explicit user force state independent of the active router strategy and preserve it across strategy toggles
- retain the existing visible fallback when a forced model cannot serve one particular request
- write a durable `/unforce-model` tombstone so stale legacy thread pins cannot reactivate the force

## Why

Ordinary session pins include the first user message so Task/Explore threads do not share automatic routing state. `/force-model` used the same key, so a parent could be forced while child threads silently routed other models. Strategy changes could also make the stored force pin ineligible.

The force control is now session-wide, but it is control state only. Child threads still keep independent automatic pins, compaction counters, and model-switch history.

## Validation

- `go test ./internal/proxy -count=1`
- focused force-model regression tests under `-race`
- `make precommit`
- `make check`

🤖 Generated with [Weave Router](https://router.workweave.ai)