### PR TITLE
fix(bandit): repair PairedModel when Thompson sampling switches model

### DIFF
--- a/internal/router/bandit/bandit.go
+++ b/internal/router/bandit/bandit.go
@@ -109,8 +109,13 @@ func (b *Router) Route(ctx context.Context, req router.Request) (router.Decision
 	argmaxModel := dec.Model
 	pick := candidates[0]
 	b.annotate(&dec, pick.model, pick.provider, b.propensity(clusterIDs, candidates, pick.model), pick.sample)
-	if pick.model != argmaxModel && md.EffectiveKnobsHash != 0 {
-		md.EffectiveKnobsHash = mixModel(md.EffectiveKnobsHash, pick.model)
+	if pick.model != argmaxModel {
+		if md.EffectiveKnobsHash != 0 {
+			md.EffectiveKnobsHash = mixModel(md.EffectiveKnobsHash, pick.model)
+		}
+		// The scorer's runner-up was computed against the argmax and may now
+		// equal the served peer; recompute it against the served model.
+		repairBandPair(&md.PairedModel, &md.PairedProvider, &md.PairedScore, md.CandidateScores, candidates, pick.model)
 	}
 	return dec, nil
 }
@@ -183,6 +188,42 @@ func (b *Router) annotate(dec *router.Decision, model, provider string, propensi
 	if s, ok := dec.Metadata.CandidateScores[model]; ok {
 		dec.Metadata.ChosenScore = s
 	}
+}
+
+// repairBandPair recomputes the band pair's runner-up against the served
+// model, writing it back through the metadata pointers. Picks the
+// highest-scoring servable peer other than served (ties broken by name);
+// clears the pair if none remains. Providers come from the live candidate
+// list (resolved before annotate) so the prior argmax stays eligible even
+// when it was only bound via Decision.Provider.
+func repairBandPair(outModel, outProvider *string, outScore *float32, scores map[string]float32, cands []candidate, served string) {
+	providers := make(map[string]string, len(cands))
+	for _, c := range cands {
+		providers[c.model] = c.provider
+	}
+	models := make([]string, 0, len(scores))
+	for m := range scores {
+		models = append(models, m)
+	}
+	sort.Strings(models)
+
+	bestModel, bestProvider := "", ""
+	var bestScore float32
+	for _, m := range models {
+		if m == served {
+			continue
+		}
+		sc := scores[m]
+		if bestModel != "" && sc <= bestScore {
+			continue
+		}
+		provider, ok := providers[m]
+		if !ok || provider == "" {
+			continue
+		}
+		bestModel, bestProvider, bestScore = m, provider, sc
+	}
+	*outModel, *outProvider, *outScore = bestModel, bestProvider, bestScore
 }
 
 func mixModel(h uint64, model string) uint64 {

--- a/internal/router/bandit/bandit.go
+++ b/internal/router/bandit/bandit.go
@@ -191,11 +191,9 @@ func (b *Router) annotate(dec *router.Decision, model, provider string, propensi
 }
 
 // repairBandPair recomputes the band pair's runner-up against the served
-// model, writing it back through the metadata pointers. Picks the
-// highest-scoring servable peer other than served (ties broken by name);
-// clears the pair if none remains. Providers come from the live candidate
-// list (resolved before annotate) so the prior argmax stays eligible even
-// when it was only bound via Decision.Provider.
+// model. Picks the highest-scoring servable peer other than served (ties
+// broken by name); clears the pair if none remains. Providers come from the
+// live candidate list so peers resolved only via Decision.Provider stay eligible.
 func repairBandPair(outModel, outProvider *string, outScore *float32, scores map[string]float32, cands []candidate, served string) {
 	providers := make(map[string]string, len(cands))
 	for _, c := range cands {

--- a/internal/router/bandit/bandit_test.go
+++ b/internal/router/bandit/bandit_test.go
@@ -131,10 +131,9 @@ func TestRoute_PropensityReflectsPosteriorOverlap(t *testing.T) {
 }
 
 func TestRoute_KeepsArgmaxWhenSameModel(t *testing.T) {
+	// Keeping the argmax must leave the scorer's PairedModel untouched.
 	scores := map[string]float32{"claude-haiku-4-5": 0.9, "claude-sonnet-4-6": 0.5}
 	inner := clusterDecision(scores, []int{0}, "claude-haiku-4-5", "anthropic")
-	// Scorer's runner-up; keeping the argmax must leave this pair untouched
-	// rather than recomputing it.
 	inner.Metadata.PairedModel = "claude-sonnet-4-6"
 	inner.Metadata.PairedProvider = "anthropic"
 	inner.Metadata.PairedScore = 0.5
@@ -163,11 +162,7 @@ func TestRoute_KeepsArgmaxWhenSameModel(t *testing.T) {
 }
 
 func TestRoute_RepairsBandPairWhenServingRunnerUp(t *testing.T) {
-	// Scorer picks sonnet (argmax 0.90) with haiku (0.85) as the frozen
-	// runner-up. Zero-noise TS prefers haiku's higher posterior mean, so the
-	// served model becomes the former runner-up. The pin pair must not
-	// collapse to {haiku, haiku}: it recomputes to the best remaining peer,
-	// sonnet (the prior argmax).
+	// Serving the former runner-up must recompute PairedModel to the prior argmax.
 	scores := map[string]float32{
 		"claude-sonnet-4-6": 0.90,
 		"claude-haiku-4-5":  0.85,

--- a/internal/router/bandit/bandit_test.go
+++ b/internal/router/bandit/bandit_test.go
@@ -133,6 +133,11 @@ func TestRoute_PropensityReflectsPosteriorOverlap(t *testing.T) {
 func TestRoute_KeepsArgmaxWhenSameModel(t *testing.T) {
 	scores := map[string]float32{"claude-haiku-4-5": 0.9, "claude-sonnet-4-6": 0.5}
 	inner := clusterDecision(scores, []int{0}, "claude-haiku-4-5", "anthropic")
+	// Scorer's runner-up; keeping the argmax must leave this pair untouched
+	// rather than recomputing it.
+	inner.Metadata.PairedModel = "claude-sonnet-4-6"
+	inner.Metadata.PairedProvider = "anthropic"
+	inner.Metadata.PairedScore = 0.5
 	post, err := LoadPosterior("testdata/ts_posterior.json")
 	if err != nil {
 		t.Fatal(err)
@@ -148,6 +153,57 @@ func TestRoute_KeepsArgmaxWhenSameModel(t *testing.T) {
 	}
 	if dec.Metadata.EffectiveKnobsHash != 99 {
 		t.Fatal("keeping argmax must preserve cache key")
+	}
+	if dec.Metadata.PairedModel != "claude-sonnet-4-6" {
+		t.Fatalf("argmax keep must preserve scorer runner-up sonnet, got %q", dec.Metadata.PairedModel)
+	}
+	if dec.Metadata.PairedScore != 0.5 {
+		t.Fatalf("argmax keep must preserve scorer paired score, got %v", dec.Metadata.PairedScore)
+	}
+}
+
+func TestRoute_RepairsBandPairWhenServingRunnerUp(t *testing.T) {
+	// Scorer picks sonnet (argmax 0.90) with haiku (0.85) as the frozen
+	// runner-up. Zero-noise TS prefers haiku's higher posterior mean, so the
+	// served model becomes the former runner-up. The pin pair must not
+	// collapse to {haiku, haiku}: it recomputes to the best remaining peer,
+	// sonnet (the prior argmax).
+	scores := map[string]float32{
+		"claude-sonnet-4-6": 0.90,
+		"claude-haiku-4-5":  0.85,
+	}
+	inner := clusterDecision(scores, []int{0}, "claude-sonnet-4-6", "anthropic")
+	inner.Metadata.PairedModel = "claude-haiku-4-5"
+	inner.Metadata.PairedProvider = "anthropic"
+	inner.Metadata.PairedScore = 0.85
+	post := &Posterior{cells: map[int]map[string]Arm{
+		0: {
+			"claude-haiku-4-5":  {Mean: 0.9, Variance: 0},
+			"claude-sonnet-4-6": {Mean: 0.1, Variance: 0},
+		},
+	}}
+	b := New(&fakeInner{dec: inner}, post)
+	b.norm = func() float64 { return 0 }
+	b.trials = 0
+
+	dec, err := b.Route(context.Background(), router.Request{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if dec.Model != "claude-haiku-4-5" {
+		t.Fatalf("expected Thompson pick haiku (runner-up), got %q", dec.Model)
+	}
+	if dec.Metadata.PairedModel == dec.Model {
+		t.Fatalf("band pair collapsed: Model and PairedModel are both %q", dec.Model)
+	}
+	if dec.Metadata.PairedModel != "claude-sonnet-4-6" {
+		t.Fatalf("expected runner-up recomputed to sonnet, got %q", dec.Metadata.PairedModel)
+	}
+	if dec.Metadata.PairedProvider != "anthropic" {
+		t.Fatalf("expected paired provider anthropic, got %q", dec.Metadata.PairedProvider)
+	}
+	if dec.Metadata.PairedScore != 0.90 {
+		t.Fatalf("expected paired score 0.90, got %v", dec.Metadata.PairedScore)
 	}
 }
 


### PR DESCRIPTION
## Summary

**Bug:** When `x-weave-router-strategy: bandit` Thompson-samples the cluster scorer's runner-up, `bandit.Router` rewrote `Model` but left `Metadata.PairedModel` pointing at that same slug. `writeNewPin` persisted `{pinned_model, paired_model}` as identical values, which silently disabled Stage 2 `bandSwapServed` for the pin's life (LARGE and SMALL resolved to one model).

**Fix:** On a real model switch, recompute the runner-up against the served model — same contract as `banditexplore.repairBandPair`. Argmax draws leave the scorer pair untouched.

Fixes #753

## What changed

| File | Change |
|---|---|
| `internal/router/bandit/bandit.go` | Call `repairBandPair` after annotate when TS switches off the argmax |
| `internal/router/bandit/bandit_test.go` | Regression tests with one-line behavior comments (AGENTS.md style) |

## Verification

Local (author):
- [x] `make check` — all checks passed
- [x] `go test ./internal/router/bandit/... -race`
- [x] Stress 5000 trials on real testdata posterior: **0 collapses** after fix (was 100% collapse on runner-up serves)

GitHub Actions (fork PR):
- [x] Cursor Bugbot — pass
- [ ] **Test / Comment Length / Cluster Routing** — currently `action_required` (first-time contributor workflow approval). A maintainer needs to click **Approve and run workflows** on the PR checks tab before these can go green.

## Checklist (CONTRIBUTING.md / AGENTS.md)

- [x] Topic branch (not on `main`)
- [x] Conventional Commits + DCO `Signed-off-by`
- [x] Test comments state asserted behavior only (no issue/PR refs, no pre-fix narration)
- [x] Linked issue