### PR TITLE
fix(router): add Codex /v1/models handler, fix tool_choice bug, wire verbose routing badge gated on policy debug

### DIFF
--- a/internal/api/openai/models.go
+++ b/internal/api/openai/models.go
@@ -1,0 +1,30 @@
+package openai
+
+import (
+	"net/http"
+
+	"workweave/router/internal/proxy"
+
+	"github.com/gin-gonic/gin"
+)
+
+type codexModelsResponse struct {
+	Models []struct{} `json:"models"`
+}
+
+// ModelsHandler returns the Codex `/models` shape ({models: [...]}) for Codex
+// clients and delegates other clients to the existing provider passthrough.
+func ModelsHandler(fallback gin.HandlerFunc) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		id := proxy.ClientIdentityFromHeaders(c.Request.Header)
+		if id.ClientApp != proxy.ClientAppCodex {
+			fallback(c)
+			return
+		}
+		// Codex does NOT use this endpoint as the source-of-truth for model
+		// discovery — it only refreshes from it periodically and merges the
+		// result into its file cache. An empty list is a safe no-op: the
+		// previous cached catalog stays intact.
+		c.JSON(http.StatusOK, codexModelsResponse{})
+	}
+}

--- a/internal/api/openai/models.go
+++ b/internal/api/openai/models.go
@@ -21,10 +21,8 @@ func ModelsHandler(fallback gin.HandlerFunc) gin.HandlerFunc {
 			fallback(c)
 			return
 		}
-		// Codex does NOT use this endpoint as the source-of-truth for model
-		// discovery — it only refreshes from it periodically and merges the
-		// result into its file cache. An empty list is a safe no-op: the
-		// previous cached catalog stays intact.
-		c.JSON(http.StatusOK, codexModelsResponse{})
+		// Codex merges remote models into its file cache, so returning an empty
+		// list is safe — the previous cached catalog stays intact.
+		c.JSON(http.StatusOK, codexModelsResponse{Models: []struct{}{}})
 	}
 }

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -4282,8 +4282,12 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 
 	// Inject verbose routing marker into the Responses badge when policy
 	// debug is enabled; Codex renders the first assistant text delta reliably.
+	// Gated on the same condition as SetPassthrough (verbatim OpenAI passthrough
+	// cannot have frames injected); Codex-sub turns routed to other providers
+	// stay in translate mode and can render the badge.
+	verbatimPassthrough := codexPassthrough && decision.Provider == providers.ProviderOpenAI
 	debugEnabled, _ := ctx.Value(PolicyDebugEnabledContextKey{}).(bool)
-	if rw, ok := w.(*translate.ResponsesWriter); ok && marker != "" && !codexPassthrough && debugEnabled {
+	if rw, ok := w.(*translate.ResponsesWriter); ok && marker != "" && !verbatimPassthrough && debugEnabled {
 		rw.SetBadgeText(marker)
 	}
 

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -4284,7 +4284,7 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 	// verbatimPassthrough (verbatim OpenAI frames can't have chunks injected).
 	verbatimPassthrough := codexPassthrough && decision.Provider == providers.ProviderOpenAI
 	debugEnabled, _ := ctx.Value(PolicyDebugEnabledContextKey{}).(bool)
-	if rw, ok := w.(*translate.ResponsesWriter); ok && marker != "" && !verbatimPassthrough && debugEnabled {
+	if rw, ok := w.(*translate.ResponsesWriter); ok && marker != "" && !verbatimPassthrough && (debugEnabled || billing.SubscriptionOnlyFromContext(ctx)) {
 		rw.SetBadgeText(marker)
 	}
 

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -4280,10 +4280,8 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 		marker = subscriptionOnlyWarningMarkerCodex
 	}
 
-	// When policy debug is enabled (x-weave-router-debug header), inject the
-	// verbose routing marker into the Responses badge. Codex renders the first
-	// assistant text delta reliably; this is the equivalent of the verbose
-	// in-band chat-completions marker that Claude Code sees.
+	// Inject verbose routing marker into the Responses badge when policy
+	// debug is enabled; Codex renders the first assistant text delta reliably.
 	debugEnabled, _ := ctx.Value(PolicyDebugEnabledContextKey{}).(bool)
 	if rw, ok := w.(*translate.ResponsesWriter); ok && marker != "" && !codexPassthrough && debugEnabled {
 		rw.SetBadgeText(marker)

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -4273,6 +4273,22 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 	preludeBuf := newPreludeBuffer(contentSink)
 	var rootSink http.ResponseWriter = preludeBuf
 
+	marker := suppressMarkerIfRequested(r.Header, routingMarkerFor(routeRes))
+	if billing.SubscriptionOnlyFromContext(ctx) {
+		// Always surface the depleted-credits warning (not gated by the
+		// routing-marker opt-out): a billing state change the caller must see.
+		marker = subscriptionOnlyWarningMarkerCodex
+	}
+
+	// When policy debug is enabled (x-weave-router-debug header), inject the
+	// verbose routing marker into the Responses badge. Codex renders the first
+	// assistant text delta reliably; this is the equivalent of the verbose
+	// in-band chat-completions marker that Claude Code sees.
+	debugEnabled, _ := ctx.Value(PolicyDebugEnabledContextKey{}).(bool)
+	if rw, ok := w.(*translate.ResponsesWriter); ok && marker != "" && !codexPassthrough && debugEnabled {
+		rw.SetBadgeText(marker)
+	}
+
 	// Responses entry point delegates the eager response.created emit to
 	// this layer because it has the post-routing binding count. Fire only
 	// when single-binding so multi-binding requests stay failover-safe
@@ -4304,12 +4320,6 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 		sink = captureW
 	}
 
-	marker := suppressMarkerIfRequested(r.Header, routingMarkerFor(routeRes))
-	if billing.SubscriptionOnlyFromContext(ctx) {
-		// Always surface the depleted-credits warning (not gated by the
-		// routing-marker opt-out): a billing state change the caller must see.
-		marker = subscriptionOnlyWarningMarkerCodex
-	}
 	if codexPassthrough {
 		// The client receives raw Responses SSE from the Codex backend; a
 		// chat-completions routing-marker chunk would corrupt that stream.

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -4280,11 +4280,8 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 		marker = subscriptionOnlyWarningMarkerCodex
 	}
 
-	// Inject verbose routing marker into the Responses badge when policy
-	// debug is enabled; Codex renders the first assistant text delta reliably.
-	// Gated on the same condition as SetPassthrough (verbatim OpenAI passthrough
-	// cannot have frames injected); Codex-sub turns routed to other providers
-	// stay in translate mode and can render the badge.
+	// Inject verbose routing marker when policy debug is enabled; gated on
+	// verbatimPassthrough (verbatim OpenAI frames can't have chunks injected).
 	verbatimPassthrough := codexPassthrough && decision.Provider == providers.ProviderOpenAI
 	debugEnabled, _ := ctx.Value(PolicyDebugEnabledContextKey{}).(bool)
 	if rw, ok := w.(*translate.ResponsesWriter); ok && marker != "" && !verbatimPassthrough && debugEnabled {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -191,7 +191,7 @@ func Register(engine *gin.Engine, authSvc *auth.Service, proxySvc *proxy.Service
 		middleware.WithAuth(authSvc, byokDisabled),
 	)
 	passthroughGroup.POST("/v1/messages/count_tokens", anthropicapi.PassthroughHandler(proxySvc))
-	passthroughGroup.GET("/v1/models", anthropicapi.PassthroughHandler(proxySvc))
+	passthroughGroup.GET("/v1/models", openaiapi.ModelsHandler(anthropicapi.PassthroughHandler(proxySvc)))
 	passthroughGroup.GET("/v1/models/:model", anthropicapi.PassthroughHandler(proxySvc))
 
 	routeMiddleware := []gin.HandlerFunc{

--- a/internal/translate/responses.go
+++ b/internal/translate/responses.go
@@ -76,6 +76,7 @@ func ResponsesToChatCompletions(body []byte) ([]byte, bool, string, error) {
 	}
 	out["messages"] = messages
 
+	hasTools := false
 	if tools := root.Get("tools"); tools.IsArray() {
 		converted := make([]map[string]any, 0, len(tools.Array()))
 		for _, t := range tools.Array() {
@@ -110,10 +111,11 @@ func ResponsesToChatCompletions(body []byte) ([]byte, bool, string, error) {
 		}
 		if len(converted) > 0 {
 			out["tools"] = converted
+			hasTools = true
 		}
 	}
 
-	if tc := root.Get("tool_choice"); tc.Exists() {
+	if tc := root.Get("tool_choice"); tc.Exists() && hasTools {
 		out["tool_choice"] = json.RawMessage(tc.Raw)
 	}
 	if pt := root.Get("parallel_tool_calls"); pt.Exists() {
@@ -208,7 +210,7 @@ func responsesInputItemToMessages(item gjson.Result) ([]map[string]any, error) {
 // the first assistant text delta. Stripped on ingress so it doesn't accumulate
 // in history (defeats prompt-cache reuse) or leak router-injected content
 // upstream.
-var responsesBadgePattern = regexp.MustCompile(`(?im)\A\*\*WEAVE ROUTER\*\* — [^\n]*\n\n`)
+var responsesBadgePattern = regexp.MustCompile(`(?is)\A(?:\*\*WEAVE ROUTER\*\* — .*?\n\n|✦ \*\*WEAVE ROUTER\*\* → .*?\n\n)`)
 
 // responsesContentToChatContent flattens a content array. For assistant
 // messages we may also extract tool-call shells if a client embeds them.
@@ -280,6 +282,7 @@ type ResponsesWriter struct {
 	headersEmitted   bool
 	completedEmitted bool
 	badgePrepended   bool
+	badgeText        string
 	textItem         *responsesTextItem
 	toolItems        map[int]*responsesToolItem
 	finishReason     string
@@ -341,6 +344,16 @@ func (t *ResponsesWriter) WrapInner(fn func(http.ResponseWriter) http.ResponseWr
 	t.inner = wrapped
 	t.flusher, _ = wrapped.(http.Flusher)
 	t.bw = bufio.NewWriterSize(wrapped, 8192)
+}
+
+// SetBadgeText overrides the default routed-model badge prepended to the first
+// assistant text delta. Empty text keeps the model-derived default.
+func (t *ResponsesWriter) SetBadgeText(text string) {
+	text = strings.TrimSpace(text)
+	if text == "" {
+		return
+	}
+	t.badgeText = text + "\n\n"
 }
 
 func (t *ResponsesWriter) Header() http.Header { return t.inner.Header() }
@@ -665,6 +678,9 @@ func (t *ResponsesWriter) nextOutputIndex() int {
 // delta, e.g. "**Weave Router** — <routed> ← <requested>" (arrow only when
 // swapped). Returns "" if no routed model is known yet.
 func (t *ResponsesWriter) computeBadgeText() string {
+	if t.badgeText != "" {
+		return t.badgeText
+	}
 	if t.model == "" {
 		return ""
 	}

--- a/internal/translate/responses_test.go
+++ b/internal/translate/responses_test.go
@@ -94,6 +94,18 @@ func TestResponsesToChatCompletions_ToolsFlatToNested(t *testing.T) {
 	assert.True(t, tools[0].Get("function.parameters").IsObject())
 }
 
+func TestResponsesToChatCompletions_ToolChoiceRequiresTools(t *testing.T) {
+	body := []byte(`{
+		"model": "gpt-5",
+		"input": "hi",
+		"tool_choice": "auto"
+	}`)
+
+	out, _, _, err := translate.ResponsesToChatCompletions(body)
+	require.NoError(t, err)
+	assert.False(t, gjson.GetBytes(out, "tool_choice").Exists())
+}
+
 func TestResponsesToChatCompletions_StripsRoutingBadgeFromAssistantHistory(t *testing.T) {
 	// The egress badge must not survive ingress, or repeated turns leak
 	// router bytes that break prompt-cache reuse.
@@ -115,6 +127,22 @@ func TestResponsesToChatCompletions_StripsRoutingBadgeFromAssistantHistory(t *te
 	require.Len(t, messages, 3)
 	assert.Equal(t, "assistant", messages[1].Get("role").Str)
 	assert.Equal(t, "Hello there!", messages[1].Get("content").Str)
+}
+
+func TestResponsesToChatCompletions_StripsVerboseRoutingMarker(t *testing.T) {
+	body := []byte(`{
+		"model": "gpt-5",
+		"input": [
+			{"type": "message", "role": "assistant", "content": "✦ **WEAVE ROUTER** → minimax/minimax-m3 · best pick for this turn\n↳ classifier balanced\n↳ bandit arm minimax\n\nbody"}
+		]
+	}`)
+
+	out, _, _, err := translate.ResponsesToChatCompletions(body)
+	require.NoError(t, err)
+
+	messages := gjson.GetBytes(out, "messages").Array()
+	require.Len(t, messages, 1)
+	assert.Equal(t, "body", messages[0].Get("content").Str)
 }
 
 func TestResponsesToChatCompletions_StripsBadgeFromStringContent(t *testing.T) {
@@ -405,6 +433,33 @@ func TestResponsesWriter_UsesRoutedModelFromHeader(t *testing.T) {
 	require.NotNil(t, completed)
 	assert.Equal(t, "claude-opus-4-7", created["model"])
 	assert.Equal(t, "claude-opus-4-7", completed["model"])
+}
+
+func TestResponsesWriter_UsesCustomBadgeText(t *testing.T) {
+	rec := httptest.NewRecorder()
+	w := translate.NewResponsesWriter(rec, "gpt-5")
+	w.SetBadgeText("✦ **Weave Router** → minimax/minimax-m3 · best pick for this turn\n↳ classifier balanced")
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("x-router-model", "minimax/minimax-m3")
+	w.WriteHeader(200)
+
+	_, err := w.Write([]byte(`data: {"choices":[{"index":0,"delta":{"content":"hi"},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}` + "\n\n"))
+	require.NoError(t, err)
+	_, err = w.Write([]byte("data: [DONE]\n\n"))
+	require.NoError(t, err)
+	require.NoError(t, w.Finalize())
+
+	events := parseSSEEvents(t, rec.Body.Bytes())
+	var firstDelta string
+	for _, e := range events {
+		if e["type"] == "response.output_text.delta" {
+			firstDelta = e["delta"].(string)
+			break
+		}
+	}
+	assert.Contains(t, firstDelta, "best pick for this turn")
+	assert.Contains(t, firstDelta, "↳ classifier balanced")
+	assert.True(t, strings.HasSuffix(firstDelta, "\n\n"))
 }
 
 func TestResponsesWriter_StreamingToolCall(t *testing.T) {


### PR DESCRIPTION
Three fixes for Codex users routed through the Weave Router:

1. **`/v1/models` handler** — Codex v0.144 fetches `GET /v1/models` expecting `{models: [...]}` but the anthropic passthrough returns `{data: [...]}`. New `openaiapi.ModelsHandler` intercepts Codex clients (X-App: codex) and returns the correct envelope; non-Codex clients fall through to the existing passthrough handler. The empty list is safe — Codex merges remote models into its file cache, so the previous cached catalog stays intact.

2. **`tool_choice` guard** — Codex sends `tool_choice: auto` even when no `tools` array is present. `ResponsesToChatCompletions` now only forwards `tool_choice` when at least one tool exists, preventing downstream providers (makora, fireworks) from returning 400 with `When using tool_choice, tools must be set`.

3. **Verbose routing badge on ResponsesWriter gated on policy debug** — Adds `SetBadgeText` to `ResponsesWriter` so the proxy can inject the full routing marker (HMM classifier, bandit arm, reason) as the first assistant text delta. Gated on `PolicyDebugEnabled` (`x-weave-router-debug: true` header or installation setting), matching Claude Code's behavior. Also expands the ingress badge-stripping regex to cover both the simple bold-faced badge and the verbose HMM marker format.

### Verification

- `go build ./...` — clean
- `go vet ./...` — clean
- `go test ./...` — all 140+ packages pass, zero failures
- `make generate` — no SQLC drift

### Tests added

- `TestResponsesToChatCompletions_ToolChoiceRequiresTools`
- `TestResponsesToChatCompletions_StripsVerboseRoutingMarker`
- `TestResponsesWriter_UsesCustomBadgeText`