### PR TITLE
feat(router): user-facing effort knob — x-weave-effort header and :level suffix on force-model pin

### DIFF
--- a/internal/proxy/force_model.go
+++ b/internal/proxy/force_model.go
@@ -220,8 +220,8 @@ func (s *Service) setForceModelPin(
 // (re)written on every request carrying the header. Unrecognized models are
 // ignored (routing proceeds automatically) rather than failing the request.
 //
-// A `:level` suffix (`:low`, `:fast`, `:ultra`) is stashed on the request
-// context as router.Overrides.ForceEffort so pin + effort land in one header.
+// A `:level` suffix is stashed on context as router.Overrides.ForceEffort
+// so pin + effort land in one header.
 func (s *Service) applyForceModelHeader(
 	ctx context.Context,
 	r *http.Request,

--- a/internal/proxy/force_model.go
+++ b/internal/proxy/force_model.go
@@ -106,18 +106,11 @@ func resolveForceModel(model string) (canonicalID, provider string, known bool) 
 	return canon, prov, kn
 }
 
-// resolveForceModelWithEffort maps a user-typed model identifier to its
-// canonical catalog ID, primary provider, and any `:level` effort suffix
-// they wrote. A `:low`/`:high`/`:max`/`:xhigh`/`:fast`/`:ultra` suffix is
-// split off before resolution and returned as the fourth value so the
-// caller can persist it (or stash it on the request context for the
-// per-turn emit path). Resolution order mirrors resolveForceModel:
-// alias -> catalog.ByID -> suffix-match fallback -> provider heuristic.
-//
-// `known` is true only for catalog matches; an unrecognized value with a
-// valid `:level` suffix still returns effort != "" and known=false, so the
-// caller can still surface a useful error to the user ("model not found")
-// rather than silently swallowing both halves of the input.
+// resolveForceModelWithEffort is like resolveForceModel but also strips a
+// `:level` suffix and returns it as effort. Resolution order: alias →
+// catalog.ByID → suffix-match → provider heuristic. `known` is true only for
+// catalog matches; known=false + effort!="" lets callers surface "model not
+// found" without swallowing the effort half.
 func resolveForceModelWithEffort(model string) (canonicalID, provider string, known bool, effort string) {
 	effortLevel, stripped := stripEffortSuffix(model)
 	model = stripped
@@ -159,11 +152,8 @@ func resolveForceModelWithEffort(model string) (canonicalID, provider string, kn
 	}
 }
 
-// stripEffortSuffix pulls a `:level` suffix off a force-model input. Maps
-// user-facing alias forms ("fast","minimal","ultra") to canonical levels
-// ("low","low","xhigh") via translate.CanonicalizeEffort, so the header
-// and the pin-and-effort surface disagree with the middleware parser.
-// No suffix → ("", input verbatim).
+// stripEffortSuffix splits a `:level` suffix off model, canonicalizes it via
+// CanonicalizeEffort, and returns ("", model) when no recognized suffix found.
 func stripEffortSuffix(model string) (effort string, modelOut string) {
 	const sep = ":"
 	idx := strings.LastIndex(model, sep)
@@ -177,10 +167,8 @@ func stripEffortSuffix(model string) (effort string, modelOut string) {
 	return translate.CanonicalizeEffort(tail), model[:idx]
 }
 
-// looksLikeEffortAlias is the cheap allow-list pre-check on colon-suffixed
-// force-model inputs. Catalog IDs don't contain `:` today (the catalog
-// is the source of truth and never used them); this guards against
-// future IDs that happen to use a colon.
+// looksLikeEffortAlias guards against future catalog IDs that contain `:`,
+// ensuring the colon is only treated as a suffix separator for known levels.
 func looksLikeEffortAlias(tail string) bool {
 	switch strings.ToLower(strings.TrimSpace(tail)) {
 	case "fast", "low", "medium", "med", "high", "max", "xhigh",
@@ -234,12 +222,8 @@ func (s *Service) setForceModelPin(
 // (re)written on every request carrying the header. Unrecognized models are
 // ignored (routing proceeds automatically) rather than failing the request.
 //
-// A `:level` suffix on the value (`:low`, `:fast`, `:ultra`, etc.) is split
-// off and stashed on the request context as router.Overrides.ForceEffort
-// so the proxy consumes it on the same turn. Eval harnesses that need to
-// pin a model AND force effort can do so in one header, instead of
-// sharing session state between a pin turn and a separate force-effort
-// turn.
+// A `:level` suffix (`:low`, `:fast`, `:ultra`) is stashed on the request
+// context as router.Overrides.ForceEffort so pin + effort land in one header.
 func (s *Service) applyForceModelHeader(
 	ctx context.Context,
 	r *http.Request,
@@ -254,11 +238,22 @@ func (s *Service) applyForceModelHeader(
 	log := observability.FromContext(ctx)
 	canonicalModel, provider, known, effortLevel := resolveForceModelWithEffort(raw)
 	if effortLevel != "" {
-		// Stash on the request context so routingKnobsForRequest + the
-		// proxy's EmitOptions build both pick it up on the same turn.
-		// Same surface the WithForceEffortOverride middleware takes.
-		overrides := router.Overrides{ForceEffort: effortLevel}
-		ctx = router.WithRoutingKnobs(ctx, &overrides)
+		// Stash on the request context so routingKnobsForRequest +
+		// the proxy's EmitOptions build both pick it up on the same
+		// turn. Merge with any existing knobs so ForceEffort doesn't
+		// silently drop a separately-configured Alpha/QualityBias.
+		merged := router.Overrides{ForceEffort: effortLevel}
+		if existing := router.RoutingKnobsFromContext(r.Context()); existing != nil {
+			merged.Alpha = existing.Alpha
+			merged.QualityBias = existing.QualityBias
+			merged.SpeedWeight = existing.SpeedWeight
+			merged.OutputCostRatio = existing.OutputCostRatio
+			merged.ExpectedOutputTokens = existing.ExpectedOutputTokens
+			merged.PerModelVerbosity = existing.PerModelVerbosity
+		}
+		// Mutate *r so the caller's downstream routingKnobsForRequest
+		// (which reads ctx from r.Context()) discovers the knob.
+		*r = *r.WithContext(router.WithRoutingKnobs(r.Context(), &merged))
 	}
 	if !known {
 		log.Info("x-weave-force-model: ignoring unrecognized model; routing automatically",

--- a/internal/proxy/force_model.go
+++ b/internal/proxy/force_model.go
@@ -107,10 +107,8 @@ func resolveForceModel(model string) (canonicalID, provider string, known bool) 
 }
 
 // resolveForceModelWithEffort is like resolveForceModel but also strips a
-// `:level` suffix and returns it as effort. Resolution order: alias →
-// catalog.ByID → suffix-match → provider heuristic. `known` is true only for
-// catalog matches; known=false + effort!="" lets callers surface "model not
-// found" without swallowing the effort half.
+// `:level` suffix. `known` is true only for catalog matches; known=false +
+// effort!="" lets callers surface "model not found" without losing the effort.
 func resolveForceModelWithEffort(model string) (canonicalID, provider string, known bool, effort string) {
 	effortLevel, stripped := stripEffortSuffix(model)
 	model = stripped

--- a/internal/proxy/force_model.go
+++ b/internal/proxy/force_model.go
@@ -238,10 +238,7 @@ func (s *Service) applyForceModelHeader(
 	log := observability.FromContext(ctx)
 	canonicalModel, provider, known, effortLevel := resolveForceModelWithEffort(raw)
 	if effortLevel != "" {
-		// Stash on the request context so routingKnobsForRequest +
-		// the proxy's EmitOptions build both pick it up on the same
-		// turn. Merge with any existing knobs so ForceEffort doesn't
-		// silently drop a separately-configured Alpha/QualityBias.
+		// Merge with any existing knobs so ForceEffort doesn't drop Alpha/QualityBias.
 		merged := router.Overrides{ForceEffort: effortLevel}
 		if existing := router.RoutingKnobsFromContext(r.Context()); existing != nil {
 			merged.Alpha = existing.Alpha

--- a/internal/proxy/force_model.go
+++ b/internal/proxy/force_model.go
@@ -11,6 +11,7 @@ import (
 
 	"workweave/router/internal/observability"
 	"workweave/router/internal/providers"
+	"workweave/router/internal/router"
 	"workweave/router/internal/router/catalog"
 	"workweave/router/internal/router/sessionpin"
 	"workweave/router/internal/translate"
@@ -98,25 +99,35 @@ var forceModelAliases = map[string]string{
 	"mistral":      "mistralai/mistral-small-2603",
 }
 
-// resolveForceModel maps a user-typed model identifier to its canonical
-// catalog ID and primary provider. The catalog is the source of truth;
-// naming heuristics are only a best-effort provider guess for inputs not in
-// it. Resolution order: alias -> exact catalog.ByID match -> suffix match
-// (so bare names like `qwen3-235b-a22b-2507` resolve to their real binding,
-// e.g. `qwen/qwen3-235b-a22b-2507`, instead of misclassifying as Anthropic)
-// -> naming heuristic.
-//
-// `known` is true only for catalog matches. False means there's no catalog
-// entry to confirm this is a real, servable model — callers must reject the
-// command rather than pin it; the heuristic provider is still returned for
-// logging.
+// resolveForceModel is the legacy two-return surface. New pin-and-effort
+// callers use resolveForceModelWithEffort.
 func resolveForceModel(model string) (canonicalID, provider string, known bool) {
+	canon, prov, kn, _ := resolveForceModelWithEffort(model)
+	return canon, prov, kn
+}
+
+// resolveForceModelWithEffort maps a user-typed model identifier to its
+// canonical catalog ID, primary provider, and any `:level` effort suffix
+// they wrote. A `:low`/`:high`/`:max`/`:xhigh`/`:fast`/`:ultra` suffix is
+// split off before resolution and returned as the fourth value so the
+// caller can persist it (or stash it on the request context for the
+// per-turn emit path). Resolution order mirrors resolveForceModel:
+// alias -> catalog.ByID -> suffix-match fallback -> provider heuristic.
+//
+// `known` is true only for catalog matches; an unrecognized value with a
+// valid `:level` suffix still returns effort != "" and known=false, so the
+// caller can still surface a useful error to the user ("model not found")
+// rather than silently swallowing both halves of the input.
+func resolveForceModelWithEffort(model string) (canonicalID, provider string, known bool, effort string) {
+	effortLevel, stripped := stripEffortSuffix(model)
+	model = stripped
 	model = strings.ToLower(strings.TrimSpace(model))
+	effort = effortLevel
 	if alias, ok := forceModelAliases[model]; ok {
 		model = alias
 	}
 	if m, ok := catalog.ByID(model); ok && len(m.Providers) > 0 {
-		return m.ID, m.Providers[0].Provider, true
+		return m.ID, m.Providers[0].Provider, true, effort
 	}
 	if !strings.Contains(model, "/") {
 		suffix := "/" + model
@@ -129,22 +140,54 @@ func resolveForceModel(model string) (canonicalID, provider string, known bool) 
 			}
 		}
 		if matches == 1 && len(matched.Providers) > 0 {
-			return matched.ID, matched.Providers[0].Provider, true
+			return matched.ID, matched.Providers[0].Provider, true, effort
 		}
 	}
 	switch {
 	case strings.HasPrefix(model, "claude-"):
-		return model, providers.ProviderAnthropic, false
+		return model, providers.ProviderAnthropic, false, effort
 	case strings.HasPrefix(model, "gpt-"),
 		model == "o1", model == "o3", model == "o1-pro", model == "o3-pro",
 		strings.HasPrefix(model, "o1-"), strings.HasPrefix(model, "o3-"), strings.HasPrefix(model, "o4-"):
-		return model, providers.ProviderOpenAI, false
+		return model, providers.ProviderOpenAI, false, effort
 	case strings.HasPrefix(model, "gemini-"):
-		return model, providers.ProviderGoogle, false
+		return model, providers.ProviderGoogle, false, effort
 	case strings.Contains(model, "/"):
-		return model, providers.ProviderOpenRouter, false
+		return model, providers.ProviderOpenRouter, false, effort
 	default:
-		return model, providers.ProviderAnthropic, false
+		return model, providers.ProviderAnthropic, false, effort
+	}
+}
+
+// stripEffortSuffix pulls a `:level` suffix off a force-model input. Maps
+// user-facing alias forms ("fast","minimal","ultra") to canonical levels
+// ("low","low","xhigh") via translate.CanonicalizeEffort, so the header
+// and the pin-and-effort surface disagree with the middleware parser.
+// No suffix → ("", input verbatim).
+func stripEffortSuffix(model string) (effort string, modelOut string) {
+	const sep = ":"
+	idx := strings.LastIndex(model, sep)
+	if idx < 0 || idx == len(model)-1 {
+		return "", model
+	}
+	tail := strings.TrimSpace(model[idx+1:])
+	if !looksLikeEffortAlias(tail) {
+		return "", model
+	}
+	return translate.CanonicalizeEffort(tail), model[:idx]
+}
+
+// looksLikeEffortAlias is the cheap allow-list pre-check on colon-suffixed
+// force-model inputs. Catalog IDs don't contain `:` today (the catalog
+// is the source of truth and never used them); this guards against
+// future IDs that happen to use a colon.
+func looksLikeEffortAlias(tail string) bool {
+	switch strings.ToLower(strings.TrimSpace(tail)) {
+	case "fast", "low", "medium", "med", "high", "max", "xhigh",
+		"ultra", "minimal", "min":
+		return true
+	default:
+		return false
 	}
 }
 
@@ -190,6 +233,13 @@ func (s *Service) setForceModelPin(
 // writing the same session pin the /force-model command writes. It's
 // (re)written on every request carrying the header. Unrecognized models are
 // ignored (routing proceeds automatically) rather than failing the request.
+//
+// A `:level` suffix on the value (`:low`, `:fast`, `:ultra`, etc.) is split
+// off and stashed on the request context as router.Overrides.ForceEffort
+// so the proxy consumes it on the same turn. Eval harnesses that need to
+// pin a model AND force effort can do so in one header, instead of
+// sharing session state between a pin turn and a separate force-effort
+// turn.
 func (s *Service) applyForceModelHeader(
 	ctx context.Context,
 	r *http.Request,
@@ -202,7 +252,14 @@ func (s *Service) applyForceModelHeader(
 		return ""
 	}
 	log := observability.FromContext(ctx)
-	canonicalModel, provider, known := resolveForceModel(raw)
+	canonicalModel, provider, known, effortLevel := resolveForceModelWithEffort(raw)
+	if effortLevel != "" {
+		// Stash on the request context so routingKnobsForRequest + the
+		// proxy's EmitOptions build both pick it up on the same turn.
+		// Same surface the WithForceEffortOverride middleware takes.
+		overrides := router.Overrides{ForceEffort: effortLevel}
+		ctx = router.WithRoutingKnobs(ctx, &overrides)
+	}
 	if !known {
 		log.Info("x-weave-force-model: ignoring unrecognized model; routing automatically",
 			"input_model", raw,
@@ -222,6 +279,7 @@ func (s *Service) applyForceModelHeader(
 		"input_model", raw,
 		"canonical_model", canonicalModel,
 		"provider", provider,
+		"effort", effortLevel,
 		"session_key_hex", fmt.Sprintf("%x", sessionKey),
 		"role", role,
 	)

--- a/internal/proxy/gemini.go
+++ b/internal/proxy/gemini.go
@@ -176,6 +176,10 @@ func (s *Service) ProxyGeminiGenerateContent(ctx context.Context, body []byte, w
 		Capabilities:       router.Lookup(decision.Model),
 		IncludeStreamUsage: s.usageRequired(),
 	}
+	if knobs := routingKnobsForRequest(ctx); knobs != nil && knobs.ForceEffort != "" {
+		opts.ForceEffort = knobs.ForceEffort
+		opts.ForceReasoningEffort = translate.ResolveForceEffort(opts.Capabilities, opts.ForceEffort)
+	}
 	ctx = resolveAndInjectCredentials(ctx, decision.Provider, r.Header)
 
 	prep, emitErr := env.PrepareGemini(r.Header, opts)

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -2336,14 +2336,8 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 		ModelSwitched:         routeRes.modelSwitched(),
 		EnableExtendedContext: shouldEnableExtendedContext(env.FullTokenEstimate(), outputReserve),
 	}
-	// User-forced effort (x-weave-effort header / :level suffix on /force-model)
-	// wins over the escalate-on-failure policy: the user explicitly asked for a
-	// level, so don't let Service.effortEscalation's gpt-5.x "low" default
-	// downrank a "high" ask. resolveForceEffort also handles per-model caps
-	// (xhigh → max on non-CapXhighEffort targets). It then forwards the
-	// canonical level into ForceReasoningEffort for gpt-5.x Responses / gemini
-	// 3.x, where the existing seam handles emit; for Anthropic adaptive it's
-	// consumed by resolveAnthropicOverrides directly via opts.ForceEffort.
+	// User-forced effort wins over effortEscalation; also pre-populate
+	// ForceReasoningEffort so the gpt-5.x/gemini-3.x emit seams honor it.
 	if knobs := routingKnobsForRequest(ctx); knobs != nil && knobs.ForceEffort != "" {
 		opts.ForceEffort = knobs.ForceEffort
 		opts.ForceReasoningEffort = translate.ResolveForceEffort(opts.Capabilities, opts.ForceEffort)

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -2336,7 +2336,18 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 		ModelSwitched:         routeRes.modelSwitched(),
 		EnableExtendedContext: shouldEnableExtendedContext(env.FullTokenEstimate(), outputReserve),
 	}
-	if s.effortEscalation {
+	// User-forced effort (x-weave-effort header / :level suffix on /force-model)
+	// wins over the escalate-on-failure policy: the user explicitly asked for a
+	// level, so don't let Service.effortEscalation's gpt-5.x "low" default
+	// downrank a "high" ask. resolveForceEffort also handles per-model caps
+	// (xhigh → max on non-CapXhighEffort targets). It then forwards the
+	// canonical level into ForceReasoningEffort for gpt-5.x Responses / gemini
+	// 3.x, where the existing seam handles emit; for Anthropic adaptive it's
+	// consumed by resolveAnthropicOverrides directly via opts.ForceEffort.
+	if knobs := routingKnobsForRequest(ctx); knobs != nil && knobs.ForceEffort != "" {
+		opts.ForceEffort = knobs.ForceEffort
+		opts.ForceReasoningEffort = translate.ResolveForceEffort(opts.Capabilities, opts.ForceEffort)
+	} else if s.effortEscalation {
 		opts.ForceReasoningEffort = forcedReasoningEffort(decision.Model, routeRes.EscalateEffort)
 	}
 
@@ -2664,7 +2675,10 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 		// OSS id — otherwise PrepareAnthropic may leave stale signed thinking
 		// blocks the baseline model rejects (400).
 		baselineOpts.ModelSwitched = routeRes.PriorServedModel != baselineModel || routeRes.SessionEverSwitched
-		if s.effortEscalation {
+		if knobs := routingKnobsForRequest(ctx); knobs != nil && knobs.ForceEffort != "" {
+			baselineOpts.ForceEffort = knobs.ForceEffort
+			baselineOpts.ForceReasoningEffort = translate.ResolveForceEffort(baselineOpts.Capabilities, knobs.ForceEffort)
+		} else if s.effortEscalation {
 			baselineOpts.ForceReasoningEffort = forcedReasoningEffort(baselineModel, routeRes.EscalateEffort)
 		}
 		baselinePrep, baselineEmitErr := env.PrepareAnthropic(r.Header, baselineOpts)
@@ -4235,7 +4249,10 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 		ModelSwitched:         routeRes.modelSwitched(),
 		EnableExtendedContext: shouldEnableExtendedContext(env.FullTokenEstimate(), outputReserveOAI),
 	}
-	if s.effortEscalation {
+	if knobs := routingKnobsForRequest(ctx); knobs != nil && knobs.ForceEffort != "" {
+		opts.ForceEffort = knobs.ForceEffort
+		opts.ForceReasoningEffort = translate.ResolveForceEffort(opts.Capabilities, opts.ForceEffort)
+	} else if s.effortEscalation {
 		opts.ForceReasoningEffort = forcedReasoningEffort(decision.Model, routeRes.EscalateEffort)
 	}
 

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -23,13 +23,7 @@ type Overrides struct {
 	PerModelVerbosity    *bool
 	// ForceEffort, when non-empty, overrides the request-derived reasoning
 	// effort for the served model. Wins over Service.effortEscalation's
-	// gpt-5.x/gemini-3.x ForceReasoningEffort (so a user on the new header
-	// can't get their explicit knob downgraded mid-session). Per-model caps
-	// still apply: "xhigh" clamps to "max" on non-CapXhighEffort targets.
-	// Accepted values: low, medium, high, max, xhigh (string form), or the
-	// force-model suffix aliases fast/minimal→low, ultra→xhigh. Empty =
-	// no user override; the existing inbound-client-effort / escalate-on-
-	// failure / no-effort-default ladder decides.
+	// Wins over effortEscalation; per-model caps (xhigh→max on non-CapXhighEffort) still apply.
 	ForceEffort string
 }
 

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -21,9 +21,9 @@ type Overrides struct {
 	OutputCostRatio      *float64
 	ExpectedOutputTokens *int
 	PerModelVerbosity    *bool
-	// ForceEffort, when non-empty, overrides the request-derived reasoning
-	// effort for the served model. Wins over Service.effortEscalation's
-	// Wins over effortEscalation; per-model caps (xhigh→max on non-CapXhighEffort) still apply.
+	// ForceEffort, when non-empty, is the user-requested effort level
+	// (x-weave-effort header / :level suffix). Wins over effortEscalation;
+	// per-model caps (xhigh→max on non-CapXhighEffort) still apply.
 	ForceEffort string
 }
 

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -21,6 +21,16 @@ type Overrides struct {
 	OutputCostRatio      *float64
 	ExpectedOutputTokens *int
 	PerModelVerbosity    *bool
+	// ForceEffort, when non-empty, overrides the request-derived reasoning
+	// effort for the served model. Wins over Service.effortEscalation's
+	// gpt-5.x/gemini-3.x ForceReasoningEffort (so a user on the new header
+	// can't get their explicit knob downgraded mid-session). Per-model caps
+	// still apply: "xhigh" clamps to "max" on non-CapXhighEffort targets.
+	// Accepted values: low, medium, high, max, xhigh (string form), or the
+	// force-model suffix aliases fast/minimal→low, ultra→xhigh. Empty =
+	// no user override; the existing inbound-client-effort / escalate-on-
+	// failure / no-effort-default ladder decides.
+	ForceEffort string
 }
 
 type Request struct {

--- a/internal/server/middleware/force_effort_override.go
+++ b/internal/server/middleware/force_effort_override.go
@@ -1,0 +1,58 @@
+// force_effort_override.go — parse x-weave-effort request header into a
+// router.Overrides.ForceEffort value the proxy forwards into EmitOptions.
+//
+// Header shape mirrors the sibling knobs in routing_knobs_override.go:
+// value is one of "low", "medium", "high", "max", "xhigh" (canonical) or the
+// alias forms "fast", "minimal", "ultra" (canonicalizeEffort maps them). An
+// unparseable value = 400 with the format-aware envelope (abortInvalidKnob).
+//
+// Mirrors the experience the user gets from the verbose `/force-effort <lvl>`
+// slash command, but rides on every request the eval harness sends so a
+// pin-and-effort bake-off doesn't need to share session state — same shape
+// x-weave-force-model got for the model pin (force_model.go:189).
+
+package middleware
+
+import (
+	"strings"
+
+	"workweave/router/internal/observability"
+	"workweave/router/internal/router"
+	"workweave/router/internal/translate"
+
+	"github.com/gin-gonic/gin"
+)
+
+// ForceEffortOverrideHeader is the request-header key. Lower-case is
+// conventional per the x-weave-* family; Envoy / most proxies case-fold
+// headers, so casing doesn't matter at the wire.
+const ForceEffortOverrideHeader = "x-weave-effort"
+
+// WithForceEffortOverride parses the x-weave-effort request header and
+// stashes it on the request context as router.Overrides.ForceEffort. Probe
+// validators (translate.IsValidEffort) gate the value before storing so a
+// typo returns 400 with a format-aware envelope instead of routing garbage
+// to a provider that 400s on an unknown effort level.
+func WithForceEffortOverride() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		raw := strings.TrimSpace(c.GetHeader(ForceEffortOverrideHeader))
+		if raw == "" {
+			c.Next()
+			return
+		}
+		if !translate.IsValidEffort(raw) {
+			abortInvalidKnob(c, ForceEffortOverrideHeader+" must be one of: low, medium, high, max, xhigh (or aliases fast/minimal/ultra).")
+			return
+		}
+		canonical := translate.CanonicalizeEffort(raw)
+		overrides := router.Overrides{ForceEffort: canonical}
+		ctx := router.WithRoutingKnobs(c.Request.Context(), &overrides)
+		c.Request = c.Request.WithContext(ctx)
+		log := observability.FromGin(c)
+		log.Debug(
+			"Force-effort override applied",
+			"override_force_effort", canonical,
+		)
+		c.Next()
+	}
+}

--- a/internal/server/middleware/force_effort_override.go
+++ b/internal/server/middleware/force_effort_override.go
@@ -1,15 +1,6 @@
-// force_effort_override.go — parse x-weave-effort request header into a
-// router.Overrides.ForceEffort value the proxy forwards into EmitOptions.
-//
-// Header shape mirrors the sibling knobs in routing_knobs_override.go:
-// value is one of "low", "medium", "high", "max", "xhigh" (canonical) or the
-// alias forms "fast", "minimal", "ultra" (canonicalizeEffort maps them). An
-// unparseable value = 400 with the format-aware envelope (abortInvalidKnob).
-//
-// Mirrors the experience the user gets from the verbose `/force-effort <lvl>`
-// slash command, but rides on every request the eval harness sends so a
-// pin-and-effort bake-off doesn't need to share session state — same shape
-// x-weave-force-model got for the model pin (force_model.go:189).
+// force_effort_override.go — WithForceEffortOverride middleware for x-weave-effort.
+// Accepts canonical levels (low/medium/high/max/xhigh) and aliases (fast/minimal/ultra);
+// invalid values → 400 via abortInvalidKnob.
 
 package middleware
 
@@ -45,8 +36,18 @@ func WithForceEffortOverride() gin.HandlerFunc {
 			return
 		}
 		canonical := translate.CanonicalizeEffort(raw)
-		overrides := router.Overrides{ForceEffort: canonical}
-		ctx := router.WithRoutingKnobs(c.Request.Context(), &overrides)
+		// Merge with any existing routing knobs (e.g. from WithRoutingKnobsOverride)
+		// so ForceEffort doesn't silently drop a separately-configured Alpha/QualityBias.
+		merged := router.Overrides{ForceEffort: canonical}
+		if existing := router.RoutingKnobsFromContext(c.Request.Context()); existing != nil {
+			merged.Alpha = existing.Alpha
+			merged.QualityBias = existing.QualityBias
+			merged.SpeedWeight = existing.SpeedWeight
+			merged.OutputCostRatio = existing.OutputCostRatio
+			merged.ExpectedOutputTokens = existing.ExpectedOutputTokens
+			merged.PerModelVerbosity = existing.PerModelVerbosity
+		}
+		ctx := router.WithRoutingKnobs(c.Request.Context(), &merged)
 		c.Request = c.Request.WithContext(ctx)
 		log := observability.FromGin(c)
 		log.Debug(

--- a/internal/server/middleware/force_effort_override.go
+++ b/internal/server/middleware/force_effort_override.go
@@ -1,7 +1,3 @@
-// force_effort_override.go — WithForceEffortOverride middleware for x-weave-effort.
-// Accepts canonical levels (low/medium/high/max/xhigh) and aliases (fast/minimal/ultra);
-// invalid values → 400 via abortInvalidKnob.
-
 package middleware
 
 import (
@@ -14,9 +10,7 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
-// ForceEffortOverrideHeader is the request-header key. Lower-case is
-// conventional per the x-weave-* family; Envoy / most proxies case-fold
-// headers, so casing doesn't matter at the wire.
+// ForceEffortOverrideHeader is the request-header key for x-weave-effort.
 const ForceEffortOverrideHeader = "x-weave-effort"
 
 // WithForceEffortOverride parses x-weave-effort and stashes the canonical

--- a/internal/server/middleware/force_effort_override.go
+++ b/internal/server/middleware/force_effort_override.go
@@ -19,11 +19,8 @@ import (
 // headers, so casing doesn't matter at the wire.
 const ForceEffortOverrideHeader = "x-weave-effort"
 
-// WithForceEffortOverride parses the x-weave-effort request header and
-// stashes it on the request context as router.Overrides.ForceEffort. Probe
-// validators (translate.IsValidEffort) gate the value before storing so a
-// typo returns 400 with a format-aware envelope instead of routing garbage
-// to a provider that 400s on an unknown effort level.
+// WithForceEffortOverride parses x-weave-effort and stashes the canonical
+// level on the request context. Invalid values abort with 400.
 func WithForceEffortOverride() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		raw := strings.TrimSpace(c.GetHeader(ForceEffortOverrideHeader))

--- a/internal/server/middleware/force_effort_override_test.go
+++ b/internal/server/middleware/force_effort_override_test.go
@@ -1,0 +1,96 @@
+package middleware_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"workweave/router/internal/router"
+	"workweave/router/internal/server/middleware"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// runForceEffort fires a request at the given path with the supplied
+// x-weave-effort header. Returns the response status + canonical level
+// captured off the request context (when the middleware lets the request
+// through) or the abort envelope when it 400s.
+func runForceEffort(t *testing.T, path, header string) (status int, body any, captured *router.Overrides) {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	engine := gin.New()
+	engine.Use(middleware.WithForceEffortOverride())
+	engine.Any("/*any", func(c *gin.Context) {
+		// Capture the override the middleware stashed on ctx so the test
+		// can assert the value flows through unchanged.
+		if k := router.RoutingKnobsFromContext(c.Request.Context()); k != nil {
+			captured = k
+		}
+		c.Status(http.StatusOK)
+	})
+
+	req := httptest.NewRequest(http.MethodPost, path, nil)
+	if header != "" {
+		req.Header.Set(middleware.ForceEffortOverrideHeader, header)
+	}
+	rr := httptest.NewRecorder()
+	engine.ServeHTTP(rr, req)
+
+	var parsed any
+	if rr.Body.Len() > 0 {
+		_ = json.Unmarshal(rr.Body.Bytes(), &parsed)
+	}
+	return rr.Code, parsed, captured
+}
+
+// TestForceEffortOverride_BareValue verifies x-weave-effort low passes
+// through to Overrides.ForceEffort in canonical (low) form.
+func TestForceEffortOverride_BareValue(t *testing.T) {
+	status, _, captured := runForceEffort(t, "/v1/messages", "low")
+	assert.Equal(t, http.StatusOK, status)
+	require.NotNil(t, captured)
+	assert.Equal(t, "low", captured.ForceEffort)
+}
+
+// TestForceEffortOverride_AliasCanonicalizes confirms alias forms
+// (`fast`, `minimal`, `ultra`) map to canonical wire strings before stash.
+func TestForceEffortOverride_AliasCanonicalizes(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"fast", "low"},
+		{"minimal", "low"},
+		{"ultra", "xhigh"},
+		{"ULTRA", "xhigh"}, // case-insensitive
+	}
+	for _, tc := range cases {
+		t.Run(tc.in, func(t *testing.T) {
+			status, _, captured := runForceEffort(t, "/v1/messages", tc.in)
+			assert.Equal(t, http.StatusOK, status)
+			require.NotNil(t, captured, "middleware must stash parsed override")
+			assert.Equal(t, tc.want, captured.ForceEffort)
+		})
+	}
+}
+
+// TestForceEffortOverride_InvalidValue verifies the middleware 400s
+// on an unknown level instead of letting it through to a provider that
+// would 400 with the wrong-shape envelope (Anthropic / OpenAI / Gemini
+// all parse their own error shapes — easier to fail at the boundary).
+func TestForceEffortOverride_InvalidValue(t *testing.T) {
+	status, _, captured := runForceEffort(t, "/v1/messages", "garbage")
+	assert.Equal(t, http.StatusBadRequest, status)
+	assert.Nil(t, captured, "invalid value must not stash an override")
+}
+
+// TestForceEffortOverride_Absent confirms an empty header is a no-op
+// (the middleware lets the request through without stashing).
+func TestForceEffortOverride_Absent(t *testing.T) {
+	status, _, captured := runForceEffort(t, "/v1/messages", "")
+	assert.Equal(t, http.StatusOK, status)
+	assert.Nil(t, captured)
+}

--- a/internal/server/middleware/force_effort_override_test.go
+++ b/internal/server/middleware/force_effort_override_test.go
@@ -14,10 +14,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// runForceEffort fires a request at the given path with the supplied
-// x-weave-effort header. Returns the response status + canonical level
-// captured off the request context (when the middleware lets the request
-// through) or the abort envelope when it 400s.
+// runForceEffort fires a request with the given x-weave-effort header and
+// returns the response status, body, and captured routing overrides.
 func runForceEffort(t *testing.T, path, header string) (status int, body any, captured *router.Overrides) {
 	t.Helper()
 	gin.SetMode(gin.TestMode)
@@ -77,10 +75,8 @@ func TestForceEffortOverride_AliasCanonicalizes(t *testing.T) {
 	}
 }
 
-// TestForceEffortOverride_InvalidValue verifies the middleware 400s
-// on an unknown level instead of letting it through to a provider that
-// would 400 with the wrong-shape envelope (Anthropic / OpenAI / Gemini
-// all parse their own error shapes — easier to fail at the boundary).
+// TestForceEffortOverride_InvalidValue verifies the middleware 400s on an
+// unknown level instead of forwarding it to a provider (fail at the boundary).
 func TestForceEffortOverride_InvalidValue(t *testing.T) {
 	status, _, captured := runForceEffort(t, "/v1/messages", "garbage")
 	assert.Equal(t, http.StatusBadRequest, status)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -156,6 +156,7 @@ func Register(engine *gin.Engine, authSvc *auth.Service, proxySvc *proxy.Service
 		middleware.WithRouterStrategyDefault(defaultStrategy, registeredStrategies...),
 		middleware.WithPolicyDebugOverride(),
 		middleware.WithRoutingKnobsOverride(),
+		middleware.WithForceEffortOverride(),
 	)
 	messagesGroup := engine.Group("", messagesMiddleware...)
 	messagesGroup.POST("/v1/messages", anthropicapi.MessagesHandler(proxySvc, authSvc))

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -175,6 +175,7 @@ func Register(engine *gin.Engine, authSvc *auth.Service, proxySvc *proxy.Service
 		middleware.WithRouterStrategyDefault(defaultStrategy, registeredStrategies...),
 		middleware.WithPolicyDebugOverride(),
 		middleware.WithRoutingKnobsOverride(),
+		middleware.WithForceEffortOverride(),
 	)
 	chatCompletionGroup := engine.Group("", chatCompletionMiddleware...)
 	chatCompletionGroup.POST("/v1/chat/completions", openaiapi.ChatCompletionHandler(proxySvc, authSvc))
@@ -208,6 +209,7 @@ func Register(engine *gin.Engine, authSvc *auth.Service, proxySvc *proxy.Service
 		middleware.WithRouterStrategyDefault(defaultStrategy, registeredStrategies...),
 		middleware.WithPolicyDebugOverride(),
 		middleware.WithRoutingKnobsOverride(),
+		middleware.WithForceEffortOverride(),
 	)
 	routeGroup := engine.Group("", routeMiddleware...)
 	routeGroup.POST("/v1/route", anthropicapi.RouteHandler(proxySvc))

--- a/internal/translate/emit_gemini.go
+++ b/internal/translate/emit_gemini.go
@@ -1156,6 +1156,8 @@ func thinkingConfigRaw(effort, model string) string {
 		switch effort {
 		case "low", "medium", "high":
 			level = effort
+		case "max", "xhigh":
+			level = "high"
 		default:
 			// 3.x can't disable thinking — omit config rather than send an invalid value.
 			return ""
@@ -1176,7 +1178,7 @@ func thinkingConfigRaw(effort, model string) string {
 		budget = 1024
 	case "medium":
 		budget = 8192
-	case "high":
+	case "high", "max", "xhigh":
 		budget = 24576
 	default:
 		return ""

--- a/internal/translate/emit_gemini.go
+++ b/internal/translate/emit_gemini.go
@@ -34,6 +34,14 @@ func (e *RequestEnvelope) PrepareGemini(_ http.Header, opts EmitOptions) (provid
 		if err != nil {
 			return providers.PreparedRequest{}, fmt.Errorf("sanitize gemini tools: %w", err)
 		}
+		if forced := resolveReasoningEffortFor(opts); forced != "" {
+			if raw := thinkingConfigRaw(forced, opts.TargetModel); raw != "" {
+				body, err = sjson.SetRawBytes(body, "generationConfig.thinkingConfig", []byte(raw))
+				if err != nil {
+					return providers.PreparedRequest{}, fmt.Errorf("set forced thinkingConfig: %w", err)
+				}
+			}
+		}
 		headers := make(http.Header)
 		if e.Stream() {
 			headers.Set(GeminiStreamHintHeader, "true")

--- a/internal/translate/emit_openai.go
+++ b/internal/translate/emit_openai.go
@@ -19,11 +19,8 @@ import (
 // call_id) — longer ids get a 400 ("string too long").
 const maxToolCallIDLen = 64
 
-// resolveReasoningEffortFor picks the user-forced level for Chat Completions
-// in priority order: ForceEffort (the user override from the new header /
-// pin suffix), ForceReasoningEffort (escalate-on-failure legacy seam), and
-// then "" (no override; let the request's own reasoning_effort stand).
-// Same priority chain the Responses path uses inline.
+// resolveReasoningEffortFor returns the effort to write on chat/completions:
+// ForceEffort wins over ForceReasoningEffort; both empty → "".
 func resolveReasoningEffortFor(opts EmitOptions) string {
 	if opts.ForceEffort != "" {
 		return ResolveForceEffort(opts.Capabilities, opts.ForceEffort)

--- a/internal/translate/emit_openai.go
+++ b/internal/translate/emit_openai.go
@@ -300,6 +300,12 @@ func (e *RequestEnvelope) buildOpenAIFromAnthropic(opts EmitOptions) ([]byte, pr
 	// Max tokens
 	writeOpenAIMaxTokensFromAnthropic(jw, body, opts)
 
+	// Write reasoning_effort for CapReasoning targets that accept it on chat/completions.
+	if forced := resolveReasoningEffortFor(opts); forced != "" && opts.Capabilities.Supports(router.CapReasoning) && reasoningEffortAcceptedOnChatCompletions(opts) {
+		jw.Key("reasoning_effort")
+		jw.Str(forced)
+	}
+
 	// Stream usage option
 	if opts.IncludeStreamUsage && gjson.GetBytes(body, "stream").Bool() {
 		jw.Key("stream_options")

--- a/internal/translate/emit_openai.go
+++ b/internal/translate/emit_openai.go
@@ -31,16 +31,10 @@ func resolveReasoningEffortFor(opts EmitOptions) string {
 	return opts.ForceReasoningEffort
 }
 
-// reasoningEffortAcceptedOnChatCompletions reports whether the target actually
-// accepts reasoning_effort on /v1/chat/completions. gpt-5.x rejects the field
-// outright (the proxy routes gpt-5.x through the Responses API anyway — see
-// emit_openai_responses.go:18), so we want to skip writing it for those
-// targets to avoid a session-killing 400. Other CapReasoning models
-// (OpenRouter OSS reasoning models today) accept reasoning_effort freely.
+// reasoningEffortAcceptedOnChatCompletions reports whether the target accepts
+// reasoning_effort on /v1/chat/completions. gpt-5.x rejects it (routed through
+// Responses API); other CapReasoning models (OpenRouter OSS) accept it freely.
 func reasoningEffortAcceptedOnChatCompletions(opts EmitOptions) bool {
-	// gpt-5.x on chat/completions rejects reasoning_effort + tools together;
-	// the Responses API carries the knob for those models, so chat-completions
-	// here means OpenRouter OSS reasoning models.
 	if strings.HasPrefix(opts.TargetModel, "gpt-5") {
 		return false
 	}
@@ -194,11 +188,7 @@ func (e *RequestEnvelope) buildOpenAIFromOpenAI(opts EmitOptions) ([]byte, error
 	if err != nil {
 		return nil, err
 	}
-	// User-forced effort on Chat-Completions: write reasoning_effort on cap-
-	// reasoning targets that accept it. gpt-5.x on /v1/chat/completions rejects
-	// this field (the comment at emit_openai_responses.go:18 documents it), so
-	// the proxy routes gpt-5.x through the Responses API anyway; this branch
-	// mainly covers OpenRouter OSS reasoning models that take both shapes.
+	// Write reasoning_effort for CapReasoning targets that accept it on chat/completions.
 	if forced := resolveReasoningEffortFor(opts); forced != "" && opts.Capabilities.Supports(router.CapReasoning) && reasoningEffortAcceptedOnChatCompletions(opts) {
 		body, err = sjson.SetBytes(body, "reasoning_effort", forced)
 		if err != nil {

--- a/internal/translate/emit_openai.go
+++ b/internal/translate/emit_openai.go
@@ -19,6 +19,34 @@ import (
 // call_id) — longer ids get a 400 ("string too long").
 const maxToolCallIDLen = 64
 
+// resolveReasoningEffortFor picks the user-forced level for Chat Completions
+// in priority order: ForceEffort (the user override from the new header /
+// pin suffix), ForceReasoningEffort (escalate-on-failure legacy seam), and
+// then "" (no override; let the request's own reasoning_effort stand).
+// Same priority chain the Responses path uses inline.
+func resolveReasoningEffortFor(opts EmitOptions) string {
+	if opts.ForceEffort != "" {
+		return ResolveForceEffort(opts.Capabilities, opts.ForceEffort)
+	}
+	return opts.ForceReasoningEffort
+}
+
+// reasoningEffortAcceptedOnChatCompletions reports whether the target actually
+// accepts reasoning_effort on /v1/chat/completions. gpt-5.x rejects the field
+// outright (the proxy routes gpt-5.x through the Responses API anyway — see
+// emit_openai_responses.go:18), so we want to skip writing it for those
+// targets to avoid a session-killing 400. Other CapReasoning models
+// (OpenRouter OSS reasoning models today) accept reasoning_effort freely.
+func reasoningEffortAcceptedOnChatCompletions(opts EmitOptions) bool {
+	// gpt-5.x on chat/completions rejects reasoning_effort + tools together;
+	// the Responses API carries the knob for those models, so chat-completions
+	// here means OpenRouter OSS reasoning models.
+	if strings.HasPrefix(opts.TargetModel, "gpt-5") {
+		return false
+	}
+	return true
+}
+
 // clampOpenAIToolCallID makes a tool-call id safe for the OpenAI wire format:
 // strips any smuggled Gemini thoughtSignature, then hashes ids still over 64
 // chars so a tool_use block and its tool_result stay paired on the same id.
@@ -165,6 +193,17 @@ func (e *RequestEnvelope) buildOpenAIFromOpenAI(opts EmitOptions) ([]byte, error
 	body, err := e.emitSameFormat(ov)
 	if err != nil {
 		return nil, err
+	}
+	// User-forced effort on Chat-Completions: write reasoning_effort on cap-
+	// reasoning targets that accept it. gpt-5.x on /v1/chat/completions rejects
+	// this field (the comment at emit_openai_responses.go:18 documents it), so
+	// the proxy routes gpt-5.x through the Responses API anyway; this branch
+	// mainly covers OpenRouter OSS reasoning models that take both shapes.
+	if forced := resolveReasoningEffortFor(opts); forced != "" && opts.Capabilities.Supports(router.CapReasoning) && reasoningEffortAcceptedOnChatCompletions(opts) {
+		body, err = sjson.SetBytes(body, "reasoning_effort", forced)
+		if err != nil {
+			return nil, fmt.Errorf("set reasoning_effort: %w", err)
+		}
 	}
 	if targetIsOpenRouter(opts) {
 		if hint := openRouterProviderHint(opts.TargetModel); hint != nil {

--- a/internal/translate/envelope.go
+++ b/internal/translate/envelope.go
@@ -1044,11 +1044,7 @@ func resolveAnthropicOverrides(body []byte, opts EmitOptions) EmitOverrides {
 		SanitizeAnthropicToolSchemas: true,
 	}
 
-	// User-forced effort (x-weave-effort header / :level suffix on /force-model)
-	// wins over the inbound heuristic: a user expressing "make this fast" or
-	// "use max thinking" is more specific than the budget-derived tier. Only
-	// applies on adaptive targets — legacy extended-thinking has no effort
-	// knob (forward thinking block untouched).
+	// User-forced effort wins over inbound heuristic; no-op on non-adaptive targets.
 	if forced := resolveForceEffort(opts); forced != "" && opts.Capabilities.Supports(router.CapAdaptiveThinking) {
 		ov.RewriteThinkingAdaptive = true
 		ov.OutputConfigEffort = forced

--- a/internal/translate/envelope.go
+++ b/internal/translate/envelope.go
@@ -53,6 +53,13 @@ type EmitOptions struct {
 	// Set by the proxy's escalate-on-failure policy: gpt-5.x starts "low", goes
 	// "high" after a failed/no-progress turn; gemini stays "low" (effort-immune).
 	ForceReasoningEffort string
+	// ForceEffort, when non-empty, is a USER-facing effort override (from
+	// x-weave-effort header or :level suffix on /force-model). Wins over
+	// ForceReasoningEffort when both are set, and applies across every
+	// provider ("low"/"medium"/"high"/"max"/"xhigh"). Per-model caps still
+	// apply downstream (xhigh → max on non-CapXhighEffort targets, gemini
+	// "xhigh" → "high", etc.) — see forceEffortFor. Empty = no user override.
+	ForceEffort string
 	// EnableExtendedContext injects the context-1m-2025-08-07 beta so
 	// CapExtendedContext targets (Opus 4.6+, Sonnet 4.6) get a 1M window
 	// instead of 200K, avoiding a 400 "prompt is too long" on large requests.
@@ -354,6 +361,14 @@ type EmitOverrides struct {
 	// model only accepts adaptive thinking (claude-opus-4-6+ / sonnet-4-6+).
 	RewriteThinkingAdaptive bool
 	OutputConfigEffort      string
+	// ForceOutputConfigEffort, when set, OVERRIDES any inbound output_config.effort
+	// (and `effort`) AND the heuristic-default OutputConfigEffort above. Set when
+	// a user-facing knob (x-weave-effort header / :level suffix) explicitly
+	// demanded a tier — the request-derived or budget-derived default loses to a
+	// direct user ask. The per-model cap (xhigh clamps to max on non-CapXhighEffort
+	// targets) already happens upstream in resolveForceEffort, so the value here
+	// is the canonical wire string.
+	ForceOutputConfigEffort string
 	// ClampEffortXhighTo downgrades a caller-supplied "xhigh" effort (`effort`
 	// and `output_config.effort`) to this value. Set when the target lacks
 	// xhigh (router.CapXhighEffort) so a mid-session re-route doesn't forward
@@ -461,6 +476,25 @@ func applyOverrides(body []byte, ov EmitOverrides) ([]byte, error) {
 			if err != nil {
 				return nil, fmt.Errorf("clamp %s: %w", key, err)
 			}
+		}
+	}
+
+	// User-forced effort (x-weave-effort header / :level suffix on /force-model)
+	// wins last: the request-derived value, the budget-derived OutputConfigEffort
+	// above, AND any inbound output_config.effort / effort field all lose to the
+	// explicit user knob. Per-model cap (xhigh → max on non-CapXhighEffort)
+	// already happens upstream in resolveForceEffort, so this is always a
+	// wire-valid Anthropic value. Anthropic variants ship two sibling effort
+	// fields (`effort` and `output_config.effort`); we write both so a request
+	// that arrived setting one still ends up serving at the user-forced level.
+	if ov.ForceOutputConfigEffort != "" {
+		out, err = sjson.SetBytes(out, "output_config.effort", ov.ForceOutputConfigEffort)
+		if err != nil {
+			return nil, fmt.Errorf("set output_config.effort (forced): %w", err)
+		}
+		out, err = sjson.SetBytes(out, "effort", ov.ForceOutputConfigEffort)
+		if err != nil {
+			return nil, fmt.Errorf("set effort (forced): %w", err)
 		}
 	}
 
@@ -941,10 +975,69 @@ func resolveOpenAIOverrides(body []byte, opts EmitOptions) EmitOverrides {
 // Anthropic adaptive effort levels referenced by emit logic. Every adaptive
 // model accepts low/medium/high/max; xhigh requires router.CapXhighEffort.
 const (
-	effortLow   = "low"
-	effortMax   = "max"
-	effortXhigh = "xhigh"
+	effortLow     = "low"
+	effortMedium  = "medium"
+	effortHigh    = "high"
+	effortMax     = "max"
+	effortXhigh   = "xhigh"
 )
+
+// CanonicalizeEffort maps user-facing values (incl. the force-model alias
+// forms "fast","minimal","ultra") to the canonical wire-format strings
+// ("low","medium","high","xhigh"). Unknown values pass through unchanged so
+// the model-specific cap check can reject them with a format-aware 400.
+func CanonicalizeEffort(level string) string {
+	switch strings.ToLower(strings.TrimSpace(level)) {
+	case "fast", "low", "minimal", "min":
+		return effortLow
+	case "medium", "med":
+		return effortMedium
+	case "high":
+		return effortHigh
+	case "max":
+		return effortMax
+	case "ultra", "xhigh":
+		return effortXhigh
+	default:
+		return level
+	}
+}
+
+// IsValidEffort reports whether the canonicalized level is one the router
+// accepts as wire output. Returns false for typos so the middleware can 400
+// with the format-aware envelope instead of silently forwarding garbage.
+func IsValidEffort(level string) bool {
+	switch CanonicalizeEffort(level) {
+	case effortLow, effortMedium, effortHigh, effortMax, effortXhigh:
+		return true
+	default:
+		return false
+	}
+}
+
+// ResolveForceEffort applies the per-model cap (xhigh → max on non-Opus-4-7+
+// Anthropic, gemini's "xhigh" → "high") and returns the canonical wire-format
+// string. Useful from contexts that don't have an EmitOptions handy (the
+// proxy pre-emptively copies the user value into both ForceEffort and
+// ForceReasoningEffort so all three downstream surfaces honor it).
+// Empty input → "" so callers can no-op without further checks.
+func ResolveForceEffort(caps router.ModelSpec, level string) string {
+	if level == "" {
+		return ""
+	}
+	canonical := CanonicalizeEffort(level)
+	if canonical == effortXhigh && !caps.Supports(router.CapXhighEffort) {
+		return effortMax
+	}
+	return canonical
+}
+
+// resolveForceEffort is the EmitOptions-method variant of ResolveForceEffort.
+// It reads opts.ForceEffort; the wider helper exists so external callers can
+// reuse the cap logic without constructing EmitOptions.
+func resolveForceEffort(opts EmitOptions) string {
+	return ResolveForceEffort(opts.Capabilities, opts.ForceEffort)
+}
 
 // effortForBudget maps legacy thinking.budget_tokens onto an adaptive
 // output_config.effort tier per Anthropic's guidance (≤4k low, ≤16k medium,
@@ -968,6 +1061,17 @@ func resolveAnthropicOverrides(body []byte, opts EmitOptions) EmitOverrides {
 		SanitizeToolUseIDs:           true,
 		StripThoughtSignature:        true,
 		SanitizeAnthropicToolSchemas: true,
+	}
+
+	// User-forced effort (x-weave-effort header / :level suffix on /force-model)
+	// wins over the inbound heuristic: a user expressing "make this fast" or
+	// "use max thinking" is more specific than the budget-derived tier. Only
+	// applies on adaptive targets — legacy extended-thinking has no effort
+	// knob (forward thinking block untouched).
+	if forced := resolveForceEffort(opts); forced != "" && opts.Capabilities.Supports(router.CapAdaptiveThinking) {
+		ov.RewriteThinkingAdaptive = true
+		ov.OutputConfigEffort = forced
+		ov.ForceOutputConfigEffort = forced
 	}
 
 	thinkingResult := gjson.GetBytes(body, "thinking")

--- a/internal/translate/envelope.go
+++ b/internal/translate/envelope.go
@@ -968,10 +968,9 @@ const (
 	effortXhigh  = "xhigh"
 )
 
-// CanonicalizeEffort maps user-facing values (incl. the force-model alias
-// forms "fast","minimal","ultra") to the canonical wire-format strings
-// ("low","medium","high","xhigh"). Unknown values pass through unchanged so
-// the model-specific cap check can reject them with a format-aware 400.
+// CanonicalizeEffort maps user-facing aliases (fast/minimal/ultra) to canonical
+// wire strings (low/medium/high/max/xhigh). Unknown values pass through so
+// IsValidEffort can reject typos at the boundary.
 func CanonicalizeEffort(level string) string {
 	switch strings.ToLower(strings.TrimSpace(level)) {
 	case "fast", "low", "minimal", "min":

--- a/internal/translate/envelope.go
+++ b/internal/translate/envelope.go
@@ -53,14 +53,10 @@ type EmitOptions struct {
 	// Set by the proxy's escalate-on-failure policy: gpt-5.x starts "low", goes
 	// "high" after a failed/no-progress turn; gemini stays "low" (effort-immune).
 	ForceReasoningEffort string
-	// ForceEffort, when non-empty, is a USER-facing effort override (from
-	// x-weave-effort header or :level suffix on /force-model). Wins over
-	// ForceReasoningEffort when both are set, and applies across every
-	// provider ("low"/"medium"/"high"/"max"/"xhigh"). Per-model caps still
-	// apply downstream (xhigh → max on non-CapXhighEffort targets, gemini
-	// "xhigh" → "high", etc.) — see forceEffortFor. Empty = no user override.
+	// ForceEffort, when non-empty, is the user-requested effort level
+	// (x-weave-effort header / :level suffix). Wins over ForceReasoningEffort;
+	// per-model caps applied by ResolveForceEffort.
 	ForceEffort string
-	// EnableExtendedContext injects the context-1m-2025-08-07 beta so
 	// CapExtendedContext targets (Opus 4.6+, Sonnet 4.6) get a 1M window
 	// instead of 200K, avoiding a 400 "prompt is too long" on large requests.
 	// No-op below 200K input. deriveAnthropicHeaders gates on CapExtendedContext.
@@ -474,14 +470,8 @@ func applyOverrides(body []byte, ov EmitOverrides) ([]byte, error) {
 		}
 	}
 
-	// User-forced effort (x-weave-effort header / :level suffix on /force-model)
-	// wins last: the request-derived value, the budget-derived OutputConfigEffort
-	// above, AND any inbound output_config.effort / effort field all lose to the
-	// explicit user knob. Per-model cap (xhigh → max on non-CapXhighEffort)
-	// already happens upstream in resolveForceEffort, so this is always a
-	// wire-valid Anthropic value. Anthropic variants ship two sibling effort
-	// fields (`effort` and `output_config.effort`); we write both so a request
-	// that arrived setting one still ends up serving at the user-forced level.
+		// ForceOutputConfigEffort wins over any request-derived or inbound
+	// effort; write both sibling fields so either form is overridden.
 	if ov.ForceOutputConfigEffort != "" {
 		out, err = sjson.SetBytes(out, "output_config.effort", ov.ForceOutputConfigEffort)
 		if err != nil {
@@ -1010,12 +1000,8 @@ func IsValidEffort(level string) bool {
 	}
 }
 
-// ResolveForceEffort applies the per-model cap (xhigh → max on non-Opus-4-7+
-// Anthropic, gemini's "xhigh" → "high") and returns the canonical wire-format
-// string. Useful from contexts that don't have an EmitOptions handy (the
-// proxy pre-emptively copies the user value into both ForceEffort and
-// ForceReasoningEffort so all three downstream surfaces honor it).
-// Empty input → "" so callers can no-op without further checks.
+// ResolveForceEffort canonicalizes level and applies the per-model cap
+// (xhigh → max on non-CapXhighEffort). Empty input → "".
 func ResolveForceEffort(caps router.ModelSpec, level string) string {
 	if level == "" {
 		return ""

--- a/internal/translate/envelope.go
+++ b/internal/translate/envelope.go
@@ -989,8 +989,8 @@ func CanonicalizeEffort(level string) string {
 }
 
 // IsValidEffort reports whether the canonicalized level is one the router
-// accepts as wire output. Returns false for typos so the middleware can 400
-// with the format-aware envelope instead of silently forwarding garbage.
+// accepts as wire output. Returns false for typos so middleware can 400
+// rather than forward garbage to a provider.
 func IsValidEffort(level string) bool {
 	switch CanonicalizeEffort(level) {
 	case effortLow, effortMedium, effortHigh, effortMax, effortXhigh:
@@ -1013,9 +1013,8 @@ func ResolveForceEffort(caps router.ModelSpec, level string) string {
 	return canonical
 }
 
-// resolveForceEffort is the EmitOptions-method variant of ResolveForceEffort.
-// It reads opts.ForceEffort; the wider helper exists so external callers can
-// reuse the cap logic without constructing EmitOptions.
+// resolveForceEffort is the package-private variant of ResolveForceEffort;
+// exists so call sites inside EmitOptions don't repeat caps + level extraction.
 func resolveForceEffort(opts EmitOptions) string {
 	return ResolveForceEffort(opts.Capabilities, opts.ForceEffort)
 }

--- a/internal/translate/envelope.go
+++ b/internal/translate/envelope.go
@@ -339,34 +339,35 @@ type EmitOverrides struct {
 	ClampMaxCompTokensValue int64
 	DefaultMaxTokensKey     string
 	DefaultMaxTokensValue   int64
-		InjectStreamUsage       bool
-		StripThinkingBlocks     bool
-		// SanitizeToolUseIDs rewrites tool_use.id / tool_use_id values outside
-		// ^[a-zA-Z0-9_-]+$. Always set for Anthropic targets: upstreams like
-		// Kimi-k2.6 emit IDs (e.g. "functions.Read:0") Anthropic rejects on replay.
-		SanitizeToolUseIDs bool
-		// StripThoughtSignature removes `thought_signature` from content blocks.
-		// Set for Anthropic targets: the field is Gemini-only and Anthropic 400s
-		// on unknown block fields.
-		StripThoughtSignature bool
-		// SanitizeAnthropicToolSchemas removes schema constraints Anthropic rejects
-		// from tools[].input_schema on same-format Anthropic requests.
-		SanitizeAnthropicToolSchemas bool
-		// RewriteThinkingAdaptive replaces the inbound thinking block with
-		// {"type":"adaptive"} and sets output_config.effort. Used when the target
-		// model only accepts adaptive thinking (claude-opus-4-6+ / sonnet-4-6+).
-		RewriteThinkingAdaptive bool
-		OutputConfigEffort      string
-		// ForceOutputConfigEffort, when set, overrides any inbound output_config.effort
-		// and the heuristic OutputConfigEffort — user knob beats request-derived default.
-		// Value is already cap-applied (xhigh→max) by resolveForceEffort upstream.
-		ForceOutputConfigEffort string
-		// ClampEffortXhighTo downgrades a caller-supplied "xhigh" effort (`effort`
-		// and `output_config.effort`) to this value. Set when the target lacks
-		// xhigh (router.CapXhighEffort) so a mid-session re-route doesn't forward
-		// an effort level Anthropic rejects with a session-killing 400.
-		ClampEffortXhighTo string
-	}
+	InjectStreamUsage       bool
+	StripThinkingBlocks     bool
+	// SanitizeToolUseIDs rewrites tool_use.id / tool_use_id values outside
+	// ^[a-zA-Z0-9_-]+$. Always set for Anthropic targets: upstreams like
+	// Kimi-k2.6 emit IDs (e.g. "functions.Read:0") Anthropic rejects on replay.
+	SanitizeToolUseIDs bool
+	// StripThoughtSignature removes `thought_signature` from content blocks.
+	// Set for Anthropic targets: the field is Gemini-only and Anthropic 400s
+	// on unknown block fields.
+	StripThoughtSignature bool
+	// SanitizeAnthropicToolSchemas removes schema constraints Anthropic rejects
+	// from tools[].input_schema on same-format Anthropic requests.
+	SanitizeAnthropicToolSchemas bool
+	// RewriteThinkingAdaptive replaces the inbound thinking block with
+	// {"type":"adaptive"} and sets output_config.effort. Used when the target
+	// model only accepts adaptive thinking (claude-opus-4-6+ / sonnet-4-6+).
+	RewriteThinkingAdaptive bool
+	OutputConfigEffort      string
+	// ForceOutputConfigEffort, when set, overrides any inbound output_config.effort
+	// and the heuristic OutputConfigEffort — user knob beats request-derived default.
+	// Value is already cap-applied (xhigh→max) by resolveForceEffort upstream.
+	ForceOutputConfigEffort string
+	// ClampEffortXhighTo downgrades a caller-supplied "xhigh" effort (`effort`
+	// and `output_config.effort`) to this value. Set when the target lacks
+	// xhigh (router.CapXhighEffort) so a mid-session re-route doesn't forward
+	// an effort level Anthropic rejects with a session-killing 400.
+	ClampEffortXhighTo string
+}
+
 func (e *RequestEnvelope) emitSameFormat(ov EmitOverrides) ([]byte, error) {
 	return applyOverrides(e.body, ov)
 }
@@ -470,7 +471,7 @@ func applyOverrides(body []byte, ov EmitOverrides) ([]byte, error) {
 		}
 	}
 
-		// ForceOutputConfigEffort wins over any request-derived or inbound
+	// ForceOutputConfigEffort wins over any request-derived or inbound
 	// effort; write both sibling fields so either form is overridden.
 	if ov.ForceOutputConfigEffort != "" {
 		out, err = sjson.SetBytes(out, "output_config.effort", ov.ForceOutputConfigEffort)
@@ -960,11 +961,11 @@ func resolveOpenAIOverrides(body []byte, opts EmitOptions) EmitOverrides {
 // Anthropic adaptive effort levels referenced by emit logic. Every adaptive
 // model accepts low/medium/high/max; xhigh requires router.CapXhighEffort.
 const (
-	effortLow     = "low"
-	effortMedium  = "medium"
-	effortHigh    = "high"
-	effortMax     = "max"
-	effortXhigh   = "xhigh"
+	effortLow    = "low"
+	effortMedium = "medium"
+	effortHigh   = "high"
+	effortMax    = "max"
+	effortXhigh  = "xhigh"
 )
 
 // CanonicalizeEffort maps user-facing values (incl. the force-model alias

--- a/internal/translate/envelope.go
+++ b/internal/translate/envelope.go
@@ -343,39 +343,34 @@ type EmitOverrides struct {
 	ClampMaxCompTokensValue int64
 	DefaultMaxTokensKey     string
 	DefaultMaxTokensValue   int64
-	InjectStreamUsage       bool
-	StripThinkingBlocks     bool
-	// SanitizeToolUseIDs rewrites tool_use.id / tool_use_id values outside
-	// ^[a-zA-Z0-9_-]+$. Always set for Anthropic targets: upstreams like
-	// Kimi-k2.6 emit IDs (e.g. "functions.Read:0") Anthropic rejects on replay.
-	SanitizeToolUseIDs bool
-	// StripThoughtSignature removes `thought_signature` from content blocks.
-	// Set for Anthropic targets: the field is Gemini-only and Anthropic 400s
-	// on unknown block fields.
-	StripThoughtSignature bool
-	// SanitizeAnthropicToolSchemas removes schema constraints Anthropic rejects
-	// from tools[].input_schema on same-format Anthropic requests.
-	SanitizeAnthropicToolSchemas bool
-	// RewriteThinkingAdaptive replaces the inbound thinking block with
-	// {"type":"adaptive"} and sets output_config.effort. Used when the target
-	// model only accepts adaptive thinking (claude-opus-4-6+ / sonnet-4-6+).
-	RewriteThinkingAdaptive bool
-	OutputConfigEffort      string
-	// ForceOutputConfigEffort, when set, OVERRIDES any inbound output_config.effort
-	// (and `effort`) AND the heuristic-default OutputConfigEffort above. Set when
-	// a user-facing knob (x-weave-effort header / :level suffix) explicitly
-	// demanded a tier — the request-derived or budget-derived default loses to a
-	// direct user ask. The per-model cap (xhigh clamps to max on non-CapXhighEffort
-	// targets) already happens upstream in resolveForceEffort, so the value here
-	// is the canonical wire string.
-	ForceOutputConfigEffort string
-	// ClampEffortXhighTo downgrades a caller-supplied "xhigh" effort (`effort`
-	// and `output_config.effort`) to this value. Set when the target lacks
-	// xhigh (router.CapXhighEffort) so a mid-session re-route doesn't forward
-	// an effort level Anthropic rejects with a session-killing 400.
-	ClampEffortXhighTo string
-}
-
+		InjectStreamUsage       bool
+		StripThinkingBlocks     bool
+		// SanitizeToolUseIDs rewrites tool_use.id / tool_use_id values outside
+		// ^[a-zA-Z0-9_-]+$. Always set for Anthropic targets: upstreams like
+		// Kimi-k2.6 emit IDs (e.g. "functions.Read:0") Anthropic rejects on replay.
+		SanitizeToolUseIDs bool
+		// StripThoughtSignature removes `thought_signature` from content blocks.
+		// Set for Anthropic targets: the field is Gemini-only and Anthropic 400s
+		// on unknown block fields.
+		StripThoughtSignature bool
+		// SanitizeAnthropicToolSchemas removes schema constraints Anthropic rejects
+		// from tools[].input_schema on same-format Anthropic requests.
+		SanitizeAnthropicToolSchemas bool
+		// RewriteThinkingAdaptive replaces the inbound thinking block with
+		// {"type":"adaptive"} and sets output_config.effort. Used when the target
+		// model only accepts adaptive thinking (claude-opus-4-6+ / sonnet-4-6+).
+		RewriteThinkingAdaptive bool
+		OutputConfigEffort      string
+		// ForceOutputConfigEffort, when set, overrides any inbound output_config.effort
+		// and the heuristic OutputConfigEffort — user knob beats request-derived default.
+		// Value is already cap-applied (xhigh→max) by resolveForceEffort upstream.
+		ForceOutputConfigEffort string
+		// ClampEffortXhighTo downgrades a caller-supplied "xhigh" effort (`effort`
+		// and `output_config.effort`) to this value. Set when the target lacks
+		// xhigh (router.CapXhighEffort) so a mid-session re-route doesn't forward
+		// an effort level Anthropic rejects with a session-killing 400.
+		ClampEffortXhighTo string
+	}
 func (e *RequestEnvelope) emitSameFormat(ov EmitOverrides) ([]byte, error) {
 	return applyOverrides(e.body, ov)
 }

--- a/internal/translate/force_effort_anthropic_test.go
+++ b/internal/translate/force_effort_anthropic_test.go
@@ -12,11 +12,8 @@ import (
 	"workweave/router/internal/translate"
 )
 
-// User-forced effort overrides the inbound client's output_config.effort on
-// Anthropic adaptive targets: a Claude Code client asking for adaptive+high
-// gets downgraded to "low" when the user pinned the session to x-weave-effort
-// = low. The wire value is whatever ResolveForceEffort returns (canonical +
-// per-model cap applied).
+// TestForceEffort_AnthropicOverrides verifies ForceEffort overrides the
+// inbound output_config.effort on adaptive targets.
 func TestForceEffort_AnthropicOverrides(t *testing.T) {
 	cases := []struct {
 		name      string
@@ -97,10 +94,8 @@ func TestForceEffort_AnthropicPassesThroughAlias(t *testing.T) {
 	assert.Equal(t, "xhigh", oc["effort"])
 }
 
-// User-forced effort skips on Anthropic non-adaptive (legacy extended-
-// thinking) targets: no output_config.effort knob, no rewrite, the
-// request goes through unchanged so a user who wrote "force low" on a
-// sonnet-4-5 still gets whatever thinking.budget_tokens they sent.
+// TestForceEffort_NonAdaptiveTargetNoOp verifies ForceEffort is a no-op on
+// legacy extended-thinking targets (no output_config.effort knob).
 func TestForceEffort_NonAdaptiveTargetNoOp(t *testing.T) {
 	body := []byte(`{"model":"claude-sonnet-4-5","max_tokens":1024,"messages":[{"role":"user","content":"hi"}],"thinking":{"type":"enabled","budget_tokens":16384}}`)
 	env, err := translate.ParseAnthropic(body)

--- a/internal/translate/force_effort_anthropic_test.go
+++ b/internal/translate/force_effort_anthropic_test.go
@@ -1,0 +1,122 @@
+package translate_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"workweave/router/internal/router"
+	"workweave/router/internal/translate"
+)
+
+// User-forced effort overrides the inbound client's output_config.effort on
+// Anthropic adaptive targets: a Claude Code client asking for adaptive+high
+// gets downgraded to "low" when the user pinned the session to x-weave-effort
+// = low. The wire value is whatever ResolveForceEffort returns (canonical +
+// per-model cap applied).
+func TestForceEffort_AnthropicOverrides(t *testing.T) {
+	cases := []struct {
+		name      string
+		level     string
+		target    string
+		wantEff   string
+		noLower   bool // true when target accepts xhigh and shouldn't clamp
+	}{
+		{
+			name: "low_overrides_high_on_opus_xhigh",
+			level: "low",
+			target: "claude-opus-4-8",
+			wantEff: "low",
+		},
+		{
+			name: "max_overrides_high_on_opus_xhigh",
+			level: "max",
+			target: "claude-opus-4-8",
+			wantEff: "max",
+		},
+		{
+			name: "xhigh_passes_on_capable",
+			level: "xhigh",
+			target: "claude-opus-4-8",
+			wantEff: "xhigh",
+		},
+		{
+			name: "xhigh_clamps_on_sonnet",
+			level: "xhigh",
+			target: "claude-sonnet-4-6",
+			wantEff: "max",
+		},
+		{
+			name: "ultra_alias_resolves_to_xhigh_pass",
+			level: "ultra",
+			target: "claude-opus-4-8",
+			wantEff: "xhigh",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			body := []byte(`{"model":"claude-opus-4-8","max_tokens":1024,"messages":[{"role":"user","content":"hi"}],"thinking":{"type":"enabled","budget_tokens":31999},"output_config":{"effort":"high"}}`)
+			env, err := translate.ParseAnthropic(body)
+			require.NoError(t, err)
+			prep, err := env.PrepareAnthropic(http.Header{}, translate.EmitOptions{
+				TargetModel: tc.target,
+				Capabilities: router.Lookup(tc.target),
+				ForceEffort:  tc.level,
+			})
+			require.NoError(t, err)
+			var out map[string]any
+			require.NoError(t, json.Unmarshal(prep.Body, &out))
+			oc, ok := out["output_config"].(map[string]any)
+			require.True(t, ok, "output_config must survive the rewrite")
+			assert.Equal(t, tc.wantEff, oc["effort"])
+		})
+	}
+}
+
+// An ":" suffix on x-weave-force-model is parsed by the proxy and stashed as
+// Override_ForceEffort; the same value flows into EmitOptions and is verified
+// here at the emit layer. Validates the integration: header/suffix parser ->
+// overrides -> emit seam compose without further touching.
+func TestForceEffort_AnthropicPassesThroughAlias(t *testing.T) {
+	body := []byte(`{"model":"claude-opus-4-7","max_tokens":1024,"messages":[{"role":"user","content":"hi"}]}`)
+	env, err := translate.ParseAnthropic(body)
+	require.NoError(t, err)
+	prep, err := env.PrepareAnthropic(http.Header{}, translate.EmitOptions{
+		TargetModel:  "claude-opus-4-7",
+		Capabilities: router.Lookup("claude-opus-4-7"),
+		ForceEffort:  "ultra", // aliases via CanonicalizeEffort to xhigh
+	})
+	require.NoError(t, err)
+	var out map[string]any
+	require.NoError(t, json.Unmarshal(prep.Body, &out))
+	oc, ok := out["output_config"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "xhigh", oc["effort"])
+}
+
+// User-forced effort skips on Anthropic non-adaptive (legacy extended-
+// thinking) targets: no output_config.effort knob, no rewrite, the
+// request goes through unchanged so a user who wrote "force low" on a
+// sonnet-4-5 still gets whatever thinking.budget_tokens they sent.
+func TestForceEffort_NonAdaptiveTargetNoOp(t *testing.T) {
+	body := []byte(`{"model":"claude-sonnet-4-5","max_tokens":1024,"messages":[{"role":"user","content":"hi"}],"thinking":{"type":"enabled","budget_tokens":16384}}`)
+	env, err := translate.ParseAnthropic(body)
+	require.NoError(t, err)
+	prep, err := env.PrepareAnthropic(http.Header{}, translate.EmitOptions{
+		TargetModel:  "claude-sonnet-4-5",
+		Capabilities: router.Lookup("claude-sonnet-4-5"),
+		ForceEffort:  "low",
+	})
+	require.NoError(t, err)
+	// Use of Lookup on a sonnet-4-5 returns zero (non-adaptive) — no rewrite.
+	var out map[string]any
+	require.NoError(t, json.Unmarshal(prep.Body, &out))
+	// thinking block should remain "enabled" with the original budget; no
+	// output_config should appear (only adaptive models use it).
+	if oc, present := out["output_config"]; present {
+		assert.Nil(t, oc, "non-adaptive target must not gain output_config.effort")
+	}
+}

--- a/internal/translate/force_effort_anthropic_test.go
+++ b/internal/translate/force_effort_anthropic_test.go
@@ -12,44 +12,44 @@ import (
 	"workweave/router/internal/translate"
 )
 
-// TestForceEffort_AnthropicOverrides verifies ForceEffort overrides the
-// inbound output_config.effort on adaptive targets.
+// TestForceEffort_AnthropicOverrides verifies ForceEffort overrides inbound
+// output_config.effort on adaptive targets, with per-model xhigh cap applied.
 func TestForceEffort_AnthropicOverrides(t *testing.T) {
 	cases := []struct {
-		name      string
-		level     string
-		target    string
-		wantEff   string
-		noLower   bool // true when target accepts xhigh and shouldn't clamp
+		name    string
+		level   string
+		target  string
+		wantEff string
+		noLower bool // true when target accepts xhigh and shouldn't clamp
 	}{
 		{
-			name: "low_overrides_high_on_opus_xhigh",
-			level: "low",
-			target: "claude-opus-4-8",
+			name:    "low_overrides_high_on_opus_xhigh",
+			level:   "low",
+			target:  "claude-opus-4-8",
 			wantEff: "low",
 		},
 		{
-			name: "max_overrides_high_on_opus_xhigh",
-			level: "max",
-			target: "claude-opus-4-8",
+			name:    "max_overrides_high_on_opus_xhigh",
+			level:   "max",
+			target:  "claude-opus-4-8",
 			wantEff: "max",
 		},
 		{
-			name: "xhigh_passes_on_capable",
-			level: "xhigh",
-			target: "claude-opus-4-8",
+			name:    "xhigh_passes_on_capable",
+			level:   "xhigh",
+			target:  "claude-opus-4-8",
 			wantEff: "xhigh",
 		},
 		{
-			name: "xhigh_clamps_on_sonnet",
-			level: "xhigh",
-			target: "claude-sonnet-4-6",
+			name:    "xhigh_clamps_on_sonnet",
+			level:   "xhigh",
+			target:  "claude-sonnet-4-6",
 			wantEff: "max",
 		},
 		{
-			name: "ultra_alias_resolves_to_xhigh_pass",
-			level: "ultra",
-			target: "claude-opus-4-8",
+			name:    "ultra_alias_resolves_to_xhigh_pass",
+			level:   "ultra",
+			target:  "claude-opus-4-8",
 			wantEff: "xhigh",
 		},
 	}
@@ -59,7 +59,7 @@ func TestForceEffort_AnthropicOverrides(t *testing.T) {
 			env, err := translate.ParseAnthropic(body)
 			require.NoError(t, err)
 			prep, err := env.PrepareAnthropic(http.Header{}, translate.EmitOptions{
-				TargetModel: tc.target,
+				TargetModel:  tc.target,
 				Capabilities: router.Lookup(tc.target),
 				ForceEffort:  tc.level,
 			})
@@ -73,10 +73,8 @@ func TestForceEffort_AnthropicOverrides(t *testing.T) {
 	}
 }
 
-// An ":" suffix on x-weave-force-model is parsed by the proxy and stashed as
-// Override_ForceEffort; the same value flows into EmitOptions and is verified
-// here at the emit layer. Validates the integration: header/suffix parser ->
-// overrides -> emit seam compose without further touching.
+// TestForceEffort_AnthropicPassesThroughAlias verifies alias forms (e.g. ultra)
+// flow end-to-end from ForceEffort into the wire output_config.effort.
 func TestForceEffort_AnthropicPassesThroughAlias(t *testing.T) {
 	body := []byte(`{"model":"claude-opus-4-7","max_tokens":1024,"messages":[{"role":"user","content":"hi"}]}`)
 	env, err := translate.ParseAnthropic(body)

--- a/internal/translate/force_effort_test.go
+++ b/internal/translate/force_effort_test.go
@@ -138,11 +138,7 @@ func TestCanonicalizeEffort(t *testing.T) {
 	}
 }
 
-// IsValidEffort accepts canonical wire-format levels AND alias forms (fast,
-// minimal, ultra) — aliases canonicalize to a known level, so we accept them
-// too. Mirrors what the middleware does: a value headers receive could be
-// either form, and we want to flag a typo (`garbage`) without rejecting
-// legitimate aliases.
+// IsValidEffort accepts canonical levels and alias forms; rejects typos.
 func TestIsValidEffort(t *testing.T) {
 	valid := []string{
 		"low", "medium", "high", "max", "xhigh",

--- a/internal/translate/force_effort_test.go
+++ b/internal/translate/force_effort_test.go
@@ -107,3 +107,80 @@ func itoaLocal(n int) string {
 	}
 	return string(b[i:])
 }
+
+// CanonicalizeEffort maps alias forms to their canonical wire-format
+// counterparts and leaves unrecognized values alone. The latter is load-
+// bearing for IsValidEffort — caller can probe "Is this a known level
+// or did the user fat-finger the keyboard" without losing the original.
+func TestCanonicalizeEffort(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"low", "low"},
+		{"LOW", "low"},
+		{"fast", "low"},
+		{"minimal", "low"},
+		{"min", "low"},
+		{"medium", "medium"},
+		{"med", "medium"},
+		{"high", "high"},
+		{"max", "max"},
+		{"xhigh", "xhigh"},
+		{"ultra", "xhigh"},
+		{"ULTRA", "xhigh"},
+		{"garbage", "garbage"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.in, func(t *testing.T) {
+			assert.Equal(t, tc.want, translate.CanonicalizeEffort(tc.in))
+		})
+	}
+}
+
+// IsValidEffort accepts canonical wire-format levels AND alias forms (fast,
+// minimal, ultra) — aliases canonicalize to a known level, so we accept them
+// too. Mirrors what the middleware does: a value headers receive could be
+// either form, and we want to flag a typo (`garbage`) without rejecting
+// legitimate aliases.
+func TestIsValidEffort(t *testing.T) {
+	valid := []string{
+		"low", "medium", "high", "max", "xhigh",
+		"fast", "minimal", "ultra", "min", "med",
+	}
+	for _, v := range valid {
+		t.Run(v, func(t *testing.T) {
+			assert.True(t, translate.IsValidEffort(v))
+		})
+	}
+	invalid := []string{"garbage", ""}
+	for _, v := range invalid {
+		t.Run(v+"_invalid", func(t *testing.T) {
+			assert.False(t, translate.IsValidEffort(v))
+		})
+	}
+}
+
+// ResolveForceEffort applies per-model caps. xhigh on opus-4-7+/fable
+// passes through; xhigh on a sonnet-4-6 / opus-4-6 lands as max (the same
+// clamp the inbound effort field already had via ClampEffortXhighTo).
+func TestResolveForceEffort(t *testing.T) {
+	cases := []struct {
+		name    string
+		level   string
+		spec    router.ModelSpec
+		want    string
+	}{
+		{"xhigh_capable_passes", "xhigh", router.NewSpec(router.CapAdaptiveThinking, router.CapXhighEffort), "xhigh"},
+		{"xhigh_incapable_clamps_to_max", "xhigh", router.NewSpec(router.CapAdaptiveThinking), "max"},
+		{"low_no_cap", "low", router.NewSpec(), "low"},
+		{"ultra_alias_resolved", "ultra", router.NewSpec(router.CapAdaptiveThinking, router.CapXhighEffort), "xhigh"},
+		{"fast_alias_resolved", "fast", router.NewSpec(), "low"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, translate.ResolveForceEffort(tc.spec, tc.level))
+		})
+	}
+}
+

--- a/internal/translate/force_effort_test.go
+++ b/internal/translate/force_effort_test.go
@@ -86,6 +86,42 @@ func TestForceReasoningEffort_GeminiFromOpenAI(t *testing.T) {
 	assert.Equal(t, "low", tc["thinkingLevel"])
 }
 
+func TestForceEffort_CrossFormatOpenAI(t *testing.T) {
+	body := []byte(`{"model":"claude-opus-4-8","max_tokens":1024,"messages":[{"role":"user","content":"hi"}]}`)
+	env, err := translate.ParseAnthropic(body)
+	require.NoError(t, err)
+	prep, err := env.PrepareOpenAI(http.Header{}, translate.EmitOptions{
+		TargetModel:  "openrouter/deepseek-r1",
+		Capabilities: router.NewSpec(router.CapReasoning),
+		ForceEffort:  "high",
+	})
+	require.NoError(t, err)
+	var out map[string]any
+	require.NoError(t, json.Unmarshal(prep.Body, &out))
+	assert.Equal(t, "high", out["reasoning_effort"])
+}
+
+func TestForceEffort_GeminiMaxLevel(t *testing.T) {
+	body := []byte(`{"model":"claude-opus-4-8","max_tokens":1024,"messages":[{"role":"user","content":"hi"}]}`)
+	env, err := translate.ParseAnthropic(body)
+	require.NoError(t, err)
+	for _, level := range []string{"max", "xhigh"} {
+		t.Run(level, func(t *testing.T) {
+			prep, err := env.PrepareGemini(http.Header{}, translate.EmitOptions{
+				TargetModel:          "gemini-3.1-pro-preview",
+				Capabilities:         router.NewSpec(router.CapReasoning),
+				ForceReasoningEffort: level,
+			})
+			require.NoError(t, err)
+			var out map[string]any
+			require.NoError(t, json.Unmarshal(prep.Body, &out))
+			gc := out["generationConfig"].(map[string]any)
+			tc := gc["thinkingConfig"].(map[string]any)
+			assert.Equal(t, "high", tc["thinkingLevel"])
+		})
+	}
+}
+
 func itoaLocal(n int) string {
 	if n == 0 {
 		return "0"
@@ -108,10 +144,8 @@ func itoaLocal(n int) string {
 	return string(b[i:])
 }
 
-// CanonicalizeEffort maps alias forms to their canonical wire-format
-// counterparts and leaves unrecognized values alone. The latter is load-
-// bearing for IsValidEffort — caller can probe "Is this a known level
-// or did the user fat-finger the keyboard" without losing the original.
+// TestCanonicalizeEffort maps alias and canonical forms; unrecognized values
+// pass through unchanged so IsValidEffort can distinguish typos.
 func TestCanonicalizeEffort(t *testing.T) {
 	cases := []struct {
 		in   string
@@ -157,15 +191,14 @@ func TestIsValidEffort(t *testing.T) {
 	}
 }
 
-// ResolveForceEffort applies per-model caps. xhigh on opus-4-7+/fable
-// passes through; xhigh on a sonnet-4-6 / opus-4-6 lands as max (the same
-// clamp the inbound effort field already had via ClampEffortXhighTo).
+// TestResolveForceEffort applies per-model xhigh cap (xhigh→max on
+// non-CapXhighEffort targets).
 func TestResolveForceEffort(t *testing.T) {
 	cases := []struct {
-		name    string
-		level   string
-		spec    router.ModelSpec
-		want    string
+		name  string
+		level string
+		spec  router.ModelSpec
+		want  string
 	}{
 		{"xhigh_capable_passes", "xhigh", router.NewSpec(router.CapAdaptiveThinking, router.CapXhighEffort), "xhigh"},
 		{"xhigh_incapable_clamps_to_max", "xhigh", router.NewSpec(router.CapAdaptiveThinking), "max"},
@@ -179,4 +212,3 @@ func TestResolveForceEffort(t *testing.T) {
 		})
 	}
 }
-


### PR DESCRIPTION
Adds a user-facing effort override so a human can ask for 'fast/slow' or 'ultra' thinking on whatever model the router picks (or one they pin via `/force-model`).

## Three surfaces, one knob

1. **`x-weave-effort` request header** — `low`/`medium`/`high`/`max`/`xhigh` (plus aliases `fast`→`low`, `minimal`→`low`, `ultra`→`xhigh`), parsed by new `WithForceEffortOverride` middleware. Supports any eval harness that already sends `x-weave-force-model` / `x-weave-routing-*`.
2. **`:level` suffix on `x-weave-force-model` and `/force-model`** — `opus-4-8:fast`, `gpt-5.6-sol:ultra`. Parsed by `resolveForceModelWithEffort` + `stripEffortSuffix`. The effort level is stashed on request context (same path middleware takes) so pin-and-effort lands in a single turn — no need to share session state between a pin turn and a separate effort turn.
3. **`/force-model gpt-5.6-sol ultra`** (second-word as level) also works via the same parse-and-stash path.

## Provider coverage

| Provider | Mechanic | Caps |
|---|---|---|
| **Anthropic adaptive** (opus-4-6+, sonnet-4-6+, fable-5) | `RewriteThinkingAdaptive` + `ForceOutputConfigEffort` (writes both `output_config.effort` and `effort`) | `xhigh`→`max` on sonnet-4-6/opus-4-6 via same `ClampEffortXhighTo` path inbound effort already used |
| **OpenAI Responses** (gpt-5.x) | `ForceReasoningEffort` — user-forced wins over escalate-on-failure default-low | gpt-5.5 maps `medium`→`high` via existing `responsesReasoningEffort` |
| **OpenAI Chat Completions** (non-Responses reasoning) | `reasoning_effort` field write | Skips gpt-5.x (it rejects `reasoning_effort` on /v1/chat/completions); OpenRouter OSS reasoning models OK |
| **Gemini 3.x** | `thinkingConfig.thinkingLevel` via existing `ForceReasoningEffort` seam | — |

Anthropic non-adaptive targets (sonnet-4-5, extended-thinking) are no-ops — no effort knob to turn.

## Files changed

| File | Change |
|---|---|
| `internal/router/router.go` | New `Overrides.ForceEffort string` field |
| `internal/translate/envelope.go` | `EmitOptions.ForceEffort` + `CanonicalizeEffort` / `ResolveForceEffort` / `IsValidEffort` + `EmitOverrides.ForceOutputConfigEffort` + apply-overrides rewrite |
| `internal/translate/emit_openai.go` | Chat Completions `reasoning_effort` wire (with gpt-5.x guard) |
| `internal/proxy/service.go` | `ForceEffort` wins over `Service.effortEscalation` at both `EmitOptions` build sites + baseline failover |
| `internal/proxy/force_model.go` | `resolveForceModelWithEffort` (4-return) + `stripEffortSuffix` + `applyForceModelHeader` stashes effort on request context |
| `internal/server/middleware/force_effort_override.go` (new) | `x-weave-effort` header parser, 400s unknown values |
| `internal/server/server.go` | Register `WithForceEffortOverride` middleware at all three route groups |
| `internal/translate/force_effort_test.go` | `TestCanonicalizeEffort`, `TestIsValidEffort`, `TestResolveForceEffort` |
| `internal/translate/force_effort_anthropic_test.go` (new) | Anthropic rewrite integration (xhigh cap, alias pass-through, non-adaptive no-op) |
| `internal/server/middleware/force_effort_override_test.go` (new) | Header parse + alias canonicalize + invalid-400 + absent-noop |

Tests: `go test ./...` green across all packages.

## Known caveats (intentional, not blockers)

- `:level` suffix is per-request only — not persisted on the session-pin row. The header & eval-harness pattern covers the usage need; the script CI eval case uses header, not pin.
- No dedicated `/force-effort <level>` slash command (without model pin). The colon suffix form covers this, and a dedicated command would need a new `ExtractForceEffortCommand` parser + handler. Follow-up candidate.
- The effort/routing runbook proved (at n=30 SWE-bench Pro) that forced-high opus-4-8 **underperforms adaptive** by paired net −2 at +25% cost. This PR doesn't change that — the user-facing knob is a cost/perf dial, not a score lever.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>