### PR TITLE
fix(proxy): suppress exhausted Claude subscription on OpenAI path

### DIFF
--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -4256,6 +4256,12 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 		opts.ForceReasoningEffort = forcedReasoningEffort(decision.Model, routeRes.EscalateEffort)
 	}
 
+	// A caller whose Claude subscription has bound its plan window can't serve
+	// another turn on it (429 until reset). Suppress the spent token so
+	// resolution falls through to the deployment/BYOK key — same as ProxyMessages.
+	if s.claudeSubscriptionExhausted(ctx, r.Header) {
+		ctx = withSuppressedClaudeSubscription(ctx)
+	}
 	ctx = resolveAndInjectCredentials(ctx, decision.Provider, r.Header)
 
 	// See ProxyMessages for the preludeBuffer rationale — wrap unconditionally
@@ -4264,12 +4270,13 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 	bindings := s.resolveBindingsForDispatch(ctx, decision)
 
 	// Subscription-only mode: the turn must serve on the caller's own
-	// subscription (Codex/Claude OAuth). If routing didn't resolve to a
-	// subscription-served credential, refuse (402) rather than dispatch to a
-	// paid model against an already-negative balance. When it did, pin dispatch
-	// to that single binding so failover can't reroute onto a paid provider.
+	// subscription (Codex/Claude OAuth). Refuse (402) when the turn wouldn't
+	// run on the sub — paid route, or the Claude subscription is
+	// observed-exhausted (a doomed 429). When it did resolve to a
+	// subscription credential, pin dispatch to that single binding so failover
+	// can't reroute onto a paid provider.
 	if billing.SubscriptionOnlyFromContext(ctx) {
-		if !servedOnSubscription(ctx) {
+		if !servedOnSubscription(ctx) || s.anthropicSubscriptionObservedExhausted(ctx, r.Header) {
 			log.Info("Subscription-only request cannot be served on the subscription; refusing",
 				"requested_model", feats.Model, "external_id", externalID, "decision_provider", decision.Provider)
 			return ErrCreditsExhaustedSubscriptionUnavailable

--- a/internal/proxy/usage_bypass_test.go
+++ b/internal/proxy/usage_bypass_test.go
@@ -260,6 +260,66 @@ func TestSubscriptionExhausted_ServesOnDeploymentKey(t *testing.T) {
 	// falls back to its own deployment key. Either way the spent token is gone.
 }
 
+// TestOpenAI_SubscriptionExhausted_ServesOnDeploymentKey locks that an
+// OpenAI-wire turn routed to Anthropic drops an exhausted Claude OAuth token
+// when a deployment Anthropic key is available, same as ProxyMessages.
+func TestOpenAI_SubscriptionExhausted_ServesOnDeploymentKey(t *testing.T) {
+	fr := &fakeRouter{decision: router.Decision{Provider: providers.ProviderAnthropic, Model: bypassScorerPickMdl}}
+	p := &fakeProvider{proxyResponse: func(w http.ResponseWriter) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"id":"msg_1","type":"message","role":"assistant","model":"` + bypassScorerPickMdl + `","content":[{"type":"text","text":"hi"}],"stop_reason":"end_turn","usage":{"input_tokens":1,"output_tokens":1}}`))
+	}}
+	obs := usage.NewObserver([]byte("salt"), 10*time.Minute, time.Now)
+	obs.Record(obs.Key([]byte(bypassSubToken)), usage.Snapshot{
+		Secondary: usage.Window{UsedPercent: 1.0, WindowMinutes: 10080},
+	})
+	svc := proxy.NewService(fr, map[string]providers.Client{providers.ProviderAnthropic: p}, nil, false, nil, nil, false, providers.ProviderAnthropic, bypassScorerPickMdl, nil).
+		WithSubscriptionAwareRouting(obs, 0.05, 2.0).
+		WithDeploymentKeyedProviders(map[string]struct{}{providers.ProviderAnthropic: {}})
+
+	body := []byte(`{"model":"` + bypassRequestedMdl + `","messages":[{"role":"user","content":"hi"}],"max_tokens":100}`)
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(""))
+	require.NoError(t, svc.ProxyOpenAIChatCompletion(bypassCtx(0.80), body, rec, req))
+
+	require.Len(t, p.proxyCreds, 1, "the turn must be dispatched once")
+	creds := p.proxyCreds[0]
+	if creds != nil {
+		assert.False(t, creds.OAuth,
+			"an exhausted subscription must not be forwarded — the turn serves on the deployment key")
+	}
+}
+
+// TestSubscriptionOnly_OpenAI_ExhaustedSubscription_Refuses402 locks that
+// subscription-only + an observed-exhausted Claude subscription refuses with
+// ErrCreditsExhaustedSubscriptionUnavailable and zero dispatches on the OpenAI
+// surface, matching ProxyMessages.
+func TestSubscriptionOnly_OpenAI_ExhaustedSubscription_Refuses402(t *testing.T) {
+	fr := &fakeRouter{decision: router.Decision{Provider: providers.ProviderAnthropic, Model: bypassScorerPickMdl}}
+	p := &fakeProvider{proxyResponse: func(w http.ResponseWriter) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"id":"msg_1","type":"message","role":"assistant","model":"` + bypassScorerPickMdl + `","content":[{"type":"text","text":"hi"}],"stop_reason":"end_turn","usage":{"input_tokens":1,"output_tokens":1}}`))
+	}}
+	obs := usage.NewObserver([]byte("salt"), 10*time.Minute, time.Now)
+	obs.Record(obs.Key([]byte(bypassSubToken)), usage.Snapshot{
+		Secondary: usage.Window{UsedPercent: 1.0, WindowMinutes: 10080},
+	})
+	svc := proxy.NewService(fr, map[string]providers.Client{providers.ProviderAnthropic: p}, nil, false, nil, nil, false, providers.ProviderAnthropic, bypassScorerPickMdl, nil).
+		WithSubscriptionAwareRouting(obs, 0.05, 2.0)
+
+	body := []byte(`{"model":"` + bypassRequestedMdl + `","messages":[{"role":"user","content":"hi"}],"max_tokens":100}`)
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(""))
+	ctx := billing.WithSubscriptionOnly(bypassCtx(0.80))
+	err := svc.ProxyOpenAIChatCompletion(ctx, body, rec, req)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, proxy.ErrCreditsExhaustedSubscriptionUnavailable),
+		"an exhausted subscription in subscription-only mode must be refused, not paid for")
+	assert.Empty(t, p.proxyBodies, "no paid dispatch may occur when the subscription can't serve the turn")
+}
+
 // TestSubscriptionExhausted_NoDeploymentKey_KeepsSubscription guards the
 // safety rail: with no deployment / BYOK Anthropic key to fall through to,
 // dropping the subscription would leave the turn with no credential (a 400,


### PR DESCRIPTION
## Summary

ProxyOpenAIChatCompletion never checked whether the caller's Claude
subscription was exhausted before injecting credentials, unlike
ProxyMessages (#519). On an OpenAI-wire turn routed to Anthropic, this meant
a spent OAuth token was dispatched instead of falling through to the
deployment/BYOK key. The subscription-only 402 guard had the same gap.

Full root-cause analysis and original live evidence: #761

## Fix

Two changes in ProxyOpenAIChatCompletion, both mirroring ProxyMessages
exactly:

1. Suppress an exhausted Claude subscription before credential resolution:
   ```go
   if s.claudeSubscriptionExhausted(ctx, r.Header) {
       ctx = withSuppressedClaudeSubscription(ctx)
   }
   ```
2. Extend the subscription-only refusal guard to also check observed
   exhaustion, matching service.go:2373's exact composition:
   ```go
   if !servedOnSubscription(ctx) || s.anthropicSubscriptionObservedExhausted(ctx, r.Header) {
   ```

## Known composition gap (documented, not fixed here)

Messages' subscription-only guard is additionally gated by
`&& !routeRes.UsageBypass`; this PR doesn't add that exclusion on the
OpenAI side. Verified this is inert today: usageBypassEngaged and
anthropicSubscriptionObservedExhausted read the identical usage-observer
snapshot (usage_bypass.go:93 and :136), so UsageBypass=true and
observed-exhausted=true cannot coexist — structurally, not just
empirically. Revisit when bypassToAnthropic/UsageBypass consumption is
wired on this surface (separate, not-yet-filed issue).

## Tests

- `TestOpenAI_SubscriptionExhausted_ServesOnDeploymentKey`
- `TestSubscriptionOnly_OpenAI_ExhaustedSubscription_Refuses402`

Both fail on main, pass on this branch. Landed in `usage_bypass_test.go`,
reusing existing fixtures (`bypassScorerPickMdl`, `bypassSubToken`, `fakeRouter`,
`fakeProvider`) rather than new mocks.

## Live verification (re-run against the actual committed diff, not a
local patch — git diff HEAD was empty throughout)

| Check | Pre-fix | Post-fix |
|---|---|---|
| Credential at dispatch (OpenAI) | spent OAuth token | none — deploy key |
| Mock-Anthropic round trip | 3 attempts, 429 to client | 1 dispatch, 200 to client |
| Subscription-only + exhausted | 1 dispatch, spent OAuth, no refusal | 0 dispatches, ErrCreditsExhaustedSubscriptionUnavailable |

## Test plan

- [x] Both new tests fail on main, pass on this branch
- [x] `make check` green
- [x] `go test ./internal/proxy/... -race` clean except pre-existing `TestFireTelemetryRecoversFromPanic` flake
- [x] Existing Codex subscription-only coverage (`subscription_only_openai_test.go`) unaffected
- [x] Live credential / 429 / subscription-only repros re-run against committed `59966cc`

Fixes #761

Made with [Cursor](https://cursor.com)