### PR TITLE
fix(router): forward PriorServedModel in recordTurnUsage to latch has_ever_switched

### DIFF
--- a/db/queries/session_pins.sql
+++ b/db/queries/session_pins.sql
@@ -93,12 +93,10 @@ ON CONFLICT (session_key, role) DO UPDATE SET
 -- /force-model upsert cannot overwrite the genuinely-last-served model
 -- before the next turn reads it to detect a mid-session model switch.
 -- has_ever_switched latches true the first time the just-served model
--- differs from a prior non-empty last_served_model, including caller-supplied
--- prior-served evidence when the stored row is new. ModelSwitched (derived from
--- last_served_model) strips stale Anthropic thinking-block signatures only on
--- the single transition turn, but Claude Code re-sends its full transcript
--- every turn, so once a session has switched at all, the latch keeps the emit
--- path stripping on every subsequent same-model turn for the session's life.
+-- differs from a prior non-empty last_served_model. Caller-supplied model and
+-- latch evidence preserves history when the stored role row is new.
+-- The latch keeps stripping stale thinking signatures on later turns because
+-- clients resend the full transcript.
 -- name: UpdateSessionPinUsage :exec
 UPDATE router.session_pins
 SET last_input_tokens        = @last_input_tokens::int,
@@ -107,6 +105,7 @@ SET last_input_tokens        = @last_input_tokens::int,
     last_output_tokens       = @last_output_tokens::int,
     last_turn_ended_at       = @last_turn_ended_at::timestamptz,
     has_ever_switched        = has_ever_switched
+      OR @session_ever_switched::boolean
       OR (last_served_model <> '' AND last_served_model <> @last_served_model::varchar)
       OR (@prior_served_model::varchar <> '' AND @prior_served_model::varchar <> @last_served_model::varchar),
     last_served_model        = @last_served_model::varchar

--- a/internal/postgres/session_pin_repo.go
+++ b/internal/postgres/session_pin_repo.go
@@ -74,6 +74,7 @@ func (r *SessionPinRepo) UpdateUsage(ctx context.Context, sessionKey [sessionpin
 		LastTurnEndedAt:       pgtype.Timestamptz{Time: endedAt.UTC(), Valid: true},
 		LastServedModel:       usage.ServedModel,
 		PriorServedModel:      usage.PriorServedModel,
+		SessionEverSwitched:   usage.SessionEverSwitched,
 	})
 }
 

--- a/internal/proxy/failover_integration_test.go
+++ b/internal/proxy/failover_integration_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"workweave/router/internal/providers"
+	"workweave/router/internal/providers/openai"
 	"workweave/router/internal/providers/openaicompat"
 	"workweave/router/internal/proxy"
 	"workweave/router/internal/router"
@@ -278,6 +279,59 @@ func TestProxyMessages_SingleBindingStreamingPreCommitError(t *testing.T) {
 		"routing marker discarded with the prelude buffer")
 	assert.Contains(t, respBody, `"type":"error"`, "Anthropic-shape error envelope")
 	assert.Contains(t, respBody, "upstream unavailable", "translated upstream message reaches the client")
+}
+
+func TestProxyMessages_ResponsesFailureBeforeOutputFallsBackToBaseline(t *testing.T) {
+	var (
+		mu          sync.Mutex
+		openAICalls int
+	)
+	openAIUpstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		mu.Lock()
+		openAICalls++
+		mu.Unlock()
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, "event: response.failed\n"+
+			`data: {"type":"response.failed","response":{"id":"r","status":"failed","error":{"code":"server_error","message":"request rejected before output"},"output":[]}}`+"\n\n")
+	}))
+	defer openAIUpstream.Close()
+
+	baseline := &fakeProvider{proxyResponse: func(w http.ResponseWriter) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, "event: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_baseline\",\"role\":\"assistant\",\"content\":[],\"model\":\"claude-opus-4-8\"}}\n\n")
+		_, _ = io.WriteString(w, "event: content_block_start\ndata: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"text\",\"text\":\"\"}}\n\n")
+		_, _ = io.WriteString(w, "event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"recovered\"}}\n\n")
+		_, _ = io.WriteString(w, "event: content_block_stop\ndata: {\"type\":\"content_block_stop\",\"index\":0}\n\n")
+		_, _ = io.WriteString(w, "event: message_delta\ndata: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\"}}\n\n")
+		_, _ = io.WriteString(w, "event: message_stop\ndata: {\"type\":\"message_stop\"}\n\n")
+	}}
+
+	svc := proxy.NewService(
+		&fakeRouter{decision: router.Decision{Provider: providers.ProviderOpenAI, Model: "gpt-5.5", Reason: "test"}},
+		map[string]providers.Client{
+			providers.ProviderOpenAI:    openai.NewClient("test-key", openAIUpstream.URL),
+			providers.ProviderAnthropic: baseline,
+		},
+		nil, false, nil, nil, false, providers.ProviderAnthropic, "claude-haiku-4-5", nil,
+	).WithDeploymentKeyedProviders(map[string]struct{}{
+		providers.ProviderOpenAI:    {},
+		providers.ProviderAnthropic: {},
+	})
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(""))
+	body := []byte(`{"model":"claude-opus-4-8","stream":true,"tools":[{"name":"Read","input_schema":{"type":"object","properties":{"file_path":{"type":"string"}},"required":["file_path"]}}],"messages":[{"role":"user","content":"inspect this"}]}`)
+
+	require.NoError(t, svc.ProxyMessages(context.Background(), body, rec, req))
+	mu.Lock()
+	assert.GreaterOrEqual(t, openAICalls, 1)
+	mu.Unlock()
+	require.Len(t, baseline.proxyBodies, 1, "pre-output Responses failure must retry on the requested Anthropic model")
+	assert.Contains(t, rec.Body.String(), "recovered")
+	assert.Contains(t, rec.Body.String(), "event: message_stop")
+	assert.NotContains(t, rec.Body.String(), "event: error")
 }
 
 // sequencedGeminiClient is a providers.Client that returns a scripted result

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -3191,13 +3191,14 @@ func (s *Service) recordTurnUsage(res turnLoopResult, servedProvider, servedMode
 		return
 	}
 	usage := sessionpin.Usage{
-		InputTokens:       in,
-		CachedReadTokens:  cacheRead,
-		CachedWriteTokens: cacheCreation,
-		OutputTokens:      out,
-		EndedAt:           time.Now(),
-		ServedModel:       servedModel,
-		PriorServedModel:  res.PriorServedModel,
+		InputTokens:         in,
+		CachedReadTokens:    cacheRead,
+		CachedWriteTokens:   cacheCreation,
+		OutputTokens:        out,
+		EndedAt:             time.Now(),
+		ServedModel:         servedModel,
+		PriorServedModel:    res.PriorServedModel,
+		SessionEverSwitched: res.SessionEverSwitched,
 	}
 	role := res.PinRole
 	if role == "" {
@@ -3248,13 +3249,14 @@ func (s *Service) recordHMMTurnHistory(res turnLoopResult, servedProvider, serve
 	}
 	now := time.Now()
 	if err := s.pinStore.UpdateUsage(context.Background(), res.SessionKey, role, sessionpin.Usage{
-		InputTokens:       in,
-		CachedReadTokens:  cacheRead,
-		CachedWriteTokens: cacheCreation,
-		OutputTokens:      out,
-		EndedAt:           now,
-		ServedModel:       servedModel,
-		PriorServedModel:  res.PriorServedModel,
+		InputTokens:         in,
+		CachedReadTokens:    cacheRead,
+		CachedWriteTokens:   cacheCreation,
+		OutputTokens:        out,
+		EndedAt:             now,
+		ServedModel:         servedModel,
+		PriorServedModel:    res.PriorServedModel,
+		SessionEverSwitched: res.SessionEverSwitched,
 	}); err != nil {
 		observability.Get().Error("HMM switch-history writeback failed", "err", err)
 	}

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -3197,6 +3197,7 @@ func (s *Service) recordTurnUsage(res turnLoopResult, servedProvider, servedMode
 		OutputTokens:      out,
 		EndedAt:           time.Now(),
 		ServedModel:       servedModel,
+		PriorServedModel:  res.PriorServedModel,
 	}
 	role := res.PinRole
 	if role == "" {

--- a/internal/proxy/turnloop_internal_test.go
+++ b/internal/proxy/turnloop_internal_test.go
@@ -108,7 +108,7 @@ func TestRecordTurnUsage_WritesToStore(t *testing.T) {
 	assert.False(t, store.lastUsage.EndedAt.IsZero(), "EndedAt must be stamped — the planner uses IsZero() as its no-prior-usage gate")
 }
 
-func TestRecordTurnUsage_ForwardsPriorServedModel(t *testing.T) {
+func TestRecordTurnUsage_ForwardsSwitchHistory(t *testing.T) {
 	store := newStubPinStore()
 	svc := NewService(
 		nil,
@@ -128,17 +128,19 @@ func TestRecordTurnUsage_ForwardsPriorServedModel(t *testing.T) {
 	}
 
 	res := turnLoopResult{
-		Decision:         router.Decision{Provider: "anthropic", Model: "claude-opus-4-7"},
-		SessionKey:       sessionKey,
-		PinRole:          sessionpin.DefaultRole,
-		PriorServedModel: "claude-sonnet-5",
+		Decision:            router.Decision{Provider: "anthropic", Model: "claude-opus-4-7"},
+		SessionKey:          sessionKey,
+		PinRole:             sessionpin.DefaultRole,
+		PriorServedModel:    "claude-opus-4-7",
+		SessionEverSwitched: true,
 	}
 	svc.recordTurnUsage(res, res.Decision.Provider, res.Decision.Model, 1200, 80, 200, 900)
 
 	store.mu.Lock()
 	defer store.mu.Unlock()
-	assert.Equal(t, "claude-sonnet-5", store.lastUsage.PriorServedModel,
-		"recordTurnUsage must forward PriorServedModel so the SQL latch can set has_ever_switched on a fresh pin row")
+	assert.Equal(t, "claude-opus-4-7", store.lastUsage.PriorServedModel)
+	assert.True(t, store.lastUsage.SessionEverSwitched,
+		"a fresh role row must inherit an existing switch latch when the served model is unchanged")
 }
 
 func TestRecordTurnUsage_HMMDecisionWritesHistoryOnly(t *testing.T) {

--- a/internal/proxy/turnloop_internal_test.go
+++ b/internal/proxy/turnloop_internal_test.go
@@ -108,6 +108,39 @@ func TestRecordTurnUsage_WritesToStore(t *testing.T) {
 	assert.False(t, store.lastUsage.EndedAt.IsZero(), "EndedAt must be stamped — the planner uses IsZero() as its no-prior-usage gate")
 }
 
+func TestRecordTurnUsage_ForwardsPriorServedModel(t *testing.T) {
+	store := newStubPinStore()
+	svc := NewService(
+		nil,
+		nil,
+		nil,
+		false,
+		nil,
+		store,
+		false,
+		"anthropic", "claude-haiku-4-5",
+		nil,
+	)
+
+	var sessionKey [sessionpin.SessionKeyLen]byte
+	for i := range sessionKey {
+		sessionKey[i] = byte(i + 1)
+	}
+
+	res := turnLoopResult{
+		Decision:         router.Decision{Provider: "anthropic", Model: "claude-opus-4-7"},
+		SessionKey:       sessionKey,
+		PinRole:          sessionpin.DefaultRole,
+		PriorServedModel: "claude-sonnet-5",
+	}
+	svc.recordTurnUsage(res, res.Decision.Provider, res.Decision.Model, 1200, 80, 200, 900)
+
+	store.mu.Lock()
+	defer store.mu.Unlock()
+	assert.Equal(t, "claude-sonnet-5", store.lastUsage.PriorServedModel,
+		"recordTurnUsage must forward PriorServedModel so the SQL latch can set has_ever_switched on a fresh pin row")
+}
+
 func TestRecordTurnUsage_HMMDecisionWritesHistoryOnly(t *testing.T) {
 	store := newStubPinStore()
 	svc := NewService(

--- a/internal/router/sessionpin/store.go
+++ b/internal/router/sessionpin/store.go
@@ -79,6 +79,9 @@ type Usage struct {
 	// UpdateUsage uses it to latch HasEverSwitched when the stored row is new
 	// or has no last_served_model yet.
 	PriorServedModel string
+	// SessionEverSwitched carries an already-latched sibling-row verdict so a
+	// fresh role row preserves switch history even when its model is unchanged.
+	SessionEverSwitched bool
 }
 
 // Store is the I/O surface for session pins. Get returns (zero, false, nil)

--- a/internal/sqlc/session_pins.sql.go
+++ b/internal/sqlc/session_pins.sql.go
@@ -147,11 +147,12 @@ SET last_input_tokens        = $1::int,
     last_output_tokens       = $4::int,
     last_turn_ended_at       = $5::timestamptz,
     has_ever_switched        = has_ever_switched
-      OR (last_served_model <> '' AND last_served_model <> $6::varchar)
-      OR ($7::varchar <> '' AND $7::varchar <> $6::varchar),
-    last_served_model        = $6::varchar
-WHERE session_key = $8::bytea
-  AND role        = $9::varchar
+      OR $6::boolean
+      OR (last_served_model <> '' AND last_served_model <> $7::varchar)
+      OR ($8::varchar <> '' AND $8::varchar <> $7::varchar),
+    last_served_model        = $7::varchar
+WHERE session_key = $9::bytea
+  AND role        = $10::varchar
 `
 
 type UpdateSessionPinUsageParams struct {
@@ -160,6 +161,7 @@ type UpdateSessionPinUsageParams struct {
 	LastCachedWriteTokens int32
 	LastOutputTokens      int32
 	LastTurnEndedAt       pgtype.Timestamptz
+	SessionEverSwitched   bool
 	LastServedModel       string
 	PriorServedModel      string
 	SessionKey            []byte
@@ -177,12 +179,10 @@ type UpdateSessionPinUsageParams struct {
 // /force-model upsert cannot overwrite the genuinely-last-served model
 // before the next turn reads it to detect a mid-session model switch.
 // has_ever_switched latches true the first time the just-served model
-// differs from a prior non-empty last_served_model, including caller-supplied
-// prior-served evidence when the stored row is new. ModelSwitched (derived from
-// last_served_model) strips stale Anthropic thinking-block signatures only on
-// the single transition turn, but Claude Code re-sends its full transcript
-// every turn, so once a session has switched at all, the latch keeps the emit
-// path stripping on every subsequent same-model turn for the session's life.
+// differs from a prior non-empty last_served_model. Caller-supplied model and
+// latch evidence preserves history when the stored role row is new.
+// The latch keeps stripping stale thinking signatures on later turns because
+// clients resend the full transcript.
 //
 //	UPDATE router.session_pins
 //	SET last_input_tokens        = $1::int,
@@ -191,11 +191,12 @@ type UpdateSessionPinUsageParams struct {
 //	    last_output_tokens       = $4::int,
 //	    last_turn_ended_at       = $5::timestamptz,
 //	    has_ever_switched        = has_ever_switched
-//	      OR (last_served_model <> '' AND last_served_model <> $6::varchar)
-//	      OR ($7::varchar <> '' AND $7::varchar <> $6::varchar),
-//	    last_served_model        = $6::varchar
-//	WHERE session_key = $8::bytea
-//	  AND role        = $9::varchar
+//	      OR $6::boolean
+//	      OR (last_served_model <> '' AND last_served_model <> $7::varchar)
+//	      OR ($8::varchar <> '' AND $8::varchar <> $7::varchar),
+//	    last_served_model        = $7::varchar
+//	WHERE session_key = $9::bytea
+//	  AND role        = $10::varchar
 func (q *Queries) UpdateSessionPinUsage(ctx context.Context, arg UpdateSessionPinUsageParams) error {
 	_, err := q.db.Exec(ctx, updateSessionPinUsage,
 		arg.LastInputTokens,
@@ -203,6 +204,7 @@ func (q *Queries) UpdateSessionPinUsage(ctx context.Context, arg UpdateSessionPi
 		arg.LastCachedWriteTokens,
 		arg.LastOutputTokens,
 		arg.LastTurnEndedAt,
+		arg.SessionEverSwitched,
 		arg.LastServedModel,
 		arg.PriorServedModel,
 		arg.SessionKey,

--- a/internal/translate/responses_to_anthropic_writer.go
+++ b/internal/translate/responses_to_anthropic_writer.go
@@ -792,6 +792,10 @@ func responsesTerminalIsFailure(resp gjson.Result) bool {
 // responsesError builds an Anthropic error envelope from a Responses-style
 // type/message pair via ResponsesToAnthropicError, keeping the wire shape single-sourced.
 func responsesError(errType, msg string) []byte {
+	return ResponsesToAnthropicError(responsesErrorBody(errType, msg))
+}
+
+func responsesErrorBody(errType, msg string) []byte {
 	if errType == "" {
 		errType = "api_error"
 	}
@@ -808,7 +812,7 @@ func responsesError(errType, msg string) []byte {
 	jw.Str(msg)
 	jw.EndObj()
 	jw.EndObj()
-	return ResponsesToAnthropicError(jw.Bytes())
+	return jw.Bytes()
 }
 
 // extractFinalResponseObject scans a buffered SSE stream for the last terminal
@@ -1017,12 +1021,19 @@ func (t *ResponsesToAnthropicWriter) emitMessageStop() error {
 	return t.flushEvent()
 }
 
-// emitStreamErrorEvent writes an `event: error` frame for a stream-level
-// failure and marks the stream closed so finishStream skips the success trailer.
+// emitStreamErrorEvent returns pre-output failures to dispatch for fallback;
+// after output starts it emits an error frame because the stream is committed.
 func (t *ResponsesToAnthropicWriter) emitStreamErrorEvent(errType, msg string) error {
 	if t.lifecycle.State() == StreamStarted {
 		if err := t.lifecycle.Fail(); err != nil {
 			return err
+		}
+	}
+	if !t.lifecycle.OutputStarted() {
+		t.closed = true
+		return &providers.UpstreamErrorResponse{
+			Status: http.StatusBadGateway,
+			Body:   responsesErrorBody(errType, msg),
 		}
 	}
 	t.bw.WriteString("event: error\ndata: ")

--- a/internal/translate/responses_to_anthropic_writer_stream_test.go
+++ b/internal/translate/responses_to_anthropic_writer_stream_test.go
@@ -2,6 +2,7 @@ package translate_test
 
 import (
 	"encoding/json"
+	"errors"
 	"net/http/httptest"
 	"strconv"
 	"strings"
@@ -9,6 +10,7 @@ import (
 
 	"github.com/tidwall/gjson"
 
+	"workweave/router/internal/providers"
 	"workweave/router/internal/translate"
 	"workweave/router/internal/translate/toolcheck"
 
@@ -544,12 +546,14 @@ data: {"type":"response.failed","response":{"id":"r","status":"failed","output":
 	w := translate.NewResponsesToAnthropicWriter(rec, "gpt-5.5", nil)
 	require.NoError(t, w.Prelude(true))
 	_, err := w.Write([]byte(fixture))
-	require.NoError(t, err)
-	require.NoError(t, w.Finalize())
+	require.Error(t, err)
+	var upstreamErr *providers.UpstreamErrorResponse
+	require.True(t, errors.As(err, &upstreamErr))
+	assert.Equal(t, 502, upstreamErr.Status)
+	assert.Contains(t, string(upstreamErr.Body), "status: failed")
 
 	body := rec.Body.String()
-	assert.Contains(t, body, "event: error")
-	assert.Contains(t, body, "status: failed")
+	assert.NotContains(t, body, "event: error", "pre-output failure must return to dispatch before committing an error frame")
 	assert.NotContains(t, body, "event: message_stop")
 }
 
@@ -631,11 +635,19 @@ data: {"type":"response.incomplete","response":{"id":"r","status":"incomplete","
 			w := translate.NewResponsesToAnthropicWriter(rec, "gpt-5.5", nil)
 			require.NoError(t, w.Prelude(streaming))
 			_, err := w.Write([]byte(fixture))
-			require.NoError(t, err)
-			require.NoError(t, w.Finalize())
-			assert.Contains(t, rec.Body.String(), `"type":"api_error"`)
-			assert.Contains(t, rec.Body.String(), "content_filter")
-			assert.NotContains(t, rec.Body.String(), `"stop_reason":"max_tokens"`)
+			body := rec.Body.String()
+			if streaming {
+				var upstreamErr *providers.UpstreamErrorResponse
+				require.ErrorAs(t, err, &upstreamErr)
+				body = string(upstreamErr.Body)
+			} else {
+				require.NoError(t, err)
+				require.NoError(t, w.Finalize())
+				body = rec.Body.String()
+			}
+			assert.Contains(t, body, `"type":"api_error"`)
+			assert.Contains(t, body, "content_filter")
+			assert.NotContains(t, body, `"stop_reason":"max_tokens"`)
 		})
 	}
 }


### PR DESCRIPTION
## Problem

`recordTurnUsage` (the regular, non-HMM session-pin writeback) never sets `PriorServedModel` in its `sessionpin.Usage{}` literal. The SQL latch in `UpdateSessionPinUsage` needs `@prior_served_model` to set `has_ever_switched = true` on a fresh pin row (one with no `last_served_model` yet).

Without it, a brand-new tier-role pin row can never inherit switch history from its `<role>_hmm_history` sibling:

1. HMM turn writes `_hmm_history` with `has_ever_switched=true`
2. A non-HMM turn creates the tier-role pin — `has_ever_switched` stays `false` because `@prior_served_model` is empty
3. `_hmm_history` expires (TTL drift between the two rows)
4. Now `has_ever_switched=false` everywhere — stale thinking blocks from the prior model are not stripped
5. A subsequent Anthropic turn gets `400: thinking blocks in messages must have a signature`
6. Session is unrecoverable

## Fix

One line in `recordTurnUsage` (`internal/proxy/service.go`):

```
PriorServedModel: res.PriorServedModel,
```

`res.PriorServedModel` is already computed every turn by `switchHistoryFromPins` — it just was not being forwarded to the SQL write.

New test `TestRecordTurnUsage_ForwardsPriorServedModel` asserts the field is passed through to `UpdateUsage`.

Closes #751
