### PR TITLE
Capture raw anthropic-ratelimit-unified-* headers on telemetry rows

### DIFF
--- a/db/migrations/0039_unified-limit-headers.down.sql
+++ b/db/migrations/0039_unified-limit-headers.down.sql
@@ -1,0 +1,6 @@
+BEGIN;
+
+ALTER TABLE router.model_router_request_telemetry
+    DROP COLUMN unified_limit_headers;
+
+COMMIT;

--- a/db/migrations/0039_unified-limit-headers.up.sql
+++ b/db/migrations/0039_unified-limit-headers.up.sql
@@ -1,0 +1,17 @@
+BEGIN;
+
+-- Phase 0 of the Claude Code cost-observing proxy design (see
+-- docs/internal/claude-code-cost-proxy-design.md in the WorkWeave monorepo):
+-- capture the full anthropic-ratelimit-unified-* header set observed on
+-- subscription-served /v1/messages turns. The router already parses this
+-- family of headers into a Snapshot for the subscription-subsidy feature
+-- (internal/proxy/usage), but discards the fields that matter for billing
+-- classification (unified-status, overage-status, overage-disabled-reason,
+-- representative-claim). This column is instrumentation only — nothing reads
+-- it yet — captured verbatim as jsonb so header-shape changes surface in the
+-- data rather than silently misclassifying. NULL on non-subscription turns and
+-- on rows written before this column existed.
+ALTER TABLE router.model_router_request_telemetry
+    ADD COLUMN unified_limit_headers JSONB;
+
+COMMIT;

--- a/db/migrations/0039_unified-limit-headers.up.sql
+++ b/db/migrations/0039_unified-limit-headers.up.sql
@@ -1,16 +1,10 @@
 BEGIN;
 
--- Phase 0 of the Claude Code cost-observing proxy design (see
--- docs/internal/claude-code-cost-proxy-design.md in the WorkWeave monorepo):
--- capture the full anthropic-ratelimit-unified-* header set observed on
--- subscription-served /v1/messages turns. The router already parses this
--- family of headers into a Snapshot for the subscription-subsidy feature
--- (internal/proxy/usage), but discards the fields that matter for billing
--- classification (unified-status, overage-status, overage-disabled-reason,
--- representative-claim). This column is instrumentation only — nothing reads
--- it yet — captured verbatim as jsonb so header-shape changes surface in the
--- data rather than silently misclassifying. NULL on non-subscription turns and
--- on rows written before this column existed.
+-- Verbatim anthropic-ratelimit-unified-* header set per subscription-served
+-- /v1/messages turn (Claude Code cost-observing-proxy Phase 0). The subsidy
+-- parser keeps only utilization/reset; billing classification needs the full
+-- vocabulary verified against real traffic first, so capture raw jsonb.
+-- Instrumentation only — nothing reads it yet. NULL on non-subscription turns.
 ALTER TABLE router.model_router_request_telemetry
     ADD COLUMN unified_limit_headers JSONB;
 

--- a/db/queries/model_router_request_telemetry.sql
+++ b/db/queries/model_router_request_telemetry.sql
@@ -20,6 +20,10 @@
 -- the upstream credential; credential_source names the precedence branch it came
 -- from. All NULL on deployment-key turns. Matching prefix/suffix values across
 -- distinct router_user_ids reveal one subscription paying for many seats.
+-- unified_limit_headers is the verbatim anthropic-ratelimit-unified-* header
+-- set observed on this turn (Claude Code cost-observing-proxy Phase 0
+-- instrumentation). NULL on non-subscription turns and on rows written before
+-- the column existed. Nothing reads it yet.
 -- name: InsertRequestTelemetry :exec
 INSERT INTO router.model_router_request_telemetry (
     installation_id,
@@ -86,7 +90,8 @@ INSERT INTO router.model_router_request_telemetry (
     tool_result_bytes,
     credential_key_prefix,
     credential_key_suffix,
-    credential_source
+    credential_source,
+    unified_limit_headers
 ) VALUES (
     @installation_id::uuid,
     sqlc.narg('api_key_id')::uuid,
@@ -152,7 +157,8 @@ INSERT INTO router.model_router_request_telemetry (
     sqlc.narg('tool_result_bytes')::int,
     sqlc.narg('credential_key_prefix')::varchar,
     sqlc.narg('credential_key_suffix')::varchar,
-    sqlc.narg('credential_source')::varchar
+    sqlc.narg('credential_source')::varchar,
+    sqlc.narg('unified_limit_headers')::jsonb
 )
 ON CONFLICT (installation_id, request_id, span_type) DO NOTHING;
 

--- a/internal/postgres/telemetry.go
+++ b/internal/postgres/telemetry.go
@@ -140,6 +140,7 @@ func (r *TelemetryRepo) InsertRequestTelemetry(ctx context.Context, p proxy.Inse
 		CredentialKeyPrefix:    stringPtrOrNil(p.CredentialKeyPrefix),
 		CredentialKeySuffix:    stringPtrOrNil(p.CredentialKeySuffix),
 		CredentialSource:       stringPtrOrNil(p.CredentialSource),
+		UnifiedLimitHeaders:    p.UnifiedLimitHeaders,
 	})
 }
 

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -3000,6 +3000,10 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 			CredentialKeyPrefix: credentialKeyPrefix,
 			CredentialKeySuffix: credentialKeySuffix,
 			CredentialSource:    credSource,
+			// Phase 0 instrumentation for the Claude Code cost-observing-proxy
+			// design — see unified_limit_capture.go. Anthropic-only; the
+			// OpenAI/Codex path below has no unified-header family to capture.
+			UnifiedLimitHeaders: unifiedLimitHeadersJSON(ctx),
 		})
 	}
 

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -3000,9 +3000,7 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 			CredentialKeyPrefix: credentialKeyPrefix,
 			CredentialKeySuffix: credentialKeySuffix,
 			CredentialSource:    credSource,
-			// Phase 0 instrumentation for the Claude Code cost-observing-proxy
-			// design — see unified_limit_capture.go. Anthropic-only; the
-			// OpenAI/Codex path below has no unified-header family to capture.
+			// Phase 0 instrumentation — Anthropic only; see unified_limit_capture.go.
 			UnifiedLimitHeaders: unifiedLimitHeadersJSON(ctx),
 		})
 	}

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -2166,7 +2166,7 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 	// On a retryable 429 the bypass falls through to re-routing; rate-limit
 	// headers prime the observer so the retry discounts Anthropic.
 	if routeRes.UsageBypass && routeRes.Decision.Provider == providers.ProviderAnthropic {
-		err := s.bypassToAnthropic(ctx, env, feats, routeRes.modelSwitched(), requestStart, requestID, externalID, r, w)
+		err := s.bypassToAnthropic(ctx, env, feats, routeRes.modelSwitched(), requestStart, requestID, externalID, routeRes.TurnType, r, w)
 		if !errors.Is(err, errBypassRetryable) {
 			s.firePolicyShadowForServingDecision(ctx, routeRes.Decision, req)
 			return err

--- a/internal/proxy/subsidy.go
+++ b/internal/proxy/subsidy.go
@@ -154,18 +154,11 @@ func RequestPresentsCoveringSubscription(ctx context.Context, headers http.Heade
 }
 
 // withUsageObserver installs a context header observer that records the present
-// subscription's rate-limit headroom from upstream response headers, AND
-// (independently — see below) captures the raw anthropic-ratelimit-unified-*
-// header set for the Claude Code cost-observing-proxy Phase 0 instrumentation
-// (docs/internal/claude-code-cost-proxy-design.md). No-op (returns ctx) when
-// neither has anything to do: the subsidy feature is off/no subscription
-// present AND no Anthropic subscription token was detected.
-//
-// providers.WithUpstreamHeaderObserver only holds one observer per context, so
-// both concerns are composed into a single callback here rather than installed
-// separately. The raw-header capture is wrapped in its own recover so a bug in
-// brand-new Phase 0 code can never take down the production subsidy/
-// usage-bypass observer it now shares a call site with.
+// subscription's rate-limit headroom and captures raw unified-limit headers for
+// Phase 0 telemetry. Both concerns share one observer slot
+// (providers.WithUpstreamHeaderObserver holds only one per ctx); the capture is
+// wrapped in recover so a Phase 0 bug can never take down the subsidy observer.
+// No-op when usageObserver is nil AND no Anthropic subscription token is present.
 func (s *Service) withUsageObserver(ctx context.Context, headers http.Header) context.Context {
 	codexTok, anthroTok := presentSubscriptionTokens(ctx, headers)
 	if s.usageObserver == nil && anthroTok == "" {

--- a/internal/proxy/subsidy.go
+++ b/internal/proxy/subsidy.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 
+	"workweave/router/internal/observability"
 	"workweave/router/internal/providers"
 	"workweave/router/internal/proxy/usage"
 	"workweave/router/internal/router/catalog"
@@ -153,17 +154,37 @@ func RequestPresentsCoveringSubscription(ctx context.Context, headers http.Heade
 }
 
 // withUsageObserver installs a context header observer that records the present
-// subscription's rate-limit headroom from upstream response headers. No-op
-// (returns ctx) when the feature is off or no subscription is present.
+// subscription's rate-limit headroom from upstream response headers, AND
+// (independently — see below) captures the raw anthropic-ratelimit-unified-*
+// header set for the Claude Code cost-observing-proxy Phase 0 instrumentation
+// (docs/internal/claude-code-cost-proxy-design.md). No-op (returns ctx) when
+// neither has anything to do: the subsidy feature is off/no subscription
+// present AND no Anthropic subscription token was detected.
+//
+// providers.WithUpstreamHeaderObserver only holds one observer per context, so
+// both concerns are composed into a single callback here rather than installed
+// separately. The raw-header capture is wrapped in its own recover so a bug in
+// brand-new Phase 0 code can never take down the production subsidy/
+// usage-bypass observer it now shares a call site with.
 func (s *Service) withUsageObserver(ctx context.Context, headers http.Header) context.Context {
-	if s.usageObserver == nil {
-		return ctx
-	}
 	codexTok, anthroTok := presentSubscriptionTokens(ctx, headers)
-	if codexTok == "" && anthroTok == "" {
+	if s.usageObserver == nil && anthroTok == "" {
 		return ctx
 	}
+	ctx = withUnifiedLimitCapture(ctx)
 	obs := func(callCtx context.Context, h http.Header) {
+		func() {
+			defer func() {
+				if r := recover(); r != nil {
+					observability.FromContext(callCtx).Error("weave-capture Phase 0: recovered from panic capturing unified limit headers", "recover", r)
+				}
+			}()
+			captureUnifiedLimitHeaders(callCtx, h)
+		}()
+
+		if s.usageObserver == nil || (codexTok == "" && anthroTok == "") {
+			return
+		}
 		// Record only when the call's RESOLVED credential is one of THIS request's
 		// detected subscription tokens — not any incidental OAuth credential — and
 		// key by that token so subsidyFactors reads the same key. Gating on the

--- a/internal/proxy/telemetry.go
+++ b/internal/proxy/telemetry.go
@@ -123,11 +123,8 @@ type InsertTelemetryParams struct {
 	CredentialSource    string
 
 	// UnifiedLimitHeaders is the verbatim anthropic-ratelimit-unified-* header
-	// set observed on this turn, pre-marshaled JSON (nil if none observed).
-	// Claude Code cost-observing-proxy Phase 0 instrumentation (see
-	// docs/internal/claude-code-cost-proxy-design.md in the WorkWeave
-	// monorepo) — captured to verify the header vocabulary against real
-	// traffic before any cost math depends on it. Nothing reads this yet.
+	// set, pre-marshaled JSON. Phase 0 instrumentation — nil on non-subscription
+	// turns. Nothing reads this yet.
 	UnifiedLimitHeaders []byte
 }
 

--- a/internal/proxy/telemetry.go
+++ b/internal/proxy/telemetry.go
@@ -121,6 +121,14 @@ type InsertTelemetryParams struct {
 	CredentialKeyPrefix string
 	CredentialKeySuffix string
 	CredentialSource    string
+
+	// UnifiedLimitHeaders is the verbatim anthropic-ratelimit-unified-* header
+	// set observed on this turn, pre-marshaled JSON (nil if none observed).
+	// Claude Code cost-observing-proxy Phase 0 instrumentation (see
+	// docs/internal/claude-code-cost-proxy-design.md in the WorkWeave
+	// monorepo) — captured to verify the header vocabulary against real
+	// traffic before any cost math depends on it. Nothing reads this yet.
+	UnifiedLimitHeaders []byte
 }
 
 // TelemetrySummary holds aggregated totals for the dashboard cards.

--- a/internal/proxy/unified_limit_capture.go
+++ b/internal/proxy/unified_limit_capture.go
@@ -14,12 +14,9 @@ import (
 // nothing reads it except the telemetry row builder; no effect on routing,
 // subsidy, or usage-bypass.
 //
-// Retry/failover semantics: the captured set describes the LAST
-// subscription-served attempt, which may not be the attempt that produced the
-// response — a 429'd subscription attempt whose retry serves on the
-// deployment key leaves the 429's headers here (that near-cap reading is
-// exactly what Phase 0 wants). Consumers disambiguate via the row's
-// failover_used and credential_source columns.
+// Retry/failover: captures the LAST subscription-served attempt's headers —
+// a 429'd subscription retry that falls over to the deployment key leaves the
+// near-cap reading here. Consumers disambiguate via failover_used + credential_source.
 type unifiedLimitCapture struct {
 	raw map[string]string
 }
@@ -63,10 +60,9 @@ func UnifiedLimitHeadersFrom(ctx context.Context) map[string]string {
 	return c.raw
 }
 
-// unifiedLimitHeadersJSON marshals the raw header map captured for this
-// request into the pre-marshaled []byte form InsertTelemetryParams expects for
-// jsonb columns (nil when nothing was captured, so the column stays NULL
-// rather than storing an empty object).
+// unifiedLimitHeadersJSON marshals the captured unified-header map to []byte
+// for InsertTelemetryParams. Returns nil (not empty JSON object) when nothing
+// was captured, so the column stays NULL.
 func unifiedLimitHeadersJSON(ctx context.Context) []byte {
 	raw := UnifiedLimitHeadersFrom(ctx)
 	if len(raw) == 0 {

--- a/internal/proxy/unified_limit_capture.go
+++ b/internal/proxy/unified_limit_capture.go
@@ -1,0 +1,85 @@
+package proxy
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+
+	"workweave/router/internal/observability"
+	"workweave/router/internal/proxy/usage"
+)
+
+// unifiedLimitCapture is a request-scoped holder for the raw
+// anthropic-ratelimit-unified-* header set observed on THIS request's own
+// subscription-served upstream call. It exists purely as Phase 0
+// instrumentation for the Claude Code cost-observing-proxy design
+// (docs/internal/claude-code-cost-proxy-design.md) — verifying the header
+// vocabulary (unified-status, overage-status, overage-disabled-reason,
+// representative-claim) against real subscription traffic before any cost
+// math depends on it. Nothing reads the captured value except the telemetry
+// row builder; it has no effect on routing, subsidy, or usage-bypass.
+type unifiedLimitCapture struct {
+	raw map[string]string
+}
+
+type unifiedLimitCaptureKey struct{}
+
+// withUnifiedLimitCapture installs an empty capture holder on ctx. The holder
+// is a pointer, so the header observer (which runs on a copy of ctx derived
+// from this one) mutates the SAME holder this function's caller retrieves
+// later via UnifiedLimitHeadersFrom — no channel or extra plumbing needed,
+// mirroring how CredentialsFromContext/clearCredentials share request state.
+func withUnifiedLimitCapture(ctx context.Context) context.Context {
+	return context.WithValue(ctx, unifiedLimitCaptureKey{}, &unifiedLimitCapture{})
+}
+
+// captureUnifiedLimitHeaders records the raw anthropic-ratelimit-unified-*
+// header set on ctx's capture holder, if the resolved credential for this
+// upstream call was a subscription (OAuth) credential and the request carries
+// a capture holder. Anthropic-only: Codex/OpenAI headers are a different
+// family (design doc §3) and out of scope for this instrumentation.
+func captureUnifiedLimitHeaders(ctx context.Context, h http.Header) {
+	c, ok := ctx.Value(unifiedLimitCaptureKey{}).(*unifiedLimitCapture)
+	if !ok || c == nil {
+		return
+	}
+	creds := CredentialsFromContext(ctx)
+	if creds == nil || !creds.OAuth {
+		return
+	}
+	raw := usage.RawAnthropicUnifiedHeaders(h)
+	if raw == nil {
+		return
+	}
+	c.raw = raw
+}
+
+// UnifiedLimitHeadersFrom returns the raw header map captured for this
+// request (nil if withUnifiedLimitCapture was never installed, or nothing was
+// captured — e.g. no subscription call was made this turn).
+func UnifiedLimitHeadersFrom(ctx context.Context) map[string]string {
+	c, ok := ctx.Value(unifiedLimitCaptureKey{}).(*unifiedLimitCapture)
+	if !ok || c == nil {
+		return nil
+	}
+	return c.raw
+}
+
+// unifiedLimitHeadersJSON marshals the raw header map captured for this
+// request into the pre-marshaled []byte form InsertTelemetryParams expects for
+// jsonb columns (nil when nothing was captured, so the column stays NULL
+// rather than storing an empty object).
+func unifiedLimitHeadersJSON(ctx context.Context) []byte {
+	raw := UnifiedLimitHeadersFrom(ctx)
+	if len(raw) == 0 {
+		return nil
+	}
+	b, err := json.Marshal(raw)
+	if err != nil {
+		// Telemetry loss is acceptable; a marshal failure must never fail the
+		// request, so log and leave the column NULL.
+		observability.FromContext(ctx).Debug("Failed to marshal unified_limit_headers for telemetry", "err", err)
+		return nil
+	}
+	return b
+}

--- a/internal/proxy/unified_limit_capture.go
+++ b/internal/proxy/unified_limit_capture.go
@@ -10,14 +10,16 @@ import (
 )
 
 // unifiedLimitCapture is a request-scoped holder for the raw
-// anthropic-ratelimit-unified-* header set observed on THIS request's own
-// subscription-served upstream call. It exists purely as Phase 0
-// instrumentation for the Claude Code cost-observing-proxy design
-// (docs/internal/claude-code-cost-proxy-design.md) — verifying the header
-// vocabulary (unified-status, overage-status, overage-disabled-reason,
-// representative-claim) against real subscription traffic before any cost
-// math depends on it. Nothing reads the captured value except the telemetry
-// row builder; it has no effect on routing, subsidy, or usage-bypass.
+// anthropic-ratelimit-unified-* header set. Phase 0 instrumentation only —
+// nothing reads it except the telemetry row builder; no effect on routing,
+// subsidy, or usage-bypass.
+//
+// Retry/failover semantics: the captured set describes the LAST
+// subscription-served attempt, which may not be the attempt that produced the
+// response — a 429'd subscription attempt whose retry serves on the
+// deployment key leaves the 429's headers here (that near-cap reading is
+// exactly what Phase 0 wants). Consumers disambiguate via the row's
+// failover_used and credential_source columns.
 type unifiedLimitCapture struct {
 	raw map[string]string
 }
@@ -25,19 +27,15 @@ type unifiedLimitCapture struct {
 type unifiedLimitCaptureKey struct{}
 
 // withUnifiedLimitCapture installs an empty capture holder on ctx. The holder
-// is a pointer, so the header observer (which runs on a copy of ctx derived
-// from this one) mutates the SAME holder this function's caller retrieves
-// later via UnifiedLimitHeadersFrom — no channel or extra plumbing needed,
-// mirroring how CredentialsFromContext/clearCredentials share request state.
+// is a pointer, so the header observer mutates the same struct the caller
+// reads later via UnifiedLimitHeadersFrom — no extra plumbing needed.
 func withUnifiedLimitCapture(ctx context.Context) context.Context {
 	return context.WithValue(ctx, unifiedLimitCaptureKey{}, &unifiedLimitCapture{})
 }
 
 // captureUnifiedLimitHeaders records the raw anthropic-ratelimit-unified-*
-// header set on ctx's capture holder, if the resolved credential for this
-// upstream call was a subscription (OAuth) credential and the request carries
-// a capture holder. Anthropic-only: Codex/OpenAI headers are a different
-// family (design doc §3) and out of scope for this instrumentation.
+// headers on ctx's holder when the resolved credential is OAuth (subscription).
+// Skipped for BYOK/deployment calls — those headers describe a different account.
 func captureUnifiedLimitHeaders(ctx context.Context, h http.Header) {
 	c, ok := ctx.Value(unifiedLimitCaptureKey{}).(*unifiedLimitCapture)
 	if !ok || c == nil {

--- a/internal/proxy/unified_limit_capture_test.go
+++ b/internal/proxy/unified_limit_capture_test.go
@@ -1,0 +1,146 @@
+package proxy
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"workweave/router/internal/providers"
+)
+
+func TestUnifiedLimitHeadersFrom_NoCaptureInstalled(t *testing.T) {
+	// A context that never went through withUnifiedLimitCapture must report
+	// nothing rather than panic — callers (unifiedLimitHeadersJSON) rely on
+	// this to leave the telemetry column NULL on any code path that doesn't
+	// route through ProxyMessages' capture wiring.
+	assert.Nil(t, UnifiedLimitHeadersFrom(context.Background()))
+}
+
+func TestCaptureUnifiedLimitHeaders_RecordsOnSubscriptionCredential(t *testing.T) {
+	ctx := withUnifiedLimitCapture(context.Background())
+	ctx = context.WithValue(ctx, CredentialsContextKey{}, &Credentials{
+		APIKey: []byte("sk-ant-oat01-live"), Source: credSourceSubscription, OAuth: true,
+	})
+
+	resp := http.Header{}
+	resp.Set("anthropic-ratelimit-unified-status", "allowed")
+	resp.Set("anthropic-ratelimit-unified-overage-status", "rejected")
+	resp.Set("content-type", "application/json") // must NOT leak into the captured set
+
+	captureUnifiedLimitHeaders(ctx, resp)
+
+	got := UnifiedLimitHeadersFrom(ctx)
+	require.NotNil(t, got)
+	assert.Equal(t, "allowed", got["anthropic-ratelimit-unified-status"])
+	assert.Equal(t, "rejected", got["anthropic-ratelimit-unified-overage-status"])
+	if _, ok := got["content-type"]; ok {
+		t.Errorf("non-unified header leaked into capture: %v", got)
+	}
+}
+
+func TestCaptureUnifiedLimitHeaders_SkipsNonOAuthCredential(t *testing.T) {
+	// A BYOK/deployment-key call (e.g. the handover summarizer after
+	// clearCredentials) must not be recorded — those headers describe a
+	// different account's quota, not the request's own subscription.
+	ctx := withUnifiedLimitCapture(context.Background())
+	ctx = context.WithValue(ctx, CredentialsContextKey{}, &Credentials{
+		APIKey: []byte("sk-ant-api-deployment"), Source: credSourceBYOK, OAuth: false,
+	})
+
+	resp := http.Header{}
+	resp.Set("anthropic-ratelimit-unified-status", "allowed")
+	captureUnifiedLimitHeaders(ctx, resp)
+
+	assert.Nil(t, UnifiedLimitHeadersFrom(ctx), "non-OAuth credential must not be captured")
+}
+
+func TestCaptureUnifiedLimitHeaders_NoCredentialsResolved(t *testing.T) {
+	ctx := withUnifiedLimitCapture(context.Background())
+	resp := http.Header{}
+	resp.Set("anthropic-ratelimit-unified-status", "allowed")
+	captureUnifiedLimitHeaders(ctx, resp) // no CredentialsContextKey set at all
+
+	assert.Nil(t, UnifiedLimitHeadersFrom(ctx))
+}
+
+func TestCaptureUnifiedLimitHeaders_NoUnifiedHeadersPresent(t *testing.T) {
+	// A subscription-served response with no unified headers at all (e.g. an
+	// endpoint other than /v1/messages) must leave the capture empty rather
+	// than recording an empty-but-non-nil map.
+	ctx := withUnifiedLimitCapture(context.Background())
+	ctx = context.WithValue(ctx, CredentialsContextKey{}, &Credentials{
+		APIKey: []byte("sk-ant-oat01-live"), Source: credSourceSubscription, OAuth: true,
+	})
+	captureUnifiedLimitHeaders(ctx, http.Header{"Content-Type": {"application/json"}})
+
+	assert.Nil(t, UnifiedLimitHeadersFrom(ctx))
+}
+
+func TestUnifiedLimitHeadersJSON(t *testing.T) {
+	t.Run("nothing captured -> nil (NULL column)", func(t *testing.T) {
+		ctx := withUnifiedLimitCapture(context.Background())
+		assert.Nil(t, unifiedLimitHeadersJSON(ctx))
+	})
+
+	t.Run("captured set round-trips through JSON", func(t *testing.T) {
+		ctx := withUnifiedLimitCapture(context.Background())
+		ctx = context.WithValue(ctx, CredentialsContextKey{}, &Credentials{
+			APIKey: []byte("sk-ant-oat01-live"), Source: credSourceSubscription, OAuth: true,
+		})
+		resp := http.Header{}
+		resp.Set("anthropic-ratelimit-unified-status", "allowed")
+		resp.Set("anthropic-ratelimit-unified-5h-utilization", "0.42")
+		captureUnifiedLimitHeaders(ctx, resp)
+
+		b := unifiedLimitHeadersJSON(ctx)
+		require.NotNil(t, b)
+		var got map[string]string
+		require.NoError(t, json.Unmarshal(b, &got))
+		assert.Equal(t, "allowed", got["anthropic-ratelimit-unified-status"])
+		assert.Equal(t, "0.42", got["anthropic-ratelimit-unified-5h-utilization"])
+	})
+}
+
+// End-to-end through the shared observer composition: a Claude Code
+// subscription request with NO subscription-aware routing configured
+// (s.usageObserver == nil) must still capture the raw unified headers. This is
+// the scenario Phase 0 dogfooding actually runs under before the subsidy
+// feature and this instrumentation are necessarily enabled together.
+func TestWithUsageObserver_CapturesRawHeadersEvenWithoutSubsidyObserver(t *testing.T) {
+	s := &Service{} // usageObserver is nil: subsidy feature not configured
+
+	headers := http.Header{}
+	headers.Set("Authorization", "Bearer sk-ant-oat01-claudecode")
+
+	ctx := s.withUsageObserver(context.Background(), headers)
+	callCtx := context.WithValue(ctx, CredentialsContextKey{}, &Credentials{
+		APIKey: []byte("sk-ant-oat01-claudecode"), Source: credSourceSubscription, OAuth: true,
+	})
+
+	resp := http.Header{}
+	resp.Set("anthropic-ratelimit-unified-status", "allowed")
+	resp.Set("anthropic-ratelimit-unified-overage-disabled-reason", "org_level_disabled")
+	providers.ObserveUpstreamHeaders(callCtx, resp)
+
+	got := UnifiedLimitHeadersFrom(ctx)
+	require.NotNil(t, got, "raw headers must be captured independent of the subsidy observer")
+	assert.Equal(t, "allowed", got["anthropic-ratelimit-unified-status"])
+	assert.Equal(t, "org_level_disabled", got["anthropic-ratelimit-unified-overage-disabled-reason"])
+}
+
+// withUsageObserver must remain a true no-op (return ctx unchanged) when there
+// is genuinely nothing to do: no subsidy observer configured AND no Anthropic
+// subscription token detected on the request. This preserves the pre-existing
+// contract other tests (TestSubsidyFactors_DisabledForInstallation etc.) rely
+// on, and confirms Phase 0 instrumentation doesn't start capturing on every
+// request regardless of auth.
+func TestWithUsageObserver_NoopWhenNothingToObserve(t *testing.T) {
+	s := &Service{}
+	ctx := context.Background()
+	got := s.withUsageObserver(ctx, http.Header{}) // no Authorization at all
+	assert.Nil(t, UnifiedLimitHeadersFrom(got), "no subscription token present -> capture never installed")
+}

--- a/internal/proxy/unified_limit_capture_test.go
+++ b/internal/proxy/unified_limit_capture_test.go
@@ -40,9 +40,7 @@ func TestCaptureUnifiedLimitHeaders_RecordsOnSubscriptionCredential(t *testing.T
 }
 
 func TestCaptureUnifiedLimitHeaders_SkipsNonOAuthCredential(t *testing.T) {
-	// A BYOK/deployment-key call (e.g. the handover summarizer after
-	// clearCredentials) must not be recorded — those headers describe a
-	// different account's quota, not the request's own subscription.
+	// BYOK/deployment-key call must not be recorded — headers describe a different account's quota.
 	ctx := withUnifiedLimitCapture(context.Background())
 	ctx = context.WithValue(ctx, CredentialsContextKey{}, &Credentials{
 		APIKey: []byte("sk-ant-api-deployment"), Source: credSourceBYOK, OAuth: false,
@@ -65,9 +63,7 @@ func TestCaptureUnifiedLimitHeaders_NoCredentialsResolved(t *testing.T) {
 }
 
 func TestCaptureUnifiedLimitHeaders_NoUnifiedHeadersPresent(t *testing.T) {
-	// A subscription-served response with no unified headers at all (e.g. an
-	// endpoint other than /v1/messages) must leave the capture empty rather
-	// than recording an empty-but-non-nil map.
+	// Subscription response with no unified headers must leave capture nil, not empty-but-non-nil.
 	ctx := withUnifiedLimitCapture(context.Background())
 	ctx = context.WithValue(ctx, CredentialsContextKey{}, &Credentials{
 		APIKey: []byte("sk-ant-oat01-live"), Source: credSourceSubscription, OAuth: true,

--- a/internal/proxy/unified_limit_capture_test.go
+++ b/internal/proxy/unified_limit_capture_test.go
@@ -13,10 +13,7 @@ import (
 )
 
 func TestUnifiedLimitHeadersFrom_NoCaptureInstalled(t *testing.T) {
-	// A context that never went through withUnifiedLimitCapture must report
-	// nothing rather than panic — callers (unifiedLimitHeadersJSON) rely on
-	// this to leave the telemetry column NULL on any code path that doesn't
-	// route through ProxyMessages' capture wiring.
+	// No capture holder installed → must return nil, not panic.
 	assert.Nil(t, UnifiedLimitHeadersFrom(context.Background()))
 }
 
@@ -105,11 +102,8 @@ func TestUnifiedLimitHeadersJSON(t *testing.T) {
 	})
 }
 
-// End-to-end through the shared observer composition: a Claude Code
-// subscription request with NO subscription-aware routing configured
-// (s.usageObserver == nil) must still capture the raw unified headers. This is
-// the scenario Phase 0 dogfooding actually runs under before the subsidy
-// feature and this instrumentation are necessarily enabled together.
+// Capture must work when s.usageObserver is nil — the Phase 0 dogfooding
+// scenario before subsidy-aware routing is enabled.
 func TestWithUsageObserver_CapturesRawHeadersEvenWithoutSubsidyObserver(t *testing.T) {
 	s := &Service{} // usageObserver is nil: subsidy feature not configured
 
@@ -132,12 +126,8 @@ func TestWithUsageObserver_CapturesRawHeadersEvenWithoutSubsidyObserver(t *testi
 	assert.Equal(t, "org_level_disabled", got["anthropic-ratelimit-unified-overage-disabled-reason"])
 }
 
-// withUsageObserver must remain a true no-op (return ctx unchanged) when there
-// is genuinely nothing to do: no subsidy observer configured AND no Anthropic
-// subscription token detected on the request. This preserves the pre-existing
-// contract other tests (TestSubsidyFactors_DisabledForInstallation etc.) rely
-// on, and confirms Phase 0 instrumentation doesn't start capturing on every
-// request regardless of auth.
+// No-op contract: nothing captured when usageObserver is nil AND no subscription
+// token is present — Phase 0 must not capture on every request.
 func TestWithUsageObserver_NoopWhenNothingToObserve(t *testing.T) {
 	s := &Service{}
 	ctx := context.Background()

--- a/internal/proxy/usage/raw_headers.go
+++ b/internal/proxy/usage/raw_headers.go
@@ -1,0 +1,42 @@
+package usage
+
+import (
+	"net/http"
+	"strings"
+)
+
+// anthropicUnifiedPrefix is the common prefix of every Anthropic unified
+// rate-limit header.
+const anthropicUnifiedPrefix = "anthropic-ratelimit-unified-"
+
+// RawAnthropicUnifiedHeaders returns every anthropic-ratelimit-unified-*
+// header verbatim as a name->value map (lowercased names), or nil if none are
+// present.
+//
+// This exists alongside ParseAnthropicUnifiedHeaders (which extracts only the
+// utilization/reset fields the subsidy feature needs) because the Claude Code
+// cost-observing-proxy design
+// (docs/internal/claude-code-cost-proxy-design.md in the WorkWeave monorepo)
+// needs the full header set — unified-status, overage-status,
+// overage-disabled-reason, representative-claim — to verify its billing
+// classification assumptions against real traffic before depending on them.
+// Capturing verbatim rather than adding fields to Snapshot keeps that
+// unverified vocabulary out of the routing-critical parse path; a header-shape
+// change here can only affect the telemetry column, never CostFactor/Exhausted.
+func RawAnthropicUnifiedHeaders(h http.Header) map[string]string {
+	var out map[string]string
+	for name, vals := range h {
+		lower := strings.ToLower(name)
+		if !strings.HasPrefix(lower, anthropicUnifiedPrefix) {
+			continue
+		}
+		if len(vals) == 0 {
+			continue
+		}
+		if out == nil {
+			out = make(map[string]string)
+		}
+		out[lower] = vals[0]
+	}
+	return out
+}

--- a/internal/proxy/usage/raw_headers.go
+++ b/internal/proxy/usage/raw_headers.go
@@ -13,15 +13,9 @@ const anthropicUnifiedPrefix = "anthropic-ratelimit-unified-"
 // header verbatim as a name->value map (lowercased names), or nil if none are
 // present.
 //
-// This exists alongside ParseAnthropicUnifiedHeaders (which extracts only the
-// utilization/reset fields the subsidy feature needs) because the Claude Code
-// cost-observing-proxy design
-// (docs/internal/claude-code-cost-proxy-design.md in the WorkWeave monorepo)
-// needs the full header set — unified-status, overage-status,
-// overage-disabled-reason, representative-claim — to verify its billing
-// classification assumptions against real traffic before depending on them.
-// Capturing verbatim rather than adding fields to Snapshot keeps that
-// unverified vocabulary out of the routing-critical parse path; a header-shape
+// Exists alongside ParseAnthropicUnifiedHeaders because Phase 0 telemetry needs
+// the full header set verbatim to verify billing vocabulary before any cost math
+// depends on it. Keeping unverified fields out of Snapshot means a header-shape
 // change here can only affect the telemetry column, never CostFactor/Exhausted.
 func RawAnthropicUnifiedHeaders(h http.Header) map[string]string {
 	var out map[string]string

--- a/internal/proxy/usage/raw_headers_test.go
+++ b/internal/proxy/usage/raw_headers_test.go
@@ -1,0 +1,35 @@
+package usage_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"workweave/router/internal/proxy/usage"
+)
+
+func TestRawAnthropicUnifiedHeaders(t *testing.T) {
+	t.Run("captures every unified-prefixed header, case-insensitively", func(t *testing.T) {
+		h := http.Header{}
+		h.Set("Anthropic-Ratelimit-Unified-Status", "allowed")
+		h.Set("anthropic-ratelimit-unified-overage-status", "rejected")
+		h.Set("Content-Type", "application/json")
+		h.Set("Request-Id", "req_123")
+
+		got := usage.RawAnthropicUnifiedHeaders(h)
+		assert.Equal(t, "allowed", got["anthropic-ratelimit-unified-status"])
+		assert.Equal(t, "rejected", got["anthropic-ratelimit-unified-overage-status"])
+		assert.Len(t, got, 2, "only unified-prefixed headers should be captured")
+	})
+
+	t.Run("no unified headers -> nil, not empty map", func(t *testing.T) {
+		h := http.Header{}
+		h.Set("Content-Type", "application/json")
+		assert.Nil(t, usage.RawAnthropicUnifiedHeaders(h))
+	})
+
+	t.Run("empty header set -> nil", func(t *testing.T) {
+		assert.Nil(t, usage.RawAnthropicUnifiedHeaders(http.Header{}))
+	})
+}

--- a/internal/proxy/usage_bypass.go
+++ b/internal/proxy/usage_bypass.go
@@ -361,13 +361,9 @@ func (s *Service) bypassToAnthropic(
 	})
 	otel.Flush(ctx)
 
-	// Persist a router.upstream telemetry row for the bypass turn. Without
-	// this, subscription pass-through turns — the primary Claude Code
-	// subscription path — are invisible to the telemetry table, which is
-	// exactly where the Phase 0 unified_limit_headers instrumentation needs
-	// them (a bypass turn is by definition subscription-served). The routed
-	// path's row carries routing-brain fields this lane doesn't have; they
-	// stay NULL here, and decision_reason="usage_bypass" marks the lane.
+	// Persist a router.upstream telemetry row so bypass turns appear in the
+	// telemetry table. Routing-brain fields stay NULL; decision_reason="usage_bypass"
+	// marks the lane. Required for Phase 0 unified_limit_headers capture.
 	if installationID := installationIDFromContext(ctx); installationID != uuid.Nil {
 		credentialKeyPrefix, credentialKeySuffix, credSource := s.credentialKeyParts(ctx)
 		s.fireTelemetry(InsertTelemetryParams{

--- a/internal/proxy/usage_bypass.go
+++ b/internal/proxy/usage_bypass.go
@@ -9,6 +9,8 @@ import (
 	"slices"
 	"time"
 
+	"github.com/google/uuid"
+
 	"workweave/router/internal/auth"
 	"workweave/router/internal/billing"
 	"workweave/router/internal/observability"
@@ -16,6 +18,7 @@ import (
 	"workweave/router/internal/providers"
 	"workweave/router/internal/router"
 	"workweave/router/internal/router/catalog"
+	"workweave/router/internal/router/turntype"
 	"workweave/router/internal/translate"
 )
 
@@ -238,6 +241,7 @@ func (s *Service) bypassToAnthropic(
 	modelSwitched bool,
 	requestStart time.Time,
 	requestID, externalID string,
+	turnType turntype.TurnType,
 	r *http.Request,
 	w http.ResponseWriter,
 ) error {
@@ -356,6 +360,52 @@ func (s *Service) bypassToAnthropic(
 			Build(),
 	})
 	otel.Flush(ctx)
+
+	// Persist a router.upstream telemetry row for the bypass turn. Without
+	// this, subscription pass-through turns — the primary Claude Code
+	// subscription path — are invisible to the telemetry table, which is
+	// exactly where the Phase 0 unified_limit_headers instrumentation needs
+	// them (a bypass turn is by definition subscription-served). The routed
+	// path's row carries routing-brain fields this lane doesn't have; they
+	// stay NULL here, and decision_reason="usage_bypass" marks the lane.
+	if installationID := installationIDFromContext(ctx); installationID != uuid.Nil {
+		credentialKeyPrefix, credentialKeySuffix, credSource := s.credentialKeyParts(ctx)
+		s.fireTelemetry(InsertTelemetryParams{
+			InstallationID:         installationID.String(),
+			APIKeyID:               apiKeyIDFromContext(ctx),
+			RequestID:              requestID,
+			SpanType:               "router.upstream",
+			TraceID:                requestID,
+			Timestamp:              requestStart,
+			RequestedModel:         feats.Model,
+			DecisionModel:          decision.Model,
+			DecisionProvider:       decision.Provider,
+			DecisionReason:         decision.Reason,
+			EstimatedInputTokens:   int32(feats.Tokens),
+			InputTokens:            int32(in),
+			OutputTokens:           int32(out),
+			RequestedInputCostUSD:  inputCost,
+			RequestedOutputCostUSD: outputCost,
+			ActualInputCostUSD:     inputCost,
+			ActualOutputCostUSD:    outputCost,
+			UpstreamLatencyMs:      time.Since(proxyStart).Milliseconds(),
+			TotalLatencyMs:         time.Since(requestStart).Milliseconds(),
+			UpstreamStatusCode:     int32(upstreamStatus(proxyErr)),
+			CaptureMode:            s.captureMode.String(),
+			TurnType:               string(turnType),
+			CacheCreationTokens:    cacheTokenPtr(cacheCreation),
+			CacheReadTokens:        cacheTokenPtr(cacheRead),
+			DeviceID:               clientID.DeviceID,
+			SessionID:              clientID.SessionID,
+			RouterUserID:           auth.UserIDFrom(ctx),
+			ClientApp:              clientID.ClientApp,
+			CredentialKeyPrefix:    credentialKeyPrefix,
+			CredentialKeySuffix:    credentialKeySuffix,
+			CredentialSource:       credSource,
+			UnifiedLimitHeaders:    unifiedLimitHeadersJSON(ctx),
+		})
+	}
+
 	log.Info("ProxyMessages usage-bypass complete",
 		"request_id", requestID,
 		"external_id", externalID,

--- a/internal/proxy/usage_bypass_internal_test.go
+++ b/internal/proxy/usage_bypass_internal_test.go
@@ -2,6 +2,7 @@ package proxy
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"io"
 	"net/http"
@@ -17,6 +18,7 @@ import (
 	"workweave/router/internal/router"
 	"workweave/router/internal/router/catalog"
 	"workweave/router/internal/router/sessionpin"
+	"workweave/router/internal/router/turntype"
 	"workweave/router/internal/translate"
 
 	"github.com/google/uuid"
@@ -165,7 +167,7 @@ func TestBypass_429_ReturnsErrBypassRetryable_NoBytesWritten(t *testing.T) {
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(""))
 
-	err := svc.bypassToAnthropic(context.Background(), env, feats, false, time.Now(), "req-1", "ext-1", req, rec)
+	err := svc.bypassToAnthropic(context.Background(), env, feats, false, time.Now(), "req-1", "ext-1", turntype.MainLoop, req, rec)
 
 	assert.ErrorIs(t, err, errBypassRetryable, "a retryable 429 must signal fall-through to routed dispatch")
 	assert.Equal(t, 1, upstream.dispatches, "the bypass attempt must hit the upstream exactly once")
@@ -190,7 +192,7 @@ func TestBypass_NonRetryableError_StillFlushes(t *testing.T) {
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(""))
 
-	err := svc.bypassToAnthropic(context.Background(), env, feats, false, time.Now(), "req-1", "ext-1", req, rec)
+	err := svc.bypassToAnthropic(context.Background(), env, feats, false, time.Now(), "req-1", "ext-1", turntype.MainLoop, req, rec)
 
 	require.NoError(t, err, "a non-retryable 400 must flush and return nil — rerouting would mask a malformed request")
 	assert.Equal(t, http.StatusBadRequest, rec.Code, "the 400 must be flushed to the client verbatim")
@@ -207,7 +209,7 @@ func TestBypass_NilError_ReturnsNil(t *testing.T) {
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(""))
 
-	err := svc.bypassToAnthropic(context.Background(), env, feats, false, time.Now(), "req-1", "ext-1", req, rec)
+	err := svc.bypassToAnthropic(context.Background(), env, feats, false, time.Now(), "req-1", "ext-1", turntype.MainLoop, req, rec)
 	require.NoError(t, err)
 }
 
@@ -226,7 +228,7 @@ func TestBypass_TransportError_ReroutesViaScorer(t *testing.T) {
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(""))
 
-	err := svc.bypassToAnthropic(context.Background(), env, feats, false, time.Now(), "req-1", "ext-1", req, rec)
+	err := svc.bypassToAnthropic(context.Background(), env, feats, false, time.Now(), "req-1", "ext-1", turntype.MainLoop, req, rec)
 
 	assert.ErrorIs(t, err, errBypassRetryable, "a transport error must signal fall-through to routed dispatch")
 	assert.Equal(t, 1, upstream.dispatches, "the bypass attempt must hit the upstream exactly once")
@@ -249,7 +251,7 @@ func TestBypass_LocalPrepError_PropagatesToClient(t *testing.T) {
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(""))
 
-	err := svc.bypassToAnthropic(context.Background(), env, feats, false, time.Now(), "req-1", "ext-1", req, rec)
+	err := svc.bypassToAnthropic(context.Background(), env, feats, false, time.Now(), "req-1", "ext-1", turntype.MainLoop, req, rec)
 
 	require.Error(t, err, "provider-not-configured must surface as a real error")
 	assert.NotErrorIs(t, err, errBypassRetryable, "local prep errors must not trigger reroute — the client must see them")
@@ -414,7 +416,7 @@ func TestBypass_EmitsUsageAndCost(t *testing.T) {
 
 	buf := otel.NewBuffer(emitter)
 	ctx := buf.WithContext(context.Background())
-	err = svc.bypassToAnthropic(ctx, env, feats, false, time.Now(), "req-1", "ext-1", req, rec)
+	err = svc.bypassToAnthropic(ctx, env, feats, false, time.Now(), "req-1", "ext-1", turntype.MainLoop, req, rec)
 	require.NoError(t, err)
 	buf.Flush()
 
@@ -446,4 +448,109 @@ func TestBypass_EmitsUsageAndCost(t *testing.T) {
 	assert.InDelta(t, wantIn, spanFloat(t, sp, "cost.actual_input_usd"), 1e-9)
 	assert.InDelta(t, wantOut, spanFloat(t, sp, "cost.requested_output_usd"), 1e-9)
 	assert.InDelta(t, wantIn, spanFloat(t, sp, "cost.requested_input_usd"), 1e-9)
+}
+
+// bypassCaptureTelemetry records InsertTelemetryParams rows for assertions.
+// Only InsertRequestTelemetry matters; the read methods satisfy the interface.
+type bypassCaptureTelemetry struct {
+	panicTelemetryRepo // inherit no-op reads
+	mu                 sync.Mutex
+	rows               []InsertTelemetryParams
+	notify             chan struct{}
+}
+
+func newBypassCaptureTelemetry() *bypassCaptureTelemetry {
+	return &bypassCaptureTelemetry{notify: make(chan struct{}, 4)}
+}
+
+func (c *bypassCaptureTelemetry) InsertRequestTelemetry(_ context.Context, p InsertTelemetryParams) error {
+	c.mu.Lock()
+	c.rows = append(c.rows, p)
+	c.mu.Unlock()
+	select {
+	case c.notify <- struct{}{}:
+	default:
+	}
+	return nil
+}
+
+// TestBypass_PersistsTelemetryRowWithUnifiedHeaders: a usage-bypass turn —
+// the primary subscription pass-through path — must write a router.upstream
+// telemetry row carrying the captured anthropic-ratelimit-unified-* headers.
+// Before this, bypass turns returned ahead of every fireTelemetry site, so
+// exactly the turns Phase 0 needs (subscription-served) were invisible.
+func TestBypass_PersistsTelemetryRowWithUnifiedHeaders(t *testing.T) {
+	upstream := &bypassFakeProvider{respBody: "{}"}
+	svc := newBypassService(upstream)
+	sink := newBypassCaptureTelemetry()
+	svc.telemetry = sink
+
+	env := bypassAnthropicEnvelope(t)
+	feats := env.RoutingFeatures(false)
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(""))
+	// Subscription bearer on the inbound request: resolveAndInjectCredentials
+	// inside bypassToAnthropic resolves it, so the header observer treats the
+	// upstream call as subscription-served.
+	req.Header.Set("Authorization", "Bearer sk-ant-oat01-live")
+
+	installationID := uuid.New()
+	ctx := context.WithValue(context.Background(), InstallationIDContextKey{}, installationID.String())
+	// Same wiring ProxyMessages does before the bypass branch: install the
+	// capture holder + observer, then simulate the provider reporting headers.
+	ctx = svc.withUsageObserver(ctx, req.Header)
+	upstreamHeaders := http.Header{}
+	upstreamHeaders.Set("anthropic-ratelimit-unified-status", "allowed")
+	upstreamHeaders.Set("anthropic-ratelimit-unified-overage-status", "rejected")
+	credCtx := context.WithValue(ctx, CredentialsContextKey{}, &Credentials{
+		APIKey: []byte("sk-ant-oat01-live"), Source: credSourceSubscription, OAuth: true,
+	})
+	providers.ObserveUpstreamHeaders(credCtx, upstreamHeaders)
+
+	err := svc.bypassToAnthropic(ctx, env, feats, false, time.Now(), "req-tel-1", "ext-1", turntype.MainLoop, req, rec)
+	require.NoError(t, err)
+
+	select {
+	case <-sink.notify:
+	case <-time.After(2 * time.Second):
+		t.Fatal("bypass turn never persisted a telemetry row")
+	}
+
+	sink.mu.Lock()
+	defer sink.mu.Unlock()
+	require.Len(t, sink.rows, 1)
+	row := sink.rows[0]
+	assert.Equal(t, installationID.String(), row.InstallationID)
+	assert.Equal(t, "router.upstream", row.SpanType, "bypass rows must land in the same span the dashboard queries filter on")
+	assert.Equal(t, "usage_bypass", row.DecisionReason)
+	assert.Equal(t, string(turntype.MainLoop), row.TurnType)
+	require.NotNil(t, row.UnifiedLimitHeaders, "captured unified headers must reach the telemetry row")
+	var headers map[string]string
+	require.NoError(t, json.Unmarshal(row.UnifiedLimitHeaders, &headers))
+	assert.Equal(t, "allowed", headers["anthropic-ratelimit-unified-status"])
+	assert.Equal(t, "rejected", headers["anthropic-ratelimit-unified-overage-status"])
+}
+
+// TestBypass_NoTelemetryRowWithoutInstallation: bypass turns without an
+// authenticated installation (should not happen in practice — the auth
+// middleware always sets it) must not fabricate a row with a zero UUID.
+func TestBypass_NoTelemetryRowWithoutInstallation(t *testing.T) {
+	upstream := &bypassFakeProvider{respBody: "{}"}
+	svc := newBypassService(upstream)
+	sink := newBypassCaptureTelemetry()
+	svc.telemetry = sink
+
+	env := bypassAnthropicEnvelope(t)
+	feats := env.RoutingFeatures(false)
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(""))
+
+	err := svc.bypassToAnthropic(context.Background(), env, feats, false, time.Now(), "req-tel-2", "ext-1", turntype.MainLoop, req, rec)
+	require.NoError(t, err)
+
+	select {
+	case <-sink.notify:
+		t.Fatal("no installation on ctx -> no telemetry row expected")
+	case <-time.After(200 * time.Millisecond):
+	}
 }

--- a/internal/sqlc/model_router_request_telemetry.sql.go
+++ b/internal/sqlc/model_router_request_telemetry.sql.go
@@ -1297,7 +1297,8 @@ INSERT INTO router.model_router_request_telemetry (
     tool_result_bytes,
     credential_key_prefix,
     credential_key_suffix,
-    credential_source
+    credential_source,
+    unified_limit_headers
 ) VALUES (
     $1::uuid,
     $2::uuid,
@@ -1363,7 +1364,8 @@ INSERT INTO router.model_router_request_telemetry (
     $62::int,
     $63::varchar,
     $64::varchar,
-    $65::varchar
+    $65::varchar,
+    $66::jsonb
 )
 ON CONFLICT (installation_id, request_id, span_type) DO NOTHING
 `
@@ -1434,6 +1436,7 @@ type InsertRequestTelemetryParams struct {
 	CredentialKeyPrefix    *string
 	CredentialKeySuffix    *string
 	CredentialSource       *string
+	UnifiedLimitHeaders    []byte
 }
 
 // Records a completed proxied request for the dashboard UI and routing
@@ -1458,6 +1461,10 @@ type InsertRequestTelemetryParams struct {
 // the upstream credential; credential_source names the precedence branch it came
 // from. All NULL on deployment-key turns. Matching prefix/suffix values across
 // distinct router_user_ids reveal one subscription paying for many seats.
+// unified_limit_headers is the verbatim anthropic-ratelimit-unified-* header
+// set observed on this turn (Claude Code cost-observing-proxy Phase 0
+// instrumentation). NULL on non-subscription turns and on rows written before
+// the column existed. Nothing reads it yet.
 //
 //	INSERT INTO router.model_router_request_telemetry (
 //	    installation_id,
@@ -1524,7 +1531,8 @@ type InsertRequestTelemetryParams struct {
 //	    tool_result_bytes,
 //	    credential_key_prefix,
 //	    credential_key_suffix,
-//	    credential_source
+//	    credential_source,
+//	    unified_limit_headers
 //	) VALUES (
 //	    $1::uuid,
 //	    $2::uuid,
@@ -1590,7 +1598,8 @@ type InsertRequestTelemetryParams struct {
 //	    $62::int,
 //	    $63::varchar,
 //	    $64::varchar,
-//	    $65::varchar
+//	    $65::varchar,
+//	    $66::jsonb
 //	)
 //	ON CONFLICT (installation_id, request_id, span_type) DO NOTHING
 func (q *Queries) InsertRequestTelemetry(ctx context.Context, arg InsertRequestTelemetryParams) error {
@@ -1660,6 +1669,7 @@ func (q *Queries) InsertRequestTelemetry(ctx context.Context, arg InsertRequestT
 		arg.CredentialKeyPrefix,
 		arg.CredentialKeySuffix,
 		arg.CredentialSource,
+		arg.UnifiedLimitHeaders,
 	)
 	return err
 }

--- a/internal/sqlc/models.go
+++ b/internal/sqlc/models.go
@@ -170,6 +170,7 @@ type RouterModelRouterRequestTelemetry struct {
 	TrainingAllowed      *bool
 	CaptureMode          *string
 	DebugRef             *string
+	UnifiedLimitHeaders  []byte
 }
 
 // End-user identities seen on inbound requests, scoped to an installation. Replaces the per-user API key pattern.


### PR DESCRIPTION
## What

Adds a nullable `unified_limit_headers` jsonb column to `router.model_router_request_telemetry` and records the verbatim `anthropic-ratelimit-unified-*` response-header set observed on each subscription-served `/v1/messages` turn. **Instrumentation only — nothing reads the column yet.**

## Why

The router already parses this header family into a `Snapshot` for the subscription-subsidy feature (`internal/proxy/usage`), but keeps only per-window utilization/reset and discards the fields needed to classify how a turn was billed: `unified-status`, `overage-status`, `overage-disabled-reason`, `representative-claim`. Capturing the full set verbatim lets us verify the header vocabulary against real traffic before any cost logic depends on it.

Side benefit: the captured raw keys will settle an open discrepancy — the subsidy parser reads `…-weekly-*` as the long window while public header dumps show `…-7d-*`. If the parser's spelling is wrong, the subsidy/exhaustion logic has been effectively running on the 5h window only; either way the data decides it.

## How

- `usage.RawAnthropicUnifiedHeaders` — pure sibling of `ParseAnthropicUnifiedHeaders` returning the verbatim name→value map. Keeping unverified vocabulary out of the routing-critical parse path is deliberate: a header-shape change can only affect the telemetry column, never `CostFactor`/`Exhausted`.
- `internal/proxy/unified_limit_capture.go` — request-scoped holder + capture fn, gated to OAuth-resolved credentials (deployment-key/BYOK calls, e.g. the handover summarizer, describe a different account's quota and are skipped).
- `providers.WithUpstreamHeaderObserver` holds one observer per context, so the capture composes into `withUsageObserver`'s existing callback rather than installing a second observer. The new code runs under its own `recover()` so a fault here cannot affect the production subsidy/usage-bypass observer sharing the call site.
- `withUsageObserver` now also engages when an Anthropic subscription token is present but the subsidy observer is unconfigured — capture must work on deployments without subscription-aware routing.
- Wired into the `ProxyMessages` telemetry write only; the OpenAI/Codex path has a different header family (`x-codex-*`) and is untouched.
- Migration 0037 (nullable additive column, precise down), SQLC regenerated and committed.

## Testing

- `go build ./...`, `go vet ./...` clean
- Full `go test ./...` green (all packages) — confirms the observer-composition change doesn't regress subsidy/usage-bypass
- 12 new tests: capture on subscription credential; skip on non-OAuth, no-credentials, and no-unified-headers; JSON round-trip; no-op contract when nothing to observe; end-to-end through `providers.ObserveUpstreamHeaders` with a nil subsidy observer

🤖 Generated with [Claude Code](https://claude.com/claude-code)