### PR TITLE
fix(openai): clamp Codex "ultra" (max) reasoning effort to xhigh off the ChatGPT backend

### DIFF
--- a/internal/providers/openai/client.go
+++ b/internal/providers/openai/client.go
@@ -17,6 +17,9 @@ import (
 	"workweave/router/internal/proxy"
 	"workweave/router/internal/router"
 	"workweave/router/internal/timing"
+
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
 )
 
 const DefaultBaseURL = "https://api.openai.com"
@@ -36,6 +39,30 @@ const (
 	codexUserAgentHeader  = "User-Agent"
 	codexUserAgentValue   = "codex_cli_rs"
 )
+
+// maxEffortToXhigh clamps a Responses-API body's top-of-ladder "max" reasoning
+// effort to "xhigh" before it reaches api.openai.com. "max" is a Codex-backend
+// (chatgpt.com/backend-api/codex) reasoning level for the "ultra" UI setting;
+// the public Responses API tops out at "xhigh" and 400s on "max"
+// ("Invalid value: 'max'. Supported values are: 'none', 'minimal', 'low',
+// 'medium', 'high', and 'xhigh'."). ProxyOpenAIResponses forwards Codex's
+// original Responses body verbatim for any NativeOnly request (custom tools,
+// reasoning-item replay) — which covers every Codex turn — but only rewrites
+// `model` before dispatch; a turn without a real ChatGPT subscription
+// credential (BYOK, deployment key, router-keyed prepaid) lands on
+// api.openai.com with the client's untouched effort value. Scoped to the
+// non-Codex-backend branch only: the Codex backend itself understands "max"
+// natively and must see it unmodified.
+func maxEffortToXhigh(body []byte) []byte {
+	if gjson.GetBytes(body, "reasoning.effort").String() != "max" {
+		return body
+	}
+	out, err := sjson.SetBytes(body, "reasoning.effort", "xhigh")
+	if err != nil {
+		return body
+	}
+	return out
+}
 
 // codexSubscriptionCreds returns the resolved credential when it's a Codex
 // (ChatGPT) subscription bearer (OAuth token with a paired account id), else
@@ -180,11 +207,16 @@ func (c *Client) Proxy(ctx context.Context, decision router.Decision, prep provi
 	if prep.Endpoint == providers.EndpointResponses {
 		path = "/v1/responses"
 	}
+	reqBody := prep.Body
 	if useCodex {
 		baseURL = c.codexBaseURL
 		path = codexResponsesPath
+	} else if prep.Endpoint == providers.EndpointResponses {
+		// Only the direct api.openai.com Responses path needs the clamp; the
+		// Codex backend branch above understands "max" natively.
+		reqBody = maxEffortToXhigh(reqBody)
 	}
-	upstream, err := http.NewRequestWithContext(ctx, http.MethodPost, baseURL+path, bytes.NewReader(prep.Body))
+	upstream, err := http.NewRequestWithContext(ctx, http.MethodPost, baseURL+path, bytes.NewReader(reqBody))
 	if err != nil {
 		return fmt.Errorf("build upstream request: %w", err)
 	}

--- a/internal/providers/openai/client.go
+++ b/internal/providers/openai/client.go
@@ -40,19 +40,9 @@ const (
 	codexUserAgentValue   = "codex_cli_rs"
 )
 
-// maxEffortToXhigh clamps a Responses-API body's top-of-ladder "max" reasoning
-// effort to "xhigh" before it reaches api.openai.com. "max" is a Codex-backend
-// (chatgpt.com/backend-api/codex) reasoning level for the "ultra" UI setting;
-// the public Responses API tops out at "xhigh" and 400s on "max"
-// ("Invalid value: 'max'. Supported values are: 'none', 'minimal', 'low',
-// 'medium', 'high', and 'xhigh'."). ProxyOpenAIResponses forwards Codex's
-// original Responses body verbatim for any NativeOnly request (custom tools,
-// reasoning-item replay) — which covers every Codex turn — but only rewrites
-// `model` before dispatch; a turn without a real ChatGPT subscription
-// credential (BYOK, deployment key, router-keyed prepaid) lands on
-// api.openai.com with the client's untouched effort value. Scoped to the
-// non-Codex-backend branch only: the Codex backend itself understands "max"
-// natively and must see it unmodified.
+// maxEffortToXhigh clamps reasoning.effort from "max" to "xhigh" in a
+// Responses-API body. "max" is valid only on the Codex backend; the public
+// api.openai.com Responses API tops out at "xhigh" and 400s on "max".
 func maxEffortToXhigh(body []byte) []byte {
 	if gjson.GetBytes(body, "reasoning.effort").String() != "max" {
 		return body

--- a/internal/providers/openai/codex_internal_test.go
+++ b/internal/providers/openai/codex_internal_test.go
@@ -123,3 +123,74 @@ func TestProxy_NoCodexCredHitsOpenAI(t *testing.T) {
 	assert.Equal(t, "/v1/chat/completions", gotPath)
 	assert.Empty(t, gotAccount, "a non-subscription request must not send the Codex account-id header")
 }
+
+// TestProxy_ResponsesMaxEffortClampedWithoutCodexCred guards against a 400
+// ("Invalid value: 'max'. Supported values are: 'none', 'minimal', 'low',
+// 'medium', 'high', and 'xhigh'.") that killed a Codex "ultra"-effort turn on
+// a request that carries no Codex subscription credential. ProxyOpenAIResponses
+// forwards Codex's original Responses body verbatim (NativeOnly) for every
+// Codex turn, "max" included — that's fine when it lands on the Codex
+// backend (which understands "max"), but a router-keyed/BYOK/deployment-key
+// request with no subscription credential dispatches to api.openai.com
+// instead, which rejects "max". Only the effort value is clamped; everything
+// else in the body must reach api.openai.com unchanged.
+func TestProxy_ResponsesMaxEffortClampedWithoutCodexCred(t *testing.T) {
+	var gotPath string
+	var gotBody []byte
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotBody, _ = io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, "event: response.completed\ndata: {\"type\":\"response.completed\"}\n\n")
+	}))
+	defer upstream.Close()
+
+	c := NewClient("deployment-key", upstream.URL)
+	c.codexBaseURL = "https://chatgpt.example.invalid" // must NOT be used
+
+	body := []byte(`{"model":"gpt-5.6-sol","input":"hi","stream":true,"reasoning":{"effort":"max","summary":"detailed"}}`)
+	prep := providers.PreparedRequest{Body: body, Endpoint: providers.EndpointResponses, Headers: make(http.Header)}
+	rec := httptest.NewRecorder()
+	clientReq := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(""))
+
+	// No Codex subscription credential in ctx — mirrors a router-keyed /
+	// BYOK / deployment-key Codex turn.
+	err := c.Proxy(context.Background(), router.Decision{Model: "gpt-5.6-sol", Provider: providers.ProviderOpenAI}, prep, rec, clientReq)
+	require.NoError(t, err)
+
+	assert.Equal(t, "/v1/responses", gotPath, "must dispatch to the public Responses API, not the Codex backend")
+	assert.JSONEq(t,
+		`{"model":"gpt-5.6-sol","input":"hi","stream":true,"reasoning":{"effort":"xhigh","summary":"detailed"}}`,
+		string(gotBody),
+		"'max' must be clamped to 'xhigh' (the top public-API level) before reaching api.openai.com; nothing else in the body changes")
+}
+
+// TestProxy_ResponsesMaxEffortUnchangedWithCodexCred confirms the clamp is
+// scoped to the non-Codex-backend branch: a real Codex subscription
+// credential understands "max" natively, so the body must reach the Codex
+// backend byte-for-byte, matching TestProxy_CodexSubscriptionDispatch.
+func TestProxy_ResponsesMaxEffortUnchangedWithCodexCred(t *testing.T) {
+	var gotBody []byte
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotBody, _ = io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, "event: response.completed\ndata: {\"type\":\"response.completed\"}\n\n")
+	}))
+	defer upstream.Close()
+
+	c := NewClient("deployment-key", upstream.URL)
+	c.codexBaseURL = upstream.URL
+
+	body := []byte(`{"model":"gpt-5.6-sol","input":"hi","stream":true,"reasoning":{"effort":"max","summary":"detailed"}}`)
+	prep := providers.PreparedRequest{Body: body, Endpoint: providers.EndpointResponses, Headers: make(http.Header)}
+	rec := httptest.NewRecorder()
+	clientReq := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(""))
+
+	ctx := codexCtx("eyJhbGciOiJ-codex-jwt", "acct-12345")
+	err := c.Proxy(ctx, router.Decision{Model: "gpt-5.6-sol", Provider: providers.ProviderOpenAI}, prep, rec, clientReq)
+	require.NoError(t, err)
+
+	assert.Equal(t, body, gotBody, "the Codex backend understands 'max' natively; the body must not be altered")
+}

--- a/internal/providers/openai/codex_internal_test.go
+++ b/internal/providers/openai/codex_internal_test.go
@@ -124,16 +124,9 @@ func TestProxy_NoCodexCredHitsOpenAI(t *testing.T) {
 	assert.Empty(t, gotAccount, "a non-subscription request must not send the Codex account-id header")
 }
 
-// TestProxy_ResponsesMaxEffortClampedWithoutCodexCred guards against a 400
-// ("Invalid value: 'max'. Supported values are: 'none', 'minimal', 'low',
-// 'medium', 'high', and 'xhigh'.") that killed a Codex "ultra"-effort turn on
-// a request that carries no Codex subscription credential. ProxyOpenAIResponses
-// forwards Codex's original Responses body verbatim (NativeOnly) for every
-// Codex turn, "max" included — that's fine when it lands on the Codex
-// backend (which understands "max"), but a router-keyed/BYOK/deployment-key
-// request with no subscription credential dispatches to api.openai.com
-// instead, which rejects "max". Only the effort value is clamped; everything
-// else in the body must reach api.openai.com unchanged.
+// TestProxy_ResponsesMaxEffortClampedWithoutCodexCred guards against the
+// api.openai.com 400 on "max" effort: without a Codex credential the request
+// lands on api.openai.com (not the Codex backend), which rejects "max".
 func TestProxy_ResponsesMaxEffortClampedWithoutCodexCred(t *testing.T) {
 	var gotPath string
 	var gotBody []byte
@@ -167,9 +160,7 @@ func TestProxy_ResponsesMaxEffortClampedWithoutCodexCred(t *testing.T) {
 }
 
 // TestProxy_ResponsesMaxEffortUnchangedWithCodexCred confirms the clamp is
-// scoped to the non-Codex-backend branch: a real Codex subscription
-// credential understands "max" natively, so the body must reach the Codex
-// backend byte-for-byte, matching TestProxy_CodexSubscriptionDispatch.
+// scoped to the non-Codex-backend branch; the Codex backend accepts "max" natively.
 func TestProxy_ResponsesMaxEffortUnchangedWithCodexCred(t *testing.T) {
 	var gotBody []byte
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Bug

Codex's `ultra` UI setting sends `reasoning.effort: "max"` on its native `/v1/responses` body. Every Codex turn is `NativeOnly` (custom tools, reasoning-item replay), so `ProxyOpenAIResponses` forwards that body **verbatim**, rewriting only `model`.

`"max"` is a valid reasoning level on the ChatGPT Codex backend (`chatgpt.com/backend-api/codex`), used only when the request carries a real Codex (ChatGPT) subscription credential. Any other credential path — BYOK, deployment key, router-keyed prepaid — dispatches that same untouched body to the public `api.openai.com` Responses API, which tops out at `xhigh` and 400s:

```
Invalid value: 'max'. Supported values are: 'none', 'minimal', 'low', 'medium', 'high', and 'xhigh'.
```

Reported by a customer whose Codex session (`gpt-5.6-sol ultra`) 400'd on every turn through the router.

## Fix

Clamp `reasoning.effort: "max"` → `"xhigh"` right before dispatch, scoped strictly to the non-Codex-backend branch in `internal/providers/openai/client.go:Proxy` — the Codex-backend branch is untouched since it natively accepts `max`.

## Tests

- `TestProxy_ResponsesMaxEffortClampedWithoutCodexCred` — no Codex credential in ctx → `max` clamped to `xhigh`, rest of body unchanged, dispatched to `/v1/responses`.
- `TestProxy_ResponsesMaxEffortUnchangedWithCodexCred` — real Codex subscription credential → body reaches the Codex backend byte-for-byte (mirrors the existing `TestProxy_CodexSubscriptionDispatch`).

Full suite: `go build ./...`, `go vet ./...`, `go test ./...` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)