### PR TITLE
feat(router): add selectable HMM embedding strategy

### DIFF
--- a/cmd/router/main.go
+++ b/cmd/router/main.go
@@ -604,6 +604,7 @@ func main() {
 	// Wired only when ROUTER_HMM_SIDECAR_URL is set; x-weave-router-strategy:
 	// hmm then routes through it. Unset fails closed with 503.
 	var hmmRouter router.Router
+	var hmmEmbeddingRouter router.Router
 	var hmmCapabilities policy.Capabilities
 	var hmmReadinessChecker admin.HealthChecker
 	if hmmSidecarURL := config.GetOr("ROUTER_HMM_SIDECAR_URL", ""); hmmSidecarURL != "" {
@@ -624,6 +625,13 @@ func main() {
 		}
 		hmmPolicyRouter := hmm.New(hmmClient, availableModels, availableProviders)
 		hmmPolicyRouter.WithCapabilities(hmmCapabilities)
+		hmmEmbeddingPolicyRouter := hmm.NewForStrategy(
+			router.StrategyHMMEmbedding,
+			hmmClient,
+			availableModels,
+			availableProviders,
+		)
+		hmmEmbeddingPolicyRouter.WithCapabilities(hmmCapabilities)
 		if capabilityErr != nil {
 			go func() {
 				retryErr := retryPolicyCapabilitiesUntilAvailable(
@@ -633,6 +641,7 @@ func main() {
 					hmmCapabilityRetryInterval,
 					func(capabilities policy.Capabilities) {
 						hmmPolicyRouter.WithCapabilities(capabilities)
+						hmmEmbeddingPolicyRouter.WithCapabilities(capabilities)
 					},
 				)
 				if retryErr != nil {
@@ -643,9 +652,17 @@ func main() {
 			}()
 		}
 		hmmRouter = hmmPolicyRouter
-		logger.Info("HMM policy router wired", "sidecar_url", hmmSidecarURL, "auth_mode", hmmAuthMode, "timeout_ms", hmmTimeout.Milliseconds(), "candidate_models", len(availableModels))
+		hmmEmbeddingRouter = hmmEmbeddingPolicyRouter
+		logger.Info(
+			"HMM policy routers wired",
+			"sidecar_url", hmmSidecarURL,
+			"auth_mode", hmmAuthMode,
+			"timeout_ms", hmmTimeout.Milliseconds(),
+			"candidate_models", len(availableModels),
+			"strategies", []router.Strategy{router.StrategyHMM, router.StrategyHMMEmbedding},
+		)
 	} else {
-		logger.Info("HMM policy router disabled (ROUTER_HMM_SIDECAR_URL unset); x-weave-router-strategy: hmm will return 503")
+		logger.Info("HMM policy routers disabled (ROUTER_HMM_SIDECAR_URL unset); HMM strategies will return 503")
 	}
 
 	// Wired only when ROUTER_BANDIT_POSTERIOR_FILE points at a ts_posterior.json;
@@ -687,6 +704,10 @@ func main() {
 		WithPolicyStrategy(policy.StrategySpec{Strategy: router.StrategyRL, Router: rlRouter, Unavailable: rl.ErrPolicyUnavailable}).
 		WithPolicyStrategy(policy.StrategySpec{
 			Strategy: router.StrategyHMM, Router: hmmRouter, Unavailable: hmm.ErrHMMUnavailable,
+			Capabilities: hmmCapabilities,
+		}).
+		WithPolicyStrategy(policy.StrategySpec{
+			Strategy: router.StrategyHMMEmbedding, Router: hmmEmbeddingRouter, Unavailable: hmm.ErrHMMUnavailable,
 			Capabilities: hmmCapabilities,
 		}).
 		WithPolicyStrategy(policy.StrategySpec{Strategy: router.StrategyBandit, Router: banditRouter, Unavailable: bandit.ErrBanditUnavailable}).

--- a/cmd/router/policy_sidecars.go
+++ b/cmd/router/policy_sidecars.go
@@ -23,10 +23,11 @@ const maxConfiguredPolicySidecars = 16
 var configuredPolicyStrategyPattern = regexp.MustCompile(`^[a-z][a-z0-9_-]{0,63}$`)
 
 var reservedPolicyStrategies = map[router.Strategy]struct{}{
-	router.StrategyCluster: {},
-	router.StrategyRL:      {},
-	router.StrategyHMM:     {},
-	router.StrategyBandit:  {},
+	router.StrategyCluster:      {},
+	router.StrategyRL:           {},
+	router.StrategyHMM:          {},
+	router.StrategyHMMEmbedding: {},
+	router.StrategyBandit:       {},
 }
 
 // buildConfiguredPolicySidecars turns a JSON strategy-to-URL map into policy.StrategySpec registrations; sidecars own model logic, the router owns candidate resolution and lifecycle.

--- a/cmd/router/policy_sidecars_test.go
+++ b/cmd/router/policy_sidecars_test.go
@@ -72,6 +72,7 @@ func TestBuildConfiguredPolicySidecarsRejectsReservedAndInvalidConfiguration(t *
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	for _, raw := range []string{
 		`{"hmm":"https://sidecar.internal"}`,
+		`{"hmm_embedding":"https://sidecar.internal"}`,
 		`{"future":"not-a-url"}`,
 		`{"future policy":"https://sidecar.internal"}`,
 		`{"Future":"https://one.internal","future":"https://two.internal"}`,

--- a/internal/policyclient/client.go
+++ b/internal/policyclient/client.go
@@ -245,7 +245,7 @@ func (c *Client) Decide(ctx context.Context, query policy.Query) (policy.Result,
 	}
 	messages := routeMessages(query.ConversationMessages)
 	var trainingDelta []routeMessage
-	if query.Strategy == router.StrategyHMM && query.TrainingAllowed {
+	if router.IsHMMStrategy(query.Strategy) && query.TrainingAllowed {
 		trainingDelta = trainingRouteMessageDelta(query.ConversationMessages)
 	}
 	body, err := json.Marshal(routeRequest{

--- a/internal/policyclient/client_test.go
+++ b/internal/policyclient/client_test.go
@@ -48,7 +48,7 @@ func TestClientPostsVersionedRouteAndParsesPolicyMetadata(t *testing.T) {
 	preferenceRank := 0
 	client := New(server.URL, server.Client(), 0)
 	result, err := client.Decide(context.Background(), policy.Query{
-		Strategy:        router.StrategyHMM,
+		Strategy:        router.StrategyHMMEmbedding,
 		ExecutionMode:   policy.ExecutionModeShadow,
 		RouteID:         "route-1",
 		OrganizationID:  "org-1",
@@ -83,7 +83,7 @@ func TestClientPostsVersionedRouteAndParsesPolicyMetadata(t *testing.T) {
 
 	require.NoError(t, err)
 	assert.Equal(t, policy.SchemaVersionV1, got.SchemaVersion)
-	assert.Equal(t, string(router.StrategyHMM), got.Strategy)
+	assert.Equal(t, string(router.StrategyHMMEmbedding), got.Strategy)
 	assert.Equal(t, policy.ExecutionModeShadow, got.ExecutionMode)
 	assert.Equal(t, "org-1", got.OrganizationID)
 	assert.Equal(t, "installation-1", got.InstallationID)

--- a/internal/proxy/router_feedback.go
+++ b/internal/proxy/router_feedback.go
@@ -118,7 +118,7 @@ func (s *Service) handleRouterFeedbackCommand(
 	if registered, ok := s.strategies[strategy]; ok && registered.feedback != nil {
 		trainingAllowed, _ := ctx.Value(PolicyTrainingAllowedContextKey{}).(bool)
 		var trainingDelta []router.ConversationMessage
-		if strategy == router.StrategyHMM && trainingAllowed {
+		if router.IsHMMStrategy(strategy) && trainingAllowed {
 			trainingDelta = routerFeedbackTrainingDelta(env)
 		}
 		s.reportRouterFeedback(ctx, registered.feedback, strategy, externalID, installationID, sessionKey, role, routerUserID, clientID, env.Model(), servedModel, rating, feedback, trainingDelta)
@@ -197,7 +197,7 @@ func (s *Service) reportRouterFeedback(
 	if installationID != uuid.Nil {
 		payload["installation_id"] = installationID.String()
 	}
-	if strategy == router.StrategyHMM && trainingAllowed && len(trainingDelta) > 0 {
+	if router.IsHMMStrategy(strategy) && trainingAllowed && len(trainingDelta) > 0 {
 		payload["training_conversation_delta"] = trainingDelta
 	}
 	log := observability.FromContext(ctx)

--- a/internal/proxy/router_feedback_proxy_test.go
+++ b/internal/proxy/router_feedback_proxy_test.go
@@ -247,7 +247,7 @@ func TestService_RouterFeedbackCommand_OmitsTrainingTranscriptWithoutPermission(
 	assert.NotContains(t, payload, "training_conversation_delta")
 }
 
-func TestService_RouterFeedbackCommand_CorrelatesCompactedHMMRoute(t *testing.T) {
+func TestService_RouterFeedbackCommand_CorrelatesCompactedHMMEmbeddingRoute(t *testing.T) {
 	routeBody := []byte(`{
 		"model":"claude-haiku-4-5",
 		"max_tokens":195000,
@@ -267,15 +267,19 @@ func TestService_RouterFeedbackCommand_CorrelatesCompactedHMMRoute(t *testing.T)
 		Provider: providers.ProviderAnthropic,
 		Model:    "claude-haiku-4-5",
 		Reason:   "hmm_policy(label=balanced)",
-		Metadata: &router.RoutingMetadata{Strategy: string(router.StrategyHMM)},
+		Metadata: &router.RoutingMetadata{Strategy: string(router.StrategyHMMEmbedding)},
 	}}
 	fr := &fakeRouter{decision: router.Decision{Provider: providers.ProviderAnthropic, Model: "claude-haiku-4-5", Reason: "cluster"}}
 	svc := newPinSvc(fr, store).
-		WithHMMRouter(policyFeedback).
+		WithPolicyStrategy(policy.StrategySpec{
+			Strategy:    router.StrategyHMMEmbedding,
+			Router:      policyFeedback,
+			Unavailable: router.ErrStrategyUnavailable,
+		}).
 		WithAvailableModels(map[string]struct{}{"claude-haiku-4-5": {}}).
 		WithCompaction(nil, proxy.DefaultCompactionTriggerPct)
 	installationID := uuid.NewString()
-	ctx := router.WithStrategy(authedCtx(installationID), router.StrategyHMM)
+	ctx := router.WithStrategy(authedCtx(installationID), router.StrategyHMMEmbedding)
 	ctx = context.WithValue(ctx, proxy.ExternalIDContextKey{}, "org-test")
 	ctx = context.WithValue(ctx, proxy.PolicyTrainingAllowedContextKey{}, true)
 	httpReq := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(""))

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -1643,7 +1643,7 @@ func defaultStrategyUnavailable(strategy router.Strategy) error {
 	switch strategy {
 	case router.StrategyRL:
 		return rl.ErrPolicyUnavailable
-	case router.StrategyHMM:
+	case router.StrategyHMM, router.StrategyHMMEmbedding:
 		return hmm.ErrHMMUnavailable
 	case router.StrategyBandit:
 		return bandit.ErrBanditUnavailable

--- a/internal/proxy/turnloop.go
+++ b/internal/proxy/turnloop.go
@@ -118,7 +118,7 @@ func (r turnLoopResult) modelSwitched() bool {
 }
 
 func isHMMDecision(dec router.Decision) bool {
-	if dec.Metadata != nil && dec.Metadata.Strategy == string(router.StrategyHMM) {
+	if dec.Metadata != nil && router.IsHMMStrategy(router.Strategy(dec.Metadata.Strategy)) {
 		return true
 	}
 	return strings.HasPrefix(strings.TrimSpace(dec.Reason), "hmm_policy")
@@ -164,7 +164,7 @@ func (s *Service) isHardPinnedTurn(ctx context.Context, tt turntype.TurnType) bo
 	case turntype.Compaction, turntype.Probe, turntype.TitleGen, turntype.Classifier:
 		return true
 	case turntype.SubAgentDispatch:
-		if router.StrategyFromContext(ctx) == router.StrategyHMM {
+		if router.IsHMMStrategy(router.StrategyFromContext(ctx)) {
 			return false
 		}
 		return s.hardPinExplore

--- a/internal/router/hmm/hmm.go
+++ b/internal/router/hmm/hmm.go
@@ -28,10 +28,16 @@ type Router struct {
 }
 
 func New(decider Decider, deployed, available map[string]struct{}) *Router {
+	return NewForStrategy(router.StrategyHMM, decider, deployed, available)
+}
+
+// NewForStrategy constructs an HMM adapter with a separately selectable
+// strategy ID while preserving the HMM roster mapping and lifecycle behavior.
+func NewForStrategy(strategy router.Strategy, decider Decider, deployed, available map[string]struct{}) *Router {
 	resolver := policy.NewResolver(deployed, available, rosterIDFor, policy.ManagedProviderPolicy())
 	return &Router{
 		SidecarRouter: policy.NewSidecarRouter(policy.SidecarRouterConfig{
-			Strategy:    router.StrategyHMM,
+			Strategy:    strategy,
 			Unavailable: ErrHMMUnavailable,
 			Reason:      reasonFor,
 		}, decider, resolver),

--- a/internal/router/hmm/hmm_test.go
+++ b/internal/router/hmm/hmm_test.go
@@ -103,6 +103,24 @@ func TestRouterMapsSidecarRosterModelBackToCatalogDecision(t *testing.T) {
 	assert.False(t, candidate.Capabilities.SupportsImages)
 }
 
+func TestRouterUsesSeparatelySelectableEmbeddingStrategy(t *testing.T) {
+	decider := &fakeDecider{res: Result{Model: "moonshotai/kimi-k2.7-code"}}
+	r := NewForStrategy(
+		router.StrategyHMMEmbedding,
+		decider,
+		map[string]struct{}{"moonshotai/kimi-k2.7": {}},
+		map[string]struct{}{providers.ProviderFireworks: {}},
+	)
+
+	decision, err := r.Route(context.Background(), router.Request{PromptText: "hello"})
+
+	require.NoError(t, err)
+	assert.Equal(t, router.StrategyHMMEmbedding, decider.query.Strategy)
+	require.NotNil(t, decision.Metadata)
+	assert.Equal(t, string(router.StrategyHMMEmbedding), decision.Metadata.Strategy)
+	assert.Contains(t, decision.Reason, "hmm_policy")
+}
+
 func TestRouterKeepsGeneratedRouteIDWhenSidecarOmitsIt(t *testing.T) {
 	decider := &fakeDecider{res: Result{
 		Model: "moonshotai/kimi-k2.7-code",

--- a/internal/router/strategy.go
+++ b/internal/router/strategy.go
@@ -23,11 +23,19 @@ const (
 	// StrategyHMM routes via an out-of-process policy sidecar. Opt-in only;
 	// never the silent default.
 	StrategyHMM Strategy = "hmm"
+	// StrategyHMMEmbedding uses the HMM sidecar with the embedding-quality-seeded bandit prior.
+	StrategyHMMEmbedding Strategy = "hmm_embedding"
 	// StrategyBandit routes via Thompson sampling over a frozen
 	// ts_posterior.json (cluster×model reward posterior). Opt-in only; wired
 	// when ROUTER_BANDIT_POSTERIOR_FILE is set at boot.
 	StrategyBandit Strategy = "bandit"
 )
+
+// IsHMMStrategy reports whether strategy uses the HMM policy contract and
+// lifecycle semantics.
+func IsHMMStrategy(strategy Strategy) bool {
+	return strategy == StrategyHMM || strategy == StrategyHMMEmbedding
+}
 
 type strategyContextKey struct{}
 

--- a/internal/router/strategy_test.go
+++ b/internal/router/strategy_test.go
@@ -1,0 +1,14 @@
+package router
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsHMMStrategy(t *testing.T) {
+	assert.True(t, IsHMMStrategy(StrategyHMM))
+	assert.True(t, IsHMMStrategy(StrategyHMMEmbedding))
+	assert.False(t, IsHMMStrategy(StrategyCluster))
+	assert.False(t, IsHMMStrategy(StrategyRL))
+}

--- a/internal/server/middleware/router_strategy_override.go
+++ b/internal/server/middleware/router_strategy_override.go
@@ -28,7 +28,12 @@ func WithRouterStrategyDefault(defaultStrategy router.Strategy, available ...rou
 	allowed := make(map[router.Strategy]struct{}, len(available)+1)
 	allowed[router.StrategyCluster] = struct{}{}
 	if len(available) == 0 {
-		available = []router.Strategy{router.StrategyRL, router.StrategyHMM, router.StrategyBandit}
+		available = []router.Strategy{
+			router.StrategyRL,
+			router.StrategyHMM,
+			router.StrategyHMMEmbedding,
+			router.StrategyBandit,
+		}
 	}
 	for _, strategy := range available {
 		allowed[strategy] = struct{}{}

--- a/internal/server/middleware/router_strategy_override_test.go
+++ b/internal/server/middleware/router_strategy_override_test.go
@@ -56,6 +56,11 @@ func TestRouterStrategyOverride_AppliesHMM(t *testing.T) {
 	assert.Equal(t, router.StrategyHMM, got, "hmm header must select the HMM strategy")
 }
 
+func TestRouterStrategyOverride_AppliesHMMEmbedding(t *testing.T) {
+	got := runStrategyOverride(t, overrideEnabledInstallation(), "hmm_embedding")
+	assert.Equal(t, router.StrategyHMMEmbedding, got)
+}
+
 func TestRouterStrategyOverride_CaseInsensitiveAndTrimmed(t *testing.T) {
 	got := runStrategyOverride(t, overrideEnabledInstallation(), "  RL  ")
 	assert.Equal(t, router.StrategyRL, got, "value must be lowercased and trimmed before matching")


### PR DESCRIPTION
Adds `hmm_embedding` as a first-class router strategy alongside standard `hmm`. Both use the authenticated HMM policy client, shared roster aliases/capabilities, and the same HMM session, subagent, outcome, feedback, and training-delta lifecycle.

The strategy is registered in the policy catalog so Internal Admin can select it per installation. It remains unavailable/fails closed when the HMM sidecar is not configured.

Paired WorkWeave sidecar/Terraform changes: workweave/WorkWeave#10656.

Validation: `go test ./...` and `go vet ./...`.
