### PR TITLE
feat: add isolated agent shadow routing

### DIFF
--- a/internal/api/anthropic/messages.go
+++ b/internal/api/anthropic/messages.go
@@ -43,7 +43,12 @@ func MessagesHandler(svc *proxy.Service, authSvc *auth.Service) gin.HandlerFunc 
 		)
 
 		ctx := stashClientIdentity(c.Request.Context(), c.Request.Header, body)
-		ctx = proxy.ResolveUserFromContext(ctx, authSvc, middleware.InstallationFrom(c))
+		// Historical eval requests may carry real Claude metadata. Preserve it
+		// for upstream request fidelity, but never upsert production router-user
+		// identity rows as a side effect of an offline shadow candidate.
+		if _, agentShadow := proxy.AgentShadowEvalFromContext(ctx); !agentShadow {
+			ctx = proxy.ResolveUserFromContext(ctx, authSvc, middleware.InstallationFrom(c))
+		}
 		c.Request = c.Request.WithContext(ctx)
 
 		if err := svc.ProxyMessages(c.Request.Context(), body, c.Writer, c.Request); err != nil {

--- a/internal/api/anthropic/messages.go
+++ b/internal/api/anthropic/messages.go
@@ -43,9 +43,7 @@ func MessagesHandler(svc *proxy.Service, authSvc *auth.Service) gin.HandlerFunc 
 		)
 
 		ctx := stashClientIdentity(c.Request.Context(), c.Request.Header, body)
-		// Historical eval requests may carry real Claude metadata. Preserve it
-		// for upstream request fidelity, but never upsert production router-user
-		// identity rows as a side effect of an offline shadow candidate.
+		// Skip identity upsert for agent-shadow eval requests to avoid mutating production router-user state.
 		if _, agentShadow := proxy.AgentShadowEvalFromContext(ctx); !agentShadow {
 			ctx = proxy.ResolveUserFromContext(ctx, authSvc, middleware.InstallationFrom(c))
 		}

--- a/internal/api/anthropic/messages_test.go
+++ b/internal/api/anthropic/messages_test.go
@@ -386,6 +386,22 @@ func TestRouteHandler_HappyPathReturnsDecision(t *testing.T) {
 	assert.Equal(t, "cheap_and_cheerful", got["reason"])
 }
 
+func TestRouteHandler_ForwardsAuthorizationForProviderEligibility(t *testing.T) {
+	decision := router.Decision{Provider: providers.ProviderAnthropic, Model: "claude-haiku-4-5"}
+	var got router.Request
+	svc := newTestService(&fakeRouter{decision: decision, got: &got}, providers.ProviderAnthropic, &fakeProviderClient{}).
+		WithByokOnly(true)
+	engine := routeEngine(svc)
+	req := httptest.NewRequest(http.MethodPost, "/v1/route", bytes.NewReader([]byte(validAnthropicBody)))
+	req.Header.Set("Authorization", "Bearer sk-ant-oat01-claude-code-token")
+	rec := httptest.NewRecorder()
+
+	engine.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	assert.Contains(t, got.EnabledProviders, providers.ProviderAnthropic)
+}
+
 func previewRouteEngine(svc *proxy.Service, authorized bool) *gin.Engine {
 	gin.SetMode(gin.TestMode)
 	engine := gin.New()
@@ -449,7 +465,7 @@ func TestRouteAnthropicRequest_ForwardsValidInstallationIDUUIDVerbatim(t *testin
 	svc := newTestService(&fakeRouter{decision: decision, got: &got}, "", nil)
 
 	ctx := context.WithValue(context.Background(), proxy.InstallationIDContextKey{}, installID.String())
-	_, err := svc.RouteAnthropicRequest(ctx, []byte(validAnthropicBody))
+	_, err := svc.RouteAnthropicRequest(ctx, []byte(validAnthropicBody), nil)
 	require.NoError(t, err)
 	assert.Equal(t, installID.String(), got.InstallationID,
 		"valid installation UUID must round-trip to the HMM sidecar unchanged")
@@ -463,7 +479,7 @@ func TestRouteAnthropicRequest_DropsMalformedInstallationIDInsteadOfForwardingRa
 	// "not-a-uuid" is the regression case: pre-fix leaked through verbatim,
 	// diverging tenant attribution from ProxyMessages (which drops invalid IDs).
 	ctx := context.WithValue(context.Background(), proxy.InstallationIDContextKey{}, "not-a-uuid")
-	_, err := svc.RouteAnthropicRequest(ctx, []byte(validAnthropicBody))
+	_, err := svc.RouteAnthropicRequest(ctx, []byte(validAnthropicBody), nil)
 	require.NoError(t, err)
 	assert.Equal(t, "", got.InstallationID,
 		"malformed installation ID must collapse to empty string so the HMM "+
@@ -476,7 +492,7 @@ func TestRouteAnthropicRequest_DropsEmptyInstallationIDInsteadOfForwardingRaw(t 
 	svc := newTestService(&fakeRouter{decision: decision, got: &got}, "", nil)
 
 	ctx := context.WithValue(context.Background(), proxy.InstallationIDContextKey{}, "")
-	_, err := svc.RouteAnthropicRequest(ctx, []byte(validAnthropicBody))
+	_, err := svc.RouteAnthropicRequest(ctx, []byte(validAnthropicBody), nil)
 	require.NoError(t, err)
 	assert.Equal(t, "", got.InstallationID,
 		"empty installation ID must collapse to empty string")
@@ -489,7 +505,7 @@ func TestRouteAnthropicRequest_DropsMissingInstallationIDInsteadOfForwardingRaw(
 
 	// No WithValue — request reached RouteAnthropicRequest with no
 	// InstallationIDContextKey on the context at all.
-	_, err := svc.RouteAnthropicRequest(context.Background(), []byte(validAnthropicBody))
+	_, err := svc.RouteAnthropicRequest(context.Background(), []byte(validAnthropicBody), nil)
 	require.NoError(t, err)
 	assert.Equal(t, "", got.InstallationID,
 		"missing installation ID context value must collapse to empty string")

--- a/internal/api/anthropic/messages_test.go
+++ b/internal/api/anthropic/messages_test.go
@@ -10,10 +10,12 @@ import (
 	"testing"
 
 	anthropicapi "workweave/router/internal/api/anthropic"
+	"workweave/router/internal/auth"
 	"workweave/router/internal/providers"
 	"workweave/router/internal/proxy"
 	"workweave/router/internal/router"
 	"workweave/router/internal/router/cluster"
+	"workweave/router/internal/router/policy"
 
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
@@ -29,6 +31,42 @@ type fakeRouter struct {
 	decision router.Decision
 	err      error
 	got      *router.Request
+}
+
+type fakeRoutePreviewer struct {
+	result policy.PreviewResult
+	got    *router.Request
+}
+
+type countingUserRepository struct {
+	upserts int
+}
+
+func (r *countingUserRepository) UpsertByEmail(context.Context, auth.UpsertUserParams) (*auth.User, error) {
+	r.upserts++
+	return &auth.User{ID: "unexpected"}, nil
+}
+
+func (r *countingUserRepository) UpsertByAccountUUID(context.Context, auth.UpsertUserByAccountUUIDParams) (*auth.User, error) {
+	r.upserts++
+	return &auth.User{ID: "unexpected"}, nil
+}
+
+func (*countingUserRepository) Get(context.Context, string) (*auth.User, error) {
+	return nil, nil
+}
+
+func (*countingUserRepository) ListForInstallation(context.Context, string) ([]*auth.User, error) {
+	return nil, nil
+}
+
+func (f *fakeRoutePreviewer) Route(context.Context, router.Request) (router.Decision, error) {
+	return router.Decision{}, errors.New("serving route must not run")
+}
+
+func (f *fakeRoutePreviewer) PreviewRoute(_ context.Context, req router.Request) (policy.PreviewResult, error) {
+	f.got = &req
+	return f.result, nil
 }
 
 func (f *fakeRouter) Route(_ context.Context, req router.Request) (router.Decision, error) {
@@ -263,6 +301,31 @@ func TestMessagesHandler_HappyPathServesUpstreamResponse(t *testing.T) {
 	assert.Equal(t, "test_reason", rec.Header().Get("x-router-decision"))
 }
 
+func TestMessagesHandler_AgentShadowDoesNotUpsertRouterUser(t *testing.T) {
+	users := &countingUserRepository{}
+	authSvc := auth.NewService(nil, nil, nil, users, nil, nil, nil)
+	provider := &fakeProviderClient{proxyBody: `{"id":"msg_eval","type":"message","role":"assistant","model":"claude-opus-4-8","content":[{"type":"text","text":"done"}],"stop_reason":"end_turn","usage":{"input_tokens":12,"output_tokens":3}}`}
+	svc := newTestService(&fakeRouter{}, providers.ProviderAnthropic, provider)
+
+	gin.SetMode(gin.TestMode)
+	engine := gin.New()
+	engine.Use(func(c *gin.Context) {
+		c.Set("router_installation", &auth.Installation{ID: uuid.NewString()})
+		ctx := context.WithValue(c.Request.Context(), proxy.AgentShadowEvalContextKey{}, proxy.AgentShadowEvaluation{
+			Model: "claude-opus-4-8", RolloutID: "pilot-1", StateID: "state-1",
+		})
+		c.Request = c.Request.WithContext(ctx)
+		c.Next()
+	})
+	engine.POST("/v1/messages", anthropicapi.MessagesHandler(svc, authSvc))
+	body := []byte(`{"model":"claude-sonnet-4-5","messages":[{"role":"user","content":"hi"}],"metadata":{"user_id":"{\"account_uuid\":\"real-account\",\"email\":\"person@example.com\"}"},"max_tokens":4096}`)
+
+	recorder := postMessages(engine, body)
+
+	require.Equal(t, http.StatusOK, recorder.Code)
+	assert.Zero(t, users.upserts, "eval traffic must not mutate router-user identity state")
+}
+
 // --- RouteHandler (/v1/route) ---
 
 func routeEngine(svc *proxy.Service) *gin.Engine {
@@ -321,6 +384,55 @@ func TestRouteHandler_HappyPathReturnsDecision(t *testing.T) {
 	assert.Equal(t, "claude-haiku-4-5", got["model"])
 	assert.Equal(t, providers.ProviderAnthropic, got["provider"])
 	assert.Equal(t, "cheap_and_cheerful", got["reason"])
+}
+
+func previewRouteEngine(svc *proxy.Service, authorized bool) *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	engine := gin.New()
+	engine.Use(func(c *gin.Context) {
+		if authorized {
+			c.Set("router_installation", &auth.Installation{ID: "eval-installation", PolicyHeaderOverridesEnabled: true})
+		}
+		c.Request = c.Request.WithContext(router.WithStrategy(c.Request.Context(), router.StrategyHMM))
+		c.Next()
+	})
+	engine.POST("/v1/route/preview", anthropicapi.PreviewRouteHandler(svc))
+	return engine
+}
+
+func TestPreviewRouteHandler_RejectsInstallationWithoutEvalAuthorization(t *testing.T) {
+	engine := previewRouteEngine(newTestService(&fakeRouter{}, "", nil), false)
+	recorder := httptest.NewRecorder()
+
+	engine.ServeHTTP(recorder, httptest.NewRequest(http.MethodPost, "/v1/route/preview", bytes.NewReader([]byte(validAnthropicBody))))
+
+	require.Equal(t, http.StatusForbidden, recorder.Code)
+	errObj := errorEnvelope(t, recorder.Body.Bytes())
+	assert.Equal(t, "permission_error", errObj["type"])
+}
+
+func TestPreviewRouteHandler_ReturnsFrozenPolicyPlan(t *testing.T) {
+	previewer := &fakeRoutePreviewer{result: policy.PreviewResult{
+		SchemaVersion:        policy.SchemaVersionV1,
+		PolicyArtifactID:     "hmm-prod",
+		PolicyArtifactSHA256: "sha256:artifact",
+		RosterSHA256:         "sha256:roster",
+		EligibleRosterIDs:    []string{"anthropic/claude-opus-4-8", "openai/gpt-5.5"},
+	}}
+	svc := newTestService(&fakeRouter{}, "", nil).WithPolicyStrategy(policy.StrategySpec{
+		Strategy: router.StrategyHMM,
+		Router:   previewer,
+	})
+	engine := previewRouteEngine(svc, true)
+	recorder := httptest.NewRecorder()
+
+	engine.ServeHTTP(recorder, httptest.NewRequest(http.MethodPost, "/v1/route/preview", bytes.NewReader([]byte(validAnthropicBody))))
+
+	require.Equal(t, http.StatusOK, recorder.Code)
+	assert.Contains(t, recorder.Body.String(), `"policy_artifact_sha256":"sha256:artifact"`)
+	assert.Contains(t, recorder.Body.String(), `"eligible_roster_ids":["anthropic/claude-opus-4-8","openai/gpt-5.5"]`)
+	require.NotNil(t, previewer.got)
+	assert.False(t, previewer.got.TrainingAllowed)
 }
 
 // --- RouteAnthropicRequest InstallationID forwarding ---

--- a/internal/api/anthropic/route.go
+++ b/internal/api/anthropic/route.go
@@ -7,7 +7,9 @@ import (
 
 	"workweave/router/internal/observability"
 	"workweave/router/internal/proxy"
+	"workweave/router/internal/router"
 	"workweave/router/internal/router/cluster"
+	"workweave/router/internal/server/middleware"
 
 	"github.com/gin-gonic/gin"
 )
@@ -49,5 +51,50 @@ func RouteHandler(svc *proxy.Service) gin.HandlerFunc {
 			"provider": decision.Provider,
 			"reason":   decision.Reason,
 		})
+	}
+}
+
+// PreviewRouteHandler exposes the side-effect-free policy preview contract to
+// router-key installations authorized for evaluation headers.
+func PreviewRouteHandler(svc *proxy.Service) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		log := observability.FromGin(c)
+		installation := middleware.InstallationFrom(c)
+		if installation == nil || !installation.PolicyHeaderOverridesEnabled {
+			writeAnthropicError(c, http.StatusForbidden, "permission_error", "Route preview isn't enabled for this installation.")
+			return
+		}
+		strategy := router.StrategyFromContext(c.Request.Context())
+		if strategy != router.StrategyHMM && strategy != router.StrategyHMMEmbedding {
+			writeAnthropicError(c, http.StatusBadRequest, "invalid_request_error", "Route preview requires an HMM strategy.")
+			return
+		}
+
+		body, err := io.ReadAll(io.LimitReader(c.Request.Body, proxy.MaxRequestBodyBytes+1))
+		if err != nil {
+			log.Debug("Failed to read route preview body", "err", err)
+			writeAnthropicError(c, http.StatusBadRequest, "invalid_request_error", "Failed to read request body.")
+			return
+		}
+		if len(body) > proxy.MaxRequestBodyBytes {
+			writeAnthropicError(c, http.StatusRequestEntityTooLarge, "invalid_request_error", "Request body too large.")
+			return
+		}
+
+		result, previewErr := svc.PreviewAnthropicRoute(c.Request.Context(), body, c.Request.Header)
+		if previewErr != nil {
+			if errors.Is(previewErr, proxy.ErrRequestNotJSONObject) {
+				writeAnthropicError(c, http.StatusBadRequest, "invalid_request_error", "Request body must be a JSON object.")
+				return
+			}
+			if errors.Is(previewErr, cluster.ErrInvalidRoutingKnobs) {
+				writeAnthropicError(c, http.StatusBadRequest, "invalid_request_error", "Invalid routing knobs supplied.")
+				return
+			}
+			log.Error("Route preview failed", "err", previewErr)
+			writeAnthropicError(c, http.StatusBadGateway, "api_error", "Route preview failed.")
+			return
+		}
+		c.JSON(http.StatusOK, result)
 	}
 }

--- a/internal/api/anthropic/route.go
+++ b/internal/api/anthropic/route.go
@@ -30,7 +30,7 @@ func RouteHandler(svc *proxy.Service) gin.HandlerFunc {
 		}
 
 		ctx := c.Request.Context()
-		decision, routeErr := svc.RouteAnthropicRequest(ctx, body)
+		decision, routeErr := svc.RouteAnthropicRequest(ctx, body, c.Request.Header)
 		if routeErr != nil {
 			if errors.Is(routeErr, proxy.ErrRequestNotJSONObject) {
 				writeAnthropicError(c, http.StatusBadRequest, "invalid_request_error", "Request body must be a JSON object.")

--- a/internal/policyclient/client.go
+++ b/internal/policyclient/client.go
@@ -235,60 +235,33 @@ type routeResponse struct {
 	Error                string                 `json:"error"`
 }
 
+type previewResponse struct {
+	SchemaVersion         string                `json:"schema_version"`
+	RouteID               string                `json:"route_id"`
+	PolicyArtifactID      string                `json:"policy_artifact_id"`
+	PolicyArtifactSHA256  string                `json:"policy_artifact_sha256"`
+	RosterSHA256          string                `json:"roster_sha256"`
+	HMMStateID            int                   `json:"hmm_state_id"`
+	HMMStatePath          []int                 `json:"hmm_state_path"`
+	HMMStateProbabilities []float64             `json:"hmm_state_probabilities"`
+	ClassOrder            []string              `json:"class_order"`
+	ClassProbabilities    map[string]float64    `json:"class_probabilities"`
+	RankedFallback        []policy.PreviewGroup `json:"ranked_fallback"`
+	SelectedGroup         string                `json:"selected_group"`
+	EligibleRosterIDs     []string              `json:"eligible_roster_ids"`
+	Error                 string                `json:"error"`
+}
+
 // Decide posts the supplied candidate set and returns the sidecar selection.
 func (c *Client) Decide(ctx context.Context, query policy.Query) (policy.Result, error) {
-	models := make([]string, 0, len(query.Candidates))
-	providerMap := make(map[string]string, len(query.Candidates))
-	for _, candidate := range query.Candidates {
-		models = append(models, candidate.RosterID)
-		providerMap[candidate.RosterID] = candidate.Provider
-	}
-	messages := routeMessages(query.ConversationMessages)
-	var trainingDelta []routeMessage
-	if router.IsHMMStrategy(query.Strategy) && query.TrainingAllowed {
-		trainingDelta = trainingRouteMessageDelta(query.ConversationMessages)
-	}
-	body, err := json.Marshal(routeRequest{
-		SchemaVersion:             policy.SchemaVersionV1,
-		Strategy:                  string(query.Strategy),
-		ExecutionMode:             query.ExecutionMode,
-		RouteID:                   query.RouteID,
-		OrganizationID:            query.OrganizationID,
-		InstallationID:            query.InstallationID,
-		ClientApp:                 query.ClientApp,
-		Harness:                   query.ClientApp,
-		RolloutID:                 query.RolloutID,
-		RequestedModel:            query.RequestedModel,
-		PromptText:                query.PromptText,
-		LatestUserText:            latestUserText(messages),
-		TurnIndex:                 turnIndex(messages),
-		ConversationMessages:      messages,
-		TrainingConversationDelta: trainingDelta,
-		AvailableTools:            clipRouteValues(query.AvailableTools, maxRouteToolCallInputKeys, maxRouteToolCallInputChars),
-		FeedbackKey:               query.FeedbackKey,
-		FeedbackRole:              query.FeedbackRole,
-		ClientSessionID:           query.ClientSessionID,
-		EstimatedInputTokens:      query.EstimatedInputTokens,
-		HasTools:                  query.HasTools,
-		HasImages:                 query.HasImages,
-		RoutingIntent:             query.RoutingIntent,
-		PreferredModels:           query.PreferredModels,
-		RoutingKnobs:              wireRoutingKnobs(query.RoutingKnobs),
-		QualityBias:               qualityBias(query.RoutingKnobs),
-		TrainingAllowed:           query.TrainingAllowed,
-		CaptureMode:               query.CaptureMode,
-		DebugEnabled:              query.DebugEnabled,
-		Candidates:                query.Candidates,
-		CandidateModels:           models,
-		CandidateProviders:        providerMap,
-	})
+	body, err := marshalRouteRequest(query)
 	if err != nil {
-		return policy.Result{}, fmt.Errorf("marshal policy route request: %w", err)
+		return policy.Result{}, err
 	}
 
 	requestCtx, cancel := context.WithTimeout(ctx, c.timeout)
 	defer cancel()
-	resp, payload, err := c.doRoute(requestCtx, body)
+	resp, payload, err := c.doPolicyRequest(requestCtx, "/route", body)
 	if err != nil {
 		return policy.Result{}, err
 	}
@@ -339,10 +312,107 @@ func (c *Client) Decide(ctx context.Context, query policy.Query) (policy.Result,
 	}, nil
 }
 
-func (c *Client) doRoute(ctx context.Context, body []byte) (*http.Response, []byte, error) {
+// Preview evaluates the supplied candidate set without serving or callbacks.
+func (c *Client) Preview(ctx context.Context, query policy.Query) (policy.PreviewResult, error) {
+	if query.ExecutionMode != policy.ExecutionModePreview {
+		return policy.PreviewResult{}, fmt.Errorf("policy preview requires preview execution mode")
+	}
+	body, err := marshalRouteRequest(query)
+	if err != nil {
+		return policy.PreviewResult{}, err
+	}
+	requestCtx, cancel := context.WithTimeout(ctx, c.timeout)
+	defer cancel()
+	resp, payload, err := c.doPolicyRequest(requestCtx, "/preview", body)
+	if err != nil {
+		return policy.PreviewResult{}, err
+	}
+	var parsed previewResponse
+	if err := json.Unmarshal(payload, &parsed); err != nil {
+		return policy.PreviewResult{}, fmt.Errorf("decode policy preview response (status %d): %w", resp.StatusCode, err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		if parsed.Error != "" {
+			return policy.PreviewResult{}, fmt.Errorf("policy preview status %d: %s", resp.StatusCode, parsed.Error)
+		}
+		return policy.PreviewResult{}, fmt.Errorf("policy preview status %d", resp.StatusCode)
+	}
+	if parsed.SchemaVersion != policy.SchemaVersionV1 {
+		return policy.PreviewResult{}, fmt.Errorf("unsupported policy preview schema %q", parsed.SchemaVersion)
+	}
+	return policy.PreviewResult{
+		SchemaVersion:         parsed.SchemaVersion,
+		RouteID:               parsed.RouteID,
+		PolicyArtifactID:      parsed.PolicyArtifactID,
+		PolicyArtifactSHA256:  parsed.PolicyArtifactSHA256,
+		RosterSHA256:          parsed.RosterSHA256,
+		HMMStateID:            parsed.HMMStateID,
+		HMMStatePath:          parsed.HMMStatePath,
+		HMMStateProbabilities: parsed.HMMStateProbabilities,
+		ClassOrder:            parsed.ClassOrder,
+		ClassProbabilities:    parsed.ClassProbabilities,
+		RankedFallback:        parsed.RankedFallback,
+		SelectedGroup:         parsed.SelectedGroup,
+		EligibleRosterIDs:     parsed.EligibleRosterIDs,
+	}, nil
+}
+
+func marshalRouteRequest(query policy.Query) ([]byte, error) {
+	models := make([]string, 0, len(query.Candidates))
+	providerMap := make(map[string]string, len(query.Candidates))
+	for _, candidate := range query.Candidates {
+		models = append(models, candidate.RosterID)
+		providerMap[candidate.RosterID] = candidate.Provider
+	}
+	messages := routeMessages(query.ConversationMessages)
+	var trainingDelta []routeMessage
+	if router.IsHMMStrategy(query.Strategy) && query.TrainingAllowed {
+		trainingDelta = trainingRouteMessageDelta(query.ConversationMessages)
+	}
+	body, err := json.Marshal(routeRequest{
+		SchemaVersion:             policy.SchemaVersionV1,
+		Strategy:                  string(query.Strategy),
+		ExecutionMode:             query.ExecutionMode,
+		RouteID:                   query.RouteID,
+		OrganizationID:            query.OrganizationID,
+		InstallationID:            query.InstallationID,
+		ClientApp:                 query.ClientApp,
+		Harness:                   query.ClientApp,
+		RolloutID:                 query.RolloutID,
+		RequestedModel:            query.RequestedModel,
+		PromptText:                query.PromptText,
+		LatestUserText:            latestUserText(messages),
+		TurnIndex:                 turnIndex(messages),
+		ConversationMessages:      messages,
+		TrainingConversationDelta: trainingDelta,
+		AvailableTools:            clipRouteValues(query.AvailableTools, maxRouteToolCallInputKeys, maxRouteToolCallInputChars),
+		FeedbackKey:               query.FeedbackKey,
+		FeedbackRole:              query.FeedbackRole,
+		ClientSessionID:           query.ClientSessionID,
+		EstimatedInputTokens:      query.EstimatedInputTokens,
+		HasTools:                  query.HasTools,
+		HasImages:                 query.HasImages,
+		RoutingIntent:             query.RoutingIntent,
+		PreferredModels:           query.PreferredModels,
+		RoutingKnobs:              wireRoutingKnobs(query.RoutingKnobs),
+		QualityBias:               qualityBias(query.RoutingKnobs),
+		TrainingAllowed:           query.TrainingAllowed,
+		CaptureMode:               query.CaptureMode,
+		DebugEnabled:              query.DebugEnabled,
+		Candidates:                query.Candidates,
+		CandidateModels:           models,
+		CandidateProviders:        providerMap,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("marshal policy route request: %w", err)
+	}
+	return body, nil
+}
+
+func (c *Client) doPolicyRequest(ctx context.Context, path string, body []byte) (*http.Response, []byte, error) {
 	var lastErr error
 	for attempt := 1; attempt <= defaultRouteAttempts; attempt++ {
-		req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/route", bytes.NewReader(body))
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+path, bytes.NewReader(body))
 		if err != nil {
 			return nil, nil, fmt.Errorf("build policy route request: %w", err)
 		}
@@ -616,5 +686,6 @@ func clipRouteValues(values []string, maxValues, maxChars int) []string {
 }
 
 var _ policy.Decider = (*Client)(nil)
+var _ policy.PreviewDecider = (*Client)(nil)
 var _ policy.OutcomeReporter = (*Client)(nil)
 var _ policy.FeedbackReporter = (*Client)(nil)

--- a/internal/policyclient/client_test.go
+++ b/internal/policyclient/client_test.go
@@ -138,6 +138,60 @@ func TestClientAcceptsLegacyRouteResponse(t *testing.T) {
 	assert.Empty(t, result.SchemaVersion)
 }
 
+func TestClientPreviewPostsNonLearningRequestAndReturnsEveryArm(t *testing.T) {
+	var got routeRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+		require.Equal(t, "/preview", request.URL.Path)
+		require.NoError(t, json.NewDecoder(request.Body).Decode(&got))
+		_ = json.NewEncoder(w).Encode(previewResponse{
+			SchemaVersion:         policy.SchemaVersionV1,
+			RouteID:               "preview-1",
+			PolicyArtifactID:      "hmm-prod",
+			PolicyArtifactSHA256:  "sha256:artifact",
+			RosterSHA256:          "sha256:roster",
+			HMMStateID:            7,
+			HMMStatePath:          []int{2, 7},
+			HMMStateProbabilities: []float64{0.01, 0.01, 0.05, 0.01, 0.01, 0.01, 0.1, 0.8},
+			ClassOrder:            []string{"hard", "balanced"},
+			ClassProbabilities:    map[string]float64{"hard": 0.75, "balanced": 0.25},
+			RankedFallback: []policy.PreviewGroup{{
+				Group:        "hard",
+				Probability:  0.75,
+				RosterArms:   []string{"arm-a", "arm-b"},
+				EligibleArms: []string{"arm-a", "arm-b"},
+			}},
+			SelectedGroup:     "hard",
+			EligibleRosterIDs: []string{"arm-a", "arm-b"},
+		})
+	}))
+	defer server.Close()
+
+	result, err := New(server.URL, server.Client(), 0).Preview(context.Background(), policy.Query{
+		ExecutionMode:   policy.ExecutionModePreview,
+		RouteID:         "preview-1",
+		TrainingAllowed: false,
+		Candidates: []policy.Candidate{
+			{RosterID: "arm-a", CatalogID: "model-a", Provider: providers.ProviderAnthropic},
+			{RosterID: "arm-b", CatalogID: "model-b", Provider: providers.ProviderOpenAI},
+		},
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, policy.ExecutionModePreview, got.ExecutionMode)
+	assert.False(t, got.TrainingAllowed)
+	assert.Equal(t, []float64{0.01, 0.01, 0.05, 0.01, 0.01, 0.01, 0.1, 0.8}, result.HMMStateProbabilities)
+	assert.Equal(t, []string{"arm-a", "arm-b"}, result.EligibleRosterIDs)
+	assert.Equal(t, "sha256:artifact", result.PolicyArtifactSHA256)
+	assert.Equal(t, "sha256:roster", result.RosterSHA256)
+}
+
+func TestClientPreviewRequiresPreviewExecutionMode(t *testing.T) {
+	_, err := New("http://unused.invalid", nil, 0).Preview(context.Background(), policy.Query{})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "requires preview execution mode")
+}
+
 func TestClientOmitsHMMTrainingTranscriptWithoutPermission(t *testing.T) {
 	var got routeRequest
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {

--- a/internal/proxy/agent_shadow_eval.go
+++ b/internal/proxy/agent_shadow_eval.go
@@ -51,7 +51,7 @@ func (s *Service) runAgentShadowEvaluationRoute(
 	}
 	rawModel := strings.TrimSpace(evaluation.Model)
 	model, provider, known, _ := resolveForceModelWithEffort(rawModel)
-	if !known || model != rawModel {
+	if !known || model != strings.ToLower(rawModel) {
 		return turnLoopResult{}, fmt.Errorf("agent-shadow model must be a canonical catalog id: %q", rawModel)
 	}
 	if _, excluded := req.ExcludedModels[model]; excluded {

--- a/internal/proxy/agent_shadow_eval.go
+++ b/internal/proxy/agent_shadow_eval.go
@@ -1,0 +1,98 @@
+package proxy
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"workweave/router/internal/router"
+	"workweave/router/internal/router/catalog"
+	"workweave/router/internal/router/cluster"
+	"workweave/router/internal/router/turntype"
+	"workweave/router/internal/translate"
+
+	"github.com/google/uuid"
+)
+
+const (
+	AgentShadowModelHeader   = "x-weave-agent-shadow-model"
+	AgentShadowRolloutHeader = "x-weave-agent-shadow-rollout-id"
+	AgentShadowStateHeader   = "x-weave-agent-shadow-state-id"
+	ReasonAgentShadowEval    = "agent_shadow_eval_force"
+)
+
+type AgentShadowEvaluation struct {
+	Model     string
+	RolloutID string
+	StateID   string
+}
+
+type AgentShadowEvalContextKey struct{}
+
+func AgentShadowEvalFromContext(ctx context.Context) (AgentShadowEvaluation, bool) {
+	value, ok := ctx.Value(AgentShadowEvalContextKey{}).(AgentShadowEvaluation)
+	return value, ok && value.Model != "" && value.RolloutID != "" && value.StateID != ""
+}
+
+// runAgentShadowEvaluationRoute applies the same translation compatibility
+// plan and current installation exclusions as serving, then returns the exact
+// preplanned model without touching pins, planners, feedback, or policy state.
+func (s *Service) runAgentShadowEvaluationRoute(
+	ctx context.Context,
+	env *translate.RequestEnvelope,
+	feats translate.RoutingFeatures,
+	installationID uuid.UUID,
+	req router.Request,
+	evaluation AgentShadowEvaluation,
+) (turnLoopResult, error) {
+	req.TranslationRequirements = env.TranslationRequirements(router.EndpointAnthropicMessages)
+	var err error
+	req, err = s.applyTranslationPlan(ctx, req)
+	if err != nil {
+		return turnLoopResult{}, err
+	}
+	rawModel := strings.TrimSpace(evaluation.Model)
+	model, provider, known, _ := resolveForceModelWithEffort(rawModel)
+	if !known || model != rawModel {
+		return turnLoopResult{}, fmt.Errorf("agent-shadow model must be a canonical catalog id: %q", rawModel)
+	}
+	if _, excluded := req.ExcludedModels[model]; excluded {
+		return turnLoopResult{}, fmt.Errorf("agent-shadow planned model %q is no longer eligible: %w", model, cluster.ErrNoEligibleProvider)
+	}
+	if req.EnabledProviders != nil {
+		if _, enabled := req.EnabledProviders[provider]; !enabled {
+			// A model may have another currently enabled provider binding. Pick
+			// the first catalog binding in serving order; dispatch retains its
+			// normal pre-response failover across the remaining bindings.
+			provider = ""
+			for _, binding := range catalog.AvailableBindings(model, req.EnabledProviders) {
+				if _, excludedProvider := s.excludedProvidersForRequest(ctx)[binding.Provider]; !excludedProvider {
+					provider = binding.Provider
+					break
+				}
+			}
+			if provider == "" {
+				return turnLoopResult{}, fmt.Errorf("agent-shadow model %q has no enabled provider: %w", model, cluster.ErrNoEligibleProvider)
+			}
+		}
+	}
+	if _, err := s.provider(provider); err != nil {
+		return turnLoopResult{}, fmt.Errorf("agent-shadow provider %q is unavailable: %w", provider, err)
+	}
+	decision := router.Decision{Model: model, Provider: provider, Reason: ReasonAgentShadowEval}
+	requestedTier := catalog.TierFor(feats.Model)
+	return turnLoopResult{
+		InstallationID: installationID,
+		TurnType:       turntype.DetectFromEnvelope(env, feats, ""),
+		PinTier:        "agent_shadow_eval",
+		PinRole:        roleForTier(requestedTier),
+		RequestedTier:  requestedTier,
+		Decision:       decision,
+		Fresh:          decision,
+	}, nil
+}
+
+func isAgentShadowEvaluation(ctx context.Context) bool {
+	_, ok := AgentShadowEvalFromContext(ctx)
+	return ok
+}

--- a/internal/proxy/agent_shadow_eval.go
+++ b/internal/proxy/agent_shadow_eval.go
@@ -34,9 +34,7 @@ func AgentShadowEvalFromContext(ctx context.Context) (AgentShadowEvaluation, boo
 	return value, ok && value.Model != "" && value.RolloutID != "" && value.StateID != ""
 }
 
-// runAgentShadowEvaluationRoute applies the same translation compatibility
-// plan and current installation exclusions as serving, then returns the exact
-// preplanned model without touching pins, planners, feedback, or policy state.
+// runAgentShadowEvaluationRoute forces the preplanned model without touching pins, planners, feedback, or policy state.
 func (s *Service) runAgentShadowEvaluationRoute(
 	ctx context.Context,
 	env *translate.RequestEnvelope,
@@ -61,9 +59,7 @@ func (s *Service) runAgentShadowEvaluationRoute(
 	}
 	if req.EnabledProviders != nil {
 		if _, enabled := req.EnabledProviders[provider]; !enabled {
-			// A model may have another currently enabled provider binding. Pick
-			// the first catalog binding in serving order; dispatch retains its
-			// normal pre-response failover across the remaining bindings.
+			// Planned provider may be disabled; fall back to the first available catalog binding.
 			provider = ""
 			for _, binding := range catalog.AvailableBindings(model, req.EnabledProviders) {
 				if _, excludedProvider := s.excludedProvidersForRequest(ctx)[binding.Provider]; !excludedProvider {
@@ -89,6 +85,8 @@ func (s *Service) runAgentShadowEvaluationRoute(
 		RequestedTier:  requestedTier,
 		Decision:       decision,
 		Fresh:          decision,
+		// Eval routing does not read pins, so request evidence must guard stale signatures.
+		StripThinkingBlocks: feats.Model != model || env.SignatureTokenSavings() > 0,
 	}, nil
 }
 

--- a/internal/proxy/route_preview.go
+++ b/internal/proxy/route_preview.go
@@ -1,0 +1,110 @@
+package proxy
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/google/uuid"
+
+	"workweave/router/internal/billing"
+	"workweave/router/internal/observability"
+	"workweave/router/internal/providers"
+	"workweave/router/internal/router"
+	"workweave/router/internal/router/policy"
+	"workweave/router/internal/translate"
+)
+
+func (s *Service) anthropicRoutingRequest(ctx context.Context, body []byte, headers http.Header) (router.Request, error) {
+	log := observability.FromContext(ctx)
+	cleanBody, err := stripRoutingMarkerFromMessages(body)
+	if err != nil {
+		return router.Request{}, fmt.Errorf("strip routing marker: %w", err)
+	}
+	if withoutFooter, footerErr := translate.StripFeedbackFooterFromMessages(cleanBody); footerErr != nil {
+		log.Error("Failed to strip feedback footer from route preview", "err", footerErr)
+	} else {
+		cleanBody = withoutFooter
+	}
+	if canonical, _, modelErr := translate.CanonicalizeModelInBody(cleanBody); modelErr != nil {
+		log.Error("Failed to canonicalize model for route preview", "err", modelErr)
+	} else {
+		cleanBody = canonical
+	}
+
+	env, err := translate.ParseAnthropic(cleanBody)
+	if err != nil {
+		return router.Request{}, fmt.Errorf("parse request: %w", err)
+	}
+	embedOnlyUser := s.ResolveEmbedOnlyUserMessage(ctx)
+	features := env.RoutingFeatures(embedOnlyUser)
+	promptText := features.PromptText
+	if embedOnlyUser && features.OnlyUserMessageText != "" {
+		promptText = features.OnlyUserMessageText
+	}
+
+	enabledProviders := s.enabledProvidersForRequest(ctx, providers.ProviderAnthropic, headers)
+	if billing.SubscriptionOnlyFromContext(ctx) {
+		enabledProviders = restrictToSubscriptionProviders(ctx, headers, enabledProviders)
+	}
+	outputReserve := contextWindowOutputReserve
+	if features.MaxTokens > outputReserve {
+		outputReserve = features.MaxTokens
+	}
+	excluded := s.excludedModelsForRequest(ctx)
+	excluded, _ = excludeContextOverflowModels(
+		env.ContextOverflowTokenEstimate(),
+		env.SignatureTokenSavings(),
+		outputReserve,
+		excluded,
+		s.availableModels,
+	)
+	excluded, _ = excludeGemini3xOnUnsignedHistory(env, excluded, s.availableModels)
+
+	organizationID, _ := ctx.Value(ExternalIDContextKey{}).(string)
+	installationID := ""
+	if id := installationIDFromContext(ctx); id != uuid.Nil {
+		installationID = id.String()
+	}
+	return router.Request{
+		RequestedModel:          features.Model,
+		EstimatedInputTokens:    features.Tokens,
+		HasTools:                features.HasTools,
+		HasImages:               features.HasImages,
+		TranslationRequirements: env.TranslationRequirements(router.EndpointAnthropicMessages),
+		PromptText:              promptText,
+		ConversationMessages:    conversationMessagesForRouting(env),
+		AvailableTools:          availableToolsForRouting(env),
+		OrganizationID:          organizationID,
+		InstallationID:          installationID,
+		ClientSessionID:         env.ClientSessionID(),
+		EnabledProviders:        enabledProviders,
+		ExcludedModels:          excluded,
+		PreferredModels:         s.preferredModelsForRequest(ctx),
+		RoutingKnobs:            routingKnobsForRequest(ctx),
+	}, nil
+}
+
+// PreviewAnthropicRoute evaluates an Anthropic request with the registered
+// policy preview contract without dispatching or invoking serving lifecycle state.
+func (s *Service) PreviewAnthropicRoute(ctx context.Context, body []byte, headers http.Header) (policy.PreviewResult, error) {
+	req, err := s.anthropicRoutingRequest(ctx, body, headers)
+	if err != nil {
+		return policy.PreviewResult{}, err
+	}
+	req, err = s.applyTranslationPlan(ctx, req)
+	if err != nil {
+		return policy.PreviewResult{}, err
+	}
+	req = s.withPolicyRequestContext(ctx, req)
+	strategy := router.StrategyFromContext(ctx)
+	registered, ok := s.strategies[strategy]
+	if !ok || registered.router == nil {
+		return policy.PreviewResult{}, fmt.Errorf("strategy %q requested but no router configured: %w", strategy, defaultStrategyUnavailable(strategy))
+	}
+	previewer, ok := registered.router.(policy.RoutePreviewer)
+	if !ok {
+		return policy.PreviewResult{}, fmt.Errorf("strategy %q has no route preview contract: %w", strategy, registered.unavailable)
+	}
+	return previewer.PreviewRoute(ctx, req)
+}

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -1664,38 +1664,11 @@ func (s *Service) Route(ctx context.Context, req router.Request) (router.Decisio
 // callers in internal/api/* never import internal/translate directly,
 // matching ProxyMessages.
 func (s *Service) RouteAnthropicRequest(ctx context.Context, body []byte) (decision router.Decision, err error) {
-	env, parseErr := translate.ParseAnthropic(body)
-	if parseErr != nil {
-		err = fmt.Errorf("parse request: %w", parseErr)
+	req, err := s.anthropicRoutingRequest(ctx, body, nil)
+	if err != nil {
 		return decision, err
 	}
-
-	embedFlag := s.ResolveEmbedOnlyUserMessage(ctx)
-	feats := env.RoutingFeatures(embedFlag)
-	promptText := feats.PromptText
-	if embedFlag && feats.OnlyUserMessageText != "" {
-		promptText = feats.OnlyUserMessageText
-	}
-	organizationID, _ := ctx.Value(ExternalIDContextKey{}).(string)
-	installationID := ""
-	if id := installationIDFromContext(ctx); id != uuid.Nil {
-		installationID = id.String()
-	}
-
-	decision, err = s.Route(ctx, router.Request{
-		RequestedModel:          feats.Model,
-		EstimatedInputTokens:    feats.Tokens,
-		HasTools:                feats.HasTools,
-		TranslationRequirements: env.TranslationRequirements(router.EndpointAnthropicMessages),
-		PromptText:              promptText,
-		ConversationMessages:    conversationMessagesForRouting(env),
-		AvailableTools:          availableToolsForRouting(env),
-		OrganizationID:          organizationID,
-		InstallationID:          installationID,
-		ClientSessionID:         env.ClientSessionID(),
-		RoutingKnobs:            router.RoutingKnobsFromContext(ctx),
-	})
-	return decision, err
+	return s.Route(ctx, req)
 }
 
 // PassthroughToProvider forwards a non-routing request to the default
@@ -1984,7 +1957,8 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 	externalID, _ := ctx.Value(ExternalIDContextKey{}).(string)
 	installationID := installationIDFromContext(ctx)
 	clientID := ClientIdentityFrom(ctx)
-	bypassEval := hasEvalOverrideHeader(r)
+	agentShadowEval, agentShadowMode := AgentShadowEvalFromContext(ctx)
+	bypassEval := hasEvalOverrideHeader(r) || agentShadowMode
 
 	// Bind session_key/request_id/api_key_id/ingress onto a ctx-scoped logger
 	// before stripping router-only history. The derived key is reused below to
@@ -2020,21 +1994,26 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 	// env.body so the upstream never sees it). Session key is derived before
 	// extraction: DeriveSessionKey can fall back to prompt text, and deriving
 	// after the strip would mismatch subsequent turns with the unstripped message.
-	if s.pinStore != nil {
+	if !agentShadowMode && s.pinStore != nil {
 		if cmd, hasCmd := env.ExtractForceModelCommand(); hasCmd {
 			log.Info("ProxyMessages force-model command", "force_model_cmd", cmd)
 			return s.handleForceModelCommand(ctx, w, env, cmd, installationID, sessionKey, feats.Tokens)
 		}
 	}
-	if cmd, hasCmd := env.ExtractRouterFeedbackCommand(); hasCmd {
-		log.Info("ProxyMessages router-feedback command")
-		return s.handleRouterFeedbackCommand(ctx, w, env, cmd, installationID, sessionKey, feats.Tokens)
+	if !agentShadowMode {
+		if cmd, hasCmd := env.ExtractRouterFeedbackCommand(); hasCmd {
+			log.Info("ProxyMessages router-feedback command")
+			return s.handleRouterFeedbackCommand(ctx, w, env, cmd, installationID, sessionKey, feats.Tokens)
+		}
 	}
 
 	// Honor the x-weave-force-model header (headless equivalent of /force-model).
 	// Writes the user-forced pin and falls through to normal routing, which picks
 	// the pin up and serves the requested model on this same turn.
-	forceModel := s.applyForceModelHeader(ctx, r, env, installationID, sessionKey)
+	forceModel := ""
+	if !agentShadowMode {
+		forceModel = s.applyForceModelHeader(ctx, r, env, installationID, sessionKey)
+	}
 
 	// Tool-call loop break: catches runaway OSS-model tool-call cycles (qwen3
 	// in particular) that the previous-turn-maxed-out guard misses because
@@ -2043,16 +2022,18 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 	// cheap/mid model escalates the session to opus instead, taking precedence
 	// over the tight-loop break below — rescuing beats stopping.
 	escalatedLoop := false
-	if cyc, csig, ccount, cratio, cwin := detectCyclicToolCallLoop(env); cyc {
-		loopRole := roleForTier(catalog.TierFor(feats.Model))
-		s.handleLoopEscalation(ctx, csig, ccount, cratio, cwin, installationID, sessionKey, loopRole, feats.Model)
-		escalatedLoop = true
-	}
-	if !escalatedLoop {
-		if loop, sig, count := detectToolCallLoop(env); loop {
+	if !agentShadowMode {
+		if cyc, csig, ccount, cratio, cwin := detectCyclicToolCallLoop(env); cyc {
 			loopRole := roleForTier(catalog.TierFor(feats.Model))
-			log.Info("ProxyMessages tool-call loop detected", "tool_sig", sig, "repeat_count", count, "role", loopRole)
-			return s.handleToolCallLoopBreak(ctx, w, env, sig, count, installationID, sessionKey, loopRole, feats.Model, providers.ProviderAnthropic, feats.Tokens)
+			s.handleLoopEscalation(ctx, csig, ccount, cratio, cwin, installationID, sessionKey, loopRole, feats.Model)
+			escalatedLoop = true
+		}
+		if !escalatedLoop {
+			if loop, sig, count := detectToolCallLoop(env); loop {
+				loopRole := roleForTier(catalog.TierFor(feats.Model))
+				log.Info("ProxyMessages tool-call loop detected", "tool_sig", sig, "repeat_count", count, "role", loopRole)
+				return s.handleToolCallLoopBreak(ctx, w, env, sig, count, installationID, sessionKey, loopRole, feats.Model, providers.ProviderAnthropic, feats.Tokens)
+			}
 		}
 	}
 
@@ -2098,21 +2079,25 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 	// session is compacted (à la Claude Code) instead of dead-ending in the
 	// scorer with no eligible provider. Mutates env; feats is recomputed after.
 	maxEligibleWindow := s.maxEligibleContextWindow(baseExcluded, env.SignatureTokenSavings())
-	compRes, compErr := s.maybeCompact(ctx, env, turntype.DetectFromEnvelope(env, feats, ""), outputReserve, maxEligibleWindow, r.Header)
-	if compErr != nil {
-		log.Warn("Compaction could not fit request to any eligible model",
-			"err", compErr, "final_estimate", compRes.FinalEstimate, "max_window", maxEligibleWindow, "requested_model", feats.Model)
-		return compErr
-	}
-	if compRes.Applied {
-		feats = env.RoutingFeatures(embedFlag)
-		log.Info("Proactive compaction applied",
-			"tool_results_cleared", compRes.ToolResultsCleared,
-			"summarized", compRes.Summarized,
-			"summary_model", compRes.SummaryModel,
-			"trimmed_to_recent", compRes.TrimmedToRecent,
-			"final_estimate", compRes.FinalEstimate,
-		)
+	var compRes compactionResult
+	if !agentShadowMode {
+		var compErr error
+		compRes, compErr = s.maybeCompact(ctx, env, turntype.DetectFromEnvelope(env, feats, ""), outputReserve, maxEligibleWindow, r.Header)
+		if compErr != nil {
+			log.Warn("Compaction could not fit request to any eligible model",
+				"err", compErr, "final_estimate", compRes.FinalEstimate, "max_window", maxEligibleWindow, "requested_model", feats.Model)
+			return compErr
+		}
+		if compRes.Applied {
+			feats = env.RoutingFeatures(embedFlag)
+			log.Info("Proactive compaction applied",
+				"tool_results_cleared", compRes.ToolResultsCleared,
+				"summarized", compRes.Summarized,
+				"summary_model", compRes.SummaryModel,
+				"trimmed_to_recent", compRes.TrimmedToRecent,
+				"final_estimate", compRes.FinalEstimate,
+			)
+		}
 	}
 
 	overflowEstimate := env.ContextOverflowTokenEstimate()
@@ -2157,7 +2142,13 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 	if installationID != uuid.Nil {
 		req.InstallationID = installationID.String()
 	}
-	routeRes, routeErr := s.runTurnLoop(ctx, env, feats, apiKeyID, installationID, "", r.Header, req)
+	var routeRes turnLoopResult
+	var routeErr error
+	if agentShadowMode {
+		routeRes, routeErr = s.runAgentShadowEvaluationRoute(ctx, env, feats, installationID, req, agentShadowEval)
+	} else {
+		routeRes, routeErr = s.runTurnLoop(ctx, env, feats, apiKeyID, installationID, "", r.Header, req)
+	}
 	if routeErr != nil {
 		log.Error("Routing failed", "err", routeErr, "route_ms", time.Since(routeStart).Milliseconds(), "requested_model", feats.Model, "total_input_tokens", feats.Tokens)
 		return routeErr
@@ -2168,7 +2159,9 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 	if routeRes.UsageBypass && routeRes.Decision.Provider == providers.ProviderAnthropic {
 		err := s.bypassToAnthropic(ctx, env, feats, routeRes.modelSwitched(), requestStart, requestID, externalID, routeRes.TurnType, r, w)
 		if !errors.Is(err, errBypassRetryable) {
-			s.firePolicyShadowForServingDecision(ctx, routeRes.Decision, req)
+			if !agentShadowMode {
+				s.firePolicyShadowForServingDecision(ctx, routeRes.Decision, req)
+			}
 			return err
 		}
 
@@ -2210,7 +2203,9 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 
 	routeRes.SuggestionMode = r.Header.Get("x-weave-suggestion-mode") == "true"
 	decision := routeRes.Decision
-	s.firePolicyShadowForServingDecision(ctx, decision, req)
+	if !agentShadowMode {
+		s.firePolicyShadowForServingDecision(ctx, decision, req)
+	}
 	tt := routeRes.TurnType
 	stickyHit := routeRes.StickyHit
 	pinTier := routeRes.PinTier
@@ -2223,7 +2218,7 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 	// Gated to tool-bearing turns so a frozen marker + frozen prompt prefix
 	// can't collide on healthy text-only turns.
 	toolBearingTurn := inboundToolCallCount > 0 || inboundLastUser.HasToolResult
-	if toolBearingTurn && s.noProgress != nil {
+	if !agentShadowMode && toolBearingTurn && s.noProgress != nil {
 		fp := computeNoProgressFingerprint(decision, promptText, feats.MessageCount, toolProgressMarker(env))
 		role := roleForTier(catalog.TierFor(feats.Model))
 		if looped, count := s.noProgress.recordAndDetect(routeRes.SessionKey, installationID, role, fp, time.Now()); looped {
@@ -2233,7 +2228,7 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 
 	// Text-repetition break: fresh tool calls each turn defeat the no-progress
 	// fingerprint; repeated narration is the durable tell. See text_repetition.go.
-	if s.textRepetitionBreakEnabled && (tt == turntype.MainLoop || tt == turntype.ToolResult) {
+	if !agentShadowMode && s.textRepetitionBreakEnabled && (tt == turntype.MainLoop || tt == turntype.ToolResult) {
 		if looped, count, sampleHash := detectTextRepetition(env); looped {
 			role := roleForTier(catalog.TierFor(feats.Model))
 			return s.handleTextRepetitionBreak(ctx, w, env, count, sampleHash, installationID, routeRes.SessionKey, role, decision.Model, decision.Provider, feats.Tokens)
@@ -2245,7 +2240,7 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 	// reason), so fire rates/precision can be measured before any escalation
 	// is armed. Main-loop / tool-result turns only — hard-pinned turn types
 	// carry history shapes that mimic the signals.
-	if s.spiralShadowEnabled && (tt == turntype.MainLoop || tt == turntype.ToolResult) {
+	if !agentShadowMode && s.spiralShadowEnabled && (tt == turntype.MainLoop || tt == turntype.ToolResult) {
 		if reasons := spiralReasons(inboundSpiralSignals); len(reasons) > 0 {
 			role := roleForTier(catalog.TierFor(feats.Model))
 			// Use the bindRequestLogger digest, not routeRes.SessionKey (zero
@@ -2269,7 +2264,7 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 	// client-trim detector as a false positive), so a compaction handover here
 	// would be a redundant summarizer call that also discards the recent-turn
 	// tail maybeCompact deliberately kept.
-	if decision.Provider != providers.ProviderAnthropic && !routeRes.HardPinned && !routeRes.Handover.Invoked && !compRes.Applied && routeRes.PrefixTrimmed {
+	if !agentShadowMode && decision.Provider != providers.ProviderAnthropic && !routeRes.HardPinned && !routeRes.Handover.Invoked && !compRes.Applied && routeRes.PrefixTrimmed {
 		log.Info("Context trimming detected on non-Anthropic route; rewriting context with handover summary",
 			"message_count", feats.MessageCount,
 			"tool_call_count", inboundToolCallCount,
@@ -2315,7 +2310,9 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 	w.Header().Set(HeaderRouterDecision, decision.Reason)
 	w.Header().Set(HeaderRouterProvider, decision.Provider)
 	w.Header().Set(HeaderRouterModel, decision.Model)
-	s.setFeedbackLinkHeader(w, installationID, externalID, requestID, auth.UserIDFrom(ctx))
+	if !agentShadowMode {
+		s.setFeedbackLinkHeader(w, installationID, externalID, requestID, auth.UserIDFrom(ctx))
+	}
 
 	if _, err := s.provider(decision.Provider); err != nil {
 		return err
@@ -2418,13 +2415,16 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 	// wrapped below the capture layer so the footer never lands in
 	// cached/logged bodies. Transparent when streaming/feedback is off.
 	clientSink := w
-	if env.Stream() {
+	if env.Stream() && !agentShadowMode {
 		if footer := s.feedbackFooter(ClientIdentityFrom(ctx).ClientApp, routeRes.TurnType); footer != "" {
 			clientSink = translate.NewAnthropicRoutingFooterWriter(w, footer)
 		}
 	}
 	contentSink, contentCap := s.maybeCaptureResponse(clientSink)
-	contentSink, policyOutcomeCap := s.capturePolicyOutcomeResponse(ctx, contentSink, routeRes, decision)
+	var policyOutcomeCap *captureWriter
+	if !agentShadowMode {
+		contentSink, policyOutcomeCap = s.capturePolicyOutcomeResponse(ctx, contentSink, routeRes, decision)
+	}
 	preludeBuf := newPreludeBuffer(contentSink)
 	var rootSink http.ResponseWriter = preludeBuf
 	var captureW *captureWriter
@@ -2901,19 +2901,30 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 		Attrs: upstreamBuilder.Build(),
 	})
 	respBody, respTrunc := capturedResponse(contentCap)
-	s.recordCallLog(ctx, upstreamBuilder.Build(), proxyErr != nil, body, respBody, respTrunc)
+	// Eval candidates are already captured by the content-addressed offline
+	// pipeline. Do not duplicate their request/response bodies into the
+	// production call-log stream, where they could be mistaken for serving
+	// traffic by a later training-data export.
+	if !agentShadowMode {
+		s.recordCallLog(ctx, upstreamBuilder.Build(), proxyErr != nil, body, respBody, respTrunc)
+	}
 	otel.Flush(ctx)
 
-	s.recordTurnUsage(routeRes, finalProvider, decision.Model, in, out, cacheCreation, cacheRead)
+	if !agentShadowMode {
+		s.recordTurnUsage(routeRes, finalProvider, decision.Model, in, out, cacheCreation, cacheRead)
+	}
 
-	if installationID != uuid.Nil {
+	// Evaluation requests must not create persistent serving telemetry. Besides
+	// contaminating customer metrics, those rows are an input to offline policy
+	// analysis and would turn forced candidates into apparent serving choices.
+	if !agentShadowMode && installationID != uuid.Nil {
 		credentialKeyPrefix, credentialKeySuffix, credSource := s.credentialKeyParts(ctx)
 		// Same-provider subscription->Weave retries keep finalProvider ==
 		// primaryProvider, so OR in subscriptionFailoverUsed to match the OTel
 		// span + completion log.
 		failoverUsed := finalProvider != primaryProvider || subscriptionFailoverUsed
 		degShadow := proxyErr == nil && isDegenerateResponse(out, respSummary.ToolUseBlocks, respSummary.StopReason, respSummary.StopReasonDemoted)
-		if degShadow {
+		if degShadow && !agentShadowMode {
 			log.Info("router.degenerate_shadow",
 				"model", decision.Model,
 				"provider", finalProvider,
@@ -3015,7 +3026,7 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 
 	// No-op when billing is unwired (selfhosted); only reached on a real
 	// upstream call since the cache-hit branch above already returned.
-	if proxyErr == nil {
+	if proxyErr == nil && !agentShadowMode {
 		s.emitBilling(ctx, requestID, externalID, decision, actPricing, routeRes, in, out, cacheCreation, cacheRead)
 		if compRes.Summarized {
 			s.billCompactionSummary(ctx, requestID, externalID, compRes.SummaryUsage)
@@ -3046,10 +3057,12 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 	// Two-strike eviction: a session pinned to a model returning non-retryable
 	// 4xx wedges until manually /force-model'd out. Expires the pin after a
 	// persistent counter hits threshold; successful turns reset it.
-	s.maybeEvictPinAfterUpstreamErr(ctx, stickyHit, proxyErr, decision.Reason, installationID, routeRes.SessionKey, stickyStateRole(routeRes))
+	if !agentShadowMode {
+		s.maybeEvictPinAfterUpstreamErr(ctx, stickyHit, proxyErr, decision.Reason, installationID, routeRes.SessionKey, stickyStateRole(routeRes))
 
-	// Re-pin the session off the refusing model if a cyber refusal was observed.
-	s.maybeRepinOnRefusal(ctx, refusalObs, routeRes.SessionKey, stickyStateRole(routeRes), decision)
+		// Re-pin the session off the refusing model if a cyber refusal was observed.
+		s.maybeRepinOnRefusal(ctx, refusalObs, routeRes.SessionKey, stickyStateRole(routeRes), decision)
+	}
 
 	// One event per tool_use block that failed toolcheck validation, including
 	// repaired ones — doubles as a per-model×provider tool-calling-quality signal.
@@ -3072,7 +3085,9 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 	if policyOutcomeCap != nil {
 		policyResp = &policyOutcomeResponse{Body: policyRespBody, Truncated: policyRespTrunc}
 	}
-	s.reportPolicyOutcome(ctx, routeRes, decision, finalProvider, feats.Tokens, in, out, cacheCreation, cacheRead, routeMs, proxyMs, proxyErr, policyResp)
+	if !agentShadowMode {
+		s.reportPolicyOutcome(ctx, routeRes, decision, finalProvider, feats.Tokens, in, out, cacheCreation, cacheRead, routeMs, proxyMs, proxyErr, policyResp)
+	}
 	return proxyErr
 }
 

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -2639,7 +2639,8 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 	baselineModel := s.baselineFor(feats.Model)
 	baselineCatalog, baselineKnown := catalog.ByID(baselineModel)
 	_, anthropicExcluded := s.excludedProvidersForRequest(ctx)[providers.ProviderAnthropic]
-	baselineEligible := decision.Reason != translate.ReasonUserForceModel &&
+	baselineEligible := !agentShadowMode &&
+		decision.Reason != translate.ReasonUserForceModel &&
 		s.shouldFailover(ctx) &&
 		!anthropicExcluded &&
 		decision.Provider != providers.ProviderAnthropic &&

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -2666,6 +2666,7 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 	// key at full cost, which is exactly the paid spend the overdraft floor
 	// forbids — a subscription throttle there surfaces raw instead.
 	subscriptionRetryEligible := decision.Provider == providers.ProviderAnthropic &&
+		!agentShadowMode &&
 		servedOnSubscription(ctx) &&
 		!billing.SubscriptionOnlyFromContext(ctx) &&
 		s.anthropicFallbackKeyAvailable(ctx)
@@ -2902,10 +2903,7 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 		Attrs: upstreamBuilder.Build(),
 	})
 	respBody, respTrunc := capturedResponse(contentCap)
-	// Eval candidates are already captured by the content-addressed offline
-	// pipeline. Do not duplicate their request/response bodies into the
-	// production call-log stream, where they could be mistaken for serving
-	// traffic by a later training-data export.
+	// Eval bodies are captured offline; exclude them from call-log so they are not mistaken for serving traffic.
 	if !agentShadowMode {
 		s.recordCallLog(ctx, upstreamBuilder.Build(), proxyErr != nil, body, respBody, respTrunc)
 	}
@@ -2915,9 +2913,7 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 		s.recordTurnUsage(routeRes, finalProvider, decision.Model, in, out, cacheCreation, cacheRead)
 	}
 
-	// Evaluation requests must not create persistent serving telemetry. Besides
-	// contaminating customer metrics, those rows are an input to offline policy
-	// analysis and would turn forced candidates into apparent serving choices.
+	// Eval rows must not enter serving telemetry; they would corrupt offline policy analysis.
 	if !agentShadowMode && installationID != uuid.Nil {
 		credentialKeyPrefix, credentialKeySuffix, credSource := s.credentialKeyParts(ctx)
 		// Same-provider subscription->Weave retries keep finalProvider ==

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -1663,8 +1663,8 @@ func (s *Service) Route(ctx context.Context, req router.Request) (router.Decisio
 // Owns translate.ParseAnthropic + RoutingFeatures extraction internally so
 // callers in internal/api/* never import internal/translate directly,
 // matching ProxyMessages.
-func (s *Service) RouteAnthropicRequest(ctx context.Context, body []byte) (decision router.Decision, err error) {
-	req, err := s.anthropicRoutingRequest(ctx, body, nil)
+func (s *Service) RouteAnthropicRequest(ctx context.Context, body []byte, headers http.Header) (decision router.Decision, err error) {
+	req, err := s.anthropicRoutingRequest(ctx, body, headers)
 	if err != nil {
 		return decision, err
 	}

--- a/internal/proxy/service_test.go
+++ b/internal/proxy/service_test.go
@@ -177,6 +177,38 @@ func TestService_AgentShadowEvaluationForcesEphemerallyWithoutServingRouter(t *t
 	assert.Zero(t, pins.resetCalls)
 }
 
+func TestService_AgentShadowEvaluationNeverSubstitutesRequestedBaseline(t *testing.T) {
+	openAIProvider := &fakeProvider{proxyErr: &providers.UpstreamStatusError{Status: http.StatusServiceUnavailable}}
+	anthropicProvider := &fakeProvider{proxyResponse: func(w http.ResponseWriter) {
+		w.WriteHeader(http.StatusOK)
+	}}
+	svc := proxy.NewService(&fakeRouter{}, map[string]providers.Client{
+		providers.ProviderAnthropic: anthropicProvider,
+		providers.ProviderOpenAI:    openAIProvider,
+	}, nil, false, nil, nil, false, providers.ProviderAnthropic, "claude-haiku-4-5", nil).
+		WithDeploymentKeyedProviders(map[string]struct{}{
+			providers.ProviderAnthropic: {},
+			providers.ProviderOpenAI:    {},
+		}).
+		WithAvailableModels(map[string]struct{}{
+			"claude-opus-4-8": {},
+			"gpt-5.5":         {},
+		})
+
+	ctx := context.WithValue(context.Background(), proxy.AgentShadowEvalContextKey{}, proxy.AgentShadowEvaluation{
+		Model: "gpt-5.5", RolloutID: "pilot-1", StateID: "state-1",
+	})
+	body := []byte(`{"model":"claude-opus-4-8","messages":[{"role":"user","content":"inspect this repository"}],"max_tokens":512}`)
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/messages", nil)
+
+	_ = svc.ProxyMessages(ctx, body, rec, req)
+
+	assert.NotEmpty(t, openAIProvider.proxyBodies, "the planned candidate must be attempted")
+	assert.Empty(t, anthropicProvider.proxyBodies, "eval forcing must never dispatch the request baseline")
+	assert.Equal(t, "gpt-5.5", rec.Header().Get(proxy.HeaderRouterModel))
+}
+
 func TestService_ProxyOpenAIResponses_CustomToolUsesNativeOpenAIFamily(t *testing.T) {
 	provider := &fakeProvider{proxyResponse: func(w http.ResponseWriter) {
 		w.Header().Set("Content-Type", "application/json")

--- a/internal/proxy/service_test.go
+++ b/internal/proxy/service_test.go
@@ -144,13 +144,24 @@ func TestService_AgentShadowEvaluationForcesEphemerallyWithoutServingRouter(t *t
 	messages := make([]map[string]any, 0, 17)
 	for i := range 8 {
 		toolID := fmt.Sprintf("tool_%d", i)
+		assistantContent := []map[string]any{
+			{"type": "tool_use", "id": toolID, "name": "Read", "input": map[string]any{"file_path": "README.md"}},
+		}
+		if i == 0 {
+			assistantContent = append([]map[string]any{
+				{"type": "thinking", "thinking": "historical thought", "signature": "stale-signature"},
+			}, assistantContent...)
+		}
 		messages = append(messages,
-			map[string]any{"role": "assistant", "content": []map[string]any{{"type": "tool_use", "id": toolID, "name": "Read", "input": map[string]any{"file_path": "README.md"}}}},
+			map[string]any{"role": "assistant", "content": assistantContent},
 			map[string]any{"role": "user", "content": []map[string]any{{"type": "tool_result", "tool_use_id": toolID, "content": fmt.Sprintf("old-result-%d", i)}}},
 		)
 	}
 	messages = append(messages, map[string]any{"role": "user", "content": "make the next edit"})
-	body, err := json.Marshal(map[string]any{"model": "claude-haiku-4-5", "messages": messages, "max_tokens": 512})
+	body, err := json.Marshal(map[string]any{
+		"model": "claude-haiku-4-5", "messages": messages, "max_tokens": 512,
+		"thinking": map[string]any{"type": "adaptive"},
+	})
 	require.NoError(t, err)
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodPost, "/v1/messages", nil)
@@ -160,6 +171,7 @@ func TestService_AgentShadowEvaluationForcesEphemerallyWithoutServingRouter(t *t
 	require.Len(t, provider.proxyBodies, 1)
 	assert.Contains(t, string(provider.proxyBodies[0]), `"model":"claude-opus-4-8"`)
 	assert.Contains(t, string(provider.proxyBodies[0]), "old-result-0")
+	assert.NotContains(t, string(provider.proxyBodies[0]), "stale-signature")
 	assert.Equal(t, "claude-opus-4-8", rec.Header().Get(proxy.HeaderRouterModel))
 	assert.Equal(t, providers.ProviderAnthropic, rec.Header().Get(proxy.HeaderRouterProvider))
 	assert.Equal(t, proxy.ReasonAgentShadowEval, rec.Header().Get(proxy.HeaderRouterDecision))
@@ -207,6 +219,30 @@ func TestService_AgentShadowEvaluationNeverSubstitutesRequestedBaseline(t *testi
 	assert.NotEmpty(t, openAIProvider.proxyBodies, "the planned candidate must be attempted")
 	assert.Empty(t, anthropicProvider.proxyBodies, "eval forcing must never dispatch the request baseline")
 	assert.Equal(t, "gpt-5.5", rec.Header().Get(proxy.HeaderRouterModel))
+}
+
+func TestService_AgentShadowEvaluationNeverRetriesSubscriptionOnDeploymentKey(t *testing.T) {
+	provider := &fakeProvider{proxyErr: &providers.UpstreamStatusError{Status: http.StatusTooManyRequests}}
+	svc := proxy.NewService(&fakeRouter{}, map[string]providers.Client{
+		providers.ProviderAnthropic: provider,
+	}, nil, false, nil, nil, false, providers.ProviderAnthropic, "claude-opus-4-8", nil).
+		WithDeploymentKeyedProviders(map[string]struct{}{providers.ProviderAnthropic: {}}).
+		WithAvailableModels(map[string]struct{}{"claude-opus-4-8": {}})
+
+	ctx := context.WithValue(context.Background(), proxy.AgentShadowEvalContextKey{}, proxy.AgentShadowEvaluation{
+		Model: "claude-opus-4-8", RolloutID: "pilot-1", StateID: "state-1",
+	})
+	ctx = context.WithValue(ctx, proxy.InstallationIDContextKey{}, "1791da5d-d0db-494c-8574-859a4cb20d97")
+	ctx = context.WithValue(ctx, proxy.AnthropicSubscriptionContextKey{}, "sk-ant-oat01-subscription-token")
+	body := []byte(`{"model":"claude-opus-4-8","messages":[{"role":"user","content":"inspect this repository"}],"max_tokens":512}`)
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/messages", nil)
+
+	_ = svc.ProxyMessages(ctx, body, rec, req)
+
+	require.Len(t, provider.proxyBodies, 1, "eval traffic must not retry on the paid deployment key")
+	require.NotNil(t, provider.proxyCreds[0])
+	assert.True(t, provider.proxyCreds[0].OAuth, "the single attempt must use the supplied subscription")
 }
 
 func TestService_ProxyOpenAIResponses_CustomToolUsesNativeOpenAIFamily(t *testing.T) {

--- a/internal/proxy/service_test.go
+++ b/internal/proxy/service_test.go
@@ -138,7 +138,7 @@ func TestService_AgentShadowEvaluationForcesEphemerallyWithoutServingRouter(t *t
 		WithCompaction(nil, 0.0001)
 
 	ctx := context.WithValue(context.Background(), proxy.AgentShadowEvalContextKey{}, proxy.AgentShadowEvaluation{
-		Model: "claude-opus-4-8", RolloutID: "pilot-1", StateID: "state-1",
+		Model: "CLAUDE-OPUS-4-8", RolloutID: "pilot-1", StateID: "state-1",
 	})
 	ctx = context.WithValue(ctx, proxy.InstallationIDContextKey{}, "1791da5d-d0db-494c-8574-859a4cb20d97")
 	messages := make([]map[string]any, 0, 17)

--- a/internal/proxy/service_test.go
+++ b/internal/proxy/service_test.go
@@ -4,15 +4,19 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"workweave/router/internal/providers"
 	"workweave/router/internal/proxy"
 	"workweave/router/internal/router"
+	"workweave/router/internal/router/policy"
+	"workweave/router/internal/router/sessionpin"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -23,6 +27,24 @@ type fakeRouter struct {
 	err         error
 	capturedReq *router.Request
 	routeCalls  int
+}
+
+type fakePreviewRouter struct {
+	previewResult policy.PreviewResult
+	previewReq    *router.Request
+	previewCalls  int
+	routeCalls    int
+}
+
+func (f *fakePreviewRouter) Route(context.Context, router.Request) (router.Decision, error) {
+	f.routeCalls++
+	return router.Decision{}, errors.New("serving route must not run during preview")
+}
+
+func (f *fakePreviewRouter) PreviewRoute(_ context.Context, req router.Request) (policy.PreviewResult, error) {
+	f.previewCalls++
+	f.previewReq = &req
+	return f.previewResult, nil
 }
 
 func (f *fakeRouter) Route(ctx context.Context, req router.Request) (router.Decision, error) {
@@ -51,6 +73,108 @@ func (f *fakeProvider) Proxy(ctx context.Context, decision router.Decision, prep
 		f.proxyResponse(w)
 	}
 	return f.proxyErr
+}
+
+func TestService_PreviewAnthropicRouteBuildsServingCandidateContextWithoutDispatch(t *testing.T) {
+	anthropicProvider := &fakeProvider{}
+	openAIProvider := &fakeProvider{}
+	previewer := &fakePreviewRouter{previewResult: policy.PreviewResult{
+		SchemaVersion:     policy.SchemaVersionV1,
+		EligibleRosterIDs: []string{"anthropic/claude-opus-4-8", "openai/gpt-5.5"},
+	}}
+	svc := proxy.NewService(&fakeRouter{}, map[string]providers.Client{
+		providers.ProviderAnthropic: anthropicProvider,
+		providers.ProviderOpenAI:    openAIProvider,
+	}, nil, false, nil, nil, false, providers.ProviderAnthropic, "claude-haiku-4-5", nil).
+		WithPolicyStrategy(policy.StrategySpec{Strategy: router.StrategyHMM, Router: previewer}).
+		WithDeploymentKeyedProviders(map[string]struct{}{
+			providers.ProviderAnthropic: {},
+			providers.ProviderOpenAI:    {},
+		})
+
+	ctx := router.WithStrategy(context.Background(), router.StrategyHMM)
+	ctx = context.WithValue(ctx, proxy.ExternalIDContextKey{}, "org-1")
+	ctx = context.WithValue(ctx, proxy.InstallationIDContextKey{}, "1791da5d-d0db-494c-8574-859a4cb20d97")
+	ctx = context.WithValue(ctx, proxy.InstallationExcludedModelsContextKey{}, []string{"gpt-5.5-mini"})
+	ctx = context.WithValue(ctx, proxy.InstallationPreferredModelsContextKey{}, []string{"claude-opus-4-8"})
+	body := []byte(`{"model":"claude-opus-4-8[1m]","messages":[{"role":"user","content":"inspect this repository"}],"max_tokens":4096,"tools":[{"name":"Read","description":"read a file","input_schema":{"type":"object"}}]}`)
+
+	result, err := svc.PreviewAnthropicRoute(ctx, body, http.Header{})
+
+	require.NoError(t, err)
+	assert.Equal(t, previewer.previewResult, result)
+	assert.Equal(t, 1, previewer.previewCalls)
+	assert.Zero(t, previewer.routeCalls)
+	require.NotNil(t, previewer.previewReq)
+	assert.Equal(t, "claude-opus-4-8", previewer.previewReq.RequestedModel)
+	assert.Equal(t, "org-1", previewer.previewReq.OrganizationID)
+	assert.Equal(t, "1791da5d-d0db-494c-8574-859a4cb20d97", previewer.previewReq.InstallationID)
+	assert.True(t, previewer.previewReq.HasTools)
+	assert.Equal(t, []string{"Read"}, previewer.previewReq.AvailableTools)
+	assert.Contains(t, previewer.previewReq.EnabledProviders, providers.ProviderAnthropic)
+	assert.Contains(t, previewer.previewReq.EnabledProviders, providers.ProviderOpenAI)
+	assert.Contains(t, previewer.previewReq.ExcludedModels, "gpt-5.5-mini")
+	assert.Equal(t, []string{"claude-opus-4-8"}, previewer.previewReq.PreferredModels)
+	assert.False(t, previewer.previewReq.TrainingAllowed)
+	assert.Empty(t, anthropicProvider.proxyBodies)
+	assert.Empty(t, openAIProvider.proxyBodies)
+}
+
+func TestService_AgentShadowEvaluationForcesEphemerallyWithoutServingRouter(t *testing.T) {
+	telemetry := newCaptureTelemetry()
+	pins := newFakePinStore()
+	pins.hasPin = true
+	pins.pin = sessionpin.Pin{Provider: providers.ProviderAnthropic, Model: "claude-haiku-4-5"}
+	provider := &fakeProvider{proxyResponse: func(w http.ResponseWriter) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"id":"msg_eval","type":"message","role":"assistant","model":"claude-opus-4-8","content":[{"type":"text","text":"done"}],"stop_reason":"end_turn","usage":{"input_tokens":12,"output_tokens":3}}`)
+	}}
+	servingRouter := &fakeRouter{err: errors.New("serving router must not run")}
+	svc := proxy.NewService(servingRouter, map[string]providers.Client{
+		providers.ProviderAnthropic: provider,
+	}, nil, false, nil, pins, false, providers.ProviderAnthropic, "claude-haiku-4-5", telemetry).
+		WithDeploymentKeyedProviders(map[string]struct{}{providers.ProviderAnthropic: {}}).
+		WithAvailableModels(map[string]struct{}{"claude-opus-4-8": {}}).
+		WithCompaction(nil, 0.0001)
+
+	ctx := context.WithValue(context.Background(), proxy.AgentShadowEvalContextKey{}, proxy.AgentShadowEvaluation{
+		Model: "claude-opus-4-8", RolloutID: "pilot-1", StateID: "state-1",
+	})
+	ctx = context.WithValue(ctx, proxy.InstallationIDContextKey{}, "1791da5d-d0db-494c-8574-859a4cb20d97")
+	messages := make([]map[string]any, 0, 17)
+	for i := range 8 {
+		toolID := fmt.Sprintf("tool_%d", i)
+		messages = append(messages,
+			map[string]any{"role": "assistant", "content": []map[string]any{{"type": "tool_use", "id": toolID, "name": "Read", "input": map[string]any{"file_path": "README.md"}}}},
+			map[string]any{"role": "user", "content": []map[string]any{{"type": "tool_result", "tool_use_id": toolID, "content": fmt.Sprintf("old-result-%d", i)}}},
+		)
+	}
+	messages = append(messages, map[string]any{"role": "user", "content": "make the next edit"})
+	body, err := json.Marshal(map[string]any{"model": "claude-haiku-4-5", "messages": messages, "max_tokens": 512})
+	require.NoError(t, err)
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/messages", nil)
+
+	require.NoError(t, svc.ProxyMessages(ctx, body, rec, req))
+	assert.Zero(t, servingRouter.routeCalls)
+	require.Len(t, provider.proxyBodies, 1)
+	assert.Contains(t, string(provider.proxyBodies[0]), `"model":"claude-opus-4-8"`)
+	assert.Contains(t, string(provider.proxyBodies[0]), "old-result-0")
+	assert.Equal(t, "claude-opus-4-8", rec.Header().Get(proxy.HeaderRouterModel))
+	assert.Equal(t, providers.ProviderAnthropic, rec.Header().Get(proxy.HeaderRouterProvider))
+	assert.Equal(t, proxy.ReasonAgentShadowEval, rec.Header().Get(proxy.HeaderRouterDecision))
+	assert.Never(t, func() bool {
+		telemetry.mu.Lock()
+		defer telemetry.mu.Unlock()
+		return len(telemetry.rows) != 0 || len(telemetry.shadowRows) != 0
+	}, 100*time.Millisecond, 5*time.Millisecond, "eval traffic must not create serving or policy telemetry")
+	pins.mu.Lock()
+	defer pins.mu.Unlock()
+	assert.Zero(t, pins.getCalls, "eval traffic must not read production session pins")
+	assert.Empty(t, pins.upserts, "eval traffic must not write production session pins")
+	assert.Empty(t, pins.usages, "eval traffic must not update production session usage")
+	assert.Zero(t, pins.incrementCalls)
+	assert.Zero(t, pins.resetCalls)
 }
 
 func TestService_ProxyOpenAIResponses_CustomToolUsesNativeOpenAIFamily(t *testing.T) {

--- a/internal/proxy/turnloop.go
+++ b/internal/proxy/turnloop.go
@@ -89,6 +89,8 @@ type turnLoopResult struct {
 	// the client transcript on every later turn, so the emit path ORs this
 	// in to keep stripping them for the life of the session.
 	SessionEverSwitched bool
+	// StripThinkingBlocks forces signature removal when switch history is unavailable.
+	StripThinkingBlocks bool
 	// Handover captures the summarize-or-trim step when the planner switched.
 	Handover handoverOutcome
 	// SuggestionMode suppresses the routing-marker badge for requests carrying
@@ -114,7 +116,7 @@ type turnLoopResult struct {
 // otherwise 400 with "Invalid signature in thinking block" on every later turn.
 func (r turnLoopResult) modelSwitched() bool {
 	transition := r.PriorServedModel != "" && r.PriorServedModel != r.Decision.Model
-	return transition || r.SessionEverSwitched
+	return transition || r.SessionEverSwitched || r.StripThinkingBlocks
 }
 
 func isHMMDecision(dec router.Decision) bool {

--- a/internal/router/policy/contract.go
+++ b/internal/router/policy/contract.go
@@ -12,6 +12,7 @@ const SchemaVersionV1 = "policy_router_v1"
 const (
 	ExecutionModeServing = "serving"
 	ExecutionModeShadow  = "shadow"
+	ExecutionModePreview = "preview"
 )
 
 // Capabilities declares which optional harness behaviors a policy supports.
@@ -94,9 +95,49 @@ type Result struct {
 	Debug                map[string]interface{}
 }
 
+// PreviewGroup records one classifier group in serving fallback order.
+type PreviewGroup struct {
+	Group        string   `json:"group"`
+	Probability  float64  `json:"probability"`
+	RosterArms   []string `json:"roster_arms"`
+	EligibleArms []string `json:"eligible_arms"`
+}
+
+// PreviewResult is a side-effect-free policy evaluation with every arm in the
+// first nonempty ranked group, plus authoritative router resolution details.
+type PreviewResult struct {
+	SchemaVersion         string             `json:"schema_version"`
+	RouteID               string             `json:"route_id"`
+	Strategy              router.Strategy    `json:"strategy"`
+	PolicyArtifactID      string             `json:"policy_artifact_id"`
+	PolicyArtifactSHA256  string             `json:"policy_artifact_sha256"`
+	RosterSHA256          string             `json:"roster_sha256"`
+	HMMStateID            int                `json:"hmm_state_id"`
+	HMMStatePath          []int              `json:"hmm_state_path"`
+	HMMStateProbabilities []float64          `json:"hmm_state_probabilities"`
+	ClassOrder            []string           `json:"class_order"`
+	ClassProbabilities    map[string]float64 `json:"class_probabilities"`
+	RankedFallback        []PreviewGroup     `json:"ranked_fallback"`
+	SelectedGroup         string             `json:"selected_group,omitempty"`
+	EligibleRosterIDs     []string           `json:"eligible_roster_ids"`
+	ResolverCandidates    []Candidate        `json:"resolver_candidates"`
+	ResolverExclusions    []Diagnostic       `json:"resolver_exclusions"`
+}
+
 // Decider asks a policy sidecar to choose one supplied candidate.
 type Decider interface {
 	Decide(ctx context.Context, query Query) (Result, error)
+}
+
+// PreviewDecider asks a policy sidecar for a decision trace without serving.
+type PreviewDecider interface {
+	Preview(ctx context.Context, query Query) (PreviewResult, error)
+}
+
+// RoutePreviewer evaluates a fully formed router request without dispatch or
+// serving lifecycle side effects.
+type RoutePreviewer interface {
+	PreviewRoute(ctx context.Context, req router.Request) (PreviewResult, error)
 }
 
 // OutcomeReporter sends final dispatch outcomes to a policy sidecar.

--- a/internal/router/policy/resolver.go
+++ b/internal/router/policy/resolver.go
@@ -57,9 +57,9 @@ const (
 // Diagnostic describes one candidate exclusion for conformance checks and
 // debug-mode inspection. It contains no request content.
 type Diagnostic struct {
-	CatalogID string
-	RosterID  string
-	Reason    ExclusionReason
+	CatalogID string          `json:"catalog_id"`
+	RosterID  string          `json:"roster_id,omitempty"`
+	Reason    ExclusionReason `json:"reason"`
 }
 
 // Candidate is one catalog-backed model offered to a policy sidecar.

--- a/internal/router/policy/sidecar_router.go
+++ b/internal/router/policy/sidecar_router.go
@@ -3,6 +3,8 @@ package policy
 import (
 	"context"
 	"fmt"
+	"math"
+	"slices"
 	"sync"
 
 	"github.com/google/uuid"
@@ -87,6 +89,166 @@ func (r *SidecarRouter) ReportFeedback(ctx context.Context, payload map[string]i
 		return nil
 	}
 	return r.feedbackReporter.ReportFeedback(ctx, payload)
+}
+
+// PreviewRoute resolves candidates and returns all arms chosen by the sidecar's
+// first nonempty ranked group without dispatching or lifecycle callbacks.
+func (r *SidecarRouter) PreviewRoute(ctx context.Context, req router.Request) (PreviewResult, error) {
+	strategy := r.config.Strategy
+	r.capabilitiesMu.RLock()
+	previewUnsupported := r.capabilitiesSet && !r.capabilities.SupportsPreview
+	r.capabilitiesMu.RUnlock()
+	if previewUnsupported {
+		return PreviewResult{}, fmt.Errorf("%s: sidecar does not support preview: %w", strategy, r.config.Unavailable)
+	}
+	previewer, ok := r.decider.(PreviewDecider)
+	if !ok {
+		return PreviewResult{}, fmt.Errorf("%s: sidecar client has no preview contract: %w", strategy, r.config.Unavailable)
+	}
+
+	resolved := r.resolver.Resolve(req)
+	requestRouteID := uuid.NewString()
+	result, err := previewer.Preview(ctx, Query{
+		Strategy:             strategy,
+		ExecutionMode:        ExecutionModePreview,
+		RouteID:              requestRouteID,
+		OrganizationID:       req.OrganizationID,
+		InstallationID:       req.InstallationID,
+		ClientApp:            req.ClientApp,
+		RolloutID:            req.RolloutID,
+		RequestedModel:       req.RequestedModel,
+		PromptText:           req.PromptText,
+		ConversationMessages: req.ConversationMessages,
+		AvailableTools:       req.AvailableTools,
+		FeedbackKey:          req.FeedbackKey,
+		FeedbackRole:         req.FeedbackRole,
+		ClientSessionID:      req.ClientSessionID,
+		EstimatedInputTokens: req.EstimatedInputTokens,
+		HasTools:             req.HasTools,
+		HasImages:            req.HasImages,
+		RoutingIntent:        req.RoutingIntent,
+		PreferredModels:      req.PreferredModels,
+		RoutingKnobs:         req.RoutingKnobs,
+		TrainingAllowed:      false,
+		CaptureMode:          req.CaptureMode,
+		DebugEnabled:         true,
+		Candidates:           resolved.Candidates,
+	})
+	if err != nil {
+		return PreviewResult{}, fmt.Errorf("%s: sidecar preview: %w: %w", strategy, err, r.config.Unavailable)
+	}
+	if result.RouteID != "" && result.RouteID != requestRouteID {
+		return PreviewResult{}, fmt.Errorf("%s: preview route id mismatch: %w", strategy, r.config.Unavailable)
+	}
+	if err := validatePreviewResult(result); err != nil {
+		return PreviewResult{}, fmt.Errorf("%s: invalid preview result: %v: %w", strategy, err, r.config.Unavailable)
+	}
+
+	seen := make(map[string]struct{}, len(result.EligibleRosterIDs))
+	for _, rosterID := range result.EligibleRosterIDs {
+		if _, duplicate := seen[rosterID]; duplicate {
+			return PreviewResult{}, fmt.Errorf("%s: preview returned duplicate roster id %q: %w", strategy, rosterID, r.config.Unavailable)
+		}
+		seen[rosterID] = struct{}{}
+		if _, offered := resolved.ByRosterID[rosterID]; !offered {
+			return PreviewResult{}, fmt.Errorf("%s: preview returned unknown roster id %q: %w", strategy, rosterID, r.config.Unavailable)
+		}
+	}
+	if (len(result.EligibleRosterIDs) > 0) != (result.SelectedGroup != "") {
+		return PreviewResult{}, fmt.Errorf("%s: preview selected group/arms mismatch: %w", strategy, r.config.Unavailable)
+	}
+
+	result.RouteID = requestRouteID
+	result.Strategy = strategy
+	result.ResolverCandidates = resolved.Candidates
+	result.ResolverExclusions = resolved.Diagnostics
+	return result, nil
+}
+
+func validatePreviewResult(result PreviewResult) error {
+	if result.SchemaVersion != SchemaVersionV1 {
+		return fmt.Errorf("unsupported schema %q", result.SchemaVersion)
+	}
+	if result.PolicyArtifactID == "" || result.PolicyArtifactSHA256 == "" || result.RosterSHA256 == "" {
+		return fmt.Errorf("missing frozen artifact identity")
+	}
+	if len(result.HMMStatePath) == 0 || len(result.HMMStateProbabilities) == 0 || len(result.ClassOrder) == 0 {
+		return fmt.Errorf("missing state or class order")
+	}
+	if result.HMMStateID < 0 || result.HMMStateID >= len(result.HMMStateProbabilities) {
+		return fmt.Errorf("HMM state id is outside the posterior vector")
+	}
+	hmmTotal := 0.0
+	for index, probability := range result.HMMStateProbabilities {
+		if math.IsNaN(probability) || probability < 0 || probability > 1 {
+			return fmt.Errorf("invalid HMM state probability at index %d", index)
+		}
+		hmmTotal += probability
+	}
+	if math.Abs(hmmTotal-1) > 1e-6 {
+		return fmt.Errorf("HMM state probabilities sum to %.9f", hmmTotal)
+	}
+	for index, stateID := range result.HMMStatePath {
+		if stateID < 0 || stateID >= len(result.HMMStateProbabilities) {
+			return fmt.Errorf("HMM state path value at index %d is outside the posterior vector", index)
+		}
+	}
+	if len(result.ClassProbabilities) != len(result.ClassOrder) || len(result.RankedFallback) != len(result.ClassOrder) {
+		return fmt.Errorf("class probability/fallback cardinality mismatch")
+	}
+	seenClasses := make(map[string]struct{}, len(result.ClassOrder))
+	total := 0.0
+	for index, className := range result.ClassOrder {
+		if className == "" {
+			return fmt.Errorf("empty class at index %d", index)
+		}
+		if _, duplicate := seenClasses[className]; duplicate {
+			return fmt.Errorf("duplicate class %q", className)
+		}
+		seenClasses[className] = struct{}{}
+		probability, ok := result.ClassProbabilities[className]
+		if !ok || math.IsNaN(probability) || probability < 0 || probability > 1 {
+			return fmt.Errorf("invalid probability for class %q", className)
+		}
+		total += probability
+	}
+	if math.Abs(total-1) > 1e-6 {
+		return fmt.Errorf("class probabilities sum to %.9f", total)
+	}
+	classRank := make(map[string]int, len(result.ClassOrder))
+	for index, className := range result.ClassOrder {
+		classRank[className] = index
+	}
+	seenFallback := make(map[string]struct{}, len(result.RankedFallback))
+	for index, fallback := range result.RankedFallback {
+		probability, ok := result.ClassProbabilities[fallback.Group]
+		if !ok || math.Abs(fallback.Probability-probability) > 1e-9 {
+			return fmt.Errorf("fallback probability mismatch for class %q", fallback.Group)
+		}
+		if _, duplicate := seenFallback[fallback.Group]; duplicate {
+			return fmt.Errorf("duplicate fallback class %q", fallback.Group)
+		}
+		seenFallback[fallback.Group] = struct{}{}
+		if index > 0 {
+			previous := result.RankedFallback[index-1]
+			if previous.Probability < fallback.Probability ||
+				(previous.Probability == fallback.Probability && classRank[previous.Group] > classRank[fallback.Group]) {
+				return fmt.Errorf("fallback groups are not deterministically ranked")
+			}
+		}
+	}
+
+	var selectedArms []string
+	for _, fallback := range result.RankedFallback {
+		if fallback.Group == result.SelectedGroup {
+			selectedArms = fallback.EligibleArms
+			break
+		}
+	}
+	if !slices.Equal(selectedArms, result.EligibleRosterIDs) {
+		return fmt.Errorf("selected fallback arms do not match eligible roster ids")
+	}
+	return nil
 }
 
 func (r *SidecarRouter) Route(ctx context.Context, req router.Request) (router.Decision, error) {
@@ -197,6 +359,8 @@ func (r *SidecarRouter) Route(ctx context.Context, req router.Request) (router.D
 		},
 	}, nil
 }
+
+var _ RoutePreviewer = (*SidecarRouter)(nil)
 
 var _ router.Router = (*SidecarRouter)(nil)
 var _ OutcomeReporter = (*SidecarRouter)(nil)

--- a/internal/router/policy/sidecar_router_test.go
+++ b/internal/router/policy/sidecar_router_test.go
@@ -16,15 +16,22 @@ import (
 )
 
 type recordingPolicy struct {
-	query    policy.Query
-	result   policy.Result
-	outcome  map[string]interface{}
-	feedback map[string]interface{}
+	query        policy.Query
+	previewQuery policy.Query
+	result       policy.Result
+	preview      policy.PreviewResult
+	outcome      map[string]interface{}
+	feedback     map[string]interface{}
 }
 
 func (p *recordingPolicy) Decide(_ context.Context, query policy.Query) (policy.Result, error) {
 	p.query = query
 	return p.result, nil
+}
+
+func (p *recordingPolicy) Preview(_ context.Context, query policy.Query) (policy.PreviewResult, error) {
+	p.previewQuery = query
+	return p.preview, nil
 }
 
 func (p *recordingPolicy) ReportOutcome(_ context.Context, payload map[string]interface{}) error {
@@ -118,6 +125,132 @@ func TestSidecarRouterMarksShadowDecisionsNonLearning(t *testing.T) {
 	assert.Equal(t, policy.ExecutionModeShadow, decider.query.ExecutionMode)
 	assert.False(t, decider.query.TrainingAllowed)
 	assert.False(t, decider.query.DebugEnabled)
+}
+
+func TestSidecarRouterPreviewReturnsAllEligibleArmsWithoutLifecycleCallbacks(t *testing.T) {
+	decider := &recordingPolicy{preview: policy.PreviewResult{
+		SchemaVersion:         policy.SchemaVersionV1,
+		PolicyArtifactID:      "hmm-prod",
+		PolicyArtifactSHA256:  "sha256:artifact",
+		RosterSHA256:          "sha256:roster",
+		HMMStateID:            7,
+		HMMStatePath:          []int{2, 7},
+		HMMStateProbabilities: []float64{0.01, 0.01, 0.05, 0.01, 0.01, 0.01, 0.1, 0.8},
+		ClassOrder:            []string{"hard", "balanced"},
+		ClassProbabilities:    map[string]float64{"hard": 0.8, "balanced": 0.2},
+		RankedFallback: []policy.PreviewGroup{{
+			Group:        "hard",
+			Probability:  0.8,
+			RosterArms:   []string{"claude-opus-4-8", "gpt-5.5"},
+			EligibleArms: []string{"claude-opus-4-8", "gpt-5.5"},
+		}, {
+			Group:       "balanced",
+			Probability: 0.2,
+		}},
+		SelectedGroup:     "hard",
+		EligibleRosterIDs: []string{"claude-opus-4-8", "gpt-5.5"},
+	}}
+	adapter := policy.NewSidecarRouter(policy.SidecarRouterConfig{
+		Strategy: router.StrategyHMM,
+	}, decider, policy.NewResolver(
+		set("claude-opus-4-8", "gpt-5.5"),
+		set(providers.ProviderAnthropic, providers.ProviderOpenAI),
+		catalogRosterID,
+		policy.ManagedProviderPolicy(),
+	)).WithCapabilities(policy.Capabilities{SupportsPreview: true})
+
+	result, err := adapter.PreviewRoute(context.Background(), router.Request{
+		OrganizationID:  "org-1",
+		InstallationID:  "installation-1",
+		TrainingAllowed: true,
+		DebugEnabled:    false,
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{"claude-opus-4-8", "gpt-5.5"}, result.EligibleRosterIDs)
+	assert.Equal(t, router.StrategyHMM, result.Strategy)
+	assert.NotEmpty(t, result.RouteID)
+	assert.Equal(t, policy.ExecutionModePreview, decider.previewQuery.ExecutionMode)
+	assert.False(t, decider.previewQuery.TrainingAllowed)
+	assert.True(t, decider.previewQuery.DebugEnabled)
+	assert.Len(t, decider.previewQuery.Candidates, 2)
+	assert.Nil(t, decider.outcome)
+	assert.Nil(t, decider.feedback)
+}
+
+func TestSidecarRouterPreviewRecordsZeroEligibleArms(t *testing.T) {
+	decider := &recordingPolicy{preview: policy.PreviewResult{
+		SchemaVersion:         policy.SchemaVersionV1,
+		PolicyArtifactID:      "hmm-prod",
+		PolicyArtifactSHA256:  "sha256:artifact",
+		RosterSHA256:          "sha256:roster",
+		HMMStateID:            1,
+		HMMStatePath:          []int{1},
+		HMMStateProbabilities: []float64{0.2, 0.8},
+		ClassOrder:            []string{"hard"},
+		ClassProbabilities:    map[string]float64{"hard": 1},
+		RankedFallback: []policy.PreviewGroup{{
+			Group:       "hard",
+			Probability: 1,
+		}},
+	}}
+	adapter := policy.NewSidecarRouter(policy.SidecarRouterConfig{
+		Strategy: router.StrategyHMM,
+	}, decider, policy.NewResolver(
+		set("gpt-5.5"),
+		set(providers.ProviderOpenAI),
+		catalogRosterID,
+		policy.ManagedProviderPolicy(),
+	)).WithCapabilities(policy.Capabilities{SupportsPreview: true})
+
+	result, err := adapter.PreviewRoute(context.Background(), router.Request{
+		ExcludedModels: set("gpt-5.5"),
+	})
+
+	require.NoError(t, err)
+	assert.Empty(t, result.EligibleRosterIDs)
+	assert.Empty(t, result.ResolverCandidates)
+	assert.Contains(t, result.ResolverExclusions, policy.Diagnostic{
+		CatalogID: "gpt-5.5",
+		Reason:    policy.ExclusionRequested,
+	})
+	assert.Empty(t, result.SelectedGroup)
+	assert.Empty(t, decider.previewQuery.Candidates)
+}
+
+func TestSidecarRouterPreviewRejectsUnknownArm(t *testing.T) {
+	decider := &recordingPolicy{preview: policy.PreviewResult{
+		SchemaVersion:         policy.SchemaVersionV1,
+		PolicyArtifactID:      "hmm-prod",
+		PolicyArtifactSHA256:  "sha256:artifact",
+		RosterSHA256:          "sha256:roster",
+		HMMStateID:            1,
+		HMMStatePath:          []int{1},
+		HMMStateProbabilities: []float64{0.2, 0.8},
+		ClassOrder:            []string{"hard"},
+		ClassProbabilities:    map[string]float64{"hard": 1},
+		RankedFallback: []policy.PreviewGroup{{
+			Group:        "hard",
+			Probability:  1,
+			RosterArms:   []string{"unoffered-model"},
+			EligibleArms: []string{"unoffered-model"},
+		}},
+		SelectedGroup:     "hard",
+		EligibleRosterIDs: []string{"unoffered-model"},
+	}}
+	adapter := policy.NewSidecarRouter(policy.SidecarRouterConfig{
+		Strategy: router.StrategyHMM,
+	}, decider, policy.NewResolver(
+		set("gpt-5.5"),
+		set(providers.ProviderOpenAI),
+		catalogRosterID,
+		policy.ManagedProviderPolicy(),
+	))
+
+	_, err := adapter.PreviewRoute(context.Background(), router.Request{})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown roster id")
 }
 
 func TestSidecarRouterCapabilitiesRejectUnsupportedShadow(t *testing.T) {

--- a/internal/server/middleware/agent_shadow_eval.go
+++ b/internal/server/middleware/agent_shadow_eval.go
@@ -10,9 +10,7 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
-// WithAgentShadowEvaluation authorizes the all-or-nothing internal evaluation
-// header triplet after normal router-key authentication. Partial headers fail
-// closed; ordinary traffic is untouched.
+// WithAgentShadowEvaluation validates the evaluation header triplet; partial headers fail closed, absent headers pass through.
 func WithAgentShadowEvaluation() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		model := strings.TrimSpace(c.GetHeader(proxy.AgentShadowModelHeader))

--- a/internal/server/middleware/agent_shadow_eval.go
+++ b/internal/server/middleware/agent_shadow_eval.go
@@ -1,0 +1,41 @@
+package middleware
+
+import (
+	"context"
+	"net/http"
+	"strings"
+
+	"workweave/router/internal/proxy"
+
+	"github.com/gin-gonic/gin"
+)
+
+// WithAgentShadowEvaluation authorizes the all-or-nothing internal evaluation
+// header triplet after normal router-key authentication. Partial headers fail
+// closed; ordinary traffic is untouched.
+func WithAgentShadowEvaluation() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		model := strings.TrimSpace(c.GetHeader(proxy.AgentShadowModelHeader))
+		rollout := strings.TrimSpace(c.GetHeader(proxy.AgentShadowRolloutHeader))
+		stateID := strings.TrimSpace(c.GetHeader(proxy.AgentShadowStateHeader))
+		present := model != "" || rollout != "" || stateID != ""
+		if !present {
+			c.Next()
+			return
+		}
+		if model == "" || rollout == "" || stateID == "" {
+			c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": "agent_shadow_eval_headers_incomplete"})
+			return
+		}
+		installation := InstallationFrom(c)
+		if installation == nil || !installation.PolicyHeaderOverridesEnabled {
+			c.AbortWithStatusJSON(http.StatusForbidden, gin.H{"error": "agent_shadow_eval_not_authorized"})
+			return
+		}
+		ctx := context.WithValue(c.Request.Context(), proxy.AgentShadowEvalContextKey{}, proxy.AgentShadowEvaluation{
+			Model: model, RolloutID: rollout, StateID: stateID,
+		})
+		c.Request = c.Request.WithContext(ctx)
+		c.Next()
+	}
+}

--- a/internal/server/middleware/agent_shadow_eval_test.go
+++ b/internal/server/middleware/agent_shadow_eval_test.go
@@ -1,0 +1,85 @@
+package middleware_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"workweave/router/internal/auth"
+	"workweave/router/internal/proxy"
+	"workweave/router/internal/server/middleware"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func runAgentShadowMiddleware(t *testing.T, installation *auth.Installation, headers http.Header) (int, bool) {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	engine := gin.New()
+	engine.Use(func(c *gin.Context) {
+		if installation != nil {
+			c.Set("router_installation", installation)
+		}
+		c.Next()
+	})
+	engine.Use(middleware.WithAgentShadowEvaluation())
+	var observed bool
+	engine.POST("/v1/messages", func(c *gin.Context) {
+		_, observed = proxy.AgentShadowEvalFromContext(c.Request.Context())
+		c.Status(http.StatusOK)
+	})
+	req := httptest.NewRequest(http.MethodPost, "/v1/messages", nil)
+	req.Header = headers
+	rec := httptest.NewRecorder()
+	engine.ServeHTTP(rec, req)
+	return rec.Code, observed
+}
+
+func TestAgentShadowEvaluation_RequiresAuthorizedCompleteTriplet(t *testing.T) {
+	headers := http.Header{}
+	headers.Set(proxy.AgentShadowModelHeader, "claude-opus-4-8")
+	headers.Set(proxy.AgentShadowRolloutHeader, "pilot-1")
+	headers.Set(proxy.AgentShadowStateHeader, "state-1")
+
+	status, observed := runAgentShadowMiddleware(t, &auth.Installation{PolicyHeaderOverridesEnabled: true}, headers)
+	require.Equal(t, http.StatusOK, status)
+	assert.True(t, observed)
+
+	status, observed = runAgentShadowMiddleware(t, &auth.Installation{}, headers)
+	assert.Equal(t, http.StatusForbidden, status)
+	assert.False(t, observed)
+
+	headers.Del(proxy.AgentShadowStateHeader)
+	status, observed = runAgentShadowMiddleware(t, &auth.Installation{PolicyHeaderOverridesEnabled: true}, headers)
+	assert.Equal(t, http.StatusBadRequest, status)
+	assert.False(t, observed)
+}
+
+func TestAgentShadowEvaluation_SkipsCustomerBillingGates(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	engine := gin.New()
+	engine.Use(func(c *gin.Context) {
+		c.Set("router_installation", &auth.Installation{
+			ExternalID:                   "customer-org",
+			PolicyHeaderOverridesEnabled: true,
+		})
+		c.Next()
+	})
+	engine.Use(middleware.WithAgentShadowEvaluation())
+	// Nil services deliberately prove each billing gate exits on the shadow
+	// context before attempting a customer balance/cap read.
+	engine.Use(middleware.WithBalanceCheck(nil, 0))
+	engine.Use(middleware.WithAPIKeySpendCap(nil))
+	engine.Use(middleware.WithOrgMonthlySpendCap(nil))
+	engine.POST("/v1/messages", func(c *gin.Context) { c.Status(http.StatusOK) })
+	req := httptest.NewRequest(http.MethodPost, "/v1/messages", nil)
+	req.Header.Set(proxy.AgentShadowModelHeader, "claude-opus-4-8")
+	req.Header.Set(proxy.AgentShadowRolloutHeader, "pilot-1")
+	req.Header.Set(proxy.AgentShadowStateHeader, "state-1")
+	rec := httptest.NewRecorder()
+
+	assert.NotPanics(t, func() { engine.ServeHTTP(rec, req) })
+	assert.Equal(t, http.StatusOK, rec.Code)
+}

--- a/internal/server/middleware/api_key_spend_cap.go
+++ b/internal/server/middleware/api_key_spend_cap.go
@@ -5,6 +5,7 @@ import (
 
 	"workweave/router/internal/billing"
 	"workweave/router/internal/observability"
+	"workweave/router/internal/proxy"
 
 	"github.com/gin-gonic/gin"
 )
@@ -25,6 +26,10 @@ import (
 func WithAPIKeySpendCap(svc *billing.Service) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		log := observability.FromGin(c)
+		if _, ok := proxy.AgentShadowEvalFromContext(c.Request.Context()); ok {
+			c.Next()
+			return
+		}
 
 		apiKey := APIKeyFrom(c)
 		if apiKey == nil || apiKey.ID == "" {

--- a/internal/server/middleware/balance_check.go
+++ b/internal/server/middleware/balance_check.go
@@ -42,6 +42,10 @@ const TopUpURL = "https://app.workweave.ai/settings/billing/router-credits"
 func WithBalanceCheck(svc *billing.Service, minBalanceMicros int64) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		log := observability.FromGin(c)
+		if _, ok := proxy.AgentShadowEvalFromContext(c.Request.Context()); ok {
+			c.Next()
+			return
+		}
 
 		installation := InstallationFrom(c)
 		if installation == nil || installation.ExternalID == "" {

--- a/internal/server/middleware/org_monthly_spend_cap.go
+++ b/internal/server/middleware/org_monthly_spend_cap.go
@@ -5,6 +5,7 @@ import (
 
 	"workweave/router/internal/billing"
 	"workweave/router/internal/observability"
+	"workweave/router/internal/proxy"
 
 	"github.com/gin-gonic/gin"
 )
@@ -14,6 +15,10 @@ import (
 func WithOrgMonthlySpendCap(svc *billing.Service) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		log := observability.FromGin(c)
+		if _, ok := proxy.AgentShadowEvalFromContext(c.Request.Context()); ok {
+			c.Next()
+			return
+		}
 
 		installation := InstallationFrom(c)
 		if installation == nil || installation.ExternalID == "" {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -147,6 +147,7 @@ func Register(engine *gin.Engine, authSvc *auth.Service, proxySvc *proxy.Service
 		middleware.WithTimingEntry(),
 		middleware.WithTimeout(messagesTimeout),
 		middleware.WithAuth(authSvc, byokDisabled),
+		middleware.WithAgentShadowEvaluation(),
 	}
 	if billingSvc != nil {
 		messagesMiddleware = append(messagesMiddleware, middleware.WithBalanceCheck(billingSvc, billing.MinBalanceMicros), middleware.WithAPIKeySpendCap(billingSvc), middleware.WithOrgMonthlySpendCap(billingSvc))
@@ -214,6 +215,17 @@ func Register(engine *gin.Engine, authSvc *auth.Service, proxySvc *proxy.Service
 	)
 	routeGroup := engine.Group("", routeMiddleware...)
 	routeGroup.POST("/v1/route", anthropicapi.RouteHandler(proxySvc))
+
+	previewGroup := engine.Group("",
+		middleware.WithTimingEntry(),
+		middleware.WithTimeout(routeTimeout),
+		middleware.WithAuth(authSvc, byokDisabled),
+		middleware.WithEmbedOnlyUserMessageOverride(),
+		middleware.WithRouterStrategyDefault(defaultStrategy, registeredStrategies...),
+		middleware.WithPolicyDebugOverride(),
+		middleware.WithRoutingKnobsOverride(),
+	)
+	previewGroup.POST("/v1/route/preview", anthropicapi.PreviewRouteHandler(proxySvc))
 
 	// No-login feedback link: the signed HMAC token in the URL/body is the
 	// sole credential, so no auth middleware. Mounted only when

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -48,6 +48,7 @@ func TestRegister_DeploymentMode(t *testing.T) {
 		"POST /v1/chat/completions",
 		"POST /v1/responses",
 		"POST /v1/route",
+		"POST /v1/route/preview",
 		"POST /v1/messages/count_tokens",
 		"GET /v1/models",
 		"GET /v1/models/:model",

--- a/sidecars/hmm/hmm_sidecar/api.py
+++ b/sidecars/hmm/hmm_sidecar/api.py
@@ -132,3 +132,32 @@ async def route(payload: dict[str, Any]) -> JSONResponse:
             **result.model_dump(mode="json"),
         }
     )
+
+
+@app.post("/preview")
+async def preview(payload: dict[str, Any]) -> JSONResponse:
+    policy: FrozenPolicy | None = getattr(app.state, "policy", None)
+    if policy is None:
+        return JSONResponse({"error": "policy not loaded"}, status_code=503)
+    if payload.get("schema_version") not in (None, SCHEMA_VERSION):
+        return JSONResponse({"error": "unsupported policy schema"}, status_code=400)
+    if payload.get("execution_mode") != "preview":
+        return JSONResponse(
+            {"error": "preview execution mode required"}, status_code=400
+        )
+    try:
+        result = await policy.preview(payload)
+    except (ValueError, EmbeddingError) as exc:
+        log.warning("HMM preview request rejected: %s", exc)
+        return JSONResponse({"error": "preview request rejected"}, status_code=422)
+    except Exception as exc:
+        log.exception("HMM preview failed")
+        return JSONResponse(
+            {"error": f"preview failed: {type(exc).__name__}"}, status_code=503
+        )
+    return JSONResponse(
+        {
+            "schema_version": SCHEMA_VERSION,
+            **result.model_dump(mode="json"),
+        }
+    )

--- a/sidecars/hmm/hmm_sidecar/policy.py
+++ b/sidecars/hmm/hmm_sidecar/policy.py
@@ -17,7 +17,42 @@ from .features import (
     tool_context_features,
 )
 from .hmm import FrozenHMM
-from .schemas import Candidate, RouteResult
+from .schemas import Candidate, RankedFallback, RoutePreviewResult, RouteResult
+
+
+def select_roster_group(
+    *,
+    probabilities: dict[str, float],
+    classes: tuple[str, ...],
+    clusters: dict[str, Any],
+    available_roster_ids: set[str],
+) -> tuple[str | None, tuple[str, ...], tuple[RankedFallback, ...]]:
+    """Select the first nonempty ranked group and retain every eligible arm."""
+    ranked_labels = sorted(
+        probabilities,
+        key=lambda label: (-probabilities[label], classes.index(label)),
+    )
+    selected_group: str | None = None
+    selected_arms: tuple[str, ...] = ()
+    fallback: list[RankedFallback] = []
+    for label in ranked_labels:
+        cluster = clusters.get(label) or {}
+        roster_arms = tuple(str(value) for value in cluster.get("arms") or [])
+        eligible_arms = tuple(
+            roster_id for roster_id in roster_arms if roster_id in available_roster_ids
+        )
+        fallback.append(
+            RankedFallback(
+                group=label,
+                probability=float(probabilities[label]),
+                roster_arms=roster_arms,
+                eligible_arms=eligible_arms,
+            )
+        )
+        if selected_group is None and eligible_arms:
+            selected_group = label
+            selected_arms = eligible_arms
+    return selected_group, selected_arms, tuple(fallback)
 
 
 def select_roster_arm(
@@ -27,16 +62,15 @@ def select_roster_arm(
     clusters: dict[str, Any],
     available_roster_ids: set[str],
 ) -> tuple[str, str]:
-    ranked_labels = sorted(
-        probabilities,
-        key=lambda label: (-probabilities[label], classes.index(label)),
+    label, arms, _ = select_roster_group(
+        probabilities=probabilities,
+        classes=classes,
+        clusters=clusters,
+        available_roster_ids=available_roster_ids,
     )
-    for label in ranked_labels:
-        cluster = clusters.get(label) or {}
-        for roster_id in cluster.get("arms") or []:
-            if roster_id in available_roster_ids:
-                return label, roster_id
-    raise ValueError("no candidate is present in the frozen HMM roster")
+    if label is None or not arms:
+        raise ValueError("no candidate is present in the frozen HMM roster")
+    return label, arms[0]
 
 
 def selected_margin(probabilities: dict[str, float], selected_label: str) -> float:
@@ -68,11 +102,13 @@ class FrozenPolicy:
             if isinstance(card, dict) and isinstance(card.get("state_id"), int)
         }
 
-    async def route(self, payload: dict[str, Any]) -> RouteResult:
+    async def _evaluate(
+        self, payload: dict[str, Any], *, allow_empty_candidates: bool
+    ) -> tuple[list[Candidate], Any, Any]:
         candidates = [
             Candidate.model_validate(value) for value in payload.get("candidates") or []
         ]
-        if not candidates:
+        if not candidates and not allow_empty_candidates:
             raise ValueError("route request has no candidates")
         by_roster = {candidate.roster_id: candidate for candidate in candidates}
         if len(by_roster) != len(candidates):
@@ -90,6 +126,38 @@ class FrozenPolicy:
             tool_context=tool_context_features(payload),
         )
         classification = self.classifier.predict(feature_row)
+        return candidates, readout, classification
+
+    async def preview(self, payload: dict[str, Any]) -> RoutePreviewResult:
+        candidates, readout, classification = await self._evaluate(
+            payload, allow_empty_candidates=True
+        )
+        selected_group, eligible_arms, ranked_fallback = select_roster_group(
+            probabilities=classification.probabilities,
+            classes=tuple(self.classifier.classes),
+            clusters=self.clusters,
+            available_roster_ids={candidate.roster_id for candidate in candidates},
+        )
+        return RoutePreviewResult(
+            route_id=str(payload.get("route_id") or ""),
+            policy_artifact_id=self.artifacts.manifest.model_id,
+            policy_artifact_sha256=self.artifacts.package_sha256,
+            roster_sha256=self.roster_version,
+            hmm_state_id=readout.state,
+            hmm_state_path=tuple(readout.state_path),
+            hmm_state_probabilities=tuple(float(value) for value in readout.gamma[-1]),
+            class_order=tuple(self.classifier.classes),
+            class_probabilities=classification.probabilities,
+            ranked_fallback=ranked_fallback,
+            selected_group=selected_group,
+            eligible_roster_ids=eligible_arms,
+        )
+
+    async def route(self, payload: dict[str, Any]) -> RouteResult:
+        candidates, readout, classification = await self._evaluate(
+            payload, allow_empty_candidates=False
+        )
+        by_roster = {candidate.roster_id: candidate for candidate in candidates}
         selected_label, selected_roster = select_roster_arm(
             probabilities=classification.probabilities,
             classes=tuple(self.classifier.classes),

--- a/sidecars/hmm/hmm_sidecar/schemas.py
+++ b/sidecars/hmm/hmm_sidecar/schemas.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import math
 from pathlib import Path
 from typing import Any
 
@@ -92,3 +93,52 @@ class RouteResult(FrozenModel):
     policy_artifact_sha256: str
     roster_version: str
     debug: dict[str, Any]
+
+
+class RankedFallback(FrozenModel):
+    group: str = Field(min_length=1)
+    probability: float = Field(ge=0.0, le=1.0)
+    roster_arms: tuple[str, ...]
+    eligible_arms: tuple[str, ...]
+
+
+class RoutePreviewResult(FrozenModel):
+    route_id: str
+    policy_artifact_id: str
+    policy_artifact_sha256: str
+    roster_sha256: str
+    hmm_state_id: int = Field(ge=0)
+    hmm_state_path: tuple[int, ...] = Field(min_length=1)
+    hmm_state_probabilities: tuple[float, ...] = Field(min_length=1)
+    class_order: tuple[str, ...] = Field(min_length=1)
+    class_probabilities: dict[str, float]
+    ranked_fallback: tuple[RankedFallback, ...] = Field(min_length=1)
+    selected_group: str | None
+    eligible_roster_ids: tuple[str, ...]
+
+    @model_validator(mode="after")
+    def validate_probabilities(self) -> "RoutePreviewResult":
+        if self.hmm_state_id >= len(self.hmm_state_probabilities):
+            raise ValueError("hmm_state_id is outside hmm_state_probabilities")
+        if any(
+            not math.isfinite(value) or value < 0.0 or value > 1.0
+            for value in self.hmm_state_probabilities
+        ):
+            raise ValueError("HMM state probabilities must be in [0,1]")
+        if abs(sum(self.hmm_state_probabilities) - 1.0) > 1e-6:
+            raise ValueError("HMM state probabilities must sum to one")
+        if any(
+            value < 0 or value >= len(self.hmm_state_probabilities)
+            for value in self.hmm_state_path
+        ):
+            raise ValueError("HMM state path is outside the posterior vector")
+        if set(self.class_probabilities) != set(self.class_order):
+            raise ValueError("classifier probabilities must match class_order")
+        if any(
+            not math.isfinite(value) or value < 0.0 or value > 1.0
+            for value in self.class_probabilities.values()
+        ):
+            raise ValueError("classifier probabilities must be in [0,1]")
+        if abs(sum(self.class_probabilities.values()) - 1.0) > 1e-6:
+            raise ValueError("classifier probabilities must sum to one")
+        return self

--- a/sidecars/hmm/tests/test_api.py
+++ b/sidecars/hmm/tests/test_api.py
@@ -3,12 +3,45 @@ from __future__ import annotations
 from fastapi.testclient import TestClient
 
 from hmm_sidecar.api import app
+from hmm_sidecar.schemas import RoutePreviewResult
 
 
 class RejectingPolicy:
     async def route(self, payload: dict[str, object]) -> None:
         del payload
         raise ValueError("private artifact path: /secret/model.npz")
+
+
+class PreviewingPolicy:
+    async def preview(self, payload: dict[str, object]) -> object:
+        assert payload["execution_mode"] == "preview"
+        return RoutePreviewResult(
+            route_id="route",
+            policy_artifact_id="artifact",
+            policy_artifact_sha256="a" * 64,
+            roster_sha256="b" * 64,
+            hmm_state_id=1,
+            hmm_state_path=(0, 1),
+            hmm_state_probabilities=(0.3, 0.7),
+            class_order=("fast", "maximum"),
+            class_probabilities={"fast": 0.6, "maximum": 0.4},
+            ranked_fallback=(
+                {
+                    "group": "fast",
+                    "probability": 0.6,
+                    "roster_arms": ("provider/a",),
+                    "eligible_arms": ("provider/a",),
+                },
+                {
+                    "group": "maximum",
+                    "probability": 0.4,
+                    "roster_arms": ("provider/b",),
+                    "eligible_arms": (),
+                },
+            ),
+            selected_group="fast",
+            eligible_roster_ids=("provider/a",),
+        )
 
 
 def test_liveness_does_not_depend_on_model_readiness() -> None:
@@ -59,3 +92,20 @@ def test_route_rejections_do_not_expose_internal_exception_text() -> None:
     assert response.status_code == 422
     assert response.json() == {"error": "route request rejected"}
     assert "/secret/model.npz" not in response.text
+
+
+def test_preview_requires_explicit_mode_and_returns_all_selected_arms() -> None:
+    with TestClient(app) as client:
+        app.state.policy = PreviewingPolicy()
+        rejected = client.post("/preview", json={"schema_version": "policy_router_v1"})
+        response = client.post(
+            "/preview",
+            json={
+                "schema_version": "policy_router_v1",
+                "execution_mode": "preview",
+            },
+        )
+
+    assert rejected.status_code == 400
+    assert response.status_code == 200
+    assert response.json()["eligible_roster_ids"] == ["provider/a"]

--- a/sidecars/hmm/tests/test_policy.py
+++ b/sidecars/hmm/tests/test_policy.py
@@ -6,7 +6,12 @@ from pathlib import Path
 import pytest
 
 from hmm_sidecar.artifacts import resolve_artifacts, sha256_file
-from hmm_sidecar.policy import FrozenPolicy, select_roster_arm, selected_margin
+from hmm_sidecar.policy import (
+    FrozenPolicy,
+    select_roster_arm,
+    select_roster_group,
+    selected_margin,
+)
 
 
 class FixedEmbedder:
@@ -33,6 +38,47 @@ def test_roster_fallback_reports_the_selected_classifier_group() -> None:
     assert label == "fast"
     assert roster_id == "provider/fast"
     assert selected_margin(probabilities, label) == pytest.approx(-0.6)
+
+
+def test_group_selection_uses_class_order_ties_and_returns_every_arm() -> None:
+    group, arms, fallback = select_roster_group(
+        probabilities={"fast": 0.5, "maximum": 0.5},
+        classes=("fast", "maximum"),
+        clusters={
+            "fast": {"arms": ["provider/a", "provider/b"]},
+            "maximum": {"arms": ["provider/c"]},
+        },
+        available_roster_ids={"provider/a", "provider/b", "provider/c"},
+    )
+
+    assert group == "fast"
+    assert arms == ("provider/a", "provider/b")
+    assert tuple(item.group for item in fallback) == ("fast", "maximum")
+
+
+def test_group_selection_falls_back_and_retains_zero_arm_result() -> None:
+    group, arms, fallback = select_roster_group(
+        probabilities={"fast": 0.8, "maximum": 0.2},
+        classes=("fast", "maximum"),
+        clusters={
+            "fast": {"arms": ["provider/a"]},
+            "maximum": {"arms": ["provider/b", "provider/c"]},
+        },
+        available_roster_ids={"provider/b", "provider/c"},
+    )
+
+    assert group == "maximum"
+    assert arms == ("provider/b", "provider/c")
+    assert fallback[0].eligible_arms == ()
+
+    empty_group, empty_arms, _ = select_roster_group(
+        probabilities={"fast": 0.8, "maximum": 0.2},
+        classes=("fast", "maximum"),
+        clusters={"fast": {"arms": ["provider/a"]}, "maximum": {"arms": []}},
+        available_roster_ids=set(),
+    )
+    assert empty_group is None
+    assert empty_arms == ()
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
Adds an authenticated, side-effect-free HMM route preview and an evaluation-only forced-model path for the one-time production agent-shadow campaign. Evaluation requests bypass session pins, policy feedback/learning, persistent serving telemetry, customer billing, identity upserts, compaction, handover, and cache state while retaining normal translation, provider binding, failover, and response normalization.\n\nValidation: make precommit; HMM sidecar 28 passed, 1 skipped.