### PR TITLE
fix(router): exclude PreferredModels turns from semantic cache

### DIFF
--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -2283,12 +2283,13 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 	// Semantic-cache eligibility: configured, non-streaming, decision has
 	// metadata, externalID present, not eval traffic. Skip when a compaction
 	// handover rewrote env (embedding predates the rewrite) or when subsidy
-	// factors are non-empty (the cache key doesn't capture quota-headroom-
-	// dependent model choice; subsidyFactors returns nil when the feature is off).
-	// Subscription-only turns are excluded (like the OpenAI path): the mode is an
-	// unfoldable routing signal absent from the cache key, so a stored body would
-	// bypass the exhausted-sub 402 guard and the depleted-credits warning below.
-	cacheEligible := s.semanticCache != nil && !env.Stream() && decision.Metadata != nil && externalID != "" && !bypassEval && !compactionHandoverRan && !billing.SubscriptionOnlyFromContext(ctx) && len(s.subsidyFactors(ctx, r.Header)) == 0
+	// factors / PreferredModels are non-empty (the cache key doesn't capture
+	// those score-perturbing inputs' effect on model choice; subsidyFactors
+	// returns nil when the feature is off). Subscription-only turns are
+	// excluded (like the OpenAI path): the mode is an unfoldable routing signal
+	// absent from the cache key, so a stored body would bypass the exhausted-sub
+	// 402 guard and the depleted-credits warning below.
+	cacheEligible := s.semanticCache != nil && !env.Stream() && decision.Metadata != nil && externalID != "" && !bypassEval && !compactionHandoverRan && !billing.SubscriptionOnlyFromContext(ctx) && len(s.subsidyFactors(ctx, r.Header)) == 0 && len(s.preferredModelsForRequest(ctx)) == 0
 	if cacheEligible {
 		if resp, hit := s.semanticCache.Lookup(externalID, cache.FormatAnthropic, decision.Metadata.Embedding, decision.Metadata.ClusterIDs, decision.Metadata.ClusterRouterVersion, decision.Metadata.EffectiveKnobsHash); hit {
 			s.writeCachedResponse(w, resp, decision)
@@ -4213,9 +4214,10 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 	pinAgeSec := routeRes.PinAgeSec
 	s.logPlannerOutcome(ctx, routeRes)
 
-	// See the ProxyMessages cache-eligibility note: subsidized requests bypass the
-	// semantic cache (the key doesn't capture headroom-dependent model choice).
-	cacheEligible := s.semanticCache != nil && !env.Stream() && decision.Metadata != nil && externalID != "" && !bypassEval && !responsesPassthrough && !billing.SubscriptionOnlyFromContext(ctx) && len(s.subsidyFactors(ctx, r.Header)) == 0
+	// See the ProxyMessages cache-eligibility note: subsidized and
+	// PreferredModels requests bypass the semantic cache (the key doesn't
+	// capture those score-perturbing inputs' effect on model choice).
+	cacheEligible := s.semanticCache != nil && !env.Stream() && decision.Metadata != nil && externalID != "" && !bypassEval && !responsesPassthrough && !billing.SubscriptionOnlyFromContext(ctx) && len(s.subsidyFactors(ctx, r.Header)) == 0 && len(s.preferredModelsForRequest(ctx)) == 0
 	if cacheEligible {
 		if resp, hit := s.semanticCache.Lookup(externalID, cache.FormatOpenAI, decision.Metadata.Embedding, decision.Metadata.ClusterIDs, decision.Metadata.ClusterRouterVersion, decision.Metadata.EffectiveKnobsHash); hit {
 			s.writeCachedResponse(w, resp, decision)

--- a/internal/proxy/service_cache_test.go
+++ b/internal/proxy/service_cache_test.go
@@ -237,3 +237,40 @@ func TestService_Cache_DisabledByNilCache(t *testing.T) {
 	assert.Len(t, provider.proxyBodies, 2, "nil cache must be a transparent passthrough")
 	assert.Empty(t, rec2.Header().Get(proxy.HeaderRouterCache))
 }
+
+// TestService_Cache_PreferredModelsBypasses guards #789: PreferredModels is a
+// per-request score-perturbing input (blendScoresV2 priorityBonus) that can
+// flip the scorer's winner without changing EffectiveKnobsHash. Without a
+// cacheEligible gate, a no-preference store is replayed to a preference-
+// bearing request (wrong model's body, live x-router-model). Same class as
+// the subsidyFactors gate from #495.
+func TestService_Cache_PreferredModelsBypasses(t *testing.T) {
+	emb := embeddingFixture(8)
+	provider := &fakeProvider{
+		proxyResponse: func(w http.ResponseWriter) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"id":"from-no-pref","content":"opus-shaped"}`))
+		},
+	}
+	// Fake router returns a fixed decision+embedding so both turns land in the
+	// same cache bucket — isolating the eligibility gate from scorer variance.
+	fr := &fakeRouter{decision: decisionWithEmbedding(emb, []int{0, 1, 2, 3})}
+	c := cache.New(cache.DefaultConfig())
+	svc := proxy.NewService(fr, map[string]providers.Client{providers.ProviderAnthropic: provider}, nil, false, c, nil, false, providers.ProviderAnthropic, "claude-haiku-4-5", nil)
+
+	body := anthropicBody("close-call prompt", false)
+
+	ctxNoPref := proxyContextWithExternalID(t, "tenant-pref")
+	rec1 := httptest.NewRecorder()
+	require.NoError(t, svc.ProxyMessages(ctxNoPref, body, rec1, httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(""))))
+	require.Len(t, provider.proxyBodies, 1, "no-preference turn must miss and hit the provider")
+
+	ctxPref := context.WithValue(ctxNoPref, proxy.InstallationPreferredModelsContextKey{}, []string{"claude-haiku-4-5"})
+	rec2 := httptest.NewRecorder()
+	require.NoError(t, svc.ProxyMessages(ctxPref, body, rec2, httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(""))))
+
+	assert.Len(t, provider.proxyBodies, 2,
+		"PreferredModels turn must bypass the semantic cache and hit the provider (no cross-preference hit)")
+	assert.Empty(t, rec2.Header().Get(proxy.HeaderRouterCache),
+		"PreferredModels turn must not report x-router-cache: hit")
+}


### PR DESCRIPTION
Fixes #789.

## Summary

`cacheEligible` already excludes requests where `subsidyFactors` (per-
installation subscription quota headroom) or `SubscriptionOnlyFromContext`
are in play, because both can change the scorer's winning model without
changing the semantic cache's isolation key (`EffectiveKnobsHash`). This PR
adds the same exclusion for `PreferredModels`, which has the identical
structural problem and was missing the gate.

## Background / root cause

The semantic cache buckets responses by `{format, clusterID, clusterVersion,
knobsHash}` (`internal/router/cache/cache.go`). `knobsHash` comes from
`ComputeKnobsHash(alpha, speedWeight, outputCostRatio, expectedOutputTokens,
perModelVerbosity)` (`internal/router/cluster/knobs.go`) — a hash over the
routing *knobs*, not over anything that identifies which model actually won.

`blendScoresV2` (`internal/router/cluster/scorer.go`) computes per-model
scores from those knobs, then adds two additional per-request adjustments
on top, inside the same loop:

```go
if f, ok := subsidyFactors[m]; ok {
    scores[m] += subsidyMaxBonus * float32(1.0-f)
}
if b, ok := priorityBonus[m]; ok {
    scores[m] += b
}
```

`priorityBonus` is built from `req.PreferredModels` (rank-0 bonus ≈0.15,
decaying by rank, added once per top-P cluster — so it compounds and can
flip a genuinely close call, not just a tie; see
`TestScorer_PreferredModelSoftNudge`). Both `subsidyFactors` and
`priorityBonus` can change which model wins **without changing
`EffectiveKnobsHash`**, because the hash is computed from knobs alone,
before either adjustment is applied.

`cacheEligible` already accounted for this for `subsidyFactors` (and
separately, `SubscriptionOnlyFromContext`, for a related but distinct
reason — see the existing comment). It didn't account for it for
`PreferredModels`, introduced later in #521. That gap meant: two requests
with the same prompt/embedding/knobs but different `PreferredModels` could
produce different winning models, land in the *same* cache bucket, and a
cache hit would serve the wrong model's response body while
`writeCachedResponse` set `x-router-model` from the current (correct)
decision — a body/header mismatch, confirmed in #789 via a mechanism-level
test against the real `Scorer` and `Cache` (see the issue for the isolated
test and its output).

## Fix

Mirrors the existing `subsidyFactors` gate exactly, at both call sites:

```go
// internal/proxy/service.go, ProxyMessages (~line 2292)
cacheEligible := s.semanticCache != nil && !env.Stream() && decision.Metadata != nil &&
    externalID != "" && !bypassEval && !compactionHandoverRan &&
    !billing.SubscriptionOnlyFromContext(ctx) &&
    len(s.subsidyFactors(ctx, r.Header)) == 0 &&
    len(s.preferredModelsForRequest(ctx)) == 0   // <- added
```

Same addition at the OpenAI path (`ProxyOpenAIChatCompletion`, ~line 4220).
Comments above both sites updated to mention `PreferredModels` alongside
subsidy factors as a "score-perturbing input the cache key doesn't capture."

### Why gate, not fold

Two existing patterns in this codebase address this class of gap:

- **Gate** (`cacheEligible` exclusion) — used by #495 (subsidy) and #747
  (`SubscriptionOnly`).
- **Fold** (incorporate the perturbing input into the hash, e.g.
  `mixModel`) — used by #338 for the bandit explorer's non-argmax pick, and
  originally by #214 for `clusterVersion`.

`PreferredModels` is structurally identical to `subsidyFactors` — both are
per-request maps added additively to `scores[m]` in the same loop, i.e.
score-*perturbing inputs*. The bandit explorer's case is different in kind:
it's a post-hoc override of an already-fixed argmax pick for online-learning
exploration, not a perturbation of the scoring function itself. Given that
structural match, gating (matching #495/#747) is the more consistent choice
here, and it's also the smaller, lower-risk diff — folding would require
either restructuring `EffectiveKnobsHash`'s computation to happen *after*
`blendScoresV2` resolves a winner (it currently runs before), or hashing the
full `priorityBonus` map, both larger changes than this PR's scope.

Trade-off: gating means any installation with a non-empty `preferred_models`
list gets zero semantic-cache benefit, full stop, rather than only losing it
on the specific requests where the preference actually changes the outcome.
Given `preferred_models` defaults to `{}` (opt-in, not the common case),
this seemed like the right trade for a minimal, safe fix — flagging here in
case there's a strong preference for the fold approach instead, since it's
a real trade either way.

## Commits

1. `bfbf829` — failing test reproducing the collision (confirmed failing
   for the right reason: cache hit + wrong body, not a compile/setup error)
2. `dec5706` — the gate, at both call sites, plus comment updates

## Testing

- New test (`TestService_Cache_PreferredModelsBypasses`) confirms: a
  request with non-empty `PreferredModels` now results in 2 real provider
  calls (no incorrect cache hit) instead of 1, and never reports
  `x-router-cache: hit`.
- Confirmed via the real service-layer request path (`ProxyMessages`,
  `ProxyOpenAIChatCompletion`), not just the `cache` package in isolation —
  `cacheEligible` is computed inline in `service.go`, so this is where the
  gate needed to be verified.
- Confirmed normal caching is unaffected: `TestService_Cache_
  HitShortCircuitsProvider` (nil/absent preferences, the common case) still
  hits correctly; an explicit empty slice (`[]string{}`) also still hits.
- Confirmed `preferredModelsForRequest(ctx)` is nil/panic-safe: missing
  context key, empty slice, and a wrong-type context value (defensive type
  assertion) all resolve to `len == 0` without panicking.
- Searched the whole repo for other `semanticCache.Lookup`/`Store` call
  sites — only the two fixed here exist. Gemini's proxy path doesn't use
  the semantic cache at all (`cache.Format*` only covers Anthropic/OpenAI).
  `ProxyOpenAIResponses` delegates to `ProxyOpenAIChatCompletion` and
  inherits the fix. `/v1/route` performs no cache I/O (dry-run).
- `go vet ./internal/proxy/...` clean; `gofmt -l internal/proxy/service.go`
  clean (no diff).
- Scoped suite green: `./internal/proxy/... ./internal/router/cluster/...
  ./internal/router/cache/...`, verbose, `-count=1`.
- Full `make check` passes clean.

## Known, deliberately unaddressed

- **Stale-preference over-gating.** The gate fires on "preference
  configured" (any non-empty `preferred_models` list on the installation),
  not "preference currently eligible for this request." An installation
  whose entire list is stale (references excluded/undeployed models —
  the same no-op case `TestScorer_PreferredModelSoftNudge` already covers
  at the scorer level) loses caching even though the scorer would ignore
  the stale entries entirely and routing is unaffected. This is safe
  (over-broad, not incorrect) and a minor hit-rate cost, not a correctness
  issue, so I left it out of this PR's scope rather than adding eligibility
  resolution logic here.
- **`ExcludedModels` sibling gap.** Same class of problem:
  `installation.ExcludedModels` can also change the scorer's winning model
  (by removing an otherwise-winning model from the eligible set) and isn't
  reflected in `cacheEligible` or `EffectiveKnobsHash` either. Didn't
  expand this PR to cover it since it's a separate root cause investigation
  and repro, but happy to open a follow-up issue if that's useful — let me
  know.