### PR TITLE
fix(router): port compaction handover to OpenAI path

### DIFF
--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -4136,6 +4136,7 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 	// Snapshot the inbound tool-output size before any env rewrite (proactive
 	// compaction below, or runTurnLoop's switch handover); see toolResultBytesPtr.
 	inboundLastUser := env.LastUserMessage()
+	inboundToolCallCountOAI := len(env.AssistantToolCallSignatures())
 
 	// Proactive context-window compaction, as in ProxyMessages. Skipped for
 	// Codex passthrough bodies, which are forwarded verbatim.
@@ -4213,9 +4214,29 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 	pinAgeSec := routeRes.PinAgeSec
 	s.logPlannerOutcome(ctx, routeRes)
 
+	// Compaction-aware handover: same consumer as ProxyMessages. Detection runs
+	// pre-routing in runTurnLoop; routeRes.PrefixTrimmed carries the verdict.
+	// Skip when a model-switch handover already rewrote env, or when proactive
+	// maybeCompact already ran this turn (would false-positive and discard the
+	// recent-turn tail maybeCompact kept). Codex Responses passthrough bodies
+	// stay verbatim — do not rewrite them with a handover summary.
+	compactionHandoverRan := false
+	var compactionHandoverOutcome handoverOutcome
+	if !responsesPassthrough && decision.Provider != providers.ProviderAnthropic && !routeRes.HardPinned && !routeRes.Handover.Invoked && !compResOAI.Applied && routeRes.PrefixTrimmed {
+		log.Info("Context trimming detected on non-Anthropic route; rewriting context with handover summary",
+			"message_count", feats.MessageCount,
+			"tool_call_count", inboundToolCallCountOAI,
+			"decision_model", decision.Model,
+			"decision_provider", decision.Provider,
+		)
+		compactionHandoverOutcome = s.runCompactionHandover(ctx, env, r.Header, decision.Model)
+		compactionHandoverRan = true
+	}
+
 	// See the ProxyMessages cache-eligibility note: subsidized requests bypass the
 	// semantic cache (the key doesn't capture headroom-dependent model choice).
-	cacheEligible := s.semanticCache != nil && !env.Stream() && decision.Metadata != nil && externalID != "" && !bypassEval && !responsesPassthrough && !billing.SubscriptionOnlyFromContext(ctx) && len(s.subsidyFactors(ctx, r.Header)) == 0
+	// Skip when a compaction handover rewrote env (embedding predates the rewrite).
+	cacheEligible := s.semanticCache != nil && !env.Stream() && decision.Metadata != nil && externalID != "" && !bypassEval && !responsesPassthrough && !compactionHandoverRan && !billing.SubscriptionOnlyFromContext(ctx) && len(s.subsidyFactors(ctx, r.Header)) == 0
 	if cacheEligible {
 		if resp, hit := s.semanticCache.Lookup(externalID, cache.FormatOpenAI, decision.Metadata.Embedding, decision.Metadata.ClusterIDs, decision.Metadata.ClusterRouterVersion, decision.Metadata.EffectiveKnobsHash); hit {
 			s.writeCachedResponse(w, resp, decision)
@@ -4668,6 +4689,27 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 		s.emitBilling(ctx, requestID, externalID, decision, actPricing, routeRes, in, out, cacheCreation, cacheRead)
 		if compResOAI.Summarized {
 			s.billCompactionSummary(ctx, requestID, externalID, compResOAI.SummaryUsage)
+		}
+		if compactionHandoverOutcome.Invoked && !compactionHandoverOutcome.FallbackToFullHistory {
+			sumUsage := compactionHandoverOutcome.SummaryUsage
+			if sumUsage.Model != "" && (sumUsage.InputTokens > 0 || sumUsage.OutputTokens > 0) {
+				sumPricing, _ := catalog.PrimaryPriceFor(sumUsage.Model)
+				apiKeyID, _ := ctx.Value(APIKeyIDContextKey{}).(string)
+				s.fireBilling(ctx, billing.DebitInferenceParams{
+					OrganizationID:  externalID,
+					RouterRequestID: requestID + "_compaction_summary",
+					Model:           sumUsage.Model,
+					Provider:        sumUsage.Provider,
+					InputTokens:     sumUsage.InputTokens,
+					OutputTokens:    sumUsage.OutputTokens,
+					CacheCreation:   sumUsage.CacheCreation,
+					CacheRead:       sumUsage.CacheRead,
+					Pricing:         sumPricing,
+					HasOverride:     billing.HasOverrideFromContext(ctx),
+					APIKeyID:        apiKeyID,
+					RouterUserID:    auth.UserIDFrom(ctx),
+				})
+			}
 		}
 	}
 

--- a/internal/proxy/turnloop_test.go
+++ b/internal/proxy/turnloop_test.go
@@ -960,6 +960,167 @@ func TestTurnLoop_SubAgentDoesNotInheritMainLoopTrimBaseline(t *testing.T) {
 	assert.Equal(t, int32(0), sz.calls.Load())
 }
 
+// compactionHandoverAnchor is the stable first-user-message used by
+// TestService_CompactionHandover_OpenAIParityWithMessages so both turns share
+// one DeriveSessionKey and one compactionTracker bucket.
+const compactionHandoverAnchor = "ANCHOR-COMPACTION-TEST: refactor the dispatch loop"
+
+// compactionHandoverTurn builds an alternating user/assistant Anthropic body
+// with a fixed first user message (session-key stable).
+func compactionHandoverTurn(t *testing.T, msgCount int) []byte {
+	t.Helper()
+	require.True(t, msgCount%2 == 1, "odd msgCount keeps the trailing message a user turn")
+	msgs := make([]string, 0, msgCount)
+	for i := 0; i < msgCount; i++ {
+		role := "user"
+		if i%2 == 1 {
+			role = "assistant"
+		}
+		msgs = append(msgs, `{"role":"`+role+`","content":"compaction-handover turn `+itoa(i)+`"}`)
+	}
+	msgs[0] = `{"role":"user","content":"` + compactionHandoverAnchor + `"}`
+	return []byte(`{"model":"claude-opus-4-7","system":"sys","messages":[` + strings.Join(msgs, ",") + `]}`)
+}
+
+// compactionHandoverTurnOpenAI is the OpenAI chat/completions equivalent of
+// compactionHandoverTurn (same dialog shapes + same first-user anchor).
+func compactionHandoverTurnOpenAI(t *testing.T, msgCount int) []byte {
+	t.Helper()
+	require.True(t, msgCount%2 == 1, "odd msgCount keeps the trailing message a user turn")
+	msgs := make([]string, 0, msgCount+1)
+	msgs = append(msgs, `{"role":"system","content":"You are helpful."}`)
+	for i := 0; i < msgCount; i++ {
+		role := "user"
+		if i%2 == 1 {
+			role = "assistant"
+		}
+		msgs = append(msgs, `{"role":"`+role+`","content":"compaction-handover turn `+itoa(i)+`"}`)
+	}
+	msgs[1] = `{"role":"user","content":"` + compactionHandoverAnchor + `"}`
+	return []byte(`{"model":"gpt-4o","messages":[` + strings.Join(msgs, ",") + `]}`)
+}
+
+func openAICompatChatJSON(w http.ResponseWriter) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write([]byte(`{"id":"chatcmpl_1","object":"chat.completion","choices":[{"index":0,"message":{"role":"assistant","content":"hi"},"finish_reason":"stop"}],"usage":{"prompt_tokens":10,"completion_tokens":1}}`))
+}
+
+func anthropicMessagesJSON(w http.ResponseWriter) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write([]byte(`{"id":"msg_1","type":"message","role":"assistant","content":[{"type":"text","text":"hi"}],"stop_reason":"end_turn","usage":{"input_tokens":10,"output_tokens":1}}`))
+}
+
+// warmNonAnthropicPin keeps the planner on a non-Anthropic stay across both
+// turns so the post-routing compaction-handover consumer is eligible
+// (gated on decision.Provider != Anthropic). Pin model == fresh model so a
+// prefix-trim cold-pin free-switch still lands on the same decision.
+func warmNonAnthropicPin(provider, model string) sessionpin.Pin {
+	return sessionpin.Pin{
+		Provider:        provider,
+		Model:           model,
+		Reason:          "cluster:v0.2",
+		PinnedUntil:     time.Now().Add(time.Hour),
+		LastInputTokens: 1500,
+		LastTurnEndedAt: time.Now().Add(-30 * time.Second),
+	}
+}
+
+// TestService_CompactionHandover_OpenAIParityWithMessages asserts that a
+// client-side 9→3 history trim on a non-Anthropic STAY invokes
+// runCompactionHandover (counting stub summarizer) on both Messages and
+// OpenAI ingress. Regression for #791: OpenAI previously detected
+// PrefixTrimmed in runTurnLoop but never consumed it post-routing.
+func TestService_CompactionHandover_OpenAIParityWithMessages(t *testing.T) {
+	const (
+		orModel  = "deepseek/deepseek-chat"
+		oaiModel = "gpt-4o"
+	)
+
+	t.Run("Messages_invokes_summarizer_on_trim", func(t *testing.T) {
+		store := newFakePinStore()
+		store.hasPin = true
+		store.pin = warmNonAnthropicPin(providers.ProviderOpenRouter, orModel)
+		fr := &fakeRouter{decision: router.Decision{
+			Provider: providers.ProviderOpenRouter,
+			Model:    orModel,
+			Reason:   "cluster:v0.2",
+		}}
+		sz := &fakeSummarizer{summary: "Prior conversation summary."}
+		svc := proxy.NewService(
+			fr,
+			map[string]providers.Client{
+				providers.ProviderAnthropic:  &fakeProvider{proxyResponse: anthropicMessagesJSON},
+				providers.ProviderOpenRouter: &fakeProvider{proxyResponse: openAICompatChatJSON},
+			},
+			nil, false, nil, store, false,
+			providers.ProviderAnthropic, "claude-haiku-4-5", nil,
+		).WithSummarizer(sz).
+			WithCompaction(nil, 0).
+			WithAvailableModels(map[string]struct{}{orModel: {}})
+
+		ctx := authedCtx(uuid.New().String())
+
+		rec1 := httptest.NewRecorder()
+		req1 := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(""))
+		require.NoError(t, svc.ProxyMessages(ctx, compactionHandoverTurn(t, 9), rec1, req1))
+		require.Equal(t, orModel, rec1.Header().Get(proxy.HeaderRouterModel),
+			"turn 1 must stay on the non-Anthropic pin")
+		require.Equal(t, int32(0), sz.calls.Load(),
+			"first observation must not fire compaction handover")
+
+		rec2 := httptest.NewRecorder()
+		req2 := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(""))
+		require.NoError(t, svc.ProxyMessages(ctx, compactionHandoverTurn(t, 3), rec2, req2))
+		require.Equal(t, orModel, rec2.Header().Get(proxy.HeaderRouterModel),
+			"turn 2 must stay on the non-Anthropic pin so handover is eligible")
+		assert.GreaterOrEqual(t, sz.calls.Load(), int32(1),
+			"Messages path must invoke the summarizer via runCompactionHandover on a 9→3 trim")
+	})
+
+	t.Run("OpenAI_invokes_summarizer_on_trim", func(t *testing.T) {
+		store := newFakePinStore()
+		store.hasPin = true
+		store.pin = warmNonAnthropicPin(providers.ProviderOpenAI, oaiModel)
+		fr := &fakeRouter{decision: router.Decision{
+			Provider: providers.ProviderOpenAI,
+			Model:    oaiModel,
+			Reason:   "cluster:v0.2",
+		}}
+		sz := &fakeSummarizer{summary: "Prior conversation summary."}
+		svc := proxy.NewService(
+			fr,
+			map[string]providers.Client{
+				providers.ProviderAnthropic: &fakeProvider{proxyResponse: anthropicMessagesJSON},
+				providers.ProviderOpenAI:    &fakeProvider{proxyResponse: openAICompatChatJSON},
+			},
+			nil, false, nil, store, false,
+			providers.ProviderAnthropic, "claude-haiku-4-5", nil,
+		).WithSummarizer(sz).
+			WithCompaction(nil, 0).
+			WithAvailableModels(map[string]struct{}{oaiModel: {}})
+
+		ctx := authedCtx(uuid.New().String())
+
+		rec1 := httptest.NewRecorder()
+		req1 := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(""))
+		require.NoError(t, svc.ProxyOpenAIChatCompletion(ctx, compactionHandoverTurnOpenAI(t, 9), rec1, req1))
+		require.Equal(t, oaiModel, rec1.Header().Get(proxy.HeaderRouterModel),
+			"turn 1 must stay on the non-Anthropic pin")
+		require.Equal(t, int32(0), sz.calls.Load(),
+			"first observation must not fire compaction handover")
+
+		rec2 := httptest.NewRecorder()
+		req2 := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(""))
+		require.NoError(t, svc.ProxyOpenAIChatCompletion(ctx, compactionHandoverTurnOpenAI(t, 3), rec2, req2))
+		require.Equal(t, oaiModel, rec2.Header().Get(proxy.HeaderRouterModel),
+			"turn 2 must stay on the non-Anthropic pin so handover is eligible")
+		assert.GreaterOrEqual(t, sz.calls.Load(), int32(1),
+			"OpenAI path must invoke the summarizer via runCompactionHandover on a 9→3 trim (#791)")
+	})
+}
+
 // Runaway-tool-call escape hatch: when the prior turn saturated the output
 // cap, the pinned model is excluded and treated as missing before the scorer
 // runs. Without this, Claude Code's auto-continue locks the session into the


### PR DESCRIPTION
Fixes #791.

## Summary

`ProxyOpenAIChatCompletion` never called `runCompactionHandover`, even
though the shared `runTurnLoop` already detects the exact trigger condition
(`PrefixTrimmed`) that `ProxyMessages` uses to fire it. This PR ports the
same consumer, plus its billing, to the OpenAI path.

## Background / root cause

`runTurnLoop`'s `compactionTracker.checkAndRecord`
(`internal/proxy/no_progress.go`) detects two shapes of client-side history
trimming by comparing each turn's message count and tool-call count to the
last observation for the same session: full compaction (message count drops
sharply from a substantial conversation, gated at
`compactionMinHistoryMessages = 8`) and rolling-window trimming (message
count flat, tool-call count shrinks). Either sets `routeRes.PrefixTrimmed`,
computed pre-routing and shared by both `ProxyMessages` and
`ProxyOpenAIChatCompletion` — both already read it for planner cold-pin /
free-switch pricing.

Only `ProxyMessages` (pre-fix) consumed it *post-routing* to protect
correctness, not just cost. PR #298 introduced this after a real production
incident: Claude Code's context compaction dropped a completed Edit and its
`tool_result` from history, and the non-Anthropic model serving that
session (DeepSeek) had no record the edit had happened — it re-applied the
same edit. `runCompactionHandover` rewrites the envelope with a summary of
the elided work before dispatch, specifically for the STAY-on-non-Anthropic
case (a SWITCH turn gets its own handover summarizer via the turn loop
already).

`ProxyOpenAIChatCompletion` had zero references to `PrefixTrimmed` or
`runCompactionHandover` post-routing. It got `maybeCompact` (the *separate*,
proactive, pre-routing feature that prevents context-window overflow) via
PR #644 — which is a different mechanism entirely and doesn't address this.
For an OpenAI-wire session pinned to a non-Anthropic model that compacts
its own history mid-session, the router forwarded the already-trimmed
history raw, with no injected "prior work" summary — the same failure
shape #298 fixed for Messages, just unaddressed on this sibling surface.

## What changed

In `ProxyOpenAIChatCompletion` (`internal/proxy/service.go`):

1. **New guard, mirroring `ProxyMessages` exactly**, with one addition:

```go
compactionHandoverRan := false
var compactionHandoverOutcome handoverOutcome
if !responsesPassthrough && decision.Provider != providers.ProviderAnthropic &&
   !routeRes.HardPinned && !routeRes.Handover.Invoked && !compResOAI.Applied &&
   routeRes.PrefixTrimmed {
    log.Info("Context trimming detected on non-Anthropic route; rewriting context with handover summary", ...)
    compactionHandoverOutcome = s.runCompactionHandover(ctx, env, r.Header, decision.Model)
    compactionHandoverRan = true
}
```

The `!responsesPassthrough` clause is new relative to the Messages guard —
Codex Responses passthrough bodies are forwarded verbatim by design
elsewhere in this function, and should stay that way rather than getting
rewritten with a handover summary.

2. **`cacheEligible` updated** to exclude `compactionHandoverRan`, matching
   the existing Messages-path comment/rationale: a handover rewrite means
   the routing decision's embedding predates the rewrite, so caching under
   that embedding would be wrong.

3. **Billing wired**, verified as a structural match (not just an
   equivalent outcome) against the Messages-path block at
   `service.go:3023` — same `DebitInferenceParams` construction, same
   `_compaction_summary` request-ID suffix, same guard shape:

```go
if compactionHandoverOutcome.Invoked && !compactionHandoverOutcome.FallbackToFullHistory {
    sumUsage := compactionHandoverOutcome.SummaryUsage
    if sumUsage.Model != "" && (sumUsage.InputTokens > 0 || sumUsage.OutputTokens > 0) {
        // ... identical to ProxyMessages' block
    }
}
```

4. **`runCompactionHandover` itself is untouched.** #791's investigation
   confirmed the summarizer already accepts OpenAI-format envelopes end to
   end:
   - `buildSummaryRequestBody` → `env.PrepareAnthropic` (`handover.go:221-222`)
   - `PrepareAnthropic` handles `FormatOpenAI` via `buildAnthropicFromOpenAI`
     (`emit_anthropic.go:21-25`)
   - `RewriteForHandover` already has an OpenAI case (`translate/handover.go`)

   This confirmed it as a call-site wiring gap, not a missing translation
   layer — so this PR is scoped to `service.go` only.

## Commits

1. `5b705ed` — `TestService_CompactionHandover_OpenAIParityWithMessages`,
   asserting the desired post-fix behavior (summarizer invoked on OpenAI,
   matching Messages). Confirmed failing against pre-fix code for the right
   reason: the trim was correctly detected
   (`"turnloop detected client history trim"` in logs) but the summarizer
   was never called (`sz.calls == 0`).
2. `9c5f0c7` — the fix described above. Test passes after.

## Testing

- New test sends an identical 9-message → 3-message trim sequence (same
  session: same API key, same first user message, per `DeriveSessionKey`)
  through both `ProxyMessages` and `ProxyOpenAIChatCompletion` against a
  real `*Service` with stub providers and a counting stub summarizer (no
  network calls). Turn 1 (first observation, nothing to compare against)
  correctly shows zero invocations on both surfaces — confirms the trigger
  is genuinely the turn-2 count drop, not incidental to message shape or
  turn count alone. Turn 2 now shows `sz.calls >= 1` on both surfaces.
- `go test ./internal/proxy/... -count=1` — clean, including all existing
  OpenAI-path and compaction-related tests (no regressions).
- `make check` — clean.

## Known, deliberately unaddressed

- **Gemini has the same missing consumer**, but fixing it isn't a matching
  wiring-only change: #755 already tracks that `ProviderSummarizer` /
  `PrepareAnthropic` can't ingest Gemini-format envelopes at all yet — a
  translation-layer gap, not just a missing call site. Gemini's compaction
  handover should wait until #755 lands; happy to pick it up at that point.
- This PR doesn't change detection (`compactionTracker.checkAndRecord`)
  or the proactive `maybeCompact` path — both already work identically on
  OpenAI (ported by #644) and Messages. Only the reactive, post-routing
  consumer was missing.

## Related (from #791)

- #298 — introduced `runCompactionHandover`, Messages-only at the time,
  after the DeepSeek duplicate-edit production incident this PR closes the
  parity gap on.
- #644 — ported the separate `maybeCompact` feature to OpenAI; didn't
  attempt this consumer (different feature, not an interrupted port of the
  same one).
- #755 — the Gemini equivalent; harder problem, left for after that lands.
- #471 — an LRU race in the compaction/no-progress tracker itself,
  unrelated to this missing call site.