### PR TITLE
fix(proxy): bypass engages through installation excluded_models

### DIFF
--- a/internal/proxy/context_overflow_internal_test.go
+++ b/internal/proxy/context_overflow_internal_test.go
@@ -75,14 +75,10 @@ func TestExcludeContextOverflowModels_SignatureSavingsOnlyForStrippingTargets(t 
 	assert.False(t, kimiExcluded, "stripping target must not be denylisted")
 }
 
-// TestSafetyExcludedModels_CatchesPolicyExcludedOverflow is the regression for
-// the bypass-safety hole: safetyExcludedModels must denylist a model that
-// overflows the context window even when that model is ALSO in the installation
-// excluded_models set. The routing-path overflow filter seeds excluded_models as
-// its base and skips anything already in it, so the both-excluded model never
-// reaches the routing denylist — but the bypass gate still has to block it, or a
-// pass-through turn 400s on the subscription. safetyExcludedModels re-runs the
-// filter against an empty base to close that gap.
+// TestSafetyExcludedModels_CatchesPolicyExcludedOverflow guards the bypass
+// gap: the routing-path filter skips models already in excluded_models, so a
+// both-policy-and-overflow model never lands on the routing denylist. The
+// safety set re-runs against an empty base to close that gap.
 func TestSafetyExcludedModels_CatchesPolicyExcludedOverflow(t *testing.T) {
 	// A body large enough that ContextOverflowTokenEstimate (len/6) plus the
 	// output reserve exceeds haiku's 200K window. ~1.3MB / 6 ≈ 217K > 200K.

--- a/internal/proxy/context_overflow_internal_test.go
+++ b/internal/proxy/context_overflow_internal_test.go
@@ -1,9 +1,13 @@
 package proxy
 
 import (
+	"strings"
 	"testing"
 
+	"workweave/router/internal/translate"
+
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // TestContextWindowForRequest_ExtendedContextModelsReport1M is the premise for
@@ -69,6 +73,41 @@ func TestExcludeContextOverflowModels_SignatureSavingsOnlyForStrippingTargets(t 
 	assert.Contains(t, overflowed, "claude-haiku-4-5", "Anthropic target keeps signatures, so the savings do not apply and it overflows 200K")
 	_, kimiExcluded := out["moonshotai/kimi-k2.7"]
 	assert.False(t, kimiExcluded, "stripping target must not be denylisted")
+}
+
+// TestSafetyExcludedModels_CatchesPolicyExcludedOverflow is the regression for
+// the bypass-safety hole: safetyExcludedModels must denylist a model that
+// overflows the context window even when that model is ALSO in the installation
+// excluded_models set. The routing-path overflow filter seeds excluded_models as
+// its base and skips anything already in it, so the both-excluded model never
+// reaches the routing denylist — but the bypass gate still has to block it, or a
+// pass-through turn 400s on the subscription. safetyExcludedModels re-runs the
+// filter against an empty base to close that gap.
+func TestSafetyExcludedModels_CatchesPolicyExcludedOverflow(t *testing.T) {
+	// A body large enough that ContextOverflowTokenEstimate (len/6) plus the
+	// output reserve exceeds haiku's 200K window. ~1.3MB / 6 ≈ 217K > 200K.
+	big := strings.Repeat("x", 1_300_000)
+	env, err := translate.ParseAnthropic([]byte(`{"model":"claude-haiku-4-5","messages":[{"role":"user","content":"` + big + `"}]}`))
+	require.NoError(t, err)
+
+	// haiku-4-5 is a 200K-only model (no extended-context beta), so the big body
+	// overflows it. It is also the requested model AND policy-excluded here.
+	s := &Service{availableModels: map[string]struct{}{"claude-haiku-4-5": {}}}
+
+	// The routing-path filter, seeded with the policy exclusion, skips haiku (it
+	// is already excluded) — so the overflow denylist it returns is empty.
+	_, routingOverflowed := excludeContextOverflowModels(
+		env.ContextOverflowTokenEstimate(), env.SignatureTokenSavings(), 8_000,
+		map[string]struct{}{"claude-haiku-4-5": {}}, s.availableModels,
+	)
+	assert.NotContains(t, routingOverflowed, "claude-haiku-4-5",
+		"the routing filter skips a policy-excluded model — this is the gap safetyExcludedModels must close")
+
+	// safetyExcludedModels re-runs against an empty base, so it DOES catch the
+	// overflow regardless of policy exclusion.
+	safety := s.safetyExcludedModels(env, 8_000)
+	_, blocked := safety["claude-haiku-4-5"]
+	assert.True(t, blocked, "a policy-excluded model that also overflows must land in the safety set so bypass blocks it")
 }
 
 // TestShouldEnableExtendedContext gates the 1M-context beta on request size:

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -560,18 +560,22 @@ func routingKnobsForRequest(ctx context.Context) *router.Overrides {
 	return nil
 }
 
-// safetyExcludedSet collects the request-time safety exclusions (context-window
-// overflow and gemini-unsigned-history) into a set. These are hard constraints a
-// model cannot satisfy on any credential, distinct from the installation's
-// configured excluded_models routing policy. The usage-bypass gate consults this
-// set so opting into pass-through overrides policy exclusions but never a hard
-// safety filter. Returns nil when neither filter fired.
-func safetyExcludedSet(ctxOverflowed, geminiUnsigned []string) map[string]struct{} {
-	if len(ctxOverflowed) == 0 && len(geminiUnsigned) == 0 {
+// safetyExcludedModels returns the request-time safety-exclusion set: the models
+// that context-overflow or gemini-unsigned-history filtering bar regardless of
+// installation policy. It re-runs both filters against an EMPTY base rather than
+// reusing the routing-path lists, because those filters skip models already in
+// excluded_models — so a model that is both policy-excluded AND over capacity
+// would be absent from the routing lists yet must still block usage bypass (it
+// would 400 on the subscription just as it would when routed). Returns nil when
+// neither filter fires.
+func (s *Service) safetyExcludedModels(env *translate.RequestEnvelope, outputReserve int) map[string]struct{} {
+	_, overflowed := excludeContextOverflowModels(env.ContextOverflowTokenEstimate(), env.SignatureTokenSavings(), outputReserve, nil, s.availableModels)
+	_, geminiUnsigned := excludeGemini3xOnUnsignedHistory(env, nil, s.availableModels)
+	if len(overflowed) == 0 && len(geminiUnsigned) == 0 {
 		return nil
 	}
-	out := make(map[string]struct{}, len(ctxOverflowed)+len(geminiUnsigned))
-	for _, m := range ctxOverflowed {
+	out := make(map[string]struct{}, len(overflowed)+len(geminiUnsigned))
+	for _, m := range overflowed {
 		out[m] = struct{}{}
 	}
 	for _, m := range geminiUnsigned {
@@ -2156,7 +2160,7 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 		ClientSessionID:      env.ClientSessionID(),
 		EnabledProviders:     enabledProviders,
 		ExcludedModels:       excluded,
-		SafetyExcludedModels: safetyExcludedSet(ctxOverflowed, geminiUnsigned),
+		SafetyExcludedModels: s.safetyExcludedModels(env, outputReserve),
 		PreferredModels:      s.preferredModelsForRequest(ctx),
 		RoutingKnobs:         routingKnobsForRequest(ctx),
 	}
@@ -4227,7 +4231,7 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 		ClientSessionID:      env.ClientSessionID(),
 		EnabledProviders:     enabledProviders,
 		ExcludedModels:       excludedOAI,
-		SafetyExcludedModels: safetyExcludedSet(ctxOverflowedOAI, geminiUnsignedOAI),
+		SafetyExcludedModels: s.safetyExcludedModels(env, outputReserveOAI),
 		PreferredModels:      s.preferredModelsForRequest(ctx),
 		RoutingKnobs:         routingKnobsForRequest(ctx),
 	}

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -560,6 +560,26 @@ func routingKnobsForRequest(ctx context.Context) *router.Overrides {
 	return nil
 }
 
+// safetyExcludedSet collects the request-time safety exclusions (context-window
+// overflow and gemini-unsigned-history) into a set. These are hard constraints a
+// model cannot satisfy on any credential, distinct from the installation's
+// configured excluded_models routing policy. The usage-bypass gate consults this
+// set so opting into pass-through overrides policy exclusions but never a hard
+// safety filter. Returns nil when neither filter fired.
+func safetyExcludedSet(ctxOverflowed, geminiUnsigned []string) map[string]struct{} {
+	if len(ctxOverflowed) == 0 && len(geminiUnsigned) == 0 {
+		return nil
+	}
+	out := make(map[string]struct{}, len(ctxOverflowed)+len(geminiUnsigned))
+	for _, m := range ctxOverflowed {
+		out[m] = struct{}{}
+	}
+	for _, m := range geminiUnsigned {
+		out[m] = struct{}{}
+	}
+	return out
+}
+
 // excludedModelsForRequest returns the request's model exclusion set.
 // Env override wins; otherwise the installation list is converted to a set.
 func (s *Service) excludedModelsForRequest(ctx context.Context) map[string]struct{} {
@@ -2131,13 +2151,14 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 		OrganizationID:          externalID,
 		// Keep this tied to client-visible history so a later feedback command
 		// can correlate with the route even if local compaction rewrites env.
-		FeedbackKey:      hex.EncodeToString(sessionKey[:]),
-		FeedbackRole:     roleForTier(catalog.TierFor(feats.Model)),
-		ClientSessionID:  env.ClientSessionID(),
-		EnabledProviders: enabledProviders,
-		ExcludedModels:   excluded,
-		PreferredModels:  s.preferredModelsForRequest(ctx),
-		RoutingKnobs:     routingKnobsForRequest(ctx),
+		FeedbackKey:          hex.EncodeToString(sessionKey[:]),
+		FeedbackRole:         roleForTier(catalog.TierFor(feats.Model)),
+		ClientSessionID:      env.ClientSessionID(),
+		EnabledProviders:     enabledProviders,
+		ExcludedModels:       excluded,
+		SafetyExcludedModels: safetyExcludedSet(ctxOverflowed, geminiUnsigned),
+		PreferredModels:      s.preferredModelsForRequest(ctx),
+		RoutingKnobs:         routingKnobsForRequest(ctx),
 	}
 	if installationID != uuid.Nil {
 		req.InstallationID = installationID.String()
@@ -4201,13 +4222,14 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 		AvailableTools:       availableToolsForRouting(env),
 		// Keep this tied to client-visible history so a later feedback command
 		// can correlate with the route even if local compaction rewrites env.
-		FeedbackKey:      hex.EncodeToString(sessionKey[:]),
-		FeedbackRole:     roleForTier(catalog.TierFor(feats.Model)),
-		ClientSessionID:  env.ClientSessionID(),
-		EnabledProviders: enabledProviders,
-		ExcludedModels:   excludedOAI,
-		PreferredModels:  s.preferredModelsForRequest(ctx),
-		RoutingKnobs:     routingKnobsForRequest(ctx),
+		FeedbackKey:          hex.EncodeToString(sessionKey[:]),
+		FeedbackRole:         roleForTier(catalog.TierFor(feats.Model)),
+		ClientSessionID:      env.ClientSessionID(),
+		EnabledProviders:     enabledProviders,
+		ExcludedModels:       excludedOAI,
+		SafetyExcludedModels: safetyExcludedSet(ctxOverflowedOAI, geminiUnsignedOAI),
+		PreferredModels:      s.preferredModelsForRequest(ctx),
+		RoutingKnobs:         routingKnobsForRequest(ctx),
 	}
 	routeStart := time.Now()
 	routeRes, err := s.runTurnLoop(ctx, env, feats, apiKeyID, installationID, subAgentHint, r.Header, routeRequest)

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -560,14 +560,12 @@ func routingKnobsForRequest(ctx context.Context) *router.Overrides {
 	return nil
 }
 
-// safetyExcludedModels returns the request-time safety-exclusion set: the models
-// that context-overflow or gemini-unsigned-history filtering bar regardless of
-// installation policy. It re-runs both filters against an EMPTY base rather than
-// reusing the routing-path lists, because those filters skip models already in
-// excluded_models — so a model that is both policy-excluded AND over capacity
-// would be absent from the routing lists yet must still block usage bypass (it
-// would 400 on the subscription just as it would when routed). Returns nil when
-// neither filter fires.
+// safetyExcludedModels returns the hard request-time safety exclusion set
+// (context-overflow + gemini-unsigned-history). It re-runs both filters
+// against an EMPTY base — the routing-path filters skip models already in
+// excluded_models, so a policy-excluded overflow model would be absent from
+// those lists yet must still block bypass (it would 400 on the subscription).
+// Returns nil when neither filter fires.
 func (s *Service) safetyExcludedModels(env *translate.RequestEnvelope, outputReserve int) map[string]struct{} {
 	_, overflowed := excludeContextOverflowModels(env.ContextOverflowTokenEstimate(), env.SignatureTokenSavings(), outputReserve, nil, s.availableModels)
 	_, geminiUnsigned := excludeGemini3xOnUnsignedHistory(env, nil, s.availableModels)

--- a/internal/proxy/turnloop.go
+++ b/internal/proxy/turnloop.go
@@ -24,6 +24,19 @@ import (
 	"github.com/google/uuid"
 )
 
+// addToSet returns set with model added, copying first so a caller-shared or nil
+// map is never mutated in place (req.SafetyExcludedModels may be shared across
+// requests or nil when no safety filter fired). Returns a fresh single-entry map
+// when set is nil/empty.
+func addToSet(set map[string]struct{}, model string) map[string]struct{} {
+	out := make(map[string]struct{}, len(set)+1)
+	for k := range set {
+		out[k] = struct{}{}
+	}
+	out[model] = struct{}{}
+	return out
+}
+
 // installationIDFromContext reads the installation ID stashed by auth
 // middleware. Returns uuid.Nil (which skips the async pin upsert) if missing or invalid.
 func installationIDFromContext(ctx context.Context) uuid.UUID {
@@ -458,6 +471,12 @@ func (s *Service) runTurnLoop(
 		}
 		excluded[maxedModel] = struct{}{}
 		req.ExcludedModels = excluded
+		// Also bar it from usage bypass: the maxed-out exclusion is a hard
+		// loop-breaking constraint, not an installation preference, so it belongs
+		// in the set the bypass gate honors. Without this, an auto-continue turn
+		// re-requesting the saturated subscription model would bypass straight back
+		// to it and reopen the degenerate max-output loop this guard breaks.
+		req.SafetyExcludedModels = addToSet(req.SafetyExcludedModels, maxedModel)
 		pinFound = false
 		pin = sessionpin.Pin{}
 	}
@@ -475,6 +494,9 @@ func (s *Service) runTurnLoop(
 		}
 		excluded[maxedModel] = struct{}{}
 		req.ExcludedModels = excluded
+		// See the active-pin path above: the maxed-out model must also block usage
+		// bypass, or an auto-continue turn re-requesting it reopens the loop.
+		req.SafetyExcludedModels = addToSet(req.SafetyExcludedModels, maxedModel)
 	}
 
 	// If the pre-filter excluded the pinned model for context overflow,
@@ -525,11 +547,7 @@ func (s *Service) runTurnLoop(
 					}
 					// Keep SafetyExcludedModels consistent: the fit-check just
 					// cleared this model's context-overflow exclusion, so it must
-					// not linger in the safety set and refuse usage bypass for the
-					// pinned model at usageBypassDecision below. The two are computed
-					// from the same estimate/window, so in practice pin.Model is
-					// absent here — this makes the invariant explicit and robust if
-					// the two fit formulas ever drift.
+					// not linger in the safety set and block usage bypass.
 					delete(req.SafetyExcludedModels, pin.Model)
 				}
 				log.Info("Session pin preserved despite context-window pre-filter exclusion",

--- a/internal/proxy/turnloop.go
+++ b/internal/proxy/turnloop.go
@@ -523,6 +523,14 @@ func (s *Service) runTurnLoop(
 						}
 						req.ExcludedModels = pruned
 					}
+					// Keep SafetyExcludedModels consistent: the fit-check just
+					// cleared this model's context-overflow exclusion, so it must
+					// not linger in the safety set and refuse usage bypass for the
+					// pinned model at usageBypassDecision below. The two are computed
+					// from the same estimate/window, so in practice pin.Model is
+					// absent here — this makes the invariant explicit and robust if
+					// the two fit formulas ever drift.
+					delete(req.SafetyExcludedModels, pin.Model)
 				}
 				log.Info("Session pin preserved despite context-window pre-filter exclusion",
 					"pin_model", pin.Model,

--- a/internal/proxy/turnloop.go
+++ b/internal/proxy/turnloop.go
@@ -24,10 +24,8 @@ import (
 	"github.com/google/uuid"
 )
 
-// addToSet returns set with model added, copying first so a caller-shared or nil
-// map is never mutated in place (req.SafetyExcludedModels may be shared across
-// requests or nil when no safety filter fired). Returns a fresh single-entry map
-// when set is nil/empty.
+// addToSet returns set with model added. Copies before mutating so a
+// caller-shared or nil map is never modified in place.
 func addToSet(set map[string]struct{}, model string) map[string]struct{} {
 	out := make(map[string]struct{}, len(set)+1)
 	for k := range set {
@@ -471,11 +469,9 @@ func (s *Service) runTurnLoop(
 		}
 		excluded[maxedModel] = struct{}{}
 		req.ExcludedModels = excluded
-		// Also bar it from usage bypass: the maxed-out exclusion is a hard
-		// loop-breaking constraint, not an installation preference, so it belongs
-		// in the set the bypass gate honors. Without this, an auto-continue turn
-		// re-requesting the saturated subscription model would bypass straight back
-		// to it and reopen the degenerate max-output loop this guard breaks.
+		// Also bar it from usage bypass — the maxed-out exclusion is a hard
+		// loop-breaking constraint; without it, an auto-continue turn re-requesting
+		// the saturated model would bypass back to it and reopen the loop.
 		req.SafetyExcludedModels = addToSet(req.SafetyExcludedModels, maxedModel)
 		pinFound = false
 		pin = sessionpin.Pin{}

--- a/internal/proxy/usage_bypass.go
+++ b/internal/proxy/usage_bypass.go
@@ -84,7 +84,14 @@ func (s *Service) usageBypassEngaged(ctx context.Context, headers http.Header, r
 			return "", false
 		}
 	}
-	if _, excluded := req.ExcludedModels[model]; excluded {
+	// Consult only the safety-exclusion subset (context-overflow, gemini-unsigned),
+	// not the full ExcludedModels union. The installation's configured
+	// excluded_models is a routing-preference policy the caller can override by
+	// opting into usage bypass ("strict pass-through until low"); serving their
+	// own subscription for a deprioritized model costs the router nothing and is
+	// exactly what the bypass toggle promises. A hard safety exclusion still
+	// disengages the gate — that model can't accept this request on any credential.
+	if _, excluded := req.SafetyExcludedModels[model]; excluded {
 		return "", false
 	}
 	if token == "" {

--- a/internal/proxy/usage_bypass.go
+++ b/internal/proxy/usage_bypass.go
@@ -84,13 +84,10 @@ func (s *Service) usageBypassEngaged(ctx context.Context, headers http.Header, r
 			return "", false
 		}
 	}
-	// Consult only the safety-exclusion subset (context-overflow, gemini-unsigned),
-	// not the full ExcludedModels union. The installation's configured
-	// excluded_models is a routing-preference policy the caller can override by
-	// opting into usage bypass ("strict pass-through until low"); serving their
-	// own subscription for a deprioritized model costs the router nothing and is
-	// exactly what the bypass toggle promises. A hard safety exclusion still
-	// disengages the gate — that model can't accept this request on any credential.
+	// Consult SafetyExcludedModels (hard request-time constraints), not the full
+	// ExcludedModels union — the installation's excluded_models is a routing
+	// preference bypass is allowed to override; context-overflow and
+	// gemini-unsigned are not (that model can't accept the request on any credential).
 	if _, excluded := req.SafetyExcludedModels[model]; excluded {
 		return "", false
 	}

--- a/internal/proxy/usage_bypass.go
+++ b/internal/proxy/usage_bypass.go
@@ -84,10 +84,9 @@ func (s *Service) usageBypassEngaged(ctx context.Context, headers http.Header, r
 			return "", false
 		}
 	}
-	// Consult SafetyExcludedModels (hard request-time constraints), not the full
-	// ExcludedModels union — the installation's excluded_models is a routing
-	// preference bypass is allowed to override; context-overflow and
-	// gemini-unsigned are not (that model can't accept the request on any credential).
+	// Use SafetyExcludedModels (hard constraints: context-overflow, gemini-unsigned),
+	// not ExcludedModels — the installation's excluded_models is a routing preference
+	// bypass may override; a model that can't accept the request on any credential cannot.
 	if _, excluded := req.SafetyExcludedModels[model]; excluded {
 		return "", false
 	}

--- a/internal/proxy/usage_bypass_internal_test.go
+++ b/internal/proxy/usage_bypass_internal_test.go
@@ -109,13 +109,10 @@ func TestUsageBypassDecision_CodexSubscriptionPreservesRequestedModel(t *testing
 }
 
 // TestUsageBypassEngaged_SafetyExclusionBlocks_PolicyExclusionDoesNot pins the
-// exclusion contract of the bypass gate: the installation's configured
-// excluded_models (carried in ExcludedModels) must NOT block bypass, but a hard
-// safety exclusion (context-overflow / gemini-unsigned, carried in
-// SafetyExcludedModels) MUST. The both-excluded case is the load-bearing one —
-// a model on the installation deny list that ALSO can't fit the context window
-// must stay blocked, because it would 400 on the subscription just as it would
-// when routed.
+// exclusion contract: ExcludedModels (policy) must NOT block bypass;
+// SafetyExcludedModels (context-overflow / gemini-unsigned) MUST. The
+// both-excluded subcase is load-bearing — a model that can't fit the context
+// window stays blocked even when also policy-excluded.
 func TestUsageBypassEngaged_SafetyExclusionBlocks_PolicyExclusionDoesNot(t *testing.T) {
 	const token = "sk-ant-oat01-test-subscription-token"
 	const model = "claude-sonnet-4-6"

--- a/internal/proxy/usage_bypass_internal_test.go
+++ b/internal/proxy/usage_bypass_internal_test.go
@@ -111,8 +111,7 @@ func TestUsageBypassDecision_CodexSubscriptionPreservesRequestedModel(t *testing
 // TestUsageBypassEngaged_SafetyExclusionBlocks_PolicyExclusionDoesNot pins the
 // exclusion contract: ExcludedModels (policy) must NOT block bypass;
 // SafetyExcludedModels (context-overflow / gemini-unsigned) MUST. The
-// both-excluded subcase is load-bearing — a model that can't fit the context
-// window stays blocked even when also policy-excluded.
+// both-excluded subcase is load-bearing: context overflow stays blocked even when also policy-excluded.
 func TestUsageBypassEngaged_SafetyExclusionBlocks_PolicyExclusionDoesNot(t *testing.T) {
 	const token = "sk-ant-oat01-test-subscription-token"
 	const model = "claude-sonnet-4-6"

--- a/internal/proxy/usage_bypass_internal_test.go
+++ b/internal/proxy/usage_bypass_internal_test.go
@@ -108,6 +108,67 @@ func TestUsageBypassDecision_CodexSubscriptionPreservesRequestedModel(t *testing
 	}, decision)
 }
 
+// TestUsageBypassEngaged_SafetyExclusionBlocks_PolicyExclusionDoesNot pins the
+// exclusion contract of the bypass gate: the installation's configured
+// excluded_models (carried in ExcludedModels) must NOT block bypass, but a hard
+// safety exclusion (context-overflow / gemini-unsigned, carried in
+// SafetyExcludedModels) MUST. The both-excluded case is the load-bearing one —
+// a model on the installation deny list that ALSO can't fit the context window
+// must stay blocked, because it would 400 on the subscription just as it would
+// when routed.
+func TestUsageBypassEngaged_SafetyExclusionBlocks_PolicyExclusionDoesNot(t *testing.T) {
+	const token = "sk-ant-oat01-test-subscription-token"
+	const model = "claude-sonnet-4-6"
+	threshold := 0.80
+	newObs := func() *usage.Observer {
+		obs := usage.NewObserver([]byte("salt"), 10*time.Minute, time.Now)
+		obs.Record(obs.Key([]byte(token)), usage.Snapshot{
+			Primary: usage.Window{UsedPercent: 0.20, WindowMinutes: 300},
+		})
+		return obs
+	}
+	baseCtx := func() context.Context {
+		ctx := context.WithValue(context.Background(), AnthropicSubscriptionContextKey{}, token)
+		return context.WithValue(ctx, InstallationUsageBypassContextKey{}, UsageBypassConfig{
+			Enabled:   true,
+			Threshold: &threshold,
+		})
+	}
+	enabled := map[string]struct{}{providers.ProviderAnthropic: {}}
+
+	t.Run("installation excluded_models does not block bypass", func(t *testing.T) {
+		svc := &Service{usageObserver: newObs()}
+		provider, ok := svc.usageBypassEngaged(baseCtx(), http.Header{}, router.Request{
+			RequestedModel:   model,
+			EnabledProviders: enabled,
+			ExcludedModels:   map[string]struct{}{model: {}},
+		})
+		assert.True(t, ok, "an installation-excluded model must still bypass under threshold")
+		assert.Equal(t, providers.ProviderAnthropic, provider)
+	})
+
+	t.Run("safety exclusion blocks bypass", func(t *testing.T) {
+		svc := &Service{usageObserver: newObs()}
+		_, ok := svc.usageBypassEngaged(baseCtx(), http.Header{}, router.Request{
+			RequestedModel:       model,
+			EnabledProviders:     enabled,
+			SafetyExcludedModels: map[string]struct{}{model: {}},
+		})
+		assert.False(t, ok, "a safety-excluded model (context overflow / gemini-unsigned) must block bypass")
+	})
+
+	t.Run("both excluded: safety exclusion still blocks", func(t *testing.T) {
+		svc := &Service{usageObserver: newObs()}
+		_, ok := svc.usageBypassEngaged(baseCtx(), http.Header{}, router.Request{
+			RequestedModel:       model,
+			EnabledProviders:     enabled,
+			ExcludedModels:       map[string]struct{}{model: {}},
+			SafetyExcludedModels: map[string]struct{}{model: {}},
+		})
+		assert.False(t, ok, "a model that is both policy- and safety-excluded must stay blocked — it would 400 on the subscription too")
+	})
+}
+
 func TestUsageBypass_PreservesSwitchHistory(t *testing.T) {
 	const token = "sk-ant-oat01-test-subscription-token"
 	threshold := 0.80

--- a/internal/proxy/usage_bypass_test.go
+++ b/internal/proxy/usage_bypass_test.go
@@ -174,17 +174,23 @@ func TestUsageBypass_NoSubscription_EngagesRouting(t *testing.T) {
 	assert.Equal(t, 1, fr.routeCalls, "no subscription credential means nothing to bypass onto — scorer must run")
 }
 
-// TestUsageBypass_ExcludedModel_EngagesRouting: a model on the installation's
-// deny list must force routing even under threshold, so the bypass can't serve
-// a policy-blocked model.
-func TestUsageBypass_ExcludedModel_EngagesRouting(t *testing.T) {
-	svc, fr, _ := bypassFixture(t, 0.20)
+// TestUsageBypass_InstallationExcludedModel_StillBypasses: the installation's
+// configured excluded_models is a routing-preference policy, not a hard block.
+// A caller who opted into usage bypass ("strict pass-through until low") must be
+// served on their own subscription for the requested model even when that model
+// is on the installation deny list — serving their own quota costs the router
+// nothing, and honoring the exclusion here would silently burn credits on a
+// substituted model, which is exactly the bug this guards against.
+func TestUsageBypass_InstallationExcludedModel_StillBypasses(t *testing.T) {
+	svc, fr, p := bypassFixture(t, 0.20)
 	svc = svc.WithExcludedModelsOverride([]string{bypassRequestedMdl})
 	rec, req, body := bypassRequest(t)
 
 	require.NoError(t, svc.ProxyMessages(bypassCtx(0.80), body, rec, req))
 
-	assert.Equal(t, 1, fr.routeCalls, "an excluded requested model must force routing even under threshold")
+	assert.Equal(t, 0, fr.routeCalls, "an installation-excluded model must still bypass — the exclusion is a routing preference, not a hard block")
+	require.Len(t, p.proxyBodies, 1, "the requested model must be dispatched to the subscription exactly once")
+	assert.Equal(t, bypassRequestedMdl, rec.Header().Get("x-router-model"), "bypass must serve the requested model, not a substituted one")
 }
 
 // TestUsageBypass_ToolResult_BeatsStalePin: a session that previously routed

--- a/internal/proxy/usage_bypass_test.go
+++ b/internal/proxy/usage_bypass_test.go
@@ -174,13 +174,11 @@ func TestUsageBypass_NoSubscription_EngagesRouting(t *testing.T) {
 	assert.Equal(t, 1, fr.routeCalls, "no subscription credential means nothing to bypass onto — scorer must run")
 }
 
-// TestUsageBypass_InstallationExcludedModel_StillBypasses: the installation's
-// configured excluded_models is a routing-preference policy, not a hard block.
-// A caller who opted into usage bypass ("strict pass-through until low") must be
-// served on their own subscription for the requested model even when that model
-// is on the installation deny list — serving their own quota costs the router
-// nothing, and honoring the exclusion here would silently burn credits on a
-// substituted model, which is exactly the bug this guards against.
+// TestUsageBypass_InstallationExcludedModel_StillBypasses: installation
+// excluded_models is a routing preference, not a hard block. A bypass-enabled
+// caller must be served on their own subscription even for a policy-excluded
+// model — honoring the exclusion here silently burns credits on a substituted
+// model, the bug this guards against.
 func TestUsageBypass_InstallationExcludedModel_StillBypasses(t *testing.T) {
 	svc, fr, p := bypassFixture(t, 0.20)
 	svc = svc.WithExcludedModelsOverride([]string{bypassRequestedMdl})

--- a/internal/proxy/usage_bypass_test.go
+++ b/internal/proxy/usage_bypass_test.go
@@ -176,9 +176,7 @@ func TestUsageBypass_NoSubscription_EngagesRouting(t *testing.T) {
 
 // TestUsageBypass_InstallationExcludedModel_StillBypasses: installation
 // excluded_models is a routing preference, not a hard block. A bypass-enabled
-// caller must be served on their own subscription even for a policy-excluded
-// model — honoring the exclusion here silently burns credits on a substituted
-// model, the bug this guards against.
+// caller must be served on their own subscription even for a policy-excluded model.
 func TestUsageBypass_InstallationExcludedModel_StillBypasses(t *testing.T) {
 	svc, fr, p := bypassFixture(t, 0.20)
 	svc = svc.WithExcludedModelsOverride([]string{bypassRequestedMdl})

--- a/internal/proxy/usage_bypass_test.go
+++ b/internal/proxy/usage_bypass_test.go
@@ -191,8 +191,7 @@ func TestUsageBypass_InstallationExcludedModel_StillBypasses(t *testing.T) {
 
 // TestUsageBypass_MaxedOutModel_EngagesRouting: the maxed-out guard writes
 // the saturated model to SafetyExcludedModels so an auto-continue re-request
-// of that model falls through to the scorer instead of bypassing back to it,
-// which would reopen the degenerate max-output loop the guard breaks.
+// falls through to the scorer, preventing bypass from reopening the max-output loop.
 func TestUsageBypass_MaxedOutModel_EngagesRouting(t *testing.T) {
 	store := newFakePinStore()
 	store.hasPin = true

--- a/internal/proxy/usage_bypass_test.go
+++ b/internal/proxy/usage_bypass_test.go
@@ -189,6 +189,46 @@ func TestUsageBypass_InstallationExcludedModel_StillBypasses(t *testing.T) {
 	assert.Equal(t, bypassRequestedMdl, rec.Header().Get("x-router-model"), "bypass must serve the requested model, not a substituted one")
 }
 
+// TestUsageBypass_MaxedOutModel_EngagesRouting: the maxed-out loop-breaking
+// guard adds the saturated model to the request's safety-exclusion set, so a
+// re-request of that same subscription model on an auto-continue turn must NOT
+// bypass — it has to fall through to the scorer, or the degenerate max-output
+// loop the guard breaks reopens on the subscription. Regression for the review
+// finding that bypass, checking only SafetyExcludedModels, ignored the maxed
+// exclusion (which the guard wrote only to ExcludedModels).
+func TestUsageBypass_MaxedOutModel_EngagesRouting(t *testing.T) {
+	store := newFakePinStore()
+	store.hasPin = true
+	store.pin = sessionpin.Pin{
+		Provider:         providers.ProviderAnthropic,
+		Model:            bypassRequestedMdl, // the model the client keeps requesting
+		LastServedModel:  bypassRequestedMdl, // saturated the output cap last turn
+		Reason:           "cluster:v0.2",
+		PinnedUntil:      time.Now().Add(30 * time.Minute),
+		FirstPinnedAt:    time.Now().Add(-5 * time.Minute),
+		LastOutputTokens: 8192, // >= prevTurnMaxedOutThreshold
+		LastTurnEndedAt:  time.Now().Add(-10 * time.Second),
+	}
+	fr := &fakeRouter{decision: router.Decision{Provider: providers.ProviderAnthropic, Model: bypassScorerPickMdl, Reason: "fresh"}}
+	obs := usage.NewObserver([]byte("salt"), 10*time.Minute, time.Now)
+	obs.Record(obs.Key([]byte(bypassSubToken)), usage.Snapshot{Primary: usage.Window{UsedPercent: 0.20, WindowMinutes: 300}})
+	svc := proxy.NewService(fr, map[string]providers.Client{providers.ProviderAnthropic: &fakeProvider{}}, nil, false, nil, store, false, providers.ProviderAnthropic, bypassScorerPickMdl, nil).
+		WithSubscriptionAwareRouting(obs, 0.05, 2.0)
+
+	ctx := context.WithValue(authedCtx(uuid.New().String()), proxy.AnthropicSubscriptionContextKey{}, bypassSubToken)
+	threshold := 0.80
+	ctx = context.WithValue(ctx, proxy.InstallationUsageBypassContextKey{}, proxy.UsageBypassConfig{Enabled: true, Threshold: &threshold})
+	rec, req, body := bypassRequest(t)
+
+	require.NoError(t, svc.ProxyMessages(ctx, body, rec, req))
+
+	assert.Equal(t, 1, fr.routeCalls, "a maxed-out model must fall through to the scorer, not re-bypass and reopen the loop")
+	require.NotNil(t, fr.capturedReq)
+	assert.Contains(t, fr.capturedReq.SafetyExcludedModels, bypassRequestedMdl,
+		"the maxed-out model must be in the safety-exclusion set so the bypass gate refuses it")
+	assert.Equal(t, bypassScorerPickMdl, rec.Header().Get("x-router-model"), "scorer's pick replaces the saturated model")
+}
+
 // TestUsageBypass_ToolResult_BeatsStalePin: a session that previously routed
 // (leaving a pin) and is now under threshold must bypass CONSISTENTLY. A
 // tool_result continuation must serve the requested model via the bypass, not

--- a/internal/proxy/usage_bypass_test.go
+++ b/internal/proxy/usage_bypass_test.go
@@ -189,13 +189,10 @@ func TestUsageBypass_InstallationExcludedModel_StillBypasses(t *testing.T) {
 	assert.Equal(t, bypassRequestedMdl, rec.Header().Get("x-router-model"), "bypass must serve the requested model, not a substituted one")
 }
 
-// TestUsageBypass_MaxedOutModel_EngagesRouting: the maxed-out loop-breaking
-// guard adds the saturated model to the request's safety-exclusion set, so a
-// re-request of that same subscription model on an auto-continue turn must NOT
-// bypass — it has to fall through to the scorer, or the degenerate max-output
-// loop the guard breaks reopens on the subscription. Regression for the review
-// finding that bypass, checking only SafetyExcludedModels, ignored the maxed
-// exclusion (which the guard wrote only to ExcludedModels).
+// TestUsageBypass_MaxedOutModel_EngagesRouting: the maxed-out guard writes
+// the saturated model to SafetyExcludedModels so an auto-continue re-request
+// of that model falls through to the scorer instead of bypassing back to it,
+// which would reopen the degenerate max-output loop the guard breaks.
 func TestUsageBypass_MaxedOutModel_EngagesRouting(t *testing.T) {
 	store := newFakePinStore()
 	store.hasPin = true

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -122,7 +122,20 @@ type Request struct {
 	EnabledProviders map[string]struct{}
 	// Per-request model exclusion — nil or empty means no exclusion.
 	// If filtering empties eligible set, scorer returns ErrNoEligibleProvider.
+	// This is the full exclusion union: the installation's configured
+	// excluded_models plus the request-time safety filters (context-overflow,
+	// gemini-unsigned). The scorer honors all of it.
 	ExcludedModels map[string]struct{}
+	// SafetyExcludedModels is the subset of ExcludedModels that reflects hard,
+	// request-time constraints a model physically cannot satisfy: context-window
+	// overflow and gemini-unsigned-history filtering. It deliberately excludes
+	// the installation's configured excluded_models policy list. The subscription
+	// usage-bypass gate consults this set (not the full ExcludedModels union) so
+	// a customer who opted into strict pass-through is served on their own
+	// subscription for models they merely deprioritized via excluded_models,
+	// while a model that literally can't accept the request still blocks bypass.
+	// nil or empty means no safety exclusion.
+	SafetyExcludedModels map[string]struct{}
 	// PreferredModels is the per-installation priority ranking (index 0 =
 	// first). The scorer adds a small rank-decaying bonus to each preferred
 	// model's score — enough to win close calls, not to override a clearly

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -122,19 +122,13 @@ type Request struct {
 	EnabledProviders map[string]struct{}
 	// Per-request model exclusion — nil or empty means no exclusion.
 	// If filtering empties eligible set, scorer returns ErrNoEligibleProvider.
-	// This is the full exclusion union: the installation's configured
-	// excluded_models plus the request-time safety filters (context-overflow,
-	// gemini-unsigned). The scorer honors all of it.
+	// Full union: installation excluded_models plus request-time safety filters.
 	ExcludedModels map[string]struct{}
-	// SafetyExcludedModels is the subset of ExcludedModels that reflects hard,
-	// request-time constraints a model physically cannot satisfy: context-window
-	// overflow and gemini-unsigned-history filtering. It deliberately excludes
-	// the installation's configured excluded_models policy list. The subscription
-	// usage-bypass gate consults this set (not the full ExcludedModels union) so
-	// a customer who opted into strict pass-through is served on their own
-	// subscription for models they merely deprioritized via excluded_models,
-	// while a model that literally can't accept the request still blocks bypass.
-	// nil or empty means no safety exclusion.
+	// SafetyExcludedModels holds only the hard request-time constraints a model
+	// physically cannot satisfy: context-window overflow and gemini-unsigned
+	// history — not the installation's excluded_models policy. The bypass gate
+	// consults this so policy exclusions don't block pass-through, but physical
+	// constraints still do. nil or empty means no safety exclusion.
 	SafetyExcludedModels map[string]struct{}
 	// PreferredModels is the per-installation priority ranking (index 0 =
 	// first). The scorer adds a small rank-decaying bonus to each preferred

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -128,7 +128,7 @@ type Request struct {
 	// physically cannot satisfy: context-window overflow and gemini-unsigned
 	// history — not the installation's excluded_models policy. The bypass gate
 	// consults this so policy exclusions don't block pass-through, but physical
-	// constraints still do. nil or empty means no safety exclusion.
+	// constraints still do.
 	SafetyExcludedModels map[string]struct{}
 	// PreferredModels is the per-installation priority ranking (index 0 =
 	// first). The scorer adds a small rank-decaying bonus to each preferred


### PR DESCRIPTION
## Problem

The subscription usage-bypass gate (the "strict pass-through until low" feature) refused to engage whenever the requested model was on the installation `excluded_models` list. An org that opted into bypass but also had a stale/broad `excluded_models` policy saw every Claude turn kicked out of the gate and routed to a substituted OSS model paid by **credits** instead of served on the caller's own **subscription** — the opposite of what the toggle promises.

`usageBypassEngaged` checked `req.ExcludedModels`, which is the union of the customer's `excluded_models` policy **plus** hard request-time safety filters (context-overflow, gemini-unsigned-history). The customer's policy list was leaking into the pass-through decision.

## Fix

Split the model-exclusion set carried on `router.Request`:

- **`ExcludedModels`** (unchanged) — the full union of installation policy exclusions + request-time safety filters. The scorer continues to honor all of it.
- **`SafetyExcludedModels`** (new) — only the request-time safety filters. The bypass gate consults *this* set, so a customer who opted into pass-through is served on their own subscription for models they merely deprioritized via `excluded_models`, while a model that literally can't accept the request (context overflow) still blocks bypass.

Wired at both dispatch sites: `ProxyMessages` (Anthropic) and `ProxyOpenAIChatCompletion` (OpenAI). The Gemini path and route-preview correctly leave the new field nil — neither engages the bypass gate.

## Verified

- `wv mr tc` — typecheck clean
- `wv mr t` — all proxy and router tests pass, including:
  - **New** `TestUsageBypassEngaged_SafetyExclusionBlocks_PolicyExclusionDoesNot` — 3 subtests: policy exclusion bypasses, safety exclusion still blocks, and the load-bearing both-excluded case (a model on the deny list that ALSO overflows the window stays blocked, since it would 400 on the subscription too).
  - **Updated** `TestUsageBypass_InstallationExcludedModel_StillBypasses` (renamed from `TestUsageBypass_ExcludedModel_EngagesRouting`, asserts the new contract).
  - All existing bypass tests unchanged and passing (including `TestUsageBypass_ExcludedProvider_EngagesRouting` — provider exclusion is a separate check, untouched).
- `go vet ./...` clean
- `gofmt -l` clean

Applies universally to every installation with bypass enabled — no per-org config change.
