### PR TITLE
fix: preserve Anthropic context management fidelity

### DIFF
--- a/internal/translate/context_management_beta_test.go
+++ b/internal/translate/context_management_beta_test.go
@@ -1,0 +1,65 @@
+package translate_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"workweave/router/internal/router"
+	"workweave/router/internal/translate"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const contextManagementBody = `{"model":"claude-sonnet-5","max_tokens":1024,"messages":[{"role":"user","content":"hi"}],"context_management":{"edits":[{"type":"clear_thinking_20251015","keep":"all"}]}}`
+
+func TestContextManagement_InjectsRequiredBeta(t *testing.T) {
+	for _, target := range []string{"claude-fable-5", "claude-opus-4-8"} {
+		t.Run(target, func(t *testing.T) {
+			env, err := translate.ParseAnthropic([]byte(contextManagementBody))
+			require.NoError(t, err)
+
+			prep, err := env.PrepareAnthropic(http.Header{}, translate.EmitOptions{
+				TargetModel:   target,
+				Capabilities:  router.Lookup(target),
+				ModelSwitched: true,
+			})
+
+			require.NoError(t, err)
+			var body map[string]any
+			require.NoError(t, json.Unmarshal(prep.Body, &body))
+			assert.Equal(t, target, body["model"])
+			assert.Contains(t, body, "context_management")
+			assert.Equal(t, "context-management-2025-06-27", prep.Headers.Get("anthropic-beta"))
+		})
+	}
+}
+
+func TestContextManagement_DedupesClientBeta(t *testing.T) {
+	env, err := translate.ParseAnthropic([]byte(contextManagementBody))
+	require.NoError(t, err)
+	in := http.Header{}
+	in.Set("anthropic-beta", "context-management-2025-06-27")
+
+	prep, err := env.PrepareAnthropic(in, translate.EmitOptions{
+		TargetModel:  "claude-opus-4-8",
+		Capabilities: router.Lookup("claude-opus-4-8"),
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, "context-management-2025-06-27", prep.Headers.Get("anthropic-beta"))
+}
+
+func TestContextManagement_AbsentDoesNotInjectBeta(t *testing.T) {
+	env, err := translate.ParseAnthropic([]byte(`{"model":"claude-opus-4-8","max_tokens":1024,"messages":[{"role":"user","content":"hi"}]}`))
+	require.NoError(t, err)
+
+	prep, err := env.PrepareAnthropic(http.Header{}, translate.EmitOptions{
+		TargetModel:  "claude-opus-4-8",
+		Capabilities: router.Lookup("claude-opus-4-8"),
+	})
+
+	require.NoError(t, err)
+	assert.Empty(t, prep.Headers.Get("anthropic-beta"))
+}

--- a/internal/translate/emit_anthropic.go
+++ b/internal/translate/emit_anthropic.go
@@ -39,10 +39,10 @@ func (e *RequestEnvelope) PrepareAnthropic(in http.Header, opts EmitOptions) (pr
 	if err != nil {
 		return providers.PreparedRequest{}, err
 	}
-	return providers.PreparedRequest{Body: body, Headers: deriveAnthropicHeaders(in, opts)}, nil
+	return providers.PreparedRequest{Body: body, Headers: deriveAnthropicHeaders(in, opts, body)}, nil
 }
 
-func deriveAnthropicHeaders(in http.Header, opts EmitOptions) http.Header {
+func deriveAnthropicHeaders(in http.Header, opts EmitOptions, body []byte) http.Header {
 	h := make(http.Header)
 	if v := in.Get("anthropic-version"); v != "" {
 		h.Set("anthropic-version", v)
@@ -53,6 +53,9 @@ func deriveAnthropicHeaders(in http.Header, opts EmitOptions) http.Header {
 	if opts.EnableExtendedContext && router.Lookup(opts.TargetModel).Supports(router.CapExtendedContext) {
 		beta = ensureBetaToken(beta, context1MBeta)
 	}
+	if gjson.GetBytes(body, "context_management").Exists() {
+		beta = ensureBetaToken(beta, contextManagementBeta)
+	}
 	if beta != "" {
 		h.Set("anthropic-beta", beta)
 	}
@@ -62,6 +65,8 @@ func deriveAnthropicHeaders(in http.Header, opts EmitOptions) http.Header {
 // context1MBeta unlocks the 1M-token context window for CapExtendedContext
 // models; native-1M models (Fable 5) accept it as a no-op.
 const context1MBeta = "context-1m-2025-08-07"
+
+const contextManagementBeta = "context-management-2025-06-27"
 
 // ensureBetaToken appends token to a comma-separated anthropic-beta list when
 // absent, preserving any tokens the client already sent.


### PR DESCRIPTION
## Summary

- inject the required context-management beta header when an emitted Anthropic body contains context_management
- preserve the literal request body instead of stripping the requested server-side context edit
- cover Fable 5, Opus 4.8, beta deduplication, and no-field behavior

## Validation

- go test ./...
- go vet ./...

This fixes same-format routed requests that otherwise reach Anthropic with a beta-only body field but without its required beta header.