### PR TITLE
fix(db): enforce tenant ownership in session_pins and billing spend queries (#796)

### DIFF
--- a/db/queries/billing.sql
+++ b/db/queries/billing.sql
@@ -76,9 +76,14 @@ key_spend AS (
     -- (the debit no-ops and the app sees ErrBalanceRowMissing) we must NOT bump
     -- the key's lifetime spend, or a capped key could trip its cap with no
     -- matching ledger debit.
-    UPDATE router.model_router_api_keys
+    -- Ownership: only bump a key whose installation's external_id matches the
+    -- org being debited (#796) — a mismatched api_key_id silently no-ops.
+    UPDATE router.model_router_api_keys k
     SET spent_usd_micros = spent_usd_micros - @delta_usd_micros::bigint
-    WHERE id = sqlc.narg('api_key_id')::uuid
+    FROM router.model_router_installations i
+    WHERE k.id = sqlc.narg('api_key_id')::uuid
+      AND k.installation_id = i.id
+      AND i.external_id = @organization_id::varchar
       AND EXISTS (SELECT 1 FROM updated)
 ),
 user_month_spend AS (
@@ -88,6 +93,8 @@ user_month_spend AS (
     -- Also no-ops when the user row no longer exists (stale cached id after a
     -- cascade delete mid-request) so a dangling FK can't roll back the debit
     -- after inference was already served.
+    -- Ownership: user must belong to an installation whose external_id matches
+    -- the org being debited (#796) — a mismatched router_user_id silently no-ops.
     INSERT INTO router.model_router_user_monthly_spend (router_user_id, month, spent_usd_micros, updated_at)
     SELECT
         sqlc.narg('router_user_id')::uuid,
@@ -97,8 +104,11 @@ user_month_spend AS (
     WHERE sqlc.narg('router_user_id')::uuid IS NOT NULL
       AND EXISTS (SELECT 1 FROM updated)
       AND EXISTS (
-          SELECT 1 FROM router.model_router_users
-          WHERE id = sqlc.narg('router_user_id')::uuid
+          SELECT 1
+          FROM router.model_router_users u
+          JOIN router.model_router_installations i ON i.id = u.installation_id
+          WHERE u.id = sqlc.narg('router_user_id')::uuid
+            AND i.external_id = @organization_id::varchar
       )
     ON CONFLICT (router_user_id, month) DO UPDATE
     SET spent_usd_micros = router.model_router_user_monthly_spend.spent_usd_micros + EXCLUDED.spent_usd_micros,

--- a/db/queries/session_pins.sql
+++ b/db/queries/session_pins.sql
@@ -8,17 +8,21 @@
 SELECT *
 FROM router.session_pins
 WHERE session_key = @session_key::bytea
-  AND role        = @role::varchar;
+  AND role        = @role::varchar
+  AND installation_id = @installation_id::uuid;
 
 -- Upserts a pin, refreshing pinned_until on every hit (sliding TTL).
 -- turn_count increments on conflict so we can observe how many turns a
 -- single (session_key, role) lives for. installation_id is set on first
 -- insert and not touched on update — re-binding a session to a different
--- installation would indicate a bug, not a legitimate state. The
--- last_*_tokens / last_turn_ended_at columns are deliberately omitted
--- from the ON CONFLICT update set: only UpdateSessionPinUsage writes
--- them, so the at-start-of-turn refresh here cannot clobber the
--- previous turn's usage with zeros before the planner reads it.
+-- installation would indicate a bug, not a legitimate state. The ON CONFLICT
+-- DO UPDATE is gated on installation_id = EXCLUDED.installation_id so a
+-- mismatched caller silently no-ops rather than overwriting another
+-- tenant's pin. The last_*_tokens / last_turn_ended_at columns are
+-- deliberately omitted from the ON CONFLICT update set: only
+-- UpdateSessionPinUsage writes them, so the at-start-of-turn refresh
+-- here cannot clobber the previous turn's usage with zeros before the
+-- planner reads it.
 --
 -- consecutive_upstream_errors is preserved on a same-model refresh (so
 -- the two-strike eviction counter accumulates across turns of the same
@@ -80,7 +84,8 @@ ON CONFLICT (session_key, role) DO UPDATE SET
     WHEN router.session_pins.pinned_model = EXCLUDED.pinned_model
       THEN router.session_pins.consecutive_upstream_errors
     ELSE 0
-  END;
+  END
+WHERE router.session_pins.installation_id = EXCLUDED.installation_id;
 
 -- Records the previous turn's upstream token usage on an existing pin
 -- row. Fired off the request path after the upstream response
@@ -110,29 +115,34 @@ SET last_input_tokens        = @last_input_tokens::int,
       OR (@prior_served_model::varchar <> '' AND @prior_served_model::varchar <> @last_served_model::varchar),
     last_served_model        = @last_served_model::varchar
 WHERE session_key = @session_key::bytea
-  AND role        = @role::varchar;
+  AND role        = @role::varchar
+  AND installation_id = @installation_id::uuid;
 
 -- Atomically increments consecutive_upstream_errors and returns the
 -- new value. The turn loop calls this after a non-retryable upstream
 -- 4xx on a sticky-pinned turn; the returned count drives the
 -- two-strike eviction decision. Returns sql.ErrNoRows if no pin
--- exists, which the adapter maps to a no-op (pin must already be
--- evicted by another path, e.g. force-model / loop-break).
+-- exists (or installation_id mismatches), which the adapter maps to a
+-- no-op (pin must already be evicted by another path, e.g. force-model /
+-- loop-break).
 -- name: IncrementSessionPinUpstreamErrors :one
 UPDATE router.session_pins
 SET consecutive_upstream_errors = consecutive_upstream_errors + 1
 WHERE session_key = @session_key::bytea
   AND role        = @role::varchar
+  AND installation_id = @installation_id::uuid
 RETURNING consecutive_upstream_errors;
 
 -- Clears the two-strike counter after a successful turn. UPDATE
--- matches by (session_key, role); zero rows affected on missing pin
--- is a successful no-op like UpdateSessionPinUsage.
+-- matches by (session_key, role, installation_id); zero rows affected
+-- on missing pin (or ownership mismatch) is a successful no-op like
+-- UpdateSessionPinUsage.
 -- name: ResetSessionPinUpstreamErrors :exec
 UPDATE router.session_pins
 SET consecutive_upstream_errors = 0
 WHERE session_key = @session_key::bytea
   AND role        = @role::varchar
+  AND installation_id = @installation_id::uuid
   AND consecutive_upstream_errors > 0;
 
 -- Garbage-collects pins that have been expired for >24h. The 24h grace

--- a/db/queries/spend_limits.sql
+++ b/db/queries/spend_limits.sql
@@ -10,22 +10,34 @@ WHERE organization_id = @organization_id::varchar;
 -- per-user override when an override row exists (its NULL means "explicitly
 -- uncapped"), otherwise the org-wide default; has_override distinguishes the
 -- two NULL meanings. spent is 0 when the user has no spend row this month.
+-- Spend/override subqueries require the user to belong to an installation
+-- whose external_id matches @organization_id (#796); a mismatched pair is a
+-- silent miss (spent 0, no override). Org default still resolves for the org.
 -- name: GetUserMonthlySpendAndLimit :one
 SELECT
     (EXISTS (
         SELECT 1 FROM router.model_router_user_spend_limits ovr
+        JOIN router.model_router_users u ON u.id = ovr.router_user_id
+        JOIN router.model_router_installations i ON i.id = u.installation_id
         WHERE ovr.router_user_id = @router_user_id::uuid
+          AND i.external_id = @organization_id::varchar
     ))::boolean AS has_override,
     (SELECT ovr.monthly_limit_usd_micros
      FROM router.model_router_user_spend_limits ovr
-     WHERE ovr.router_user_id = @router_user_id::uuid) AS override_limit_usd_micros,
+     JOIN router.model_router_users u ON u.id = ovr.router_user_id
+     JOIN router.model_router_installations i ON i.id = u.installation_id
+     WHERE ovr.router_user_id = @router_user_id::uuid
+       AND i.external_id = @organization_id::varchar) AS override_limit_usd_micros,
     (SELECT lim.user_monthly_limit_usd_micros
      FROM router.organization_spend_limits lim
      WHERE lim.organization_id = @organization_id::varchar) AS org_default_limit_usd_micros,
     COALESCE((
         SELECT sp.spent_usd_micros
         FROM router.model_router_user_monthly_spend sp
+        JOIN router.model_router_users u ON u.id = sp.router_user_id
+        JOIN router.model_router_installations i ON i.id = u.installation_id
         WHERE sp.router_user_id = @router_user_id::uuid
+          AND i.external_id = @organization_id::varchar
           AND sp.month = DATE_TRUNC('month', NOW() AT TIME ZONE 'utc')::date
     ), 0)::bigint AS spent_usd_micros;
 

--- a/internal/postgres/session_pin_repo.go
+++ b/internal/postgres/session_pin_repo.go
@@ -9,6 +9,7 @@ import (
 	"workweave/router/internal/router/sessionpin"
 	"workweave/router/internal/sqlc"
 
+	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgtype"
 )
 
@@ -24,11 +25,12 @@ func NewSessionPinRepo(tx sqlc.DBTX) *SessionPinRepo {
 
 var _ sessionpin.Store = (*SessionPinRepo)(nil)
 
-func (r *SessionPinRepo) Get(ctx context.Context, sessionKey [sessionpin.SessionKeyLen]byte, role string) (sessionpin.Pin, bool, error) {
+func (r *SessionPinRepo) Get(ctx context.Context, sessionKey [sessionpin.SessionKeyLen]byte, role string, installationID uuid.UUID) (sessionpin.Pin, bool, error) {
 	q := sqlc.New(r.tx)
 	row, err := q.GetSessionPin(ctx, sqlc.GetSessionPinParams{
-		SessionKey: sessionKey[:],
-		Role:       role,
+		SessionKey:     sessionKey[:],
+		Role:           role,
+		InstallationID: installationID,
 	})
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
@@ -56,9 +58,10 @@ func (r *SessionPinRepo) Upsert(ctx context.Context, p sessionpin.Pin) error {
 }
 
 // UpdateUsage records the previous turn's usage on the pin row. A missing
-// pin (evicted/swept/never created) is a no-op, not an error. A zero
-// EndedAt is stamped with time.Now so the column is always populated.
-func (r *SessionPinRepo) UpdateUsage(ctx context.Context, sessionKey [sessionpin.SessionKeyLen]byte, role string, usage sessionpin.Usage) error {
+// pin (evicted/swept/never created) or ownership mismatch is a no-op, not
+// an error. A zero EndedAt is stamped with time.Now so the column is always
+// populated.
+func (r *SessionPinRepo) UpdateUsage(ctx context.Context, sessionKey [sessionpin.SessionKeyLen]byte, role string, installationID uuid.UUID, usage sessionpin.Usage) error {
 	endedAt := usage.EndedAt
 	if endedAt.IsZero() {
 		endedAt = time.Now()
@@ -67,6 +70,7 @@ func (r *SessionPinRepo) UpdateUsage(ctx context.Context, sessionKey [sessionpin
 	return q.UpdateSessionPinUsage(ctx, sqlc.UpdateSessionPinUsageParams{
 		SessionKey:            sessionKey[:],
 		Role:                  role,
+		InstallationID:        installationID,
 		LastInputTokens:       int32(usage.InputTokens),
 		LastCachedReadTokens:  int32(usage.CachedReadTokens),
 		LastCachedWriteTokens: int32(usage.CachedWriteTokens),
@@ -79,13 +83,15 @@ func (r *SessionPinRepo) UpdateUsage(ctx context.Context, sessionKey [sessionpin
 }
 
 // IncrementUpstreamErrors atomically bumps the consecutive-error counter.
-// A missing pin (already evicted or never created) returns (0, nil): the
-// two-strike check treats it as a no-op since there's no row left to evict.
-func (r *SessionPinRepo) IncrementUpstreamErrors(ctx context.Context, sessionKey [sessionpin.SessionKeyLen]byte, role string) (int, error) {
+// A missing pin (already evicted, never created, or ownership mismatch)
+// returns (0, nil): the two-strike check treats it as a no-op since there's
+// no row left to evict.
+func (r *SessionPinRepo) IncrementUpstreamErrors(ctx context.Context, sessionKey [sessionpin.SessionKeyLen]byte, role string, installationID uuid.UUID) (int, error) {
 	q := sqlc.New(r.tx)
 	count, err := q.IncrementSessionPinUpstreamErrors(ctx, sqlc.IncrementSessionPinUpstreamErrorsParams{
-		SessionKey: sessionKey[:],
-		Role:       role,
+		SessionKey:     sessionKey[:],
+		Role:           role,
+		InstallationID: installationID,
 	})
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
@@ -97,12 +103,14 @@ func (r *SessionPinRepo) IncrementUpstreamErrors(ctx context.Context, sessionKey
 }
 
 // ResetUpstreamErrors clears the consecutive-error counter after a
-// successful turn. Missing pin is a no-op, same as UpdateUsage.
-func (r *SessionPinRepo) ResetUpstreamErrors(ctx context.Context, sessionKey [sessionpin.SessionKeyLen]byte, role string) error {
+// successful turn. Missing pin / ownership mismatch is a no-op, same as
+// UpdateUsage.
+func (r *SessionPinRepo) ResetUpstreamErrors(ctx context.Context, sessionKey [sessionpin.SessionKeyLen]byte, role string, installationID uuid.UUID) error {
 	q := sqlc.New(r.tx)
 	return q.ResetSessionPinUpstreamErrors(ctx, sqlc.ResetSessionPinUpstreamErrorsParams{
-		SessionKey: sessionKey[:],
-		Role:       role,
+		SessionKey:     sessionKey[:],
+		Role:           role,
+		InstallationID: installationID,
 	})
 }
 

--- a/internal/postgres/tenant_isolation_796_test.go
+++ b/internal/postgres/tenant_isolation_796_test.go
@@ -1,0 +1,319 @@
+package postgres_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"workweave/router/internal/billing"
+	"workweave/router/internal/postgres"
+	"workweave/router/internal/router/sessionpin"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stretchr/testify/require"
+)
+
+// #796 permanent regressions: SQL must enforce tenant ownership rather than
+// relying solely on the app layer always passing same-tenant IDs.
+//
+// Gated on ROUTER_TEST_DATABASE_URL (falls back to DATABASE_URL). Uses real
+// Postgres + real SessionPinRepo / BillingRepo — no mocks.
+
+func testDatabaseURL(t *testing.T) string {
+	t.Helper()
+	dsn := os.Getenv("ROUTER_TEST_DATABASE_URL")
+	if dsn == "" {
+		dsn = os.Getenv("DATABASE_URL")
+	}
+	if dsn == "" {
+		t.Skip("ROUTER_TEST_DATABASE_URL / DATABASE_URL not set; need live Postgres for #796 tenant-isolation regressions")
+	}
+	return dsn
+}
+
+func openRouterPool(t *testing.T, dsn string) *pgxpool.Pool {
+	t.Helper()
+	ctx := context.Background()
+	cfg, err := pgxpool.ParseConfig(dsn)
+	require.NoError(t, err)
+	cfg.AfterConnect = func(ctx context.Context, conn *pgx.Conn) error {
+		_, err := conn.Exec(ctx, "SET search_path TO router, public")
+		return err
+	}
+	pool, err := pgxpool.NewWithConfig(ctx, cfg)
+	require.NoError(t, err)
+	t.Cleanup(pool.Close)
+	require.NoError(t, pool.Ping(ctx))
+	return pool
+}
+
+// TestSessionPin_UpsertDoesNotCrossInstallation reproduces #796 finding 1:
+// UpsertSessionPin's ON CONFLICT must not overwrite another installation's
+// pin (model/provider) while leaving installation_id stuck on the original
+// owner. Mismatch = silent no-op; owner row unchanged.
+func TestSessionPin_UpsertDoesNotCrossInstallation(t *testing.T) {
+	pool := openRouterPool(t, testDatabaseURL(t))
+	ctx := context.Background()
+
+	suffix := time.Now().UnixNano()
+	orgA := fmt.Sprintf("796-pin-a-%d", suffix%1_000_000_000_000)
+	orgB := fmt.Sprintf("796-pin-b-%d", suffix%1_000_000_000_000)
+	instA, instB := uuid.New(), uuid.New()
+	var sessionKey [sessionpin.SessionKeyLen]byte
+	copy(sessionKey[:], []byte(fmt.Sprintf("796pin%08d", suffix%100_000_000)))
+
+	_, err := pool.Exec(ctx, `
+		INSERT INTO model_router_installations (id, external_id, name)
+		VALUES ($1, $2, '796-pin-A'), ($3, $4, '796-pin-B')`,
+		instA, orgA, instB, orgB)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		c, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		_, _ = pool.Exec(c, `DELETE FROM session_pins WHERE session_key = $1`, sessionKey[:])
+		_, _ = pool.Exec(c, `DELETE FROM model_router_installations WHERE id IN ($1, $2)`, instA, instB)
+	})
+
+	store := postgres.NewSessionPinRepo(pool)
+	require.NoError(t, store.Upsert(ctx, sessionpin.Pin{
+		SessionKey:     sessionKey,
+		Role:           sessionpin.DefaultRole,
+		InstallationID: instA,
+		Provider:       "anthropic",
+		Model:          "model-from-A",
+		Reason:         "796-test-A",
+		TurnCount:      1,
+		PinnedUntil:    time.Now().UTC().Add(time.Hour),
+	}))
+
+	// Cross-tenant collision attempt: same (session_key, role), different install.
+	require.NoError(t, store.Upsert(ctx, sessionpin.Pin{
+		SessionKey:     sessionKey,
+		Role:           sessionpin.DefaultRole,
+		InstallationID: instB,
+		Provider:       "openai",
+		Model:          "model-from-B",
+		Reason:         "796-test-B",
+		TurnCount:      1,
+		PinnedUntil:    time.Now().UTC().Add(time.Hour),
+	}))
+
+	var (
+		gotInstall uuid.UUID
+		gotModel   string
+		gotProv    string
+		turnCount  int
+	)
+	err = pool.QueryRow(ctx, `
+		SELECT installation_id, pinned_model, pinned_provider, turn_count
+		FROM session_pins
+		WHERE session_key = $1 AND role = $2`, sessionKey[:], sessionpin.DefaultRole).
+		Scan(&gotInstall, &gotModel, &gotProv, &turnCount)
+	require.NoError(t, err)
+
+	require.Equal(t, instA, gotInstall, "installation_id must stay on original owner A")
+	require.Equal(t, "model-from-A", gotModel,
+		"#796: mismatched Upsert must not overwrite pinned_model (got %q from install B)", gotModel)
+	require.Equal(t, "anthropic", gotProv,
+		"#796: mismatched Upsert must not overwrite pinned_provider")
+	require.Equal(t, 1, turnCount,
+		"#796: mismatched Upsert must not bump turn_count on the owner row")
+}
+
+// TestDebitOrgCredits_KeySpendRequiresOrgOwnership reproduces #796 finding 2:
+// key_spend must not bump a foreign key's spent_usd_micros when organization_id
+// and api_key_id belong to different tenants.
+func TestDebitOrgCredits_KeySpendRequiresOrgOwnership(t *testing.T) {
+	pool := openRouterPool(t, testDatabaseURL(t))
+	ctx := context.Background()
+
+	suffix := time.Now().UnixNano()
+	orgA := fmt.Sprintf("796-key-a-%d", suffix%1_000_000_000_000)
+	orgB := fmt.Sprintf("796-key-b-%d", suffix%1_000_000_000_000)
+	instA, instB := uuid.New(), uuid.New()
+	keyA, keyB := uuid.New(), uuid.New()
+	const (
+		startBalance int64 = 1_000_000_000 // $1000
+		debitMicros  int64 = 500_000       // $0.50
+	)
+
+	_, err := pool.Exec(ctx, `
+		INSERT INTO model_router_installations (id, external_id, name)
+		VALUES ($1, $2, '796-key-A'), ($3, $4, '796-key-B')`,
+		instA, orgA, instB, orgB)
+	require.NoError(t, err)
+	_, err = pool.Exec(ctx, `
+		INSERT INTO model_router_api_keys
+			(id, installation_id, external_id, key_prefix, key_hash, key_suffix, spent_usd_micros)
+		VALUES
+			($1, $2, $3, 'rk_a796_', $4, 'aaaa', 0),
+			($5, $6, $7, 'rk_b796_', $8, 'bbbb', 0)`,
+		keyA, instA, "kid-a-"+orgA, fmt.Sprintf("hash-a-%d", suffix),
+		keyB, instB, "kid-b-"+orgB, fmt.Sprintf("hash-b-%d", suffix))
+	require.NoError(t, err)
+	_, err = pool.Exec(ctx, `
+		INSERT INTO organization_credit_balance (organization_id, balance_usd_micros)
+		VALUES ($1, $2), ($3, $2)`, orgA, startBalance, orgB)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		c, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		_, _ = pool.Exec(c, `DELETE FROM organization_credit_ledger WHERE organization_id IN ($1, $2)`, orgA, orgB)
+		_, _ = pool.Exec(c, `DELETE FROM organization_monthly_spend WHERE organization_id IN ($1, $2)`, orgA, orgB)
+		_, _ = pool.Exec(c, `DELETE FROM organization_credit_balance WHERE organization_id IN ($1, $2)`, orgA, orgB)
+		_, _ = pool.Exec(c, `DELETE FROM model_router_api_keys WHERE id IN ($1, $2)`, keyA, keyB)
+		_, _ = pool.Exec(c, `DELETE FROM model_router_installations WHERE id IN ($1, $2)`, instA, instB)
+	})
+
+	repo := postgres.NewBillingRepo(pool)
+	_, err = repo.DebitInference(ctx, billing.DebitParams{
+		OrganizationID:     orgA,
+		DeltaUsdMicros:     -debitMicros,
+		NotionalCostMicros: debitMicros,
+		EntryType:          billing.EntryTypeInference,
+		RouterRequestID:    fmt.Sprintf("796-key-%d", suffix),
+		RouterModel:        "796-fixture",
+		APIKeyID:           keyB.String(), // foreign key — must NOT receive the spend bump
+	})
+	require.NoError(t, err)
+
+	var spentB int64
+	err = pool.QueryRow(ctx, `SELECT spent_usd_micros FROM model_router_api_keys WHERE id = $1`, keyB).Scan(&spentB)
+	require.NoError(t, err)
+	require.Equal(t, int64(0), spentB,
+		"#796: debiting org A with org B's api_key_id must not bump B's spent_usd_micros (got %d)", spentB)
+
+	var spentA int64
+	err = pool.QueryRow(ctx, `SELECT spent_usd_micros FROM model_router_api_keys WHERE id = $1`, keyA).Scan(&spentA)
+	require.NoError(t, err)
+	require.Equal(t, int64(0), spentA, "org A's own key was not attributed; spend must stay 0")
+
+	balA, err := repo.GetBalance(ctx, orgA)
+	require.NoError(t, err)
+	require.Equal(t, startBalance-debitMicros, balA, "org A balance must still debit")
+}
+
+// TestDebitOrgCredits_UserMonthSpendRequiresOrgOwnership reproduces the
+// write-side twin of #796 finding 3: user_month_spend must not bump a
+// foreign user's monthly counter when organization_id and router_user_id
+// belong to different tenants.
+func TestDebitOrgCredits_UserMonthSpendRequiresOrgOwnership(t *testing.T) {
+	pool := openRouterPool(t, testDatabaseURL(t))
+	ctx := context.Background()
+
+	suffix := time.Now().UnixNano()
+	orgA := fmt.Sprintf("796-usr-a-%d", suffix%1_000_000_000_000)
+	orgB := fmt.Sprintf("796-usr-b-%d", suffix%1_000_000_000_000)
+	instA, instB := uuid.New(), uuid.New()
+	userA, userB := uuid.New(), uuid.New()
+	const (
+		startBalance int64 = 1_000_000_000
+		debitMicros  int64 = 424_242
+	)
+
+	_, err := pool.Exec(ctx, `
+		INSERT INTO model_router_installations (id, external_id, name)
+		VALUES ($1, $2, '796-usr-A'), ($3, $4, '796-usr-B')`,
+		instA, orgA, instB, orgB)
+	require.NoError(t, err)
+	_, err = pool.Exec(ctx, `
+		INSERT INTO model_router_users (id, installation_id, email)
+		VALUES ($1, $2, $3), ($4, $5, $6)`,
+		userA, instA, fmt.Sprintf("a-%d@example.com", suffix),
+		userB, instB, fmt.Sprintf("b-%d@example.com", suffix))
+	require.NoError(t, err)
+	_, err = pool.Exec(ctx, `
+		INSERT INTO organization_credit_balance (organization_id, balance_usd_micros)
+		VALUES ($1, $2), ($3, $2)`, orgA, startBalance, orgB)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		c, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		_, _ = pool.Exec(c, `DELETE FROM model_router_user_monthly_spend WHERE router_user_id IN ($1, $2)`, userA, userB)
+		_, _ = pool.Exec(c, `DELETE FROM organization_credit_ledger WHERE organization_id IN ($1, $2)`, orgA, orgB)
+		_, _ = pool.Exec(c, `DELETE FROM organization_monthly_spend WHERE organization_id IN ($1, $2)`, orgA, orgB)
+		_, _ = pool.Exec(c, `DELETE FROM organization_credit_balance WHERE organization_id IN ($1, $2)`, orgA, orgB)
+		_, _ = pool.Exec(c, `DELETE FROM model_router_users WHERE id IN ($1, $2)`, userA, userB)
+		_, _ = pool.Exec(c, `DELETE FROM model_router_installations WHERE id IN ($1, $2)`, instA, instB)
+	})
+
+	repo := postgres.NewBillingRepo(pool)
+	_, err = repo.DebitInference(ctx, billing.DebitParams{
+		OrganizationID:     orgA,
+		DeltaUsdMicros:     -debitMicros,
+		NotionalCostMicros: debitMicros,
+		EntryType:          billing.EntryTypeInference,
+		RouterRequestID:    fmt.Sprintf("796-usr-%d", suffix),
+		RouterModel:        "796-fixture",
+		RouterUserID:       userB.String(), // foreign user — must NOT receive the month spend bump
+	})
+	require.NoError(t, err)
+
+	var countB int
+	err = pool.QueryRow(ctx, `
+		SELECT COUNT(*) FROM model_router_user_monthly_spend
+		WHERE router_user_id = $1
+		  AND month = DATE_TRUNC('month', NOW() AT TIME ZONE 'utc')::date`, userB).Scan(&countB)
+	require.NoError(t, err)
+	require.Equal(t, 0, countB,
+		"#796: debiting org A with org B's router_user_id must not insert/bump B's monthly spend row")
+}
+
+// TestGetUserMonthlySpendAndLimit_RequiresUserOrgOwnership reproduces #796
+// finding 3: spend/override subqueries must not return a foreign user's
+// figures when organization_id and router_user_id belong to different tenants.
+// Mismatch = silent miss (spent 0, no override); org default still resolves.
+func TestGetUserMonthlySpendAndLimit_RequiresUserOrgOwnership(t *testing.T) {
+	pool := openRouterPool(t, testDatabaseURL(t))
+	ctx := context.Background()
+
+	suffix := time.Now().UnixNano()
+	orgA := fmt.Sprintf("796-rd-a-%d", suffix%1_000_000_000_000)
+	orgB := fmt.Sprintf("796-rd-b-%d", suffix%1_000_000_000_000)
+	instA, instB := uuid.New(), uuid.New()
+	userB := uuid.New()
+	const (
+		orgADefault int64 = 1_111_111
+		userBSpent  int64 = 424_242
+	)
+
+	_, err := pool.Exec(ctx, `
+		INSERT INTO model_router_installations (id, external_id, name)
+		VALUES ($1, $2, '796-rd-A'), ($3, $4, '796-rd-B')`,
+		instA, orgA, instB, orgB)
+	require.NoError(t, err)
+	_, err = pool.Exec(ctx, `
+		INSERT INTO model_router_users (id, installation_id, email)
+		VALUES ($1, $2, $3)`, userB, instB, fmt.Sprintf("b-rd-%d@example.com", suffix))
+	require.NoError(t, err)
+	_, err = pool.Exec(ctx, `
+		INSERT INTO organization_spend_limits (organization_id, user_monthly_limit_usd_micros)
+		VALUES ($1, $2)`, orgA, orgADefault)
+	require.NoError(t, err)
+	_, err = pool.Exec(ctx, `
+		INSERT INTO model_router_user_monthly_spend (router_user_id, month, spent_usd_micros)
+		VALUES ($1, DATE_TRUNC('month', NOW() AT TIME ZONE 'utc')::date, $2)`, userB, userBSpent)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		c, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		_, _ = pool.Exec(c, `DELETE FROM model_router_user_monthly_spend WHERE router_user_id = $1`, userB)
+		_, _ = pool.Exec(c, `DELETE FROM organization_spend_limits WHERE organization_id = $1`, orgA)
+		_, _ = pool.Exec(c, `DELETE FROM model_router_users WHERE id = $1`, userB)
+		_, _ = pool.Exec(c, `DELETE FROM model_router_installations WHERE id IN ($1, $2)`, instA, instB)
+	})
+
+	repo := postgres.NewBillingRepo(pool)
+	spent, limit, err := repo.GetUserMonthlySpendAndLimit(ctx, orgA, userB.String())
+	require.NoError(t, err)
+
+	require.Equal(t, int64(0), spent,
+		"#796: org A + foreign user B must not return B's real spend (got %d)", spent)
+	require.NotNil(t, limit)
+	require.Equal(t, orgADefault, *limit,
+		"org default limit for A must still resolve on a mismatched user read")
+}

--- a/internal/proxy/cyber_refusal_internal_test.go
+++ b/internal/proxy/cyber_refusal_internal_test.go
@@ -18,7 +18,7 @@ type repinFakeStore struct {
 	upserts []sessionpin.Pin
 }
 
-func (f *repinFakeStore) Get(_ context.Context, key [sessionpin.SessionKeyLen]byte, role string) (sessionpin.Pin, bool, error) {
+func (f *repinFakeStore) Get(_ context.Context, key [sessionpin.SessionKeyLen]byte, role string, _ uuid.UUID) (sessionpin.Pin, bool, error) {
 	if !f.hasPin {
 		return sessionpin.Pin{}, false, nil
 	}
@@ -31,13 +31,13 @@ func (f *repinFakeStore) Upsert(_ context.Context, p sessionpin.Pin) error {
 	f.upserts = append(f.upserts, p)
 	return nil
 }
-func (f *repinFakeStore) UpdateUsage(context.Context, [sessionpin.SessionKeyLen]byte, string, sessionpin.Usage) error {
+func (f *repinFakeStore) UpdateUsage(context.Context, [sessionpin.SessionKeyLen]byte, string, uuid.UUID, sessionpin.Usage) error {
 	return nil
 }
-func (f *repinFakeStore) IncrementUpstreamErrors(context.Context, [sessionpin.SessionKeyLen]byte, string) (int, error) {
+func (f *repinFakeStore) IncrementUpstreamErrors(context.Context, [sessionpin.SessionKeyLen]byte, string, uuid.UUID) (int, error) {
 	return 0, nil
 }
-func (f *repinFakeStore) ResetUpstreamErrors(context.Context, [sessionpin.SessionKeyLen]byte, string) error {
+func (f *repinFakeStore) ResetUpstreamErrors(context.Context, [sessionpin.SessionKeyLen]byte, string, uuid.UUID) error {
 	return nil
 }
 func (f *repinFakeStore) SweepExpired(context.Context) error { return nil }

--- a/internal/proxy/force_model.go
+++ b/internal/proxy/force_model.go
@@ -193,7 +193,7 @@ func (s *Service) setForceModelPin(
 	}
 	log := observability.FromContext(ctx)
 	var lastServedModel string
-	existing, found, err := s.pinStore.Get(ctx, sessionKey, role)
+	existing, found, err := s.pinStore.Get(ctx, sessionKey, role, installationID)
 	if err != nil {
 		log.Error("force-model: prior pin lookup failed", "err", err)
 	} else if found {

--- a/internal/proxy/force_model_pin_ttl_internal_test.go
+++ b/internal/proxy/force_model_pin_ttl_internal_test.go
@@ -21,20 +21,20 @@ type recordingPinStore struct {
 	upserts []sessionpin.Pin
 }
 
-func (s *recordingPinStore) Get(context.Context, [sessionpin.SessionKeyLen]byte, string) (sessionpin.Pin, bool, error) {
+func (s *recordingPinStore) Get(context.Context, [sessionpin.SessionKeyLen]byte, string, uuid.UUID) (sessionpin.Pin, bool, error) {
 	return sessionpin.Pin{}, false, nil
 }
 func (s *recordingPinStore) Upsert(_ context.Context, p sessionpin.Pin) error {
 	s.upserts = append(s.upserts, p)
 	return nil
 }
-func (s *recordingPinStore) UpdateUsage(context.Context, [sessionpin.SessionKeyLen]byte, string, sessionpin.Usage) error {
+func (s *recordingPinStore) UpdateUsage(context.Context, [sessionpin.SessionKeyLen]byte, string, uuid.UUID, sessionpin.Usage) error {
 	return nil
 }
-func (s *recordingPinStore) IncrementUpstreamErrors(context.Context, [sessionpin.SessionKeyLen]byte, string) (int, error) {
+func (s *recordingPinStore) IncrementUpstreamErrors(context.Context, [sessionpin.SessionKeyLen]byte, string, uuid.UUID) (int, error) {
 	return 0, nil
 }
-func (s *recordingPinStore) ResetUpstreamErrors(context.Context, [sessionpin.SessionKeyLen]byte, string) error {
+func (s *recordingPinStore) ResetUpstreamErrors(context.Context, [sessionpin.SessionKeyLen]byte, string, uuid.UUID) error {
 	return nil
 }
 func (s *recordingPinStore) SweepExpired(context.Context) error { return nil }

--- a/internal/proxy/force_model_tier_fallback_internal_test.go
+++ b/internal/proxy/force_model_tier_fallback_internal_test.go
@@ -49,20 +49,20 @@ type forcedPinStore struct {
 	pin sessionpin.Pin
 }
 
-func (s *forcedPinStore) Get(_ context.Context, key [sessionpin.SessionKeyLen]byte, role string) (sessionpin.Pin, bool, error) {
+func (s *forcedPinStore) Get(_ context.Context, key [sessionpin.SessionKeyLen]byte, role string, _ uuid.UUID) (sessionpin.Pin, bool, error) {
 	p := s.pin
 	p.SessionKey = key
 	p.Role = role
 	return p, true, nil
 }
 func (s *forcedPinStore) Upsert(context.Context, sessionpin.Pin) error { return nil }
-func (s *forcedPinStore) UpdateUsage(context.Context, [sessionpin.SessionKeyLen]byte, string, sessionpin.Usage) error {
+func (s *forcedPinStore) UpdateUsage(context.Context, [sessionpin.SessionKeyLen]byte, string, uuid.UUID, sessionpin.Usage) error {
 	return nil
 }
-func (s *forcedPinStore) IncrementUpstreamErrors(context.Context, [sessionpin.SessionKeyLen]byte, string) (int, error) {
+func (s *forcedPinStore) IncrementUpstreamErrors(context.Context, [sessionpin.SessionKeyLen]byte, string, uuid.UUID) (int, error) {
 	return 0, nil
 }
-func (s *forcedPinStore) ResetUpstreamErrors(context.Context, [sessionpin.SessionKeyLen]byte, string) error {
+func (s *forcedPinStore) ResetUpstreamErrors(context.Context, [sessionpin.SessionKeyLen]byte, string, uuid.UUID) error {
 	return nil
 }
 func (s *forcedPinStore) SweepExpired(context.Context) error { return nil }
@@ -72,7 +72,7 @@ type overwritingPinStore struct {
 	found bool
 }
 
-func (s *overwritingPinStore) Get(_ context.Context, key [sessionpin.SessionKeyLen]byte, role string) (sessionpin.Pin, bool, error) {
+func (s *overwritingPinStore) Get(_ context.Context, key [sessionpin.SessionKeyLen]byte, role string, _ uuid.UUID) (sessionpin.Pin, bool, error) {
 	if !s.found {
 		return sessionpin.Pin{}, false, nil
 	}
@@ -87,13 +87,13 @@ func (s *overwritingPinStore) Upsert(_ context.Context, p sessionpin.Pin) error 
 	s.found = true
 	return nil
 }
-func (s *overwritingPinStore) UpdateUsage(context.Context, [sessionpin.SessionKeyLen]byte, string, sessionpin.Usage) error {
+func (s *overwritingPinStore) UpdateUsage(context.Context, [sessionpin.SessionKeyLen]byte, string, uuid.UUID, sessionpin.Usage) error {
 	return nil
 }
-func (s *overwritingPinStore) IncrementUpstreamErrors(context.Context, [sessionpin.SessionKeyLen]byte, string) (int, error) {
+func (s *overwritingPinStore) IncrementUpstreamErrors(context.Context, [sessionpin.SessionKeyLen]byte, string, uuid.UUID) (int, error) {
 	return 0, nil
 }
-func (s *overwritingPinStore) ResetUpstreamErrors(context.Context, [sessionpin.SessionKeyLen]byte, string) error {
+func (s *overwritingPinStore) ResetUpstreamErrors(context.Context, [sessionpin.SessionKeyLen]byte, string, uuid.UUID) error {
 	return nil
 }
 func (s *overwritingPinStore) SweepExpired(context.Context) error { return nil }

--- a/internal/proxy/loop_detection.go
+++ b/internal/proxy/loop_detection.go
@@ -188,7 +188,7 @@ func (s *Service) handleLoopEscalation(
 	loopingModel := routedModel
 	userForced := false
 	if s.pinStore != nil && installationID != uuid.Nil {
-		existing, found, err := s.pinStore.Get(ctx, sessionKey, role)
+		existing, found, err := s.pinStore.Get(ctx, sessionKey, role, installationID)
 		if err != nil {
 			log.Error("loop-escalation: prior pin lookup failed", "err", err)
 		} else if found {
@@ -263,7 +263,7 @@ func (s *Service) handleLoopEscalation(
 			return
 		}
 		var lastServed string
-		if existing, found, err := s.pinStore.Get(ctx, sessionKey, role); err == nil && found {
+		if existing, found, err := s.pinStore.Get(ctx, sessionKey, role, installationID); err == nil && found {
 			lastServed = existing.LastServedModel
 		}
 		pin := sessionpin.Pin{

--- a/internal/proxy/no_progress.go
+++ b/internal/proxy/no_progress.go
@@ -262,7 +262,7 @@ func (s *Service) handleNoProgressBreak(
 	log := observability.FromContext(ctx)
 	preserveForcedPin := false
 	if s.pinStore != nil && installationID != uuid.Nil && sessionKey != ([sessionpin.SessionKeyLen]byte{}) {
-		pin, found := s.loadPin(ctx, sessionKey, role)
+		pin, found := s.loadPin(ctx, sessionKey, role, installationID)
 		preserveForcedPin = found && isUserForcedReason(pin.Reason)
 	}
 	pinAction := "clearing the session pin so the next message re-routes"

--- a/internal/proxy/pin_eviction.go
+++ b/internal/proxy/pin_eviction.go
@@ -140,7 +140,7 @@ func (s *Service) maybeEvictPinAfterUpstreamErr(
 	if proxyErr == nil {
 		// context.Background(): the request ctx is already canceled by the
 		// time streaming finishes, but this reset must still go through.
-		if err := s.pinStore.ResetUpstreamErrors(context.Background(), sessionKey, role); err != nil {
+		if err := s.pinStore.ResetUpstreamErrors(context.Background(), sessionKey, role, installationID); err != nil {
 			log.Error("pin error-counter reset failed", "err", err, "role", role)
 		}
 		return
@@ -156,7 +156,7 @@ func (s *Service) maybeEvictPinAfterUpstreamErr(
 		return
 	}
 
-	count, err := s.pinStore.IncrementUpstreamErrors(context.Background(), sessionKey, role)
+	count, err := s.pinStore.IncrementUpstreamErrors(context.Background(), sessionKey, role, installationID)
 	if err != nil {
 		log.Error("pin error-counter increment failed", "err", err, "role", role, "upstream_status", status)
 		return

--- a/internal/proxy/pin_eviction_internal_test.go
+++ b/internal/proxy/pin_eviction_internal_test.go
@@ -27,7 +27,7 @@ type evictionStubPinStore struct {
 	upserts        []sessionpin.Pin
 }
 
-func (s *evictionStubPinStore) Get(context.Context, [sessionpin.SessionKeyLen]byte, string) (sessionpin.Pin, bool, error) {
+func (s *evictionStubPinStore) Get(context.Context, [sessionpin.SessionKeyLen]byte, string, uuid.UUID) (sessionpin.Pin, bool, error) {
 	return sessionpin.Pin{}, false, nil
 }
 
@@ -38,11 +38,11 @@ func (s *evictionStubPinStore) Upsert(_ context.Context, p sessionpin.Pin) error
 	return nil
 }
 
-func (s *evictionStubPinStore) UpdateUsage(context.Context, [sessionpin.SessionKeyLen]byte, string, sessionpin.Usage) error {
+func (s *evictionStubPinStore) UpdateUsage(context.Context, [sessionpin.SessionKeyLen]byte, string, uuid.UUID, sessionpin.Usage) error {
 	return nil
 }
 
-func (s *evictionStubPinStore) IncrementUpstreamErrors(context.Context, [sessionpin.SessionKeyLen]byte, string) (int, error) {
+func (s *evictionStubPinStore) IncrementUpstreamErrors(context.Context, [sessionpin.SessionKeyLen]byte, string, uuid.UUID) (int, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.incrementCalls++
@@ -54,7 +54,7 @@ func (s *evictionStubPinStore) IncrementUpstreamErrors(context.Context, [session
 	return v, nil
 }
 
-func (s *evictionStubPinStore) ResetUpstreamErrors(context.Context, [sessionpin.SessionKeyLen]byte, string) error {
+func (s *evictionStubPinStore) ResetUpstreamErrors(context.Context, [sessionpin.SessionKeyLen]byte, string, uuid.UUID) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.resetCalls++

--- a/internal/proxy/router_feedback.go
+++ b/internal/proxy/router_feedback.go
@@ -80,7 +80,7 @@ func (s *Service) handleRouterFeedbackCommand(
 	// last served, falling back to the pin's target model.
 	var servedModel string
 	if s.pinStore != nil {
-		if pin, found, err := s.pinStore.Get(ctx, sessionKey, role); err != nil {
+		if pin, found, err := s.pinStore.Get(ctx, sessionKey, role, installationID); err != nil {
 			log.Error("/router-feedback: pin lookup failed", "err", err)
 		} else if found {
 			servedModel = pin.LastServedModel

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -1892,7 +1892,7 @@ func (s *Service) maybeRepinOnRefusal(ctx context.Context, obs *refusalObserver,
 	// Prefer the scorer's runner-up (PairedModel); use context.Background() because
 	// the request ctx may already be canceled when the response has been written.
 	fbModel, fbProvider := s.cyberRefusalFallbackModel, ""
-	if existing, found, err := s.pinStore.Get(context.Background(), sessionKey, role); err == nil && found && existing.PairedModel != "" {
+	if existing, found, err := s.pinStore.Get(context.Background(), sessionKey, role, installationID); err == nil && found && existing.PairedModel != "" {
 		fbModel, fbProvider = existing.PairedModel, existing.PairedProvider
 	}
 	if fbProvider == "" {
@@ -2208,8 +2208,8 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 		if s.pinStore != nil {
 			sessionKey := DeriveSessionKey(env, apiKeyID)
 			role := roleForTier(catalog.TierFor(feats.Model))
-			pin, _ := s.loadPin(ctx, sessionKey, role)
-			hmmHistory := s.loadHMMHistory(ctx, sessionKey, role)
+			pin, _ := s.loadPin(ctx, sessionKey, role, installationIDFromContext(ctx))
+			hmmHistory := s.loadHMMHistory(ctx, sessionKey, role, installationIDFromContext(ctx))
 			routeRes.SessionKey = sessionKey
 			routeRes.PriorServedModel, routeRes.SessionEverSwitched = switchHistoryFromPins(pin, hmmHistory)
 		}
@@ -3253,7 +3253,7 @@ func (s *Service) recordTurnUsage(res turnLoopResult, servedProvider, servedMode
 	if role == "" {
 		role = sessionpin.DefaultRole
 	}
-	if err := s.pinStore.UpdateUsage(context.Background(), res.SessionKey, role, usage); err != nil {
+	if err := s.pinStore.UpdateUsage(context.Background(), res.SessionKey, role, res.InstallationID, usage); err != nil {
 		observability.Get().Error("session pin usage writeback failed", "err", err)
 	}
 }
@@ -3275,7 +3275,7 @@ func (s *Service) recordHMMTurnHistory(res turnLoopResult, servedProvider, serve
 	if !hasUsage {
 		// A failed turn has no usage writeback; preserve the prior provider to
 		// avoid an invalid model/provider pair on the next HMM stay.
-		if prior := s.loadHMMHistory(context.Background(), res.SessionKey, res.PinRole); prior.Provider != "" {
+		if prior := s.loadHMMHistory(context.Background(), res.SessionKey, res.PinRole, res.InstallationID); prior.Provider != "" {
 			historyProvider = prior.Provider
 		}
 	}
@@ -3297,7 +3297,7 @@ func (s *Service) recordHMMTurnHistory(res turnLoopResult, servedProvider, serve
 		return
 	}
 	now := time.Now()
-	if err := s.pinStore.UpdateUsage(context.Background(), res.SessionKey, role, sessionpin.Usage{
+	if err := s.pinStore.UpdateUsage(context.Background(), res.SessionKey, role, res.InstallationID, sessionpin.Usage{
 		InputTokens:         in,
 		CachedReadTokens:    cacheRead,
 		CachedWriteTokens:   cacheCreation,

--- a/internal/proxy/service_session_pin_test.go
+++ b/internal/proxy/service_session_pin_test.go
@@ -51,7 +51,7 @@ func newFakePinStore() *fakePinStore {
 	}
 }
 
-func (f *fakePinStore) Get(ctx context.Context, key [sessionpin.SessionKeyLen]byte, role string) (sessionpin.Pin, bool, error) {
+func (f *fakePinStore) Get(ctx context.Context, key [sessionpin.SessionKeyLen]byte, role string, _ uuid.UUID) (sessionpin.Pin, bool, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.getCalls++
@@ -87,7 +87,7 @@ func (f *fakePinStore) Upsert(ctx context.Context, p sessionpin.Pin) error {
 	return nil
 }
 
-func (f *fakePinStore) UpdateUsage(ctx context.Context, key [sessionpin.SessionKeyLen]byte, role string, usage sessionpin.Usage) error {
+func (f *fakePinStore) UpdateUsage(ctx context.Context, key [sessionpin.SessionKeyLen]byte, role string, _ uuid.UUID, usage sessionpin.Usage) error {
 	f.mu.Lock()
 	f.usages = append(f.usages, usage)
 	f.mu.Unlock()
@@ -98,7 +98,7 @@ func (f *fakePinStore) UpdateUsage(ctx context.Context, key [sessionpin.SessionK
 	return nil
 }
 
-func (f *fakePinStore) IncrementUpstreamErrors(ctx context.Context, key [sessionpin.SessionKeyLen]byte, role string) (int, error) {
+func (f *fakePinStore) IncrementUpstreamErrors(ctx context.Context, key [sessionpin.SessionKeyLen]byte, role string, _ uuid.UUID) (int, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.incrementCalls++
@@ -108,7 +108,7 @@ func (f *fakePinStore) IncrementUpstreamErrors(ctx context.Context, key [session
 	return f.incrementReturns, nil
 }
 
-func (f *fakePinStore) ResetUpstreamErrors(ctx context.Context, key [sessionpin.SessionKeyLen]byte, role string) error {
+func (f *fakePinStore) ResetUpstreamErrors(ctx context.Context, key [sessionpin.SessionKeyLen]byte, role string, _ uuid.UUID) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.resetCalls++

--- a/internal/proxy/turnloop.go
+++ b/internal/proxy/turnloop.go
@@ -281,7 +281,7 @@ func (s *Service) runTurnLoop(
 	threadSessionKey := DeriveSessionKey(env, apiKeyID)
 	hardPinnedTurn := s.isHardPinnedTurn(ctx, res.TurnType)
 	if s.pinStore != nil && hardPinnedTurn {
-		if forcedPin, found := s.loadPin(ctx, threadSessionKey, res.PinRole); found &&
+		if forcedPin, found := s.loadPin(ctx, threadSessionKey, res.PinRole, installationID); found &&
 			isUserForcedReason(forcedPin.Reason) && forcedPinEligible(forcedPin, req) {
 			res.SessionKey = threadSessionKey
 			res.PinModel = forcedPin.Model
@@ -384,8 +384,8 @@ func (s *Service) runTurnLoop(
 
 	res.SessionKey = sessionKey
 
-	pin, pinFound := s.loadPin(ctx, res.SessionKey, res.PinRole)
-	hmmHistory := s.loadHMMHistory(ctx, res.SessionKey, res.PinRole)
+	pin, pinFound := s.loadPin(ctx, res.SessionKey, res.PinRole, installationID)
+	hmmHistory := s.loadHMMHistory(ctx, res.SessionKey, res.PinRole, installationID)
 	res.PriorServedModel, res.SessionEverSwitched = switchHistoryFromPins(pin, hmmHistory)
 	// Computed before any same-turn pin-drop guards below so it reflects the
 	// prior turn's outcome; Service.effortEscalation gates whether it's acted on.
@@ -1050,10 +1050,12 @@ func roleForTier(t catalog.Tier) string {
 // loadPin returns the stored pin and whether it may actively serve this turn.
 // Expired rows are misses for routing, but their history fields still protect
 // Anthropic emit from stale thinking-block signatures in the client transcript.
-func (s *Service) loadPin(ctx context.Context, sessionKey [sessionpin.SessionKeyLen]byte, role string) (sessionpin.Pin, bool) {
+// An installation_id mismatch is treated as not-found (defense-in-depth for
+// #796); callers then fall through to the same miss path as an absent pin.
+func (s *Service) loadPin(ctx context.Context, sessionKey [sessionpin.SessionKeyLen]byte, role string, installationID uuid.UUID) (sessionpin.Pin, bool) {
 	log := observability.FromContext(ctx)
 	log.Debug("loadPin called", "role", role, "session_key_hex", fmt.Sprintf("%x", sessionKey))
-	pin, found, err := s.pinStore.Get(ctx, sessionKey, role)
+	pin, found, err := s.pinStore.Get(ctx, sessionKey, role, installationID)
 	if err != nil {
 		log.Error("session pin store unavailable; falling through to cluster scorer", "err", err)
 		return sessionpin.Pin{}, false
@@ -1067,9 +1069,9 @@ func (s *Service) loadPin(ctx context.Context, sessionKey [sessionpin.SessionKey
 	return pin, true
 }
 
-func (s *Service) loadHMMHistory(ctx context.Context, sessionKey [sessionpin.SessionKeyLen]byte, role string) sessionpin.Pin {
+func (s *Service) loadHMMHistory(ctx context.Context, sessionKey [sessionpin.SessionKeyLen]byte, role string, installationID uuid.UUID) sessionpin.Pin {
 	log := observability.FromContext(ctx)
-	pin, found, err := s.pinStore.Get(ctx, sessionKey, hmmHistoryRole(role))
+	pin, found, err := s.pinStore.Get(ctx, sessionKey, hmmHistoryRole(role), installationID)
 	if err != nil {
 		log.Error("HMM switch-history store unavailable", "err", err)
 		return sessionpin.Pin{}

--- a/internal/proxy/turnloop_internal_test.go
+++ b/internal/proxy/turnloop_internal_test.go
@@ -33,7 +33,7 @@ func newStubPinStore() *stubPinStore {
 	return &stubPinStore{}
 }
 
-func (s *stubPinStore) Get(context.Context, [sessionpin.SessionKeyLen]byte, string) (sessionpin.Pin, bool, error) {
+func (s *stubPinStore) Get(context.Context, [sessionpin.SessionKeyLen]byte, string, uuid.UUID) (sessionpin.Pin, bool, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return s.getPin, s.getFound, nil
@@ -49,7 +49,7 @@ func (s *stubPinStore) Upsert(_ context.Context, p sessionpin.Pin) error {
 	return nil
 }
 
-func (s *stubPinStore) UpdateUsage(_ context.Context, _ [sessionpin.SessionKeyLen]byte, role string, u sessionpin.Usage) error {
+func (s *stubPinStore) UpdateUsage(_ context.Context, _ [sessionpin.SessionKeyLen]byte, role string, _ uuid.UUID, u sessionpin.Usage) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.lastUsage = u
@@ -58,11 +58,11 @@ func (s *stubPinStore) UpdateUsage(_ context.Context, _ [sessionpin.SessionKeyLe
 	return nil
 }
 
-func (s *stubPinStore) IncrementUpstreamErrors(context.Context, [sessionpin.SessionKeyLen]byte, string) (int, error) {
+func (s *stubPinStore) IncrementUpstreamErrors(context.Context, [sessionpin.SessionKeyLen]byte, string, uuid.UUID) (int, error) {
 	return 0, nil
 }
 
-func (s *stubPinStore) ResetUpstreamErrors(context.Context, [sessionpin.SessionKeyLen]byte, string) error {
+func (s *stubPinStore) ResetUpstreamErrors(context.Context, [sessionpin.SessionKeyLen]byte, string, uuid.UUID) error {
 	return nil
 }
 
@@ -970,7 +970,7 @@ func TestLoadPin_DoesNotServeExpiredPostgresPinButKeepsEmitHistory(t *testing.T)
 	}
 	store.getFound = true
 
-	pin, found := svc.loadPin(context.Background(), sessionKey, sessionpin.DefaultRole)
+	pin, found := svc.loadPin(context.Background(), sessionKey, sessionpin.DefaultRole, uuid.Nil)
 	assert.False(t, found, "expired Postgres row must not be served")
 	assert.Equal(t, "claude-opus-4-7", pin.LastServedModel, "expired row history must be available for emit")
 	assert.True(t, pin.HasEverSwitched, "expired row latch must be available for emit")
@@ -1015,7 +1015,7 @@ func TestLoadPin_ServesFreshPostgresPin(t *testing.T) {
 	}
 	store.getFound = true
 
-	pin, found := svc.loadPin(context.Background(), sessionKey, sessionpin.DefaultRole)
+	pin, found := svc.loadPin(context.Background(), sessionKey, sessionpin.DefaultRole, uuid.Nil)
 	require.True(t, found, "non-expired Postgres row must be returned")
 	assert.Equal(t, "claude-opus-4-7", pin.Model)
 	assert.Equal(t, "anthropic", pin.Provider)

--- a/internal/router/sessionpin/store.go
+++ b/internal/router/sessionpin/store.go
@@ -85,17 +85,18 @@ type Usage struct {
 }
 
 // Store is the I/O surface for session pins. Get returns (zero, false, nil)
-// when no row exists; UpdateUsage/IncrementUpstreamErrors/ResetUpstreamErrors
-// are no-ops on an evicted or missing pin.
+// when no row exists (or installation_id mismatches); UpdateUsage /
+// IncrementUpstreamErrors / ResetUpstreamErrors are no-ops on an evicted,
+// missing, or cross-installation pin.
 //
 // IncrementUpstreamErrors atomically bumps the error counter and returns the
 // new count so the turn loop can two-strike-evict without a cross-pod
 // read-modify-write race; it returns (0, nil) for a missing pin.
 type Store interface {
-	Get(ctx context.Context, sessionKey [SessionKeyLen]byte, role string) (Pin, bool, error)
+	Get(ctx context.Context, sessionKey [SessionKeyLen]byte, role string, installationID uuid.UUID) (Pin, bool, error)
 	Upsert(ctx context.Context, p Pin) error
-	UpdateUsage(ctx context.Context, sessionKey [SessionKeyLen]byte, role string, usage Usage) error
-	IncrementUpstreamErrors(ctx context.Context, sessionKey [SessionKeyLen]byte, role string) (int, error)
-	ResetUpstreamErrors(ctx context.Context, sessionKey [SessionKeyLen]byte, role string) error
+	UpdateUsage(ctx context.Context, sessionKey [SessionKeyLen]byte, role string, installationID uuid.UUID, usage Usage) error
+	IncrementUpstreamErrors(ctx context.Context, sessionKey [SessionKeyLen]byte, role string, installationID uuid.UUID) (int, error)
+	ResetUpstreamErrors(ctx context.Context, sessionKey [SessionKeyLen]byte, role string, installationID uuid.UUID) error
 	SweepExpired(ctx context.Context) error
 }

--- a/internal/sqlc/billing.sql.go
+++ b/internal/sqlc/billing.sql.go
@@ -90,9 +90,14 @@ key_spend AS (
     -- (the debit no-ops and the app sees ErrBalanceRowMissing) we must NOT bump
     -- the key's lifetime spend, or a capped key could trip its cap with no
     -- matching ledger debit.
-    UPDATE router.model_router_api_keys
+    -- Ownership: only bump a key whose installation's external_id matches the
+    -- org being debited (#796) — a mismatched api_key_id silently no-ops.
+    UPDATE router.model_router_api_keys k
     SET spent_usd_micros = spent_usd_micros - $1::bigint
-    WHERE id = $7::uuid
+    FROM router.model_router_installations i
+    WHERE k.id = $7::uuid
+      AND k.installation_id = i.id
+      AND i.external_id = $2::varchar
       AND EXISTS (SELECT 1 FROM updated)
 ),
 user_month_spend AS (
@@ -102,6 +107,8 @@ user_month_spend AS (
     -- Also no-ops when the user row no longer exists (stale cached id after a
     -- cascade delete mid-request) so a dangling FK can't roll back the debit
     -- after inference was already served.
+    -- Ownership: user must belong to an installation whose external_id matches
+    -- the org being debited (#796) — a mismatched router_user_id silently no-ops.
     INSERT INTO router.model_router_user_monthly_spend (router_user_id, month, spent_usd_micros, updated_at)
     SELECT
         $8::uuid,
@@ -111,8 +118,11 @@ user_month_spend AS (
     WHERE $8::uuid IS NOT NULL
       AND EXISTS (SELECT 1 FROM updated)
       AND EXISTS (
-          SELECT 1 FROM router.model_router_users
-          WHERE id = $8::uuid
+          SELECT 1
+          FROM router.model_router_users u
+          JOIN router.model_router_installations i ON i.id = u.installation_id
+          WHERE u.id = $8::uuid
+            AND i.external_id = $2::varchar
       )
     ON CONFLICT (router_user_id, month) DO UPDATE
     SET spent_usd_micros = router.model_router_user_monthly_spend.spent_usd_micros + EXCLUDED.spent_usd_micros,
@@ -201,9 +211,14 @@ type DebitOrgCreditsParams struct {
 //	    -- (the debit no-ops and the app sees ErrBalanceRowMissing) we must NOT bump
 //	    -- the key's lifetime spend, or a capped key could trip its cap with no
 //	    -- matching ledger debit.
-//	    UPDATE router.model_router_api_keys
+//	    -- Ownership: only bump a key whose installation's external_id matches the
+//	    -- org being debited (#796) — a mismatched api_key_id silently no-ops.
+//	    UPDATE router.model_router_api_keys k
 //	    SET spent_usd_micros = spent_usd_micros - $1::bigint
-//	    WHERE id = $7::uuid
+//	    FROM router.model_router_installations i
+//	    WHERE k.id = $7::uuid
+//	      AND k.installation_id = i.id
+//	      AND i.external_id = $2::varchar
 //	      AND EXISTS (SELECT 1 FROM updated)
 //	),
 //	user_month_spend AS (
@@ -213,6 +228,8 @@ type DebitOrgCreditsParams struct {
 //	    -- Also no-ops when the user row no longer exists (stale cached id after a
 //	    -- cascade delete mid-request) so a dangling FK can't roll back the debit
 //	    -- after inference was already served.
+//	    -- Ownership: user must belong to an installation whose external_id matches
+//	    -- the org being debited (#796) — a mismatched router_user_id silently no-ops.
 //	    INSERT INTO router.model_router_user_monthly_spend (router_user_id, month, spent_usd_micros, updated_at)
 //	    SELECT
 //	        $8::uuid,
@@ -222,8 +239,11 @@ type DebitOrgCreditsParams struct {
 //	    WHERE $8::uuid IS NOT NULL
 //	      AND EXISTS (SELECT 1 FROM updated)
 //	      AND EXISTS (
-//	          SELECT 1 FROM router.model_router_users
-//	          WHERE id = $8::uuid
+//	          SELECT 1
+//	          FROM router.model_router_users u
+//	          JOIN router.model_router_installations i ON i.id = u.installation_id
+//	          WHERE u.id = $8::uuid
+//	            AND i.external_id = $2::varchar
 //	      )
 //	    ON CONFLICT (router_user_id, month) DO UPDATE
 //	    SET spent_usd_micros = router.model_router_user_monthly_spend.spent_usd_micros + EXCLUDED.spent_usd_micros,

--- a/internal/sqlc/session_pins.sql.go
+++ b/internal/sqlc/session_pins.sql.go
@@ -17,11 +17,13 @@ SELECT session_key, role, installation_id, pinned_provider, pinned_model, decisi
 FROM router.session_pins
 WHERE session_key = $1::bytea
   AND role        = $2::varchar
+  AND installation_id = $3::uuid
 `
 
 type GetSessionPinParams struct {
-	SessionKey []byte
-	Role       string
+	SessionKey     []byte
+	Role           string
+	InstallationID uuid.UUID
 }
 
 // Reads the active pin for a (session_key, role) pair. Single-row;
@@ -35,8 +37,9 @@ type GetSessionPinParams struct {
 //	FROM router.session_pins
 //	WHERE session_key = $1::bytea
 //	  AND role        = $2::varchar
+//	  AND installation_id = $3::uuid
 func (q *Queries) GetSessionPin(ctx context.Context, arg GetSessionPinParams) (RouterSessionPin, error) {
-	row := q.db.QueryRow(ctx, getSessionPin, arg.SessionKey, arg.Role)
+	row := q.db.QueryRow(ctx, getSessionPin, arg.SessionKey, arg.Role, arg.InstallationID)
 	var i RouterSessionPin
 	err := row.Scan(
 		&i.SessionKey,
@@ -68,28 +71,32 @@ UPDATE router.session_pins
 SET consecutive_upstream_errors = consecutive_upstream_errors + 1
 WHERE session_key = $1::bytea
   AND role        = $2::varchar
+  AND installation_id = $3::uuid
 RETURNING consecutive_upstream_errors
 `
 
 type IncrementSessionPinUpstreamErrorsParams struct {
-	SessionKey []byte
-	Role       string
+	SessionKey     []byte
+	Role           string
+	InstallationID uuid.UUID
 }
 
 // Atomically increments consecutive_upstream_errors and returns the
 // new value. The turn loop calls this after a non-retryable upstream
 // 4xx on a sticky-pinned turn; the returned count drives the
 // two-strike eviction decision. Returns sql.ErrNoRows if no pin
-// exists, which the adapter maps to a no-op (pin must already be
-// evicted by another path, e.g. force-model / loop-break).
+// exists (or installation_id mismatches), which the adapter maps to a
+// no-op (pin must already be evicted by another path, e.g. force-model /
+// loop-break).
 //
 //	UPDATE router.session_pins
 //	SET consecutive_upstream_errors = consecutive_upstream_errors + 1
 //	WHERE session_key = $1::bytea
 //	  AND role        = $2::varchar
+//	  AND installation_id = $3::uuid
 //	RETURNING consecutive_upstream_errors
 func (q *Queries) IncrementSessionPinUpstreamErrors(ctx context.Context, arg IncrementSessionPinUpstreamErrorsParams) (int32, error) {
-	row := q.db.QueryRow(ctx, incrementSessionPinUpstreamErrors, arg.SessionKey, arg.Role)
+	row := q.db.QueryRow(ctx, incrementSessionPinUpstreamErrors, arg.SessionKey, arg.Role, arg.InstallationID)
 	var consecutive_upstream_errors int32
 	err := row.Scan(&consecutive_upstream_errors)
 	return consecutive_upstream_errors, err
@@ -100,25 +107,29 @@ UPDATE router.session_pins
 SET consecutive_upstream_errors = 0
 WHERE session_key = $1::bytea
   AND role        = $2::varchar
+  AND installation_id = $3::uuid
   AND consecutive_upstream_errors > 0
 `
 
 type ResetSessionPinUpstreamErrorsParams struct {
-	SessionKey []byte
-	Role       string
+	SessionKey     []byte
+	Role           string
+	InstallationID uuid.UUID
 }
 
 // Clears the two-strike counter after a successful turn. UPDATE
-// matches by (session_key, role); zero rows affected on missing pin
-// is a successful no-op like UpdateSessionPinUsage.
+// matches by (session_key, role, installation_id); zero rows affected
+// on missing pin (or ownership mismatch) is a successful no-op like
+// UpdateSessionPinUsage.
 //
 //	UPDATE router.session_pins
 //	SET consecutive_upstream_errors = 0
 //	WHERE session_key = $1::bytea
 //	  AND role        = $2::varchar
+//	  AND installation_id = $3::uuid
 //	  AND consecutive_upstream_errors > 0
 func (q *Queries) ResetSessionPinUpstreamErrors(ctx context.Context, arg ResetSessionPinUpstreamErrorsParams) error {
-	_, err := q.db.Exec(ctx, resetSessionPinUpstreamErrors, arg.SessionKey, arg.Role)
+	_, err := q.db.Exec(ctx, resetSessionPinUpstreamErrors, arg.SessionKey, arg.Role, arg.InstallationID)
 	return err
 }
 
@@ -153,6 +164,7 @@ SET last_input_tokens        = $1::int,
     last_served_model        = $7::varchar
 WHERE session_key = $9::bytea
   AND role        = $10::varchar
+  AND installation_id = $11::uuid
 `
 
 type UpdateSessionPinUsageParams struct {
@@ -166,6 +178,7 @@ type UpdateSessionPinUsageParams struct {
 	PriorServedModel      string
 	SessionKey            []byte
 	Role                  string
+	InstallationID        uuid.UUID
 }
 
 // Records the previous turn's upstream token usage on an existing pin
@@ -197,6 +210,7 @@ type UpdateSessionPinUsageParams struct {
 //	    last_served_model        = $7::varchar
 //	WHERE session_key = $9::bytea
 //	  AND role        = $10::varchar
+//	  AND installation_id = $11::uuid
 func (q *Queries) UpdateSessionPinUsage(ctx context.Context, arg UpdateSessionPinUsageParams) error {
 	_, err := q.db.Exec(ctx, updateSessionPinUsage,
 		arg.LastInputTokens,
@@ -209,6 +223,7 @@ func (q *Queries) UpdateSessionPinUsage(ctx context.Context, arg UpdateSessionPi
 		arg.PriorServedModel,
 		arg.SessionKey,
 		arg.Role,
+		arg.InstallationID,
 	)
 	return err
 }
@@ -258,6 +273,7 @@ ON CONFLICT (session_key, role) DO UPDATE SET
       THEN router.session_pins.consecutive_upstream_errors
     ELSE 0
   END
+WHERE router.session_pins.installation_id = EXCLUDED.installation_id
 `
 
 type UpsertSessionPinParams struct {
@@ -277,11 +293,14 @@ type UpsertSessionPinParams struct {
 // turn_count increments on conflict so we can observe how many turns a
 // single (session_key, role) lives for. installation_id is set on first
 // insert and not touched on update — re-binding a session to a different
-// installation would indicate a bug, not a legitimate state. The
-// last_*_tokens / last_turn_ended_at columns are deliberately omitted
-// from the ON CONFLICT update set: only UpdateSessionPinUsage writes
-// them, so the at-start-of-turn refresh here cannot clobber the
-// previous turn's usage with zeros before the planner reads it.
+// installation would indicate a bug, not a legitimate state. The ON CONFLICT
+// DO UPDATE is gated on installation_id = EXCLUDED.installation_id so a
+// mismatched caller silently no-ops rather than overwriting another
+// tenant's pin. The last_*_tokens / last_turn_ended_at columns are
+// deliberately omitted from the ON CONFLICT update set: only
+// UpdateSessionPinUsage writes them, so the at-start-of-turn refresh
+// here cannot clobber the previous turn's usage with zeros before the
+// planner reads it.
 //
 // consecutive_upstream_errors is preserved on a same-model refresh (so
 // the two-strike eviction counter accumulates across turns of the same
@@ -344,6 +363,7 @@ type UpsertSessionPinParams struct {
 //	      THEN router.session_pins.consecutive_upstream_errors
 //	    ELSE 0
 //	  END
+//	WHERE router.session_pins.installation_id = EXCLUDED.installation_id
 func (q *Queries) UpsertSessionPin(ctx context.Context, arg UpsertSessionPinParams) error {
 	_, err := q.db.Exec(ctx, upsertSessionPin,
 		arg.SessionKey,

--- a/internal/sqlc/spend_limits.sql.go
+++ b/internal/sqlc/spend_limits.sql.go
@@ -78,18 +78,27 @@ const getUserMonthlySpendAndLimit = `-- name: GetUserMonthlySpendAndLimit :one
 SELECT
     (EXISTS (
         SELECT 1 FROM router.model_router_user_spend_limits ovr
+        JOIN router.model_router_users u ON u.id = ovr.router_user_id
+        JOIN router.model_router_installations i ON i.id = u.installation_id
         WHERE ovr.router_user_id = $1::uuid
+          AND i.external_id = $2::varchar
     ))::boolean AS has_override,
     (SELECT ovr.monthly_limit_usd_micros
      FROM router.model_router_user_spend_limits ovr
-     WHERE ovr.router_user_id = $1::uuid) AS override_limit_usd_micros,
+     JOIN router.model_router_users u ON u.id = ovr.router_user_id
+     JOIN router.model_router_installations i ON i.id = u.installation_id
+     WHERE ovr.router_user_id = $1::uuid
+       AND i.external_id = $2::varchar) AS override_limit_usd_micros,
     (SELECT lim.user_monthly_limit_usd_micros
      FROM router.organization_spend_limits lim
      WHERE lim.organization_id = $2::varchar) AS org_default_limit_usd_micros,
     COALESCE((
         SELECT sp.spent_usd_micros
         FROM router.model_router_user_monthly_spend sp
+        JOIN router.model_router_users u ON u.id = sp.router_user_id
+        JOIN router.model_router_installations i ON i.id = u.installation_id
         WHERE sp.router_user_id = $1::uuid
+          AND i.external_id = $2::varchar
           AND sp.month = DATE_TRUNC('month', NOW() AT TIME ZONE 'utc')::date
     ), 0)::bigint AS spent_usd_micros
 `
@@ -111,22 +120,34 @@ type GetUserMonthlySpendAndLimitRow struct {
 // per-user override when an override row exists (its NULL means "explicitly
 // uncapped"), otherwise the org-wide default; has_override distinguishes the
 // two NULL meanings. spent is 0 when the user has no spend row this month.
+// Spend/override subqueries require the user to belong to an installation
+// whose external_id matches @organization_id (#796); a mismatched pair is a
+// silent miss (spent 0, no override). Org default still resolves for the org.
 //
 //	SELECT
 //	    (EXISTS (
 //	        SELECT 1 FROM router.model_router_user_spend_limits ovr
+//	        JOIN router.model_router_users u ON u.id = ovr.router_user_id
+//	        JOIN router.model_router_installations i ON i.id = u.installation_id
 //	        WHERE ovr.router_user_id = $1::uuid
+//	          AND i.external_id = $2::varchar
 //	    ))::boolean AS has_override,
 //	    (SELECT ovr.monthly_limit_usd_micros
 //	     FROM router.model_router_user_spend_limits ovr
-//	     WHERE ovr.router_user_id = $1::uuid) AS override_limit_usd_micros,
+//	     JOIN router.model_router_users u ON u.id = ovr.router_user_id
+//	     JOIN router.model_router_installations i ON i.id = u.installation_id
+//	     WHERE ovr.router_user_id = $1::uuid
+//	       AND i.external_id = $2::varchar) AS override_limit_usd_micros,
 //	    (SELECT lim.user_monthly_limit_usd_micros
 //	     FROM router.organization_spend_limits lim
 //	     WHERE lim.organization_id = $2::varchar) AS org_default_limit_usd_micros,
 //	    COALESCE((
 //	        SELECT sp.spent_usd_micros
 //	        FROM router.model_router_user_monthly_spend sp
+//	        JOIN router.model_router_users u ON u.id = sp.router_user_id
+//	        JOIN router.model_router_installations i ON i.id = u.installation_id
 //	        WHERE sp.router_user_id = $1::uuid
+//	          AND i.external_id = $2::varchar
 //	          AND sp.month = DATE_TRUNC('month', NOW() AT TIME ZONE 'utc')::date
 //	    ), 0)::bigint AS spent_usd_micros
 func (q *Queries) GetUserMonthlySpendAndLimit(ctx context.Context, arg GetUserMonthlySpendAndLimitParams) (GetUserMonthlySpendAndLimitRow, error) {


### PR DESCRIPTION
Fixes #796.

## Summary

Four SQL ownership gaps where tenant isolation was enforced only by the 
application layer always passing trusted, same-tenant IDs, not by the SQL 
itself. Same pattern as #536 (closed, fixed for 
`SoftDeleteModelRouterAPIKey`), found here on four additional call sites: 
`session_pins` (reads and writes), and three billing queries (`key_spend` 
and `user_month_spend` in `DebitOrgCredits`, plus 
`GetUserMonthlySpendAndLimit`). The fourth (`user_month_spend`) was found 
during the fix-design investigation, the same class of gap as the 
`GetUserMonthlySpendAndLimit` read-side finding, just on the write side of 
the same query, included here since it's the same pattern and the same 
file already being touched for `key_spend`.

Confirmed in #796 (independently verified twice before filing: an 
independent investigation pass, and manual live SQL reproduction on local 
Postgres) that none of these are reachable via any current authenticated 
`/v1/*` request. This is a hardening fix, not a response to an active 
exploit.

## Fix

`session_pins`: added `AND installation_id = @installation_id::uuid` to 
`GetSessionPin`, `UpdateSessionPinUsage`, 
`IncrementSessionPinUpstreamErrors`, and `ResetSessionPinUpstreamErrors`. 
`UpsertSessionPin`'s `ON CONFLICT DO UPDATE` gained `WHERE 
router.session_pins.installation_id = EXCLUDED.installation_id`, so a 
mismatched caller's upsert silently no-ops rather than overwriting another 
tenant's pin, without needing a PK migration. `installation_id` threaded 
through the `sessionpin.Store` interface (`Get`, `UpdateUsage`, 
`IncrementUpstreamErrors`, `ResetUpstreamErrors`) and every call site 
(`loadPin`, `setForceModelPin`, `maybeRepinOnRefusal`, loop-escalation 
handling, `recordTurnUsage`, `maybeEvictPinAfterUpstreamErr`, 
cyber-refusal re-pin, the feedback pin lookup). `SweepExpiredSessionPins` 
is intentionally untouched, it's global GC by `expires_at`, not 
tenant-scoped.

`key_spend` and `user_month_spend` CTEs (`DebitOrgCredits`): both now join 
`api_key_id`/`router_user_id` through to 
`model_router_installations.external_id` and confirm it matches the 
`organization_id` being debited, before bumping the key's or user's spend 
counter. A mismatched ID silently no-ops that one CTE, the org debit and 
ledger row still proceed correctly, same no-op pattern the query already 
uses for a missing key or deleted user.

`GetUserMonthlySpendAndLimit`: the `has_override`, 
`override_limit_usd_micros`, and `spent_usd_micros` subqueries now join 
through `model_router_users` to `model_router_installations.external_id` 
and require it to match the `organization_id` parameter. 
`org_default_limit_usd_micros` is correctly left unjoined, it's 
org-scoped only, with no user dimension.

All four: mismatch means a silent miss or no-op (0 spend, no override, 
pin treated as not-found), not a new error path, matching how each of 
these already handles a missing row today.

## Commits

1. test: failing regression tests reproducing all four gaps against real 
   Postgres and real repo/service code
2. fix(db): session_pins ownership, SQL + Store interface + every call 
   site
3. fix(db): key_spend, user_month_spend, and GetUserMonthlySpendAndLimit 
   ownership joins

## Testing

- Four permanent regression tests, one per finding, confirmed failing 
  against pre-fix code for the right reason (the actual cross-tenant leak 
  occurring, not a setup error), then passing after each corresponding 
  fix commit.
- go test ./internal/proxy/... ./internal/router/sessionpin/... -count=1 
  after the session_pins commit, clean.
- go test ./internal/billing/... ./internal/postgres/... -v -count=1 
  after the billing commit, clean.
- go test ./... -count=1, zero regressions anywhere in the repo, 
  including after a rebase onto origin/main (which had landed unrelated 
  changes touching internal/proxy/service.go and turnloop.go, #797/#798 
  no file overlap with session_pins/billing queries; full suite + 
  make check re-run clean post-rebase).
- make check, clean.
- Manual before/after reproduction (real Go code, test data cleaned up 
  after):

| Finding | Before | After |
|---|---|---|
| session_pins | install=A, model overwritten to model-from-B, turn_count=2 | install=A, model stays model-from-A, turn_count=1; a Get as B correctly misses |
| key_spend | org A debited correctly, but B's key spent_usd_micros also bumped to $0.50 | org A debited correctly, B's key stays at $0.00 |
| user_month_spend | B's monthly spend row created (count=1) from an org A debit | no row created for B (count=0) |
| GetUserMonthlySpendAndLimit | org A + B's user id returned B's real spend ($0.42) under org A's limit | returns $0.00 spend, org A's limit unaffected |

## No migration required

All four fixes are query-level (plus sqlc regeneration); every column 
referenced already exists.

## Related

#796 (this PR fixes it), #536 (closed, same pattern precedent, different 
table).