### PR TITLE
feat: add provider-aware policy arms

### DIFF
--- a/internal/policyclient/client.go
+++ b/internal/policyclient/client.go
@@ -381,11 +381,11 @@ func marshalRouteRequest(query policy.Query) ([]byte, error) {
 	models := make([]string, 0, len(query.Candidates))
 	providerMap := make(map[string]string, len(query.Candidates))
 	for _, candidate := range query.Candidates {
-		models = append(models, candidate.RosterID)
 		providerKey := candidate.RosterID
 		if schemaVersion == policy.SchemaVersionV2 {
 			providerKey = candidate.ArmID
 		}
+		models = append(models, providerKey)
 		providerMap[providerKey] = candidate.Provider
 	}
 	messages := routeMessages(query.ConversationMessages)

--- a/internal/policyclient/client.go
+++ b/internal/policyclient/client.go
@@ -382,7 +382,11 @@ func marshalRouteRequest(query policy.Query) ([]byte, error) {
 	providerMap := make(map[string]string, len(query.Candidates))
 	for _, candidate := range query.Candidates {
 		models = append(models, candidate.RosterID)
-		providerMap[candidate.RosterID] = candidate.Provider
+		providerKey := candidate.RosterID
+		if schemaVersion == policy.SchemaVersionV2 {
+			providerKey = candidate.ArmID
+		}
+		providerMap[providerKey] = candidate.Provider
 	}
 	messages := routeMessages(query.ConversationMessages)
 	wireTurnIndex := turnIndex(messages)

--- a/internal/policyclient/client.go
+++ b/internal/policyclient/client.go
@@ -291,7 +291,7 @@ func (c *Client) Decide(ctx context.Context, query policy.Query) (policy.Result,
 		}
 		return policy.Result{}, fmt.Errorf("policy sidecar status %d", resp.StatusCode)
 	}
-	if parsed.SchemaVersion != "" && parsed.SchemaVersion != policy.SchemaVersionV1 {
+	if parsed.SchemaVersion != "" && parsed.SchemaVersion != policy.SchemaVersionV1 && parsed.SchemaVersion != policy.SchemaVersionV2 {
 		return policy.Result{}, fmt.Errorf("unsupported policy route schema %q", parsed.SchemaVersion)
 	}
 	selectedModel := firstNonEmpty(parsed.SelectedRosterID, parsed.Model)
@@ -374,6 +374,10 @@ func (c *Client) Preview(ctx context.Context, query policy.Query) (policy.Previe
 }
 
 func marshalRouteRequest(query policy.Query) ([]byte, error) {
+	schemaVersion := query.SchemaVersion
+	if schemaVersion == "" {
+		schemaVersion = policy.SchemaVersionV1
+	}
 	models := make([]string, 0, len(query.Candidates))
 	providerMap := make(map[string]string, len(query.Candidates))
 	for _, candidate := range query.Candidates {
@@ -411,7 +415,7 @@ func marshalRouteRequest(query policy.Query) ([]byte, error) {
 		trainingDelta = trainingRouteMessageDelta(query.ConversationMessages)
 	}
 	body, err := json.Marshal(routeRequest{
-		SchemaVersion:             policy.SchemaVersionV1,
+		SchemaVersion:             schemaVersion,
 		Strategy:                  string(query.Strategy),
 		ExecutionMode:             query.ExecutionMode,
 		RouteID:                   query.RouteID,

--- a/internal/policyclient/client.go
+++ b/internal/policyclient/client.go
@@ -216,6 +216,7 @@ type routeToolResult struct {
 type routeResponse struct {
 	SchemaVersion        string                 `json:"schema_version"`
 	RouteID              string                 `json:"route_id"`
+	SelectedArmID        string                 `json:"selected_arm_id"`
 	SelectedRosterID     string                 `json:"selected_roster_id"`
 	SelectedProvider     string                 `json:"selected_provider"`
 	Model                string                 `json:"model"`
@@ -294,8 +295,8 @@ func (c *Client) Decide(ctx context.Context, query policy.Query) (policy.Result,
 		return policy.Result{}, fmt.Errorf("unsupported policy route schema %q", parsed.SchemaVersion)
 	}
 	selectedModel := firstNonEmpty(parsed.SelectedRosterID, parsed.Model)
-	if selectedModel == "" {
-		return policy.Result{}, fmt.Errorf("policy sidecar returned empty model")
+	if parsed.SelectedArmID == "" && selectedModel == "" {
+		return policy.Result{}, fmt.Errorf("policy sidecar returned empty arm and model")
 	}
 	score := parsed.Score
 	if parsed.ChosenScore != nil {
@@ -304,6 +305,7 @@ func (c *Client) Decide(ctx context.Context, query policy.Query) (policy.Result,
 	return policy.Result{
 		SchemaVersion:        parsed.SchemaVersion,
 		RouteID:              parsed.RouteID,
+		ArmID:                parsed.SelectedArmID,
 		Model:                selectedModel,
 		Provider:             parsed.SelectedProvider,
 		Score:                score,

--- a/internal/policyclient/client.go
+++ b/internal/policyclient/client.go
@@ -101,7 +101,7 @@ func (c *Client) Capabilities(ctx context.Context) (policy.Capabilities, error) 
 	if err := json.Unmarshal(payload, &capabilities); err != nil {
 		return policy.Capabilities{}, fmt.Errorf("decode policy capabilities response: %w", err)
 	}
-	if capabilities.SchemaVersion != policy.SchemaVersionV1 {
+	if capabilities.SchemaVersion != policy.SchemaVersionV1 && capabilities.SchemaVersion != policy.SchemaVersionV2 {
 		return policy.Capabilities{}, fmt.Errorf("unsupported policy capabilities schema %q", capabilities.SchemaVersion)
 	}
 	return capabilities, nil

--- a/internal/policyclient/client.go
+++ b/internal/policyclient/client.go
@@ -377,7 +377,7 @@ func (c *Client) Preview(ctx context.Context, query policy.Query) (policy.Previe
 		}
 		return policy.PreviewResult{}, fmt.Errorf("policy preview status %d", resp.StatusCode)
 	}
-	if parsed.SchemaVersion != policy.SchemaVersionV1 {
+	if parsed.SchemaVersion != policy.SchemaVersionV1 && parsed.SchemaVersion != policy.SchemaVersionV2 {
 		return policy.PreviewResult{}, fmt.Errorf("unsupported policy preview schema %q", parsed.SchemaVersion)
 	}
 	return policy.PreviewResult{

--- a/internal/policyclient/client.go
+++ b/internal/policyclient/client.go
@@ -140,47 +140,71 @@ func (c *Client) post(ctx context.Context, path string, payload map[string]inter
 }
 
 type routeRequest struct {
-	SchemaVersion             string             `json:"schema_version"`
-	Strategy                  string             `json:"strategy"`
-	ExecutionMode             string             `json:"execution_mode"`
-	RouteID                   string             `json:"route_id"`
-	OrganizationID            string             `json:"organization_id,omitempty"`
-	InstallationID            string             `json:"installation_id,omitempty"`
-	ClientApp                 string             `json:"client_app,omitempty"`
-	Harness                   string             `json:"harness,omitempty"`
-	RolloutID                 string             `json:"rollout_id,omitempty"`
-	RequestedModel            string             `json:"requested_model,omitempty"`
-	PromptText                string             `json:"prompt_text"`
-	LatestUserText            string             `json:"latest_user_text,omitempty"`
-	TurnIndex                 int                `json:"turn_index"`
-	VisibleTurnIndex          *int               `json:"visible_turn_index,omitempty"`
-	SessionTurnCount          *int               `json:"session_turn_count,omitempty"`
-	TurnType                  string             `json:"turn_type,omitempty"`
-	PreviousServedModel       string             `json:"previous_served_model,omitempty"`
-	PreviousProvider          string             `json:"previous_provider,omitempty"`
-	CacheState                string             `json:"cache_state,omitempty"`
-	PriorOutputTokens         *int               `json:"prior_output_tokens,omitempty"`
-	SessionEverSwitched       *bool              `json:"session_ever_switched,omitempty"`
-	HistoryTruncated          *bool              `json:"history_truncated,omitempty"`
-	ConversationMessages      []routeMessage     `json:"conversation_messages,omitempty"`
-	TrainingConversationDelta []routeMessage     `json:"training_conversation_delta,omitempty"`
-	AvailableTools            []string           `json:"available_tools,omitempty"`
-	FeedbackKey               string             `json:"feedback_key,omitempty"`
-	FeedbackRole              string             `json:"feedback_role,omitempty"`
-	ClientSessionID           string             `json:"client_session_id,omitempty"`
-	EstimatedInputTokens      int                `json:"estimated_input_tokens"`
-	HasTools                  bool               `json:"has_tools"`
-	HasImages                 bool               `json:"has_images"`
-	RoutingIntent             string             `json:"routing_intent,omitempty"`
-	PreferredModels           []string           `json:"preferred_models,omitempty"`
-	RoutingKnobs              *routingKnobs      `json:"routing_knobs,omitempty"`
-	QualityBias               *float64           `json:"quality_bias,omitempty"`
-	TrainingAllowed           bool               `json:"training_allowed"`
-	CaptureMode               string             `json:"capture_mode,omitempty"`
-	DebugEnabled              bool               `json:"debug_enabled"`
-	Candidates                []policy.Candidate `json:"candidates"`
-	CandidateModels           []string           `json:"candidate_models"`
-	CandidateProviders        map[string]string  `json:"candidate_providers"`
+	SchemaVersion             string            `json:"schema_version"`
+	Strategy                  string            `json:"strategy"`
+	ExecutionMode             string            `json:"execution_mode"`
+	RouteID                   string            `json:"route_id"`
+	OrganizationID            string            `json:"organization_id,omitempty"`
+	InstallationID            string            `json:"installation_id,omitempty"`
+	ClientApp                 string            `json:"client_app,omitempty"`
+	Harness                   string            `json:"harness,omitempty"`
+	RolloutID                 string            `json:"rollout_id,omitempty"`
+	RequestedModel            string            `json:"requested_model,omitempty"`
+	PromptText                string            `json:"prompt_text"`
+	LatestUserText            string            `json:"latest_user_text,omitempty"`
+	TurnIndex                 int               `json:"turn_index"`
+	VisibleTurnIndex          *int              `json:"visible_turn_index,omitempty"`
+	SessionTurnCount          *int              `json:"session_turn_count,omitempty"`
+	TurnType                  string            `json:"turn_type,omitempty"`
+	PreviousServedModel       string            `json:"previous_served_model,omitempty"`
+	PreviousProvider          string            `json:"previous_provider,omitempty"`
+	CacheState                string            `json:"cache_state,omitempty"`
+	PriorOutputTokens         *int              `json:"prior_output_tokens,omitempty"`
+	SessionEverSwitched       *bool             `json:"session_ever_switched,omitempty"`
+	HistoryTruncated          *bool             `json:"history_truncated,omitempty"`
+	ConversationMessages      []routeMessage    `json:"conversation_messages,omitempty"`
+	TrainingConversationDelta []routeMessage    `json:"training_conversation_delta,omitempty"`
+	AvailableTools            []string          `json:"available_tools,omitempty"`
+	FeedbackKey               string            `json:"feedback_key,omitempty"`
+	FeedbackRole              string            `json:"feedback_role,omitempty"`
+	ClientSessionID           string            `json:"client_session_id,omitempty"`
+	EstimatedInputTokens      int               `json:"estimated_input_tokens"`
+	HasTools                  bool              `json:"has_tools"`
+	HasImages                 bool              `json:"has_images"`
+	RoutingIntent             string            `json:"routing_intent,omitempty"`
+	PreferredModels           []string          `json:"preferred_models,omitempty"`
+	RoutingKnobs              *routingKnobs     `json:"routing_knobs,omitempty"`
+	QualityBias               *float64          `json:"quality_bias,omitempty"`
+	TrainingAllowed           bool              `json:"training_allowed"`
+	CaptureMode               string            `json:"capture_mode,omitempty"`
+	DebugEnabled              bool              `json:"debug_enabled"`
+	Candidates                []routeCandidate  `json:"candidates"`
+	CandidateModels           []string          `json:"candidate_models"`
+	CandidateProviders        map[string]string `json:"candidate_providers"`
+}
+
+type routeCandidate struct {
+	RosterID                  string                       `json:"roster_id"`
+	CatalogID                 string                       `json:"catalog_id"`
+	Provider                  string                       `json:"provider"`
+	UpstreamID                string                       `json:"upstream_id"`
+	PreferenceRank            *int                         `json:"preference_rank,omitempty"`
+	InputUSDPer1M             float64                      `json:"input_usd_per_1m"`
+	OutputUSDPer1M            float64                      `json:"output_usd_per_1m"`
+	EstimatedCostUSD          float64                      `json:"estimated_cost_usd"`
+	CacheReadMultiplier       float64                      `json:"cache_read_multiplier"`
+	MarginalCostFactor        float64                      `json:"marginal_cost_factor"`
+	EffectiveInputUSDPer1M    float64                      `json:"effective_input_usd_per_1m"`
+	EffectiveOutputUSDPer1M   float64                      `json:"effective_output_usd_per_1m"`
+	EffectiveEstimatedCostUSD float64                      `json:"effective_estimated_cost_usd"`
+	Capabilities              policy.CandidateCapabilities `json:"capabilities"`
+
+	ArmID                        string `json:"arm_id,omitempty"`
+	BindingIndex                 *int   `json:"binding_index,omitempty"`
+	Endpoint                     string `json:"endpoint,omitempty"`
+	ModelRevision                string `json:"model_revision,omitempty"`
+	ReasoningConfigurationSHA256 string `json:"reasoning_configuration_sha256,omitempty"`
+	ToolConfigurationSHA256      string `json:"tool_configuration_sha256,omitempty"`
 }
 
 type routingKnobs struct {
@@ -378,6 +402,7 @@ func marshalRouteRequest(query policy.Query) ([]byte, error) {
 	if schemaVersion == "" {
 		schemaVersion = policy.SchemaVersionV1
 	}
+	candidates := routeCandidates(query.Candidates, schemaVersion)
 	models := make([]string, 0, len(query.Candidates))
 	providerMap := make(map[string]string, len(query.Candidates))
 	for _, candidate := range query.Candidates {
@@ -457,7 +482,7 @@ func marshalRouteRequest(query policy.Query) ([]byte, error) {
 		TrainingAllowed:           query.TrainingAllowed,
 		CaptureMode:               query.CaptureMode,
 		DebugEnabled:              query.DebugEnabled,
-		Candidates:                query.Candidates,
+		Candidates:                candidates,
 		CandidateModels:           models,
 		CandidateProviders:        providerMap,
 	})
@@ -465,6 +490,39 @@ func marshalRouteRequest(query policy.Query) ([]byte, error) {
 		return nil, fmt.Errorf("marshal policy route request: %w", err)
 	}
 	return body, nil
+}
+
+func routeCandidates(candidates []policy.Candidate, schemaVersion string) []routeCandidate {
+	result := make([]routeCandidate, 0, len(candidates))
+	for _, candidate := range candidates {
+		wireCandidate := routeCandidate{
+			RosterID:                  candidate.RosterID,
+			CatalogID:                 candidate.CatalogID,
+			Provider:                  candidate.Provider,
+			UpstreamID:                candidate.UpstreamID,
+			PreferenceRank:            candidate.PreferenceRank,
+			InputUSDPer1M:             candidate.InputUSDPer1M,
+			OutputUSDPer1M:            candidate.OutputUSDPer1M,
+			EstimatedCostUSD:          candidate.EstimatedCostUSD,
+			CacheReadMultiplier:       candidate.CacheReadMultiplier,
+			MarginalCostFactor:        candidate.MarginalCostFactor,
+			EffectiveInputUSDPer1M:    candidate.EffectiveInputUSDPer1M,
+			EffectiveOutputUSDPer1M:   candidate.EffectiveOutputUSDPer1M,
+			EffectiveEstimatedCostUSD: candidate.EffectiveEstimatedCostUSD,
+			Capabilities:              candidate.Capabilities,
+		}
+		if schemaVersion == policy.SchemaVersionV2 {
+			bindingIndex := candidate.BindingIndex
+			wireCandidate.ArmID = candidate.ArmID
+			wireCandidate.BindingIndex = &bindingIndex
+			wireCandidate.Endpoint = candidate.Endpoint
+			wireCandidate.ModelRevision = candidate.ModelRevision
+			wireCandidate.ReasoningConfigurationSHA256 = candidate.ReasoningConfigurationSHA256
+			wireCandidate.ToolConfigurationSHA256 = candidate.ToolConfigurationSHA256
+		}
+		result = append(result, wireCandidate)
+	}
+	return result
 }
 
 func pointerTo[T any](value T) *T {

--- a/internal/policyclient/client_test.go
+++ b/internal/policyclient/client_test.go
@@ -414,16 +414,24 @@ func TestClientReturnsErrorAfterTransientRetriesExhausted(t *testing.T) {
 }
 
 func TestClientCapabilities(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
-		require.Equal(t, "/capabilities", request.URL.Path)
-		_ = json.NewEncoder(w).Encode(policy.Capabilities{SchemaVersion: policy.SchemaVersionV1, ReportsFeedback: true})
-	}))
-	defer server.Close()
+	for _, schemaVersion := range []string{policy.SchemaVersionV1, policy.SchemaVersionV2} {
+		t.Run(schemaVersion, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+				require.Equal(t, "/capabilities", request.URL.Path)
+				_ = json.NewEncoder(w).Encode(policy.Capabilities{
+					SchemaVersion:   schemaVersion,
+					ReportsFeedback: true,
+				})
+			}))
+			defer server.Close()
 
-	capabilities, err := New(server.URL, server.Client(), 0).Capabilities(context.Background())
+			capabilities, err := New(server.URL, server.Client(), 0).Capabilities(context.Background())
 
-	require.NoError(t, err)
-	assert.True(t, capabilities.ReportsFeedback)
+			require.NoError(t, err)
+			assert.Equal(t, schemaVersion, capabilities.SchemaVersion)
+			assert.True(t, capabilities.ReportsFeedback)
+		})
+	}
 }
 
 func TestClientCheckHealth(t *testing.T) {

--- a/internal/policyclient/client_test.go
+++ b/internal/policyclient/client_test.go
@@ -25,6 +25,7 @@ func TestClientPostsVersionedRouteAndParsesPolicyMetadata(t *testing.T) {
 		_ = json.NewEncoder(w).Encode(routeResponse{
 			SchemaVersion:        policy.SchemaVersionV1,
 			RouteID:              "route-1",
+			SelectedArmID:        "arm-kimi-fireworks",
 			SelectedRosterID:     "moonshotai/kimi-k2.7-code",
 			SelectedProvider:     providers.ProviderFireworks,
 			ChosenScore:          floatPtr(0.91),
@@ -91,6 +92,7 @@ func TestClientPostsVersionedRouteAndParsesPolicyMetadata(t *testing.T) {
 		ClientSessionID: "client-session-abc",
 		TrainingAllowed: true,
 		Candidates: []policy.Candidate{{
+			ArmID:          "arm-kimi-fireworks",
 			RosterID:       "moonshotai/kimi-k2.7-code",
 			CatalogID:      "moonshotai/kimi-k2.7",
 			Provider:       providers.ProviderFireworks,
@@ -146,6 +148,7 @@ func TestClientPostsVersionedRouteAndParsesPolicyMetadata(t *testing.T) {
 	assert.Equal(t, "success", got.ConversationMessages[2].ToolResults[0].ExitCategory)
 	assert.Empty(t, got.ConversationMessages[3].ToolCalls[0].InputJSON)
 	require.Len(t, got.Candidates, 1)
+	assert.Equal(t, "arm-kimi-fireworks", got.Candidates[0].ArmID)
 	assert.Equal(t, "moonshotai/kimi-k2.7", got.Candidates[0].CatalogID)
 	assert.Equal(t, "accounts/fireworks/models/kimi-k2p5", got.Candidates[0].UpstreamID)
 	assert.Equal(t, "balanced|open", result.PolicyRouteKey)
@@ -153,6 +156,7 @@ func TestClientPostsVersionedRouteAndParsesPolicyMetadata(t *testing.T) {
 	assert.Equal(t, "hmm-prod", result.PolicyArtifactID)
 	assert.Equal(t, "sha256:abc", result.PolicyArtifactSHA256)
 	assert.Equal(t, "roster-v2", result.RosterVersion)
+	assert.Equal(t, "arm-kimi-fireworks", result.ArmID)
 	assert.Equal(t, "debug-1", result.DebugRef)
 	assert.Equal(t, 0.91, result.Score)
 	assert.Equal(t, map[string]float32{"moonshotai/kimi-k2.7-code": 0.91}, result.CandidateScores)

--- a/internal/policyclient/client_test.go
+++ b/internal/policyclient/client_test.go
@@ -148,7 +148,8 @@ func TestClientPostsVersionedRouteAndParsesPolicyMetadata(t *testing.T) {
 	assert.Equal(t, "success", got.ConversationMessages[2].ToolResults[0].ExitCategory)
 	assert.Empty(t, got.ConversationMessages[3].ToolCalls[0].InputJSON)
 	require.Len(t, got.Candidates, 1)
-	assert.Equal(t, "arm-kimi-fireworks", got.Candidates[0].ArmID)
+	assert.Empty(t, got.Candidates[0].ArmID)
+	assert.Nil(t, got.Candidates[0].BindingIndex)
 	assert.Equal(t, "moonshotai/kimi-k2.7", got.Candidates[0].CatalogID)
 	assert.Equal(t, "accounts/fireworks/models/kimi-k2p5", got.Candidates[0].UpstreamID)
 	assert.Equal(t, "balanced|open", result.PolicyRouteKey)
@@ -160,6 +161,40 @@ func TestClientPostsVersionedRouteAndParsesPolicyMetadata(t *testing.T) {
 	assert.Equal(t, "debug-1", result.DebugRef)
 	assert.Equal(t, 0.91, result.Score)
 	assert.Equal(t, map[string]float32{"moonshotai/kimi-k2.7-code": 0.91}, result.CandidateScores)
+}
+
+func TestClientOmitsV2CandidateFieldsFromV1(t *testing.T) {
+	body, err := marshalRouteRequest(policy.Query{
+		SchemaVersion: policy.SchemaVersionV1,
+		Candidates: []policy.Candidate{{
+			ArmID:                        "arm-fireworks",
+			RosterID:                     "deepseek/deepseek-v4-pro",
+			CatalogID:                    "deepseek/deepseek-v4-pro",
+			Provider:                     providers.ProviderFireworks,
+			BindingIndex:                 0,
+			Endpoint:                     string(router.EndpointAnthropicMessages),
+			ModelRevision:                "2026-07-20",
+			ReasoningConfigurationSHA256: "reasoning-hash",
+			ToolConfigurationSHA256:      "tool-hash",
+		}},
+	})
+
+	require.NoError(t, err)
+	var payload struct {
+		Candidates []map[string]json.RawMessage `json:"candidates"`
+	}
+	require.NoError(t, json.Unmarshal(body, &payload))
+	require.Len(t, payload.Candidates, 1)
+	for _, field := range []string{
+		"arm_id",
+		"binding_index",
+		"endpoint",
+		"model_revision",
+		"reasoning_configuration_sha256",
+		"tool_configuration_sha256",
+	} {
+		assert.NotContains(t, payload.Candidates[0], field)
+	}
 }
 
 func TestClientPostsArmProviderMapForV2(t *testing.T) {
@@ -178,16 +213,18 @@ func TestClientPostsArmProviderMapForV2(t *testing.T) {
 		SchemaVersion: policy.SchemaVersionV2,
 		Candidates: []policy.Candidate{
 			{
-				ArmID:     "arm-fireworks",
-				RosterID:  "deepseek/deepseek-v4-pro",
-				CatalogID: "deepseek/deepseek-v4-pro",
-				Provider:  providers.ProviderFireworks,
+				ArmID:        "arm-fireworks",
+				RosterID:     "deepseek/deepseek-v4-pro",
+				CatalogID:    "deepseek/deepseek-v4-pro",
+				Provider:     providers.ProviderFireworks,
+				BindingIndex: 0,
 			},
 			{
-				ArmID:     "arm-makora",
-				RosterID:  "deepseek/deepseek-v4-pro",
-				CatalogID: "deepseek/deepseek-v4-pro",
-				Provider:  providers.ProviderMakora,
+				ArmID:        "arm-makora",
+				RosterID:     "deepseek/deepseek-v4-pro",
+				CatalogID:    "deepseek/deepseek-v4-pro",
+				Provider:     providers.ProviderMakora,
+				BindingIndex: 1,
 			},
 		},
 	})
@@ -198,6 +235,9 @@ func TestClientPostsArmProviderMapForV2(t *testing.T) {
 		"arm-makora":    providers.ProviderMakora,
 	}, got.CandidateProviders)
 	assert.Equal(t, []string{"arm-fireworks", "arm-makora"}, got.CandidateModels)
+	require.NotNil(t, got.Candidates[0].BindingIndex)
+	assert.Equal(t, 0, *got.Candidates[0].BindingIndex)
+	assert.Equal(t, "arm-fireworks", got.Candidates[0].ArmID)
 }
 
 func TestClientAcceptsLegacyRouteResponse(t *testing.T) {

--- a/internal/policyclient/client_test.go
+++ b/internal/policyclient/client_test.go
@@ -197,6 +197,7 @@ func TestClientPostsArmProviderMapForV2(t *testing.T) {
 		"arm-fireworks": providers.ProviderFireworks,
 		"arm-makora":    providers.ProviderMakora,
 	}, got.CandidateProviders)
+	assert.Equal(t, []string{"arm-fireworks", "arm-makora"}, got.CandidateModels)
 }
 
 func TestClientAcceptsLegacyRouteResponse(t *testing.T) {

--- a/internal/policyclient/client_test.go
+++ b/internal/policyclient/client_test.go
@@ -162,6 +162,43 @@ func TestClientPostsVersionedRouteAndParsesPolicyMetadata(t *testing.T) {
 	assert.Equal(t, map[string]float32{"moonshotai/kimi-k2.7-code": 0.91}, result.CandidateScores)
 }
 
+func TestClientPostsArmProviderMapForV2(t *testing.T) {
+	var got routeRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+		require.NoError(t, json.NewDecoder(request.Body).Decode(&got))
+		_ = json.NewEncoder(w).Encode(routeResponse{
+			SchemaVersion:    policy.SchemaVersionV2,
+			SelectedArmID:    "arm-fireworks",
+			SelectedRosterID: "deepseek/deepseek-v4-pro",
+		})
+	}))
+	defer server.Close()
+
+	_, err := New(server.URL, server.Client(), 0).Decide(context.Background(), policy.Query{
+		SchemaVersion: policy.SchemaVersionV2,
+		Candidates: []policy.Candidate{
+			{
+				ArmID:     "arm-fireworks",
+				RosterID:  "deepseek/deepseek-v4-pro",
+				CatalogID: "deepseek/deepseek-v4-pro",
+				Provider:  providers.ProviderFireworks,
+			},
+			{
+				ArmID:     "arm-makora",
+				RosterID:  "deepseek/deepseek-v4-pro",
+				CatalogID: "deepseek/deepseek-v4-pro",
+				Provider:  providers.ProviderMakora,
+			},
+		},
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, map[string]string{
+		"arm-fireworks": providers.ProviderFireworks,
+		"arm-makora":    providers.ProviderMakora,
+	}, got.CandidateProviders)
+}
+
 func TestClientAcceptsLegacyRouteResponse(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		_ = json.NewEncoder(w).Encode(map[string]interface{}{"model": "anthropic/claude-opus-4-8"})

--- a/internal/policyclient/client_test.go
+++ b/internal/policyclient/client_test.go
@@ -240,6 +240,27 @@ func TestClientPostsArmProviderMapForV2(t *testing.T) {
 	assert.Equal(t, "arm-fireworks", got.Candidates[0].ArmID)
 }
 
+func TestClientPreviewAcceptsV2Schema(t *testing.T) {
+	var got routeRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+		require.NoError(t, json.NewDecoder(request.Body).Decode(&got))
+		_ = json.NewEncoder(w).Encode(previewResponse{
+			SchemaVersion: policy.SchemaVersionV2,
+		})
+	}))
+	defer server.Close()
+
+	result, err := New(server.URL, server.Client(), 0).Preview(context.Background(), policy.Query{
+		SchemaVersion: policy.SchemaVersionV2,
+		ExecutionMode: policy.ExecutionModePreview,
+		Candidates:    []policy.Candidate{{ArmID: "arm-a", RosterID: "model-a"}},
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, policy.SchemaVersionV2, got.SchemaVersion)
+	assert.Equal(t, policy.SchemaVersionV2, result.SchemaVersion)
+}
+
 func TestClientAcceptsLegacyRouteResponse(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		_ = json.NewEncoder(w).Encode(map[string]interface{}{"model": "anthropic/claude-opus-4-8"})

--- a/internal/proxy/fallback.go
+++ b/internal/proxy/fallback.go
@@ -386,7 +386,11 @@ func (s *Service) resolveBindingsForDispatch(ctx context.Context, decision route
 		available = filtered
 	}
 	_, primaryExcluded := excluded[decision.Provider]
-	bindings := catalog.AvailableBindings(decision.Model, available)
+	indexedBindings := catalog.EnumerateBindings(decision.Model, available)
+	bindings := make([]catalog.ProviderBinding, 0, len(indexedBindings))
+	for _, binding := range indexedBindings {
+		bindings = append(bindings, binding.ProviderBinding)
+	}
 	if len(bindings) == 0 {
 		if primaryExcluded {
 			// Decision names an excluded provider with no other bindings (a
@@ -400,6 +404,18 @@ func (s *Service) resolveBindingsForDispatch(ctx context.Context, decision route
 			}
 		}
 		return []catalog.ProviderBinding{primary}
+	}
+	if decision.Metadata != nil && decision.Metadata.SelectedArmID != "" {
+		bindings, found := prioritizeSelectedArmBinding(
+			indexedBindings,
+			decision.Model,
+			decision.Provider,
+			decision.Metadata.SelectedUpstreamID,
+			decision.Metadata.BindingIndex,
+		)
+		if found {
+			return bindings
+		}
 	}
 	if len(bindings) == 1 && !primaryExcluded {
 		return []catalog.ProviderBinding{primary}
@@ -420,6 +436,35 @@ func (s *Service) resolveBindingsForDispatch(ctx context.Context, decision route
 		return out
 	}
 	return bindings
+}
+
+func prioritizeSelectedArmBinding(
+	bindings []catalog.IndexedBinding,
+	catalogID string,
+	provider string,
+	upstreamID string,
+	bindingIndex int,
+) ([]catalog.ProviderBinding, bool) {
+	ordered := make([]catalog.ProviderBinding, 0, len(bindings))
+	for _, binding := range bindings {
+		if binding.Index != bindingIndex || binding.Provider != provider {
+			continue
+		}
+		if catalog.UpstreamIDFor(catalogID, binding.UpstreamID) != upstreamID {
+			return nil, false
+		}
+		ordered = append(ordered, binding.ProviderBinding)
+		break
+	}
+	if len(ordered) == 0 {
+		return nil, false
+	}
+	for _, binding := range bindings {
+		if binding.Index != bindingIndex {
+			ordered = append(ordered, binding.ProviderBinding)
+		}
+	}
+	return ordered, true
 }
 
 // flushBufferedIfPresent writes an *UpstreamErrorResponse through to the

--- a/internal/proxy/fallback_test.go
+++ b/internal/proxy/fallback_test.go
@@ -678,6 +678,21 @@ func TestResolveBindingsForDispatch(t *testing.T) {
 		assert.Equal(t, "fireworks", bs[0].Provider, "catalog order: fireworks primary")
 		assert.Equal(t, "openrouter", bs[1].Provider, "catalog order: openrouter fallback")
 	})
+	t.Run("selected temporal arm is first dispatch attempt", func(t *testing.T) {
+		s := &Service{deploymentKeyedProviders: map[string]struct{}{"fireworks": {}, "openrouter": {}}}
+		bs := s.resolveBindingsForDispatch(context.Background(), router.Decision{
+			Model:    "deepseek/deepseek-v4-pro",
+			Provider: "openrouter",
+			Metadata: &router.RoutingMetadata{
+				SelectedArmID:      "tq_arm_selected",
+				SelectedUpstreamID: "deepseek/deepseek-v4-pro",
+				BindingIndex:       3,
+			},
+		})
+		require.GreaterOrEqual(t, len(bs), 2)
+		assert.Equal(t, "openrouter", bs[0].Provider)
+		assert.Equal(t, "fireworks", bs[1].Provider)
+	})
 	t.Run("single-binding Anthropic model returns one binding even with multiple keys wired", func(t *testing.T) {
 		s := &Service{deploymentKeyedProviders: map[string]struct{}{"anthropic": {}, "openrouter": {}}}
 		bs := s.resolveBindingsForDispatch(context.Background(), router.Decision{Model: "claude-opus-4-7", Provider: "anthropic"})

--- a/internal/proxy/gemini.go
+++ b/internal/proxy/gemini.go
@@ -90,18 +90,21 @@ func (s *Service) ProxyGeminiGenerateContent(ctx context.Context, body []byte, w
 	subAgentHint := r.Header.Get("x-weave-subagent-type")
 
 	routeRequest := router.Request{
-		RequestedModel:       feats.Model,
-		EstimatedInputTokens: feats.Tokens,
-		HasTools:             feats.HasTools,
-		HasImages:            feats.HasImages,
-		PromptText:           promptText,
-		ConversationMessages: conversationMessagesForRouting(env),
-		AvailableTools:       availableToolsForRouting(env),
-		ClientSessionID:      env.ClientSessionID(),
-		EnabledProviders:     s.enabledProvidersForRequest(ctx, providers.ProviderGoogle, r.Header),
-		ExcludedModels:       s.excludedModelsForRequest(ctx),
-		PreferredModels:      s.preferredModelsForRequest(ctx),
-		RoutingKnobs:         router.RoutingKnobsFromContext(ctx),
+		RequestedModel:               feats.Model,
+		EstimatedInputTokens:         feats.Tokens,
+		HasTools:                     feats.HasTools,
+		HasImages:                    feats.HasImages,
+		TranslationRequirements:      env.TranslationRequirements(router.EndpointGeminiGenerate),
+		ReasoningConfigurationSHA256: env.ReasoningConfigurationSHA256(),
+		ToolConfigurationSHA256:      env.ToolConfigurationSHA256(),
+		PromptText:                   promptText,
+		ConversationMessages:         conversationMessagesForRouting(env),
+		AvailableTools:               availableToolsForRouting(env),
+		ClientSessionID:              env.ClientSessionID(),
+		EnabledProviders:             s.enabledProvidersForRequest(ctx, providers.ProviderGoogle, r.Header),
+		ExcludedModels:               s.excludedModelsForRequest(ctx),
+		PreferredModels:              s.preferredModelsForRequest(ctx),
+		RoutingKnobs:                 router.RoutingKnobsFromContext(ctx),
 	}
 	routeStart := time.Now()
 	routeRes, err := s.runTurnLoop(ctx, env, feats, apiKeyID, installationID, subAgentHint, r.Header, routeRequest)

--- a/internal/proxy/route_preview.go
+++ b/internal/proxy/route_preview.go
@@ -67,21 +67,23 @@ func (s *Service) anthropicRoutingRequest(ctx context.Context, body []byte, head
 		installationID = id.String()
 	}
 	return router.Request{
-		RequestedModel:          features.Model,
-		EstimatedInputTokens:    features.Tokens,
-		HasTools:                features.HasTools,
-		HasImages:               features.HasImages,
-		TranslationRequirements: env.TranslationRequirements(router.EndpointAnthropicMessages),
-		PromptText:              promptText,
-		ConversationMessages:    conversationMessagesForRouting(env),
-		AvailableTools:          availableToolsForRouting(env),
-		OrganizationID:          organizationID,
-		InstallationID:          installationID,
-		ClientSessionID:         env.ClientSessionID(),
-		EnabledProviders:        enabledProviders,
-		ExcludedModels:          excluded,
-		PreferredModels:         s.preferredModelsForRequest(ctx),
-		RoutingKnobs:            routingKnobsForRequest(ctx),
+		RequestedModel:               features.Model,
+		EstimatedInputTokens:         features.Tokens,
+		HasTools:                     features.HasTools,
+		HasImages:                    features.HasImages,
+		TranslationRequirements:      env.TranslationRequirements(router.EndpointAnthropicMessages),
+		ReasoningConfigurationSHA256: env.ReasoningConfigurationSHA256(),
+		ToolConfigurationSHA256:      env.ToolConfigurationSHA256(),
+		PromptText:                   promptText,
+		ConversationMessages:         conversationMessagesForRouting(env),
+		AvailableTools:               availableToolsForRouting(env),
+		OrganizationID:               organizationID,
+		InstallationID:               installationID,
+		ClientSessionID:              env.ClientSessionID(),
+		EnabledProviders:             enabledProviders,
+		ExcludedModels:               excluded,
+		PreferredModels:              s.preferredModelsForRequest(ctx),
+		RoutingKnobs:                 routingKnobsForRequest(ctx),
 	}, nil
 }
 

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -2153,17 +2153,19 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 
 	routeStart := time.Now()
 	req := router.Request{
-		RequestedModel:          feats.Model,
-		ForceModel:              forceModel,
-		EstimatedInputTokens:    feats.Tokens,
-		HasTools:                feats.HasTools,
-		HasImages:               feats.HasImages,
-		TranslationRequirements: env.TranslationRequirements(router.EndpointAnthropicMessages),
-		PromptText:              promptText,
-		ConversationMessages:    conversationMessagesForRouting(env),
-		AvailableTools:          availableToolsForRouting(env),
-		HistoryTruncated:        compRes.Applied,
-		OrganizationID:          externalID,
+		RequestedModel:               feats.Model,
+		ForceModel:                   forceModel,
+		EstimatedInputTokens:         feats.Tokens,
+		HasTools:                     feats.HasTools,
+		HasImages:                    feats.HasImages,
+		TranslationRequirements:      env.TranslationRequirements(router.EndpointAnthropicMessages),
+		ReasoningConfigurationSHA256: env.ReasoningConfigurationSHA256(),
+		ToolConfigurationSHA256:      env.ToolConfigurationSHA256(),
+		PromptText:                   promptText,
+		ConversationMessages:         conversationMessagesForRouting(env),
+		AvailableTools:               availableToolsForRouting(env),
+		HistoryTruncated:             compRes.Applied,
+		OrganizationID:               externalID,
 		// Keep this tied to client-visible history so a later feedback command
 		// can correlate with the route even if local compaction rewrites env.
 		FeedbackKey:          hex.EncodeToString(sessionKey[:]),
@@ -4249,15 +4251,18 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 	}
 
 	routeRequest := router.Request{
-		RequestedModel:       feats.Model,
-		ForceModel:           forceModel,
-		EstimatedInputTokens: feats.Tokens,
-		HasTools:             feats.HasTools,
-		HasImages:            feats.HasImages,
-		PromptText:           promptText,
-		ConversationMessages: conversationMessagesForRouting(env),
-		AvailableTools:       availableToolsForRouting(env),
-		HistoryTruncated:     compResOAI.Applied,
+		RequestedModel:               feats.Model,
+		ForceModel:                   forceModel,
+		EstimatedInputTokens:         feats.Tokens,
+		HasTools:                     feats.HasTools,
+		HasImages:                    feats.HasImages,
+		TranslationRequirements:      env.TranslationRequirements(router.EndpointOpenAIChat),
+		ReasoningConfigurationSHA256: env.ReasoningConfigurationSHA256(),
+		ToolConfigurationSHA256:      env.ToolConfigurationSHA256(),
+		PromptText:                   promptText,
+		ConversationMessages:         conversationMessagesForRouting(env),
+		AvailableTools:               availableToolsForRouting(env),
+		HistoryTruncated:             compResOAI.Applied,
 		// Keep this tied to client-visible history so a later feedback command
 		// can correlate with the route even if local compaction rewrites env.
 		FeedbackKey:          hex.EncodeToString(sessionKey[:]),

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -303,6 +303,10 @@ type OpenAIAccountIDContextKey struct{}
 // Responses body to the Codex backend (its presence marks the passthrough).
 type codexResponsesBodyContextKey struct{}
 
+// nativeResponsesReasoningHashContextKey preserves reasoning that only native
+// Responses dispatch can represent.
+type nativeResponsesReasoningHashContextKey struct{}
+
 // InstallationExcludedModelsContextKey is the context key for the authed
 // installation's model exclusion list. Carried as []string.
 type InstallationExcludedModelsContextKey struct{}
@@ -4197,6 +4201,10 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 	// provider.
 	responsesBody, _ := ctx.Value(codexResponsesBodyContextKey{}).([]byte)
 	responsesPassthrough := len(responsesBody) > 0
+	reasoningConfigurationHash := env.ReasoningConfigurationSHA256()
+	if nativeResponsesHash, ok := ctx.Value(nativeResponsesReasoningHashContextKey{}).(string); ok {
+		reasoningConfigurationHash = nativeResponsesHash
+	}
 
 	// Pre-filter models whose context window cannot fit this request.
 	outputReserveOAI := contextWindowOutputReserve
@@ -4257,7 +4265,7 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 		HasTools:                     feats.HasTools,
 		HasImages:                    feats.HasImages,
 		TranslationRequirements:      env.TranslationRequirements(router.EndpointOpenAIChat),
-		ReasoningConfigurationSHA256: env.ReasoningConfigurationSHA256(),
+		ReasoningConfigurationSHA256: reasoningConfigurationHash,
 		ToolConfigurationSHA256:      env.ToolConfigurationSHA256(),
 		PromptText:                   promptText,
 		ConversationMessages:         conversationMessagesForRouting(env),
@@ -4851,6 +4859,13 @@ func (s *Service) ProxyOpenAIResponses(ctx context.Context, body []byte, w http.
 	// Completions (NativeOnly) or a Codex subscription is using its direct endpoint.
 	if conversion.Requirements.NativeOnly || codexResponsesRequest(ctx, r.Header) {
 		ctx = context.WithValue(ctx, codexResponsesBodyContextKey{}, conversion.OriginalBody)
+	}
+	if conversion.Requirements.NativeOnly {
+		originalEnvelope, parseErr := translate.ParseOpenAI(conversion.OriginalBody)
+		if parseErr != nil {
+			return fmt.Errorf("parse native Responses request: %w", parseErr)
+		}
+		ctx = context.WithValue(ctx, nativeResponsesReasoningHashContextKey{}, originalEnvelope.ReasoningConfigurationSHA256())
 	}
 	ctx = context.WithValue(ctx, responsesRequirementsContextKey{}, conversion.Requirements)
 	ctx = context.WithValue(ctx, responsesTransformsContextKey{}, conversion.Report)

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -307,6 +307,9 @@ type codexResponsesBodyContextKey struct{}
 // Responses dispatch can represent.
 type nativeResponsesReasoningHashContextKey struct{}
 
+// nativeResponsesToolHashContextKey preserves native Responses tool identity.
+type nativeResponsesToolHashContextKey struct{}
+
 // InstallationExcludedModelsContextKey is the context key for the authed
 // installation's model exclusion list. Carried as []string.
 type InstallationExcludedModelsContextKey struct{}
@@ -4205,6 +4208,10 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 	if nativeResponsesHash, ok := ctx.Value(nativeResponsesReasoningHashContextKey{}).(string); ok {
 		reasoningConfigurationHash = nativeResponsesHash
 	}
+	toolConfigurationHash := env.ToolConfigurationSHA256()
+	if nativeResponsesHash, ok := ctx.Value(nativeResponsesToolHashContextKey{}).(string); ok {
+		toolConfigurationHash = nativeResponsesHash
+	}
 
 	// Pre-filter models whose context window cannot fit this request.
 	outputReserveOAI := contextWindowOutputReserve
@@ -4266,7 +4273,7 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 		HasImages:                    feats.HasImages,
 		TranslationRequirements:      env.TranslationRequirements(router.EndpointOpenAIChat),
 		ReasoningConfigurationSHA256: reasoningConfigurationHash,
-		ToolConfigurationSHA256:      env.ToolConfigurationSHA256(),
+		ToolConfigurationSHA256:      toolConfigurationHash,
 		PromptText:                   promptText,
 		ConversationMessages:         conversationMessagesForRouting(env),
 		AvailableTools:               availableToolsForRouting(env),
@@ -4866,6 +4873,7 @@ func (s *Service) ProxyOpenAIResponses(ctx context.Context, body []byte, w http.
 			return fmt.Errorf("parse native Responses request: %w", parseErr)
 		}
 		ctx = context.WithValue(ctx, nativeResponsesReasoningHashContextKey{}, originalEnvelope.ReasoningConfigurationSHA256())
+		ctx = context.WithValue(ctx, nativeResponsesToolHashContextKey{}, originalEnvelope.ToolConfigurationSHA256())
 	}
 	ctx = context.WithValue(ctx, responsesRequirementsContextKey{}, conversion.Requirements)
 	ctx = context.WithValue(ctx, responsesTransformsContextKey{}, conversion.Report)

--- a/internal/proxy/service_test.go
+++ b/internal/proxy/service_test.go
@@ -17,6 +17,7 @@ import (
 	"workweave/router/internal/router"
 	"workweave/router/internal/router/policy"
 	"workweave/router/internal/router/sessionpin"
+	"workweave/router/internal/translate"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -256,15 +257,18 @@ func TestService_ProxyOpenAIResponses_CustomToolUsesNativeOpenAIFamily(t *testin
 		providers.ProviderOpenAI:    provider,
 	}, nil, false, nil, nil, false, providers.ProviderAnthropic, "claude-haiku-4-5", nil)
 
-	body := []byte(`{"model":"gpt-5.5","input":"apply a patch","tools":[{"type":"custom","name":"apply_patch"}]}`)
+	body := []byte(`{"model":"gpt-5.5","input":"apply a patch","reasoning":{"effort":"high"},"tools":[{"type":"custom","name":"apply_patch"}]}`)
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(""))
 	require.NoError(t, svc.ProxyOpenAIResponses(context.Background(), body, rec, req))
 
 	require.NotNil(t, fr.capturedReq)
+	originalEnvelope, err := translate.ParseOpenAI(body)
+	require.NoError(t, err)
+	assert.Equal(t, originalEnvelope.ReasoningConfigurationSHA256(), fr.capturedReq.ReasoningConfigurationSHA256)
 	assert.Equal(t, map[string]struct{}{providers.ProviderOpenAI: {}}, fr.capturedReq.EnabledProviders)
 	require.Len(t, provider.proxyBodies, 1)
-	assert.JSONEq(t, `{"model":"gpt-5.5","input":"apply a patch","tools":[{"type":"custom","name":"apply_patch"}]}`, string(provider.proxyBodies[0]))
+	assert.JSONEq(t, `{"model":"gpt-5.5","input":"apply a patch","reasoning":{"effort":"high"},"tools":[{"type":"custom","name":"apply_patch"}]}`, string(provider.proxyBodies[0]))
 	assert.Equal(t, providers.EndpointResponses, provider.proxyEndpoints[0])
 	assert.JSONEq(t, `{"id":"resp_1","object":"response","output":[]}`, rec.Body.String())
 }

--- a/internal/proxy/service_test.go
+++ b/internal/proxy/service_test.go
@@ -266,6 +266,7 @@ func TestService_ProxyOpenAIResponses_CustomToolUsesNativeOpenAIFamily(t *testin
 	originalEnvelope, err := translate.ParseOpenAI(body)
 	require.NoError(t, err)
 	assert.Equal(t, originalEnvelope.ReasoningConfigurationSHA256(), fr.capturedReq.ReasoningConfigurationSHA256)
+	assert.Equal(t, originalEnvelope.ToolConfigurationSHA256(), fr.capturedReq.ToolConfigurationSHA256)
 	assert.Equal(t, map[string]struct{}{providers.ProviderOpenAI: {}}, fr.capturedReq.EnabledProviders)
 	require.Len(t, provider.proxyBodies, 1)
 	assert.JSONEq(t, `{"model":"gpt-5.5","input":"apply a patch","reasoning":{"effort":"high"},"tools":[{"type":"custom","name":"apply_patch"}]}`, string(provider.proxyBodies[0]))

--- a/internal/router/catalog/lookup.go
+++ b/internal/router/catalog/lookup.go
@@ -51,17 +51,41 @@ func ResolveBinding(id string, available map[string]struct{}) (ProviderBinding, 
 // is in `available`, in catalog order. Used by the proxy's failover loop:
 // index 0 is primary, indexes >0 are ordered fallbacks.
 func AvailableBindings(id string, available map[string]struct{}) []ProviderBinding {
+	indexed := EnumerateBindings(id, available)
+	out := make([]ProviderBinding, 0, len(indexed))
+	for _, binding := range indexed {
+		out = append(out, binding.ProviderBinding)
+	}
+	return out
+}
+
+// IndexedBinding identifies a provider binding by its stable catalog order.
+type IndexedBinding struct {
+	Index int
+	ProviderBinding
+}
+
+// EnumerateBindings returns every enabled binding in stable catalog order.
+func EnumerateBindings(id string, available map[string]struct{}) []IndexedBinding {
 	m, ok := ByID(id)
 	if !ok {
 		return nil
 	}
-	out := make([]ProviderBinding, 0, len(m.Providers))
-	for _, b := range m.Providers {
+	out := make([]IndexedBinding, 0, len(m.Providers))
+	for index, b := range m.Providers {
 		if _, ok := available[b.Provider]; ok {
-			out = append(out, b)
+			out = append(out, IndexedBinding{Index: index, ProviderBinding: b})
 		}
 	}
 	return out
+}
+
+// UpstreamIDFor returns the upstream model ID for a catalog binding.
+func UpstreamIDFor(catalogID, bindingID string) string {
+	if bindingID != "" {
+		return bindingID
+	}
+	return catalogID
 }
 
 // PriceFor returns the per-(provider, model) pricing.

--- a/internal/router/policy/arm.go
+++ b/internal/router/policy/arm.go
@@ -43,24 +43,40 @@ func MakeArmID(identity ArmIdentity) string {
 	return "tq_arm_" + hex.EncodeToString(sum[:])
 }
 
-// DeriveArmContext derives a privacy-safe action context; ingress hashes take priority over fallback normalization.
+// DeriveArmContext combines privacy-safe ingress and routing-level configuration.
 func DeriveArmContext(req router.Request) ArmContext {
 	context := ArmContext{
 		Endpoint:                     string(req.TranslationRequirements.Endpoint),
 		ModelRevision:                catalogModelRevision,
-		ReasoningConfigurationSHA256: req.ReasoningConfigurationSHA256,
+		ReasoningConfigurationSHA256: combineReasoningConfigurationHash(req),
 		ToolConfigurationSHA256:      req.ToolConfigurationSHA256,
 	}
 	if context.Endpoint == "" {
 		context.Endpoint = "unknown"
 	}
-	if context.ReasoningConfigurationSHA256 == "" {
-		context.ReasoningConfigurationSHA256 = hashReasoningConfiguration(req)
-	}
 	if context.ToolConfigurationSHA256 == "" {
 		context.ToolConfigurationSHA256 = hashToolConfiguration(req)
 	}
 	return context
+}
+
+func combineReasoningConfigurationHash(req router.Request) string {
+	routingHash := hashReasoningConfiguration(req)
+	if req.ReasoningConfigurationSHA256 == "" {
+		return routingHash
+	}
+	payload := struct {
+		IngressHash string `json:"ingress_hash"`
+		RoutingHash string `json:"routing_hash"`
+	}{
+		IngressHash: req.ReasoningConfigurationSHA256,
+		RoutingHash: routingHash,
+	}
+	encoded, err := json.Marshal(payload)
+	if err != nil {
+		panic("marshal combined temporal-Q reasoning configuration: " + err.Error())
+	}
+	return sha256Bytes(encoded)
 }
 
 func hashReasoningConfiguration(req router.Request) string {

--- a/internal/router/policy/arm.go
+++ b/internal/router/policy/arm.go
@@ -1,0 +1,109 @@
+package policy
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"sort"
+	"strings"
+
+	"workweave/router/internal/router"
+)
+
+const catalogModelRevision = "catalog-v1"
+
+// ArmIdentity is the complete immutable identity of one dispatchable temporal-Q
+// action. It intentionally mirrors temporal_q.ids.make_arm_id.
+type ArmIdentity struct {
+	CanonicalModel               string `json:"canonical_model"`
+	Endpoint                     string `json:"endpoint"`
+	ModelRevision                string `json:"model_revision"`
+	Provider                     string `json:"provider"`
+	ReasoningConfigurationSHA256 string `json:"reasoning_configuration_sha256"`
+	ToolConfigurationSHA256      string `json:"tool_configuration_sha256"`
+	UpstreamID                   string `json:"upstream_id"`
+}
+
+// ArmContext identifies request-scoped compatibility settings that affect a
+// dispatched model action.
+type ArmContext struct {
+	Endpoint                     string
+	ModelRevision                string
+	ReasoningConfigurationSHA256 string
+	ToolConfigurationSHA256      string
+}
+
+// MakeArmID returns a deterministic cross-language identity for an arm.
+func MakeArmID(identity ArmIdentity) string {
+	payload, err := json.Marshal(identity)
+	if err != nil {
+		panic("marshal temporal-Q arm identity: " + err.Error())
+	}
+	sum := sha256.Sum256(payload)
+	return "tq_arm_" + hex.EncodeToString(sum[:])
+}
+
+// DeriveArmContext derives a privacy-safe action context from router-visible
+// request configuration. Ingress may provide stronger hashes; the fallback
+// only uses normalized routing metadata.
+func DeriveArmContext(req router.Request) ArmContext {
+	context := ArmContext{
+		Endpoint:                     string(req.TranslationRequirements.Endpoint),
+		ModelRevision:                catalogModelRevision,
+		ReasoningConfigurationSHA256: req.ReasoningConfigurationSHA256,
+		ToolConfigurationSHA256:      req.ToolConfigurationSHA256,
+	}
+	if context.Endpoint == "" {
+		context.Endpoint = "unknown"
+	}
+	if context.ReasoningConfigurationSHA256 == "" {
+		context.ReasoningConfigurationSHA256 = hashReasoningConfiguration(req)
+	}
+	if context.ToolConfigurationSHA256 == "" {
+		context.ToolConfigurationSHA256 = hashToolConfiguration(req)
+	}
+	return context
+}
+
+func hashReasoningConfiguration(req router.Request) string {
+	forceEffort := ""
+	if req.RoutingKnobs != nil {
+		forceEffort = strings.ToLower(strings.TrimSpace(req.RoutingKnobs.ForceEffort))
+	}
+	payload := struct {
+		ForceEffort        string `json:"force_effort"`
+		ReasoningReplay    bool   `json:"reasoning_replay"`
+		ReasoningSignature bool   `json:"reasoning_signature"`
+	}{
+		ForceEffort:        forceEffort,
+		ReasoningReplay:    req.TranslationRequirements.ReasoningReplay,
+		ReasoningSignature: req.TranslationRequirements.ReasoningSignature,
+	}
+	encoded, err := json.Marshal(payload)
+	if err != nil {
+		panic("marshal temporal-Q reasoning configuration: " + err.Error())
+	}
+	return sha256Bytes(encoded)
+}
+
+func hashToolConfiguration(req router.Request) string {
+	tools := append([]string(nil), req.AvailableTools...)
+	sort.Strings(tools)
+	payload := struct {
+		HasTools bool     `json:"has_tools"`
+		Tools    []string `json:"tools"`
+	}{
+		HasTools: req.HasTools,
+		Tools:    tools,
+	}
+	encoded, err := json.Marshal(payload)
+	if err != nil {
+		panic("marshal temporal-Q tool configuration: " + err.Error())
+	}
+	return sha256Bytes(encoded)
+}
+
+func sha256Bytes(encoded []byte) string {
+	sum := sha256.Sum256(encoded)
+	return hex.EncodeToString(sum[:])
+}

--- a/internal/router/policy/arm.go
+++ b/internal/router/policy/arm.go
@@ -43,9 +43,7 @@ func MakeArmID(identity ArmIdentity) string {
 	return "tq_arm_" + hex.EncodeToString(sum[:])
 }
 
-// DeriveArmContext derives a privacy-safe action context from router-visible
-// request configuration. Ingress may provide stronger hashes; the fallback
-// only uses normalized routing metadata.
+// DeriveArmContext derives a privacy-safe action context; ingress hashes take priority over fallback normalization.
 func DeriveArmContext(req router.Request) ArmContext {
 	context := ArmContext{
 		Endpoint:                     string(req.TranslationRequirements.Endpoint),

--- a/internal/router/policy/arm_test.go
+++ b/internal/router/policy/arm_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"workweave/router/internal/router"
 	"workweave/router/internal/router/policy"
 )
 
@@ -41,4 +42,16 @@ func TestMakeArmIDBindsEveryConfigurationField(t *testing.T) {
 	changed.ToolConfigurationSHA256 = strings.Repeat("d", 64)
 
 	assert.NotEqual(t, policy.MakeArmID(identity), policy.MakeArmID(changed))
+}
+
+func TestDeriveArmContextIncludesIngressAndForceEffort(t *testing.T) {
+	base := router.Request{ReasoningConfigurationSHA256: strings.Repeat("a", 64)}
+	forced := base
+	forced.RoutingKnobs = &router.Overrides{ForceEffort: "high"}
+
+	assert.NotEqual(
+		t,
+		policy.DeriveArmContext(base).ReasoningConfigurationSHA256,
+		policy.DeriveArmContext(forced).ReasoningConfigurationSHA256,
+	)
 }

--- a/internal/router/policy/arm_test.go
+++ b/internal/router/policy/arm_test.go
@@ -1,0 +1,44 @@
+package policy_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"workweave/router/internal/router/policy"
+)
+
+func TestMakeArmIDMatchesPythonTemporalQContract(t *testing.T) {
+	identity := policy.ArmIdentity{
+		CanonicalModel:               "candidate-a",
+		Provider:                     "provider-a",
+		UpstreamID:                   "candidate-a-upstream",
+		Endpoint:                     "responses",
+		ModelRevision:                "candidate-a-r1",
+		ReasoningConfigurationSHA256: strings.Repeat("b", 64),
+		ToolConfigurationSHA256:      strings.Repeat("c", 64),
+	}
+
+	assert.Equal(
+		t,
+		"tq_arm_0758a2ae1bc05e56a3866cf63665ab07f588662f6fc8d15ca208ead5f47d3fae",
+		policy.MakeArmID(identity),
+	)
+}
+
+func TestMakeArmIDBindsEveryConfigurationField(t *testing.T) {
+	identity := policy.ArmIdentity{
+		CanonicalModel:               "candidate-a",
+		Provider:                     "provider-a",
+		UpstreamID:                   "candidate-a-upstream",
+		Endpoint:                     "responses",
+		ModelRevision:                "candidate-a-r1",
+		ReasoningConfigurationSHA256: strings.Repeat("b", 64),
+		ToolConfigurationSHA256:      strings.Repeat("c", 64),
+	}
+	changed := identity
+	changed.ToolConfigurationSHA256 = strings.Repeat("d", 64)
+
+	assert.NotEqual(t, policy.MakeArmID(identity), policy.MakeArmID(changed))
+}

--- a/internal/router/policy/contract.go
+++ b/internal/router/policy/contract.go
@@ -9,6 +9,10 @@ import (
 // SchemaVersionV1 is the first stable policy-sidecar wire contract.
 const SchemaVersionV1 = "policy_router_v1"
 
+// SchemaVersionV2 identifies sidecar requests that carry configuration-level
+// arm identities and require arm-aware selection when a roster is ambiguous.
+const SchemaVersionV2 = "policy_router_v2"
+
 const (
 	ExecutionModeServing = "serving"
 	ExecutionModeShadow  = "shadow"
@@ -47,6 +51,7 @@ type StrategySpec struct {
 
 // Query contains the strategy-neutral request context supplied to a policy.
 type Query struct {
+	SchemaVersion        string
 	Strategy             router.Strategy
 	ExecutionMode        string
 	RouteID              string

--- a/internal/router/policy/contract.go
+++ b/internal/router/policy/contract.go
@@ -78,6 +78,7 @@ type Query struct {
 type Result struct {
 	SchemaVersion        string
 	RouteID              string
+	ArmID                string
 	Model                string
 	Provider             string
 	Score                float64

--- a/internal/router/policy/resolver.go
+++ b/internal/router/policy/resolver.go
@@ -3,6 +3,8 @@
 package policy
 
 import (
+	"crypto/sha256"
+	"fmt"
 	"sort"
 
 	"workweave/router/internal/providers"
@@ -64,6 +66,7 @@ type Diagnostic struct {
 
 // Candidate is one catalog-backed model offered to a policy sidecar.
 type Candidate struct {
+	ArmID                     string                `json:"arm_id"`
 	RosterID                  string                `json:"roster_id"`
 	CatalogID                 string                `json:"catalog_id"`
 	Provider                  string                `json:"provider"`
@@ -91,13 +94,15 @@ type CandidateCapabilities struct {
 
 // Binding is the authoritative dispatch binding for an offered roster ID.
 type Binding struct {
-	CatalogID string
-	Provider  string
+	CatalogID  string
+	Provider   string
+	UpstreamID string
 }
 
 // ResolvedCandidates is the complete result of candidate resolution.
 type ResolvedCandidates struct {
 	Candidates  []Candidate
+	ByArmID     map[string]Binding
 	ByRosterID  map[string]Binding
 	Diagnostics []Diagnostic
 }
@@ -123,8 +128,12 @@ func (r ResolvedCandidates) CandidateProviders() map[string]string {
 // CatalogCandidateScores translates sidecar roster IDs to telemetry catalog IDs.
 func (r ResolvedCandidates) CatalogCandidateScores(scores map[string]float32) map[string]float32 {
 	result := make(map[string]float32, len(scores))
-	for rosterID, score := range scores {
-		if binding, ok := r.ByRosterID[rosterID]; ok {
+	for selectionID, score := range scores {
+		if binding, ok := r.ByArmID[selectionID]; ok {
+			result[binding.CatalogID] = score
+			continue
+		}
+		if binding, ok := r.ByRosterID[selectionID]; ok {
 			result[binding.CatalogID] = score
 		}
 	}
@@ -136,12 +145,13 @@ func (r ResolvedCandidates) CatalogCandidateScores(scores map[string]float32) ma
 
 // Resolver builds the eligible catalog-backed candidate set for a policy.
 type Resolver struct {
-	deployed       map[string]struct{}
-	available      map[string]struct{}
-	mapper         RosterMapper
-	providerPolicy ProviderPolicy
-	toolLow        map[string]struct{}
-	imageLow       map[string]struct{}
+	deployed          map[string]struct{}
+	available         map[string]struct{}
+	mapper            RosterMapper
+	providerPolicy    ProviderPolicy
+	enumerateBindings bool
+	toolLow           map[string]struct{}
+	imageLow          map[string]struct{}
 }
 
 // NewResolver constructs a reusable policy candidate resolver.
@@ -154,6 +164,15 @@ func NewResolver(deployed, available map[string]struct{}, mapper RosterMapper, p
 		toolLow:        catalog.ToolUseLowSet(),
 		imageLow:       catalog.ImageUnsupportedSet(),
 	}
+}
+
+// NewArmResolver returns every enabled catalog provider binding as a distinct
+// policy candidate. It is for policies that score dispatch arms rather than
+// logical catalog models; existing policy artifacts should keep NewResolver.
+func NewArmResolver(deployed, available map[string]struct{}, mapper RosterMapper, providerPolicy ProviderPolicy) *Resolver {
+	resolver := NewResolver(deployed, available, mapper, providerPolicy)
+	resolver.enumerateBindings = true
+	return resolver
 }
 
 type eligibleCandidate struct {
@@ -198,58 +217,73 @@ func (r *Resolver) Resolve(req router.Request) ResolvedCandidates {
 		if providerSet == nil {
 			providerSet = r.available
 		}
-		binding, ok := catalog.ResolveBinding(id, r.allowedProviders(providerSet))
-		if !ok {
+		allowedBindings := catalog.AvailableBindings(
+			id,
+			r.allowedProviders(providerSet),
+		)
+		if len(allowedBindings) == 0 {
 			reason := ExclusionNoProvider
-			if unrestrictedBinding, found := catalog.ResolveBinding(id, providerSet); found && !r.providerPolicy.Allows(unrestrictedBinding.Provider) {
+			if unrestrictedBindings := catalog.AvailableBindings(id, providerSet); len(unrestrictedBindings) > 0 {
 				reason = ExclusionProviderPolicy
 			}
 			diagnostics = append(diagnostics, Diagnostic{CatalogID: id, RosterID: rosterID, Reason: reason})
 			continue
 		}
 
-		marginalCostFactor := 1.0
-		if factor, found := req.SubsidizedModelCostFactor[id]; found && factor > 0 {
-			marginalCostFactor = factor
+		if !r.enumerateBindings {
+			allowedBindings = allowedBindings[:1]
 		}
-		base = append(base, eligibleCandidate{Candidate: Candidate{
-			RosterID:                  rosterID,
-			CatalogID:                 id,
-			Provider:                  binding.Provider,
-			UpstreamID:                upstreamID(id, binding.UpstreamID),
-			PreferenceRank:            preferenceRanks[id],
-			InputUSDPer1M:             binding.Price.InputUSDPer1M,
-			OutputUSDPer1M:            binding.Price.OutputUSDPer1M,
-			EstimatedCostUSD:          estimatedCostUSD(req, binding.Price),
-			CacheReadMultiplier:       binding.Price.EffectiveCacheReadMultiplier(),
-			MarginalCostFactor:        marginalCostFactor,
-			EffectiveInputUSDPer1M:    binding.Price.InputUSDPer1M * marginalCostFactor,
-			EffectiveOutputUSDPer1M:   binding.Price.OutputUSDPer1M * marginalCostFactor,
-			EffectiveEstimatedCostUSD: estimatedCostUSD(req, binding.Price) * marginalCostFactor,
-			Capabilities: CandidateCapabilities{
-				ContextWindow:  contextWindow,
-				Tier:           model.Tier.String(),
-				SupportsTools:  model.ToolUseQuality != catalog.ToolUseLow && model.AgenticUse != catalog.AgenticLow,
-				SupportsImages: model.ImageInput != catalog.ImageInputUnsupported,
-			},
-		}})
+		for _, binding := range allowedBindings {
+			upstreamID := upstreamID(id, binding.UpstreamID)
+			armID := rosterID
+			if r.enumerateBindings {
+				armID = makeArmID(rosterID, id, binding.Provider, upstreamID)
+			}
+			marginalCostFactor := 1.0
+			if factor, found := req.SubsidizedModelCostFactor[id]; found && factor > 0 {
+				marginalCostFactor = factor
+			}
+			base = append(base, eligibleCandidate{Candidate: Candidate{
+				ArmID:                     armID,
+				RosterID:                  rosterID,
+				CatalogID:                 id,
+				Provider:                  binding.Provider,
+				UpstreamID:                upstreamID,
+				PreferenceRank:            preferenceRanks[id],
+				InputUSDPer1M:             binding.Price.InputUSDPer1M,
+				OutputUSDPer1M:            binding.Price.OutputUSDPer1M,
+				EstimatedCostUSD:          estimatedCostUSD(req, binding.Price),
+				CacheReadMultiplier:       binding.Price.EffectiveCacheReadMultiplier(),
+				MarginalCostFactor:        marginalCostFactor,
+				EffectiveInputUSDPer1M:    binding.Price.InputUSDPer1M * marginalCostFactor,
+				EffectiveOutputUSDPer1M:   binding.Price.OutputUSDPer1M * marginalCostFactor,
+				EffectiveEstimatedCostUSD: estimatedCostUSD(req, binding.Price) * marginalCostFactor,
+				Capabilities: CandidateCapabilities{
+					ContextWindow:  contextWindow,
+					Tier:           model.Tier.String(),
+					SupportsTools:  model.ToolUseQuality != catalog.ToolUseLow && model.AgenticUse != catalog.AgenticLow,
+					SupportsImages: model.ImageInput != catalog.ImageInputUnsupported,
+				},
+			}})
+		}
 	}
 
 	base, diagnostics = softFilter(base, req.HasImages, r.imageLow, ExclusionImageCapability, diagnostics)
 	base, diagnostics = softFilter(base, req.HasTools, r.toolLow, ExclusionToolCapability, diagnostics)
 
-	rosterCounts := make(map[string]int, len(base))
+	selectionCounts := make(map[string]int, len(base))
 	for _, candidate := range base {
-		rosterCounts[candidate.RosterID]++
+		selectionCounts[candidate.ArmID]++
 	}
 
 	resolved := ResolvedCandidates{
 		Candidates:  make([]Candidate, 0, len(base)),
+		ByArmID:     make(map[string]Binding, len(base)),
 		ByRosterID:  make(map[string]Binding, len(base)),
 		Diagnostics: diagnostics,
 	}
 	for _, candidate := range base {
-		if rosterCounts[candidate.RosterID] > 1 {
+		if selectionCounts[candidate.ArmID] > 1 {
 			resolved.Diagnostics = append(resolved.Diagnostics, Diagnostic{
 				CatalogID: candidate.CatalogID,
 				RosterID:  candidate.RosterID,
@@ -258,9 +292,30 @@ func (r *Resolver) Resolve(req router.Request) ResolvedCandidates {
 			continue
 		}
 		resolved.Candidates = append(resolved.Candidates, candidate.Candidate)
-		resolved.ByRosterID[candidate.RosterID] = Binding{CatalogID: candidate.CatalogID, Provider: candidate.Provider}
+		binding := Binding{
+			CatalogID:  candidate.CatalogID,
+			Provider:   candidate.Provider,
+			UpstreamID: candidate.UpstreamID,
+		}
+		resolved.ByArmID[candidate.ArmID] = binding
+		if _, exists := resolved.ByRosterID[candidate.RosterID]; !exists {
+			resolved.ByRosterID[candidate.RosterID] = binding
+		} else {
+			delete(resolved.ByRosterID, candidate.RosterID)
+		}
 	}
 	return resolved
+}
+
+// BindingForSelection resolves a sidecar selection by arm ID first, then
+// preserves legacy roster-ID selection for existing policy artifacts.
+func (r ResolvedCandidates) BindingForSelection(armID, rosterID string) (Binding, bool) {
+	if armID != "" {
+		binding, ok := r.ByArmID[armID]
+		return binding, ok
+	}
+	binding, ok := r.ByRosterID[rosterID]
+	return binding, ok
 }
 
 func upstreamID(catalogID, bindingID string) string {
@@ -268,6 +323,13 @@ func upstreamID(catalogID, bindingID string) string {
 		return bindingID
 	}
 	return catalogID
+}
+
+func makeArmID(rosterID, catalogID, provider, upstreamID string) string {
+	sum := sha256.Sum256([]byte(
+		rosterID + "\x00" + catalogID + "\x00" + provider + "\x00" + upstreamID,
+	))
+	return fmt.Sprintf("arm_%x", sum)
 }
 
 func estimatedCostUSD(req router.Request, pricing catalog.Pricing) float64 {

--- a/internal/router/policy/resolver.go
+++ b/internal/router/policy/resolver.go
@@ -139,6 +139,9 @@ func (r ResolvedCandidates) CandidateArmIDs() []string {
 func (r ResolvedCandidates) CandidateProviders() map[string]string {
 	result := make(map[string]string, len(r.Candidates))
 	for _, candidate := range r.Candidates {
+		if _, exists := result[candidate.CatalogID]; exists {
+			continue
+		}
 		result[candidate.CatalogID] = candidate.Provider
 	}
 	return result
@@ -156,13 +159,16 @@ func (r ResolvedCandidates) CandidateArmProviders() map[string]string {
 // CatalogCandidateScores translates sidecar roster IDs to telemetry catalog IDs.
 func (r ResolvedCandidates) CatalogCandidateScores(scores map[string]float32) map[string]float32 {
 	result := make(map[string]float32, len(scores))
-	for selectionID, score := range scores {
-		if binding, ok := r.ByArmID[selectionID]; ok {
-			result[binding.CatalogID] = score
+	for _, candidate := range r.Candidates {
+		if _, exists := result[candidate.CatalogID]; exists {
 			continue
 		}
-		if binding, ok := r.ByRosterID[selectionID]; ok {
-			result[binding.CatalogID] = score
+		score, ok := scores[candidate.ArmID]
+		if !ok {
+			score, ok = scores[candidate.RosterID]
+		}
+		if ok {
+			result[candidate.CatalogID] = score
 		}
 	}
 	if len(result) == 0 {

--- a/internal/router/policy/resolver.go
+++ b/internal/router/policy/resolver.go
@@ -64,6 +64,7 @@ type Diagnostic struct {
 
 // Candidate is one catalog-backed model offered to a policy sidecar.
 type Candidate struct {
+	// ArmID is a configuration-level temporal-Q action ID; equals RosterID on the legacy resolver.
 	ArmID                        string                `json:"arm_id"`
 	RosterID                     string                `json:"roster_id"`
 	CatalogID                    string                `json:"catalog_id"`
@@ -184,9 +185,7 @@ func NewResolver(deployed, available map[string]struct{}, mapper RosterMapper, p
 	}
 }
 
-// NewArmResolver returns every enabled catalog provider binding as a distinct
-// policy candidate. It is for policies that score dispatch arms rather than
-// logical catalog models; existing policy artifacts should keep NewResolver.
+// NewArmResolver enumerates every enabled provider binding as a distinct candidate for arm-scoring policies; use NewResolver for model-scoring policies.
 func NewArmResolver(deployed, available map[string]struct{}, mapper RosterMapper, providerPolicy ProviderPolicy) *Resolver {
 	resolver := NewResolver(deployed, available, mapper, providerPolicy)
 	resolver.enumerateBindings = true

--- a/internal/router/policy/resolver.go
+++ b/internal/router/policy/resolver.go
@@ -117,10 +117,15 @@ type ResolvedCandidates struct {
 	Diagnostics []Diagnostic
 }
 
-// CandidateModels returns catalog IDs in deterministic candidate order.
+// CandidateModels returns unique catalog IDs in first-candidate order.
 func (r ResolvedCandidates) CandidateModels() []string {
 	models := make([]string, 0, len(r.Candidates))
+	seen := make(map[string]struct{}, len(r.Candidates))
 	for _, candidate := range r.Candidates {
+		if _, exists := seen[candidate.CatalogID]; exists {
+			continue
+		}
+		seen[candidate.CatalogID] = struct{}{}
 		models = append(models, candidate.CatalogID)
 	}
 	return models

--- a/internal/router/policy/resolver.go
+++ b/internal/router/policy/resolver.go
@@ -3,8 +3,6 @@
 package policy
 
 import (
-	"crypto/sha256"
-	"fmt"
 	"sort"
 
 	"workweave/router/internal/providers"
@@ -66,21 +64,26 @@ type Diagnostic struct {
 
 // Candidate is one catalog-backed model offered to a policy sidecar.
 type Candidate struct {
-	ArmID                     string                `json:"arm_id"`
-	RosterID                  string                `json:"roster_id"`
-	CatalogID                 string                `json:"catalog_id"`
-	Provider                  string                `json:"provider"`
-	UpstreamID                string                `json:"upstream_id"`
-	PreferenceRank            *int                  `json:"preference_rank,omitempty"`
-	InputUSDPer1M             float64               `json:"input_usd_per_1m"`
-	OutputUSDPer1M            float64               `json:"output_usd_per_1m"`
-	EstimatedCostUSD          float64               `json:"estimated_cost_usd"`
-	CacheReadMultiplier       float64               `json:"cache_read_multiplier"`
-	MarginalCostFactor        float64               `json:"marginal_cost_factor"`
-	EffectiveInputUSDPer1M    float64               `json:"effective_input_usd_per_1m"`
-	EffectiveOutputUSDPer1M   float64               `json:"effective_output_usd_per_1m"`
-	EffectiveEstimatedCostUSD float64               `json:"effective_estimated_cost_usd"`
-	Capabilities              CandidateCapabilities `json:"capabilities"`
+	ArmID                        string                `json:"arm_id"`
+	RosterID                     string                `json:"roster_id"`
+	CatalogID                    string                `json:"catalog_id"`
+	Provider                     string                `json:"provider"`
+	UpstreamID                   string                `json:"upstream_id"`
+	BindingIndex                 int                   `json:"binding_index"`
+	Endpoint                     string                `json:"endpoint"`
+	ModelRevision                string                `json:"model_revision"`
+	ReasoningConfigurationSHA256 string                `json:"reasoning_configuration_sha256"`
+	ToolConfigurationSHA256      string                `json:"tool_configuration_sha256"`
+	PreferenceRank               *int                  `json:"preference_rank,omitempty"`
+	InputUSDPer1M                float64               `json:"input_usd_per_1m"`
+	OutputUSDPer1M               float64               `json:"output_usd_per_1m"`
+	EstimatedCostUSD             float64               `json:"estimated_cost_usd"`
+	CacheReadMultiplier          float64               `json:"cache_read_multiplier"`
+	MarginalCostFactor           float64               `json:"marginal_cost_factor"`
+	EffectiveInputUSDPer1M       float64               `json:"effective_input_usd_per_1m"`
+	EffectiveOutputUSDPer1M      float64               `json:"effective_output_usd_per_1m"`
+	EffectiveEstimatedCostUSD    float64               `json:"effective_estimated_cost_usd"`
+	Capabilities                 CandidateCapabilities `json:"capabilities"`
 }
 
 // CandidateCapabilities describes only dispatch-relevant catalog facts. It is
@@ -94,9 +97,15 @@ type CandidateCapabilities struct {
 
 // Binding is the authoritative dispatch binding for an offered roster ID.
 type Binding struct {
-	CatalogID  string
-	Provider   string
-	UpstreamID string
+	ArmID                        string
+	CatalogID                    string
+	Provider                     string
+	UpstreamID                   string
+	BindingIndex                 int
+	Endpoint                     string
+	ModelRevision                string
+	ReasoningConfigurationSHA256 string
+	ToolConfigurationSHA256      string
 }
 
 // ResolvedCandidates is the complete result of candidate resolution.
@@ -114,6 +123,15 @@ func (r ResolvedCandidates) CandidateModels() []string {
 		models = append(models, candidate.CatalogID)
 	}
 	return models
+}
+
+// CandidateArmIDs returns configuration-level action IDs in candidate order.
+func (r ResolvedCandidates) CandidateArmIDs() []string {
+	armIDs := make([]string, 0, len(r.Candidates))
+	for _, candidate := range r.Candidates {
+		armIDs = append(armIDs, candidate.ArmID)
+	}
+	return armIDs
 }
 
 // CandidateProviders returns the resolved provider for each catalog model.
@@ -175,6 +193,14 @@ func NewArmResolver(deployed, available map[string]struct{}, mapper RosterMapper
 	return resolver
 }
 
+// SchemaVersion returns the sidecar contract required by this resolver.
+func (r *Resolver) SchemaVersion() string {
+	if r.enumerateBindings {
+		return SchemaVersionV2
+	}
+	return SchemaVersionV1
+}
+
 type eligibleCandidate struct {
 	Candidate
 }
@@ -185,6 +211,7 @@ func (r *Resolver) Resolve(req router.Request) ResolvedCandidates {
 	diagnostics := make([]Diagnostic, 0)
 	base := make([]eligibleCandidate, 0, len(r.deployed))
 	preferenceRanks := preferenceRanks(req.PreferredModels)
+	armContext := DeriveArmContext(req)
 
 	deployedIDs := make([]string, 0, len(r.deployed))
 	for id := range r.deployed {
@@ -217,13 +244,13 @@ func (r *Resolver) Resolve(req router.Request) ResolvedCandidates {
 		if providerSet == nil {
 			providerSet = r.available
 		}
-		allowedBindings := catalog.AvailableBindings(
+		allowedBindings := catalog.EnumerateBindings(
 			id,
 			r.allowedProviders(providerSet),
 		)
 		if len(allowedBindings) == 0 {
 			reason := ExclusionNoProvider
-			if unrestrictedBindings := catalog.AvailableBindings(id, providerSet); len(unrestrictedBindings) > 0 {
+			if unrestrictedBindings := catalog.EnumerateBindings(id, providerSet); len(unrestrictedBindings) > 0 {
 				reason = ExclusionProviderPolicy
 			}
 			diagnostics = append(diagnostics, Diagnostic{CatalogID: id, RosterID: rosterID, Reason: reason})
@@ -234,30 +261,43 @@ func (r *Resolver) Resolve(req router.Request) ResolvedCandidates {
 			allowedBindings = allowedBindings[:1]
 		}
 		for _, binding := range allowedBindings {
-			upstreamID := upstreamID(id, binding.UpstreamID)
+			upstreamID := catalog.UpstreamIDFor(id, binding.UpstreamID)
 			armID := rosterID
 			if r.enumerateBindings {
-				armID = makeArmID(rosterID, id, binding.Provider, upstreamID)
+				armID = MakeArmID(ArmIdentity{
+					CanonicalModel:               id,
+					Provider:                     binding.Provider,
+					UpstreamID:                   upstreamID,
+					Endpoint:                     armContext.Endpoint,
+					ModelRevision:                armContext.ModelRevision,
+					ReasoningConfigurationSHA256: armContext.ReasoningConfigurationSHA256,
+					ToolConfigurationSHA256:      armContext.ToolConfigurationSHA256,
+				})
 			}
 			marginalCostFactor := 1.0
 			if factor, found := req.SubsidizedModelCostFactor[id]; found && factor > 0 {
 				marginalCostFactor = factor
 			}
 			base = append(base, eligibleCandidate{Candidate: Candidate{
-				ArmID:                     armID,
-				RosterID:                  rosterID,
-				CatalogID:                 id,
-				Provider:                  binding.Provider,
-				UpstreamID:                upstreamID,
-				PreferenceRank:            preferenceRanks[id],
-				InputUSDPer1M:             binding.Price.InputUSDPer1M,
-				OutputUSDPer1M:            binding.Price.OutputUSDPer1M,
-				EstimatedCostUSD:          estimatedCostUSD(req, binding.Price),
-				CacheReadMultiplier:       binding.Price.EffectiveCacheReadMultiplier(),
-				MarginalCostFactor:        marginalCostFactor,
-				EffectiveInputUSDPer1M:    binding.Price.InputUSDPer1M * marginalCostFactor,
-				EffectiveOutputUSDPer1M:   binding.Price.OutputUSDPer1M * marginalCostFactor,
-				EffectiveEstimatedCostUSD: estimatedCostUSD(req, binding.Price) * marginalCostFactor,
+				ArmID:                        armID,
+				RosterID:                     rosterID,
+				CatalogID:                    id,
+				Provider:                     binding.Provider,
+				UpstreamID:                   upstreamID,
+				BindingIndex:                 binding.Index,
+				Endpoint:                     armContext.Endpoint,
+				ModelRevision:                armContext.ModelRevision,
+				ReasoningConfigurationSHA256: armContext.ReasoningConfigurationSHA256,
+				ToolConfigurationSHA256:      armContext.ToolConfigurationSHA256,
+				PreferenceRank:               preferenceRanks[id],
+				InputUSDPer1M:                binding.Price.InputUSDPer1M,
+				OutputUSDPer1M:               binding.Price.OutputUSDPer1M,
+				EstimatedCostUSD:             estimatedCostUSD(req, binding.Price),
+				CacheReadMultiplier:          binding.Price.EffectiveCacheReadMultiplier(),
+				MarginalCostFactor:           marginalCostFactor,
+				EffectiveInputUSDPer1M:       binding.Price.InputUSDPer1M * marginalCostFactor,
+				EffectiveOutputUSDPer1M:      binding.Price.OutputUSDPer1M * marginalCostFactor,
+				EffectiveEstimatedCostUSD:    estimatedCostUSD(req, binding.Price) * marginalCostFactor,
 				Capabilities: CandidateCapabilities{
 					ContextWindow:  contextWindow,
 					Tier:           model.Tier.String(),
@@ -293,9 +333,15 @@ func (r *Resolver) Resolve(req router.Request) ResolvedCandidates {
 		}
 		resolved.Candidates = append(resolved.Candidates, candidate.Candidate)
 		binding := Binding{
-			CatalogID:  candidate.CatalogID,
-			Provider:   candidate.Provider,
-			UpstreamID: candidate.UpstreamID,
+			ArmID:                        candidate.ArmID,
+			CatalogID:                    candidate.CatalogID,
+			Provider:                     candidate.Provider,
+			UpstreamID:                   candidate.UpstreamID,
+			BindingIndex:                 candidate.BindingIndex,
+			Endpoint:                     candidate.Endpoint,
+			ModelRevision:                candidate.ModelRevision,
+			ReasoningConfigurationSHA256: candidate.ReasoningConfigurationSHA256,
+			ToolConfigurationSHA256:      candidate.ToolConfigurationSHA256,
 		}
 		resolved.ByArmID[candidate.ArmID] = binding
 		if _, exists := resolved.ByRosterID[candidate.RosterID]; !exists {
@@ -316,20 +362,6 @@ func (r ResolvedCandidates) BindingForSelection(armID, rosterID string) (Binding
 	}
 	binding, ok := r.ByRosterID[rosterID]
 	return binding, ok
-}
-
-func upstreamID(catalogID, bindingID string) string {
-	if bindingID != "" {
-		return bindingID
-	}
-	return catalogID
-}
-
-func makeArmID(rosterID, catalogID, provider, upstreamID string) string {
-	sum := sha256.Sum256([]byte(
-		rosterID + "\x00" + catalogID + "\x00" + provider + "\x00" + upstreamID,
-	))
-	return fmt.Sprintf("arm_%x", sum)
 }
 
 func estimatedCostUSD(req router.Request, pricing catalog.Pricing) float64 {

--- a/internal/router/policy/resolver.go
+++ b/internal/router/policy/resolver.go
@@ -321,6 +321,7 @@ func (r *Resolver) Resolve(req router.Request) ResolvedCandidates {
 		ByRosterID:  make(map[string]Binding, len(base)),
 		Diagnostics: diagnostics,
 	}
+	ambiguousRosterIDs := make(map[string]struct{})
 	for _, candidate := range base {
 		if selectionCounts[candidate.ArmID] > 1 {
 			resolved.Diagnostics = append(resolved.Diagnostics, Diagnostic{
@@ -343,10 +344,14 @@ func (r *Resolver) Resolve(req router.Request) ResolvedCandidates {
 			ToolConfigurationSHA256:      candidate.ToolConfigurationSHA256,
 		}
 		resolved.ByArmID[candidate.ArmID] = binding
+		if _, ambiguous := ambiguousRosterIDs[candidate.RosterID]; ambiguous {
+			continue
+		}
 		if _, exists := resolved.ByRosterID[candidate.RosterID]; !exists {
 			resolved.ByRosterID[candidate.RosterID] = binding
 		} else {
 			delete(resolved.ByRosterID, candidate.RosterID)
+			ambiguousRosterIDs[candidate.RosterID] = struct{}{}
 		}
 	}
 	return resolved

--- a/internal/router/policy/resolver.go
+++ b/internal/router/policy/resolver.go
@@ -144,6 +144,15 @@ func (r ResolvedCandidates) CandidateProviders() map[string]string {
 	return result
 }
 
+// CandidateArmProviders returns the resolved provider for every configuration-level arm.
+func (r ResolvedCandidates) CandidateArmProviders() map[string]string {
+	result := make(map[string]string, len(r.Candidates))
+	for _, candidate := range r.Candidates {
+		result[candidate.ArmID] = candidate.Provider
+	}
+	return result
+}
+
 // CatalogCandidateScores translates sidecar roster IDs to telemetry catalog IDs.
 func (r ResolvedCandidates) CatalogCandidateScores(scores map[string]float32) map[string]float32 {
 	result := make(map[string]float32, len(scores))
@@ -154,6 +163,20 @@ func (r ResolvedCandidates) CatalogCandidateScores(scores map[string]float32) ma
 		}
 		if binding, ok := r.ByRosterID[selectionID]; ok {
 			result[binding.CatalogID] = score
+		}
+	}
+	if len(result) == 0 {
+		return nil
+	}
+	return result
+}
+
+// ArmCandidateScores keeps arm-level scores distinct for configuration-aware telemetry.
+func (r ResolvedCandidates) ArmCandidateScores(scores map[string]float32) map[string]float32 {
+	result := make(map[string]float32, len(scores))
+	for armID, score := range scores {
+		if _, ok := r.ByArmID[armID]; ok {
+			result[armID] = score
 		}
 	}
 	if len(result) == 0 {

--- a/internal/router/policy/resolver_test.go
+++ b/internal/router/policy/resolver_test.go
@@ -47,6 +47,30 @@ func TestResolverDefaultsUpstreamIDToCatalogID(t *testing.T) {
 
 	require.Len(t, resolved.Candidates, 1)
 	assert.Equal(t, "claude-opus-4-8", resolved.Candidates[0].UpstreamID)
+	assert.Equal(t, resolved.Candidates[0].RosterID, resolved.Candidates[0].ArmID)
+}
+
+func TestArmResolverEnumeratesEachAllowedProviderBinding(t *testing.T) {
+	resolver := policy.NewArmResolver(
+		set("deepseek/deepseek-v4-pro"),
+		set(providers.ProviderMakora, providers.ProviderFireworks),
+		catalogRosterID,
+		policy.ManagedProviderPolicy(),
+	)
+
+	resolved := resolver.Resolve(router.Request{})
+
+	require.Len(t, resolved.Candidates, 2)
+	assert.Equal(t, "deepseek/deepseek-v4-pro", resolved.Candidates[0].RosterID)
+	assert.Equal(t, "deepseek/deepseek-v4-pro", resolved.Candidates[1].RosterID)
+	assert.NotEqual(t, resolved.Candidates[0].ArmID, resolved.Candidates[1].ArmID)
+	assert.Empty(t, resolved.ByRosterID)
+	for _, candidate := range resolved.Candidates {
+		binding, ok := resolved.BindingForSelection(candidate.ArmID, "")
+		require.True(t, ok)
+		assert.Equal(t, candidate.Provider, binding.Provider)
+		assert.Equal(t, candidate.UpstreamID, binding.UpstreamID)
+	}
 }
 
 func TestResolverAppliesHardFiltersAndPreferenceRanks(t *testing.T) {

--- a/internal/router/policy/resolver_test.go
+++ b/internal/router/policy/resolver_test.go
@@ -69,13 +69,17 @@ func TestArmResolverEnumeratesEachAllowedProviderBinding(t *testing.T) {
 		resolved.Candidates[0].ArmID: resolved.Candidates[0].Provider,
 		resolved.Candidates[1].ArmID: resolved.Candidates[1].Provider,
 	}, resolved.CandidateArmProviders())
+	armScores := map[string]float32{
+		resolved.Candidates[0].ArmID: 0.1,
+		resolved.Candidates[1].ArmID: 0.2,
+	}
+	assert.Equal(t, armScores, resolved.ArmCandidateScores(armScores))
+	assert.Equal(t, map[string]string{
+		resolved.Candidates[0].CatalogID: resolved.Candidates[0].Provider,
+	}, resolved.CandidateProviders())
 	assert.Equal(t, map[string]float32{
-		resolved.Candidates[0].ArmID: 0.1,
-		resolved.Candidates[1].ArmID: 0.2,
-	}, resolved.ArmCandidateScores(map[string]float32{
-		resolved.Candidates[0].ArmID: 0.1,
-		resolved.Candidates[1].ArmID: 0.2,
-	}))
+		resolved.Candidates[0].CatalogID: 0.1,
+	}, resolved.CatalogCandidateScores(armScores))
 	for _, candidate := range resolved.Candidates {
 		binding, ok := resolved.BindingForSelection(candidate.ArmID, "")
 		require.True(t, ok)

--- a/internal/router/policy/resolver_test.go
+++ b/internal/router/policy/resolver_test.go
@@ -73,6 +73,27 @@ func TestArmResolverEnumeratesEachAllowedProviderBinding(t *testing.T) {
 	}
 }
 
+func TestArmResolverRejectsRosterOnlySelectionForThreeBindings(t *testing.T) {
+	resolver := policy.NewArmResolver(
+		set("deepseek/deepseek-v4-pro"),
+		set(
+			providers.ProviderMakora,
+			providers.ProviderTogether,
+			providers.ProviderFireworks,
+			providers.ProviderOpenRouter,
+		),
+		func(catalog.Model) string { return "shared/arm" },
+		policy.ProviderPolicy{},
+	)
+
+	resolved := resolver.Resolve(router.Request{})
+
+	require.Len(t, resolved.Candidates, 4)
+	assert.Empty(t, resolved.ByRosterID)
+	_, ok := resolved.BindingForSelection("", "shared/arm")
+	assert.False(t, ok)
+}
+
 func TestResolverAppliesHardFiltersAndPreferenceRanks(t *testing.T) {
 	resolver := policy.NewResolver(
 		set("claude-opus-4-8", "gpt-5.5"),

--- a/internal/router/policy/resolver_test.go
+++ b/internal/router/policy/resolver_test.go
@@ -65,6 +65,17 @@ func TestArmResolverEnumeratesEachAllowedProviderBinding(t *testing.T) {
 	assert.Equal(t, "deepseek/deepseek-v4-pro", resolved.Candidates[1].RosterID)
 	assert.NotEqual(t, resolved.Candidates[0].ArmID, resolved.Candidates[1].ArmID)
 	assert.Empty(t, resolved.ByRosterID)
+	assert.Equal(t, map[string]string{
+		resolved.Candidates[0].ArmID: resolved.Candidates[0].Provider,
+		resolved.Candidates[1].ArmID: resolved.Candidates[1].Provider,
+	}, resolved.CandidateArmProviders())
+	assert.Equal(t, map[string]float32{
+		resolved.Candidates[0].ArmID: 0.1,
+		resolved.Candidates[1].ArmID: 0.2,
+	}, resolved.ArmCandidateScores(map[string]float32{
+		resolved.Candidates[0].ArmID: 0.1,
+		resolved.Candidates[1].ArmID: 0.2,
+	}))
 	for _, candidate := range resolved.Candidates {
 		binding, ok := resolved.BindingForSelection(candidate.ArmID, "")
 		require.True(t, ok)

--- a/internal/router/policy/resolver_test.go
+++ b/internal/router/policy/resolver_test.go
@@ -65,6 +65,7 @@ func TestArmResolverEnumeratesEachAllowedProviderBinding(t *testing.T) {
 	assert.Equal(t, "deepseek/deepseek-v4-pro", resolved.Candidates[1].RosterID)
 	assert.NotEqual(t, resolved.Candidates[0].ArmID, resolved.Candidates[1].ArmID)
 	assert.Empty(t, resolved.ByRosterID)
+	assert.Equal(t, []string{"deepseek/deepseek-v4-pro"}, resolved.CandidateModels())
 	assert.Equal(t, map[string]string{
 		resolved.Candidates[0].ArmID: resolved.Candidates[0].Provider,
 		resolved.Candidates[1].ArmID: resolved.Candidates[1].Provider,

--- a/internal/router/policy/sidecar_router.go
+++ b/internal/router/policy/sidecar_router.go
@@ -109,6 +109,7 @@ func (r *SidecarRouter) PreviewRoute(ctx context.Context, req router.Request) (P
 	resolved := r.resolver.Resolve(req)
 	requestRouteID := uuid.NewString()
 	result, err := previewer.Preview(ctx, Query{
+		SchemaVersion:        r.resolver.SchemaVersion(),
 		Strategy:             strategy,
 		ExecutionMode:        ExecutionModePreview,
 		RouteID:              requestRouteID,
@@ -141,17 +142,21 @@ func (r *SidecarRouter) PreviewRoute(ctx context.Context, req router.Request) (P
 	if result.RouteID != "" && result.RouteID != requestRouteID {
 		return PreviewResult{}, fmt.Errorf("%s: preview route id mismatch: %w", strategy, r.config.Unavailable)
 	}
-	if err := validatePreviewResult(result); err != nil {
+	if err := validatePreviewResult(result, r.resolver.SchemaVersion()); err != nil {
 		return PreviewResult{}, fmt.Errorf("%s: invalid preview result: %v: %w", strategy, err, r.config.Unavailable)
 	}
 
+	eligibleCandidates := resolved.ByRosterID
+	if r.resolver.SchemaVersion() == SchemaVersionV2 {
+		eligibleCandidates = resolved.ByArmID
+	}
 	seen := make(map[string]struct{}, len(result.EligibleRosterIDs))
 	for _, rosterID := range result.EligibleRosterIDs {
 		if _, duplicate := seen[rosterID]; duplicate {
 			return PreviewResult{}, fmt.Errorf("%s: preview returned duplicate roster id %q: %w", strategy, rosterID, r.config.Unavailable)
 		}
 		seen[rosterID] = struct{}{}
-		if _, offered := resolved.ByRosterID[rosterID]; !offered {
+		if _, offered := eligibleCandidates[rosterID]; !offered {
 			return PreviewResult{}, fmt.Errorf("%s: preview returned unknown roster id %q: %w", strategy, rosterID, r.config.Unavailable)
 		}
 	}
@@ -166,8 +171,8 @@ func (r *SidecarRouter) PreviewRoute(ctx context.Context, req router.Request) (P
 	return result, nil
 }
 
-func validatePreviewResult(result PreviewResult) error {
-	if result.SchemaVersion != SchemaVersionV1 {
+func validatePreviewResult(result PreviewResult, expectedSchemaVersion string) error {
+	if result.SchemaVersion != expectedSchemaVersion {
 		return fmt.Errorf("unsupported schema %q", result.SchemaVersion)
 	}
 	if result.PolicyArtifactID == "" || result.PolicyArtifactSHA256 == "" || result.RosterSHA256 == "" {

--- a/internal/router/policy/sidecar_router.go
+++ b/internal/router/policy/sidecar_router.go
@@ -304,9 +304,9 @@ func (r *SidecarRouter) Route(ctx context.Context, req router.Request) (router.D
 		observability.FromContext(ctx).Error("Policy router sidecar decision failed", "strategy", strategy, "err", err)
 		return router.Decision{}, fmt.Errorf("%s: sidecar decide: %w: %w", strategy, err, r.config.Unavailable)
 	}
-	binding, ok := resolved.ByRosterID[res.Model]
+	binding, ok := resolved.BindingForSelection(res.ArmID, res.Model)
 	if !ok {
-		return router.Decision{}, fmt.Errorf("%s: sidecar returned unknown model %q: %w", strategy, res.Model, r.config.Unavailable)
+		return router.Decision{}, fmt.Errorf("%s: sidecar returned unknown arm %q or model %q: %w", strategy, res.ArmID, res.Model, r.config.Unavailable)
 	}
 	if res.Provider != "" && res.Provider != binding.Provider {
 		return router.Decision{}, fmt.Errorf("%s: sidecar returned provider %q for %q, expected %q: %w", strategy, res.Provider, res.Model, binding.Provider, r.config.Unavailable)
@@ -337,6 +337,7 @@ func (r *SidecarRouter) Route(ctx context.Context, req router.Request) (router.D
 		"route_id", routeID,
 		"model", binding.CatalogID,
 		"provider", binding.Provider,
+		"arm_id", res.ArmID,
 		"roster_model", res.Model,
 		"score", res.Score,
 	)
@@ -357,6 +358,7 @@ func (r *SidecarRouter) Route(ctx context.Context, req router.Request) (router.D
 			PolicyArtifactID:              res.PolicyArtifactID,
 			PolicyArtifactSHA256:          res.PolicyArtifactSHA256,
 			RosterVersion:                 res.RosterVersion,
+			SelectedArmID:                 res.ArmID,
 			SidecarSchemaVersion:          res.SchemaVersion,
 			DebugRef:                      debugRef,
 			AuthoritativePerTurnSelection: capabilities.AuthoritativePerTurnSelection,

--- a/internal/router/policy/sidecar_router.go
+++ b/internal/router/policy/sidecar_router.go
@@ -350,6 +350,8 @@ func (r *SidecarRouter) Route(ctx context.Context, req router.Request) (router.D
 			CandidateModels:               resolved.CandidateModels(),
 			CandidateProviders:            resolved.CandidateProviders(),
 			CandidateScores:               resolved.CatalogCandidateScores(res.CandidateScores),
+			CandidateArmProviders:         resolved.CandidateArmProviders(),
+			CandidateArmScores:            resolved.ArmCandidateScores(res.CandidateScores),
 			ChosenScore:                   float32(res.Score),
 			Propensity:                    propensity,
 			DisplayMarker:                 res.DisplayMarker,

--- a/internal/router/policy/sidecar_router.go
+++ b/internal/router/policy/sidecar_router.go
@@ -274,6 +274,7 @@ func (r *SidecarRouter) Route(ctx context.Context, req router.Request) (router.D
 	}
 	requestRouteID := uuid.NewString()
 	res, err := r.decider.Decide(ctx, Query{
+		SchemaVersion:        r.resolver.SchemaVersion(),
 		Strategy:             strategy,
 		ExecutionMode:        executionMode,
 		RouteID:              requestRouteID,
@@ -362,6 +363,9 @@ func (r *SidecarRouter) Route(ctx context.Context, req router.Request) (router.D
 			SidecarSchemaVersion:          res.SchemaVersion,
 			DebugRef:                      debugRef,
 			AuthoritativePerTurnSelection: capabilities.AuthoritativePerTurnSelection,
+			SelectedUpstreamID:            binding.UpstreamID,
+			BindingIndex:                  binding.BindingIndex,
+			CandidateArmIDs:               resolved.CandidateArmIDs(),
 		},
 	}, nil
 }

--- a/internal/router/policy/sidecar_router_test.go
+++ b/internal/router/policy/sidecar_router_test.go
@@ -125,6 +125,33 @@ func TestSidecarRouterOnboardsFutureStrategyWithoutProxyChanges(t *testing.T) {
 	assert.Equal(t, "positive", decider.feedback["feedback"])
 }
 
+func TestSidecarRouterDispatchesSidecarSelectedArm(t *testing.T) {
+	resolver := policy.NewArmResolver(
+		set("deepseek/deepseek-v4-pro"),
+		set(providers.ProviderMakora, providers.ProviderFireworks),
+		func(model catalog.Model) string { return model.ID },
+		policy.ManagedProviderPolicy(),
+	)
+	resolved := resolver.Resolve(router.Request{})
+	require.Len(t, resolved.Candidates, 2)
+	selected := resolved.Candidates[1]
+	decider := &recordingPolicy{result: policy.Result{
+		ArmID:    selected.ArmID,
+		Provider: selected.Provider,
+		Score:    0.9,
+	}}
+	adapter := policy.NewSidecarRouter(policy.SidecarRouterConfig{
+		Strategy: router.Strategy("future-policy"),
+	}, decider, resolver)
+
+	decision, err := adapter.Route(context.Background(), router.Request{})
+
+	require.NoError(t, err)
+	assert.Equal(t, selected.CatalogID, decision.Model)
+	assert.Equal(t, selected.Provider, decision.Provider)
+	assert.Equal(t, selected.ArmID, decision.Metadata.SelectedArmID)
+}
+
 func TestSidecarRouterMarksShadowDecisionsNonLearning(t *testing.T) {
 	decider := &recordingPolicy{result: policy.Result{Model: "gpt-5.5"}}
 	adapter := policy.NewSidecarRouter(policy.SidecarRouterConfig{

--- a/internal/router/policy/sidecar_router_test.go
+++ b/internal/router/policy/sidecar_router_test.go
@@ -106,6 +106,7 @@ func TestSidecarRouterOnboardsFutureStrategyWithoutProxyChanges(t *testing.T) {
 	assert.True(t, decision.Metadata.AuthoritativePerTurnSelection)
 	assert.Empty(t, decision.Metadata.DebugRef)
 	assert.Equal(t, strategy, decider.query.Strategy)
+	assert.Equal(t, policy.SchemaVersionV1, decider.query.SchemaVersion)
 	assert.Equal(t, policy.ExecutionModeServing, decider.query.ExecutionMode)
 	assert.Equal(t, "org-1", decider.query.OrganizationID)
 	assert.Equal(t, "cursor", decider.query.ClientApp)
@@ -150,6 +151,7 @@ func TestSidecarRouterDispatchesSidecarSelectedArm(t *testing.T) {
 	assert.Equal(t, selected.CatalogID, decision.Model)
 	assert.Equal(t, selected.Provider, decision.Provider)
 	assert.Equal(t, selected.ArmID, decision.Metadata.SelectedArmID)
+	assert.Equal(t, policy.SchemaVersionV2, decider.query.SchemaVersion)
 }
 
 func TestSidecarRouterMarksShadowDecisionsNonLearning(t *testing.T) {

--- a/internal/router/policy/sidecar_router_test.go
+++ b/internal/router/policy/sidecar_router_test.go
@@ -230,12 +230,52 @@ func TestSidecarRouterPreviewReturnsAllEligibleArmsWithoutLifecycleCallbacks(t *
 	assert.Equal(t, []string{"claude-opus-4-8", "gpt-5.5"}, result.EligibleRosterIDs)
 	assert.Equal(t, router.StrategyHMM, result.Strategy)
 	assert.NotEmpty(t, result.RouteID)
+	assert.Equal(t, policy.SchemaVersionV1, decider.previewQuery.SchemaVersion)
 	assert.Equal(t, policy.ExecutionModePreview, decider.previewQuery.ExecutionMode)
 	assert.False(t, decider.previewQuery.TrainingAllowed)
 	assert.True(t, decider.previewQuery.DebugEnabled)
 	assert.Len(t, decider.previewQuery.Candidates, 2)
 	assert.Nil(t, decider.outcome)
 	assert.Nil(t, decider.feedback)
+}
+
+func TestSidecarRouterPreviewUsesArmSchemaAndIDs(t *testing.T) {
+	resolver := policy.NewArmResolver(
+		set("deepseek/deepseek-v4-pro"),
+		set(providers.ProviderMakora, providers.ProviderFireworks),
+		catalogRosterID,
+		policy.ManagedProviderPolicy(),
+	)
+	resolved := resolver.Resolve(router.Request{})
+	require.Len(t, resolved.Candidates, 2)
+	selectedArmID := resolved.Candidates[0].ArmID
+	decider := &recordingPolicy{preview: policy.PreviewResult{
+		SchemaVersion:         policy.SchemaVersionV2,
+		PolicyArtifactID:      "temporal-q-v1",
+		PolicyArtifactSHA256:  "sha256:artifact",
+		RosterSHA256:          "sha256:roster",
+		HMMStateID:            0,
+		HMMStatePath:          []int{0},
+		HMMStateProbabilities: []float64{1},
+		ClassOrder:            []string{"provider-aware"},
+		ClassProbabilities:    map[string]float64{"provider-aware": 1},
+		RankedFallback: []policy.PreviewGroup{{
+			Group:        "provider-aware",
+			Probability:  1,
+			EligibleArms: []string{selectedArmID},
+		}},
+		SelectedGroup:     "provider-aware",
+		EligibleRosterIDs: []string{selectedArmID},
+	}}
+	adapter := policy.NewSidecarRouter(policy.SidecarRouterConfig{
+		Strategy: router.Strategy("temporal-q"),
+	}, decider, resolver).WithCapabilities(policy.Capabilities{SupportsPreview: true})
+
+	result, err := adapter.PreviewRoute(context.Background(), router.Request{})
+
+	require.NoError(t, err)
+	assert.Equal(t, policy.SchemaVersionV2, decider.previewQuery.SchemaVersion)
+	assert.Equal(t, []string{selectedArmID}, result.EligibleRosterIDs)
 }
 
 func TestSidecarRouterPreviewRecordsZeroEligibleArms(t *testing.T) {

--- a/internal/router/policy/sidecar_router_test.go
+++ b/internal/router/policy/sidecar_router_test.go
@@ -140,6 +140,10 @@ func TestSidecarRouterDispatchesSidecarSelectedArm(t *testing.T) {
 		ArmID:    selected.ArmID,
 		Provider: selected.Provider,
 		Score:    0.9,
+		CandidateScores: map[string]float32{
+			resolved.Candidates[0].ArmID: 0.1,
+			resolved.Candidates[1].ArmID: 0.9,
+		},
 	}}
 	adapter := policy.NewSidecarRouter(policy.SidecarRouterConfig{
 		Strategy: router.Strategy("future-policy"),
@@ -151,6 +155,14 @@ func TestSidecarRouterDispatchesSidecarSelectedArm(t *testing.T) {
 	assert.Equal(t, selected.CatalogID, decision.Model)
 	assert.Equal(t, selected.Provider, decision.Provider)
 	assert.Equal(t, selected.ArmID, decision.Metadata.SelectedArmID)
+	assert.Equal(t, map[string]string{
+		resolved.Candidates[0].ArmID: resolved.Candidates[0].Provider,
+		resolved.Candidates[1].ArmID: resolved.Candidates[1].Provider,
+	}, decision.Metadata.CandidateArmProviders)
+	assert.Equal(t, map[string]float32{
+		resolved.Candidates[0].ArmID: 0.1,
+		resolved.Candidates[1].ArmID: 0.9,
+	}, decision.Metadata.CandidateArmScores)
 	assert.Equal(t, policy.SchemaVersionV2, decider.query.SchemaVersion)
 }
 

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -258,10 +258,14 @@ type RoutingMetadata struct {
 	// CandidateScores: full pre-argmax blended score per eligible model, for
 	// off-policy analysis (contextual bandit substrate). Doesn't affect routing.
 	CandidateScores map[string]float32
+	// CandidateArmScores preserves scores for configuration-level actions.
+	CandidateArmScores map[string]float32
 	// CandidateProviders: per-request resolved provider per eligible model, so
 	// an exploration policy can switch to an in-band peer using this request's
 	// binding (correct under BYOK) rather than a boot-time default.
 	CandidateProviders map[string]string
+	// CandidateArmProviders preserves providers for configuration-level actions.
+	CandidateArmProviders map[string]string
 	// Propensity is the probability the chosen model was selected under the
 	// acting policy: 1.0 for deterministic argmax, <1.0 under exploration.
 	// Logged as the importance weight an off-policy estimator needs.

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -238,6 +238,7 @@ type RoutingMetadata struct {
 	PolicyArtifactID     string
 	PolicyArtifactSHA256 string
 	RosterVersion        string
+	SelectedArmID        string
 	SidecarSchemaVersion string
 	DebugRef             string
 	// AuthoritativePerTurnSelection means downstream orchestration may retry

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -105,9 +105,7 @@ type Request struct {
 	// ingress. Routing implementations must not turn their empty result into
 	// an incompatible fallback pool.
 	TranslationRequirements TranslationRequirements
-	// ReasoningConfigurationSHA256 and ToolConfigurationSHA256 are
-	// privacy-safe ingress hashes of the request semantics that constrain an
-	// arm. They never contain raw request content.
+	// ReasoningConfigurationSHA256 and ToolConfigurationSHA256 are privacy-safe hashes; raw request content is never stored here.
 	ReasoningConfigurationSHA256 string
 	ToolConfigurationSHA256      string
 	PromptText                   string

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -105,7 +105,12 @@ type Request struct {
 	// ingress. Routing implementations must not turn their empty result into
 	// an incompatible fallback pool.
 	TranslationRequirements TranslationRequirements
-	PromptText              string
+	// ReasoningConfigurationSHA256 and ToolConfigurationSHA256 are
+	// privacy-safe ingress hashes of the request semantics that constrain an
+	// arm. They never contain raw request content.
+	ReasoningConfigurationSHA256 string
+	ToolConfigurationSHA256      string
+	PromptText                   string
 	// ConversationMessages is provider-neutral visible history for sidecar
 	// routers that need multi-turn context.
 	ConversationMessages []ConversationMessage
@@ -239,6 +244,9 @@ type RoutingMetadata struct {
 	PolicyArtifactSHA256 string
 	RosterVersion        string
 	SelectedArmID        string
+	SelectedUpstreamID   string
+	BindingIndex         int
+	CandidateArmIDs      []string
 	SidecarSchemaVersion string
 	DebugRef             string
 	// AuthoritativePerTurnSelection means downstream orchestration may retry

--- a/internal/translate/configuration_hashes.go
+++ b/internal/translate/configuration_hashes.go
@@ -1,6 +1,7 @@
 package translate
 
 import (
+	"bytes"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
@@ -13,11 +14,19 @@ func (e *RequestEnvelope) ToolConfigurationSHA256() string {
 	if e == nil {
 		return sha256String("")
 	}
-	return sha256String(gjson.GetBytes(e.body, "tools").Raw)
+	raw := gjson.GetBytes(e.body, "tools").Raw
+	canonical, err := canonicalizeJSON(json.RawMessage(raw))
+	if err != nil {
+		return sha256String(raw)
+	}
+	return sha256Bytes(canonical)
 }
 
 // ReasoningConfigurationSHA256 returns a normalized hash; equivalent wire syntaxes (reasoning_effort vs reasoning.effort) produce the same value via ReasoningIntent.
 func (e *RequestEnvelope) ReasoningConfigurationSHA256() string {
+	if e == nil {
+		return sha256String("")
+	}
 	intent := e.ReasoningIntent()
 	payload := struct {
 		BudgetTokens int64  `json:"budget_tokens"`
@@ -44,4 +53,37 @@ func sha256String(value string) string {
 func sha256Bytes(value []byte) string {
 	sum := sha256.Sum256(value)
 	return hex.EncodeToString(sum[:])
+}
+
+func canonicalizeJSON(raw json.RawMessage) ([]byte, error) {
+	var object map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &object); err == nil {
+		for key, value := range object {
+			canonical, err := canonicalizeJSON(value)
+			if err != nil {
+				return nil, err
+			}
+			object[key] = canonical
+		}
+		return json.Marshal(object)
+	}
+
+	var array []json.RawMessage
+	if err := json.Unmarshal(raw, &array); err == nil {
+		for index, value := range array {
+			canonical, err := canonicalizeJSON(value)
+			if err != nil {
+				return nil, err
+			}
+			array[index] = canonical
+		}
+		return json.Marshal(array)
+	}
+
+	var compact bytes.Buffer
+	err := json.Compact(&compact, raw)
+	if err != nil {
+		return nil, err
+	}
+	return compact.Bytes(), nil
 }

--- a/internal/translate/configuration_hashes.go
+++ b/internal/translate/configuration_hashes.go
@@ -8,9 +8,7 @@ import (
 	"github.com/tidwall/gjson"
 )
 
-// ToolConfigurationSHA256 returns a content-retention-safe identity for the
-// complete inbound tool configuration. It is never persisted with raw schema
-// or description text.
+// ToolConfigurationSHA256 returns a privacy-safe hash of the inbound tool configuration; raw schema text is never persisted.
 func (e *RequestEnvelope) ToolConfigurationSHA256() string {
 	if e == nil {
 		return sha256String("")
@@ -18,9 +16,7 @@ func (e *RequestEnvelope) ToolConfigurationSHA256() string {
 	return sha256String(gjson.GetBytes(e.body, "tools").Raw)
 }
 
-// ReasoningConfigurationSHA256 returns a normalized identity for the inbound
-// reasoning configuration. Equivalent wire syntaxes normalize through
-// ReasoningIntent before hashing.
+// ReasoningConfigurationSHA256 returns a normalized hash; equivalent wire syntaxes (reasoning_effort vs reasoning.effort) produce the same value via ReasoningIntent.
 func (e *RequestEnvelope) ReasoningConfigurationSHA256() string {
 	intent := e.ReasoningIntent()
 	payload := struct {

--- a/internal/translate/configuration_hashes.go
+++ b/internal/translate/configuration_hashes.go
@@ -1,0 +1,51 @@
+package translate
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+
+	"github.com/tidwall/gjson"
+)
+
+// ToolConfigurationSHA256 returns a content-retention-safe identity for the
+// complete inbound tool configuration. It is never persisted with raw schema
+// or description text.
+func (e *RequestEnvelope) ToolConfigurationSHA256() string {
+	if e == nil {
+		return sha256String("")
+	}
+	return sha256String(gjson.GetBytes(e.body, "tools").Raw)
+}
+
+// ReasoningConfigurationSHA256 returns a normalized identity for the inbound
+// reasoning configuration. Equivalent wire syntaxes normalize through
+// ReasoningIntent before hashing.
+func (e *RequestEnvelope) ReasoningConfigurationSHA256() string {
+	intent := e.ReasoningIntent()
+	payload := struct {
+		BudgetTokens int64  `json:"budget_tokens"`
+		Explicit     bool   `json:"explicit"`
+		Kind         string `json:"kind"`
+		Level        string `json:"level"`
+	}{
+		BudgetTokens: intent.BudgetTokens,
+		Explicit:     intent.Explicit,
+		Kind:         string(intent.Kind),
+		Level:        intent.Level,
+	}
+	encoded, err := json.Marshal(payload)
+	if err != nil {
+		panic("marshal reasoning configuration: " + err.Error())
+	}
+	return sha256Bytes(encoded)
+}
+
+func sha256String(value string) string {
+	return sha256Bytes([]byte(value))
+}
+
+func sha256Bytes(value []byte) string {
+	sum := sha256.Sum256(value)
+	return hex.EncodeToString(sum[:])
+}

--- a/internal/translate/configuration_hashes_test.go
+++ b/internal/translate/configuration_hashes_test.go
@@ -1,0 +1,45 @@
+package translate
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestToolConfigurationSHA256ChangesWithSchema(t *testing.T) {
+	first, err := ParseAnthropic([]byte(`{
+		"model":"claude-sonnet-4-5",
+		"max_tokens":32,
+		"messages":[{"role":"user","content":"hi"}],
+		"tools":[{"name":"Read","input_schema":{"type":"object","properties":{"path":{"type":"string"}}}}]
+	}`))
+	require.NoError(t, err)
+	second, err := ParseAnthropic([]byte(`{
+		"model":"claude-sonnet-4-5",
+		"max_tokens":32,
+		"messages":[{"role":"user","content":"hi"}],
+		"tools":[{"name":"Read","input_schema":{"type":"object","properties":{"path":{"type":"integer"}}}}]
+	}`))
+	require.NoError(t, err)
+
+	assert.NotEmpty(t, first.ToolConfigurationSHA256())
+	assert.NotEqual(t, first.ToolConfigurationSHA256(), second.ToolConfigurationSHA256())
+}
+
+func TestReasoningConfigurationSHA256NormalizesReasoningIntent(t *testing.T) {
+	first, err := ParseOpenAI([]byte(`{
+		"model":"gpt-5",
+		"messages":[{"role":"user","content":"hi"}],
+		"reasoning_effort":"high"
+	}`))
+	require.NoError(t, err)
+	second, err := ParseOpenAI([]byte(`{
+		"model":"gpt-5",
+		"messages":[{"role":"user","content":"hi"}],
+		"reasoning":{"effort":"high"}
+	}`))
+	require.NoError(t, err)
+
+	assert.Equal(t, first.ReasoningConfigurationSHA256(), second.ReasoningConfigurationSHA256())
+}

--- a/internal/translate/configuration_hashes_test.go
+++ b/internal/translate/configuration_hashes_test.go
@@ -27,6 +27,25 @@ func TestToolConfigurationSHA256ChangesWithSchema(t *testing.T) {
 	assert.NotEqual(t, first.ToolConfigurationSHA256(), second.ToolConfigurationSHA256())
 }
 
+func TestToolConfigurationSHA256NormalizesJSONKeyOrder(t *testing.T) {
+	first, err := ParseAnthropic([]byte(`{
+		"model":"claude-sonnet-4-5",
+		"max_tokens":32,
+		"messages":[{"role":"user","content":"hi"}],
+		"tools":[{"name":"Read","input_schema":{"type":"object","properties":{"path":{"type":"string"}}}}]
+	}`))
+	require.NoError(t, err)
+	second, err := ParseAnthropic([]byte(`{
+		"model":"claude-sonnet-4-5",
+		"max_tokens":32,
+		"messages":[{"role":"user","content":"hi"}],
+		"tools":[{"input_schema":{"properties":{"path":{"type":"string"}},"type":"object"},"name":"Read"}]
+	}`))
+	require.NoError(t, err)
+
+	assert.Equal(t, first.ToolConfigurationSHA256(), second.ToolConfigurationSHA256())
+}
+
 func TestReasoningConfigurationSHA256NormalizesReasoningIntent(t *testing.T) {
 	first, err := ParseOpenAI([]byte(`{
 		"model":"gpt-5",
@@ -42,4 +61,11 @@ func TestReasoningConfigurationSHA256NormalizesReasoningIntent(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, first.ReasoningConfigurationSHA256(), second.ReasoningConfigurationSHA256())
+}
+
+func TestConfigurationHashesHandleNilEnvelope(t *testing.T) {
+	var envelope *RequestEnvelope
+
+	assert.NotEmpty(t, envelope.ToolConfigurationSHA256())
+	assert.NotEmpty(t, envelope.ReasoningConfigurationSHA256())
 }


### PR DESCRIPTION
## Summary
- Add provider-aware temporal-Q arms: each enabled provider/upstream binding becomes a distinct, deterministic action for `policy_router_v2`.
- Carry privacy-safe reasoning and tool-configuration hashes into arm identity, so routing can distinguish bindings whose effective configuration differs.
- Keep `policy_router_v1` compatible: legacy HMM payloads retain their existing candidate shape; V2-only arm fields are sent only under the V2 contract.
- Record selected arm, upstream, binding index, and candidate-level arm scores/providers in routing metadata for attribution and later temporal-Q evaluation.

## Safety and compatibility
- V2 selections resolve by arm ID and reject ambiguous roster-only fallback.
- Configuration hashes normalize equivalent wire formats and canonicalize tool JSON key ordering.
- Provider fallback dispatch prioritizes the policy-selected binding.

## Validation
- `wv mr tc`
- `wv mr t`
- Frozen HMM sidecar compatibility is covered by the V1 wire-contract test.