### PR TITLE
feat: make policy selection authoritative per turn

### DIFF
--- a/db/queries/session_pins.sql
+++ b/db/queries/session_pins.sql
@@ -92,6 +92,8 @@ ON CONFLICT (session_key, role) DO UPDATE SET
 -- served this turn; it lives here (not in UpsertSessionPin) so a
 -- /force-model upsert cannot overwrite the genuinely-last-served model
 -- before the next turn reads it to detect a mid-session model switch.
+-- pinned_provider is updated to the binding that actually served so per-turn
+-- policies receive correct previous-provider cache affinity after fallback.
 -- has_ever_switched latches true the first time the just-served model
 -- differs from a prior non-empty last_served_model. Caller-supplied model and
 -- latch evidence preserves history when the stored role row is new.
@@ -104,6 +106,7 @@ SET last_input_tokens        = @last_input_tokens::int,
     last_cached_write_tokens = @last_cached_write_tokens::int,
     last_output_tokens       = @last_output_tokens::int,
     last_turn_ended_at       = @last_turn_ended_at::timestamptz,
+    pinned_provider          = @last_served_provider::varchar,
     has_ever_switched        = has_ever_switched
       OR @session_ever_switched::boolean
       OR (last_served_model <> '' AND last_served_model <> @last_served_model::varchar)

--- a/docs/POLICY_ROUTER_HARNESS.md
+++ b/docs/POLICY_ROUTER_HARNESS.md
@@ -57,9 +57,19 @@ Example capabilities response:
   "honors_quality_price_bias": true,
   "supports_debug_route_detail": true,
   "supports_preview": false,
-  "supports_shadow": true
+  "supports_shadow": true,
+  "authoritative_per_turn_selection": false
 }
 ```
+
+When `authoritative_per_turn_selection=true`, each eligible main-loop or
+tool-result `/route` selection is model-authoritative for that turn. Go still
+owns hard eligibility, explicit force-model/operator pins, credentials, and
+same-model provider retries. It disables automatic session reuse, EV planner
+overrides, model-changing baseline failover, semantic-cache hits, and
+router-generated summarizer calls for those turns. Post-selection synthetic
+loop breakers are also bypassed so one accepted policy action maps to one
+selected model dispatch attempt.
 
 ## Route contract
 
@@ -78,6 +88,15 @@ structured candidate list. Candidate bindings are authoritative.
   "rollout_id": "quality-v2-prod-1",
   "routing_intent": "high",
   "preferred_models": ["gpt-5.5"],
+  "visible_turn_index": 7,
+  "session_turn_count": 9,
+  "turn_type": "tool_result",
+  "previous_served_model": "claude-opus-4-8",
+  "previous_provider": "anthropic",
+  "cache_state": "warm",
+  "prior_output_tokens": 321,
+  "session_ever_switched": true,
+  "history_truncated": false,
   "training_allowed": false,
   "debug_enabled": false,
   "candidates": [
@@ -87,7 +106,14 @@ structured candidate list. Candidate bindings are authoritative.
       "provider": "openai",
       "upstream_id": "gpt-5.5",
       "preference_rank": 0,
+      "input_usd_per_1m": 5.0,
+      "output_usd_per_1m": 30.0,
       "estimated_cost_usd": 0.03,
+      "cache_read_multiplier": 0.1,
+      "marginal_cost_factor": 0.25,
+      "effective_input_usd_per_1m": 1.25,
+      "effective_output_usd_per_1m": 7.5,
+      "effective_estimated_cost_usd": 0.0075,
       "capabilities": {
         "context_window": 400000,
         "tier": "high",
@@ -123,6 +149,11 @@ holds any policy-internal arm, bucket, cluster, or mode. During migration,
 The router rejects empty selections, unknown roster IDs, provider mismatches,
 and unsupported schema versions. Rich `debug` data is internal to the sidecar;
 only an opaque `debug_ref` is projected when authorized debug mode is enabled.
+
+`POST /outcome` reports `selected_model`, `selected_provider`, `served_model`,
+`served_provider`, `selected_served_model_match`, and
+`authoritative_per_turn_selection`. An authoritative model mismatch is marked
+ineligible for training and logged as an error.
 
 ## Privacy and execution modes
 

--- a/internal/policyclient/client.go
+++ b/internal/policyclient/client.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"workweave/router/internal/router"
 	"workweave/router/internal/router/policy"
@@ -152,6 +153,15 @@ type routeRequest struct {
 	PromptText                string             `json:"prompt_text"`
 	LatestUserText            string             `json:"latest_user_text,omitempty"`
 	TurnIndex                 int                `json:"turn_index"`
+	VisibleTurnIndex          *int               `json:"visible_turn_index,omitempty"`
+	SessionTurnCount          *int               `json:"session_turn_count,omitempty"`
+	TurnType                  string             `json:"turn_type,omitempty"`
+	PreviousServedModel       string             `json:"previous_served_model,omitempty"`
+	PreviousProvider          string             `json:"previous_provider,omitempty"`
+	CacheState                string             `json:"cache_state,omitempty"`
+	PriorOutputTokens         *int               `json:"prior_output_tokens,omitempty"`
+	SessionEverSwitched       *bool              `json:"session_ever_switched,omitempty"`
+	HistoryTruncated          *bool              `json:"history_truncated,omitempty"`
 	ConversationMessages      []routeMessage     `json:"conversation_messages,omitempty"`
 	TrainingConversationDelta []routeMessage     `json:"training_conversation_delta,omitempty"`
 	AvailableTools            []string           `json:"available_tools,omitempty"`
@@ -194,9 +204,13 @@ type routeToolCall struct {
 }
 
 type routeToolResult struct {
-	ToolUseID string `json:"tool_use_id,omitempty"`
-	IsError   bool   `json:"is_error,omitempty"`
-	Text      string `json:"text,omitempty"`
+	ToolUseID     string `json:"tool_use_id,omitempty"`
+	IsError       bool   `json:"is_error,omitempty"`
+	Text          string `json:"text,omitempty"`
+	ResultPresent bool   `json:"result_present,omitempty"`
+	CharCount     int    `json:"char_count,omitempty"`
+	ByteCount     int    `json:"byte_count,omitempty"`
+	ExitCategory  string `json:"exit_category,omitempty"`
 }
 
 type routeResponse struct {
@@ -365,6 +379,31 @@ func marshalRouteRequest(query policy.Query) ([]byte, error) {
 		providerMap[candidate.RosterID] = candidate.Provider
 	}
 	messages := routeMessages(query.ConversationMessages)
+	wireTurnIndex := turnIndex(messages)
+	var visibleTurnIndex *int
+	var sessionTurnCount *int
+	var sessionEverSwitched *bool
+	var historyTruncated *bool
+	var turnType string
+	var previousServedModel string
+	var previousProvider string
+	var cacheState string
+	var priorOutputTokens *int
+	if query.TurnContext != nil {
+		wireTurnIndex = query.TurnContext.VisibleTurnIndex
+		visibleTurnIndex = pointerTo(query.TurnContext.VisibleTurnIndex)
+		sessionTurnCount = pointerTo(query.TurnContext.SessionTurnCount)
+		sessionEverSwitched = pointerTo(query.TurnContext.SessionEverSwitched)
+		historyTruncated = pointerTo(
+			query.TurnContext.HistoryTruncated ||
+				routeMessagesTruncated(query.ConversationMessages),
+		)
+		turnType = query.TurnContext.TurnType
+		previousServedModel = query.TurnContext.PreviousServedModel
+		previousProvider = query.TurnContext.PreviousProvider
+		cacheState = query.TurnContext.CacheState
+		priorOutputTokens = query.TurnContext.PriorOutputTokens
+	}
 	var trainingDelta []routeMessage
 	if router.IsHMMStrategy(query.Strategy) && query.TrainingAllowed {
 		trainingDelta = trainingRouteMessageDelta(query.ConversationMessages)
@@ -382,7 +421,16 @@ func marshalRouteRequest(query policy.Query) ([]byte, error) {
 		RequestedModel:            query.RequestedModel,
 		PromptText:                query.PromptText,
 		LatestUserText:            latestUserText(messages),
-		TurnIndex:                 turnIndex(messages),
+		TurnIndex:                 wireTurnIndex,
+		VisibleTurnIndex:          visibleTurnIndex,
+		SessionTurnCount:          sessionTurnCount,
+		TurnType:                  turnType,
+		PreviousServedModel:       previousServedModel,
+		PreviousProvider:          previousProvider,
+		CacheState:                cacheState,
+		PriorOutputTokens:         priorOutputTokens,
+		SessionEverSwitched:       sessionEverSwitched,
+		HistoryTruncated:          historyTruncated,
 		ConversationMessages:      messages,
 		TrainingConversationDelta: trainingDelta,
 		AvailableTools:            clipRouteValues(query.AvailableTools, maxRouteToolCallInputKeys, maxRouteToolCallInputChars),
@@ -407,6 +455,10 @@ func marshalRouteRequest(query policy.Query) ([]byte, error) {
 		return nil, fmt.Errorf("marshal policy route request: %w", err)
 	}
 	return body, nil
+}
+
+func pointerTo[T any](value T) *T {
+	return &value
 }
 
 func (c *Client) doPolicyRequest(ctx context.Context, path string, body []byte) (*http.Response, []byte, error) {
@@ -502,6 +554,35 @@ func routeMessages(messages []router.ConversationMessage) []routeMessage {
 	})
 }
 
+func routeMessagesTruncated(messages []router.ConversationMessage) bool {
+	if len(messages) > maxRouteMessages {
+		return true
+	}
+	totalText := 0
+	for _, message := range messages {
+		text := strings.TrimSpace(message.Text)
+		if len(text) > maxRouteMessageTextChars {
+			return true
+		}
+		totalText += len(text)
+		if totalText > maxRouteMessageTotalChars {
+			return true
+		}
+		for _, call := range message.ToolCalls {
+			if len(strings.TrimSpace(call.Name)) > maxRouteToolCallInputChars ||
+				len(call.InputKeys) > maxRouteToolCallInputKeys {
+				return true
+			}
+			for _, key := range call.InputKeys {
+				if len(strings.TrimSpace(key)) > maxRouteToolCallInputChars {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
 func trainingRouteMessageDelta(messages []router.ConversationMessage) []routeMessage {
 	if len(messages) == 0 {
 		return nil
@@ -582,9 +663,23 @@ func convertRouteMessages(messages []router.ConversationMessage, limits routeMes
 		}
 		results := make([]routeToolResult, 0, len(message.ToolResults))
 		for _, result := range message.ToolResults {
+			charCount := result.CharCount
+			byteCount := result.ByteCount
+			if result.Text != "" {
+				if charCount == 0 {
+					charCount = utf8.RuneCountInString(result.Text)
+				}
+				if byteCount == 0 {
+					byteCount = len(result.Text)
+				}
+			}
 			routeResult := routeToolResult{
-				ToolUseID: clipRouteText(result.ToolUseID, limits.maxToolCallInputChars),
-				IsError:   result.IsError,
+				ToolUseID:     clipRouteText(result.ToolUseID, limits.maxToolCallInputChars),
+				IsError:       result.IsError,
+				ResultPresent: result.ResultPresent || result.ToolUseID != "" || result.Text != "",
+				CharCount:     charCount,
+				ByteCount:     byteCount,
+				ExitCategory:  result.ExitCategory,
 			}
 			if limits.includeToolResultText {
 				routeResult.Text = clipRouteText(result.Text, limits.maxTextChars)

--- a/internal/policyclient/client_test.go
+++ b/internal/policyclient/client_test.go
@@ -64,8 +64,26 @@ func TestClientPostsVersionedRouteAndParsesPolicyMetadata(t *testing.T) {
 		ConversationMessages: []router.ConversationMessage{
 			{Role: "user", Text: "please explore the repo"},
 			{Role: "assistant", Text: "done"},
-			{Role: "user", ToolResults: []router.ConversationToolResult{{ToolUseID: "toolu_123", Text: "full tool result"}}},
+			{Role: "user", ToolResults: []router.ConversationToolResult{{
+				ToolUseID:     "toolu_123",
+				Text:          "full tool result",
+				ResultPresent: true,
+				CharCount:     16,
+				ByteCount:     16,
+				ExitCategory:  "success",
+			}}},
 			{Role: "user", Text: "latest hello", ToolCalls: []router.ConversationToolCall{{Name: "Read", InputKeys: []string{"file_path"}, InputJSON: `{"file_path":"README.md"}`}}},
+		},
+		TurnContext: &router.PolicyTurnContext{
+			VisibleTurnIndex:    7,
+			SessionTurnCount:    9,
+			TurnType:            "tool_result",
+			PreviousServedModel: "claude-opus-4-8",
+			PreviousProvider:    providers.ProviderAnthropic,
+			CacheState:          router.PolicyCacheStateWarm,
+			PriorOutputTokens:   intPointer(321),
+			SessionEverSwitched: true,
+			HistoryTruncated:    true,
 		},
 		AvailableTools:  []string{"Read", "Grep", "Read", ""},
 		FeedbackKey:     "feedback-session",
@@ -97,7 +115,21 @@ func TestClientPostsVersionedRouteAndParsesPolicyMetadata(t *testing.T) {
 	assert.True(t, got.TrainingAllowed)
 	assert.True(t, got.DebugEnabled)
 	assert.Equal(t, "latest hello", got.LatestUserText)
-	assert.Equal(t, 1, got.TurnIndex)
+	assert.Equal(t, 7, got.TurnIndex)
+	require.NotNil(t, got.VisibleTurnIndex)
+	assert.Equal(t, 7, *got.VisibleTurnIndex)
+	require.NotNil(t, got.SessionTurnCount)
+	assert.Equal(t, 9, *got.SessionTurnCount)
+	assert.Equal(t, "tool_result", got.TurnType)
+	assert.Equal(t, "claude-opus-4-8", got.PreviousServedModel)
+	assert.Equal(t, providers.ProviderAnthropic, got.PreviousProvider)
+	assert.Equal(t, router.PolicyCacheStateWarm, got.CacheState)
+	require.NotNil(t, got.PriorOutputTokens)
+	assert.Equal(t, 321, *got.PriorOutputTokens)
+	require.NotNil(t, got.SessionEverSwitched)
+	assert.True(t, *got.SessionEverSwitched)
+	require.NotNil(t, got.HistoryTruncated)
+	assert.True(t, *got.HistoryTruncated)
 	assert.Equal(t, []string{"Read", "Grep"}, got.AvailableTools)
 	assert.Equal(t, "feedback-session", got.FeedbackKey)
 	assert.Equal(t, "default", got.FeedbackRole)
@@ -109,6 +141,9 @@ func TestClientPostsVersionedRouteAndParsesPolicyMetadata(t *testing.T) {
 	require.Len(t, got.TrainingConversationDelta[2].ToolCalls, 1)
 	assert.Equal(t, `{"file_path":"README.md"}`, got.TrainingConversationDelta[2].ToolCalls[0].InputJSON)
 	assert.Empty(t, got.ConversationMessages[2].ToolResults[0].Text)
+	assert.True(t, got.ConversationMessages[2].ToolResults[0].ResultPresent)
+	assert.Equal(t, 16, got.ConversationMessages[2].ToolResults[0].CharCount)
+	assert.Equal(t, "success", got.ConversationMessages[2].ToolResults[0].ExitCategory)
 	assert.Empty(t, got.ConversationMessages[3].ToolCalls[0].InputJSON)
 	require.Len(t, got.Candidates, 1)
 	assert.Equal(t, "moonshotai/kimi-k2.7", got.Candidates[0].CatalogID)
@@ -336,18 +371,22 @@ func TestClientUsesBoundedDefaultHTTPClient(t *testing.T) {
 }
 
 func TestRouteMessagesPreservesLatestUserWhenPayloadIsCapped(t *testing.T) {
-	messages := routeMessages([]router.ConversationMessage{
+	source := []router.ConversationMessage{
 		{Role: "user", Text: strings.Repeat("a", maxRouteMessageTotalChars+100)},
 		{Role: "assistant", Text: "older response"},
 		{Role: "tool", Text: "raw tool output should be skipped"},
 		{Role: "user", Text: "latest request"},
-	})
+	}
+	messages := routeMessages(source)
 
 	assert.Equal(t, "latest request", latestUserText(messages))
 	assert.Equal(t, 1, turnIndex(messages))
+	assert.True(t, routeMessagesTruncated(source))
 	for _, message := range messages {
 		assert.NotEqual(t, "tool", message.Role)
 	}
 }
 
 func floatPtr(value float64) *float64 { return &value }
+
+func intPointer(value int) *int { return &value }

--- a/internal/postgres/session_pin_repo.go
+++ b/internal/postgres/session_pin_repo.go
@@ -73,6 +73,7 @@ func (r *SessionPinRepo) UpdateUsage(ctx context.Context, sessionKey [sessionpin
 		LastOutputTokens:      int32(usage.OutputTokens),
 		LastTurnEndedAt:       pgtype.Timestamptz{Time: endedAt.UTC(), Valid: true},
 		LastServedModel:       usage.ServedModel,
+		LastServedProvider:    usage.ServedProvider,
 		PriorServedModel:      usage.PriorServedModel,
 		SessionEverSwitched:   usage.SessionEverSwitched,
 	})

--- a/internal/proxy/authoritative_turnloop_internal_test.go
+++ b/internal/proxy/authoritative_turnloop_internal_test.go
@@ -1,0 +1,274 @@
+package proxy
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"workweave/router/internal/providers"
+	"workweave/router/internal/router"
+	"workweave/router/internal/router/handover"
+	"workweave/router/internal/router/planner"
+	"workweave/router/internal/router/policy"
+	"workweave/router/internal/router/sessionpin"
+	"workweave/router/internal/translate"
+)
+
+type authoritativeTestRouter struct {
+	decision router.Decision
+	requests []router.Request
+}
+
+func (r *authoritativeTestRouter) Route(_ context.Context, req router.Request) (router.Decision, error) {
+	r.requests = append(r.requests, req)
+	return r.decision, nil
+}
+
+type authoritativeHandoverSummarizer struct {
+	calls int
+}
+
+func (s *authoritativeHandoverSummarizer) Summarize(
+	_ context.Context,
+	_ *translate.RequestEnvelope,
+) (string, handover.Usage, error) {
+	s.calls++
+	return "must not run", handover.Usage{}, nil
+}
+
+func (s *authoritativeHandoverSummarizer) Provider() string {
+	return providers.ProviderAnthropic
+}
+
+func TestAuthoritativePolicySelectsEveryEligibleTurn(t *testing.T) {
+	strategy := router.Strategy("authoritative-test")
+	tests := []struct {
+		name             string
+		body             []byte
+		pinFound         bool
+		pinExpires       time.Time
+		historyTruncated bool
+	}{
+		{
+			name:       "first turn routes once",
+			body:       []byte(`{"model":"claude-opus-4-8","messages":[{"role":"user","content":"start"}]}`),
+			pinExpires: time.Now().Add(time.Hour),
+		},
+		{
+			name:       "main loop ignores planner stay",
+			body:       []byte(`{"model":"claude-opus-4-8","messages":[{"role":"user","content":"fix the failing test"}]}`),
+			pinFound:   true,
+			pinExpires: time.Now().Add(time.Hour),
+		},
+		{
+			name: "tool result ignores sticky kill switch",
+			body: []byte(`{
+				"model":"claude-opus-4-8",
+				"tools":[{"name":"Read","description":"read","input_schema":{"type":"object"}}],
+				"messages":[
+					{"role":"user","content":"inspect the repository"},
+					{"role":"assistant","content":[{"type":"tool_use","id":"toolu_1","name":"Read","input":{"path":"README.md"}}]},
+					{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_1","content":"contents"}]}
+				]
+			}`),
+			pinFound:   true,
+			pinExpires: time.Now().Add(time.Hour),
+		},
+		{
+			name:       "expired pin does not reanchor",
+			body:       []byte(`{"model":"claude-opus-4-8","messages":[{"role":"user","content":"continue"}]}`),
+			pinFound:   true,
+			pinExpires: time.Now().Add(-time.Minute),
+		},
+		{
+			name:             "deterministic compaction is visible",
+			body:             []byte(`{"model":"claude-opus-4-8","messages":[{"role":"user","content":"continue after trim"}]}`),
+			pinFound:         true,
+			pinExpires:       time.Now().Add(time.Hour),
+			historyTruncated: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			store := newStubPinStore()
+			store.getFound = test.pinFound
+			store.getPin = sessionpin.Pin{
+				Provider:         providers.ProviderAnthropic,
+				Model:            "claude-opus-4-7",
+				Reason:           "cluster:v0.2",
+				TurnCount:        7,
+				PinnedUntil:      test.pinExpires,
+				LastTurnEndedAt:  time.Now().Add(-time.Minute),
+				LastServedModel:  "claude-opus-4-7",
+				LastOutputTokens: 321,
+				HasEverSwitched:  true,
+			}
+			policyRouter := &authoritativeTestRouter{decision: router.Decision{
+				Provider: providers.ProviderAnthropic,
+				Model:    "claude-opus-4-8",
+				Reason:   "authoritative-test_policy",
+			}}
+			summarizer := &authoritativeHandoverSummarizer{}
+			svc := NewService(
+				nil,
+				nil,
+				nil,
+				false,
+				nil,
+				store,
+				false,
+				providers.ProviderAnthropic,
+				"claude-haiku-4-5",
+				nil,
+			).WithScoreToolResultTurns(false).
+				WithPlanner(planner.EVConfig{
+					ThresholdUSD:           1_000_000,
+					ExpectedRemainingTurns: 3,
+				}).
+				WithSummarizer(summarizer).
+				WithPolicyStrategy(policy.StrategySpec{
+					Strategy: strategy,
+					Router:   policyRouter,
+					Capabilities: policy.Capabilities{
+						SchemaVersion:                 policy.SchemaVersionV1,
+						AuthoritativePerTurnSelection: true,
+					},
+				})
+			env, err := translate.ParseAnthropic(test.body)
+			require.NoError(t, err)
+			features := env.RoutingFeatures(false)
+			ctx := router.WithStrategy(context.Background(), strategy)
+			req := router.Request{
+				RequestedModel:       features.Model,
+				EstimatedInputTokens: features.Tokens,
+				HasTools:             features.HasTools,
+				ConversationMessages: conversationMessagesForRouting(env),
+				HistoryTruncated:     test.historyTruncated,
+			}
+
+			result, err := svc.runTurnLoop(
+				ctx,
+				env,
+				features,
+				"api-key",
+				uuid.New(),
+				"",
+				http.Header{},
+				req,
+			)
+
+			require.NoError(t, err)
+			assert.True(t, result.AuthoritativePerTurn)
+			assert.Equal(t, "claude-opus-4-8", result.Decision.Model)
+			assert.Equal(t, "authoritative_per_turn", result.PinTier)
+			assert.False(t, result.StickyHit)
+			assert.Empty(t, result.PlannerDecision.Outcome)
+			assert.False(t, result.Handover.Invoked)
+			assert.Equal(t, 0, summarizer.calls)
+			require.Len(t, policyRouter.requests, 1)
+			turnContext := policyRouter.requests[0].PolicyTurnContext
+			require.NotNil(t, turnContext)
+			assert.Equal(t, test.historyTruncated, turnContext.HistoryTruncated)
+			if test.pinFound {
+				assert.Equal(t, 7, turnContext.SessionTurnCount)
+				assert.Equal(t, "claude-opus-4-7", turnContext.PreviousServedModel)
+				assert.Equal(t, providers.ProviderAnthropic, turnContext.PreviousProvider)
+				expectedCacheState := router.PolicyCacheStateWarm
+				if test.historyTruncated {
+					expectedCacheState = router.PolicyCacheStateCold
+				}
+				assert.Equal(t, expectedCacheState, turnContext.CacheState)
+				require.NotNil(t, turnContext.PriorOutputTokens)
+				assert.Equal(t, 321, *turnContext.PriorOutputTokens)
+				assert.True(t, turnContext.SessionEverSwitched)
+			} else {
+				assert.Zero(t, turnContext.SessionTurnCount)
+				assert.Empty(t, turnContext.PreviousServedModel)
+				assert.Empty(t, turnContext.PreviousProvider)
+				assert.Equal(t, router.PolicyCacheStateUnknown, turnContext.CacheState)
+				assert.Nil(t, turnContext.PriorOutputTokens)
+				assert.False(t, turnContext.SessionEverSwitched)
+			}
+			require.Len(t, store.upserts, 1)
+			assert.Equal(t, "claude-opus-4-8", store.upserts[0].Model)
+		})
+	}
+}
+
+func TestAuthoritativePolicyDisablesSemanticCache(t *testing.T) {
+	strategy := router.Strategy("authoritative-test")
+	svc := (&Service{}).WithPolicyStrategy(policy.StrategySpec{
+		Strategy: strategy,
+		Router:   &authoritativeTestRouter{},
+		Capabilities: policy.Capabilities{
+			AuthoritativePerTurnSelection: true,
+		},
+	})
+
+	assert.False(t, svc.semanticCacheAllowed(router.WithStrategy(context.Background(), strategy)))
+	assert.True(t, svc.semanticCacheAllowed(context.Background()))
+}
+
+func TestAuthoritativePolicyPreservesExplicitForceModel(t *testing.T) {
+	strategy := router.Strategy("authoritative-force-test")
+	store := newStubPinStore()
+	store.getFound = true
+	store.getPin = sessionpin.Pin{
+		Provider:    providers.ProviderAnthropic,
+		Model:       "claude-opus-4-7",
+		Reason:      translate.ReasonUserForceModel,
+		PinnedUntil: time.Now().Add(time.Hour),
+	}
+	policyRouter := &authoritativeTestRouter{decision: router.Decision{
+		Provider: providers.ProviderAnthropic,
+		Model:    "claude-opus-4-8",
+	}}
+	svc := NewService(
+		nil,
+		nil,
+		nil,
+		false,
+		nil,
+		store,
+		false,
+		providers.ProviderAnthropic,
+		"claude-haiku-4-5",
+		nil,
+	).WithPolicyStrategy(policy.StrategySpec{
+		Strategy: strategy,
+		Router:   policyRouter,
+		Capabilities: policy.Capabilities{
+			AuthoritativePerTurnSelection: true,
+		},
+	})
+	env, err := translate.ParseAnthropic(
+		[]byte(`{"model":"claude-opus-4-8","messages":[{"role":"user","content":"continue"}]}`),
+	)
+	require.NoError(t, err)
+	features := env.RoutingFeatures(false)
+
+	result, err := svc.runTurnLoop(
+		router.WithStrategy(context.Background(), strategy),
+		env,
+		features,
+		"api-key",
+		uuid.New(),
+		"",
+		http.Header{},
+		router.Request{
+			RequestedModel:       features.Model,
+			ConversationMessages: conversationMessagesForRouting(env),
+		},
+	)
+
+	require.NoError(t, err)
+	assert.Equal(t, "claude-opus-4-7", result.Decision.Model)
+	assert.True(t, result.StickyHit)
+	assert.Empty(t, policyRouter.requests)
+}

--- a/internal/proxy/baseline_failover_integration_test.go
+++ b/internal/proxy/baseline_failover_integration_test.go
@@ -14,6 +14,7 @@ import (
 	"workweave/router/internal/providers/openaicompat"
 	"workweave/router/internal/proxy"
 	"workweave/router/internal/router"
+	"workweave/router/internal/router/policy"
 	"workweave/router/internal/translate"
 
 	"github.com/stretchr/testify/assert"
@@ -122,6 +123,90 @@ func TestProxyMessages_OSSOutageFailsOverToBaselineAnthropic(t *testing.T) {
 	// the cost-routed OSS id — otherwise next-turn switch detection is wrong.
 	require.NotEmpty(t, store.usages, "baseline failover must write pin usage")
 	assert.Equal(t, "claude-opus-4-8", store.usages[len(store.usages)-1].ServedModel, "pin usage records the served baseline model")
+}
+
+func TestProxyMessages_AuthoritativePolicyNeverChangesModelOnFailover(t *testing.T) {
+	var (
+		mu              sync.Mutex
+		fireworksCount  int
+		openRouterCount int
+		anthropicCount  int
+	)
+	fail503 := func(counter *int) http.HandlerFunc {
+		return func(w http.ResponseWriter, _ *http.Request) {
+			mu.Lock()
+			*counter++
+			mu.Unlock()
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusServiceUnavailable)
+			_, _ = w.Write([]byte(`{"error":{"message":"provider unavailable"}}`))
+		}
+	}
+	fireworks := httptest.NewServer(fail503(&fireworksCount))
+	defer fireworks.Close()
+	openrouter := httptest.NewServer(fail503(&openRouterCount))
+	defer openrouter.Close()
+	anthropicUpstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		mu.Lock()
+		anthropicCount++
+		mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer anthropicUpstream.Close()
+
+	strategy := router.Strategy("authoritative-failover-test")
+	policyRouter := &fakeRouter{decision: router.Decision{
+		Provider: providers.ProviderFireworks,
+		Model:    "deepseek/deepseek-v4-pro",
+		Reason:   "authoritative-test_policy",
+		Metadata: &router.RoutingMetadata{
+			RouteID:                       "route-authoritative",
+			Strategy:                      string(strategy),
+			AuthoritativePerTurnSelection: true,
+		},
+	}}
+	svc := proxy.NewService(
+		nil,
+		map[string]providers.Client{
+			providers.ProviderFireworks:  openaicompat.NewClient("test-fw-key", fireworks.URL),
+			providers.ProviderOpenRouter: openaicompat.NewClient("test-or-key", openrouter.URL),
+			providers.ProviderAnthropic:  anthropic.NewClient("test-anthropic-key", anthropicUpstream.URL),
+		},
+		nil,
+		false,
+		nil,
+		newFakePinStore(),
+		false,
+		providers.ProviderAnthropic,
+		"claude-haiku-4-5",
+		newCaptureTelemetry(),
+	).WithDeploymentKeyedProviders(map[string]struct{}{
+		providers.ProviderFireworks:  {},
+		providers.ProviderOpenRouter: {},
+		providers.ProviderAnthropic:  {},
+	}).WithPolicyStrategy(policy.StrategySpec{
+		Strategy: strategy,
+		Router:   policyRouter,
+		Capabilities: policy.Capabilities{
+			SchemaVersion:                 policy.SchemaVersionV1,
+			AuthoritativePerTurnSelection: true,
+		},
+	})
+	ctx := router.WithStrategy(
+		authedCtx("11111111-1111-1111-1111-111111111111"),
+		strategy,
+	)
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(""))
+	body := []byte(`{"model":"claude-opus-4-8","stream":true,"messages":[{"role":"user","content":"hi"}]}`)
+
+	_ = svc.ProxyMessages(ctx, body, rec, req)
+
+	mu.Lock()
+	defer mu.Unlock()
+	assert.Equal(t, 1, fireworksCount)
+	assert.Equal(t, 1, openRouterCount)
+	assert.Equal(t, 0, anthropicCount, "authoritative policy must surface failure instead of substituting another model")
 }
 
 // TestProxyMessages_ForcedModelUnavailableDoesNotSubstituteAnthropic ensures a

--- a/internal/proxy/compaction.go
+++ b/internal/proxy/compaction.go
@@ -143,7 +143,8 @@ func (s *Service) maybeCompact(ctx context.Context, env *translate.RequestEnvelo
 	}
 
 	// Tier 3: structured summarization with a window-aware model.
-	if s.compactionSummarizer != nil {
+	// Authoritative-policy turns skip LLM summarization; deterministic cleanup and rescue trimming still run.
+	if s.compactionSummarizer != nil && !s.authoritativePerTurnSelection(ctx) {
 		if summary, usage, model, ok := s.runCompactionSummary(ctx, env, reqHeaders); ok {
 			env.RewriteForCompaction(summary, compactionRecentTurns)
 			res.Applied = true

--- a/internal/proxy/compaction_test.go
+++ b/internal/proxy/compaction_test.go
@@ -9,7 +9,9 @@ import (
 	"testing"
 
 	"workweave/router/internal/providers"
+	"workweave/router/internal/router"
 	"workweave/router/internal/router/handover"
+	"workweave/router/internal/router/policy"
 	"workweave/router/internal/router/turntype"
 	"workweave/router/internal/translate"
 
@@ -150,6 +152,29 @@ func TestMaybeCompact_SkipsHardPinnedTurns(t *testing.T) {
 	assert.False(t, res.Applied, "hard-pinned turns must skip compaction")
 	assert.Equal(t, 0, fake.calls, "summarizer must not be called for a Compaction turn")
 	assert.Equal(t, before, env.ContextOverflowTokenEstimate(), "env must be untouched")
+}
+
+func TestMaybeCompact_AuthoritativePolicyNeverCallsSummarizer(t *testing.T) {
+	strategy := router.Strategy("authoritative-compaction-test")
+	fake := &fakeCompactionSummarizer{summary: "must not run"}
+	s := (&Service{
+		compactionTriggerPct: DefaultCompactionTriggerPct,
+		compactionSummarizer: fake,
+	}).WithPolicyStrategy(policy.StrategySpec{
+		Strategy: strategy,
+		Router:   &authoritativeTestRouter{},
+		Capabilities: policy.Capabilities{
+			AuthoritativePerTurnSelection: true,
+		},
+	})
+	env, err := translate.ParseAnthropic(alternatingAnthropicBody(20, 200))
+	require.NoError(t, err)
+	ctx := router.WithStrategy(context.Background(), strategy)
+
+	result, _ := s.maybeCompact(ctx, env, turntype.MainLoop, 100, 1_000, http.Header{})
+
+	assert.Equal(t, 0, fake.calls)
+	assert.False(t, result.Summarized)
 }
 
 func TestWithCompaction_ZeroPctDisables(t *testing.T) {

--- a/internal/proxy/conversation_messages.go
+++ b/internal/proxy/conversation_messages.go
@@ -1,6 +1,8 @@
 package proxy
 
 import (
+	"unicode/utf8"
+
 	"workweave/router/internal/router"
 	"workweave/router/internal/translate"
 )
@@ -22,10 +24,18 @@ func conversationMessagesForRouting(env *translate.RequestEnvelope) []router.Con
 		}
 		results := make([]router.ConversationToolResult, 0, len(msg.ToolResults))
 		for _, result := range msg.ToolResults {
+			exitCategory := "success"
+			if result.IsError {
+				exitCategory = "error"
+			}
 			results = append(results, router.ConversationToolResult{
-				ToolUseID: result.ToolUseID,
-				IsError:   result.IsError,
-				Text:      result.Text,
+				ToolUseID:     result.ToolUseID,
+				IsError:       result.IsError,
+				Text:          result.Text,
+				ResultPresent: true,
+				CharCount:     utf8.RuneCountInString(result.Text),
+				ByteCount:     len(result.Text),
+				ExitCategory:  exitCategory,
 			})
 		}
 		out = append(out, router.ConversationMessage{

--- a/internal/proxy/hmm_outcome_internal_test.go
+++ b/internal/proxy/hmm_outcome_internal_test.go
@@ -74,8 +74,12 @@ func TestReportPolicyOutcome_UsesFreshMetadataForStickyServedDecision(t *testing
 	select {
 	case payload := <-reporter.ch:
 		require.Equal(t, "route-fresh", payload["route_id"])
+		assert.Equal(t, "moonshotai/kimi-k2.7", payload["selected_model"])
+		assert.Equal(t, providers.ProviderFireworks, payload["selected_provider"])
 		assert.Equal(t, "claude-haiku-4-5", payload["served_model"])
 		assert.Equal(t, providers.ProviderAnthropic, payload["served_provider"])
+		assert.Equal(t, false, payload["selected_served_model_match"])
+		assert.NotContains(t, payload, "training_exclusion_reason")
 		assert.Equal(t, "moonshotai/kimi-k2.7", payload["decision_model"])
 		assert.Equal(t, providers.ProviderFireworks, payload["decision_provider"])
 		assert.Equal(t, "medium|mid", payload["policy_route_key"])
@@ -110,6 +114,57 @@ func TestReportPolicyOutcome_OmitsResponseBodyWhenTrainingIsNotAllowed(t *testin
 		assert.Equal(t, false, payload["training_allowed"])
 		assert.NotContains(t, payload, "response_body")
 		assert.NotContains(t, payload, "response_body_truncated")
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for policy outcome payload")
+	}
+}
+
+func TestReportPolicyOutcome_AuthoritativeMismatchFailsClosedForTraining(t *testing.T) {
+	strategy := router.Strategy("authoritative-outcome-test")
+	reporter := &captureHMMOutcomeReporter{ch: make(chan map[string]interface{}, 1)}
+	s := (&Service{}).WithPolicyStrategy(policy.StrategySpec{
+		Strategy: strategy,
+		Router:   reporter,
+	})
+	selected := router.Decision{
+		Model:    "claude-opus-4-8",
+		Provider: providers.ProviderAnthropic,
+		Metadata: &router.RoutingMetadata{
+			RouteID:                       "route-authoritative",
+			Strategy:                      string(strategy),
+			AuthoritativePerTurnSelection: true,
+		},
+	}
+	served := router.Decision{
+		Model:    "claude-haiku-4-5",
+		Provider: providers.ProviderAnthropic,
+	}
+	ctx := context.WithValue(context.Background(), PolicyTrainingAllowedContextKey{}, true)
+
+	s.reportPolicyOutcome(
+		ctx,
+		turnLoopResult{Fresh: selected, AuthoritativePerTurn: true},
+		served,
+		providers.ProviderAnthropic,
+		100,
+		90,
+		10,
+		0,
+		0,
+		12,
+		34,
+		nil,
+		&policyOutcomeResponse{Body: []byte("must not train")},
+	)
+
+	select {
+	case payload := <-reporter.ch:
+		assert.Equal(t, "claude-opus-4-8", payload["selected_model"])
+		assert.Equal(t, "claude-haiku-4-5", payload["served_model"])
+		assert.Equal(t, false, payload["selected_served_model_match"])
+		assert.Equal(t, false, payload["training_allowed"])
+		assert.Equal(t, "selected_served_model_mismatch", payload["training_exclusion_reason"])
+		assert.NotContains(t, payload, "response_body")
 	case <-time.After(time.Second):
 		t.Fatal("timed out waiting for policy outcome payload")
 	}

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -1539,6 +1539,18 @@ func (s *Service) PolicyCapabilities(strategy router.Strategy) (policy.Capabilit
 	return registered.capabilities, ok
 }
 
+func (s *Service) authoritativePerTurnSelection(ctx context.Context) bool {
+	if s == nil {
+		return false
+	}
+	capabilities, ok := s.PolicyCapabilities(router.StrategyFromContext(ctx))
+	return ok && capabilities.AuthoritativePerTurnSelection
+}
+
+func (s *Service) semanticCacheAllowed(ctx context.Context) bool {
+	return !s.authoritativePerTurnSelection(ctx)
+}
+
 // PolicyStrategyAvailable reports whether a strategy has a live router;
 // registration stays visible when a sidecar is absent so callers see the gap.
 func (s *Service) PolicyStrategyAvailable(strategy router.Strategy) bool {
@@ -2150,6 +2162,7 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 		PromptText:              promptText,
 		ConversationMessages:    conversationMessagesForRouting(env),
 		AvailableTools:          availableToolsForRouting(env),
+		HistoryTruncated:        compRes.Applied,
 		OrganizationID:          externalID,
 		// Keep this tied to client-visible history so a later feedback command
 		// can correlate with the route even if local compaction rewrites env.
@@ -2241,7 +2254,7 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 	// Gated to tool-bearing turns so a frozen marker + frozen prompt prefix
 	// can't collide on healthy text-only turns.
 	toolBearingTurn := inboundToolCallCount > 0 || inboundLastUser.HasToolResult
-	if !agentShadowMode && toolBearingTurn && s.noProgress != nil {
+	if !agentShadowMode && !routeRes.AuthoritativePerTurn && toolBearingTurn && s.noProgress != nil {
 		fp := computeNoProgressFingerprint(decision, promptText, feats.MessageCount, toolProgressMarker(env))
 		role := roleForTier(catalog.TierFor(feats.Model))
 		if looped, count := s.noProgress.recordAndDetect(routeRes.SessionKey, installationID, role, fp, time.Now()); looped {
@@ -2251,7 +2264,7 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 
 	// Text-repetition break: fresh tool calls each turn defeat the no-progress
 	// fingerprint; repeated narration is the durable tell. See text_repetition.go.
-	if !agentShadowMode && s.textRepetitionBreakEnabled && (tt == turntype.MainLoop || tt == turntype.ToolResult) {
+	if !agentShadowMode && !routeRes.AuthoritativePerTurn && s.textRepetitionBreakEnabled && (tt == turntype.MainLoop || tt == turntype.ToolResult) {
 		if looped, count, sampleHash := detectTextRepetition(env); looped {
 			role := roleForTier(catalog.TierFor(feats.Model))
 			return s.handleTextRepetitionBreak(ctx, w, env, count, sampleHash, installationID, routeRes.SessionKey, role, decision.Model, decision.Provider, feats.Tokens)
@@ -2287,7 +2300,7 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 	// client-trim detector as a false positive), so a compaction handover here
 	// would be a redundant summarizer call that also discards the recent-turn
 	// tail maybeCompact deliberately kept.
-	if !agentShadowMode && decision.Provider != providers.ProviderAnthropic && !routeRes.HardPinned && !routeRes.Handover.Invoked && !compRes.Applied && routeRes.PrefixTrimmed {
+	if !agentShadowMode && !routeRes.AuthoritativePerTurn && decision.Provider != providers.ProviderAnthropic && !routeRes.HardPinned && !routeRes.Handover.Invoked && !compRes.Applied && routeRes.PrefixTrimmed {
 		log.Info("Context trimming detected on non-Anthropic route; rewriting context with handover summary",
 			"message_count", feats.MessageCount,
 			"tool_call_count", inboundToolCallCount,
@@ -2306,7 +2319,7 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 	// Subscription-only turns are excluded (like the OpenAI path): the mode is an
 	// unfoldable routing signal absent from the cache key, so a stored body would
 	// bypass the exhausted-sub 402 guard and the depleted-credits warning below.
-	cacheEligible := s.semanticCache != nil && !env.Stream() && decision.Metadata != nil && externalID != "" && !bypassEval && !compactionHandoverRan && !billing.SubscriptionOnlyFromContext(ctx) && len(s.subsidyFactors(ctx, r.Header)) == 0
+	cacheEligible := s.semanticCacheAllowed(ctx) && s.semanticCache != nil && !env.Stream() && decision.Metadata != nil && externalID != "" && !bypassEval && !compactionHandoverRan && !billing.SubscriptionOnlyFromContext(ctx) && len(s.subsidyFactors(ctx, r.Header)) == 0
 	if cacheEligible {
 		if resp, hit := s.semanticCache.Lookup(externalID, cache.FormatAnthropic, decision.Metadata.Embedding, decision.Metadata.ClusterIDs, decision.Metadata.ClusterRouterVersion, decision.Metadata.EffectiveKnobsHash); hit {
 			s.writeCachedResponse(w, resp, decision)
@@ -2662,7 +2675,8 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 	baselineModel := s.baselineFor(feats.Model)
 	baselineCatalog, baselineKnown := catalog.ByID(baselineModel)
 	_, anthropicExcluded := s.excludedProvidersForRequest(ctx)[providers.ProviderAnthropic]
-	baselineEligible := !agentShadowMode &&
+	baselineEligible := !routeRes.AuthoritativePerTurn &&
+		!agentShadowMode &&
 		decision.Reason != translate.ReasonUserForceModel &&
 		s.shouldFailover(ctx) &&
 		!anthropicExcluded &&
@@ -3246,6 +3260,7 @@ func (s *Service) recordTurnUsage(res turnLoopResult, servedProvider, servedMode
 		OutputTokens:        out,
 		EndedAt:             time.Now(),
 		ServedModel:         servedModel,
+		ServedProvider:      servedProvider,
 		PriorServedModel:    res.PriorServedModel,
 		SessionEverSwitched: res.SessionEverSwitched,
 	}
@@ -3304,6 +3319,7 @@ func (s *Service) recordHMMTurnHistory(res turnLoopResult, servedProvider, serve
 		OutputTokens:        out,
 		EndedAt:             now,
 		ServedModel:         servedModel,
+		ServedProvider:      servedProvider,
 		PriorServedModel:    res.PriorServedModel,
 		SessionEverSwitched: res.SessionEverSwitched,
 	}); err != nil {
@@ -3357,35 +3373,54 @@ func (s *Service) reportPolicyOutcome(ctx context.Context, res turnLoopResult, d
 	installationID, _ := ctx.Value(InstallationIDContextKey{}).(string)
 	trainingAllowed, _ := ctx.Value(PolicyTrainingAllowedContextKey{}).(bool)
 	clientIdentity := ClientIdentityFrom(ctx)
+	selectedServedModelMatch := routeDecision.Model == decision.Model
+	authoritativeModelMismatch := routeMetadata.AuthoritativePerTurnSelection &&
+		!selectedServedModelMatch
+	if authoritativeModelMismatch {
+		trainingAllowed = false
+		observability.FromContext(ctx).Error(
+			"Authoritative policy model did not match served model",
+			"route_id", routeMetadata.RouteID,
+			"selected_model", routeDecision.Model,
+			"served_model", decision.Model,
+		)
+	}
 	payload := map[string]interface{}{
-		"route_id":               routeMetadata.RouteID,
-		"strategy":               routeMetadata.Strategy,
-		"organization_id":        organizationID,
-		"installation_id":        installationID,
-		"client_app":             clientIdentity.ClientApp,
-		"rollout_id":             policyRolloutIDFromContext(ctx),
-		"training_allowed":       trainingAllowed,
-		"capture_mode":           s.captureMode.String(),
-		"policy_route_key":       routeMetadata.PolicyRouteKey,
-		"policy_artifact_id":     routeMetadata.PolicyArtifactID,
-		"policy_artifact_sha256": routeMetadata.PolicyArtifactSHA256,
-		"roster_version":         routeMetadata.RosterVersion,
-		"sidecar_schema_version": routeMetadata.SidecarSchemaVersion,
-		"served_model":           decision.Model,
-		"served_provider":        finalProvider,
-		"decision_model":         routeDecision.Model,
-		"decision_provider":      routeDecision.Provider,
-		"status":                 upstreamStatus(proxyErr),
-		"error":                  "",
-		"estimated_input_tokens": estimatedInputTokens,
-		"input_tokens":           inputTokens,
-		"output_tokens":          outputTokens,
-		"cache_creation_tokens":  cacheCreation,
-		"cache_read_tokens":      cacheRead,
-		"route_latency_ms":       routeMs,
-		"upstream_latency_ms":    proxyMs,
-		"turn_type":              string(res.TurnType),
-		"sticky_hit":             res.StickyHit,
+		"route_id":                         routeMetadata.RouteID,
+		"strategy":                         routeMetadata.Strategy,
+		"organization_id":                  organizationID,
+		"installation_id":                  installationID,
+		"client_app":                       clientIdentity.ClientApp,
+		"rollout_id":                       policyRolloutIDFromContext(ctx),
+		"training_allowed":                 trainingAllowed,
+		"capture_mode":                     s.captureMode.String(),
+		"policy_route_key":                 routeMetadata.PolicyRouteKey,
+		"policy_artifact_id":               routeMetadata.PolicyArtifactID,
+		"policy_artifact_sha256":           routeMetadata.PolicyArtifactSHA256,
+		"roster_version":                   routeMetadata.RosterVersion,
+		"sidecar_schema_version":           routeMetadata.SidecarSchemaVersion,
+		"selected_model":                   routeDecision.Model,
+		"selected_provider":                routeDecision.Provider,
+		"served_model":                     decision.Model,
+		"served_provider":                  finalProvider,
+		"decision_model":                   routeDecision.Model,
+		"decision_provider":                routeDecision.Provider,
+		"selected_served_model_match":      selectedServedModelMatch,
+		"authoritative_per_turn_selection": routeMetadata.AuthoritativePerTurnSelection,
+		"status":                           upstreamStatus(proxyErr),
+		"error":                            "",
+		"estimated_input_tokens":           estimatedInputTokens,
+		"input_tokens":                     inputTokens,
+		"output_tokens":                    outputTokens,
+		"cache_creation_tokens":            cacheCreation,
+		"cache_read_tokens":                cacheRead,
+		"route_latency_ms":                 routeMs,
+		"upstream_latency_ms":              proxyMs,
+		"turn_type":                        string(res.TurnType),
+		"sticky_hit":                       res.StickyHit,
+	}
+	if authoritativeModelMismatch {
+		payload["training_exclusion_reason"] = "selected_served_model_mismatch"
 	}
 	if trainingAllowed && response != nil {
 		payload["response_body_truncated"] = response.Truncated
@@ -4222,6 +4257,7 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 		PromptText:           promptText,
 		ConversationMessages: conversationMessagesForRouting(env),
 		AvailableTools:       availableToolsForRouting(env),
+		HistoryTruncated:     compResOAI.Applied,
 		// Keep this tied to client-visible history so a later feedback command
 		// can correlate with the route even if local compaction rewrites env.
 		FeedbackKey:          hex.EncodeToString(sessionKey[:]),
@@ -4251,7 +4287,7 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 
 	// See the ProxyMessages cache-eligibility note: subsidized requests bypass the
 	// semantic cache (the key doesn't capture headroom-dependent model choice).
-	cacheEligible := s.semanticCache != nil && !env.Stream() && decision.Metadata != nil && externalID != "" && !bypassEval && !responsesPassthrough && !billing.SubscriptionOnlyFromContext(ctx) && len(s.subsidyFactors(ctx, r.Header)) == 0
+	cacheEligible := s.semanticCacheAllowed(ctx) && s.semanticCache != nil && !env.Stream() && decision.Metadata != nil && externalID != "" && !bypassEval && !responsesPassthrough && !billing.SubscriptionOnlyFromContext(ctx) && len(s.subsidyFactors(ctx, r.Header)) == 0
 	if cacheEligible {
 		if resp, hit := s.semanticCache.Lookup(externalID, cache.FormatOpenAI, decision.Metadata.Embedding, decision.Metadata.ClusterIDs, decision.Metadata.ClusterRouterVersion, decision.Metadata.EffectiveKnobsHash); hit {
 			s.writeCachedResponse(w, resp, decision)

--- a/internal/proxy/turnloop.go
+++ b/internal/proxy/turnloop.go
@@ -67,6 +67,9 @@ type turnLoopResult struct {
 	TurnType       turntype.TurnType
 	StickyHit      bool
 	HardPinned     bool
+	// AuthoritativePerTurn is true only for eligible main/tool-result turns
+	// whose active policy declared model-authoritative dispatch.
+	AuthoritativePerTurn bool
 	// UsageBypass is true when the caller's own subscription has headroom:
 	// ProxyMessages must serve the requested model straight through with no
 	// billing debit, bypassing Decision's normal dispatch.
@@ -186,6 +189,10 @@ func (s *Service) isHardPinnedTurn(ctx context.Context, tt turntype.TurnType) bo
 	}
 }
 
+func authoritativePolicyTurn(tt turntype.TurnType) bool {
+	return tt == turntype.MainLoop || tt == turntype.ToolResult
+}
+
 func isUserForcedReason(reason string) bool {
 	return strings.HasPrefix(reason, translate.ReasonUserForceModel)
 }
@@ -264,6 +271,8 @@ func (s *Service) runTurnLoop(
 		PinTier:        "miss",
 		RequestedTier:  catalog.TierFor(feats.Model),
 	}
+	res.AuthoritativePerTurn = authoritativePolicyTurn(res.TurnType) &&
+		s.authoritativePerTurnSelection(ctx)
 	res.PinRole = roleForTier(res.RequestedTier)
 	log.Info("turnloop classified",
 		"turn_type", string(res.TurnType),
@@ -368,10 +377,13 @@ func (s *Service) runTurnLoop(
 	// Without a pin store, run the scorer and return its decision. The usage
 	// bypass intercepts the fresh scorer decision here too (no pins to honor).
 	if s.pinStore == nil {
-		if dec, ok := s.usageBypassDecision(ctx, reqHeaders, req); ok {
-			res.Decision = dec
-			res.UsageBypass = true
-			return res, nil
+		req.PolicyTurnContext = buildPolicyTurnContext(req, res, sessionpin.Pin{}, sessionpin.Pin{})
+		if !res.AuthoritativePerTurn {
+			if dec, ok := s.usageBypassDecision(ctx, reqHeaders, req); ok {
+				res.Decision = dec
+				res.UsageBypass = true
+				return res, nil
+			}
 		}
 		decision, err := s.routeFor(ctx, req)
 		if err != nil {
@@ -387,6 +399,7 @@ func (s *Service) runTurnLoop(
 	pin, pinFound := s.loadPin(ctx, res.SessionKey, res.PinRole)
 	hmmHistory := s.loadHMMHistory(ctx, res.SessionKey, res.PinRole)
 	res.PriorServedModel, res.SessionEverSwitched = switchHistoryFromPins(pin, hmmHistory)
+	req.PolicyTurnContext = buildPolicyTurnContext(req, res, pin, hmmHistory)
 	// Computed before any same-turn pin-drop guards below so it reflects the
 	// prior turn's outcome; Service.effortEscalation gates whether it's acted on.
 	res.EscalateEffort = pinFound && !pin.LastTurnEndedAt.IsZero() &&
@@ -592,10 +605,12 @@ func (s *Service) runTurnLoop(
 	// stale pin from a prior routed stretch can't make a tool_result
 	// continuation diverge from the bypassed tool_use turn. The pin itself is
 	// untouched and resumes once utilization crosses the threshold.
-	if dec, ok := s.usageBypassDecision(ctx, reqHeaders, req); ok {
-		res.Decision = dec
-		res.UsageBypass = true
-		return res, nil
+	if !res.AuthoritativePerTurn {
+		if dec, ok := s.usageBypassDecision(ctx, reqHeaders, req); ok {
+			res.Decision = dec
+			res.UsageBypass = true
+			return res, nil
+		}
 	}
 
 	// Tool-result turns: by default, fall through to the scorer + planner for
@@ -603,7 +618,10 @@ func (s *Service) runTurnLoop(
 	// The #82 noisy-embedding concern is stale under only_user_message embed mode:
 	// translate.userPromptTextGJSON strips tool_result blocks from the embed input.
 	// Switches degrade safely — handover.RewriteEnvelope strips orphaned tool_results.
-	if !s.scoreToolResultTurns && res.TurnType == turntype.ToolResult && pinFound {
+	if !res.AuthoritativePerTurn &&
+		!s.scoreToolResultTurns &&
+		res.TurnType == turntype.ToolResult &&
+		pinFound {
 		decision := pinDecision(pin)
 		res.Decision = decision
 		res.StickyHit = true
@@ -613,7 +631,7 @@ func (s *Service) runTurnLoop(
 	}
 
 	// Planner-disabled + pin found: preserve first-decision-wins behavior.
-	if !s.plannerEnabled && pinFound {
+	if !res.AuthoritativePerTurn && !s.plannerEnabled && pinFound {
 		decision := pinDecision(pin)
 		res.Decision = decision
 		res.StickyHit = true
@@ -639,6 +657,8 @@ func (s *Service) runTurnLoop(
 					"fresh_model", dec.Model,
 					"fresh_provider", dec.Provider,
 				)
+			} else if res.AuthoritativePerTurn {
+				return res, derr
 			} else {
 				log.Info("tier-constrained reroute found no candidate; using unconstrained scorer",
 					"forced_tier", forcedTierFloor.String(), "err", derr)
@@ -659,6 +679,12 @@ func (s *Service) runTurnLoop(
 		"fresh_reason", fresh.Reason,
 	)
 	res.Fresh = fresh
+	if res.AuthoritativePerTurn {
+		res.Decision = fresh
+		res.PinTier = "authoritative_per_turn"
+		s.writeNewPin(ctx, installationID, res.SessionKey, res.PinRole, fresh)
+		return res, nil
+	}
 	if isHMMDecision(fresh) {
 		activePin := sessionpin.Pin{}
 		if pinFound {
@@ -1093,6 +1119,53 @@ func switchHistoryFromPins(activePin, hmmHistory sessionpin.Pin) (string, bool) 
 		sessionEverSwitched = true
 	}
 	return priorServedModel, sessionEverSwitched
+}
+
+func buildPolicyTurnContext(
+	req router.Request,
+	res turnLoopResult,
+	activePin sessionpin.Pin,
+	hmmHistory sessionpin.Pin,
+) *router.PolicyTurnContext {
+	previous := activePin
+	if hmmHistory.LastServedModel != "" &&
+		(previous.LastServedModel == "" ||
+			hmmHistory.LastTurnEndedAt.After(previous.LastTurnEndedAt)) {
+		previous = hmmHistory
+	}
+	cacheState := router.PolicyCacheStateUnknown
+	var priorOutputTokens *int
+	if !previous.LastTurnEndedAt.IsZero() {
+		cacheState = router.PolicyCacheStateCold
+		if cacheWarm(previous) && !res.PrefixTrimmed && !req.HistoryTruncated {
+			cacheState = router.PolicyCacheStateWarm
+		}
+		outputTokens := previous.LastOutputTokens
+		priorOutputTokens = &outputTokens
+	}
+	userTurns := 0
+	for _, message := range req.ConversationMessages {
+		if strings.EqualFold(message.Role, "user") {
+			userTurns++
+		}
+	}
+	visibleTurnIndex := max(userTurns-1, 0)
+	sessionTurnCount := max(activePin.TurnCount, hmmHistory.TurnCount)
+	previousProvider := ""
+	if res.PriorServedModel != "" {
+		previousProvider = previous.Provider
+	}
+	return &router.PolicyTurnContext{
+		VisibleTurnIndex:    visibleTurnIndex,
+		SessionTurnCount:    sessionTurnCount,
+		TurnType:            string(res.TurnType),
+		PreviousServedModel: res.PriorServedModel,
+		PreviousProvider:    previousProvider,
+		CacheState:          cacheState,
+		PriorOutputTokens:   priorOutputTokens,
+		SessionEverSwitched: res.SessionEverSwitched,
+		HistoryTruncated:    req.HistoryTruncated || res.PrefixTrimmed,
+	}
 }
 
 // refreshPin extends the TTL on an existing pin. Carries the existing pin's

--- a/internal/proxy/turnloop_internal_test.go
+++ b/internal/proxy/turnloop_internal_test.go
@@ -105,6 +105,7 @@ func TestRecordTurnUsage_WritesToStore(t *testing.T) {
 	assert.Equal(t, 200, store.lastUsage.CachedWriteTokens)
 	assert.Equal(t, 80, store.lastUsage.OutputTokens)
 	assert.Equal(t, "claude-opus-4-7", store.lastUsage.ServedModel)
+	assert.Equal(t, "anthropic", store.lastUsage.ServedProvider)
 	assert.False(t, store.lastUsage.EndedAt.IsZero(), "EndedAt must be stamped — the planner uses IsZero() as its no-prior-usage gate")
 }
 

--- a/internal/router/policy/contract.go
+++ b/internal/router/policy/contract.go
@@ -25,6 +25,9 @@ type Capabilities struct {
 	SupportsDebugRouteDetail bool   `json:"supports_debug_route_detail"`
 	SupportsPreview          bool   `json:"supports_preview"`
 	SupportsShadow           bool   `json:"supports_shadow"`
+	// AuthoritativePerTurnSelection makes eligible main/tool-result decisions
+	// model-authoritative through dispatch.
+	AuthoritativePerTurnSelection bool `json:"authoritative_per_turn_selection"`
 }
 
 // CapabilitySource returns the live capability set of a sidecar router.
@@ -58,6 +61,7 @@ type Query struct {
 	FeedbackKey          string
 	FeedbackRole         string
 	ClientSessionID      string
+	TurnContext          *router.PolicyTurnContext
 	EstimatedInputTokens int
 	HasTools             bool
 	HasImages            bool

--- a/internal/router/policy/resolver.go
+++ b/internal/router/policy/resolver.go
@@ -64,15 +64,20 @@ type Diagnostic struct {
 
 // Candidate is one catalog-backed model offered to a policy sidecar.
 type Candidate struct {
-	RosterID         string                `json:"roster_id"`
-	CatalogID        string                `json:"catalog_id"`
-	Provider         string                `json:"provider"`
-	UpstreamID       string                `json:"upstream_id"`
-	PreferenceRank   *int                  `json:"preference_rank,omitempty"`
-	InputUSDPer1M    float64               `json:"input_usd_per_1m"`
-	OutputUSDPer1M   float64               `json:"output_usd_per_1m"`
-	EstimatedCostUSD float64               `json:"estimated_cost_usd"`
-	Capabilities     CandidateCapabilities `json:"capabilities"`
+	RosterID                  string                `json:"roster_id"`
+	CatalogID                 string                `json:"catalog_id"`
+	Provider                  string                `json:"provider"`
+	UpstreamID                string                `json:"upstream_id"`
+	PreferenceRank            *int                  `json:"preference_rank,omitempty"`
+	InputUSDPer1M             float64               `json:"input_usd_per_1m"`
+	OutputUSDPer1M            float64               `json:"output_usd_per_1m"`
+	EstimatedCostUSD          float64               `json:"estimated_cost_usd"`
+	CacheReadMultiplier       float64               `json:"cache_read_multiplier"`
+	MarginalCostFactor        float64               `json:"marginal_cost_factor"`
+	EffectiveInputUSDPer1M    float64               `json:"effective_input_usd_per_1m"`
+	EffectiveOutputUSDPer1M   float64               `json:"effective_output_usd_per_1m"`
+	EffectiveEstimatedCostUSD float64               `json:"effective_estimated_cost_usd"`
+	Capabilities              CandidateCapabilities `json:"capabilities"`
 }
 
 // CandidateCapabilities describes only dispatch-relevant catalog facts. It is
@@ -203,15 +208,24 @@ func (r *Resolver) Resolve(req router.Request) ResolvedCandidates {
 			continue
 		}
 
+		marginalCostFactor := 1.0
+		if factor, found := req.SubsidizedModelCostFactor[id]; found && factor > 0 {
+			marginalCostFactor = factor
+		}
 		base = append(base, eligibleCandidate{Candidate: Candidate{
-			RosterID:         rosterID,
-			CatalogID:        id,
-			Provider:         binding.Provider,
-			UpstreamID:       upstreamID(id, binding.UpstreamID),
-			PreferenceRank:   preferenceRanks[id],
-			InputUSDPer1M:    binding.Price.InputUSDPer1M,
-			OutputUSDPer1M:   binding.Price.OutputUSDPer1M,
-			EstimatedCostUSD: estimatedCostUSD(req, binding.Price),
+			RosterID:                  rosterID,
+			CatalogID:                 id,
+			Provider:                  binding.Provider,
+			UpstreamID:                upstreamID(id, binding.UpstreamID),
+			PreferenceRank:            preferenceRanks[id],
+			InputUSDPer1M:             binding.Price.InputUSDPer1M,
+			OutputUSDPer1M:            binding.Price.OutputUSDPer1M,
+			EstimatedCostUSD:          estimatedCostUSD(req, binding.Price),
+			CacheReadMultiplier:       binding.Price.EffectiveCacheReadMultiplier(),
+			MarginalCostFactor:        marginalCostFactor,
+			EffectiveInputUSDPer1M:    binding.Price.InputUSDPer1M * marginalCostFactor,
+			EffectiveOutputUSDPer1M:   binding.Price.OutputUSDPer1M * marginalCostFactor,
+			EffectiveEstimatedCostUSD: estimatedCostUSD(req, binding.Price) * marginalCostFactor,
 			Capabilities: CandidateCapabilities{
 				ContextWindow:  contextWindow,
 				Tier:           model.Tier.String(),

--- a/internal/router/policy/resolver_test.go
+++ b/internal/router/policy/resolver_test.go
@@ -157,6 +157,32 @@ func TestResolverIncludesExpectedOutputInContextBudget(t *testing.T) {
 	})
 }
 
+func TestResolverIncludesLiveCandidateEconomics(t *testing.T) {
+	resolver := policy.NewResolver(
+		set("claude-opus-4-8"),
+		set(providers.ProviderAnthropic),
+		catalogRosterID,
+		policy.ManagedProviderPolicy(),
+	)
+	expectedOutputTokens := 500
+
+	resolved := resolver.Resolve(router.Request{
+		EstimatedInputTokens: 1_000,
+		RoutingKnobs:         &router.Overrides{ExpectedOutputTokens: &expectedOutputTokens},
+		SubsidizedModelCostFactor: map[string]float64{
+			"claude-opus-4-8": 0.25,
+		},
+	})
+
+	require.Len(t, resolved.Candidates, 1)
+	candidate := resolved.Candidates[0]
+	assert.Equal(t, 0.1, candidate.CacheReadMultiplier)
+	assert.Equal(t, 0.25, candidate.MarginalCostFactor)
+	assert.Equal(t, 1.25, candidate.EffectiveInputUSDPer1M)
+	assert.Equal(t, 6.25, candidate.EffectiveOutputUSDPer1M)
+	assert.InDelta(t, candidate.EstimatedCostUSD*0.25, candidate.EffectiveEstimatedCostUSD, 1e-12)
+}
+
 func set(values ...string) map[string]struct{} {
 	result := make(map[string]struct{}, len(values))
 	for _, value := range values {

--- a/internal/router/policy/sidecar_router.go
+++ b/internal/router/policy/sidecar_router.go
@@ -123,6 +123,7 @@ func (r *SidecarRouter) PreviewRoute(ctx context.Context, req router.Request) (P
 		FeedbackKey:          req.FeedbackKey,
 		FeedbackRole:         req.FeedbackRole,
 		ClientSessionID:      req.ClientSessionID,
+		TurnContext:          req.PolicyTurnContext,
 		EstimatedInputTokens: req.EstimatedInputTokens,
 		HasTools:             req.HasTools,
 		HasImages:            req.HasImages,
@@ -254,7 +255,8 @@ func validatePreviewResult(result PreviewResult) error {
 func (r *SidecarRouter) Route(ctx context.Context, req router.Request) (router.Decision, error) {
 	strategy := r.config.Strategy
 	r.capabilitiesMu.RLock()
-	shadowUnsupported := r.capabilitiesSet && !r.capabilities.SupportsShadow
+	capabilities := r.capabilities
+	shadowUnsupported := r.capabilitiesSet && !capabilities.SupportsShadow
 	r.capabilitiesMu.RUnlock()
 	if req.ShadowMode && shadowUnsupported {
 		return router.Decision{}, fmt.Errorf("%s: sidecar does not support shadow routing: %w", strategy, r.config.Unavailable)
@@ -286,6 +288,7 @@ func (r *SidecarRouter) Route(ctx context.Context, req router.Request) (router.D
 		FeedbackKey:          req.FeedbackKey,
 		FeedbackRole:         req.FeedbackRole,
 		ClientSessionID:      req.ClientSessionID,
+		TurnContext:          req.PolicyTurnContext,
 		EstimatedInputTokens: req.EstimatedInputTokens,
 		HasTools:             req.HasTools,
 		HasImages:            req.HasImages,
@@ -342,20 +345,21 @@ func (r *SidecarRouter) Route(ctx context.Context, req router.Request) (router.D
 		Model:    binding.CatalogID,
 		Reason:   reason,
 		Metadata: &router.RoutingMetadata{
-			CandidateModels:      resolved.CandidateModels(),
-			CandidateProviders:   resolved.CandidateProviders(),
-			CandidateScores:      resolved.CatalogCandidateScores(res.CandidateScores),
-			ChosenScore:          float32(res.Score),
-			Propensity:           propensity,
-			DisplayMarker:        res.DisplayMarker,
-			RouteID:              routeID,
-			Strategy:             string(strategy),
-			PolicyRouteKey:       res.PolicyRouteKey,
-			PolicyArtifactID:     res.PolicyArtifactID,
-			PolicyArtifactSHA256: res.PolicyArtifactSHA256,
-			RosterVersion:        res.RosterVersion,
-			SidecarSchemaVersion: res.SchemaVersion,
-			DebugRef:             debugRef,
+			CandidateModels:               resolved.CandidateModels(),
+			CandidateProviders:            resolved.CandidateProviders(),
+			CandidateScores:               resolved.CatalogCandidateScores(res.CandidateScores),
+			ChosenScore:                   float32(res.Score),
+			Propensity:                    propensity,
+			DisplayMarker:                 res.DisplayMarker,
+			RouteID:                       routeID,
+			Strategy:                      string(strategy),
+			PolicyRouteKey:                res.PolicyRouteKey,
+			PolicyArtifactID:              res.PolicyArtifactID,
+			PolicyArtifactSHA256:          res.PolicyArtifactSHA256,
+			RosterVersion:                 res.RosterVersion,
+			SidecarSchemaVersion:          res.SchemaVersion,
+			DebugRef:                      debugRef,
+			AuthoritativePerTurnSelection: capabilities.AuthoritativePerTurnSelection,
 		},
 	}, nil
 }

--- a/internal/router/policy/sidecar_router_test.go
+++ b/internal/router/policy/sidecar_router_test.go
@@ -68,7 +68,13 @@ func TestSidecarRouterOnboardsFutureStrategyWithoutProxyChanges(t *testing.T) {
 	adapter := policy.NewSidecarRouter(policy.SidecarRouterConfig{
 		Strategy:    strategy,
 		Unavailable: errors.New("future unavailable"),
-	}, decider, resolver)
+	}, decider, resolver).WithCapabilities(policy.Capabilities{
+		SchemaVersion:                 policy.SchemaVersionV1,
+		AuthoritativePerTurnSelection: true,
+		ReportsOutcomes:               true,
+		ReportsFeedback:               true,
+	})
+	priorOutputTokens := 42
 
 	decision, err := adapter.Route(context.Background(), router.Request{
 		OrganizationID:       "org-1",
@@ -78,6 +84,15 @@ func TestSidecarRouterOnboardsFutureStrategyWithoutProxyChanges(t *testing.T) {
 		TrainingAllowed:      true,
 		CaptureMode:          "hashed",
 		EstimatedInputTokens: 1000,
+		PolicyTurnContext: &router.PolicyTurnContext{
+			VisibleTurnIndex:    3,
+			SessionTurnCount:    4,
+			TurnType:            "main_loop",
+			PreviousServedModel: "gpt-5.4",
+			PreviousProvider:    providers.ProviderOpenAI,
+			CacheState:          router.PolicyCacheStateWarm,
+			PriorOutputTokens:   &priorOutputTokens,
+		},
 	})
 
 	require.NoError(t, err)
@@ -88,6 +103,7 @@ func TestSidecarRouterOnboardsFutureStrategyWithoutProxyChanges(t *testing.T) {
 	assert.Equal(t, "high", decision.Metadata.PolicyRouteKey)
 	assert.Equal(t, "future-prod", decision.Metadata.PolicyArtifactID)
 	assert.Equal(t, map[string]float32{"gpt-5.5": 0.9}, decision.Metadata.CandidateScores)
+	assert.True(t, decision.Metadata.AuthoritativePerTurnSelection)
 	assert.Empty(t, decision.Metadata.DebugRef)
 	assert.Equal(t, strategy, decider.query.Strategy)
 	assert.Equal(t, policy.ExecutionModeServing, decider.query.ExecutionMode)
@@ -95,6 +111,9 @@ func TestSidecarRouterOnboardsFutureStrategyWithoutProxyChanges(t *testing.T) {
 	assert.Equal(t, "cursor", decider.query.ClientApp)
 	assert.True(t, decider.query.TrainingAllowed)
 	assert.Equal(t, "hashed", decider.query.CaptureMode)
+	require.NotNil(t, decider.query.TurnContext)
+	assert.Equal(t, 3, decider.query.TurnContext.VisibleTurnIndex)
+	assert.Equal(t, "gpt-5.4", decider.query.TurnContext.PreviousServedModel)
 	require.Len(t, decider.query.Candidates, 1)
 	assert.Equal(t, "future/gpt-5.5", decider.query.Candidates[0].RosterID)
 	assert.Greater(t, decider.query.Candidates[0].InputUSDPer1M, 0.0)

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -111,6 +111,12 @@ type Request struct {
 	ConversationMessages []ConversationMessage
 	// AvailableTools is a bounded list of tool names declared on this request.
 	AvailableTools []string
+	// PolicyTurnContext carries persisted, content-free state from the turn
+	// orchestrator. Nil keeps older policy clients wire-compatible.
+	PolicyTurnContext *PolicyTurnContext
+	// HistoryTruncated records deterministic ingress rewrites that happened
+	// before the turn orchestrator could build PolicyTurnContext.
+	HistoryTruncated bool
 	// FeedbackKey/FeedbackRole are optional opaque correlation fields for
 	// sidecar routers that accept per-session feedback.
 	FeedbackKey  string
@@ -174,10 +180,34 @@ type ConversationToolCall struct {
 }
 
 type ConversationToolResult struct {
-	ToolUseID string `json:"tool_use_id,omitempty"`
-	IsError   bool   `json:"is_error,omitempty"`
-	Text      string `json:"text,omitempty"`
+	ToolUseID     string `json:"tool_use_id,omitempty"`
+	IsError       bool   `json:"is_error,omitempty"`
+	Text          string `json:"text,omitempty"`
+	ResultPresent bool   `json:"result_present,omitempty"`
+	CharCount     int    `json:"char_count,omitempty"`
+	ByteCount     int    `json:"byte_count,omitempty"`
+	ExitCategory  string `json:"exit_category,omitempty"`
 }
+
+// PolicyTurnContext describes the current per-turn decision state without
+// carrying raw tool-result content.
+type PolicyTurnContext struct {
+	VisibleTurnIndex    int
+	SessionTurnCount    int
+	TurnType            string
+	PreviousServedModel string
+	PreviousProvider    string
+	CacheState          string
+	PriorOutputTokens   *int
+	SessionEverSwitched bool
+	HistoryTruncated    bool
+}
+
+const (
+	PolicyCacheStateUnknown = "unknown"
+	PolicyCacheStateCold    = "cold"
+	PolicyCacheStateWarm    = "warm"
+)
 
 type Decision struct {
 	Provider string
@@ -210,6 +240,9 @@ type RoutingMetadata struct {
 	RosterVersion        string
 	SidecarSchemaVersion string
 	DebugRef             string
+	// AuthoritativePerTurnSelection means downstream orchestration may retry
+	// providers but must not replace this decision's model on this turn.
+	AuthoritativePerTurnSelection bool
 	// DisplayMarker is an optional, already-humanized route badge. Sidecars
 	// use this to show strategy-specific labels without moving their display
 	// logic into router-internal.

--- a/internal/router/sessionpin/store.go
+++ b/internal/router/sessionpin/store.go
@@ -75,6 +75,9 @@ type Usage struct {
 	EndedAt           time.Time
 	// ServedModel is the model that served the turn this usage came from.
 	ServedModel string
+	// ServedProvider is the provider binding that served the turn. UpdateUsage
+	// persists it into Provider so the next policy sees actual cache affinity.
+	ServedProvider string
 	// PriorServedModel is optional prior-turn evidence known by the caller.
 	// UpdateUsage uses it to latch HasEverSwitched when the stored row is new
 	// or has no last_served_model yet.

--- a/internal/sqlc/session_pins.sql.go
+++ b/internal/sqlc/session_pins.sql.go
@@ -146,13 +146,14 @@ SET last_input_tokens        = $1::int,
     last_cached_write_tokens = $3::int,
     last_output_tokens       = $4::int,
     last_turn_ended_at       = $5::timestamptz,
+    pinned_provider          = $6::varchar,
     has_ever_switched        = has_ever_switched
-      OR $6::boolean
-      OR (last_served_model <> '' AND last_served_model <> $7::varchar)
-      OR ($8::varchar <> '' AND $8::varchar <> $7::varchar),
-    last_served_model        = $7::varchar
-WHERE session_key = $9::bytea
-  AND role        = $10::varchar
+      OR $7::boolean
+      OR (last_served_model <> '' AND last_served_model <> $8::varchar)
+      OR ($9::varchar <> '' AND $9::varchar <> $8::varchar),
+    last_served_model        = $8::varchar
+WHERE session_key = $10::bytea
+  AND role        = $11::varchar
 `
 
 type UpdateSessionPinUsageParams struct {
@@ -161,6 +162,7 @@ type UpdateSessionPinUsageParams struct {
 	LastCachedWriteTokens int32
 	LastOutputTokens      int32
 	LastTurnEndedAt       pgtype.Timestamptz
+	LastServedProvider    string
 	SessionEverSwitched   bool
 	LastServedModel       string
 	PriorServedModel      string
@@ -178,6 +180,8 @@ type UpdateSessionPinUsageParams struct {
 // served this turn; it lives here (not in UpsertSessionPin) so a
 // /force-model upsert cannot overwrite the genuinely-last-served model
 // before the next turn reads it to detect a mid-session model switch.
+// pinned_provider is updated to the binding that actually served so per-turn
+// policies receive correct previous-provider cache affinity after fallback.
 // has_ever_switched latches true the first time the just-served model
 // differs from a prior non-empty last_served_model. Caller-supplied model and
 // latch evidence preserves history when the stored role row is new.
@@ -190,13 +194,14 @@ type UpdateSessionPinUsageParams struct {
 //	    last_cached_write_tokens = $3::int,
 //	    last_output_tokens       = $4::int,
 //	    last_turn_ended_at       = $5::timestamptz,
+//	    pinned_provider          = $6::varchar,
 //	    has_ever_switched        = has_ever_switched
-//	      OR $6::boolean
-//	      OR (last_served_model <> '' AND last_served_model <> $7::varchar)
-//	      OR ($8::varchar <> '' AND $8::varchar <> $7::varchar),
-//	    last_served_model        = $7::varchar
-//	WHERE session_key = $9::bytea
-//	  AND role        = $10::varchar
+//	      OR $7::boolean
+//	      OR (last_served_model <> '' AND last_served_model <> $8::varchar)
+//	      OR ($9::varchar <> '' AND $9::varchar <> $8::varchar),
+//	    last_served_model        = $8::varchar
+//	WHERE session_key = $10::bytea
+//	  AND role        = $11::varchar
 func (q *Queries) UpdateSessionPinUsage(ctx context.Context, arg UpdateSessionPinUsageParams) error {
 	_, err := q.db.Exec(ctx, updateSessionPinUsage,
 		arg.LastInputTokens,
@@ -204,6 +209,7 @@ func (q *Queries) UpdateSessionPinUsage(ctx context.Context, arg UpdateSessionPi
 		arg.LastCachedWriteTokens,
 		arg.LastOutputTokens,
 		arg.LastTurnEndedAt,
+		arg.LastServedProvider,
 		arg.SessionEverSwitched,
 		arg.LastServedModel,
 		arg.PriorServedModel,

--- a/sidecars/hmm/hmm_sidecar/api.py
+++ b/sidecars/hmm/hmm_sidecar/api.py
@@ -90,6 +90,7 @@ def capabilities() -> JSONResponse:
             "supports_debug_route_detail": True,
             "supports_preview": True,
             "supports_shadow": True,
+            "authoritative_per_turn_selection": False,
             "learning": {
                 "enabled": False,
                 "state": "frozen_policy",

--- a/sidecars/hmm/hmm_sidecar/schemas.py
+++ b/sidecars/hmm/hmm_sidecar/schemas.py
@@ -72,6 +72,11 @@ class Candidate(FrozenModel):
     input_usd_per_1m: float = 0.0
     output_usd_per_1m: float = 0.0
     estimated_cost_usd: float = 0.0
+    cache_read_multiplier: float = 0.0
+    marginal_cost_factor: float = 1.0
+    effective_input_usd_per_1m: float = 0.0
+    effective_output_usd_per_1m: float = 0.0
+    effective_estimated_cost_usd: float = 0.0
     capabilities: dict[str, Any] = Field(default_factory=dict)
 
 


### PR DESCRIPTION
## Summary
- Add optional persisted turn context and live candidate economics to the generic policy sidecar contract.
- Make capability-gated main/tool-result policy selections authoritative through dispatch, bypassing sticky/planner/model-changing/cache/summarizer overrides while preserving hard constraints and same-model provider retries.
- Report selected-versus-served identity, persist actual served provider context, and keep frozen HMM sidecars wire-compatible.

## Test plan
- [x] `wv mr tc`
- [x] `wv mr t`
- [x] `go vet ./...`
- [x] `docker compose --profile hmm config --quiet`
- [x] `cd sidecars/hmm && poetry run pytest -q`
- [x] Verify pinned HMM artifact and run `HMM_TEST_PACKAGE=... poetry run pytest -q tests/test_policy.py`
- [ ] `docker build --file sidecars/hmm/Dockerfile --tag router-hmm-sidecar:test .` (local Docker daemon stalled pulling the base image; CI exercises this build)