### PR TITLE
Authenticate generic policy sidecars

### DIFF
--- a/cmd/router/main.go
+++ b/cmd/router/main.go
@@ -688,6 +688,7 @@ func main() {
 	configuredPolicySpecs, err := buildConfiguredPolicySidecars(
 		context.Background(),
 		config.GetOr("ROUTER_POLICY_SIDECARS", ""),
+		config.GetOr("ROUTER_POLICY_SIDECAR_AUTH", ""),
 		parseEnvDurationMs("ROUTER_POLICY_SIDECAR_TIMEOUT_MS", policyclient.DefaultTimeout),
 		availableModels,
 		availableProviders,

--- a/cmd/router/policy_sidecar_auth.go
+++ b/cmd/router/policy_sidecar_auth.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"net/http"
 	"strings"
 	"time"
 
@@ -27,14 +28,63 @@ func buildHMMPolicyClientWithGoogleIDTokenFactory(
 	timeout time.Duration,
 	newGoogleIDTokenClient func(string, time.Duration) (*policyclient.Client, error),
 ) (*policyclient.Client, error) {
+	return buildPolicyClientWithGoogleIDTokenFactory(
+		sidecarURL,
+		authMode,
+		timeout,
+		nil,
+		"ROUTER_HMM_SIDECAR_AUTH",
+		newGoogleIDTokenClient,
+	)
+}
+
+func buildConfiguredPolicyClient(
+	sidecarURL, authMode string,
+	timeout time.Duration,
+	httpClient *http.Client,
+) (*policyclient.Client, error) {
+	return buildPolicyClientWithGoogleIDTokenFactory(
+		sidecarURL,
+		authMode,
+		timeout,
+		httpClient,
+		"ROUTER_POLICY_SIDECAR_AUTH",
+		policyclient.NewGoogleIDToken,
+	)
+}
+
+func buildConfiguredPolicyClientWithGoogleIDTokenFactory(
+	sidecarURL, authMode string,
+	timeout time.Duration,
+	httpClient *http.Client,
+	newGoogleIDTokenClient func(string, time.Duration) (*policyclient.Client, error),
+) (*policyclient.Client, error) {
+	return buildPolicyClientWithGoogleIDTokenFactory(
+		sidecarURL,
+		authMode,
+		timeout,
+		httpClient,
+		"ROUTER_POLICY_SIDECAR_AUTH",
+		newGoogleIDTokenClient,
+	)
+}
+
+func buildPolicyClientWithGoogleIDTokenFactory(
+	sidecarURL, authMode string,
+	timeout time.Duration,
+	httpClient *http.Client,
+	authSetting string,
+	newGoogleIDTokenClient func(string, time.Duration) (*policyclient.Client, error),
+) (*policyclient.Client, error) {
 	switch strings.ToLower(strings.TrimSpace(authMode)) {
 	case "", policySidecarAuthNone:
-		return policyclient.New(sidecarURL, nil, timeout), nil
+		return policyclient.New(sidecarURL, httpClient, timeout), nil
 	case policySidecarAuthGoogleIDToken:
 		return newGoogleIDTokenClient(sidecarURL, timeout)
 	default:
 		return nil, fmt.Errorf(
-			"unsupported ROUTER_HMM_SIDECAR_AUTH %q (expected %q or %q)",
+			"unsupported %s %q (expected %q or %q)",
+			authSetting,
 			authMode,
 			policySidecarAuthNone,
 			policySidecarAuthGoogleIDToken,

--- a/cmd/router/policy_sidecar_auth_test.go
+++ b/cmd/router/policy_sidecar_auth_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"errors"
+	"net/http"
 	"testing"
 	"time"
 
@@ -37,4 +38,48 @@ func TestBuildHMMPolicyClientFailsClosedWhenGoogleCredentialsCannotBuild(t *test
 
 	require.ErrorIs(t, err, wantErr)
 	assert.Nil(t, client)
+}
+
+func TestBuildConfiguredPolicyClientPreservesProvidedLocalClient(t *testing.T) {
+	httpClient := &http.Client{}
+	client, err := buildConfiguredPolicyClient(
+		"http://localhost:8094",
+		policySidecarAuthNone,
+		time.Second,
+		httpClient,
+	)
+
+	require.NoError(t, err)
+	assert.NotNil(t, client)
+}
+
+func TestBuildConfiguredPolicyClientUsesGoogleIDTokenAudience(t *testing.T) {
+	var audience string
+	client, err := buildConfiguredPolicyClientWithGoogleIDTokenFactory(
+		"https://sidecar.internal",
+		policySidecarAuthGoogleIDToken,
+		time.Second,
+		nil,
+		func(gotAudience string, _ time.Duration) (*policyclient.Client, error) {
+			audience = gotAudience
+			return policyclient.New(gotAudience, nil, time.Second), nil
+		},
+	)
+
+	require.NoError(t, err)
+	assert.NotNil(t, client)
+	assert.Equal(t, "https://sidecar.internal", audience)
+}
+
+func TestBuildConfiguredPolicyClientRejectsUnknownAuthMode(t *testing.T) {
+	client, err := buildConfiguredPolicyClient(
+		"https://sidecar.internal",
+		"api-key",
+		time.Second,
+		nil,
+	)
+
+	require.Error(t, err)
+	assert.Nil(t, client)
+	assert.Contains(t, err.Error(), "unsupported ROUTER_POLICY_SIDECAR_AUTH")
 }

--- a/cmd/router/policy_sidecars.go
+++ b/cmd/router/policy_sidecars.go
@@ -12,7 +12,6 @@ import (
 	"strings"
 	"time"
 
-	"workweave/router/internal/policyclient"
 	"workweave/router/internal/router"
 	"workweave/router/internal/router/catalog"
 	"workweave/router/internal/router/policy"
@@ -33,13 +32,16 @@ var reservedPolicyStrategies = map[router.Strategy]struct{}{
 // buildConfiguredPolicySidecars turns a JSON strategy-to-URL map into policy.StrategySpec registrations; sidecars own model logic, the router owns candidate resolution and lifecycle.
 func buildConfiguredPolicySidecars(
 	ctx context.Context,
-	raw string,
+	raw, rawAuth string,
 	timeout time.Duration,
 	deployed, availableProviders map[string]struct{},
 	httpClient *http.Client,
 	logger *slog.Logger,
 ) ([]policy.StrategySpec, error) {
 	if strings.TrimSpace(raw) == "" {
+		if strings.TrimSpace(rawAuth) != "" {
+			return nil, fmt.Errorf("ROUTER_POLICY_SIDECAR_AUTH requires ROUTER_POLICY_SIDECARS")
+		}
 		return nil, nil
 	}
 	var configured map[string]string
@@ -56,7 +58,7 @@ func buildConfiguredPolicySidecars(
 	}
 	sort.Strings(strategies)
 	seen := make(map[router.Strategy]struct{}, len(strategies))
-	registrations := make([]policy.StrategySpec, 0, len(strategies))
+	normalized := make(map[string]router.Strategy, len(strategies))
 	for _, configuredName := range strategies {
 		strategy := router.Strategy(strings.ToLower(strings.TrimSpace(configuredName)))
 		if strategy == "" {
@@ -72,14 +74,26 @@ func buildConfiguredPolicySidecars(
 			return nil, fmt.Errorf("ROUTER_POLICY_SIDECARS strategy %q is duplicated after normalization", strategy)
 		}
 		seen[strategy] = struct{}{}
+		normalized[configuredName] = strategy
+	}
+	authModes, err := parseConfiguredPolicySidecarAuth(rawAuth, seen)
+	if err != nil {
+		return nil, err
+	}
 
+	registrations := make([]policy.StrategySpec, 0, len(strategies))
+	for _, configuredName := range strategies {
+		strategy := normalized[configuredName]
 		sidecarURL := strings.TrimSpace(configured[configuredName])
 		parsed, err := url.Parse(sidecarURL)
 		if err != nil || parsed.Host == "" || (parsed.Scheme != "http" && parsed.Scheme != "https") {
 			return nil, fmt.Errorf("ROUTER_POLICY_SIDECARS strategy %q has invalid URL %q", strategy, sidecarURL)
 		}
 
-		client := policyclient.New(sidecarURL, httpClient, timeout)
+		client, err := buildConfiguredPolicyClient(sidecarURL, authModes[strategy], timeout, httpClient)
+		if err != nil {
+			return nil, fmt.Errorf("build %s policy sidecar client: %w", strategy, err)
+		}
 		capabilityCtx, cancel := context.WithTimeout(ctx, timeout)
 		capabilities, capabilityErr := client.Capabilities(capabilityCtx)
 		cancel()
@@ -111,4 +125,29 @@ func buildConfiguredPolicySidecars(
 		})
 	}
 	return registrations, nil
+}
+
+func parseConfiguredPolicySidecarAuth(
+	raw string,
+	configured map[router.Strategy]struct{},
+) (map[router.Strategy]string, error) {
+	if strings.TrimSpace(raw) == "" {
+		return nil, nil
+	}
+	var values map[string]string
+	if err := json.Unmarshal([]byte(raw), &values); err != nil {
+		return nil, fmt.Errorf("parse ROUTER_POLICY_SIDECAR_AUTH: %w", err)
+	}
+	authModes := make(map[router.Strategy]string, len(values))
+	for configuredName, authMode := range values {
+		strategy := router.Strategy(strings.ToLower(strings.TrimSpace(configuredName)))
+		if _, ok := configured[strategy]; !ok {
+			return nil, fmt.Errorf("ROUTER_POLICY_SIDECAR_AUTH strategy %q is not configured", strategy)
+		}
+		if _, duplicate := authModes[strategy]; duplicate {
+			return nil, fmt.Errorf("ROUTER_POLICY_SIDECAR_AUTH strategy %q is duplicated after normalization", strategy)
+		}
+		authModes[strategy] = authMode
+	}
+	return authModes, nil
 }

--- a/cmd/router/policy_sidecars_test.go
+++ b/cmd/router/policy_sidecars_test.go
@@ -51,6 +51,7 @@ func TestBuildConfiguredPolicySidecarsOnboardsFutureStrategy(t *testing.T) {
 	registrations, err := buildConfiguredPolicySidecars(
 		context.Background(),
 		`{"future-policy":"`+server.URL+`"}`,
+		"",
 		time.Second,
 		map[string]struct{}{"gpt-5.5": {}},
 		map[string]struct{}{providers.ProviderOpenAI: {}},
@@ -78,8 +79,44 @@ func TestBuildConfiguredPolicySidecarsRejectsReservedAndInvalidConfiguration(t *
 		`{"Future":"https://one.internal","future":"https://two.internal"}`,
 	} {
 		_, err := buildConfiguredPolicySidecars(
-			context.Background(), raw, time.Second, nil, nil, nil, logger,
+			context.Background(), raw, "", time.Second, nil, nil, nil, logger,
 		)
 		require.Error(t, err, raw)
 	}
+}
+
+func TestParseConfiguredPolicySidecarAuthNormalizesStrategies(t *testing.T) {
+	authModes, err := parseConfiguredPolicySidecarAuth(
+		`{" Future-Policy ":"google-id-token"}`,
+		map[router.Strategy]struct{}{"future-policy": {}},
+	)
+
+	require.NoError(t, err)
+	assert.Equal(t, policySidecarAuthGoogleIDToken, authModes["future-policy"])
+}
+
+func TestParseConfiguredPolicySidecarAuthRejectsUnknownStrategy(t *testing.T) {
+	_, err := parseConfiguredPolicySidecarAuth(
+		`{"unknown":"google-id-token"}`,
+		map[router.Strategy]struct{}{"future-policy": {}},
+	)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "is not configured")
+}
+
+func TestBuildConfiguredPolicySidecarsRejectsAuthWithoutSidecars(t *testing.T) {
+	_, err := buildConfiguredPolicySidecars(
+		context.Background(),
+		"",
+		`{"future-policy":"google-id-token"}`,
+		time.Second,
+		nil,
+		nil,
+		nil,
+		slog.New(slog.NewTextHandler(io.Discard, nil)),
+	)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "requires ROUTER_POLICY_SIDECARS")
 }

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -92,6 +92,7 @@ privacy context, and telemetry.
 | Variable                           | Default | Purpose |
 | ---------------------------------- | ------- | ------- |
 | `ROUTER_POLICY_SIDECARS`           | *(none)* | JSON object mapping a new strategy ID to its sidecar origin, for example `{"quality-v2":"https://quality-v2.internal"}`. IDs must match `[a-z][a-z0-9_-]{0,63}`. At most 16 may be configured. `cluster`, `rl`, `hmm`, and `bandit` are reserved. |
+| `ROUTER_POLICY_SIDECAR_AUTH`       | *(none)* | JSON object mapping configured generic strategy IDs to `none` or `google-id-token`, for example `{"quality-v2":"google-id-token"}`. Google ID-token mode uses the exact sidecar origin as token audience and fails router startup when application default credentials cannot build the client. |
 | `ROUTER_POLICY_SIDECAR_TIMEOUT_MS` | `3000`  | Total timeout for each generic policy decision, including transient retries. Also bounds startup capability discovery. |
 | `ROUTER_HMM_SIDECAR_URL`           | *(none)* | Legacy built-in HMM registration. Prefer the generic map for new strategies. |
 | `ROUTER_HMM_SIDECAR_TIMEOUT_MS`    | `3000`  | Total HMM decision timeout. |

--- a/docs/POLICY_ROUTER_HARNESS.md
+++ b/docs/POLICY_ROUTER_HARNESS.md
@@ -201,13 +201,16 @@ Example registration:
 
 ```bash
 export ROUTER_POLICY_SIDECARS='{"quality-v2":"https://quality-v2.internal"}'
+export ROUTER_POLICY_SIDECAR_AUTH='{"quality-v2":"google-id-token"}'
 export ROUTER_POLICY_SIDECAR_TIMEOUT_MS=3000
 ```
 
 The strategy ID must match `[a-z][a-z0-9_-]{0,63}` and cannot be `cluster`,
 `rl`, `hmm`, or `bandit`. New policies use catalog IDs as roster IDs at the
 wire boundary; an artifact with different internal labels translates them
-inside the sidecar.
+inside the sidecar. `google-id-token` authentication uses the exact configured
+origin as the token audience and fails router startup when credentials cannot
+build an authenticated client.
 
 ## Release gates
 


### PR DESCRIPTION
## Summary
- add per-strategy authentication config for generic policy sidecars
- support Cloud Run Google ID tokens using exact sidecar origin as audience
- fail startup on unknown auth mappings or unavailable credentials

## Test plan
- [x] `go test ./cmd/router`
- [x] `wv mr tc`
- [x] `wv mr t`