### PR TITLE
fix(translate): restore silent-strip for $schema/additionalProperties/propertyNames on Gemini emit

### DIFF
--- a/internal/translate/emit_gemini.go
+++ b/internal/translate/emit_gemini.go
@@ -1327,6 +1327,21 @@ func sanitizeGeminiSchemaNode(v any, path string) (any, error) {
 		if key == "const" {
 			continue
 		}
+		// $schema (a meta-annotation), additionalProperties, and
+		// propertyNames have no Gemini function-calling equivalent — Gemini
+		// always behaves as if additionalProperties were disallowed and has
+		// no way to constrain key names — so they carry no representable
+		// semantic content either way. Drop them rather than reject the
+		// whole tool: real client schemas emit all three routinely (e.g.
+		// Claude Code's Agent/Task tool), and toolcheck validates emitted
+		// tool calls against the ORIGINAL inbound schema, not this
+		// sanitized one, so dropping them here is lossless. Regressed by
+		// #764, which switched this sanitizer from a strip-list to an
+		// allowlist without carrying these three over (originally fixed in
+		// #62 against a prod 400 on every Gemini 3.x tool-bearing request).
+		if key == "$schema" || key == "additionalProperties" || key == "propertyNames" {
+			continue
+		}
 		if _, supported := geminiSchemaAllowedKeys[key]; !supported {
 			return nil, fmt.Errorf("%w at %s.%s: unsupported constraint", ErrGeminiSchemaIncompatible, path, key)
 		}

--- a/internal/translate/fidelity_test.go
+++ b/internal/translate/fidelity_test.go
@@ -59,9 +59,18 @@ func TestPrepareGemini_SchemaFidelity(t *testing.T) {
 			wantErr: translate.ErrGeminiSchemaIncompatible,
 		},
 		{
-			name:    "unsupported constraint rejects instead of dropping",
-			schema:  `{"type":"object","additionalProperties":false}`,
-			wantErr: translate.ErrGeminiSchemaIncompatible,
+			// additionalProperties has no Gemini equivalent (Gemini always
+			// behaves as if it were disallowed) and toolcheck validates
+			// emitted tool calls against the original inbound schema, not
+			// this sanitized one — so it's dropped, not rejected. See
+			// TestPrepareGemini_StripsJSONSchemaFieldsGoogleRejects for the
+			// prod-observed case (Claude Code's Agent/Task tool schema).
+			name:   "additionalProperties is dropped, not rejected",
+			schema: `{"type":"object","additionalProperties":false}`,
+			check: func(t *testing.T, schema map[string]any) {
+				assert.NotContains(t, schema, "additionalProperties")
+				assert.Equal(t, "object", schema["type"])
+			},
 		},
 	}
 

--- a/internal/translate/gemini_test.go
+++ b/internal/translate/gemini_test.go
@@ -579,8 +579,16 @@ func must(t *testing.T, m map[string]any, k string) any {
 }
 
 func TestPrepareGemini_StripsJSONSchemaFieldsGoogleRejects(t *testing.T) {
-	// Regression: Claude Code tool defs include JSON Schema fields (`$schema`,
-	// `additionalProperties`, `propertyNames`) Google rejects with 400.
+	// Regression (#62, re-regressed by #764's switch to an allowlist and
+	// fixed again here): Claude Code tool defs — including the Agent/Task
+	// subagent tool itself — include JSON Schema fields (`$schema`,
+	// `additionalProperties`, `propertyNames`) Google's function-calling API
+	// rejects outright. These must be silently dropped, not turned into a
+	// hard tool-declaration failure: #764 briefly did the latter, which
+	// 502'd every real Claude Code turn against any Gemini 3.x model that
+	// included the Agent tool (caught 2026-07-21 onboarding gemini-3.6-flash
+	// / gemini-3.5-flash-lite, but affected already-deployed Gemini models
+	// too).
 	body := []byte(`{
 		"messages": [{"role":"user","content":"hi"}],
 		"tools": [{
@@ -604,8 +612,28 @@ func TestPrepareGemini_StripsJSONSchemaFieldsGoogleRejects(t *testing.T) {
 	}`)
 	env, err := translate.ParseAnthropic(body)
 	require.NoError(t, err)
-	_, err = env.PrepareGemini(http.Header{}, translate.EmitOptions{})
-	require.ErrorIs(t, err, translate.ErrGeminiSchemaIncompatible)
+	prep, err := env.PrepareGemini(http.Header{}, translate.EmitOptions{})
+	require.NoError(t, err)
+
+	out := mustUnmarshal(t, prep.Body)
+	tools := out["tools"].([]any)
+	require.Len(t, tools, 1)
+	decls := tools[0].(map[string]any)["functionDeclarations"].([]any)
+	require.Len(t, decls, 1)
+	params := decls[0].(map[string]any)["parameters"].(map[string]any)
+
+	// The rejected keys are gone at every level...
+	assert.NotContains(t, params, "$schema")
+	assert.NotContains(t, params, "additionalProperties")
+	nested := params["properties"].(map[string]any)["params"].(map[string]any)
+	assert.NotContains(t, nested, "additionalProperties")
+	assert.NotContains(t, nested, "propertyNames")
+
+	// ...but the schema's actual meaning survives.
+	assert.Equal(t, "object", params["type"])
+	assert.Equal(t, []any{"url"}, params["required"])
+	props := params["properties"].(map[string]any)
+	assert.Equal(t, "string", props["url"].(map[string]any)["type"])
 }
 
 func TestPrepareGemini_PrunesDanglingRequired(t *testing.T) {
@@ -926,7 +954,9 @@ func TestPrepareGemini_PreservesEnumValueTypes(t *testing.T) {
 
 func TestPrepareGemini_UserDefinedPropertyNamedProperties(t *testing.T) {
 	// A user-defined property named "properties" must not be mistaken for the
-	// JSON Schema "properties" keyword. Its value schema must still be filtered.
+	// JSON Schema "properties" keyword. Its value schema must still be
+	// filtered — and additionalProperties within it silently dropped, not
+	// treated as a rejection (see TestPrepareGemini_StripsJSONSchemaFieldsGoogleRejects).
 	body := []byte(`{
 		"messages": [{"role":"user","content":"hi"}],
 		"tools": [{
@@ -946,12 +976,25 @@ func TestPrepareGemini_UserDefinedPropertyNamedProperties(t *testing.T) {
 	}`)
 	env, err := translate.ParseAnthropic(body)
 	require.NoError(t, err)
-	_, err = env.PrepareGemini(http.Header{}, translate.EmitOptions{})
-	require.ErrorIs(t, err, translate.ErrGeminiSchemaIncompatible)
+	prep, err := env.PrepareGemini(http.Header{}, translate.EmitOptions{})
+	require.NoError(t, err)
+
+	out := mustUnmarshal(t, prep.Body)
+	decls := out["tools"].([]any)[0].(map[string]any)["functionDeclarations"].([]any)
+	params := decls[0].(map[string]any)["parameters"].(map[string]any)
+	properties := params["properties"].(map[string]any)
+
+	nested, ok := properties["properties"].(map[string]any)
+	require.True(t, ok, `the user-defined "properties" key must survive as an object schema`)
+	assert.Equal(t, "object", nested["type"])
+	assert.Equal(t, "Additional properties", nested["description"])
+	assert.NotContains(t, nested, "additionalProperties")
 }
 
 func TestPrepareGemini_GeminiFormatSanitizesTools(t *testing.T) {
-	// The same-format (FormatGemini) path must also sanitize tool schemas.
+	// The same-format (FormatGemini) path must also sanitize tool schemas —
+	// additionalProperties dropped silently, not rejected (see
+	// TestPrepareGemini_StripsJSONSchemaFieldsGoogleRejects).
 	body := []byte(`{
 		"model": "gemini-3.1-pro-preview",
 		"stream": false,
@@ -969,8 +1012,14 @@ func TestPrepareGemini_GeminiFormatSanitizesTools(t *testing.T) {
 	}`)
 	env, err := translate.ParseGemini(body)
 	require.NoError(t, err)
-	_, err = env.PrepareGemini(http.Header{}, translate.EmitOptions{})
-	require.ErrorIs(t, err, translate.ErrGeminiSchemaIncompatible)
+	prep, err := env.PrepareGemini(http.Header{}, translate.EmitOptions{})
+	require.NoError(t, err)
+
+	out := mustUnmarshal(t, prep.Body)
+	decls := out["tools"].([]any)[0].(map[string]any)["functionDeclarations"].([]any)
+	params := decls[0].(map[string]any)["parameters"].(map[string]any)
+	assert.NotContains(t, params, "additionalProperties")
+	assert.Equal(t, "object", params["type"])
 }
 
 func TestPrepareGemini_GeminiFormatInlinesSchemaRefs(t *testing.T) {


### PR DESCRIPTION
## Summary

Fixes a live regression: **every real Claude Code turn against any Gemini 3.x model that reaches the Agent/Task subagent tool 502s with zero turns**, because the tool's own schema carries `$schema` and `additionalProperties`, and the router now hard-rejects both instead of stripping them.

## Root cause

#764 rewrote `sanitizeSchemaForGemini` from a strip-list (drop unsupported keys, keep going) to an allowlist (reject on any unrecognized key). In doing so it dropped `$schema`, `additionalProperties`, and `propertyNames` from the set of keys that get silently stripped — these were the *original* three keys #62 fixed against a prod 400 ("Cannot find field") on every Gemini 3.x tool-bearing request. None of the three are representable in Gemini's function-calling schema, but none carry semantic content Gemini could act on either way — Gemini already behaves as if `additionalProperties` were always false, and has no notion of `propertyNames`/`$schema` at all. `toolcheck` validates emitted tool calls against the **original** inbound schema, never this sanitized one, so dropping them here is lossless.

## How it was found

Caught while onboarding `gemini-3.6-flash` / `gemini-3.5-flash-lite` (this repo, catalog PR #807): the harness-faithful SWE-bench Pro smoke 502'd on the very first real Claude Code request. Router logs:

```
Failed to translate Anthropic request to Gemini format
function "Agent" input_schema: gemini schema is not representable at $.additionalProperties: unsupported constraint
```

Reproduced directly against `gemini-3.1-pro-preview` — already deployed, already in the HMM `high` roster cluster — confirming this isn't specific to the two new models; it silently breaks every real agentic Gemini 3.x session today, the moment the turn includes the Agent tool. No historical occurrence of this error exists in staging logs before 2026-07-21, suggesting this schema shape was never actually exercised against Gemini in the harness-faithful eval path since #764 shipped 2026-07-16/17.

## Fix

Add `$schema`, `additionalProperties`, and `propertyNames` back to the silently-dropped set in `sanitizeGeminiSchemaNode`, right where `$defs`/`definitions`/`$ref`/`const` are already dropped.

## Tests

Three existing tests had been updated by #764 to assert the regressed (reject) behavior as the intended one:
- `TestPrepareGemini_StripsJSONSchemaFieldsGoogleRejects` — rewritten to assert the fields are dropped and schema meaning survives (restoring the original #62 test's intent), using the exact Claude Code Agent-tool schema shape that 502'd in prod
- `TestPrepareGemini_UserDefinedPropertyNamedProperties`
- `TestPrepareGemini_GeminiFormatSanitizesTools`
- `TestPrepareGemini_SchemaFidelity/unsupported_constraint_rejects_instead_of_dropping` → renamed to `additionalProperties_is_dropped,_not_rejected`

All now assert the corrected strip behavior. Full repo test suite (`go test ./...`, 46 packages) passes; `go build ./...` and `go vet ./...` clean.

## Out of scope

#764 also dropped the `x-*`/`$*`-prefix vendor-extension strip from #104 (MCP tools carrying `x-google-*` schema extensions would also hard-reject today). No known live traffic hits this path, so it's not fixed here — flagging since it's the same regression class and worth a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)