### PR TITLE
fix(translate): drop Gemini-unsupported "format" values instead of rejecting

### DIFF
--- a/internal/translate/emit_gemini.go
+++ b/internal/translate/emit_gemini.go
@@ -1383,7 +1383,10 @@ func sanitizeGeminiSchemaNode(v any, path string) (any, error) {
 				return nil, fmt.Errorf("%w at %s.format: expected string", ErrGeminiSchemaIncompatible, path)
 			}
 			if _, supported := geminiSupportedFormats[format]; !supported {
-				return nil, fmt.Errorf("%w at %s.format: %q is unsupported", ErrGeminiSchemaIncompatible, path, format)
+				// Drop unsupported format values (#387; #764 regressed to a hard
+				// reject). toolcheck validates against the ORIGINAL schema, so
+				// the format hint is still enforced where it matters.
+				continue
 			}
 			out[key] = format
 		default:

--- a/internal/translate/gemini_test.go
+++ b/internal/translate/gemini_test.go
@@ -850,8 +850,27 @@ func TestPrepareGemini_DropsUnsupportedFormatValues(t *testing.T) {
 	}`)
 	env, err := translate.ParseAnthropic(body)
 	require.NoError(t, err)
-	_, err = env.PrepareGemini(http.Header{}, translate.EmitOptions{})
-	require.ErrorIs(t, err, translate.ErrGeminiSchemaIncompatible)
+	prep, err := env.PrepareGemini(http.Header{}, translate.EmitOptions{})
+	require.NoError(t, err)
+
+	out := mustUnmarshal(t, prep.Body)
+	decls := out["tools"].([]any)[0].(map[string]any)["functionDeclarations"].([]any)
+	props := decls[0].(map[string]any)["parameters"].(map[string]any)["properties"].(map[string]any)
+
+	homepage := props["homepage"].(map[string]any)
+	assert.Equal(t, "string", homepage["type"])
+	assert.Equal(t, "site", homepage["description"])
+	assert.NotContains(t, homepage, "format", "unsupported format value 'uri' must be dropped silently")
+
+	contact := props["contact"].(map[string]any)
+	assert.Equal(t, "string", contact["type"])
+	assert.NotContains(t, contact, "format", "unsupported format value 'email' must be dropped silently")
+
+	// Supported formats survive untouched.
+	when := props["when"].(map[string]any)
+	assert.Equal(t, "date-time", when["format"])
+	score := props["score"].(map[string]any)
+	assert.Equal(t, "double", score["format"])
 }
 
 func TestPrepareGemini_CollapsesItemsBool(t *testing.T) {


### PR DESCRIPTION
## Summary

Same regression class as #808 and #809. PR #387 (2026-06-12) added the drop semantics with explicit prose: *"drop formats outside this set rather than forwarding the key with its value intact"*. PR #764 (2026-07-16) converted `sanitizeSchemaFiltered` to an allowlist and switched the `format` branch from `continue` to `ErrGeminiSchemaIncompatible`.

Gemini's function-calling surface accepts only a narrow `format` set (string: `enum`/`date-time`; number: `float`/`double`/`int32`/`int64`), but Claude Code's MCP-tools ecosystem routinely uses additional values — most commonly `uri` (Claude Code's built-in WebFetch.url), but also `email`/`uuid`/`hostname`/etc. Forwarding any of those causes Google to 400 the request, so MCP round-trips against Gemini 3.x have been silently broken on every request that includes WebFetch (or any tool with a non-Anthropic-format property).

## How it was found

Validating #809: the SWE-bench Pro smokes for gemini-3.6-flash and gemini-3.5-flash-lite now 502'd on the WebFetch tool's url parameter after the `$schema`/`additionalProperties` and `exclusiveMinimum` gaps got fixed. Wire-curling against the same harness request directly via `/v1/messages` worked (no `WebFetch` tool in the test request), confirming it was a tool-set shape problem.

## Fix

Restores the #387 behavior: drop the unsupported `format` key (the value gets lost), keep the rest of the property schema intact. Test `TestPrepareGemini_DropsUnsupportedFormatValues` updated to assert the corrected drop + survival behavior instead of the regressed reject. `toolcheck` re-validates emitted tool calls against the original inbound schema so the `format` hint is still enforced where it matters.

Same comment about `go build`/`go vet`/`go test ./...` (46 packages) passing, though won't repeat the full output here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)