### PR TITLE
feat(proxy): resolve /rf feedback to a specific turn via sequence number

### DIFF
--- a/db/migrations/0041_router-feedback-turn-id-metadata.down.sql
+++ b/db/migrations/0041_router-feedback-turn-id-metadata.down.sql
@@ -1,0 +1,3 @@
+BEGIN;
+ALTER TABLE router.router_feedback DROP COLUMN request_id, DROP COLUMN route_id;
+COMMIT;

--- a/db/migrations/0041_router-feedback-turn-id-metadata.up.sql
+++ b/db/migrations/0041_router-feedback-turn-id-metadata.up.sql
@@ -1,0 +1,12 @@
+BEGIN;
+
+ALTER TABLE router.router_feedback
+    ADD COLUMN request_id VARCHAR,
+    ADD COLUMN route_id VARCHAR;
+
+COMMENT ON COLUMN router.router_feedback.request_id IS
+    'Telemetry request_id for the specific turn this feedback targets. NULL when no sequence was specified.';
+COMMENT ON COLUMN router.router_feedback.route_id IS
+    'Sidecar correlation id from the telemetry row (HMM/RL). NULL when no sequence was specified.';
+
+COMMIT;

--- a/db/queries/model_router_request_telemetry.sql
+++ b/db/queries/model_router_request_telemetry.sql
@@ -463,3 +463,46 @@ WHERE t.installation_id = @installation_id::uuid
   AND t.timestamp < @to_time::timestamptz
 ORDER BY t.timestamp DESC
 LIMIT @row_limit::int;
+
+-- Returns the Nth main_loop telemetry row for a (session_key, role) within
+-- an installation, ordered ascending by timestamp. seq is 1-based.
+-- request_id is the secondary sort key so the same query for the same input
+-- resolves to the same row across replicas (timestamp ties would otherwise
+-- make sequence assignment nondeterministic).
+-- name: GetTelemetryBySessionAsc :one
+SELECT
+    request_id,
+    decision_model,
+    decision_provider,
+    route_id,
+    strategy,
+    timestamp
+FROM router.model_router_request_telemetry
+WHERE installation_id = @installation_id::uuid
+  AND session_key = @session_key::bytea
+  AND role = @role::varchar
+  AND turn_type = 'main_loop'
+  AND span_type = 'router.upstream'
+ORDER BY timestamp ASC, request_id ASC
+LIMIT 1 OFFSET @turn_offset::int;
+
+-- Returns the Nth-from-latest main_loop telemetry row for a (session_key, role)
+-- within an installation, ordered descending by timestamp. abs_seq is 1-based
+-- (1 = latest, 2 = one-before-latest, etc.). request_id is the secondary sort
+-- key so timestamp ties resolve deterministically.
+-- name: GetTelemetryBySessionDesc :one
+SELECT
+    request_id,
+    decision_model,
+    decision_provider,
+    route_id,
+    strategy,
+    timestamp
+FROM router.model_router_request_telemetry
+WHERE installation_id = @installation_id::uuid
+  AND session_key = @session_key::bytea
+  AND role = @role::varchar
+  AND turn_type = 'main_loop'
+  AND span_type = 'router.upstream'
+ORDER BY timestamp DESC, request_id DESC
+LIMIT 1 OFFSET @turn_offset::int;

--- a/db/queries/router_feedback.sql
+++ b/db/queries/router_feedback.sql
@@ -2,6 +2,8 @@
 -- context.Background() (the synthetic ack response may already have been
 -- flushed and the request ctx canceled). served_model is the session pin's
 -- LastServedModel at submission time; empty when the session had no pin.
+-- request_id and route_id are populated when a turn sequence was specified
+-- so the policy sidecar can join the rating to the specific routing decision.
 -- name: InsertRouterFeedback :exec
 INSERT INTO router.router_feedback (
     installation_id,
@@ -15,7 +17,9 @@ INSERT INTO router.router_feedback (
     feedback,
     rating,
     suggested_label,
-    source
+    source,
+    request_id,
+    route_id
 ) VALUES (
     @installation_id::uuid,
     @session_key::bytea,
@@ -28,5 +32,7 @@ INSERT INTO router.router_feedback (
     @feedback::text,
     sqlc.narg('rating')::varchar,
     sqlc.narg('suggested_label')::varchar,
-    @source::varchar
+    @source::varchar,
+    sqlc.narg('request_id')::varchar,
+    sqlc.narg('route_id')::varchar
 );

--- a/internal/postgres/telemetry.go
+++ b/internal/postgres/telemetry.go
@@ -196,6 +196,8 @@ func (r *TelemetryRepo) InsertRouterFeedback(ctx context.Context, p proxy.Router
 		SuggestedLabel: stringPtrOrNil(p.SuggestedLabel),
 		Feedback:       p.Feedback,
 		Source:         p.Source,
+		RequestID:      stringPtrOrNil(p.RequestID),
+		RouteID:        stringPtrOrNil(p.RouteID),
 	})
 }
 
@@ -749,4 +751,48 @@ func modelBucketFromHourlyAllRow(row sqlc.GetTelemetryModelBreakdownHourlyAllRow
 		TotalTokens:   row.TotalTokens,
 		ActualCostUSD: microsToUSD(row.ActualCostUsd),
 	}
+}
+
+// GetTelemetryBySessionSequence returns the N-th main_loop telemetry row for
+// (installation_id, session_key, role). seq > 0 = absolute 1-based ASC,
+// seq < 0 = relative 1-based DESC. Returns pgx.ErrNoRows when fewer than
+// |seq| rows exist.
+func (r *TelemetryRepo) GetTelemetryBySessionSequence(ctx context.Context, installationID uuid.UUID, sessionKey []byte, role string, seq int) (proxy.TelemetryTurnResult, error) {
+	q := sqlc.New(r.tx)
+	if seq > 0 {
+		row, err := q.GetTelemetryBySessionAsc(ctx, sqlc.GetTelemetryBySessionAscParams{
+			InstallationID: installationID,
+			SessionKey:     sessionKey,
+			Role:           role,
+			TurnOffset:     int32(seq - 1),
+		})
+		if err != nil {
+			return proxy.TelemetryTurnResult{}, err
+		}
+		return proxy.TelemetryTurnResult{
+			RequestID:        row.RequestID,
+			DecisionModel:    derefString(row.DecisionModel),
+			DecisionProvider: derefString(row.DecisionProvider),
+			RouteID:          derefString(row.RouteID),
+			Strategy:         derefString(row.Strategy),
+			Timestamp:        row.Timestamp.Time,
+		}, nil
+	}
+	row, err := q.GetTelemetryBySessionDesc(ctx, sqlc.GetTelemetryBySessionDescParams{
+		InstallationID: installationID,
+		SessionKey:     sessionKey,
+		Role:           role,
+		TurnOffset:     int32(-seq - 1),
+	})
+	if err != nil {
+		return proxy.TelemetryTurnResult{}, err
+	}
+	return proxy.TelemetryTurnResult{
+		RequestID:        row.RequestID,
+		DecisionModel:    derefString(row.DecisionModel),
+		DecisionProvider: derefString(row.DecisionProvider),
+		RouteID:          derefString(row.RouteID),
+		Strategy:         derefString(row.Strategy),
+		Timestamp:        row.Timestamp.Time,
+	}, nil
 }

--- a/internal/proxy/fire_telemetry_panic_internal_test.go
+++ b/internal/proxy/fire_telemetry_panic_internal_test.go
@@ -10,6 +10,7 @@ import (
 
 	"workweave/router/internal/observability"
 
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -51,6 +52,10 @@ func (panicTelemetryRepo) GetTelemetryModelBreakdown(ctx context.Context, instal
 
 func (panicTelemetryRepo) GetTelemetryModelBreakdownAll(ctx context.Context, from, to time.Time, granularity string) ([]TelemetryModelBucket, error) {
 	return nil, nil
+}
+
+func (panicTelemetryRepo) GetTelemetryBySessionSequence(ctx context.Context, installationID uuid.UUID, sessionKey []byte, role string, seq int) (TelemetryTurnResult, error) {
+	return TelemetryTurnResult{}, nil
 }
 
 // TestFireTelemetryRecoversFromPanic proves a panic inside the async

--- a/internal/proxy/router_feedback.go
+++ b/internal/proxy/router_feedback.go
@@ -94,9 +94,7 @@ func (s *Service) handleRouterFeedbackCommand(
 	}
 
 	// The model the user is most likely commenting on: what the session pin
-	// last served, falling back to the pin's target model. When a sequence was
-	// explicitly named, telemetry resolves to a specific turn — its
-	// decision_model wins over the pin's last served.
+	// last served, falling back to the pin's target model; a sequence token overrides both.
 	var servedModel string
 	var telemetryRequestID string
 	var telemetryRouteID string

--- a/internal/proxy/router_feedback.go
+++ b/internal/proxy/router_feedback.go
@@ -93,8 +93,7 @@ func (s *Service) handleRouterFeedbackCommand(
 		return writeSyntheticCommandResponse(w, env, msg, inputTokens)
 	}
 
-	// The model the user is most likely commenting on: what the session pin
-	// last served, falling back to the pin's target model; a sequence token overrides both.
+	// The model to attribute: pin's last served (or target), overridden by the resolved telemetry turn when a sequence was specified.
 	var servedModel string
 	var telemetryRequestID string
 	var telemetryRouteID string
@@ -180,10 +179,8 @@ func (s *Service) handleRouterFeedbackCommand(
 		}
 	}
 
-	// Use the resolved turn's strategy, not the current request: StrategyFromContext would route credit to the wrong reporter
-	// when the rated turn was served by a different strategy (e.g. HMM) than the active one. A resolved strategy with no
-	// feedback reporter (e.g. cluster) suppresses policy feedback entirely — falling back to the active reporter would
-	// credit that reporter with another strategy's request_id/route_id.
+	// Use the resolved turn's strategy, not the current request: StrategyFromContext credits the wrong reporter
+	// when the rated turn ran under a different strategy. A resolved strategy with no reporter (e.g. cluster) suppresses feedback — falling back would credit the active reporter with another strategy's request_id/route_id.
 	strategy := router.StrategyFromContext(ctx)
 	if telemetryStrategy != "" {
 		strategy = router.Strategy(telemetryStrategy)

--- a/internal/proxy/router_feedback.go
+++ b/internal/proxy/router_feedback.go
@@ -54,13 +54,9 @@ type RouterFeedbackEvent struct {
 	// Source is how the feedback was submitted: "user" (explicit /rf command)
 	// or "auto" (automated judge at session stop).
 	Source string
-	// RequestID is the telemetry request_id of the specific turn this feedback
-	// targets. Populated only when the user specified a sequence number;
-	// empty for default (pin-based last-turn) feedback.
+	// RequestID is the telemetry request_id of the rated turn; empty when no sequence was specified.
 	RequestID string
-	// RouteID is the opaque sidecar correlation id (HMM/RL) joining a decision
-	// to its outcome report, so the sidecar can credit the rating to the
-	// specific routing decision. Empty when no sequence was specified.
+	// RouteID is the opaque sidecar join key (HMM/RL) for credit assignment; empty when no sequence was specified.
 	RouteID string
 }
 
@@ -203,14 +199,8 @@ func (s *Service) handleRouterFeedbackCommand(
 	}
 	if registered, ok := s.strategies[strategy]; ok && registered.feedback != nil {
 		trainingAllowed, _ := ctx.Value(PolicyTrainingAllowedContextKey{}).(bool)
-		// The training delta is sliced from the latest assistant segment of env.
-		// For a sequence-targeted rating, that slice matches the rated turn only
-		// when the rated turn IS the latest user→assistant pair in the envelope:
-		// `cmd.Sequence == 0` (rate the latest), `cmd.Sequence == -1` (rate the
-		// previous turn — which is the most recent one the model actually produced
-		// in env). Anything older (`/rf -2`, `/rf 2` against a multi-turn session)
-		// slices the wrong conversation; suppress the delta and emit request_id
-		// + route_id directly so the sidecar still has the per-decision join key.
+		// Delta only matches the rated turn for sequence 0 (latest) or -1 (the last assistant segment in env).
+		// For anything older, suppress the delta; request_id + route_id give the sidecar the join key.
 		trainingDelta := []router.ConversationMessage(nil)
 		if (cmd.Sequence == 0 || cmd.Sequence == -1) && router.IsHMMStrategy(strategy) && trainingAllowed {
 			trainingDelta = routerFeedbackTrainingDelta(env)

--- a/internal/proxy/router_feedback.go
+++ b/internal/proxy/router_feedback.go
@@ -183,12 +183,12 @@ func (s *Service) handleRouterFeedbackCommand(
 	}
 
 	// Use the resolved turn's strategy, not the current request: StrategyFromContext would route credit to the wrong reporter
-	// when the rated turn was served by a different strategy (e.g. HMM) than the active one.
+	// when the rated turn was served by a different strategy (e.g. HMM) than the active one. A resolved strategy with no
+	// feedback reporter (e.g. cluster) suppresses policy feedback entirely — falling back to the active reporter would
+	// credit that reporter with another strategy's request_id/route_id.
 	strategy := router.StrategyFromContext(ctx)
 	if telemetryStrategy != "" {
-		if rs, ok := s.strategies[router.Strategy(telemetryStrategy)]; ok && rs.feedback != nil {
-			strategy = router.Strategy(telemetryStrategy)
-		}
+		strategy = router.Strategy(telemetryStrategy)
 	}
 	if registered, ok := s.strategies[strategy]; ok && registered.feedback != nil {
 		trainingAllowed, _ := ctx.Value(PolicyTrainingAllowedContextKey{}).(bool)

--- a/internal/proxy/router_feedback.go
+++ b/internal/proxy/router_feedback.go
@@ -165,11 +165,7 @@ func (s *Service) handleRouterFeedbackCommand(
 			return err
 		}
 	}
-	// When the sequence resolved to a specific request, also converge onto the
-	// per-request feedback table so both channels share one truth. The
-	// up/down-only rating column rejects empty ratings (note-only), so skip
-	// the upsert in that case to avoid overwriting a prior thumb on the same
-	// request_id with an invalid row.
+	// Skip upsert for note-only ratings: up/down-only column rejects empty rating and would overwrite a prior thumb.
 	if telemetryRequestID != "" && rating != "" && s.feedbackRepo != nil {
 		comment := feedback
 		upsertParams := UpsertFeedbackParams{
@@ -186,11 +182,8 @@ func (s *Service) handleRouterFeedbackCommand(
 		}
 	}
 
-	// Reporter must be selected by the rated turn's strategy, not the current
-	// request. When a sequence points at an earlier HMM/RL decision but the
-	// current request sits on cluster, StrategyFromContext routes the rating
-	// to the wrong reporter (or skips it entirely). The resolved strategy is
-	// empty only when the row fell back to the pin path.
+	// Use the resolved turn's strategy, not the current request: StrategyFromContext would route credit to the wrong reporter
+	// when the rated turn was served by a different strategy (e.g. HMM) than the active one.
 	strategy := router.StrategyFromContext(ctx)
 	if telemetryStrategy != "" {
 		if rs, ok := s.strategies[router.Strategy(telemetryStrategy)]; ok && rs.feedback != nil {

--- a/internal/proxy/router_feedback.go
+++ b/internal/proxy/router_feedback.go
@@ -2,7 +2,9 @@ package proxy
 
 import (
 	"context"
+	"database/sql"
 	"encoding/hex"
+	"errors"
 	"net/http"
 	"strings"
 	"time"
@@ -52,6 +54,14 @@ type RouterFeedbackEvent struct {
 	// Source is how the feedback was submitted: "user" (explicit /rf command)
 	// or "auto" (automated judge at session stop).
 	Source string
+	// RequestID is the telemetry request_id of the specific turn this feedback
+	// targets. Populated only when the user specified a sequence number;
+	// empty for default (pin-based last-turn) feedback.
+	RequestID string
+	// RouteID is the opaque sidecar correlation id (HMM/RL) joining a decision
+	// to its outcome report, so the sidecar can credit the rating to the
+	// specific routing decision. Empty when no sequence was specified.
+	RouteID string
 }
 
 // RouterFeedbackSource values for validated event persistence.
@@ -88,9 +98,39 @@ func (s *Service) handleRouterFeedbackCommand(
 	}
 
 	// The model the user is most likely commenting on: what the session pin
-	// last served, falling back to the pin's target model.
+	// last served, falling back to the pin's target model. When a sequence was
+	// explicitly named, telemetry resolves to a specific turn — its
+	// decision_model wins over the pin's last served.
 	var servedModel string
-	if s.pinStore != nil {
+	var telemetryRequestID string
+	var telemetryRouteID string
+	var telemetryStrategy string
+	if cmd.Sequence != 0 && s.telemetry != nil {
+		turn, err := s.telemetry.GetTelemetryBySessionSequence(ctx, installationID, sessionKey[:], role, cmd.Sequence)
+		if err != nil {
+			log.Error("/router-feedback: sequence lookup failed", "sequence", cmd.Sequence, "err", err)
+			if errors.Is(err, sql.ErrNoRows) {
+				msg := "✦ **Weave Router** → No turn found at that sequence number. Try `/rf` without a number for the last turn.\n\n"
+				if env.SourceFormat() == translate.FormatOpenAI {
+					msg = "Weave Router: No turn found at that sequence number. Try `/rf` without a number for the last turn."
+				}
+				return writeSyntheticCommandResponse(w, env, msg, inputTokens)
+			}
+			// Infrastructure error: log it, fall through to the pin path so the
+			// rating is persisted with the pin's servedModel rather than dropped.
+		} else {
+			servedModel = turn.DecisionModel
+			telemetryRequestID = turn.RequestID
+			telemetryRouteID = turn.RouteID
+			telemetryStrategy = turn.Strategy
+			log.Info("/router-feedback: resolved sequence to telemetry turn",
+				"sequence", cmd.Sequence,
+				"request_id", telemetryRequestID,
+				"served_model", servedModel,
+			)
+		}
+	}
+	if servedModel == "" && s.pinStore != nil {
 		if pin, found, err := s.pinStore.Get(ctx, sessionKey, role); err != nil {
 			log.Error("/router-feedback: pin lookup failed", "err", err)
 		} else if found {
@@ -119,6 +159,8 @@ func (s *Service) handleRouterFeedbackCommand(
 			SuggestedLabel: cmd.SuggestedLabel,
 			Feedback:       persistedFeedbackText(rating, feedback),
 			Source:         RouterFeedbackSourceUser,
+			RequestID:      telemetryRequestID,
+			RouteID:        telemetryRouteID,
 		}
 		// context.Background(): ctx may already be canceled (client disconnected
 		// mid-command); don't drop feedback the user explicitly typed.
@@ -127,35 +169,81 @@ func (s *Service) handleRouterFeedbackCommand(
 			return err
 		}
 	}
+	// When the sequence resolved to a specific request, also converge onto the
+	// per-request feedback table so both channels share one truth. The
+	// up/down-only rating column rejects empty ratings (note-only), so skip
+	// the upsert in that case to avoid overwriting a prior thumb on the same
+	// request_id with an invalid row.
+	if telemetryRequestID != "" && rating != "" && s.feedbackRepo != nil {
+		comment := feedback
+		upsertParams := UpsertFeedbackParams{
+			InstallationID: installationID.String(),
+			ExternalID:     externalID,
+			RequestID:      telemetryRequestID,
+			Rating:         rating,
+			Comment:        &comment,
+			Source:         "router-feedback-command",
+			RouterUserID:   routerUserID,
+		}
+		if err := s.feedbackRepo.Upsert(context.Background(), upsertParams); err != nil {
+			log.Error("/router-feedback: request_feedback upsert failed", "request_id", telemetryRequestID, "err", err)
+		}
+	}
+
+	// Reporter must be selected by the rated turn's strategy, not the current
+	// request. When a sequence points at an earlier HMM/RL decision but the
+	// current request sits on cluster, StrategyFromContext routes the rating
+	// to the wrong reporter (or skips it entirely). The resolved strategy is
+	// empty only when the row fell back to the pin path.
 	strategy := router.StrategyFromContext(ctx)
+	if telemetryStrategy != "" {
+		if rs, ok := s.strategies[router.Strategy(telemetryStrategy)]; ok && rs.feedback != nil {
+			strategy = router.Strategy(telemetryStrategy)
+		}
+	}
 	if registered, ok := s.strategies[strategy]; ok && registered.feedback != nil {
 		trainingAllowed, _ := ctx.Value(PolicyTrainingAllowedContextKey{}).(bool)
-		var trainingDelta []router.ConversationMessage
-		if router.IsHMMStrategy(strategy) && trainingAllowed {
+		// The training delta is sliced from the latest assistant segment of env.
+		// For a sequence-targeted rating, that slice matches the rated turn only
+		// when the rated turn IS the latest user→assistant pair in the envelope:
+		// `cmd.Sequence == 0` (rate the latest), `cmd.Sequence == -1` (rate the
+		// previous turn — which is the most recent one the model actually produced
+		// in env). Anything older (`/rf -2`, `/rf 2` against a multi-turn session)
+		// slices the wrong conversation; suppress the delta and emit request_id
+		// + route_id directly so the sidecar still has the per-decision join key.
+		trainingDelta := []router.ConversationMessage(nil)
+		if (cmd.Sequence == 0 || cmd.Sequence == -1) && router.IsHMMStrategy(strategy) && trainingAllowed {
 			trainingDelta = routerFeedbackTrainingDelta(env)
 		}
-		s.reportRouterFeedback(ctx, registered.feedback, strategy, externalID, installationID, sessionKey, role, routerUserID, clientID, env.Model(), servedModel, rating, feedback, cmd.SuggestedLabel, RouterFeedbackSourceUser, trainingDelta)
+		s.reportRouterFeedback(ctx, registered.feedback, strategy, externalID, installationID, sessionKey, role, routerUserID, clientID, env.Model(), servedModel, rating, feedback, cmd.SuggestedLabel, RouterFeedbackSourceUser, trainingDelta, telemetryRequestID, telemetryRouteID)
 	}
 
 	now := time.Now()
+	attrs := otel.NewAttrBuilder(15).
+		String("external_id", externalID).
+		String("router_user_id", routerUserID).
+		String("client.device_id", clientID.DeviceID).
+		String("client.session_id", clientID.SessionID).
+		String("client.user_agent", clientID.UserAgent).
+		String("client.app", clientID.ClientApp).
+		String("requested.model", env.Model()).
+		String("feedback.served_model", servedModel).
+		String("feedback.role", role).
+		String("feedback.rating", rating).
+		Int64("feedback.sequence", int64(cmd.Sequence)).
+		String("feedback.text", feedback).
+		String("feedback.source", RouterFeedbackSourceUser)
+	if telemetryRequestID != "" {
+		attrs = attrs.String("feedback.request_id", telemetryRequestID)
+	}
+	if telemetryRouteID != "" {
+		attrs = attrs.String("feedback.route_id", telemetryRouteID)
+	}
 	otel.Record(ctx, otel.Span{
 		Name:  routerFeedbackCommandSpanName,
 		Start: now,
 		End:   now,
-		Attrs: otel.NewAttrBuilder(12).
-			String("external_id", externalID).
-			String("router_user_id", routerUserID).
-			String("client.device_id", clientID.DeviceID).
-			String("client.session_id", clientID.SessionID).
-			String("client.user_agent", clientID.UserAgent).
-			String("client.app", clientID.ClientApp).
-			String("requested.model", env.Model()).
-			String("feedback.served_model", servedModel).
-			String("feedback.role", role).
-			String("feedback.rating", rating).
-			String("feedback.text", feedback).
-			String("feedback.source", RouterFeedbackSourceUser).
-			Build(),
+		Attrs: attrs.Build(),
 	})
 	otel.Flush(ctx)
 
@@ -165,6 +253,9 @@ func (s *Service) handleRouterFeedbackCommand(
 		"served_model", servedModel,
 		"requested_model", env.Model(),
 		"role", role,
+		"sequence", cmd.Sequence,
+		"request_id", telemetryRequestID,
+		"route_id", telemetryRouteID,
 	)
 
 	return writeSyntheticCommandResponse(w, env, routerFeedbackAck(env.SourceFormat(), rating), inputTokens)
@@ -187,6 +278,8 @@ func (s *Service) reportRouterFeedback(
 	suggestedLabel string,
 	source string,
 	trainingDelta []router.ConversationMessage,
+	requestID string,
+	routeID string,
 ) {
 	payload := map[string]interface{}{
 		"strategy":          string(strategy),
@@ -200,6 +293,8 @@ func (s *Service) reportRouterFeedback(
 		"client_app":        clientID.ClientApp,
 		"client_session_id": clientID.SessionID,
 		"source":            source,
+		"request_id":        requestID,
+		"route_id":          routeID,
 	}
 	if suggestedLabel != "" {
 		payload["suggested_label"] = suggestedLabel

--- a/internal/proxy/router_feedback_proxy_test.go
+++ b/internal/proxy/router_feedback_proxy_test.go
@@ -664,9 +664,7 @@ func TestService_RouterFeedbackCommand_SequenceWithRatingUpsertsRequestFeedback(
 }
 
 func TestService_RouterFeedbackCommand_SequenceResolvesStrategyRoutesToItsReporter(t *testing.T) {
-	// Current request context is on the cluster strategy (no policy reporter).
-	// The user's `/rf -2` resolves to telemetry whose strategy is RL, which
-	// has a registered feedback reporter. Policy feedback must land on RL.
+	// cluster strategy has no policy reporter; RL does — resolved turn must route to RL, not fall through to context.
 	const body = `{
 		"model":"claude-sonnet-4-6",
 		"max_tokens":1024,
@@ -785,9 +783,7 @@ func TestService_RouterFeedbackCommand_NegativeOnePreservesTrainingDelta(t *test
 }
 
 func TestService_RouterFeedbackCommand_ClusterResolvedTurnSkipsPolicyFeedback(t *testing.T) {
-	// The rated turn was served by the cluster scorer (no feedback reporter).
-	// The active session strategy is HMM — reporting there would credit HMM
-	// with a cluster decision's request_id, so policy feedback must be skipped.
+	// The rated turn was served by cluster (no feedback reporter); crediting the active HMM reporter would pair its request_id with the wrong strategy.
 	const body = `{
 		"model":"claude-sonnet-4-6",
 		"max_tokens":1024,

--- a/internal/proxy/router_feedback_proxy_test.go
+++ b/internal/proxy/router_feedback_proxy_test.go
@@ -2,8 +2,10 @@ package proxy_test
 
 import (
 	"context"
+	"database/sql"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -459,4 +461,325 @@ func TestService_RouterFeedbackCommand_ThumbsDownShortcutWithNote(t *testing.T) 
 	require.Len(t, feedback.events, 1)
 	assert.Equal(t, "down", feedback.events[0].Rating)
 	assert.Equal(t, "wrong model for this refactor", feedback.events[0].Feedback, "the note is stored verbatim alongside the verdict")
+}
+
+type recordingFeedbackRepo struct {
+	mu      sync.Mutex
+	upserts []proxy.UpsertFeedbackParams
+}
+
+func (f *recordingFeedbackRepo) Upsert(_ context.Context, p proxy.UpsertFeedbackParams) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.upserts = append(f.upserts, p)
+	return nil
+}
+
+func (f *recordingFeedbackRepo) GetContext(_ context.Context, _, _ string) (proxy.FeedbackContext, error) {
+	return proxy.FeedbackContext{}, nil
+}
+
+func TestService_RouterFeedbackCommand_SequenceResolvesTelemetryTurn(t *testing.T) {
+	const body = `{
+		"model":"claude-sonnet-4-6",
+		"max_tokens":1024,
+		"messages":[
+			{"role":"user","content":"/rf -2 - wrong tier for this"}
+		]
+	}`
+	store := newFakePinStore()
+	store.hasPin = true
+	store.pin = sessionpin.Pin{Provider: providers.ProviderAnthropic, Model: "claude-haiku-4-5", LastServedModel: "claude-haiku-4-5"}
+	feedback := &fakeFeedbackStore{}
+	telem := newCaptureTelemetry()
+	telem.seqResult = proxy.TelemetryTurnResult{RequestID: "req-abc", DecisionModel: "claude-opus-4-7", RouteID: "hmm:xyz"}
+	fr := &fakeRouter{decision: router.Decision{Provider: providers.ProviderAnthropic, Model: "claude-sonnet-4-6", Reason: "cluster"}}
+	svc := newPinSvcWithTelemetry(fr, store, telem).WithRouterFeedbackStore(feedback)
+
+	ctx := authedCtx(uuid.New().String())
+	rec := httptest.NewRecorder()
+	httpReq := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(""))
+	require.NoError(t, svc.ProxyMessages(ctx, []byte(body), rec, httpReq))
+
+	require.Equal(t, []int{-2}, telem.seqCalls, "the parsed relative sequence must be resolved against telemetry")
+	require.Len(t, feedback.events, 1)
+	ev := feedback.events[0]
+	assert.Equal(t, "claude-opus-4-7", ev.ServedModel, "served_model comes from the resolved telemetry row, not the pin")
+	assert.Equal(t, "req-abc", ev.RequestID)
+	assert.Equal(t, "hmm:xyz", ev.RouteID)
+	assert.Equal(t, "down", ev.Rating)
+	assert.Equal(t, "wrong tier for this", ev.Feedback)
+}
+
+func TestService_RouterFeedbackCommand_SequenceNotFoundAcksGuidance(t *testing.T) {
+	const body = `{
+		"model":"claude-sonnet-4-6",
+		"max_tokens":1024,
+		"messages":[
+			{"role":"user","content":"/rf -9 too slow"}
+		]
+	}`
+	store := newFakePinStore()
+	feedback := &fakeFeedbackStore{}
+	telem := newCaptureTelemetry()
+	telem.seqErr = sql.ErrNoRows
+	fr := &fakeRouter{decision: router.Decision{Provider: providers.ProviderAnthropic, Model: "claude-sonnet-4-6", Reason: "cluster"}}
+	svc := newPinSvcWithTelemetry(fr, store, telem).WithRouterFeedbackStore(feedback)
+
+	ctx := authedCtx(uuid.New().String())
+	rec := httptest.NewRecorder()
+	httpReq := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(""))
+	require.NoError(t, svc.ProxyMessages(ctx, []byte(body), rec, httpReq))
+
+	assert.Equal(t, 0, fr.routeCalls, "an unresolvable sequence must short-circuit routing")
+	assert.Empty(t, feedback.events, "no feedback row is written when the sequence cannot be resolved")
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	blocks, _ := resp["content"].([]any)
+	require.NotEmpty(t, blocks)
+	first, _ := blocks[0].(map[string]any)
+	text, _ := first["text"].(string)
+	assert.Contains(t, text, "No turn found at that sequence number")
+}
+
+func TestService_RouterFeedbackCommand_DBErrorFallsBackToPin(t *testing.T) {
+	const body = `{
+		"model":"claude-sonnet-4-6",
+		"max_tokens":1024,
+		"messages":[
+			{"role":"user","content":"/rf -2 + wrong tier"}
+		]
+	}`
+	store := newFakePinStore()
+	store.hasPin = true
+	store.pin = sessionpin.Pin{Provider: providers.ProviderAnthropic, Model: "claude-haiku-4-5", LastServedModel: "claude-haiku-4-5"}
+	feedback := &fakeFeedbackStore{}
+	telem := newCaptureTelemetry()
+	telem.seqErr = errors.New("connection refused")
+	fr := &fakeRouter{decision: router.Decision{Provider: providers.ProviderAnthropic, Model: "claude-sonnet-4-6", Reason: "cluster"}}
+	svc := newPinSvcWithTelemetry(fr, store, telem).WithRouterFeedbackStore(feedback)
+
+	ctx := authedCtx(uuid.New().String())
+	rec := httptest.NewRecorder()
+	httpReq := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(""))
+	require.NoError(t, svc.ProxyMessages(ctx, []byte(body), rec, httpReq))
+
+	require.Len(t, feedback.events, 1, "feedback must persist on transient DB errors, falling back to pin servedModel")
+	ev := feedback.events[0]
+	assert.Equal(t, "claude-haiku-4-5", ev.ServedModel, "falls back to the pin on transient DB failure")
+	assert.Empty(t, ev.RequestID, "no telemetry row, so requestID is empty")
+	assert.Equal(t, "up", ev.Rating)
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	blocks, _ := resp["content"].([]any)
+	require.NotEmpty(t, blocks)
+	first, _ := blocks[0].(map[string]any)
+	text, _ := first["text"].(string)
+	assert.Contains(t, text, "Feedback recorded", "ack shows normally even on transient telemetry error")
+}
+
+func TestService_RouterFeedbackCommand_NoSequenceKeepsPinServedModel(t *testing.T) {
+	const body = `{
+		"model":"claude-sonnet-4-6",
+		"max_tokens":1024,
+		"messages":[
+			{"role":"user","content":"/rf- too slow"}
+		]
+	}`
+	store := newFakePinStore()
+	store.hasPin = true
+	store.pin = sessionpin.Pin{Provider: providers.ProviderAnthropic, Model: "claude-haiku-4-5", LastServedModel: "claude-haiku-4-5"}
+	feedback := &fakeFeedbackStore{}
+	telem := newCaptureTelemetry()
+	fr := &fakeRouter{decision: router.Decision{Provider: providers.ProviderAnthropic, Model: "claude-sonnet-4-6", Reason: "cluster"}}
+	svc := newPinSvcWithTelemetry(fr, store, telem).WithRouterFeedbackStore(feedback)
+
+	ctx := authedCtx(uuid.New().String())
+	rec := httptest.NewRecorder()
+	httpReq := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(""))
+	require.NoError(t, svc.ProxyMessages(ctx, []byte(body), rec, httpReq))
+
+	assert.Empty(t, telem.seqCalls, "no sequence means no telemetry lookup")
+	require.Len(t, feedback.events, 1)
+	ev := feedback.events[0]
+	assert.Equal(t, "claude-haiku-4-5", ev.ServedModel, "falls back to the pin's last served model")
+	assert.Empty(t, ev.RequestID)
+	assert.Empty(t, ev.RouteID)
+}
+
+func TestService_RouterFeedbackCommand_SequenceNoteOnlySkipsRequestFeedbackUpsert(t *testing.T) {
+	const body = `{
+		"model":"claude-sonnet-4-6",
+		"max_tokens":1024,
+		"messages":[
+			{"role":"user","content":"/rf -2 the diff was incomplete"}
+		]
+	}`
+	store := newFakePinStore()
+	feedback := &fakeFeedbackStore{}
+	telem := newCaptureTelemetry()
+	telem.seqResult = proxy.TelemetryTurnResult{RequestID: "req-note-only", DecisionModel: "claude-opus-4-7"}
+	repo := &recordingFeedbackRepo{}
+	fr := &fakeRouter{decision: router.Decision{Provider: providers.ProviderAnthropic, Model: "claude-sonnet-4-6", Reason: "cluster"}}
+	svc := newPinSvcWithTelemetry(fr, store, telem).WithRouterFeedbackStore(feedback).WithFeedback(repo, nil, "")
+
+	ctx := authedCtx(uuid.New().String())
+	rec := httptest.NewRecorder()
+	httpReq := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(""))
+	require.NoError(t, svc.ProxyMessages(ctx, []byte(body), rec, httpReq))
+
+	require.Len(t, feedback.events, 1)
+	assert.Empty(t, feedback.events[0].Rating, "note-only submission carries no verdict")
+	assert.Empty(t, repo.upserts, "a note-only rating must not upsert into the up/down-only request_feedback table")
+}
+
+func TestService_RouterFeedbackCommand_SequenceWithRatingUpsertsRequestFeedback(t *testing.T) {
+	const body = `{
+		"model":"claude-sonnet-4-6",
+		"max_tokens":1024,
+		"messages":[
+			{"role":"user","content":"/rf -2 - too slow"}
+		]
+	}`
+	store := newFakePinStore()
+	feedback := &fakeFeedbackStore{}
+	telem := newCaptureTelemetry()
+	telem.seqResult = proxy.TelemetryTurnResult{RequestID: "req-rated", DecisionModel: "claude-opus-4-7"}
+	repo := &recordingFeedbackRepo{}
+	fr := &fakeRouter{decision: router.Decision{Provider: providers.ProviderAnthropic, Model: "claude-sonnet-4-6", Reason: "cluster"}}
+	svc := newPinSvcWithTelemetry(fr, store, telem).WithRouterFeedbackStore(feedback).WithFeedback(repo, nil, "")
+
+	ctx := authedCtx(uuid.New().String())
+	rec := httptest.NewRecorder()
+	httpReq := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(""))
+	require.NoError(t, svc.ProxyMessages(ctx, []byte(body), rec, httpReq))
+
+	require.Len(t, repo.upserts, 1, "a rated, sequence-resolved submission converges onto request_feedback")
+	up := repo.upserts[0]
+	assert.Equal(t, "req-rated", up.RequestID)
+	assert.Equal(t, "down", up.Rating)
+	assert.Equal(t, "router-feedback-command", up.Source)
+}
+
+func TestService_RouterFeedbackCommand_SequenceResolvesStrategyRoutesToItsReporter(t *testing.T) {
+	// Current request context is on the cluster strategy (no policy reporter).
+	// The user's `/rf -2` resolves to telemetry whose strategy is RL, which
+	// has a registered feedback reporter. Policy feedback must land on RL.
+	const body = `{
+		"model":"claude-sonnet-4-6",
+		"max_tokens":1024,
+		"messages":[
+			{"role":"user","content":"/rf -2 + wrong tier"}
+		]
+	}`
+	store := newFakePinStore()
+	feedback := &fakeFeedbackStore{}
+	telem := newCaptureTelemetry()
+	telem.seqResult = proxy.TelemetryTurnResult{
+		RequestID:     "req-resolved-on-RL",
+		DecisionModel: "claude-opus-4-7",
+		Strategy:      "rl",
+	}
+	hmmReporter := &fakePolicyFeedbackRouter{}
+	rlReporter := &fakePolicyFeedbackRouter{}
+	fr := &fakeRouter{decision: router.Decision{Provider: providers.ProviderAnthropic, Model: "claude-sonnet-4-6", Reason: "cluster"}}
+	ctx := authedCtx(uuid.New().String())
+	svc := newPinSvcWithTelemetry(fr, store, telem).
+		WithRouterFeedbackStore(feedback).
+		WithPolicyStrategy(policy.StrategySpec{Strategy: router.StrategyRL, Router: rlReporter}).
+		WithHMMRouter(hmmReporter)
+	require.NoError(t, svc.ProxyMessages(ctx, []byte(body), httptest.NewRecorder(), httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(""))))
+
+	require.Eventually(t, func() bool { return len(rlReporter.Payloads()) == 1 }, time.Second, 10*time.Millisecond)
+	require.Empty(t, hmmReporter.Payloads(), "current request is on cluster; HMM reporter must not be selected just because the current context might happen to be HMM somewhere else")
+	payload := rlReporter.Payloads()[0]
+	assert.Equal(t, "rl", payload["strategy"], "the resolved turn's strategy must drive both the payload and the reporter")
+	assert.Equal(t, "req-resolved-on-RL", payload["request_id"])
+	assert.Equal(t, "claude-opus-4-7", payload["served_model"])
+	assert.NotContains(t, payload, "training_conversation_delta", "training delta is suppressed for sequence-rated feedback (latest-turn slice is wrong for older turns)")
+}
+
+func TestService_RouterFeedbackCommand_SequenceRejectsHMMDeltaWithResolvedStrategy(t *testing.T) {
+	// When an HMM-rated historical turn is being rated, the sidecar should
+	// receive the rating + resolved-turn identifiers but no mis-paired delta.
+	const body = `{
+		"model":"claude-sonnet-4-6",
+		"max_tokens":1024,
+		"messages":[
+			{"role":"user","content":"/rf -2 - too slow"}
+		]
+	}`
+	store := newFakePinStore()
+	feedback := &fakeFeedbackStore{}
+	telem := newCaptureTelemetry()
+	telem.seqResult = proxy.TelemetryTurnResult{
+		RequestID:     "req-resolved-hmm",
+		DecisionModel: "claude-opus-4-7",
+		Strategy:      "hmm_embedding",
+	}
+	hmmReporter := &fakePolicyFeedbackRouter{}
+	fr := &fakeRouter{decision: router.Decision{Provider: providers.ProviderAnthropic, Model: "claude-sonnet-4-6", Reason: "cluster"}}
+	ctx := router.WithStrategy(authedCtx(uuid.New().String()), router.StrategyHMMEmbedding)
+	svc := newPinSvcWithTelemetry(fr, store, telem).
+		WithRouterFeedbackStore(feedback).
+		WithPolicyStrategy(policy.StrategySpec{
+			Strategy:    router.StrategyHMMEmbedding,
+			Router:      hmmReporter,
+			Unavailable: router.ErrStrategyUnavailable,
+		}).
+		WithAvailableModels(map[string]struct{}{"claude-opus-4-7": {}}).
+		WithCompaction(nil, proxy.DefaultCompactionTriggerPct)
+	ctx = context.WithValue(ctx, proxy.PolicyTrainingAllowedContextKey{}, true)
+	require.NoError(t, svc.ProxyMessages(ctx, []byte(body), httptest.NewRecorder(), httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(""))))
+
+	require.Eventually(t, func() bool { return len(hmmReporter.Payloads()) == 1 }, time.Second, 10*time.Millisecond)
+	payload := hmmReporter.Payloads()[0]
+	assert.Equal(t, "hmm_embedding", payload["strategy"])
+	assert.Equal(t, "req-resolved-hmm", payload["request_id"])
+	assert.NotContains(t, payload, "training_conversation_delta", "training delta would pair the resolved turn with the wrong conversation")
+}
+
+func TestService_RouterFeedbackCommand_NegativeOnePreservesTrainingDelta(t *testing.T) {
+	// `/rf -1` is "rate the previous turn" — the latest assistant message
+	// in env IS the rated turn, so the training-delta slice matches.
+	body := []byte(`{
+		"model":"claude-haiku-4-5",
+		"max_tokens":1024,
+		"messages":[
+			{"role":"user","content":"first request"},
+			{"role":"assistant","content":"first response"},
+			{"role":"user","content":"/rf -1 +"}
+		]
+	}`)
+	store := newFakePinStore()
+	feedback := &fakeFeedbackStore{}
+	telem := newCaptureTelemetry()
+	telem.seqResult = proxy.TelemetryTurnResult{RequestID: "req-prev", DecisionModel: "claude-haiku-4-5", Strategy: "hmm_embedding"}
+	hmmReporter := &fakePolicyFeedbackRouter{}
+	fr := &fakeRouter{decision: router.Decision{Provider: providers.ProviderAnthropic, Model: "claude-haiku-4-5", Reason: "cluster"}}
+	svc := newPinSvcWithTelemetry(fr, store, telem).
+		WithRouterFeedbackStore(feedback).
+		WithPolicyStrategy(policy.StrategySpec{
+			Strategy:    router.StrategyHMMEmbedding,
+			Router:      hmmReporter,
+			Unavailable: router.ErrStrategyUnavailable,
+		}).
+		WithAvailableModels(map[string]struct{}{"claude-haiku-4-5": {}}).
+		WithCompaction(nil, proxy.DefaultCompactionTriggerPct)
+	ctx := router.WithStrategy(authedCtx(uuid.NewString()), router.StrategyHMMEmbedding)
+	ctx = context.WithValue(ctx, proxy.PolicyTrainingAllowedContextKey{}, true)
+	require.NoError(t, svc.ProxyMessages(ctx, body, httptest.NewRecorder(), httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(""))))
+	require.Eventually(t, func() bool { return len(hmmReporter.Payloads()) == 1 }, time.Second, 10*time.Millisecond)
+	payload := hmmReporter.Payloads()[0]
+	assert.Equal(t, "hmm_embedding", payload["strategy"])
+	assert.Equal(t, "req-prev", payload["request_id"])
+	delta, ok := payload["training_conversation_delta"].([]router.ConversationMessage)
+	require.True(t, ok, "the rated turn is the latest assistant segment in env, so the delta must be present")
+	require.Len(t, delta, 2)
+	assert.Equal(t, "user", delta[0].Role)
+	assert.Equal(t, "first request", delta[0].Text)
+	assert.Equal(t, "assistant", delta[1].Role)
+	assert.Equal(t, "first response", delta[1].Text)
 }

--- a/internal/proxy/router_feedback_proxy_test.go
+++ b/internal/proxy/router_feedback_proxy_test.go
@@ -783,3 +783,37 @@ func TestService_RouterFeedbackCommand_NegativeOnePreservesTrainingDelta(t *test
 	assert.Equal(t, "assistant", delta[1].Role)
 	assert.Equal(t, "first response", delta[1].Text)
 }
+
+func TestService_RouterFeedbackCommand_ClusterResolvedTurnSkipsPolicyFeedback(t *testing.T) {
+	// The rated turn was served by the cluster scorer (no feedback reporter).
+	// The active session strategy is HMM — reporting there would credit HMM
+	// with a cluster decision's request_id, so policy feedback must be skipped.
+	const body = `{
+		"model":"claude-sonnet-4-6",
+		"max_tokens":1024,
+		"messages":[
+			{"role":"user","content":"/rf -2 - wrong tier"}
+		]
+	}`
+	store := newFakePinStore()
+	feedback := &fakeFeedbackStore{}
+	telem := newCaptureTelemetry()
+	telem.seqResult = proxy.TelemetryTurnResult{
+		RequestID:     "req-cluster-turn",
+		DecisionModel: "claude-haiku-4-5",
+		Strategy:      "cluster",
+	}
+	hmmReporter := &fakePolicyFeedbackRouter{}
+	fr := &fakeRouter{decision: router.Decision{Provider: providers.ProviderAnthropic, Model: "claude-sonnet-4-6", Reason: "cluster"}}
+	ctx := router.WithStrategy(authedCtx(uuid.New().String()), router.StrategyHMM)
+	svc := newPinSvcWithTelemetry(fr, store, telem).
+		WithRouterFeedbackStore(feedback).
+		WithHMMRouter(hmmReporter)
+	require.NoError(t, svc.ProxyMessages(ctx, []byte(body), httptest.NewRecorder(), httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(""))))
+
+	require.Len(t, feedback.events, 1, "durable feedback still persists")
+	assert.Equal(t, "req-cluster-turn", feedback.events[0].RequestID)
+	// Policy feedback must not fire: give the async path a moment, then confirm silence.
+	time.Sleep(50 * time.Millisecond)
+	assert.Empty(t, hmmReporter.Payloads(), "a cluster-resolved turn must not be credited to the active HMM reporter")
+}

--- a/internal/proxy/service_observation_test.go
+++ b/internal/proxy/service_observation_test.go
@@ -29,6 +29,11 @@ type captureTelemetry struct {
 	shadowRows   []proxy.PolicyShadowDecision
 	notify       chan struct{}
 	shadowNotify chan struct{}
+	// seqResult and seqErr configure GetTelemetryBySessionSequence; seqCalls
+	// records the sequence arguments the code under test resolved against.
+	seqResult proxy.TelemetryTurnResult
+	seqErr    error
+	seqCalls  []int
 }
 
 func newCaptureTelemetry() *captureTelemetry {
@@ -90,6 +95,15 @@ func (c *captureTelemetry) GetTelemetryModelBreakdown(context.Context, string, t
 
 func (c *captureTelemetry) GetTelemetryModelBreakdownAll(context.Context, time.Time, time.Time, string) ([]proxy.TelemetryModelBucket, error) {
 	return nil, nil
+}
+
+func (c *captureTelemetry) GetTelemetryBySessionSequence(_ context.Context, _ uuid.UUID, _ []byte, _ string, seq int) (proxy.TelemetryTurnResult, error) {
+	c.mu.Lock()
+	c.seqCalls = append(c.seqCalls, seq)
+	res := c.seqResult
+	err := c.seqErr
+	c.mu.Unlock()
+	return res, err
 }
 
 func (c *captureTelemetry) firstRow(t *testing.T) proxy.InsertTelemetryParams {

--- a/internal/proxy/service_session_pin_test.go
+++ b/internal/proxy/service_session_pin_test.go
@@ -152,6 +152,21 @@ func newPinSvc(fr *fakeRouter, store *fakePinStore) *proxy.Service {
 	)
 }
 
+func newPinSvcWithTelemetry(fr *fakeRouter, store *fakePinStore, telemetry proxy.TelemetryRepository) *proxy.Service {
+	return proxy.NewService(
+		fr,
+		map[string]providers.Client{providers.ProviderAnthropic: &fakeProvider{}},
+		nil,
+		false,
+		nil,
+		store,
+		false,
+		providers.ProviderAnthropic,
+		"claude-haiku-4-5",
+		telemetry,
+	)
+}
+
 func authedCtx(installationID string) context.Context {
 	ctx := context.WithValue(context.Background(), proxy.APIKeyIDContextKey{}, "key-1")
 	return context.WithValue(ctx, proxy.InstallationIDContextKey{}, installationID)

--- a/internal/proxy/telemetry.go
+++ b/internal/proxy/telemetry.go
@@ -3,6 +3,8 @@ package proxy
 import (
 	"context"
 	"time"
+
+	"github.com/google/uuid"
 )
 
 // InstallationIDContextKey is the request-context key for the authenticated installation UUID.
@@ -19,6 +21,7 @@ type TelemetryRepository interface {
 	GetTelemetryRowsAll(ctx context.Context, from, to time.Time, limit int32) ([]TelemetryRow, error)
 	GetTelemetryModelBreakdown(ctx context.Context, installationID string, from, to time.Time, granularity string) ([]TelemetryModelBucket, error)
 	GetTelemetryModelBreakdownAll(ctx context.Context, from, to time.Time, granularity string) ([]TelemetryModelBucket, error)
+	GetTelemetryBySessionSequence(ctx context.Context, installationID uuid.UUID, sessionKey []byte, role string, seq int) (TelemetryTurnResult, error)
 }
 
 // InsertTelemetryParams mirrors one router.upstream span row.
@@ -175,4 +178,15 @@ type TelemetryRow struct {
 	ClientApp           string
 	TurnType            string
 	UserEmail           string
+}
+
+// TelemetryTurnResult is the per-turn telemetry metadata relevant for
+// sequence-based router feedback attribution.
+type TelemetryTurnResult struct {
+	RequestID        string
+	DecisionModel    string
+	DecisionProvider string
+	RouteID          string
+	Strategy         string
+	Timestamp        time.Time
 }

--- a/internal/proxy/turnloop_test.go
+++ b/internal/proxy/turnloop_test.go
@@ -1077,3 +1077,7 @@ func (recordingTelemetry) GetTelemetryModelBreakdown(ctx context.Context, instal
 func (recordingTelemetry) GetTelemetryModelBreakdownAll(ctx context.Context, from, to time.Time, granularity string) ([]proxy.TelemetryModelBucket, error) {
 	return nil, nil
 }
+
+func (recordingTelemetry) GetTelemetryBySessionSequence(ctx context.Context, installationID uuid.UUID, sessionKey []byte, role string, seq int) (proxy.TelemetryTurnResult, error) {
+	return proxy.TelemetryTurnResult{}, nil
+}

--- a/internal/sqlc/model_router_request_telemetry.sql.go
+++ b/internal/sqlc/model_router_request_telemetry.sql.go
@@ -71,6 +71,153 @@ func (q *Queries) GetRequestForFeedback(ctx context.Context, arg GetRequestForFe
 	return i, err
 }
 
+const getTelemetryBySessionAsc = `-- name: GetTelemetryBySessionAsc :one
+SELECT
+    request_id,
+    decision_model,
+    decision_provider,
+    route_id,
+    strategy,
+    timestamp
+FROM router.model_router_request_telemetry
+WHERE installation_id = $1::uuid
+  AND session_key = $2::bytea
+  AND role = $3::varchar
+  AND turn_type = 'main_loop'
+  AND span_type = 'router.upstream'
+ORDER BY timestamp ASC, request_id ASC
+LIMIT 1 OFFSET $4::int
+`
+
+type GetTelemetryBySessionAscParams struct {
+	InstallationID uuid.UUID
+	SessionKey     []byte
+	Role           string
+	TurnOffset     int32
+}
+
+type GetTelemetryBySessionAscRow struct {
+	RequestID        string
+	DecisionModel    *string
+	DecisionProvider *string
+	RouteID          *string
+	Strategy         *string
+	Timestamp        pgtype.Timestamptz
+}
+
+// Returns the Nth main_loop telemetry row for a (session_key, role) within
+// an installation, ordered ascending by timestamp. seq is 1-based.
+// request_id is the secondary sort key so the same query for the same input
+// resolves to the same row across replicas (timestamp ties would otherwise
+// make sequence assignment nondeterministic).
+//
+//	SELECT
+//	    request_id,
+//	    decision_model,
+//	    decision_provider,
+//	    route_id,
+//	    strategy,
+//	    timestamp
+//	FROM router.model_router_request_telemetry
+//	WHERE installation_id = $1::uuid
+//	  AND session_key = $2::bytea
+//	  AND role = $3::varchar
+//	  AND turn_type = 'main_loop'
+//	  AND span_type = 'router.upstream'
+//	ORDER BY timestamp ASC, request_id ASC
+//	LIMIT 1 OFFSET $4::int
+func (q *Queries) GetTelemetryBySessionAsc(ctx context.Context, arg GetTelemetryBySessionAscParams) (GetTelemetryBySessionAscRow, error) {
+	row := q.db.QueryRow(ctx, getTelemetryBySessionAsc,
+		arg.InstallationID,
+		arg.SessionKey,
+		arg.Role,
+		arg.TurnOffset,
+	)
+	var i GetTelemetryBySessionAscRow
+	err := row.Scan(
+		&i.RequestID,
+		&i.DecisionModel,
+		&i.DecisionProvider,
+		&i.RouteID,
+		&i.Strategy,
+		&i.Timestamp,
+	)
+	return i, err
+}
+
+const getTelemetryBySessionDesc = `-- name: GetTelemetryBySessionDesc :one
+SELECT
+    request_id,
+    decision_model,
+    decision_provider,
+    route_id,
+    strategy,
+    timestamp
+FROM router.model_router_request_telemetry
+WHERE installation_id = $1::uuid
+  AND session_key = $2::bytea
+  AND role = $3::varchar
+  AND turn_type = 'main_loop'
+  AND span_type = 'router.upstream'
+ORDER BY timestamp DESC, request_id DESC
+LIMIT 1 OFFSET $4::int
+`
+
+type GetTelemetryBySessionDescParams struct {
+	InstallationID uuid.UUID
+	SessionKey     []byte
+	Role           string
+	TurnOffset     int32
+}
+
+type GetTelemetryBySessionDescRow struct {
+	RequestID        string
+	DecisionModel    *string
+	DecisionProvider *string
+	RouteID          *string
+	Strategy         *string
+	Timestamp        pgtype.Timestamptz
+}
+
+// Returns the Nth-from-latest main_loop telemetry row for a (session_key, role)
+// within an installation, ordered descending by timestamp. abs_seq is 1-based
+// (1 = latest, 2 = one-before-latest, etc.). request_id is the secondary sort
+// key so timestamp ties resolve deterministically.
+//
+//	SELECT
+//	    request_id,
+//	    decision_model,
+//	    decision_provider,
+//	    route_id,
+//	    strategy,
+//	    timestamp
+//	FROM router.model_router_request_telemetry
+//	WHERE installation_id = $1::uuid
+//	  AND session_key = $2::bytea
+//	  AND role = $3::varchar
+//	  AND turn_type = 'main_loop'
+//	  AND span_type = 'router.upstream'
+//	ORDER BY timestamp DESC, request_id DESC
+//	LIMIT 1 OFFSET $4::int
+func (q *Queries) GetTelemetryBySessionDesc(ctx context.Context, arg GetTelemetryBySessionDescParams) (GetTelemetryBySessionDescRow, error) {
+	row := q.db.QueryRow(ctx, getTelemetryBySessionDesc,
+		arg.InstallationID,
+		arg.SessionKey,
+		arg.Role,
+		arg.TurnOffset,
+	)
+	var i GetTelemetryBySessionDescRow
+	err := row.Scan(
+		&i.RequestID,
+		&i.DecisionModel,
+		&i.DecisionProvider,
+		&i.RouteID,
+		&i.Strategy,
+		&i.Timestamp,
+	)
+	return i, err
+}
+
 const getTelemetryModelBreakdownDaily = `-- name: GetTelemetryModelBreakdownDaily :many
 SELECT
     date_trunc('day', timestamp)::timestamptz                                AS bucket,

--- a/internal/sqlc/models.go
+++ b/internal/sqlc/models.go
@@ -389,6 +389,10 @@ type RouterRouterFeedback struct {
 	SuggestedLabel *string
 	// How the feedback was submitted: "user" (explicit /rf command), "auto" (automated judge at session stop).
 	Source string
+	// Telemetry request_id for the specific turn this feedback targets. NULL when no sequence was specified.
+	RequestID *string
+	// Sidecar correlation id from the telemetry row (HMM/RL). NULL when no sequence was specified.
+	RouteID *string
 }
 
 // Session-sticky routing pins; sliding 1h TTL matching Anthropic prompt cache

--- a/internal/sqlc/router_feedback.sql.go
+++ b/internal/sqlc/router_feedback.sql.go
@@ -25,7 +25,9 @@ INSERT INTO router.router_feedback (
     feedback,
     rating,
     suggested_label,
-    source
+    source,
+    request_id,
+    route_id
 ) VALUES (
     $1::uuid,
     $2::bytea,
@@ -38,7 +40,9 @@ INSERT INTO router.router_feedback (
     $9::text,
     $10::varchar,
     $11::varchar,
-    $12::varchar
+    $12::varchar,
+    $13::varchar,
+    $14::varchar
 )
 `
 
@@ -55,12 +59,16 @@ type InsertRouterFeedbackParams struct {
 	Rating         *string
 	SuggestedLabel *string
 	Source         string
+	RequestID      *string
+	RouteID        *string
 }
 
 // Records one /router-feedback submission. Written with
 // context.Background() (the synthetic ack response may already have been
 // flushed and the request ctx canceled). served_model is the session pin's
 // LastServedModel at submission time; empty when the session had no pin.
+// request_id and route_id are populated when a turn sequence was specified
+// so the policy sidecar can join the rating to the specific routing decision.
 //
 //	INSERT INTO router.router_feedback (
 //	    installation_id,
@@ -74,7 +82,9 @@ type InsertRouterFeedbackParams struct {
 //	    feedback,
 //	    rating,
 //	    suggested_label,
-//	    source
+//	    source,
+//	    request_id,
+//	    route_id
 //	) VALUES (
 //	    $1::uuid,
 //	    $2::bytea,
@@ -87,7 +97,9 @@ type InsertRouterFeedbackParams struct {
 //	    $9::text,
 //	    $10::varchar,
 //	    $11::varchar,
-//	    $12::varchar
+//	    $12::varchar,
+//	    $13::varchar,
+//	    $14::varchar
 //	)
 func (q *Queries) InsertRouterFeedback(ctx context.Context, arg InsertRouterFeedbackParams) error {
 	_, err := q.db.Exec(ctx, insertRouterFeedback,
@@ -103,6 +115,8 @@ func (q *Queries) InsertRouterFeedback(ctx context.Context, arg InsertRouterFeed
 		arg.Rating,
 		arg.SuggestedLabel,
 		arg.Source,
+		arg.RequestID,
+		arg.RouteID,
 	)
 	return err
 }

--- a/internal/translate/router_feedback.go
+++ b/internal/translate/router_feedback.go
@@ -325,6 +325,10 @@ func splitSequence(s string) (seq int, rest string) {
 		return 0, s
 	}
 	if strings.HasPrefix(tok, "-") && len(tok) > 1 && tok[1] >= '1' && tok[1] <= '9' {
+		// Same 1-2 digit cap as positives: "-404 not found" is a status code in a note, not turn -404.
+		if len(tok) > 3 {
+			return 0, s
+		}
 		restDigits := tok[2:]
 		allDigits := true
 		for i := 0; i < len(restDigits); i++ {

--- a/internal/translate/router_feedback.go
+++ b/internal/translate/router_feedback.go
@@ -17,10 +17,8 @@ type RouterFeedbackResult struct {
 	// Feedback is the free-form note the user submitted after the command,
 	// minus any leading rating token and trailing --label flag.
 	Feedback string
-	// Sequence is an optional leading turn-sequence indicator parsed from the
-	// feedback body. 0 = last turn (default, no sequence specified),
-	// positive = absolute turn sequence number, negative = relative offset
-	// from the last turn (e.g. -3 means three turns back).
+	// Sequence is an optional leading turn-selector: 0 = last turn (default),
+	// positive = absolute 1-based index, negative = relative offset from last (e.g. -3).
 	Sequence int
 }
 

--- a/internal/translate/router_feedback.go
+++ b/internal/translate/router_feedback.go
@@ -352,10 +352,7 @@ func splitSequence(s string) (seq int, rest string) {
 		}
 	}
 	if allDigits {
-		// Bound the absolute-sequence consume to short turns (1-2 digits): 3+
-		// digit prefixes are almost always status codes or IDs (`404`, `1001`)
-		// and must stay in the note text. This matches the relative heuristic
-		// where -1, -2, -3 are consumed unconditionally.
+		// Only consume 1-2 digit tokens; 3+ digits are almost always status codes or IDs (404, 1001).
 		if len(tok) > 2 {
 			return 0, s
 		}

--- a/internal/translate/router_feedback.go
+++ b/internal/translate/router_feedback.go
@@ -132,9 +132,7 @@ func parseRouterFeedbackCommand(text string) (res RouterFeedbackResult, found bo
 		}
 		feedback += rest
 	}
-	// splitSequence must run before splitLeadingRating so a bare "-" in
-	// feedback is left for the verdict parser rather than being eaten as
-	// part of a negative sequence token.
+	// Must precede splitLeadingRating so a bare "-" is left for the verdict parser.
 	var seq int
 	seq, feedback = splitSequence(feedback)
 	// A note that opens with a bare verdict ("/rf 👍 too slow") promotes to a
@@ -142,9 +140,7 @@ func parseRouterFeedbackCommand(text string) (res RouterFeedbackResult, found bo
 	if rating == "" {
 		rating, feedback = splitLeadingRating(feedback)
 	}
-	// splitSequence must also run before stripTrailingLabel so a slash at the start
-	// of the note is disambiguated as a sequence index rather than read as
-	// prose by the --label scanner.
+	// Must precede stripTrailingLabel so a leading digit is not misread as prose by the --label scanner.
 	var label string
 	if rating == RouterFeedbackRatingDown {
 		label, feedback = stripTrailingLabel(feedback)
@@ -317,16 +313,10 @@ func extractQuotedOrBareValue(s string) (val, rest string, ok bool) {
 	return val, tail, true
 }
 
-// splitSequence extracts an optional leading sequence token from s. Returns
-// the sequence value and the remaining text.
-//
-// Rules:
-//   - /\d+/ (1–2 digits) = absolute positive sequence number, always consumed
-//   - 3+ digits stay in the note text (almost always status codes or IDs)
-//   - /-[1-9]\d*/ = relative negative sequence (must have digits after minus)
-//   - A bare "-" followed by space or end is NOT a sequence (it's a verdict down)
-//   - "-0" does NOT parse as a sequence
-//   - Only the first sequence-parseable token is consumed
+// splitSequence extracts an optional leading sequence token from s.
+// Negative token (-N, N>=1) = relative offset from last turn; positive 1-2 digit token = absolute 1-based index
+// (3+ digits stay in the note — almost always status codes or IDs, so "404 not found" is not a sequence).
+// "-", "-0", and bare zero are left untouched. Returns (0, s) when no sequence is found.
 func splitSequence(s string) (seq int, rest string) {
 	s = strings.TrimSpace(s)
 	if s == "" {
@@ -380,4 +370,3 @@ func splitSequence(s string) (seq int, rest string) {
 	}
 	return 0, s
 }
-

--- a/internal/translate/router_feedback.go
+++ b/internal/translate/router_feedback.go
@@ -321,15 +321,12 @@ func extractQuotedOrBareValue(s string) (val, rest string, ok bool) {
 // the sequence value and the remaining text.
 //
 // Rules:
-//   - /\d+/ = absolute positive sequence number
+//   - /\d+/ (1–2 digits) = absolute positive sequence number, always consumed
+//   - 3+ digits stay in the note text (almost always status codes or IDs)
 //   - /-[1-9]\d*/ = relative negative sequence (must have digits after minus)
 //   - A bare "-" followed by space or end is NOT a sequence (it's a verdict down)
 //   - "-0" does NOT parse as a sequence
 //   - Only the first sequence-parseable token is consumed
-//   - Positive integers only consume when they are the lone remaining token
-//     or the immediately following token is a verdict; otherwise the digit
-//     stays in the note so things like "404 not found" don't trigger a
-//     sequence lookup that would drop the feedback.
 func splitSequence(s string) (seq int, rest string) {
 	s = strings.TrimSpace(s)
 	if s == "" {
@@ -365,10 +362,11 @@ func splitSequence(s string) (seq int, rest string) {
 		}
 	}
 	if allDigits {
-		next := strings.TrimSpace(after)
-		lone := next == ""
-		verdictFollows := lone || isVerdictToken(next)
-		if !verdictFollows {
+		// Bound the absolute-sequence consume to short turns (1-2 digits): 3+
+		// digit prefixes are almost always status codes or IDs (`404`, `1001`)
+		// and must stay in the note text. This matches the relative heuristic
+		// where -1, -2, -3 are consumed unconditionally.
+		if len(tok) > 2 {
 			return 0, s
 		}
 		seq := 0
@@ -383,14 +381,3 @@ func splitSequence(s string) (seq int, rest string) {
 	return 0, s
 }
 
-// isVerdictToken reports whether s opens with a verdict recognized by
-// splitLeadingRating. Used to disambiguate `/rf N <verdict>` from
-// `/rf N <prose>`.
-func isVerdictToken(s string) bool {
-	tok, _, _ := strings.Cut(s, " ")
-	switch strings.ToLower(tok) {
-	case "+", "-", "👍", "👎", "up", "down", "thumbsup", "thumbsdown":
-		return true
-	}
-	return false
-}

--- a/internal/translate/router_feedback.go
+++ b/internal/translate/router_feedback.go
@@ -17,6 +17,11 @@ type RouterFeedbackResult struct {
 	// Feedback is the free-form note the user submitted after the command,
 	// minus any leading rating token and trailing --label flag.
 	Feedback string
+	// Sequence is an optional leading turn-sequence indicator parsed from the
+	// feedback body. 0 = last turn (default, no sequence specified),
+	// positive = absolute turn sequence number, negative = relative offset
+	// from the last turn (e.g. -3 means three turns back).
+	Sequence int
 }
 
 // RouterFeedbackRatingUp and RouterFeedbackRatingDown are the canonical
@@ -127,17 +132,24 @@ func parseRouterFeedbackCommand(text string) (res RouterFeedbackResult, found bo
 		}
 		feedback += rest
 	}
+	// splitSequence must run before splitLeadingRating so a bare "-" in
+	// feedback is left for the verdict parser rather than being eaten as
+	// part of a negative sequence token.
+	var seq int
+	seq, feedback = splitSequence(feedback)
 	// A note that opens with a bare verdict ("/rf 👍 too slow") promotes to a
 	// rating, so a single command can carry both verdict and explanation.
 	if rating == "" {
 		rating, feedback = splitLeadingRating(feedback)
 	}
-	// A --label correction only applies to a negative verdict; positive and note-only ratings leave the flag in the note.
+	// splitSequence must also run before stripTrailingLabel so a slash at the start
+	// of the note is disambiguated as a sequence index rather than read as
+	// prose by the --label scanner.
 	var label string
 	if rating == RouterFeedbackRatingDown {
 		label, feedback = stripTrailingLabel(feedback)
 	}
-	return RouterFeedbackResult{Rating: rating, SuggestedLabel: label, Feedback: feedback}, true, strings.TrimSpace(prefix)
+	return RouterFeedbackResult{Rating: rating, SuggestedLabel: label, Feedback: feedback, Sequence: seq}, true, strings.TrimSpace(prefix)
 }
 
 func isRouterFeedbackCommandOnlyContent(content gjson.Result) bool {
@@ -209,8 +221,10 @@ func isRouterFeedbackAckText(text string) bool {
 	trimmed := strings.TrimSpace(text)
 	return strings.HasPrefix(trimmed, "Weave Router: Feedback recorded") ||
 		strings.HasPrefix(trimmed, "Weave Router: router-feedback needs a verdict") ||
+		strings.HasPrefix(trimmed, "Weave Router: No turn found at that sequence number") ||
 		strings.HasPrefix(trimmed, "✦ **Weave Router** → Feedback recorded") ||
-		strings.HasPrefix(trimmed, "✦ **Weave Router** → Router-feedback needs a verdict")
+		strings.HasPrefix(trimmed, "✦ **Weave Router** → Router-feedback needs a verdict") ||
+		strings.HasPrefix(trimmed, "✦ **Weave Router** → No turn found at that sequence number")
 }
 
 // matchRouterFeedbackCommand recognizes the command token at the start of the
@@ -301,4 +315,82 @@ func extractQuotedOrBareValue(s string) (val, rest string, ok bool) {
 	}
 	val, tail, _ := strings.Cut(s, " ")
 	return val, tail, true
+}
+
+// splitSequence extracts an optional leading sequence token from s. Returns
+// the sequence value and the remaining text.
+//
+// Rules:
+//   - /\d+/ = absolute positive sequence number
+//   - /-[1-9]\d*/ = relative negative sequence (must have digits after minus)
+//   - A bare "-" followed by space or end is NOT a sequence (it's a verdict down)
+//   - "-0" does NOT parse as a sequence
+//   - Only the first sequence-parseable token is consumed
+//   - Positive integers only consume when they are the lone remaining token
+//     or the immediately following token is a verdict; otherwise the digit
+//     stays in the note so things like "404 not found" don't trigger a
+//     sequence lookup that would drop the feedback.
+func splitSequence(s string) (seq int, rest string) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return 0, ""
+	}
+	tok, after, _ := strings.Cut(s, " ")
+	if tok == "-" || tok == "-0" {
+		return 0, s
+	}
+	if strings.HasPrefix(tok, "-") && len(tok) > 1 && tok[1] >= '1' && tok[1] <= '9' {
+		restDigits := tok[2:]
+		allDigits := true
+		for i := 0; i < len(restDigits); i++ {
+			if restDigits[i] < '0' || restDigits[i] > '9' {
+				allDigits = false
+				break
+			}
+		}
+		if allDigits {
+			seq := 0
+			for _, ch := range tok[1:] {
+				seq = seq*10 + int(ch-'0')
+			}
+			return -seq, strings.TrimSpace(after)
+		}
+		return 0, s
+	}
+	allDigits := len(tok) > 0
+	for i := 0; i < len(tok); i++ {
+		if tok[i] < '0' || tok[i] > '9' {
+			allDigits = false
+			break
+		}
+	}
+	if allDigits {
+		next := strings.TrimSpace(after)
+		lone := next == ""
+		verdictFollows := lone || isVerdictToken(next)
+		if !verdictFollows {
+			return 0, s
+		}
+		seq := 0
+		for _, ch := range tok {
+			seq = seq*10 + int(ch-'0')
+		}
+		if seq == 0 {
+			return 0, s
+		}
+		return seq, strings.TrimSpace(after)
+	}
+	return 0, s
+}
+
+// isVerdictToken reports whether s opens with a verdict recognized by
+// splitLeadingRating. Used to disambiguate `/rf N <verdict>` from
+// `/rf N <prose>`.
+func isVerdictToken(s string) bool {
+	tok, _, _ := strings.Cut(s, " ")
+	switch strings.ToLower(tok) {
+	case "+", "-", "👍", "👎", "up", "down", "thumbsup", "thumbsdown":
+		return true
+	}
+	return false
 }

--- a/internal/translate/router_feedback_test.go
+++ b/internal/translate/router_feedback_test.go
@@ -17,6 +17,7 @@ func TestParseRouterFeedbackCommand(t *testing.T) {
 		wantRating         string
 		wantSuggestedLabel string
 		wantFeedback       string
+		wantSequence       int
 		wantFound          bool
 		wantStripped       string
 	}{
@@ -218,6 +219,56 @@ func TestParseRouterFeedbackCommand(t *testing.T) {
 			wantFeedback:       "too simple for this",
 			wantFound:          true,
 		},
+		{
+			name:         "rf with negative one-digit sequence consumes as sequence",
+			input:        "/rf -1 too slow",
+			wantSequence: -1,
+			wantFeedback: "too slow",
+			wantFound:    true,
+		},
+		{
+			name:         "rf with negative sequence plus rating up",
+			input:        "/rf -3 + too slow on haiku",
+			wantRating:   "up",
+			wantSequence: -3,
+			wantFeedback: "too slow on haiku",
+			wantFound:    true,
+		},
+		{
+			name:         "rf with one-digit absolute sequence consumes as sequence",
+			input:        "/rf 3 the diff was incomplete",
+			wantSequence: 3,
+			wantFeedback: "the diff was incomplete",
+			wantFound:    true,
+		},
+		{
+			name:         "rf with two-digit absolute sequence consumes as sequence",
+			input:        "/rf 12 stuck in a loop",
+			wantSequence: 12,
+			wantFeedback: "stuck in a loop",
+			wantFound:    true,
+		},
+		{
+			name:         "rf with three-digit prefix stays in note (status code)",
+			input:        "/rf 1001 too slow",
+			wantSequence: 0,
+			wantFeedback: "1001 too slow",
+			wantFound:    true,
+		},
+		{
+			name:         "rf with status code 404 stays in note",
+			input:        "/rf 404 not found",
+			wantSequence: 0,
+			wantFeedback: "404 not found",
+			wantFound:    true,
+		},
+		{
+			name:         "rf with zero token is note text not sequence",
+			input:        "/rf 0 days late",
+			wantSequence: 0,
+			wantFeedback: "0 days late",
+			wantFound:    true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -233,6 +284,7 @@ func TestParseRouterFeedbackCommand(t *testing.T) {
 			assert.Equal(t, tt.wantRating, res.Rating)
 			assert.Equal(t, tt.wantSuggestedLabel, res.SuggestedLabel)
 			assert.Equal(t, tt.wantFeedback, res.Feedback)
+			assert.Equal(t, tt.wantSequence, res.Sequence)
 
 			stripped := lastUserMessageText(t, env)
 			assert.Equal(t, tt.wantStripped, stripped)

--- a/internal/translate/router_feedback_test.go
+++ b/internal/translate/router_feedback_test.go
@@ -227,6 +227,20 @@ func TestParseRouterFeedbackCommand(t *testing.T) {
 			wantFound:    true,
 		},
 		{
+			name:         "rf with negative two-digit sequence consumes as sequence",
+			input:        "/rf -12 stuck in a loop back then",
+			wantSequence: -12,
+			wantFeedback: "stuck in a loop back then",
+			wantFound:    true,
+		},
+		{
+			name:         "rf with negative three-digit prefix stays in note (status code)",
+			input:        "/rf -404 not found",
+			wantSequence: 0,
+			wantFeedback: "-404 not found",
+			wantFound:    true,
+		},
+		{
 			name:         "rf with negative sequence plus rating up",
 			input:        "/rf -3 + too slow on haiku",
 			wantRating:   "up",

--- a/internal/translate/strip_seq_ack_test.go
+++ b/internal/translate/strip_seq_ack_test.go
@@ -1,0 +1,36 @@
+package translate_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"workweave/router/internal/translate"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStripRouterFeedbackArtifacts_StripsSequenceNotFoundAck(t *testing.T) {
+	body := mustMarshalJSON(t, map[string]any{
+		"model": "claude-sonnet-4-6",
+		"messages": []any{
+			map[string]any{"role": "user", "content": "first request"},
+			map[string]any{"role": "assistant", "content": "first response"},
+			map[string]any{"role": "user", "content": "/rf -9 - never happened"},
+			map[string]any{"role": "assistant", "content": "✦ **Weave Router** → No turn found at that sequence number. Try `/rf` without a number for the last turn.\n\n"},
+			map[string]any{"role": "user", "content": "/rf + all good now"},
+		},
+		"max_tokens": 1024,
+	})
+	env, err := translate.ParseAnthropic(body)
+	require.NoError(t, err)
+
+	removed := env.StripRouterFeedbackArtifacts()
+	assert.Equal(t, 2, removed, "both the prior command and its sequence-not-found ack must be stripped")
+
+	raw, _ := env.PrepareAnthropic(nil, translate.EmitOptions{TargetModel: "claude-sonnet-4-6"})
+	var got map[string]any
+	require.NoError(t, json.Unmarshal(raw.Body, &got))
+	msgs, _ := got["messages"].([]any)
+	require.Len(t, msgs, 3, "only the real turns plus the current command survive")
+}


### PR DESCRIPTION
/router-feedback previously attributed every rating to the session pin's
LastServedModel, so feedback about an earlier turn could land on the wrong
model once the planner switched mid-session. Adding an optional leading
sequence token (/rf -N for relative, /rf N for absolute, default = last
turn) resolves the rating against the exact main_loop telemetry row,
carrying its request_id and route_id through to the durable feedback
table, the request_feedback convergence upsert, and the policy sidecar
payload for per-decision credit assignment.

Signed-off-by: Samir Amin <aminsamir45@gmail.com>