### PR TITLE
fix(translate/router): resolve bot review-thread findings on #814 (sequence feed)

### DIFF
--- a/internal/postgres/pgx_chain_test.go
+++ b/internal/postgres/pgx_chain_test.go
@@ -1,0 +1,20 @@
+package postgres
+
+import (
+	"database/sql"
+	"errors"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+)
+
+// TestPgxErrNoRowsUnwrapsSql pins the cross-package error chain the proxy
+// layer relies on: postgres returns pgx.ErrNoRows; the proxy checks
+// errors.Is(err, sql.ErrNoRows). pgx.ErrNoRows is a newProxyErr wrapping
+// sql.ErrNoRows, so errors.Is unwraps correctly today — this test fails
+// the moment a pgx upgrade changes the wrap behavior.
+func TestPgxErrNoRowsUnwrapsSql(t *testing.T) {
+	if !errors.Is(pgx.ErrNoRows, sql.ErrNoRows) {
+		t.Fatal("pgx.ErrNoRows must be errors.Is-comparable to sql.ErrNoRows so handleRouterFeedbackCommand's no-rows branch fires for real Postgres no-rows errors")
+	}
+}

--- a/internal/postgres/pgx_chain_test.go
+++ b/internal/postgres/pgx_chain_test.go
@@ -8,11 +8,9 @@ import (
 	"github.com/jackc/pgx/v5"
 )
 
-// TestPgxErrNoRowsUnwrapsSql pins the cross-package error chain the proxy
-// layer relies on: postgres returns pgx.ErrNoRows; the proxy checks
-// errors.Is(err, sql.ErrNoRows). pgx.ErrNoRows is a newProxyErr wrapping
-// sql.ErrNoRows, so errors.Is unwraps correctly today — this test fails
-// the moment a pgx upgrade changes the wrap behavior.
+// TestPgxErrNoRowsUnwrapsSql pins the pgx->sql error-chain that the proxy's
+// no-rows detection relies on. pgx.ErrNoRows wraps sql.ErrNoRows; if a pgx
+// upgrade changes that, this test fails before prod does.
 func TestPgxErrNoRowsUnwrapsSql(t *testing.T) {
 	if !errors.Is(pgx.ErrNoRows, sql.ErrNoRows) {
 		t.Fatal("pgx.ErrNoRows must be errors.Is-comparable to sql.ErrNoRows so handleRouterFeedbackCommand's no-rows branch fires for real Postgres no-rows errors")

--- a/internal/postgres/telemetry.go
+++ b/internal/postgres/telemetry.go
@@ -754,9 +754,8 @@ func modelBucketFromHourlyAllRow(row sqlc.GetTelemetryModelBreakdownHourlyAllRow
 }
 
 // GetTelemetryBySessionSequence returns the N-th main_loop telemetry row for
-// (installation_id, session_key, role). seq > 0 = absolute 1-based ASC,
-// seq < 0 = relative 1-based DESC. Returns pgx.ErrNoRows when fewer than
-// |seq| rows exist.
+// (installationID, sessionKey, role): seq > 0 = ASC 1-based, seq < 0 = DESC 1-based.
+// Returns pgx.ErrNoRows when fewer than |seq| rows exist.
 func (r *TelemetryRepo) GetTelemetryBySessionSequence(ctx context.Context, installationID uuid.UUID, sessionKey []byte, role string, seq int) (proxy.TelemetryTurnResult, error) {
 	q := sqlc.New(r.tx)
 	if seq > 0 {

--- a/internal/translate/router_feedback.go
+++ b/internal/translate/router_feedback.go
@@ -312,9 +312,8 @@ func extractQuotedOrBareValue(s string) (val, rest string, ok bool) {
 }
 
 // splitSequence extracts an optional leading sequence token from s.
-// Negative token (-N, N>=1) = relative offset from last turn; positive 1-2 digit token = absolute 1-based index
-// (3+ digits stay in the note — almost always status codes or IDs, so "404 not found" is not a sequence).
-// "-", "-0", and bare zero are left untouched. Returns (0, s) when no sequence is found.
+// Negative (-N, 1–2 digits) = relative offset from last turn; positive (1–2 digits) = absolute 1-based index;
+// 3+ digits stay in the note. "-", "-0", and bare zero are left untouched. Returns (0, s) when no token found.
 func splitSequence(s string) (seq int, rest string) {
 	s = strings.TrimSpace(s)
 	if s == "" {


### PR DESCRIPTION
Forward-ports the post-merge review fixes for #814 onto `workweave/router` main. PR #814 itself merged cleanly; the bot review cycle that resolved 24 review threads landed commits on the `feat/router-feedback-turn-sequence` branch but never reached main, so prod is running the v1 (with the bugs below) rather than v2.

What's in this forward-port (10 commits, +865/-28):
- splitSequence gates positive integers on a verdict-following token — `/rf 404 not found` keeps \"404\" in the note instead of dropping the feedback on an out-of-range lookup
- splitSequence caps negative sequences at 2 digits — `/rf -404 not found` no longer parses as turn -404
- Note-only sequence-resolved ratings skip the `request_feedback` upsert (no longer overwrite prior thumbs on the same `request_id` with an invalid up/down column)
- `/rf` sequence-not-found synthetic ack is stripped from history on ingress (matches the existing routing-marker scrub path)
- `training_conversation_delta` is gated on `Sequence == 0 || -1` — the latest-turn cases — and reporter lookup uses the resolved turn's strategy instead of the current request context
- Telemetry tiebreaker `ORDER BY (timestamp ASC|DESC, request_id ASC|DESC)` for stable cross-replica sequence resolution
- Resolved-turn strategy routes feedback to the correct sidecar reporter (HMM/RL historical rating no longer leaks to cluster strategy)
- New regression tests for naked-digit splits, ack stripping, and the resolved-strategy routing
- E2E verified via docker compose + Postgres: rows landed with correct `request_id`/`route_id`/`served_model`, convergence into `request_feedback` with `source='router-feedback-command'`, prior-thumb overwrite prevented.

Cores on the bot-fix cycle for #814, all 24 reviewer threads already resolved.