### PR TITLE
feat(router): serve the HMM roster from /v1/router/models per strategy

### DIFF
--- a/cmd/router/hmm_roster_source.go
+++ b/cmd/router/hmm_roster_source.go
@@ -35,19 +35,16 @@ type hmmRosterSource struct {
 	haveCache bool
 }
 
-// newHMMRosterSource initializes the cached HMM roster source. The caller
-// must ensure the registered catalogModelsTimeout exceeds the sidecar client
-// budget (policyclient.DefaultTimeout or ROUTER_HMM_SIDECAR_TIMEOUT_MS),
-// otherwise a cold/expired cache is cancelled before the roster returns.
+// newHMMRosterSource initializes the cached HMM roster source.
 func newHMMRosterSource(fetch rosterFetcher) *hmmRosterSource {
 	return &hmmRosterSource{fetch: fetch}
 }
 
 // HMMDeployedModels returns catalog entries for the HMM roster. The lock is
-// not held across the sidecar fetch so concurrent callers don't serialize;
-// a failed refresh with a prior snapshot serves stale + backs off so an
-// outage doesn't hammer the sidecar on every request. A racing successful
-// fetch is preserved — it cannot be overwritten by a slower failing fetch.
+// not held across the fetch so concurrent callers don't serialize; a failing
+// refresh with a prior snapshot serves stale and backs off. Neither the
+// success nor the failure write-back can clobber a concurrent winner: both
+// commit only while our in-flight marker is still the current fetchedAt.
 func (s *hmmRosterSource) HMMDeployedModels(ctx context.Context) (entries []cluster.DeployedEntry, err error) {
 	s.mu.Lock()
 	if s.haveCache && time.Since(s.fetchedAt) < hmmRosterTTL {
@@ -81,9 +78,14 @@ func (s *hmmRosterSource) HMMDeployedModels(ctx context.Context) (entries []clus
 
 	mapped := hmm.DeployedModelsForRosterIDs(rosterIDs)
 	s.mu.Lock()
-	s.cached = mapped
-	s.fetchedAt = time.Now()
-	s.haveCache = true
+	// Same guard as the failure path: only commit if no concurrent refresh
+	// has updated the cache since we marked it in flight, so a slower success
+	// can't overwrite a newer winner. Either snapshot is valid to return.
+	if s.fetchedAt.Equal(fetching) {
+		s.cached = mapped
+		s.fetchedAt = time.Now()
+		s.haveCache = true
+	}
 	s.mu.Unlock()
 	return cloneDeployedEntries(mapped), nil
 }

--- a/cmd/router/hmm_roster_source.go
+++ b/cmd/router/hmm_roster_source.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"workweave/router/internal/router/cluster"
+	"workweave/router/internal/router/hmm"
+)
+
+// hmmRosterTTL reuses the same freshness window as the control plane's own
+// deployed-models cache; the HMM roster only changes on a bandit-state swap.
+const hmmRosterTTL = 5 * time.Minute
+
+// rosterFetcher is the subset of the policy sidecar client the roster source
+// needs; satisfied by *policyclient.Client.
+type rosterFetcher interface {
+	Roster(ctx context.Context) ([]string, error)
+}
+
+// hmmRosterSource adapts the HMM sidecar's roster arms into the deployed-models
+// shape the control plane reads. It caches per hmmRosterTTL and, on a fetch
+// failure with a prior snapshot, serves the stale list rather than blanking the
+// settings roster — the same stale-on-failure contract as the cluster catalog.
+type hmmRosterSource struct {
+	fetch rosterFetcher
+
+	mu        sync.Mutex
+	cached    []cluster.DeployedEntry
+	fetchedAt time.Time
+	haveCache bool
+}
+
+func newHMMRosterSource(fetch rosterFetcher) *hmmRosterSource {
+	return &hmmRosterSource{fetch: fetch}
+}
+
+// HMMDeployedModels returns the models the HMM strategy routes across, mapped
+// from the sidecar roster arms to catalog {model, provider} entries.
+func (s *hmmRosterSource) HMMDeployedModels(ctx context.Context) (entries []cluster.DeployedEntry, err error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.haveCache && time.Since(s.fetchedAt) < hmmRosterTTL {
+		return cloneDeployedEntries(s.cached), nil
+	}
+
+	rosterIDs, fetchErr := s.fetch.Roster(ctx)
+	if fetchErr != nil {
+		if s.haveCache {
+			return cloneDeployedEntries(s.cached), nil
+		}
+		return nil, fetchErr
+	}
+
+	mapped := hmm.DeployedModelsForRosterIDs(rosterIDs)
+	s.cached = mapped
+	s.fetchedAt = time.Now()
+	s.haveCache = true
+	return cloneDeployedEntries(mapped), nil
+}
+
+func cloneDeployedEntries(in []cluster.DeployedEntry) []cluster.DeployedEntry {
+	out := make([]cluster.DeployedEntry, len(in))
+	copy(out, in)
+	return out
+}

--- a/cmd/router/hmm_roster_source.go
+++ b/cmd/router/hmm_roster_source.go
@@ -19,10 +19,8 @@ type rosterFetcher interface {
 	Roster(ctx context.Context) ([]string, error)
 }
 
-// hmmRosterSource adapts the HMM sidecar's roster arms into the deployed-models
-// shape the control plane reads. It caches per hmmRosterTTL and, on a fetch
-// failure with a prior snapshot, serves the stale list rather than blanking the
-// settings roster — the same stale-on-failure contract as the cluster catalog.
+// hmmRosterSource adapts HMM sidecar roster arms to deployed-model entries.
+// On fetch failure it serves the prior snapshot rather than blanking the roster.
 type hmmRosterSource struct {
 	fetch rosterFetcher
 

--- a/cmd/router/hmm_roster_source.go
+++ b/cmd/router/hmm_roster_source.go
@@ -17,15 +17,8 @@ import (
 const hmmRosterTTL = 5 * time.Minute
 
 // hmmRosterRetryBackoff caps how often a failing refresh re-hits the sidecar
-// while stale data is being served. Without it, every reader after TTL expiry
-// would re-enter the slow failing fetch during a sidecar outage.
+// while stale data is being served, to avoid hammering it during an outage.
 const hmmRosterRetryBackoff = 30 * time.Second
-
-// hmmRosterFetchTimeout bounds the detached shared roster fetch. It matches
-// the sidecar client's own per-call budget; the shared fetch runs under this
-// rather than any single caller's request context so one caller cancelling
-// doesn't abort the refresh for the others.
-const hmmRosterFetchTimeout = policyclient.DefaultTimeout
 
 // rosterFetcher is the subset of the policy sidecar client the roster source
 // needs; satisfied by *policyclient.Client.
@@ -36,12 +29,11 @@ type rosterFetcher interface {
 // hmmRosterSource adapts HMM sidecar roster arms to deployed-model entries.
 // On fetch failure it serves the prior snapshot rather than blanking the roster.
 type hmmRosterSource struct {
-	fetch rosterFetcher
+	fetch        rosterFetcher
+	fetchTimeout time.Duration
 
-	// group collapses concurrent refreshes into a single sidecar call, so a
-	// stampede (including a cold cache) never fans out and there is exactly
-	// one writer per refresh — no marker juggling to protect against a slow
-	// fetch clobbering a newer one.
+	// group collapses concurrent refreshes via singleflight — exactly one
+	// writer per refresh, no clobber risk from a slow fetch racing a newer one.
 	group singleflight.Group
 
 	mu        sync.Mutex
@@ -51,15 +43,16 @@ type hmmRosterSource struct {
 }
 
 // newHMMRosterSource initializes the cached HMM roster source.
-func newHMMRosterSource(fetch rosterFetcher) *hmmRosterSource {
-	return &hmmRosterSource{fetch: fetch}
+func newHMMRosterSource(fetch rosterFetcher, fetchTimeout time.Duration) *hmmRosterSource {
+	if fetchTimeout <= 0 {
+		fetchTimeout = policyclient.DefaultTimeout
+	}
+	return &hmmRosterSource{fetch: fetch, fetchTimeout: fetchTimeout}
 }
 
-// HMMDeployedModels returns catalog entries for the HMM roster. A fresh cache
-// is served without any fetch; otherwise concurrent callers collapse onto one
-// sidecar refresh (singleflight). A failing refresh with a prior snapshot
-// serves stale and backs off so an outage doesn't hammer the sidecar; a
-// failing refresh with no snapshot surfaces the error.
+// HMMDeployedModels returns catalog entries for the HMM roster. Serves a
+// cached snapshot when fresh; collapses concurrent refreshes via singleflight.
+// On failure with a prior snapshot returns stale; otherwise surfaces the error.
 func (s *hmmRosterSource) HMMDeployedModels(ctx context.Context) (entries []cluster.DeployedEntry, err error) {
 	s.mu.Lock()
 	if s.haveCache && time.Since(s.fetchedAt) < hmmRosterTTL {
@@ -69,13 +62,11 @@ func (s *hmmRosterSource) HMMDeployedModels(ctx context.Context) (entries []clus
 	}
 	s.mu.Unlock()
 
-	// singleflight collapses a concurrent stampede onto one refresh whose
-	// result is shared with every waiter. The shared fetch runs under its own
-	// detached, budget-bounded context (not this caller's ctx) so one caller
-	// disconnecting doesn't cancel the fetch for the others; each caller still
-	// honors its own ctx via the select below.
-	ch := s.group.DoChan("roster", func() (interface{}, error) {
-		fetchCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), hmmRosterFetchTimeout)
+	// singleflight collapses concurrent callers onto one refresh; the shared
+	// fetch runs under a detached context so a cancelling caller doesn't abort
+	// others. Each caller honors its own ctx via the select below.
+	ch := s.group.DoChan("roster", func() (any, error) {
+		fetchCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), s.fetchTimeout)
 		defer cancel()
 		return s.refresh(fetchCtx)
 	})
@@ -91,11 +82,8 @@ func (s *hmmRosterSource) HMMDeployedModels(ctx context.Context) (entries []clus
 	}
 }
 
-// refresh fetches the roster from the sidecar and updates the cache. On
-// failure it serves the prior snapshot (extending fetchedAt by the backoff so
-// the next refresh doesn't immediately re-hit a failing sidecar), or returns
-// the error when the cache is cold. Runs under singleflight, so it is the sole
-// writer for its refresh.
+// refresh fetches the roster from the sidecar and updates the cache;
+// on failure with a prior snapshot backs off rather than erroring.
 func (s *hmmRosterSource) refresh(ctx context.Context) ([]cluster.DeployedEntry, error) {
 	rosterIDs, fetchErr := s.fetch.Roster(ctx)
 	if fetchErr != nil {

--- a/cmd/router/hmm_roster_source.go
+++ b/cmd/router/hmm_roster_source.go
@@ -13,6 +13,11 @@ import (
 // deployed-models cache; the HMM roster only changes on a bandit-state swap.
 const hmmRosterTTL = 5 * time.Minute
 
+// hmmRosterRetryBackoff caps how often a failing refresh re-hits the sidecar
+// while stale data is being served. Without it, every reader after TTL expiry
+// would re-enter the slow failing fetch during a sidecar outage.
+const hmmRosterRetryBackoff = 30 * time.Second
+
 // rosterFetcher is the subset of the policy sidecar client the roster source
 // needs; satisfied by *policyclient.Client.
 type rosterFetcher interface {
@@ -35,27 +40,39 @@ func newHMMRosterSource(fetch rosterFetcher) *hmmRosterSource {
 }
 
 // HMMDeployedModels returns the models the HMM strategy routes across, mapped
-// from the sidecar roster arms to catalog {model, provider} entries.
+// from the sidecar roster arms to catalog {model, provider} entries. The lock
+// is not held across the sidecar fetch, so concurrent readers don't serialize
+// behind one slow call; a post-expiry fetch failure serves stale data and
+// backs off (hmmRosterRetryBackoff) so an outage doesn't re-hit the failing
+// sidecar on every request.
 func (s *hmmRosterSource) HMMDeployedModels(ctx context.Context) (entries []cluster.DeployedEntry, err error) {
 	s.mu.Lock()
-	defer s.mu.Unlock()
-
 	if s.haveCache && time.Since(s.fetchedAt) < hmmRosterTTL {
-		return cloneDeployedEntries(s.cached), nil
+		cached := cloneDeployedEntries(s.cached)
+		s.mu.Unlock()
+		return cached, nil
 	}
+	s.mu.Unlock()
 
 	rosterIDs, fetchErr := s.fetch.Roster(ctx)
 	if fetchErr != nil {
+		s.mu.Lock()
+		defer s.mu.Unlock()
 		if s.haveCache {
+			// Keep serving stale, but treat it as fresh for a short backoff so
+			// the next reader doesn't immediately re-enter this failing fetch.
+			s.fetchedAt = time.Now().Add(hmmRosterRetryBackoff - hmmRosterTTL)
 			return cloneDeployedEntries(s.cached), nil
 		}
 		return nil, fetchErr
 	}
 
 	mapped := hmm.DeployedModelsForRosterIDs(rosterIDs)
+	s.mu.Lock()
 	s.cached = mapped
 	s.fetchedAt = time.Now()
 	s.haveCache = true
+	s.mu.Unlock()
 	return cloneDeployedEntries(mapped), nil
 }
 

--- a/cmd/router/hmm_roster_source.go
+++ b/cmd/router/hmm_roster_source.go
@@ -7,6 +7,7 @@ import (
 
 	"golang.org/x/sync/singleflight"
 
+	"workweave/router/internal/policyclient"
 	"workweave/router/internal/router/cluster"
 	"workweave/router/internal/router/hmm"
 )
@@ -19,6 +20,12 @@ const hmmRosterTTL = 5 * time.Minute
 // while stale data is being served. Without it, every reader after TTL expiry
 // would re-enter the slow failing fetch during a sidecar outage.
 const hmmRosterRetryBackoff = 30 * time.Second
+
+// hmmRosterFetchTimeout bounds the detached shared roster fetch. It matches
+// the sidecar client's own per-call budget; the shared fetch runs under this
+// rather than any single caller's request context so one caller cancelling
+// doesn't abort the refresh for the others.
+const hmmRosterFetchTimeout = policyclient.DefaultTimeout
 
 // rosterFetcher is the subset of the policy sidecar client the roster source
 // needs; satisfied by *policyclient.Client.
@@ -62,16 +69,26 @@ func (s *hmmRosterSource) HMMDeployedModels(ctx context.Context) (entries []clus
 	}
 	s.mu.Unlock()
 
-	// singleflight collapses a concurrent stampede onto one refresh. The
-	// shared result is returned to every waiter; only that one goroutine
-	// touches the cache, so there is no clobber race in either outcome.
-	result, refreshErr, _ := s.group.Do("roster", func() (interface{}, error) {
-		return s.refresh(ctx)
+	// singleflight collapses a concurrent stampede onto one refresh whose
+	// result is shared with every waiter. The shared fetch runs under its own
+	// detached, budget-bounded context (not this caller's ctx) so one caller
+	// disconnecting doesn't cancel the fetch for the others; each caller still
+	// honors its own ctx via the select below.
+	ch := s.group.DoChan("roster", func() (interface{}, error) {
+		fetchCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), hmmRosterFetchTimeout)
+		defer cancel()
+		return s.refresh(fetchCtx)
 	})
-	if refreshErr != nil {
-		return nil, refreshErr
+
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case res := <-ch:
+		if res.Err != nil {
+			return nil, res.Err
+		}
+		return cloneDeployedEntries(res.Val.([]cluster.DeployedEntry)), nil
 	}
-	return cloneDeployedEntries(result.([]cluster.DeployedEntry)), nil
 }
 
 // refresh fetches the roster from the sidecar and updates the cache. On

--- a/cmd/router/hmm_roster_source.go
+++ b/cmd/router/hmm_roster_source.go
@@ -35,16 +35,19 @@ type hmmRosterSource struct {
 	haveCache bool
 }
 
+// newHMMRosterSource initializes the cached HMM roster source. The caller
+// must ensure the registered catalogModelsTimeout exceeds the sidecar client
+// budget (policyclient.DefaultTimeout or ROUTER_HMM_SIDECAR_TIMEOUT_MS),
+// otherwise a cold/expired cache is cancelled before the roster returns.
 func newHMMRosterSource(fetch rosterFetcher) *hmmRosterSource {
 	return &hmmRosterSource{fetch: fetch}
 }
 
-// HMMDeployedModels returns the models the HMM strategy routes across, mapped
-// from the sidecar roster arms to catalog {model, provider} entries. The lock
-// is not held across the sidecar fetch, so concurrent readers don't serialize
-// behind one slow call; a post-expiry fetch failure serves stale data and
-// backs off (hmmRosterRetryBackoff) so an outage doesn't re-hit the failing
-// sidecar on every request.
+// HMMDeployedModels returns catalog entries for the HMM roster. The lock is
+// not held across the sidecar fetch so concurrent callers don't serialize;
+// a failed refresh with a prior snapshot serves stale + backs off so an
+// outage doesn't hammer the sidecar on every request. A racing successful
+// fetch is preserved — it cannot be overwritten by a slower failing fetch.
 func (s *hmmRosterSource) HMMDeployedModels(ctx context.Context) (entries []cluster.DeployedEntry, err error) {
 	s.mu.Lock()
 	if s.haveCache && time.Since(s.fetchedAt) < hmmRosterTTL {
@@ -52,6 +55,11 @@ func (s *hmmRosterSource) HMMDeployedModels(ctx context.Context) (entries []clus
 		s.mu.Unlock()
 		return cached, nil
 	}
+	// Mark stale so a concurrent caller knows a fetch is in flight and
+	// doesn't re-dispatch — a fresh fetch sets this back to now(), and a
+	// failing fetch sets the backoff watermark.
+	fetching := time.Now()
+	s.fetchedAt = fetching
 	s.mu.Unlock()
 
 	rosterIDs, fetchErr := s.fetch.Roster(ctx)
@@ -59,9 +67,13 @@ func (s *hmmRosterSource) HMMDeployedModels(ctx context.Context) (entries []clus
 		s.mu.Lock()
 		defer s.mu.Unlock()
 		if s.haveCache {
-			// Keep serving stale, but treat it as fresh for a short backoff so
-			// the next reader doesn't immediately re-enter this failing fetch.
-			s.fetchedAt = time.Now().Add(hmmRosterRetryBackoff - hmmRosterTTL)
+			// A concurrent refresh that finished while this fetch was in
+			// flight already set fetchedAt to a real timestamp. Only
+			// back off if our stale marker is still the value there —
+			// otherwise a slow failure would clobber the winner.
+			if s.fetchedAt.Equal(fetching) {
+				s.fetchedAt = time.Now().Add(hmmRosterRetryBackoff - hmmRosterTTL)
+			}
 			return cloneDeployedEntries(s.cached), nil
 		}
 		return nil, fetchErr

--- a/cmd/router/hmm_roster_source.go
+++ b/cmd/router/hmm_roster_source.go
@@ -5,6 +5,8 @@ import (
 	"sync"
 	"time"
 
+	"golang.org/x/sync/singleflight"
+
 	"workweave/router/internal/router/cluster"
 	"workweave/router/internal/router/hmm"
 )
@@ -29,6 +31,12 @@ type rosterFetcher interface {
 type hmmRosterSource struct {
 	fetch rosterFetcher
 
+	// group collapses concurrent refreshes into a single sidecar call, so a
+	// stampede (including a cold cache) never fans out and there is exactly
+	// one writer per refresh — no marker juggling to protect against a slow
+	// fetch clobbering a newer one.
+	group singleflight.Group
+
 	mu        sync.Mutex
 	cached    []cluster.DeployedEntry
 	fetchedAt time.Time
@@ -40,11 +48,11 @@ func newHMMRosterSource(fetch rosterFetcher) *hmmRosterSource {
 	return &hmmRosterSource{fetch: fetch}
 }
 
-// HMMDeployedModels returns catalog entries for the HMM roster. The lock is
-// not held across the fetch so concurrent callers don't serialize; a failing
-// refresh with a prior snapshot serves stale and backs off. Neither the
-// success nor the failure write-back can clobber a concurrent winner: both
-// commit only while our in-flight marker is still the current fetchedAt.
+// HMMDeployedModels returns catalog entries for the HMM roster. A fresh cache
+// is served without any fetch; otherwise concurrent callers collapse onto one
+// sidecar refresh (singleflight). A failing refresh with a prior snapshot
+// serves stale and backs off so an outage doesn't hammer the sidecar; a
+// failing refresh with no snapshot surfaces the error.
 func (s *hmmRosterSource) HMMDeployedModels(ctx context.Context) (entries []cluster.DeployedEntry, err error) {
 	s.mu.Lock()
 	if s.haveCache && time.Since(s.fetchedAt) < hmmRosterTTL {
@@ -52,25 +60,32 @@ func (s *hmmRosterSource) HMMDeployedModels(ctx context.Context) (entries []clus
 		s.mu.Unlock()
 		return cached, nil
 	}
-	// Mark stale so a concurrent caller knows a fetch is in flight and
-	// doesn't re-dispatch — a fresh fetch sets this back to now(), and a
-	// failing fetch sets the backoff watermark.
-	fetching := time.Now()
-	s.fetchedAt = fetching
 	s.mu.Unlock()
 
+	// singleflight collapses a concurrent stampede onto one refresh. The
+	// shared result is returned to every waiter; only that one goroutine
+	// touches the cache, so there is no clobber race in either outcome.
+	result, refreshErr, _ := s.group.Do("roster", func() (interface{}, error) {
+		return s.refresh(ctx)
+	})
+	if refreshErr != nil {
+		return nil, refreshErr
+	}
+	return cloneDeployedEntries(result.([]cluster.DeployedEntry)), nil
+}
+
+// refresh fetches the roster from the sidecar and updates the cache. On
+// failure it serves the prior snapshot (extending fetchedAt by the backoff so
+// the next refresh doesn't immediately re-hit a failing sidecar), or returns
+// the error when the cache is cold. Runs under singleflight, so it is the sole
+// writer for its refresh.
+func (s *hmmRosterSource) refresh(ctx context.Context) ([]cluster.DeployedEntry, error) {
 	rosterIDs, fetchErr := s.fetch.Roster(ctx)
 	if fetchErr != nil {
 		s.mu.Lock()
 		defer s.mu.Unlock()
 		if s.haveCache {
-			// A concurrent refresh that finished while this fetch was in
-			// flight already set fetchedAt to a real timestamp. Only
-			// back off if our stale marker is still the value there —
-			// otherwise a slow failure would clobber the winner.
-			if s.fetchedAt.Equal(fetching) {
-				s.fetchedAt = time.Now().Add(hmmRosterRetryBackoff - hmmRosterTTL)
-			}
+			s.fetchedAt = time.Now().Add(hmmRosterRetryBackoff - hmmRosterTTL)
 			return cloneDeployedEntries(s.cached), nil
 		}
 		return nil, fetchErr
@@ -78,16 +93,11 @@ func (s *hmmRosterSource) HMMDeployedModels(ctx context.Context) (entries []clus
 
 	mapped := hmm.DeployedModelsForRosterIDs(rosterIDs)
 	s.mu.Lock()
-	// Same guard as the failure path: only commit if no concurrent refresh
-	// has updated the cache since we marked it in flight, so a slower success
-	// can't overwrite a newer winner. Either snapshot is valid to return.
-	if s.fetchedAt.Equal(fetching) {
-		s.cached = mapped
-		s.fetchedAt = time.Now()
-		s.haveCache = true
-	}
+	s.cached = mapped
+	s.fetchedAt = time.Now()
+	s.haveCache = true
 	s.mu.Unlock()
-	return cloneDeployedEntries(mapped), nil
+	return mapped, nil
 }
 
 func cloneDeployedEntries(in []cluster.DeployedEntry) []cluster.DeployedEntry {

--- a/cmd/router/hmm_roster_source_test.go
+++ b/cmd/router/hmm_roster_source_test.go
@@ -9,6 +9,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"workweave/router/internal/router/cluster"
 )
 
 type stubRosterFetcher struct {
@@ -76,6 +78,46 @@ func TestHMMRosterSource_ErrorsWhenNoSnapshot(t *testing.T) {
 
 	_, err := src.HMMDeployedModels(context.Background())
 	require.Error(t, err)
+}
+
+func TestHMMRosterSource_CallerCancelDoesNotAbortSharedFetch(t *testing.T) {
+	// One caller cancels while the shared cold-start fetch is in flight; a
+	// concurrent caller with a live context must still get the roster (the
+	// shared fetch runs under a detached context, not the canceller's).
+	fetch := &stubRosterFetcher{
+		ids:     []string{"openai/gpt-5.6-sol"},
+		gate:    make(chan struct{}),
+		entered: make(chan struct{}, 2),
+	}
+	src := newHMMRosterSource(fetch)
+
+	cancelCtx, cancel := context.WithCancel(context.Background())
+	var wg sync.WaitGroup
+	var liveEntries []cluster.DeployedEntry
+	var liveErr error
+
+	wg.Add(2)
+	// Caller A: will be cancelled mid-fetch.
+	go func() {
+		defer wg.Done()
+		_, _ = src.HMMDeployedModels(cancelCtx)
+	}()
+	// Caller B: live context, must receive the roster.
+	go func() {
+		defer wg.Done()
+		liveEntries, liveErr = src.HMMDeployedModels(context.Background())
+	}()
+
+	// Wait until the (single) shared fetch is in flight, cancel caller A, then
+	// release the fetch. Caller B must still succeed.
+	<-fetch.entered
+	cancel()
+	close(fetch.gate)
+	wg.Wait()
+
+	require.NoError(t, liveErr, "a live-context caller must not inherit another caller's cancellation")
+	require.Len(t, liveEntries, 1)
+	assert.Equal(t, "gpt-5.6-sol", liveEntries[0].Model)
 }
 
 func TestHMMRosterSource_ColdStartStampedeCollapsesToOneFetch(t *testing.T) {

--- a/cmd/router/hmm_roster_source_test.go
+++ b/cmd/router/hmm_roster_source_test.go
@@ -51,6 +51,13 @@ func TestHMMRosterSource_ServesStaleOnFetchFailure(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, stale, 1)
 	assert.Equal(t, "gpt-5.6-sol", stale[0].Model)
+
+	callsAfterFailure := fetch.calls
+	// Within the backoff window the next reader serves stale without re-hitting
+	// the failing sidecar.
+	_, err = src.HMMDeployedModels(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, callsAfterFailure, fetch.calls, "backoff must suppress re-fetch during an outage")
 }
 
 func TestHMMRosterSource_ErrorsWhenNoSnapshot(t *testing.T) {

--- a/cmd/router/hmm_roster_source_test.go
+++ b/cmd/router/hmm_roster_source_test.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type stubRosterFetcher struct {
+	ids   []string
+	err   error
+	calls int
+}
+
+func (s *stubRosterFetcher) Roster(context.Context) ([]string, error) {
+	s.calls++
+	return s.ids, s.err
+}
+
+func TestHMMRosterSource_MapsAndCaches(t *testing.T) {
+	fetch := &stubRosterFetcher{ids: []string{"openai/gpt-5.6-sol"}}
+	src := newHMMRosterSource(fetch)
+
+	first, err := src.HMMDeployedModels(context.Background())
+	require.NoError(t, err)
+	require.Len(t, first, 1)
+	assert.Equal(t, "gpt-5.6-sol", first[0].Model)
+
+	// Second call inside the TTL window must not re-hit the sidecar.
+	second, err := src.HMMDeployedModels(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, first, second)
+	assert.Equal(t, 1, fetch.calls)
+}
+
+func TestHMMRosterSource_ServesStaleOnFetchFailure(t *testing.T) {
+	fetch := &stubRosterFetcher{ids: []string{"openai/gpt-5.6-sol"}}
+	src := newHMMRosterSource(fetch)
+
+	_, err := src.HMMDeployedModels(context.Background())
+	require.NoError(t, err)
+
+	// Force the cache stale, then fail the refresh: the prior snapshot survives.
+	src.fetchedAt = src.fetchedAt.Add(-2 * hmmRosterTTL)
+	fetch.err = errors.New("sidecar down")
+
+	stale, err := src.HMMDeployedModels(context.Background())
+	require.NoError(t, err)
+	require.Len(t, stale, 1)
+	assert.Equal(t, "gpt-5.6-sol", stale[0].Model)
+}
+
+func TestHMMRosterSource_ErrorsWhenNoSnapshot(t *testing.T) {
+	fetch := &stubRosterFetcher{err: errors.New("sidecar down")}
+	src := newHMMRosterSource(fetch)
+
+	_, err := src.HMMDeployedModels(context.Background())
+	require.Error(t, err)
+}

--- a/cmd/router/hmm_roster_source_test.go
+++ b/cmd/router/hmm_roster_source_test.go
@@ -3,6 +3,8 @@ package main
 import (
 	"context"
 	"errors"
+	"sync"
+	"sync/atomic"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -10,13 +12,21 @@ import (
 )
 
 type stubRosterFetcher struct {
-	ids   []string
-	err   error
-	calls int
+	ids     []string
+	err     error
+	calls   atomic.Int64
+	gate    chan struct{} // if non-nil, Roster blocks until closed (forces fetch overlap)
+	entered chan struct{} // if non-nil, Roster signals once per entry before blocking
 }
 
 func (s *stubRosterFetcher) Roster(context.Context) ([]string, error) {
-	s.calls++
+	s.calls.Add(1)
+	if s.entered != nil {
+		s.entered <- struct{}{}
+	}
+	if s.gate != nil {
+		<-s.gate
+	}
 	return s.ids, s.err
 }
 
@@ -33,7 +43,7 @@ func TestHMMRosterSource_MapsAndCaches(t *testing.T) {
 	second, err := src.HMMDeployedModels(context.Background())
 	require.NoError(t, err)
 	assert.Equal(t, first, second)
-	assert.Equal(t, 1, fetch.calls)
+	assert.Equal(t, int64(1), fetch.calls.Load())
 }
 
 func TestHMMRosterSource_ServesStaleOnFetchFailure(t *testing.T) {
@@ -52,12 +62,12 @@ func TestHMMRosterSource_ServesStaleOnFetchFailure(t *testing.T) {
 	require.Len(t, stale, 1)
 	assert.Equal(t, "gpt-5.6-sol", stale[0].Model)
 
-	callsAfterFailure := fetch.calls
+	callsAfterFailure := fetch.calls.Load()
 	// Within the backoff window the next reader serves stale without re-hitting
 	// the failing sidecar.
 	_, err = src.HMMDeployedModels(context.Background())
 	require.NoError(t, err)
-	assert.Equal(t, callsAfterFailure, fetch.calls, "backoff must suppress re-fetch during an outage")
+	assert.Equal(t, callsAfterFailure, fetch.calls.Load(), "backoff must suppress re-fetch during an outage")
 }
 
 func TestHMMRosterSource_ErrorsWhenNoSnapshot(t *testing.T) {
@@ -66,4 +76,45 @@ func TestHMMRosterSource_ErrorsWhenNoSnapshot(t *testing.T) {
 
 	_, err := src.HMMDeployedModels(context.Background())
 	require.Error(t, err)
+}
+
+func TestHMMRosterSource_ColdStartStampedeCollapsesToOneFetch(t *testing.T) {
+	// Cold cache + concurrent callers: singleflight collapses them onto one
+	// sidecar fetch, and every caller gets the successfully-fetched roster
+	// (no caller 503s because a sibling's fetch "won"). The gate forces the
+	// callers to overlap before the fetch returns.
+	const callers = 8
+	fetch := &stubRosterFetcher{
+		ids:     []string{"openai/gpt-5.6-sol"},
+		gate:    make(chan struct{}),
+		entered: make(chan struct{}, callers),
+	}
+	src := newHMMRosterSource(fetch)
+
+	var wg sync.WaitGroup
+	results := make([][]string, callers)
+	errs := make([]error, callers)
+	for i := range callers {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			entries, err := src.HMMDeployedModels(context.Background())
+			errs[idx] = err
+			for _, e := range entries {
+				results[idx] = append(results[idx], e.Model)
+			}
+		}(i)
+	}
+
+	// Let at least one fetch enter, then release the gate so the collapsed
+	// call returns to every waiter.
+	<-fetch.entered
+	close(fetch.gate)
+	wg.Wait()
+
+	for i := range callers {
+		require.NoErrorf(t, errs[i], "caller %d must not 503 on a successful cold-start fetch", i)
+		assert.Equalf(t, []string{"gpt-5.6-sol"}, results[i], "caller %d got the wrong roster", i)
+	}
+	assert.LessOrEqual(t, fetch.calls.Load(), int64(2), "stampede must collapse to ~one sidecar fetch")
 }

--- a/cmd/router/hmm_roster_source_test.go
+++ b/cmd/router/hmm_roster_source_test.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -14,15 +15,20 @@ import (
 )
 
 type stubRosterFetcher struct {
-	ids     []string
-	err     error
-	calls   atomic.Int64
-	gate    chan struct{} // if non-nil, Roster blocks until closed (forces fetch overlap)
-	entered chan struct{} // if non-nil, Roster signals once per entry before blocking
+	ids      []string
+	err      error
+	calls    atomic.Int64
+	gate     chan struct{} // if non-nil, Roster blocks until closed (forces fetch overlap)
+	entered  chan struct{} // if non-nil, Roster signals once per entry before blocking
+	deadline chan time.Time
 }
 
-func (s *stubRosterFetcher) Roster(context.Context) ([]string, error) {
+func (s *stubRosterFetcher) Roster(ctx context.Context) ([]string, error) {
 	s.calls.Add(1)
+	if s.deadline != nil {
+		deadline, _ := ctx.Deadline()
+		s.deadline <- deadline
+	}
 	if s.entered != nil {
 		s.entered <- struct{}{}
 	}
@@ -34,7 +40,7 @@ func (s *stubRosterFetcher) Roster(context.Context) ([]string, error) {
 
 func TestHMMRosterSource_MapsAndCaches(t *testing.T) {
 	fetch := &stubRosterFetcher{ids: []string{"openai/gpt-5.6-sol"}}
-	src := newHMMRosterSource(fetch)
+	src := newHMMRosterSource(fetch, 0)
 
 	first, err := src.HMMDeployedModels(context.Background())
 	require.NoError(t, err)
@@ -48,9 +54,26 @@ func TestHMMRosterSource_MapsAndCaches(t *testing.T) {
 	assert.Equal(t, int64(1), fetch.calls.Load())
 }
 
+func TestHMMRosterSource_UsesConfiguredFetchTimeout(t *testing.T) {
+	const fetchTimeout = 10 * time.Second
+	fetch := &stubRosterFetcher{
+		ids:      []string{"openai/gpt-5.6-sol"},
+		deadline: make(chan time.Time, 1),
+	}
+	src := newHMMRosterSource(fetch, fetchTimeout)
+
+	startedAt := time.Now()
+	_, err := src.HMMDeployedModels(context.Background())
+	require.NoError(t, err)
+
+	deadline := <-fetch.deadline
+	assert.Greater(t, deadline.Sub(startedAt), 9*time.Second)
+	assert.Less(t, deadline.Sub(startedAt), 11*time.Second)
+}
+
 func TestHMMRosterSource_ServesStaleOnFetchFailure(t *testing.T) {
 	fetch := &stubRosterFetcher{ids: []string{"openai/gpt-5.6-sol"}}
-	src := newHMMRosterSource(fetch)
+	src := newHMMRosterSource(fetch, 0)
 
 	_, err := src.HMMDeployedModels(context.Background())
 	require.NoError(t, err)
@@ -74,22 +97,21 @@ func TestHMMRosterSource_ServesStaleOnFetchFailure(t *testing.T) {
 
 func TestHMMRosterSource_ErrorsWhenNoSnapshot(t *testing.T) {
 	fetch := &stubRosterFetcher{err: errors.New("sidecar down")}
-	src := newHMMRosterSource(fetch)
+	src := newHMMRosterSource(fetch, 0)
 
 	_, err := src.HMMDeployedModels(context.Background())
 	require.Error(t, err)
 }
 
 func TestHMMRosterSource_CallerCancelDoesNotAbortSharedFetch(t *testing.T) {
-	// One caller cancels while the shared cold-start fetch is in flight; a
-	// concurrent caller with a live context must still get the roster (the
-	// shared fetch runs under a detached context, not the canceller's).
+	// One caller cancels mid-fetch; the concurrent live-context caller must
+	// still get the roster because the shared fetch runs under a detached context.
 	fetch := &stubRosterFetcher{
 		ids:     []string{"openai/gpt-5.6-sol"},
 		gate:    make(chan struct{}),
 		entered: make(chan struct{}, 2),
 	}
-	src := newHMMRosterSource(fetch)
+	src := newHMMRosterSource(fetch, 0)
 
 	cancelCtx, cancel := context.WithCancel(context.Background())
 	var wg sync.WaitGroup
@@ -121,17 +143,15 @@ func TestHMMRosterSource_CallerCancelDoesNotAbortSharedFetch(t *testing.T) {
 }
 
 func TestHMMRosterSource_ColdStartStampedeCollapsesToOneFetch(t *testing.T) {
-	// Cold cache + concurrent callers: singleflight collapses them onto one
-	// sidecar fetch, and every caller gets the successfully-fetched roster
-	// (no caller 503s because a sibling's fetch "won"). The gate forces the
-	// callers to overlap before the fetch returns.
+	// Cold cache + concurrent callers: singleflight collapses to one fetch;
+	// every caller must succeed — no 503 because a sibling's fetch "won".
 	const callers = 8
 	fetch := &stubRosterFetcher{
 		ids:     []string{"openai/gpt-5.6-sol"},
 		gate:    make(chan struct{}),
 		entered: make(chan struct{}, callers),
 	}
-	src := newHMMRosterSource(fetch)
+	src := newHMMRosterSource(fetch, 0)
 
 	var wg sync.WaitGroup
 	results := make([][]string, callers)

--- a/cmd/router/main.go
+++ b/cmd/router/main.go
@@ -607,6 +607,7 @@ func main() {
 	var hmmEmbeddingRouter router.Router
 	var hmmCapabilities policy.Capabilities
 	var hmmReadinessChecker admin.HealthChecker
+	var hmmRosterModels admin.HMMRosterSource
 	if hmmSidecarURL := config.GetOr("ROUTER_HMM_SIDECAR_URL", ""); hmmSidecarURL != "" {
 		hmmTimeout := parseEnvDurationMs("ROUTER_HMM_SIDECAR_TIMEOUT_MS", policyclient.DefaultTimeout)
 		hmmAuthMode := config.GetOr("ROUTER_HMM_SIDECAR_AUTH", policySidecarAuthNone)
@@ -616,6 +617,7 @@ func main() {
 			panic(clientErr)
 		}
 		hmmReadinessChecker = hmmClient
+		hmmRosterModels = newHMMRosterSource(hmmClient)
 		capabilityCtx, cancelCapabilityDiscovery := context.WithTimeout(context.Background(), hmmTimeout)
 		var capabilityErr error
 		hmmCapabilities, capabilityErr = hmmClient.Capabilities(capabilityCtx)
@@ -851,7 +853,7 @@ func main() {
 	// Lets the admin model-selection handler surface deployed models; nil
 	// fallback keeps non-cluster routers bootable.
 	deployedModels, _ := rtr.(*cluster.Multiversion)
-	server.Register(engine, authSvc, proxySvc, deployedModels, deploymentMode, billingSvc, hmmReadinessChecker)
+	server.Register(engine, authSvc, proxySvc, deployedModels, hmmRosterModels, deploymentMode, billingSvc, hmmReadinessChecker)
 
 	srv := &http.Server{
 		Addr:    ":" + config.GetOr("PORT", "8080"),

--- a/cmd/router/main.go
+++ b/cmd/router/main.go
@@ -617,7 +617,7 @@ func main() {
 			panic(clientErr)
 		}
 		hmmReadinessChecker = hmmClient
-		hmmRosterModels = newHMMRosterSource(hmmClient)
+		hmmRosterModels = newHMMRosterSource(hmmClient, hmmTimeout)
 		capabilityCtx, cancelCapabilityDiscovery := context.WithTimeout(context.Background(), hmmTimeout)
 		var capabilityErr error
 		hmmCapabilities, capabilityErr = hmmClient.Capabilities(capabilityCtx)

--- a/go.mod
+++ b/go.mod
@@ -27,9 +27,11 @@ require (
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v1.43.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.43.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.43.0
+	go.opentelemetry.io/otel/metric v1.43.0
 	go.opentelemetry.io/otel/sdk v1.43.0
 	go.opentelemetry.io/otel/sdk/metric v1.43.0
 	go.opentelemetry.io/proto/otlp v1.10.0
+	golang.org/x/sync v0.20.0
 	golang.org/x/text v0.37.0
 	google.golang.org/protobuf v1.36.11
 	gopkg.in/yaml.v3 v3.0.1
@@ -92,7 +94,6 @@ require (
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.61.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.61.0 // indirect
-	go.opentelemetry.io/otel/metric v1.43.0 // indirect
 	go.opentelemetry.io/otel/trace v1.43.0 // indirect
 	golang.org/x/arch v0.17.0 // indirect
 	golang.org/x/crypto v0.51.0 // indirect
@@ -100,7 +101,6 @@ require (
 	golang.org/x/image v0.38.0 // indirect
 	golang.org/x/net v0.55.0 // indirect
 	golang.org/x/oauth2 v0.36.0 // indirect
-	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/sys v0.45.0 // indirect
 	golang.org/x/term v0.43.0 // indirect
 	golang.org/x/time v0.15.0 // indirect

--- a/internal/api/admin/catalog.go
+++ b/internal/api/admin/catalog.go
@@ -1,7 +1,13 @@
 package admin
 
 import (
+	"context"
 	"net/http"
+	"strings"
+
+	"workweave/router/internal/observability"
+	"workweave/router/internal/router"
+	"workweave/router/internal/router/cluster"
 
 	"github.com/gin-gonic/gin"
 )
@@ -13,15 +19,43 @@ type CatalogModelsResponse struct {
 	Models []deployedModelDTO `json:"models"`
 }
 
-// CatalogModelsHandler returns the deployed-models catalog for the active
-// cluster artifact. Read-only, unauthed metadata — mounted in both selfhosted
+// HMMRosterSource exposes the models the HMM policy strategy actually routes
+// across (the sidecar roster arms mapped to catalog entries), which differs
+// from the cluster artifact's registry that DeployedModelsSource reports.
+type HMMRosterSource interface {
+	HMMDeployedModels(ctx context.Context) ([]cluster.DeployedEntry, error)
+}
+
+// CatalogModelsHandler returns the deployed-models catalog for the caller's
+// routing strategy. Read-only, unauthed metadata — mounted in both selfhosted
 // and managed deployment modes so the Weave control plane (which is the only
 // caller in managed mode) can fetch it without juggling router API keys.
 //
+// Without a ?strategy= query (or for the cluster strategy) it returns the
+// active cluster artifact's registry. For an HMM strategy it returns the HMM
+// roster from hmmModels; the control plane passes the org's effective strategy
+// so the settings UI shows the roster that actually serves that org. hmmModels
+// may be nil (HMM not wired) — then HMM requests fall back to the cluster list.
+//
 // The list is publicly known (we publish per-version model registries on the
 // RouterArena leaderboard) so there is no leak risk from leaving this open.
-func CatalogModelsHandler(models DeployedModelsSource) gin.HandlerFunc {
+func CatalogModelsHandler(models DeployedModelsSource, hmmModels HMMRosterSource) gin.HandlerFunc {
 	return func(c *gin.Context) {
+		strategy := router.Strategy(strings.ToLower(strings.TrimSpace(c.Query("strategy"))))
+		if router.IsHMMStrategy(strategy) && hmmModels != nil {
+			entries, err := hmmModels.HMMDeployedModels(c.Request.Context())
+			if err != nil {
+				observability.FromGin(c).Error(
+					"Failed to fetch HMM roster for deployed-models endpoint",
+					"err", err,
+					"strategy", string(strategy),
+				)
+				c.JSON(http.StatusServiceUnavailable, gin.H{"error": "hmm roster unavailable"})
+				return
+			}
+			c.JSON(http.StatusOK, CatalogModelsResponse{Models: entriesToDTO(entries)})
+			return
+		}
 		c.JSON(http.StatusOK, CatalogModelsResponse{Models: deployedModelsDTO(models)})
 	}
 }

--- a/internal/api/admin/catalog.go
+++ b/internal/api/admin/catalog.go
@@ -31,8 +31,10 @@ type HMMRosterSource interface {
 // and managed deployment modes so the Weave control plane (which is the only
 // caller in managed mode) can fetch it without juggling router API keys.
 //
-// Without a ?strategy= query (or for the cluster strategy) it returns the
-	// For ?strategy=hmm* returns the HMM sidecar roster; nil hmmModels falls back to the cluster list.
+// Without a ?strategy= query (or the cluster strategy) it returns the cluster
+// artifact's registry. For an HMM strategy it returns the HMM sidecar roster;
+// a nil hmmModels (HMM not wired) falls back to the cluster list.
+//
 // The list is publicly known (we publish per-version model registries on the
 // RouterArena leaderboard) so there is no leak risk from leaving this open.
 func CatalogModelsHandler(models DeployedModelsSource, hmmModels HMMRosterSource) gin.HandlerFunc {

--- a/internal/api/admin/catalog.go
+++ b/internal/api/admin/catalog.go
@@ -19,21 +19,16 @@ type CatalogModelsResponse struct {
 	Models []deployedModelDTO `json:"models"`
 }
 
-// HMMRosterSource exposes the models the HMM policy strategy actually routes
-// across (the sidecar roster arms mapped to catalog entries), which differs
-// from the cluster artifact's registry that DeployedModelsSource reports.
+// HMMRosterSource exposes the HMM sidecar roster arms as catalog entries;
+// its roster differs from the cluster artifact's DeployedModelsSource.
 type HMMRosterSource interface {
 	HMMDeployedModels(ctx context.Context) ([]cluster.DeployedEntry, error)
 }
 
 // CatalogModelsHandler returns the deployed-models catalog for the caller's
 // routing strategy. Read-only, unauthed metadata — mounted in both selfhosted
-// and managed deployment modes so the Weave control plane (which is the only
-// caller in managed mode) can fetch it without juggling router API keys.
-//
-// Without a ?strategy= query (or the cluster strategy) it returns the cluster
-// artifact's registry. For an HMM strategy it returns the HMM sidecar roster;
-// a nil hmmModels (HMM not wired) falls back to the cluster list.
+// and managed modes. For ?strategy=hmm* returns the HMM sidecar roster;
+// nil hmmModels falls back to the cluster list.
 //
 // The list is publicly known (we publish per-version model registries on the
 // RouterArena leaderboard) so there is no leak risk from leaving this open.

--- a/internal/api/admin/catalog.go
+++ b/internal/api/admin/catalog.go
@@ -32,11 +32,7 @@ type HMMRosterSource interface {
 // caller in managed mode) can fetch it without juggling router API keys.
 //
 // Without a ?strategy= query (or for the cluster strategy) it returns the
-// active cluster artifact's registry. For an HMM strategy it returns the HMM
-// roster from hmmModels; the control plane passes the org's effective strategy
-// so the settings UI shows the roster that actually serves that org. hmmModels
-// may be nil (HMM not wired) — then HMM requests fall back to the cluster list.
-//
+	// For ?strategy=hmm* returns the HMM sidecar roster; nil hmmModels falls back to the cluster list.
 // The list is publicly known (we publish per-version model registries on the
 // RouterArena leaderboard) so there is no leak risk from leaving this open.
 func CatalogModelsHandler(models DeployedModelsSource, hmmModels HMMRosterSource) gin.HandlerFunc {

--- a/internal/api/admin/catalog_test.go
+++ b/internal/api/admin/catalog_test.go
@@ -1,7 +1,9 @@
 package admin_test
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -32,7 +34,7 @@ func TestCatalogModelsHandler_SortsByProviderThenModel(t *testing.T) {
 	}}
 
 	engine := gin.New()
-	engine.GET("/v1/router/models", admin.CatalogModelsHandler(src))
+	engine.GET("/v1/router/models", admin.CatalogModelsHandler(src, nil))
 
 	req := httptest.NewRequest(http.MethodGet, "/v1/router/models", nil)
 	rec := httptest.NewRecorder()
@@ -58,7 +60,7 @@ func TestCatalogModelsHandler_EmptyListReturnsEmptyArray(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
 	engine := gin.New()
-	engine.GET("/v1/router/models", admin.CatalogModelsHandler(fakeDeployedModels{}))
+	engine.GET("/v1/router/models", admin.CatalogModelsHandler(fakeDeployedModels{}, nil))
 
 	req := httptest.NewRequest(http.MethodGet, "/v1/router/models", nil)
 	rec := httptest.NewRecorder()
@@ -68,4 +70,84 @@ func TestCatalogModelsHandler_EmptyListReturnsEmptyArray(t *testing.T) {
 	// Empty slice must round-trip as [], not null — the Weave control plane
 	// distinguishes "no models" from "missing field".
 	assert.JSONEq(t, `{"models":[]}`, rec.Body.String())
+}
+
+type fakeHMMRoster struct {
+	entries []cluster.DeployedEntry
+	err     error
+	calls   int
+}
+
+func (f *fakeHMMRoster) HMMDeployedModels(context.Context) ([]cluster.DeployedEntry, error) {
+	f.calls++
+	if f.err != nil {
+		return nil, f.err
+	}
+	return f.entries, nil
+}
+
+func TestCatalogModelsHandler_HMMStrategyReturnsRosterNotCluster(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	clusterSrc := fakeDeployedModels{entries: []cluster.DeployedEntry{
+		{Model: "gpt-5.5", Provider: providers.ProviderOpenAI},
+	}}
+	hmmSrc := &fakeHMMRoster{entries: []cluster.DeployedEntry{
+		{Model: "gpt-5.6-sol", Provider: providers.ProviderOpenAI},
+		{Model: "claude-opus-4-8", Provider: providers.ProviderAnthropic},
+	}}
+
+	engine := gin.New()
+	engine.GET("/v1/router/models", admin.CatalogModelsHandler(clusterSrc, hmmSrc))
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/router/models?strategy=hmm", nil)
+	rec := httptest.NewRecorder()
+	engine.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Equal(t, 1, hmmSrc.calls)
+
+	var got admin.CatalogModelsResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
+	require.Len(t, got.Models, 2)
+	// Sorted provider-then-model: anthropic first, then openai's 5.6 — and
+	// crucially the cluster's gpt-5.5 does NOT appear.
+	assert.Equal(t, "claude-opus-4-8", got.Models[0].Model)
+	assert.Equal(t, "gpt-5.6-sol", got.Models[1].Model)
+}
+
+func TestCatalogModelsHandler_HMMStrategyFallsBackToClusterWhenNoSource(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	clusterSrc := fakeDeployedModels{entries: []cluster.DeployedEntry{
+		{Model: "gpt-5.5", Provider: providers.ProviderOpenAI},
+	}}
+
+	engine := gin.New()
+	engine.GET("/v1/router/models", admin.CatalogModelsHandler(clusterSrc, nil))
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/router/models?strategy=hmm", nil)
+	rec := httptest.NewRecorder()
+	engine.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	var got admin.CatalogModelsResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
+	require.Len(t, got.Models, 1)
+	assert.Equal(t, "gpt-5.5", got.Models[0].Model)
+}
+
+func TestCatalogModelsHandler_HMMRosterErrorReturns503(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	hmmSrc := &fakeHMMRoster{err: errors.New("sidecar unavailable")}
+
+	engine := gin.New()
+	engine.GET("/v1/router/models", admin.CatalogModelsHandler(fakeDeployedModels{}, hmmSrc))
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/router/models?strategy=hmm_embedding", nil)
+	rec := httptest.NewRecorder()
+	engine.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusServiceUnavailable, rec.Code)
 }

--- a/internal/api/admin/excluded_models.go
+++ b/internal/api/admin/excluded_models.go
@@ -44,7 +44,12 @@ type updateExcludedModelsRequest struct {
 // deployedModelsDTO converts the deployed-models list to sorted DTO form,
 // centralized so the GET and PUT responses cannot drift apart.
 func deployedModelsDTO(models DeployedModelsSource) []deployedModelDTO {
-	entries := models.DefaultDeployedModels()
+	return entriesToDTO(models.DefaultDeployedModels())
+}
+
+// entriesToDTO converts deployed entries to sorted DTO form, shared by the
+// cluster source and the HMM roster source so both wire shapes stay identical.
+func entriesToDTO(entries []cluster.DeployedEntry) []deployedModelDTO {
 	out := make([]deployedModelDTO, 0, len(entries))
 	for _, e := range entries {
 		out = append(out, deployedModelDTO{Model: e.Model, Provider: e.Provider})

--- a/internal/policyclient/client.go
+++ b/internal/policyclient/client.go
@@ -114,9 +114,8 @@ type rosterResponse struct {
 	RosterIDs     []string `json:"roster_ids"`
 }
 
-// Roster fetches the union of roster arm IDs the sidecar can actually select.
-// Unlike the cluster artifact's model registry, this is the roster the HMM
-// strategy routes across, so the control plane can show it per org strategy.
+// Roster fetches roster arm IDs from the sidecar; unlike the cluster
+// artifact registry, this is the set the HMM strategy actually routes across.
 func (c *Client) Roster(ctx context.Context) ([]string, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+"/roster", nil)
 	if err != nil {

--- a/internal/policyclient/client.go
+++ b/internal/policyclient/client.go
@@ -107,6 +107,43 @@ func (c *Client) Capabilities(ctx context.Context) (policy.Capabilities, error) 
 	return capabilities, nil
 }
 
+// rosterResponse is the shape of the sidecar's GET /roster body.
+type rosterResponse struct {
+	SchemaVersion string   `json:"schema_version"`
+	RosterVersion string   `json:"roster_version"`
+	RosterIDs     []string `json:"roster_ids"`
+}
+
+// Roster fetches the union of roster arm IDs the sidecar can actually select.
+// Unlike the cluster artifact's model registry, this is the roster the HMM
+// strategy routes across, so the control plane can show it per org strategy.
+func (c *Client) Roster(ctx context.Context) ([]string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+"/roster", nil)
+	if err != nil {
+		return nil, fmt.Errorf("build policy roster request: %w", err)
+	}
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("call policy roster endpoint: %w", err)
+	}
+	defer resp.Body.Close()
+	payload, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return nil, fmt.Errorf("read policy roster response: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("policy roster status %d", resp.StatusCode)
+	}
+	var roster rosterResponse
+	if err := json.Unmarshal(payload, &roster); err != nil {
+		return nil, fmt.Errorf("decode policy roster response: %w", err)
+	}
+	if roster.SchemaVersion != policy.SchemaVersionV1 && roster.SchemaVersion != policy.SchemaVersionV2 {
+		return nil, fmt.Errorf("unsupported policy roster schema %q", roster.SchemaVersion)
+	}
+	return roster.RosterIDs, nil
+}
+
 func (c *Client) post(ctx context.Context, path string, payload map[string]interface{}, label string) error {
 	body, err := json.Marshal(payload)
 	if err != nil {

--- a/internal/policyclient/client_test.go
+++ b/internal/policyclient/client_test.go
@@ -434,6 +434,45 @@ func TestClientCapabilities(t *testing.T) {
 	}
 }
 
+func TestClientRoster(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+		require.Equal(t, "/roster", request.URL.Path)
+		_ = json.NewEncoder(w).Encode(rosterResponse{
+			SchemaVersion: policy.SchemaVersionV2,
+			RosterVersion: "abc123",
+			RosterIDs:     []string{"openai/gpt-5.6-sol", "anthropic/claude-opus-4.8"},
+		})
+	}))
+	defer server.Close()
+
+	rosterIDs, err := New(server.URL, server.Client(), 0).Roster(context.Background())
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{"openai/gpt-5.6-sol", "anthropic/claude-opus-4.8"}, rosterIDs)
+}
+
+func TestClientRosterRejectsUnknownSchema(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(rosterResponse{SchemaVersion: "v99", RosterIDs: []string{"x"}})
+	}))
+	defer server.Close()
+
+	_, err := New(server.URL, server.Client(), 0).Roster(context.Background())
+
+	require.Error(t, err)
+}
+
+func TestClientRosterPropagatesStatusError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer server.Close()
+
+	_, err := New(server.URL, server.Client(), 0).Roster(context.Background())
+
+	require.Error(t, err)
+}
+
 func TestClientCheckHealth(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
 		assert.Equal(t, http.MethodGet, request.Method)

--- a/internal/router/hmm/roster.go
+++ b/internal/router/hmm/roster.go
@@ -5,12 +5,8 @@ import (
 	"workweave/router/internal/router/cluster"
 )
 
-// DeployedModelsForRosterIDs maps sidecar roster IDs back to catalog
-// {model, provider} entries, so the deployed-models endpoint can report the
-// HMM strategy's routable roster instead of the cluster artifact's registry.
-// Input order is preserved; unknown roster IDs and duplicate catalog models
-// are dropped so the result mirrors the DeployedEntry shape the cluster source
-// produces.
+// DeployedModelsForRosterIDs maps sidecar roster IDs to catalog {model, provider} entries.
+// Unknown IDs are dropped; first occurrence wins on duplicates.
 func DeployedModelsForRosterIDs(rosterIDs []string) []cluster.DeployedEntry {
 	inverse := make(map[string]catalog.Model, len(catalog.Models))
 	for _, m := range catalog.Models {

--- a/internal/router/hmm/roster.go
+++ b/internal/router/hmm/roster.go
@@ -1,0 +1,40 @@
+package hmm
+
+import (
+	"workweave/router/internal/router/catalog"
+	"workweave/router/internal/router/cluster"
+)
+
+// DeployedModelsForRosterIDs maps sidecar roster IDs back to catalog
+// {model, provider} entries, so the deployed-models endpoint can report the
+// HMM strategy's routable roster instead of the cluster artifact's registry.
+// Input order is preserved; unknown roster IDs and duplicate catalog models
+// are dropped so the result mirrors the DeployedEntry shape the cluster source
+// produces.
+func DeployedModelsForRosterIDs(rosterIDs []string) []cluster.DeployedEntry {
+	inverse := make(map[string]catalog.Model, len(catalog.Models))
+	for _, m := range catalog.Models {
+		rosterID := rosterIDFor(m)
+		if rosterID == "" {
+			continue
+		}
+		if _, exists := inverse[rosterID]; !exists {
+			inverse[rosterID] = m
+		}
+	}
+
+	out := make([]cluster.DeployedEntry, 0, len(rosterIDs))
+	seen := make(map[string]struct{}, len(rosterIDs))
+	for _, rosterID := range rosterIDs {
+		m, ok := inverse[rosterID]
+		if !ok {
+			continue
+		}
+		if _, dup := seen[m.ID]; dup {
+			continue
+		}
+		seen[m.ID] = struct{}{}
+		out = append(out, cluster.DeployedEntry{Model: m.ID, Provider: m.PrimaryProvider()})
+	}
+	return out
+}

--- a/internal/router/hmm/roster_test.go
+++ b/internal/router/hmm/roster_test.go
@@ -11,9 +11,8 @@ import (
 )
 
 func TestDeployedModelsForRosterIDs_MapsRosterSlugsToCatalogEntries(t *testing.T) {
-	// Roster slugs are provider-prefixed (openai/…, anthropic/…); the mapped
-	// entries carry the bare catalog IDs and primary provider, matching the
-	// shape the cluster source produces.
+	// Roster slugs are provider-prefixed (openai/…); entries carry bare
+	// catalog IDs and primary provider, matching the cluster source shape.
 	got := hmm.DeployedModelsForRosterIDs([]string{
 		"openai/gpt-5.6-sol",
 		"anthropic/claude-opus-4.8",

--- a/internal/router/hmm/roster_test.go
+++ b/internal/router/hmm/roster_test.go
@@ -1,0 +1,49 @@
+package hmm_test
+
+import (
+	"testing"
+
+	"workweave/router/internal/providers"
+	"workweave/router/internal/router/hmm"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDeployedModelsForRosterIDs_MapsRosterSlugsToCatalogEntries(t *testing.T) {
+	// Roster slugs are provider-prefixed (openai/…, anthropic/…); the mapped
+	// entries carry the bare catalog IDs and primary provider, matching the
+	// shape the cluster source produces.
+	got := hmm.DeployedModelsForRosterIDs([]string{
+		"openai/gpt-5.6-sol",
+		"anthropic/claude-opus-4.8",
+		"deepseek/deepseek-v4-flash",
+	})
+
+	byModel := make(map[string]string, len(got))
+	for _, e := range got {
+		byModel[e.Model] = e.Provider
+	}
+
+	assert.Equal(t, providers.ProviderOpenAI, byModel["gpt-5.6-sol"])
+	assert.Equal(t, providers.ProviderAnthropic, byModel["claude-opus-4-8"])
+	// OSS slugs already carry their provider prefix, so the roster_id equals
+	// the catalog ID; provider is whatever the catalog lists first.
+	require.Contains(t, byModel, "deepseek/deepseek-v4-flash")
+	assert.NotEmpty(t, byModel["deepseek/deepseek-v4-flash"])
+}
+
+func TestDeployedModelsForRosterIDs_PreservesOrderAndDropsUnknown(t *testing.T) {
+	got := hmm.DeployedModelsForRosterIDs([]string{
+		"openai/gpt-5.6-sol",
+		"not/a-real-roster-id",
+		"openai/gpt-5.6-sol", // duplicate: only the first survives
+	})
+
+	require.Len(t, got, 1)
+	assert.Equal(t, "gpt-5.6-sol", got[0].Model)
+}
+
+func TestDeployedModelsForRosterIDs_EmptyInput(t *testing.T) {
+	assert.Empty(t, hmm.DeployedModelsForRosterIDs(nil))
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -15,6 +15,7 @@ import (
 	openaiapi "workweave/router/internal/api/openai"
 	"workweave/router/internal/auth"
 	"workweave/router/internal/billing"
+	"workweave/router/internal/policyclient"
 	"workweave/router/internal/proxy"
 	"workweave/router/internal/router"
 	"workweave/router/internal/server/middleware"
@@ -32,12 +33,13 @@ const (
 	passthroughTimeout    = 10 * time.Second
 	routeTimeout          = 5 * time.Second
 	adminTimeout          = 10 * time.Second
-	// catalogModelsTimeout bounds GET /v1/router/models. The HMM strategy path
-	// fetches the roster from the sidecar, whose client budget defaults to 3s
-	// (policyclient.DefaultTimeout), so this must exceed that or a cold/expired
-	// cache would be cancelled before the roster returns. The cluster path is
-	// in-memory and returns well within this.
-	catalogModelsTimeout = 5 * time.Second
+	// catalogModelsTimeout bounds GET /v1/router/models. It must exceed the
+	// HMM sidecar client's own per-call budget so the handler doesn't cancel
+	// a cold/expired cache fetch before the sidecar responds. Using 2× the
+	// policy client default leaves room for one retry within the same window.
+	// If ROUTER_HMM_SIDECAR_TIMEOUT_MS is set above policyclient.DefaultTimeout,
+	// increase this to match.
+	catalogModelsTimeout = policyclient.DefaultTimeout * 2
 	// feedbackTimeout bounds the no-login feedback link reads/writes. Both are
 	// single-row Postgres ops plus an async span emit, so 5s is generous.
 	feedbackTimeout = 5 * time.Second
@@ -61,8 +63,7 @@ const (
 // deployedModels may be nil in tests; required in selfhosted prod so the
 // dashboard can render the universe of routable models.
 //
-// hmmModels is the HMM strategy's roster source; nil when no HMM sidecar is
-// wired, in which case /v1/router/models?strategy=hmm falls back to the
+// hmmModels is optional; nil when no HMM sidecar is wired — falls back to the
 // cluster registry.
 //
 // billingSvc is set only in managed mode when credit-billing is enabled; it

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -33,12 +33,9 @@ const (
 	passthroughTimeout    = 10 * time.Second
 	routeTimeout          = 5 * time.Second
 	adminTimeout          = 10 * time.Second
-	// catalogModelsTimeout bounds GET /v1/router/models. It must exceed the
-	// HMM sidecar client's own per-call budget so the handler doesn't cancel
-	// a cold/expired cache fetch before the sidecar responds. Using 2× the
-	// policy client default leaves room for one retry within the same window.
-	// If ROUTER_HMM_SIDECAR_TIMEOUT_MS is set above policyclient.DefaultTimeout,
-	// increase this to match.
+	// catalogModelsTimeout bounds GET /v1/router/models; must exceed the HMM
+	// sidecar client budget (policyclient.DefaultTimeout) or a cold/expired
+	// cache fetch is cancelled and the caller gets 503.
 	catalogModelsTimeout = policyclient.DefaultTimeout * 2
 	// feedbackTimeout bounds the no-login feedback link reads/writes. Both are
 	// single-row Postgres ops plus an async span emit, so 5s is generous.

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -55,12 +55,16 @@ const (
 // deployedModels may be nil in tests; required in selfhosted prod so the
 // dashboard can render the universe of routable models.
 //
+// hmmModels is the HMM strategy's roster source; nil when no HMM sidecar is
+// wired, in which case /v1/router/models?strategy=hmm falls back to the
+// cluster registry.
+//
 // billingSvc is set only in managed mode when credit-billing is enabled; it
 // gates every inference route on prepaid balance via WithBalanceCheck. nil
 // leaves inference routes open (BYOK/platform key still controls upstream auth).
 //
 // readinessChecker gates /readyz only; /health remains process liveness.
-func Register(engine *gin.Engine, authSvc *auth.Service, proxySvc *proxy.Service, deployedModels admin.DeployedModelsSource, mode DeploymentMode, billingSvc *billing.Service, readinessChecker admin.HealthChecker) {
+func Register(engine *gin.Engine, authSvc *auth.Service, proxySvc *proxy.Service, deployedModels admin.DeployedModelsSource, hmmModels admin.HMMRosterSource, mode DeploymentMode, billingSvc *billing.Service, readinessChecker admin.HealthChecker) {
 	// Managed mode bills via platform-key credits; a leftover BYOK row would
 	// double-charge (upstream provider + Weave credits), so drop it here.
 	byokDisabled := mode == DeploymentModeManaged
@@ -91,7 +95,7 @@ func Register(engine *gin.Engine, authSvc *auth.Service, proxySvc *proxy.Service
 	// hand-copying it per gitlink bump. Unauthed: read-only, and the list is
 	// already public on the RouterArena leaderboard.
 	if deployedModels != nil {
-		engine.GET("/v1/router/models", middleware.WithTimeout(healthTimeout), admin.CatalogModelsHandler(deployedModels))
+		engine.GET("/v1/router/models", middleware.WithTimeout(healthTimeout), admin.CatalogModelsHandler(deployedModels, hmmModels))
 
 		// Projects the quality-vs-price dial's model mix across dial positions
 		// for the dashboard's distribution preview. Same unauthed rationale as

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -34,8 +34,7 @@ const (
 	routeTimeout          = 5 * time.Second
 	adminTimeout          = 10 * time.Second
 	// catalogModelsTimeout bounds GET /v1/router/models; must exceed the HMM
-	// sidecar client budget (policyclient.DefaultTimeout) or a cold/expired
-	// cache fetch is cancelled and the caller gets 503.
+	// sidecar client budget (policyclient.DefaultTimeout) or a cold cache 503s.
 	catalogModelsTimeout = policyclient.DefaultTimeout * 2
 	// feedbackTimeout bounds the no-login feedback link reads/writes. Both are
 	// single-row Postgres ops plus an async span emit, so 5s is generous.

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -32,6 +32,12 @@ const (
 	passthroughTimeout    = 10 * time.Second
 	routeTimeout          = 5 * time.Second
 	adminTimeout          = 10 * time.Second
+	// catalogModelsTimeout bounds GET /v1/router/models. The HMM strategy path
+	// fetches the roster from the sidecar, whose client budget defaults to 3s
+	// (policyclient.DefaultTimeout), so this must exceed that or a cold/expired
+	// cache would be cancelled before the roster returns. The cluster path is
+	// in-memory and returns well within this.
+	catalogModelsTimeout = 5 * time.Second
 	// feedbackTimeout bounds the no-login feedback link reads/writes. Both are
 	// single-row Postgres ops plus an async span emit, so 5s is generous.
 	feedbackTimeout = 5 * time.Second
@@ -95,7 +101,7 @@ func Register(engine *gin.Engine, authSvc *auth.Service, proxySvc *proxy.Service
 	// hand-copying it per gitlink bump. Unauthed: read-only, and the list is
 	// already public on the RouterArena leaderboard.
 	if deployedModels != nil {
-		engine.GET("/v1/router/models", middleware.WithTimeout(healthTimeout), admin.CatalogModelsHandler(deployedModels, hmmModels))
+		engine.GET("/v1/router/models", middleware.WithTimeout(catalogModelsTimeout), admin.CatalogModelsHandler(deployedModels, hmmModels))
 
 		// Projects the quality-vs-price dial's model mix across dial positions
 		// for the dashboard's distribution preview. Same unauthed rationale as

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -78,7 +78,7 @@ func TestRegister_DeploymentMode(t *testing.T) {
 	t.Run("selfhosted mounts dashboard and product routes", func(t *testing.T) {
 		engine := gin.New()
 		// Nil services are fine: engine.Routes() inspection never invokes the closure-captured handlers.
-		server.Register(engine, nil, nil, fakeDeployedModelsSource{}, server.DeploymentModeSelfHosted, nil, nil)
+		server.Register(engine, nil, nil, fakeDeployedModelsSource{}, nil, server.DeploymentModeSelfHosted, nil, nil)
 		got := routeSet(engine)
 		for _, want := range productRoutes {
 			assert.Contains(t, got, want, "product route missing in selfhosted mode")
@@ -93,7 +93,7 @@ func TestRegister_DeploymentMode(t *testing.T) {
 		// Pass a non-nil DeployedModelsSource: managed prod always boots a
 		// *cluster.Multiversion router, so the catalog endpoint must mount
 		// even though the dashboard does not.
-		server.Register(engine, nil, nil, fakeDeployedModelsSource{}, server.DeploymentModeManaged, nil, nil)
+		server.Register(engine, nil, nil, fakeDeployedModelsSource{}, nil, server.DeploymentModeManaged, nil, nil)
 		got := routeSet(engine)
 		for _, want := range productRoutes {
 			assert.Contains(t, got, want, "product route missing in managed mode")
@@ -105,7 +105,7 @@ func TestRegister_DeploymentMode(t *testing.T) {
 
 	t.Run("nil deployed-models source skips catalog endpoint", func(t *testing.T) {
 		engine := gin.New()
-		server.Register(engine, nil, nil, nil, server.DeploymentModeManaged, nil, nil)
+		server.Register(engine, nil, nil, nil, nil, server.DeploymentModeManaged, nil, nil)
 		got := routeSet(engine)
 		assert.NotContains(t, got, "GET /v1/router/models", "catalog endpoint must not mount without a deployed-models source")
 	})
@@ -117,7 +117,7 @@ func TestRegisterSeparatesLivenessFromReadiness(t *testing.T) {
 	checker := healthCheckerFunc(func(context.Context) error {
 		return errors.New("dependency unavailable")
 	})
-	server.Register(engine, nil, nil, nil, server.DeploymentModeManaged, nil, checker)
+	server.Register(engine, nil, nil, nil, nil, server.DeploymentModeManaged, nil, checker)
 
 	for _, test := range []struct {
 		path       string

--- a/sidecars/hmm/hmm_sidecar/api.py
+++ b/sidecars/hmm/hmm_sidecar/api.py
@@ -100,6 +100,20 @@ def capabilities() -> JSONResponse:
     )
 
 
+@app.get("/roster")
+def roster() -> JSONResponse:
+    policy: FrozenPolicy | None = getattr(app.state, "policy", None)
+    if policy is None:
+        return JSONResponse({"error": "policy unavailable"}, status_code=503)
+    return JSONResponse(
+        {
+            "schema_version": SCHEMA_VERSION,
+            "roster_version": policy.roster_version,
+            "roster_ids": policy.roster_ids(),
+        }
+    )
+
+
 @app.post("/outcome", status_code=204)
 def outcome() -> None:
     return None

--- a/sidecars/hmm/hmm_sidecar/policy.py
+++ b/sidecars/hmm/hmm_sidecar/policy.py
@@ -102,6 +102,18 @@ class FrozenPolicy:
             if isinstance(card, dict) and isinstance(card.get("state_id"), int)
         }
 
+    def roster_ids(self) -> list[str]:
+        """Deduplicated union of arm roster IDs across every cluster, in first-seen order."""
+        seen: set[str] = set()
+        ordered: list[str] = []
+        for cluster in self.clusters.values():
+            for arm in cluster.get("arms") or []:
+                arm_id = str(arm)
+                if arm_id not in seen:
+                    seen.add(arm_id)
+                    ordered.append(arm_id)
+        return ordered
+
     async def _evaluate(
         self, payload: dict[str, Any], *, allow_empty_candidates: bool
     ) -> tuple[list[Candidate], Any, Any]:

--- a/sidecars/hmm/tests/test_api.py
+++ b/sidecars/hmm/tests/test_api.py
@@ -44,6 +44,13 @@ class PreviewingPolicy:
         )
 
 
+class RosterPolicy:
+    roster_version = "b" * 64
+
+    def roster_ids(self) -> list[str]:
+        return ["openai/gpt-5.6-sol", "anthropic/claude-opus-4.8"]
+
+
 def test_liveness_does_not_depend_on_model_readiness() -> None:
     with TestClient(app) as client:
         response = client.get("/livez")
@@ -109,3 +116,25 @@ def test_preview_requires_explicit_mode_and_returns_all_selected_arms() -> None:
     assert rejected.status_code == 400
     assert response.status_code == 200
     assert response.json()["eligible_roster_ids"] == ["provider/a"]
+
+
+def test_roster_returns_arm_union() -> None:
+    with TestClient(app) as client:
+        app.state.policy = RosterPolicy()
+        response = client.get("/roster")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["schema_version"] == "policy_router_v1"
+    assert payload["roster_ids"] == [
+        "openai/gpt-5.6-sol",
+        "anthropic/claude-opus-4.8",
+    ]
+
+
+def test_roster_fails_closed_without_policy() -> None:
+    with TestClient(app) as client:
+        app.state.policy = None
+        response = client.get("/roster")
+
+    assert response.status_code == 503

--- a/sidecars/hmm/tests/test_policy.py
+++ b/sidecars/hmm/tests/test_policy.py
@@ -22,6 +22,21 @@ class FixedEmbedder:
         return [self.vector for _ in texts]
 
 
+def test_roster_ids_dedupes_arms_across_clusters_in_first_seen_order() -> None:
+    policy = object.__new__(FrozenPolicy)
+    policy.clusters = {
+        "fast": {"arms": ["deepseek/deepseek-v4-flash", "openai/gpt-5.4-nano"]},
+        "balanced": {"arms": ["openai/gpt-5.6-luna", "deepseek/deepseek-v4-flash"]},
+        "empty": {},
+    }
+
+    assert policy.roster_ids() == [
+        "deepseek/deepseek-v4-flash",
+        "openai/gpt-5.4-nano",
+        "openai/gpt-5.6-luna",
+    ]
+
+
 def test_roster_fallback_reports_the_selected_classifier_group() -> None:
     probabilities = {"fast": 0.2, "maximum": 0.8}
 


### PR DESCRIPTION
## Why

`GET /v1/router/models` (the deployed-models catalog the control plane reads for the settings roster) always returned the active **cluster** artifact's model registry. But the deployment default routing strategy is **HMM**, whose routable roster — the sidecar's `roster_v2` cluster arms — is a different set than the cluster registry. So the settings roster showed a model universe the HMM strategy doesn't actually route across (e.g. a model live on HMM was invisible; a cluster-only model was shown).

## What

Make the deployed-models endpoint strategy-aware so the control plane can request the roster that actually serves a given org:

- **sidecar**: `GET /roster` exposes the deduplicated union of `roster_v2` cluster arm IDs, plus a `FrozenPolicy.roster_ids()` helper.
- **policyclient**: `Client.Roster` fetches it (schema-checked, same contract style as `Capabilities`).
- **hmm**: `DeployedModelsForRosterIDs` maps roster IDs (e.g. `openai/…`) back to catalog `{model, provider}` entries so the wire shape matches the cluster source.
- **admin**: `GET /v1/router/models?strategy=` returns the HMM roster for an HMM strategy (cached with stale-on-failure), the cluster registry otherwise. A nil HMM source (no sidecar wired) or an absent/unknown `?strategy=` falls back to the cluster registry, so the endpoint stays backward-compatible.

## Testing

- `go build ./...`, `go vet ./...`, full `go test ./...` (46 packages) green.
- New Go tests: roster mapping (slug→catalog, dedup, order, unknown-drop), `Client.Roster` (success/bad-schema/status-error), strategy-aware handler (HMM roster vs cluster, nil fallback, 503 on fetch error), and the cached source (map+cache, stale-on-failure, error-without-snapshot).
- Sidecar: full suite (31 passed) + new `/roster` endpoint and `roster_ids()` dedup tests; `black` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)