### PR TITLE
Add cache control data to Anthropic -> Anthropic requests

### DIFF
--- a/internal/proxy/service_test.go
+++ b/internal/proxy/service_test.go
@@ -397,7 +397,16 @@ func TestService_ProxyMessages_StripsRoutingMarkerFromInboundHistory(t *testing.
 	upstream := string(provider.proxyBodies[0])
 	assert.NotContains(t, upstream, markerSentinel, "routing marker must not reach upstream")
 	assert.Contains(t, upstream, "real assistant reply", "non-marker assistant content must survive")
-	assert.Contains(t, upstream, "</result>", "wrapper text around an embedded marker must survive")
+
+	// The last user message's content is promoted to an array with a cache_control
+	// marker; unmarshal to verify the wrapper text survived.
+	var upstreamJSON map[string]any
+	require.NoError(t, json.Unmarshal(provider.proxyBodies[0], &upstreamJSON))
+	msgs, _ := upstreamJSON["messages"].([]any)
+	lastMsg, _ := msgs[len(msgs)-1].(map[string]any)
+	blocks, _ := lastMsg["content"].([]any)
+	lastBlock, _ := blocks[len(blocks)-1].(map[string]any)
+	assert.Contains(t, lastBlock["text"], "</result>", "wrapper text around an embedded marker must survive")
 }
 
 func TestService_ProxyMessages_EmbedOnlyUserMessageFlag(t *testing.T) {

--- a/internal/router/handover/summarizer_test.go
+++ b/internal/router/handover/summarizer_test.go
@@ -56,9 +56,15 @@ func TestRewriteEnvelope_AnthropicCollapsesToSummaryPlusLastUser(t *testing.T) {
 	assert.True(t, strings.HasPrefix(summaryText, translate.HandoverSummaryTag), "summary must carry the tag prefix; got %q", summaryText)
 	assert.Contains(t, summaryText, "Refactor of pkg/foo")
 
-	// Second entry: the original trailing user message verbatim.
+	// Second entry: the original trailing user message.
+	// Content may be promoted to an array with a cache_control marker.
 	assert.Equal(t, "user", msgs[1].Get("role").String())
-	assert.Equal(t, "Continue with step 2.", msgs[1].Get("content").String())
+	content := msgs[1].Get("content")
+	if content.IsArray() {
+		assert.Equal(t, "Continue with step 2.", content.Get("0.text").String())
+	} else {
+		assert.Equal(t, "Continue with step 2.", content.String())
+	}
 }
 
 func TestRewriteEnvelope_NilEnvelopeReturnsZeroAndDoesNotPanic(t *testing.T) {
@@ -164,8 +170,21 @@ func TestTrimLastN_KeepsLastNMessagesAndSystem(t *testing.T) {
 	msgs := gjson.GetBytes(prep.Body, "messages").Array()
 	require.Len(t, msgs, 3)
 	assert.Equal(t, "m8", msgs[0].Get("content").String())
-	assert.Equal(t, "m9", msgs[1].Get("content").String())
-	assert.Equal(t, "m10", msgs[2].Get("content").String())
+	assert.Equal(t, "user", msgs[1].Get("role").String())
+	// Content may be promoted to an array with a cache_control marker.
+	c1 := msgs[1].Get("content")
+	if c1.IsArray() {
+		assert.Equal(t, "m9", c1.Get("0.text").String())
+	} else {
+		assert.Equal(t, "m9", c1.String())
+	}
+	assert.Equal(t, "assistant", msgs[2].Get("role").String())
+	c2 := msgs[2].Get("content")
+	if c2.IsArray() {
+		assert.Equal(t, "m10", c2.Get("0.text").String())
+	} else {
+		assert.Equal(t, "m10", c2.String())
+	}
 }
 
 func TestTrimLastN_ZeroDefaultsToThree(t *testing.T) {
@@ -231,7 +250,13 @@ func TestTrimLastN_StripsOrphanedAnthropicToolResults(t *testing.T) {
 	assert.Equal(t, "assistant", msgs[0].Get("role").String())
 	assert.Equal(t, "done", msgs[0].Get("content").String())
 	assert.Equal(t, "user", msgs[1].Get("role").String())
-	assert.Equal(t, "next question", msgs[1].Get("content").String())
+	// Content may be promoted to an array with a cache_control marker.
+	c := msgs[1].Get("content")
+	if c.IsArray() {
+		assert.Equal(t, "next question", c.Get("0.text").String())
+	} else {
+		assert.Equal(t, "next question", c.String())
+	}
 }
 
 func TestTrimLastN_PreservesMatchedToolResults(t *testing.T) {

--- a/internal/translate/cache_control.go
+++ b/internal/translate/cache_control.go
@@ -68,6 +68,13 @@ func validateAnthropicCacheControls(request map[string]any) (int, error) {
 		count++
 		return nil
 	}
+	if tools, ok := request["tools"].([]any); ok {
+		for _, tool := range tools {
+			if err := visit(tool); err != nil {
+				return 0, err
+			}
+		}
+	}
 	if system, ok := request["system"].([]any); ok {
 		for _, block := range system {
 			if err := visit(block); err != nil {

--- a/internal/translate/emit_anthropic.go
+++ b/internal/translate/emit_anthropic.go
@@ -31,11 +31,7 @@ func (e *RequestEnvelope) PrepareAnthropic(in http.Header, opts EmitOptions) (pr
 	default:
 		return providers.PreparedRequest{}, fmt.Errorf("unsupported source format for Anthropic emit: %d", e.format)
 	}
-	if e.format == FormatOpenAI {
-		body, err = applyAnthropicCachePolicy(body, true)
-	} else {
-		body, err = applyAnthropicCachePolicy(body, false)
-	}
+	body, err = applyAnthropicCachePolicy(body, true)
 	if err != nil {
 		return providers.PreparedRequest{}, err
 	}

--- a/internal/translate/emit_same_format_test.go
+++ b/internal/translate/emit_same_format_test.go
@@ -63,9 +63,7 @@ func TestAnthropicSameFormat_AddsTailCacheBreakpointWhenSystemAlreadyCached(t *t
 }
 
 func TestAnthropicSameFormat_ToolCacheControlCountsTowardCapacity(t *testing.T) {
-	// A native client (e.g. Claude Code) pins the last tool and fills the rest
-	// of the 4-breakpoint budget on system blocks. Tool breakpoints count too,
-	// so the router must inject nothing rather than push the total past 4.
+	// 1 tool + 3 system = 4 breakpoints; router must not inject a fifth.
 	body := []byte(`{"model":"claude-opus-4-8","max_tokens":1024,` +
 		`"tools":[{"name":"a","input_schema":{"type":"object"}},` +
 		`{"name":"b","input_schema":{"type":"object"},"cache_control":{"type":"ephemeral"}}],` +

--- a/internal/translate/emit_same_format_test.go
+++ b/internal/translate/emit_same_format_test.go
@@ -62,6 +62,38 @@ func TestAnthropicSameFormat_AddsTailCacheBreakpointWhenSystemAlreadyCached(t *t
 	assert.Equal(t, map[string]any{"type": "ephemeral"}, lastBlock["cache_control"])
 }
 
+func TestAnthropicSameFormat_ToolCacheControlCountsTowardCapacity(t *testing.T) {
+	// A native client (e.g. Claude Code) pins the last tool and fills the rest
+	// of the 4-breakpoint budget on system blocks. Tool breakpoints count too,
+	// so the router must inject nothing rather than push the total past 4.
+	body := []byte(`{"model":"claude-opus-4-8","max_tokens":1024,` +
+		`"tools":[{"name":"a","input_schema":{"type":"object"}},` +
+		`{"name":"b","input_schema":{"type":"object"},"cache_control":{"type":"ephemeral"}}],` +
+		`"system":[{"type":"text","text":"one","cache_control":{"type":"ephemeral"}},` +
+		`{"type":"text","text":"two","cache_control":{"type":"ephemeral"}},` +
+		`{"type":"text","text":"three","cache_control":{"type":"ephemeral"}}],` +
+		`"messages":[{"role":"user","content":"hi"}]}`)
+	out := parseAndEmit(t, body, "anthropic", translate.EmitOptions{TargetModel: "claude-opus-4-8", Capabilities: router.Lookup("claude-opus-4-8")})
+
+	lastMessage := out["messages"].([]any)[0].(map[string]any)
+	assert.Equal(t, "hi", lastMessage["content"], "capacity is full (1 tool + 3 system = 4), so the router injects no tail breakpoint")
+}
+
+func TestAnthropicSameFormat_ToolCacheControlOverflowRejected(t *testing.T) {
+	// Five tool breakpoints alone exceed the 4-breakpoint capacity; the count
+	// must include tools or this overflow slips through as a silent upstream 400.
+	body := []byte(`{"model":"claude-opus-4-8","max_tokens":1024,"messages":[{"role":"user","content":"hi"}],"tools":[` +
+		`{"name":"a","input_schema":{"type":"object"},"cache_control":{"type":"ephemeral"}},` +
+		`{"name":"b","input_schema":{"type":"object"},"cache_control":{"type":"ephemeral"}},` +
+		`{"name":"c","input_schema":{"type":"object"},"cache_control":{"type":"ephemeral"}},` +
+		`{"name":"d","input_schema":{"type":"object"},"cache_control":{"type":"ephemeral"}},` +
+		`{"name":"e","input_schema":{"type":"object"},"cache_control":{"type":"ephemeral"}}]}`)
+	env, err := translate.ParseAnthropic(body)
+	require.NoError(t, err)
+	_, err = env.PrepareAnthropic(http.Header{}, translate.EmitOptions{TargetModel: "claude-opus-4-8", Capabilities: router.Lookup("claude-opus-4-8")})
+	require.ErrorIs(t, err, translate.ErrAnthropicCacheControlOverflow)
+}
+
 func TestOpenAISameFormat_ModelRewrite(t *testing.T) {
 	body := []byte(`{"model":"gpt-4o","messages":[{"role":"user","content":"hello"}],"stream":true}`)
 	opts := translate.EmitOptions{

--- a/internal/translate/emit_same_format_test.go
+++ b/internal/translate/emit_same_format_test.go
@@ -40,6 +40,28 @@ func parseAndEmit(t *testing.T, body []byte, format string, opts translate.EmitO
 	}
 }
 
+func TestAnthropicSameFormat_AddsTailCacheBreakpointWhenSystemAlreadyCached(t *testing.T) {
+	body := []byte(`{"model":"claude-opus-4-8","max_tokens":1024,"system":[{"type":"text","text":"cached rules","cache_control":{"type":"ephemeral","ttl":"1h"}}],"messages":[{"role":"user","content":"first"},{"role":"assistant","content":"ok"},{"role":"user","content":"continue"}]}`)
+	out := parseAndEmit(t, body, "anthropic", translate.EmitOptions{TargetModel: "claude-opus-4-8", Capabilities: router.Lookup("claude-opus-4-8")})
+
+	system := out["system"].([]any)
+	require.Len(t, system, 1)
+	assert.Equal(t, map[string]any{"type": "ephemeral", "ttl": "1h"}, system[0].(map[string]any)["cache_control"])
+
+	messages := out["messages"].([]any)
+	require.Len(t, messages, 3)
+	first := messages[0].(map[string]any)
+	assert.Equal(t, "first", first["content"])
+
+	last := messages[2].(map[string]any)
+	blocks := last["content"].([]any)
+	require.Len(t, blocks, 1)
+	lastBlock := blocks[0].(map[string]any)
+	assert.Equal(t, "text", lastBlock["type"])
+	assert.Equal(t, "continue", lastBlock["text"])
+	assert.Equal(t, map[string]any{"type": "ephemeral"}, lastBlock["cache_control"])
+}
+
 func TestOpenAISameFormat_ModelRewrite(t *testing.T) {
 	body := []byte(`{"model":"gpt-4o","messages":[{"role":"user","content":"hello"}],"stream":true}`)
 	opts := translate.EmitOptions{

--- a/internal/translate/force_model_test.go
+++ b/internal/translate/force_model_test.go
@@ -284,8 +284,16 @@ func lastUserMessageText(t *testing.T, env *translate.RequestEnvelope) string {
 	for i := len(msgs) - 1; i >= 0; i-- {
 		msg, _ := msgs[i].(map[string]any)
 		if msg["role"] == "user" {
-			content, _ := msg["content"].(string)
-			return content
+			if content, ok := msg["content"].(string); ok {
+				return content
+			}
+			blocks, _ := msg["content"].([]any)
+			if len(blocks) > 0 {
+				block, _ := blocks[len(blocks)-1].(map[string]any)
+				if block["type"] == "text" {
+					return block["text"].(string)
+				}
+			}
 		}
 	}
 	return ""


### PR DESCRIPTION
<details>
<summary>How I validated:</summary>

**Setup**: Docker compose stack with real Anthropic API key + a logging forward-proxy at :8099 that dumped every upstream request structure (breakpoint counts/positions) and response usage block (cache tokens). Only Anthropic deployment key enabled → all turns routed decision_provider=anthropic (cross_format=false).

**Results** (tool-looping session, 4 real Read/Write turns):

```
┌──────┬──────────┬─────────────┬────────────┬────────────────┬──────────┐
│ Turn │ Messages │ Breakpoints │ Cache Read │ Cache Creation │ Uncached │
├──────┼──────────┼─────────────┼────────────┼────────────────┼──────────┤
│ 1    │ 1        │ 4           │ 0          │ 39,753         │ 2        │
├──────┼──────────┼─────────────┼────────────┼────────────────┼──────────┤
│ 2    │ 3        │ 4           │ 39,753     │ 203            │ 2        │
├──────┼──────────┼─────────────┼────────────┼────────────────┼──────────┤
│ 3    │ 5        │ 4           │ 40,394     │ 219            │ 2        │
├──────┼──────────┼─────────────┼────────────┼────────────────┼──────────┤
│ 4    │ 7        │ 4           │ 40,613     │ 344            │ 2        │
└──────┴──────────┴─────────────┴────────────┴────────────────┴──────────┘
```

Cache-read tokens grew monotically turn-over-turn with only ~2 new input tokens each turn. On the last turn the cache hit rate was 40613 / (40613 + 344 + 2) ≈ 99.2%.

Breakpoint placement: 3 system-block breakpoints (preserving Claude Code's own) + 1 last-message breakpoint (router-injected moving breakpoint).

**Counterfactual proof**

Running the same session with applyAnthropicCachePolicy(body, false) (pre-diff behavior) on the Anthropic→Anthropic path showed:
- Only 3 breakpoints (last system block uncached — Claude Code's breakpoints only)
- Turn 1 had 5,965 uncached input tokens vs 2 with the diff — because the uncached system tail doesn't extend the cache prefix

The extra breakpoint the router injects on the Anthropic→Anthropic path is the difference between ~0 and ~5000 uncached tokens on the first tool turn.
</details>