### PR TITLE
feat(translate): keep CC orchestration tools on cross-vendor routes by default

### DIFF
--- a/cmd/router/main.go
+++ b/cmd/router/main.go
@@ -499,6 +499,7 @@ func main() {
 	cyberRefusalRepin := config.GetOr("ROUTER_CYBER_REFUSAL_REPIN", "false") == "true"
 	cyberRefusalFallbackModel := config.GetOr("ROUTER_CYBER_REFUSAL_FALLBACK_MODEL", "claude-sonnet-5")
 	effortEscalation := config.GetOr("ROUTER_EFFORT_ESCALATION", "false") == "true"
+	ccOrchToolsCrossVendor := config.GetOr("ROUTER_CC_ORCH_TOOLS_CROSSVENDOR", "true") == "true"
 	// Per-turn large-vs-small action-classifier swap. Off by default until the
 	// Layer-2 extrinsic validation clears it; enabling loads the compiled-in head.
 	bandSwapEnabled := config.GetOr("ROUTER_BAND_SWAP", "false") == "true"
@@ -728,6 +729,7 @@ func main() {
 		WithHMMUpgradeConfidenceThreshold(hmmUpgradeConfidence).
 		WithEscapeNormalize(escapeNormalize).
 		WithEffortEscalation(effortEscalation).
+		WithCCOrchestrationToolsCrossVendor(ccOrchToolsCrossVendor).
 		WithBandSwap(bandSwapEnabled).
 		WithLoopEscalationConfig(loopEscalationEnabled, loopEscalationHoldoutPct).
 		WithLoopEscalationStore(repo.Telemetry).
@@ -746,6 +748,7 @@ func main() {
 		logger.Info("Generic policy sidecar wired", "strategy", spec.Strategy, "candidate_models", len(availableModels))
 	}
 	logger.Info("Effort escalation configured", "enabled", effortEscalation)
+	logger.Info("Cross-vendor Claude Code orchestration tools configured", "enabled", ccOrchToolsCrossVendor)
 	logger.Info("Loop escalation configured", "enabled", loopEscalationEnabled, "holdout_pct", loopEscalationHoldoutPct)
 	logger.Info("Spiral shadow detector configured", "enabled", spiralShadowEnabled)
 	logger.Info("Text-repetition break configured", "enabled", textRepetitionBreakEnabled)

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -146,6 +146,13 @@ type Service struct {
 	// failed/no-progress turn; gemini is pinned low. Off by default (set from
 	// ROUTER_EFFORT_ESCALATION) so it can be baked off before enabling.
 	effortEscalation bool
+	// ccOrchToolsCrossVendor keeps the Claude Code orchestration tools (Task*,
+	// Workflow, Skill, plan-mode) in the tool set on Anthropic→non-Anthropic
+	// routes instead of stripping them, so subagents/workflows can run off the
+	// Anthropic family. On by default (kill switch: ROUTER_CC_ORCH_TOOLS_CROSSVENDOR
+	// =false restores the strip-everything behavior); the rest of the CC-only
+	// tools stay stripped regardless.
+	ccOrchToolsCrossVendor bool
 	// bandSwap is the per-turn large-vs-small action classifier. Non-nil only
 	// when ROUTER_BAND_SWAP is on and the head loaded; a sticky MainLoop STAY
 	// then serves the predicted band (one of the pin's {Model, PairedModel})
@@ -939,6 +946,7 @@ func NewService(r router.Router, providerMap map[string]providers.Client, emitte
 		spiralTracker:                newSpiralTracker(),
 		spiralShadowEnabled:          true,
 		textRepetitionBreakEnabled:   true,
+		ccOrchToolsCrossVendor:       true,
 		hardPinExplore:               hardPinExplore,
 		hardPinProvider:              hardPinProvider,
 		hardPinModel:                 hardPinModel,
@@ -1040,6 +1048,15 @@ func (s *Service) WithEscapeNormalize(enabled bool) *Service {
 // When false (default) the router leaves request-derived effort untouched.
 func (s *Service) WithEffortEscalation(enabled bool) *Service {
 	s.effortEscalation = enabled
+	return s
+}
+
+// WithCCOrchestrationToolsCrossVendor preserves the Claude Code orchestration
+// tools (Task*, Workflow, Skill, plan-mode) on Anthropic→non-Anthropic routes
+// instead of stripping them. On by default; passing false restores the
+// strip-everything behavior for all Claude-Code-only tools cross-vendor.
+func (s *Service) WithCCOrchestrationToolsCrossVendor(enabled bool) *Service {
+	s.ccOrchToolsCrossVendor = enabled
 	return s
 }
 
@@ -2403,13 +2420,14 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 	otel.Flush(ctx)
 
 	opts := translate.EmitOptions{
-		TargetModel:           decision.Model,
-		TargetProvider:        decision.Provider,
-		Capabilities:          router.Lookup(decision.Model),
-		IncludeStreamUsage:    s.usageRequired(),
-		SessionAffinity:       sessionAffinityHint(routeRes.SessionKey),
-		ModelSwitched:         routeRes.modelSwitched(),
-		EnableExtendedContext: shouldEnableExtendedContext(env.FullTokenEstimate(), outputReserve),
+		TargetModel:                       decision.Model,
+		TargetProvider:                    decision.Provider,
+		Capabilities:                      router.Lookup(decision.Model),
+		IncludeStreamUsage:                s.usageRequired(),
+		SessionAffinity:                   sessionAffinityHint(routeRes.SessionKey),
+		ModelSwitched:                     routeRes.modelSwitched(),
+		EnableExtendedContext:             shouldEnableExtendedContext(env.FullTokenEstimate(), outputReserve),
+		KeepCrossVendorOrchestrationTools: s.ccOrchToolsCrossVendor,
 	}
 	// User-forced effort wins over effortEscalation; also pre-populate
 	// ForceReasoningEffort so the gpt-5.x/gemini-3.x emit seams honor it.

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -146,12 +146,9 @@ type Service struct {
 	// failed/no-progress turn; gemini is pinned low. Off by default (set from
 	// ROUTER_EFFORT_ESCALATION) so it can be baked off before enabling.
 	effortEscalation bool
-	// ccOrchToolsCrossVendor keeps the Claude Code orchestration tools (Task*,
-	// Workflow, Skill, plan-mode) in the tool set on Anthropic→non-Anthropic
-	// routes instead of stripping them, so subagents/workflows can run off the
-	// Anthropic family. On by default (kill switch: ROUTER_CC_ORCH_TOOLS_CROSSVENDOR
-	// =false restores the strip-everything behavior); the rest of the CC-only
-	// tools stay stripped regardless.
+	// ccOrchToolsCrossVendor keeps CC orchestration tools (Task*, Workflow,
+	// Skill, plan-mode) on cross-vendor routes. Kill switch:
+	// ROUTER_CC_ORCH_TOOLS_CROSSVENDOR=false strips all CC-only tools.
 	ccOrchToolsCrossVendor bool
 	// bandSwap is the per-turn large-vs-small action classifier. Non-nil only
 	// when ROUTER_BAND_SWAP is on and the head loaded; a sticky MainLoop STAY
@@ -1051,10 +1048,8 @@ func (s *Service) WithEffortEscalation(enabled bool) *Service {
 	return s
 }
 
-// WithCCOrchestrationToolsCrossVendor preserves the Claude Code orchestration
-// tools (Task*, Workflow, Skill, plan-mode) on Anthropic→non-Anthropic routes
-// instead of stripping them. On by default; passing false restores the
-// strip-everything behavior for all Claude-Code-only tools cross-vendor.
+// WithCCOrchestrationToolsCrossVendor preserves Claude Code orchestration
+// tools (Task*, Workflow, Skill, plan-mode) on cross-vendor emit. False strips all.
 func (s *Service) WithCCOrchestrationToolsCrossVendor(enabled bool) *Service {
 	s.ccOrchToolsCrossVendor = enabled
 	return s

--- a/internal/translate/claudecode_tool_filter.go
+++ b/internal/translate/claudecode_tool_filter.go
@@ -57,9 +57,8 @@ func isClaudeCodeOnlyTool(name string) bool {
 }
 
 // claudeCodeOrchestrationToolNames is the subset of claudeCodeOnlyToolNames
-// whose tools a capable non-Anthropic model can act on (subagent dispatch,
-// workflow runs, skill invocation, plan-mode toggles). Must stay a strict
-// subset of claudeCodeOnlyToolNames — see TestOrchestrationToolsAreSubsetOfCCOnly.
+// a capable non-Anthropic model can act on. Must stay a strict subset of
+// claudeCodeOnlyToolNames — see TestOrchestrationToolsAreSubsetOfCCOnly.
 var claudeCodeOrchestrationToolNames = map[string]struct{}{
 	"Task":          {},
 	"TaskCreate":    {},

--- a/internal/translate/claudecode_tool_filter.go
+++ b/internal/translate/claudecode_tool_filter.go
@@ -57,13 +57,9 @@ func isClaudeCodeOnlyTool(name string) bool {
 }
 
 // claudeCodeOrchestrationToolNames is the subset of claudeCodeOnlyToolNames
-// that drives multi-step work the client executes on the model's behalf:
-// subagent dispatch (Task*), workflow runs, skill invocation, and plan-mode
-// toggles. Unlike the rest of the CC-only set (Cron*, Monitor, MCP-resource
-// tools, worktree/LSP helpers), a capable non-Anthropic model can emit a
-// well-formed call to one of these and have the client action it — so they are
-// optionally preserved on cross-vendor emit to let workflows/subagents run off
-// the Anthropic family. Must stay a strict subset of claudeCodeOnlyToolNames.
+// whose tools a capable non-Anthropic model can act on (subagent dispatch,
+// workflow runs, skill invocation, plan-mode toggles). Must stay a strict
+// subset of claudeCodeOnlyToolNames — see TestOrchestrationToolsAreSubsetOfCCOnly.
 var claudeCodeOrchestrationToolNames = map[string]struct{}{
 	"Task":          {},
 	"TaskCreate":    {},

--- a/internal/translate/claudecode_tool_filter.go
+++ b/internal/translate/claudecode_tool_filter.go
@@ -100,8 +100,7 @@ func shouldStripCCTool(name string, keepOrchestration bool) bool {
 // without paying a re-serialize cost on the common case.
 //
 // When keepOrchestration is set, the orchestration subset (Task*, Workflow,
-// Skill, plan-mode) is retained so capable non-Anthropic models can drive
-// subagents/workflows/skills; the remaining CC-only tools are still dropped.
+// Skill, plan-mode) is retained; other CC-only tools are still dropped.
 //
 // Only the tools array is rewritten; tool_choice and message content are
 // left alone. tool_choice is rare and Anthropic only honors "any"/"auto"/

--- a/internal/translate/claudecode_tool_filter.go
+++ b/internal/translate/claudecode_tool_filter.go
@@ -56,10 +56,56 @@ func isClaudeCodeOnlyTool(name string) bool {
 	return ok
 }
 
+// claudeCodeOrchestrationToolNames is the subset of claudeCodeOnlyToolNames
+// that drives multi-step work the client executes on the model's behalf:
+// subagent dispatch (Task*), workflow runs, skill invocation, and plan-mode
+// toggles. Unlike the rest of the CC-only set (Cron*, Monitor, MCP-resource
+// tools, worktree/LSP helpers), a capable non-Anthropic model can emit a
+// well-formed call to one of these and have the client action it — so they are
+// optionally preserved on cross-vendor emit to let workflows/subagents run off
+// the Anthropic family. Must stay a strict subset of claudeCodeOnlyToolNames.
+var claudeCodeOrchestrationToolNames = map[string]struct{}{
+	"Task":          {},
+	"TaskCreate":    {},
+	"TaskUpdate":    {},
+	"TaskGet":       {},
+	"TaskList":      {},
+	"TaskOutput":    {},
+	"TaskStop":      {},
+	"Workflow":      {},
+	"Skill":         {},
+	"EnterPlanMode": {},
+	"ExitPlanMode":  {},
+}
+
+// isCrossVendorOrchestrationTool reports whether name is a Claude Code
+// orchestration tool that may be preserved on cross-vendor emit.
+func isCrossVendorOrchestrationTool(name string) bool {
+	_, ok := claudeCodeOrchestrationToolNames[name]
+	return ok
+}
+
+// shouldStripCCTool reports whether a tool must be dropped from a cross-vendor
+// emit. Non-CC-only tools are always kept. CC-only tools are dropped, except
+// that orchestration tools are retained when keepOrchestration is set.
+func shouldStripCCTool(name string, keepOrchestration bool) bool {
+	if !isClaudeCodeOnlyTool(name) {
+		return false
+	}
+	if keepOrchestration && isCrossVendorOrchestrationTool(name) {
+		return false
+	}
+	return true
+}
+
 // filterClaudeCodeOnlyToolsFromAnthropicBody returns body with any
 // Claude-Code-only tools removed from the top-level "tools" array. Returns
 // body unchanged when none match, so callers can apply this unconditionally
 // without paying a re-serialize cost on the common case.
+//
+// When keepOrchestration is set, the orchestration subset (Task*, Workflow,
+// Skill, plan-mode) is retained so capable non-Anthropic models can drive
+// subagents/workflows/skills; the remaining CC-only tools are still dropped.
 //
 // Only the tools array is rewritten; tool_choice and message content are
 // left alone. tool_choice is rare and Anthropic only honors "any"/"auto"/
@@ -68,14 +114,14 @@ func isClaudeCodeOnlyTool(name string) bool {
 // blocks from past turns) is not rewritten because those represent history
 // the model has already acted on — rewriting it would invalidate prompt
 // caches and could leave dangling tool_use_id references.
-func filterClaudeCodeOnlyToolsFromAnthropicBody(body []byte) (out []byte, removed int, err error) {
+func filterClaudeCodeOnlyToolsFromAnthropicBody(body []byte, keepOrchestration bool) (out []byte, removed int, err error) {
 	tools := gjson.GetBytes(body, "tools")
 	if !tools.Exists() || !tools.IsArray() {
 		return body, 0, nil
 	}
 
 	tools.ForEach(func(_, t gjson.Result) bool {
-		if isClaudeCodeOnlyTool(t.Get("name").String()) {
+		if shouldStripCCTool(t.Get("name").String(), keepOrchestration) {
 			removed++
 		}
 		return true
@@ -87,7 +133,7 @@ func filterClaudeCodeOnlyToolsFromAnthropicBody(body []byte) (out []byte, remove
 	jw := newJSONWriter()
 	jw.Arr()
 	tools.ForEach(func(_, t gjson.Result) bool {
-		if !isClaudeCodeOnlyTool(t.Get("name").String()) {
+		if !shouldStripCCTool(t.Get("name").String(), keepOrchestration) {
 			jw.Raw(t.Raw)
 		}
 		return true

--- a/internal/translate/claudecode_tool_filter_internal_test.go
+++ b/internal/translate/claudecode_tool_filter_internal_test.go
@@ -1,0 +1,39 @@
+package translate
+
+import "testing"
+
+// The orchestration set must stay a strict subset of the CC-only set: shouldStripCCTool
+// only reaches its keep-orchestration branch for names it already treats as CC-only, so
+// an orchestration entry that isn't also CC-only would be a silent no-op (and a lie in
+// the docs). This breaks the moment someone adds an orchestration name without adding it
+// to claudeCodeOnlyToolNames.
+func TestOrchestrationToolsAreSubsetOfCCOnly(t *testing.T) {
+	for name := range claudeCodeOrchestrationToolNames {
+		if !isClaudeCodeOnlyTool(name) {
+			t.Errorf("orchestration tool %q is not in claudeCodeOnlyToolNames; the subset invariant is broken", name)
+		}
+	}
+}
+
+func TestShouldStripCCTool(t *testing.T) {
+	cases := []struct {
+		name              string
+		keepOrchestration bool
+		want              bool
+	}{
+		{"Read", false, false},          // real tool: never stripped
+		{"Read", true, false},           // real tool: never stripped
+		{"Task", false, true},           // orchestration: stripped when flag off
+		{"Task", true, false},           // orchestration: kept when flag on
+		{"Workflow", true, false},       // orchestration: kept when flag on
+		{"ExitPlanMode", true, false},   // orchestration: kept when flag on
+		{"AskUserQuestion", true, true}, // CC-only non-orchestration: stripped even when flag on
+		{"NotebookEdit", true, true},    // CC-only non-orchestration: stripped even when flag on
+		{"CronCreate", false, true},     // CC-only non-orchestration: stripped
+	}
+	for _, tc := range cases {
+		if got := shouldStripCCTool(tc.name, tc.keepOrchestration); got != tc.want {
+			t.Errorf("shouldStripCCTool(%q, keep=%v) = %v, want %v", tc.name, tc.keepOrchestration, got, tc.want)
+		}
+	}
+}

--- a/internal/translate/claudecode_tool_filter_internal_test.go
+++ b/internal/translate/claudecode_tool_filter_internal_test.go
@@ -2,11 +2,9 @@ package translate
 
 import "testing"
 
-// The orchestration set must stay a strict subset of the CC-only set: shouldStripCCTool
-// only reaches its keep-orchestration branch for names it already treats as CC-only, so
-// an orchestration entry that isn't also CC-only would be a silent no-op (and a lie in
-// the docs). This breaks the moment someone adds an orchestration name without adding it
-// to claudeCodeOnlyToolNames.
+// claudeCodeOrchestrationToolNames must be a strict subset of claudeCodeOnlyToolNames;
+// otherwise shouldStripCCTool silently skips the keep-orchestration branch for any
+// name missing from the CC-only set.
 func TestOrchestrationToolsAreSubsetOfCCOnly(t *testing.T) {
 	for name := range claudeCodeOrchestrationToolNames {
 		if !isClaudeCodeOnlyTool(name) {

--- a/internal/translate/claudecode_tool_filter_test.go
+++ b/internal/translate/claudecode_tool_filter_test.go
@@ -149,6 +149,66 @@ func TestStripCCTools_AnthropicSourceAnthropicTarget_KeepsCCOnly(t *testing.T) {
 	assert.Contains(t, got, "Read", "real coding tools must also survive on passthrough")
 }
 
+func TestKeepOrchestrationTools_OpenAITarget_KeepsOrchestrationDropsRest(t *testing.T) {
+	// With the cross-vendor orchestration flag on, Task*/Skill/Workflow/plan-mode
+	// survive so a capable non-Anthropic model can drive subagents/workflows,
+	// while the remaining CC-only tools (AskUserQuestion, NotebookEdit) are still
+	// stripped.
+	env, err := translate.ParseAnthropic([]byte(claudeCodeMixedToolBody))
+	require.NoError(t, err)
+
+	out, err := env.PrepareOpenAI(nil, translate.EmitOptions{
+		TargetModel:                       "deepseek/deepseek-v4-pro",
+		KeepCrossVendorOrchestrationTools: true,
+	})
+	require.NoError(t, err)
+
+	names := emittedToolNames(t, out.Body)
+	assert.ElementsMatch(t, []string{
+		"Read", "Edit", "Write", "Bash",
+		"Task", "TaskCreate", "TaskUpdate", "TaskList",
+		"EnterPlanMode", "ExitPlanMode", "Skill", "Workflow",
+	}, names, "orchestration tools survive when the flag is on; other CC-only tools still stripped")
+	assert.NotContains(t, names, "AskUserQuestion", "non-orchestration CC-only tools stay stripped")
+	assert.NotContains(t, names, "NotebookEdit")
+}
+
+func TestKeepOrchestrationTools_GeminiTarget_KeepsOrchestrationDropsRest(t *testing.T) {
+	env, err := translate.ParseAnthropic([]byte(claudeCodeMixedToolBody))
+	require.NoError(t, err)
+
+	out, err := env.PrepareGemini(http.Header{}, translate.EmitOptions{
+		TargetModel:                       "gemini-3.1-pro-preview",
+		KeepCrossVendorOrchestrationTools: true,
+	})
+	require.NoError(t, err)
+
+	names := emittedGeminiToolNames(t, out.Body)
+	assert.ElementsMatch(t, []string{
+		"Read", "Edit", "Write", "Bash",
+		"Task", "TaskCreate", "TaskUpdate", "TaskList",
+		"EnterPlanMode", "ExitPlanMode", "Skill", "Workflow",
+	}, names, "Anthropic→Gemini keeps orchestration tools when the flag is on")
+	assert.NotContains(t, names, "AskUserQuestion")
+	assert.NotContains(t, names, "NotebookEdit")
+}
+
+func TestKeepOrchestrationTools_EmitOptionsZeroValue_StripsAll(t *testing.T) {
+	// The translate layer requires explicit opt-in: a zero-value EmitOptions
+	// (KeepCrossVendorOrchestrationTools unset) must strip every CC-only tool,
+	// so a caller that doesn't set the field gets the historical behavior. The
+	// production default (on) is applied by the proxy composition root, not here.
+	env, err := translate.ParseAnthropic([]byte(claudeCodeMixedToolBody))
+	require.NoError(t, err)
+
+	out, err := env.PrepareOpenAI(nil, translate.EmitOptions{TargetModel: "deepseek/deepseek-v4-pro"})
+	require.NoError(t, err)
+
+	names := emittedToolNames(t, out.Body)
+	assert.ElementsMatch(t, []string{"Read", "Edit", "Write", "Bash"}, names,
+		"unset flag must strip every CC-only tool including orchestration ones")
+}
+
 func TestStripCCTools_NoCCToolsNoRewrite(t *testing.T) {
 	// When the request carries no CC-only tools, the filter must not
 	// re-serialize the body (cheap fast path).

--- a/internal/translate/claudecode_tool_filter_test.go
+++ b/internal/translate/claudecode_tool_filter_test.go
@@ -150,10 +150,7 @@ func TestStripCCTools_AnthropicSourceAnthropicTarget_KeepsCCOnly(t *testing.T) {
 }
 
 func TestKeepOrchestrationTools_OpenAITarget_KeepsOrchestrationDropsRest(t *testing.T) {
-	// With the cross-vendor orchestration flag on, Task*/Skill/Workflow/plan-mode
-	// survive so a capable non-Anthropic model can drive subagents/workflows,
-	// while the remaining CC-only tools (AskUserQuestion, NotebookEdit) are still
-	// stripped.
+	// Flag on: orchestration tools survive; other CC-only tools (AskUserQuestion, NotebookEdit) are still stripped.
 	env, err := translate.ParseAnthropic([]byte(claudeCodeMixedToolBody))
 	require.NoError(t, err)
 
@@ -194,10 +191,8 @@ func TestKeepOrchestrationTools_GeminiTarget_KeepsOrchestrationDropsRest(t *test
 }
 
 func TestKeepOrchestrationTools_EmitOptionsZeroValue_StripsAll(t *testing.T) {
-	// The translate layer requires explicit opt-in: a zero-value EmitOptions
-	// (KeepCrossVendorOrchestrationTools unset) must strip every CC-only tool,
-	// so a caller that doesn't set the field gets the historical behavior. The
-	// production default (on) is applied by the proxy composition root, not here.
+	// Zero-value EmitOptions strips all CC-only tools; production default
+	// (on) is set by the proxy composition root, not the translate layer.
 	env, err := translate.ParseAnthropic([]byte(claudeCodeMixedToolBody))
 	require.NoError(t, err)
 

--- a/internal/translate/emit_gemini.go
+++ b/internal/translate/emit_gemini.go
@@ -79,7 +79,7 @@ func (e *RequestEnvelope) PrepareGemini(_ http.Header, opts EmitOptions) (provid
 			return providers.PreparedRequest{}, err
 		}
 	case FormatAnthropic:
-		filtered, removed, err := filterClaudeCodeOnlyToolsFromAnthropicBody(e.body)
+		filtered, removed, err := filterClaudeCodeOnlyToolsFromAnthropicBody(e.body, opts.KeepCrossVendorOrchestrationTools)
 		if err != nil {
 			return providers.PreparedRequest{}, fmt.Errorf("strip claude-code-only tools: %w", err)
 		}

--- a/internal/translate/emit_openai.go
+++ b/internal/translate/emit_openai.go
@@ -244,7 +244,7 @@ func targetIsOpenRouter(opts EmitOptions) bool {
 
 func (e *RequestEnvelope) buildOpenAIFromAnthropic(opts EmitOptions) ([]byte, providers.RequestMutationStats, error) {
 	var stats providers.RequestMutationStats
-	body, removed, err := filterClaudeCodeOnlyToolsFromAnthropicBody(e.body)
+	body, removed, err := filterClaudeCodeOnlyToolsFromAnthropicBody(e.body, opts.KeepCrossVendorOrchestrationTools)
 	if err != nil {
 		return nil, stats, fmt.Errorf("strip claude-code-only tools: %w", err)
 	}

--- a/internal/translate/emit_openai_responses.go
+++ b/internal/translate/emit_openai_responses.go
@@ -98,7 +98,7 @@ const minResponsesOutputTokens = 16000
 
 func (e *RequestEnvelope) buildResponsesFromAnthropic(opts EmitOptions) ([]byte, providers.RequestMutationStats, error) {
 	var stats providers.RequestMutationStats
-	body, removed, err := filterClaudeCodeOnlyToolsFromAnthropicBody(e.body)
+	body, removed, err := filterClaudeCodeOnlyToolsFromAnthropicBody(e.body, opts.KeepCrossVendorOrchestrationTools)
 	if err != nil {
 		return nil, stats, fmt.Errorf("strip claude-code-only tools: %w", err)
 	}

--- a/internal/translate/envelope.go
+++ b/internal/translate/envelope.go
@@ -61,13 +61,10 @@ type EmitOptions struct {
 	// instead of 200K, avoiding a 400 "prompt is too long" on large requests.
 	// No-op below 200K input. deriveAnthropicHeaders gates on CapExtendedContext.
 	EnableExtendedContext bool
-	// KeepCrossVendorOrchestrationTools preserves the Claude Code orchestration
-	// tools (Task*, Workflow, Skill, plan-mode) on Anthropic→non-Anthropic emit
-	// instead of stripping them, so a capable upstream can drive subagents /
-	// workflows / skills. The rest of the Claude-Code-only set (Cron*, Monitor,
-	// MCP-resource tools, ...) is still stripped. The proxy sets this from the
-	// ROUTER_CC_ORCH_TOOLS_CROSSVENDOR flag (on by default); the zero value here
-	// is false so a caller that doesn't opt in still gets the historical strip.
+	// KeepCrossVendorOrchestrationTools preserves CC orchestration tools
+	// (Task*, Workflow, Skill, plan-mode) on cross-vendor emit; other CC-only
+	// tools are always stripped. Set from ROUTER_CC_ORCH_TOOLS_CROSSVENDOR;
+	// zero value false preserves historical strip-all behavior.
 	KeepCrossVendorOrchestrationTools bool
 	// DowngradeGeminiValidatedToAuto emits functionCallingConfig.mode=AUTO
 	// instead of VALIDATED for Gemini 3.x. VALIDATED compiles tool schemas into

--- a/internal/translate/envelope.go
+++ b/internal/translate/envelope.go
@@ -61,6 +61,14 @@ type EmitOptions struct {
 	// instead of 200K, avoiding a 400 "prompt is too long" on large requests.
 	// No-op below 200K input. deriveAnthropicHeaders gates on CapExtendedContext.
 	EnableExtendedContext bool
+	// KeepCrossVendorOrchestrationTools preserves the Claude Code orchestration
+	// tools (Task*, Workflow, Skill, plan-mode) on Anthropic→non-Anthropic emit
+	// instead of stripping them, so a capable upstream can drive subagents /
+	// workflows / skills. The rest of the Claude-Code-only set (Cron*, Monitor,
+	// MCP-resource tools, ...) is still stripped. The proxy sets this from the
+	// ROUTER_CC_ORCH_TOOLS_CROSSVENDOR flag (on by default); the zero value here
+	// is false so a caller that doesn't opt in still gets the historical strip.
+	KeepCrossVendorOrchestrationTools bool
 	// DowngradeGeminiValidatedToAuto emits functionCallingConfig.mode=AUTO
 	// instead of VALIDATED for Gemini 3.x. VALIDATED compiles tool schemas into
 	// a decode-time grammar and 400s INVALID_ARGUMENT if one won't compile; the


### PR DESCRIPTION
## What

Adds `ROUTER_CC_ORCH_TOOLS_CROSSVENDOR` (**on by default**; set `=false` as a kill switch). The Anthropic→non-Anthropic emit paths (OpenAI chat, OpenAI Responses, Gemini) now **preserve** the Claude Code orchestration tools — `Task*`, `Workflow`, `Skill`, `EnterPlanMode`/`ExitPlanMode` — instead of stripping them, so a capable non-Anthropic upstream can actually drive subagents / workflows / skills off the Anthropic family.

The rest of the Claude-Code-only set (`Cron*`, `Monitor`, `PushNotification`, `RemoteTrigger`, worktree/LSP helpers, MCP-resource tools, `NotebookEdit`, `AskUserQuestion`) stays stripped regardless — those have no benefit to a remote model and are pure hallucination surface.

## Why

Previously `claudecode_tool_filter.go` stripped all CC-only tools on every cross-vendor emit (a v0.57 anti-phantom-tool measure). The side effect: when the router routes a turn to a non-Anthropic model, that model literally can't see or invoke `Task`/`Workflow`/`Skill` — so Claude Code workflows/subagents silently don't work through the router on non-Anthropic routes.

Scoping to the orchestration subset (rather than un-stripping everything) follows Anthropic's own guidance that tool-selection accuracy degrades with large tool sets — a smaller executable namespace is better for a weaker non-Anthropic model — while keeping the highest-noise meta-tools out of reach.

## How

- Split out `claudeCodeOrchestrationToolNames` (a strict subset of `claudeCodeOnlyToolNames`) + `shouldStripCCTool(name, keepOrchestration)`.
- New `EmitOptions.KeepCrossVendorOrchestrationTools`, threaded from `main.go` env → `Service` (`WithCCOrchestrationToolsCrossVendor`) → the ProxyMessages emit `opts` → the three cross-vendor filter call sites.
- Default on: `NewService` defaults the field `true` and `main.go` reads the env with default `"true"` (mirrors the `spiralShadowEnabled` pattern). The translate-layer `EmitOptions` zero value stays `false`, so a caller that doesn't opt in still gets the historical strip.

No response-path or history changes needed: the response-side `toolcheck` validator compiles from the **unfiltered** inbound body, so `Task`/`Workflow`/`Skill` are already known tools — their args are validated/repaired on every response path the moment the definitions are forwarded. Un-stripping also removes the pre-existing inconsistency where a history `Task` tool_use was emitted as a native call referencing an undeclared tool.

## Tests

- Flag-on keeps orchestration / drops the rest — OpenAI and Gemini targets.
- `EmitOptions` zero-value still strips everything (translate-layer opt-in invariant).
- `shouldStripCCTool` table + a subset-invariant test (breaks if an orchestration name isn't also CC-only).

`go build ./...`, `go vet ./...`, full `go test ./...` all green; gofmt clean.

## Follow-up

Recommend baking off with the v0.57-style SWE-bench shard (flag on vs. off) to watch phantom-call and empty-patch rates. If phantoms reappear, the next lever is dropping *unrepairable* orchestration-tool calls on the response path (deferred out of this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)