### PR TITLE
fix(translate): normalize typeless OpenAI anyOf branches

### DIFF
--- a/internal/translate/claudecode_tool_filter_test.go
+++ b/internal/translate/claudecode_tool_filter_test.go
@@ -170,6 +170,35 @@ func TestKeepOrchestrationTools_OpenAITarget_KeepsOrchestrationDropsRest(t *test
 	assert.NotContains(t, names, "NotebookEdit")
 }
 
+func TestKeepOrchestrationTools_OpenAITarget_NormalizesTypelessAnyOf(t *testing.T) {
+	body := `{
+		"model":"claude-opus-4-7",
+		"messages":[{"role":"user","content":"run a workflow"}],
+		"tools":[{
+			"name":"Workflow",
+			"input_schema":{"type":"object","properties":{"args":{"anyOf":[{}, {"type":"null"}]}}}
+		}]
+	}`
+	env, err := translate.ParseAnthropic([]byte(body))
+	require.NoError(t, err)
+
+	out, err := env.PrepareOpenAI(nil, translate.EmitOptions{
+		TargetModel:                       "deepseek/deepseek-v4-pro",
+		KeepCrossVendorOrchestrationTools: true,
+	})
+	require.NoError(t, err)
+
+	var doc map[string]any
+	require.NoError(t, json.Unmarshal(out.Body, &doc))
+	tools := doc["tools"].([]any)
+	workflow := tools[0].(map[string]any)["function"].(map[string]any)
+	params := workflow["parameters"].(map[string]any)
+	args := params["properties"].(map[string]any)["args"].(map[string]any)
+	branch := args["anyOf"].([]any)[0].(map[string]any)
+	assert.Equal(t, []any{"string", "number", "boolean", "object", "array", "null"}, branch["type"],
+		"OpenAI requires every anyOf branch to declare a type")
+}
+
 func TestKeepOrchestrationTools_GeminiTarget_KeepsOrchestrationDropsRest(t *testing.T) {
 	env, err := translate.ParseAnthropic([]byte(claudeCodeMixedToolBody))
 	require.NoError(t, err)

--- a/internal/translate/emit_openai.go
+++ b/internal/translate/emit_openai.go
@@ -889,10 +889,26 @@ func sanitizeOpenAIToolSchema(node any) {
 		if arr, ok := m[key].([]any); ok {
 			for _, v := range arr {
 				sanitizeOpenAIToolSchema(v)
+				if key == "anyOf" {
+					addOpenAIAnyOfBranchType(v)
+				}
 			}
 		}
 	}
 	sanitizeOpenAIToolSchema(m["not"])
+}
+
+// addOpenAIAnyOfBranchType makes an unconstrained JSON Schema branch explicit.
+// OpenAI rejects a typeless anyOf branch, while `{}` means every JSON value.
+func addOpenAIAnyOfBranchType(node any) {
+	m, ok := node.(map[string]any)
+	if !ok {
+		return
+	}
+	if _, hasType := m["type"]; hasType {
+		return
+	}
+	m["type"] = []any{"string", "number", "boolean", "object", "array", "null"}
 }
 
 func appendSchemaConstraintDescription(node map[string]any, key string, value any) {


### PR DESCRIPTION
Fixes the OpenAI 400 introduced when #823 preserved Claude Code orchestration tools cross-vendor.

`Workflow` can include an unconstrained `{}` branch in `args.anyOf`; OpenAI requires every `anyOf` branch to provide `type`. Normalize that branch to the complete set of JSON value types, preserving its original semantics.

Test: `go test ./internal/translate`