### PR TITLE
docs: canonical router semantics (session/round/turn/action/step)

### DIFF
--- a/.claude/skills/test-claude-locally/SKILL.md
+++ b/.claude/skills/test-claude-locally/SKILL.md
@@ -92,7 +92,7 @@ Then <task that requires tool use>, then stop.' \
 
 ### 6. Verify via logs
 
-The decision + completion log per turn carries the signals you need. Strip ANSI first:
+The decision + completion log per action (one `ProxyMessages complete`) carries the signals you need. Strip ANSI first:
 
 ```bash
 docker compose logs server --since=3m 2>&1 | sed -E 's/\x1b\[[0-9;]*m//g' \

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,7 +70,7 @@ Three concentric layers. Imports flow inward only.
 |  |  |  internal/proxy     (routing/dispatch service:        |  |  |
 |  |  |                      Route, ProxyMessages,            |  |  |
 |  |  |                      ProxyOpenAIChatCompletion,       |  |  |
-|  |  |                      ProxyGemini; turn loop,          |  |  |
+|  |  |                      ProxyGemini; action loop,          |  |  |
 |  |  |                      handover adapter, cache writer,  |  |  |
 |  |  |                      session-key derivation)          |  |  |
 |  |  |  internal/proxy/usage (Anthropic unified-limit        |  |  |
@@ -109,7 +109,7 @@ Three concentric layers. Imports flow inward only.
 
 ### Hard rules
 
-- **Layering is load-bearing.** Imports flow inward only. Inner-ring packages must not import adapter or presentation packages; adapters never import each other; only `cmd/router/main.go` constructs concrete things. Inner-ring packages may import each other (e.g. `proxy.Service.Route` returns `router.Decision`; `proxy.Service` calls `translate`, `sessionpin`, `planner`, `handover`, `cache`, `catalog`, `turntype`, `usage`, `billing` to compose a turn).
+- **Layering is load-bearing.** Imports flow inward only. Inner-ring packages must not import adapter or presentation packages; adapters never import each other; only `cmd/router/main.go` constructs concrete things. Inner-ring packages may import each other (e.g. `proxy.Service.Route` returns `router.Decision`; `proxy.Service` calls `translate`, `sessionpin`, `planner`, `handover`, `cache`, `catalog`, `turntype`, `usage`, `billing` to compose an action).
 - **Small utility third-party libs allowed at every layer.** Layering = about *where I/O and behavior live*, not banning go.mod entries. Reach for vetted small lib (`golang-lru`, `uuid`, error helpers) before rolling own. Reject heavyweight frameworks (DI containers, ORMs, metaprogramming kits).
 - **Inner-ring packages are I/O-free.** `internal/router`, `internal/providers`, `internal/translate`, `internal/sse`, `internal/timing`, `internal/feedback`, `internal/router/{cache,catalog,handover,planner,sessionpin,turntype,banditexplore}`, `internal/proxy/usage` define interfaces, value types, pure functions only. Adding I/O method (HTTP, DB, queue, FS) = layering violation; put on `auth.Service` / `proxy.Service` / `billing.Service` or adapter subpackage. Pure-Go utility libs fine.
 - **Adapters depend only on inner ring.** `internal/postgres` may also import `internal/sqlc`. Adapters never import each other — `internal/postgres` doesn't know `internal/api/admin` etc. Note: provider adapters (`internal/providers/<name>/`) import `internal/proxy` for `OnUpstreamMeta` callback so streaming responses record usage/headers back to proxy — one of few inward-pointing adapter→inner-ring imports, intentional. `internal/server/middleware` and `internal/providers/httputil` (both adapters) stamp/read request latency via `internal/timing`'s `Timing` value type instead of importing `internal/observability/otel` directly — `Timing` used to live in `otel` and was pulled out specifically so these adapters (and `internal/providers/{anthropic,openai,google,openaicompat}`) don't need a concrete dependency on the OTel exporter adapter just to stamp a timestamp. `internal/proxy` also imports `internal/timing` (an inner-ring package importing another inner-ring package, which is allowed) to read timing back into span attributes.
@@ -127,7 +127,7 @@ Pick by responsibility, then read that package's `CLAUDE.md`:
 |---|---|---|
 | HTTP endpoint (handler + route) | `internal/api/<group>/` | [internal/api/CLAUDE.md](internal/api/CLAUDE.md) |
 | Identity / API-key logic | `internal/auth` (method on `*Service`) | [internal/auth/CLAUDE.md](internal/auth/CLAUDE.md) |
-| Routing / dispatch / per-turn orchestration | `internal/proxy` (method on `*Service`) | [internal/proxy/CLAUDE.md](internal/proxy/CLAUDE.md) |
+| Routing / dispatch / per-action orchestration | `internal/proxy` (method on `*Service`) | [internal/proxy/CLAUDE.md](internal/proxy/CLAUDE.md) |
 | Balance check / inference debit | `internal/billing` (method on `*Service`) | — |
 | Feedback-link token signing (no I/O) | `internal/feedback` | — |
 | Cross-format wire conversion (no I/O) | `internal/translate` | [internal/translate/CLAUDE.md](internal/translate/CLAUDE.md) |
@@ -135,7 +135,7 @@ Pick by responsibility, then read that package's `CLAUDE.md`:
 | New `Router` implementation | `internal/router/<name>/` | [internal/router/CLAUDE.md](internal/router/CLAUDE.md) |
 | Cluster scorer / artifacts | `internal/router/cluster/` | [internal/router/cluster/CLAUDE.md](internal/router/cluster/CLAUDE.md) |
 | New model / per-model pricing data | `internal/router/catalog/` | [internal/router/catalog/CLAUDE.md](internal/router/catalog/CLAUDE.md) |
-| Cache-aware turn routing internals | `internal/router/{planner,handover,cache,sessionpin,turntype}/` | each has its own CLAUDE.md |
+| Cache-aware action routing internals | `internal/router/{planner,handover,cache,sessionpin,turntype}/` | each has its own CLAUDE.md |
 | Bounded quality-tie-band exploration | `internal/router/banditexplore/` | — |
 | Anthropic usage-bypass gate | `internal/proxy/usage` | [internal/proxy/usage/CLAUDE.md](internal/proxy/usage/CLAUDE.md) |
 | New column / SQL query | `db/queries/` + `internal/postgres/` | [db/CLAUDE.md](db/CLAUDE.md), [internal/postgres/CLAUDE.md](internal/postgres/CLAUDE.md) |
@@ -215,7 +215,7 @@ The eval harness is a sibling Poetry package, **not in this repo** — lives at 
 **Per-request router selection (server side):**
 
 - [`internal/server/middleware`](internal/server/middleware).`WithClusterVersionOverride` reads `x-weave-cluster-version: v0.X` header + stashes version on request context. `cluster.Multiversion.Route` reads via `cluster.VersionFromContext` + dispatches to matching `Scorer`. Customer traffic (no header) always serves deployment's default version (`ROUTER_CLUSTER_VERSION` → `artifacts/latest`).
-- `WithEmbedOnlyUserMessageOverride` honors `x-weave-embed-only-user-message: true|false` header, flipping proxy between embedding user-role text only (default) + concatenated turn stream.
+- `WithEmbedOnlyUserMessageOverride` honors `x-weave-embed-only-user-message: true|false` header, flipping proxy between embedding user-role text only (default) + concatenated action stream.
 
 **What to NOT do:**
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,7 +70,7 @@ Three concentric layers. Imports flow inward only.
 |  |  |  internal/proxy     (routing/dispatch service:        |  |  |
 |  |  |                      Route, ProxyMessages,            |  |  |
 |  |  |                      ProxyOpenAIChatCompletion,       |  |  |
-|  |  |                      ProxyGemini; turn loop,          |  |  |
+|  |  |                      ProxyGemini; action loop,          |  |  |
 |  |  |                      handover adapter, cache writer,  |  |  |
 |  |  |                      session-key derivation)          |  |  |
 |  |  |  internal/proxy/usage (Anthropic unified-limit        |  |  |
@@ -109,7 +109,7 @@ Three concentric layers. Imports flow inward only.
 
 ### Hard rules
 
-- **Layering is load-bearing.** Imports flow inward only. Inner-ring packages must not import adapter or presentation packages; adapters never import each other; only `cmd/router/main.go` constructs concrete things. Inner-ring packages may import each other (e.g. `proxy.Service.Route` returns `router.Decision`; `proxy.Service` calls `translate`, `sessionpin`, `planner`, `handover`, `cache`, `catalog`, `turntype`, `usage`, `billing` to compose a turn).
+- **Layering is load-bearing.** Imports flow inward only. Inner-ring packages must not import adapter or presentation packages; adapters never import each other; only `cmd/router/main.go` constructs concrete things. Inner-ring packages may import each other (e.g. `proxy.Service.Route` returns `router.Decision`; `proxy.Service` calls `translate`, `sessionpin`, `planner`, `handover`, `cache`, `catalog`, `turntype`, `usage`, `billing` to compose an action).
 - **Small utility third-party libs allowed at every layer.** Layering = about *where I/O and behavior live*, not banning go.mod entries. Reach for vetted small lib (`golang-lru`, `uuid`, error helpers) before rolling own. Reject heavyweight frameworks (DI containers, ORMs, metaprogramming kits).
 - **Inner-ring packages are I/O-free.** `internal/router`, `internal/providers`, `internal/translate`, `internal/sse`, `internal/timing`, `internal/feedback`, `internal/router/{cache,catalog,handover,planner,sessionpin,turntype,banditexplore}`, `internal/proxy/usage` define interfaces, value types, pure functions only. Adding I/O method (HTTP, DB, queue, FS) = layering violation; put on `auth.Service` / `proxy.Service` / `billing.Service` or adapter subpackage. Pure-Go utility libs fine.
 - **Adapters depend only on inner ring.** `internal/postgres` may also import `internal/sqlc`. Adapters never import each other — `internal/postgres` doesn't know `internal/api/admin` etc. Note: provider adapters (`internal/providers/<name>/`) import `internal/proxy` for `OnUpstreamMeta` callback so streaming responses record usage/headers back to proxy — one of few inward-pointing adapter→inner-ring imports, intentional. `internal/server/middleware` and `internal/providers/httputil` (both adapters) stamp/read request latency via `internal/timing`'s `Timing` value type instead of importing `internal/observability/otel` directly — `Timing` used to live in `otel` and was pulled out specifically so these adapters (and `internal/providers/{anthropic,openai,google,openaicompat}`) don't need a concrete dependency on the OTel exporter adapter just to stamp a timestamp. `internal/proxy` also imports `internal/timing` (an inner-ring package importing another inner-ring package, which is allowed) to read timing back into span attributes.
@@ -127,7 +127,7 @@ Pick by responsibility, then read that package's `CLAUDE.md`:
 |---|---|---|
 | HTTP endpoint (handler + route) | `internal/api/<group>/` | [internal/api/CLAUDE.md](internal/api/CLAUDE.md) |
 | Identity / API-key logic | `internal/auth` (method on `*Service`) | [internal/auth/CLAUDE.md](internal/auth/CLAUDE.md) |
-| Routing / dispatch / per-turn orchestration | `internal/proxy` (method on `*Service`) | [internal/proxy/CLAUDE.md](internal/proxy/CLAUDE.md) |
+| Routing / dispatch / per-action orchestration | `internal/proxy` (method on `*Service`) | [internal/proxy/CLAUDE.md](internal/proxy/CLAUDE.md) |
 | Balance check / inference debit | `internal/billing` (method on `*Service`) | — |
 | Feedback-link token signing (no I/O) | `internal/feedback` | — |
 | Cross-format wire conversion (no I/O) | `internal/translate` | [internal/translate/CLAUDE.md](internal/translate/CLAUDE.md) |
@@ -135,7 +135,7 @@ Pick by responsibility, then read that package's `CLAUDE.md`:
 | New `Router` implementation | `internal/router/<name>/` | [internal/router/CLAUDE.md](internal/router/CLAUDE.md) |
 | Cluster scorer / artifacts | `internal/router/cluster/` | [internal/router/cluster/CLAUDE.md](internal/router/cluster/CLAUDE.md) |
 | New model / per-model pricing data | `internal/router/catalog/` | [internal/router/catalog/CLAUDE.md](internal/router/catalog/CLAUDE.md) |
-| Cache-aware turn routing internals | `internal/router/{planner,handover,cache,sessionpin,turntype}/` | each has its own CLAUDE.md |
+| Cache-aware action routing internals | `internal/router/{planner,handover,cache,sessionpin,turntype}/` | each has its own CLAUDE.md |
 | Bounded quality-tie-band exploration | `internal/router/banditexplore/` | — |
 | Anthropic usage-bypass gate | `internal/proxy/usage` | [internal/proxy/usage/CLAUDE.md](internal/proxy/usage/CLAUDE.md) |
 | New column / SQL query | `db/queries/` + `internal/postgres/` | [db/CLAUDE.md](db/CLAUDE.md), [internal/postgres/CLAUDE.md](internal/postgres/CLAUDE.md) |
@@ -215,7 +215,7 @@ The eval harness is a sibling Poetry package, **not in this repo** — lives at 
 **Per-request router selection (server side):**
 
 - [`internal/server/middleware`](internal/server/middleware).`WithClusterVersionOverride` reads `x-weave-cluster-version: v0.X` header + stashes version on request context. `cluster.Multiversion.Route` reads via `cluster.VersionFromContext` + dispatches to matching `Scorer`. Customer traffic (no header) always serves deployment's default version (`ROUTER_CLUSTER_VERSION` → `artifacts/latest`).
-- `WithEmbedOnlyUserMessageOverride` honors `x-weave-embed-only-user-message: true|false` header, flipping proxy between embedding user-role text only (default) + concatenated turn stream.
+- `WithEmbedOnlyUserMessageOverride` honors `x-weave-embed-only-user-message: true|false` header, flipping proxy between embedding user-role text only (default) + concatenated action stream.
 
 **What to NOT do:**
 

--- a/README.md
+++ b/README.md
@@ -40,9 +40,11 @@ loved by Robinhood, PostHog, Reducto, and hundreds of others.*
 
 Point Claude Code, Codex, Cursor, or your own app at `localhost:8080`. The router:
 
-- 🎯 **Routes per request.** A cluster scorer derived from
+- 🎯 **Routes per action.** A cluster scorer derived from
   [Avengers-Pro](https://arxiv.org/abs/2508.12631) [^1] picks the right
-  model from your enabled providers, every turn.
+  model from your enabled providers, for every upstream API request.
+  (See [docs/SEMANTICS.md](docs/SEMANTICS.md) for the canonical terminology:
+  the router routes per **action**, not per **turn**.)
 - 🔌 **Speaks everyone's API.** Anthropic Messages, OpenAI Chat Completions,
   Gemini native. Streaming, tools, vision, the works.
 - 🧠 **Knows OSS too.** DeepSeek, Kimi, GLM, Qwen, Llama, Mistral via
@@ -180,6 +182,8 @@ Keep liveness probes on `/health`. Point startup or readiness probes at
 
 - 📐 [**Configuration reference**](docs/CONFIGURATION.md): every env var,
   BYOK encryption, OTel knobs, cluster routing.
+- 🧭 [**Semantics and terminology**](docs/SEMANTICS.md): canonical definitions
+  for session, round, turn, action, and step.
 - [**Policy router harness**](docs/POLICY_ROUTER_HARNESS.md): contract and
   rollout checklist for adding an out-of-process policy model.
 - 🛠️ [**Contributing**](CONTRIBUTING.md): layering rules, hot-reload dev,

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,13 @@
+# Router documentation
+
+Index of Markdown documentation in the `router/` repo.
+
+| Doc | What it covers |
+|---|---|
+| [SEMANTICS.md](SEMANTICS.md) | **Canonical terminology** for sessions, rounds, turns, actions, and steps. Read this first before other docs. |
+| [CONFIGURATION.md](CONFIGURATION.md) | Environment variables, BYOK encryption, OTel knobs, cluster routing artifacts. |
+| [POLICY_ROUTER_HARNESS.md](POLICY_ROUTER_HARNESS.md) | Contract for out-of-process policy sidecars. |
+| [TRANSLATION_COMPATIBILITY.md](TRANSLATION_COMPATIBILITY.md) | Cross-format translation requirements and rollout modes. |
+
+For engineering conventions (layer model, package layout, recipes), see the
+root [`CLAUDE.md`](../CLAUDE.md) (and its mirror [`AGENTS.md`](../AGENTS.md)).

--- a/docs/SEMANTICS.md
+++ b/docs/SEMANTICS.md
@@ -1,0 +1,78 @@
+# Router semantics
+
+> **Established 2026-07-23.** Canonical definitions for the Weave Router
+> codebase and documentation. These terms replace the historical usage
+> where "turn" often meant a single upstream API request.
+
+## Terms
+
+| Term | Definition | Notes |
+|------|------------|-------|
+| **Session** | The full conversation between a user and an agent. | Identified by `session_id`. Spans many rounds. |
+| **Round** | One user-agent interaction within a session. | Typically one user turn followed by one agent turn. |
+| **Turn** | A single user input or a single agent output within a round. | E.g. a user message (`U1`) or an agent response (`A1`). |
+| **Action** | A single agent API request to an upstream model. | One `POST /v1/messages`, `POST /v1/chat/completions`, or `generateContent` call. This is the router's finest addressable routing grain. |
+| **Step** | An action within a turn, addressed by its ordinal position. | An agent turn is made of one or more steps; each step is one action. `A1_S3` = agent turn 1, step 3 (its 3rd action). |
+
+**Action vs. step.** An *action* and a *step* denote the same physical unit —
+one upstream API request. "Action" names *what it is* (a single agent API
+request, the routable grain); "step" names *where it sits* (its ordinal
+position within a turn). Use "action" when talking about routing; use "step"
+when addressing a specific request inside a turn.
+
+## Hierarchy
+
+```
+Session
+  └── Round (one user-agent interaction)
+        └── Turn (one user input or one agent output)
+              └── Step (one action within the turn = one upstream API request)
+```
+
+A session contains many rounds. Each round is typically one user turn plus one
+agent turn. An agent turn is made of one or more **steps**, and each step is a
+single **action** — one upstream API request that the router routes
+independently.
+
+## Notation
+
+Turns are labeled by actor and index; steps and subagents nest after them with
+`_`-separated segments.
+
+| Label | Meaning |
+|-------|---------|
+| `U1` | User turn 1 |
+| `A1` | Agent turn 1 |
+| `A1_S3` | Agent turn 1, step 3 (its 3rd action) |
+| `A2_S4_SA1_S1` | Agent turn 2, step 4, subagent 1, step 1 |
+| `A2_S4_SA2_S1` | Agent turn 2, step 4, subagent 2, step 1 |
+
+Segment prefixes: `U` = user turn, `A` = agent turn, `S` = step, `SA` =
+subagent. When a step spawns subagents, each subagent carries its own steps
+(`..._SA<n>_S<m>`), so the two subagents launched from `A2_S4` above are
+`A2_S4_SA1_S1` and `A2_S4_SA2_S1`.
+
+## What the router routes
+
+The router makes a decision per **action** (i.e. per **step**): for every
+inbound API request, it selects a model and provider. It does not route per
+turn, per round, or per session, though it may use session-level state (e.g.
+the session pin) to inform the per-action decision.
+
+## Legacy naming
+
+Some existing code and older documentation still uses **"turn"** to mean what
+we now call an **action** / **step** (a single upstream API request). Notable
+historical names:
+
+- `internal/router/turntype` — classifies an **action** based on the kind of
+  step it handles (e.g. `MainLoop`, `ToolResult`). A future rename to
+  `actiontype` would align with these semantics.
+- "per-turn routing" / "per-turn orchestration" in older docs means
+  **per-action** routing.
+- "turn loop" in `internal/proxy` means the **action loop** that processes
+  one inbound API request.
+
+New code, documentation, and telemetry should use the terms above. When
+touching legacy docs, prefer updating them to the new terminology or adding a
+note that they use the pre-2026-07-23 convention.

--- a/install/opencode-weave/README.md
+++ b/install/opencode-weave/README.md
@@ -3,7 +3,7 @@
 Lets a caller's own **AI subscriptions** pay for their **opencode** turns, routed
 through the Weave Router. A subscription is a **credential scoped to the model
 family it can pay for**, not a provider you pick: you connect your ChatGPT
-(Codex) and/or Claude (Pro/Max) plan once, the router routes every turn to the
+(Codex) and/or Claude (Pro/Max) plan once, the router routes every request to the
 best model, and bills the plan that matches the model it served — ChatGPT pays
 for GPT/Codex turns, Claude pays for Claude turns, your Weave key pays for
 everything else.
@@ -34,9 +34,9 @@ router's dedicated headers:
 | `X-Weave-Anthropic-Subscription: <sk-ant-oat token>` | pays Claude turns, refreshed on expiry |
 | `X-Weave-Router-Key: rk_…` | from `opencode.json` `options.headers` — the router authenticates off this |
 
-The router routes the turn across every model the caller's subs + key can pay
+The router routes each request across every model the caller's subs + key can pay
 for and resolves the subscription matching the chosen provider, so a sub is
-never billed for a turn outside its family.
+never billed for a request outside its family.
 
 ## Two storage slots, one request provider
 

--- a/internal/proxy/AGENTS.md
+++ b/internal/proxy/AGENTS.md
@@ -2,7 +2,7 @@
 
 > **Mirror notice.** Verbatim sync with [CLAUDE.md](CLAUDE.md). **Update both together** — divergence = bug.
 
-Routing/dispatch service. Per-turn orchestrator that composes scorer, planner, handover, cache, sessionpin, catalog, turntype, usage, billing, providers, and translate. Read [root CLAUDE.md](../../CLAUDE.md) first.
+Routing/dispatch service. Per-action orchestrator that composes scorer, planner, handover, cache, sessionpin, catalog, turntype, usage, billing, providers, and translate. Read [root CLAUDE.md](../../CLAUDE.md) first.
 
 ## Surface
 
@@ -13,7 +13,7 @@ Routing/dispatch service. Per-turn orchestrator that composes scorer, planner, h
 - `ProxyOpenAIChatCompletion` — OpenAI Chat Completions
 - `ProxyGemini` — Gemini native generateContent
 
-Plus the turn loop, handover adapter, cache writer, and session-key derivation in sibling files.
+Plus the action loop, handover adapter, cache writer, and session-key derivation in sibling files.
 
 ## Adding a method to `*proxy.Service`
 
@@ -21,21 +21,21 @@ Plus the turn loop, handover adapter, cache writer, and session-key derivation i
 2. **If you need new repo methods**, surface them as an interface in the inner-ring package, implement in `internal/postgres/`. Example: `sessionpin.Store` in [`../router/sessionpin/store.go`](../router/sessionpin/store.go), implemented by `postgres.SessionPinRepository`.
 3. **Update `service_test.go` fakes** to satisfy the expanded interface. Real assertions on return values, not "mock called with X".
 
-## Per-turn flow (cache-aware turn routing)
+## Per-action flow (cache-aware action routing)
 
-The per-turn flow is more than "scorer → dispatch". Pinned session, planner verdict, optional handover summary, and the semantic response cache all sit between the inbound request and the upstream provider. Packages are intentionally small + single-purpose so each is unit-testable without the others.
+The per-action flow is more than "scorer → dispatch". Pinned session, planner verdict, optional handover summary, and the semantic response cache all sit between the inbound request and the upstream provider. Packages are intentionally small + single-purpose so each is unit-testable without the others. ("Action" = one upstream API request; see [../../docs/SEMANTICS.md](../../docs/SEMANTICS.md). The `Stage` column below is a pipeline stage *within* one action, not a router step.)
 
-| Step | Package | Notes |
+| Stage | Package | Notes |
 |---|---|---|
 | Turn-type classification | [`../router/turntype`](../router/turntype) | MainLoop / ToolResult / SubAgentDispatch / Compaction / Probe |
 | Session-pin lookup | [`../router/sessionpin`](../router/sessionpin) | Sticky `(api_key_id, session_key, role)` pin |
 | Fresh routing decision | [`../router/cluster`](../router/cluster) | Cluster scorer argmax |
 | STAY vs SWITCH | [`../router/planner`](../router/planner) | Cache-aware EV policy |
-| Handover summary on SWITCH | [`../router/handover`](../router/handover) | Bounds switch-turn input cost |
+| Handover summary on SWITCH | [`../router/handover`](../router/handover) | Bounds switch-action input cost |
 | Semantic response cache | [`../router/cache`](../router/cache) | Cross-request, non-streaming only |
 | Subscription strict pass-through gate | [`usage`](usage) | See [`usage/CLAUDE.md`](usage/CLAUDE.md) |
 
-The provider-backed `Summarizer` implementation for handover lives in [`handover.go`](handover.go); the inner-ring `handover` package only defines the contract. On summarizer timeout or error, proxy keeps the full prior history unchanged (it does **not** trim) — a pricier switch turn beats silently dropping the conversation the switched-to model needs.
+The provider-backed `Summarizer` implementation for handover lives in [`handover.go`](handover.go); the inner-ring `handover` package only defines the contract. On summarizer timeout or error, proxy keeps the full prior history unchanged (it does **not** trim) — a pricier switch action beats silently dropping the conversation the switched-to model needs.
 
 ## Proactive context-window compaction
 
@@ -49,9 +49,9 @@ The provider-backed `Summarizer` implementation for handover lives in [`handover
 
 Multi-binding models (deepseek/qwen/moonshot with Fireworks/Makora/Bedrock primary + OpenRouter fallback in [`catalog.Model.Providers`](../router/catalog/catalog.go)) dispatch through [`dispatchWithFallback`](fallback.go). The helper walks the ordered binding list, retries on `providers.IsRetryable` errors (5xx/408/429 buffered responses, transport errors, `httputil.ErrUpstreamIdleTimeout`), and on exhaustion writes the final upstream error envelope via a format-specific renderer (`flushUpstreamErrorAsAnthropic` for ProxyMessages, `flushBufferedIfPresent` for ProxyOpenAIChatCompletion).
 
-**Model-not-found 404 → cross-binding failover (only).** A buffered upstream 404 (`providers.IsUpstreamModelNotFound`) means the chosen provider doesn't serve the model — a stale/wrong upstream id or a provider with no active endpoints. It is deliberately *not* in `IsRetryable`: re-hitting the same provider is futile (so it never triggers same-binding retry), but a different provider binding may carry the model, so it triggers one cross-binding hop. This rescues a turn that would otherwise hard-fail at the client as "selected model may not exist." On the last binding the 404 still flushes.
+**Model-not-found 404 → cross-binding failover (only).** A buffered upstream 404 (`providers.IsUpstreamModelNotFound`) means the chosen provider doesn't serve the model — a stale/wrong upstream id or a provider with no active endpoints. It is deliberately *not* in `IsRetryable`: re-hitting the same provider is futile (so it never triggers same-binding retry), but a different provider binding may carry the model, so it triggers one cross-binding hop. This rescues a request that would otherwise hard-fail at the client as "selected model may not exist." On the last binding the 404 still flushes.
 
-**Single-binding same-binding retry.** Most catalog models carry one binding (Anthropic/OpenAI/Google), so cross-binding failover has nowhere to walk — a sole-provider 5xx/timeout would kill the turn. For these, `dispatchWithFallback` retries the *same* binding in place up to `maxSameBindingRetries` (2) with exponential backoff (`sameBindingBackoff`: 250ms, 500ms), pre-commit only, abortable on ctx cancel (`sleepWithContext`). Multi-binding models skip in-place retry (`len(bindings) > 1` breaks the inner loop) and fail straight over to the next provider — a different upstream beats re-hitting the flaky one. Tests inject `Service.retrySleep` to keep the backoff instant.
+**Single-binding same-binding retry.** Most catalog models carry one binding (Anthropic/OpenAI/Google), so cross-binding failover has nowhere to walk — a sole-provider 5xx/timeout would kill the request. For these, `dispatchWithFallback` retries the *same* binding in place up to `maxSameBindingRetries` (2) with exponential backoff (`sameBindingBackoff`: 250ms, 500ms), pre-commit only, abortable on ctx cancel (`sleepWithContext`). Multi-binding models skip in-place retry (`len(bindings) > 1` breaks the inner loop) and fail straight over to the next provider — a different upstream beats re-hitting the flaky one. Tests inject `Service.retrySleep` to keep the backoff instant.
 
 `preludeBuffer` wraps the client writer on every request so the eager SSE Prelude doesn't commit the response to the client before the upstream produces its first byte. The buffer absorbs pre-Seal writes (Prelude's status + `message_start`), commits on the first post-Seal write (= first upstream chunk), and `Discard()`s pre-commit state between attempts so a retry begins with a pristine writer. `Committed()` is the retry gate: once it flips, the response is on the wire and no further retry is allowed.
 
@@ -67,7 +67,7 @@ Per-attempt body rebuild: each closure constructs `EmitOptions` with `TargetProv
 
 ## `OnUpstreamMeta` callbacks
 
-Provider adapters call back into `proxy.OnUpstreamMeta` so streaming responses record usage/headers back to proxy without coupling provider packages to proxy internals. The catalog / planner stack depends on per-turn token counts being recorded promptly — **don't add a provider that forgets to call the callback.**
+Provider adapters call back into `proxy.OnUpstreamMeta` so streaming responses record usage/headers back to proxy without coupling provider packages to proxy internals. The catalog / planner stack depends on per-action token counts being recorded promptly — **don't add a provider that forgets to call the callback.**
 
 ## What NOT to do
 

--- a/internal/proxy/CLAUDE.md
+++ b/internal/proxy/CLAUDE.md
@@ -2,7 +2,7 @@
 
 > **Mirror notice.** Verbatim sync with [AGENTS.md](AGENTS.md). **Update both together** — divergence = bug.
 
-Routing/dispatch service. Per-turn orchestrator that composes scorer, planner, handover, cache, sessionpin, catalog, turntype, usage, billing, providers, and translate. Read [root CLAUDE.md](../../CLAUDE.md) first.
+Routing/dispatch service. Per-action orchestrator that composes scorer, planner, handover, cache, sessionpin, catalog, turntype, usage, billing, providers, and translate. Read [root CLAUDE.md](../../CLAUDE.md) first.
 
 ## Surface
 
@@ -13,7 +13,7 @@ Routing/dispatch service. Per-turn orchestrator that composes scorer, planner, h
 - `ProxyOpenAIChatCompletion` — OpenAI Chat Completions
 - `ProxyGemini` — Gemini native generateContent
 
-Plus the turn loop, handover adapter, cache writer, and session-key derivation in sibling files.
+Plus the action loop, handover adapter, cache writer, and session-key derivation in sibling files.
 
 ## Adding a method to `*proxy.Service`
 
@@ -21,21 +21,21 @@ Plus the turn loop, handover adapter, cache writer, and session-key derivation i
 2. **If you need new repo methods**, surface them as an interface in the inner-ring package, implement in `internal/postgres/`. Example: `sessionpin.Store` in [`../router/sessionpin/store.go`](../router/sessionpin/store.go), implemented by `postgres.SessionPinRepository`.
 3. **Update `service_test.go` fakes** to satisfy the expanded interface. Real assertions on return values, not "mock called with X".
 
-## Per-turn flow (cache-aware turn routing)
+## Per-action flow (cache-aware action routing)
 
-The per-turn flow is more than "scorer → dispatch". Pinned session, planner verdict, optional handover summary, and the semantic response cache all sit between the inbound request and the upstream provider. Packages are intentionally small + single-purpose so each is unit-testable without the others.
+The per-action flow is more than "scorer → dispatch". Pinned session, planner verdict, optional handover summary, and the semantic response cache all sit between the inbound request and the upstream provider. Packages are intentionally small + single-purpose so each is unit-testable without the others. ("Action" = one upstream API request; see [../../docs/SEMANTICS.md](../../docs/SEMANTICS.md). The `Stage` column below is a pipeline stage *within* one action, not a router step.)
 
-| Step | Package | Notes |
+| Stage | Package | Notes |
 |---|---|---|
 | Turn-type classification | [`../router/turntype`](../router/turntype) | MainLoop / ToolResult / SubAgentDispatch / Compaction / Probe |
 | Session-pin lookup | [`../router/sessionpin`](../router/sessionpin) | Sticky `(api_key_id, session_key, role)` pin |
 | Fresh routing decision | [`../router/cluster`](../router/cluster) | Cluster scorer argmax |
 | STAY vs SWITCH | [`../router/planner`](../router/planner) | Cache-aware EV policy |
-| Handover summary on SWITCH | [`../router/handover`](../router/handover) | Bounds switch-turn input cost |
+| Handover summary on SWITCH | [`../router/handover`](../router/handover) | Bounds switch-action input cost |
 | Semantic response cache | [`../router/cache`](../router/cache) | Cross-request, non-streaming only |
 | Subscription strict pass-through gate | [`usage`](usage) | See [`usage/CLAUDE.md`](usage/CLAUDE.md) |
 
-The provider-backed `Summarizer` implementation for handover lives in [`handover.go`](handover.go); the inner-ring `handover` package only defines the contract. On summarizer timeout or error, proxy keeps the full prior history unchanged (it does **not** trim) — a pricier switch turn beats silently dropping the conversation the switched-to model needs.
+The provider-backed `Summarizer` implementation for handover lives in [`handover.go`](handover.go); the inner-ring `handover` package only defines the contract. On summarizer timeout or error, proxy keeps the full prior history unchanged (it does **not** trim) — a pricier switch action beats silently dropping the conversation the switched-to model needs.
 
 ## Proactive context-window compaction
 
@@ -49,9 +49,9 @@ The provider-backed `Summarizer` implementation for handover lives in [`handover
 
 Multi-binding models (deepseek/qwen/moonshot with Fireworks/Makora/Bedrock primary + OpenRouter fallback in [`catalog.Model.Providers`](../router/catalog/catalog.go)) dispatch through [`dispatchWithFallback`](fallback.go). The helper walks the ordered binding list, retries on `providers.IsRetryable` errors (5xx/408/429 buffered responses, transport errors, `httputil.ErrUpstreamIdleTimeout`), and on exhaustion writes the final upstream error envelope via a format-specific renderer (`flushUpstreamErrorAsAnthropic` for ProxyMessages, `flushBufferedIfPresent` for ProxyOpenAIChatCompletion).
 
-**Model-not-found 404 → cross-binding failover (only).** A buffered upstream 404 (`providers.IsUpstreamModelNotFound`) means the chosen provider doesn't serve the model — a stale/wrong upstream id or a provider with no active endpoints. It is deliberately *not* in `IsRetryable`: re-hitting the same provider is futile (so it never triggers same-binding retry), but a different provider binding may carry the model, so it triggers one cross-binding hop. This rescues a turn that would otherwise hard-fail at the client as "selected model may not exist." On the last binding the 404 still flushes.
+**Model-not-found 404 → cross-binding failover (only).** A buffered upstream 404 (`providers.IsUpstreamModelNotFound`) means the chosen provider doesn't serve the model — a stale/wrong upstream id or a provider with no active endpoints. It is deliberately *not* in `IsRetryable`: re-hitting the same provider is futile (so it never triggers same-binding retry), but a different provider binding may carry the model, so it triggers one cross-binding hop. This rescues a request that would otherwise hard-fail at the client as "selected model may not exist." On the last binding the 404 still flushes.
 
-**Single-binding same-binding retry.** Most catalog models carry one binding (Anthropic/OpenAI/Google), so cross-binding failover has nowhere to walk — a sole-provider 5xx/timeout would kill the turn. For these, `dispatchWithFallback` retries the *same* binding in place up to `maxSameBindingRetries` (2) with exponential backoff (`sameBindingBackoff`: 250ms, 500ms), pre-commit only, abortable on ctx cancel (`sleepWithContext`). Multi-binding models skip in-place retry (`len(bindings) > 1` breaks the inner loop) and fail straight over to the next provider — a different upstream beats re-hitting the flaky one. Tests inject `Service.retrySleep` to keep the backoff instant.
+**Single-binding same-binding retry.** Most catalog models carry one binding (Anthropic/OpenAI/Google), so cross-binding failover has nowhere to walk — a sole-provider 5xx/timeout would kill the request. For these, `dispatchWithFallback` retries the *same* binding in place up to `maxSameBindingRetries` (2) with exponential backoff (`sameBindingBackoff`: 250ms, 500ms), pre-commit only, abortable on ctx cancel (`sleepWithContext`). Multi-binding models skip in-place retry (`len(bindings) > 1` breaks the inner loop) and fail straight over to the next provider — a different upstream beats re-hitting the flaky one. Tests inject `Service.retrySleep` to keep the backoff instant.
 
 `preludeBuffer` wraps the client writer on every request so the eager SSE Prelude doesn't commit the response to the client before the upstream produces its first byte. The buffer absorbs pre-Seal writes (Prelude's status + `message_start`), commits on the first post-Seal write (= first upstream chunk), and `Discard()`s pre-commit state between attempts so a retry begins with a pristine writer. `Committed()` is the retry gate: once it flips, the response is on the wire and no further retry is allowed.
 
@@ -67,7 +67,7 @@ Per-attempt body rebuild: each closure constructs `EmitOptions` with `TargetProv
 
 ## `OnUpstreamMeta` callbacks
 
-Provider adapters call back into `proxy.OnUpstreamMeta` so streaming responses record usage/headers back to proxy without coupling provider packages to proxy internals. The catalog / planner stack depends on per-turn token counts being recorded promptly — **don't add a provider that forgets to call the callback.**
+Provider adapters call back into `proxy.OnUpstreamMeta` so streaming responses record usage/headers back to proxy without coupling provider packages to proxy internals. The catalog / planner stack depends on per-action token counts being recorded promptly — **don't add a provider that forgets to call the callback.**
 
 ## What NOT to do
 

--- a/internal/router/AGENTS.md
+++ b/internal/router/AGENTS.md
@@ -2,7 +2,7 @@
 
 > **Mirror notice.** Verbatim sync with [CLAUDE.md](CLAUDE.md). **Update both together** — divergence = bug.
 
-Inner-ring `Router` interface + `Request`/`Decision`/`ModelSpec`/`ModelRegistry` value types. Plus subpackages for cache-aware turn-routing primitives. Read [root CLAUDE.md](../../CLAUDE.md) first.
+Inner-ring `Router` interface + `Request`/`Decision`/`ModelSpec`/`ModelRegistry` value types. Plus subpackages for cache-aware action-routing primitives. Read [root CLAUDE.md](../../CLAUDE.md) first.
 
 ## Subpackages
 

--- a/internal/router/CLAUDE.md
+++ b/internal/router/CLAUDE.md
@@ -2,7 +2,7 @@
 
 > **Mirror notice.** Verbatim sync with [AGENTS.md](AGENTS.md). **Update both together** — divergence = bug.
 
-Inner-ring `Router` interface + `Request`/`Decision`/`ModelSpec`/`ModelRegistry` value types. Plus subpackages for cache-aware turn-routing primitives. Read [root CLAUDE.md](../../CLAUDE.md) first.
+Inner-ring `Router` interface + `Request`/`Decision`/`ModelSpec`/`ModelRegistry` value types. Plus subpackages for cache-aware action-routing primitives. Read [root CLAUDE.md](../../CLAUDE.md) first.
 
 ## Subpackages
 

--- a/internal/router/handover/AGENTS.md
+++ b/internal/router/handover/AGENTS.md
@@ -6,7 +6,7 @@
 
 ## What it does
 
-When the planner decides SWITCH, proxy asks a small model to summarize prior conversation + rewrites the message history to `[synthesizedSummary, latestUser]` before dispatching to the new model. Bounds the switch turn's input cost regardless of session length.
+When the planner decides SWITCH, proxy asks a small model to summarize prior conversation + rewrites the message history to `[synthesizedSummary, latestUser]` before dispatching to the new model. Bounds the switch action's input cost regardless of session length.
 
 ## Layout
 
@@ -15,5 +15,5 @@ When the planner decides SWITCH, proxy asks a small model to summarize prior con
 
 ## Invariants
 
-- **`Summarizer` implementations MUST respect the context deadline.** On summarizer timeout or error, proxy keeps the full prior history unchanged (no trim) — a pricier switch turn beats silently dropping context. Do not "fix" by waiting longer, and do not reintroduce a silent trim fallback.
+- **`Summarizer` implementations MUST respect the context deadline.** On summarizer timeout or error, proxy keeps the full prior history unchanged (no trim) — a pricier switch action beats silently dropping context. Do not "fix" by waiting longer, and do not reintroduce a silent trim fallback.
 - **No I/O in this package.** All I/O lives in the proxy-side implementation.

--- a/internal/router/handover/CLAUDE.md
+++ b/internal/router/handover/CLAUDE.md
@@ -6,7 +6,7 @@
 
 ## What it does
 
-When the planner decides SWITCH, proxy asks a small model to summarize prior conversation + rewrites the message history to `[synthesizedSummary, latestUser]` before dispatching to the new model. Bounds the switch turn's input cost regardless of session length.
+When the planner decides SWITCH, proxy asks a small model to summarize prior conversation + rewrites the message history to `[synthesizedSummary, latestUser]` before dispatching to the new model. Bounds the switch action's input cost regardless of session length.
 
 ## Layout
 
@@ -15,5 +15,5 @@ When the planner decides SWITCH, proxy asks a small model to summarize prior con
 
 ## Invariants
 
-- **`Summarizer` implementations MUST respect the context deadline.** On summarizer timeout or error, proxy keeps the full prior history unchanged (no trim) — a pricier switch turn beats silently dropping context. Do not "fix" by waiting longer, and do not reintroduce a silent trim fallback.
+- **`Summarizer` implementations MUST respect the context deadline.** On summarizer timeout or error, proxy keeps the full prior history unchanged (no trim) — a pricier switch action beats silently dropping context. Do not "fix" by waiting longer, and do not reintroduce a silent trim fallback.
 - **No I/O in this package.** All I/O lives in the proxy-side implementation.

--- a/internal/router/planner/AGENTS.md
+++ b/internal/router/planner/AGENTS.md
@@ -2,7 +2,7 @@
 
 > **Mirror notice.** Verbatim sync with [CLAUDE.md](CLAUDE.md). **Update both together** — divergence = bug.
 
-Prism-style cache-aware EV policy. Decides STAY (preserve pinned model's upstream prompt cache) vs SWITCH (take cluster scorer's fresh decision + eat one-time cache miss) per turn. Read [root CLAUDE.md](../../../CLAUDE.md) first.
+Prism-style cache-aware EV policy. Decides STAY (preserve pinned model's upstream prompt cache) vs SWITCH (take cluster scorer's fresh decision + eat one-time cache miss) per action. Read [root CLAUDE.md](../../../CLAUDE.md) first.
 
 ## Contract
 
@@ -15,7 +15,7 @@ Decide(pin, fresh router.Decision, estimated tokens, available models) → STAY 
 
 ## Math, briefly
 
-Compares expected per-turn savings over the remaining horizon against the eviction cost of warming a new cache. The **tier-upgrade guard** fires when STAY would clearly under-serve the prompt — uses [`../catalog`](../catalog)'s Low/Mid/High tier to overturn a cost-driven "stay" when the fresh decision is in a strictly higher tier than the pin.
+Compares expected per-action savings over the remaining horizon against the eviction cost of warming a new cache. The **tier-upgrade guard** fires when STAY would clearly under-serve the prompt — uses [`../catalog`](../catalog)'s Low/Mid/High tier to overturn a cost-driven "stay" when the fresh decision is in a strictly higher tier than the pin.
 
 **Cache-warmth gate.** The cache-read multipliers and eviction cost only apply while the pin's upstream cache is warm. When `Inputs.PinCacheCold` is set (the pinned provider's cache TTL has lapsed — short and best-effort on the OSS compat providers vs Anthropic's 1h window; see [`../../providers`](../../providers).`CacheTTLFor`), both sides are priced uncached so raw economics + the tier guard decide, instead of a phantom cache gluing the session to a stale pin. The zero value means "assume warm", preserving the original behavior.
 

--- a/internal/router/planner/CLAUDE.md
+++ b/internal/router/planner/CLAUDE.md
@@ -2,7 +2,7 @@
 
 > **Mirror notice.** Verbatim sync with [AGENTS.md](AGENTS.md). **Update both together** — divergence = bug.
 
-Prism-style cache-aware EV policy. Decides STAY (preserve pinned model's upstream prompt cache) vs SWITCH (take cluster scorer's fresh decision + eat one-time cache miss) per turn. Read [root CLAUDE.md](../../../CLAUDE.md) first.
+Prism-style cache-aware EV policy. Decides STAY (preserve pinned model's upstream prompt cache) vs SWITCH (take cluster scorer's fresh decision + eat one-time cache miss) per action. Read [root CLAUDE.md](../../../CLAUDE.md) first.
 
 ## Contract
 
@@ -15,7 +15,7 @@ Decide(pin, fresh router.Decision, estimated tokens, available models) → STAY 
 
 ## Math, briefly
 
-Compares expected per-turn savings over the remaining horizon against the eviction cost of warming a new cache. The **tier-upgrade guard** fires when STAY would clearly under-serve the prompt — uses [`../catalog`](../catalog)'s Low/Mid/High tier to overturn a cost-driven "stay" when the fresh decision is in a strictly higher tier than the pin.
+Compares expected per-action savings over the remaining horizon against the eviction cost of warming a new cache. The **tier-upgrade guard** fires when STAY would clearly under-serve the prompt — uses [`../catalog`](../catalog)'s Low/Mid/High tier to overturn a cost-driven "stay" when the fresh decision is in a strictly higher tier than the pin.
 
 **Cache-warmth gate.** The cache-read multipliers and eviction cost only apply while the pin's upstream cache is warm. When `Inputs.PinCacheCold` is set (the pinned provider's cache TTL has lapsed — short and best-effort on the OSS compat providers vs Anthropic's 1h window; see [`../../providers`](../../providers).`CacheTTLFor`), both sides are priced uncached so raw economics + the tier guard decide, instead of a phantom cache gluing the session to a stale pin. The zero value means "assume warm", preserving the original behavior.
 

--- a/internal/router/turntype/AGENTS.md
+++ b/internal/router/turntype/AGENTS.md
@@ -9,14 +9,14 @@ Inbound turn-type classifier. Read [root CLAUDE.md](../../../CLAUDE.md) first.
 Classifies inbound requests into:
 
 - `MainLoop`
-- `ToolResult` — proxy short-circuits to the session pin (these turns' embeddings are mostly noise)
+- `ToolResult` — proxy short-circuits to the session pin (these actions' embeddings are mostly noise)
 - `SubAgentDispatch`
 - `Compaction` — proxy forces Haiku
 - `Probe` — proxy bypasses routing entirely
 - `TitleGen` — Claude Code sidebar-title generation; hard-pinned AND skips session-pin creation (an anchored pin here would leak the cheap-model decision into the real conversation that follows ~25ms later)
 - `Classifier` — short-form classification call (e.g. Claude Code's security monitor); hard-pinned AND skips session-pin creation
 
-Used by [`../../proxy`](../../proxy) to keep the turn loop cheap + correct.
+Used by [`../../proxy`](../../proxy) to keep the action loop cheap + correct.
 
 ## Invariants
 

--- a/internal/router/turntype/CLAUDE.md
+++ b/internal/router/turntype/CLAUDE.md
@@ -9,14 +9,14 @@ Inbound turn-type classifier. Read [root CLAUDE.md](../../../CLAUDE.md) first.
 Classifies inbound requests into:
 
 - `MainLoop`
-- `ToolResult` — proxy short-circuits to the session pin (these turns' embeddings are mostly noise)
+- `ToolResult` — proxy short-circuits to the session pin (these actions' embeddings are mostly noise)
 - `SubAgentDispatch`
 - `Compaction` — proxy forces Haiku
 - `Probe` — proxy bypasses routing entirely
 - `TitleGen` — Claude Code sidebar-title generation; hard-pinned AND skips session-pin creation (an anchored pin here would leak the cheap-model decision into the real conversation that follows ~25ms later)
 - `Classifier` — short-form classification call (e.g. Claude Code's security monitor); hard-pinned AND skips session-pin creation
 
-Used by [`../../proxy`](../../proxy) to keep the turn loop cheap + correct.
+Used by [`../../proxy`](../../proxy) to keep the action loop cheap + correct.
 
 ## Invariants
 


### PR DESCRIPTION
## Summary

- Add `docs/SEMANTICS.md` as the single source of truth for router terminology, established 2026-07-23. Defines **session → round → turn → step (= action)**: a *step* is an *action* (one upstream API request) addressed by its ordinal position within a turn, and the router routes **per action**. Includes the label notation (`U1`, `A1_S3`, `A2_S4_SA1_S1` / `A2_S4_SA2_S1`).
- Add `docs/README.md` doc index pointing to SEMANTICS.md as read-first, and link it from the root `README.md`.
- Reconcile existing "turn"-as-request prose across the root guides, `internal/proxy`, `internal/router` index, `planner`, `handover`, `turntype`, the opencode install README, and a test skill — keeping every `CLAUDE.md`/`AGENTS.md` mirror pair verbatim in sync.
- Retain legacy proper nouns (`turntype` package, "turn-type classifier") and note them as pre-2026-07-23 naming.

## Notes

Docs-only change; no code or behavior affected. "Action" and "step" denote the same physical unit (one upstream API request) — "action" names *what it is* (the routable grain), "step" names *where it sits* (position within a turn).

## Test plan

- [ ] Read `docs/SEMANTICS.md` — hierarchy, action-vs-step note, and notation table match the intended semantics
- [ ] Confirm each edited `CLAUDE.md` has its `AGENTS.md` mirror byte-identical below the 3-line header