### PR TITLE
fix(translate): bail to non-strict for bare-{} optional tool args

### DIFF
--- a/internal/translate/strictify_openai.go
+++ b/internal/translate/strictify_openai.go
@@ -168,6 +168,17 @@ func strictifyNode(node map[string]any, depth int, propCount *int) (out map[stri
 			return nil, false
 		}
 		if _, req := originallyRequired[name]; !req {
+			// An optional property with no strict-expressible type (a bare {}
+			// "any JSON value", e.g. Workflow.args) cannot be made nullable
+			// without either admitting "object" — which strict mode then
+			// requires to carry additionalProperties:false, forbidding the
+			// arbitrary keys the schema exists to accept — or narrowing the
+			// value space and silently dropping valid object/array args.
+			// There is no strict representation of an open value, so bail to
+			// non-strict emission per this file's fail-open contract.
+			if !schemaHasStrictType(sp) {
+				return nil, false
+			}
 			sp = makeNullable(sp)
 		}
 		outProps[name] = sp
@@ -206,13 +217,11 @@ func makeNullable(node map[string]any) map[string]any {
 		node["anyOf"] = append(branches, map[string]any{"type": "null"})
 		return node
 	}
-	// No type and no anyOf: give the synthetic branch an explicit value-type union
-	// so OpenAI strict mode accepts it; preserve any inline constraints on the original node.
-	branch := map[string]any{"type": []any{"string", "number", "boolean", "object", "array", "null"}}
-	for k, v := range node {
-		branch[k] = v
-	}
-	return map[string]any{"anyOf": []any{branch, map[string]any{"type": "null"}}}
+	// No type and no anyOf (e.g. bare enum): wrap the node itself. Callers must
+	// not pass a fully typeless node here — strictifyNode bails on typeless
+	// optionals before reaching this point, since an open value has no strict
+	// representation (see the schemaHasStrictType guard in strictifyNode).
+	return map[string]any{"anyOf": []any{node, map[string]any{"type": "null"}}}
 }
 
 // schemaHasStrictType reports whether node carries a type OpenAI strict mode

--- a/internal/translate/strictify_openai_test.go
+++ b/internal/translate/strictify_openai_test.go
@@ -236,21 +236,16 @@ func TestStrictify_UnevaluatedPropertiesBails(t *testing.T) {
 	require.False(t, ok, "unevaluatedProperties is not expressible in strict mode; must bail")
 }
 
-// Workflow.args is bare {} — makeNullable's synthetic anyOf branch had no 'type' key
-// and OpenAI strict mode 400'd; verify the fix adds an explicit value-type union.
-func TestStrictify_TypelessOptionalGetsExplicitValueType(t *testing.T) {
-	out, ok := strictifyFromJSON(t, `{
+// Workflow.args is a bare {} "any JSON value" optional. #829 kept it strict by
+// synthesizing a 6-type union branch, but that branch admits "object" without
+// additionalProperties:false, so OpenAI strict mode still 400'd
+// (context=('properties','args','anyOf','0','type','3')). An open value has no
+// strict representation, so the whole tool must bail to non-strict emission.
+func TestStrictify_TypelessOptionalBails(t *testing.T) {
+	_, ok := strictifyFromJSON(t, `{
 		"type":"object",
 		"properties":{"args":{}},
 		"required":[]
 	}`)
-	require.True(t, ok, "a typeless optional property must survive strictification, not bail")
-
-	args := out["properties"].(map[string]any)["args"].(map[string]any)
-	branches, has := args["anyOf"].([]any)
-	require.True(t, has, "a typeless optional is made nullable via anyOf")
-	require.Len(t, branches, 2)
-	assert.Equal(t, []any{"string", "number", "boolean", "object", "array", "null"}, branches[0].(map[string]any)["type"],
-		"a typeless branch must carry an explicit value-type union so OpenAI strict mode doesn't 400")
-	assert.Equal(t, map[string]any{"type": "null"}, branches[1])
+	require.False(t, ok, "a bare {} optional (any JSON value) has no strict form; must fall back to non-strict")
 }


### PR DESCRIPTION
## Problem

Claude Code sessions routed to an OpenAI Responses-path model (gpt-5.x) were dying on the first turn that carried the `Workflow` tool:

```
API Error: 400 Invalid schema for function 'Workflow':
In context=('properties','args','anyOf','0','type','3'),
'additionalProperties' is required to be supplied and to be false.
```

`Workflow.args` is a bare `{}` "any JSON value" optional parameter. #829 addressed an earlier form of this 400 by having `makeNullable` synthesize a six-type union branch (`["string","number","boolean","object","array","null"]`) so the tool could stay `strict:true`. But that union admits `"object"`, and OpenAI strict mode then requires the node to also carry `additionalProperties:false` — which the synthetic branch lacks. So the request still 400s, just one level deeper (note the error path lands on `anyOf.0.type.3`, i.e. index 3 = `"object"` of the synthesized union).

## Why not just add `additionalProperties:false` to the synthetic branch?

Because a bare `{}` has **no** valid strict representation:

- Closing it with `additionalProperties:false` and no `properties` constrains `args` to an *empty object only* — breaking a parameter whose entire purpose is passing arbitrary JSON.
- Narrowing the type union to exclude `object`/`array` silently drops valid structured args.

An open value is exactly the case `strictify` is meant to **bail** on and fall back to non-strict emission (the file's documented fail-open contract). Non-strict emission is already the path for `oneOf`, unresolved `$ref`, tuple items, etc., and `toolcheck` still validates tool calls against the original schema downstream.

## Change

- `strictifyNode`: when an **optional** property has no strict-expressible type (`!schemaHasStrictType`), return `ok=false` so the whole tool emits non-strict, instead of letting `makeNullable` synthesize an unrepresentable branch.
- `makeNullable`: revert the #829 typeless fallback back to wrapping the node in `anyOf` + null. That path is now unreachable behind the new guard; the comment says so.
- Replace `TestStrictify_TypelessOptionalGetsExplicitValueType` (asserted the now-wrong "stays strict" contract) with `TestStrictify_TypelessOptionalBails`.

## Validation

- `go vet ./internal/translate/` — clean
- `go test ./internal/translate/...` — pass (translate + toolcheck)
- `wv mr tc` — clean
- `wv mr t` (full router suite) — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)