### PR TITLE
fix(proxy): classify Anthropic cache_control validation errors as 400, not 502

### DIFF
--- a/internal/proxy/dispatch_error.go
+++ b/internal/proxy/dispatch_error.go
@@ -226,10 +226,9 @@ func ClassifyDispatchError(err error) (DispatchErrorClass, bool) {
 	}
 }
 
-// unwrapToSentinelMessage walks err's wrap chain and returns the message of
-// the wrapper whose direct child is one of the two cache_control sentinels —
-// strips outer prefixes like "emit body: " while keeping the sentinel's own
-// dynamic detail. Falls back to err.Error() if no such layer is found.
+// unwrapToSentinelMessage returns the message of the wrap layer whose direct
+// child is one of the cache_control sentinels, stripping outer prefixes like
+// "emit body: ". Falls back to err.Error().
 func unwrapToSentinelMessage(err error) string {
 	for e := err; e != nil; e = errors.Unwrap(e) {
 		if child := errors.Unwrap(e); child == translate.ErrAnthropicCacheControlOverflow || child == translate.ErrAnthropicCacheControlInvalid {

--- a/internal/proxy/dispatch_error.go
+++ b/internal/proxy/dispatch_error.go
@@ -12,6 +12,7 @@ import (
 	"workweave/router/internal/router/cluster"
 	"workweave/router/internal/router/hmm"
 	"workweave/router/internal/router/rl"
+	"workweave/router/internal/translate"
 )
 
 // DispatchErrorKind identifies which sentinel a dispatch error (from
@@ -42,6 +43,7 @@ const (
 	DispatchErrorTranslationProviderUnavailable
 	DispatchErrorUserSpendLimitReached
 	DispatchErrorSpendLimitUnavailable
+	DispatchErrorAnthropicCacheControlInvalid
 )
 
 // DispatchErrorClass is the format-agnostic classification of a dispatch
@@ -97,6 +99,16 @@ func ClassifyDispatchError(err error) (DispatchErrorClass, bool) {
 			Kind:    DispatchErrorRequestNotJSONObject,
 			Status:  http.StatusBadRequest,
 			Message: "Request body must be a JSON object.",
+		}, true
+	case errors.Is(err, translate.ErrAnthropicCacheControlOverflow), errors.Is(err, translate.ErrAnthropicCacheControlInvalid):
+		// Client's explicit cache_control is invalid (overflow or bad TTL order);
+		// validator caught it pre-dispatch, so the generic 502 was misleading.
+		return DispatchErrorClass{
+			Kind:       DispatchErrorAnthropicCacheControlInvalid,
+			Status:     http.StatusBadRequest,
+			Message:    unwrapToSentinelMessage(err),
+			LogLevel:   "warn",
+			LogMessage: "Rejected request: invalid Anthropic cache_control",
 		}, true
 	case errors.Is(err, ErrTranslationIntrinsicallyIncompatible):
 		return DispatchErrorClass{
@@ -214,13 +226,26 @@ func ClassifyDispatchError(err error) (DispatchErrorClass, bool) {
 	}
 }
 
+// unwrapToSentinelMessage walks err's wrap chain and returns the message of
+// the wrapper whose direct child is one of the two cache_control sentinels —
+// strips outer prefixes like "emit body: " while keeping the sentinel's own
+// dynamic detail. Falls back to err.Error() if no such layer is found.
+func unwrapToSentinelMessage(err error) string {
+	for e := err; e != nil; e = errors.Unwrap(e) {
+		if child := errors.Unwrap(e); child == translate.ErrAnthropicCacheControlOverflow || child == translate.ErrAnthropicCacheControlInvalid {
+			return e.Error()
+		}
+	}
+	return err.Error()
+}
+
 // IsClientError reports whether the classified error stems from a bad
 // request (as opposed to an upstream/routing failure), which anthropic and
 // openai handlers surface as the "invalid_request_error" envelope type
 // rather than "api_error".
 func (k DispatchErrorKind) IsClientError() bool {
 	switch k {
-	case DispatchErrorRequestNotJSONObject, DispatchErrorNoEligibleProvider, DispatchErrorContextWindowExceeded, DispatchErrorInvalidRoutingKnobs, DispatchErrorTranslationIntrinsicallyIncompatible:
+	case DispatchErrorRequestNotJSONObject, DispatchErrorNoEligibleProvider, DispatchErrorContextWindowExceeded, DispatchErrorInvalidRoutingKnobs, DispatchErrorTranslationIntrinsicallyIncompatible, DispatchErrorAnthropicCacheControlInvalid:
 		return true
 	default:
 		return false

--- a/internal/proxy/dispatch_error_test.go
+++ b/internal/proxy/dispatch_error_test.go
@@ -13,6 +13,7 @@ import (
 	"workweave/router/internal/router/cluster"
 	"workweave/router/internal/router/hmm"
 	"workweave/router/internal/router/rl"
+	"workweave/router/internal/translate"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -138,4 +139,33 @@ func TestClassifyDispatchError_SpendLimitUnavailableFailsClosed503(t *testing.T)
 	assert.Equal(t, http.StatusServiceUnavailable, cls.Status)
 	assert.True(t, cls.RetryAfter)
 	assert.Equal(t, "error", cls.LogLevel)
+}
+
+func TestClassifyDispatchError_AnthropicCacheControlOverflowIs400(t *testing.T) {
+	// Mirror the wrapping service.go uses: fmt.Errorf("emit body: %w", emitErr).
+	err := fmt.Errorf("emit body: %w", fmt.Errorf("%w: got 5, maximum is 4", translate.ErrAnthropicCacheControlOverflow))
+
+	cls, ok := proxy.ClassifyDispatchError(err)
+
+	require.True(t, ok, "ErrAnthropicCacheControlOverflow must be classified, not fall through to a generic 502")
+	assert.Equal(t, proxy.DispatchErrorAnthropicCacheControlInvalid, cls.Kind)
+	assert.Equal(t, http.StatusBadRequest, cls.Status)
+	assert.True(t, cls.Kind.IsClientError(), "the client's own explicit breakpoints exceeded capacity, not an upstream/routing problem")
+	assert.Equal(t, "warn", cls.LogLevel)
+	assert.False(t, cls.RetryAfter)
+	assert.NotContains(t, cls.Message, "emit body:", "the internal wrap-chain prefix must not leak into the client-facing message")
+	assert.Contains(t, cls.Message, "got 5, maximum is 4", "the validator's dynamic detail must survive unwrapping")
+}
+
+func TestClassifyDispatchError_AnthropicCacheControlInvalidTTLOrderingIs400(t *testing.T) {
+	err := fmt.Errorf("emit body: %w", fmt.Errorf("%w: ttl=1h cache_control must not follow ttl=5m", translate.ErrAnthropicCacheControlInvalid))
+
+	cls, ok := proxy.ClassifyDispatchError(err)
+
+	require.True(t, ok)
+	assert.Equal(t, proxy.DispatchErrorAnthropicCacheControlInvalid, cls.Kind)
+	assert.Equal(t, http.StatusBadRequest, cls.Status)
+	assert.True(t, cls.Kind.IsClientError())
+	assert.NotContains(t, cls.Message, "emit body:", "the internal wrap-chain prefix must not leak into the client-facing message")
+	assert.Contains(t, cls.Message, "ttl=1h cache_control must not follow ttl=5m")
 }


### PR DESCRIPTION
## What

Anthropic `cache_control` validation errors (breakpoint overflow past the 4-cap, or a `ttl=1h` breakpoint ordered after a `ttl=5m` one) previously fell through `ClassifyDispatchError` to the generic "Upstream call failed" 502 handler — even though no upstream call was ever attempted. The router's own translate-layer validator (`internal/translate/cache_control.go`) rejects these before dispatch.

Now classified as a clean 400 (`DispatchErrorAnthropicCacheControlInvalid`), matching the pattern used for the other client-input error kinds. `unwrapToSentinelMessage` walks the error's wrap chain to strip the internal `"emit body: "` prefix while keeping the validator's own dynamic detail (`"got 5, maximum is 4"`).

## Why

Found by the router's real-Anthropic smoke suite (#828, `smoke/cache_test.go`'s overflow-rejection scenario) on its first run against the real API — the in-process conformance suite never exercises what `ClassifyDispatchError` actually returns for this sentinel pair end to end. Split out of #828 per review — that PR is the test harness; this is the standalone production fix it caught.

## Testing

- `go test ./internal/proxy/...` — new unit tests assert 400 + `IsClientError()` + no leaked wrap prefix for both the overflow and TTL-ordering sentinels.
- `go build ./...`, `go vet ./...`, `gofmt -l .` all clean.