### PR TITLE
fix(translate): satisfy OpenAI strict-mode object/array requirements on makeNullable's typeless-branch fallback

### DIFF
--- a/internal/translate/strictify_openai.go
+++ b/internal/translate/strictify_openai.go
@@ -208,7 +208,19 @@ func makeNullable(node map[string]any) map[string]any {
 	}
 	// No type and no anyOf: give the synthetic branch an explicit value-type union
 	// so OpenAI strict mode accepts it; preserve any inline constraints on the original node.
-	branch := map[string]any{"type": []any{"string", "number", "boolean", "object", "array", "null"}}
+	//
+	// OpenAI strict mode requires, on every node whose type can be "object": additionalProperties:false
+	// + empty properties/required (400: "'additionalProperties' is required to be supplied and to be false").
+	// On every node whose type can be "array": an "items" sub-schema (400: "array schema missing items").
+	// items bottoms out at primitives — this branch means "no type info at all", so a shallow
+	// terminating schema is deliberate.
+	branch := map[string]any{
+		"type":                 []any{"string", "number", "boolean", "object", "array", "null"},
+		"additionalProperties": false,
+		"properties":           map[string]any{},
+		"required":             []any{},
+		"items":                map[string]any{"type": []any{"string", "number", "boolean", "null"}},
+	}
 	for k, v := range node {
 		branch[k] = v
 	}

--- a/internal/translate/strictify_openai_test.go
+++ b/internal/translate/strictify_openai_test.go
@@ -255,9 +255,7 @@ func TestStrictify_TypelessOptionalGetsExplicitValueType(t *testing.T) {
 		"a typeless branch must carry an explicit value-type union so OpenAI strict mode doesn't 400")
 	assert.Equal(t, map[string]any{"type": "null"}, branches[1])
 
-	// A type union including "object" needs additionalProperties:false + empty properties/required;
-	// OpenAI strict mode 400s otherwise ("'additionalProperties' is required to be supplied and to
-	// be false", index 3 = the "object" entry in the six-element type array above).
+	// Object-capable union needs additionalProperties:false + empty properties/required (OpenAI strict-mode 400).
 	assert.Equal(t, false, valueBranch["additionalProperties"],
 		"a type union including \"object\" needs additionalProperties:false or OpenAI 400s")
 	assert.Equal(t, map[string]any{}, valueBranch["properties"],

--- a/internal/translate/strictify_openai_test.go
+++ b/internal/translate/strictify_openai_test.go
@@ -250,7 +250,26 @@ func TestStrictify_TypelessOptionalGetsExplicitValueType(t *testing.T) {
 	branches, has := args["anyOf"].([]any)
 	require.True(t, has, "a typeless optional is made nullable via anyOf")
 	require.Len(t, branches, 2)
-	assert.Equal(t, []any{"string", "number", "boolean", "object", "array", "null"}, branches[0].(map[string]any)["type"],
+	valueBranch := branches[0].(map[string]any)
+	assert.Equal(t, []any{"string", "number", "boolean", "object", "array", "null"}, valueBranch["type"],
 		"a typeless branch must carry an explicit value-type union so OpenAI strict mode doesn't 400")
 	assert.Equal(t, map[string]any{"type": "null"}, branches[1])
+
+	// A type union including "object" needs additionalProperties:false + empty properties/required;
+	// OpenAI strict mode 400s otherwise ("'additionalProperties' is required to be supplied and to
+	// be false", index 3 = the "object" entry in the six-element type array above).
+	assert.Equal(t, false, valueBranch["additionalProperties"],
+		"a type union including \"object\" needs additionalProperties:false or OpenAI 400s")
+	assert.Equal(t, map[string]any{}, valueBranch["properties"],
+		"an object-capable branch needs a properties map, even if empty")
+	assert.Equal(t, []any{}, valueBranch["required"],
+		"an object-capable branch needs a required list, even if empty")
+
+	// A type union including "array" needs an items sub-schema; OpenAI strict mode
+	// 400s otherwise ("array schema missing items", index 4 = the "array" entry).
+	// items bottoms out at primitives — deliberate, since this branch means "no type info".
+	items, hasItems := valueBranch["items"].(map[string]any)
+	require.True(t, hasItems, "a type union including \"array\" needs an items sub-schema or OpenAI 400s")
+	assert.Equal(t, []any{"string", "number", "boolean", "null"}, items["type"],
+		"items must bottom out at primitives, not recurse into object/array")
 }

--- a/internal/translate/strictify_openai_test.go
+++ b/internal/translate/strictify_openai_test.go
@@ -265,9 +265,7 @@ func TestStrictify_TypelessOptionalGetsExplicitValueType(t *testing.T) {
 	assert.Equal(t, []any{}, valueBranch["required"],
 		"an object-capable branch needs a required list, even if empty")
 
-	// A type union including "array" needs an items sub-schema; OpenAI strict mode
-	// 400s otherwise ("array schema missing items", index 4 = the "array" entry).
-	// items bottoms out at primitives — deliberate, since this branch means "no type info".
+	// Array-capable union needs an items sub-schema (OpenAI strict-mode 400); primitives only, no recursion.
 	items, hasItems := valueBranch["items"].(map[string]any)
 	require.True(t, hasItems, "a type union including \"array\" needs an items sub-schema or OpenAI 400s")
 	assert.Equal(t, []any{"string", "number", "boolean", "null"}, items["type"],


### PR DESCRIPTION
## What

#829 fixed `makeNullable`'s fallback for a typeless optional property (no `"type"`/`"anyOf"`/`"enum"`) by stamping an explicit value-type union (`["string","number","boolean","object","array","null"]`) on the synthetic `anyOf` branch. Necessary, but not sufficient — OpenAI's strict-mode validator has two more requirements for any node whose type *can* be `"object"` or `"array"`, with no exception for a union that merely includes those types alongside primitives:

- `additionalProperties:false` (+ empty `properties`/`required`) on every object-capable node — 400: `"'additionalProperties' is required to be supplied and to be false"`
- an `"items"` sub-schema on every array-capable node — 400: `"array schema missing items"`

Fix: the synthetic branch now carries both. `items` bottoms out at primitives only (no recursion) — deliberate, since this branch already means "no type information at all."

## Why

Both gaps were found live, back to back, on the same real-OpenAI smoke run (#828): a request to `gpt-5.4-nano` with a Workflow-tool-shaped typeless `args` param 400'd on `additionalProperties`; after fixing that, the very next request 400'd on the array/`items` gap. Split out of #828 per review — that PR is the test harness; this is the standalone production fix it caught.

## Testing

- `go test ./internal/translate/...` — strengthened `TestStrictify_TypelessOptionalGetsExplicitValueType` with assertions on all four fields (`additionalProperties`, `properties`, `required`, `items`); their absence is exactly what let both gaps ship.
- `go build ./...`, `go vet ./...`, `gofmt -l .` all clean.