### PR TITLE
fix(translate): keep CC scheduling tools on cross-vendor emit

### DIFF
--- a/internal/translate/claudecode_tool_filter.go
+++ b/internal/translate/claudecode_tool_filter.go
@@ -20,31 +20,50 @@ import (
 // only on Anthropic→non-Anthropic emit paths (buildOpenAIFromAnthropic and
 // the Anthropic case of PrepareGemini). The Anthropic→Anthropic passthrough
 // preserves them.
+//
+// Scheduling / wake-up tools (ScheduleWakeup, CronCreate/Delete/List, Monitor)
+// are intentionally NOT in this set: they are client-executed the same way as
+// Read/Bash, and when the schema is present non-Anthropic models call them
+// correctly (observed in prod CC transcripts). Stripping Cron*/Monitor while
+// leaving ScheduleWakeup broke fixed-interval /loop on non-Anthropic routes.
+// NotebookEdit is also omitted — it is a real coding tool (same family as
+// Edit), not a CC-internal control-plane tool.
 var claudeCodeOnlyToolNames = map[string]struct{}{
-	"Task":                 {},
-	"TaskCreate":           {},
-	"TaskUpdate":           {},
-	"TaskGet":              {},
-	"TaskList":             {},
-	"TaskOutput":           {},
-	"TaskStop":             {},
-	"EnterPlanMode":        {},
-	"ExitPlanMode":         {},
-	"Skill":                {},
-	"Workflow":             {},
-	"AskUserQuestion":      {},
-	"CronCreate":           {},
-	"CronDelete":           {},
-	"CronList":             {},
-	"Monitor":              {},
-	"PushNotification":     {},
-	"RemoteTrigger":        {},
-	"EnterWorktree":        {},
-	"ExitWorktree":         {},
-	"LSP":                  {},
-	"ListMcpResourcesTool": {},
-	"ReadMcpResourceTool":  {},
-	"NotebookEdit":         {},
+	// Subagent dispatch. Task = pre-2.1 name; Agent = current CC name.
+	"Task":       {},
+	"Agent":      {},
+	"TaskCreate": {},
+	"TaskUpdate": {},
+	"TaskGet":    {},
+	"TaskList":   {},
+	"TaskOutput": {},
+	"TaskStop":   {},
+	// Plan mode / skills / workflows.
+	"EnterPlanMode":   {},
+	"ExitPlanMode":    {},
+	"UpdatePlan":      {},
+	"Skill":           {},
+	"Workflow":        {},
+	"AskUserQuestion": {},
+	// Tool registry / deferred-loading discovery (Anthropic-native protocol;
+	// non-Anthropic emit drops defer_loading anyway, so ToolSearch is noise).
+	"ToolSearch": {},
+	// Todo / shell-session bookkeeping that non-Anthropic models invent.
+	"TodoWrite":  {},
+	"BashOutput": {},
+	"KillShell":  {},
+	// Notifications / remote triggers / worktrees / LSP.
+	"PushNotification": {},
+	"RemoteTrigger":    {},
+	"EnterWorktree":    {},
+	"ExitWorktree":     {},
+	"LSP":              {},
+	// MCP resource listing — both historic *Tool suffix and current names.
+	"ListMcpResourcesTool":     {},
+	"ReadMcpResourceTool":      {},
+	"ListMcpResources":         {},
+	"ListMcpResourceTemplates": {},
+	"ReadMcpResource":          {},
 }
 
 // isClaudeCodeOnlyTool reports whether name is one of the tools Claude Code
@@ -61,6 +80,7 @@ func isClaudeCodeOnlyTool(name string) bool {
 // claudeCodeOnlyToolNames — see TestOrchestrationToolsAreSubsetOfCCOnly.
 var claudeCodeOrchestrationToolNames = map[string]struct{}{
 	"Task":          {},
+	"Agent":         {},
 	"TaskCreate":    {},
 	"TaskUpdate":    {},
 	"TaskGet":       {},

--- a/internal/translate/claudecode_tool_filter.go
+++ b/internal/translate/claudecode_tool_filter.go
@@ -22,12 +22,9 @@ import (
 // preserves them.
 //
 // Scheduling / wake-up tools (ScheduleWakeup, CronCreate/Delete/List, Monitor)
-// are intentionally NOT in this set: they are client-executed the same way as
-// Read/Bash, and when the schema is present non-Anthropic models call them
-// correctly (observed in prod CC transcripts). Stripping Cron*/Monitor while
-// leaving ScheduleWakeup broke fixed-interval /loop on non-Anthropic routes.
-// NotebookEdit is also omitted — it is a real coding tool (same family as
-// Edit), not a CC-internal control-plane tool.
+// are client-executed like Read/Bash; stripping them while leaving ScheduleWakeup
+// broke fixed-interval /loop on non-Anthropic routes. NotebookEdit is a coding
+// tool (same family as Edit), not a CC-internal control-plane tool.
 var claudeCodeOnlyToolNames = map[string]struct{}{
 	// Subagent dispatch. Task = pre-2.1 name; Agent = current CC name.
 	"Task":       {},

--- a/internal/translate/claudecode_tool_filter.go
+++ b/internal/translate/claudecode_tool_filter.go
@@ -22,9 +22,10 @@ import (
 // preserves them.
 //
 // Scheduling / wake-up tools (ScheduleWakeup, CronCreate/Delete/List, Monitor)
-// are client-executed like Read/Bash; stripping them while leaving ScheduleWakeup
-// broke fixed-interval /loop on non-Anthropic routes. NotebookEdit is a coding
-// tool (same family as Edit), not a CC-internal control-plane tool.
+// and shell-session tools (BashOutput, KillShell) are client-executed like
+// Read/Bash; stripping them broke /loop and background-shell control on
+// non-Anthropic routes. NotebookEdit is a coding tool (same family as Edit),
+// not a CC-internal control-plane tool.
 var claudeCodeOnlyToolNames = map[string]struct{}{
 	// Subagent dispatch. Task = pre-2.1 name; Agent = current CC name.
 	"Task":       {},
@@ -45,10 +46,8 @@ var claudeCodeOnlyToolNames = map[string]struct{}{
 	// Tool registry / deferred-loading discovery (Anthropic-native protocol;
 	// non-Anthropic emit drops defer_loading anyway, so ToolSearch is noise).
 	"ToolSearch": {},
-	// Todo / shell-session bookkeeping that non-Anthropic models invent.
-	"TodoWrite":  {},
-	"BashOutput": {},
-	"KillShell":  {},
+	// Todo bookkeeping that non-Anthropic models invent.
+	"TodoWrite": {},
 	// Notifications / remote triggers / worktrees / LSP.
 	"PushNotification": {},
 	"RemoteTrigger":    {},
@@ -88,6 +87,7 @@ var claudeCodeOrchestrationToolNames = map[string]struct{}{
 	"Skill":         {},
 	"EnterPlanMode": {},
 	"ExitPlanMode":  {},
+	"UpdatePlan":    {},
 }
 
 // isCrossVendorOrchestrationTool reports whether name is a Claude Code

--- a/internal/translate/claudecode_tool_filter_internal_test.go
+++ b/internal/translate/claudecode_tool_filter_internal_test.go
@@ -19,15 +19,20 @@ func TestShouldStripCCTool(t *testing.T) {
 		keepOrchestration bool
 		want              bool
 	}{
-		{"Read", false, false},          // real tool: never stripped
-		{"Read", true, false},           // real tool: never stripped
-		{"Task", false, true},           // orchestration: stripped when flag off
-		{"Task", true, false},           // orchestration: kept when flag on
-		{"Workflow", true, false},       // orchestration: kept when flag on
-		{"ExitPlanMode", true, false},   // orchestration: kept when flag on
-		{"AskUserQuestion", true, true}, // CC-only non-orchestration: stripped even when flag on
-		{"NotebookEdit", true, true},    // CC-only non-orchestration: stripped even when flag on
-		{"CronCreate", false, true},     // CC-only non-orchestration: stripped
+		{"Read", false, false},            // real tool: never stripped
+		{"Read", true, false},             // real tool: never stripped
+		{"NotebookEdit", false, false},    // coding tool: never stripped
+		{"ScheduleWakeup", false, false},  // scheduling: never stripped
+		{"CronCreate", false, false},      // scheduling: never stripped
+		{"Monitor", true, false},          // scheduling: never stripped
+		{"Task", false, true},             // orchestration: stripped when flag off
+		{"Task", true, false},             // orchestration: kept when flag on
+		{"Agent", true, false},            // orchestration (current CC name): kept when flag on
+		{"Workflow", true, false},         // orchestration: kept when flag on
+		{"ExitPlanMode", true, false},     // orchestration: kept when flag on
+		{"AskUserQuestion", true, true},   // CC-only non-orchestration: stripped even when flag on
+		{"ToolSearch", true, true},        // CC-only non-orchestration: stripped even when flag on
+		{"TodoWrite", false, true},        // CC-only non-orchestration: stripped
 	}
 	for _, tc := range cases {
 		if got := shouldStripCCTool(tc.name, tc.keepOrchestration); got != tc.want {

--- a/internal/translate/claudecode_tool_filter_internal_test.go
+++ b/internal/translate/claudecode_tool_filter_internal_test.go
@@ -19,20 +19,20 @@ func TestShouldStripCCTool(t *testing.T) {
 		keepOrchestration bool
 		want              bool
 	}{
-		{"Read", false, false},            // real tool: never stripped
-		{"Read", true, false},             // real tool: never stripped
-		{"NotebookEdit", false, false},    // coding tool: never stripped
-		{"ScheduleWakeup", false, false},  // scheduling: never stripped
-		{"CronCreate", false, false},      // scheduling: never stripped
-		{"Monitor", true, false},          // scheduling: never stripped
-		{"Task", false, true},             // orchestration: stripped when flag off
-		{"Task", true, false},             // orchestration: kept when flag on
-		{"Agent", true, false},            // orchestration (current CC name): kept when flag on
-		{"Workflow", true, false},         // orchestration: kept when flag on
-		{"ExitPlanMode", true, false},     // orchestration: kept when flag on
-		{"AskUserQuestion", true, true},   // CC-only non-orchestration: stripped even when flag on
-		{"ToolSearch", true, true},        // CC-only non-orchestration: stripped even when flag on
-		{"TodoWrite", false, true},        // CC-only non-orchestration: stripped
+		{"Read", false, false},           // real tool: never stripped
+		{"Read", true, false},            // real tool: never stripped
+		{"NotebookEdit", false, false},   // coding tool: never stripped
+		{"ScheduleWakeup", false, false}, // scheduling: never stripped
+		{"CronCreate", false, false},     // scheduling: never stripped
+		{"Monitor", true, false},         // scheduling: never stripped
+		{"Task", false, true},            // orchestration: stripped when flag off
+		{"Task", true, false},            // orchestration: kept when flag on
+		{"Agent", true, false},           // orchestration (current CC name): kept when flag on
+		{"Workflow", true, false},        // orchestration: kept when flag on
+		{"ExitPlanMode", true, false},    // orchestration: kept when flag on
+		{"AskUserQuestion", true, true},  // CC-only non-orchestration: stripped even when flag on
+		{"ToolSearch", true, true},       // CC-only non-orchestration: stripped even when flag on
+		{"TodoWrite", false, true},       // CC-only non-orchestration: stripped
 	}
 	for _, tc := range cases {
 		if got := shouldStripCCTool(tc.name, tc.keepOrchestration); got != tc.want {

--- a/internal/translate/claudecode_tool_filter_internal_test.go
+++ b/internal/translate/claudecode_tool_filter_internal_test.go
@@ -25,11 +25,14 @@ func TestShouldStripCCTool(t *testing.T) {
 		{"ScheduleWakeup", false, false}, // scheduling: never stripped
 		{"CronCreate", false, false},     // scheduling: never stripped
 		{"Monitor", true, false},         // scheduling: never stripped
+		{"BashOutput", false, false},     // shell session: never stripped
+		{"KillShell", true, false},       // shell session: never stripped
 		{"Task", false, true},            // orchestration: stripped when flag off
 		{"Task", true, false},            // orchestration: kept when flag on
 		{"Agent", true, false},           // orchestration (current CC name): kept when flag on
 		{"Workflow", true, false},        // orchestration: kept when flag on
 		{"ExitPlanMode", true, false},    // orchestration: kept when flag on
+		{"UpdatePlan", true, false},      // orchestration: kept when flag on
 		{"AskUserQuestion", true, true},  // CC-only non-orchestration: stripped even when flag on
 		{"ToolSearch", true, true},       // CC-only non-orchestration: stripped even when flag on
 		{"TodoWrite", false, true},       // CC-only non-orchestration: stripped

--- a/internal/translate/claudecode_tool_filter_test.go
+++ b/internal/translate/claudecode_tool_filter_test.go
@@ -72,8 +72,7 @@ func emittedGeminiToolNames(t *testing.T, body []byte) []string {
 }
 
 // claudeCodeMixedToolBody is a representative Anthropic request body carrying
-// the real coding tools Claude Code uses (Read/Edit/Write/Bash) interleaved
-// with the Claude-Code-only tools that have no upstream behavior.
+// coding + scheduling tools interleaved with CC-only control-plane tools.
 const claudeCodeMixedToolBody = `{
 	"model":"claude-opus-4-7",
 	"system":"You are a helpful coding assistant.",
@@ -83,7 +82,12 @@ const claudeCodeMixedToolBody = `{
 		{"name":"Edit","description":"e","input_schema":{"type":"object"}},
 		{"name":"Write","description":"w","input_schema":{"type":"object"}},
 		{"name":"Bash","description":"b","input_schema":{"type":"object"}},
+		{"name":"NotebookEdit","description":"nb","input_schema":{"type":"object"}},
+		{"name":"ScheduleWakeup","description":"loop wake","input_schema":{"type":"object"}},
+		{"name":"CronCreate","description":"cron","input_schema":{"type":"object"}},
+		{"name":"Monitor","description":"watch","input_schema":{"type":"object"}},
 		{"name":"Task","description":"sub-agent dispatch","input_schema":{"type":"object"}},
+		{"name":"Agent","description":"sub-agent dispatch","input_schema":{"type":"object"}},
 		{"name":"TaskCreate","description":"","input_schema":{"type":"object"}},
 		{"name":"TaskUpdate","description":"","input_schema":{"type":"object"}},
 		{"name":"TaskList","description":"","input_schema":{"type":"object"}},
@@ -92,10 +96,18 @@ const claudeCodeMixedToolBody = `{
 		{"name":"Skill","description":"","input_schema":{"type":"object"}},
 		{"name":"Workflow","description":"","input_schema":{"type":"object"}},
 		{"name":"AskUserQuestion","description":"","input_schema":{"type":"object"}},
-		{"name":"NotebookEdit","description":"","input_schema":{"type":"object"}}
+		{"name":"ToolSearch","description":"","input_schema":{"type":"object"}},
+		{"name":"TodoWrite","description":"","input_schema":{"type":"object"}}
 	],
 	"max_tokens":256
 }`
+
+// keptOnNonAnthropicDefault are tools that survive Anthropic→non-Anthropic emit
+// when KeepCrossVendorOrchestrationTools is off: coding + scheduling.
+var keptOnNonAnthropicDefault = []string{
+	"Read", "Edit", "Write", "Bash", "NotebookEdit",
+	"ScheduleWakeup", "CronCreate", "Monitor",
+}
 
 func TestStripCCTools_AnthropicSourceOpenAITarget_DropsCCOnlyKeepsReal(t *testing.T) {
 	env, err := translate.ParseAnthropic([]byte(claudeCodeMixedToolBody))
@@ -105,8 +117,11 @@ func TestStripCCTools_AnthropicSourceOpenAITarget_DropsCCOnlyKeepsReal(t *testin
 	require.NoError(t, err)
 
 	names := emittedToolNames(t, out.Body)
-	assert.ElementsMatch(t, []string{"Read", "Edit", "Write", "Bash"}, names,
-		"only real coding tools survive; every CC-only schema must be stripped on the Anthropic→OpenAI emit path")
+	assert.ElementsMatch(t, keptOnNonAnthropicDefault, names,
+		"coding + scheduling tools survive; CC-only control-plane schemas stripped on Anthropic→OpenAI")
+	assert.NotContains(t, names, "Task")
+	assert.NotContains(t, names, "Agent")
+	assert.NotContains(t, names, "ToolSearch")
 }
 
 func TestStripCCTools_AnthropicSourceGeminiTarget_DropsCCOnlyKeepsReal(t *testing.T) {
@@ -117,8 +132,8 @@ func TestStripCCTools_AnthropicSourceGeminiTarget_DropsCCOnlyKeepsReal(t *testin
 	require.NoError(t, err)
 
 	names := emittedGeminiToolNames(t, out.Body)
-	assert.ElementsMatch(t, []string{"Read", "Edit", "Write", "Bash"}, names,
-		"Anthropic→Gemini emit path must drop CC-only schemas before functionDeclarations")
+	assert.ElementsMatch(t, keptOnNonAnthropicDefault, names,
+		"Anthropic→Gemini keeps scheduling tools and drops CC-only control-plane schemas")
 }
 
 func TestStripCCTools_AnthropicSourceAnthropicTarget_KeepsCCOnly(t *testing.T) {
@@ -144,13 +159,18 @@ func TestStripCCTools_AnthropicSourceAnthropicTarget_KeepsCCOnly(t *testing.T) {
 		}
 	}
 	assert.Contains(t, got, "Task", "Anthropic passthrough must keep Task — only the cross-provider emit strips it")
+	assert.Contains(t, got, "Agent")
 	assert.Contains(t, got, "TaskUpdate")
 	assert.Contains(t, got, "Skill")
+	assert.Contains(t, got, "ScheduleWakeup")
+	assert.Contains(t, got, "CronCreate")
+	assert.Contains(t, got, "NotebookEdit")
 	assert.Contains(t, got, "Read", "real coding tools must also survive on passthrough")
 }
 
 func TestKeepOrchestrationTools_OpenAITarget_KeepsOrchestrationDropsRest(t *testing.T) {
-	// Flag on: orchestration tools survive; other CC-only tools (AskUserQuestion, NotebookEdit) are still stripped.
+	// Flag on: orchestration tools survive; other CC-only tools (AskUserQuestion,
+	// ToolSearch) are still stripped. Scheduling/NotebookEdit are not CC-only.
 	env, err := translate.ParseAnthropic([]byte(claudeCodeMixedToolBody))
 	require.NoError(t, err)
 
@@ -162,12 +182,14 @@ func TestKeepOrchestrationTools_OpenAITarget_KeepsOrchestrationDropsRest(t *test
 
 	names := emittedToolNames(t, out.Body)
 	assert.ElementsMatch(t, []string{
-		"Read", "Edit", "Write", "Bash",
-		"Task", "TaskCreate", "TaskUpdate", "TaskList",
+		"Read", "Edit", "Write", "Bash", "NotebookEdit",
+		"ScheduleWakeup", "CronCreate", "Monitor",
+		"Task", "Agent", "TaskCreate", "TaskUpdate", "TaskList",
 		"EnterPlanMode", "ExitPlanMode", "Skill", "Workflow",
-	}, names, "orchestration tools survive when the flag is on; other CC-only tools still stripped")
+	}, names, "orchestration + scheduling tools survive when the flag is on")
 	assert.NotContains(t, names, "AskUserQuestion", "non-orchestration CC-only tools stay stripped")
-	assert.NotContains(t, names, "NotebookEdit")
+	assert.NotContains(t, names, "ToolSearch")
+	assert.NotContains(t, names, "TodoWrite")
 }
 
 func TestKeepOrchestrationTools_OpenAITarget_NormalizesTypelessAnyOf(t *testing.T) {
@@ -211,17 +233,19 @@ func TestKeepOrchestrationTools_GeminiTarget_KeepsOrchestrationDropsRest(t *test
 
 	names := emittedGeminiToolNames(t, out.Body)
 	assert.ElementsMatch(t, []string{
-		"Read", "Edit", "Write", "Bash",
-		"Task", "TaskCreate", "TaskUpdate", "TaskList",
+		"Read", "Edit", "Write", "Bash", "NotebookEdit",
+		"ScheduleWakeup", "CronCreate", "Monitor",
+		"Task", "Agent", "TaskCreate", "TaskUpdate", "TaskList",
 		"EnterPlanMode", "ExitPlanMode", "Skill", "Workflow",
-	}, names, "Anthropic→Gemini keeps orchestration tools when the flag is on")
+	}, names, "Anthropic→Gemini keeps orchestration + scheduling tools when the flag is on")
 	assert.NotContains(t, names, "AskUserQuestion")
-	assert.NotContains(t, names, "NotebookEdit")
+	assert.NotContains(t, names, "ToolSearch")
 }
 
 func TestKeepOrchestrationTools_EmitOptionsZeroValue_StripsAll(t *testing.T) {
-	// Zero-value EmitOptions strips all CC-only tools; production default
-	// (on) is set by the proxy composition root, not the translate layer.
+	// Zero-value EmitOptions strips CC-only control-plane tools (incl.
+	// orchestration); production default (on) is set by the proxy composition
+	// root. Scheduling + coding tools are not CC-only and always survive.
 	env, err := translate.ParseAnthropic([]byte(claudeCodeMixedToolBody))
 	require.NoError(t, err)
 
@@ -229,8 +253,11 @@ func TestKeepOrchestrationTools_EmitOptionsZeroValue_StripsAll(t *testing.T) {
 	require.NoError(t, err)
 
 	names := emittedToolNames(t, out.Body)
-	assert.ElementsMatch(t, []string{"Read", "Edit", "Write", "Bash"}, names,
-		"unset flag must strip every CC-only tool including orchestration ones")
+	assert.ElementsMatch(t, keptOnNonAnthropicDefault, names,
+		"unset flag must strip orchestration CC-only tools; scheduling tools stay")
+	assert.NotContains(t, names, "Task")
+	assert.NotContains(t, names, "Agent")
+	assert.NotContains(t, names, "Skill")
 }
 
 func TestStripCCTools_NoCCToolsNoRewrite(t *testing.T) {

--- a/internal/translate/claudecode_tool_filter_test.go
+++ b/internal/translate/claudecode_tool_filter_test.go
@@ -86,6 +86,8 @@ const claudeCodeMixedToolBody = `{
 		{"name":"ScheduleWakeup","description":"loop wake","input_schema":{"type":"object"}},
 		{"name":"CronCreate","description":"cron","input_schema":{"type":"object"}},
 		{"name":"Monitor","description":"watch","input_schema":{"type":"object"}},
+		{"name":"BashOutput","description":"bg out","input_schema":{"type":"object"}},
+		{"name":"KillShell","description":"bg kill","input_schema":{"type":"object"}},
 		{"name":"Task","description":"sub-agent dispatch","input_schema":{"type":"object"}},
 		{"name":"Agent","description":"sub-agent dispatch","input_schema":{"type":"object"}},
 		{"name":"TaskCreate","description":"","input_schema":{"type":"object"}},
@@ -93,6 +95,7 @@ const claudeCodeMixedToolBody = `{
 		{"name":"TaskList","description":"","input_schema":{"type":"object"}},
 		{"name":"EnterPlanMode","description":"","input_schema":{"type":"object"}},
 		{"name":"ExitPlanMode","description":"","input_schema":{"type":"object"}},
+		{"name":"UpdatePlan","description":"","input_schema":{"type":"object"}},
 		{"name":"Skill","description":"","input_schema":{"type":"object"}},
 		{"name":"Workflow","description":"","input_schema":{"type":"object"}},
 		{"name":"AskUserQuestion","description":"","input_schema":{"type":"object"}},
@@ -103,10 +106,10 @@ const claudeCodeMixedToolBody = `{
 }`
 
 // keptOnNonAnthropicDefault are tools that survive Anthropic→non-Anthropic emit
-// when KeepCrossVendorOrchestrationTools is off: coding + scheduling.
+// when KeepCrossVendorOrchestrationTools is off: coding + scheduling + shell session.
 var keptOnNonAnthropicDefault = []string{
 	"Read", "Edit", "Write", "Bash", "NotebookEdit",
-	"ScheduleWakeup", "CronCreate", "Monitor",
+	"ScheduleWakeup", "CronCreate", "Monitor", "BashOutput", "KillShell",
 }
 
 func TestStripCCTools_AnthropicSourceOpenAITarget_DropsCCOnlyKeepsReal(t *testing.T) {
@@ -183,9 +186,9 @@ func TestKeepOrchestrationTools_OpenAITarget_KeepsOrchestrationDropsRest(t *test
 	names := emittedToolNames(t, out.Body)
 	assert.ElementsMatch(t, []string{
 		"Read", "Edit", "Write", "Bash", "NotebookEdit",
-		"ScheduleWakeup", "CronCreate", "Monitor",
+		"ScheduleWakeup", "CronCreate", "Monitor", "BashOutput", "KillShell",
 		"Task", "Agent", "TaskCreate", "TaskUpdate", "TaskList",
-		"EnterPlanMode", "ExitPlanMode", "Skill", "Workflow",
+		"EnterPlanMode", "ExitPlanMode", "UpdatePlan", "Skill", "Workflow",
 	}, names, "orchestration + scheduling tools survive when the flag is on")
 	assert.NotContains(t, names, "AskUserQuestion", "non-orchestration CC-only tools stay stripped")
 	assert.NotContains(t, names, "ToolSearch")
@@ -234,9 +237,9 @@ func TestKeepOrchestrationTools_GeminiTarget_KeepsOrchestrationDropsRest(t *test
 	names := emittedGeminiToolNames(t, out.Body)
 	assert.ElementsMatch(t, []string{
 		"Read", "Edit", "Write", "Bash", "NotebookEdit",
-		"ScheduleWakeup", "CronCreate", "Monitor",
+		"ScheduleWakeup", "CronCreate", "Monitor", "BashOutput", "KillShell",
 		"Task", "Agent", "TaskCreate", "TaskUpdate", "TaskList",
-		"EnterPlanMode", "ExitPlanMode", "Skill", "Workflow",
+		"EnterPlanMode", "ExitPlanMode", "UpdatePlan", "Skill", "Workflow",
 	}, names, "Anthropic→Gemini keeps orchestration + scheduling tools when the flag is on")
 	assert.NotContains(t, names, "AskUserQuestion")
 	assert.NotContains(t, names, "ToolSearch")


### PR DESCRIPTION
Cron*/Monitor/NotebookEdit were stripped on Anthropic→non-Anthropic routes,
breaking fixed-interval /loop while ScheduleWakeup (not in the list) still
worked. Stop stripping client-executed scheduling + notebook edit tools;
add stale CC-only names (Agent, ToolSearch, TodoWrite, …) to the strip set.