### PR TITLE
Fix Anthropic unified-header parsing: 7d spelling and 0-1 utilization scale

### DIFF
--- a/internal/proxy/usage/usage.go
+++ b/internal/proxy/usage/usage.go
@@ -338,10 +338,8 @@ func parseResetTime(s string) (time.Time, bool) {
 }
 
 // parsePercent parses a 0-100 percent header (Codex used-percent) into a
-// clamped [0,1] fraction. Always divides by 100 — Codex documents these as
-// 0-100 — rather than guessing the scale from the magnitude, which silently
-// misreads the boundary (e.g. "1" = 1% must become 0.01, not 1.0). The
-// remaining/limit path computes its fraction directly and does not call this.
+// clamped [0,1] fraction. Divides by 100 — not guessing scale from magnitude
+// avoids misreading boundary values (e.g. "1" = 1%, not 100%).
 func parsePercent(s string) (float64, bool) {
 	v, ok := parseFloat(s)
 	if !ok {

--- a/internal/proxy/usage/usage.go
+++ b/internal/proxy/usage/usage.go
@@ -285,12 +285,17 @@ func parseCodexWindow(h http.Header, which string, defaultWindowMinutes int) (Wi
 
 // ParseAnthropicUnifiedHeaders extracts a Snapshot from Anthropic's unified
 // subscription rate-limit headers (the `claude /usage` data):
-// anthropic-ratelimit-unified-5h-* (primary) and -weekly-* (secondary). Prefers
-// an explicit *-utilization header; else derives used = 1 - remaining/limit.
-// Reports false if neither window is present.
+// anthropic-ratelimit-unified-5h-* (primary) and -7d-* (secondary; "-weekly-"
+// accepted as a legacy fallback — prod traffic emits "7d", per the Phase 0
+// unified_limit_headers capture). Prefers an explicit *-utilization header
+// (a 0-1 fraction on the wire; can exceed 1.0 mid-overage, clamped); else
+// derives used = 1 - remaining/limit. Reports false if neither window is present.
 func ParseAnthropicUnifiedHeaders(h http.Header) (Snapshot, bool) {
 	primary, pOK := parseAnthropicWindow(h, "5h", 5*60)
-	secondary, sOK := parseAnthropicWindow(h, "weekly", 7*24*60)
+	secondary, sOK := parseAnthropicWindow(h, "7d", 7*24*60)
+	if !sOK {
+		secondary, sOK = parseAnthropicWindow(h, "weekly", 7*24*60)
+	}
 	if !pOK && !sOK {
 		return Snapshot{}, false
 	}
@@ -300,7 +305,7 @@ func ParseAnthropicUnifiedHeaders(h http.Header) (Snapshot, bool) {
 func parseAnthropicWindow(h http.Header, which string, windowMinutes int) (Window, bool) {
 	prefix := "anthropic-ratelimit-unified-" + which + "-"
 	resetAt, _ := parseResetTime(h.Get(prefix + "reset"))
-	if used, ok := parsePercent(h.Get(prefix + "utilization")); ok {
+	if used, ok := parseFraction(h.Get(prefix + "utilization")); ok {
 		return Window{UsedPercent: used, WindowMinutes: windowMinutes, ResetAt: resetAt}, true
 	}
 	limit, lOK := parseFloat(h.Get(prefix + "limit"))
@@ -332,18 +337,37 @@ func parseResetTime(s string) (time.Time, bool) {
 	return time.Time{}, false
 }
 
-// parsePercent parses a 0-100 percent header (Codex used-percent, Anthropic
-// utilization) into a clamped [0,1] fraction. Always divides by 100 — both
-// backends document these as 0-100 — rather than guessing the scale from the
-// magnitude, which silently misreads the boundary (e.g. "1" = 1% must become
-// 0.01, not 1.0). The remaining/limit path computes its fraction directly and
-// does not call this.
+// parsePercent parses a 0-100 percent header (Codex used-percent) into a
+// clamped [0,1] fraction. Always divides by 100 — Codex documents these as
+// 0-100 — rather than guessing the scale from the magnitude, which silently
+// misreads the boundary (e.g. "1" = 1% must become 0.01, not 1.0). The
+// remaining/limit path computes its fraction directly and does not call this.
 func parsePercent(s string) (float64, bool) {
 	v, ok := parseFloat(s)
 	if !ok {
 		return 0, false
 	}
 	v /= 100
+	if v < 0 {
+		v = 0
+	}
+	if v > 1 {
+		v = 1
+	}
+	return v, true
+}
+
+// parseFraction parses a 0-1 fraction header (Anthropic unified utilization,
+// e.g. "0.7370692663445869") into a clamped [0,1] value. Prod headers exceed
+// 1.0 while a window is served on overage credits (observed up to ~2.0);
+// clamping preserves "at cap" for Exhausted/CostFactor. Distinct from
+// parsePercent (Codex, 0-100 wire scale) — dividing these by 100 shrank every
+// reading ~100x and made real utilization invisible to subsidy/exhaustion.
+func parseFraction(s string) (float64, bool) {
+	v, ok := parseFloat(s)
+	if !ok {
+		return 0, false
+	}
 	if v < 0 {
 		v = 0
 	}

--- a/internal/proxy/usage/usage.go
+++ b/internal/proxy/usage/usage.go
@@ -357,12 +357,9 @@ func parsePercent(s string) (float64, bool) {
 	return v, true
 }
 
-// parseFraction parses a 0-1 fraction header (Anthropic unified utilization,
-// e.g. "0.7370692663445869") into a clamped [0,1] value. Prod headers exceed
-// 1.0 while a window is served on overage credits (observed up to ~2.0);
-// clamping preserves "at cap" for Exhausted/CostFactor. Distinct from
-// parsePercent (Codex, 0-100 wire scale) — dividing these by 100 shrank every
-// reading ~100x and made real utilization invisible to subsidy/exhaustion.
+// parseFraction parses a 0-1 fraction header (Anthropic unified utilization)
+// into a clamped [0,1] value. Clamping to 1.0 handles overage-credit windows
+// where the wire value exceeds 1.0. Distinct from parsePercent (Codex, 0-100).
 func parseFraction(s string) (float64, bool) {
 	v, ok := parseFloat(s)
 	if !ok {

--- a/internal/proxy/usage/usage_test.go
+++ b/internal/proxy/usage/usage_test.go
@@ -66,8 +66,8 @@ func TestParseAnthropicUnified_FromRemainingLimit(t *testing.T) {
 	h := http.Header{}
 	h.Set("anthropic-ratelimit-unified-5h-limit", "1000")
 	h.Set("anthropic-ratelimit-unified-5h-remaining", "250") // 75% used
-	h.Set("anthropic-ratelimit-unified-weekly-limit", "100000")
-	h.Set("anthropic-ratelimit-unified-weekly-remaining", "90000") // 10% used
+	h.Set("anthropic-ratelimit-unified-7d-limit", "100000")
+	h.Set("anthropic-ratelimit-unified-7d-remaining", "90000") // 10% used
 
 	snap, ok := usage.ParseAnthropicUnifiedHeaders(h)
 	require.True(t, ok)
@@ -75,12 +75,44 @@ func TestParseAnthropicUnified_FromRemainingLimit(t *testing.T) {
 	assert.InDelta(t, 0.10, snap.Secondary.UsedPercent, 1e-9)
 }
 
+// Utilization values are 0-1 fractions on the wire (prod: "0.7370692663445869"),
+// NOT 0-100 percents like Codex used-percent. Dividing by 100 here shrank every
+// reading ~100x and silently disabled subsidy fade + exhaustion detection.
 func TestParseAnthropicUnified_PrefersUtilization(t *testing.T) {
 	h := http.Header{}
-	h.Set("anthropic-ratelimit-unified-5h-utilization", "63")
+	h.Set("anthropic-ratelimit-unified-5h-utilization", "0.63")
+	h.Set("anthropic-ratelimit-unified-7d-utilization", "0.7370692663445869")
 	snap, ok := usage.ParseAnthropicUnifiedHeaders(h)
 	require.True(t, ok)
 	assert.InDelta(t, 0.63, snap.Primary.UsedPercent, 1e-9)
+	assert.InDelta(t, 0.7370692663445869, snap.Secondary.UsedPercent, 1e-9)
+}
+
+// Prod emits utilization above 1.0 while a window is served on overage credits
+// (observed up to ~2.0). Clamp to 1.0 so Exhausted/CostFactor read "at cap".
+func TestParseAnthropicUnified_OverageUtilizationClamped(t *testing.T) {
+	h := http.Header{}
+	h.Set("anthropic-ratelimit-unified-5h-utilization", "1.28")
+	snap, ok := usage.ParseAnthropicUnifiedHeaders(h)
+	require.True(t, ok)
+	assert.InDelta(t, 1.0, snap.Primary.UsedPercent, 1e-9)
+	assert.True(t, snap.Exhausted())
+}
+
+// Prod traffic spells the long window "7d" (53k-row Phase 0 capture: zero
+// "weekly" keys); "weekly" is kept as a legacy fallback only.
+func TestParseAnthropicUnified_WeeklySpellingFallback(t *testing.T) {
+	h := http.Header{}
+	h.Set("anthropic-ratelimit-unified-weekly-utilization", "0.42")
+	snap, ok := usage.ParseAnthropicUnifiedHeaders(h)
+	require.True(t, ok)
+	assert.InDelta(t, 0.42, snap.Secondary.UsedPercent, 1e-9)
+
+	// When both spellings appear, 7d (the prod spelling) wins.
+	h.Set("anthropic-ratelimit-unified-7d-utilization", "0.90")
+	snap, ok = usage.ParseAnthropicUnifiedHeaders(h)
+	require.True(t, ok)
+	assert.InDelta(t, 0.90, snap.Secondary.UsedPercent, 1e-9)
 }
 
 func TestCostFactor_SlackIsCheap_BindingIsFullPrice(t *testing.T) {
@@ -276,15 +308,15 @@ func TestSnapshot_Exhausted(t *testing.T) {
 func TestParseAnthropicUnifiedHeaders_ResetAt(t *testing.T) {
 	t.Run("RFC3339 reset", func(t *testing.T) {
 		h := http.Header{}
-		h.Set("anthropic-ratelimit-unified-weekly-utilization", "100")
-		h.Set("anthropic-ratelimit-unified-weekly-reset", "2026-06-28T03:00:00Z")
+		h.Set("anthropic-ratelimit-unified-7d-utilization", "1.0")
+		h.Set("anthropic-ratelimit-unified-7d-reset", "2026-06-28T03:00:00Z")
 		snap, ok := usage.ParseAnthropicUnifiedHeaders(h)
 		require.True(t, ok)
 		assert.Equal(t, "2026-06-28T03:00:00Z", snap.Secondary.ResetAt.Format(time.RFC3339))
 	})
 	t.Run("unix-seconds reset fallback", func(t *testing.T) {
 		h := http.Header{}
-		h.Set("anthropic-ratelimit-unified-5h-utilization", "90")
+		h.Set("anthropic-ratelimit-unified-5h-utilization", "0.90")
 		h.Set("anthropic-ratelimit-unified-5h-reset", "1782702000")
 		snap, ok := usage.ParseAnthropicUnifiedHeaders(h)
 		require.True(t, ok)
@@ -292,7 +324,7 @@ func TestParseAnthropicUnifiedHeaders_ResetAt(t *testing.T) {
 	})
 	t.Run("absent reset leaves zero", func(t *testing.T) {
 		h := http.Header{}
-		h.Set("anthropic-ratelimit-unified-weekly-utilization", "50")
+		h.Set("anthropic-ratelimit-unified-7d-utilization", "0.50")
 		snap, ok := usage.ParseAnthropicUnifiedHeaders(h)
 		require.True(t, ok)
 		assert.True(t, snap.Secondary.ResetAt.IsZero())

--- a/internal/proxy/usage/usage_test.go
+++ b/internal/proxy/usage/usage_test.go
@@ -75,9 +75,7 @@ func TestParseAnthropicUnified_FromRemainingLimit(t *testing.T) {
 	assert.InDelta(t, 0.10, snap.Secondary.UsedPercent, 1e-9)
 }
 
-// Utilization values are 0-1 fractions on the wire (prod: "0.7370692663445869"),
-// NOT 0-100 percents like Codex used-percent. Dividing by 100 here shrank every
-// reading ~100x and silently disabled subsidy fade + exhaustion detection.
+// Utilization headers are 0-1 fractions on the wire, not 0-100 percents.
 func TestParseAnthropicUnified_PrefersUtilization(t *testing.T) {
 	h := http.Header{}
 	h.Set("anthropic-ratelimit-unified-5h-utilization", "0.63")


### PR DESCRIPTION
## What

Two bugs in `ParseAnthropicUnifiedHeaders` (`internal/proxy/usage`), both proven by the Phase 0 `unified_limit_headers` capture (#777) — 53k prod rows over 10 days:

1. **Window spelling** — prod emits `anthropic-ratelimit-unified-7d-*`; the parser read `-weekly-*` (**zero** occurrences in the capture). The weekly window was never parsed. Now parses `7d`, keeping `weekly` as a legacy fallback.
2. **Utilization scale** — values are **0–1 fractions** on the wire (e.g. `0.7370692663445869`), not 0–100 percents like Codex `used-percent`. `parsePercent` divided them by 100, shrinking every reading ~100x.

## Impact of the bugs (before this fix)

- A fully-bound window read as ~1% used → the subsidy `CostFactor` never faded toward full price, and `Exhausted()` never fired off utilization headers → exhaustion failover onto the Weave key didn't engage from these readings.
- The weekly window was invisible entirely (spelling), so even correct scaling would have covered only the 5h window.
- The `remaining/limit` derivation path was unaffected (computes its own fraction), which is why exhaustion behavior still worked where upstreams sent limit/remaining pairs — e.g. the existing usage-bypass 429 tests, which keep passing on the fallback spelling.

## Evidence (prod capture, 53,796 rows)

- Header names: `…-7d-status/-utilization/-reset` on 51,347 rows; **no** `-weekly-*` keys
- Utilization values: high-precision fractions, range 0–1.99 (values >1.0 occur while a window is served on overage credits — `overage-in-use: true`)
- Cross-check: rows with `unified-status: rejected` + `representative-claim: five_hour` average **1.034** 5h-utilization; `allowed` rows average 0.346 — consistent with a 0–1 fraction bound at ~1.0, impossible under a 0–100 read

## Changes

- `ParseAnthropicUnifiedHeaders`: secondary window reads `7d` first, `weekly` as fallback
- New `parseFraction` (clamped [0,1]) for unified utilization; `parsePercent` stays for Codex `used-percent` (genuinely 0–100)
- Tests updated to prod-observed fixture values; new cases for the >1.0 overage clamp and the 7d-over-weekly preference

## Testing

`go build ./...", `go vet ./...` clean; full `go test ./...` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)