### PR TITLE
fix(hmm): preserve tool-execution routing after low-class migration

### DIFF
--- a/internal/router/hmm/hmm.go
+++ b/internal/router/hmm/hmm.go
@@ -61,7 +61,12 @@ func reasonFor(res Result) string {
 
 func isToolExecutionResult(res Result) bool {
 	group := strings.TrimSpace(strings.ToLower(res.PolicyGroup))
-	if group == "explore" {
+	// "explore" is the retired five-class label (roster_v2, still the pinned
+	// prod package); "low" is its four-class successor (roster_v4) that the
+	// retired explore cluster was merged into. Both carry the same
+	// tool-execution semantics, so both must be recognized during the
+	// migration window where either package can be deployed.
+	if group == "explore" || group == "low" {
 		return true
 	}
 	label := strings.TrimSpace(strings.ToLower(res.PolicyLabel))

--- a/internal/router/hmm/hmm_test.go
+++ b/internal/router/hmm/hmm_test.go
@@ -237,3 +237,27 @@ func TestRosterIDForSkipsAmbiguousBareProviderIDs(t *testing.T) {
 
 	assert.Empty(t, got)
 }
+
+func TestIsToolExecutionResultRecognizesBothTaxonomies(t *testing.T) {
+	// "explore" is the retired five-class label (roster_v2, still the pinned
+	// prod package); "low" is its four-class successor (roster_v4) that the
+	// retired explore cluster was merged into. Both must route as tool
+	// execution during the migration window where either package can be
+	// deployed.
+	assert.True(t, isToolExecutionResult(Result{PolicyGroup: "explore"}))
+	assert.True(t, isToolExecutionResult(Result{PolicyGroup: "low"}))
+	assert.True(t, isToolExecutionResult(Result{PolicyGroup: "EXPLORE"}))
+	assert.True(t, isToolExecutionResult(Result{PolicyGroup: " Low "}))
+	assert.True(t, isToolExecutionResult(Result{PolicyLabel: "spawn_explore"}))
+	assert.True(t, isToolExecutionResult(Result{PolicyLabel: "prefix_tool_call_suffix"}))
+	assert.False(t, isToolExecutionResult(Result{PolicyGroup: "fast"}))
+	assert.False(t, isToolExecutionResult(Result{PolicyGroup: "balanced"}))
+	assert.False(t, isToolExecutionResult(Result{PolicyGroup: "medium"}))
+	assert.False(t, isToolExecutionResult(Result{}))
+}
+
+func TestReasonForTagsToolExecutionPrefixForBothTaxonomies(t *testing.T) {
+	assert.Equal(t, "hmm_policy:tool_execution(label=explore)", reasonFor(Result{PolicyGroup: "explore", PolicyLabel: "explore"}))
+	assert.Equal(t, "hmm_policy:tool_execution(label=low)", reasonFor(Result{PolicyGroup: "low", PolicyLabel: "low"}))
+	assert.Equal(t, "hmm_policy(label=balanced)", reasonFor(Result{PolicyGroup: "balanced", PolicyLabel: "balanced"}))
+}


### PR DESCRIPTION
## Summary

Unblocks the HMM 5→4 class migration by making the Go router adapter recognize both taxonomy values for the tool-execution phase:

- legacy 5-class package: `explore`
- current 4-class package: `low`

The router turn-loop keys off `hmm_policy:tool_execution` in the decision reason. Before this change, a future `low` package would silently lose that phase boundary because `isToolExecutionResult` only matched `explore`.

## Validation

- `go test ./internal/router/hmm`

🤖 Generated with [Claude Code](https://claude.com/claude-code)