### PR TITLE
fix(install): correct npx invocation so npm<=6 can't resolve the wrong package

### DIFF
--- a/install/README.md
+++ b/install/README.md
@@ -22,13 +22,12 @@ npx @workweave/router --codex    --scope project   # Codex
 npx @workweave/router --opencode --scope project   # opencode
 ```
 
-Prefer `curl`? The same installer is also served as a shell script:
+On npm ≤ 6 the bundled `npx` mis-parses a leading `-y` (it consumes the next
+token, dropping the package name), so name the binary explicitly there — or
+just upgrade with `npm i -g npm@latest`:
 
 ```bash
-curl -fsSL https://weave.ai/cc/install.sh | sh
-curl -fsSL https://weave.ai/cc/install.sh | sh -s -- --codex
-curl -fsSL https://weave.ai/cc/install.sh | sh -s -- --opencode
-curl -fsSL https://weave.ai/cc/install.sh | sh -s -- --scope project
+npx --package @workweave/router -y -- weave-router --claude
 ```
 
 Or from a clone of this repo:

--- a/install/install.sh
+++ b/install/install.sh
@@ -127,7 +127,10 @@ skip() { printf "%s⊙%s %s%s%s\n" "$C_DIM" "$C_RESET" "$C_DIM" "$*" "$C_RESET";
 # print after a successful install is copy-paste-correct. Kept in sync with
 # uninstall.sh's flag surface.
 uninstall_cmd() {
-  local cmd="npx -y @workweave/router --uninstall"
+  # --package + `--` is load-bearing: npm <= 6's bundled npx treats an
+  # undeclared `-y` as consuming the NEXT token, so `npx -y @workweave/router`
+  # loses the package name and resolves whatever follows as the command.
+  local cmd="npx --package @workweave/router -y -- weave-router --uninstall"
   case "$target" in
     codex)    cmd="$cmd --codex" ;;
     opencode) cmd="$cmd --opencode" ;;

--- a/install/npm/README.md
+++ b/install/npm/README.md
@@ -84,6 +84,18 @@ for the full reference.
 
 ## Why npx
 
-`curl -fsSL https://weave.ai/cc/install.sh | sh` still works and is fine.
-`npx @workweave/router` adds: Windows support via Git Bash, painless version
-pinning, no `curl | sh` aversion, and discoverability via the npm registry.
+`npx @workweave/router` gives Windows support via Git Bash, painless version
+pinning, and discoverability via the npm registry.
+
+## Older npm
+
+On npm ≤ 6 the bundled `npx` treats an undeclared `-y` as consuming the next
+token, so `npx -y @workweave/router --claude` silently drops the package name
+and resolves the following argument as the command instead. Either upgrade
+(`npm i -g npm@latest`) or name the binary explicitly:
+
+```bash
+npx --package @workweave/router -y -- weave-router --claude
+```
+
+That form is correct on every npm version.

--- a/install/npm/package.json
+++ b/install/npm/package.json
@@ -3,7 +3,8 @@
   "version": "0.2.5",
   "description": "One-command installer that points Claude Code, Codex, opencode, or pi at the Weave Router. For pi it also ships the routing extension, loaded via pi.extensions.",
   "bin": {
-    "weave-router": "bin.js"
+    "weave-router": "bin.js",
+    "router": "bin.js"
   },
   "pi": {
     "extensions": [

--- a/install/pi-router/README.md
+++ b/install/pi-router/README.md
@@ -9,8 +9,8 @@ LLM proxy that picks the most cost-efficient model that still solves each task.
 Installed automatically by the Weave Router installer:
 
 ```bash
-WEAVE_ROUTER_KEY=rk_… npx -y @workweave/router --pi          # user scope
-WEAVE_ROUTER_KEY=rk_… npx -y @workweave/router --pi --local  # local router (http://localhost:8080)
+WEAVE_ROUTER_KEY=rk_… npx --package @workweave/router -y -- weave-router --pi
+WEAVE_ROUTER_KEY=rk_… npx --package @workweave/router -y -- weave-router --pi --local  # local router
 ```
 
 That writes `~/.pi/agent/models.json` (the `weave` provider), adds


### PR DESCRIPTION
## Problem

npm ≤ 6 bundles a legacy `npx` whose arg parser treats any flag it does not declare as consuming the **next token**. `-y` is undeclared, so our published command:

```bash
npx -y @workweave/router --claude --scope user
```

parses as `command="user"`, `package=["user@latest"]` — it installs and runs an unrelated package from the public registry. Both `user@0.0.0` and `project@0.1.6` exist, so `--scope user` and `--scope project` each resolve to a real third-party package.

Without a `--scope` argument there is nothing positional left and legacy npx aborts with `ERROR: You must supply a command`, which is how users hit this.

Reproduced against `libnpx@10.2.4`:

| invocation | `command` | `package` |
|---|---|---|
| `npx -y @workweave/router --claude --scope user` | `"user"` | `["user@latest"]` |
| `npx @workweave/router --claude` | `"router"` | `["@workweave/router@latest"]` |
| `npx --package @workweave/router -y -- weave-router --claude` | `"weave-router"` | `["@workweave/router@latest"]` |

## Two independent breakages

1. **Argument order.** Published invocations now name the package with `--package` and the binary after `--`. Verified correct on `libnpx@10.2.4` (parse) and `npm 10.9.2` (end-to-end).
2. **Bin resolution.** Legacy npx guesses the binary from the package's *unscoped* name (`router`), but the only declared bin was `weave-router` — so even a correctly-parsed short form failed to resolve. `router` is now an alias for the same entrypoint, which makes the plain `npx @workweave/router` form work on old npm too.

## Also

Removes the `curl … | sh` block from the installer README. It pointed at a domain this project does not control (it redirects off-site and 404s), no such endpoint is served anywhere in our infra, and `install.sh` is bash with 123 bashisms so `| sh` would fail on dash regardless.

## Validation

- `bash -n install/install.sh`, `bash -n install/uninstall.sh` — clean
- `package.json` parses; both bins declared
- Emitted uninstall hint re-parsed under legacy npx → `command="weave-router"`, `package=["@workweave/router@latest"]`
- Swept the repo for remaining `-y @workweave` forms; `install/pi-router/README.md` had two more, also fixed

## Note for reviewers

Adding a `router` bin means a global install puts `router` on PATH, which could collide with an unrelated tool of that name. That is the standard fix for npx's bin-guessing and the collision risk seemed clearly worth closing a wrong-package-execution path, but say the word if you'd rather rely on the explicit `--package … -- weave-router` form alone.