### PR TITLE
fix(auth): stop reporting infra failures as an invalid key

### DIFF
--- a/cmd/router/main.go
+++ b/cmd/router/main.go
@@ -92,12 +92,13 @@ func main() {
 	}
 	defer pool.Close()
 
-	// pgxpool connects lazily, so without this the first serving request pays to
-	// build the pool's first connection inside its own (short) budget. Warn-only:
-	// a DB that is briefly unreachable at boot must not stop the process from
-	// coming up, since every handler already degrades on its own.
-	if err := pool.Ping(context.Background()); err != nil {
-		logger.Warn("Postgres ping at boot failed; early requests may be slow", "err", err)
+	// pgxpool connects lazily; first request otherwise pays to build the pool inside
+	// its own budget. Bounded and warn-only so an unreachable DB can't stall boot.
+	pingCtx, pingCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	pingErr := pool.Ping(pingCtx)
+	pingCancel()
+	if pingErr != nil {
+		logger.Warn("Postgres ping at boot failed; early requests may be slow", "err", pingErr)
 	}
 
 	// Gates the self-hoster dashboard + /admin/v1/* API. Defaults to selfhosted

--- a/cmd/router/main.go
+++ b/cmd/router/main.go
@@ -92,6 +92,14 @@ func main() {
 	}
 	defer pool.Close()
 
+	// pgxpool connects lazily, so without this the first serving request pays to
+	// build the pool's first connection inside its own (short) budget. Warn-only:
+	// a DB that is briefly unreachable at boot must not stop the process from
+	// coming up, since every handler already degrades on its own.
+	if err := pool.Ping(context.Background()); err != nil {
+		logger.Warn("Postgres ping at boot failed; early requests may be slow", "err", err)
+	}
+
 	// Gates the self-hoster dashboard + /admin/v1/* API. Defaults to selfhosted
 	// so docker-compose/bare-binary deploys work out of the box; managed Cloud
 	// Run services set ROUTER_DEPLOYMENT_MODE=managed to drop that surface.

--- a/internal/server/middleware/auth.go
+++ b/internal/server/middleware/auth.go
@@ -230,8 +230,14 @@ func handleAuthError(c *gin.Context, err error) {
 	case errors.Is(err, auth.ErrInvalidToken):
 		logger.Debug("Auth rejected: bearer token did not match an active key")
 	default:
-		// Infra failure (DB unreachable, etc.). Still 401 to the caller; logged as Error for on-call.
+		// Infra failure (DB unreachable, pool exhausted, deadline elapsed). Must not
+		// be a 401: an opaque invalid_key makes a transient outage indistinguishable
+		// from a wrong key, so clients stop retrying and users are told to re-check a
+		// credential that was never the problem.
 		logger.Error("Auth check errored", "err", err)
+		c.Header("Retry-After", "1")
+		c.AbortWithStatusJSON(http.StatusServiceUnavailable, gin.H{"error": "auth_unavailable"})
+		return
 	}
 	c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "invalid_key"})
 }

--- a/internal/server/middleware/auth.go
+++ b/internal/server/middleware/auth.go
@@ -230,10 +230,7 @@ func handleAuthError(c *gin.Context, err error) {
 	case errors.Is(err, auth.ErrInvalidToken):
 		logger.Debug("Auth rejected: bearer token did not match an active key")
 	default:
-		// Infra failure (DB unreachable, pool exhausted, deadline elapsed). Must not
-		// be a 401: an opaque invalid_key makes a transient outage indistinguishable
-		// from a wrong key, so clients stop retrying and users are told to re-check a
-		// credential that was never the problem.
+		// Infra failure — not a bad key. 503 so clients retry instead of treating it as terminal.
 		logger.Error("Auth check errored", "err", err)
 		c.Header("Retry-After", "1")
 		c.AbortWithStatusJSON(http.StatusServiceUnavailable, gin.H{"error": "auth_unavailable"})

--- a/internal/server/middleware/auth_test.go
+++ b/internal/server/middleware/auth_test.go
@@ -46,8 +46,11 @@ func (f *fakeExternalAPIKeyRepository) MarkUsed(context.Context, string) error {
 
 type fakeAPIKeyRepository struct {
 	byHash map[string]fakeKeyRow
-	mu     sync.Mutex
-	used   []string
+	// lookupErr stands in for an infra failure (pool exhausted, DB unreachable,
+	// deadline elapsed) as opposed to a key that simply isn't there.
+	lookupErr error
+	mu        sync.Mutex
+	used      []string
 }
 
 type fakeKeyRow struct {
@@ -60,6 +63,9 @@ func (f *fakeAPIKeyRepository) Create(ctx context.Context, params auth.CreateAPI
 }
 
 func (f *fakeAPIKeyRepository) GetActiveByHashWithInstallation(ctx context.Context, keyHash string) (*auth.APIKey, *auth.Installation, error) {
+	if f.lookupErr != nil {
+		return nil, nil, f.lookupErr
+	}
 	row, ok := f.byHash[keyHash]
 	if !ok {
 		return nil, nil, sql.ErrNoRows
@@ -243,4 +249,66 @@ func TestWithAuthKeepsLegacyBearerFallback(t *testing.T) {
 	engine.ServeHTTP(rr, req)
 
 	require.Equal(t, http.StatusOK, rr.Code)
+}
+
+func TestWithAuthInfraFailureIsRetryable503NotInvalidKey(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	const routerToken = "rk_valid_but_db_is_down"
+	hash, _, _ := auth.APITokenFingerprint(routerToken)
+	repo := &fakeAPIKeyRepository{
+		byHash:    map[string]fakeKeyRow{hash: {apiKey: &auth.APIKey{ID: "key-1"}, installation: &auth.Installation{ID: "inst-1"}}},
+		lookupErr: context.DeadlineExceeded,
+	}
+	svc := auth.NewService(fakeInstallationRepository{}, repo, nil, nil, auth.NoOpAPIKeyCache{}, nil, func() time.Time { return time.Now() })
+
+	engine := gin.New()
+	engine.Use(middleware.WithAuth(svc, false))
+	engine.GET("/probe", func(c *gin.Context) { c.Status(http.StatusOK) })
+
+	req := httptest.NewRequest(http.MethodGet, "/probe", nil)
+	req.Header.Set(middleware.RouterKeyHeader, routerToken)
+	rr := httptest.NewRecorder()
+	engine.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusServiceUnavailable, rr.Code,
+		"an infra failure reported as 401 makes a transient outage indistinguishable from a wrong key")
+	assert.Equal(t, "1", rr.Header().Get("Retry-After"))
+	assert.NotContains(t, rr.Body.String(), "invalid_key")
+}
+
+func TestWithAuthUnknownKeyStays401(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	repo := &fakeAPIKeyRepository{byHash: map[string]fakeKeyRow{}}
+	svc := auth.NewService(fakeInstallationRepository{}, repo, nil, nil, auth.NoOpAPIKeyCache{}, nil, func() time.Time { return time.Now() })
+
+	engine := gin.New()
+	engine.Use(middleware.WithAuth(svc, false))
+	engine.GET("/probe", func(c *gin.Context) { c.Status(http.StatusOK) })
+
+	req := httptest.NewRequest(http.MethodGet, "/probe", nil)
+	req.Header.Set(middleware.RouterKeyHeader, "rk_no_such_key")
+	rr := httptest.NewRecorder()
+	engine.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusUnauthorized, rr.Code)
+	assert.Contains(t, rr.Body.String(), "invalid_key")
+	assert.Empty(t, rr.Header().Get("Retry-After"))
+}
+
+func TestWithAuthMalformedPrefixStays401(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	repo := &fakeAPIKeyRepository{byHash: map[string]fakeKeyRow{}}
+	svc := auth.NewService(fakeInstallationRepository{}, repo, nil, nil, auth.NoOpAPIKeyCache{}, nil, func() time.Time { return time.Now() })
+
+	engine := gin.New()
+	engine.Use(middleware.WithAuth(svc, false))
+	engine.GET("/probe", func(c *gin.Context) { c.Status(http.StatusOK) })
+
+	req := httptest.NewRequest(http.MethodGet, "/probe", nil)
+	req.Header.Set("Authorization", "Bearer sk-ant-oat-not-a-router-key")
+	rr := httptest.NewRecorder()
+	engine.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusUnauthorized, rr.Code)
+	assert.Contains(t, rr.Body.String(), "invalid_key")
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -27,7 +27,10 @@ import (
 const (
 	healthTimeout    = 1 * time.Second
 	readinessTimeout = 2 * time.Second
-	validateTimeout  = 1 * time.Second
+	// A cache miss on the client-facing key probe costs three sequential
+	// Postgres round trips, so a 1s budget turned an ordinary cold cache into a
+	// rejected-credential verdict for the caller.
+	validateTimeout = 5 * time.Second
 
 	messagesTimeout       = 600 * time.Second
 	chatCompletionTimeout = 600 * time.Second

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -27,9 +27,7 @@ import (
 const (
 	healthTimeout    = 1 * time.Second
 	readinessTimeout = 2 * time.Second
-	// A cache miss on the client-facing key probe costs three sequential
-	// Postgres round trips, so a 1s budget turned an ordinary cold cache into a
-	// rejected-credential verdict for the caller.
+	// Cold-cache key probe costs 3 sequential Postgres round trips; 1s made that a credential rejection.
 	validateTimeout = 5 * time.Second
 
 	messagesTimeout       = 600 * time.Second


### PR DESCRIPTION
## Problem

`handleAuthError` collapsed every non-identity error into `401 invalid_key`:

```go
default:
    // Infra failure (DB unreachable, etc.). Still 401 to the caller; logged as Error for on-call.
    logger.Error("Auth check errored", "err", err)
}
c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "invalid_key"})
```

So a pool timeout, an unreachable DB, or an elapsed deadline was indistinguishable from a wrong bearer token. Two consequences:

- Clients treat 401 as terminal and stop retrying, so a transient blip becomes a hard failure.
- Users get told to re-check a credential that was never the problem. Our own installer does exactly this — its `/validate` probe reports "Router rejected the API key" on *any* non-zero curl exit.

`VerifyAPIKey` already separates the cases correctly (`sql.ErrNoRows` → `ErrInvalidToken`; anything else propagates raw), so only the HTTP mapping was wrong.

## Changes

1. **`middleware/auth.go`** — infra errors return `503 auth_unavailable` + `Retry-After: 1`. `ErrInvalidPrefix` / `ErrInvalidToken` keep their opaque 401.
2. **`server.go`** — `validateTimeout` 1s → 5s (matching `routeTimeout`). A cache miss on `/validate` costs three sequential Postgres round trips, so 1s turned an ordinary cold cache into a rejected-credential verdict.
3. **`cmd/router/main.go`** — `pool.Ping` at boot. pgxpool connects lazily, so the first serving request otherwise pays to build the pool's first connection inside its own budget; that made a first run right after install the most likely time to hit this. Warn-only so a DB blip at boot doesn't block startup.

## Tests

Three new cases in `auth_test.go`, via a `lookupErr` injection hook on the existing fake repo:

- `TestWithAuthInfraFailureIsRetryable503NotInvalidKey` — asserts 503 + `Retry-After`, and that the body does *not* say `invalid_key`. Fails on `main` (returns 401).
- `TestWithAuthUnknownKeyStays401` — guards against over-correcting; a genuinely unknown key must stay 401 with no `Retry-After`.
- `TestWithAuthMalformedPrefixStays401` — same for a non-`rk_` bearer.

## Validation

- `go vet ./...` clean, `go build ./...` clean, `gofmt` clean
- `wv mr t` — 46 packages, no failures