### PR TITLE
fix(routing): gate images nested in tool_result, and on forced pins

### DIFF
--- a/internal/proxy/force_model_image_guard_internal_test.go
+++ b/internal/proxy/force_model_image_guard_internal_test.go
@@ -1,0 +1,120 @@
+package proxy
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"workweave/router/internal/providers"
+	"workweave/router/internal/router"
+	"workweave/router/internal/router/catalog"
+	"workweave/router/internal/router/sessionpin"
+	"workweave/router/internal/translate"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// An agent returning a screenshot nests the image inside a tool_result rather
+// than putting it at the top level of the message content.
+const toolResultImageBody = `{"model":"claude-sonnet-4-6","messages":[
+	{"role":"assistant","content":[{"type":"tool_use","id":"toolu_1","name":"Read","input":{"file_path":"/tmp/shot.png"}}]},
+	{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_1","content":[
+		{"type":"image","source":{"type":"base64","media_type":"image/png","data":"AAA"}}]}]}]}`
+
+const textOnlyForcedModel = "qwen/qwen3-coder-next"
+
+// Regression: a user-forced pin skipped every automatic capability gate, so an
+// image-bearing turn dispatched to a text-only model and the upstream rejected
+// the request outright ("... is not a multimodal model").
+func TestRunTurnLoop_ForcedTextOnlyModel_DropsPinForImageTurn(t *testing.T) {
+	require.False(t, catalog.AcceptsImages(textOnlyForcedModel), "test premise: forced model is text-only")
+	require.True(t, catalog.AcceptsImages("claude-sonnet-4-6"), "test premise: replacement accepts images")
+
+	fr := &tierProbeRouter{available: map[string]struct{}{
+		textOnlyForcedModel: {},
+		"claude-sonnet-4-6": {},
+	}}
+	store := &forcedPinStore{pin: sessionpin.Pin{
+		Provider:    providers.ProviderFireworks,
+		Model:       textOnlyForcedModel,
+		Reason:      translate.ReasonUserForceModel,
+		PinnedUntil: time.Now().Add(time.Hour),
+	}}
+	svc := NewService(fr, nil, nil, false, nil, store, false,
+		providers.ProviderAnthropic, "claude-haiku-4-5", nil).
+		WithAvailableModels(fr.available).
+		WithPlannerEnabled(false)
+
+	env, err := translate.ParseAnthropic([]byte(toolResultImageBody))
+	require.NoError(t, err)
+	feats := env.RoutingFeatures(false)
+	require.True(t, feats.HasImages, "the nested tool_result image must register as an image-bearing turn")
+
+	res, err := svc.runTurnLoop(context.Background(), env, feats, "key-1", uuid.New(), "", nil, router.Request{
+		RequestedModel: feats.Model,
+		HasImages:      feats.HasImages,
+	})
+	require.NoError(t, err)
+
+	assert.NotEqual(t, textOnlyForcedModel, res.Decision.Model,
+		"a text-only forced pin must not serve an image-bearing turn")
+	assert.True(t, catalog.AcceptsImages(res.Decision.Model),
+		"the replacement must accept images")
+	assert.False(t, res.StickyHit, "the pin was dropped, so this is not a sticky hit")
+
+	require.Len(t, fr.captured, 1, "exactly one scorer call after the pin is dropped")
+	_, textOnlyExcluded := fr.captured[0].ExcludedModels[textOnlyForcedModel]
+	assert.True(t, textOnlyExcluded,
+		"the dropped text-only model must be excluded from the scorer pool, not left available to re-pick")
+}
+
+// Control: the same forced pin must still be honored when the turn carries no
+// image, so the guard can't be mistaken for "forced pins stopped working".
+func TestRunTurnLoop_ForcedTextOnlyModel_HonoredWithoutImages(t *testing.T) {
+	fr := &tierProbeRouter{available: map[string]struct{}{
+		textOnlyForcedModel: {},
+		"claude-sonnet-4-6": {},
+	}}
+	store := &forcedPinStore{pin: sessionpin.Pin{
+		Provider:    providers.ProviderFireworks,
+		Model:       textOnlyForcedModel,
+		Reason:      translate.ReasonUserForceModel,
+		PinnedUntil: time.Now().Add(time.Hour),
+	}}
+	svc := NewService(fr, nil, nil, false, nil, store, false,
+		providers.ProviderAnthropic, "claude-haiku-4-5", nil).
+		WithAvailableModels(fr.available).
+		WithPlannerEnabled(false)
+
+	env, err := translate.ParseAnthropic([]byte(`{"model":"claude-sonnet-4-6","messages":[{"role":"user","content":"plain text turn"}]}`))
+	require.NoError(t, err)
+	feats := env.RoutingFeatures(false)
+	require.False(t, feats.HasImages)
+
+	res, err := svc.runTurnLoop(context.Background(), env, feats, "key-1", uuid.New(), "", nil, router.Request{
+		RequestedModel: feats.Model,
+		HasImages:      feats.HasImages,
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, textOnlyForcedModel, res.Decision.Model, "a text-only forced pin still serves text-only turns")
+	assert.True(t, res.StickyHit)
+	assert.Empty(t, fr.captured, "an honored forced pin must not invoke the scorer")
+}
+
+// forcedPinEligible is the gate for the hard-pinned-turn fast path, which is a
+// separate branch from the one above and needs the same guard.
+func TestForcedPinEligible_RejectsTextOnlyModelOnImageTurn(t *testing.T) {
+	pin := sessionpin.Pin{Provider: providers.ProviderFireworks, Model: textOnlyForcedModel}
+
+	assert.False(t, forcedPinEligible(pin, router.Request{HasImages: true}),
+		"text-only forced pin must be ineligible for an image-bearing turn")
+	assert.True(t, forcedPinEligible(pin, router.Request{HasImages: false}),
+		"same pin stays eligible without images")
+	assert.True(t, forcedPinEligible(
+		sessionpin.Pin{Provider: providers.ProviderAnthropic, Model: "claude-sonnet-4-6"},
+		router.Request{HasImages: true}),
+		"an image-capable forced pin stays eligible on an image turn")
+}

--- a/internal/proxy/turnloop.go
+++ b/internal/proxy/turnloop.go
@@ -197,11 +197,36 @@ func isUserForcedReason(reason string) bool {
 	return strings.HasPrefix(reason, translate.ReasonUserForceModel)
 }
 
+// pinServesImages reports whether a pinned model can carry an image-bearing
+// turn. Forced pins outrank every automatic gate, so without this check the
+// pasted-screenshot turn dispatches to a text-only model and the upstream
+// rejects the whole request.
+func pinServesImages(pin sessionpin.Pin, req router.Request) bool {
+	return !req.HasImages || catalog.AcceptsImages(pin.Model)
+}
+
+// excludingModel returns excluded plus model, copying instead of mutating the
+// caller's map.
+func excludingModel(excluded map[string]struct{}, model string) map[string]struct{} {
+	if _, ok := excluded[model]; ok {
+		return excluded
+	}
+	out := make(map[string]struct{}, len(excluded)+1)
+	for k := range excluded {
+		out[k] = struct{}{}
+	}
+	out[model] = struct{}{}
+	return out
+}
+
 func forcedPinEligible(pin sessionpin.Pin, req router.Request) bool {
 	if pin.Model == "" || pin.Provider == "" {
 		return false
 	}
 	if _, excluded := req.ExcludedModels[pin.Model]; excluded {
+		return false
+	}
+	if !pinServesImages(pin, req) {
 		return false
 	}
 	if req.EnabledProviders == nil {
@@ -425,7 +450,8 @@ func (s *Service) runTurnLoop(
 	// Still enforced per-request: (1) exclusion policy — a newly-excluded forced
 	// model falls through to normal routing; (2) provider eligibility — a BYOK
 	// request missing the pinned provider's creds falls through rather than
-	// guaranteeing a 401.
+	// guaranteeing a 401; (3) image capability — a text-only forced model falls
+	// through rather than guaranteeing an upstream 400 on a screenshot turn.
 	//
 	// forcedTierFloor preserves the user's tier intent when the forced pin gets
 	// dropped below (usually the session outgrew the model's context window):
@@ -436,7 +462,8 @@ func (s *Service) runTurnLoop(
 		_, excluded := req.ExcludedModels[pin.Model]
 		_, providerEnabled := req.EnabledProviders[pin.Provider]
 		providerEligible := req.EnabledProviders == nil || providerEnabled
-		if !excluded && providerEligible {
+		imageCapable := pinServesImages(pin, req)
+		if !excluded && providerEligible && imageCapable {
 			decision := pinDecision(pin)
 			decision.Reason = pin.Reason
 			res.PinTier = pin.Reason
@@ -445,10 +472,16 @@ func (s *Service) runTurnLoop(
 			s.refreshPin(ctx, installationID, res.SessionKey, pin, res.PinRole, pinDecision(pin))
 			return res, nil
 		}
-		if excluded {
+		if excluded || !imageCapable {
 			// User still asked for this tier; constrain the fresh decision
 			// to it below rather than losing the intent entirely.
 			forcedTierFloor = catalog.TierFor(pin.Model)
+		}
+		if !imageCapable {
+			// The scorer's own image filter fails open when no image-capable
+			// candidate survives, so make the drop explicit here instead of
+			// letting the same text-only model be re-picked.
+			req.ExcludedModels = excludingModel(req.ExcludedModels, pin.Model)
 		}
 		// Treat as missing so downstream sticky branches don't dispatch to an
 		// unauthorized provider. The row stays in storage — a later request

--- a/internal/translate/features.go
+++ b/internal/translate/features.go
@@ -517,7 +517,10 @@ func appendText(b *strings.Builder, s string) {
 }
 
 // anthropicHasImages reports whether any content block is
-// {"type":"image",...}. String content never has an image.
+// {"type":"image",...}, including images nested in a tool_result — the shape an
+// agent produces when a tool hands back a screenshot, and the dominant one in
+// practice. Kept in sync with anthropicImageBytes, which walks the same two
+// positions. String content never has an image.
 func anthropicHasImages(body []byte) bool {
 	found := false
 	gjson.GetBytes(body, "messages").ForEach(func(_, msg gjson.Result) bool {
@@ -526,11 +529,18 @@ func anthropicHasImages(body []byte) bool {
 			return true
 		}
 		content.ForEach(func(_, block gjson.Result) bool {
-			if block.Get("type").String() == "image" {
+			switch block.Get("type").String() {
+			case "image":
 				found = true
-				return false
+			case "tool_result":
+				block.Get("content").ForEach(func(_, inner gjson.Result) bool {
+					if inner.Get("type").String() == "image" {
+						found = true
+					}
+					return !found
+				})
 			}
-			return true
+			return !found
 		})
 		return !found
 	})

--- a/internal/translate/features_images_test.go
+++ b/internal/translate/features_images_test.go
@@ -67,6 +67,25 @@ func TestHasImages_Anthropic(t *testing.T) {
 			body: `{"model":"Weave","messages":[{"role":"user","content":"hello"}]}`,
 			want: false,
 		},
+		{
+			// An agent handing back a screenshot nests the image inside the
+			// tool_result rather than at the top level. Every image capability
+			// gate keys off this one signal, so missing this shape lets the turn
+			// dispatch to a text-only model.
+			name: "image nested in tool_result",
+			body: `{"model":"Weave","messages":[{"role":"assistant","content":[{"type":"tool_use","id":"toolu_1","name":"Read","input":{}}]},{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_1","content":[{"type":"image","source":{"type":"base64","media_type":"image/png","data":"AAA"}}]}]}]}`,
+			want: true,
+		},
+		{
+			name: "tool_result with text only",
+			body: `{"model":"Weave","messages":[{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_1","content":[{"type":"text","text":"file contents"}]}]}]}`,
+			want: false,
+		},
+		{
+			name: "tool_result with string content",
+			body: `{"model":"Weave","messages":[{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_1","content":"ok"}]}]}`,
+			want: false,
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
## Problem

An upstream was rejecting entire requests with `<model> is not a multimodal model` — an image had reached a text-only model and the client got the raw provider error as a fatal failure.

The image capability filter does exist and does run on the live policy path (`policy/resolver.go` `softFilter` → `catalog.ImageUnsupportedSet()`), and text-only models are correctly flagged in the catalog. Two independent holes let the turn through anyway.

### 1. `HasImages` was blind to `tool_result`-nested images

`anthropicHasImages` walked only top-level `messages[].content[]`, while its sibling `anthropicImageBytes` already descended into `tool_result.content[]`. An agent handing back a screenshot (a `Read` of a PNG, an MCP screenshot tool) produces exactly the nested shape:

```json
{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_1",
  "content":[{"type":"image","source":{"type":"base64",...}}]}]}
```

Every image gate keys off this single signal — the policy resolver's `softFilter`, the pin-drop guards in `turnloop.go`, the band-swap check — so missing this shape blinded all of them simultaneously. Worse, on a cross-format target the nested image is dropped in translation rather than forwarded, so the model silently answers a question about a screenshot it never received.

### 2. User-forced pins had no image guard

Forced pins outrank every automatic gate. `forcedPinEligible` checked model, provider and exclusions but not image capability, and the immutable forced-pin branch checked only `excluded` + `providerEligible`. Every *automatic* pin path already guards this — the forced path was the sole omission.

## Changes

- `translate/features.go` — `anthropicHasImages` descends into `tool_result.content[]`, matching `anthropicImageBytes`. Comment on both notes they walk the same two positions.
- `proxy/turnloop.go` — new `pinServesImages` helper, applied in `forcedPinEligible` (the hard-pinned-turn fast path) and in the immutable forced-pin branch. A dropped pin falls through to normal routing and keeps the user's tier intent via the existing `forcedTierFloor`, so a forced high-tier model isn't silently replaced by a cheap vision model.
- The dropped model is added to the request's exclusion set. `softFilter` **fails open** when no image-capable candidate survives, so relying on it to re-filter the same model would reintroduce the bug; making the drop explicit keeps the decision local.

## Tests

`translate` — three new `TestHasImages_Anthropic` cases: nested `tool_result` image (**fails on main**), plus `tool_result` with text-only content and with string content to pin down the negative cases.

`proxy/force_model_image_guard_internal_test.go`:
- `TestRunTurnLoop_ForcedTextOnlyModel_DropsPinForImageTurn` — end-to-end through `runTurnLoop` with a real nested-`tool_result` body, so it exercises both halves of the fix. Asserts the pin is dropped, the replacement accepts images, and the text-only model is excluded from the scorer pool.
- `TestRunTurnLoop_ForcedTextOnlyModel_HonoredWithoutImages` — control, so this can't be mistaken for "forced pins stopped working".
- `TestForcedPinEligible_RejectsTextOnlyModelOnImageTurn` — covers the separate hard-pinned-turn branch.

## Deliberately not in this PR

`toolResultContentGJSON` (`translate/crossformat.go`) keeps text parts only, so a nested image is dropped when targeting an OpenAI-compatible upstream. With this PR such a turn no longer routes to a *text-only* model, but a vision-capable OpenAI-compat target still won't receive the image. Fixing that means hoisting the image into a following user message — a translation-semantics change that deserves its own PR rather than riding along with a capability-gating fix.

## Validation

`go vet ./...` clean, `gofmt` clean, `go test ./...` — 46 packages, no failures.