### PR TITLE
fix(translate): carry real token counts past the routing marker

### DIFF
--- a/internal/translate/anthropic_marker.go
+++ b/internal/translate/anthropic_marker.go
@@ -23,7 +23,17 @@ type AnthropicRoutingMarkerWriter struct {
 
 	markerEmitted bool
 
+	// upstreamUsage holds the input-side token counts lifted off the upstream's
+	// dropped message_start, pending merge into message_delta.
+	upstreamUsage []usageField
+
 	onOutputProgress func()
+}
+
+// usageField is one key/raw-JSON pair from an upstream usage object.
+type usageField struct {
+	key string
+	raw string
 }
 
 // NewAnthropicRoutingMarkerWriter injects marker as a text block at index 0.
@@ -128,9 +138,18 @@ func (w *AnthropicRoutingMarkerWriter) processUpstream(data []byte) (int, error)
 
 		switch string(eventType) {
 		case "message_start":
-			// Drop upstream's message_start; we already sent one.
+			// Drop upstream's message_start; we already sent one. Ours was
+			// emitted before the upstream replied, so it could not carry real
+			// token counts — stash them and fold them into message_delta below.
+			w.captureUpstreamUsage(eventData)
 			w.buf.Next(n)
 			continue
+
+		case "message_delta":
+			if _, err := w.Inner.Write(w.mergeUpstreamUsage(event[:n], eventData)); err != nil {
+				return 0, err
+			}
+			w.buf.Next(n)
 
 		case "content_block_start", "content_block_delta", "content_block_stop":
 			// Mark on output-bearing content_block_delta only; start/stop are structural.
@@ -159,7 +178,7 @@ func (w *AnthropicRoutingMarkerWriter) processUpstream(data []byte) (int, error)
 			w.buf.Next(n)
 
 		default:
-			// message_delta, message_stop, ping, error, etc. — pass through untouched.
+			// message_stop, ping, error, etc. — pass through untouched.
 			if _, err := w.Inner.Write(event[:n]); err != nil {
 				return 0, err
 			}
@@ -167,6 +186,56 @@ func (w *AnthropicRoutingMarkerWriter) processUpstream(data []byte) (int, error)
 		}
 	}
 	return len(data), nil
+}
+
+// captureUpstreamUsage records the input-side token counts from the upstream's
+// message_start. Only input-side fields are kept: output_tokens on
+// message_start is a placeholder that message_delta supersedes.
+func (w *AnthropicRoutingMarkerWriter) captureUpstreamUsage(eventData []byte) {
+	usage := gjson.GetBytes(eventData, "message.usage")
+	if !usage.Exists() {
+		return
+	}
+	w.upstreamUsage = w.upstreamUsage[:0]
+	usage.ForEach(func(key, value gjson.Result) bool {
+		if key.String() == "output_tokens" {
+			return true
+		}
+		w.upstreamUsage = append(w.upstreamUsage, usageField{key: key.String(), raw: value.Raw})
+		return true
+	})
+}
+
+// mergeUpstreamUsage folds the stashed message_start counts into a
+// message_delta's usage object, so the assembled message a client ends up with
+// reports real input and cache tokens instead of the zeros our early
+// message_start had to guess. Fields the upstream already set on the delta win.
+// Returns event unchanged when there is nothing to merge or the rewrite fails —
+// a mangled usage object would be worse than an incomplete one.
+func (w *AnthropicRoutingMarkerWriter) mergeUpstreamUsage(event, eventData []byte) []byte {
+	if len(w.upstreamUsage) == 0 {
+		return event
+	}
+	merged := eventData
+	for _, f := range w.upstreamUsage {
+		if gjson.GetBytes(merged, "usage."+f.key).Exists() {
+			continue
+		}
+		out, err := sjson.SetRawBytes(merged, "usage."+f.key, []byte(f.raw))
+		if err != nil {
+			return event
+		}
+		merged = out
+	}
+	if bytes.Equal(merged, eventData) {
+		return event
+	}
+	var b bytes.Buffer
+	b.Grow(len(merged) + 32)
+	b.WriteString("event: message_delta\ndata: ")
+	b.Write(merged)
+	b.WriteString("\n\n")
+	return b.Bytes()
 }
 
 // ArmOutputProgress fires mark on output-bearing content_block_delta frames only

--- a/internal/translate/anthropic_marker_test.go
+++ b/internal/translate/anthropic_marker_test.go
@@ -429,3 +429,85 @@ func TestAnthropicRoutingMarkerWriter_EventSplitAcrossWrites(t *testing.T) {
 	}
 	assert.True(t, foundShiftedDelta, "split event must be reassembled with shifted index and preserved text")
 }
+
+// The prelude message_start is emitted before the upstream replies, so it
+// cannot carry real token counts. Dropping the upstream's message_start without
+// carrying its usage forward left the client with input_tokens:0 on every
+// routed turn, which is what /cost, /context and auto-compact read.
+func TestAnthropicRoutingMarkerWriter_CarriesUpstreamUsageIntoMessageDelta(t *testing.T) {
+	rec := httptest.NewRecorder()
+	w := translate.NewAnthropicRoutingMarkerWriter(rec, "claude-opus-5", "✦ marker\n\n")
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.WriteHeader(http.StatusOK)
+
+	upstream := buildAnthropicSSE("message_start", `{"type":"message_start","message":{"id":"msg_1","type":"message","role":"assistant","content":[],"model":"claude-opus-5","stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":1234,"output_tokens":0,"cache_read_input_tokens":98765,"cache_creation_input_tokens":432}}}`) +
+		buildAnthropicSSE("message_delta", `{"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"output_tokens":77}}`) +
+		buildAnthropicSSE("message_stop", `{"type":"message_stop"}`)
+
+	_, err := w.Write([]byte(upstream))
+	require.NoError(t, err)
+
+	var delta string
+	for _, ev := range splitSSEEvents(rec.Body.String()) {
+		if strings.Contains(ev, "event: message_delta") {
+			delta = ev
+		}
+	}
+	require.NotEmpty(t, delta, "message_delta must still reach the client")
+
+	data := delta[strings.Index(delta, "data: ")+len("data: "):]
+	usage := gjson.Get(data, "usage")
+	assert.Equal(t, int64(1234), usage.Get("input_tokens").Int(),
+		"real input tokens must survive the dropped upstream message_start")
+	assert.Equal(t, int64(98765), usage.Get("cache_read_input_tokens").Int(),
+		"cache reads are the signal that prompt caching is working; losing them hides cache misses")
+	assert.Equal(t, int64(432), usage.Get("cache_creation_input_tokens").Int())
+	assert.Equal(t, int64(77), usage.Get("output_tokens").Int(),
+		"the delta's own output_tokens must win over the message_start placeholder")
+	assert.Equal(t, "end_turn", gjson.Get(data, "delta.stop_reason").String(),
+		"merging usage must not disturb the rest of the event")
+}
+
+// A delta that already carries its own input-side counts must not be rewritten.
+func TestAnthropicRoutingMarkerWriter_DeltaUsageWinsOverMessageStart(t *testing.T) {
+	rec := httptest.NewRecorder()
+	w := translate.NewAnthropicRoutingMarkerWriter(rec, "claude-opus-5", "✦ marker\n\n")
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.WriteHeader(http.StatusOK)
+
+	upstream := buildAnthropicSSE("message_start", `{"type":"message_start","message":{"usage":{"input_tokens":10,"output_tokens":0}}}`) +
+		buildAnthropicSSE("message_delta", `{"type":"message_delta","delta":{},"usage":{"input_tokens":999,"output_tokens":5}}`)
+
+	_, err := w.Write([]byte(upstream))
+	require.NoError(t, err)
+
+	var delta string
+	for _, ev := range splitSSEEvents(rec.Body.String()) {
+		if strings.Contains(ev, "event: message_delta") {
+			delta = ev
+		}
+	}
+	require.NotEmpty(t, delta)
+	data := delta[strings.Index(delta, "data: ")+len("data: "):]
+	assert.Equal(t, int64(999), gjson.Get(data, "usage.input_tokens").Int(),
+		"upstream's own delta usage is authoritative")
+}
+
+// No usage on message_start (or no message_start at all) must leave the delta
+// byte-identical rather than synthesizing counts.
+func TestAnthropicRoutingMarkerWriter_NoUpstreamUsageLeavesDeltaUntouched(t *testing.T) {
+	rec := httptest.NewRecorder()
+	w := translate.NewAnthropicRoutingMarkerWriter(rec, "claude-opus-5", "✦ marker\n\n")
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.WriteHeader(http.StatusOK)
+
+	const deltaEvent = `{"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":3}}`
+	upstream := buildAnthropicSSE("message_start", `{"type":"message_start","message":{"id":"msg_1"}}`) +
+		buildAnthropicSSE("message_delta", deltaEvent)
+
+	_, err := w.Write([]byte(upstream))
+	require.NoError(t, err)
+
+	assert.Contains(t, rec.Body.String(), deltaEvent, "delta must pass through verbatim")
+	assert.False(t, gjson.Get(deltaEvent, "usage.input_tokens").Exists())
+}


### PR DESCRIPTION
## Problem

`AnthropicRoutingMarkerWriter` emits its own `message_start` during the prelude — before the upstream has replied — so its usage object is necessarily a placeholder:

```go
w.BW.WriteString(",\"stop_reason\":null,\"stop_sequence\":null,\"usage\":{\"input_tokens\":0,\"output_tokens\":0}}}\n\n")
```

It then dropped the upstream's `message_start` on the grounds that one had already been sent. But `message_start` is the **only** Anthropic SSE event carrying `input_tokens`, `cache_read_input_tokens` and `cache_creation_input_tokens`. So those counts were discarded on every streamed turn that gets a marker — which is effectively every routed turn, since the marker is suppressed only for a sticky hit with no reason code and no model change.

**This is client-visible only.** The router's own telemetry reads usage via `UsageExtractor`, which sits outside this writer and was always correct. But the client assembles its final message from the stream, so:

- `/cost` and `/context` report zero input tokens
- cache read/creation counts never surface, so a broken cache looks identical to a working one
- anything that drives off context size has nothing to act on, so a session can consume its budget with no warning

## Fix

Stash the input-side counts off the dropped `message_start` and fold them into `message_delta`. That is exactly what `AnthropicSSETranslator` already does on the cross-format paths (`stream.go:1562-1578` emits `input_tokens` / `cache_*` in `message_delta.usage`), so accumulating clients already expect them there.

Deliberate details:

- **`output_tokens` is never copied.** It is a placeholder on `message_start`; `message_delta` supersedes it.
- **Upstream's own delta values win.** If the delta already sets a field, it is left alone.
- **Verbatim passthrough on nothing-to-merge or rewrite failure.** A mangled usage object is worse than an incomplete one.
- No arithmetic on `input_tokens`. On the Anthropic→Anthropic path upstream's value is already fresh-only, unlike the cross-format path which has to subtract cache from an OpenAI-style total.

## Tests

Three new cases, plus all 11 pre-existing marker tests still pass:

- `TestAnthropicRoutingMarkerWriter_CarriesUpstreamUsageIntoMessageDelta` — real input + both cache fields survive; the delta's own `output_tokens` wins; `stop_reason` undisturbed. **Fails on main** (input_tokens absent → 0).
- `TestAnthropicRoutingMarkerWriter_DeltaUsageWinsOverMessageStart` — no clobbering when upstream sets its own.
- `TestAnthropicRoutingMarkerWriter_NoUpstreamUsageLeavesDeltaUntouched` — no synthesized counts; delta passes through verbatim.

## Scope

The OpenAI and Gemini marker writers prepend a chunk rather than fabricating a `message_start`, so neither has this bug. Anthropic-specific.

## Validation

`go vet ./...` clean, `gofmt` clean, `go test ./...` — 46 packages, no failures.