### PR TITLE
fix(proxy): rescue a turn the routed model provably cannot serve

### DIFF
--- a/internal/providers/provider.go
+++ b/internal/providers/provider.go
@@ -337,12 +337,9 @@ func IsUpstreamModelNotFound(err error) bool {
 	return false
 }
 
-// capabilityRejectionPhrases are upstream 400 bodies meaning "this model cannot
-// serve a request of this shape" rather than "your request is malformed".
-// Providers state it in prose with no machine-readable code, so substring
-// matching is the only available signal. Keep the list narrow and specific: a
-// false positive spends one extra upstream call, and a phrase loose enough to
-// match ordinary validation errors would do that on every bad request.
+// capabilityRejectionPhrases are prose 400 bodies meaning the model cannot
+// serve this request shape. Substring-matching is the only signal; keep phrases
+// narrow — a loose match fires on ordinary validation errors.
 var capabilityRejectionPhrases = []string{
 	"not a multimodal model",
 	"does not support image",
@@ -353,10 +350,8 @@ var capabilityRejectionPhrases = []string{
 }
 
 // IsUpstreamCapabilityRejection reports whether err is a buffered upstream 400
-// stating the model cannot handle a modality the request carries. Unlike
-// IsUpstreamModelNotFound this is deliberately NOT a cross-binding signal — the
-// same model on another provider rejects identically — so it gates only the
-// higher-level fallback onto a different model.
+// stating the model cannot handle a modality the request carries. Deliberately
+// not a cross-binding signal — the same model rejects identically elsewhere.
 func IsUpstreamCapabilityRejection(err error) bool {
 	var buffered *UpstreamErrorResponse
 	if !errors.As(err, &buffered) || buffered.Status != http.StatusBadRequest {

--- a/internal/providers/provider.go
+++ b/internal/providers/provider.go
@@ -337,6 +337,40 @@ func IsUpstreamModelNotFound(err error) bool {
 	return false
 }
 
+// capabilityRejectionPhrases are upstream 400 bodies meaning "this model cannot
+// serve a request of this shape" rather than "your request is malformed".
+// Providers state it in prose with no machine-readable code, so substring
+// matching is the only available signal. Keep the list narrow and specific: a
+// false positive spends one extra upstream call, and a phrase loose enough to
+// match ordinary validation errors would do that on every bad request.
+var capabilityRejectionPhrases = []string{
+	"not a multimodal model",
+	"does not support image",
+	"image input is not supported",
+	"image input is unsupported",
+	"does not support vision",
+	"multimodal input is not supported",
+}
+
+// IsUpstreamCapabilityRejection reports whether err is a buffered upstream 400
+// stating the model cannot handle a modality the request carries. Unlike
+// IsUpstreamModelNotFound this is deliberately NOT a cross-binding signal — the
+// same model on another provider rejects identically — so it gates only the
+// higher-level fallback onto a different model.
+func IsUpstreamCapabilityRejection(err error) bool {
+	var buffered *UpstreamErrorResponse
+	if !errors.As(err, &buffered) || buffered.Status != http.StatusBadRequest {
+		return false
+	}
+	body := strings.ToLower(string(buffered.Body))
+	for _, phrase := range capabilityRejectionPhrases {
+		if strings.Contains(body, phrase) {
+			return true
+		}
+	}
+	return false
+}
+
 // PreparedRequest holds the encoded target-format request body and format-specific header overrides.
 // Endpoint selects which upstream path a provider client POSTs to. Zero value
 // is chat/completions; EndpointResponses routes to `/v1/responses`, required

--- a/internal/providers/provider_retry_test.go
+++ b/internal/providers/provider_retry_test.go
@@ -66,3 +66,68 @@ func TestIsRetryable_RequestDeadlineExceeded(t *testing.T) {
 	require.ErrorIs(t, err, context.DeadlineExceeded)
 	assert.False(t, providers.IsRetryable(err))
 }
+
+// A capability rejection must be recognised from the upstream's prose, and must
+// NOT be classified as retryable — re-sending the same model to a different
+// provider gets the same rejection, so the only useful response is a different
+// model.
+func TestIsUpstreamCapabilityRejection(t *testing.T) {
+	cases := []struct {
+		name   string
+		status int
+		body   string
+		want   bool
+	}{
+		{
+			name:   "together multimodal rejection",
+			status: http.StatusBadRequest,
+			body:   `{"error":{"message":"deepseek-ai/DeepSeek-V4-Pro is not a multimodal model"}}`,
+			want:   true,
+		},
+		{
+			name:   "does not support images",
+			status: http.StatusBadRequest,
+			body:   `{"error":{"message":"This model does not support image inputs."}}`,
+			want:   true,
+		},
+		{
+			name:   "case insensitive",
+			status: http.StatusBadRequest,
+			body:   `{"error":{"message":"Model Does Not Support Vision"}}`,
+			want:   true,
+		},
+		{
+			name:   "ordinary validation 400 is not a capability rejection",
+			status: http.StatusBadRequest,
+			body:   `{"error":{"message":"messages: at least one message is required"}}`,
+			want:   false,
+		},
+		{
+			name:   "same phrasing on a 500 is an outage, not a capability verdict",
+			status: http.StatusInternalServerError,
+			body:   `{"error":{"message":"not a multimodal model"}}`,
+			want:   false,
+		},
+		{
+			name:   "404 stays model-not-found",
+			status: http.StatusNotFound,
+			body:   `{"error":{"message":"model not found"}}`,
+			want:   false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := &providers.UpstreamErrorResponse{Status: tc.status, Body: []byte(tc.body)}
+			assert.Equal(t, tc.want, providers.IsUpstreamCapabilityRejection(err))
+			if tc.want {
+				assert.False(t, providers.IsRetryable(err),
+					"a capability rejection must not trigger same-model retries")
+				assert.False(t, providers.IsUpstreamModelNotFound(err),
+					"a capability rejection must not be confused with model-not-found")
+			}
+		})
+	}
+
+	assert.False(t, providers.IsUpstreamCapabilityRejection(nil))
+	assert.False(t, providers.IsUpstreamCapabilityRejection(fmt.Errorf("transport blew up")))
+}

--- a/internal/providers/provider_retry_test.go
+++ b/internal/providers/provider_retry_test.go
@@ -67,10 +67,8 @@ func TestIsRetryable_RequestDeadlineExceeded(t *testing.T) {
 	assert.False(t, providers.IsRetryable(err))
 }
 
-// A capability rejection must be recognised from the upstream's prose, and must
-// NOT be classified as retryable — re-sending the same model to a different
-// provider gets the same rejection, so the only useful response is a different
-// model.
+// TestIsUpstreamCapabilityRejection checks phrase matching and asserts that
+// capability rejections are neither retryable nor model-not-found.
 func TestIsUpstreamCapabilityRejection(t *testing.T) {
 	cases := []struct {
 		name   string

--- a/internal/proxy/baseline_failover_integration_test.go
+++ b/internal/proxy/baseline_failover_integration_test.go
@@ -372,3 +372,98 @@ func TestProxyMessages_FailedBaselineReportsAnthropicProvider(t *testing.T) {
 	assert.Equal(t, "claude-opus-4-8", row.DecisionModel, "telemetry records the baseline model after failover")
 	assert.Equal(t, providers.ProviderAnthropic, row.DecisionProvider, "failed-baseline provider must match the baseline model, not the OSS primary")
 }
+
+// A capability rejection is categorically different from an outage: the upstream
+// has stated the routed model cannot serve this request shape at all, so there
+// is nothing to retry and the client would otherwise get the raw provider 400.
+// The authoritative-per-turn contract covers which model the policy PICKS, not
+// whether a provably-unservable request may be rescued.
+func TestProxyMessages_AuthoritativePolicyFailsOverOnCapabilityRejection(t *testing.T) {
+	var (
+		mu                     sync.Mutex
+		fireworksCount         int
+		openRouterCount        int
+		anthropicCount         int
+		anthropicReceivedModel string
+	)
+	rejectCapability := func(counter *int) http.HandlerFunc {
+		return func(w http.ResponseWriter, _ *http.Request) {
+			mu.Lock()
+			*counter++
+			mu.Unlock()
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write([]byte(`{"error":{"message":"deepseek-ai/DeepSeek-V4-Pro is not a multimodal model"}}`))
+		}
+	}
+	fireworks := httptest.NewServer(rejectCapability(&fireworksCount))
+	defer fireworks.Close()
+	openrouter := httptest.NewServer(rejectCapability(&openRouterCount))
+	defer openrouter.Close()
+	anthropicUpstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		mu.Lock()
+		anthropicCount++
+		anthropicReceivedModel = gjson.GetBytes(body, "model").String()
+		mu.Unlock()
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(anthropicMessageSSE))
+		if f, ok := w.(http.Flusher); ok {
+			f.Flush()
+		}
+	}))
+	defer anthropicUpstream.Close()
+
+	strategy := router.Strategy("authoritative-capability-test")
+	policyRouter := &fakeRouter{decision: router.Decision{
+		Provider: providers.ProviderFireworks,
+		Model:    "deepseek/deepseek-v4-pro",
+		Reason:   "authoritative-capability_policy",
+		Metadata: &router.RoutingMetadata{
+			RouteID:                       "route-capability",
+			Strategy:                      string(strategy),
+			AuthoritativePerTurnSelection: true,
+		},
+	}}
+	svc := proxy.NewService(
+		nil,
+		map[string]providers.Client{
+			providers.ProviderFireworks:  openaicompat.NewClient("test-fw-key", fireworks.URL),
+			providers.ProviderOpenRouter: openaicompat.NewClient("test-or-key", openrouter.URL),
+			providers.ProviderAnthropic:  anthropic.NewClient("test-anthropic-key", anthropicUpstream.URL),
+		},
+		nil, false, nil, newFakePinStore(), false,
+		providers.ProviderAnthropic, "claude-haiku-4-5", newCaptureTelemetry(),
+	).WithDeploymentKeyedProviders(map[string]struct{}{
+		providers.ProviderFireworks:  {},
+		providers.ProviderOpenRouter: {},
+		providers.ProviderAnthropic:  {},
+	}).WithPolicyStrategy(policy.StrategySpec{
+		Strategy: strategy,
+		Router:   policyRouter,
+		Capabilities: policy.Capabilities{
+			SchemaVersion:                 policy.SchemaVersionV1,
+			AuthoritativePerTurnSelection: true,
+		},
+	})
+	ctx := router.WithStrategy(authedCtx("11111111-1111-1111-1111-111111111111"), strategy)
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(""))
+	body := []byte(`{"model":"claude-opus-4-8","stream":true,"messages":[{"role":"user","content":[{"type":"image","source":{"type":"base64","media_type":"image/png","data":"AAA"}}]}]}`)
+
+	err := svc.ProxyMessages(ctx, body, rec, req)
+	require.NoError(t, err, "the turn must be rescued on the requested Anthropic model")
+
+	mu.Lock()
+	defer mu.Unlock()
+	assert.Equal(t, 1, fireworksCount, "routed model tried once")
+	assert.Equal(t, 0, openRouterCount,
+		"a capability rejection is not provider-specific; a cross-binding hop would fail identically and must not be spent")
+	assert.Equal(t, 1, anthropicCount, "rescued on Anthropic despite authoritative-per-turn selection")
+	assert.Equal(t, "claude-opus-4-8", anthropicReceivedModel, "rescue targets the model the caller asked for")
+
+	respBody := rec.Body.String()
+	assert.Contains(t, respBody, "event: message_stop", "client sees a complete stream, not the provider's 400")
+	assert.NotContains(t, respBody, "is not a multimodal model", "the raw provider capability error must not reach the client")
+}

--- a/internal/proxy/baseline_failover_integration_test.go
+++ b/internal/proxy/baseline_failover_integration_test.go
@@ -373,11 +373,8 @@ func TestProxyMessages_FailedBaselineReportsAnthropicProvider(t *testing.T) {
 	assert.Equal(t, providers.ProviderAnthropic, row.DecisionProvider, "failed-baseline provider must match the baseline model, not the OSS primary")
 }
 
-// A capability rejection is categorically different from an outage: the upstream
-// has stated the routed model cannot serve this request shape at all, so there
-// is nothing to retry and the client would otherwise get the raw provider 400.
-// The authoritative-per-turn contract covers which model the policy PICKS, not
-// whether a provably-unservable request may be rescued.
+// TestProxyMessages_AuthoritativePolicyFailsOverOnCapabilityRejection verifies
+// that a capability rejection rescues via baseline even under authoritative-per-turn policy.
 func TestProxyMessages_AuthoritativePolicyFailsOverOnCapabilityRejection(t *testing.T) {
 	var (
 		mu                     sync.Mutex

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -2714,14 +2714,18 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 	baselineModel := s.baselineFor(feats.Model)
 	baselineCatalog, baselineKnown := catalog.ByID(baselineModel)
 	_, anthropicExcluded := s.excludedProvidersForRequest(ctx)[providers.ProviderAnthropic]
-	baselineEligible := !routeRes.AuthoritativePerTurn &&
-		!agentShadowMode &&
+	// baselineViable omits the authoritative-per-turn term: a policy that owns
+	// per-turn model choice still cannot be allowed to strand a request its
+	// chosen model provably cannot serve (see the capability-rejection rescue
+	// below). Everything else about the fallback has to hold either way.
+	baselineViable := !agentShadowMode &&
 		decision.Reason != translate.ReasonUserForceModel &&
 		s.shouldFailover(ctx) &&
 		!anthropicExcluded &&
 		decision.Provider != providers.ProviderAnthropic &&
 		baselineModel != decision.Model &&
 		baselineKnown && baselineCatalog.PrimaryProvider() == providers.ProviderAnthropic
+	baselineEligible := !routeRes.AuthoritativePerTurn && baselineViable
 
 	// Subscription-credit failover eligibility. A Claude turn served on the
 	// caller's subscription (sk-ant-oat) is pinned to a single Anthropic
@@ -2757,7 +2761,7 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 		bindings:               bindings,
 		attempt:                attempt,
 		flushErr:               flushUpstreamErrorAsAnthropic,
-		deferFlushOnExhaustion: baselineEligible || subscriptionRetryEligible,
+		deferFlushOnExhaustion: baselineViable || subscriptionRetryEligible,
 	})
 
 	// The routed model's bindings all failed with a fault another model could
@@ -2766,8 +2770,22 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 	// telemetry reflects the binding that actually served.
 	baselineFailoverUsed := false
 	baselineAttempted := false
-	if baselineEligible && proxyErr != nil && !preludeBuf.Committed() &&
-		(providers.IsRetryable(proxyErr) || providers.IsUpstreamModelNotFound(proxyErr)) {
+	// A capability rejection is not a routing-policy question: the upstream has
+	// stated the routed model cannot serve this request shape at all, so no
+	// number of retries on that model helps and the client would otherwise get
+	// the raw provider 400. Rescue it on the requested Anthropic model even when
+	// the policy owns per-turn selection.
+	capabilityRejected := providers.IsUpstreamCapabilityRejection(proxyErr)
+	if capabilityRejected {
+		log.Error("Upstream rejected the request as unsupported by the routed model",
+			"model", decision.Model,
+			"provider", primaryProvider,
+			"upstream_status", upstreamStatus(proxyErr),
+			"has_images", feats.HasImages)
+	}
+	if proxyErr != nil && !preludeBuf.Committed() &&
+		((baselineEligible && (providers.IsRetryable(proxyErr) || providers.IsUpstreamModelNotFound(proxyErr))) ||
+			(baselineViable && capabilityRejected)) {
 		baselineDecision := decision
 		baselineDecision.Model = baselineModel
 		baselineDecision.Provider = providers.ProviderAnthropic
@@ -2822,9 +2840,10 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 			// not report baseline_failover=true and skew bake-off analysis.
 			baselineFailoverUsed = proxyErr == nil
 		}
-	} else if baselineEligible && proxyErr != nil {
+	} else if baselineViable && proxyErr != nil {
 		// Baseline didn't run (mid-stream commit, or non-failoverable error);
-		// surface the deferred original error now.
+		// surface the deferred original error now. Guard must match
+		// deferFlushOnExhaustion above, or a deferred error is never flushed.
 		flushUpstreamErrorAsAnthropic(contentSink, proxyErr)
 	}
 

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -2714,10 +2714,8 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 	baselineModel := s.baselineFor(feats.Model)
 	baselineCatalog, baselineKnown := catalog.ByID(baselineModel)
 	_, anthropicExcluded := s.excludedProvidersForRequest(ctx)[providers.ProviderAnthropic]
-	// baselineViable omits the authoritative-per-turn term: a policy that owns
-	// per-turn model choice still cannot be allowed to strand a request its
-	// chosen model provably cannot serve (see the capability-rejection rescue
-	// below). Everything else about the fallback has to hold either way.
+	// baselineViable omits authoritative-per-turn: that contract governs which
+	// model the policy picks, not whether a provably-unservable request can be rescued.
 	baselineViable := !agentShadowMode &&
 		decision.Reason != translate.ReasonUserForceModel &&
 		s.shouldFailover(ctx) &&
@@ -2770,11 +2768,8 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 	// telemetry reflects the binding that actually served.
 	baselineFailoverUsed := false
 	baselineAttempted := false
-	// A capability rejection is not a routing-policy question: the upstream has
-	// stated the routed model cannot serve this request shape at all, so no
-	// number of retries on that model helps and the client would otherwise get
-	// the raw provider 400. Rescue it on the requested Anthropic model even when
-	// the policy owns per-turn selection.
+	// Capability rejection means the routed model cannot serve this shape at all —
+	// rescue via baseline even when the policy owns per-turn selection.
 	capabilityRejected := providers.IsUpstreamCapabilityRejection(proxyErr)
 	if capabilityRejected {
 		log.Error("Upstream rejected the request as unsupported by the routed model",


### PR DESCRIPTION
## Problem

An upstream 400 whose body says the model cannot accept a modality the request carries — e.g. `deepseek-ai/DeepSeek-V4-Pro is not a multimodal model` — was treated as an ordinary client error:

- `IsRetryableStatus` covers 408/429/5xx only, so not retryable (correct).
- `IsUpstreamModelNotFound` matches 404 only, so the one existing "semantic 4xx → try something else" hook didn't apply.
- Baseline failover's gate didn't include it.
- `ClassifyDispatchError` gave it `LogLevel: ""` — **not logged at all**, so this failure class was invisible in prod.

`flushUpstreamErrorAsAnthropic` then wrote the provider's own body through verbatim, so a user's session ended with a raw vendor string naming a model they never chose.

## Why baseline failover is the right remedy

It re-dispatches **the model the caller asked for** on Anthropic. When a cost-routed text-only model is handed an image, the caller's original Claude model is exactly the model that can serve it. No new fallback machinery needed.

## Changes

**1. `providers.IsUpstreamCapabilityRejection`** — classifies these bodies. Deliberately kept *out* of `IsRetryable` and `IsUpstreamModelNotFound`: the same model on another provider rejects identically, so a cross-binding hop is wasted work. Phrase matching is narrow on purpose — providers state this in prose with no machine-readable code, and a phrase loose enough to match ordinary validation errors would burn an extra upstream call on every malformed request.

**2. Baseline eligibility split** into `baselineViable` (everything about the fallback being *possible*) and `baselineEligible` (= viable **and** not authoritative-per-turn).

- Retryable / model-not-found faults keep the existing authoritative-per-turn restriction — unchanged behavior.
- A capability rejection intentionally does **not**. That contract governs which model the policy *picks*; it should not extend to stranding a request the chosen model provably cannot serve. Without the exception the client just gets the raw 400.

`deferFlushOnExhaustion` and its paired late flush both move to `baselineViable` **together**, preserving the invariant that a deferred error is flushed exactly once. In the previously-ineligible case this only moves the flush from `dispatchWithFallback` to `ProxyMessages` — the same path the eligible case has always used.

**3. Logging** — capability rejections log at error with model, provider, upstream status, and whether the request carried images.

## Tests

`TestProxyMessages_AuthoritativePolicyFailsOverOnCapabilityRejection` — full `ProxyMessages` integration under an authoritative-per-turn policy with an image-bearing body. Asserts the routed model is tried once, **OpenRouter is not tried at all** (no wasted cross-binding hop), Anthropic serves `claude-opus-4-8`, the client gets a complete stream, and the raw `is not a multimodal model` string never reaches the client.

`TestIsUpstreamCapabilityRejection` — table over real provider phrasings plus the cases that must *not* match: an ordinary validation 400, the same phrasing on a 500 (outage, not a capability verdict), and a 404. For every positive it also asserts `IsRetryable` and `IsUpstreamModelNotFound` stay false.

`TestProxyMessages_AuthoritativePolicyNeverChangesModelOnFailover` (pre-existing) still passes: it uses a 503, which remains gated on `baselineEligible`.

## Relationship to #842

#842 stops image-bearing turns being *routed* to text-only models in the first place. This PR is the backstop for when that filter can't help — `softFilter` fails open when no image-capable candidate survives, and no per-model gating exists yet for tool calling, structured outputs, PDF blocks or audio. Those degrade instead of hard-failing now.

## Validation

`go vet ./...` clean, `gofmt` clean, `go test ./...` — 46 packages, no failures.