### PR TITLE
fix(cluster): reject non-finite and zero-norm embeddings

### DIFF
--- a/internal/router/cluster/scorer.go
+++ b/internal/router/cluster/scorer.go
@@ -471,14 +471,18 @@ func (s *Scorer) Route(ctx context.Context, req router.Request) (router.Decision
 		)
 		return router.Decision{}, fmt.Errorf("embed failed after %dms: %w (cause: %v)", embedMs, ErrClusterUnavailable, err)
 	}
-	if len(vec) != s.centroids.Dim {
+	if reason, verr := validateEmbedding(vec, s.centroids.Dim); verr != nil {
 		log.Error(
-			"Cluster scorer: embedding dim mismatch; returning ErrClusterUnavailable",
+			"Cluster scorer: invalid embedding; returning ErrClusterUnavailable",
+			"reason", reason,
+			"err", verr,
+			"embedder_id", s.embed.ID(),
 			"got_dim", len(vec),
 			"want_dim", s.centroids.Dim,
 			"embed_ms", embedMs,
+			"requested_model", req.RequestedModel,
 		)
-		return router.Decision{}, fmt.Errorf("embedding dim %d != expected %d: %w", len(vec), s.centroids.Dim, ErrClusterUnavailable)
+		return router.Decision{}, fmt.Errorf("%v: %w", verr, ErrClusterUnavailable)
 	}
 
 	// Re-walk multi-binding rows under the per-request EnabledProviders set: a
@@ -900,6 +904,50 @@ func (s *Scorer) lookupCandidate(model string) *DeployedEntry {
 		}
 	}
 	return nil
+}
+
+// embeddingRejection categorizes why a post-embed vector was refused. It is
+// logged as a bare field so rejections can be counted by reason without
+// recording vector values or prompt content.
+type embeddingRejection string
+
+const (
+	rejectWrongDimension embeddingRejection = "wrong_dimension"
+	rejectNaN            embeddingRejection = "nan"
+	rejectPositiveInf    embeddingRejection = "positive_inf"
+	rejectNegativeInf    embeddingRejection = "negative_inf"
+	rejectZeroNorm       embeddingRejection = "zero_norm"
+)
+
+// validateEmbedding rejects vectors that carry no meaningful cosine ordering.
+// A successful Embed is not sufficient evidence of a usable vector: hugot's
+// WithNormalization floors the denominator at 1e-12, so an all-zero vector
+// stays zero and NaN/Inf stay non-finite. Both then reach topPNearest, where a
+// zero vector ties every centroid at similarity 0 (making artifact order an
+// unintended routing feature) and a non-finite vector breaks the comparator's
+// strict weak ordering. A tiny-but-nonzero vector is deliberately accepted —
+// it still orders centroids correctly up to scale.
+func validateEmbedding(vec []float32, wantDim int) (embeddingRejection, error) {
+	if len(vec) != wantDim {
+		return rejectWrongDimension, fmt.Errorf("embedding dim %d != expected %d", len(vec), wantDim)
+	}
+	var normSq float64
+	for i, v := range vec {
+		x := float64(v)
+		switch {
+		case math.IsNaN(x):
+			return rejectNaN, fmt.Errorf("embedding contains NaN at index %d", i)
+		case math.IsInf(x, 1):
+			return rejectPositiveInf, fmt.Errorf("embedding contains +Inf at index %d", i)
+		case math.IsInf(x, -1):
+			return rejectNegativeInf, fmt.Errorf("embedding contains -Inf at index %d", i)
+		}
+		normSq += x * x
+	}
+	if normSq == 0 {
+		return rejectZeroNorm, errors.New("embedding has zero norm")
+	}
+	return "", nil
 }
 
 // topPNearest returns indices of the p centroids closest to vec by

--- a/internal/router/cluster/scorer_test.go
+++ b/internal/router/cluster/scorer_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"log/slog"
+	"math"
 	"strings"
 	"sync"
 	"testing"
@@ -455,6 +456,83 @@ func TestScorer_ReturnsErrOnDimMismatch(t *testing.T) {
 	_, err := s.Route(context.Background(), router.Request{PromptText: strings.Repeat("x", 100)})
 	require.Error(t, err)
 	assert.True(t, errors.Is(err, ErrClusterUnavailable))
+}
+
+// vecWith returns an EmbedDim vector whose index i holds v, so a single
+// corrupted lane can be placed at the start, middle, or end of the buffer.
+func vecWith(i int, v float32) []float32 {
+	out := make([]float32, EmbedDim)
+	out[0] = 1
+	out[i] = v
+	return out
+}
+
+func TestScorer_RejectsNonFiniteAndZeroNormEmbeddings(t *testing.T) {
+	nan := float32(math.NaN())
+	posInf := float32(math.Inf(1))
+	negInf := float32(math.Inf(-1))
+
+	tests := []struct {
+		name    string
+		vec     []float32
+		wantErr string
+	}{
+		{"all zero", make([]float32, EmbedDim), "zero norm"},
+		{"NaN at first index", vecWith(0, nan), "NaN at index 0"},
+		{"NaN mid buffer", vecWith(EmbedDim/2, nan), "NaN at index 384"},
+		{"NaN at last index", vecWith(EmbedDim-1, nan), "NaN at index 767"},
+		{"positive Inf", vecWith(3, posInf), "+Inf at index 3"},
+		{"negative Inf", vecWith(3, negInf), "-Inf at index 3"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := newScorerForTest(t, &fakeEmbedder{vec: tt.vec}, cfgForTest())
+
+			got, err := s.Route(context.Background(), router.Request{PromptText: strings.Repeat("x", 100)})
+			require.Error(t, err)
+			assert.True(t, errors.Is(err, ErrClusterUnavailable),
+				"a numerically corrupt embedding must fail closed, not route")
+			assert.Contains(t, err.Error(), tt.wantErr)
+			assert.Empty(t, got.Model, "no model may be selected from an invalid embedding")
+		})
+	}
+}
+
+// A tiny-but-nonzero vector still orders centroids correctly up to scale, so
+// the exact zero-norm check must not reject it.
+func TestScorer_RoutesTinyNonZeroEmbedding(t *testing.T) {
+	s := newScorerForTest(t, &fakeEmbedder{vec: vecWith(0, 1e-20)}, cfgForTest())
+
+	got, err := s.Route(context.Background(), router.Request{PromptText: strings.Repeat("x", 100)})
+	require.NoError(t, err)
+	assert.Equal(t, "claude-opus-4-7", got.Model)
+}
+
+func TestValidateEmbedding_ReportsRejectionReason(t *testing.T) {
+	tests := []struct {
+		name string
+		vec  []float32
+		want embeddingRejection
+	}{
+		{"wrong dimension", make([]float32, 7), rejectWrongDimension},
+		{"all zero", make([]float32, EmbedDim), rejectZeroNorm},
+		{"NaN", vecWith(1, float32(math.NaN())), rejectNaN},
+		{"positive Inf", vecWith(1, float32(math.Inf(1))), rejectPositiveInf},
+		{"negative Inf", vecWith(1, float32(math.Inf(-1))), rejectNegativeInf},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			reason, err := validateEmbedding(tt.vec, EmbedDim)
+			require.Error(t, err)
+			assert.Equal(t, tt.want, reason)
+		})
+	}
+
+	reason, err := validateEmbedding(makeOpusVec(), EmbedDim)
+	require.NoError(t, err)
+	assert.Empty(t, reason, "a valid embedding carries no rejection reason")
 }
 
 func TestScorer_TailTruncatesBeforeEmbed(t *testing.T) {


### PR DESCRIPTION
Fixes #780.

## What changed

`Scorer.Route` verified only the embedding *dimension* after a successful `Embed`. A dimensionally valid **zero**, **NaN**, or **Inf** vector proceeded into `topPNearest` and produced a routing decision from similarities that are not numerically meaningful.

This adds `validateEmbedding`, called at the same point the dimension check used to happen. Non-finite and exact zero-norm vectors now return `ErrClusterUnavailable` (→ HTTP 503) instead of silently routing.

## Why the embedder can hand us these

hugot's `WithNormalization` does not convert them into errors — it floors the denominator at `1e-12`, so an all-zero vector stays zero and NaN/Inf stay non-finite. This is not only a test-double case.

Once accepted, a **zero** vector ties every centroid at similarity 0, so stable selection falls to the lowest-index centroid — artifact order becomes an unintended routing feature. A **non-finite** vector breaks the `topPNearest` comparator's strict weak ordering, so the selected centroids are not semantically valid.

## Design notes

**Validation lives in `Scorer.Route`, not the ONNX adapter.** `s.embed.Embed` is the package's only embed call site, making `Route` the trust boundary, and the `Scorer` can receive alternative embedders or wrappers.

**`topPNearest` is deliberately left unchanged.** `distribution.go` also calls it, but scores trusted centroid rows loaded from the bundle — not embedder output. Gating at the trust boundary covers every path that consumes an embedding; a second check there would be unreachable.

**Exact `normSq == 0`, no epsilon.** A tiny-but-nonzero vector still orders centroids correctly up to scale. There's a test asserting a `1e-20` vector continues to route.

**Rejection reasons are logged, not counted via a metrics dependency.** Each rejection carries a `reason` (`zero_norm`, `nan`, `positive_inf`, `negative_inf`, `wrong_dimension`) so it's countable from existing log pipelines. I avoided wiring a counter because `internal/router/cluster` and `internal/observability/otel` are both adapters, and adapters don't import each other. Happy to route this through a different seam if you'd prefer real metrics.

No vector values or prompt content are logged.

## Testing

`make check` passes (`generate fmt vet build test`, sqlc v1.30.0 to match CI); `git diff internal/sqlc/` is clean.

The tests are non-tautological — verified by reverting the call site to the old length-only check while keeping the helper compiled:

| vector | pre-fix | with fix |
|---|---|---|
| all-zero | routes, `nil` error | `ErrClusterUnavailable` |
| NaN (first / middle / last index) | routes, `nil` error | `ErrClusterUnavailable` |
| ±Inf | routes, `nil` error | `ErrClusterUnavailable` |
| tiny nonzero (`1e-20`) | routes | routes (unchanged) |

This reproduces the verification table in #780 independently.

Hot-path cost, since this now walks every lane on each request: **1106 ns/op, 0 allocs** at 768 dims — roughly 0.002% of a typical embed call.

## One thing to flag

The log message changes from `"Cluster scorer: embedding dim mismatch; ..."` to `"Cluster scorer: invalid embedding; ..."`, since it now covers more than dimension. If anything alerts on that exact string, it needs updating. The returned **error** string for the dimension case is byte-identical to before, and the existing `TestScorer_ReturnsErrOnDimMismatch` passes unmodified.