### PR TITLE
feat(install): set Claude Code attribution so commits/PRs credit Weave Router

### DIFF
--- a/install/README.md
+++ b/install/README.md
@@ -88,14 +88,14 @@ the target flag:
 
 | Path                                  | Purpose                                                       |
 | ------------------------------------- | ------------------------------------------------------------- |
-| `~/.claude/settings.json`             | Sets `env.ANTHROPIC_BASE_URL`, `env.ANTHROPIC_CUSTOM_HEADERS` with `X-Weave-Router-Key`, `env.ENABLE_TOOL_SEARCH=auto` (a custom base URL otherwise disables Claude Code's MCP tool-search deferral), and `statusLine`. Other keys preserved. |
+| `~/.claude/settings.json`             | Sets `env.ANTHROPIC_BASE_URL`, `env.ANTHROPIC_CUSTOM_HEADERS` with `X-Weave-Router-Key`, `env.ENABLE_TOOL_SEARCH=auto` (a custom base URL otherwise disables Claude Code's MCP tool-search deferral), `statusLine`, and Claude Code `attribution` so commits/PRs credit Weave Router. Other keys preserved. |
 | `~/.weave/cc-statusline.sh`           | The status line script. Reads the router's decisions log + the CC transcript to show routed-model + savings. |
 
 **Project scope (`--scope project`):**
 
 | Path                                | Committed? | Purpose                                                       |
 | ----------------------------------- | ---------- | ------------------------------------------------------------- |
-| `<repo>/.claude/settings.json`      | ✅ commit  | Sets `env.ANTHROPIC_BASE_URL`, `statusLine` (relative paths). **No token.** |
+| `<repo>/.claude/settings.json`      | ✅ commit  | Sets `env.ANTHROPIC_BASE_URL`, `statusLine` (relative paths), and Claude Code `attribution` so commits/PRs credit Weave Router. **No token.** |
 | `<repo>/.gitignore`                 | ✅ commit  | Adds the four `.claude/` paths below to the ignore list.       |
 | `<repo>/.claude/cc-statusline.sh`   | ❌ ignored | Status line script — runs on every CC session.                 |
 | `<repo>/.claude/settings.local.json`| ❌ ignored | Stores your local `ANTHROPIC_CUSTOM_HEADERS` router-key header and any other per-teammate overrides. |

--- a/install/install.sh
+++ b/install/install.sh
@@ -2480,12 +2480,20 @@ custom_headers="$custom_headers"$'\n'"X-App: claude-code"
 if [ "$scope" = "project" ] && [ -z "$install_dir" ]; then
   jq -n --arg url "$base_url" --arg sl "$statusline_path_for_settings" '{
     env: { ANTHROPIC_BASE_URL: $url, ENABLE_TOOL_SEARCH: "auto" },
-    statusLine: { type: "command", command: $sl }
+    statusLine: { type: "command", command: $sl },
+    attribution: {
+      commit: "Co-Authored-By: Weave Router <noreply@workweave.ai>",
+      pr: "🤖 Generated with [Weave Router](https://router.workweave.ai)"
+    }
   }' >"$tmp_patch"
 else
   jq -n --arg url "$base_url" --arg header "$custom_headers" --arg sl "$statusline_path_for_settings" '{
     env: { ANTHROPIC_BASE_URL: $url, ANTHROPIC_CUSTOM_HEADERS: $header, ENABLE_TOOL_SEARCH: "auto" },
-    statusLine: { type: "command", command: $sl }
+    statusLine: { type: "command", command: $sl },
+    attribution: {
+      commit: "Co-Authored-By: Weave Router <noreply@workweave.ai>",
+      pr: "🤖 Generated with [Weave Router](https://router.workweave.ai)"
+    }
   }' >"$tmp_patch"
 fi
 
@@ -2501,6 +2509,7 @@ if [ -f "$settings_file" ]; then
     | (if (.env | length) == 0 then del(.env) else . end)
     | del(.apiKeyHelper)
     | (if $b.statusLine then .statusLine = $b.statusLine else . end)
+    | (if $b.attribution then .attribution = $b.attribution else . end)
   ' "$settings_file" "$tmp_patch")"
   printf '%s\n' "$merged" >"$settings_file"
 else

--- a/install/uninstall.sh
+++ b/install/uninstall.sh
@@ -523,6 +523,9 @@ if [ -f "$settings_file" ]; then
          then del(.statusLine) else . end)
     | (if (.apiKeyHelper // "" | tostring | endswith("weave-key.sh"))
          then del(.apiKeyHelper) else . end)
+    | (if (.attribution.commit == "Co-Authored-By: Weave Router <noreply@workweave.ai>"
+              and .attribution.pr == "🤖 Generated with [Weave Router](https://router.workweave.ai)")
+         then del(.attribution) else . end)
   ' "$settings_file")"
   printf '%s\n' "$cleaned" >"$settings_file"
   ok "Cleaned $settings_file"


### PR DESCRIPTION
When Claude Code routes through the Weave Router, git commits show the selected model name ("Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>") — the user's selected model, not the router's. The router can't influence this by rewriting API response fields because Claude Code reads the model from client config, not from the server's response `model` field.

Claude Code v2.1.220+ has the `attribution` setting that overrides both the commit co-author trailer and pull request footer. This PR adds it to the installer so every router onboarding ships it automatically:

- `attribution.commit`: replaces the Claude model trailer with `Co-Authored-By: Weave Router <noreply@workweave.ai>`
- `attribution.pr`: replaces the "Generated with Claude Code" PR footer with a Weave Router link

Also updates `uninstall.sh` to clean the override on removal.

Codex and opencode have no equivalent setting.

## Verification

- `bash -n install/install.sh && bash -n install/uninstall.sh` clean
- Fresh user-scope install writes the expected `attribution` key
- Fresh project-scope install writes attribution to `.claude/settings.json` with the key only in `.claude/settings.local.json`
- Uninstall removes `attribution`, `env`, and `statusLine`
- Claude Code sees the correct commit trailer instruction with the generated setting

🤖 Generated with [Weave Router](https://router.workweave.ai)