### PR TITLE
chore(install): bump router npm package to 0.2.6

### DIFF
--- a/install/npm/package.json
+++ b/install/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@workweave/router",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "description": "One-command installer that points Claude Code, Codex, opencode, or pi at the Weave Router. For pi it also ships the routing extension, loaded via pi.extensions.",
   "bin": {
     "weave-router": "bin.js",


### PR DESCRIPTION
## Summary
- Bump @workweave/router from 0.2.5 to 0.2.6 so the latest installer changes can publish to npm.
- This picks up the already-merged opencode installer behavior that exposes only weave/auto.

## Validation
- npm pack from install/npm
- inspected packaged install.sh and confirmed write_opencode_config contains weave/auto and no stale multi-model opencode picker entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)