### PR TITLE
fix(statusline): refresh on a pricing-table miss instead of waiting out the interval

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -106,6 +106,19 @@ jobs:
       - name: Run tests
         run: go test -count=1 ./...
 
+  # Separate job: needs no Go toolchain, Postgres, or network. The statusline is
+  # shipped to users as a standalone script, so a regression there is invisible
+  # to `go test`.
+  test-statusline:
+    name: Test cc-statusline
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Run statusline tests
+        run: make test-statusline
+
   test-hmm-sidecar:
     name: Test frozen HMM sidecar
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@
 #   (and .env.local if present). Start Postgres via `make db` or point
 #   DATABASE_URL at any Postgres you already have running.
 
-.PHONY: generate generate-statusline build test test-verbose initdb migrate-up migrate-down migrate-create seed setup full-setup db dev check fmt vet precommit install-hooks help install-cc uninstall-cc up up-hmm down down-hmm logs
+.PHONY: generate generate-statusline build test test-verbose test-statusline initdb migrate-up migrate-down migrate-create seed setup full-setup db dev check fmt vet precommit install-hooks help install-cc uninstall-cc up up-hmm down down-hmm logs
 
 # Load DATABASE_URL from .env files (matches docker-compose defaults).
 -include .env.development
@@ -34,6 +34,9 @@ test: ## Run all tests
 
 test-verbose: ## Run all tests with verbose output
 	go test -v ./...
+
+test-statusline: ## Run the cc-statusline.sh regression tests (offline)
+	@bash install/tests/cc-statusline_test.sh
 
 initdb: ## Create the database and router schema (idempotent)
 	@go run ./cmd/initdb
@@ -173,7 +176,7 @@ fmt: ## Check gofmt (fails on unformatted files)
 vet: ## Run go vet
 	go vet ./...
 
-precommit: fmt vet build test ## Fast pre-commit check (no codegen, no DB)
+precommit: fmt vet build test test-statusline ## Fast pre-commit check (no codegen, no DB)
 
 install-hooks: ## Install git pre-commit hook
 	@HOOK_DIR=$$(git rev-parse --git-common-dir)/hooks; \
@@ -182,7 +185,7 @@ install-hooks: ## Install git pre-commit hook
 	chmod +x "$$HOOK_DIR/pre-commit"; \
 	echo "Pre-commit hook installed at $$HOOK_DIR/pre-commit"
 
-check: generate fmt vet build test ## Full CI-equivalent check
+check: generate fmt vet build test test-statusline ## Full CI-equivalent check
 	@if ! git diff --quiet internal/sqlc/; then \
 		echo "error: sqlc generation produced uncommitted changes"; \
 		git diff internal/sqlc/; \

--- a/install/cc-statusline.sh
+++ b/install/cc-statusline.sh
@@ -33,10 +33,18 @@ set -euo pipefail
 # lives in their per-user cache dir, and on no-content-change days we skip
 # the mv entirely so the repo working tree stays clean. When upstream does
 # change, the first teammate's commit propagates the new version to the rest.
+# A pricing-table miss also triggers a refresh off-schedule — see
+# weave_refresh_on_price_miss below.
 #
 # Opt out entirely with `export WEAVE_STATUSLINE_UPDATE=0`. Override the
 # source with `WEAVE_STATUSLINE_URL=...`, e.g. for self-hosters who fork.
+#
+# $1 is an optional stamp suffix, so a caller refreshing for a reason other than
+# "the interval elapsed" rate-limits on its own clock rather than sharing the
+# periodic check's budget.
 weave_self_refresh() {
+  local stamp_suffix="${1:-}"
+
   [ "${WEAVE_STATUSLINE_UPDATE:-1}" = "0" ] && return 0
   command -v curl >/dev/null 2>&1 || return 0
 
@@ -53,7 +61,7 @@ weave_self_refresh() {
   mkdir -p "$cache_dir" 2>/dev/null || return 0
   local script_slug
   script_slug="$(printf '%s' "$self" | tr -c 'A-Za-z0-9._-' '_')"
-  local stamp="$cache_dir/checked-at${script_slug}"
+  local stamp="$cache_dir/checked-at${script_slug}${stamp_suffix}"
 
   local now stamp_mtime
   now="$(date +%s 2>/dev/null)" || return 0
@@ -398,6 +406,42 @@ if [[ -n "$transcript_path" && -f "$transcript_path" ]]; then
            END{printf "%.4f %d %d %d %d\n", s, i, o, r, w}'
   ) || true
 fi
+
+# ---------- refresh when a model isn't in the pricing table ----------
+#
+# A model that shipped after this copy of the script has no price entry, so the
+# jq guard above zeroes savings on every turn and the line reads "saved $0.00"
+# — indistinguishable from "the router ran and didn't beat your selection". The
+# periodic check heals that eventually, but a week late, and a model launch is
+# exactly when the number gets looked at. Refresh off-schedule instead.
+#
+# Keyed on its own stamp per unpriced id: a model we never price (self-hosted,
+# unrecognized) then costs one download per interval, not one per turn, and
+# can't starve the periodic check.
+weave_refresh_on_price_miss() {
+  local candidates="" m
+  for m in "$@"; do
+    case "$m" in
+      "" | "?" | failure | weave-router | "<synthetic>") continue ;;
+    esac
+    candidates="${candidates}${m}"$'\n'
+  done
+  [ -n "$candidates" ] || return 0
+
+  # A malformed $prices emits nothing here, which fails closed (no refresh)
+  # rather than re-downloading every turn.
+  local missing
+  missing="$(printf '%s' "$candidates" \
+    | jq -rR --argjson p "$prices" \
+        'select($p.input[.] == null or $p.output[.] == null)' 2>/dev/null \
+    | head -n 1)" || return 0
+  [ -n "$missing" ] || return 0
+
+  local model_slug
+  model_slug="$(printf '%s' "$missing" | tr -c 'A-Za-z0-9._-' '_')"
+  weave_self_refresh ".miss.${model_slug}"
+}
+weave_refresh_on_price_miss "$requested_norm" "$routed" 2>/dev/null || true
 
 # Brand color (#FF6C47) on terminals that grok 24-bit truecolor — that's
 # every modern one (iTerm2, Apple Terminal, vscode, ghostty, alacritty,

--- a/install/cc-statusline.sh
+++ b/install/cc-statusline.sh
@@ -41,9 +41,12 @@ set -euo pipefail
 #
 # $1 is an optional stamp suffix, so a caller refreshing for a reason other than
 # "the interval elapsed" rate-limits on its own clock rather than sharing the
-# periodic check's budget.
+# periodic check's budget. $2=1 drops the stamp again if the download fails, for
+# callers recovering from a known-bad state where waiting out the full interval
+# on a transient network error is worse than retrying next turn.
 weave_self_refresh() {
   local stamp_suffix="${1:-}"
+  local retry_on_fail="${2:-0}"
 
   [ "${WEAVE_STATUSLINE_UPDATE:-1}" = "0" ] && return 0
   command -v curl >/dev/null 2>&1 || return 0
@@ -104,6 +107,11 @@ weave_self_refresh() {
       fi
     else
       rm -f "$tmp"
+      # A download that never landed shouldn't spend the caller's whole
+      # interval; drop the stamp so the next turn can try again.
+      if [ "$retry_on_fail" = "1" ]; then
+        rm -f "$stamp"
+      fi
     fi
   ) >/dev/null 2>&1 &
   disown 2>/dev/null || true
@@ -439,7 +447,7 @@ weave_refresh_on_price_miss() {
 
   local model_slug
   model_slug="$(printf '%s' "$missing" | tr -c 'A-Za-z0-9._-' '_')"
-  weave_self_refresh ".miss.${model_slug}"
+  weave_self_refresh ".miss.${model_slug}" 1
 }
 weave_refresh_on_price_miss "$requested_norm" "$routed" 2>/dev/null || true
 

--- a/install/install.sh
+++ b/install/install.sh
@@ -1999,10 +1999,18 @@ set -euo pipefail
 # lives in their per-user cache dir, and on no-content-change days we skip
 # the mv entirely so the repo working tree stays clean. When upstream does
 # change, the first teammate's commit propagates the new version to the rest.
+# A pricing-table miss also triggers a refresh off-schedule — see
+# weave_refresh_on_price_miss below.
 #
 # Opt out entirely with `export WEAVE_STATUSLINE_UPDATE=0`. Override the
 # source with `WEAVE_STATUSLINE_URL=...`, e.g. for self-hosters who fork.
+#
+# $1 is an optional stamp suffix, so a caller refreshing for a reason other than
+# "the interval elapsed" rate-limits on its own clock rather than sharing the
+# periodic check's budget.
 weave_self_refresh() {
+  local stamp_suffix="${1:-}"
+
   [ "${WEAVE_STATUSLINE_UPDATE:-1}" = "0" ] && return 0
   command -v curl >/dev/null 2>&1 || return 0
 
@@ -2019,7 +2027,7 @@ weave_self_refresh() {
   mkdir -p "$cache_dir" 2>/dev/null || return 0
   local script_slug
   script_slug="$(printf '%s' "$self" | tr -c 'A-Za-z0-9._-' '_')"
-  local stamp="$cache_dir/checked-at${script_slug}"
+  local stamp="$cache_dir/checked-at${script_slug}${stamp_suffix}"
 
   local now stamp_mtime
   now="$(date +%s 2>/dev/null)" || return 0
@@ -2364,6 +2372,42 @@ if [[ -n "$transcript_path" && -f "$transcript_path" ]]; then
            END{printf "%.4f %d %d %d %d\n", s, i, o, r, w}'
   ) || true
 fi
+
+# ---------- refresh when a model isn't in the pricing table ----------
+#
+# A model that shipped after this copy of the script has no price entry, so the
+# jq guard above zeroes savings on every turn and the line reads "saved $0.00"
+# — indistinguishable from "the router ran and didn't beat your selection". The
+# periodic check heals that eventually, but a week late, and a model launch is
+# exactly when the number gets looked at. Refresh off-schedule instead.
+#
+# Keyed on its own stamp per unpriced id: a model we never price (self-hosted,
+# unrecognized) then costs one download per interval, not one per turn, and
+# can't starve the periodic check.
+weave_refresh_on_price_miss() {
+  local candidates="" m
+  for m in "$@"; do
+    case "$m" in
+      "" | "?" | failure | weave-router | "<synthetic>") continue ;;
+    esac
+    candidates="${candidates}${m}"$'\n'
+  done
+  [ -n "$candidates" ] || return 0
+
+  # A malformed $prices emits nothing here, which fails closed (no refresh)
+  # rather than re-downloading every turn.
+  local missing
+  missing="$(printf '%s' "$candidates" \
+    | jq -rR --argjson p "$prices" \
+        'select($p.input[.] == null or $p.output[.] == null)' 2>/dev/null \
+    | head -n 1)" || return 0
+  [ -n "$missing" ] || return 0
+
+  local model_slug
+  model_slug="$(printf '%s' "$missing" | tr -c 'A-Za-z0-9._-' '_')"
+  weave_self_refresh ".miss.${model_slug}"
+}
+weave_refresh_on_price_miss "$requested_norm" "$routed" 2>/dev/null || true
 
 # Brand color (#FF6C47) on terminals that grok 24-bit truecolor — that's
 # every modern one (iTerm2, Apple Terminal, vscode, ghostty, alacritty,

--- a/install/install.sh
+++ b/install/install.sh
@@ -2007,9 +2007,12 @@ set -euo pipefail
 #
 # $1 is an optional stamp suffix, so a caller refreshing for a reason other than
 # "the interval elapsed" rate-limits on its own clock rather than sharing the
-# periodic check's budget.
+# periodic check's budget. $2=1 drops the stamp again if the download fails, for
+# callers recovering from a known-bad state where waiting out the full interval
+# on a transient network error is worse than retrying next turn.
 weave_self_refresh() {
   local stamp_suffix="${1:-}"
+  local retry_on_fail="${2:-0}"
 
   [ "${WEAVE_STATUSLINE_UPDATE:-1}" = "0" ] && return 0
   command -v curl >/dev/null 2>&1 || return 0
@@ -2070,6 +2073,11 @@ weave_self_refresh() {
       fi
     else
       rm -f "$tmp"
+      # A download that never landed shouldn't spend the caller's whole
+      # interval; drop the stamp so the next turn can try again.
+      if [ "$retry_on_fail" = "1" ]; then
+        rm -f "$stamp"
+      fi
     fi
   ) >/dev/null 2>&1 &
   disown 2>/dev/null || true
@@ -2405,7 +2413,7 @@ weave_refresh_on_price_miss() {
 
   local model_slug
   model_slug="$(printf '%s' "$missing" | tr -c 'A-Za-z0-9._-' '_')"
-  weave_self_refresh ".miss.${model_slug}"
+  weave_self_refresh ".miss.${model_slug}" 1
 }
 weave_refresh_on_price_miss "$requested_norm" "$routed" 2>/dev/null || true
 

--- a/install/tests/cc-statusline_test.sh
+++ b/install/tests/cc-statusline_test.sh
@@ -1,0 +1,243 @@
+#!/usr/bin/env bash
+#
+# Regression tests for install/cc-statusline.sh.
+#
+# Fully offline: every case points WEAVE_STATUSLINE_URL at a file:// copy under
+# a temp dir, so no test ever reaches raw.githubusercontent.com. Run directly or
+# via `make test-statusline`.
+#
+# Deliberately exercises the script through its real entrypoint (JSON on stdin,
+# a transcript on disk) rather than sourcing individual functions — the bugs
+# worth catching here live in the interaction between the rate-limit stamps, the
+# forked download, and the pricing lookup.
+
+set -uo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+statusline="$script_dir/../cc-statusline.sh"
+[ -f "$statusline" ] || { echo "cannot find cc-statusline.sh at $statusline" >&2; exit 1; }
+
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+
+pass=0
+fail=0
+
+ok() { echo "  ok   $1"; pass=$((pass + 1)); }
+no() { echo "  FAIL $1"; echo "         expected: $2"; echo "         actual:   $3"; fail=$((fail + 1)); }
+
+check() { # check <name> <actual> <expected>
+  if [ "$2" = "$3" ]; then ok "$1"; else no "$1" "$3" "$2"; fi
+}
+
+check_contains() { # check_contains <name> <haystack> <needle>
+  case "$2" in
+    *"$3"*) ok "$1" ;;
+    *) no "$1" "output containing '$3'" "$2" ;;
+  esac
+}
+
+check_not_contains() { # check_not_contains <name> <haystack> <needle>
+  case "$2" in
+    *"$3"*) no "$1" "output WITHOUT '$3'" "$2" ;;
+    *) ok "$1" ;;
+  esac
+}
+
+# The refresh runs in a forked subshell, so its effect lands asynchronously.
+# Poll instead of sleeping a fixed amount, which would be both slower and
+# flakier on a loaded CI runner.
+wait_for() { # wait_for <timeout_seconds> <command...>
+  local deadline=$(($(date +%s) + $1))
+  shift
+  until "$@" 2>/dev/null; do
+    [ "$(date +%s)" -lt "$deadline" ] || return 1
+    sleep 0.2
+  done
+}
+
+# On a cold cache the periodic check fires too and would refresh the copy on its
+# own, masking whether the price-miss path did anything. Pre-seeding its stamp
+# puts it inside its interval so the miss path is the only thing that can act.
+seed_periodic_stamp() { # seed_periodic_stamp <cache_home> <script_path>
+  local dir="$1/weave-router"
+  mkdir -p "$dir"
+  : > "$dir/checked-at$(printf '%s' "$2" | tr -c 'A-Za-z0-9._-' '_')"
+}
+
+count_stamps() { # count_stamps <cache_home> [<name_filter>]
+  local dir="$1/weave-router"
+  [ -d "$dir" ] || { echo 0; return 0; }
+  if [ -n "${2:-}" ]; then
+    find "$dir" -type f -name "*$2*" | wc -l | tr -d ' '
+  else
+    find "$dir" -type f | wc -l | tr -d ' '
+  fi
+}
+
+# curl must speak file:// for the offline fixtures to work. Fail loudly rather
+# than silently skipping the download-dependent cases.
+probe="$work/probe.txt"
+echo probe > "$probe"
+if ! curl -fsS "file://$probe" >/dev/null 2>&1; then
+  echo "FATAL: this curl has no file:// support; cannot run offline refresh tests" >&2
+  exit 1
+fi
+
+# ---------- fixtures ----------
+
+# A transcript with one assistant turn routed to a model that IS priced, so the
+# only variable across cases is whether the CC-side selection is priced.
+transcript="$work/transcript.jsonl"
+cat > "$transcript" <<'JSONL'
+{"type":"user","message":{"role":"user","content":"hi"}}
+{"type":"assistant","message":{"id":"msg_test_1","model":"deepseek/deepseek-v4-pro","usage":{"input_tokens":10000,"output_tokens":2000,"cache_creation_input_tokens":0,"cache_read_input_tokens":0}}}
+JSONL
+
+# "upstream" is the real script; "installed" copies are mutated per-case to
+# simulate an older on-disk copy.
+upstream="$work/upstream.sh"
+cp "$statusline" "$upstream"
+
+# Strip a model's price entries to simulate a copy written before that model
+# shipped. PRICED_MODEL stays in the table; STALE_MODEL is removed.
+STALE_MODEL="claude-opus-5"
+
+make_installed() { # make_installed <dest> [stale]
+  local dest="$1"
+  mkdir -p "$(dirname "$dest")"
+  if [ "${2:-}" = "stale" ]; then
+    grep -v "\"$STALE_MODEL\":" "$upstream" > "$dest"
+  else
+    cp "$upstream" "$dest"
+  fi
+  chmod +x "$dest"
+}
+
+# Replace the generated price block with syntactically-valid bash holding
+# invalid JSON, to prove the jq probe fails closed instead of looping.
+make_installed_bad_prices() { # make_installed_bad_prices <dest>
+  local dest="$1"
+  mkdir -p "$(dirname "$dest")"
+  awk '
+    /^# BEGIN_GENERATED_PRICES$/ { print; print "prices='"'"'{ not valid json'"'"'"; skip = 1; next }
+    /^# END_GENERATED_PRICES$/   { skip = 0 }
+    !skip { print }
+  ' "$upstream" > "$dest"
+  chmod +x "$dest"
+}
+
+render() { # render <installed_script> <cache_home> <url> <model_id> [transcript]
+  echo "{\"model\":{\"id\":\"$4\"},\"transcript_path\":\"${5-$transcript}\"}" \
+    | XDG_CACHE_HOME="$2" WEAVE_STATUSLINE_URL="$3" bash "$1" 2>&1 \
+    | sed 's/\x1b\[[0-9;]*m//g'
+}
+
+# ---------- cases ----------
+
+echo "cc-statusline.sh"
+
+# Baseline: a priced selection reports real savings. Guards against the whole
+# suite passing vacuously because savings never render at all.
+c="$work/c1"; mkdir -p "$c/cache"; make_installed "$c/cc.sh"
+out="$(render "$c/cc.sh" "$c/cache" "file://$upstream" "$STALE_MODEL")"
+check_not_contains "priced selection reports nonzero savings" "$out" 'saved $0.00'
+check_contains "priced selection still names the routed model" "$out" "deepseek/deepseek-v4-pro"
+check "priced selection writes no miss stamp" "$(count_stamps "$c/cache" .miss.)" 0
+
+# The bug this path exists for: an unpriced selection renders $0.00, and the
+# script heals itself for the next turn instead of waiting out the interval.
+c="$work/c2"; mkdir -p "$c/cache"; make_installed "$c/cc.sh" stale
+seed_periodic_stamp "$c/cache" "$c/cc.sh"
+out="$(render "$c/cc.sh" "$c/cache" "file://$upstream" "$STALE_MODEL")"
+check_contains "unpriced selection renders \$0.00" "$out" 'saved $0.00'
+if wait_for 20 grep -q "\"$STALE_MODEL\":" "$c/cc.sh"; then
+  ok "unpriced selection refreshes the on-disk copy"
+  out="$(render "$c/cc.sh" "$c/cache" "file://$upstream" "$STALE_MODEL")"
+  check_not_contains "next turn reports real savings" "$out" 'saved $0.00'
+else
+  no "unpriced selection refreshes the on-disk copy" "price entries restored" "still missing after 20s"
+fi
+
+# Regression: a transient download failure must not consume the retry interval.
+# Before the retry_on_fail flag this left the user on $0.00 for a full 7 days.
+c="$work/c3"; mkdir -p "$c/cache"; make_installed "$c/cc.sh" stale
+seed_periodic_stamp "$c/cache" "$c/cc.sh"
+render "$c/cc.sh" "$c/cache" "file://$work/does-not-exist.sh" "$STALE_MODEL" >/dev/null
+if wait_for 20 test "$(count_stamps "$c/cache" .miss.)" = 0; then
+  ok "failed download does not consume the retry interval"
+else
+  no "failed download does not consume the retry interval" "miss stamp removed" "stamp still present"
+fi
+out="$(render "$c/cc.sh" "$c/cache" "file://$upstream" "$STALE_MODEL")"
+if wait_for 20 grep -q "\"$STALE_MODEL\":" "$c/cc.sh"; then
+  ok "retry after a failed download heals the copy"
+else
+  no "retry after a failed download heals the copy" "price entries restored" "still missing"
+fi
+
+# Cost guardrail: a model nothing will ever price must not download per turn.
+c="$work/c4"; mkdir -p "$c/cache"; make_installed "$c/cc.sh"
+for _ in 1 2 3 4 5; do
+  render "$c/cc.sh" "$c/cache" "file://$upstream" "model-nobody-prices" >/dev/null
+done
+sleep 1
+check "never-priced model refreshes at most once per interval" \
+  "$(count_stamps "$c/cache" .miss.)" 1
+check "miss stamp does not replace the periodic stamp" \
+  "$(count_stamps "$c/cache")" 2
+
+# Malformed pricing must fail closed: no crash, no refresh loop.
+c="$work/c5"; mkdir -p "$c/cache"; make_installed_bad_prices "$c/cc.sh"
+out="$(render "$c/cc.sh" "$c/cache" "file://$upstream" "$STALE_MODEL")"
+check_contains "malformed prices still render the routed model" "$out" "deepseek/deepseek-v4-pro"
+sleep 1
+check "malformed prices trigger no refresh" "$(count_stamps "$c/cache" .miss.)" 0
+
+# Sentinels are not models and can never be priced; refreshing on them would
+# download once per sentinel forever.
+for sentinel in "?" "failure" "weave-router"; do
+  c="$work/c6-$(printf '%s' "$sentinel" | tr -c 'A-Za-z0-9' '_')"
+  mkdir -p "$c/cache"; make_installed "$c/cc.sh" stale
+  render "$c/cc.sh" "$c/cache" "file://$upstream" "$sentinel" >/dev/null
+  sleep 0.5
+  check "sentinel '$sentinel' triggers no refresh" "$(count_stamps "$c/cache" .miss.)" 0
+done
+
+# Opt-out must suppress every network path, including the miss-triggered one.
+c="$work/c7"; mkdir -p "$c/cache"; make_installed "$c/cc.sh" stale
+echo "{\"model\":{\"id\":\"$STALE_MODEL\"},\"transcript_path\":\"$transcript\"}" \
+  | XDG_CACHE_HOME="$c/cache" WEAVE_STATUSLINE_UPDATE=0 \
+    WEAVE_STATUSLINE_URL="file://$upstream" bash "$c/cc.sh" >/dev/null 2>&1
+sleep 0.5
+check "WEAVE_STATUSLINE_UPDATE=0 writes no stamps" "$(count_stamps "$c/cache")" 0
+
+# A missing transcript is normal on a fresh session.
+c="$work/c8"; mkdir -p "$c/cache"; make_installed "$c/cc.sh"
+echo "{\"model\":{\"id\":\"$STALE_MODEL\"}}" \
+  | XDG_CACHE_HOME="$c/cache" WEAVE_STATUSLINE_URL="file://$upstream" \
+    bash "$c/cc.sh" >/dev/null 2>&1
+check "missing transcript exits 0" "$?" 0
+
+# install.sh ships the statusline as a heredoc; genprices keeps only the price
+# block in sync, so a code edit to one copy silently diverges from the other.
+installer="$script_dir/../install.sh"
+if [ -f "$installer" ]; then
+  start="$(grep -n 'STATUSLINE_EOF' "$installer" | head -1 | cut -d: -f1)"
+  end="$(grep -n 'STATUSLINE_EOF' "$installer" | tail -1 | cut -d: -f1)"
+  if [ -n "$start" ] && [ -n "$end" ] && [ "$end" -gt "$start" ]; then
+    awk -v s="$start" -v e="$end" 'NR>s && NR<e' "$installer" > "$work/heredoc.sh"
+    if diff -q "$work/heredoc.sh" "$statusline" >/dev/null 2>&1; then
+      ok "install.sh heredoc matches cc-statusline.sh"
+    else
+      no "install.sh heredoc matches cc-statusline.sh" "byte-identical copies" \
+        "$(diff "$work/heredoc.sh" "$statusline" | head -5)"
+    fi
+  else
+    no "install.sh heredoc matches cc-statusline.sh" "locatable STATUSLINE_EOF markers" "not found"
+  fi
+fi
+
+echo
+echo "$pass passed, $fail failed"
+[ "$fail" -eq 0 ]


### PR DESCRIPTION
## What

When the statusline can't price the CC-side selection or the routed model, kick off the self-refresh immediately instead of waiting for the 7-day interval to elapse.

`weave_self_refresh` now takes an optional stamp suffix; the new `weave_refresh_on_price_miss` passes one keyed by the unpriced model id.

## Why

The price table is baked into `cc-statusline.sh`, so a model that ships *after* a user's copy was written has no entry. The savings `jq` then hits its null-price guard:

```
if ($rin == null or $rout == null or $sin == null or $sout == null) then 0
```

...and emits 0 for **every** turn. `fmt_money` renders exactly-0 as `$0.00`, which is indistinguishable from "the router ran and didn't beat your selection" — so it reads as a broken feature rather than "I can't price that model yet."

`claude-opus-5` landed in the table in #833 (2026-07-24). Every install whose 7-day refresh window hadn't elapsed kept reporting `$0.00` to anyone who switched to Opus 5 — i.e. precisely the window when people check the number. This surfaced as an internal report: *"Seems like the 'Saved $X.XX' isn't working anymore? This entire session has been on deepseek."*

Replaying a real 1,373-turn deepseek transcript with `model.id = claude-opus-5[1m]`:

| version | date | renders |
|---|---|---|
| `eeb467d` (pre-#833) | 07-21 | `saved $0.00` |
| `3d44c0e` (#833) | 07-24 | `saved $95.64` |

`diff` between those two versions is *only* the two `claude-opus-5` price lines — routing was fine and genuinely saving money the whole time; just the readout was zero.

This generalizes: without this change, **every** new-model launch produces up to a week of `$0.00` for existing installs.

## Guardrails

The forced path uses its own stamp (`checked-at<script>.miss.<model-id>`), so:

- a model we never price (self-hosted, unrecognized) costs **one** download per interval, not one per turn;
- it can't starve the periodic check, which keeps its own separate stamp;
- `WEAVE_STATUSLINE_UPDATE=0` still disables everything;
- the `""` / `?` / `failure` / `weave-router` / `<synthetic>` sentinels are skipped — they're not models and will never be priced;
- a malformed `$prices` makes the `jq` probe emit nothing, which fails closed (no refresh) rather than re-downloading every turn.

## Testing

11-case matrix, all passing on **bash 3.2** (macOS system bash) under `set -euo pipefail`:

- stale copy renders `$0.00`, then self-heals to `$95.64` on the next turn, with the `claude-opus-5` entries restored on disk
- no `.miss` stamp created when every model is priced
- 5 consecutive turns on a never-priced id → exactly 1 `.miss` stamp + 1 untouched periodic stamp
- mutating "upstream" between turns is not picked up while rate-limited (proves the limit actually gates the download)
- `WEAVE_STATUSLINE_UPDATE=0` writes no stamps at all
- `?`, `failure`, `weave-router` each trigger no refresh
- missing transcript still exits 0

Repo checks:

- `install.sh`'s heredoc verified byte-identical to the standalone `cc-statusline.sh`
- `go run ./cmd/genprices` is a no-op on the patch, and both files remain in lockstep after it
- end-to-end `install.sh --claude --dir <sandbox>` writes the patched script verbatim and it renders `saved $95.64`
- `make fmt`, `go vet ./...`, `go build ./...`, `go test ./...` (46 pkgs) all clean

## Follow-up

Users on a copy predating the self-refresh itself (#135, 2026-05-15) will never pick this up — they have no refresh code to run. Those installs are identifiable by the *absent* savings clause (pre-#651 behavior dropped it entirely rather than flooring at `$0.00`) and need a manual re-install. Not addressed here.