### PR TITLE
fix(statusline): give each concurrent refresh its own temp file

### DIFF
--- a/install/cc-statusline.sh
+++ b/install/cc-statusline.sh
@@ -88,7 +88,13 @@ weave_self_refresh() {
   : > "$stamp" 2>/dev/null || return 0
 
   local url="${WEAVE_STATUSLINE_URL:-https://raw.githubusercontent.com/workweave/router/main/install/cc-statusline.sh}"
-  local tmp="${self}.tmp.$$"
+  # $$ alone is not unique: two calls can run in one invocation (the periodic
+  # check and a pricing-miss retry both fire on a cold cache) and would then
+  # curl -o into the same path and mv over each other, installing a truncated
+  # script that can never self-heal. The stamp suffix is the right key — it is
+  # what makes two callers mutually exclusive in the first place, so callers
+  # that could overlap necessarily have different suffixes.
+  local tmp="${self}.tmp.$$${stamp_suffix}"
   (
     # Detach stdin (CC pipes JSON to us) so curl can't accidentally consume
     # it, and silence all output so nothing leaks into the statusline.

--- a/install/install.sh
+++ b/install/install.sh
@@ -2054,7 +2054,13 @@ weave_self_refresh() {
   : > "$stamp" 2>/dev/null || return 0
 
   local url="${WEAVE_STATUSLINE_URL:-https://raw.githubusercontent.com/workweave/router/main/install/cc-statusline.sh}"
-  local tmp="${self}.tmp.$$"
+  # $$ alone is not unique: two calls can run in one invocation (the periodic
+  # check and a pricing-miss retry both fire on a cold cache) and would then
+  # curl -o into the same path and mv over each other, installing a truncated
+  # script that can never self-heal. The stamp suffix is the right key — it is
+  # what makes two callers mutually exclusive in the first place, so callers
+  # that could overlap necessarily have different suffixes.
+  local tmp="${self}.tmp.$$${stamp_suffix}"
   (
     # Detach stdin (CC pipes JSON to us) so curl can't accidentally consume
     # it, and silence all output so nothing leaks into the statusline.

--- a/install/tests/cc-statusline_test.sh
+++ b/install/tests/cc-statusline_test.sh
@@ -187,6 +187,31 @@ check "never-priced model refreshes at most once per interval" \
 check "miss stamp does not replace the periodic stamp" \
   "$(count_stamps "$c/cache")" 2
 
+# On a cold cache the periodic check and the pricing-miss retry both fire in one
+# invocation. They must not share a download path: concurrent curl -o plus mv on
+# one temp file can install a truncated script, and a syntax-broken statusline
+# can never self-heal because it cannot run its own refresh.
+c="$work/c4b"; mkdir -p "$c/cache" "$c/bin"; make_installed "$c/cc.sh" stale
+cat > "$c/bin/curl" <<'SHIM'
+#!/usr/bin/env bash
+# Record each download target, then delegate to the real curl.
+args=("$@")
+for i in "${!args[@]}"; do
+  if [ "${args[$i]}" = "-o" ]; then echo "${args[$((i + 1))]}" >> "$WEAVE_TEST_CURL_LOG"; fi
+done
+exec /usr/bin/curl "$@"
+SHIM
+chmod +x "$c/bin/curl"
+curl_log="$c/targets.log"; : > "$curl_log"
+echo "{\"model\":{\"id\":\"$STALE_MODEL\"},\"transcript_path\":\"$transcript\"}" \
+  | PATH="$c/bin:$PATH" WEAVE_TEST_CURL_LOG="$curl_log" XDG_CACHE_HOME="$c/cache" \
+    WEAVE_STATUSLINE_URL="file://$upstream" bash "$c/cc.sh" >/dev/null 2>&1
+wait_for 20 test "$(wc -l < "$curl_log" | tr -d ' ')" -ge 2 || true
+downloads="$(wc -l < "$curl_log" | tr -d ' ')"
+distinct="$(sort -u "$curl_log" | wc -l | tr -d ' ')"
+check "cold cache fires both the periodic and price-miss refresh" "$downloads" 2
+check "concurrent refreshes use distinct temp files" "$distinct" "$downloads"
+
 # Malformed pricing must fail closed: no crash, no refresh loop.
 c="$work/c5"; mkdir -p "$c/cache"; make_installed_bad_prices "$c/cc.sh"
 out="$(render "$c/cc.sh" "$c/cache" "file://$upstream" "$STALE_MODEL")"

--- a/install/tests/cc-statusline_test.sh
+++ b/install/tests/cc-statusline_test.sh
@@ -75,6 +75,17 @@ count_stamps() { # count_stamps <cache_home> [<name_filter>]
   fi
 }
 
+# wait_for re-invokes its argv on every poll, so a value that changes over time
+# has to be recomputed inside the callee. Interpolating `$(...)` at the call site
+# freezes it at its first value and the wait can only ever time out.
+stamp_count_is() { # stamp_count_is <cache_home> <filter> <expected>
+  [ "$(count_stamps "$1" "$2")" = "$3" ]
+}
+
+line_count_at_least() { # line_count_at_least <file> <n>
+  [ "$(wc -l < "$1" | tr -d ' ')" -ge "$2" ]
+}
+
 # curl must speak file:// for the offline fixtures to work. Fail loudly rather
 # than silently skipping the download-dependent cases.
 probe="$work/probe.txt"
@@ -164,7 +175,7 @@ fi
 c="$work/c3"; mkdir -p "$c/cache"; make_installed "$c/cc.sh" stale
 seed_periodic_stamp "$c/cache" "$c/cc.sh"
 render "$c/cc.sh" "$c/cache" "file://$work/does-not-exist.sh" "$STALE_MODEL" >/dev/null
-if wait_for 20 test "$(count_stamps "$c/cache" .miss.)" = 0; then
+if wait_for 20 stamp_count_is "$c/cache" .miss. 0; then
   ok "failed download does not consume the retry interval"
 else
   no "failed download does not consume the retry interval" "miss stamp removed" "stamp still present"
@@ -206,7 +217,7 @@ curl_log="$c/targets.log"; : > "$curl_log"
 echo "{\"model\":{\"id\":\"$STALE_MODEL\"},\"transcript_path\":\"$transcript\"}" \
   | PATH="$c/bin:$PATH" WEAVE_TEST_CURL_LOG="$curl_log" XDG_CACHE_HOME="$c/cache" \
     WEAVE_STATUSLINE_URL="file://$upstream" bash "$c/cc.sh" >/dev/null 2>&1
-wait_for 20 test "$(wc -l < "$curl_log" | tr -d ' ')" -ge 2 || true
+wait_for 20 line_count_at_least "$curl_log" 2
 downloads="$(wc -l < "$curl_log" | tr -d ' ')"
 distinct="$(sort -u "$curl_log" | wc -l | tr -d ' ')"
 check "cold cache fires both the periodic and price-miss refresh" "$downloads" 2

--- a/install/tests/cc-statusline_test.sh
+++ b/install/tests/cc-statusline_test.sh
@@ -203,6 +203,10 @@ check "miss stamp does not replace the periodic stamp" \
 # one temp file can install a truncated script, and a syntax-broken statusline
 # can never self-heal because it cannot run its own refresh.
 c="$work/c4b"; mkdir -p "$c/cache" "$c/bin"; make_installed "$c/cc.sh" stale
+# Resolve curl before the shim dir shadows it, and delegate through that. A
+# hardcoded /usr/bin/curl would silently fail its downloads wherever curl lives
+# elsewhere, leaving the -o log populated but no refresh actually performed.
+real_curl="$(command -v curl)"
 cat > "$c/bin/curl" <<'SHIM'
 #!/usr/bin/env bash
 # Record each download target, then delegate to the real curl.
@@ -210,18 +214,32 @@ args=("$@")
 for i in "${!args[@]}"; do
   if [ "${args[$i]}" = "-o" ]; then echo "${args[$((i + 1))]}" >> "$WEAVE_TEST_CURL_LOG"; fi
 done
-exec /usr/bin/curl "$@"
+exec "$WEAVE_TEST_REAL_CURL" "$@"
 SHIM
 chmod +x "$c/bin/curl"
 curl_log="$c/targets.log"; : > "$curl_log"
 echo "{\"model\":{\"id\":\"$STALE_MODEL\"},\"transcript_path\":\"$transcript\"}" \
-  | PATH="$c/bin:$PATH" WEAVE_TEST_CURL_LOG="$curl_log" XDG_CACHE_HOME="$c/cache" \
-    WEAVE_STATUSLINE_URL="file://$upstream" bash "$c/cc.sh" >/dev/null 2>&1
+  | PATH="$c/bin:$PATH" WEAVE_TEST_CURL_LOG="$curl_log" WEAVE_TEST_REAL_CURL="$real_curl" \
+    XDG_CACHE_HOME="$c/cache" WEAVE_STATUSLINE_URL="file://$upstream" \
+    bash "$c/cc.sh" >/dev/null 2>&1
 wait_for 20 line_count_at_least "$curl_log" 2
 downloads="$(wc -l < "$curl_log" | tr -d ' ')"
 distinct="$(sort -u "$curl_log" | wc -l | tr -d ' ')"
 check "cold cache fires both the periodic and price-miss refresh" "$downloads" 2
 check "concurrent refreshes use distinct temp files" "$distinct" "$downloads"
+# Counting -o targets alone would pass even if every download failed, so assert
+# the refresh landed and left a script that still parses — a corrupt one is the
+# actual consequence of sharing the temp path.
+if wait_for 20 grep -q "\"$STALE_MODEL\":" "$c/cc.sh"; then
+  ok "concurrent refreshes actually install the new script"
+else
+  no "concurrent refreshes actually install the new script" "price entries restored" "still missing"
+fi
+if bash -n "$c/cc.sh" 2>/dev/null; then
+  ok "script surviving concurrent refreshes still parses"
+else
+  no "script surviving concurrent refreshes still parses" "valid bash" "syntax error"
+fi
 
 # Malformed pricing must fail closed: no crash, no refresh loop.
 c="$work/c5"; mkdir -p "$c/cache"; make_installed_bad_prices "$c/cc.sh"


### PR DESCRIPTION
## What

Key the self-refresh download path on the stamp suffix (`${self}.tmp.$$${stamp_suffix}`) instead of `$$` alone, so the periodic refresh and the pricing-miss refresh can't write the same file.

## Why

#850 made `weave_self_refresh` callable **twice in one statusline invocation** — the periodic check at the top, and the pricing-miss retry after the transcript pass. Both forks built their temp path from `$$`, which a subshell inherits from its parent, so both got the *same* path.

On a cold cache both are due, so this is the common case, not a rare race. Verified with a `curl` shim recording every `-o` target:

```
curl invocations for one statusline run: 2
distinct -o temp paths:                 1
  /tmp/.../cc.sh.tmp.99680
  /tmp/.../cc.sh.tmp.99680
```

Two concurrent `curl -o` on one file, each then running `[ -s ]` / shebang / size validation and `mv`-ing over the live script. The validation is no protection — it races the other writer. Worst case installs a truncated `cc-statusline.sh`, and **a syntax-broken statusline never self-heals**, because the thing that would repair it is the script itself.

Keying on the stamp suffix is the right discriminator rather than an arbitrary nonce: the suffix is precisely what makes two callers mutually exclusive (it's their rate-limit key), so any two callers that can overlap necessarily have different suffixes. A future third caller gets correctness by construction rather than by remembering to pick a unique name.

Reported by Cursor Bugbot on WorkWeave#11242, the pin-bump PR carrying #850.

## Tests

Two new cases in `install/tests/cc-statusline_test.sh` (20 total):

- **cold cache fires both the periodic and price-miss refresh** — guards the premise. Without it, a regression that collapses to one download would make the path assertion vacuously true.
- **concurrent refreshes use distinct temp files** — asserts `distinct == downloads`.

Mutation-checked: restoring `local tmp="${self}.tmp.$$"` fails the second case and only that case.

Full run: 20/20 on bash 5 and macOS bash 3.2; `make fmt`, `go vet ./...`, `go build ./...`, `go test ./...` (46 pkgs) clean; `genprices` a no-op; `install.sh` heredoc still byte-identical to the standalone; end-to-end `--dir` install matches the repo copy.

## Note on the pin bump

WorkWeave#11242 currently carries #850 **with** this bug. It should wait for this to merge and re-sync rather than merging as-is — `install_template.sh` there is a generated artifact, so fixing it on that branch would diverge from this source and be overwritten by the next bump.