### PR TITLE
feat(proxy): disable overloaded provider for session after consecutive 529 exhaustion

### DIFF
--- a/db/migrations/0043_session-pin-overload-tracking.down.sql
+++ b/db/migrations/0043_session-pin-overload-tracking.down.sql
@@ -1,0 +1,6 @@
+BEGIN;
+
+ALTER TABLE router.session_pins DROP COLUMN disabled_providers;
+ALTER TABLE router.session_pins DROP COLUMN consecutive_overload_errors;
+
+COMMIT;

--- a/db/migrations/0043_session-pin-overload-tracking.up.sql
+++ b/db/migrations/0043_session-pin-overload-tracking.up.sql
@@ -1,0 +1,21 @@
+BEGIN;
+
+-- Counts consecutive turns that exhausted with a client-visible 529
+-- (Anthropic's SSE-prelude overloaded_error) on the currently-pinned
+-- provider. Distinct from consecutive_upstream_errors (0009), which only
+-- counts non-retryable 4xx: a 529 is retryable in-turn (same-binding retry
+-- + cross-binding failover), so it never touched that counter, and a
+-- session pinned to an overloaded provider would keep re-trying it turn
+-- after turn with no memory of the prior exhaustion.
+ALTER TABLE router.session_pins
+  ADD COLUMN consecutive_overload_errors INTEGER NOT NULL DEFAULT 0;
+
+-- Providers struck out for this pin's session after repeated 529
+-- exhaustion. Deliberately not touched by UpsertSessionPin's ON CONFLICT
+-- update -- it only grows, for the life of this (session_key, role) row,
+-- so a provider stays disabled until the pin itself is evicted/expires
+-- (no separate time-based cooldown).
+ALTER TABLE router.session_pins
+  ADD COLUMN disabled_providers TEXT[] NOT NULL DEFAULT '{}';
+
+COMMIT;

--- a/db/queries/session_pins.sql
+++ b/db/queries/session_pins.sql
@@ -138,6 +138,47 @@ WHERE session_key = @session_key::bytea
   AND role        = @role::varchar
   AND consecutive_upstream_errors > 0;
 
+-- Atomically increments consecutive_overload_errors and returns the new
+-- value. The turn loop calls this after a turn exhausts with a
+-- client-visible 529 (Anthropic overloaded_error) on a sticky-pinned
+-- turn; the returned count drives the two-strike provider-disable
+-- decision. Returns sql.ErrNoRows if no pin exists, which the adapter
+-- maps to a no-op. Separate from IncrementSessionPinUpstreamErrors
+-- because a 529 is retryable in-turn and must not also trip the
+-- non-retryable-4xx eviction counter.
+-- name: IncrementSessionPinOverloadErrors :one
+UPDATE router.session_pins
+SET consecutive_overload_errors = consecutive_overload_errors + 1
+WHERE session_key = @session_key::bytea
+  AND role        = @role::varchar
+RETURNING consecutive_overload_errors;
+
+-- Clears the overload strike counter after a successful turn. UPDATE
+-- matches by (session_key, role); zero rows affected on missing pin is
+-- a successful no-op like ResetSessionPinUpstreamErrors.
+-- name: ResetSessionPinOverloadErrors :exec
+UPDATE router.session_pins
+SET consecutive_overload_errors = 0
+WHERE session_key = @session_key::bytea
+  AND role        = @role::varchar
+  AND consecutive_overload_errors > 0;
+
+-- Appends a provider to disabled_providers (deduped) and resets the
+-- overload strike counter in the same statement, fired once the
+-- two-strike threshold is reached. disabled_providers only grows for the
+-- life of this pin row -- UpsertSessionPin's ON CONFLICT update never
+-- touches it, so a struck-out provider stays disabled until the pin
+-- itself is evicted/expires, with no separate time-based cooldown.
+-- name: DisableSessionPinProvider :exec
+UPDATE router.session_pins
+SET disabled_providers = CASE
+      WHEN @provider::varchar = ANY(disabled_providers) THEN disabled_providers
+      ELSE array_append(disabled_providers, @provider::varchar)
+    END,
+    consecutive_overload_errors = 0
+WHERE session_key = @session_key::bytea
+  AND role        = @role::varchar;
+
 -- Garbage-collects pins that have been expired for >24h. The 24h grace
 -- means a transient Postgres outage doesn't immediately prune live pins;
 -- the hourly sweep is bounded because the row count is one per active

--- a/db/queries/session_pins.sql
+++ b/db/queries/session_pins.sql
@@ -80,6 +80,16 @@ ON CONFLICT (session_key, role) DO UPDATE SET
     WHEN router.session_pins.pinned_model = EXCLUDED.pinned_model
       THEN router.session_pins.consecutive_upstream_errors
     ELSE 0
+  END,
+  -- Mirrors consecutive_upstream_errors above: a stray 529 strike must not
+  -- survive an unrelated pin rewrite (degenerate eviction, loop-break, 4xx
+  -- eviction, planner switch) onto a different model, or one 529 on the
+  -- fresh pin could immediately hit the two-strike threshold instead of
+  -- requiring two genuine consecutive strikes on the SAME served provider.
+  consecutive_overload_errors = CASE
+    WHEN router.session_pins.pinned_model = EXCLUDED.pinned_model
+      THEN router.session_pins.consecutive_overload_errors
+    ELSE 0
   END;
 
 -- Records the previous turn's upstream token usage on an existing pin

--- a/internal/postgres/session_pin_repo.go
+++ b/internal/postgres/session_pin_repo.go
@@ -107,6 +107,45 @@ func (r *SessionPinRepo) ResetUpstreamErrors(ctx context.Context, sessionKey [se
 	})
 }
 
+// IncrementOverloadErrors atomically bumps the consecutive-529-exhaustion
+// counter. A missing pin returns (0, nil), mirroring IncrementUpstreamErrors.
+func (r *SessionPinRepo) IncrementOverloadErrors(ctx context.Context, sessionKey [sessionpin.SessionKeyLen]byte, role string) (int, error) {
+	q := sqlc.New(r.tx)
+	count, err := q.IncrementSessionPinOverloadErrors(ctx, sqlc.IncrementSessionPinOverloadErrorsParams{
+		SessionKey: sessionKey[:],
+		Role:       role,
+	})
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return 0, nil
+		}
+		return 0, err
+	}
+	return int(count), nil
+}
+
+// ResetOverloadErrors clears the consecutive-529-exhaustion counter after a
+// successful turn. Missing pin is a no-op, same as ResetUpstreamErrors.
+func (r *SessionPinRepo) ResetOverloadErrors(ctx context.Context, sessionKey [sessionpin.SessionKeyLen]byte, role string) error {
+	q := sqlc.New(r.tx)
+	return q.ResetSessionPinOverloadErrors(ctx, sqlc.ResetSessionPinOverloadErrorsParams{
+		SessionKey: sessionKey[:],
+		Role:       role,
+	})
+}
+
+// DisableProvider appends provider to disabled_providers (deduped) and
+// resets the overload strike counter in the same write. Missing pin is a
+// no-op: the eviction that accompanies this call has nothing left to guard.
+func (r *SessionPinRepo) DisableProvider(ctx context.Context, sessionKey [sessionpin.SessionKeyLen]byte, role, provider string) error {
+	q := sqlc.New(r.tx)
+	return q.DisableSessionPinProvider(ctx, sqlc.DisableSessionPinProviderParams{
+		SessionKey: sessionKey[:],
+		Role:       role,
+		Provider:   provider,
+	})
+}
+
 func (r *SessionPinRepo) SweepExpired(ctx context.Context) error {
 	q := sqlc.New(r.tx)
 	return q.SweepExpiredSessionPins(ctx)
@@ -133,6 +172,8 @@ func toSessionPin(row sqlc.RouterSessionPin) sessionpin.Pin {
 		LastServedModel:           row.LastServedModel,
 		HasEverSwitched:           row.HasEverSwitched,
 		ConsecutiveUpstreamErrors: int(row.ConsecutiveUpstreamErrors),
+		ConsecutiveOverloadErrors: int(row.ConsecutiveOverloadErrors),
+		DisabledProviders:         row.DisabledProviders,
 	}
 	// Bounded copy guards against a corrupt row panicking the request handler.
 	copy(pin.SessionKey[:], row.SessionKey)

--- a/internal/proxy/cyber_refusal_internal_test.go
+++ b/internal/proxy/cyber_refusal_internal_test.go
@@ -40,6 +40,15 @@ func (f *repinFakeStore) IncrementUpstreamErrors(context.Context, [sessionpin.Se
 func (f *repinFakeStore) ResetUpstreamErrors(context.Context, [sessionpin.SessionKeyLen]byte, string) error {
 	return nil
 }
+func (f *repinFakeStore) IncrementOverloadErrors(context.Context, [sessionpin.SessionKeyLen]byte, string) (int, error) {
+	return 0, nil
+}
+func (f *repinFakeStore) ResetOverloadErrors(context.Context, [sessionpin.SessionKeyLen]byte, string) error {
+	return nil
+}
+func (f *repinFakeStore) DisableProvider(context.Context, [sessionpin.SessionKeyLen]byte, string, string) error {
+	return nil
+}
 func (f *repinFakeStore) SweepExpired(context.Context) error { return nil }
 
 // A realistic Anthropic-native refusal SSE (the router-visible wire shape:

--- a/internal/proxy/failover_integration_test.go
+++ b/internal/proxy/failover_integration_test.go
@@ -435,13 +435,9 @@ func TestProxyMessages_TwoConsecutiveOverloadExhaustionsDisableProvider(t *testi
 
 // TestProxyMessages_BaselineOverloadExhaustionDoesNotDisableAnthropic
 // regression-tests a Cursor Bugbot finding: a session pinned to an OSS
-// provider that exhausts retryably rescues via baseline failover onto
-// Anthropic (finalProvider becomes "anthropic" even though the sticky pin's
-// own provider is the OSS one). If that Anthropic RESCUE attempt itself
-// exhausts on 529 twice across turns, the two-strike breaker must not
-// disable Anthropic or evict the unrelated OSS pin -- doing so would both
-// misattribute the strike (Anthropic didn't cause the original failure) and
-// remove the exact rescue hatch the overload window needs.
+// TestProxyMessages_BaselineOverloadExhaustionDoesNotDisableAnthropic
+// asserts that a baseline-rescue Anthropic 529 (OSS primary 503 -> Anthropic
+// failover) never disables Anthropic or evicts the unrelated OSS pin.
 func TestProxyMessages_BaselineOverloadExhaustionDoesNotDisableAnthropic(t *testing.T) {
 	ossUpstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")

--- a/internal/proxy/failover_integration_test.go
+++ b/internal/proxy/failover_integration_test.go
@@ -434,8 +434,6 @@ func TestProxyMessages_TwoConsecutiveOverloadExhaustionsDisableProvider(t *testi
 }
 
 // TestProxyMessages_BaselineOverloadExhaustionDoesNotDisableAnthropic
-// regression-tests a Cursor Bugbot finding: a session pinned to an OSS
-// TestProxyMessages_BaselineOverloadExhaustionDoesNotDisableAnthropic
 // asserts that a baseline-rescue Anthropic 529 (OSS primary 503 -> Anthropic
 // failover) never disables Anthropic or evicts the unrelated OSS pin.
 func TestProxyMessages_BaselineOverloadExhaustionDoesNotDisableAnthropic(t *testing.T) {

--- a/internal/proxy/failover_integration_test.go
+++ b/internal/proxy/failover_integration_test.go
@@ -421,10 +421,9 @@ func TestProxyMessages_TwoConsecutiveOverloadExhaustionsDisableProvider(t *testi
 	require.Contains(t, store.disabledProviders, providers.ProviderAnthropic,
 		"second consecutive exhausted 529 must strike the provider out for the session")
 
-	// Turn 3: the pin was evicted (Provider/Model cleared), so this turn is a
-	// fresh scorer call. The disabled provider must be excluded from
-	// EnabledProviders even though it's the only deployment-keyed provider —
-	// proving the exclusion actually reaches the scorer, not just the pin row.
+	// Turn 3: pin was evicted, so this is a fresh scorer call. The
+	// disabled provider must be excluded from EnabledProviders, proving
+	// the exclusion reaches the scorer rather than just the pin row.
 	rec3 := httptest.NewRecorder()
 	req3 := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(""))
 	_ = svc.ProxyMessages(ctx, body, rec3, req3)

--- a/internal/proxy/failover_integration_test.go
+++ b/internal/proxy/failover_integration_test.go
@@ -372,11 +372,8 @@ func TestProxyMessages_AnthropicSSEOverloadExhaustionRecords529(t *testing.T) {
 }
 
 // TestProxyMessages_TwoConsecutiveOverloadExhaustionsDisableProvider drives
-// two full turns against a sticky pin, each exhausting on the SSE
-// overloaded_error stub (same shape as
-// TestProxyMessages_AnthropicSSEOverloadExhaustionRecords529 above), and
-// asserts the pin's disabled_providers gains "anthropic" after the second,
-// and the scorer's next Route call no longer carries anthropic in
+// two full turns exhausting on 529, asserts disabled_providers gains
+// "anthropic" after the second, and the third turn excludes it from
 // EnabledProviders.
 func TestProxyMessages_TwoConsecutiveOverloadExhaustionsDisableProvider(t *testing.T) {
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -434,6 +431,77 @@ func TestProxyMessages_TwoConsecutiveOverloadExhaustionsDisableProvider(t *testi
 	require.NotNil(t, fr.capturedReq)
 	_, stillEnabled := fr.capturedReq.EnabledProviders[providers.ProviderAnthropic]
 	assert.False(t, stillEnabled, "anthropic must be excluded from EnabledProviders on the turn after being struck out")
+}
+
+// TestProxyMessages_BaselineOverloadExhaustionDoesNotDisableAnthropic
+// regression-tests a Cursor Bugbot finding: a session pinned to an OSS
+// provider that exhausts retryably rescues via baseline failover onto
+// Anthropic (finalProvider becomes "anthropic" even though the sticky pin's
+// own provider is the OSS one). If that Anthropic RESCUE attempt itself
+// exhausts on 529 twice across turns, the two-strike breaker must not
+// disable Anthropic or evict the unrelated OSS pin -- doing so would both
+// misattribute the strike (Anthropic didn't cause the original failure) and
+// remove the exact rescue hatch the overload window needs.
+func TestProxyMessages_BaselineOverloadExhaustionDoesNotDisableAnthropic(t *testing.T) {
+	ossUpstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusServiceUnavailable)
+		_, _ = w.Write([]byte(`{"error":{"message":"oss provider down"}}`))
+	}))
+	defer ossUpstream.Close()
+
+	anthropicUpstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, "event: error\ndata: {\"type\":\"error\",\"error\":{\"type\":\"overloaded_error\",\"message\":\"Overloaded\"}}\n\n")
+	}))
+	defer anthropicUpstream.Close()
+
+	store := newFakePinStore()
+	store.hasPin = true
+	store.pin = sessionpin.Pin{
+		Provider:      providers.ProviderFireworks,
+		Model:         "deepseek/deepseek-v4-pro",
+		Reason:        "fresh",
+		PinnedUntil:   time.Now().Add(30 * time.Minute),
+		FirstPinnedAt: time.Now().Add(-5 * time.Minute),
+	}
+	fr := &fakeRouter{decision: router.Decision{Provider: providers.ProviderFireworks, Model: "deepseek/deepseek-v4-pro", Reason: "fresh"}}
+	svc := proxy.NewService(
+		fr,
+		map[string]providers.Client{
+			providers.ProviderFireworks: openaicompat.NewClient("test-fw-key", ossUpstream.URL),
+			providers.ProviderAnthropic: anthropic.NewClient("test-key", anthropicUpstream.URL),
+		},
+		nil, false, nil, store, false, providers.ProviderAnthropic, "claude-haiku-4-5", nil,
+	).WithDeploymentKeyedProviders(map[string]struct{}{
+		providers.ProviderFireworks: {},
+		providers.ProviderAnthropic: {},
+	}).WithPlannerEnabled(false)
+
+	ctx := authedCtx(uuid.New().String())
+	// "model" resolves baselineFor to claude-haiku-4-5 (a known Anthropic
+	// catalog model), so a retryable OSS exhaustion rescues onto Anthropic.
+	body := []byte(`{"model":"claude-haiku-4-5","stream":true,"messages":[{"role":"user","content":"hi"}]}`)
+
+	// Turn 1: OSS primary 503s (retryable), baseline rescues onto Anthropic,
+	// which itself exhausts on 529. First Anthropic strike, not yet disabled.
+	rec1 := httptest.NewRecorder()
+	req1 := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(""))
+	err1 := svc.ProxyMessages(ctx, body, rec1, req1)
+	require.Error(t, err1)
+	assert.Empty(t, store.disabledProviders, "one baseline-rescue exhaustion must not yet disable anthropic")
+
+	// Turn 2: same OSS-fails-then-Anthropic-529s sequence. Without the fix,
+	// this would be the second consecutive Anthropic strike and disable it.
+	rec2 := httptest.NewRecorder()
+	req2 := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(""))
+	err2 := svc.ProxyMessages(ctx, body, rec2, req2)
+	require.Error(t, err2)
+	assert.Empty(t, store.disabledProviders,
+		"anthropic must never be disabled for 529s hit only via baseline rescue of an unrelated OSS pin")
+	assert.True(t, store.hasPin, "the OSS pin must not be evicted by a baseline-rescue overload strike")
+	assert.Equal(t, "deepseek/deepseek-v4-pro", store.pin.Model, "the OSS pin's identity must be untouched")
 }
 
 func TestProxyMessages_ResponsesFailureBeforeOutputFallsBackToBaseline(t *testing.T) {

--- a/internal/proxy/failover_integration_test.go
+++ b/internal/proxy/failover_integration_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"workweave/router/internal/providers"
 	"workweave/router/internal/providers/anthropic"
@@ -16,7 +17,9 @@ import (
 	"workweave/router/internal/providers/openaicompat"
 	"workweave/router/internal/proxy"
 	"workweave/router/internal/router"
+	"workweave/router/internal/router/sessionpin"
 
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -366,6 +369,71 @@ func TestProxyMessages_AnthropicSSEOverloadExhaustionRecords529(t *testing.T) {
 	assert.Contains(t, rec.Body.String(), "overloaded_error")
 	row := telemetry.firstRow(t)
 	assert.Equal(t, int32(529), row.UpstreamStatusCode)
+}
+
+// TestProxyMessages_TwoConsecutiveOverloadExhaustionsDisableProvider drives
+// two full turns against a sticky pin, each exhausting on the SSE
+// overloaded_error stub (same shape as
+// TestProxyMessages_AnthropicSSEOverloadExhaustionRecords529 above), and
+// asserts the pin's disabled_providers gains "anthropic" after the second,
+// and the scorer's next Route call no longer carries anthropic in
+// EnabledProviders.
+func TestProxyMessages_TwoConsecutiveOverloadExhaustionsDisableProvider(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, "event: error\ndata: {\"type\":\"error\",\"error\":{\"type\":\"overloaded_error\",\"message\":\"Overloaded\"}}\n\n")
+	}))
+	defer upstream.Close()
+
+	store := newFakePinStore()
+	store.hasPin = true
+	store.pin = sessionpin.Pin{
+		Provider:      providers.ProviderAnthropic,
+		Model:         "claude-haiku-4-5",
+		Reason:        "fresh",
+		PinnedUntil:   time.Now().Add(30 * time.Minute),
+		FirstPinnedAt: time.Now().Add(-5 * time.Minute),
+	}
+	fr := &fakeRouter{decision: router.Decision{Provider: providers.ProviderAnthropic, Model: "claude-haiku-4-5", Reason: "fresh"}}
+	svc := proxy.NewService(
+		fr,
+		map[string]providers.Client{providers.ProviderAnthropic: anthropic.NewClient("test-key", upstream.URL)},
+		nil, false, nil, store, false, providers.ProviderAnthropic, "claude-haiku-4-5", nil,
+	).WithDeploymentKeyedProviders(map[string]struct{}{providers.ProviderAnthropic: {}}).
+		WithPlannerEnabled(false) // first-decision-wins: a pin hit serves straight through without scorer-vs-planner EV noise.
+
+	ctx := authedCtx(uuid.New().String())
+	body := []byte(`{"model":"claude-haiku-4-5","stream":true,"messages":[{"role":"user","content":"hi"}]}`)
+
+	// Turn 1: exhausts on 529, one strike recorded, not yet disabled.
+	rec1 := httptest.NewRecorder()
+	req1 := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(""))
+	err1 := svc.ProxyMessages(ctx, body, rec1, req1)
+	var upstreamErr *providers.UpstreamErrorResponse
+	require.ErrorAs(t, err1, &upstreamErr)
+	assert.Equal(t, 529, upstreamErr.Status)
+	assert.Empty(t, store.disabledProviders, "one exhausted 529 must not yet disable the provider")
+
+	// Turn 2: exhausts on 529 again — second consecutive strike disables
+	// anthropic for the session and evicts the pin.
+	rec2 := httptest.NewRecorder()
+	req2 := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(""))
+	err2 := svc.ProxyMessages(ctx, body, rec2, req2)
+	require.ErrorAs(t, err2, &upstreamErr)
+	require.Contains(t, store.disabledProviders, providers.ProviderAnthropic,
+		"second consecutive exhausted 529 must strike the provider out for the session")
+
+	// Turn 3: the pin was evicted (Provider/Model cleared), so this turn is a
+	// fresh scorer call. The disabled provider must be excluded from
+	// EnabledProviders even though it's the only deployment-keyed provider —
+	// proving the exclusion actually reaches the scorer, not just the pin row.
+	rec3 := httptest.NewRecorder()
+	req3 := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(""))
+	_ = svc.ProxyMessages(ctx, body, rec3, req3)
+	require.NotNil(t, fr.capturedReq)
+	_, stillEnabled := fr.capturedReq.EnabledProviders[providers.ProviderAnthropic]
+	assert.False(t, stillEnabled, "anthropic must be excluded from EnabledProviders on the turn after being struck out")
 }
 
 func TestProxyMessages_ResponsesFailureBeforeOutputFallsBackToBaseline(t *testing.T) {

--- a/internal/proxy/force_model_pin_ttl_internal_test.go
+++ b/internal/proxy/force_model_pin_ttl_internal_test.go
@@ -37,6 +37,15 @@ func (s *recordingPinStore) IncrementUpstreamErrors(context.Context, [sessionpin
 func (s *recordingPinStore) ResetUpstreamErrors(context.Context, [sessionpin.SessionKeyLen]byte, string) error {
 	return nil
 }
+func (s *recordingPinStore) IncrementOverloadErrors(context.Context, [sessionpin.SessionKeyLen]byte, string) (int, error) {
+	return 0, nil
+}
+func (s *recordingPinStore) ResetOverloadErrors(context.Context, [sessionpin.SessionKeyLen]byte, string) error {
+	return nil
+}
+func (s *recordingPinStore) DisableProvider(context.Context, [sessionpin.SessionKeyLen]byte, string, string) error {
+	return nil
+}
 func (s *recordingPinStore) SweepExpired(context.Context) error { return nil }
 
 // TestPinExpiry_UserForcedNeverExpires is the regression for the debug-session

--- a/internal/proxy/force_model_tier_fallback_internal_test.go
+++ b/internal/proxy/force_model_tier_fallback_internal_test.go
@@ -65,6 +65,15 @@ func (s *forcedPinStore) IncrementUpstreamErrors(context.Context, [sessionpin.Se
 func (s *forcedPinStore) ResetUpstreamErrors(context.Context, [sessionpin.SessionKeyLen]byte, string) error {
 	return nil
 }
+func (s *forcedPinStore) IncrementOverloadErrors(context.Context, [sessionpin.SessionKeyLen]byte, string) (int, error) {
+	return 0, nil
+}
+func (s *forcedPinStore) ResetOverloadErrors(context.Context, [sessionpin.SessionKeyLen]byte, string) error {
+	return nil
+}
+func (s *forcedPinStore) DisableProvider(context.Context, [sessionpin.SessionKeyLen]byte, string, string) error {
+	return nil
+}
 func (s *forcedPinStore) SweepExpired(context.Context) error { return nil }
 
 type overwritingPinStore struct {
@@ -94,6 +103,15 @@ func (s *overwritingPinStore) IncrementUpstreamErrors(context.Context, [sessionp
 	return 0, nil
 }
 func (s *overwritingPinStore) ResetUpstreamErrors(context.Context, [sessionpin.SessionKeyLen]byte, string) error {
+	return nil
+}
+func (s *overwritingPinStore) IncrementOverloadErrors(context.Context, [sessionpin.SessionKeyLen]byte, string) (int, error) {
+	return 0, nil
+}
+func (s *overwritingPinStore) ResetOverloadErrors(context.Context, [sessionpin.SessionKeyLen]byte, string) error {
+	return nil
+}
+func (s *overwritingPinStore) DisableProvider(context.Context, [sessionpin.SessionKeyLen]byte, string, string) error {
 	return nil
 }
 func (s *overwritingPinStore) SweepExpired(context.Context) error { return nil }

--- a/internal/proxy/force_model_tier_fallback_internal_test.go
+++ b/internal/proxy/force_model_tier_fallback_internal_test.go
@@ -209,6 +209,57 @@ func TestRunTurnLoop_ForcedModelOverridesHardPin(t *testing.T) {
 	assert.Empty(t, fr.captured, "a forced pin must not invoke the scorer")
 }
 
+// Regression (Bugbot): a user-forced pin targeting exactly a provider this
+// session already struck out for repeated 529 exhaustion must still serve
+// through the fast path -- the circuit breaker exists to steer AUTOMATIC
+// re-routing away from an overloaded provider, not to silently override an
+// explicit /force-model choice. Before the fix, DisabledProviders was
+// subtracted from EnabledProviders unconditionally, so a forced pin's own
+// eligibility check (providerEligible) would see its provider excluded and
+// fall through to normal routing, ignoring the user's directive.
+func TestRunTurnLoop_ForcedModelServesDespiteDisabledProvider(t *testing.T) {
+	store := &forcedPinStore{pin: sessionpin.Pin{
+		Provider:          providers.ProviderAnthropic,
+		Model:             "claude-opus-4-8",
+		Reason:            translate.ReasonUserForceModel,
+		PinnedUntil:       time.Now().Add(time.Hour),
+		DisabledProviders: []string{providers.ProviderAnthropic},
+	}}
+	fr := &tierProbeRouter{available: map[string]struct{}{"claude-haiku-4-5": {}}}
+	svc := NewService(
+		fr,
+		nil,
+		nil,
+		false,
+		nil,
+		store,
+		false,
+		providers.ProviderAnthropic,
+		"claude-haiku-4-5",
+		nil,
+	)
+
+	env, err := translate.ParseAnthropic([]byte(`{
+		"model":"claude-opus-4-8",
+		"messages":[{"role":"user","content":"hello"}]
+	}`))
+	require.NoError(t, err)
+	feats := env.RoutingFeatures(false)
+
+	res, err := svc.runTurnLoop(context.Background(), env, feats, "key-1", uuid.New(), "", nil, router.Request{
+		RequestedModel:   feats.Model,
+		EnabledProviders: map[string]struct{}{providers.ProviderAnthropic: {}},
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, "claude-opus-4-8", res.Decision.Model,
+		"force-model must serve through the pinned provider despite the session-level disable")
+	assert.Equal(t, providers.ProviderAnthropic, res.Decision.Provider)
+	assert.Equal(t, translate.ReasonUserForceModel, res.Decision.Reason)
+	assert.True(t, res.StickyHit)
+	assert.Empty(t, fr.captured, "a forced pin must not invoke the scorer")
+}
+
 func TestForceModelHeader_OverridesHardPin(t *testing.T) {
 	store := &overwritingPinStore{pin: sessionpin.Pin{
 		Provider:    providers.ProviderAnthropic,

--- a/internal/proxy/force_model_tier_fallback_internal_test.go
+++ b/internal/proxy/force_model_tier_fallback_internal_test.go
@@ -209,14 +209,9 @@ func TestRunTurnLoop_ForcedModelOverridesHardPin(t *testing.T) {
 	assert.Empty(t, fr.captured, "a forced pin must not invoke the scorer")
 }
 
-// Regression (Bugbot): a user-forced pin targeting exactly a provider this
-// session already struck out for repeated 529 exhaustion must still serve
-// through the fast path -- the circuit breaker exists to steer AUTOMATIC
-// re-routing away from an overloaded provider, not to silently override an
-// explicit /force-model choice. Before the fix, DisabledProviders was
-// subtracted from EnabledProviders unconditionally, so a forced pin's own
-// eligibility check (providerEligible) would see its provider excluded and
-// fall through to normal routing, ignoring the user's directive.
+// Regression: a forced pin targeting a session-struck-out provider must
+// serve through the fast path; the breaker skips force-model to avoid
+// silently reverting an explicit user choice.
 func TestRunTurnLoop_ForcedModelServesDespiteDisabledProvider(t *testing.T) {
 	store := &forcedPinStore{pin: sessionpin.Pin{
 		Provider:          providers.ProviderAnthropic,

--- a/internal/proxy/gemini.go
+++ b/internal/proxy/gemini.go
@@ -294,11 +294,9 @@ func (s *Service) ProxyGeminiGenerateContent(ctx context.Context, body []byte, w
 		s.emitBilling(ctx, requestID, externalID, decision, actPricing, routeRes, in, out, cacheCreation, cacheRead)
 	}
 
-	// Two-strike provider disable: see ProxyMessages for the rationale.
-	// Native Gemini rarely produces a real 529 (it isn't a Google API
-	// status), but this covers a future translate-layer path that
-	// synthesizes one, and costs nothing when it never fires.
-	s.maybeDisableProviderAfterOverload(ctx, stickyHit, proxyErr, finalProvider, decision.Reason, installationID, routeRes.SessionKey, stickyStateRole(routeRes))
+	// Two-strike provider disable: see ProxyMessages. Gemini rarely produces a
+	// real 529, but covers a future translate-layer path that might synthesize one.
+	s.maybeDisableProviderAfterOverload(ctx, stickyHit, proxyErr, finalProvider, decision.Reason, installationID, routeRes.SessionKey, stickyStateRole(routeRes), routeRes.PinRole)
 
 	log.Info("ProxyGeminiGenerateContent complete", append([]any{"requested_model", feats.Model, "baseline_model", s.baselineFor(feats.Model), "decision_model", decision.Model, "decision_provider", decision.Provider, "decision_reason", decision.Reason, "embedded_tokens", len(promptText) / 4, "total_input_tokens", feats.Tokens, "has_tools", feats.HasTools, "embed_input", embedInput, "sticky_hit", stickyHit, "pin_tier", pinTier, "turn_type", string(tt), "route_ms", routeMs, "proxy_ms", proxyMs, "proxy_err", proxyErr, "upstream_status", upstreamStatus(proxyErr)}, plannerLogFields(routeRes)...)...)
 	s.reportPolicyOutcome(ctx, routeRes, decision, decision.Provider, feats.Tokens, in, out, cacheCreation, cacheRead, routeMs, proxyMs, proxyErr, nil)

--- a/internal/proxy/gemini.go
+++ b/internal/proxy/gemini.go
@@ -115,6 +115,9 @@ func (s *Service) ProxyGeminiGenerateContent(ctx context.Context, body []byte, w
 		log.Error("Routing failed for Gemini request", "err", err, "route_ms", routeMs, "requested_model", feats.Model, "total_input_tokens", feats.Tokens)
 		return err
 	}
+	if len(routeRes.SessionDisabledProviders) > 0 {
+		ctx = context.WithValue(ctx, SessionDisabledProvidersContextKey{}, routeRes.SessionDisabledProviders)
+	}
 	routeRes.SuggestionMode = r.Header.Get("x-weave-suggestion-mode") == "true"
 	decision := routeRes.Decision
 	s.firePolicyShadowForServingDecision(ctx, decision, routeRequest)
@@ -228,7 +231,7 @@ func (s *Service) ProxyGeminiGenerateContent(ctx context.Context, body []byte, w
 		}
 		return err
 	}
-	_, proxyErr := s.dispatchWithFallback(ctx, failoverInputs{
+	winnerIdx, proxyErr := s.dispatchWithFallback(ctx, failoverInputs{
 		w:               contentSink,
 		buf:             preludeBuf,
 		initialDecision: decision,
@@ -237,6 +240,10 @@ func (s *Service) ProxyGeminiGenerateContent(ctx context.Context, body []byte, w
 		flushErr:        flushBufferedIfPresent,
 	})
 	proxyMs := time.Since(proxyStart).Milliseconds()
+	finalProvider := decision.Provider
+	if winnerIdx >= 0 && winnerIdx < len(bindings) {
+		finalProvider = bindings[winnerIdx].Provider
+	}
 
 	in, out := extractor.Tokens()
 	cacheCreation, cacheRead := extractor.CacheTokens()
@@ -281,11 +288,17 @@ func (s *Service) ProxyGeminiGenerateContent(ctx context.Context, body []byte, w
 
 	// Persist last-turn usage to the pin row so the next turn's planner
 	// has cache-hit evidence. Off the request path; drops on saturation.
-	s.recordTurnUsage(routeRes, decision.Provider, decision.Model, in, out, cacheCreation, cacheRead)
+	s.recordTurnUsage(routeRes, finalProvider, decision.Model, in, out, cacheCreation, cacheRead)
 
 	if proxyErr == nil {
 		s.emitBilling(ctx, requestID, externalID, decision, actPricing, routeRes, in, out, cacheCreation, cacheRead)
 	}
+
+	// Two-strike provider disable: see ProxyMessages for the rationale.
+	// Native Gemini rarely produces a real 529 (it isn't a Google API
+	// status), but this covers a future translate-layer path that
+	// synthesizes one, and costs nothing when it never fires.
+	s.maybeDisableProviderAfterOverload(ctx, stickyHit, proxyErr, finalProvider, decision.Reason, installationID, routeRes.SessionKey, stickyStateRole(routeRes))
 
 	log.Info("ProxyGeminiGenerateContent complete", append([]any{"requested_model", feats.Model, "baseline_model", s.baselineFor(feats.Model), "decision_model", decision.Model, "decision_provider", decision.Provider, "decision_reason", decision.Reason, "embedded_tokens", len(promptText) / 4, "total_input_tokens", feats.Tokens, "has_tools", feats.HasTools, "embed_input", embedInput, "sticky_hit", stickyHit, "pin_tier", pinTier, "turn_type", string(tt), "route_ms", routeMs, "proxy_ms", proxyMs, "proxy_err", proxyErr, "upstream_status", upstreamStatus(proxyErr)}, plannerLogFields(routeRes)...)...)
 	s.reportPolicyOutcome(ctx, routeRes, decision, decision.Provider, feats.Tokens, in, out, cacheCreation, cacheRead, routeMs, proxyMs, proxyErr, nil)

--- a/internal/proxy/pin_eviction_internal_test.go
+++ b/internal/proxy/pin_eviction_internal_test.go
@@ -61,6 +61,18 @@ func (s *evictionStubPinStore) ResetUpstreamErrors(context.Context, [sessionpin.
 	return nil
 }
 
+func (s *evictionStubPinStore) IncrementOverloadErrors(context.Context, [sessionpin.SessionKeyLen]byte, string) (int, error) {
+	return 0, nil
+}
+
+func (s *evictionStubPinStore) ResetOverloadErrors(context.Context, [sessionpin.SessionKeyLen]byte, string) error {
+	return nil
+}
+
+func (s *evictionStubPinStore) DisableProvider(context.Context, [sessionpin.SessionKeyLen]byte, string, string) error {
+	return nil
+}
+
 func (s *evictionStubPinStore) SweepExpired(context.Context) error { return nil }
 
 func newEvictionTestService(store *evictionStubPinStore) *Service {

--- a/internal/proxy/provider_overload.go
+++ b/internal/proxy/provider_overload.go
@@ -22,15 +22,11 @@ const providerOverloadStrikeThreshold = 2
 // maybeDisableProviderAfterOverload applies the two-strike overload policy for
 // a sticky-pin turn: success resets the counter; a 529 exhaustion increments it;
 // hitting providerOverloadStrikeThreshold appends finalProvider to
-// DisabledProviders and evicts both the active and HMM-history pin rows so the
+// DisabledProviders and evicts both pin rows (active + HMM history) so the
 // next turn re-routes around it. No-ops when !stickyHit, zero session key,
 // uuid.Nil installation, user-forced pin, or non-529 error.
-//
-// role is the tracking row that actually served this turn (stickyStateRole:
-// PinRole on a normal sticky hit, the _hmm_history role on an HMM stay).
-// pinRole is always the base PinRole (never the _hmm_history variant), used
-// to expire both rows: an HMM-sticky turn stores strikes on _hmm_history but
-// hmmStayPin reads from both rows, so on threshold both must be cleared.
+// role is stickyStateRole (PinRole or _hmm_history); pinRole is always the
+// base role — expireSessionPinAndHMMHistory needs the pair computed from it.
 func (s *Service) maybeDisableProviderAfterOverload(
 	ctx context.Context,
 	stickyHit bool,
@@ -87,12 +83,8 @@ func (s *Service) maybeDisableProviderAfterOverload(
 		log.Error("pin provider-disable upsert failed", "err", err, "role", role, "provider", finalProvider)
 		return
 	}
-	// Expire both the active pin and its HMM history row: an HMM-sticky turn
-	// stores strikes on _hmm_history, but the next turn's hmmStayPin considers
-	// both rows (activePin and hmmHistory) as stay candidates, and a live
-	// active-pin row with the same provider would let the overloaded provider
-	// slip through. Uses pinRole (the base role, never history-suffixed) so
-	// expireSessionPinAndHMMHistory computes the pair correctly.
+	// Expire both rows: hmmStayPin considers activePin and hmmHistory as stay
+	// candidates, so a surviving active-pin row lets the overloaded provider slip through.
 	if pinRole == "" {
 		pinRole = sessionpin.DefaultRole
 	}

--- a/internal/proxy/provider_overload.go
+++ b/internal/proxy/provider_overload.go
@@ -1,0 +1,119 @@
+package proxy
+
+import (
+	"context"
+	"strings"
+
+	"workweave/router/internal/observability"
+	"workweave/router/internal/router/sessionpin"
+	"workweave/router/internal/translate"
+
+	"github.com/google/uuid"
+)
+
+// providerOverloadedStatus is the HTTP status Anthropic's SSE prelude
+// synthesizes for an in-stream `overloaded_error` event
+// (anthropic.anthropicOverloadedStatus). It is the only "provider is out of
+// capacity, not just a transient 5xx" signal in this codebase today — other
+// 5xx/429/408 are ordinary transient faults already handled by
+// dispatchWithFallback's retry/failover loop.
+const providerOverloadedStatus = 529
+
+// providerOverloadStrikeThreshold mirrors pinEvictionStrikeThreshold: two
+// consecutive turns that exhaust with a client-visible 529 on the same
+// pinned provider before it's struck out for the rest of the session. One
+// tolerates a single blip that clears on the next turn; a second confirms
+// the provider is genuinely out of capacity right now.
+const providerOverloadStrikeThreshold = 2
+
+// maybeDisableProviderAfterOverload applies the two-strike overload policy
+// for a turn run against a sticky pin: a successful turn resets the strike
+// counter, a turn that exhausts with a client-visible 529 increments it, and
+// hitting providerOverloadStrikeThreshold adds finalProvider to the pin's
+// DisabledProviders set and evicts the pin so the next turn re-routes around
+// it.
+//
+// finalProvider is the binding that actually served (or last attempted) this
+// turn — dispatchWithFallback may have already walked away from the
+// routing decision's original provider before exhausting, and it's the
+// provider that just proved unreliable, not necessarily decision.Provider,
+// that must be struck out.
+//
+// No-ops when there's no decision history yet (!stickyHit), no addressable
+// pin row (zero session_key/installation_id), the pin was user-forced (user
+// keeps /unforce-model as the escape hatch), or the error isn't a 529.
+// Ordinary retryable 5xx/429/408 from other providers already have
+// dispatchWithFallback's retry/failover and don't touch this counter — a
+// generic "any 5xx trips this" policy would strike out a provider for one
+// unlucky blip instead of confirmed sustained overload. Errors from the
+// increment/disable/upsert are logged and swallowed since this is
+// best-effort and must not change the client-visible outcome.
+func (s *Service) maybeDisableProviderAfterOverload(
+	ctx context.Context,
+	stickyHit bool,
+	proxyErr error,
+	finalProvider string,
+	decisionReason string,
+	installationID uuid.UUID,
+	sessionKey [sessionpin.SessionKeyLen]byte,
+	role string,
+) {
+	if !stickyHit || s.pinStore == nil || installationID == uuid.Nil {
+		return
+	}
+	if sessionKey == ([sessionpin.SessionKeyLen]byte{}) {
+		return
+	}
+	// Prefix check covers both ReasonUserForceModel and its tier_clamp suffix.
+	if strings.HasPrefix(decisionReason, translate.ReasonUserForceModel) {
+		return
+	}
+
+	log := observability.FromContext(ctx)
+
+	if proxyErr == nil {
+		// context.Background(): the request ctx is already canceled by the
+		// time streaming finishes, but this reset must still go through.
+		if err := s.pinStore.ResetOverloadErrors(context.Background(), sessionKey, role); err != nil {
+			log.Error("pin overload-counter reset failed", "err", err, "role", role)
+		}
+		return
+	}
+
+	if upstreamStatus(proxyErr) != providerOverloadedStatus {
+		return
+	}
+
+	count, err := s.pinStore.IncrementOverloadErrors(context.Background(), sessionKey, role)
+	if err != nil {
+		log.Error("pin overload-counter increment failed", "err", err, "role", role, "provider", finalProvider)
+		return
+	}
+	if count < providerOverloadStrikeThreshold {
+		log.Debug("pin overload-counter incremented",
+			"role", role,
+			"provider", finalProvider,
+			"consecutive_overload_errors", count,
+			"strike_threshold", providerOverloadStrikeThreshold,
+		)
+		return
+	}
+
+	if err := s.pinStore.DisableProvider(context.Background(), sessionKey, role, finalProvider); err != nil {
+		log.Error("pin provider-disable upsert failed", "err", err, "role", role, "provider", finalProvider)
+		return
+	}
+	// Expire via a PinnedUntil in the past, same pattern as loop-break /
+	// no-progress / force-model, so loadPin discards it next turn and the
+	// scorer re-routes with the newly-disabled provider excluded.
+	if err := s.expireSessionPin(ctx, installationID, sessionKey, role, "provider_overloaded"); err != nil {
+		log.Error("pin eviction after provider overload failed", "err", err, "role", role, "provider", finalProvider)
+		return
+	}
+	log.Info("provider disabled for session after consecutive overload errors",
+		"role", role,
+		"provider", finalProvider,
+		"consecutive_overload_errors", count,
+		"strike_threshold", providerOverloadStrikeThreshold,
+	)
+}

--- a/internal/proxy/provider_overload.go
+++ b/internal/proxy/provider_overload.go
@@ -22,9 +22,15 @@ const providerOverloadStrikeThreshold = 2
 // maybeDisableProviderAfterOverload applies the two-strike overload policy for
 // a sticky-pin turn: success resets the counter; a 529 exhaustion increments it;
 // hitting providerOverloadStrikeThreshold appends finalProvider to
-// DisabledProviders and evicts the pin so the next turn re-routes around it.
-// No-ops when !stickyHit, zero session key, uuid.Nil installation, user-forced
-// pin, or non-529 error.
+// DisabledProviders and evicts both the active and HMM-history pin rows so the
+// next turn re-routes around it. No-ops when !stickyHit, zero session key,
+// uuid.Nil installation, user-forced pin, or non-529 error.
+//
+// role is the tracking row that actually served this turn (stickyStateRole:
+// PinRole on a normal sticky hit, the _hmm_history role on an HMM stay).
+// pinRole is always the base PinRole (never the _hmm_history variant), used
+// to expire both rows: an HMM-sticky turn stores strikes on _hmm_history but
+// hmmStayPin reads from both rows, so on threshold both must be cleared.
 func (s *Service) maybeDisableProviderAfterOverload(
 	ctx context.Context,
 	stickyHit bool,
@@ -34,6 +40,7 @@ func (s *Service) maybeDisableProviderAfterOverload(
 	installationID uuid.UUID,
 	sessionKey [sessionpin.SessionKeyLen]byte,
 	role string,
+	pinRole string,
 ) {
 	if !stickyHit || s.pinStore == nil || installationID == uuid.Nil {
 		return
@@ -80,11 +87,17 @@ func (s *Service) maybeDisableProviderAfterOverload(
 		log.Error("pin provider-disable upsert failed", "err", err, "role", role, "provider", finalProvider)
 		return
 	}
-	// Expire via a PinnedUntil in the past, same pattern as loop-break /
-	// no-progress / force-model, so loadPin discards it next turn and the
-	// scorer re-routes with the newly-disabled provider excluded.
-	if err := s.expireSessionPin(ctx, installationID, sessionKey, role, "provider_overloaded"); err != nil {
-		log.Error("pin eviction after provider overload failed", "err", err, "role", role, "provider", finalProvider)
+	// Expire both the active pin and its HMM history row: an HMM-sticky turn
+	// stores strikes on _hmm_history, but the next turn's hmmStayPin considers
+	// both rows (activePin and hmmHistory) as stay candidates, and a live
+	// active-pin row with the same provider would let the overloaded provider
+	// slip through. Uses pinRole (the base role, never history-suffixed) so
+	// expireSessionPinAndHMMHistory computes the pair correctly.
+	if pinRole == "" {
+		pinRole = sessionpin.DefaultRole
+	}
+	if err := s.expireSessionPinAndHMMHistory(ctx, installationID, sessionKey, pinRole, "provider_overloaded"); err != nil {
+		log.Error("pin eviction after provider overload failed", "err", err, "role", role, "pin_role", pinRole, "provider", finalProvider)
 		return
 	}
 	log.Info("provider disabled for session after consecutive overload errors",

--- a/internal/proxy/provider_overload.go
+++ b/internal/proxy/provider_overload.go
@@ -19,14 +19,12 @@ const providerOverloadedStatus = 529
 // consecutive 529-exhausted turns before the provider is struck out for the session.
 const providerOverloadStrikeThreshold = 2
 
-// maybeDisableProviderAfterOverload applies the two-strike overload policy for
-// a sticky-pin turn: success resets the counter; a 529 exhaustion increments it;
-// hitting providerOverloadStrikeThreshold appends finalProvider to
-// DisabledProviders and evicts both pin rows (active + HMM history) so the
-// next turn re-routes around it. No-ops when !stickyHit, zero session key,
-// uuid.Nil installation, user-forced pin, or non-529 error.
-// role is stickyStateRole (PinRole or _hmm_history); pinRole is always the
-// base role — expireSessionPinAndHMMHistory needs the pair computed from it.
+// maybeDisableProviderAfterOverload applies the two-strike overload policy:
+// success resets the counter; a 529 exhaustion increments it; hitting the
+// threshold disables finalProvider for the session and evicts both pin rows.
+// No-ops when !stickyHit, zero session key, uuid.Nil installation,
+// user-forced pin, or non-529 error. role is stickyStateRole; pinRole is
+// the base role needed by expireSessionPinAndHMMHistory.
 func (s *Service) maybeDisableProviderAfterOverload(
 	ctx context.Context,
 	stickyHit bool,

--- a/internal/proxy/provider_overload.go
+++ b/internal/proxy/provider_overload.go
@@ -11,43 +11,20 @@ import (
 	"github.com/google/uuid"
 )
 
-// providerOverloadedStatus is the HTTP status Anthropic's SSE prelude
-// synthesizes for an in-stream `overloaded_error` event
-// (anthropic.anthropicOverloadedStatus). It is the only "provider is out of
-// capacity, not just a transient 5xx" signal in this codebase today — other
-// 5xx/429/408 are ordinary transient faults already handled by
-// dispatchWithFallback's retry/failover loop.
+// providerOverloadedStatus is the HTTP status Anthropic synthesizes for an
+// in-stream overloaded_error; distinct from ordinary 5xx/429 transient faults.
 const providerOverloadedStatus = 529
 
 // providerOverloadStrikeThreshold mirrors pinEvictionStrikeThreshold: two
-// consecutive turns that exhaust with a client-visible 529 on the same
-// pinned provider before it's struck out for the rest of the session. One
-// tolerates a single blip that clears on the next turn; a second confirms
-// the provider is genuinely out of capacity right now.
+// consecutive 529-exhausted turns before the provider is struck out for the session.
 const providerOverloadStrikeThreshold = 2
 
-// maybeDisableProviderAfterOverload applies the two-strike overload policy
-// for a turn run against a sticky pin: a successful turn resets the strike
-// counter, a turn that exhausts with a client-visible 529 increments it, and
-// hitting providerOverloadStrikeThreshold adds finalProvider to the pin's
-// DisabledProviders set and evicts the pin so the next turn re-routes around
-// it.
-//
-// finalProvider is the binding that actually served (or last attempted) this
-// turn — dispatchWithFallback may have already walked away from the
-// routing decision's original provider before exhausting, and it's the
-// provider that just proved unreliable, not necessarily decision.Provider,
-// that must be struck out.
-//
-// No-ops when there's no decision history yet (!stickyHit), no addressable
-// pin row (zero session_key/installation_id), the pin was user-forced (user
-// keeps /unforce-model as the escape hatch), or the error isn't a 529.
-// Ordinary retryable 5xx/429/408 from other providers already have
-// dispatchWithFallback's retry/failover and don't touch this counter — a
-// generic "any 5xx trips this" policy would strike out a provider for one
-// unlucky blip instead of confirmed sustained overload. Errors from the
-// increment/disable/upsert are logged and swallowed since this is
-// best-effort and must not change the client-visible outcome.
+// maybeDisableProviderAfterOverload applies the two-strike overload policy for
+// a sticky-pin turn: success resets the counter; a 529 exhaustion increments it;
+// hitting providerOverloadStrikeThreshold appends finalProvider to
+// DisabledProviders and evicts the pin so the next turn re-routes around it.
+// No-ops when !stickyHit, zero session key, uuid.Nil installation, user-forced
+// pin, or non-529 error.
 func (s *Service) maybeDisableProviderAfterOverload(
 	ctx context.Context,
 	stickyHit bool,

--- a/internal/proxy/provider_overload_internal_test.go
+++ b/internal/proxy/provider_overload_internal_test.go
@@ -177,11 +177,8 @@ func TestMaybeDisableProviderAfterOverload_SuccessResets(t *testing.T) {
 	assert.Empty(t, store.upserts)
 }
 
-// Ordinary retryable errors (exhausted 5xx/429/408 from any provider) must
-// not touch the overload counter — dispatchWithFallback's retry/failover
-// already covers those, and treating every retryable exhaustion as a
-// overload strike would disable a provider on one unlucky blip instead of
-// confirmed sustained overload.
+// Non-529 exhaustion (5xx/429/408) must not touch the overload counter;
+// dispatchWithFallback's retry/failover already handles those.
 func TestMaybeDisableProviderAfterOverload_NonOverloadStatusIgnored(t *testing.T) {
 	for _, status := range []int{http.StatusRequestTimeout, http.StatusTooManyRequests, http.StatusInternalServerError, http.StatusBadGateway, http.StatusServiceUnavailable, http.StatusBadRequest} {
 		store := &overloadStubPinStore{incrementNext: []int{99}}

--- a/internal/proxy/provider_overload_internal_test.go
+++ b/internal/proxy/provider_overload_internal_test.go
@@ -94,9 +94,8 @@ func newOverloadTestService(store *overloadStubPinStore) *Service {
 	)
 }
 
-// A single exhausted 529 must increment the counter but not disable the
-// provider — disable waits for a second consecutive strike so one blip
-// doesn't strike out a provider that clears on the next turn.
+// A single exhausted 529 must increment the counter but not disable
+// the provider — two consecutive strikes are required.
 func TestMaybeDisableProviderAfterOverload_FirstStrikeOnlyIncrements(t *testing.T) {
 	store := &overloadStubPinStore{incrementNext: []int{1}}
 	svc := newOverloadTestService(store)

--- a/internal/proxy/provider_overload_internal_test.go
+++ b/internal/proxy/provider_overload_internal_test.go
@@ -110,7 +110,7 @@ func TestMaybeDisableProviderAfterOverload_FirstStrikeOnlyIncrements(t *testing.
 		"cluster:v0.57 model=claude-sonnet-5 provider=anthropic",
 		uuid.New(),
 		nonZeroSessionKey(),
-		sessionpin.DefaultRole,
+		sessionpin.DefaultRole, sessionpin.DefaultRole,
 	)
 
 	assert.Equal(t, 1, store.incrementCalls, "first exhausted 529 must increment exactly once")
@@ -137,15 +137,17 @@ func TestMaybeDisableProviderAfterOverload_SecondStrikeDisablesAndEvicts(t *test
 		"cluster:v0.57 model=claude-sonnet-5 provider=anthropic",
 		installationID,
 		sessionKey,
-		sessionpin.DefaultRole,
+		sessionpin.DefaultRole, sessionpin.DefaultRole,
 	)
 
 	require.Len(t, store.disabledProviders, 1)
 	assert.Equal(t, "anthropic", store.disabledProviders[0])
-	require.Len(t, store.upserts, 1, "threshold strike must trigger an expired-pin upsert")
+	require.Len(t, store.upserts, 2, "threshold strike must expire both the main pin and its HMM history row")
 	expired := store.upserts[0]
 	assert.Equal(t, sessionpin.DefaultRole, expired.Role)
 	assert.Equal(t, installationID, expired.InstallationID)
+	// Second upsert is the HMM history row.
+	assert.Equal(t, hmmHistoryRole(sessionpin.DefaultRole), store.upserts[1].Role, "must expire the _hmm_history row too")
 	assert.Empty(t, expired.Provider, "expired pin must clear provider so loadPin discards it")
 	assert.Empty(t, expired.Model, "expired pin must clear model so loadPin discards it")
 	assert.True(t, expired.PinnedUntil.Before(time.Now()),
@@ -168,7 +170,7 @@ func TestMaybeDisableProviderAfterOverload_SuccessResets(t *testing.T) {
 		"cluster:v0.57 model=claude-sonnet-5 provider=anthropic",
 		uuid.New(),
 		nonZeroSessionKey(),
-		sessionpin.DefaultRole,
+		sessionpin.DefaultRole, sessionpin.DefaultRole,
 	)
 
 	assert.Equal(t, 1, store.resetCalls, "successful turn on a sticky pin must clear the overload strike counter")
@@ -192,7 +194,7 @@ func TestMaybeDisableProviderAfterOverload_NonOverloadStatusIgnored(t *testing.T
 			"cluster:v0.57 model=claude-sonnet-5 provider=anthropic",
 			uuid.New(),
 			nonZeroSessionKey(),
-			sessionpin.DefaultRole,
+			sessionpin.DefaultRole, sessionpin.DefaultRole,
 		)
 
 		assert.Zero(t, store.incrementCalls, "status %d is not a 529 and must not bump the overload counter", status)
@@ -216,7 +218,7 @@ func TestMaybeDisableProviderAfterOverload_UserForcedSkipped(t *testing.T) {
 			reason,
 			uuid.New(),
 			nonZeroSessionKey(),
-			sessionpin.DefaultRole,
+			sessionpin.DefaultRole, sessionpin.DefaultRole,
 		)
 
 		assert.Zero(t, store.incrementCalls, "user-forced pins (%q) must skip the counter increment", reason)
@@ -238,7 +240,7 @@ func TestMaybeDisableProviderAfterOverload_NoStickyHitSkipped(t *testing.T) {
 		"cluster:v0.57 model=claude-sonnet-5 provider=anthropic",
 		uuid.New(),
 		nonZeroSessionKey(),
-		sessionpin.DefaultRole,
+		sessionpin.DefaultRole, sessionpin.DefaultRole,
 	)
 
 	assert.Zero(t, store.incrementCalls)
@@ -259,7 +261,7 @@ func TestMaybeDisableProviderAfterOverload_ZeroSessionKeySkipped(t *testing.T) {
 		"cluster:v0.57 model=claude-sonnet-5 provider=anthropic",
 		uuid.New(),
 		[sessionpin.SessionKeyLen]byte{}, // zero key
-		sessionpin.DefaultRole,
+		sessionpin.DefaultRole, sessionpin.DefaultRole,
 	)
 
 	assert.Zero(t, store.incrementCalls)
@@ -280,7 +282,7 @@ func TestMaybeDisableProviderAfterOverload_NilInstallationSkipped(t *testing.T) 
 		"cluster:v0.57 model=claude-sonnet-5 provider=anthropic",
 		uuid.Nil,
 		nonZeroSessionKey(),
-		sessionpin.DefaultRole,
+		sessionpin.DefaultRole, sessionpin.DefaultRole,
 	)
 
 	assert.Zero(t, store.incrementCalls)
@@ -301,7 +303,7 @@ func TestMaybeDisableProviderAfterOverload_NonUpstreamErrorIgnored(t *testing.T)
 		"cluster:v0.57 model=claude-sonnet-5 provider=anthropic",
 		uuid.New(),
 		nonZeroSessionKey(),
-		sessionpin.DefaultRole,
+		sessionpin.DefaultRole, sessionpin.DefaultRole,
 	)
 
 	assert.Zero(t, store.incrementCalls)

--- a/internal/proxy/provider_overload_internal_test.go
+++ b/internal/proxy/provider_overload_internal_test.go
@@ -1,0 +1,312 @@
+package proxy
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"sync"
+	"testing"
+	"time"
+
+	"workweave/router/internal/providers"
+	"workweave/router/internal/router/sessionpin"
+	"workweave/router/internal/translate"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// overloadStubPinStore records overload-counter and provider-disable calls
+// so each two-strike branch can be asserted independently; incrementNext
+// drives the threshold directly, mirroring evictionStubPinStore.
+type overloadStubPinStore struct {
+	mu                sync.Mutex
+	incrementCalls    int
+	incrementNext     []int // values returned by IncrementOverloadErrors, in order
+	resetCalls        int
+	disabledProviders []string
+	upserts           []sessionpin.Pin
+}
+
+func (s *overloadStubPinStore) Get(context.Context, [sessionpin.SessionKeyLen]byte, string) (sessionpin.Pin, bool, error) {
+	return sessionpin.Pin{}, false, nil
+}
+
+func (s *overloadStubPinStore) Upsert(_ context.Context, p sessionpin.Pin) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.upserts = append(s.upserts, p)
+	return nil
+}
+
+func (s *overloadStubPinStore) UpdateUsage(context.Context, [sessionpin.SessionKeyLen]byte, string, sessionpin.Usage) error {
+	return nil
+}
+
+func (s *overloadStubPinStore) IncrementUpstreamErrors(context.Context, [sessionpin.SessionKeyLen]byte, string) (int, error) {
+	return 0, nil
+}
+
+func (s *overloadStubPinStore) ResetUpstreamErrors(context.Context, [sessionpin.SessionKeyLen]byte, string) error {
+	return nil
+}
+
+func (s *overloadStubPinStore) IncrementOverloadErrors(context.Context, [sessionpin.SessionKeyLen]byte, string) (int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.incrementCalls++
+	if len(s.incrementNext) == 0 {
+		return 0, nil
+	}
+	v := s.incrementNext[0]
+	s.incrementNext = s.incrementNext[1:]
+	return v, nil
+}
+
+func (s *overloadStubPinStore) ResetOverloadErrors(context.Context, [sessionpin.SessionKeyLen]byte, string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.resetCalls++
+	return nil
+}
+
+func (s *overloadStubPinStore) DisableProvider(_ context.Context, _ [sessionpin.SessionKeyLen]byte, _, provider string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.disabledProviders = append(s.disabledProviders, provider)
+	return nil
+}
+
+func (s *overloadStubPinStore) SweepExpired(context.Context) error { return nil }
+
+func newOverloadTestService(store *overloadStubPinStore) *Service {
+	return NewService(
+		nil,
+		nil,
+		nil,
+		false,
+		nil,
+		store,
+		false,
+		"anthropic", "claude-haiku-4-5",
+		nil,
+	)
+}
+
+// A single exhausted 529 must increment the counter but not disable the
+// provider — disable waits for a second consecutive strike so one blip
+// doesn't strike out a provider that clears on the next turn.
+func TestMaybeDisableProviderAfterOverload_FirstStrikeOnlyIncrements(t *testing.T) {
+	store := &overloadStubPinStore{incrementNext: []int{1}}
+	svc := newOverloadTestService(store)
+
+	overloadErr := &providers.UpstreamErrorResponse{Status: providerOverloadedStatus}
+	svc.maybeDisableProviderAfterOverload(
+		context.Background(),
+		true, // stickyHit
+		overloadErr,
+		"anthropic",
+		"cluster:v0.57 model=claude-sonnet-5 provider=anthropic",
+		uuid.New(),
+		nonZeroSessionKey(),
+		sessionpin.DefaultRole,
+	)
+
+	assert.Equal(t, 1, store.incrementCalls, "first exhausted 529 must increment exactly once")
+	assert.Equal(t, 0, store.resetCalls, "reset must not fire on a failed turn")
+	assert.Empty(t, store.disabledProviders, "first strike must not disable the provider — waits for strike #2")
+	assert.Empty(t, store.upserts, "first strike must not evict the pin")
+}
+
+// Two consecutive exhausted 529s on the same pinned provider disable it and
+// evict the pin so the next turn re-routes.
+func TestMaybeDisableProviderAfterOverload_SecondStrikeDisablesAndEvicts(t *testing.T) {
+	store := &overloadStubPinStore{incrementNext: []int{providerOverloadStrikeThreshold}}
+	svc := newOverloadTestService(store)
+
+	overloadErr := &providers.UpstreamErrorResponse{Status: providerOverloadedStatus}
+	installationID := uuid.New()
+	sessionKey := nonZeroSessionKey()
+
+	svc.maybeDisableProviderAfterOverload(
+		context.Background(),
+		true,
+		overloadErr,
+		"anthropic",
+		"cluster:v0.57 model=claude-sonnet-5 provider=anthropic",
+		installationID,
+		sessionKey,
+		sessionpin.DefaultRole,
+	)
+
+	require.Len(t, store.disabledProviders, 1)
+	assert.Equal(t, "anthropic", store.disabledProviders[0])
+	require.Len(t, store.upserts, 1, "threshold strike must trigger an expired-pin upsert")
+	expired := store.upserts[0]
+	assert.Equal(t, sessionpin.DefaultRole, expired.Role)
+	assert.Equal(t, installationID, expired.InstallationID)
+	assert.Empty(t, expired.Provider, "expired pin must clear provider so loadPin discards it")
+	assert.Empty(t, expired.Model, "expired pin must clear model so loadPin discards it")
+	assert.True(t, expired.PinnedUntil.Before(time.Now()),
+		"PinnedUntil must be in the past so loadPin's expiry check discards the row")
+	assert.Equal(t, "provider_overloaded", expired.Reason,
+		"eviction reason is the audit trail that distinguishes this path from upstream_error_strike_threshold")
+}
+
+// A successful turn between two 529s must reset the counter, so strikes
+// track consecutive failures, not lifetime ones.
+func TestMaybeDisableProviderAfterOverload_SuccessResets(t *testing.T) {
+	store := &overloadStubPinStore{}
+	svc := newOverloadTestService(store)
+
+	svc.maybeDisableProviderAfterOverload(
+		context.Background(),
+		true,
+		nil, // success
+		"anthropic",
+		"cluster:v0.57 model=claude-sonnet-5 provider=anthropic",
+		uuid.New(),
+		nonZeroSessionKey(),
+		sessionpin.DefaultRole,
+	)
+
+	assert.Equal(t, 1, store.resetCalls, "successful turn on a sticky pin must clear the overload strike counter")
+	assert.Equal(t, 0, store.incrementCalls)
+	assert.Empty(t, store.disabledProviders)
+	assert.Empty(t, store.upserts)
+}
+
+// Ordinary retryable errors (exhausted 5xx/429/408 from any provider) must
+// not touch the overload counter — dispatchWithFallback's retry/failover
+// already covers those, and treating every retryable exhaustion as a
+// overload strike would disable a provider on one unlucky blip instead of
+// confirmed sustained overload.
+func TestMaybeDisableProviderAfterOverload_NonOverloadStatusIgnored(t *testing.T) {
+	for _, status := range []int{http.StatusRequestTimeout, http.StatusTooManyRequests, http.StatusInternalServerError, http.StatusBadGateway, http.StatusServiceUnavailable, http.StatusBadRequest} {
+		store := &overloadStubPinStore{incrementNext: []int{99}}
+		svc := newOverloadTestService(store)
+
+		svc.maybeDisableProviderAfterOverload(
+			context.Background(),
+			true,
+			&providers.UpstreamErrorResponse{Status: status},
+			"anthropic",
+			"cluster:v0.57 model=claude-sonnet-5 provider=anthropic",
+			uuid.New(),
+			nonZeroSessionKey(),
+			sessionpin.DefaultRole,
+		)
+
+		assert.Zero(t, store.incrementCalls, "status %d is not a 529 and must not bump the overload counter", status)
+		assert.Empty(t, store.disabledProviders, "status %d must not disable a provider", status)
+	}
+}
+
+// A force-model'd session must never auto-strike its provider — that would
+// silently revert the user's explicit choice; /unforce-model is the intended
+// escape hatch.
+func TestMaybeDisableProviderAfterOverload_UserForcedSkipped(t *testing.T) {
+	for _, reason := range []string{translate.ReasonUserForceModel, translate.ReasonUserForceModel + "+tier_clamp"} {
+		store := &overloadStubPinStore{incrementNext: []int{providerOverloadStrikeThreshold}}
+		svc := newOverloadTestService(store)
+
+		svc.maybeDisableProviderAfterOverload(
+			context.Background(),
+			true,
+			&providers.UpstreamErrorResponse{Status: providerOverloadedStatus},
+			"anthropic",
+			reason,
+			uuid.New(),
+			nonZeroSessionKey(),
+			sessionpin.DefaultRole,
+		)
+
+		assert.Zero(t, store.incrementCalls, "user-forced pins (%q) must skip the counter increment", reason)
+		assert.Zero(t, store.resetCalls)
+		assert.Empty(t, store.disabledProviders, "user-forced pins must never be auto-struck (%q)", reason)
+	}
+}
+
+// A freshly-scored turn (no sticky pin) has no prior decision to reconsider.
+func TestMaybeDisableProviderAfterOverload_NoStickyHitSkipped(t *testing.T) {
+	store := &overloadStubPinStore{incrementNext: []int{providerOverloadStrikeThreshold}}
+	svc := newOverloadTestService(store)
+
+	svc.maybeDisableProviderAfterOverload(
+		context.Background(),
+		false, // !stickyHit
+		&providers.UpstreamErrorResponse{Status: providerOverloadedStatus},
+		"anthropic",
+		"cluster:v0.57 model=claude-sonnet-5 provider=anthropic",
+		uuid.New(),
+		nonZeroSessionKey(),
+		sessionpin.DefaultRole,
+	)
+
+	assert.Zero(t, store.incrementCalls)
+	assert.Empty(t, store.disabledProviders)
+	assert.Empty(t, store.upserts)
+}
+
+// Guards against a corrupted pin row shared by every zero-keyed caller.
+func TestMaybeDisableProviderAfterOverload_ZeroSessionKeySkipped(t *testing.T) {
+	store := &overloadStubPinStore{incrementNext: []int{providerOverloadStrikeThreshold}}
+	svc := newOverloadTestService(store)
+
+	svc.maybeDisableProviderAfterOverload(
+		context.Background(),
+		true,
+		&providers.UpstreamErrorResponse{Status: providerOverloadedStatus},
+		"anthropic",
+		"cluster:v0.57 model=claude-sonnet-5 provider=anthropic",
+		uuid.New(),
+		[sessionpin.SessionKeyLen]byte{}, // zero key
+		sessionpin.DefaultRole,
+	)
+
+	assert.Zero(t, store.incrementCalls)
+	assert.Empty(t, store.disabledProviders)
+}
+
+// Unauthenticated path (no installation_id) must no-op rather than write a
+// uuid.Nil-installed row to Postgres.
+func TestMaybeDisableProviderAfterOverload_NilInstallationSkipped(t *testing.T) {
+	store := &overloadStubPinStore{incrementNext: []int{providerOverloadStrikeThreshold}}
+	svc := newOverloadTestService(store)
+
+	svc.maybeDisableProviderAfterOverload(
+		context.Background(),
+		true,
+		&providers.UpstreamErrorResponse{Status: providerOverloadedStatus},
+		"anthropic",
+		"cluster:v0.57 model=claude-sonnet-5 provider=anthropic",
+		uuid.Nil,
+		nonZeroSessionKey(),
+		sessionpin.DefaultRole,
+	)
+
+	assert.Zero(t, store.incrementCalls)
+	assert.Empty(t, store.disabledProviders)
+}
+
+// A generic transport/build/context-cancel error has no upstream status and
+// is not a 529, so the overload counter must not advance.
+func TestMaybeDisableProviderAfterOverload_NonUpstreamErrorIgnored(t *testing.T) {
+	store := &overloadStubPinStore{incrementNext: []int{providerOverloadStrikeThreshold}}
+	svc := newOverloadTestService(store)
+
+	svc.maybeDisableProviderAfterOverload(
+		context.Background(),
+		true,
+		errors.New("upstream call: dial tcp: connection refused"),
+		"anthropic",
+		"cluster:v0.57 model=claude-sonnet-5 provider=anthropic",
+		uuid.New(),
+		nonZeroSessionKey(),
+		sessionpin.DefaultRole,
+	)
+
+	assert.Zero(t, store.incrementCalls)
+	assert.Empty(t, store.disabledProviders)
+}

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -2254,11 +2254,8 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 		return routeErr
 	}
 	if len(routeRes.SessionDisabledProviders) > 0 {
-		// Applies the same session-struck-out providers runTurnLoop already
-		// excluded from the scorer to dispatch's failover walk
-		// (resolveBindingsForDispatch reads excludedProvidersForRequest from
-		// ctx, not req.EnabledProviders, which is a local by the time we're
-		// back here).
+		// resolveBindingsForDispatch reads excludedProvidersForRequest from ctx,
+		// not req.EnabledProviders, so stash here for the failover walk too.
 		ctx = context.WithValue(ctx, SessionDisabledProvidersContextKey{}, routeRes.SessionDisabledProviders)
 	}
 
@@ -3181,12 +3178,16 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 	if !agentShadowMode {
 		s.maybeEvictPinAfterUpstreamErr(ctx, stickyHit, proxyErr, decision.Reason, installationID, routeRes.SessionKey, stickyStateRole(routeRes))
 
-		// Two-strike provider disable: a turn that exhausted with a
-		// client-visible 529 strikes finalProvider out of this session after
-		// a second consecutive exhaustion. Distinct counter/mechanism from
-		// the 4xx eviction above -- a 529 is retryable in-turn, so it never
-		// trips that one.
-		s.maybeDisableProviderAfterOverload(ctx, stickyHit, proxyErr, finalProvider, decision.Reason, installationID, routeRes.SessionKey, stickyStateRole(routeRes))
+		// Two-strike provider disable: complements the 4xx eviction above;
+		// 529 is retryable in-turn so it never trips that counter.
+		// Skipped when baseline rescue ran: finalProvider is then Anthropic
+		// even though the sticky pin is the OSS model that actually failed --
+		// disabling Anthropic here would evict an unrelated OSS pin and take
+		// away the rescue hatch this turn just needed, during the exact
+		// overload window this breaker targets.
+		if !baselineAttempted {
+			s.maybeDisableProviderAfterOverload(ctx, stickyHit, proxyErr, finalProvider, decision.Reason, installationID, routeRes.SessionKey, stickyStateRole(routeRes))
+		}
 
 		// Re-pin the session off the refusing model if a cyber refusal was observed.
 		s.maybeRepinOnRefusal(ctx, refusalObs, routeRes.SessionKey, stickyStateRole(routeRes), decision)

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -3178,9 +3178,9 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 		s.maybeEvictPinAfterUpstreamErr(ctx, stickyHit, proxyErr, decision.Reason, installationID, routeRes.SessionKey, stickyStateRole(routeRes))
 
 		// Two-strike provider disable: complements the 4xx eviction above;
-		// 529 is retryable in-turn so it never trips that counter. Skipped
-		// when baseline rescue ran: finalProvider is then Anthropic for a
-		// different pin so disabling Anthropic would evict an unrelated pin.
+		// 529 is retryable in-turn so it never trips that counter.
+		// Skipped when baseline rescue ran: finalProvider is the rescue
+		// provider, not the sticky pin's, so disabling it evicts the wrong pin.
 		if !baselineAttempted {
 			s.maybeDisableProviderAfterOverload(ctx, stickyHit, proxyErr, finalProvider, decision.Reason, installationID, routeRes.SessionKey, stickyStateRole(routeRes), routeRes.PinRole)
 		}

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -322,12 +322,9 @@ type InstallationExcludedModelsContextKey struct{}
 // installation's provider exclusion list. Carried as []string.
 type InstallationExcludedProvidersContextKey struct{}
 
-// SessionDisabledProvidersContextKey is the context key for providers the
-// current session's pin has struck out after repeated 529 exhaustion
-// (turnLoopResult.SessionDisabledProviders / sessionpin.Pin.DisabledProviders).
-// Carried as []string. Stashed by each entry point right after runTurnLoop
-// returns, so resolveBindingsForDispatch's failover walk also honors the
-// exclusion, not just the scorer call runTurnLoop already applied it to.
+// SessionDisabledProvidersContextKey carries providers struck out by repeated
+// 529 exhaustion ([]string). Stashed after runTurnLoop so
+// resolveBindingsForDispatch's failover walk honors the exclusion too.
 type SessionDisabledProvidersContextKey struct{}
 
 // InstallationPreferredModelsContextKey is the context key for the authed
@@ -643,12 +640,8 @@ func sessionDisabledProvidersFromContext(ctx context.Context) []string {
 	return out
 }
 
-// excludedProvidersForRequest returns the request's provider exclusion set:
-// the deployment-wide env override or per-installation list, plus (always,
-// regardless of which of those fired) any providers this session has struck
-// out for repeated 529 exhaustion — an orthogonal, session-scoped signal
-// that must apply on top of the operator/installation-level exclusions, not
-// instead of them.
+// excludedProvidersForRequest merges the deployment/installation exclusion list
+// with any providers this session has struck out for repeated 529 exhaustion.
 func (s *Service) excludedProvidersForRequest(ctx context.Context) map[string]struct{} {
 	var base map[string]struct{}
 	if s.excludedProvidersOverride != nil {

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -628,9 +628,8 @@ func installationExcludedProvidersFromContext(ctx context.Context) []string {
 	return out
 }
 
-// sessionDisabledProvidersFromContext returns the providers the current
-// session's pin has struck out after repeated 529 exhaustion, stashed by
-// SessionDisabledProvidersContextKey.
+// sessionDisabledProvidersFromContext extracts the SessionDisabledProvidersContextKey
+// value set by runTurnLoop.
 func sessionDisabledProvidersFromContext(ctx context.Context) []string {
 	v := ctx.Value(SessionDisabledProvidersContextKey{})
 	if v == nil {

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -3179,14 +3179,11 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 		s.maybeEvictPinAfterUpstreamErr(ctx, stickyHit, proxyErr, decision.Reason, installationID, routeRes.SessionKey, stickyStateRole(routeRes))
 
 		// Two-strike provider disable: complements the 4xx eviction above;
-		// 529 is retryable in-turn so it never trips that counter.
-		// Skipped when baseline rescue ran: finalProvider is then Anthropic
-		// even though the sticky pin is the OSS model that actually failed --
-		// disabling Anthropic here would evict an unrelated OSS pin and take
-		// away the rescue hatch this turn just needed, during the exact
-		// overload window this breaker targets.
+		// 529 is retryable in-turn so it never trips that counter. Skipped
+		// when baseline rescue ran: finalProvider is then Anthropic for a
+		// different pin so disabling Anthropic would evict an unrelated pin.
 		if !baselineAttempted {
-			s.maybeDisableProviderAfterOverload(ctx, stickyHit, proxyErr, finalProvider, decision.Reason, installationID, routeRes.SessionKey, stickyStateRole(routeRes))
+			s.maybeDisableProviderAfterOverload(ctx, stickyHit, proxyErr, finalProvider, decision.Reason, installationID, routeRes.SessionKey, stickyStateRole(routeRes), routeRes.PinRole)
 		}
 
 		// Re-pin the session off the refusing model if a cyber refusal was observed.
@@ -4857,7 +4854,7 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 	// See ProxyMessages for the two-strike eviction rationale.
 	s.maybeEvictPinAfterUpstreamErr(ctx, stickyHit, proxyErr, decision.Reason, installationIDFromContext(ctx), routeRes.SessionKey, stickyStateRole(routeRes))
 	// See ProxyMessages for the two-strike provider-disable rationale.
-	s.maybeDisableProviderAfterOverload(ctx, stickyHit, proxyErr, finalProvider, decision.Reason, installationIDFromContext(ctx), routeRes.SessionKey, stickyStateRole(routeRes))
+	s.maybeDisableProviderAfterOverload(ctx, stickyHit, proxyErr, finalProvider, decision.Reason, installationIDFromContext(ctx), routeRes.SessionKey, stickyStateRole(routeRes), routeRes.PinRole)
 
 	installationIDOAI, _ := ctx.Value(InstallationIDContextKey{}).(string)
 	if installationIDOAI != "" {

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -322,6 +322,14 @@ type InstallationExcludedModelsContextKey struct{}
 // installation's provider exclusion list. Carried as []string.
 type InstallationExcludedProvidersContextKey struct{}
 
+// SessionDisabledProvidersContextKey is the context key for providers the
+// current session's pin has struck out after repeated 529 exhaustion
+// (turnLoopResult.SessionDisabledProviders / sessionpin.Pin.DisabledProviders).
+// Carried as []string. Stashed by each entry point right after runTurnLoop
+// returns, so resolveBindingsForDispatch's failover walk also honors the
+// exclusion, not just the scorer call runTurnLoop already applied it to.
+type SessionDisabledProvidersContextKey struct{}
+
 // InstallationPreferredModelsContextKey is the context key for the authed
 // installation's model priority ranking. Carried as []string in descending
 // preference (index 0 = first preference). See preferredModelsForRequest.
@@ -623,18 +631,43 @@ func installationExcludedProvidersFromContext(ctx context.Context) []string {
 	return out
 }
 
-// excludedProvidersForRequest returns the request's provider exclusion set.
-// Env override wins; otherwise the installation list is converted to a set.
-func (s *Service) excludedProvidersForRequest(ctx context.Context) map[string]struct{} {
-	if s.excludedProvidersOverride != nil {
-		return s.excludedProvidersOverride
-	}
-	excluded := installationExcludedProvidersFromContext(ctx)
-	if len(excluded) == 0 {
+// sessionDisabledProvidersFromContext returns the providers the current
+// session's pin has struck out after repeated 529 exhaustion, stashed by
+// SessionDisabledProvidersContextKey.
+func sessionDisabledProvidersFromContext(ctx context.Context) []string {
+	v := ctx.Value(SessionDisabledProvidersContextKey{})
+	if v == nil {
 		return nil
 	}
-	out := make(map[string]struct{}, len(excluded))
-	for _, p := range excluded {
+	out, _ := v.([]string)
+	return out
+}
+
+// excludedProvidersForRequest returns the request's provider exclusion set:
+// the deployment-wide env override or per-installation list, plus (always,
+// regardless of which of those fired) any providers this session has struck
+// out for repeated 529 exhaustion — an orthogonal, session-scoped signal
+// that must apply on top of the operator/installation-level exclusions, not
+// instead of them.
+func (s *Service) excludedProvidersForRequest(ctx context.Context) map[string]struct{} {
+	var base map[string]struct{}
+	if s.excludedProvidersOverride != nil {
+		base = s.excludedProvidersOverride
+	} else if excluded := installationExcludedProvidersFromContext(ctx); len(excluded) > 0 {
+		base = make(map[string]struct{}, len(excluded))
+		for _, p := range excluded {
+			base[p] = struct{}{}
+		}
+	}
+	sessionDisabled := sessionDisabledProvidersFromContext(ctx)
+	if len(sessionDisabled) == 0 {
+		return base
+	}
+	out := make(map[string]struct{}, len(base)+len(sessionDisabled))
+	for p := range base {
+		out[p] = struct{}{}
+	}
+	for _, p := range sessionDisabled {
 		out[p] = struct{}{}
 	}
 	return out
@@ -2227,6 +2260,14 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 		log.Error("Routing failed", "err", routeErr, "route_ms", time.Since(routeStart).Milliseconds(), "requested_model", feats.Model, "total_input_tokens", feats.Tokens)
 		return routeErr
 	}
+	if len(routeRes.SessionDisabledProviders) > 0 {
+		// Applies the same session-struck-out providers runTurnLoop already
+		// excluded from the scorer to dispatch's failover walk
+		// (resolveBindingsForDispatch reads excludedProvidersForRequest from
+		// ctx, not req.EnabledProviders, which is a local by the time we're
+		// back here).
+		ctx = context.WithValue(ctx, SessionDisabledProvidersContextKey{}, routeRes.SessionDisabledProviders)
+	}
 
 	// On a retryable 429 the bypass falls through to re-routing; rate-limit
 	// headers prime the observer so the retry discounts Anthropic.
@@ -3146,6 +3187,13 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 	// persistent counter hits threshold; successful turns reset it.
 	if !agentShadowMode {
 		s.maybeEvictPinAfterUpstreamErr(ctx, stickyHit, proxyErr, decision.Reason, installationID, routeRes.SessionKey, stickyStateRole(routeRes))
+
+		// Two-strike provider disable: a turn that exhausted with a
+		// client-visible 529 strikes finalProvider out of this session after
+		// a second consecutive exhaustion. Distinct counter/mechanism from
+		// the 4xx eviction above -- a 529 is retryable in-turn, so it never
+		// trips that one.
+		s.maybeDisableProviderAfterOverload(ctx, stickyHit, proxyErr, finalProvider, decision.Reason, installationID, routeRes.SessionKey, stickyStateRole(routeRes))
 
 		// Re-pin the session off the refusing model if a cyber refusal was observed.
 		s.maybeRepinOnRefusal(ctx, refusalObs, routeRes.SessionKey, stickyStateRole(routeRes), decision)
@@ -4342,6 +4390,9 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 		log.Error("Routing failed for OpenAI request", "err", err, "route_ms", routeMs, "requested_model", feats.Model, "total_input_tokens", feats.Tokens)
 		return err
 	}
+	if len(routeRes.SessionDisabledProviders) > 0 {
+		ctx = context.WithValue(ctx, SessionDisabledProvidersContextKey{}, routeRes.SessionDisabledProviders)
+	}
 	routeRes.SuggestionMode = r.Header.Get("x-weave-suggestion-mode") == "true"
 	decision := routeRes.Decision
 	s.firePolicyShadowForServingDecision(ctx, decision, routeRequest)
@@ -4811,6 +4862,8 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 
 	// See ProxyMessages for the two-strike eviction rationale.
 	s.maybeEvictPinAfterUpstreamErr(ctx, stickyHit, proxyErr, decision.Reason, installationIDFromContext(ctx), routeRes.SessionKey, stickyStateRole(routeRes))
+	// See ProxyMessages for the two-strike provider-disable rationale.
+	s.maybeDisableProviderAfterOverload(ctx, stickyHit, proxyErr, finalProvider, decision.Reason, installationIDFromContext(ctx), routeRes.SessionKey, stickyStateRole(routeRes))
 
 	installationIDOAI, _ := ctx.Value(InstallationIDContextKey{}).(string)
 	if installationIDOAI != "" {

--- a/internal/proxy/service_session_pin_test.go
+++ b/internal/proxy/service_session_pin_test.go
@@ -125,10 +125,8 @@ func (f *fakePinStore) IncrementOverloadErrors(ctx context.Context, key [session
 	if !f.hasPin {
 		return 0, nil
 	}
-	// Real incrementing (unlike IncrementUpstreamErrors' canned-return
-	// above) so a multi-turn test can observe the counter actually
-	// accumulate across ProxyMessages calls, the way the real two-strike
-	// disable path depends on.
+	// Real (accumulating) counter so multi-turn integration tests observe
+	// consecutive strikes, unlike IncrementUpstreamErrors' canned return.
 	f.pin.ConsecutiveOverloadErrors++
 	return f.pin.ConsecutiveOverloadErrors, nil
 }

--- a/internal/proxy/service_session_pin_test.go
+++ b/internal/proxy/service_session_pin_test.go
@@ -28,20 +28,23 @@ import (
 )
 
 type fakePinStore struct {
-	mu               sync.Mutex
-	pin              sessionpin.Pin
-	hasPin           bool
-	hmmHistory       sessionpin.Pin
-	hasHMMHistory    bool
-	getErr           error
-	getCalls         int
-	upserts          []sessionpin.Pin
-	upsertCh         chan struct{}
-	usages           []sessionpin.Usage
-	usageCh          chan struct{}
-	incrementCalls   int
-	incrementReturns int // value returned by IncrementUpstreamErrors when hasPin is true
-	resetCalls       int
+	mu                     sync.Mutex
+	pin                    sessionpin.Pin
+	hasPin                 bool
+	hmmHistory             sessionpin.Pin
+	hasHMMHistory          bool
+	getErr                 error
+	getCalls               int
+	upserts                []sessionpin.Pin
+	upsertCh               chan struct{}
+	usages                 []sessionpin.Usage
+	usageCh                chan struct{}
+	incrementCalls         int
+	incrementReturns       int // value returned by IncrementUpstreamErrors when hasPin is true
+	resetCalls             int
+	overloadIncrementCalls int
+	overloadResetCalls     int
+	disabledProviders      []string
 }
 
 func newFakePinStore() *fakePinStore {
@@ -112,6 +115,47 @@ func (f *fakePinStore) ResetUpstreamErrors(ctx context.Context, key [sessionpin.
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.resetCalls++
+	return nil
+}
+
+func (f *fakePinStore) IncrementOverloadErrors(ctx context.Context, key [sessionpin.SessionKeyLen]byte, role string) (int, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.overloadIncrementCalls++
+	if !f.hasPin {
+		return 0, nil
+	}
+	// Real incrementing (unlike IncrementUpstreamErrors' canned-return
+	// above) so a multi-turn test can observe the counter actually
+	// accumulate across ProxyMessages calls, the way the real two-strike
+	// disable path depends on.
+	f.pin.ConsecutiveOverloadErrors++
+	return f.pin.ConsecutiveOverloadErrors, nil
+}
+
+func (f *fakePinStore) ResetOverloadErrors(ctx context.Context, key [sessionpin.SessionKeyLen]byte, role string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.overloadResetCalls++
+	if f.hasPin {
+		f.pin.ConsecutiveOverloadErrors = 0
+	}
+	return nil
+}
+
+func (f *fakePinStore) DisableProvider(ctx context.Context, key [sessionpin.SessionKeyLen]byte, role, provider string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.disabledProviders = append(f.disabledProviders, provider)
+	if f.hasPin {
+		for _, p := range f.pin.DisabledProviders {
+			if p == provider {
+				return nil
+			}
+		}
+		f.pin.DisabledProviders = append(f.pin.DisabledProviders, provider)
+		f.pin.ConsecutiveOverloadErrors = 0
+	}
 	return nil
 }
 

--- a/internal/proxy/turnloop.go
+++ b/internal/proxy/turnloop.go
@@ -435,8 +435,32 @@ func (s *Service) runTurnLoop(
 	// routing miss, but DisabledProviders on that same row must still steer
 	// the scorer away from the just-struck-out provider on this very turn --
 	// otherwise the eviction only prevents re-anchoring, not re-selection.
-	if len(pin.DisabledProviders) > 0 {
-		res.SessionDisabledProviders = pin.DisabledProviders
+	disabledProviders := pin.DisabledProviders
+	// A user-forced pin (/force-model) targeting exactly a struck-out
+	// provider must still be able to retry it: the circuit breaker exists to
+	// steer AUTOMATIC re-routing away from an overloaded provider, not to
+	// silently override the user's explicit choice -- Bugbot correctly
+	// flagged that Upsert never clears disabled_providers, so a forced pin
+	// re-hitting a previously-disabled provider would otherwise fail
+	// providerEligible below and silently fall through to normal routing.
+	// /unforce-model remains the escape hatch out of a bad forced pin.
+	// Loop-escalation is deliberately excluded here: it's an automatic
+	// safety pin (tool-call loop detected), not a user override, so it must
+	// still respect the breaker like any other automatic decision. Every
+	// other struck-out provider stays excluded, so a fresh-routing fallback
+	// (if this pin turns out ineligible on some other dimension below)
+	// still avoids them.
+	if pinFound && pin.Provider != "" && isUserForcedReason(pin.Reason) {
+		filtered := make([]string, 0, len(disabledProviders))
+		for _, p := range disabledProviders {
+			if p != pin.Provider {
+				filtered = append(filtered, p)
+			}
+		}
+		disabledProviders = filtered
+	}
+	if len(disabledProviders) > 0 {
+		res.SessionDisabledProviders = disabledProviders
 		// nil EnabledProviders means "unrestricted" elsewhere in this file
 		// (see forcedPinEligible); there's no concrete universe to subtract
 		// from here, so leave it alone rather than manufacture an empty map
@@ -446,7 +470,7 @@ func (s *Service) runTurnLoop(
 			for p := range req.EnabledProviders {
 				filtered[p] = struct{}{}
 			}
-			for _, p := range pin.DisabledProviders {
+			for _, p := range disabledProviders {
 				delete(filtered, p)
 			}
 			req.EnabledProviders = filtered

--- a/internal/proxy/turnloop.go
+++ b/internal/proxy/turnloop.go
@@ -455,8 +455,8 @@ func (s *Service) runTurnLoop(
 	hmmHistory := s.loadHMMHistory(ctx, res.SessionKey, res.PinRole)
 	// Applied regardless of pinFound: eviction sets PinnedUntil in the past
 	// (routing miss) but DisabledProviders must still steer the scorer away
-	// from the struck-out provider this same turn. Merged from both rows:
-	// HMM-sticky strikes write to _hmm_history, not PinRole.
+	// from the struck-out provider this same turn; HMM-sticky strikes write
+	// to _hmm_history, not PinRole, so either row can carry evidence.
 	disabledProviders := mergeDisabledProviders(pin.DisabledProviders, hmmHistory.DisabledProviders)
 	// User-forced pin exempts its own provider: an explicit /force-model
 	// must not be silently reverted by the session-level breaker.

--- a/internal/proxy/turnloop.go
+++ b/internal/proxy/turnloop.go
@@ -147,11 +147,9 @@ type turnLoopResult struct {
 	// the escalate-on-failure policy (Service.effortEscalation) reads it to
 	// bump a gpt-5.x turn from low to high effort, and is a no-op when disabled.
 	EscalateEffort bool
-	// SessionDisabledProviders are providers this pin's session has struck
-	// out after repeated 529 exhaustion (sessionpin.Pin.DisabledProviders).
-	// The caller stashes this on ctx so it also excludes those providers
-	// from resolveBindingsForDispatch's failover walk, not just this turn's
-	// scorer call.
+	// SessionDisabledProviders are providers struck out by repeated 529
+	// exhaustion. Stashed on ctx so resolveBindingsForDispatch's failover
+	// walk also honors the exclusion, not just this turn's scorer.
 	SessionDisabledProviders []string
 }
 
@@ -455,14 +453,10 @@ func (s *Service) runTurnLoop(
 
 	pin, pinFound := s.loadPin(ctx, res.SessionKey, res.PinRole)
 	hmmHistory := s.loadHMMHistory(ctx, res.SessionKey, res.PinRole)
-	// Providers this session has struck out after repeated 529 exhaustion
-	// (provider_overload.go). Applied regardless of pinFound: an overload
-	// eviction deliberately sets PinnedUntil in the past so the pin is a
-	// routing miss, but DisabledProviders on that same row must still steer
-	// the scorer away from the just-struck-out provider on this very turn --
-	// otherwise the eviction only prevents re-anchoring, not re-selection.
-	// Merged from both pin and hmmHistory: HMM-sticky strikes write to
-	// stickyStateRole (_hmm_history), not PinRole, so either row can carry evidence.
+	// Applied regardless of pinFound: eviction sets PinnedUntil in the past
+	// (routing miss) but DisabledProviders must still steer the scorer away
+	// from the struck-out provider this same turn. Merged from both rows:
+	// HMM-sticky strikes write to _hmm_history, not PinRole.
 	disabledProviders := mergeDisabledProviders(pin.DisabledProviders, hmmHistory.DisabledProviders)
 	// User-forced pin (/force-model) exempts its own provider from the
 	// breaker so an explicit override isn't silently ignored; loop-escalation
@@ -478,10 +472,8 @@ func (s *Service) runTurnLoop(
 	}
 	if len(disabledProviders) > 0 {
 		res.SessionDisabledProviders = disabledProviders
-		// nil EnabledProviders means "unrestricted" elsewhere in this file
-		// (see forcedPinEligible); there's no concrete universe to subtract
-		// from here, so leave it alone rather than manufacture an empty map
-		// that would wrongly read as "every provider excluded."
+		// nil EnabledProviders means "unrestricted"; skip rather than
+		// produce an empty map that reads as "every provider excluded."
 		if req.EnabledProviders != nil {
 			filtered := make(map[string]struct{}, len(req.EnabledProviders))
 			for p := range req.EnabledProviders {

--- a/internal/proxy/turnloop.go
+++ b/internal/proxy/turnloop.go
@@ -458,9 +458,8 @@ func (s *Service) runTurnLoop(
 	// from the struck-out provider this same turn. Merged from both rows:
 	// HMM-sticky strikes write to _hmm_history, not PinRole.
 	disabledProviders := mergeDisabledProviders(pin.DisabledProviders, hmmHistory.DisabledProviders)
-	// User-forced pin (/force-model) exempts its own provider from the
-	// breaker so an explicit override isn't silently ignored; loop-escalation
-	// (automatic) is not exempt and still respects the exclusion.
+	// User-forced pin exempts its own provider: an explicit /force-model
+	// must not be silently reverted by the session-level breaker.
 	if pinFound && pin.Provider != "" && isUserForcedReason(pin.Reason) {
 		filtered := make([]string, 0, len(disabledProviders))
 		for _, p := range disabledProviders {

--- a/internal/proxy/turnloop.go
+++ b/internal/proxy/turnloop.go
@@ -121,6 +121,12 @@ type turnLoopResult struct {
 	// the escalate-on-failure policy (Service.effortEscalation) reads it to
 	// bump a gpt-5.x turn from low to high effort, and is a no-op when disabled.
 	EscalateEffort bool
+	// SessionDisabledProviders are providers this pin's session has struck
+	// out after repeated 529 exhaustion (sessionpin.Pin.DisabledProviders).
+	// The caller stashes this on ctx so it also excludes those providers
+	// from resolveBindingsForDispatch's failover walk, not just this turn's
+	// scorer call.
+	SessionDisabledProviders []string
 }
 
 // modelSwitched reports whether the Anthropic emit path must strip historical
@@ -423,6 +429,29 @@ func (s *Service) runTurnLoop(
 
 	pin, pinFound := s.loadPin(ctx, res.SessionKey, res.PinRole)
 	hmmHistory := s.loadHMMHistory(ctx, res.SessionKey, res.PinRole)
+	// Providers this session has struck out after repeated 529 exhaustion
+	// (provider_overload.go). Applied regardless of pinFound: an overload
+	// eviction deliberately sets PinnedUntil in the past so the pin is a
+	// routing miss, but DisabledProviders on that same row must still steer
+	// the scorer away from the just-struck-out provider on this very turn --
+	// otherwise the eviction only prevents re-anchoring, not re-selection.
+	if len(pin.DisabledProviders) > 0 {
+		res.SessionDisabledProviders = pin.DisabledProviders
+		// nil EnabledProviders means "unrestricted" elsewhere in this file
+		// (see forcedPinEligible); there's no concrete universe to subtract
+		// from here, so leave it alone rather than manufacture an empty map
+		// that would wrongly read as "every provider excluded."
+		if req.EnabledProviders != nil {
+			filtered := make(map[string]struct{}, len(req.EnabledProviders))
+			for p := range req.EnabledProviders {
+				filtered[p] = struct{}{}
+			}
+			for _, p := range pin.DisabledProviders {
+				delete(filtered, p)
+			}
+			req.EnabledProviders = filtered
+		}
+	}
 	res.PriorServedModel, res.SessionEverSwitched = switchHistoryFromPins(pin, hmmHistory)
 	req.PolicyTurnContext = buildPolicyTurnContext(req, res, pin, hmmHistory)
 	// Computed before any same-turn pin-drop guards below so it reflects the

--- a/internal/proxy/turnloop.go
+++ b/internal/proxy/turnloop.go
@@ -436,20 +436,9 @@ func (s *Service) runTurnLoop(
 	// the scorer away from the just-struck-out provider on this very turn --
 	// otherwise the eviction only prevents re-anchoring, not re-selection.
 	disabledProviders := pin.DisabledProviders
-	// A user-forced pin (/force-model) targeting exactly a struck-out
-	// provider must still be able to retry it: the circuit breaker exists to
-	// steer AUTOMATIC re-routing away from an overloaded provider, not to
-	// silently override the user's explicit choice -- Bugbot correctly
-	// flagged that Upsert never clears disabled_providers, so a forced pin
-	// re-hitting a previously-disabled provider would otherwise fail
-	// providerEligible below and silently fall through to normal routing.
-	// /unforce-model remains the escape hatch out of a bad forced pin.
-	// Loop-escalation is deliberately excluded here: it's an automatic
-	// safety pin (tool-call loop detected), not a user override, so it must
-	// still respect the breaker like any other automatic decision. Every
-	// other struck-out provider stays excluded, so a fresh-routing fallback
-	// (if this pin turns out ineligible on some other dimension below)
-	// still avoids them.
+	// User-forced pin (/force-model) exempts its own provider from the
+	// breaker so an explicit override isn't silently ignored; loop-escalation
+	// (automatic) is not exempt and still respects the exclusion.
 	if pinFound && pin.Provider != "" && isUserForcedReason(pin.Reason) {
 		filtered := make([]string, 0, len(disabledProviders))
 		for _, p := range disabledProviders {

--- a/internal/proxy/turnloop.go
+++ b/internal/proxy/turnloop.go
@@ -35,10 +35,8 @@ func addToSet(set map[string]struct{}, model string) map[string]struct{} {
 	return out
 }
 
-// mergeDisabledProviders unions two pins' DisabledProviders (deduped, order
-// not significant): the active pin and its HMM history row can each carry
-// independent overload strikes (see the runTurnLoop call site), so either
-// alone would miss a provider struck out on the other row.
+// mergeDisabledProviders unions two pins' DisabledProviders (deduped): either
+// the active pin or its HMM history row can carry overload strikes independently.
 func mergeDisabledProviders(a, b []string) []string {
 	if len(a) == 0 {
 		return b
@@ -463,10 +461,8 @@ func (s *Service) runTurnLoop(
 	// routing miss, but DisabledProviders on that same row must still steer
 	// the scorer away from the just-struck-out provider on this very turn --
 	// otherwise the eviction only prevents re-anchoring, not re-selection.
-	// Merged from BOTH pin and hmmHistory: an HMM-sticky turn's strikes/
-	// disable write to stickyStateRole, which is the _hmm_history role, not
-	// PinRole (mirrors switchHistoryFromPins' activePin+hmmHistory merge
-	// below for the same reason -- either row can carry the evidence).
+	// Merged from both pin and hmmHistory: HMM-sticky strikes write to
+	// stickyStateRole (_hmm_history), not PinRole, so either row can carry evidence.
 	disabledProviders := mergeDisabledProviders(pin.DisabledProviders, hmmHistory.DisabledProviders)
 	// User-forced pin (/force-model) exempts its own provider from the
 	// breaker so an explicit override isn't silently ignored; loop-escalation

--- a/internal/proxy/turnloop.go
+++ b/internal/proxy/turnloop.go
@@ -35,6 +35,34 @@ func addToSet(set map[string]struct{}, model string) map[string]struct{} {
 	return out
 }
 
+// mergeDisabledProviders unions two pins' DisabledProviders (deduped, order
+// not significant): the active pin and its HMM history row can each carry
+// independent overload strikes (see the runTurnLoop call site), so either
+// alone would miss a provider struck out on the other row.
+func mergeDisabledProviders(a, b []string) []string {
+	if len(a) == 0 {
+		return b
+	}
+	if len(b) == 0 {
+		return a
+	}
+	seen := make(map[string]struct{}, len(a)+len(b))
+	out := make([]string, 0, len(a)+len(b))
+	for _, p := range a {
+		if _, ok := seen[p]; !ok {
+			seen[p] = struct{}{}
+			out = append(out, p)
+		}
+	}
+	for _, p := range b {
+		if _, ok := seen[p]; !ok {
+			seen[p] = struct{}{}
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
 // installationIDFromContext reads the installation ID stashed by auth
 // middleware. Returns uuid.Nil (which skips the async pin upsert) if missing or invalid.
 func installationIDFromContext(ctx context.Context) uuid.UUID {
@@ -435,7 +463,11 @@ func (s *Service) runTurnLoop(
 	// routing miss, but DisabledProviders on that same row must still steer
 	// the scorer away from the just-struck-out provider on this very turn --
 	// otherwise the eviction only prevents re-anchoring, not re-selection.
-	disabledProviders := pin.DisabledProviders
+	// Merged from BOTH pin and hmmHistory: an HMM-sticky turn's strikes/
+	// disable write to stickyStateRole, which is the _hmm_history role, not
+	// PinRole (mirrors switchHistoryFromPins' activePin+hmmHistory merge
+	// below for the same reason -- either row can carry the evidence).
+	disabledProviders := mergeDisabledProviders(pin.DisabledProviders, hmmHistory.DisabledProviders)
 	// User-forced pin (/force-model) exempts its own provider from the
 	// breaker so an explicit override isn't silently ignored; loop-escalation
 	// (automatic) is not exempt and still respects the exclusion.

--- a/internal/proxy/turnloop_internal_test.go
+++ b/internal/proxy/turnloop_internal_test.go
@@ -66,6 +66,18 @@ func (s *stubPinStore) ResetUpstreamErrors(context.Context, [sessionpin.SessionK
 	return nil
 }
 
+func (s *stubPinStore) IncrementOverloadErrors(context.Context, [sessionpin.SessionKeyLen]byte, string) (int, error) {
+	return 0, nil
+}
+
+func (s *stubPinStore) ResetOverloadErrors(context.Context, [sessionpin.SessionKeyLen]byte, string) error {
+	return nil
+}
+
+func (s *stubPinStore) DisableProvider(context.Context, [sessionpin.SessionKeyLen]byte, string, string) error {
+	return nil
+}
+
 func (s *stubPinStore) SweepExpired(context.Context) error { return nil }
 
 // TestRecordTurnUsage_WritesToStore guards the synchronous UpdateUsage write:

--- a/internal/router/sessionpin/store.go
+++ b/internal/router/sessionpin/store.go
@@ -64,6 +64,17 @@ type Pin struct {
 	// thinking blocks from an earlier cross-model excursion are stripped on
 	// every later turn, not just the one the switch happened on.
 	HasEverSwitched bool
+	// ConsecutiveOverloadErrors counts consecutive turns that exhausted with a
+	// client-visible 529 (Anthropic overloaded_error) on the currently-pinned
+	// provider. Distinct from ConsecutiveUpstreamErrors: a 529 is retryable
+	// in-turn (same-binding retry + cross-binding failover), so it never
+	// trips that counter. DisableProvider resets this to 0 when it fires.
+	ConsecutiveOverloadErrors int
+	// DisabledProviders are providers struck out for this pin's session after
+	// repeated 529 exhaustion (see DisableProvider). Only grows for the life
+	// of the row -- Upsert never touches it -- so a struck-out provider stays
+	// disabled until the pin itself is evicted/expires.
+	DisabledProviders []string
 }
 
 // Usage captures the previous turn's upstream token accounting.
@@ -100,5 +111,15 @@ type Store interface {
 	UpdateUsage(ctx context.Context, sessionKey [SessionKeyLen]byte, role string, usage Usage) error
 	IncrementUpstreamErrors(ctx context.Context, sessionKey [SessionKeyLen]byte, role string) (int, error)
 	ResetUpstreamErrors(ctx context.Context, sessionKey [SessionKeyLen]byte, role string) error
+	// IncrementOverloadErrors atomically bumps ConsecutiveOverloadErrors and
+	// returns the new count, mirroring IncrementUpstreamErrors but for
+	// client-visible 529 exhaustion instead of non-retryable 4xx.
+	IncrementOverloadErrors(ctx context.Context, sessionKey [SessionKeyLen]byte, role string) (int, error)
+	// ResetOverloadErrors clears ConsecutiveOverloadErrors after a successful
+	// turn, mirroring ResetUpstreamErrors.
+	ResetOverloadErrors(ctx context.Context, sessionKey [SessionKeyLen]byte, role string) error
+	// DisableProvider appends provider to DisabledProviders (deduped) and
+	// resets ConsecutiveOverloadErrors in the same write.
+	DisableProvider(ctx context.Context, sessionKey [SessionKeyLen]byte, role, provider string) error
 	SweepExpired(ctx context.Context) error
 }

--- a/internal/router/sessionpin/store.go
+++ b/internal/router/sessionpin/store.go
@@ -68,10 +68,9 @@ type Pin struct {
 	// pinned provider. Distinct from ConsecutiveUpstreamErrors: a 529 is
 	// retryable in-turn, so it never trips that counter.
 	ConsecutiveOverloadErrors int
-	// DisabledProviders are providers struck out for this pin's session after
-	// repeated 529 exhaustion (see DisableProvider). Only grows for the life
-	// of the row -- Upsert never touches it -- so a struck-out provider stays
-	// disabled until the pin itself is evicted/expires.
+	// DisabledProviders are providers struck out for this pin's session
+	// after repeated 529 exhaustion (see DisableProvider). Only grows for
+	// the life of the row; Upsert never touches it.
 	DisabledProviders []string
 }
 

--- a/internal/router/sessionpin/store.go
+++ b/internal/router/sessionpin/store.go
@@ -64,11 +64,9 @@ type Pin struct {
 	// thinking blocks from an earlier cross-model excursion are stripped on
 	// every later turn, not just the one the switch happened on.
 	HasEverSwitched bool
-	// ConsecutiveOverloadErrors counts consecutive turns that exhausted with a
-	// client-visible 529 (Anthropic overloaded_error) on the currently-pinned
-	// provider. Distinct from ConsecutiveUpstreamErrors: a 529 is retryable
-	// in-turn (same-binding retry + cross-binding failover), so it never
-	// trips that counter. DisableProvider resets this to 0 when it fires.
+	// ConsecutiveOverloadErrors counts consecutive 529-exhausted turns on the
+	// pinned provider. Distinct from ConsecutiveUpstreamErrors: a 529 is
+	// retryable in-turn, so it never trips that counter.
 	ConsecutiveOverloadErrors int
 	// DisabledProviders are providers struck out for this pin's session after
 	// repeated 529 exhaustion (see DisableProvider). Only grows for the life

--- a/internal/sqlc/models.go
+++ b/internal/sqlc/models.go
@@ -429,6 +429,8 @@ type RouterSessionPin struct {
 	HasEverSwitched           bool
 	PairedProvider            string
 	PairedModel               string
+	ConsecutiveOverloadErrors int32
+	DisabledProviders         []string
 }
 
 // Shadow-mode spiral (death-march) detections: log-only fire-rate corpus measured on live traffic before escalation is armed

--- a/internal/sqlc/session_pins.sql.go
+++ b/internal/sqlc/session_pins.sql.go
@@ -363,6 +363,16 @@ ON CONFLICT (session_key, role) DO UPDATE SET
     WHEN router.session_pins.pinned_model = EXCLUDED.pinned_model
       THEN router.session_pins.consecutive_upstream_errors
     ELSE 0
+  END,
+  -- Mirrors consecutive_upstream_errors above: a stray 529 strike must not
+  -- survive an unrelated pin rewrite (degenerate eviction, loop-break, 4xx
+  -- eviction, planner switch) onto a different model, or one 529 on the
+  -- fresh pin could immediately hit the two-strike threshold instead of
+  -- requiring two genuine consecutive strikes on the SAME served provider.
+  consecutive_overload_errors = CASE
+    WHEN router.session_pins.pinned_model = EXCLUDED.pinned_model
+      THEN router.session_pins.consecutive_overload_errors
+    ELSE 0
   END
 `
 
@@ -448,6 +458,16 @@ type UpsertSessionPinParams struct {
 //	  consecutive_upstream_errors = CASE
 //	    WHEN router.session_pins.pinned_model = EXCLUDED.pinned_model
 //	      THEN router.session_pins.consecutive_upstream_errors
+//	    ELSE 0
+//	  END,
+//	  -- Mirrors consecutive_upstream_errors above: a stray 529 strike must not
+//	  -- survive an unrelated pin rewrite (degenerate eviction, loop-break, 4xx
+//	  -- eviction, planner switch) onto a different model, or one 529 on the
+//	  -- fresh pin could immediately hit the two-strike threshold instead of
+//	  -- requiring two genuine consecutive strikes on the SAME served provider.
+//	  consecutive_overload_errors = CASE
+//	    WHEN router.session_pins.pinned_model = EXCLUDED.pinned_model
+//	      THEN router.session_pins.consecutive_overload_errors
 //	    ELSE 0
 //	  END
 func (q *Queries) UpsertSessionPin(ctx context.Context, arg UpsertSessionPinParams) error {

--- a/internal/sqlc/session_pins.sql.go
+++ b/internal/sqlc/session_pins.sql.go
@@ -12,8 +12,45 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 )
 
+const disableSessionPinProvider = `-- name: DisableSessionPinProvider :exec
+UPDATE router.session_pins
+SET disabled_providers = CASE
+      WHEN $1::varchar = ANY(disabled_providers) THEN disabled_providers
+      ELSE array_append(disabled_providers, $1::varchar)
+    END,
+    consecutive_overload_errors = 0
+WHERE session_key = $2::bytea
+  AND role        = $3::varchar
+`
+
+type DisableSessionPinProviderParams struct {
+	Provider   string
+	SessionKey []byte
+	Role       string
+}
+
+// Appends a provider to disabled_providers (deduped) and resets the
+// overload strike counter in the same statement, fired once the
+// two-strike threshold is reached. disabled_providers only grows for the
+// life of this pin row -- UpsertSessionPin's ON CONFLICT update never
+// touches it, so a struck-out provider stays disabled until the pin
+// itself is evicted/expires, with no separate time-based cooldown.
+//
+//	UPDATE router.session_pins
+//	SET disabled_providers = CASE
+//	      WHEN $1::varchar = ANY(disabled_providers) THEN disabled_providers
+//	      ELSE array_append(disabled_providers, $1::varchar)
+//	    END,
+//	    consecutive_overload_errors = 0
+//	WHERE session_key = $2::bytea
+//	  AND role        = $3::varchar
+func (q *Queries) DisableSessionPinProvider(ctx context.Context, arg DisableSessionPinProviderParams) error {
+	_, err := q.db.Exec(ctx, disableSessionPinProvider, arg.Provider, arg.SessionKey, arg.Role)
+	return err
+}
+
 const getSessionPin = `-- name: GetSessionPin :one
-SELECT session_key, role, installation_id, pinned_provider, pinned_model, decision_reason, turn_count, pinned_until, first_pinned_at, last_seen_at, last_input_tokens, last_cached_read_tokens, last_cached_write_tokens, last_output_tokens, last_turn_ended_at, consecutive_upstream_errors, last_served_model, has_ever_switched, paired_provider, paired_model
+SELECT session_key, role, installation_id, pinned_provider, pinned_model, decision_reason, turn_count, pinned_until, first_pinned_at, last_seen_at, last_input_tokens, last_cached_read_tokens, last_cached_write_tokens, last_output_tokens, last_turn_ended_at, consecutive_upstream_errors, last_served_model, has_ever_switched, paired_provider, paired_model, consecutive_overload_errors, disabled_providers
 FROM router.session_pins
 WHERE session_key = $1::bytea
   AND role        = $2::varchar
@@ -31,7 +68,7 @@ type GetSessionPinParams struct {
 // last_turn_ended_at carry the previous turn's upstream usage; the
 // planner reads them to weigh switch EV against eviction cost.
 //
-//	SELECT session_key, role, installation_id, pinned_provider, pinned_model, decision_reason, turn_count, pinned_until, first_pinned_at, last_seen_at, last_input_tokens, last_cached_read_tokens, last_cached_write_tokens, last_output_tokens, last_turn_ended_at, consecutive_upstream_errors, last_served_model, has_ever_switched, paired_provider, paired_model
+//	SELECT session_key, role, installation_id, pinned_provider, pinned_model, decision_reason, turn_count, pinned_until, first_pinned_at, last_seen_at, last_input_tokens, last_cached_read_tokens, last_cached_write_tokens, last_output_tokens, last_turn_ended_at, consecutive_upstream_errors, last_served_model, has_ever_switched, paired_provider, paired_model, consecutive_overload_errors, disabled_providers
 //	FROM router.session_pins
 //	WHERE session_key = $1::bytea
 //	  AND role        = $2::varchar
@@ -59,8 +96,44 @@ func (q *Queries) GetSessionPin(ctx context.Context, arg GetSessionPinParams) (R
 		&i.HasEverSwitched,
 		&i.PairedProvider,
 		&i.PairedModel,
+		&i.ConsecutiveOverloadErrors,
+		&i.DisabledProviders,
 	)
 	return i, err
+}
+
+const incrementSessionPinOverloadErrors = `-- name: IncrementSessionPinOverloadErrors :one
+UPDATE router.session_pins
+SET consecutive_overload_errors = consecutive_overload_errors + 1
+WHERE session_key = $1::bytea
+  AND role        = $2::varchar
+RETURNING consecutive_overload_errors
+`
+
+type IncrementSessionPinOverloadErrorsParams struct {
+	SessionKey []byte
+	Role       string
+}
+
+// Atomically increments consecutive_overload_errors and returns the new
+// value. The turn loop calls this after a turn exhausts with a
+// client-visible 529 (Anthropic overloaded_error) on a sticky-pinned
+// turn; the returned count drives the two-strike provider-disable
+// decision. Returns sql.ErrNoRows if no pin exists, which the adapter
+// maps to a no-op. Separate from IncrementSessionPinUpstreamErrors
+// because a 529 is retryable in-turn and must not also trip the
+// non-retryable-4xx eviction counter.
+//
+//	UPDATE router.session_pins
+//	SET consecutive_overload_errors = consecutive_overload_errors + 1
+//	WHERE session_key = $1::bytea
+//	  AND role        = $2::varchar
+//	RETURNING consecutive_overload_errors
+func (q *Queries) IncrementSessionPinOverloadErrors(ctx context.Context, arg IncrementSessionPinOverloadErrorsParams) (int32, error) {
+	row := q.db.QueryRow(ctx, incrementSessionPinOverloadErrors, arg.SessionKey, arg.Role)
+	var consecutive_overload_errors int32
+	err := row.Scan(&consecutive_overload_errors)
+	return consecutive_overload_errors, err
 }
 
 const incrementSessionPinUpstreamErrors = `-- name: IncrementSessionPinUpstreamErrors :one
@@ -93,6 +166,33 @@ func (q *Queries) IncrementSessionPinUpstreamErrors(ctx context.Context, arg Inc
 	var consecutive_upstream_errors int32
 	err := row.Scan(&consecutive_upstream_errors)
 	return consecutive_upstream_errors, err
+}
+
+const resetSessionPinOverloadErrors = `-- name: ResetSessionPinOverloadErrors :exec
+UPDATE router.session_pins
+SET consecutive_overload_errors = 0
+WHERE session_key = $1::bytea
+  AND role        = $2::varchar
+  AND consecutive_overload_errors > 0
+`
+
+type ResetSessionPinOverloadErrorsParams struct {
+	SessionKey []byte
+	Role       string
+}
+
+// Clears the overload strike counter after a successful turn. UPDATE
+// matches by (session_key, role); zero rows affected on missing pin is
+// a successful no-op like ResetSessionPinUpstreamErrors.
+//
+//	UPDATE router.session_pins
+//	SET consecutive_overload_errors = 0
+//	WHERE session_key = $1::bytea
+//	  AND role        = $2::varchar
+//	  AND consecutive_overload_errors > 0
+func (q *Queries) ResetSessionPinOverloadErrors(ctx context.Context, arg ResetSessionPinOverloadErrorsParams) error {
+	_, err := q.db.Exec(ctx, resetSessionPinOverloadErrors, arg.SessionKey, arg.Role)
+	return err
 }
 
 const resetSessionPinUpstreamErrors = `-- name: ResetSessionPinUpstreamErrors :exec


### PR DESCRIPTION
## Summary

Prod is seeing sustained Anthropic `529 overloaded_error` traffic -- 260+ SSE-prelude overload events and 59 client-visible 529s in the last 24h, all on `claude-sonnet-5`. The router already retries a 529 in-turn (same-binding retry x2, PR #794 + cross-binding failover when another binding exists), but has no cross-turn memory: a session pinned to an overloaded provider just keeps re-trying it turn after turn.

This adds a two-strike session-scoped provider disable: after **two consecutive turns** on a sticky session pin exhaust with a client-visible 529 from the same provider, that provider is added to a per-session `disabled_providers` set and the pin is evicted, so the next turn re-routes around it. The set persists for the life of that `(session_key, role)` pin row -- no separate time-based expiry -- matching the existing two-strike eviction pattern for non-retryable 4xx (`pin_eviction.go`) as closely as possible.

Scope is deliberately literal: only HTTP status **529** counts as a strike (the status Anthropic's SSE prelude synthesizes for `overloaded_error`, and the only provider in this codebase that produces it today). Ordinary 5xx/429 from other providers are untouched -- already covered by the existing retry/failover machinery.

## Changes

- **New migration** (`0043`): `session_pins` gains `consecutive_overload_errors` and `disabled_providers TEXT[]`. The latter is deliberately never touched by `UpsertSessionPin`'s `ON CONFLICT` update, so it only grows for the life of the row.
- **`sessionpin.Store`** gains `IncrementOverloadErrors` / `ResetOverloadErrors` / `DisableProvider`, implemented in the Postgres adapter.
- **New `internal/proxy/provider_overload.go`**: `maybeDisableProviderAfterOverload` mirrors `maybeEvictPinAfterUpstreamErr`'s two-strike shape, but gated on status `529` specifically instead of "any non-retryable 4xx."
- **Wired into routing at two points:**
  1. `runTurnLoop` subtracts a pin's `DisabledProviders` from `req.EnabledProviders` before the scorer runs.
  2. A new `SessionDisabledProvidersContextKey`, merged into `excludedProvidersForRequest`, so `resolveBindingsForDispatch`'s failover walk also honors the exclusion (that function reads exclusions from context, not from the scorer's `req`).
- **Hooked into all three surfaces**: `ProxyMessages`, `ProxyOpenAIChatCompletion`, `ProxyGeminiGenerateContent` (native Gemini rarely produces a real 529, but the hook is free and future-proofs a translate-layer path that might synthesize one).

## Tests

- 9 new unit tests in `provider_overload_internal_test.go` (mirrors `pin_eviction_internal_test.go`): below-threshold, two-strike disable+evict, reset-on-success, non-529 statuses ignored, force-model exemption, zero-session-key/nil-installation/non-upstream-error guards.
- New integration test `TestProxyMessages_TwoConsecutiveOverloadExhaustionsDisableProvider` in `failover_integration_test.go`: drives two full turns against a stub Anthropic server returning the SSE `overloaded_error` event, asserts the pin's `disabled_providers` gains `anthropic` after the second, and a third turn's scorer request no longer carries `anthropic` in `EnabledProviders`.
- Existing `fakePinStore`/stub pin-store test fakes across the package extended to satisfy the expanded `sessionpin.Store` interface.

## Validation

- `go vet ./...`, `gofmt -l .` clean.
- `go test ./...` passes (one pre-existing, unrelated flaky test excluded -- `TestFireTelemetryRecoversFromPanic`, a known race documented elsewhere in this package, untouched by this PR and reproduces identically on `main`).
- `go test ./internal/proxy/... -race` clean aside from that same known flake.
- Migration applied up and down against a local Postgres via `migrate`, confirmed the schema change and its exact rollback.
- `sqlc generate` produces no drift beyond the intended query additions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>