### PR TITLE
fix(proxy): sanitize orphaned tool_calls before dispatch

### DIFF
--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -2051,6 +2051,14 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 	if removed := env.StripRouterFeedbackArtifacts(); removed > 0 {
 		log.Info("Stripped router-feedback artifacts from Anthropic history", "removed_messages", removed)
 	}
+	// A dangling tool_use left by a prior mid-stream failure 400s permanently
+	// on providers that validate tool-call/response pairing (Together); other
+	// providers silently accept it, so the failure only shows up depending on
+	// which model the router picks. Must run before maybeCompact/routing so
+	// every dispatch attempt this turn sees a wire-valid history.
+	if sanitized := env.SanitizeOrphanedToolCalls(); sanitized > 0 {
+		log.Info("Sanitized orphaned tool calls before dispatch", "sanitized", sanitized)
+	}
 
 	embedFlag := s.embedOnlyUserMessage
 	if v, ok := embedOnlyUserMessageOverride(ctx); ok {
@@ -4173,6 +4181,14 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 	ctx, log, sessionKey = bindRequestLogger(ctx, env, apiKeyID, requestID, "openai_chat_completions")
 	if removed := env.StripRouterFeedbackArtifacts(); removed > 0 {
 		log.Info("Stripped router-feedback artifacts from OpenAI history", "removed_messages", removed)
+	}
+	// A dangling tool_use left by a prior mid-stream failure 400s permanently
+	// on providers that validate tool-call/response pairing (Together); other
+	// providers silently accept it, so the failure only shows up depending on
+	// which model the router picks. Must run before maybeCompact/routing so
+	// every dispatch attempt this turn sees a wire-valid history.
+	if sanitized := env.SanitizeOrphanedToolCalls(); sanitized > 0 {
+		log.Info("Sanitized orphaned tool calls before dispatch", "sanitized", sanitized)
 	}
 	embedFlag := s.embedOnlyUserMessage
 	if v, ok := embedOnlyUserMessageOverride(ctx); ok {

--- a/internal/translate/handover.go
+++ b/internal/translate/handover.go
@@ -429,3 +429,224 @@ func stripOrphanedOpenAIToolMessages(msgs []string) []string {
 	}
 	return result
 }
+
+// stripOrphanedOpenAIToolCalls removes tool_calls entries from assistant
+// messages whose id has no matching role:"tool" tool_call_id in the set.
+// Returns the modified message list and the count of orphaned tool_calls
+// stripped. An assistant message whose tool_calls are all orphaned gets the
+// key removed entirely so the field is absent from the wire payload. A
+// healthy client-submitted history never has an unanswered tool_calls entry
+// (the client's own tool loop always finishes answering one turn's calls
+// before sending the next request), so stripping is unconditional — there is
+// no legitimate "still in flight" case to protect against.
+func stripOrphanedOpenAIToolCalls(msgs []string) ([]string, int) {
+	knownIDs := make(map[string]struct{})
+	for _, raw := range msgs {
+		parsed := gjson.Parse(raw)
+		if parsed.Get("role").String() != "tool" {
+			continue
+		}
+		if id := parsed.Get("tool_call_id").String(); id != "" {
+			knownIDs[id] = struct{}{}
+		}
+	}
+
+	result := make([]string, 0, len(msgs))
+	stripped := 0
+	for _, raw := range msgs {
+		parsed := gjson.Parse(raw)
+		if parsed.Get("role").String() != "assistant" {
+			result = append(result, raw)
+			continue
+		}
+		tc := parsed.Get("tool_calls")
+		if !tc.IsArray() || tc.Get("#").Int() == 0 {
+			result = append(result, raw)
+			continue
+		}
+
+		var kept []string
+		tc.ForEach(func(_, entry gjson.Result) bool {
+			id := entry.Get("id").String()
+			if _, ok := knownIDs[id]; ok {
+				kept = append(kept, entry.Raw)
+			} else {
+				stripped++
+			}
+			return true
+		})
+		if len(kept) == 0 {
+			out, err := sjson.DeleteBytes([]byte(raw), "tool_calls")
+			if err != nil {
+				result = append(result, raw)
+				continue
+			}
+			result = append(result, string(out))
+			continue
+		}
+		if len(kept) == int(tc.Get("#").Int()) {
+			result = append(result, raw)
+			continue
+		}
+		newTC := "[" + strings.Join(kept, ",") + "]"
+		out, err := sjson.SetRawBytes([]byte(raw), "tool_calls", []byte(newTC))
+		if err != nil {
+			result = append(result, raw)
+			continue
+		}
+		result = append(result, string(out))
+	}
+	return result, stripped
+}
+
+// SanitizeOrphanedToolCalls strips tool_calls entries from assistant messages
+// that have no matching tool response in the request history, then strips
+// tool_result content blocks from user messages whose IDs are unmatched.
+// Some providers (Together) enforce strict tool-call/response pairing and 400
+// on orphaned IDs that other providers silently accept. This pass runs once
+// per turn so a session is never bricked by a single mid-stream failure that
+// left a dangling tool_use block on the wire. Returns the total count of
+// blocks/messages stripped; zero when clean or when the format is Gemini
+// (Gemini doesn't validate pairing).
+func (e *RequestEnvelope) SanitizeOrphanedToolCalls() int {
+	if e == nil {
+		return 0
+	}
+	switch e.format {
+	case FormatOpenAI:
+		return e.sanitizeOrphanedOpenAIToolCalls()
+	case FormatAnthropic:
+		return e.sanitizeOrphanedAnthropicToolCalls()
+	default:
+		return 0
+	}
+}
+
+func (e *RequestEnvelope) sanitizeOrphanedOpenAIToolCalls() int {
+	msgs := gjson.GetBytes(e.body, "messages")
+	if !msgs.IsArray() {
+		return 0
+	}
+	all := msgs.Array()
+	if len(all) == 0 {
+		return 0
+	}
+	raws := make([]string, 0, len(all))
+	for _, m := range all {
+		raws = append(raws, m.Raw)
+	}
+	cleanedCalls, callStripped := stripOrphanedOpenAIToolCalls(raws)
+	cleaned := stripOrphanedOpenAIToolMessages(cleanedCalls)
+	resultStripped := len(raws) - len(cleaned)
+	if callStripped == 0 && resultStripped == 0 {
+		return 0
+	}
+	newMessages := "[" + strings.Join(cleaned, ",") + "]"
+	out, err := sjson.SetRawBytes(e.body, "messages", []byte(newMessages))
+	if err != nil {
+		return 0
+	}
+	e.body = out
+	return callStripped + resultStripped
+}
+
+// collectAnthropicToolResultIDs returns the set of tool_use_ids referenced by
+// tool_result blocks in user messages. Reverse of collectAnthropicToolUseIDs.
+func collectAnthropicToolResultIDs(msgs []gjson.Result) map[string]struct{} {
+	ids := make(map[string]struct{})
+	for _, m := range msgs {
+		if m.Get("role").String() != "user" {
+			continue
+		}
+		m.Get("content").ForEach(func(_, block gjson.Result) bool {
+			if block.Get("type").String() == "tool_result" {
+				if id := block.Get("tool_use_id").String(); id != "" {
+					ids[id] = struct{}{}
+				}
+			}
+			return true
+		})
+	}
+	return ids
+}
+
+// stripOrphanedAnthropicToolCalls removes tool_use content blocks from
+// assistant messages whose id has no matching tool_result in the set.
+// Returns the number of orphaned tool_use blocks stripped. Unconditional
+// like stripOrphanedOpenAIToolCalls: a well-formed client history never ends
+// on (or contains) an unanswered tool_use, so there's no legitimate
+// in-flight case a knownIDs-empty guard would need to protect.
+func stripOrphanedAnthropicToolCalls(msgs []gjson.Result) (int, []gjson.Result) {
+	knownIDs := collectAnthropicToolResultIDs(msgs)
+
+	result := make([]gjson.Result, 0, len(msgs))
+	stripped := 0
+	for _, m := range msgs {
+		if m.Get("role").String() != "assistant" {
+			result = append(result, m)
+			continue
+		}
+		content := m.Get("content")
+		if !content.IsArray() {
+			result = append(result, m)
+			continue
+		}
+
+		var kept []string
+		content.ForEach(func(_, block gjson.Result) bool {
+			if block.Get("type").String() == "tool_use" {
+				id := block.Get("id").String()
+				if _, ok := knownIDs[id]; !ok {
+					stripped++
+					return true
+				}
+			}
+			kept = append(kept, block.Raw)
+			return true
+		})
+		if len(kept) == len(content.Array()) {
+			result = append(result, m)
+			continue
+		}
+		if len(kept) == 0 {
+			// Drop the message entirely — no content left after
+			// stripping orphaned tool_use blocks.
+			continue
+		}
+		newContent := "[" + strings.Join(kept, ",") + "]"
+		out, err := sjson.SetRawBytes([]byte(m.Raw), "content", []byte(newContent))
+		if err != nil {
+			result = append(result, m)
+			continue
+		}
+		result = append(result, gjson.ParseBytes(out))
+	}
+	return stripped, result
+}
+
+func (e *RequestEnvelope) sanitizeOrphanedAnthropicToolCalls() int {
+	msgs := gjson.GetBytes(e.body, "messages")
+	if !msgs.IsArray() {
+		return 0
+	}
+	all := msgs.Array()
+	if len(all) == 0 {
+		return 0
+	}
+	callStripped, cleaned := stripOrphanedAnthropicToolCalls(all)
+	if callStripped == 0 {
+		return 0
+	}
+	// stripOrphanedAnthropicToolCalls already accounts for any assistant
+	// message it drops entirely inside callStripped; only count messages the
+	// second pass (orphaned tool_results left behind by the first) removes.
+	cleanedRaw := stripOrphanedAnthropicToolResults(cleaned)
+	totalStripped := callStripped + (len(cleaned) - len(cleanedRaw))
+	newMessages := "[" + strings.Join(cleanedRaw, ",") + "]"
+	out, err := sjson.SetRawBytes(e.body, "messages", []byte(newMessages))
+	if err != nil {
+		return 0
+	}
+	e.body = out
+	return totalStripped
+}

--- a/internal/translate/handover_test.go
+++ b/internal/translate/handover_test.go
@@ -1,0 +1,182 @@
+package translate
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+)
+
+func TestSanitizeOrphanedToolCalls_OpenAI_HasOrphan(t *testing.T) {
+	body := `{"messages":[` +
+		`{"role":"user","content":"go"},` +
+		`{"role":"assistant","tool_calls":[` +
+		`{"id":"a","type":"function","function":{"name":"f","arguments":"{}"}},` +
+		`{"id":"b","type":"function","function":{"name":"g","arguments":"{}"}}` +
+		`]},` +
+		`{"role":"tool","tool_call_id":"a","content":"result a"}` +
+		`]}`
+	e, err := ParseOpenAI([]byte(body))
+	require.NoError(t, err)
+
+	sanitized := e.SanitizeOrphanedToolCalls()
+	assert.Equal(t, 1, sanitized, "the one orphaned tool_call (id b) should be stripped")
+
+	msgs := gjson.GetBytes(e.body, "messages").Array()
+	require.Len(t, msgs, 3)
+	assistant := msgs[1]
+	tc := assistant.Get("tool_calls").Array()
+	require.Len(t, tc, 1)
+	assert.Equal(t, "a", tc[0].Get("id").String())
+}
+
+func TestSanitizeOrphanedToolCalls_OpenAI_AllOrphaned(t *testing.T) {
+	body := `{"messages":[` +
+		`{"role":"user","content":"go"},` +
+		`{"role":"assistant","tool_calls":[` +
+		`{"id":"a","type":"function","function":{"name":"f","arguments":"{}"}},` +
+		`{"id":"b","type":"function","function":{"name":"g","arguments":"{}"}}` +
+		`]}` +
+		`]}`
+	e, err := ParseOpenAI([]byte(body))
+	require.NoError(t, err)
+
+	sanitized := e.SanitizeOrphanedToolCalls()
+	assert.Equal(t, 2, sanitized, "both orphaned tool_calls should be stripped")
+
+	msgs := gjson.GetBytes(e.body, "messages").Array()
+	require.Len(t, msgs, 2, "the assistant message itself is preserved, just without tool_calls")
+	assistant := msgs[1]
+	assert.False(t, assistant.Get("tool_calls").Exists(), "tool_calls key must be removed entirely, not left as []")
+}
+
+func TestSanitizeOrphanedToolCalls_OpenAI_NoOrphans(t *testing.T) {
+	body := `{"messages":[` +
+		`{"role":"user","content":"go"},` +
+		`{"role":"assistant","tool_calls":[{"id":"a","type":"function","function":{"name":"f","arguments":"{}"}}]},` +
+		`{"role":"tool","tool_call_id":"a","content":"result a"}` +
+		`]}`
+	e, err := ParseOpenAI([]byte(body))
+	require.NoError(t, err)
+	before := string(e.body)
+
+	sanitized := e.SanitizeOrphanedToolCalls()
+	assert.Equal(t, 0, sanitized)
+	assert.Equal(t, before, string(e.body), "body must be byte-identical when nothing is orphaned")
+}
+
+func TestSanitizeOrphanedToolCalls_OpenAI_TrailingUnansweredCallIsStripped(t *testing.T) {
+	// A well-formed client request never ends on an assistant tool_calls
+	// message with nothing after it — the client always appends the tool
+	// result (or a new user message) before calling the router again. A
+	// trailing unanswered tool_calls is therefore always anomalous (the
+	// mid-stream-failure artifact this fix targets), not a legitimate
+	// in-flight turn, so it must be stripped unconditionally.
+	body := `{"messages":[` +
+		`{"role":"user","content":"go"},` +
+		`{"role":"assistant","tool_calls":[{"id":"a","type":"function","function":{"name":"f","arguments":"{}"}}]}` +
+		`]}`
+	e, err := ParseOpenAI([]byte(body))
+	require.NoError(t, err)
+
+	sanitized := e.SanitizeOrphanedToolCalls()
+	assert.Equal(t, 1, sanitized)
+
+	msgs := gjson.GetBytes(e.body, "messages").Array()
+	require.Len(t, msgs, 2)
+	assert.False(t, msgs[1].Get("tool_calls").Exists())
+}
+
+func TestSanitizeOrphanedToolCalls_OpenAI_OrphanedResultAlsoStripped(t *testing.T) {
+	// role:"tool" with a tool_call_id that matches nothing (the reverse
+	// direction, already handled by stripOrphanedOpenAIToolMessages) must
+	// also be cleaned up by the same pass.
+	body := `{"messages":[` +
+		`{"role":"user","content":"go"},` +
+		`{"role":"assistant","tool_calls":[{"id":"a","type":"function","function":{"name":"f","arguments":"{}"}}]},` +
+		`{"role":"tool","tool_call_id":"a","content":"result a"},` +
+		`{"role":"tool","tool_call_id":"stale","content":"orphaned result"}` +
+		`]}`
+	e, err := ParseOpenAI([]byte(body))
+	require.NoError(t, err)
+
+	sanitized := e.SanitizeOrphanedToolCalls()
+	assert.Equal(t, 1, sanitized)
+
+	msgs := gjson.GetBytes(e.body, "messages").Array()
+	require.Len(t, msgs, 3)
+	for _, m := range msgs {
+		assert.NotEqual(t, "stale", m.Get("tool_call_id").String())
+	}
+}
+
+func TestSanitizeOrphanedToolCalls_Anthropic_HasOrphan(t *testing.T) {
+	body := `{"messages":[` +
+		`{"role":"user","content":[{"type":"text","text":"go"}]},` +
+		`{"role":"assistant","content":[` +
+		`{"type":"tool_use","id":"x","name":"read","input":{}},` +
+		`{"type":"text","text":"done"}` +
+		`]},` +
+		`{"role":"user","content":[{"type":"text","text":"continuing anyway"}]}` +
+		`]}`
+	e, err := ParseAnthropic([]byte(body))
+	require.NoError(t, err)
+
+	sanitized := e.SanitizeOrphanedToolCalls()
+	assert.Equal(t, 1, sanitized, "the orphaned tool_use (id x, no matching tool_result) should be stripped")
+
+	msgs := gjson.GetBytes(e.body, "messages").Array()
+	require.Len(t, msgs, 3)
+	assistant := msgs[1]
+	blocks := assistant.Get("content").Array()
+	require.Len(t, blocks, 1, "only the text block should remain")
+	assert.Equal(t, "text", blocks[0].Get("type").String())
+}
+
+func TestSanitizeOrphanedToolCalls_Anthropic_NoOrphans(t *testing.T) {
+	body := `{"messages":[` +
+		`{"role":"user","content":[{"type":"text","text":"go"}]},` +
+		`{"role":"assistant","content":[{"type":"tool_use","id":"x","name":"read","input":{}}]},` +
+		`{"role":"user","content":[{"type":"tool_result","tool_use_id":"x","content":"ok"}]}` +
+		`]}`
+	e, err := ParseAnthropic([]byte(body))
+	require.NoError(t, err)
+	before := string(e.body)
+
+	sanitized := e.SanitizeOrphanedToolCalls()
+	assert.Equal(t, 0, sanitized)
+	assert.Equal(t, before, string(e.body))
+}
+
+func TestSanitizeOrphanedToolCalls_Anthropic_AllBlocksOrphaned(t *testing.T) {
+	// Assistant message whose only content is an orphaned tool_use is dropped
+	// entirely rather than left as an empty-content message (which upstreams
+	// reject just as readily as an orphaned tool_use).
+	body := `{"messages":[` +
+		`{"role":"user","content":[{"type":"text","text":"go"}]},` +
+		`{"role":"assistant","content":[{"type":"tool_use","id":"x","name":"read","input":{}}]},` +
+		`{"role":"user","content":[{"type":"text","text":"still going"}]}` +
+		`]}`
+	e, err := ParseAnthropic([]byte(body))
+	require.NoError(t, err)
+
+	sanitized := e.SanitizeOrphanedToolCalls()
+	assert.Equal(t, 1, sanitized)
+
+	msgs := gjson.GetBytes(e.body, "messages").Array()
+	require.Len(t, msgs, 2, "the now-empty assistant message must be dropped")
+	assert.Equal(t, "user", msgs[0].Get("role").String())
+	assert.Equal(t, "user", msgs[1].Get("role").String())
+}
+
+func TestSanitizeOrphanedToolCalls_Gemini_NoOp(t *testing.T) {
+	body := `{"contents":[{"role":"user","parts":[{"text":"go"}]}]}`
+	e, err := ParseGemini([]byte(body))
+	require.NoError(t, err)
+	before := string(e.body)
+
+	sanitized := e.SanitizeOrphanedToolCalls()
+	assert.Equal(t, 0, sanitized, "Gemini doesn't validate tool-call pairing; sanitization is a no-op")
+	assert.Equal(t, before, string(e.body))
+}


### PR DESCRIPTION
## Summary

A mid-stream upstream failure can leave an assistant `tool_calls`/`tool_use` block on the wire with no matching tool response. Providers that validate strict tool-call/response pairing (Together) 400 permanently on any subsequent turn that references that history, while other providers (Anthropic, Google) silently accept it — so a session with one orphaned tool call appears to work or fail depending on which model the router happens to pick, with no way to self-heal short of starting a new session.

Found investigating a customer report of a persistent `upstream_error` on `z-ai/glm-5.2` (Together):
```
"incomplete parallel tool-call group: tool call 'toolu_...' has no tool response;
all tool calls in a parallel group must be answered before continuing"
```

## Root cause

The router already strips orphaned tool **results** during handover/compaction rewrites (`stripOrphanedOpenAIToolMessages`, `stripOrphanedAnthropicToolResults`), but nothing stripped the reverse case — an orphaned `tool_calls`/`tool_use` entry with no response — and neither existing pass runs unless the session is switching models (handover) or the context window is already ≥85% full (compaction). A session well below that threshold with one dangling tool call from an earlier mid-stream failure had no path to recovery.

## Fix

Adds `RequestEnvelope.SanitizeOrphanedToolCalls()`, which strips orphaned `tool_calls` (OpenAI) / `tool_use` blocks (Anthropic) from assistant messages before every dispatch, independent of compaction/handover state:

- `stripOrphanedOpenAIToolCalls` — mirrors the existing `stripOrphanedOpenAIToolMessages` in reverse: collects known `tool_call_id`s from `role:"tool"` messages, then filters `tool_calls[]` entries in assistant messages down to only those with a matching response. An assistant message left with zero surviving `tool_calls` has the key removed entirely rather than an empty array.
- `stripOrphanedAnthropicToolCalls` — same idea for Anthropic's `content[]` blocks; an assistant message left with no content after stripping is dropped.
- Called from both `ProxyOpenAIChatCompletion` and `ProxyMessages` immediately after parsing (before `maybeCompact`/routing), so every provider this turn might route to sees a wire-valid history.
- Gemini is a no-op — it doesn't validate tool-call pairing, so there's no failure mode to fix there.

## Testing

- New unit tests in `internal/translate/handover_test.go` covering: single orphan stripped, all-orphaned (key removed), no-orphans no-op (byte-identical body), orphaned tool_result also cleaned up in the same pass, and the Anthropic all-blocks-orphaned case (message dropped).
- `go build ./...`, `go vet ./...`, `go test ./...` (full suite) all pass with no regressions.
- `docker compose --profile hmm config --quiet` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)