### PR TITLE
fix(anthropic): stop claiming the OAuth beta on deployment-key auth

### DIFF
--- a/internal/providers/anthropic/client.go
+++ b/internal/providers/anthropic/client.go
@@ -125,18 +125,25 @@ func (c *Client) setAuth(ctx context.Context, upstream *http.Request, inbound *h
 // sk-ant-oat Authorization bearer. Must run AFTER prep.Headers is copied onto
 // the upstream request so it merges with, rather than is clobbered by, the
 // model-capability-filtered anthropic-beta that translate produced.
-func applyOAuthBeta(ctx context.Context, upstream, inbound *http.Request) {
-	if !subscriptionAuth(ctx, inbound) {
+func (c *Client) applyOAuthBeta(ctx context.Context, upstream, inbound *http.Request) {
+	if !c.subscriptionAuth(ctx, inbound) {
 		return
 	}
 	upstream.Header.Set("anthropic-beta", mergeBeta(upstream.Header.Get("anthropic-beta"), oauthBetaToken))
 }
 
 // subscriptionAuth reports whether this request will authenticate with a Claude
-// subscription OAuth token.
-func subscriptionAuth(ctx context.Context, inbound *http.Request) bool {
+// subscription OAuth token. The inbound-bearer branch mirrors setAuth's own
+// precedence: a configured deployment key outranks the inbound Authorization,
+// so the call goes out as x-api-key and must not claim the oauth beta — a
+// suppressed (exhausted) subscription failing over to the deployment key
+// otherwise sends key auth plus an OAuth-only beta, which Anthropic rejects.
+func (c *Client) subscriptionAuth(ctx context.Context, inbound *http.Request) bool {
 	if creds := proxy.CredentialsFromContext(ctx); creds != nil {
 		return creds.OAuth
+	}
+	if c.apiKey != "" {
+		return false
 	}
 	if raw, found := strings.CutPrefix(inbound.Header.Get("authorization"), "Bearer "); found {
 		return strings.HasPrefix(strings.TrimSpace(raw), subscriptionTokenPrefix)
@@ -171,7 +178,7 @@ func (c *Client) Proxy(ctx context.Context, decision router.Decision, prep provi
 	for k, vs := range prep.Headers {
 		upstream.Header[http.CanonicalHeaderKey(k)] = vs
 	}
-	applyOAuthBeta(ctx, upstream, r)
+	c.applyOAuthBeta(ctx, upstream, r)
 	if v := r.Header.Get("accept"); v != "" {
 		upstream.Header.Set("accept", v)
 	}
@@ -276,7 +283,7 @@ func (c *Client) Passthrough(ctx context.Context, prep providers.PreparedRequest
 	for k, vs := range prep.Headers {
 		upstream.Header[http.CanonicalHeaderKey(k)] = vs
 	}
-	applyOAuthBeta(ctx, upstream, r)
+	c.applyOAuthBeta(ctx, upstream, r)
 	if v := r.Header.Get("accept"); v != "" {
 		upstream.Header.Set("accept", v)
 	}

--- a/internal/providers/anthropic/client_test.go
+++ b/internal/providers/anthropic/client_test.go
@@ -276,6 +276,73 @@ func TestProxy_PassesThroughInboundSubscriptionWithBetaHeader(t *testing.T) {
 	assert.Contains(t, gotBeta, "oauth-2025-04-20", "a passed-through subscription bearer must still get the oauth beta flag")
 }
 
+func TestProxy_DeploymentKeyOutranksInboundSubscriptionBearerAndDropsBeta(t *testing.T) {
+	var (
+		gotAuth   string
+		gotAPIKey string
+		gotBeta   string
+	)
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		gotAPIKey = r.Header.Get("x-api-key")
+		gotBeta = r.Header.Get("anthropic-beta")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"id":"msg_1"}`))
+	}))
+	defer upstream.Close()
+
+	// A suppressed (exhausted) subscription leaves an explicit nil credential on
+	// ctx while Claude Code keeps its own sk-ant-oat bearer on the inbound
+	// Authorization. setAuth authenticates with the deployment key here, so the
+	// oauth beta must NOT ride along — Anthropic rejects it on x-api-key auth.
+	c := anthropic.NewClient("deployment-key", upstream.URL)
+	ctx := context.WithValue(context.Background(), proxy.CredentialsContextKey{}, (*proxy.Credentials)(nil))
+	rec := httptest.NewRecorder()
+	clientReq := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(""))
+	clientReq.Header.Set("Authorization", "Bearer sk-ant-oat01-subscription-token")
+	prep := providers.PreparedRequest{Body: []byte(`{"model":"x"}`), Headers: make(http.Header)}
+
+	err := c.Proxy(ctx, router.Decision{Model: "claude-opus-4-8"}, prep, rec, clientReq)
+	require.NoError(t, err)
+
+	assert.Equal(t, "deployment-key", gotAPIKey, "the deployment key outranks the inbound bearer")
+	assert.Empty(t, gotAuth, "the inbound subscription bearer must not be forwarded when a deployment key is configured")
+	assert.NotContains(t, gotBeta, "oauth-2025-04-20",
+		"an x-api-key-authenticated call must not claim the OAuth-only beta")
+}
+
+func TestPassthrough_DeploymentKeyOutranksInboundSubscriptionBearerAndDropsBeta(t *testing.T) {
+	var (
+		gotAuth   string
+		gotAPIKey string
+		gotBeta   string
+	)
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		gotAPIKey = r.Header.Get("x-api-key")
+		gotBeta = r.Header.Get("anthropic-beta")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"input_tokens":1}`))
+	}))
+	defer upstream.Close()
+
+	// PassthroughToNamedProvider never resolves credentials, so ctx carries none
+	// and /v1/messages/count_tokens hits the same deployment-key branch.
+	c := anthropic.NewClient("deployment-key", upstream.URL)
+	rec := httptest.NewRecorder()
+	clientReq := httptest.NewRequest(http.MethodPost, "/v1/messages/count_tokens", strings.NewReader(""))
+	clientReq.Header.Set("Authorization", "Bearer sk-ant-oat01-subscription-token")
+	prep := providers.PreparedRequest{Body: []byte(`{"model":"x"}`), Headers: make(http.Header)}
+
+	err := c.Passthrough(context.Background(), prep, rec, clientReq)
+	require.NoError(t, err)
+
+	assert.Equal(t, "deployment-key", gotAPIKey, "the deployment key outranks the inbound bearer")
+	assert.Empty(t, gotAuth, "the inbound subscription bearer must not be forwarded when a deployment key is configured")
+	assert.NotContains(t, gotBeta, "oauth-2025-04-20",
+		"an x-api-key-authenticated passthrough must not claim the OAuth-only beta")
+}
+
 func TestProxy_BuffersUpstream4xx(t *testing.T) {
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")


### PR DESCRIPTION
Closes #857.

## What

`subscriptionAuth` decides whether to stamp `anthropic-beta: oauth-2025-04-20` on the upstream request. It gates that on the raw inbound `Authorization` bearer, but never checks whether that bearer is what `setAuth` actually sends upstream.

`setAuth` ranks a configured deployment key **above** the inbound header:

```go
if creds := proxy.CredentialsFromContext(ctx); creds != nil { ... }
if c.apiKey != "" {                      // deployment key wins here
    upstream.Header.Set("x-api-key", c.apiKey)
    return
}
// inbound Authorization only reaches upstream below this point
```

So on any deployment with `ANTHROPIC_API_KEY` set, a request carrying a client `sk-ant-oat…` bearer goes out as **`x-api-key` auth plus an OAuth-only beta flag**.

`applyOAuthBeta`'s own doc comment already scopes the inbound-bearer case to *"(pure passthrough, no deployment key)"* — the guard it describes was never implemented, because `subscriptionAuth` was a package-level func with no access to `c.apiKey`.

## Why that combination is invalid

Anthropic validates `anthropic-beta` against an allowlist rather than ignoring unknown values. Per the [Beta headers docs](https://platform.claude.com/docs/en/api/beta-headers) → *Error handling*:

> If you use an invalid beta name, **or a beta your organization doesn't have access to**, you'll receive a `400` error response.

`oauth-2025-04-20` is not in the published beta list — it belongs to the Claude.ai subscription OAuth flow. See #857 for the full evidence chain, including the caveat that the in-the-wild capture of that rejection is from Vertex/LiteLLM rather than first-party `api.anthropic.com`. The code is wrong either way: the router should not assert an auth mode it isn't using.

## Why it matters

Both surfaces this client serves are affected:

- **`/v1/messages`** — when a Claude subscription is suppressed (exhausted, or `subscriptionRoutingDisabled`). `resolveAndInjectCredentials` deliberately stores an explicit nil credential so the deployment key takes over, while Claude Code keeps its own `sk-ant-oat` bearer on the inbound `Authorization`. `CredentialsFromContext` returns a typed nil, so **both** `setAuth` and `subscriptionAuth` fall through — the deployment-key failover turn goes out carrying the OAuth beta. That's precisely the subscription-exhaustion failover path.
- **`/v1/messages/count_tokens` and `/v1/models`** — these reach `Passthrough` via `PassthroughToNamedProvider`, which never resolves credentials at all, so ctx credentials are always nil there.

## Fix

`applyOAuthBeta` / `subscriptionAuth` become methods on `*Client` so the beta gate mirrors `setAuth`'s precedence rather than restating half of it: when a deployment key is configured, the inbound bearer is not what authenticates the call, so no OAuth beta.

## Testing

Two regression tests, one per surface. Both **fail without the guard and pass with it**:

```
--- FAIL: TestProxy_DeploymentKeyOutranksInboundSubscriptionBearerAndDropsBeta
        "oauth-2025-04-20" should not contain "oauth-2025-04-20"
--- FAIL: TestPassthrough_DeploymentKeyOutranksInboundSubscriptionBearerAndDropsBeta
        "oauth-2025-04-20" should not contain "oauth-2025-04-20"
```

The three existing auth/beta tests are unchanged and still pass — notably `TestProxy_PassesThroughInboundSubscriptionWithBetaHeader`, which constructs `NewClient("", ...)`, i.e. the genuine pure-passthrough case this fix preserves.

`go build ./...`, `go vet ./internal/providers/...`, `gofmt -l`, and `go test ./...` are all clean across the module.

## Scope

Deliberately limited to the Anthropic adapter and to the beta-flag decision. Credential precedence in `setAuth` is untouched — a suppressed subscription is *supposed* to fall back to the deployment key; the bug is only that the request kept advertising OAuth while doing so.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
