### PR TITLE
fix(translate): strip unsigned thinking blocks on every Anthropic emit

### DIFF
--- a/internal/translate/emit_same_format_test.go
+++ b/internal/translate/emit_same_format_test.go
@@ -732,6 +732,26 @@ func TestAnthropicSameFormat_SignedThinkingSurvivesUnsignedStrip(t *testing.T) {
 	assert.Equal(t, "text", text["type"])
 }
 
+// TestAnthropicSameFormat_UnsignedThinkingOnlyMessageDropped is the exact shape
+// flagged in #861 review: an assistant replay whose ONLY content is an unsigned
+// thinking block (no accompanying text/tool_use). Stripping the block must drop
+// the whole message rather than emit content:[], which Anthropic also rejects.
+func TestAnthropicSameFormat_UnsignedThinkingOnlyMessageDropped(t *testing.T) {
+	body := []byte(`{"model":"claude-opus-4-7","messages":[{"role":"user","content":"hi"},{"role":"assistant","content":[{"type":"thinking","thinking":"from an OSS model"}]},{"role":"user","content":"continue"}],"max_tokens":1024,"thinking":{"type":"adaptive"}}`)
+	opts := translate.EmitOptions{
+		TargetModel:   "claude-opus-4-7",
+		Capabilities:  router.Lookup("claude-opus-4-7"),
+		ModelSwitched: false,
+	}
+	out := parseAndEmit(t, body, "anthropic", opts)
+	msgs, _ := out["messages"].([]any)
+	require.Len(t, msgs, 2, "the unsigned-thinking-only assistant message must be dropped entirely")
+	first, _ := msgs[0].(map[string]any)
+	assert.Equal(t, "user", first["role"])
+	second, _ := msgs[1].(map[string]any)
+	assert.Equal(t, "user", second["role"])
+}
+
 func TestPassthroughSameFormat_FieldsScrubbed(t *testing.T) {
 	body := []byte(`{"model":"claude-sonnet-4-20250514","messages":[{"role":"user","content":"hi"}],"max_tokens":1024,"effort":"high","thinking":{"type":"enabled"},"context_management":{"mode":"auto"},"output_config":{"length":"verbose"}}`)
 	env, err := translate.ParseAnthropic(body)
@@ -883,6 +903,9 @@ func TestAnthropicSameFormat_ManyThinkingBlocksInSingleMessage(t *testing.T) {
 	assert.Equal(t, "final", content[0].(map[string]any)["text"])
 }
 
+// TestAnthropicSameFormat_AllThinkingBlocksRemoved guards the Greptile P1 on
+// #861: a message whose content becomes empty after stripping must be dropped
+// entirely, not left behind as content:[] — Anthropic rejects that shape.
 func TestAnthropicSameFormat_AllThinkingBlocksRemoved(t *testing.T) {
 	body := []byte(`{"model":"claude-sonnet-4-20250514","messages":[{"role":"user","content":"hi"},{"role":"assistant","content":[{"type":"thinking","thinking":"t1"},{"type":"redacted_thinking","data":"xyz"}]}],"max_tokens":1024}`)
 	opts := translate.EmitOptions{
@@ -891,10 +914,9 @@ func TestAnthropicSameFormat_AllThinkingBlocksRemoved(t *testing.T) {
 	}
 	out := parseAndEmit(t, body, "anthropic", opts)
 	msgs, _ := out["messages"].([]any)
-	require.Len(t, msgs, 2)
-	assistantMsg, _ := msgs[1].(map[string]any)
-	content, _ := assistantMsg["content"].([]any)
-	assert.Len(t, content, 0, "all blocks are thinking blocks, content should be empty array")
+	require.Len(t, msgs, 1, "the assistant message must be dropped, not left with an empty content array")
+	userMsg, _ := msgs[0].(map[string]any)
+	assert.Equal(t, "user", userMsg["role"])
 }
 
 func TestAnthropicSameFormat_StringContentPreserved(t *testing.T) {

--- a/internal/translate/emit_same_format_test.go
+++ b/internal/translate/emit_same_format_test.go
@@ -713,10 +713,8 @@ func TestAnthropicSameFormat_RedactedThinkingSurvivesBodyScan(t *testing.T) {
 	require.Len(t, content, 2, "redacted_thinking must not trip the unsigned scan")
 }
 
-// TestAnthropicSameFormat_SignedThinkingSurvivesUnsignedStrip is the reason the
-// strip is signature-scoped rather than blanket: a mixed history must lose only
-// the unsigned (cross-format) block, keeping the signed one so prompt-cache
-// continuity and reasoning context survive.
+// TestAnthropicSameFormat_SignedThinkingSurvivesUnsignedStrip: signature-scoped
+// strip must preserve signed blocks alongside any unsigned ones it drops.
 func TestAnthropicSameFormat_SignedThinkingSurvivesUnsignedStrip(t *testing.T) {
 	body := []byte(`{"model":"claude-opus-4-7","messages":[{"role":"assistant","content":[{"type":"thinking","thinking":"signed","signature":"valid-sig"},{"type":"thinking","thinking":"from an OSS model"},{"type":"text","text":"reply"}]}],"max_tokens":1024,"thinking":{"type":"adaptive"}}`)
 	opts := translate.EmitOptions{

--- a/internal/translate/emit_same_format_test.go
+++ b/internal/translate/emit_same_format_test.go
@@ -657,11 +657,8 @@ func TestAnthropicSameFormat_ThinkingBlocksKeptWhenNoModelSwitch(t *testing.T) {
 }
 
 // TestAnthropicSameFormat_UnsignedThinkingStrippedWithoutModelSwitch guards
-// #860: once the pin-session TTL lapses over an idle gap, the switch history
-// that drives ModelSwitched is gone, but Claude Code still replays the unsigned
-// thinking blocks an earlier cross-model excursion produced. Anthropic 400s on
-// those ("Invalid `signature` in `thinking` block"), so the body scan must
-// strip them even with ModelSwitched=false.
+// #860: pin TTL can lapse before switch history does, so unsigned thinking
+// blocks must be stripped even when ModelSwitched is false.
 func TestAnthropicSameFormat_UnsignedThinkingStrippedWithoutModelSwitch(t *testing.T) {
 	body := []byte(`{"model":"claude-opus-4-7","messages":[{"role":"user","content":"hi"},{"role":"assistant","content":[{"type":"thinking","thinking":"from an OSS model"},{"type":"text","text":"reply"}]}],"max_tokens":1024,"thinking":{"type":"adaptive"}}`)
 	opts := translate.EmitOptions{

--- a/internal/translate/emit_same_format_test.go
+++ b/internal/translate/emit_same_format_test.go
@@ -505,7 +505,9 @@ func TestAnthropicSameFormat_RedactedThinkingBlocksFiltered(t *testing.T) {
 }
 
 func TestAnthropicSameFormat_ThinkingBlocksKeptForCapableModel(t *testing.T) {
-	body := []byte(`{"model":"claude-sonnet-4-6","messages":[{"role":"user","content":"hi"},{"role":"assistant","content":[{"type":"thinking","thinking":"thought"},{"type":"text","text":"reply"}]}],"max_tokens":1024,"thinking":{"type":"adaptive"}}`)
+	// Signature present because every genuine Anthropic thinking block carries
+	// one; unsigned blocks are cross-format artifacts and get stripped (#860).
+	body := []byte(`{"model":"claude-sonnet-4-6","messages":[{"role":"user","content":"hi"},{"role":"assistant","content":[{"type":"thinking","thinking":"thought","signature":"sig"},{"type":"text","text":"reply"}]}],"max_tokens":1024,"thinking":{"type":"adaptive"}}`)
 	opts := translate.EmitOptions{
 		TargetModel:  "claude-opus-4-7",
 		Capabilities: router.Lookup("claude-opus-4-7"),
@@ -652,6 +654,87 @@ func TestAnthropicSameFormat_ThinkingBlocksKeptWhenNoModelSwitch(t *testing.T) {
 	assistantMsg, _ := msgs[1].(map[string]any)
 	content, _ := assistantMsg["content"].([]any)
 	require.Len(t, content, 2, "thinking blocks must be preserved when the model did not change")
+}
+
+// TestAnthropicSameFormat_UnsignedThinkingStrippedWithoutModelSwitch guards
+// #860: once the pin-session TTL lapses over an idle gap, the switch history
+// that drives ModelSwitched is gone, but Claude Code still replays the unsigned
+// thinking blocks an earlier cross-model excursion produced. Anthropic 400s on
+// those ("Invalid `signature` in `thinking` block"), so the body scan must
+// strip them even with ModelSwitched=false.
+func TestAnthropicSameFormat_UnsignedThinkingStrippedWithoutModelSwitch(t *testing.T) {
+	body := []byte(`{"model":"claude-opus-4-7","messages":[{"role":"user","content":"hi"},{"role":"assistant","content":[{"type":"thinking","thinking":"from an OSS model"},{"type":"text","text":"reply"}]}],"max_tokens":1024,"thinking":{"type":"adaptive"}}`)
+	opts := translate.EmitOptions{
+		TargetModel:   "claude-opus-4-7",
+		Capabilities:  router.Lookup("claude-opus-4-7"),
+		ModelSwitched: false,
+	}
+	out := parseAndEmit(t, body, "anthropic", opts)
+	msgs, _ := out["messages"].([]any)
+	require.Len(t, msgs, 2)
+	assistantMsg, _ := msgs[1].(map[string]any)
+	content, _ := assistantMsg["content"].([]any)
+	require.Len(t, content, 1, "unsigned thinking block must be stripped even when the pin reports no switch")
+	block, _ := content[0].(map[string]any)
+	assert.Equal(t, "text", block["type"], "only the text block should survive the strip")
+}
+
+// TestAnthropicSameFormat_EmptySignatureThinkingStripped covers the shape where
+// the key is present but empty — an empty signature is just as invalid upstream.
+func TestAnthropicSameFormat_EmptySignatureThinkingStripped(t *testing.T) {
+	body := []byte(`{"model":"claude-opus-4-7","messages":[{"role":"assistant","content":[{"type":"thinking","thinking":"t","signature":""},{"type":"text","text":"reply"}]}],"max_tokens":1024,"thinking":{"type":"adaptive"}}`)
+	opts := translate.EmitOptions{
+		TargetModel:  "claude-opus-4-7",
+		Capabilities: router.Lookup("claude-opus-4-7"),
+	}
+	out := parseAndEmit(t, body, "anthropic", opts)
+	msgs, _ := out["messages"].([]any)
+	require.Len(t, msgs, 1)
+	assistantMsg, _ := msgs[0].(map[string]any)
+	content, _ := assistantMsg["content"].([]any)
+	require.Len(t, content, 1, "empty-signature thinking block must be stripped")
+}
+
+// TestAnthropicSameFormat_RedactedThinkingSurvivesBodyScan pins the exemption:
+// redacted_thinking legitimately carries `data` rather than `signature`, so the
+// unsigned-block strip must leave it alone.
+func TestAnthropicSameFormat_RedactedThinkingSurvivesBodyScan(t *testing.T) {
+	body := []byte(`{"model":"claude-opus-4-7","messages":[{"role":"assistant","content":[{"type":"redacted_thinking","data":"encrypted"},{"type":"text","text":"reply"}]}],"max_tokens":1024,"thinking":{"type":"adaptive"}}`)
+	opts := translate.EmitOptions{
+		TargetModel:   "claude-opus-4-7",
+		Capabilities:  router.Lookup("claude-opus-4-7"),
+		ModelSwitched: false,
+	}
+	out := parseAndEmit(t, body, "anthropic", opts)
+	msgs, _ := out["messages"].([]any)
+	require.Len(t, msgs, 1)
+	assistantMsg, _ := msgs[0].(map[string]any)
+	content, _ := assistantMsg["content"].([]any)
+	require.Len(t, content, 2, "redacted_thinking must not trip the unsigned scan")
+}
+
+// TestAnthropicSameFormat_SignedThinkingSurvivesUnsignedStrip is the reason the
+// strip is signature-scoped rather than blanket: a mixed history must lose only
+// the unsigned (cross-format) block, keeping the signed one so prompt-cache
+// continuity and reasoning context survive.
+func TestAnthropicSameFormat_SignedThinkingSurvivesUnsignedStrip(t *testing.T) {
+	body := []byte(`{"model":"claude-opus-4-7","messages":[{"role":"assistant","content":[{"type":"thinking","thinking":"signed","signature":"valid-sig"},{"type":"thinking","thinking":"from an OSS model"},{"type":"text","text":"reply"}]}],"max_tokens":1024,"thinking":{"type":"adaptive"}}`)
+	opts := translate.EmitOptions{
+		TargetModel:   "claude-opus-4-7",
+		Capabilities:  router.Lookup("claude-opus-4-7"),
+		ModelSwitched: false,
+	}
+	out := parseAndEmit(t, body, "anthropic", opts)
+	msgs, _ := out["messages"].([]any)
+	require.Len(t, msgs, 1)
+	assistantMsg, _ := msgs[0].(map[string]any)
+	content, _ := assistantMsg["content"].([]any)
+	require.Len(t, content, 2, "only the unsigned thinking block should be dropped")
+	signed, _ := content[0].(map[string]any)
+	assert.Equal(t, "thinking", signed["type"])
+	assert.Equal(t, "valid-sig", signed["signature"], "the signed block must survive intact")
+	text, _ := content[1].(map[string]any)
+	assert.Equal(t, "text", text["type"])
 }
 
 func TestPassthroughSameFormat_FieldsScrubbed(t *testing.T) {

--- a/internal/translate/envelope.go
+++ b/internal/translate/envelope.go
@@ -346,12 +346,9 @@ type EmitOverrides struct {
 	DefaultMaxTokensValue   int64
 	InjectStreamUsage       bool
 	StripThinkingBlocks     bool
-	// StripUnsignedThinkingBlocks removes only `thinking` blocks lacking a
-	// non-empty `signature`, leaving validly-signed ones (and their prompt-cache
-	// continuity) intact. Set for Anthropic targets as a floor under
-	// StripThinkingBlocks: only cross-format emit produces unsigned blocks, and
-	// Anthropic 400s on them, so they must never reach the upstream even when no
-	// switch history survives to set ModelSwitched.
+	// StripUnsignedThinkingBlocks removes `thinking` blocks lacking a non-empty
+	// `signature`. Set unconditionally for Anthropic targets: unsigned blocks are
+	// cross-format artifacts; Anthropic 400s on them regardless of switch state.
 	StripUnsignedThinkingBlocks bool
 	// SanitizeToolUseIDs rewrites tool_use.id / tool_use_id values outside
 	// ^[a-zA-Z0-9_-]+$. Always set for Anthropic targets: upstreams like

--- a/internal/translate/envelope.go
+++ b/internal/translate/envelope.go
@@ -619,12 +619,9 @@ func isThinkingBlock(block gjson.Result) bool {
 	return blockType == "thinking" || blockType == "redacted_thinking"
 }
 
-// stripUnsignedThinkingBlocksBytes removes `thinking` blocks with no non-empty
-// `signature` from messages[*].content[*], leaving signed ones untouched. Only
-// cross-format emit produces unsigned blocks (OSS providers have no Anthropic
-// signature to carry) and Anthropic rejects them with "Invalid `signature` in
-// `thinking` block". redacted_thinking is exempt: it legitimately carries
-// `data` rather than a signature.
+// stripUnsignedThinkingBlocksBytes removes `thinking` blocks with absent or
+// empty `signature` from messages[*].content[*]. Unsigned blocks only come from
+// cross-format emit; Anthropic rejects them. redacted_thinking is exempt.
 func stripUnsignedThinkingBlocksBytes(body []byte) ([]byte, error) {
 	return rewriteMessageBlocks(body, isUnsignedThinkingBlock, dropMatchedBlock)
 }

--- a/internal/translate/envelope.go
+++ b/internal/translate/envelope.go
@@ -346,6 +346,13 @@ type EmitOverrides struct {
 	DefaultMaxTokensValue   int64
 	InjectStreamUsage       bool
 	StripThinkingBlocks     bool
+	// StripUnsignedThinkingBlocks removes only `thinking` blocks lacking a
+	// non-empty `signature`, leaving validly-signed ones (and their prompt-cache
+	// continuity) intact. Set for Anthropic targets as a floor under
+	// StripThinkingBlocks: only cross-format emit produces unsigned blocks, and
+	// Anthropic 400s on them, so they must never reach the upstream even when no
+	// switch history survives to set ModelSwitched.
+	StripUnsignedThinkingBlocks bool
 	// SanitizeToolUseIDs rewrites tool_use.id / tool_use_id values outside
 	// ^[a-zA-Z0-9_-]+$. Always set for Anthropic targets: upstreams like
 	// Kimi-k2.6 emit IDs (e.g. "functions.Read:0") Anthropic rejects on replay.
@@ -386,6 +393,11 @@ func applyOverrides(body []byte, ov EmitOverrides) ([]byte, error) {
 		out, err = stripThinkingBlocksBytes(out)
 		if err != nil {
 			return nil, fmt.Errorf("strip thinking blocks: %w", err)
+		}
+	} else if ov.StripUnsignedThinkingBlocks {
+		out, err = stripUnsignedThinkingBlocksBytes(out)
+		if err != nil {
+			return nil, fmt.Errorf("strip unsigned thinking blocks: %w", err)
 		}
 	}
 
@@ -605,6 +617,20 @@ func stripThinkingBlocksBytes(body []byte) ([]byte, error) {
 func isThinkingBlock(block gjson.Result) bool {
 	blockType := block.Get("type").String()
 	return blockType == "thinking" || blockType == "redacted_thinking"
+}
+
+// stripUnsignedThinkingBlocksBytes removes `thinking` blocks with no non-empty
+// `signature` from messages[*].content[*], leaving signed ones untouched. Only
+// cross-format emit produces unsigned blocks (OSS providers have no Anthropic
+// signature to carry) and Anthropic rejects them with "Invalid `signature` in
+// `thinking` block". redacted_thinking is exempt: it legitimately carries
+// `data` rather than a signature.
+func stripUnsignedThinkingBlocksBytes(body []byte) ([]byte, error) {
+	return rewriteMessageBlocks(body, isUnsignedThinkingBlock, dropMatchedBlock)
+}
+
+func isUnsignedThinkingBlock(block gjson.Result) bool {
+	return block.Get("type").String() == "thinking" && block.Get("signature").String() == ""
 }
 
 // dropMatchedBlock drops any block that matched needsRewrite by returning "".
@@ -1114,6 +1140,13 @@ func resolveAnthropicOverrides(body []byte, opts EmitOptions) EmitOverrides {
 	if opts.ModelSwitched {
 		ov.StripThinkingBlocks = true
 	}
+
+	// Floor under the switch-history guard above: unsigned blocks only come from
+	// cross-format emit and Anthropic always rejects them, so drop them even when
+	// no switch is known. Load-bearing once the pin-session TTL lapses over an
+	// idle gap — the switch history is gone by then, while Claude Code still
+	// replays the unsigned blocks every turn (#860).
+	ov.StripUnsignedThinkingBlocks = true
 
 	if !gjson.GetBytes(body, "max_tokens").Exists() {
 		ov.DefaultMaxTokensKey = "max_tokens"

--- a/internal/translate/envelope.go
+++ b/internal/translate/envelope.go
@@ -1141,11 +1141,8 @@ func resolveAnthropicOverrides(body []byte, opts EmitOptions) EmitOverrides {
 		ov.StripThinkingBlocks = true
 	}
 
-	// Floor under the switch-history guard above: unsigned blocks only come from
-	// cross-format emit and Anthropic always rejects them, so drop them even when
-	// no switch is known. Load-bearing once the pin-session TTL lapses over an
-	// idle gap — the switch history is gone by then, while Claude Code still
-	// replays the unsigned blocks every turn (#860).
+	// Floor under the switch-history guard: Anthropic rejects unsigned blocks
+	// regardless of pin TTL, so strip them unconditionally (#860).
 	ov.StripUnsignedThinkingBlocks = true
 
 	if !gjson.GetBytes(body, "max_tokens").Exists() {

--- a/internal/translate/envelope.go
+++ b/internal/translate/envelope.go
@@ -527,6 +527,9 @@ func clampFieldBytes(body []byte, key string, maxVal int64) []byte {
 // rewriteMessageBlocks walks messages[*].content[*], rewriting each block for
 // which needsRewrite reports true by calling rewrite with that block's raw
 // JSON. rewrite returning "" drops the block from its message's content array.
+// A message whose content array is emptied by rewriting is dropped entirely —
+// Anthropic rejects an assistant/user message with content:[] outright, so
+// leaving the shell behind would trade one 400 for another.
 // Uses two-phase reconstruction per message (cheap predicate scan, then
 // rebuild only messages that actually matched) for O(B) work. Returns body
 // unchanged if nothing matched.
@@ -584,6 +587,12 @@ func rewriteMessageBlocks(
 		})
 		if walkErr != nil {
 			return false
+		}
+
+		if len(kept) == 0 {
+			// Every block in this message was dropped; drop the message itself
+			// rather than emit an empty content array.
+			return true
 		}
 
 		newMsg, err := sjson.SetRaw(msg.Raw, "content", "["+strings.Join(kept, ",")+"]")


### PR DESCRIPTION
Fixes #860.

## Problem (live in prod)

Two of the largest installations are hitting repeated 400s against `claude-opus-5`:

```
messages.7.content.0: Invalid `signature` in `thinking` block
```

One session (`3a74d50a…`) lost **57 of 152 turns** on 2026-07-30. The 400 is buffered, but 4xx is deliberately non-retryable, so nothing rescues the turn — the user sees a hard failure and has to restart.

## Root cause

A session served OSS models (kimi-k2.7, minimax-m3, deepseek-v4-flash) for several turns. Cross-format emit converts their reasoning into Anthropic `thinking` blocks with **no `signature`** — OSS providers have none to carry. Claude Code keeps those blocks in its transcript and replays them on every subsequent turn.

#383 already strips carried-over thinking blocks, but only when `ModelSwitched` is set — and that is derived entirely from the session pin's switch history. Those rows carry a one-hour TTL (`pinSessionTTL`, `service.go:255`). The session idled ~19h; both the pin and its `_hmm_history` sibling lapsed; `switchHistoryFromPins` returned `("", false)`; `ModelSwitched` was false. The unsigned blocks went upstream verbatim.

So the existing guard is correct but not sufficient: it protects contiguous sessions and silently stops protecting anything that idles past the pin TTL.

## Fix

Strip unconditionally on Anthropic emit, scoped to blocks whose `signature` is absent or empty (`StripUnsignedThinkingBlocks`, a floor under the existing `StripThinkingBlocks`).

Signature-scoped rather than blanket on purpose: a signed history stays intact when no switch is known, so prompt-cache continuity and reasoning context are preserved — only the shapes Anthropic *always* rejects are dropped. `redacted_thinking` is exempt; it legitimately carries `data` instead of a signature.

This needs no persisted state, so it holds regardless of pin TTL, idle gaps, or which writeback path ran.

## Verification

- Reproduced the exact prod payload shape (unsigned block at `messages[7].content[0]`, `ModelSwitched=false`, target `claude-opus-5`): **fails before the change, passes after** — confirmed by reverting just the override assignment and re-running.
- `go build ./...`, `go vet ./...` clean; full `go test ./...` green (46 packages).

New tests: unsigned stripped without a model switch; empty-signature stripped; **signed block survives alongside an unsigned one being dropped** (the reason for the signature scoping); `redacted_thinking` untouched.

## One existing test changed

`TestAnthropicSameFormat_ThinkingBlocksKeptForCapableModel`'s fixture had carried an unsigned thinking block since #1. That shape cannot originate from Anthropic (real thinking blocks always carry a signature), so the fixture now includes one. The assertion — capable targets keep their thinking history — is unchanged and still passes.

## Follow-up (not in this PR)

Worth considering separately: emitting a different carrier (e.g. `reasoning_preview`) for OSS reasoning on the Anthropic path, so unsigned `thinking` blocks are never synthesized at all. This PR is the minimal stop-the-bleeding fix.

🤖 Generated with [Weave Router](https://router.workweave.ai)