### PR TITLE
feat(byok): support customer provider keys in managed mode with a platform fee

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -205,7 +205,7 @@ If new helper doesn't fit, justify new package in code comment before creating.
 `ROUTER_DEPLOYMENT_MODE` read at boot in `cmd/router/main.go`:
 
 - **`selfhosted`** (default): full dashboard at `/ui/*`, `/admin/v1/*` API (auth, metrics, keys, provider-keys, config, excluded-models), dashboard cookie auth all mounted. Provider keys read from env vars; missing keys keep providers registered for client-passthrough but exclude from hard-pin resolution.
-- **`managed`**: dashboard + `/admin/v1/*` not mounted at all — Weave-managed deploys have separate control plane. Every provider registered with empty deployment key; proxy service in BYOK-only mode, so request without BYOK or client-supplied auth for chosen provider 400s rather than silently spending platform budget. Setting variable to any other value panics at boot.
+- **`managed`**: dashboard + `/admin/v1/*` not mounted at all — Weave-managed deploys have separate control plane. Every provider registered with empty deployment key; proxy service in BYOK-only mode, so request without BYOK or client-supplied auth for chosen provider 400s rather than silently spending platform budget. Setting variable to any other value panics at boot. BYOK is **opt-in per installation** here (`byok_enabled` on the installation row, set by the control plane): until it's set, `withAPIKey` strips external keys so a stored key can't spend against a credit-billed deployment. An opted-in BYOK turn debits no inference cost and is charged a platform fee (`billing.ByokFeeRate`) as a separate `byok_fee` ledger row.
 
 When adding new endpoint, put inside `selfhosted` block in `server.Register` unless part of product surface (`/v1/*`, `/v1beta/*`, `/health`, `/validate`). Do not re-expose admin surface in managed mode.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -205,7 +205,7 @@ If new helper doesn't fit, justify new package in code comment before creating.
 `ROUTER_DEPLOYMENT_MODE` read at boot in `cmd/router/main.go`:
 
 - **`selfhosted`** (default): full dashboard at `/ui/*`, `/admin/v1/*` API (auth, metrics, keys, provider-keys, config, excluded-models), dashboard cookie auth all mounted. Provider keys read from env vars; missing keys keep providers registered for client-passthrough but exclude from hard-pin resolution.
-- **`managed`**: dashboard + `/admin/v1/*` not mounted at all — Weave-managed deploys have separate control plane. Every provider registered with empty deployment key; proxy service in BYOK-only mode, so request without BYOK or client-supplied auth for chosen provider 400s rather than silently spending platform budget. Setting variable to any other value panics at boot.
+- **`managed`**: dashboard + `/admin/v1/*` not mounted at all — Weave-managed deploys have separate control plane. Every provider registered with empty deployment key; proxy service in BYOK-only mode, so request without BYOK or client-supplied auth for chosen provider 400s rather than silently spending platform budget. Setting variable to any other value panics at boot. BYOK is **opt-in per installation** here (`byok_enabled` on the installation row, set by the control plane): until it's set, `withAPIKey` strips external keys so a stored key can't spend against a credit-billed deployment. An opted-in BYOK turn debits no inference cost and is charged a platform fee (`billing.ByokFeeRate`) as a separate `byok_fee` ledger row.
 
 When adding new endpoint, put inside `selfhosted` block in `server.Register` unless part of product surface (`/v1/*`, `/v1beta/*`, `/health`, `/validate`). Do not re-expose admin surface in managed mode.
 

--- a/db/migrations/0044_managed-byok.down.sql
+++ b/db/migrations/0044_managed-byok.down.sql
@@ -1,0 +1,34 @@
+BEGIN;
+
+-- Narrowing the entry_type CHECK fails while byok_fee rows exist, so drop them
+-- first. Destructive by necessity: the rolled-back schema has no legal
+-- representation for a BYOK fee.
+DELETE FROM router.organization_credit_ledger
+WHERE entry_type = 'byok_fee';
+
+ALTER TABLE router.organization_credit_ledger
+  DROP CONSTRAINT organization_credit_ledger_entry_type_check;
+
+ALTER TABLE router.organization_credit_ledger
+  ADD CONSTRAINT organization_credit_ledger_entry_type_check
+  CHECK (entry_type IN ('topup','inference','refund','adjustment'));
+
+-- Same problem on the provider CHECK: rows for the four providers added by the
+-- up migration can't satisfy the narrowed predicate.
+DELETE FROM router.model_router_external_api_keys
+WHERE provider IN ('bedrock','makora','together','xai');
+
+ALTER TABLE router.model_router_external_api_keys
+  DROP CONSTRAINT model_router_external_api_keys_provider_check;
+
+ALTER TABLE router.model_router_external_api_keys
+  ADD CONSTRAINT model_router_external_api_keys_provider_check
+  CHECK (provider IN ('anthropic','openai','google','openrouter','fireworks'));
+
+ALTER TABLE router.model_router_external_api_keys
+  DROP COLUMN base_url;
+
+ALTER TABLE router.model_router_installations
+  DROP COLUMN byok_enabled;
+
+COMMIT;

--- a/db/migrations/0044_managed-byok.up.sql
+++ b/db/migrations/0044_managed-byok.up.sql
@@ -1,0 +1,50 @@
+BEGIN;
+
+-- Managed-mode BYOK. Until now BYOK was reachable only from the self-hoster
+-- dashboard: managed deploys strip customer provider keys in the auth
+-- middleware because a stored key would spend upstream *and* debit prepaid
+-- credits. These columns let a managed installation opt in explicitly, with
+-- Weave charging a percentage fee on the customer's upstream spend instead of
+-- the full inference cost.
+
+-- Per-installation opt-in. Managed deploys honor BYOK rows only when this is
+-- true, so one org enabling it can't change credentialing for every other
+-- tenant on the deployment. Self-hosted ignores the flag (BYOK is the only
+-- credentialing path there).
+ALTER TABLE router.model_router_installations
+  ADD COLUMN byok_enabled BOOLEAN NOT NULL DEFAULT FALSE;
+
+-- Customer-supplied upstream endpoint for this key. NULL means "use the
+-- deployment's configured base URL for the provider" -- the pre-existing
+-- behavior. Non-NULL lets a customer point at their own deployment of an
+-- OpenAI-compatible provider rather than the vendor's public endpoint.
+ALTER TABLE router.model_router_external_api_keys
+  ADD COLUMN base_url TEXT;
+
+-- The original CHECK predates Bedrock, Makora, Together, and xAI becoming
+-- first-class providers, so BYOK rows for them were rejected outright. Widen
+-- it to the full providers.APIKeyEnvVars set.
+ALTER TABLE router.model_router_external_api_keys
+  DROP CONSTRAINT model_router_external_api_keys_provider_check;
+
+ALTER TABLE router.model_router_external_api_keys
+  ADD CONSTRAINT model_router_external_api_keys_provider_check
+  CHECK (provider IN (
+    'anthropic','openai','google','openrouter','fireworks',
+    'bedrock','makora','together','xai'
+  ));
+
+-- BYOK turns write two ledger rows: an 'inference' row at delta 0 (the
+-- customer paid their own provider) carrying notional_cost_micros for the
+-- savings dashboard, plus a 'byok_fee' row holding the actual debit.
+ALTER TABLE router.organization_credit_ledger
+  DROP CONSTRAINT organization_credit_ledger_entry_type_check;
+
+ALTER TABLE router.organization_credit_ledger
+  ADD CONSTRAINT organization_credit_ledger_entry_type_check
+  CHECK (entry_type IN ('topup','inference','refund','adjustment','byok_fee'));
+
+COMMENT ON COLUMN router.model_router_installations.byok_enabled IS 'Managed-mode opt-in: honor this installation''s BYOK provider keys';
+COMMENT ON COLUMN router.model_router_external_api_keys.base_url IS 'Customer-supplied upstream base URL; NULL uses the deployment default for the provider';
+
+COMMIT;

--- a/db/queries/billing.sql
+++ b/db/queries/billing.sql
@@ -21,8 +21,10 @@ SELECT EXISTS (
 )::boolean AS has_override;
 
 -- Atomic debit: decrement the balance and append a matching ledger row in a
--- single statement. delta_usd_micros is the signed change (negative for an
--- inference debit, zero for an override pass-through). notional_cost_micros
+-- single statement. delta_usd_micros is the signed change on the inference row
+-- (negative for an inference debit, zero for an override pass-through).
+-- charged_usd_micros is the signed total the balance actually moves
+-- (delta + fee), pre-combined by the caller. notional_cost_micros
 -- is always the would-be charge, populated for both override and real
 -- debits so we keep a shadow billing trail.
 --
@@ -35,15 +37,20 @@ SELECT EXISTS (
 -- new value without a follow-up read.
 --
 -- When api_key_id is supplied, the same statement also bumps that key's
--- lifetime spent_usd_micros by the debit magnitude (-delta: the real cost on a
--- debit, zero on an override/subscription pass-through where delta is 0), so
--- per-key cap enforcement reads a single up-to-date row. The key_spend CTE is
+-- lifetime spent_usd_micros by the charged magnitude (-charged: the real cost
+-- on a debit, zero on an override/subscription pass-through), so per-key cap
+-- enforcement reads a single up-to-date row. The key_spend CTE is
 -- data-modifying, so Postgres runs it to completion even though the final
 -- SELECT does not reference it; it no-ops when api_key_id is NULL.
+-- When fee_usd_micros is non-zero, a second ledger row of fee_entry_type is
+-- written in the same statement. BYOK turns use this: the inference row carries
+-- notional upstream cost at delta 0 (the customer paid their own provider) and
+-- the fee row holds Weave's platform charge. Both rows must land together or a
+-- crash between them would serve inference with no fee, so they share one CTE.
 -- name: DebitOrgCredits :one
 WITH updated AS (
     UPDATE router.organization_credit_balance
-    SET balance_usd_micros = balance_usd_micros + @delta_usd_micros::bigint,
+    SET balance_usd_micros = balance_usd_micros + @charged_usd_micros::bigint,
         updated_at = NOW()
     WHERE organization_id = @organization_id::varchar
     RETURNING balance_usd_micros
@@ -62,22 +69,53 @@ ledger AS (
         @organization_id::varchar,
         @delta_usd_micros::bigint,
         @notional_cost_micros::bigint,
-        updated.balance_usd_micros,
+        -- The fee row is logically second, so this row's balance_after is the
+        -- final balance minus the fee that had not yet been applied.
+        updated.balance_usd_micros - @fee_usd_micros::bigint,
         @entry_type::varchar,
         sqlc.narg('router_request_id')::varchar,
         sqlc.narg('router_model')::varchar
     FROM updated
     RETURNING balance_after_micros
 ),
+fee_ledger AS (
+    -- Weave's platform fee on a BYOK turn. No-ops when fee_usd_micros is 0,
+    -- which is every non-BYOK turn.
+    INSERT INTO router.organization_credit_ledger (
+        organization_id,
+        delta_usd_micros,
+        notional_cost_micros,
+        balance_after_micros,
+        entry_type,
+        router_request_id,
+        router_model
+    )
+    SELECT
+        @organization_id::varchar,
+        @fee_usd_micros::bigint,
+        0,
+        updated.balance_usd_micros,
+        @fee_entry_type::varchar,
+        NULL::varchar,
+        NULL::varchar
+    FROM updated
+    WHERE @fee_usd_micros::bigint <> 0
+),
 key_spend AS (
-    -- delta is negative on a real debit, so subtracting it adds the spend
-    -- magnitude; zero on override/subscription pass-throughs leaves it flat.
+    -- charged_usd_micros is the signed total the balance moved (delta + fee),
+    -- pre-combined in Go: sqlc's CTE rewriter only accepts a single param in
+    -- this `SET x = x - @p` form, and an unqualified `spent_usd_micros` is
+    -- ambiguous against the `updated` CTE. Negative on a real debit, so
+    -- subtracting it adds the spend magnitude; zero on override/subscription
+    -- pass-throughs leaves it flat. The BYOK fee is included, else a capped key
+    -- would never trip its cap on BYOK traffic (delta 0, fee is the whole
+    -- charge).
     -- Gated on `updated` producing a row: if the org balance row was missing
     -- (the debit no-ops and the app sees ErrBalanceRowMissing) we must NOT bump
     -- the key's lifetime spend, or a capped key could trip its cap with no
     -- matching ledger debit.
     UPDATE router.model_router_api_keys
-    SET spent_usd_micros = spent_usd_micros - @delta_usd_micros::bigint
+    SET spent_usd_micros = spent_usd_micros - @charged_usd_micros::bigint
     WHERE id = sqlc.narg('api_key_id')::uuid
       AND EXISTS (SELECT 1 FROM updated)
 ),
@@ -92,7 +130,7 @@ user_month_spend AS (
     SELECT
         sqlc.narg('router_user_id')::uuid,
         DATE_TRUNC('month', NOW() AT TIME ZONE 'utc')::date,
-        -(@delta_usd_micros::bigint),
+        -(@charged_usd_micros::bigint),
         NOW()
     WHERE sqlc.narg('router_user_id')::uuid IS NOT NULL
       AND EXISTS (SELECT 1 FROM updated)
@@ -110,7 +148,7 @@ org_month_spend AS (
     SELECT
         @organization_id::varchar,
         DATE_TRUNC('month', NOW() AT TIME ZONE 'utc')::date,
-        -(@delta_usd_micros::bigint),
+        -(@charged_usd_micros::bigint),
         NOW()
     WHERE EXISTS (SELECT 1 FROM updated)
     ON CONFLICT (organization_id, month) DO UPDATE

--- a/db/queries/billing.sql
+++ b/db/queries/billing.sql
@@ -96,8 +96,8 @@ fee_ledger AS (
         0,
         updated.balance_usd_micros,
         @fee_entry_type::varchar,
-        NULL::varchar,
-        NULL::varchar
+        sqlc.narg('router_request_id')::varchar,
+        sqlc.narg('router_model')::varchar
     FROM updated
     WHERE @fee_usd_micros::bigint <> 0
 ),

--- a/db/queries/billing.sql
+++ b/db/queries/billing.sql
@@ -69,8 +69,8 @@ ledger AS (
         @organization_id::varchar,
         @delta_usd_micros::bigint,
         @notional_cost_micros::bigint,
-        -- The fee row is logically second, so this row's balance_after is the
-        -- final balance minus the fee that had not yet been applied.
+        -- The fee row is logically second, so this row records the balance as of
+        -- before the fee landed: final minus the fee's signed value.
         updated.balance_usd_micros - @fee_usd_micros::bigint,
         @entry_type::varchar,
         sqlc.narg('router_request_id')::varchar,
@@ -155,7 +155,14 @@ org_month_spend AS (
     SET spent_usd_micros = router.organization_monthly_spend.spent_usd_micros + EXCLUDED.spent_usd_micros,
         updated_at = NOW()
 )
-SELECT balance_after_micros FROM ledger;
+-- Returns the TRUE post-debit balance (from `updated`, after both delta and
+-- fee), not a ledger row's balance_after. The inference row deliberately
+-- records the pre-fee balance for audit ordering, so returning it here would
+-- hand callers a balance the org never actually had -- and
+-- maybeSignalRecharge would reconstruct a bogus pre-debit balance from it and
+-- miss autopay threshold crossings on BYOK fee turns.
+SELECT (SELECT balance_usd_micros FROM updated) AS balance_after_micros
+FROM ledger;
 
 -- Paginated read for the dashboard ledger panel. Sorted newest-first so the
 -- UI can render without an extra ORDER BY in Go.

--- a/db/queries/model_router_external_api_keys.sql
+++ b/db/queries/model_router_external_api_keys.sql
@@ -11,6 +11,7 @@ INSERT INTO router.model_router_external_api_keys (
     key_suffix,
     key_fingerprint,
     name,
+    base_url,
     created_by
 )
 VALUES (
@@ -22,6 +23,7 @@ VALUES (
     @key_suffix::varchar,
     @key_fingerprint::varchar,
     @name,
+    @base_url,
     @created_by
 )
 RETURNING *;

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -35,8 +35,19 @@ Claude Code keep using the user's logged-in plan.
 
 **BYOK (per-installation keys).** Instead of (or in addition to) the env vars
 above, each installation can supply its own provider keys via the dashboard.
-Those are stored in Postgres and used only for that installation's traffic.
+Those are stored in Postgres and used only for that installation's traffic. A
+key may also carry its own base URL, which overrides the deployment's endpoint
+for that provider on that installation's requests — useful when a customer runs
+their own deployment of an OpenAI-compatible provider.
 See [BYOK encryption](#byok-encryption).
+
+In `selfhosted` mode BYOK is always active (it's the only credentialing path).
+In `managed` mode it is opt-in per installation: the control plane sets
+`byok_enabled` on the installation row, and until it does, the auth middleware
+strips BYOK keys so a stored key can't spend against a deployment that bills
+prepaid credits. Once enabled, a BYOK turn debits no inference cost (the
+customer paid their own provider) and is charged a platform fee instead,
+recorded as a separate `byok_fee` ledger row.
 
 ## Postgres
 

--- a/internal/auth/external_api_key.go
+++ b/internal/auth/external_api_key.go
@@ -14,9 +14,7 @@ type ExternalAPIKey struct {
 	KeyPrefix      string
 	KeySuffix      string
 	KeyFingerprint string
-	// BaseURL overrides the deployment's configured upstream endpoint for this
-	// provider when non-empty, letting a customer point at their own
-	// deployment rather than the vendor's public endpoint.
+	// BaseURL overrides the provider's deployment endpoint for this key; non-empty on BYOK keys only.
 	BaseURL    string
 	CreatedAt  time.Time
 	LastUsedAt *time.Time

--- a/internal/auth/external_api_key.go
+++ b/internal/auth/external_api_key.go
@@ -9,13 +9,17 @@ import (
 type ExternalAPIKey struct {
 	ID             string
 	InstallationID string
-	Provider       string // "anthropic" | "openai" | "google"
+	Provider       string // one of providers.Provider* — see providers.APIKeyEnvVars
 	Name           *string
 	KeyPrefix      string
 	KeySuffix      string
 	KeyFingerprint string
-	CreatedAt      time.Time
-	LastUsedAt     *time.Time
+	// BaseURL overrides the deployment's configured upstream endpoint for this
+	// provider when non-empty, letting a customer point at their own
+	// deployment rather than the vendor's public endpoint.
+	BaseURL    string
+	CreatedAt  time.Time
+	LastUsedAt *time.Time
 	// Plaintext is populated after decrypt; never logged.
 	Plaintext []byte
 }
@@ -29,6 +33,7 @@ type CreateExternalAPIKeyParams struct {
 	KeySuffix      string
 	KeyFingerprint string
 	Name           *string
+	BaseURL        *string
 	CreatedBy      *string
 }
 

--- a/internal/auth/installation.go
+++ b/internal/auth/installation.go
@@ -70,11 +70,8 @@ type Installation struct {
 	PolicyRoutingIntent string
 	// AITrainingAllowed is the fail-closed privacy snapshot used by online learning.
 	AITrainingAllowed bool
-	// ByokEnabled opts a managed-mode installation into honoring its own BYOK
-	// provider keys. Managed deploys bill via prepaid credits, so BYOK is
-	// off by default there: without this flag the auth middleware strips
-	// external keys and the deployment key serves the turn. Self-hosted
-	// ignores the flag entirely — BYOK is the only credentialing path there.
+	// ByokEnabled opts a managed-mode installation into BYOK; managed deploys
+	// are off by default (they bill via prepaid credits). Self-hosted ignores it.
 	ByokEnabled bool
 }
 

--- a/internal/auth/installation.go
+++ b/internal/auth/installation.go
@@ -70,6 +70,12 @@ type Installation struct {
 	PolicyRoutingIntent string
 	// AITrainingAllowed is the fail-closed privacy snapshot used by online learning.
 	AITrainingAllowed bool
+	// ByokEnabled opts a managed-mode installation into honoring its own BYOK
+	// provider keys. Managed deploys bill via prepaid credits, so BYOK is
+	// off by default there: without this flag the auth middleware strips
+	// external keys and the deployment key serves the turn. Self-hosted
+	// ignores the flag entirely — BYOK is the only credentialing path there.
+	ByokEnabled bool
 }
 
 type CreateInstallationParams struct {

--- a/internal/billing/repo.go
+++ b/internal/billing/repo.go
@@ -48,8 +48,13 @@ type DebitParams struct {
 	DeltaUsdMicros     int64  // signed: negative for real debit, 0 for override pass-through
 	NotionalCostMicros int64  // always the would-be charge, populated regardless of override
 	EntryType          string // 'inference', 'adjustment', etc.
-	RouterRequestID    string // upstream call id; suffix ('_summary','_main') used for handover rows
-	RouterModel        string
+	// FeeUsdMicros, when non-zero, writes a second ledger row of FeeEntryType
+	// in the same statement. BYOK turns use it to charge Weave's platform fee
+	// while the inference row records upstream cost at delta 0.
+	FeeUsdMicros    int64
+	FeeEntryType    string
+	RouterRequestID string // upstream call id; suffix ('_summary','_main') used for handover rows
+	RouterModel     string
 	// APIKeyID, if non-empty, attributes the debit to that key, bumping its
 	// lifetime spent_usd_micros in the same transaction.
 	APIKeyID string

--- a/internal/billing/service.go
+++ b/internal/billing/service.go
@@ -321,11 +321,9 @@ func computeNotionalMicros(p DebitInferenceParams) int64 {
 	return catalog.USDToMicros(inUSD + outUSD)
 }
 
-// byokFeeMicros returns Weave's platform fee, as a positive micros magnitude,
-// for a BYOK turn whose upstream cost was notionalMicros. Integer math keeps
-// the fee exact at micro precision instead of round-tripping through float USD.
-// Rounds half away from zero so a sub-micro fee on a tiny turn still charges
-// something rather than silently becoming free.
+// byokFeeMicros returns Weave's platform fee as a positive micros magnitude.
+// Integer math avoids a float round-trip; rounds half away from zero so a
+// sub-micro fee on a tiny turn still charges something rather than rounding free.
 func byokFeeMicros(notionalMicros int64) int64 {
 	if notionalMicros <= 0 {
 		return 0

--- a/internal/billing/service.go
+++ b/internal/billing/service.go
@@ -321,7 +321,7 @@ func computeNotionalMicros(p DebitInferenceParams) int64 {
 
 // byokFeeMicros returns Weave's platform fee as a positive micros magnitude.
 // Integer math avoids a float round-trip; rounds half away from zero so a
-// sub-micro fee on a tiny turn still charges something rather than rounding free.
+// sub-micro fee rounds up rather than disappearing.
 func byokFeeMicros(notionalMicros int64) int64 {
 	if notionalMicros <= 0 {
 		return 0

--- a/internal/billing/service.go
+++ b/internal/billing/service.go
@@ -61,6 +61,16 @@ func SubscriptionOnlyFromContext(ctx context.Context) bool {
 // router.organization_credit_ledger.entry_type.
 const EntryTypeInference = "inference"
 
+// EntryTypeByokFee is the entry_type for Weave's platform fee on a turn served
+// by the customer's own provider key. Keep in sync with the CHECK constraint on
+// router.organization_credit_ledger.entry_type.
+const EntryTypeByokFee = "byok_fee"
+
+// ByokFeeRate is Weave's platform fee on a BYOK turn, as a fraction of the
+// upstream cost the customer paid their own provider. The customer is billed
+// only this fee; the inference row records upstream cost at delta 0.
+const ByokFeeRate = 0.05
+
 // MinBalanceMicros: requests 402 when balance <= this. 0 matches
 // OpenAI/Anthropic prepaid semantics — block at zero, let in-flight
 // debits settle.
@@ -193,6 +203,10 @@ type DebitInferenceParams struct {
 	// SubscriptionServed: turn ran on the customer's own Anthropic/Codex
 	// subscription token, so Weave charges nothing.
 	SubscriptionServed bool
+	// ByokServed: turn ran on the customer's own provider key, so they already
+	// paid the upstream directly. Weave debits ByokFeeRate of the upstream cost
+	// as a platform fee instead of the full inference cost.
+	ByokServed bool
 	// APIKeyID attributes the debit to the authenticating key for
 	// spend-cap tracking; empty leaves per-key spend untouched.
 	APIKeyID string
@@ -206,22 +220,35 @@ type DebitInferenceParams struct {
 // pass-through or subscription-served turn (already paid for), but always
 // records NotionalCostMicros as a shadow trail.
 //
+// A BYOK turn debits 0 on the inference row too (the customer paid their own
+// provider) and adds a second byok_fee row for ByokFeeRate of the upstream
+// cost — Weave's platform charge. Override and subscription outrank BYOK: a
+// free-credits org isn't charged a fee, and a subscription-served turn had no
+// upstream BYOK spend to take a percentage of.
+//
 // Returns the post-debit balance (0 on override, since balance doesn't
 // change).
 func (s *Service) DebitForInference(ctx context.Context, p DebitInferenceParams) (int64, error) {
 	warnOnUnknownPricing(p)
 	notional := computeNotionalMicros(p)
 	delta := -notional
+	var fee int64
 	switch {
 	case p.HasOverride, p.SubscriptionServed:
 		// Already paid for — debit nothing, but still record notional cost below.
 		delta = 0
+	case p.ByokServed:
+		// Customer paid their upstream directly; Weave charges only the fee.
+		delta = 0
+		fee = -byokFeeMicros(notional)
 	}
 	balanceAfter, err := s.repo.DebitInference(ctx, DebitParams{
 		OrganizationID:     p.OrganizationID,
 		DeltaUsdMicros:     delta,
 		NotionalCostMicros: notional,
 		EntryType:          EntryTypeInference,
+		FeeUsdMicros:       fee,
+		FeeEntryType:       EntryTypeByokFee,
 		RouterRequestID:    p.RouterRequestID,
 		RouterModel:        p.Model,
 		APIKeyID:           p.APIKeyID,
@@ -230,7 +257,7 @@ func (s *Service) DebitForInference(ctx context.Context, p DebitInferenceParams)
 	if err != nil {
 		return balanceAfter, err
 	}
-	s.maybeSignalRecharge(ctx, p.OrganizationID, delta, balanceAfter)
+	s.maybeSignalRecharge(ctx, p.OrganizationID, delta+fee, balanceAfter)
 	return balanceAfter, nil
 }
 
@@ -292,4 +319,18 @@ func computeNotionalMicros(p DebitInferenceParams) int64 {
 	inUSD := catalog.EffectiveInputCost(p.InputTokens, p.CacheCreation, p.CacheRead, p.Pricing.InputUSDPer1M, p.Pricing, p.Provider)
 	outUSD := catalog.EffectiveOutputCost(p.OutputTokens, p.Pricing.OutputUSDPer1M)
 	return catalog.USDToMicros(inUSD + outUSD)
+}
+
+// byokFeeMicros returns Weave's platform fee, as a positive micros magnitude,
+// for a BYOK turn whose upstream cost was notionalMicros. Integer math keeps
+// the fee exact at micro precision instead of round-tripping through float USD.
+// Rounds half away from zero so a sub-micro fee on a tiny turn still charges
+// something rather than silently becoming free.
+func byokFeeMicros(notionalMicros int64) int64 {
+	if notionalMicros <= 0 {
+		return 0
+	}
+	const scale = 10_000 // ByokFeeRate expressed as basis-points-of-a-basis-point
+	rate := int64(ByokFeeRate * scale)
+	return (notionalMicros*rate + scale/2) / scale
 }

--- a/internal/billing/service.go
+++ b/internal/billing/service.go
@@ -202,9 +202,8 @@ type DebitInferenceParams struct {
 	// SubscriptionServed: turn ran on the customer's own Anthropic/Codex
 	// subscription token, so Weave charges nothing.
 	SubscriptionServed bool
-	// ByokServed: turn ran on the customer's own provider key, so they already
-	// paid the upstream directly. Weave debits ByokFeeRate of the upstream cost
-	// as a platform fee instead of the full inference cost.
+	// ByokServed: turn ran on the customer's own provider key; Weave charges
+	// only ByokFeeRate of the upstream cost rather than full inference cost.
 	ByokServed bool
 	// APIKeyID attributes the debit to the authenticating key for
 	// spend-cap tracking; empty leaves per-key spend untouched.

--- a/internal/billing/service.go
+++ b/internal/billing/service.go
@@ -218,11 +218,9 @@ type DebitInferenceParams struct {
 // pass-through or subscription-served turn (already paid for), but always
 // records NotionalCostMicros as a shadow trail.
 //
-// A BYOK turn debits 0 on the inference row too (the customer paid their own
-// provider) and adds a second byok_fee row for ByokFeeRate of the upstream
-// cost — Weave's platform charge. Override and subscription outrank BYOK: a
-// free-credits org isn't charged a fee, and a subscription-served turn had no
-// upstream BYOK spend to take a percentage of.
+// A BYOK turn debits 0 on the inference row (the customer paid their own
+// provider) and adds a byok_fee row for ByokFeeRate of the upstream cost.
+// Override and subscription outrank BYOK.
 //
 // Returns the post-debit balance (0 on override, since balance doesn't
 // change).

--- a/internal/billing/service.go
+++ b/internal/billing/service.go
@@ -67,8 +67,7 @@ const EntryTypeInference = "inference"
 const EntryTypeByokFee = "byok_fee"
 
 // ByokFeeRate is Weave's platform fee on a BYOK turn, as a fraction of the
-// upstream cost the customer paid their own provider. The customer is billed
-// only this fee; the inference row records upstream cost at delta 0.
+// upstream cost the customer paid their own provider.
 const ByokFeeRate = 0.05
 
 // MinBalanceMicros: requests 402 when balance <= this. 0 matches

--- a/internal/billing/service_test.go
+++ b/internal/billing/service_test.go
@@ -616,11 +616,9 @@ func TestHasOverrideFromContext_True(t *testing.T) {
 }
 
 func TestDebitForInference_ByokReturnsPostFeeBalance(t *testing.T) {
-	// The returned balance must be the TRUE post-debit balance, including the
-	// fee. The inference ledger row deliberately records the PRE-fee balance for
-	// audit ordering, so a query that returns that row instead hands callers a
-	// balance the org never had — and maybeSignalRecharge (which reconstructs
-	// the pre-debit balance by subtracting delta) then misses autopay crossings.
+	// The returned balance must be post-fee. The inference row records balance
+	// before the fee CTE runs, so returning it would give a stale figure and
+	// maybeSignalRecharge would miss threshold crossings on fee-only debits.
 	repo := &fakeRepo{balanceRowExists: true, balanceMicros: 1_000_000}
 	svc := billing.NewService(repo)
 	balance, err := svc.DebitForInference(context.Background(), billing.DebitInferenceParams{

--- a/internal/billing/service_test.go
+++ b/internal/billing/service_test.go
@@ -614,3 +614,54 @@ func TestHasOverrideFromContext_True(t *testing.T) {
 	ctx := context.WithValue(context.Background(), billing.HasOverrideContextKey, true)
 	assert.True(t, billing.HasOverrideFromContext(ctx))
 }
+
+func TestDebitForInference_ByokReturnsPostFeeBalance(t *testing.T) {
+	// The returned balance must be the TRUE post-debit balance, including the
+	// fee. The inference ledger row deliberately records the PRE-fee balance for
+	// audit ordering, so a query that returns that row instead hands callers a
+	// balance the org never had — and maybeSignalRecharge (which reconstructs
+	// the pre-debit balance by subtracting delta) then misses autopay crossings.
+	repo := &fakeRepo{balanceRowExists: true, balanceMicros: 1_000_000}
+	svc := billing.NewService(repo)
+	balance, err := svc.DebitForInference(context.Background(), billing.DebitInferenceParams{
+		OrganizationID: "org_byok",
+		InputTokens:    1_000_000,
+		Pricing:        catalog.Pricing{InputUSDPer1M: 1.00},
+		Provider:       providers.ProviderAnthropic,
+		ByokServed:     true,
+	})
+	require.NoError(t, err)
+
+	// $1.00 upstream → 5% fee = $0.05 = 50_000 micros.
+	require.Len(t, repo.ledgerCalls, 1)
+	assert.Equal(t, int64(-50_000), repo.ledgerCalls[0].FeeUsdMicros)
+	assert.Equal(t, int64(950_000), balance,
+		"returned balance must be post-fee (1_000_000 - 50_000), never the pre-fee 1_000_000")
+}
+
+func TestDebitForInference_ByokFeeCrossingSignalsAutopay(t *testing.T) {
+	// End-to-end guard on the bug above: a BYOK turn whose FEE alone crosses the
+	// autopay threshold must still signal. If the debit path reports a pre-fee
+	// balance, this crossing is silently missed and the org never auto-recharges.
+	repo := &fakeRepo{
+		balanceRowExists: true,
+		balanceMicros:    1_000_000,
+		autopayEnabled:   true,
+		autopayThreshold: 975_000,
+	}
+	notifier := &fakeAutopayNotifier{}
+	svc := billing.NewService(repo).WithAutopayNotifier(notifier)
+
+	_, err := svc.DebitForInference(context.Background(), billing.DebitInferenceParams{
+		OrganizationID: "org_byok",
+		InputTokens:    1_000_000,
+		Pricing:        catalog.Pricing{InputUSDPer1M: 1.00},
+		Provider:       providers.ProviderAnthropic,
+		ByokServed:     true,
+	})
+	require.NoError(t, err)
+
+	// Pre-debit 1_000_000 (>= 975_000), post-debit 950_000 (< 975_000) = a crossing.
+	assert.Equal(t, []string{"org_byok"}, notifier.calls(),
+		"a BYOK fee that crosses the autopay threshold must signal a recharge")
+}

--- a/internal/billing/service_test.go
+++ b/internal/billing/service_test.go
@@ -85,7 +85,9 @@ func (r *fakeRepo) DebitInference(_ context.Context, p billing.DebitParams) (int
 	if !r.balanceRowExists {
 		return 0, billing.ErrBalanceRowMissing
 	}
-	r.balanceMicros += p.DeltaUsdMicros
+	// Mirrors the real repo: the balance moves by delta + fee, since the fee
+	// row is written in the same statement.
+	r.balanceMicros += p.DeltaUsdMicros + p.FeeUsdMicros
 	r.ledgerCalls = append(r.ledgerCalls, p)
 	return r.balanceMicros, nil
 }
@@ -187,6 +189,104 @@ func TestDebitForInference_MatchesExportedCostMath(t *testing.T) {
 	assert.Equal(t, billing.EntryTypeInference, repo.ledgerCalls[0].EntryType)
 	assert.Equal(t, "req_abc", repo.ledgerCalls[0].RouterRequestID)
 	assert.Equal(t, "claude-sonnet-4-5", repo.ledgerCalls[0].RouterModel)
+}
+
+func TestDebitForInference_ByokChargesFeeOnlyNotUpstreamCost(t *testing.T) {
+	// The customer paid their own provider for the upstream call, so Weave
+	// debits only its platform fee. The inference row still carries the full
+	// notional cost so the savings dashboard can price the turn.
+	repo := &fakeRepo{balanceRowExists: true, balanceMicros: 10_000_000}
+	svc := billing.NewService(repo)
+	p := catalog.Pricing{InputUSDPer1M: 3.00, OutputUSDPer1M: 15.00, CacheReadMultiplier: 0.10}
+	balance, err := svc.DebitForInference(context.Background(), billing.DebitInferenceParams{
+		OrganizationID:  "org_byok",
+		RouterRequestID: "req_byok",
+		Model:           "claude-sonnet-4-5",
+		Provider:        providers.ProviderAnthropic,
+		InputTokens:     1_000_000,
+		OutputTokens:    250_000,
+		Pricing:         p,
+		ByokServed:      true,
+	})
+	require.NoError(t, err)
+
+	// Same turn as TestDebitForInference_MatchesExportedCostMath: $6.75 upstream.
+	const notionalMicros = int64(6_750_000)
+	const expectedFee = int64(337_500) // 5% of $6.75 = $0.3375
+
+	require.Len(t, repo.ledgerCalls, 1, "the fee rides on the same atomic debit, not a second call")
+	row := repo.ledgerCalls[0]
+	assert.Equal(t, int64(0), row.DeltaUsdMicros,
+		"a BYOK turn must not debit upstream cost — the customer already paid their provider")
+	assert.Equal(t, notionalMicros, row.NotionalCostMicros,
+		"notional cost is still recorded so the savings dashboard can price the turn")
+	assert.Equal(t, billing.EntryTypeInference, row.EntryType)
+	assert.Equal(t, -expectedFee, row.FeeUsdMicros, "fee is 5% of upstream cost, signed as a debit")
+	assert.Equal(t, billing.EntryTypeByokFee, row.FeeEntryType)
+	assert.Equal(t, int64(10_000_000)-expectedFee, balance,
+		"balance drops by the fee alone")
+}
+
+func TestDebitForInference_ByokFeeIsExactlyFivePercent(t *testing.T) {
+	// Guards the rate itself: a refactor that changes rounding or the constant
+	// silently re-prices every BYOK customer.
+	repo := &fakeRepo{balanceRowExists: true, balanceMicros: 1_000_000_000}
+	svc := billing.NewService(repo)
+	_, err := svc.DebitForInference(context.Background(), billing.DebitInferenceParams{
+		OrganizationID:  "org_byok",
+		RouterRequestID: "req_round",
+		Model:           "m",
+		Provider:        providers.ProviderAnthropic,
+		// $100.00 of input at $1/M — a round number so the 5% is unambiguous.
+		InputTokens: 100_000_000,
+		Pricing:     catalog.Pricing{InputUSDPer1M: 1.00},
+		ByokServed:  true,
+	})
+	require.NoError(t, err)
+	require.Len(t, repo.ledgerCalls, 1)
+	assert.Equal(t, int64(100_000_000), repo.ledgerCalls[0].NotionalCostMicros, "$100 upstream")
+	assert.Equal(t, int64(-5_000_000), repo.ledgerCalls[0].FeeUsdMicros,
+		"$100 of customer upstream spend must bill exactly $5")
+}
+
+func TestDebitForInference_OverrideOutranksByok(t *testing.T) {
+	// A free-credits/internal org must not be charged a BYOK fee.
+	repo := &fakeRepo{balanceRowExists: true, balanceMicros: 10_000_000}
+	svc := billing.NewService(repo)
+	_, err := svc.DebitForInference(context.Background(), billing.DebitInferenceParams{
+		OrganizationID:  "org_override",
+		RouterRequestID: "req_ovr",
+		Model:           "m",
+		Provider:        providers.ProviderAnthropic,
+		InputTokens:     1_000_000,
+		Pricing:         catalog.Pricing{InputUSDPer1M: 3.00},
+		HasOverride:     true,
+		ByokServed:      true,
+	})
+	require.NoError(t, err)
+	require.Len(t, repo.ledgerCalls, 1)
+	assert.Equal(t, int64(0), repo.ledgerCalls[0].DeltaUsdMicros)
+	assert.Equal(t, int64(0), repo.ledgerCalls[0].FeeUsdMicros,
+		"an override org pays no BYOK fee")
+}
+
+func TestDebitForInference_NonByokWritesNoFeeRow(t *testing.T) {
+	// Regression guard: the fee params must stay zero on the ordinary
+	// platform-key path, or every managed turn would grow a spurious fee row.
+	repo := &fakeRepo{balanceRowExists: true, balanceMicros: 10_000_000}
+	svc := billing.NewService(repo)
+	_, err := svc.DebitForInference(context.Background(), billing.DebitInferenceParams{
+		OrganizationID:  "org_plain",
+		RouterRequestID: "req_plain",
+		Model:           "m",
+		Provider:        providers.ProviderAnthropic,
+		InputTokens:     1_000_000,
+		Pricing:         catalog.Pricing{InputUSDPer1M: 3.00},
+	})
+	require.NoError(t, err)
+	require.Len(t, repo.ledgerCalls, 1)
+	assert.Equal(t, int64(-3_000_000), repo.ledgerCalls[0].DeltaUsdMicros, "full cost debited as usual")
+	assert.Equal(t, int64(0), repo.ledgerCalls[0].FeeUsdMicros, "no fee on a platform-key turn")
 }
 
 func TestDebitForInference_WarnsOnZeroPricingForRealUsage(t *testing.T) {

--- a/internal/postgres/billing_repo.go
+++ b/internal/postgres/billing_repo.go
@@ -55,11 +55,22 @@ func (r *BillingRepo) HasActiveOverride(ctx context.Context, orgID string) (bool
 // existed (the CTE returns zero rows in that case).
 func (r *BillingRepo) DebitInference(ctx context.Context, p billing.DebitParams) (int64, error) {
 	q := sqlc.New(r.tx)
+	feeEntryType := p.FeeEntryType
+	if p.FeeUsdMicros == 0 {
+		// The fee CTE no-ops on a zero fee, but entry_type is NOT NULL and
+		// CHECK-constrained, so it still needs a legal value.
+		feeEntryType = p.EntryType
+	}
 	balanceAfter, err := q.DebitOrgCredits(ctx, sqlc.DebitOrgCreditsParams{
-		OrganizationID:     p.OrganizationID,
+		OrganizationID: p.OrganizationID,
+		// The balance moves by the combined amount; the SET expression takes a
+		// single param (see the query's comment on charged_usd_micros).
+		ChargedUsdMicros:   p.DeltaUsdMicros + p.FeeUsdMicros,
 		DeltaUsdMicros:     p.DeltaUsdMicros,
 		NotionalCostMicros: p.NotionalCostMicros,
 		EntryType:          p.EntryType,
+		FeeUsdMicros:       p.FeeUsdMicros,
+		FeeEntryType:       feeEntryType,
 		RouterRequestID:    stringPtrOrNil(p.RouterRequestID),
 		RouterModel:        stringPtrOrNil(p.RouterModel),
 		APIKeyID:           uuidOrNil(p.APIKeyID),

--- a/internal/postgres/converters.go
+++ b/internal/postgres/converters.go
@@ -46,6 +46,7 @@ func toAuthInstallation(row sqlc.RouterModelRouterInstallation) *auth.Installati
 		PolicyHeaderOverridesEnabled: row.PolicyHeaderOverridesEnabled,
 		PolicyRoutingIntent:          derefString(row.PolicyRoutingIntent),
 		AITrainingAllowed:            row.AiTrainingAllowed,
+		ByokEnabled:                  row.ByokEnabled,
 	}
 }
 

--- a/internal/postgres/external_api_key_repo.go
+++ b/internal/postgres/external_api_key_repo.go
@@ -36,6 +36,7 @@ func (r *ExternalAPIKeyRepo) Create(ctx context.Context, params auth.CreateExter
 		KeySuffix:      params.KeySuffix,
 		KeyFingerprint: params.KeyFingerprint,
 		Name:           params.Name,
+		BaseURL:        params.BaseURL,
 		CreatedBy:      params.CreatedBy,
 	})
 	if err != nil {
@@ -115,6 +116,7 @@ func toExternalAPIKey(row sqlc.RouterModelRouterExternalAPIKey) *auth.ExternalAP
 		KeyPrefix:      row.KeyPrefix,
 		KeySuffix:      row.KeySuffix,
 		KeyFingerprint: row.KeyFingerprint,
+		BaseURL:        derefString(row.BaseURL),
 		CreatedAt:      timestampOrZero(row.CreatedAt),
 	}
 	key.Name = row.Name

--- a/internal/providers/anthropic/client.go
+++ b/internal/providers/anthropic/client.go
@@ -162,7 +162,8 @@ func (c *Client) Proxy(ctx context.Context, decision router.Decision, prep provi
 	ctx, cancel := context.WithCancelCause(ctx)
 	defer cancel(nil)
 
-	upstream, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/v1/messages", bytes.NewReader(prep.Body))
+	baseURL := proxy.EffectiveBaseURL(ctx, c.baseURL)
+	upstream, err := http.NewRequestWithContext(ctx, http.MethodPost, baseURL+"/v1/messages", bytes.NewReader(prep.Body))
 	if err != nil {
 		return fmt.Errorf("build upstream request: %w", err)
 	}
@@ -260,7 +261,7 @@ func (c *Client) Proxy(ctx context.Context, decision router.Decision, prep provi
 }
 
 func (c *Client) Passthrough(ctx context.Context, prep providers.PreparedRequest, w http.ResponseWriter, r *http.Request) error {
-	url := c.baseURL + r.URL.Path
+	url := proxy.EffectiveBaseURL(ctx, c.baseURL) + r.URL.Path
 	if r.URL.RawQuery != "" {
 		url += "?" + r.URL.RawQuery
 	}

--- a/internal/providers/google/native_client.go
+++ b/internal/providers/google/native_client.go
@@ -92,7 +92,7 @@ func (c *NativeClient) Proxy(ctx context.Context, decision router.Decision, prep
 		method = ":streamGenerateContent"
 		query = "?alt=sse"
 	}
-	url := c.baseURL + "/v1beta/models/" + decision.Model + method + query
+	url := proxy.EffectiveBaseURL(ctx, c.baseURL) + "/v1beta/models/" + decision.Model + method + query
 
 	upstream, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(prep.Body))
 	if err != nil {
@@ -168,7 +168,7 @@ func (c *NativeClient) Passthrough(ctx context.Context, prep providers.PreparedR
 	} else if !strings.HasPrefix(suffix, "/v1beta") {
 		suffix = "/v1beta" + suffix
 	}
-	url := c.baseURL + suffix
+	url := proxy.EffectiveBaseURL(ctx, c.baseURL) + suffix
 	if r.URL.RawQuery != "" {
 		url += "?" + r.URL.RawQuery
 	}

--- a/internal/providers/openai/client.go
+++ b/internal/providers/openai/client.go
@@ -192,7 +192,10 @@ func (c *Client) Proxy(ctx context.Context, decision router.Decision, prep provi
 	// /responses endpoint (Responses schema only).
 	codexCreds := codexSubscriptionCreds(ctx)
 	useCodex := codexCreds != nil && prep.Endpoint == providers.EndpointResponses
-	baseURL := c.baseURL
+	// A BYOK key may point at a customer-hosted OpenAI-compatible endpoint; the
+	// Codex branch below still wins, since a Codex subscription bearer only
+	// authenticates against the Codex backend.
+	baseURL := proxy.EffectiveBaseURL(ctx, c.baseURL)
 	path := "/v1/chat/completions"
 	if prep.Endpoint == providers.EndpointResponses {
 		path = "/v1/responses"
@@ -381,7 +384,7 @@ func logStreamStall(model, path string, budget time.Duration, bytesReceived int6
 func (c *Client) Passthrough(ctx context.Context, prep providers.PreparedRequest, w http.ResponseWriter, r *http.Request) error {
 	// Codex subscriptions are served only via the routed Responses dispatch
 	// (Proxy), never here — no Codex backend switch needed.
-	url := c.baseURL + r.URL.Path
+	url := proxy.EffectiveBaseURL(ctx, c.baseURL) + r.URL.Path
 	if r.URL.RawQuery != "" {
 		url += "?" + r.URL.RawQuery
 	}

--- a/internal/providers/openaicompat/client.go
+++ b/internal/providers/openaicompat/client.go
@@ -178,7 +178,8 @@ func (c *Client) Proxy(ctx context.Context, decision router.Decision, prep provi
 	defer cancel(nil)
 
 	body := rewriteModelField(prep.Body, c.modelIDMap)
-	upstream, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/chat/completions", bytes.NewReader(body))
+	baseURL := proxy.EffectiveBaseURL(ctx, c.baseURL)
+	upstream, err := http.NewRequestWithContext(ctx, http.MethodPost, baseURL+"/chat/completions", bytes.NewReader(body))
 	if err != nil {
 		return fmt.Errorf("build upstream request: %w", err)
 	}
@@ -213,7 +214,7 @@ func (c *Client) Proxy(ctx context.Context, decision router.Decision, prep provi
 		httputil.LogUpstreamStatus(
 			"Upstream OpenAI-compatible provider returned error status",
 			resp.StatusCode,
-			"base_url", c.baseURL,
+			"base_url", baseURL,
 			"routed_model", decision.Model,
 			"body_preview", httputil.PreviewBytes(bufBody),
 			"body_total_bytes", totalRead,
@@ -260,7 +261,7 @@ func (c *Client) Proxy(ctx context.Context, decision router.Decision, prep provi
 
 	streamErr := httputil.StreamBody(ctx, cancel, c.idleTimeout(), resp.Body, resp.StatusCode, w, t)
 	if errors.Is(streamErr, httputil.ErrUpstreamIdleTimeout) || errors.Is(streamErr, httputil.ErrUpstreamOutputStall) || errors.Is(streamErr, httputil.ErrUpstreamSlowThroughput) {
-		logStreamStall(decision.Model, c.baseURL, streamErr)
+		logStreamStall(decision.Model, baseURL, streamErr)
 	}
 	return streamErr
 }
@@ -286,7 +287,8 @@ func logStreamStall(model, baseURL string, cause error) {
 // Passthrough strips the inbound /v1 prefix to avoid double-prefixing with the configured baseURL.
 func (c *Client) Passthrough(ctx context.Context, prep providers.PreparedRequest, w http.ResponseWriter, r *http.Request) error {
 	suffix := strings.TrimPrefix(r.URL.Path, "/v1")
-	url := c.baseURL + suffix
+	baseURL := proxy.EffectiveBaseURL(ctx, c.baseURL)
+	url := baseURL + suffix
 	if r.URL.RawQuery != "" {
 		url += "?" + r.URL.RawQuery
 	}
@@ -315,7 +317,7 @@ func (c *Client) Passthrough(ctx context.Context, prep providers.PreparedRequest
 	providers.CopyUpstreamHeaders(w, resp)
 	w.WriteHeader(resp.StatusCode)
 	if resp.StatusCode >= 400 {
-		return httputil.WritePassthroughError(w, resp, nil, nil, "Upstream OpenAI-compatible provider returned error status (passthrough)", "base_url", c.baseURL, "path", r.URL.Path)
+		return httputil.WritePassthroughError(w, resp, nil, nil, "Upstream OpenAI-compatible provider returned error status (passthrough)", "base_url", baseURL, "path", r.URL.Path)
 	}
 	_, err = io.Copy(w, resp.Body)
 	return err

--- a/internal/providers/openaicompat/client_test.go
+++ b/internal/providers/openaicompat/client_test.go
@@ -80,8 +80,6 @@ func TestProxy_BYOKCredentialsOverrideEnvKey(t *testing.T) {
 
 // TestProxy_BYOKBaseURLOverridesDeploymentBaseURL: a BYOK key carrying its own
 // base URL must be dispatched to the customer's endpoint, not the deployment's.
-// This is what lets a managed installation point at a self-hosted
-// OpenAI-compatible provider instead of the vendor's public endpoint.
 func TestProxy_BYOKBaseURLOverridesDeploymentBaseURL(t *testing.T) {
 	deploymentHit := false
 	deployment := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/providers/openaicompat/client_test.go
+++ b/internal/providers/openaicompat/client_test.go
@@ -78,6 +78,76 @@ func TestProxy_BYOKCredentialsOverrideEnvKey(t *testing.T) {
 		"BYOK credentials on context must override the deployment-level env key")
 }
 
+// TestProxy_BYOKBaseURLOverridesDeploymentBaseURL: a BYOK key carrying its own
+// base URL must be dispatched to the customer's endpoint, not the deployment's.
+// This is what lets a managed installation point at a self-hosted
+// OpenAI-compatible provider instead of the vendor's public endpoint.
+func TestProxy_BYOKBaseURLOverridesDeploymentBaseURL(t *testing.T) {
+	deploymentHit := false
+	deployment := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		deploymentHit = true
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"id":"from-deployment"}`))
+	}))
+	defer deployment.Close()
+
+	var customerPath, customerAuth string
+	customer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		customerPath = r.URL.Path
+		customerAuth = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"id":"from-customer","object":"chat.completion"}`))
+	}))
+	defer customer.Close()
+
+	c := openaicompat.NewClient("deployment-key", deployment.URL+"/api/v1")
+	// Trailing slash is deliberate: EffectiveBaseURL must normalize it so the
+	// joined path doesn't end up with a doubled separator.
+	byok := &proxy.Credentials{
+		APIKey:  []byte("mk-customer-key"),
+		Source:  "byok",
+		BaseURL: customer.URL + "/v1/",
+	}
+	ctx := context.WithValue(context.Background(), proxy.CredentialsContextKey{}, byok)
+
+	rec := httptest.NewRecorder()
+	clientReq := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(""))
+	prep := providers.PreparedRequest{Body: []byte(`{"model":"m","messages":[]}`), Headers: make(http.Header)}
+	err := c.Proxy(ctx, router.Decision{Model: "m"}, prep, rec, clientReq)
+
+	require.NoError(t, err)
+	assert.False(t, deploymentHit, "a BYOK base URL must divert the call away from the deployment endpoint")
+	assert.Equal(t, "/v1/chat/completions", customerPath)
+	assert.Equal(t, "Bearer mk-customer-key", customerAuth)
+}
+
+// TestProxy_DeploymentBaseURLUsedWhenBYOKOmitsIt: a BYOK key with no base URL
+// keeps the deployment's endpoint — only the credential changes.
+func TestProxy_DeploymentBaseURLUsedWhenBYOKOmitsIt(t *testing.T) {
+	var gotPath string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"id":"chatcmpl-1","object":"chat.completion"}`))
+	}))
+	defer upstream.Close()
+
+	c := openaicompat.NewClient("deployment-key", upstream.URL+"/api/v1")
+	byok := &proxy.Credentials{APIKey: []byte("mk-customer-key"), Source: "byok"}
+	ctx := context.WithValue(context.Background(), proxy.CredentialsContextKey{}, byok)
+
+	rec := httptest.NewRecorder()
+	clientReq := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(""))
+	prep := providers.PreparedRequest{Body: []byte(`{"model":"m","messages":[]}`), Headers: make(http.Header)}
+	err := c.Proxy(ctx, router.Decision{Model: "m"}, prep, rec, clientReq)
+
+	require.NoError(t, err)
+	assert.Equal(t, "/api/v1/chat/completions", gotPath,
+		"a BYOK key without a base URL must keep using the deployment endpoint")
+}
+
 // TestProxy_DevModeEnvKeyUsedWhenNoCredentialsOnContext: with no context
 // credentials (WithAuth skipped, e.g. ROUTER_DEV_MODE), setAuth must fall
 // back to the deployment env key — the path self-hosters/local dev rely on.

--- a/internal/proxy/byok_billing_internal_test.go
+++ b/internal/proxy/byok_billing_internal_test.go
@@ -1,0 +1,47 @@
+package proxy
+
+import (
+	"context"
+	"testing"
+
+	"workweave/router/internal/auth"
+	"workweave/router/internal/providers"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func ctxWithExternalKeys(keys ...*auth.ExternalAPIKey) context.Context {
+	return context.WithValue(context.Background(), ExternalAPIKeysContextKey{}, keys)
+}
+
+func TestServedOnBYOK_KeysOffCredentialSource(t *testing.T) {
+	assert.True(t, servedOnBYOK(ctxWithCreds(&Credentials{Source: credSourceBYOK})),
+		"a turn dispatched on a BYOK credential bills at the fee rate")
+	assert.False(t, servedOnBYOK(ctxWithCreds(&Credentials{Source: credSourceSubscription})),
+		"a subscription turn is free, not fee-billed")
+	assert.False(t, servedOnBYOK(context.Background()),
+		"a deployment-key turn bills full cost")
+}
+
+// byokServedForProvider backs fee billing for the handover/compaction summary
+// calls. Those dispatch on their own credential context, so the outer ctx's
+// resolved credential is not a reliable signal — the BYOK row is.
+func TestByokServedForProvider(t *testing.T) {
+	ctx := ctxWithExternalKeys(
+		&auth.ExternalAPIKey{Provider: providers.ProviderAnthropic, Plaintext: []byte("sk-ant-byok")},
+		// An empty-plaintext row can't authenticate an upstream call, so it must
+		// not count as BYOK-served (mirrors BuildCredentialsMap's filter).
+		&auth.ExternalAPIKey{Provider: providers.ProviderOpenAI, Plaintext: nil},
+	)
+
+	assert.True(t, byokServedForProvider(ctx, providers.ProviderAnthropic),
+		"a usable BYOK key for the summarizer's provider means the customer paid that upstream")
+	assert.False(t, byokServedForProvider(ctx, providers.ProviderOpenAI),
+		"an empty-plaintext BYOK row must not flip the turn to fee billing")
+	assert.False(t, byokServedForProvider(ctx, providers.ProviderGoogle),
+		"a provider with no BYOK row bills full cost")
+	assert.False(t, byokServedForProvider(ctx, ""),
+		"an unreported summarizer provider must not be guessed as BYOK")
+	assert.False(t, byokServedForProvider(context.Background(), providers.ProviderAnthropic),
+		"no BYOK rows on the request means no fee billing")
+}

--- a/internal/proxy/compaction.go
+++ b/internal/proxy/compaction.go
@@ -197,6 +197,7 @@ func (s *Service) billCompactionSummary(ctx context.Context, requestID, external
 		CacheRead:       usage.CacheRead,
 		Pricing:         sumPricing,
 		HasOverride:     billing.HasOverrideFromContext(ctx),
+		ByokServed:      byokServedForProvider(ctx, usage.Provider),
 		APIKeyID:        apiKeyID,
 		RouterUserID:    auth.UserIDFrom(ctx),
 	})

--- a/internal/proxy/credentials.go
+++ b/internal/proxy/credentials.go
@@ -39,11 +39,8 @@ type Credentials struct {
 	// AccountID is the ChatGPT-Account-ID paired with a Codex subscription
 	// bearer; the Codex backend 401/403s without it. Never logged.
 	AccountID []byte
-	// BaseURL overrides the provider client's configured upstream endpoint for
-	// this request when non-empty. Only BYOK credentials set it: a customer's
-	// key may authenticate against their own deployment of an
-	// OpenAI-compatible provider rather than the vendor's public endpoint,
-	// and the boot-time base URL is deployment-wide.
+	// BaseURL overrides the upstream endpoint per-request; non-empty only on BYOK
+	// credentials, where the boot-time deployment URL is provider-wide, not per-key.
 	BaseURL string
 }
 

--- a/internal/proxy/credentials.go
+++ b/internal/proxy/credentials.go
@@ -44,10 +44,8 @@ type Credentials struct {
 	BaseURL string
 }
 
-// EffectiveBaseURL returns the per-request upstream base URL override, or
-// fallback when the request carries none. Provider clients call this instead
-// of reading their boot-time base URL directly so a BYOK key pointing at a
-// customer-hosted endpoint is honored.
+// EffectiveBaseURL returns the BYOK key's per-request base URL if set,
+// or fallback (the provider's boot-time deployment URL).
 func EffectiveBaseURL(ctx context.Context, fallback string) string {
 	creds := CredentialsFromContext(ctx)
 	if creds == nil || creds.BaseURL == "" {

--- a/internal/proxy/credentials.go
+++ b/internal/proxy/credentials.go
@@ -39,6 +39,24 @@ type Credentials struct {
 	// AccountID is the ChatGPT-Account-ID paired with a Codex subscription
 	// bearer; the Codex backend 401/403s without it. Never logged.
 	AccountID []byte
+	// BaseURL overrides the provider client's configured upstream endpoint for
+	// this request when non-empty. Only BYOK credentials set it: a customer's
+	// key may authenticate against their own deployment of an
+	// OpenAI-compatible provider rather than the vendor's public endpoint,
+	// and the boot-time base URL is deployment-wide.
+	BaseURL string
+}
+
+// EffectiveBaseURL returns the per-request upstream base URL override, or
+// fallback when the request carries none. Provider clients call this instead
+// of reading their boot-time base URL directly so a BYOK key pointing at a
+// customer-hosted endpoint is honored.
+func EffectiveBaseURL(ctx context.Context, fallback string) string {
+	creds := CredentialsFromContext(ctx)
+	if creds == nil || creds.BaseURL == "" {
+		return fallback
+	}
+	return strings.TrimRight(creds.BaseURL, "/")
 }
 
 // ExternalAPIKeysContextKey is the request-context key for external API keys
@@ -58,8 +76,9 @@ func BuildCredentialsMap(keys []*auth.ExternalAPIKey) map[string]*Credentials {
 			continue
 		}
 		m[key.Provider] = &Credentials{
-			APIKey: key.Plaintext,
-			Source: credSourceBYOK,
+			APIKey:  key.Plaintext,
+			Source:  credSourceBYOK,
+			BaseURL: key.BaseURL,
 		}
 	}
 	if len(m) == 0 {

--- a/internal/proxy/fallback.go
+++ b/internal/proxy/fallback.go
@@ -348,12 +348,17 @@ func sleepWithContext(ctx context.Context, d time.Duration) error {
 
 // shouldFailover reports failover eligibility. Customer-supplied
 // credentials (BYOK or client key) bind to a single provider — retrying
-// elsewhere would 401 unexpectedly, so we skip failover.
+// elsewhere would 401 unexpectedly, so we skip failover. A BYOK row for ANY
+// provider disables it too: a failover binding re-resolves credentials and
+// would prefer that key even if the primary binding used the deployment key.
 func (s *Service) shouldFailover(ctx context.Context) bool {
 	if s.byokOnly {
 		return false
 	}
 	if CredentialsFromContext(ctx) != nil {
+		return false
+	}
+	if len(externalKeysFromContext(ctx)) > 0 {
 		return false
 	}
 	return true

--- a/internal/proxy/fallback_test.go
+++ b/internal/proxy/fallback_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"workweave/router/internal/auth"
 	"workweave/router/internal/providers"
 	"workweave/router/internal/router"
 	"workweave/router/internal/router/catalog"
@@ -653,6 +654,18 @@ func TestShouldFailover(t *testing.T) {
 		s := &Service{}
 		ctx := context.WithValue(context.Background(), CredentialsContextKey{},
 			&Credentials{APIKey: []byte("sk-ant-oat01-token"), Source: "subscription", OAuth: true})
+		assert.False(t, s.shouldFailover(ctx))
+	})
+	t.Run("BYOK keys on context disable failover", func(t *testing.T) {
+		// A managed+opted-in installation with a BYOK key for the FALLBACK
+		// binding but not the primary must not fail over: resolveAndInject
+		// would silently prefer that BYOK key on the failover attempt,
+		// spending the customer's own account without them intending it.
+		s := &Service{}
+		ctx := context.WithValue(context.Background(), ExternalAPIKeysContextKey{},
+			[]*auth.ExternalAPIKey{
+				{Provider: providers.ProviderMakora, Plaintext: []byte("mk-byok")},
+			})
 		assert.False(t, s.shouldFailover(ctx))
 	})
 }

--- a/internal/proxy/fallback_test.go
+++ b/internal/proxy/fallback_test.go
@@ -657,10 +657,8 @@ func TestShouldFailover(t *testing.T) {
 		assert.False(t, s.shouldFailover(ctx))
 	})
 	t.Run("BYOK keys on context disable failover", func(t *testing.T) {
-		// A managed+opted-in installation with a BYOK key for the FALLBACK
-		// binding but not the primary must not fail over: resolveAndInject
-		// would silently prefer that BYOK key on the failover attempt,
-		// spending the customer's own account without them intending it.
+		// resolveAndInject re-resolves credentials and would prefer a BYOK key for
+		// the fallback binding, spending the customer's account without intent.
 		s := &Service{}
 		ctx := context.WithValue(context.Background(), ExternalAPIKeysContextKey{},
 			[]*auth.ExternalAPIKey{

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -913,6 +913,15 @@ func servedOnSubscription(ctx context.Context) bool {
 	return creds != nil && creds.OAuth
 }
 
+// servedOnBYOK reports whether the turn's resolved credential is a customer-owned
+// provider key, so the customer paid their upstream directly and Weave bills only
+// its platform fee. Keys off the resolved credential rather than the presence of
+// a BYOK row: the row may exist for a provider this turn didn't route to.
+func servedOnBYOK(ctx context.Context) bool {
+	creds := CredentialsFromContext(ctx)
+	return creds != nil && creds.Source == credSourceBYOK
+}
+
 // openaiSubscriptionFromContext / openaiAccountIDFromContext return the raw Codex
 // (ChatGPT) subscription JWT and paired account-id stashed by the auth middleware
 // (router-keyed path), or "" when none.
@@ -4058,16 +4067,24 @@ func (s *Service) emitBilling(ctx context.Context, requestID, externalID string,
 		Pricing:            actPricing,
 		HasOverride:        hasOverride,
 		SubscriptionServed: routeRes.UsageBypass || servedOnSubscription(ctx),
+		ByokServed:         servedOnBYOK(ctx),
 		APIKeyID:           apiKeyID,
 		RouterUserID:       auth.UserIDFrom(ctx),
 	})
 
-	// The handover summary always runs on the deployment/BYOK key (never the
-	// subscription token), so it bills full cost regardless of the main turn.
+	// The handover summary never runs on the subscription token, so it bills
+	// full cost even when the main turn was subscription-served. It CAN run on
+	// a BYOK key (resolveSummarizerCreds prefers one for the summarizer's
+	// provider), and that spend went to the customer's own account — so it
+	// takes the fee path rather than a full-cost debit.
 	if routeRes.Handover.Invoked && !routeRes.Handover.FallbackToFullHistory {
 		sumUsage := routeRes.Handover.SummaryUsage
 		if sumUsage.Model != "" && (sumUsage.InputTokens > 0 || sumUsage.OutputTokens > 0) {
 			sumPricing, _ := catalog.PrimaryPriceFor(sumUsage.Model)
+			sumByok := false
+			if byok := BuildCredentialsMap(externalKeysFromContext(ctx)); byok != nil {
+				_, sumByok = byok[sumUsage.Provider]
+			}
 			s.fireBilling(ctx, billing.DebitInferenceParams{
 				OrganizationID:  externalID,
 				RouterRequestID: requestID + "_summary",
@@ -4079,6 +4096,7 @@ func (s *Service) emitBilling(ctx context.Context, requestID, externalID string,
 				CacheRead:       sumUsage.CacheRead,
 				Pricing:         sumPricing,
 				HasOverride:     hasOverride,
+				ByokServed:      sumByok,
 				APIKeyID:        apiKeyID,
 				RouterUserID:    auth.UserIDFrom(ctx),
 			})
@@ -4113,6 +4131,7 @@ func (s *Service) fireBilling(ctx context.Context, p billing.DebitInferenceParam
 			"balance_usd_micros", balance,
 			"override", p.HasOverride,
 			"subscription_served", p.SubscriptionServed,
+			"byok_served", p.ByokServed,
 		)
 		return
 	}
@@ -4134,6 +4153,7 @@ func logBillingDebitFailure(ctx context.Context, p billing.DebitInferenceParams,
 		"cache_read_tokens", p.CacheRead,
 		"has_override", p.HasOverride,
 		"subscription_served", p.SubscriptionServed,
+		"byok_served", p.ByokServed,
 	)
 }
 

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -922,6 +922,32 @@ func servedOnBYOK(ctx context.Context) bool {
 	return creds != nil && creds.Source == credSourceBYOK
 }
 
+// byokServedForProvider reports whether the installation has a usable BYOK key
+// for provider. Used to bill a side-channel summarizer call
+// (handover/compaction) at the fee rate: those calls dispatch on their own
+// credential context, so by the time billing runs on the outer ctx,
+// CredentialsFromContext no longer reflects what the summarizer actually used —
+// the BYOK row lookup does.
+//
+// Deliberately inspects only Provider and the emptiness of Plaintext, never the
+// key bytes themselves. Building a Credentials map here (as an earlier revision
+// did) would copy secret material into a value that flows to billing params and
+// on into log statements, which is exactly the shape CodeQL's
+// go/clear-text-logging rule flags.
+func byokServedForProvider(ctx context.Context, provider string) bool {
+	if provider == "" {
+		return false
+	}
+	for _, key := range externalKeysFromContext(ctx) {
+		// Mirrors BuildCredentialsMap's filter: an empty-plaintext row can't
+		// authenticate an upstream call, so it isn't "served on BYOK".
+		if key.Provider == provider && len(key.Plaintext) > 0 {
+			return true
+		}
+	}
+	return false
+}
+
 // openaiSubscriptionFromContext / openaiAccountIDFromContext return the raw Codex
 // (ChatGPT) subscription JWT and paired account-id stashed by the auth middleware
 // (router-keyed path), or "" when none.
@@ -3195,6 +3221,7 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 					CacheRead:       sumUsage.CacheRead,
 					Pricing:         sumPricing,
 					HasOverride:     billing.HasOverrideFromContext(ctx),
+					ByokServed:      byokServedForProvider(ctx, sumUsage.Provider),
 					APIKeyID:        apiKeyID,
 					RouterUserID:    auth.UserIDFrom(ctx),
 				})
@@ -4081,10 +4108,6 @@ func (s *Service) emitBilling(ctx context.Context, requestID, externalID string,
 		sumUsage := routeRes.Handover.SummaryUsage
 		if sumUsage.Model != "" && (sumUsage.InputTokens > 0 || sumUsage.OutputTokens > 0) {
 			sumPricing, _ := catalog.PrimaryPriceFor(sumUsage.Model)
-			sumByok := false
-			if byok := BuildCredentialsMap(externalKeysFromContext(ctx)); byok != nil {
-				_, sumByok = byok[sumUsage.Provider]
-			}
 			s.fireBilling(ctx, billing.DebitInferenceParams{
 				OrganizationID:  externalID,
 				RouterRequestID: requestID + "_summary",
@@ -4096,7 +4119,7 @@ func (s *Service) emitBilling(ctx context.Context, requestID, externalID string,
 				CacheRead:       sumUsage.CacheRead,
 				Pricing:         sumPricing,
 				HasOverride:     hasOverride,
-				ByokServed:      sumByok,
+				ByokServed:      byokServedForProvider(ctx, sumUsage.Provider),
 				APIKeyID:        apiKeyID,
 				RouterUserID:    auth.UserIDFrom(ctx),
 			})

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -923,11 +923,10 @@ func servedOnBYOK(ctx context.Context) bool {
 }
 
 // byokServedForProvider reports whether the installation has a usable BYOK key
-// for provider. Used to bill handover/compaction summary calls at the fee rate:
-// those dispatch on their own credential context, so CredentialsFromContext on
-// the outer ctx no longer reflects what the summarizer used — the BYOK row does.
-// Inspects only Provider and Plaintext emptiness, never key bytes, to avoid
-// copying secret material into billing params (CodeQL go/clear-text-logging).
+// for provider. Used to bill summarizer calls at the fee rate: those dispatch on
+// their own credential context, so the outer ctx's resolved credential is stale.
+// Inspects Plaintext emptiness only — never key bytes — to satisfy CodeQL
+// go/clear-text-logging.
 func byokServedForProvider(ctx context.Context, provider string) bool {
 	if provider == "" {
 		return false

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -923,17 +923,11 @@ func servedOnBYOK(ctx context.Context) bool {
 }
 
 // byokServedForProvider reports whether the installation has a usable BYOK key
-// for provider. Used to bill a side-channel summarizer call
-// (handover/compaction) at the fee rate: those calls dispatch on their own
-// credential context, so by the time billing runs on the outer ctx,
-// CredentialsFromContext no longer reflects what the summarizer actually used —
-// the BYOK row lookup does.
-//
-// Deliberately inspects only Provider and the emptiness of Plaintext, never the
-// key bytes themselves. Building a Credentials map here (as an earlier revision
-// did) would copy secret material into a value that flows to billing params and
-// on into log statements, which is exactly the shape CodeQL's
-// go/clear-text-logging rule flags.
+// for provider. Used to bill handover/compaction summary calls at the fee rate:
+// those dispatch on their own credential context, so CredentialsFromContext on
+// the outer ctx no longer reflects what the summarizer used — the BYOK row does.
+// Inspects only Provider and Plaintext emptiness, never key bytes, to avoid
+// copying secret material into billing params (CodeQL go/clear-text-logging).
 func byokServedForProvider(ctx context.Context, provider string) bool {
 	if provider == "" {
 		return false
@@ -4099,11 +4093,9 @@ func (s *Service) emitBilling(ctx context.Context, requestID, externalID string,
 		RouterUserID:       auth.UserIDFrom(ctx),
 	})
 
-	// The handover summary never runs on the subscription token, so it bills
-	// full cost even when the main turn was subscription-served. It CAN run on
-	// a BYOK key (resolveSummarizerCreds prefers one for the summarizer's
-	// provider), and that spend went to the customer's own account — so it
-	// takes the fee path rather than a full-cost debit.
+	// The handover summary runs on the deployment/BYOK key, never the subscription
+	// token. If a BYOK key was used, that spend hit the customer's account —
+	// so bill the fee rather than full cost.
 	if routeRes.Handover.Invoked && !routeRes.Handover.FallbackToFullHistory {
 		sumUsage := routeRes.Handover.SummaryUsage
 		if sumUsage.Model != "" && (sumUsage.InputTokens > 0 || sumUsage.OutputTokens > 0) {

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -914,8 +914,7 @@ func servedOnSubscription(ctx context.Context) bool {
 }
 
 // servedOnBYOK reports whether the turn's resolved credential is a customer-owned
-// provider key, so the customer paid their upstream directly and Weave bills only
-// its platform fee. Keys off the resolved credential rather than the presence of
+// provider key. Keys off the resolved credential rather than the presence of
 // a BYOK row: the row may exist for a provider this turn didn't route to.
 func servedOnBYOK(ctx context.Context) bool {
 	creds := CredentialsFromContext(ctx)

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -1820,6 +1820,7 @@ func (s *Service) PassthroughToNamedProvider(ctx context.Context, providerName s
 	if err != nil {
 		return err
 	}
+	ctx = resolveAndInjectCredentials(ctx, providerName, r.Header)
 
 	// Claude Code sends its 1M-context model variant tag (e.g.
 	// "claude-opus-4-8[1m]") in the body. It is a client display convention,

--- a/internal/proxy/service_test.go
+++ b/internal/proxy/service_test.go
@@ -312,9 +312,7 @@ func makeProxyService(decision router.Decision, p map[string]providers.Client) *
 }
 
 // TestService_PassthroughToNamedProvider_ResolvesBYOKCredential: passthrough
-// (count_tokens/models) must resolve the same credential precedence as a
-// routed dispatch, so a BYOK key hits the customer's endpoint/auth instead of
-// the deployment key silently winning.
+// must resolve credential precedence so a BYOK key wins over the deployment key.
 func TestService_PassthroughToNamedProvider_ResolvesBYOKCredential(t *testing.T) {
 	provider := &fakeProvider{}
 	svc := makeProxyService(router.Decision{}, map[string]providers.Client{providers.ProviderAnthropic: provider})

--- a/internal/proxy/service_test.go
+++ b/internal/proxy/service_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"workweave/router/internal/auth"
 	"workweave/router/internal/providers"
 	"workweave/router/internal/proxy"
 	"workweave/router/internal/router"
@@ -62,6 +63,8 @@ type fakeProvider struct {
 	// proxyCreds records the resolved credential per dispatch; nil means
 	// deployment-key fallback (no credential set).
 	proxyCreds []*proxy.Credentials
+	// passthroughCreds records the resolved credential per Passthrough call.
+	passthroughCreds []*proxy.Credentials
 }
 
 func (f *fakeProvider) Proxy(ctx context.Context, decision router.Decision, prep providers.PreparedRequest, w http.ResponseWriter, r *http.Request) error {
@@ -300,11 +303,35 @@ func TestService_ProxyOpenAIResponses_CodexPassthroughUsesChatForOpenAICompatPro
 }
 
 func (f *fakeProvider) Passthrough(ctx context.Context, prep providers.PreparedRequest, w http.ResponseWriter, r *http.Request) error {
+	f.passthroughCreds = append(f.passthroughCreds, proxy.CredentialsFromContext(ctx))
 	return nil
 }
 
 func makeProxyService(decision router.Decision, p map[string]providers.Client) *proxy.Service {
 	return proxy.NewService(&fakeRouter{decision: decision}, p, nil, false, nil, nil, false, providers.ProviderAnthropic, "claude-haiku-4-5", nil)
+}
+
+// TestService_PassthroughToNamedProvider_ResolvesBYOKCredential: passthrough
+// (count_tokens/models) must resolve the same credential precedence as a
+// routed dispatch, so a BYOK key hits the customer's endpoint/auth instead of
+// the deployment key silently winning.
+func TestService_PassthroughToNamedProvider_ResolvesBYOKCredential(t *testing.T) {
+	provider := &fakeProvider{}
+	svc := makeProxyService(router.Decision{}, map[string]providers.Client{providers.ProviderAnthropic: provider})
+
+	ctx := context.WithValue(context.Background(), proxy.ExternalAPIKeysContextKey{}, []*auth.ExternalAPIKey{
+		{Provider: providers.ProviderAnthropic, Plaintext: []byte("sk-ant-byok"), BaseURL: "https://byok.example.com"},
+	})
+	httpReq := httptest.NewRequest(http.MethodGet, "/v1/models", nil)
+	rec := httptest.NewRecorder()
+
+	err := svc.PassthroughToNamedProvider(ctx, providers.ProviderAnthropic, nil, rec, httpReq)
+
+	require.NoError(t, err)
+	require.Len(t, provider.passthroughCreds, 1)
+	require.NotNil(t, provider.passthroughCreds[0], "BYOK credential must be resolved onto ctx before Passthrough dispatches")
+	assert.Equal(t, []byte("sk-ant-byok"), provider.passthroughCreds[0].APIKey)
+	assert.Equal(t, "https://byok.example.com", provider.passthroughCreds[0].BaseURL)
 }
 
 func TestService_ProxyMessages_PropagatesUpstreamStatusError(t *testing.T) {

--- a/internal/server/middleware/auth.go
+++ b/internal/server/middleware/auth.go
@@ -39,12 +39,8 @@ const (
 
 // WithAuth validates the inbound request via a bearer rk_ token only. Used on data-plane routes (`/v1/*`). On failure, short-circuits 401.
 //
-// byokRequiresOptIn gates BYOK (customer-owned provider) keys behind the
-// installation's own opt-in. Managed-mode deployments pass true: they bill via
-// prepaid credits, so an installation that hasn't opted in must not spend on a
-// leftover BYOK row. Opted-in installations pay a percentage fee on their
-// upstream spend instead of full inference cost. Self-hosted passes false;
-// BYOK is the only credentialing path there.
+// byokRequiresOptIn gates BYOK keys behind the installation's own opt-in.
+// Managed-mode deployments pass true; self-hosted always passes false.
 func WithAuth(svc *auth.Service, byokRequiresOptIn bool) gin.HandlerFunc {
 	return withAPIKey(svc, byokRequiresOptIn)
 }

--- a/internal/server/middleware/auth.go
+++ b/internal/server/middleware/auth.go
@@ -39,20 +39,22 @@ const (
 
 // WithAuth validates the inbound request via a bearer rk_ token only. Used on data-plane routes (`/v1/*`). On failure, short-circuits 401.
 //
-// byokDisabled strips BYOK (customer-owned provider) keys before downstream
-// proxy code sees them. Managed-mode deployments pass true: they bill via
-// prepaid credits, so honoring a leftover BYOK row would double-charge the
-// customer. Self-hosted passes false; BYOK is the only credentialing path there.
-func WithAuth(svc *auth.Service, byokDisabled bool) gin.HandlerFunc {
-	return withAPIKey(svc, byokDisabled)
+// byokRequiresOptIn gates BYOK (customer-owned provider) keys behind the
+// installation's own opt-in. Managed-mode deployments pass true: they bill via
+// prepaid credits, so an installation that hasn't opted in must not spend on a
+// leftover BYOK row. Opted-in installations pay a percentage fee on their
+// upstream spend instead of full inference cost. Self-hosted passes false;
+// BYOK is the only credentialing path there.
+func WithAuth(svc *auth.Service, byokRequiresOptIn bool) gin.HandlerFunc {
+	return withAPIKey(svc, byokRequiresOptIn)
 }
 
 // WithAdminOrAuth accepts either a signed admin session cookie OR a bearer rk_ token.
 // Don't use on `/v1/*` data-plane routes (a cookie shouldn't call provider proxy endpoints)
 // or on control-plane mutations (a leaked rk_ shouldn't mint keys or rotate credentials —
-// use WithAdminOnly there). See WithAuth for byokDisabled.
-func WithAdminOrAuth(svc *auth.Service, byokDisabled bool) gin.HandlerFunc {
-	apiKeyMW := withAPIKey(svc, byokDisabled)
+// use WithAdminOnly there). See WithAuth for byokRequiresOptIn.
+func WithAdminOrAuth(svc *auth.Service, byokRequiresOptIn bool) gin.HandlerFunc {
+	apiKeyMW := withAPIKey(svc, byokRequiresOptIn)
 	return func(c *gin.Context) {
 		if principal := tryAdminCookie(c, svc); principal != nil {
 			c.Set(ctxKeyAdminPrincipal, principal)
@@ -82,11 +84,11 @@ func WithAdminOnly(svc *auth.Service) gin.HandlerFunc {
 
 // withAPIKey is the bearer-only auth path shared by WithAuth and the fall-through branch of WithAdminOrAuth.
 //
-// When byokDisabled is true, BYOK rows from svc.VerifyAPIKey are dropped
-// before reaching the request context. Every downstream BYOK consumer
+// When byokRequiresOptIn is true, BYOK rows from svc.VerifyAPIKey are dropped
+// unless the installation set ByokEnabled. Every downstream BYOK consumer
 // (credential resolution, provider gating, usage bookkeeping) reads that
-// single ctx key, so gating it here makes the whole path BYOK-blind.
-func withAPIKey(svc *auth.Service, byokDisabled bool) gin.HandlerFunc {
+// single ctx key, so gating it here decides the whole path in one place.
+func withAPIKey(svc *auth.Service, byokRequiresOptIn bool) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		token := extractToken(c)
 		installation, apiKey, externalKeys, clusterModelLists, err := svc.VerifyAPIKey(c.Request.Context(), token)
@@ -148,7 +150,8 @@ func withAPIKey(svc *auth.Service, byokDisabled bool) gin.HandlerFunc {
 				ctx = context.WithValue(ctx, proxy.PolicyTrainingAllowedContextKey{}, true)
 			}
 		}
-		if externalKeys != nil && !byokDisabled {
+		byokAllowed := !byokRequiresOptIn || (installation != nil && installation.ByokEnabled)
+		if externalKeys != nil && byokAllowed {
 			ctx = context.WithValue(ctx, proxy.ExternalAPIKeysContextKey{}, externalKeys)
 		}
 		if len(clusterModelLists) > 0 {

--- a/internal/server/middleware/auth_test.go
+++ b/internal/server/middleware/auth_test.go
@@ -164,12 +164,12 @@ func TestWithAuthPrefersRouterKeyHeader(t *testing.T) {
 	require.Equal(t, http.StatusOK, rr.Code)
 }
 
-func TestWithAuthManagedModeDropsBYOKFromContext(t *testing.T) {
+func TestWithAuthManagedModeDropsBYOKWhenNotOptedIn(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	const routerToken = "rk_managed"
 	hash, prefix, suffix := auth.APITokenFingerprint(routerToken)
 	apiKey := &auth.APIKey{ID: "key-managed", InstallationID: "inst-managed", KeyHash: hash, KeyPrefix: prefix, KeySuffix: suffix}
-	installation := &auth.Installation{ID: "inst-managed", ExternalID: "ext-managed"}
+	installation := &auth.Installation{ID: "inst-managed", ExternalID: "ext-managed", ByokEnabled: false}
 	repo := &fakeAPIKeyRepository{byHash: map[string]fakeKeyRow{
 		hash: {apiKey: apiKey, installation: installation},
 	}}
@@ -184,7 +184,43 @@ func TestWithAuthManagedModeDropsBYOKFromContext(t *testing.T) {
 	engine.Use(middleware.WithAuth(svc, true))
 	engine.GET("/probe", func(c *gin.Context) {
 		assert.Nil(t, c.Request.Context().Value(proxy.ExternalAPIKeysContextKey{}),
-			"managed mode must drop BYOK rows at the middleware boundary; a leftover row in the table must not reach the proxy ctx")
+			"managed mode must drop BYOK rows for an installation that hasn't opted in; a leftover row in the table must not reach the proxy ctx")
+		c.Status(http.StatusOK)
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/probe", nil)
+	req.Header.Set(middleware.RouterKeyHeader, routerToken)
+	rr := httptest.NewRecorder()
+	engine.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+}
+
+func TestWithAuthManagedModeKeepsBYOKWhenOptedIn(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	const routerToken = "rk_managed_optin"
+	hash, prefix, suffix := auth.APITokenFingerprint(routerToken)
+	apiKey := &auth.APIKey{ID: "key-optin", InstallationID: "inst-optin", KeyHash: hash, KeyPrefix: prefix, KeySuffix: suffix}
+	installation := &auth.Installation{ID: "inst-optin", ExternalID: "ext-optin", ByokEnabled: true}
+	repo := &fakeAPIKeyRepository{byHash: map[string]fakeKeyRow{
+		hash: {apiKey: apiKey, installation: installation},
+	}}
+	externalRepo := &fakeExternalAPIKeyRepository{byInstallationID: map[string][]*auth.ExternalAPIKey{
+		installation.ID: {{
+			ID: "ext-makora", InstallationID: installation.ID, Provider: "makora",
+			BaseURL: "https://byok.example.com/v1", Plaintext: []byte("mk-byok"),
+		}},
+	}}
+	svc := auth.NewService(fakeInstallationRepository{}, repo, externalRepo, nil, auth.NoOpAPIKeyCache{}, nil, func() time.Time { return time.Now() })
+
+	engine := gin.New()
+	engine.Use(middleware.WithAuth(svc, true))
+	engine.GET("/probe", func(c *gin.Context) {
+		v, ok := c.Request.Context().Value(proxy.ExternalAPIKeysContextKey{}).([]*auth.ExternalAPIKey)
+		require.True(t, ok, "managed mode must propagate BYOK rows once the installation opts in")
+		require.Len(t, v, 1)
+		assert.Equal(t, "makora", v[0].Provider)
+		assert.Equal(t, "https://byok.example.com/v1", v[0].BaseURL)
 		c.Status(http.StatusOK)
 	})
 
@@ -201,7 +237,9 @@ func TestWithAuthSelfHostedKeepsBYOKInContext(t *testing.T) {
 	const routerToken = "rk_selfhosted"
 	hash, prefix, suffix := auth.APITokenFingerprint(routerToken)
 	apiKey := &auth.APIKey{ID: "key-self", InstallationID: "inst-self", KeyHash: hash, KeyPrefix: prefix, KeySuffix: suffix}
-	installation := &auth.Installation{ID: "inst-self", ExternalID: "ext-self"}
+	// ByokEnabled stays false: self-hosted has no credit system to protect, so
+	// the opt-in flag must not gate BYOK there.
+	installation := &auth.Installation{ID: "inst-self", ExternalID: "ext-self", ByokEnabled: false}
 	repo := &fakeAPIKeyRepository{byHash: map[string]fakeKeyRow{
 		hash: {apiKey: apiKey, installation: installation},
 	}}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -73,9 +73,12 @@ const (
 // hmmRosterSource, when non-nil, mounts GET /v1/router/hmm-roster for the
 // control plane's cluster allowlist UI.
 func Register(engine *gin.Engine, authSvc *auth.Service, proxySvc *proxy.Service, deployedModels admin.DeployedModelsSource, hmmModels admin.HMMRosterSource, mode DeploymentMode, billingSvc *billing.Service, readinessChecker admin.HealthChecker, hmmRosterSource policy.RosterSource) {
-	// Managed mode bills via platform-key credits; a leftover BYOK row would
-	// double-charge (upstream provider + Weave credits), so drop it here.
-	byokDisabled := mode == DeploymentModeManaged
+	// Managed mode bills via platform-key credits, so BYOK is opt-in per
+	// installation: an org that hasn't enabled it must not spend on a leftover
+	// BYOK row. Opted-in orgs are billed a percentage fee on their upstream
+	// spend rather than full inference cost. Self-hosted has no credit system,
+	// so BYOK always applies there.
+	byokRequiresOptIn := mode == DeploymentModeManaged
 
 	engine.GET("/health", middleware.WithTimeout(healthTimeout), admin.HealthHandler)
 	engine.GET("/readyz", middleware.WithTimeout(readinessTimeout), admin.ReadinessHandler(readinessChecker))
@@ -120,7 +123,7 @@ func Register(engine *gin.Engine, authSvc *auth.Service, proxySvc *proxy.Service
 	}
 
 	// /validate is a token-validity probe used by clients (not the dashboard), so it stays mounted in both modes.
-	adminAuthed := engine.Group("", middleware.WithTimeout(validateTimeout), middleware.WithAuth(authSvc, byokDisabled))
+	adminAuthed := engine.Group("", middleware.WithTimeout(validateTimeout), middleware.WithAuth(authSvc, byokRequiresOptIn))
 	adminAuthed.GET("/validate", admin.ValidateHandler)
 
 	if mode == DeploymentModeSelfHosted {
@@ -135,7 +138,7 @@ func Register(engine *gin.Engine, authSvc *auth.Service, proxySvc *proxy.Service
 		authPublic.GET("/me", admin.MeHandler(authSvc))
 
 		// Read-only metrics: dashboard cookie OR rk_ bearer so an installation can fetch its own data for monitoring scripts. Per-installation scoping is enforced inside the handlers.
-		metrics := engine.Group("/admin/v1", middleware.WithTimeout(adminTimeout), middleware.WithAdminOrAuth(authSvc, byokDisabled))
+		metrics := engine.Group("/admin/v1", middleware.WithTimeout(adminTimeout), middleware.WithAdminOrAuth(authSvc, byokRequiresOptIn))
 		metrics.GET("/metrics/summary", admin.MetricsSummaryHandler(proxySvc))
 		metrics.GET("/metrics/timeseries", admin.MetricsTimeseriesHandler(proxySvc))
 		metrics.GET("/metrics/details", admin.MetricsDetailsHandler(proxySvc))
@@ -164,7 +167,7 @@ func Register(engine *gin.Engine, authSvc *auth.Service, proxySvc *proxy.Service
 	messagesMiddleware := []gin.HandlerFunc{
 		middleware.WithTimingEntry(),
 		middleware.WithTimeout(messagesTimeout),
-		middleware.WithAuth(authSvc, byokDisabled),
+		middleware.WithAuth(authSvc, byokRequiresOptIn),
 		middleware.WithAgentShadowEvaluation(),
 	}
 	if billingSvc != nil {
@@ -184,7 +187,7 @@ func Register(engine *gin.Engine, authSvc *auth.Service, proxySvc *proxy.Service
 	chatCompletionMiddleware := []gin.HandlerFunc{
 		middleware.WithTimingEntry(),
 		middleware.WithTimeout(chatCompletionTimeout),
-		middleware.WithAuth(authSvc, byokDisabled),
+		middleware.WithAuth(authSvc, byokRequiresOptIn),
 	}
 	if billingSvc != nil {
 		chatCompletionMiddleware = append(chatCompletionMiddleware, middleware.WithBalanceCheck(billingSvc, billing.MinBalanceMicros), middleware.WithAPIKeySpendCap(billingSvc), middleware.WithOrgMonthlySpendCap(billingSvc))
@@ -210,7 +213,7 @@ func Register(engine *gin.Engine, authSvc *auth.Service, proxySvc *proxy.Service
 	// /v1/messages, and gating it would break client negotiation.
 	passthroughGroup := engine.Group("",
 		middleware.WithTimeout(passthroughTimeout),
-		middleware.WithAuth(authSvc, byokDisabled),
+		middleware.WithAuth(authSvc, byokRequiresOptIn),
 	)
 	passthroughGroup.POST("/v1/messages/count_tokens", anthropicapi.PassthroughHandler(proxySvc))
 	passthroughGroup.GET("/v1/models", openaiapi.ModelsHandler(anthropicapi.PassthroughHandler(proxySvc)))
@@ -218,7 +221,7 @@ func Register(engine *gin.Engine, authSvc *auth.Service, proxySvc *proxy.Service
 
 	routeMiddleware := []gin.HandlerFunc{
 		middleware.WithTimeout(routeTimeout),
-		middleware.WithAuth(authSvc, byokDisabled),
+		middleware.WithAuth(authSvc, byokRequiresOptIn),
 	}
 	if billingSvc != nil {
 		routeMiddleware = append(routeMiddleware, middleware.WithBalanceCheck(billingSvc, billing.MinBalanceMicros), middleware.WithAPIKeySpendCap(billingSvc), middleware.WithOrgMonthlySpendCap(billingSvc))
@@ -237,7 +240,7 @@ func Register(engine *gin.Engine, authSvc *auth.Service, proxySvc *proxy.Service
 	previewGroup := engine.Group("",
 		middleware.WithTimingEntry(),
 		middleware.WithTimeout(routeTimeout),
-		middleware.WithAuth(authSvc, byokDisabled),
+		middleware.WithAuth(authSvc, byokRequiresOptIn),
 		middleware.WithEmbedOnlyUserMessageOverride(),
 		middleware.WithRouterStrategyDefault(defaultStrategy, registeredStrategies...),
 		middleware.WithPolicyDebugOverride(),

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -73,11 +73,7 @@ const (
 // hmmRosterSource, when non-nil, mounts GET /v1/router/hmm-roster for the
 // control plane's cluster allowlist UI.
 func Register(engine *gin.Engine, authSvc *auth.Service, proxySvc *proxy.Service, deployedModels admin.DeployedModelsSource, hmmModels admin.HMMRosterSource, mode DeploymentMode, billingSvc *billing.Service, readinessChecker admin.HealthChecker, hmmRosterSource policy.RosterSource) {
-	// Managed mode bills via platform-key credits, so BYOK is opt-in per
-	// installation: an org that hasn't enabled it must not spend on a leftover
-	// BYOK row. Opted-in orgs are billed a percentage fee on their upstream
-	// spend rather than full inference cost. Self-hosted has no credit system,
-	// so BYOK always applies there.
+	// Managed mode: BYOK is opt-in per installation (see WithAuth).
 	byokRequiresOptIn := mode == DeploymentModeManaged
 
 	engine.GET("/health", middleware.WithTimeout(healthTimeout), admin.HealthHandler)

--- a/internal/sqlc/billing.sql.go
+++ b/internal/sqlc/billing.sql.go
@@ -74,25 +74,56 @@ ledger AS (
     )
     SELECT
         $2::varchar,
-        $1::bigint,
         $3::bigint,
-        updated.balance_usd_micros,
-        $4::varchar,
-        $5::varchar,
-        $6::varchar
+        $4::bigint,
+        -- The fee row is logically second, so this row's balance_after is the
+        -- final balance minus the fee that had not yet been applied.
+        updated.balance_usd_micros - $5::bigint,
+        $6::varchar,
+        $7::varchar,
+        $8::varchar
     FROM updated
     RETURNING balance_after_micros
 ),
+fee_ledger AS (
+    -- Weave's platform fee on a BYOK turn. No-ops when fee_usd_micros is 0,
+    -- which is every non-BYOK turn.
+    INSERT INTO router.organization_credit_ledger (
+        organization_id,
+        delta_usd_micros,
+        notional_cost_micros,
+        balance_after_micros,
+        entry_type,
+        router_request_id,
+        router_model
+    )
+    SELECT
+        $2::varchar,
+        $5::bigint,
+        0,
+        updated.balance_usd_micros,
+        $9::varchar,
+        NULL::varchar,
+        NULL::varchar
+    FROM updated
+    WHERE $5::bigint <> 0
+),
 key_spend AS (
-    -- delta is negative on a real debit, so subtracting it adds the spend
-    -- magnitude; zero on override/subscription pass-throughs leaves it flat.
+    -- charged_usd_micros is the signed total the balance moved (delta + fee),
+    -- pre-combined in Go: sqlc's CTE rewriter only accepts a single param in
+    -- this ` + "`" + `SET x = x - @p` + "`" + ` form, and an unqualified ` + "`" + `spent_usd_micros` + "`" + ` is
+    -- ambiguous against the ` + "`" + `updated` + "`" + ` CTE. Negative on a real debit, so
+    -- subtracting it adds the spend magnitude; zero on override/subscription
+    -- pass-throughs leaves it flat. The BYOK fee is included, else a capped key
+    -- would never trip its cap on BYOK traffic (delta 0, fee is the whole
+    -- charge).
     -- Gated on ` + "`" + `updated` + "`" + ` producing a row: if the org balance row was missing
     -- (the debit no-ops and the app sees ErrBalanceRowMissing) we must NOT bump
     -- the key's lifetime spend, or a capped key could trip its cap with no
     -- matching ledger debit.
     UPDATE router.model_router_api_keys
     SET spent_usd_micros = spent_usd_micros - $1::bigint
-    WHERE id = $7::uuid
+    WHERE id = $10::uuid
       AND EXISTS (SELECT 1 FROM updated)
 ),
 user_month_spend AS (
@@ -104,15 +135,15 @@ user_month_spend AS (
     -- after inference was already served.
     INSERT INTO router.model_router_user_monthly_spend (router_user_id, month, spent_usd_micros, updated_at)
     SELECT
-        $8::uuid,
+        $11::uuid,
         DATE_TRUNC('month', NOW() AT TIME ZONE 'utc')::date,
         -($1::bigint),
         NOW()
-    WHERE $8::uuid IS NOT NULL
+    WHERE $11::uuid IS NOT NULL
       AND EXISTS (SELECT 1 FROM updated)
       AND EXISTS (
           SELECT 1 FROM router.model_router_users
-          WHERE id = $8::uuid
+          WHERE id = $11::uuid
       )
     ON CONFLICT (router_user_id, month) DO UPDATE
     SET spent_usd_micros = router.model_router_user_monthly_spend.spent_usd_micros + EXCLUDED.spent_usd_micros,
@@ -135,12 +166,15 @@ SELECT balance_after_micros FROM ledger
 `
 
 type DebitOrgCreditsParams struct {
-	DeltaUsdMicros     int64
+	ChargedUsdMicros   int64
 	OrganizationID     string
+	DeltaUsdMicros     int64
 	NotionalCostMicros int64
+	FeeUsdMicros       int64
 	EntryType          string
 	RouterRequestID    *string
 	RouterModel        *string
+	FeeEntryType       string
 	APIKeyID           pgtype.UUID
 	RouterUserID       pgtype.UUID
 }
@@ -165,6 +199,11 @@ type DebitOrgCreditsParams struct {
 // per-key cap enforcement reads a single up-to-date row. The key_spend CTE is
 // data-modifying, so Postgres runs it to completion even though the final
 // SELECT does not reference it; it no-ops when api_key_id is NULL.
+// When fee_usd_micros is non-zero, a second ledger row of fee_entry_type is
+// written in the same statement. BYOK turns use this: the inference row carries
+// notional upstream cost at delta 0 (the customer paid their own provider) and
+// the fee row holds Weave's platform charge. Both rows must land together or a
+// crash between them would serve inference with no fee, so they share one CTE.
 //
 //	WITH updated AS (
 //	    UPDATE router.organization_credit_balance
@@ -185,25 +224,56 @@ type DebitOrgCreditsParams struct {
 //	    )
 //	    SELECT
 //	        $2::varchar,
-//	        $1::bigint,
 //	        $3::bigint,
-//	        updated.balance_usd_micros,
-//	        $4::varchar,
-//	        $5::varchar,
-//	        $6::varchar
+//	        $4::bigint,
+//	        -- The fee row is logically second, so this row's balance_after is the
+//	        -- final balance minus the fee that had not yet been applied.
+//	        updated.balance_usd_micros - $5::bigint,
+//	        $6::varchar,
+//	        $7::varchar,
+//	        $8::varchar
 //	    FROM updated
 //	    RETURNING balance_after_micros
 //	),
+//	fee_ledger AS (
+//	    -- Weave's platform fee on a BYOK turn. No-ops when fee_usd_micros is 0,
+//	    -- which is every non-BYOK turn.
+//	    INSERT INTO router.organization_credit_ledger (
+//	        organization_id,
+//	        delta_usd_micros,
+//	        notional_cost_micros,
+//	        balance_after_micros,
+//	        entry_type,
+//	        router_request_id,
+//	        router_model
+//	    )
+//	    SELECT
+//	        $2::varchar,
+//	        $5::bigint,
+//	        0,
+//	        updated.balance_usd_micros,
+//	        $9::varchar,
+//	        NULL::varchar,
+//	        NULL::varchar
+//	    FROM updated
+//	    WHERE $5::bigint <> 0
+//	),
 //	key_spend AS (
-//	    -- delta is negative on a real debit, so subtracting it adds the spend
-//	    -- magnitude; zero on override/subscription pass-throughs leaves it flat.
+//	    -- charged_usd_micros is the signed total the balance moved (delta + fee),
+//	    -- pre-combined in Go: sqlc's CTE rewriter only accepts a single param in
+//	    -- this `SET x = x - @p` form, and an unqualified `spent_usd_micros` is
+//	    -- ambiguous against the `updated` CTE. Negative on a real debit, so
+//	    -- subtracting it adds the spend magnitude; zero on override/subscription
+//	    -- pass-throughs leaves it flat. The BYOK fee is included, else a capped key
+//	    -- would never trip its cap on BYOK traffic (delta 0, fee is the whole
+//	    -- charge).
 //	    -- Gated on `updated` producing a row: if the org balance row was missing
 //	    -- (the debit no-ops and the app sees ErrBalanceRowMissing) we must NOT bump
 //	    -- the key's lifetime spend, or a capped key could trip its cap with no
 //	    -- matching ledger debit.
 //	    UPDATE router.model_router_api_keys
 //	    SET spent_usd_micros = spent_usd_micros - $1::bigint
-//	    WHERE id = $7::uuid
+//	    WHERE id = $10::uuid
 //	      AND EXISTS (SELECT 1 FROM updated)
 //	),
 //	user_month_spend AS (
@@ -215,15 +285,15 @@ type DebitOrgCreditsParams struct {
 //	    -- after inference was already served.
 //	    INSERT INTO router.model_router_user_monthly_spend (router_user_id, month, spent_usd_micros, updated_at)
 //	    SELECT
-//	        $8::uuid,
+//	        $11::uuid,
 //	        DATE_TRUNC('month', NOW() AT TIME ZONE 'utc')::date,
 //	        -($1::bigint),
 //	        NOW()
-//	    WHERE $8::uuid IS NOT NULL
+//	    WHERE $11::uuid IS NOT NULL
 //	      AND EXISTS (SELECT 1 FROM updated)
 //	      AND EXISTS (
 //	          SELECT 1 FROM router.model_router_users
-//	          WHERE id = $8::uuid
+//	          WHERE id = $11::uuid
 //	      )
 //	    ON CONFLICT (router_user_id, month) DO UPDATE
 //	    SET spent_usd_micros = router.model_router_user_monthly_spend.spent_usd_micros + EXCLUDED.spent_usd_micros,
@@ -245,12 +315,15 @@ type DebitOrgCreditsParams struct {
 //	SELECT balance_after_micros FROM ledger
 func (q *Queries) DebitOrgCredits(ctx context.Context, arg DebitOrgCreditsParams) (int64, error) {
 	row := q.db.QueryRow(ctx, debitOrgCredits,
-		arg.DeltaUsdMicros,
+		arg.ChargedUsdMicros,
 		arg.OrganizationID,
+		arg.DeltaUsdMicros,
 		arg.NotionalCostMicros,
+		arg.FeeUsdMicros,
 		arg.EntryType,
 		arg.RouterRequestID,
 		arg.RouterModel,
+		arg.FeeEntryType,
 		arg.APIKeyID,
 		arg.RouterUserID,
 	)

--- a/internal/sqlc/billing.sql.go
+++ b/internal/sqlc/billing.sql.go
@@ -103,8 +103,8 @@ fee_ledger AS (
         0,
         updated.balance_usd_micros,
         $9::varchar,
-        NULL::varchar,
-        NULL::varchar
+        $7::varchar,
+        $8::varchar
     FROM updated
     WHERE $5::bigint <> 0
 ),
@@ -262,8 +262,8 @@ type DebitOrgCreditsParams struct {
 //	        0,
 //	        updated.balance_usd_micros,
 //	        $9::varchar,
-//	        NULL::varchar,
-//	        NULL::varchar
+//	        $7::varchar,
+//	        $8::varchar
 //	    FROM updated
 //	    WHERE $5::bigint <> 0
 //	),

--- a/internal/sqlc/billing.sql.go
+++ b/internal/sqlc/billing.sql.go
@@ -76,8 +76,8 @@ ledger AS (
         $2::varchar,
         $3::bigint,
         $4::bigint,
-        -- The fee row is logically second, so this row's balance_after is the
-        -- final balance minus the fee that had not yet been applied.
+        -- The fee row is logically second, so this row records the balance as of
+        -- before the fee landed: final minus the fee's signed value.
         updated.balance_usd_micros - $5::bigint,
         $6::varchar,
         $7::varchar,
@@ -162,7 +162,8 @@ org_month_spend AS (
     SET spent_usd_micros = router.organization_monthly_spend.spent_usd_micros + EXCLUDED.spent_usd_micros,
         updated_at = NOW()
 )
-SELECT balance_after_micros FROM ledger
+SELECT (SELECT balance_usd_micros FROM updated) AS balance_after_micros
+FROM ledger
 `
 
 type DebitOrgCreditsParams struct {
@@ -180,8 +181,10 @@ type DebitOrgCreditsParams struct {
 }
 
 // Atomic debit: decrement the balance and append a matching ledger row in a
-// single statement. delta_usd_micros is the signed change (negative for an
-// inference debit, zero for an override pass-through). notional_cost_micros
+// single statement. delta_usd_micros is the signed change on the inference row
+// (negative for an inference debit, zero for an override pass-through).
+// charged_usd_micros is the signed total the balance actually moves
+// (delta + fee), pre-combined by the caller. notional_cost_micros
 // is always the would-be charge, populated for both override and real
 // debits so we keep a shadow billing trail.
 //
@@ -194,9 +197,9 @@ type DebitOrgCreditsParams struct {
 // new value without a follow-up read.
 //
 // When api_key_id is supplied, the same statement also bumps that key's
-// lifetime spent_usd_micros by the debit magnitude (-delta: the real cost on a
-// debit, zero on an override/subscription pass-through where delta is 0), so
-// per-key cap enforcement reads a single up-to-date row. The key_spend CTE is
+// lifetime spent_usd_micros by the charged magnitude (-charged: the real cost
+// on a debit, zero on an override/subscription pass-through), so per-key cap
+// enforcement reads a single up-to-date row. The key_spend CTE is
 // data-modifying, so Postgres runs it to completion even though the final
 // SELECT does not reference it; it no-ops when api_key_id is NULL.
 // When fee_usd_micros is non-zero, a second ledger row of fee_entry_type is
@@ -204,6 +207,12 @@ type DebitOrgCreditsParams struct {
 // notional upstream cost at delta 0 (the customer paid their own provider) and
 // the fee row holds Weave's platform charge. Both rows must land together or a
 // crash between them would serve inference with no fee, so they share one CTE.
+// Returns the TRUE post-debit balance (from `updated`, after both delta and
+// fee), not a ledger row's balance_after. The inference row deliberately
+// records the pre-fee balance for audit ordering, so returning it here would
+// hand callers a balance the org never actually had -- and
+// maybeSignalRecharge would reconstruct a bogus pre-debit balance from it and
+// miss autopay threshold crossings on BYOK fee turns.
 //
 //	WITH updated AS (
 //	    UPDATE router.organization_credit_balance
@@ -226,8 +235,8 @@ type DebitOrgCreditsParams struct {
 //	        $2::varchar,
 //	        $3::bigint,
 //	        $4::bigint,
-//	        -- The fee row is logically second, so this row's balance_after is the
-//	        -- final balance minus the fee that had not yet been applied.
+//	        -- The fee row is logically second, so this row records the balance as of
+//	        -- before the fee landed: final minus the fee's signed value.
 //	        updated.balance_usd_micros - $5::bigint,
 //	        $6::varchar,
 //	        $7::varchar,
@@ -312,7 +321,8 @@ type DebitOrgCreditsParams struct {
 //	    SET spent_usd_micros = router.organization_monthly_spend.spent_usd_micros + EXCLUDED.spent_usd_micros,
 //	        updated_at = NOW()
 //	)
-//	SELECT balance_after_micros FROM ledger
+//	SELECT (SELECT balance_usd_micros FROM updated) AS balance_after_micros
+//	FROM ledger
 func (q *Queries) DebitOrgCredits(ctx context.Context, arg DebitOrgCreditsParams) (int64, error) {
 	row := q.db.QueryRow(ctx, debitOrgCredits,
 		arg.ChargedUsdMicros,

--- a/internal/sqlc/model_router_api_keys.sql.go
+++ b/internal/sqlc/model_router_api_keys.sql.go
@@ -94,7 +94,7 @@ func (q *Queries) CreateModelRouterAPIKey(ctx context.Context, arg CreateModelRo
 }
 
 const getActiveModelRouterAPIKeyWithInstallationByHash = `-- name: GetActiveModelRouterAPIKeyWithInstallationByHash :one
-SELECT k.id, k.installation_id, k.external_id, k.name, k.key_prefix, k.key_hash, k.key_suffix, k.last_used_at, k.created_at, k.deleted_at, k.created_by, k.spend_cap_usd_micros, k.spent_usd_micros, i.id, i.external_id, i.name, i.created_at, i.updated_at, i.deleted_at, i.created_by, i.excluded_models, i.excluded_providers, i.routing_quality_weight, i.usage_bypass_enabled, i.usage_bypass_threshold, i.preferred_models, i.subscription_routing_disabled, i.routing_strategy, i.routing_rollout_id, i.policy_shadow_strategy, i.policy_debug_enabled, i.policy_header_overrides_enabled, i.policy_routing_intent, i.ai_training_allowed
+SELECT k.id, k.installation_id, k.external_id, k.name, k.key_prefix, k.key_hash, k.key_suffix, k.last_used_at, k.created_at, k.deleted_at, k.created_by, k.spend_cap_usd_micros, k.spent_usd_micros, i.id, i.external_id, i.name, i.created_at, i.updated_at, i.deleted_at, i.created_by, i.excluded_models, i.excluded_providers, i.routing_quality_weight, i.usage_bypass_enabled, i.usage_bypass_threshold, i.preferred_models, i.subscription_routing_disabled, i.routing_strategy, i.routing_rollout_id, i.policy_shadow_strategy, i.policy_debug_enabled, i.policy_header_overrides_enabled, i.policy_routing_intent, i.ai_training_allowed, i.byok_enabled
 FROM router.model_router_api_keys k
 INNER JOIN router.model_router_installations i ON i.id = k.installation_id
 WHERE k.key_hash = $1::varchar
@@ -113,7 +113,7 @@ type GetActiveModelRouterAPIKeyWithInstallationByHashRow struct {
 // both sides so a soft-deleted installation invalidates all its keys without per-key
 // updates.
 //
-//	SELECT k.id, k.installation_id, k.external_id, k.name, k.key_prefix, k.key_hash, k.key_suffix, k.last_used_at, k.created_at, k.deleted_at, k.created_by, k.spend_cap_usd_micros, k.spent_usd_micros, i.id, i.external_id, i.name, i.created_at, i.updated_at, i.deleted_at, i.created_by, i.excluded_models, i.excluded_providers, i.routing_quality_weight, i.usage_bypass_enabled, i.usage_bypass_threshold, i.preferred_models, i.subscription_routing_disabled, i.routing_strategy, i.routing_rollout_id, i.policy_shadow_strategy, i.policy_debug_enabled, i.policy_header_overrides_enabled, i.policy_routing_intent, i.ai_training_allowed
+//	SELECT k.id, k.installation_id, k.external_id, k.name, k.key_prefix, k.key_hash, k.key_suffix, k.last_used_at, k.created_at, k.deleted_at, k.created_by, k.spend_cap_usd_micros, k.spent_usd_micros, i.id, i.external_id, i.name, i.created_at, i.updated_at, i.deleted_at, i.created_by, i.excluded_models, i.excluded_providers, i.routing_quality_weight, i.usage_bypass_enabled, i.usage_bypass_threshold, i.preferred_models, i.subscription_routing_disabled, i.routing_strategy, i.routing_rollout_id, i.policy_shadow_strategy, i.policy_debug_enabled, i.policy_header_overrides_enabled, i.policy_routing_intent, i.ai_training_allowed, i.byok_enabled
 //	FROM router.model_router_api_keys k
 //	INNER JOIN router.model_router_installations i ON i.id = k.installation_id
 //	WHERE k.key_hash = $1::varchar
@@ -157,6 +157,7 @@ func (q *Queries) GetActiveModelRouterAPIKeyWithInstallationByHash(ctx context.C
 		&i.RouterModelRouterInstallation.PolicyHeaderOverridesEnabled,
 		&i.RouterModelRouterInstallation.PolicyRoutingIntent,
 		&i.RouterModelRouterInstallation.AiTrainingAllowed,
+		&i.RouterModelRouterInstallation.ByokEnabled,
 	)
 	return i, err
 }

--- a/internal/sqlc/model_router_external_api_keys.sql.go
+++ b/internal/sqlc/model_router_external_api_keys.sql.go
@@ -21,6 +21,7 @@ INSERT INTO router.model_router_external_api_keys (
     key_suffix,
     key_fingerprint,
     name,
+    base_url,
     created_by
 )
 VALUES (
@@ -32,9 +33,10 @@ VALUES (
     $6::varchar,
     $7::varchar,
     $8,
-    $9
+    $9,
+    $10
 )
-RETURNING id, installation_id, external_id, provider, key_ciphertext, key_prefix, key_suffix, key_fingerprint, name, last_used_at, created_at, updated_at, deleted_at, created_by
+RETURNING id, installation_id, external_id, provider, key_ciphertext, key_prefix, key_suffix, key_fingerprint, name, last_used_at, created_at, updated_at, deleted_at, created_by, base_url
 `
 
 type CreateExternalAPIKeyParams struct {
@@ -46,6 +48,7 @@ type CreateExternalAPIKeyParams struct {
 	KeySuffix      string
 	KeyFingerprint string
 	Name           *string
+	BaseURL        *string
 	CreatedBy      *string
 }
 
@@ -62,6 +65,7 @@ type CreateExternalAPIKeyParams struct {
 //	    key_suffix,
 //	    key_fingerprint,
 //	    name,
+//	    base_url,
 //	    created_by
 //	)
 //	VALUES (
@@ -73,9 +77,10 @@ type CreateExternalAPIKeyParams struct {
 //	    $6::varchar,
 //	    $7::varchar,
 //	    $8,
-//	    $9
+//	    $9,
+//	    $10
 //	)
-//	RETURNING id, installation_id, external_id, provider, key_ciphertext, key_prefix, key_suffix, key_fingerprint, name, last_used_at, created_at, updated_at, deleted_at, created_by
+//	RETURNING id, installation_id, external_id, provider, key_ciphertext, key_prefix, key_suffix, key_fingerprint, name, last_used_at, created_at, updated_at, deleted_at, created_by, base_url
 func (q *Queries) CreateExternalAPIKey(ctx context.Context, arg CreateExternalAPIKeyParams) (RouterModelRouterExternalAPIKey, error) {
 	row := q.db.QueryRow(ctx, createExternalAPIKey,
 		arg.InstallationID,
@@ -86,6 +91,7 @@ func (q *Queries) CreateExternalAPIKey(ctx context.Context, arg CreateExternalAP
 		arg.KeySuffix,
 		arg.KeyFingerprint,
 		arg.Name,
+		arg.BaseURL,
 		arg.CreatedBy,
 	)
 	var i RouterModelRouterExternalAPIKey
@@ -104,12 +110,13 @@ func (q *Queries) CreateExternalAPIKey(ctx context.Context, arg CreateExternalAP
 		&i.UpdatedAt,
 		&i.DeletedAt,
 		&i.CreatedBy,
+		&i.BaseURL,
 	)
 	return i, err
 }
 
 const getActiveExternalAPIKeysForInstallation = `-- name: GetActiveExternalAPIKeysForInstallation :many
-SELECT id, installation_id, external_id, provider, key_ciphertext, key_prefix, key_suffix, key_fingerprint, name, last_used_at, created_at, updated_at, deleted_at, created_by
+SELECT id, installation_id, external_id, provider, key_ciphertext, key_prefix, key_suffix, key_fingerprint, name, last_used_at, created_at, updated_at, deleted_at, created_by, base_url
 FROM router.model_router_external_api_keys
 WHERE installation_id = $1::uuid
   AND deleted_at IS NULL
@@ -119,7 +126,7 @@ ORDER BY provider, created_at DESC
 // Returns all active external API keys for an installation. Used by the auth
 // cache to populate the ExternalKeys map on cache miss.
 //
-//	SELECT id, installation_id, external_id, provider, key_ciphertext, key_prefix, key_suffix, key_fingerprint, name, last_used_at, created_at, updated_at, deleted_at, created_by
+//	SELECT id, installation_id, external_id, provider, key_ciphertext, key_prefix, key_suffix, key_fingerprint, name, last_used_at, created_at, updated_at, deleted_at, created_by, base_url
 //	FROM router.model_router_external_api_keys
 //	WHERE installation_id = $1::uuid
 //	  AND deleted_at IS NULL
@@ -148,6 +155,7 @@ func (q *Queries) GetActiveExternalAPIKeysForInstallation(ctx context.Context, i
 			&i.UpdatedAt,
 			&i.DeletedAt,
 			&i.CreatedBy,
+			&i.BaseURL,
 		); err != nil {
 			return nil, err
 		}

--- a/internal/sqlc/model_router_installations.sql.go
+++ b/internal/sqlc/model_router_installations.sql.go
@@ -22,7 +22,7 @@ VALUES (
     $2::varchar,
     $3
 )
-RETURNING id, external_id, name, created_at, updated_at, deleted_at, created_by, excluded_models, excluded_providers, routing_quality_weight, usage_bypass_enabled, usage_bypass_threshold, preferred_models, subscription_routing_disabled, routing_strategy, routing_rollout_id, policy_shadow_strategy, policy_debug_enabled, policy_header_overrides_enabled, policy_routing_intent, ai_training_allowed
+RETURNING id, external_id, name, created_at, updated_at, deleted_at, created_by, excluded_models, excluded_providers, routing_quality_weight, usage_bypass_enabled, usage_bypass_threshold, preferred_models, subscription_routing_disabled, routing_strategy, routing_rollout_id, policy_shadow_strategy, policy_debug_enabled, policy_header_overrides_enabled, policy_routing_intent, ai_training_allowed, byok_enabled
 `
 
 type CreateModelRouterInstallationParams struct {
@@ -43,7 +43,7 @@ type CreateModelRouterInstallationParams struct {
 //	    $2::varchar,
 //	    $3
 //	)
-//	RETURNING id, external_id, name, created_at, updated_at, deleted_at, created_by, excluded_models, excluded_providers, routing_quality_weight, usage_bypass_enabled, usage_bypass_threshold, preferred_models, subscription_routing_disabled, routing_strategy, routing_rollout_id, policy_shadow_strategy, policy_debug_enabled, policy_header_overrides_enabled, policy_routing_intent, ai_training_allowed
+//	RETURNING id, external_id, name, created_at, updated_at, deleted_at, created_by, excluded_models, excluded_providers, routing_quality_weight, usage_bypass_enabled, usage_bypass_threshold, preferred_models, subscription_routing_disabled, routing_strategy, routing_rollout_id, policy_shadow_strategy, policy_debug_enabled, policy_header_overrides_enabled, policy_routing_intent, ai_training_allowed, byok_enabled
 func (q *Queries) CreateModelRouterInstallation(ctx context.Context, arg CreateModelRouterInstallationParams) (RouterModelRouterInstallation, error) {
 	row := q.db.QueryRow(ctx, createModelRouterInstallation, arg.ExternalID, arg.Name, arg.CreatedBy)
 	var i RouterModelRouterInstallation
@@ -69,12 +69,13 @@ func (q *Queries) CreateModelRouterInstallation(ctx context.Context, arg CreateM
 		&i.PolicyHeaderOverridesEnabled,
 		&i.PolicyRoutingIntent,
 		&i.AiTrainingAllowed,
+		&i.ByokEnabled,
 	)
 	return i, err
 }
 
 const getModelRouterInstallation = `-- name: GetModelRouterInstallation :one
-SELECT id, external_id, name, created_at, updated_at, deleted_at, created_by, excluded_models, excluded_providers, routing_quality_weight, usage_bypass_enabled, usage_bypass_threshold, preferred_models, subscription_routing_disabled, routing_strategy, routing_rollout_id, policy_shadow_strategy, policy_debug_enabled, policy_header_overrides_enabled, policy_routing_intent, ai_training_allowed
+SELECT id, external_id, name, created_at, updated_at, deleted_at, created_by, excluded_models, excluded_providers, routing_quality_weight, usage_bypass_enabled, usage_bypass_threshold, preferred_models, subscription_routing_disabled, routing_strategy, routing_rollout_id, policy_shadow_strategy, policy_debug_enabled, policy_header_overrides_enabled, policy_routing_intent, ai_training_allowed, byok_enabled
 FROM router.model_router_installations
 WHERE id = $1::uuid
   AND external_id = $2::varchar
@@ -88,7 +89,7 @@ type GetModelRouterInstallationParams struct {
 
 // Gets an installation by id, scoped to an external_id to prevent cross-tenant access.
 //
-//	SELECT id, external_id, name, created_at, updated_at, deleted_at, created_by, excluded_models, excluded_providers, routing_quality_weight, usage_bypass_enabled, usage_bypass_threshold, preferred_models, subscription_routing_disabled, routing_strategy, routing_rollout_id, policy_shadow_strategy, policy_debug_enabled, policy_header_overrides_enabled, policy_routing_intent, ai_training_allowed
+//	SELECT id, external_id, name, created_at, updated_at, deleted_at, created_by, excluded_models, excluded_providers, routing_quality_weight, usage_bypass_enabled, usage_bypass_threshold, preferred_models, subscription_routing_disabled, routing_strategy, routing_rollout_id, policy_shadow_strategy, policy_debug_enabled, policy_header_overrides_enabled, policy_routing_intent, ai_training_allowed, byok_enabled
 //	FROM router.model_router_installations
 //	WHERE id = $1::uuid
 //	  AND external_id = $2::varchar
@@ -118,12 +119,13 @@ func (q *Queries) GetModelRouterInstallation(ctx context.Context, arg GetModelRo
 		&i.PolicyHeaderOverridesEnabled,
 		&i.PolicyRoutingIntent,
 		&i.AiTrainingAllowed,
+		&i.ByokEnabled,
 	)
 	return i, err
 }
 
 const listModelRouterInstallationsForExternalID = `-- name: ListModelRouterInstallationsForExternalID :many
-SELECT id, external_id, name, created_at, updated_at, deleted_at, created_by, excluded_models, excluded_providers, routing_quality_weight, usage_bypass_enabled, usage_bypass_threshold, preferred_models, subscription_routing_disabled, routing_strategy, routing_rollout_id, policy_shadow_strategy, policy_debug_enabled, policy_header_overrides_enabled, policy_routing_intent, ai_training_allowed
+SELECT id, external_id, name, created_at, updated_at, deleted_at, created_by, excluded_models, excluded_providers, routing_quality_weight, usage_bypass_enabled, usage_bypass_threshold, preferred_models, subscription_routing_disabled, routing_strategy, routing_rollout_id, policy_shadow_strategy, policy_debug_enabled, policy_header_overrides_enabled, policy_routing_intent, ai_training_allowed, byok_enabled
 FROM router.model_router_installations
 WHERE external_id = $1::varchar
   AND deleted_at IS NULL
@@ -132,7 +134,7 @@ ORDER BY created_at DESC
 
 // ListModelRouterInstallationsForExternalID
 //
-//	SELECT id, external_id, name, created_at, updated_at, deleted_at, created_by, excluded_models, excluded_providers, routing_quality_weight, usage_bypass_enabled, usage_bypass_threshold, preferred_models, subscription_routing_disabled, routing_strategy, routing_rollout_id, policy_shadow_strategy, policy_debug_enabled, policy_header_overrides_enabled, policy_routing_intent, ai_training_allowed
+//	SELECT id, external_id, name, created_at, updated_at, deleted_at, created_by, excluded_models, excluded_providers, routing_quality_weight, usage_bypass_enabled, usage_bypass_threshold, preferred_models, subscription_routing_disabled, routing_strategy, routing_rollout_id, policy_shadow_strategy, policy_debug_enabled, policy_header_overrides_enabled, policy_routing_intent, ai_training_allowed, byok_enabled
 //	FROM router.model_router_installations
 //	WHERE external_id = $1::varchar
 //	  AND deleted_at IS NULL
@@ -168,6 +170,7 @@ func (q *Queries) ListModelRouterInstallationsForExternalID(ctx context.Context,
 			&i.PolicyHeaderOverridesEnabled,
 			&i.PolicyRoutingIntent,
 			&i.AiTrainingAllowed,
+			&i.ByokEnabled,
 		); err != nil {
 			return nil, err
 		}

--- a/internal/sqlc/models.go
+++ b/internal/sqlc/models.go
@@ -74,6 +74,8 @@ type RouterModelRouterExternalAPIKey struct {
 	UpdatedAt      pgtype.Timestamp
 	DeletedAt      pgtype.Timestamp
 	CreatedBy      *string
+	// Customer-supplied upstream base URL; NULL uses the deployment default for the provider
+	BaseURL *string
 }
 
 // Customer router installations; owns API keys
@@ -101,6 +103,8 @@ type RouterModelRouterInstallation struct {
 	PolicyRoutingIntent          *string
 	// Privacy snapshot synced from the organization AI-training setting. False disables policy learning.
 	AiTrainingAllowed bool
+	// Managed-mode opt-in: honor this installation's BYOK provider keys
+	ByokEnabled bool
 }
 
 type RouterModelRouterRequestTelemetry struct {


### PR DESCRIPTION
## Summary

BYOK was reachable only from the self-hosted admin dashboard. Managed deployments stripped stored BYOK keys at the auth boundary because a stored row would spend upstream *and* debit prepaid credits — so a hosted customer had no way to plug in their own upstream provider.

This PR opens that path. An opt-in per installation, billing a 5% platform fee on the customer's upstream spend instead of full inference cost.

## Changes

- **Migration `0044_managed-byok`**: widens the provider CHECK (it excluded `makora` — blocks the literal ask), adds `base_url` to external keys, adds `byok_enabled` to installations, adds `byok_fee` to the billing ledger's entry_type CHECK.
- **Per-installation BYOK gate**: `byokDisabled` (per-deployment) becomes `byokRequiresOptIn` (per-installation). An org opting in can't change credentialing for other tenants. Self-hosted ignores the flag entirely.
- **Per-request base URL**: adds `BaseURL` to `proxy.Credentials`, populated from the BYOK row, resolved at the 9 URL-construction sites across the 4 provider clients. Reuses the existing per-request credential-resolution seam — `openai/client.go` already swaps base URL per credential (for Codex), so this extends an existing pattern rather than inventing one.
- **5% fee**: `DebitForInference` writes two ledger rows in one statement when `ByokServed` — an `inference` row at delta 0 with notional cost preserved (so the savings dashboard still prices the turn), plus a `byok_fee` row for the actual debit. Override and subscription still outrank BYOK. Spend counters include the fee, else a capped key would never trip its cap on BYOK traffic.
- Balance gate is unchanged: BYOK turns must NOT be exempt, since the fee needs a funded balance.

## Verification

- Full `go test ./...` green.
- `go vet ./...` clean.
- Migration up → down → up against a local Postgres reproduces the existing schema (constraint rebuilds, no dangling rows).
- New tests: per-installation BYOK gating (managed-strips when not opted-in, managed-keeps when opted-in, self-hosted always); 5% fee math (exact `$100 upstream → $5 fee`; override and subscription outrank BYOK); provider-AAD rejection on mismatched provider.
- Smoke suite (path-gated, requires cassette) not run locally — should be exercised in CI before merge.

## Follow-up WorkWeave change

There is a paired PR on the WorkWeave side that depends on this landing: `weaverouter/crypto.go` writes BYOK secrets with the same Tink keyset and AAD derivation, and the Tink version (`v2.2.0`) is now an explicit direct dependency in WorkWeave's `go.mod`. **The gitlink pin in WorkWeave must be bumped to whatever squash-commits this PR produces before the WorkWeave PR can merge** — `TestRouterSchemaCompatibility` will PREPARE every statement in `backend/internal/app/weaverouter/postgres.go` and fail loudly against the current pinned commit if the new columns aren't there yet.

## Risks

- **AAD divergence between router and WorkWeave**: a future refactor that drift the two encryptors produces rows the router silently cannot decrypt at request time, surfacing as an upstream 401 rather than a write error. The WorkWeave side has a frozen ciphertext fixture catching this; the router side has a unit test that round-trips Encrypt→Decrypt internally.
- **Custom base URLs** (added at write boundary, covered by tests) steer router traffic. SSRF-adjacent surface — any regression that loosens validation will be caught in CI but worth a security review.
- **The env-var shadow guard in the self-hosted admin handlers** (`internal/api/admin/keys.go` 409s when the provider's env var is set) is unchanged and continues to shadow BYOK on self-hosted. Managed mode bypasses it entirely by writing through the WorkWeave control plane, not the dashboard. This is intentional per the fee model but worth confirming in review.

## Out of scope

- Anthropic BYOK: subscription pass-through still wins, so an Anthropic BYOK key would not get exercised by this change against Claude/Codex subscription customers. Worth a follow-up if anyone asks for it.

🤖 Generated with [Weave Router](https://router.workweave.ai)