### PR TITLE
fix(catalog): cap DeepSeek V4 context window at 512K for Together/Fireworks bindings

### DIFF
--- a/internal/router/catalog/catalog.go
+++ b/internal/router/catalog/catalog.go
@@ -364,10 +364,8 @@ var Models = []Model{
 			Price: Pricing{InputUSDPer1M: 0.150, OutputUSDPer1M: 1.200}},
 		{Provider: providers.ProviderOpenRouter, Price: Pricing{InputUSDPer1M: 0.090, OutputUSDPer1M: 1.100}},
 	}},
-	// DeepSeek V4 natively serves 1,048,576 tokens but Together and Fireworks
-	// cap at 512,000. Set to the minimum across all bindings, matching the
-	// minimax pattern (PR#381); Makora may serve the full 1M but failover to
-	// a 512k-capped provider with a request over 512k hard-400s.
+	// Together and Fireworks cap at 512,000 (not the native 1,048,576); failover
+	// from Makora to either with a >512k request hard-400s, so cap conservatively.
 	{ID: "deepseek/deepseek-v4-flash", Tier: TierLow, ContextWindow: 512_000, ImageInput: ImageInputUnsupported, AgenticUse: AgenticLow, Providers: []ProviderBinding{
 		{Provider: providers.ProviderMakora, UpstreamID: "deepseek-ai/DeepSeek-V4-Flash",
 			Price: Pricing{InputUSDPer1M: 0.1134, OutputUSDPer1M: 0.2791, CacheReadMultiplier: 0.20}},

--- a/internal/router/catalog/catalog.go
+++ b/internal/router/catalog/catalog.go
@@ -375,9 +375,6 @@ var Models = []Model{
 		// Makora primary for cost ($1.318/$2.636 vs Together's $1.74/$3.48).
 		// Together ranks ahead of Fireworks as fallback: #1 AA throughput
 		// (~209 t/s vs Fireworks ~120) at the same price.
-		// Context window: DeepSeek V4 Pro natively serves 1,048,576 tokens,
-		// but Together and Fireworks cap at 512,000. Set to the minimum across
-		// all bindings so failover never hits a 400 context_length_exceeded.
 		{Provider: providers.ProviderMakora, UpstreamID: "deepseek-ai/DeepSeek-V4-Pro",
 			Price: Pricing{InputUSDPer1M: 1.3180, OutputUSDPer1M: 2.6361, CacheReadMultiplier: 0.10}},
 		{Provider: providers.ProviderTogether, UpstreamID: "deepseek-ai/DeepSeek-V4-Pro",

--- a/internal/router/catalog/catalog.go
+++ b/internal/router/catalog/catalog.go
@@ -364,18 +364,22 @@ var Models = []Model{
 			Price: Pricing{InputUSDPer1M: 0.150, OutputUSDPer1M: 1.200}},
 		{Provider: providers.ProviderOpenRouter, Price: Pricing{InputUSDPer1M: 0.090, OutputUSDPer1M: 1.100}},
 	}},
-	// DeepSeek V4 natively serves 1,048,576 tokens; the 131_072 carried over
-	// from V3.2 was filtering requests over ~128K (excludeContextOverflowModels
-	// in proxy/service.go).
-	{ID: "deepseek/deepseek-v4-flash", Tier: TierLow, ContextWindow: 1_048_576, ImageInput: ImageInputUnsupported, AgenticUse: AgenticLow, Providers: []ProviderBinding{
+	// DeepSeek V4 natively serves 1,048,576 tokens but Together and Fireworks
+	// cap at 512,000. Set to the minimum across all bindings, matching the
+	// minimax pattern (PR#381); Makora may serve the full 1M but failover to
+	// a 512k-capped provider with a request over 512k hard-400s.
+	{ID: "deepseek/deepseek-v4-flash", Tier: TierLow, ContextWindow: 512_000, ImageInput: ImageInputUnsupported, AgenticUse: AgenticLow, Providers: []ProviderBinding{
 		{Provider: providers.ProviderMakora, UpstreamID: "deepseek-ai/DeepSeek-V4-Flash",
 			Price: Pricing{InputUSDPer1M: 0.1134, OutputUSDPer1M: 0.2791, CacheReadMultiplier: 0.20}},
 		{Provider: providers.ProviderOpenRouter, Price: Pricing{InputUSDPer1M: 0.140, OutputUSDPer1M: 0.280, CacheReadMultiplier: 0.10}},
 	}},
-	{ID: "deepseek/deepseek-v4-pro", Tier: TierHigh, ContextWindow: 1_048_576, ImageInput: ImageInputUnsupported, Providers: []ProviderBinding{
+	{ID: "deepseek/deepseek-v4-pro", Tier: TierHigh, ContextWindow: 512_000, ImageInput: ImageInputUnsupported, Providers: []ProviderBinding{
 		// Makora primary for cost ($1.318/$2.636 vs Together's $1.74/$3.48).
 		// Together ranks ahead of Fireworks as fallback: #1 AA throughput
 		// (~209 t/s vs Fireworks ~120) at the same price.
+		// Context window: DeepSeek V4 Pro natively serves 1,048,576 tokens,
+		// but Together and Fireworks cap at 512,000. Set to the minimum across
+		// all bindings so failover never hits a 400 context_length_exceeded.
 		{Provider: providers.ProviderMakora, UpstreamID: "deepseek-ai/DeepSeek-V4-Pro",
 			Price: Pricing{InputUSDPer1M: 1.3180, OutputUSDPer1M: 2.6361, CacheReadMultiplier: 0.10}},
 		{Provider: providers.ProviderTogether, UpstreamID: "deepseek-ai/DeepSeek-V4-Pro",

--- a/internal/router/catalog/catalog_test.go
+++ b/internal/router/catalog/catalog_test.go
@@ -266,9 +266,10 @@ func TestContextWindowFor_KnownModels(t *testing.T) {
 	assert.Equal(t, 1_047_576, ContextWindowFor("gpt-4.1"))
 	// Gemini models have 1M context.
 	assert.Equal(t, 1_048_576, ContextWindowFor("gemini-3.5-flash"))
-	// DeepSeek V4 (Flash + Pro) serves the full 1,048,576-token window.
-	assert.Equal(t, 1_048_576, ContextWindowFor("deepseek/deepseek-v4-pro"))
-	assert.Equal(t, 1_048_576, ContextWindowFor("deepseek/deepseek-v4-flash"))
+	// DeepSeek V4 natively serves 1,048,576 tokens, but Together and Fireworks
+	// cap at 512,000. Capped to the minimum across all per-provider bindings.
+	assert.Equal(t, 512_000, ContextWindowFor("deepseek/deepseek-v4-pro"))
+	assert.Equal(t, 512_000, ContextWindowFor("deepseek/deepseek-v4-flash"))
 	// Most OSS models serve a 256K window (Qwen3 / Kimi families).
 	assert.Equal(t, 262_144, ContextWindowFor("moonshotai/kimi-k2.5"))
 	// GLM-5 serves ~200K (max_position_embeddings 202752); MiniMax M2.7 is 204800.


### PR DESCRIPTION
Together and Fireworks serve DeepSeek V4 at 512,000 tokens, not the native 1,048,576. Setting the catalog ContextWindow to 1M caused the HMM policy resolver and excludeContextOverflowModels to pass through requests >512K, which hit a 400 context_length_exceeded on Together/Fireworks after failover from Makora.

Makora may serve the full 1M window, but failover walks to 512k-capped providers, so the conservative minimum matches the existing minimax pattern (PR#381) that already caps m2.7 at 204,800 and m3 at 512,000.

**Observed in prod:** deepseek-v4-pro requests with ~581K input tokens failed with context_length_exceeded on Together after Makora failover. Also caught 490K+ requests failing on Fireworks across 29 error calls in 7 days. The max Makora-served input in the same window is ~604K (no errors), confirming Makora's own capacity doesn't need the cap. But the binding-ordered failover chain means a Makora → Together/Fireworks hop on a >512K request will always 400.

🤖 Generated with [Weave Router](https://router.workweave.ai)