### PR TITLE
fix(translate): strip orphaned tool_result blocks on the Anthropic surface

### DIFF
--- a/internal/translate/compaction.go
+++ b/internal/translate/compaction.go
@@ -280,7 +280,7 @@ func (e *RequestEnvelope) rewriteAnthropicForCompaction(summary string, keepRece
 		return 0
 	}
 	start := userAlignedStart(all, keepRecent)
-	cleaned := stripOrphanedAnthropicToolResults(all[start:])
+	cleaned, _ := stripOrphanedAnthropicToolResults(all[start:])
 	rebuilt := append([]string{anthropicAssistantSummaryBlock(summary)}, cleaned...)
 	elided := max(len(all)-len(cleaned), 0)
 	return e.setMessages(rebuilt, elided)

--- a/internal/translate/handover.go
+++ b/internal/translate/handover.go
@@ -78,7 +78,7 @@ func (e *RequestEnvelope) rewriteAnthropicForHandover(summary string) int {
 	if latestUser.Exists() {
 		// Strip tool_result blocks: the summary has no tool_use blocks,
 		// so any tool_results would be orphaned.
-		cleaned := stripAnthropicToolResultMsg(latestUser, nil)
+		cleaned, _ := stripAnthropicToolResultMsg(latestUser, nil)
 		if cleaned != "" {
 			rebuilt = append(rebuilt, cleaned)
 			preserved = 1
@@ -128,7 +128,7 @@ func (e *RequestEnvelope) trimAnthropicLastN(n int) int {
 		return 0
 	}
 	keep := all[len(all)-n:]
-	rebuilt := stripOrphanedAnthropicToolResults(keep)
+	rebuilt, _ := stripOrphanedAnthropicToolResults(keep)
 	newMessages := "[" + strings.Join(rebuilt, ",") + "]"
 	out, err := sjson.SetRawBytes(e.body, "messages", []byte(newMessages))
 	if err != nil {
@@ -318,21 +318,25 @@ func (e *RequestEnvelope) trimGeminiLastN(n int) int {
 
 // stripOrphanedAnthropicToolResults drops tool_result blocks whose tool_use_id
 // has no matching tool_use among the set's assistant messages; user messages
-// left empty afterward are omitted entirely.
-func stripOrphanedAnthropicToolResults(msgs []gjson.Result) []string {
+// left empty afterward are omitted entirely. Also returns the number of blocks
+// removed, which callers cannot infer from the message count: a user message
+// carrying other content survives the strip with the count unchanged.
+func stripOrphanedAnthropicToolResults(msgs []gjson.Result) ([]string, int) {
 	knownIDs := collectAnthropicToolUseIDs(msgs)
 	result := make([]string, 0, len(msgs))
+	stripped := 0
 	for _, m := range msgs {
 		if m.Get("role").String() != "user" {
 			result = append(result, m.Raw)
 			continue
 		}
-		cleaned := stripAnthropicToolResultMsg(m, knownIDs)
+		cleaned, n := stripAnthropicToolResultMsg(m, knownIDs)
+		stripped += n
 		if cleaned != "" {
 			result = append(result, cleaned)
 		}
 	}
-	return result
+	return result, stripped
 }
 
 // collectAnthropicToolUseIDs returns the set of tool_use IDs present in
@@ -356,11 +360,12 @@ func collectAnthropicToolUseIDs(msgs []gjson.Result) map[string]struct{} {
 }
 
 // stripAnthropicToolResultMsg removes tool_result blocks not in knownIDs (nil
-// strips all). Returns "" if the message is left with no content.
-func stripAnthropicToolResultMsg(msg gjson.Result, knownIDs map[string]struct{}) string {
+// strips all). Returns "" if the message is left with no content, plus the
+// number of blocks removed.
+func stripAnthropicToolResultMsg(msg gjson.Result, knownIDs map[string]struct{}) (string, int) {
 	content := msg.Get("content")
 	if !content.IsArray() {
-		return msg.Raw
+		return msg.Raw, 0
 	}
 
 	hasOrphans := false
@@ -375,14 +380,16 @@ func stripAnthropicToolResultMsg(msg gjson.Result, knownIDs map[string]struct{})
 		return true
 	})
 	if !hasOrphans {
-		return msg.Raw
+		return msg.Raw, 0
 	}
 
 	var kept []string
+	stripped := 0
 	content.ForEach(func(_, block gjson.Result) bool {
 		if block.Get("type").String() == "tool_result" {
 			id := block.Get("tool_use_id").String()
 			if _, ok := knownIDs[id]; !ok {
+				stripped++
 				return true
 			}
 		}
@@ -390,14 +397,14 @@ func stripAnthropicToolResultMsg(msg gjson.Result, knownIDs map[string]struct{})
 		return true
 	})
 	if len(kept) == 0 {
-		return ""
+		return "", stripped
 	}
 	newContent := "[" + strings.Join(kept, ",") + "]"
 	out, err := sjson.SetRawBytes([]byte(msg.Raw), "content", []byte(newContent))
 	if err != nil {
-		return msg.Raw
+		return msg.Raw, 0
 	}
-	return string(out)
+	return string(out), stripped
 }
 
 // stripOrphanedOpenAIToolMessages removes role:"tool" messages whose
@@ -634,14 +641,15 @@ func (e *RequestEnvelope) sanitizeOrphanedAnthropicToolCalls() int {
 		return 0
 	}
 	callStripped, cleaned := stripOrphanedAnthropicToolCalls(all)
-	if callStripped == 0 {
+	// Both passes run unconditionally. An orphaned tool_result can be present
+	// with no orphaned tool_use at all (a resumed session whose assistant turn
+	// was never persisted), and Anthropic rejects that wherever it appears —
+	// unlike an unanswered tool_use, which only 400s as the final message.
+	cleanedRaw, resultStripped := stripOrphanedAnthropicToolResults(cleaned)
+	if callStripped == 0 && resultStripped == 0 {
 		return 0
 	}
-	// stripOrphanedAnthropicToolCalls already accounts for any assistant
-	// message it drops entirely inside callStripped; only count messages the
-	// second pass (orphaned tool_results left behind by the first) removes.
-	cleanedRaw := stripOrphanedAnthropicToolResults(cleaned)
-	totalStripped := callStripped + (len(cleaned) - len(cleanedRaw))
+	totalStripped := callStripped + resultStripped
 	newMessages := "[" + strings.Join(cleanedRaw, ",") + "]"
 	out, err := sjson.SetRawBytes(e.body, "messages", []byte(newMessages))
 	if err != nil {

--- a/internal/translate/handover_test.go
+++ b/internal/translate/handover_test.go
@@ -170,6 +170,53 @@ func TestSanitizeOrphanedToolCalls_Anthropic_AllBlocksOrphaned(t *testing.T) {
 	assert.Equal(t, "user", msgs[1].Get("role").String())
 }
 
+func TestSanitizeOrphanedToolCalls_Anthropic_OrphanedToolResultWithNoOrphanedToolUse(t *testing.T) {
+	// A resumed session whose assistant turn was never persisted: the
+	// tool_result survives with nothing to pair against. Anthropic rejects
+	// this wherever it appears, unlike an unanswered tool_use, which only
+	// 400s as the final message.
+	body := `{"messages":[` +
+		`{"role":"user","content":[{"type":"text","text":"go"}]},` +
+		`{"role":"assistant","content":[{"type":"text","text":"working on it"}]},` +
+		`{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_missing","content":"result"}]}` +
+		`]}`
+	e, err := ParseAnthropic([]byte(body))
+	require.NoError(t, err)
+
+	sanitized := e.SanitizeOrphanedToolCalls()
+	assert.Equal(t, 1, sanitized, "the orphaned tool_result must be stripped even though no tool_use is orphaned")
+
+	msgs := gjson.GetBytes(e.body, "messages").Array()
+	require.Len(t, msgs, 2, "the user message held only the orphan, so it is dropped entirely")
+	assert.False(t, gjson.GetBytes(e.body, "messages").Get(`#(content.#(type=="tool_result"))`).Exists(),
+		"no tool_result may survive without a matching tool_use")
+}
+
+func TestSanitizeOrphanedToolCalls_Anthropic_OrphanedToolResultBesideOtherContent(t *testing.T) {
+	// The message survives (it carries a text block), so the message count is
+	// unchanged — the strip is only observable as a block-level count.
+	body := `{"messages":[` +
+		`{"role":"user","content":[{"type":"text","text":"go"}]},` +
+		`{"role":"assistant","content":[{"type":"text","text":"working on it"}]},` +
+		`{"role":"user","content":[` +
+		`{"type":"text","text":"keep me"},` +
+		`{"type":"tool_result","tool_use_id":"toolu_missing","content":"result"}` +
+		`]}` +
+		`]}`
+	e, err := ParseAnthropic([]byte(body))
+	require.NoError(t, err)
+
+	sanitized := e.SanitizeOrphanedToolCalls()
+	assert.Equal(t, 1, sanitized, "a block-level strip must be reported even when no message is dropped")
+
+	msgs := gjson.GetBytes(e.body, "messages").Array()
+	require.Len(t, msgs, 3, "the message itself carries other content and must survive")
+	blocks := msgs[2].Get("content").Array()
+	require.Len(t, blocks, 1, "only the text block should remain")
+	assert.Equal(t, "text", blocks[0].Get("type").String())
+	assert.Equal(t, "keep me", blocks[0].Get("text").String())
+}
+
 func TestSanitizeOrphanedToolCalls_Gemini_NoOp(t *testing.T) {
 	body := `{"contents":[{"role":"user","parts":[{"text":"go"}]}]}`
 	e, err := ParseGemini([]byte(body))


### PR DESCRIPTION
Closes #862.

## What

`SanitizeOrphanedToolCalls` (#855) keeps a wire-valid tool history so a session isn't bricked by a dangling block. The OpenAI half sanitizes both directions. The Anthropic half returned early:

```go
callStripped, cleaned := stripOrphanedAnthropicToolCalls(all)
if callStripped == 0 {
    return 0                                   // tool_results never examined
}
cleanedRaw := stripOrphanedAnthropicToolResults(cleaned)
```

So an orphaned `tool_result` was only cleaned if an orphaned `tool_use` also happened to be present. `stripOrphanedAnthropicToolResults` was already correct — just unreachable.

## Why it matters

Anthropic rejects an unmatched `tool_result` with a 400:

> ``unexpected `tool_use_id` found in `tool_result` blocks: toolu_… Each `tool_result` block must have a corresponding `tool_use` block in the previous message.``

This is the **stricter** of the two directions. An unanswered `tool_use` only 400s when it is the final message; an unmatched `tool_result` is rejected wherever it appears. The pass that ran unconditionally was guarding the more forgiving case.

It is also the more common one in the wild — the dominant trigger is **conversation resume**, where the assistant turn carrying the `tool_use` was never persisted but the following `tool_result` was, which is exactly "orphaned tool_result, no orphaned tool_use": [claude-code#11026](https://github.com/anthropics/claude-code/issues/11026), [#15205](https://github.com/anthropics/claude-code/issues/15205), [#18947](https://github.com/anthropics/claude-code/issues/18947), [#65726](https://github.com/anthropics/claude-code/issues/65726), [#69828](https://github.com/anthropics/claude-code/issues/69828).

The 400 is permanent for the session: every retry resends the same history. That is the bricked session #855 set out to prevent, and because Anthropic validates this itself, it is not limited to strict OSS providers.

## Why the signature changed

Mirroring the OpenAI structure is the obvious fix, but `resultStripped` **cannot** be derived from the message count. `stripOrphanedAnthropicToolResults` removes *blocks* and only drops a message when nothing is left, so a user message carrying other content is modified while the count stays the same.

I verified this rather than assuming it. With the early return removed but detection still based on message count — the naive port — one of the two new tests still fails:

```
--- FAIL: TestSanitizeOrphanedToolCalls_Anthropic_OrphanedToolResultBesideOtherContent
        expected: 1
        actual  : 0
        a block-level strip must be reported even when no message is dropped
```

The cleaned body would be computed and then discarded. So `stripOrphanedAnthropicToolResults` now returns a block-level count, mirroring its OpenAI counterpart. `stripAnthropicToolResultMsg` returns one too; the three other call sites (`rewriteAnthropicForHandover`, `trimAnthropicLastN`, `rewriteAnthropicForCompaction`) discard it.

## Testing

Two regression tests, one per shape — message dropped entirely, and message survives with a block removed. Both fail before the fix:

```
--- FAIL: TestSanitizeOrphanedToolCalls_Anthropic_OrphanedToolResultWithNoOrphanedToolUse
        expected: 1  actual: 0
        the orphaned tool_result must be stripped even though no tool_use is orphaned
--- FAIL: TestSanitizeOrphanedToolCalls_Anthropic_OrphanedToolResultBesideOtherContent
        expected: 1  actual: 0
        a block-level strip must be reported even when no message is dropped
```

All nine pre-existing `SanitizeOrphanedToolCalls` tests pass unchanged, including `_Anthropic_NoOrphans` (asserts the body is byte-identical when clean) and `_Anthropic_AllBlocksOrphaned` (count semantics unchanged at 1).

`go build ./...`, `go vet ./internal/translate/...`, `gofmt -l`, and `go test ./...` are clean across the module.

## Scope

Limited to the Anthropic sanitize path and the counting plumbing it needs. The OpenAI and Gemini branches are untouched, and the strip logic itself is unchanged — only its reachability and its reporting.
