### PR TITLE
chore(install): bump router npm package to 0.2.7

### DIFF
--- a/install/npm/package.json
+++ b/install/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@workweave/router",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "description": "One-command installer that points Claude Code, Codex, opencode, or pi at the Weave Router. For pi it also ships the routing extension, loaded via pi.extensions.",
   "bin": {
     "weave-router": "bin.js",


### PR DESCRIPTION
Publishes the merged Pi Loom plugin through @workweave/router.