### PR TITLE
feat(hmm): suppress lateral same-tier switches on a live session pin

### DIFF
--- a/cmd/router/main.go
+++ b/cmd/router/main.go
@@ -557,6 +557,7 @@ func main() {
 	}
 	prefixTrimFreeSwitch := config.GetOr("ROUTER_PREFIX_TRIM_FREE_SWITCH", "true") == "true"
 	hmmUpgradeConfidence := parseEnvFloat("ROUTER_HMM_UPGRADE_CONFIDENCE_THRESHOLD", 0.85)
+	hmmSameTierPin := config.GetOr("ROUTER_HMM_SAME_TIER_PIN", "false") == "true"
 	handoverProviderName := config.GetOr("ROUTER_HANDOVER_PROVIDER", providers.ProviderAnthropic)
 	handoverModel := config.GetOr("ROUTER_HANDOVER_MODEL", proxy.DefaultHandoverModel)
 	handoverTimeout := parseEnvDurationMs("ROUTER_HANDOVER_TIMEOUT_MS", proxy.DefaultHandoverTimeout)
@@ -755,6 +756,7 @@ func main() {
 		WithCyberRefusalFallbackModel(cyberRefusalFallbackModel).
 		WithPrefixTrimFreeSwitch(prefixTrimFreeSwitch).
 		WithHMMUpgradeConfidenceThreshold(hmmUpgradeConfidence).
+		WithHMMSameTierPin(hmmSameTierPin).
 		WithEscapeNormalize(escapeNormalize).
 		WithEffortEscalation(effortEscalation).
 		WithCCOrchestrationToolsCrossVendor(ccOrchToolsCrossVendor).

--- a/internal/proxy/marker_internal_test.go
+++ b/internal/proxy/marker_internal_test.go
@@ -65,6 +65,19 @@ func TestRoutingMarkerFor_PlannerPaths(t *testing.T) {
 			},
 		},
 		{
+			name: "same_tier_pinned: collapses into stayed bucket",
+			res: turnLoopResult{
+				Decision:        decision,
+				PlannerDecision: planner.Decision{Reason: planner.ReasonSameTierPinned},
+			},
+			wantContains: []string{
+				"· " + markerReasonStayed,
+			},
+			wantNotContain: []string{
+				"same_tier_pinned",
+			},
+		},
+		{
 			name: "same_model: collapses into best-pick bucket",
 			res: turnLoopResult{
 				Decision:        decision,

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -130,11 +130,8 @@ type Service struct {
 	// hmmUpgradeConfidenceThreshold is the minimum classifier confidence needed
 	// for HMM to switch upward to a more expensive model despite cache inertia.
 	hmmUpgradeConfidenceThreshold float64
-	// hmmSameTierPin, when true, suppresses an EV-positive HMM switch between
-	// two models of the same catalog.Tier — once a session settles on a
-	// model, a same-tier lateral cost switch is no longer followed. Legitimate
-	// switches (pin unavailable/excluded, tier upgrade, tool-execution phase
-	// change) are unaffected. Env ROUTER_HMM_SAME_TIER_PIN, off by default.
+	// hmmSameTierPin suppresses EV-positive same-tier lateral switches once a
+	// session pin is live. Env ROUTER_HMM_SAME_TIER_PIN, off by default.
 	hmmSameTierPin bool
 	// plannerEnabled is the kill switch. When false, the orchestrator falls
 	// back to first-decision-wins behavior.

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -130,6 +130,12 @@ type Service struct {
 	// hmmUpgradeConfidenceThreshold is the minimum classifier confidence needed
 	// for HMM to switch upward to a more expensive model despite cache inertia.
 	hmmUpgradeConfidenceThreshold float64
+	// hmmSameTierPin, when true, suppresses an EV-positive HMM switch between
+	// two models of the same catalog.Tier — once a session settles on a
+	// model, a same-tier lateral cost switch is no longer followed. Legitimate
+	// switches (pin unavailable/excluded, tier upgrade, tool-execution phase
+	// change) are unaffected. Env ROUTER_HMM_SAME_TIER_PIN, off by default.
+	hmmSameTierPin bool
 	// plannerEnabled is the kill switch. When false, the orchestrator falls
 	// back to first-decision-wins behavior.
 	plannerEnabled bool
@@ -541,7 +547,7 @@ func humanReasonFromPlanner(code string) string {
 	switch code {
 	case planner.ReasonEVPositive:
 		return markerReasonSwitched
-	case planner.ReasonEVNegative, planner.ReasonNoPriorUsage:
+	case planner.ReasonEVNegative, planner.ReasonNoPriorUsage, planner.ReasonSameTierPinned:
 		return markerReasonStayed
 	case planner.ReasonTierUpgrade:
 		return markerReasonTierUpgrade
@@ -1095,6 +1101,13 @@ func (s *Service) WithHMMUpgradeConfidenceThreshold(v float64) *Service {
 		return s
 	}
 	s.hmmUpgradeConfidenceThreshold = v
+	return s
+}
+
+// WithHMMSameTierPin is the kill switch (ROUTER_HMM_SAME_TIER_PIN) for
+// suppressing an EV-positive HMM switch between two same-tier models.
+func (s *Service) WithHMMSameTierPin(enabled bool) *Service {
+	s.hmmSameTierPin = enabled
 	return s
 }
 

--- a/internal/proxy/turnloop.go
+++ b/internal/proxy/turnloop.go
@@ -1026,6 +1026,19 @@ func (s *Service) hmmCostGatedDecision(
 		}
 	}
 
+	// Same-tier hard pin: once a session settles on a model, suppress a
+	// lateral cost-driven switch to an equal-tier model. This runs after the
+	// upgrade block above, so a confident upgrade (which already rewrote
+	// Reason away from ReasonEVPositive) can never be overturned here — only
+	// a same-tier "switch to save on cache" survives to this check.
+	if s.hmmSameTierPin && base.Outcome == planner.OutcomeSwitch && base.Reason == planner.ReasonEVPositive {
+		pinTier, freshTier := catalog.TierFor(stayPin.Model), catalog.TierFor(fresh.Model)
+		if pinTier != catalog.TierUnknown && pinTier == freshTier {
+			base.Outcome = planner.OutcomeStay
+			base.Reason = planner.ReasonSameTierPinned
+		}
+	}
+
 	if base.Outcome == planner.OutcomeStay && stayPin.Model != fresh.Model {
 		return pinDecision(stayPin), base, true, stayPin.Model
 	}

--- a/internal/proxy/turnloop.go
+++ b/internal/proxy/turnloop.go
@@ -1026,11 +1026,8 @@ func (s *Service) hmmCostGatedDecision(
 		}
 	}
 
-	// Same-tier hard pin: once a session settles on a model, suppress a
-	// lateral cost-driven switch to an equal-tier model. This runs after the
-	// upgrade block above, so a confident upgrade (which already rewrote
-	// Reason away from ReasonEVPositive) can never be overturned here — only
-	// a same-tier "switch to save on cache" survives to this check.
+	// Runs after the upgrade block, so only a plain ReasonEVPositive switch
+	// reaches here; a confident upgrade has already changed Reason.
 	if s.hmmSameTierPin && base.Outcome == planner.OutcomeSwitch && base.Reason == planner.ReasonEVPositive {
 		pinTier, freshTier := catalog.TierFor(stayPin.Model), catalog.TierFor(fresh.Model)
 		if pinTier != catalog.TierUnknown && pinTier == freshTier {

--- a/internal/proxy/turnloop_internal_test.go
+++ b/internal/proxy/turnloop_internal_test.go
@@ -12,6 +12,7 @@ import (
 
 	"workweave/router/internal/providers"
 	"workweave/router/internal/router"
+	"workweave/router/internal/router/catalog"
 	"workweave/router/internal/router/planner"
 	"workweave/router/internal/router/sessionpin"
 )
@@ -551,6 +552,207 @@ func TestHMMCostGate_SwitchesCheaperFreshWhenEVPositive(t *testing.T) {
 	assert.False(t, sticky)
 	assert.Equal(t, "deepseek/deepseek-v4-flash", decision.Model)
 	assert.Equal(t, "claude-sonnet-5", stayModel)
+	assert.Equal(t, planner.OutcomeSwitch, plan.Outcome)
+	assert.Equal(t, planner.ReasonEVPositive, plan.Reason)
+}
+
+func TestHMMCostGate_SameTierPinSuppressesLateralSwitchWhenEnabled(t *testing.T) {
+	svc := NewService(
+		nil,
+		map[string]providers.Client{providers.ProviderOpenAI: nil, providers.ProviderMakora: nil},
+		nil,
+		false,
+		nil,
+		nil,
+		false,
+		"anthropic", "claude-haiku-4-5",
+		nil,
+	)
+	history := sessionpin.Pin{
+		Provider:        providers.ProviderOpenAI,
+		LastServedModel: "gpt-4.1-mini",
+		LastTurnEndedAt: time.Now().Add(-30 * time.Second),
+	}
+	fresh := router.Decision{
+		Provider: providers.ProviderMakora,
+		Model:    "deepseek/deepseek-v4-flash",
+		Reason:   "hmm_policy(classifier 'fast')",
+		Metadata: &router.RoutingMetadata{
+			Strategy:    string(router.StrategyHMM),
+			RouteID:     "route-1",
+			ChosenScore: 0.70,
+		},
+	}
+	// gpt-4.1-mini and deepseek/deepseek-v4-flash are both catalog.TierLow —
+	// confirm the fixture actually exercises the same-tier branch, not a
+	// tier-upgrade/downgrade one the guard must not touch.
+	require.Equal(t, catalog.TierFor(history.LastServedModel), catalog.TierFor(fresh.Model))
+	require.NotEqual(t, catalog.TierUnknown, catalog.TierFor(history.LastServedModel))
+
+	// Flag off (default): unaffected, same as any other EV-positive switch.
+	decision, plan, sticky, stayModel := svc.hmmCostGatedDecision(
+		router.Request{},
+		sessionpin.Pin{},
+		history,
+		fresh,
+		10_000,
+		false,
+	)
+	assert.False(t, sticky)
+	assert.Equal(t, "deepseek/deepseek-v4-flash", decision.Model)
+	assert.Equal(t, "gpt-4.1-mini", stayModel)
+	assert.Equal(t, planner.OutcomeSwitch, plan.Outcome)
+	assert.Equal(t, planner.ReasonEVPositive, plan.Reason)
+
+	// Flag on: the lateral same-tier switch is suppressed; the pin sticks.
+	svc.WithHMMSameTierPin(true)
+	decision, plan, sticky, stayModel = svc.hmmCostGatedDecision(
+		router.Request{},
+		sessionpin.Pin{},
+		history,
+		fresh,
+		10_000,
+		false,
+	)
+	assert.True(t, sticky)
+	assert.Equal(t, "gpt-4.1-mini", decision.Model)
+	assert.Equal(t, providers.ProviderOpenAI, decision.Provider)
+	assert.Equal(t, "gpt-4.1-mini", stayModel)
+	assert.Equal(t, planner.OutcomeStay, plan.Outcome)
+	assert.Equal(t, planner.ReasonSameTierPinned, plan.Reason)
+}
+
+func TestHMMCostGate_SameTierPinDoesNotBlockCrossTierSwitch(t *testing.T) {
+	svc := NewService(
+		nil,
+		map[string]providers.Client{providers.ProviderAnthropic: nil, providers.ProviderMakora: nil},
+		nil,
+		false,
+		nil,
+		nil,
+		false,
+		"anthropic", "claude-haiku-4-5",
+		nil,
+	).WithHMMSameTierPin(true)
+	history := sessionpin.Pin{
+		Provider:        providers.ProviderAnthropic,
+		LastServedModel: "claude-sonnet-5",
+		LastTurnEndedAt: time.Now().Add(-30 * time.Second),
+	}
+	fresh := router.Decision{
+		Provider: providers.ProviderMakora,
+		Model:    "deepseek/deepseek-v4-flash",
+		Reason:   "hmm_policy(classifier 'fast')",
+		Metadata: &router.RoutingMetadata{
+			Strategy:    string(router.StrategyHMM),
+			RouteID:     "route-1",
+			ChosenScore: 0.70,
+		},
+	}
+	require.NotEqual(t, catalog.TierFor(history.LastServedModel), catalog.TierFor(fresh.Model))
+
+	decision, plan, sticky, stayModel := svc.hmmCostGatedDecision(
+		router.Request{},
+		sessionpin.Pin{},
+		history,
+		fresh,
+		10_000,
+		false,
+	)
+
+	assert.False(t, sticky)
+	assert.Equal(t, "deepseek/deepseek-v4-flash", decision.Model)
+	assert.Equal(t, "claude-sonnet-5", stayModel)
+	assert.Equal(t, planner.OutcomeSwitch, plan.Outcome)
+	assert.Equal(t, planner.ReasonEVPositive, plan.Reason)
+}
+
+func TestHMMCostGate_SameTierPinDoesNotBlockConfidentUpgrade(t *testing.T) {
+	svc := NewService(
+		nil,
+		map[string]providers.Client{providers.ProviderAnthropic: nil, providers.ProviderFireworks: nil},
+		nil,
+		false,
+		nil,
+		nil,
+		false,
+		"anthropic", "claude-haiku-4-5",
+		nil,
+	).WithHMMSameTierPin(true)
+	history := sessionpin.Pin{
+		Provider:        providers.ProviderFireworks,
+		LastServedModel: "moonshotai/kimi-k2.7",
+		LastTurnEndedAt: time.Now().Add(-30 * time.Second),
+	}
+	fresh := router.Decision{
+		Provider: providers.ProviderAnthropic,
+		Model:    "claude-sonnet-5",
+		Reason:   "hmm_policy(classifier 'high')",
+		Metadata: &router.RoutingMetadata{
+			Strategy:    string(router.StrategyHMM),
+			RouteID:     "route-1",
+			ChosenScore: 0.85,
+		},
+	}
+	require.NotEqual(t, catalog.TierFor(history.LastServedModel), catalog.TierFor(fresh.Model))
+
+	decision, plan, sticky, stayModel := svc.hmmCostGatedDecision(
+		router.Request{},
+		sessionpin.Pin{},
+		history,
+		fresh,
+		10_000,
+		false,
+	)
+
+	assert.False(t, sticky)
+	assert.Equal(t, "claude-sonnet-5", decision.Model)
+	assert.Equal(t, "moonshotai/kimi-k2.7", stayModel)
+	assert.Equal(t, planner.OutcomeSwitch, plan.Outcome)
+	assert.Equal(t, hmmReasonConfidentUpgrade, plan.Reason)
+}
+
+func TestHMMCostGate_SameTierPinIgnoresUnknownTierModels(t *testing.T) {
+	svc := NewService(
+		nil,
+		map[string]providers.Client{providers.ProviderAnthropic: nil, providers.ProviderMakora: nil},
+		nil,
+		false,
+		nil,
+		nil,
+		false,
+		"anthropic", "claude-haiku-4-5",
+		nil,
+	).WithHMMSameTierPin(true)
+	history := sessionpin.Pin{
+		Provider:        providers.ProviderAnthropic,
+		LastServedModel: "claude-opus-4-5", // untiered (TierUnknown) in the catalog fixture
+		LastTurnEndedAt: time.Now().Add(-30 * time.Second),
+	}
+	fresh := router.Decision{
+		Provider: providers.ProviderMakora,
+		Model:    "deepseek/deepseek-v4-flash",
+		Reason:   "hmm_policy(classifier 'fast')",
+		Metadata: &router.RoutingMetadata{
+			Strategy:    string(router.StrategyHMM),
+			RouteID:     "route-1",
+			ChosenScore: 0.70,
+		},
+	}
+	require.Equal(t, catalog.TierUnknown, catalog.TierFor(history.LastServedModel))
+
+	decision, plan, sticky, stayModel := svc.hmmCostGatedDecision(
+		router.Request{},
+		sessionpin.Pin{},
+		history,
+		fresh,
+		10_000,
+		false,
+	)
+
+	assert.False(t, sticky)
+	assert.Equal(t, "deepseek/deepseek-v4-flash", decision.Model)
+	assert.Equal(t, "claude-opus-4-5", stayModel)
 	assert.Equal(t, planner.OutcomeSwitch, plan.Outcome)
 	assert.Equal(t, planner.ReasonEVPositive, plan.Reason)
 }

--- a/internal/proxy/turnloop_internal_test.go
+++ b/internal/proxy/turnloop_internal_test.go
@@ -583,9 +583,7 @@ func TestHMMCostGate_SameTierPinSuppressesLateralSwitchWhenEnabled(t *testing.T)
 			ChosenScore: 0.70,
 		},
 	}
-	// gpt-4.1-mini and deepseek/deepseek-v4-flash are both catalog.TierLow —
-	// confirm the fixture actually exercises the same-tier branch, not a
-	// tier-upgrade/downgrade one the guard must not touch.
+	// Confirm both models share the same tier before exercising the guard.
 	require.Equal(t, catalog.TierFor(history.LastServedModel), catalog.TierFor(fresh.Model))
 	require.NotEqual(t, catalog.TierUnknown, catalog.TierFor(history.LastServedModel))
 

--- a/internal/router/planner/policy.go
+++ b/internal/router/planner/policy.go
@@ -99,6 +99,12 @@ const (
 	ReasonEVNegative      = "ev_negative"
 	ReasonTierUpgrade     = "tier_upgrade"
 	ReasonColdPinFresh    = "cold_pin_follow_fresh"
+	// ReasonSameTierPinned marks an EV-positive switch overturned by a
+	// same-tier hard-pin policy (see internal/proxy.Service.hmmSameTierPin):
+	// once a session settles on a model, a same-tier lateral cost switch is
+	// suppressed rather than followed. Set by the caller, never by Decide
+	// itself — Decide has no HMM-specific policy knowledge.
+	ReasonSameTierPinned = "same_tier_pinned"
 )
 
 // Decide returns the planner verdict for this turn.

--- a/internal/router/planner/policy.go
+++ b/internal/router/planner/policy.go
@@ -99,11 +99,8 @@ const (
 	ReasonEVNegative      = "ev_negative"
 	ReasonTierUpgrade     = "tier_upgrade"
 	ReasonColdPinFresh    = "cold_pin_follow_fresh"
-	// ReasonSameTierPinned marks an EV-positive switch overturned by a
-	// same-tier hard-pin policy (see internal/proxy.Service.hmmSameTierPin):
-	// once a session settles on a model, a same-tier lateral cost switch is
-	// suppressed rather than followed. Set by the caller, never by Decide
-	// itself — Decide has no HMM-specific policy knowledge.
+	// ReasonSameTierPinned is set by the caller (not Decide) when a same-tier
+	// lateral switch is suppressed by hmmSameTierPin.
 	ReasonSameTierPinned = "same_tier_pinned"
 )
 


### PR DESCRIPTION
Once HMM's cost gate settles a session on a model, an EV-positive switch to
a different model in the same catalog.Tier is now suppressed behind
`ROUTER_HMM_SAME_TIER_PIN` (default off) — a lateral cost-driven move no
longer overrides the pin. Legitimate switches are unaffected: pin
unavailable/excluded, tier upgrade (`hmm_confident_upgrade`), and
tool-execution phase change all still proceed as before.

🤖 Generated with [Weave Router](https://router.workweave.ai)
