### PR TITLE
fix: decouple HMM candidates from legacy cluster

### DIFF
--- a/cmd/router/main.go
+++ b/cmd/router/main.go
@@ -578,9 +578,11 @@ func main() {
 	}
 	compactionPct := parseEnvFloat("ROUTER_COMPACTION_PCT", proxy.DefaultCompactionTriggerPct)
 
-	// Lets the planner force a switch when a pinned model's provider is
-	// removed. nil on a missing/unloadable bundle treats every pin as routable.
-	availableModels := resolveAvailableModels(availableProviders, logger)
+	// Catalog tier + registered providers define what this deployment can route
+	// automatically. Strategy-specific artifacts own selection membership; in
+	// particular, the legacy cluster bundle must not constrain HMM candidates.
+	routingTargets := catalog.RoutingTargetSet(availableProviders)
+	logger.Info("Catalog routing targets resolved", "catalog_routing_targets", len(routingTargets))
 
 	// OFF by default: wraps only the proxy's routing entrypoint, so rtr stays
 	// the *cluster.Multiversion the admin cast and semantic cache reference.
@@ -614,14 +616,14 @@ func main() {
 		rlHeaders := rlSidecarHeadersFromEnv()
 		rlRouter = rl.New(
 			rl.NewHTTPDeciderWithHeaders(rlSidecarURL, nil, rlTimeout, rlHeaders),
-			availableModels,
+			routingTargets,
 			availableProviders,
 		)
 		logger.Info(
 			"RL policy router wired",
 			"sidecar_url", rlSidecarURL,
 			"timeout_ms", rlTimeout.Milliseconds(),
-			"candidate_models", len(availableModels),
+			"candidate_models", len(routingTargets),
 			"modal_proxy_auth", len(rlHeaders) > 0,
 		)
 	} else {
@@ -654,12 +656,11 @@ func main() {
 		if capabilityErr != nil {
 			logger.Warn("HMM policy sidecar capabilities unavailable at boot; optional behavior remains disabled", "sidecar_url", hmmSidecarURL, "err", capabilityErr)
 		}
-		hmmPolicyRouter := hmm.New(hmmClient, availableModels, availableProviders)
+		hmmPolicyRouter := hmm.New(hmmClient, availableProviders)
 		hmmPolicyRouter.WithCapabilities(hmmCapabilities)
 		hmmEmbeddingPolicyRouter := hmm.NewForStrategy(
 			router.StrategyHMMEmbedding,
 			hmmClient,
-			availableModels,
 			availableProviders,
 		)
 		hmmEmbeddingPolicyRouter.WithCapabilities(hmmCapabilities)
@@ -689,7 +690,7 @@ func main() {
 			"sidecar_url", hmmSidecarURL,
 			"auth_mode", hmmAuthMode,
 			"timeout_ms", hmmTimeout.Milliseconds(),
-			"candidate_models", len(availableModels),
+			"candidate_models", len(routingTargets),
 			"strategies", []router.Strategy{router.StrategyHMM, router.StrategyHMMEmbedding},
 		)
 	} else {
@@ -721,7 +722,7 @@ func main() {
 		config.GetOr("ROUTER_POLICY_SIDECARS", ""),
 		config.GetOr("ROUTER_POLICY_SIDECAR_AUTH", ""),
 		parseEnvDurationMs("ROUTER_POLICY_SIDECAR_TIMEOUT_MS", policyclient.DefaultTimeout),
-		availableModels,
+		routingTargets,
 		availableProviders,
 		nil,
 		logger,
@@ -770,26 +771,26 @@ func main() {
 		WithPlanner(plannerCfg).
 		WithSummarizer(summarizer).
 		WithCompaction(compactionSz, compactionPct).
-		WithAvailableModels(availableModels).
+		WithAvailableModels(routingTargets).
 		WithDefaultBaselineModel(resolveDefaultBaselineModel()).
 		WithBillingService(billingSvc)
 	for _, spec := range configuredPolicySpecs {
 		proxySvc = proxySvc.WithPolicyStrategy(spec)
-		logger.Info("Generic policy sidecar wired", "strategy", spec.Strategy, "candidate_models", len(availableModels))
+		logger.Info("Generic policy sidecar wired", "strategy", spec.Strategy, "candidate_models", len(routingTargets))
 	}
 	logger.Info("Effort escalation configured", "enabled", effortEscalation)
 	logger.Info("Cross-vendor Claude Code orchestration tools configured", "enabled", ccOrchToolsCrossVendor)
 	logger.Info("Loop escalation configured", "enabled", loopEscalationEnabled, "holdout_pct", loopEscalationHoldoutPct)
 	logger.Info("Spiral shadow detector configured", "enabled", spiralShadowEnabled)
 	logger.Info("Text-repetition break configured", "enabled", textRepetitionBreakEnabled)
-	logger.Info("Planner configured", "enabled", plannerEnabled, "threshold_usd", plannerCfg.ThresholdUSD, "expected_remaining_turns", plannerCfg.ExpectedRemainingTurns, "tier_upgrade_enabled", plannerCfg.TierUpgradeEnabled, "cold_pin_follow_fresh", plannerCfg.ColdPinFollowFresh, "prefix_trim_free_switch", prefixTrimFreeSwitch, "available_models_count", len(availableModels))
+	logger.Info("Planner configured", "enabled", plannerEnabled, "threshold_usd", plannerCfg.ThresholdUSD, "expected_remaining_turns", plannerCfg.ExpectedRemainingTurns, "tier_upgrade_enabled", plannerCfg.TierUpgradeEnabled, "cold_pin_follow_fresh", plannerCfg.ColdPinFollowFresh, "prefix_trim_free_switch", prefixTrimFreeSwitch, "routing_targets_count", len(routingTargets))
 	logger.Info("Tool-result scoring configured", "enabled", scoreToolResultTurns)
 
 	// Fail loud if a deployed model is missing from the tier table;
 	// TierUnknown would silently disable the guard for that pair.
-	if plannerCfg.TierUpgradeEnabled && len(availableModels) > 0 {
-		deployed := make([]string, 0, len(availableModels))
-		for m := range availableModels {
+	if plannerCfg.TierUpgradeEnabled && len(routingTargets) > 0 {
+		deployed := make([]string, 0, len(routingTargets))
+		for m := range routingTargets {
 			deployed = append(deployed, m)
 		}
 		if err := catalog.ValidateDeployed(deployed); err != nil {
@@ -1444,28 +1445,6 @@ func resolveHardPinModel(available map[string]struct{}, logger *slog.Logger) (pr
 		return defaultHardPinProvider, defaultHardPinModel
 	}
 	return p, m
-}
-
-// resolveAvailableModels returns the boot-time set of routable model names
-// (default bundle's deployed_models ∩ registered providers), or nil on load
-// failure so the planner treats every pin as routable.
-func resolveAvailableModels(availableProviders map[string]struct{}, logger *slog.Logger) map[string]struct{} {
-	reqVersion := config.GetOr("ROUTER_CLUSTER_VERSION", cluster.LatestVersion)
-	defaultVersion, err := cluster.ResolveVersion(reqVersion)
-	if err != nil {
-		logger.Warn("Available-models set: could not resolve cluster version; planner will treat every pin as routable", "err", err)
-		return nil
-	}
-	bundle, err := cluster.LoadBundle(defaultVersion)
-	if err != nil {
-		logger.Warn("Available-models set: could not load bundle; planner will treat every pin as routable", "err", err)
-		return nil
-	}
-	out := cluster.RoutableModelSet(bundle.Registry, availableProviders)
-	if len(out) == 0 {
-		return nil
-	}
-	return out
 }
 
 // envVarHint returns the env var name for a provider's API key, for log

--- a/cmd/router/main.go
+++ b/cmd/router/main.go
@@ -578,9 +578,7 @@ func main() {
 	}
 	compactionPct := parseEnvFloat("ROUTER_COMPACTION_PCT", proxy.DefaultCompactionTriggerPct)
 
-	// Catalog tier + registered providers define what this deployment can route
-	// automatically. Strategy-specific artifacts own selection membership; in
-	// particular, the legacy cluster bundle must not constrain HMM candidates.
+	// Strategy-specific artifacts own selection membership; the legacy cluster bundle must not constrain HMM candidates.
 	routingTargets := catalog.RoutingTargetSet(availableProviders)
 	logger.Info("Catalog routing targets resolved", "catalog_routing_targets", len(routingTargets))
 

--- a/internal/proxy/turnloop_internal_test.go
+++ b/internal/proxy/turnloop_internal_test.go
@@ -399,6 +399,34 @@ func TestNormalizeHMMStayPin_ReResolvesDisabledProvider(t *testing.T) {
 		"a sticky HMM pin must re-resolve a disabled provider for its retained model")
 }
 
+func TestNormalizeHMMStayPin_PreservesCatalogRoutableTerra(t *testing.T) {
+	availableProviders := map[string]struct{}{providers.ProviderOpenAI: {}}
+	svc := NewService(
+		nil,
+		map[string]providers.Client{providers.ProviderOpenAI: nil},
+		nil,
+		false,
+		nil,
+		nil,
+		false,
+		providers.ProviderAnthropic, "claude-haiku-4-5",
+		nil,
+	).WithAvailableModels(catalog.RoutingTargetSet(availableProviders))
+	pin := sessionpin.Pin{
+		Provider:        providers.ProviderOpenAI,
+		Model:           "gpt-5.6-terra",
+		LastServedModel: "gpt-5.6-terra",
+		LastTurnEndedAt: time.Now(),
+		PinnedUntil:     time.Now().Add(time.Hour),
+	}
+
+	normalized, ok := svc.normalizeHMMStayPin(router.Request{}, pin)
+
+	require.True(t, ok)
+	assert.Equal(t, "gpt-5.6-terra", normalized.Model)
+	assert.Equal(t, providers.ProviderOpenAI, normalized.Provider)
+}
+
 func TestRecordTurnUsage_HMMEVStayWritesHistoryOnly(t *testing.T) {
 	store := newStubPinStore()
 	svc := NewService(

--- a/internal/router/catalog/catalog.go
+++ b/internal/router/catalog/catalog.go
@@ -154,10 +154,11 @@ func (m Model) PrimaryProvider() string {
 }
 
 // Models is the source of truth, one struct literal per model, grouped by
-// family and tier. To add a model: append a Model{} below, and if the deploy
-// should route to it, list it in the cluster bundle's model_registry.json
-// (that file controls which versions route to it; this catalog controls
-// pricing/dispatch). No other files need to change.
+// family and tier. Tiered models with a registered provider are automatic
+// routing targets. Strategy artifacts own selection membership: legacy cluster
+// versions use their model_registry.json, while policy sidecars such as HMM
+// intersect catalog targets with their own roster. This catalog controls
+// pricing and dispatch for every strategy.
 var Models = []Model{
 	// --- Anthropic ---
 	// $1/$5 per the published table (the $0.80/$4 rate that used to sit here

--- a/internal/router/catalog/catalog_test.go
+++ b/internal/router/catalog/catalog_test.go
@@ -139,6 +139,21 @@ func TestResolveBinding_GemmaUsesNativeGoogleUpstreamID(t *testing.T) {
 	assert.Equal(t, "gemma-4-26b-a4b-it", b.UpstreamID)
 }
 
+func TestRoutingTargetSet_FiltersByTierAndRegisteredProviders(t *testing.T) {
+	targets := RoutingTargetSet(map[string]struct{}{providers.ProviderOpenAI: {}})
+
+	assert.Contains(t, targets, "gpt-5.6-terra")
+	assert.NotContains(t, targets, "claude-sonnet-5", "unregistered providers must not contribute targets")
+	assert.NotContains(t, targets, "gpt-4o", "untiered passthrough models must not become routing targets")
+}
+
+func TestRoutingTargetSet_AcceptsAnyRegisteredFallbackBinding(t *testing.T) {
+	targets := RoutingTargetSet(map[string]struct{}{providers.ProviderOpenRouter: {}})
+
+	assert.Contains(t, targets, "qwen/qwen3-coder-next", "a registered fallback binding makes the model dispatchable")
+	assert.NotContains(t, targets, "gpt-5.6-terra", "models with no registered binding stay unavailable")
+}
+
 func TestAllowedAtOrBelow_FiltersOutUnknownTier(t *testing.T) {
 	allowed := AllowedAtOrBelow(TierMid)
 	// claude-haiku-4-5 (Low) and claude-sonnet-4-5 (Mid) should be in.

--- a/internal/router/catalog/lookup.go
+++ b/internal/router/catalog/lookup.go
@@ -80,6 +80,23 @@ func EnumerateBindings(id string, available map[string]struct{}) []IndexedBindin
 	return out
 }
 
+// RoutingTargetSet returns the automatic routing targets that have at least
+// one binding backed by a provider registered in this deployment. Untiered
+// catalog rows are passthrough-only and must never become policy candidates.
+func RoutingTargetSet(availableProviders map[string]struct{}) map[string]struct{} {
+	out := make(map[string]struct{}, len(Models))
+	for _, model := range Models {
+		if model.Tier == TierUnknown {
+			continue
+		}
+		if len(EnumerateBindings(model.ID, availableProviders)) == 0 {
+			continue
+		}
+		out[model.ID] = struct{}{}
+	}
+	return out
+}
+
 // UpstreamIDFor returns the upstream model ID for a catalog binding.
 func UpstreamIDFor(catalogID, bindingID string) string {
 	if bindingID != "" {

--- a/internal/router/hmm/e2e_test.go
+++ b/internal/router/hmm/e2e_test.go
@@ -50,7 +50,6 @@ func TestHTTPRouterEndToEndWithSidecar(t *testing.T) {
 
 	r := New(
 		policyclient.New(server.URL, server.Client(), 0),
-		map[string]struct{}{"moonshotai/kimi-k2.7": {}},
 		map[string]struct{}{providers.ProviderFireworks: {}},
 	)
 	decision, err := r.Route(context.Background(), router.Request{

--- a/internal/router/hmm/hmm.go
+++ b/internal/router/hmm/hmm.go
@@ -46,9 +46,7 @@ func NewForStrategy(strategy router.Strategy, decider Decider, availableProvider
 	)
 }
 
-// newWithRoutingTargets keeps focused tests small without exposing a public
-// constructor that application composition could reconnect to a legacy model
-// registry.
+// newWithRoutingTargets allows focused tests to inject a fixed target set.
 func newWithRoutingTargets(strategy router.Strategy, decider Decider, routingTargets, availableProviders map[string]struct{}) *Router {
 	resolver := policy.NewResolver(routingTargets, availableProviders, rosterIDFor, policy.ManagedProviderPolicy())
 	return &Router{

--- a/internal/router/hmm/hmm.go
+++ b/internal/router/hmm/hmm.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"workweave/router/internal/router"
+	"workweave/router/internal/router/catalog"
 	"workweave/router/internal/router/policy"
 )
 
@@ -27,14 +28,29 @@ type Router struct {
 	resolver *policy.Resolver
 }
 
-func New(decider Decider, deployed, available map[string]struct{}) *Router {
-	return NewForStrategy(router.StrategyHMM, decider, deployed, available)
+func New(decider Decider, availableProviders map[string]struct{}) *Router {
+	return NewForStrategy(router.StrategyHMM, decider, availableProviders)
 }
 
 // NewForStrategy constructs an HMM adapter with a separately selectable
 // strategy ID while preserving the HMM roster mapping and lifecycle behavior.
-func NewForStrategy(strategy router.Strategy, decider Decider, deployed, available map[string]struct{}) *Router {
-	resolver := policy.NewResolver(deployed, available, rosterIDFor, policy.ManagedProviderPolicy())
+// Its candidate universe comes from the catalog and registered providers; the
+// HMM sidecar owns roster membership and intersects these candidates with the
+// selected cluster's arms.
+func NewForStrategy(strategy router.Strategy, decider Decider, availableProviders map[string]struct{}) *Router {
+	return newWithRoutingTargets(
+		strategy,
+		decider,
+		catalog.RoutingTargetSet(availableProviders),
+		availableProviders,
+	)
+}
+
+// newWithRoutingTargets keeps focused tests small without exposing a public
+// constructor that application composition could reconnect to a legacy model
+// registry.
+func newWithRoutingTargets(strategy router.Strategy, decider Decider, routingTargets, availableProviders map[string]struct{}) *Router {
+	resolver := policy.NewResolver(routingTargets, availableProviders, rosterIDFor, policy.ManagedProviderPolicy())
 	return &Router{
 		SidecarRouter: policy.NewSidecarRouter(policy.SidecarRouterConfig{
 			Strategy:    strategy,

--- a/internal/router/hmm/hmm_test.go
+++ b/internal/router/hmm/hmm_test.go
@@ -46,7 +46,7 @@ func TestRouterMapsSidecarRosterModelBackToCatalogDecision(t *testing.T) {
 	}}
 	deployed := map[string]struct{}{"moonshotai/kimi-k2.7": {}}
 	available := map[string]struct{}{providers.ProviderFireworks: {}}
-	r := New(decider, deployed, available)
+	r := newWithRoutingTargets(router.StrategyHMM, decider, deployed, available)
 
 	decision, err := r.Route(context.Background(), router.Request{
 		OrganizationID: "org-1",
@@ -105,7 +105,7 @@ func TestRouterMapsSidecarRosterModelBackToCatalogDecision(t *testing.T) {
 
 func TestRouterUsesSeparatelySelectableEmbeddingStrategy(t *testing.T) {
 	decider := &fakeDecider{res: Result{Model: "moonshotai/kimi-k2.7-code"}}
-	r := NewForStrategy(
+	r := newWithRoutingTargets(
 		router.StrategyHMMEmbedding,
 		decider,
 		map[string]struct{}{"moonshotai/kimi-k2.7": {}},
@@ -125,7 +125,7 @@ func TestRouterKeepsGeneratedRouteIDWhenSidecarOmitsIt(t *testing.T) {
 	decider := &fakeDecider{res: Result{
 		Model: "moonshotai/kimi-k2.7-code",
 	}}
-	r := New(decider, map[string]struct{}{"moonshotai/kimi-k2.7": {}}, map[string]struct{}{providers.ProviderFireworks: {}})
+	r := newWithRoutingTargets(router.StrategyHMM, decider, map[string]struct{}{"moonshotai/kimi-k2.7": {}}, map[string]struct{}{providers.ProviderFireworks: {}})
 
 	decision, err := r.Route(context.Background(), router.Request{PromptText: "hello"})
 
@@ -137,7 +137,7 @@ func TestRouterKeepsGeneratedRouteIDWhenSidecarOmitsIt(t *testing.T) {
 
 func TestRouterFailsClosedOnUnknownReturnedModel(t *testing.T) {
 	decider := &fakeDecider{res: Result{Model: "unknown/model"}}
-	r := New(decider, map[string]struct{}{"moonshotai/kimi-k2.7": {}}, map[string]struct{}{providers.ProviderFireworks: {}})
+	r := newWithRoutingTargets(router.StrategyHMM, decider, map[string]struct{}{"moonshotai/kimi-k2.7": {}}, map[string]struct{}{providers.ProviderFireworks: {}})
 
 	_, err := r.Route(context.Background(), router.Request{PromptText: "hello"})
 
@@ -147,7 +147,7 @@ func TestRouterFailsClosedOnUnknownReturnedModel(t *testing.T) {
 
 func TestRouterFailsClosedOnReturnedProviderMismatch(t *testing.T) {
 	decider := &fakeDecider{res: Result{Model: "moonshotai/kimi-k2.7-code", Provider: providers.ProviderOpenRouter}}
-	r := New(decider, map[string]struct{}{"moonshotai/kimi-k2.7": {}}, map[string]struct{}{providers.ProviderFireworks: {}})
+	r := newWithRoutingTargets(router.StrategyHMM, decider, map[string]struct{}{"moonshotai/kimi-k2.7": {}}, map[string]struct{}{providers.ProviderFireworks: {}})
 
 	_, err := r.Route(context.Background(), router.Request{PromptText: "hello"})
 
@@ -159,7 +159,6 @@ func TestRouterDoesNotOfferOpenRouterFallbackCandidates(t *testing.T) {
 	decider := &fakeDecider{res: Result{Model: "minimax/minimax-m3"}}
 	r := New(
 		decider,
-		map[string]struct{}{"minimax/minimax-m3": {}},
 		map[string]struct{}{providers.ProviderOpenRouter: {}},
 	)
 
@@ -174,22 +173,7 @@ func TestRouterDoesNotOfferOpenRouterFallbackCandidates(t *testing.T) {
 	assert.Zero(t, decider.calls)
 }
 
-func TestCurrentHMMRosterCatalogArmsResolveToCurrentProviders(t *testing.T) {
-	deployed := map[string]struct{}{
-		"deepseek/deepseek-v4-flash": {},
-		"qwen/qwen3-coder-next":      {},
-		"gpt-5.4-nano":               {},
-		"minimax/minimax-m3":         {},
-		"moonshotai/kimi-k2.7":       {},
-		"deepseek/deepseek-v4-pro":   {},
-		"gemini-3.5-flash":           {},
-		"claude-sonnet-5":            {},
-		"claude-opus-4-8":            {},
-		"gpt-5.5":                    {},
-		"z-ai/glm-5.2":               {},
-		"gemini-3.1-pro-preview":     {},
-		"claude-fable-5":             {},
-	}
+func TestCatalogRoutingTargetsResolveCurrentHMMRosterArmsToProviders(t *testing.T) {
 	available := map[string]struct{}{
 		providers.ProviderAnthropic:  {},
 		providers.ProviderOpenAI:     {},
@@ -201,7 +185,7 @@ func TestCurrentHMMRosterCatalogArmsResolveToCurrentProviders(t *testing.T) {
 		providers.ProviderTogether:   {},
 		providers.ProviderXAI:        {},
 	}
-	r := New(&fakeDecider{}, deployed, available)
+	r := New(&fakeDecider{}, available)
 
 	candidates := r.resolver.Resolve(router.Request{}).Candidates
 
@@ -210,7 +194,7 @@ func TestCurrentHMMRosterCatalogArmsResolveToCurrentProviders(t *testing.T) {
 		assert.NotEqual(t, providers.ProviderOpenRouter, candidate.Provider, candidate.RosterID)
 		gotRosterIDs = append(gotRosterIDs, candidate.RosterID)
 	}
-	assert.ElementsMatch(t, []string{
+	for _, rosterID := range []string{
 		"deepseek/deepseek-v4-flash",
 		"qwen/qwen3-coder-next",
 		"openai/gpt-5.4-nano",
@@ -219,12 +203,46 @@ func TestCurrentHMMRosterCatalogArmsResolveToCurrentProviders(t *testing.T) {
 		"deepseek/deepseek-v4-pro",
 		"google/gemini-3.5-flash",
 		"anthropic/claude-sonnet-5",
-		"anthropic/claude-opus-4.8",
+		"anthropic/claude-opus-5",
 		"openai/gpt-5.5",
+		"openai/gpt-5.6-terra",
 		"z-ai/glm-5.2",
 		"google/gemini-3.1-pro-preview",
 		"anthropic/claude-fable-5",
-	}, gotRosterIDs)
+	} {
+		assert.Contains(t, gotRosterIDs, rosterID)
+	}
+}
+
+func TestRouterOffersAndSelectsTerraWithoutLegacyDeployedSet(t *testing.T) {
+	decider := &fakeDecider{res: Result{
+		Model:    "openai/gpt-5.6-terra",
+		Provider: providers.ProviderOpenAI,
+	}}
+	r := New(decider, map[string]struct{}{providers.ProviderOpenAI: {}})
+
+	decision, err := r.Route(context.Background(), router.Request{PromptText: "solve this"})
+
+	require.NoError(t, err)
+	assert.Equal(t, "gpt-5.6-terra", decision.Model)
+	assert.Equal(t, providers.ProviderOpenAI, decision.Provider)
+	assert.Contains(t, candidateRosterIDs(decider.query.Candidates), "openai/gpt-5.6-terra")
+}
+
+func TestRouterDoesNotOfferTerraWithoutRegisteredOpenAIProvider(t *testing.T) {
+	r := New(&fakeDecider{}, map[string]struct{}{providers.ProviderAnthropic: {}})
+
+	candidates := r.resolver.Resolve(router.Request{}).Candidates
+
+	assert.NotContains(t, candidateRosterIDs(candidates), "openai/gpt-5.6-terra")
+}
+
+func candidateRosterIDs(candidates []Candidate) []string {
+	ids := make([]string, 0, len(candidates))
+	for _, candidate := range candidates {
+		ids = append(ids, candidate.RosterID)
+	}
+	return ids
 }
 
 func TestRosterIDForSkipsAmbiguousBareProviderIDs(t *testing.T) {

--- a/internal/router/model.go
+++ b/internal/router/model.go
@@ -206,6 +206,7 @@ var registry = map[string]ModelSpec{
 	"gemini-3-flash-preview":        google3Base,
 	"gemini-3.1-flash-lite-preview": google3Base,
 	"gemini-3.1-flash-live-preview": google3Base,
+	"gemini-3.5-flash":              google3Base,
 	"gemini-3.5-flash-lite":         google3Base,
 	"gemini-3.6-flash":              google3Base,
 

--- a/internal/translate/gemini_test.go
+++ b/internal/translate/gemini_test.go
@@ -228,6 +228,26 @@ func TestPrepareGemini_ReasoningEffortMapsToThinkingLevel_Gemini3x(t *testing.T)
 	}
 }
 
+func TestPrepareGemini_AnthropicAdaptiveThinkingMapsToGemini35Flash(t *testing.T) {
+	body := []byte(`{
+		"model":"claude-sonnet-5",
+		"max_tokens":4096,
+		"thinking":{"type":"adaptive"},
+		"output_config":{"effort":"high"},
+		"messages":[{"role":"user","content":"solve this"}]
+	}`)
+	env, err := translate.ParseAnthropic(body)
+	require.NoError(t, err)
+
+	prep, err := env.PrepareGemini(http.Header{}, translate.EmitOptions{TargetModel: "gemini-3.5-flash"})
+	require.NoError(t, err)
+	out := mustUnmarshal(t, prep.Body)
+	generationConfig := out["generationConfig"].(map[string]any)
+	thinkingConfig := generationConfig["thinkingConfig"].(map[string]any)
+	assert.Equal(t, "high", thinkingConfig["thinkingLevel"])
+	assert.NotContains(t, thinkingConfig, "thinkingBudget")
+}
+
 func TestPrepareGemini_StreamHintHeaderSet(t *testing.T) {
 	body := []byte(`{"messages":[{"role":"user","content":"x"}],"stream":true}`)
 	env, _ := translate.ParseOpenAI(body)


### PR DESCRIPTION
## Summary

- derive automatic routing targets from the catalog and registered providers instead of the legacy cluster bundle
- make HMM construct its candidate universe internally while the sidecar remains authoritative for roster membership
- register Gemini 3.5 Flash reasoning support and cover Anthropic adaptive-thinking translation
- add regressions proving Terra is offered, selectable, and remains pinnable when OpenAI is available

## Why

The legacy cluster bundle was accidentally acting as a global deployment roster. Because v0.75 does not contain gpt-5.6-terra, the HMM resolver removed Terra before the HMM sidecar could evaluate it, biasing affected benchmark clusters toward Sonnet. This keeps legacy bundle membership local to the legacy cluster strategy.

## Validation

- go test ./...
- go vet ./...
- wv mr tc
- wv mr t
- poetry run pytest -q (HMM sidecar: 33 passed, 1 skipped)
- docker compose --profile hmm config --quiet
- docker build --file sidecars/hmm/Dockerfile --tag router-hmm-sidecar:test .

