### PR TITLE
fix(pi-router): safeguard routed tool-loop compaction

### DIFF
--- a/install/pi-router/README.md
+++ b/install/pi-router/README.md
@@ -31,8 +31,12 @@ from npm on next start and loads this extension via its `pi.extensions` field.
   The persistent status changes to `WEAVE ROUTER — <model> [forced]` after the
   router validates and canonicalizes the requested model.
 - **Per-process routing bias.** Static `x-weave-routing-*` knob headers bias the
-  router: quality on the main loop, speed + cheap on subagents, cheapest on
-  compaction.
+  router: quality on the main loop and speed + cheap on subagents.
+- **Long tool-loop compaction.** Pi 0.74 can cross its context threshold inside
+  an uninterrupted tool loop before its normal post-run compaction check. The
+  extension preserves a usable output budget for the real continuation and
+  compacts once the loop settles, while leaving ordinary threshold compaction
+  to Pi.
 - **Sticky sessions.** `metadata.user_id = "pi:<sessionId>"` pins the main loop
   to one model for the session; subagents get their own pins.
 - **`dispatch` tool — parallel, context-isolated subagents.** pi has none
@@ -65,7 +69,7 @@ from npm on next start and loads this extension via its `pi.extensions` field.
 | `WEAVE_PI_ALLOW_SUBAGENT_TOOLS` | unset | `1` lets `dispatch` grant subagents write/exec tools (bash, write, edit); default strips them |
 | `WEAVE_ROUTING_ALPHA` / `…_SPEED_WEIGHT` / `…_OUTPUT_COST_RATIO` / `…_EXPECTED_OUTPUT_TOKENS` | role preset | Override individual routing knobs (main process only — children always use their role preset) |
 | `WEAVE_NO_SAFETY` | unset | `1` disables the catastrophic-bash gate |
-| `WEAVE_CHEAP_COMPACTION` | unset | `1` enables the (experimental) cheap-compaction path |
+| `WEAVE_PI_AUTO_COMPACTION` | unset | `0` disables the routed tool-loop compaction safeguard |
 
 Internal: `WEAVE_PI_SUBAGENT=1` and `WEAVE_PI_SUBAGENT_ID` are set by `dispatch`
 on child processes; don't set them yourself.
@@ -83,5 +87,5 @@ version with each response so resumed totals remain auditable.
 
 ## Notes
 
-- Cheap compaction is currently a reserved flag — the handler defers to pi's
-  built-in compaction until the router-routed path is validated end-to-end.
+- Actual SDK/router probes keep their small output budget. Only a probe-sized
+  request carrying a real tool-result continuation is repaired.

--- a/install/pi-router/src/compaction.ts
+++ b/install/pi-router/src/compaction.ts
@@ -1,26 +1,150 @@
 /**
- * EXPERIMENTAL, off by default (enable with WEAVE_CHEAP_COMPACTION=1).
+ * Compaction safeguards for Pi's routed provider.
  *
- * Intent: run context compaction through the cheapest routing knobs. The
- * catch is that compaction bypasses provider hooks and reuses the session's
- * static provider headers (the main loop's quality knobs), and
- * `session_before_compact` is the only per-turn lever. Producing a fully
- * router-routed cheap CompactionResult here is not yet validated, so this
- * handler currently defers to pi's built-in compaction (returns no override)
- * and only reserves the flag + surfaces that it's active. Promote to a real
- * cheap path once validated end-to-end.
+ * Pi 0.74 checks automatic compaction only after an entire agent loop. A long
+ * tool loop can therefore cross the virtual model's context window between
+ * turns. Pi then clamps the next request to max_tokens=1, which looks exactly
+ * like an SDK quota probe to the router and produces a one-token response.
+ *
+ * Preserve real probes, but restore a usable budget for a clamped request that
+ * contains an actual tool result. Once the agent finishes, compact using the
+ * highest context reading seen during the run; routed providers tokenize and
+ * report caches differently, so the final response alone is not authoritative.
  */
 
-import type { ExtensionAPI, ExtensionContext, SessionBeforeCompactEvent } from "@mariozechner/pi-coding-agent";
+import type {
+	AgentEndEvent,
+	BeforeProviderRequestEvent,
+	ExtensionAPI,
+	ExtensionContext,
+	SessionCompactEvent,
+	TurnEndEvent,
+} from "@mariozechner/pi-coding-agent";
+import type { AssistantMessage } from "@mariozechner/pi-ai";
 
-export function registerCheapCompaction(pi: ExtensionAPI): void {
-	let announced = false;
-	pi.on("session_before_compact", (_event: SessionBeforeCompactEvent, ctx: ExtensionContext) => {
-		if (ctx.hasUI && !announced) {
-			announced = true;
-			ctx.ui.setStatus("weave-compaction", "cheap compaction: experimental (using built-in)");
-		}
-		// Defer to built-in compaction until the router-routed cheap path is validated.
-		return undefined;
+const PROBE_MAX_TOKENS = 4;
+const CONTINUATION_MAX_TOKENS = 16_384;
+const COMPACTION_RESERVE_TOKENS = 16_384;
+const STATUS_KEY = "weave-compaction";
+
+interface ProviderPayload {
+	max_tokens?: unknown;
+	messages?: unknown;
+	tools?: unknown;
+}
+
+interface ProviderMessage {
+	content?: unknown;
+}
+
+type Schedule = (callback: () => void) => unknown;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null;
+}
+
+function containsToolResult(messages: unknown): boolean {
+	if (!Array.isArray(messages)) return false;
+	return messages.some((message: unknown) => {
+		if (!isRecord(message)) return false;
+		const content = (message as ProviderMessage).content;
+		return Array.isArray(content) && content.some((block: unknown) => isRecord(block) && block.type === "tool_result");
+	});
+}
+
+/**
+ * Repair only the Pi context-exhaustion shape. Genuine SDK probes have no tool
+ * result transcript and remain at max_tokens=1..4 for the router to hard-pin.
+ */
+export function repairClampedToolContinuation(payload: unknown): boolean {
+	if (!isRecord(payload)) return false;
+	const body = payload as ProviderPayload;
+	if (typeof body.max_tokens !== "number" || body.max_tokens < 1 || body.max_tokens > PROBE_MAX_TOKENS) return false;
+	if (!Array.isArray(body.tools) || body.tools.length === 0) return false;
+	if (!containsToolResult(body.messages)) return false;
+	body.max_tokens = CONTINUATION_MAX_TOKENS;
+	return true;
+}
+
+function contextTokens(message: AssistantMessage): number {
+	const usage = message.usage;
+	if (usage.totalTokens > 0) return usage.totalTokens;
+	return usage.input + usage.output + usage.cacheRead + usage.cacheWrite;
+}
+
+function latestCompactionId(ctx: ExtensionContext): string | undefined {
+	const branch = ctx.sessionManager.getBranch();
+	for (let i = branch.length - 1; i >= 0; i--) {
+		const entry = branch[i];
+		if (entry?.type === "compaction") return entry.id;
+	}
+	return undefined;
+}
+
+export function registerCompaction(pi: ExtensionAPI, schedule: Schedule = (callback) => setTimeout(callback, 0)): void {
+	let highWaterTokens = 0;
+	let lastTurnTokens = 0;
+	let repairedContinuation = false;
+	let compactionScheduled = false;
+
+	const resetRun = () => {
+		highWaterTokens = 0;
+		lastTurnTokens = 0;
+		repairedContinuation = false;
+	};
+
+	const finishCompaction = (ctx: ExtensionContext) => {
+		compactionScheduled = false;
+		resetRun();
+		if (ctx.hasUI) ctx.ui.setStatus(STATUS_KEY, undefined);
+	};
+
+	pi.on("session_start", resetRun);
+	pi.on("agent_start", resetRun);
+	pi.on("session_compact", (_event: SessionCompactEvent, ctx: ExtensionContext) => finishCompaction(ctx));
+
+	pi.on("before_provider_request", (event: BeforeProviderRequestEvent) => {
+		if (repairClampedToolContinuation(event.payload)) repairedContinuation = true;
+	});
+
+	pi.on("turn_end", (event: TurnEndEvent) => {
+		if (event.message.role !== "assistant") return;
+		lastTurnTokens = contextTokens(event.message as AssistantMessage);
+		highWaterTokens = Math.max(highWaterTokens, lastTurnTokens);
+	});
+
+	pi.on("agent_end", (_event: AgentEndEvent, ctx: ExtensionContext) => {
+		if (process.env.WEAVE_PI_AUTO_COMPACTION === "0" || compactionScheduled) return;
+		const contextWindow = ctx.model?.contextWindow ?? ctx.getContextUsage()?.contextWindow ?? 0;
+		if (contextWindow <= COMPACTION_RESERVE_TOKENS) return;
+		const threshold = contextWindow - COMPACTION_RESERVE_TOKENS;
+		// Pi's built-in check runs immediately after this event and owns the
+		// ordinary final-turn threshold case. Starting another compaction while
+		// that async summary is in flight would race it.
+		if (lastTurnTokens > threshold) return;
+		if (!repairedContinuation && highWaterTokens <= threshold) return;
+
+		compactionScheduled = true;
+		const previousCompactionId = latestCompactionId(ctx);
+
+		// Pi is still settling agent_end while extension handlers run. Schedule
+		// manual compaction for the next event-loop turn to avoid abort/wait
+		// recursion, and let Pi's own auto-compaction win if it already ran.
+		schedule(() => {
+			if (!compactionScheduled) return;
+			const currentCompactionId = latestCompactionId(ctx);
+			if (currentCompactionId !== previousCompactionId) {
+				finishCompaction(ctx);
+				return;
+			}
+			if (ctx.hasUI) ctx.ui.setStatus(STATUS_KEY, "compacting routed context...");
+			ctx.compact({
+				onComplete: () => finishCompaction(ctx),
+				onError: (error) => {
+					compactionScheduled = false;
+					if (ctx.hasUI) ctx.ui.setStatus(STATUS_KEY, `compaction failed: ${error.message}`);
+				},
+			});
+		});
 	});
 }

--- a/install/pi-router/src/index.ts
+++ b/install/pi-router/src/index.ts
@@ -9,7 +9,7 @@
  *                   detection.
  *   - Loom UI:      branded header, Wooly animation, actual route, and saved $.
  *   - safety:       block catastrophic bash (unless WEAVE_NO_SAFETY=1).
- *   - compaction:   experimental cheap path (only when WEAVE_CHEAP_COMPACTION=1).
+ *   - compaction:   protect long tool loops, then compact routed context.
  *   - dispatch:     parallel, context-isolated subagents — top-level process
  *                   only (no grandchildren).
  *
@@ -20,7 +20,7 @@
 import { fileURLToPath } from "node:url";
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import { isSubagent } from "./config.js";
-import { registerCheapCompaction } from "./compaction.js";
+import { registerCompaction } from "./compaction.js";
 import { registerDispatch } from "./dispatch.js";
 import { registerForceModelCommands } from "./force-model.js";
 import { registerMetadata } from "./metadata.js";
@@ -40,9 +40,9 @@ export default function (pi: ExtensionAPI): void {
 	registerMetadata(pi);
 	registerForceModelCommands(pi);
 	registerRoutedModel(pi);
+	registerCompaction(pi);
 
 	if (process.env.WEAVE_NO_SAFETY !== "1") registerSafety(pi);
-	if (process.env.WEAVE_CHEAP_COMPACTION === "1") registerCheapCompaction(pi);
 
 	// Only the top-level process fans out. Children (WEAVE_PI_SUBAGENT=1) load
 	// this same extension but get no dispatch tool, so subagents can't spawn

--- a/install/pi-router/src/ui.ts
+++ b/install/pi-router/src/ui.ts
@@ -26,6 +26,16 @@ export interface RouterUiSnapshot {
 	savings: SavingsAggregate;
 }
 
+type LegacyCompatibleExtensionContext = ExtensionContext & { mode?: string };
+
+function isTuiContext(ctx: ExtensionContext): boolean {
+	const mode = (ctx as LegacyCompatibleExtensionContext).mode;
+	// Pi 0.74.2 supports headers and widgets but predates ctx.mode. In that
+	// release hasUI is true only for the interactive TUI, so it is the safe
+	// compatibility signal. Newer Pi releases expose mode and take precedence.
+	return mode === "tui" || (mode === undefined && ctx.hasUI);
+}
+
 function brand(text: string): string {
 	return `${BRAND_OPEN}${text}${BRAND_CLOSE}`;
 }
@@ -45,7 +55,7 @@ function headerLines(theme: Theme, width: number): string[] {
 }
 
 export function installLoomUi(ctx: ExtensionContext): void {
-	if (ctx.mode !== "tui") return;
+	if (!isTuiContext(ctx)) return;
 	ctx.ui.setTitle("Loom · Weave Router");
 	ctx.ui.setHeader((_tui: TUI, theme: Theme) => ({
 		invalidate() {},
@@ -59,7 +69,7 @@ export function installLoomUi(ctx: ExtensionContext): void {
 export function clearLoomUi(ctx: ExtensionContext): void {
 	if (!ctx.hasUI) return;
 	ctx.ui.setStatus(STATUS_KEY, undefined);
-	if (ctx.mode === "tui") {
+	if (isTuiContext(ctx)) {
 		ctx.ui.setWidget(WOOLY_WIDGET_KEY, undefined);
 		ctx.ui.setHeader(undefined);
 	}
@@ -74,7 +84,8 @@ export function updateRouterStatus(ctx: ExtensionContext, snapshot: RouterUiSnap
 	else if (requestedModel) route = `${requestedModel} · awaiting route`;
 	else route = "automatic routing";
 
-	const label = ctx.mode === "tui" ? ctx.ui.theme.bold(brand("WEAVE ROUTER")) : "WEAVE ROUTER";
+	const tui = isTuiContext(ctx);
+	const label = tui ? ctx.ui.theme.bold(brand("WEAVE ROUTER")) : "WEAVE ROUTER";
 	const detail = forcedModel ? `${forcedModel} [forced]` : `${route} · ${formatSavings(savings)}`;
-	ctx.ui.setStatus(STATUS_KEY, `${label} — ${ctx.mode === "tui" ? ctx.ui.theme.fg("dim", detail) : detail}`);
+	ctx.ui.setStatus(STATUS_KEY, `${label} — ${tui ? ctx.ui.theme.fg("dim", detail) : detail}`);
 }

--- a/install/pi-router/test/compaction.test.ts
+++ b/install/pi-router/test/compaction.test.ts
@@ -1,0 +1,125 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
+import { registerCompaction, repairClampedToolContinuation } from "../src/compaction.js";
+
+type CapturedHandler = (event: any, ctx: ExtensionContext) => unknown;
+
+function extensionHarness(schedule?: (callback: () => void) => unknown) {
+	const handlers = new Map<string, CapturedHandler[]>();
+	const pi = {
+		on(event: string, handler: CapturedHandler) {
+			const eventHandlers = handlers.get(event) ?? [];
+			eventHandlers.push(handler);
+			handlers.set(event, eventHandlers);
+		},
+	} as unknown as ExtensionAPI;
+	registerCompaction(pi, schedule);
+	return {
+		emit(event: string, payload: unknown, ctx: ExtensionContext) {
+			for (const handler of handlers.get(event) ?? []) handler(payload, ctx);
+		},
+	};
+}
+
+function assistant(totalTokens: number) {
+	return {
+		role: "assistant",
+		content: [],
+		usage: {
+			input: totalTokens,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens,
+		},
+		stopReason: "stop",
+	};
+}
+
+function contextHarness() {
+	let compactCalls = 0;
+	let status: string | undefined;
+	const branch: any[] = [];
+	const ctx = {
+		hasUI: true,
+		model: { contextWindow: 200_000 },
+		getContextUsage: () => ({ tokens: 0, contextWindow: 200_000, percent: 0 }),
+		sessionManager: { getBranch: () => branch },
+		ui: {
+			setStatus(_key: string, value: string | undefined) {
+				status = value;
+			},
+		},
+		compact(options?: { onComplete?: (result: unknown) => void }) {
+			compactCalls += 1;
+			options?.onComplete?.({});
+		},
+	} as unknown as ExtensionContext;
+	return { ctx, compactCalls: () => compactCalls, status: () => status };
+}
+
+test("repairs only clamped requests that continue from a tool result", () => {
+	const genuineProbe = {
+		max_tokens: 1,
+		messages: [{ role: "user", content: [{ type: "text", text: "ping" }] }],
+		tools: [],
+	};
+	assert.equal(repairClampedToolContinuation(genuineProbe), false);
+	assert.equal(genuineProbe.max_tokens, 1);
+
+	const continuation = {
+		max_tokens: 1,
+		messages: [
+			{ role: "assistant", content: [{ type: "tool_use", id: "tool-1", name: "bash", input: {} }] },
+			{ role: "user", content: [{ type: "tool_result", tool_use_id: "tool-1", content: "done" }] },
+		],
+		tools: [{ name: "bash" }],
+	};
+	assert.equal(repairClampedToolContinuation(continuation), true);
+	assert.equal(continuation.max_tokens, 16_384);
+
+	const normalTurn = { ...continuation, max_tokens: 64_000 };
+	assert.equal(repairClampedToolContinuation(normalTurn), false);
+	assert.equal(normalTurn.max_tokens, 64_000);
+});
+
+test("compacts once after a routed tool loop crosses the virtual context window", () => {
+	const extension = extensionHarness((callback) => callback());
+	const { ctx, compactCalls, status } = contextHarness();
+	extension.emit("agent_start", { type: "agent_start" }, ctx);
+	extension.emit("turn_end", { type: "turn_end", message: assistant(210_910), toolResults: [] }, ctx);
+
+	const continuation = {
+		max_tokens: 1,
+		messages: [{ role: "user", content: [{ type: "tool_result", tool_use_id: "tool-1", content: "done" }] }],
+		tools: [{ name: "bash" }],
+	};
+	extension.emit("before_provider_request", { type: "before_provider_request", payload: continuation }, ctx);
+	extension.emit("turn_end", { type: "turn_end", message: assistant(135_652), toolResults: [] }, ctx);
+	extension.emit("agent_end", { type: "agent_end", messages: [] }, ctx);
+
+	assert.equal(continuation.max_tokens, 16_384);
+	assert.equal(compactCalls(), 1);
+	assert.equal(status(), undefined);
+});
+
+test("does not compact a run that stays below Pi's normal reserve threshold", () => {
+	const extension = extensionHarness((callback) => callback());
+	const { ctx, compactCalls } = contextHarness();
+	extension.emit("agent_start", { type: "agent_start" }, ctx);
+	extension.emit("turn_end", { type: "turn_end", message: assistant(150_000), toolResults: [] }, ctx);
+	extension.emit("agent_end", { type: "agent_end", messages: [] }, ctx);
+
+	assert.equal(compactCalls(), 0);
+});
+
+test("leaves an over-threshold final turn to Pi's built-in compaction", () => {
+	const extension = extensionHarness((callback) => callback());
+	const { ctx, compactCalls } = contextHarness();
+	extension.emit("agent_start", { type: "agent_start" }, ctx);
+	extension.emit("turn_end", { type: "turn_end", message: assistant(190_000), toolResults: [] }, ctx);
+	extension.emit("agent_end", { type: "agent_end", messages: [] }, ctx);
+
+	assert.equal(compactCalls(), 0);
+});

--- a/install/pi-router/test/e2e.sh
+++ b/install/pi-router/test/e2e.sh
@@ -17,8 +17,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PKG_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 INSTALL_SH="$(cd "$PKG_DIR/.." && pwd)/install.sh"
 EXT="$PKG_DIR/src/index.ts"
-SAVINGS_TEST="$SCRIPT_DIR/savings.test.ts"
-FORCE_MODEL_TEST="$SCRIPT_DIR/force-model.test.ts"
+UNIT_SUITE="$SCRIPT_DIR/unit-suite.ts"
 MOCK="$SCRIPT_DIR/mock_router.py"
 
 PORT="${MOCK_PORT:-8899}"
@@ -28,8 +27,7 @@ for tool in pi jq python3 curl; do
   command -v "$tool" >/dev/null 2>&1 || { echo "FATAL: '$tool' not on PATH"; exit 2; }
 done
 [ -f "$EXT" ]        || { echo "FATAL: extension not found: $EXT"; exit 2; }
-[ -f "$SAVINGS_TEST" ] || { echo "FATAL: savings test not found: $SAVINGS_TEST"; exit 2; }
-[ -f "$FORCE_MODEL_TEST" ] || { echo "FATAL: force-model test not found: $FORCE_MODEL_TEST"; exit 2; }
+[ -f "$UNIT_SUITE" ]  || { echo "FATAL: unit suite not found: $UNIT_SUITE"; exit 2; }
 [ -f "$INSTALL_SH" ] || { echo "FATAL: installer not found: $INSTALL_SH"; exit 2; }
 [ -f "$MOCK" ]       || { echo "FATAL: mock not found: $MOCK"; exit 2; }
 
@@ -129,23 +127,17 @@ printf '%s\n' "$STRIPPED" >"$PI_DIR/settings.json"
 
 # -------------------------------------------------------------------------
 phase "Phase 2 — generated pricing + savings contract"
-# Loading the focused node:test file through pi exercises the same TypeScript
-# loader and module resolution that the published extension uses.
+# Loading the focused node:test suite through pi exercises the same TypeScript
+# loader and module resolution that the published extension uses. The wrapper
+# deliberately is not named *.test.ts because Pi 0.74 excludes those paths.
 if with_timeout 30 env PI_CODING_AGENT_DIR="$PI_DIR" \
-  pi -e "$SAVINGS_TEST" --offline --list-models weave >"$WORK/savings.out" 2>&1 </dev/null; then
-  [ "$(grep -c '^✔ ' "$WORK/savings.out" || true)" = "8" ] \
-    && ok "generated catalog + savings arithmetic tests passed" \
-    || bad "savings tests did not report all eight passes (see $WORK/savings.out)"
+  pi -e "$UNIT_SUITE" --no-session --offline --model weave/claude-sonnet-4-6 \
+  -p "Run the unit suite." >"$WORK/unit.out" 2>&1 </dev/null; then
+  [ "$(grep -Ec '^(✔ |ok [0-9]+ - )' "$WORK/unit.out" || true)" = "22" ] \
+    && ok "pricing, force-model, UI, and compaction unit suite passed" \
+    || bad "unit suite did not report all 22 passes (see $WORK/unit.out)"
 else
-  bad "savings tests failed to load through pi (see $WORK/savings.out)"
-fi
-if with_timeout 30 env PI_CODING_AGENT_DIR="$PI_DIR" \
-  pi -e "$FORCE_MODEL_TEST" --offline --list-models weave >"$WORK/force-model.out" 2>&1 </dev/null; then
-  [ "$(grep -c '^✔ ' "$WORK/force-model.out" || true)" = "8" ] \
-    && ok "force-model command + branch restoration tests passed" \
-    || bad "force-model tests did not report all eight passes (see $WORK/force-model.out)"
-else
-  bad "force-model tests failed to load through pi (see $WORK/force-model.out)"
+  bad "unit suite failed to load through pi (see $WORK/unit.out)"
 fi
 
 # -------------------------------------------------------------------------

--- a/install/pi-router/test/ui.test.ts
+++ b/install/pi-router/test/ui.test.ts
@@ -1,0 +1,75 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { ExtensionContext } from "@mariozechner/pi-coding-agent";
+import { aggregateSavings } from "../src/savings.js";
+import { clearLoomUi, installLoomUi, updateRouterStatus } from "../src/ui.js";
+
+function uiHarness(mode: "tui" | "rpc" | "json" | "print" | undefined, hasUI: boolean) {
+	let title: string | undefined;
+	let header: unknown;
+	let widget: unknown;
+	let status: string | undefined;
+	const ctx = {
+		...(mode === undefined ? {} : { mode }),
+		hasUI,
+		ui: {
+			theme: {
+				bold(text: string) {
+					return `<bold>${text}</bold>`;
+				},
+				fg(color: string, text: string) {
+					return `<${color}>${text}</${color}>`;
+				},
+			},
+			setTitle(value: string) {
+				title = value;
+			},
+			setHeader(value: unknown) {
+				header = value;
+			},
+			setWidget(_key: string, value: unknown) {
+				widget = value;
+			},
+			setStatus(_key: string, value: string | undefined) {
+				status = value;
+			},
+		},
+	} as unknown as ExtensionContext;
+	return {
+		ctx,
+		values: () => ({ title, header, widget, status }),
+	};
+}
+
+test("Pi 0.74 TUI renders and clears Loom without ctx.mode", () => {
+	const { ctx, values } = uiHarness(undefined, true);
+	installLoomUi(ctx);
+	updateRouterStatus(ctx, {
+		requestedModel: "claude-sonnet-4-6",
+		savings: aggregateSavings([]),
+	});
+
+	assert.equal(values().title, "Loom · Weave Router");
+	assert.equal(typeof values().header, "function");
+	assert.equal(typeof values().widget, "function");
+	assert.match(values().status ?? "", /<bold>.*WEAVE ROUTER.*<\/bold>/);
+
+	clearLoomUi(ctx);
+	assert.equal(values().header, undefined);
+	assert.equal(values().widget, undefined);
+	assert.equal(values().status, undefined);
+});
+
+test("modern non-TUI modes do not receive terminal components", () => {
+	const { ctx, values } = uiHarness("rpc", true);
+	installLoomUi(ctx);
+	updateRouterStatus(ctx, {
+		requestedModel: "claude-sonnet-4-6",
+		savings: aggregateSavings([]),
+	});
+
+	assert.equal(values().title, undefined);
+	assert.equal(values().header, undefined);
+	assert.equal(values().widget, undefined);
+	assert.equal(values().status, "WEAVE ROUTER — claude-sonnet-4-6 · awaiting route · saved —");
+});

--- a/install/pi-router/test/unit-suite.ts
+++ b/install/pi-router/test/unit-suite.ts
@@ -1,0 +1,11 @@
+// Pi 0.74 intentionally ignores files named *.test.ts when loading extensions.
+// Use a non-test wrapper so the E2E harness exercises these modules through
+// Pi's own TypeScript loader on both the legacy and current runtimes.
+import "./savings.test.js";
+import "./force-model.test.js";
+import "./ui.test.js";
+import "./compaction.test.js";
+
+// Pi 0.74 also requires an extension-shaped default export before evaluating
+// the module. Test registration itself happens through the side-effect imports.
+export default function unitSuite(): void {}


### PR DESCRIPTION
## Summary
# Changes to pi router 
- Repair clamped continuation requests only when they contain real tool results, preserving genuine low-token router probes.
- Schedule one routed compaction after long tool loops exceed the context reserve, while leaving Pi normal threshold compaction intact.
- Support Pi 0.74 interactive TUI contexts that do not expose `ctx.mode`.
- Add focused compaction and UI coverage, and run the expanded unit suite through Pi extension loading.

##
    Validation

- Not run locally.