### PR TITLE
fix(proxy): resolve force-model provider against live availability (#874)

### DIFF
--- a/internal/proxy/agent_shadow_eval.go
+++ b/internal/proxy/agent_shadow_eval.go
@@ -50,7 +50,10 @@ func (s *Service) runAgentShadowEvaluationRoute(
 		return turnLoopResult{}, err
 	}
 	rawModel := strings.TrimSpace(evaluation.Model)
-	model, provider, known, _ := resolveForceModelWithEffort(rawModel)
+	// nil available: this call site re-walks req.EnabledProviders itself just
+	// below (with its own excludedProvidersForRequest gate), so the shared
+	// availability check in resolveForceModelWithEffort would be redundant.
+	model, provider, known, _ := resolveForceModelWithEffort(rawModel, nil)
 	if !known || model != strings.ToLower(rawModel) {
 		return turnLoopResult{}, fmt.Errorf("agent-shadow model must be a canonical catalog id: %q", rawModel)
 	}

--- a/internal/proxy/force_model.go
+++ b/internal/proxy/force_model.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"sort"
 	"strings"
 	"time"
 
@@ -111,16 +112,26 @@ var forceModelAliases = map[string]string{
 }
 
 // resolveForceModel is the legacy two-return surface. New pin-and-effort
-// callers use resolveForceModelWithEffort.
-func resolveForceModel(model string) (canonicalID, provider string, known bool) {
-	canon, prov, kn, _ := resolveForceModelWithEffort(model)
+// callers use resolveForceModelWithEffort. available is the deployment's
+// live enabled-provider set (nil means "unrestricted": pick the primary
+// binding regardless of availability) — see resolveForceModelWithEffort.
+func resolveForceModel(model string, available map[string]struct{}) (canonicalID, provider string, known bool) {
+	canon, prov, kn, _ := resolveForceModelWithEffort(model, available)
 	return canon, prov, kn
 }
 
 // resolveForceModelWithEffort is like resolveForceModel but also strips a
 // `:level` suffix. `known` is true only for catalog matches; known=false +
-// effort!="" lets callers surface "model not found" without losing the effort.
-func resolveForceModelWithEffort(model string) (canonicalID, provider string, known bool, effort string) {
+// effort!="" lets callers surface "model not found" without losing the
+// effort. For a catalog match, provider is resolved via
+// catalog.ResolveBinding against `available` — the same binding walk
+// cluster.Scorer's resolveProviderFor does for automatic routing — rather
+// than unconditionally picking Providers[0]. If none of the model's bindings
+// are in available, provider is "" (known stays true: the model is real,
+// there's just nothing that can currently serve it). nil available skips the
+// walk and always returns the primary binding, matching pre-existing
+// behavior for callers that haven't threaded the enabled set through yet.
+func resolveForceModelWithEffort(model string, available map[string]struct{}) (canonicalID, provider string, known bool, effort string) {
 	effortLevel, stripped := stripEffortSuffix(model)
 	model = stripped
 	model = strings.ToLower(strings.TrimSpace(model))
@@ -135,21 +146,25 @@ func resolveForceModelWithEffort(model string) (canonicalID, provider string, kn
 	if alias, ok := forceModelAliases[model]; ok {
 		model = alias
 	}
-	if m, ok := catalog.ByID(model); ok && len(m.Providers) > 0 && (requiredProvider == "" || m.Providers[0].Provider == requiredProvider) {
-		return m.ID, m.Providers[0].Provider, true, effort
+	if m, ok := catalog.ByID(model); ok && len(m.Providers) > 0 {
+		if bound, nativeMismatch := resolveForcedBinding(m, requiredProvider, available); !nativeMismatch {
+			return m.ID, bound, true, effort
+		}
 	}
 	if !strings.Contains(model, "/") {
 		suffix := "/" + model
 		var matched catalog.Model
 		var matches int
 		for _, m := range catalog.Models {
-			if strings.HasSuffix(m.ID, suffix) && len(m.Providers) > 0 && (requiredProvider == "" || m.Providers[0].Provider == requiredProvider) {
+			if strings.HasSuffix(m.ID, suffix) && len(m.Providers) > 0 {
 				matched = m
 				matches++
 			}
 		}
-		if matches == 1 && len(matched.Providers) > 0 {
-			return matched.ID, matched.Providers[0].Provider, true, effort
+		if matches == 1 {
+			if bound, nativeMismatch := resolveForcedBinding(matched, requiredProvider, available); !nativeMismatch {
+				return matched.ID, bound, true, effort
+			}
 		}
 	}
 	if requiredProvider != "" {
@@ -169,6 +184,57 @@ func resolveForceModelWithEffort(model string) (canonicalID, provider string, kn
 	default:
 		return model, providers.ProviderAnthropic, false, effort
 	}
+}
+
+// resolveForcedBinding picks the provider to pin a resolved catalog model to.
+// requiredProvider (set only for an explicit "openai/<id>" native prefix)
+// first narrows the model's bindings to that provider; nativeMismatch=true
+// means the model has no binding under that provider at all, distinct from
+// "has one, just not available right now". Given the (possibly narrowed)
+// binding list, it walks in catalog order for the first entry in available —
+// mirroring cluster.Scorer's resolveProviderFor, so /force-model can't pin a
+// binding the deployment can't actually serve. nil available (callers that
+// haven't threaded the enabled-provider set through yet) skips the
+// availability walk and returns the first (narrowed) binding, preserving
+// prior unconditional-Providers[0] behavior. A known model with no available
+// binding returns ("", false) — not a mismatch, just currently unservable.
+func resolveForcedBinding(m catalog.Model, requiredProvider string, available map[string]struct{}) (provider string, nativeMismatch bool) {
+	bindings := m.Providers
+	if requiredProvider != "" {
+		filtered := make([]catalog.ProviderBinding, 0, len(bindings))
+		for _, b := range bindings {
+			if b.Provider == requiredProvider {
+				filtered = append(filtered, b)
+			}
+		}
+		if len(filtered) == 0 {
+			return "", true
+		}
+		bindings = filtered
+	}
+	if available == nil {
+		return bindings[0].Provider, false
+	}
+	for _, b := range bindings {
+		if _, ok := available[b.Provider]; ok {
+			return b.Provider, false
+		}
+	}
+	return "", false
+}
+
+// sortedProviderKeys returns a deterministic sorted slice of a provider set,
+// for stable log output. nil input (unrestricted) returns nil.
+func sortedProviderKeys(m map[string]struct{}) []string {
+	if m == nil {
+		return nil
+	}
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
 }
 
 // stripEffortSuffix splits a `:level` suffix off model, canonicalizes it via
@@ -240,6 +306,9 @@ func (s *Service) setForceModelPin(
 // writing the same session pin the /force-model command writes. It's
 // (re)written on every request carrying the header. Unrecognized models are
 // ignored (routing proceeds automatically) rather than failing the request.
+// enabledProviders is the deployment's live enabled-provider set (nil =
+// unrestricted), threaded through to resolveForceModelWithEffort so the pin
+// can't land on an excluded/unregistered binding (#874).
 //
 // A `:level` suffix is stashed on context as router.Overrides.ForceEffort
 // so pin + effort land in one header.
@@ -249,13 +318,14 @@ func (s *Service) applyForceModelHeader(
 	env *translate.RequestEnvelope,
 	installationID uuid.UUID,
 	sessionKey [sessionpin.SessionKeyLen]byte,
+	enabledProviders map[string]struct{},
 ) string {
 	raw := strings.TrimSpace(r.Header.Get(ForceModelHeader))
 	if raw == "" {
 		return ""
 	}
 	log := observability.FromContext(ctx)
-	canonicalModel, provider, known, effortLevel := resolveForceModelWithEffort(raw)
+	canonicalModel, provider, known, effortLevel := resolveForceModelWithEffort(raw, enabledProviders)
 	if effortLevel != "" {
 		// Merge with any existing knobs so ForceEffort doesn't drop Alpha/QualityBias.
 		merged := router.Overrides{ForceEffort: effortLevel}
@@ -274,6 +344,18 @@ func (s *Service) applyForceModelHeader(
 	if !known {
 		log.Info("x-weave-force-model: ignoring unrecognized model; routing automatically",
 			"input_model", raw,
+			"session_key_hex", fmt.Sprintf("%x", sessionKey),
+		)
+		return ""
+	}
+	if provider == "" {
+		// Recognized model, but none of its bindings are available under this
+		// deployment's enabled-provider set — pinning would silently point at
+		// a dead provider (#874). Loud rather than falling through quietly.
+		log.Warn("x-weave-force-model: no available provider for model; routing automatically",
+			"input_model", raw,
+			"canonical_model", canonicalModel,
+			"enabled_providers", sortedProviderKeys(enabledProviders),
 			"session_key_hex", fmt.Sprintf("%x", sessionKey),
 		)
 		return ""
@@ -301,7 +383,8 @@ func (s *Service) applyForceModelHeader(
 // writes (or expires) the session pin and returns a synthetic acknowledgment
 // response without dispatching upstream. inputTokens should be the request's
 // RoutingFeatures.Tokens so the token counter reflects actual turn input, not
-// just the synthetic response text.
+// just the synthetic response text. enabledProviders is the deployment's
+// live enabled-provider set (nil = unrestricted); see applyForceModelHeader.
 func (s *Service) handleForceModelCommand(
 	ctx context.Context,
 	w http.ResponseWriter,
@@ -310,6 +393,7 @@ func (s *Service) handleForceModelCommand(
 	installationID uuid.UUID,
 	sessionKey [sessionpin.SessionKeyLen]byte,
 	inputTokens int,
+	enabledProviders map[string]struct{},
 ) error {
 	log := observability.FromContext(ctx)
 	role := roleForTier(catalog.TierFor(env.Model()))
@@ -318,7 +402,8 @@ func (s *Service) handleForceModelCommand(
 	// StripRoutingMarkerFromMessages strips it from later inbound requests;
 	// otherwise it'd persist in history and leak router internals upstream.
 	var msg string
-	if cmd.Clear {
+	switch {
+	case cmd.Clear:
 		if s.pinStore != nil && installationID != uuid.Nil {
 			if err := s.expireSessionPin(ctx, installationID, sessionKey, role, "user_unforced"); err != nil {
 				log.Error("/unforce-model: pin store upsert failed", "err", err)
@@ -334,34 +419,53 @@ func (s *Service) handleForceModelCommand(
 			"session_key_hex", fmt.Sprintf("%x", sessionKey),
 			"role", role,
 		)
-	} else if canonicalModel, provider, known := resolveForceModel(cmd.Model); !known {
-		// Not in the catalog (e.g. truncated "/force-model gpt-") — reject
-		// rather than pin something we can't honor; prior pin left untouched.
-		log.Info("/force-model: rejected unknown model",
-			"input_model", cmd.Model,
-			"session_key_hex", fmt.Sprintf("%x", sessionKey),
-			"role", role,
-		)
-		msg = fmt.Sprintf("✦ **Weave Router** → force-model: %q isn't a recognized model · keeping automatic routing. Use a full model ID, e.g. claude-opus-5, gpt-5.5, or gemini-3-pro-preview.\n\n", cmd.Model)
-		if env.SourceFormat() == translate.FormatOpenAI {
-			msg = fmt.Sprintf("Weave Router: force-model: %q isn't a recognized model; keeping automatic routing. Use a full model ID, e.g. claude-opus-5, gpt-5.5, or gemini-3-pro-preview.", cmd.Model)
+	default:
+		canonicalModel, provider, known := resolveForceModel(cmd.Model, enabledProviders)
+		switch {
+		case !known:
+			// Not in the catalog (e.g. truncated "/force-model gpt-") — reject
+			// rather than pin something we can't honor; prior pin left untouched.
+			log.Info("/force-model: rejected unknown model",
+				"input_model", cmd.Model,
+				"session_key_hex", fmt.Sprintf("%x", sessionKey),
+				"role", role,
+			)
+			msg = fmt.Sprintf("✦ **Weave Router** → force-model: %q isn't a recognized model · keeping automatic routing. Use a full model ID, e.g. claude-opus-5, gpt-5.5, or gemini-3-pro-preview.\n\n", cmd.Model)
+			if env.SourceFormat() == translate.FormatOpenAI {
+				msg = fmt.Sprintf("Weave Router: force-model: %q isn't a recognized model; keeping automatic routing. Use a full model ID, e.g. claude-opus-5, gpt-5.5, or gemini-3-pro-preview.", cmd.Model)
+			}
+		case provider == "":
+			// Recognized model, but no binding is available under this
+			// deployment's enabled-provider set (e.g. its only binding is
+			// excluded) — reject rather than pin a dead provider (#874).
+			log.Warn("/force-model: rejected model with no available provider",
+				"input_model", cmd.Model,
+				"canonical_model", canonicalModel,
+				"enabled_providers", sortedProviderKeys(enabledProviders),
+				"session_key_hex", fmt.Sprintf("%x", sessionKey),
+				"role", role,
+			)
+			msg = fmt.Sprintf("✦ **Weave Router** → force-model: %s has no available provider on this deployment · keeping automatic routing\n\n", canonicalModel)
+			if env.SourceFormat() == translate.FormatOpenAI {
+				msg = fmt.Sprintf("Weave Router: force-model: %s has no available provider on this deployment; keeping automatic routing.", canonicalModel)
+			}
+		default:
+			if err := s.setForceModelPin(ctx, sessionKey, role, installationID, canonicalModel, provider); err != nil {
+				log.Error("/force-model: pin store upsert failed", "err", err)
+				return err
+			}
+			msg = fmt.Sprintf("✦ **Weave Router** → force-model applied: %s (%s) · Use /unforce-model to clear\n\n", canonicalModel, provider)
+			if env.SourceFormat() == translate.FormatOpenAI {
+				msg = fmt.Sprintf("Weave Router: force-model applied: %s (%s). Use /unforce-model to clear.", canonicalModel, provider)
+			}
+			log.Debug("/force-model: session pin set",
+				"input_model", cmd.Model,
+				"canonical_model", canonicalModel,
+				"provider", provider,
+				"session_key_hex", fmt.Sprintf("%x", sessionKey),
+				"role", role,
+			)
 		}
-	} else {
-		if err := s.setForceModelPin(ctx, sessionKey, role, installationID, canonicalModel, provider); err != nil {
-			log.Error("/force-model: pin store upsert failed", "err", err)
-			return err
-		}
-		msg = fmt.Sprintf("✦ **Weave Router** → force-model applied: %s (%s) · Use /unforce-model to clear\n\n", canonicalModel, provider)
-		if env.SourceFormat() == translate.FormatOpenAI {
-			msg = fmt.Sprintf("Weave Router: force-model applied: %s (%s). Use /unforce-model to clear.", canonicalModel, provider)
-		}
-		log.Debug("/force-model: session pin set",
-			"input_model", cmd.Model,
-			"canonical_model", canonicalModel,
-			"provider", provider,
-			"session_key_hex", fmt.Sprintf("%x", sessionKey),
-			"role", role,
-		)
 	}
 
 	switch env.SourceFormat() {

--- a/internal/proxy/force_model_internal_test.go
+++ b/internal/proxy/force_model_internal_test.go
@@ -12,6 +12,7 @@ func TestResolveForceModel(t *testing.T) {
 	tests := []struct {
 		name         string
 		input        string
+		available    map[string]struct{}
 		wantID       string
 		wantProvider string
 		wantKnown    bool
@@ -171,11 +172,42 @@ func TestResolveForceModel(t *testing.T) {
 			wantProvider: providers.ProviderOpenAI,
 			wantKnown:    false,
 		},
+		// Availability-aware resolution (#874): a multi-binding model whose
+		// primary binding is excluded/unregistered must not silently resolve
+		// to it — the same binding walk the scorer's resolveProviderFor does.
+		{
+			name:         "deepseek-flash falls over to available fallback binding when primary excluded",
+			input:        "deepseek-flash",
+			available:    map[string]struct{}{providers.ProviderOpenRouter: {}},
+			wantID:       "deepseek/deepseek-v4-flash",
+			wantProvider: providers.ProviderOpenRouter,
+			wantKnown:    true,
+		},
+		{
+			name:         "deepseek-flash resolves to primary binding when it is available",
+			input:        "deepseek-flash",
+			available:    map[string]struct{}{providers.ProviderMakora: {}, providers.ProviderOpenRouter: {}},
+			wantID:       "deepseek/deepseek-v4-flash",
+			wantProvider: providers.ProviderMakora,
+			wantKnown:    true,
+		},
+		{
+			name:      "known model with no available provider resolves with empty provider",
+			input:     "deepseek-flash",
+			available: map[string]struct{}{providers.ProviderFireworks: {}},
+			wantID:    "deepseek/deepseek-v4-flash",
+			// Empty provider signals "recognized model, but no binding is
+			// available" — distinct from wantKnown=false (not a catalog model
+			// at all), so callers can reject with an accurate message instead
+			// of silently pinning an unservable provider.
+			wantProvider: "",
+			wantKnown:    true,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotID, gotProvider, gotKnown := resolveForceModel(tt.input)
+			gotID, gotProvider, gotKnown := resolveForceModel(tt.input, tt.available)
 			assert.Equal(t, tt.wantID, gotID, "canonical id")
 			assert.Equal(t, tt.wantProvider, gotProvider, "provider")
 			assert.Equal(t, tt.wantKnown, gotKnown, "known")

--- a/internal/proxy/force_model_provider_unavailable_internal_test.go
+++ b/internal/proxy/force_model_provider_unavailable_internal_test.go
@@ -1,0 +1,53 @@
+package proxy
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"workweave/router/internal/providers"
+	"workweave/router/internal/router"
+	"workweave/router/internal/router/sessionpin"
+	"workweave/router/internal/translate"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Regression for #874: a stored forced pin whose provider is no longer in
+// req.EnabledProviders (excluded mid-session, BYOK creds removed, etc.) must
+// fall through to automatic routing rather than silently serving as if no
+// pin existed — the scorer must still see it as ineligible and route around it.
+func TestRunTurnLoop_ForcedPin_FallsThroughWhenProviderUnavailable(t *testing.T) {
+	fr := &tierProbeRouter{available: map[string]struct{}{
+		"deepseek/deepseek-v4-flash": {},
+		"claude-sonnet-4-6":          {},
+	}}
+	store := &forcedPinStore{pin: sessionpin.Pin{
+		Provider:    providers.ProviderMakora,
+		Model:       "deepseek/deepseek-v4-flash",
+		Reason:      translate.ReasonUserForceModel,
+		PinnedUntil: time.Now().Add(time.Hour),
+	}}
+	svc := NewService(fr, nil, nil, false, nil, store, false,
+		providers.ProviderAnthropic, "claude-haiku-4-5", nil).
+		WithAvailableModels(fr.available).
+		WithPlannerEnabled(false)
+
+	env, err := translate.ParseAnthropic([]byte(`{"model":"claude-sonnet-4-6","messages":[{"role":"user","content":"hi"}]}`))
+	require.NoError(t, err)
+	feats := env.RoutingFeatures(false)
+
+	res, err := svc.runTurnLoop(context.Background(), env, feats, "key-1", uuid.New(), "", nil, router.Request{
+		RequestedModel: feats.Model,
+		// Makora excluded from this turn's enabled set — mirrors
+		// ROUTER_EXCLUDED_PROVIDERS=makora from the issue's repro.
+		EnabledProviders: map[string]struct{}{providers.ProviderOpenRouter: {}, providers.ProviderAnthropic: {}},
+	})
+	require.NoError(t, err)
+
+	assert.False(t, res.StickyHit, "a pin on an unavailable provider must not be served as a sticky hit")
+	assert.NotEqual(t, providers.ProviderMakora, res.Decision.Provider,
+		"routing must not serve the excluded provider")
+}

--- a/internal/proxy/force_model_tier_fallback_internal_test.go
+++ b/internal/proxy/force_model_tier_fallback_internal_test.go
@@ -286,7 +286,7 @@ func TestForceModelHeader_OverridesHardPin(t *testing.T) {
 	headerReq, err := http.NewRequest(http.MethodPost, "/v1/messages", nil)
 	require.NoError(t, err)
 	headerReq.Header.Set(ForceModelHeader, "opus")
-	svc.applyForceModelHeader(context.Background(), headerReq, env, uuid.New(), key)
+	svc.applyForceModelHeader(context.Background(), headerReq, env, uuid.New(), key, nil)
 
 	feats := env.RoutingFeatures(false)
 	res, err := svc.runTurnLoop(context.Background(), env, feats, "key-1", uuid.New(), "", headerReq.Header, router.Request{

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -2148,10 +2148,19 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 	// env.body so the upstream never sees it). Session key is derived before
 	// extraction: DeriveSessionKey can fall back to prompt text, and deriving
 	// after the strip would mismatch subsequent turns with the unstripped message.
+	//
+	// enabledProviders computed here (ahead of its usual spot below routing
+	// diagnostics) so a forced pin's provider is validated against the same
+	// live availability set the scorer uses (#874) — a pin can't land on an
+	// excluded/unregistered binding.
+	enabledProviders := s.enabledProvidersForRequest(ctx, providers.ProviderAnthropic, r.Header)
+	if billing.SubscriptionOnlyFromContext(ctx) {
+		enabledProviders = restrictToSubscriptionProviders(ctx, r.Header, enabledProviders)
+	}
 	if !agentShadowMode && s.pinStore != nil {
 		if cmd, hasCmd := env.ExtractForceModelCommand(); hasCmd {
 			log.Info("ProxyMessages force-model command", "force_model_cmd", cmd)
-			return s.handleForceModelCommand(ctx, w, env, cmd, installationID, sessionKey, feats.Tokens)
+			return s.handleForceModelCommand(ctx, w, env, cmd, installationID, sessionKey, feats.Tokens, enabledProviders)
 		}
 	}
 	if !agentShadowMode {
@@ -2166,7 +2175,7 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 	// the pin up and serves the requested model on this same turn.
 	forceModel := ""
 	if !agentShadowMode {
-		forceModel = s.applyForceModelHeader(ctx, r, env, installationID, sessionKey)
+		forceModel = s.applyForceModelHeader(ctx, r, env, installationID, sessionKey, enabledProviders)
 	}
 
 	// Tool-call loop break: catches runaway OSS-model tool-call cycles (qwen3
@@ -2195,18 +2204,6 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 	// Lets us audit whether a misbehaving turn was provoked by a malformed prior
 	// tool_result or an out-of-shape tool spec, without dumping the whole body.
 	logInboundRequestDiagnostics(log, env)
-
-	// Anthropic packs sub-agent identity into metadata.user_id; the
-	// x-weave-subagent-type header is for non-Anthropic ingress only.
-	enabledProviders := s.enabledProvidersForRequest(ctx, providers.ProviderAnthropic, r.Header)
-
-	// Subscription-only mode: restrict
-	// routing to the providers the caller's own subscription can serve, so the
-	// scorer can't pick a paid model. The post-routing guard below refuses if a
-	// turn (e.g. a hard-pin or force-model) still didn't resolve onto the sub.
-	if billing.SubscriptionOnlyFromContext(ctx) {
-		enabledProviders = restrictToSubscriptionProviders(ctx, r.Header, enabledProviders)
-	}
 
 	// Pre-filter models whose context window cannot fit this request.
 	// FullTokenEstimate uses raw body bytes (÷5) to capture tool definitions,
@@ -4300,10 +4297,18 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 	// env.body so the upstream never sees it). Session key is derived before
 	// extraction: DeriveSessionKey can fall back to prompt text, and deriving
 	// after the strip would mismatch subsequent turns with the unstripped message.
+	//
+	// enabledProviders computed here (ahead of its usual spot below routing
+	// diagnostics) so a forced pin's provider is validated against the same
+	// live availability set the scorer uses (#874).
+	enabledProviders := s.enabledProvidersForRequest(ctx, providers.ProviderOpenAI, r.Header)
+	if billing.SubscriptionOnlyFromContext(ctx) {
+		enabledProviders = restrictToSubscriptionProviders(ctx, r.Header, enabledProviders)
+	}
 	if s.pinStore != nil {
 		if cmd, hasCmd := env.ExtractForceModelCommand(); hasCmd {
 			log.Info("ProxyOpenAIChatCompletion force-model command", "force_model_cmd", cmd)
-			return s.handleForceModelCommand(ctx, w, env, cmd, installationID, sessionKey, feats.Tokens)
+			return s.handleForceModelCommand(ctx, w, env, cmd, installationID, sessionKey, feats.Tokens, enabledProviders)
 		}
 	}
 	if cmd, hasCmd := env.ExtractRouterFeedbackCommand(); hasCmd {
@@ -4314,7 +4319,7 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 	// Honor the x-weave-force-model header (headless equivalent of /force-model).
 	// Writes the user-forced pin and falls through to normal routing, which picks
 	// the pin up and serves the requested model on this same turn.
-	forceModel := s.applyForceModelHeader(ctx, r, env, installationID, sessionKey)
+	forceModel := s.applyForceModelHeader(ctx, r, env, installationID, sessionKey, enabledProviders)
 
 	// Wide cyclic re-read loop → escalate to opus (same path as the Anthropic
 	// ingress). See detectCyclicToolCallLoop / handleLoopEscalation.
@@ -4338,17 +4343,6 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 
 	// OpenAI signals sub-agent identity via x-weave-subagent-type (no metadata.user_id).
 	subAgentHint := r.Header.Get("x-weave-subagent-type")
-
-	enabledProviders := s.enabledProvidersForRequest(ctx, providers.ProviderOpenAI, r.Header)
-
-	// Subscription-only mode: restrict
-	// routing to the providers the caller's own subscription can serve, so the
-	// scorer can't pick a paid model. Mirrors the Anthropic path's forced
-	// usage-bypass; the post-routing guard below refuses if it still can't serve
-	// on the subscription.
-	if billing.SubscriptionOnlyFromContext(ctx) {
-		enabledProviders = restrictToSubscriptionProviders(ctx, r.Header, enabledProviders)
-	}
 
 	// Codex (ChatGPT) subscription passthrough: ProxyOpenAIResponses stashed the
 	// caller's original Responses body. Such turns skip the routing marker +

--- a/internal/proxy/turnloop.go
+++ b/internal/proxy/turnloop.go
@@ -552,6 +552,18 @@ func (s *Service) runTurnLoop(
 			// to it below rather than losing the intent entirely.
 			forcedTierFloor = catalog.TierFor(pin.Model)
 		}
+		if !providerEligible {
+			// The pinned provider became unavailable mid-session (exclusion
+			// changed, BYOK creds removed) — loud rather than silently falling
+			// through to automatic routing indistinguishable from "no pin"
+			// (#874). The pin row is left in storage; a later request with the
+			// provider re-enabled resumes serving it.
+			log.Warn("turnloop: forced pin's provider unavailable; falling through to automatic routing",
+				"pin_model", pin.Model,
+				"pin_provider", pin.Provider,
+				"pin_reason", pin.Reason,
+			)
+		}
 		if !imageCapable {
 			// The scorer's own image filter fails open when no image-capable
 			// candidate survives, so make the drop explicit here instead of


### PR DESCRIPTION
## Summary

Fixes #874: `/force-model` and `x-weave-force-model` resolved a model's provider via `catalog.Model.Providers[0]` unconditionally, ignoring the deployment's actual enabled/excluded provider set. If the primary binding was excluded (e.g. `makora` via `ROUTER_EXCLUDED_PROVIDERS`), the pin silently pointed at a dead provider — the next turn's pin lookup treated it as equivalent to no pin (`reason:"no_pin"`) and the cluster scorer silently overwrote it, with no error, no warning, and a force-model ack that falsely reported success.

## Changes

- `resolveForceModelWithEffort` / `resolveForceModel` now take the deployment's live enabled-provider set and walk a model's bindings in catalog order for the first available one — the same pattern `cluster.Scorer`'s `resolveProviderFor` already uses for automatic routing — instead of hard-picking `Providers[0]`. A known model with no available binding now returns `provider=""` so callers can reject cleanly rather than pin a dead one.
- `applyForceModelHeader` / `handleForceModelCommand` thread the enabled-provider set through (computed earlier in the request path so it's available before force-model handling runs) and reject with a clear ack message + Warn log when no binding is available.
- `turnloop`'s forced-pin fall-through now logs a `Warn` when a stored pin's provider became unavailable mid-session, so that drop is distinguishable in logs from ordinary no-pin automatic routing.

## Testing

- `TestResolveForceModel` extended with availability-aware cases (primary binding excluded → falls to fallback binding; no binding available → empty provider).
- New `TestRunTurnLoop_ForcedPin_FallsThroughWhenProviderUnavailable` reproduces the issue's repro shape and asserts the pin is dropped rather than served, with the new Warn log confirmed in output.
- `go build ./...`, `go vet ./...`, `go test ./...` all pass.

## Explicitly not done

Did not set `ROUTER_HARD_PIN_MODEL`/`ROUTER_HARD_PIN_PROVIDER` as "the fix" — that's a global override disabling the cluster scorer entirely for main-loop turns, discussed and rejected in the issue as a real solution.

🤖 Generated with Claude