### PR TITLE
feat(providers): remap outbound model IDs for deployment-key endpoints

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -58,6 +58,14 @@ POSTGRES_SSLMODE=require       # set to `disable` for local Docker
 # GOOGLE_API_KEY=...
 # GOOGLE_BASE_URL=https://generativelanguage.googleapis.com/v1beta/openai
 
+# Remap outbound model IDs per provider, for an OpenAI-compatible endpoint
+# that publishes the catalog's models under its own names. JSON map of
+# catalog model ID -> the name that endpoint expects. <PROVIDER> is one of
+# OPENROUTER, FIREWORKS, MAKORA, MINIMAX, TOGETHER, XAI, META, WAFER, or
+# BEDROCK. Routing, pricing, and analytics stay keyed on the catalog ID.
+# See docs/CONFIGURATION.md -> Deployment-level model aliases.
+# ROUTER_OPENROUTER_MODEL_ALIASES={"deepseek/deepseek-v4-flash":"deepseek-v4-flash"}
+
 # --------------------------------------------------------------------
 # Server.
 # --------------------------------------------------------------------

--- a/cmd/AGENTS.md
+++ b/cmd/AGENTS.md
@@ -15,6 +15,7 @@ Composition root. Only place that constructs concrete adapters + wires them toge
   - `runSessionPinSweep` — TTL sweep loop
   - `resolveHardPinModel` / `resolveCompactionModel` / `resolveDefaultBaselineModel` / `resolveAvailableModels` — boot-time model resolution
   - `registerDeploymentKeyedProvider` — shared "resolve key → build client → log" registration for the providers whose gating collapses to that shape (Fireworks, Makora, Together, Bedrock, Google); OpenRouter and Anthropic/OpenAI stay bespoke
+  - `resolveModelAliases` ([`model_aliases.go`](router/model_aliases.go)) — each OpenAI-compatible provider's outbound model ID map: catalog `UpstreamID` bindings with `ROUTER_<PROVIDER>_MODEL_ALIASES` overrides layered on top
   - small env parsers (e.g. `envVarHint`, `parseEnvInt`, `parseEnvFloat`, `parseEnvDurationMs`)
 - **No more heuristic-fallback router.** If cluster routing fails to boot, `main.go` panics. Misconfiguration must abort the process rather than silently degrade.
 - Validate deployment target overrides through `policy.Registry.ValidateDeployment` after provider/model configuration is resolved. A partial or catalog-incompatible explicit target is a startup error, not permission to substitute a default.

--- a/cmd/CLAUDE.md
+++ b/cmd/CLAUDE.md
@@ -15,6 +15,7 @@ Composition root. Only place that constructs concrete adapters + wires them toge
   - `runSessionPinSweep` — TTL sweep loop
   - `resolveHardPinModel` / `resolveCompactionModel` / `resolveDefaultBaselineModel` / `resolveAvailableModels` — boot-time model resolution
   - `registerDeploymentKeyedProvider` — shared "resolve key → build client → log" registration for the providers whose gating collapses to that shape (Fireworks, Makora, Together, Bedrock, Google); OpenRouter and Anthropic/OpenAI stay bespoke
+  - `resolveModelAliases` ([`model_aliases.go`](router/model_aliases.go)) — each OpenAI-compatible provider's outbound model ID map: catalog `UpstreamID` bindings with `ROUTER_<PROVIDER>_MODEL_ALIASES` overrides layered on top
   - small env parsers (e.g. `envVarHint`, `parseEnvInt`, `parseEnvFloat`, `parseEnvDurationMs`)
 - **No more heuristic-fallback router.** If cluster routing fails to boot, `main.go` panics. Misconfiguration must abort the process rather than silently degrade.
 - Validate deployment target overrides through `policy.Registry.ValidateDeployment` after provider/model configuration is resolved. A partial or catalog-incompatible explicit target is a startup error, not permission to substitute a default.

--- a/cmd/router/main.go
+++ b/cmd/router/main.go
@@ -199,6 +199,11 @@ func main() {
 	// platform-key mode gated by balance checks. Self-hosted is never BYOK-only.
 	byokOnly := deploymentMode == server.DeploymentModeManaged && billingSvc == nil
 
+	modelAliases, err := resolveModelAliases(logger)
+	if err != nil {
+		panic(err)
+	}
+
 	// Always registered. With ANTHROPIC_API_KEY (selfhosted only) the router
 	// uses its own key; otherwise client auth headers pass through directly.
 	anthropicKey := ""
@@ -264,7 +269,7 @@ func main() {
 		if !byokOnly && openRouterPlatformEnabled {
 			openRouterKey = config.GetOr("OPENROUTER_API_KEY", "")
 		}
-		providerMap[providers.ProviderOpenRouter] = openaiCompatProvider.NewClient(openRouterKey, openRouterBaseURL)
+		providerMap[providers.ProviderOpenRouter] = openaiCompatProvider.NewClientWithModelIDMap(openRouterKey, openRouterBaseURL, modelAliases[providers.ProviderOpenRouter])
 		switch {
 		case byokOnly:
 			logger.Info("OpenRouter provider enabled (BYOK only)", "base_url", openRouterBaseURL)
@@ -283,7 +288,7 @@ func main() {
 		registerDeploymentKeyedProvider(providerMap, envKeyedProviders, logger,
 			providers.ProviderFireworks, "Fireworks", "FIREWORKS_API_KEY", fireworksBaseURL, byokOnly,
 			func(key, baseURL string) providers.Client {
-				return openaiCompatProvider.NewClientWithModelIDMap(key, baseURL, upstreamIDsForProvider(providers.ProviderFireworks))
+				return openaiCompatProvider.NewClientWithModelIDMap(key, baseURL, modelAliases[providers.ProviderFireworks])
 			})
 	}
 
@@ -294,7 +299,7 @@ func main() {
 		registerDeploymentKeyedProvider(providerMap, envKeyedProviders, logger,
 			providers.ProviderMakora, "Makora", "MAKORA_API_KEY", makoraBaseURL, byokOnly,
 			func(key, baseURL string) providers.Client {
-				return openaiCompatProvider.NewClientWithModelIDMap(key, baseURL, upstreamIDsForProvider(providers.ProviderMakora))
+				return openaiCompatProvider.NewClientWithModelIDMap(key, baseURL, modelAliases[providers.ProviderMakora])
 			})
 	}
 
@@ -307,7 +312,7 @@ func main() {
 		registerDeploymentKeyedProvider(providerMap, envKeyedProviders, logger,
 			providers.ProviderTogether, "Together", "TOGETHER_API_KEY", togetherBaseURL, byokOnly,
 			func(key, baseURL string) providers.Client {
-				return openaiCompatProvider.NewClientWithModelIDMap(key, baseURL, upstreamIDsForProvider(providers.ProviderTogether))
+				return openaiCompatProvider.NewClientWithModelIDMap(key, baseURL, modelAliases[providers.ProviderTogether])
 			})
 	}
 
@@ -317,7 +322,7 @@ func main() {
 		registerDeploymentKeyedProvider(providerMap, envKeyedProviders, logger,
 			providers.ProviderMiniMax, "MiniMax", "MINIMAX_API_KEY", minimaxBaseURL, byokOnly,
 			func(key, baseURL string) providers.Client {
-				return openaiCompatProvider.NewClientWithModelIDMap(key, baseURL, upstreamIDsForProvider(providers.ProviderMiniMax))
+				return openaiCompatProvider.NewClientWithModelIDMap(key, baseURL, modelAliases[providers.ProviderMiniMax])
 			})
 	}
 
@@ -326,7 +331,7 @@ func main() {
 		registerDeploymentKeyedProvider(providerMap, envKeyedProviders, logger,
 			providers.ProviderXAI, "XAI", "XAI_API_KEY", xaiBaseURL, byokOnly,
 			func(key, baseURL string) providers.Client {
-				return openaiCompatProvider.NewClient(key, baseURL)
+				return openaiCompatProvider.NewClientWithModelIDMap(key, baseURL, modelAliases[providers.ProviderXAI])
 			})
 	}
 
@@ -335,7 +340,7 @@ func main() {
 		registerDeploymentKeyedProvider(providerMap, envKeyedProviders, logger,
 			providers.ProviderMeta, "Meta", "META_API_KEY", metaBaseURL, byokOnly,
 			func(key, baseURL string) providers.Client {
-				return openaiCompatProvider.NewClient(key, baseURL)
+				return openaiCompatProvider.NewClientWithModelIDMap(key, baseURL, modelAliases[providers.ProviderMeta])
 			})
 	}
 
@@ -346,7 +351,7 @@ func main() {
 		registerDeploymentKeyedProvider(providerMap, envKeyedProviders, logger,
 			providers.ProviderWafer, "Wafer", "WAFER_API_KEY", waferBaseURL, byokOnly,
 			func(key, baseURL string) providers.Client {
-				return openaiCompatProvider.NewClientWithModelIDMap(key, baseURL, upstreamIDsForProvider(providers.ProviderWafer)).
+				return openaiCompatProvider.NewClientWithModelIDMap(key, baseURL, modelAliases[providers.ProviderWafer]).
 					WithProtectedHeaders(http.Header{"Wafer-ZDR": []string{"required"}})
 			})
 	}
@@ -382,7 +387,7 @@ func main() {
 		registerDeploymentKeyedProvider(providerMap, envKeyedProviders, logger,
 			providers.ProviderBedrock, "Bedrock", "AWS_BEARER_TOKEN_BEDROCK", bedrockBaseURL, byokOnly,
 			func(key, baseURL string) providers.Client {
-				return openaiCompatProvider.NewClientWithModelIDMap(key, baseURL, upstreamIDsForProvider(providers.ProviderBedrock))
+				return openaiCompatProvider.NewClientWithModelIDMap(key, baseURL, modelAliases[providers.ProviderBedrock])
 			},
 			"region", bedrockRegion)
 	}
@@ -2058,9 +2063,6 @@ func envVarHint(provider string) string {
 	return "<unknown provider " + provider + ">"
 }
 
-// upstreamIDsForProvider maps public model ID -> upstream model ID for a
-// provider's bindings with a non-empty UpstreamID; nil if no rewriting is
-// needed (e.g. OpenRouter, where the slug IS the upstream ID).
 // registerDeploymentKeyedProvider resolves a provider's deployment-level API
 // key (respecting byokOnly), constructs its client via newClient, registers
 // it in providerMap, and logs its BYOK/keyed/passthrough state. Shared by the
@@ -2092,21 +2094,6 @@ func registerDeploymentKeyedProvider(
 	default:
 		logger.Info(displayName+" provider registered (BYOK only — set "+keyEnvVar+" for deployment-level use)", "base_url", baseURL)
 	}
-}
-
-func upstreamIDsForProvider(provider string) map[string]string {
-	out := make(map[string]string)
-	for _, m := range catalog.Models {
-		for _, b := range m.Providers {
-			if b.Provider == provider && b.UpstreamID != "" {
-				out[m.ID] = b.UpstreamID
-			}
-		}
-	}
-	if len(out) == 0 {
-		return nil
-	}
-	return out
 }
 
 func runEscalationSweep(ctx context.Context, store escalation.Store) {

--- a/cmd/router/model_aliases.go
+++ b/cmd/router/model_aliases.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"strings"
+
+	"weave-os/router/internal/config"
+	"weave-os/router/internal/providers"
+	"weave-os/router/internal/router/catalog"
+)
+
+// aliasableProviders are the OpenAI-compatible upstreams whose outbound model
+// ID can be rewritten before dispatch.
+var aliasableProviders = []string{
+	providers.ProviderOpenRouter,
+	providers.ProviderFireworks,
+	providers.ProviderMakora,
+	providers.ProviderMiniMax,
+	providers.ProviderTogether,
+	providers.ProviderXAI,
+	providers.ProviderMeta,
+	providers.ProviderWafer,
+	providers.ProviderBedrock,
+}
+
+// modelAliasEnvVar names the operator override for a provider's outbound model IDs.
+func modelAliasEnvVar(provider string) string {
+	return "ROUTER_" + strings.ToUpper(provider) + "_MODEL_ALIASES"
+}
+
+// resolveModelAliases returns each aliasable provider's public model ID ->
+// upstream model ID map: the catalog's UpstreamID bindings with that provider's
+// ROUTER_<PROVIDER>_MODEL_ALIASES entries layered on top.
+func resolveModelAliases(logger *slog.Logger) (map[string]map[string]string, error) {
+	out := make(map[string]map[string]string, len(aliasableProviders))
+	for _, provider := range aliasableProviders {
+		envVar := modelAliasEnvVar(provider)
+		overrides, err := parseModelAliases(config.GetOr(envVar, ""))
+		if err != nil {
+			return nil, fmt.Errorf("%s: %w", envVar, err)
+		}
+		merged := upstreamIDsForProvider(provider)
+		for id, upstreamID := range overrides {
+			if _, known := catalog.ByID(id); !known {
+				// Retiring a catalog model must not turn a stale alias into a boot failure.
+				logger.Warn("Ignoring model alias for unknown catalog model", "env_var", envVar, "model", id)
+				continue
+			}
+			if merged == nil {
+				merged = make(map[string]string, len(overrides))
+			}
+			merged[id] = upstreamID
+		}
+		if len(merged) > 0 {
+			out[provider] = merged
+		}
+	}
+	return out, nil
+}
+
+// parseModelAliases decodes a JSON object of public model ID -> upstream model
+// ID. An empty value yields no entries.
+func parseModelAliases(raw string) (map[string]string, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return nil, nil
+	}
+	var aliases map[string]string
+	if err := json.Unmarshal([]byte(raw), &aliases); err != nil {
+		return nil, fmt.Errorf("expected a JSON object mapping model ID to upstream model ID: %w", err)
+	}
+	for id, upstreamID := range aliases {
+		if strings.TrimSpace(id) == "" {
+			return nil, errors.New("empty model ID")
+		}
+		if strings.TrimSpace(upstreamID) == "" {
+			return nil, fmt.Errorf("model %q maps to an empty upstream model ID", id)
+		}
+	}
+	return aliases, nil
+}
+
+// upstreamIDsForProvider maps public model ID -> upstream model ID for a
+// provider's bindings with a non-empty UpstreamID; nil if no rewriting is
+// needed (e.g. OpenRouter, where the slug IS the upstream ID).
+func upstreamIDsForProvider(provider string) map[string]string {
+	out := make(map[string]string)
+	for _, m := range catalog.Models {
+		for _, b := range m.Providers {
+			if b.Provider == provider && b.UpstreamID != "" {
+				out[m.ID] = b.UpstreamID
+			}
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}

--- a/cmd/router/model_aliases_test.go
+++ b/cmd/router/model_aliases_test.go
@@ -1,0 +1,116 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"weave-os/router/internal/providers"
+	"weave-os/router/internal/router/catalog"
+)
+
+// bindingWithUpstreamID returns the first catalog model bound to provider with a
+// non-empty UpstreamID, so tests survive catalog churn instead of pinning an ID.
+func bindingWithUpstreamID(t *testing.T, provider string) (modelID, upstreamID string) {
+	t.Helper()
+	for _, m := range catalog.Models {
+		for _, b := range m.Providers {
+			if b.Provider == provider && b.UpstreamID != "" {
+				return m.ID, b.UpstreamID
+			}
+		}
+	}
+	t.Skipf("catalog has no %s binding with an UpstreamID", provider)
+	return "", ""
+}
+
+func TestModelAliasEnvVar(t *testing.T) {
+	assert.Equal(t, "ROUTER_OPENROUTER_MODEL_ALIASES", modelAliasEnvVar(providers.ProviderOpenRouter))
+	assert.Equal(t, "ROUTER_BEDROCK_MODEL_ALIASES", modelAliasEnvVar(providers.ProviderBedrock))
+}
+
+func TestParseModelAliases(t *testing.T) {
+	t.Run("empty value yields no entries", func(t *testing.T) {
+		aliases, err := parseModelAliases("   ")
+		require.NoError(t, err)
+		assert.Empty(t, aliases)
+	})
+
+	t.Run("decodes a JSON object", func(t *testing.T) {
+		aliases, err := parseModelAliases(`{"deepseek/deepseek-v4-flash":"deepseek-v4-flash","z-ai/glm-5.2":"glm-5.2"}`)
+		require.NoError(t, err)
+		assert.Equal(t, map[string]string{
+			"deepseek/deepseek-v4-flash": "deepseek-v4-flash",
+			"z-ai/glm-5.2":               "glm-5.2",
+		}, aliases)
+	})
+
+	t.Run("rejects malformed JSON", func(t *testing.T) {
+		_, err := parseModelAliases(`{"deepseek/deepseek-v4-flash":`)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "JSON object")
+	})
+
+	t.Run("rejects a JSON array", func(t *testing.T) {
+		_, err := parseModelAliases(`["deepseek-v4-flash"]`)
+		require.Error(t, err)
+	})
+
+	t.Run("rejects an empty upstream model ID", func(t *testing.T) {
+		_, err := parseModelAliases(`{"deepseek/deepseek-v4-flash":"  "}`)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "deepseek/deepseek-v4-flash")
+	})
+
+	t.Run("rejects an empty model ID", func(t *testing.T) {
+		_, err := parseModelAliases(`{"":"deepseek-v4-flash"}`)
+		require.Error(t, err)
+	})
+}
+
+func TestResolveModelAliasesAppliesEnvOverride(t *testing.T) {
+	require.NotEmpty(t, catalog.Models)
+	modelID := catalog.Models[0].ID
+	t.Setenv(modelAliasEnvVar(providers.ProviderOpenRouter), `{"`+modelID+`":"gateway-name"}`)
+
+	aliases, err := resolveModelAliases(discardLogger())
+	require.NoError(t, err)
+	assert.Equal(t, "gateway-name", aliases[providers.ProviderOpenRouter][modelID])
+}
+
+func TestResolveModelAliasesOverridesCatalogUpstreamID(t *testing.T) {
+	modelID, catalogUpstreamID := bindingWithUpstreamID(t, providers.ProviderTogether)
+	t.Setenv(modelAliasEnvVar(providers.ProviderTogether), `{"`+modelID+`":"operator-name"}`)
+
+	aliases, err := resolveModelAliases(discardLogger())
+	require.NoError(t, err)
+	assert.Equal(t, "operator-name", aliases[providers.ProviderTogether][modelID])
+	assert.NotEqual(t, catalogUpstreamID, aliases[providers.ProviderTogether][modelID])
+}
+
+func TestResolveModelAliasesKeepsUnaliasedCatalogBindings(t *testing.T) {
+	modelID, catalogUpstreamID := bindingWithUpstreamID(t, providers.ProviderTogether)
+	require.NotEmpty(t, catalog.Models)
+	t.Setenv(modelAliasEnvVar(providers.ProviderTogether), `{"`+catalog.Models[0].ID+`":"operator-name"}`)
+
+	aliases, err := resolveModelAliases(discardLogger())
+	require.NoError(t, err)
+	assert.Equal(t, catalogUpstreamID, aliases[providers.ProviderTogether][modelID])
+}
+
+func TestResolveModelAliasesSkipsUnknownModel(t *testing.T) {
+	t.Setenv(modelAliasEnvVar(providers.ProviderOpenRouter), `{"vendor/not-in-catalog":"whatever"}`)
+
+	aliases, err := resolveModelAliases(discardLogger())
+	require.NoError(t, err)
+	assert.NotContains(t, aliases[providers.ProviderOpenRouter], "vendor/not-in-catalog")
+}
+
+func TestResolveModelAliasesRejectsMalformedValue(t *testing.T) {
+	t.Setenv(modelAliasEnvVar(providers.ProviderFireworks), "not-json")
+
+	_, err := resolveModelAliases(discardLogger())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "ROUTER_FIREWORKS_MODEL_ALIASES")
+}

--- a/cmd/router/model_aliases_wire_test.go
+++ b/cmd/router/model_aliases_wire_test.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"weave-os/router/internal/providers"
+	openaiCompatProvider "weave-os/router/internal/providers/openaicompat"
+	"weave-os/router/internal/router"
+)
+
+// stubUpstream stands in for an OpenAI-compatible endpoint that publishes the
+// catalog's models under its own names, and records the model it was sent.
+func stubUpstream(t *testing.T, gotModel *string) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		var payload struct {
+			Model string `json:"model"`
+		}
+		require.NoError(t, json.Unmarshal(body, &payload))
+		*gotModel = payload.Model
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"1","object":"chat.completion","choices":[]}`))
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func dispatchToStub(t *testing.T, client providers.Client, modelID string) {
+	t.Helper()
+	prep := providers.PreparedRequest{
+		Body:    []byte(`{"model":"` + modelID + `","messages":[{"role":"user","content":"hi"}]}`),
+		Headers: http.Header{},
+	}
+	decision := router.Decision{Provider: providers.ProviderOpenRouter, Model: modelID}
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", http.NoBody)
+	require.NoError(t, client.Proxy(context.Background(), decision, prep, httptest.NewRecorder(), req))
+}
+
+// Reproduces #541: the router put its catalog slash-form ID on the wire and a
+// gateway publishing bare names rejected it.
+func TestModelAliasRewritesModelOnTheWire(t *testing.T) {
+	const (
+		catalogID  = "deepseek/deepseek-v4-flash"
+		gatewayID  = "deepseek-v4-flash"
+		otherModel = "xiaomi/mimo-v2.5-pro"
+	)
+
+	t.Run("without an alias the catalog ID reaches the endpoint", func(t *testing.T) {
+		var got string
+		srv := stubUpstream(t, &got)
+
+		aliases, err := resolveModelAliases(discardLogger())
+		require.NoError(t, err)
+		client := openaiCompatProvider.NewClientWithModelIDMap("k", srv.URL, aliases[providers.ProviderOpenRouter])
+
+		dispatchToStub(t, client, catalogID)
+		assert.Equal(t, catalogID, got)
+	})
+
+	t.Run("the alias puts the endpoint's own name on the wire", func(t *testing.T) {
+		var got string
+		srv := stubUpstream(t, &got)
+		t.Setenv(modelAliasEnvVar(providers.ProviderOpenRouter), `{"`+catalogID+`":"`+gatewayID+`"}`)
+
+		aliases, err := resolveModelAliases(discardLogger())
+		require.NoError(t, err)
+		client := openaiCompatProvider.NewClientWithModelIDMap("k", srv.URL, aliases[providers.ProviderOpenRouter])
+
+		dispatchToStub(t, client, catalogID)
+		assert.Equal(t, gatewayID, got)
+	})
+
+	t.Run("an unaliased model is still sent unchanged", func(t *testing.T) {
+		var got string
+		srv := stubUpstream(t, &got)
+		t.Setenv(modelAliasEnvVar(providers.ProviderOpenRouter), `{"`+catalogID+`":"`+gatewayID+`"}`)
+
+		aliases, err := resolveModelAliases(discardLogger())
+		require.NoError(t, err)
+		client := openaiCompatProvider.NewClientWithModelIDMap("k", srv.URL, aliases[providers.ProviderOpenRouter])
+
+		dispatchToStub(t, client, otherModel)
+		assert.Equal(t, otherModel, got)
+	})
+}

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -51,6 +51,7 @@ Claude Code keep using the user's logged-in plan.
 | `OPENAI_GATEWAY_TOKEN`       | *(none)*                                           | Token for that gateway, sent as `Authorization: Bearer`. Only used when `OPENAI_GATEWAY_BASE_URL` is also set. |
 | `WAFER_API_KEY`   | *(none)*                                                  | Enables Wafer Serverless (both its OpenAI-compatible `wafer` and Anthropic-compatible `wafer_anthropic` surfaces; one key covers both). |
 | `WAFER_BASE_URL`  | `https://pass.wafer.ai/v1`                                | Override for the Wafer OpenAI-compatible endpoint (`wafer_anthropic` uses the fixed `/v1/messages` endpoint). |
+| `ROUTER_<PROVIDER>_MODEL_ALIASES` | *(none)*                                      | JSON map of catalog model ID to the name that provider's endpoint publishes. See [Deployment-level model aliases](#deployment-level-model-aliases). |
 
 **Anthropic-compatible gateway.** Some enterprises front Claude with their own
 gateway that speaks the Anthropic Messages spec but authenticates with a bearer
@@ -121,6 +122,29 @@ thinking blocks and `cache_control` natively) and falls back to the other. A
 tenant that can't issue a long-lived PAT configures each key with an RSA
 private key instead — see [Key-pair auth](#key-pair-auth) — or with no secret
 at all, see [Workload identity federation](#workload-identity-federation).
+### Deployment-level model aliases
+
+An OpenAI-compatible endpoint may publish the catalog's models under its own
+names: a gateway that serves `deepseek-v4-flash` where the catalog says
+`deepseek/deepseek-v4-flash`, or a Bedrock-backed proxy that expects AWS
+dot-form IDs. Point a provider at the endpoint with its `*_BASE_URL` and remap
+the outbound names with `ROUTER_<PROVIDER>_MODEL_ALIASES`:
+
+```bash
+OPENROUTER_BASE_URL=https://gateway.example.com/v1
+ROUTER_OPENROUTER_MODEL_ALIASES='{"deepseek/deepseek-v4-flash":"deepseek-v4-flash","xiaomi/mimo-v2.5-pro":"mimo-v2.5-pro"}'
+```
+
+`<PROVIDER>` is the upper-cased provider name — `OPENROUTER`, `FIREWORKS`,
+`MAKORA`, `MINIMAX`, `TOGETHER`, `XAI`, `META`, `WAFER`, or `BEDROCK`. Keys are
+catalog model IDs and values are what goes on the wire. Only the outbound model
+name changes: routing, pricing, and analytics stay keyed on the catalog ID.
+
+Entries layer on top of the catalog's own per-binding upstream IDs, so aliasing
+one model leaves that provider's other bindings alone, and a BYOK key's
+`model_aliases` still wins over both. A malformed value aborts boot. An alias
+naming a model outside the deployed catalog is logged and skipped, so retiring a
+model can't turn a stale alias into a failed start.
 
 **BYOK (per-installation keys).** Instead of (or in addition to) the env vars
 above, each installation can supply its own provider keys via the dashboard.


### PR DESCRIPTION
## What

Adds `ROUTER_<PROVIDER>_MODEL_ALIASES`, a JSON map of catalog model ID → the model name a provider's endpoint publishes, applied to the outbound request body on the deployment-key path.

Closes #526
Closes #541

## Why

Pointing a provider at an OpenAI-compatible endpoint that isn't the vendor itself is already a supported, documented setup — `.env.example` describes `OPENROUTER_BASE_URL` as "override for vLLM/Together/etc." But if that endpoint publishes the catalog's models under different names, there is no way to rewrite them, and every turn 400s.

#541 reproduces it end to end: the router sends `deepseek/deepseek-v4-flash`, the gateway expects `deepseek-v4-flash`, and the response is `Model ... is not supported`.

Rewriting exists, but only on paths that don't cover this case:

| Path | Mechanism | Covers a re-named deployment endpoint? |
|---|---|---|
| Catalog `UpstreamID` | `upstreamIDsForProvider`, baked into the binding | No — fixed at build time, and OpenRouter/XAI/Meta bindings carry none |
| BYOK key (#892) | `ExternalAPIKey.ModelAliases` → `proxy.ApplyModelAlias` | No — per-key, and only non-empty on BYOK credentials |

So a self-hosted deployment using `OPENROUTER_API_KEY` + `OPENROUTER_BASE_URL` — exactly #541's repro — has no mechanism at all. This adds the third layer.

## How

`resolveModelAliases` reads `ROUTER_<PROVIDER>_MODEL_ALIASES` for each OpenAI-compatible provider and layers the entries over that provider's catalog-derived `UpstreamID` map. The merged map goes to the existing `NewClientWithModelIDMap`, so the rewrite itself reuses `rewriteModelField` unchanged — no new code on the request path.

Precedence, outermost wins: **catalog `UpstreamID` < `ROUTER_<PROVIDER>_MODEL_ALIASES` < BYOK `model_aliases`**. The BYOK layer keeps winning for free, because `Client.Proxy` already applies it after the catalog map.

Only the outbound wire name changes. Routing, pricing, and analytics stay keyed on the catalog ID.

**Failure modes.** A malformed value aborts boot (`panic`, consistent with `config.MustGet` and `ROUTER_DEPLOYMENT_MODE`) — the error names the env var. An alias naming a model outside the deployed catalog is logged and skipped rather than fatal, so retiring a model can't turn a stale alias into a failed start.

**Validation is against catalog IDs, not per-provider bindings**, deliberately. An operator pointing `OPENROUTER_BASE_URL` at a different gateway may well be served models the catalog binds elsewhere — #526's own list includes `z-ai/glm-5.2`, which the catalog binds to Together and Fireworks. Rejecting those would reject the use case.

**Placement.** The logic sits in `cmd/router` rather than `internal/config` because it needs `internal/router/catalog`, and the root guide requires `internal/config` to stay a leaf that imports nothing else under `internal/`. It is boot-time wiring, which is the composition root's job, and `cmd/CLAUDE.md` lists small env parsers as belonging there.

## Behavior change

None without configuration. `resolveModelAliases` with no env vars set produces exactly the maps in use today:

| Provider | Catalog-derived entries | Resolved entries |
|---|---|---|
| openrouter | 0 | 0 |
| fireworks | 16 | 16 |
| makora | 2 | 2 |
| minimax | 2 | 2 |
| together | 7 | 7 |
| xai | 0 | 0 |
| meta | 0 | 0 |
| wafer | 3 | 3 |
| bedrock | 4 | 4 |

OpenRouter, XAI and Meta now construct via `NewClientWithModelIDMap` where they previously called `NewClient`. All three resolve to zero entries, so the map is nil and `rewriteModelField` returns the body untouched — an unconfigured deployment puts the same bytes on the wire as before.

The first-party OpenAI client and Wafer's Anthropic-compatible surface keep their own catalog maps and are deliberately out of scope; this PR covers the nine OpenAI-compatible deployment-keyed providers.

## Testing

`make build`, `vet`, `test`, `test-statusline`, `test-install`, `inference-boundary`, `check-docs` and `check-agent-guides` are all green. No `db/queries/` or migration files are touched, so `internal/sqlc/` is untouched (I couldn't run `sqlc generate` locally).

**`model_aliases_wire_test.go` reproduces #541 at the wire.** An `httptest` stub stands in for a gateway publishing bare names, and the assertion is the `model` field it actually receives:

| Case | Model on the wire |
|---|---|
| No alias configured (the #541 bug) | `deepseek/deepseek-v4-flash` — what the gateway rejects |
| `ROUTER_OPENROUTER_MODEL_ALIASES` set | `deepseek-v4-flash` — what it accepts |
| A different, unaliased model | `xiaomi/mimo-v2.5-pro`, unchanged |

I chose this over booting the compose stack because it pins the exact byte #541 is about, runs in CI on every change, and needs no upstream key. It also closes a gap: nothing else asserts `modelIDMap` rewriting at all.

**`model_aliases_test.go`** adds parsing cases (empty, valid, malformed JSON, JSON array, empty key, empty value), env override application, override beating a catalog `UpstreamID`, unaliased bindings surviving the merge, unknown models skipped without error, and a malformed value erroring with the env var named. They discover a suitable model from `catalog.Models` at run time rather than pinning an ID, so catalog churn doesn't break them.

Mutation-checked: dropping the `merged[id] = upstreamID` write fails `TestResolveModelAliasesAppliesEnvOverride`, `TestResolveModelAliasesOverridesCatalogUpstreamID` and the wire test's alias case, while the two no-alias cases correctly keep passing.

**Not run:** the full `docker compose` stack against a real re-named endpoint. The evidence above is the test suite plus the resolved-map parity table.

## Docs

- `docs/CONFIGURATION.md` — new "Deployment-level model aliases" subsection plus a row in the provider table.
- `.env.example` — commented `ROUTER_OPENROUTER_MODEL_ALIASES` example next to the other provider vars.
- `cmd/CLAUDE.md` — `resolveModelAliases` added to the composition-root helper list. `cmd/AGENTS.md` is regenerated via `make generate-agent-guides`, and `make check-agent-guides` passes.

## Incidental

`upstreamIDsForProvider` moves into the new file alongside its callers. Its doc comment had drifted onto `registerDeploymentKeyedProvider` in `main.go`; moving the function reunites the two.

## Rebase note

Rebased onto current `main` after the move to `weave-os/router` — the original branch was cut about 290 commits back. Carried forward in the rebase: the three OpenAI-compatible providers added since (MiniMax, Meta, Wafer) are aliasable too, imports moved to the `weave-os/router` module path, `AGENTS.md` is now generated so only `cmd/CLAUDE.md` is hand-edited, and two test helpers were renamed to avoid colliding with `flag_registry_test.go`'s `discardLogger` and the new `internal/dispatch` package.