### PR TITLE
fix: preserve Codex OAuth with Weave router

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@
 #   (and .env.local if present). Start Postgres via `make db` or point
 #   DATABASE_URL at any Postgres you already have running.
 
-.PHONY: generate generate-statusline build test test-verbose test-statusline smoke initdb migrate-up migrate-down migrate-create seed setup full-setup db dev check fmt vet precommit install-hooks help install-cc uninstall-cc up up-hmm down down-hmm logs
+.PHONY: generate generate-statusline build test test-verbose test-statusline test-install smoke initdb migrate-up migrate-down migrate-create seed setup full-setup db dev check fmt vet precommit install-hooks help install-cc uninstall-cc up up-hmm down down-hmm logs
 
 # Load DATABASE_URL from .env files (matches docker-compose defaults).
 -include .env.development
@@ -37,6 +37,9 @@ test-verbose: ## Run all tests with verbose output
 
 test-statusline: ## Run the cc-statusline.sh regression tests (offline)
 	@bash install/tests/cc-statusline_test.sh
+
+test-install: ## Run offline installer regression tests
+	@bash install/tests/codex_install_test.sh
 
 smoke: ## Pre-merge smoke suite: real router stack + real Anthropic (needs ANTHROPIC_API_KEY)
 	./scripts/smoke/run.sh
@@ -179,7 +182,7 @@ fmt: ## Check gofmt (fails on unformatted files)
 vet: ## Run go vet
 	go vet ./...
 
-precommit: fmt vet build test test-statusline ## Fast pre-commit check (no codegen, no DB)
+precommit: fmt vet build test test-statusline test-install ## Fast pre-commit check (no codegen, no DB)
 
 install-hooks: ## Install git pre-commit hook
 	@HOOK_DIR=$$(git rev-parse --git-common-dir)/hooks; \
@@ -188,7 +191,7 @@ install-hooks: ## Install git pre-commit hook
 	chmod +x "$$HOOK_DIR/pre-commit"; \
 	echo "Pre-commit hook installed at $$HOOK_DIR/pre-commit"
 
-check: generate fmt vet build test test-statusline ## Full CI-equivalent check
+check: generate fmt vet build test test-statusline test-install ## Full CI-equivalent check
 	@if ! git diff --quiet internal/sqlc/; then \
 		echo "error: sqlc generation produced uncommitted changes"; \
 		git diff internal/sqlc/; \

--- a/README.md
+++ b/README.md
@@ -169,10 +169,11 @@ above.
 **Codex** (OpenAI CLI). `npx @workweave/router --codex` patches
 `~/.codex/config.toml` (or `<repo>/.codex/config.toml` with `--scope project`)
 with a managed `[model_providers.weave]` block and sets `model_provider = "weave"`.
-Codex's existing `OPENAI_API_KEY` flows through to api.openai.com for the
-plan-based passthrough; the router key rides in an `X-Weave-Router-Key` HTTP
-header. Re-install and `--uninstall --codex` rewrite/remove only the managed
-block, leaving the rest of your Codex config untouched.
+The provider requires Codex's existing ChatGPT OAuth login, which Codex forwards
+to the router for plan-based passthrough; the router key rides in an
+`X-Weave-Router-Key` HTTP header. Re-install and `--uninstall --codex`
+rewrite/remove only the managed block, leaving the rest of your Codex config
+untouched.
 
 **opencode.** `npx @workweave/router --opencode` merges a `provider.weave`
 entry into `~/.config/opencode/opencode.json` (or `<repo>/opencode.json`

--- a/install/README.md
+++ b/install/README.md
@@ -111,7 +111,7 @@ logged-in user's Team/Pro/Max/individual plan.
 
 | Path                       | Purpose                                                       |
 | -------------------------- | ------------------------------------------------------------- |
-| `~/.codex/config.toml`     | Adds a managed `[model_providers.weave]` block + sets top-level `model_provider = "weave"`, both between `# >>> weave-router managed` markers. Anything outside the markers is preserved. |
+| `~/.codex/config.toml`     | Adds a managed `[model_providers.weave]` block + sets top-level `model_provider = "weave"`, both between `# >>> weave-router managed` markers. The provider requires and forwards the existing ChatGPT OAuth login for plan-backed routing; anything outside the markers is preserved. |
 
 **Project scope (`--scope project`):**
 

--- a/install/install.sh
+++ b/install/install.sh
@@ -415,7 +415,9 @@ resolve_user_email() {
 
 # write_codex_config writes a managed [model_providers.weave] block to the
 # Codex CLI's config.toml. Sets `model_provider = "weave"` at the top level so
-# Codex picks the routed provider by default. Both lines live inside the
+# Codex picks the routed provider by default. The provider requires OpenAI
+# authentication, preserving the user's ChatGPT plan credential and forwarding
+# it to the router alongside the router key. Both settings live inside the
 # managed-block markers so uninstall removes them cleanly. We strip any
 # top-level `model_provider = ...` declaration OUTSIDE the markers before
 # appending so the file doesn't end up with a duplicate key (TOML rejects
@@ -476,6 +478,7 @@ model_provider = "weave"
 name = "Weave Router"
 base_url = "${esc_url}/v1"
 wire_api = "responses"
+requires_openai_auth = true
 ${headers_line}
 ${WEAVE_CODEX_END_MARKER}
 TOML

--- a/install/npm/README.md
+++ b/install/npm/README.md
@@ -62,10 +62,11 @@ Four install targets:
   api.anthropic.com.
 - **Codex** (`--codex`) — patches `~/.codex/config.toml` (or
   `<repo>/.codex/config.toml`) with a managed `[model_providers.weave]`
-  block plus `model_provider = "weave"`. OpenAI plan credentials flow
-  through to api.openai.com. The block lives between begin/end markers so
-  re-running the installer rewrites it cleanly and `--uninstall --codex`
-  removes it without touching the rest of your config.
+  block plus `model_provider = "weave"`. The provider requires and forwards
+  the existing ChatGPT OAuth login for plan-backed routing. The block lives
+  between begin/end markers so re-running the installer rewrites it cleanly
+  and `--uninstall --codex` removes it without touching the rest of your
+  config.
 - **opencode** (`--opencode`) — merges a `provider.weave` entry (backed by
   opencode's built-in `@ai-sdk/anthropic` provider) into
   `~/.config/opencode/opencode.json` (or `<repo>/opencode.json` with

--- a/install/tests/codex_install_test.sh
+++ b/install/tests/codex_install_test.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+#
+# Regression tests for Codex installation. The loopback endpoint keeps router
+# validation local, and an isolated HOME prevents changes to real config.
+
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+installer="${INSTALLER:-$script_dir/../install.sh}"
+[ -f "$installer" ] || { echo "cannot find installer at $installer" >&2; exit 1; }
+
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+home="$work/home"
+mkdir -p "$home"
+
+run_install() {
+  HOME="$home" WEAVE_ROUTER_KEY="rk_test_key" NO_COLOR=1 \
+    bash "$installer" --codex --scope user --quiet \
+      --base-url http://127.0.0.1:9
+}
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+run_install
+config="$home/.codex/config.toml"
+[ -f "$config" ] || fail "Codex config was not created"
+grep -qx 'model_provider = "weave"' "$config" \
+  || fail "Weave was not selected as the default provider"
+grep -qx 'requires_openai_auth = true' "$config" \
+  || fail "Weave provider does not require ChatGPT OAuth"
+
+# A repeat install must refresh one managed block, not duplicate its auth rule.
+run_install
+[ "$(grep -cx 'requires_openai_auth = true' "$config")" -eq 1 ] \
+  || fail "repeat install duplicated the OAuth requirement"
+
+echo "Codex installer OAuth regression tests passed"


### PR DESCRIPTION
Require ChatGPT OAuth for the Weave Codex provider, preserving plan authentication while requests remain routed through Weave. Includes installer regression coverage.