### PR TITLE
fix: pin HMM sessions during arm-selector fallback

### DIFF
--- a/cmd/router/main.go
+++ b/cmd/router/main.go
@@ -577,6 +577,7 @@ func main() {
 	prefixTrimFreeSwitch := config.GetOr("ROUTER_PREFIX_TRIM_FREE_SWITCH", "true") == "true"
 	hmmUpgradeConfidence := parseEnvFloat("ROUTER_HMM_UPGRADE_CONFIDENCE_THRESHOLD", 0.85)
 	hmmSameTierPin := config.GetOr("ROUTER_HMM_SAME_TIER_PIN", "false") == "true"
+	hmPinStickyOnArmSelectorUnavail := config.GetOr("ROUTER_HMM_PIN_STICKY_ON_ARM_SELECTOR_UNAVAIL", "false") == "true"
 	handoverProviderName := config.GetOr("ROUTER_HANDOVER_PROVIDER", providers.ProviderAnthropic)
 	handoverModel := config.GetOr("ROUTER_HANDOVER_MODEL", proxy.DefaultHandoverModel)
 	handoverTimeout := parseEnvDurationMs("ROUTER_HANDOVER_TIMEOUT_MS", proxy.DefaultHandoverTimeout)
@@ -775,6 +776,7 @@ func main() {
 		WithPrefixTrimFreeSwitch(prefixTrimFreeSwitch).
 		WithHMMUpgradeConfidenceThreshold(hmmUpgradeConfidence).
 		WithHMMSameTierPin(hmmSameTierPin).
+		WithHMPinStickyOnArmSelectorUnavail(hmPinStickyOnArmSelectorUnavail).
 		WithEscapeNormalize(escapeNormalize).
 		WithEffortEscalation(effortEscalation).
 		WithCCOrchestrationToolsCrossVendor(ccOrchToolsCrossVendor).

--- a/db/migrations/0050_session-pin-policy-group.down.sql
+++ b/db/migrations/0050_session-pin-policy-group.down.sql
@@ -1,0 +1,6 @@
+BEGIN;
+
+ALTER TABLE router.session_pins
+    DROP COLUMN policy_group;
+
+COMMIT;

--- a/db/migrations/0050_session-pin-policy-group.up.sql
+++ b/db/migrations/0050_session-pin-policy-group.up.sql
@@ -1,0 +1,17 @@
+BEGIN;
+
+-- Records the policy-internal cluster/group the pinned decision was drawn from
+-- (the HMM complexity cluster), copied from RoutingMetadata.PolicyGroup. It is
+-- refreshed on a genuine policy re-route and preserved on a same-model sticky
+-- refresh, mirroring the paired_provider/paired_model maintenance below it.
+--
+-- The arm-selector-unavailable pin-sticky guard compares this against the fresh
+-- decision's group: the legacy pairwise bandit only draws within one cluster, so
+-- a matching group means the reroute is fallback noise the pin may suppress,
+-- while a differing group is a real classifier escalation that must switch
+-- through. Empty string for pins written outside a policy router (force-model,
+-- loop-break, cluster/planner routing) or by sidecars that report no group.
+ALTER TABLE router.session_pins
+    ADD COLUMN policy_group VARCHAR(64) NOT NULL DEFAULT '';
+
+COMMIT;

--- a/db/queries/session_pins.sql
+++ b/db/queries/session_pins.sql
@@ -36,16 +36,23 @@ WHERE session_key = @session_key::bytea
 -- inherits a stale runner-up across a non-scorer model change, and never
 -- collapses pinned_model and paired_model onto the same slug. A later per-turn
 -- swap policy reads the pair that matches the active decision.
+--
+-- policy_group follows the same three-way maintenance: a fresh policy decision
+-- supplies a non-empty group, a same-model refresh preserves the stored one, and
+-- a model change without a group (force-model, loop-break, eviction) clears it.
+-- The pin-sticky arm-selector guard compares it against the fresh decision's
+-- group, so a stale group must never survive onto a different pinned model.
 -- name: UpsertSessionPin :exec
 INSERT INTO router.session_pins (
   session_key, role, installation_id, pinned_provider,
   pinned_model, paired_provider, paired_model,
-  decision_reason, turn_count, pinned_until
+  decision_reason, policy_group, turn_count, pinned_until
 ) VALUES (
   @session_key::bytea, @role::varchar, @installation_id::uuid,
   @pinned_provider::varchar, @pinned_model::varchar,
   @paired_provider::varchar, @paired_model::varchar,
-  @decision_reason::text, @turn_count::int, @pinned_until::timestamp
+  @decision_reason::text, @policy_group::varchar,
+  @turn_count::int, @pinned_until::timestamp
 )
 ON CONFLICT (session_key, role) DO UPDATE SET
   pinned_provider = EXCLUDED.pinned_provider,
@@ -74,6 +81,13 @@ ON CONFLICT (session_key, role) DO UPDATE SET
       THEN EXCLUDED.paired_model
     WHEN EXCLUDED.pinned_model = router.session_pins.pinned_model
       THEN router.session_pins.paired_model
+    ELSE ''
+  END,
+  policy_group = CASE
+    WHEN EXCLUDED.policy_group <> ''
+      THEN EXCLUDED.policy_group
+    WHEN EXCLUDED.pinned_model = router.session_pins.pinned_model
+      THEN router.session_pins.policy_group
     ELSE ''
   END,
   consecutive_upstream_errors = CASE

--- a/internal/postgres/session_pin_repo.go
+++ b/internal/postgres/session_pin_repo.go
@@ -50,6 +50,7 @@ func (r *SessionPinRepo) Upsert(ctx context.Context, p sessionpin.Pin) error {
 		PairedProvider: p.PairedProvider,
 		PairedModel:    p.PairedModel,
 		DecisionReason: p.Reason,
+		PolicyGroup:    p.PolicyGroup,
 		TurnCount:      int32(p.TurnCount),
 		PinnedUntil:    pgtype.Timestamp{Time: p.PinnedUntil.UTC(), Valid: true},
 	})
@@ -160,6 +161,7 @@ func toSessionPin(row sqlc.RouterSessionPin) sessionpin.Pin {
 		PairedProvider:            row.PairedProvider,
 		PairedModel:               row.PairedModel,
 		Reason:                    row.DecisionReason,
+		PolicyGroup:               row.PolicyGroup,
 		TurnCount:                 int(row.TurnCount),
 		PinnedUntil:               timestampOrZero(row.PinnedUntil),
 		FirstPinnedAt:             timestampOrZero(row.FirstPinnedAt),

--- a/internal/proxy/hmm_pin_sticky_internal_test.go
+++ b/internal/proxy/hmm_pin_sticky_internal_test.go
@@ -25,17 +25,30 @@ const hmmPinStickyTestFallbackReason = "arm-selector unavailable for 'high': arm
 
 // TestStickPinOnArmSelectorUnavailable directly exercises the pure predicate
 // against the full stick/no-stick matrix. Only the exact
-// arm-selector-unavailable-fallback + same-HMM-pin-reason + different model +
-// non-trimmed combination may suppress a fresh decision.
+// arm-selector-unavailable-fallback + same-HMM-pin-reason + same-policy-group +
+// different model + non-trimmed combination may suppress a fresh decision.
 func TestStickPinOnArmSelectorUnavailable(t *testing.T) {
 	const pinnedModel = "claude-opus-4-7"         // catalog.TierHigh
 	const sameTierFresh = "claude-opus-4-6"       // catalog.TierHigh
-	const differentTierFresh = "claude-haiku-4-5" // catalog.TierLow — different tier, but the legacy bandit draws within one cluster, not within one catalog tier, so the sentinel alone gates this case.
+	const differentTierFresh = "claude-haiku-4-5" // catalog.TierLow — different tier, but the legacy bandit draws within one cluster, not within one catalog tier, so tier is not what gates this case.
+	const pinnedGroup = "high"
+	const otherGroup = "low"
 
 	basePin := sessionpin.Pin{
-		Provider: providers.ProviderAnthropic,
-		Model:    pinnedModel,
-		Reason:   "hmm_policy(classifier 'high' (p=0.32))",
+		Provider:    providers.ProviderAnthropic,
+		Model:       pinnedModel,
+		Reason:      "hmm_policy(classifier 'high' (p=0.32))",
+		PolicyGroup: pinnedGroup,
+	}
+
+	// fallbackDecision builds a fresh decision carrying the arm-selector
+	// fallback sentinel and the supplied policy group.
+	fallbackDecision := func(model, group string) router.Decision {
+		return router.Decision{
+			Model:    model,
+			Reason:   hmmPinStickyTestFallbackReason,
+			Metadata: &router.RoutingMetadata{PolicyGroup: group},
+		}
 	}
 
 	tests := []struct {
@@ -47,61 +60,87 @@ func TestStickPinOnArmSelectorUnavailable(t *testing.T) {
 		want         bool
 	}{
 		{
-			name:     "sticks: fallback sentinel, same HMM pin, different model",
+			name:     "sticks: fallback sentinel, same HMM pin, same group, different model",
+			fresh:    fallbackDecision(sameTierFresh, pinnedGroup),
+			pin:      basePin,
+			pinFound: true,
+			want:     true,
+		},
+		{
+			name:     "sticks even if catalog tier differs, as long as the group matches",
+			fresh:    fallbackDecision(differentTierFresh, pinnedGroup),
+			pin:      basePin,
+			pinFound: true,
+			want:     true,
+		},
+		{
+			name:     "no stick: classifier escalated into a different cluster",
+			fresh:    fallbackDecision(differentTierFresh, otherGroup),
+			pin:      basePin,
+			pinFound: true,
+			want:     false,
+		},
+		{
+			name:     "no stick: fresh decision reports no group (cannot prove same cluster)",
 			fresh:    router.Decision{Model: sameTierFresh, Reason: hmmPinStickyTestFallbackReason},
 			pin:      basePin,
 			pinFound: true,
-			want:     true,
+			want:     false,
 		},
 		{
-			name:     "sticks even if catalog tier differs (real prod bug shape)",
-			fresh:    router.Decision{Model: differentTierFresh, Reason: hmmPinStickyTestFallbackReason},
-			pin:      basePin,
+			name:  "no stick: pin predates group persistence",
+			fresh: fallbackDecision(sameTierFresh, pinnedGroup),
+			pin: sessionpin.Pin{
+				Provider: providers.ProviderAnthropic,
+				Model:    pinnedModel,
+				Reason:   "hmm_policy(classifier 'high' (p=0.32))",
+			},
 			pinFound: true,
-			want:     true,
+			want:     false,
 		},
 		{
 			name:     "no stick: fresh has no sentinel (real scorer decision)",
-			fresh:    router.Decision{Model: sameTierFresh, Reason: "hmm_policy(classifier 'high' (p=0.91); arm-selector XGBoost greedy arm)"},
+			fresh:    router.Decision{Model: sameTierFresh, Reason: "hmm_policy(classifier 'high' (p=0.91); arm-selector XGBoost greedy arm)", Metadata: &router.RoutingMetadata{PolicyGroup: pinnedGroup}},
 			pin:      basePin,
 			pinFound: true,
 			want:     false,
 		},
 		{
 			name:     "no stick: no active pin",
-			fresh:    router.Decision{Model: sameTierFresh, Reason: hmmPinStickyTestFallbackReason},
+			fresh:    fallbackDecision(sameTierFresh, pinnedGroup),
 			pin:      sessionpin.Pin{},
 			pinFound: false,
 			want:     false,
 		},
 		{
 			name:     "no stick: pin found but empty model",
-			fresh:    router.Decision{Model: sameTierFresh, Reason: hmmPinStickyTestFallbackReason},
-			pin:      sessionpin.Pin{Reason: "hmm_policy(...)"},
+			fresh:    fallbackDecision(sameTierFresh, pinnedGroup),
+			pin:      sessionpin.Pin{Reason: "hmm_policy(...)", PolicyGroup: pinnedGroup},
 			pinFound: true,
 			want:     false,
 		},
 		{
 			name:  "no stick: pin reason is not HMM-written (stale cluster pin)",
-			fresh: router.Decision{Model: sameTierFresh, Reason: hmmPinStickyTestFallbackReason},
+			fresh: fallbackDecision(sameTierFresh, pinnedGroup),
 			pin: sessionpin.Pin{
-				Provider: providers.ProviderAnthropic,
-				Model:    pinnedModel,
-				Reason:   "cluster:v0.2",
+				Provider:    providers.ProviderAnthropic,
+				Model:       pinnedModel,
+				Reason:      "cluster:v0.2",
+				PolicyGroup: pinnedGroup,
 			},
 			pinFound: true,
 			want:     false,
 		},
 		{
 			name:     "no stick: scorer agrees with pin (no-op)",
-			fresh:    router.Decision{Model: pinnedModel, Reason: hmmPinStickyTestFallbackReason},
+			fresh:    fallbackDecision(pinnedModel, pinnedGroup),
 			pin:      basePin,
 			pinFound: true,
 			want:     false,
 		},
 		{
 			name:         "no stick: prefix trimmed (cache broken)",
-			fresh:        router.Decision{Model: sameTierFresh, Reason: hmmPinStickyTestFallbackReason},
+			fresh:        fallbackDecision(sameTierFresh, pinnedGroup),
 			pin:          basePin,
 			pinFound:     true,
 			prefixBroken: true,
@@ -128,31 +167,45 @@ func (r *hmmPinStickyTestRouter) Route(_ context.Context, _ router.Request) (rou
 }
 
 // TestHMMPinStickyOnArmSelectorUnavailableWiredIntoTurnLoop proves the
-// pure predicate is actually consulted on the AuthoritativePerTurn path and
-// that the kill switch (ROUTER_HMM_PIN_STICKY_ON_ARM_SELECTOR_UNAVAIL) gates
-// it end to end: same inputs, opposite outcomes with the switch flipped.
+// pure predicate is actually consulted on the AuthoritativePerTurn path, that
+// the kill switch (ROUTER_HMM_PIN_STICKY_ON_ARM_SELECTOR_UNAVAIL) gates it end
+// to end, and that an authoritative decision landing in a different policy
+// group still switches through even with the switch enabled.
 func TestHMMPinStickyOnArmSelectorUnavailableWiredIntoTurnLoop(t *testing.T) {
 	strategy := router.Strategy("hmm-pin-sticky-wiring-test")
 	const pinnedModel = "claude-opus-4-7"
 	const sameTierFresh = "claude-opus-4-6"
+	const pinnedGroup = "high"
+	const otherGroup = "low"
 
 	tests := []struct {
 		name          string
 		enabled       bool
+		freshGroup    string
 		wantStickyHit bool
 		wantModel     string
 		wantPinTier   string
 	}{
 		{
-			name:          "enabled: suppresses reroute, keeps pin",
+			name:          "enabled, same group: suppresses reroute, keeps pin",
 			enabled:       true,
+			freshGroup:    pinnedGroup,
 			wantStickyHit: true,
 			wantModel:     pinnedModel,
 			wantPinTier:   hmmPinStickyArmSelectorUnavailReason,
 		},
 		{
+			name:          "enabled, different group: authoritative escalation still serves",
+			enabled:       true,
+			freshGroup:    otherGroup,
+			wantStickyHit: false,
+			wantModel:     sameTierFresh,
+			wantPinTier:   "authoritative_per_turn",
+		},
+		{
 			name:          "disabled: fresh decision serves as usual",
 			enabled:       false,
+			freshGroup:    pinnedGroup,
 			wantStickyHit: false,
 			wantModel:     sameTierFresh,
 			wantPinTier:   "authoritative_per_turn",
@@ -167,6 +220,7 @@ func TestHMMPinStickyOnArmSelectorUnavailableWiredIntoTurnLoop(t *testing.T) {
 				Provider:        providers.ProviderAnthropic,
 				Model:           pinnedModel,
 				Reason:          "hmm_policy(classifier 'high' (p=0.32))",
+				PolicyGroup:     pinnedGroup,
 				PinnedUntil:     time.Now().Add(time.Hour),
 				LastTurnEndedAt: time.Now().Add(-time.Minute),
 				LastServedModel: pinnedModel,
@@ -175,6 +229,7 @@ func TestHMMPinStickyOnArmSelectorUnavailableWiredIntoTurnLoop(t *testing.T) {
 				Provider: providers.ProviderAnthropic,
 				Model:    sameTierFresh,
 				Reason:   hmmPinStickyTestFallbackReason,
+				Metadata: &router.RoutingMetadata{PolicyGroup: test.freshGroup},
 			}}
 			svc := NewService(
 				nil,
@@ -224,6 +279,19 @@ func TestHMMPinStickyOnArmSelectorUnavailableWiredIntoTurnLoop(t *testing.T) {
 			assert.Equal(t, test.wantStickyHit, result.StickyHit)
 			assert.Equal(t, test.wantModel, result.Decision.Model)
 			assert.Equal(t, test.wantPinTier, result.PinTier)
+
+			// The predicate can only compare groups if the write path actually
+			// persists one: a fresh authoritative write carries the decision's
+			// group, a suppressed reroute carries the pin's forward.
+			store.mu.Lock()
+			upserts := append([]sessionpin.Pin(nil), store.upserts...)
+			store.mu.Unlock()
+			require.NotEmpty(t, upserts)
+			wantGroup := test.freshGroup
+			if test.wantStickyHit {
+				wantGroup = pinnedGroup
+			}
+			assert.Equal(t, wantGroup, upserts[len(upserts)-1].PolicyGroup)
 		})
 	}
 }

--- a/internal/proxy/hmm_pin_sticky_internal_test.go
+++ b/internal/proxy/hmm_pin_sticky_internal_test.go
@@ -23,10 +23,7 @@ const hmmPinStickyTestFallbackReason = "arm-selector unavailable for 'high': arm
 	"legacy pairwise arm 'z-ai/glm-5.2' among 2/5 eligible [explored] " +
 	hmmArmSelectorUnavailableSentinel
 
-// TestStickPinOnArmSelectorUnavailable directly exercises the pure predicate
-// against the full stick/no-stick matrix. Only the exact
-// arm-selector-unavailable-fallback + same-HMM-pin-reason + same-policy-group +
-// different model + non-trimmed combination may suppress a fresh decision.
+// TestStickPinOnArmSelectorUnavailable exercises the pure predicate against the full stick/no-stick matrix.
 func TestStickPinOnArmSelectorUnavailable(t *testing.T) {
 	const pinnedModel = "claude-opus-4-7"         // catalog.TierHigh
 	const sameTierFresh = "claude-opus-4-6"       // catalog.TierHigh
@@ -166,11 +163,8 @@ func (r *hmmPinStickyTestRouter) Route(_ context.Context, _ router.Request) (rou
 	return r.decision, nil
 }
 
-// TestHMMPinStickyOnArmSelectorUnavailableWiredIntoTurnLoop proves the
-// pure predicate is actually consulted on the AuthoritativePerTurn path, that
-// the kill switch (ROUTER_HMM_PIN_STICKY_ON_ARM_SELECTOR_UNAVAIL) gates it end
-// to end, and that an authoritative decision landing in a different policy
-// group still switches through even with the switch enabled.
+// TestHMMPinStickyOnArmSelectorUnavailableWiredIntoTurnLoop proves the kill switch gates the
+// predicate end to end and that an authoritative cluster escalation still serves.
 func TestHMMPinStickyOnArmSelectorUnavailableWiredIntoTurnLoop(t *testing.T) {
 	strategy := router.Strategy("hmm-pin-sticky-wiring-test")
 	const pinnedModel = "claude-opus-4-7"

--- a/internal/proxy/hmm_pin_sticky_internal_test.go
+++ b/internal/proxy/hmm_pin_sticky_internal_test.go
@@ -1,0 +1,229 @@
+package proxy
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"workweave/router/internal/providers"
+	"workweave/router/internal/router"
+	"workweave/router/internal/router/policy"
+	"workweave/router/internal/router/sessionpin"
+	"workweave/router/internal/translate"
+)
+
+const hmmPinStickyTestFallbackReason = "arm-selector unavailable for 'high': arm selector requires " +
+	"at least 2 trained eligible arm(s) in cluster 'high'; " +
+	"eligible=['anthropic/claude-opus-4-7', 'openai/gpt-5.6-terra']; " +
+	"legacy pairwise arm 'z-ai/glm-5.2' among 2/5 eligible [explored] " +
+	hmmArmSelectorUnavailableSentinel
+
+// TestStickPinOnArmSelectorUnavailable directly exercises the pure predicate
+// against the full stick/no-stick matrix. Only the exact
+// arm-selector-unavailable-fallback + same-HMM-pin-reason + different model +
+// non-trimmed combination may suppress a fresh decision.
+func TestStickPinOnArmSelectorUnavailable(t *testing.T) {
+	const pinnedModel = "claude-opus-4-7"         // catalog.TierHigh
+	const sameTierFresh = "claude-opus-4-6"       // catalog.TierHigh
+	const differentTierFresh = "claude-haiku-4-5" // catalog.TierLow — different tier, but the legacy bandit draws within one cluster, not within one catalog tier, so the sentinel alone gates this case.
+
+	basePin := sessionpin.Pin{
+		Provider: providers.ProviderAnthropic,
+		Model:    pinnedModel,
+		Reason:   "hmm_policy(classifier 'high' (p=0.32))",
+	}
+
+	tests := []struct {
+		name         string
+		fresh        router.Decision
+		pin          sessionpin.Pin
+		pinFound     bool
+		prefixBroken bool
+		want         bool
+	}{
+		{
+			name:     "sticks: fallback sentinel, same HMM pin, different model",
+			fresh:    router.Decision{Model: sameTierFresh, Reason: hmmPinStickyTestFallbackReason},
+			pin:      basePin,
+			pinFound: true,
+			want:     true,
+		},
+		{
+			name:     "sticks even if catalog tier differs (real prod bug shape)",
+			fresh:    router.Decision{Model: differentTierFresh, Reason: hmmPinStickyTestFallbackReason},
+			pin:      basePin,
+			pinFound: true,
+			want:     true,
+		},
+		{
+			name:     "no stick: fresh has no sentinel (real scorer decision)",
+			fresh:    router.Decision{Model: sameTierFresh, Reason: "hmm_policy(classifier 'high' (p=0.91); arm-selector XGBoost greedy arm)"},
+			pin:      basePin,
+			pinFound: true,
+			want:     false,
+		},
+		{
+			name:     "no stick: no active pin",
+			fresh:    router.Decision{Model: sameTierFresh, Reason: hmmPinStickyTestFallbackReason},
+			pin:      sessionpin.Pin{},
+			pinFound: false,
+			want:     false,
+		},
+		{
+			name:     "no stick: pin found but empty model",
+			fresh:    router.Decision{Model: sameTierFresh, Reason: hmmPinStickyTestFallbackReason},
+			pin:      sessionpin.Pin{Reason: "hmm_policy(...)"},
+			pinFound: true,
+			want:     false,
+		},
+		{
+			name:  "no stick: pin reason is not HMM-written (stale cluster pin)",
+			fresh: router.Decision{Model: sameTierFresh, Reason: hmmPinStickyTestFallbackReason},
+			pin: sessionpin.Pin{
+				Provider: providers.ProviderAnthropic,
+				Model:    pinnedModel,
+				Reason:   "cluster:v0.2",
+			},
+			pinFound: true,
+			want:     false,
+		},
+		{
+			name:     "no stick: scorer agrees with pin (no-op)",
+			fresh:    router.Decision{Model: pinnedModel, Reason: hmmPinStickyTestFallbackReason},
+			pin:      basePin,
+			pinFound: true,
+			want:     false,
+		},
+		{
+			name:         "no stick: prefix trimmed (cache broken)",
+			fresh:        router.Decision{Model: sameTierFresh, Reason: hmmPinStickyTestFallbackReason},
+			pin:          basePin,
+			pinFound:     true,
+			prefixBroken: true,
+			want:         false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := stickPinOnArmSelectorUnavailable(test.fresh, test.pin, test.pinFound, test.prefixBroken)
+			assert.Equal(t, test.want, got)
+		})
+	}
+}
+
+// hmmPinStickyTestRouter always returns a fixed fresh decision, mirroring
+// authoritativeTestRouter in authoritative_turnloop_internal_test.go.
+type hmmPinStickyTestRouter struct {
+	decision router.Decision
+}
+
+func (r *hmmPinStickyTestRouter) Route(_ context.Context, _ router.Request) (router.Decision, error) {
+	return r.decision, nil
+}
+
+// TestHMMPinStickyOnArmSelectorUnavailableWiredIntoTurnLoop proves the
+// pure predicate is actually consulted on the AuthoritativePerTurn path and
+// that the kill switch (ROUTER_HMM_PIN_STICKY_ON_ARM_SELECTOR_UNAVAIL) gates
+// it end to end: same inputs, opposite outcomes with the switch flipped.
+func TestHMMPinStickyOnArmSelectorUnavailableWiredIntoTurnLoop(t *testing.T) {
+	strategy := router.Strategy("hmm-pin-sticky-wiring-test")
+	const pinnedModel = "claude-opus-4-7"
+	const sameTierFresh = "claude-opus-4-6"
+
+	tests := []struct {
+		name          string
+		enabled       bool
+		wantStickyHit bool
+		wantModel     string
+		wantPinTier   string
+	}{
+		{
+			name:          "enabled: suppresses reroute, keeps pin",
+			enabled:       true,
+			wantStickyHit: true,
+			wantModel:     pinnedModel,
+			wantPinTier:   hmmPinStickyArmSelectorUnavailReason,
+		},
+		{
+			name:          "disabled: fresh decision serves as usual",
+			enabled:       false,
+			wantStickyHit: false,
+			wantModel:     sameTierFresh,
+			wantPinTier:   "authoritative_per_turn",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			store := newStubPinStore()
+			store.getFound = true
+			store.getPin = sessionpin.Pin{
+				Provider:        providers.ProviderAnthropic,
+				Model:           pinnedModel,
+				Reason:          "hmm_policy(classifier 'high' (p=0.32))",
+				PinnedUntil:     time.Now().Add(time.Hour),
+				LastTurnEndedAt: time.Now().Add(-time.Minute),
+				LastServedModel: pinnedModel,
+			}
+			policyRouter := &hmmPinStickyTestRouter{decision: router.Decision{
+				Provider: providers.ProviderAnthropic,
+				Model:    sameTierFresh,
+				Reason:   hmmPinStickyTestFallbackReason,
+			}}
+			svc := NewService(
+				nil,
+				nil,
+				nil,
+				false,
+				nil,
+				store,
+				false,
+				providers.ProviderAnthropic,
+				"claude-haiku-4-5",
+				nil,
+			).WithHMPinStickyOnArmSelectorUnavail(test.enabled).
+				WithPolicyStrategy(policy.StrategySpec{
+					Strategy: strategy,
+					Router:   policyRouter,
+					Capabilities: policy.Capabilities{
+						SchemaVersion:                 policy.SchemaVersionV1,
+						AuthoritativePerTurnSelection: true,
+					},
+				})
+			env, err := translate.ParseAnthropic(
+				[]byte(`{"model":"claude-opus-4-8","messages":[{"role":"user","content":"continue"}]}`),
+			)
+			require.NoError(t, err)
+			features := env.RoutingFeatures(false)
+			ctx := router.WithStrategy(context.Background(), strategy)
+			req := router.Request{
+				RequestedModel:       features.Model,
+				EstimatedInputTokens: features.Tokens,
+				HasTools:             features.HasTools,
+				ConversationMessages: conversationMessagesForRouting(env),
+			}
+
+			result, err := svc.runTurnLoop(
+				ctx,
+				env,
+				features,
+				"api-key",
+				uuid.New(),
+				"",
+				http.Header{},
+				req,
+			)
+
+			require.NoError(t, err)
+			assert.Equal(t, test.wantStickyHit, result.StickyHit)
+			assert.Equal(t, test.wantModel, result.Decision.Model)
+			assert.Equal(t, test.wantPinTier, result.PinTier)
+		})
+	}
+}

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -133,12 +133,8 @@ type Service struct {
 	// hmmSameTierPin suppresses EV-positive same-tier lateral switches once a
 	// session pin is live. Env ROUTER_HMM_SAME_TIER_PIN, off by default.
 	hmmSameTierPin bool
-	// hmPinStickyOnArmSelectorUnavail suppresses a same-cluster reroute when
-	// the fresh HMM decision came from the legacy pairwise-bandit fallback
-	// because the contextual arm-selector had too few trained arms in the
-	// cluster (route_selector.PIN_STICKY_OVERRIDE_ELIGIBLE_SENTINEL in
-	// Reason) rather than a real scorer decision. Env
-	// ROUTER_HMM_PIN_STICKY_ON_ARM_SELECTOR_UNAVAIL, off by default.
+	// hmPinStickyOnArmSelectorUnavail suppresses a fresh decision that came from the arm-selector
+	// unavailable fallback bandit. Env ROUTER_HMM_PIN_STICKY_ON_ARM_SELECTOR_UNAVAIL, off by default.
 	hmPinStickyOnArmSelectorUnavail bool
 	// plannerEnabled is the kill switch. When false, the orchestrator falls
 	// back to first-decision-wins behavior.
@@ -1125,11 +1121,8 @@ func (s *Service) WithHMMSameTierPin(enabled bool) *Service {
 	return s
 }
 
-// WithHMPinStickyOnArmSelectorUnavail is the kill switch
-// (ROUTER_HMM_PIN_STICKY_ON_ARM_SELECTOR_UNAVAIL) for suppressing a
-// same-cluster reroute that only happened because the contextual
-// arm-selector had too few trained arms and fell back to an epsilon-greedy
-// bandit draw over the whole cluster roster.
+// WithHMPinStickyOnArmSelectorUnavail is the kill switch (ROUTER_HMM_PIN_STICKY_ON_ARM_SELECTOR_UNAVAIL)
+// for suppressing a reroute caused by the arm-selector unavailable fallback bandit.
 func (s *Service) WithHMPinStickyOnArmSelectorUnavail(enabled bool) *Service {
 	s.hmPinStickyOnArmSelectorUnavail = enabled
 	return s

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -133,6 +133,13 @@ type Service struct {
 	// hmmSameTierPin suppresses EV-positive same-tier lateral switches once a
 	// session pin is live. Env ROUTER_HMM_SAME_TIER_PIN, off by default.
 	hmmSameTierPin bool
+	// hmPinStickyOnArmSelectorUnavail suppresses a same-cluster reroute when
+	// the fresh HMM decision came from the legacy pairwise-bandit fallback
+	// because the contextual arm-selector had too few trained arms in the
+	// cluster (route_selector.PIN_STICKY_OVERRIDE_ELIGIBLE_SENTINEL in
+	// Reason) rather than a real scorer decision. Env
+	// ROUTER_HMM_PIN_STICKY_ON_ARM_SELECTOR_UNAVAIL, off by default.
+	hmPinStickyOnArmSelectorUnavail bool
 	// plannerEnabled is the kill switch. When false, the orchestrator falls
 	// back to first-decision-wins behavior.
 	plannerEnabled bool
@@ -1115,6 +1122,16 @@ func (s *Service) WithHMMUpgradeConfidenceThreshold(v float64) *Service {
 // suppressing an EV-positive HMM switch between two same-tier models.
 func (s *Service) WithHMMSameTierPin(enabled bool) *Service {
 	s.hmmSameTierPin = enabled
+	return s
+}
+
+// WithHMPinStickyOnArmSelectorUnavail is the kill switch
+// (ROUTER_HMM_PIN_STICKY_ON_ARM_SELECTOR_UNAVAIL) for suppressing a
+// same-cluster reroute that only happened because the contextual
+// arm-selector had too few trained arms and fell back to an epsilon-greedy
+// bandit draw over the whole cluster roster.
+func (s *Service) WithHMPinStickyOnArmSelectorUnavail(enabled bool) *Service {
+	s.hmPinStickyOnArmSelectorUnavail = enabled
 	return s
 }
 

--- a/internal/proxy/turnloop.go
+++ b/internal/proxy/turnloop.go
@@ -187,11 +187,22 @@ const hmmPinStickyArmSelectorUnavailReason = "hmm_pin_sticky_arm_selector_unavai
 // draw without a schema bump. Keep in sync across the Python/Go boundary.
 const hmmArmSelectorUnavailableSentinel = "[pin_sticky_override_eligible]"
 
+// decisionPolicyGroup returns the policy cluster/group a decision was drawn
+// from, or "" for reconstructed pins and routers that report no group.
+func decisionPolicyGroup(dec router.Decision) string {
+	if dec.Metadata == nil {
+		return ""
+	}
+	return dec.Metadata.PolicyGroup
+}
+
 // stickPinOnArmSelectorUnavailable reports whether the active pin should override a fresh
 // authoritative-per-turn decision. Returns true only when the fresh Reason carries
 // hmmArmSelectorUnavailableSentinel — the arm-selector fell back to per-turn epsilon-greedy
 // draws over the full cluster roster (ArmSelectorUnavailableError), causing churn on every
 // tool_result turn. No tier check: the bandit draws within one cluster, not one catalog tier.
+// Both sides must report the SAME policy group, so a classifier escalation into a different
+// cluster still switches through even when that cluster's selector is also undertrained.
 func stickPinOnArmSelectorUnavailable(fresh router.Decision, pin sessionpin.Pin, pinFound, prefixBroken bool) bool {
 	if !pinFound || pin.Model == "" {
 		return false
@@ -200,6 +211,12 @@ func stickPinOnArmSelectorUnavailable(fresh router.Decision, pin sessionpin.Pin,
 		return false
 	}
 	if !strings.Contains(fresh.Reason, hmmArmSelectorUnavailableSentinel) {
+		return false
+	}
+	// Unknown group on either side means we cannot prove the reroute stayed in
+	// the pin's cluster, so fail open and let the fresh decision serve.
+	freshGroup := decisionPolicyGroup(fresh)
+	if freshGroup == "" || pin.PolicyGroup == "" || freshGroup != pin.PolicyGroup {
 		return false
 	}
 	if pin.Model == fresh.Model {
@@ -1371,9 +1388,12 @@ func (s *Service) refreshPin(ctx context.Context, installationID uuid.UUID, sess
 		Model:          chosen.Model,
 		// No scorer runs on a plain refresh, so carry the existing pair
 		// forward unchanged (ON CONFLICT preserves an empty one).
-		PairedProvider:        existing.PairedProvider,
-		PairedModel:           existing.PairedModel,
-		Reason:                chosen.Reason,
+		PairedProvider: existing.PairedProvider,
+		PairedModel:    existing.PairedModel,
+		Reason:         chosen.Reason,
+		// Same rationale as the pair above: a refresh runs no policy, so the
+		// reconstructed decision carries no group. Carry the stored one forward.
+		PolicyGroup:           existing.PolicyGroup,
 		TurnCount:             1,
 		PinnedUntil:           pinExpiry(chosen.Reason),
 		LastInputTokens:       existing.LastInputTokens,
@@ -1412,6 +1432,7 @@ func (s *Service) writeNewPin(ctx context.Context, installationID uuid.UUID, ses
 		PairedProvider: pairedProvider,
 		PairedModel:    pairedModel,
 		Reason:         chosen.Reason,
+		PolicyGroup:    decisionPolicyGroup(chosen),
 		TurnCount:      1,
 		PinnedUntil:    pinExpiry(chosen.Reason),
 	}

--- a/internal/proxy/turnloop.go
+++ b/internal/proxy/turnloop.go
@@ -179,6 +179,60 @@ const (
 	hmmReasonPhaseChange          = "hmm_phase_change"
 )
 
+// hmmPinStickyArmSelectorUnavailReason is the PinTier value recorded when a
+// same-cluster reroute is suppressed because it came from
+// hmmArmSelectorUnavailableSentinel fallback noise rather than a real
+// scorer decision.
+const hmmPinStickyArmSelectorUnavailReason = "hmm_pin_sticky_arm_selector_unavailable"
+
+// hmmArmSelectorUnavailableSentinel mirrors
+// ml_dev.hmm_router.route_selector.PIN_STICKY_OVERRIDE_ELIGIBLE_SENTINEL.
+// The sidecar's Reason string is opaque to Go, so a substring match is the
+// cheapest way to detect "this fresh decision is a legacy-pairwise-bandit
+// fallback draw, not a contextual-arm-selector decision" without a schema
+// bump. Keep these two constants in sync across the Python/Go boundary.
+const hmmArmSelectorUnavailableSentinel = "[pin_sticky_override_eligible]"
+
+// stickPinOnArmSelectorUnavailable reports whether an authoritative-per-turn
+// HMM decision should be suppressed in favor of the active pin. It exists
+// because the contextual arm-selector falls back to a per-turn
+// epsilon-greedy bandit draw over the WHOLE cluster roster whenever fewer
+// than two roster arms have real training data in that cluster
+// (arm_selector.py's ArmSelectorUnavailableError) — with
+// authoritative-per-turn selection this fallback re-rolls independently on
+// every tool_result turn, producing visible mid-conversation churn between
+// arms nobody trained a preference between. A genuine EV upgrade, tier
+// change, or cache-breaking event must still switch normally, so this only
+// fires when the fresh decision itself carries the fallback sentinel.
+//
+// NOTE on tier check: the legacy pairwise bandit draws only within one
+// cluster's roster (roster_arms = self.roster.arms_for(cluster) at
+// route_selector.py:358, then bandit.choose(eligible_arms=eligible_arms) at
+// :432) — so the reroute is ALWAYS within the same cluster. A catalog-tier
+// mismatch between pin and fresh is NOT necessarily evidence of an upgrade:
+// in the prod incident the cluster was 'high' and the two candidates
+// (claude-sonnet-5 mid-tier, z-ai/glm-5.2 high-tier) are in DIFFERENT
+// catalog tiers despite being in the same HMM cluster. We gate on the
+// sentinel alone, not on tier.
+func stickPinOnArmSelectorUnavailable(fresh router.Decision, pin sessionpin.Pin, pinFound, prefixBroken bool) bool {
+	if !pinFound || pin.Model == "" {
+		return false
+	}
+	if !isHMMPinReason(pin.Reason) {
+		return false
+	}
+	if !strings.Contains(fresh.Reason, hmmArmSelectorUnavailableSentinel) {
+		return false
+	}
+	if pin.Model == fresh.Model {
+		return false
+	}
+	if prefixBroken {
+		return false
+	}
+	return true
+}
+
 func hmmHistoryRole(role string) string {
 	if role == "" {
 		role = sessionpin.DefaultRole
@@ -812,6 +866,20 @@ func (s *Service) runTurnLoop(
 	)
 	res.Fresh = fresh
 	if res.AuthoritativePerTurn {
+		if s.hmPinStickyOnArmSelectorUnavail && stickPinOnArmSelectorUnavailable(fresh, pin, pinFound, prefixBroken) {
+			decision := pinDecision(pin)
+			res.Decision = decision
+			res.StickyHit = true
+			res.PinTier = hmmPinStickyArmSelectorUnavailReason
+			log.Info("turnloop suppressed arm-selector-unavailable reroute; keeping session pin",
+				"pin_model", pin.Model,
+				"pin_provider", pin.Provider,
+				"fresh_model", fresh.Model,
+				"fresh_provider", fresh.Provider,
+			)
+			s.refreshPin(ctx, installationID, res.SessionKey, pin, res.PinRole, decision)
+			return res, nil
+		}
 		res.Decision = fresh
 		res.PinTier = "authoritative_per_turn"
 		s.writeNewPin(ctx, installationID, res.SessionKey, res.PinRole, fresh)

--- a/internal/proxy/turnloop.go
+++ b/internal/proxy/turnloop.go
@@ -197,12 +197,10 @@ func decisionPolicyGroup(dec router.Decision) string {
 }
 
 // stickPinOnArmSelectorUnavailable reports whether the active pin should override a fresh
-// authoritative-per-turn decision. Returns true only when the fresh Reason carries
-// hmmArmSelectorUnavailableSentinel — the arm-selector fell back to per-turn epsilon-greedy
-// draws over the full cluster roster (ArmSelectorUnavailableError), causing churn on every
-// tool_result turn. No tier check: the bandit draws within one cluster, not one catalog tier.
-// Both sides must report the SAME policy group, so a classifier escalation into a different
-// cluster still switches through even when that cluster's selector is also undertrained.
+// authoritative-per-turn decision when hmmArmSelectorUnavailableSentinel is present —
+// the arm-selector fell back to per-turn epsilon-greedy draws (ArmSelectorUnavailableError),
+// causing turn-to-turn churn. No tier check: the bandit draws within one cluster, not one
+// catalog tier; both groups must match so a genuine cluster escalation still switches through.
 func stickPinOnArmSelectorUnavailable(fresh router.Decision, pin sessionpin.Pin, pinFound, prefixBroken bool) bool {
 	if !pinFound || pin.Model == "" {
 		return false

--- a/internal/proxy/turnloop.go
+++ b/internal/proxy/turnloop.go
@@ -179,41 +179,19 @@ const (
 	hmmReasonPhaseChange          = "hmm_phase_change"
 )
 
-// hmmPinStickyArmSelectorUnavailReason is the PinTier value recorded when a
-// same-cluster reroute is suppressed because it came from
-// hmmArmSelectorUnavailableSentinel fallback noise rather than a real
-// scorer decision.
+// hmmPinStickyArmSelectorUnavailReason is the PinTier value when a reroute is suppressed by the arm-selector unavailable fallback.
 const hmmPinStickyArmSelectorUnavailReason = "hmm_pin_sticky_arm_selector_unavailable"
 
-// hmmArmSelectorUnavailableSentinel mirrors
-// ml_dev.hmm_router.route_selector.PIN_STICKY_OVERRIDE_ELIGIBLE_SENTINEL.
-// The sidecar's Reason string is opaque to Go, so a substring match is the
-// cheapest way to detect "this fresh decision is a legacy-pairwise-bandit
-// fallback draw, not a contextual-arm-selector decision" without a schema
-// bump. Keep these two constants in sync across the Python/Go boundary.
+// hmmArmSelectorUnavailableSentinel mirrors ml_dev.hmm_router.route_selector.PIN_STICKY_OVERRIDE_ELIGIBLE_SENTINEL.
+// Substring-matched against the sidecar's opaque Reason string to detect a legacy pairwise-bandit fallback
+// draw without a schema bump. Keep in sync across the Python/Go boundary.
 const hmmArmSelectorUnavailableSentinel = "[pin_sticky_override_eligible]"
 
-// stickPinOnArmSelectorUnavailable reports whether an authoritative-per-turn
-// HMM decision should be suppressed in favor of the active pin. It exists
-// because the contextual arm-selector falls back to a per-turn
-// epsilon-greedy bandit draw over the WHOLE cluster roster whenever fewer
-// than two roster arms have real training data in that cluster
-// (arm_selector.py's ArmSelectorUnavailableError) — with
-// authoritative-per-turn selection this fallback re-rolls independently on
-// every tool_result turn, producing visible mid-conversation churn between
-// arms nobody trained a preference between. A genuine EV upgrade, tier
-// change, or cache-breaking event must still switch normally, so this only
-// fires when the fresh decision itself carries the fallback sentinel.
-//
-// NOTE on tier check: the legacy pairwise bandit draws only within one
-// cluster's roster (roster_arms = self.roster.arms_for(cluster) at
-// route_selector.py:358, then bandit.choose(eligible_arms=eligible_arms) at
-// :432) — so the reroute is ALWAYS within the same cluster. A catalog-tier
-// mismatch between pin and fresh is NOT necessarily evidence of an upgrade:
-// in the prod incident the cluster was 'high' and the two candidates
-// (claude-sonnet-5 mid-tier, z-ai/glm-5.2 high-tier) are in DIFFERENT
-// catalog tiers despite being in the same HMM cluster. We gate on the
-// sentinel alone, not on tier.
+// stickPinOnArmSelectorUnavailable reports whether the active pin should override a fresh
+// authoritative-per-turn decision. Returns true only when the fresh Reason carries
+// hmmArmSelectorUnavailableSentinel — the arm-selector fell back to per-turn epsilon-greedy
+// draws over the full cluster roster (ArmSelectorUnavailableError), causing churn on every
+// tool_result turn. No tier check: the bandit draws within one cluster, not one catalog tier.
 func stickPinOnArmSelectorUnavailable(fresh router.Decision, pin sessionpin.Pin, pinFound, prefixBroken bool) bool {
 	if !pinFound || pin.Model == "" {
 		return false

--- a/internal/router/policy/sidecar_router.go
+++ b/internal/router/policy/sidecar_router.go
@@ -390,6 +390,7 @@ func (r *SidecarRouter) Route(ctx context.Context, req router.Request) (router.D
 			RouteID:                       routeID,
 			Strategy:                      string(strategy),
 			PolicyRouteKey:                res.PolicyRouteKey,
+			PolicyGroup:                   res.PolicyGroup,
 			PolicyArtifactID:              res.PolicyArtifactID,
 			PolicyArtifactSHA256:          res.PolicyArtifactSHA256,
 			RosterVersion:                 res.RosterVersion,

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -241,6 +241,10 @@ type RoutingMetadata struct {
 	// PolicyRouteKey is the generic policy-internal bucket/arm key used for
 	// online learning. HMM routing_bucket values map here.
 	PolicyRouteKey string
+	// PolicyGroup is the policy-internal cluster/group the decision was drawn
+	// from (HMM complexity cluster). Session pins persist it so a later turn can
+	// tell a within-cluster reroute from a genuine cluster change.
+	PolicyGroup string
 	// Policy artifact metadata identifies the immutable production package.
 	PolicyArtifactID     string
 	PolicyArtifactSHA256 string

--- a/internal/router/sessionpin/store.go
+++ b/internal/router/sessionpin/store.go
@@ -43,10 +43,9 @@ type Pin struct {
 	PairedProvider string
 	PairedModel    string
 	Reason         string
-	// PolicyGroup is the policy-internal cluster/group the pinned decision came
-	// from (HMM complexity cluster), copied from RoutingMetadata.PolicyGroup.
-	// Empty for non-policy pins. Comparing it to a fresh decision's group
-	// separates a within-cluster reroute from a genuine cluster change.
+	// PolicyGroup is the HMM complexity cluster the pinned decision came from
+	// (RoutingMetadata.PolicyGroup). Compared to the fresh decision's group to
+	// distinguish a within-cluster reroute from a genuine cluster change.
 	PolicyGroup               string
 	TurnCount                 int
 	PinnedUntil               time.Time

--- a/internal/router/sessionpin/store.go
+++ b/internal/router/sessionpin/store.go
@@ -40,9 +40,14 @@ type Pin struct {
 	// eviction) so the stored pair never goes stale. Empty for non-scorer pins
 	// or single-candidate routing; a later per-turn policy swaps between the
 	// pair without re-scoring.
-	PairedProvider            string
-	PairedModel               string
-	Reason                    string
+	PairedProvider string
+	PairedModel    string
+	Reason         string
+	// PolicyGroup is the policy-internal cluster/group the pinned decision came
+	// from (HMM complexity cluster), copied from RoutingMetadata.PolicyGroup.
+	// Empty for non-policy pins. Comparing it to a fresh decision's group
+	// separates a within-cluster reroute from a genuine cluster change.
+	PolicyGroup               string
 	TurnCount                 int
 	PinnedUntil               time.Time
 	FirstPinnedAt             time.Time

--- a/internal/sqlc/models.go
+++ b/internal/sqlc/models.go
@@ -445,6 +445,7 @@ type RouterSessionPin struct {
 	PairedModel               string
 	ConsecutiveOverloadErrors int32
 	DisabledProviders         []string
+	PolicyGroup               string
 }
 
 // Shadow-mode spiral (death-march) detections: log-only fire-rate corpus measured on live traffic before escalation is armed

--- a/internal/sqlc/session_pins.sql.go
+++ b/internal/sqlc/session_pins.sql.go
@@ -50,7 +50,7 @@ func (q *Queries) DisableSessionPinProvider(ctx context.Context, arg DisableSess
 }
 
 const getSessionPin = `-- name: GetSessionPin :one
-SELECT session_key, role, installation_id, pinned_provider, pinned_model, decision_reason, turn_count, pinned_until, first_pinned_at, last_seen_at, last_input_tokens, last_cached_read_tokens, last_cached_write_tokens, last_output_tokens, last_turn_ended_at, consecutive_upstream_errors, last_served_model, has_ever_switched, paired_provider, paired_model, consecutive_overload_errors, disabled_providers
+SELECT session_key, role, installation_id, pinned_provider, pinned_model, decision_reason, turn_count, pinned_until, first_pinned_at, last_seen_at, last_input_tokens, last_cached_read_tokens, last_cached_write_tokens, last_output_tokens, last_turn_ended_at, consecutive_upstream_errors, last_served_model, has_ever_switched, paired_provider, paired_model, consecutive_overload_errors, disabled_providers, policy_group
 FROM router.session_pins
 WHERE session_key = $1::bytea
   AND role        = $2::varchar
@@ -68,7 +68,7 @@ type GetSessionPinParams struct {
 // last_turn_ended_at carry the previous turn's upstream usage; the
 // planner reads them to weigh switch EV against eviction cost.
 //
-//	SELECT session_key, role, installation_id, pinned_provider, pinned_model, decision_reason, turn_count, pinned_until, first_pinned_at, last_seen_at, last_input_tokens, last_cached_read_tokens, last_cached_write_tokens, last_output_tokens, last_turn_ended_at, consecutive_upstream_errors, last_served_model, has_ever_switched, paired_provider, paired_model, consecutive_overload_errors, disabled_providers
+//	SELECT session_key, role, installation_id, pinned_provider, pinned_model, decision_reason, turn_count, pinned_until, first_pinned_at, last_seen_at, last_input_tokens, last_cached_read_tokens, last_cached_write_tokens, last_output_tokens, last_turn_ended_at, consecutive_upstream_errors, last_served_model, has_ever_switched, paired_provider, paired_model, consecutive_overload_errors, disabled_providers, policy_group
 //	FROM router.session_pins
 //	WHERE session_key = $1::bytea
 //	  AND role        = $2::varchar
@@ -98,6 +98,7 @@ func (q *Queries) GetSessionPin(ctx context.Context, arg GetSessionPinParams) (R
 		&i.PairedModel,
 		&i.ConsecutiveOverloadErrors,
 		&i.DisabledProviders,
+		&i.PolicyGroup,
 	)
 	return i, err
 }
@@ -323,12 +324,13 @@ const upsertSessionPin = `-- name: UpsertSessionPin :exec
 INSERT INTO router.session_pins (
   session_key, role, installation_id, pinned_provider,
   pinned_model, paired_provider, paired_model,
-  decision_reason, turn_count, pinned_until
+  decision_reason, policy_group, turn_count, pinned_until
 ) VALUES (
   $1::bytea, $2::varchar, $3::uuid,
   $4::varchar, $5::varchar,
   $6::varchar, $7::varchar,
-  $8::text, $9::int, $10::timestamp
+  $8::text, $9::varchar,
+  $10::int, $11::timestamp
 )
 ON CONFLICT (session_key, role) DO UPDATE SET
   pinned_provider = EXCLUDED.pinned_provider,
@@ -359,6 +361,13 @@ ON CONFLICT (session_key, role) DO UPDATE SET
       THEN router.session_pins.paired_model
     ELSE ''
   END,
+  policy_group = CASE
+    WHEN EXCLUDED.policy_group <> ''
+      THEN EXCLUDED.policy_group
+    WHEN EXCLUDED.pinned_model = router.session_pins.pinned_model
+      THEN router.session_pins.policy_group
+    ELSE ''
+  END,
   consecutive_upstream_errors = CASE
     WHEN router.session_pins.pinned_model = EXCLUDED.pinned_model
       THEN router.session_pins.consecutive_upstream_errors
@@ -385,6 +394,7 @@ type UpsertSessionPinParams struct {
 	PairedProvider string
 	PairedModel    string
 	DecisionReason string
+	PolicyGroup    string
 	TurnCount      int32
 	PinnedUntil    pgtype.Timestamp
 }
@@ -416,15 +426,22 @@ type UpsertSessionPinParams struct {
 // collapses pinned_model and paired_model onto the same slug. A later per-turn
 // swap policy reads the pair that matches the active decision.
 //
+// policy_group follows the same three-way maintenance: a fresh policy decision
+// supplies a non-empty group, a same-model refresh preserves the stored one, and
+// a model change without a group (force-model, loop-break, eviction) clears it.
+// The pin-sticky arm-selector guard compares it against the fresh decision's
+// group, so a stale group must never survive onto a different pinned model.
+//
 //	INSERT INTO router.session_pins (
 //	  session_key, role, installation_id, pinned_provider,
 //	  pinned_model, paired_provider, paired_model,
-//	  decision_reason, turn_count, pinned_until
+//	  decision_reason, policy_group, turn_count, pinned_until
 //	) VALUES (
 //	  $1::bytea, $2::varchar, $3::uuid,
 //	  $4::varchar, $5::varchar,
 //	  $6::varchar, $7::varchar,
-//	  $8::text, $9::int, $10::timestamp
+//	  $8::text, $9::varchar,
+//	  $10::int, $11::timestamp
 //	)
 //	ON CONFLICT (session_key, role) DO UPDATE SET
 //	  pinned_provider = EXCLUDED.pinned_provider,
@@ -455,6 +472,13 @@ type UpsertSessionPinParams struct {
 //	      THEN router.session_pins.paired_model
 //	    ELSE ''
 //	  END,
+//	  policy_group = CASE
+//	    WHEN EXCLUDED.policy_group <> ''
+//	      THEN EXCLUDED.policy_group
+//	    WHEN EXCLUDED.pinned_model = router.session_pins.pinned_model
+//	      THEN router.session_pins.policy_group
+//	    ELSE ''
+//	  END,
 //	  consecutive_upstream_errors = CASE
 //	    WHEN router.session_pins.pinned_model = EXCLUDED.pinned_model
 //	      THEN router.session_pins.consecutive_upstream_errors
@@ -480,6 +504,7 @@ func (q *Queries) UpsertSessionPin(ctx context.Context, arg UpsertSessionPinPara
 		arg.PairedProvider,
 		arg.PairedModel,
 		arg.DecisionReason,
+		arg.PolicyGroup,
 		arg.TurnCount,
 		arg.PinnedUntil,
 	)


### PR DESCRIPTION
## Problem

When the HMM sidecar's contextual arm-selector has fewer than two trained
arms in a cluster, it raises `ArmSelectorUnavailableError` and falls back to
a legacy epsilon-greedy pairwise bandit over the *whole* cluster roster. With
`authoritative_per_turn_selection=true` (the prod default), this fallback
runs fresh on every turn — including tool_result turns — so a session can be
rerouted to a different arm mid-conversation purely from an exploration draw,
with no memory of which arm the session is already on.

Traced from a real prod session: a session pinned to `claude-sonnet-5` in the
`high` cluster got rerouted to `z-ai/glm-5.2` on one tool_result turn, then
back to `claude-sonnet-5` on the next — a pure epsilon-draw artifact, not a
quality-driven switch.

## Fix

- `ml_dev/hmm_router/route_selector.py`: tags the fallback `reason` string
  with a `[pin_sticky_override_eligible]` sentinel, but only on the true
  `ArmSelectorUnavailableError` path (not `PAIRWISE_ALWAYS_CLUSTERS`, which
  should keep exploring).
- `internal/proxy/turnloop.go`: new `stickPinOnArmSelectorUnavailable`
  predicate, gated behind a new kill switch
  (`ROUTER_HMM_PIN_STICKY_ON_ARM_SELECTOR_UNAVAIL`, default `false`), wired
  into the `AuthoritativePerTurn` branch. Suppresses the reroute only when:
  the active pin is HMM-written, the fresh decision carries the sentinel,
  and the models differ. Any real EV/tier/cache-break switch is untouched.
  Deliberately does **not** gate on catalog tier — the real incident crossed
  catalog tiers (`claude-sonnet-5` mid, `z-ai/glm-5.2` high) while staying in
  the same HMM cluster, so a tier check would have missed it.

Off by default. Staging → prod rollout plan lives in the companion WorkWeave
PR/doc.

## Testing

- `wv mr tc`, `wv mr t` — full suite passes, no regressions.
- New Go tests: 8 cases on the pure predicate + 2 end-to-end
  `runTurnLoop` wiring cases (kill switch on/off).
- New Python test asserts the sentinel is present only on the true
  arm-selector-unavailable fallback path.