### PR TITLE
fix: codex router now routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,11 +169,21 @@ above.
 **Codex** (OpenAI CLI). `npx @workweave/router --codex` patches
 `~/.codex/config.toml` (or `<repo>/.codex/config.toml` with `--scope project`)
 with a managed `[model_providers.weave]` block and sets `model_provider = "weave"`.
-The provider requires Codex's existing ChatGPT OAuth login, which Codex forwards
-to the router for plan-based passthrough; the router key rides in an
-`X-Weave-Router-Key` HTTP header. Re-install and `--uninstall --codex`
-rewrite/remove only the managed block, leaving the rest of your Codex config
-untouched.
+The provider preserves Codex's existing ChatGPT OAuth login while the router
+key rides in an `X-Weave-Router-Key` HTTP header and the installer selects the
+HMM strategy for the public hosted endpoint. `--codex --local` and custom
+self-hosted URLs keep their router's configured default because the HMM
+sidecar is optional. HMM and forced selections in the native Codex family
+(`gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-5.6-luna`) use that OAuth credential;
+every other selected model uses its WorkWeave deployment or BYOK credential,
+matching the Claude Code plugin's model-to-credential dispatch.
+Codex does not load third-party slash-command files; send router directives
+with one leading space (for example, ` /force-model gpt-5.6-terra`). Re-install
+and `--uninstall --codex` rewrite/remove only the managed block, leaving the
+rest of your Codex config untouched. Invoke `$disable-routing` to switch the
+next Codex session back to its normal provider, or run
+`npx @workweave/router disable-routing` in a shell; a literal
+`/disable-routing` is not a third-party extension point in Codex.
 
 **opencode.** `npx @workweave/router --opencode` merges a `provider.weave`
 entry into `~/.config/opencode/opencode.json` (or `<repo>/opencode.json`

--- a/install/README.md
+++ b/install/README.md
@@ -70,6 +70,13 @@ the target flag:
 ./router/install/install.sh --codex --local --scope project    # team scope Codex
 ```
 
+Self-hosted routers, including the bundled local stack, may not run the optional
+HMM sidecar. For that reason, Codex `--local` and custom `--base-url` installs
+do not force a strategy header; they keep that router's configured default.
+Installs targeting the public `https://router.workweave.ai` endpoint select HMM
+automatically. A self-hosted HMM deployment can add
+`X-Weave-Router-Strategy: hmm` explicitly to its managed Codex config.
+
 ### Self-hosted on a custom URL
 
 ```bash
@@ -111,7 +118,7 @@ logged-in user's Team/Pro/Max/individual plan.
 
 | Path                       | Purpose                                                       |
 | -------------------------- | ------------------------------------------------------------- |
-| `~/.codex/config.toml`     | Adds a managed `[model_providers.weave]` block + sets top-level `model_provider = "weave"`, both between `# >>> weave-router managed` markers. The provider requires and forwards the existing ChatGPT OAuth login for plan-backed routing; anything outside the markers is preserved. |
+| `~/.codex/config.toml`     | Adds a managed `[model_providers.weave]` block + sets top-level `model_provider = "weave"`, both between `# >>> weave-router managed` markers. The provider preserves the existing ChatGPT OAuth login; the public hosted endpoint selects HMM while self-hosted URLs keep their router default. Anything outside the markers is preserved. |
 
 **Project scope (`--scope project`):**
 
@@ -126,6 +133,32 @@ up the project-local config instead of `~/.codex/`.
 Re-running the installer rewrites only the managed block (TOML between the
 markers + a top-level `model_provider =` outside it). Everything else —
 profiles, alternate providers, comments — stays untouched.
+
+Routing is model-aware after HMM or force-model selection. The native Codex
+models `gpt-5.6-sol`, `gpt-5.6-terra`, and `gpt-5.6-luna` use the caller's
+ChatGPT OAuth plan. Other OpenAI, Anthropic, Gemini, and OpenAI-compatible
+models use their matching WorkWeave deployment or BYOK credentials, just as
+they do when routed from Claude Code.
+
+Codex does not load third-party Markdown slash commands. To send a router
+directive, start the message with one literal space so Codex submits it as a
+normal prompt rather than consuming it as an unknown local command:
+
+```text
+ /force-model gpt-5.6-terra
+ /unforce-model
+ /rf - the previous response was too slow --label=high
+```
+
+To return to regular Codex, invoke the installer-provided Codex skill as
+`$disable-routing`. It runs the safe local off toggle, preserves the router
+configuration and ChatGPT OAuth, and takes effect when you start the next
+`codex` session. A literal `/disable-routing` is not possible because Codex
+reserves slash commands for its built-ins. The shell equivalent is:
+
+```bash
+npx --package @workweave/router -y -- weave-router disable-routing
+```
 
 ### opencode (`--opencode`)
 
@@ -188,6 +221,7 @@ instant. These never prompt for a key and require an explicit client:
 npx @workweave/router off --claude       # route Claude Code directly to Anthropic
 npx @workweave/router on --claude        # route Claude Code through the router again
 npx @workweave/router status --codex     # report whether Codex is on the router or direct
+npx @workweave/router disable-routing    # switch Codex back to its default provider
 npx @workweave/router off --opencode --scope project   # project-scoped opencode
 ```
 
@@ -229,10 +263,12 @@ errors invoking `cc-statusline.sh`. The script needs `jq` on PATH.
 
 1. Open `~/.codex/config.toml` (or `<repo>/.codex/config.toml` for project
    scope) and confirm the `# >>> weave-router managed >>>` block exists with
-   your `X-Weave-Router-Key`.
+   your `X-Weave-Router-Key`. Hosted installs also contain
+   `X-Weave-Router-Strategy = "hmm"`; self-hosted installs intentionally do not.
 2. Run `codex` and issue a turn. Provider should be `Weave Router`.
-3. Check the router's dashboard at `<base-url>/ui/dashboard` to see the
-   routed decision.
+3. Check the router's dashboard at `<base-url>/ui/dashboard` to see the HMM
+   routed decision; Codex's `/status` shows its request model, not the
+   upstream model selected by the router.
 
 **opencode:**
 

--- a/install/codex-skills/disable-routing/SKILL.md
+++ b/install/codex-skills/disable-routing/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: disable-routing
+description: "Switch Codex back to its normal provider for future sessions."
+---
+
+<!-- weave-router managed disable-routing skill -->
+
+# Disable Weave routing
+
+When the user invokes `$disable-routing`, switch the current Codex installation
+off the Weave Router without logging out or deleting its router configuration.
+
+1. Explain that the change takes effect on the next `codex` launch and that it
+   can later be reversed with `npx --package @workweave/router -y -- weave-router on --codex{{SCOPE}}`.
+2. Run exactly:
+
+   ```bash
+   npx --package @workweave/router -y -- weave-router off --codex{{SCOPE}}
+   ```
+
+3. Report the command result. Do not uninstall the router or alter any other
+   Codex settings.

--- a/install/install.sh
+++ b/install/install.sh
@@ -52,6 +52,7 @@
 #   npx @workweave/router off --claude                     # route directly to Anthropic again (Claude Code)
 #   npx @workweave/router on --codex                       # route through the Weave Router again (Codex)
 #   npx @workweave/router status --opencode                # report whether opencode is on the router or direct
+#   npx @workweave/router disable-routing                   # Codex shortcut: use Codex's normal provider again
 # Claude Code reads env at launch, so an off/on takes effect on the next
 # `claude` start; Codex and opencode re-read config every invocation.
 # Cursor's base URL lives in its own settings UI (no file we own), so there's
@@ -61,8 +62,9 @@ set -euo pipefail
 
 # ---------- defaults ----------
 
-# The hosted Weave Router URL. Override with --base-url for self-hosted.
-DEFAULT_BASE_URL="${WEAVE_ROUTER_URL:-https://router.workweave.ai}"
+# The public hosted Weave Router URL. Override with --base-url for self-hosted.
+HOSTED_BASE_URL="https://router.workweave.ai"
+DEFAULT_BASE_URL="${WEAVE_ROUTER_URL:-$HOSTED_BASE_URL}"
 
 
 scope="user"
@@ -88,6 +90,7 @@ target_explicit="false"
 # "status" toggle or report an existing install without touching the router
 # key/identity — see the toggle_* helpers and the dispatch block below.
 mode="install"
+disable_routing_alias="false"
 
 # ---------- helpers ----------
 
@@ -297,6 +300,7 @@ refuse_if_symlink() {
 # --codex) can find and replace the block instead of duplicating it.
 WEAVE_CODEX_BEGIN_MARKER="# >>> weave-router managed (do not edit between markers) >>>"
 WEAVE_CODEX_END_MARKER="# <<< weave-router managed <<<"
+WEAVE_CODEX_SKILL_MARKER="<!-- weave-router managed disable-routing skill -->"
 
 # ---------- identity helpers ----------
 #
@@ -416,9 +420,11 @@ resolve_user_email() {
 # write_codex_config writes a managed [model_providers.weave] block to the
 # Codex CLI's config.toml. Sets `model_provider = "weave"` at the top level so
 # Codex picks the routed provider by default. The provider requires OpenAI
-# authentication, preserving the user's ChatGPT plan credential and forwarding
-# it to the router alongside the router key. Both settings live inside the
-# managed-block markers so uninstall removes them cleanly. We strip any
+# authentication, preserving the user's ChatGPT plan credential while the
+# router key is sent independently. The router applies OAuth only to its
+# native gpt-5.6 Sol/Terra/Luna family; all other routed models use WorkWeave
+# deployment or BYOK credentials. Both settings live inside the managed-block
+# markers so uninstall removes them cleanly. We strip any
 # top-level `model_provider = ...` declaration OUTSIDE the markers before
 # appending so the file doesn't end up with a duplicate key (TOML rejects
 # that). Inline `model_provider` keys inside `[profiles.*]` sections stay
@@ -464,6 +470,14 @@ write_codex_config() {
   # that share the same router key. The router otherwise has to guess from
   # User-Agent.
   headers_parts="${headers_parts}, \"X-App\" = \"codex\""
+  # Match the public hosted Claude Code installation: Codex needs this
+  # explicit policy selection because that endpoint otherwise uses its
+  # cluster default. Self-hosted endpoints may not run the optional HMM
+  # sidecar, so every custom URL deliberately keeps the router's own default.
+  # Keep this inside the managed block so a re-install can change it safely.
+  if [ "$block_url" = "$HOSTED_BASE_URL" ]; then
+    headers_parts="${headers_parts}, \"X-Weave-Router-Strategy\" = \"hmm\""
+  fi
   local headers_line="http_headers = { ${headers_parts} }"
 
   local block
@@ -947,6 +961,12 @@ while [ $# -gt 0 ]; do
       # npm wrapper forwards argv verbatim so either form reaches us.
       mode="${1#--}"; shift
       ;;
+    disable-routing|--disable-routing)
+      # Convenience alias for the Codex-specific off toggle. Unlike generic
+      # `off`, it deliberately resolves the target after all flags are parsed,
+      # so `disable-routing --claude` cannot silently change Claude settings.
+      mode="off"; disable_routing_alias="true"; shift
+      ;;
     -h|--help)
       usage 0
       ;;
@@ -955,6 +975,15 @@ while [ $# -gt 0 ]; do
       ;;
   esac
 done
+
+if [ "$disable_routing_alias" = "true" ]; then
+  if [ "$target_explicit" = "true" ] && [ "$target" != "codex" ]; then
+    err "disable-routing only applies to Codex; omit the client flag or use --codex."
+    exit 2
+  fi
+  target="codex"
+  target_explicit="true"
+fi
 
 # Toggle verbs only flip config install.sh already wrote: no key, no identity,
 # no prompts. Require an explicit client so we never guess which config to
@@ -1684,19 +1713,21 @@ else
   info "No identity set — router traffic will be attributed by account UUID only."
 fi
 
-# ---------- slash command wrappers (shared by both targets) ----------
+# ---------- slash command wrappers (Claude Code and opencode) ----------
 #
-# Claude Code intercepts any prompt starting with "/" as a local slash command,
-# so a typed /force-model would resolve to "Unknown command" and never reach
-# the router. Codex CLI does the same (its built-in / menu has its own set).
-# Drop wrapper markdown files into the per-target commands directory so the
-# slash invocation expands locally into a literal "/force-model …" prompt that
-# the router's first-line parser picks up.
+# Claude Code and opencode expand command Markdown locally rather than sending
+# the literal invocation to the model, so they need wrappers that expand to a
+# router directive.
 #
 # Layout:
 #   Claude:  <settings_dir>/commands/{force-model,unforce-model}.md  → /force-model
-#   Codex:   <codex_dir>/prompts/{force-model,unforce-model}.md      → /prompts:force-model
 #   opencode: <commands_dir>/{force-model,unforce-model}.md          → /force-model
+#
+# Codex intentionally is not listed: its slash menu only exposes built-in
+# commands and does not load these Markdown wrappers. A user can send a router
+# directive by starting it with one literal space (for example,
+# ` /force-model gpt-5.6-terra`); Codex submits the trimmed prompt to the
+# router without interpreting it as a local slash command.
 #
 # Files come from install/commands/ in the repo (or the colocated commands/
 # directory the npm package ships alongside install.sh).
@@ -1719,11 +1750,11 @@ install_slash_commands() {
   fi
   mkdir -p "$dst_dir"
 
-  # force-model/unforce-model are router-intercepted prompt expansions and
-  # apply to every target. The router-off/on/status wrappers shell out to this
-  # installer to flip the *local* config, so they're Claude Code-only and need
-  # the install scope baked into the command (the .md can't discover it at
-  # invocation time). {{SCOPE}} is substituted accordingly.
+  # force-model/unforce-model are router-intercepted prompt expansions for the
+  # command-capable clients. The router-off/on/status wrappers shell out to
+  # this installer to flip the *local* config, so they're Claude Code-only and
+  # need the install scope baked into the command (the .md can't discover it
+  # at invocation time). {{SCOPE}} is substituted accordingly.
   installed="force-model, unforce-model, router-feedback, fm, ufm, rf"
   cmds="force-model unforce-model router-feedback fm ufm rf"
   if [ "$target" = "claude" ]; then
@@ -1758,12 +1789,103 @@ install_slash_commands() {
   ok "Slash commands written to $dst_dir ($installed)"
 }
 
+# Codex builds before custom prompt discovery existed were given wrapper files
+# under ~/.codex/prompts. They were never invocable as the advertised aliases.
+# Remove only byte-for-byte copies of our old wrappers; retain any prompt the
+# user has changed or created independently.
+remove_obsolete_codex_prompt_wrappers() {
+  local dst_dir="$1"
+  local commands_src_dir=""
+  local candidate cmd src dst
+
+  [ -d "$dst_dir" ] || return 0
+  for candidate in \
+    "$script_dir/commands" \
+    "$script_dir/../commands"
+  do
+    if [ -d "$candidate" ]; then
+      commands_src_dir="$candidate"
+      break
+    fi
+  done
+  [ -n "$commands_src_dir" ] || return 0
+
+  if [ "$scope" = "project" ] || [ -n "$install_dir" ]; then
+    refuse_if_symlink "$dst_dir"
+  fi
+
+  for cmd in force-model unforce-model router-feedback fm ufm rf; do
+    src="$commands_src_dir/$cmd.md"
+    dst="$dst_dir/$cmd.md"
+    [ -f "$src" ] && [ -f "$dst" ] || continue
+    # A symlink is user-controlled at user scope. Leave it untouched; project
+    # scope rejects it through the same guard used by normal installs.
+    [ -L "$dst" ] && continue
+    if [ "$scope" = "project" ] || [ -n "$install_dir" ]; then
+      refuse_if_symlink "$dst"
+    fi
+    cmp -s "$src" "$dst" && rm -f "$dst"
+  done
+  rmdir "$dst_dir" 2>/dev/null || true
+}
+
+# Codex skills are the supported local extension surface for an action that
+# must edit Codex's configuration. A literal third-party slash command cannot
+# do this because Codex reserves `/…` for built-ins. The skill is invoked as
+# `$disable-routing`, asks Codex to run the existing safe toggle, and leaves
+# the managed router block in place for a later re-enable.
+install_codex_disable_routing_skill() {
+  local skill_src=""
+  local candidate dst_dir dst_file scope_args body
+  for candidate in \
+    "$script_dir/codex-skills/disable-routing/SKILL.md" \
+    "$script_dir/../codex-skills/disable-routing/SKILL.md"
+  do
+    if [ -f "$candidate" ]; then
+      skill_src="$candidate"
+      break
+    fi
+  done
+  [ -n "$skill_src" ] || { warn "Codex disable-routing skill template is missing; router configuration is still installed."; return 0; }
+  grep -Fq "$WEAVE_CODEX_SKILL_MARKER" "$skill_src" \
+    || { warn "Codex disable-routing skill template has no ownership marker; leaving skills unchanged."; return 0; }
+
+  dst_dir="$codex_dir/skills/disable-routing"
+  dst_file="$dst_dir/SKILL.md"
+  if [ "$scope" = "project" ] || [ -n "$install_dir" ]; then
+    refuse_if_symlink "$codex_dir/skills"
+    refuse_if_symlink "$dst_dir"
+    refuse_if_symlink "$dst_file"
+  elif [ -L "$codex_dir/skills" ] || [ -L "$dst_dir" ] || [ -L "$dst_file" ]; then
+    warn "Codex disable-routing skill path contains a symlink; leaving it untouched."
+    return 0
+  fi
+  if [ -e "$dst_file" ] && { [ ! -f "$dst_file" ] || ! grep -Fq "$WEAVE_CODEX_SKILL_MARKER" "$dst_file"; }; then
+    warn "A user-owned Codex disable-routing skill already exists at $dst_file; leaving it untouched."
+    return 0
+  fi
+  mkdir -p "$dst_dir"
+
+  scope_args=""
+  if [ -n "$install_dir" ]; then
+    scope_args=" --dir $(printf '%q' "$install_dir")"
+  elif [ "$scope" = "project" ]; then
+    scope_args=" --scope project"
+  fi
+  body="$(<"$skill_src")"
+  body="${body//\{\{SCOPE\}\}/$scope_args}"
+  printf '%s\n' "$body" >"$dst_file"
+  ok "Codex skill installed: \$disable-routing"
+}
+
 # ---------- codex install path (dispatch + exit before the Claude-only writes) ----------
 
 if [ "$target" = "codex" ]; then
   write_codex_config "$codex_config_file" "$base_url" "$api_key" "$user_email" "$user_name"
   ok "Codex config written to $codex_config_file"
-  install_slash_commands "$codex_dir/prompts"
+  remove_obsolete_codex_prompt_wrappers "$codex_dir/prompts"
+  install_codex_disable_routing_skill
+  info "Codex router directives: begin the message with one space, e.g. ' /force-model gpt-5.6-terra'."
 
   # Project scope: ensure the per-teammate config (which holds the router key)
   # is gitignored. The base URL is the same for every teammate, so a

--- a/install/npm/README.md
+++ b/install/npm/README.md
@@ -32,6 +32,9 @@ npx @workweave/router status --codex    # is Codex on the router or direct?
 Claude Code reads its router setting at launch, so quit and reopen it after an
 on/off. Codex and opencode pick it up on their next run. Inside Claude Code the
 slash commands `/router-off`, `/router-on`, and `/router-status` do the same.
+Codex installs a `$disable-routing` skill that switches its next session back
+to the normal provider; Codex does not support third-party `/disable-routing`
+slash commands. The shell equivalent is `npx @workweave/router disable-routing`.
 Cursor has no config file we own — toggle its base URL override in **Settings →
 Models** instead.
 
@@ -62,11 +65,19 @@ Four install targets:
   api.anthropic.com.
 - **Codex** (`--codex`) — patches `~/.codex/config.toml` (or
   `<repo>/.codex/config.toml`) with a managed `[model_providers.weave]`
-  block plus `model_provider = "weave"`. The provider requires and forwards
-  the existing ChatGPT OAuth login for plan-backed routing. The block lives
-  between begin/end markers so re-running the installer rewrites it cleanly
-  and `--uninstall --codex` removes it without touching the rest of your
-  config.
+  block plus `model_provider = "weave"`. The provider preserves the existing
+  ChatGPT OAuth login. The public hosted endpoint sends
+  `X-Weave-Router-Strategy: hmm`; `--local` and custom self-hosted URLs keep
+  their router's configured default because its HMM sidecar is optional. HMM or forced
+  `gpt-5.6-sol`, `gpt-5.6-terra`, and `gpt-5.6-luna` turns use that plan;
+  every other selected model uses its WorkWeave deployment or BYOK credential.
+  The block lives between begin/end markers
+  so re-running the installer rewrites it cleanly and `--uninstall --codex`
+  removes it without touching the rest of your config. Codex does not load
+  third-party slash-command files; to send a router directive, type it with
+  one leading space (for example, ` /force-model gpt-5.6-terra`). Its
+  `$disable-routing` skill returns the next Codex session to the default
+  provider without logging out or deleting the router configuration.
 - **opencode** (`--opencode`) — merges a `provider.weave` entry (backed by
   opencode's built-in `@ai-sdk/anthropic` provider) into
   `~/.config/opencode/opencode.json` (or `<repo>/opencode.json` with

--- a/install/npm/codex-skills/disable-routing/SKILL.md
+++ b/install/npm/codex-skills/disable-routing/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: disable-routing
+description: "Switch Codex back to its normal provider for future sessions."
+---
+
+<!-- weave-router managed disable-routing skill -->
+
+# Disable Weave routing
+
+When the user invokes `$disable-routing`, switch the current Codex installation
+off the Weave Router without logging out or deleting its router configuration.
+
+1. Explain that the change takes effect on the next `codex` launch and that it
+   can later be reversed with `npx --package @workweave/router -y -- weave-router on --codex{{SCOPE}}`.
+2. Run exactly:
+
+   ```bash
+   npx --package @workweave/router -y -- weave-router off --codex{{SCOPE}}
+   ```
+
+3. Report the command result. Do not uninstall the router or alter any other
+   Codex settings.

--- a/install/npm/package.json
+++ b/install/npm/package.json
@@ -17,6 +17,7 @@
     "uninstall.sh",
     "cc-statusline.sh",
     "commands/",
+    "codex-skills/",
     "pi-router/",
     "opencode-weave/",
     "README.md",

--- a/install/npm/scripts/copy-installer.js
+++ b/install/npm/scripts/copy-installer.js
@@ -42,6 +42,18 @@ for (const f of readdirSync(commandsSrc)) {
   console.log(`Copied commands/${f}.`);
 }
 
+// Codex discovers local skills under $CODEX_HOME/skills. Bundle the one
+// installer-owned template explicitly, refusing a source symlink just as the
+// command-file packaging path above does.
+const codexSkillSrc = path.join(installDir, "codex-skills", "disable-routing", "SKILL.md");
+const codexSkillDst = path.join(root, "codex-skills", "disable-routing", "SKILL.md");
+if (lstatSync(codexSkillSrc).isSymbolicLink()) {
+  throw new Error(`Refusing to package symlinked Codex skill: ${codexSkillSrc}`);
+}
+mkdirSync(path.dirname(codexSkillDst), { recursive: true });
+copyFileSync(codexSkillSrc, codexSkillDst);
+console.log("Copied codex-skills/disable-routing/SKILL.md.");
+
 // Bundle the pi extension so the single @workweave/router package is BOTH the
 // installer and the pi-router extension: pi loads it via the "pi.extensions"
 // field in package.json, and install.sh adds `npm:@workweave/router` to pi's

--- a/install/tests/codex_install_test.sh
+++ b/install/tests/codex_install_test.sh
@@ -1,23 +1,50 @@
 #!/usr/bin/env bash
 #
-# Regression tests for Codex installation. The loopback endpoint keeps router
-# validation local, and an isolated HOME prevents changes to real config.
+# Regression tests for Codex installation. A fake curl keeps validation
+# offline, and an isolated HOME prevents changes to real config.
 
 set -euo pipefail
 
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 installer="${INSTALLER:-$script_dir/../install.sh}"
 [ -f "$installer" ] || { echo "cannot find installer at $installer" >&2; exit 1; }
+uninstaller="${UNINSTALLER:-$(dirname "$installer")/uninstall.sh}"
+[ -f "$uninstaller" ] || { echo "cannot find uninstaller at $uninstaller" >&2; exit 1; }
 
 work="$(mktemp -d)"
 trap 'rm -rf "$work"' EXIT
 home="$work/home"
-mkdir -p "$home"
+fake_bin="$work/bin"
+mkdir -p "$home" "$fake_bin"
+printf '%s\n' '#!/usr/bin/env bash' 'exit 22' >"$fake_bin/curl"
+chmod +x "$fake_bin/curl"
+test_path="$fake_bin:$PATH"
+
+run_hosted_install() {
+  HOME="$home" PATH="$test_path" WEAVE_ROUTER_KEY="rk_test_key" NO_COLOR=1 \
+    bash "$installer" --codex --scope user --quiet \
+      --base-url https://router.workweave.ai
+}
 
 run_install() {
-  HOME="$home" WEAVE_ROUTER_KEY="rk_test_key" NO_COLOR=1 \
+  HOME="$home" PATH="$test_path" WEAVE_ROUTER_KEY="rk_test_key" NO_COLOR=1 \
     bash "$installer" --codex --scope user --quiet \
       --base-url http://127.0.0.1:9
+}
+
+run_local_install() {
+  HOME="$home" PATH="$test_path" WEAVE_ROUTER_KEY="rk_test_key" NO_COLOR=1 \
+    bash "$installer" --codex --scope user --quiet --local
+}
+
+run_disable_routing() {
+  HOME="$home" PATH="$test_path" NO_COLOR=1 \
+    bash "$installer" disable-routing --scope user --quiet
+}
+
+run_uninstall() {
+  HOME="$home" PATH="$test_path" NO_COLOR=1 \
+    bash "$uninstaller" --codex --scope user
 }
 
 fail() {
@@ -25,17 +52,87 @@ fail() {
   exit 1
 }
 
-run_install
+# Old installer versions placed Markdown wrappers here, but current Codex does
+# not discover them as slash commands. The upgrade must remove only those
+# canonical files and leave unrelated user prompts alone.
+mkdir -p "$home/.codex/prompts"
+for command in force-model unforce-model router-feedback fm ufm rf; do
+  cp "$script_dir/../commands/$command.md" "$home/.codex/prompts/$command.md"
+done
+printf '%s\n' 'user-authored prompt' >"$home/.codex/prompts/keep-me.md"
+
+run_hosted_install
 config="$home/.codex/config.toml"
 [ -f "$config" ] || fail "Codex config was not created"
 grep -qx 'model_provider = "weave"' "$config" \
   || fail "Weave was not selected as the default provider"
 grep -qx 'requires_openai_auth = true' "$config" \
   || fail "Weave provider does not require ChatGPT OAuth"
+grep -Fq '"X-Weave-Router-Strategy" = "hmm"' "$config" \
+  || fail "Codex provider does not select HMM routing"
+
+# Self-hosted routers may not have the optional HMM sidecar. Both --local and
+# a custom --base-url must keep the router's own default instead of forcing a
+# 503, while a later public-hosted install restores the explicit HMM header.
+run_local_install
+grep -Fq 'base_url = "http://localhost:8080/v1"' "$config" \
+  || fail "Codex --local did not select the local router"
+if grep -Fq 'X-Weave-Router-Strategy' "$config"; then
+  fail "Codex --local forced the optional HMM strategy"
+fi
+run_install
+grep -Fq 'base_url = "http://127.0.0.1:9/v1"' "$config" \
+  || fail "Codex custom --base-url was not preserved"
+if grep -Fq 'X-Weave-Router-Strategy' "$config"; then
+  fail "Codex custom --base-url forced the optional HMM strategy"
+fi
+run_hosted_install
+grep -Fq '"X-Weave-Router-Strategy" = "hmm"' "$config" \
+  || fail "public-hosted Codex reinstall did not restore HMM routing"
+
+# The stale wrappers must no longer suggest unsupported `/prompts:*` aliases.
+for command in force-model unforce-model router-feedback fm ufm rf; do
+  prompt="$home/.codex/prompts/$command.md"
+  [ ! -e "$prompt" ] || fail "obsolete Codex $command prompt was not removed"
+done
+[ -f "$home/.codex/prompts/keep-me.md" ] \
+  || fail "installer removed an unrelated Codex prompt"
+
+skill="$home/.codex/skills/disable-routing/SKILL.md"
+[ -f "$skill" ] || fail "Codex disable-routing skill was not installed"
+grep -Fq '<!-- weave-router managed disable-routing skill -->' "$skill" \
+  || fail "Codex disable-routing skill has no ownership marker"
+grep -Fq 'weave-router off --codex' "$skill" \
+  || fail "Codex disable-routing skill does not use the safe off toggle"
+if HOME="$home" PATH="$test_path" NO_COLOR=1 bash "$installer" disable-routing --claude --scope user --quiet >/dev/null 2>&1; then
+  fail "disable-routing accepted a non-Codex target"
+fi
+
+# The alias must pick Codex even without a --codex flag and return a later
+# process to Codex's default provider without removing the managed block.
+run_disable_routing
+grep -qx '# model_provider = "weave"  # weave-router: off (run on to re-enable)' "$config" \
+  || fail "disable-routing did not turn off the Codex provider"
+[ "$(grep -c '^\[model_providers\.weave\]$' "$config")" -eq 1 ] \
+  || fail "disable-routing removed or duplicated the managed provider"
 
 # A repeat install must refresh one managed block, not duplicate its auth rule.
-run_install
+run_hosted_install
 [ "$(grep -cx 'requires_openai_auth = true' "$config")" -eq 1 ] \
   || fail "repeat install duplicated the OAuth requirement"
 
-echo "Codex installer OAuth regression tests passed"
+run_uninstall
+[ ! -e "$skill" ] || fail "uninstall did not remove the Codex disable-routing skill"
+
+# A same-named user skill is not ours to overwrite or remove. This also
+# covers an upgrade on a machine where the name was already taken.
+mkdir -p "$(dirname "$skill")"
+printf '%s\n' 'user-authored skill' >"$skill"
+run_hosted_install
+grep -qx 'user-authored skill' "$skill" \
+  || fail "install overwrote a user-owned Codex disable-routing skill"
+run_uninstall
+grep -qx 'user-authored skill' "$skill" \
+  || fail "uninstall removed a user-owned Codex disable-routing skill"
+
+echo "Codex installer routing regression tests passed"

--- a/install/uninstall.sh
+++ b/install/uninstall.sh
@@ -30,6 +30,7 @@ install_dir=""
 target="claude"
 
 err()  { printf "\033[31merror:\033[0m %s\n" "$*" >&2; }
+warn() { printf "\033[33mwarning:\033[0m %s\n" "$*" >&2; }
 info() { printf "\033[36m==>\033[0m %s\n" "$*"; }
 ok()   { printf "\033[32m✓\033[0m %s\n" "$*"; }
 
@@ -91,6 +92,7 @@ fi
 # Markers must stay in sync with install.sh. Keep verbatim.
 WEAVE_CODEX_BEGIN_MARKER="# >>> weave-router managed (do not edit between markers) >>>"
 WEAVE_CODEX_END_MARKER="# <<< weave-router managed <<<"
+WEAVE_CODEX_SKILL_MARKER="<!-- weave-router managed disable-routing skill -->"
 
 # strip_codex_block rewrites config.toml without the managed block and any
 # top-level `model_provider = "weave"` that lived outside the markers (which
@@ -434,6 +436,26 @@ if [ "$target" = "codex" ]; then
       fi
     done
     rmdir "$codex_prompts_dir" 2>/dev/null || true
+  fi
+
+  # The installer-owned skill switches Codex back to its normal provider. It
+  # is separate from config.toml, so remove it when removing the router too.
+  # A same-named skill without our marker belongs to the user and is preserved.
+  codex_skill_dir="$codex_dir/skills/disable-routing"
+  codex_skill_file="$codex_skill_dir/SKILL.md"
+  if [ -d "$codex_skill_dir" ]; then
+    refuse_if_symlink "$codex_skill_dir"
+    if [ -f "$codex_skill_file" ]; then
+      refuse_if_symlink "$codex_skill_file"
+      if grep -Fq "$WEAVE_CODEX_SKILL_MARKER" "$codex_skill_file"; then
+        rm -f "$codex_skill_file"
+        ok "Removed $codex_skill_file"
+      else
+        warn "Leaving user-owned Codex skill at $codex_skill_file untouched."
+      fi
+    fi
+    rmdir "$codex_skill_dir" 2>/dev/null || true
+    rmdir "$codex_dir/skills" 2>/dev/null || true
   fi
 
   if [ -n "$install_dir" ]; then

--- a/internal/providers/openai/client.go
+++ b/internal/providers/openai/client.go
@@ -170,6 +170,15 @@ func (c *Client) setAuth(ctx context.Context, upstream *http.Request, inbound *h
 		upstream.Header.Set("Authorization", "Bearer "+c.apiKey)
 		return
 	}
+	// A ChatGPT OAuth bearer is valid only against the Codex backend. When
+	// model-aware credential resolution deliberately suppresses it for an
+	// infrastructure-served OpenAI model, never let the generic passthrough
+	// tier relay the same bearer to api.openai.com. Inspect the complete
+	// credential shape: an ordinary sk- API key remains a client credential
+	// even if a caller also supplied a stray ChatGPT-Account-ID header.
+	if creds := proxy.ExtractClientCredentials(providers.ProviderOpenAI, inbound.Header); creds != nil && creds.OAuth {
+		return
+	}
 	v := inbound.Header.Get("authorization")
 	if v == "" {
 		return
@@ -191,6 +200,9 @@ func (c *Client) Proxy(ctx context.Context, decision router.Decision, prep provi
 	// that happens to resolve a Codex credential never hits the Codex
 	// /responses endpoint (Responses schema only).
 	codexCreds := codexSubscriptionCreds(ctx)
+	if codexCreds != nil && !proxy.CodexSubscriptionCoversModel(decision.Model) {
+		return fmt.Errorf("refusing Codex subscription credential for infrastructure model %q", decision.Model)
+	}
 	useCodex := codexCreds != nil && prep.Endpoint == providers.EndpointResponses
 	// A BYOK key may point at a customer-hosted OpenAI-compatible endpoint; the
 	// Codex branch below still wins, since a Codex subscription bearer only

--- a/internal/providers/openai/codex_internal_test.go
+++ b/internal/providers/openai/codex_internal_test.go
@@ -48,13 +48,13 @@ func TestProxy_CodexSubscriptionDispatch(t *testing.T) {
 	c := NewClient("deployment-key", upstream.URL)
 	c.codexBaseURL = upstream.URL // point the Codex backend at the test server
 
-	body := []byte(`{"model":"gpt-5.5","input":"hi","stream":true}`)
+	body := []byte(`{"model":"gpt-5.6-sol","input":"hi","stream":true}`)
 	prep := providers.PreparedRequest{Body: body, Endpoint: providers.EndpointResponses, Headers: make(http.Header)}
 	rec := httptest.NewRecorder()
 	clientReq := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(""))
 
 	ctx := codexCtx("eyJhbGciOiJ-codex-jwt", "acct-12345")
-	err := c.Proxy(ctx, router.Decision{Model: "gpt-5.5", Provider: providers.ProviderOpenAI}, prep, rec, clientReq)
+	err := c.Proxy(ctx, router.Decision{Model: "gpt-5.6-sol", Provider: providers.ProviderOpenAI}, prep, rec, clientReq)
 	require.NoError(t, err)
 
 	assert.Equal(t, "/responses", gotPath, "a Codex subscription turn must hit the Codex backend's /responses endpoint, not api.openai.com")
@@ -64,6 +64,28 @@ func TestProxy_CodexSubscriptionDispatch(t *testing.T) {
 	assert.Equal(t, "codex_cli_rs", gotOriginator)
 	assert.Empty(t, rec.Header().Get("x-api-key"))
 	assert.Equal(t, body, gotBody, "the prepared Responses body must reach the Codex backend unchanged")
+}
+
+func TestProxy_CodexSubscriptionCredentialRejectsInfrastructureModel(t *testing.T) {
+	c := NewClient("deployment-key", "https://api.openai.example")
+	prep := providers.PreparedRequest{
+		Body:     []byte(`{"model":"gpt-5.4-nano","input":"hi"}`),
+		Endpoint: providers.EndpointResponses,
+		Headers:  make(http.Header),
+	}
+	rec := httptest.NewRecorder()
+	clientReq := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(""))
+
+	err := c.Proxy(
+		codexCtx("eyJhbGciOiJ-codex-jwt", "acct-12345"),
+		router.Decision{Model: "gpt-5.4-nano", Provider: providers.ProviderOpenAI},
+		prep,
+		rec,
+		clientReq,
+	)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "refusing Codex subscription credential")
 }
 
 // TestProxy_CodexCredOnChatEndpointDoesNotMisroute guards the Bugbot finding:
@@ -84,12 +106,12 @@ func TestProxy_CodexCredOnChatEndpointDoesNotMisroute(t *testing.T) {
 	c.codexBaseURL = "https://chatgpt.example.invalid" // must NOT be used for a chat body
 
 	// EndpointChatCompletions (zero value) — a chat-shaped body.
-	prep := providers.PreparedRequest{Body: []byte(`{"model":"gpt-5.5","messages":[]}`), Headers: make(http.Header)}
+	prep := providers.PreparedRequest{Body: []byte(`{"model":"gpt-5.6-sol","messages":[]}`), Headers: make(http.Header)}
 	rec := httptest.NewRecorder()
 	clientReq := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(""))
 
 	ctx := codexCtx("eyJhbGciOiJ-codex-jwt", "acct-12345")
-	err := c.Proxy(ctx, router.Decision{Model: "gpt-5.5", Provider: providers.ProviderOpenAI}, prep, rec, clientReq)
+	err := c.Proxy(ctx, router.Decision{Model: "gpt-5.6-sol", Provider: providers.ProviderOpenAI}, prep, rec, clientReq)
 	require.NoError(t, err)
 
 	assert.Equal(t, "/v1/chat/completions", gotPath,

--- a/internal/providers/openai/setauth_internal_test.go
+++ b/internal/providers/openai/setauth_internal_test.go
@@ -38,7 +38,31 @@ func TestSetAuth_PassthroughRejectsRouterKey(t *testing.T) {
 		c.setAuth(context.Background(), upstream, inbound)
 
 		assert.Equal(t, "Bearer sk-proj-real", upstream.Header.Get("Authorization"),
-			"Codex plan keys must reach api.openai.com untouched")
+			"genuine OpenAI API keys must reach api.openai.com untouched")
+	})
+
+	t.Run("ChatGPT OAuth is never forwarded to public OpenAI", func(t *testing.T) {
+		inbound := httptest.NewRequest(http.MethodPost, "/v1/responses", nil)
+		inbound.Header.Set("Authorization", "Bearer eyJhbGciOi.codex.jwt")
+		inbound.Header.Set("ChatGPT-Account-ID", "acct-123")
+		upstream := httptest.NewRequest(http.MethodPost, "https://api.openai.com/v1/responses", nil)
+
+		c.setAuth(context.Background(), upstream, inbound)
+
+		assert.Empty(t, upstream.Header.Get("Authorization"),
+			"a suppressed ChatGPT bearer must never fall through to api.openai.com")
+	})
+
+	t.Run("genuine OpenAI Bearer with stray account id still flows through", func(t *testing.T) {
+		inbound := httptest.NewRequest(http.MethodPost, "/v1/responses", nil)
+		inbound.Header.Set("Authorization", "Bearer sk-proj-real")
+		inbound.Header.Set("ChatGPT-Account-ID", "acct-stray")
+		upstream := httptest.NewRequest(http.MethodPost, "https://api.openai.com/v1/responses", nil)
+
+		c.setAuth(context.Background(), upstream, inbound)
+
+		assert.Equal(t, "Bearer sk-proj-real", upstream.Header.Get("Authorization"),
+			"a non-OAuth OpenAI client key must be unaffected by Codex-specific hardening")
 	})
 
 	t.Run("non-Bearer authorization flows through", func(t *testing.T) {

--- a/internal/proxy/enabled_providers_internal_test.go
+++ b/internal/proxy/enabled_providers_internal_test.go
@@ -5,6 +5,8 @@ import (
 	"net/http"
 	"testing"
 
+	"workweave/router/internal/auth"
+	"workweave/router/internal/billing"
 	"workweave/router/internal/providers"
 
 	"github.com/stretchr/testify/assert"
@@ -227,6 +229,54 @@ func TestEnabledProvidersForRequest_CodexSubscriptionEnrollsOpenAI(t *testing.T)
 		got := makeService().enabledProvidersForRequest(ctx, providers.ProviderOpenAI, http.Header{})
 		assert.NotContains(t, got, providers.ProviderOpenAI,
 			"a provider exclusion must subtract OpenAI even when a Codex subscription is present")
+	})
+}
+
+func TestExcludeCodexOAuthOnlyModels(t *testing.T) {
+	const codexJWT = "eyJhbGciOiJSUzI1NiJ9.codex.sig"
+	ctx := context.WithValue(routerKeyedCtx(), OpenAISubscriptionContextKey{}, codexJWT)
+	ctx = context.WithValue(ctx, OpenAIAccountIDContextKey{}, "acct-123")
+	enabled := map[string]struct{}{providers.ProviderOpenAI: {}}
+
+	t.Run("OAuth-only excludes infrastructure OpenAI models", func(t *testing.T) {
+		s := &Service{
+			byokOnly:                     true,
+			providers:                    map[string]providers.Client{providers.ProviderOpenAI: nil},
+			deploymentKeyedProviders:     map[string]struct{}{},
+			passthroughEligibleProviders: map[string]struct{}{},
+		}
+		got := s.excludeCodexOAuthOnlyModels(ctx, http.Header{}, enabled, nil)
+		assert.Contains(t, got, "gpt-5.4-nano")
+		assert.NotContains(t, got, "gpt-5.6-sol")
+		assert.NotContains(t, got, "gpt-5.6-terra")
+		assert.NotContains(t, got, "gpt-5.6-luna")
+	})
+
+	t.Run("OpenAI BYOK keeps infrastructure models eligible", func(t *testing.T) {
+		s := &Service{
+			byokOnly:                     true,
+			providers:                    map[string]providers.Client{providers.ProviderOpenAI: nil},
+			deploymentKeyedProviders:     map[string]struct{}{},
+			passthroughEligibleProviders: map[string]struct{}{},
+		}
+		byokCtx := context.WithValue(ctx, ExternalAPIKeysContextKey{}, []*auth.ExternalAPIKey{
+			{Provider: providers.ProviderOpenAI, Plaintext: []byte("sk-oai-byok")},
+		})
+		got := s.excludeCodexOAuthOnlyModels(byokCtx, http.Header{}, enabled, nil)
+		assert.NotContains(t, got, "gpt-5.4-nano")
+	})
+
+	t.Run("subscription-only ignores infrastructure credentials", func(t *testing.T) {
+		s := &Service{
+			providers: map[string]providers.Client{providers.ProviderOpenAI: nil},
+			deploymentKeyedProviders: map[string]struct{}{
+				providers.ProviderOpenAI: {},
+			},
+			passthroughEligibleProviders: map[string]struct{}{},
+		}
+		got := s.excludeCodexOAuthOnlyModels(billing.WithSubscriptionOnly(ctx), http.Header{}, enabled, nil)
+		assert.Contains(t, got, "gpt-5.4-nano")
+		assert.NotContains(t, got, "gpt-5.6-sol")
 	})
 }
 

--- a/internal/proxy/fallback.go
+++ b/internal/proxy/fallback.go
@@ -197,7 +197,7 @@ func (s *Service) dispatchWithFallback(ctx context.Context, in failoverInputs) (
 		// the only source left is the deployment env key on the next client.
 		attemptCtx := ctx
 		if i > 0 {
-			attemptCtx = resolveAndInjectCredentials(ctx, b.Provider, http.Header{})
+			attemptCtx = resolveAndInjectCredentials(ctx, b.Provider, in.initialDecision.Model, http.Header{})
 			// Drop the previous attempt's buffered Prelude bytes + any
 			// header mutations it made. Safe pre-commit only.
 			if in.buf != nil {

--- a/internal/proxy/gemini.go
+++ b/internal/proxy/gemini.go
@@ -185,7 +185,7 @@ func (s *Service) ProxyGeminiGenerateContent(ctx context.Context, body []byte, w
 		opts.ForceEffort = knobs.ForceEffort
 		opts.ForceReasoningEffort = translate.ResolveForceEffort(opts.Capabilities, opts.ForceEffort)
 	}
-	ctx = resolveAndInjectCredentials(ctx, decision.Provider, r.Header)
+	ctx = resolveAndInjectCredentials(ctx, decision.Provider, decision.Model, r.Header)
 
 	prep, emitErr := env.PrepareGemini(r.Header, opts)
 	if emitErr != nil {

--- a/internal/proxy/route_preview.go
+++ b/internal/proxy/route_preview.go
@@ -51,7 +51,7 @@ func (s *Service) anthropicRoutingRequest(ctx context.Context, body []byte, head
 	if features.MaxTokens > outputReserve {
 		outputReserve = features.MaxTokens
 	}
-	excluded := s.excludedModelsForRequest(ctx)
+	excluded := s.excludeCodexOAuthOnlyModels(ctx, headers, enabledProviders, s.excludedModelsForRequest(ctx))
 	excluded, _ = excludeContextOverflowModels(
 		env.ContextOverflowTokenEstimate(),
 		env.SignatureTokenSavings(),

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -1840,7 +1840,7 @@ func (s *Service) PassthroughToNamedProvider(ctx context.Context, providerName s
 	if err != nil {
 		return err
 	}
-	ctx = resolveAndInjectCredentials(ctx, providerName, r.Header)
+	ctx = resolveAndInjectCredentials(ctx, providerName, "", r.Header)
 
 	// Claude Code sends its 1M-context model variant tag (e.g.
 	// "claude-opus-4-8[1m]") in the body. It is a client display convention,
@@ -2229,7 +2229,7 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 	if feats.MaxTokens > outputReserve {
 		outputReserve = feats.MaxTokens
 	}
-	baseExcluded := s.excludedModelsForRequest(ctx)
+	baseExcluded := s.excludeCodexOAuthOnlyModels(ctx, r.Header, enabledProviders, s.excludedModelsForRequest(ctx))
 
 	// Snapshot inbound (client-sent) state BEFORE any env rewrite. The
 	// compaction tracker, spiral scan, and tool-output telemetry must compare
@@ -2561,7 +2561,7 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 	if s.claudeSubscriptionExhausted(ctx, r.Header) {
 		ctx = withSuppressedClaudeSubscription(ctx)
 	}
-	ctx = resolveAndInjectCredentials(ctx, decision.Provider, r.Header)
+	ctx = resolveAndInjectCredentials(ctx, decision.Provider, decision.Model, r.Header)
 
 	// Wrap every request (not just multi-binding) in a preludeBuffer so a
 	// pre-first-byte upstream error can discard the buffered prelude (marker +
@@ -2917,7 +2917,7 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 				ctx = withSuppressedClaudeSubscription(ctx)
 				baselineCtx = withSuppressedClaudeSubscription(baselineCtx)
 			}
-			baselineCtx = resolveAndInjectCredentials(baselineCtx, providers.ProviderAnthropic, r.Header)
+			baselineCtx = resolveAndInjectCredentials(baselineCtx, providers.ProviderAnthropic, baselineModel, r.Header)
 			baselineBindings := s.resolveBindingsForDispatch(baselineCtx, baselineDecision)
 			baselineMarker := suppressMarkerIfRequested(r.Header, baselineRoutingMarkerFor(routeRes, baselineModel))
 			baselineAttempt := s.anthropicNativeAttempt(env, r, baselinePrep, sink, preludeBuf, baselineMarker, setExtractor)
@@ -2958,7 +2958,7 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 		(providers.IsRetryable(proxyErr) || anthropicOAuthCredentialRejected(proxyErr)) {
 		subscriptionRetryRan = true
 		subCtx := withSuppressedClaudeSubscription(ctx)
-		subCtx = resolveAndInjectCredentials(subCtx, providers.ProviderAnthropic, r.Header)
+		subCtx = resolveAndInjectCredentials(subCtx, providers.ProviderAnthropic, decision.Model, r.Header)
 		// Model is unchanged, but rebuild prep so the retry gets a pristine
 		// PreparedRequest under the suppressed-subscription context.
 		subPrep, subEmitErr := env.PrepareAnthropic(r.Header, opts)
@@ -3022,7 +3022,7 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 	if subscriptionFailoverUsed {
 		ctx = withSuppressedClaudeSubscription(ctx)
 	}
-	ctx = resolveAndInjectCredentials(ctx, finalProvider, r.Header)
+	ctx = resolveAndInjectCredentials(ctx, finalProvider, decision.Model, r.Header)
 
 	// Re-resolve pricing for the binding that actually served: the
 	// pre-dispatch lookup always returns the catalog's PRIMARY binding price,
@@ -3878,9 +3878,72 @@ func (s *Service) enabledProvidersForRequest(ctx context.Context, surfaceProvide
 	return out
 }
 
-// resolveAndInjectCredentials resolves credentials for provider and stashes
-// them on ctx, in precedence order: Claude subscription (Anthropic only),
-// then BYOK, then a client-supplied header credential.
+// hasOpenAIInfrastructureCredential reports whether an OpenAI model can be
+// served without the caller's ChatGPT OAuth: deployment key, installation
+// BYOK, or a non-OAuth client credential on an unkeyed passthrough request.
+func (s *Service) hasOpenAIInfrastructureCredential(ctx context.Context, headers http.Header) bool {
+	if byokServedForProvider(ctx, providers.ProviderOpenAI) {
+		return true
+	}
+	if !s.byokOnly {
+		if s.deploymentKeyedProviders == nil {
+			_, registered := s.providers[providers.ProviderOpenAI]
+			if registered {
+				return true
+			}
+		} else if _, keyed := s.deploymentKeyedProviders[providers.ProviderOpenAI]; keyed {
+			return true
+		}
+	}
+	if installationIDFromContext(ctx) == uuid.Nil {
+		if client := ExtractClientCredentials(providers.ProviderOpenAI, headers); client != nil && !client.OAuth {
+			return true
+		}
+	}
+	return false
+}
+
+// excludeCodexOAuthOnlyModels keeps model eligibility aligned with credential
+// resolution. When ChatGPT OAuth is the only way OpenAI became eligible (or
+// billing has restricted the turn to subscriptions), only the exact native
+// Codex family may select the OpenAI binding. Infrastructure-backed requests
+// retain the full catalog and route other OpenAI models normally.
+func (s *Service) excludeCodexOAuthOnlyModels(
+	ctx context.Context,
+	headers http.Header,
+	enabledProviders map[string]struct{},
+	excluded map[string]struct{},
+) map[string]struct{} {
+	codex, _ := presentSubscriptionTokens(ctx, headers)
+	if codex == "" || (!billing.SubscriptionOnlyFromContext(ctx) && s.hasOpenAIInfrastructureCredential(ctx, headers)) {
+		return excluded
+	}
+	for _, model := range catalog.Models {
+		if codexSubscriptionCoversModel(model.ID) {
+			continue
+		}
+		// Match catalog binding resolution: the first enabled binding is the one
+		// this model would dispatch through. If that binding is OAuth-only OpenAI,
+		// the whole model is ineligible for this request.
+		for _, binding := range model.Providers {
+			if enabledProviders != nil {
+				if _, enabled := enabledProviders[binding.Provider]; !enabled {
+					continue
+				}
+			}
+			if binding.Provider == providers.ProviderOpenAI {
+				excluded = excludingModel(excluded, model.ID)
+			}
+			break
+		}
+	}
+	return excluded
+}
+
+// resolveAndInjectCredentials resolves credentials for the selected provider
+// and model and stashes them on ctx. Claude OAuth applies to Anthropic models;
+// Codex OAuth applies only to the explicit native Codex model family. All other
+// selections fall through to BYOK, a client API key, or the deployment key.
 //
 // Subscription-first lets a caller's own Claude subscription pay for Claude
 // turns. It arrives via the dedicated X-Weave-Anthropic-Subscription header,
@@ -3892,12 +3955,14 @@ func (s *Service) enabledProvidersForRequest(ctx context.Context, surfaceProvide
 // API key is NOT extracted on the router-key path, since that would forward
 // the client's inbound key to a different upstream provider. The deployment
 // env key is the correct fallback there.
-func resolveAndInjectCredentials(ctx context.Context, provider string, headers http.Header) context.Context {
+func resolveAndInjectCredentials(ctx context.Context, provider, model string, headers http.Header) context.Context {
 	routerKeyed := installationIDFromContext(ctx) != (uuid.UUID{})
-	// Skip subscription OAuth (fall through to BYOK / deployment key): exhausted (Anthropic-only, avoid re-429) or toggle off (provider-wide).
+	// Skip subscription OAuth (fall through to BYOK / deployment key):
+	// exhausted (Anthropic-only, avoid re-429), toggle off (provider-wide), or
+	// an OpenAI-provider model outside the native Codex OAuth family.
 	subDisabled := subscriptionRoutingDisabledForRequest(ctx)
 	suppressClaudeSub := claudeSubscriptionSuppressed(ctx) || subDisabled
-	suppressCodexSub := subDisabled
+	suppressCodexSub := subDisabled || !codexSubscriptionCoversModel(model)
 	if provider == providers.ProviderAnthropic && !suppressClaudeSub {
 		// Subscription-first (subscription -> BYOK -> deployment), resolved here
 		// explicitly rather than relying on BYOK being absent off the router-key
@@ -4393,7 +4458,7 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 	if feats.MaxTokens > outputReserveOAI {
 		outputReserveOAI = feats.MaxTokens
 	}
-	baseExcludedOAI := s.excludedModelsForRequest(ctx)
+	baseExcludedOAI := s.excludeCodexOAuthOnlyModels(ctx, r.Header, enabledProviders, s.excludedModelsForRequest(ctx))
 
 	// Snapshot the inbound tool-output size before any env rewrite (proactive
 	// compaction below, or runTurnLoop's switch handover); see toolResultBytesPtr.
@@ -4573,7 +4638,7 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 		opts.ForceReasoningEffort = forcedReasoningEffort(decision.Model, routeRes.EscalateEffort)
 	}
 
-	ctx = resolveAndInjectCredentials(ctx, decision.Provider, r.Header)
+	ctx = resolveAndInjectCredentials(ctx, decision.Provider, decision.Model, r.Header)
 
 	// See ProxyMessages for the preludeBuffer rationale — wrap unconditionally
 	// so single-binding upstream errors don't strand the routing-marker chunk
@@ -4847,7 +4912,7 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 
 	// Re-resolve credentials for the binding that actually served — each
 	// failover attempt gets its own context with potentially different creds.
-	ctx = resolveAndInjectCredentials(ctx, finalProvider, r.Header)
+	ctx = resolveAndInjectCredentials(ctx, finalProvider, decision.Model, r.Header)
 
 	// Re-resolve pricing for the binding that actually served (see ProxyMessages).
 	if actBindingPricing, ok := catalog.PriceFor(finalProvider, decision.Model); ok {

--- a/internal/proxy/service_test.go
+++ b/internal/proxy/service_test.go
@@ -118,10 +118,37 @@ func TestService_PreviewAnthropicRouteBuildsServingCandidateContextWithoutDispat
 	assert.Contains(t, previewer.previewReq.EnabledProviders, providers.ProviderAnthropic)
 	assert.Contains(t, previewer.previewReq.EnabledProviders, providers.ProviderOpenAI)
 	assert.Contains(t, previewer.previewReq.ExcludedModels, "gpt-5.5-mini")
+	assert.NotContains(t, previewer.previewReq.ExcludedModels, "gpt-5.4-nano",
+		"a normal non-Codex preview must retain infrastructure OpenAI candidates")
 	assert.Equal(t, []string{"claude-opus-4-8"}, previewer.previewReq.PreferredModels)
 	assert.False(t, previewer.previewReq.TrainingAllowed)
 	assert.Empty(t, anthropicProvider.proxyBodies)
 	assert.Empty(t, openAIProvider.proxyBodies)
+}
+
+func TestService_PreviewAnthropicRouteExcludesInfrastructureModelsForOAuthOnlyCodex(t *testing.T) {
+	previewer := &fakePreviewRouter{previewResult: policy.PreviewResult{
+		SchemaVersion: policy.SchemaVersionV1,
+	}}
+	svc := proxy.NewService(&fakeRouter{}, map[string]providers.Client{
+		providers.ProviderOpenAI: &fakeProvider{},
+	}, nil, false, nil, nil, false, providers.ProviderAnthropic, "claude-haiku-4-5", nil).
+		WithByokOnly(true).
+		WithPolicyStrategy(policy.StrategySpec{Strategy: router.StrategyHMM, Router: previewer})
+
+	ctx := router.WithStrategy(context.Background(), router.StrategyHMM)
+	ctx = context.WithValue(ctx, proxy.OpenAISubscriptionContextKey{}, "eyJhbGciOiJSUzI1NiJ9.codex.sig")
+	ctx = context.WithValue(ctx, proxy.OpenAIAccountIDContextKey{}, "acct-123")
+	body := []byte(`{"model":"claude-opus-4-8","messages":[{"role":"user","content":"preview this turn"}],"max_tokens":1024}`)
+
+	_, err := svc.PreviewAnthropicRoute(ctx, body, http.Header{})
+
+	require.NoError(t, err)
+	require.NotNil(t, previewer.previewReq)
+	assert.Contains(t, previewer.previewReq.EnabledProviders, providers.ProviderOpenAI)
+	assert.Contains(t, previewer.previewReq.ExcludedModels, "gpt-5.4-nano",
+		"route and HMM previews must not advertise models that Codex OAuth cannot serve")
+	assert.NotContains(t, previewer.previewReq.ExcludedModels, "gpt-5.6-sol")
 }
 
 func TestService_AgentShadowEvaluationForcesEphemerallyWithoutServingRouter(t *testing.T) {
@@ -275,6 +302,86 @@ func TestService_ProxyOpenAIResponses_CustomToolUsesNativeOpenAIFamily(t *testin
 	assert.JSONEq(t, `{"model":"gpt-5.5","input":"apply a patch","reasoning":{"effort":"high"},"tools":[{"type":"custom","name":"apply_patch"}]}`, string(provider.proxyBodies[0]))
 	assert.Equal(t, providers.EndpointResponses, provider.proxyEndpoints[0])
 	assert.JSONEq(t, `{"id":"resp_1","object":"response","output":[]}`, rec.Body.String())
+}
+
+func TestService_CodexRequestRoutesInfrastructureOpenAIModelWithoutOAuth(t *testing.T) {
+	provider := &fakeProvider{proxyResponse: func(w http.ResponseWriter) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"id":"resp_1","object":"response","output":[]}`)
+	}}
+	fr := &fakeRouter{decision: router.Decision{
+		Provider: providers.ProviderOpenAI,
+		Model:    "gpt-5.4-nano",
+		Reason:   "hmm:test",
+	}}
+	svc := proxy.NewService(fr, map[string]providers.Client{
+		providers.ProviderOpenAI: provider,
+	}, nil, false, nil, nil, false, providers.ProviderOpenAI, "gpt-5.6-sol", nil).
+		WithDeploymentKeyedProviders(map[string]struct{}{providers.ProviderOpenAI: {}})
+
+	ctx := context.WithValue(context.Background(), proxy.OpenAISubscriptionContextKey{}, "eyJhbGciOiJSUzI1NiJ9.codex.sig")
+	ctx = context.WithValue(ctx, proxy.OpenAIAccountIDContextKey{}, "acct-123")
+	body := []byte(`{"model":"gpt-5.6-sol","input":"route this turn"}`)
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(""))
+
+	require.NoError(t, svc.ProxyOpenAIResponses(ctx, body, rec, req))
+	require.Len(t, provider.proxyBodies, 1)
+	assert.Equal(t, providers.EndpointResponses, provider.proxyEndpoints[0])
+	assert.Contains(t, string(provider.proxyBodies[0]), `"model":"gpt-5.4-nano"`)
+	assert.Nil(t, provider.proxyCreds[0],
+		"an HMM-selected infrastructure model must use the OpenAI deployment key, never caller OAuth")
+}
+
+func TestService_CodexForcedModelUsesModelScopedCredential(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		model     string
+		wantOAuth bool
+	}{
+		{name: "native Codex model", model: "gpt-5.6-terra", wantOAuth: true},
+		{name: "infrastructure OpenAI model", model: "gpt-5.4-nano", wantOAuth: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			provider := &fakeProvider{proxyResponse: func(w http.ResponseWriter) {
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = io.WriteString(w, `{"id":"resp_1","object":"response","output":[]}`)
+			}}
+			store := newFakePinStore()
+			store.hasPin = true
+			store.pin = sessionpin.Pin{
+				Provider:    providers.ProviderOpenAI,
+				Model:       tc.model,
+				Reason:      translate.ReasonUserForceModel,
+				PinnedUntil: time.Now().Add(time.Hour),
+			}
+			fr := &fakeRouter{err: errors.New("forced pin must bypass the scorer")}
+			svc := proxy.NewService(fr, map[string]providers.Client{
+				providers.ProviderOpenAI: provider,
+			}, nil, false, nil, store, false, providers.ProviderOpenAI, "gpt-5.6-sol", nil).
+				WithDeploymentKeyedProviders(map[string]struct{}{providers.ProviderOpenAI: {}})
+
+			ctx := authedCtx("11111111-1111-1111-1111-111111111111")
+			ctx = context.WithValue(ctx, proxy.OpenAISubscriptionContextKey{}, "eyJhbGciOiJSUzI1NiJ9.codex.sig")
+			ctx = context.WithValue(ctx, proxy.OpenAIAccountIDContextKey{}, "acct-123")
+			body := []byte(`{"model":"gpt-5.6-sol","input":"use the forced model"}`)
+			rec := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(""))
+
+			require.NoError(t, svc.ProxyOpenAIResponses(ctx, body, rec, req))
+			assert.Zero(t, fr.routeCalls, "the stored user-forced model must bypass automatic routing")
+			require.Len(t, provider.proxyCreds, 1)
+			if tc.wantOAuth {
+				require.NotNil(t, provider.proxyCreds[0])
+				assert.True(t, provider.proxyCreds[0].OAuth)
+				assert.Equal(t, "codex_subscription", provider.proxyCreds[0].Source)
+			} else {
+				assert.Nil(t, provider.proxyCreds[0],
+					"the infrastructure model must fall through to the OpenAI deployment key")
+			}
+			assert.Contains(t, string(provider.proxyBodies[0]), `"model":"`+tc.model+`"`)
+		})
+	}
 }
 
 func TestService_ProxyOpenAIResponses_CodexPassthroughUsesChatForOpenAICompatProvider(t *testing.T) {

--- a/internal/proxy/subscription_exhaustion_internal_test.go
+++ b/internal/proxy/subscription_exhaustion_internal_test.go
@@ -40,7 +40,7 @@ func TestResolveAndInjectCredentials_SuppressedSubscriptionFallsThroughToBYOK(t 
 	ctx = withSuppressedClaudeSubscription(ctx)
 	headers := http.Header{"Authorization": []string{"Bearer " + exhaustedSubToken}}
 
-	out := resolveAndInjectCredentials(ctx, providers.ProviderAnthropic, headers)
+	out := resolveAndInjectCredentials(ctx, providers.ProviderAnthropic, "claude-opus-4-8", headers)
 	creds := CredentialsFromContext(out)
 	require.NotNil(t, creds)
 	assert.False(t, creds.OAuth, "the spent subscription token must be skipped")
@@ -57,7 +57,7 @@ func TestResolveAndInjectCredentials_SuppressedSubscriptionFallsThroughToDeploym
 	ctx := context.WithValue(context.Background(), AnthropicSubscriptionContextKey{}, exhaustedSubToken)
 	ctx = withSuppressedClaudeSubscription(ctx)
 
-	out := resolveAndInjectCredentials(ctx, providers.ProviderAnthropic, http.Header{})
+	out := resolveAndInjectCredentials(ctx, providers.ProviderAnthropic, "claude-opus-4-8", http.Header{})
 	assert.Nil(t, CredentialsFromContext(out),
 		"with the subscription suppressed and no BYOK, no credential is set so the deployment key serves the turn")
 }
@@ -71,7 +71,7 @@ func TestResolveAndInjectCredentials_SuppressedInboundBearerNotReResolved(t *tes
 	ctx := withSuppressedClaudeSubscription(context.Background())
 	headers := http.Header{"Authorization": []string{"Bearer " + exhaustedSubToken}}
 
-	out := resolveAndInjectCredentials(ctx, providers.ProviderAnthropic, headers)
+	out := resolveAndInjectCredentials(ctx, providers.ProviderAnthropic, "claude-opus-4-8", headers)
 	assert.Nil(t, CredentialsFromContext(out),
 		"a suppressed inbound subscription bearer must not be re-resolved via client extraction")
 }
@@ -83,7 +83,7 @@ func TestResolveAndInjectCredentials_SuppressedKeepsRealClientApiKey(t *testing.
 	ctx := withSuppressedClaudeSubscription(context.Background())
 	headers := http.Header{"X-Api-Key": []string{"sk-ant-api-real-client-key"}}
 
-	out := resolveAndInjectCredentials(ctx, providers.ProviderAnthropic, headers)
+	out := resolveAndInjectCredentials(ctx, providers.ProviderAnthropic, "claude-opus-4-8", headers)
 	creds := CredentialsFromContext(out)
 	require.NotNil(t, creds, "a real client API key is not the suppressed subscription and must be kept")
 	assert.False(t, creds.OAuth)
@@ -99,7 +99,7 @@ func TestResolveAndInjectCredentials_ClaudeSuppressionLeavesCodexIntact(t *testi
 	ctx = context.WithValue(ctx, OpenAIAccountIDContextKey{}, "acct-1")
 	ctx = withSuppressedClaudeSubscription(ctx)
 
-	out := resolveAndInjectCredentials(ctx, providers.ProviderOpenAI, http.Header{})
+	out := resolveAndInjectCredentials(ctx, providers.ProviderOpenAI, "gpt-5.6-sol", http.Header{})
 	creds := CredentialsFromContext(out)
 	require.NotNil(t, creds)
 	assert.True(t, creds.OAuth, "the Codex subscription must survive Claude-only suppression")
@@ -112,7 +112,7 @@ func TestResolveAndInjectCredentials_UnsuppressedSubscriptionStillWins(t *testin
 	// into the normal path.
 	ctx := context.WithValue(context.Background(), AnthropicSubscriptionContextKey{}, exhaustedSubToken)
 
-	out := resolveAndInjectCredentials(ctx, providers.ProviderAnthropic, http.Header{})
+	out := resolveAndInjectCredentials(ctx, providers.ProviderAnthropic, "claude-opus-4-8", http.Header{})
 	creds := CredentialsFromContext(out)
 	require.NotNil(t, creds)
 	assert.True(t, creds.OAuth, "a non-suppressed subscription must still be resolved")
@@ -210,14 +210,14 @@ func TestBaselineFailoverCtxSuppression(t *testing.T) {
 	base := context.Background()
 
 	t.Run("unsuppressed ctx resolves the inbound bearer", func(t *testing.T) {
-		out := resolveAndInjectCredentials(base, providers.ProviderAnthropic, headers)
+		out := resolveAndInjectCredentials(base, providers.ProviderAnthropic, "claude-opus-4-8", headers)
 		assert.True(t, servedOnSubscription(out),
 			"without suppression the OAuth bearer is injected and the turn bills the subscription")
 	})
 
 	t.Run("suppressed ctx drops the bearer", func(t *testing.T) {
 		suppressed := withSuppressedClaudeSubscription(base)
-		out := resolveAndInjectCredentials(suppressed, providers.ProviderAnthropic, headers)
+		out := resolveAndInjectCredentials(suppressed, providers.ProviderAnthropic, "claude-opus-4-8", headers)
 		assert.False(t, servedOnSubscription(out),
 			"with suppression the OAuth bearer is dropped and the turn bills at full cost")
 		creds := CredentialsFromContext(out)

--- a/internal/proxy/subscription_internal_test.go
+++ b/internal/proxy/subscription_internal_test.go
@@ -50,7 +50,7 @@ func TestResolveAndInjectCredentials_SubscriptionHeaderBeatsBYOK(t *testing.T) {
 	})
 	ctx = context.WithValue(ctx, AnthropicSubscriptionContextKey{}, "sk-ant-oat01-subscription-token")
 
-	out := resolveAndInjectCredentials(ctx, providers.ProviderAnthropic, http.Header{})
+	out := resolveAndInjectCredentials(ctx, providers.ProviderAnthropic, "claude-opus-4-8", http.Header{})
 	creds := CredentialsFromContext(out)
 	require.NotNil(t, creds)
 	assert.True(t, creds.OAuth)
@@ -68,7 +68,7 @@ func TestResolveAndInjectCredentials_SubscriptionHeaderIgnoredForNonAnthropic(t 
 	})
 	ctx = context.WithValue(ctx, AnthropicSubscriptionContextKey{}, "sk-ant-oat01-subscription-token")
 
-	out := resolveAndInjectCredentials(ctx, providers.ProviderOpenAI, http.Header{})
+	out := resolveAndInjectCredentials(ctx, providers.ProviderOpenAI, "gpt-5.4-nano", http.Header{})
 	creds := CredentialsFromContext(out)
 	require.NotNil(t, creds)
 	assert.False(t, creds.OAuth)
@@ -83,7 +83,7 @@ func TestResolveAndInjectCredentials_InboundSubscriptionBeatsBYOK(t *testing.T) 
 		{Provider: providers.ProviderAnthropic, Plaintext: []byte("sk-ant-api-byok")},
 	})
 	headers := http.Header{"Authorization": []string{"Bearer sk-ant-oat01-subscription-token"}}
-	out := resolveAndInjectCredentials(ctx, providers.ProviderAnthropic, headers)
+	out := resolveAndInjectCredentials(ctx, providers.ProviderAnthropic, "claude-opus-4-8", headers)
 	creds := CredentialsFromContext(out)
 	require.NotNil(t, creds)
 	assert.True(t, creds.OAuth, "the inbound subscription bearer must win over BYOK")
@@ -95,7 +95,7 @@ func TestResolveAndInjectCredentials_SelfHostedInboundSubscription(t *testing.T)
 	// No router key (nil installation): the caller's own Authorization bearer
 	// carries the subscription token and is resolved via client extraction.
 	headers := http.Header{"Authorization": []string{"Bearer sk-ant-oat01-subscription-token"}}
-	out := resolveAndInjectCredentials(context.Background(), providers.ProviderAnthropic, headers)
+	out := resolveAndInjectCredentials(context.Background(), providers.ProviderAnthropic, "claude-opus-4-8", headers)
 	creds := CredentialsFromContext(out)
 	require.NotNil(t, creds)
 	assert.True(t, creds.OAuth)
@@ -108,7 +108,7 @@ func TestResolveAndInjectCredentials_RouterKeyedInboundSubscription(t *testing.T
 	// must still resolve as the subscription credential.
 	ctx := context.WithValue(context.Background(), InstallationIDContextKey{}, testInstallationID)
 	headers := http.Header{"Authorization": []string{"Bearer sk-ant-oat01-subscription-token"}}
-	out := resolveAndInjectCredentials(ctx, providers.ProviderAnthropic, headers)
+	out := resolveAndInjectCredentials(ctx, providers.ProviderAnthropic, "claude-opus-4-8", headers)
 	creds := CredentialsFromContext(out)
 	require.NotNil(t, creds)
 	assert.True(t, creds.OAuth,
@@ -122,7 +122,7 @@ func TestResolveAndInjectCredentials_RouterKeyedInboundApiKeyNotForwarded(t *tes
 	// sk-ant-oat OAuth subset — otherwise it'd widen the cross-provider-leak guard.
 	ctx := context.WithValue(context.Background(), InstallationIDContextKey{}, testInstallationID)
 	headers := http.Header{"Authorization": []string{"Bearer sk-ant-api-real-client-key"}}
-	out := resolveAndInjectCredentials(ctx, providers.ProviderAnthropic, headers)
+	out := resolveAndInjectCredentials(ctx, providers.ProviderAnthropic, "claude-opus-4-8", headers)
 	assert.Nil(t, CredentialsFromContext(out),
 		"a non-OAuth inbound API key must not be forwarded on the router-key path; the deployment key is the correct fallback")
 }
@@ -139,7 +139,7 @@ func TestResolveAndInjectCredentials_CodexDedicatedHeadersBeatBYOK(t *testing.T)
 	ctx = context.WithValue(ctx, OpenAISubscriptionContextKey{}, codexTestJWT)
 	ctx = context.WithValue(ctx, OpenAIAccountIDContextKey{}, "acct-999")
 
-	out := resolveAndInjectCredentials(ctx, providers.ProviderOpenAI, http.Header{})
+	out := resolveAndInjectCredentials(ctx, providers.ProviderOpenAI, "gpt-5.6-sol", http.Header{})
 	creds := CredentialsFromContext(out)
 	require.NotNil(t, creds)
 	assert.True(t, creds.OAuth)
@@ -158,7 +158,7 @@ func TestResolveAndInjectCredentials_CodexInboundBeatsBYOK(t *testing.T) {
 		"Authorization":      []string{"Bearer " + codexTestJWT},
 		"Chatgpt-Account-Id": []string{"acct-999"},
 	}
-	out := resolveAndInjectCredentials(ctx, providers.ProviderOpenAI, headers)
+	out := resolveAndInjectCredentials(ctx, providers.ProviderOpenAI, "gpt-5.6-sol", headers)
 	creds := CredentialsFromContext(out)
 	require.NotNil(t, creds)
 	assert.True(t, creds.OAuth, "the inbound Codex subscription must win over BYOK")
@@ -175,7 +175,7 @@ func TestResolveAndInjectCredentials_RouterKeyedInboundCodexSubscription(t *test
 		"Authorization":      []string{"Bearer " + codexTestJWT},
 		"Chatgpt-Account-Id": []string{"acct-999"},
 	}
-	out := resolveAndInjectCredentials(ctx, providers.ProviderOpenAI, headers)
+	out := resolveAndInjectCredentials(ctx, providers.ProviderOpenAI, "gpt-5.6-sol", headers)
 	creds := CredentialsFromContext(out)
 	require.NotNil(t, creds)
 	assert.True(t, creds.OAuth,
@@ -184,12 +184,71 @@ func TestResolveAndInjectCredentials_RouterKeyedInboundCodexSubscription(t *test
 	assert.Equal(t, []byte("acct-999"), creds.AccountID)
 }
 
+func TestCodexSubscriptionCoversModel(t *testing.T) {
+	for _, model := range []string{"gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"} {
+		assert.Truef(t, codexSubscriptionCoversModel(model), "%s must use the caller's Codex OAuth", model)
+	}
+	for _, model := range []string{"gpt-5.4-nano", "gpt-5.5", "gpt-4o", "gpt-5.6", ""} {
+		assert.Falsef(t, codexSubscriptionCoversModel(model), "%s must use infrastructure credentials", model)
+	}
+}
+
+func TestResolveAndInjectCredentials_CodexCoverageIsModelScoped(t *testing.T) {
+	for _, model := range []string{"gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"} {
+		t.Run(model+" uses Codex OAuth", func(t *testing.T) {
+			ctx := context.WithValue(context.Background(), InstallationIDContextKey{}, testInstallationID)
+			ctx = context.WithValue(ctx, ExternalAPIKeysContextKey{}, []*auth.ExternalAPIKey{
+				{Provider: providers.ProviderOpenAI, Plaintext: []byte("sk-oai-byok")},
+			})
+			ctx = context.WithValue(ctx, OpenAISubscriptionContextKey{}, codexTestJWT)
+			ctx = context.WithValue(ctx, OpenAIAccountIDContextKey{}, "acct-999")
+
+			creds := CredentialsFromContext(resolveAndInjectCredentials(ctx, providers.ProviderOpenAI, model, http.Header{}))
+			require.NotNil(t, creds)
+			assert.True(t, creds.OAuth)
+			assert.Equal(t, credSourceCodexSubscription, creds.Source)
+		})
+	}
+
+	t.Run("infrastructure OpenAI model uses BYOK", func(t *testing.T) {
+		ctx := context.WithValue(context.Background(), InstallationIDContextKey{}, testInstallationID)
+		ctx = context.WithValue(ctx, ExternalAPIKeysContextKey{}, []*auth.ExternalAPIKey{
+			{Provider: providers.ProviderOpenAI, Plaintext: []byte("sk-oai-byok")},
+		})
+		ctx = context.WithValue(ctx, OpenAISubscriptionContextKey{}, codexTestJWT)
+		ctx = context.WithValue(ctx, OpenAIAccountIDContextKey{}, "acct-999")
+
+		creds := CredentialsFromContext(resolveAndInjectCredentials(ctx, providers.ProviderOpenAI, "gpt-5.4-nano", http.Header{}))
+		require.NotNil(t, creds)
+		assert.False(t, creds.OAuth)
+		assert.Equal(t, credSourceBYOK, creds.Source)
+		assert.Equal(t, []byte("sk-oai-byok"), creds.APIKey)
+	})
+
+	t.Run("infrastructure OpenAI model clears prior Codex OAuth for deployment fallback", func(t *testing.T) {
+		prior := &Credentials{
+			APIKey:    []byte(codexTestJWT),
+			AccountID: []byte("acct-999"),
+			Source:    credSourceCodexSubscription,
+			OAuth:     true,
+		}
+		ctx := context.WithValue(context.Background(), InstallationIDContextKey{}, testInstallationID)
+		ctx = context.WithValue(ctx, CredentialsContextKey{}, prior)
+		ctx = context.WithValue(ctx, OpenAISubscriptionContextKey{}, codexTestJWT)
+		ctx = context.WithValue(ctx, OpenAIAccountIDContextKey{}, "acct-999")
+
+		out := resolveAndInjectCredentials(ctx, providers.ProviderOpenAI, "gpt-5.4-nano", http.Header{})
+		assert.Nil(t, CredentialsFromContext(out),
+			"an infrastructure model must clear Codex OAuth so the OpenAI client uses its deployment key")
+	})
+}
+
 func TestResolveAndInjectCredentials_RouterKeyedInboundOpenAIApiKeyNotForwarded(t *testing.T) {
 	// Router-key path must not forward a general inbound OpenAI key — only the
 	// Codex OAuth subset (JWT + ChatGPT-Account-ID) is honored.
 	ctx := context.WithValue(context.Background(), InstallationIDContextKey{}, testInstallationID)
 	headers := http.Header{"Authorization": []string{"Bearer sk-proj-real-client-key"}}
-	out := resolveAndInjectCredentials(ctx, providers.ProviderOpenAI, headers)
+	out := resolveAndInjectCredentials(ctx, providers.ProviderOpenAI, "gpt-5.6-sol", headers)
 	assert.Nil(t, CredentialsFromContext(out),
 		"a non-OAuth inbound OpenAI key must not be forwarded on the router-key path; the deployment key is the correct fallback")
 }
@@ -204,7 +263,7 @@ func TestResolveAndInjectCredentials_CodexHeadersIgnoredForNonOpenAI(t *testing.
 	ctx = context.WithValue(ctx, OpenAISubscriptionContextKey{}, codexTestJWT)
 	ctx = context.WithValue(ctx, OpenAIAccountIDContextKey{}, "acct-999")
 
-	out := resolveAndInjectCredentials(ctx, providers.ProviderAnthropic, http.Header{})
+	out := resolveAndInjectCredentials(ctx, providers.ProviderAnthropic, "claude-opus-4-8", http.Header{})
 	creds := CredentialsFromContext(out)
 	require.NotNil(t, creds)
 	assert.False(t, creds.OAuth)

--- a/internal/proxy/subscription_only_openai_test.go
+++ b/internal/proxy/subscription_only_openai_test.go
@@ -41,16 +41,16 @@ func codexSubRequest(t *testing.T, body string) (*httptest.ResponseRecorder, *ht
 // subscription (OAuth credential => $0 debit), dispatch exactly once (no paid
 // failover), and surface the depleted-credits warning.
 func TestSubscriptionOnly_OpenAI_ServesOnCodexSub(t *testing.T) {
-	fr := &fakeRouter{decision: router.Decision{Provider: providers.ProviderOpenAI, Model: "gpt-4o", Reason: "test"}}
+	fr := &fakeRouter{decision: router.Decision{Provider: providers.ProviderOpenAI, Model: "gpt-5.6-sol", Reason: "test"}}
 	p := &fakeProvider{proxyResponse: func(w http.ResponseWriter) {
 		w.Header().Set("Content-Type", "text/event-stream")
 		w.WriteHeader(http.StatusOK)
 		_, _ = io.WriteString(w, "data: {\"id\":\"chatcmpl-1\",\"object\":\"chat.completion.chunk\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"hi\"}}]}\n\n")
 		_, _ = io.WriteString(w, "data: [DONE]\n\n")
 	}}
-	svc := proxy.NewService(fr, map[string]providers.Client{providers.ProviderOpenAI: p}, nil, false, nil, nil, false, providers.ProviderOpenAI, "gpt-4o", nil)
+	svc := proxy.NewService(fr, map[string]providers.Client{providers.ProviderOpenAI: p}, nil, false, nil, nil, false, providers.ProviderOpenAI, "gpt-5.6-sol", nil)
 
-	body := `{"model":"gpt-4o","messages":[{"role":"user","content":"hi"}],"max_tokens":100,"stream":true}`
+	body := `{"model":"gpt-5.6-sol","messages":[{"role":"user","content":"hi"}],"max_tokens":100,"stream":true}`
 	rec, req := codexSubRequest(t, body)
 
 	ctx := billing.WithSubscriptionOnly(context.Background())
@@ -75,12 +75,12 @@ func TestSubscriptionOnly_OpenAI_PaidRoute_Refuses402(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 		_, _ = io.WriteString(w, `{"id":"x","object":"chat.completion"}`)
 	}}
-	svc := proxy.NewService(fr, map[string]providers.Client{providers.ProviderOpenRouter: p}, nil, false, nil, nil, false, providers.ProviderOpenAI, "gpt-4o", nil)
+	svc := proxy.NewService(fr, map[string]providers.Client{providers.ProviderOpenRouter: p}, nil, false, nil, nil, false, providers.ProviderOpenAI, "gpt-5.6-sol", nil)
 
 	// MainLoop-shaped (tools + large max_tokens) so the turn isn't classified as
 	// a hard-pinned classifier turn; that would bypass the scorer and defeat the
 	// paid-route scenario under test.
-	body := `{"model":"gpt-4o","messages":[{"role":"user","content":"Refactor the auth middleware and add tests."}],"max_tokens":4096,"tools":[{"type":"function","function":{"name":"edit_file","parameters":{"type":"object"}}}]}`
+	body := `{"model":"gpt-5.6-sol","messages":[{"role":"user","content":"Refactor the auth middleware and add tests."}],"max_tokens":4096,"tools":[{"type":"function","function":{"name":"edit_file","parameters":{"type":"object"}}}]}`
 	rec, req := codexSubRequest(t, body)
 
 	ctx := billing.WithSubscriptionOnly(context.Background())
@@ -92,6 +92,26 @@ func TestSubscriptionOnly_OpenAI_PaidRoute_Refuses402(t *testing.T) {
 	assert.Empty(t, p.proxyBodies, "no paid dispatch may occur below the floor in subscription-only mode")
 }
 
+func TestSubscriptionOnly_OpenAI_InfrastructureModelRefusesWithoutDispatch(t *testing.T) {
+	fr := &fakeRouter{decision: router.Decision{Provider: providers.ProviderOpenAI, Model: "gpt-5.4-nano", Reason: "test"}}
+	p := &fakeProvider{}
+	svc := proxy.NewService(fr, map[string]providers.Client{
+		providers.ProviderOpenAI: p,
+	}, nil, false, nil, nil, false, providers.ProviderOpenAI, "gpt-5.6-sol", nil).
+		WithDeploymentKeyedProviders(map[string]struct{}{providers.ProviderOpenAI: {}})
+
+	body := `{"model":"gpt-5.6-sol","messages":[{"role":"user","content":"Refactor the auth middleware and add tests."}],"max_tokens":4096,"tools":[{"type":"function","function":{"name":"edit_file","parameters":{"type":"object"}}}]}`
+	rec, req := codexSubRequest(t, body)
+
+	err := svc.ProxyOpenAIChatCompletion(billing.WithSubscriptionOnly(context.Background()), []byte(body), rec, req)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, proxy.ErrCreditsExhaustedSubscriptionUnavailable)
+	require.NotNil(t, fr.capturedReq)
+	assert.Contains(t, fr.capturedReq.ExcludedModels, "gpt-5.4-nano",
+		"subscription-only candidate selection must exclude OpenAI models outside the native Codex family")
+	assert.Empty(t, p.proxyBodies, "the infrastructure model must never dispatch against depleted credits")
+}
+
 // TestSubscriptionOnly_OpenAI_SubFailure_NoPaidFailover: when the caller's own
 // subscription attempt fails (e.g. a 429 weekly-limit), paid failover is
 // disabled — the turn must dispatch exactly once (its own sub) and surface the
@@ -99,11 +119,11 @@ func TestSubscriptionOnly_OpenAI_PaidRoute_Refuses402(t *testing.T) {
 // is reserved for turns that can't run on the sub at all (see PaidRoute test);
 // mislabeling a served-sub 429 as "credits exhausted" would be inaccurate.
 func TestSubscriptionOnly_OpenAI_SubFailure_NoPaidFailover(t *testing.T) {
-	fr := &fakeRouter{decision: router.Decision{Provider: providers.ProviderOpenAI, Model: "gpt-4o", Reason: "test"}}
+	fr := &fakeRouter{decision: router.Decision{Provider: providers.ProviderOpenAI, Model: "gpt-5.6-sol", Reason: "test"}}
 	p := &fakeProvider{proxyErr: &providers.UpstreamStatusError{Status: http.StatusTooManyRequests}}
-	svc := proxy.NewService(fr, map[string]providers.Client{providers.ProviderOpenAI: p}, nil, false, nil, nil, false, providers.ProviderOpenAI, "gpt-4o", nil)
+	svc := proxy.NewService(fr, map[string]providers.Client{providers.ProviderOpenAI: p}, nil, false, nil, nil, false, providers.ProviderOpenAI, "gpt-5.6-sol", nil)
 
-	body := `{"model":"gpt-4o","messages":[{"role":"user","content":"hi"}],"max_tokens":100}`
+	body := `{"model":"gpt-5.6-sol","messages":[{"role":"user","content":"hi"}],"max_tokens":100}`
 	rec, req := codexSubRequest(t, body)
 
 	ctx := billing.WithSubscriptionOnly(context.Background())

--- a/internal/proxy/subscription_suppression_credential_internal_test.go
+++ b/internal/proxy/subscription_suppression_credential_internal_test.go
@@ -39,7 +39,7 @@ func TestResolveAndInjectCredentials_SuppressedSubClearedOnRouterKeyedPath(t *te
 	headers := http.Header{}
 	headers.Set("Authorization", "Bearer sk-ant-oat01-spent")
 
-	out := resolveAndInjectCredentials(ctx, providers.ProviderAnthropic, headers)
+	out := resolveAndInjectCredentials(ctx, providers.ProviderAnthropic, "claude-opus-4-8", headers)
 
 	assert.Nil(t, CredentialsFromContext(out),
 		"a suppressed subscription must be cleared so the client uses its deployment key, not the spent token")
@@ -51,7 +51,7 @@ func TestResolveAndInjectCredentials_UnsuppressedSubStillForwarded(t *testing.T)
 	headers := http.Header{}
 	headers.Set("Authorization", "Bearer sk-ant-oat01-live")
 
-	out := resolveAndInjectCredentials(routerKeyedCtx(), providers.ProviderAnthropic, headers)
+	out := resolveAndInjectCredentials(routerKeyedCtx(), providers.ProviderAnthropic, "claude-opus-4-8", headers)
 
 	got := CredentialsFromContext(out)
 	require.NotNil(t, got, "a live subscription must resolve on the router-key path")
@@ -68,7 +68,7 @@ func TestResolveAndInjectCredentials_SuppressionDoesNotClearCodexOpenAITurn(t *t
 	headers.Set("Authorization", "Bearer eyJhbGciOi.codex.jwt")
 	headers.Set("ChatGPT-Account-ID", "acct-1")
 
-	out := resolveAndInjectCredentials(ctx, providers.ProviderOpenAI, headers)
+	out := resolveAndInjectCredentials(ctx, providers.ProviderOpenAI, "gpt-5.6-sol", headers)
 
 	got := CredentialsFromContext(out)
 	require.NotNil(t, got, "a Codex subscription must still resolve for its OpenAI turn")
@@ -86,7 +86,7 @@ func TestResolveAndInjectCredentials_DisabledSuppressesClaudeSubscription(t *tes
 	headers := http.Header{}
 	headers.Set("Authorization", "Bearer sk-ant-oat01-live")
 
-	out := resolveAndInjectCredentials(subscriptionDisabledCtx(), providers.ProviderAnthropic, headers)
+	out := resolveAndInjectCredentials(subscriptionDisabledCtx(), providers.ProviderAnthropic, "claude-opus-4-8", headers)
 
 	assert.Nil(t, CredentialsFromContext(out),
 		"toggle off must suppress the Claude subscription so the turn bills prepaid")
@@ -99,7 +99,7 @@ func TestResolveAndInjectCredentials_DisabledSuppressesCodexSubscription(t *test
 	headers.Set("Authorization", "Bearer eyJhbGciOi.codex.jwt")
 	headers.Set("ChatGPT-Account-ID", "acct-1")
 
-	out := resolveAndInjectCredentials(subscriptionDisabledCtx(), providers.ProviderOpenAI, headers)
+	out := resolveAndInjectCredentials(subscriptionDisabledCtx(), providers.ProviderOpenAI, "gpt-5.6-sol", headers)
 
 	assert.Nil(t, CredentialsFromContext(out),
 		"toggle off must suppress the Codex subscription so the turn bills prepaid")
@@ -127,7 +127,7 @@ func TestResolveAndInjectCredentials_DisabledCodexNotReResolvedFromContext(t *te
 	headers.Set("Authorization", "Bearer eyJhbGciOi.codex.jwt")
 	headers.Set("ChatGPT-Account-ID", "acct-1")
 
-	out := resolveAndInjectCredentials(ctx, providers.ProviderOpenAI, headers)
+	out := resolveAndInjectCredentials(ctx, providers.ProviderOpenAI, "gpt-5.6-sol", headers)
 
 	assert.Nil(t, CredentialsFromContext(out),
 		"a disabled Codex subscription carried on ctx must be cleared, not re-resolved")

--- a/internal/proxy/subsidy.go
+++ b/internal/proxy/subsidy.go
@@ -20,13 +20,28 @@ const (
 	routePathResponses       = "/v1/responses"
 )
 
-// codexCoveredModels is the conservative set of GPT models a ChatGPT/Codex
-// subscription actually pays for via the Codex backend (chatgpt.com/backend-api/
-// codex). Deliberately a curated allowlist, not "every OpenAI model": the plan
-// only bills the Codex-served GPT family, so subsidizing an OpenAI model the
-// backend won't bill would bias toward a turn that then 4xxs. Extend as the
-// catalog's Codex-billable GPT set grows.
-var codexCoveredModels = []string{"gpt-5.5", "gpt-5.4", "gpt-5.4-mini"}
+// codexCoveredModels is the fail-closed set of models the Codex CLI may serve
+// through the caller's ChatGPT OAuth credential. Deliberately a curated
+// allowlist, not "every OpenAI model": infrastructure-served OpenAI models
+// share ProviderOpenAI with the native Codex family, but must use BYOK or the
+// router deployment credential instead of chatgpt.com/backend-api/codex.
+var codexCoveredModels = []string{"gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"}
+
+// CodexSubscriptionCoversModel reports whether model may receive the caller's
+// ChatGPT OAuth credential. Exact canonical IDs only; aliases are resolved
+// before routing, and unknown/future models fail closed.
+func CodexSubscriptionCoversModel(model string) bool {
+	for _, covered := range codexCoveredModels {
+		if model == covered {
+			return true
+		}
+	}
+	return false
+}
+
+func codexSubscriptionCoversModel(model string) bool {
+	return CodexSubscriptionCoversModel(model)
+}
 
 // claudeCoveredModels returns the catalog models a Claude (Pro/Max) subscription
 // covers — every Anthropic-primary model. Derived from the catalog so it tracks
@@ -98,9 +113,10 @@ func presentSubscriptionTokens(ctx context.Context, headers http.Header) (codex,
 	return codex, anthropic
 }
 
-// subscriptionServableProviders returns the providers the caller's own
-// subscription can serve inference on: OpenAI for a Codex (ChatGPT) sub,
-// Anthropic for a Claude sub. Empty when the caller presents no usable sub.
+// subscriptionServableProviders returns the provider lanes the caller's own
+// subscription can enter: OpenAI for a Codex (ChatGPT) sub, Anthropic for a
+// Claude sub. Codex model coverage is narrower than its provider lane and is
+// applied by excludeCodexOAuthOnlyModels before routing.
 func subscriptionServableProviders(ctx context.Context, headers http.Header) map[string]struct{} {
 	codex, anthropic := presentSubscriptionTokens(ctx, headers)
 	out := make(map[string]struct{}, 2)
@@ -134,9 +150,10 @@ func restrictToSubscriptionProviders(ctx context.Context, headers http.Header, e
 }
 
 // RequestPresentsCoveringSubscription reports whether the request carries a
-// validated subscription credential capable of serving inference on routePath:
-// a Claude (sk-ant-oat…) sub for /v1/messages, a Codex sub for /v1/chat/completions
-// and /v1/responses. Any other route returns false.
+// validated subscription credential that can serve at least one model on
+// routePath: a Claude (sk-ant-oat…) sub for /v1/messages, a Codex sub for
+// /v1/chat/completions and /v1/responses. Codex's exact model coverage is
+// applied downstream before selection. Any other route returns false.
 //
 // Scoped to the covering family (not "any subscription present") so a Codex
 // bearer on /v1/messages — which can't serve that route — doesn't exempt a

--- a/internal/proxy/subsidy_test.go
+++ b/internal/proxy/subsidy_test.go
@@ -95,10 +95,12 @@ func TestSubsidy_RecordReadKeyAgreement(t *testing.T) {
 	// subsidyFactors must read back the SAME key and discount covered GPT models.
 	factors := s.subsidyFactors(ctx, headers)
 	require.NotNil(t, factors, "headroom was observed; factors must be non-nil")
-	f, ok := factors["gpt-5.5"]
+	f, ok := factors["gpt-5.6-sol"]
 	require.True(t, ok, "covered GPT model must be subsidized")
 	assert.Less(t, f, 1.0, "10%% used → discounted below full price")
 	assert.GreaterOrEqual(t, f, 0.05, "never below epsilon")
+	assert.NotContains(t, factors, "gpt-5.4-nano",
+		"infrastructure OpenAI models must not receive the caller-subscription discount")
 }
 
 // Bootstrap: a present subscription with NO observed headroom yet must still

--- a/internal/proxy/usage_bypass.go
+++ b/internal/proxy/usage_bypass.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"slices"
 	"time"
 
 	"github.com/google/uuid"
@@ -72,7 +71,7 @@ func (s *Service) usageBypassEngaged(ctx context.Context, headers http.Header, r
 	case providers.ProviderAnthropic:
 		token = anthroTok
 	case providers.ProviderOpenAI:
-		if !slices.Contains(codexCoveredModels, model) {
+		if !codexSubscriptionCoversModel(model) {
 			return "", false
 		}
 		token = codexTok
@@ -267,7 +266,7 @@ func (s *Service) bypassToAnthropic(
 	// the subscription (or BYOK / client) credential exactly as a routed turn
 	// would, and so servedOnSubscription / the usage observer key off the same
 	// token the upstream call sends.
-	ctx = resolveAndInjectCredentials(ctx, decision.Provider, r.Header)
+	ctx = resolveAndInjectCredentials(ctx, decision.Provider, decision.Model, r.Header)
 
 	outputReserve := contextWindowOutputReserve
 	if feats.MaxTokens > outputReserve {

--- a/internal/proxy/usage_bypass_internal_test.go
+++ b/internal/proxy/usage_bypass_internal_test.go
@@ -94,7 +94,7 @@ func TestUsageBypassDecision_CodexSubscriptionPreservesRequestedModel(t *testing
 	})
 
 	decision, ok := svc.usageBypassDecision(ctx, http.Header{}, router.Request{
-		RequestedModel: "gpt-5.5",
+		RequestedModel: "gpt-5.6-sol",
 		EnabledProviders: map[string]struct{}{
 			providers.ProviderOpenAI: {},
 		},
@@ -103,7 +103,7 @@ func TestUsageBypassDecision_CodexSubscriptionPreservesRequestedModel(t *testing
 	require.True(t, ok)
 	assert.Equal(t, router.Decision{
 		Provider: providers.ProviderOpenAI,
-		Model:    "gpt-5.5",
+		Model:    "gpt-5.6-sol",
 		Reason:   "usage_bypass",
 	}, decision)
 }
@@ -330,7 +330,7 @@ func subscriptionCtx() context.Context {
 // subscription flips credential resolution onto the deployment key.
 func TestSubscriptionFailover_EligibilityAndSuppression(t *testing.T) {
 	// A request whose Anthropic credential resolves to the caller's subscription.
-	ctx := resolveAndInjectCredentials(subscriptionCtx(), providers.ProviderAnthropic, http.Header{})
+	ctx := resolveAndInjectCredentials(subscriptionCtx(), providers.ProviderAnthropic, "claude-opus-4-8", http.Header{})
 	require.True(t, servedOnSubscription(ctx), "a resolved subscription token must report servedOnSubscription")
 
 	t.Run("no fallback key: not eligible", func(t *testing.T) {
@@ -350,7 +350,7 @@ func TestSubscriptionFailover_EligibilityAndSuppression(t *testing.T) {
 		// subscription token — so the retry dispatches on the deployment key and
 		// servedOnSubscription reports false (billed at full cost, not sub rate).
 		suppressed := withSuppressedClaudeSubscription(subscriptionCtx())
-		suppressed = resolveAndInjectCredentials(suppressed, providers.ProviderAnthropic, http.Header{})
+		suppressed = resolveAndInjectCredentials(suppressed, providers.ProviderAnthropic, "claude-opus-4-8", http.Header{})
 		assert.False(t, servedOnSubscription(suppressed),
 			"a suppressed subscription must not resolve back as the served credential")
 	})

--- a/internal/proxy/usage_bypass_test.go
+++ b/internal/proxy/usage_bypass_test.go
@@ -131,7 +131,7 @@ func TestUsageBypass_CodexSubscriptionPreservesRequestedModel(t *testing.T) {
 		Enabled:   true,
 		Threshold: &threshold,
 	})
-	body := []byte(`{"model":"gpt-5.5","messages":[{"role":"user","content":"hi"}]}`)
+	body := []byte(`{"model":"gpt-5.6-sol","messages":[{"role":"user","content":"hi"}]}`)
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(""))
 
@@ -139,9 +139,9 @@ func TestUsageBypass_CodexSubscriptionPreservesRequestedModel(t *testing.T) {
 
 	assert.Equal(t, 0, fr.routeCalls, "strict pass-through must not call the scorer")
 	require.Len(t, p.proxyBodies, 1)
-	assert.Contains(t, string(p.proxyBodies[0]), `"model":"gpt-5.5"`)
+	assert.Contains(t, string(p.proxyBodies[0]), `"model":"gpt-5.6-sol"`)
 	assert.Equal(t, "usage_bypass", rec.Header().Get("x-router-decision"))
-	assert.Equal(t, "gpt-5.5", rec.Header().Get("x-router-model"))
+	assert.Equal(t, "gpt-5.6-sol", rec.Header().Get("x-router-model"))
 }
 
 // TestUsageBypass_GateDisabled_EngagesRouting: with no per-installation config


### PR DESCRIPTION
enable HMM only for Codex installs targeting the public hosted router, use ChatGPT OAuth only for Sol, Terra, and Luna; route every other selected model through WorkWeave/BYOK