### PR TITLE
fix: route Codex Responses across model providers

### DIFF
--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -5162,6 +5162,9 @@ func (s *Service) ProxyOpenAIResponses(ctx context.Context, body []byte, w http.
 	// Routing, billing, and telemetry are reused via
 	// ProxyOpenAIChatCompletion; chatBody is used only for routing features.
 	wrapper := translate.NewResponsesWriter(w, model)
+	if clientAppCodex {
+		wrapper.EnableCodexBadgeProvenance()
+	}
 	wrapper.SetToolMappings(conversion.ToolMappings)
 	// Defer the high-fidelity call-log emission until after Finalize: the
 	// ResponsesWriter buffers (non-streaming) and emits tail events only in

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -4712,7 +4712,16 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 		// single-binding GPT model with no cross-format fallback to retry
 		// into. If a GPT model ever gains a fallback, gate this per-attempt.
 		if verbatimPassthrough {
-			rw.SetPassthrough()
+			markerEnabled := suppressMarkerIfRequested(r.Header, "enabled") != "" && !routeRes.SuggestionMode
+			mandatoryWarning := billing.SubscriptionOnlyFromContext(ctx)
+			if clientID.ClientApp == ClientAppCodex && (markerEnabled || mandatoryWarning) {
+				if mandatoryWarning {
+					rw.SetBadgeText(subscriptionOnlyWarningMarkerCodex)
+				}
+				rw.SetPassthroughBadge()
+			} else {
+				rw.SetPassthrough()
+			}
 		}
 		if len(bindings) <= 1 {
 			if err := rw.Prelude(env.Stream()); err != nil {
@@ -5113,17 +5122,34 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 // pricing, and translation matrix unchanged.
 func (s *Service) ProxyOpenAIResponses(ctx context.Context, body []byte, w http.ResponseWriter, r *http.Request) error {
 	ctx = s.withUsageObserver(ctx, r.Header)
-	conversion, err := translate.ConvertResponsesToChatCompletions(body)
+	clientAppCodex := ClientIdentityFrom(ctx).ClientApp == ClientAppCodex
+	conversion, err := translate.ConvertResponsesToChatCompletionsWithOptions(body, translate.ResponsesConversionOptions{
+		PortableCodex: clientAppCodex,
+	})
 	if err != nil {
 		return fmt.Errorf("translate responses request: %w", err)
 	}
 	chatBody, model := conversion.Body, conversion.Model
+	codexNativeRequest := codexResponsesRequest(ctx, r.Header)
 	// Keep original bytes only when the request is unrepresentable as Chat
 	// Completions (NativeOnly) or a Codex subscription is using its direct endpoint.
-	if conversion.Requirements.NativeOnly || codexResponsesRequest(ctx, r.Header) {
-		ctx = context.WithValue(ctx, codexResponsesBodyContextKey{}, conversion.OriginalBody)
+	if conversion.Requirements.NativeOnly || codexNativeRequest {
+		nativeBody := conversion.OriginalBody
+		if clientAppCodex {
+			// Codex records response.output_item.done as conversation history and
+			// sends it back in the next native request. Remove only the badge this
+			// client opted into so router text never reaches the selected model.
+			nativeBody, err = translate.StripRoutingBadgeFromResponsesInput(nativeBody)
+			if err != nil {
+				return fmt.Errorf("strip native Responses routing badge: %w", err)
+			}
+		}
+		ctx = context.WithValue(ctx, codexResponsesBodyContextKey{}, nativeBody)
 	}
-	if conversion.Requirements.NativeOnly {
+	// Routing and sticky-state hashes must describe the exact native payload
+	// that an OpenAI/Codex decision will receive, even when the portable Codex
+	// projection lets HMM consider other deployed providers.
+	if conversion.Requirements.NativeOnly || (clientAppCodex && codexNativeRequest) {
 		originalEnvelope, parseErr := translate.ParseOpenAI(conversion.OriginalBody)
 		if parseErr != nil {
 			return fmt.Errorf("parse native Responses request: %w", parseErr)
@@ -5136,6 +5162,7 @@ func (s *Service) ProxyOpenAIResponses(ctx context.Context, body []byte, w http.
 	// Routing, billing, and telemetry are reused via
 	// ProxyOpenAIChatCompletion; chatBody is used only for routing features.
 	wrapper := translate.NewResponsesWriter(w, model)
+	wrapper.SetToolMappings(conversion.ToolMappings)
 	// Defer the high-fidelity call-log emission until after Finalize: the
 	// ResponsesWriter buffers (non-streaming) and emits tail events only in
 	// Finalize, so the captured io.response_body is incomplete until then.

--- a/internal/proxy/service_test.go
+++ b/internal/proxy/service_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
 )
 
 type fakeRouter struct {
@@ -304,6 +305,75 @@ func TestService_ProxyOpenAIResponses_CustomToolUsesNativeOpenAIFamily(t *testin
 	assert.JSONEq(t, `{"id":"resp_1","object":"response","output":[]}`, rec.Body.String())
 }
 
+func TestService_ProxyOpenAIResponses_NativeBadgeIsCodexOnlyAndHonorsSuppression(t *testing.T) {
+	const native = "event: response.output_text.delta\n" +
+		"data: {\"type\":\"response.output_text.delta\",\"sequence_number\":0,\"item_id\":\"msg_1\",\"output_index\":0,\"content_index\":0,\"delta\":\"ok\"}\n\n" +
+		"event: response.output_item.done\n" +
+		"data: {\"type\":\"response.output_item.done\",\"sequence_number\":1,\"output_index\":0,\"item\":{\"id\":\"msg_1\",\"type\":\"message\",\"role\":\"assistant\",\"content\":[{\"type\":\"output_text\",\"text\":\"ok\"}]}}\n\n" +
+		"event: response.completed\n" +
+		"data: {\"type\":\"response.completed\",\"sequence_number\":2,\"response\":{\"id\":\"resp_1\",\"model\":\"gpt-5.6-terra\",\"output\":[{\"id\":\"msg_1\",\"type\":\"message\",\"role\":\"assistant\",\"content\":[{\"type\":\"output_text\",\"text\":\"ok\"}]}]}}\n\n"
+	const priorBadge = "**Weave Router** — gpt-5.6-sol\n\nold answer"
+
+	for _, tc := range []struct {
+		name       string
+		clientApp  string
+		marker     string
+		suggestion bool
+		wantBadge  bool
+		wantStrip  bool
+	}{
+		{name: "Codex", clientApp: proxy.ClientAppCodex, wantBadge: true, wantStrip: true},
+		{name: "Codex marker opt-out", clientApp: proxy.ClientAppCodex, marker: "off", wantStrip: true},
+		{name: "Codex suggestion mode", clientApp: proxy.ClientAppCodex, suggestion: true, wantStrip: true},
+		{name: "non-Codex", clientApp: proxy.ClientAppOpencode},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			provider := &fakeProvider{proxyResponse: func(w http.ResponseWriter) {
+				w.Header().Set("Content-Type", "text/event-stream")
+				w.WriteHeader(http.StatusOK)
+				_, _ = io.WriteString(w, native)
+			}}
+			fr := &fakeRouter{decision: router.Decision{
+				Provider: providers.ProviderOpenAI,
+				Model:    "gpt-5.6-terra",
+				Reason:   "test",
+			}}
+			svc := proxy.NewService(fr, map[string]providers.Client{
+				providers.ProviderOpenAI: provider,
+			}, nil, false, nil, nil, false, providers.ProviderOpenAI, "gpt-5.6-sol", nil)
+
+			ctx := context.WithValue(context.Background(), proxy.OpenAISubscriptionContextKey{}, "eyJhbGciOiJSUzI1NiJ9.codex.sig")
+			ctx = context.WithValue(ctx, proxy.OpenAIAccountIDContextKey{}, "acct-123")
+			ctx = context.WithValue(ctx, proxy.ClientIdentityContextKey{}, proxy.ClientIdentity{ClientApp: tc.clientApp})
+			body := []byte(`{"model":"gpt-5.6-sol","stream":true,"input":[{"type":"message","role":"assistant","content":[{"type":"output_text","text":"**Weave Router** — gpt-5.6-sol\n\nold answer"}]},{"type":"message","role":"user","content":"continue"}]}`)
+			rec := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(""))
+			if tc.marker != "" {
+				req.Header.Set("X-Weave-Routing-Marker", tc.marker)
+			}
+			if tc.suggestion {
+				req.Header.Set("x-weave-suggestion-mode", "true")
+			}
+
+			require.NoError(t, svc.ProxyOpenAIResponses(ctx, body, rec, req))
+			require.Len(t, provider.proxyBodies, 1)
+			assert.Equal(t, "gpt-5.6-terra", gjson.GetBytes(provider.proxyBodies[0], "model").Str)
+			upstreamHistory := gjson.GetBytes(provider.proxyBodies[0], "input.0.content.0.text").Str
+			if tc.wantStrip {
+				assert.Equal(t, "old answer", upstreamHistory)
+			} else {
+				assert.Equal(t, priorBadge, upstreamHistory)
+			}
+			if tc.wantBadge {
+				assert.Contains(t, rec.Body.String(), "**Weave Router** — gpt-5.6-terra ← gpt-5.6-sol")
+				assert.NotEqual(t, native, rec.Body.String())
+			} else {
+				assert.Equal(t, native, rec.Body.String(), "suppressed and non-Codex clients retain byte identity")
+			}
+		})
+	}
+}
+
 func TestService_CodexRequestRoutesInfrastructureOpenAIModelWithoutOAuth(t *testing.T) {
 	provider := &fakeProvider{proxyResponse: func(w http.ResponseWriter) {
 		w.Header().Set("Content-Type", "application/json")
@@ -407,6 +477,80 @@ func TestService_ProxyOpenAIResponses_CodexPassthroughUsesChatForOpenAICompatPro
 	assert.Equal(t, providers.EndpointChatCompletions, openRouter.proxyEndpoints[0])
 	assert.Contains(t, string(openRouter.proxyBodies[0]), `"messages"`)
 	assert.NotContains(t, string(openRouter.proxyBodies[0]), `"input_text"`)
+}
+
+func TestService_ProxyOpenAIResponses_CodexPortableBridgeKeepsHMMProvidersAndRestoresCustomTool(t *testing.T) {
+	fireworks := &fakeProvider{proxyResponse: func(w http.ResponseWriter) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w,
+			`data: {"id":"chatcmpl_1","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_new","type":"function","function":{"name":"exec","arguments":"{\"input\":\"return tools.apply_patch({});\"}"}}]},"finish_reason":null}]}`+"\n\n"+
+				`data: {"id":"chatcmpl_1","object":"chat.completion.chunk","choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}]}`+"\n\n"+
+				"data: [DONE]\n\n")
+	}}
+	fr := &fakeRouter{decision: router.Decision{
+		Provider: providers.ProviderFireworks,
+		Model:    "moonshotai/kimi-k2.7",
+		Reason:   "hmm:test",
+	}}
+	svc := proxy.NewService(fr, map[string]providers.Client{
+		providers.ProviderOpenAI:    &fakeProvider{},
+		providers.ProviderAnthropic: &fakeProvider{},
+		providers.ProviderFireworks: fireworks,
+		providers.ProviderGoogle:    &fakeProvider{},
+		providers.ProviderTogether:  &fakeProvider{},
+	}, nil, false, nil, nil, false, providers.ProviderOpenAI, "gpt-5.6-sol", nil).
+		WithDeploymentKeyedProviders(map[string]struct{}{
+			providers.ProviderOpenAI:    {},
+			providers.ProviderAnthropic: {},
+			providers.ProviderFireworks: {},
+			providers.ProviderGoogle:    {},
+			providers.ProviderTogether:  {},
+		})
+
+	ctx := context.WithValue(context.Background(), proxy.OpenAISubscriptionContextKey{}, "eyJhbGciOiJSUzI1NiJ9.codex.sig")
+	ctx = context.WithValue(ctx, proxy.OpenAIAccountIDContextKey{}, "acct-123")
+	ctx = context.WithValue(ctx, proxy.ClientIdentityContextKey{}, proxy.ClientIdentity{ClientApp: proxy.ClientAppCodex})
+	body := []byte(`{
+		"model":"gpt-5.6-sol",
+		"stream":true,
+		"input":[
+			{"type":"reasoning","id":"rs_1","summary":[],"encrypted_content":"opaque"},
+			{"type":"custom_tool_call","id":"ctc_old","call_id":"call_old","name":"exec","input":"return tools.read({});"},
+			{"type":"custom_tool_call_output","call_id":"call_old","output":[{"type":"input_text","text":"first"},{"type":"input_text","text":"second"}]},
+			{"type":"function_call","id":"fc_old","call_id":"call_send","namespace":"collaboration","name":"send_message","arguments":"{\"target\":\"/root\"}"},
+			{"type":"function_call_output","call_id":"call_send","output":"ok"},
+			{"type":"message","role":"user","content":[{"type":"input_text","text":"continue"}]}
+		],
+		"tools":[{"type":"namespace","name":"functions","tools":[
+			{"type":"custom","name":"exec","description":"Run code mode","format":{"type":"grammar","syntax":"lark","definition":"start: /.+/"}},
+			{"type":"namespace","name":"collaboration","tools":[{"type":"function","name":"send_message","parameters":{"type":"object"}}]}
+		]}]
+	}`)
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(""))
+
+	require.NoError(t, svc.ProxyOpenAIResponses(ctx, body, rec, req))
+	require.NotNil(t, fr.capturedReq)
+	assert.True(t, fr.capturedReq.HasTools)
+	assert.Contains(t, fr.capturedReq.EnabledProviders, providers.ProviderOpenAI)
+	assert.Contains(t, fr.capturedReq.EnabledProviders, providers.ProviderFireworks,
+		"portable Codex turns must reach the ordinary deployed HMM provider roster")
+	assert.Contains(t, fr.capturedReq.EnabledProviders, providers.ProviderAnthropic)
+	assert.Contains(t, fr.capturedReq.EnabledProviders, providers.ProviderGoogle)
+	assert.Contains(t, fr.capturedReq.EnabledProviders, providers.ProviderTogether)
+	require.Len(t, fireworks.proxyBodies, 1)
+	chatBody := fireworks.proxyBodies[0]
+	assert.Equal(t, "moonshotai/kimi-k2.7", gjson.GetBytes(chatBody, "model").Str)
+	assert.Equal(t, "exec", gjson.GetBytes(chatBody, "tools.0.function.name").Str)
+	assert.Equal(t, "collaboration__send_message", gjson.GetBytes(chatBody, "tools.1.function.name").Str)
+	assert.Contains(t, string(chatBody), `"tool_call_id":"call_old"`)
+	assert.Contains(t, string(chatBody), "first")
+	assert.Contains(t, string(chatBody), "second")
+	assert.Contains(t, rec.Body.String(), `"type":"custom_tool_call"`)
+	assert.Contains(t, rec.Body.String(), `"name":"exec"`)
+	assert.Contains(t, rec.Body.String(), `"input":"return tools.apply_patch({});"`)
+	assert.NotContains(t, rec.Body.String(), `"type":"function_call","status":"completed","call_id":"call_new"`)
 }
 
 func (f *fakeProvider) Passthrough(ctx context.Context, prep providers.PreparedRequest, w http.ResponseWriter, r *http.Request) error {

--- a/internal/proxy/service_test.go
+++ b/internal/proxy/service_test.go
@@ -312,7 +312,7 @@ func TestService_ProxyOpenAIResponses_NativeBadgeIsCodexOnlyAndHonorsSuppression
 		"data: {\"type\":\"response.output_item.done\",\"sequence_number\":1,\"output_index\":0,\"item\":{\"id\":\"msg_1\",\"type\":\"message\",\"role\":\"assistant\",\"content\":[{\"type\":\"output_text\",\"text\":\"ok\"}]}}\n\n" +
 		"event: response.completed\n" +
 		"data: {\"type\":\"response.completed\",\"sequence_number\":2,\"response\":{\"id\":\"resp_1\",\"model\":\"gpt-5.6-terra\",\"output\":[{\"id\":\"msg_1\",\"type\":\"message\",\"role\":\"assistant\",\"content\":[{\"type\":\"output_text\",\"text\":\"ok\"}]}]}}\n\n"
-	const priorBadge = "**Weave Router** — gpt-5.6-sol\n\nold answer"
+	const priorBadge = "\u2063\u2060\u2063\u2060**Weave Router** — gpt-5.6-sol\n\nold answer"
 
 	for _, tc := range []struct {
 		name       string
@@ -345,7 +345,7 @@ func TestService_ProxyOpenAIResponses_NativeBadgeIsCodexOnlyAndHonorsSuppression
 			ctx := context.WithValue(context.Background(), proxy.OpenAISubscriptionContextKey{}, "eyJhbGciOiJSUzI1NiJ9.codex.sig")
 			ctx = context.WithValue(ctx, proxy.OpenAIAccountIDContextKey{}, "acct-123")
 			ctx = context.WithValue(ctx, proxy.ClientIdentityContextKey{}, proxy.ClientIdentity{ClientApp: tc.clientApp})
-			body := []byte(`{"model":"gpt-5.6-sol","stream":true,"input":[{"type":"message","role":"assistant","content":[{"type":"output_text","text":"**Weave Router** — gpt-5.6-sol\n\nold answer"}]},{"type":"message","role":"user","content":"continue"}]}`)
+			body := []byte(`{"model":"gpt-5.6-sol","stream":true,"input":[{"type":"message","role":"assistant","content":[{"type":"output_text","text":"\u2063\u2060\u2063\u2060**Weave Router** — gpt-5.6-sol\n\nold answer"}]},{"type":"message","role":"user","content":"continue"}]}`)
 			rec := httptest.NewRecorder()
 			req := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(""))
 			if tc.marker != "" {
@@ -512,9 +512,12 @@ func TestService_ProxyOpenAIResponses_CodexPortableBridgeKeepsHMMProvidersAndRes
 	ctx = context.WithValue(ctx, proxy.OpenAIAccountIDContextKey{}, "acct-123")
 	ctx = context.WithValue(ctx, proxy.ClientIdentityContextKey{}, proxy.ClientIdentity{ClientApp: proxy.ClientAppCodex})
 	body := []byte(`{
-		"model":"gpt-5.6-sol",
-		"stream":true,
-		"input":[
+			"model":"gpt-5.6-sol",
+			"stream":true,
+			"service_tier":"priority",
+			"prompt_cache_key":"codex-cache-key",
+			"text":{"verbosity":"low"},
+			"input":[
 			{"type":"reasoning","id":"rs_1","summary":[],"encrypted_content":"opaque"},
 			{"type":"custom_tool_call","id":"ctc_old","call_id":"call_old","name":"exec","input":"return tools.read({});"},
 			{"type":"custom_tool_call_output","call_id":"call_old","output":[{"type":"input_text","text":"first"},{"type":"input_text","text":"second"}]},
@@ -524,7 +527,7 @@ func TestService_ProxyOpenAIResponses_CodexPortableBridgeKeepsHMMProvidersAndRes
 		],
 		"tools":[{"type":"namespace","name":"functions","tools":[
 			{"type":"custom","name":"exec","description":"Run code mode","format":{"type":"grammar","syntax":"lark","definition":"start: /.+/"}},
-			{"type":"namespace","name":"collaboration","tools":[{"type":"function","name":"send_message","parameters":{"type":"object"}}]}
+				{"type":"namespace","name":"collaboration","tools":[{"type":"function","name":"send_message","parameters":{"type":"object","$defs":{"target":{"type":"string"}},"properties":{"target":{"$ref":"#/$defs/target"}}}}]}
 		]}]
 	}`)
 	rec := httptest.NewRecorder()
@@ -544,6 +547,12 @@ func TestService_ProxyOpenAIResponses_CodexPortableBridgeKeepsHMMProvidersAndRes
 	assert.Equal(t, "moonshotai/kimi-k2.7", gjson.GetBytes(chatBody, "model").Str)
 	assert.Equal(t, "exec", gjson.GetBytes(chatBody, "tools.0.function.name").Str)
 	assert.Equal(t, "collaboration__send_message", gjson.GetBytes(chatBody, "tools.1.function.name").Str)
+	assert.Equal(t, "string", gjson.GetBytes(chatBody, "tools.1.function.parameters.properties.target.type").Str)
+	assert.False(t, gjson.GetBytes(chatBody, "tools.1.function.parameters.$defs").Exists())
+	assert.NotContains(t, gjson.GetBytes(chatBody, "tools.1.function.parameters").Raw, `"$ref"`)
+	assert.False(t, gjson.GetBytes(chatBody, "service_tier").Exists())
+	assert.False(t, gjson.GetBytes(chatBody, "prompt_cache_key").Exists())
+	assert.Equal(t, "Keep the response concise and focused.", gjson.GetBytes(chatBody, "messages.0.content").Str)
 	assert.Contains(t, string(chatBody), `"tool_call_id":"call_old"`)
 	assert.Contains(t, string(chatBody), "first")
 	assert.Contains(t, string(chatBody), "second")

--- a/internal/translate/responses.go
+++ b/internal/translate/responses.go
@@ -277,10 +277,8 @@ func responsesInputItemToMessages(item gjson.Result) ([]map[string]any, error) {
 // upstream.
 var responsesBadgePattern = regexp.MustCompile(`(?is)\A(?:\*\*WEAVE ROUTER\*\* — .*?\n\n|✦ \*\*WEAVE ROUTER\*\* → .*?\n\n)`)
 
-// codexResponsesBadgeSentinel is an invisible, router-owned prefix carried in
-// Codex assistant history. Native/portable Codex ingress requires this prefix
-// before removing badge text, so ordinary assistant prose that happens to
-// begin with the visible Weave heading is never mistaken for injected metadata.
+// codexResponsesBadgeSentinel is an invisible router-owned prefix that
+// distinguishes injected badge text from user-authored assistant prose.
 const codexResponsesBadgeSentinel = "\u2063\u2060\u2063\u2060"
 
 var codexResponsesBadgePattern = regexp.MustCompile(
@@ -522,9 +520,8 @@ func (t *ResponsesWriter) SetBadgeText(text string) {
 	t.badgeText = text + "\n\n"
 }
 
-// EnableCodexBadgeProvenance marks any in-band Responses badge with the
-// invisible prefix required by Codex-specific ingress stripping. It is kept
-// opt-in so other Responses clients preserve their existing wire behavior.
+// EnableCodexBadgeProvenance prefixes in-band badges with the invisible
+// sentinel so ingress stripping only removes router-injected text.
 func (t *ResponsesWriter) EnableCodexBadgeProvenance() {
 	t.codexBadgeProvenance = true
 }
@@ -964,9 +961,7 @@ func (t *ResponsesWriter) rewriteNativeResponsesEvent(raw []byte) []byte {
 	if offset < 0 {
 		return raw
 	}
-	// Preallocate only the already-realized event size. The badge may make the
-	// payload larger; append can grow safely without overflow-prone capacity
-	// arithmetic over provider-controlled stream lengths.
+	// Preallocate only len(raw); badge growth is handled safely by append.
 	rewritten := make([]byte, 0, len(raw))
 	rewritten = append(rewritten, raw[:offset]...)
 	rewritten = append(rewritten, rewrittenData...)

--- a/internal/translate/responses.go
+++ b/internal/translate/responses.go
@@ -277,10 +277,19 @@ func responsesInputItemToMessages(item gjson.Result) ([]map[string]any, error) {
 // upstream.
 var responsesBadgePattern = regexp.MustCompile(`(?is)\A(?:\*\*WEAVE ROUTER\*\* — .*?\n\n|✦ \*\*WEAVE ROUTER\*\* → .*?\n\n)`)
 
-// StripRoutingBadgeFromResponsesInput removes a router badge from prior
-// assistant message items while preserving every other native Responses field.
-// Callers should scope this to clients for which the router itself injected the
-// badge; generic native Responses callers retain byte-for-byte input semantics.
+// codexResponsesBadgeSentinel is an invisible, router-owned prefix carried in
+// Codex assistant history. Native/portable Codex ingress requires this prefix
+// before removing badge text, so ordinary assistant prose that happens to
+// begin with the visible Weave heading is never mistaken for injected metadata.
+const codexResponsesBadgeSentinel = "\u2063\u2060\u2063\u2060"
+
+var codexResponsesBadgePattern = regexp.MustCompile(
+	`(?is)\A` + regexp.QuoteMeta(codexResponsesBadgeSentinel) +
+		`(?:\*\*WEAVE ROUTER\*\* — .*?\n\n|✦ \*\*WEAVE ROUTER\*\* → .*?\n\n)`,
+)
+
+// StripRoutingBadgeFromResponsesInput removes a provenance-marked router badge
+// from assistant items. Call only for clients opted into the Codex badge.
 func StripRoutingBadgeFromResponsesInput(body []byte) ([]byte, error) {
 	input := gjson.GetBytes(body, "input")
 	if !input.IsArray() {
@@ -300,7 +309,7 @@ func StripRoutingBadgeFromResponsesInput(body []byte) ([]byte, error) {
 
 		content := item.Get("content")
 		if content.Type == gjson.String {
-			stripped := responsesBadgePattern.ReplaceAllString(content.Str, "")
+			stripped := codexResponsesBadgePattern.ReplaceAllString(content.Str, "")
 			if stripped == content.Str {
 				continue
 			}
@@ -320,7 +329,7 @@ func StripRoutingBadgeFromResponsesInput(body []byte) ([]byte, error) {
 			switch part.Get("type").Str {
 			case "input_text", "output_text", "text":
 				text := part.Get("text").Str
-				stripped := responsesBadgePattern.ReplaceAllString(text, "")
+				stripped := codexResponsesBadgePattern.ReplaceAllString(text, "")
 				if stripped != text {
 					var err error
 					path := "input." + strconv.Itoa(itemIndex) + ".content." + strconv.Itoa(partIndex) + ".text"
@@ -414,6 +423,7 @@ type ResponsesWriter struct {
 	completedEmitted           bool
 	badgePrepended             bool
 	badgeText                  string
+	codexBadgeProvenance       bool
 	nativeBadgeTargetSelected  bool
 	nativeBadgeDeltaPrepended  bool
 	nativeBadgeItemID          string
@@ -512,6 +522,13 @@ func (t *ResponsesWriter) SetBadgeText(text string) {
 	t.badgeText = text + "\n\n"
 }
 
+// EnableCodexBadgeProvenance marks any in-band Responses badge with the
+// invisible prefix required by Codex-specific ingress stripping. It is kept
+// opt-in so other Responses clients preserve their existing wire behavior.
+func (t *ResponsesWriter) EnableCodexBadgeProvenance() {
+	t.codexBadgeProvenance = true
+}
+
 func (t *ResponsesWriter) Header() http.Header { return t.inner.Header() }
 
 // SetPassthrough switches to verbatim mode: bytes forwarded unchanged, no
@@ -526,6 +543,7 @@ func (t *ResponsesWriter) SetPassthrough() { t.passthrough = true }
 // fields in the first assistant message; event order, sequence numbers,
 // response/item ids, output indices, reasoning, and tool calls remain native.
 func (t *ResponsesWriter) SetPassthroughBadge() {
+	t.EnableCodexBadgeProvenance()
 	t.passthrough = true
 	t.passthroughBadge = true
 }
@@ -819,7 +837,7 @@ func (t *ResponsesWriter) observeNativeBadgeTarget(ref nativeResponsesBadgeRef) 
 
 func (t *ResponsesWriter) prefixNativeBadge(data []byte, path string) ([]byte, bool) {
 	text := gjson.GetBytes(data, path)
-	if text.Type != gjson.String || text.Str == "" || responsesBadgePattern.MatchString(text.Str) {
+	if text.Type != gjson.String || text.Str == "" || codexResponsesBadgePattern.MatchString(text.Str) {
 		return data, false
 	}
 	badge := t.computeBadgeText()
@@ -946,7 +964,10 @@ func (t *ResponsesWriter) rewriteNativeResponsesEvent(raw []byte) []byte {
 	if offset < 0 {
 		return raw
 	}
-	rewritten := make([]byte, 0, len(raw)-len(data)+len(rewrittenData))
+	// Preallocate only the already-realized event size. The badge may make the
+	// payload larger; append can grow safely without overflow-prone capacity
+	// arithmetic over provider-controlled stream lengths.
+	rewritten := make([]byte, 0, len(raw))
 	rewritten = append(rewritten, raw[:offset]...)
 	rewritten = append(rewritten, rewrittenData...)
 	rewritten = append(rewritten, raw[offset+len(data):]...)
@@ -1229,17 +1250,23 @@ func (t *ResponsesWriter) nextOutputIndex() int {
 // delta, e.g. "**Weave Router** — <routed> ← <requested>" (arrow only when
 // swapped). Returns "" if no routed model is known yet.
 func (t *ResponsesWriter) computeBadgeText() string {
+	var badge string
 	if t.badgeText != "" {
-		return t.badgeText
+		badge = t.badgeText
+	} else {
+		if t.model == "" {
+			return ""
+		}
+		badge = "**Weave Router** — " + t.model
+		if t.requestedModel != "" && t.requestedModel != t.model {
+			badge += " ← " + t.requestedModel
+		}
+		badge += "\n\n"
 	}
-	if t.model == "" {
-		return ""
+	if t.codexBadgeProvenance && !strings.HasPrefix(badge, codexResponsesBadgeSentinel) {
+		badge = codexResponsesBadgeSentinel + badge
 	}
-	badge := "**Weave Router** — " + t.model
-	if t.requestedModel != "" && t.requestedModel != t.model {
-		badge += " ← " + t.requestedModel
-	}
-	return badge + "\n\n"
+	return badge
 }
 
 func (t *ResponsesWriter) closeOpenItems() error {

--- a/internal/translate/responses.go
+++ b/internal/translate/responses.go
@@ -17,6 +17,7 @@ import (
 	"workweave/router/internal/sse"
 
 	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
 )
 
 // ResponsesConversion is the typed ingress result for a Responses request.
@@ -29,6 +30,7 @@ type ResponsesConversion struct {
 	Model        string
 	Requirements router.TranslationRequirements
 	Report       []ResponseTransform
+	ToolMappings map[string]ResponsesToolMapping
 }
 
 // ResponseTransform reports an ingress conversion outcome with a stable code.
@@ -275,6 +277,71 @@ func responsesInputItemToMessages(item gjson.Result) ([]map[string]any, error) {
 // upstream.
 var responsesBadgePattern = regexp.MustCompile(`(?is)\A(?:\*\*WEAVE ROUTER\*\* — .*?\n\n|✦ \*\*WEAVE ROUTER\*\* → .*?\n\n)`)
 
+// StripRoutingBadgeFromResponsesInput removes a router badge from prior
+// assistant message items while preserving every other native Responses field.
+// Callers should scope this to clients for which the router itself injected the
+// badge; generic native Responses callers retain byte-for-byte input semantics.
+func StripRoutingBadgeFromResponsesInput(body []byte) ([]byte, error) {
+	input := gjson.GetBytes(body, "input")
+	if !input.IsArray() {
+		return body, nil
+	}
+
+	out := body
+	changed := false
+	for itemIndex, item := range input.Array() {
+		itemType := item.Get("type").Str
+		if itemType != "message" && !(itemType == "" && item.Get("role").Str != "") {
+			continue
+		}
+		if item.Get("role").Str != "assistant" {
+			continue
+		}
+
+		content := item.Get("content")
+		if content.Type == gjson.String {
+			stripped := responsesBadgePattern.ReplaceAllString(content.Str, "")
+			if stripped == content.Str {
+				continue
+			}
+			var err error
+			out, err = sjson.SetBytes(out, "input."+strconv.Itoa(itemIndex)+".content", stripped)
+			if err != nil {
+				return nil, fmt.Errorf("strip Responses routing badge from string content: %w", err)
+			}
+			changed = true
+			continue
+		}
+		if !content.IsArray() {
+			continue
+		}
+	contentParts:
+		for partIndex, part := range content.Array() {
+			switch part.Get("type").Str {
+			case "input_text", "output_text", "text":
+				text := part.Get("text").Str
+				stripped := responsesBadgePattern.ReplaceAllString(text, "")
+				if stripped != text {
+					var err error
+					path := "input." + strconv.Itoa(itemIndex) + ".content." + strconv.Itoa(partIndex) + ".text"
+					out, err = sjson.SetBytes(out, path, stripped)
+					if err != nil {
+						return nil, fmt.Errorf("strip Responses routing badge from content part: %w", err)
+					}
+					changed = true
+				}
+				// The egress marker is only ever prepended to the first text part.
+				// Do not strip a marker-like string from later assistant content.
+				break contentParts
+			}
+		}
+	}
+	if !changed {
+		return body, nil
+	}
+	return out, nil
+}
+
 // responsesContentToChatContent flattens a content array. For assistant
 // messages we may also extract tool-call shells if a client embeds them.
 func responsesContentToChatContent(content gjson.Result, role string) (string, []map[string]any) {
@@ -333,25 +400,34 @@ type ResponsesWriter struct {
 	responseID     string
 	createdAt      int64
 
-	statusCode      int
-	streaming       bool
-	httpHeadersSent bool
-	passthrough     bool
-	buf             bytes.Buffer
+	statusCode       int
+	streaming        bool
+	httpHeadersSent  bool
+	passthrough      bool
+	passthroughBadge bool
+	buf              bytes.Buffer
 
 	seq int64
 
 	// Streaming state.
-	headersEmitted   bool
-	completedEmitted bool
-	badgePrepended   bool
-	badgeText        string
-	textItem         *responsesTextItem
-	toolItems        map[int]*responsesToolItem
-	finishReason     string
-	usage            *responsesUsage
-	lifecycle        *StreamLifecycle
-	toolLedger       *ToolCallLedger
+	headersEmitted             bool
+	completedEmitted           bool
+	badgePrepended             bool
+	badgeText                  string
+	nativeBadgeTargetSelected  bool
+	nativeBadgeDeltaPrepended  bool
+	nativeBadgeItemID          string
+	nativeBadgeOutputIndex     int64
+	nativeBadgeHasOutputIndex  bool
+	nativeBadgeContentIndex    int64
+	nativeBadgeHasContentIndex bool
+	textItem                   *responsesTextItem
+	toolItems                  map[int]*responsesToolItem
+	finishReason               string
+	usage                      *responsesUsage
+	lifecycle                  *StreamLifecycle
+	toolLedger                 *ToolCallLedger
+	toolMappings               map[string]ResponsesToolMapping
 }
 
 type responsesTextItem struct {
@@ -366,8 +442,10 @@ type responsesToolItem struct {
 	itemID      string
 	callID      string
 	name        string
+	mapping     ResponsesToolMapping
 	outputIndex int
 	arguments   strings.Builder
+	opened      bool
 	closed      bool
 }
 
@@ -403,6 +481,17 @@ func NewResponsesWriter(w http.ResponseWriter, model string) *ResponsesWriter {
 	}
 }
 
+// SetToolMappings teaches the Responses writer how synthetic Chat function
+// aliases map back to the function/custom tool contract Codex originally sent.
+// A nil map preserves the ordinary function-call behavior for every other
+// Responses client.
+func (t *ResponsesWriter) SetToolMappings(mappings map[string]ResponsesToolMapping) {
+	if len(mappings) == 0 {
+		return
+	}
+	t.toolMappings = mappings
+}
+
 // WrapInner splices fn between this writer and the client writer, rebinding
 // inner and bw so every byte (prelude, SSE events, final envelope) flows
 // through fn — used for content-capture telemetry. Call before any writes.
@@ -432,23 +521,33 @@ func (t *ResponsesWriter) Header() http.Header { return t.inner.Header() }
 // routing, before Prelude).
 func (t *ResponsesWriter) SetPassthrough() { t.passthrough = true }
 
+// SetPassthroughBadge switches to native Responses passthrough while opting
+// into a Codex-visible routed-model badge. It rewrites only existing text
+// fields in the first assistant message; event order, sequence numbers,
+// response/item ids, output indices, reasoning, and tool calls remain native.
+func (t *ResponsesWriter) SetPassthroughBadge() {
+	t.passthrough = true
+	t.passthroughBadge = true
+}
+
 func (t *ResponsesWriter) WriteHeader(code int) {
+	// Prelude can run before routing completes, so learn the served model from
+	// the proxy header at the last safe point before either response mode writes.
+	if routed := t.inner.Header().Get("x-router-model"); routed != "" {
+		t.model = routed
+	}
 	if t.passthrough {
 		if t.httpHeadersSent {
 			return
 		}
 		t.statusCode = code
+		t.streaming = strings.Contains(t.inner.Header().Get("Content-Type"), "text/event-stream") && code < 400
 		// Codex backend already sets text/event-stream; only drop length/encoding.
 		t.inner.Header().Del("Content-Length")
 		t.inner.Header().Del("Content-Encoding")
 		t.inner.WriteHeader(code)
 		t.httpHeadersSent = true
 		return
-	}
-	// Prelude fires before routing completes (x-router-model unset yet), so
-	// this later call is our only chance to learn the routed name.
-	if routed := t.inner.Header().Get("x-router-model"); routed != "" {
-		t.model = routed
 	}
 	if t.httpHeadersSent {
 		return
@@ -469,12 +568,27 @@ func (t *ResponsesWriter) WriteHeader(code int) {
 
 func (t *ResponsesWriter) Write(data []byte) (int, error) {
 	if t.passthrough {
-		// Forward verbatim. The upstream (Codex backend) emits Responses SSE
-		// natively, so there is nothing to translate.
 		if !t.httpHeadersSent {
+			t.streaming = strings.Contains(t.inner.Header().Get("Content-Type"), "text/event-stream")
 			t.inner.WriteHeader(http.StatusOK)
 			t.httpHeadersSent = true
 		}
+		// Generic native Responses callers remain byte-for-byte passthrough. Only
+		// the explicitly enabled Codex display path parses native SSE.
+		if t.passthroughBadge && t.streaming {
+			n := len(data)
+			t.buf.Write(data)
+			err := t.processPassthroughSSEBuffer()
+			if err == nil {
+				err = t.bw.Flush()
+				if t.flusher != nil {
+					t.flusher.Flush()
+				}
+			}
+			return n, err
+		}
+		// Forward verbatim. The upstream emits Responses natively, so there is
+		// nothing to translate for clients that did not opt into the display badge.
 		written, err := t.bw.Write(data)
 		if err == nil {
 			err = t.bw.Flush()
@@ -540,7 +654,12 @@ func (t *ResponsesWriter) Flush() {
 // Finalize handles non-streaming bodies and end-of-stream completion events.
 func (t *ResponsesWriter) Finalize() error {
 	if t.passthrough {
-		// Nothing to synthesize; bodies were already forwarded as-is in Write.
+		if t.passthroughBadge && t.streaming {
+			if err := t.processFinalPassthroughSSETail(); err != nil {
+				return err
+			}
+		}
+		// Nothing is synthesized; the upstream remains the event authority.
 		return t.bw.Flush()
 	}
 	if t.streaming {
@@ -566,7 +685,7 @@ func (t *ResponsesWriter) Finalize() error {
 		return err
 	}
 
-	translated, err := chatCompletionToResponse(body, t.responseID, t.model, t.createdAt)
+	translated, err := chatCompletionToResponse(body, t.responseID, t.model, t.createdAt, t.toolMappings)
 	if err != nil {
 		t.inner.Header().Set("Content-Type", "application/json")
 		t.inner.WriteHeader(http.StatusBadGateway)
@@ -577,6 +696,296 @@ func (t *ResponsesWriter) Finalize() error {
 	t.inner.WriteHeader(t.statusCode)
 	_, err = t.inner.Write(translated)
 	return err
+}
+
+type nativeResponsesBadgeRef struct {
+	itemID          string
+	outputIndex     int64
+	hasOutputIndex  bool
+	contentIndex    int64
+	hasContentIndex bool
+}
+
+func nativeResponsesIndex(root gjson.Result, path string) (int64, bool) {
+	value := root.Get(path)
+	return value.Int(), value.Exists()
+}
+
+func nativeResponsesEventRef(root gjson.Result, itemIDPath string) nativeResponsesBadgeRef {
+	outputIndex, hasOutputIndex := nativeResponsesIndex(root, "output_index")
+	contentIndex, hasContentIndex := nativeResponsesIndex(root, "content_index")
+	return nativeResponsesBadgeRef{
+		itemID:          root.Get(itemIDPath).Str,
+		outputIndex:     outputIndex,
+		hasOutputIndex:  hasOutputIndex,
+		contentIndex:    contentIndex,
+		hasContentIndex: hasContentIndex,
+	}
+}
+
+func nativeResponsesAssistantMessage(item gjson.Result) bool {
+	if item.Get("type").Str != "message" {
+		return false
+	}
+	role := item.Get("role").Str
+	return role == "" || role == "assistant"
+}
+
+func firstNativeOutputTextPart(item gjson.Result) (int, bool) {
+	content := item.Get("content")
+	if !content.IsArray() {
+		return 0, false
+	}
+	for index, part := range content.Array() {
+		if part.Get("type").Str == "output_text" && part.Get("text").Type == gjson.String {
+			return index, true
+		}
+	}
+	return 0, false
+}
+
+func (t *ResponsesWriter) nativeOutputTextPart(item gjson.Result) (int, bool) {
+	content := item.Get("content")
+	if !content.IsArray() {
+		return 0, false
+	}
+	if !t.nativeBadgeHasContentIndex {
+		return firstNativeOutputTextPart(item)
+	}
+	index := int(t.nativeBadgeContentIndex)
+	parts := content.Array()
+	if index < 0 || index >= len(parts) {
+		return 0, false
+	}
+	part := parts[index]
+	if part.Get("type").Str != "output_text" || part.Get("text").Type != gjson.String {
+		return 0, false
+	}
+	return index, true
+}
+
+func (t *ResponsesWriter) nativeBadgeTargetMatches(ref nativeResponsesBadgeRef, includeContent bool) bool {
+	if !t.nativeBadgeTargetSelected {
+		return false
+	}
+	matched := false
+	if t.nativeBadgeItemID != "" && ref.itemID != "" {
+		if t.nativeBadgeItemID != ref.itemID {
+			return false
+		}
+		matched = true
+	}
+	if t.nativeBadgeHasOutputIndex && ref.hasOutputIndex {
+		if t.nativeBadgeOutputIndex != ref.outputIndex {
+			return false
+		}
+		matched = true
+	}
+	if includeContent && t.nativeBadgeHasContentIndex && ref.hasContentIndex {
+		if t.nativeBadgeContentIndex != ref.contentIndex {
+			return false
+		}
+		matched = true
+	}
+	return matched
+}
+
+func (t *ResponsesWriter) observeNativeBadgeTarget(ref nativeResponsesBadgeRef) bool {
+	if !t.nativeBadgeTargetSelected {
+		t.nativeBadgeTargetSelected = true
+		t.nativeBadgeItemID = ref.itemID
+		t.nativeBadgeOutputIndex = ref.outputIndex
+		t.nativeBadgeHasOutputIndex = ref.hasOutputIndex
+		t.nativeBadgeContentIndex = ref.contentIndex
+		t.nativeBadgeHasContentIndex = ref.hasContentIndex
+		return true
+	}
+	if !t.nativeBadgeTargetMatches(ref, false) {
+		return false
+	}
+	if t.nativeBadgeItemID == "" {
+		t.nativeBadgeItemID = ref.itemID
+	}
+	if !t.nativeBadgeHasOutputIndex && ref.hasOutputIndex {
+		t.nativeBadgeOutputIndex = ref.outputIndex
+		t.nativeBadgeHasOutputIndex = true
+	}
+	if !t.nativeBadgeHasContentIndex && ref.hasContentIndex {
+		t.nativeBadgeContentIndex = ref.contentIndex
+		t.nativeBadgeHasContentIndex = true
+	}
+	return true
+}
+
+func (t *ResponsesWriter) prefixNativeBadge(data []byte, path string) ([]byte, bool) {
+	text := gjson.GetBytes(data, path)
+	if text.Type != gjson.String || text.Str == "" || responsesBadgePattern.MatchString(text.Str) {
+		return data, false
+	}
+	badge := t.computeBadgeText()
+	if badge == "" {
+		return data, false
+	}
+	rewritten, err := sjson.SetBytes(append([]byte(nil), data...), path, badge+text.Str)
+	if err != nil {
+		// The badge is cosmetic. A malformed or unexpected event must retain the
+		// upstream bytes instead of terminating an otherwise valid model stream.
+		return data, false
+	}
+	return rewritten, true
+}
+
+func (t *ResponsesWriter) rewriteNativeResponsesPayload(data []byte) ([]byte, bool) {
+	if !gjson.ValidBytes(data) {
+		return data, false
+	}
+	root := gjson.ParseBytes(data)
+	switch root.Get("type").Str {
+	case "response.content_part.added":
+		if root.Get("part.type").Str != "output_text" {
+			return data, false
+		}
+		t.observeNativeBadgeTarget(nativeResponsesEventRef(root, "item_id"))
+		return data, false
+
+	case "response.output_text.delta":
+		ref := nativeResponsesEventRef(root, "item_id")
+		if !t.observeNativeBadgeTarget(ref) || !t.nativeBadgeTargetMatches(ref, true) {
+			return data, false
+		}
+		delta := root.Get("delta")
+		if t.nativeBadgeDeltaPrepended || delta.Type != gjson.String || delta.Str == "" {
+			return data, false
+		}
+		// Each delta carries only newly generated text. Prefix exactly the first
+		// non-empty one; the cumulative done snapshots below are rewritten
+		// independently so Codex history and the live stream agree.
+		t.nativeBadgeDeltaPrepended = true
+		return t.prefixNativeBadge(data, "delta")
+
+	case "response.output_text.done":
+		ref := nativeResponsesEventRef(root, "item_id")
+		if !t.observeNativeBadgeTarget(ref) || !t.nativeBadgeTargetMatches(ref, true) {
+			return data, false
+		}
+		return t.prefixNativeBadge(data, "text")
+
+	case "response.content_part.done":
+		if root.Get("part.type").Str != "output_text" {
+			return data, false
+		}
+		ref := nativeResponsesEventRef(root, "item_id")
+		if !t.observeNativeBadgeTarget(ref) || !t.nativeBadgeTargetMatches(ref, true) {
+			return data, false
+		}
+		return t.prefixNativeBadge(data, "part.text")
+
+	case "response.output_item.done":
+		item := root.Get("item")
+		if !nativeResponsesAssistantMessage(item) {
+			return data, false
+		}
+		ref := nativeResponsesEventRef(root, "item.id")
+		if t.nativeBadgeTargetSelected && !t.nativeBadgeTargetMatches(ref, false) {
+			return data, false
+		}
+		partIndex, ok := t.nativeOutputTextPart(item)
+		if !ok {
+			return data, false
+		}
+		ref.contentIndex = int64(partIndex)
+		ref.hasContentIndex = true
+		if !t.observeNativeBadgeTarget(ref) || !t.nativeBadgeTargetMatches(ref, true) {
+			return data, false
+		}
+		return t.prefixNativeBadge(data, "item.content."+strconv.Itoa(partIndex)+".text")
+
+	case "response.completed", "response.incomplete":
+		output := root.Get("response.output")
+		if !output.IsArray() {
+			return data, false
+		}
+		for outputIndex, item := range output.Array() {
+			if !nativeResponsesAssistantMessage(item) {
+				continue
+			}
+			ref := nativeResponsesBadgeRef{
+				itemID:         item.Get("id").Str,
+				outputIndex:    int64(outputIndex),
+				hasOutputIndex: true,
+			}
+			if t.nativeBadgeTargetSelected && !t.nativeBadgeTargetMatches(ref, false) {
+				continue
+			}
+			partIndex, ok := t.nativeOutputTextPart(item)
+			if !ok {
+				continue
+			}
+			ref.contentIndex = int64(partIndex)
+			ref.hasContentIndex = true
+			if !t.observeNativeBadgeTarget(ref) || !t.nativeBadgeTargetMatches(ref, true) {
+				continue
+			}
+			path := "response.output." + strconv.Itoa(outputIndex) + ".content." + strconv.Itoa(partIndex) + ".text"
+			return t.prefixNativeBadge(data, path)
+		}
+	}
+	return data, false
+}
+
+func (t *ResponsesWriter) rewriteNativeResponsesEvent(raw []byte) []byte {
+	_, data := sse.ParseEvent(raw)
+	if len(data) == 0 {
+		return raw
+	}
+	rewrittenData, changed := t.rewriteNativeResponsesPayload(data)
+	if !changed {
+		return raw
+	}
+	offset := bytes.Index(raw, data)
+	if offset < 0 {
+		return raw
+	}
+	rewritten := make([]byte, 0, len(raw)-len(data)+len(rewrittenData))
+	rewritten = append(rewritten, raw[:offset]...)
+	rewritten = append(rewritten, rewrittenData...)
+	rewritten = append(rewritten, raw[offset+len(data):]...)
+	return rewritten
+}
+
+func (t *ResponsesWriter) writeNativeResponsesEvent(event, delimiter []byte) error {
+	if _, err := t.bw.Write(t.rewriteNativeResponsesEvent(event)); err != nil {
+		return err
+	}
+	if len(delimiter) > 0 {
+		_, err := t.bw.Write(delimiter)
+		return err
+	}
+	return nil
+}
+
+func (t *ResponsesWriter) processPassthroughSSEBuffer() error {
+	for {
+		buffered := t.buf.Bytes()
+		event, n := sse.SplitNext(buffered)
+		if n == 0 {
+			return nil
+		}
+		err := t.writeNativeResponsesEvent(event, buffered[len(event):n])
+		t.buf.Next(n)
+		if err != nil {
+			return err
+		}
+	}
+}
+
+func (t *ResponsesWriter) processFinalPassthroughSSETail() error {
+	if t.buf.Len() == 0 {
+		return nil
+	}
+	event := append([]byte(nil), t.buf.Bytes()...)
+	t.buf.Reset()
+	return t.writeNativeResponsesEvent(event, nil)
 }
 
 // FinalizeError emits a response.failed terminal event when upstream fails
@@ -592,12 +1001,15 @@ func (t *ResponsesWriter) FinalizeError(_ error) error {
 			return err
 		}
 	}
-	t.closeOpenItems()
+	closeErr := t.closeOpenItems()
 	if err := t.emitFailed(); err != nil {
 		return err
 	}
 	t.completedEmitted = true
-	return t.bw.Flush()
+	if err := t.bw.Flush(); err != nil {
+		return err
+	}
+	return closeErr
 }
 
 // processSSEBuffer drains complete chat.completion.chunk events.
@@ -633,7 +1045,9 @@ func (t *ResponsesWriter) translateChunk(raw []byte) error {
 		if !t.lifecycle.OutputStarted() {
 			return nil
 		}
-		t.closeOpenItems()
+		if err := t.closeOpenItems(); err != nil {
+			return err
+		}
 		if t.completedEmitted {
 			return nil
 		}
@@ -682,7 +1096,9 @@ func (t *ResponsesWriter) translateChunk(raw []byte) error {
 
 	if fr := choice.Get("finish_reason"); fr.Type == gjson.String && fr.Str != "" {
 		t.finishReason = fr.Str
-		t.closeOpenItems()
+		if err := t.closeOpenItems(); err != nil {
+			return err
+		}
 		if !t.completedEmitted {
 			if err := t.lifecycle.Terminal(); err != nil {
 				return err
@@ -734,29 +1150,67 @@ func (t *ResponsesWriter) appendText(s string) error {
 func (t *ResponsesWriter) appendToolCall(idx int, tc gjson.Result) error {
 	entry := t.toolLedger.Upsert(idx, tc.Get("id").Str, tc.Get("function.name").Str)
 	item, ok := t.toolItems[idx]
+	justOpened := false
 	if !ok {
+		mapping := ResponsesToolMapping{Name: entry.Name}
+		if mapped, found := t.toolMappings[entry.Name]; found {
+			mapping = mapped
+		}
 		item = &responsesToolItem{
-			itemID: newResponsesID("fc"),
+			itemID:  newResponsesID("fc"),
+			mapping: mapping,
 		}
 		t.toolItems[idx] = item
 		item.outputIndex = t.nextOutputIndex()
 		item.callID = entry.ExternalID
-		item.name = entry.Name
-		if err := t.emitFunctionCallItemAdded(item); err != nil {
-			return err
+		item.name = mapping.Name
+		if item.name == "" {
+			item.name = entry.Name
+		}
+		// The portable Codex bridge needs the function name to decide whether
+		// this is a Responses function_call or custom_tool_call. Buffer rare
+		// nameless leading chunks until a later delta supplies the name. The
+		// nil-mapping legacy path retains its prior immediate emission.
+		if len(t.toolMappings) == 0 || item.name != "" {
+			if err := t.emitFunctionCallItemAdded(item); err != nil {
+				return err
+			}
+			item.opened = true
+			justOpened = true
 		}
 	}
 	// Later chunks may carry name/id only on first delta; pick up any later
 	// arrivals defensively.
-	if item.name == "" {
-		item.name = entry.Name
+	if item.name == "" && entry.Name != "" {
+		if mapped, found := t.toolMappings[entry.Name]; found {
+			item.mapping = mapped
+			item.name = mapped.Name
+		} else {
+			item.name = entry.Name
+		}
+	}
+	if !item.opened && item.name != "" {
+		if err := t.emitFunctionCallItemAdded(item); err != nil {
+			return err
+		}
+		item.opened = true
+		justOpened = true
 	}
 	if err := t.lifecycle.Output(item.outputIndex); err != nil {
 		return err
 	}
-	if args := tc.Get("function.arguments").Str; args != "" {
+	args := tc.Get("function.arguments").Str
+	if args != "" {
 		t.toolLedger.AppendArguments(idx, tc.Get("id").Str, tc.Get("function.name").Str, args)
 		item.arguments.WriteString(args)
+	}
+	if !item.opened {
+		return nil
+	}
+	if justOpened && item.arguments.Len() > 0 {
+		return t.emitFunctionArgsDelta(item, item.arguments.String())
+	}
+	if args != "" {
 		return t.emitFunctionArgsDelta(item, args)
 	}
 	return nil
@@ -788,21 +1242,35 @@ func (t *ResponsesWriter) computeBadgeText() string {
 	return badge + "\n\n"
 }
 
-func (t *ResponsesWriter) closeOpenItems() {
+func (t *ResponsesWriter) closeOpenItems() error {
 	if t.textItem != nil && !t.textItem.closed {
-		_ = t.emitTextDone(t.textItem)
-		_ = t.emitContentPartDone(t.textItem)
-		_ = t.emitMessageItemDone(t.textItem)
+		if err := t.emitTextDone(t.textItem); err != nil && len(t.toolMappings) > 0 {
+			return err
+		}
+		if err := t.emitContentPartDone(t.textItem); err != nil && len(t.toolMappings) > 0 {
+			return err
+		}
+		if err := t.emitMessageItemDone(t.textItem); err != nil && len(t.toolMappings) > 0 {
+			return err
+		}
 		t.textItem.closed = true
 	}
 	for _, item := range t.toolItems {
 		if item.closed {
 			continue
 		}
-		_ = t.emitFunctionArgsDone(item)
-		_ = t.emitFunctionCallItemDone(item)
+		if len(t.toolMappings) > 0 && !item.opened {
+			return fmt.Errorf("portable Codex tool call is missing a function name")
+		}
+		if err := t.emitFunctionArgsDone(item); err != nil && len(t.toolMappings) > 0 {
+			return err
+		}
+		if err := t.emitFunctionCallItemDone(item); err != nil && len(t.toolMappings) > 0 {
+			return err
+		}
 		item.closed = true
 	}
+	return nil
 }
 
 // emitIncompleteFailure terminates a committed translated stream without
@@ -811,12 +1279,15 @@ func (t *ResponsesWriter) emitIncompleteFailure() error {
 	if err := t.lifecycle.Fail(); err != nil {
 		return err
 	}
-	t.closeOpenItems()
+	closeErr := t.closeOpenItems()
 	if err := t.emitFailed(); err != nil {
 		return err
 	}
 	t.completedEmitted = true
-	return t.bw.Flush()
+	if err := t.bw.Flush(); err != nil {
+		return err
+	}
+	return closeErr
 }
 
 // ---------- event emitters ----------
@@ -950,20 +1421,48 @@ func (t *ResponsesWriter) emitMessageItemDone(item *responsesTextItem) error {
 }
 
 func (t *ResponsesWriter) emitFunctionCallItemAdded(item *responsesToolItem) error {
+	if item.mapping.Custom {
+		call := map[string]any{
+			"id":      item.itemID,
+			"type":    "custom_tool_call",
+			"status":  "in_progress",
+			"call_id": item.callID,
+			"name":    item.name,
+			"input":   "",
+		}
+		if item.mapping.Namespace != "" {
+			call["namespace"] = item.mapping.Namespace
+		}
+		return t.writeEvent("response.output_item.added", map[string]any{
+			"output_index": item.outputIndex,
+			"item":         call,
+		})
+	}
+	call := map[string]any{
+		"id":        item.itemID,
+		"type":      "function_call",
+		"status":    "in_progress",
+		"call_id":   item.callID,
+		"name":      item.name,
+		"arguments": "",
+	}
+	if item.mapping.Namespace != "" {
+		call["namespace"] = item.mapping.Namespace
+	}
 	return t.writeEvent("response.output_item.added", map[string]any{
 		"output_index": item.outputIndex,
-		"item": map[string]any{
-			"id":        item.itemID,
-			"type":      "function_call",
-			"status":    "in_progress",
-			"call_id":   item.callID,
-			"name":      item.name,
-			"arguments": "",
-		},
+		"item":         call,
 	})
 }
 
 func (t *ResponsesWriter) emitFunctionArgsDelta(item *responsesToolItem, delta string) error {
+	if item.mapping.Custom {
+		// Chat providers stream fragments of the JSON wrapper, not fragments of
+		// the raw freeform input. Emitting them as custom deltas would expose
+		// invalid patch/JavaScript text to Codex, so the validated raw input is
+		// emitted atomically when the call closes.
+		return nil
+	}
 	return t.writeEvent("response.function_call_arguments.delta", map[string]any{
 		"item_id":      item.itemID,
 		"output_index": item.outputIndex,
@@ -972,6 +1471,23 @@ func (t *ResponsesWriter) emitFunctionArgsDelta(item *responsesToolItem, delta s
 }
 
 func (t *ResponsesWriter) emitFunctionArgsDone(item *responsesToolItem) error {
+	if item.mapping.Custom {
+		input, err := customToolInput(item.arguments.String())
+		if err != nil {
+			return err
+		}
+		if input != "" {
+			if err := t.writeEvent("response.custom_tool_call_input.delta", map[string]any{
+				"item_id":      item.itemID,
+				"call_id":      item.callID,
+				"output_index": item.outputIndex,
+				"delta":        input,
+			}); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
 	return t.writeEvent("response.function_call_arguments.done", map[string]any{
 		"item_id":      item.itemID,
 		"output_index": item.outputIndex,
@@ -980,17 +1496,28 @@ func (t *ResponsesWriter) emitFunctionArgsDone(item *responsesToolItem) error {
 }
 
 func (t *ResponsesWriter) emitFunctionCallItemDone(item *responsesToolItem) error {
-	return t.writeEvent("response.output_item.done", map[string]any{
-		"output_index": item.outputIndex,
-		"item": map[string]any{
-			"id":        item.itemID,
-			"type":      "function_call",
-			"status":    "completed",
-			"call_id":   item.callID,
-			"name":      item.name,
-			"arguments": item.arguments.String(),
-		},
-	})
+	if item.mapping.Custom {
+		input, err := customToolInput(item.arguments.String())
+		if err != nil {
+			return err
+		}
+		call := map[string]any{
+			"id": item.itemID, "type": "custom_tool_call", "status": "completed",
+			"call_id": item.callID, "name": item.name, "input": input,
+		}
+		if item.mapping.Namespace != "" {
+			call["namespace"] = item.mapping.Namespace
+		}
+		return t.writeEvent("response.output_item.done", map[string]any{"output_index": item.outputIndex, "item": call})
+	}
+	call := map[string]any{
+		"id": item.itemID, "type": "function_call", "status": "completed",
+		"call_id": item.callID, "name": item.name, "arguments": item.arguments.String(),
+	}
+	if item.mapping.Namespace != "" {
+		call["namespace"] = item.mapping.Namespace
+	}
+	return t.writeEvent("response.output_item.done", map[string]any{"output_index": item.outputIndex, "item": call})
 }
 
 func (t *ResponsesWriter) emitCompleted() error {
@@ -1048,14 +1575,40 @@ func (t *ResponsesWriter) assembleOutput() []any {
 	sort.Ints(indices)
 	for _, idx := range indices {
 		item := t.toolItems[idx]
-		out = append(out, map[string]any{
+		if len(t.toolMappings) > 0 && !item.opened {
+			continue
+		}
+		if item.mapping.Custom {
+			input, err := customToolInput(item.arguments.String())
+			if err != nil {
+				continue
+			}
+			call := map[string]any{
+				"id":      item.itemID,
+				"type":    "custom_tool_call",
+				"status":  "completed",
+				"call_id": item.callID,
+				"name":    item.name,
+				"input":   input,
+			}
+			if item.mapping.Namespace != "" {
+				call["namespace"] = item.mapping.Namespace
+			}
+			out = append(out, call)
+			continue
+		}
+		call := map[string]any{
 			"id":        item.itemID,
 			"type":      "function_call",
 			"status":    "completed",
 			"call_id":   item.callID,
 			"name":      item.name,
 			"arguments": item.arguments.String(),
-		})
+		}
+		if item.mapping.Namespace != "" {
+			call["namespace"] = item.mapping.Namespace
+		}
+		out = append(out, call)
 	}
 	return out
 }
@@ -1063,7 +1616,7 @@ func (t *ResponsesWriter) assembleOutput() []any {
 // chatCompletionToResponse converts a buffered chat-completions JSON body into
 // a Responses-shaped JSON body. Only used when the client requested
 // stream:false; Codex always streams, but other clients may not.
-func chatCompletionToResponse(body []byte, responseID, model string, createdAt int64) ([]byte, error) {
+func chatCompletionToResponse(body []byte, responseID, model string, createdAt int64, mappings map[string]ResponsesToolMapping) ([]byte, error) {
 	if !gjson.ValidBytes(body) {
 		return nil, fmt.Errorf("invalid JSON")
 	}
@@ -1097,14 +1650,32 @@ func chatCompletionToResponse(body []byte, responseID, model string, createdAt i
 	}
 	if tcs := choice.Get("tool_calls"); tcs.IsArray() {
 		for _, tc := range tcs.Array() {
-			output = append(output, map[string]any{
-				"id":        newResponsesID("fc"),
-				"type":      "function_call",
-				"status":    "completed",
-				"call_id":   tc.Get("id").Str,
-				"name":      tc.Get("function.name").Str,
-				"arguments": tc.Get("function.arguments").Str,
-			})
+			alias := tc.Get("function.name").Str
+			mapping, mapped := mappings[alias]
+			if !mapped {
+				mapping = ResponsesToolMapping{Name: alias}
+			}
+			item := map[string]any{
+				"id":      newResponsesID("fc"),
+				"status":  "completed",
+				"call_id": tc.Get("id").Str,
+				"name":    mapping.Name,
+			}
+			if mapping.Namespace != "" {
+				item["namespace"] = mapping.Namespace
+			}
+			if mapping.Custom {
+				input, err := customToolInput(tc.Get("function.arguments").Str)
+				if err != nil {
+					return nil, err
+				}
+				item["type"] = "custom_tool_call"
+				item["input"] = input
+			} else {
+				item["type"] = "function_call"
+				item["arguments"] = tc.Get("function.arguments").Str
+			}
+			output = append(output, item)
 		}
 	}
 	out["output"] = output

--- a/internal/translate/responses.go
+++ b/internal/translate/responses.go
@@ -1183,10 +1183,8 @@ func (t *ResponsesWriter) appendToolCall(idx int, tc gjson.Result) error {
 		if item.name == "" {
 			item.name = entry.Name
 		}
-		// The portable Codex bridge needs the function name to decide whether
-		// this is a Responses function_call or custom_tool_call. Buffer rare
-		// nameless leading chunks until a later delta supplies the name. The
-		// nil-mapping legacy path retains its prior immediate emission.
+		// Buffer nameless chunks; the mapping decides function_call vs
+		// custom_tool_call only once the name arrives from a later delta.
 		if len(t.toolMappings) == 0 || item.name != "" {
 			if err := t.emitFunctionCallItemAdded(item); err != nil {
 				return err

--- a/internal/translate/responses_codex.go
+++ b/internal/translate/responses_codex.go
@@ -334,9 +334,8 @@ func (c *portableCodexResponsesConverter) convertMessage(item gjson.Result, path
 		}
 	}
 	if role == "developer" {
-		// Responses Lite carries Codex base instructions as a developer input
-		// message. System is the portable equivalent understood by Chat-only
-		// providers and their downstream protocol adapters.
+		// Responses Lite sends base instructions as developer-role messages;
+		// project to system for Chat-only provider compatibility.
 		role = "system"
 		c.report("responses_developer_message_projected", "projected", path+".role")
 	}

--- a/internal/translate/responses_codex.go
+++ b/internal/translate/responses_codex.go
@@ -82,8 +82,17 @@ func convertPortableCodexResponses(body []byte) (ResponsesConversion, error) {
 
 	converter.collectDeclaredTools(root)
 	messages := converter.convertInput(root.Get("input"))
+	var systemMessages []map[string]any
 	if instructions := root.Get("instructions").Str; instructions != "" {
-		messages = append([]map[string]any{{"role": "system", "content": instructions}}, messages...)
+		systemMessages = append(systemMessages, map[string]any{"role": "system", "content": instructions})
+	}
+	if verbosity := root.Get("text.verbosity"); verbosity.Exists() {
+		if instruction, ok := converter.convertTextVerbosity(verbosity); ok {
+			systemMessages = append(systemMessages, map[string]any{"role": "system", "content": instruction})
+		}
+	}
+	if len(systemMessages) > 0 {
+		messages = append(systemMessages, messages...)
 	}
 	out["messages"] = messages
 	if len(converter.tools) > 0 {
@@ -168,7 +177,24 @@ func (c *portableCodexResponsesConverter) collectFunctionTool(tool gjson.Result,
 		function["description"] = description
 	}
 	if parameters := firstExisting(tool.Get("parameters"), tool.Get("function.parameters")); parameters.Exists() {
-		function["parameters"] = json.RawMessage(parameters.Raw)
+		var schema any
+		if !parameters.IsObject() || json.Unmarshal([]byte(parameters.Raw), &schema) != nil {
+			c.markNativeOnly("responses_function_schema_native_only", path+".parameters")
+			return
+		}
+		hadDefinitions := schemaContainsDefinitionsOrRefs(schema)
+		schema = inlineSchemaDefs(schema)
+		if schemaContainsDefinitionsOrRefs(schema) {
+			// Cyclic and external references cannot be made self-contained. Keep
+			// this turn on native Responses instead of sending an invalid schema
+			// to a Chat-only provider.
+			c.markNativeOnly("responses_function_schema_native_only", path+".parameters")
+			return
+		}
+		function["parameters"] = schema
+		if hadDefinitions {
+			c.report("responses_function_schema_inlined", "inlined", path+".parameters")
+		}
 	}
 	if strict := firstExisting(tool.Get("strict"), tool.Get("function.strict")); strict.Exists() {
 		function["strict"] = strict.Bool()
@@ -331,7 +357,7 @@ func (c *portableCodexResponsesConverter) convertMessageContent(content gjson.Re
 	if content.Type == gjson.String {
 		text := content.Str
 		if role == "assistant" {
-			text = responsesBadgePattern.ReplaceAllString(text, "")
+			text = codexResponsesBadgePattern.ReplaceAllString(text, "")
 		}
 		return text, true
 	}
@@ -348,7 +374,7 @@ func (c *portableCodexResponsesConverter) convertMessageContent(content gjson.Re
 		case "input_text", "output_text", "text":
 			text := part.Get("text").Str
 			if role == "assistant" && firstAssistantText {
-				text = responsesBadgePattern.ReplaceAllString(text, "")
+				text = codexResponsesBadgePattern.ReplaceAllString(text, "")
 				firstAssistantText = false
 			}
 			parts = append(parts, map[string]any{"type": "text", "text": text})
@@ -498,11 +524,13 @@ func (c *portableCodexResponsesConverter) copyRequestControls(root gjson.Result,
 	if metadata := root.Get("metadata"); metadata.IsObject() {
 		out["metadata"] = json.RawMessage(metadata.Raw)
 	}
-	if serviceTier := root.Get("service_tier"); serviceTier.Type == gjson.String {
-		out["service_tier"] = serviceTier.Str
+	if serviceTier := root.Get("service_tier"); serviceTier.Exists() {
+		// OriginalBody retains this OpenAI-only hint for native OpenAI dispatch.
+		// The portable body may be sent to any HMM-selected Chat provider.
+		c.report("responses_service_tier_dropped", "dropped", "service_tier")
 	}
-	if promptCacheKey := root.Get("prompt_cache_key"); promptCacheKey.Type == gjson.String {
-		out["prompt_cache_key"] = promptCacheKey.Str
+	if promptCacheKey := root.Get("prompt_cache_key"); promptCacheKey.Exists() {
+		c.report("responses_prompt_cache_key_dropped", "dropped", "prompt_cache_key")
 	}
 	if responseFormat := root.Get("response_format"); responseFormat.IsObject() {
 		out["response_format"] = json.RawMessage(responseFormat.Raw)
@@ -513,6 +541,27 @@ func (c *portableCodexResponsesConverter) copyRequestControls(root gjson.Result,
 			out["response_format"] = converted
 		}
 	}
+}
+
+func (c *portableCodexResponsesConverter) convertTextVerbosity(verbosity gjson.Result) (string, bool) {
+	if verbosity.Type != gjson.String {
+		c.markNativeOnly("responses_text_verbosity_native_only", "text.verbosity")
+		return "", false
+	}
+	var instruction string
+	switch verbosity.Str {
+	case "low":
+		instruction = "Keep the response concise and focused."
+	case "medium":
+		instruction = "Use a moderate level of detail in the response."
+	case "high":
+		instruction = "Provide a detailed and thorough response."
+	default:
+		c.markNativeOnly("responses_text_verbosity_native_only", "text.verbosity")
+		return "", false
+	}
+	c.report("responses_text_verbosity_projected", "projected", "text.verbosity")
+	return instruction, true
 }
 
 func (c *portableCodexResponsesConverter) convertToolChoice(choice gjson.Result) (any, bool) {
@@ -677,4 +726,47 @@ func firstNonEmpty(values ...string) string {
 		}
 	}
 	return ""
+}
+
+func schemaContainsDefinitionsOrRefs(node any) bool {
+	var visit func(any) bool
+	visit = func(value any) bool {
+		switch typed := value.(type) {
+		case map[string]any:
+			if _, ok := typed["$ref"]; ok {
+				return true
+			}
+			if _, ok := typed["$defs"]; ok {
+				return true
+			}
+			if _, ok := typed["definitions"]; ok {
+				return true
+			}
+			for key, child := range typed {
+				// Keys inside properties are user field names, not schema
+				// keywords. Recurse into each property's schema instead.
+				if key == "properties" {
+					if properties, ok := child.(map[string]any); ok {
+						for _, propertySchema := range properties {
+							if visit(propertySchema) {
+								return true
+							}
+						}
+					}
+					continue
+				}
+				if visit(child) {
+					return true
+				}
+			}
+		case []any:
+			for _, child := range typed {
+				if visit(child) {
+					return true
+				}
+			}
+		}
+		return false
+	}
+	return visit(node)
 }

--- a/internal/translate/responses_codex.go
+++ b/internal/translate/responses_codex.go
@@ -185,9 +185,7 @@ func (c *portableCodexResponsesConverter) collectFunctionTool(tool gjson.Result,
 		hadDefinitions := schemaContainsDefinitionsOrRefs(schema)
 		schema = inlineSchemaDefs(schema)
 		if schemaContainsDefinitionsOrRefs(schema) {
-			// Cyclic and external references cannot be made self-contained. Keep
-			// this turn on native Responses instead of sending an invalid schema
-			// to a Chat-only provider.
+			// Unresolvable refs can't be made self-contained; keep native.
 			c.markNativeOnly("responses_function_schema_native_only", path+".parameters")
 			return
 		}

--- a/internal/translate/responses_codex.go
+++ b/internal/translate/responses_codex.go
@@ -1,0 +1,680 @@
+package translate
+
+import (
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"workweave/router/internal/router"
+
+	"github.com/tidwall/gjson"
+)
+
+const (
+	responsesDefaultToolNamespace = "functions"
+	responsesMaxToolAliasBytes    = 64
+)
+
+// ResponsesConversionOptions selects opt-in Responses ingress projections.
+// The zero value preserves ConvertResponsesToChatCompletions behavior.
+type ResponsesConversionOptions struct {
+	PortableCodex bool
+}
+
+// ConvertResponsesToChatCompletionsWithOptions projects a Responses request
+// into Chat Completions using the explicitly requested compatibility mode.
+func ConvertResponsesToChatCompletionsWithOptions(body []byte, options ResponsesConversionOptions) (ResponsesConversion, error) {
+	if !options.PortableCodex {
+		return ConvertResponsesToChatCompletions(body)
+	}
+	return convertPortableCodexResponses(body)
+}
+
+type responsesToolIdentity struct {
+	name      string
+	namespace string
+	custom    bool
+}
+
+type portableCodexResponsesConverter struct {
+	result          ResponsesConversion
+	toolAliases     map[responsesToolIdentity]string
+	declaredAliases map[string]struct{}
+	tools           []map[string]any
+}
+
+func convertPortableCodexResponses(body []byte) (ResponsesConversion, error) {
+	if err := validateJSONObject(body); err != nil {
+		return ResponsesConversion{}, err
+	}
+
+	root := gjson.ParseBytes(body)
+	converter := portableCodexResponsesConverter{
+		result: ResponsesConversion{
+			OriginalBody: body,
+			Requirements: router.TranslationRequirements{
+				SourceFormat: router.WireFormatOpenAI,
+				Endpoint:     router.EndpointOpenAIResponses,
+			},
+			ToolMappings: make(map[string]ResponsesToolMapping),
+		},
+		toolAliases:     make(map[responsesToolIdentity]string),
+		declaredAliases: make(map[string]struct{}),
+	}
+	converter.result.Requirements.Images = root.Get("input").Exists() && containsAnyKey(body, "image_url", "input_image")
+	converter.result.Requirements.Audio, converter.result.Requirements.Files = openAIMediaRequirements(body)
+	converter.result.Requirements.CitationsOrSearch = containsAnyKey(body, "web_search", "web_search_preview", "file_search", "computer_use")
+	converter.result.Requirements.StructuredOutput = root.Get("text.format").Exists() || root.Get("response_format").Exists()
+
+	out := make(map[string]any)
+	if model := root.Get("model").Str; model != "" {
+		converter.result.Model = model
+		out["model"] = model
+	}
+	converter.result.Stream = root.Get("stream").Bool()
+	converter.result.Requirements.UsageDetail = converter.result.Stream && root.Get("stream_options.include_usage").Bool()
+	out["stream"] = converter.result.Stream
+	if converter.result.Stream {
+		out["stream_options"] = map[string]any{"include_usage": true}
+	}
+
+	converter.collectDeclaredTools(root)
+	messages := converter.convertInput(root.Get("input"))
+	if instructions := root.Get("instructions").Str; instructions != "" {
+		messages = append([]map[string]any{{"role": "system", "content": instructions}}, messages...)
+	}
+	out["messages"] = messages
+	if len(converter.tools) > 0 {
+		out["tools"] = converter.tools
+	}
+	converter.copyRequestControls(root, out)
+
+	bodyOut, err := json.Marshal(out)
+	if err != nil {
+		return ResponsesConversion{}, fmt.Errorf("marshal portable Codex chat completions: %w", err)
+	}
+	converter.result.Body = bodyOut
+	if len(converter.result.ToolMappings) == 0 {
+		converter.result.ToolMappings = nil
+	}
+	return converter.result, nil
+}
+
+func (c *portableCodexResponsesConverter) collectDeclaredTools(root gjson.Result) {
+	if tools := root.Get("tools"); tools.IsArray() {
+		c.collectToolArray(tools, "", "tools")
+	}
+	input := root.Get("input")
+	if !input.IsArray() {
+		return
+	}
+	for index, item := range input.Array() {
+		if item.Get("type").Str != "additional_tools" {
+			continue
+		}
+		tools := item.Get("tools")
+		path := "input." + strconv.Itoa(index) + ".tools"
+		if !tools.IsArray() {
+			c.markNativeOnly("responses_additional_tools_native_only", path)
+			continue
+		}
+		c.collectToolArray(tools, "", path)
+	}
+}
+
+func (c *portableCodexResponsesConverter) collectToolArray(tools gjson.Result, namespace, path string) {
+	for index, tool := range tools.Array() {
+		toolPath := path + "." + strconv.Itoa(index)
+		switch tool.Get("type").Str {
+		case "namespace":
+			name := normalizeResponsesToolNamespace(tool.Get("name").Str)
+			children := tool.Get("tools")
+			if tool.Get("name").Str == "" || !children.IsArray() {
+				c.markNativeOnly("responses_namespace_tool_native_only", toolPath)
+				continue
+			}
+			c.collectToolArray(children, name, toolPath+".tools")
+		case "function":
+			c.collectFunctionTool(tool, namespace, toolPath)
+		case "custom":
+			c.collectCustomTool(tool, namespace, toolPath)
+		default:
+			c.result.Requirements.CustomTools = true
+			c.markNativeOnly("responses_unknown_tool_native_only", toolPath)
+		}
+	}
+}
+
+func (c *portableCodexResponsesConverter) collectFunctionTool(tool gjson.Result, namespace, path string) {
+	name := tool.Get("name").Str
+	if name == "" {
+		name = tool.Get("function.name").Str
+	}
+	if name == "" {
+		c.markNativeOnly("responses_function_tool_native_only", path)
+		return
+	}
+	c.result.Requirements.FunctionTools = true
+	alias := c.ensureToolMapping(name, namespace, false)
+	if _, duplicate := c.declaredAliases[alias]; duplicate {
+		return
+	}
+	c.declaredAliases[alias] = struct{}{}
+
+	function := map[string]any{"name": alias}
+	if description := firstNonEmpty(tool.Get("description").Str, tool.Get("function.description").Str); description != "" {
+		function["description"] = description
+	}
+	if parameters := firstExisting(tool.Get("parameters"), tool.Get("function.parameters")); parameters.Exists() {
+		function["parameters"] = json.RawMessage(parameters.Raw)
+	}
+	if strict := firstExisting(tool.Get("strict"), tool.Get("function.strict")); strict.Exists() {
+		function["strict"] = strict.Bool()
+	}
+	c.tools = append(c.tools, map[string]any{"type": "function", "function": function})
+	if namespace != "" {
+		c.report("responses_namespace_tool_flattened", "flattened", path)
+	}
+}
+
+func (c *portableCodexResponsesConverter) collectCustomTool(tool gjson.Result, namespace, path string) {
+	name := tool.Get("name").Str
+	if name == "" {
+		c.markNativeOnly("responses_custom_tool_native_only", path)
+		return
+	}
+	c.result.Requirements.CustomTools = true
+	c.result.Requirements.FunctionTools = true
+	alias := c.ensureToolMapping(name, namespace, true)
+	if _, duplicate := c.declaredAliases[alias]; duplicate {
+		return
+	}
+	c.declaredAliases[alias] = struct{}{}
+
+	description := tool.Get("description").Str
+	if format := portableCustomToolFormatDescription(tool.Get("format")); format != "" {
+		if description != "" {
+			description += "\n\n"
+		}
+		description += format
+	}
+	function := map[string]any{
+		"name":        alias,
+		"description": description,
+		"parameters": map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"input": map[string]any{"type": "string", "description": "Raw custom-tool input."},
+			},
+			"required":             []string{"input"},
+			"additionalProperties": false,
+		},
+		"strict": true,
+	}
+	c.tools = append(c.tools, map[string]any{"type": "function", "function": function})
+	c.report("responses_custom_tool_projected", "projected", path)
+}
+
+func (c *portableCodexResponsesConverter) convertInput(input gjson.Result) []map[string]any {
+	messages := make([]map[string]any, 0, 8)
+	switch {
+	case input.Type == gjson.String:
+		return append(messages, map[string]any{"role": "user", "content": input.Str})
+	case !input.IsArray():
+		return messages
+	}
+
+	for index, item := range input.Array() {
+		path := "input." + strconv.Itoa(index)
+		itemType := item.Get("type").Str
+		if itemType == "" && item.Get("role").Str != "" {
+			itemType = "message"
+		}
+		switch itemType {
+		case "additional_tools":
+			continue
+		case "message":
+			if message, ok := c.convertMessage(item, path); ok {
+				messages = append(messages, message)
+			}
+		case "agent_message":
+			if message, ok := c.convertAgentMessage(item, path); ok {
+				messages = append(messages, message)
+			}
+		case "reasoning":
+			c.convertReasoning(item, path)
+		case "function_call":
+			c.appendToolCall(&messages, item, path, false)
+		case "custom_tool_call":
+			c.appendToolCall(&messages, item, path, true)
+		case "function_call_output", "custom_tool_call_output":
+			if message, ok := c.convertToolOutput(item, path); ok {
+				messages = append(messages, message)
+			}
+		default:
+			c.markNativeOnly("responses_unknown_input_native_only", path)
+		}
+	}
+	return messages
+}
+
+func (c *portableCodexResponsesConverter) convertReasoning(item gjson.Result, path string) {
+	summary := item.Get("summary")
+	if summary.Exists() && (!summary.IsArray() || len(summary.Array()) > 0) {
+		c.result.Requirements.ReasoningReplay = true
+		c.markNativeOnly("responses_reasoning_summary_native_only", path+".summary")
+		return
+	}
+	content := item.Get("content")
+	if content.Exists() && (!content.IsArray() || len(content.Array()) > 0) {
+		c.result.Requirements.ReasoningReplay = true
+		c.markNativeOnly("responses_reasoning_content_native_only", path+".content")
+		return
+	}
+	unknown := false
+	item.ForEach(func(key, _ gjson.Result) bool {
+		switch key.Str {
+		case "type", "id", "summary", "content", "encrypted_content", "status", "internal_chat_message_metadata_passthrough":
+		default:
+			unknown = true
+		}
+		return true
+	})
+	if unknown {
+		c.result.Requirements.ReasoningReplay = true
+		c.markNativeOnly("responses_reasoning_unknown_native_only", path)
+		return
+	}
+	if encrypted := item.Get("encrypted_content"); encrypted.Type != gjson.String || encrypted.Str == "" {
+		c.result.Requirements.ReasoningReplay = true
+		c.markNativeOnly("responses_reasoning_replay_native_only", path)
+		return
+	}
+	c.report("responses_encrypted_reasoning_dropped", "dropped", path)
+}
+
+func (c *portableCodexResponsesConverter) convertMessage(item gjson.Result, path string) (map[string]any, bool) {
+	role := item.Get("role").Str
+	if role == "" {
+		role = "user"
+	}
+	if phase := item.Get("phase"); phase.Exists() {
+		if role != "assistant" || phase.Type != gjson.String || (phase.Str != "commentary" && phase.Str != "final_answer") {
+			c.markNativeOnly("responses_message_phase_native_only", path+".phase")
+		} else {
+			// Chat Completions has no equivalent field. The phase only classifies
+			// already-visible assistant text for Codex's presentation layer.
+			c.report("responses_message_phase_dropped", "dropped", path+".phase")
+		}
+	}
+	if role == "developer" {
+		// Responses Lite carries Codex base instructions as a developer input
+		// message. System is the portable equivalent understood by Chat-only
+		// providers and their downstream protocol adapters.
+		role = "system"
+		c.report("responses_developer_message_projected", "projected", path+".role")
+	}
+	if role != "user" && role != "assistant" && role != "system" {
+		c.markNativeOnly("responses_message_role_native_only", path+".role")
+		return nil, false
+	}
+	content, ok := c.convertMessageContent(item.Get("content"), role, path+".content")
+	if !ok {
+		return nil, false
+	}
+	return map[string]any{"role": role, "content": content}, true
+}
+
+func (c *portableCodexResponsesConverter) convertMessageContent(content gjson.Result, role, path string) (any, bool) {
+	if content.Type == gjson.String {
+		text := content.Str
+		if role == "assistant" {
+			text = responsesBadgePattern.ReplaceAllString(text, "")
+		}
+		return text, true
+	}
+	if !content.IsArray() {
+		c.markNativeOnly("responses_message_content_native_only", path)
+		return nil, false
+	}
+
+	parts := make([]map[string]any, 0, len(content.Array()))
+	firstAssistantText := true
+	for index, part := range content.Array() {
+		partPath := path + "." + strconv.Itoa(index)
+		switch part.Get("type").Str {
+		case "input_text", "output_text", "text":
+			text := part.Get("text").Str
+			if role == "assistant" && firstAssistantText {
+				text = responsesBadgePattern.ReplaceAllString(text, "")
+				firstAssistantText = false
+			}
+			parts = append(parts, map[string]any{"type": "text", "text": text})
+		case "refusal":
+			parts = append(parts, map[string]any{"type": "text", "text": part.Get("refusal").Str})
+		default:
+			c.markNativeOnly("responses_message_content_native_only", partPath)
+			return nil, false
+		}
+	}
+	return parts, true
+}
+
+func (c *portableCodexResponsesConverter) convertAgentMessage(item gjson.Result, path string) (map[string]any, bool) {
+	content := item.Get("content")
+	if !content.IsArray() {
+		c.markNativeOnly("responses_agent_message_native_only", path)
+		return nil, false
+	}
+	textParts := make([]string, 0, len(content.Array()))
+	hasPlainText := false
+	for index, part := range content.Array() {
+		partPath := path + ".content." + strconv.Itoa(index)
+		switch part.Get("type").Str {
+		case "input_text", "output_text", "text":
+			text := part.Get("text").Str
+			textParts = append(textParts, text)
+			hasPlainText = hasPlainText || strings.TrimSpace(text) != ""
+		case "encrypted_content":
+			c.report("responses_encrypted_agent_content_dropped", "dropped", partPath)
+		default:
+			c.markNativeOnly("responses_agent_message_native_only", partPath)
+			return nil, false
+		}
+	}
+	if !hasPlainText {
+		c.markNativeOnly("responses_agent_message_native_only", path)
+		return nil, false
+	}
+	c.report("responses_agent_message_projected", "projected", path)
+	return map[string]any{"role": "assistant", "content": strings.Join(textParts, "\n")}, true
+}
+
+func (c *portableCodexResponsesConverter) appendToolCall(messages *[]map[string]any, item gjson.Result, path string, custom bool) {
+	name := item.Get("name").Str
+	callID := firstNonEmpty(item.Get("call_id").Str, item.Get("id").Str)
+	if name == "" || callID == "" {
+		c.markNativeOnly("responses_tool_call_native_only", path)
+		return
+	}
+	namespace := normalizeResponsesToolNamespace(item.Get("namespace").Str)
+	alias := c.ensureToolMapping(name, namespace, custom)
+
+	arguments := item.Get("arguments")
+	if custom {
+		arguments = item.Get("input")
+	}
+	if arguments.Type != gjson.String {
+		c.markNativeOnly("responses_tool_call_native_only", path)
+		return
+	}
+	argumentText := arguments.Str
+	if custom {
+		encoded, err := json.Marshal(map[string]string{"input": argumentText})
+		if err != nil {
+			c.markNativeOnly("responses_tool_call_native_only", path)
+			return
+		}
+		argumentText = string(encoded)
+	}
+	toolCall := map[string]any{
+		"id":   callID,
+		"type": "function",
+		"function": map[string]any{
+			"name":      alias,
+			"arguments": argumentText,
+		},
+	}
+
+	current := *messages
+	if len(current) > 0 && current[len(current)-1]["role"] == "assistant" {
+		if calls, ok := current[len(current)-1]["tool_calls"].([]map[string]any); ok {
+			current[len(current)-1]["tool_calls"] = append(calls, toolCall)
+			return
+		}
+	}
+	*messages = append(current, map[string]any{
+		"role":       "assistant",
+		"content":    "",
+		"tool_calls": []map[string]any{toolCall},
+	})
+}
+
+func (c *portableCodexResponsesConverter) convertToolOutput(item gjson.Result, path string) (map[string]any, bool) {
+	callID := item.Get("call_id").Str
+	if callID == "" {
+		c.markNativeOnly("responses_tool_output_native_only", path)
+		return nil, false
+	}
+	content, structured, ok := c.convertToolOutputContent(item.Get("output"), path+".output")
+	if !ok {
+		return nil, false
+	}
+	if structured {
+		c.report("responses_structured_tool_output_projected", "projected", path+".output")
+	}
+	return map[string]any{"role": "tool", "tool_call_id": callID, "content": content}, true
+}
+
+func (c *portableCodexResponsesConverter) convertToolOutputContent(output gjson.Result, path string) (any, bool, bool) {
+	if output.Type == gjson.String {
+		return output.Str, false, true
+	}
+	if !output.IsArray() {
+		c.markNativeOnly("responses_tool_output_native_only", path)
+		return nil, false, false
+	}
+	parts := make([]string, 0, len(output.Array()))
+	for index, part := range output.Array() {
+		if part.Get("type").Str != "input_text" {
+			c.markNativeOnly("responses_tool_output_native_only", path+"."+strconv.Itoa(index))
+			return nil, true, false
+		}
+		parts = append(parts, part.Get("text").Str)
+	}
+	return strings.Join(parts, "\n"), true, true
+}
+
+func (c *portableCodexResponsesConverter) copyRequestControls(root gjson.Result, out map[string]any) {
+	if choice := root.Get("tool_choice"); choice.Exists() && len(c.tools) > 0 {
+		if converted, ok := c.convertToolChoice(choice); ok {
+			out["tool_choice"] = converted
+		}
+	}
+	if parallel := root.Get("parallel_tool_calls"); parallel.Exists() {
+		out["parallel_tool_calls"] = parallel.Bool()
+	}
+	if temperature := root.Get("temperature"); temperature.Exists() {
+		out["temperature"] = temperature.Num
+	}
+	if topP := root.Get("top_p"); topP.Exists() {
+		out["top_p"] = topP.Num
+	}
+	if maxOutput := root.Get("max_output_tokens"); maxOutput.Exists() {
+		out["max_completion_tokens"] = maxOutput.Int()
+	}
+	if metadata := root.Get("metadata"); metadata.IsObject() {
+		out["metadata"] = json.RawMessage(metadata.Raw)
+	}
+	if serviceTier := root.Get("service_tier"); serviceTier.Type == gjson.String {
+		out["service_tier"] = serviceTier.Str
+	}
+	if promptCacheKey := root.Get("prompt_cache_key"); promptCacheKey.Type == gjson.String {
+		out["prompt_cache_key"] = promptCacheKey.Str
+	}
+	if responseFormat := root.Get("response_format"); responseFormat.IsObject() {
+		out["response_format"] = json.RawMessage(responseFormat.Raw)
+		return
+	}
+	if format := root.Get("text.format"); format.Exists() {
+		if converted, ok := c.convertTextFormat(format); ok {
+			out["response_format"] = converted
+		}
+	}
+}
+
+func (c *portableCodexResponsesConverter) convertToolChoice(choice gjson.Result) (any, bool) {
+	if choice.Type == gjson.String {
+		switch choice.Str {
+		case "auto", "none", "required":
+			return choice.Str, true
+		default:
+			c.markNativeOnly("responses_tool_choice_native_only", "tool_choice")
+			return nil, false
+		}
+	}
+	if !choice.IsObject() {
+		c.markNativeOnly("responses_tool_choice_native_only", "tool_choice")
+		return nil, false
+	}
+	choiceType := choice.Get("type").Str
+	custom := choiceType == "custom"
+	if choiceType != "function" && !custom {
+		c.markNativeOnly("responses_tool_choice_native_only", "tool_choice")
+		return nil, false
+	}
+	name := firstNonEmpty(choice.Get("name").Str, choice.Get("function.name").Str)
+	namespace := normalizeResponsesToolNamespace(firstNonEmpty(choice.Get("namespace").Str, choice.Get("function.namespace").Str))
+	alias, ok := c.toolAliases[responsesToolIdentity{name: name, namespace: namespace, custom: custom}]
+	if !ok {
+		c.markNativeOnly("responses_tool_choice_native_only", "tool_choice")
+		return nil, false
+	}
+	return map[string]any{"type": "function", "function": map[string]any{"name": alias}}, true
+}
+
+func (c *portableCodexResponsesConverter) convertTextFormat(format gjson.Result) (any, bool) {
+	switch format.Get("type").Str {
+	case "json_schema":
+		schema := format.Get("schema")
+		if !schema.IsObject() {
+			c.markNativeOnly("responses_text_format_native_only", "text.format")
+			return nil, false
+		}
+		jsonSchema := map[string]any{"schema": json.RawMessage(schema.Raw)}
+		if name := format.Get("name").Str; name != "" {
+			jsonSchema["name"] = name
+		}
+		if strict := format.Get("strict"); strict.Exists() {
+			jsonSchema["strict"] = strict.Bool()
+		}
+		return map[string]any{"type": "json_schema", "json_schema": jsonSchema}, true
+	case "json_object":
+		return map[string]any{"type": "json_object"}, true
+	case "text", "":
+		return nil, false
+	default:
+		c.markNativeOnly("responses_text_format_native_only", "text.format")
+		return nil, false
+	}
+}
+
+func (c *portableCodexResponsesConverter) ensureToolMapping(name, namespace string, custom bool) string {
+	namespace = normalizeResponsesToolNamespace(namespace)
+	identity := responsesToolIdentity{name: name, namespace: namespace, custom: custom}
+	if alias, ok := c.toolAliases[identity]; ok {
+		return alias
+	}
+	base := name
+	if namespace != "" {
+		base = namespace + "__" + name
+	}
+	base = sanitizeResponsesToolAlias(base)
+	if base == "" {
+		base = "tool"
+	}
+	alias := base
+	if _, collision := c.result.ToolMappings[alias]; collision {
+		alias = responsesToolAliasWithHash(base, identity, 0)
+		for attempt := 1; ; attempt++ {
+			if _, collision := c.result.ToolMappings[alias]; !collision {
+				break
+			}
+			alias = responsesToolAliasWithHash(base, identity, attempt)
+		}
+	}
+	mapping := ResponsesToolMapping{Alias: alias, Name: name, Namespace: namespace, Custom: custom}
+	c.toolAliases[identity] = alias
+	c.result.ToolMappings[alias] = mapping
+	return alias
+}
+
+func (c *portableCodexResponsesConverter) report(code, action, path string) {
+	c.result.Report = append(c.result.Report, ResponseTransform{Code: code, Action: action, Path: path})
+}
+
+func (c *portableCodexResponsesConverter) markNativeOnly(code, path string) {
+	c.result.Requirements.NativeOnly = true
+	c.report(code, "preserved", path)
+}
+
+func normalizeResponsesToolNamespace(namespace string) string {
+	if namespace == responsesDefaultToolNamespace {
+		return ""
+	}
+	return namespace
+}
+
+func sanitizeResponsesToolAlias(name string) string {
+	var out strings.Builder
+	for _, char := range name {
+		if (char >= 'a' && char <= 'z') || (char >= 'A' && char <= 'Z') || (char >= '0' && char <= '9') || char == '_' || char == '-' {
+			out.WriteRune(char)
+			continue
+		}
+		out.WriteByte('_')
+	}
+	alias := out.String()
+	if len(alias) > responsesMaxToolAliasBytes {
+		alias = alias[:responsesMaxToolAliasBytes]
+	}
+	return alias
+}
+
+func responsesToolAliasWithHash(base string, identity responsesToolIdentity, attempt int) string {
+	sum := sha256.Sum256([]byte(identity.namespace + "\x00" + identity.name + "\x00" + strconv.FormatBool(identity.custom) + "\x00" + strconv.Itoa(attempt)))
+	suffix := fmt.Sprintf("__%x", sum[:5])
+	maxBase := responsesMaxToolAliasBytes - len(suffix)
+	if len(base) > maxBase {
+		base = base[:maxBase]
+	}
+	return base + suffix
+}
+
+func portableCustomToolFormatDescription(format gjson.Result) string {
+	if !format.IsObject() {
+		return ""
+	}
+	definition := format.Get("definition").Str
+	if definition == "" {
+		return ""
+	}
+	syntax := format.Get("syntax").Str
+	if syntax == "" {
+		syntax = format.Get("type").Str
+	}
+	if syntax == "" {
+		return "Custom tool input format:\n" + definition
+	}
+	return "Custom tool input format (" + syntax + "):\n" + definition
+}
+
+func firstExisting(values ...gjson.Result) gjson.Result {
+	for _, value := range values {
+		if value.Exists() {
+			return value
+		}
+	}
+	return gjson.Result{}
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if value != "" {
+			return value
+		}
+	}
+	return ""
+}

--- a/internal/translate/responses_codex_egress_test.go
+++ b/internal/translate/responses_codex_egress_test.go
@@ -1,0 +1,232 @@
+package translate_test
+
+import (
+	"encoding/json"
+	"net/http/httptest"
+	"testing"
+
+	"workweave/router/internal/translate"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResponsesWriter_RestoresCodexCustomToolFromSplitChatArguments(t *testing.T) {
+	rec := httptest.NewRecorder()
+	w := translate.NewResponsesWriter(rec, "gpt-5.6-sol")
+	w.SetToolMappings(map[string]translate.ResponsesToolMapping{
+		"ww_custom_exec": {Alias: "ww_custom_exec", Name: "exec", Custom: true},
+	})
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("x-router-model", "moonshotai/kimi-k2.7")
+	w.WriteHeader(200)
+
+	for _, chunk := range []string{
+		`data: {"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_exec","type":"function","function":{"name":"ww_custom_exec","arguments":"{\"input\":\"const x = "}}]},"finish_reason":null}]}` + "\n\n",
+		`data: {"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"1;\"}"}}]},"finish_reason":null}]}` + "\n\n",
+		`data: {"choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}]}` + "\n\n",
+		"data: [DONE]\n\n",
+	} {
+		_, err := w.Write([]byte(chunk))
+		require.NoError(t, err)
+	}
+	require.NoError(t, w.Finalize())
+
+	events := parseSSEEvents(t, rec.Body.Bytes())
+	var added, delta, done, completed map[string]any
+	for _, event := range events {
+		switch event["type"] {
+		case "response.output_item.added":
+			item, _ := event["item"].(map[string]any)
+			if item["type"] == "custom_tool_call" {
+				added = event
+			}
+		case "response.custom_tool_call_input.delta":
+			delta = event
+		case "response.output_item.done":
+			item, _ := event["item"].(map[string]any)
+			if item["type"] == "custom_tool_call" {
+				done = event
+			}
+		case "response.completed":
+			completed = event
+		}
+		assert.NotEqual(t, "response.function_call_arguments.delta", event["type"])
+		assert.NotEqual(t, "response.function_call_arguments.done", event["type"])
+	}
+	require.NotNil(t, added)
+	require.NotNil(t, delta)
+	require.NotNil(t, done)
+	require.NotNil(t, completed)
+	assert.Equal(t, "const x = 1;", delta["delta"])
+	item := done["item"].(map[string]any)
+	assert.Equal(t, "exec", item["name"])
+	assert.Equal(t, "call_exec", item["call_id"])
+	assert.Equal(t, "const x = 1;", item["input"])
+	output := completed["response"].(map[string]any)["output"].([]any)
+	assert.Equal(t, "custom_tool_call", output[0].(map[string]any)["type"])
+	assert.Equal(t, "const x = 1;", output[0].(map[string]any)["input"])
+}
+
+func TestResponsesWriter_RestoresCodexFunctionNamespace(t *testing.T) {
+	rec := httptest.NewRecorder()
+	w := translate.NewResponsesWriter(rec, "gpt-5.6-sol")
+	w.SetToolMappings(map[string]translate.ResponsesToolMapping{
+		"ww_fn_collaboration_send_message": {
+			Alias: "ww_fn_collaboration_send_message", Name: "send_message", Namespace: "collaboration",
+		},
+	})
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.WriteHeader(200)
+	_, err := w.Write([]byte(`data: {"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_send","type":"function","function":{"name":"ww_fn_collaboration_send_message","arguments":"{\"target\":\"/root\"}"}}]},"finish_reason":"tool_calls"}]}` + "\n\n"))
+	require.NoError(t, err)
+	require.NoError(t, w.Finalize())
+
+	events := parseSSEEvents(t, rec.Body.Bytes())
+	for _, event := range events {
+		if event["type"] != "response.output_item.done" {
+			continue
+		}
+		item := event["item"].(map[string]any)
+		if item["type"] != "function_call" {
+			continue
+		}
+		assert.Equal(t, "send_message", item["name"])
+		assert.Equal(t, "collaboration", item["namespace"])
+		assert.JSONEq(t, `{"target":"/root"}`, item["arguments"].(string))
+		return
+	}
+	t.Fatal("missing namespaced function_call output item")
+}
+
+func TestResponsesWriter_NonStreamingRestoresCodexCustomTool(t *testing.T) {
+	rec := httptest.NewRecorder()
+	w := translate.NewResponsesWriter(rec, "gpt-5.6-sol")
+	w.SetToolMappings(map[string]translate.ResponsesToolMapping{
+		"ww_custom_exec": {Alias: "ww_custom_exec", Name: "exec", Custom: true},
+	})
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(200)
+	body := map[string]any{
+		"choices": []any{map[string]any{"message": map[string]any{
+			"role": "assistant",
+			"tool_calls": []any{map[string]any{
+				"id": "call_exec", "type": "function",
+				"function": map[string]any{"name": "ww_custom_exec", "arguments": `{"input":"return 1;"}`},
+			}},
+		}}},
+	}
+	raw, err := json.Marshal(body)
+	require.NoError(t, err)
+	_, err = w.Write(raw)
+	require.NoError(t, err)
+	require.NoError(t, w.Finalize())
+
+	var response map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &response))
+	output := response["output"].([]any)
+	assert.Equal(t, "custom_tool_call", output[0].(map[string]any)["type"])
+	assert.Equal(t, "exec", output[0].(map[string]any)["name"])
+	assert.Equal(t, "return 1;", output[0].(map[string]any)["input"])
+}
+
+func TestResponsesWriter_RejectsMalformedCodexCustomWrapperAndTerminatesFailed(t *testing.T) {
+	rec := httptest.NewRecorder()
+	w := translate.NewResponsesWriter(rec, "gpt-5.6-sol")
+	w.SetToolMappings(map[string]translate.ResponsesToolMapping{
+		"exec": {Alias: "exec", Name: "exec", Custom: true},
+	})
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.WriteHeader(200)
+
+	_, err := w.Write([]byte(`data: {"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_exec","type":"function","function":{"name":"exec","arguments":"{\"input\":\"ok\",\"extra\":true}"}}]},"finish_reason":"tool_calls"}]}` + "\n\n"))
+	require.ErrorContains(t, err, "expected exactly one input field")
+	require.Error(t, w.FinalizeError(err))
+
+	events := parseSSEEvents(t, rec.Body.Bytes())
+	var failed bool
+	for _, event := range events {
+		assert.NotEqual(t, "response.completed", event["type"])
+		if event["type"] == "response.failed" {
+			failed = true
+		}
+	}
+	assert.True(t, failed, "a malformed custom call must terminate the committed Codex stream")
+}
+
+func TestResponsesWriter_PortableCodexBuffersUntilLateCustomToolName(t *testing.T) {
+	rec := httptest.NewRecorder()
+	w := translate.NewResponsesWriter(rec, "gpt-5.6-sol")
+	w.SetToolMappings(map[string]translate.ResponsesToolMapping{
+		"exec": {Alias: "exec", Name: "exec", Custom: true},
+	})
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.WriteHeader(200)
+
+	for _, chunk := range []string{
+		`data: {"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_exec","type":"function","function":{"arguments":"{\"input\":\"return "}}]},"finish_reason":null}]}` + "\n\n",
+		`data: {"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"name":"exec","arguments":"1;\"}"}}]},"finish_reason":"tool_calls"}]}` + "\n\n",
+	} {
+		_, err := w.Write([]byte(chunk))
+		require.NoError(t, err)
+	}
+	require.NoError(t, w.Finalize())
+
+	events := parseSSEEvents(t, rec.Body.Bytes())
+	var customAdded, customDone bool
+	for _, event := range events {
+		if event["type"] != "response.output_item.added" && event["type"] != "response.output_item.done" {
+			continue
+		}
+		item := event["item"].(map[string]any)
+		assert.NotEmpty(t, item["name"])
+		assert.Equal(t, "custom_tool_call", item["type"])
+		customAdded = customAdded || event["type"] == "response.output_item.added"
+		customDone = customDone || event["type"] == "response.output_item.done"
+		if event["type"] == "response.output_item.done" {
+			assert.Equal(t, "return 1;", item["input"])
+		}
+	}
+	assert.True(t, customAdded)
+	assert.True(t, customDone)
+}
+
+func TestResponsesWriter_PortableCodexRejectsNamelessToolCall(t *testing.T) {
+	rec := httptest.NewRecorder()
+	w := translate.NewResponsesWriter(rec, "gpt-5.6-sol")
+	w.SetToolMappings(map[string]translate.ResponsesToolMapping{
+		"exec": {Alias: "exec", Name: "exec", Custom: true},
+	})
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.WriteHeader(200)
+
+	_, err := w.Write([]byte(`data: {"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_bad","type":"function","function":{"arguments":"{}"}}]},"finish_reason":"tool_calls"}]}` + "\n\n"))
+	require.ErrorContains(t, err, "missing a function name")
+	require.Error(t, w.FinalizeError(err))
+	assert.Contains(t, rec.Body.String(), `"type":"response.failed"`)
+	assert.NotContains(t, rec.Body.String(), `"type":"function_call"`)
+	assert.NotContains(t, rec.Body.String(), `"type":"custom_tool_call"`)
+}
+
+func TestResponsesWriter_WithoutCodexMappingsPreservesLegacyFunctionShape(t *testing.T) {
+	rec := httptest.NewRecorder()
+	w := translate.NewResponsesWriter(rec, "gpt-5.6-sol")
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.WriteHeader(200)
+	_, err := w.Write([]byte(`data: {"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_lookup","type":"function","function":{"name":"lookup","arguments":"{}"}}]},"finish_reason":"tool_calls"}]}` + "\n\n"))
+	require.NoError(t, err)
+	require.NoError(t, w.Finalize())
+
+	events := parseSSEEvents(t, rec.Body.Bytes())
+	for _, event := range events {
+		if event["type"] != "response.output_item.added" && event["type"] != "response.output_item.done" {
+			continue
+		}
+		item, ok := event["item"].(map[string]any)
+		if !ok || item["type"] != "function_call" {
+			continue
+		}
+		_, hasNamespace := item["namespace"]
+		assert.False(t, hasNamespace, "non-Codex translated Responses output must retain its legacy shape")
+	}
+}

--- a/internal/translate/responses_codex_test.go
+++ b/internal/translate/responses_codex_test.go
@@ -1,0 +1,240 @@
+package translate_test
+
+import (
+	"testing"
+
+	"workweave/router/internal/translate"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+)
+
+func TestConvertResponsesToChatCompletionsWithOptions_PortableCodexTools(t *testing.T) {
+	body := []byte(`{
+		"model":"gpt-5.6-sol",
+		"stream":true,
+		"input":[
+			{"type":"additional_tools","role":"developer","tools":[
+				{"type":"namespace","name":"functions","description":"default","tools":[
+					{"type":"function","name":"lookup","description":"look up","parameters":{"type":"object","properties":{"q":{"type":"string"}}}},
+					{"type":"custom","name":"exec","description":"run code","format":{"type":"grammar","syntax":"javascript","definition":"program"}}
+				]},
+				{"type":"namespace","name":"a","description":"first","tools":[
+					{"type":"function","name":"b__c","parameters":{"type":"object"}}
+				]},
+				{"type":"namespace","name":"a__b","description":"collision","tools":[
+					{"type":"function","name":"c","parameters":{"type":"object"}}
+				]}
+			]},
+			{"type":"message","role":"developer","content":[{"type":"input_text","text":"base instructions"}]},
+			{"type":"message","role":"user","content":[{"type":"input_text","text":"do it"}]}
+		]
+	}`)
+
+	converted, err := translate.ConvertResponsesToChatCompletionsWithOptions(body, translate.ResponsesConversionOptions{PortableCodex: true})
+	require.NoError(t, err)
+	assert.Equal(t, body, converted.OriginalBody)
+	assert.False(t, converted.Requirements.NativeOnly)
+	assert.True(t, converted.Requirements.FunctionTools)
+	assert.True(t, converted.Requirements.CustomTools)
+
+	tools := gjson.GetBytes(converted.Body, "tools").Array()
+	require.Len(t, tools, 4)
+	assert.Equal(t, "lookup", tools[0].Get("function.name").Str)
+	assert.Equal(t, "exec", tools[1].Get("function.name").Str)
+	assert.Equal(t, "string", tools[1].Get("function.parameters.properties.input.type").Str)
+	assert.Equal(t, "a__b__c", tools[2].Get("function.name").Str)
+	collisionAlias := tools[3].Get("function.name").Str
+	assert.Regexp(t, `^a__b__c__[0-9a-f]{10}$`, collisionAlias)
+
+	assert.Equal(t, translate.ResponsesToolMapping{Alias: "lookup", Name: "lookup"}, converted.ToolMappings["lookup"])
+	assert.Equal(t, translate.ResponsesToolMapping{Alias: "exec", Name: "exec", Custom: true}, converted.ToolMappings["exec"])
+	assert.Equal(t, translate.ResponsesToolMapping{Alias: "a__b__c", Name: "b__c", Namespace: "a"}, converted.ToolMappings["a__b__c"])
+	assert.Equal(t, translate.ResponsesToolMapping{Alias: collisionAlias, Name: "c", Namespace: "a__b"}, converted.ToolMappings[collisionAlias])
+	assert.Equal(t, "system", gjson.GetBytes(converted.Body, "messages.0.role").Str)
+	assert.Equal(t, "base instructions", gjson.GetBytes(converted.Body, "messages.0.content.0.text").Str)
+	assert.Equal(t, "user", gjson.GetBytes(converted.Body, "messages.1.role").Str)
+	assert.Equal(t, "do it", gjson.GetBytes(converted.Body, "messages.1.content.0.text").Str)
+	assertReportCode(t, converted.Report, "responses_developer_message_projected")
+	assert.NotEmpty(t, converted.Report)
+}
+
+func TestConvertResponsesToChatCompletionsWithOptions_PortableCodexHistory(t *testing.T) {
+	body := []byte("{ \"model\":\"gpt-5.6-sol\",\"input\":[" +
+		`{"type":"reasoning","id":"rs_1","encrypted_content":"opaque","summary":[]},` +
+		`{"type":"agent_message","id":"am_1","author":"child","recipient":"parent","content":[{"type":"input_text","text":"plain update"},{"type":"encrypted_content","encrypted_content":"opaque-agent"}]},` +
+		`{"type":"function_call","call_id":"call_fn","name":"lookup","namespace":"collaboration","arguments":"{\"q\":1}"},` +
+		`{"type":"custom_tool_call","call_id":"call_custom","name":"exec","namespace":"functions","input":"text(true);"},` +
+		`{"type":"function_call_output","call_id":"call_fn","output":[{"type":"input_text","text":"one"},{"type":"input_text","text":"two"}]},` +
+		`{"type":"custom_tool_call_output","call_id":"call_custom","name":"exec","output":"ok"},` +
+		`{"type":"message","role":"assistant","phase":"final_answer","content":[{"type":"output_text","text":"final"}]},` +
+		`{"type":"message","role":"user","content":"continue"}` +
+		"] }\n")
+
+	converted, err := translate.ConvertResponsesToChatCompletionsWithOptions(body, translate.ResponsesConversionOptions{PortableCodex: true})
+	require.NoError(t, err)
+	assert.Equal(t, body, converted.OriginalBody, "native replay bytes must remain exact")
+	assert.False(t, converted.Requirements.NativeOnly)
+
+	messages := gjson.GetBytes(converted.Body, "messages").Array()
+	require.Len(t, messages, 6)
+	assert.Equal(t, "assistant", messages[0].Get("role").Str)
+	assert.Equal(t, "plain update", messages[0].Get("content").Str)
+
+	assert.Equal(t, "assistant", messages[1].Get("role").Str)
+	require.Len(t, messages[1].Get("tool_calls").Array(), 2)
+	assert.Equal(t, "collaboration__lookup", messages[1].Get("tool_calls.0.function.name").Str)
+	assert.JSONEq(t, `{"q":1}`, messages[1].Get("tool_calls.0.function.arguments").Str)
+	assert.Equal(t, "exec", messages[1].Get("tool_calls.1.function.name").Str)
+	assert.JSONEq(t, `{"input":"text(true);"}`, messages[1].Get("tool_calls.1.function.arguments").Str)
+
+	assert.Equal(t, "tool", messages[2].Get("role").Str)
+	assert.Equal(t, "call_fn", messages[2].Get("tool_call_id").Str)
+	assert.Equal(t, "one\ntwo", messages[2].Get("content").Str)
+	assert.Equal(t, "call_custom", messages[3].Get("tool_call_id").Str)
+	assert.Equal(t, "ok", messages[3].Get("content").Str)
+	assert.Equal(t, "final", messages[4].Get("content.0.text").Str)
+	assert.Equal(t, "continue", messages[5].Get("content").Str)
+
+	assert.Equal(t, translate.ResponsesToolMapping{Alias: "collaboration__lookup", Name: "lookup", Namespace: "collaboration"}, converted.ToolMappings["collaboration__lookup"])
+	assert.Equal(t, translate.ResponsesToolMapping{Alias: "exec", Name: "exec", Custom: true}, converted.ToolMappings["exec"])
+	assertReportCode(t, converted.Report, "responses_encrypted_reasoning_dropped")
+	assertReportCode(t, converted.Report, "responses_encrypted_agent_content_dropped")
+	assertReportCode(t, converted.Report, "responses_agent_message_projected")
+	assertReportCode(t, converted.Report, "responses_structured_tool_output_projected")
+	assertReportCode(t, converted.Report, "responses_message_phase_dropped")
+}
+
+func TestConvertResponsesToChatCompletionsWithOptions_PortableCodexUnknownMessagePhaseFailsClosed(t *testing.T) {
+	body := []byte(`{
+		"model":"gpt-5.6-sol",
+		"input":[{"type":"message","role":"assistant","phase":"future_phase","content":[{"type":"output_text","text":"hello"}]}]
+	}`)
+
+	converted, err := translate.ConvertResponsesToChatCompletionsWithOptions(body, translate.ResponsesConversionOptions{PortableCodex: true})
+	require.NoError(t, err)
+	assert.True(t, converted.Requirements.NativeOnly)
+	assertReportCode(t, converted.Report, "responses_message_phase_native_only")
+}
+
+func TestConvertResponsesToChatCompletionsWithOptions_PortableCodexReasoningFailsClosed(t *testing.T) {
+	tests := []struct {
+		name string
+		item string
+		code string
+	}{
+		{
+			name: "public summary",
+			item: `{"type":"reasoning","encrypted_content":"opaque","summary":[{"type":"summary_text","text":"public"}]}`,
+			code: "responses_reasoning_summary_native_only",
+		},
+		{
+			name: "plaintext content",
+			item: `{"type":"reasoning","encrypted_content":"opaque","summary":[],"content":[{"type":"reasoning_text","text":"private"}]}`,
+			code: "responses_reasoning_content_native_only",
+		},
+		{
+			name: "unknown plaintext field",
+			item: `{"type":"reasoning","encrypted_content":"opaque","summary":[],"plaintext":"private"}`,
+			code: "responses_reasoning_unknown_native_only",
+		},
+		{
+			name: "missing encrypted replay",
+			item: `{"type":"reasoning","summary":[]}`,
+			code: "responses_reasoning_replay_native_only",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			body := []byte(`{"model":"gpt-5.6-sol","input":[` + test.item + `]}`)
+			converted, err := translate.ConvertResponsesToChatCompletionsWithOptions(body, translate.ResponsesConversionOptions{PortableCodex: true})
+			require.NoError(t, err)
+			assert.True(t, converted.Requirements.NativeOnly)
+			assert.True(t, converted.Requirements.ReasoningReplay)
+			assertReportCode(t, converted.Report, test.code)
+		})
+	}
+}
+
+func TestConvertResponsesToChatCompletionsWithOptions_PortableCodexEncryptedOnlyAgentMessageFailsClosed(t *testing.T) {
+	body := []byte(`{
+		"model":"gpt-5.6-sol",
+		"input":[{"type":"agent_message","author":"child","recipient":"parent","content":[{"type":"encrypted_content","encrypted_content":"opaque"}]}]
+	}`)
+
+	converted, err := translate.ConvertResponsesToChatCompletionsWithOptions(body, translate.ResponsesConversionOptions{PortableCodex: true})
+	require.NoError(t, err)
+	assert.True(t, converted.Requirements.NativeOnly)
+	assert.Empty(t, gjson.GetBytes(converted.Body, "messages").Array())
+	assertReportCode(t, converted.Report, "responses_encrypted_agent_content_dropped")
+	assertReportCode(t, converted.Report, "responses_agent_message_native_only")
+}
+
+func TestConvertResponsesToChatCompletionsWithOptions_PortableCodexCustomStructuredOutputIsString(t *testing.T) {
+	body := []byte(`{
+		"model":"gpt-5.6-sol",
+		"input":[
+			{"type":"custom_tool_call","call_id":"call_1","name":"exec","input":"text(true);"},
+			{"type":"custom_tool_call_output","call_id":"call_1","name":"exec","output":[{"type":"input_text","text":"first"},{"type":"input_text","text":"second"}]}
+		]
+	}`)
+
+	converted, err := translate.ConvertResponsesToChatCompletionsWithOptions(body, translate.ResponsesConversionOptions{PortableCodex: true})
+	require.NoError(t, err)
+	assert.False(t, converted.Requirements.NativeOnly)
+	assert.Equal(t, "first\nsecond", gjson.GetBytes(converted.Body, "messages.1.content").Str)
+	assertReportCode(t, converted.Report, "responses_structured_tool_output_projected")
+}
+
+func TestConvertResponsesToChatCompletionsWithOptions_PortableCodexStructuredTextFormat(t *testing.T) {
+	body := []byte(`{
+		"model":"gpt-5.6-sol",
+		"input":"answer",
+		"text":{"verbosity":"low","format":{"type":"json_schema","name":"answer","strict":true,"schema":{"type":"object","properties":{"answer":{"type":"string"}},"required":["answer"]}}}
+	}`)
+
+	converted, err := translate.ConvertResponsesToChatCompletionsWithOptions(body, translate.ResponsesConversionOptions{PortableCodex: true})
+	require.NoError(t, err)
+	assert.Equal(t, "json_schema", gjson.GetBytes(converted.Body, "response_format.type").Str)
+	assert.Equal(t, "answer", gjson.GetBytes(converted.Body, "response_format.json_schema.name").Str)
+	assert.True(t, gjson.GetBytes(converted.Body, "response_format.json_schema.strict").Bool())
+	assert.Equal(t, "string", gjson.GetBytes(converted.Body, "response_format.json_schema.schema.properties.answer.type").Str)
+}
+
+func TestConvertResponsesToChatCompletionsWithOptions_PortableCodexUnknownStaysNative(t *testing.T) {
+	body := []byte(`{
+		"model":"gpt-5.6-sol",
+		"input":[{"type":"computer_call","id":"comp_1","action":{"type":"click"}}],
+		"tools":[{"type":"web_search","search_context_size":"medium"}]
+	}`)
+
+	converted, err := translate.ConvertResponsesToChatCompletionsWithOptions(body, translate.ResponsesConversionOptions{PortableCodex: true})
+	require.NoError(t, err)
+	assert.True(t, converted.Requirements.NativeOnly)
+	assert.Equal(t, body, converted.OriginalBody)
+	assertReportCode(t, converted.Report, "responses_unknown_input_native_only")
+	assertReportCode(t, converted.Report, "responses_unknown_tool_native_only")
+}
+
+func TestConvertResponsesToChatCompletionsWithOptions_ZeroValueMatchesLegacy(t *testing.T) {
+	body := []byte(`{"model":"gpt-5","input":"use it","tools":[{"type":"custom","name":"exec"}]}`)
+
+	legacy, err := translate.ConvertResponsesToChatCompletions(body)
+	require.NoError(t, err)
+	withOptions, err := translate.ConvertResponsesToChatCompletionsWithOptions(body, translate.ResponsesConversionOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, legacy, withOptions)
+	assert.True(t, withOptions.Requirements.NativeOnly)
+}
+
+func assertReportCode(t *testing.T, reports []translate.ResponseTransform, code string) {
+	t.Helper()
+	for _, report := range reports {
+		if report.Code == code {
+			return
+		}
+	}
+	assert.Fail(t, "missing response transform report", "code %q in %#v", code, reports)
+}

--- a/internal/translate/responses_codex_test.go
+++ b/internal/translate/responses_codex_test.go
@@ -1,6 +1,7 @@
 package translate_test
 
 import (
+	"encoding/json"
 	"testing"
 
 	"workweave/router/internal/translate"
@@ -17,7 +18,7 @@ func TestConvertResponsesToChatCompletionsWithOptions_PortableCodexTools(t *test
 		"input":[
 			{"type":"additional_tools","role":"developer","tools":[
 				{"type":"namespace","name":"functions","description":"default","tools":[
-					{"type":"function","name":"lookup","description":"look up","parameters":{"type":"object","properties":{"q":{"type":"string"}}}},
+					{"type":"function","name":"lookup","description":"look up","parameters":{"type":"object","$defs":{"query":{"type":"string","minLength":1}},"properties":{"q":{"$ref":"#/$defs/query"}}}},
 					{"type":"custom","name":"exec","description":"run code","format":{"type":"grammar","syntax":"javascript","definition":"program"}}
 				]},
 				{"type":"namespace","name":"a","description":"first","tools":[
@@ -42,6 +43,10 @@ func TestConvertResponsesToChatCompletionsWithOptions_PortableCodexTools(t *test
 	tools := gjson.GetBytes(converted.Body, "tools").Array()
 	require.Len(t, tools, 4)
 	assert.Equal(t, "lookup", tools[0].Get("function.name").Str)
+	assert.Equal(t, "string", tools[0].Get("function.parameters.properties.q.type").Str)
+	assert.Equal(t, int64(1), tools[0].Get("function.parameters.properties.q.minLength").Int())
+	assert.False(t, tools[0].Get("function.parameters.$defs").Exists())
+	assert.NotContains(t, tools[0].Get("function.parameters").Raw, `"$ref"`)
 	assert.Equal(t, "exec", tools[1].Get("function.name").Str)
 	assert.Equal(t, "string", tools[1].Get("function.parameters.properties.input.type").Str)
 	assert.Equal(t, "a__b__c", tools[2].Get("function.name").Str)
@@ -57,6 +62,7 @@ func TestConvertResponsesToChatCompletionsWithOptions_PortableCodexTools(t *test
 	assert.Equal(t, "user", gjson.GetBytes(converted.Body, "messages.1.role").Str)
 	assert.Equal(t, "do it", gjson.GetBytes(converted.Body, "messages.1.content.0.text").Str)
 	assertReportCode(t, converted.Report, "responses_developer_message_projected")
+	assertReportCode(t, converted.Report, "responses_function_schema_inlined")
 	assert.NotEmpty(t, converted.Report)
 }
 
@@ -190,9 +196,11 @@ func TestConvertResponsesToChatCompletionsWithOptions_PortableCodexCustomStructu
 
 func TestConvertResponsesToChatCompletionsWithOptions_PortableCodexStructuredTextFormat(t *testing.T) {
 	body := []byte(`{
-		"model":"gpt-5.6-sol",
-		"input":"answer",
-		"text":{"verbosity":"low","format":{"type":"json_schema","name":"answer","strict":true,"schema":{"type":"object","properties":{"answer":{"type":"string"}},"required":["answer"]}}}
+			"model":"gpt-5.6-sol",
+			"input":"answer",
+			"service_tier":"priority",
+			"prompt_cache_key":"caller-key",
+			"text":{"verbosity":"low","format":{"type":"json_schema","name":"answer","strict":true,"schema":{"type":"object","properties":{"answer":{"type":"string"}},"required":["answer"]}}}
 	}`)
 
 	converted, err := translate.ConvertResponsesToChatCompletionsWithOptions(body, translate.ResponsesConversionOptions{PortableCodex: true})
@@ -201,6 +209,55 @@ func TestConvertResponsesToChatCompletionsWithOptions_PortableCodexStructuredTex
 	assert.Equal(t, "answer", gjson.GetBytes(converted.Body, "response_format.json_schema.name").Str)
 	assert.True(t, gjson.GetBytes(converted.Body, "response_format.json_schema.strict").Bool())
 	assert.Equal(t, "string", gjson.GetBytes(converted.Body, "response_format.json_schema.schema.properties.answer.type").Str)
+	assert.Equal(t, "system", gjson.GetBytes(converted.Body, "messages.0.role").Str)
+	assert.Equal(t, "Keep the response concise and focused.", gjson.GetBytes(converted.Body, "messages.0.content").Str)
+	assert.Equal(t, "answer", gjson.GetBytes(converted.Body, "messages.1.content").Str)
+	assert.False(t, gjson.GetBytes(converted.Body, "service_tier").Exists())
+	assert.False(t, gjson.GetBytes(converted.Body, "prompt_cache_key").Exists())
+	assert.Equal(t, "priority", gjson.GetBytes(converted.OriginalBody, "service_tier").Str)
+	assert.Equal(t, "caller-key", gjson.GetBytes(converted.OriginalBody, "prompt_cache_key").Str)
+	assertReportCode(t, converted.Report, "responses_text_verbosity_projected")
+	assertReportCode(t, converted.Report, "responses_service_tier_dropped")
+	assertReportCode(t, converted.Report, "responses_prompt_cache_key_dropped")
+}
+
+func TestConvertResponsesToChatCompletionsWithOptions_PortableCodexUnsupportedVerbosityStaysNative(t *testing.T) {
+	body := []byte(`{"model":"gpt-5.6-sol","input":"answer","text":{"verbosity":"future"}}`)
+
+	converted, err := translate.ConvertResponsesToChatCompletionsWithOptions(body, translate.ResponsesConversionOptions{PortableCodex: true})
+	require.NoError(t, err)
+	assert.True(t, converted.Requirements.NativeOnly)
+	assertReportCode(t, converted.Report, "responses_text_verbosity_native_only")
+}
+
+func TestConvertResponsesToChatCompletionsWithOptions_PortableCodexUnresolvedToolRefStaysNative(t *testing.T) {
+	body := []byte(`{"model":"gpt-5.6-sol","input":"answer","tools":[{"type":"function","name":"lookup","parameters":{"type":"object","properties":{"q":{"$ref":"https://example.com/query.json"}}}}]}`)
+
+	converted, err := translate.ConvertResponsesToChatCompletionsWithOptions(body, translate.ResponsesConversionOptions{PortableCodex: true})
+	require.NoError(t, err)
+	assert.True(t, converted.Requirements.NativeOnly)
+	assert.Empty(t, gjson.GetBytes(converted.Body, "tools").Array())
+	assertReportCode(t, converted.Report, "responses_function_schema_native_only")
+}
+
+func TestConvertResponsesToChatCompletionsWithOptions_PortableCodexBadgeNeedsProvenance(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		text string
+		want string
+	}{
+		{name: "injected badge", text: "\u2063\u2060\u2063\u2060**Weave Router** — gpt-5.6-terra\n\nanswer", want: "answer"},
+		{name: "organic heading", text: "**Weave Router** — an ordinary heading\n\nkeep this", want: "**Weave Router** — an ordinary heading\n\nkeep this"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			encoded, err := json.Marshal(tc.text)
+			require.NoError(t, err)
+			body := []byte(`{"model":"gpt-5.6-sol","input":[{"type":"message","role":"assistant","content":` + string(encoded) + `}]}`)
+			converted, err := translate.ConvertResponsesToChatCompletionsWithOptions(body, translate.ResponsesConversionOptions{PortableCodex: true})
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, gjson.GetBytes(converted.Body, "messages.0.content").Str)
+		})
+	}
 }
 
 func TestConvertResponsesToChatCompletionsWithOptions_PortableCodexUnknownStaysNative(t *testing.T) {

--- a/internal/translate/responses_codex_types.go
+++ b/internal/translate/responses_codex_types.go
@@ -1,0 +1,37 @@
+package translate
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// ResponsesToolMapping describes one Responses tool after it has been
+// projected into a flat Chat Completions function. Alias is the synthetic Chat
+// function name. Name and Namespace are restored on the way back to Codex;
+// Custom means the function's {"input":"..."} arguments must be emitted as a
+// raw Responses custom_tool_call rather than a function_call.
+type ResponsesToolMapping struct {
+	Alias     string
+	Name      string
+	Namespace string
+	Custom    bool
+}
+
+func customToolInput(arguments string) (string, error) {
+	var wrapper map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(arguments), &wrapper); err != nil {
+		return "", fmt.Errorf("decode custom tool arguments: %w", err)
+	}
+	if len(wrapper) != 1 {
+		return "", fmt.Errorf("decode custom tool arguments: expected exactly one input field")
+	}
+	raw, ok := wrapper["input"]
+	if !ok {
+		return "", fmt.Errorf("decode custom tool arguments: required string field input is missing")
+	}
+	var input string
+	if err := json.Unmarshal(raw, &input); err != nil {
+		return "", fmt.Errorf("decode custom tool arguments: input must be a string: %w", err)
+	}
+	return input, nil
+}

--- a/internal/translate/responses_test.go
+++ b/internal/translate/responses_test.go
@@ -16,6 +16,8 @@ import (
 	"github.com/tidwall/gjson"
 )
 
+const codexResponsesBadgeSentinelForTest = "\u2063\u2060\u2063\u2060"
+
 func TestResponsesToChatCompletions_InstructionsAndInput(t *testing.T) {
 	body := []byte(`{
 		"model": "gpt-5",
@@ -217,7 +219,7 @@ func TestStripRoutingBadgeFromResponsesInput_PreservesNativeFields(t *testing.T)
 			{"type":"reasoning","id":"rs_1","encrypted_content":"opaque"},
 			{"type":"message","id":"msg_1","role":"assistant","status":"completed","content":[
 				{"type":"refusal","refusal":""},
-				{"type":"output_text","text":"**Weave Router** — gpt-5.6-terra ← gpt-5.6-sol\n\nanswer","annotations":[{"type":"url_citation","url":"https://example.com"}]},
+				{"type":"output_text","text":"\u2063\u2060\u2063\u2060**Weave Router** — gpt-5.6-terra ← gpt-5.6-sol\n\nanswer","annotations":[{"type":"url_citation","url":"https://example.com"}]},
 				{"type":"output_text","text":"**WEAVE ROUTER** — user-authored\n\nlater part"}
 			]},
 			{"type":"function_call","id":"fc_1","call_id":"call_1","name":"lookup","arguments":"{\"x\":1}"}
@@ -240,6 +242,14 @@ func TestStripRoutingBadgeFromResponsesInput_PreservesNativeFields(t *testing.T)
 
 func TestStripRoutingBadgeFromResponsesInput_NoMatchPreservesBytes(t *testing.T) {
 	body := []byte("{ \"model\" : \"gpt-5.6-sol\", \"input\" : [{\"type\":\"message\",\"role\":\"assistant\",\"content\":\"plain answer\"}] }\n")
+
+	out, err := translate.StripRoutingBadgeFromResponsesInput(body)
+	require.NoError(t, err)
+	assert.Equal(t, body, out)
+}
+
+func TestStripRoutingBadgeFromResponsesInput_PreservesOrganicAssistantHeading(t *testing.T) {
+	body := []byte("{ \"model\" : \"gpt-5.6-sol\", \"input\" : [{\"type\":\"message\",\"role\":\"assistant\",\"content\":\"**WEAVE ROUTER** — an ordinary heading\\n\\nkeep this paragraph\"}] }\n")
 
 	out, err := translate.StripRoutingBadgeFromResponsesInput(body)
 	require.NoError(t, err)
@@ -441,7 +451,7 @@ func TestResponsesWriter_PassthroughBadgePreservesNativeStream(t *testing.T) {
 				assert.Equal(t, gjson.Get(payloads[index], "type").Str, event["type"])
 			}
 
-			badge := "**Weave Router** — gpt-5.6-terra ← gpt-5.6-sol\n\n"
+			badge := codexResponsesBadgeSentinelForTest + "**Weave Router** — gpt-5.6-terra ← gpt-5.6-sol\n\n"
 			assert.Equal(t, badge+"o", events[4]["delta"], "only the first text delta gets the badge")
 			assert.Equal(t, "k", events[5]["delta"], "later deltas stay native")
 			assert.Equal(t, badge+"ok", events[6]["text"])
@@ -465,6 +475,29 @@ func TestResponsesWriter_PassthroughBadgePreservesNativeStream(t *testing.T) {
 			assert.Equal(t, originalTool, output[1])
 		})
 	}
+}
+
+func TestResponsesWriter_PassthroughBadgeCanGrowPastOriginalEventCapacity(t *testing.T) {
+	rec := httptest.NewRecorder()
+	w := translate.NewResponsesWriter(rec, "gpt-5.6-sol")
+	badge := strings.Repeat("routed-model ", 511) + "routed-model"
+	w.SetBadgeText(badge)
+	w.SetPassthroughBadge()
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("x-router-model", "gpt-5.6-terra")
+	w.WriteHeader(200)
+
+	native := `event: response.output_text.delta
+data: {"type":"response.output_text.delta","item_id":"msg_native","output_index":0,"content_index":0,"delta":"ok"}
+
+`
+	_, err := w.Write([]byte(native))
+	require.NoError(t, err)
+	require.NoError(t, w.Finalize())
+
+	events := parseSSEEvents(t, rec.Body.Bytes())
+	require.Len(t, events, 1)
+	assert.Equal(t, codexResponsesBadgeSentinelForTest+badge+"\n\nok", events[0]["delta"])
 }
 
 func TestResponsesWriter_PrependsBadgeOnSwap(t *testing.T) {

--- a/internal/translate/responses_test.go
+++ b/internal/translate/responses_test.go
@@ -209,6 +209,43 @@ func TestResponsesToChatCompletions_LeavesUserContentAlone(t *testing.T) {
 	assert.Contains(t, messages[0].Get("content").Str, "**WEAVE ROUTER**")
 }
 
+func TestStripRoutingBadgeFromResponsesInput_PreservesNativeFields(t *testing.T) {
+	body := []byte(`{
+		"model":"gpt-5.6-sol",
+		"input":[
+			{"type":"message","role":"user","content":[{"type":"input_text","text":"**WEAVE ROUTER** — quoted\n\ndo not strip"}]},
+			{"type":"reasoning","id":"rs_1","encrypted_content":"opaque"},
+			{"type":"message","id":"msg_1","role":"assistant","status":"completed","content":[
+				{"type":"refusal","refusal":""},
+				{"type":"output_text","text":"**Weave Router** — gpt-5.6-terra ← gpt-5.6-sol\n\nanswer","annotations":[{"type":"url_citation","url":"https://example.com"}]},
+				{"type":"output_text","text":"**WEAVE ROUTER** — user-authored\n\nlater part"}
+			]},
+			{"type":"function_call","id":"fc_1","call_id":"call_1","name":"lookup","arguments":"{\"x\":1}"}
+		],
+		"metadata":{"keep":true}
+	}`)
+
+	out, err := translate.StripRoutingBadgeFromResponsesInput(body)
+	require.NoError(t, err)
+
+	root := gjson.ParseBytes(out)
+	assert.Equal(t, "**WEAVE ROUTER** — quoted\n\ndo not strip", root.Get("input.0.content.0.text").Str)
+	assert.Equal(t, "opaque", root.Get("input.1.encrypted_content").Str)
+	assert.Equal(t, "answer", root.Get("input.2.content.1.text").Str)
+	assert.Equal(t, "https://example.com", root.Get("input.2.content.1.annotations.0.url").Str)
+	assert.Equal(t, "**WEAVE ROUTER** — user-authored\n\nlater part", root.Get("input.2.content.2.text").Str)
+	assert.Equal(t, "call_1", root.Get("input.3.call_id").Str)
+	assert.True(t, root.Get("metadata.keep").Bool())
+}
+
+func TestStripRoutingBadgeFromResponsesInput_NoMatchPreservesBytes(t *testing.T) {
+	body := []byte("{ \"model\" : \"gpt-5.6-sol\", \"input\" : [{\"type\":\"message\",\"role\":\"assistant\",\"content\":\"plain answer\"}] }\n")
+
+	out, err := translate.StripRoutingBadgeFromResponsesInput(body)
+	require.NoError(t, err)
+	assert.Equal(t, body, out)
+}
+
 func TestResponsesToChatCompletions_MaxOutputAndDropsReasoning(t *testing.T) {
 	body := []byte(`{
 		"model": "gpt-5",
@@ -355,6 +392,79 @@ func TestResponsesWriter_PassthroughForwardsVerbatim(t *testing.T) {
 	// Output is exactly the upstream bytes: no chat->Responses translation, no
 	// synthesized or duplicated events.
 	assert.Equal(t, native, rec.Body.String())
+}
+
+func TestResponsesWriter_PassthroughBadgePreservesNativeStream(t *testing.T) {
+	for _, terminalType := range []string{"response.completed", "response.incomplete"} {
+		t.Run(terminalType, func(t *testing.T) {
+			payloads := []string{
+				`{"type":"response.created","sequence_number":0,"response":{"id":"resp_native","model":"gpt-5.6-terra","status":"in_progress","output":[]}}`,
+				`{"type":"response.in_progress","sequence_number":1,"response":{"id":"resp_native","model":"gpt-5.6-terra","status":"in_progress","output":[]}}`,
+				`{"type":"response.output_item.added","sequence_number":2,"output_index":0,"item":{"id":"msg_native","type":"message","role":"assistant","status":"in_progress","content":[]}}`,
+				`{"type":"response.content_part.added","sequence_number":3,"item_id":"msg_native","output_index":0,"content_index":0,"part":{"type":"output_text","text":"","annotations":[]}}`,
+				`{"type":"response.output_text.delta","sequence_number":4,"item_id":"msg_native","output_index":0,"content_index":0,"delta":"o"}`,
+				`{"type":"response.output_text.delta","sequence_number":5,"item_id":"msg_native","output_index":0,"content_index":0,"delta":"k"}`,
+				`{"type":"response.output_text.done","sequence_number":6,"item_id":"msg_native","output_index":0,"content_index":0,"text":"ok"}`,
+				`{"type":"response.content_part.done","sequence_number":7,"item_id":"msg_native","output_index":0,"content_index":0,"part":{"type":"output_text","text":"ok","annotations":[]}}`,
+				`{"type":"response.output_item.done","sequence_number":8,"output_index":0,"item":{"id":"msg_native","type":"message","role":"assistant","status":"completed","content":[{"type":"output_text","text":"ok","annotations":[]}]}}`,
+				`{"type":"response.output_item.added","sequence_number":9,"output_index":1,"item":{"id":"fc_native","type":"function_call","call_id":"call_native","name":"lookup","arguments":"","status":"in_progress"}}`,
+				`{"type":"response.function_call_arguments.delta","sequence_number":10,"item_id":"fc_native","output_index":1,"delta":"{\"x\":1}"}`,
+				`{"type":"response.function_call_arguments.done","sequence_number":11,"item_id":"fc_native","output_index":1,"arguments":"{\"x\":1}"}`,
+				`{"type":"response.output_item.done","sequence_number":12,"output_index":1,"item":{"id":"fc_native","type":"function_call","call_id":"call_native","name":"lookup","arguments":"{\"x\":1}","status":"completed"}}`,
+				`{"type":"` + terminalType + `","sequence_number":13,"response":{"id":"resp_native","model":"gpt-5.6-terra","status":"completed","output":[{"id":"msg_native","type":"message","role":"assistant","status":"completed","content":[{"type":"output_text","text":"ok","annotations":[]}]},{"id":"fc_native","type":"function_call","call_id":"call_native","name":"lookup","arguments":"{\"x\":1}","status":"completed"}]}}`,
+			}
+			var native strings.Builder
+			for _, payload := range payloads {
+				native.WriteString("event: " + gjson.Get(payload, "type").Str + "\n")
+				native.WriteString("data: " + payload + "\n\n")
+			}
+
+			rec := httptest.NewRecorder()
+			w := translate.NewResponsesWriter(rec, "gpt-5.6-sol")
+			w.SetPassthroughBadge()
+			w.Header().Set("Content-Type", "text/event-stream")
+			w.Header().Set("x-router-model", "gpt-5.6-terra")
+			w.WriteHeader(200)
+
+			raw := []byte(native.String())
+			for start := 0; start < len(raw); start += 37 {
+				end := min(start+37, len(raw))
+				_, err := w.Write(raw[start:end])
+				require.NoError(t, err)
+			}
+			require.NoError(t, w.Finalize())
+
+			events := parseSSEEvents(t, rec.Body.Bytes())
+			require.Len(t, events, len(payloads))
+			for index, event := range events {
+				assert.EqualValues(t, index, event["sequence_number"], "sequence number at event %d", index)
+				assert.Equal(t, gjson.Get(payloads[index], "type").Str, event["type"])
+			}
+
+			badge := "**Weave Router** — gpt-5.6-terra ← gpt-5.6-sol\n\n"
+			assert.Equal(t, badge+"o", events[4]["delta"], "only the first text delta gets the badge")
+			assert.Equal(t, "k", events[5]["delta"], "later deltas stay native")
+			assert.Equal(t, badge+"ok", events[6]["text"])
+			assert.Equal(t, badge+"ok", events[7]["part"].(map[string]any)["text"])
+			assert.Equal(t, badge+"ok", events[8]["item"].(map[string]any)["content"].([]any)[0].(map[string]any)["text"])
+			response := events[13]["response"].(map[string]any)
+			assert.Equal(t, "resp_native", response["id"])
+			assert.Equal(t, "gpt-5.6-terra", response["model"])
+			output := response["output"].([]any)
+			assert.Equal(t, badge+"ok", output[0].(map[string]any)["content"].([]any)[0].(map[string]any)["text"])
+
+			// Tool events and the completed aggregate tool item stay untouched.
+			for _, index := range []int{9, 10, 11, 12} {
+				var original map[string]any
+				require.NoError(t, json.Unmarshal([]byte(payloads[index]), &original))
+				assert.Equal(t, original, events[index])
+			}
+			var originalTerminal map[string]any
+			require.NoError(t, json.Unmarshal([]byte(payloads[13]), &originalTerminal))
+			originalTool := originalTerminal["response"].(map[string]any)["output"].([]any)[1]
+			assert.Equal(t, originalTool, output[1])
+		})
+	}
 }
 
 func TestResponsesWriter_PrependsBadgeOnSwap(t *testing.T) {


### PR DESCRIPTION
Enables Codex Responses turns to participate in HMM cross-provider routing by projecting supported namespaced and custom tools into a portable format, then restoring native Responses events for Codex.

Also shows the actual served model in native Codex responses. All new translation and badge behavior is gated to Codex; Claude Code, Cursor, and other clients retain their existing behavior.