### PR TITLE
fix(catalog): retire gpt-5.5 from cluster routing and the generic gpt alias

### DIFF
--- a/internal/proxy/force_model.go
+++ b/internal/proxy/force_model.go
@@ -55,8 +55,12 @@ var forceModelAliases = map[string]string{
 	"claude-haiku":  "claude-haiku-4-5",
 	"haiku-4-5":     "claude-haiku-4-5",
 	"haiku-4.5":     "claude-haiku-4-5",
-	"gpt":           "gpt-5.5",
-	"openai":        "gpt-5.5",
+	// Generic GPT aliases follow the current flagship, not a pinned version;
+	// they pointed at gpt-5.5 until it was retired. Version-specific aliases
+	// (gpt-5-5*) deliberately still resolve to their exact model, which stays
+	// available as priced passthrough.
+	"gpt":    "gpt-5.6-sol",
+	"openai": "gpt-5.6-sol",
 	// The bare gpt-5.6 alias routes to Sol, matching OpenAI's own alias.
 	"gpt-5.6":       "gpt-5.6-sol",
 	"gpt-5-6":       "gpt-5.6-sol",

--- a/internal/proxy/force_model_internal_test.go
+++ b/internal/proxy/force_model_internal_test.go
@@ -50,7 +50,7 @@ func TestResolveForceModel(t *testing.T) {
 		{
 			name:         "alias gpt",
 			input:        "gpt",
-			wantID:       "gpt-5.5",
+			wantID:       "gpt-5.6-sol",
 			wantProvider: providers.ProviderOpenAI,
 			wantKnown:    true,
 		},

--- a/internal/router/catalog/catalog.go
+++ b/internal/router/catalog/catalog.go
@@ -280,7 +280,11 @@ var Models = []Model{
 	{ID: "gpt-5.5-mini", Tier: TierMid, ContextWindow: 1_000_000, Providers: []ProviderBinding{
 		{Provider: providers.ProviderOpenAI, Price: Pricing{InputUSDPer1M: 0.50, OutputUSDPer1M: 2.50, CacheReadMultiplier: 0.10}},
 	}},
-	{ID: "gpt-5.5", Tier: TierHigh, ContextWindow: 1_050_000, Providers: []ProviderBinding{
+	// gpt-5.5 retired from routing; kept as priced passthrough so lingering
+	// session pins and direct requests still bill at real cost. The HMM rosters
+	// dropped it, but an untiered row is what also removes it from cluster
+	// candidates — leaving it tiered kept the legacy strategy selecting it.
+	{ID: "gpt-5.5", ContextWindow: 1_050_000, Providers: []ProviderBinding{
 		{Provider: providers.ProviderOpenAI, Price: Pricing{InputUSDPer1M: 5.00, OutputUSDPer1M: 30.00, CacheReadMultiplier: 0.10}},
 	}},
 	{ID: "gpt-5.5-pro", Tier: TierHigh, ContextWindow: 1_000_000, Providers: []ProviderBinding{

--- a/internal/router/cluster/candidate_k12_test.go
+++ b/internal/router/cluster/candidate_k12_test.go
@@ -79,9 +79,11 @@ func TestCandidateK12Loads(t *testing.T) {
 		assert.InDeltaf(t, 0.7, a, 1e-9, "cluster %d alpha must be the 0.7 sweet spot", i)
 	}
 
-	// 18 of 21: deepseek-v4-pro, claude-opus-4-8, qwen/qwen3.7-plus retired to
-	// passthrough-only after this bundle was trained; none leads a cluster.
-	require.Len(t, s.models, 18, "retired models must be the only ones dropped under the full provider set")
+	// 17 of the frozen bundle's 21: deepseek-v4-pro, claude-opus-4-8,
+	// qwen/qwen3.7-plus and gpt-5.5 were retired to passthrough-only in the
+	// catalog after this bundle was trained, so the scorer drops them. None
+	// leads a cluster, so the win mix below is unaffected.
+	require.Len(t, s.models, 17, "retired models must be the only ones dropped under the full provider set")
 
 	wins := map[string]int{}
 	for c := 0; c < bundle.Centroids.K; c++ {

--- a/internal/router/hmm/hmm_test.go
+++ b/internal/router/hmm/hmm_test.go
@@ -203,7 +203,6 @@ func TestCatalogRoutingTargetsResolveCurrentHMMRosterArmsToProviders(t *testing.
 		"google/gemini-3.5-flash",
 		"anthropic/claude-sonnet-5",
 		"anthropic/claude-opus-5",
-		"openai/gpt-5.5",
 		"openai/gpt-5.6-terra",
 		"z-ai/glm-5.2",
 		"google/gemini-3.1-pro-preview",


### PR DESCRIPTION
## What

A model retirement covered only one of the two routing strategies, so a retired model kept being served — and kept 400ing for one class of caller.

`gpt-5.5` was retired from the HMM rosters. **That worked**: prod telemetry shows zero HMM-served gpt-5.5 after the retirement date. But the catalog row stayed tiered, and the legacy `cluster` strategy ranks from the catalog plus its own frozen artifacts — so cluster-pinned installations kept selecting it: **315 turns across 5 installations** in the two weeks since, most recently the day before this PR.

| strategy | before Jul 29 | after | errors after |
|---|---:|---:|---:|
| `hmm` | 16 | **0** | 0 |
| `hmm_embedding` | 4 | **0** | 0 |
| `cluster` | 0 | **68** | 15 |

*(Codex slice; the cluster figure across all clients is 315 turns.)*

## Why only Codex broke

Of those turns, **every single 400 was a Codex-subscription caller**. The same model served ~247 turns to non-subscription callers with **zero** errors. Codex-subscription traffic dispatches to `chatgpt.com/backend-api/codex`, which stopped serving the retired model; regular `api.openai.com` still serves it.

## Changes

| File | Change |
|---|---|
| `catalog.go` | **The fix.** Drop gpt-5.5's `Tier`, matching the `claude-opus-4-8` precedent. Untiered rows are passthrough-only, so #897's `resolveProviderFor` drops it from cluster candidates while **pricing is preserved** for lingering pins and direct requests. |
| `force_model.go` | The generic `gpt`/`openai` aliases pointed at the retired model. Repoint to the current flagship; version-specific `gpt-5-5*` aliases keep resolving exactly, since passthrough still works. |

### Dropped on rebase

This PR originally also pruned gpt-5.5 from `codexCoveredModels`. **Main independently did that and did it better** — the list is now fail-closed with an exported `CodexSubscriptionCoversModel`. The rebase takes main's version wholesale rather than reverting it, so the subsidy half is no longer part of this PR.

## Test changes are consequences, not accommodations

- `candidate_k12_test`: cluster candidates drop to **17** — gpt-5.5 joins deepseek-v4-pro, opus-4-8 and qwen3.7-plus as catalog-retired. This is the fix working.
- `hmm_test`: its hardcoded *"current HMM roster arms"* list still asserted `openai/gpt-5.5`. It had silently drifted from the actual roster since the retirement — same cross-repo drift class as the bug itself.

## Verification

`gofmt` clean, `go vet ./...` clean, `go test ./...` — **48 packages OK, 0 failures**, on the rebased base.

Passthrough safety: `PrimaryProvider()` reads `Providers[0]` and is unaffected by tier, and the catalog's positive-pricing invariant test still passes for gpt-5.5 — so explicit requests and lingering pins still resolve and bill correctly.

## Follow-up not in this PR

The cluster strategy is still serving other roster-retired models (~502 turns of `deepseek-v4-pro`). Worth a sweep. Separately, the router records `upstream_status_code` but never the upstream error body — a 400 is currently undiagnosable from stored data, which is what made this take a full investigation rather than a log lookup.

Write-up: `router-internal/docs/eval/RESULTS_codex_gpt55_retirement_gap.md` (WorkWeave #11720).

🤖 Generated with [Weave Router](https://router.workweave.ai)