### PR TITLE
Show routing badge only when the served model changes

### DIFF
--- a/internal/proxy/marker_internal_test.go
+++ b/internal/proxy/marker_internal_test.go
@@ -37,59 +37,43 @@ func TestRoutingMarkerFor_PlannerPaths(t *testing.T) {
 			},
 		},
 		{
-			name: "ev_negative: planner stayed",
+			// Stay reasons only fire when the scorer/planner re-confirmed the same
+			// model already serving this session — which is exactly the case the
+			// switch-only gate now suppresses.
+			name: "ev_negative: same model as last turn, marker suppressed",
 			res: turnLoopResult{
-				Decision:        decision,
-				PlannerDecision: planner.Decision{Reason: planner.ReasonEVNegative},
+				Decision:         decision,
+				PlannerDecision:  planner.Decision{Reason: planner.ReasonEVNegative},
+				PriorServedModel: decision.Model,
 			},
-			wantContains: []string{
-				"· " + markerReasonStayed,
-			},
-			wantNotContain: []string{
-				"(openrouter)",
-				"reason:",
-				"ev_negative",
-			},
+			wantEmpty: true,
 		},
 		{
-			name: "no_prior_usage: collapses into stayed bucket",
+			name: "no_prior_usage: same model as last turn, marker suppressed",
 			res: turnLoopResult{
-				Decision:        decision,
-				PlannerDecision: planner.Decision{Reason: planner.ReasonNoPriorUsage},
+				Decision:         decision,
+				PlannerDecision:  planner.Decision{Reason: planner.ReasonNoPriorUsage},
+				PriorServedModel: decision.Model,
 			},
-			wantContains: []string{
-				"· " + markerReasonStayed,
-			},
-			wantNotContain: []string{
-				"no cache stats",
-			},
+			wantEmpty: true,
 		},
 		{
-			name: "same_tier_pinned: collapses into stayed bucket",
+			name: "same_tier_pinned: same model as last turn, marker suppressed",
 			res: turnLoopResult{
-				Decision:        decision,
-				PlannerDecision: planner.Decision{Reason: planner.ReasonSameTierPinned},
+				Decision:         decision,
+				PlannerDecision:  planner.Decision{Reason: planner.ReasonSameTierPinned},
+				PriorServedModel: decision.Model,
 			},
-			wantContains: []string{
-				"· " + markerReasonStayed,
-			},
-			wantNotContain: []string{
-				"same_tier_pinned",
-			},
+			wantEmpty: true,
 		},
 		{
-			name: "same_model: collapses into best-pick bucket",
+			name: "same_model: same model as last turn, marker suppressed",
 			res: turnLoopResult{
-				Decision:        decision,
-				PlannerDecision: planner.Decision{Reason: planner.ReasonSameModel},
+				Decision:         decision,
+				PlannerDecision:  planner.Decision{Reason: planner.ReasonSameModel},
+				PriorServedModel: decision.Model,
 			},
-			wantContains: []string{
-				"· " + markerReasonBestPick,
-			},
-			wantNotContain: []string{
-				"scorer matches the pin",
-				"reason:",
-			},
+			wantEmpty: true,
 		},
 		{
 			name: "tier_upgrade: planner bumped to a higher tier",
@@ -141,18 +125,12 @@ func TestRoutingMarkerFor_PlannerPaths(t *testing.T) {
 			},
 		},
 		{
-			name: "hard-pin path: planner didn't run, mark it accordingly",
+			name: "hard-pin path: marker suppressed regardless of prior model",
 			res: turnLoopResult{
 				Decision:   decision,
 				HardPinned: true,
 			},
-			wantContains: []string{
-				"· " + markerReasonHardPinned,
-			},
-			wantNotContain: []string{
-				"hard pin",
-				"reason:",
-			},
+			wantEmpty: true,
 		},
 		{
 			name: "tool-result short-circuit: marker suppressed",
@@ -365,6 +343,20 @@ func TestRoutingMarkerFor_ClampsSidecarDisplayMarker(t *testing.T) {
 
 	assert.LessOrEqual(t, len([]rune(strings.TrimSpace(got))), maxSidecarDisplayMarkerRunes)
 	assert.Contains(t, got, "✦ **Weave Router** → ")
+}
+
+func TestBaselineRoutingMarkerFor_SuppressedWhenBaselineAlreadyServing(t *testing.T) {
+	got := baselineRoutingMarkerFor(turnLoopResult{
+		PriorServedModel: "claude-opus-4-8",
+	}, "claude-opus-4-8")
+	assert.Empty(t, got, "a failover that lands back on the model already serving must stay quiet")
+}
+
+func TestBaselineRoutingMarkerFor_ShowsOnGenuineSwitch(t *testing.T) {
+	got := baselineRoutingMarkerFor(turnLoopResult{
+		PriorServedModel: "deepseek/deepseek-v4-pro",
+	}, "claude-opus-4-8")
+	assert.Equal(t, "✦ **Weave Router** → claude-opus-4-8 · "+markerReasonBaseline+"\n\n", got)
 }
 
 func TestHumanReasonFromPlanner_UnknownCodeIsSilenced(t *testing.T) {

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -446,18 +446,26 @@ func routingMarkerFor(res turnLoopResult) string {
 	if res.SuggestionMode {
 		return ""
 	}
-	// Suppress on tool-result follow-ups (would re-emit a duplicate mid-stream),
-	// but always show it if the model changed, even with an unknown reason code.
-	modelChanged := res.PriorServedModel != "" && res.PriorServedModel != res.Decision.Model
-	if res.PlannerDecision.Reason == "" && !res.HardPinned && res.StickyHit && !modelChanged {
-		return ""
-	}
-	parts := []string{"✦ **Weave Router** → " + decision.Model}
+	// A sidecar-supplied marker is a genuine per-turn status line (e.g.
+	// "Delegating work with ...") independent of whether the serving model
+	// changed, so it bypasses the switch gate below and always prints.
 	if decision.Metadata != nil {
 		if marker := sanitizeSidecarDisplayMarker(decision.Metadata.DisplayMarker); marker != "" {
 			return marker + "\n\n"
 		}
 	}
+	// Hard pins (compaction / sub-agent) return before the pin is loaded, so
+	// PriorServedModel is always empty there — suppress explicitly rather than
+	// letting it read as a first turn.
+	if res.HardPinned {
+		return ""
+	}
+	// Same model as last turn: the user already knows. Empty prior model means
+	// the first turn of this session (or role), which still shows.
+	if res.PriorServedModel == res.Decision.Model {
+		return ""
+	}
+	parts := []string{"✦ **Weave Router** → " + decision.Model}
 	if reason := routingReasonShort(res); reason != "" {
 		parts = append(parts, reason)
 	}
@@ -501,7 +509,6 @@ func sanitizeSidecarDisplayMarker(raw string) string {
 // the marker wording; tests assert the mapping against these constants rather
 // than re-spelling the literals.
 const (
-	markerReasonHardPinned    = "pinned for compaction / sub-agent"
 	markerReasonUserForced    = "pinned by force-model"
 	markerReasonLoopEscalated = "escalated due to loop"
 	markerReasonSwitched      = "switched for positive EV after cache eviction"
@@ -519,15 +526,17 @@ func baselineRoutingMarkerFor(res turnLoopResult, baselineModel string) string {
 	if res.SuggestionMode || baselineModel == "" {
 		return ""
 	}
+	// A failover that lands back on the model already serving is a no-op repeat;
+	// only a genuine switch to a different model is worth surfacing.
+	if res.PriorServedModel == baselineModel {
+		return ""
+	}
 	return "✦ **Weave Router** → " + baselineModel + " · " + markerReasonBaseline + "\n\n"
 }
 
 // routingReasonShort returns a short user-facing reason for the routing
 // decision, or empty when the underlying code is internal recovery noise.
 func routingReasonShort(res turnLoopResult) string {
-	if res.HardPinned {
-		return markerReasonHardPinned
-	}
 	if res.PlannerDecision.Reason != "" {
 		return humanReasonFromPlanner(res.PlannerDecision.Reason)
 	}

--- a/smoke/harness_test.go
+++ b/smoke/harness_test.go
@@ -272,7 +272,12 @@ func parseSSE(r io.Reader) (events []string, msg *anthropicMessage, raw []byte, 
 
 // applyStreamEvent folds a single SSE data payload into the reconstructed
 // message: message_start carries the initial message (model + input usage),
-// message_delta carries stop_reason and output-token usage.
+// message_delta carries stop_reason and usage. Input-side usage can arrive on
+// either event: a plain upstream response puts it on message_start, but the
+// routing-marker writer emits a synthetic message_start (before the upstream
+// call even lands, for TTFB) with zeroed usage and folds the real input
+// counts into message_delta.usage once upstream responds — so message_delta
+// must win over a zero value from message_start, not just add output tokens.
 func applyStreamEvent(msg *anthropicMessage, event, payload string) {
 	switch event {
 	case "message_start":
@@ -295,6 +300,15 @@ func applyStreamEvent(msg *anthropicMessage, event, payload string) {
 		if json.Unmarshal([]byte(payload), &env) == nil {
 			if env.Delta.StopReason != "" {
 				msg.StopReason = env.Delta.StopReason
+			}
+			if env.Usage.InputTokens > 0 {
+				msg.Usage.InputTokens = env.Usage.InputTokens
+			}
+			if env.Usage.CacheCreationInputTokens > 0 {
+				msg.Usage.CacheCreationInputTokens = env.Usage.CacheCreationInputTokens
+			}
+			if env.Usage.CacheReadInputTokens > 0 {
+				msg.Usage.CacheReadInputTokens = env.Usage.CacheReadInputTokens
 			}
 			if env.Usage.OutputTokens > 0 {
 				msg.Usage.OutputTokens = env.Usage.OutputTokens


### PR DESCRIPTION
## Summary

The routing badge fired on nearly every turn because the existing
suppression gate only triggered when the planner didn't run (tool-result
follow-ups). On a main turn the planner always reports a reason, so the
badge printed even when the model was identical to the prior turn —
20 of 22 badges in one observed session carried no information.

## Changes

- **internal/proxy/service.go**: rewrite the gate in `routingMarkerFor`
  to suppress whenever `PriorServedModel == decision.Model`, always
  emit on a genuine switch or on the first turn of a session/role.
  Suppress `HardPinned` turns explicitly (they never load the pin, so
  `PriorServedModel` is empty there). Sidecar `DisplayMarker` always
  prints — it's a genuine per-turn status line independent of whether
  the model changed. Apply the same same-model suppression to
  `baselineRoutingMarkerFor` so a failover landing back on the
  already-serving model stays quiet. `markerReasonHardPinned` becomes
  dead and is removed.
- **internal/proxy/marker_internal_test.go**: flip the four stay-reason
  cases (`ev_negative`, `no_prior_usage`, `same_tier_pinned`,
  `same_model`) to set a matching `PriorServedModel` and assert the
  marker is suppressed; invert the hard-pin case to assert suppression;
  add two new unit tests for `baselineRoutingMarkerFor`'s new gate.

🤖 Generated with [Weave Router](https://router.workweave.ai)