### PR TITLE
Fix invalid thought signature when translating for Gemini

### DIFF
--- a/internal/translate/emit_anthropic.go
+++ b/internal/translate/emit_anthropic.go
@@ -837,7 +837,21 @@ func sanitizeToolUseID(id string) string {
 // some vLLM/SGLang hosts) reuse a stable id every turn; Claude Code dedupes
 // by id and silently drops repeats, stalling the session. Nonce shared per
 // response so ids pair within a turn. Idempotent; empty id gets synthetic one.
+//
+// id may already carry a Gemini thoughtSignature embedded by embedSignatureInID
+// (the Gemini->OpenAI emit path embeds it before this ever runs). The
+// signature is extracted first and re-embedded after nonce-ing the clean id —
+// appending the nonce directly to an already-embedded id would land it inside
+// the base64 payload, corrupting the length (and thus the signature) rather
+// than the id.
 func uniqueToolUseIDWithNonce(id, nonce string) string {
+	cleanID, sig := extractSignatureFromID(id)
+	return embedSignatureInID(uniqueSanitizedIDWithNonce(cleanID, nonce), sig)
+}
+
+// uniqueSanitizedIDWithNonce is uniqueToolUseIDWithNonce's inner id+nonce
+// logic, applied only to the signature-free id portion.
+func uniqueSanitizedIDWithNonce(id, nonce string) string {
 	if nonce == "" {
 		return sanitizeToolUseID(id)
 	}

--- a/internal/translate/tool_call_id_internal_test.go
+++ b/internal/translate/tool_call_id_internal_test.go
@@ -21,6 +21,22 @@ func TestSanitizeToolUseID_PreservesLongThoughtSignatureID(t *testing.T) {
 	assert.NotEmpty(t, sig, "thoughtSignature still recoverable after sanitize")
 }
 
+func TestUniqueToolUseIDWithNoncePreservesEmbeddedThoughtSignature(t *testing.T) {
+	// Regression: appending the response nonce directly to an id that already
+	// carries an embedded Gemini thoughtSignature (Gemini->OpenAI->Anthropic
+	// chain) landed the nonce inside the base64 payload, corrupting its length
+	// and making the next-turn thoughtSignature unparseable upstream.
+	sig := strings.Repeat("signature-data/", 200)
+	embedded := embedSignatureInID("call_abc", sig)
+
+	got := uniqueToolUseIDWithNonce(embedded, "0123456789ab")
+	cleanID, gotSig := extractSignatureFromID(got)
+
+	assert.Equal(t, "call_abc_0123456789ab", cleanID)
+	assert.Equal(t, sig, gotSig)
+	assert.Equal(t, got, uniqueToolUseIDWithNonce(got, "0123456789ab"))
+}
+
 func TestOpenAIReasoningSignatureRoundTrip(t *testing.T) {
 	sig := encodeOpenAIReasoningSignature("rs_123", "enc_opaque")
 	require.NotEmpty(t, sig)


### PR DESCRIPTION
## Fix invalid thought signature when translating for Gemini

`uniqueToolUseIDWithNonce` appended the response nonce directly to the tool_use id. In the Gemini → OpenAI → Anthropic chain that id famously carries a Gemini `thoughtSignature` smuggled via `embedSignatureInID` (`call_XXXX__thought__<base64>`), so the nonce landed inside the base64 payload rather than before the delimiter. The 13-char suffix (`_` + 12 hex chars) corrupted the signature length, producing:

```
API Error: 400 Invalid value at 'contents[3].parts[0].thought_signature'
  (TYPE_BYTES), Base64 decoding failed …
```

The fix splits the id around any embedded signature, nonces only the clean id, then re-embeds the signature so it stays intact at the tail. Both the streaming (`AnthropicSSETranslator`) and non-streaming (`writeAnthropicContentFromOpenAI`) code paths share this helper, so both are fixed in one change. `embedSignatureInID`'s idempotency short-circuit was masking the bug — once the nonce was added the second call was a no-op.

### Tested with `/test-claude-locally`

Ran the router in docker compose against the real Google Gemini API. Multi-turn Claude Code session with `/force-model gemini-3.1-pro-preview` pinned the session; tool_use → tool_result → next Gemini turn round-tripped cleanly with all four Gemini-served turns completing at `upstream_status=0`. Log scan for `base64 decod`, `thought_signature.*fail`, `invalid_argument`, and `400` shows no actual errors.

Tool_use.id format now is `call_<rand>_<nonce>__thought__<b64>` (nonce lands before the delimiter, base64 payload decodes to the correct length).

🤖 Generated with [Weave Router](https://router.workweave.ai)
