### PR TITLE
Add `x-weave-force-cluster` header

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -184,10 +184,49 @@ the command answers with the reason and leaves routing (and any prior pin)
 alone, and the header fails the request with HTTP 400. A model with one
 permitted binding left is forced normally and served through that binding. A
 live session whose forced pin is later excluded fails the same way rather than
-quietly reverting to automatic routing — clear it with `/unforce-model`.
+quietly reverting to automatic routing — clear it with `/unforce-model`. The
+same holds a level up: exclusions that empty a forced routing cluster fail the
+request too (see [Forcing a model or a routing
+cluster](#forcing-a-model-or-a-routing-cluster)).
 
 Excluding every provider that serves the models you route to leaves requests
 with nowhere to go (HTTP 503 from the scorer), so exclude deliberately.
+
+## Forcing a model or a routing cluster
+
+Two request headers let a headless caller (eval harness, CI, any client whose
+UI eats slash commands) override routing. Both fail the request rather than
+routing on, so a typo can't look like it took effect.
+
+| Header | Effect |
+| ------ | ------ |
+| `x-weave-force-model` | Pins the session to one model, exactly as `/force-model` does. Accepts a canonical catalog ID or an alias (`opus`, `gpt`, `qwen-max`, …) plus an optional `:level` effort suffix (`opus:high`). A value naming no catalog model is HTTP 400. |
+| `x-weave-force-cluster` | Constrains serving to one of the policy sidecar's routing clusters, leaving the choice *within* it to the policy. |
+
+`x-weave-force-cluster` takes an opaque label — the router holds no list of
+valid ones. The live cluster vocabulary belongs to the deployed policy artifact
+and changes when it does, so the only authority is the roster the sidecar
+reports on that very request; a hardcoded list would silently go stale on the
+next roster bump. Consequences:
+
+- A label absent from the live roster is HTTP 400, whether it's a typo or a
+  cluster the current artifact retired. Both are equally unservable.
+- A label that *is* in the roster but has no eligible model for this request
+  (everything in it excluded, over-window, or filtered out on capability) is
+  also HTTP 400 — including when a per-key cluster model list empties it.
+- The header only works on the `hmm` / `hmm_embedding` strategies. The default
+  `cluster` strategy scores anonymous centroids with no named groups, so there
+  is nothing to constrain to and the request is HTTP 400 rather than a silent
+  no-op.
+- A sidecar too old to report its clusters also 400s. The constraint can't be
+  proven against a roster the router can't see, and serving anyway would ignore
+  the force.
+
+Unlike `x-weave-force-model` the cluster header writes no session pin: every
+turn carrying it is constrained on its own merits. Which models make up a
+cluster stays control-plane config (the dashboard's per-API-key "Cluster model
+lists" panel) — the header only says *which* cluster this turn must come from,
+and any list configured for that cluster still orders the arm that serves.
 
 ## Policy sidecars
 

--- a/docs/SMOKE.md
+++ b/docs/SMOKE.md
@@ -117,7 +117,7 @@ across both providers, a few cents. Skip recording OpenAI by omitting
 | File | Scenario |
 |---|---|
 | `smoke/boot_test.go` | `/health`, `/v1/version`, `/v1/router/models` respond and are well-formed |
-| `smoke/basic_test.go` | `/force-model` command turn; non-stream turn (usage + decision headers); streamed turn well-ordered |
+| `smoke/basic_test.go` | `/force-model` command turn; non-stream turn (usage + decision headers); streamed turn well-ordered; `x-weave-force-cluster` / unknown `x-weave-force-model` refused with 400 pre-dispatch |
 | `smoke/cache_test.go` | router-injected caching warms then reads; client-at-capacity doesn't over-inject; `ttl=1h` breakpoint not poisoned; overflow rejected cleanly by the router |
 | `smoke/streaming_test.go` | tool-use stream lifecycle: balanced `content_block_start/stop`, exactly one `message_stop`, `stop_reason` present |
 | `smoke/openai_test.go` | OpenAI Responses-API translation path (gpt-5.x + tools): a genuinely typeless optional tool param round-trips without a 400; basic turn served correctly |

--- a/internal/proxy/dispatch_error.go
+++ b/internal/proxy/dispatch_error.go
@@ -11,6 +11,7 @@ import (
 	"workweave/router/internal/router/bandit"
 	"workweave/router/internal/router/cluster"
 	"workweave/router/internal/router/hmm"
+	"workweave/router/internal/router/policy"
 	"workweave/router/internal/router/rl"
 	"workweave/router/internal/translate"
 )
@@ -45,6 +46,9 @@ const (
 	DispatchErrorSpendLimitUnavailable
 	DispatchErrorAnthropicCacheControlInvalid
 	DispatchErrorForcedModelExcluded
+	DispatchErrorForcedModelUnknown
+	DispatchErrorForcedClusterUnsupportedStrategy
+	DispatchErrorForcedClusterUnservable
 )
 
 // DispatchErrorClass is the format-agnostic classification of a dispatch
@@ -77,6 +81,9 @@ type DispatchErrorClass struct {
 func ClassifyDispatchError(err error) (DispatchErrorClass, bool) {
 	var statusErr *providers.UpstreamStatusError
 	var forcedExcluded *ForcedModelExcludedError
+	var forcedUnknown *ForcedModelUnknownError
+	var forcedClusterStrategy *ForcedClusterUnsupportedStrategyError
+	var forcedClusterUnservable *policy.ForcedClusterUnservableError
 	switch {
 	case errors.As(err, &forcedExcluded):
 		// Ahead of the sentinel cases so the reason reaches the caller: a bare
@@ -87,6 +94,30 @@ func ClassifyDispatchError(err error) (DispatchErrorClass, bool) {
 			Message:    forcedExcluded.Reason + ". Clear the force (/unforce-model) or pick a model from a permitted provider.",
 			LogLevel:   "warn",
 			LogMessage: "Rejected request: forced model is excluded on this installation",
+		}, true
+	case errors.As(err, &forcedUnknown):
+		return DispatchErrorClass{
+			Kind:       DispatchErrorForcedModelUnknown,
+			Status:     http.StatusBadRequest,
+			Message:    forcedUnknown.Error() + ". Use a full model ID, e.g. claude-opus-5, gpt-5.6-sol, or gemini-3-pro-preview.",
+			LogLevel:   "warn",
+			LogMessage: "Rejected request: forced model is not a known model",
+		}, true
+	case errors.As(err, &forcedClusterStrategy):
+		return DispatchErrorClass{
+			Kind:       DispatchErrorForcedClusterUnsupportedStrategy,
+			Status:     http.StatusBadRequest,
+			Message:    forcedClusterStrategy.Error() + ". Clear " + ForceClusterHeader + ", or move the installation to a policy-sidecar strategy.",
+			LogLevel:   "warn",
+			LogMessage: "Rejected request: forced cluster on a strategy with no policy sidecar",
+		}, true
+	case errors.As(err, &forcedClusterUnservable):
+		return DispatchErrorClass{
+			Kind:       DispatchErrorForcedClusterUnservable,
+			Status:     http.StatusBadRequest,
+			Message:    forcedClusterUnservable.Reason + ". Clear " + ForceClusterHeader + " or update the cluster's model list.",
+			LogLevel:   "warn",
+			LogMessage: "Rejected request: forced cluster has no eligible model",
 		}, true
 	case errors.As(err, &statusErr):
 		return DispatchErrorClass{
@@ -256,7 +287,7 @@ func unwrapToSentinelMessage(err error) string {
 // rather than "api_error".
 func (k DispatchErrorKind) IsClientError() bool {
 	switch k {
-	case DispatchErrorRequestNotJSONObject, DispatchErrorNoEligibleProvider, DispatchErrorContextWindowExceeded, DispatchErrorInvalidRoutingKnobs, DispatchErrorTranslationIntrinsicallyIncompatible, DispatchErrorAnthropicCacheControlInvalid, DispatchErrorForcedModelExcluded:
+	case DispatchErrorRequestNotJSONObject, DispatchErrorNoEligibleProvider, DispatchErrorContextWindowExceeded, DispatchErrorInvalidRoutingKnobs, DispatchErrorTranslationIntrinsicallyIncompatible, DispatchErrorAnthropicCacheControlInvalid, DispatchErrorForcedModelExcluded, DispatchErrorForcedModelUnknown, DispatchErrorForcedClusterUnsupportedStrategy, DispatchErrorForcedClusterUnservable:
 		return true
 	default:
 		return false

--- a/internal/proxy/dispatch_error_test.go
+++ b/internal/proxy/dispatch_error_test.go
@@ -12,6 +12,7 @@ import (
 	"workweave/router/internal/router/bandit"
 	"workweave/router/internal/router/cluster"
 	"workweave/router/internal/router/hmm"
+	"workweave/router/internal/router/policy"
 	"workweave/router/internal/router/rl"
 	"workweave/router/internal/translate"
 
@@ -168,4 +169,47 @@ func TestClassifyDispatchError_AnthropicCacheControlInvalidTTLOrderingIs400(t *t
 	assert.True(t, cls.Kind.IsClientError())
 	assert.NotContains(t, cls.Message, "emit body:", "the internal wrap-chain prefix must not leak into the client-facing message")
 	assert.Contains(t, cls.Message, "ttl=1h cache_control must not follow ttl=5m")
+}
+
+func TestClassifyDispatchError_ForcedModelUnknownIs400(t *testing.T) {
+	cls, ok := proxy.ClassifyDispatchError(&proxy.ForcedModelUnknownError{Model: "gpt-"})
+
+	require.True(t, ok)
+	assert.Equal(t, proxy.DispatchErrorForcedModelUnknown, cls.Kind)
+	assert.Equal(t, http.StatusBadRequest, cls.Status)
+	assert.True(t, cls.Kind.IsClientError(), "an unresolvable force is a client-input problem")
+	assert.Contains(t, cls.Message, "gpt-", "the caller must see the value that failed to resolve")
+	assert.Equal(t, "warn", cls.LogLevel)
+}
+
+func TestClassifyDispatchError_ForcedClusterUnsupportedStrategyIs400(t *testing.T) {
+	cls, ok := proxy.ClassifyDispatchError(&proxy.ForcedClusterUnsupportedStrategyError{
+		Cluster:  "maximum",
+		Strategy: "cluster",
+	})
+
+	require.True(t, ok)
+	assert.Equal(t, proxy.DispatchErrorForcedClusterUnsupportedStrategy, cls.Kind)
+	assert.Equal(t, http.StatusBadRequest, cls.Status)
+	assert.True(t, cls.Kind.IsClientError())
+	assert.Contains(t, cls.Message, "maximum")
+	assert.Contains(t, cls.Message, proxy.ForceClusterHeader, "the caller must be told which header to clear")
+}
+
+// The unservable error is raised inside the policy router, so it must classify
+// through the wrap chain Route returns it in — not just bare.
+func TestClassifyDispatchError_ForcedClusterUnservableIs400(t *testing.T) {
+	err := fmt.Errorf("route: %w", &policy.ForcedClusterUnservableError{
+		Cluster: "explore",
+		Reason:  `"explore" is not a routing cluster on this installation`,
+	})
+
+	cls, ok := proxy.ClassifyDispatchError(err)
+
+	require.True(t, ok)
+	assert.Equal(t, proxy.DispatchErrorForcedClusterUnservable, cls.Kind)
+	assert.Equal(t, http.StatusBadRequest, cls.Status)
+	assert.True(t, cls.Kind.IsClientError(), "a bad cluster label is a client error, not a sidecar outage")
+	assert.Contains(t, cls.Message, "explore")
+	assert.NotContains(t, cls.Message, "route:", "the internal wrap prefix must not leak to the client")
 }

--- a/internal/proxy/force_cluster.go
+++ b/internal/proxy/force_cluster.go
@@ -1,0 +1,70 @@
+package proxy
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"workweave/router/internal/observability"
+	"workweave/router/internal/router"
+)
+
+// ForceClusterHeader constrains serving to one of the policy sidecar's
+// classifier groups, leaving the within-group selection to the policy. It is
+// the group-level analogue of ForceModelHeader, for headless callers that want
+// a routing tier rather than one specific model.
+//
+// The value is deliberately not validated against a list baked into the router:
+// the live group vocabulary belongs to the deployed policy artifact and changes
+// with it, so the only authority is the roster the sidecar reports on this very
+// request (see policy.ApplyClusterArmOverridesRequireMatch).
+const ForceClusterHeader = "x-weave-force-cluster"
+
+// ErrForcedClusterUnsupportedStrategy is returned when a caller forces a
+// cluster on an installation whose strategy never runs a policy sidecar, so no
+// roster exists to constrain serving to.
+var ErrForcedClusterUnsupportedStrategy = errors.New("forced cluster requires an hmm strategy")
+
+// ForcedClusterUnsupportedStrategyError carries the refused label and the
+// strategy that was actually active, so the caller learns why the header can't
+// be honored here.
+type ForcedClusterUnsupportedStrategyError struct {
+	Cluster  string
+	Strategy string
+}
+
+// Error implements error.
+func (e *ForcedClusterUnsupportedStrategyError) Error() string {
+	return fmt.Sprintf("cannot force cluster %q: strategy %q runs no policy sidecar", e.Cluster, e.Strategy)
+}
+
+// Unwrap ties the typed error to ErrForcedClusterUnsupportedStrategy for errors.Is.
+func (e *ForcedClusterUnsupportedStrategyError) Unwrap() error {
+	return ErrForcedClusterUnsupportedStrategy
+}
+
+// applyForceClusterHeader resolves the x-weave-force-cluster header into the
+// label carried on router.Request.ForceCluster. An absent header is a no-op.
+//
+// Only the strategy is checked here. Whether the named cluster exists and has
+// an eligible model can't be known until the sidecar answers with this
+// request's roster, so that check lives in the policy router; this is the one
+// half that can be answered — and refused — before paying for a round trip.
+func applyForceClusterHeader(ctx context.Context, r *http.Request) (string, error) {
+	label := strings.ToLower(strings.TrimSpace(r.Header.Get(ForceClusterHeader)))
+	if label == "" {
+		return "", nil
+	}
+	strategy := router.StrategyFromContext(ctx)
+	if !router.IsHMMStrategy(strategy) {
+		observability.FromContext(ctx).Warn("x-weave-force-cluster: rejected on a strategy with no policy sidecar",
+			"cluster", label,
+			"strategy", strategy,
+		)
+		return "", &ForcedClusterUnsupportedStrategyError{Cluster: label, Strategy: string(strategy)}
+	}
+	observability.FromContext(ctx).Info("x-weave-force-cluster applied", "cluster", label, "strategy", strategy)
+	return label, nil
+}

--- a/internal/proxy/force_cluster_internal_test.go
+++ b/internal/proxy/force_cluster_internal_test.go
@@ -1,0 +1,121 @@
+package proxy
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"workweave/router/internal/providers"
+	"workweave/router/internal/router"
+	"workweave/router/internal/router/policy"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func forceClusterRequest(t *testing.T, value string) *http.Request {
+	t.Helper()
+	r, err := http.NewRequest(http.MethodPost, "/v1/messages", nil)
+	require.NoError(t, err)
+	if value != "" {
+		r.Header.Set(ForceClusterHeader, value)
+	}
+	return r
+}
+
+func TestApplyForceClusterHeader_AbsentIsNoOp(t *testing.T) {
+	label, err := applyForceClusterHeader(context.Background(), forceClusterRequest(t, ""))
+
+	require.NoError(t, err)
+	assert.Empty(t, label)
+}
+
+func TestApplyForceClusterHeader_ThreadsLabelOnHMMStrategy(t *testing.T) {
+	for _, strategy := range []router.Strategy{router.StrategyHMM, router.StrategyHMMEmbedding} {
+		t.Run(string(strategy), func(t *testing.T) {
+			ctx := router.WithStrategy(context.Background(), strategy)
+
+			label, err := applyForceClusterHeader(ctx, forceClusterRequest(t, "  Maximum  "))
+
+			require.NoError(t, err, "eligibility is only knowable after the sidecar answers")
+			assert.Equal(t, "maximum", label, "the label is trimmed and lowercased, not validated here")
+		})
+	}
+}
+
+// The default cluster strategy scores anonymous centroids, so there is no named
+// group to constrain to — refusing beats serving an unconstrained model.
+func TestApplyForceClusterHeader_RejectsNonSidecarStrategy(t *testing.T) {
+	ctx := router.WithStrategy(context.Background(), router.StrategyCluster)
+
+	label, err := applyForceClusterHeader(ctx, forceClusterRequest(t, "maximum"))
+
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrForcedClusterUnsupportedStrategy))
+	assert.Empty(t, label)
+
+	cls, ok := ClassifyDispatchError(err)
+	require.True(t, ok)
+	assert.Equal(t, http.StatusBadRequest, cls.Status)
+	assert.True(t, cls.Kind.IsClientError())
+	assert.Contains(t, cls.Message, "maximum")
+}
+
+// ProxyMessages must refuse before routing, not after: a request that reached
+// the scorer would be served from a cluster the caller didn't ask for.
+func TestProxyMessages_ForceClusterOnNonSidecarStrategyRejects(t *testing.T) {
+	fr := &stripFailureRouter{}
+	fp := &stripFailureProvider{}
+	svc := NewService(fr, map[string]providers.Client{providers.ProviderAnthropic: fp}, nil, false, nil, nil, false,
+		providers.ProviderAnthropic, "claude-haiku-4-5", nil)
+
+	body := `{"model":"claude-opus-4-8","max_tokens":64,"messages":[{"role":"user","content":"hi"}]}`
+	rec := httptest.NewRecorder()
+
+	err := svc.ProxyMessages(context.Background(), []byte(body), rec, forceClusterRequest(t, "maximum"))
+
+	require.ErrorIs(t, err, ErrForcedClusterUnsupportedStrategy)
+	assert.Zero(t, fr.routeCalls, "must abort before routing runs")
+	assert.Zero(t, fp.proxyCalls, "must abort before dispatching upstream")
+}
+
+// forceClusterCapturingRouter records the request the turn loop routed with, so
+// the header's journey from ingress to router.Request is provable.
+type forceClusterCapturingRouter struct {
+	captured router.Request
+	decision router.Decision
+}
+
+func (r *forceClusterCapturingRouter) Route(_ context.Context, req router.Request) (router.Decision, error) {
+	r.captured = req
+	return r.decision, nil
+}
+
+// On an HMM installation the label must reach the policy router — that's where
+// the roster check that enforces it lives.
+func TestProxyMessages_ForceClusterReachesRouterRequest(t *testing.T) {
+	strategy := router.StrategyHMM
+	fr := &forceClusterCapturingRouter{decision: router.Decision{
+		Provider: providers.ProviderAnthropic,
+		Model:    "claude-haiku-4-5",
+		Reason:   "hmm_policy:force_cluster",
+	}}
+	fp := &stripFailureProvider{}
+	svc := NewService(nil, map[string]providers.Client{providers.ProviderAnthropic: fp}, nil, false, nil, nil, false,
+		providers.ProviderAnthropic, "claude-haiku-4-5", nil).
+		WithPolicyStrategy(policy.StrategySpec{Strategy: strategy, Router: fr})
+
+	// Tools + a real max_tokens keep the turn off the classifier/probe hard-pin
+	// fast paths, which would never reach the router at all.
+	body := `{"model":"claude-opus-4-8","max_tokens":4096,` +
+		`"tools":[{"name":"Bash","input_schema":{"type":"object"}}],` +
+		`"messages":[{"role":"user","content":"hi"}]}`
+	ctx := router.WithStrategy(context.Background(), strategy)
+
+	require.NoError(t, svc.ProxyMessages(ctx, []byte(body), httptest.NewRecorder(),
+		forceClusterRequest(t, "maximum")))
+
+	assert.Equal(t, "maximum", fr.captured.ForceCluster)
+}

--- a/internal/proxy/force_model.go
+++ b/internal/proxy/force_model.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -23,9 +24,28 @@ import (
 // /force-model chat command. Needed for headless clients (eval harness, CI
 // smoke runs): Claude Code eats "/force-model …" as a client-side slash
 // command before it reaches the router. The header rides on every request,
-// so the pin is (re)written and served on the same turn. Unrecognized values
-// are ignored; routing proceeds automatically rather than failing.
+// so the pin is (re)written and served on the same turn. Values that name no
+// catalog model fail the request; so do excluded ones.
 const ForceModelHeader = "x-weave-force-model"
+
+// ErrForcedModelUnknown is returned when a caller forces a model name that
+// resolves to no catalog entry. Failing is the point: routing on regardless
+// serves a model the caller never asked for while looking like the force took.
+var ErrForcedModelUnknown = errors.New("forced model is not a known model")
+
+// ForcedModelUnknownError carries the unresolvable value so the dispatch
+// classifier can quote it back.
+type ForcedModelUnknownError struct {
+	Model string
+}
+
+// Error implements error.
+func (e *ForcedModelUnknownError) Error() string {
+	return fmt.Sprintf("%q is not a known model", e.Model)
+}
+
+// Unwrap ties the typed error to ErrForcedModelUnknown for errors.Is.
+func (e *ForcedModelUnknownError) Unwrap() error { return ErrForcedModelUnknown }
 
 var forceModelAliases = map[string]string{
 	"anthropic":   "claude-opus-5",
@@ -253,10 +273,9 @@ func (s *Service) setForceModelPin(
 
 // applyForceModelHeader honors the x-weave-force-model request header,
 // writing the same session pin the /force-model command writes. It's
-// (re)written on every request carrying the header. Unrecognized models are
-// ignored (routing proceeds automatically) rather than failing the request;
-// an excluded model fails it — silently routing elsewhere would serve a model
-// the caller never asked for.
+// (re)written on every request carrying the header. A model that names no
+// catalog entry, or one the exclusion policy forbids, fails the request —
+// silently routing elsewhere would serve a model the caller never asked for.
 //
 // A `:level` suffix is stashed on context as router.Overrides.ForceEffort
 // so pin + effort land in one header.
@@ -289,11 +308,11 @@ func (s *Service) applyForceModelHeader(
 		*r = *r.WithContext(router.WithRoutingKnobs(r.Context(), &merged))
 	}
 	if !known {
-		log.Info("x-weave-force-model: ignoring unrecognized model; routing automatically",
+		log.Warn("x-weave-force-model: rejected unrecognized model",
 			"input_model", raw,
 			"session_key_hex", fmt.Sprintf("%x", sessionKey),
 		)
-		return "", nil
+		return "", &ForcedModelUnknownError{Model: raw}
 	}
 	binding, reason := s.forcedModelBinding(ctx, canonicalModel, provider)
 	if reason != "" {

--- a/internal/proxy/gemini.go
+++ b/internal/proxy/gemini.go
@@ -90,8 +90,14 @@ func (s *Service) ProxyGeminiGenerateContent(ctx context.Context, body []byte, w
 
 	subAgentHint := r.Header.Get("x-weave-subagent-type")
 
+	forceCluster, forceErr := applyForceClusterHeader(ctx, r)
+	if forceErr != nil {
+		return forceErr
+	}
+
 	routeRequest := router.Request{
 		RequestedModel:               feats.Model,
+		ForceCluster:                 forceCluster,
 		EstimatedInputTokens:         feats.Tokens,
 		HasTools:                     feats.HasTools,
 		HasImages:                    feats.HasImages,

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -2194,9 +2194,14 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 	// Writes the user-forced pin and falls through to normal routing, which picks
 	// the pin up and serves the requested model on this same turn.
 	forceModel := ""
+	forceCluster := ""
 	if !agentShadowMode {
 		var forceErr error
 		forceModel, forceErr = s.applyForceModelHeader(ctx, r, env, installationID, sessionKey)
+		if forceErr != nil {
+			return forceErr
+		}
+		forceCluster, forceErr = applyForceClusterHeader(ctx, r)
 		if forceErr != nil {
 			return forceErr
 		}
@@ -2308,6 +2313,7 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 	req := router.Request{
 		RequestedModel:               feats.Model,
 		ForceModel:                   forceModel,
+		ForceCluster:                 forceCluster,
 		EstimatedInputTokens:         feats.Tokens,
 		HasTools:                     feats.HasTools,
 		HasImages:                    feats.HasImages,
@@ -4379,6 +4385,10 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 	if forceErr != nil {
 		return forceErr
 	}
+	forceCluster, forceErr := applyForceClusterHeader(ctx, r)
+	if forceErr != nil {
+		return forceErr
+	}
 
 	// Wide cyclic re-read loop → escalate to opus (same path as the Anthropic
 	// ingress). See detectCyclicToolCallLoop / handleLoopEscalation.
@@ -4490,6 +4500,7 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 	routeRequest := router.Request{
 		RequestedModel:               feats.Model,
 		ForceModel:                   forceModel,
+		ForceCluster:                 forceCluster,
 		EstimatedInputTokens:         feats.Tokens,
 		HasTools:                     feats.HasTools,
 		HasImages:                    feats.HasImages,

--- a/internal/proxy/service_session_pin_test.go
+++ b/internal/proxy/service_session_pin_test.go
@@ -1409,9 +1409,10 @@ func TestService_ForceModelHeader_WritesUserForcedPin(t *testing.T) {
 	assert.Equal(t, "claude-opus-5", fr.capturedReq.ForceModel, "valid force-model header must bypass router decorators")
 }
 
-// An unrecognized x-weave-force-model value must be ignored, so a typo
-// can't strand a session on an unservable directive.
-func TestService_ForceModelHeader_UnknownModelIgnored(t *testing.T) {
+// An unrecognized x-weave-force-model value fails the request: routing on
+// regardless would serve a model the caller never asked for while looking to
+// them like the force took.
+func TestService_ForceModelHeader_UnknownModelRejected(t *testing.T) {
 	store := newFakePinStore()
 	fr := &fakeRouter{decision: router.Decision{Provider: providers.ProviderAnthropic, Model: "claude-haiku-4-5", Reason: "fresh"}}
 	svc := newPinSvc(fr, store)
@@ -1420,12 +1421,15 @@ func TestService_ForceModelHeader_UnknownModelIgnored(t *testing.T) {
 	rec := httptest.NewRecorder()
 	httpReq := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(""))
 	httpReq.Header.Set(proxy.ForceModelHeader, "totally-not-a-model")
-	require.NoError(t, svc.ProxyMessages(ctx, []byte(pinTestBody), rec, httpReq))
+	err := svc.ProxyMessages(ctx, []byte(pinTestBody), rec, httpReq)
 
-	waitForUpsert(t, store) // normal routing still writes a fresh pin
+	require.Error(t, err)
+	cls, ok := proxy.ClassifyDispatchError(err)
+	require.True(t, ok)
+	assert.Equal(t, http.StatusBadRequest, cls.Status)
+	assert.Contains(t, cls.Message, "totally-not-a-model")
+	assert.Equal(t, 0, fr.routeCalls, "an unservable force must not fall through to the scorer")
 	store.mu.Lock()
 	defer store.mu.Unlock()
-	for _, p := range store.upserts {
-		assert.NotEqual(t, translate.ReasonUserForceModel, p.Reason, "unrecognized header must not write a user_forced pin")
-	}
+	assert.Empty(t, store.upserts, "a refused force must not write any pin")
 }

--- a/internal/router/policy/cluster_override.go
+++ b/internal/router/policy/cluster_override.go
@@ -1,5 +1,29 @@
 package policy
 
+import (
+	"errors"
+	"fmt"
+)
+
+// ErrForcedClusterUnservable is returned when a caller forces a classifier
+// group that this request cannot be served from — the label is not in the live
+// roster, or it is but has no eligible arm left after exclusions, capability
+// filtering, and any per-key allowlist.
+var ErrForcedClusterUnservable = errors.New("forced cluster has no eligible model")
+
+// ForcedClusterUnservableError carries the caller-facing reason a forced
+// cluster was refused, so the dispatch classifier can name the cluster.
+type ForcedClusterUnservableError struct {
+	Cluster string
+	Reason  string
+}
+
+// Error implements error.
+func (e *ForcedClusterUnservableError) Error() string { return e.Reason }
+
+// Unwrap ties the typed error to ErrForcedClusterUnservable for errors.Is.
+func (e *ForcedClusterUnservableError) Unwrap() error { return ErrForcedClusterUnservable }
+
 // ClusterOverrideResult is the outcome of applying per-key cluster allowlists
 // to a sidecar decision.
 type ClusterOverrideResult struct {
@@ -33,29 +57,18 @@ func ApplyClusterArmOverrides(
 		return ClusterOverrideResult{}
 	}
 
-	catalogToRoster := make(map[string]string, len(resolved.Candidates))
-	rosterToArm := make(map[string]string, len(resolved.Candidates))
-	eligibleRosterIDs := make(map[string]struct{}, len(resolved.Candidates))
-	for _, candidate := range resolved.Candidates {
-		if _, exists := catalogToRoster[candidate.CatalogID]; !exists {
-			catalogToRoster[candidate.CatalogID] = candidate.RosterID
-		}
-		if _, exists := rosterToArm[candidate.RosterID]; !exists {
-			rosterToArm[candidate.RosterID] = candidate.ArmID
-		}
-		eligibleRosterIDs[candidate.RosterID] = struct{}{}
-	}
+	index := indexCandidates(resolved)
 
 	for _, group := range rankedFallback {
 		override, hasOverride := overrides[group.Group]
-		effective := effectiveArms(group, override, hasOverride, catalogToRoster, eligibleRosterIDs)
+		effective := effectiveArms(group, override, hasOverride, index.catalogToRoster, index.eligibleRosterIDs)
 		if len(effective) == 0 {
 			continue
 		}
 		selected := effective[0]
 		return ClusterOverrideResult{
 			RosterID: selected,
-			ArmID:    rosterToArm[selected],
+			ArmID:    index.rosterToArm[selected],
 			Group:    group.Group,
 			Applied:  true,
 			Changed:  selected != sidecarRosterID,
@@ -66,6 +79,90 @@ func ApplyClusterArmOverrides(
 	// not-applied so the caller keeps the sidecar's selection (fail-open); the
 	// alternative — no eligible arm anywhere — would hard-fail the turn.
 	return ClusterOverrideResult{}
+}
+
+// ApplyClusterArmOverridesRequireMatch is ApplyClusterArmOverrides's fail-closed
+// sibling for a caller-forced cluster. A per-key allowlist is control-plane
+// config validated against the roster at write time, so falling open to the
+// sidecar's own pick is right for it; a forced label is unvalidated caller input
+// on this turn, so an unmatched or emptied group is an error rather than a
+// silent fall-through to a cluster the caller didn't ask for.
+func ApplyClusterArmOverridesRequireMatch(
+	overrides map[string][]string,
+	rankedFallback []PreviewGroup,
+	resolved ResolvedCandidates,
+	sidecarRosterID string,
+	requiredLabel string,
+) (ClusterOverrideResult, error) {
+	if len(rankedFallback) == 0 {
+		// Opposite polarity to the fail-open path above: with no ranked fallback
+		// there is no roster to prove the constraint against, and serving the
+		// sidecar's unconstrained pick would silently ignore the force.
+		return ClusterOverrideResult{}, &ForcedClusterUnservableError{
+			Cluster: requiredLabel,
+			Reason:  fmt.Sprintf("cannot force cluster %q: the policy sidecar does not report its routing clusters", requiredLabel),
+		}
+	}
+
+	var matched PreviewGroup
+	found := false
+	for _, group := range rankedFallback {
+		if group.Group == requiredLabel {
+			matched = group
+			found = true
+			break
+		}
+	}
+	if !found {
+		return ClusterOverrideResult{}, &ForcedClusterUnservableError{
+			Cluster: requiredLabel,
+			Reason:  fmt.Sprintf("%q is not a routing cluster on this installation", requiredLabel),
+		}
+	}
+
+	index := indexCandidates(resolved)
+	override, hasOverride := overrides[requiredLabel]
+	effective := effectiveArms(matched, override, hasOverride, index.catalogToRoster, index.eligibleRosterIDs)
+	if len(effective) == 0 {
+		return ClusterOverrideResult{}, &ForcedClusterUnservableError{
+			Cluster: requiredLabel,
+			Reason:  fmt.Sprintf("no model in cluster %q can serve this request", requiredLabel),
+		}
+	}
+
+	selected := effective[0]
+	return ClusterOverrideResult{
+		RosterID: selected,
+		ArmID:    index.rosterToArm[selected],
+		Group:    requiredLabel,
+		Applied:  true,
+		Changed:  selected != sidecarRosterID,
+	}, nil
+}
+
+// candidateIndex is the per-request lookup set both override paths need.
+type candidateIndex struct {
+	catalogToRoster   map[string]string
+	rosterToArm       map[string]string
+	eligibleRosterIDs map[string]struct{}
+}
+
+func indexCandidates(resolved ResolvedCandidates) candidateIndex {
+	index := candidateIndex{
+		catalogToRoster:   make(map[string]string, len(resolved.Candidates)),
+		rosterToArm:       make(map[string]string, len(resolved.Candidates)),
+		eligibleRosterIDs: make(map[string]struct{}, len(resolved.Candidates)),
+	}
+	for _, candidate := range resolved.Candidates {
+		if _, exists := index.catalogToRoster[candidate.CatalogID]; !exists {
+			index.catalogToRoster[candidate.CatalogID] = candidate.RosterID
+		}
+		if _, exists := index.rosterToArm[candidate.RosterID]; !exists {
+			index.rosterToArm[candidate.RosterID] = candidate.ArmID
+		}
+		index.eligibleRosterIDs[candidate.RosterID] = struct{}{}
+	}
+	return index
 }
 
 // effectiveArms returns the ordered eligible roster arms for one ranked group

--- a/internal/router/policy/cluster_override_test.go
+++ b/internal/router/policy/cluster_override_test.go
@@ -138,3 +138,77 @@ func TestApplyClusterArmOverrides_OldSidecarNoFallbackKeepsSidecar(t *testing.T)
 	out := policy.ApplyClusterArmOverrides(overrides, nil, resolved, "anthropic/opus")
 	assert.False(t, out.Applied, "no ranked fallback (old sidecar) must fail open")
 }
+
+func TestApplyClusterArmOverridesRequireMatch_ServesFirstEligibleArm(t *testing.T) {
+	ranked := []policy.PreviewGroup{
+		{Group: "maximum", EligibleArms: []string{"anthropic/opus", "anthropic/fable"}},
+		{Group: "fast", EligibleArms: []string{"anthropic/haiku"}},
+	}
+	resolved := resolvedFor(map[string]string{
+		"opus": "anthropic/opus", "fable": "anthropic/fable", "haiku": "anthropic/haiku",
+	})
+
+	// The sidecar's own pick was in "fast"; forcing "maximum" must move off it.
+	out, err := policy.ApplyClusterArmOverridesRequireMatch(nil, ranked, resolved, "anthropic/haiku", "maximum")
+	require.NoError(t, err)
+	assert.Equal(t, "anthropic/opus", out.RosterID, "the forced group's first eligible arm must serve")
+	assert.Equal(t, "maximum", out.Group)
+	assert.True(t, out.Changed)
+}
+
+func TestApplyClusterArmOverridesRequireMatch_HonorsPerKeyOverride(t *testing.T) {
+	ranked := []policy.PreviewGroup{
+		{Group: "maximum", EligibleArms: []string{"anthropic/opus", "anthropic/fable"}},
+	}
+	resolved := resolvedFor(map[string]string{"opus": "anthropic/opus", "fable": "anthropic/fable"})
+	overrides := map[string][]string{"maximum": {"fable", "opus"}}
+
+	out, err := policy.ApplyClusterArmOverridesRequireMatch(overrides, ranked, resolved, "anthropic/opus", "maximum")
+	require.NoError(t, err)
+	assert.Equal(t, "anthropic/fable", out.RosterID,
+		"the key's own ordering must still narrow the forced group")
+}
+
+func TestApplyClusterArmOverridesRequireMatch_UnknownLabelErrors(t *testing.T) {
+	ranked := []policy.PreviewGroup{
+		{Group: "maximum", EligibleArms: []string{"anthropic/opus"}},
+	}
+	resolved := resolvedFor(map[string]string{"opus": "anthropic/opus"})
+
+	_, err := policy.ApplyClusterArmOverridesRequireMatch(nil, ranked, resolved, "anthropic/opus", "explore")
+	require.ErrorIs(t, err, policy.ErrForcedClusterUnservable)
+	assert.Contains(t, err.Error(), "explore",
+		"a retired or misspelled label must be named back to the caller")
+}
+
+func TestApplyClusterArmOverridesRequireMatch_EmptyGroupErrors(t *testing.T) {
+	ranked := []policy.PreviewGroup{
+		{Group: "maximum", RosterArms: []string{"anthropic/opus"}, EligibleArms: nil},
+		{Group: "fast", EligibleArms: []string{"anthropic/haiku"}},
+	}
+	resolved := resolvedFor(map[string]string{"haiku": "anthropic/haiku"})
+
+	// The group exists but every arm was filtered out for this request; serving
+	// "fast" instead would silently ignore the force.
+	_, err := policy.ApplyClusterArmOverridesRequireMatch(nil, ranked, resolved, "anthropic/haiku", "maximum")
+	require.ErrorIs(t, err, policy.ErrForcedClusterUnservable)
+}
+
+func TestApplyClusterArmOverridesRequireMatch_OverrideEmptiesGroupErrors(t *testing.T) {
+	ranked := []policy.PreviewGroup{
+		{Group: "maximum", EligibleArms: []string{"anthropic/opus"}},
+	}
+	resolved := resolvedFor(map[string]string{"opus": "anthropic/opus"})
+	overrides := map[string][]string{"maximum": {"ghost"}}
+
+	_, err := policy.ApplyClusterArmOverridesRequireMatch(overrides, ranked, resolved, "anthropic/opus", "maximum")
+	require.ErrorIs(t, err, policy.ErrForcedClusterUnservable)
+}
+
+func TestApplyClusterArmOverridesRequireMatch_NoRankedFallbackFailsClosed(t *testing.T) {
+	resolved := resolvedFor(map[string]string{"opus": "anthropic/opus"})
+
+	_, err := policy.ApplyClusterArmOverridesRequireMatch(nil, nil, resolved, "anthropic/opus", "maximum")
+	require.ErrorIs(t, err, policy.ErrForcedClusterUnservable,
+		"unlike a DB override, a forced cluster cannot fail open — there is no roster to prove it against")
+}

--- a/internal/router/policy/sidecar_router.go
+++ b/internal/router/policy/sidecar_router.go
@@ -317,7 +317,32 @@ func (r *SidecarRouter) Route(ctx context.Context, req router.Request) (router.D
 	overrideArmID := res.ArmID
 	overrideRosterID := res.Model
 	overrideReasonSuffix := ""
-	if len(req.ClusterArmOverrides) > 0 && len(res.RankedFallback) > 0 {
+	// reselected records that the served arm is the router's pick rather than the
+	// sidecar's, which is the only case where res.Provider legitimately names a
+	// different provider than the resolved binding.
+	reselected := false
+	switch {
+	case req.ForceCluster != "":
+		// Returned unwrapped: the caller's dispatch classifier matches the typed
+		// error to a 400, and burying it under the strategy's unavailable sentinel
+		// would report a bad header as a sidecar outage.
+		outcome, err := ApplyClusterArmOverridesRequireMatch(req.ClusterArmOverrides, res.RankedFallback, resolved, res.Model, req.ForceCluster)
+		if err != nil {
+			return router.Decision{}, err
+		}
+		overrideArmID = outcome.ArmID
+		overrideRosterID = outcome.RosterID
+		// Annotated even when the forced cluster is the one the sidecar picked
+		// anyway, so telemetry can tell a constrained turn from a free one.
+		overrideReasonSuffix = ":force_cluster"
+		reselected = outcome.Changed
+		observability.FromContext(ctx).Info("Forced cluster applied",
+			"strategy", strategy,
+			"group", outcome.Group,
+			"sidecar_arm", res.Model,
+			"forced_arm", outcome.RosterID,
+		)
+	case len(req.ClusterArmOverrides) > 0 && len(res.RankedFallback) > 0:
 		outcome := ApplyClusterArmOverrides(req.ClusterArmOverrides, res.RankedFallback, resolved, res.Model)
 		if outcome.Applied && outcome.RosterID != "" {
 			// Use the resolved arm ID: on arm-enumerating resolvers a roster ID can
@@ -326,6 +351,7 @@ func (r *SidecarRouter) Route(ctx context.Context, req router.Request) (router.D
 			overrideRosterID = outcome.RosterID
 			if outcome.Changed {
 				overrideReasonSuffix = ":cluster_override"
+				reselected = true
 				observability.FromContext(ctx).Info("Cluster allowlist override applied",
 					"strategy", strategy,
 					"group", outcome.Group,
@@ -340,7 +366,7 @@ func (r *SidecarRouter) Route(ctx context.Context, req router.Request) (router.D
 	if !ok {
 		return router.Decision{}, fmt.Errorf("%s: sidecar returned unknown arm %q or model %q: %w", strategy, overrideArmID, overrideRosterID, r.config.Unavailable)
 	}
-	if res.Provider != "" && overrideReasonSuffix == "" && res.Provider != binding.Provider {
+	if res.Provider != "" && !reselected && res.Provider != binding.Provider {
 		return router.Decision{}, fmt.Errorf("%s: sidecar returned provider %q for %q, expected %q: %w", strategy, res.Provider, res.Model, binding.Provider, r.config.Unavailable)
 	}
 

--- a/internal/router/policy/sidecar_router_test.go
+++ b/internal/router/policy/sidecar_router_test.go
@@ -525,6 +525,154 @@ func TestSidecarRouterClusterOverrideFailsOpenWithoutRankedFallback(t *testing.T
 	assert.NotContains(t, decision.Reason, "cluster_override")
 }
 
+func TestSidecarRouterServesWithinForcedCluster(t *testing.T) {
+	resolver := policy.NewResolver(
+		set("claude-opus-4-8", "claude-haiku-4-5"),
+		set(providers.ProviderAnthropic),
+		clusterOverrideMapper,
+		policy.ManagedProviderPolicy(),
+	)
+	// The sidecar classified into "maximum" and would serve opus.
+	decider := &recordingPolicy{result: policy.Result{
+		SchemaVersion: policy.SchemaVersionV1,
+		Model:         "anthropic/claude-opus-4-8",
+		Provider:      providers.ProviderAnthropic,
+		PolicyGroup:   "maximum",
+		RankedFallback: []policy.PreviewGroup{
+			{Group: "maximum", Probability: 0.8, EligibleArms: []string{"anthropic/claude-opus-4-8"}},
+			{Group: "fast", Probability: 0.2, EligibleArms: []string{"anthropic/claude-haiku-4-5"}},
+		},
+	}}
+	adapter := policy.NewSidecarRouter(policy.SidecarRouterConfig{
+		Strategy: router.StrategyHMM,
+	}, decider, resolver)
+
+	decision, err := adapter.Route(context.Background(), router.Request{ForceCluster: "fast"})
+
+	require.NoError(t, err)
+	assert.Equal(t, "claude-haiku-4-5", decision.Model,
+		"the forced cluster must outrank the sidecar's own argmax group")
+	assert.Contains(t, decision.Reason, "force_cluster")
+	assert.Len(t, decider.query.Candidates, 2,
+		"the sidecar still classifies over the full candidate set; the force is enforced router-side")
+}
+
+// A force that coincides with the sidecar's own pick must not waive the
+// provider-agreement check: nothing was re-selected, so a mismatched provider
+// still means the sidecar and resolver disagree.
+func TestSidecarRouterForcedClusterKeepsProviderAgreementCheck(t *testing.T) {
+	resolver := policy.NewResolver(
+		set("claude-opus-4-8"),
+		set(providers.ProviderAnthropic),
+		clusterOverrideMapper,
+		policy.ManagedProviderPolicy(),
+	)
+	decider := &recordingPolicy{result: policy.Result{
+		SchemaVersion: policy.SchemaVersionV1,
+		Model:         "anthropic/claude-opus-4-8",
+		Provider:      providers.ProviderOpenAI, // disagrees with the resolved binding
+		RankedFallback: []policy.PreviewGroup{{
+			Group:        "maximum",
+			EligibleArms: []string{"anthropic/claude-opus-4-8"},
+		}},
+	}}
+	unavailable := errors.New("hmm unavailable")
+	adapter := policy.NewSidecarRouter(policy.SidecarRouterConfig{
+		Strategy:    router.StrategyHMM,
+		Unavailable: unavailable,
+	}, decider, resolver)
+
+	_, err := adapter.Route(context.Background(), router.Request{ForceCluster: "maximum"})
+
+	require.ErrorIs(t, err, unavailable,
+		"an unchanged selection must still be validated against the sidecar's provider")
+}
+
+func TestSidecarRouterForcedClusterNarrowedByPerKeyOverride(t *testing.T) {
+	resolver := policy.NewResolver(
+		set("claude-opus-4-8", "claude-sonnet-5"),
+		set(providers.ProviderAnthropic),
+		clusterOverrideMapper,
+		policy.ManagedProviderPolicy(),
+	)
+	decider := &recordingPolicy{result: policy.Result{
+		SchemaVersion: policy.SchemaVersionV1,
+		Model:         "anthropic/claude-opus-4-8",
+		Provider:      providers.ProviderAnthropic,
+		RankedFallback: []policy.PreviewGroup{{
+			Group:        "maximum",
+			EligibleArms: []string{"anthropic/claude-opus-4-8", "anthropic/claude-sonnet-5"},
+		}},
+	}}
+	adapter := policy.NewSidecarRouter(policy.SidecarRouterConfig{
+		Strategy: router.StrategyHMM,
+	}, decider, resolver)
+
+	decision, err := adapter.Route(context.Background(), router.Request{
+		ForceCluster:        "maximum",
+		ClusterArmOverrides: map[string][]string{"maximum": {"claude-sonnet-5", "claude-opus-4-8"}},
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, "claude-sonnet-5", decision.Model,
+		"the key's cluster model list must still order the forced group")
+}
+
+func TestSidecarRouterForcedClusterNotInRosterErrorsUnwrapped(t *testing.T) {
+	resolver := policy.NewResolver(
+		set("claude-opus-4-8"),
+		set(providers.ProviderAnthropic),
+		clusterOverrideMapper,
+		policy.ManagedProviderPolicy(),
+	)
+	decider := &recordingPolicy{result: policy.Result{
+		SchemaVersion: policy.SchemaVersionV1,
+		Model:         "anthropic/claude-opus-4-8",
+		Provider:      providers.ProviderAnthropic,
+		RankedFallback: []policy.PreviewGroup{{
+			Group:        "maximum",
+			EligibleArms: []string{"anthropic/claude-opus-4-8"},
+		}},
+	}}
+	unavailable := errors.New("hmm unavailable")
+	adapter := policy.NewSidecarRouter(policy.SidecarRouterConfig{
+		Strategy:    router.StrategyHMM,
+		Unavailable: unavailable,
+	}, decider, resolver)
+
+	_, err := adapter.Route(context.Background(), router.Request{ForceCluster: "explore"})
+
+	require.Error(t, err)
+	var unservable *policy.ForcedClusterUnservableError
+	require.ErrorAs(t, err, &unservable, "the typed error must survive for dispatch classification")
+	assert.Equal(t, "explore", unservable.Cluster)
+	assert.NotErrorIs(t, err, unavailable,
+		"a bad header is a client error, not a sidecar outage")
+}
+
+func TestSidecarRouterForcedClusterFailsClosedWithoutRankedFallback(t *testing.T) {
+	resolver := policy.NewResolver(
+		set("claude-opus-4-8"),
+		set(providers.ProviderAnthropic),
+		clusterOverrideMapper,
+		policy.ManagedProviderPolicy(),
+	)
+	// Older sidecar: serves a decision but reports no roster to verify against.
+	decider := &recordingPolicy{result: policy.Result{
+		SchemaVersion: policy.SchemaVersionV1,
+		Model:         "anthropic/claude-opus-4-8",
+		Provider:      providers.ProviderAnthropic,
+	}}
+	adapter := policy.NewSidecarRouter(policy.SidecarRouterConfig{
+		Strategy: router.StrategyHMM,
+	}, decider, resolver)
+
+	_, err := adapter.Route(context.Background(), router.Request{ForceCluster: "maximum"})
+
+	require.ErrorIs(t, err, policy.ErrForcedClusterUnservable,
+		"with no roster the constraint can't be proven, so serving anything would ignore the force")
+}
+
 func TestSidecarRouterCapabilityRefreshIsConcurrentSafe(t *testing.T) {
 	adapter := policy.NewSidecarRouter(policy.SidecarRouterConfig{
 		Strategy: router.Strategy("future-policy"),

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -86,7 +86,17 @@ type Request struct {
 	// ForceModel is the canonical model named by a valid explicit force-model
 	// request. Router decorators must preserve the underlying selection rather
 	// than applying alternative-policy behavior such as exploration.
-	ForceModel           string
+	ForceModel string
+	// ForceCluster is the sidecar classifier-group label forced by
+	// x-weave-force-cluster on this turn. Empty means no cluster constraint.
+	// Unlike ForceModel (which pins one canonical model), it constrains the pool
+	// the policy's own selection may draw from; the sidecar is never told a
+	// cluster is forced, so enforcement is a router-side re-check of the live
+	// Result.RankedFallback after the sidecar responds (see
+	// policy.ApplyClusterArmOverridesRequireMatch). Meaningless outside the
+	// hmm/hmm_embedding strategies, which the proxy construction sites reject
+	// with a typed error rather than silently ignoring.
+	ForceCluster         string
 	EstimatedInputTokens int
 	// OrganizationID and InstallationID are opaque external identifiers used
 	// to correlate policy decisions with rollout and privacy state.

--- a/smoke/basic_test.go
+++ b/smoke/basic_test.go
@@ -58,6 +58,46 @@ func TestBasic(t *testing.T) {
 	})
 }
 
+// TestForceHeaderRejections covers the two force-header refusals that resolve
+// before any upstream call, so they need no cassette and run in replay-only CI.
+//
+// The success path (a label that IS in the live roster serving from that
+// cluster's arms) is deliberately absent: it needs the HMM sidecar container,
+// which the smoke stack doesn't boot, and the MITM proxy intercepts only
+// outbound HTTPS provider calls — not the router's plain-HTTP sidecar hop — so
+// there is nothing to record it against. Verify that path against a real
+// sidecar (`make up-hmm`).
+func TestForceHeaderRejections(t *testing.T) {
+	t.Run("force-cluster on the default cluster strategy is refused", func(t *testing.T) {
+		// The default strategy scores anonymous centroids, so there is no named
+		// cluster to constrain to. Silently serving would look like the force took.
+		body := newRequest("smoke-force-cluster-unsupported").tokens(64).
+			text("Reply with exactly the word: ok").build(t)
+		r := callModelWithHeaders(t, body, cfg.PinModel,
+			map[string]string{forceClusterHeader: "maximum"})
+
+		if r.status != http.StatusBadRequest {
+			t.Fatalf("want 400, got %d; body: %s", r.status, truncate(r.body, 600))
+		}
+		if !strings.Contains(string(r.body), "invalid_request_error") {
+			t.Errorf("want an invalid_request_error envelope, got: %s", truncate(r.body, 600))
+		}
+	})
+
+	t.Run("force-model naming no catalog model is refused", func(t *testing.T) {
+		body := newRequest("smoke-force-model-unknown").tokens(64).
+			text("Reply with exactly the word: ok").build(t)
+		r := callModel(t, body, "totally-not-a-model")
+
+		if r.status != http.StatusBadRequest {
+			t.Fatalf("want 400, got %d; body: %s", r.status, truncate(r.body, 600))
+		}
+		if !strings.Contains(string(r.body), "totally-not-a-model") {
+			t.Errorf("want the unresolvable value quoted back, got: %s", truncate(r.body, 600))
+		}
+	})
+}
+
 // assertServedByPin checks the x-router-model / x-router-provider decision
 // headers name the pinned model on Anthropic.
 func assertServedByPin(t *testing.T, r response) {

--- a/smoke/harness_test.go
+++ b/smoke/harness_test.go
@@ -50,6 +50,10 @@ const anthropicVersion = "2023-06-01"
 // Must match internal/proxy/force_model.go:ForceModelHeader.
 const forceModelHeader = "x-weave-force-model"
 
+// forceClusterHeader constrains serving to one policy-sidecar routing cluster.
+// Must match internal/proxy/force_cluster.go:ForceClusterHeader.
+const forceClusterHeader = "x-weave-force-cluster"
+
 // httpClient is shared; the streaming scenarios need a generous timeout because
 // real Anthropic turns can take several seconds.
 var httpClient = &http.Client{Timeout: 90 * time.Second}
@@ -171,12 +175,19 @@ func call(t *testing.T, body []byte) response {
 // when stream:true, JSON otherwise.
 func callModel(t *testing.T, body []byte, model string) response {
 	t.Helper()
+	return callModelWithHeaders(t, body, model, nil)
+}
+
+// callModelWithHeaders is callModel plus extra request headers, for scenarios
+// that drive a router header rather than just the model pin.
+func callModelWithHeaders(t *testing.T, body []byte, model string, extra map[string]string) response {
+	t.Helper()
 	streaming := jsonBool(body, "stream")
 
 	var resp response
 	var err error
 	for attempt := 0; attempt < 2; attempt++ {
-		resp, err = doCall(body, streaming, model)
+		resp, err = doCall(body, streaming, model, extra)
 		if err != nil {
 			t.Fatalf("request failed: %v", err)
 		}
@@ -193,7 +204,7 @@ func callModel(t *testing.T, body []byte, model string) response {
 	return resp
 }
 
-func doCall(body []byte, streaming bool, model string) (response, error) {
+func doCall(body []byte, streaming bool, model string, extra map[string]string) (response, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
 	defer cancel()
 
@@ -208,6 +219,9 @@ func doCall(body []byte, streaming bool, model string) (response, error) {
 	// (those must route through the command handler, not re-pin).
 	if !isForceModelCommand(body) {
 		req.Header.Set(forceModelHeader, model)
+	}
+	for k, v := range extra {
+		req.Header.Set(k, v)
 	}
 
 	httpResp, err := httpClient.Do(req)


### PR DESCRIPTION
Adds `x-weave-force-cluster`, the headless group-level analogue of `x-weave-force-model`: constrains serving to one named HMM policy-sidecar routing cluster, leaving the within-cluster pick to the policy. No cluster vocabulary is hardcoded — the label is validated against the live `RankedFallback` the sidecar reports on that request (via a new fail-closed `ApplyClusterArmOverridesRequireMatch`), so it never drifts from the deployed roster. The header 400s on non-HMM strategies, on an unknown or emptied cluster, and on a sidecar too old to report its roster.

Also tightens `x-weave-force-model`: a value naming no catalog model now 400s (`ForcedModelUnknownError`) instead of logging and routing on regardless.

New `DispatchErrorKind` cases classify both header families as 400 `invalid_request_error`. Docs (`CONFIGURATION.md`) and smoke coverage updated — smoke only covers the pre-dispatch refusal scenarios, since the success path needs a live HMM sidecar the smoke stack doesn't boot.

🤖 Generated with [Weave Router](https://router.workweave.ai)