### PR TITLE
Auto update Claude Code router config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,7 @@ test-statusline: ## Run the cc-statusline.sh regression tests (offline)
 
 test-install: ## Run offline installer regression tests
 	@bash install/tests/codex_install_test.sh
+	@bash install/tests/key_reuse_test.sh
 
 smoke: ## Pre-merge smoke suite: real router stack + real Anthropic (needs ANTHROPIC_API_KEY)
 	./scripts/smoke/run.sh

--- a/install/README.md
+++ b/install/README.md
@@ -47,7 +47,8 @@ Without `--scope`, it then asks user vs. project (defaults to user).
 useful for CI and `curl | sh` pipelines.
 
 The installer also prompts for your API key (or reads `$WEAVE_ROUTER_KEY`
-for non-interactive installs).
+for non-interactive installs). Re-running it reuses the key already on disk,
+so you only ever paste it once — see [Staying up to date](#staying-up-to-date).
 
 ### Self-hosted via `docker compose` (zero-config)
 
@@ -194,7 +195,8 @@ claude                                             # or `CODEX_HOME=.codex codex
 ```
 
 The `--scope project` step only needs to run once per checkout (re-run if
-`cc-statusline.sh` is updated upstream).
+`cc-statusline.sh` is updated upstream; the re-run reuses your installed key,
+so no key paste is needed).
 
 ## Flags
 
@@ -207,9 +209,64 @@ The `--scope project` step only needs to run once per checkout (re-run if
 | `--local`                  | off                           | Shortcut for the bundled docker-compose router (`localhost:8080`).      |
 | `--base-url <url>`         | `https://router.workweave.ai` | Override the router endpoint. Use for self-hosted / custom port.        |
 | `--non-interactive`        | off                           | Fail if `$WEAVE_ROUTER_KEY` isn't set instead of prompting. Defaults target to Claude Code so existing CI pipelines don't shift semantics. |
+| `--rotate-key`             | off                           | Ignore the key already installed and prompt for a new one (or take `$WEAVE_ROUTER_KEY`). Use when rotating a key. |
 
 Override the default base URL globally by setting `$WEAVE_ROUTER_URL` before
 running the installer.
+
+## Staying up to date
+
+The installer is re-run periodically because the pieces it writes do change —
+statusline features and pricing, slash commands, config shape. Two things make
+that painless.
+
+**Your key is remembered.** Key resolution order is `$WEAVE_ROUTER_KEY` →
+the key already installed for this target and scope → interactive prompt. So a
+plain re-run needs no key at all:
+
+```bash
+npx @workweave/router --claude                  # reuses the installed key
+npx @workweave/router --claude --rotate-key     # ignore it, prompt for a new one
+```
+
+If the installed key turns out to be revoked, an interactive run says so and
+asks once for a replacement rather than leaving a broken install behind.
+
+**`update` is the scriptable form.** It never prompts, resolves the key from
+env or disk only, refreshes the managed config and assets in place, and errors
+(rather than asking) if no key can be found — safe for cron:
+
+```bash
+npx @workweave/router update --claude                    # user scope
+npx @workweave/router update --claude --scope project    # in the repo
+```
+
+A rejected key is an error for `update` (exit 1), not a warning, so a scheduled
+run surfaces a revoked key instead of logging past it. `update` currently
+supports `--claude`; for the other targets re-run the installer normally — it
+reuses your installed key the same way.
+
+**Claude Code also refreshes itself.** `cc-statusline.sh` checks
+`raw.githubusercontent.com` for a newer copy of itself at most once every
+`$WEAVE_STATUSLINE_UPDATE_INTERVAL_DAYS` (default 7) in a detached background
+fork, and on the same schedule refreshes the `.claude/commands/*.md` slash-command
+wrappers. Both swap only on a real content change, and a wrapper is replaced
+only when its bytes still match the last canonical copy — a wrapper you edited
+is never overwritten, and one you deleted is never resurrected. All state
+(stamps, baselines) lives under `${XDG_CACHE_HOME:-~/.cache}/weave-router/`, so
+nothing lands in a repo working tree.
+
+| Environment variable                       | Default | Effect                                                        |
+| ------------------------------------------ | ------- | ------------------------------------------------------------- |
+| `WEAVE_STATUSLINE_UPDATE=0`                 | on      | Disable every background network path in the statusline.       |
+| `WEAVE_COMMANDS_UPDATE=0`                   | on      | Disable only the slash-command refresh.                        |
+| `WEAVE_STATUSLINE_UPDATE_INTERVAL_DAYS`     | `7`     | How often either check may run.                                |
+| `WEAVE_STATUSLINE_URL`                      | GitHub raw | Source for the statusline (self-hosters who fork).          |
+| `WEAVE_COMMANDS_URL_BASE`                   | GitHub raw | Source directory for the slash-command wrappers.            |
+
+Codex, opencode, and pi have no equivalent per-turn hook, so they don't
+auto-refresh. Re-run the installer for those (`npx @workweave/router --codex`
+and friends) — thanks to key reuse, that no longer means re-pasting a key.
 
 ## Switching on and off
 

--- a/install/cc-statusline.sh
+++ b/install/cc-statusline.sh
@@ -125,6 +125,141 @@ weave_self_refresh() {
 }
 weave_self_refresh 2>/dev/null || true
 
+# ---------- background slash-command refresh ----------
+#
+# The /force-model, /router-* … wrappers under <install>/.claude/commands/ are
+# written once at install time and then never touched again, so a user who
+# doesn't re-run the installer keeps whatever set shipped that day. This script
+# is the only thing Claude Code invokes on every turn, so it doubles as the
+# refresh point for them: same rate limit, same detached fork, same
+# content-diff no-op as the self-refresh above.
+#
+# Never clobber a wrapper the user edited. The only way to tell an edit from a
+# stale copy is to remember what we last downloaded, so each canonical file is
+# cached (unrendered) per install under the user cache dir and a wrapper is
+# replaced only when its bytes still match that baseline. With no baseline yet
+# we can't prove anything, so the first run only seeds the cache and a swap can
+# happen from the next one on. install.sh seeds it too, so fresh installs skip
+# that warm-up round.
+#
+# Opt out with WEAVE_COMMANDS_UPDATE=0 (WEAVE_STATUSLINE_UPDATE=0 disables this
+# too, along with every other network path here). Override the source with
+# WEAVE_COMMANDS_URL_BASE=..., e.g. for self-hosters who fork.
+
+# weave_render_command prints $1 with the installer's {{SCOPE}} placeholder
+# replaced by $2, matching how install_slash_commands writes the same file.
+# Trailing newlines are stripped on both sides of every comparison below.
+weave_render_command() {
+  local body
+  body="$(cat "$1" 2>/dev/null)" || return 1
+  printf '%s' "${body//\{\{SCOPE\}\}/$2}"
+}
+
+weave_sync_commands() {
+  [ "${WEAVE_STATUSLINE_UPDATE:-1}" = "0" ] && return 0
+  [ "${WEAVE_COMMANDS_UPDATE:-1}" = "0" ] && return 0
+  command -v curl >/dev/null 2>&1 || return 0
+
+  local self="${BASH_SOURCE[0]:-$0}" self_dir cmd_dir
+  self_dir="$(cd "$(dirname "$self")" 2>/dev/null && pwd -P)" || return 0
+  # User scope installs this script at <base>/.weave/, project and --dir at
+  # <base>/.claude/. Claude Code reads commands from <base>/.claude/commands in
+  # both layouts.
+  case "${self_dir##*/}" in
+    .weave)  cmd_dir="${self_dir%/*}/.claude/commands" ;;
+    .claude) cmd_dir="$self_dir/commands" ;;
+    *)       return 0 ;;
+  esac
+  [ -d "$cmd_dir" ] && [ -w "$cmd_dir" ] || return 0
+
+  local cache_dir="${XDG_CACHE_HOME:-$HOME/.cache}/weave-router"
+  local dir_slug
+  dir_slug="$(printf '%s' "$cmd_dir" | tr -c 'A-Za-z0-9._-' '_')"
+  # Baseline is keyed by install, not shared: two installs refresh on their own
+  # clocks, and a shared baseline updated by one would make the other's still-
+  # canonical wrappers look user-edited and freeze them forever.
+  local baseline_dir="$cache_dir/commands${dir_slug}"
+  local stamp="$cache_dir/checked-at${dir_slug}.commands"
+  mkdir -p "$baseline_dir" 2>/dev/null || return 0
+
+  local interval_days="${WEAVE_STATUSLINE_UPDATE_INTERVAL_DAYS:-7}"
+  local now stamp_mtime
+  now="$(date +%s 2>/dev/null)" || return 0
+  if [ -f "$stamp" ]; then
+    stamp_mtime="$(stat -c %Y "$stamp" 2>/dev/null || stat -f %m "$stamp" 2>/dev/null)" || stamp_mtime=0
+  else
+    stamp_mtime=0
+  fi
+  if [ -n "${stamp_mtime:-}" ] && [ "$stamp_mtime" -gt 0 ] \
+     && [ $(( now - stamp_mtime )) -lt $(( interval_days * 86400 )) ]; then
+    return 0
+  fi
+  # Stamp before forking, same as the self-refresh: Claude Code calls us on
+  # every turn and concurrent invocations must not all start downloading.
+  : > "$stamp" 2>/dev/null || return 0
+
+  # router-off/on/status bake this install's scope selector into their npx
+  # line (upstream carries {{SCOPE}} there). Recover it from the installed copy
+  # so a project or --dir install keeps toggling its own config; when it can't
+  # be recovered those three are skipped rather than rewritten to point at the
+  # user-scope install.
+  local scope_args="" scope_known="false" off="$cmd_dir/router-off.md"
+  if [ -f "$off" ] && grep -q '^`npx @workweave/router off --claude.*`$' "$off" 2>/dev/null; then
+    scope_known="true"
+    scope_args="$(sed -n 's|^`npx @workweave/router off --claude\(.*\)`$|\1|p' "$off" | head -n 1)"
+  fi
+
+  local url_base="${WEAVE_COMMANDS_URL_BASE:-https://raw.githubusercontent.com/workweave/router/main/install/commands}"
+  local name installed raw prev tmp new_body prev_body installed_body
+  (
+    # Detach stdin (CC pipes JSON to us) so curl can't consume it, and silence
+    # everything so no output leaks into the statusline.
+    exec </dev/null
+    for name in force-model unforce-model router-feedback fm ufm rf \
+                router-off router-on router-status router-session; do
+      installed="$cmd_dir/$name.md"
+      # Only ever refresh a wrapper that is already installed: a missing one
+      # was uninstalled or deliberately deleted, and resurrecting it would be
+      # a surprise. A symlink is user-owned; leave it alone.
+      [ -f "$installed" ] || continue
+      [ -L "$installed" ] && continue
+
+      raw="$baseline_dir/$name.md.tmp.$$"
+      curl -fsSL --max-time 15 "$url_base/$name.md" -o "$raw" 2>/dev/null || { rm -f "$raw"; continue; }
+      # Shape check: every wrapper opens with YAML front matter, so a 404 page
+      # or a truncated body can never be installed as a command.
+      if [ ! -s "$raw" ] || [ "$(head -n 1 "$raw")" != "---" ]; then
+        rm -f "$raw"
+        continue
+      fi
+
+      prev="$baseline_dir/$name.md"
+      if grep -q '{{SCOPE}}' "$raw" && [ "$scope_known" != "true" ]; then
+        mv "$raw" "$prev" 2>/dev/null || rm -f "$raw"
+        continue
+      fi
+
+      if [ -f "$prev" ]; then
+        new_body="$(weave_render_command "$raw" "$scope_args")"
+        prev_body="$(weave_render_command "$prev" "$scope_args")"
+        installed_body="$(cat "$installed" 2>/dev/null)" || installed_body=""
+        if [ "$prev_body" = "$installed_body" ] && [ "$new_body" != "$installed_body" ]; then
+          tmp="$installed.tmp.$$"
+          if printf '%s\n' "$new_body" >"$tmp" 2>/dev/null; then
+            mv "$tmp" "$installed" 2>/dev/null || rm -f "$tmp"
+          else
+            rm -f "$tmp"
+          fi
+        fi
+      fi
+      mv "$raw" "$prev" 2>/dev/null || rm -f "$raw"
+    done
+  ) >/dev/null 2>&1 &
+  disown 2>/dev/null || true
+  return 0
+}
+weave_sync_commands 2>/dev/null || true
+
 input="$(cat)"
 transcript_path="$(printf '%s' "$input" | jq -r '.transcript_path // empty')"
 # Prefer model.id over display_name: pricing keys + the routed model id in

--- a/install/cc-statusline.sh
+++ b/install/cc-statusline.sh
@@ -142,9 +142,22 @@ weave_self_refresh 2>/dev/null || true
 # happen from the next one on. install.sh seeds it too, so fresh installs skip
 # that warm-up round.
 #
+# Never touch a wrapper git tracks either. A project-scope install writes the
+# wrappers into the repo's own .claude/commands/, and unlike cc-statusline.sh
+# the installer does not gitignore them — so an unattended weekly rewrite would
+# surface as unexplained dirty files (and could ride along in someone's commit).
+# Only the installer changes tracked files, and only when a human runs it.
+#
 # Opt out with WEAVE_COMMANDS_UPDATE=0 (WEAVE_STATUSLINE_UPDATE=0 disables this
 # too, along with every other network path here). Override the source with
 # WEAVE_COMMANDS_URL_BASE=..., e.g. for self-hosters who fork.
+
+# weave_command_tracked_by_git returns 0 when $1 is a file git tracks. Used to
+# leave repo-committed wrappers alone; no git (or no repo) means untracked.
+weave_command_tracked_by_git() {
+  command -v git >/dev/null 2>&1 || return 1
+  git -C "$(dirname "$1")" ls-files --error-unmatch -- "$1" >/dev/null 2>&1
+}
 
 # weave_render_command prints $1 with the installer's {{SCOPE}} placeholder
 # replaced by $2, matching how install_slash_commands writes the same file.
@@ -220,9 +233,12 @@ weave_sync_commands() {
       installed="$cmd_dir/$name.md"
       # Only ever refresh a wrapper that is already installed: a missing one
       # was uninstalled or deliberately deleted, and resurrecting it would be
-      # a surprise. A symlink is user-owned; leave it alone.
+      # a surprise. A symlink is user-owned; leave it alone. A git-tracked
+      # wrapper belongs to the repo — rewriting it would dirty a working tree
+      # nobody asked us to touch.
       [ -f "$installed" ] || continue
       [ -L "$installed" ] && continue
+      weave_command_tracked_by_git "$installed" && continue
 
       raw="$baseline_dir/$name.md.tmp.$$"
       curl -fsSL --max-time 15 "$url_base/$name.md" -o "$raw" 2>/dev/null || { rm -f "$raw"; continue; }

--- a/install/install.sh
+++ b/install/install.sh
@@ -3053,6 +3053,15 @@ write_claude_settings() {
   fi
 }
 
+# write_claude_settings rewrote the full router config live, so a parked
+# sidecar left over from `off` is now redundant: the router is back on and the
+# key/base URL it preserved are in the settings files. Leave it in place and
+# `status` would keep reporting off, and `off` would no-op against live router
+# config the user can no longer toggle.
+if [ "$target" = "claude" ] && [ -f "$settings_dir/.weave-parked.json" ]; then
+  rm -f "$settings_dir/.weave-parked.json"
+fi
+
 write_claude_settings "$api_key"
 
 # Slash command wrappers — see install_slash_commands() below for the why.

--- a/install/install.sh
+++ b/install/install.sh
@@ -3038,9 +3038,14 @@ write_claude_settings() {
       env: { ANTHROPIC_CUSTOM_HEADERS: $header }
     }' >"$tmp_patch"
     if [ -f "$local_settings_file" ]; then
+      # Also strip ANTHROPIC_BASE_URL: `off` in project scope points this file
+      # straight at Anthropic (the committed settings.json carries the router
+      # URL instead). Leaving that override in place would have every request
+      # keep bypassing the router even though this install/update just wrote
+      # a fresh key and reports success.
       merged="$(jq -s '.[0] as $a | .[1] as $b
         | $a
-        | .env = (($a.env // {} | del(.ANTHROPIC_AUTH_TOKEN, .ANTHROPIC_CUSTOM_HEADERS)) + ($b.env // {}))
+        | .env = (($a.env // {} | del(.ANTHROPIC_AUTH_TOKEN, .ANTHROPIC_CUSTOM_HEADERS, .ANTHROPIC_BASE_URL)) + ($b.env // {}))
         | (if (.env | length) == 0 then del(.env) else . end)
         | del(.apiKeyHelper)
       ' "$local_settings_file" "$tmp_patch")"

--- a/install/install.sh
+++ b/install/install.sh
@@ -43,7 +43,14 @@
 #   npx @workweave/router --base-url http://localhost:8080 # self-hosted, custom port
 #   npx @workweave/router --non-interactive                # require WEAVE_ROUTER_KEY env var (defaults target to claude)
 #   npx @workweave/router --quiet                          # suppress banner, ping check, and trailing tips
+#   npx @workweave/router --rotate-key                     # ignore the installed key and prompt for a new one
 #   npx @workweave/router --uninstall                      # remove a previous install (delegates to uninstall.sh)
+#
+# Re-running the installer reuses the key already on disk, so you only paste it
+# once. `update` is the scriptable form of that: it never prompts, refreshes the
+# managed config + assets in place, and errors (rather than asking) when no key
+# can be found:
+#   npx @workweave/router update --claude                  # refresh the Claude Code install in place
 #
 # Toggle an existing install on/off without losing the router config (so
 # switching back is instant). These never prompt for a key and require an
@@ -86,11 +93,19 @@ router_key_header="X-Weave-Router-Key"
 target="claude"
 target_explicit="false"
 
-# Operation mode. "install" (default) writes/refreshes config. "off"/"on"/
+# Operation mode. "install" (default) writes/refreshes config. "update" is a
+# never-prompting install that reuses the key already on disk. "off"/"on"/
 # "status" toggle or report an existing install without touching the router
 # key/identity — see the toggle_* helpers and the dispatch block below.
 mode="install"
 disable_routing_alias="false"
+
+# --rotate-key forces the interactive key prompt even when a usable key is
+# already installed, so a rotated key can replace it.
+rotate_key="false"
+# Where $api_key came from: env | disk | prompt. Drives the fallback re-prompt
+# when /validate rejects a key we read back off disk.
+api_key_source=""
 
 # ---------- helpers ----------
 
@@ -938,6 +953,9 @@ while [ $# -gt 0 ]; do
     --quiet)
       quiet="true"; shift
       ;;
+    --rotate-key)
+      rotate_key="true"; shift
+      ;;
     --dir)
       install_dir="${2:-}"; shift 2
       [ -n "$install_dir" ] || { err "--dir requires a path."; exit 2; }
@@ -961,6 +979,11 @@ while [ $# -gt 0 ]; do
       # Toggle/report verbs. Bare (off) or dashed (--off) both accepted; the
       # npm wrapper forwards argv verbatim so either form reaches us.
       mode="${1#--}"; shift
+      ;;
+    update|--update)
+      # Non-interactive refresh of an existing install. Takes the same target
+      # and scope flags as install; resolves the key from env or disk only.
+      mode="update"; shift
       ;;
     disable-routing|--disable-routing)
       # Convenience alias for the Codex-specific off toggle. Unlike generic
@@ -989,10 +1012,26 @@ fi
 # Toggle verbs only flip config install.sh already wrote: no key, no identity,
 # no prompts. Require an explicit client so we never guess which config to
 # touch, and suppress every interactive prompt downstream.
-if [ "$mode" != "install" ]; then
+if [ "$mode" != "install" ] && [ "$mode" != "update" ]; then
   non_interactive="true"
   if [ "$target_explicit" != "true" ]; then
     err "'$mode' requires an explicit client: --claude, --codex, or --opencode."
+    exit 2
+  fi
+fi
+
+# `update` is an install that never prompts: it refreshes the managed config
+# and assets using the key already on disk (or in the environment). Suppressing
+# prompts here also settles the target/scope pickers below on their defaults,
+# which is what a cron/script caller wants.
+if [ "$mode" = "update" ]; then
+  non_interactive="true"
+  if [ "$rotate_key" = "true" ]; then
+    err "--rotate-key needs a prompt, which 'update' never issues. Re-run the installer without 'update'."
+    exit 2
+  fi
+  if [ "$target" != "claude" ]; then
+    err "'update' currently supports --claude only. Re-run the installer for $target (it reuses your installed key)."
     exit 2
   fi
 fi
@@ -1116,6 +1155,8 @@ fi
 
 if [ "$mode" = "install" ]; then
   [ "$quiet" = "true" ] || info "scope=${C_BOLD}${scope}${C_RESET}  target=${C_BOLD}${target}${C_RESET}  base_url=${C_BOLD}${base_url}${C_RESET}"
+elif [ "$mode" = "update" ]; then
+  [ "$quiet" = "true" ] || info "mode=${C_BOLD}update${C_RESET}  scope=${C_BOLD}${scope}${C_RESET}  target=${C_BOLD}${target}${C_RESET}  base_url=${C_BOLD}${base_url}${C_RESET}"
 else
   [ "$quiet" = "true" ] || info "mode=${C_BOLD}${mode}${C_RESET}  scope=${C_BOLD}${scope}${C_RESET}  target=${C_BOLD}${target}${C_RESET}"
 fi
@@ -1127,9 +1168,11 @@ fi
 if [ "$target" = "claude" ] || [ "$target" = "opencode" ] || [ "$target" = "pi" ]; then
   require_cmd jq    "macOS: 'brew install jq' · Debian/Ubuntu: 'sudo apt install jq'"
 fi
-# curl is only used by the install path's health/validate probes; toggles never
-# hit the network.
-[ "$mode" = "install" ] && require_cmd curl  "macOS/Linux: usually preinstalled — check your package manager"
+# curl is only used by the install/update paths' health/validate probes;
+# toggles never hit the network.
+if [ "$mode" = "install" ] || [ "$mode" = "update" ]; then
+  require_cmd curl  "macOS/Linux: usually preinstalled — check your package manager"
+fi
 
 case "$target" in
   claude)
@@ -1331,6 +1374,19 @@ json_get() {
   jq -r "${2} // empty" "$1" 2>/dev/null || true
 }
 
+# read_claude_key prints the router key already installed in the given settings
+# file, or nothing when the file is absent / carries no key header. Claude Code
+# packs several headers into one newline-delimited ANTHROPIC_CUSTOM_HEADERS
+# value, so we pick the router-key line out of it and trim the header name.
+# Read-only and tolerant of every missing-file case — never trips set -e.
+read_claude_key() {
+  [ -n "${1:-}" ] || return 0
+  json_get "$1" '.env.ANTHROPIC_CUSTOM_HEADERS' \
+    | sed -n "s/^[[:space:]]*${router_key_header}:[[:space:]]*//p" \
+    | head -n 1 \
+    | tr -d '[:space:]'
+}
+
 # claude_key_present returns 0 when the given settings file's
 # env.ANTHROPIC_CUSTOM_HEADERS carries the router key header. "On" is only valid
 # when this is true: in project scope the committed settings.json holds the
@@ -1338,10 +1394,7 @@ json_get() {
 # (or the parked sidecar), so a router URL alone doesn't mean requests can
 # authenticate.
 claude_key_present() {
-  case "$(json_get "$1" '.env.ANTHROPIC_CUSTOM_HEADERS')" in
-    *X-Weave-Router-Key*) return 0 ;;
-    *) return 1 ;;
-  esac
+  [ -n "$(read_claude_key "$1")" ]
 }
 
 # gitignore_add appends an entry to the repo .gitignore in project scope so a
@@ -1646,7 +1699,7 @@ toggle_opencode() {
   esac
 }
 
-if [ "$mode" != "install" ]; then
+if [ "$mode" != "install" ] && [ "$mode" != "update" ]; then
   case "$target" in
     claude)   toggle_claude ;;
     codex)    toggle_codex ;;
@@ -1656,34 +1709,82 @@ if [ "$mode" != "install" ]; then
 fi
 
 # ---------- token handling ----------
+#
+# Resolution order: WEAVE_ROUTER_KEY, then the key this install already wrote to
+# disk, then an interactive prompt. Reading the installed key back is what makes
+# a re-run painless — the installer refreshes assets and config shape often
+# enough that users re-run it routinely, and re-pasting a key every time is pure
+# friction. --rotate-key skips the read-back so a new key can replace the old.
+
+# read_installed_key prints the router key this install already has on disk, or
+# nothing. Only Claude Code is supported today; the other targets still prompt.
+read_installed_key() {
+  [ "$target" = "claude" ] || return 0
+  local key=""
+  # Mirror where the install path writes the key: project scope (no --dir) puts
+  # it in the gitignored settings.local.json, everything else inlines it into
+  # settings.json. Check the other file too — a scope was possibly changed, or a
+  # project checkout may carry a committed header from an older install.
+  if [ "$scope" = "project" ] && [ -z "$install_dir" ]; then
+    key="$(read_claude_key "$local_settings_file")"
+    [ -n "$key" ] || key="$(read_claude_key "$settings_file")"
+  else
+    key="$(read_claude_key "$settings_file")"
+    [ -n "$key" ] || key="$(read_claude_key "$local_settings_file")"
+  fi
+  printf '%s' "$key"
+}
+
+# prompt_for_key reads a key from the controlling terminal into $api_key. Only
+# ever called on an interactive install; callers check first.
+prompt_for_key() {
+  # Read from /dev/tty explicitly so the prompt works under `curl -fsSL ... | sh`,
+  # where stdin is the curl pipe (already at EOF by the time we get here, and
+  # `set -e` would abort on read returning 1).
+  # _spin_cleanup (installed globally above) already restores stty echo on
+  # any exit path, so we don't need a separate trap here — that would
+  # overwrite the spinner cleanup and leak the cursor / child PID on Ctrl-C.
+  printf "%sGet your Weave Router API key at %s%s\n" "$C_BRAND" "$base_url" "$C_RESET"
+  printf "%sPaste your key here (rk_…):%s " "$C_DIM" "$C_RESET"
+  stty -echo </dev/tty 2>/dev/null || true
+  read -r api_key </dev/tty
+  stty echo </dev/tty 2>/dev/null || true
+  printf "\n"
+  api_key_source="prompt"
+  [ -n "$api_key" ] || { err "No key provided."; exit 1; }
+}
 
 api_key=""
+installed_key=""
+[ "$rotate_key" = "true" ] || installed_key="$(read_installed_key)"
+
 if [ -n "${WEAVE_ROUTER_KEY:-}" ]; then
-    api_key="$WEAVE_ROUTER_KEY"
-    info "Using WEAVE_ROUTER_KEY from environment."
-  elif [ "$non_interactive" = "true" ]; then
-    err "--non-interactive set but WEAVE_ROUTER_KEY is empty. Export it and re-run."
-    exit 1
+  api_key="$WEAVE_ROUTER_KEY"
+  api_key_source="env"
+  info "Using WEAVE_ROUTER_KEY from environment."
+elif [ -n "$installed_key" ]; then
+  api_key="$installed_key"
+  api_key_source="disk"
+  [ "$quiet" = "true" ] || info "Reusing the router key already installed (pass --rotate-key to replace it)."
+elif [ "$mode" = "update" ]; then
+  err "No router key found for $target. Export WEAVE_ROUTER_KEY, or run the installer once to set one up."
+  exit 1
+elif [ "$non_interactive" = "true" ]; then
+  if [ "$rotate_key" = "true" ]; then
+    err "--rotate-key needs either a prompt or WEAVE_ROUTER_KEY, and neither is available. Export the new key and re-run."
   else
-    # Read from /dev/tty explicitly so the prompt works under `curl -fsSL ... | sh`,
-    # where stdin is the curl pipe (already at EOF by the time we get here, and
-    # `set -e` would abort on read returning 1). If /dev/tty isn't available
-    # (e.g. CI without a controlling terminal) the user must use --non-interactive.
-    if [ ! -r /dev/tty ]; then
-      err "No controlling terminal — set WEAVE_ROUTER_KEY and re-run with --non-interactive."
-      exit 1
-    fi
-    # _spin_cleanup (installed globally above) already restores stty echo on
-    # any exit path, so we don't need a separate trap here — that would
-    # overwrite the spinner cleanup and leak the cursor / child PID on Ctrl-C.
-    printf "%sGet your Weave Router API key at %s%s\n" "$C_BRAND" "$base_url" "$C_RESET"
-    printf "%sPaste your key here (rk_…):%s " "$C_DIM" "$C_RESET"
-    stty -echo </dev/tty 2>/dev/null || true
-    read -r api_key </dev/tty
-    stty echo </dev/tty 2>/dev/null || true
-    printf "\n"
-    [ -n "$api_key" ] || { err "No key provided."; exit 1; }
+    err "--non-interactive set but WEAVE_ROUTER_KEY is empty and no installed key was found. Export it and re-run."
   fi
+  exit 1
+else
+  # If /dev/tty isn't available (e.g. CI without a controlling terminal) the
+  # user must use --non-interactive.
+  if [ ! -r /dev/tty ]; then
+    err "No controlling terminal — set WEAVE_ROUTER_KEY and re-run with --non-interactive."
+    exit 1
+  fi
+  prompt_for_key
+fi
 
 # ---------- identity (user email + name) ----------
 #
@@ -1787,7 +1888,38 @@ install_slash_commands() {
     body="${body//\{\{SCOPE\}\}/$scope_args}"
     printf '%s\n' "$body" >"$dst"
   done
+  seed_command_baseline "$commands_src_dir" "$cmds"
   ok "Slash commands written to $dst_dir ($installed)"
+}
+
+# seed_command_baseline records the canonical (unrendered) wrapper bodies this
+# run installed, in the cache dir the statusline's background refresh reads. The
+# refresh replaces an installed wrapper only when its bytes still match that
+# baseline, which is how it tells "stale copy" from "user edited it" — without a
+# seed it has to spend one whole interval establishing one. Claude Code only:
+# the statusline is the refresh point and it only ever runs there.
+#
+# Keyed off the statusline's own location, exactly as the refresh derives it, so
+# both sides land on the same cache path.
+seed_command_baseline() {
+  local src_dir="$1" names="$2"
+  [ "$target" = "claude" ] || return 0
+  local sl_dir cmd_dir
+  sl_dir="$(cd "$(dirname "$statusline_file")" 2>/dev/null && pwd -P)" || return 0
+  case "${sl_dir##*/}" in
+    .weave)  cmd_dir="${sl_dir%/*}/.claude/commands" ;;
+    .claude) cmd_dir="$sl_dir/commands" ;;
+    *)       return 0 ;;
+  esac
+  local dir_slug
+  dir_slug="$(printf '%s' "$cmd_dir" | tr -c 'A-Za-z0-9._-' '_')"
+  local baseline_dir="${XDG_CACHE_HOME:-$HOME/.cache}/weave-router/commands${dir_slug}"
+  mkdir -p "$baseline_dir" 2>/dev/null || return 0
+  local name
+  for name in $names; do
+    [ -f "$src_dir/$name.md" ] || continue
+    cp "$src_dir/$name.md" "$baseline_dir/$name.md" 2>/dev/null || true
+  done
 }
 
 # Codex builds before custom prompt discovery existed were given wrapper files
@@ -2216,6 +2348,141 @@ weave_self_refresh() {
   return 0
 }
 weave_self_refresh 2>/dev/null || true
+
+# ---------- background slash-command refresh ----------
+#
+# The /force-model, /router-* … wrappers under <install>/.claude/commands/ are
+# written once at install time and then never touched again, so a user who
+# doesn't re-run the installer keeps whatever set shipped that day. This script
+# is the only thing Claude Code invokes on every turn, so it doubles as the
+# refresh point for them: same rate limit, same detached fork, same
+# content-diff no-op as the self-refresh above.
+#
+# Never clobber a wrapper the user edited. The only way to tell an edit from a
+# stale copy is to remember what we last downloaded, so each canonical file is
+# cached (unrendered) per install under the user cache dir and a wrapper is
+# replaced only when its bytes still match that baseline. With no baseline yet
+# we can't prove anything, so the first run only seeds the cache and a swap can
+# happen from the next one on. install.sh seeds it too, so fresh installs skip
+# that warm-up round.
+#
+# Opt out with WEAVE_COMMANDS_UPDATE=0 (WEAVE_STATUSLINE_UPDATE=0 disables this
+# too, along with every other network path here). Override the source with
+# WEAVE_COMMANDS_URL_BASE=..., e.g. for self-hosters who fork.
+
+# weave_render_command prints $1 with the installer's {{SCOPE}} placeholder
+# replaced by $2, matching how install_slash_commands writes the same file.
+# Trailing newlines are stripped on both sides of every comparison below.
+weave_render_command() {
+  local body
+  body="$(cat "$1" 2>/dev/null)" || return 1
+  printf '%s' "${body//\{\{SCOPE\}\}/$2}"
+}
+
+weave_sync_commands() {
+  [ "${WEAVE_STATUSLINE_UPDATE:-1}" = "0" ] && return 0
+  [ "${WEAVE_COMMANDS_UPDATE:-1}" = "0" ] && return 0
+  command -v curl >/dev/null 2>&1 || return 0
+
+  local self="${BASH_SOURCE[0]:-$0}" self_dir cmd_dir
+  self_dir="$(cd "$(dirname "$self")" 2>/dev/null && pwd -P)" || return 0
+  # User scope installs this script at <base>/.weave/, project and --dir at
+  # <base>/.claude/. Claude Code reads commands from <base>/.claude/commands in
+  # both layouts.
+  case "${self_dir##*/}" in
+    .weave)  cmd_dir="${self_dir%/*}/.claude/commands" ;;
+    .claude) cmd_dir="$self_dir/commands" ;;
+    *)       return 0 ;;
+  esac
+  [ -d "$cmd_dir" ] && [ -w "$cmd_dir" ] || return 0
+
+  local cache_dir="${XDG_CACHE_HOME:-$HOME/.cache}/weave-router"
+  local dir_slug
+  dir_slug="$(printf '%s' "$cmd_dir" | tr -c 'A-Za-z0-9._-' '_')"
+  # Baseline is keyed by install, not shared: two installs refresh on their own
+  # clocks, and a shared baseline updated by one would make the other's still-
+  # canonical wrappers look user-edited and freeze them forever.
+  local baseline_dir="$cache_dir/commands${dir_slug}"
+  local stamp="$cache_dir/checked-at${dir_slug}.commands"
+  mkdir -p "$baseline_dir" 2>/dev/null || return 0
+
+  local interval_days="${WEAVE_STATUSLINE_UPDATE_INTERVAL_DAYS:-7}"
+  local now stamp_mtime
+  now="$(date +%s 2>/dev/null)" || return 0
+  if [ -f "$stamp" ]; then
+    stamp_mtime="$(stat -c %Y "$stamp" 2>/dev/null || stat -f %m "$stamp" 2>/dev/null)" || stamp_mtime=0
+  else
+    stamp_mtime=0
+  fi
+  if [ -n "${stamp_mtime:-}" ] && [ "$stamp_mtime" -gt 0 ] \
+     && [ $(( now - stamp_mtime )) -lt $(( interval_days * 86400 )) ]; then
+    return 0
+  fi
+  # Stamp before forking, same as the self-refresh: Claude Code calls us on
+  # every turn and concurrent invocations must not all start downloading.
+  : > "$stamp" 2>/dev/null || return 0
+
+  # router-off/on/status bake this install's scope selector into their npx
+  # line (upstream carries {{SCOPE}} there). Recover it from the installed copy
+  # so a project or --dir install keeps toggling its own config; when it can't
+  # be recovered those three are skipped rather than rewritten to point at the
+  # user-scope install.
+  local scope_args="" scope_known="false" off="$cmd_dir/router-off.md"
+  if [ -f "$off" ] && grep -q '^`npx @workweave/router off --claude.*`$' "$off" 2>/dev/null; then
+    scope_known="true"
+    scope_args="$(sed -n 's|^`npx @workweave/router off --claude\(.*\)`$|\1|p' "$off" | head -n 1)"
+  fi
+
+  local url_base="${WEAVE_COMMANDS_URL_BASE:-https://raw.githubusercontent.com/workweave/router/main/install/commands}"
+  local name installed raw prev tmp new_body prev_body installed_body
+  (
+    # Detach stdin (CC pipes JSON to us) so curl can't consume it, and silence
+    # everything so no output leaks into the statusline.
+    exec </dev/null
+    for name in force-model unforce-model router-feedback fm ufm rf \
+                router-off router-on router-status router-session; do
+      installed="$cmd_dir/$name.md"
+      # Only ever refresh a wrapper that is already installed: a missing one
+      # was uninstalled or deliberately deleted, and resurrecting it would be
+      # a surprise. A symlink is user-owned; leave it alone.
+      [ -f "$installed" ] || continue
+      [ -L "$installed" ] && continue
+
+      raw="$baseline_dir/$name.md.tmp.$$"
+      curl -fsSL --max-time 15 "$url_base/$name.md" -o "$raw" 2>/dev/null || { rm -f "$raw"; continue; }
+      # Shape check: every wrapper opens with YAML front matter, so a 404 page
+      # or a truncated body can never be installed as a command.
+      if [ ! -s "$raw" ] || [ "$(head -n 1 "$raw")" != "---" ]; then
+        rm -f "$raw"
+        continue
+      fi
+
+      prev="$baseline_dir/$name.md"
+      if grep -q '{{SCOPE}}' "$raw" && [ "$scope_known" != "true" ]; then
+        mv "$raw" "$prev" 2>/dev/null || rm -f "$raw"
+        continue
+      fi
+
+      if [ -f "$prev" ]; then
+        new_body="$(weave_render_command "$raw" "$scope_args")"
+        prev_body="$(weave_render_command "$prev" "$scope_args")"
+        installed_body="$(cat "$installed" 2>/dev/null)" || installed_body=""
+        if [ "$prev_body" = "$installed_body" ] && [ "$new_body" != "$installed_body" ]; then
+          tmp="$installed.tmp.$$"
+          if printf '%s\n' "$new_body" >"$tmp" 2>/dev/null; then
+            mv "$tmp" "$installed" 2>/dev/null || rm -f "$tmp"
+          else
+            rm -f "$tmp"
+          fi
+        fi
+      fi
+      mv "$raw" "$prev" 2>/dev/null || rm -f "$raw"
+    done
+  ) >/dev/null 2>&1 &
+  disown 2>/dev/null || true
+  return 0
+}
+weave_sync_commands 2>/dev/null || true
 
 input="$(cat)"
 transcript_path="$(printf '%s' "$input" | jq -r '.transcript_path // empty')"
@@ -2646,86 +2913,97 @@ tmp_patch="$(mktemp)"
 # leave the cursor hidden if Ctrl-C lands during settings.json patching.
 trap '_spin_cleanup; rm -f "$tmp_patch"' EXIT INT TERM HUP
 
-# Claude Code splits ANTHROPIC_CUSTOM_HEADERS on newlines, so multiple headers
-# ride in the same env var separated by \n. Append identity headers alongside
-# the router key so a single var carries them all. When email/name are empty
-# we keep the bare router-key form so a re-install for a user who opted out
-# cleanly removes the old line.
-custom_headers="$router_key_header: $api_key"
-if [ -n "$user_email" ]; then
-  custom_headers="$custom_headers"$'\n'"X-Weave-User-Email: $user_email"
-fi
-if [ -n "$user_name" ]; then
-  custom_headers="$custom_headers"$'\n'"X-Weave-User-Name: $user_name"
-fi
-custom_headers="$custom_headers"$'\n'"X-App: claude-code"
+# write_claude_settings merges the router config into settings.json (and, in
+# project scope, the key header into settings.local.json) for the key in $1.
+# Factored out so the /validate fallback can rewrite both files with a
+# replacement key without re-running the whole install.
+write_claude_settings() {
+  local block_key="$1"
 
-# Setting ANTHROPIC_BASE_URL makes Claude Code treat us as non-first-party and
-# disable MCP tool-search deferral, inlining every tool schema into every request
-# — a large uncompactable prefix that can push a session into an autocompact
-# thrash loop. ENABLE_TOOL_SEARCH=auto restores on-demand loading (Claude Code's
-# own first-party default).
-if [ "$scope" = "project" ] && [ -z "$install_dir" ]; then
-  jq -n --arg url "$base_url" --arg sl "$statusline_path_for_settings" '{
-    env: { ANTHROPIC_BASE_URL: $url, ENABLE_TOOL_SEARCH: "auto" },
-    statusLine: { type: "command", command: $sl },
-    attribution: {
-      commit: "Co-Authored-By: Weave Router <router@workweave.ai>",
-      pr: "🤖 Generated with [Weave Router](https://router.workweave.ai)"
-    }
-  }' >"$tmp_patch"
-else
-  jq -n --arg url "$base_url" --arg header "$custom_headers" --arg sl "$statusline_path_for_settings" '{
-    env: { ANTHROPIC_BASE_URL: $url, ANTHROPIC_CUSTOM_HEADERS: $header, ENABLE_TOOL_SEARCH: "auto" },
-    statusLine: { type: "command", command: $sl },
-    attribution: {
-      commit: "Co-Authored-By: Weave Router <router@workweave.ai>",
-      pr: "🤖 Generated with [Weave Router](https://router.workweave.ai)"
-    }
-  }' >"$tmp_patch"
-fi
+  # Claude Code splits ANTHROPIC_CUSTOM_HEADERS on newlines, so multiple headers
+  # ride in the same env var separated by \n. Append identity headers alongside
+  # the router key so a single var carries them all. When email/name are empty
+  # we keep the bare router-key form so a re-install for a user who opted out
+  # cleanly removes the old line.
+  local custom_headers="$router_key_header: $block_key"
+  if [ -n "$user_email" ]; then
+    custom_headers="$custom_headers"$'\n'"X-Weave-User-Email: $user_email"
+  fi
+  if [ -n "$user_name" ]; then
+    custom_headers="$custom_headers"$'\n'"X-Weave-User-Name: $user_name"
+  fi
+  custom_headers="$custom_headers"$'\n'"X-App: claude-code"
 
-# Merge with existing settings. Deep-merge env and replace statusLine.
-# We strip router-owned auth from the existing settings BEFORE merging —
-# otherwise switching auth mode (key→dev-mode) would leave stale credentials
-# behind. ANTHROPIC_AUTH_TOKEN/apiKeyHelper are also removed to migrate older
-# installs that used them for router auth.
-if [ -f "$settings_file" ]; then
-  merged="$(jq -s '.[0] as $a | .[1] as $b
-    | $a
-    | .env = (($a.env // {} | del(.ANTHROPIC_AUTH_TOKEN, .ANTHROPIC_CUSTOM_HEADERS)) + ($b.env // {}))
-    | (if (.env | length) == 0 then del(.env) else . end)
-    | del(.apiKeyHelper)
-    | (if $b.statusLine then .statusLine = $b.statusLine else . end)
-    | (if $b.attribution then .attribution = $b.attribution else . end)
-  ' "$settings_file" "$tmp_patch")"
-  printf '%s\n' "$merged" >"$settings_file"
-else
-  cp "$tmp_patch" "$settings_file"
-fi
-ok "Settings written to $settings_file"
+  # Setting ANTHROPIC_BASE_URL makes Claude Code treat us as non-first-party and
+  # disable MCP tool-search deferral, inlining every tool schema into every request
+  # — a large uncompactable prefix that can push a session into an autocompact
+  # thrash loop. ENABLE_TOOL_SEARCH=auto restores on-demand loading (Claude Code's
+  # own first-party default).
+  if [ "$scope" = "project" ] && [ -z "$install_dir" ]; then
+    jq -n --arg url "$base_url" --arg sl "$statusline_path_for_settings" '{
+      env: { ANTHROPIC_BASE_URL: $url, ENABLE_TOOL_SEARCH: "auto" },
+      statusLine: { type: "command", command: $sl },
+      attribution: {
+        commit: "Co-Authored-By: Weave Router <router@workweave.ai>",
+        pr: "🤖 Generated with [Weave Router](https://router.workweave.ai)"
+      }
+    }' >"$tmp_patch"
+  else
+    jq -n --arg url "$base_url" --arg header "$custom_headers" --arg sl "$statusline_path_for_settings" '{
+      env: { ANTHROPIC_BASE_URL: $url, ANTHROPIC_CUSTOM_HEADERS: $header, ENABLE_TOOL_SEARCH: "auto" },
+      statusLine: { type: "command", command: $sl },
+      attribution: {
+        commit: "Co-Authored-By: Weave Router <router@workweave.ai>",
+        pr: "🤖 Generated with [Weave Router](https://router.workweave.ai)"
+      }
+    }' >"$tmp_patch"
+  fi
 
-# Slash command wrappers — see install_slash_commands() below for the why.
-install_slash_commands "$settings_dir/commands"
-
-if [ "$scope" = "project" ] && [ -z "$install_dir" ]; then
-  jq -n --arg header "$custom_headers" '{
-    env: { ANTHROPIC_CUSTOM_HEADERS: $header }
-  }' >"$tmp_patch"
-  if [ -f "$local_settings_file" ]; then
+  # Merge with existing settings. Deep-merge env and replace statusLine.
+  # We strip router-owned auth from the existing settings BEFORE merging —
+  # otherwise switching auth mode (key→dev-mode) would leave stale credentials
+  # behind. ANTHROPIC_AUTH_TOKEN/apiKeyHelper are also removed to migrate older
+  # installs that used them for router auth.
+  local merged
+  if [ -f "$settings_file" ]; then
     merged="$(jq -s '.[0] as $a | .[1] as $b
       | $a
       | .env = (($a.env // {} | del(.ANTHROPIC_AUTH_TOKEN, .ANTHROPIC_CUSTOM_HEADERS)) + ($b.env // {}))
       | (if (.env | length) == 0 then del(.env) else . end)
       | del(.apiKeyHelper)
-    ' "$local_settings_file" "$tmp_patch")"
-    printf '%s\n' "$merged" >"$local_settings_file"
+      | (if $b.statusLine then .statusLine = $b.statusLine else . end)
+      | (if $b.attribution then .attribution = $b.attribution else . end)
+    ' "$settings_file" "$tmp_patch")"
+    printf '%s\n' "$merged" >"$settings_file"
   else
-    cp "$tmp_patch" "$local_settings_file"
+    cp "$tmp_patch" "$settings_file"
   fi
-  chmod 600 "$local_settings_file"
-  ok "Router key header written to $local_settings_file"
-fi
+  ok "Settings written to $settings_file"
+
+  if [ "$scope" = "project" ] && [ -z "$install_dir" ]; then
+    jq -n --arg header "$custom_headers" '{
+      env: { ANTHROPIC_CUSTOM_HEADERS: $header }
+    }' >"$tmp_patch"
+    if [ -f "$local_settings_file" ]; then
+      merged="$(jq -s '.[0] as $a | .[1] as $b
+        | $a
+        | .env = (($a.env // {} | del(.ANTHROPIC_AUTH_TOKEN, .ANTHROPIC_CUSTOM_HEADERS)) + ($b.env // {}))
+        | (if (.env | length) == 0 then del(.env) else . end)
+        | del(.apiKeyHelper)
+      ' "$local_settings_file" "$tmp_patch")"
+      printf '%s\n' "$merged" >"$local_settings_file"
+    else
+      cp "$tmp_patch" "$local_settings_file"
+    fi
+    chmod 600 "$local_settings_file"
+    ok "Router key header written to $local_settings_file"
+  fi
+}
+
+write_claude_settings "$api_key"
+
+# Slash command wrappers — see install_slash_commands() below for the why.
+install_slash_commands "$settings_dir/commands"
 
 # ---------- gitignore for project scope ----------
 
@@ -2766,13 +3044,43 @@ if [ -n "$api_key" ]; then
       | curl -fsS --max-time 5 --header @- "$base_url/validate"
   }
   if ! spin "Validating API key" validate_key; then
-    warn "Router rejected the API key (check it matches the dashboard at $base_url)."
+    # A key we read back off disk can have been revoked or rotated since it was
+    # installed, and reusing it silently would leave a broken install behind
+    # exactly where the old behavior (always prompt) would have fixed it. Ask
+    # once, then rewrite the settings with whatever the user pastes. Anywhere a
+    # prompt isn't available — non-interactive, update, --quiet, no tty, or a
+    # key that didn't come from disk — keep the historical warn-and-continue.
+    if [ "$api_key_source" = "disk" ] && [ "$non_interactive" != "true" ] \
+       && [ "$quiet" != "true" ] && [ -r /dev/tty ]; then
+      warn "The router key already installed was rejected (revoked or rotated)."
+      prompt_for_key
+      write_claude_settings "$api_key"
+      if ! spin "Validating API key" validate_key; then
+        warn "Router rejected the API key (check it matches the dashboard at $base_url)."
+      fi
+    elif [ "$mode" = "update" ]; then
+      # update is meant for cron/scripting: a rejected key is a real failure,
+      # not a note in the log. --quiet callers opted out of the noise.
+      if [ "$quiet" = "true" ]; then
+        warn "Router rejected the installed API key. Re-run the installer to set a new one."
+      else
+        err "Router rejected the installed API key. Re-run the installer to set a new one."
+        exit 1
+      fi
+    else
+      warn "Router rejected the API key (check it matches the dashboard at $base_url)."
+    fi
   fi
 fi
 
 # ---------- done ----------
 
 printf "\n"
+if [ "$mode" = "update" ]; then
+  printf "%s✓%s %s%sWeave Router config refreshed for Claude Code.%s\n" \
+    "$C_GREEN" "$C_RESET" "$C_BOLD" "$C_BRAND" "$C_RESET"
+  exit 0
+fi
 printf "%s✓%s %s%sWeave Router installed for Claude Code.%s\n" \
   "$C_GREEN" "$C_RESET" "$C_BOLD" "$C_BRAND" "$C_RESET"
 print_uninstall_hint

--- a/install/install.sh
+++ b/install/install.sh
@@ -3053,16 +3053,18 @@ write_claude_settings() {
   fi
 }
 
-# write_claude_settings rewrote the full router config live, so a parked
-# sidecar left over from `off` is now redundant: the router is back on and the
-# key/base URL it preserved are in the settings files. Leave it in place and
-# `status` would keep reporting off, and `off` would no-op against live router
-# config the user can no longer toggle.
+# write_claude_settings rewrites the full router config live, so a parked
+# sidecar left over from `off` is redundant afterward: the router is back on
+# and the key/base URL it preserved are in the settings files. Leave it in
+# place and `status` would keep reporting off, and `off` would no-op against
+# live router config the user can no longer toggle. Removed AFTER the write
+# succeeds (not before) — deleting it first would lose the only on-disk copy
+# of the key if the write itself failed midway under `set -e`.
+write_claude_settings "$api_key"
+
 if [ "$target" = "claude" ] && [ -f "$settings_dir/.weave-parked.json" ]; then
   rm -f "$settings_dir/.weave-parked.json"
 fi
-
-write_claude_settings "$api_key"
 
 # Slash command wrappers — see install_slash_commands() below for the why.
 install_slash_commands "$settings_dir/commands"

--- a/install/install.sh
+++ b/install/install.sh
@@ -78,6 +78,7 @@ scope="user"
 scope_explicit="false"
 install_dir=""
 base_url=""
+base_url_explicit="false"
 non_interactive="false"
 quiet="false"
 router_key_header="X-Weave-Router-Key"
@@ -941,10 +942,12 @@ while [ $# -gt 0 ]; do
     --base-url)
       base_url="${2:-}"; shift 2
       [ -n "$base_url" ] || { err "--base-url requires a value."; exit 2; }
+      base_url_explicit="true"
       ;;
     --local)
       # Shorthand for local dev: localhost:8080 (matches `wv mr` / `make dev` default PORT).
       base_url="http://localhost:8080"
+      base_url_explicit="true"
       shift
       ;;
     --non-interactive)
@@ -1153,11 +1156,7 @@ fi
 
 # ---------- pre-flight ----------
 
-if [ "$mode" = "install" ]; then
-  [ "$quiet" = "true" ] || info "scope=${C_BOLD}${scope}${C_RESET}  target=${C_BOLD}${target}${C_RESET}  base_url=${C_BOLD}${base_url}${C_RESET}"
-elif [ "$mode" = "update" ]; then
-  [ "$quiet" = "true" ] || info "mode=${C_BOLD}update${C_RESET}  scope=${C_BOLD}${scope}${C_RESET}  target=${C_BOLD}${target}${C_RESET}  base_url=${C_BOLD}${base_url}${C_RESET}"
-else
+if [ "$mode" != "install" ] && [ "$mode" != "update" ]; then
   [ "$quiet" = "true" ] || info "mode=${C_BOLD}${mode}${C_RESET}  scope=${C_BOLD}${scope}${C_RESET}  target=${C_BOLD}${target}${C_RESET}"
 fi
 
@@ -1708,6 +1707,39 @@ if [ "$mode" != "install" ] && [ "$mode" != "update" ]; then
   exit 0
 fi
 
+# ---------- endpoint carry-over for update ----------
+#
+# `update` refreshes an install in place, so it must not silently retarget a
+# self-hosted or custom endpoint at the hosted default just because --base-url
+# wasn't repeated. Read the endpoint already configured and keep it; an explicit
+# --base-url / --local still wins, and install mode is untouched (it is how you
+# deliberately move an install to a new endpoint).
+#
+# `off` parks the router URL and points Claude Code at Anthropic, so the parked
+# sidecar is the authority while toggled off — reading the live file there would
+# pin the install to api.anthropic.com.
+if [ "$mode" = "update" ] && [ "$base_url_explicit" != "true" ] && [ "$target" = "claude" ]; then
+  installed_base=""
+  for candidate in \
+    "$settings_dir/.weave-parked.json" \
+    "$settings_file" \
+    "$local_settings_file"
+  do
+    installed_base="$(json_get "$candidate" '.env.ANTHROPIC_BASE_URL')"
+    router_shaped_url "$installed_base" && break
+    installed_base=""
+  done
+  if [ -n "$installed_base" ]; then
+    base_url="${installed_base%/}"
+  fi
+fi
+
+if [ "$mode" = "install" ]; then
+  [ "$quiet" = "true" ] || info "scope=${C_BOLD}${scope}${C_RESET}  target=${C_BOLD}${target}${C_RESET}  base_url=${C_BOLD}${base_url}${C_RESET}"
+else
+  [ "$quiet" = "true" ] || info "mode=${C_BOLD}update${C_RESET}  scope=${C_BOLD}${scope}${C_RESET}  target=${C_BOLD}${target}${C_RESET}  base_url=${C_BOLD}${base_url}${C_RESET}"
+fi
+
 # ---------- token handling ----------
 #
 # Resolution order: WEAVE_ROUTER_KEY, then the key this install already wrote to
@@ -1732,6 +1764,11 @@ read_installed_key() {
     key="$(read_claude_key "$settings_file")"
     [ -n "$key" ] || key="$(read_claude_key "$local_settings_file")"
   fi
+  # Last resort: `off` moves the key header out of the settings files and into
+  # the parked sidecar, so an install/update run while toggled off finds nothing
+  # above even though the key is still on disk. Same {"env":{…}} shape, so
+  # read_claude_key reads it directly.
+  [ -n "$key" ] || key="$(read_claude_key "$settings_dir/.weave-parked.json")"
   printf '%s' "$key"
 }
 
@@ -2366,9 +2403,22 @@ weave_self_refresh 2>/dev/null || true
 # happen from the next one on. install.sh seeds it too, so fresh installs skip
 # that warm-up round.
 #
+# Never touch a wrapper git tracks either. A project-scope install writes the
+# wrappers into the repo's own .claude/commands/, and unlike cc-statusline.sh
+# the installer does not gitignore them — so an unattended weekly rewrite would
+# surface as unexplained dirty files (and could ride along in someone's commit).
+# Only the installer changes tracked files, and only when a human runs it.
+#
 # Opt out with WEAVE_COMMANDS_UPDATE=0 (WEAVE_STATUSLINE_UPDATE=0 disables this
 # too, along with every other network path here). Override the source with
 # WEAVE_COMMANDS_URL_BASE=..., e.g. for self-hosters who fork.
+
+# weave_command_tracked_by_git returns 0 when $1 is a file git tracks. Used to
+# leave repo-committed wrappers alone; no git (or no repo) means untracked.
+weave_command_tracked_by_git() {
+  command -v git >/dev/null 2>&1 || return 1
+  git -C "$(dirname "$1")" ls-files --error-unmatch -- "$1" >/dev/null 2>&1
+}
 
 # weave_render_command prints $1 with the installer's {{SCOPE}} placeholder
 # replaced by $2, matching how install_slash_commands writes the same file.
@@ -2444,9 +2494,12 @@ weave_sync_commands() {
       installed="$cmd_dir/$name.md"
       # Only ever refresh a wrapper that is already installed: a missing one
       # was uninstalled or deliberately deleted, and resurrecting it would be
-      # a surprise. A symlink is user-owned; leave it alone.
+      # a surprise. A symlink is user-owned; leave it alone. A git-tracked
+      # wrapper belongs to the repo — rewriting it would dirty a working tree
+      # nobody asked us to touch.
       [ -f "$installed" ] || continue
       [ -L "$installed" ] && continue
+      weave_command_tracked_by_git "$installed" && continue
 
       raw="$baseline_dir/$name.md.tmp.$$"
       curl -fsSL --max-time 15 "$url_base/$name.md" -o "$raw" 2>/dev/null || { rm -f "$raw"; continue; }
@@ -3060,13 +3113,15 @@ if [ -n "$api_key" ]; then
       fi
     elif [ "$mode" = "update" ]; then
       # update is meant for cron/scripting: a rejected key is a real failure,
-      # not a note in the log. --quiet callers opted out of the noise.
+      # not a note in the log. --quiet callers opted out of the noise, not out
+      # of the nonzero exit — a scheduled run that reports success here would
+      # hide a revoked key indefinitely.
       if [ "$quiet" = "true" ]; then
         warn "Router rejected the installed API key. Re-run the installer to set a new one."
       else
         err "Router rejected the installed API key. Re-run the installer to set a new one."
-        exit 1
       fi
+      exit 1
     else
       warn "Router rejected the API key (check it matches the dashboard at $base_url)."
     fi

--- a/install/npm/README.md
+++ b/install/npm/README.md
@@ -14,6 +14,22 @@ npx @workweave/router --base-url https://router.acme.internal
 npx @workweave/router --non-interactive     # reads $WEAVE_ROUTER_KEY, no prompts (defaults to claude)
 ```
 
+Re-running the installer to pick up changes reuses the key already on disk, so
+you paste it once and never again. `update` is the never-prompting form of that
+(safe for cron; errors instead of asking when no key can be found):
+
+```bash
+npx @workweave/router --claude                # reuses the installed key
+npx @workweave/router --claude --rotate-key   # ignore it and prompt for a new one
+npx @workweave/router update --claude         # non-interactive refresh in place
+```
+
+For Claude Code the installed statusline and `/force-model`, `/router-*` slash
+commands also refresh themselves in the background about once a week (never
+overwriting a wrapper you edited). Opt out with `WEAVE_STATUSLINE_UPDATE=0`, or
+just the commands with `WEAVE_COMMANDS_UPDATE=0`. Codex, opencode, and pi have
+no per-turn hook to refresh from — re-run the installer for those.
+
 Version-pin for reproducible setups:
 
 ```bash

--- a/install/tests/cc-statusline_test.sh
+++ b/install/tests/cc-statusline_test.sh
@@ -273,6 +273,123 @@ echo "{\"model\":{\"id\":\"$STALE_MODEL\"}}" \
     bash "$c/cc.sh" >/dev/null 2>&1
 check "missing transcript exits 0" "$?" 0
 
+# ---------- slash-command refresh ----------
+#
+# The wrappers under <install>/.claude/commands/ have no other refresh point —
+# the statusline is the only thing Claude Code runs every turn. Same offline
+# technique: a file:// "upstream" commands dir the fixtures mutate per case.
+
+commands_upstream="$work/commands-upstream"
+mkdir -p "$commands_upstream"
+cp "$script_dir/../commands"/*.md "$commands_upstream/"
+
+# Lay out a user-scope install: statusline under .weave/, wrappers under
+# .claude/commands/, and a seeded baseline (what install.sh writes) holding the
+# unrendered canonical bodies.
+make_command_install() { # make_command_install <root> <cache_home> [scope_args]
+  local root="$1" cache="$2" scope_args="${3:-}" name body
+  mkdir -p "$root/.weave" "$root/.claude/commands"
+  cp "$upstream" "$root/.weave/cc-statusline.sh"
+  chmod +x "$root/.weave/cc-statusline.sh"
+  local baseline="$cache/weave-router/commands$(printf '%s' "$(cd "$root/.claude/commands" && pwd -P)" | tr -c 'A-Za-z0-9._-' '_')"
+  mkdir -p "$baseline"
+  for name in "$script_dir/../commands"/*.md; do
+    body="$(cat "$name")"
+    printf '%s\n' "${body//\{\{SCOPE\}\}/$scope_args}" >"$root/.claude/commands/$(basename "$name")"
+    cp "$name" "$baseline/$(basename "$name")"
+  done
+}
+
+# WEAVE_STATUSLINE_UPDATE=0 is a master kill switch that covers this path too,
+# so these cases can't use it to isolate the wrapper refresh. Point the script's
+# own refresh at the same offline fixture instead — it lands as a content no-op.
+sync_commands() { # sync_commands <root> <cache_home> <commands_url_base>
+  echo "{\"model\":{\"id\":\"$STALE_MODEL\"},\"transcript_path\":\"$transcript\"}" \
+    | XDG_CACHE_HOME="$2" WEAVE_STATUSLINE_URL="file://$upstream" WEAVE_COMMANDS_URL_BASE="$3" \
+      bash "$1/.weave/cc-statusline.sh" >/dev/null 2>&1
+}
+
+# An upstream wrapper change reaches an untouched install.
+c="$work/cmd1"; mkdir -p "$c/cache"; make_command_install "$c/root" "$c/cache"
+printf '%s\n' '---' 'description: refreshed fm.' '---' '' '/force-model $ARGUMENTS' \
+  >"$commands_upstream/fm.md"
+sync_commands "$c/root" "$c/cache" "file://$commands_upstream"
+if wait_for 20 grep -q 'refreshed fm.' "$c/root/.claude/commands/fm.md"; then
+  ok "an upstream wrapper change reaches the install"
+else
+  no "an upstream wrapper change reaches the install" "refreshed body" "$(cat "$c/root/.claude/commands/fm.md")"
+fi
+
+# A wrapper the user edited is theirs. Overwriting it is the one unrecoverable
+# mistake here, so the baseline comparison must veto the swap.
+c="$work/cmd2"; mkdir -p "$c/cache"; make_command_install "$c/root" "$c/cache"
+printf '%s\n' 'MY OWN WRAPPER' >"$c/root/.claude/commands/rf.md"
+printf '%s\n' '---' 'description: refreshed rf.' '---' '' '/router-feedback $ARGUMENTS' \
+  >"$commands_upstream/rf.md"
+sync_commands "$c/root" "$c/cache" "file://$commands_upstream"
+sleep 1
+check "a user-edited wrapper is never overwritten" \
+  "$(cat "$c/root/.claude/commands/rf.md")" "MY OWN WRAPPER"
+
+# The router-* wrappers bake this install's scope into their npx line. A
+# refresh that dropped it would point a project install's toggle at the
+# user-scope config — silently flipping the wrong install.
+c="$work/cmd3"; mkdir -p "$c/cache"
+make_command_install "$c/root" "$c/cache" " --scope project"
+printf '%s\n' '---' 'description: refreshed off.' 'allowed-tools: Bash(npx:*)' '---' '' \
+  'Turn it off:' '' '`npx @workweave/router off --claude{{SCOPE}}`' \
+  >"$commands_upstream/router-off.md"
+sync_commands "$c/root" "$c/cache" "file://$commands_upstream"
+if wait_for 20 grep -q 'refreshed off.' "$c/root/.claude/commands/router-off.md"; then
+  check_contains "refreshed router-off keeps this install's scope" \
+    "$(cat "$c/root/.claude/commands/router-off.md")" 'off --claude --scope project'
+else
+  no "refreshed router-off keeps this install's scope" "refreshed body" "not refreshed"
+fi
+
+# A 404 (or any HTML error page) must never land as a slash command.
+c="$work/cmd4"; mkdir -p "$c/cache"; make_command_install "$c/root" "$c/cache"
+before="$(cat "$c/root/.claude/commands/fm.md")"
+sync_commands "$c/root" "$c/cache" "file://$work/no-such-commands-dir"
+sleep 1
+check "a failed fetch leaves the installed wrapper alone" \
+  "$(cat "$c/root/.claude/commands/fm.md")" "$before"
+
+# A wrapper the user uninstalled must stay uninstalled — resurrecting it is a
+# surprise, and the refresh has no way to know it was ever wanted.
+c="$work/cmd5"; mkdir -p "$c/cache"; make_command_install "$c/root" "$c/cache"
+rm -f "$c/root/.claude/commands/ufm.md"
+sync_commands "$c/root" "$c/cache" "file://$commands_upstream"
+sleep 1
+if [ -e "$c/root/.claude/commands/ufm.md" ]; then
+  no "a removed wrapper is not resurrected" "still absent" "file re-created"
+else
+  ok "a removed wrapper is not resurrected"
+fi
+
+# Opt-out has to cover this path too, not just the script's own refresh.
+c="$work/cmd6"; mkdir -p "$c/cache"; make_command_install "$c/root" "$c/cache"
+before="$(cat "$c/root/.claude/commands/fm.md")"
+echo "{\"model\":{\"id\":\"$STALE_MODEL\"},\"transcript_path\":\"$transcript\"}" \
+  | XDG_CACHE_HOME="$c/cache" WEAVE_STATUSLINE_URL="file://$upstream" WEAVE_COMMANDS_UPDATE=0 \
+    WEAVE_COMMANDS_URL_BASE="file://$commands_upstream" \
+    bash "$c/root/.weave/cc-statusline.sh" >/dev/null 2>&1
+sleep 1
+check "WEAVE_COMMANDS_UPDATE=0 suppresses the wrapper refresh" \
+  "$(cat "$c/root/.claude/commands/fm.md")" "$before"
+
+# The master kill switch has to cover the wrapper refresh too, not just the
+# script's own — a user who opted out of one network path opted out of both.
+c="$work/cmd7"; mkdir -p "$c/cache"; make_command_install "$c/root" "$c/cache"
+before="$(cat "$c/root/.claude/commands/fm.md")"
+echo "{\"model\":{\"id\":\"$STALE_MODEL\"},\"transcript_path\":\"$transcript\"}" \
+  | XDG_CACHE_HOME="$c/cache" WEAVE_STATUSLINE_UPDATE=0 \
+    WEAVE_COMMANDS_URL_BASE="file://$commands_upstream" \
+    bash "$c/root/.weave/cc-statusline.sh" >/dev/null 2>&1
+sleep 1
+check "WEAVE_STATUSLINE_UPDATE=0 suppresses the wrapper refresh too" \
+  "$(cat "$c/root/.claude/commands/fm.md")" "$before"
+
 # install.sh ships the statusline as a heredoc; genprices keeps only the price
 # block in sync, so a code edit to one copy silently diverges from the other.
 installer="$script_dir/../install.sh"

--- a/install/tests/cc-statusline_test.sh
+++ b/install/tests/cc-statusline_test.sh
@@ -331,6 +331,20 @@ sleep 1
 check "a user-edited wrapper is never overwritten" \
   "$(cat "$c/root/.claude/commands/rf.md")" "MY OWN WRAPPER"
 
+# A project-scope install writes wrappers straight into the repo's own
+# .claude/commands/ and (unlike cc-statusline.sh) does not gitignore them, so a
+# git-tracked wrapper must never be rewritten by the unattended weekly refresh —
+# that would surface as unexplained dirty files in someone's working tree.
+c="$work/cmd2b"; mkdir -p "$c/cache"; make_command_install "$c/root" "$c/cache"
+( cd "$c/root" && git init -q . && git add .claude/commands/fm.md && git commit -q -m "commit wrappers" )
+before="$(cat "$c/root/.claude/commands/fm.md")"
+printf '%s\n' '---' 'description: refreshed fm again.' '---' '' '/force-model $ARGUMENTS' \
+  >"$commands_upstream/fm.md"
+sync_commands "$c/root" "$c/cache" "file://$commands_upstream"
+sleep 1
+check "a git-tracked wrapper is never overwritten" \
+  "$(cat "$c/root/.claude/commands/fm.md")" "$before"
+
 # The router-* wrappers bake this install's scope into their npx line. A
 # refresh that dropped it would point a project install's toggle at the
 # user-scope config — silently flipping the wrong install.

--- a/install/tests/key_reuse_test.sh
+++ b/install/tests/key_reuse_test.sh
@@ -108,10 +108,11 @@ run "$upd_home" -- update --claude
 check "update surfaces a rejected key as an error" "$?" 1
 check "update still refreshed the config" "$(installed_key "$upd_settings")" "rk_upd"
 
-# --quiet downgrades that to a warning: quiet callers opted out of the noise
-# and out of a nonzero exit for a config refresh that did land.
+# --quiet downgrades the message to a warning but must not downgrade the exit
+# code: a cron job checks $? for success, and a scheduled run that reports 0
+# here would silently hide a revoked key until the router starts 401ing.
 run "$upd_home" -- update --claude --quiet
-check "quiet update exits 0 despite the rejection" "$?" 0
+check "quiet update still exits nonzero on rejection" "$?" 1
 
 # update never prompts, so it has no use for a flag whose whole job is to force
 # one. Accepting it silently would look like rotation happened.
@@ -144,6 +145,36 @@ if grep -q '{{SCOPE}}' "$baseline/router-off.md" 2>/dev/null; then
 else
   no "seeded baseline keeps the {{SCOPE}} placeholder" "unrendered copy" "placeholder substituted"
 fi
+
+# ---------- update after `off`: parked sidecar key + base URL carry-over ----------
+#
+# `off` moves the router URL and key header out of settings.json/settings.local.json
+# and into .weave-parked.json. A re-run while toggled off must still find the key
+# there (not demand a fresh paste) and must not silently retarget the endpoint at
+# the hosted default just because --base-url wasn't repeated.
+
+off_home="$work/off"; mkdir -p "$off_home"
+off_settings="$off_home/.claude/settings.json"
+custom_url="http://custom-router.internal:9999"
+
+HOME="$off_home" XDG_CACHE_HOME="$off_home/.cache" PATH="$test_path" NO_COLOR=1 \
+  WEAVE_ROUTER_KEY="rk_off" \
+  bash "$installer" --claude --scope user --quiet --non-interactive --base-url "$custom_url" </dev/null >/dev/null 2>&1
+HOME="$off_home" PATH="$test_path" NO_COLOR=1 \
+  bash "$installer" off --claude </dev/null >/dev/null 2>&1
+check "off parks the router key, not settings.json" "$(installed_key "$off_settings")" ""
+
+# Direct invocation, not the `run` helper — `run` always appends its own
+# --base-url, which would make base_url_explicit=true and defeat the very
+# carry-over behavior this checks.
+HOME="$off_home" XDG_CACHE_HOME="$off_home/.cache" PATH="$test_path" NO_COLOR=1 \
+  bash "$installer" update --claude </dev/null >/dev/null 2>&1
+check "update while off finds the parked key" \
+  "$(jq -r '.env.ANTHROPIC_CUSTOM_HEADERS // ""' "$off_home/.claude/.weave-parked.json" 2>/dev/null \
+     | sed -n 's/^X-Weave-Router-Key: //p')" \
+  "rk_off"
+check "update while off preserves the custom base URL, not the hosted default" \
+  "$(jq -r '.env.ANTHROPIC_BASE_URL // ""' "$off_settings")" "$custom_url"
 
 echo
 echo "$pass passed, $fail failed"

--- a/install/tests/key_reuse_test.sh
+++ b/install/tests/key_reuse_test.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+#
+# Regression tests for Claude Code key reuse, --rotate-key, and `update`.
+#
+# Fully offline: an isolated $HOME keeps real config untouched and a fake curl
+# (always exit 22) stands in for the /health + /validate probes, so no case
+# reaches the network. Run directly or via `make test-install`.
+
+set -uo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+installer="${INSTALLER:-$script_dir/../install.sh}"
+[ -f "$installer" ] || { echo "cannot find installer at $installer" >&2; exit 1; }
+
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+
+fake_bin="$work/bin"
+mkdir -p "$fake_bin"
+printf '%s\n' '#!/usr/bin/env bash' 'exit 22' >"$fake_bin/curl"
+chmod +x "$fake_bin/curl"
+test_path="$fake_bin:$PATH"
+
+pass=0
+fail=0
+ok() { echo "  ok   $1"; pass=$((pass + 1)); }
+no() { echo "  FAIL $1"; echo "         expected: $2"; echo "         actual:   $3"; fail=$((fail + 1)); }
+
+check() { # check <name> <actual> <expected>
+  if [ "$2" = "$3" ]; then ok "$1"; else no "$1" "$3" "$2"; fi
+}
+
+# run <home> [env KEY=...] -- <installer args...>
+# Runs the installer with an isolated HOME and no controlling terminal on stdin,
+# so any code path that would prompt fails loudly instead of hanging the suite.
+run() {
+  local home="$1"; shift
+  local key=""
+  if [ "${1:-}" != "--" ]; then key="$1"; shift; fi
+  [ "${1:-}" = "--" ] && shift
+  HOME="$home" XDG_CACHE_HOME="$home/.cache" PATH="$test_path" NO_COLOR=1 \
+    WEAVE_ROUTER_KEY="$key" \
+    bash "$installer" "$@" --base-url http://127.0.0.1:9 </dev/null >/dev/null 2>&1
+}
+
+installed_key() { # installed_key <settings_file>
+  jq -r '.env.ANTHROPIC_CUSTOM_HEADERS // ""' "$1" 2>/dev/null \
+    | sed -n 's/^X-Weave-Router-Key: //p'
+}
+
+echo "install.sh key reuse"
+
+# ---------- user scope ----------
+
+home="$work/user"; mkdir -p "$home"
+settings="$home/.claude/settings.json"
+
+run "$home" rk_first -- --claude --scope user --quiet --non-interactive
+check "first install stores the env key" "$(installed_key "$settings")" "rk_first"
+
+# The complaint this exists for: re-running to pick up new assets must not
+# demand the key again. Without read-back this is a hard exit 1.
+run "$home" -- --claude --scope user --quiet --non-interactive
+check "re-run with no env var succeeds" "$?" 0
+check "re-run keeps the installed key" "$(installed_key "$settings")" "rk_first"
+
+# Env must stay the highest-precedence source: a rotated key exported by the
+# user cannot be silently ignored in favor of the stale one on disk.
+run "$home" rk_second -- --claude --scope user --quiet --non-interactive
+check "env key overwrites the installed key" "$(installed_key "$settings")" "rk_second"
+
+# --rotate-key deliberately skips read-back. With no env and no tty there is
+# nothing to rotate to, so it must fail rather than reuse or hang.
+run "$home" -- --claude --scope user --quiet --non-interactive --rotate-key
+check "--rotate-key with no key source fails" "$?" 1
+check "--rotate-key failure leaves the key intact" "$(installed_key "$settings")" "rk_second"
+
+# ---------- project scope ----------
+#
+# The key lives in the gitignored settings.local.json here, not settings.json,
+# so read-back has to look in a different place than user scope.
+
+proj_home="$work/project-home"; proj="$work/project"
+mkdir -p "$proj_home" "$proj"
+git -C "$proj" init -q .
+local_settings="$proj/.claude/settings.local.json"
+
+( cd "$proj" && run "$proj_home" rk_proj -- --claude --scope project --quiet --non-interactive )
+check "project install stores the key locally" "$(installed_key "$local_settings")" "rk_proj"
+( cd "$proj" && run "$proj_home" -- --claude --scope project --quiet --non-interactive )
+check "project re-run reuses settings.local.json key" "$(installed_key "$local_settings")" "rk_proj"
+
+# ---------- update ----------
+
+upd_home="$work/update"; mkdir -p "$upd_home"
+upd_settings="$upd_home/.claude/settings.json"
+
+# update against a machine with no install must error, not prompt or no-op.
+run "$upd_home" -- update --claude
+check "update with no installed key errors" "$?" 1
+[ ! -f "$upd_settings" ] && ok "update with no key wrote no settings" \
+  || no "update with no key wrote no settings" "no settings.json" "file exists"
+
+run "$upd_home" rk_upd -- --claude --scope user --quiet --non-interactive
+# The fake curl rejects /validate, and update treats that as fatal (unlike
+# install's warn) so cron catches a revoked key instead of logging past it.
+run "$upd_home" -- update --claude
+check "update surfaces a rejected key as an error" "$?" 1
+check "update still refreshed the config" "$(installed_key "$upd_settings")" "rk_upd"
+
+# --quiet downgrades that to a warning: quiet callers opted out of the noise
+# and out of a nonzero exit for a config refresh that did land.
+run "$upd_home" -- update --claude --quiet
+check "quiet update exits 0 despite the rejection" "$?" 0
+
+# update never prompts, so it has no use for a flag whose whole job is to force
+# one. Accepting it silently would look like rotation happened.
+run "$upd_home" -- update --claude --rotate-key
+check "update rejects --rotate-key" "$?" 2
+
+# Only Claude Code is wired up; the other targets must say so rather than
+# half-running an install path that still expects a prompt.
+run "$upd_home" -- update --codex
+check "update rejects an unsupported target" "$?" 2
+
+# ---------- command baseline seeding ----------
+#
+# The statusline's background wrapper refresh only swaps a file whose bytes
+# match the last canonical copy. install.sh seeds that baseline so a fresh
+# install doesn't burn an interval establishing one. Both sides key the cache
+# on the physical command-dir path, so resolve it the same way here — on macOS
+# mktemp hands back /var/... for /private/var/....
+cmd_dir_real="$(cd "$upd_home/.claude/commands" && pwd -P)"
+baseline="$upd_home/.cache/weave-router/commands$(printf '%s' "$cmd_dir_real" | tr -c 'A-Za-z0-9._-' '_')"
+if [ -f "$baseline/force-model.md" ] && [ -f "$baseline/router-off.md" ]; then
+  ok "install seeds the slash-command baseline"
+else
+  no "install seeds the slash-command baseline" "canonical wrappers cached" "missing under $baseline"
+fi
+# Baselines are the UNRENDERED canonical files: the refresh renders {{SCOPE}}
+# per install, and a pre-rendered baseline would never match upstream.
+if grep -q '{{SCOPE}}' "$baseline/router-off.md" 2>/dev/null; then
+  ok "seeded baseline keeps the {{SCOPE}} placeholder"
+else
+  no "seeded baseline keeps the {{SCOPE}} placeholder" "unrendered copy" "placeholder substituted"
+fi
+
+echo
+echo "$pass passed, $fail failed"
+[ "$fail" -eq 0 ]

--- a/install/tests/key_reuse_test.sh
+++ b/install/tests/key_reuse_test.sh
@@ -152,9 +152,15 @@ fi
 # and into .weave-parked.json. A re-run while toggled off must still find the key
 # there (not demand a fresh paste) and must not silently retarget the endpoint at
 # the hosted default just because --base-url wasn't repeated.
+#
+# It must also leave the toggle in a coherent state: an update rewrites the full
+# router config live, so it re-enables the router and has to consume the sidecar.
+# Leaving it behind desyncs the toggle — `status` would keep reporting off while
+# traffic routes through the router, and `off` would no-op instead of undoing it.
 
 off_home="$work/off"; mkdir -p "$off_home"
 off_settings="$off_home/.claude/settings.json"
+off_parked="$off_home/.claude/.weave-parked.json"
 custom_url="http://custom-router.internal:9999"
 
 HOME="$off_home" XDG_CACHE_HOME="$off_home/.cache" PATH="$test_path" NO_COLOR=1 \
@@ -169,12 +175,21 @@ check "off parks the router key, not settings.json" "$(installed_key "$off_setti
 # carry-over behavior this checks.
 HOME="$off_home" XDG_CACHE_HOME="$off_home/.cache" PATH="$test_path" NO_COLOR=1 \
   bash "$installer" update --claude </dev/null >/dev/null 2>&1
-check "update while off finds the parked key" \
-  "$(jq -r '.env.ANTHROPIC_CUSTOM_HEADERS // ""' "$off_home/.claude/.weave-parked.json" 2>/dev/null \
-     | sed -n 's/^X-Weave-Router-Key: //p')" \
-  "rk_off"
+check "update while off recovers the parked key into settings.json" \
+  "$(installed_key "$off_settings")" "rk_off"
 check "update while off preserves the custom base URL, not the hosted default" \
   "$(jq -r '.env.ANTHROPIC_BASE_URL // ""' "$off_settings")" "$custom_url"
+
+# The sidecar has to be gone, or the toggle is desynced from what's live.
+[ ! -f "$off_parked" ] && ok "update while off consumes the parked sidecar" \
+  || no "update while off consumes the parked sidecar" "sidecar removed" "file still present"
+
+# The real symptom of a desync: `off` silently no-ops because the stale sidecar
+# makes it think it's already off, leaving router config live with no way back.
+HOME="$off_home" PATH="$test_path" NO_COLOR=1 \
+  bash "$installer" off --claude </dev/null >/dev/null 2>&1
+check "off still works after an update that ran while off" \
+  "$(installed_key "$off_settings")" ""
 
 echo
 echo "$pass passed, $fail failed"

--- a/install/tests/key_reuse_test.sh
+++ b/install/tests/key_reuse_test.sh
@@ -191,6 +191,38 @@ HOME="$off_home" PATH="$test_path" NO_COLOR=1 \
 check "off still works after an update that ran while off" \
   "$(installed_key "$off_settings")" ""
 
+# ---------- project scope: update while off must drop the direct override ----------
+#
+# In project scope `off` parks settings.local.json's env and then overrides
+# ANTHROPIC_BASE_URL to Anthropic *in that same file*, since the committed
+# settings.json (shared by the team) never carries the off state. write_claude_settings'
+# local-file merge has to strip that override same as it strips the old auth
+# headers, or it silently wins over the freshly-written router URL and a
+# "successful" update leaves Claude Code talking straight to Anthropic.
+
+proj_off_home="$work/project-off"; proj_off="$work/project-off-repo"
+mkdir -p "$proj_off_home" "$proj_off"
+git -C "$proj_off" init -q .
+proj_off_settings="$proj_off/.claude/settings.json"
+proj_off_local="$proj_off/.claude/settings.local.json"
+
+( cd "$proj_off" && HOME="$proj_off_home" XDG_CACHE_HOME="$proj_off_home/.cache" PATH="$test_path" NO_COLOR=1 \
+    WEAVE_ROUTER_KEY="rk_proj_off" \
+    bash "$installer" --claude --scope project --quiet --non-interactive </dev/null >/dev/null 2>&1 )
+( cd "$proj_off" && HOME="$proj_off_home" PATH="$test_path" NO_COLOR=1 \
+    bash "$installer" off --claude --scope project </dev/null >/dev/null 2>&1 )
+check "project off overrides settings.local.json's base URL" \
+  "$(jq -r '.env.ANTHROPIC_BASE_URL // ""' "$proj_off_local")" "https://api.anthropic.com"
+
+( cd "$proj_off" && HOME="$proj_off_home" XDG_CACHE_HOME="$proj_off_home/.cache" PATH="$test_path" NO_COLOR=1 \
+    bash "$installer" update --claude --scope project </dev/null >/dev/null 2>&1 )
+check "update while off (project scope) recovers the key into settings.local.json" \
+  "$(installed_key "$proj_off_local")" "rk_proj_off"
+check "update while off (project scope) drops the direct-to-Anthropic override" \
+  "$(jq -r '.env.ANTHROPIC_BASE_URL // ""' "$proj_off_local")" ""
+check "update while off (project scope) leaves the router URL live in settings.json" \
+  "$(jq -r '.env.ANTHROPIC_BASE_URL // ""' "$proj_off_settings")" "https://router.workweave.ai"
+
 echo
 echo "$pass passed, $fail failed"
 [ "$fail" -eq 0 ]


### PR DESCRIPTION
Makes two changes to the Claude Code router setup:
1. Uses your existing key if possible when running `npx @workweave/router` for an existing install
2. Auto updates the installed files (e.g. skill definitions)

🤖 Generated with [Weave Router](https://router.workweave.ai)