### PR TITLE
feat(routing): route harness-protocol turns up, never down; auto-detect claimed-tool-unavailable

### DIFF
--- a/cmd/router/main.go
+++ b/cmd/router/main.go
@@ -568,6 +568,9 @@ func main() {
 	// Enforcing text-repetition break ships enabled; the switch is the kill
 	// switch if it ever false-positives on legit repeated narration.
 	textRepetitionBreakEnabled := config.GetOr("ROUTER_TEXT_REPETITION_BREAK_ENABLED", "true") == "true"
+	// Harness-protocol escalation clamp ships enabled; the switch exists so a
+	// misdetection (turntype false positive) can be killed without a redeploy.
+	harnessEscalationEnabled := config.GetOr("ROUTER_HARNESS_ESCALATION_ENABLED", "true") == "true"
 	plannerCfg := planner.EVConfig{
 		ThresholdUSD:           parseEnvFloat("ROUTER_SWITCH_EV_THRESHOLD_USD", proxy.DefaultPlannerThresholdUSD),
 		ExpectedRemainingTurns: parseEnvInt("ROUTER_SWITCH_EXPECTED_REMAINING_TURNS", proxy.DefaultPlannerExpectedRemainingTurns),
@@ -783,6 +786,7 @@ func main() {
 		WithBandSwap(bandSwapEnabled).
 		WithLoopEscalationConfig(loopEscalationEnabled, loopEscalationHoldoutPct).
 		WithLoopEscalationStore(repo.Telemetry).
+		WithHarnessEscalationConfig(harnessEscalationEnabled).
 		WithSpiralShadowConfig(spiralShadowEnabled).
 		WithSpiralShadowStore(repo.Telemetry).
 		WithTextRepetitionBreak(textRepetitionBreakEnabled).
@@ -800,6 +804,7 @@ func main() {
 	logger.Info("Effort escalation configured", "enabled", effortEscalation)
 	logger.Info("Cross-vendor Claude Code orchestration tools configured", "enabled", ccOrchToolsCrossVendor)
 	logger.Info("Loop escalation configured", "enabled", loopEscalationEnabled, "holdout_pct", loopEscalationHoldoutPct)
+	logger.Info("Harness escalation configured", "enabled", harnessEscalationEnabled)
 	logger.Info("Spiral shadow detector configured", "enabled", spiralShadowEnabled)
 	logger.Info("Text-repetition break configured", "enabled", textRepetitionBreakEnabled)
 	logger.Info("Planner configured", "enabled", plannerEnabled, "threshold_usd", plannerCfg.ThresholdUSD, "expected_remaining_turns", plannerCfg.ExpectedRemainingTurns, "tier_upgrade_enabled", plannerCfg.TierUpgradeEnabled, "cold_pin_follow_fresh", plannerCfg.ColdPinFollowFresh, "prefix_trim_free_switch", prefixTrimFreeSwitch, "routing_targets_count", len(routingTargets))

--- a/internal/proxy/claimed_tool_unavailable.go
+++ b/internal/proxy/claimed_tool_unavailable.go
@@ -1,0 +1,332 @@
+// The claimed-tool-unavailable detector flags a routed model that says a
+// tool is not in its toolset while the request actually declared that tool —
+// a detectable model failure. Post-stream: capture-gated (no respBody means
+// no-op, e.g. self-hosted no-capture deploys). Persist-only — writes a
+// source="auto" negative RouterFeedbackEvent offline; it never influences
+// routing, pins, or the live reward loop (ML consumes the auto rows offline).
+package proxy
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"time"
+
+	"workweave/router/internal/auth"
+	"workweave/router/internal/observability"
+	"workweave/router/internal/router/sessionpin"
+
+	"github.com/google/uuid"
+	lru "github.com/hashicorp/golang-lru/v2/expirable"
+	"github.com/tidwall/gjson"
+)
+
+// claimedUnavailablePhrases are the "claimed unavailable" tell-strings matched
+// against the lowercased ±160-byte window around a declared tool name. Each is
+// a loose substring: "not available" captures "is not available" / "not
+// available in my toolset", "don't have access" covers "I don't have access".
+// Keep this a package var so tests pin the exact list.
+var claimedUnavailablePhrases = []string{
+	"not available",
+	"isn't available",
+	"is unavailable",
+	"no such tool",
+	"not in my",
+	"not directly callable",
+	"not callable",
+	"don't have access",
+	"do not have access",
+	"have no access",
+	"no mechanism to load",
+	"not a loadable",
+	"not exposed",
+	"not in my available toolset",
+}
+
+// claimedTool... knobs for the claimed-tool-unavailable tracker — size/TTL
+// mirror the spiral detector's shape (spiral_detection.go:172-175).
+const (
+	// claimedToolFiredCacheSize bounds the per-replica dedup LRU.
+	claimedToolFiredCacheSize = 4096
+	// claimedToolFiredCacheTTL is how long a fired (session, role, tool)
+	// stays suppressed on this replica. The durable once-per-event budget is
+	// cheap; this only trims repeat rows for very long sessions.
+	claimedToolFiredCacheTTL = 24 * time.Hour
+	// claimedToolWindowBytes is the lowercased window scanned around each
+	// declared tool-name occurrence. Long enough to span "There is no ... tool
+	// in my available toolset"-style sentences, short enough to not match a
+	// "not available" elsewhere in a long reply.
+	claimedToolWindowBytes = 160
+	// claimedToolNoPrecedeBytes is how far before an occurrence "no " /
+	// "there is no " (the "no <tool> tool" signal) is checked.
+	claimedToolNoPrecedeBytes = 24
+	// claimedToolMaxFindings caps findings per response so one reply can't
+	// spam the dedup keys.
+	claimedToolMaxFindings = 4
+	// claimedToolScanMaxBytes bounds the text extracted from captured bytes.
+	claimedToolScanMaxBytes = 262144
+)
+
+// claimedToolTracker de-dupes automatic negative feedback fires per
+// (session, role, tool) on this replica, mirroring spiralTracker's shape.
+type claimedToolTracker struct {
+	fired *lru.LRU[string, struct{}]
+}
+
+func newClaimedToolTracker() *claimedToolTracker {
+	return &claimedToolTracker{
+		fired: lru.NewLRU[string, struct{}](claimedToolFiredCacheSize, nil, claimedToolFiredCacheTTL),
+	}
+}
+
+func claimedToolFiredKey(sessionKey [sessionpin.SessionKeyLen]byte, role, tool string) string {
+	return string(sessionKey[:]) + "\x00" + role + "\x00" + tool
+}
+
+// claimedToolUnavailableFromBody extracts the model's response text from the
+// captured client-bound bytes — Anthropic SSE frames when streaming, a single
+// JSON body otherwise — and reports the declared tools it claims unavailable.
+// Malformed/truncated input fails open (returns no findings): the capture cap
+// can cut mid-frame, and this detector must never error or panic.
+func claimedToolUnavailableFromBody(respBody []byte, streaming bool, availableTools []string) []string {
+	if !streaming {
+		return detectClaimedToolUnavailable(nonStreamingText(respBody), availableTools)
+	}
+	var text strings.Builder
+	text.Grow(len(respBody) / 2)
+	scanCap := claimedToolScanMaxBytes
+	for _, rawLine := range bytes.Split(respBody, []byte("\n")) {
+		if !bytes.HasPrefix(rawLine, []byte("data: ")) {
+			continue
+		}
+		data := bytes.TrimRight(rawLine[len("data: "):], "\r")
+		if string(data) == "[DONE]" {
+			continue
+		}
+		frame := gjson.ParseBytes(data)
+		if frame.Get("type").String() != "content_block_delta" {
+			continue
+		}
+		if frame.Get("delta.type").String() != "text_delta" {
+			continue
+		}
+		delta := frame.Get("delta.text").String()
+		if delta == "" {
+			continue
+		}
+		if len(delta) > scanCap {
+			delta = delta[:scanCap]
+		}
+		text.WriteString(delta)
+		scanCap -= len(delta)
+		if scanCap <= 0 {
+			break
+		}
+	}
+	return detectClaimedToolUnavailable(text.String(), availableTools)
+}
+
+// nonStreamingText gathers text from a single JSON response body: content
+// blocks with type == "text". Any other shape yields no text (fail open).
+func nonStreamingText(respBody []byte) string {
+	content := gjson.GetBytes(respBody, "content")
+	if !content.IsArray() {
+		return ""
+	}
+	var text strings.Builder
+	text.Grow(len(respBody) / 2)
+	scanCap := claimedToolScanMaxBytes
+	content.ForEach(func(_, block gjson.Result) bool {
+		if block.Get("type").String() != "text" {
+			return true
+		}
+		blockText := block.Get("text").String()
+		if len(blockText) > scanCap {
+			blockText = blockText[:scanCap]
+		}
+		text.WriteString(blockText)
+		scanCap -= len(blockText)
+		return scanCap > 0
+	})
+	return text.String()
+}
+
+// detectClaimedToolUnavailable scans text for each declared tool name and
+// reports the names the model claims unavailable. Name matching is
+// case-SENSITIVE with word boundaries (a name nested inside a longer
+// identifier does not count); around each occurrence a lowercased
+// ±claimedToolWindowBytes window is checked against claimedUnavailablePhrases,
+// or a "no "/"there is no " immediately preceding the name. Returns deduped
+// findings capped at claimedToolMaxFindings. Pure — unit-test directly.
+func detectClaimedToolUnavailable(text string, availableTools []string) []string {
+	if text == "" || len(availableTools) == 0 {
+		return nil
+	}
+	var findings []string
+	for _, tool := range availableTools {
+		if tool == "" {
+			continue
+		}
+		if containsClaimedUnavailable(text, tool) {
+			findings = append(findings, tool)
+			if len(findings) >= claimedToolMaxFindings {
+				break
+			}
+		}
+	}
+	return findings
+}
+
+// containsClaimedUnavailable reports whether any word-boundary occurrence of
+// tool in text sits next to an unavailable-claim. Iterates all occurrences:
+// the model may mention the tool normally and deny it later in the same reply.
+func containsClaimedUnavailable(text, tool string) bool {
+	lower := strings.ToLower(text)
+	for offset := 0; offset < len(text); {
+		idx := strings.Index(text[offset:], tool)
+		if idx < 0 {
+			break
+		}
+		idx += offset
+		start, end := idx, idx+len(tool)
+		if !leftIdentifierEdge(text, start) || !rightIdentifierEdge(text, end) {
+			offset = idx + len(tool)
+			continue
+		}
+		if windowClaimsUnavailable(lower, start, end) {
+			return true
+		}
+		offset = idx + len(tool)
+	}
+	return false
+}
+
+// leftIdentifierEdge reports whether i is a clean left identifier edge: text
+// start, or preceded by a byte that is not identifier-class.
+func leftIdentifierEdge(s string, i int) bool {
+	return i == 0 || !isIdentifierClass(s[i-1])
+}
+
+// rightIdentifierEdge reports whether i (just past an occurrence) is a clean
+// right identifier edge: text end, or followed by a byte that is not
+// identifier-class.
+func rightIdentifierEdge(s string, i int) bool {
+	return i >= len(s) || !isIdentifierClass(s[i])
+}
+
+// isIdentifierClass is the identifier-boundary class: ASCII letter, digit, or
+// underscore. Bytes >= 0x80 count as boundaries (a surrounding non-ASCII
+// character must never break a match), and single-byte reads avoid any
+// partial-rune decoding on multibyte text.
+func isIdentifierClass(b byte) bool {
+	return (b >= 'a' && b <= 'z') || (b >= 'A' && b <= 'Z') || (b >= '0' && b <= '9') || b == '_'
+}
+
+// windowClaimsUnavailable checks the "no <tool> tool" precede signal (a "no "
+// or "there is no " ending within claimedToolNoPrecedeBytes before the match)
+// and the lowercased ±claimedToolWindowBytes window around the occurrence for
+// any claimedUnavailablePhrases entry.
+func windowClaimsUnavailable(lower string, occStart, occEnd int) bool {
+	// The direct precedent: "...no " / "...there is no " ending immediately
+	// before the name. Covers "no <name> tool" without needing a window phrase.
+	before := occStart
+	if before > claimedToolNoPrecedeBytes {
+		before = claimedToolNoPrecedeBytes
+	}
+	if endsWithNoPhrase(lower[occStart-before : occStart]) {
+		return true
+	}
+	lo := occStart - claimedToolWindowBytes
+	if lo < 0 {
+		lo = 0
+	}
+	hi := occEnd + claimedToolWindowBytes
+	if hi > len(lower) {
+		hi = len(lower)
+	}
+	window := lower[lo:hi]
+	for _, phrase := range claimedUnavailablePhrases {
+		if strings.Contains(window, phrase) {
+			return true
+		}
+	}
+	return false
+}
+
+// endsWithNoPhrase reports whether the lowercased text ending at the tool
+// name ends with "no " or "there is no " — i.e. the name was introduced by a
+// durative negation ("There is no ToolSearch tool in my available toolset").
+func endsWithNoPhrase(lower string) bool {
+	pre := strings.TrimRight(lower, " \t")
+	return strings.HasSuffix(pre, "no") || strings.HasSuffix(pre, "there is no")
+}
+
+// maybeReportClaimedToolUnavailable persists one source="auto" negative
+// RouterFeedbackEvent per (session, role, tool) when the captured response
+// text claims a declared tool is unavailable. Best-effort and off the
+// response path: capture-gated (no respBody -> no-op), never influences
+// routing, and hard stops on nil deps.
+func (s *Service) maybeReportClaimedToolUnavailable(
+	ctx context.Context,
+	respBody []byte,
+	streaming bool,
+	availableTools []string,
+	installationID uuid.UUID,
+	sessionKey [sessionpin.SessionKeyLen]byte,
+	role string,
+	requestedModel string,
+	servedModel string,
+	requestID string,
+	routeID string,
+	clientID ClientIdentity,
+) {
+	if s.feedbackStore == nil || s.claimedToolTracker == nil {
+		return
+	}
+	if installationID == uuid.Nil || len(respBody) == 0 || len(availableTools) == 0 {
+		return
+	}
+	found := claimedToolUnavailableFromBody(respBody, streaming, availableTools)
+	if len(found) == 0 {
+		return
+	}
+	log := observability.FromContext(ctx)
+	routerUserID := auth.UserIDFrom(ctx)
+	for _, tool := range found {
+		key := claimedToolFiredKey(sessionKey, role, tool)
+		if _, seen := s.claimedToolTracker.fired.Get(key); seen {
+			continue
+		}
+		log.Info("router.claimed_tool_unavailable",
+			"tool", tool,
+			"served_model", servedModel,
+			"requested_model", requestedModel,
+			"request_id", requestID,
+			"session_key_prefix", shortSessionKey(sessionKey),
+			"role", role,
+		)
+		event := RouterFeedbackEvent{
+			InstallationID: installationID.String(),
+			SessionKey:     sessionKey[:],
+			Role:           role,
+			RouterUserID:   routerUserID,
+			ClientApp:      clientID.ClientApp,
+			SessionID:      clientID.SessionID,
+			RequestedModel: requestedModel,
+			ServedModel:    servedModel,
+			Rating:         "down",
+			Feedback:       "claimed-tool-unavailable:" + tool,
+			Source:         RouterFeedbackSourceAuto,
+			RequestID:      requestID,
+			RouteID:        routeID,
+		}
+		// context.Background(): the request ctx may already be canceled by the
+		// time this runs post-stream; losing the row would drop the failing
+		// turn from the auto corpus.
+		if err := s.feedbackStore.InsertRouterFeedback(context.Background(), event); err != nil {
+			log.Error("router.claimed_tool_unavailable: feedback insert failed", "err", err)
+			continue // leave the LRU unset so the next turn retries
+		}
+		s.claimedToolTracker.fired.Add(key, struct{}{})
+	}
+}

--- a/internal/proxy/claimed_tool_unavailable_internal_test.go
+++ b/internal/proxy/claimed_tool_unavailable_internal_test.go
@@ -1,0 +1,321 @@
+package proxy
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"sync"
+	"testing"
+
+	"workweave/router/internal/router/sessionpin"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// claimedToolFakeStore captures RouterFeedbackEvents for method-level tests;
+// clusters, so the dedupe path (one insert per [session, role, tool]) is
+// directly observable. err supplies insert failures on demand.
+type claimedToolFakeStore struct {
+	mu     sync.Mutex
+	events []RouterFeedbackEvent
+	err    error
+}
+
+func (f *claimedToolFakeStore) InsertRouterFeedback(ctx context.Context, p RouterFeedbackEvent) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.err != nil {
+		return f.err
+	}
+	f.events = append(f.events, p)
+	return nil
+}
+
+func (f *claimedToolFakeStore) snap() []RouterFeedbackEvent {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]RouterFeedbackEvent(nil), f.events...)
+}
+
+func claimedToolHost() (uuid.UUID, [sessionpin.SessionKeyLen]byte) {
+	return uuid.New(), sessionKeyFromString("claimed-tool-test")
+}
+
+func claimedToolService(store RouterFeedbackStore) *Service {
+	if store == nil {
+		store = &claimedToolFakeStore{}
+	}
+	return &Service{
+		feedbackStore:      store,
+		claimedToolTracker: newClaimedToolTracker(),
+	}
+}
+
+func TestDetectClaimedToolUnavailable_Positives(t *testing.T) {
+	cases := []struct {
+		name string
+		text string
+		tool string
+	}{
+		{"no-tool-in-toolset", "There is no ToolSearch tool in my available toolset", "ToolSearch"},
+		{"not-directly-callable", "EnterPlanMode is not directly callable, so I'll just edit the file", "EnterPlanMode"},
+		{"dont-have-access", "I don't have access to the Read tool right now", "Read"},
+		{"isn't-available", "The Bash tool isn't available in this environment", "Bash"},
+		{"there-is-no-precede", "sorry, there is no WebSearch tool that I can call", "WebSearch"},
+		{"not-exposed", "The Read tool is not exposed in this toolset", "Read"},
+		{"tool-name-in-backticks", "the `WebSearch` tool is not callable here", "WebSearch"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			found := detectClaimedToolUnavailable(tc.text, []string{tc.tool})
+			assert.Equal(t, []string{tc.tool}, found)
+		})
+	}
+}
+
+func TestDetectClaimedToolUnavailable_WindowBoundary(t *testing.T) {
+	// Pins both sides of the ±claimedToolWindowBytes window. With two filler
+	// sentences (~100 bytes) the claim phrase starts ~140 bytes after the name
+	// and is inside the window; with four (~200 bytes) it falls outside and
+	// must not fire.
+	filler := "I will run the search and summarize what I find. "
+	inside := `That's fine — ToolSearch for the workspace is active, ` +
+		strings.Repeat(filler, 2) +
+		`but it is not available from this agent, so I'll skip it`
+	assert.Equal(t, []string{"ToolSearch"}, detectClaimedToolUnavailable(inside, []string{"ToolSearch"}))
+
+	outside := `That's fine — ToolSearch for the workspace is active, ` +
+		strings.Repeat(filler, 4) +
+		`but it is not available from this agent, so I'll skip it`
+	assert.Empty(t, detectClaimedToolUnavailable(outside, []string{"ToolSearch"}))
+}
+
+func TestDetectClaimedToolUnavailable_Negatives(t *testing.T) {
+	cases := []struct {
+		name string
+		text string
+		tool string
+	}{
+		{"tool-praised-normally", "I'll use ToolSearch to load the needed files", "ToolSearch"},
+		{"name-as-substring", "MyToolSearchWrapper is not available in this build", "ToolSearch"},
+		{"phrase-mismatched-case", "there is no toolsearch tool in my available toolset", "ToolSearch"},
+		{"name-flanked-by-ass,no-claim", "ToolSearch_extra is fine", "ToolSearch"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			found := detectClaimedToolUnavailable(tc.text, []string{tc.tool})
+			assert.Empty(t, found)
+		})
+	}
+}
+
+func TestDetectClaimedToolUnavailable_PhraseAboutUndeclaredTool(t *testing.T) {
+	// "Bash" is claimed unavailable, but only ToolSearch was declared — the
+	// scan matches declared names exclusively, so it must not fire.
+	found := detectClaimedToolUnavailable(
+		"I don't have access to the Bash tool here", []string{"ToolSearch"})
+	assert.Empty(t, found)
+}
+
+func TestDetectClaimedToolUnavailable_PhraseBeyondWindow(t *testing.T) {
+	// The name and the claim are separated by far more than 160 bytes.
+	padding := strings.Repeat("lorem ipsum dolor sit amet consectetur ", 60)
+	text := "ToolSearch can be tried via Bash. " + padding + "it is not available today."
+	found := detectClaimedToolUnavailable(text, []string{"ToolSearch"})
+	assert.Empty(t, found)
+}
+
+func TestDetectClaimedToolUnavailable_EmptyText(t *testing.T) {
+	assert.Empty(t, detectClaimedToolUnavailable("", []string{"ToolSearch"}))
+	assert.Empty(t, detectClaimedToolUnavailable("no claim here", nil))
+}
+
+func TestDetectClaimedToolUnavailable_DedupesAndCaps(t *testing.T) {
+	tools := []string{"Read", "Write", "WebSearch", "Bash", "Task"}
+	text := `I don't have access to Read, Write, WebSearch, Bash, or Task here.`
+	found := detectClaimedToolUnavailable(text, tools)
+	// All five were declared and (within 160 bytes of each name) claimed
+	// unavailable — but findings are deduped by name and capped at 4.
+	assert.Len(t, found, claimedToolMaxFindings)
+	seen := map[string]bool{}
+	for _, f := range found {
+		assert.False(t, seen[f], "duplicate finding %q", f)
+		seen[f] = true
+	}
+}
+
+func TestClaimedToolUnavailableFromBody_SSEAcrossDeltas(t *testing.T) {
+	sse := strings.Join([]string{
+		"event: message_start",
+		`data: {"type":"message_start","message":{"id":"msg_1","role":"assistant"}}`,
+		"",
+		"event: content_block_start",
+		`data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}`,
+		"",
+		"event: content_block_delta",
+		`data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"I'd like to use "}}`,
+		"",
+		"event: content_block_delta",
+		`data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"the ToolSearch "}}`,
+		"",
+		"event: content_block_delta",
+		`data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"tool, but there is "}}`,
+		"",
+		"event: content_block_delta",
+		`data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"no such tool here."}}`,
+		"",
+		"event: content_block_delta",
+		`data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"shrug"}}`,
+		"",
+		"event: content_block_delta",
+		`data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"{}"}}`,
+		"",
+		"event: content_block_stop",
+		`data: {"type":"content_block_stop","index":0}`,
+		"",
+		"event: message_stop",
+		`data: {"type":"message_stop"}`,
+		"",
+	}, "\n")
+
+	found := claimedToolUnavailableFromBody([]byte(sse), true, []string{"ToolSearch"})
+	// The claim is split across four text_delta frames; extraction
+	// concatenates them, so the phrase is still detected.
+	assert.Equal(t, []string{"ToolSearch"}, found)
+}
+
+func TestClaimedToolUnavailableFromBody_SSEMalformedFailsOpen(t *testing.T) {
+	// Truncated mid-frame JSON and a bare data line (no space) must not error
+	// or panic, and must produce no findings.
+	bad := []byte("event: content_block_delta\ndata: {\"type\":\"content_")
+	require.NotPanics(t, func() {
+		assert.Empty(t, claimedToolUnavailableFromBody(bad, true, []string{"ToolSearch"}))
+	})
+	assert.Empty(t, claimedToolUnavailableFromBody(
+		[]byte("data:{\"type\":\"content_block_delta\"}\ndata: [DONE]"), true, []string{"ToolSearch"}))
+}
+
+func TestClaimedToolUnavailableFromBody_NonStreaming(t *testing.T) {
+	body := `{
+		"id": "msg_2",
+		"type": "message",
+		"role": "assistant",
+		"content": [
+			{"type": "text", "text": "I would normally use this."},
+			{"type": "text", "text": " The EnterPlanMode tool is not directly callable from my toolset."},
+			{"type": "tool_use", "id": "toolu_1", "name": "Edit", "input": {}}
+		]
+	}`
+	found := claimedToolUnavailableFromBody([]byte(body), false, []string{"EnterPlanMode", "Edit"})
+	assert.Equal(t, []string{"EnterPlanMode"}, found)
+}
+
+func TestClaimedToolUnavailableFromBody_NonStreamingMalformed(t *testing.T) {
+	assert.Empty(t, claimedToolUnavailableFromBody([]byte(`{"content": "notanarray"`), false, []string{"Read"}))
+	assert.Empty(t, claimedToolUnavailableFromBody([]byte(`{truncated`), false, []string{"Read"}))
+}
+
+func TestMaybeReportClaimedToolUnavailable_InsertsOneEvent(t *testing.T) {
+	store := &claimedToolFakeStore{}
+	svc := claimedToolService(store)
+	installationID, sessionKey := claimedToolHost()
+	body := []byte(`{"content":[{"type":"text","text":"There is no ToolSearch tool in my available toolset."}]}`)
+
+	svc.maybeReportClaimedToolUnavailable(
+		context.Background(), body, false, []string{"ToolSearch"},
+		installationID, sessionKey, "default_high", "claude-sonnet-5", "qwen3",
+		"req-1", "route-1", ClientIdentity{ClientApp: ClientAppClaudeCode, SessionID: "sess-1"},
+	)
+
+	events := store.snap()
+	require.Len(t, events, 1)
+	ev := events[0]
+	assert.Equal(t, installationID.String(), ev.InstallationID)
+	assert.Equal(t, []byte(sessionKey[:]), ev.SessionKey)
+	assert.Equal(t, "default_high", ev.Role)
+	assert.Equal(t, "claude-sonnet-5", ev.RequestedModel)
+	assert.Equal(t, "qwen3", ev.ServedModel)
+	assert.Equal(t, "down", ev.Rating)
+	assert.Equal(t, "claimed-tool-unavailable:ToolSearch", ev.Feedback)
+	assert.Equal(t, RouterFeedbackSourceAuto, ev.Source)
+	assert.Equal(t, "req-1", ev.RequestID)
+	assert.Equal(t, "route-1", ev.RouteID)
+	assert.Equal(t, ClientAppClaudeCode, ev.ClientApp)
+	assert.Equal(t, "sess-1", ev.SessionID)
+}
+
+func TestMaybeReportClaimedToolUnavailable_DedupesSecondCall(t *testing.T) {
+	store := &claimedToolFakeStore{}
+	svc := claimedToolService(store)
+	installationID, sessionKey := claimedToolHost()
+	body := []byte(`{"content":[{"type":"text","text":"I don't have access to the Read tool."}]}`)
+
+	svc.maybeReportClaimedToolUnavailable(
+		context.Background(), body, false, []string{"Read"},
+		installationID, sessionKey, "default_high", "a", "b", "req-1", "route-1", ClientIdentity{})
+	svc.maybeReportClaimedToolUnavailable(
+		context.Background(), body, false, []string{"Read"},
+		installationID, sessionKey, "default_high", "a", "b", "req-2", "route-1", ClientIdentity{})
+
+	events := store.snap()
+	require.Len(t, events, 1, "same (session, role, tool) must fire once")
+	assert.Equal(t, "req-1", events[0].RequestID)
+}
+
+func TestMaybeReportClaimedToolUnavailable_InsertErrorLeavesLRUUnset(t *testing.T) {
+	store := &claimedToolFakeStore{}
+	svc := claimedToolService(store)
+	installationID, sessionKey := claimedToolHost()
+	body := []byte(`{"content":[{"type":"text","text":"The Task tool is not callable here."}]}`)
+
+	store.err = errors.New("db down")
+	svc.maybeReportClaimedToolUnavailable(
+		context.Background(), body, false, []string{"Task"},
+		installationID, sessionKey, "default_high", "a", "b", "req-1", "route-1", ClientIdentity{})
+	require.Empty(t, store.snap(), "failed insert must not persist a row")
+
+	// Insert failure leaves the LRU unset, so a later turn retries and lands.
+	store.err = nil
+	svc.maybeReportClaimedToolUnavailable(
+		context.Background(), body, false, []string{"Task"},
+		installationID, sessionKey, "default_high", "a", "b", "req-2", "route-1", ClientIdentity{})
+	events := store.snap()
+	require.Len(t, events, 1)
+	assert.Equal(t, "claimed-tool-unavailable:Task", events[0].Feedback)
+}
+
+func TestMaybeReportClaimedToolUnavailable_NilStoreShortCircuits(t *testing.T) {
+	svc := &Service{feedbackStore: nil, claimedToolTracker: newClaimedToolTracker()}
+	installationID, sessionKey := claimedToolHost()
+	// No store: must not panic, must produce no events.
+	require.NotPanics(t, func() {
+		svc.maybeReportClaimedToolUnavailable(
+			context.Background(), []byte(`{"content":[{"type":"text","text":"no Read tool!"}]}`), false,
+			[]string{"Read"}, installationID, sessionKey, "default_high", "a", "b",
+			"req-1", "route-1", ClientIdentity{})
+	})
+}
+
+func TestMaybeReportClaimedToolUnavailable_NilInstallationShortCircuits(t *testing.T) {
+	store := &claimedToolFakeStore{}
+	svc := claimedToolService(store)
+	_, sessionKey := claimedToolHost()
+	svc.maybeReportClaimedToolUnavailable(
+		context.Background(), []byte(`{"content":[{"type":"text","text":"Read is not available."}]}`), false,
+		[]string{"Read"}, uuid.Nil, sessionKey, "default_high", "a", "b",
+		"req-1", "route-1", ClientIdentity{})
+	assert.Empty(t, store.snap(), "uuid.Nil installation must not persist feedback")
+}
+
+func TestMaybeReportClaimedToolUnavailable_NoAvailableToolsShortCircuits(t *testing.T) {
+	store := &claimedToolFakeStore{}
+	svc := claimedToolService(store)
+	installationID, sessionKey := claimedToolHost()
+	svc.maybeReportClaimedToolUnavailable(
+		context.Background(), []byte(`{"content":[{"type":"text","text":"Read is not available."}]}`), false,
+		nil, installationID, sessionKey, "default_high", "a", "b",
+		"req-1", "route-1", ClientIdentity{})
+	assert.Empty(t, store.snap(), "no declared tools must not produce a finding")
+}

--- a/internal/proxy/feedback.go
+++ b/internal/proxy/feedback.go
@@ -206,7 +206,10 @@ func (s *Service) feedbackFooter(clientApp string, tt turntype.TurnType) string 
 	if _, ok := terminalFeedbackClients[clientApp]; !ok {
 		return ""
 	}
-	if tt != turntype.MainLoop && tt != turntype.ToolResult {
+	// Base() so the harness variants (HarnessMeta/Recovery, whose underlying
+	// shape is MainLoop/ToolResult) still surface the footer; SubAgentHarnessMeta
+	// (-> SubAgentDispatch) stays excluded like any other sub-agent dispatch.
+	if tt.Base() != turntype.MainLoop && tt.Base() != turntype.ToolResult {
 		return ""
 	}
 	return feedbackFooterText

--- a/internal/proxy/harness_escalation.go
+++ b/internal/proxy/harness_escalation.go
@@ -1,0 +1,170 @@
+// The harness-protocol escalation clamp is a deterministic per-turn guard that
+// routes harness-bound turns UP, never down. Detected harness variants
+// (HarnessMeta, SubAgentHarnessMeta, Recovery — see turntype.HarnessEscalation)
+// operate the harness control plane (plan-mode tools, deferred-tool discovery,
+// recovery from harness-shape failures); a non-Anthropic or weak upstream that
+// hallucinates those primitives corrupts the client's harness state. So once
+// the routing decision resolves, if the chosen model is not a strong
+// Claude-family TierHigh model the decision is replaced with the escalation
+// target. The clamp is per-TURN and non-persisted — it only rewrites the
+// current decision; it never touches session pins, so the next turn routes
+// through the normal pipeline again.
+package proxy
+
+import (
+	"context"
+
+	"workweave/router/internal/observability"
+	"workweave/router/internal/providers"
+	"workweave/router/internal/router"
+	"workweave/router/internal/router/catalog"
+	"workweave/router/internal/translate"
+)
+
+// Harness-escalation action taxonomy, recorded per clamp attempt. Exactly one
+// applies. Mirrors the loop-escalation action-taxonomy comment style
+// (loop_detection.go): each name records why the clamp did or did not engage.
+const (
+	// harnessActionEscalated: the decision was replaced with escalateModel.
+	harnessActionEscalated = "escalated"
+	// harnessActionAlreadyStrong: the resolved decision is already a strong
+	// Claude-family model — the clamp is a no-op.
+	harnessActionAlreadyStrong = "already_strong"
+	// harnessActionUsageBypass: the caller's subscription usage-bypass outranks
+	// the clamp; the requested model is served straight through.
+	harnessActionUsageBypass = "usage_bypass"
+	// harnessActionHardPinned: an operator/planner hard pin outranks the clamp;
+	// the pinned decision is left in place.
+	harnessActionHardPinned = "hard_pinned"
+	// harnessActionUserForced: a /force-model pin (or x-weave-force-model)
+	// outranks the clamp; the forced model is left in place.
+	harnessActionUserForced = "user_forced"
+	// harnessActionAlreadyEscalated: the decision was already replaced by the
+	// loop-escalation pin (an earlier, stronger escalation) — no further clamp.
+	harnessActionAlreadyEscalated = "already_escalated"
+	// harnessActionDisabled: the ROUTER_HARNESS_ESCALATION_ENABLED kill switch
+	// is off; the clamp does not engage.
+	harnessActionDisabled = "disabled"
+	// harnessActionProviderIneligible: anthropic is not in the request's
+	// enabled-provider set (or the set is empty of anthropic), so the escalate
+	// target is unservable; the original decision stands.
+	harnessActionProviderIneligible = "provider_ineligible"
+	// harnessActionModelExcluded: the request's excluded-models set blocks
+	// escalateModel; the original decision stands.
+	harnessActionModelExcluded = "model_excluded"
+)
+
+// applyHarnessEscalation clamps a resolved harness-protocol turn decision to a
+// strong Claude-family model (route up, never down). It runs exactly once per
+// turn, after routing, as the single choke point on every decision path.
+//
+// The clamp is a deterministic decision rewrite and never errors: every branch
+// either leaves res.Decision untouched (logging why) or replaces it with
+// {anthropic, escalateModel}. Pins, PinTier, StickyHit and Fresh are never
+// mutated — the next turn routes fresh.
+func (s *Service) applyHarnessEscalation(ctx context.Context, res *turnLoopResult, req router.Request) {
+	if !res.TurnType.HarnessEscalation() {
+		return
+	}
+	log := observability.FromContext(ctx)
+
+	// Precedence: a subscription usage-bypass, an operator/planner hard pin, and
+	// a user /force-model pin each outrank the clamp (the same three that
+	// outrank loop escalation). A loop-escalation decision already landed on
+	// opus — a stronger escalation than this clamp — so it needs no rewrite.
+	switch {
+	case res.UsageBypass:
+		log.Info("router.harness_escalation",
+			"action", harnessActionUsageBypass,
+			"turn_type", string(res.TurnType),
+			"from_model", res.Decision.Model,
+			"from_provider", res.Decision.Provider,
+			"to_model", escalateModel,
+		)
+		return
+	case res.HardPinned:
+		log.Info("router.harness_escalation",
+			"action", harnessActionHardPinned,
+			"turn_type", string(res.TurnType),
+			"from_model", res.Decision.Model,
+			"from_provider", res.Decision.Provider,
+			"to_model", escalateModel,
+		)
+		return
+	case isUserForcedReason(res.Decision.Reason):
+		log.Info("router.harness_escalation",
+			"action", harnessActionUserForced,
+			"turn_type", string(res.TurnType),
+			"from_model", res.Decision.Model,
+			"from_provider", res.Decision.Provider,
+			"to_model", escalateModel,
+		)
+		return
+	case res.Decision.Reason == translate.ReasonLoopEscalation:
+		log.Info("router.harness_escalation",
+			"action", harnessActionAlreadyEscalated,
+			"turn_type", string(res.TurnType),
+			"from_model", res.Decision.Model,
+			"from_provider", res.Decision.Provider,
+			"to_model", escalateModel,
+		)
+		return
+	case !s.harnessEscalationEnabled:
+		log.Info("router.harness_escalation",
+			"action", harnessActionDisabled,
+			"turn_type", string(res.TurnType),
+			"from_model", res.Decision.Model,
+			"from_provider", res.Decision.Provider,
+			"to_model", escalateModel,
+		)
+		return
+	case catalog.IsClaudeFamily(res.Decision.Model) && catalog.TierFor(res.Decision.Model) >= catalog.TierHigh:
+		log.Info("router.harness_escalation",
+			"action", harnessActionAlreadyStrong,
+			"turn_type", string(res.TurnType),
+			"from_model", res.Decision.Model,
+			"from_provider", res.Decision.Provider,
+			"to_model", escalateModel,
+		)
+		return
+	}
+
+	// Eligible-provider / excluded-model guards: the escalate target must be
+	// servable for this request, or clamping would dead-end the turn.
+	if req.EnabledProviders != nil {
+		if _, ok := req.EnabledProviders[providers.ProviderAnthropic]; !ok {
+			log.Info("router.harness_escalation",
+				"action", harnessActionProviderIneligible,
+				"turn_type", string(res.TurnType),
+				"from_model", res.Decision.Model,
+				"from_provider", res.Decision.Provider,
+				"to_model", escalateModel,
+			)
+			return
+		}
+	}
+	if _, ok := req.ExcludedModels[escalateModel]; ok {
+		log.Info("router.harness_escalation",
+			"action", harnessActionModelExcluded,
+			"turn_type", string(res.TurnType),
+			"from_model", res.Decision.Model,
+			"from_provider", res.Decision.Provider,
+			"to_model", escalateModel,
+		)
+		return
+	}
+
+	log.Info("router.harness_escalation",
+		"action", harnessActionEscalated,
+		"turn_type", string(res.TurnType),
+		"from_model", res.Decision.Model,
+		"from_provider", res.Decision.Provider,
+		"to_model", escalateModel,
+	)
+	res.Decision = router.Decision{
+		Provider: providers.ProviderAnthropic,
+		Model:    escalateModel,
+		Reason:   translate.ReasonHarnessEscalation,
+	}
+	res.HarnessEscalated = true
+}

--- a/internal/proxy/harness_escalation_internal_test.go
+++ b/internal/proxy/harness_escalation_internal_test.go
@@ -1,0 +1,203 @@
+package proxy
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"workweave/router/internal/providers"
+	"workweave/router/internal/router"
+	"workweave/router/internal/router/turntype"
+	"workweave/router/internal/translate"
+)
+
+// newHarnessEscalationSvc wires a Service with just the pieces
+// applyHarnessEscalation touches.
+func newHarnessEscalationSvc() *Service {
+	return NewService(nil, nil, nil, false, nil, newStubPinStore(), false, "anthropic", "claude-haiku-4-5", nil)
+}
+
+func TestApplyHarnessEscalation_EscalatesLowTierNonClaudeOnEachHarnessTurnType(t *testing.T) {
+	for _, tt := range []turntype.TurnType{turntype.HarnessMeta, turntype.SubAgentHarnessMeta, turntype.Recovery} {
+		t.Run(string(tt), func(t *testing.T) {
+			svc := newHarnessEscalationSvc()
+			res := turnLoopResult{
+				TurnType: tt,
+				Decision: router.Decision{Provider: providers.ProviderOpenAI, Model: "gpt-5-mini", Reason: "best_pick"},
+			}
+			svc.applyHarnessEscalation(context.Background(), &res, router.Request{})
+
+			assert.Equal(t, escalateModel, res.Decision.Model)
+			assert.Equal(t, providers.ProviderAnthropic, res.Decision.Provider)
+			assert.Equal(t, translate.ReasonHarnessEscalation, res.Decision.Reason)
+			assert.True(t, res.HarnessEscalated, "clamp must flag the rewrite")
+		})
+	}
+}
+
+func TestApplyHarnessEscalation_NonHarnessTurnTypeUntouched(t *testing.T) {
+	for _, tt := range []turntype.TurnType{turntype.MainLoop, turntype.ToolResult, turntype.SubAgentDispatch, turntype.Compaction, turntype.Probe, turntype.TitleGen, turntype.Classifier} {
+		t.Run(string(tt), func(t *testing.T) {
+			svc := newHarnessEscalationSvc()
+			original := router.Decision{Provider: providers.ProviderOpenAI, Model: "gpt-5-mini", Reason: "best_pick"}
+			res := turnLoopResult{TurnType: tt, Decision: original}
+			svc.applyHarnessEscalation(context.Background(), &res, router.Request{})
+
+			assert.Equal(t, original, res.Decision, "clamp must not engage for a non-harness turn type")
+			assert.False(t, res.HarnessEscalated)
+		})
+	}
+}
+
+func TestApplyHarnessEscalation_AlreadyStrongClaudeTierHighUntouched(t *testing.T) {
+	svc := newHarnessEscalationSvc()
+	original := router.Decision{Provider: providers.ProviderAnthropic, Model: escalateModel, Reason: "best_pick"}
+	res := turnLoopResult{TurnType: turntype.HarnessMeta, Decision: original}
+	svc.applyHarnessEscalation(context.Background(), &res, router.Request{})
+
+	assert.Equal(t, original, res.Decision, "already on a strong Claude-family model -> no-op")
+	assert.False(t, res.HarnessEscalated)
+}
+
+func TestApplyHarnessEscalation_ClaudeMidTierStillEscalates(t *testing.T) {
+	// claude-sonnet-4-6 is Claude-family but TierMid, not TierHigh — the clamp
+	// must still route up rather than treating any Claude model as strong enough.
+	svc := newHarnessEscalationSvc()
+	res := turnLoopResult{
+		TurnType: turntype.HarnessMeta,
+		Decision: router.Decision{Provider: providers.ProviderAnthropic, Model: "claude-sonnet-4-6", Reason: "best_pick"},
+	}
+	svc.applyHarnessEscalation(context.Background(), &res, router.Request{})
+
+	assert.Equal(t, escalateModel, res.Decision.Model, "Claude family but below TierHigh must still escalate")
+	assert.True(t, res.HarnessEscalated)
+}
+
+func TestApplyHarnessEscalation_NonClaudeTierHighStillEscalates(t *testing.T) {
+	// gpt-5 is TierHigh but not Claude-family — the clamp cares about family,
+	// not just tier, since a non-Anthropic upstream can still hallucinate
+	// harness primitives.
+	svc := newHarnessEscalationSvc()
+	res := turnLoopResult{
+		TurnType: turntype.HarnessMeta,
+		Decision: router.Decision{Provider: providers.ProviderOpenAI, Model: "gpt-5", Reason: "best_pick"},
+	}
+	svc.applyHarnessEscalation(context.Background(), &res, router.Request{})
+
+	assert.Equal(t, escalateModel, res.Decision.Model, "TierHigh but non-Claude-family must still escalate")
+	assert.True(t, res.HarnessEscalated)
+}
+
+func TestApplyHarnessEscalation_UsageBypassOutranksClamp(t *testing.T) {
+	svc := newHarnessEscalationSvc()
+	original := router.Decision{Provider: providers.ProviderOpenAI, Model: "gpt-5-mini", Reason: "best_pick"}
+	res := turnLoopResult{TurnType: turntype.HarnessMeta, Decision: original, UsageBypass: true}
+	svc.applyHarnessEscalation(context.Background(), &res, router.Request{})
+
+	assert.Equal(t, original, res.Decision, "subscription usage-bypass outranks the clamp")
+	assert.False(t, res.HarnessEscalated)
+}
+
+func TestApplyHarnessEscalation_HardPinnedOutranksClamp(t *testing.T) {
+	svc := newHarnessEscalationSvc()
+	original := router.Decision{Provider: providers.ProviderOpenAI, Model: "gpt-5-mini", Reason: "best_pick"}
+	res := turnLoopResult{TurnType: turntype.HarnessMeta, Decision: original, HardPinned: true}
+	svc.applyHarnessEscalation(context.Background(), &res, router.Request{})
+
+	assert.Equal(t, original, res.Decision, "an operator/planner hard pin outranks the clamp")
+	assert.False(t, res.HarnessEscalated)
+}
+
+func TestApplyHarnessEscalation_UserForcedOutranksClamp(t *testing.T) {
+	svc := newHarnessEscalationSvc()
+	original := router.Decision{Provider: providers.ProviderOpenAI, Model: "gpt-5-mini", Reason: translate.ReasonUserForceModel}
+	res := turnLoopResult{TurnType: turntype.HarnessMeta, Decision: original}
+	svc.applyHarnessEscalation(context.Background(), &res, router.Request{})
+
+	assert.Equal(t, original, res.Decision, "a /force-model pin outranks the clamp")
+	assert.False(t, res.HarnessEscalated)
+}
+
+func TestApplyHarnessEscalation_AlreadyLoopEscalatedOutranksClamp(t *testing.T) {
+	svc := newHarnessEscalationSvc()
+	original := router.Decision{Provider: providers.ProviderAnthropic, Model: escalateModel, Reason: translate.ReasonLoopEscalation}
+	res := turnLoopResult{TurnType: turntype.Recovery, Decision: original}
+	svc.applyHarnessEscalation(context.Background(), &res, router.Request{})
+
+	assert.Equal(t, original, res.Decision, "an existing loop-escalation decision is already a stronger rescue")
+	assert.False(t, res.HarnessEscalated)
+}
+
+func TestApplyHarnessEscalation_KillSwitchDisablesClamp(t *testing.T) {
+	svc := newHarnessEscalationSvc().WithHarnessEscalationConfig(false)
+	original := router.Decision{Provider: providers.ProviderOpenAI, Model: "gpt-5-mini", Reason: "best_pick"}
+	res := turnLoopResult{TurnType: turntype.HarnessMeta, Decision: original}
+	svc.applyHarnessEscalation(context.Background(), &res, router.Request{})
+
+	assert.Equal(t, original, res.Decision, "ROUTER_HARNESS_ESCALATION_ENABLED=false must suppress the clamp")
+	assert.False(t, res.HarnessEscalated)
+}
+
+func TestApplyHarnessEscalation_ProviderIneligibleLeavesDecisionUntouched(t *testing.T) {
+	svc := newHarnessEscalationSvc()
+	original := router.Decision{Provider: providers.ProviderOpenAI, Model: "gpt-5-mini", Reason: "best_pick"}
+	res := turnLoopResult{TurnType: turntype.HarnessMeta, Decision: original}
+	req := router.Request{EnabledProviders: map[string]struct{}{providers.ProviderOpenAI: {}}}
+	svc.applyHarnessEscalation(context.Background(), &res, req)
+
+	assert.Equal(t, original, res.Decision, "anthropic not in EnabledProviders -> escalate target unservable")
+	assert.False(t, res.HarnessEscalated)
+}
+
+func TestApplyHarnessEscalation_ModelExcludedLeavesDecisionUntouched(t *testing.T) {
+	svc := newHarnessEscalationSvc()
+	original := router.Decision{Provider: providers.ProviderOpenAI, Model: "gpt-5-mini", Reason: "best_pick"}
+	res := turnLoopResult{TurnType: turntype.HarnessMeta, Decision: original}
+	req := router.Request{ExcludedModels: map[string]struct{}{escalateModel: {}}}
+	svc.applyHarnessEscalation(context.Background(), &res, req)
+
+	assert.Equal(t, original, res.Decision, "escalateModel excluded -> original decision stands")
+	assert.False(t, res.HarnessEscalated)
+}
+
+func TestApplyHarnessEscalation_NilEnabledProvidersIsUnrestricted(t *testing.T) {
+	// A nil EnabledProviders map means "no restriction" per router.Request
+	// semantics — the clamp must not treat nil as "anthropic disabled".
+	svc := newHarnessEscalationSvc()
+	res := turnLoopResult{
+		TurnType: turntype.HarnessMeta,
+		Decision: router.Decision{Provider: providers.ProviderOpenAI, Model: "gpt-5-mini", Reason: "best_pick"},
+	}
+	svc.applyHarnessEscalation(context.Background(), &res, router.Request{EnabledProviders: nil})
+
+	assert.Equal(t, escalateModel, res.Decision.Model, "nil EnabledProviders must not block escalation")
+	assert.True(t, res.HarnessEscalated)
+}
+
+// TestIsHardPinnedTurn_SubAgentHarnessMetaNeverHardPinned guards the
+// isHardPinnedTurn branch added alongside the clamp: even with the legacy
+// hardPinExplore switch AND a sub-agent override both configured,
+// SubAgentHarnessMeta must never take the hard-pin short-circuit — it needs
+// to reach the scorer/planner so applyHarnessEscalation (not a hard pin) can
+// decide the model.
+func TestIsHardPinnedTurn_SubAgentHarnessMetaNeverHardPinned(t *testing.T) {
+	svc := NewService(nil, nil, nil, false, nil, newStubPinStore(), true, "anthropic", "claude-haiku-4-5", nil).
+		WithSubAgentOverride("anthropic", "claude-haiku-4-5")
+
+	require.True(t, svc.hasSubAgentOverride())
+	assert.False(t, svc.isHardPinnedTurn(context.Background(), turntype.SubAgentHarnessMeta))
+	// Sanity: plain SubAgentDispatch DOES hard-pin under this same config, so
+	// the exemption above is specific to the harness variant, not a config bug.
+	assert.True(t, svc.isHardPinnedTurn(context.Background(), turntype.SubAgentDispatch))
+}
+
+func TestAuthoritativePolicyTurn_HarnessVariantsMatchUnderlyingShape(t *testing.T) {
+	assert.Equal(t, authoritativePolicyTurn(turntype.MainLoop), authoritativePolicyTurn(turntype.HarnessMeta),
+		"HarnessMeta must match MainLoop's authoritative-policy behavior")
+	assert.Equal(t, authoritativePolicyTurn(turntype.ToolResult), authoritativePolicyTurn(turntype.Recovery),
+		"Recovery must match ToolResult's authoritative-policy behavior")
+	assert.False(t, authoritativePolicyTurn(turntype.SubAgentHarnessMeta),
+		"SubAgentHarnessMeta's base (SubAgentDispatch) is not an authoritative-policy turn")
+}

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -170,6 +170,12 @@ type Service struct {
 	// escalate-to-opus action. False keeps detection/telemetry running
 	// (action=disabled) but writes no escalation pin. Defaults true.
 	loopEscalationEnabled bool
+	// harnessEscalationEnabled is the kill switch for the harness-protocol
+	// escalate clamp (route harness-bound turns up, never down). False keeps
+	// the clamp from engaging (action=disabled) while harness turn-type
+	// detection and routing continue unchanged. Defaults true; knob is
+	// ROUTER_HARNESS_ESCALATION_ENABLED.
+	harnessEscalationEnabled bool
 	// loopEscalationHoldoutPct is the percentage of loop-detected sessions
 	// deterministically assigned to a log-not-act holdout, so the self-recovery
 	// baseline can be subtracted from rescue-rate claims. 0 disables it.
@@ -189,6 +195,9 @@ type Service struct {
 	// spiralTracker de-duplicates shadow fires per (session, role, reason) on
 	// this replica.
 	spiralTracker *spiralTracker
+	// claimedToolTracker de-duplicates claimed-tool-unavailable auto-feedback
+	// per (session, role, tool) on this replica (see claimed_tool_unavailable.go).
+	claimedToolTracker *claimedToolTracker
 	// spiralShadowStore persists shadow spiral detections durably
 	// (router.spiral_shadow_events) and enforces the once-per-(session,
 	// reason) budget. Nil degrades to log-only fires.
@@ -516,13 +525,14 @@ func sanitizeSidecarDisplayMarker(raw string) string {
 // the marker wording; tests assert the mapping against these constants rather
 // than re-spelling the literals.
 const (
-	markerReasonUserForced    = "pinned by force-model"
-	markerReasonLoopEscalated = "escalated due to loop"
-	markerReasonSwitched      = "switched for positive EV after cache eviction"
-	markerReasonStayed        = "stayed on your last pick"
-	markerReasonTierUpgrade   = "upgraded to a stronger tier"
-	markerReasonBestPick      = "best pick for this turn"
-	markerReasonBaseline      = "fell back to baseline after provider outage"
+	markerReasonUserForced       = "pinned by force-model"
+	markerReasonLoopEscalated    = "escalated due to loop"
+	markerReasonHarnessEscalated = "escalated for harness protocol"
+	markerReasonSwitched         = "switched for positive EV after cache eviction"
+	markerReasonStayed           = "stayed on your last pick"
+	markerReasonTierUpgrade      = "upgraded to a stronger tier"
+	markerReasonBestPick         = "best pick for this turn"
+	markerReasonBaseline         = "fell back to baseline after provider outage"
 )
 
 // baselineRoutingMarkerFor renders the routing badge for an in-turn baseline
@@ -552,6 +562,8 @@ func routingReasonShort(res turnLoopResult) string {
 		return markerReasonUserForced
 	case translate.ReasonLoopEscalation:
 		return markerReasonLoopEscalated
+	case translate.ReasonHarnessEscalation:
+		return markerReasonHarnessEscalated
 	}
 	return markerReasonBestPick
 }
@@ -1061,6 +1073,7 @@ func NewService(r router.Router, providerMap map[string]providers.Client, emitte
 		plannerEnabled:                true,
 		scoreToolResultTurns:          true,
 		loopEscalationEnabled:         true,
+		harnessEscalationEnabled:      true,
 		cyberRefusalRepin:             false,
 		cyberRefusalFallbackModel:     "claude-sonnet-5",
 	}
@@ -1204,6 +1217,14 @@ func (s *Service) WithLoopEscalationConfig(enabled bool, holdoutPct int) *Servic
 		holdoutPct = 100
 	}
 	s.loopEscalationHoldoutPct = holdoutPct
+	return s
+}
+
+// WithHarnessEscalationConfig sets the harness-protocol escalation clamp
+// kill switch. enabled=false keeps the clamp from engaging (action=disabled)
+// while harness turn-type detection and routing continue unchanged.
+func (s *Service) WithHarnessEscalationConfig(enabled bool) *Service {
+	s.harnessEscalationEnabled = enabled
 	return s
 }
 
@@ -2438,7 +2459,7 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 
 	// Text-repetition break: fresh tool calls each turn defeat the no-progress
 	// fingerprint; repeated narration is the durable tell. See text_repetition.go.
-	if !agentShadowMode && !routeRes.AuthoritativePerTurn && s.textRepetitionBreakEnabled && (tt == turntype.MainLoop || tt == turntype.ToolResult) {
+	if !agentShadowMode && !routeRes.AuthoritativePerTurn && s.textRepetitionBreakEnabled && (tt.Base() == turntype.MainLoop || tt.Base() == turntype.ToolResult) {
 		if looped, count, sampleHash := detectTextRepetition(env); looped {
 			role := roleForTier(catalog.TierFor(feats.Model))
 			return s.handleTextRepetitionBreak(ctx, w, env, count, sampleHash, installationID, routeRes.SessionKey, role, decision.Model, decision.Provider, feats.Tokens)
@@ -2450,7 +2471,7 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 	// reason), so fire rates/precision can be measured before any escalation
 	// is armed. Main-loop / tool-result turns only — hard-pinned turn types
 	// carry history shapes that mimic the signals.
-	if !agentShadowMode && s.spiralShadowEnabled && (tt == turntype.MainLoop || tt == turntype.ToolResult) {
+	if !agentShadowMode && s.spiralShadowEnabled && (tt.Base() == turntype.MainLoop || tt.Base() == turntype.ToolResult) {
 		if reasons := spiralReasons(inboundSpiralSignals); len(reasons) > 0 {
 			role := roleForTier(catalog.TierFor(feats.Model))
 			// Use the bindRequestLogger digest, not routeRes.SessionKey (zero
@@ -3134,6 +3155,10 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 	if !agentShadowMode {
 		s.recordCallLog(ctx, upstreamBuilder.Build(), proxyErr != nil, body, respBody, respTrunc)
 	}
+	// Eval rows must not enter the auto-feedback corpus either.
+	if !agentShadowMode {
+		s.maybeReportClaimedToolUnavailable(ctx, respBody, env.Stream(), env.AvailableToolNames(), installationID, sessionKey, routeRes.PinRole, feats.Model, decision.Model, requestID, obs.RouteID, clientID)
+	}
 	otel.Flush(ctx)
 
 	if !agentShadowMode {
@@ -3652,6 +3677,9 @@ func pinDecision(p sessionpin.Pin) router.Decision {
 // stays anchored so the pair survives for the next turn's swap.
 func (s *Service) bandSwapServed(ctx context.Context, turnType turntype.TurnType, pin sessionpin.Pin, fresh router.Decision, hasImages bool, enabledProviders, excludedModels map[string]struct{}) router.Decision {
 	anchor := pinDecision(pin)
+	// turnType intentionally compared raw (not Base()): a harness-variant turn
+	// (Recovery is the tool-result shape) skips band swap and serves the anchor,
+	// leaving the harness escalation clamp to decide the model for that turn.
 	if s.bandSwap == nil || pin.PairedModel == "" || turnType != turntype.MainLoop {
 		return anchor
 	}
@@ -4120,7 +4148,7 @@ func int64PtrIf(known bool, v int64) *int64 {
 // history, so a trailing assistant reply after a prior tool_result would
 // otherwise write a stale non-NULL value.
 func toolResultBytesPtr(inbound translate.LastUserMessageInfo, tt turntype.TurnType) *int32 {
-	if tt != turntype.ToolResult || !inbound.HasToolResult {
+	if tt.Base() != turntype.ToolResult || !inbound.HasToolResult {
 		return nil
 	}
 	v := int32(inbound.ToolResultBytes)

--- a/internal/proxy/turnloop.go
+++ b/internal/proxy/turnloop.go
@@ -151,6 +151,10 @@ type turnLoopResult struct {
 	// exhaustion. Stashed on ctx so resolveBindingsForDispatch's failover
 	// walk also honors the exclusion, not just this turn's scorer.
 	SessionDisabledProviders []string
+	// HarnessEscalated is true when the harness-protocol escalation clamp
+	// replaced this turn's decision (see applyHarnessEscalation). Per-turn
+	// only — never persisted to a session pin.
+	HarnessEscalated bool
 }
 
 // modelSwitched reports whether the Anthropic emit path must strip historical
@@ -269,13 +273,23 @@ func (s *Service) isHardPinnedTurn(ctx context.Context, tt turntype.TurnType) bo
 			return false
 		}
 		return s.hardPinExplore || s.hasSubAgentOverride()
+	case turntype.SubAgentHarnessMeta:
+		// Never hard-pinned: the harness escalation clamp routes sub-agent
+		// harness turns UP (its job), overriding any low-tier background pin a
+		// hard pin here would impose.
+		return false
 	default:
 		return false
 	}
 }
 
+// authoritativePolicyTurn reports whether tt is a model-authoritative policy
+// turn. Compared on tt.Base() so the harness variants (HarnessMeta →
+// MainLoop, Recovery → ToolResult) keep the authoritative-policy behavior of
+// their underlying shape, while SubAgentHarnessMeta (→ SubAgentDispatch) stays
+// out.
 func authoritativePolicyTurn(tt turntype.TurnType) bool {
-	return tt == turntype.MainLoop || tt == turntype.ToolResult
+	return tt.Base() == turntype.MainLoop || tt.Base() == turntype.ToolResult
 }
 
 func isUserForcedReason(reason string) bool {
@@ -321,13 +335,35 @@ func forcedPinEligible(pin sessionpin.Pin, req router.Request) bool {
 	return ok
 }
 
-// runTurnLoop is the format-agnostic routing orchestrator: detect turn type,
+// runTurnLoop is the format-agnostic routing orchestrator. It is the single
+// choke point every decision path passes through exactly once: after the
+// routing decision resolves it applies the harness-protocol escalation clamp
+// (route harness-bound turns up, never down), then returns the result.
+func (s *Service) runTurnLoop(
+	ctx context.Context,
+	env *translate.RequestEnvelope,
+	feats translate.RoutingFeatures,
+	apiKeyID string,
+	installationID uuid.UUID,
+	subAgentHint string,
+	reqHeaders http.Header,
+	req router.Request,
+) (turnLoopResult, error) {
+	res, err := s.runTurnLoopInner(ctx, env, feats, apiKeyID, installationID, subAgentHint, reqHeaders, req)
+	if err != nil {
+		return turnLoopResult{}, err
+	}
+	s.applyHarnessEscalation(ctx, &res, req)
+	return res, nil
+}
+
+// runTurnLoopInner is the body of the routing orchestrator: detect turn type,
 // short-circuit hard pins, load pin, run scorer, hand to planner, and on
 // switch attempt bounded-cost handover.
 //
 // installationID == uuid.Nil skips the async pin upsert (rows need one); the
 // rest of the path runs normally.
-func (s *Service) runTurnLoop(
+func (s *Service) runTurnLoopInner(
 	ctx context.Context,
 	env *translate.RequestEnvelope,
 	feats translate.RoutingFeatures,
@@ -433,6 +469,8 @@ func (s *Service) runTurnLoop(
 		provider, model := s.hardPinProvider, s.hardPinModel
 		// Sub-agent override is explicit operator config (mirrors ROUTER_HARD_PIN_MODEL
 		// semantics), so it skips hardPinResolver rather than being resolved dynamically.
+		// SubAgentHarnessMeta never reaches here: isHardPinnedTurn returns false for
+		// it, so the harness escalation clamp (not a hard pin) routes it up.
 		useSubAgentOverride := res.TurnType == turntype.SubAgentDispatch && s.hasSubAgentOverride()
 		if useSubAgentOverride {
 			provider, model = s.subAgentProvider, s.subAgentModel
@@ -799,7 +837,7 @@ func (s *Service) runTurnLoop(
 	// Switches degrade safely — handover.RewriteEnvelope strips orphaned tool_results.
 	if !res.AuthoritativePerTurn &&
 		!s.scoreToolResultTurns &&
-		res.TurnType == turntype.ToolResult &&
+		res.TurnType.Base() == turntype.ToolResult &&
 		pinFound {
 		decision := pinDecision(pin)
 		res.Decision = decision
@@ -1359,9 +1397,12 @@ func buildPolicyTurnContext(
 		previousProvider = previous.Provider
 	}
 	return &router.PolicyTurnContext{
-		VisibleTurnIndex:    visibleTurnIndex,
-		SessionTurnCount:    sessionTurnCount,
-		TurnType:            string(res.TurnType),
+		VisibleTurnIndex: visibleTurnIndex,
+		SessionTurnCount: sessionTurnCount,
+		// Base() keeps the policy sidecar's turn-type vocabulary stable: the
+		// harness variants report their underlying shape so a deployed roster
+		// does not need to re-publish when a new harness detection lands.
+		TurnType:            string(res.TurnType.Base()),
 		PreviousServedModel: res.PriorServedModel,
 		PreviousProvider:    previousProvider,
 		CacheState:          cacheState,

--- a/internal/router/catalog/family.go
+++ b/internal/router/catalog/family.go
@@ -13,6 +13,18 @@ import (
 // number (gpt-4o) don't match and are treated as singleton families.
 var familyVersionPattern = regexp.MustCompile(`^(.+?)(\d+)(?:[.-](\d+))?(-[a-z][a-z0-9\-]*)?$`)
 
+// IsClaudeFamily reports whether id's family is a Claude family (family name
+// starts with "claude"). Unknown/ungenerational ids (gpt-4o, "") are false.
+// Used by the harness-protocol escalation clamp to test whether a resolved
+// decision already sits on a strong Claude-family model.
+func IsClaudeFamily(id string) bool {
+	family, _, ok := FamilyAndVersion(id)
+	if !ok {
+		return false
+	}
+	return strings.HasPrefix(family, "claude")
+}
+
 // FamilyAndVersion parses id into a family key (generation stripped, suffix
 // kept, e.g. "gpt-5.4-mini" → family "gpt-mini") and a (major, minor) version
 // tuple. ok=false means id has no generation number; treat as singleton family.

--- a/internal/router/catalog/family_test.go
+++ b/internal/router/catalog/family_test.go
@@ -67,6 +67,29 @@ func TestFamilyAndVersion(t *testing.T) {
 	}
 }
 
+func TestIsClaudeFamily(t *testing.T) {
+	tests := []struct {
+		id   string
+		want bool
+	}{
+		{"claude-opus-5", true},
+		{"claude-fable-5", true},
+		{"claude-haiku-4-5", true},
+		{"claude-opus-4-6", true},
+		{"gpt-5", false},
+		{"qwen/qwen3.8-max", false},
+		{"deepseek/deepseek-v4-flash", false},
+		{"", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.id, func(t *testing.T) {
+			if got := IsClaudeFamily(tt.id); got != tt.want {
+				t.Errorf("IsClaudeFamily(%q) = %v, want %v", tt.id, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestFamilyDuplicates(t *testing.T) {
 	ids := []string{
 		"claude-haiku-4-5",

--- a/internal/router/turntype/AGENTS.md
+++ b/internal/router/turntype/AGENTS.md
@@ -15,6 +15,11 @@ Classifies inbound requests into:
 - `Probe` — proxy bypasses routing entirely
 - `TitleGen` — Claude Code sidebar-title generation; hard-pinned AND skips session-pin creation (an anchored pin here would leak the cheap-model decision into the real conversation that follows ~25ms later)
 - `Classifier` — short-form classification call (e.g. Claude Code's security monitor); hard-pinned AND skips session-pin creation
+- `HarnessMeta` — main-turn skill/command invocation referencing harness primitives; proxy clamps these to a strong Claude-family model (route up, never down); detection is deliberately narrow (command markers + harness keyword gate)
+- `SubAgentHarnessMeta` — sub-agent dispatch whose prompt references harness primitives; same clamp as `HarnessMeta` (route up, never down); detection is deliberately narrow (harness keyword gate over a bounded prompt prefix)
+- `Recovery` — tool-result turn recovering from a deferred-tool/`InputValidationError` failure; same clamp (route up, never down); detection is deliberately narrow (`InputValidationError` + deferred-tool context)
+
+`TurnType.Base()` maps the three harness variants back to their underlying shape (`MainLoop` / `SubAgentDispatch` / `ToolResult`) for call sites that must stay behavior-compatible with the pre-harness vocabulary — notably the policy sidecar, whose turn-type labels must remain stable. `TurnType.HarnessEscalation()` reports whether the proxy's escalation clamp applies.
 
 Used by [`../../proxy`](../../proxy) to keep the action loop cheap + correct.
 

--- a/internal/router/turntype/CLAUDE.md
+++ b/internal/router/turntype/CLAUDE.md
@@ -15,6 +15,11 @@ Classifies inbound requests into:
 - `Probe` — proxy bypasses routing entirely
 - `TitleGen` — Claude Code sidebar-title generation; hard-pinned AND skips session-pin creation (an anchored pin here would leak the cheap-model decision into the real conversation that follows ~25ms later)
 - `Classifier` — short-form classification call (e.g. Claude Code's security monitor); hard-pinned AND skips session-pin creation
+- `HarnessMeta` — main-turn skill/command invocation referencing harness primitives; proxy clamps these to a strong Claude-family model (route up, never down); detection is deliberately narrow (command markers + harness keyword gate)
+- `SubAgentHarnessMeta` — sub-agent dispatch whose prompt references harness primitives; same clamp as `HarnessMeta` (route up, never down); detection is deliberately narrow (harness keyword gate over a bounded prompt prefix)
+- `Recovery` — tool-result turn recovering from a deferred-tool/`InputValidationError` failure; same clamp (route up, never down); detection is deliberately narrow (`InputValidationError` + deferred-tool context)
+
+`TurnType.Base()` maps the three harness variants back to their underlying shape (`MainLoop` / `SubAgentDispatch` / `ToolResult`) for call sites that must stay behavior-compatible with the pre-harness vocabulary — notably the policy sidecar, whose turn-type labels must remain stable. `TurnType.HarnessEscalation()` reports whether the proxy's escalation clamp applies.
 
 Used by [`../../proxy`](../../proxy) to keep the action loop cheap + correct.
 

--- a/internal/router/turntype/detect.go
+++ b/internal/router/turntype/detect.go
@@ -26,6 +26,23 @@ const (
 	// Classifier: short-form classification call (security monitor, etc.).
 	// Hard-pinned AND skips session-pin creation.
 	Classifier TurnType = "classifier"
+	// HarnessMeta: main-turn skill/command invocation referencing harness
+	// primitives (plan-mode tools, deferred-tool discovery, etc.). The proxy
+	// clamps these to a strong Claude-family model so the harness control plane
+	// cannot be silently downgraded to a non-Anthropic upstream that
+	// hallucinates harness primitives.
+	HarnessMeta TurnType = "harness_meta"
+	// SubAgentHarnessMeta: sub-agent dispatch whose dispatch prompt references
+	// harness primitives. Same clamp as HarnessMeta, scoped to sub-agent turns
+	// so a parent conversation routing up does not accidentally leak the
+	// hard-pin into the orchestrated sub-agent path.
+	SubAgentHarnessMeta TurnType = "sub_agent_harness_meta"
+	// Recovery: tool-result turn recovering from a deferred-tool
+	// InputValidationError. The previous turn's tool call failed for a
+	// harness-shape reason rather than an ordinary schema mistake; routing up
+	// here both retries against a model that knows the deferred-tool protocol
+	// and prevents a thrash loop against a weak upstream.
+	Recovery TurnType = "recovery"
 )
 
 const probeMaxTokensThreshold = 4
@@ -61,10 +78,25 @@ func DetectFromEnvelope(env *translate.RequestEnvelope, feats translate.RoutingF
 		return Compaction
 	}
 	if isSubAgentDispatch(env.MetadataUserID(), env.FirstUserMessageText(), subAgentHint) {
+		if isHarnessMetaSubAgent(env.FirstUserMessageText()) {
+			return SubAgentHarnessMeta
+		}
 		return SubAgentDispatch
 	}
 	if isClassifier(feats) {
 		return Classifier
+	}
+	// Recovery before harness-meta: both look at the last user message, but a
+	// tool_result turn must NEVER classify as HarnessMeta — its underlying
+	// shape is a continuation, not a skill invocation, so the only escalation
+	// it can earn is Recovery. The explicit LastKind guard below enforces that
+	// even when a tool_result turn's <system-reminder> text happens to contain
+	// command markers.
+	if env.SourceFormat() == translate.FormatAnthropic && isRecoveryTurn(env, feats) {
+		return Recovery
+	}
+	if env.SourceFormat() == translate.FormatAnthropic && feats.LastKind != "tool_result" && isHarnessMetaMainTurn(env) {
+		return HarnessMeta
 	}
 	if feats.LastKind == "tool_result" {
 		return ToolResult
@@ -129,4 +161,36 @@ func isSubAgentDispatch(metadataUserID, firstUserText, subAgentHint string) bool
 		prefix = prefix[:sniffLen]
 	}
 	return strings.Contains(prefix, "<transcript>")
+}
+
+// Base returns the underlying turn shape a harness variant should be treated
+// as at call sites that must keep behavior-compatible with the pre-harness
+// vocabulary (the policy sidecar in particular: its turn-type labels must
+// stay stable so a deployed roster does not need to re-publish when a new
+// harness detection lands). Maps HarnessMeta → MainLoop,
+// SubAgentHarnessMeta → SubAgentDispatch, Recovery → ToolResult; identity
+// for every other value.
+func (t TurnType) Base() TurnType {
+	switch t {
+	case HarnessMeta:
+		return MainLoop
+	case SubAgentHarnessMeta:
+		return SubAgentDispatch
+	case Recovery:
+		return ToolResult
+	default:
+		return t
+	}
+}
+
+// HarnessEscalation reports whether the proxy's escalation clamp should
+// treat the turn as harness-bound (route up, never down). True for exactly
+// the three new harness-variant turn types; every existing value is false.
+func (t TurnType) HarnessEscalation() bool {
+	switch t {
+	case HarnessMeta, SubAgentHarnessMeta, Recovery:
+		return true
+	default:
+		return false
+	}
 }

--- a/internal/router/turntype/detect_test.go
+++ b/internal/router/turntype/detect_test.go
@@ -260,6 +260,88 @@ func TestDetectFromEnvelope_Anthropic(t *testing.T) {
 			body: `{"model":"claude-opus-4-7","max_tokens":64,"metadata":{"user_id":"subagent:Explore"},"messages":[{"role":"user","content":"grep"}]}`,
 			want: turntype.SubAgentDispatch,
 		},
+		{
+			// The real failing fixture: a sub-agent dispatched to load a
+			// deferred tool's schema was routed to a weak model that cannot
+			// honor the deferred-tool protocol. Detected via header hint.
+			name: "sub-agent dispatch asking for a deferred tool schema is sub_agent_harness_meta",
+			body: `{"model":"claude-haiku-4-5","tools":[{"name":"ToolSearch","input_schema":{"type":"object"}}],"messages":[{"role":"user","content":"Load EnterPlanMode tool schema"}]}`,
+			hint: "general-purpose",
+			want: turntype.SubAgentHarnessMeta,
+		},
+		{
+			// Same fixture reached via the <transcript> signal instead of the
+			// header — both sub-agent detection paths must escalate.
+			name: "sub-agent via <transcript> asking for a deferred tool schema is sub_agent_harness_meta",
+			body: `{"model":"claude-opus-4-7","messages":[{"role":"user","content":"<transcript>\nUser: Load EnterPlanMode tool schema\n</transcript>"}]}`,
+			want: turntype.SubAgentHarnessMeta,
+		},
+		{
+			// Regression guard: an ordinary code-search dispatch must stay on
+			// the cheap sub-agent path. Escalating every sub-agent would undo
+			// the whole point of sub-agent routing.
+			name: "sub-agent with a plain coding prompt stays sub_agent_dispatch",
+			body: `{"model":"claude-haiku-4-5","messages":[{"role":"user","content":"Find all callers of foo in pkg/bar"}]}`,
+			hint: "Explore",
+			want: turntype.SubAgentDispatch,
+		},
+		{
+			// Claude Code emits <command-message>/<command-name> verbatim for
+			// slash + skill invocations; paired with a harness reference this
+			// is a control-plane turn.
+			name: "slash command invoking plan mode is harness_meta",
+			body: `{"model":"claude-opus-4-7","tools":[{"name":"Bash","input_schema":{"type":"object"}}],"messages":[{"role":"user","content":"<command-message>qplan</command-message><command-name>/qplan</command-name>\nPlan the change, then call ExitPlanMode to leave plan mode."}]}`,
+			want: turntype.HarnessMeta,
+		},
+		{
+			// Half the AND: command markers alone must not escalate, or every
+			// slash command in the harness would route up.
+			name: "slash command with no harness reference stays main_loop",
+			body: `{"model":"claude-opus-4-7","tools":[{"name":"Bash","input_schema":{"type":"object"}}],"messages":[{"role":"user","content":"<command-name>/standup</command-name>\nSummarize what I shipped yesterday."}]}`,
+			want: turntype.MainLoop,
+		},
+		{
+			// Other half of the AND: prose that merely discusses a harness
+			// tool is not an invocation of it.
+			name: "prose mentioning ToolSearch without command markers stays main_loop",
+			body: `{"model":"claude-opus-4-7","tools":[{"name":"Bash","input_schema":{"type":"object"}}],"messages":[{"role":"user","content":"Explain how ToolSearch works and whether deferred tool loading is worth it."}]}`,
+			want: turntype.MainLoop,
+		},
+		{
+			// Errored tool_result naming a harness primitive: the previous
+			// turn's deferred-tool call failed, so retry on a strong model.
+			name: "errored InputValidationError about a deferred tool is recovery",
+			body: `{"model":"claude-sonnet-4-5","tools":[{"name":"Bash","input_schema":{"type":"object"}}],"messages":[
+					{"role":"user","content":"enter plan mode"},
+					{"role":"assistant","content":[{"type":"tool_use","id":"t1","name":"EnterPlanMode","input":{}}]},
+					{"role":"user","content":[{"type":"tool_result","tool_use_id":"t1","is_error":true,"content":"InputValidationError: tool EnterPlanMode requires its schema to be fetched first"}]}
+				]}`,
+			want: turntype.Recovery,
+		},
+		{
+			// Regression guard: an ordinary parameter-type mistake is a normal
+			// retry, not a harness failure. Escalating these would route up on
+			// every sloppy tool call.
+			name: "errored InputValidationError about an ordinary schema mistake stays tool_result",
+			body: `{"model":"claude-sonnet-4-5","tools":[{"name":"Bash","input_schema":{"type":"object"}}],"messages":[
+					{"role":"user","content":"run it"},
+					{"role":"assistant","content":[{"type":"tool_use","id":"t1","name":"Bash","input":{}}]},
+					{"role":"user","content":[{"type":"tool_result","tool_use_id":"t1","is_error":true,"content":"InputValidationError: command must be a string, got number"}]}
+				]}`,
+			want: turntype.ToolResult,
+		},
+		{
+			// Regression guard: is_error is load-bearing. A SUCCESSFUL tool
+			// result that happens to print the phrase (e.g. grepping this very
+			// test file) must not escalate.
+			name: "successful tool_result mentioning InputValidationError stays tool_result",
+			body: `{"model":"claude-sonnet-4-5","tools":[{"name":"Bash","input_schema":{"type":"object"}}],"messages":[
+					{"role":"user","content":"grep the logs"},
+					{"role":"assistant","content":[{"type":"tool_use","id":"t1","name":"Bash","input":{}}]},
+					{"role":"user","content":[{"type":"tool_result","tool_use_id":"t1","content":"harness.go:42: InputValidationError EnterPlanMode deferred"}]}
+				]}`,
+			want: turntype.ToolResult,
+		},
 	}
 
 	for _, tc := range tests {
@@ -345,6 +427,16 @@ func TestDetectFromEnvelope_OpenAI(t *testing.T) {
 			name: "max_tokens=1 is probe (legacy OpenAI SDK)",
 			body: `{"model":"gpt-4o","max_tokens":1,"messages":[{"role":"user","content":"quota"}]}`,
 			want: turntype.Probe,
+		},
+		{
+			// Harness-meta detection is gated on Anthropic wire format (the
+			// markers are a Claude Code emission). A Codex/OpenAI client that
+			// echoes marker-shaped text must not be escalated.
+			name: "command-marker text in OpenAI body is not harness_meta",
+			body: `{"model":"gpt-4o","tools":[{"type":"function","function":{"name":"Bash","parameters":{"type":"object"}}}],"messages":[
+					{"role":"user","content":"<command-message>qplan</command-message><command-name>/qplan</command-name>\nPlan it, then ExitPlanMode to leave plan mode."}
+				]}`,
+			want: turntype.MainLoop,
 		},
 	}
 
@@ -445,4 +537,44 @@ func TestDetectFromEnvelope_Gemini(t *testing.T) {
 func TestDetectFromEnvelope_NilEnv(t *testing.T) {
 	got := turntype.DetectFromEnvelope(nil, translate.RoutingFeatures{}, "")
 	assert.Equal(t, turntype.MainLoop, got)
+}
+
+func TestTurnType_Base(t *testing.T) {
+	tests := []struct {
+		name string
+		in   turntype.TurnType
+		want turntype.TurnType
+	}{
+		// Harness variants collapse to their underlying shape.
+		{"harness_meta maps to main_loop", turntype.HarnessMeta, turntype.MainLoop},
+		{"sub_agent_harness_meta maps to sub_agent_dispatch", turntype.SubAgentHarnessMeta, turntype.SubAgentDispatch},
+		{"recovery maps to tool_result", turntype.Recovery, turntype.ToolResult},
+		// Existing values are identity.
+		{"main_loop identity", turntype.MainLoop, turntype.MainLoop},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, tc.in.Base())
+		})
+	}
+}
+
+func TestTurnType_HarnessEscalation(t *testing.T) {
+	tests := []struct {
+		name string
+		in   turntype.TurnType
+		want bool
+	}{
+		// The three new values escalate.
+		{"harness_meta escalates", turntype.HarnessMeta, true},
+		{"sub_agent_harness_meta escalates", turntype.SubAgentHarnessMeta, true},
+		{"recovery escalates", turntype.Recovery, true},
+		// Existing values do not.
+		{"main_loop does not escalate", turntype.MainLoop, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, tc.in.HarnessEscalation())
+		})
+	}
 }

--- a/internal/router/turntype/harness.go
+++ b/internal/router/turntype/harness.go
@@ -1,0 +1,193 @@
+package turntype
+
+import (
+	"strings"
+
+	"workweave/router/internal/translate"
+)
+
+// Bounded prefixes the harness-meta sniffers scan before giving up. A real
+// Claude Code command dispatch keeps the skill/command markers + the harness
+// reference well within the first few KB; binding the scan protects against
+// pathological-but-templated requests padding out the prefix.
+const (
+	harnessMetaMainTurnScanMaxBytes = 16384
+	harnessMetaSubAgentScanMaxBytes = 4096
+)
+
+// Harness-reference keyword gate (case-insensitive). "plan mode" + "tool
+// schema" + "deferred tool" are the three human-language phrases a CC turn
+// uses when invoking the harness control plane; false-positive aversion
+// matters because the proxy preserves model choice based on this signal.
+// Claude-Code-only tool names (matched case-sensitively per the PascalCase
+// convention in translate/claudecode_tool_filter.go) are layered on top of
+// the phrase match so a sub-agent dispatch whose first user line is
+// literally "Load EnterPlanMode tool schema" cannot drift past the gate
+// just because it lacks the prose phrases.
+var harnessKeywordPhrases = []string{"plan mode", "tool schema", "deferred tool"}
+
+// harnessMetaCCToolScanNames is the CC-only tool-name set filtered down to
+// only names whose length is > 8. The short names ("Task", "Agent",
+// "Skill", "Workflow", "LSP", "TaskGet") appear constantly in ordinary
+// prompts and even inside non-harness sub-agent dispatch text, so excluding
+// them keeps the gate tight: a real harness-meta turn references a SPECIFIC
+// tool, not the family name. Built once at init from
+// translate.ClaudeCodeOnlyToolNames() so a future rename in the CC tool
+// list flows through automatically.
+var harnessMetaCCToolScanNames []string
+
+func init() {
+	ccMinLen := 8
+	for _, name := range translate.ClaudeCodeOnlyToolNames() {
+		// length filter: drop the short family names. Strict > 8 so
+		// length-8 ("Workflow", "TaskList", "TaskStop") is excluded along
+		// with shorter ones — see the const comment for the rationale.
+		if len(name) <= ccMinLen {
+			continue
+		}
+		harnessMetaCCToolScanNames = append(harnessMetaCCToolScanNames, name)
+	}
+}
+
+// referencesHarnessPrimitives returns true when text is plausibly invoking
+// a harness control-plane primitive. Prose phrases are matched
+// case-insensitively (LLM text is loose); CC-only tool names are matched
+// case-sensitively with word boundaries so a backticked/quoted name hits
+// while an incidental mention like "MyToolSearchThing" or "TaskProvider"
+// does not.
+func referencesHarnessPrimitives(text string) bool {
+	if text == "" {
+		return false
+	}
+	lower := strings.ToLower(text)
+	for _, phrase := range harnessKeywordPhrases {
+		if strings.Contains(lower, phrase) {
+			return true
+		}
+	}
+	for _, name := range harnessMetaCCToolScanNames {
+		if containsWord(text, name) {
+			return true
+		}
+	}
+	return false
+}
+
+// containsWord reports whether needle appears in haystack as a
+// contiguous run framed by non-word runes (anything outside [A-Za-z0-9_]).
+// Case-sensitive per the PascalCase rule in
+// translate/claudecode_tool_filter.go:65-68 (CC emits tool names verbatim).
+// Bounded search protects against pathological inputs but no input here
+// exceeds harnessMetaMainTurnScanMaxBytes / harnessMetaSubAgentScanMaxBytes.
+func containsWord(haystack, needle string) bool {
+	for start := 0; start <= len(haystack)-len(needle); {
+		idx := strings.Index(haystack[start:], needle)
+		if idx < 0 {
+			return false
+		}
+		idx += start
+		leftOK := idx == 0 || !isWordRune(rune(haystack[idx-1]))
+		end := idx + len(needle)
+		rightOK := end == len(haystack) || !isWordRune(rune(haystack[end]))
+		if leftOK && rightOK {
+			return true
+		}
+		// advance past this candidate index to keep scanning.
+		start = idx + 1
+	}
+	return false
+}
+
+func isWordRune(r rune) bool {
+	switch {
+	case r >= 'a' && r <= 'z':
+		return true
+	case r >= 'A' && r <= 'Z':
+		return true
+	case r >= '0' && r <= '9':
+		return true
+	case r == '_':
+		return true
+	}
+	return false
+}
+
+// isHarnessMetaSubAgent reports whether the first user text of a sub-agent
+// dispatch prompt references harness primitives. Bounded by
+// harnessMetaSubAgentScanMaxBytes so we never walk the entirety of a
+// long dispatch prompt — the harness signal always sits in the first KB
+// of the dispatched prompt (CC's Agent tool template).
+func isHarnessMetaSubAgent(firstUserText string) bool {
+	if firstUserText == "" {
+		return false
+	}
+	scanned := firstUserText
+	if len(scanned) > harnessMetaSubAgentScanMaxBytes {
+		scanned = scanned[:harnessMetaSubAgentScanMaxBytes]
+	}
+	return referencesHarnessPrimitives(scanned)
+}
+
+// isHarnessMetaMainTurn reports whether the last user message in a
+// non-sub-agent, non-classifier main turn is a Claude Code skill/command
+// invocation referencing harness primitives. Requires BOTH a command
+// marker (Claude Code emits "<command-name>...</command-name>" and
+// "<command-message>...</command-message>" verbatim for slash and skill
+// invocations) AND the shared harness-reference gate — the AND keeps
+// ordinary slash commands like /standup or /help from escalating.
+func isHarnessMetaMainTurn(env *translate.RequestEnvelope) bool {
+	if env == nil {
+		return false
+	}
+	text := env.LastUserMessage().Text
+	if text == "" {
+		return false
+	}
+	if len(text) > harnessMetaMainTurnScanMaxBytes {
+		text = text[:harnessMetaMainTurnScanMaxBytes]
+	}
+	if !strings.Contains(text, "<command-name>") && !strings.Contains(text, "<command-message>") {
+		return false
+	}
+	return referencesHarnessPrimitives(text)
+}
+
+// isRecoveryTurn reports whether this is a tool_result turn recovering
+// from a deferred-tool InputValidationError. Requires BOTH:
+//   - feats.LastKind == "tool_result" (gated by the caller; re-checked
+//     defensively),
+//   - the errored tool_result payload contains "InputValidationError",
+//   - and either the substring "deferred" (any case) OR any CC-only tool
+//     name matched by the shared harness gate.
+//
+// The hard AND prevents ordinary schema-mistake retries (wrong parameter
+// type on Bash, etc.) from being misclassified as harness control-plane
+// failures — only the ones whose failure mentions a deferred-tool or other
+// harness primitive are gated up.
+func isRecoveryTurn(env *translate.RequestEnvelope, feats translate.RoutingFeatures) bool {
+	if env == nil {
+		return false
+	}
+	if feats.LastKind != "tool_result" {
+		return false
+	}
+	errText := env.LastUserToolResultErrorText(harnessMetaMainTurnScanMaxBytes)
+	if errText == "" {
+		return false
+	}
+	if !strings.Contains(errText, "InputValidationError") {
+		return false
+	}
+	return hasDeferredToolContext(errText)
+}
+
+// hasDeferredToolContext reports whether the errored text references a
+// deferred-tool context: literally the substring "deferred" (any case) OR
+// any CC-only tool name. Same case-sensitivity rules as
+// referencesHarnessPrimitives for the tool-name sweep.
+func hasDeferredToolContext(text string) bool {
+	if strings.Contains(strings.ToLower(text), "deferred") {
+		return true
+	}
+	return referencesHarnessPrimitives(text)
+}

--- a/internal/translate/claudecode_tool_filter.go
+++ b/internal/translate/claudecode_tool_filter.go
@@ -1,6 +1,8 @@
 package translate
 
 import (
+	"sort"
+
 	"github.com/tidwall/gjson"
 	"github.com/tidwall/sjson"
 )
@@ -69,6 +71,20 @@ var claudeCodeOnlyToolNames = map[string]struct{}{
 func isClaudeCodeOnlyTool(name string) bool {
 	_, ok := claudeCodeOnlyToolNames[name]
 	return ok
+}
+
+// ClaudeCodeOnlyToolNames returns a sorted copy of the Claude-Code-only tool
+// names. Exported for the turntype package's harness-reference gate, which
+// scans prompt text for these names to detect harness-protocol-bound turns;
+// sharing the list keeps the gate in sync with the emit-path filter instead
+// of duplicating the name set. Sorted for deterministic iteration.
+func ClaudeCodeOnlyToolNames() []string {
+	names := make([]string, 0, len(claudeCodeOnlyToolNames))
+	for name := range claudeCodeOnlyToolNames {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
 }
 
 // claudeCodeOrchestrationToolNames is the subset of claudeCodeOnlyToolNames

--- a/internal/translate/force_model.go
+++ b/internal/translate/force_model.go
@@ -17,6 +17,11 @@ const ReasonUserForceModel = "user_forced"
 // ReasonUserForceModel, so the session doesn't re-route back into the loop.
 const ReasonLoopEscalation = "loop_escalation"
 
+// ReasonHarnessEscalation marks a per-turn decision replaced by the
+// harness-protocol escalation clamp (route up, never down). Per-TURN only —
+// never written as a session-pin reason.
+const ReasonHarnessEscalation = "harness_escalation"
+
 // ForceModelResult holds the parsed outcome of a force-model command.
 type ForceModelResult struct {
 	// Model is the target model name; empty when Clear is true.

--- a/internal/translate/lastuser_toolresult.go
+++ b/internal/translate/lastuser_toolresult.go
@@ -1,0 +1,99 @@
+package translate
+
+import (
+	"strings"
+
+	"github.com/tidwall/gjson"
+)
+
+// LastUserToolResultErrorText returns the concatenated text of the last user
+// message's errored (is_error: true) tool_result blocks, truncated to
+// maxBytes. Anthropic format only — returns "" for OpenAI/Gemini, whose
+// tool-failure shapes carry no equivalent is_error marker on the wire.
+//
+// Exists separately from LastUserMessageInfo because the turntype harness
+// gate needs the failure text itself, not just the presence/size of a
+// tool_result: distinguishing a deferred-tool InputValidationError from an
+// ordinary schema mistake requires reading the payload.
+//
+// tool_result `content` may be a plain string OR an array of typed blocks
+// ({"type":"text","text":...}); both shapes are handled. Blocks are joined
+// with a newline. maxBytes <= 0 returns "".
+func (e *RequestEnvelope) LastUserToolResultErrorText(maxBytes int) string {
+	if e.format != FormatAnthropic || maxBytes <= 0 {
+		return ""
+	}
+	msgs := gjson.GetBytes(e.body, "messages")
+	if !msgs.IsArray() {
+		return ""
+	}
+	var lastUser gjson.Result
+	msgs.ForEach(func(_, msg gjson.Result) bool {
+		if msg.Get("role").String() == "user" {
+			lastUser = msg
+		}
+		return true
+	})
+	if !lastUser.Exists() {
+		return ""
+	}
+	content := lastUser.Get("content")
+	if !content.IsArray() {
+		return ""
+	}
+
+	var b strings.Builder
+	content.ForEach(func(_, block gjson.Result) bool {
+		if block.Get("type").String() != "tool_result" {
+			return true
+		}
+		if !block.Get("is_error").Bool() {
+			return true
+		}
+		text := toolResultBlockText(block.Get("content"))
+		if text == "" {
+			return true
+		}
+		if b.Len() > 0 {
+			b.WriteByte('\n')
+		}
+		b.WriteString(text)
+		// Keep accumulating only until we have enough to satisfy maxBytes;
+		// a huge errored payload should not be fully walked.
+		return b.Len() < maxBytes
+	})
+
+	out := b.String()
+	if len(out) > maxBytes {
+		return out[:maxBytes]
+	}
+	return out
+}
+
+// toolResultBlockText extracts text from a tool_result block's `content`,
+// which Anthropic accepts either as a plain string or as an array of typed
+// blocks. Non-text blocks (e.g. image) contribute nothing.
+func toolResultBlockText(content gjson.Result) string {
+	if content.Type == gjson.String {
+		return content.String()
+	}
+	if !content.IsArray() {
+		return ""
+	}
+	var b strings.Builder
+	content.ForEach(func(_, part gjson.Result) bool {
+		if part.Get("type").String() != "text" {
+			return true
+		}
+		text := part.Get("text").String()
+		if text == "" {
+			return true
+		}
+		if b.Len() > 0 {
+			b.WriteByte('\n')
+		}
+		b.WriteString(text)
+		return true
+	})
+	return b.String()
+}

--- a/internal/translate/lastuser_toolresult_test.go
+++ b/internal/translate/lastuser_toolresult_test.go
@@ -1,0 +1,134 @@
+package translate_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"workweave/router/internal/translate"
+)
+
+func TestLastUserToolResultErrorText(t *testing.T) {
+	t.Run("non-anthropic format returns empty string", func(t *testing.T) {
+		// OpenAI: tool-failure is encoded differently and is not a wire-level
+		// is_error marker we can read, so the accessor returns "".
+		body := []byte(`{"model":"gpt-4o","messages":[
+			{"role":"user","content":"run grep"},
+			{"role":"assistant","content":null,"tool_calls":[{"id":"t1","type":"function","function":{"name":"Bash","arguments":"{}"}}]},
+			{"role":"tool","tool_call_id":"t1","content":"InputValidationError: schema mismatch"}
+		]}`)
+		env, err := translate.ParseOpenAI(body)
+		require.NoError(t, err)
+		assert.Equal(t, "", env.LastUserToolResultErrorText(4096))
+	})
+
+	t.Run("array-form errored tool_result text is concatenated", func(t *testing.T) {
+		body := []byte(`{"model":"claude-sonnet-4-5","tools":[],"messages":[
+			{"role":"user","content":"run"},
+			{"role":"assistant","content":[{"type":"tool_use","id":"t1","name":"EnterPlanMode","input":{}}]},
+			{"role":"user","content":[
+				{"type":"tool_result","tool_use_id":"t1","is_error":true,"content":[
+					{"type":"text","text":"InputValidationError: needs deferred schema for EnterPlanMode"}
+				]},
+				{"type":"text","text":"trailing user note ignored"}
+			]}
+		]}`)
+		env, err := translate.ParseAnthropic(body)
+		require.NoError(t, err)
+		got := env.LastUserToolResultErrorText(8192)
+		assert.Contains(t, got, "InputValidationError")
+		assert.Contains(t, got, "EnterPlanMode")
+	})
+
+	t.Run("plain-string errored tool_result text is returned", func(t *testing.T) {
+		body := []byte(`{"model":"claude-opus-4-7","tools":[],"messages":[
+			{"role":"user","content":"hi"},
+			{"role":"assistant","content":[{"type":"tool_use","id":"t1","name":"X","input":{}}]},
+			{"role":"user","content":[
+				{"type":"tool_result","tool_use_id":"t1","is_error":true,"content":"InputValidationError: bad param"}
+			]}
+		]}`)
+		env, err := translate.ParseAnthropic(body)
+		require.NoError(t, err)
+		assert.Contains(t, env.LastUserToolResultErrorText(4096), "InputValidationError")
+	})
+
+	t.Run("non-errored block with same text is not surfaced", func(t *testing.T) {
+		// Successful tool_result printing InputValidationError must not be
+		// picked up — the harness gate's Recovery classifier depends on this
+		// (its is_error gate is the load-bearing half).
+		body := []byte(`{"model":"claude-sonnet-4-5","tools":[],"messages":[
+			{"role":"user","content":"grep"},
+			{"role":"assistant","content":[{"type":"tool_use","id":"t1","name":"Bash","input":{}}]},
+			{"role":"user","content":[
+				{"type":"tool_result","tool_use_id":"t1","content":"found InputValidationError in logs"}
+			]}
+		]}`)
+		env, err := translate.ParseAnthropic(body)
+		require.NoError(t, err)
+		assert.Equal(t, "", env.LastUserToolResultErrorText(4096))
+	})
+
+	t.Run("max bytes truncates output", func(t *testing.T) {
+		pad := "x"
+		for i := 0; i < 50; i++ {
+			pad += "x"
+		}
+		body := []byte(`{"model":"claude-sonnet-4-5","tools":[],"messages":[
+			{"role":"user","content":"r"},
+			{"role":"assistant","content":[{"type":"tool_use","id":"t1","name":"X","input":{}}]},
+			{"role":"user","content":[
+				{"type":"tool_result","tool_use_id":"t1","is_error":true,"content":"InputValidationError ` + pad + ` long tail"}
+			]}
+		]}`)
+		env, err := translate.ParseAnthropic(body)
+		require.NoError(t, err)
+		got := env.LastUserToolResultErrorText(64)
+		assert.LessOrEqual(t, len(got), 64)
+	})
+
+	t.Run("max bytes <= 0 returns empty", func(t *testing.T) {
+		body := []byte(`{"model":"claude-opus-4-7","tools":[],"messages":[
+			{"role":"user","content":"r"},
+			{"role":"assistant","content":[{"type":"tool_use","id":"t1","name":"X","input":{}}]},
+			{"role":"user","content":[
+				{"type":"tool_result","tool_use_id":"t1","is_error":true,"content":"InputValidationError"}
+			]}
+		]}`)
+		env, err := translate.ParseAnthropic(body)
+		require.NoError(t, err)
+		assert.Equal(t, "", env.LastUserToolResultErrorText(0))
+	})
+
+	t.Run("only the last user message is read", func(t *testing.T) {
+		// Earlier errored tool_result must be ignored; the gate looks at
+		// the LAST user-side input, which is the context the next turn has
+		// to act on.
+		body := []byte(`{"model":"claude-sonnet-4-5","tools":[],"messages":[
+			{"role":"user","content":"first step"},
+			{"role":"assistant","content":[{"type":"tool_use","id":"t1","name":"X","input":{}}]},
+			{"role":"user","content":[
+				{"type":"tool_result","tool_use_id":"t1","is_error":true,"content":"InputValidationError OLD harness failure"}
+			]},
+			{"role":"assistant","content":[{"type":"text","text":"retrying..."}]},
+			{"role":"user","content":[
+				{"type":"tool_result","tool_use_id":"t2","is_error":true,"content":"InputValidationError fresh recovery context with EnterPlanMode"}
+			]}
+		]}`)
+		env, err := translate.ParseAnthropic(body)
+		require.NoError(t, err)
+		got := env.LastUserToolResultErrorText(4096)
+		// Last user message wins; earlier "OLD" payload must be ignored.
+		assert.NotContains(t, got, "OLD")
+		// Last payload's recovery-style text is what the gate sees.
+		assert.Contains(t, got, "fresh recovery context")
+	})
+
+	t.Run("no user messages yields empty", func(t *testing.T) {
+		body := []byte(`{"model":"claude-opus-4-7","tools":[],"messages":[]}`)
+		env, err := translate.ParseAnthropic(body)
+		require.NoError(t, err)
+		assert.Equal(t, "", env.LastUserToolResultErrorText(4096))
+	})
+}


### PR DESCRIPTION
## Summary

Two related routing-quality changes, motivated by a large agentic session where a sub-agent turn ("Load EnterPlanMode tool schema") was served by a flash-tier model that couldn't drive the deferred-tool protocol — the session silently lost plan mode, and the response claimed `ToolSearch` didn't exist while the request had declared it.

### 1. Harness-protocol escalation gate (route up, never down)

Three new deterministic turn classifications in `internal/router/turntype`:

- **`harness_meta`** — main-turn skill/command invocation (`<command-name>`/`<command-message>` markers) whose text references harness primitives
- **`sub_agent_harness_meta`** — sub-agent dispatch whose prompt references harness primitives (keyword gate over a bounded prefix; reuses the CC-only tool-name registry, length-filtered so "Task"/"Agent"/"Workflow" can't false-positive)
- **`recovery`** — tool-result turn recovering from a deferred-tool `InputValidationError` (requires BOTH the error class AND deferred-tool context, so ordinary schema-mistake retries don't escalate)

`runTurnLoop` now wraps the routing orchestrator so every decision path passes `applyHarnessEscalation` exactly once: if the turn is harness-bound and the resolved model is not already Claude-family TierHigh, the decision is replaced with `claude-opus-5` (the loop-escalation target). Precedence mirrors loop escalation: subscription usage-bypass, operator hard pins, `/force-model` pins, and an existing loop-escalation decision all outrank the clamp. `sub_agent_harness_meta` is carved out of the cheap sub-agent hard-pin path. Kill switch: `ROUTER_HARNESS_ESCALATION_ENABLED` (default on).

**Sidecar compatibility:** the policy sidecar keeps its stable turn-type vocabulary — `TurnType.Base()` maps the harness variants back to `main_loop`/`sub_agent_dispatch`/`tool_result` at the policy boundary and at behavior-compatible call sites (spiral/text-repetition gates, feedback footer, tool-result stickies), while telemetry and OTel record the full new values. The clamp is per-turn and never writes a pin, so it can't anchor a session.

### 2. Claimed-tool-unavailable auto-feedback

A capture-gated post-stream detector (`internal/proxy/claimed_tool_unavailable.go`, spiral-shadow shape): when the captured response text claims a tool is unavailable ("There is no ToolSearch tool in my available toolset", "not directly callable", …) AND that exact name is in the request's declared tools, it writes a `router.router_feedback` row with `source='auto'`, `rating='down'`, `feedback='claimed-tool-unavailable:<Tool>'`. Persist-only: no strategy forwarding, no routing action, LRU-deduped per (session, role, tool), fail-open on malformed/truncated capture. Uses the previously-unused `RouterFeedbackSourceAuto` constant and the existing `source` column — no migration.

## Testing

- `go build ./...`, `go vet ./...`, full `go test ./...` pass; gofmt clean
- Turn-type fixtures include the real failing sub-agent prompt and a `<command-message>qplan</command-message>` main-turn fixture, plus negative guards (prose *about* ToolSearch, command turns without harness references, OpenAI-format gate, ordinary InputValidationError retries)
- Clamp precedence table: escalates low-tier and TierHigh-non-Claude picks on all three turn types; no-ops for already-strong, user-forced, hard-pinned, usage-bypass, kill-switch-off, provider-ineligible, model-excluded
- Detector: phrase table positives/negatives, ±window boundary pinned on both sides, SSE claim split across text_delta frames, non-streaming body, dedup + insert-failure retry semantics

🤖 Generated with [Weave Router](https://router.workweave.ai)
