### PR TITLE
chore(install): bump router npm package to 0.2.10

### DIFF
--- a/install/npm/package.json
+++ b/install/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@workweave/router",
-  "version": "0.2.9",
+  "version": "0.2.10",
   "description": "One-command installer that points Claude Code, Codex, opencode, or pi at the Weave Router. For pi it also ships the routing extension, loaded via pi.extensions.",
   "bin": {
     "weave-router": "bin.js",


### PR DESCRIPTION
Bump `@workweave/router` to 0.2.10 to release the auto-update install changes from #918.

The tag `router-v0.2.10` will be the signal for `publish_npm.yml` to publish the new version after this lands on main.

🤖 Generated with [Weave Router](https://router.workweave.ai)

Co-Authored-By: Weave Router <router@workweave.ai>