### PR TITLE
sidecars/hmm: log per-stage timings for each routing decision

### DIFF
--- a/sidecars/hmm/hmm_sidecar/api.py
+++ b/sidecars/hmm/hmm_sidecar/api.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 import os
+import sys
 from contextlib import asynccontextmanager
 from typing import Any
 
@@ -19,10 +20,34 @@ from .policy import FrozenPolicy
 
 log = logging.getLogger(__name__)
 VERSION = os.environ.get("VERSION", "dev")
+LOG_LEVEL = os.environ.get("HMM_LOG_LEVEL", "INFO").upper()
+
+
+def configure_logging() -> None:
+    """Make this package's INFO records reach stdout.
+
+    uvicorn configures only its own ``uvicorn*`` loggers and the root logger has
+    no handler, so anything below WARNING emitted here falls through to
+    ``logging.lastResort`` and is silently dropped — which is why the per-stage
+    route timings were invisible until this ran.
+
+    Deliberately not ``basicConfig``: a handler is attached only when nothing
+    else has configured logging. If a host already owns the root logger, raising
+    this logger's level is enough for records to propagate into that setup, and
+    adding our own handler would duplicate every line.
+    """
+    package_log = logging.getLogger(__package__ or "hmm_sidecar")
+    package_log.setLevel(getattr(logging, LOG_LEVEL, logging.INFO))
+    if logging.getLogger().handlers or package_log.handlers:
+        return
+    handler = logging.StreamHandler(sys.stdout)
+    handler.setFormatter(logging.Formatter("%(levelname)s: %(name)s %(message)s"))
+    package_log.addHandler(handler)
 
 
 @asynccontextmanager
 async def lifespan(application: FastAPI):
+    configure_logging()
     try:
         artifacts = resolve_artifacts()
         embedder = build_embedder(artifacts.manifest.embedding_contract)
@@ -139,7 +164,7 @@ async def route(payload: dict[str, Any]) -> JSONResponse:
     if payload.get("schema_version") not in (None, SCHEMA_VERSION):
         return JSONResponse({"error": "unsupported policy schema"}, status_code=400)
     try:
-        result = await policy.route(payload)
+        result, timings = await policy.route_with_timings(payload)
     except (ValueError, EmbeddingError) as exc:
         log.warning("HMM route request rejected: %s", exc)
         return JSONResponse({"error": "route request rejected"}, status_code=422)
@@ -148,6 +173,11 @@ async def route(payload: dict[str, Any]) -> JSONResponse:
         return JSONResponse(
             {"error": f"route failed: {type(exc).__name__}"}, status_code=503
         )
+    # One line per decision, durations and counts only. The routing decision is
+    # serialized ahead of the upstream request, so this is the only place the
+    # per-stage cost of that wait is observable; the response contract carries
+    # no timing fields and the caller sees a single opaque total.
+    log.info("hmm route timing %s", timings.log_fields())
     return JSONResponse(
         {
             "schema_version": SCHEMA_VERSION,

--- a/sidecars/hmm/hmm_sidecar/embeddings.py
+++ b/sidecars/hmm/hmm_sidecar/embeddings.py
@@ -4,6 +4,7 @@ import asyncio
 import math
 import os
 from collections import OrderedDict
+from dataclasses import dataclass
 from typing import Protocol
 
 import httpx
@@ -170,6 +171,24 @@ async def verify_embedding_contract(
     return similarity
 
 
+@dataclass(frozen=True, slots=True)
+class EmbedStats:
+    """Per-call cache accounting for one ``CachedEmbedder.embed`` invocation.
+
+    ``fetched`` is the number of texts that actually crossed the network. It is
+    the interesting one: the policy embeds the whole conversation on every turn,
+    so a warm cache should leave only the newest turn(s) to fetch, and a
+    persistently high ``fetched`` means the cache is not doing its job (each
+    process holds its own LRU, so a session spread across instances re-fetches
+    turns another instance already has).
+    """
+
+    requested: int
+    unique: int
+    cached: int
+    fetched: int
+
+
 class CachedEmbedder:
     def __init__(self, inner: Embedder, dimensions: int) -> None:
         self.inner = inner
@@ -178,6 +197,18 @@ class CachedEmbedder:
         self.lock = asyncio.Lock()
 
     async def embed(self, texts: list[str]) -> list[np.ndarray]:
+        vectors, _ = await self.embed_with_stats(texts)
+        return vectors
+
+    async def embed_with_stats(
+        self, texts: list[str]
+    ) -> tuple[list[np.ndarray], EmbedStats]:
+        """Same as :meth:`embed`, plus what the cache did.
+
+        Stats are returned rather than recorded on the instance because the
+        sidecar serves several requests concurrently, so an instance attribute
+        would be read by the wrong request.
+        """
         unique = list(dict.fromkeys(texts))
         async with self.lock:
             cached = {text: self.cache[text] for text in unique if text in self.cache}
@@ -199,4 +230,10 @@ class CachedEmbedder:
             while len(self.cache) > MAX_CACHE_ITEMS:
                 self.cache.popitem(last=False)
         resolved = {**cached, **fetched}
-        return [resolved[text] for text in texts]
+        stats = EmbedStats(
+            requested=len(texts),
+            unique=len(unique),
+            cached=len(cached),
+            fetched=len(missing),
+        )
+        return [resolved[text] for text in texts], stats

--- a/sidecars/hmm/hmm_sidecar/policy.py
+++ b/sidecars/hmm/hmm_sidecar/policy.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import hashlib
 import json
+import time
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
@@ -9,7 +11,7 @@ import numpy as np
 
 from .artifacts import FrozenArtifacts
 from .classifier import FrozenClassifier
-from .embeddings import CachedEmbedder, Embedder
+from .embeddings import CachedEmbedder, Embedder, EmbedStats
 from .features import (
     classifier_features,
     conversation_sequence,
@@ -18,6 +20,70 @@ from .features import (
 )
 from .hmm import FrozenHMM
 from .schemas import Candidate, RankedFallback, RoutePreviewResult, RouteResult
+
+
+@dataclass(frozen=True, slots=True)
+class RouteTimings:
+    """Wall-clock cost of each stage of one routing decision, in milliseconds.
+
+    The decision runs to completion before the router dispatches the upstream
+    request, so this is time added to the caller's wait for a first token. It is
+    reported per stage because the stages have very different characters: the
+    embed hop is a network round trip whose cost tracks how many turns missed
+    the cache, while the rest is local numpy/XGBoost work that tracks sequence
+    length. Without the split, a regression in either is a single opaque number.
+
+    Carries no text, ids, or model output — only durations and counts — so it is
+    safe to log verbatim.
+    """
+
+    sequence_ms: float
+    embed_ms: float
+    hmm_ms: float
+    classifier_ms: float
+    total_ms: float
+    turns: int
+    embed_requested: int
+    embed_cached: int
+    embed_fetched: int
+
+    @classmethod
+    def build(
+        cls,
+        *,
+        started: float,
+        sequence_ms: float,
+        embed_ms: float,
+        hmm_ms: float,
+        classifier_ms: float,
+        turns: int,
+        stats: EmbedStats,
+    ) -> RouteTimings:
+        return cls(
+            sequence_ms=sequence_ms,
+            embed_ms=embed_ms,
+            hmm_ms=hmm_ms,
+            classifier_ms=classifier_ms,
+            total_ms=(time.perf_counter() - started) * 1000.0,
+            turns=turns,
+            embed_requested=stats.requested,
+            embed_cached=stats.cached,
+            embed_fetched=stats.fetched,
+        )
+
+    def log_fields(self) -> str:
+        """Compact ``key=value`` rendering for one log line."""
+        return (
+            f"total_ms={self.total_ms:.1f} "
+            f"sequence_ms={self.sequence_ms:.1f} "
+            f"embed_ms={self.embed_ms:.1f} "
+            f"hmm_ms={self.hmm_ms:.1f} "
+            f"classifier_ms={self.classifier_ms:.1f} "
+            f"turns={self.turns} "
+            f"embed_requested={self.embed_requested} "
+            f"embed_cached={self.embed_cached} "
+            f"embed_fetched={self.embed_fetched}"
+        )
 
 
 def select_roster_group(
@@ -116,7 +182,8 @@ class FrozenPolicy:
 
     async def _evaluate(
         self, payload: dict[str, Any], *, allow_empty_candidates: bool
-    ) -> tuple[list[Candidate], Any, Any]:
+    ) -> tuple[list[Candidate], Any, Any, RouteTimings]:
+        started = time.perf_counter()
         candidates = [
             Candidate.model_validate(value) for value in payload.get("candidates") or []
         ]
@@ -125,9 +192,22 @@ class FrozenPolicy:
         by_roster = {candidate.roster_id: candidate for candidate in candidates}
         if len(by_roster) != len(candidates):
             raise ValueError("candidate roster_id values must be unique")
+
+        mark = time.perf_counter()
         turns = conversation_sequence(payload)
-        embeddings = await self.embedder.embed([turn.text for turn in turns])
+        sequence_ms = (time.perf_counter() - mark) * 1000.0
+
+        mark = time.perf_counter()
+        embeddings, embed_stats = await self.embedder.embed_with_stats(
+            [turn.text for turn in turns]
+        )
+        embed_ms = (time.perf_counter() - mark) * 1000.0
+
+        mark = time.perf_counter()
         readout = self.hmm.posterior(raw_hmm_features(embeddings, turns))
+        hmm_ms = (time.perf_counter() - mark) * 1000.0
+
+        mark = time.perf_counter()
         feature_row = classifier_features(
             embedding=embeddings[-1],
             gamma=readout.gamma[-1],
@@ -138,10 +218,21 @@ class FrozenPolicy:
             tool_context=tool_context_features(payload),
         )
         classification = self.classifier.predict(feature_row)
-        return candidates, readout, classification
+        classifier_ms = (time.perf_counter() - mark) * 1000.0
+
+        timings = RouteTimings.build(
+            started=started,
+            sequence_ms=sequence_ms,
+            embed_ms=embed_ms,
+            hmm_ms=hmm_ms,
+            classifier_ms=classifier_ms,
+            turns=len(turns),
+            stats=embed_stats,
+        )
+        return candidates, readout, classification, timings
 
     async def preview(self, payload: dict[str, Any]) -> RoutePreviewResult:
-        candidates, readout, classification = await self._evaluate(
+        candidates, readout, classification, _ = await self._evaluate(
             payload, allow_empty_candidates=True
         )
         selected_group, eligible_arms, ranked_fallback = select_roster_group(
@@ -166,7 +257,19 @@ class FrozenPolicy:
         )
 
     async def route(self, payload: dict[str, Any]) -> RouteResult:
-        candidates, readout, classification = await self._evaluate(
+        result, _ = await self.route_with_timings(payload)
+        return result
+
+    async def route_with_timings(
+        self, payload: dict[str, Any]
+    ) -> tuple[RouteResult, RouteTimings]:
+        """Same as :meth:`route`, plus the per-stage cost of producing it.
+
+        Split out rather than folded into :class:`RouteResult` so the response
+        the router validates stays byte-identical — timings are an operational
+        signal, not part of the policy contract.
+        """
+        candidates, readout, classification, timings = await self._evaluate(
             payload, allow_empty_candidates=False
         )
         by_roster = {candidate.roster_id: candidate for candidate in candidates}
@@ -206,7 +309,7 @@ class FrozenPolicy:
             f"raw_top={classification.label!r}); "
             f"frozen roster arm {selected_roster_id!r}"
         )
-        return RouteResult(
+        result = RouteResult(
             route_id=route_id,
             selected_roster_id=selected.roster_id,
             selected_provider=selected.provider,
@@ -233,3 +336,4 @@ class FrozenPolicy:
                 "frozen_policy": True,
             },
         )
+        return result, timings

--- a/sidecars/hmm/tests/test_api.py
+++ b/sidecars/hmm/tests/test_api.py
@@ -1,13 +1,16 @@
 from __future__ import annotations
 
+import logging
+
 from fastapi.testclient import TestClient
 
-from hmm_sidecar.api import app
-from hmm_sidecar.schemas import RoutePreviewResult
+from hmm_sidecar.api import app, configure_logging
+from hmm_sidecar.policy import RouteTimings
+from hmm_sidecar.schemas import RoutePreviewResult, RouteResult
 
 
 class RejectingPolicy:
-    async def route(self, payload: dict[str, object]) -> None:
+    async def route_with_timings(self, payload: dict[str, object]) -> None:
         del payload
         raise ValueError("private artifact path: /secret/model.npz")
 
@@ -162,3 +165,162 @@ def test_roster_fails_closed_without_policy() -> None:
         response = client.get("/roster")
 
     assert response.status_code == 503
+
+
+class TimedPolicy:
+    """Returns a fixed decision plus fixed timings, so the log line is assertable."""
+
+    def __init__(self) -> None:
+        self.calls = 0
+
+    async def route_with_timings(self, payload: dict[str, object]):
+        del payload
+        self.calls += 1
+        return (
+            RouteResult(
+                route_id="route",
+                selected_roster_id="provider/a",
+                selected_provider="provider",
+                score=0.9,
+                candidate_scores={"provider/a": 0.9},
+                reason="test",
+                state_label="state_1",
+                policy_group="fast",
+                policy_label="fast",
+                policy_route_key="hmm:1:fast",
+                confidence=0.9,
+                margin=0.4,
+                propensity=1.0,
+                policy_artifact_id="artifact",
+                policy_artifact_sha256="a" * 64,
+                roster_version="b" * 64,
+                debug={"frozen_policy": True},
+            ),
+            RouteTimings(
+                sequence_ms=1.25,
+                embed_ms=604.5,
+                hmm_ms=7.5,
+                classifier_ms=2.5,
+                total_ms=616.0,
+                turns=12,
+                embed_requested=12,
+                embed_cached=10,
+                embed_fetched=2,
+            ),
+        )
+
+
+def test_route_logs_one_stage_timing_line(caplog) -> None:
+    """The whole point of the change: the per-stage split reaches the logs.
+
+    Asserting the individual stage keys, not just that something was logged —
+    a line that collapsed back to a single total would be the regression.
+    """
+    policy = TimedPolicy()
+    with caplog.at_level(logging.INFO, logger="hmm_sidecar.api"):
+        with TestClient(app) as client:
+            app.state.policy = policy
+            response = client.post(
+                "/route", json={"schema_version": "policy_router_v1"}
+            )
+
+    assert response.status_code == 200
+    assert policy.calls == 1
+
+    lines = [
+        r.getMessage() for r in caplog.records if "hmm route timing" in r.getMessage()
+    ]
+    assert len(lines) == 1, lines
+    line = lines[0]
+    for field in (
+        "total_ms=616.0",
+        "sequence_ms=1.2",
+        "embed_ms=604.5",
+        "hmm_ms=7.5",
+        "classifier_ms=2.5",
+        "turns=12",
+        "embed_requested=12",
+        "embed_cached=10",
+        "embed_fetched=2",
+    ):
+        assert field in line, f"{field!r} missing from {line!r}"
+
+
+def test_route_timing_log_carries_no_request_content() -> None:
+    """Durations and counts only — the line must stay safe to ship to logs."""
+    timings = RouteTimings(
+        sequence_ms=1.0,
+        embed_ms=2.0,
+        hmm_ms=3.0,
+        classifier_ms=4.0,
+        total_ms=10.0,
+        turns=2,
+        embed_requested=2,
+        embed_cached=1,
+        embed_fetched=1,
+    )
+
+    rendered = timings.log_fields()
+
+    assert set(rendered.split()) == {
+        "total_ms=10.0",
+        "sequence_ms=1.0",
+        "embed_ms=2.0",
+        "hmm_ms=3.0",
+        "classifier_ms=4.0",
+        "turns=2",
+        "embed_requested=2",
+        "embed_cached=1",
+        "embed_fetched=1",
+    }
+
+
+def test_route_failures_do_not_log_a_timing_line(caplog) -> None:
+    """A rejected route has no meaningful split; logging one would poison the
+    percentiles computed off these lines."""
+    with caplog.at_level(logging.INFO, logger="hmm_sidecar.api"):
+        with TestClient(app) as client:
+            app.state.policy = RejectingPolicy()
+            response = client.post(
+                "/route", json={"schema_version": "policy_router_v1"}
+            )
+
+    assert response.status_code == 422
+    assert not [r for r in caplog.records if "hmm route timing" in r.getMessage()]
+
+
+def test_package_logger_is_raised_so_info_records_are_not_dropped() -> None:
+    """Regression: the timing line was emitted but never reached stdout.
+
+    uvicorn configures only its own loggers and the root logger has no handler,
+    so hmm_sidecar INFO records fell through to logging.lastResort (WARNING+)
+    and vanished. A route timing that nothing can read is not instrumentation.
+    """
+    package_log = logging.getLogger("hmm_sidecar")
+    original_level = package_log.level
+    try:
+        package_log.setLevel(logging.NOTSET)
+        configure_logging()
+        assert package_log.isEnabledFor(logging.INFO)
+    finally:
+        package_log.setLevel(original_level)
+
+
+def test_configure_logging_does_not_duplicate_an_existing_setup() -> None:
+    """When a host already owns the root logger, records must propagate into it
+    rather than getting a second handler here (which would double every line)."""
+    package_log = logging.getLogger("hmm_sidecar")
+    root = logging.getLogger()
+    original_level = package_log.level
+    original_handlers = list(package_log.handlers)
+    probe = logging.StreamHandler()
+    package_log.handlers = []
+    root.addHandler(probe)
+    try:
+        configure_logging()
+        assert package_log.handlers == []
+        assert package_log.propagate is True
+    finally:
+        root.removeHandler(probe)
+        package_log.handlers = original_handlers
+        package_log.setLevel(original_level)

--- a/sidecars/hmm/tests/test_embedding_contract.py
+++ b/sidecars/hmm/tests/test_embedding_contract.py
@@ -135,3 +135,62 @@ async def test_cache_returns_hits_that_are_evicted_during_a_concurrent_fetch(
     assert len(vectors) == 2
     np.testing.assert_array_equal(vectors[0], [1.0, 2.0, 3.0])
     np.testing.assert_array_equal(vectors[1], [1.0, 2.0, 3.0])
+
+
+async def test_embed_stats_count_only_the_texts_that_crossed_the_network() -> None:
+    """The fetched count is the signal the timing log exists to expose.
+
+    The policy embeds the whole conversation on every turn, so a warm cache must
+    leave only the new text to fetch. Counting requested texts instead of misses
+    would report a constant batch size and hide the cache working (or not).
+    """
+
+    class CountingEmbedder:
+        def __init__(self) -> None:
+            self.calls: list[list[str]] = []
+
+        async def embed(self, texts: list[str]) -> list[list[float]]:
+            self.calls.append(list(texts))
+            return [[1.0, 2.0, 3.0] for _ in texts]
+
+    inner = CountingEmbedder()
+    embedder = CachedEmbedder(inner, dimensions=3)
+
+    _, first = await embedder.embed_with_stats(["turn-1", "turn-2"])
+    assert (first.requested, first.unique, first.cached, first.fetched) == (2, 2, 0, 2)
+
+    # Next turn of the same conversation: two texts already seen, one new.
+    _, second = await embedder.embed_with_stats(["turn-1", "turn-2", "turn-3"])
+    assert (second.requested, second.unique, second.cached, second.fetched) == (
+        3,
+        3,
+        2,
+        1,
+    )
+    assert inner.calls == [["turn-1", "turn-2"], ["turn-3"]]
+
+
+async def test_embed_stats_collapse_duplicate_texts() -> None:
+    """Duplicate turns are embedded once, and the stats must say so."""
+
+    inner = FakeEmbedder([1.0, 2.0, 3.0])
+    embedder = CachedEmbedder(inner, dimensions=3)
+
+    vectors, stats = await embedder.embed_with_stats(["same", "same", "same"])
+
+    assert len(vectors) == 3
+    assert (stats.requested, stats.unique, stats.fetched) == (3, 1, 1)
+
+
+async def test_embed_returns_the_same_vectors_with_or_without_stats() -> None:
+    """embed() is the compatibility wrapper; it must not drift from the stats path."""
+
+    inner = FakeEmbedder([4.0, 5.0, 6.0])
+    embedder = CachedEmbedder(inner, dimensions=3)
+
+    plain = await embedder.embed(["a", "b"])
+    with_stats, _ = await embedder.embed_with_stats(["a", "b"])
+
+    assert len(plain) == len(with_stats) == 2
+    for left, right in zip(plain, with_stats, strict=True):
+        np.testing.assert_array_equal(left, right)

--- a/sidecars/hmm/tests/test_policy.py
+++ b/sidecars/hmm/tests/test_policy.py
@@ -139,3 +139,152 @@ async def test_published_package_routes_an_offered_candidate(
     # cluster allowlist overrides.
     assert result.ranked_fallback
     assert any(group.group == selected_label for group in result.ranked_fallback)
+
+
+async def test_stage_timings_attribute_slow_work_to_the_stage_that_did_it() -> None:
+    """A slow embed must show up as embed_ms, not smeared across the total.
+
+    This is the property the whole change exists for: the router only ever saw
+    one opaque number, so a regression in the network hop and a regression in
+    the local model work looked identical. The test makes a stage deliberately
+    slow and asserts the split points at it.
+    """
+    import asyncio
+    import types
+
+    import numpy as np
+
+    from hmm_sidecar.embeddings import CachedEmbedder
+
+    dims = 4
+    embed_delay_s = 0.05
+
+    class SlowEmbedder:
+        async def embed(self, texts: list[str]) -> list[list[float]]:
+            await asyncio.sleep(embed_delay_s)
+            return [[0.1] * dims for _ in texts]
+
+    class FakeHMM:
+        n_states = 2
+
+        def posterior(self, features: np.ndarray):
+            steps = features.shape[0]
+            return types.SimpleNamespace(
+                gamma=np.full((steps, self.n_states), 0.5),
+                state=1,
+                previous_state=0,
+                state_path=[0] * steps,
+                confidence=0.5,
+                margin=0.0,
+            )
+
+    class FakeClassifier:
+        classes = ("fast", "maximum")
+
+        def predict(self, row: np.ndarray):
+            del row
+            return types.SimpleNamespace(
+                label="fast", probabilities={"fast": 0.7, "maximum": 0.3}
+            )
+
+    policy = object.__new__(FrozenPolicy)
+    policy.embedder = CachedEmbedder(SlowEmbedder(), dimensions=dims)
+    policy.hmm = FakeHMM()
+    policy.classifier = FakeClassifier()
+
+    payload = {
+        "candidates": [
+            {
+                "roster_id": "provider/a",
+                "catalog_id": "model-a",
+                "provider": "provider",
+            }
+        ],
+        "conversation_messages": [
+            {"role": "user", "text": "Inspect the repository."},
+            {"role": "assistant", "text": "Done."},
+            {"role": "user", "text": "Now fix the bug."},
+        ],
+    }
+
+    _, _, _, timings = await policy._evaluate(payload, allow_empty_candidates=False)
+
+    assert timings.embed_ms >= embed_delay_s * 1000 * 0.9
+    assert timings.hmm_ms < timings.embed_ms
+    assert timings.classifier_ms < timings.embed_ms
+    assert timings.total_ms >= timings.embed_ms
+    assert timings.turns == 3
+    assert timings.embed_requested == 3
+    assert timings.embed_fetched == 3
+    assert timings.embed_cached == 0
+
+
+async def test_stage_timings_report_cache_hits_on_a_continuing_conversation() -> None:
+    """Second turn of a session re-sends earlier turns; those must count as hits."""
+    import types
+
+    import numpy as np
+
+    from hmm_sidecar.embeddings import CachedEmbedder
+
+    dims = 4
+
+    class CountingEmbedder:
+        def __init__(self) -> None:
+            self.batches: list[int] = []
+
+        async def embed(self, texts: list[str]) -> list[list[float]]:
+            self.batches.append(len(texts))
+            return [[0.2] * dims for _ in texts]
+
+    class FakeHMM:
+        def posterior(self, features: np.ndarray):
+            steps = features.shape[0]
+            return types.SimpleNamespace(
+                gamma=np.full((steps, 2), 0.5),
+                state=0,
+                previous_state=0,
+                state_path=[0] * steps,
+                confidence=0.5,
+                margin=0.0,
+            )
+
+    class FakeClassifier:
+        classes = ("fast", "maximum")
+
+        def predict(self, row: np.ndarray):
+            del row
+            return types.SimpleNamespace(
+                label="fast", probabilities={"fast": 0.6, "maximum": 0.4}
+            )
+
+    inner = CountingEmbedder()
+    policy = object.__new__(FrozenPolicy)
+    policy.embedder = CachedEmbedder(inner, dimensions=dims)
+    policy.hmm = FakeHMM()
+    policy.classifier = FakeClassifier()
+
+    candidates = [
+        {"roster_id": "provider/a", "catalog_id": "model-a", "provider": "provider"}
+    ]
+    first = {
+        "candidates": candidates,
+        "conversation_messages": [{"role": "user", "text": "Inspect the repository."}],
+    }
+    second = {
+        "candidates": candidates,
+        "conversation_messages": [
+            {"role": "user", "text": "Inspect the repository."},
+            {"role": "assistant", "text": "Done."},
+            {"role": "user", "text": "Now fix the bug."},
+        ],
+    }
+
+    *_, first_timings = await policy._evaluate(first, allow_empty_candidates=False)
+    *_, second_timings = await policy._evaluate(second, allow_empty_candidates=False)
+
+    assert (first_timings.embed_cached, first_timings.embed_fetched) == (0, 1)
+    # The opening turn's text repeats verbatim, so only the new turns are fetched.
+    assert second_timings.embed_cached == 1
+    assert second_timings.embed_fetched == 2
+    assert inner.batches == [1, 2]


### PR DESCRIPTION
## Why

The routing decision runs to completion before the upstream request is dispatched, so every millisecond it costs is prepended to the caller's wait for a first token. Today that cost is a single opaque number — the sidecar has no internal timing at all, `RouteResult` carries no timing fields, and the caller sees only a total. A regression in the embed round trip and a regression in the local model work look identical.

## What

Time each stage of `FrozenPolicy._evaluate` and emit one line per decision:

```
hmm route timing total_ms=493.5 sequence_ms=0.0 embed_ms=487.1 hmm_ms=2.5 \
  classifier_ms=3.9 turns=3 embed_requested=3 embed_cached=0 embed_fetched=3
```

The line carries durations and counts only — no text, ids, or model output.

## What it shows

Three requests against the frozen v1 package in the built image:

| scenario | total | embed | hmm | classifier | cache |
|---|---|---|---|---|---|
| cold, 3 turns | 493.5ms | **487.1ms** | 2.5ms | 3.9ms | 0 hit / 3 fetched |
| same conversation, warm | **5.6ms** | 0.0ms | 2.6ms | 2.8ms | 3 hit / 0 fetched |
| 15 turns, partly warm | 807.4ms | **802.3ms** | 3.6ms | 1.3ms | 3 hit / 12 fetched |

The split is lopsided: a cold decision is ~99% embed round trip, while the HMM posterior and classifier together cost ~5ms and barely move with sequence length (2.5ms at 3 turns, 3.6ms at 15). A fully warm decision is 5.6ms.

That is why the cache counters are in the line. The policy embeds the whole conversation on every turn, so a warm cache should leave only the newest turn to fetch. A persistently high `embed_fetched` means the cache is not working — and since each process holds its own LRU, a session spread across replicas re-fetches turns another replica already has. The counters make that visible instead of inferable.

## Contract

Timings come back from a new `route_with_timings()` rather than being added to `RouteResult`, so the response the caller validates is byte-identical and the policy contract is untouched. `route()` and `CachedEmbedder.embed()` remain as wrappers. The embedding contract, startup probe, and data-only runtime boundary are unchanged.

## The bug this also fixes

None of the above would have appeared in a deployment. Nothing in the service configured logging, uvicorn configures only its own `uvicorn*` loggers, and the root logger has no handler — so every `hmm_sidecar` record below WARNING fell through to `logging.lastResort` and was dropped. The first container smoke test returned `200` with no timing line at all.

`configure_logging()` raises this package's level and attaches a stdout handler **only when nothing else has configured logging**, so a host that owns the root logger keeps its setup and does not get duplicated lines. Overridable with `HMM_LOG_LEVEL`.

## Validation

- `poetry run pytest -q` in `sidecars/hmm/` — 43 passed, 1 skipped
- `HMM_TEST_PACKAGE=<v1 package> poetry run pytest -q tests/test_policy.py` — 7 passed (the artifact-gated test no longer skips; exercises the real 110-state HMM / 3431-feature classifier through the new path)
- `poetry run python -m scripts.verify_artifact` on the v1 package — digest matches
- `go vet ./...`, `wv mr tc`, `docker compose --profile hmm config --quiet`
- `docker build --file sidecars/hmm/Dockerfile` and a live container: booted, `/route` returned 200, timing line present in `docker logs`
- `black --check hmm_sidecar/ tests/` clean

New tests assert behaviour, not plumbing: that a deliberately slow embed lands in `embed_ms` and not smeared across the total; that a continuing conversation reports its earlier turns as cache hits; that a rejected route logs no timing line (which would poison percentiles computed off these lines); and that the package logger is actually enabled for INFO — the regression the smoke test caught.

🤖 Generated with [Weave Router](https://router.workweave.ai)