### PR TITLE
feat(proxy): degrade to session pin (or tier-3 default) on policy sidecar deadline instead of 503

### DIFF
--- a/cmd/router/main.go
+++ b/cmd/router/main.go
@@ -578,15 +578,10 @@ func main() {
 	hmmUpgradeConfidence := parseEnvFloat("ROUTER_HMM_UPGRADE_CONFIDENCE_THRESHOLD", 0.85)
 	hmmSameTierPin := config.GetOr("ROUTER_HMM_SAME_TIER_PIN", "false") == "true"
 	hmPinStickyOnArmSelectorUnavail := config.GetOr("ROUTER_HMM_PIN_STICKY_ON_ARM_SELECTOR_UNAVAIL", "false") == "true"
-	// policyDeadlineFallback degrades a policy sidecar deadline/transport
-	// failure to the session pin (or the tier-3 static default below) instead
-	// of a 503. Off by default: enabling requires a build with this fallback
-	// wired, so a self-hoster on an old binary can't set the env var and get
-	// a config no-op.
+	// policyDeadlineFallback degrades a policy sidecar deadline/transport failure to
+	// the session pin (or tier-3 default below) instead of a 503. Kill switch; off by default.
 	policyDeadlineFallback := config.GetOr("ROUTER_POLICY_DEADLINE_FALLBACK", "false") == "true"
-	// policyDeadlineDefaultModel is the tier-3 static safe default served on a
-	// policy deadline miss with no session pin yet (~0.2% of failures). Empty
-	// (default) preserves fail-closed (503) for pinless sessions.
+	// policyDeadlineDefaultModel is the tier-3 static fallback on a deadline miss with no pin; empty = fail-closed.
 	policyDeadlineDefaultModel := config.GetOr("ROUTER_POLICY_DEADLINE_DEFAULT_MODEL", "")
 	handoverProviderName := config.GetOr("ROUTER_HANDOVER_PROVIDER", providers.ProviderAnthropic)
 	handoverModel := config.GetOr("ROUTER_HANDOVER_MODEL", proxy.DefaultHandoverModel)

--- a/cmd/router/main.go
+++ b/cmd/router/main.go
@@ -578,6 +578,16 @@ func main() {
 	hmmUpgradeConfidence := parseEnvFloat("ROUTER_HMM_UPGRADE_CONFIDENCE_THRESHOLD", 0.85)
 	hmmSameTierPin := config.GetOr("ROUTER_HMM_SAME_TIER_PIN", "false") == "true"
 	hmPinStickyOnArmSelectorUnavail := config.GetOr("ROUTER_HMM_PIN_STICKY_ON_ARM_SELECTOR_UNAVAIL", "false") == "true"
+	// policyDeadlineFallback degrades a policy sidecar deadline/transport
+	// failure to the session pin (or the tier-3 static default below) instead
+	// of a 503. Off by default: enabling requires a build with this fallback
+	// wired, so a self-hoster on an old binary can't set the env var and get
+	// a config no-op.
+	policyDeadlineFallback := config.GetOr("ROUTER_POLICY_DEADLINE_FALLBACK", "false") == "true"
+	// policyDeadlineDefaultModel is the tier-3 static safe default served on a
+	// policy deadline miss with no session pin yet (~0.2% of failures). Empty
+	// (default) preserves fail-closed (503) for pinless sessions.
+	policyDeadlineDefaultModel := config.GetOr("ROUTER_POLICY_DEADLINE_DEFAULT_MODEL", "")
 	handoverProviderName := config.GetOr("ROUTER_HANDOVER_PROVIDER", providers.ProviderAnthropic)
 	handoverModel := config.GetOr("ROUTER_HANDOVER_MODEL", proxy.DefaultHandoverModel)
 	handoverTimeout := parseEnvDurationMs("ROUTER_HANDOVER_TIMEOUT_MS", proxy.DefaultHandoverTimeout)
@@ -777,6 +787,8 @@ func main() {
 		WithHMMUpgradeConfidenceThreshold(hmmUpgradeConfidence).
 		WithHMMSameTierPin(hmmSameTierPin).
 		WithHMPinStickyOnArmSelectorUnavail(hmPinStickyOnArmSelectorUnavail).
+		WithPolicyDeadlineFallback(policyDeadlineFallback).
+		WithPolicyDeadlineDefaultModel(policyDeadlineDefaultModel).
 		WithEscapeNormalize(escapeNormalize).
 		WithEffortEscalation(effortEscalation).
 		WithCCOrchestrationToolsCrossVendor(ccOrchToolsCrossVendor).

--- a/internal/proxy/gemini.go
+++ b/internal/proxy/gemini.go
@@ -154,6 +154,7 @@ func (s *Service) ProxyGeminiGenerateContent(ctx context.Context, body []byte, w
 		String("decision.model", decision.Model).
 		String("decision.provider", decision.Provider).
 		String("decision.reason", decision.Reason).
+		Bool("routing.policy_fallback", routeRes.PolicyFallback).
 		Bool("routing.sticky_hit", stickyHit).
 		Bool("routing.session_pin_hit", pinTier == "in_proc" || pinTier == "postgres").
 		String("routing.session_pin_tier", pinTier).

--- a/internal/proxy/policy_deadline_fallback_internal_test.go
+++ b/internal/proxy/policy_deadline_fallback_internal_test.go
@@ -20,11 +20,9 @@ import (
 	"workweave/router/internal/translate"
 )
 
-// policyDeadlineTestErr mirrors the real error chain a deadline-exceeded
-// sidecar call produces: policyclient wraps context.DeadlineExceeded with %w,
-// SidecarRouter.Decide wraps that with hmm.ErrHMMUnavailable via %w: %w (see
-// internal/router/policy/sidecar_router.go:311). Both sentinels must survive
-// via errors.Is for isPolicyDeadlineErr to see them.
+// policyDeadlineTestErr mirrors the real error chain: policyclient wraps
+// context.DeadlineExceeded with %w; SidecarRouter wraps that with hmm.ErrHMMUnavailable
+// via %w:%w (sidecar_router.go:311). Both must survive for errors.Is to see them.
 var policyDeadlineTestErr = fmt.Errorf(
 	"hmm_embedding: sidecar decide: policy sidecar retries exhausted: %w: %w",
 	context.DeadlineExceeded,
@@ -137,7 +135,12 @@ func buildPolicyDeadlineFallbackService(
 		})
 }
 
-func runPolicyDeadlineFallbackTurnLoop(t *testing.T, svc *Service, strategy router.Strategy) (turnLoopResult, error) {
+func runPolicyDeadlineFallbackTurnLoop(
+	t *testing.T,
+	svc *Service,
+	strategy router.Strategy,
+	excludedModels ...string,
+) (turnLoopResult, error) {
 	t.Helper()
 	env, err := translate.ParseAnthropic(
 		[]byte(`{"model":"claude-opus-4-8","messages":[{"role":"user","content":"continue"}]}`),
@@ -145,11 +148,19 @@ func runPolicyDeadlineFallbackTurnLoop(t *testing.T, svc *Service, strategy rout
 	require.NoError(t, err)
 	features := env.RoutingFeatures(false)
 	ctx := router.WithStrategy(context.Background(), strategy)
+	var excluded map[string]struct{}
+	if len(excludedModels) > 0 {
+		excluded = make(map[string]struct{}, len(excludedModels))
+		for _, model := range excludedModels {
+			excluded[model] = struct{}{}
+		}
+	}
 	req := router.Request{
 		RequestedModel:       features.Model,
 		EstimatedInputTokens: features.Tokens,
 		HasTools:             features.HasTools,
 		ConversationMessages: conversationMessagesForRouting(env),
+		ExcludedModels:       excluded,
 	}
 	return svc.runTurnLoop(ctx, env, features, "api-key", uuid.New(), "", http.Header{}, req)
 }
@@ -191,6 +202,31 @@ func TestTurnLoop_DeadlineFallbackToPin(t *testing.T) {
 	store.mu.Unlock()
 	require.NotEmpty(t, upserts)
 	assert.Equal(t, pinnedModel, upserts[len(upserts)-1].Model)
+	assert.Equal(t, store.getPin.Reason, upserts[len(upserts)-1].Reason,
+		"the persisted pin must keep its hmm_policy reason so later turns still see an HMM pin")
+}
+
+// TestTurnLoop_DeadlineFallbackDefaultExcludedFailsClosed proves the tier-3
+// default honours this turn's exclusions instead of serving (and pinning) a
+// model the request forbids.
+func TestTurnLoop_DeadlineFallbackDefaultExcludedFailsClosed(t *testing.T) {
+	strategy := router.Strategy("policy-deadline-fallback-default-excluded-test")
+	const defaultModel = "claude-haiku-4-5"
+
+	store := newStubPinStore()
+	store.getFound = false
+
+	svc := buildPolicyDeadlineFallbackService(t, strategy, policyDeadlineTestErr, store, true, defaultModel)
+
+	_, err := runPolicyDeadlineFallbackTurnLoop(t, svc, strategy, defaultModel)
+
+	require.Error(t, err, "an excluded tier-3 default must fail closed, not be served")
+	assert.ErrorIs(t, err, hmm.ErrHMMUnavailable)
+
+	store.mu.Lock()
+	upserts := append([]sessionpin.Pin(nil), store.upserts...)
+	store.mu.Unlock()
+	assert.Empty(t, upserts, "an excluded model must never be persisted as a pin")
 }
 
 // TestTurnLoop_DeadlineFallbackToTierThreeDefault covers the pinless branch:

--- a/internal/proxy/policy_deadline_fallback_internal_test.go
+++ b/internal/proxy/policy_deadline_fallback_internal_test.go
@@ -20,9 +20,8 @@ import (
 	"workweave/router/internal/translate"
 )
 
-// policyDeadlineTestErr mirrors the real error chain: policyclient wraps
-// context.DeadlineExceeded with %w; SidecarRouter wraps that with hmm.ErrHMMUnavailable
-// via %w:%w (sidecar_router.go:311). Both must survive for errors.Is to see them.
+// policyDeadlineTestErr mirrors the real chain: policyclient wraps context.DeadlineExceeded with %w;
+// SidecarRouter wraps that with hmm.ErrHMMUnavailable via %w:%w. Both must survive for errors.Is.
 var policyDeadlineTestErr = fmt.Errorf(
 	"hmm_embedding: sidecar decide: policy sidecar retries exhausted: %w: %w",
 	context.DeadlineExceeded,

--- a/internal/proxy/policy_deadline_fallback_internal_test.go
+++ b/internal/proxy/policy_deadline_fallback_internal_test.go
@@ -1,0 +1,292 @@
+package proxy
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"workweave/router/internal/providers"
+	"workweave/router/internal/router"
+	"workweave/router/internal/router/hmm"
+	"workweave/router/internal/router/policy"
+	"workweave/router/internal/router/sessionpin"
+	"workweave/router/internal/translate"
+)
+
+// policyDeadlineTestErr mirrors the real error chain a deadline-exceeded
+// sidecar call produces: policyclient wraps context.DeadlineExceeded with %w,
+// SidecarRouter.Decide wraps that with hmm.ErrHMMUnavailable via %w: %w (see
+// internal/router/policy/sidecar_router.go:311). Both sentinels must survive
+// via errors.Is for isPolicyDeadlineErr to see them.
+var policyDeadlineTestErr = fmt.Errorf(
+	"hmm_embedding: sidecar decide: policy sidecar retries exhausted: %w: %w",
+	context.DeadlineExceeded,
+	hmm.ErrHMMUnavailable,
+)
+
+// policyContractViolationTestErr mirrors a genuine contract violation
+// (sidecar_router.go:367/370) — also wraps hmm.ErrHMMUnavailable, but without
+// a deadline/cancel in the chain. isPolicyDeadlineErr must return false for
+// this so contract violations still fail closed.
+var policyContractViolationTestErr = fmt.Errorf(
+	"hmm_embedding: sidecar returned unknown arm %q or model %q: %w",
+	"bogus-arm", "bogus-model",
+	hmm.ErrHMMUnavailable,
+)
+
+// erroringTestRouter always returns a fixed error, simulating a policy
+// sidecar deadline/transport failure or contract violation.
+type erroringTestRouter struct {
+	err error
+}
+
+func (r *erroringTestRouter) Route(_ context.Context, _ router.Request) (router.Decision, error) {
+	return router.Decision{}, r.err
+}
+
+func TestIsPolicyDeadlineErr(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "nil error",
+			err:  nil,
+			want: false,
+		},
+		{
+			name: "deadline exceeded wrapping ErrHMMUnavailable",
+			err:  policyDeadlineTestErr,
+			want: true,
+		},
+		{
+			name: "context canceled wrapping ErrHMMUnavailable",
+			err: fmt.Errorf("hmm_embedding: sidecar decide: %w: %w",
+				context.Canceled, hmm.ErrHMMUnavailable),
+			want: true,
+		},
+		{
+			name: "contract violation (unknown arm) must still fail closed",
+			err:  policyContractViolationTestErr,
+			want: false,
+		},
+		{
+			name: "contract violation (provider mismatch) must still fail closed",
+			err: fmt.Errorf("hmm_embedding: sidecar returned provider %q for %q, expected %q: %w",
+				"openai", "claude-opus-4-7", "anthropic", hmm.ErrHMMUnavailable),
+			want: false,
+		},
+		{
+			name: "ErrHMMUnavailable without a deadline/cancel is not a deadline error",
+			err:  fmt.Errorf("hmm_embedding: sidecar unavailable: %w", hmm.ErrHMMUnavailable),
+			want: false,
+		},
+		{
+			name: "unrelated error",
+			err:  errors.New("boom"),
+			want: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := isPolicyDeadlineErr(test.err)
+			assert.Equal(t, test.want, got)
+		})
+	}
+}
+
+// buildPolicyDeadlineFallbackService constructs a *Service wired with an
+// erroring policy strategy so runTurnLoop's routeFor call fails with err.
+func buildPolicyDeadlineFallbackService(
+	t *testing.T,
+	strategy router.Strategy,
+	err error,
+	store sessionpin.Store,
+	fallbackEnabled bool,
+	defaultModel string,
+) *Service {
+	t.Helper()
+	return NewService(
+		nil,
+		map[string]providers.Client{providers.ProviderAnthropic: nil},
+		nil,
+		false,
+		nil,
+		store,
+		false,
+		providers.ProviderAnthropic,
+		"claude-haiku-4-5",
+		nil,
+	).WithPolicyDeadlineFallback(fallbackEnabled).
+		WithPolicyDeadlineDefaultModel(defaultModel).
+		WithPolicyStrategy(policy.StrategySpec{
+			Strategy: strategy,
+			Router:   &erroringTestRouter{err: err},
+			Capabilities: policy.Capabilities{
+				SchemaVersion: policy.SchemaVersionV1,
+			},
+		})
+}
+
+func runPolicyDeadlineFallbackTurnLoop(t *testing.T, svc *Service, strategy router.Strategy) (turnLoopResult, error) {
+	t.Helper()
+	env, err := translate.ParseAnthropic(
+		[]byte(`{"model":"claude-opus-4-8","messages":[{"role":"user","content":"continue"}]}`),
+	)
+	require.NoError(t, err)
+	features := env.RoutingFeatures(false)
+	ctx := router.WithStrategy(context.Background(), strategy)
+	req := router.Request{
+		RequestedModel:       features.Model,
+		EstimatedInputTokens: features.Tokens,
+		HasTools:             features.HasTools,
+		ConversationMessages: conversationMessagesForRouting(env),
+	}
+	return svc.runTurnLoop(ctx, env, features, "api-key", uuid.New(), "", http.Header{}, req)
+}
+
+// TestTurnLoop_DeadlineFallbackToPin covers T5: with a pin present and the
+// fallback enabled, a deadline error degrades to the pin instead of a 503.
+func TestTurnLoop_DeadlineFallbackToPin(t *testing.T) {
+	strategy := router.Strategy("policy-deadline-fallback-pin-test")
+	const pinnedModel = "claude-sonnet-4-6"
+	const pinnedProvider = providers.ProviderAnthropic
+
+	store := newStubPinStore()
+	store.getFound = true
+	store.getPin = sessionpin.Pin{
+		Provider:        pinnedProvider,
+		Model:           pinnedModel,
+		Reason:          "hmm_policy(classifier 'mid' (p=0.55))",
+		PolicyGroup:     "mid",
+		PinnedUntil:     time.Now().Add(time.Hour),
+		LastTurnEndedAt: time.Now().Add(-time.Minute),
+		LastServedModel: pinnedModel,
+	}
+
+	svc := buildPolicyDeadlineFallbackService(t, strategy, policyDeadlineTestErr, store, true, "")
+
+	result, err := runPolicyDeadlineFallbackTurnLoop(t, svc, strategy)
+
+	require.NoError(t, err, "a policy deadline miss with a pin present must serve, not error")
+	assert.Equal(t, pinnedModel, result.Decision.Model)
+	assert.Equal(t, pinnedProvider, result.Decision.Provider)
+	assert.Equal(t, policyDeadlineFallbackReason, result.Decision.Reason)
+	assert.True(t, result.StickyHit)
+	assert.True(t, result.PolicyFallback)
+	assert.Equal(t, policyDeadlineFallbackReason, result.PinTier)
+
+	// The pin must be refreshed, not silently left to expire.
+	store.mu.Lock()
+	upserts := append([]sessionpin.Pin(nil), store.upserts...)
+	store.mu.Unlock()
+	require.NotEmpty(t, upserts)
+	assert.Equal(t, pinnedModel, upserts[len(upserts)-1].Model)
+}
+
+// TestTurnLoop_DeadlineFallbackToTierThreeDefault covers the pinless branch:
+// no session pin yet, but a tier-3 static default model is configured.
+func TestTurnLoop_DeadlineFallbackToTierThreeDefault(t *testing.T) {
+	strategy := router.Strategy("policy-deadline-fallback-default-test")
+	const defaultModel = "claude-haiku-4-5"
+
+	store := newStubPinStore()
+	store.getFound = false // no pin: session start
+
+	svc := buildPolicyDeadlineFallbackService(t, strategy, policyDeadlineTestErr, store, true, defaultModel)
+
+	result, err := runPolicyDeadlineFallbackTurnLoop(t, svc, strategy)
+
+	require.NoError(t, err, "a policy deadline miss with a configured tier-3 default must serve, not error")
+	assert.Equal(t, defaultModel, result.Decision.Model)
+	assert.Equal(t, providers.ProviderAnthropic, result.Decision.Provider)
+	assert.Equal(t, policyDeadlineDefaultReason, result.Decision.Reason)
+	assert.False(t, result.StickyHit, "the tier-3 default is a fresh pin, not a sticky reuse")
+	assert.True(t, result.PolicyFallback)
+	assert.Equal(t, policyDeadlineFallbackReason, result.PinTier)
+
+	store.mu.Lock()
+	upserts := append([]sessionpin.Pin(nil), store.upserts...)
+	store.mu.Unlock()
+	require.NotEmpty(t, upserts, "the tier-3 default decision must be written as a new pin")
+	assert.Equal(t, defaultModel, upserts[len(upserts)-1].Model)
+}
+
+// TestTurnLoop_DeadlineFallbackNoPinNoDefault covers the last rung: no pin,
+// no tier-3 default configured — must still fail closed with a 503-mapping error.
+func TestTurnLoop_DeadlineFallbackNoPinNoDefault(t *testing.T) {
+	strategy := router.Strategy("policy-deadline-fallback-no-default-test")
+
+	store := newStubPinStore()
+	store.getFound = false
+
+	svc := buildPolicyDeadlineFallbackService(t, strategy, policyDeadlineTestErr, store, true, "")
+
+	_, err := runPolicyDeadlineFallbackTurnLoop(t, svc, strategy)
+
+	require.Error(t, err, "no pin and no tier-3 default must preserve the 503 (fail closed)")
+	assert.ErrorIs(t, err, hmm.ErrHMMUnavailable)
+}
+
+// TestTurnLoop_DeadlineFallbackKillSwitchOff proves ROUTER_POLICY_DEADLINE_FALLBACK=false
+// preserves the 503 even with a pin present.
+func TestTurnLoop_DeadlineFallbackKillSwitchOff(t *testing.T) {
+	strategy := router.Strategy("policy-deadline-fallback-killswitch-test")
+	const pinnedModel = "claude-sonnet-4-6"
+
+	store := newStubPinStore()
+	store.getFound = true
+	store.getPin = sessionpin.Pin{
+		Provider:        providers.ProviderAnthropic,
+		Model:           pinnedModel,
+		Reason:          "hmm_policy(classifier 'mid' (p=0.55))",
+		PolicyGroup:     "mid",
+		PinnedUntil:     time.Now().Add(time.Hour),
+		LastTurnEndedAt: time.Now().Add(-time.Minute),
+		LastServedModel: pinnedModel,
+	}
+
+	svc := buildPolicyDeadlineFallbackService(t, strategy, policyDeadlineTestErr, store, false, "")
+
+	_, err := runPolicyDeadlineFallbackTurnLoop(t, svc, strategy)
+
+	require.Error(t, err, "kill switch off must preserve the 503 even with a pin present")
+	assert.ErrorIs(t, err, hmm.ErrHMMUnavailable)
+}
+
+// TestTurnLoop_DeadlineFallbackContractViolationStillFailsClosed is the
+// required regression: a contract violation (not a deadline/transport
+// failure) must never degrade, even with the fallback enabled and a pin
+// present. Serving on a contract violation would write a wrong route ledger.
+func TestTurnLoop_DeadlineFallbackContractViolationStillFailsClosed(t *testing.T) {
+	strategy := router.Strategy("policy-deadline-fallback-contract-violation-test")
+	const pinnedModel = "claude-sonnet-4-6"
+
+	store := newStubPinStore()
+	store.getFound = true
+	store.getPin = sessionpin.Pin{
+		Provider:        providers.ProviderAnthropic,
+		Model:           pinnedModel,
+		Reason:          "hmm_policy(classifier 'mid' (p=0.55))",
+		PolicyGroup:     "mid",
+		PinnedUntil:     time.Now().Add(time.Hour),
+		LastTurnEndedAt: time.Now().Add(-time.Minute),
+		LastServedModel: pinnedModel,
+	}
+
+	svc := buildPolicyDeadlineFallbackService(t, strategy, policyContractViolationTestErr, store, true, "claude-haiku-4-5")
+
+	_, err := runPolicyDeadlineFallbackTurnLoop(t, svc, strategy)
+
+	require.Error(t, err, "a contract violation must fail closed even with fallback enabled, a pin, and a tier-3 default")
+	assert.ErrorIs(t, err, hmm.ErrHMMUnavailable)
+}

--- a/internal/proxy/policy_deadline_fallback_internal_test.go
+++ b/internal/proxy/policy_deadline_fallback_internal_test.go
@@ -29,10 +29,8 @@ var policyDeadlineTestErr = fmt.Errorf(
 	hmm.ErrHMMUnavailable,
 )
 
-// policyContractViolationTestErr mirrors a genuine contract violation
-// (sidecar_router.go:367/370) — also wraps hmm.ErrHMMUnavailable, but without
-// a deadline/cancel in the chain. isPolicyDeadlineErr must return false for
-// this so contract violations still fail closed.
+// policyContractViolationTestErr mirrors a contract violation (sidecar_router.go:367/370): wraps
+// ErrHMMUnavailable without a deadline/cancel, so isPolicyDeadlineErr must return false.
 var policyContractViolationTestErr = fmt.Errorf(
 	"hmm_embedding: sidecar returned unknown arm %q or model %q: %w",
 	"bogus-arm", "bogus-model",
@@ -299,10 +297,8 @@ func TestTurnLoop_DeadlineFallbackKillSwitchOff(t *testing.T) {
 	assert.ErrorIs(t, err, hmm.ErrHMMUnavailable)
 }
 
-// TestTurnLoop_DeadlineFallbackContractViolationStillFailsClosed is the
-// required regression: a contract violation (not a deadline/transport
-// failure) must never degrade, even with the fallback enabled and a pin
-// present. Serving on a contract violation would write a wrong route ledger.
+// TestTurnLoop_DeadlineFallbackContractViolationStillFailsClosed: contract violations must never
+// degrade even with fallback enabled — serving one would write a wrong route ledger.
 func TestTurnLoop_DeadlineFallbackContractViolationStillFailsClosed(t *testing.T) {
 	strategy := router.Strategy("policy-deadline-fallback-contract-violation-test")
 	const pinnedModel = "claude-sonnet-4-6"

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -140,10 +140,8 @@ type Service struct {
 	// failure to the session's last-known-good pin instead of a 503. Kill
 	// switch: env ROUTER_POLICY_DEADLINE_FALLBACK, off by default.
 	policyDeadlineFallback bool
-	// policyDeadlineDefaultModel is the tier-3 static safe default served on a
-	// policy deadline miss when the session has no pin yet (~0.2% of
-	// failures). Empty preserves fail-closed (503) for pinless sessions. Env
-	// ROUTER_POLICY_DEADLINE_DEFAULT_MODEL.
+	// policyDeadlineDefaultModel is the tier-3 static fallback on a policy deadline
+	// miss with no session pin (~0.2% of failures); empty = fail-closed (503). Env ROUTER_POLICY_DEADLINE_DEFAULT_MODEL.
 	policyDeadlineDefaultModel string
 	// plannerEnabled is the kill switch. When false, the orchestrator falls
 	// back to first-decision-wins behavior.
@@ -3717,18 +3715,29 @@ func pinDecision(p sessionpin.Pin) router.Decision {
 	}
 }
 
-// policyDeadlineDefaultDecision resolves the configured tier-3 static safe
-// default model (ROUTER_POLICY_DEADLINE_DEFAULT_MODEL) to a dispatchable
-// router.Decision against this deployment's registered providers. It reports
-// false if no default is configured or the configured model has no live
-// provider binding here — callers must fail closed (503) in that case, not
-// silently serve an undispatchable decision.
-func (s *Service) policyDeadlineDefaultDecision() (router.Decision, bool) {
+// policyDeadlineDefaultDecision resolves ROUTER_POLICY_DEADLINE_DEFAULT_MODEL to a
+// dispatchable Decision, honouring this turn's eligibility (enabled providers and
+// excluded models). Reports false when unset, excluded, or without a live binding —
+// callers must fail closed (503), not serve an ineligible decision.
+func (s *Service) policyDeadlineDefaultDecision(req router.Request) (router.Decision, bool) {
 	if s.policyDeadlineDefaultModel == "" {
 		return router.Decision{}, false
 	}
+	if _, excluded := req.ExcludedModels[s.policyDeadlineDefaultModel]; excluded {
+		return router.Decision{}, false
+	}
+	if _, excluded := req.SafetyExcludedModels[s.policyDeadlineDefaultModel]; excluded {
+		return router.Decision{}, false
+	}
+	// nil EnabledProviders means unrestricted, so fall back to everything this
+	// deployment registered; otherwise only providers this turn can authenticate.
 	providerSet := make(map[string]struct{}, len(s.providers))
 	for provider := range s.providers {
+		if req.EnabledProviders != nil {
+			if _, enabled := req.EnabledProviders[provider]; !enabled {
+				continue
+			}
+		}
 		providerSet[provider] = struct{}{}
 	}
 	binding, ok := catalog.ResolveBinding(s.policyDeadlineDefaultModel, providerSet)

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -136,9 +136,8 @@ type Service struct {
 	// hmPinStickyOnArmSelectorUnavail suppresses a fresh decision that came from the arm-selector
 	// unavailable fallback bandit. Env ROUTER_HMM_PIN_STICKY_ON_ARM_SELECTOR_UNAVAIL, off by default.
 	hmPinStickyOnArmSelectorUnavail bool
-	// policyDeadlineFallback degrades a policy sidecar deadline/transport
-	// failure to the session's last-known-good pin instead of a 503. Kill
-	// switch: env ROUTER_POLICY_DEADLINE_FALLBACK, off by default.
+	// policyDeadlineFallback degrades a policy sidecar deadline/transport failure to
+	// the session pin instead of a 503. Kill switch: env ROUTER_POLICY_DEADLINE_FALLBACK, off by default.
 	policyDeadlineFallback bool
 	// policyDeadlineDefaultModel is the tier-3 static fallback on a policy deadline
 	// miss with no session pin (~0.2% of failures); empty = fail-closed (503). Env ROUTER_POLICY_DEADLINE_DEFAULT_MODEL.

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -136,6 +136,15 @@ type Service struct {
 	// hmPinStickyOnArmSelectorUnavail suppresses a fresh decision that came from the arm-selector
 	// unavailable fallback bandit. Env ROUTER_HMM_PIN_STICKY_ON_ARM_SELECTOR_UNAVAIL, off by default.
 	hmPinStickyOnArmSelectorUnavail bool
+	// policyDeadlineFallback degrades a policy sidecar deadline/transport
+	// failure to the session's last-known-good pin instead of a 503. Kill
+	// switch: env ROUTER_POLICY_DEADLINE_FALLBACK, off by default.
+	policyDeadlineFallback bool
+	// policyDeadlineDefaultModel is the tier-3 static safe default served on a
+	// policy deadline miss when the session has no pin yet (~0.2% of
+	// failures). Empty preserves fail-closed (503) for pinless sessions. Env
+	// ROUTER_POLICY_DEADLINE_DEFAULT_MODEL.
+	policyDeadlineDefaultModel string
 	// plannerEnabled is the kill switch. When false, the orchestrator falls
 	// back to first-decision-wins behavior.
 	plannerEnabled bool
@@ -1141,6 +1150,23 @@ func (s *Service) WithHMMSameTierPin(enabled bool) *Service {
 // for suppressing a reroute caused by the arm-selector unavailable fallback bandit.
 func (s *Service) WithHMPinStickyOnArmSelectorUnavail(enabled bool) *Service {
 	s.hmPinStickyOnArmSelectorUnavail = enabled
+	return s
+}
+
+// WithPolicyDeadlineFallback is the kill switch (ROUTER_POLICY_DEADLINE_FALLBACK)
+// for degrading a policy sidecar deadline/transport failure to the session's
+// last-known-good pin instead of a 503.
+func (s *Service) WithPolicyDeadlineFallback(enabled bool) *Service {
+	s.policyDeadlineFallback = enabled
+	return s
+}
+
+// WithPolicyDeadlineDefaultModel sets the tier-3 static safe default model
+// served on a policy deadline miss when the session has no pin yet
+// (ROUTER_POLICY_DEADLINE_DEFAULT_MODEL). Empty preserves fail-closed (503)
+// for pinless sessions.
+func (s *Service) WithPolicyDeadlineDefaultModel(model string) *Service {
+	s.policyDeadlineDefaultModel = model
 	return s
 }
 
@@ -2590,6 +2616,7 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 		String("decision.model", decision.Model).
 		String("decision.provider", decision.Provider).
 		String("decision.reason", decision.Reason).
+		Bool("routing.policy_fallback", routeRes.PolicyFallback).
 		Bool("routing.sticky_hit", stickyHit).
 		Bool("routing.session_pin_hit", pinTier == "in_proc" || pinTier == "postgres").
 		String("routing.session_pin_tier", pinTier).
@@ -3690,6 +3717,31 @@ func pinDecision(p sessionpin.Pin) router.Decision {
 	}
 }
 
+// policyDeadlineDefaultDecision resolves the configured tier-3 static safe
+// default model (ROUTER_POLICY_DEADLINE_DEFAULT_MODEL) to a dispatchable
+// router.Decision against this deployment's registered providers. It reports
+// false if no default is configured or the configured model has no live
+// provider binding here — callers must fail closed (503) in that case, not
+// silently serve an undispatchable decision.
+func (s *Service) policyDeadlineDefaultDecision() (router.Decision, bool) {
+	if s.policyDeadlineDefaultModel == "" {
+		return router.Decision{}, false
+	}
+	providerSet := make(map[string]struct{}, len(s.providers))
+	for provider := range s.providers {
+		providerSet[provider] = struct{}{}
+	}
+	binding, ok := catalog.ResolveBinding(s.policyDeadlineDefaultModel, providerSet)
+	if !ok {
+		return router.Decision{}, false
+	}
+	return router.Decision{
+		Provider: binding.Provider,
+		Model:    s.policyDeadlineDefaultModel,
+		Reason:   policyDeadlineDefaultReason,
+	}, true
+}
+
 // bandSwapServed picks which half of a pinned band pair serves this sticky
 // turn. Returns the pin's anchor unchanged when the swap head is disabled,
 // the pin has no runner-up, the turn isn't MainLoop, the embedding is
@@ -4646,6 +4698,7 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 		String("decision.model", decision.Model).
 		String("decision.provider", decision.Provider).
 		String("decision.reason", decision.Reason).
+		Bool("routing.policy_fallback", routeRes.PolicyFallback).
 		Bool("routing.sticky_hit", stickyHit).
 		Bool("routing.session_pin_hit", pinTier == "in_proc" || pinTier == "postgres").
 		String("routing.session_pin_tier", pinTier).

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -1151,18 +1151,14 @@ func (s *Service) WithHMPinStickyOnArmSelectorUnavail(enabled bool) *Service {
 	return s
 }
 
-// WithPolicyDeadlineFallback is the kill switch (ROUTER_POLICY_DEADLINE_FALLBACK)
-// for degrading a policy sidecar deadline/transport failure to the session's
-// last-known-good pin instead of a 503.
+// WithPolicyDeadlineFallback sets the kill switch (ROUTER_POLICY_DEADLINE_FALLBACK) for degrading a policy sidecar deadline to the session pin instead of a 503.
 func (s *Service) WithPolicyDeadlineFallback(enabled bool) *Service {
 	s.policyDeadlineFallback = enabled
 	return s
 }
 
-// WithPolicyDeadlineDefaultModel sets the tier-3 static safe default model
-// served on a policy deadline miss when the session has no pin yet
-// (ROUTER_POLICY_DEADLINE_DEFAULT_MODEL). Empty preserves fail-closed (503)
-// for pinless sessions.
+// WithPolicyDeadlineDefaultModel sets ROUTER_POLICY_DEADLINE_DEFAULT_MODEL: the tier-3 static fallback
+// on a deadline miss with no pin yet. Empty preserves fail-closed (503) for pinless sessions.
 func (s *Service) WithPolicyDeadlineDefaultModel(model string) *Service {
 	s.policyDeadlineDefaultModel = model
 	return s

--- a/internal/proxy/turnloop.go
+++ b/internal/proxy/turnloop.go
@@ -232,14 +232,10 @@ func stickPinOnArmSelectorUnavailable(fresh router.Decision, pin sessionpin.Pin,
 	return true
 }
 
-// policyDeadlineFallbackReason is the PinTier value when a policy sidecar
-// deadline/transport failure degrades to a session pin or the tier-3 static
-// default, instead of a 503.
+// policyDeadlineFallbackReason is set as PinTier when a policy sidecar deadline degrades to a pin or tier-3 default.
 const policyDeadlineFallbackReason = "policy_deadline_last_known_good"
 
-// policyDeadlineDefaultReason is the router.Decision.Reason value when a
-// policy sidecar deadline/transport failure with no session pin falls all the
-// way to the tier-3 static safe default model.
+// policyDeadlineDefaultReason is the Decision.Reason when a deadline miss with no pin falls to the tier-3 default.
 const policyDeadlineDefaultReason = "policy_deadline_default_model"
 
 // isPolicyDeadlineErr reports whether err is a policy sidecar deadline/transport

--- a/internal/proxy/turnloop.go
+++ b/internal/proxy/turnloop.go
@@ -2,6 +2,7 @@ package proxy
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"sort"
@@ -16,6 +17,7 @@ import (
 	"workweave/router/internal/router/catalog"
 	"workweave/router/internal/router/cluster"
 	"workweave/router/internal/router/handover"
+	"workweave/router/internal/router/hmm"
 	"workweave/router/internal/router/planner"
 	"workweave/router/internal/router/sessionpin"
 	"workweave/router/internal/router/turntype"
@@ -102,6 +104,13 @@ type turnLoopResult struct {
 	UsageBypass bool
 	PinTier     string
 	PinAgeSec   int64
+	// PolicyFallback is true when Decision was served by degrading a policy
+	// sidecar deadline/transport failure to a session pin or the tier-3
+	// static default, instead of the sidecar's own ranking. Callers must
+	// exclude such turns from bandit training (no propensity was ever
+	// assigned) and flag them on the route ledger/OTel span so degraded-mode
+	// spend is distinguishable from policy-attributable spend.
+	PolicyFallback bool
 	// RequestedTier drives the session-pin role split (roleForTier) so a
 	// low-tier background turn and a high-tier main turn never share a pin.
 	RequestedTier catalog.Tier
@@ -224,6 +233,34 @@ func stickPinOnArmSelectorUnavailable(fresh router.Decision, pin sessionpin.Pin,
 		return false
 	}
 	return true
+}
+
+// policyDeadlineFallbackReason is the PinTier value when a policy sidecar
+// deadline/transport failure degrades to a session pin or the tier-3 static
+// default, instead of a 503.
+const policyDeadlineFallbackReason = "policy_deadline_last_known_good"
+
+// policyDeadlineDefaultReason is the router.Decision.Reason value when a
+// policy sidecar deadline/transport failure with no session pin falls all the
+// way to the tier-3 static safe default model.
+const policyDeadlineDefaultReason = "policy_deadline_default_model"
+
+// isPolicyDeadlineErr reports whether err is the policy sidecar missing its
+// deadline (or an equivalent transport failure), as opposed to a contract
+// violation. Only the former is safe to degrade: a contract violation (unknown
+// arm, provider mismatch, bad schema) means the router and sidecar disagree
+// about the roster, and serving on that basis would write a wrong route
+// ledger. Both context.DeadlineExceeded/Canceled and hmm.ErrHMMUnavailable
+// must be present in the chain — sidecar_router.go wraps contract violations
+// with ErrHMMUnavailable too, so the deadline/cancel check is load-bearing.
+func isPolicyDeadlineErr(err error) bool {
+	if err == nil {
+		return false
+	}
+	if !errors.Is(err, hmm.ErrHMMUnavailable) {
+		return false
+	}
+	return errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled)
 }
 
 func hmmHistoryRole(role string) string {
@@ -847,6 +884,52 @@ func (s *Service) runTurnLoop(
 	if !routed {
 		dec, err := s.routeFor(ctx, req)
 		if err != nil {
+			// A policy DEADLINE is not a reason to fail the user: every
+			// resolved candidate was already dispatchable, so losing the
+			// ranking costs model quality, not correctness. Degrade to this
+			// session's last-known-good pin, or (no pin yet — ~0.2% of
+			// failures) the tier-3 static default. Contract violations
+			// (unknown arm, provider mismatch, bad schema) deliberately still
+			// fail closed via isPolicyDeadlineErr's DeadlineExceeded/Canceled
+			// check.
+			if s.policyDeadlineFallback && isPolicyDeadlineErr(err) {
+				if pinFound && pin.Model != "" {
+					decision := pinDecision(pin)
+					// Overwrite Reason (rather than keep the pin's original
+					// hmm_policy(...) string) so the telemetry row's
+					// DecisionReason column distinguishes a degraded-mode
+					// fallback turn from a genuine policy-chosen STAY — both
+					// would otherwise read identically in cost-of-routing
+					// analytics.
+					decision.Reason = policyDeadlineFallbackReason
+					res.Decision = decision
+					res.StickyHit = true
+					res.PinTier = policyDeadlineFallbackReason
+					res.PolicyFallback = true
+					log.Warn("policy sidecar missed its deadline; serving session pin",
+						"err", err,
+						"pin_model", pin.Model,
+						"pin_provider", pin.Provider,
+						"pin_policy_group", pin.PolicyGroup,
+						"requested_model", req.RequestedModel,
+					)
+					s.refreshPin(ctx, installationID, res.SessionKey, pin, res.PinRole, decision)
+					return res, nil
+				}
+				if decision, ok := s.policyDeadlineDefaultDecision(); ok {
+					res.Decision = decision
+					res.PinTier = policyDeadlineFallbackReason
+					res.PolicyFallback = true
+					log.Warn("policy sidecar missed its deadline; no session pin, serving tier-3 default",
+						"err", err,
+						"default_model", decision.Model,
+						"default_provider", decision.Provider,
+						"requested_model", req.RequestedModel,
+					)
+					s.writeNewPin(ctx, installationID, res.SessionKey, res.PinRole, decision)
+					return res, nil
+				}
+			}
 			log.Error("turnloop scorer failed", "err", err, "requested_model", req.RequestedModel)
 			return res, err
 		}

--- a/internal/proxy/turnloop.go
+++ b/internal/proxy/turnloop.go
@@ -104,12 +104,9 @@ type turnLoopResult struct {
 	UsageBypass bool
 	PinTier     string
 	PinAgeSec   int64
-	// PolicyFallback is true when Decision was served by degrading a policy
-	// sidecar deadline/transport failure to a session pin or the tier-3
-	// static default, instead of the sidecar's own ranking. Callers must
-	// exclude such turns from bandit training (no propensity was ever
-	// assigned) and flag them on the route ledger/OTel span so degraded-mode
-	// spend is distinguishable from policy-attributable spend.
+	// PolicyFallback is true when the decision came from degrading a policy sidecar
+	// deadline to a session pin or tier-3 default. Exclude from bandit training and
+	// flag on the OTel span so degraded-mode spend is distinguishable.
 	PolicyFallback bool
 	// RequestedTier drives the session-pin role split (roleForTier) so a
 	// low-tier background turn and a high-tier main turn never share a pin.
@@ -245,14 +242,11 @@ const policyDeadlineFallbackReason = "policy_deadline_last_known_good"
 // way to the tier-3 static safe default model.
 const policyDeadlineDefaultReason = "policy_deadline_default_model"
 
-// isPolicyDeadlineErr reports whether err is the policy sidecar missing its
-// deadline (or an equivalent transport failure), as opposed to a contract
-// violation. Only the former is safe to degrade: a contract violation (unknown
-// arm, provider mismatch, bad schema) means the router and sidecar disagree
-// about the roster, and serving on that basis would write a wrong route
-// ledger. Both context.DeadlineExceeded/Canceled and hmm.ErrHMMUnavailable
-// must be present in the chain — sidecar_router.go wraps contract violations
-// with ErrHMMUnavailable too, so the deadline/cancel check is load-bearing.
+// isPolicyDeadlineErr reports whether err is a policy sidecar deadline/transport
+// failure (safe to degrade) rather than a contract violation (must fail closed).
+// Both context.DeadlineExceeded/Canceled and hmm.ErrHMMUnavailable must be present —
+// sidecar_router.go also wraps contract violations with ErrHMMUnavailable, so the
+// deadline/cancel check is load-bearing.
 func isPolicyDeadlineErr(err error) bool {
 	if err == nil {
 		return false
@@ -884,23 +878,13 @@ func (s *Service) runTurnLoop(
 	if !routed {
 		dec, err := s.routeFor(ctx, req)
 		if err != nil {
-			// A policy DEADLINE is not a reason to fail the user: every
-			// resolved candidate was already dispatchable, so losing the
-			// ranking costs model quality, not correctness. Degrade to this
-			// session's last-known-good pin, or (no pin yet — ~0.2% of
-			// failures) the tier-3 static default. Contract violations
-			// (unknown arm, provider mismatch, bad schema) deliberately still
-			// fail closed via isPolicyDeadlineErr's DeadlineExceeded/Canceled
-			// check.
+			// Deadline != correctness failure: all candidates were dispatchable; only
+			// ranking is lost. Contract violations still fail closed via isPolicyDeadlineErr.
 			if s.policyDeadlineFallback && isPolicyDeadlineErr(err) {
 				if pinFound && pin.Model != "" {
 					decision := pinDecision(pin)
-					// Overwrite Reason (rather than keep the pin's original
-					// hmm_policy(...) string) so the telemetry row's
-					// DecisionReason column distinguishes a degraded-mode
-					// fallback turn from a genuine policy-chosen STAY — both
-					// would otherwise read identically in cost-of-routing
-					// analytics.
+					// Use a distinct Reason so degraded-mode turns don't
+					// read identically to genuine policy-chosen STAYs in analytics.
 					decision.Reason = policyDeadlineFallbackReason
 					res.Decision = decision
 					res.StickyHit = true
@@ -913,10 +897,14 @@ func (s *Service) runTurnLoop(
 						"pin_policy_group", pin.PolicyGroup,
 						"requested_model", req.RequestedModel,
 					)
-					s.refreshPin(ctx, installationID, res.SessionKey, pin, res.PinRole, decision)
+					// Persist the pin's own reason, not the degraded-mode one:
+					// isHMMPinReason gates later HMM stickiness on it.
+					refreshed := decision
+					refreshed.Reason = pin.Reason
+					s.refreshPin(ctx, installationID, res.SessionKey, pin, res.PinRole, refreshed)
 					return res, nil
 				}
-				if decision, ok := s.policyDeadlineDefaultDecision(); ok {
+				if decision, ok := s.policyDeadlineDefaultDecision(req); ok {
 					res.Decision = decision
 					res.PinTier = policyDeadlineFallbackReason
 					res.PolicyFallback = true


### PR DESCRIPTION
Axis 2 of `PLAN_fix_hmm_sidecar_deadline_503.md` (WorkWeave repo,
`router-internal/docs/plans/`). Since `ROUTER_DEFAULT_STRATEGY=hmm` is the
sole decision path for 100% of prod traffic, a policy sidecar deadline miss
today returns a user-facing 503 (`Router unavailable: HMM policy router
failed and no fallback is configured`) even though every resolved candidate
was already a dispatchable model — the failure is in *ranking*, not in
whether we can serve at all.

This extends the existing `stickPinOnArmSelectorUnavailable` pattern
(`turnloop.go:204`) to policy deadline/transport failures specifically:

- `isPolicyDeadlineErr(err)`: true only for `context.DeadlineExceeded`/`Canceled`
  wrapping `hmm.ErrHMMUnavailable`. Contract violations (unknown arm, provider
  mismatch, bad schema) also wrap `ErrHMMUnavailable` but carry no
  deadline/cancel, so they deliberately still fail closed — serving on a
  contract violation would write a wrong route ledger.
- Fallback ladder: (1) session's last-known-good pin if one exists (~99.8%
  of failures are mid-session); (2) a configured tier-3 static default model
  (`ROUTER_POLICY_DEADLINE_DEFAULT_MODEL`) resolved against this deployment's
  registered providers via `catalog.ResolveBinding`; (3) fail closed (503) if
  neither applies.
- Both paths set `res.PolicyFallback=true` and `res.PinTier` to a dedicated
  reason string, surfaced as a `routing.policy_fallback` OTel span attribute
  on all three serving paths (Anthropic, OpenAI, Gemini) and as the pin/default
  decision's `Reason` so the telemetry row's `DecisionReason` column can
  distinguish a degraded-mode turn from a genuine policy-chosen STAY (both
  would otherwise read identically in cost-of-routing analytics — adding a
  dedicated telemetry column is a Postgres migration, out of scope here).
- No change needed to `reportPolicyOutcome`/`policyOutcomeRoute`: a fallback
  decision always has `Metadata=nil` and `res.Fresh` is never set (the
  `routeFor` error returns before that assignment), so `policyOutcomeRoute`'s
  existing `routeMetadata == nil` guard already excludes fallback turns from
  bandit outcome reporting — there was no contamination risk to guard against.

Kill switches, both off by default:
- `ROUTER_POLICY_DEADLINE_FALLBACK` (bool) — false restores today's fail-closed
  behavior with no rebuild.
- `ROUTER_POLICY_DEADLINE_DEFAULT_MODEL` (string) — empty preserves 503 for the
  ~0.2% of failures with no session pin yet.

Tests (`internal/proxy/policy_deadline_fallback_internal_test.go`):
- `isPolicyDeadlineErr` unit tests covering the full deadline/cancel/contract-
  violation/unrelated-error matrix.
- End-to-end `runTurnLoop` tests: pin-present fallback, pinless
  tier-3-default fallback, pinless-no-default fails closed, kill-switch-off
  fails closed even with a pin, and the required regression that a contract
  violation fails closed even with the fallback enabled and a pin present.

`go build ./...`, `go vet ./...`, and `go test ./...` all pass across the
whole module.

This is a submodule-only change. The terraform env vars that enable it, plus
a CI diff-guard on `ROUTER_*` env vars in
`terraform/modules/environment/router*.tf` (to prevent a repeat of the
#11717/#11723 silent-clobber regression that caused this incident), ship in a
follow-up WorkWeave PR after this merges and the gitlink is bumped
(`wv mr sync`).

Part of a 2-stage fix — see [WorkWeave PR #11814](https://github.com/workweave/WorkWeave/pull/11814)
for Axis 1 (make the HMM sidecar decision fast), which ships independently
and reduces the failure rate this PR then degrades gracefully instead of
erroring on.

🤖 Generated with [Weave Router](https://router.workweave.ai)