### PR TITLE
feat(proxy): emit latency.embed_ms on decision spans from sidecar route timings

### DIFF
--- a/internal/policyclient/client.go
+++ b/internal/policyclient/client.go
@@ -368,7 +368,14 @@ type routeResponse struct {
 	DebugRef             string                 `json:"debug_ref"`
 	Debug                map[string]interface{} `json:"debug"`
 	RankedFallback       []policy.PreviewGroup  `json:"ranked_fallback"`
+	Timings              *routeTimings          `json:"timings"`
 	Error                string                 `json:"error"`
+}
+
+// routeTimings is the sidecar's optional per-request latency breakdown.
+// EmbedMs is nil (not zero) when embedding didn't run for this request.
+type routeTimings struct {
+	EmbedMs *float64 `json:"embed_ms"`
 }
 
 type previewResponse struct {
@@ -423,6 +430,10 @@ func (c *Client) Decide(ctx context.Context, query policy.Query) (policy.Result,
 	if parsed.ChosenScore != nil {
 		score = *parsed.ChosenScore
 	}
+	var embedMs *float64
+	if parsed.Timings != nil {
+		embedMs = parsed.Timings.EmbedMs
+	}
 	return policy.Result{
 		SchemaVersion:        parsed.SchemaVersion,
 		RouteID:              parsed.RouteID,
@@ -447,6 +458,7 @@ func (c *Client) Decide(ctx context.Context, query policy.Query) (policy.Result,
 		DebugRef:             parsed.DebugRef,
 		Debug:                parsed.Debug,
 		RankedFallback:       parsed.RankedFallback,
+		EmbedMs:              embedMs,
 	}, nil
 }
 

--- a/internal/policyclient/client_test.go
+++ b/internal/policyclient/client_test.go
@@ -163,6 +163,56 @@ func TestClientPostsVersionedRouteAndParsesPolicyMetadata(t *testing.T) {
 	assert.Equal(t, map[string]float32{"moonshotai/kimi-k2.7-code": 0.91}, result.CandidateScores)
 }
 
+func TestClientDecideParsesEmbedMs(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(routeResponse{
+			SelectedRosterID: "anthropic/claude-opus-4-8",
+			Timings:          &routeTimings{EmbedMs: floatPtr(12.5)},
+		})
+	}))
+	defer server.Close()
+
+	result, err := New(server.URL, server.Client(), 0).Decide(context.Background(), policy.Query{
+		Candidates: []policy.Candidate{{RosterID: "anthropic/claude-opus-4-8", CatalogID: "claude-opus-4-8", Provider: providers.ProviderAnthropic}},
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, result.EmbedMs)
+	assert.Equal(t, 12.5, *result.EmbedMs)
+}
+
+func TestClientDecidePreservesPresentZeroEmbedMs(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(routeResponse{
+			SelectedRosterID: "anthropic/claude-opus-4-8",
+			Timings:          &routeTimings{EmbedMs: floatPtr(0)},
+		})
+	}))
+	defer server.Close()
+
+	result, err := New(server.URL, server.Client(), 0).Decide(context.Background(), policy.Query{
+		Candidates: []policy.Candidate{{RosterID: "anthropic/claude-opus-4-8", CatalogID: "claude-opus-4-8", Provider: providers.ProviderAnthropic}},
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, result.EmbedMs)
+	assert.Equal(t, 0.0, *result.EmbedMs)
+}
+
+func TestClientDecideLeavesEmbedMsNilWhenTimingsOmitted(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{"model": "anthropic/claude-opus-4-8"})
+	}))
+	defer server.Close()
+
+	result, err := New(server.URL, server.Client(), 0).Decide(context.Background(), policy.Query{
+		Candidates: []policy.Candidate{{RosterID: "anthropic/claude-opus-4-8", CatalogID: "claude-opus-4-8", Provider: providers.ProviderAnthropic}},
+	})
+
+	require.NoError(t, err)
+	assert.Nil(t, result.EmbedMs)
+}
+
 func TestClientOmitsV2CandidateFieldsFromV1(t *testing.T) {
 	body, err := marshalRouteRequest(policy.Query{
 		SchemaVersion: policy.SchemaVersionV1,

--- a/internal/proxy/decision_span_embed_test.go
+++ b/internal/proxy/decision_span_embed_test.go
@@ -156,9 +156,8 @@ func TestDecisionSpan_EmbedMsAbsent_NilMetadataAndNilEmbedMiss(t *testing.T) {
 	}
 }
 
-// TestDecisionSpan_EmbedMs_SurvivesPlannerStay pins the STAY path: the
-// planner serves a pin-derived decision (nil Metadata), but embed_ms must
-// still be emitted from the fresh sidecar measurement.
+// TestDecisionSpan_EmbedMs_SurvivesPlannerStay pins the STAY path:
+// embed_ms must still be emitted from the fresh sidecar measurement.
 func TestDecisionSpan_EmbedMs_SurvivesPlannerStay(t *testing.T) {
 	collector := newBypassSpanCollector(t)
 	store := newStubPinStore()

--- a/internal/proxy/decision_span_embed_test.go
+++ b/internal/proxy/decision_span_embed_test.go
@@ -70,10 +70,9 @@ func embedTurnBody() []byte {
 		`"messages":[{"role":"user","content":"hi"}]}`)
 }
 
-// newEmbedTestService wires a nil pin store so the turn loop takes the fresh
-// scorer branch; a tools + max_tokens body keeps the turn off the
-// classifier/probe hard-pin fast paths, which would never reach the router.
-func newEmbedTestService(t *testing.T, collector *bypassSpanCollector, rt router.Router) *Service {
+// newEmbedTestService wires the given pin store (nil = fresh scorer branch);
+// the tools + max_tokens body keeps turns off the hard-pin fast paths.
+func newEmbedTestService(t *testing.T, collector *bypassSpanCollector, rt router.Router, pins sessionpin.Store) *Service {
 	t.Helper()
 	emitter, err := otel.NewEmitter(otel.EmitterConfig{
 		Endpoint:      collector.srv.URL,
@@ -84,13 +83,12 @@ func newEmbedTestService(t *testing.T, collector *bypassSpanCollector, rt router
 	})
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = emitter.Shutdown(context.Background()) })
-	return NewService(rt, map[string]providers.Client{providers.ProviderAnthropic: embedTestProvider{}}, emitter, false, nil, nil, false,
+	return NewService(rt, map[string]providers.Client{providers.ProviderAnthropic: embedTestProvider{}}, emitter, false, nil, pins, false,
 		providers.ProviderAnthropic, "claude-haiku-4-5", nil)
 }
 
-// decisionSpanEmbed drives one Anthropic turn through the service and returns
-// the exported router.decision span. The emitter shutdown is synchronous, so
-// the collector is quiescent afterwards (span assertions are read-only to it).
+// decisionSpanEmbed drives one Anthropic turn and returns the exported
+// router.decision span; emitter shutdown is synchronous so spans are stable.
 func decisionSpanEmbed(t *testing.T, svc *Service, collector *bypassSpanCollector) *tracev1.Span {
 	t.Helper()
 	rec := httptest.NewRecorder()
@@ -107,13 +105,11 @@ func decisionSpanEmbed(t *testing.T, svc *Service, collector *bypassSpanCollecto
 	return spans[0]
 }
 
-// TestDecisionSpan_EmbedMsHit_Present pins the latency.embed_ms attribute as
-// an int64 carrying the whole-millisecond embed time. The
-// float->int64 conversion is lossy at half-millisecond boundaries: a 12.5ms
-// embed must round UP to 13, never truncate to 12.
+// TestDecisionSpan_EmbedMsHit_Present pins latency.embed_ms as int64;
+// 12.5ms must round to 13, not truncate to 12.
 func TestDecisionSpan_EmbedMsHit_Present(t *testing.T) {
 	collector := newBypassSpanCollector(t)
-	svc := newEmbedTestService(t, collector, &embedTestRouter{metadata: &router.RoutingMetadata{EmbedMs: embedMsPtr(12.5)}})
+	svc := newEmbedTestService(t, collector, &embedTestRouter{metadata: &router.RoutingMetadata{EmbedMs: embedMsPtr(12.5)}}, nil)
 
 	sp := decisionSpanEmbed(t, svc, collector)
 
@@ -130,7 +126,7 @@ func TestDecisionSpan_EmbedMsHit_Present(t *testing.T) {
 // attribute being absent.
 func TestDecisionSpan_EmbedMsWarmCache_PresentZero(t *testing.T) {
 	collector := newBypassSpanCollector(t)
-	svc := newEmbedTestService(t, collector, &embedTestRouter{metadata: &router.RoutingMetadata{EmbedMs: embedMsPtr(0.4)}})
+	svc := newEmbedTestService(t, collector, &embedTestRouter{metadata: &router.RoutingMetadata{EmbedMs: embedMsPtr(0.4)}}, nil)
 
 	sp := decisionSpanEmbed(t, svc, collector)
 
@@ -139,11 +135,8 @@ func TestDecisionSpan_EmbedMsWarmCache_PresentZero(t *testing.T) {
 	assert.Zero(t, embedMs)
 }
 
-// TestDecisionSpan_EmbedMsAbsent_NilMetadataAndNilEmbedMiss pins the nil
-// guard: a decision that never computed the embedding (Metadata nil, or
-// metadata present without EmbedMs) must NOT fabricate a zero measurement.
-// Presence is the contract — an absent attribute is upstream's signal to
-// skip the metric entirely.
+// TestDecisionSpan_EmbedMsAbsent_NilMetadataAndNilEmbedMiss pins that absent
+// embedding must not fabricate a zero — absence is the upstream skip signal.
 func TestDecisionSpan_EmbedMsAbsent_NilMetadataAndNilEmbedMiss(t *testing.T) {
 	for _, tc := range []struct {
 		name     string
@@ -154,7 +147,7 @@ func TestDecisionSpan_EmbedMsAbsent_NilMetadataAndNilEmbedMiss(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			collector := newBypassSpanCollector(t)
-			svc := newEmbedTestService(t, collector, &embedTestRouter{metadata: tc.metadata})
+			svc := newEmbedTestService(t, collector, &embedTestRouter{metadata: tc.metadata}, nil)
 
 			sp := decisionSpanEmbed(t, svc, collector)
 
@@ -166,11 +159,32 @@ func TestDecisionSpan_EmbedMsAbsent_NilMetadataAndNilEmbedMiss(t *testing.T) {
 	}
 }
 
-// TestPinDecision_NeverRehydratesMetadata pins the replay guard: pinDecision
-// rehydrates a decision from a stored pin with Metadata nil. Embedding is not
-// persisted into pins, and must stay that way — a pin that carried Metadata
-// would re-emit a stale latency.embed_ms measurement on every subsequent
-// sticky hit as if it were a fresh decision.
+// TestDecisionSpan_EmbedMs_SurvivesPlannerStay pins the STAY path: a live
+// same-model pin makes the planner serve the pin-derived decision (nil
+// Metadata), but the sidecar still embedded this turn, so the span must
+// carry the fresh measurement.
+func TestDecisionSpan_EmbedMs_SurvivesPlannerStay(t *testing.T) {
+	collector := newBypassSpanCollector(t)
+	store := newStubPinStore()
+	store.getFound = true
+	store.getPin = sessionpin.Pin{
+		Provider:    providers.ProviderAnthropic,
+		Model:       "claude-haiku-4-5",
+		Reason:      "cluster",
+		PinnedUntil: time.Now().Add(time.Hour),
+	}
+	svc := newEmbedTestService(t, collector, &embedTestRouter{metadata: &router.RoutingMetadata{EmbedMs: embedMsPtr(12.5)}}, store)
+
+	sp := decisionSpanEmbed(t, svc, collector)
+
+	require.Equal(t, "stay", spanStr(t, sp, "planner.outcome"), "pin must be served via a planner STAY for this test to pin anything")
+	got, present := spanEmbedInt(sp, "latency.embed_ms")
+	require.True(t, present, "a STAY turn still embedded this request — dropping it undercounts EMBED on sticky sessions")
+	assert.Equal(t, int64(13), got)
+}
+
+// TestPinDecision_NeverRehydratesMetadata guards against stale embed_ms
+// replay: pins must rehydrate with Metadata nil.
 func TestPinDecision_NeverRehydratesMetadata(t *testing.T) {
 	dec := pinDecision(sessionpin.Pin{
 		Provider: providers.ProviderAnthropic,

--- a/internal/proxy/decision_span_embed_test.go
+++ b/internal/proxy/decision_span_embed_test.go
@@ -61,9 +61,8 @@ func spanEmbedInt(sp *tracev1.Span, key string) (int64, bool) {
 
 func embedMsPtr(ms float64) *float64 { return &ms }
 
-// embedTurnBody mirrors the force-cluster harness body: tools + a real
-// max_tokens keep the turn off the classifier/probe hard-pin fast paths,
-// which would never reach the router at all.
+// embedTurnBody mirrors the force-cluster harness body: tools + max_tokens
+// keep the turn off the classifier/probe hard-pin fast paths.
 func embedTurnBody() []byte {
 	return []byte(`{"model":"claude-opus-4-8","max_tokens":4096,` +
 		`"tools":[{"name":"Bash","input_schema":{"type":"object"}}],` +
@@ -120,10 +119,8 @@ func TestDecisionSpan_EmbedMsHit_Present(t *testing.T) {
 	assert.True(t, routePresent, "the established route_ms attribute must stay present")
 }
 
-// TestDecisionSpan_EmbedMsWarmCache_PresentZero pins the warm-cache contract:
-// a present sub-half-millisecond embed (0.4ms) round-zeros to a PRESENT 0,
-// which downstream ingests as a real measurement — distinct from the
-// attribute being absent.
+// TestDecisionSpan_EmbedMsWarmCache_PresentZero pins that a present 0.4ms
+// rounds to a PRESENT 0 int64 — distinct from the attribute being absent.
 func TestDecisionSpan_EmbedMsWarmCache_PresentZero(t *testing.T) {
 	collector := newBypassSpanCollector(t)
 	svc := newEmbedTestService(t, collector, &embedTestRouter{metadata: &router.RoutingMetadata{EmbedMs: embedMsPtr(0.4)}}, nil)
@@ -159,10 +156,9 @@ func TestDecisionSpan_EmbedMsAbsent_NilMetadataAndNilEmbedMiss(t *testing.T) {
 	}
 }
 
-// TestDecisionSpan_EmbedMs_SurvivesPlannerStay pins the STAY path: a live
-// same-model pin makes the planner serve the pin-derived decision (nil
-// Metadata), but the sidecar still embedded this turn, so the span must
-// carry the fresh measurement.
+// TestDecisionSpan_EmbedMs_SurvivesPlannerStay pins the STAY path: the
+// planner serves a pin-derived decision (nil Metadata), but embed_ms must
+// still be emitted from the fresh sidecar measurement.
 func TestDecisionSpan_EmbedMs_SurvivesPlannerStay(t *testing.T) {
 	collector := newBypassSpanCollector(t)
 	store := newStubPinStore()

--- a/internal/proxy/decision_span_embed_test.go
+++ b/internal/proxy/decision_span_embed_test.go
@@ -1,0 +1,181 @@
+package proxy
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"workweave/router/internal/observability/otel"
+	"workweave/router/internal/providers"
+	"workweave/router/internal/router"
+	"workweave/router/internal/router/sessionpin"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	commonv1 "go.opentelemetry.io/proto/otlp/common/v1"
+	tracev1 "go.opentelemetry.io/proto/otlp/trace/v1"
+)
+
+// embedTestRouter returns a router.Decision carrying the supplied Metadata,
+// so a test can prove what reaches the router.decision span.
+type embedTestRouter struct {
+	metadata *router.RoutingMetadata
+}
+
+func (r *embedTestRouter) Route(context.Context, router.Request) (router.Decision, error) {
+	return router.Decision{
+		Provider: providers.ProviderAnthropic,
+		Model:    "claude-haiku-4-5",
+		Reason:   "cluster",
+		Metadata: r.metadata,
+	}, nil
+}
+
+type embedTestProvider struct{}
+
+func (embedTestProvider) Proxy(context.Context, router.Decision, providers.PreparedRequest, http.ResponseWriter, *http.Request) error {
+	return nil
+}
+
+func (embedTestProvider) Passthrough(context.Context, providers.PreparedRequest, http.ResponseWriter, *http.Request) error {
+	return nil
+}
+
+// spanEmbedInt returns the int64 value of the named attribute on the span, or
+// 0 (and false) if it isn't present.
+func spanEmbedInt(sp *tracev1.Span, key string) (int64, bool) {
+	for _, kv := range sp.Attributes {
+		if kv.Key != key {
+			continue
+		}
+		if iv, ok := kv.Value.Value.(*commonv1.AnyValue_IntValue); ok {
+			return iv.IntValue, true
+		}
+	}
+	return 0, false
+}
+
+func embedMsPtr(ms float64) *float64 { return &ms }
+
+// embedTurnBody mirrors the force-cluster harness body: tools + a real
+// max_tokens keep the turn off the classifier/probe hard-pin fast paths,
+// which would never reach the router at all.
+func embedTurnBody() []byte {
+	return []byte(`{"model":"claude-opus-4-8","max_tokens":4096,` +
+		`"tools":[{"name":"Bash","input_schema":{"type":"object"}}],` +
+		`"messages":[{"role":"user","content":"hi"}]}`)
+}
+
+// newEmbedTestService wires a nil pin store so the turn loop takes the fresh
+// scorer branch; a tools + max_tokens body keeps the turn off the
+// classifier/probe hard-pin fast paths, which would never reach the router.
+func newEmbedTestService(t *testing.T, collector *bypassSpanCollector, rt router.Router) *Service {
+	t.Helper()
+	emitter, err := otel.NewEmitter(otel.EmitterConfig{
+		Endpoint:      collector.srv.URL,
+		Workers:       1,
+		QueueSize:     100,
+		BatchSize:     1,
+		FlushInterval: 10 * time.Millisecond,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = emitter.Shutdown(context.Background()) })
+	return NewService(rt, map[string]providers.Client{providers.ProviderAnthropic: embedTestProvider{}}, emitter, false, nil, nil, false,
+		providers.ProviderAnthropic, "claude-haiku-4-5", nil)
+}
+
+// decisionSpanEmbed drives one Anthropic turn through the service and returns
+// the exported router.decision span. The emitter shutdown is synchronous, so
+// the collector is quiescent afterwards (span assertions are read-only to it).
+func decisionSpanEmbed(t *testing.T, svc *Service, collector *bypassSpanCollector) *tracev1.Span {
+	t.Helper()
+	rec := httptest.NewRecorder()
+	httpReq := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(""))
+	require.NoError(t, svc.ProxyMessages(context.Background(), embedTurnBody(), rec, httpReq))
+
+	em := svc.emitter.(*otel.Emitter)
+	require.NoError(t, em.Shutdown(context.Background()))
+
+	collector.mu.Lock()
+	defer collector.mu.Unlock()
+	spans := collector.byName["router.decision"]
+	require.Len(t, spans, 1, "exactly one router.decision span must be exported")
+	return spans[0]
+}
+
+// TestDecisionSpan_EmbedMsHit_Present pins the latency.embed_ms attribute as
+// an int64 carrying the whole-millisecond embed time. The
+// float->int64 conversion is lossy at half-millisecond boundaries: a 12.5ms
+// embed must round UP to 13, never truncate to 12.
+func TestDecisionSpan_EmbedMsHit_Present(t *testing.T) {
+	collector := newBypassSpanCollector(t)
+	svc := newEmbedTestService(t, collector, &embedTestRouter{metadata: &router.RoutingMetadata{EmbedMs: embedMsPtr(12.5)}})
+
+	sp := decisionSpanEmbed(t, svc, collector)
+
+	embedMs, present := spanEmbedInt(sp, "latency.embed_ms")
+	require.True(t, present, "a fresh decision with EmbedMs must carry latency.embed_ms")
+	assert.Equal(t, int64(13), embedMs, "EmbedMs must round to the nearest whole millisecond, not truncate")
+	_, routePresent := spanEmbedInt(sp, "latency.route_ms")
+	assert.True(t, routePresent, "the established route_ms attribute must stay present")
+}
+
+// TestDecisionSpan_EmbedMsWarmCache_PresentZero pins the warm-cache contract:
+// a present sub-half-millisecond embed (0.4ms) round-zeros to a PRESENT 0,
+// which downstream ingests as a real measurement — distinct from the
+// attribute being absent.
+func TestDecisionSpan_EmbedMsWarmCache_PresentZero(t *testing.T) {
+	collector := newBypassSpanCollector(t)
+	svc := newEmbedTestService(t, collector, &embedTestRouter{metadata: &router.RoutingMetadata{EmbedMs: embedMsPtr(0.4)}})
+
+	sp := decisionSpanEmbed(t, svc, collector)
+
+	embedMs, present := spanEmbedInt(sp, "latency.embed_ms")
+	require.True(t, present, "a warm-cache embed (< 0.5ms) must still be emitted as a present 0, not dropped")
+	assert.Zero(t, embedMs)
+}
+
+// TestDecisionSpan_EmbedMsAbsent_NilMetadataAndNilEmbedMiss pins the nil
+// guard: a decision that never computed the embedding (Metadata nil, or
+// metadata present without EmbedMs) must NOT fabricate a zero measurement.
+// Presence is the contract — an absent attribute is upstream's signal to
+// skip the metric entirely.
+func TestDecisionSpan_EmbedMsAbsent_NilMetadataAndNilEmbedMiss(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		metadata *router.RoutingMetadata
+	}{
+		{name: "nil metadata", metadata: nil},
+		{name: "metadata without embed", metadata: &router.RoutingMetadata{}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			collector := newBypassSpanCollector(t)
+			svc := newEmbedTestService(t, collector, &embedTestRouter{metadata: tc.metadata})
+
+			sp := decisionSpanEmbed(t, svc, collector)
+
+			_, present := spanEmbedInt(sp, "latency.embed_ms")
+			assert.False(t, present, "a decision that never measured the embed must not emit latency.embed_ms")
+			_, routePresent := spanEmbedInt(sp, "latency.route_ms")
+			assert.True(t, routePresent, "the span must still carry latency.route_ms — only the embed attribute is absent")
+		})
+	}
+}
+
+// TestPinDecision_NeverRehydratesMetadata pins the replay guard: pinDecision
+// rehydrates a decision from a stored pin with Metadata nil. Embedding is not
+// persisted into pins, and must stay that way — a pin that carried Metadata
+// would re-emit a stale latency.embed_ms measurement on every subsequent
+// sticky hit as if it were a fresh decision.
+func TestPinDecision_NeverRehydratesMetadata(t *testing.T) {
+	dec := pinDecision(sessionpin.Pin{
+		Provider: providers.ProviderAnthropic,
+		Model:    "claude-haiku-4-5",
+		Reason:   "compaction",
+	})
+	assert.Nil(t, dec.Metadata, "pins must never carry routing metadata — rehydrating it would replay stale embed measurements")
+}

--- a/internal/proxy/gemini.go
+++ b/internal/proxy/gemini.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"math"
 	"net/http"
 	"time"
 
@@ -169,9 +168,7 @@ func (s *Service) ProxyGeminiGenerateContent(ctx context.Context, body []byte, w
 		Float64("catalog.actual_input_per_1m", actPricing.InputUSDPer1M).
 		Float64("catalog.actual_output_per_1m", actPricing.OutputUSDPer1M).
 		Int64("latency.route_ms", routeMs)
-	if decision.Metadata != nil && decision.Metadata.EmbedMs != nil {
-		geminiDecisionBuilder.Int64("latency.embed_ms", int64(math.Round(*decision.Metadata.EmbedMs)))
-	}
+	applyEmbedLatencyAttr(geminiDecisionBuilder, routeRes)
 	applyPlannerAttrs(geminiDecisionBuilder, routeRes)
 	applyRoutingStateAttrs(geminiDecisionBuilder, routeRes, decision.Model, sessionKey)
 	otel.Record(ctx, otel.Span{

--- a/internal/proxy/gemini.go
+++ b/internal/proxy/gemini.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math"
 	"net/http"
 	"time"
 
@@ -168,6 +169,9 @@ func (s *Service) ProxyGeminiGenerateContent(ctx context.Context, body []byte, w
 		Float64("catalog.actual_input_per_1m", actPricing.InputUSDPer1M).
 		Float64("catalog.actual_output_per_1m", actPricing.OutputUSDPer1M).
 		Int64("latency.route_ms", routeMs)
+	if decision.Metadata != nil && decision.Metadata.EmbedMs != nil {
+		geminiDecisionBuilder.Int64("latency.embed_ms", int64(math.Round(*decision.Metadata.EmbedMs)))
+	}
 	applyPlannerAttrs(geminiDecisionBuilder, routeRes)
 	applyRoutingStateAttrs(geminiDecisionBuilder, routeRes, decision.Model, sessionKey)
 	otel.Record(ctx, otel.Span{

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"math"
 	"net/http"
 	"sort"
 	"strings"
@@ -2624,6 +2625,9 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 		Float64("catalog.actual_input_per_1m", actPricing.InputUSDPer1M).
 		Float64("catalog.actual_output_per_1m", actPricing.OutputUSDPer1M).
 		Int64("latency.route_ms", routeMs)
+	if decision.Metadata != nil && decision.Metadata.EmbedMs != nil {
+		decisionBuilder.Int64("latency.embed_ms", int64(math.Round(*decision.Metadata.EmbedMs)))
+	}
 	applyPlannerAttrs(decisionBuilder, routeRes)
 	applyRoutingStateAttrs(decisionBuilder, routeRes, decision.Model, sessionKey)
 	otel.Record(ctx, otel.Span{
@@ -4718,6 +4722,9 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 		Float64("catalog.actual_input_per_1m", actPricing.InputUSDPer1M).
 		Float64("catalog.actual_output_per_1m", actPricing.OutputUSDPer1M).
 		Int64("latency.route_ms", routeMs)
+	if decision.Metadata != nil && decision.Metadata.EmbedMs != nil {
+		openaiDecisionBuilder.Int64("latency.embed_ms", int64(math.Round(*decision.Metadata.EmbedMs)))
+	}
 	applyPlannerAttrs(openaiDecisionBuilder, routeRes)
 	applyRoutingStateAttrs(openaiDecisionBuilder, routeRes, decision.Model, sessionKey)
 	otel.Record(ctx, otel.Span{

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -3397,10 +3397,9 @@ func applyPlannerAttrs(b *otel.AttrBuilder, res turnLoopResult) *otel.AttrBuilde
 	return b
 }
 
-// applyEmbedLatencyAttr stamps the sidecar's embedding time for this request.
-// It reads the FRESH decision, not the served one: a planner STAY serves a
-// pin-derived decision whose Metadata is nil even though the sidecar embedded
-// this very turn. Absent = no embedding ran; a present 0 is a warm cache.
+// applyEmbedLatencyAttr reads the FRESH decision's EmbedMs, not the served
+// one: a planner STAY has nil Metadata even when the sidecar embedded this
+// turn. Absent = no embedding ran; present 0 = warm cache.
 func applyEmbedLatencyAttr(b *otel.AttrBuilder, res turnLoopResult) *otel.AttrBuilder {
 	if res.Fresh.Metadata != nil && res.Fresh.Metadata.EmbedMs != nil {
 		b.Int64("latency.embed_ms", int64(math.Round(*res.Fresh.Metadata.EmbedMs)))

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -2625,9 +2625,7 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 		Float64("catalog.actual_input_per_1m", actPricing.InputUSDPer1M).
 		Float64("catalog.actual_output_per_1m", actPricing.OutputUSDPer1M).
 		Int64("latency.route_ms", routeMs)
-	if decision.Metadata != nil && decision.Metadata.EmbedMs != nil {
-		decisionBuilder.Int64("latency.embed_ms", int64(math.Round(*decision.Metadata.EmbedMs)))
-	}
+	applyEmbedLatencyAttr(decisionBuilder, routeRes)
 	applyPlannerAttrs(decisionBuilder, routeRes)
 	applyRoutingStateAttrs(decisionBuilder, routeRes, decision.Model, sessionKey)
 	otel.Record(ctx, otel.Span{
@@ -3396,6 +3394,17 @@ func applyPlannerAttrs(b *otel.AttrBuilder, res turnLoopResult) *otel.AttrBuilde
 		Int64("handover.latency_ms", res.Handover.LatencyMS).
 		Int64("handover.summary_tokens", int64(res.Handover.SummaryTokens)).
 		Bool("handover.fallback_to_full_history", res.Handover.FallbackToFullHistory)
+	return b
+}
+
+// applyEmbedLatencyAttr stamps the sidecar's embedding time for this request.
+// It reads the FRESH decision, not the served one: a planner STAY serves a
+// pin-derived decision whose Metadata is nil even though the sidecar embedded
+// this very turn. Absent = no embedding ran; a present 0 is a warm cache.
+func applyEmbedLatencyAttr(b *otel.AttrBuilder, res turnLoopResult) *otel.AttrBuilder {
+	if res.Fresh.Metadata != nil && res.Fresh.Metadata.EmbedMs != nil {
+		b.Int64("latency.embed_ms", int64(math.Round(*res.Fresh.Metadata.EmbedMs)))
+	}
 	return b
 }
 
@@ -4722,9 +4731,7 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 		Float64("catalog.actual_input_per_1m", actPricing.InputUSDPer1M).
 		Float64("catalog.actual_output_per_1m", actPricing.OutputUSDPer1M).
 		Int64("latency.route_ms", routeMs)
-	if decision.Metadata != nil && decision.Metadata.EmbedMs != nil {
-		openaiDecisionBuilder.Int64("latency.embed_ms", int64(math.Round(*decision.Metadata.EmbedMs)))
-	}
+	applyEmbedLatencyAttr(openaiDecisionBuilder, routeRes)
 	applyPlannerAttrs(openaiDecisionBuilder, routeRes)
 	applyRoutingStateAttrs(openaiDecisionBuilder, routeRes, decision.Model, sessionKey)
 	otel.Record(ctx, otel.Span{

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -3397,9 +3397,9 @@ func applyPlannerAttrs(b *otel.AttrBuilder, res turnLoopResult) *otel.AttrBuilde
 	return b
 }
 
-// applyEmbedLatencyAttr reads the FRESH decision's EmbedMs, not the served
-// one: a planner STAY has nil Metadata even when the sidecar embedded this
-// turn. Absent = no embedding ran; present 0 = warm cache.
+// applyEmbedLatencyAttr reads Fresh.Metadata, not the served decision:
+// STAY replaces the decision with a pin (nil Metadata) even when the
+// sidecar embedded this turn. Absent = no embedding; present 0 = warm cache.
 func applyEmbedLatencyAttr(b *otel.AttrBuilder, res turnLoopResult) *otel.AttrBuilder {
 	if res.Fresh.Metadata != nil && res.Fresh.Metadata.EmbedMs != nil {
 		b.Int64("latency.embed_ms", int64(math.Round(*res.Fresh.Metadata.EmbedMs)))

--- a/internal/router/policy/contract.go
+++ b/internal/router/policy/contract.go
@@ -103,9 +103,13 @@ type Result struct {
 	DisplayMarker        string
 	PolicyArtifactID     string
 	PolicyArtifactSHA256 string
-	RosterVersion        string
-	DebugRef             string
-	Debug                map[string]interface{}
+	// EmbedMs is the embedding duration in milliseconds the policy sidecar
+	// reported for this decision. Nil when the sidecar did not measure one;
+	// a present 0 is a real (warm-cache) measurement.
+	EmbedMs       *float64
+	RosterVersion string
+	DebugRef      string
+	Debug         map[string]interface{}
 	// RankedFallback is every classifier group in serving fallback order, each
 	// with its full and eligible roster arms. Populated when ReportsRankedFallback;
 	// empty on older sidecars (arm override fails open).

--- a/internal/router/policy/contract.go
+++ b/internal/router/policy/contract.go
@@ -103,9 +103,8 @@ type Result struct {
 	DisplayMarker        string
 	PolicyArtifactID     string
 	PolicyArtifactSHA256 string
-	// EmbedMs is the embedding duration in milliseconds the policy sidecar
-	// reported for this decision. Nil when the sidecar did not measure one;
-	// a present 0 is a real (warm-cache) measurement.
+	// EmbedMs is the sidecar's embedding duration in ms; nil when embedding
+	// didn't run, present 0 is a real warm-cache measurement.
 	EmbedMs       *float64
 	RosterVersion string
 	DebugRef      string

--- a/internal/router/policy/sidecar_router.go
+++ b/internal/router/policy/sidecar_router.go
@@ -429,6 +429,7 @@ func (r *SidecarRouter) Route(ctx context.Context, req router.Request) (router.D
 			PolicyArtifactID:              res.PolicyArtifactID,
 			PolicyArtifactSHA256:          res.PolicyArtifactSHA256,
 			RosterVersion:                 res.RosterVersion,
+			EmbedMs:                       res.EmbedMs,
 			SelectedArmID:                 binding.ArmID,
 			SidecarSchemaVersion:          res.SchemaVersion,
 			DebugRef:                      debugRef,

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -263,6 +263,10 @@ type RoutingMetadata struct {
 	PolicyArtifactID     string
 	PolicyArtifactSHA256 string
 	RosterVersion        string
+	// EmbedMs is populated only on fresh sidecar decisions and must never be
+	// persisted into session pins: a replayed pin would re-emit a stale
+	// measurement as if it were a new one.
+	EmbedMs              *float64
 	SelectedArmID        string
 	SelectedUpstreamID   string
 	BindingIndex         int

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -263,9 +263,8 @@ type RoutingMetadata struct {
 	PolicyArtifactID     string
 	PolicyArtifactSHA256 string
 	RosterVersion        string
-	// EmbedMs is populated only on fresh sidecar decisions and must never be
-	// persisted into session pins: a replayed pin would re-emit a stale
-	// measurement as if it were a new one.
+	// EmbedMs is set only on fresh sidecar decisions; never persist into pins
+	// or a replayed pin re-emits a stale measurement.
 	EmbedMs              *float64
 	SelectedArmID        string
 	SelectedUpstreamID   string


### PR DESCRIPTION
## Summary

- Parse the optional `timings` object the HMM policy sidecar now returns on `/route`: `timings.embed_ms` is float milliseconds, **omitted entirely when embedding didn't run** (Gemma path, RL sidecar), and a **present 0.0 is a real warm-cache measurement**.
- Thread it as `EmbedMs *float64` through `policy.Result` → `router.RoutingMetadata`. Only the sidecar policy router populates it; the RL and cluster routers intentionally leave it nil.
- Emit `latency.embed_ms` as an **int64** attribute (`math.Round` of the float) on the `router.decision` span at all three decision sites — Anthropic `/v1/messages`, OpenAI `/v1/chat/completions`, Gemini — **only when present**. Absent is never zero-faked.

## Why

Completes the embedding segment of the router latency waterfall end to end. The consuming side (sidecar `timings` response, OTLP ingest → `router_latency_samples.embed_latency_ms`, GraphQL `EMBED` segment, admin waterfall UI) is already merged via workweave/WorkWeave#11839 — the ingest reads this attribute with `GetIntValue()` and stores a present 0 unconditionally. The router currently ignores the unknown `timings` JSON field, so the EMBED bar stays empty until this lands.

## Sticky-pin safety

`RoutingMetadata` must never replay a stale embed measurement on a sticky hit. That is structurally guaranteed today: `pinDecision` rehydrates pin-hit decisions with `Metadata: nil` and `sessionpin.Pin` persists only a hand-picked field subset. This PR deliberately does NOT touch pin code, and pins the invariant with `TestPinDecision_NeverRehydratesMetadata` so any future metadata hydration from pins fails a named test.

## Deploy order

Free in every direction. Old sidecar + new router → attribute absent; new sidecar + old router → field ignored; the Postgres column simply stays NULL until both sides are live. The self-hosted frozen sidecar (`sidecars/hmm/`) does not return `timings` yet — the field is optional, so self-hosted deployments are unaffected (mirroring it there is a non-blocking follow-up).

## Testing

- `gofmt`, `go build ./...`, `go vet ./...`, `go test ./...` all green locally.
- New tests: policyclient parse (present 12.5 / present-0 / timings absent), decision-span emission (12.5 → 13 pins rounding-not-truncation; 0.4 → present 0 pins the warm-cache contract; nil metadata and nil EmbedMs both leave the attribute absent while `latency.route_ms` stays present), and the pin-rehydration invariant.

🤖 Generated with [Weave Router](https://router.workweave.ai)