### PR TITLE
fix: price cache planner by provider binding

### DIFF
--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -3388,7 +3388,9 @@ func applyPlannerAttrs(b *otel.AttrBuilder, res turnLoopResult) *otel.AttrBuilde
 			String("planner.pin_model", res.PinModel).
 			String("planner.fresh_model", res.Fresh.Model).
 			String("planner.chosen_model", res.Decision.Model).
-			Bool("planner.pin_cache_warm", !res.PlannerDecision.PinCacheCold)
+			Bool("planner.pin_cache_warm", !res.PlannerDecision.PinCacheCold).
+			Bool("planner.pin_price_fallback", res.PlannerDecision.PinPriceFallback).
+			Bool("planner.fresh_price_fallback", res.PlannerDecision.FreshPriceFallback)
 	}
 	b.Bool("handover.invoked", res.Handover.Invoked).
 		Int64("handover.latency_ms", res.Handover.LatencyMS).
@@ -3460,6 +3462,8 @@ func plannerLogFields(res turnLoopResult) []any {
 		"planner_fresh_model", res.Fresh.Model,
 		"planner_chosen_model", res.Decision.Model,
 		"planner_pin_cache_warm", pinCacheWarm,
+		"planner_pin_price_fallback", res.PlannerDecision.PinPriceFallback,
+		"planner_fresh_price_fallback", res.PlannerDecision.FreshPriceFallback,
 	}
 }
 

--- a/internal/router/planner/policy.go
+++ b/internal/router/planner/policy.go
@@ -44,6 +44,13 @@ type Decision struct {
 	ExpectedSavingsUSD float64
 	EvictionCostUSD    float64
 	ThresholdUSD       float64
+	// PinPriceFallback and FreshPriceFallback report that the named provider
+	// binding was absent and pricing fell back to the model's primary binding.
+	// Custom and legacy decisions can legitimately take this path; callers use
+	// these fields to distinguish that deliberate approximation from normal
+	// provider-specific pricing.
+	PinPriceFallback   bool
+	FreshPriceFallback bool
 	// PinCacheCold echoes the warmth assumption the EV math ran under, for
 	// observability. Only meaningful on the EV path; false on early returns.
 	PinCacheCold bool
@@ -127,8 +134,8 @@ func Decide(in Inputs, cfg EVConfig) Decision {
 		return Decision{Outcome: OutcomeStay, Reason: ReasonNoPriorUsage}
 	}
 
-	pinPrice, ok1 := catalog.PrimaryPriceFor(in.Pin.Model)
-	freshPrice, ok2 := catalog.PrimaryPriceFor(in.Fresh.Model)
+	pinPrice, pinPriceFallback, ok1 := priceForDecision(in.Pin.Provider, in.Pin.Model)
+	freshPrice, freshPriceFallback, ok2 := priceForDecision(in.Fresh.Provider, in.Fresh.Model)
 	if !ok1 || !ok2 {
 		return Decision{Outcome: OutcomeStay, Reason: ReasonPricingMissing}
 	}
@@ -163,6 +170,8 @@ func Decide(in Inputs, cfg EVConfig) Decision {
 		EvictionCostUSD:    evictionCost,
 		ThresholdUSD:       cfg.ThresholdUSD,
 		PinCacheCold:       in.PinCacheCold,
+		PinPriceFallback:   pinPriceFallback,
+		FreshPriceFallback: freshPriceFallback,
 	}
 	switch {
 	case expectedSavings-evictionCost > cfg.ThresholdUSD:
@@ -179,6 +188,20 @@ func Decide(in Inputs, cfg EVConfig) Decision {
 		d.Reason = ReasonEVNegative
 	}
 	return d
+}
+
+// priceForDecision prices the provider/model binding named by a routing
+// decision. Older pins and custom bindings can name a provider that is not in
+// the compiled catalog; retain the primary-binding price as an explicit,
+// observable fallback until the custom binding has pricing metadata.
+func priceForDecision(provider, model string) (catalog.Pricing, bool, bool) {
+	if provider != "" {
+		if price, ok := catalog.PriceFor(provider, model); ok {
+			return price, false, true
+		}
+	}
+	price, ok := catalog.PrimaryPriceFor(model)
+	return price, true, ok
 }
 
 // applySubsidy scales a model's price by its subscription cost factor when the

--- a/internal/router/planner/policy.go
+++ b/internal/router/planner/policy.go
@@ -44,11 +44,8 @@ type Decision struct {
 	ExpectedSavingsUSD float64
 	EvictionCostUSD    float64
 	ThresholdUSD       float64
-	// PinPriceFallback and FreshPriceFallback report that the named provider
-	// binding was absent and pricing fell back to the model's primary binding.
-	// Custom and legacy decisions can legitimately take this path; callers use
-	// these fields to distinguish that deliberate approximation from normal
-	// provider-specific pricing.
+	// PinPriceFallback and FreshPriceFallback are true when the named provider
+	// binding has no catalog entry and pricing fell back to the model's primary binding.
 	PinPriceFallback   bool
 	FreshPriceFallback bool
 	// PinCacheCold echoes the warmth assumption the EV math ran under, for
@@ -195,10 +192,8 @@ func Decide(in Inputs, cfg EVConfig) Decision {
 	return d
 }
 
-// priceForDecision prices the provider/model binding named by a routing
-// decision. Older pins and custom bindings can name a provider that is not in
-// the compiled catalog; retain the primary-binding price as an explicit,
-// observable fallback until the custom binding has pricing metadata.
+// priceForDecision returns the price for the named provider/model binding,
+// falling back to the model's primary binding when the provider is absent from the catalog.
 func priceForDecision(provider, model string) (catalog.Pricing, bool, bool) {
 	if provider != "" {
 		if price, ok := catalog.PriceFor(provider, model); ok {

--- a/internal/router/planner/policy.go
+++ b/internal/router/planner/policy.go
@@ -137,7 +137,12 @@ func Decide(in Inputs, cfg EVConfig) Decision {
 	pinPrice, pinPriceFallback, ok1 := priceForDecision(in.Pin.Provider, in.Pin.Model)
 	freshPrice, freshPriceFallback, ok2 := priceForDecision(in.Fresh.Provider, in.Fresh.Model)
 	if !ok1 || !ok2 {
-		return Decision{Outcome: OutcomeStay, Reason: ReasonPricingMissing}
+		return Decision{
+			Outcome:            OutcomeStay,
+			Reason:             ReasonPricingMissing,
+			PinPriceFallback:   pinPriceFallback && ok1,
+			FreshPriceFallback: freshPriceFallback && ok2,
+		}
 	}
 	// Subscription discount: price a covered model at its subsidized marginal
 	// cost in the EV math too, so a pin on a cheap model correctly switches to a

--- a/internal/router/planner/policy_test.go
+++ b/internal/router/planner/policy_test.go
@@ -135,10 +135,12 @@ func TestDecide_PrimaryPriceFallbackIsExplicit(t *testing.T) {
 	assert.False(t, got.FreshPriceFallback)
 
 	missing := in
-	missing.Pin.Model = modelUnknown
-	missing.AvailableModels = map[string]struct{}{modelUnknown: {}, modelOpus: {}}
+	missing.Fresh.Model = modelUnknown
+	missing.AvailableModels = map[string]struct{}{modelHaiku: {}, modelUnknown: {}}
 	got = planner.Decide(missing, defaultCfg)
 	require.Equal(t, planner.ReasonPricingMissing, got.Reason)
+	assert.True(t, got.PinPriceFallback, "successful fallback pricing must be retained on a missing-price decision")
+	assert.False(t, got.FreshPriceFallback)
 }
 
 // With ColdPinFollowFresh enabled, a cold pin follows the scorer's fresh pick

--- a/internal/router/planner/policy_test.go
+++ b/internal/router/planner/policy_test.go
@@ -5,7 +5,9 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
+	"workweave/router/internal/providers"
 	"workweave/router/internal/router"
 	"workweave/router/internal/router/planner"
 	"workweave/router/internal/router/sessionpin"
@@ -79,6 +81,64 @@ func TestDecide_SubscriptionDiscountFlipsSwitch(t *testing.T) {
 	zero := planner.Decide(zeroFactor, defaultCfg)
 	assert.Equal(t, planner.OutcomeSwitch, zero.Outcome,
 		"a 0.0 covered-model factor must still be treated as free (switch), not uncovered")
+}
+
+func TestDecide_UsesNamedProviderBindings(t *testing.T) {
+	t.Parallel()
+
+	base := planner.Inputs{
+		Pin: sessionpin.Pin{
+			Provider:        providers.ProviderMakora,
+			Model:           "deepseek/deepseek-v4-flash",
+			LastTurnEndedAt: time.Date(2026, 5, 12, 12, 0, 0, 0, time.UTC),
+		},
+		Fresh: router.Decision{
+			Provider: providers.ProviderOpenRouter,
+			Model:    "qwen/qwen3-coder-next",
+		},
+		EstimatedInputTokens: 1_000_000,
+		AvailableModels: map[string]struct{}{
+			"deepseek/deepseek-v4-flash": {},
+			"qwen/qwen3-coder-next":      {},
+		},
+	}
+
+	makoraPin := planner.Decide(base, planner.EVConfig{ExpectedRemainingTurns: 3})
+	assert.InDelta(t, -0.03696, makoraPin.ExpectedSavingsUSD, 1e-9)
+	assert.False(t, makoraPin.PinPriceFallback)
+	assert.False(t, makoraPin.FreshPriceFallback)
+
+	openRouterPinInput := base
+	openRouterPinInput.Pin.Provider = providers.ProviderOpenRouter
+	openRouterPin := planner.Decide(openRouterPinInput, planner.EVConfig{ExpectedRemainingTurns: 3})
+	assert.InDelta(t, -0.063, openRouterPin.ExpectedSavingsUSD, 1e-9)
+	assert.NotEqual(t, makoraPin.ExpectedSavingsUSD, openRouterPin.ExpectedSavingsUSD,
+		"the pin's named provider must affect its cache economics")
+}
+
+func TestDecide_PrimaryPriceFallbackIsExplicit(t *testing.T) {
+	t.Parallel()
+
+	in := planner.Inputs{
+		Pin: sessionpin.Pin{
+			Provider:        "custom-provider",
+			Model:           modelHaiku,
+			LastTurnEndedAt: time.Date(2026, 5, 12, 12, 0, 0, 0, time.UTC),
+		},
+		Fresh:                router.Decision{Provider: providers.ProviderAnthropic, Model: modelOpus},
+		EstimatedInputTokens: 50_000,
+		AvailableModels:      availableAll,
+	}
+
+	got := planner.Decide(in, defaultCfg)
+	assert.True(t, got.PinPriceFallback, "custom bindings use the documented primary-price fallback")
+	assert.False(t, got.FreshPriceFallback)
+
+	missing := in
+	missing.Pin.Model = modelUnknown
+	missing.AvailableModels = map[string]struct{}{modelUnknown: {}, modelOpus: {}}
+	got = planner.Decide(missing, defaultCfg)
+	require.Equal(t, planner.ReasonPricingMissing, got.Reason)
 }
 
 // With ColdPinFollowFresh enabled, a cold pin follows the scorer's fresh pick


### PR DESCRIPTION
## Scope
Prices cache-planner pin and fresh routes by their named provider/model binding. Legacy or custom bindings deliberately fall back to the model primary price, with the fallback recorded in planner logs and spans.

## Dependency
Base layer on `main`.

## Routing impact
Yes. This corrects STAY/SWITCH EV inputs where a model has provider-specific prices.

## Tests
`go test ./internal/router/planner ./internal/router/catalog ./internal/proxy`
`go test ./internal/router/planner ./internal/router/catalog ./internal/router/policy ./internal/policyclient ./internal/translate ./internal/proxy`
`go vet ./...`

## Rollout
No feature flag. Monitor the explicit fallback attributes for legacy/custom bindings after deploy.