### PR TITLE
test: lock cache planner HMM contract

### DIFF
--- a/internal/proxy/turnloop.go
+++ b/internal/proxy/turnloop.go
@@ -87,9 +87,7 @@ func cacheWarm(pin sessionpin.Pin) bool {
 	return time.Since(pin.LastTurnEndedAt) < providers.CacheTTLFor(pin.Provider)
 }
 
-// pinCacheCold is the shared planner contract for ordinary and HMM routes.
-// Semantic routing chooses the fresh candidate; the Go planner owns the cache
-// economics and must treat an unstable prefix as cold regardless of TTL.
+// pinCacheCold keeps ordinary and HMM paths on the same cache-economics rule.
 func pinCacheCold(pin sessionpin.Pin, prefixBroken bool) bool {
 	return !cacheWarm(pin) || prefixBroken
 }
@@ -1162,9 +1160,8 @@ func (s *Service) hmmCostGatedDecision(
 	}
 
 	cfg := s.planner
-	// HMM owns semantic selection; the shared Go planner owns cache economics.
-	// The generic tier guard is too coarse here because HMM clusters and router
-	// catalog tiers are not the same axis.
+	// HMM owns semantic selection; the shared Go planner owns cache economics
+	// because HMM clusters and catalog tiers are not the same axis.
 	cfg.TierUpgradeEnabled = false
 	base := planner.Decide(planner.Inputs{
 		Pin:                  stayPin,

--- a/internal/proxy/turnloop.go
+++ b/internal/proxy/turnloop.go
@@ -87,6 +87,13 @@ func cacheWarm(pin sessionpin.Pin) bool {
 	return time.Since(pin.LastTurnEndedAt) < providers.CacheTTLFor(pin.Provider)
 }
 
+// pinCacheCold is the shared planner contract for ordinary and HMM routes.
+// Semantic routing chooses the fresh candidate; the Go planner owns the cache
+// economics and must treat an unstable prefix as cold regardless of TTL.
+func pinCacheCold(pin sessionpin.Pin, prefixBroken bool) bool {
+	return !cacheWarm(pin) || prefixBroken
+}
+
 // turnLoopResult bundles the routing decision and pin/planner state.
 type turnLoopResult struct {
 	Decision       router.Decision
@@ -1041,7 +1048,7 @@ func (s *Service) runTurnLoop(
 		EstimatedInputTokens: feats.Tokens,
 		AvailableModels:      s.availableModels,
 		// A trimmed prefix kills the cache even inside the provider TTL.
-		PinCacheCold: pinFound && (!cacheWarm(pin) || prefixBroken),
+		PinCacheCold: pinFound && pinCacheCold(pin, prefixBroken),
 		// Applies the subsidy discount to pinned sessions too, not just fresh
 		// decisions. nil when subscription-aware routing is off.
 		SubsidizedCostFactor: req.SubsidizedModelCostFactor,
@@ -1155,15 +1162,16 @@ func (s *Service) hmmCostGatedDecision(
 	}
 
 	cfg := s.planner
-	// HMM owns semantic upgrades. The generic planner tier guard is too coarse
-	// here because HMM clusters and router catalog tiers are not the same axis.
+	// HMM owns semantic selection; the shared Go planner owns cache economics.
+	// The generic tier guard is too coarse here because HMM clusters and router
+	// catalog tiers are not the same axis.
 	cfg.TierUpgradeEnabled = false
 	base := planner.Decide(planner.Inputs{
 		Pin:                  stayPin,
 		Fresh:                fresh,
 		EstimatedInputTokens: estimatedInputTokens,
 		AvailableModels:      s.availableModels,
-		PinCacheCold:         !cacheWarm(stayPin) || prefixBroken,
+		PinCacheCold:         pinCacheCold(stayPin, prefixBroken),
 		SubsidizedCostFactor: req.SubsidizedModelCostFactor,
 	}, cfg)
 

--- a/internal/proxy/turnloop_internal_test.go
+++ b/internal/proxy/turnloop_internal_test.go
@@ -81,6 +81,21 @@ func (s *stubPinStore) DisableProvider(context.Context, [sessionpin.SessionKeyLe
 
 func (s *stubPinStore) SweepExpired(context.Context) error { return nil }
 
+func TestPinCacheCold_OrdinaryAndHMMShareTheSameRule(t *testing.T) {
+	t.Parallel()
+
+	warm := sessionpin.Pin{
+		Provider:        providers.ProviderAnthropic,
+		LastTurnEndedAt: time.Now().Add(-time.Minute),
+	}
+	cold := warm
+	cold.LastTurnEndedAt = time.Now().Add(-2 * time.Hour)
+
+	assert.False(t, pinCacheCold(warm, false), "a warm unmodified prefix remains cache-eligible")
+	assert.True(t, pinCacheCold(warm, true), "a prefix break makes a warm pin cold")
+	assert.True(t, pinCacheCold(cold, false), "an expired pin is cold without a prefix break")
+}
+
 // TestRecordTurnUsage_WritesToStore guards the synchronous UpdateUsage write:
 // recordTurnUsage must persist Last* fields in-line so the planner has
 // prior-turn evidence by the next turn.


### PR DESCRIPTION
## Scope
Documents the ownership boundary: HMM selects semantic candidates and the shared Go planner owns cache economics. Both ordinary and HMM paths use the same `!cacheWarm(pin) || prefixBroken` cold-state rule.

## Dependency
Depends on #938 for the provider-specific planner pricing layer.

## Routing impact
No intended behavior change. This is a contract-preserving refactor and focused test.

## Tests
`go test ./internal/proxy ./internal/router/planner`
`go test ./internal/router/planner ./internal/router/catalog ./internal/router/policy ./internal/policyclient ./internal/translate ./internal/proxy`
`go vet ./...`

## Rollout
No rollout or calibration required; HMM-specific confidence and same-tier overrides remain independently controlled.