### PR TITLE
feat: add cache retention shadow telemetry

### DIFF
--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -3389,8 +3389,13 @@ func applyPlannerAttrs(b *otel.AttrBuilder, res turnLoopResult) *otel.AttrBuilde
 			String("planner.fresh_model", res.Fresh.Model).
 			String("planner.chosen_model", res.Decision.Model).
 			Bool("planner.pin_cache_warm", !res.PlannerDecision.PinCacheCold).
+			String("cache.pin_provider", res.PinProvider).
+			Bool("cache.prefix_stable", !res.PrefixBroken).
 			Bool("planner.pin_price_fallback", res.PlannerDecision.PinPriceFallback).
 			Bool("planner.fresh_price_fallback", res.PlannerDecision.FreshPriceFallback)
+		if res.PriorTurnGapMS != nil {
+			b.Int64("cache.prior_turn_gap_ms", *res.PriorTurnGapMS)
+		}
 	}
 	b.Bool("handover.invoked", res.Handover.Invoked).
 		Int64("handover.latency_ms", res.Handover.LatencyMS).
@@ -3462,6 +3467,9 @@ func plannerLogFields(res turnLoopResult) []any {
 		"planner_fresh_model", res.Fresh.Model,
 		"planner_chosen_model", res.Decision.Model,
 		"planner_pin_cache_warm", pinCacheWarm,
+		"cache_pin_provider", res.PinProvider,
+		"cache_prefix_stable", !res.PrefixBroken,
+		"cache_prior_turn_gap_ms", res.PriorTurnGapMS,
 		"planner_pin_price_fallback", res.PlannerDecision.PinPriceFallback,
 		"planner_fresh_price_fallback", res.PlannerDecision.FreshPriceFallback,
 	}

--- a/internal/proxy/turn_logs_internal_test.go
+++ b/internal/proxy/turn_logs_internal_test.go
@@ -17,6 +17,7 @@ import (
 	collogspb "go.opentelemetry.io/proto/otlp/collector/logs/v1"
 
 	"workweave/router/internal/observability/otel"
+	"workweave/router/internal/providers"
 	"workweave/router/internal/router"
 	"workweave/router/internal/router/planner"
 	"workweave/router/internal/router/sessionpin"
@@ -340,9 +341,11 @@ func TestApplyPlannerAttrs_OmitsDetailsWhenSkipped(t *testing.T) {
 
 func TestApplyPlannerAttrs_EmitsDetailsWhenEvaluated(t *testing.T) {
 	res := turnLoopResult{
-		Decision: router.Decision{Model: "claude-haiku-4-5"},
-		Fresh:    router.Decision{Model: "claude-opus-4-7"},
-		PinModel: "claude-haiku-4-5",
+		Decision:     router.Decision{Model: "claude-haiku-4-5"},
+		Fresh:        router.Decision{Model: "claude-opus-4-7"},
+		PinModel:     "claude-haiku-4-5",
+		PinProvider:  providers.ProviderAnthropic,
+		PrefixBroken: true,
 		PlannerDecision: planner.Decision{
 			Outcome:            planner.OutcomeStay,
 			Reason:             planner.ReasonEVNegative,
@@ -359,5 +362,7 @@ func TestApplyPlannerAttrs_EmitsDetailsWhenEvaluated(t *testing.T) {
 	assert.Equal(t, "stay", attrs["planner.outcome"].GetStringValue())
 	assert.Equal(t, planner.ReasonEVNegative, attrs["planner.reason"].GetStringValue())
 	assert.True(t, attrs["planner.pin_cache_warm"].GetBoolValue())
+	assert.Equal(t, providers.ProviderAnthropic, attrs["cache.pin_provider"].GetStringValue())
+	assert.False(t, attrs["cache.prefix_stable"].GetBoolValue())
 	assert.InDelta(t, 0.003, attrs["planner.eviction_cost_usd"].GetDoubleValue(), 1e-12)
 }

--- a/internal/proxy/turnloop.go
+++ b/internal/proxy/turnloop.go
@@ -109,6 +109,11 @@ type turnLoopResult struct {
 	UsageBypass bool
 	PinTier     string
 	PinAgeSec   int64
+	// PinProvider, PrefixBroken, and PriorTurnGapMS preserve the cache-state
+	// evidence used by the planner for span-level shadow analysis.
+	PinProvider    string
+	PrefixBroken   bool
+	PriorTurnGapMS *int64
 	// PolicyFallback is true when the decision came from degrading a policy sidecar
 	// deadline to a session pin or tier-3 default. Exclude from bandit training and
 	// flag on the OTel span so degraded-mode spend is distinguishable.
@@ -523,6 +528,7 @@ func (s *Service) runTurnLoop(
 	// prefixTrimFreeSwitch gates actions only; detection stays unconditional
 	// so the compaction handover keeps working when the lever is off.
 	prefixBroken := s.prefixTrimFreeSwitch && res.PrefixTrimmed
+	res.PrefixBroken = prefixBroken
 	if res.PrefixTrimmed {
 		log.Info("turnloop detected client history trim",
 			"message_count", feats.MessageCount,
@@ -609,7 +615,10 @@ func (s *Service) runTurnLoop(
 		(pin.LastOutputTokens == 0 || pin.ConsecutiveUpstreamErrors > 0)
 	if pinFound {
 		res.PinModel = pin.Model
+		res.PinProvider = pin.Provider
 		res.PinAgeSec = pinAge(pin)
+		gapMS := time.Since(pin.LastTurnEndedAt).Milliseconds()
+		res.PriorTurnGapMS = &gapMS
 		log.Info("turnloop pin lookup hit",
 			"pin_model", pin.Model,
 			"pin_provider", pin.Provider,

--- a/internal/proxy/turnloop.go
+++ b/internal/proxy/turnloop.go
@@ -92,6 +92,16 @@ func pinCacheCold(pin sessionpin.Pin, prefixBroken bool) bool {
 	return !cacheWarm(pin) || prefixBroken
 }
 
+func applyPinEvidence(res *turnLoopResult, pin sessionpin.Pin) {
+	res.PinModel = pin.Model
+	res.PinProvider = pin.Provider
+	res.PinAgeSec = pinAge(pin)
+	if !pin.LastTurnEndedAt.IsZero() {
+		gapMS := time.Since(pin.LastTurnEndedAt).Milliseconds()
+		res.PriorTurnGapMS = &gapMS
+	}
+}
+
 // turnLoopResult bundles the routing decision and pin/planner state.
 type turnLoopResult struct {
 	Decision       router.Decision
@@ -614,11 +624,7 @@ func (s *Service) runTurnLoop(
 	res.EscalateEffort = pinFound && !pin.LastTurnEndedAt.IsZero() &&
 		(pin.LastOutputTokens == 0 || pin.ConsecutiveUpstreamErrors > 0)
 	if pinFound {
-		res.PinModel = pin.Model
-		res.PinProvider = pin.Provider
-		res.PinAgeSec = pinAge(pin)
-		gapMS := time.Since(pin.LastTurnEndedAt).Milliseconds()
-		res.PriorTurnGapMS = &gapMS
+		applyPinEvidence(&res, pin)
 		log.Info("turnloop pin lookup hit",
 			"pin_model", pin.Model,
 			"pin_provider", pin.Provider,
@@ -976,6 +982,9 @@ func (s *Service) runTurnLoop(
 		res.PlannerDecision = hmmPlannerDecision
 		if hmmStayModel != "" {
 			res.PinModel = hmmStayModel
+			if hmmPin, ok := s.hmmStayPin(req, activePin, hmmHistory); ok && hmmPin.Model == hmmStayModel {
+				applyPinEvidence(&res, hmmPin)
+			}
 		}
 		if hmmSticky {
 			res.StickyHit = true

--- a/internal/proxy/turnloop.go
+++ b/internal/proxy/turnloop.go
@@ -102,6 +102,13 @@ func applyPinEvidence(res *turnLoopResult, pin sessionpin.Pin) {
 	}
 }
 
+func clearPinEvidence(res *turnLoopResult) {
+	res.PinModel = ""
+	res.PinProvider = ""
+	res.PinAgeSec = 0
+	res.PriorTurnGapMS = nil
+}
+
 // turnLoopResult bundles the routing decision and pin/planner state.
 type turnLoopResult struct {
 	Decision       router.Decision
@@ -823,6 +830,9 @@ func (s *Service) runTurnLoop(
 		)
 		pinFound = false
 		pin = sessionpin.Pin{}
+	}
+	if !pinFound {
+		clearPinEvidence(&res)
 	}
 
 	// Positioned after hard-pin/forced-pin (higher precedence) and after all

--- a/internal/proxy/turnloop_internal_test.go
+++ b/internal/proxy/turnloop_internal_test.go
@@ -96,6 +96,28 @@ func TestPinCacheCold_OrdinaryAndHMMShareTheSameRule(t *testing.T) {
 	assert.True(t, pinCacheCold(cold, false), "an expired pin is cold without a prefix break")
 }
 
+func TestApplyPinEvidence_UsesAvailablePriorTurnData(t *testing.T) {
+	t.Parallel()
+
+	zeroTimestamp := turnLoopResult{}
+	applyPinEvidence(&zeroTimestamp, sessionpin.Pin{
+		Provider: providers.ProviderAnthropic,
+		Model:    "claude-haiku-4-5",
+	})
+	assert.Equal(t, providers.ProviderAnthropic, zeroTimestamp.PinProvider)
+	assert.Nil(t, zeroTimestamp.PriorTurnGapMS)
+
+	withHistory := turnLoopResult{}
+	applyPinEvidence(&withHistory, sessionpin.Pin{
+		Provider:        providers.ProviderFireworks,
+		Model:           "accounts/fireworks/models/qwen3-235b-a22b",
+		LastTurnEndedAt: time.Now().Add(-time.Second),
+	})
+	assert.Equal(t, providers.ProviderFireworks, withHistory.PinProvider)
+	require.NotNil(t, withHistory.PriorTurnGapMS)
+	assert.Greater(t, *withHistory.PriorTurnGapMS, int64(0))
+}
+
 // TestRecordTurnUsage_WritesToStore guards the synchronous UpdateUsage write:
 // recordTurnUsage must persist Last* fields in-line so the planner has
 // prior-turn evidence by the next turn.

--- a/internal/proxy/turnloop_internal_test.go
+++ b/internal/proxy/turnloop_internal_test.go
@@ -116,6 +116,12 @@ func TestApplyPinEvidence_UsesAvailablePriorTurnData(t *testing.T) {
 	assert.Equal(t, providers.ProviderFireworks, withHistory.PinProvider)
 	require.NotNil(t, withHistory.PriorTurnGapMS)
 	assert.Greater(t, *withHistory.PriorTurnGapMS, int64(0))
+
+	clearPinEvidence(&withHistory)
+	assert.Empty(t, withHistory.PinModel)
+	assert.Empty(t, withHistory.PinProvider)
+	assert.Zero(t, withHistory.PinAgeSec)
+	assert.Nil(t, withHistory.PriorTurnGapMS)
 }
 
 // TestRecordTurnUsage_WritesToStore guards the synchronous UpdateUsage write:


### PR DESCRIPTION
## Scope
Adds span/log shadow telemetry for the pin provider, prefix stability, and prior-turn gap. Existing telemetry continues to record planned/final provider bindings and realized input, cache-read, cache-creation, and output tokens.

## Dependency
Depends on #939.

## Routing impact
Shadow-only; no TTL or routing-policy behavior changes.

## Tests
`go test ./internal/proxy`
`go test ./...`
`go vet ./...`

## Rollout
Use the new span attributes for calibration. Emitted cache-control provenance and exact prior request-start timestamps are not yet persisted, so no retention policy should be promoted from this layer alone.