### PR TITLE
refactor: centralize cache write pricing

### DIFF
--- a/internal/router/catalog/catalog.go
+++ b/internal/router/catalog/catalog.go
@@ -40,6 +40,10 @@ func (t Tier) String() string {
 type Pricing struct {
 	InputUSDPer1M  float64
 	OutputUSDPer1M float64
+	// CacheWriteMultiplier is the cache-creation input price relative to base
+	// input price. Zero means the vendor has not published a binding-specific
+	// value, so existing production pricing is preserved.
+	CacheWriteMultiplier float64
 	// CacheReadMultiplier is the cost of a cache hit relative to the base
 	// input price (e.g. 0.10 for Anthropic, 0.50 for OpenAI). Zero means
 	// "unspecified — use DefaultCacheReadMultiplier".
@@ -51,6 +55,10 @@ type Pricing struct {
 // treat unknown providers as free caching, low enough to not block switches.
 const DefaultCacheReadMultiplier = 0.5
 
+// DefaultCacheWriteMultiplier preserves the legacy production cache-creation
+// calculation until provider/model/retention-specific data is verified.
+const DefaultCacheWriteMultiplier = 1.25
+
 // EffectiveCacheReadMultiplier returns CacheReadMultiplier if set, else
 // DefaultCacheReadMultiplier.
 func (p Pricing) EffectiveCacheReadMultiplier() float64 {
@@ -58,6 +66,15 @@ func (p Pricing) EffectiveCacheReadMultiplier() float64 {
 		return p.CacheReadMultiplier
 	}
 	return DefaultCacheReadMultiplier
+}
+
+// EffectiveCacheWriteMultiplier returns the binding-specific cache-write
+// multiplier when known, otherwise the legacy production multiplier.
+func (p Pricing) EffectiveCacheWriteMultiplier() float64 {
+	if p.CacheWriteMultiplier > 0 {
+		return p.CacheWriteMultiplier
+	}
+	return DefaultCacheWriteMultiplier
 }
 
 // ProviderBinding is one (provider, upstream-model-ID, price) tuple for a

--- a/internal/router/catalog/catalog.go
+++ b/internal/router/catalog/catalog.go
@@ -40,9 +40,8 @@ func (t Tier) String() string {
 type Pricing struct {
 	InputUSDPer1M  float64
 	OutputUSDPer1M float64
-	// CacheWriteMultiplier is the cache-creation input price relative to base
-	// input price. Zero means the vendor has not published a binding-specific
-	// value, so existing production pricing is preserved.
+	// CacheWriteMultiplier is the cache-creation price relative to base input price.
+	// Zero means unspecified — existing production pricing is preserved.
 	CacheWriteMultiplier float64
 	// CacheReadMultiplier is the cost of a cache hit relative to the base
 	// input price (e.g. 0.10 for Anthropic, 0.50 for OpenAI). Zero means

--- a/internal/router/catalog/cost.go
+++ b/internal/router/catalog/cost.go
@@ -7,8 +7,9 @@ import (
 )
 
 // EffectiveInputCost returns the true USD input cost after applying cache
-// pricing. Fresh tokens at base rate; cache-creation at 1.25x; cache-read
-// at the binding's effective multiplier. upstreamProvider distinguishes
+// pricing. Fresh tokens at base rate; cache-creation at the binding's
+// effective write multiplier; cache-read at the binding's effective read
+// multiplier. upstreamProvider distinguishes
 // Anthropic (input_tokens is fresh-only) from OpenAI / Gemini
 // (prompt_tokens includes cached tokens — must subtract).
 //
@@ -23,7 +24,7 @@ func EffectiveInputCost(inputTokens, cacheCreation, cacheRead int, pricePer1M fl
 		fresh = 0
 	}
 	return (float64(fresh) +
-		float64(cacheCreation)*1.25 +
+		float64(cacheCreation)*p.EffectiveCacheWriteMultiplier() +
 		float64(cacheRead)*p.EffectiveCacheReadMultiplier()) / 1_000_000 * pricePer1M
 }
 

--- a/internal/router/catalog/cost_test.go
+++ b/internal/router/catalog/cost_test.go
@@ -68,3 +68,13 @@ func TestUSDToMicros_RoundsHalfAwayFromZero(t *testing.T) {
 	// rounds half away from zero, matching both legacy implementations).
 	assert.Equal(t, int64(6_750_001), catalog.USDToMicros(6.7500005))
 }
+
+func TestEffectiveInputCost_UsesBindingCacheWritePrice(t *testing.T) {
+	price := catalog.Pricing{InputUSDPer1M: 2, CacheReadMultiplier: 0.5, CacheWriteMultiplier: 2}
+	got := catalog.EffectiveInputCost(100, 10, 20, price.InputUSDPer1M, price, "openai")
+	assert.InDelta(t, 0.0002, got, 1e-12)
+
+	price.CacheWriteMultiplier = 0
+	legacy := catalog.EffectiveInputCost(100, 10, 20, price.InputUSDPer1M, price, "openai")
+	assert.InDelta(t, 0.000185, legacy, 1e-12, "unspecified values preserve legacy 1.25x behavior")
+}


### PR DESCRIPTION
## Scope
Introduces binding-level cache-write pricing metadata and routes realized input cost through one accessor. Unspecified provider/model values deliberately retain the legacy 1.25x cache-write multiplier.

## Dependency
Depends on #941.

## Routing impact
No planner formula change. Billing and telemetry keep current behavior unless verified binding-specific metadata is supplied.

## Tests
`go test ./internal/router/catalog ./internal/proxy`
`go test ./...`
`go vet ./...`

## Rollout
Do not add vendor constants without primary-source verification and retention-mode context. Planner use of the revised formula remains shadow-only in the next layer.