### PR TITLE
feat: add cache cost model shadow

### DIFF
--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -3384,6 +3384,10 @@ func applyPlannerAttrs(b *otel.AttrBuilder, res turnLoopResult) *otel.AttrBuilde
 			String("planner.reason", res.PlannerDecision.Reason).
 			Float64("planner.expected_savings_usd", res.PlannerDecision.ExpectedSavingsUSD).
 			Float64("planner.eviction_cost_usd", res.PlannerDecision.EvictionCostUSD).
+			String("planner.shadow_outcome", plannerOutcome(res.PlannerDecision.ShadowOutcome)).
+			Float64("planner.shadow_expected_savings_usd", res.PlannerDecision.ShadowExpectedSavingsUSD).
+			Float64("planner.shadow_stay_cost_usd", res.PlannerDecision.ShadowStayCostUSD).
+			Float64("planner.shadow_switch_cost_usd", res.PlannerDecision.ShadowSwitchCostUSD).
 			Float64("planner.threshold_usd", res.PlannerDecision.ThresholdUSD).
 			String("planner.pin_model", res.PinModel).
 			String("planner.fresh_model", res.Fresh.Model).
@@ -3402,6 +3406,13 @@ func applyPlannerAttrs(b *otel.AttrBuilder, res turnLoopResult) *otel.AttrBuilde
 		Int64("handover.summary_tokens", int64(res.Handover.SummaryTokens)).
 		Bool("handover.fallback_to_full_history", res.Handover.FallbackToFullHistory)
 	return b
+}
+
+func plannerOutcome(outcome planner.Outcome) string {
+	if outcome == planner.OutcomeSwitch {
+		return "switch"
+	}
+	return "stay"
 }
 
 // applySidecarLatencyAttrs reads Fresh.Metadata, not the served decision:

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -3384,10 +3384,6 @@ func applyPlannerAttrs(b *otel.AttrBuilder, res turnLoopResult) *otel.AttrBuilde
 			String("planner.reason", res.PlannerDecision.Reason).
 			Float64("planner.expected_savings_usd", res.PlannerDecision.ExpectedSavingsUSD).
 			Float64("planner.eviction_cost_usd", res.PlannerDecision.EvictionCostUSD).
-			String("planner.shadow_outcome", plannerOutcome(res.PlannerDecision.ShadowOutcome)).
-			Float64("planner.shadow_expected_savings_usd", res.PlannerDecision.ShadowExpectedSavingsUSD).
-			Float64("planner.shadow_stay_cost_usd", res.PlannerDecision.ShadowStayCostUSD).
-			Float64("planner.shadow_switch_cost_usd", res.PlannerDecision.ShadowSwitchCostUSD).
 			Float64("planner.threshold_usd", res.PlannerDecision.ThresholdUSD).
 			String("planner.pin_model", res.PinModel).
 			String("planner.fresh_model", res.Fresh.Model).
@@ -3399,6 +3395,12 @@ func applyPlannerAttrs(b *otel.AttrBuilder, res turnLoopResult) *otel.AttrBuilde
 			Bool("planner.fresh_price_fallback", res.PlannerDecision.FreshPriceFallback)
 		if res.PriorTurnGapMS != nil {
 			b.Int64("cache.prior_turn_gap_ms", *res.PriorTurnGapMS)
+		}
+		if res.PlannerDecision.ShadowComputed {
+			b.String("planner.shadow_outcome", plannerOutcome(res.PlannerDecision.ShadowOutcome)).
+				Float64("planner.shadow_expected_savings_usd", res.PlannerDecision.ShadowExpectedSavingsUSD).
+				Float64("planner.shadow_stay_cost_usd", res.PlannerDecision.ShadowStayCostUSD).
+				Float64("planner.shadow_switch_cost_usd", res.PlannerDecision.ShadowSwitchCostUSD)
 		}
 	}
 	b.Bool("handover.invoked", res.Handover.Invoked).

--- a/internal/proxy/turn_logs_internal_test.go
+++ b/internal/proxy/turn_logs_internal_test.go
@@ -331,11 +331,14 @@ func TestApplyRoutingStateAttrs_UsesRequestKeyWhenRoutingKeyIsEmpty(t *testing.T
 
 func TestApplyPlannerAttrs_OmitsDetailsWhenSkipped(t *testing.T) {
 	b := otel.NewAttrBuilder(8)
-	applyPlannerAttrs(b, turnLoopResult{})
+	applyPlannerAttrs(b, turnLoopResult{PlannerDecision: planner.Decision{Reason: planner.ReasonNoPin}})
 	attrs := attrsByKey(b.Build())
 
-	assert.NotContains(t, attrs, "planner.outcome")
-	assert.NotContains(t, attrs, "planner.pin_cache_warm")
+	assert.Contains(t, attrs, "planner.outcome")
+	assert.NotContains(t, attrs, "planner.shadow_outcome")
+	assert.NotContains(t, attrs, "planner.shadow_expected_savings_usd")
+	assert.NotContains(t, attrs, "planner.shadow_stay_cost_usd")
+	assert.NotContains(t, attrs, "planner.shadow_switch_cost_usd")
 	assert.Contains(t, attrs, "handover.invoked")
 }
 
@@ -347,12 +350,16 @@ func TestApplyPlannerAttrs_EmitsDetailsWhenEvaluated(t *testing.T) {
 		PinProvider:  providers.ProviderAnthropic,
 		PrefixBroken: true,
 		PlannerDecision: planner.Decision{
-			Outcome:            planner.OutcomeStay,
-			Reason:             planner.ReasonEVNegative,
-			ExpectedSavingsUSD: 0.002,
-			EvictionCostUSD:    0.003,
-			ThresholdUSD:       0.001,
-			PinCacheCold:       false,
+			Outcome:             planner.OutcomeStay,
+			Reason:              planner.ReasonEVNegative,
+			ShadowComputed:      true,
+			ShadowOutcome:       planner.OutcomeSwitch,
+			ShadowStayCostUSD:   0.003,
+			ShadowSwitchCostUSD: 0.001,
+			ExpectedSavingsUSD:  0.002,
+			EvictionCostUSD:     0.003,
+			ThresholdUSD:        0.001,
+			PinCacheCold:        false,
 		},
 	}
 	b := otel.NewAttrBuilder(16)
@@ -365,4 +372,5 @@ func TestApplyPlannerAttrs_EmitsDetailsWhenEvaluated(t *testing.T) {
 	assert.Equal(t, providers.ProviderAnthropic, attrs["cache.pin_provider"].GetStringValue())
 	assert.False(t, attrs["cache.prefix_stable"].GetBoolValue())
 	assert.InDelta(t, 0.003, attrs["planner.eviction_cost_usd"].GetDoubleValue(), 1e-12)
+	assert.Equal(t, "switch", attrs["planner.shadow_outcome"].GetStringValue())
 }

--- a/internal/proxy/turnloop.go
+++ b/internal/proxy/turnloop.go
@@ -109,6 +109,10 @@ func clearPinEvidence(res *turnLoopResult) {
 	res.PriorTurnGapMS = nil
 }
 
+func cacheablePrefixTokens(pin sessionpin.Pin, total int) int {
+	return min(pin.LastCachedReadTokens+pin.LastCachedWriteTokens, total)
+}
+
 // turnLoopResult bundles the routing decision and pin/planner state.
 type turnLoopResult struct {
 	Decision       router.Decision
@@ -1072,7 +1076,7 @@ func (s *Service) runTurnLoop(
 		Pin:                   pin,
 		Fresh:                 fresh,
 		EstimatedInputTokens:  feats.Tokens,
-		CacheablePrefixTokens: min(pin.LastCachedReadTokens, feats.Tokens),
+		CacheablePrefixTokens: cacheablePrefixTokens(pin, feats.Tokens),
 		AvailableModels:       s.availableModels,
 		// A trimmed prefix kills the cache even inside the provider TTL.
 		PinCacheCold: pinFound && pinCacheCold(pin, prefixBroken),
@@ -1196,7 +1200,7 @@ func (s *Service) hmmCostGatedDecision(
 		Pin:                   stayPin,
 		Fresh:                 fresh,
 		EstimatedInputTokens:  estimatedInputTokens,
-		CacheablePrefixTokens: min(stayPin.LastCachedReadTokens, estimatedInputTokens),
+		CacheablePrefixTokens: cacheablePrefixTokens(stayPin, estimatedInputTokens),
 		AvailableModels:       s.availableModels,
 		PinCacheCold:          pinCacheCold(stayPin, prefixBroken),
 		SubsidizedCostFactor:  req.SubsidizedModelCostFactor,

--- a/internal/proxy/turnloop.go
+++ b/internal/proxy/turnloop.go
@@ -1069,10 +1069,11 @@ func (s *Service) runTurnLoop(
 	}
 
 	plannerIn := planner.Inputs{
-		Pin:                  pin,
-		Fresh:                fresh,
-		EstimatedInputTokens: feats.Tokens,
-		AvailableModels:      s.availableModels,
+		Pin:                   pin,
+		Fresh:                 fresh,
+		EstimatedInputTokens:  feats.Tokens,
+		CacheablePrefixTokens: min(pin.LastCachedReadTokens, feats.Tokens),
+		AvailableModels:       s.availableModels,
 		// A trimmed prefix kills the cache even inside the provider TTL.
 		PinCacheCold: pinFound && pinCacheCold(pin, prefixBroken),
 		// Applies the subsidy discount to pinned sessions too, not just fresh
@@ -1192,12 +1193,13 @@ func (s *Service) hmmCostGatedDecision(
 	// because HMM clusters and catalog tiers are not the same axis.
 	cfg.TierUpgradeEnabled = false
 	base := planner.Decide(planner.Inputs{
-		Pin:                  stayPin,
-		Fresh:                fresh,
-		EstimatedInputTokens: estimatedInputTokens,
-		AvailableModels:      s.availableModels,
-		PinCacheCold:         pinCacheCold(stayPin, prefixBroken),
-		SubsidizedCostFactor: req.SubsidizedModelCostFactor,
+		Pin:                   stayPin,
+		Fresh:                 fresh,
+		EstimatedInputTokens:  estimatedInputTokens,
+		CacheablePrefixTokens: min(stayPin.LastCachedReadTokens, estimatedInputTokens),
+		AvailableModels:       s.availableModels,
+		PinCacheCold:          pinCacheCold(stayPin, prefixBroken),
+		SubsidizedCostFactor:  req.SubsidizedModelCostFactor,
 	}, cfg)
 
 	if hmmFreshIsMoreExpensive(stayPin.Model, fresh.Model, req.SubsidizedModelCostFactor) {

--- a/internal/proxy/turnloop.go
+++ b/internal/proxy/turnloop.go
@@ -109,7 +109,10 @@ func clearPinEvidence(res *turnLoopResult) {
 	res.PriorTurnGapMS = nil
 }
 
-func cacheablePrefixTokens(pin sessionpin.Pin, total int) int {
+func cacheablePrefixTokens(pin sessionpin.Pin, total int, prefixBroken bool) int {
+	if prefixBroken {
+		return 0
+	}
 	return min(pin.LastCachedReadTokens+pin.LastCachedWriteTokens, total)
 }
 
@@ -1076,7 +1079,7 @@ func (s *Service) runTurnLoop(
 		Pin:                   pin,
 		Fresh:                 fresh,
 		EstimatedInputTokens:  feats.Tokens,
-		CacheablePrefixTokens: cacheablePrefixTokens(pin, feats.Tokens),
+		CacheablePrefixTokens: cacheablePrefixTokens(pin, feats.Tokens, prefixBroken),
 		AvailableModels:       s.availableModels,
 		// A trimmed prefix kills the cache even inside the provider TTL.
 		PinCacheCold: pinFound && pinCacheCold(pin, prefixBroken),
@@ -1200,7 +1203,7 @@ func (s *Service) hmmCostGatedDecision(
 		Pin:                   stayPin,
 		Fresh:                 fresh,
 		EstimatedInputTokens:  estimatedInputTokens,
-		CacheablePrefixTokens: cacheablePrefixTokens(stayPin, estimatedInputTokens),
+		CacheablePrefixTokens: cacheablePrefixTokens(stayPin, estimatedInputTokens, prefixBroken),
 		AvailableModels:       s.availableModels,
 		PinCacheCold:          pinCacheCold(stayPin, prefixBroken),
 		SubsidizedCostFactor:  req.SubsidizedModelCostFactor,

--- a/internal/proxy/turnloop_internal_test.go
+++ b/internal/proxy/turnloop_internal_test.go
@@ -129,6 +129,7 @@ func TestCacheablePrefixTokens_UsesReadOrWriteEvidence(t *testing.T) {
 
 	assert.Equal(t, 4_000, cacheablePrefixTokens(sessionpin.Pin{LastCachedWriteTokens: 4_000}, 10_000))
 	assert.Equal(t, 2_000, cacheablePrefixTokens(sessionpin.Pin{LastCachedReadTokens: 4_000}, 2_000))
+	assert.Equal(t, 7_000, cacheablePrefixTokens(sessionpin.Pin{LastCachedReadTokens: 4_000, LastCachedWriteTokens: 3_000}, 10_000))
 }
 
 // TestRecordTurnUsage_WritesToStore guards the synchronous UpdateUsage write:

--- a/internal/proxy/turnloop_internal_test.go
+++ b/internal/proxy/turnloop_internal_test.go
@@ -127,9 +127,11 @@ func TestApplyPinEvidence_UsesAvailablePriorTurnData(t *testing.T) {
 func TestCacheablePrefixTokens_UsesReadOrWriteEvidence(t *testing.T) {
 	t.Parallel()
 
-	assert.Equal(t, 4_000, cacheablePrefixTokens(sessionpin.Pin{LastCachedWriteTokens: 4_000}, 10_000))
-	assert.Equal(t, 2_000, cacheablePrefixTokens(sessionpin.Pin{LastCachedReadTokens: 4_000}, 2_000))
-	assert.Equal(t, 7_000, cacheablePrefixTokens(sessionpin.Pin{LastCachedReadTokens: 4_000, LastCachedWriteTokens: 3_000}, 10_000))
+	pin := sessionpin.Pin{LastCachedReadTokens: 4_000, LastCachedWriteTokens: 3_000}
+	assert.Equal(t, 4_000, cacheablePrefixTokens(sessionpin.Pin{LastCachedWriteTokens: 4_000}, 10_000, false))
+	assert.Equal(t, 2_000, cacheablePrefixTokens(sessionpin.Pin{LastCachedReadTokens: 4_000}, 2_000, false))
+	assert.Equal(t, 7_000, cacheablePrefixTokens(pin, 10_000, false))
+	assert.Zero(t, cacheablePrefixTokens(pin, 10_000, true))
 }
 
 // TestRecordTurnUsage_WritesToStore guards the synchronous UpdateUsage write:

--- a/internal/proxy/turnloop_internal_test.go
+++ b/internal/proxy/turnloop_internal_test.go
@@ -124,6 +124,13 @@ func TestApplyPinEvidence_UsesAvailablePriorTurnData(t *testing.T) {
 	assert.Nil(t, withHistory.PriorTurnGapMS)
 }
 
+func TestCacheablePrefixTokens_UsesReadOrWriteEvidence(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, 4_000, cacheablePrefixTokens(sessionpin.Pin{LastCachedWriteTokens: 4_000}, 10_000))
+	assert.Equal(t, 2_000, cacheablePrefixTokens(sessionpin.Pin{LastCachedReadTokens: 4_000}, 2_000))
+}
+
 // TestRecordTurnUsage_WritesToStore guards the synchronous UpdateUsage write:
 // recordTurnUsage must persist Last* fields in-line so the planner has
 // prior-turn evidence by the next turn.

--- a/internal/router/planner/policy.go
+++ b/internal/router/planner/policy.go
@@ -48,8 +48,8 @@ type Decision struct {
 	// binding has no catalog entry and pricing fell back to the model's primary binding.
 	PinPriceFallback   bool
 	FreshPriceFallback bool
-	// Shadow* is the inclusive current-plus-future cache model. It is emitted
-	// for calibration only; Outcome continues to use the production policy.
+	// Shadow* is calibration-only; Outcome continues to use the production policy.
+	ShadowComputed           bool
 	ShadowOutcome            Outcome
 	ShadowExpectedSavingsUSD float64
 	ShadowStayCostUSD        float64
@@ -188,6 +188,7 @@ func Decide(in Inputs, cfg EVConfig) Decision {
 	d.ShadowOutcome, d.ShadowExpectedSavingsUSD, d.ShadowStayCostUSD, d.ShadowSwitchCostUSD = shadowCosts(
 		pinPrice, freshPrice, tokens, float64(in.CacheablePrefixTokens), cfg.ExpectedRemainingTurns, in.PinCacheCold, cfg.ThresholdUSD,
 	)
+	d.ShadowComputed = true
 	switch {
 	case expectedSavings-evictionCost > cfg.ThresholdUSD:
 		d.Outcome = OutcomeSwitch

--- a/internal/router/planner/policy.go
+++ b/internal/router/planner/policy.go
@@ -82,9 +82,8 @@ type Inputs struct {
 	Pin                  sessionpin.Pin
 	Fresh                router.Decision
 	EstimatedInputTokens int
-	// CacheablePrefixTokens estimates the stable portion of the input. It is
-	// used only by the shadow model; production continues to use its existing
-	// full-input approximation until calibrated.
+	// CacheablePrefixTokens estimates the stable portion of the input.
+	// Shadow-only; production uses EstimatedInputTokens until calibrated.
 	CacheablePrefixTokens int
 	AvailableModels       map[string]struct{}
 	// PinCacheCold reports that the pin's upstream prompt cache has lapsed —

--- a/internal/router/planner/policy.go
+++ b/internal/router/planner/policy.go
@@ -48,6 +48,12 @@ type Decision struct {
 	// binding has no catalog entry and pricing fell back to the model's primary binding.
 	PinPriceFallback   bool
 	FreshPriceFallback bool
+	// Shadow* is the inclusive current-plus-future cache model. It is emitted
+	// for calibration only; Outcome continues to use the production policy.
+	ShadowOutcome            Outcome
+	ShadowExpectedSavingsUSD float64
+	ShadowStayCostUSD        float64
+	ShadowSwitchCostUSD      float64
 	// PinCacheCold echoes the warmth assumption the EV math ran under, for
 	// observability. Only meaningful on the EV path; false on early returns.
 	PinCacheCold bool
@@ -76,7 +82,11 @@ type Inputs struct {
 	Pin                  sessionpin.Pin
 	Fresh                router.Decision
 	EstimatedInputTokens int
-	AvailableModels      map[string]struct{}
+	// CacheablePrefixTokens estimates the stable portion of the input. It is
+	// used only by the shadow model; production continues to use its existing
+	// full-input approximation until calibrated.
+	CacheablePrefixTokens int
+	AvailableModels       map[string]struct{}
 	// PinCacheCold reports that the pin's upstream prompt cache has lapsed —
 	// no turn completed within the pinned provider's cache TTL. The proxy
 	// computes this (it owns the clock); the planner stays a pure function.
@@ -175,6 +185,9 @@ func Decide(in Inputs, cfg EVConfig) Decision {
 		PinPriceFallback:   pinPriceFallback,
 		FreshPriceFallback: freshPriceFallback,
 	}
+	d.ShadowOutcome, d.ShadowExpectedSavingsUSD, d.ShadowStayCostUSD, d.ShadowSwitchCostUSD = shadowCosts(
+		pinPrice, freshPrice, tokens, float64(in.CacheablePrefixTokens), cfg.ExpectedRemainingTurns, in.PinCacheCold, cfg.ThresholdUSD,
+	)
 	switch {
 	case expectedSavings-evictionCost > cfg.ThresholdUSD:
 		d.Outcome = OutcomeSwitch
@@ -190,6 +203,34 @@ func Decide(in Inputs, cfg EVConfig) Decision {
 		d.Reason = ReasonEVNegative
 	}
 	return d
+}
+
+// shadowCosts evaluates the inclusive-action model in shadow only.
+// N counts the current action once; K cacheable-prefix tokens get cache pricing.
+func shadowCosts(pin, fresh catalog.Pricing, total, prefix float64, remaining int, pinCold bool, threshold float64) (Outcome, float64, float64, float64) {
+	if remaining < 1 {
+		remaining = 1
+	}
+	prefix = min(max(prefix, 0), total)
+	tail := total - prefix
+	warm := func(p catalog.Pricing) float64 {
+		return (prefix*p.InputUSDPer1M*p.EffectiveCacheReadMultiplier() + tail*p.InputUSDPer1M) / 1e6
+	}
+	cold := func(p catalog.Pricing) float64 {
+		return (prefix*p.InputUSDPer1M*p.EffectiveCacheWriteMultiplier() + tail*p.InputUSDPer1M) / 1e6
+	}
+	pinWarm, freshWarm := warm(pin), warm(fresh)
+	stayCurrent := pinWarm
+	if pinCold {
+		stayCurrent = cold(pin)
+	}
+	stay := stayCurrent + float64(remaining-1)*pinWarm
+	switchCost := cold(fresh) + float64(remaining-1)*freshWarm
+	savings := stay - switchCost
+	if savings > threshold {
+		return OutcomeSwitch, savings, stay, switchCost
+	}
+	return OutcomeStay, savings, stay, switchCost
 }
 
 // priceForDecision returns the price for the named provider/model binding,

--- a/internal/router/planner/policy_test.go
+++ b/internal/router/planner/policy_test.go
@@ -143,6 +143,32 @@ func TestDecide_PrimaryPriceFallbackIsExplicit(t *testing.T) {
 	assert.False(t, got.FreshPriceFallback)
 }
 
+func TestDecide_ShadowInclusiveCostModel(t *testing.T) {
+	t.Parallel()
+
+	in := planner.Inputs{
+		Pin:                   pinWithUsage(modelOpus),
+		Fresh:                 router.Decision{Model: modelHaiku},
+		EstimatedInputTokens:  100,
+		CacheablePrefixTokens: 60,
+		AvailableModels:       availableAll,
+	}
+	got := planner.Decide(in, planner.EVConfig{ExpectedRemainingTurns: 1})
+	assert.InDelta(t, got.ShadowStayCostUSD, got.ShadowExpectedSavingsUSD+got.ShadowSwitchCostUSD, 1e-12)
+	assert.Greater(t, got.ShadowSwitchCostUSD, 0.0, "N=1 prices the current switch action exactly once")
+
+	in.CacheablePrefixTokens = 0
+	noPrefix := planner.Decide(in, planner.EVConfig{ExpectedRemainingTurns: 1})
+	in.PinCacheCold = true
+	noPrefixCold := planner.Decide(in, planner.EVConfig{ExpectedRemainingTurns: 1})
+	assert.InDelta(t, noPrefix.ShadowStayCostUSD, noPrefixCold.ShadowStayCostUSD, 1e-12,
+		"K=0 removes cache-write advantage")
+
+	in.CacheablePrefixTokens = 100
+	cold := planner.Decide(in, planner.EVConfig{ExpectedRemainingTurns: 1})
+	assert.Greater(t, cold.ShadowStayCostUSD, got.ShadowStayCostUSD, "a cold pin pays its current cache write")
+}
+
 // With ColdPinFollowFresh enabled, a cold pin follows the scorer's fresh pick
 // even when the raw-price EV is below threshold.
 func TestDecide_ColdPinFollowFresh(t *testing.T) {

--- a/internal/router/planner/policy_test.go
+++ b/internal/router/planner/policy_test.go
@@ -154,6 +154,7 @@ func TestDecide_ShadowInclusiveCostModel(t *testing.T) {
 		AvailableModels:       availableAll,
 	}
 	got := planner.Decide(in, planner.EVConfig{ExpectedRemainingTurns: 1})
+	assert.True(t, got.ShadowComputed)
 	assert.InDelta(t, got.ShadowStayCostUSD, got.ShadowExpectedSavingsUSD+got.ShadowSwitchCostUSD, 1e-12)
 	assert.Greater(t, got.ShadowSwitchCostUSD, 0.0, "N=1 prices the current switch action exactly once")
 


### PR DESCRIPTION
## Scope
Adds an inclusive-action cache cost model in shadow mode. It separates cacheable prefix and uncached tail tokens, prices the current action exactly once, and records old/new cost outputs on planner spans.

## Dependency
Depends on #942.

## Routing impact
Shadow-only. The live STAY/SWITCH decision still uses the existing policy.

## Tests
`go test ./internal/router/planner ./internal/proxy`
`go test ./...`
`go vet ./...`

## Rollout
Calibrate predicted versus realized cost and divergence before enabling the formula. Output-cost modeling is intentionally excluded pending model/action-specific historical estimates.