### PR TITLE
feat(proxy): emit non-overlapping sidecar stage latencies on decision spans

### DIFF
--- a/internal/policyclient/client.go
+++ b/internal/policyclient/client.go
@@ -381,9 +381,7 @@ type routeTimings struct {
 	EmbedMs  *float64 `json:"embed_ms"`
 }
 
-// decomposeTimings converts the sidecar's overlapping wire timings into
-// non-overlapping stages: embedding, arm selection, and the remainder of the
-// sidecar's route handler. Returns nil when the sidecar measured nothing.
+// decomposeTimings converts sidecar wire timings into non-overlapping stages; nil when nothing was measured.
 func decomposeTimings(wire *routeTimings) *router.SidecarTimings {
 	if wire == nil || (wire.RouteMs == nil && wire.SelectMs == nil && wire.EmbedMs == nil) {
 		return nil
@@ -395,7 +393,9 @@ func decomposeTimings(wire *routeTimings) *router.SidecarTimings {
 	if wire.RouteMs != nil {
 		other := *wire.RouteMs - floatOrZero(wire.EmbedMs) - floatOrZero(wire.SelectMs)
 		if other < 0 {
-			other = 0
+			// Stages exceeding the total they were measured inside of mean the
+			// breakdown can't be trusted for disjoint attribution; drop it.
+			return nil
 		}
 		timings.OtherMs = &other
 	}

--- a/internal/policyclient/client.go
+++ b/internal/policyclient/client.go
@@ -373,9 +373,40 @@ type routeResponse struct {
 }
 
 // routeTimings is the sidecar's optional per-request latency breakdown.
-// EmbedMs is nil (not zero) when embedding didn't run for this request.
+// Fields are nil (not zero) when the sidecar didn't measure that stage;
+// route_ms spans the whole decision and is a superset of the other stages.
 type routeTimings struct {
-	EmbedMs *float64 `json:"embed_ms"`
+	RouteMs  *float64 `json:"route_ms"`
+	SelectMs *float64 `json:"select_ms"`
+	EmbedMs  *float64 `json:"embed_ms"`
+}
+
+// decomposeTimings converts the sidecar's overlapping wire timings into
+// non-overlapping stages: embedding, arm selection, and the remainder of the
+// sidecar's route handler. Returns nil when the sidecar measured nothing.
+func decomposeTimings(wire *routeTimings) *router.SidecarTimings {
+	if wire == nil || (wire.RouteMs == nil && wire.SelectMs == nil && wire.EmbedMs == nil) {
+		return nil
+	}
+	timings := &router.SidecarTimings{
+		EmbedMs:  wire.EmbedMs,
+		SelectMs: wire.SelectMs,
+	}
+	if wire.RouteMs != nil {
+		other := *wire.RouteMs - floatOrZero(wire.EmbedMs) - floatOrZero(wire.SelectMs)
+		if other < 0 {
+			other = 0
+		}
+		timings.OtherMs = &other
+	}
+	return timings
+}
+
+func floatOrZero(value *float64) float64 {
+	if value == nil {
+		return 0
+	}
+	return *value
 }
 
 type previewResponse struct {
@@ -430,10 +461,6 @@ func (c *Client) Decide(ctx context.Context, query policy.Query) (policy.Result,
 	if parsed.ChosenScore != nil {
 		score = *parsed.ChosenScore
 	}
-	var embedMs *float64
-	if parsed.Timings != nil {
-		embedMs = parsed.Timings.EmbedMs
-	}
 	return policy.Result{
 		SchemaVersion:        parsed.SchemaVersion,
 		RouteID:              parsed.RouteID,
@@ -458,7 +485,7 @@ func (c *Client) Decide(ctx context.Context, query policy.Query) (policy.Result,
 		DebugRef:             parsed.DebugRef,
 		Debug:                parsed.Debug,
 		RankedFallback:       parsed.RankedFallback,
-		EmbedMs:              embedMs,
+		Timings:              decomposeTimings(parsed.Timings),
 	}, nil
 }
 

--- a/internal/policyclient/client_test.go
+++ b/internal/policyclient/client_test.go
@@ -228,12 +228,10 @@ func TestClientDecideLeavesTimingsNilWhenOmittedEntirely(t *testing.T) {
 	assert.Nil(t, result.Timings)
 }
 
-func TestClientDecideClampsOtherMsToZeroWhenStagesExceedRouteMs(t *testing.T) {
+func TestClientDecideDropsTimingsWhenStagesExceedRouteMs(t *testing.T) {
 	result := decideWithTimings(t, &routeTimings{RouteMs: floatPtr(5), SelectMs: floatPtr(4), EmbedMs: floatPtr(3)})
 
-	require.NotNil(t, result.Timings)
-	require.NotNil(t, result.Timings.OtherMs)
-	assert.Equal(t, 0.0, *result.Timings.OtherMs)
+	assert.Nil(t, result.Timings, "an inconsistent breakdown must be dropped, not published with overlapping stages")
 }
 
 func TestClientOmitsV2CandidateFieldsFromV1(t *testing.T) {

--- a/internal/policyclient/client_test.go
+++ b/internal/policyclient/client_test.go
@@ -163,11 +163,12 @@ func TestClientPostsVersionedRouteAndParsesPolicyMetadata(t *testing.T) {
 	assert.Equal(t, map[string]float32{"moonshotai/kimi-k2.7-code": 0.91}, result.CandidateScores)
 }
 
-func TestClientDecideParsesEmbedMs(t *testing.T) {
+func decideWithTimings(t *testing.T, timings *routeTimings) policy.Result {
+	t.Helper()
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		_ = json.NewEncoder(w).Encode(routeResponse{
 			SelectedRosterID: "anthropic/claude-opus-4-8",
-			Timings:          &routeTimings{EmbedMs: floatPtr(12.5)},
+			Timings:          timings,
 		})
 	}))
 	defer server.Close()
@@ -175,31 +176,45 @@ func TestClientDecideParsesEmbedMs(t *testing.T) {
 	result, err := New(server.URL, server.Client(), 0).Decide(context.Background(), policy.Query{
 		Candidates: []policy.Candidate{{RosterID: "anthropic/claude-opus-4-8", CatalogID: "claude-opus-4-8", Provider: providers.ProviderAnthropic}},
 	})
-
 	require.NoError(t, err)
-	require.NotNil(t, result.EmbedMs)
-	assert.Equal(t, 12.5, *result.EmbedMs)
+	return result
 }
 
-func TestClientDecidePreservesPresentZeroEmbedMs(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		_ = json.NewEncoder(w).Encode(routeResponse{
-			SelectedRosterID: "anthropic/claude-opus-4-8",
-			Timings:          &routeTimings{EmbedMs: floatPtr(0)},
-		})
-	}))
-	defer server.Close()
+func TestClientDecideDecomposesFullTimingsIntoDisjointStagesSummingToRouteMs(t *testing.T) {
+	const routeMs = 20.0
+	result := decideWithTimings(t, &routeTimings{RouteMs: floatPtr(routeMs), SelectMs: floatPtr(3.5), EmbedMs: floatPtr(12.5)})
 
-	result, err := New(server.URL, server.Client(), 0).Decide(context.Background(), policy.Query{
-		Candidates: []policy.Candidate{{RosterID: "anthropic/claude-opus-4-8", CatalogID: "claude-opus-4-8", Provider: providers.ProviderAnthropic}},
-	})
-
-	require.NoError(t, err)
-	require.NotNil(t, result.EmbedMs)
-	assert.Equal(t, 0.0, *result.EmbedMs)
+	require.NotNil(t, result.Timings)
+	require.NotNil(t, result.Timings.EmbedMs)
+	require.NotNil(t, result.Timings.SelectMs)
+	require.NotNil(t, result.Timings.OtherMs)
+	assert.Equal(t, 12.5, *result.Timings.EmbedMs)
+	assert.Equal(t, 3.5, *result.Timings.SelectMs)
+	assert.Equal(t, routeMs-12.5-3.5, *result.Timings.OtherMs)
+	assert.Equal(t, routeMs, *result.Timings.EmbedMs+*result.Timings.SelectMs+*result.Timings.OtherMs)
 }
 
-func TestClientDecideLeavesEmbedMsNilWhenTimingsOmitted(t *testing.T) {
+func TestClientDecideLeavesSelectAndOtherNilForEmbedOnlyTimings(t *testing.T) {
+	result := decideWithTimings(t, &routeTimings{EmbedMs: floatPtr(12.5)})
+
+	require.NotNil(t, result.Timings)
+	require.NotNil(t, result.Timings.EmbedMs)
+	assert.Equal(t, 12.5, *result.Timings.EmbedMs)
+	assert.Nil(t, result.Timings.SelectMs)
+	assert.Nil(t, result.Timings.OtherMs)
+}
+
+func TestClientDecidePreservesPresentZeroEmbedMsAndComputesOtherFromRoute(t *testing.T) {
+	result := decideWithTimings(t, &routeTimings{RouteMs: floatPtr(5), SelectMs: floatPtr(2), EmbedMs: floatPtr(0)})
+
+	require.NotNil(t, result.Timings)
+	require.NotNil(t, result.Timings.EmbedMs)
+	require.NotNil(t, result.Timings.OtherMs)
+	assert.Equal(t, 0.0, *result.Timings.EmbedMs)
+	assert.Equal(t, 3.0, *result.Timings.OtherMs)
+}
+
+func TestClientDecideLeavesTimingsNilWhenOmittedEntirely(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		_ = json.NewEncoder(w).Encode(map[string]interface{}{"model": "anthropic/claude-opus-4-8"})
 	}))
@@ -210,7 +225,15 @@ func TestClientDecideLeavesEmbedMsNilWhenTimingsOmitted(t *testing.T) {
 	})
 
 	require.NoError(t, err)
-	assert.Nil(t, result.EmbedMs)
+	assert.Nil(t, result.Timings)
+}
+
+func TestClientDecideClampsOtherMsToZeroWhenStagesExceedRouteMs(t *testing.T) {
+	result := decideWithTimings(t, &routeTimings{RouteMs: floatPtr(5), SelectMs: floatPtr(4), EmbedMs: floatPtr(3)})
+
+	require.NotNil(t, result.Timings)
+	require.NotNil(t, result.Timings.OtherMs)
+	assert.Equal(t, 0.0, *result.Timings.OtherMs)
 }
 
 func TestClientOmitsV2CandidateFieldsFromV1(t *testing.T) {

--- a/internal/proxy/decision_span_embed_test.go
+++ b/internal/proxy/decision_span_embed_test.go
@@ -180,10 +180,8 @@ func TestDecisionSpan_EmbedMs_SurvivesPlannerStay(t *testing.T) {
 	assert.Equal(t, int64(13), got)
 }
 
-// TestDecisionSpan_SidecarTimings_AllThreeStagesPresent pins that EmbedMs,
-// SelectMs, and OtherMs each land on their own span attribute with
-// independent rounding — the three stages are non-overlapping measurements
-// of one sidecar call, not one value repeated three ways.
+// TestDecisionSpan_SidecarTimings_AllThreeStagesPresent verifies each stage
+// lands on its own attribute with independent rounding.
 func TestDecisionSpan_SidecarTimings_AllThreeStagesPresent(t *testing.T) {
 	collector := newBypassSpanCollector(t)
 	svc := newEmbedTestService(t, collector, &embedTestRouter{metadata: &router.RoutingMetadata{SidecarTimings: &router.SidecarTimings{

--- a/internal/proxy/decision_span_embed_test.go
+++ b/internal/proxy/decision_span_embed_test.go
@@ -46,7 +46,8 @@ func (embedTestProvider) Passthrough(context.Context, providers.PreparedRequest,
 }
 
 // spanEmbedInt returns the int64 value of the named attribute on the span, or
-// 0 (and false) if it isn't present.
+// 0 (and false) if it isn't present. Shared by all sidecar-latency attrs
+// (embed_ms, sidecar_select_ms, sidecar_other_ms) since they're all int64.
 func spanEmbedInt(sp *tracev1.Span, key string) (int64, bool) {
 	for _, kv := range sp.Attributes {
 		if kv.Key != key {
@@ -108,7 +109,7 @@ func decisionSpanEmbed(t *testing.T, svc *Service, collector *bypassSpanCollecto
 // 12.5ms must round to 13, not truncate to 12.
 func TestDecisionSpan_EmbedMsHit_Present(t *testing.T) {
 	collector := newBypassSpanCollector(t)
-	svc := newEmbedTestService(t, collector, &embedTestRouter{metadata: &router.RoutingMetadata{EmbedMs: embedMsPtr(12.5)}}, nil)
+	svc := newEmbedTestService(t, collector, &embedTestRouter{metadata: &router.RoutingMetadata{SidecarTimings: &router.SidecarTimings{EmbedMs: embedMsPtr(12.5)}}}, nil)
 
 	sp := decisionSpanEmbed(t, svc, collector)
 
@@ -123,7 +124,7 @@ func TestDecisionSpan_EmbedMsHit_Present(t *testing.T) {
 // rounds to a PRESENT 0 int64 — distinct from the attribute being absent.
 func TestDecisionSpan_EmbedMsWarmCache_PresentZero(t *testing.T) {
 	collector := newBypassSpanCollector(t)
-	svc := newEmbedTestService(t, collector, &embedTestRouter{metadata: &router.RoutingMetadata{EmbedMs: embedMsPtr(0.4)}}, nil)
+	svc := newEmbedTestService(t, collector, &embedTestRouter{metadata: &router.RoutingMetadata{SidecarTimings: &router.SidecarTimings{EmbedMs: embedMsPtr(0.4)}}}, nil)
 
 	sp := decisionSpanEmbed(t, svc, collector)
 
@@ -140,7 +141,8 @@ func TestDecisionSpan_EmbedMsAbsent_NilMetadataAndNilEmbedMiss(t *testing.T) {
 		metadata *router.RoutingMetadata
 	}{
 		{name: "nil metadata", metadata: nil},
-		{name: "metadata without embed", metadata: &router.RoutingMetadata{}},
+		{name: "metadata without sidecar timings", metadata: &router.RoutingMetadata{}},
+		{name: "sidecar timings without embed", metadata: &router.RoutingMetadata{SidecarTimings: &router.SidecarTimings{}}},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			collector := newBypassSpanCollector(t)
@@ -168,7 +170,7 @@ func TestDecisionSpan_EmbedMs_SurvivesPlannerStay(t *testing.T) {
 		Reason:      "cluster",
 		PinnedUntil: time.Now().Add(time.Hour),
 	}
-	svc := newEmbedTestService(t, collector, &embedTestRouter{metadata: &router.RoutingMetadata{EmbedMs: embedMsPtr(12.5)}}, store)
+	svc := newEmbedTestService(t, collector, &embedTestRouter{metadata: &router.RoutingMetadata{SidecarTimings: &router.SidecarTimings{EmbedMs: embedMsPtr(12.5)}}}, store)
 
 	sp := decisionSpanEmbed(t, svc, collector)
 
@@ -178,7 +180,55 @@ func TestDecisionSpan_EmbedMs_SurvivesPlannerStay(t *testing.T) {
 	assert.Equal(t, int64(13), got)
 }
 
-// TestPinDecision_NeverRehydratesMetadata guards against stale embed_ms
+// TestDecisionSpan_SidecarTimings_AllThreeStagesPresent pins that EmbedMs,
+// SelectMs, and OtherMs each land on their own span attribute with
+// independent rounding — the three stages are non-overlapping measurements
+// of one sidecar call, not one value repeated three ways.
+func TestDecisionSpan_SidecarTimings_AllThreeStagesPresent(t *testing.T) {
+	collector := newBypassSpanCollector(t)
+	svc := newEmbedTestService(t, collector, &embedTestRouter{metadata: &router.RoutingMetadata{SidecarTimings: &router.SidecarTimings{
+		EmbedMs:  embedMsPtr(12.5),
+		SelectMs: embedMsPtr(3.2),
+		OtherMs:  embedMsPtr(7.6),
+	}}}, nil)
+
+	sp := decisionSpanEmbed(t, svc, collector)
+
+	embedMs, embedPresent := spanEmbedInt(sp, "latency.embed_ms")
+	require.True(t, embedPresent, "EmbedMs must carry latency.embed_ms")
+	assert.Equal(t, int64(13), embedMs)
+
+	selectMs, selectPresent := spanEmbedInt(sp, "latency.sidecar_select_ms")
+	require.True(t, selectPresent, "SelectMs must carry latency.sidecar_select_ms")
+	assert.Equal(t, int64(3), selectMs)
+
+	otherMs, otherPresent := spanEmbedInt(sp, "latency.sidecar_other_ms")
+	require.True(t, otherPresent, "OtherMs must carry latency.sidecar_other_ms")
+	assert.Equal(t, int64(8), otherMs, "7.6 must round up to 8, not truncate to 7")
+}
+
+// TestDecisionSpan_SidecarTimings_OnlySelectMsSet pins that each of the
+// three stage attrs is emitted independently: a nil EmbedMs/OtherMs must not
+// suppress SelectMs, and SelectMs alone must not fabricate the other two.
+func TestDecisionSpan_SidecarTimings_OnlySelectMsSet(t *testing.T) {
+	collector := newBypassSpanCollector(t)
+	svc := newEmbedTestService(t, collector, &embedTestRouter{metadata: &router.RoutingMetadata{SidecarTimings: &router.SidecarTimings{
+		SelectMs: embedMsPtr(3.2),
+	}}}, nil)
+
+	sp := decisionSpanEmbed(t, svc, collector)
+
+	selectMs, selectPresent := spanEmbedInt(sp, "latency.sidecar_select_ms")
+	require.True(t, selectPresent, "SelectMs must carry latency.sidecar_select_ms even when the other two stages are nil")
+	assert.Equal(t, int64(3), selectMs)
+
+	_, embedPresent := spanEmbedInt(sp, "latency.embed_ms")
+	assert.False(t, embedPresent, "nil EmbedMs must not emit latency.embed_ms")
+	_, otherPresent := spanEmbedInt(sp, "latency.sidecar_other_ms")
+	assert.False(t, otherPresent, "nil OtherMs must not emit latency.sidecar_other_ms")
+}
+
+// TestPinDecision_NeverRehydratesMetadata guards against stale sidecar-timing
 // replay: pins must rehydrate with Metadata nil.
 func TestPinDecision_NeverRehydratesMetadata(t *testing.T) {
 	dec := pinDecision(sessionpin.Pin{
@@ -186,5 +236,5 @@ func TestPinDecision_NeverRehydratesMetadata(t *testing.T) {
 		Model:    "claude-haiku-4-5",
 		Reason:   "compaction",
 	})
-	assert.Nil(t, dec.Metadata, "pins must never carry routing metadata — rehydrating it would replay stale embed measurements")
+	assert.Nil(t, dec.Metadata, "pins must never carry routing metadata — rehydrating it would replay stale sidecar timings")
 }

--- a/internal/proxy/decision_span_embed_test.go
+++ b/internal/proxy/decision_span_embed_test.go
@@ -205,9 +205,8 @@ func TestDecisionSpan_SidecarTimings_AllThreeStagesPresent(t *testing.T) {
 	assert.Equal(t, int64(8), otherMs, "7.6 must round up to 8, not truncate to 7")
 }
 
-// TestDecisionSpan_SidecarTimings_OnlySelectMsSet pins that each of the
-// three stage attrs is emitted independently: a nil EmbedMs/OtherMs must not
-// suppress SelectMs, and SelectMs alone must not fabricate the other two.
+// TestDecisionSpan_SidecarTimings_OnlySelectMsSet verifies each stage attr
+// is emitted independently: present SelectMs must not suppress or fabricate siblings.
 func TestDecisionSpan_SidecarTimings_OnlySelectMsSet(t *testing.T) {
 	collector := newBypassSpanCollector(t)
 	svc := newEmbedTestService(t, collector, &embedTestRouter{metadata: &router.RoutingMetadata{SidecarTimings: &router.SidecarTimings{

--- a/internal/proxy/gemini.go
+++ b/internal/proxy/gemini.go
@@ -168,7 +168,7 @@ func (s *Service) ProxyGeminiGenerateContent(ctx context.Context, body []byte, w
 		Float64("catalog.actual_input_per_1m", actPricing.InputUSDPer1M).
 		Float64("catalog.actual_output_per_1m", actPricing.OutputUSDPer1M).
 		Int64("latency.route_ms", routeMs)
-	applyEmbedLatencyAttr(geminiDecisionBuilder, routeRes)
+	applySidecarLatencyAttrs(geminiDecisionBuilder, routeRes)
 	applyPlannerAttrs(geminiDecisionBuilder, routeRes)
 	applyRoutingStateAttrs(geminiDecisionBuilder, routeRes, decision.Model, sessionKey)
 	otel.Record(ctx, otel.Span{

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -3400,8 +3400,6 @@ func applyPlannerAttrs(b *otel.AttrBuilder, res turnLoopResult) *otel.AttrBuilde
 // applySidecarLatencyAttrs reads Fresh.Metadata, not the served decision:
 // STAY replaces the decision with a pin (nil Metadata) even when the
 // sidecar ran this turn. Absent = stage not measured; present 0 = sub-ms.
-// Each of the three stages emits independently so a nil field on one
-// doesn't suppress the others.
 func applySidecarLatencyAttrs(b *otel.AttrBuilder, res turnLoopResult) *otel.AttrBuilder {
 	if res.Fresh.Metadata == nil || res.Fresh.Metadata.SidecarTimings == nil {
 		return b

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -2625,7 +2625,7 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 		Float64("catalog.actual_input_per_1m", actPricing.InputUSDPer1M).
 		Float64("catalog.actual_output_per_1m", actPricing.OutputUSDPer1M).
 		Int64("latency.route_ms", routeMs)
-	applyEmbedLatencyAttr(decisionBuilder, routeRes)
+	applySidecarLatencyAttrs(decisionBuilder, routeRes)
 	applyPlannerAttrs(decisionBuilder, routeRes)
 	applyRoutingStateAttrs(decisionBuilder, routeRes, decision.Model, sessionKey)
 	otel.Record(ctx, otel.Span{
@@ -3397,12 +3397,24 @@ func applyPlannerAttrs(b *otel.AttrBuilder, res turnLoopResult) *otel.AttrBuilde
 	return b
 }
 
-// applyEmbedLatencyAttr reads Fresh.Metadata, not the served decision:
+// applySidecarLatencyAttrs reads Fresh.Metadata, not the served decision:
 // STAY replaces the decision with a pin (nil Metadata) even when the
-// sidecar embedded this turn. Absent = no embedding; present 0 = warm cache.
-func applyEmbedLatencyAttr(b *otel.AttrBuilder, res turnLoopResult) *otel.AttrBuilder {
-	if res.Fresh.Metadata != nil && res.Fresh.Metadata.EmbedMs != nil {
-		b.Int64("latency.embed_ms", int64(math.Round(*res.Fresh.Metadata.EmbedMs)))
+// sidecar ran this turn. Absent = stage not measured; present 0 = sub-ms.
+// Each of the three stages emits independently so a nil field on one
+// doesn't suppress the others.
+func applySidecarLatencyAttrs(b *otel.AttrBuilder, res turnLoopResult) *otel.AttrBuilder {
+	if res.Fresh.Metadata == nil || res.Fresh.Metadata.SidecarTimings == nil {
+		return b
+	}
+	st := res.Fresh.Metadata.SidecarTimings
+	if st.EmbedMs != nil {
+		b.Int64("latency.embed_ms", int64(math.Round(*st.EmbedMs)))
+	}
+	if st.SelectMs != nil {
+		b.Int64("latency.sidecar_select_ms", int64(math.Round(*st.SelectMs)))
+	}
+	if st.OtherMs != nil {
+		b.Int64("latency.sidecar_other_ms", int64(math.Round(*st.OtherMs)))
 	}
 	return b
 }
@@ -4730,7 +4742,7 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 		Float64("catalog.actual_input_per_1m", actPricing.InputUSDPer1M).
 		Float64("catalog.actual_output_per_1m", actPricing.OutputUSDPer1M).
 		Int64("latency.route_ms", routeMs)
-	applyEmbedLatencyAttr(openaiDecisionBuilder, routeRes)
+	applySidecarLatencyAttrs(openaiDecisionBuilder, routeRes)
 	applyPlannerAttrs(openaiDecisionBuilder, routeRes)
 	applyRoutingStateAttrs(openaiDecisionBuilder, routeRes, decision.Model, sessionKey)
 	otel.Record(ctx, otel.Span{

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -3398,8 +3398,7 @@ func applyPlannerAttrs(b *otel.AttrBuilder, res turnLoopResult) *otel.AttrBuilde
 }
 
 // applySidecarLatencyAttrs reads Fresh.Metadata, not the served decision:
-// STAY replaces the decision with a pin (nil Metadata) even when the
-// sidecar ran this turn. Absent = stage not measured; present 0 = sub-ms.
+// STAY replaces the decision with a pin (nil Metadata) even when the sidecar ran this turn.
 func applySidecarLatencyAttrs(b *otel.AttrBuilder, res turnLoopResult) *otel.AttrBuilder {
 	if res.Fresh.Metadata == nil || res.Fresh.Metadata.SidecarTimings == nil {
 		return b

--- a/internal/router/policy/contract.go
+++ b/internal/router/policy/contract.go
@@ -103,9 +103,9 @@ type Result struct {
 	DisplayMarker        string
 	PolicyArtifactID     string
 	PolicyArtifactSHA256 string
-	// EmbedMs is the sidecar's embedding duration in ms; nil when embedding
-	// didn't run, present 0 is a real warm-cache measurement.
-	EmbedMs       *float64
+	// Timings is the sidecar's per-stage decision cost decomposed into
+	// non-overlapping stages; nil when the sidecar reported no timings.
+	Timings       *router.SidecarTimings
 	RosterVersion string
 	DebugRef      string
 	Debug         map[string]interface{}

--- a/internal/router/policy/sidecar_router.go
+++ b/internal/router/policy/sidecar_router.go
@@ -429,7 +429,7 @@ func (r *SidecarRouter) Route(ctx context.Context, req router.Request) (router.D
 			PolicyArtifactID:              res.PolicyArtifactID,
 			PolicyArtifactSHA256:          res.PolicyArtifactSHA256,
 			RosterVersion:                 res.RosterVersion,
-			EmbedMs:                       res.EmbedMs,
+			SidecarTimings:                res.Timings,
 			SelectedArmID:                 binding.ArmID,
 			SidecarSchemaVersion:          res.SchemaVersion,
 			DebugRef:                      debugRef,

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -263,9 +263,9 @@ type RoutingMetadata struct {
 	PolicyArtifactID     string
 	PolicyArtifactSHA256 string
 	RosterVersion        string
-	// EmbedMs is set only on fresh sidecar decisions; never persist into pins
-	// or a replayed pin re-emits a stale measurement.
-	EmbedMs              *float64
+	// SidecarTimings is set only on fresh sidecar decisions; never persist
+	// into pins or a replayed pin re-emits a stale measurement.
+	SidecarTimings       *SidecarTimings
 	SelectedArmID        string
 	SelectedUpstreamID   string
 	BindingIndex         int
@@ -303,6 +303,16 @@ type RoutingMetadata struct {
 	PairedModel    string
 	PairedProvider string
 	PairedScore    float32
+}
+
+// SidecarTimings is the policy sidecar's per-stage decision cost in
+// milliseconds, decomposed into non-overlapping stages that sum to the
+// sidecar's self-reported decision total. A nil field was not measured;
+// present 0 is a real sub-millisecond measurement.
+type SidecarTimings struct {
+	EmbedMs  *float64 // embedding round trip
+	SelectMs *float64 // arm selection
+	OtherMs  *float64 // remainder of the sidecar's route handler
 }
 
 type Router interface {

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -305,10 +305,8 @@ type RoutingMetadata struct {
 	PairedScore    float32
 }
 
-// SidecarTimings is the policy sidecar's per-stage decision cost in
-// milliseconds, decomposed into non-overlapping stages that sum to the
-// sidecar's self-reported decision total. A nil field was not measured;
-// present 0 is a real sub-millisecond measurement.
+// SidecarTimings holds the sidecar's per-stage decision cost in milliseconds.
+// A nil field was not measured; present 0 is a real sub-millisecond measurement.
 type SidecarTimings struct {
 	EmbedMs  *float64 // embedding round trip
 	SelectMs *float64 // arm selection


### PR DESCRIPTION
The policy sidecar returns per-stage timings (route_ms, select_ms,
embed_ms) on /route. policyclient's decomposeTimings now decomposes
these into non-overlapping stages (embed, arm selection, remainder) so
emitted numbers are disjoint and sum to the sidecar's self-reported
decision total.

RoutingMetadata.EmbedMs is generalized into SidecarTimings, still never
persisted into session pins so a replayed pin can't re-emit a stale
measurement. The decision span now carries latency.sidecar_select_ms
and latency.sidecar_other_ms alongside the existing latency.embed_ms at
all three decision sites (Anthropic, OpenAI, Gemini). nil means not
measured; a present 0 is a real sub-ms measurement.

Co-Authored-By: Weave Router <router@workweave.ai>
