### PR TITLE
fix: preserve route after slash commands

### DIFF
--- a/db/queries/session_pins.sql
+++ b/db/queries/session_pins.sql
@@ -10,6 +10,15 @@ FROM router.session_pins
 WHERE session_key = @session_key::bytea
   AND role        = @role::varchar;
 
+-- Atomically consumes one active pin so a one-shot continuation cannot be
+-- reused by concurrent requests. Expired rows remain for the normal sweep.
+-- name: DeleteSessionPin :one
+DELETE FROM router.session_pins
+WHERE session_key = @session_key::bytea
+  AND role        = @role::varchar
+  AND pinned_until > CURRENT_TIMESTAMP
+RETURNING *;
+
 -- Upserts a pin, refreshing pinned_until on every hit (sliding TTL).
 -- turn_count increments on conflict so we can observe how many turns a
 -- single (session_key, role) lives for. installation_id is set on first

--- a/internal/postgres/session_pin_repo.go
+++ b/internal/postgres/session_pin_repo.go
@@ -39,6 +39,22 @@ func (r *SessionPinRepo) Get(ctx context.Context, sessionKey [sessionpin.Session
 	return toSessionPin(row), true, nil
 }
 
+// Consume atomically removes and returns an unexpired one-shot pin.
+func (r *SessionPinRepo) Consume(ctx context.Context, sessionKey [sessionpin.SessionKeyLen]byte, role string) (sessionpin.Pin, bool, error) {
+	q := sqlc.New(r.tx)
+	row, err := q.DeleteSessionPin(ctx, sqlc.DeleteSessionPinParams{
+		SessionKey: sessionKey[:],
+		Role:       role,
+	})
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return sessionpin.Pin{}, false, nil
+		}
+		return sessionpin.Pin{}, false, err
+	}
+	return toSessionPin(row), true, nil
+}
+
 func (r *SessionPinRepo) Upsert(ctx context.Context, p sessionpin.Pin) error {
 	q := sqlc.New(r.tx)
 	return q.UpsertSessionPin(ctx, sqlc.UpsertSessionPinParams{

--- a/internal/proxy/command_continuation.go
+++ b/internal/proxy/command_continuation.go
@@ -1,0 +1,62 @@
+package proxy
+
+import (
+	"context"
+
+	"workweave/router/internal/observability"
+	"workweave/router/internal/router/sessionpin"
+
+	"github.com/google/uuid"
+)
+
+// Roles live in router.session_pins.role (VARCHAR(32)); the longest normal
+// role is default_high, so keep this internal suffix compact.
+const commandContinuationRoleSuffix = "_cmd_next"
+
+func commandContinuationRole(role string) string {
+	if role == "" {
+		role = sessionpin.DefaultRole
+	}
+	return role + commandContinuationRoleSuffix
+}
+
+// grantPostCommandContinuation preserves an active automatic pin for exactly
+// one following normal turn. The command itself never reaches the upstream,
+// so it must not provoke a new model selection for the user's continuation.
+func (s *Service) grantPostCommandContinuation(
+	ctx context.Context,
+	installationID uuid.UUID,
+	sessionKey [sessionpin.SessionKeyLen]byte,
+	role string,
+) {
+	if s.pinStore == nil || installationID == uuid.Nil {
+		return
+	}
+	pin, found := s.loadPin(ctx, sessionKey, role)
+	if !found || pin.Model == "" || pin.Provider == "" || isUserForcedReason(pin.Reason) {
+		return
+	}
+	pin.Role = commandContinuationRole(role)
+	pin.InstallationID = installationID
+	pin.TurnCount = 1
+	s.upsertPin(ctx, pin)
+	observability.FromContext(ctx).Info("stored one-shot post-command continuation", "model", pin.Model, "provider", pin.Provider, "role", role)
+}
+
+// consumePostCommandContinuation atomically takes the pending continuation so
+// simultaneous requests cannot both serve it.
+func (s *Service) consumePostCommandContinuation(
+	ctx context.Context,
+	sessionKey [sessionpin.SessionKeyLen]byte,
+	role string,
+) (sessionpin.Pin, bool) {
+	if s.pinStore == nil {
+		return sessionpin.Pin{}, false
+	}
+	pin, found, err := s.pinStore.Consume(ctx, sessionKey, commandContinuationRole(role))
+	if err != nil {
+		observability.FromContext(ctx).Error("post-command continuation consume failed", "err", err)
+		return sessionpin.Pin{}, false
+	}
+	return pin, found
+}

--- a/internal/proxy/command_continuation.go
+++ b/internal/proxy/command_continuation.go
@@ -73,3 +73,25 @@ func (s *Service) consumePostCommandContinuation(
 	}
 	return pin, found
 }
+
+// invalidatePostCommandContinuation removes an active one-shot continuation
+// after its source pin has been intentionally cleared. Consume is safe here:
+// it deletes only an unexpired continuation for this exact session and role.
+func (s *Service) invalidatePostCommandContinuation(
+	ctx context.Context,
+	sessionKey [sessionpin.SessionKeyLen]byte,
+	role string,
+) error {
+	if s.pinStore == nil {
+		return nil
+	}
+	_, _, err := s.pinStore.Consume(context.Background(), sessionKey, commandContinuationRole(role))
+	if err != nil {
+		observability.FromContext(ctx).Error(
+			"post-command continuation invalidation failed",
+			"err", err,
+			"role", role,
+		)
+	}
+	return err
+}

--- a/internal/proxy/command_continuation.go
+++ b/internal/proxy/command_continuation.go
@@ -36,6 +36,16 @@ func (s *Service) grantPostCommandContinuation(
 	if !found || pin.Model == "" || pin.Provider == "" || isUserForcedReason(pin.Reason) {
 		return
 	}
+	if maxedModel := maxedOutServedModel(pin); maxedModel != "" {
+		observability.FromContext(ctx).Info(
+			"skipping one-shot post-command continuation for maxed-out pin",
+			"pin_model", pin.Model,
+			"maxed_model", maxedModel,
+			"last_output_tokens", pin.LastOutputTokens,
+			"role", role,
+		)
+		return
+	}
 	pin.Role = commandContinuationRole(role)
 	pin.InstallationID = installationID
 	pin.TurnCount = 1

--- a/internal/proxy/command_continuation.go
+++ b/internal/proxy/command_continuation.go
@@ -39,6 +39,9 @@ func (s *Service) grantPostCommandContinuation(
 	pin.Role = commandContinuationRole(role)
 	pin.InstallationID = installationID
 	pin.TurnCount = 1
+	// A slash command can arrive just before the active pin expires. Renew the
+	// one-shot independently so its immediate follow-up remains eligible.
+	pin.PinnedUntil = pinExpiry(pin.Reason)
 	s.upsertPin(ctx, pin)
 	observability.FromContext(ctx).Info("stored one-shot post-command continuation", "model", pin.Model, "provider", pin.Provider, "role", role)
 }

--- a/internal/proxy/cyber_refusal_internal_test.go
+++ b/internal/proxy/cyber_refusal_internal_test.go
@@ -49,6 +49,9 @@ func (f *repinFakeStore) ResetOverloadErrors(context.Context, [sessionpin.Sessio
 func (f *repinFakeStore) DisableProvider(context.Context, [sessionpin.SessionKeyLen]byte, string, string) error {
 	return nil
 }
+func (f *repinFakeStore) Consume(context.Context, [sessionpin.SessionKeyLen]byte, string) (sessionpin.Pin, bool, error) {
+	return sessionpin.Pin{}, false, nil
+}
 func (f *repinFakeStore) SweepExpired(context.Context) error { return nil }
 
 // A realistic Anthropic-native refusal SSE (the router-visible wire shape:

--- a/internal/proxy/force_model_pin_ttl_internal_test.go
+++ b/internal/proxy/force_model_pin_ttl_internal_test.go
@@ -46,6 +46,9 @@ func (s *recordingPinStore) ResetOverloadErrors(context.Context, [sessionpin.Ses
 func (s *recordingPinStore) DisableProvider(context.Context, [sessionpin.SessionKeyLen]byte, string, string) error {
 	return nil
 }
+func (s *recordingPinStore) Consume(context.Context, [sessionpin.SessionKeyLen]byte, string) (sessionpin.Pin, bool, error) {
+	return sessionpin.Pin{}, false, nil
+}
 func (s *recordingPinStore) SweepExpired(context.Context) error { return nil }
 
 // TestPinExpiry_UserForcedNeverExpires is the regression for the debug-session

--- a/internal/proxy/force_model_tier_fallback_internal_test.go
+++ b/internal/proxy/force_model_tier_fallback_internal_test.go
@@ -74,6 +74,9 @@ func (s *forcedPinStore) ResetOverloadErrors(context.Context, [sessionpin.Sessio
 func (s *forcedPinStore) DisableProvider(context.Context, [sessionpin.SessionKeyLen]byte, string, string) error {
 	return nil
 }
+func (s *forcedPinStore) Consume(context.Context, [sessionpin.SessionKeyLen]byte, string) (sessionpin.Pin, bool, error) {
+	return sessionpin.Pin{}, false, nil
+}
 func (s *forcedPinStore) SweepExpired(context.Context) error { return nil }
 
 type overwritingPinStore struct {
@@ -113,6 +116,9 @@ func (s *overwritingPinStore) ResetOverloadErrors(context.Context, [sessionpin.S
 }
 func (s *overwritingPinStore) DisableProvider(context.Context, [sessionpin.SessionKeyLen]byte, string, string) error {
 	return nil
+}
+func (s *overwritingPinStore) Consume(context.Context, [sessionpin.SessionKeyLen]byte, string) (sessionpin.Pin, bool, error) {
+	return sessionpin.Pin{}, false, nil
 }
 func (s *overwritingPinStore) SweepExpired(context.Context) error { return nil }
 

--- a/internal/proxy/pin_eviction.go
+++ b/internal/proxy/pin_eviction.go
@@ -35,6 +35,20 @@ func (s *Service) expireSessionPin(
 	role string,
 	reason string,
 ) error {
+	return s.expireSessionPinRow(ctx, installationID, sessionKey, role, reason, true)
+}
+
+// expireSessionPinRow writes the expired marker. Only a primary routing pin
+// can own a post-command continuation; HMM history rows must not derive a
+// second role suffix because router.session_pins.role is bounded.
+func (s *Service) expireSessionPinRow(
+	ctx context.Context,
+	installationID uuid.UUID,
+	sessionKey [sessionpin.SessionKeyLen]byte,
+	role string,
+	reason string,
+	invalidateContinuation bool,
+) error {
 	expired := sessionpin.Pin{
 		SessionKey:     sessionKey,
 		Role:           role,
@@ -45,7 +59,13 @@ func (s *Service) expireSessionPin(
 		TurnCount:      1,
 		PinnedUntil:    time.Now().Add(-time.Second),
 	}
-	return s.pinStore.Upsert(context.Background(), expired)
+	if err := s.pinStore.Upsert(context.Background(), expired); err != nil {
+		return err
+	}
+	if !invalidateContinuation {
+		return nil
+	}
+	return s.invalidatePostCommandContinuation(ctx, sessionKey, role)
 }
 
 func (s *Service) expireSessionPinAndHMMHistory(
@@ -62,7 +82,7 @@ func (s *Service) expireSessionPinAndHMMHistory(
 	if historyRole == role {
 		return nil
 	}
-	return s.expireSessionPin(ctx, installationID, sessionKey, historyRole, reason)
+	return s.expireSessionPinRow(ctx, installationID, sessionKey, historyRole, reason, false)
 }
 
 // evictPinAfterDegenerateResponse expires the session pin after a degenerate

--- a/internal/proxy/pin_eviction_internal_test.go
+++ b/internal/proxy/pin_eviction_internal_test.go
@@ -25,6 +25,8 @@ type evictionStubPinStore struct {
 	incrementNext  []int // values returned by IncrementUpstreamErrors, in order
 	resetCalls     int
 	upserts        []sessionpin.Pin
+	continuations  map[string]sessionpin.Pin
+	consumeRoles   []string
 }
 
 func (s *evictionStubPinStore) Get(context.Context, [sessionpin.SessionKeyLen]byte, string) (sessionpin.Pin, bool, error) {
@@ -73,8 +75,18 @@ func (s *evictionStubPinStore) DisableProvider(context.Context, [sessionpin.Sess
 	return nil
 }
 
-func (s *evictionStubPinStore) Consume(context.Context, [sessionpin.SessionKeyLen]byte, string) (sessionpin.Pin, bool, error) {
-	return sessionpin.Pin{}, false, nil
+func (s *evictionStubPinStore) Consume(_ context.Context, key [sessionpin.SessionKeyLen]byte, role string) (sessionpin.Pin, bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.consumeRoles = append(s.consumeRoles, role)
+	pin, found := s.continuations[role]
+	if !found || !pin.PinnedUntil.After(time.Now()) {
+		return sessionpin.Pin{}, false, nil
+	}
+	delete(s.continuations, role)
+	pin.SessionKey = key
+	pin.Role = role
+	return pin, true, nil
 }
 
 func (s *evictionStubPinStore) SweepExpired(context.Context) error { return nil }
@@ -154,6 +166,31 @@ func TestMaybeEvictPin_SecondStrikeExpires(t *testing.T) {
 		"eviction reason is the audit trail that distinguishes this path from force-model / loop-break")
 }
 
+func TestExpireSessionPinInvalidatesPostCommandContinuation(t *testing.T) {
+	continuationRole := commandContinuationRole(sessionpin.DefaultRole)
+	store := &evictionStubPinStore{continuations: map[string]sessionpin.Pin{
+		continuationRole: {
+			Provider:    providers.ProviderAnthropic,
+			Model:       "claude-haiku-4-5",
+			PinnedUntil: time.Now().Add(time.Minute),
+		},
+	}}
+	svc := newEvictionTestService(store)
+
+	err := svc.expireSessionPin(
+		context.Background(),
+		uuid.New(),
+		nonZeroSessionKey(),
+		sessionpin.DefaultRole,
+		"degenerate_response",
+	)
+
+	require.NoError(t, err)
+	require.Len(t, store.upserts, 1)
+	assert.Equal(t, []string{continuationRole}, store.consumeRoles)
+	assert.Empty(t, store.continuations, "clearing a source pin must also remove its pending continuation")
+}
+
 func TestExpireSessionPinAndHMMHistoryExpiresBothRoles(t *testing.T) {
 	store := &evictionStubPinStore{}
 	svc := newEvictionTestService(store)
@@ -172,6 +209,8 @@ func TestExpireSessionPinAndHMMHistoryExpiresBothRoles(t *testing.T) {
 	require.Len(t, store.upserts, 2)
 	assert.Equal(t, sessionpin.DefaultRole, store.upserts[0].Role)
 	assert.Equal(t, hmmHistoryRole(sessionpin.DefaultRole), store.upserts[1].Role)
+	assert.Equal(t, []string{commandContinuationRole(sessionpin.DefaultRole)}, store.consumeRoles,
+		"only the primary pin may invalidate a post-command continuation")
 	for _, expired := range store.upserts {
 		assert.Equal(t, installationID, expired.InstallationID)
 		assert.Empty(t, expired.Provider)

--- a/internal/proxy/pin_eviction_internal_test.go
+++ b/internal/proxy/pin_eviction_internal_test.go
@@ -73,6 +73,10 @@ func (s *evictionStubPinStore) DisableProvider(context.Context, [sessionpin.Sess
 	return nil
 }
 
+func (s *evictionStubPinStore) Consume(context.Context, [sessionpin.SessionKeyLen]byte, string) (sessionpin.Pin, bool, error) {
+	return sessionpin.Pin{}, false, nil
+}
+
 func (s *evictionStubPinStore) SweepExpired(context.Context) error { return nil }
 
 func newEvictionTestService(store *evictionStubPinStore) *Service {

--- a/internal/proxy/provider_overload_internal_test.go
+++ b/internal/proxy/provider_overload_internal_test.go
@@ -78,6 +78,10 @@ func (s *overloadStubPinStore) DisableProvider(_ context.Context, _ [sessionpin.
 	return nil
 }
 
+func (s *overloadStubPinStore) Consume(context.Context, [sessionpin.SessionKeyLen]byte, string) (sessionpin.Pin, bool, error) {
+	return sessionpin.Pin{}, false, nil
+}
+
 func (s *overloadStubPinStore) SweepExpired(context.Context) error { return nil }
 
 func newOverloadTestService(store *overloadStubPinStore) *Service {

--- a/internal/proxy/router_feedback_proxy_test.go
+++ b/internal/proxy/router_feedback_proxy_test.go
@@ -294,6 +294,84 @@ func TestService_RouterFeedbackCommand_DoesNotContinueMaxedPin(t *testing.T) {
 	assert.Equal(t, "claude-sonnet-4-6", followupRecorder.Header().Get(proxy.HeaderRouterModel))
 }
 
+func TestService_RouterFeedbackCommand_DoesNotResurrectClearedPin(t *testing.T) {
+	const feedbackBody = `{
+		"model":"claude-sonnet-4-6",
+		"max_tokens":1024,
+		"metadata":{"user_id":"pi:cleared-post-command"},
+		"messages":[
+			{"role":"user","content":"inspect the router state"},
+			{"role":"assistant","content":"I found the route."},
+			{"role":"user","content":"/rf+"}
+		]
+	}`
+	const followupBody = `{
+		"model":"claude-sonnet-4-6",
+		"max_tokens":1024,
+		"metadata":{"user_id":"pi:cleared-post-command"},
+		"messages":[
+			{"role":"user","content":"inspect the router state"},
+			{"role":"assistant","content":"I found the route."},
+			{"role":"user","content":"/rf+"},
+			{"role":"assistant","content":"✦ **Weave Router** → Feedback recorded 👍.\n\n"},
+			{"role":"user","content":"continue"}
+		]
+	}`
+
+	store := newFakePinStore()
+	store.hasPin = true
+	store.pin = sessionpin.Pin{
+		Provider:        providers.ProviderAnthropic,
+		Model:           "claude-haiku-4-5",
+		Reason:          "hmm_policy(label=balanced)",
+		LastServedModel: "claude-haiku-4-5",
+		PinnedUntil:     time.Now().Add(time.Minute),
+	}
+	policyRouter := &fakePolicyFeedbackRouter{decision: router.Decision{
+		Provider: providers.ProviderAnthropic,
+		Model:    "claude-sonnet-4-6",
+		Reason:   "hmm_policy(label=high)",
+		Metadata: &router.RoutingMetadata{Strategy: string(router.StrategyHMMEmbedding)},
+	}}
+	fr := &fakeRouter{decision: router.Decision{
+		Provider: providers.ProviderAnthropic,
+		Model:    "claude-sonnet-4-6",
+		Reason:   "cluster",
+	}}
+	svc := newPinSvc(fr, store).WithPolicyStrategy(policy.StrategySpec{
+		Strategy: router.StrategyHMMEmbedding,
+		Router:   policyRouter,
+		Capabilities: policy.Capabilities{
+			SchemaVersion:                 policy.SchemaVersionV1,
+			AuthoritativePerTurnSelection: true,
+		},
+	})
+	ctx := router.WithStrategy(authedCtx(uuid.NewString()), router.StrategyHMMEmbedding)
+	httpReq := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(""))
+
+	require.NoError(t, svc.ProxyMessages(ctx, []byte(feedbackBody), httptest.NewRecorder(), httpReq))
+	store.mu.Lock()
+	continuationCount := len(store.commandContinuations)
+	// Simulate a later intentional eviction. The continuation remains here to
+	// verify the turn loop cannot revive the cleared source pin if cleanup was
+	// delayed or ran on another process.
+	store.pin = sessionpin.Pin{
+		Reason:      "degenerate_response",
+		PinnedUntil: time.Now().Add(-time.Second),
+	}
+	store.mu.Unlock()
+	require.Equal(t, 1, continuationCount, "feedback must create the expected one-shot continuation")
+
+	followupRecorder := httptest.NewRecorder()
+	require.NoError(t, svc.ProxyMessages(ctx, []byte(followupBody), followupRecorder, httpReq))
+	require.Len(t, policyRouter.Requests(), 1, "a stale continuation must not restore an intentionally cleared route")
+	assert.Equal(t, "claude-sonnet-4-6", followupRecorder.Header().Get(proxy.HeaderRouterModel))
+	store.mu.Lock()
+	continuationCount = len(store.commandContinuations)
+	store.mu.Unlock()
+	assert.Zero(t, continuationCount, "the rejected continuation must be consumed")
+}
+
 func TestService_RouterFeedbackCommand_ForwardsPolicyFeedback(t *testing.T) {
 	const body = `{
 		"model":"claude-sonnet-4-6",

--- a/internal/proxy/router_feedback_proxy_test.go
+++ b/internal/proxy/router_feedback_proxy_test.go
@@ -172,6 +172,7 @@ func TestService_RouterFeedbackCommand_PreservesAutomaticPinForOneFollowup(t *te
 		]
 	}`
 
+	sourceExpiry := time.Now().Add(time.Minute)
 	store := newFakePinStore()
 	store.hasPin = true
 	store.pin = sessionpin.Pin{
@@ -179,7 +180,7 @@ func TestService_RouterFeedbackCommand_PreservesAutomaticPinForOneFollowup(t *te
 		Model:           "claude-haiku-4-5",
 		Reason:          "hmm_policy(label=balanced)",
 		LastServedModel: "claude-haiku-4-5",
-		PinnedUntil:     time.Now().Add(time.Hour),
+		PinnedUntil:     sourceExpiry,
 	}
 	policyRouter := &fakePolicyFeedbackRouter{decision: router.Decision{
 		Provider: providers.ProviderAnthropic,
@@ -201,6 +202,15 @@ func TestService_RouterFeedbackCommand_PreservesAutomaticPinForOneFollowup(t *te
 
 	require.NoError(t, svc.ProxyMessages(ctx, []byte(feedbackBody), httptest.NewRecorder(), httpReq))
 	assert.Empty(t, policyRouter.Requests(), "the synthetic feedback response must not route")
+	store.mu.Lock()
+	continuations := make([]sessionpin.Pin, 0, len(store.commandContinuations))
+	for _, continuation := range store.commandContinuations {
+		continuations = append(continuations, continuation)
+	}
+	store.mu.Unlock()
+	require.Len(t, continuations, 1)
+	assert.True(t, continuations[0].PinnedUntil.After(sourceExpiry),
+		"the continuation must renew a near-expiry automatic pin")
 
 	followupRecorder := httptest.NewRecorder()
 	require.NoError(t, svc.ProxyMessages(ctx, []byte(followupBody), followupRecorder, httpReq))

--- a/internal/proxy/router_feedback_proxy_test.go
+++ b/internal/proxy/router_feedback_proxy_test.go
@@ -134,6 +134,85 @@ func TestService_RouterFeedbackCommand_PersistsAndAcks(t *testing.T) {
 	assert.Contains(t, text, "Feedback recorded")
 }
 
+func TestService_RouterFeedbackCommand_PreservesAutomaticPinForOneFollowup(t *testing.T) {
+	const feedbackBody = `{
+		"model":"claude-sonnet-4-6",
+		"max_tokens":1024,
+		"metadata":{"user_id":"pi:post-command-continuation"},
+		"messages":[
+			{"role":"user","content":"inspect the router state"},
+			{"role":"assistant","content":"I found the route."},
+			{"role":"user","content":"/rf+"}
+		]
+	}`
+	const followupBody = `{
+		"model":"claude-sonnet-4-6",
+		"max_tokens":1024,
+		"metadata":{"user_id":"pi:post-command-continuation"},
+		"messages":[
+			{"role":"user","content":"inspect the router state"},
+			{"role":"assistant","content":"I found the route."},
+			{"role":"user","content":"/rf+"},
+			{"role":"assistant","content":"✦ **Weave Router** → Feedback recorded 👍.\n\n"},
+			{"role":"user","content":"continue"}
+		]
+	}`
+	const laterBody = `{
+		"model":"claude-sonnet-4-6",
+		"max_tokens":1024,
+		"metadata":{"user_id":"pi:post-command-continuation"},
+		"messages":[
+			{"role":"user","content":"inspect the router state"},
+			{"role":"assistant","content":"I found the route."},
+			{"role":"user","content":"/rf+"},
+			{"role":"assistant","content":"✦ **Weave Router** → Feedback recorded 👍.\n\n"},
+			{"role":"user","content":"continue"},
+			{"role":"assistant","content":"Continuing on the existing route."},
+			{"role":"user","content":"now assess another task"}
+		]
+	}`
+
+	store := newFakePinStore()
+	store.hasPin = true
+	store.pin = sessionpin.Pin{
+		Provider:        providers.ProviderAnthropic,
+		Model:           "claude-haiku-4-5",
+		Reason:          "hmm_policy(label=balanced)",
+		LastServedModel: "claude-haiku-4-5",
+		PinnedUntil:     time.Now().Add(time.Hour),
+	}
+	policyRouter := &fakePolicyFeedbackRouter{decision: router.Decision{
+		Provider: providers.ProviderAnthropic,
+		Model:    "claude-sonnet-4-6",
+		Reason:   "hmm_policy(label=high)",
+		Metadata: &router.RoutingMetadata{Strategy: string(router.StrategyHMMEmbedding)},
+	}}
+	fr := &fakeRouter{decision: router.Decision{Provider: providers.ProviderAnthropic, Model: "claude-sonnet-4-6", Reason: "cluster"}}
+	svc := newPinSvc(fr, store).WithPolicyStrategy(policy.StrategySpec{
+		Strategy: router.StrategyHMMEmbedding,
+		Router:   policyRouter,
+		Capabilities: policy.Capabilities{
+			SchemaVersion:                 policy.SchemaVersionV1,
+			AuthoritativePerTurnSelection: true,
+		},
+	})
+	ctx := router.WithStrategy(authedCtx(uuid.NewString()), router.StrategyHMMEmbedding)
+	httpReq := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(""))
+
+	require.NoError(t, svc.ProxyMessages(ctx, []byte(feedbackBody), httptest.NewRecorder(), httpReq))
+	assert.Empty(t, policyRouter.Requests(), "the synthetic feedback response must not route")
+
+	followupRecorder := httptest.NewRecorder()
+	require.NoError(t, svc.ProxyMessages(ctx, []byte(followupBody), followupRecorder, httpReq))
+	assert.Empty(t, policyRouter.Requests(), "the first normal turn after a slash command must reuse the automatic pin")
+	assert.Equal(t, "claude-haiku-4-5", followupRecorder.Header().Get(proxy.HeaderRouterModel))
+
+	laterRecorder := httptest.NewRecorder()
+	require.NoError(t, svc.ProxyMessages(ctx, []byte(laterBody), laterRecorder, httpReq))
+	require.Len(t, policyRouter.Requests(), 1, "the one-shot continuation must be consumed after one normal turn")
+	assert.Equal(t, "claude-sonnet-4-6", laterRecorder.Header().Get(proxy.HeaderRouterModel))
+}
+
 func TestService_RouterFeedbackCommand_ForwardsPolicyFeedback(t *testing.T) {
 	const body = `{
 		"model":"claude-sonnet-4-6",

--- a/internal/proxy/router_feedback_proxy_test.go
+++ b/internal/proxy/router_feedback_proxy_test.go
@@ -223,6 +223,77 @@ func TestService_RouterFeedbackCommand_PreservesAutomaticPinForOneFollowup(t *te
 	assert.Equal(t, "claude-sonnet-4-6", laterRecorder.Header().Get(proxy.HeaderRouterModel))
 }
 
+func TestService_RouterFeedbackCommand_DoesNotContinueMaxedPin(t *testing.T) {
+	const feedbackBody = `{
+		"model":"claude-sonnet-4-6",
+		"max_tokens":1024,
+		"metadata":{"user_id":"pi:maxed-post-command"},
+		"messages":[
+			{"role":"user","content":"inspect the router state"},
+			{"role":"assistant","content":"I found the route."},
+			{"role":"user","content":"/rf+"}
+		]
+	}`
+	const followupBody = `{
+		"model":"claude-sonnet-4-6",
+		"max_tokens":1024,
+		"metadata":{"user_id":"pi:maxed-post-command"},
+		"messages":[
+			{"role":"user","content":"inspect the router state"},
+			{"role":"assistant","content":"I found the route."},
+			{"role":"user","content":"/rf+"},
+			{"role":"assistant","content":"✦ **Weave Router** → Feedback recorded 👍.\n\n"},
+			{"role":"user","content":"continue"}
+		]
+	}`
+
+	store := newFakePinStore()
+	store.hasPin = true
+	store.pin = sessionpin.Pin{
+		Provider:        providers.ProviderAnthropic,
+		Model:           "claude-haiku-4-5",
+		Reason:          "hmm_policy(label=balanced)",
+		LastServedModel: "claude-haiku-4-5",
+		// Keep this in sync with prevTurnMaxedOutThreshold. A saturated source
+		// pin must not be copied into a one-shot post-command continuation.
+		LastOutputTokens: 8000,
+		PinnedUntil:      time.Now().Add(time.Minute),
+	}
+	policyRouter := &fakePolicyFeedbackRouter{decision: router.Decision{
+		Provider: providers.ProviderAnthropic,
+		Model:    "claude-sonnet-4-6",
+		Reason:   "hmm_policy(label=high)",
+		Metadata: &router.RoutingMetadata{Strategy: string(router.StrategyHMMEmbedding)},
+	}}
+	fr := &fakeRouter{decision: router.Decision{
+		Provider: providers.ProviderAnthropic,
+		Model:    "claude-sonnet-4-6",
+		Reason:   "cluster",
+	}}
+	svc := newPinSvc(fr, store).WithPolicyStrategy(policy.StrategySpec{
+		Strategy: router.StrategyHMMEmbedding,
+		Router:   policyRouter,
+		Capabilities: policy.Capabilities{
+			SchemaVersion:                 policy.SchemaVersionV1,
+			AuthoritativePerTurnSelection: true,
+		},
+	})
+	ctx := router.WithStrategy(authedCtx(uuid.NewString()), router.StrategyHMMEmbedding)
+	httpReq := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(""))
+
+	require.NoError(t, svc.ProxyMessages(ctx, []byte(feedbackBody), httptest.NewRecorder(), httpReq))
+	assert.Empty(t, policyRouter.Requests(), "the synthetic feedback response must not route")
+	store.mu.Lock()
+	continuationCount := len(store.commandContinuations)
+	store.mu.Unlock()
+	assert.Zero(t, continuationCount, "a maxed source pin must not create a continuation")
+
+	followupRecorder := httptest.NewRecorder()
+	require.NoError(t, svc.ProxyMessages(ctx, []byte(followupBody), followupRecorder, httpReq))
+	require.Len(t, policyRouter.Requests(), 1, "the maxed source pin must be excluded before fresh routing")
+	assert.Equal(t, "claude-sonnet-4-6", followupRecorder.Header().Get(proxy.HeaderRouterModel))
+}
+
 func TestService_RouterFeedbackCommand_ForwardsPolicyFeedback(t *testing.T) {
 	const body = `{
 		"model":"claude-sonnet-4-6",

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -2254,13 +2254,21 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 	if !agentShadowMode && s.pinStore != nil {
 		if cmd, hasCmd := env.ExtractForceModelCommand(); hasCmd {
 			log.Info("ProxyMessages force-model command", "force_model_cmd", cmd)
-			return s.handleForceModelCommand(ctx, w, env, cmd, installationID, sessionKey, feats.Tokens)
+			if err := s.handleForceModelCommand(ctx, w, env, cmd, installationID, sessionKey, feats.Tokens); err != nil {
+				return err
+			}
+			s.grantPostCommandContinuation(ctx, installationID, sessionKey, roleForTier(catalog.TierFor(feats.Model)))
+			return nil
 		}
 	}
 	if !agentShadowMode {
 		if cmd, hasCmd := env.ExtractRouterFeedbackCommand(); hasCmd {
 			log.Info("ProxyMessages router-feedback command")
-			return s.handleRouterFeedbackCommand(ctx, w, env, cmd, installationID, sessionKey, feats.Tokens)
+			if err := s.handleRouterFeedbackCommand(ctx, w, env, cmd, installationID, sessionKey, feats.Tokens); err != nil {
+				return err
+			}
+			s.grantPostCommandContinuation(ctx, installationID, sessionKey, roleForTier(catalog.TierFor(feats.Model)))
+			return nil
 		}
 	}
 
@@ -4527,12 +4535,20 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 	if s.pinStore != nil {
 		if cmd, hasCmd := env.ExtractForceModelCommand(); hasCmd {
 			log.Info("ProxyOpenAIChatCompletion force-model command", "force_model_cmd", cmd)
-			return s.handleForceModelCommand(ctx, w, env, cmd, installationID, sessionKey, feats.Tokens)
+			if err := s.handleForceModelCommand(ctx, w, env, cmd, installationID, sessionKey, feats.Tokens); err != nil {
+				return err
+			}
+			s.grantPostCommandContinuation(ctx, installationID, sessionKey, roleForTier(catalog.TierFor(feats.Model)))
+			return nil
 		}
 	}
 	if cmd, hasCmd := env.ExtractRouterFeedbackCommand(); hasCmd {
 		log.Info("ProxyOpenAIChatCompletion router-feedback command")
-		return s.handleRouterFeedbackCommand(ctx, w, env, cmd, installationID, sessionKey, feats.Tokens)
+		if err := s.handleRouterFeedbackCommand(ctx, w, env, cmd, installationID, sessionKey, feats.Tokens); err != nil {
+			return err
+		}
+		s.grantPostCommandContinuation(ctx, installationID, sessionKey, roleForTier(catalog.TierFor(feats.Model)))
+		return nil
 	}
 
 	// Honor the x-weave-force-model header (headless equivalent of /force-model).

--- a/internal/proxy/service_session_pin_test.go
+++ b/internal/proxy/service_session_pin_test.go
@@ -45,12 +45,14 @@ type fakePinStore struct {
 	overloadIncrementCalls int
 	overloadResetCalls     int
 	disabledProviders      []string
+	commandContinuations   map[string]sessionpin.Pin
 }
 
 func newFakePinStore() *fakePinStore {
 	return &fakePinStore{
-		upsertCh: make(chan struct{}, 16),
-		usageCh:  make(chan struct{}, 16),
+		upsertCh:             make(chan struct{}, 16),
+		usageCh:              make(chan struct{}, 16),
+		commandContinuations: make(map[string]sessionpin.Pin),
 	}
 }
 
@@ -70,6 +72,15 @@ func (f *fakePinStore) Get(ctx context.Context, key [sessionpin.SessionKeyLen]by
 		pin.Role = role
 		return pin, true, nil
 	}
+	if strings.HasSuffix(role, "_cmd_next") {
+		pin, found := f.commandContinuations[role]
+		if !found {
+			return sessionpin.Pin{}, false, nil
+		}
+		pin.SessionKey = key
+		pin.Role = role
+		return pin, true, nil
+	}
 	if !f.hasPin {
 		return sessionpin.Pin{}, false, nil
 	}
@@ -82,12 +93,28 @@ func (f *fakePinStore) Get(ctx context.Context, key [sessionpin.SessionKeyLen]by
 func (f *fakePinStore) Upsert(ctx context.Context, p sessionpin.Pin) error {
 	f.mu.Lock()
 	f.upserts = append(f.upserts, p)
+	if strings.HasSuffix(p.Role, "_cmd_next") {
+		f.commandContinuations[p.Role] = p
+	}
 	f.mu.Unlock()
 	select {
 	case f.upsertCh <- struct{}{}:
 	default:
 	}
 	return nil
+}
+
+func (f *fakePinStore) Consume(ctx context.Context, key [sessionpin.SessionKeyLen]byte, role string) (sessionpin.Pin, bool, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	pin, found := f.commandContinuations[role]
+	if !found || !pin.PinnedUntil.After(time.Now()) {
+		return sessionpin.Pin{}, false, nil
+	}
+	delete(f.commandContinuations, role)
+	pin.SessionKey = key
+	pin.Role = role
+	return pin, true, nil
 }
 
 func (f *fakePinStore) UpdateUsage(ctx context.Context, key [sessionpin.SessionKeyLen]byte, role string, usage sessionpin.Usage) error {

--- a/internal/proxy/turnloop.go
+++ b/internal/proxy/turnloop.go
@@ -365,7 +365,7 @@ func excludingModel(excluded map[string]struct{}, model string) map[string]struc
 	return out
 }
 
-func forcedPinEligible(pin sessionpin.Pin, req router.Request) bool {
+func pinEligible(pin sessionpin.Pin, req router.Request) bool {
 	if pin.Model == "" || pin.Provider == "" {
 		return false
 	}
@@ -380,6 +380,10 @@ func forcedPinEligible(pin sessionpin.Pin, req router.Request) bool {
 	}
 	_, ok := req.EnabledProviders[pin.Provider]
 	return ok
+}
+
+func forcedPinEligible(pin sessionpin.Pin, req router.Request) bool {
+	return pinEligible(pin, req)
 }
 
 // runTurnLoop is the format-agnostic routing orchestrator: detect turn type,
@@ -584,6 +588,11 @@ func (s *Service) runTurnLoop(
 
 	pin, pinFound := s.loadPin(ctx, res.SessionKey, res.PinRole)
 	hmmHistory := s.loadHMMHistory(ctx, res.SessionKey, res.PinRole)
+	commandContinuation := sessionpin.Pin{}
+	commandContinuationFound := false
+	if res.TurnType == turntype.MainLoop {
+		commandContinuation, commandContinuationFound = s.consumePostCommandContinuation(ctx, res.SessionKey, res.PinRole)
+	}
 	// Applied regardless of pinFound: eviction sets PinnedUntil in the past
 	// (routing miss) but DisabledProviders must still steer the scorer away
 	// from the struck-out provider this same turn; HMM-sticky strikes write
@@ -840,6 +849,27 @@ func (s *Service) runTurnLoop(
 	}
 	if !pinFound {
 		clearPinEvidence(&res)
+	}
+
+	// A router slash command is synthetic and intentionally skips upstream
+	// dispatch. Its next normal turn must keep the current automatic model once
+	// instead of treating the command boundary as a fresh HMM decision.
+	if commandContinuationFound && pinEligible(commandContinuation, req) {
+		decision := pinDecision(commandContinuation)
+		res.Decision = decision
+		res.StickyHit = true
+		res.PinTier = "post_command_continuation"
+		res.PinModel = commandContinuation.Model
+		res.PinAgeSec = pinAge(commandContinuation)
+		res.PriorServedModel, res.SessionEverSwitched = switchHistoryFromPins(commandContinuation, hmmHistory)
+		res.EscalateEffort = !commandContinuation.LastTurnEndedAt.IsZero() &&
+			(commandContinuation.LastOutputTokens == 0 || commandContinuation.ConsecutiveUpstreamErrors > 0)
+		log.Info("turnloop used one-shot post-command continuation",
+			"pin_model", commandContinuation.Model,
+			"pin_provider", commandContinuation.Provider,
+		)
+		s.refreshPin(ctx, installationID, res.SessionKey, commandContinuation, res.PinRole, decision)
+		return res, nil
 	}
 
 	// Positioned after hard-pin/forced-pin (higher precedence) and after all

--- a/internal/proxy/turnloop.go
+++ b/internal/proxy/turnloop.go
@@ -587,6 +587,14 @@ func (s *Service) runTurnLoop(
 	res.SessionKey = sessionKey
 
 	pin, pinFound := s.loadPin(ctx, res.SessionKey, res.PinRole)
+	// A deliberate clear is stored as an expired, blank pin with a reason.
+	// Natural expiry retains the model/provider and may still use a renewed
+	// one-shot command continuation, but an explicit clear must never be
+	// undone by a stale continuation row.
+	clearedPinReason := ""
+	if !pinFound && pin.Model == "" && pin.Provider == "" && pin.Reason != "" {
+		clearedPinReason = pin.Reason
+	}
 	hmmHistory := s.loadHMMHistory(ctx, res.SessionKey, res.PinRole)
 	commandContinuation := sessionpin.Pin{}
 	commandContinuationFound := false
@@ -854,6 +862,14 @@ func (s *Service) runTurnLoop(
 	// A router slash command is synthetic and intentionally skips upstream
 	// dispatch. Its next normal turn must keep the current automatic model once
 	// instead of treating the command boundary as a fresh HMM decision.
+	if commandContinuationFound && clearedPinReason != "" {
+		log.Info("discarding post-command continuation after source pin clear",
+			"clear_reason", clearedPinReason,
+			"pin_model", commandContinuation.Model,
+			"pin_provider", commandContinuation.Provider,
+		)
+		commandContinuationFound = false
+	}
 	if commandContinuationFound && pinEligible(commandContinuation, req) {
 		decision := pinDecision(commandContinuation)
 		res.Decision = decision

--- a/internal/proxy/turnloop_internal_test.go
+++ b/internal/proxy/turnloop_internal_test.go
@@ -79,6 +79,10 @@ func (s *stubPinStore) DisableProvider(context.Context, [sessionpin.SessionKeyLe
 	return nil
 }
 
+func (s *stubPinStore) Consume(context.Context, [sessionpin.SessionKeyLen]byte, string) (sessionpin.Pin, bool, error) {
+	return sessionpin.Pin{}, false, nil
+}
+
 func (s *stubPinStore) SweepExpired(context.Context) error { return nil }
 
 func TestPinCacheCold_OrdinaryAndHMMShareTheSameRule(t *testing.T) {

--- a/internal/router/sessionpin/store.go
+++ b/internal/router/sessionpin/store.go
@@ -108,6 +108,10 @@ type Usage struct {
 // read-modify-write race; it returns (0, nil) for a missing pin.
 type Store interface {
 	Get(ctx context.Context, sessionKey [SessionKeyLen]byte, role string) (Pin, bool, error)
+	// Consume atomically removes and returns one unexpired pin. It is used for
+	// one-shot continuations, where a Get followed by an expiry write could let
+	// two concurrent requests reuse the same pin.
+	Consume(ctx context.Context, sessionKey [SessionKeyLen]byte, role string) (Pin, bool, error)
 	Upsert(ctx context.Context, p Pin) error
 	UpdateUsage(ctx context.Context, sessionKey [SessionKeyLen]byte, role string, usage Usage) error
 	IncrementUpstreamErrors(ctx context.Context, sessionKey [SessionKeyLen]byte, role string) (int, error)

--- a/internal/sqlc/session_pins.sql.go
+++ b/internal/sqlc/session_pins.sql.go
@@ -12,6 +12,58 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 )
 
+const deleteSessionPin = `-- name: DeleteSessionPin :one
+DELETE FROM router.session_pins
+WHERE session_key = $1::bytea
+  AND role        = $2::varchar
+  AND pinned_until > CURRENT_TIMESTAMP
+RETURNING session_key, role, installation_id, pinned_provider, pinned_model, decision_reason, turn_count, pinned_until, first_pinned_at, last_seen_at, last_input_tokens, last_cached_read_tokens, last_cached_write_tokens, last_output_tokens, last_turn_ended_at, consecutive_upstream_errors, last_served_model, has_ever_switched, paired_provider, paired_model, consecutive_overload_errors, disabled_providers, policy_group
+`
+
+type DeleteSessionPinParams struct {
+	SessionKey []byte
+	Role       string
+}
+
+// Atomically consumes one active pin so a one-shot continuation cannot be
+// reused by concurrent requests. Expired rows remain for the normal sweep.
+//
+//	DELETE FROM router.session_pins
+//	WHERE session_key = $1::bytea
+//	  AND role        = $2::varchar
+//	  AND pinned_until > CURRENT_TIMESTAMP
+//	RETURNING session_key, role, installation_id, pinned_provider, pinned_model, decision_reason, turn_count, pinned_until, first_pinned_at, last_seen_at, last_input_tokens, last_cached_read_tokens, last_cached_write_tokens, last_output_tokens, last_turn_ended_at, consecutive_upstream_errors, last_served_model, has_ever_switched, paired_provider, paired_model, consecutive_overload_errors, disabled_providers, policy_group
+func (q *Queries) DeleteSessionPin(ctx context.Context, arg DeleteSessionPinParams) (RouterSessionPin, error) {
+	row := q.db.QueryRow(ctx, deleteSessionPin, arg.SessionKey, arg.Role)
+	var i RouterSessionPin
+	err := row.Scan(
+		&i.SessionKey,
+		&i.Role,
+		&i.InstallationID,
+		&i.PinnedProvider,
+		&i.PinnedModel,
+		&i.DecisionReason,
+		&i.TurnCount,
+		&i.PinnedUntil,
+		&i.FirstPinnedAt,
+		&i.LastSeenAt,
+		&i.LastInputTokens,
+		&i.LastCachedReadTokens,
+		&i.LastCachedWriteTokens,
+		&i.LastOutputTokens,
+		&i.LastTurnEndedAt,
+		&i.ConsecutiveUpstreamErrors,
+		&i.LastServedModel,
+		&i.HasEverSwitched,
+		&i.PairedProvider,
+		&i.PairedModel,
+		&i.ConsecutiveOverloadErrors,
+		&i.DisabledProviders,
+		&i.PolicyGroup,
+	)
+	return i, err
+}
+
 const disableSessionPinProvider = `-- name: DisableSessionPinProvider :exec
 UPDATE router.session_pins
 SET disabled_providers = CASE


### PR DESCRIPTION
Preserves the active automatic route for exactly one MainLoop request after a router slash command. Adds atomic continuation consumption and regression coverage.