### PR TITLE
feat(install): add /models slash command for router model selection

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -119,6 +119,19 @@ jobs:
       - name: Run statusline tests
         run: make test-statusline
 
+  # Same rationale as the statusline: install.sh is shipped standalone, so its
+  # config patching, key reuse, and the `models` API client are only ever
+  # covered here. Fully offline — fake curl, isolated $HOME.
+  test-install:
+    name: Test installer
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Run installer tests
+        run: make test-install
+
   test-hmm-sidecar:
     name: Test frozen HMM sidecar
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,7 @@ test-statusline: ## Run the cc-statusline.sh regression tests (offline)
 test-install: ## Run offline installer regression tests
 	@bash install/tests/codex_install_test.sh
 	@bash install/tests/key_reuse_test.sh
+	@bash install/tests/models_test.sh
 
 smoke: ## Pre-merge smoke suite: real router stack + real Anthropic (needs ANTHROPIC_API_KEY)
 	./scripts/smoke/run.sh

--- a/README.md
+++ b/README.md
@@ -210,6 +210,15 @@ reports which way it's pointing. Claude Code also gets `/router-off`,
 `/router-on`, and `/router-status` slash commands. Cursor toggles via the same
 Settings → Models override above. See [install/README.md](install/README.md#switching-on-and-off).
 
+**Choosing which models the router may pick.** `npx @workweave/router models
+--claude` lists every deployed model with its on/off state, and `models enable`
+/ `models disable` change it — the same setting as the dashboard's settings
+page, edited from the terminal. Claude Code gets this as `/router-models`
+(alias `/models`). Requires a router that serves the model-selection API;
+against the Weave-hosted router the list still prints and points you at the
+dashboard, where selection is an organization-wide setting. See
+[install/README.md](install/README.md#choosing-which-models-the-router-may-pick).
+
 > Two keys, don't mix them up:
 > - `sk-or-...` / `sk-ant-...` / `sk-...` = your **upstream** provider key. Lives in `.env.local`.
 > - `rk_...` = your **router** key. Clients send this as a Bearer token.

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -265,6 +265,13 @@ Without either env var the lists come from the installation, editable in the
 dashboard or through `PUT /admin/v1/excluded-providers` and
 `PUT /admin/v1/excluded-models`.
 
+From a terminal, `npx @workweave/router models --claude` lists every deployed
+model with its on/off state and `models enable` / `models disable` edit it,
+reading the endpoint and key from the Claude Code install already on disk.
+Claude Code gets the same thing as `/router-models` (alias `/models`). While
+either env var is set the CLI surfaces the 403 verbatim rather than pretending
+the edit landed. See [install/README.md](../install/README.md#choosing-which-models-the-router-may-pick).
+
 Exclusions are authoritative, not a preference. An excluded provider is
 subtracted from the request's eligible set before anything routes, so the
 scorer, the turn-type hard pins, session pins, and cross-binding failover all

--- a/install/README.md
+++ b/install/README.md
@@ -285,8 +285,8 @@ npx @workweave/router off --opencode --scope project   # project-scoped opencode
 Inside Claude Code you can also run the slash commands `/router-off`,
 `/router-on`, `/router-status`, and `/router-session` (which prints the
 session id used for telemetry correlation and transcript lookup) — installed
-alongside `/force-model` (alias `/fm`), `/unforce-model` (alias `/ufm`), and
-`/router-feedback` (alias `/rf`).
+alongside `/force-model` (alias `/fm`), `/unforce-model` (alias `/ufm`),
+`/router-feedback` (alias `/rf`), and `/router-models` (alias `/models`).
 
 What each `off` does (and `on` reverses byte-for-byte):
 
@@ -303,6 +303,55 @@ What each `off` does (and `on` reverses byte-for-byte):
 **Cursor** has no config file we own — its base URL lives in Cursor's own
 settings UI. To toggle it, open **Settings → Models → Override OpenAI Base
 URL** and turn the override (`<base-url>/v1`) on or off there.
+
+## Choosing which models the router may pick
+
+`models` reads and edits the model selection for the installation whose key is
+on disk — the same list, and the same stored setting, as the checkboxes on the
+router dashboard's settings page. It writes nothing locally: the endpoint and
+router key both come from the install already configured, so a self-hosted
+install talks to its own router with its own key, and the key is never passed
+as a command-line argument.
+
+```bash
+npx @workweave/router models --claude                          # every model, with its on/off state
+npx @workweave/router models disable gpt-5.6 --claude          # take a model out of rotation
+npx @workweave/router models enable gpt-5.6 --claude           # put it back
+npx @workweave/router models providers --claude                # same, one row per provider
+npx @workweave/router models providers disable openai --claude # drop a whole provider
+npx @workweave/router models prefer claude-opus-5 --claude     # priority ranking ('clear' to drop it)
+npx @workweave/router models list --json --claude              # machine-readable, for scripts
+```
+
+The list groups by provider and marks each model `[x]` (the router may pick it)
+or `[ ]` (it may not):
+
+```
+Weave Router models · http://localhost:8080
+2 of 3 enabled
+
+anthropic
+  [x] claude-opus-5
+  [ ] claude-haiku-4-5
+openai
+  [x] gpt-5.6
+```
+
+Inside Claude Code, `/router-models` (alias `/models`) runs the same thing and
+turns the result into a checklist you can edit conversationally — `/models
+disable haiku` disables it and re-lists.
+
+Changes take effect on the router's next routing decision; nothing restarts.
+A model excluded here is never selected, so excluding everything in a cluster
+leaves the router nothing to pick — re-enable rather than empty it out.
+
+Editing requires a router that serves the model-selection API (self-hosted and
+local routers do). The Weave-hosted router keeps model selection with the
+organization instead, so there `models` lists what the router can pick from and
+points you at <https://router.workweave.ai/dashboard/settings>. If your
+deployment pins the lists via `ROUTER_EXCLUDED_MODELS` /
+`ROUTER_EXCLUDED_PROVIDERS`, the router refuses the edit and says so — clear the
+env var to make the setting editable.
 
 ## Verifying
 

--- a/install/cc-statusline.sh
+++ b/install/cc-statusline.sh
@@ -229,7 +229,8 @@ weave_sync_commands() {
     # everything so no output leaks into the statusline.
     exec </dev/null
     for name in force-model unforce-model router-feedback fm ufm rf \
-                router-off router-on router-status router-session; do
+                router-off router-on router-status router-session \
+                router-models models; do
       installed="$cmd_dir/$name.md"
       # Only ever refresh a wrapper that is already installed: a missing one
       # was uninstalled or deliberately deleted, and resurrecting it would be

--- a/install/commands/models.md
+++ b/install/commands/models.md
@@ -1,0 +1,46 @@
+---
+description: Alias for /router-models — list the models the Weave Router may route to, and turn them on or off.
+argument-hint: [model or provider to enable/disable]
+allowed-tools: Bash(npx:*)
+---
+
+Show me which models this installation lets the Weave Router pick from, and
+change that selection when I ask. This is the same list — and the same stored
+setting — as the checkboxes on the router dashboard's settings page.
+
+Start by running:
+
+`npx @workweave/router models --claude{{SCOPE}}`
+
+That prints every deployed model grouped by provider, with `[x]` for models the
+router may pick and `[ ]` for models it may not. Present it back to me as a
+compact checklist in that same `[x]` / `[ ]` form, keeping the provider
+grouping and the exact model ids — I select models by id.
+
+Then:
+
+- If I named models or providers in `$ARGUMENTS`, work out whether I want them
+  on or off from how I phrased it, and apply it with
+  `npx @workweave/router models enable <id>... --claude{{SCOPE}}` or
+  `npx @workweave/router models disable <id>... --claude{{SCOPE}}` (add
+  `providers` before `enable`/`disable` to switch a whole provider). Several
+  ids can go in one call. Then re-run the list and show me the result.
+- If I named nothing, stop after the list and ask which ones I want to change.
+  Don't change anything I didn't ask for.
+
+Other things I might ask for:
+
+- Rank models by preference:
+  `npx @workweave/router models prefer <id> <id>... --claude{{SCOPE}}` (order
+  matters), or `npx @workweave/router models prefer clear --claude{{SCOPE}}` to
+  drop the ranking.
+- Providers only: `npx @workweave/router models providers --claude{{SCOPE}}`.
+
+If the command reports that this router doesn't expose model selection, that's
+a Weave-hosted router: model selection belongs to the whole organization there,
+so tell me to change it at https://router.workweave.ai/dashboard/settings —
+don't try to work around it. Its listing carries no on/off state, so present it
+as a plain list; don't infer which models are enabled.
+
+Disabling a model takes effect on the router's next routing decision; no
+restart is needed.

--- a/install/commands/router-models.md
+++ b/install/commands/router-models.md
@@ -1,0 +1,46 @@
+---
+description: List the models the Weave Router may route to, and turn them on or off.
+argument-hint: [model or provider to enable/disable]
+allowed-tools: Bash(npx:*)
+---
+
+Show me which models this installation lets the Weave Router pick from, and
+change that selection when I ask. This is the same list — and the same stored
+setting — as the checkboxes on the router dashboard's settings page.
+
+Start by running:
+
+`npx @workweave/router models --claude{{SCOPE}}`
+
+That prints every deployed model grouped by provider, with `[x]` for models the
+router may pick and `[ ]` for models it may not. Present it back to me as a
+compact checklist in that same `[x]` / `[ ]` form, keeping the provider
+grouping and the exact model ids — I select models by id.
+
+Then:
+
+- If I named models or providers in `$ARGUMENTS`, work out whether I want them
+  on or off from how I phrased it, and apply it with
+  `npx @workweave/router models enable <id>... --claude{{SCOPE}}` or
+  `npx @workweave/router models disable <id>... --claude{{SCOPE}}` (add
+  `providers` before `enable`/`disable` to switch a whole provider). Several
+  ids can go in one call. Then re-run the list and show me the result.
+- If I named nothing, stop after the list and ask which ones I want to change.
+  Don't change anything I didn't ask for.
+
+Other things I might ask for:
+
+- Rank models by preference:
+  `npx @workweave/router models prefer <id> <id>... --claude{{SCOPE}}` (order
+  matters), or `npx @workweave/router models prefer clear --claude{{SCOPE}}` to
+  drop the ranking.
+- Providers only: `npx @workweave/router models providers --claude{{SCOPE}}`.
+
+If the command reports that this router doesn't expose model selection, that's
+a Weave-hosted router: model selection belongs to the whole organization there,
+so tell me to change it at https://router.workweave.ai/dashboard/settings —
+don't try to work around it. Its listing carries no on/off state, so present it
+as a plain list; don't infer which models are enabled.
+
+Disabling a model takes effect on the router's next routing decision; no
+restart is needed.

--- a/install/install.sh
+++ b/install/install.sh
@@ -1020,16 +1020,11 @@ while [ $# -gt 0 ]; do
       mode="off"; disable_routing_alias="true"; shift
       ;;
     models|--models)
-      # Model selection. Everything up to the next flag is the sub-verb and its
-      # operands, so `models disable a b --claude` reads naturally; the flags
-      # after them fall back through to this same parser.
+      # Model selection. Sub-verb and operand collection happens in the
+      # catch-all arm below (guarded on mode="models"), not here — that lets
+      # `--claude`/`--json`/etc. appear before, after, or between operands
+      # instead of only after every operand has been consumed.
       mode="models"; shift
-      while [ $# -gt 0 ]; do
-        case "$1" in
-          -*) break ;;
-          *)  models_args="${models_args}${models_args:+$'\n'}$1"; shift ;;
-        esac
-      done
       ;;
     --json)
       models_json="true"; shift
@@ -1038,7 +1033,16 @@ while [ $# -gt 0 ]; do
       usage 0
       ;;
     *)
-      err "Unknown flag: $1."; usage 2
+      # In `models` mode, a bare (non-dashed) word is a sub-verb or operand —
+      # collect it and keep parsing, so a flag can appear before, after, or
+      # between them (`models --claude enable x` and `models enable x --claude`
+      # both work). A dashed token nothing above matched is still an error,
+      # models mode or not.
+      if [ "$mode" = "models" ] && [ "${1#-}" = "$1" ]; then
+        models_args="${models_args}${models_args:+$'\n'}$1"; shift
+      else
+        err "Unknown flag: $1."; usage 2
+      fi
       ;;
   esac
 done
@@ -1953,19 +1957,33 @@ models_print_preferred() {
 # Deliberately not rendered as a checklist — this endpoint reports the deployed
 # catalog, not the installation's selection, so marking every row [x] would
 # claim models are enabled that the dashboard may well have excluded.
+#
+# $1 selects what to print from the same catalog payload: "models" (the
+# default) or "providers" — `models providers` hits this same 404 and must
+# degrade the same way `models list` does rather than hard-failing, since both
+# are read-only listing commands.
 models_list_catalog() {
-  models_api GET "$MODELS_CATALOG_PATH" || models_fail "listing models"
+  local what="${1:-models}"
+  models_api GET "$MODELS_CATALOG_PATH" || models_fail "listing $what"
   if [ "$models_json" = "true" ]; then
-    printf '%s\n' "$models_http_body"
+    if [ "$what" = "providers" ]; then
+      printf '%s' "$models_http_body" | jq -c '[.models[].provider] | unique'
+    else
+      printf '%s\n' "$models_http_body"
+    fi
     return 0
   fi
-  printf "%s%sWeave Router models%s %s· %s%s\n" "$C_BOLD" "$C_BRAND" "$C_RESET" "$C_DIM" "$base_url" "$C_RESET"
+  printf "%s%sWeave Router %s%s %s· %s%s\n" "$C_BOLD" "$C_BRAND" "$what" "$C_RESET" "$C_DIM" "$base_url" "$C_RESET"
   printf "%severything this router can route to%s\n\n" "$C_DIM" "$C_RESET"
-  printf '%s' "$models_http_body" | jq -r --arg reset "$C_RESET" --arg bold "$C_BOLD" '
-    .models | group_by(.provider)[]
-    | ($bold + .[0].provider + $reset),
-      (.[] | "  " + .model)
-  '
+  if [ "$what" = "providers" ]; then
+    printf '%s' "$models_http_body" | jq -r '[.models[].provider] | unique[] | "  " + .'
+  else
+    printf '%s' "$models_http_body" | jq -r --arg reset "$C_RESET" --arg bold "$C_BOLD" '
+      .models | group_by(.provider)[]
+      | ($bold + .[0].provider + $reset),
+        (.[] | "  " + .model)
+    '
+  fi
   printf "\n%sThis router does not report which of them your installation has enabled:%s\n" "$C_DIM" "$C_RESET"
   printf "%sselection is an organization-wide setting here. See it, and change it, at%s\n" "$C_DIM" "$C_RESET"
   printf "%s%s%s\n" "$C_DIM" "$MODELS_DASHBOARD_URL" "$C_RESET"
@@ -1975,7 +1993,7 @@ models_list() {
   if ! models_api GET "/admin/v1/models"; then
     # Only a missing API is worth degrading for; anything else is a real error.
     [ "$models_http_status" = "404" ] || models_fail "listing models"
-    models_list_catalog
+    models_list_catalog models
     return 0
   fi
   if [ "$models_json" = "true" ]; then
@@ -1989,7 +2007,15 @@ models_list() {
 }
 
 models_providers_list() {
-  models_api GET "/admin/v1/providers" || models_fail "listing providers"
+  if ! models_api GET "/admin/v1/providers"; then
+    # Same 404 degrade as models_list: a router with no model-selection API
+    # still answers the unauthed catalog, and this is a read-only listing
+    # command same as `models list` — no reason to hard-fail one and not
+    # the other.
+    [ "$models_http_status" = "404" ] || models_fail "listing providers"
+    models_list_catalog providers
+    return 0
+  fi
   if [ "$models_json" = "true" ]; then
     printf '%s\n' "$models_http_body"
     return 0

--- a/install/install.sh
+++ b/install/install.sh
@@ -1476,25 +1476,34 @@ claude_key_present() {
 # nothing. Only Claude Code is supported today; the other targets still prompt.
 # Defined up here rather than with the rest of token handling because `models`
 # dispatches (and needs a key) before that section runs.
+#
+# models_key_file_order echoes the precedence this uses, so a caller that needs
+# to know *which* file the key came from can walk the same list (a command
+# substitution around this function would discard any global it set).
+models_key_file_order() {
+  if [ "$scope" = "project" ] && [ -z "$install_dir" ]; then
+    printf '%s\n%s\n%s\n' "$local_settings_file" "$settings_file" "$settings_dir/.weave-parked.json"
+  else
+    printf '%s\n%s\n%s\n' "$settings_file" "$local_settings_file" "$settings_dir/.weave-parked.json"
+  fi
+}
+
 read_installed_key() {
   [ "$target" = "claude" ] || return 0
-  local key=""
+  local key="" candidate
   # Mirror where the install path writes the key: project scope (no --dir) puts
   # it in the gitignored settings.local.json, everything else inlines it into
   # settings.json. Check the other file too — a scope was possibly changed, or a
   # project checkout may carry a committed header from an older install.
-  if [ "$scope" = "project" ] && [ -z "$install_dir" ]; then
-    key="$(read_claude_key "$local_settings_file")"
-    [ -n "$key" ] || key="$(read_claude_key "$settings_file")"
-  else
-    key="$(read_claude_key "$settings_file")"
-    [ -n "$key" ] || key="$(read_claude_key "$local_settings_file")"
-  fi
-  # Last resort: `off` moves the key header out of the settings files and into
-  # the parked sidecar, so an install/update run while toggled off finds nothing
-  # above even though the key is still on disk. Same {"env":{…}} shape, so
-  # read_claude_key reads it directly.
-  [ -n "$key" ] || key="$(read_claude_key "$settings_dir/.weave-parked.json")"
+  # The parked sidecar is last: `off` moves the key header out of the settings
+  # files and into it, so a run while toggled off finds nothing above even
+  # though the key is still on disk. Same {"env":{…}} shape, so read_claude_key
+  # reads it directly.
+  while IFS= read -r candidate; do
+    [ -n "$candidate" ] || continue
+    key="$(read_claude_key "$candidate")"
+    [ -n "$key" ] && break
+  done <<<"$(models_key_file_order)"
   printf '%s' "$key"
 }
 
@@ -1503,20 +1512,50 @@ read_installed_key() {
 # one. The parked sidecar comes first: `off` moves the router URL there and
 # leaves api.anthropic.com in the live file, so reading the live file while
 # toggled off would report Anthropic as the router.
+#
+# models_base_file_order echoes that same precedence for callers that need to
+# know which file supplied the endpoint (see models_key_file_order).
+models_base_file_order() {
+  printf '%s\n%s\n%s\n' "$settings_dir/.weave-parked.json" "$settings_file" "$local_settings_file"
+}
+
 resolve_installed_base_url() {
   local candidate found
-  for candidate in \
-    "$settings_dir/.weave-parked.json" \
-    "$settings_file" \
-    "$local_settings_file"
-  do
+  while IFS= read -r candidate; do
+    [ -n "$candidate" ] || continue
     found="$(json_get "$candidate" '.env.ANTHROPIC_BASE_URL')"
     if router_shaped_url "$found"; then
       printf '%s' "${found%/}"
       return 0
     fi
-  done
+  done <<<"$(models_base_file_order)"
   printf ''
+}
+
+# models_endpoint_is_trusted returns 0 when it is safe to send the router key
+# resolved from $2 to the endpoint resolved from $1.
+#
+# Project scope deliberately splits the two: the endpoint lives in the
+# committed settings.json (teammates share it) while each teammate's key lives
+# in the gitignored settings.local.json. That split is fine on its own, but it
+# means a *hostile* repo can commit a settings.json naming an endpoint it
+# controls and have this command mail the developer's key to it. Endpoint and
+# credential from the same file are self-consistent and always fine. When they
+# differ, the endpoint must be one the user vouched for out-of-band — the
+# hosted default, or an explicit --base-url — rather than whatever the checkout
+# happened to contain.
+models_endpoint_is_trusted() {
+  local url="$1" base_src="$2" key_src="$3"
+  [ "$base_url_explicit" = "true" ] && return 0
+  [ "$url" = "$HOSTED_BASE_URL" ] && return 0
+  [ -n "$base_src" ] && [ "$base_src" = "$key_src" ] && return 0
+  # A repo can only pre-plant a file git tracks; an untracked local file is the
+  # user's own. If the endpoint's file isn't tracked, it wasn't planted. Checked
+  # inline rather than via weave_command_tracked_by_git, which is defined further
+  # down (inside the statusline heredoc's neighborhood) and isn't in scope here.
+  command -v git >/dev/null 2>&1 || return 1
+  git -C "$(dirname "$base_src")" ls-files --error-unmatch -- "$base_src" >/dev/null 2>&1 || return 0
+  return 1
 }
 
 # gitignore_add appends an entry to the repo .gitignore in project scope so a
@@ -2050,7 +2089,12 @@ models_toggle() {
     if ! models_api POST "$path" "$body"; then
       models_fail "$doing $label '$id'"
     fi
-    if [ "$action" = "enable" ]; then
+    # Under --json the router's own response body is the output: a scripted
+    # caller parses stdout, and printing prose there makes it report a parse
+    # failure for a mutation that already succeeded.
+    if [ "$models_json" = "true" ]; then
+      printf '%s\n' "$models_http_body"
+    elif [ "$action" = "enable" ]; then
       printf "%s✓%s %s %s%s%s is enabled\n" "$C_GREEN" "$C_RESET" "$label" "$C_BOLD" "$id" "$C_RESET"
     else
       printf "%s✓%s %s %s%s%s is disabled — the router will not pick it\n" "$C_GREEN" "$C_RESET" "$label" "$C_BOLD" "$id" "$C_RESET"
@@ -2069,6 +2113,10 @@ models_prefer() {
     body="$(printf '%s' "$ids" | jq -c -R -s '{preferred: (split("\n") | map(select(length > 0)))}')"
   fi
   models_api PUT "/admin/v1/preferred-models" "$body" || models_fail "setting the preferred-model ranking"
+  if [ "$models_json" = "true" ]; then
+    printf '%s\n' "$models_http_body"
+    return 0
+  fi
   stored="$(printf '%s' "$models_http_body" | jq -r '(.preferred // []) | join(" > ")')"
   if [ -n "$stored" ]; then
     printf "%s✓%s Preferred order: %s\n" "$C_GREEN" "$C_RESET" "$stored"
@@ -2132,6 +2180,11 @@ run_models() {
 }
 
 if [ "$mode" = "models" ]; then
+  # Which file supplied the endpoint / the key. Empty means "not from a settings
+  # file" — an explicit --base-url, or WEAVE_ROUTER_KEY. Initialized before the
+  # branches below so `set -u` holds on every path.
+  models_base_source=""
+  models_key_source=""
   # Editing model selection needs the endpoint and key of one specific install,
   # never the hosted defaults: a self-hosted user pointing at their own router
   # would otherwise silently edit the hosted one's installation.
@@ -2142,10 +2195,52 @@ if [ "$mode" = "models" ]; then
       exit 1
     fi
     base_url="$models_base"
+    # resolve_installed_base_url ran in a command substitution, so any global it
+    # set died with that subshell. Recover the source by walking the same
+    # precedence to find which file holds the endpoint we just adopted.
+    while IFS= read -r models_src_candidate; do
+      [ -n "$models_src_candidate" ] || continue
+      models_src_url="$(json_get "$models_src_candidate" '.env.ANTHROPIC_BASE_URL')"
+      if [ "${models_src_url%/}" = "$models_base" ]; then
+        models_base_source="$models_src_candidate"
+        break
+      fi
+    done <<<"$(models_base_file_order)"
   fi
-  api_key="${WEAVE_ROUTER_KEY:-$(read_installed_key)}"
+  # WEAVE_ROUTER_KEY is the user's own choice, so it pairs with any endpoint.
+  if [ -n "${WEAVE_ROUTER_KEY:-}" ]; then
+    api_key="$WEAVE_ROUTER_KEY"
+    models_key_source="env:WEAVE_ROUTER_KEY"
+  else
+    api_key="$(read_installed_key)"
+    # Same subshell caveat as the endpoint above: recover which file the key
+    # came from by re-reading them in read_installed_key's own precedence.
+    models_key_source=""
+    while IFS= read -r models_src_candidate; do
+      [ -n "$models_src_candidate" ] || continue
+      if [ -n "$(read_claude_key "$models_src_candidate")" ]; then
+        models_key_source="$models_src_candidate"
+        break
+      fi
+    done <<<"$(models_key_file_order)"
+  fi
   if [ -z "$api_key" ]; then
     err "No router key found for Claude Code in this scope. Re-run 'npx @workweave/router --claude', or export WEAVE_ROUTER_KEY."
+    exit 1
+  fi
+  # Never send a key to an endpoint the checkout supplied. See
+  # models_endpoint_is_trusted: a hostile repo can commit a settings.json naming
+  # its own router, and pairing that with the teammate key from the gitignored
+  # settings.local.json would hand the key to whoever wrote the repo.
+  if [ "$models_key_source" != "env:WEAVE_ROUTER_KEY" ] \
+     && ! models_endpoint_is_trusted "$base_url" "$models_base_source" "$models_key_source"; then
+    err "Refusing to send this installation's router key to $base_url."
+    printf "  %sThat endpoint comes from %s, which git tracks — a checked-out repo can set it —%s\n" \
+      "$C_DIM" "${models_base_source##*/}" "$C_RESET" >&2
+    printf "  %swhile the key comes from %s. Pass --base-url <url> to confirm the endpoint,%s\n" \
+      "$C_DIM" "${models_key_source##*/}" "$C_RESET" >&2
+    printf "  %sor re-run 'npx @workweave/router --claude' to install against the one you want.%s\n" \
+      "$C_DIM" "$C_RESET" >&2
     exit 1
   fi
   run_models

--- a/install/install.sh
+++ b/install/install.sh
@@ -1549,6 +1549,19 @@ models_endpoint_is_trusted() {
   [ "$base_url_explicit" = "true" ] && return 0
   [ "$url" = "$HOSTED_BASE_URL" ] && return 0
   [ -n "$base_src" ] && [ "$base_src" = "$key_src" ] && return 0
+  # Project-scoped self-hosted installs intentionally split the endpoint and
+  # key. The installer writes a gitignored marker beside the key; require that
+  # marker to match before trusting the split. A tracked/symlinked local file is
+  # not a teammate's private configuration and cannot vouch for an endpoint.
+  if [ "$key_src" = "$local_settings_file" ] && [ ! -L "$key_src" ]; then
+    local marked_url
+    marked_url="$(json_get "$key_src" '.env.WEAVE_ROUTER_BASE_URL')"
+    if [ "${marked_url%/}" = "${url%/}" ]; then
+      command -v git >/dev/null 2>&1 || return 1
+      git -C "$(dirname "$key_src")" ls-files --error-unmatch -- "$key_src" >/dev/null 2>&1 && return 1
+      return 0
+    fi
+  fi
   # A repo can only pre-plant a file git tracks; an untracked local file is the
   # user's own. If the endpoint's file isn't tracked, it wasn't planted. Checked
   # inline rather than via weave_command_tracked_by_git, which is defined further
@@ -3558,8 +3571,8 @@ write_claude_settings() {
   ok "Settings written to $settings_file"
 
   if [ "$scope" = "project" ] && [ -z "$install_dir" ]; then
-    jq -n --arg header "$custom_headers" '{
-      env: { ANTHROPIC_CUSTOM_HEADERS: $header }
+    jq -n --arg header "$custom_headers" --arg router_url "$base_url" '{
+      env: { ANTHROPIC_CUSTOM_HEADERS: $header, WEAVE_ROUTER_BASE_URL: $router_url }
     }' >"$tmp_patch"
     if [ -f "$local_settings_file" ]; then
       # Also strip ANTHROPIC_BASE_URL: `off` in project scope points this file

--- a/install/install.sh
+++ b/install/install.sh
@@ -64,6 +64,22 @@
 # `claude` start; Codex and opencode re-read config every invocation.
 # Cursor's base URL lives in its own settings UI (no file we own), so there's
 # nothing to toggle here — flip "Override OpenAI Base URL" in Cursor settings.
+#
+# Inspect and edit which models this installation lets the router pick from —
+# the same lists the router dashboard's settings page renders. The endpoint and
+# router key both come from the install already on disk, so nothing is prompted
+# and no key is ever passed on the command line:
+#   npx @workweave/router models --claude                            # every model, with its on/off state
+#   npx @workweave/router models disable gpt-5.6 --claude            # take a model out of rotation
+#   npx @workweave/router models enable gpt-5.6 --claude             # put it back
+#   npx @workweave/router models providers --claude                  # same, one row per provider
+#   npx @workweave/router models providers disable openai --claude   # drop a whole provider
+#   npx @workweave/router models prefer claude-opus-5 --claude       # set the preferred-model ranking
+#   npx @workweave/router models list --json --claude                # machine-readable, for scripts
+# Editing needs a router that mounts the model-selection API (self-hosted and
+# local routers do). The Weave-hosted router keeps model selection with the
+# organization, in the Weave dashboard — there `models` lists and points you at
+# it rather than editing.
 
 set -euo pipefail
 
@@ -98,8 +114,17 @@ target_explicit="false"
 # never-prompting install that reuses the key already on disk. "off"/"on"/
 # "status" toggle or report an existing install without touching the router
 # key/identity — see the toggle_* helpers and the dispatch block below.
+# "models" reads and edits the installation's model selection over the router's
+# admin API; it touches no local config at all.
 mode="install"
 disable_routing_alias="false"
+
+# `models` sub-verb plus its operands (model / provider ids), newline-delimited
+# in argument order. Catalog ids and provider names never contain whitespace,
+# so a newline-delimited string stays readable where a bash 3.2 array under
+# `set -u` would not. --json switches the output to the raw API payload.
+models_args=""
+models_json="false"
 
 # --rotate-key forces the interactive key prompt even when a usable key is
 # already installed, so a rotated key can replace it.
@@ -994,6 +1019,21 @@ while [ $# -gt 0 ]; do
       # so `disable-routing --claude` cannot silently change Claude settings.
       mode="off"; disable_routing_alias="true"; shift
       ;;
+    models|--models)
+      # Model selection. Everything up to the next flag is the sub-verb and its
+      # operands, so `models disable a b --claude` reads naturally; the flags
+      # after them fall back through to this same parser.
+      mode="models"; shift
+      while [ $# -gt 0 ]; do
+        case "$1" in
+          -*) break ;;
+          *)  models_args="${models_args}${models_args:+$'\n'}$1"; shift ;;
+        esac
+      done
+      ;;
+    --json)
+      models_json="true"; shift
+      ;;
     -h|--help)
       usage 0
       ;;
@@ -1014,13 +1054,37 @@ fi
 
 # Toggle verbs only flip config install.sh already wrote: no key, no identity,
 # no prompts. Require an explicit client so we never guess which config to
-# touch, and suppress every interactive prompt downstream.
+# touch, and suppress every interactive prompt downstream. `models` edits no
+# local config, but it still reads the endpoint and key out of one install, so
+# it needs the same explicit choice.
 if [ "$mode" != "install" ] && [ "$mode" != "update" ]; then
   non_interactive="true"
   if [ "$target_explicit" != "true" ]; then
-    err "'$mode' requires an explicit client: --claude, --codex, or --opencode."
+    if [ "$mode" = "models" ]; then
+      err "'models' requires an explicit client: --claude."
+    else
+      err "'$mode' requires an explicit client: --claude, --codex, or --opencode."
+    fi
     exit 2
   fi
+fi
+
+# Only Claude Code's settings are read back for a key today (read_installed_key),
+# so `models` can't authenticate as any other client. Fail fast here rather than
+# falling through to the toggle dispatch, which would flip config nobody asked
+# to change.
+if [ "$mode" = "models" ] && [ "$target" != "claude" ]; then
+  err "'models' currently supports --claude only (it reads the router key from Claude Code's settings)."
+  exit 2
+fi
+
+# --json prints the API payload verbatim, so nothing else may reach stdout.
+if [ "$models_json" = "true" ]; then
+  if [ "$mode" != "models" ]; then
+    err "--json only applies to 'models'."
+    exit 2
+  fi
+  quiet="true"
 fi
 
 # `update` is an install that never prompts: it refreshes the managed config
@@ -1156,7 +1220,9 @@ fi
 
 # ---------- pre-flight ----------
 
-if [ "$mode" != "install" ] && [ "$mode" != "update" ]; then
+# `models` skips this line: it prints its own header carrying the endpoint it
+# resolved, which is the part a reader actually needs.
+if [ "$mode" != "install" ] && [ "$mode" != "update" ] && [ "$mode" != "models" ]; then
   [ "$quiet" = "true" ] || info "mode=${C_BOLD}${mode}${C_RESET}  scope=${C_BOLD}${scope}${C_RESET}  target=${C_BOLD}${target}${C_RESET}"
 fi
 
@@ -1167,12 +1233,17 @@ fi
 if [ "$target" = "claude" ] || [ "$target" = "opencode" ] || [ "$target" = "pi" ]; then
   require_cmd jq    "macOS: 'brew install jq' · Debian/Ubuntu: 'sudo apt install jq'"
 fi
-# curl is only used by the install/update paths' health/validate probes;
-# toggles never hit the network.
-if [ "$mode" = "install" ] || [ "$mode" = "update" ]; then
+# curl is used by the install/update paths' health/validate probes and by every
+# `models` call; the on/off/status toggles never hit the network.
+if [ "$mode" = "install" ] || [ "$mode" = "update" ] || [ "$mode" = "models" ]; then
   require_cmd curl  "macOS/Linux: usually preinstalled — check your package manager"
 fi
 
+# Every warning below says the client's config will be written anyway, which is
+# true for install/update/toggles and false for `models` — it only reads that
+# config to find the router. Whether the client itself is installed has no
+# bearing on a model-selection call, so skip the check there entirely.
+if [ "$mode" != "models" ]; then
 case "$target" in
   claude)
     if ! command -v claude >/dev/null 2>&1; then
@@ -1199,6 +1270,7 @@ case "$target" in
     fi
     ;;
 esac
+fi
 
 script_dir="$(cd "$(dirname "$0")" 2>/dev/null && pwd || true)"
 
@@ -1394,6 +1466,53 @@ read_claude_key() {
 # authenticate.
 claude_key_present() {
   [ -n "$(read_claude_key "$1")" ]
+}
+
+# read_installed_key prints the router key this install already has on disk, or
+# nothing. Only Claude Code is supported today; the other targets still prompt.
+# Defined up here rather than with the rest of token handling because `models`
+# dispatches (and needs a key) before that section runs.
+read_installed_key() {
+  [ "$target" = "claude" ] || return 0
+  local key=""
+  # Mirror where the install path writes the key: project scope (no --dir) puts
+  # it in the gitignored settings.local.json, everything else inlines it into
+  # settings.json. Check the other file too — a scope was possibly changed, or a
+  # project checkout may carry a committed header from an older install.
+  if [ "$scope" = "project" ] && [ -z "$install_dir" ]; then
+    key="$(read_claude_key "$local_settings_file")"
+    [ -n "$key" ] || key="$(read_claude_key "$settings_file")"
+  else
+    key="$(read_claude_key "$settings_file")"
+    [ -n "$key" ] || key="$(read_claude_key "$local_settings_file")"
+  fi
+  # Last resort: `off` moves the key header out of the settings files and into
+  # the parked sidecar, so an install/update run while toggled off finds nothing
+  # above even though the key is still on disk. Same {"env":{…}} shape, so
+  # read_claude_key reads it directly.
+  [ -n "$key" ] || key="$(read_claude_key "$settings_dir/.weave-parked.json")"
+  printf '%s' "$key"
+}
+
+# resolve_installed_base_url prints the router endpoint this Claude Code install
+# already points at, or nothing when none of its files carry a router-shaped
+# one. The parked sidecar comes first: `off` moves the router URL there and
+# leaves api.anthropic.com in the live file, so reading the live file while
+# toggled off would report Anthropic as the router.
+resolve_installed_base_url() {
+  local candidate found
+  for candidate in \
+    "$settings_dir/.weave-parked.json" \
+    "$settings_file" \
+    "$local_settings_file"
+  do
+    found="$(json_get "$candidate" '.env.ANTHROPIC_BASE_URL')"
+    if router_shaped_url "$found"; then
+      printf '%s' "${found%/}"
+      return 0
+    fi
+  done
+  printf ''
 }
 
 # gitignore_add appends an entry to the repo .gitignore in project scope so a
@@ -1698,6 +1817,315 @@ toggle_opencode() {
   esac
 }
 
+# ---------- model selection ----------
+#
+# `models` reads and edits the installation's model/provider selection through
+# the router's /admin/v1 API — the same lists the router dashboard's settings
+# page renders, backed by the same columns. Nothing local is written: the
+# endpoint and router key are read out of the install already on disk so a
+# self-hosted install talks to its own router with its own key.
+#
+# The Weave-hosted router runs in `managed` mode and mounts no /admin/v1 at
+# all — there model selection belongs to the organization and is edited in the
+# Weave dashboard. That surfaces as a 404, which reads (for a list) as "fall
+# back to the public catalog and say where to edit" and (for an edit) as a
+# refusal naming the dashboard.
+
+# Public, unauthed catalog of everything the router can route to. Mounted in
+# both deployment modes, so it is the one listing that always works.
+MODELS_CATALOG_PATH="/v1/router/models"
+MODELS_DASHBOARD_URL="https://router.workweave.ai/dashboard/settings"
+
+# Set by models_api on every call.
+models_http_status=""
+models_http_body=""
+
+# models_api METHOD PATH [JSON_BODY] — call the router and capture status+body.
+# The key rides in on stdin (curl --header @-) rather than a -H argument so it
+# never appears in the process arg list, which any other local user can read.
+models_api() {
+  local method="$1" path="$2" body="${3:-}"
+  local out status=""
+  out="$(mktemp)" || { err "Could not create a temp file."; exit 1; }
+  if [ -n "$body" ]; then
+    status="$(printf '%s: %s\n' "$router_key_header" "$api_key" \
+      | curl -sS --max-time 20 -X "$method" \
+             -H 'Content-Type: application/json' --data-binary "$body" \
+             --header @- -o "$out" -w '%{http_code}' "$base_url$path" 2>/dev/null)" || status=""
+  else
+    status="$(printf '%s: %s\n' "$router_key_header" "$api_key" \
+      | curl -sS --max-time 20 -X "$method" \
+             --header @- -o "$out" -w '%{http_code}' "$base_url$path" 2>/dev/null)" || status=""
+  fi
+  models_http_status="$status"
+  models_http_body="$(cat "$out" 2>/dev/null || true)"
+  rm -f "$out"
+  case "$models_http_status" in
+    2*) return 0 ;;
+    *)  return 1 ;;
+  esac
+}
+
+# models_api_error prints the router's own `error` field, when it sent one.
+models_api_error() {
+  printf '%s' "$models_http_body" | jq -r '.error // empty' 2>/dev/null || true
+}
+
+# models_fail turns the status left by models_api into a message that says what
+# to do next, then exits. $1 names the attempted operation.
+models_fail() {
+  local what="$1" detail
+  detail="$(models_api_error)"
+  case "$models_http_status" in
+    ""|000)
+      err "Could not reach the router at $base_url. Is it running?"
+      ;;
+    401|403)
+      # 403 with a message is the ROUTER_EXCLUDED_MODELS/PROVIDERS env pin,
+      # which is actionable on its own; a bare 401/403 is a key problem.
+      if [ -n "$detail" ]; then
+        err "$detail"
+      else
+        err "The router rejected this installation's key. Re-run 'npx @workweave/router --claude --rotate-key' to install a current one."
+      fi
+      ;;
+    404)
+      err "This router does not expose the model-selection API, so $what is not available here."
+      printf "  %sWeave-hosted routers keep model selection with the organization — edit it at %s%s\n" \
+        "$C_DIM" "$MODELS_DASHBOARD_URL" "$C_RESET" >&2
+      printf "  %sSelf-hosted? Update the router to a build that serves /admin/v1/models.%s\n" \
+        "$C_DIM" "$C_RESET" >&2
+      ;;
+    *)
+      if [ -n "$detail" ]; then
+        err "$what failed (HTTP $models_http_status): $detail"
+      else
+        err "$what failed (HTTP $models_http_status)."
+      fi
+      ;;
+  esac
+  exit 1
+}
+
+# models_render_list prints the [{model,provider,enabled}] payload as a
+# provider-grouped checklist. The API sorts by provider then model, which is
+# what group_by needs, and what keeps two runs comparable.
+models_render_list() {
+  local payload="$1" total enabled
+  total="$(printf '%s' "$payload" | jq 'length')"
+  enabled="$(printf '%s' "$payload" | jq '[.[] | select(.enabled)] | length')"
+  printf "%s%sWeave Router models%s %s· %s%s\n" "$C_BOLD" "$C_BRAND" "$C_RESET" "$C_DIM" "$base_url" "$C_RESET"
+  printf "%s%s of %s enabled%s\n\n" "$C_DIM" "$enabled" "$total" "$C_RESET"
+  printf '%s' "$payload" | jq -r --arg on "$C_GREEN" --arg off "$C_DIM" --arg reset "$C_RESET" --arg bold "$C_BOLD" '
+    group_by(.provider)[]
+    | ($bold + .[0].provider + $reset),
+      (.[] | if .enabled
+             then "  " + $on + "[x]" + $reset + " " + .model
+             else "  " + $off + "[ ] " + .model + $reset
+             end)
+  '
+}
+
+# models_render_providers prints the [{provider,enabled}] payload.
+models_render_providers() {
+  local payload="$1"
+  printf "%s%sWeave Router providers%s %s· %s%s\n\n" "$C_BOLD" "$C_BRAND" "$C_RESET" "$C_DIM" "$base_url" "$C_RESET"
+  printf '%s' "$payload" | jq -r --arg on "$C_GREEN" --arg off "$C_DIM" --arg reset "$C_RESET" '
+    .[] | if .enabled
+          then "  " + $on + "[x]" + $reset + " " + .provider
+          else "  " + $off + "[ ] " + .provider + $reset
+          end
+  '
+}
+
+# models_print_preferred appends the priority ranking when one is set. Absent
+# is the norm (the router picks per turn), so silence is the right output.
+models_print_preferred() {
+  models_api GET "/admin/v1/preferred-models" || return 0
+  local list
+  list="$(printf '%s' "$models_http_body" | jq -r '(.preferred // []) | join(" > ")' 2>/dev/null || true)"
+  [ -n "$list" ] || return 0
+  printf "\n%sPreferred order:%s %s\n" "$C_DIM" "$C_RESET" "$list"
+}
+
+# models_list_catalog is the read-only fallback for a router with no
+# model-selection API: list what it can route to and say where to change it.
+# Deliberately not rendered as a checklist — this endpoint reports the deployed
+# catalog, not the installation's selection, so marking every row [x] would
+# claim models are enabled that the dashboard may well have excluded.
+models_list_catalog() {
+  models_api GET "$MODELS_CATALOG_PATH" || models_fail "listing models"
+  if [ "$models_json" = "true" ]; then
+    printf '%s\n' "$models_http_body"
+    return 0
+  fi
+  printf "%s%sWeave Router models%s %s· %s%s\n" "$C_BOLD" "$C_BRAND" "$C_RESET" "$C_DIM" "$base_url" "$C_RESET"
+  printf "%severything this router can route to%s\n\n" "$C_DIM" "$C_RESET"
+  printf '%s' "$models_http_body" | jq -r --arg reset "$C_RESET" --arg bold "$C_BOLD" '
+    .models | group_by(.provider)[]
+    | ($bold + .[0].provider + $reset),
+      (.[] | "  " + .model)
+  '
+  printf "\n%sThis router does not report which of them your installation has enabled:%s\n" "$C_DIM" "$C_RESET"
+  printf "%sselection is an organization-wide setting here. See it, and change it, at%s\n" "$C_DIM" "$C_RESET"
+  printf "%s%s%s\n" "$C_DIM" "$MODELS_DASHBOARD_URL" "$C_RESET"
+}
+
+models_list() {
+  if ! models_api GET "/admin/v1/models"; then
+    # Only a missing API is worth degrading for; anything else is a real error.
+    [ "$models_http_status" = "404" ] || models_fail "listing models"
+    models_list_catalog
+    return 0
+  fi
+  if [ "$models_json" = "true" ]; then
+    printf '%s\n' "$models_http_body"
+    return 0
+  fi
+  models_render_list "$models_http_body"
+  models_print_preferred
+  printf "\n%sEnable a model:%s  npx @workweave/router models enable <id> --claude\n" "$C_DIM" "$C_RESET"
+  printf "%sDisable a model:%s npx @workweave/router models disable <id> --claude\n" "$C_DIM" "$C_RESET"
+}
+
+models_providers_list() {
+  models_api GET "/admin/v1/providers" || models_fail "listing providers"
+  if [ "$models_json" = "true" ]; then
+    printf '%s\n' "$models_http_body"
+    return 0
+  fi
+  models_render_providers "$models_http_body"
+}
+
+# models_toggle KIND ACTION IDS — flip one or more models/providers on or off.
+# Each id is its own request so a typo in the third id can't roll back the two
+# that already applied, and so the report names exactly what changed.
+models_toggle() {
+  local kind="$1" action="$2" ids="$3"
+  local path body id label doing
+  case "$kind" in
+    model)    path="/admin/v1/excluded-models"    ; label="model"    ;;
+    provider) path="/admin/v1/excluded-providers" ; label="provider" ;;
+  esac
+  # Enabling means dropping the id from the exclusion list, disabling means
+  # adding it — the API's remove/add endpoints, inverted here so the CLI reads
+  # the way the dashboard's checkboxes do.
+  doing="disabling"
+  if [ "$action" = "enable" ]; then
+    doing="enabling"
+    path="$path/remove"
+  fi
+
+  # Fed by a here-string, not a pipe: a pipe would run the loop in a subshell
+  # where models_fail's exit only kills that subshell.
+  while IFS= read -r id; do
+    [ -n "$id" ] || continue
+    body="$(jq -nc --arg v "$id" --arg k "$label" '{($k): $v}')"
+    if ! models_api POST "$path" "$body"; then
+      models_fail "$doing $label '$id'"
+    fi
+    if [ "$action" = "enable" ]; then
+      printf "%s✓%s %s %s%s%s is enabled\n" "$C_GREEN" "$C_RESET" "$label" "$C_BOLD" "$id" "$C_RESET"
+    else
+      printf "%s✓%s %s %s%s%s is disabled — the router will not pick it\n" "$C_GREEN" "$C_RESET" "$label" "$C_BOLD" "$id" "$C_RESET"
+    fi
+  done <<<"$ids"
+}
+
+# models_prefer replaces the priority ranking outright (the API's PUT), because
+# a ranking is an ordering: appending one id at a time can't express "this one
+# first". `clear` drops it and returns the installation to plain routing.
+models_prefer() {
+  local ids="$1" body stored
+  if [ "$ids" = "clear" ] || [ "$ids" = "none" ]; then
+    body='{"preferred":[]}'
+  else
+    body="$(printf '%s' "$ids" | jq -c -R -s '{preferred: (split("\n") | map(select(length > 0)))}')"
+  fi
+  models_api PUT "/admin/v1/preferred-models" "$body" || models_fail "setting the preferred-model ranking"
+  stored="$(printf '%s' "$models_http_body" | jq -r '(.preferred // []) | join(" > ")')"
+  if [ -n "$stored" ]; then
+    printf "%s✓%s Preferred order: %s\n" "$C_GREEN" "$C_RESET" "$stored"
+  else
+    printf "%s✓%s Preferred-model ranking cleared.\n" "$C_GREEN" "$C_RESET"
+  fi
+}
+
+models_usage() {
+  err "$1"
+  printf '%s\n' \
+    "  npx @workweave/router models --claude                          # list models" \
+    "  npx @workweave/router models enable  <id> [<id>…] --claude" \
+    "  npx @workweave/router models disable <id> [<id>…] --claude" \
+    "  npx @workweave/router models providers --claude                # list providers" \
+    "  npx @workweave/router models providers disable <name> --claude" \
+    "  npx @workweave/router models prefer <id> [<id>…] --claude      # ranking ('clear' to drop)" >&2
+  exit 2
+}
+
+run_models() {
+  local verb operands
+  verb="$(printf '%s' "$models_args" | head -n 1)"
+  operands="$(printf '%s' "$models_args" | tail -n +2)"
+
+  # `models providers …` shifts one more word: the sub-verb is the second word.
+  case "$verb" in
+    ""|list)
+      [ -z "$operands" ] || models_usage "'models $verb' takes no arguments."
+      models_list
+      ;;
+    enable|disable)
+      [ -n "$operands" ] || models_usage "'models $verb' needs at least one model id."
+      models_toggle model "$verb" "$operands"
+      ;;
+    prefer)
+      [ -n "$operands" ] || models_usage "'models prefer' needs model ids, or 'clear'."
+      models_prefer "$operands"
+      ;;
+    providers)
+      local sub rest
+      sub="$(printf '%s' "$operands" | head -n 1)"
+      rest="$(printf '%s' "$operands" | tail -n +2)"
+      case "$sub" in
+        ""|list)
+          models_providers_list
+          ;;
+        enable|disable)
+          [ -n "$rest" ] || models_usage "'models providers $sub' needs at least one provider name."
+          models_toggle provider "$sub" "$rest"
+          ;;
+        *)
+          models_usage "Unknown providers sub-command: '$sub'."
+          ;;
+      esac
+      ;;
+    *)
+      models_usage "Unknown models sub-command: '$verb'."
+      ;;
+  esac
+}
+
+if [ "$mode" = "models" ]; then
+  # Editing model selection needs the endpoint and key of one specific install,
+  # never the hosted defaults: a self-hosted user pointing at their own router
+  # would otherwise silently edit the hosted one's installation.
+  if [ "$base_url_explicit" != "true" ]; then
+    models_base="$(resolve_installed_base_url)"
+    if [ -z "$models_base" ]; then
+      err "No Weave Router install found for Claude Code in this scope. Run 'npx @workweave/router --claude' first, or pass --base-url."
+      exit 1
+    fi
+    base_url="$models_base"
+  fi
+  api_key="${WEAVE_ROUTER_KEY:-$(read_installed_key)}"
+  if [ -z "$api_key" ]; then
+    err "No router key found for Claude Code in this scope. Re-run 'npx @workweave/router --claude', or export WEAVE_ROUTER_KEY."
+    exit 1
+  fi
+  run_models
+  exit 0
+fi
+
 if [ "$mode" != "install" ] && [ "$mode" != "update" ]; then
   case "$target" in
     claude)   toggle_claude ;;
@@ -1719,16 +2147,7 @@ fi
 # sidecar is the authority while toggled off — reading the live file there would
 # pin the install to api.anthropic.com.
 if [ "$mode" = "update" ] && [ "$base_url_explicit" != "true" ] && [ "$target" = "claude" ]; then
-  installed_base=""
-  for candidate in \
-    "$settings_dir/.weave-parked.json" \
-    "$settings_file" \
-    "$local_settings_file"
-  do
-    installed_base="$(json_get "$candidate" '.env.ANTHROPIC_BASE_URL')"
-    router_shaped_url "$installed_base" && break
-    installed_base=""
-  done
+  installed_base="$(resolve_installed_base_url)"
   if [ -n "$installed_base" ]; then
     base_url="${installed_base%/}"
   fi
@@ -1747,30 +2166,7 @@ fi
 # a re-run painless — the installer refreshes assets and config shape often
 # enough that users re-run it routinely, and re-pasting a key every time is pure
 # friction. --rotate-key skips the read-back so a new key can replace the old.
-
-# read_installed_key prints the router key this install already has on disk, or
-# nothing. Only Claude Code is supported today; the other targets still prompt.
-read_installed_key() {
-  [ "$target" = "claude" ] || return 0
-  local key=""
-  # Mirror where the install path writes the key: project scope (no --dir) puts
-  # it in the gitignored settings.local.json, everything else inlines it into
-  # settings.json. Check the other file too — a scope was possibly changed, or a
-  # project checkout may carry a committed header from an older install.
-  if [ "$scope" = "project" ] && [ -z "$install_dir" ]; then
-    key="$(read_claude_key "$local_settings_file")"
-    [ -n "$key" ] || key="$(read_claude_key "$settings_file")"
-  else
-    key="$(read_claude_key "$settings_file")"
-    [ -n "$key" ] || key="$(read_claude_key "$local_settings_file")"
-  fi
-  # Last resort: `off` moves the key header out of the settings files and into
-  # the parked sidecar, so an install/update run while toggled off finds nothing
-  # above even though the key is still on disk. Same {"env":{…}} shape, so
-  # read_claude_key reads it directly.
-  [ -n "$key" ] || key="$(read_claude_key "$settings_dir/.weave-parked.json")"
-  printf '%s' "$key"
-}
+# read_installed_key itself is defined above, next to the other settings readers.
 
 # prompt_for_key reads a key from the controlling terminal into $api_key. Only
 # ever called on an interactive install; callers check first.
@@ -1893,12 +2289,14 @@ install_slash_commands() {
   # command-capable clients. The router-off/on/status wrappers shell out to
   # this installer to flip the *local* config, so they're Claude Code-only and
   # need the install scope baked into the command (the .md can't discover it
-  # at invocation time). {{SCOPE}} is substituted accordingly.
+  # at invocation time). {{SCOPE}} is substituted accordingly. router-models
+  # (alias models) is in the same boat: it shells out to read this install's
+  # endpoint and key.
   installed="force-model, unforce-model, router-feedback, fm, ufm, rf"
   cmds="force-model unforce-model router-feedback fm ufm rf"
   if [ "$target" = "claude" ]; then
-    cmds="$cmds router-off router-on router-status router-session"
-    installed="$installed, router-off, router-on, router-status, router-session"
+    cmds="$cmds router-off router-on router-status router-session router-models models"
+    installed="$installed, router-off, router-on, router-status, router-session, router-models, models"
   fi
 
   # Bake the same scope selector the toggle needs to find this install: --dir
@@ -2490,7 +2888,8 @@ weave_sync_commands() {
     # everything so no output leaks into the statusline.
     exec </dev/null
     for name in force-model unforce-model router-feedback fm ufm rf \
-                router-off router-on router-status router-session; do
+                router-off router-on router-status router-session \
+                router-models models; do
       installed="$cmd_dir/$name.md"
       # Only ever refresh a wrapper that is already installed: a missing one
       # was uninstalled or deliberately deleted, and resurrecting it would be

--- a/install/npm/README.md
+++ b/install/npm/README.md
@@ -54,6 +54,19 @@ slash commands. The shell equivalent is `npx @workweave/router disable-routing`.
 Cursor has no config file we own — toggle its base URL override in **Settings →
 Models** instead.
 
+Pick which models the router is allowed to route to:
+
+```bash
+npx @workweave/router models --claude                  # list every model, with its on/off state
+npx @workweave/router models disable gpt-5.6 --claude  # take one out of rotation
+npx @workweave/router models enable gpt-5.6 --claude   # put it back
+```
+
+Inside Claude Code that's `/router-models` (alias `/models`). Editing needs a
+router that serves the model-selection API; against the Weave-hosted router the
+list still prints and points you at the dashboard, where model selection is an
+organization-wide setting.
+
 Uninstall:
 
 ```bash

--- a/install/tests/models_test.sh
+++ b/install/tests/models_test.sh
@@ -1,0 +1,328 @@
+#!/usr/bin/env bash
+#
+# Regression tests for `npx @workweave/router models` — the model-selection CLI
+# behind the /models slash command.
+#
+# Fully offline: an isolated $HOME keeps real config untouched, and a fake curl
+# on PATH answers the router's /admin/v1 endpoints from canned JSON while
+# logging every request so the assertions can check method, path, and body.
+# Run directly or via `make test-install`.
+
+set -uo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+installer="${INSTALLER:-$script_dir/../install.sh}"
+[ -f "$installer" ] || { echo "cannot find installer at $installer" >&2; exit 1; }
+
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+
+fake_bin="$work/bin"
+mkdir -p "$fake_bin"
+
+# Fake curl. Understands the flags install.sh actually passes (-X, --data-binary,
+# -o, -w, --header @-) and routes on the request path. $ROUTER_MODE decides which
+# router it impersonates:
+#   full    — serves the model-selection API
+#   managed — 404s /admin/v1/* (the Weave-hosted router) but serves the catalog
+#   down    — connection failure
+# Requests are appended to $REQUEST_LOG as "METHOD PATH BODY".
+cat >"$fake_bin/curl" <<'FAKE_CURL'
+#!/usr/bin/env bash
+method="GET"; out=""; url=""; body=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    -X) method="$2"; shift 2 ;;
+    -o) out="$2"; shift 2 ;;
+    --data-binary|-d) body="$2"; shift 2 ;;
+    -w|-H|--max-time) shift 2 ;;
+    --header) shift 2 ;;
+    -sS|-fsS|-s|-S|-f) shift ;;
+    http*) url="$1"; shift ;;
+    *) shift ;;
+  esac
+done
+cat >/dev/null 2>&1 || true   # drain the key header on stdin
+path="${url#http://}"; path="${path#https://}"; path="/${path#*/}"
+[ -n "${REQUEST_LOG:-}" ] && printf '%s %s %s\n' "$method" "$path" "$body" >>"$REQUEST_LOG"
+
+emit() { # emit <status> <json>
+  [ -n "$out" ] && printf '%s' "$2" >"$out"
+  printf '%s' "$1"
+  exit 0
+}
+
+if [ "${ROUTER_MODE:-full}" = "down" ]; then
+  printf '000'
+  exit 7
+fi
+
+catalog='{"models":[{"model":"claude-opus-5","provider":"anthropic"},{"model":"gpt-5.6","provider":"openai"}]}'
+models='[{"model":"claude-opus-5","provider":"anthropic","enabled":true},{"model":"claude-haiku-4-5","provider":"anthropic","enabled":false},{"model":"gpt-5.6","provider":"openai","enabled":true}]'
+providers='[{"provider":"anthropic","enabled":true},{"provider":"openai","enabled":false}]'
+
+case "$path" in
+  /v1/router/models) emit 200 "$catalog" ;;
+esac
+
+if [ "${ROUTER_MODE:-full}" = "managed" ]; then
+  emit 404 '{"error":"404 page not found"}'
+fi
+
+case "$path" in
+  /admin/v1/models)                  emit 200 "$models" ;;
+  /admin/v1/providers)               emit 200 "$providers" ;;
+  /admin/v1/preferred-models)        emit 200 '{"preferred":["claude-opus-5"]}' ;;
+esac
+
+# The router validates ids against the deployed set, so a typo comes back 400.
+case "$body" in
+  *no-such-model*) emit 400 '{"error":"unknown model: \"no-such-model\""}' ;;
+esac
+
+case "$path" in
+  /admin/v1/excluded-models*)        emit 200 '{"available":[],"excluded":["gpt-5.6"],"env_override_active":false}' ;;
+  /admin/v1/excluded-providers*)     emit 200 '{"available":[],"excluded":["openai"],"env_override_active":false}' ;;
+  *)                                 emit 404 '{"error":"404 page not found"}' ;;
+esac
+FAKE_CURL
+chmod +x "$fake_bin/curl"
+test_path="$fake_bin:$PATH"
+
+pass=0
+fail=0
+ok() { echo "  ok   $1"; pass=$((pass + 1)); }
+no() { echo "  FAIL $1"; echo "         expected: $2"; echo "         actual:   $3"; fail=$((fail + 1)); }
+
+check() { # check <name> <actual> <expected>
+  if [ "$2" = "$3" ]; then ok "$1"; else no "$1" "$3" "$2"; fi
+}
+
+contains() { # contains <name> <haystack> <needle>
+  case "$2" in
+    *"$3"*) ok "$1" ;;
+    *)      no "$1" "output containing: $3" "$2" ;;
+  esac
+}
+
+# seed_install writes the settings.json an install would leave behind, without
+# running the installer (these tests are about `models`, not about install).
+seed_install() { # seed_install <home> <base-url> <key>
+  mkdir -p "$1/.claude"
+  cat >"$1/.claude/settings.json" <<EOF
+{"env":{"ANTHROPIC_BASE_URL":"$2","ANTHROPIC_CUSTOM_HEADERS":"X-Weave-Router-Key: $3"}}
+EOF
+}
+
+# run_models <home> -- <installer args...>. Sets $out (stdout+stderr) and $rc.
+# Deliberately not a command substitution at the call site: that would run the
+# function in a subshell and throw the exit status away.
+out=""
+rc=0
+run_models() {
+  local home="$1"; shift
+  [ "${1:-}" = "--" ] && shift
+  HOME="$home" XDG_CACHE_HOME="$home/.cache" PATH="$test_path" NO_COLOR=1 \
+    ROUTER_MODE="${ROUTER_MODE:-full}" REQUEST_LOG="${REQUEST_LOG:-}" \
+    bash "$installer" models "$@" </dev/null >"$work/out" 2>&1
+  rc=$?
+  out="$(cat "$work/out")"
+}
+
+# run_models_stdout is the same, but keeps stderr out of $out — the shape a
+# `--json` consumer sees when it pipes the command into jq.
+run_models_stdout() {
+  local home="$1"; shift
+  [ "${1:-}" = "--" ] && shift
+  HOME="$home" XDG_CACHE_HOME="$home/.cache" PATH="$test_path" NO_COLOR=1 \
+    ROUTER_MODE="${ROUTER_MODE:-full}" REQUEST_LOG="${REQUEST_LOG:-}" \
+    bash "$installer" models "$@" </dev/null >"$work/out" 2>"$work/err"
+  rc=$?
+  out="$(cat "$work/out")"
+  errout="$(cat "$work/err")"
+}
+
+echo "install.sh models"
+
+# ---------- listing ----------
+
+home="$work/list"; mkdir -p "$home"
+seed_install "$home" "http://127.0.0.1:8080" "rk_list"
+export REQUEST_LOG="$work/list.log"
+: >"$REQUEST_LOG"
+
+run_models "$home" -- --claude
+check "list exits 0" "$rc" "0"
+contains "list marks an enabled model" "$out" "[x] claude-opus-5"
+contains "list marks a disabled model" "$out" "[ ] claude-haiku-4-5"
+contains "list groups by provider" "$out" "openai"
+contains "list reports the enabled count" "$out" "2 of 3 enabled"
+contains "list shows the preferred ranking" "$out" "Preferred order: claude-opus-5"
+check "list reads the installed endpoint, not the hosted default" \
+  "$(grep -c '^GET /admin/v1/models ' "$REQUEST_LOG")" "1"
+
+run_models_stdout "$home" -- --claude --json
+check "--json emits the raw payload" \
+  "$(printf '%s' "$out" | jq -r '.[0].model')" "claude-opus-5"
+# models writes no config, so the install-time "client not on PATH, we'll write
+# it anyway" warnings must not fire — they would also corrupt a piped --json.
+check "--json writes nothing to stderr" "$errout" ""
+
+run_models "$home" -- providers --claude
+contains "providers list marks an enabled provider" "$out" "[x] anthropic"
+contains "providers list marks a disabled provider" "$out" "[ ] openai"
+
+# ---------- editing ----------
+
+: >"$REQUEST_LOG"
+run_models "$home" -- disable gpt-5.6 --claude
+check "disable exits 0" "$rc" "0"
+contains "disable reports the model" "$out" "model gpt-5.6 is disabled"
+check "disable adds to the exclusion list" \
+  "$(grep -c '^POST /admin/v1/excluded-models {"model":"gpt-5.6"}$' "$REQUEST_LOG")" "1"
+
+: >"$REQUEST_LOG"
+run_models "$home" -- enable gpt-5.6 --claude
+contains "enable reports the model" "$out" "model gpt-5.6 is enabled"
+check "enable removes from the exclusion list" \
+  "$(grep -c '^POST /admin/v1/excluded-models/remove {"model":"gpt-5.6"}$' "$REQUEST_LOG")" "1"
+
+: >"$REQUEST_LOG"
+run_models "$home" -- disable claude-haiku-4-5 gpt-5.6 --claude
+check "disable accepts several models in one call" \
+  "$(grep -c '^POST /admin/v1/excluded-models ' "$REQUEST_LOG")" "2"
+
+: >"$REQUEST_LOG"
+run_models "$home" -- providers disable openai --claude
+check "providers disable hits the provider endpoint" \
+  "$(grep -c '^POST /admin/v1/excluded-providers {"provider":"openai"}$' "$REQUEST_LOG")" "1"
+
+: >"$REQUEST_LOG"
+run_models "$home" -- prefer claude-opus-5 gpt-5.6 --claude
+check "prefer replaces the whole ranking" \
+  "$(grep -c '^PUT /admin/v1/preferred-models {"preferred":\["claude-opus-5","gpt-5.6"\]}$' "$REQUEST_LOG")" "1"
+
+: >"$REQUEST_LOG"
+run_models "$home" -- prefer clear --claude
+check "prefer clear empties the ranking" \
+  "$(grep -c '^PUT /admin/v1/preferred-models {"preferred":\[\]}$' "$REQUEST_LOG")" "1"
+
+# A model id the router doesn't know comes back 400; the CLI must surface the
+# router's own message rather than a bare status code, and stop.
+: >"$REQUEST_LOG"
+run_models "$home" -- disable no-such-model gpt-5.6 --claude
+check "an unknown model id fails" "$rc" "1"
+contains "an unknown model id surfaces the router's message" "$out" "unknown model"
+check "an unknown model id stops before the remaining ids" \
+  "$(grep -c '^POST ' "$REQUEST_LOG")" "1"
+
+# ---------- a router without the model-selection API ----------
+
+ROUTER_MODE="managed"
+: >"$REQUEST_LOG"
+run_models "$home" -- --claude
+check "list against a router without the API still exits 0" "$rc" "0"
+contains "list falls back to the public catalog" "$out" "claude-opus-5"
+contains "list says where model selection lives" "$out" "router.workweave.ai/dashboard/settings"
+# The catalog endpoint reports what is deployed, not what this installation
+# enabled, so the fallback must not render on/off state it cannot know.
+case "$out" in
+  *"[x]"*|*"[ ]"*) no "the fallback claims no on/off state" "no checkbox markers" "$out" ;;
+  *)               ok "the fallback claims no on/off state" ;;
+esac
+
+run_models "$home" -- disable gpt-5.6 --claude
+check "editing against a router without the API fails" "$rc" "1"
+contains "the failure names the dashboard" "$out" "router.workweave.ai/dashboard/settings"
+ROUTER_MODE="full"
+
+# ---------- unreachable router ----------
+
+ROUTER_MODE="down"
+run_models "$home" -- --claude
+check "an unreachable router fails" "$rc" "1"
+contains "an unreachable router says so" "$out" "Could not reach the router"
+ROUTER_MODE="full"
+
+# ---------- endpoint + key resolution ----------
+
+selfhosted="$work/selfhosted"; mkdir -p "$selfhosted"
+seed_install "$selfhosted" "https://router.internal.example" "rk_selfhosted"
+export REQUEST_LOG="$work/selfhosted.log"
+: >"$REQUEST_LOG"
+run_models "$selfhosted" -- --claude
+check "a self-hosted install talks to its own router" \
+  "$(grep -c '^GET /admin/v1/models ' "$REQUEST_LOG")" "1"
+
+# `off` parks the router URL + key in the sidecar and points settings.json at
+# Anthropic. models must read the sidecar, or it would treat api.anthropic.com
+# as the router.
+parked="$work/parked"; mkdir -p "$parked/.claude"
+cat >"$parked/.claude/settings.json" <<'EOF'
+{"env":{"ANTHROPIC_BASE_URL":"https://api.anthropic.com"}}
+EOF
+cat >"$parked/.claude/.weave-parked.json" <<'EOF'
+{"env":{"ANTHROPIC_BASE_URL":"http://127.0.0.1:8080","ANTHROPIC_CUSTOM_HEADERS":"X-Weave-Router-Key: rk_parked"}}
+EOF
+export REQUEST_LOG="$work/parked.log"
+: >"$REQUEST_LOG"
+run_models "$parked" -- --claude
+check "models works while the router is toggled off" "$rc" "0"
+check "models reads the parked endpoint, not api.anthropic.com" \
+  "$(grep -c '^GET /admin/v1/models ' "$REQUEST_LOG")" "1"
+
+empty="$work/empty"; mkdir -p "$empty"
+run_models "$empty" -- --claude
+check "no install found fails" "$rc" "1"
+contains "no install found explains how to fix it" "$out" "npx @workweave/router --claude"
+
+nokey="$work/nokey"; mkdir -p "$nokey/.claude"
+cat >"$nokey/.claude/settings.json" <<'EOF'
+{"env":{"ANTHROPIC_BASE_URL":"http://127.0.0.1:8080"}}
+EOF
+run_models "$nokey" -- --claude
+check "an install with no key fails" "$rc" "1"
+contains "an install with no key says so" "$out" "No router key found"
+
+# ---------- argument handling ----------
+
+run_models "$home" -- --codex
+check "models rejects a non-Claude client" "$rc" "2"
+contains "models says which client it supports" "$out" "supports --claude only"
+
+HOME="$home" PATH="$test_path" NO_COLOR=1 bash "$installer" models </dev/null >"$work/out" 2>&1
+check "models without a client flag is refused" "$?" "2"
+contains "models without a client flag names --claude" "$(cat "$work/out")" "requires an explicit client"
+
+run_models "$home" -- enable --claude
+check "enable with no model id is refused" "$rc" "2"
+contains "enable with no model id shows usage" "$out" "needs at least one model id"
+
+run_models "$home" -- frobnicate --claude
+check "an unknown sub-command is refused" "$rc" "2"
+contains "an unknown sub-command shows usage" "$out" "Unknown models sub-command"
+
+# ---------- the shipped slash commands ----------
+
+# `models` refuses to guess a client, so every command line the wrapper tells
+# Claude Code to run has to name one. {{SCOPE}} renders empty in user scope,
+# which is exactly where a missing --claude would surface as a hard failure.
+commands_dir="$script_dir/../commands"
+for wrapper in router-models models; do
+  file="$commands_dir/$wrapper.md"
+  if [ ! -f "$file" ]; then
+    no "$wrapper.md is shipped" "a file at $file" "missing"
+    continue
+  fi
+  bad="$(grep -o 'npx @workweave/router models[^`]*' "$file" | grep -cv -- '--claude' || true)"
+  check "every $wrapper.md command line names a client" "$bad" "0"
+done
+
+# The alias must stay a copy of the primary wrapper, or the two drift.
+check "models.md and router-models.md share one body" \
+  "$(diff <(sed -n '6,$p' "$commands_dir/router-models.md") <(sed -n '6,$p' "$commands_dir/models.md") >/dev/null 2>&1 && echo same || echo differs)" \
+  "same"
+
+echo
+echo "$pass passed, $fail failed"
+[ "$fail" -eq 0 ]

--- a/install/tests/models_test.sh
+++ b/install/tests/models_test.sh
@@ -222,6 +222,18 @@ run_models "$home" -- prefer clear --claude
 check "prefer clear empties the ranking" \
   "$(grep -c '^PUT /admin/v1/preferred-models {"preferred":\[\]}$' "$REQUEST_LOG")" "1"
 
+# --json is a contract about stdout: a scripted caller parses it. A mutation
+# that succeeds but prints prose makes that caller report a parse failure for
+# work already committed, and a retry then acts on stale assumptions.
+for mutation in "disable gpt-5.6" "enable gpt-5.6" "providers disable openai" \
+                "prefer claude-opus-5" "prefer clear"; do
+  # shellcheck disable=SC2086
+  run_models_stdout "$home" -- $mutation --claude --json
+  check "'models $mutation --json' exits 0" "$rc" "0"
+  check "'models $mutation --json' emits JSON on stdout" \
+    "$(printf '%s' "$out" | jq -e . >/dev/null 2>&1 && echo json || echo prose)" "json"
+done
+
 # A model id the router doesn't know comes back 400; the CLI must surface the
 # router's own message rather than a bare status code, and stop.
 : >"$REQUEST_LOG"
@@ -318,6 +330,67 @@ EOF
 run_models "$nokey" -- --claude
 check "an install with no key fails" "$rc" "1"
 contains "an install with no key says so" "$out" "No router key found"
+
+# ---------- committed-endpoint / local-key split (key disclosure) ----------
+#
+# Project scope deliberately splits config: the endpoint lives in the committed
+# settings.json, each teammate's key in the gitignored settings.local.json. A
+# hostile repo can therefore commit a settings.json naming a router it controls
+# and, without a trust check, this command would mail the teammate's key to it.
+# run_models_project runs inside a real git repo so the tracked-file check is
+# exercised for real rather than mocked.
+run_models_project() { # run_models_project <repo> [extra args...]
+  local repo="$1"; shift
+  ( cd "$repo" && HOME="$repo/../home" XDG_CACHE_HOME="$repo/../home/.cache" \
+      PATH="$test_path" NO_COLOR=1 ROUTER_MODE="${ROUTER_MODE:-full}" \
+      REQUEST_LOG="${REQUEST_LOG:-}" \
+      bash "$installer" models --claude --scope project "$@" </dev/null >"$work/out" 2>&1 )
+  rc=$?
+  out="$(cat "$work/out")"
+}
+
+# seed_project_split builds a git repo whose committed settings.json carries
+# $2 as the endpoint and whose gitignored settings.local.json carries the key.
+seed_project_split() { # seed_project_split <root> <committed-endpoint>
+  mkdir -p "$1/home" "$1/repo/.claude"
+  git -C "$1/repo" init -q .
+  printf '{"env":{"ANTHROPIC_BASE_URL":"%s"}}\n' "$2" >"$1/repo/.claude/settings.json"
+  printf '%s\n' '{"env":{"ANTHROPIC_CUSTOM_HEADERS":"X-Weave-Router-Key: rk_teammate"}}' \
+    >"$1/repo/.claude/settings.local.json"
+  git -C "$1/repo" add -A >/dev/null 2>&1
+  git -C "$1/repo" -c user.email=t@example.com -c user.name=t commit -qm seed >/dev/null 2>&1
+}
+
+hostile="$work/hostile"
+seed_project_split "$hostile" "https://evil.example.com"
+export REQUEST_LOG="$work/hostile.log"
+: >"$REQUEST_LOG"
+run_models_project "$hostile/repo"
+check "a git-tracked endpoint paired with a local key is refused" "$rc" "1"
+contains "the refusal names the endpoint" "$out" "evil.example.com"
+check "the refusal sends no request at all" "$(wc -l <"$REQUEST_LOG" | tr -d ' ')" "0"
+
+# The same split against the hosted default is the layout the installer itself
+# writes, so it must keep working — the endpoint is one the user can vouch for.
+legit="$work/legit"
+seed_project_split "$legit" "https://router.workweave.ai"
+export REQUEST_LOG="$work/legit.log"
+: >"$REQUEST_LOG"
+run_models_project "$legit/repo"
+check "the installer's own committed-hosted layout still works" "$rc" "0"
+check "the hosted-default endpoint is actually called" \
+  "$(grep -c '^GET /admin/v1/models ' "$REQUEST_LOG")" "1"
+
+# An explicit --base-url is the user vouching out-of-band, so it overrides the
+# committed value rather than being refused.
+override="$work/override"
+seed_project_split "$override" "https://evil.example.com"
+export REQUEST_LOG="$work/override.log"
+: >"$REQUEST_LOG"
+run_models_project "$override/repo" --base-url http://127.0.0.1:8080
+check "an explicit --base-url overrides a committed endpoint" "$rc" "0"
+check "the explicit endpoint is the one called" \
+  "$(grep -c '^GET /admin/v1/models ' "$REQUEST_LOG")" "1"
 
 # ---------- argument handling ----------
 

--- a/install/tests/models_test.sh
+++ b/install/tests/models_test.sh
@@ -351,12 +351,20 @@ run_models_project() { # run_models_project <repo> [extra args...]
 
 # seed_project_split builds a git repo whose committed settings.json carries
 # $2 as the endpoint and whose gitignored settings.local.json carries the key.
-seed_project_split() { # seed_project_split <root> <committed-endpoint>
+# A third "trusted" argument simulates the marker written by the installer for
+# project-scoped self-hosted installs.
+seed_project_split() { # seed_project_split <root> <committed-endpoint> [trusted]
   mkdir -p "$1/home" "$1/repo/.claude"
   git -C "$1/repo" init -q .
   printf '{"env":{"ANTHROPIC_BASE_URL":"%s"}}\n' "$2" >"$1/repo/.claude/settings.json"
-  printf '%s\n' '{"env":{"ANTHROPIC_CUSTOM_HEADERS":"X-Weave-Router-Key: rk_teammate"}}' \
-    >"$1/repo/.claude/settings.local.json"
+  if [ "${3:-}" = "trusted" ]; then
+    printf '{"env":{"ANTHROPIC_CUSTOM_HEADERS":"X-Weave-Router-Key: rk_teammate","WEAVE_ROUTER_BASE_URL":"%s"}}\n' "$2" \
+      >"$1/repo/.claude/settings.local.json"
+  else
+    printf '%s\n' '{"env":{"ANTHROPIC_CUSTOM_HEADERS":"X-Weave-Router-Key: rk_teammate"}}' \
+      >"$1/repo/.claude/settings.local.json"
+  fi
+  printf '.claude/settings.local.json\n' >"$1/repo/.gitignore"
   git -C "$1/repo" add -A >/dev/null 2>&1
   git -C "$1/repo" -c user.email=t@example.com -c user.name=t commit -qm seed >/dev/null 2>&1
 }
@@ -379,6 +387,22 @@ export REQUEST_LOG="$work/legit.log"
 run_models_project "$legit/repo"
 check "the installer's own committed-hosted layout still works" "$rc" "0"
 check "the hosted-default endpoint is actually called" \
+  "$(grep -c '^GET /admin/v1/models ' "$REQUEST_LOG")" "1"
+
+# A self-hosted project endpoint gets the same marker from a real installer
+# run, so the split layout is accepted after installation rather than only for
+# the hosted default.
+selfhosted_project="$work/selfhosted-project"
+mkdir -p "$selfhosted_project/home" "$selfhosted_project/repo"
+git -C "$selfhosted_project/repo" init -q .
+(cd "$selfhosted_project/repo" && HOME="$selfhosted_project/home" XDG_CACHE_HOME="$selfhosted_project/home/.cache" \
+  PATH="$test_path" NO_COLOR=1 WEAVE_ROUTER_KEY=rk_teammate \
+  bash "$installer" --claude --scope project --quiet --non-interactive --base-url http://127.0.0.1:8080 >/dev/null 2>&1)
+export REQUEST_LOG="$work/selfhosted-project.log"
+: >"$REQUEST_LOG"
+run_models_project "$selfhosted_project/repo"
+check "the installer's committed self-hosted layout still works" "$rc" "0"
+check "the trusted self-hosted endpoint is actually called" \
   "$(grep -c '^GET /admin/v1/models ' "$REQUEST_LOG")" "1"
 
 # An explicit --base-url is the user vouching out-of-band, so it overrides the

--- a/install/tests/models_test.sh
+++ b/install/tests/models_test.sh
@@ -187,6 +187,21 @@ contains "enable reports the model" "$out" "model gpt-5.6 is enabled"
 check "enable removes from the exclusion list" \
   "$(grep -c '^POST /admin/v1/excluded-models/remove {"model":"gpt-5.6"}$' "$REQUEST_LOG")" "1"
 
+# A flag may appear before, after, or between operands — the slash wrapper's
+# first call is `models --claude` (flag before any sub-verb), so a follow-up
+# `enable`/`disable` written the same way must not become "Unknown flag".
+: >"$REQUEST_LOG"
+run_models "$home" -- --claude enable gpt-5.6
+check "enable with the client flag before the sub-verb exits 0" "$rc" "0"
+check "enable with the client flag before the sub-verb still calls the API" \
+  "$(grep -c '^POST /admin/v1/excluded-models/remove {"model":"gpt-5.6"}$' "$REQUEST_LOG")" "1"
+
+: >"$REQUEST_LOG"
+run_models "$home" -- disable --claude gpt-5.6
+check "disable with the client flag between the verb and the id exits 0" "$rc" "0"
+check "disable with the client flag between the verb and the id still calls the API" \
+  "$(grep -c '^POST /admin/v1/excluded-models {"model":"gpt-5.6"}$' "$REQUEST_LOG")" "1"
+
 : >"$REQUEST_LOG"
 run_models "$home" -- disable claude-haiku-4-5 gpt-5.6 --claude
 check "disable accepts several models in one call" \
@@ -234,6 +249,26 @@ esac
 run_models "$home" -- disable gpt-5.6 --claude
 check "editing against a router without the API fails" "$rc" "1"
 contains "the failure names the dashboard" "$out" "router.workweave.ai/dashboard/settings"
+
+# `models providers` is read-only, same as `models list` — it must degrade the
+# same way on a 404 rather than hard-failing while listing still succeeds.
+run_models "$home" -- providers --claude
+check "providers list against a router without the API still exits 0" "$rc" "0"
+contains "providers list falls back to the public catalog" "$out" "anthropic"
+contains "providers list says where selection lives" "$out" "router.workweave.ai/dashboard/settings"
+case "$out" in
+  *"[x]"*|*"[ ]"*) no "the providers fallback claims no on/off state" "no checkbox markers" "$out" ;;
+  *)               ok "the providers fallback claims no on/off state" ;;
+esac
+
+run_models_stdout "$home" -- providers --claude --json
+check "providers list --json against a router without the API emits the provider names" \
+  "$(printf '%s' "$out" | jq -c 'sort')" '["anthropic","openai"]'
+
+run_models "$home" -- providers disable openai --claude
+check "editing providers against a router without the API still fails" "$rc" "1"
+contains "the providers failure names the dashboard" "$out" "router.workweave.ai/dashboard/settings"
+
 ROUTER_MODE="full"
 
 # ---------- unreachable router ----------

--- a/install/uninstall.sh
+++ b/install/uninstall.sh
@@ -592,7 +592,7 @@ done
 commands_dir="$(dirname "$settings_file")/commands"
 if [ -d "$commands_dir" ]; then
   refuse_if_symlink "$commands_dir"
-  for cmd in force-model unforce-model router-feedback fm ufm rf router-off router-on router-status router-session; do
+  for cmd in force-model unforce-model router-feedback fm ufm rf router-off router-on router-status router-session router-models models; do
     cmd_file="$commands_dir/$cmd.md"
     if [ -f "$cmd_file" ]; then
       refuse_if_symlink "$cmd_file"


### PR DESCRIPTION
Adds `npx @workweave/router models` plus the Claude Code wrappers **`/router-models`** (alias **`/models`**), so the models an installation lets the router pick from can be listed and toggled from the terminal — the same stored setting as the checkboxes on the dashboard's settings page.

```
$ npx @workweave/router models --claude
Weave Router models · http://localhost:8080
2 of 3 enabled

anthropic
  [x] claude-opus-5
  [ ] claude-haiku-4-5
openai
  [x] gpt-5.6

Preferred order: claude-opus-5
```

Sub-verbs: `list` (default), `enable`, `disable`, `providers [enable|disable]`, `prefer` (`clear` to drop), and `--json` for scripts.

### Depends on #835

The write paths call the installation-scoped `/admin/v1` endpoints added in #835 (`GET /models`, `POST /excluded-models[/remove]`, `PUT /preferred-models`, the provider equivalents). This PR is based on `main` rather than stacked on that branch, because #835 is ~89 commits behind and predates the installer test suite entirely.

It is safe to merge in either order: a router without those endpoints 404s, and the CLI treats that as a first-class case rather than an error — see below.

### Routers without the model-selection API

`/admin/v1` is mounted only in `selfhosted` mode, so the Weave-hosted router doesn't serve it and model selection there is an org-wide setting in the Weave dashboard. On a 404:

- **listing** falls back to the unauthed `GET /v1/router/models` catalog (mounted in both modes) and names the dashboard;
- **editing** refuses and names the dashboard.

The fallback endpoint reports the *deployed catalog*, not the installation's selection, so it renders a plain list — rendering `[x]` on every row would claim state it cannot see.

### Notes

- The endpoint and key come from the install already on disk (including the parked sidecar while routing is toggled `off`), so a self-hosted install talks to its own router with its own key. The key rides in on stdin (`curl --header @-`), never as a `-H` argument.
- `ROUTER_EXCLUDED_MODELS` / `ROUTER_EXCLUDED_PROVIDERS` pins surface as the router's own 403 message rather than a silent no-op.
- Two fixes fall out: `read_installed_key` moves up so `models` can dispatch before the token-handling section, and the *"client not on PATH — config will be written anyway"* preflight is skipped for `models`, which writes no config (its stderr also corrupted a piped `--json`).

### Tests

`install/tests/models_test.sh` — 49 assertions, fully offline against a fake curl: rendering, every sub-verb's exact request method/path/body, endpoint + key resolution (self-hosted, toggled-off/parked, missing install, missing key), the 404 fallback and refusal, unreachable router, a 400 typo'd id stopping the batch, argument handling, and an invariant that every command line in the shipped wrappers names a client.

**CI now runs `make test-install`.** The installer suites existed but no workflow ran them — only `make test-statusline` did. Verified green on Linux (`ubuntu:24.04`) as well as macOS: codex ✓, key-reuse 26/26, models 49/49, statusline 30/30.

### Rollout

Reaching users needs an `@workweave/router` npm publish; the statusline's background wrapper refresh only updates wrappers already installed, so existing users pick `/models` up on their next installer run.

🤖 Generated with [Weave Router](https://router.workweave.ai)