### PR TITLE
fix(translate): drop non-string enums instead of validate-and-reject on Gemini emit

### DIFF
--- a/internal/translate/emit_gemini.go
+++ b/internal/translate/emit_gemini.go
@@ -1603,15 +1603,11 @@ func validateGeminiRequired(schema map[string]any, path string) error {
 	return nil
 }
 
-// resolveGeminiEnum drops an enum Gemini cannot represent. Google's function
-// declaration schema types every enum member as TYPE_STRING, so a numeric,
-// boolean, or null member 400s the whole request ("Invalid value at
-// ...enum[0] (TYPE_STRING), 7") regardless of the sibling "type". Stringifying
-// would change the tool's input language — toolcheck validates model output
-// against the ORIGINAL schema, so a coerced "7" would then read as a violation
-// of the caller's `enum: [7]`. Dropping is the lossless option: the value set
-// is unenforced upstream but still enforced where it matters (#65, #83; #764
-// regressed this to a validate-and-reject that missed type-less enums).
+// resolveGeminiEnum drops enum keys Gemini cannot represent. Google types
+// every enum member as TYPE_STRING and 400s on anything else. Stringifying
+// was rejected: toolcheck validates model output against the ORIGINAL schema,
+// so a coerced "7" breaks the caller's `enum: [7]`. Dropping is lossless
+// where it counts (#65, #83; #764 regressed this by missing type-less enums).
 func resolveGeminiEnum(schema map[string]any) {
 	values, exists := schema["enum"]
 	if !exists {

--- a/internal/translate/emit_gemini.go
+++ b/internal/translate/emit_gemini.go
@@ -1412,9 +1412,7 @@ func sanitizeGeminiSchemaNode(v any, path string) (any, error) {
 	if err := validateGeminiRequired(out, path); err != nil {
 		return nil, err
 	}
-	if err := validateGeminiEnum(out, path); err != nil {
-		return nil, err
-	}
+	resolveGeminiEnum(out)
 	return out, nil
 }
 
@@ -1605,44 +1603,37 @@ func validateGeminiRequired(schema map[string]any, path string) error {
 	return nil
 }
 
-func validateGeminiEnum(schema map[string]any, path string) error {
+// resolveGeminiEnum drops an enum Gemini cannot represent. Google's function
+// declaration schema types every enum member as TYPE_STRING, so a numeric,
+// boolean, or null member 400s the whole request ("Invalid value at
+// ...enum[0] (TYPE_STRING), 7") regardless of the sibling "type". Stringifying
+// would change the tool's input language — toolcheck validates model output
+// against the ORIGINAL schema, so a coerced "7" would then read as a violation
+// of the caller's `enum: [7]`. Dropping is the lossless option: the value set
+// is unenforced upstream but still enforced where it matters (#65, #83; #764
+// regressed this to a validate-and-reject that missed type-less enums).
+func resolveGeminiEnum(schema map[string]any) {
 	values, exists := schema["enum"]
 	if !exists {
-		return nil
+		return
 	}
-	enum, ok := values.([]any)
-	if !ok || len(enum) == 0 {
-		return fmt.Errorf("%w at %s.enum: expected non-empty array", ErrGeminiSchemaIncompatible, path)
+	if enum, ok := values.([]any); ok && len(enum) > 0 && allStringEnum(enum) {
+		return
 	}
-	typ, _ := schema["type"].(string)
-	for _, value := range enum {
-		if !enumMatchesType(value, typ, schema["nullable"] == true) {
-			return fmt.Errorf("%w at %s.enum: value needs type coercion", ErrGeminiSchemaIncompatible, path)
-		}
+	delete(schema, "enum")
+	// format:"enum" without an enum is itself unrepresentable.
+	if format, _ := schema["format"].(string); format == "enum" {
+		delete(schema, "format")
 	}
-	return nil
 }
 
-func enumMatchesType(value any, typ string, nullable bool) bool {
-	if value == nil {
-		return nullable || typ == ""
+func allStringEnum(enum []any) bool {
+	for _, value := range enum {
+		if _, ok := value.(string); !ok {
+			return false
+		}
 	}
-	if typ == "" {
-		return true
-	}
-	switch typ {
-	case "string":
-		_, ok := value.(string)
-		return ok
-	case "boolean":
-		_, ok := value.(bool)
-		return ok
-	case "number", "integer":
-		_, ok := value.(float64)
-		return ok
-	default:
-		return false
-	}
+	return true
 }
 
 func valueInEnum(value, enum any) bool {

--- a/internal/translate/fidelity_test.go
+++ b/internal/translate/fidelity_test.go
@@ -21,11 +21,9 @@ func TestPrepareGemini_SchemaFidelity(t *testing.T) {
 		check   func(*testing.T, map[string]any)
 	}{
 		{
-			// Gemini types every enum member as TYPE_STRING, so the enum a
-			// numeric const lowers to is unrepresentable and gets dropped —
-			// same reasoning as additionalProperties below: toolcheck still
-			// enforces const against the original inbound schema. Keeping the
-			// enum 400s the request ("(TYPE_STRING), 7").
+			// Gemini types every enum member as TYPE_STRING; a numeric const lowers
+			// to a numeric enum that 400s the request, so it gets dropped. toolcheck
+			// still enforces const against the original schema.
 			name:   "numeric const drops the unrepresentable enum but keeps the type",
 			schema: `{"type":"number","const":7}`,
 			check: func(t *testing.T, schema map[string]any) {

--- a/internal/translate/fidelity_test.go
+++ b/internal/translate/fidelity_test.go
@@ -21,10 +21,23 @@ func TestPrepareGemini_SchemaFidelity(t *testing.T) {
 		check   func(*testing.T, map[string]any)
 	}{
 		{
-			name:   "const preserves numeric type",
+			// Gemini types every enum member as TYPE_STRING, so the enum a
+			// numeric const lowers to is unrepresentable and gets dropped —
+			// same reasoning as additionalProperties below: toolcheck still
+			// enforces const against the original inbound schema. Keeping the
+			// enum 400s the request ("(TYPE_STRING), 7").
+			name:   "numeric const drops the unrepresentable enum but keeps the type",
 			schema: `{"type":"number","const":7}`,
 			check: func(t *testing.T, schema map[string]any) {
-				assert.Equal(t, []any{float64(7)}, schema["enum"])
+				assert.NotContains(t, schema, "enum")
+				assert.Equal(t, "number", schema["type"])
+			},
+		},
+		{
+			name:   "string const still lowers to an enum",
+			schema: `{"type":"string","const":"go"}`,
+			check: func(t *testing.T, schema map[string]any) {
+				assert.Equal(t, []any{"go"}, schema["enum"])
 			},
 		},
 		{

--- a/internal/translate/gemini_test.go
+++ b/internal/translate/gemini_test.go
@@ -1042,6 +1042,56 @@ func TestPrepareGemini_PreservesEnumValueTypes(t *testing.T) {
 	assert.Equal(t, []any{"a", "b"}, normal["enum"], "well-formed enums must pass through unchanged")
 }
 
+func TestPrepareGemini_DropsNonStringEnums(t *testing.T) {
+	// Google types every function-declaration enum member as TYPE_STRING and
+	// 400s on anything else, regardless of the sibling "type" — the prod
+	// failure was a type-less numeric enum:
+	//   Invalid value at '...properties[1].value.enum[0]' (TYPE_STRING), 7
+	// Dropping is lossless where it counts: toolcheck validates emitted tool
+	// calls against the ORIGINAL inbound schema, so the value set is still
+	// enforced. Stringifying would instead change the tool's input language.
+	body := []byte(`{
+		"messages": [{"role":"user","content":"hi"}],
+		"tools": [{
+			"name":"lookback",
+			"input_schema":{
+				"type":"object",
+				"properties":{
+					"untyped_numeric":{"enum":[7,14,30]},
+					"typed_numeric":{"type":"integer","enum":[7,14,30]},
+					"mixed":{"enum":["all",30]},
+					"boolean":{"type":"boolean","enum":[true,false]},
+					"nullable":{"type":"string","nullable":true,"enum":["a",null]},
+					"format_enum":{"type":"string","format":"enum","enum":[1,2]},
+					"strings":{"type":"string","enum":["day","week"]}
+				}
+			}
+		}]
+	}`)
+	env, err := translate.ParseAnthropic(body)
+	require.NoError(t, err)
+	prep, err := env.PrepareGemini(http.Header{}, translate.EmitOptions{})
+	require.NoError(t, err, "an unrepresentable enum must not fail the whole tool")
+
+	out := mustUnmarshal(t, prep.Body)
+	params := out["tools"].([]any)[0].(map[string]any)["functionDeclarations"].([]any)[0].(map[string]any)["parameters"].(map[string]any)
+	props := params["properties"].(map[string]any)
+
+	for _, name := range []string{"untyped_numeric", "typed_numeric", "mixed", "boolean", "nullable", "format_enum"} {
+		assert.NotContains(t, props[name], "enum", "%s: non-string enum must be dropped", name)
+	}
+
+	// Only the enum is dropped — the rest of each property survives.
+	assert.Equal(t, "integer", props["typed_numeric"].(map[string]any)["type"])
+	assert.Equal(t, "boolean", props["boolean"].(map[string]any)["type"])
+
+	// format:"enum" is meaningless once the enum is gone, so it goes too.
+	assert.NotContains(t, props["format_enum"], "format")
+
+	assert.Equal(t, []any{"day", "week"}, props["strings"].(map[string]any)["enum"],
+		"all-string enums must pass through unchanged")
+}
+
 func TestPrepareGemini_UserDefinedPropertyNamedProperties(t *testing.T) {
 	// A user-defined property named "properties" must not be mistaken for the
 	// JSON Schema "properties" keyword. Its value schema must still be

--- a/internal/translate/gemini_test.go
+++ b/internal/translate/gemini_test.go
@@ -1043,13 +1043,8 @@ func TestPrepareGemini_PreservesEnumValueTypes(t *testing.T) {
 }
 
 func TestPrepareGemini_DropsNonStringEnums(t *testing.T) {
-	// Google types every function-declaration enum member as TYPE_STRING and
-	// 400s on anything else, regardless of the sibling "type" — the prod
-	// failure was a type-less numeric enum:
-	//   Invalid value at '...properties[1].value.enum[0]' (TYPE_STRING), 7
-	// Dropping is lossless where it counts: toolcheck validates emitted tool
-	// calls against the ORIGINAL inbound schema, so the value set is still
-	// enforced. Stringifying would instead change the tool's input language.
+	// Gemini types every enum member as TYPE_STRING and 400s on anything else.
+	// Dropping is lossless: toolcheck enforces against the original schema.
 	body := []byte(`{
 		"messages": [{"role":"user","content":"hi"}],
 		"tools": [{


### PR DESCRIPTION
## Problem

Claude Code sessions routed to a Gemini target model can 400 on tool schemas with a numeric/mixed-type `enum`:

```
Invalid value at 'tools[0].function_declarations[45].parameters.properties[1].value.enum[0]' (TYPE_STRING), 7
Invalid value at '...properties[1].value.enum[1]' (TYPE_STRING), 14
Invalid value at '...properties[1].value.enum[2]' (TYPE_STRING), 30
```

Gemini's function-calling API types every enum member as `TYPE_STRING` and rejects the whole request on anything else — regardless of the sibling `"type"` key.

## Root cause

This is a regression. #65 and #83 both fixed this exact class of bug (numeric enums, mixed-type enums, empty-string enums) by dropping the offending values. #764's schema-sanitization rewrite replaced that with `validateGeminiEnum`/`enumMatchesType`, which only *rejects the whole tool* when an enum value conflicts with an **explicitly declared** `"type"`. A property with a bare `enum` and no `type` key satisfies `enumMatchesType` unconditionally (`typ == "" → true`), so the malformed schema passes sanitization untouched and gets forwarded to Gemini verbatim.

## Fix

Replace `validateGeminiEnum` (reject) with `resolveGeminiEnum` (drop): when any enum member isn't a string, delete the `enum` key instead of rejecting the tool or stringifying the values.

Stringifying was considered and rejected — `toolcheck` validates model-emitted tool calls against the **original** Anthropic `input_schema`, not the Gemini-sanitized one, so a coerced `"7"` would then read as a violation of the caller's `enum: [7]`. Dropping is lossless where it counts: the value set goes unenforced by Gemini's decode-time grammar but is still enforced by toolcheck against the real schema.

Also drops `format: "enum"` once the enum itself is gone, since it's meaningless without one.

## Testing

- New regression test (`TestPrepareGemini_DropsNonStringEnums`) reproduces the exact production error shape (untyped numeric enum) plus the sibling cases from #65/#83: typed numeric, mixed string/number, boolean, nullable, and `format:"enum"`.
- Updated `TestPrepareGemini_SchemaFidelity`'s `const preserves numeric type` case, which was asserting the buggy behavior (a numeric `const` lowering to a numeric `enum`) — split into a numeric-const case (enum dropped, type kept) and a new string-const case (enum still produced).
- Existing all-string enum tests (`TestPrepareGemini_PreservesEnumValueTypes`) untouched and still pass.
- `go build ./...`, `go vet ./...`, and the full `go test ./...` suite all pass.

🤖 Generated with [Weave Router](https://router.workweave.ai)