### PR TITLE
feat(routing): org positive model allowlist

### DIFF
--- a/db/migrations/0057_installation-allowed-models.down.sql
+++ b/db/migrations/0057_installation-allowed-models.down.sql
@@ -1,0 +1,6 @@
+BEGIN;
+
+ALTER TABLE router.model_router_installations
+  DROP COLUMN allowed_models;
+
+COMMIT;

--- a/db/migrations/0057_installation-allowed-models.up.sql
+++ b/db/migrations/0057_installation-allowed-models.up.sql
@@ -1,0 +1,13 @@
+BEGIN;
+
+-- Positive counterpart to excluded_models: when non-empty, routing is confined
+-- to these models. Composes with (does not replace) excluded_models — the
+-- effective set is allowed_models minus excluded_models. Empty array means "no
+-- restriction", matching excluded_models' empty-means-none convention, so NULL
+-- and empty never have to be distinguished at the read site.
+ALTER TABLE router.model_router_installations
+  ADD COLUMN allowed_models TEXT[] NOT NULL DEFAULT '{}';
+
+COMMENT ON COLUMN router.model_router_installations.allowed_models IS 'Org-level positive model allowlist. Empty = no restriction. Effective set = allowed_models minus excluded_models. Fail-closed: an allowlist with no eligible overlap refuses the turn.';
+
+COMMIT;

--- a/db/queries/model_router_installations.sql
+++ b/db/queries/model_router_installations.sql
@@ -45,6 +45,18 @@ WHERE id = @id::uuid
   AND external_id = @external_id::varchar
   AND deleted_at IS NULL;
 
+-- Replaces the per-installation positive model allowlist, scoped to an
+-- external_id to prevent cross-tenant updates. Empty array means "no
+-- restriction" (all models routable), NOT "no models". Bumps updated_at so
+-- dashboards see the change.
+-- name: UpdateModelRouterInstallationAllowedModels :execrows
+UPDATE router.model_router_installations
+SET allowed_models = @allowed_models::text[],
+    updated_at = NOW()
+WHERE id = @id::uuid
+  AND external_id = @external_id::varchar
+  AND deleted_at IS NULL;
+
 -- Replaces the per-installation provider exclusion list, scoped to an
 -- external_id to prevent cross-tenant updates. Empty array means "no
 -- exclusion". Bumps updated_at so dashboards see the change.

--- a/internal/api/admin/allowed_models.go
+++ b/internal/api/admin/allowed_models.go
@@ -1,0 +1,83 @@
+package admin
+
+import (
+	"errors"
+	"net/http"
+	"sort"
+
+	"workweave/router/internal/auth"
+	"workweave/router/internal/observability"
+
+	"github.com/gin-gonic/gin"
+)
+
+type allowedModelsResponse struct {
+	Available []deployedModelDTO `json:"available"`
+	Allowed   []string           `json:"allowed"`
+}
+
+type updateAllowedModelsRequest struct {
+	Allowed []string `json:"allowed"`
+}
+
+// GetAllowedModelsHandler returns deployed models and the installation's
+// positive allowlist. An empty list means no restriction — every deployed
+// model is routable, subject to the separate exclusion list.
+func GetAllowedModelsHandler(authSvc *auth.Service, models DeployedModelsSource) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		installation, ok := resolveInstallation(c, authSvc)
+		if !ok {
+			return
+		}
+
+		allowed := append([]string{}, installation.AllowedModels...)
+		sort.Strings(allowed)
+
+		c.JSON(http.StatusOK, allowedModelsResponse{
+			Available: deployedModelsDTO(models),
+			Allowed:   allowed,
+		})
+	}
+}
+
+// UpdateAllowedModelsHandler replaces the installation's positive allowlist.
+// 400 on unknown model IDs. Unlike the exclusion list there is no env override
+// to contend with — the allowlist is purely a per-installation control.
+func UpdateAllowedModelsHandler(authSvc *auth.Service, models DeployedModelsSource) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		log := observability.FromGin(c)
+		installation, ok := resolveInstallation(c, authSvc)
+		if !ok {
+			return
+		}
+
+		var req updateAllowedModelsRequest
+		if err := c.ShouldBindJSON(&req); err != nil {
+			c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": "Invalid request body."})
+			return
+		}
+
+		deployed := models.DefaultDeployedModels()
+		allowed := make(map[string]struct{}, len(deployed))
+		for _, e := range deployed {
+			allowed[e.Model] = struct{}{}
+		}
+
+		stored, err := authSvc.SetInstallationAllowedModels(c.Request.Context(), installation.ExternalID, installation.ID, req.Allowed, allowed)
+		if err != nil {
+			if errors.Is(err, auth.ErrUnknownModel) {
+				c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+				return
+			}
+			log.Error("Failed to update allowed models", "err", err, "installation_id", installation.ID)
+			c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"error": "Failed to update allowed models."})
+			return
+		}
+
+		sort.Strings(stored)
+		c.JSON(http.StatusOK, allowedModelsResponse{
+			Available: deployedModelsDTO(models),
+			Allowed:   stored,
+		})
+	}
+}

--- a/internal/auth/installation.go
+++ b/internal/auth/installation.go
@@ -20,6 +20,12 @@ type Installation struct {
 	// ExcludedModels is the per-installation model exclusion list.
 	// Empty means no exclusion.
 	ExcludedModels []string
+	// AllowedModels is the per-installation positive model allowlist: when
+	// non-empty, routing is confined to these models. Composes with (does not
+	// replace) ExcludedModels — the effective set is AllowedModels minus
+	// ExcludedModels. Empty means no restriction. Fail-closed: an allowlist
+	// with no eligible overlap refuses the turn.
+	AllowedModels []string
 	// ExcludedProviders is the per-installation provider exclusion list.
 	// Empty means no exclusion.
 	ExcludedProviders []string
@@ -97,6 +103,10 @@ type InstallationRepository interface {
 	// UpdateExcludedModels replaces the per-installation exclusion list.
 	// An empty (or nil) slice clears the list.
 	UpdateExcludedModels(ctx context.Context, externalID, id string, models []string) error
+	// UpdateAllowedModels replaces the per-installation positive model
+	// allowlist. An empty (or nil) slice clears it, which means "no
+	// restriction" — NOT "no models routable".
+	UpdateAllowedModels(ctx context.Context, externalID, id string, models []string) error
 	// UpdateExcludedProviders replaces the per-installation provider
 	// exclusion list. An empty (or nil) slice clears the list.
 	UpdateExcludedProviders(ctx context.Context, externalID, id string, providerNames []string) error

--- a/internal/auth/installation.go
+++ b/internal/auth/installation.go
@@ -20,11 +20,9 @@ type Installation struct {
 	// ExcludedModels is the per-installation model exclusion list.
 	// Empty means no exclusion.
 	ExcludedModels []string
-	// AllowedModels is the per-installation positive model allowlist: when
-	// non-empty, routing is confined to these models. Composes with (does not
-	// replace) ExcludedModels — the effective set is AllowedModels minus
-	// ExcludedModels. Empty means no restriction. Fail-closed: an allowlist
-	// with no eligible overlap refuses the turn.
+	// AllowedModels is the org's positive model allowlist; when non-empty,
+	// routing is confined to these models minus ExcludedModels.
+	// Empty = no restriction; fail-closed when no eligible overlap remains.
 	AllowedModels []string
 	// ExcludedProviders is the per-installation provider exclusion list.
 	// Empty means no exclusion.

--- a/internal/auth/service.go
+++ b/internal/auth/service.go
@@ -388,10 +388,9 @@ func (s *Service) SetInstallationExcludedModels(ctx context.Context, externalID,
 }
 
 // SetInstallationAllowedModels replaces the per-installation positive model
-// allowlist. An empty list clears the restriction (all deployed models
-// routable) — it does NOT mean "no models". allowed is the set of valid model
-// IDs; passing nil skips validation, and validation is skipped entirely when
-// models is empty so a catalog outage can never block clearing a restriction.
+// allowlist. Empty list clears the restriction (all models routable — NOT "no
+// models"). Validation skipped when models is empty so a catalog outage can't
+// block clearing a restriction; pass nil allowed to skip validation entirely.
 func (s *Service) SetInstallationAllowedModels(ctx context.Context, externalID, installationID string, models []string, allowed map[string]struct{}) ([]string, error) {
 	if models == nil {
 		models = []string{}

--- a/internal/auth/service.go
+++ b/internal/auth/service.go
@@ -387,6 +387,39 @@ func (s *Service) SetInstallationExcludedModels(ctx context.Context, externalID,
 	return out, nil
 }
 
+// SetInstallationAllowedModels replaces the per-installation positive model
+// allowlist. An empty list clears the restriction (all deployed models
+// routable) — it does NOT mean "no models". allowed is the set of valid model
+// IDs; passing nil skips validation, and validation is skipped entirely when
+// models is empty so a catalog outage can never block clearing a restriction.
+func (s *Service) SetInstallationAllowedModels(ctx context.Context, externalID, installationID string, models []string, allowed map[string]struct{}) ([]string, error) {
+	if models == nil {
+		models = []string{}
+	}
+	if allowed != nil && len(models) > 0 {
+		for _, m := range models {
+			if _, ok := allowed[m]; !ok {
+				return nil, fmt.Errorf("%w: %q", ErrUnknownModel, m)
+			}
+		}
+	}
+	// De-dupe while preserving order so the persisted list is stable.
+	seen := make(map[string]struct{}, len(models))
+	out := make([]string, 0, len(models))
+	for _, m := range models {
+		if _, dup := seen[m]; dup {
+			continue
+		}
+		seen[m] = struct{}{}
+		out = append(out, m)
+	}
+	if err := s.installations.UpdateAllowedModels(ctx, externalID, installationID, out); err != nil {
+		return nil, err
+	}
+	s.invalidateInstallation(installationID)
+	return out, nil
+}
+
 // SetInstallationExcludedProviders replaces the per-installation provider exclusion list.
 // allowed is the set of valid provider names; passing nil skips validation.
 func (s *Service) SetInstallationExcludedProviders(ctx context.Context, externalID, installationID string, providerNames []string, allowed map[string]struct{}) ([]string, error) {

--- a/internal/auth/service_test.go
+++ b/internal/auth/service_test.go
@@ -136,6 +136,8 @@ func (f *fakeExternalAPIKeyRepo) MarkUsed(ctx context.Context, id string) error 
 type fakeInstallationRepository struct {
 	excludedModelsByID              map[string][]string
 	excludedModelsExternalByID      map[string]string
+	allowedModelsByID               map[string][]string
+	allowedModelsExternalByID       map[string]string
 	excludedProvidersByID           map[string][]string
 	excludedProvidersExternalByID   map[string]string
 	routingQualityByID              map[string]*float64
@@ -174,6 +176,20 @@ func (f *fakeInstallationRepository) UpdateExcludedModels(ctx context.Context, e
 	}
 	f.excludedModelsByID[id] = append([]string{}, models...)
 	f.excludedModelsExternalByID[id] = externalID
+	return nil
+}
+func (f *fakeInstallationRepository) UpdateAllowedModels(ctx context.Context, externalID, id string, models []string) error {
+	if f.updateErr != nil {
+		return f.updateErr
+	}
+	if f.allowedModelsByID == nil {
+		f.allowedModelsByID = map[string][]string{}
+	}
+	if f.allowedModelsExternalByID == nil {
+		f.allowedModelsExternalByID = map[string]string{}
+	}
+	f.allowedModelsByID[id] = append([]string{}, models...)
+	f.allowedModelsExternalByID[id] = externalID
 	return nil
 }
 func (f *fakeInstallationRepository) UpdateExcludedProviders(ctx context.Context, externalID, id string, providerNames []string) error {

--- a/internal/postgres/converters.go
+++ b/internal/postgres/converters.go
@@ -24,6 +24,10 @@ func toAuthInstallation(row sqlc.RouterModelRouterInstallation) *auth.Installati
 	if preferred == nil {
 		preferred = []string{}
 	}
+	allowed := row.AllowedModels
+	if allowed == nil {
+		allowed = []string{}
+	}
 	return &auth.Installation{
 		ID:                           row.ID.String(),
 		ExternalID:                   row.ExternalID,
@@ -33,6 +37,7 @@ func toAuthInstallation(row sqlc.RouterModelRouterInstallation) *auth.Installati
 		DeletedAt:                    timestampPtr(row.DeletedAt),
 		CreatedBy:                    row.CreatedBy,
 		ExcludedModels:               excluded,
+		AllowedModels:                allowed,
 		ExcludedProviders:            excludedProviders,
 		PreferredModels:              preferred,
 		RoutingQualityWeight:         row.RoutingQualityWeight,

--- a/internal/postgres/repository.go
+++ b/internal/postgres/repository.go
@@ -117,6 +117,29 @@ func (r *installationRepo) UpdateExcludedModels(ctx context.Context, externalID,
 	return nil
 }
 
+func (r *installationRepo) UpdateAllowedModels(ctx context.Context, externalID, id string, models []string) error {
+	parsed, err := uuid.Parse(id)
+	if err != nil {
+		return err
+	}
+	if models == nil {
+		models = []string{}
+	}
+	q := sqlc.New(r.tx)
+	rows, err := q.UpdateModelRouterInstallationAllowedModels(ctx, sqlc.UpdateModelRouterInstallationAllowedModelsParams{
+		ID:            parsed,
+		ExternalID:    externalID,
+		AllowedModels: models,
+	})
+	if err != nil {
+		return err
+	}
+	if rows == 0 {
+		return auth.ErrInstallationNotFound
+	}
+	return nil
+}
+
 func (r *installationRepo) UpdateExcludedProviders(ctx context.Context, externalID, id string, providerNames []string) error {
 	parsed, err := uuid.Parse(id)
 	if err != nil {

--- a/internal/proxy/allowlist_internal_test.go
+++ b/internal/proxy/allowlist_internal_test.go
@@ -1,0 +1,127 @@
+package proxy
+
+import (
+	"context"
+	"testing"
+
+	"workweave/router/internal/router/catalog"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func ctxWithAllowedModels(models ...string) context.Context {
+	return context.WithValue(context.Background(), InstallationAllowedModelsContextKey{}, models)
+}
+
+func ctxWithExcludedAndAllowed(excluded, allowed []string) context.Context {
+	ctx := context.Background()
+	if len(excluded) > 0 {
+		ctx = context.WithValue(ctx, InstallationExcludedModelsContextKey{}, excluded)
+	}
+	if len(allowed) > 0 {
+		ctx = context.WithValue(ctx, InstallationAllowedModelsContextKey{}, allowed)
+	}
+	return ctx
+}
+
+func TestAllowedModelsForRequest_EmptyMeansNoRestriction(t *testing.T) {
+	assert.Nil(t, allowedModelsForRequest(context.Background()))
+	assert.Nil(t, allowedModelsForRequest(ctxWithAllowedModels()))
+}
+
+func TestAllowedModelsForRequest_BuildsSet(t *testing.T) {
+	got := allowedModelsForRequest(ctxWithAllowedModels("a", "b"))
+	assert.Equal(t, map[string]struct{}{"a": {}, "b": {}}, got)
+}
+
+// The allowlist is enforced by desugaring into the exclusion set: every
+// routable model absent from a non-empty allowlist must come back excluded.
+func TestExcludedModelsForRequest_AllowlistExcludesTheComplement(t *testing.T) {
+	s := &Service{availableModels: map[string]struct{}{
+		"keep-me": {}, "drop-me": {}, "drop-me-too": {},
+	}}
+
+	got := s.excludedModelsForRequest(ctxWithAllowedModels("keep-me"))
+
+	require.NotNil(t, got)
+	assert.NotContains(t, got, "keep-me")
+	assert.Contains(t, got, "drop-me")
+	assert.Contains(t, got, "drop-me-too")
+}
+
+// Allowlist and exclusions compose: effective set = allowlist minus exclusions.
+func TestExcludedModelsForRequest_AllowlistUnionsWithExclusions(t *testing.T) {
+	s := &Service{availableModels: map[string]struct{}{
+		"a": {}, "b": {}, "c": {},
+	}}
+
+	got := s.excludedModelsForRequest(ctxWithExcludedAndAllowed([]string{"b"}, []string{"a", "b"}))
+
+	// c is excluded by the allowlist, b by the explicit exclusion, leaving a.
+	assert.NotContains(t, got, "a")
+	assert.Contains(t, got, "b")
+	assert.Contains(t, got, "c")
+}
+
+func TestExcludedModelsForRequest_EmptyAllowlistIsANoOp(t *testing.T) {
+	s := &Service{availableModels: map[string]struct{}{"a": {}, "b": {}}}
+
+	assert.Nil(t, s.excludedModelsForRequest(context.Background()))
+
+	got := s.excludedModelsForRequest(ctxWithExcludedAndAllowed([]string{"a"}, nil))
+	assert.Equal(t, map[string]struct{}{"a": {}}, got)
+}
+
+// An allowlist entry naming a model this deployment can't serve is a harmless
+// no-op rather than an error — a stale entry after a catalog removal must not
+// break routing for the models that remain.
+func TestExcludedModelsForRequest_UndeployedAllowlistEntryIgnored(t *testing.T) {
+	s := &Service{availableModels: map[string]struct{}{"a": {}, "b": {}}}
+
+	got := s.excludedModelsForRequest(ctxWithAllowedModels("a", "retired-model"))
+
+	assert.NotContains(t, got, "a")
+	assert.Contains(t, got, "b")
+	assert.NotContains(t, got, "retired-model")
+}
+
+// The env override is a deliberate operator escape hatch: an operator debugging
+// a deployment is not silently constrained by one org's allowlist.
+func TestExcludedModelsForRequest_EnvOverrideBypassesAllowlist(t *testing.T) {
+	override := map[string]struct{}{"env-excluded": {}}
+	s := &Service{
+		availableModels:        map[string]struct{}{"a": {}, "b": {}},
+		excludedModelsOverride: override,
+	}
+
+	got := s.excludedModelsForRequest(ctxWithAllowedModels("a"))
+
+	assert.Equal(t, override, got)
+	assert.NotContains(t, got, "b")
+}
+
+// nil availableModels means "every catalog model is routable". Missing this
+// would make the allowlist a silent no-op on such deployments.
+func TestRoutableUniverse_NilAvailableModelsFallsBackToCatalog(t *testing.T) {
+	s := &Service{}
+
+	universe := s.routableUniverse()
+
+	require.NotEmpty(t, universe)
+	assert.Len(t, universe, len(catalog.Models))
+	for _, m := range catalog.Models {
+		assert.Contains(t, universe, m.ID)
+	}
+}
+
+func TestExcludedModelsForRequest_AllowlistAppliesWithNilAvailableModels(t *testing.T) {
+	s := &Service{}
+	require.NotEmpty(t, catalog.Models, "catalog must be non-empty for this test to mean anything")
+	keep := catalog.Models[0].ID
+
+	got := s.excludedModelsForRequest(ctxWithAllowedModels(keep))
+
+	assert.NotContains(t, got, keep)
+	assert.Len(t, got, len(catalog.Models)-1)
+}

--- a/internal/proxy/baseline_internal_test.go
+++ b/internal/proxy/baseline_internal_test.go
@@ -35,11 +35,8 @@ func TestWithDefaultBaselineModel(t *testing.T) {
 	assert.Equal(t, "claude-sonnet-4-5", s.defaultBaselineModel)
 }
 
-// The baseline is derived from the client's requested model, which can be a
-// passthrough-only catalog model — and passthrough models never enter the
-// desugared exclusion set. If the baseline rescue path read only
-// ExcludedModels, an allowed model's dispatch failure would rescue the turn
-// onto a model the org prohibits.
+// The baseline rescue path must check the allowlist directly: passthrough-only
+// models never enter the desugared exclusion set, so ExcludedModels alone won't block them.
 func TestBaselineModelPermittedByAllowlist(t *testing.T) {
 	restricted := context.WithValue(context.Background(),
 		InstallationAllowedModelsContextKey{}, []string{"claude-opus-5"})

--- a/internal/proxy/baseline_internal_test.go
+++ b/internal/proxy/baseline_internal_test.go
@@ -1,6 +1,7 @@
 package proxy
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -32,4 +33,22 @@ func TestWithDefaultBaselineModel(t *testing.T) {
 	s := &Service{}
 	s.WithDefaultBaselineModel("claude-sonnet-4-5")
 	assert.Equal(t, "claude-sonnet-4-5", s.defaultBaselineModel)
+}
+
+// The baseline is derived from the client's requested model, which can be a
+// passthrough-only catalog model — and passthrough models never enter the
+// desugared exclusion set. If the baseline rescue path read only
+// ExcludedModels, an allowed model's dispatch failure would rescue the turn
+// onto a model the org prohibits.
+func TestBaselineModelPermittedByAllowlist(t *testing.T) {
+	restricted := context.WithValue(context.Background(),
+		InstallationAllowedModelsContextKey{}, []string{"claude-opus-5"})
+
+	assert.True(t, modelPermittedByAllowlist(restricted, "claude-opus-5"),
+		"an allowlisted model clears the gate")
+	assert.False(t, modelPermittedByAllowlist(restricted, "claude-opus-4-8"),
+		"a passthrough-only model outside the allowlist must NOT be rescued to")
+
+	assert.True(t, modelPermittedByAllowlist(context.Background(), "claude-opus-4-8"),
+		"no allowlist means no restriction, so passthrough stays servable")
 }

--- a/internal/proxy/dispatch_error.go
+++ b/internal/proxy/dispatch_error.go
@@ -32,6 +32,7 @@ const (
 	DispatchErrorProviderNotConfigured
 	DispatchErrorRequestNotJSONObject
 	DispatchErrorNoEligibleProvider
+	DispatchErrorAllowlistEmptiesPool
 	DispatchErrorContextWindowExceeded
 	DispatchErrorInvalidRoutingKnobs
 	DispatchErrorRLPolicyUnavailable
@@ -170,6 +171,17 @@ func ClassifyDispatchError(err error) (DispatchErrorClass, bool) {
 			LogLevel:   "warn",
 			LogMessage: "Compatible translation provider unavailable",
 		}, true
+	// Must precede the ErrNoEligibleProvider case: ErrAllowlistEmptiesPool
+	// wraps it, so the generic case would otherwise match first and report a
+	// missing-provider-keys problem for what is actually a config decision.
+	case errors.Is(err, cluster.ErrAllowlistEmptiesPool):
+		return DispatchErrorClass{
+			Kind:       DispatchErrorAllowlistEmptiesPool,
+			Status:     http.StatusBadRequest,
+			Message:    "No allowed model can serve this request: your organization's model allowlist has no eligible overlap. Ask your org admin to widen it.",
+			LogLevel:   "warn",
+			LogMessage: "Model allowlist leaves no eligible candidates",
+		}, true
 	case errors.Is(err, cluster.ErrNoEligibleProvider):
 		return DispatchErrorClass{
 			Kind:       DispatchErrorNoEligibleProvider,
@@ -287,7 +299,7 @@ func unwrapToSentinelMessage(err error) string {
 // rather than "api_error".
 func (k DispatchErrorKind) IsClientError() bool {
 	switch k {
-	case DispatchErrorRequestNotJSONObject, DispatchErrorNoEligibleProvider, DispatchErrorContextWindowExceeded, DispatchErrorInvalidRoutingKnobs, DispatchErrorTranslationIntrinsicallyIncompatible, DispatchErrorAnthropicCacheControlInvalid, DispatchErrorForcedModelExcluded, DispatchErrorForcedModelUnknown, DispatchErrorForcedClusterUnsupportedStrategy, DispatchErrorForcedClusterUnservable:
+	case DispatchErrorRequestNotJSONObject, DispatchErrorNoEligibleProvider, DispatchErrorAllowlistEmptiesPool, DispatchErrorContextWindowExceeded, DispatchErrorInvalidRoutingKnobs, DispatchErrorTranslationIntrinsicallyIncompatible, DispatchErrorAnthropicCacheControlInvalid, DispatchErrorForcedModelExcluded, DispatchErrorForcedModelUnknown, DispatchErrorForcedClusterUnsupportedStrategy, DispatchErrorForcedClusterUnservable:
 		return true
 	default:
 		return false

--- a/internal/proxy/dispatch_error_test.go
+++ b/internal/proxy/dispatch_error_test.go
@@ -68,6 +68,23 @@ func TestClassifyDispatchError_NoEligibleProviderIsClientErrorAndWarns(t *testin
 	assert.False(t, cls.RetryAfter)
 }
 
+// The allowlist sentinel wraps ErrNoEligibleProvider, so ordering in the
+// classifier's switch is load-bearing: the generic case would otherwise match
+// first and tell an admin they have no provider keys when in fact their own
+// allowlist is the cause.
+func TestClassifyDispatchError_AllowlistEmptiesPoolPrecedesNoEligibleProvider(t *testing.T) {
+	cls, ok := proxy.ClassifyDispatchError(cluster.ErrAllowlistEmptiesPool)
+
+	require.True(t, ok)
+	assert.Equal(t, proxy.DispatchErrorAllowlistEmptiesPool, cls.Kind)
+	assert.NotEqual(t, proxy.DispatchErrorNoEligibleProvider, cls.Kind, "must not fall through to the generic no-eligible-provider case")
+	assert.Equal(t, http.StatusBadRequest, cls.Status)
+	assert.True(t, cls.Kind.IsClientError())
+	assert.Equal(t, "warn", cls.LogLevel)
+	assert.False(t, cls.RetryAfter)
+	assert.Contains(t, cls.Message, "allowlist")
+}
+
 func TestClassifyDispatchError_BanditRLandHMMUnavailableRetry(t *testing.T) {
 	for _, err := range []error{bandit.ErrBanditUnavailable, rl.ErrPolicyUnavailable, hmm.ErrHMMUnavailable} {
 		cls, ok := proxy.ClassifyDispatchError(err)

--- a/internal/proxy/dispatch_error_test.go
+++ b/internal/proxy/dispatch_error_test.go
@@ -68,10 +68,8 @@ func TestClassifyDispatchError_NoEligibleProviderIsClientErrorAndWarns(t *testin
 	assert.False(t, cls.RetryAfter)
 }
 
-// The allowlist sentinel wraps ErrNoEligibleProvider, so ordering in the
-// classifier's switch is load-bearing: the generic case would otherwise match
-// first and tell an admin they have no provider keys when in fact their own
-// allowlist is the cause.
+// ErrAllowlistEmptiesPool wraps ErrNoEligibleProvider, so switch ordering is
+// load-bearing: the generic case must not match first and misattribute the cause.
 func TestClassifyDispatchError_AllowlistEmptiesPoolPrecedesNoEligibleProvider(t *testing.T) {
 	cls, ok := proxy.ClassifyDispatchError(cluster.ErrAllowlistEmptiesPool)
 

--- a/internal/proxy/force_model_exclusions.go
+++ b/internal/proxy/force_model_exclusions.go
@@ -36,6 +36,14 @@ func (e *ForcedModelExcludedError) Unwrap() error { return ErrForcedModelExclude
 // pin the fallback — otherwise the eligibility check in runTurnLoop drops it.
 func (s *Service) forcedModelBinding(ctx context.Context, model, provider string) (binding, reason string) {
 	if _, drop := s.excludedModelsForRequest(ctx)[model]; drop {
+		// The allowlist is desugared into the exclusion set, so distinguish the
+		// two here — telling an engineer their model is "excluded" when the org
+		// simply never allowlisted it sends them to the wrong setting.
+		if allowed := allowedModelsForRequest(ctx); len(allowed) > 0 {
+			if _, ok := allowed[model]; !ok {
+				return "", fmt.Sprintf("%s is not on this organization's allowed-model list", model)
+			}
+		}
 		return "", fmt.Sprintf("%s is excluded on this installation", model)
 	}
 	excluded := s.policyExcludedProviders(ctx)

--- a/internal/proxy/force_model_exclusions.go
+++ b/internal/proxy/force_model_exclusions.go
@@ -35,15 +35,12 @@ func (e *ForcedModelExcludedError) Unwrap() error { return ErrForcedModelExclude
 // a model's primary, so an excluded primary whose fallback is permitted must
 // pin the fallback — otherwise the eligibility check in runTurnLoop drops it.
 func (s *Service) forcedModelBinding(ctx context.Context, model, provider string) (binding, reason string) {
+	// Checked directly, not via the exclusion set: a forced model may be
+	// passthrough-only and so never enters the desugared exclusions.
+	if !modelPermittedByAllowlist(ctx, model) {
+		return "", fmt.Sprintf("%s is not on this organization's allowed-model list", model)
+	}
 	if _, drop := s.excludedModelsForRequest(ctx)[model]; drop {
-		// The allowlist is desugared into the exclusion set, so distinguish the
-		// two here — telling an engineer their model is "excluded" when the org
-		// simply never allowlisted it sends them to the wrong setting.
-		if allowed := allowedModelsForRequest(ctx); len(allowed) > 0 {
-			if _, ok := allowed[model]; !ok {
-				return "", fmt.Sprintf("%s is not on this organization's allowed-model list", model)
-			}
-		}
 		return "", fmt.Sprintf("%s is excluded on this installation", model)
 	}
 	excluded := s.policyExcludedProviders(ctx)

--- a/internal/proxy/force_model_exclusions_internal_test.go
+++ b/internal/proxy/force_model_exclusions_internal_test.go
@@ -393,3 +393,55 @@ func TestClassifyDispatchError_ForcedModelExcluded(t *testing.T) {
 	assert.Contains(t, cls.Message, "claude-opus-5")
 	assert.Contains(t, cls.Message, "/unforce-model")
 }
+
+// TestForcedModelBinding_RejectsPassthroughModelOutsideAllowlist covers the
+// hole the allowlist desugaring cannot close on its own: the desugaring only
+// excludes members of routableUniverse, and claude-opus-4-8 is passthrough-only
+// (priced, no Tier) so it is never in that set. Checking only ExcludedModels
+// would let an org that allowlists just claude-opus-5 still force and serve it.
+func TestForcedModelBinding_RejectsPassthroughModelOutsideAllowlist(t *testing.T) {
+	svc := NewService(nil, nil, nil, false, nil, nil, false,
+		providers.ProviderAnthropic, "claude-haiku-4-5", nil).
+		WithDeploymentKeyedProviders(keyed(providers.ProviderAnthropic)).
+		// availableModels set to a routing-targets-only universe, matching
+		// production (catalog.RoutingTargetSet excludes passthrough-only
+		// models) — nil here would enumerate the whole catalog and mask the
+		// hole this test exists to close.
+		WithAvailableModels(map[string]struct{}{"claude-opus-5": {}})
+
+	ctx := context.WithValue(context.Background(),
+		InstallationAllowedModelsContextKey{}, []string{"claude-opus-5"})
+
+	binding, reason := svc.forcedModelBinding(ctx, "claude-opus-4-8", providers.ProviderAnthropic)
+
+	assert.Empty(t, binding, "a passthrough model outside the allowlist must not resolve a binding")
+	assert.Contains(t, reason, "allowed-model list",
+		"the refusal must name the allowlist, not a generic exclusion")
+}
+
+// The allowlist must only ever narrow: an allowlisted model still forces fine.
+func TestForcedModelBinding_AllowsPassthroughModelInsideAllowlist(t *testing.T) {
+	svc := NewService(nil, nil, nil, false, nil, nil, false,
+		providers.ProviderAnthropic, "claude-haiku-4-5", nil).
+		WithDeploymentKeyedProviders(keyed(providers.ProviderAnthropic))
+
+	ctx := context.WithValue(context.Background(),
+		InstallationAllowedModelsContextKey{}, []string{"claude-opus-4-8"})
+
+	binding, reason := svc.forcedModelBinding(ctx, "claude-opus-4-8", providers.ProviderAnthropic)
+
+	assert.Empty(t, reason)
+	assert.Equal(t, providers.ProviderAnthropic, binding)
+}
+
+// No allowlist configured = no restriction, so passthrough forcing is unchanged.
+func TestForcedModelBinding_NoAllowlistLeavesPassthroughForcingUnchanged(t *testing.T) {
+	svc := NewService(nil, nil, nil, false, nil, nil, false,
+		providers.ProviderAnthropic, "claude-haiku-4-5", nil).
+		WithDeploymentKeyedProviders(keyed(providers.ProviderAnthropic))
+
+	binding, reason := svc.forcedModelBinding(context.Background(), "claude-opus-4-8", providers.ProviderAnthropic)
+
+	assert.Empty(t, reason)
+	assert.Equal(t, providers.ProviderAnthropic, binding)
+}

--- a/internal/proxy/force_model_exclusions_internal_test.go
+++ b/internal/proxy/force_model_exclusions_internal_test.go
@@ -394,19 +394,14 @@ func TestClassifyDispatchError_ForcedModelExcluded(t *testing.T) {
 	assert.Contains(t, cls.Message, "/unforce-model")
 }
 
-// TestForcedModelBinding_RejectsPassthroughModelOutsideAllowlist covers the
-// hole the allowlist desugaring cannot close on its own: the desugaring only
-// excludes members of routableUniverse, and claude-opus-4-8 is passthrough-only
-// (priced, no Tier) so it is never in that set. Checking only ExcludedModels
-// would let an org that allowlists just claude-opus-5 still force and serve it.
+// Desugaring only covers routableUniverse; claude-opus-4-8 is passthrough-only
+// and never in that set, so the allowlist check in forcedModelBinding must be direct.
 func TestForcedModelBinding_RejectsPassthroughModelOutsideAllowlist(t *testing.T) {
 	svc := NewService(nil, nil, nil, false, nil, nil, false,
 		providers.ProviderAnthropic, "claude-haiku-4-5", nil).
 		WithDeploymentKeyedProviders(keyed(providers.ProviderAnthropic)).
-		// availableModels set to a routing-targets-only universe, matching
-		// production (catalog.RoutingTargetSet excludes passthrough-only
-		// models) — nil here would enumerate the whole catalog and mask the
-		// hole this test exists to close.
+		// nil availableModels enumerates the full catalog and masks the passthrough-
+		// only bypass; must be a routing-targets-only universe.
 		WithAvailableModels(map[string]struct{}{"claude-opus-5": {}})
 
 	ctx := context.WithValue(context.Background(),

--- a/internal/proxy/gemini.go
+++ b/internal/proxy/gemini.go
@@ -111,6 +111,7 @@ func (s *Service) ProxyGeminiGenerateContent(ctx context.Context, body []byte, w
 		EnabledProviders:             s.enabledProvidersForRequest(ctx, providers.ProviderGoogle, r.Header),
 		CustomBindings:               s.customBindingsForRequest(ctx),
 		ExcludedModels:               s.excludedModelsForRequest(ctx),
+		AllowedModels:                allowedModelsForRequest(ctx),
 		PreferredModels:              s.preferredModelsForRequest(ctx),
 		RoutingKnobs:                 router.RoutingKnobsFromContext(ctx),
 		ClusterArmOverrides:          clusterArmOverridesForRequest(ctx),

--- a/internal/proxy/route_preview.go
+++ b/internal/proxy/route_preview.go
@@ -83,6 +83,7 @@ func (s *Service) anthropicRoutingRequest(ctx context.Context, body []byte, head
 		EnabledProviders:             enabledProviders,
 		CustomBindings:               s.customBindingsForRequest(ctx),
 		ExcludedModels:               excluded,
+		AllowedModels:                allowedModelsForRequest(ctx),
 		PreferredModels:              s.preferredModelsForRequest(ctx),
 		RoutingKnobs:                 routingKnobsForRequest(ctx),
 	}, nil

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -662,6 +662,21 @@ func allowedModelsForRequest(ctx context.Context) map[string]struct{} {
 	return out
 }
 
+// modelPermittedByAllowlist reports whether model clears the org's positive
+// allowlist. Callers that resolve a model OUTSIDE routableUniverse must use
+// this rather than relying on the ExcludedModels desugaring: the desugaring
+// only excludes members of that universe, so a passthrough-only model (priced,
+// no Tier) never lands in the exclusion set and would otherwise slip past the
+// allowlist. Empty allowlist = no restriction.
+func modelPermittedByAllowlist(ctx context.Context, model string) bool {
+	allowed := allowedModelsForRequest(ctx)
+	if len(allowed) == 0 {
+		return true
+	}
+	_, ok := allowed[model]
+	return ok
+}
+
 // routableUniverse is every model this deployment can serve: the configured
 // availableModels set, or the whole catalog when it is nil. Extracted so the
 // allowlist desugaring and restrictToTier share one universe definition and
@@ -728,12 +743,9 @@ func (s *Service) safetyExcludedModels(env *translate.RequestEnvelope, outputRes
 }
 
 // excludedModelsForRequest returns the request's model exclusion set.
-// Env override wins — an operator debugging a deployment is deliberately not
-// constrained by per-org config; this is an intentional escape hatch, not an
-// oversight. Otherwise the installation list is converted to a set, then
-// desugared with the positive allowlist: every routable model absent from a
-// non-empty allowlist is excluded, so the allowlist is fail-closed by reusing
-// exactly the exclusion machinery.
+// Env override wins (intentional escape hatch, not an oversight).
+// Otherwise desugars the positive allowlist into the exclusion set:
+// every routable model absent from a non-empty allowlist is excluded.
 func (s *Service) excludedModelsForRequest(ctx context.Context) map[string]struct{} {
 	if s.excludedModelsOverride != nil {
 		return s.excludedModelsOverride
@@ -3089,12 +3101,14 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 	baselineModel := s.baselineFor(feats.Model)
 	baselineCatalog, baselineKnown := catalog.ByID(baselineModel)
 	_, anthropicExcluded := s.excludedProvidersForRequest(ctx)[providers.ProviderAnthropic]
+	baselineAllowed := modelPermittedByAllowlist(ctx, baselineModel)
 	// baselineViable omits authoritative-per-turn: that contract governs which
 	// model the policy picks, not whether a provably-unservable request can be rescued.
 	baselineViable := !agentShadowMode &&
 		decision.Reason != translate.ReasonUserForceModel &&
 		s.shouldFailover(ctx) &&
 		!anthropicExcluded &&
+		baselineAllowed &&
 		decision.Provider != providers.ProviderAnthropic &&
 		baselineModel != decision.Model &&
 		baselineKnown && baselineCatalog.PrimaryProvider() == providers.ProviderAnthropic

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -357,6 +357,11 @@ type nativeResponsesToolHashContextKey struct{}
 // installation's model exclusion list. Carried as []string.
 type InstallationExcludedModelsContextKey struct{}
 
+// InstallationAllowedModelsContextKey is the context key for the authed
+// installation's positive model allowlist. Carried as []string; empty/absent
+// means no restriction.
+type InstallationAllowedModelsContextKey struct{}
+
 // InstallationExcludedProvidersContextKey is the context key for the authed
 // installation's provider exclusion list. Carried as []string.
 type InstallationExcludedProvidersContextKey struct{}
@@ -632,6 +637,46 @@ func installationExcludedModelsFromContext(ctx context.Context) []string {
 	return out
 }
 
+// installationAllowedModelsFromContext returns the per-installation positive
+// allowlist stashed on ctx by the auth middleware, or nil when absent.
+func installationAllowedModelsFromContext(ctx context.Context) []string {
+	v := ctx.Value(InstallationAllowedModelsContextKey{})
+	if v == nil {
+		return nil
+	}
+	out, _ := v.([]string)
+	return out
+}
+
+// allowedModelsForRequest returns the org's positive model allowlist as a set,
+// or nil when empty (no restriction).
+func allowedModelsForRequest(ctx context.Context) map[string]struct{} {
+	allowed := installationAllowedModelsFromContext(ctx)
+	if len(allowed) == 0 {
+		return nil
+	}
+	out := make(map[string]struct{}, len(allowed))
+	for _, m := range allowed {
+		out[m] = struct{}{}
+	}
+	return out
+}
+
+// routableUniverse is every model this deployment can serve: the configured
+// availableModels set, or the whole catalog when it is nil. Extracted so the
+// allowlist desugaring and restrictToTier share one universe definition and
+// cannot drift.
+func (s *Service) routableUniverse() map[string]struct{} {
+	if s.availableModels != nil {
+		return s.availableModels
+	}
+	out := make(map[string]struct{}, len(catalog.Models))
+	for _, m := range catalog.Models {
+		out[m.ID] = struct{}{}
+	}
+	return out
+}
+
 // subscriptionRoutingDisabledForRequest reports whether the authed installation
 // has turned off subscription-aware routing. When true, the subscription
 // subsidy bonus is suppressed for this request so routing decides on merits.
@@ -683,18 +728,30 @@ func (s *Service) safetyExcludedModels(env *translate.RequestEnvelope, outputRes
 }
 
 // excludedModelsForRequest returns the request's model exclusion set.
-// Env override wins; otherwise the installation list is converted to a set.
+// Env override wins — an operator debugging a deployment is deliberately not
+// constrained by per-org config; this is an intentional escape hatch, not an
+// oversight. Otherwise the installation list is converted to a set, then
+// desugared with the positive allowlist: every routable model absent from a
+// non-empty allowlist is excluded, so the allowlist is fail-closed by reusing
+// exactly the exclusion machinery.
 func (s *Service) excludedModelsForRequest(ctx context.Context) map[string]struct{} {
 	if s.excludedModelsOverride != nil {
 		return s.excludedModelsOverride
 	}
 	excluded := installationExcludedModelsFromContext(ctx)
-	if len(excluded) == 0 {
-		return nil
-	}
 	out := make(map[string]struct{}, len(excluded))
 	for _, m := range excluded {
 		out[m] = struct{}{}
+	}
+	if allowed := allowedModelsForRequest(ctx); len(allowed) > 0 {
+		for model := range s.routableUniverse() {
+			if _, ok := allowed[model]; !ok {
+				out[model] = struct{}{}
+			}
+		}
+	}
+	if len(out) == 0 {
+		return nil
 	}
 	return out
 }
@@ -2496,6 +2553,7 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 		EnabledProviders:     enabledProviders,
 		CustomBindings:       s.customBindingsForRequest(ctx),
 		ExcludedModels:       excluded,
+		AllowedModels:        allowedModelsForRequest(ctx),
 		SafetyExcludedModels: s.safetyExcludedModels(env, outputReserve),
 		PreferredModels:      s.preferredModelsForRequest(ctx),
 		RoutingKnobs:         routingKnobsForRequest(ctx),
@@ -4899,6 +4957,7 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 		EnabledProviders:     enabledProviders,
 		CustomBindings:       s.customBindingsForRequest(ctx),
 		ExcludedModels:       excludedOAI,
+		AllowedModels:        allowedModelsForRequest(ctx),
 		SafetyExcludedModels: s.safetyExcludedModels(env, outputReserveOAI),
 		PreferredModels:      s.preferredModelsForRequest(ctx),
 		RoutingKnobs:         routingKnobsForRequest(ctx),

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -663,11 +663,9 @@ func allowedModelsForRequest(ctx context.Context) map[string]struct{} {
 }
 
 // modelPermittedByAllowlist reports whether model clears the org's positive
-// allowlist. Callers that resolve a model OUTSIDE routableUniverse must use
-// this rather than relying on the ExcludedModels desugaring: the desugaring
-// only excludes members of that universe, so a passthrough-only model (priced,
-// no Tier) never lands in the exclusion set and would otherwise slip past the
-// allowlist. Empty allowlist = no restriction.
+// allowlist. Must be used directly for models outside routableUniverse —
+// passthrough-only models (no Tier) never enter the desugared exclusion set.
+// Empty allowlist = no restriction.
 func modelPermittedByAllowlist(ctx context.Context, model string) bool {
 	allowed := allowedModelsForRequest(ctx)
 	if len(allowed) == 0 {

--- a/internal/proxy/usage_bypass.go
+++ b/internal/proxy/usage_bypass.go
@@ -89,12 +89,9 @@ func (s *Service) usageBypassEngaged(ctx context.Context, headers http.Header, r
 	if _, excluded := req.SafetyExcludedModels[model]; excluded {
 		return "", false
 	}
-	// The org's positive allowlist is NOT a routing preference — it is a
-	// compliance boundary, so unlike excluded_models the bypass must honor it.
-	// Checked explicitly rather than via SafetyExcludedModels, which has other
-	// readers with different semantics. Without this, every subscription-backed
-	// turn would pass straight through to any requested model and the allowlist
-	// would be silently inert for exactly the traffic that skips routing.
+	// Allowlist is a compliance boundary, not a routing preference —
+	// unlike excluded_models the bypass must honor it. Checked explicitly
+	// because SafetyExcludedModels has different readers and semantics.
 	if len(req.AllowedModels) > 0 {
 		if _, allowed := req.AllowedModels[model]; !allowed {
 			return "", false

--- a/internal/proxy/usage_bypass.go
+++ b/internal/proxy/usage_bypass.go
@@ -89,6 +89,17 @@ func (s *Service) usageBypassEngaged(ctx context.Context, headers http.Header, r
 	if _, excluded := req.SafetyExcludedModels[model]; excluded {
 		return "", false
 	}
+	// The org's positive allowlist is NOT a routing preference — it is a
+	// compliance boundary, so unlike excluded_models the bypass must honor it.
+	// Checked explicitly rather than via SafetyExcludedModels, which has other
+	// readers with different semantics. Without this, every subscription-backed
+	// turn would pass straight through to any requested model and the allowlist
+	// would be silently inert for exactly the traffic that skips routing.
+	if len(req.AllowedModels) > 0 {
+		if _, allowed := req.AllowedModels[model]; !allowed {
+			return "", false
+		}
+	}
 	if token == "" {
 		return "", false
 	}

--- a/internal/proxy/usage_bypass_test.go
+++ b/internal/proxy/usage_bypass_test.go
@@ -189,13 +189,8 @@ func TestUsageBypass_InstallationExcludedModel_StillBypasses(t *testing.T) {
 	assert.Equal(t, bypassRequestedMdl, rec.Header().Get("x-router-model"), "bypass must serve the requested model, not a substituted one")
 }
 
-// TestUsageBypass_NotAllowlistedModel_EngagesRouting is the counterpart to the
-// excluded-model case above, and the reason the allowlist needed an explicit
-// check in usageBypassEngaged: excluded_models is a routing preference the
-// bypass may override, but the org allowlist is a compliance boundary it must
-// not. Without the check, every subscription-backed turn would pass straight
-// through to any requested model and the allowlist would be silently inert for
-// exactly the traffic that skips routing.
+// TestUsageBypass_NotAllowlistedModel_EngagesRouting: allowlist is a
+// compliance boundary (not a preference), so bypass must not skip it.
 func TestUsageBypass_NotAllowlistedModel_EngagesRouting(t *testing.T) {
 	svc, fr, _ := bypassFixture(t, 0.20)
 	rec, req, body := bypassRequest(t)

--- a/internal/proxy/usage_bypass_test.go
+++ b/internal/proxy/usage_bypass_test.go
@@ -189,6 +189,39 @@ func TestUsageBypass_InstallationExcludedModel_StillBypasses(t *testing.T) {
 	assert.Equal(t, bypassRequestedMdl, rec.Header().Get("x-router-model"), "bypass must serve the requested model, not a substituted one")
 }
 
+// TestUsageBypass_NotAllowlistedModel_EngagesRouting is the counterpart to the
+// excluded-model case above, and the reason the allowlist needed an explicit
+// check in usageBypassEngaged: excluded_models is a routing preference the
+// bypass may override, but the org allowlist is a compliance boundary it must
+// not. Without the check, every subscription-backed turn would pass straight
+// through to any requested model and the allowlist would be silently inert for
+// exactly the traffic that skips routing.
+func TestUsageBypass_NotAllowlistedModel_EngagesRouting(t *testing.T) {
+	svc, fr, _ := bypassFixture(t, 0.20)
+	rec, req, body := bypassRequest(t)
+	// The org allowlists only the scorer's pick, never the requested model.
+	ctx := context.WithValue(bypassCtx(0.80), proxy.InstallationAllowedModelsContextKey{}, []string{bypassScorerPickMdl})
+
+	require.NoError(t, svc.ProxyMessages(ctx, body, rec, req))
+
+	assert.Equal(t, 1, fr.routeCalls, "a model outside the org allowlist must NOT bypass — the allowlist is a compliance boundary, not a preference")
+	assert.Equal(t, bypassScorerPickMdl, rec.Header().Get("x-router-model"), "routing must serve an allowlisted model instead")
+}
+
+// TestUsageBypass_AllowlistedModel_StillBypasses: the allowlist check must gate
+// only non-allowlisted models — an allowlisted model keeps its fast path.
+func TestUsageBypass_AllowlistedModel_StillBypasses(t *testing.T) {
+	svc, fr, p := bypassFixture(t, 0.20)
+	rec, req, body := bypassRequest(t)
+	ctx := context.WithValue(bypassCtx(0.80), proxy.InstallationAllowedModelsContextKey{}, []string{bypassRequestedMdl})
+
+	require.NoError(t, svc.ProxyMessages(ctx, body, rec, req))
+
+	assert.Equal(t, 0, fr.routeCalls, "an allowlisted model must still bypass")
+	require.Len(t, p.proxyBodies, 1)
+	assert.Equal(t, bypassRequestedMdl, rec.Header().Get("x-router-model"))
+}
+
 // TestUsageBypass_MaxedOutModel_EngagesRouting: the maxed-out guard writes
 // the saturated model to SafetyExcludedModels so an auto-continue re-request
 // falls through to the scorer, preventing bypass from reopening the max-output loop.

--- a/internal/router/cluster/scorer.go
+++ b/internal/router/cluster/scorer.go
@@ -22,6 +22,12 @@ var ErrClusterUnavailable = errors.New("cluster: routing unavailable")
 // overlap with boot-time candidates. Callers map to HTTP 4xx.
 var ErrNoEligibleProvider = errors.New("cluster: no eligible provider for request")
 
+// ErrAllowlistEmptiesPool is returned when the org's positive model allowlist
+// leaves no eligible candidate. Wraps ErrNoEligibleProvider so existing
+// errors.Is checks keep matching, while letting the HTTP layer name the
+// allowlist instead of dumping the desugared exclusion list.
+var ErrAllowlistEmptiesPool = fmt.Errorf("cluster: model allowlist leaves no eligible candidates: %w", ErrNoEligibleProvider)
+
 // ErrInvalidRoutingKnobs is returned when effective routing knobs fail validation.
 var ErrInvalidRoutingKnobs = errors.New("cluster: invalid routing knobs")
 
@@ -527,6 +533,18 @@ func (s *Scorer) Route(ctx context.Context, req router.Request) (router.Decision
 			}
 		}
 		if len(filtered) == 0 {
+			// An allowlist is desugared into ExcludedModels upstream, so report
+			// the allowlist as the cause when one is configured — otherwise the
+			// error names dozens of implicitly-excluded models and reads as a
+			// bug rather than a policy decision.
+			if len(req.AllowedModels) > 0 {
+				log.Warn(
+					"Cluster scorer: model allowlist empties eligible pool; returning ErrAllowlistEmptiesPool",
+					"allowed_models", sortedKeys(req.AllowedModels),
+					"requested_model", req.RequestedModel,
+				)
+				return router.Decision{}, fmt.Errorf("allowed models %v leave no eligible candidates: %w", sortedKeys(req.AllowedModels), ErrAllowlistEmptiesPool)
+			}
 			log.Warn(
 				"Cluster scorer: exclusion list empties eligible pool; returning ErrNoEligibleProvider",
 				"excluded_models", sortedKeys(req.ExcludedModels),

--- a/internal/router/cluster/scorer.go
+++ b/internal/router/cluster/scorer.go
@@ -22,10 +22,8 @@ var ErrClusterUnavailable = errors.New("cluster: routing unavailable")
 // overlap with boot-time candidates. Callers map to HTTP 4xx.
 var ErrNoEligibleProvider = errors.New("cluster: no eligible provider for request")
 
-// ErrAllowlistEmptiesPool is returned when the org's positive model allowlist
-// leaves no eligible candidate. Wraps ErrNoEligibleProvider so existing
-// errors.Is checks keep matching, while letting the HTTP layer name the
-// allowlist instead of dumping the desugared exclusion list.
+// ErrAllowlistEmptiesPool wraps ErrNoEligibleProvider so existing errors.Is
+// checks keep matching, while naming the allowlist instead of the desugared exclusion list.
 var ErrAllowlistEmptiesPool = fmt.Errorf("cluster: model allowlist leaves no eligible candidates: %w", ErrNoEligibleProvider)
 
 // ErrInvalidRoutingKnobs is returned when effective routing knobs fail validation.

--- a/internal/router/cluster/scorer_test.go
+++ b/internal/router/cluster/scorer_test.go
@@ -1001,6 +1001,31 @@ func TestScorer_ExcludedModelsEmptyingPoolReturnsErrNoEligibleProvider(t *testin
 	assert.False(t, errors.Is(err, ErrClusterUnavailable))
 }
 
+// An allowlist that leaves no eligible candidate must surface the
+// allowlist-specific sentinel — which still wraps ErrNoEligibleProvider so
+// every existing errors.Is check keeps matching — rather than reporting the
+// desugared exclusion list, which reads as a bug instead of a config decision.
+func TestScorer_AllowlistEmptyingPoolReturnsErrAllowlistEmptiesPool(t *testing.T) {
+	emb := &fakeEmbedder{vec: makeOpusVec()}
+	s := newTwoProviderScorer(t, emb)
+
+	_, err := s.Route(context.Background(), router.Request{
+		PromptText: strings.Repeat("x", 100),
+		// The proxy desugars the allowlist into ExcludedModels; AllowedModels
+		// only names the cause.
+		ExcludedModels: map[string]struct{}{
+			"gpt-5":           {},
+			"claude-opus-4-7": {},
+		},
+		AllowedModels: map[string]struct{}{"some-retired-model": {}},
+	})
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrAllowlistEmptiesPool))
+	assert.True(t, errors.Is(err, ErrNoEligibleProvider), "must still satisfy existing ErrNoEligibleProvider checks")
+	assert.Contains(t, err.Error(), "some-retired-model", "the error must name the allowlist, not the desugared exclusions")
+	assert.False(t, errors.Is(err, ErrClusterUnavailable))
+}
+
 // has_tools=true must subtract catalog.ToolUseLowSet from the argmax pool
 // so weak tool-callers like qwen3-235b-Instruct aren't picked for agentic work.
 func TestScorer_HasToolsExcludesToolUseLowFromArgmax(t *testing.T) {

--- a/internal/router/cluster/scorer_test.go
+++ b/internal/router/cluster/scorer_test.go
@@ -1001,10 +1001,8 @@ func TestScorer_ExcludedModelsEmptyingPoolReturnsErrNoEligibleProvider(t *testin
 	assert.False(t, errors.Is(err, ErrClusterUnavailable))
 }
 
-// An allowlist that leaves no eligible candidate must surface the
-// allowlist-specific sentinel — which still wraps ErrNoEligibleProvider so
-// every existing errors.Is check keeps matching — rather than reporting the
-// desugared exclusion list, which reads as a bug instead of a config decision.
+// ErrAllowlistEmptiesPool must wrap ErrNoEligibleProvider (existing checks keep
+// matching) and name the allowlist, not the desugared exclusion list.
 func TestScorer_AllowlistEmptyingPoolReturnsErrAllowlistEmptiesPool(t *testing.T) {
 	emb := &fakeEmbedder{vec: makeOpusVec()}
 	s := newTwoProviderScorer(t, emb)

--- a/internal/router/policy/resolver.go
+++ b/internal/router/policy/resolver.go
@@ -36,6 +36,10 @@ type ExclusionReason string
 const (
 	// ExclusionRequested means the installation or request excluded the model.
 	ExclusionRequested ExclusionReason = "requested_exclusion"
+	// ExclusionNotAllowlisted means the org's positive model allowlist omits the
+	// model. Reported ahead of ExclusionRequested (the allowlist is desugared
+	// into the exclusion set upstream) so diagnostics name the real cause.
+	ExclusionNotAllowlisted ExclusionReason = "not_allowlisted"
 	// ExclusionUnknownCatalogModel means the deployed set named no catalog row.
 	ExclusionUnknownCatalogModel ExclusionReason = "unknown_catalog_model"
 	// ExclusionUnmappedRoster means the strategy intentionally has no roster ID.
@@ -254,7 +258,13 @@ func (r *Resolver) Resolve(req router.Request) ResolvedCandidates {
 
 	for _, id := range deployedIDs {
 		if _, excluded := req.ExcludedModels[id]; excluded {
-			diagnostics = append(diagnostics, Diagnostic{CatalogID: id, Reason: ExclusionRequested})
+			reason := ExclusionRequested
+			if len(req.AllowedModels) > 0 {
+				if _, allowed := req.AllowedModels[id]; !allowed {
+					reason = ExclusionNotAllowlisted
+				}
+			}
+			diagnostics = append(diagnostics, Diagnostic{CatalogID: id, Reason: reason})
 			continue
 		}
 		model, ok := catalog.ByID(id)

--- a/internal/router/policy/resolver_test.go
+++ b/internal/router/policy/resolver_test.go
@@ -252,3 +252,53 @@ func set(values ...string) map[string]struct{} {
 	}
 	return result
 }
+
+// The allowlist is desugared into ExcludedModels before the resolver runs, so
+// diagnostics would otherwise attribute every non-allowlisted model to an
+// explicit exclusion the admin never made. AllowedModels lets the resolver
+// report the real cause.
+func TestResolverReportsNotAllowlistedSeparatelyFromRequestedExclusion(t *testing.T) {
+	resolver := policy.NewResolver(
+		set("claude-opus-4-8", "claude-haiku-4-5"),
+		set(providers.ProviderAnthropic),
+		catalogRosterID,
+		policy.ManagedProviderPolicy(),
+	)
+
+	resolved := resolver.Resolve(router.Request{
+		// Both are excluded on the wire; only one is an explicit exclusion.
+		ExcludedModels: map[string]struct{}{
+			"claude-opus-4-8":  {},
+			"claude-haiku-4-5": {},
+		},
+		AllowedModels: map[string]struct{}{"claude-haiku-4-5": {}},
+	})
+
+	assert.Contains(t, resolved.Diagnostics, policy.Diagnostic{
+		CatalogID: "claude-opus-4-8",
+		Reason:    policy.ExclusionNotAllowlisted,
+	}, "a model absent from the allowlist must be reported as not-allowlisted")
+	assert.Contains(t, resolved.Diagnostics, policy.Diagnostic{
+		CatalogID: "claude-haiku-4-5",
+		Reason:    policy.ExclusionRequested,
+	}, "an allowlisted model excluded explicitly stays a requested exclusion")
+}
+
+// Without an allowlist configured, exclusion diagnostics must be unchanged.
+func TestResolverKeepsRequestedExclusionWhenNoAllowlist(t *testing.T) {
+	resolver := policy.NewResolver(
+		set("claude-opus-4-8"),
+		set(providers.ProviderAnthropic),
+		catalogRosterID,
+		policy.ManagedProviderPolicy(),
+	)
+
+	resolved := resolver.Resolve(router.Request{
+		ExcludedModels: map[string]struct{}{"claude-opus-4-8": {}},
+	})
+
+	assert.Contains(t, resolved.Diagnostics, policy.Diagnostic{
+		CatalogID: "claude-opus-4-8",
+		Reason:    policy.ExclusionRequested,
+	})
+}

--- a/internal/router/policy/resolver_test.go
+++ b/internal/router/policy/resolver_test.go
@@ -253,10 +253,8 @@ func set(values ...string) map[string]struct{} {
 	return result
 }
 
-// The allowlist is desugared into ExcludedModels before the resolver runs, so
-// diagnostics would otherwise attribute every non-allowlisted model to an
-// explicit exclusion the admin never made. AllowedModels lets the resolver
-// report the real cause.
+// The allowlist desugars into ExcludedModels, so diagnostics must distinguish
+// not-allowlisted from an explicit admin exclusion via AllowedModels.
 func TestResolverReportsNotAllowlistedSeparatelyFromRequestedExclusion(t *testing.T) {
 	resolver := policy.NewResolver(
 		set("claude-opus-4-8", "claude-haiku-4-5"),

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -148,10 +148,9 @@ type Request struct {
 	// Full union: installation excluded_models plus request-time safety filters.
 	ExcludedModels map[string]struct{}
 	// AllowedModels is the org's positive model allowlist as a set; nil means no
-	// restriction. Enforcement is already effected through ExcludedModels (the
-	// proxy desugars the allowlist into it), so nothing needs to filter on this
-	// field. It exists so the scorer and resolver can NAME the constraint in
-	// errors and diagnostics rather than reporting a large exclusion list.
+	// restriction. Enforcement is via ExcludedModels (proxy desugars the allowlist
+	// into it); this field lets scorer/resolver NAME the constraint in errors
+	// rather than reporting a large exclusion list.
 	AllowedModels map[string]struct{}
 	// SafetyExcludedModels holds only the hard request-time constraints a model
 	// physically cannot satisfy: context-window overflow and gemini-unsigned

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -147,6 +147,12 @@ type Request struct {
 	// If filtering empties eligible set, scorer returns ErrNoEligibleProvider.
 	// Full union: installation excluded_models plus request-time safety filters.
 	ExcludedModels map[string]struct{}
+	// AllowedModels is the org's positive model allowlist as a set; nil means no
+	// restriction. Enforcement is already effected through ExcludedModels (the
+	// proxy desugars the allowlist into it), so nothing needs to filter on this
+	// field. It exists so the scorer and resolver can NAME the constraint in
+	// errors and diagnostics rather than reporting a large exclusion list.
+	AllowedModels map[string]struct{}
 	// SafetyExcludedModels holds only the hard request-time constraints a model
 	// physically cannot satisfy: context-window overflow and gemini-unsigned
 	// history — not the installation's excluded_models policy. The bypass gate

--- a/internal/server/middleware/auth.go
+++ b/internal/server/middleware/auth.go
@@ -108,6 +108,9 @@ func withAPIKey(svc *auth.Service, byokRequiresOptIn bool) gin.HandlerFunc {
 			if len(installation.ExcludedModels) > 0 {
 				ctx = context.WithValue(ctx, proxy.InstallationExcludedModelsContextKey{}, installation.ExcludedModels)
 			}
+			if len(installation.AllowedModels) > 0 {
+				ctx = context.WithValue(ctx, proxy.InstallationAllowedModelsContextKey{}, installation.AllowedModels)
+			}
 			if len(installation.ExcludedProviders) > 0 {
 				ctx = context.WithValue(ctx, proxy.InstallationExcludedProvidersContextKey{}, installation.ExcludedProviders)
 			}

--- a/internal/server/middleware/auth_test.go
+++ b/internal/server/middleware/auth_test.go
@@ -114,6 +114,10 @@ func (fakeInstallationRepository) UpdateExcludedModels(ctx context.Context, exte
 	return errors.New("not used")
 }
 
+func (fakeInstallationRepository) UpdateAllowedModels(ctx context.Context, externalID, id string, models []string) error {
+	return errors.New("not used")
+}
+
 func (fakeInstallationRepository) UpdateExcludedProviders(ctx context.Context, externalID, id string, providerNames []string) error {
 	return errors.New("not used")
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -166,6 +166,8 @@ func Register(engine *gin.Engine, authSvc *auth.Service, proxySvc *proxy.Service
 		if deployedModels != nil {
 			mgmt.GET("/excluded-models", admin.GetExcludedModelsHandler(authSvc, deployedModels, proxySvc))
 			mgmt.PUT("/excluded-models", admin.UpdateExcludedModelsHandler(authSvc, deployedModels, proxySvc))
+			mgmt.GET("/allowed-models", admin.GetAllowedModelsHandler(authSvc, deployedModels))
+			mgmt.PUT("/allowed-models", admin.UpdateAllowedModelsHandler(authSvc, deployedModels))
 			mgmt.GET("/excluded-providers", admin.GetExcludedProvidersHandler(authSvc, deployedModels, proxySvc))
 			mgmt.PUT("/excluded-providers", admin.UpdateExcludedProvidersHandler(authSvc, deployedModels, proxySvc))
 		}

--- a/internal/sqlc/model_router_api_keys.sql.go
+++ b/internal/sqlc/model_router_api_keys.sql.go
@@ -102,7 +102,7 @@ func (q *Queries) CreateModelRouterAPIKey(ctx context.Context, arg CreateModelRo
 }
 
 const getActiveModelRouterAPIKeyWithInstallationByHash = `-- name: GetActiveModelRouterAPIKeyWithInstallationByHash :one
-SELECT k.id, k.installation_id, k.external_id, k.name, k.key_prefix, k.key_hash, k.key_suffix, k.last_used_at, k.created_at, k.deleted_at, k.created_by, k.spend_cap_usd_micros, k.spent_usd_micros, k.scope, i.id, i.external_id, i.name, i.created_at, i.updated_at, i.deleted_at, i.created_by, i.excluded_models, i.excluded_providers, i.routing_quality_weight, i.usage_bypass_enabled, i.usage_bypass_threshold, i.preferred_models, i.subscription_routing_disabled, i.routing_strategy, i.routing_rollout_id, i.policy_shadow_strategy, i.policy_debug_enabled, i.policy_header_overrides_enabled, i.policy_routing_intent, i.ai_training_allowed, i.byok_enabled, i.content_capture_mode, i.hide_terminal_surfaces
+SELECT k.id, k.installation_id, k.external_id, k.name, k.key_prefix, k.key_hash, k.key_suffix, k.last_used_at, k.created_at, k.deleted_at, k.created_by, k.spend_cap_usd_micros, k.spent_usd_micros, k.scope, i.id, i.external_id, i.name, i.created_at, i.updated_at, i.deleted_at, i.created_by, i.excluded_models, i.excluded_providers, i.routing_quality_weight, i.usage_bypass_enabled, i.usage_bypass_threshold, i.preferred_models, i.subscription_routing_disabled, i.routing_strategy, i.routing_rollout_id, i.policy_shadow_strategy, i.policy_debug_enabled, i.policy_header_overrides_enabled, i.policy_routing_intent, i.ai_training_allowed, i.byok_enabled, i.content_capture_mode, i.hide_terminal_surfaces, i.allowed_models
 FROM router.model_router_api_keys k
 INNER JOIN router.model_router_installations i ON i.id = k.installation_id
 WHERE k.key_hash = $1::varchar
@@ -121,7 +121,7 @@ type GetActiveModelRouterAPIKeyWithInstallationByHashRow struct {
 // both sides so a soft-deleted installation invalidates all its keys without per-key
 // updates.
 //
-//	SELECT k.id, k.installation_id, k.external_id, k.name, k.key_prefix, k.key_hash, k.key_suffix, k.last_used_at, k.created_at, k.deleted_at, k.created_by, k.spend_cap_usd_micros, k.spent_usd_micros, k.scope, i.id, i.external_id, i.name, i.created_at, i.updated_at, i.deleted_at, i.created_by, i.excluded_models, i.excluded_providers, i.routing_quality_weight, i.usage_bypass_enabled, i.usage_bypass_threshold, i.preferred_models, i.subscription_routing_disabled, i.routing_strategy, i.routing_rollout_id, i.policy_shadow_strategy, i.policy_debug_enabled, i.policy_header_overrides_enabled, i.policy_routing_intent, i.ai_training_allowed, i.byok_enabled, i.content_capture_mode, i.hide_terminal_surfaces
+//	SELECT k.id, k.installation_id, k.external_id, k.name, k.key_prefix, k.key_hash, k.key_suffix, k.last_used_at, k.created_at, k.deleted_at, k.created_by, k.spend_cap_usd_micros, k.spent_usd_micros, k.scope, i.id, i.external_id, i.name, i.created_at, i.updated_at, i.deleted_at, i.created_by, i.excluded_models, i.excluded_providers, i.routing_quality_weight, i.usage_bypass_enabled, i.usage_bypass_threshold, i.preferred_models, i.subscription_routing_disabled, i.routing_strategy, i.routing_rollout_id, i.policy_shadow_strategy, i.policy_debug_enabled, i.policy_header_overrides_enabled, i.policy_routing_intent, i.ai_training_allowed, i.byok_enabled, i.content_capture_mode, i.hide_terminal_surfaces, i.allowed_models
 //	FROM router.model_router_api_keys k
 //	INNER JOIN router.model_router_installations i ON i.id = k.installation_id
 //	WHERE k.key_hash = $1::varchar
@@ -169,6 +169,7 @@ func (q *Queries) GetActiveModelRouterAPIKeyWithInstallationByHash(ctx context.C
 		&i.RouterModelRouterInstallation.ByokEnabled,
 		&i.RouterModelRouterInstallation.ContentCaptureMode,
 		&i.RouterModelRouterInstallation.HideTerminalSurfaces,
+		&i.RouterModelRouterInstallation.AllowedModels,
 	)
 	return i, err
 }

--- a/internal/sqlc/model_router_installations.sql.go
+++ b/internal/sqlc/model_router_installations.sql.go
@@ -22,7 +22,7 @@ VALUES (
     $2::varchar,
     $3
 )
-RETURNING id, external_id, name, created_at, updated_at, deleted_at, created_by, excluded_models, excluded_providers, routing_quality_weight, usage_bypass_enabled, usage_bypass_threshold, preferred_models, subscription_routing_disabled, routing_strategy, routing_rollout_id, policy_shadow_strategy, policy_debug_enabled, policy_header_overrides_enabled, policy_routing_intent, ai_training_allowed, byok_enabled, content_capture_mode, hide_terminal_surfaces
+RETURNING id, external_id, name, created_at, updated_at, deleted_at, created_by, excluded_models, excluded_providers, routing_quality_weight, usage_bypass_enabled, usage_bypass_threshold, preferred_models, subscription_routing_disabled, routing_strategy, routing_rollout_id, policy_shadow_strategy, policy_debug_enabled, policy_header_overrides_enabled, policy_routing_intent, ai_training_allowed, byok_enabled, content_capture_mode, hide_terminal_surfaces, allowed_models
 `
 
 type CreateModelRouterInstallationParams struct {
@@ -43,7 +43,7 @@ type CreateModelRouterInstallationParams struct {
 //	    $2::varchar,
 //	    $3
 //	)
-//	RETURNING id, external_id, name, created_at, updated_at, deleted_at, created_by, excluded_models, excluded_providers, routing_quality_weight, usage_bypass_enabled, usage_bypass_threshold, preferred_models, subscription_routing_disabled, routing_strategy, routing_rollout_id, policy_shadow_strategy, policy_debug_enabled, policy_header_overrides_enabled, policy_routing_intent, ai_training_allowed, byok_enabled, content_capture_mode, hide_terminal_surfaces
+//	RETURNING id, external_id, name, created_at, updated_at, deleted_at, created_by, excluded_models, excluded_providers, routing_quality_weight, usage_bypass_enabled, usage_bypass_threshold, preferred_models, subscription_routing_disabled, routing_strategy, routing_rollout_id, policy_shadow_strategy, policy_debug_enabled, policy_header_overrides_enabled, policy_routing_intent, ai_training_allowed, byok_enabled, content_capture_mode, hide_terminal_surfaces, allowed_models
 func (q *Queries) CreateModelRouterInstallation(ctx context.Context, arg CreateModelRouterInstallationParams) (RouterModelRouterInstallation, error) {
 	row := q.db.QueryRow(ctx, createModelRouterInstallation, arg.ExternalID, arg.Name, arg.CreatedBy)
 	var i RouterModelRouterInstallation
@@ -72,12 +72,13 @@ func (q *Queries) CreateModelRouterInstallation(ctx context.Context, arg CreateM
 		&i.ByokEnabled,
 		&i.ContentCaptureMode,
 		&i.HideTerminalSurfaces,
+		&i.AllowedModels,
 	)
 	return i, err
 }
 
 const getModelRouterInstallation = `-- name: GetModelRouterInstallation :one
-SELECT id, external_id, name, created_at, updated_at, deleted_at, created_by, excluded_models, excluded_providers, routing_quality_weight, usage_bypass_enabled, usage_bypass_threshold, preferred_models, subscription_routing_disabled, routing_strategy, routing_rollout_id, policy_shadow_strategy, policy_debug_enabled, policy_header_overrides_enabled, policy_routing_intent, ai_training_allowed, byok_enabled, content_capture_mode, hide_terminal_surfaces
+SELECT id, external_id, name, created_at, updated_at, deleted_at, created_by, excluded_models, excluded_providers, routing_quality_weight, usage_bypass_enabled, usage_bypass_threshold, preferred_models, subscription_routing_disabled, routing_strategy, routing_rollout_id, policy_shadow_strategy, policy_debug_enabled, policy_header_overrides_enabled, policy_routing_intent, ai_training_allowed, byok_enabled, content_capture_mode, hide_terminal_surfaces, allowed_models
 FROM router.model_router_installations
 WHERE id = $1::uuid
   AND external_id = $2::varchar
@@ -91,7 +92,7 @@ type GetModelRouterInstallationParams struct {
 
 // Gets an installation by id, scoped to an external_id to prevent cross-tenant access.
 //
-//	SELECT id, external_id, name, created_at, updated_at, deleted_at, created_by, excluded_models, excluded_providers, routing_quality_weight, usage_bypass_enabled, usage_bypass_threshold, preferred_models, subscription_routing_disabled, routing_strategy, routing_rollout_id, policy_shadow_strategy, policy_debug_enabled, policy_header_overrides_enabled, policy_routing_intent, ai_training_allowed, byok_enabled, content_capture_mode, hide_terminal_surfaces
+//	SELECT id, external_id, name, created_at, updated_at, deleted_at, created_by, excluded_models, excluded_providers, routing_quality_weight, usage_bypass_enabled, usage_bypass_threshold, preferred_models, subscription_routing_disabled, routing_strategy, routing_rollout_id, policy_shadow_strategy, policy_debug_enabled, policy_header_overrides_enabled, policy_routing_intent, ai_training_allowed, byok_enabled, content_capture_mode, hide_terminal_surfaces, allowed_models
 //	FROM router.model_router_installations
 //	WHERE id = $1::uuid
 //	  AND external_id = $2::varchar
@@ -124,12 +125,13 @@ func (q *Queries) GetModelRouterInstallation(ctx context.Context, arg GetModelRo
 		&i.ByokEnabled,
 		&i.ContentCaptureMode,
 		&i.HideTerminalSurfaces,
+		&i.AllowedModels,
 	)
 	return i, err
 }
 
 const listModelRouterInstallationsForExternalID = `-- name: ListModelRouterInstallationsForExternalID :many
-SELECT id, external_id, name, created_at, updated_at, deleted_at, created_by, excluded_models, excluded_providers, routing_quality_weight, usage_bypass_enabled, usage_bypass_threshold, preferred_models, subscription_routing_disabled, routing_strategy, routing_rollout_id, policy_shadow_strategy, policy_debug_enabled, policy_header_overrides_enabled, policy_routing_intent, ai_training_allowed, byok_enabled, content_capture_mode, hide_terminal_surfaces
+SELECT id, external_id, name, created_at, updated_at, deleted_at, created_by, excluded_models, excluded_providers, routing_quality_weight, usage_bypass_enabled, usage_bypass_threshold, preferred_models, subscription_routing_disabled, routing_strategy, routing_rollout_id, policy_shadow_strategy, policy_debug_enabled, policy_header_overrides_enabled, policy_routing_intent, ai_training_allowed, byok_enabled, content_capture_mode, hide_terminal_surfaces, allowed_models
 FROM router.model_router_installations
 WHERE external_id = $1::varchar
   AND deleted_at IS NULL
@@ -138,7 +140,7 @@ ORDER BY created_at DESC
 
 // ListModelRouterInstallationsForExternalID
 //
-//	SELECT id, external_id, name, created_at, updated_at, deleted_at, created_by, excluded_models, excluded_providers, routing_quality_weight, usage_bypass_enabled, usage_bypass_threshold, preferred_models, subscription_routing_disabled, routing_strategy, routing_rollout_id, policy_shadow_strategy, policy_debug_enabled, policy_header_overrides_enabled, policy_routing_intent, ai_training_allowed, byok_enabled, content_capture_mode, hide_terminal_surfaces
+//	SELECT id, external_id, name, created_at, updated_at, deleted_at, created_by, excluded_models, excluded_providers, routing_quality_weight, usage_bypass_enabled, usage_bypass_threshold, preferred_models, subscription_routing_disabled, routing_strategy, routing_rollout_id, policy_shadow_strategy, policy_debug_enabled, policy_header_overrides_enabled, policy_routing_intent, ai_training_allowed, byok_enabled, content_capture_mode, hide_terminal_surfaces, allowed_models
 //	FROM router.model_router_installations
 //	WHERE external_id = $1::varchar
 //	  AND deleted_at IS NULL
@@ -177,6 +179,7 @@ func (q *Queries) ListModelRouterInstallationsForExternalID(ctx context.Context,
 			&i.ByokEnabled,
 			&i.ContentCaptureMode,
 			&i.HideTerminalSurfaces,
+			&i.AllowedModels,
 		); err != nil {
 			return nil, err
 		}

--- a/internal/sqlc/model_router_installations.sql.go
+++ b/internal/sqlc/model_router_installations.sql.go
@@ -216,6 +216,40 @@ func (q *Queries) SoftDeleteModelRouterInstallation(ctx context.Context, arg Sof
 	return err
 }
 
+const updateModelRouterInstallationAllowedModels = `-- name: UpdateModelRouterInstallationAllowedModels :execrows
+UPDATE router.model_router_installations
+SET allowed_models = $1::text[],
+    updated_at = NOW()
+WHERE id = $2::uuid
+  AND external_id = $3::varchar
+  AND deleted_at IS NULL
+`
+
+type UpdateModelRouterInstallationAllowedModelsParams struct {
+	AllowedModels []string
+	ID            uuid.UUID
+	ExternalID    string
+}
+
+// Replaces the per-installation positive model allowlist, scoped to an
+// external_id to prevent cross-tenant updates. Empty array means "no
+// restriction" (all models routable), NOT "no models". Bumps updated_at so
+// dashboards see the change.
+//
+//	UPDATE router.model_router_installations
+//	SET allowed_models = $1::text[],
+//	    updated_at = NOW()
+//	WHERE id = $2::uuid
+//	  AND external_id = $3::varchar
+//	  AND deleted_at IS NULL
+func (q *Queries) UpdateModelRouterInstallationAllowedModels(ctx context.Context, arg UpdateModelRouterInstallationAllowedModelsParams) (int64, error) {
+	result, err := q.db.Exec(ctx, updateModelRouterInstallationAllowedModels, arg.AllowedModels, arg.ID, arg.ExternalID)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
 const updateModelRouterInstallationContentCaptureMode = `-- name: UpdateModelRouterInstallationContentCaptureMode :execrows
 UPDATE router.model_router_installations
 SET content_capture_mode = $1,

--- a/internal/sqlc/models.go
+++ b/internal/sqlc/models.go
@@ -122,6 +122,8 @@ type RouterModelRouterInstallation struct {
 	// Per-installation capture ceiling (off|hashed|full); NULL uses the deployment default
 	ContentCaptureMode   *string
 	HideTerminalSurfaces bool
+	// Org-level positive model allowlist. Empty = no restriction. Effective set = allowed_models minus excluded_models. Fail-closed: an allowlist with no eligible overlap refuses the turn.
+	AllowedModels []string
 }
 
 type RouterModelRouterRequestTelemetry struct {


### PR DESCRIPTION
## What

Adds an org-level **positive** model allowlist (`allowed_models` on `model_router_installations`), the counterpart to today's `excluded_models` deny list. The two compose: **effective set = allowlist − exclusions**. An empty allowlist means *no restriction*, not *no models*.

## How

**The allowlist is desugared into the exclusion set** at the proxy boundary rather than filtered separately. `excludedModelsForRequest` adds every routable model absent from a non-empty allowlist to the exclusion set, so all six existing enforcement sites — cluster scorer, policy resolver, session pins, sibling failover, force-model, fallback — honor it with no new filter loops.

`router.Request.AllowedModels` exists only so errors and diagnostics can *name* the allowlist instead of dumping a 50-entry desugared exclusion list.

## Two paths that needed explicit handling

Both intentionally bypass `excluded_models`, so neither would have honored the allowlist for free:

1. **`usageBypassEngaged`** consults `SafetyExcludedModels`, not `ExcludedModels`, on the documented rationale that exclusions are a routing preference the bypass may override. An allowlist is a compliance boundary, not a preference — without an explicit check the allowlist was **silently inert for all subscription-backed traffic**. `TestUsageBypass_NotAllowlistedModel_EngagesRouting` covers this and fails without the fix.

2. **`ROUTER_EXCLUDED_MODELS`** short-circuits `excludedModelsForRequest` entirely. Left as-is deliberately — an operator debugging a deployment shouldn't be constrained by one org's config — but now commented as an intentional gap rather than an accident.

## Error surfaces

- `ErrAllowlistEmptiesPool` wraps `ErrNoEligibleProvider`, so existing `errors.Is` checks keep matching while the message names the allowlist.
- New `not_allowlisted` resolver diagnostic, checked ahead of `requested_exclusion`.
- Dispatch-error class ordered **before** the generic no-eligible-provider case — `errors.Is` would otherwise match the wrapper first and tell an admin they have no provider keys.

## Admin API

`GET`/`PUT /admin/v1/allowed-models`, mirroring the excluded-models handlers.

## Validation

- `go build ./...`, `go vet ./...`, `go test ./...` all clean
- Migration applied and rolled back both directions locally
- The two behavioral tests were each verified to **fail** with the fix reverted

Part 1 of 2; per-user per-cluster selection follows in a stacked PR.

🤖 Generated with [Weave Router](https://router.workweave.ai)