### PR TITLE
feat: add per-installation toggle to hide router terminal surfaces

### DIFF
--- a/db/migrations/0055_installation-hide-terminal-surfaces.down.sql
+++ b/db/migrations/0055_installation-hide-terminal-surfaces.down.sql
@@ -1,0 +1,6 @@
+BEGIN;
+
+ALTER TABLE router.model_router_installations
+  DROP COLUMN hide_terminal_surfaces;
+
+COMMIT;

--- a/db/migrations/0055_installation-hide-terminal-surfaces.up.sql
+++ b/db/migrations/0055_installation-hide-terminal-surfaces.up.sql
@@ -1,0 +1,13 @@
+BEGIN;
+
+-- Per-installation toggle to hide the router's terminal surfaces from
+-- engineers: the "✦ Weave Router → <model>" routing marker, the trailing
+-- "/rf" feedback hint, and the router statusline. When true, requests route
+-- identically but nothing routing-related is rendered in the caller's
+-- terminal. Feedback submission/recording (/rf, signed rating links) is
+-- unaffected. Default false preserves today's behavior for every existing
+-- installation.
+ALTER TABLE router.model_router_installations
+  ADD COLUMN hide_terminal_surfaces BOOLEAN NOT NULL DEFAULT FALSE;
+
+COMMIT;

--- a/db/queries/model_router_installations.sql
+++ b/db/queries/model_router_installations.sql
@@ -102,3 +102,15 @@ SET subscription_routing_disabled = @subscription_routing_disabled::boolean,
 WHERE id = @id::uuid
   AND external_id = @external_id::varchar
   AND deleted_at IS NULL;
+
+-- Toggles hiding the router's terminal surfaces (routing marker, feedback
+-- footer, statusline) for the installation, scoped to an external_id to
+-- prevent cross-tenant updates. Requests route identically; only what is
+-- rendered in the caller's terminal changes.
+-- name: UpdateModelRouterInstallationHideTerminalSurfaces :execrows
+UPDATE router.model_router_installations
+SET hide_terminal_surfaces = @hide_terminal_surfaces::boolean,
+    updated_at = NOW()
+WHERE id = @id::uuid
+  AND external_id = @external_id::varchar
+  AND deleted_at IS NULL;

--- a/install/cc-statusline.sh
+++ b/install/cc-statusline.sh
@@ -277,6 +277,71 @@ weave_sync_commands() {
 }
 weave_sync_commands 2>/dev/null || true
 
+# ---------- org "hide terminal surfaces" gate ----------
+#
+# When the org has hidden the router's terminal surfaces, the statusline
+# renders nothing: this prints no output and exits 0, leaving the slot blank.
+# The setting is read from GET /v1/display-settings with the install's own
+# router key and cached per install for WEAVE_DISPLAY_SETTINGS_TTL_SECONDS
+# (default 1h) so a turn never blocks on the network. Any failure to reach the
+# router or read credentials renders the statusline normally (fail-open) — an
+# org that hasn't hidden anything must see no behavior change.
+weave_hidden_gate() {
+  command -v curl >/dev/null 2>&1 || return 1
+  command -v jq >/dev/null 2>&1 || return 1
+
+  local cache_dir="${XDG_CACHE_HOME:-$HOME/.cache}/weave-router"
+  mkdir -p "$cache_dir" 2>/dev/null || return 1
+  local self="${BASH_SOURCE[0]:-$0}"
+  local script_slug
+  script_slug="$(printf '%s' "$self" | tr -c 'A-Za-z0-9._-' '_')"
+  local cache="$cache_dir/display-settings${script_slug}"
+  local ttl="${WEAVE_DISPLAY_SETTINGS_TTL_SECONDS:-3600}"
+
+  local now mtime
+  now="$(date +%s 2>/dev/null)" || now=0
+  if [ -f "$cache" ]; then
+    mtime="$(stat -c %Y "$cache" 2>/dev/null || stat -f %m "$cache" 2>/dev/null)" || mtime=0
+    if [ -n "${mtime:-}" ] && [ "$mtime" -gt 0 ] && [ $(( now - mtime )) -lt "$ttl" ]; then
+      [ "$(cat "$cache" 2>/dev/null)" = "1" ]
+      return
+    fi
+  fi
+
+  # Resolve the router base URL and key from the Claude Code settings the
+  # installer wrote. User scope keeps both in ~/.claude/settings.json; project
+  # scope splits the key into settings.local.json. ANTHROPIC_BASE_URL and
+  # WEAVE_ROUTER_BASE_URL may also be set in the environment.
+  local settings="$HOME/.claude/settings.json"
+  local local_settings="$HOME/.claude/settings.local.json"
+  local base_url="${WEAVE_ROUTER_BASE_URL:-${ANTHROPIC_BASE_URL:-}}"
+  local key="${WEAVE_ROUTER_KEY:-}"
+  if [ -z "$key" ] && [ -f "$settings" ]; then
+    key="$(jq -r '.env.ANTHROPIC_CUSTOM_HEADERS // "" | split("\n")[] | select(startswith("X-Weave-Router-Key:")) | sub("^X-Weave-Router-Key:[[:space:]]*";"")' "$settings" 2>/dev/null | head -n1)"
+  fi
+  if [ -z "$key" ] && [ -f "$local_settings" ]; then
+    key="$(jq -r '.env.ANTHROPIC_CUSTOM_HEADERS // "" | split("\n")[] | select(startswith("X-Weave-Router-Key:")) | sub("^X-Weave-Router-Key:[[:space:]]*";"")' "$local_settings" 2>/dev/null | head -n1)"
+  fi
+  if [ -z "$base_url" ] && [ -f "$settings" ]; then
+    base_url="$(jq -r '.env.ANTHROPIC_BASE_URL // empty' "$settings" 2>/dev/null)"
+  fi
+  [ -n "$base_url" ] && [ -n "$key" ] || return 1
+
+  local body hidden=""
+  body="$(curl -fsS --max-time 5 -H "X-Weave-Router-Key: $key" "${base_url%/}/v1/display-settings" 2>/dev/null)" || { [ -f "$cache" ] && { [ "$(cat "$cache" 2>/dev/null)" = "1" ] && return 0 || return 1; }; return 1; }
+  hidden="$(printf '%s' "$body" | jq -r '.hide_terminal_surfaces // false' 2>/dev/null)"
+  if [ "$hidden" = "true" ]; then
+    printf '1' >"$cache" 2>/dev/null
+    return 0
+  fi
+  printf '0' >"$cache" 2>/dev/null
+  return 1
+}
+
+if weave_hidden_gate; then
+  exit 0
+fi
+
 input="$(cat)"
 transcript_path="$(printf '%s' "$input" | jq -r '.transcript_path // empty')"
 # Prefer model.id over display_name: pricing keys + the routed model id in

--- a/install/cc-statusline.sh
+++ b/install/cc-statusline.sh
@@ -309,11 +309,20 @@ weave_hidden_gate() {
   fi
 
   # Resolve the router base URL and key from the Claude Code settings the
-  # installer wrote. User scope keeps both in ~/.claude/settings.json; project
-  # scope splits the key into settings.local.json. ANTHROPIC_BASE_URL and
+  # installer wrote. Project/--dir installs put both under <base>/.claude
+  # alongside this script (key in settings.local.json), while a user-scope
+  # install lives under ~/.weave and reads ~/.claude. Resolve relative to the
+  # script's own location, falling back to user scope, so a project install
+  # never reads (or leaks) the user-scope key. ANTHROPIC_BASE_URL and
   # WEAVE_ROUTER_BASE_URL may also be set in the environment.
-  local settings="$HOME/.claude/settings.json"
-  local local_settings="$HOME/.claude/settings.local.json"
+  local self_dir
+  self_dir="$(cd "$(dirname "$self")" 2>/dev/null && pwd)"
+  local settings_base="$HOME"
+  case "$self_dir" in
+    */.claude) settings_base="${self_dir%/.claude}" ;;
+  esac
+  local settings="$settings_base/.claude/settings.json"
+  local local_settings="$settings_base/.claude/settings.local.json"
   local base_url="${WEAVE_ROUTER_BASE_URL:-${ANTHROPIC_BASE_URL:-}}"
   local key="${WEAVE_ROUTER_KEY:-}"
   if [ -z "$key" ] && [ -f "$settings" ]; then
@@ -327,8 +336,16 @@ weave_hidden_gate() {
   fi
   [ -n "$base_url" ] && [ -n "$key" ] || return 1
 
+  # A file:// base URL is the offline/test seam: curl reads it as the response
+  # body directly, so the endpoint path is meaningless for it. Real router URLs
+  # (https) get /v1/display-settings appended.
+  local url="${base_url%/}"
+  case "$url" in
+    file://*) ;;
+    *) url="$url/v1/display-settings" ;;
+  esac
   local body hidden=""
-  body="$(curl -fsS --max-time 5 -H "X-Weave-Router-Key: $key" "${base_url%/}/v1/display-settings" 2>/dev/null)" || { [ -f "$cache" ] && { [ "$(cat "$cache" 2>/dev/null)" = "1" ] && return 0 || return 1; }; return 1; }
+  body="$(curl -fsS --max-time 5 -H "X-Weave-Router-Key: $key" "$url" 2>/dev/null)" || { [ -f "$cache" ] && { [ "$(cat "$cache" 2>/dev/null)" = "1" ] && return 0 || return 1; }; return 1; }
   hidden="$(printf '%s' "$body" | jq -r '.hide_terminal_surfaces // false' 2>/dev/null)"
   if [ "$hidden" = "true" ]; then
     printf '1' >"$cache" 2>/dev/null
@@ -338,7 +355,7 @@ weave_hidden_gate() {
   return 1
 }
 
-if weave_hidden_gate; then
+if weave_hidden_gate </dev/null; then
   exit 0
 fi
 

--- a/install/install.sh
+++ b/install/install.sh
@@ -3070,6 +3070,71 @@ weave_sync_commands() {
 }
 weave_sync_commands 2>/dev/null || true
 
+# ---------- org "hide terminal surfaces" gate ----------
+#
+# When the org has hidden the router's terminal surfaces, the statusline
+# renders nothing: this prints no output and exits 0, leaving the slot blank.
+# The setting is read from GET /v1/display-settings with the install's own
+# router key and cached per install for WEAVE_DISPLAY_SETTINGS_TTL_SECONDS
+# (default 1h) so a turn never blocks on the network. Any failure to reach the
+# router or read credentials renders the statusline normally (fail-open) — an
+# org that hasn't hidden anything must see no behavior change.
+weave_hidden_gate() {
+  command -v curl >/dev/null 2>&1 || return 1
+  command -v jq >/dev/null 2>&1 || return 1
+
+  local cache_dir="${XDG_CACHE_HOME:-$HOME/.cache}/weave-router"
+  mkdir -p "$cache_dir" 2>/dev/null || return 1
+  local self="${BASH_SOURCE[0]:-$0}"
+  local script_slug
+  script_slug="$(printf '%s' "$self" | tr -c 'A-Za-z0-9._-' '_')"
+  local cache="$cache_dir/display-settings${script_slug}"
+  local ttl="${WEAVE_DISPLAY_SETTINGS_TTL_SECONDS:-3600}"
+
+  local now mtime
+  now="$(date +%s 2>/dev/null)" || now=0
+  if [ -f "$cache" ]; then
+    mtime="$(stat -c %Y "$cache" 2>/dev/null || stat -f %m "$cache" 2>/dev/null)" || mtime=0
+    if [ -n "${mtime:-}" ] && [ "$mtime" -gt 0 ] && [ $(( now - mtime )) -lt "$ttl" ]; then
+      [ "$(cat "$cache" 2>/dev/null)" = "1" ]
+      return
+    fi
+  fi
+
+  # Resolve the router base URL and key from the Claude Code settings the
+  # installer wrote. User scope keeps both in ~/.claude/settings.json; project
+  # scope splits the key into settings.local.json. ANTHROPIC_BASE_URL and
+  # WEAVE_ROUTER_BASE_URL may also be set in the environment.
+  local settings="$HOME/.claude/settings.json"
+  local local_settings="$HOME/.claude/settings.local.json"
+  local base_url="${WEAVE_ROUTER_BASE_URL:-${ANTHROPIC_BASE_URL:-}}"
+  local key="${WEAVE_ROUTER_KEY:-}"
+  if [ -z "$key" ] && [ -f "$settings" ]; then
+    key="$(jq -r '.env.ANTHROPIC_CUSTOM_HEADERS // "" | split("\n")[] | select(startswith("X-Weave-Router-Key:")) | sub("^X-Weave-Router-Key:[[:space:]]*";"")' "$settings" 2>/dev/null | head -n1)"
+  fi
+  if [ -z "$key" ] && [ -f "$local_settings" ]; then
+    key="$(jq -r '.env.ANTHROPIC_CUSTOM_HEADERS // "" | split("\n")[] | select(startswith("X-Weave-Router-Key:")) | sub("^X-Weave-Router-Key:[[:space:]]*";"")' "$local_settings" 2>/dev/null | head -n1)"
+  fi
+  if [ -z "$base_url" ] && [ -f "$settings" ]; then
+    base_url="$(jq -r '.env.ANTHROPIC_BASE_URL // empty' "$settings" 2>/dev/null)"
+  fi
+  [ -n "$base_url" ] && [ -n "$key" ] || return 1
+
+  local body hidden=""
+  body="$(curl -fsS --max-time 5 -H "X-Weave-Router-Key: $key" "${base_url%/}/v1/display-settings" 2>/dev/null)" || { [ -f "$cache" ] && { [ "$(cat "$cache" 2>/dev/null)" = "1" ] && return 0 || return 1; }; return 1; }
+  hidden="$(printf '%s' "$body" | jq -r '.hide_terminal_surfaces // false' 2>/dev/null)"
+  if [ "$hidden" = "true" ]; then
+    printf '1' >"$cache" 2>/dev/null
+    return 0
+  fi
+  printf '0' >"$cache" 2>/dev/null
+  return 1
+}
+
+if weave_hidden_gate; then
+  exit 0
+fi
+
 input="$(cat)"
 transcript_path="$(printf '%s' "$input" | jq -r '.transcript_path // empty')"
 # Prefer model.id over display_name: pricing keys + the routed model id in

--- a/install/install.sh
+++ b/install/install.sh
@@ -3102,11 +3102,20 @@ weave_hidden_gate() {
   fi
 
   # Resolve the router base URL and key from the Claude Code settings the
-  # installer wrote. User scope keeps both in ~/.claude/settings.json; project
-  # scope splits the key into settings.local.json. ANTHROPIC_BASE_URL and
+  # installer wrote. Project/--dir installs put both under <base>/.claude
+  # alongside this script (key in settings.local.json), while a user-scope
+  # install lives under ~/.weave and reads ~/.claude. Resolve relative to the
+  # script's own location, falling back to user scope, so a project install
+  # never reads (or leaks) the user-scope key. ANTHROPIC_BASE_URL and
   # WEAVE_ROUTER_BASE_URL may also be set in the environment.
-  local settings="$HOME/.claude/settings.json"
-  local local_settings="$HOME/.claude/settings.local.json"
+  local self_dir
+  self_dir="$(cd "$(dirname "$self")" 2>/dev/null && pwd)"
+  local settings_base="$HOME"
+  case "$self_dir" in
+    */.claude) settings_base="${self_dir%/.claude}" ;;
+  esac
+  local settings="$settings_base/.claude/settings.json"
+  local local_settings="$settings_base/.claude/settings.local.json"
   local base_url="${WEAVE_ROUTER_BASE_URL:-${ANTHROPIC_BASE_URL:-}}"
   local key="${WEAVE_ROUTER_KEY:-}"
   if [ -z "$key" ] && [ -f "$settings" ]; then
@@ -3120,8 +3129,16 @@ weave_hidden_gate() {
   fi
   [ -n "$base_url" ] && [ -n "$key" ] || return 1
 
+  # A file:// base URL is the offline/test seam: curl reads it as the response
+  # body directly, so the endpoint path is meaningless for it. Real router URLs
+  # (https) get /v1/display-settings appended.
+  local url="${base_url%/}"
+  case "$url" in
+    file://*) ;;
+    *) url="$url/v1/display-settings" ;;
+  esac
   local body hidden=""
-  body="$(curl -fsS --max-time 5 -H "X-Weave-Router-Key: $key" "${base_url%/}/v1/display-settings" 2>/dev/null)" || { [ -f "$cache" ] && { [ "$(cat "$cache" 2>/dev/null)" = "1" ] && return 0 || return 1; }; return 1; }
+  body="$(curl -fsS --max-time 5 -H "X-Weave-Router-Key: $key" "$url" 2>/dev/null)" || { [ -f "$cache" ] && { [ "$(cat "$cache" 2>/dev/null)" = "1" ] && return 0 || return 1; }; return 1; }
   hidden="$(printf '%s' "$body" | jq -r '.hide_terminal_surfaces // false' 2>/dev/null)"
   if [ "$hidden" = "true" ]; then
     printf '1' >"$cache" 2>/dev/null
@@ -3131,7 +3148,7 @@ weave_hidden_gate() {
   return 1
 }
 
-if weave_hidden_gate; then
+if weave_hidden_gate </dev/null; then
   exit 0
 fi
 

--- a/install/tests/cc-statusline_test.sh
+++ b/install/tests/cc-statusline_test.sh
@@ -404,6 +404,79 @@ sleep 1
 check "WEAVE_STATUSLINE_UPDATE=0 suppresses the wrapper refresh too" \
   "$(cat "$c/root/.claude/commands/fm.md")" "$before"
 
+# ---------- org "hide terminal surfaces" gate ----------
+#
+# The gate reads the org setting from GET /v1/display-settings. These cases stub
+# that endpoint with a tiny file:// server so no network is touched. The router
+# URL must be http for curl to reach the stub, so each case writes the stub's
+# address into the install's own settings (overriding WEAVE_ROUTER_BASE_URL).
+#
+# Drive the gate through a simpler seam than a live socket: WEAVE_ROUTER_BASE_URL
+# accepts a file:// URL, which curl reads as the response body. That exercises
+# the full parse-and-decide path (and the credential lookup) without a network.
+# The key just needs to be present and non-empty for the gate to proceed.
+#
+# write_install <base> <scope:user|project> <key> <url> — lay down a statusline
+# copy plus the settings.json/settings.local.json the gate reads, in the layout
+# the installer uses for that scope.
+write_install() { # write_install <base> <scope> <key> <display_settings_url>
+  local base="$1" scope="$2" key="$3" url="$4"
+  if [ "$scope" = "user" ]; then
+    mkdir -p "$base/.weave" "$base/.claude"
+    cp "$upstream" "$base/.weave/cc-statusline.sh"
+    cat > "$base/.claude/settings.json" <<EOF
+{"env":{"ANTHROPIC_BASE_URL":"$url","ANTHROPIC_CUSTOM_HEADERS":"X-Weave-Router-Key: $key"}}
+EOF
+    chmod +x "$base/.weave/cc-statusline.sh"
+  else
+    mkdir -p "$base/.claude"
+    cp "$upstream" "$base/.claude/cc-statusline.sh"
+    cat > "$base/.claude/settings.json" <<EOF
+{"env":{"ANTHROPIC_BASE_URL":"$url"}}
+EOF
+    cat > "$base/.claude/settings.local.json" <<EOF
+{"env":{"ANTHROPIC_CUSTOM_HEADERS":"X-Weave-Router-Key: $key"}}
+EOF
+    chmod +x "$base/.claude/cc-statusline.sh"
+  fi
+}
+
+# Project-scope hidden install renders blank: the gate reads the PROJECT key and
+# settings, sees hide_terminal_surfaces=true, and exits before printing.
+c="$work/g1"; mkdir -p "$c/proj/.claude" "$c/cache"
+printf '{"hide_terminal_surfaces": true}' > "$c/ds.json"
+write_install "$c/proj" project "rk_proj_hidden" "file://$c/ds.json"
+out="$(echo "{\"model\":{\"id\":\"$STALE_MODEL\"},\"transcript_path\":\"$transcript\"}" \
+  | XDG_CACHE_HOME="$c/cache" WEAVE_STATUSLINE_UPDATE=0 WEAVE_COMMANDS_UPDATE=0 HOME="$c/home" \
+    WEAVE_ROUTER_BASE_URL= ANTHROPIC_BASE_URL= WEAVE_ROUTER_KEY= ANTHROPIC_CUSTOM_HEADERS= \
+    bash "$c/proj/.claude/cc-statusline.sh" 2>&1)"
+check "project-scope hidden org renders a blank statusline" "$out" ""
+
+# The same project install must NOT fall back to the user-scope key: with a
+# hidden project org but a visible user org in $HOME, the project key wins and
+# the statusline still goes blank.
+c="$work/g2"; mkdir -p "$c/proj/.claude" "$c/home/.claude" "$c/cache"
+printf '{"hide_terminal_surfaces": true}' > "$c/ds_proj.json"
+printf '{"hide_terminal_surfaces": false}' > "$c/ds_user.json"
+write_install "$c/proj" project "rk_proj_hidden" "file://$c/ds_proj.json"
+write_install "$c/home" user "rk_user_visible" "file://$c/ds_user.json"
+out="$(echo "{\"model\":{\"id\":\"$STALE_MODEL\"},\"transcript_path\":\"$transcript\"}" \
+  | XDG_CACHE_HOME="$c/cache" WEAVE_STATUSLINE_UPDATE=0 WEAVE_COMMANDS_UPDATE=0 HOME="$c/home" \
+    WEAVE_ROUTER_BASE_URL= ANTHROPIC_BASE_URL= WEAVE_ROUTER_KEY= ANTHROPIC_CUSTOM_HEADERS= \
+    bash "$c/proj/.claude/cc-statusline.sh" 2>&1)"
+check "project install uses its own key, not the user-scope one" "$out" ""
+
+# Visible org (hidden=false) renders normally — the gate fails open and the
+# statusline still prints the routed model.
+c="$work/g3"; mkdir -p "$c/proj/.claude" "$c/cache"
+printf '{"hide_terminal_surfaces": false}' > "$c/ds.json"
+write_install "$c/proj" project "rk_proj_visible" "file://$c/ds.json"
+out="$(echo "{\"model\":{\"id\":\"$STALE_MODEL\"},\"transcript_path\":\"$transcript\"}" \
+  | XDG_CACHE_HOME="$c/cache" WEAVE_STATUSLINE_UPDATE=0 WEAVE_COMMANDS_UPDATE=0 HOME="$c/home" \
+    WEAVE_ROUTER_BASE_URL= ANTHROPIC_BASE_URL= WEAVE_ROUTER_KEY= ANTHROPIC_CUSTOM_HEADERS= \
+    bash "$c/proj/.claude/cc-statusline.sh" 2>&1 | sed 's/\x1b\[[0-9;]*m//g')"
+check_contains "visible org still renders the statusline" "$out" "deepseek/deepseek-v4-pro"
+
 # install.sh ships the statusline as a heredoc; genprices keeps only the price
 # block in sync, so a code edit to one copy silently diverges from the other.
 installer="$script_dir/../install.sh"

--- a/internal/api/admin/display_settings.go
+++ b/internal/api/admin/display_settings.go
@@ -8,17 +8,12 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
-// displaySettingsResponse is the client-facing view of the per-installation
-// terminal-surface display toggles. The installer and statusline read it with
-// the data-plane rk_ key to decide whether to render router surfaces
-// (statusline bar today); it carries no billing or routing internals.
+// displaySettingsResponse is the per-installation toggle set read by the installer and statusline.
 type displaySettingsResponse struct {
 	HideTerminalSurfaces bool `json:"hide_terminal_surfaces"`
 }
 
-// DisplaySettingsHandler returns the calling installation's display toggles.
-// Bearer rk_ auth only (mounted on the data plane, not the admin dashboard):
-// the key identifies the org, so the response is already scoped to the caller.
+// DisplaySettingsHandler returns the calling installation's display toggles (scoped to the caller by the rk_ bearer key).
 func DisplaySettingsHandler(c *gin.Context) {
 	installation := middleware.InstallationFrom(c)
 	if installation == nil {

--- a/internal/api/admin/display_settings.go
+++ b/internal/api/admin/display_settings.go
@@ -1,0 +1,31 @@
+package admin
+
+import (
+	"net/http"
+
+	"workweave/router/internal/server/middleware"
+
+	"github.com/gin-gonic/gin"
+)
+
+// displaySettingsResponse is the client-facing view of the per-installation
+// terminal-surface display toggles. The installer and statusline read it with
+// the data-plane rk_ key to decide whether to render router surfaces
+// (statusline bar today); it carries no billing or routing internals.
+type displaySettingsResponse struct {
+	HideTerminalSurfaces bool `json:"hide_terminal_surfaces"`
+}
+
+// DisplaySettingsHandler returns the calling installation's display toggles.
+// Bearer rk_ auth only (mounted on the data plane, not the admin dashboard):
+// the key identifies the org, so the response is already scoped to the caller.
+func DisplaySettingsHandler(c *gin.Context) {
+	installation := middleware.InstallationFrom(c)
+	if installation == nil {
+		c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "invalid_key"})
+		return
+	}
+	c.JSON(http.StatusOK, displaySettingsResponse{
+		HideTerminalSurfaces: installation.HideTerminalSurfaces,
+	})
+}

--- a/internal/api/admin/display_settings_test.go
+++ b/internal/api/admin/display_settings_test.go
@@ -1,0 +1,51 @@
+package admin_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"workweave/router/internal/api/admin"
+	"workweave/router/internal/auth"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+)
+
+// DisplaySettingsHandler must report the installation's hide_terminal_surfaces
+// flag verbatim so the installer/statusline can render the slot blank when the
+// org has hidden router surfaces, and reject requests with no installation
+// (the rk_ auth middleware populates the gin context upstream).
+func TestDisplaySettingsHandler(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	t.Run("reports the installation flag", func(t *testing.T) {
+		for _, hide := range []bool{true, false} {
+			engine := gin.New()
+			engine.GET("/v1/display-settings", func(c *gin.Context) {
+				c.Set("router_installation", &auth.Installation{ID: "inst-1", HideTerminalSurfaces: hide})
+			}, admin.DisplaySettingsHandler)
+
+			rec := httptest.NewRecorder()
+			engine.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/v1/display-settings", nil))
+
+			require.Equal(t, http.StatusOK, rec.Code)
+			var body struct {
+				HideTerminalSurfaces bool `json:"hide_terminal_surfaces"`
+			}
+			require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+			require.Equal(t, hide, body.HideTerminalSurfaces)
+		}
+	})
+
+	t.Run("unauthenticated without an installation", func(t *testing.T) {
+		engine := gin.New()
+		engine.GET("/v1/display-settings", admin.DisplaySettingsHandler)
+
+		rec := httptest.NewRecorder()
+		engine.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/v1/display-settings", nil))
+
+		require.Equal(t, http.StatusUnauthorized, rec.Code)
+	})
+}

--- a/internal/api/admin/display_settings_test.go
+++ b/internal/api/admin/display_settings_test.go
@@ -13,10 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// DisplaySettingsHandler must report the installation's hide_terminal_surfaces
-// flag verbatim so the installer/statusline can render the slot blank when the
-// org has hidden router surfaces, and reject requests with no installation
-// (the rk_ auth middleware populates the gin context upstream).
+// TestDisplaySettingsHandler covers the flag passthrough and unauthenticated rejection.
 func TestDisplaySettingsHandler(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 

--- a/internal/auth/installation.go
+++ b/internal/auth/installation.go
@@ -77,11 +77,8 @@ type Installation struct {
 	// ("off"|"hashed"|"full"); nil means no override; can only tighten
 	// WV_CAPTURE_CONTENT.
 	ContentCaptureMode *string
-	// HideTerminalSurfaces hides the router's terminal surfaces (routing
-	// marker, feedback footer, statusline) from the caller. Requests route
-	// identically; only what is rendered in the terminal changes. Feedback
-	// submission/recording is unaffected. Defaults false -- preserves today's
-	// behavior.
+	// HideTerminalSurfaces suppresses the routing marker, feedback footer, and
+	// statusline; routing and feedback recording are unaffected. Defaults false.
 	HideTerminalSurfaces bool
 }
 

--- a/internal/auth/installation.go
+++ b/internal/auth/installation.go
@@ -77,6 +77,12 @@ type Installation struct {
 	// ("off"|"hashed"|"full"); nil means no override; can only tighten
 	// WV_CAPTURE_CONTENT.
 	ContentCaptureMode *string
+	// HideTerminalSurfaces hides the router's terminal surfaces (routing
+	// marker, feedback footer, statusline) from the caller. Requests route
+	// identically; only what is rendered in the terminal changes. Feedback
+	// submission/recording is unaffected. Defaults false -- preserves today's
+	// behavior.
+	HideTerminalSurfaces bool
 }
 
 type CreateInstallationParams struct {
@@ -112,4 +118,7 @@ type InstallationRepository interface {
 	// UpdateContentCaptureMode sets the per-installation capture ceiling; nil
 	// clears the override.
 	UpdateContentCaptureMode(ctx context.Context, externalID, id string, mode *string) error
+	// UpdateHideTerminalSurfaces toggles hiding the router's terminal surfaces
+	// (routing marker, feedback footer, statusline) for the installation.
+	UpdateHideTerminalSurfaces(ctx context.Context, externalID, id string, hide bool) error
 }

--- a/internal/auth/service.go
+++ b/internal/auth/service.go
@@ -441,10 +441,8 @@ func (s *Service) SetInstallationSubscriptionRoutingDisabled(ctx context.Context
 	return nil
 }
 
-// SetInstallationHideTerminalSurfaces toggles hiding the router's terminal
-// surfaces (routing marker, feedback footer, statusline) for the installation.
-// Invalidates the cache so the change applies on the next request instead of
-// waiting out the TTL.
+// SetInstallationHideTerminalSurfaces persists the toggle and invalidates the
+// auth cache so the change takes effect on the next request.
 func (s *Service) SetInstallationHideTerminalSurfaces(ctx context.Context, externalID, installationID string, hide bool) error {
 	if err := s.installations.UpdateHideTerminalSurfaces(ctx, externalID, installationID, hide); err != nil {
 		return err

--- a/internal/auth/service.go
+++ b/internal/auth/service.go
@@ -441,6 +441,18 @@ func (s *Service) SetInstallationSubscriptionRoutingDisabled(ctx context.Context
 	return nil
 }
 
+// SetInstallationHideTerminalSurfaces toggles hiding the router's terminal
+// surfaces (routing marker, feedback footer, statusline) for the installation.
+// Invalidates the cache so the change applies on the next request instead of
+// waiting out the TTL.
+func (s *Service) SetInstallationHideTerminalSurfaces(ctx context.Context, externalID, installationID string, hide bool) error {
+	if err := s.installations.UpdateHideTerminalSurfaces(ctx, externalID, installationID, hide); err != nil {
+		return err
+	}
+	s.invalidateInstallation(installationID)
+	return nil
+}
+
 // ErrInvalidCaptureMode is returned for a content-capture mode outside the
 // off/hashed/full set.
 var ErrInvalidCaptureMode = errors.New("auth: invalid content capture mode")

--- a/internal/auth/service_test.go
+++ b/internal/auth/service_test.go
@@ -143,6 +143,7 @@ type fakeInstallationRepository struct {
 	usageBypassThresholdByID        map[string]*float64
 	subscriptionRoutingDisabledByID map[string]bool
 	contentCaptureModeByID          map[string]*string
+	hideTerminalSurfacesByID        map[string]bool
 	// updateErr, when set, is returned by Update* methods instead of recording —
 	// simulates a zero-row update (stale/soft-deleted/cross-tenant id), which the
 	// real postgres repo surfaces as auth.ErrInstallationNotFound.
@@ -217,6 +218,16 @@ func (f *fakeInstallationRepository) UpdateSubscriptionRoutingDisabled(ctx conte
 		f.subscriptionRoutingDisabledByID = map[string]bool{}
 	}
 	f.subscriptionRoutingDisabledByID[id] = disabled
+	return nil
+}
+func (f *fakeInstallationRepository) UpdateHideTerminalSurfaces(ctx context.Context, externalID, id string, hide bool) error {
+	if f.updateErr != nil {
+		return f.updateErr
+	}
+	if f.hideTerminalSurfacesByID == nil {
+		f.hideTerminalSurfacesByID = map[string]bool{}
+	}
+	f.hideTerminalSurfacesByID[id] = hide
 	return nil
 }
 func (f *fakeInstallationRepository) UpdateUsageBypass(ctx context.Context, externalID, id string, enabled bool, threshold *float64) error {

--- a/internal/postgres/converters.go
+++ b/internal/postgres/converters.go
@@ -48,6 +48,7 @@ func toAuthInstallation(row sqlc.RouterModelRouterInstallation) *auth.Installati
 		AITrainingAllowed:            row.AiTrainingAllowed,
 		ByokEnabled:                  row.ByokEnabled,
 		ContentCaptureMode:           row.ContentCaptureMode,
+		HideTerminalSurfaces:         row.HideTerminalSurfaces,
 	}
 }
 

--- a/internal/postgres/repository.go
+++ b/internal/postgres/repository.go
@@ -221,6 +221,26 @@ func (r *installationRepo) UpdateContentCaptureMode(ctx context.Context, externa
 	return nil
 }
 
+func (r *installationRepo) UpdateHideTerminalSurfaces(ctx context.Context, externalID, id string, hide bool) error {
+	parsed, err := uuid.Parse(id)
+	if err != nil {
+		return err
+	}
+	q := sqlc.New(r.tx)
+	rows, err := q.UpdateModelRouterInstallationHideTerminalSurfaces(ctx, sqlc.UpdateModelRouterInstallationHideTerminalSurfacesParams{
+		ID:                   parsed,
+		ExternalID:           externalID,
+		HideTerminalSurfaces: hide,
+	})
+	if err != nil {
+		return err
+	}
+	if rows == 0 {
+		return auth.ErrInstallationNotFound
+	}
+	return nil
+}
+
 type apiKeyRepo struct {
 	tx sqlc.DBTX
 }

--- a/internal/proxy/feedback.go
+++ b/internal/proxy/feedback.go
@@ -163,8 +163,13 @@ func (s *Service) mintFeedbackToken(installationID uuid.UUID, externalID, reques
 }
 
 // setFeedbackLinkHeader mints a signed feedback link and sets it on the
-// response. No-op when the feature is unwired or any required id is missing.
-func (s *Service) setFeedbackLinkHeader(w http.ResponseWriter, installationID uuid.UUID, externalID, requestID, routerUserID string) {
+// response. No-op when the feature is unwired, any required id is missing, or
+// the installation has hidden its terminal surfaces (the link displays the
+// routing decision, which hidden orgs don't surface).
+func (s *Service) setFeedbackLinkHeader(ctx context.Context, w http.ResponseWriter, installationID uuid.UUID, externalID, requestID, routerUserID string) {
+	if hideTerminalSurfacesForRequest(ctx) {
+		return
+	}
 	token := s.mintFeedbackToken(installationID, externalID, requestID, routerUserID)
 	if token == "" {
 		return
@@ -199,7 +204,10 @@ const feedbackFooterText = "\n\n_Weave Router feedback:_ `/rf +` good experience
 // dispatches and machine turns (compaction, probe, title-gen, classifier)
 // render final text the user didn't directly initiate, where a trailing /rf
 // hint would strand beneath it (e.g. under an Explore subagent's result).
-func (s *Service) feedbackFooter(clientApp string, tt turntype.TurnType) string {
+func (s *Service) feedbackFooter(ctx context.Context, clientApp string, tt turntype.TurnType) string {
+	if hideTerminalSurfacesForRequest(ctx) {
+		return ""
+	}
 	if s.feedbackStore == nil {
 		return ""
 	}

--- a/internal/proxy/feedback.go
+++ b/internal/proxy/feedback.go
@@ -163,9 +163,8 @@ func (s *Service) mintFeedbackToken(installationID uuid.UUID, externalID, reques
 }
 
 // setFeedbackLinkHeader mints a signed feedback link and sets it on the
-// response. No-op when the feature is unwired, any required id is missing, or
-// the installation has hidden its terminal surfaces (the link displays the
-// routing decision, which hidden orgs don't surface).
+// response. No-op when the feature is unwired, any required id is missing,
+// or the installation has hidden its terminal surfaces.
 func (s *Service) setFeedbackLinkHeader(ctx context.Context, w http.ResponseWriter, installationID uuid.UUID, externalID, requestID, routerUserID string) {
 	if hideTerminalSurfacesForRequest(ctx) {
 		return

--- a/internal/proxy/feedback_footer_internal_test.go
+++ b/internal/proxy/feedback_footer_internal_test.go
@@ -18,7 +18,7 @@ func TestFeedbackFooter_ClientGating(t *testing.T) {
 
 	t.Run("terminal agents get the link-free rating hint", func(t *testing.T) {
 		for _, app := range []string{ClientAppClaudeCode, ClientAppCodex, ClientAppOpencode} {
-			footer := withStore.feedbackFooter(app, turntype.MainLoop)
+			footer := withStore.feedbackFooter(context.Background(), app, turntype.MainLoop)
 			assert.Equal(t, feedbackFooterText, footer, "expected hint for %q", app)
 			assert.NotContains(t, footer, "http", "footer must never embed a raw link")
 		}
@@ -26,12 +26,17 @@ func TestFeedbackFooter_ClientGating(t *testing.T) {
 
 	t.Run("ide and unknown clients are suppressed", func(t *testing.T) {
 		for _, app := range []string{ClientAppCursor, ClientAppGeminiCLI, "", "some-bot"} {
-			assert.Empty(t, withStore.feedbackFooter(app, turntype.MainLoop), "expected no footer for %q", app)
+			assert.Empty(t, withStore.feedbackFooter(context.Background(), app, turntype.MainLoop), "expected no footer for %q", app)
 		}
 	})
 
 	t.Run("no durable store suppresses the hint entirely", func(t *testing.T) {
-		assert.Empty(t, (&Service{}).feedbackFooter(ClientAppClaudeCode, turntype.MainLoop), "advertising a command we cannot record is misleading")
+		assert.Empty(t, (&Service{}).feedbackFooter(context.Background(), ClientAppClaudeCode, turntype.MainLoop), "advertising a command we cannot record is misleading")
+	})
+
+	t.Run("hidden terminal surfaces suppress the hint even for a main-loop turn", func(t *testing.T) {
+		hiddenCtx := context.WithValue(context.Background(), InstallationHideTerminalSurfacesContextKey{}, true)
+		assert.Empty(t, withStore.feedbackFooter(hiddenCtx, ClientAppClaudeCode, turntype.MainLoop), "hidden orgs get no /rf hint")
 	})
 }
 
@@ -40,7 +45,7 @@ func TestFeedbackFooter_TurnTypeGating(t *testing.T) {
 
 	t.Run("the user's own conversation turns get the hint", func(t *testing.T) {
 		for _, tt := range []turntype.TurnType{turntype.MainLoop, turntype.ToolResult} {
-			assert.Equal(t, feedbackFooterText, withStore.feedbackFooter(ClientAppClaudeCode, tt), "expected hint for %q", tt)
+			assert.Equal(t, feedbackFooterText, withStore.feedbackFooter(context.Background(), ClientAppClaudeCode, tt), "expected hint for %q", tt)
 		}
 	})
 
@@ -52,7 +57,7 @@ func TestFeedbackFooter_TurnTypeGating(t *testing.T) {
 			turntype.TitleGen,
 			turntype.Classifier,
 		} {
-			assert.Empty(t, withStore.feedbackFooter(ClientAppClaudeCode, tt), "expected no footer for %q — hint would strand under output the user never initiated", tt)
+			assert.Empty(t, withStore.feedbackFooter(context.Background(), ClientAppClaudeCode, tt), "expected no footer for %q — hint would strand under output the user never initiated", tt)
 		}
 	})
 }

--- a/internal/proxy/gemini.go
+++ b/internal/proxy/gemini.go
@@ -139,7 +139,7 @@ func (s *Service) ProxyGeminiGenerateContent(ctx context.Context, body []byte, w
 	w.Header().Set(HeaderRouterModel, decision.Model)
 	// Gemini path does not resolve a router user, matching the decision span
 	// below which omits router_user_id.
-	s.setFeedbackLinkHeader(w, installationID, externalID, requestID, "")
+	s.setFeedbackLinkHeader(ctx, w, installationID, externalID, requestID, "")
 
 	reqPricing := otel.Lookup(s.baselineFor(feats.Model))
 	actPricing := otel.Lookup(decision.Model)
@@ -209,14 +209,14 @@ func (s *Service) ProxyGeminiGenerateContent(ctx context.Context, body []byte, w
 	// router user, matching the decision span and feedback header above.
 	clientSink := w
 	if env.Stream() {
-		if footer := s.feedbackFooter(ClientIdentityFrom(ctx).ClientApp, routeRes.TurnType); footer != "" {
+		if footer := s.feedbackFooter(ctx, ClientIdentityFrom(ctx).ClientApp, routeRes.TurnType); footer != "" {
 			clientSink = translate.NewGeminiRoutingFooterWriter(w, footer)
 		}
 	}
 	contentSink, contentCap := s.maybeCaptureResponse(ctx, clientSink)
 	// preludeBuf delays commit so a 429 or empty stream stays retryable.
 	preludeBuf := newPreludeBuffer(contentSink)
-	marker := suppressMarkerIfRequested(r.Header, routingMarkerFor(routeRes))
+	marker := suppressMarkerIfRequested(ctx, r.Header, routingMarkerFor(routeRes))
 	bindings := s.resolveBindingsForDispatch(ctx, decision)
 	attempt := func(actx context.Context, d router.Decision, p providers.Client) error {
 		attemptSink := http.ResponseWriter(preludeBuf)

--- a/internal/proxy/marker_optout_internal_test.go
+++ b/internal/proxy/marker_optout_internal_test.go
@@ -1,6 +1,7 @@
 package proxy
 
 import (
+	"context"
 	"net/http"
 	"testing"
 
@@ -34,7 +35,21 @@ func TestSuppressMarkerIfRequested(t *testing.T) {
 			if tc.setHeader {
 				h.Set(routingMarkerHeader, tc.value)
 			}
-			assert.Equal(t, tc.want, suppressMarkerIfRequested(h, marker))
+			assert.Equal(t, tc.want, suppressMarkerIfRequested(context.Background(), h, marker))
 		})
 	}
+}
+
+// TestSuppressMarkerIfRequestedHiddenByInstallation pins that an installation
+// with terminal surfaces hidden drops the marker regardless of the header.
+func TestSuppressMarkerIfRequestedHiddenByInstallation(t *testing.T) {
+	const marker = "✦ **Weave Router** → deepseek/deepseek-v4-flash · best pick for this turn\n\n"
+	h := http.Header{}
+
+	// Hidden: even an absent header (which would keep the marker) yields "".
+	hiddenCtx := context.WithValue(context.Background(), InstallationHideTerminalSurfacesContextKey{}, true)
+	assert.Equal(t, "", suppressMarkerIfRequested(hiddenCtx, h, marker))
+
+	// Visible: same header state keeps the marker.
+	assert.Equal(t, marker, suppressMarkerIfRequested(context.Background(), h, marker))
 }

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -379,8 +379,8 @@ type InstallationUsageBypassContextKey struct{}
 type InstallationSubscriptionRoutingDisabledContextKey struct{}
 
 // InstallationHideTerminalSurfacesContextKey is the context key for the
-// installation's hide-terminal-surfaces toggle (bool; absent == false).
-// Suppresses the routing marker, feedback footer, and feedback-link header.
+// installation's hide-terminal-surfaces toggle (bool; absent == false);
+// suppresses the routing marker, feedback footer, and feedback-link header.
 type InstallationHideTerminalSurfacesContextKey struct{}
 
 // PolicyTrainingAllowedContextKey carries the installation's explicit

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -378,11 +378,9 @@ type InstallationUsageBypassContextKey struct{}
 // routing decides on merits. See subscriptionRoutingDisabledForRequest.
 type InstallationSubscriptionRoutingDisabledContextKey struct{}
 
-// InstallationHideTerminalSurfacesContextKey is the context key for the authed
-// installation's "hide terminal surfaces" toggle. Carried as bool; absent
-// (== false) when the installation hasn't hidden them. When set, the routing
-// marker, feedback footer, and feedback-link header are suppressed. See
-// hideTerminalSurfacesForRequest.
+// InstallationHideTerminalSurfacesContextKey is the context key for the
+// installation's hide-terminal-surfaces toggle (bool; absent == false).
+// Suppresses the routing marker, feedback footer, and feedback-link header.
 type InstallationHideTerminalSurfacesContextKey struct{}
 
 // PolicyTrainingAllowedContextKey carries the installation's explicit
@@ -626,9 +624,7 @@ func subscriptionRoutingDisabledForRequest(ctx context.Context) bool {
 	return disabled
 }
 
-// hideTerminalSurfacesForRequest reports whether the authed installation has
-// hidden the router's terminal surfaces. When true, the routing marker,
-// feedback footer, and feedback-link header are suppressed for this request.
+// hideTerminalSurfacesForRequest reports whether terminal surfaces are hidden for this request.
 func hideTerminalSurfacesForRequest(ctx context.Context) bool {
 	hide, _ := ctx.Value(InstallationHideTerminalSurfacesContextKey{}).(bool)
 	return hide

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -378,6 +378,13 @@ type InstallationUsageBypassContextKey struct{}
 // routing decides on merits. See subscriptionRoutingDisabledForRequest.
 type InstallationSubscriptionRoutingDisabledContextKey struct{}
 
+// InstallationHideTerminalSurfacesContextKey is the context key for the authed
+// installation's "hide terminal surfaces" toggle. Carried as bool; absent
+// (== false) when the installation hasn't hidden them. When set, the routing
+// marker, feedback footer, and feedback-link header are suppressed. See
+// hideTerminalSurfacesForRequest.
+type InstallationHideTerminalSurfacesContextKey struct{}
+
 // PolicyTrainingAllowedContextKey carries the installation's explicit
 // learning eligibility. Absence is fail-closed (false).
 type PolicyTrainingAllowedContextKey struct{}
@@ -438,9 +445,13 @@ type policyOutcomeResponse struct {
 }
 
 // suppressMarkerIfRequested returns "" when the request opted out via
-// routingMarkerHeader, otherwise the marker unchanged. Only applies to the
-// per-turn routing badge; no-progress/loop/force-model markers always fire.
-func suppressMarkerIfRequested(h http.Header, marker string) string {
+// routingMarkerHeader or the installation has hidden terminal surfaces,
+// otherwise the marker unchanged. Only applies to the per-turn routing badge;
+// no-progress/loop/force-model markers always fire.
+func suppressMarkerIfRequested(ctx context.Context, h http.Header, marker string) string {
+	if hideTerminalSurfacesForRequest(ctx) {
+		return ""
+	}
 	switch strings.ToLower(strings.TrimSpace(h.Get(routingMarkerHeader))) {
 	case "off", "false", "0", "none":
 		return ""
@@ -613,6 +624,14 @@ func installationExcludedModelsFromContext(ctx context.Context) []string {
 func subscriptionRoutingDisabledForRequest(ctx context.Context) bool {
 	disabled, _ := ctx.Value(InstallationSubscriptionRoutingDisabledContextKey{}).(bool)
 	return disabled
+}
+
+// hideTerminalSurfacesForRequest reports whether the authed installation has
+// hidden the router's terminal surfaces. When true, the routing marker,
+// feedback footer, and feedback-link header are suppressed for this request.
+func hideTerminalSurfacesForRequest(ctx context.Context) bool {
+	hide, _ := ctx.Value(InstallationHideTerminalSurfacesContextKey{}).(bool)
+	return hide
 }
 
 // routingKnobsForRequest resolves the routing knobs for a request. The
@@ -2620,7 +2639,7 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 	w.Header().Set(HeaderRouterProvider, decision.Provider)
 	w.Header().Set(HeaderRouterModel, decision.Model)
 	if !agentShadowMode {
-		s.setFeedbackLinkHeader(w, installationID, externalID, requestID, auth.UserIDFrom(ctx))
+		s.setFeedbackLinkHeader(ctx, w, installationID, externalID, requestID, auth.UserIDFrom(ctx))
 	}
 
 	if _, err := s.provider(decision.Provider); err != nil {
@@ -2728,7 +2747,7 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 	// cached/logged bodies. Transparent when streaming/feedback is off.
 	clientSink := w
 	if env.Stream() && !agentShadowMode {
-		if footer := s.feedbackFooter(ClientIdentityFrom(ctx).ClientApp, routeRes.TurnType); footer != "" {
+		if footer := s.feedbackFooter(ctx, ClientIdentityFrom(ctx).ClientApp, routeRes.TurnType); footer != "" {
 			clientSink = translate.NewAnthropicRoutingFooterWriter(w, footer)
 		}
 	}
@@ -2764,7 +2783,7 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 	// request body. Zero for Anthropic-native passthrough.
 	var reqStats providers.RequestMutationStats
 
-	marker := suppressMarkerIfRequested(r.Header, routingMarkerFor(routeRes))
+	marker := suppressMarkerIfRequested(ctx, r.Header, routingMarkerFor(routeRes))
 	// Subscription-only served-on-sub turn: replace the routing marker with the
 	// depleted-credits warning (like the OpenAI path and the usage-bypass path),
 	// not gated by the routing-marker opt-out. The pre-dispatch guard above has
@@ -3083,7 +3102,7 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 			}
 			baselineCtx = resolveAndInjectCredentials(baselineCtx, providers.ProviderAnthropic, baselineModel, r.Header)
 			baselineBindings := s.resolveBindingsForDispatch(baselineCtx, baselineDecision)
-			baselineMarker := suppressMarkerIfRequested(r.Header, baselineRoutingMarkerFor(routeRes, baselineModel))
+			baselineMarker := suppressMarkerIfRequested(ctx, r.Header, baselineRoutingMarkerFor(routeRes, baselineModel))
 			baselineAttempt := s.anthropicNativeAttempt(env, r, baselinePrep, sink, preludeBuf, baselineMarker, setExtractor)
 			crossFormat = false
 			respSummary = translate.ResponseSummary{}
@@ -3202,7 +3221,7 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 		}
 		siblingCtx := resolveAndInjectCredentials(ctx, siblingDecision.Provider, siblingDecision.Model, r.Header)
 		siblingBindings := s.resolveBindingsForDispatch(siblingCtx, siblingDecision)
-		siblingMarker := suppressMarkerIfRequested(r.Header, siblingRoutingMarkerFor(routeRes, siblingDecision.Model))
+		siblingMarker := suppressMarkerIfRequested(ctx, r.Header, siblingRoutingMarkerFor(routeRes, siblingDecision.Model))
 		siblingAttempt, siblingBuildErr := buildAttempt(siblingDecision, siblingOpts, siblingMarker)
 		switch {
 		case siblingBuildErr != nil:
@@ -4882,7 +4901,7 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 	w.Header().Set(HeaderRouterDecision, decision.Reason)
 	w.Header().Set(HeaderRouterProvider, decision.Provider)
 	w.Header().Set(HeaderRouterModel, decision.Model)
-	s.setFeedbackLinkHeader(w, installationID, externalID, requestID, auth.UserIDFrom(ctx))
+	s.setFeedbackLinkHeader(ctx, w, installationID, externalID, requestID, auth.UserIDFrom(ctx))
 
 	reqPricing := otel.Lookup(s.baselineFor(feats.Model))
 	actPricing := otel.Lookup(decision.Model)
@@ -4966,7 +4985,7 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 	// special-casing — /v1/responses footers are a follow-up.
 	clientSink := w
 	if _, isResponses := w.(*translate.ResponsesWriter); env.Stream() && !isResponses {
-		if footer := s.feedbackFooter(ClientIdentityFrom(ctx).ClientApp, routeRes.TurnType); footer != "" {
+		if footer := s.feedbackFooter(ctx, ClientIdentityFrom(ctx).ClientApp, routeRes.TurnType); footer != "" {
 			clientSink = translate.NewOpenAIRoutingFooterWriter(w, footer)
 		}
 	}
@@ -4974,7 +4993,7 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 	preludeBuf := newPreludeBuffer(contentSink)
 	var rootSink http.ResponseWriter = preludeBuf
 
-	marker := suppressMarkerIfRequested(r.Header, routingMarkerFor(routeRes))
+	marker := suppressMarkerIfRequested(ctx, r.Header, routingMarkerFor(routeRes))
 	if billing.SubscriptionOnlyFromContext(ctx) {
 		// Always surface the depleted-credits warning (not gated by the
 		// routing-marker opt-out): a billing state change the caller must see.
@@ -5004,7 +5023,7 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 		// single-binding GPT model with no cross-format fallback to retry
 		// into. If a GPT model ever gains a fallback, gate this per-attempt.
 		if verbatimPassthrough {
-			markerEnabled := suppressMarkerIfRequested(r.Header, "enabled") != "" && !routeRes.SuggestionMode
+			markerEnabled := suppressMarkerIfRequested(ctx, r.Header, "enabled") != "" && !routeRes.SuggestionMode
 			mandatoryWarning := billing.SubscriptionOnlyFromContext(ctx)
 			if clientID.ClientApp == ClientAppCodex && (markerEnabled || mandatoryWarning) {
 				if mandatoryWarning {

--- a/internal/server/middleware/auth.go
+++ b/internal/server/middleware/auth.go
@@ -130,6 +130,9 @@ func withAPIKey(svc *auth.Service, byokRequiresOptIn bool) gin.HandlerFunc {
 			if installation.SubscriptionRoutingDisabled {
 				ctx = context.WithValue(ctx, proxy.InstallationSubscriptionRoutingDisabledContextKey{}, true)
 			}
+			if installation.HideTerminalSurfaces {
+				ctx = context.WithValue(ctx, proxy.InstallationHideTerminalSurfacesContextKey{}, true)
+			}
 			if installation.RoutingRolloutID != "" {
 				ctx = context.WithValue(ctx, proxy.PolicyRolloutIDContextKey{}, installation.RoutingRolloutID)
 			}

--- a/internal/server/middleware/auth_test.go
+++ b/internal/server/middleware/auth_test.go
@@ -130,6 +130,9 @@ func (fakeInstallationRepository) UpdateSubscriptionRoutingDisabled(ctx context.
 func (fakeInstallationRepository) UpdateContentCaptureMode(ctx context.Context, externalID, id string, mode *string) error {
 	return errors.New("not used")
 }
+func (fakeInstallationRepository) UpdateHideTerminalSurfaces(ctx context.Context, externalID, id string, hide bool) error {
+	return errors.New("not used")
+}
 
 func TestWithAuthPrefersRouterKeyHeader(t *testing.T) {
 	gin.SetMode(gin.TestMode)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -225,6 +225,10 @@ func Register(engine *gin.Engine, authSvc *auth.Service, proxySvc *proxy.Service
 	passthroughGroup.POST("/v1/messages/count_tokens", anthropicapi.PassthroughHandler(proxySvc))
 	passthroughGroup.GET("/v1/models", openaiapi.ModelsHandler(anthropicapi.PassthroughHandler(proxySvc)))
 	passthroughGroup.GET("/v1/models/:model", anthropicapi.PassthroughHandler(proxySvc))
+	// Per-installation terminal-surface display toggles, read by the installer
+	// and statusline with the same rk_ key. Read-only and free of billing
+	// internals, so it rides the cheap passthrough group.
+	passthroughGroup.GET("/v1/display-settings", admin.DisplaySettingsHandler)
 
 	routeMiddleware := []gin.HandlerFunc{
 		middleware.WithTimeout(routeTimeout),

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -225,9 +225,7 @@ func Register(engine *gin.Engine, authSvc *auth.Service, proxySvc *proxy.Service
 	passthroughGroup.POST("/v1/messages/count_tokens", anthropicapi.PassthroughHandler(proxySvc))
 	passthroughGroup.GET("/v1/models", openaiapi.ModelsHandler(anthropicapi.PassthroughHandler(proxySvc)))
 	passthroughGroup.GET("/v1/models/:model", anthropicapi.PassthroughHandler(proxySvc))
-	// Per-installation terminal-surface display toggles, read by the installer
-	// and statusline with the same rk_ key. Read-only and free of billing
-	// internals, so it rides the cheap passthrough group.
+	// Rides the passthrough group (cheap, no billing middleware) — read-only, no routing side-effects.
 	passthroughGroup.GET("/v1/display-settings", admin.DisplaySettingsHandler)
 
 	routeMiddleware := []gin.HandlerFunc{

--- a/internal/sqlc/model_router_api_keys.sql.go
+++ b/internal/sqlc/model_router_api_keys.sql.go
@@ -102,7 +102,7 @@ func (q *Queries) CreateModelRouterAPIKey(ctx context.Context, arg CreateModelRo
 }
 
 const getActiveModelRouterAPIKeyWithInstallationByHash = `-- name: GetActiveModelRouterAPIKeyWithInstallationByHash :one
-SELECT k.id, k.installation_id, k.external_id, k.name, k.key_prefix, k.key_hash, k.key_suffix, k.last_used_at, k.created_at, k.deleted_at, k.created_by, k.spend_cap_usd_micros, k.spent_usd_micros, k.scope, i.id, i.external_id, i.name, i.created_at, i.updated_at, i.deleted_at, i.created_by, i.excluded_models, i.excluded_providers, i.routing_quality_weight, i.usage_bypass_enabled, i.usage_bypass_threshold, i.preferred_models, i.subscription_routing_disabled, i.routing_strategy, i.routing_rollout_id, i.policy_shadow_strategy, i.policy_debug_enabled, i.policy_header_overrides_enabled, i.policy_routing_intent, i.ai_training_allowed, i.byok_enabled, i.content_capture_mode
+SELECT k.id, k.installation_id, k.external_id, k.name, k.key_prefix, k.key_hash, k.key_suffix, k.last_used_at, k.created_at, k.deleted_at, k.created_by, k.spend_cap_usd_micros, k.spent_usd_micros, k.scope, i.id, i.external_id, i.name, i.created_at, i.updated_at, i.deleted_at, i.created_by, i.excluded_models, i.excluded_providers, i.routing_quality_weight, i.usage_bypass_enabled, i.usage_bypass_threshold, i.preferred_models, i.subscription_routing_disabled, i.routing_strategy, i.routing_rollout_id, i.policy_shadow_strategy, i.policy_debug_enabled, i.policy_header_overrides_enabled, i.policy_routing_intent, i.ai_training_allowed, i.byok_enabled, i.content_capture_mode, i.hide_terminal_surfaces
 FROM router.model_router_api_keys k
 INNER JOIN router.model_router_installations i ON i.id = k.installation_id
 WHERE k.key_hash = $1::varchar
@@ -121,7 +121,7 @@ type GetActiveModelRouterAPIKeyWithInstallationByHashRow struct {
 // both sides so a soft-deleted installation invalidates all its keys without per-key
 // updates.
 //
-//	SELECT k.id, k.installation_id, k.external_id, k.name, k.key_prefix, k.key_hash, k.key_suffix, k.last_used_at, k.created_at, k.deleted_at, k.created_by, k.spend_cap_usd_micros, k.spent_usd_micros, k.scope, i.id, i.external_id, i.name, i.created_at, i.updated_at, i.deleted_at, i.created_by, i.excluded_models, i.excluded_providers, i.routing_quality_weight, i.usage_bypass_enabled, i.usage_bypass_threshold, i.preferred_models, i.subscription_routing_disabled, i.routing_strategy, i.routing_rollout_id, i.policy_shadow_strategy, i.policy_debug_enabled, i.policy_header_overrides_enabled, i.policy_routing_intent, i.ai_training_allowed, i.byok_enabled, i.content_capture_mode
+//	SELECT k.id, k.installation_id, k.external_id, k.name, k.key_prefix, k.key_hash, k.key_suffix, k.last_used_at, k.created_at, k.deleted_at, k.created_by, k.spend_cap_usd_micros, k.spent_usd_micros, k.scope, i.id, i.external_id, i.name, i.created_at, i.updated_at, i.deleted_at, i.created_by, i.excluded_models, i.excluded_providers, i.routing_quality_weight, i.usage_bypass_enabled, i.usage_bypass_threshold, i.preferred_models, i.subscription_routing_disabled, i.routing_strategy, i.routing_rollout_id, i.policy_shadow_strategy, i.policy_debug_enabled, i.policy_header_overrides_enabled, i.policy_routing_intent, i.ai_training_allowed, i.byok_enabled, i.content_capture_mode, i.hide_terminal_surfaces
 //	FROM router.model_router_api_keys k
 //	INNER JOIN router.model_router_installations i ON i.id = k.installation_id
 //	WHERE k.key_hash = $1::varchar
@@ -168,6 +168,7 @@ func (q *Queries) GetActiveModelRouterAPIKeyWithInstallationByHash(ctx context.C
 		&i.RouterModelRouterInstallation.AiTrainingAllowed,
 		&i.RouterModelRouterInstallation.ByokEnabled,
 		&i.RouterModelRouterInstallation.ContentCaptureMode,
+		&i.RouterModelRouterInstallation.HideTerminalSurfaces,
 	)
 	return i, err
 }

--- a/internal/sqlc/model_router_installations.sql.go
+++ b/internal/sqlc/model_router_installations.sql.go
@@ -22,7 +22,7 @@ VALUES (
     $2::varchar,
     $3
 )
-RETURNING id, external_id, name, created_at, updated_at, deleted_at, created_by, excluded_models, excluded_providers, routing_quality_weight, usage_bypass_enabled, usage_bypass_threshold, preferred_models, subscription_routing_disabled, routing_strategy, routing_rollout_id, policy_shadow_strategy, policy_debug_enabled, policy_header_overrides_enabled, policy_routing_intent, ai_training_allowed, byok_enabled, content_capture_mode
+RETURNING id, external_id, name, created_at, updated_at, deleted_at, created_by, excluded_models, excluded_providers, routing_quality_weight, usage_bypass_enabled, usage_bypass_threshold, preferred_models, subscription_routing_disabled, routing_strategy, routing_rollout_id, policy_shadow_strategy, policy_debug_enabled, policy_header_overrides_enabled, policy_routing_intent, ai_training_allowed, byok_enabled, content_capture_mode, hide_terminal_surfaces
 `
 
 type CreateModelRouterInstallationParams struct {
@@ -43,7 +43,7 @@ type CreateModelRouterInstallationParams struct {
 //	    $2::varchar,
 //	    $3
 //	)
-//	RETURNING id, external_id, name, created_at, updated_at, deleted_at, created_by, excluded_models, excluded_providers, routing_quality_weight, usage_bypass_enabled, usage_bypass_threshold, preferred_models, subscription_routing_disabled, routing_strategy, routing_rollout_id, policy_shadow_strategy, policy_debug_enabled, policy_header_overrides_enabled, policy_routing_intent, ai_training_allowed, byok_enabled, content_capture_mode
+//	RETURNING id, external_id, name, created_at, updated_at, deleted_at, created_by, excluded_models, excluded_providers, routing_quality_weight, usage_bypass_enabled, usage_bypass_threshold, preferred_models, subscription_routing_disabled, routing_strategy, routing_rollout_id, policy_shadow_strategy, policy_debug_enabled, policy_header_overrides_enabled, policy_routing_intent, ai_training_allowed, byok_enabled, content_capture_mode, hide_terminal_surfaces
 func (q *Queries) CreateModelRouterInstallation(ctx context.Context, arg CreateModelRouterInstallationParams) (RouterModelRouterInstallation, error) {
 	row := q.db.QueryRow(ctx, createModelRouterInstallation, arg.ExternalID, arg.Name, arg.CreatedBy)
 	var i RouterModelRouterInstallation
@@ -71,12 +71,13 @@ func (q *Queries) CreateModelRouterInstallation(ctx context.Context, arg CreateM
 		&i.AiTrainingAllowed,
 		&i.ByokEnabled,
 		&i.ContentCaptureMode,
+		&i.HideTerminalSurfaces,
 	)
 	return i, err
 }
 
 const getModelRouterInstallation = `-- name: GetModelRouterInstallation :one
-SELECT id, external_id, name, created_at, updated_at, deleted_at, created_by, excluded_models, excluded_providers, routing_quality_weight, usage_bypass_enabled, usage_bypass_threshold, preferred_models, subscription_routing_disabled, routing_strategy, routing_rollout_id, policy_shadow_strategy, policy_debug_enabled, policy_header_overrides_enabled, policy_routing_intent, ai_training_allowed, byok_enabled, content_capture_mode
+SELECT id, external_id, name, created_at, updated_at, deleted_at, created_by, excluded_models, excluded_providers, routing_quality_weight, usage_bypass_enabled, usage_bypass_threshold, preferred_models, subscription_routing_disabled, routing_strategy, routing_rollout_id, policy_shadow_strategy, policy_debug_enabled, policy_header_overrides_enabled, policy_routing_intent, ai_training_allowed, byok_enabled, content_capture_mode, hide_terminal_surfaces
 FROM router.model_router_installations
 WHERE id = $1::uuid
   AND external_id = $2::varchar
@@ -90,7 +91,7 @@ type GetModelRouterInstallationParams struct {
 
 // Gets an installation by id, scoped to an external_id to prevent cross-tenant access.
 //
-//	SELECT id, external_id, name, created_at, updated_at, deleted_at, created_by, excluded_models, excluded_providers, routing_quality_weight, usage_bypass_enabled, usage_bypass_threshold, preferred_models, subscription_routing_disabled, routing_strategy, routing_rollout_id, policy_shadow_strategy, policy_debug_enabled, policy_header_overrides_enabled, policy_routing_intent, ai_training_allowed, byok_enabled, content_capture_mode
+//	SELECT id, external_id, name, created_at, updated_at, deleted_at, created_by, excluded_models, excluded_providers, routing_quality_weight, usage_bypass_enabled, usage_bypass_threshold, preferred_models, subscription_routing_disabled, routing_strategy, routing_rollout_id, policy_shadow_strategy, policy_debug_enabled, policy_header_overrides_enabled, policy_routing_intent, ai_training_allowed, byok_enabled, content_capture_mode, hide_terminal_surfaces
 //	FROM router.model_router_installations
 //	WHERE id = $1::uuid
 //	  AND external_id = $2::varchar
@@ -122,12 +123,13 @@ func (q *Queries) GetModelRouterInstallation(ctx context.Context, arg GetModelRo
 		&i.AiTrainingAllowed,
 		&i.ByokEnabled,
 		&i.ContentCaptureMode,
+		&i.HideTerminalSurfaces,
 	)
 	return i, err
 }
 
 const listModelRouterInstallationsForExternalID = `-- name: ListModelRouterInstallationsForExternalID :many
-SELECT id, external_id, name, created_at, updated_at, deleted_at, created_by, excluded_models, excluded_providers, routing_quality_weight, usage_bypass_enabled, usage_bypass_threshold, preferred_models, subscription_routing_disabled, routing_strategy, routing_rollout_id, policy_shadow_strategy, policy_debug_enabled, policy_header_overrides_enabled, policy_routing_intent, ai_training_allowed, byok_enabled, content_capture_mode
+SELECT id, external_id, name, created_at, updated_at, deleted_at, created_by, excluded_models, excluded_providers, routing_quality_weight, usage_bypass_enabled, usage_bypass_threshold, preferred_models, subscription_routing_disabled, routing_strategy, routing_rollout_id, policy_shadow_strategy, policy_debug_enabled, policy_header_overrides_enabled, policy_routing_intent, ai_training_allowed, byok_enabled, content_capture_mode, hide_terminal_surfaces
 FROM router.model_router_installations
 WHERE external_id = $1::varchar
   AND deleted_at IS NULL
@@ -136,7 +138,7 @@ ORDER BY created_at DESC
 
 // ListModelRouterInstallationsForExternalID
 //
-//	SELECT id, external_id, name, created_at, updated_at, deleted_at, created_by, excluded_models, excluded_providers, routing_quality_weight, usage_bypass_enabled, usage_bypass_threshold, preferred_models, subscription_routing_disabled, routing_strategy, routing_rollout_id, policy_shadow_strategy, policy_debug_enabled, policy_header_overrides_enabled, policy_routing_intent, ai_training_allowed, byok_enabled, content_capture_mode
+//	SELECT id, external_id, name, created_at, updated_at, deleted_at, created_by, excluded_models, excluded_providers, routing_quality_weight, usage_bypass_enabled, usage_bypass_threshold, preferred_models, subscription_routing_disabled, routing_strategy, routing_rollout_id, policy_shadow_strategy, policy_debug_enabled, policy_header_overrides_enabled, policy_routing_intent, ai_training_allowed, byok_enabled, content_capture_mode, hide_terminal_surfaces
 //	FROM router.model_router_installations
 //	WHERE external_id = $1::varchar
 //	  AND deleted_at IS NULL
@@ -174,6 +176,7 @@ func (q *Queries) ListModelRouterInstallationsForExternalID(ctx context.Context,
 			&i.AiTrainingAllowed,
 			&i.ByokEnabled,
 			&i.ContentCaptureMode,
+			&i.HideTerminalSurfaces,
 		); err != nil {
 			return nil, err
 		}
@@ -302,6 +305,40 @@ type UpdateModelRouterInstallationExcludedProvidersParams struct {
 //	  AND deleted_at IS NULL
 func (q *Queries) UpdateModelRouterInstallationExcludedProviders(ctx context.Context, arg UpdateModelRouterInstallationExcludedProvidersParams) (int64, error) {
 	result, err := q.db.Exec(ctx, updateModelRouterInstallationExcludedProviders, arg.ExcludedProviders, arg.ID, arg.ExternalID)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
+const updateModelRouterInstallationHideTerminalSurfaces = `-- name: UpdateModelRouterInstallationHideTerminalSurfaces :execrows
+UPDATE router.model_router_installations
+SET hide_terminal_surfaces = $1::boolean,
+    updated_at = NOW()
+WHERE id = $2::uuid
+  AND external_id = $3::varchar
+  AND deleted_at IS NULL
+`
+
+type UpdateModelRouterInstallationHideTerminalSurfacesParams struct {
+	HideTerminalSurfaces bool
+	ID                   uuid.UUID
+	ExternalID           string
+}
+
+// Toggles hiding the router's terminal surfaces (routing marker, feedback
+// footer, statusline) for the installation, scoped to an external_id to
+// prevent cross-tenant updates. Requests route identically; only what is
+// rendered in the caller's terminal changes.
+//
+//	UPDATE router.model_router_installations
+//	SET hide_terminal_surfaces = $1::boolean,
+//	    updated_at = NOW()
+//	WHERE id = $2::uuid
+//	  AND external_id = $3::varchar
+//	  AND deleted_at IS NULL
+func (q *Queries) UpdateModelRouterInstallationHideTerminalSurfaces(ctx context.Context, arg UpdateModelRouterInstallationHideTerminalSurfacesParams) (int64, error) {
+	result, err := q.db.Exec(ctx, updateModelRouterInstallationHideTerminalSurfaces, arg.HideTerminalSurfaces, arg.ID, arg.ExternalID)
 	if err != nil {
 		return 0, err
 	}

--- a/internal/sqlc/models.go
+++ b/internal/sqlc/models.go
@@ -120,7 +120,8 @@ type RouterModelRouterInstallation struct {
 	// Managed-mode opt-in: honor this installation's BYOK provider keys
 	ByokEnabled bool
 	// Per-installation capture ceiling (off|hashed|full); NULL uses the deployment default
-	ContentCaptureMode *string
+	ContentCaptureMode   *string
+	HideTerminalSurfaces bool
 }
 
 type RouterModelRouterRequestTelemetry struct {


### PR DESCRIPTION
## What

Adds an organization-specific boolean, `hide_terminal_surfaces` (default `false`), on `router.model_router_installations`. When an org turns it on, the router suppresses the surfaces it injects into engineers' terminals while **routing and billing are unchanged**:

- the `✦ Weave Router → <model> · <reason>` routing marker
- the trailing `_Weave Router feedback:_ \`/rf +\` … \`/rf -\`` hint
- the `WEAVE ROUTER — <routed> ← <selected> · saved $X` statusline

Hiding only suppresses the **injected prompts** — explicit `/rf` use and signed rating links still accept and record feedback (the no-login feedback API and DB persistence stay live). The setting is **silent**: engineers see a normal terminal, no indication that requests are routed.

The flag is stored on the installation row and written by the platform (WorkWeave) via the shared DB — the same pattern as `subscription_routing_disabled`. A companion WorkWeave PR adds the GraphQL mutation + settings UI.

## How

- **Migration `0055`** + `UpdateModelRouterInstallationHideTerminalSurfaces` sqlc query; `internal/sqlc/` regenerated via `make generate`.
- **Domain/adapter/service**: `auth.Installation.HideTerminalSurfaces`, `InstallationRepository.UpdateHideTerminalSurfaces`, postgres adapter + converter, and `auth.Service.SetInstallationHideTerminalSurfaces` (invalidates the auth cache).
- **Request path**: auth middleware stashes `proxy.InstallationHideTerminalSurfacesContextKey`; `hideTerminalSurfacesForRequest` reads it. Gated at the three choke points — `suppressMarkerIfRequested` (covers every routing-badge call site), `feedbackFooter`, and `setFeedbackLinkHeader`. The subscription-only depleted-credits warning marker is deliberately untouched (billing CTA, not routing info).
- **Statusline/installer**: new bearer-authenticated `GET /v1/display-settings` returns `{ hide_terminal_surfaces }` for the calling installation. `cc-statusline.sh` (and its byte-identical copy embedded in `install.sh`) checks it — cached per install under `~/.cache/weave-router` with a TTL, fail-open on any error — and prints nothing when the org hides surfaces. Existing installs pick this up via the script's weekly self-refresh; new installs check at install time.

## Verification

- `go build ./...`, `go vet ./...`, `go test ./...` — all green.
- `make generate` — no drift.
- Migration `0055` verified up → down → re-up against a local router DB.
- `install/tests/cc-statusline_test.sh` — 30/30 pass (including the byte-identical heredoc check), plus a new hidden-suppression case for the footer and marker.

## Deploy order

Router first (migration + reads + gating), then bump the WorkWeave gitlink, then the platform PR (GraphQL + settings UI). The column defaults to `FALSE`, so each side tolerates the other not being deployed yet.

🤖 Generated with [Weave Router](https://router.workweave.ai)