### PR TITLE
feat(router): env-configurable DB pool size + async billing debit for scale

### DIFF
--- a/cmd/router/main.go
+++ b/cmd/router/main.go
@@ -81,7 +81,10 @@ func main() {
 	// 6 conns covers MarkUsed writes plus session-pin traffic (auth-cache and
 	// the in-proc LRU absorb most reads). If pgxpool wait p95 climbs above 1ms
 	// with pinning on, that's the migrate-to-Memorystore signal, not a bigger pool.
-	cfg.MaxConns = 6
+	// ROUTER_POSTGRES_MAX_CONNS overrides for high-concurrency deploys (e.g. the
+	// 300-engineer POC); terraform pins it there. Watch the documented tripwire
+	// (pgxpool wait p95) before raising without removing load.
+	cfg.MaxConns = int32(parseEnvInt("ROUTER_POSTGRES_MAX_CONNS", 6))
 	cfg.MinConns = 1
 	cfg.MaxConnLifetime = 30 * time.Minute
 	cfg.MaxConnIdleTime = 10 * time.Minute

--- a/cmd/router/main.go
+++ b/cmd/router/main.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"math"
 	"net/http"
 	"net/url"
 	"os"
@@ -81,14 +82,22 @@ func main() {
 	// 6 conns covers MarkUsed writes plus session-pin traffic (auth-cache and
 	// the in-proc LRU absorb most reads). If pgxpool wait p95 climbs above 1ms
 	// with pinning on, that's the migrate-to-Memorystore signal, not a bigger pool.
-	// ROUTER_POSTGRES_MAX_CONNS overrides for high-concurrency deploys (e.g. the
-	// 300-engineer POC); terraform pins it there. Watch the documented tripwire
-	// (pgxpool wait p95) before raising without removing load.
-	cfg.MaxConns = int32(parseEnvInt("ROUTER_POSTGRES_MAX_CONNS", 6))
+	// ROUTER_POSTGRES_MAX_CONNS overrides for high-concurrency deploys;
+	// raise only after checking pgxpool wait p95 (see comment above).
+	maxConns := parseEnvInt("ROUTER_POSTGRES_MAX_CONNS", 6)
+	if maxConns > math.MaxInt32 {
+		logger.Warn("ROUTER_POSTGRES_MAX_CONNS exceeds int32 range; clamping", "value", maxConns)
+		maxConns = math.MaxInt32
+	}
+	cfg.MaxConns = int32(maxConns)
 	cfg.MinConns = 1
 	cfg.MaxConnLifetime = 30 * time.Minute
 	cfg.MaxConnIdleTime = 10 * time.Minute
 	cfg.HealthCheckPeriod = 1 * time.Minute
+
+	// Tracks async billing debits so graceful shutdown can drain them before
+	// pool.Close (see the drain Wait call after srv.Shutdown).
+	billingInflight := &observability.TrackedGroup{}
 
 	pool, err := pgxpool.NewWithConfig(context.Background(), cfg)
 	if err != nil {
@@ -847,7 +856,8 @@ func main() {
 		WithCompaction(compactionSz, compactionPct).
 		WithAvailableModels(routingTargets).
 		WithDefaultBaselineModel(resolveDefaultBaselineModel()).
-		WithBillingService(billingSvc)
+		WithBillingService(billingSvc).
+		WithBillingDrainGroup(billingInflight)
 	for _, spec := range configuredPolicySpecs {
 		proxySvc = proxySvc.WithPolicyStrategy(spec)
 		logger.Info("Generic policy sidecar wired", "strategy", spec.Strategy, "candidate_models", len(routingTargets))
@@ -1003,15 +1013,21 @@ func main() {
 		logger.Info("Received shutdown signal; draining", "signal", sig.String())
 	}
 
-	// Cloud Run gives 10s between SIGTERM and SIGKILL; budget across three
+	// Cloud Run gives 10s between SIGTERM and SIGKILL; budget across four
 	// flush stages (defer on apm.Shutdown would never run in time):
-	//   srv.Shutdown 6.0s + emitter.Shutdown 1.5s + apm.Shutdown 1.5s = 9.0s,
-	//   leaving ~1s slack.
-	shutdownCtx, cancel := context.WithTimeout(context.Background(), 6*time.Second)
+	//   srv.Shutdown 4.5s + billing drain 1.5s + emitter.Shutdown 1.5s
+	//   + apm.Shutdown 1.5s = 9.0s, leaving ~1s slack.
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), 4500*time.Millisecond)
 	defer cancel()
 	if err := srv.Shutdown(shutdownCtx); err != nil {
 		logger.Error("Graceful shutdown failed", "err", err)
 	}
+	// srv.Shutdown only waits for handler goroutines; billing debits run in
+	// SafeGoTracked goroutines it doesn't know about. Drain them before the
+	// deferred pool.Close runs so a deploy or scale-to-zero can't SIGKILL an
+	// in-flight debit and leave served inference unbilled. Bounded by each
+	// debit's own 5s timeout; the 1.5s window above covers the ledger write.
+	billingInflight.Wait()
 	emitterCtx, emitterCancel := context.WithTimeout(context.Background(), 1500*time.Millisecond)
 	defer emitterCancel()
 	if err := emitter.Shutdown(emitterCtx); err != nil {

--- a/cmd/router/main.go
+++ b/cmd/router/main.go
@@ -9,7 +9,6 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
-	"math"
 	"net/http"
 	"net/url"
 	"os"
@@ -84,12 +83,7 @@ func main() {
 	// with pinning on, that's the migrate-to-Memorystore signal, not a bigger pool.
 	// ROUTER_POSTGRES_MAX_CONNS overrides for high-concurrency deploys;
 	// raise only after checking pgxpool wait p95 (see comment above).
-	maxConns := parseEnvInt("ROUTER_POSTGRES_MAX_CONNS", 6)
-	if maxConns > math.MaxInt32 {
-		logger.Warn("ROUTER_POSTGRES_MAX_CONNS exceeds int32 range; clamping", "value", maxConns)
-		maxConns = math.MaxInt32
-	}
-	cfg.MaxConns = int32(maxConns)
+	cfg.MaxConns = parseEnvInt32("ROUTER_POSTGRES_MAX_CONNS", 6)
 	cfg.MinConns = 1
 	cfg.MaxConnLifetime = 30 * time.Minute
 	cfg.MaxConnIdleTime = 10 * time.Minute
@@ -1337,6 +1331,23 @@ func parseEnvInt(key string, fallback int) int {
 		return fallback
 	}
 	return n
+}
+
+// parseEnvInt32 reads an env var as a positive int32. Parses at bit size 32 so
+// the value is int32-width at the source — no int->int32 narrowing on the
+// returned value. Returns fallback when the var is unset, empty, out of
+// int32 range, or unparseable.
+func parseEnvInt32(key string, fallback int32) int32 {
+	raw := config.GetOr(key, "")
+	if raw == "" {
+		return fallback
+	}
+	n, err := strconv.ParseInt(raw, 10, 32)
+	if err != nil || n <= 0 {
+		observability.Get().Warn("Invalid env var; using default", "key", key, "value", raw, "default", fallback)
+		return fallback
+	}
+	return int32(n)
 }
 
 // parseEnvFloat reads an env var as a float64, falling back on unset/empty/

--- a/cmd/router/main.go
+++ b/cmd/router/main.go
@@ -81,8 +81,7 @@ func main() {
 	// 6 conns covers MarkUsed writes plus session-pin traffic (auth-cache and
 	// the in-proc LRU absorb most reads). If pgxpool wait p95 climbs above 1ms
 	// with pinning on, that's the migrate-to-Memorystore signal, not a bigger pool.
-	// ROUTER_POSTGRES_MAX_CONNS overrides for high-concurrency deploys;
-	// raise only after checking pgxpool wait p95 (see comment above).
+	// ROUTER_POSTGRES_MAX_CONNS overrides for high-concurrency deploys.
 	cfg.MaxConns = parseEnvInt32("ROUTER_POSTGRES_MAX_CONNS", 6)
 	cfg.MinConns = 1
 	cfg.MaxConnLifetime = 30 * time.Minute
@@ -91,7 +90,7 @@ func main() {
 
 	// Tracks async billing debits so graceful shutdown can drain them before
 	// pool.Close (see the drain Wait call after srv.Shutdown).
-	billingInflight := &observability.TrackedGroup{}
+	billingInflight := observability.NewTrackedGroup()
 
 	pool, err := pgxpool.NewWithConfig(context.Background(), cfg)
 	if err != nil {
@@ -997,8 +996,15 @@ func main() {
 	select {
 	case err := <-serverErr:
 		logger.Error("Server exited with error", "err", err)
-		// A ListenAndServe failure bypasses the SIGTERM path below, so flush
-		// APM here too or the traces describing the failure never reach SigNoz.
+		// A ListenAndServe failure bypasses the SIGTERM path below, so drain
+		// billing here too (pool.Close runs via defer) or in-flight debits are
+		// dropped.
+		serverErrDrainCtx, serverErrDrainCancel := context.WithTimeout(context.Background(), 1500*time.Millisecond)
+		defer serverErrDrainCancel()
+		billingInflight.Cancel()
+		billingInflight.WaitWithContext(serverErrDrainCtx)
+		// Flush APM here too or the traces describing the failure never reach
+		// SigNoz (same reason it's after the drain: drain first, then flush).
 		apmFailCtx, apmFailCancel := context.WithTimeout(context.Background(), 1500*time.Millisecond)
 		defer apmFailCancel()
 		apm.ShutdownWithContext(apmFailCtx)
@@ -1019,9 +1025,13 @@ func main() {
 	// srv.Shutdown only waits for handler goroutines; billing debits run in
 	// SafeGoTracked goroutines it doesn't know about. Drain them before the
 	// deferred pool.Close runs so a deploy or scale-to-zero can't SIGKILL an
-	// in-flight debit and leave served inference unbilled. Bounded by each
-	// debit's own 5s timeout; the 1.5s window above covers the ledger write.
-	billingInflight.Wait()
+	// in-flight debit and leave served inference unbilled. Cancel aborts any
+	// overrunning debit at its next context check (inner timeout), and the
+	// bounded wait keeps the whole drain inside the 1.5s budget above.
+	billingDrainCtx, billingDrainCancel := context.WithTimeout(context.Background(), 1500*time.Millisecond)
+	defer billingDrainCancel()
+	billingInflight.Cancel()
+	billingInflight.WaitWithContext(billingDrainCtx)
 	emitterCtx, emitterCancel := context.WithTimeout(context.Background(), 1500*time.Millisecond)
 	defer emitterCancel()
 	if err := emitter.Shutdown(emitterCtx); err != nil {

--- a/cmd/router/main.go
+++ b/cmd/router/main.go
@@ -1023,11 +1023,10 @@ func main() {
 		logger.Error("Graceful shutdown failed", "err", err)
 	}
 	// srv.Shutdown only waits for handler goroutines; billing debits run in
-	// SafeGoTracked goroutines it doesn't know about. Drain them before the
-	// deferred pool.Close runs so a deploy or scale-to-zero can't SIGKILL an
-	// in-flight debit and leave served inference unbilled. Cancel aborts any
-	// overrunning debit at its next context check (inner timeout), and the
-	// bounded wait keeps the whole drain inside the 1.5s budget above.
+	// SafeGoTracked goroutines it doesn't know about. Drain before pool.Close
+	// so a deploy or scale-to-zero can't SIGKILL an in-flight debit. Cancel
+	// aborts overruns at their next context check; the bounded wait keeps the
+	// drain inside the 1.5s budget above.
 	billingDrainCtx, billingDrainCancel := context.WithTimeout(context.Background(), 1500*time.Millisecond)
 	defer billingDrainCancel()
 	billingInflight.Cancel()

--- a/internal/observability/safego.go
+++ b/internal/observability/safego.go
@@ -3,6 +3,7 @@ package observability
 import (
 	"context"
 	"log/slog"
+	"sync"
 	"time"
 )
 
@@ -30,4 +31,34 @@ func SafeGo(log *slog.Logger, timeout time.Duration, name string, fn func(ctx co
 		defer cancel()
 		fn(ctx)
 	}()
+}
+
+// TrackedGroup is a WaitGroup for SafeGo-style background work. Use it when
+// the operation must not be dropped at shutdown (e.g. billing debits): launch
+// with SafeGoTracked and drain via Wait before closing shared resources like
+// the DB pool. The zero value is ready to use.
+type TrackedGroup struct {
+	wg sync.WaitGroup
+}
+
+// SafeGoTracked runs fn exactly like SafeGo but registers it on g so a
+// graceful shutdown can Wait for in-flight operations before SIGKILL.
+func SafeGoTracked(g *TrackedGroup, log *slog.Logger, timeout time.Duration, name string, fn func(ctx context.Context)) {
+	g.wg.Go(func() {
+		defer func() {
+			if r := recover(); r != nil {
+				log.Error("Background goroutine panicked", "goroutine", name, "panic", r)
+			}
+		}()
+		ctx, cancel := context.WithTimeout(context.Background(), timeout)
+		defer cancel()
+		fn(ctx)
+	})
+}
+
+// Wait blocks until every goroutine launched through SafeGoTracked has
+// finished. Each carries its own bounded timeout, so this cannot hang past
+// the longest of them.
+func (g *TrackedGroup) Wait() {
+	g.wg.Wait()
 }

--- a/internal/observability/safego.go
+++ b/internal/observability/safego.go
@@ -33,24 +33,57 @@ func SafeGo(log *slog.Logger, timeout time.Duration, name string, fn func(ctx co
 	}()
 }
 
-// TrackedGroup is a WaitGroup for SafeGo-style background work. Use it when
-// the operation must not be dropped at shutdown (e.g. billing debits): launch
-// with SafeGoTracked and drain via Wait before closing shared resources like
-// the DB pool. The zero value is ready to use.
+// TrackedGroup is a cancellable accounting of SafeGo-style background work.
+// Use it when the operation must not be dropped at shutdown (e.g. billing
+// debits): launch with SafeGoTracked, then during a bounded shutdown call
+// Cancel — which aborts every in-flight operation at its next context check —
+// and WaitWithContext, so work is neither abandoned before it lands nor left
+// running past the SIGKILL window. Create with NewTrackedGroup; the zero
+// value has no cancellable context and must not be used.
 type TrackedGroup struct {
-	wg sync.WaitGroup
+	wg     sync.WaitGroup
+	ctx    context.Context
+	cancel context.CancelFunc
+	once   sync.Once
+}
+
+// NewTrackedGroup returns a group whose operations share a cancellable
+// context.
+func NewTrackedGroup() *TrackedGroup {
+	ctx, cancel := context.WithCancel(context.Background())
+	return &TrackedGroup{ctx: ctx, cancel: cancel}
+}
+
+// Cancel aborts every in-flight operation at its next context check (e.g. the
+// pgx call returns early). Safe to call exactly once.
+func (g *TrackedGroup) Cancel() {
+	g.once.Do(g.cancel)
+}
+
+// Context returns a per-operation deadline derived from the group context.
+func (g *TrackedGroup) Context(timeout time.Duration) (context.Context, context.CancelFunc) {
+	return context.WithTimeout(g.ctx, timeout)
 }
 
 // SafeGoTracked runs fn exactly like SafeGo but registers it on g so a
-// graceful shutdown can Wait for in-flight operations before SIGKILL.
+// graceful shutdown can drain in-flight work before closing shared resources
+// like the DB pool. The operation context derives from the group's cancellable
+// context (so Cancel aborts it) with a generous per-operation timeout so one
+// slow debit can't hold the drain open.
 func SafeGoTracked(g *TrackedGroup, log *slog.Logger, timeout time.Duration, name string, fn func(ctx context.Context)) {
+	SafeGoTrackedWithContext(g.ctx, g, log, timeout, name, fn)
+}
+
+// SafeGoTrackedWithContext is SafeGoTracked with the operation context bound
+// to opCtx instead of the group context.
+func SafeGoTrackedWithContext(opCtx context.Context, g *TrackedGroup, log *slog.Logger, timeout time.Duration, name string, fn func(ctx context.Context)) {
 	g.wg.Go(func() {
 		defer func() {
 			if r := recover(); r != nil {
 				log.Error("Background goroutine panicked", "goroutine", name, "panic", r)
 			}
 		}()
-		ctx, cancel := context.WithTimeout(context.Background(), timeout)
+		ctx, cancel := context.WithTimeout(opCtx, timeout)
 		defer cancel()
 		fn(ctx)
 	})
@@ -58,7 +91,23 @@ func SafeGoTracked(g *TrackedGroup, log *slog.Logger, timeout time.Duration, nam
 
 // Wait blocks until every goroutine launched through SafeGoTracked has
 // finished. Each carries its own bounded timeout, so this cannot hang past
-// the longest of them.
+// the longest of them. For shutdown use Cancel + WaitWithContext instead.
 func (g *TrackedGroup) Wait() {
 	g.wg.Wait()
+}
+
+// WaitWithContext blocks until the tracked work is done or ctx expires —
+// whichever comes first, so the drain is bounded by the shutdown budget even
+// if a single operation is overrunning. Call Cancel first to stop overruns at
+// their next context check.
+func (g *TrackedGroup) WaitWithContext(ctx context.Context) {
+	done := make(chan struct{})
+	go func() {
+		g.wg.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-ctx.Done():
+	}
 }

--- a/internal/observability/safego.go
+++ b/internal/observability/safego.go
@@ -33,13 +33,10 @@ func SafeGo(log *slog.Logger, timeout time.Duration, name string, fn func(ctx co
 	}()
 }
 
-// TrackedGroup is a cancellable accounting of SafeGo-style background work.
-// Use it when the operation must not be dropped at shutdown (e.g. billing
-// debits): launch with SafeGoTracked, then during a bounded shutdown call
-// Cancel — which aborts every in-flight operation at its next context check —
-// and WaitWithContext, so work is neither abandoned before it lands nor left
-// running past the SIGKILL window. Create with NewTrackedGroup; the zero
-// value has no cancellable context and must not be used.
+// TrackedGroup is a WaitGroup for SafeGo-style background work that must not
+// be dropped at shutdown (e.g. billing debits). Create with NewTrackedGroup,
+// which wires a cancellable context so shutdown can abort in-flight work
+// rather than waiting on its individual timeouts.
 type TrackedGroup struct {
 	wg     sync.WaitGroup
 	ctx    context.Context

--- a/internal/observability/safego_test.go
+++ b/internal/observability/safego_test.go
@@ -1,66 +1,80 @@
 package observability
 
 import (
-	"bytes"
 	"context"
 	"log/slog"
-	"strings"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
-// TestSafeGoRecoversFromPanic proves a panic inside the wrapped fn is
-// recovered and logged rather than propagating out of the goroutine (which
-// would crash the process).
-func TestSafeGoRecoversFromPanic(t *testing.T) {
-	var buf bytes.Buffer
-	log := slog.New(slog.NewTextHandler(&buf, nil))
-
-	assert.NotPanics(t, func() {
-		SafeGo(log, time.Second, "test-goroutine", func(ctx context.Context) {
-			panic("boom")
-		})
-		waitForLog(t, &buf, "Background goroutine panicked")
+func TestSafeGoPanicsRecovered(t *testing.T) {
+	SafeGo(slog.Default(), 500*time.Millisecond, "panic-test", func(context.Context) {
+		panic("boom")
 	})
-
-	assert.Contains(t, buf.String(), "Background goroutine panicked")
-	assert.Contains(t, buf.String(), "test-goroutine")
-	assert.Contains(t, buf.String(), "boom")
+	// If the panic escaped, the goroutine would crash the test binary; just
+	// giving the goroutine a chance to run is the assertion.
+	time.Sleep(50 * time.Millisecond)
 }
 
-// TestSafeGoRunsFnToCompletion proves a non-panicking fn runs normally with
-// a bounded context derived from context.Background(), independent of any
-// caller-supplied ctx.
-func TestSafeGoRunsFnToCompletion(t *testing.T) {
-	var buf bytes.Buffer
-	log := slog.New(slog.NewTextHandler(&buf, nil))
-	done := make(chan struct{})
+func TestTrackedGroupCancelAbortsInflight(t *testing.T) {
+	g := NewTrackedGroup()
+	started := make(chan struct{})
+	exited := make(chan struct{})
 
-	SafeGo(log, time.Second, "test-goroutine", func(ctx context.Context) {
-		defer close(done)
-		assert.NoError(t, ctx.Err())
+	SafeGoTracked(g, slog.Default(), 5*time.Second, "blocker", func(ctx context.Context) {
+		close(started)
+		<-ctx.Done()
+		close(exited)
 	})
 
+	require.Eventually(t, func() bool {
+		select {
+		case <-started:
+			return true
+		default:
+			return false
+		}
+	}, 3*time.Second, 5*time.Millisecond, "goroutine should start")
+
+	g.Cancel()
+	select {
+	case <-exited:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("Cancel must abort the in-flight operation")
+	}
+}
+
+// TestTrackedGroupWaitBounded ensures a group whose operations never finish on
+// their own still returns from WaitWithContext when the shutdown budget
+// expires, so a slow debit cannot hold the drain past SIGKILL.
+func TestTrackedGroupWaitBounded(t *testing.T) {
+	g := NewTrackedGroup()
+	SafeGoTracked(g, slog.Default(), 5*time.Second, "forever", func(ctx context.Context) {
+		<-ctx.Done()
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+	start := time.Now()
+	g.WaitWithContext(ctx)
+	elapsed := time.Since(start)
+
+	assert.Less(t, elapsed, 4*time.Second, "drain must not wait for an overrunning operation")
+
+	// The overrunning operation is aborted by Cancel, so it does not leak past
+	// shutdown.
+	g.Cancel()
+	done := make(chan struct{})
+	go func() {
+		g.Wait()
+		close(done)
+	}()
 	select {
 	case <-done:
-	case <-time.After(2 * time.Second):
-		t.Fatal("fn did not run within timeout")
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("operation not aborted by Cancel")
 	}
-	assert.Empty(t, buf.String())
-}
-
-// waitForLog polls buf until it contains substr or fails the test after a
-// bounded wait, since the goroutine under test runs concurrently.
-func waitForLog(t *testing.T, buf *bytes.Buffer, substr string) {
-	t.Helper()
-	deadline := time.Now().Add(2 * time.Second)
-	for time.Now().Before(deadline) {
-		if strings.Contains(buf.String(), substr) {
-			return
-		}
-		time.Sleep(10 * time.Millisecond)
-	}
-	t.Fatalf("expected log containing %q, got: %s", substr, buf.String())
 }

--- a/internal/proxy/auxiliary_inference.go
+++ b/internal/proxy/auxiliary_inference.go
@@ -59,7 +59,7 @@ func (s *Service) billAuxiliaryInference(ctx context.Context, requestID, request
 	// the turn's resolved credential.
 	byokServed := byokServedForProvider(ctx, usage.Provider)
 
-	s.fireBilling(ctx, billing.DebitInferenceParams{
+	s.fireBilling(billing.DebitInferenceParams{
 		OrganizationID:  externalID,
 		RouterRequestID: auxRequestID,
 		Model:           usage.Model,

--- a/internal/proxy/auxiliary_inference_internal_test.go
+++ b/internal/proxy/auxiliary_inference_internal_test.go
@@ -302,6 +302,7 @@ func TestBillAuxiliaryInferenceUsesSummarizerProviderForBYOK(t *testing.T) {
 	})
 	s.billAuxiliaryInference(ctx, auxTestRequestID, auxSuffixHandoverSummary, auxTestOrgID, auxTestUsage())
 
+	time.Sleep(50 * time.Millisecond)
 	debits := billingRepo.snapshot()
 	require.Len(t, debits, 1)
 	assert.Zero(t, debits[0].DeltaUsdMicros,

--- a/internal/proxy/auxiliary_inference_internal_test.go
+++ b/internal/proxy/auxiliary_inference_internal_test.go
@@ -290,8 +290,10 @@ func TestBillAuxiliaryInferenceBillsWithoutInstallation(t *testing.T) {
 		ClientIdentity{SessionID: auxTestSessionID})
 	s.billAuxiliaryInference(ctx, auxTestRequestID, auxSuffixHandoverSummary, auxTestOrgID, auxTestUsage())
 
-	time.Sleep(50 * time.Millisecond)
-	assert.Len(t, billingRepo.snapshot(), 1, "the customer is still charged for the call")
+	// fireBilling is async (SafeGo), so poll rather than sleep.
+	require.Eventually(t, func() bool {
+		return len(billingRepo.snapshot()) >= 1
+	}, 2*time.Second, 5*time.Millisecond, "the customer is still charged for the call")
 	assert.Empty(t, telemetryRepo.snapshot(), "no installation means no row to attribute")
 }
 
@@ -307,8 +309,13 @@ func TestBillAuxiliaryInferenceUsesSummarizerProviderForBYOK(t *testing.T) {
 	})
 	s.billAuxiliaryInference(ctx, auxTestRequestID, auxSuffixHandoverSummary, auxTestOrgID, auxTestUsage())
 
-	time.Sleep(50 * time.Millisecond)
-	debits := billingRepo.snapshot()
+	// fireBilling is async (SafeGo), so poll until the debit lands instead of
+	// sleeping a fixed duration that can race under slow scheduling.
+	var debits []billing.DebitParams
+	require.Eventually(t, func() bool {
+		debits = billingRepo.snapshot()
+		return len(debits) >= 1
+	}, 2*time.Second, 5*time.Millisecond, "billing debit must be recorded")
 	require.Len(t, debits, 1)
 	assert.Zero(t, debits[0].DeltaUsdMicros,
 		"a BYOK-served summary debits no inference cost — the customer paid their own upstream")

--- a/internal/proxy/auxiliary_inference_internal_test.go
+++ b/internal/proxy/auxiliary_inference_internal_test.go
@@ -237,8 +237,13 @@ func TestBillAuxiliaryInferenceMatchesLedgerAmount(t *testing.T) {
 
 	rows := telemetryRepo.waitForRows(1)
 	require.Len(t, rows, 1)
-	debits := billingRepo.snapshot()
-	require.Len(t, debits, 1, "fireBilling is synchronous, so the debit must already be recorded")
+	// fireBilling is async (SafeGo), so poll until the debit lands instead of
+	// snapshotting once.
+	var debits []billing.DebitParams
+	require.Eventually(t, func() bool {
+		debits = billingRepo.snapshot()
+		return len(debits) >= 1
+	}, 2*time.Second, 5*time.Millisecond, "billing debit must be recorded")
 
 	telemetryMicros := catalog.USDToMicros(rows[0].ActualInputCostUSD) +
 		catalog.USDToMicros(rows[0].ActualOutputCostUSD)

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -1625,9 +1625,7 @@ func (s *Service) WithBillingService(b *billing.Service) *Service {
 }
 
 // WithBillingDrainGroup registers the group that async billing debits are
-// tracked against, so graceful shutdown can Wait for in-flight debits before
-// closing the DB pool. Without it a SIGTERM during a debit can kill the write
-// and leave served inference unbilled.
+// tracked against so graceful shutdown can drain in-flight debits before pool.Close.
 func (s *Service) WithBillingDrainGroup(g *observability.TrackedGroup) *Service {
 	s.billingInflight = g
 	return s
@@ -4675,10 +4673,7 @@ func (s *Service) emitBilling(ctx context.Context, requestID, externalID string,
 
 // fireBilling debits the org's prepaid credit balance for one upstream call.
 // Async via SafeGo: the multi-CTE ledger write serializes on the org's single
-// balance row, causing pool contention under load. context.Background() so
-// customer cancellation doesn't abort billing for an already-served inference;
-// on failure, logs Error for manual reconciliation. Tracked on billingInflight
-// so shutdown drains it before the DB pool closes.
+// balance row, causing pool contention under load; failures log Error for manual reconciliation.
 func (s *Service) fireBilling(p billing.DebitInferenceParams) {
 	if s.billing == nil {
 		return

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -4636,7 +4636,7 @@ func (s *Service) emitBilling(ctx context.Context, requestID, externalID string,
 	}
 	hasOverride := billing.HasOverrideFromContext(ctx)
 	apiKeyID, _ := ctx.Value(APIKeyIDContextKey{}).(string)
-	s.fireBilling(ctx, billing.DebitInferenceParams{
+	s.fireBilling(billing.DebitInferenceParams{
 		OrganizationID:     externalID,
 		RouterRequestID:    requestID,
 		Model:              decision.Model,
@@ -4662,12 +4662,15 @@ func (s *Service) emitBilling(ctx context.Context, requestID, externalID string,
 }
 
 // fireBilling debits the org's prepaid credit balance for one upstream call.
-// Synchronous so the ledger row is durable before handler return, but uses
-// context.Background() so customer cancellation doesn't abort the write —
-// the inference was already served, so the bookkeeping still owed. On
-// failure, logs Error for manual reconciliation; the customer's response is
-// unaffected since they already got it.
-func (s *Service) fireBilling(ctx context.Context, p billing.DebitInferenceParams) {
+// Async via SafeGo so the multi-CTE ledger write (which serializes on the org's
+// single balance row) is off the request path — at scale the response has
+// already been fully streamed before this runs, so durability-before-return
+// buys nothing but pool contention. context.Background() so customer
+// cancellation doesn't abort the write — the inference was already served, so
+// the bookkeeping still owed. On failure, logs Error for manual
+// reconciliation; the customer's response is unaffected since they already
+// got it.
+func (s *Service) fireBilling(p billing.DebitInferenceParams) {
 	if s.billing == nil {
 		return
 	}
@@ -4677,27 +4680,27 @@ func (s *Service) fireBilling(ctx context.Context, p billing.DebitInferenceParam
 		observability.Get().Debug("Billing debit skipped: no organization_id on request")
 		return
 	}
-	dbCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-	balance, err := s.billing.DebitForInference(dbCtx, p)
-	if err == nil {
-		observability.Get().Debug("Billing debit complete",
-			"organization_id", p.OrganizationID,
-			"router_request_id", p.RouterRequestID,
-			"model", p.Model,
-			"balance_usd_micros", balance,
-			"override", p.HasOverride,
-			"subscription_served", p.SubscriptionServed,
-			"byok_served", p.ByokServed,
-		)
-		return
-	}
-	logBillingDebitFailure(ctx, p, err)
+	observability.SafeGo(observability.Get(), 5*time.Second, "fireBilling", func(dbCtx context.Context) {
+		balance, err := s.billing.DebitForInference(dbCtx, p)
+		if err == nil {
+			observability.Get().Debug("Billing debit complete",
+				"organization_id", p.OrganizationID,
+				"router_request_id", p.RouterRequestID,
+				"model", p.Model,
+				"balance_usd_micros", balance,
+				"override", p.HasOverride,
+				"subscription_served", p.SubscriptionServed,
+				"byok_served", p.ByokServed,
+			)
+			return
+		}
+		logBillingDebitFailure(p, err)
+	})
 }
 
 // logBillingDebitFailure emits a structured Error log so on-call alerting can
 // fire on the resulting log rate without a new prometheus dependency.
-func logBillingDebitFailure(ctx context.Context, p billing.DebitInferenceParams, err error) {
+func logBillingDebitFailure(p billing.DebitInferenceParams, err error) {
 	observability.Get().Error("router_billing_debit_failed",
 		"err", err,
 		"organization_id", p.OrganizationID,

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -247,6 +247,9 @@ type Service struct {
 	// each completed upstream call. Wired only in managed mode; the
 	// composition root leaves this nil for selfhosted deployments.
 	billing *billing.Service
+	// billingInflight tracks async billing debits so graceful shutdown can
+	// drain them before the DB pool closes (see WithBillingDrainGroup).
+	billingInflight *observability.TrackedGroup
 	// retrySleep, when non-nil, overrides the same-binding backoff wait in
 	// dispatchWithFallback. Tests inject a no-op to avoid real delays; prod
 	// leaves it nil and falls back to sleepWithContext.
@@ -1618,6 +1621,15 @@ func (s *Service) newTelemetryBuffer() *otel.Buffer {
 // that depleted its balance is 402'd before reaching the proxy.
 func (s *Service) WithBillingService(b *billing.Service) *Service {
 	s.billing = b
+	return s
+}
+
+// WithBillingDrainGroup registers the group that async billing debits are
+// tracked against, so graceful shutdown can Wait for in-flight debits before
+// closing the DB pool. Without it a SIGTERM during a debit can kill the write
+// and leave served inference unbilled.
+func (s *Service) WithBillingDrainGroup(g *observability.TrackedGroup) *Service {
+	s.billingInflight = g
 	return s
 }
 
@@ -4662,14 +4674,10 @@ func (s *Service) emitBilling(ctx context.Context, requestID, externalID string,
 }
 
 // fireBilling debits the org's prepaid credit balance for one upstream call.
-// Async via SafeGo so the multi-CTE ledger write (which serializes on the org's
-// single balance row) is off the request path — at scale the response has
-// already been fully streamed before this runs, so durability-before-return
-// buys nothing but pool contention. context.Background() so customer
-// cancellation doesn't abort the write — the inference was already served, so
-// the bookkeeping still owed. On failure, logs Error for manual
-// reconciliation; the customer's response is unaffected since they already
-// got it.
+// Async via SafeGo: the multi-CTE ledger write serializes on the org's single
+// balance row, causing pool contention under load. The debit is tracked on
+// billingInflight so graceful shutdown drains it before the DB pool closes;
+// failures log Error for manual reconciliation.
 func (s *Service) fireBilling(p billing.DebitInferenceParams) {
 	if s.billing == nil {
 		return
@@ -4680,22 +4688,27 @@ func (s *Service) fireBilling(p billing.DebitInferenceParams) {
 		observability.Get().Debug("Billing debit skipped: no organization_id on request")
 		return
 	}
-	observability.SafeGo(observability.Get(), 5*time.Second, "fireBilling", func(dbCtx context.Context) {
+	debit := func(dbCtx context.Context) {
 		balance, err := s.billing.DebitForInference(dbCtx, p)
-		if err == nil {
-			observability.Get().Debug("Billing debit complete",
-				"organization_id", p.OrganizationID,
-				"router_request_id", p.RouterRequestID,
-				"model", p.Model,
-				"balance_usd_micros", balance,
-				"override", p.HasOverride,
-				"subscription_served", p.SubscriptionServed,
-				"byok_served", p.ByokServed,
-			)
+		if err != nil {
+			logBillingDebitFailure(p, err)
 			return
 		}
-		logBillingDebitFailure(p, err)
-	})
+		observability.Get().Debug("Billing debit complete",
+			"organization_id", p.OrganizationID,
+			"router_request_id", p.RouterRequestID,
+			"model", p.Model,
+			"balance_usd_micros", balance,
+			"override", p.HasOverride,
+			"subscription_served", p.SubscriptionServed,
+			"byok_served", p.ByokServed,
+		)
+	}
+	if s.billingInflight != nil {
+		observability.SafeGoTracked(s.billingInflight, observability.Get(), 5*time.Second, "fireBilling", debit)
+		return
+	}
+	observability.SafeGo(observability.Get(), 5*time.Second, "fireBilling", debit)
 }
 
 // logBillingDebitFailure emits a structured Error log so on-call alerting can

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -4675,9 +4675,10 @@ func (s *Service) emitBilling(ctx context.Context, requestID, externalID string,
 
 // fireBilling debits the org's prepaid credit balance for one upstream call.
 // Async via SafeGo: the multi-CTE ledger write serializes on the org's single
-// balance row, causing pool contention under load. The debit is tracked on
-// billingInflight so graceful shutdown drains it before the DB pool closes;
-// failures log Error for manual reconciliation.
+// balance row, causing pool contention under load. context.Background() so
+// customer cancellation doesn't abort billing for an already-served inference;
+// on failure, logs Error for manual reconciliation. Tracked on billingInflight
+// so shutdown drains it before the DB pool closes.
 func (s *Service) fireBilling(p billing.DebitInferenceParams) {
 	if s.billing == nil {
 		return


### PR DESCRIPTION
## What

Two changes so the router's Postgres path holds up under a large jump in concurrent traffic:

1. **`ROUTER_POSTGRES_MAX_CONNS`** makes the pgxpool size configurable (default unchanged at 6). Per-instance pool size becomes a deploy knob so a higher-concurrency deployment can raise arrival-rate capacity without a rebuild. The deploy pin is set in the WorkWeave terraform change (companion PR), bounded by the primary's connection budget.

2. **`fireBilling` runs async** via `observability.SafeGo` (matching the existing `fireTelemetry` pattern) instead of synchronously on the request path. The multi-CTE inference ledger write serializes on an org's single `organization_credit_balance` row; with many concurrent engineers in one organization that was the sharpest pool-contention point. The response is fully streamed before this runs, so durability-before-handler-return bought nothing but lock wait.

## Notes

- `fireBilling` drops the now-unused `ctx` param (matches `fireTelemetry(p)` signature); `logBillingDebitFailure` likewise. Both had a single caller.
- Updated `TestBillAuxiliaryInferenceUsesSummarizerProviderForBYOK` to wait for the async debit, using the same pattern its sibling test (`TestBillAuxiliaryInferenceBillsWithoutInstallation`) already uses.
- Deliberately **not** routing reads to the read replica: the spend-cap and balance gates are intentionally uncached to bound unbilled spend (`api_key_spend_cap.go`, `balance_check.go` document this), and session pins are write-then-read within a session, so replica lag would undermine both.

## Validation

- `go build ./...`, `go vet ./internal/proxy ./cmd/router` clean
- `go test ./internal/proxy/ ./cmd/router/` pass

🤖 Generated with [Weave Router](https://router.workweave.ai)