### PR TITLE
fix(proxy): apply cost gates to authoritative-per-turn decisions

### DIFF
--- a/cmd/router/main.go
+++ b/cmd/router/main.go
@@ -603,6 +603,9 @@ func main() {
 	hmmUpgradeConfidence := parseEnvFloat("ROUTER_HMM_UPGRADE_CONFIDENCE_THRESHOLD", 0.85)
 	hmmSameTierPin := config.GetOr("ROUTER_HMM_SAME_TIER_PIN", "false") == "true"
 	hmPinStickyOnArmSelectorUnavail := config.GetOr("ROUTER_HMM_PIN_STICKY_ON_ARM_SELECTOR_UNAVAIL", "false") == "true"
+	// authoritativeUpgradeGate keeps the 0.85 escalation floor active for authoritative-per-turn
+	// policies; kill switch for a return to verbatim policy selection.
+	authoritativeUpgradeGate := config.GetOr("ROUTER_AUTHORITATIVE_UPGRADE_GATE", "true") == "true"
 	// policyDeadlineFallback degrades a policy sidecar deadline/transport failure to
 	// the session pin (or tier-3 default below) instead of a 503. Kill switch; off by default.
 	policyDeadlineFallback := config.GetOr("ROUTER_POLICY_DEADLINE_FALLBACK", "false") == "true"
@@ -818,6 +821,7 @@ func main() {
 		WithHMMUpgradeConfidenceThreshold(hmmUpgradeConfidence).
 		WithHMMSameTierPin(hmmSameTierPin).
 		WithHMPinStickyOnArmSelectorUnavail(hmPinStickyOnArmSelectorUnavail).
+		WithAuthoritativeUpgradeGate(authoritativeUpgradeGate).
 		WithPolicyDeadlineFallback(policyDeadlineFallback).
 		WithPolicyDeadlineDefaultModel(policyDeadlineDefaultModel).
 		WithEscapeNormalize(escapeNormalize).

--- a/internal/proxy/authoritative_turnloop_internal_test.go
+++ b/internal/proxy/authoritative_turnloop_internal_test.go
@@ -272,3 +272,162 @@ func TestAuthoritativePolicyPreservesExplicitForceModel(t *testing.T) {
 	assert.True(t, result.StickyHit)
 	assert.Empty(t, policyRouter.requests)
 }
+
+func TestAuthoritativeUpgradeConfidenceGate(t *testing.T) {
+	strategy := router.Strategy("authoritative-test")
+	body := []byte(`{"model":"claude-opus-4-8","messages":[{"role":"user","content":"fix the failing test"}]}`)
+
+	tests := []struct {
+		name       string
+		gateOff    bool
+		pinFound   bool
+		pinModel   string
+		fresh      router.Decision
+		wantModel  string
+		wantSticky bool
+		wantTier   string
+	}{
+		{
+			name:     "low-confidence upgrade keeps cheaper pin",
+			pinFound: true,
+			pinModel: "claude-haiku-4-5",
+			fresh: router.Decision{
+				Provider: providers.ProviderAnthropic,
+				Model:    "claude-opus-4-8",
+				Reason:   "hmm_policy(tool-result communication reroute: classifier 'maximum' (p=0.180))",
+				Metadata: &router.RoutingMetadata{ChosenScore: 0.18},
+			},
+			wantModel:  "claude-haiku-4-5",
+			wantSticky: true,
+			wantTier:   "authoritative_hmm_upgrade_confidence_low",
+		},
+		{
+			name:     "confident upgrade serves fresh",
+			pinFound: true,
+			pinModel: "claude-haiku-4-5",
+			fresh: router.Decision{
+				Provider: providers.ProviderAnthropic,
+				Model:    "claude-opus-4-8",
+				Reason:   "hmm_policy(classifier 'maximum' (p=0.91))",
+				Metadata: &router.RoutingMetadata{ChosenScore: 0.91},
+			},
+			wantModel:  "claude-opus-4-8",
+			wantSticky: false,
+			wantTier:   "authoritative_per_turn",
+		},
+		{
+			name:     "downgrade serves fresh despite low confidence",
+			pinFound: true,
+			pinModel: "claude-opus-4-8",
+			fresh: router.Decision{
+				Provider: providers.ProviderAnthropic,
+				Model:    "claude-haiku-4-5",
+				Reason:   "hmm_policy(classifier 'fast' (p=0.20))",
+				Metadata: &router.RoutingMetadata{ChosenScore: 0.20},
+			},
+			wantModel:  "claude-haiku-4-5",
+			wantSticky: false,
+			wantTier:   "authoritative_per_turn",
+		},
+		{
+			name:     "unscored upgrade fails open",
+			pinFound: true,
+			pinModel: "claude-haiku-4-5",
+			fresh: router.Decision{
+				Provider: providers.ProviderAnthropic,
+				Model:    "claude-opus-4-8",
+				Reason:   "authoritative-test_policy",
+			},
+			wantModel:  "claude-opus-4-8",
+			wantSticky: false,
+			wantTier:   "authoritative_per_turn",
+		},
+		{
+			name:     "first turn without pin serves fresh",
+			pinFound: false,
+			fresh: router.Decision{
+				Provider: providers.ProviderAnthropic,
+				Model:    "claude-opus-4-8",
+				Reason:   "hmm_policy(classifier 'maximum' (p=0.18))",
+				Metadata: &router.RoutingMetadata{ChosenScore: 0.18},
+			},
+			wantModel:  "claude-opus-4-8",
+			wantSticky: false,
+			wantTier:   "authoritative_per_turn",
+		},
+		{
+			name:     "gate disabled serves fresh",
+			gateOff:  true,
+			pinFound: true,
+			pinModel: "claude-haiku-4-5",
+			fresh: router.Decision{
+				Provider: providers.ProviderAnthropic,
+				Model:    "claude-opus-4-8",
+				Reason:   "hmm_policy(classifier 'maximum' (p=0.18))",
+				Metadata: &router.RoutingMetadata{ChosenScore: 0.18},
+			},
+			wantModel:  "claude-opus-4-8",
+			wantSticky: false,
+			wantTier:   "authoritative_per_turn",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			store := newStubPinStore()
+			store.getFound = test.pinFound
+			store.getPin = sessionpin.Pin{
+				Provider:    providers.ProviderAnthropic,
+				Model:       test.pinModel,
+				Reason:      "hmm_policy(classifier 'fast' (p=0.60))",
+				PinnedUntil: time.Now().Add(time.Hour),
+			}
+			policyRouter := &authoritativeTestRouter{decision: test.fresh}
+			svc := NewService(
+				nil,
+				nil,
+				nil,
+				false,
+				nil,
+				store,
+				false,
+				providers.ProviderAnthropic,
+				"claude-haiku-4-5",
+				nil,
+			).WithPolicyStrategy(policy.StrategySpec{
+				Strategy: strategy,
+				Router:   policyRouter,
+				Capabilities: policy.Capabilities{
+					SchemaVersion:                 policy.SchemaVersionV1,
+					AuthoritativePerTurnSelection: true,
+				},
+			})
+			if test.gateOff {
+				svc = svc.WithAuthoritativeUpgradeGate(false)
+			}
+			env, err := translate.ParseAnthropic(body)
+			require.NoError(t, err)
+			features := env.RoutingFeatures(false)
+
+			result, err := svc.runTurnLoop(
+				router.WithStrategy(context.Background(), strategy),
+				env,
+				features,
+				"api-key",
+				uuid.New(),
+				"",
+				http.Header{},
+				router.Request{
+					RequestedModel:       features.Model,
+					ConversationMessages: conversationMessagesForRouting(env),
+				},
+			)
+
+			require.NoError(t, err)
+			assert.True(t, result.AuthoritativePerTurn)
+			assert.Equal(t, test.wantModel, result.Decision.Model)
+			assert.Equal(t, test.wantSticky, result.StickyHit)
+			assert.Equal(t, test.wantTier, result.PinTier)
+		})
+	}
+}

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -137,6 +137,11 @@ type Service struct {
 	// hmPinStickyOnArmSelectorUnavail suppresses a fresh decision that came from the arm-selector
 	// unavailable fallback bandit. Env ROUTER_HMM_PIN_STICKY_ON_ARM_SELECTOR_UNAVAIL, off by default.
 	hmPinStickyOnArmSelectorUnavail bool
+	// authoritativeUpgradeGate applies the upgrade-confidence threshold to
+	// authoritative-per-turn decisions too: a scored fresh decision that is
+	// pricier than the session pin only escalates at confidence >=
+	// hmmUpgradeConfidenceThreshold. Env ROUTER_AUTHORITATIVE_UPGRADE_GATE, on by default.
+	authoritativeUpgradeGate bool
 	// policyDeadlineFallback degrades a policy sidecar deadline/transport failure to
 	// the session pin instead of a 503. Kill switch: env ROUTER_POLICY_DEADLINE_FALLBACK, off by default.
 	policyDeadlineFallback bool
@@ -1108,6 +1113,7 @@ func NewService(r router.Router, providerMap map[string]providers.Client, emitte
 			TierUpgradeEnabled:     DefaultPlannerTierUpgradeEnabled,
 		},
 		hmmUpgradeConfidenceThreshold: defaultHMMUpgradeConfidenceThreshold,
+		authoritativeUpgradeGate:      true,
 		plannerEnabled:                true,
 		scoreToolResultTurns:          true,
 		loopEscalationEnabled:         true,
@@ -1199,6 +1205,14 @@ func (s *Service) WithHMMSameTierPin(enabled bool) *Service {
 // for suppressing a reroute caused by the arm-selector unavailable fallback bandit.
 func (s *Service) WithHMPinStickyOnArmSelectorUnavail(enabled bool) *Service {
 	s.hmPinStickyOnArmSelectorUnavail = enabled
+	return s
+}
+
+// WithAuthoritativeUpgradeGate is the kill switch (ROUTER_AUTHORITATIVE_UPGRADE_GATE)
+// for applying the upgrade-confidence threshold to authoritative-per-turn
+// decisions. On by default; disabling restores verbatim policy selection.
+func (s *Service) WithAuthoritativeUpgradeGate(enabled bool) *Service {
+	s.authoritativeUpgradeGate = enabled
 	return s
 }
 

--- a/internal/proxy/turnloop.go
+++ b/internal/proxy/turnloop.go
@@ -1033,6 +1033,30 @@ func (s *Service) runTurnLoop(
 			s.refreshPin(ctx, installationID, res.SessionKey, pin, res.PinRole, decision)
 			return res, nil
 		}
+		// Upgrade-confidence guard: authoritative selection bypasses the HMM
+		// cost gate, but the escalation floor still applies. A scored fresh
+		// decision that costs more than the pinned model only wins at
+		// confidence >= threshold; below it the session stays on its pin.
+		// Unscored decisions, downgrades, and unpinned turns pass through.
+		if s.authoritativeUpgradeGate && pinFound && pin.Model != "" && pin.Model != fresh.Model &&
+			hmmFreshIsMoreExpensive(pin.Model, fresh.Model, req.SubsidizedModelCostFactor) {
+			if confidence, ok := hmmDecisionConfidence(fresh); ok && confidence < s.hmmUpgradeConfidenceThreshold {
+				decision := pinDecision(pin)
+				res.Decision = decision
+				res.StickyHit = true
+				res.PinTier = "authoritative_" + hmmReasonUpgradeConfidenceLow
+				log.Info("turnloop suppressed low-confidence authoritative upgrade; keeping session pin",
+					"pin_model", pin.Model,
+					"pin_provider", pin.Provider,
+					"fresh_model", fresh.Model,
+					"fresh_provider", fresh.Provider,
+					"confidence", confidence,
+					"threshold", s.hmmUpgradeConfidenceThreshold,
+				)
+				s.refreshPin(ctx, installationID, res.SessionKey, pin, res.PinRole, decision)
+				return res, nil
+			}
+		}
 		res.Decision = fresh
 		res.PinTier = "authoritative_per_turn"
 		s.writeNewPin(ctx, installationID, res.SessionKey, res.PinRole, fresh)


### PR DESCRIPTION
## Summary

Authoritative per-turn selection (#802) returns the fresh policy decision before any of the router's cost machinery runs. Two guards that protect every other HMM turn were silently skipped on these turns:

1. **The upgrade-confidence floor** (`ROUTER_HMM_UPGRADE_CONFIDENCE_THRESHOLD`, default 0.85)
2. **The cache-eviction planner** (EV of paying the pin's cache warmup vs. expected savings)

Observed in prod (session `01a02032…`, 2026-08-20 ~17:22 UTC, request `b9499e1d…`): a tool-result reroute escalated deepseek-v4-flash → claude-opus-5 at classifier confidence **0.180**, then flipped down to qwen/qwen3.8-max at **0.227** — three providers (makora → anthropic → fireworks) in 22 seconds, each evicting the upstream prompt cache, `planner_outcome=skipped` and `planner_eviction_cost_usd=0` on every turn.

This PR applies both guards inside the authoritative branch, mirroring their counterparts on the HMM cost-gated path:

| Guard | Blocks | Passes through |
|---|---|---|
| Confidence floor (commit 1) | scored fresh decision **pricier** than the pin at confidence < threshold → keep pin (`pin_tier=authoritative_hmm_upgrade_confidence_low`) | confident upgrades (≥ threshold), downgrades/lateral, unscored decisions (fail-open), unpinned turns |
| Eviction veto (commit 2) | **non-upgrade** cross-model switch where `planner.Decide` says eviction outweighs expected savings → keep pin (`pin_tier=authoritative_ev_stay_<reason>`, same EV math as `hmmCostGatedDecision`, `TierUpgradeEnabled=false`) | EV-positive switches, confident upgrades (bypass EV, exactly like the normal path), unpinned turns |

Net contract: **policy owns semantic selection; the router still owns escalation economics and cache economics.** Kill switches: `ROUTER_AUTHORITATIVE_UPGRADE_GATE` and `ROUTER_AUTHORITATIVE_EVICTION_VETO`, both default **true**; either `false` restores the previous verbatim behavior for that guard.

## Needs human attention

- **Contract change vs #802**: two pre-existing test tables encoded "authoritative ignores the planner/sticky entirely." Their scenarios now correctly hit the eviction veto (warm pin, zero-savings lateral switch), so they disable the veto explicitly and point at the dedicated economics coverage. @aminsamir45 — flagging since you own #802; if verbatim execution must remain absolute for some strategies, both guards have kill switches.
- **Default-on choice**: both guards enforce already-established product invariants (the 0.85 floor, the planner's EV rule) whose absence caused observable prod churn. Flip defaults or envs if reviewers prefer opt-in.
- Suppressed turns trip the existing selected≠served telemetry backstop (logged, excluded from training) — same precedent as the arm-selector-unavailable guard.
- Separate observation, not fixed here: prod behaved authoritatively for `strategy=hmm_embedding` turns while the sidecar source declares `authoritative_per_turn_selection: false`, and other sessions on the same key ran the planner normally. The capability wiring inconsistency deserves its own investigation.
- **Follow-up (separate PR)**: removing the hard-coded tool-result communication reroute from the policy sidecar so classifier probabilities are served verbatim. The eviction veto in commit 2 is what makes that removal safe — without it, low-tier turns would oscillate against the pin and re-pay cache warmup every few turns.

## Test plan

- [x] `TestAuthoritativeUpgradeConfidenceGate`: 6 cases (block / confident-pass / downgrade-pass / unscored-fail-open / no-pin / kill-switch)
- [x] `TestAuthoritativeEvictionVeto`: 5 cases (EV-negative stay / EV-positive switch / confident-upgrade bypass / no-prior-usage stay / kill-switch)
- [x] Pre-existing authoritative + sticky-wiring tables updated and green
- [x] `go build ./...`, `go vet ./...` clean; full module suite: 49 packages pass
