### PR TITLE
fix(db): let routing_strategy follow the deployment default

### DIFF
--- a/db/migrations/0058_routing-strategy-follow-deployment-default.down.sql
+++ b/db/migrations/0058_routing-strategy-follow-deployment-default.down.sql
@@ -1,0 +1,15 @@
+BEGIN;
+
+-- Precise inverse of the up. Refilling NULL with 'cluster' before reimposing the
+-- constraint is required: NULL is exactly what the up introduced, and SET NOT NULL
+-- would otherwise fail on those rows. This restores the pre-edit 0034 shape, so an
+-- environment rolled back here resumes stamping new installations 'cluster'.
+UPDATE router.model_router_installations
+SET routing_strategy = 'cluster'
+WHERE routing_strategy IS NULL;
+
+ALTER TABLE router.model_router_installations
+  ALTER COLUMN routing_strategy SET DEFAULT 'cluster',
+  ALTER COLUMN routing_strategy SET NOT NULL;
+
+COMMIT;

--- a/db/migrations/0058_routing-strategy-follow-deployment-default.up.sql
+++ b/db/migrations/0058_routing-strategy-follow-deployment-default.up.sql
@@ -1,0 +1,30 @@
+BEGIN;
+
+-- Realign routing_strategy with the shape 0034 declares. 0034 originally shipped
+-- this column as NOT NULL DEFAULT 'cluster' and was edited in place an hour later
+-- to be nullable; environments that had already applied the original ran the
+-- stricter form and never picked up the edit. The result is live drift: an
+-- environment on the pre-edit form silently stamps every new installation
+-- 'cluster', which pins it to the legacy scorer instead of following
+-- ROUTER_DEFAULT_STRATEGY. Idempotent by construction — on an environment that
+-- applied the edited 0034 both statements are already-satisfied no-ops.
+ALTER TABLE router.model_router_installations
+  ALTER COLUMN routing_strategy DROP DEFAULT,
+  ALTER COLUMN routing_strategy DROP NOT NULL;
+
+-- Release the installations the column default captured. Scoped to rows that
+-- carry no other policy-rollout state: UpdateInstallationPolicy always co-writes
+-- routing_rollout_id / policy_shadow_strategy / policy_debug_enabled /
+-- policy_header_overrides_enabled / policy_routing_intent, so a row at defaults
+-- across all five was never touched by a deliberate pin and only holds 'cluster'
+-- because Postgres filled it in. A genuine operator pin keeps its value.
+UPDATE router.model_router_installations
+SET routing_strategy = NULL
+WHERE routing_strategy = 'cluster'
+  AND routing_rollout_id IS NULL
+  AND policy_shadow_strategy IS NULL
+  AND policy_routing_intent IS NULL
+  AND policy_debug_enabled = FALSE
+  AND policy_header_overrides_enabled = FALSE;
+
+COMMIT;


### PR DESCRIPTION
## Problem

Migration `0034` shipped `routing_strategy` as `NOT NULL DEFAULT 'cluster'`, then was **edited in place** an hour later (#694) to plain `VARCHAR(64)`. Environments that had already applied the original ran the stricter form and never picked up the edit — golang-migrate tracks a version cursor, not file contents.

The two environments have since disagreed:

| Environment | `is_nullable` | `column_default` |
|---|---|---|
| A (drifted) | `NO` | `'cluster'` |
| B | `YES` | *(none)* |

`CreateInstallation` doesn't write the column, so on the drifted environment Postgres fills in `'cluster'` for every new installation. The strategy middleware only falls back to `ROUTER_DEFAULT_STRATEGY` when the persisted value is **empty** (`router_strategy_override.go:50`) — a literal `'cluster'` isn't empty, so it short-circuits the default and pins the installation to the legacy scorer.

A one-off backfill fixed the rows that existed at the time, but the column default kept stamping everything created afterwards. The result is a clean cutover in the data: installations created before the backfill are on the intended default; **every one created since is pinned to `cluster`** — and changing `ROUTER_DEFAULT_STRATEGY` can never move them.

## Fix

1. `DROP DEFAULT` + `DROP NOT NULL` so the live column matches what `0034` declares and what the read path already expects — `converters.go:42` maps `NULL` → `""`, which *is* the follow-the-default sentinel.
2. Release the rows the default captured, scoped to those still at defaults across all five policy-rollout columns `UpdateInstallationPolicy` co-writes (`routing_rollout_id`, `policy_shadow_strategy`, `policy_routing_intent`, `policy_debug_enabled`, `policy_header_overrides_enabled`). A deliberate operator pin keeps its value.

I checked every affected row before scoping this: none carried any of those five signals, and the only ones ever updated post-create had changed excluded/preferred models, the dial, or BYOK — never strategy. Deliberate non-default pins are untouched.

No application code changes — the read path already handles `NULL`.

## Validation

Ran against a real Postgres in both schema shapes:

- **Drifted shape** — accidental rows released to `NULL`; a deliberate `hmm` row and three pinned-`cluster` rows (rollout-id / debug / intent) all preserved; a fresh insert now lands `NULL` (follows the deployment default).
- **Already-correct shape** — confirmed a true no-op: both `ALTER`s are already-satisfied and the `UPDATE` matches nothing; row data byte-identical before/after.
- Full **up → down → up** cycle clean. The down refills `NULL` before re-imposing `NOT NULL`, so it's a precise inverse.

`wv mr tc`, `wv mr t` (no failures), and `go vet ./...` all pass. Filename satisfies the four `check_migrations.yml` rules (format, up/down pair, single migration, highest sequence).

## Rollout

Merge → bump the WorkWeave gitlink; the migration runs from the pin on deploy. The drifted environment converges to the correct shape and its captured installations start following `ROUTER_DEFAULT_STRATEGY`; the other environment is unaffected.

🤖 Generated with [Weave Router](https://router.workweave.ai)