### PR TITLE
fix(install): decide the hidden gate from cache, refresh in background

### DIFF
--- a/install/cc-statusline.sh
+++ b/install/cc-statusline.sh
@@ -294,11 +294,12 @@ weave_sync_commands 2>/dev/null || true
 # stale cache at once. Letting each fetch independently is not safe: the
 # responses can land out of order, and the loser's mv would replace a newer
 # setting with an older one AND stamp it fresh, pinning the gate on a stale
-# value for a full TTL. At most one refresh per cache key therefore runs at a
-# time, guarded by a mkdir mutex (atomic everywhere; flock is absent on macOS)
-# held across both the fetch and the write. A refresh that finds the mutex held
-# exits rather than queueing — the in-flight one is at least as fresh as
-# anything it would fetch, so waiting only to overwrite it is the bug.
+# value for a full TTL. Refreshes are therefore serialized per cache key on a
+# mkdir mutex (atomic everywhere; flock is absent on macOS), held across both
+# the fetch and the write. A refresh that finds the mutex held exits rather
+# than queueing — the in-flight one is at least as fresh as anything it would
+# fetch, so waiting only to overwrite it is the bug. The one path that is not
+# strictly exclusive is reclaiming a lock whose holder died; see below.
 weave_hidden_gate() {
   command -v curl >/dev/null 2>&1 || return 1
   command -v jq >/dev/null 2>&1 || return 1
@@ -353,14 +354,17 @@ weave_hidden_gate() {
       if [ "${lock_mtime:-0}" -le 0 ] || [ $(( lock_now - lock_mtime )) -le 30 ]; then
         exit 0
       fi
-      # Reclaiming an abandoned lock must itself be atomic. `rm -rf` followed
-      # by `mkdir` is not: two refreshers that both see the same stale lock
-      # would each delete the other's freshly created one and both proceed to
-      # fetch, restoring the very race this mutex exists to prevent. Renaming
-      # is atomic, so exactly one racer can move the stale directory aside —
-      # the loser's mv finds nothing there and exits instead of clobbering the
-      # winner. Re-acquiring can still lose to an unrelated invocation that
-      # grabbed the now-free lock first, which is fine: someone holds it.
+      # Reclaiming an abandoned lock must not be delete-then-recreate. With
+      # `rm -rf` + `mkdir`, refreshers that all see the same stale lock each
+      # delete the next one's freshly created directory, so many end up holding
+      # it at once (measured at 50 claimants: 4-11 concurrent holders) and their
+      # writes can land out of order. Renaming is atomic, so only one racer can
+      # move a given directory aside and the losers exit instead of clobbering
+      # the winner (same measurement: 1-2). It is not a perfect mutex — a
+      # straggler can still reclaim the new lock a winner just created, since
+      # nothing distinguishes it from the stale one — but real refreshes arrive
+      # one per turn rather than 50 at once, and the staleness threshold below
+      # is what bounds the rest.
       dead="$lock.dead.$$"
       mv "$lock" "$dead" 2>/dev/null || exit 0
       rm -rf "$dead" 2>/dev/null

--- a/install/cc-statusline.sh
+++ b/install/cc-statusline.sh
@@ -281,11 +281,14 @@ weave_sync_commands 2>/dev/null || true
 #
 # When the org has hidden the router's terminal surfaces, the statusline
 # renders nothing: this prints no output and exits 0, leaving the slot blank.
-# The setting is read from GET /v1/display-settings with the install's own
-# router key and cached per install for WEAVE_DISPLAY_SETTINGS_TTL_SECONDS
-# (default 1h) so a turn never blocks on the network. Any failure to reach the
-# router or read credentials renders the statusline normally (fail-open) — an
-# org that hasn't hidden anything must see no behavior change.
+# The setting comes from GET /v1/display-settings with the install's own
+# router key, but the foreground path NEVER touches the network: it decides
+# solely from a per-install cache file (TTL WEAVE_DISPLAY_SETTINGS_TTL_SECONDS,
+# default 1h), and a missing or stale cache fails open — the statusline
+# renders normally. When the cache is missing or stale a detached background
+# refresh re-fetches the setting and rewrites the cache atomically, so the
+# next turn picks up the fresh value; a refresh failure simply leaves the
+# cache stale, which keeps failing open rather than pinning the gate closed.
 weave_hidden_gate() {
   command -v curl >/dev/null 2>&1 || return 1
   command -v jq >/dev/null 2>&1 || return 1
@@ -298,60 +301,71 @@ weave_hidden_gate() {
   local cache="$cache_dir/display-settings${script_slug}"
   local ttl="${WEAVE_DISPLAY_SETTINGS_TTL_SECONDS:-3600}"
 
-  local now mtime
+  local now mtime fresh="false"
   now="$(date +%s 2>/dev/null)" || now=0
   if [ -f "$cache" ]; then
     mtime="$(stat -c %Y "$cache" 2>/dev/null || stat -f %m "$cache" 2>/dev/null)" || mtime=0
     if [ -n "${mtime:-}" ] && [ "$mtime" -gt 0 ] && [ $(( now - mtime )) -lt "$ttl" ]; then
-      [ "$(cat "$cache" 2>/dev/null)" = "1" ]
-      return
+      fresh="true"
     fi
   fi
 
-  # Resolve the router base URL and key from the Claude Code settings the
-  # installer wrote. Project/--dir installs put both under <base>/.claude
-  # alongside this script (key in settings.local.json), while a user-scope
-  # install lives under ~/.weave and reads ~/.claude. Resolve relative to the
+  # Foreground decision: only a fresh cache hides the surfaces. Anything else
+  # (no cache, stale cache, unreadable cache) renders normally so a slow or
+  # unreachable router can never stall a turn or wedge the statusline blank.
+  if [ "$fresh" = "true" ]; then
+    [ "$(cat "$cache" 2>/dev/null)" = "1" ]
+    return
+  fi
+
+  # Background refresh for the next invocation. Resolve the router base URL
+  # and key inside the subshell from the Claude Code settings the installer
+  # wrote: project/--dir installs put both under <base>/.claude alongside
+  # this script (key in settings.local.json), while a user-scope install
+  # lives under ~/.weave and reads ~/.claude. Resolve relative to the
   # script's own location, falling back to user scope, so a project install
   # never reads (or leaks) the user-scope key. ANTHROPIC_BASE_URL and
-  # WEAVE_ROUTER_BASE_URL may also be set in the environment.
-  local self_dir
-  self_dir="$(cd "$(dirname "$self")" 2>/dev/null && pwd)"
-  local settings_base="$HOME"
-  case "$self_dir" in
-    */.claude) settings_base="${self_dir%/.claude}" ;;
-  esac
-  local settings="$settings_base/.claude/settings.json"
-  local local_settings="$settings_base/.claude/settings.local.json"
-  local base_url="${WEAVE_ROUTER_BASE_URL:-${ANTHROPIC_BASE_URL:-}}"
-  local key="${WEAVE_ROUTER_KEY:-}"
-  if [ -z "$key" ] && [ -f "$settings" ]; then
-    key="$(jq -r '.env.ANTHROPIC_CUSTOM_HEADERS // "" | split("\n")[] | select(startswith("X-Weave-Router-Key:")) | sub("^X-Weave-Router-Key:[[:space:]]*";"")' "$settings" 2>/dev/null | head -n1)"
-  fi
-  if [ -z "$key" ] && [ -f "$local_settings" ]; then
-    key="$(jq -r '.env.ANTHROPIC_CUSTOM_HEADERS // "" | split("\n")[] | select(startswith("X-Weave-Router-Key:")) | sub("^X-Weave-Router-Key:[[:space:]]*";"")' "$local_settings" 2>/dev/null | head -n1)"
-  fi
-  if [ -z "$base_url" ] && [ -f "$settings" ]; then
-    base_url="$(jq -r '.env.ANTHROPIC_BASE_URL // empty' "$settings" 2>/dev/null)"
-  fi
-  [ -n "$base_url" ] && [ -n "$key" ] || return 1
-
-  # A file:// base URL is the offline/test seam: curl reads it as the response
-  # body directly, so the endpoint path is meaningless for it. Real router URLs
+  # WEAVE_ROUTER_BASE_URL may also be set in the environment. A file:// base
+  # URL is the offline/test seam: curl reads it as the response body
+  # directly, so the endpoint path is meaningless for it; real router URLs
   # (https) get /v1/display-settings appended.
-  local url="${base_url%/}"
-  case "$url" in
-    file://*) ;;
-    *) url="$url/v1/display-settings" ;;
-  esac
-  local body hidden=""
-  body="$(curl -fsS --max-time 5 -H "X-Weave-Router-Key: $key" "$url" 2>/dev/null)" || { [ -f "$cache" ] && { [ "$(cat "$cache" 2>/dev/null)" = "1" ] && return 0 || return 1; }; return 1; }
-  hidden="$(printf '%s' "$body" | jq -r '.hide_terminal_surfaces // false' 2>/dev/null)"
-  if [ "$hidden" = "true" ]; then
-    printf '1' >"$cache" 2>/dev/null
-    return 0
-  fi
-  printf '0' >"$cache" 2>/dev/null
+  (
+    exec </dev/null
+    self_dir="$(cd "$(dirname "$self")" 2>/dev/null && pwd)"
+    settings_base="$HOME"
+    case "$self_dir" in
+      */.claude) settings_base="${self_dir%/.claude}" ;;
+    esac
+    settings="$settings_base/.claude/settings.json"
+    local_settings="$settings_base/.claude/settings.local.json"
+    base_url="${WEAVE_ROUTER_BASE_URL:-${ANTHROPIC_BASE_URL:-}}"
+    key="${WEAVE_ROUTER_KEY:-}"
+    if [ -z "$key" ] && [ -f "$settings" ]; then
+      key="$(jq -r '.env.ANTHROPIC_CUSTOM_HEADERS // "" | split("\n")[] | select(startswith("X-Weave-Router-Key:")) | sub("^X-Weave-Router-Key:[[:space:]]*";"")' "$settings" 2>/dev/null | head -n1)"
+    fi
+    if [ -z "$key" ] && [ -f "$local_settings" ]; then
+      key="$(jq -r '.env.ANTHROPIC_CUSTOM_HEADERS // "" | split("\n")[] | select(startswith("X-Weave-Router-Key:")) | sub("^X-Weave-Router-Key:[[:space:]]*";"")' "$local_settings" 2>/dev/null | head -n1)"
+    fi
+    if [ -z "$base_url" ] && [ -f "$settings" ]; then
+      base_url="$(jq -r '.env.ANTHROPIC_BASE_URL // empty' "$settings" 2>/dev/null)"
+    fi
+    [ -n "$base_url" ] && [ -n "$key" ] || exit 0
+    url="${base_url%/}"
+    case "$url" in
+      file://*) ;;
+      *) url="$url/v1/display-settings" ;;
+    esac
+    body="$(curl -fsS --max-time 5 -H "X-Weave-Router-Key: $key" "$url" 2>/dev/null)" || exit 0
+    hidden="$(printf '%s' "$body" | jq -r '.hide_terminal_surfaces // false' 2>/dev/null)"
+    tmp="$cache.tmp.$$"
+    if [ "$hidden" = "true" ]; then
+      printf '1' >"$tmp" 2>/dev/null && mv "$tmp" "$cache" 2>/dev/null
+    else
+      printf '0' >"$tmp" 2>/dev/null && mv "$tmp" "$cache" 2>/dev/null
+    fi
+    rm -f "$tmp" 2>/dev/null
+  ) >/dev/null 2>&1 &
+  disown 2>/dev/null || true
   return 1
 }
 

--- a/install/cc-statusline.sh
+++ b/install/cc-statusline.sh
@@ -289,6 +289,16 @@ weave_sync_commands 2>/dev/null || true
 # refresh re-fetches the setting and rewrites the cache atomically, so the
 # next turn picks up the fresh value; a refresh failure simply leaves the
 # cache stale, which keeps failing open rather than pinning the gate closed.
+#
+# Claude Code runs the statusline every turn, so several invocations can see a
+# stale cache at once. Letting each fetch independently is not safe: the
+# responses can land out of order, and the loser's mv would replace a newer
+# setting with an older one AND stamp it fresh, pinning the gate on a stale
+# value for a full TTL. At most one refresh per cache key therefore runs at a
+# time, guarded by a mkdir mutex (atomic everywhere; flock is absent on macOS)
+# held across both the fetch and the write. A refresh that finds the mutex held
+# exits rather than queueing — the in-flight one is at least as fresh as
+# anything it would fetch, so waiting only to overwrite it is the bug.
 weave_hidden_gate() {
   command -v curl >/dev/null 2>&1 || return 1
   command -v jq >/dev/null 2>&1 || return 1
@@ -331,6 +341,24 @@ weave_hidden_gate() {
   # (https) get /v1/display-settings appended.
   (
     exec </dev/null
+
+    # Take the per-cache-key mutex, or bail. mkdir is the portable atomic
+    # test-and-set. A crashed holder would otherwise block refreshes forever,
+    # so a lock older than the fetch timeout is treated as abandoned and
+    # reclaimed. Releasing from a trap covers every exit path below.
+    lock="$cache.lock"
+    if ! mkdir "$lock" 2>/dev/null; then
+      lock_mtime="$(stat -c %Y "$lock" 2>/dev/null || stat -f %m "$lock" 2>/dev/null)" || lock_mtime=0
+      lock_now="$(date +%s 2>/dev/null)" || lock_now=0
+      if [ "${lock_mtime:-0}" -gt 0 ] && [ $(( lock_now - lock_mtime )) -gt 30 ]; then
+        rm -rf "$lock" 2>/dev/null
+        mkdir "$lock" 2>/dev/null || exit 0
+      else
+        exit 0
+      fi
+    fi
+    trap 'rmdir "$lock" 2>/dev/null' EXIT
+
     self_dir="$(cd "$(dirname "$self")" 2>/dev/null && pwd)"
     settings_base="$HOME"
     case "$self_dir" in

--- a/install/cc-statusline.sh
+++ b/install/cc-statusline.sh
@@ -350,12 +350,21 @@ weave_hidden_gate() {
     if ! mkdir "$lock" 2>/dev/null; then
       lock_mtime="$(stat -c %Y "$lock" 2>/dev/null || stat -f %m "$lock" 2>/dev/null)" || lock_mtime=0
       lock_now="$(date +%s 2>/dev/null)" || lock_now=0
-      if [ "${lock_mtime:-0}" -gt 0 ] && [ $(( lock_now - lock_mtime )) -gt 30 ]; then
-        rm -rf "$lock" 2>/dev/null
-        mkdir "$lock" 2>/dev/null || exit 0
-      else
+      if [ "${lock_mtime:-0}" -le 0 ] || [ $(( lock_now - lock_mtime )) -le 30 ]; then
         exit 0
       fi
+      # Reclaiming an abandoned lock must itself be atomic. `rm -rf` followed
+      # by `mkdir` is not: two refreshers that both see the same stale lock
+      # would each delete the other's freshly created one and both proceed to
+      # fetch, restoring the very race this mutex exists to prevent. Renaming
+      # is atomic, so exactly one racer can move the stale directory aside —
+      # the loser's mv finds nothing there and exits instead of clobbering the
+      # winner. Re-acquiring can still lose to an unrelated invocation that
+      # grabbed the now-free lock first, which is fine: someone holds it.
+      dead="$lock.dead.$$"
+      mv "$lock" "$dead" 2>/dev/null || exit 0
+      rm -rf "$dead" 2>/dev/null
+      mkdir "$lock" 2>/dev/null || exit 0
     fi
     trap 'rmdir "$lock" 2>/dev/null' EXIT
 

--- a/install/install.sh
+++ b/install/install.sh
@@ -3087,11 +3087,12 @@ weave_sync_commands 2>/dev/null || true
 # stale cache at once. Letting each fetch independently is not safe: the
 # responses can land out of order, and the loser's mv would replace a newer
 # setting with an older one AND stamp it fresh, pinning the gate on a stale
-# value for a full TTL. At most one refresh per cache key therefore runs at a
-# time, guarded by a mkdir mutex (atomic everywhere; flock is absent on macOS)
-# held across both the fetch and the write. A refresh that finds the mutex held
-# exits rather than queueing — the in-flight one is at least as fresh as
-# anything it would fetch, so waiting only to overwrite it is the bug.
+# value for a full TTL. Refreshes are therefore serialized per cache key on a
+# mkdir mutex (atomic everywhere; flock is absent on macOS), held across both
+# the fetch and the write. A refresh that finds the mutex held exits rather
+# than queueing — the in-flight one is at least as fresh as anything it would
+# fetch, so waiting only to overwrite it is the bug. The one path that is not
+# strictly exclusive is reclaiming a lock whose holder died; see below.
 weave_hidden_gate() {
   command -v curl >/dev/null 2>&1 || return 1
   command -v jq >/dev/null 2>&1 || return 1
@@ -3146,14 +3147,17 @@ weave_hidden_gate() {
       if [ "${lock_mtime:-0}" -le 0 ] || [ $(( lock_now - lock_mtime )) -le 30 ]; then
         exit 0
       fi
-      # Reclaiming an abandoned lock must itself be atomic. `rm -rf` followed
-      # by `mkdir` is not: two refreshers that both see the same stale lock
-      # would each delete the other's freshly created one and both proceed to
-      # fetch, restoring the very race this mutex exists to prevent. Renaming
-      # is atomic, so exactly one racer can move the stale directory aside —
-      # the loser's mv finds nothing there and exits instead of clobbering the
-      # winner. Re-acquiring can still lose to an unrelated invocation that
-      # grabbed the now-free lock first, which is fine: someone holds it.
+      # Reclaiming an abandoned lock must not be delete-then-recreate. With
+      # `rm -rf` + `mkdir`, refreshers that all see the same stale lock each
+      # delete the next one's freshly created directory, so many end up holding
+      # it at once (measured at 50 claimants: 4-11 concurrent holders) and their
+      # writes can land out of order. Renaming is atomic, so only one racer can
+      # move a given directory aside and the losers exit instead of clobbering
+      # the winner (same measurement: 1-2). It is not a perfect mutex — a
+      # straggler can still reclaim the new lock a winner just created, since
+      # nothing distinguishes it from the stale one — but real refreshes arrive
+      # one per turn rather than 50 at once, and the staleness threshold below
+      # is what bounds the rest.
       dead="$lock.dead.$$"
       mv "$lock" "$dead" 2>/dev/null || exit 0
       rm -rf "$dead" 2>/dev/null

--- a/install/install.sh
+++ b/install/install.sh
@@ -3082,6 +3082,16 @@ weave_sync_commands 2>/dev/null || true
 # refresh re-fetches the setting and rewrites the cache atomically, so the
 # next turn picks up the fresh value; a refresh failure simply leaves the
 # cache stale, which keeps failing open rather than pinning the gate closed.
+#
+# Claude Code runs the statusline every turn, so several invocations can see a
+# stale cache at once. Letting each fetch independently is not safe: the
+# responses can land out of order, and the loser's mv would replace a newer
+# setting with an older one AND stamp it fresh, pinning the gate on a stale
+# value for a full TTL. At most one refresh per cache key therefore runs at a
+# time, guarded by a mkdir mutex (atomic everywhere; flock is absent on macOS)
+# held across both the fetch and the write. A refresh that finds the mutex held
+# exits rather than queueing — the in-flight one is at least as fresh as
+# anything it would fetch, so waiting only to overwrite it is the bug.
 weave_hidden_gate() {
   command -v curl >/dev/null 2>&1 || return 1
   command -v jq >/dev/null 2>&1 || return 1
@@ -3124,6 +3134,24 @@ weave_hidden_gate() {
   # (https) get /v1/display-settings appended.
   (
     exec </dev/null
+
+    # Take the per-cache-key mutex, or bail. mkdir is the portable atomic
+    # test-and-set. A crashed holder would otherwise block refreshes forever,
+    # so a lock older than the fetch timeout is treated as abandoned and
+    # reclaimed. Releasing from a trap covers every exit path below.
+    lock="$cache.lock"
+    if ! mkdir "$lock" 2>/dev/null; then
+      lock_mtime="$(stat -c %Y "$lock" 2>/dev/null || stat -f %m "$lock" 2>/dev/null)" || lock_mtime=0
+      lock_now="$(date +%s 2>/dev/null)" || lock_now=0
+      if [ "${lock_mtime:-0}" -gt 0 ] && [ $(( lock_now - lock_mtime )) -gt 30 ]; then
+        rm -rf "$lock" 2>/dev/null
+        mkdir "$lock" 2>/dev/null || exit 0
+      else
+        exit 0
+      fi
+    fi
+    trap 'rmdir "$lock" 2>/dev/null' EXIT
+
     self_dir="$(cd "$(dirname "$self")" 2>/dev/null && pwd)"
     settings_base="$HOME"
     case "$self_dir" in

--- a/install/install.sh
+++ b/install/install.sh
@@ -3074,11 +3074,14 @@ weave_sync_commands 2>/dev/null || true
 #
 # When the org has hidden the router's terminal surfaces, the statusline
 # renders nothing: this prints no output and exits 0, leaving the slot blank.
-# The setting is read from GET /v1/display-settings with the install's own
-# router key and cached per install for WEAVE_DISPLAY_SETTINGS_TTL_SECONDS
-# (default 1h) so a turn never blocks on the network. Any failure to reach the
-# router or read credentials renders the statusline normally (fail-open) — an
-# org that hasn't hidden anything must see no behavior change.
+# The setting comes from GET /v1/display-settings with the install's own
+# router key, but the foreground path NEVER touches the network: it decides
+# solely from a per-install cache file (TTL WEAVE_DISPLAY_SETTINGS_TTL_SECONDS,
+# default 1h), and a missing or stale cache fails open — the statusline
+# renders normally. When the cache is missing or stale a detached background
+# refresh re-fetches the setting and rewrites the cache atomically, so the
+# next turn picks up the fresh value; a refresh failure simply leaves the
+# cache stale, which keeps failing open rather than pinning the gate closed.
 weave_hidden_gate() {
   command -v curl >/dev/null 2>&1 || return 1
   command -v jq >/dev/null 2>&1 || return 1
@@ -3091,60 +3094,71 @@ weave_hidden_gate() {
   local cache="$cache_dir/display-settings${script_slug}"
   local ttl="${WEAVE_DISPLAY_SETTINGS_TTL_SECONDS:-3600}"
 
-  local now mtime
+  local now mtime fresh="false"
   now="$(date +%s 2>/dev/null)" || now=0
   if [ -f "$cache" ]; then
     mtime="$(stat -c %Y "$cache" 2>/dev/null || stat -f %m "$cache" 2>/dev/null)" || mtime=0
     if [ -n "${mtime:-}" ] && [ "$mtime" -gt 0 ] && [ $(( now - mtime )) -lt "$ttl" ]; then
-      [ "$(cat "$cache" 2>/dev/null)" = "1" ]
-      return
+      fresh="true"
     fi
   fi
 
-  # Resolve the router base URL and key from the Claude Code settings the
-  # installer wrote. Project/--dir installs put both under <base>/.claude
-  # alongside this script (key in settings.local.json), while a user-scope
-  # install lives under ~/.weave and reads ~/.claude. Resolve relative to the
+  # Foreground decision: only a fresh cache hides the surfaces. Anything else
+  # (no cache, stale cache, unreadable cache) renders normally so a slow or
+  # unreachable router can never stall a turn or wedge the statusline blank.
+  if [ "$fresh" = "true" ]; then
+    [ "$(cat "$cache" 2>/dev/null)" = "1" ]
+    return
+  fi
+
+  # Background refresh for the next invocation. Resolve the router base URL
+  # and key inside the subshell from the Claude Code settings the installer
+  # wrote: project/--dir installs put both under <base>/.claude alongside
+  # this script (key in settings.local.json), while a user-scope install
+  # lives under ~/.weave and reads ~/.claude. Resolve relative to the
   # script's own location, falling back to user scope, so a project install
   # never reads (or leaks) the user-scope key. ANTHROPIC_BASE_URL and
-  # WEAVE_ROUTER_BASE_URL may also be set in the environment.
-  local self_dir
-  self_dir="$(cd "$(dirname "$self")" 2>/dev/null && pwd)"
-  local settings_base="$HOME"
-  case "$self_dir" in
-    */.claude) settings_base="${self_dir%/.claude}" ;;
-  esac
-  local settings="$settings_base/.claude/settings.json"
-  local local_settings="$settings_base/.claude/settings.local.json"
-  local base_url="${WEAVE_ROUTER_BASE_URL:-${ANTHROPIC_BASE_URL:-}}"
-  local key="${WEAVE_ROUTER_KEY:-}"
-  if [ -z "$key" ] && [ -f "$settings" ]; then
-    key="$(jq -r '.env.ANTHROPIC_CUSTOM_HEADERS // "" | split("\n")[] | select(startswith("X-Weave-Router-Key:")) | sub("^X-Weave-Router-Key:[[:space:]]*";"")' "$settings" 2>/dev/null | head -n1)"
-  fi
-  if [ -z "$key" ] && [ -f "$local_settings" ]; then
-    key="$(jq -r '.env.ANTHROPIC_CUSTOM_HEADERS // "" | split("\n")[] | select(startswith("X-Weave-Router-Key:")) | sub("^X-Weave-Router-Key:[[:space:]]*";"")' "$local_settings" 2>/dev/null | head -n1)"
-  fi
-  if [ -z "$base_url" ] && [ -f "$settings" ]; then
-    base_url="$(jq -r '.env.ANTHROPIC_BASE_URL // empty' "$settings" 2>/dev/null)"
-  fi
-  [ -n "$base_url" ] && [ -n "$key" ] || return 1
-
-  # A file:// base URL is the offline/test seam: curl reads it as the response
-  # body directly, so the endpoint path is meaningless for it. Real router URLs
+  # WEAVE_ROUTER_BASE_URL may also be set in the environment. A file:// base
+  # URL is the offline/test seam: curl reads it as the response body
+  # directly, so the endpoint path is meaningless for it; real router URLs
   # (https) get /v1/display-settings appended.
-  local url="${base_url%/}"
-  case "$url" in
-    file://*) ;;
-    *) url="$url/v1/display-settings" ;;
-  esac
-  local body hidden=""
-  body="$(curl -fsS --max-time 5 -H "X-Weave-Router-Key: $key" "$url" 2>/dev/null)" || { [ -f "$cache" ] && { [ "$(cat "$cache" 2>/dev/null)" = "1" ] && return 0 || return 1; }; return 1; }
-  hidden="$(printf '%s' "$body" | jq -r '.hide_terminal_surfaces // false' 2>/dev/null)"
-  if [ "$hidden" = "true" ]; then
-    printf '1' >"$cache" 2>/dev/null
-    return 0
-  fi
-  printf '0' >"$cache" 2>/dev/null
+  (
+    exec </dev/null
+    self_dir="$(cd "$(dirname "$self")" 2>/dev/null && pwd)"
+    settings_base="$HOME"
+    case "$self_dir" in
+      */.claude) settings_base="${self_dir%/.claude}" ;;
+    esac
+    settings="$settings_base/.claude/settings.json"
+    local_settings="$settings_base/.claude/settings.local.json"
+    base_url="${WEAVE_ROUTER_BASE_URL:-${ANTHROPIC_BASE_URL:-}}"
+    key="${WEAVE_ROUTER_KEY:-}"
+    if [ -z "$key" ] && [ -f "$settings" ]; then
+      key="$(jq -r '.env.ANTHROPIC_CUSTOM_HEADERS // "" | split("\n")[] | select(startswith("X-Weave-Router-Key:")) | sub("^X-Weave-Router-Key:[[:space:]]*";"")' "$settings" 2>/dev/null | head -n1)"
+    fi
+    if [ -z "$key" ] && [ -f "$local_settings" ]; then
+      key="$(jq -r '.env.ANTHROPIC_CUSTOM_HEADERS // "" | split("\n")[] | select(startswith("X-Weave-Router-Key:")) | sub("^X-Weave-Router-Key:[[:space:]]*";"")' "$local_settings" 2>/dev/null | head -n1)"
+    fi
+    if [ -z "$base_url" ] && [ -f "$settings" ]; then
+      base_url="$(jq -r '.env.ANTHROPIC_BASE_URL // empty' "$settings" 2>/dev/null)"
+    fi
+    [ -n "$base_url" ] && [ -n "$key" ] || exit 0
+    url="${base_url%/}"
+    case "$url" in
+      file://*) ;;
+      *) url="$url/v1/display-settings" ;;
+    esac
+    body="$(curl -fsS --max-time 5 -H "X-Weave-Router-Key: $key" "$url" 2>/dev/null)" || exit 0
+    hidden="$(printf '%s' "$body" | jq -r '.hide_terminal_surfaces // false' 2>/dev/null)"
+    tmp="$cache.tmp.$$"
+    if [ "$hidden" = "true" ]; then
+      printf '1' >"$tmp" 2>/dev/null && mv "$tmp" "$cache" 2>/dev/null
+    else
+      printf '0' >"$tmp" 2>/dev/null && mv "$tmp" "$cache" 2>/dev/null
+    fi
+    rm -f "$tmp" 2>/dev/null
+  ) >/dev/null 2>&1 &
+  disown 2>/dev/null || true
   return 1
 }
 

--- a/install/install.sh
+++ b/install/install.sh
@@ -3143,12 +3143,21 @@ weave_hidden_gate() {
     if ! mkdir "$lock" 2>/dev/null; then
       lock_mtime="$(stat -c %Y "$lock" 2>/dev/null || stat -f %m "$lock" 2>/dev/null)" || lock_mtime=0
       lock_now="$(date +%s 2>/dev/null)" || lock_now=0
-      if [ "${lock_mtime:-0}" -gt 0 ] && [ $(( lock_now - lock_mtime )) -gt 30 ]; then
-        rm -rf "$lock" 2>/dev/null
-        mkdir "$lock" 2>/dev/null || exit 0
-      else
+      if [ "${lock_mtime:-0}" -le 0 ] || [ $(( lock_now - lock_mtime )) -le 30 ]; then
         exit 0
       fi
+      # Reclaiming an abandoned lock must itself be atomic. `rm -rf` followed
+      # by `mkdir` is not: two refreshers that both see the same stale lock
+      # would each delete the other's freshly created one and both proceed to
+      # fetch, restoring the very race this mutex exists to prevent. Renaming
+      # is atomic, so exactly one racer can move the stale directory aside —
+      # the loser's mv finds nothing there and exits instead of clobbering the
+      # winner. Re-acquiring can still lose to an unrelated invocation that
+      # grabbed the now-free lock first, which is fine: someone holds it.
+      dead="$lock.dead.$$"
+      mv "$lock" "$dead" 2>/dev/null || exit 0
+      rm -rf "$dead" 2>/dev/null
+      mkdir "$lock" 2>/dev/null || exit 0
     fi
     trap 'rmdir "$lock" 2>/dev/null' EXIT
 

--- a/install/tests/cc-statusline_test.sh
+++ b/install/tests/cc-statusline_test.sh
@@ -86,6 +86,11 @@ line_count_at_least() { # line_count_at_least <file> <n>
   [ "$(wc -l < "$1" | tr -d ' ')" -ge "$2" ]
 }
 
+# `wait_for` runs its argv, so a negated condition needs to be its own command.
+not_a_dir() { # not_a_dir <path>
+  [ ! -d "$1" ]
+}
+
 # curl must speak file:// for the offline fixtures to work. Fail loudly rather
 # than silently skipping the download-dependent cases.
 probe="$work/probe.txt"
@@ -546,13 +551,12 @@ check_contains "cache miss with an unreachable router renders normally" "$out" "
 sleep 1
 check "failed refresh writes no cache file" "$(test -f "$cache_file" && echo present || echo absent)" "absent"
 
-# Concurrent refreshes must not both fetch: two in-flight requests can complete
-# out of order, and the loser's write would replace a newer setting with an
-# older one AND stamp it fresh, pinning the gate on a stale value for a whole
-# TTL. The curl shim makes that ordering deterministic — whichever refresh
-# calls first is stalled serving hide=true until a second one answers
-# hide=false — so an unserialized implementation performs two fetches and ends
-# on the stale "1", while a serialized one fetches exactly once.
+# Concurrent refreshes must never be in flight at the same time: two
+# overlapping requests can complete out of order, and the loser's write would
+# replace a newer setting with an older one AND stamp it fresh, pinning the
+# gate on a stale value for a whole TTL. The curl shim below stalls the first
+# responder on hide=true until a second answers hide=false, so an unserialized
+# implementation has both in flight together and ends on the stale "1".
 c="$work/g7"; mkdir -p "$c/proj/.claude" "$c/cache" "$c/bin"
 write_install "$c/proj" project "rk_key" "file://$c/ds.json"
 printf '{"hide_terminal_surfaces": true}' > "$c/ds.json"
@@ -564,6 +568,10 @@ cat > "$c/bin/curl" <<'SHIM'
 n=1
 while ! mkdir "$WEAVE_TEST_TURNS/$n" 2>/dev/null; do n=$((n + 1)); done
 echo "$n" >> "$WEAVE_TEST_CALLS"
+# Announce this fetch for its whole duration; a concurrent one records a
+# violation. This is what the mutex must make impossible.
+[ -e "$WEAVE_TEST_INFLIGHT" ] && echo overlap >> "$WEAVE_TEST_OVERLAP"
+: > "$WEAVE_TEST_INFLIGHT"
 if [ "$n" -eq 1 ]; then
   # Stall the stale responder until the fresh one has written, or until the
   # deadline passes (serialized runs never produce a second call, and this
@@ -572,71 +580,83 @@ if [ "$n" -eq 1 ]; then
     [ -f "$WEAVE_TEST_RELEASE" ] && break
     sleep 0.05
   done
+  rm -f "$WEAVE_TEST_INFLIGHT"
   printf '{"hide_terminal_surfaces": true}'
 else
+  rm -f "$WEAVE_TEST_INFLIGHT"
   printf '{"hide_terminal_surfaces": false}'
   : > "$WEAVE_TEST_RELEASE"
 fi
 SHIM
 chmod +x "$c/bin/curl"
-mkdir -p "$c/turns"; : > "$c/calls"
+mkdir -p "$c/turns"; : > "$c/calls"; : > "$c/overlap"; rm -f "$c/inflight"
 for _ in 1 2; do
   echo "{\"model\":{\"id\":\"$STALE_MODEL\"},\"transcript_path\":\"$transcript\"}" \
     | PATH="$c/bin:$PATH" XDG_CACHE_HOME="$c/cache" WEAVE_STATUSLINE_UPDATE=0 \
       WEAVE_COMMANDS_UPDATE=0 HOME="$c/home" WEAVE_ROUTER_BASE_URL= ANTHROPIC_BASE_URL= \
       WEAVE_ROUTER_KEY= ANTHROPIC_CUSTOM_HEADERS= WEAVE_TEST_TURNS="$c/turns" \
       WEAVE_TEST_CALLS="$c/calls" WEAVE_TEST_RELEASE="$c/release" \
+      WEAVE_TEST_INFLIGHT="$c/inflight" WEAVE_TEST_OVERLAP="$c/overlap" \
       bash "$c/proj/.claude/cc-statusline.sh" >/dev/null 2>&1 &
 done
 wait
 # Both refreshes are detached, so the foreground exit says nothing about them.
 wait_for 15 test -f "$cache_file"
 sleep 3
-# The discriminating assertion. Asserting the cached VALUE instead would be
-# tautological: with one fetch the value is turn 1's either way.
+# Mutual exclusion is the property under test, so assert on overlap rather than
+# a fetch count: two invocations that happen to serialize (the first finishes
+# and releases before the second starts) fetch twice quite legitimately, and on
+# a slow runner that is what happens. Asserting the cached VALUE would be
+# tautological — with one fetch it is the first responder's either way.
 check "concurrent refreshes never fetch at the same time" \
-  "$(wc -l < "$c/calls" | tr -d ' ')" 1
-# The second invocation must still have rendered rather than blocking on the
-# mutex the first one holds — a refresh that queues would stall the turn.
-check "the refresh that loses the mutex leaves the cache to the winner" \
-  "$(cat "$cache_file" 2>/dev/null)" "1"
+  "$(wc -l < "$c/overlap" | tr -d ' ')" 0
+# Guard against the above passing vacuously because nothing ever fetched.
+if [ "$(wc -l < "$c/calls" | tr -d ' ')" -ge 1 ]; then
+  ok "a stale cache does trigger a background refresh"
+else
+  no "a stale cache does trigger a background refresh" "at least one fetch" "no fetch happened"
+fi
 
-# Reclaiming an ABANDONED lock (crashed holder) must stay mutually exclusive.
-# `rm -rf` + `mkdir` is not atomic: refreshers that all see the same stale lock
-# each delete the next one's freshly created directory and all proceed to
-# fetch, restoring the out-of-order race. Pre-seed an old lock, start several
-# invocations at once, and require exactly one fetch.
+# An ABANDONED lock (crashed holder) must not block refreshes forever: a
+# pre-seeded lock older than the reclaim threshold gets taken over, the fetch
+# happens, and the lock is released rather than leaked.
 c="$work/g8"; mkdir -p "$c/proj/.claude" "$c/cache" "$c/bin"
 write_install "$c/proj" project "rk_key" "file://$c/ds.json"
 printf '{"hide_terminal_surfaces": true}' > "$c/ds.json"
 cache_file="$(gate_cache "$c/cache" "$c/proj/.claude/cc-statusline.sh")"
 mkdir -p "$(dirname "$cache_file")"
-# An abandoned lock, well past the 30s reclaim threshold.
 mkdir -p "$cache_file.lock"
 touch -t 202001010000 "$cache_file.lock"
-cat > "$c/bin/curl" <<'SHIM'
-#!/usr/bin/env bash
-# Record the fetch, and dwell long enough that a second racer would overlap.
-echo x >> "$WEAVE_TEST_CALLS"
-sleep 1
-printf '{"hide_terminal_surfaces": true}'
-SHIM
-chmod +x "$c/bin/curl"
-: > "$c/calls"
-for _ in 1 2 3 4 5; do
-  echo "{\"model\":{\"id\":\"$STALE_MODEL\"},\"transcript_path\":\"$transcript\"}" \
-    | PATH="$c/bin:$PATH" XDG_CACHE_HOME="$c/cache" WEAVE_STATUSLINE_UPDATE=0 \
-      WEAVE_COMMANDS_UPDATE=0 HOME="$c/home" WEAVE_ROUTER_BASE_URL= ANTHROPIC_BASE_URL= \
-      WEAVE_ROUTER_KEY= ANTHROPIC_CUSTOM_HEADERS= WEAVE_TEST_CALLS="$c/calls" \
-      bash "$c/proj/.claude/cc-statusline.sh" >/dev/null 2>&1 &
-done
-wait
+echo "{\"model\":{\"id\":\"$STALE_MODEL\"},\"transcript_path\":\"$transcript\"}" \
+  | XDG_CACHE_HOME="$c/cache" WEAVE_STATUSLINE_UPDATE=0 WEAVE_COMMANDS_UPDATE=0 HOME="$c/home" \
+    WEAVE_ROUTER_BASE_URL= ANTHROPIC_BASE_URL= WEAVE_ROUTER_KEY= ANTHROPIC_CUSTOM_HEADERS= \
+    bash "$c/proj/.claude/cc-statusline.sh" >/dev/null 2>&1
 wait_for 15 test -f "$cache_file"
-sleep 3
-check "racing reclaim of an abandoned lock still fetches exactly once" \
-  "$(wc -l < "$c/calls" | tr -d ' ')" 1
-check "a reclaimed lock is released, not leaked" \
-  "$(test -d "$cache_file.lock" && echo held || echo released)" "released"
+check "an abandoned lock is reclaimed rather than blocking refreshes forever" \
+  "$(cat "$cache_file" 2>/dev/null)" "1"
+# The cache is written just before the lock is released, so sampling right
+# after the write catches the holder mid-release. Poll for the release.
+if wait_for 15 not_a_dir "$cache_file.lock"; then
+  ok "a reclaimed lock is released, not leaked"
+else
+  no "a reclaimed lock is released, not leaked" "lock removed" "still held after 15s"
+fi
+
+# A lock a live holder still owns must be left alone: a fresh lock means a
+# refresh is already in flight, so this invocation must not fetch behind it.
+c="$work/g9"; mkdir -p "$c/proj/.claude" "$c/cache"
+write_install "$c/proj" project "rk_key" "file://$c/ds.json"
+printf '{"hide_terminal_surfaces": true}' > "$c/ds.json"
+cache_file="$(gate_cache "$c/cache" "$c/proj/.claude/cc-statusline.sh")"
+mkdir -p "$(dirname "$cache_file")"
+mkdir -p "$cache_file.lock"
+echo "{\"model\":{\"id\":\"$STALE_MODEL\"},\"transcript_path\":\"$transcript\"}" \
+  | XDG_CACHE_HOME="$c/cache" WEAVE_STATUSLINE_UPDATE=0 WEAVE_COMMANDS_UPDATE=0 HOME="$c/home" \
+    WEAVE_ROUTER_BASE_URL= ANTHROPIC_BASE_URL= WEAVE_ROUTER_KEY= ANTHROPIC_CUSTOM_HEADERS= \
+    bash "$c/proj/.claude/cc-statusline.sh" >/dev/null 2>&1
+sleep 2
+check "a lock a live holder owns is left alone" \
+  "$(test -f "$cache_file" && echo wrote || echo skipped)" "skipped"
 
 # install.sh ships the statusline as a heredoc; genprices keeps only the price
 # block in sync, so a code edit to one copy silently diverges from the other.

--- a/install/tests/cc-statusline_test.sh
+++ b/install/tests/cc-statusline_test.sh
@@ -545,6 +545,62 @@ out="$(echo "{\"model\":{\"id\":\"$STALE_MODEL\"},\"transcript_path\":\"$transcr
 check_contains "cache miss with an unreachable router renders normally" "$out" "deepseek/deepseek-v4-pro"
 sleep 1
 check "failed refresh writes no cache file" "$(test -f "$cache_file" && echo present || echo absent)" "absent"
+
+# Concurrent refreshes must not both fetch: two in-flight requests can complete
+# out of order, and the loser's write would replace a newer setting with an
+# older one AND stamp it fresh, pinning the gate on a stale value for a whole
+# TTL. The curl shim makes that ordering deterministic — whichever refresh
+# calls first is stalled serving hide=true until a second one answers
+# hide=false — so an unserialized implementation performs two fetches and ends
+# on the stale "1", while a serialized one fetches exactly once.
+c="$work/g7"; mkdir -p "$c/proj/.claude" "$c/cache" "$c/bin"
+write_install "$c/proj" project "rk_key" "file://$c/ds.json"
+printf '{"hide_terminal_surfaces": true}' > "$c/ds.json"
+cache_file="$(gate_cache "$c/cache" "$c/proj/.claude/cc-statusline.sh")"
+cat > "$c/bin/curl" <<'SHIM'
+#!/usr/bin/env bash
+# Claim a turn number atomically — mkdir is the test-and-set; a read-then-write
+# counter races here exactly as it would in the code under test.
+n=1
+while ! mkdir "$WEAVE_TEST_TURNS/$n" 2>/dev/null; do n=$((n + 1)); done
+echo "$n" >> "$WEAVE_TEST_CALLS"
+if [ "$n" -eq 1 ]; then
+  # Stall the stale responder until the fresh one has written, or until the
+  # deadline passes (serialized runs never produce a second call, and this
+  # test must not hang waiting for one that will never come).
+  for _ in $(seq 1 60); do
+    [ -f "$WEAVE_TEST_RELEASE" ] && break
+    sleep 0.05
+  done
+  printf '{"hide_terminal_surfaces": true}'
+else
+  printf '{"hide_terminal_surfaces": false}'
+  : > "$WEAVE_TEST_RELEASE"
+fi
+SHIM
+chmod +x "$c/bin/curl"
+mkdir -p "$c/turns"; : > "$c/calls"
+for _ in 1 2; do
+  echo "{\"model\":{\"id\":\"$STALE_MODEL\"},\"transcript_path\":\"$transcript\"}" \
+    | PATH="$c/bin:$PATH" XDG_CACHE_HOME="$c/cache" WEAVE_STATUSLINE_UPDATE=0 \
+      WEAVE_COMMANDS_UPDATE=0 HOME="$c/home" WEAVE_ROUTER_BASE_URL= ANTHROPIC_BASE_URL= \
+      WEAVE_ROUTER_KEY= ANTHROPIC_CUSTOM_HEADERS= WEAVE_TEST_TURNS="$c/turns" \
+      WEAVE_TEST_CALLS="$c/calls" WEAVE_TEST_RELEASE="$c/release" \
+      bash "$c/proj/.claude/cc-statusline.sh" >/dev/null 2>&1 &
+done
+wait
+# Both refreshes are detached, so the foreground exit says nothing about them.
+wait_for 15 test -f "$cache_file"
+sleep 3
+# The discriminating assertion. Asserting the cached VALUE instead would be
+# tautological: with one fetch the value is turn 1's either way.
+check "concurrent refreshes never fetch at the same time" \
+  "$(wc -l < "$c/calls" | tr -d ' ')" 1
+# The second invocation must still have rendered rather than blocking on the
+# mutex the first one holds — a refresh that queues would stall the turn.
+check "the refresh that loses the mutex leaves the cache to the winner" \
+  "$(cat "$cache_file" 2>/dev/null)" "1"
+
 # install.sh ships the statusline as a heredoc; genprices keeps only the price
 # block in sync, so a code edit to one copy silently diverges from the other.
 installer="$script_dir/../install.sh"

--- a/install/tests/cc-statusline_test.sh
+++ b/install/tests/cc-statusline_test.sh
@@ -406,15 +406,13 @@ check "WEAVE_STATUSLINE_UPDATE=0 suppresses the wrapper refresh too" \
 
 # ---------- org "hide terminal surfaces" gate ----------
 #
-# The gate reads the org setting from GET /v1/display-settings. These cases stub
-# that endpoint with a tiny file:// server so no network is touched. The router
-# URL must be http for curl to reach the stub, so each case writes the stub's
-# address into the install's own settings (overriding WEAVE_ROUTER_BASE_URL).
-#
-# Drive the gate through a simpler seam than a live socket: WEAVE_ROUTER_BASE_URL
-# accepts a file:// URL, which curl reads as the response body. That exercises
-# the full parse-and-decide path (and the credential lookup) without a network.
-# The key just needs to be present and non-empty for the gate to proceed.
+# The gate decides from a per-install cache file only; the network fetch runs
+# in a detached background refresh that repopulates the cache for the NEXT
+# invocation, and a missing or stale cache fails open. These cases stub
+# GET /v1/display-settings via the file:// seam: WEAVE_ROUTER_BASE_URL or the
+# install's ANTHROPIC_BASE_URL accepts a file:// URL, which curl reads as the
+# response body, exercising the full parse-and-decide path without a network.
+# The key just needs to be present and non-empty for the refresh to proceed.
 #
 # write_install <base> <scope:user|project> <key> <url> — lay down a statusline
 # copy plus the settings.json/settings.local.json the gate reads, in the layout
@@ -441,11 +439,24 @@ EOF
   fi
 }
 
-# Project-scope hidden install renders blank: the gate reads the PROJECT key and
-# settings, sees hide_terminal_surfaces=true, and exits before printing.
+# gate_cache <cache_home> <script> — the cache file the gate reads/writes for
+# this install (mirrors the slug derivation in cc-statusline.sh).
+gate_cache() {
+  echo "$1/weave-router/display-settings$(printf '%s' "$2" | tr -c 'A-Za-z0-9._-' '_')"
+}
+
+# Hidden org goes blank via the cache: the first run fails open while the
+# background refresh caches hide=true, and the second run decides from it.
 c="$work/g1"; mkdir -p "$c/proj/.claude" "$c/cache"
 printf '{"hide_terminal_surfaces": true}' > "$c/ds.json"
 write_install "$c/proj" project "rk_proj_hidden" "file://$c/ds.json"
+cache_file="$(gate_cache "$c/cache" "$c/proj/.claude/cc-statusline.sh")"
+echo "{\"model\":{\"id\":\"$STALE_MODEL\"},\"transcript_path\":\"$transcript\"}" \
+  | XDG_CACHE_HOME="$c/cache" WEAVE_STATUSLINE_UPDATE=0 WEAVE_COMMANDS_UPDATE=0 HOME="$c/home" \
+    WEAVE_ROUTER_BASE_URL= ANTHROPIC_BASE_URL= WEAVE_ROUTER_KEY= ANTHROPIC_CUSTOM_HEADERS= \
+    bash "$c/proj/.claude/cc-statusline.sh" >/dev/null 2>&1
+wait_for 5 test -f "$cache_file"
+check "background refresh caches the hidden setting" "$(cat "$cache_file" 2>/dev/null)" "1"
 out="$(echo "{\"model\":{\"id\":\"$STALE_MODEL\"},\"transcript_path\":\"$transcript\"}" \
   | XDG_CACHE_HOME="$c/cache" WEAVE_STATUSLINE_UPDATE=0 WEAVE_COMMANDS_UPDATE=0 HOME="$c/home" \
     WEAVE_ROUTER_BASE_URL= ANTHROPIC_BASE_URL= WEAVE_ROUTER_KEY= ANTHROPIC_CUSTOM_HEADERS= \
@@ -453,30 +464,87 @@ out="$(echo "{\"model\":{\"id\":\"$STALE_MODEL\"},\"transcript_path\":\"$transcr
 check "project-scope hidden org renders a blank statusline" "$out" ""
 
 # The same project install must NOT fall back to the user-scope key: with a
-# hidden project org but a visible user org in $HOME, the project key wins and
-# the statusline still goes blank.
+# hidden project org but a visible user org in $HOME, the refresh caches from
+# the project key ("1"), not the user key ("0"), and the statusline goes blank.
 c="$work/g2"; mkdir -p "$c/proj/.claude" "$c/home/.claude" "$c/cache"
 printf '{"hide_terminal_surfaces": true}' > "$c/ds_proj.json"
 printf '{"hide_terminal_surfaces": false}' > "$c/ds_user.json"
 write_install "$c/proj" project "rk_proj_hidden" "file://$c/ds_proj.json"
 write_install "$c/home" user "rk_user_visible" "file://$c/ds_user.json"
+cache_file="$(gate_cache "$c/cache" "$c/proj/.claude/cc-statusline.sh")"
+echo "{\"model\":{\"id\":\"$STALE_MODEL\"},\"transcript_path\":\"$transcript\"}" \
+  | XDG_CACHE_HOME="$c/cache" WEAVE_STATUSLINE_UPDATE=0 WEAVE_COMMANDS_UPDATE=0 HOME="$c/home" \
+    WEAVE_ROUTER_BASE_URL= ANTHROPIC_BASE_URL= WEAVE_ROUTER_KEY= ANTHROPIC_CUSTOM_HEADERS= \
+    bash "$c/proj/.claude/cc-statusline.sh" >/dev/null 2>&1
+wait_for 5 test -f "$cache_file"
+check "project install caches from its own key, not the user-scope one" \
+  "$(cat "$cache_file" 2>/dev/null)" "1"
 out="$(echo "{\"model\":{\"id\":\"$STALE_MODEL\"},\"transcript_path\":\"$transcript\"}" \
   | XDG_CACHE_HOME="$c/cache" WEAVE_STATUSLINE_UPDATE=0 WEAVE_COMMANDS_UPDATE=0 HOME="$c/home" \
     WEAVE_ROUTER_BASE_URL= ANTHROPIC_BASE_URL= WEAVE_ROUTER_KEY= ANTHROPIC_CUSTOM_HEADERS= \
     bash "$c/proj/.claude/cc-statusline.sh" 2>&1)"
-check "project install uses its own key, not the user-scope one" "$out" ""
+check "project install hides via its own org setting" "$out" ""
 
-# Visible org (hidden=false) renders normally — the gate fails open and the
-# statusline still prints the routed model.
+# Visible org (hidden=false) caches "0" and keeps rendering normally.
 c="$work/g3"; mkdir -p "$c/proj/.claude" "$c/cache"
 printf '{"hide_terminal_surfaces": false}' > "$c/ds.json"
 write_install "$c/proj" project "rk_proj_visible" "file://$c/ds.json"
+cache_file="$(gate_cache "$c/cache" "$c/proj/.claude/cc-statusline.sh")"
+echo "{\"model\":{\"id\":\"$STALE_MODEL\"},\"transcript_path\":\"$transcript\"}" \
+  | XDG_CACHE_HOME="$c/cache" WEAVE_STATUSLINE_UPDATE=0 WEAVE_COMMANDS_UPDATE=0 HOME="$c/home" \
+    WEAVE_ROUTER_BASE_URL= ANTHROPIC_BASE_URL= WEAVE_ROUTER_KEY= ANTHROPIC_CUSTOM_HEADERS= \
+    bash "$c/proj/.claude/cc-statusline.sh" >/dev/null 2>&1
+wait_for 5 test -f "$cache_file"
+check "visible org caches the visible setting" "$(cat "$cache_file" 2>/dev/null)" "0"
 out="$(echo "{\"model\":{\"id\":\"$STALE_MODEL\"},\"transcript_path\":\"$transcript\"}" \
   | XDG_CACHE_HOME="$c/cache" WEAVE_STATUSLINE_UPDATE=0 WEAVE_COMMANDS_UPDATE=0 HOME="$c/home" \
     WEAVE_ROUTER_BASE_URL= ANTHROPIC_BASE_URL= WEAVE_ROUTER_KEY= ANTHROPIC_CUSTOM_HEADERS= \
     bash "$c/proj/.claude/cc-statusline.sh" 2>&1 | sed 's/\x1b\[[0-9;]*m//g')"
 check_contains "visible org still renders the statusline" "$out" "deepseek/deepseek-v4-pro"
 
+# A fresh hidden cache decides without any network access: the install points
+# at an unreachable endpoint, but the pre-seeded fresh cache blanks the
+# statusline on the very first run.
+c="$work/g4"; mkdir -p "$c/proj/.claude" "$c/cache"
+write_install "$c/proj" project "rk_key" "file://$c/missing.json"
+cache_file="$(gate_cache "$c/cache" "$c/proj/.claude/cc-statusline.sh")"
+mkdir -p "$(dirname "$cache_file")"
+printf '1' > "$cache_file"
+out="$(echo "{\"model\":{\"id\":\"$STALE_MODEL\"},\"transcript_path\":\"$transcript\"}" \
+  | XDG_CACHE_HOME="$c/cache" WEAVE_STATUSLINE_UPDATE=0 WEAVE_COMMANDS_UPDATE=0 HOME="$c/home" \
+    WEAVE_ROUTER_BASE_URL= ANTHROPIC_BASE_URL= WEAVE_ROUTER_KEY= ANTHROPIC_CUSTOM_HEADERS= \
+    bash "$c/proj/.claude/cc-statusline.sh" 2>&1)"
+check "fresh hidden cache blanks the statusline without touching the network" "$out" ""
+
+# A STALE hidden cache must fail open, not pin the gate closed: with the TTL
+# forced to zero the pre-seeded "1" is stale, the endpoint is unreachable, and
+# the statusline renders normally instead of staying hidden forever.
+c="$work/g5"; mkdir -p "$c/proj/.claude" "$c/cache"
+write_install "$c/proj" project "rk_key" "file://$c/missing.json"
+cache_file="$(gate_cache "$c/cache" "$c/proj/.claude/cc-statusline.sh")"
+mkdir -p "$(dirname "$cache_file")"
+printf '1' > "$cache_file"
+out="$(echo "{\"model\":{\"id\":\"$STALE_MODEL\"},\"transcript_path\":\"$transcript\"}" \
+  | XDG_CACHE_HOME="$c/cache" WEAVE_STATUSLINE_UPDATE=0 WEAVE_COMMANDS_UPDATE=0 HOME="$c/home" \
+    WEAVE_ROUTER_BASE_URL= ANTHROPIC_BASE_URL= WEAVE_ROUTER_KEY= ANTHROPIC_CUSTOM_HEADERS= \
+    WEAVE_DISPLAY_SETTINGS_TTL_SECONDS=0 \
+    bash "$c/proj/.claude/cc-statusline.sh" 2>&1 | sed 's/\x1b\[[0-9;]*m//g')"
+check_contains "stale hidden cache fails open when the router is unreachable" "$out" "deepseek/deepseek-v4-pro"
+sleep 1
+check "failed refresh leaves the stale cache untouched" "$(cat "$cache_file" 2>/dev/null)" "1"
+
+# Cache miss with an unreachable router renders normally (fail-open on first
+# run) and the failed refresh leaves no cache file behind.
+c="$work/g6"; mkdir -p "$c/proj/.claude" "$c/cache"
+write_install "$c/proj" project "rk_key" "file://$c/missing.json"
+cache_file="$(gate_cache "$c/cache" "$c/proj/.claude/cc-statusline.sh")"
+out="$(echo "{\"model\":{\"id\":\"$STALE_MODEL\"},\"transcript_path\":\"$transcript\"}" \
+  | XDG_CACHE_HOME="$c/cache" WEAVE_STATUSLINE_UPDATE=0 WEAVE_COMMANDS_UPDATE=0 HOME="$c/home" \
+    WEAVE_ROUTER_BASE_URL= ANTHROPIC_BASE_URL= WEAVE_ROUTER_KEY= ANTHROPIC_CUSTOM_HEADERS= \
+    bash "$c/proj/.claude/cc-statusline.sh" 2>&1 | sed 's/\x1b\[[0-9;]*m//g')"
+check_contains "cache miss with an unreachable router renders normally" "$out" "deepseek/deepseek-v4-pro"
+sleep 1
+check "failed refresh writes no cache file" "$(test -f "$cache_file" && echo present || echo absent)" "absent"
 # install.sh ships the statusline as a heredoc; genprices keeps only the price
 # block in sync, so a code edit to one copy silently diverges from the other.
 installer="$script_dir/../install.sh"

--- a/install/tests/cc-statusline_test.sh
+++ b/install/tests/cc-statusline_test.sh
@@ -601,6 +601,43 @@ check "concurrent refreshes never fetch at the same time" \
 check "the refresh that loses the mutex leaves the cache to the winner" \
   "$(cat "$cache_file" 2>/dev/null)" "1"
 
+# Reclaiming an ABANDONED lock (crashed holder) must stay mutually exclusive.
+# `rm -rf` + `mkdir` is not atomic: refreshers that all see the same stale lock
+# each delete the next one's freshly created directory and all proceed to
+# fetch, restoring the out-of-order race. Pre-seed an old lock, start several
+# invocations at once, and require exactly one fetch.
+c="$work/g8"; mkdir -p "$c/proj/.claude" "$c/cache" "$c/bin"
+write_install "$c/proj" project "rk_key" "file://$c/ds.json"
+printf '{"hide_terminal_surfaces": true}' > "$c/ds.json"
+cache_file="$(gate_cache "$c/cache" "$c/proj/.claude/cc-statusline.sh")"
+mkdir -p "$(dirname "$cache_file")"
+# An abandoned lock, well past the 30s reclaim threshold.
+mkdir -p "$cache_file.lock"
+touch -t 202001010000 "$cache_file.lock"
+cat > "$c/bin/curl" <<'SHIM'
+#!/usr/bin/env bash
+# Record the fetch, and dwell long enough that a second racer would overlap.
+echo x >> "$WEAVE_TEST_CALLS"
+sleep 1
+printf '{"hide_terminal_surfaces": true}'
+SHIM
+chmod +x "$c/bin/curl"
+: > "$c/calls"
+for _ in 1 2 3 4 5; do
+  echo "{\"model\":{\"id\":\"$STALE_MODEL\"},\"transcript_path\":\"$transcript\"}" \
+    | PATH="$c/bin:$PATH" XDG_CACHE_HOME="$c/cache" WEAVE_STATUSLINE_UPDATE=0 \
+      WEAVE_COMMANDS_UPDATE=0 HOME="$c/home" WEAVE_ROUTER_BASE_URL= ANTHROPIC_BASE_URL= \
+      WEAVE_ROUTER_KEY= ANTHROPIC_CUSTOM_HEADERS= WEAVE_TEST_CALLS="$c/calls" \
+      bash "$c/proj/.claude/cc-statusline.sh" >/dev/null 2>&1 &
+done
+wait
+wait_for 15 test -f "$cache_file"
+sleep 3
+check "racing reclaim of an abandoned lock still fetches exactly once" \
+  "$(wc -l < "$c/calls" | tr -d ' ')" 1
+check "a reclaimed lock is released, not leaked" \
+  "$(test -d "$cache_file.lock" && echo held || echo released)" "released"
+
 # install.sh ships the statusline as a heredoc; genprices keeps only the price
 # block in sync, so a code edit to one copy silently diverges from the other.
 installer="$script_dir/../install.sh"


### PR DESCRIPTION
## What

`weave_hidden_gate` ran a **synchronous** `curl` to `/v1/display-settings` on every statusline invocation whose cache was missing or past TTL (default 1h):

- **Blocks the statusline** up to 5s per invocation on a slow/unreachable router — including orgs that never hid surfaces (fail-open did not hold on the network path).
- **Wedges the statusline hidden forever**: when the fetch failed while a stale cache held `"1"`, the gate returned the stale value indefinitely, contradicting the documented fail-open behavior.

## Fix

The foreground path now decides **solely from the per-install cache file** and never touches the network:

- Only a cache fresh within `WEAVE_DISPLAY_SETTINGS_TTL_SECONDS` hides the surfaces; a missing or stale cache renders normally (fail-open).
- When the cache is missing or stale, a **detached background subshell** re-fetches the setting and atomically rewrites the cache for the *next* turn (write temp + `mv`). The current invocation never waits on it.
- A failed refresh simply leaves the cache stale, so the gate keeps failing open rather than pinning closed.

`install.sh`'s `STATUSLINE_EOF` heredoc is re-synced byte-identically (asserted by the test suite).

## Tests

`make test-statusline` — 41/41 pass, including new regression coverage:

- background refresh caches the hidden setting; second run renders blank
- project install caches from its own key (not the user-scope key)
- fresh hidden cache blanks the statusline with **zero** network access
- stale hidden cache + unreachable router → renders normally (fail-open), and the failed refresh leaves the stale cache untouched
- cache miss + unreachable router → renders normally, no cache file written

Also: `make test-install` (79/79), `go vet ./...`, `wv mr tc`, `wv mr t`.

🤖 Generated with [Weave Router](https://router.workweave.ai)