### PR TITLE
feat(catalog): retire claude-fable-5 from routing targets

### DIFF
--- a/internal/router/catalog/catalog.go
+++ b/internal/router/catalog/catalog.go
@@ -247,10 +247,11 @@ var Models = []Model{
 		{Provider: providers.ProviderAnthropicGateway, Price: Pricing{InputUSDPer1M: 5.00, OutputUSDPer1M: 25.00}},
 		{Provider: providers.ProviderOpenAIGateway, Price: Pricing{InputUSDPer1M: 5.00, OutputUSDPer1M: 25.00}},
 	}},
-	// Ships 1M context by default (no beta header needed), unlike Opus 4.6+.
+	// Fable 5 retired from routing; kept as priced passthrough so lingering
+	// BYOK/direct pins and the compaction summarizer bill at real cost.
 	// Safety classifiers can return stop_reason "refusal" (HTTP 200); see
 	// mapStopReason in translate.
-	{ID: "claude-fable-5", Tier: TierHigh, ContextWindow: 1_000_000, Providers: []ProviderBinding{
+	{ID: "claude-fable-5", ContextWindow: 1_000_000, Providers: []ProviderBinding{
 		{Provider: providers.ProviderAnthropic, Price: Pricing{InputUSDPer1M: 10.00, OutputUSDPer1M: 50.00, CacheReadMultiplier: 0.10}},
 	}},
 

--- a/internal/router/cluster/candidate_k12_test.go
+++ b/internal/router/cluster/candidate_k12_test.go
@@ -63,9 +63,7 @@ func TestCandidateK12Loads(t *testing.T) {
 	s, err := NewScorer(bundle, DefaultConfig(), &fakeEmbedder{dim: bundle.Centroids.Dim}, providers)
 	require.NoError(t, err, "candidate-k12 must construct a Scorer")
 
-	// glm-5.2 must be routable (resolvable provider binding). fable-5 is
-	// deliberately NOT routable: it was retired to catalog passthrough, so the
-	// candidate's former fable-5-led mix no longer routes through it.
+	// glm-5.2 routable; fable-5 retired to passthrough, deliberately excluded.
 	routable := RoutableModelSet(bundle.Registry, providers)
 	for _, m := range []string{"z-ai/glm-5.2", "claude-sonnet-5"} {
 		_, ok := routable[m]
@@ -84,10 +82,9 @@ func TestCandidateK12Loads(t *testing.T) {
 		assert.InDeltaf(t, 0.7, a, 1e-9, "cluster %d alpha must be the 0.7 sweet spot", i)
 	}
 
-	// 16 of the frozen bundle's 21: deepseek-v4-pro, claude-opus-4-8,
-	// qwen/qwen3.7-plus, gpt-5.5 and claude-fable-5 were retired to
-	// passthrough-only in the catalog, so the scorer drops them. fable-5 led
-	// four clusters in the original mix; dropping it reshapes the wins below.
+	// 16 of the frozen bundle's 21: deepseek-v4-pro, opus-4-8, qwen3.7-plus,
+	// gpt-5.5 and fable-5 retired to passthrough; fable-5 led 4 clusters so
+	// dropping it reshapes the wins below.
 	require.Len(t, s.models, 16, "retired models must be the only ones dropped under the full provider set")
 
 	wins := map[string]int{}
@@ -98,9 +95,7 @@ func TestCandidateK12Loads(t *testing.T) {
 		wins[winner]++
 	}
 
-	// With fable-5 retired from routing, the candidate's former fable-5-led
-	// clusters regress under the full-catalog blend: c1 to claude-sonnet-5,
-	// c7/c10/c11 to glm-5.2. The mix is still glm-5.2-led.
+	// fable-5 retired: c1→sonnet-5, c7/c10/c11→glm-5.2; mix still glm-5.2-led.
 	assert.Equal(t, 11, wins["z-ai/glm-5.2"], "glm-5.2 must lead 11 clusters at alpha=0.7 after fable-5 retirement")
 	assert.Equal(t, 1, wins["claude-sonnet-5"], "claude-sonnet-5 must lead 1 cluster at alpha=0.7 after fable-5 retirement")
 	// No retired-to-passthrough model should win a cluster.

--- a/internal/router/cluster/candidate_k12_test.go
+++ b/internal/router/cluster/candidate_k12_test.go
@@ -40,8 +40,9 @@ func TestCandidateK12Loads(t *testing.T) {
 		}
 	}
 
-	// The three headline models for this candidate must be in the roster + axes.
-	for _, m := range []string{"claude-fable-5", "z-ai/glm-5.2", "claude-sonnet-5"} {
+	// The roster + axes for this candidate must include the incumbent arm
+	// (glm-5.2) and the catalog still tracks fable-5 as a passthrough entry.
+	for _, m := range []string{"claude-fable-5", "z-ai/glm-5.2"} {
 		assert.Contains(t, models, m, "%s must be a deployed model", m)
 		_, ok := bundle.ModelAxes[m]
 		assert.Truef(t, ok, "%s must have operational axes", m)
@@ -62,12 +63,16 @@ func TestCandidateK12Loads(t *testing.T) {
 	s, err := NewScorer(bundle, DefaultConfig(), &fakeEmbedder{dim: bundle.Centroids.Dim}, providers)
 	require.NoError(t, err, "candidate-k12 must construct a Scorer")
 
-	// fable-5, glm-5.2, sonnet-5 must be routable (resolvable provider binding).
+	// glm-5.2 must be routable (resolvable provider binding). fable-5 is
+	// deliberately NOT routable: it was retired to catalog passthrough, so the
+	// candidate's former fable-5-led mix no longer routes through it.
 	routable := RoutableModelSet(bundle.Registry, providers)
-	for _, m := range []string{"claude-fable-5", "z-ai/glm-5.2", "claude-sonnet-5"} {
+	for _, m := range []string{"z-ai/glm-5.2", "claude-sonnet-5"} {
 		_, ok := routable[m]
 		assert.Truef(t, ok, "%s must be routable", m)
 	}
+	_, fableRoutable := routable["claude-fable-5"]
+	assert.Falsef(t, fableRoutable, "fable-5 retired from routing; must not be a cluster target")
 
 	// Per-cluster argmax through the live v2 blend (the authoritative runtime
 	// path: blendScoresV2 over a single cluster with the bundle's default knobs =
@@ -79,11 +84,11 @@ func TestCandidateK12Loads(t *testing.T) {
 		assert.InDeltaf(t, 0.7, a, 1e-9, "cluster %d alpha must be the 0.7 sweet spot", i)
 	}
 
-	// 17 of the frozen bundle's 21: deepseek-v4-pro, claude-opus-4-8,
-	// qwen/qwen3.7-plus and gpt-5.5 were retired to passthrough-only in the
-	// catalog after this bundle was trained, so the scorer drops them. None
-	// leads a cluster, so the win mix below is unaffected.
-	require.Len(t, s.models, 17, "retired models must be the only ones dropped under the full provider set")
+	// 16 of the frozen bundle's 21: deepseek-v4-pro, claude-opus-4-8,
+	// qwen/qwen3.7-plus, gpt-5.5 and claude-fable-5 were retired to
+	// passthrough-only in the catalog, so the scorer drops them. fable-5 led
+	// four clusters in the original mix; dropping it reshapes the wins below.
+	require.Len(t, s.models, 16, "retired models must be the only ones dropped under the full provider set")
 
 	wins := map[string]int{}
 	for c := 0; c < bundle.Centroids.K; c++ {
@@ -93,9 +98,13 @@ func TestCandidateK12Loads(t *testing.T) {
 		wins[winner]++
 	}
 
-	// The bake-off candidate is intentionally a glm-5.2 + fable-5 coding mix.
-	assert.Equal(t, 8, wins["z-ai/glm-5.2"], "glm-5.2 must lead 8 clusters at alpha=0.7")
-	assert.Equal(t, 4, wins["claude-fable-5"], "fable-5 must lead 4 clusters at alpha=0.7")
+	// With fable-5 retired from routing, the candidate's former fable-5-led
+	// clusters regress under the full-catalog blend: c1 to claude-sonnet-5,
+	// c7/c10/c11 to glm-5.2. The mix is still glm-5.2-led.
+	assert.Equal(t, 11, wins["z-ai/glm-5.2"], "glm-5.2 must lead 11 clusters at alpha=0.7 after fable-5 retirement")
+	assert.Equal(t, 1, wins["claude-sonnet-5"], "claude-sonnet-5 must lead 1 cluster at alpha=0.7 after fable-5 retirement")
+	// No retired-to-passthrough model should win a cluster.
+	assert.Zero(t, wins["claude-fable-5"], "fable-5 is retired; no cluster should route to it")
 	// No opus/haiku/legacy-sonnet cluster wins — the whole point of the candidate.
 	assert.Zero(t, wins["claude-opus-4-8"], "no cluster should route to opus-4-8 at the screen alpha")
 	assert.Zero(t, wins["claude-haiku-4-5"], "no cluster should route to haiku at the screen alpha")

--- a/internal/router/hmm/hmm_test.go
+++ b/internal/router/hmm/hmm_test.go
@@ -206,7 +206,6 @@ func TestCatalogRoutingTargetsResolveCurrentHMMRosterArmsToProviders(t *testing.
 		"openai/gpt-5.6-terra",
 		"z-ai/glm-5.2",
 		"google/gemini-3.1-pro-preview",
-		"anthropic/claude-fable-5",
 	} {
 		assert.Contains(t, gotRosterIDs, rosterID)
 	}


### PR DESCRIPTION
## What & why

Fable 5 is no longer an intended production routing target — the HMM roster (`roster_v5_5c.json`) dropped it — but it never left the Go catalog's `TierHigh` routing set. As a result it stays in the candidate universe the HMM policy returns and in the sibling-failover pool. Whenever a routed Fireworks arm goes down (the kimi-k3 / qwen3.8-max outage pattern), fable-5 becomes the default rescue model, and a handful of overloaded sessions pin to it for hours — even though no policy decision ever chooses it. Prod logs across a 6–8h window showed 45+ `sibling_failover` completions to fable-5, concentrated in a few sessions.

## Change

Drop `Tier` from the `claude-fable-5` catalog entry (mirrors the [opus-4-8 retirement](https://github.com/workweave/router/commit/3d44c0e), keeping it as **priced passthrough**):

- `RoutingTargetSet` (lookup.go:167) skips `TierUnknown` rows → fable-5 vanishes from HMM candidates → vanishes from the sibling-failover rescue pool.
- The cluster scorer (`resolveProviderWithCustom`, scorer.go:369) also drops untiered rows → fable-5 no longer routes under the legacy `cluster` strategy either.
- The row stays priced ($10/$50, Anthropic) so lingering BYOK/direct pins and the **compaction summarizer** still bill at real cost.

## Test updates

- `internal/router/hmm/hmm_test.go`: removed `anthropic/claude-fable-5` from the expected HMM routing candidates.
- `internal/router/cluster/candidate_k12_test.go`: the load-gate no longer asserts fable-5 is routable. That bake-off bundle's former fable-5-led mix now regresses — probed actual winners: **glm-5.2×11, claude-sonnet-5×1** (c1 → sonnet, c7/c10/c11 → glm-5.2); retired-model count 17→16. The comment documents this honestly rather than pretending the old mix still holds.

## Not in this PR (follow-ups)

- **`candidate-k12` bundle**: it's a staging bake-off artifact explicitly built on a fable-5-led mix. This change de-facto retires that candidate. The test is updated to load-gate reality; whether to formally retire/drop the bundle is a scientist's call (registry decision), left out to avoid silently discarding a registered experiment.
- **Cluster artifact `v0.75` (= `artifacts/latest`)**: still lists `claude-fable-5` in `model_registry.json`. It only serves installs explicitly pinned to the legacy `cluster` strategy (prod/staging run HMM), and the scorer already drops untiered fable-5 at resolve time, so it's harmless today — but the model row should eventually be dropped from `v0.75` for full cleanliness.
- **Turnloop anchoring**: sibling-failover rescue models persist as the effective session stick across turns without a `writeNewPin`. Worth its own investigation.

## Validation

- `go build ./...`, `go vet ./internal/router/{catalog,hmm,cluster}/`, and the full `go test ./internal/... ./cmd/...` all pass.
- Probed the candidate-k12 per-cluster winners under the new catalog to make the test assertions truthful.

🤖 Generated with [Weave Router](https://router.workweave.ai)