### PR TITLE
fix(translate): hoist tool_result images into the OpenAI user message

### DIFF
--- a/internal/translate/crossformat_request_test.go
+++ b/internal/translate/crossformat_request_test.go
@@ -921,10 +921,8 @@ func TestCrossFormat_AnthropicToOpenAI_Image(t *testing.T) {
 	assert.Contains(t, url, "iVBORw0KGgo=")
 }
 
-// Agent harnesses return screenshots nested inside tool_result blocks rather
-// than at the top level of the user message. OpenAI role:tool content is
-// text-only, so the image must be hoisted into the trailing user message —
-// dropping it leaves the upstream model staring at an empty tool result.
+// Agent harnesses return screenshots in tool_result blocks; OpenAI role:tool
+// content is text-only, so images must be hoisted into the trailing user message.
 func TestCrossFormat_AnthropicToOpenAI_ToolResultImageHoisted(t *testing.T) {
 	body := []byte(`{
 		"model": "claude-opus-4-8",

--- a/internal/translate/crossformat_request_test.go
+++ b/internal/translate/crossformat_request_test.go
@@ -921,6 +921,100 @@ func TestCrossFormat_AnthropicToOpenAI_Image(t *testing.T) {
 	assert.Contains(t, url, "iVBORw0KGgo=")
 }
 
+// Agent harnesses return screenshots nested inside tool_result blocks rather
+// than at the top level of the user message. OpenAI role:tool content is
+// text-only, so the image must be hoisted into the trailing user message —
+// dropping it leaves the upstream model staring at an empty tool result.
+func TestCrossFormat_AnthropicToOpenAI_ToolResultImageHoisted(t *testing.T) {
+	body := []byte(`{
+		"model": "claude-opus-4-8",
+		"messages": [
+			{"role": "user", "content": [{"type": "text", "text": "Read the screenshot"}]},
+			{"role": "assistant", "content": [
+				{"type": "tool_use", "id": "toolu_1", "name": "Read", "input": {"file_path": "/tmp/shot.png"}}
+			]},
+			{"role": "user", "content": [
+				{"type": "tool_result", "tool_use_id": "toolu_1", "content": [
+					{"type": "image", "source": {"type": "base64", "media_type": "image/png", "data": "iVBORw0KGgo="}}
+				]}
+			]}
+		],
+		"max_tokens": 512
+	}`)
+
+	env, err := translate.ParseAnthropic(body)
+	require.NoError(t, err)
+	prep, err := env.PrepareOpenAI(http.Header{}, translate.EmitOptions{
+		TargetModel:    "gpt-4",
+		TargetProvider: "openai",
+	})
+	require.NoError(t, err)
+
+	doc := unmarshalBody(t, prep.Body)
+	msgs := getArray(t, doc, "messages")
+	require.Len(t, msgs, 4)
+
+	toolMsg := msgAt(t, msgs, 2)
+	assert.Equal(t, "tool", toolMsg["role"])
+	assert.Equal(t, "toolu_1", toolMsg["tool_call_id"])
+	assert.Equal(t, "", toolMsg["content"], "text-only tool content stays empty")
+
+	userMsg := msgAt(t, msgs, 3)
+	assert.Equal(t, "user", userMsg["role"], "hoisted image rides a trailing user message")
+	content := userMsg["content"].([]any)
+	require.Len(t, content, 1)
+	imgPart := content[0].(map[string]any)
+	assert.Equal(t, "image_url", imgPart["type"])
+	imageURL := getMap(t, imgPart, "image_url")
+	url, ok := imageURL["url"].(string)
+	require.True(t, ok)
+	assert.Equal(t, "data:image/png;base64,iVBORw0KGgo=", url)
+}
+
+// A tool_result carrying both text and an image keeps its text on the tool
+// message; only the image is hoisted.
+func TestCrossFormat_AnthropicToOpenAI_ToolResultTextAndImageSplit(t *testing.T) {
+	body := []byte(`{
+		"model": "claude-opus-4-8",
+		"messages": [
+			{"role": "user", "content": [{"type": "text", "text": "Read the screenshot"}]},
+			{"role": "assistant", "content": [
+				{"type": "tool_use", "id": "toolu_1", "name": "Read", "input": {"file_path": "/tmp/shot.png"}}
+			]},
+			{"role": "user", "content": [
+				{"type": "tool_result", "tool_use_id": "toolu_1", "content": [
+					{"type": "text", "text": "PNG image data, 2986 x 546"},
+					{"type": "image", "source": {"type": "base64", "media_type": "image/png", "data": "iVBORw0KGgo="}}
+				]}
+			]}
+		],
+		"max_tokens": 512
+	}`)
+
+	env, err := translate.ParseAnthropic(body)
+	require.NoError(t, err)
+	prep, err := env.PrepareOpenAI(http.Header{}, translate.EmitOptions{
+		TargetModel:    "gpt-4",
+		TargetProvider: "openai",
+	})
+	require.NoError(t, err)
+
+	doc := unmarshalBody(t, prep.Body)
+	msgs := getArray(t, doc, "messages")
+	require.Len(t, msgs, 4)
+
+	toolMsg := msgAt(t, msgs, 2)
+	assert.Equal(t, "tool", toolMsg["role"])
+	assert.Equal(t, "PNG image data, 2986 x 546", toolMsg["content"], "text stays on the tool message")
+
+	userMsg := msgAt(t, msgs, 3)
+	assert.Equal(t, "user", userMsg["role"])
+	content := userMsg["content"].([]any)
+	require.Len(t, content, 1)
+	imgPart := content[0].(map[string]any)
+	assert.Equal(t, "image_url", imgPart["type"], "only the image is hoisted")
+}
+
 func TestCrossFormat_AnthropicToOpenAI_ArraySystemFlattened(t *testing.T) {
 	env, err := translate.ParseAnthropic(anthropicArraySystemConversation)
 	require.NoError(t, err)

--- a/internal/translate/emit_openai.go
+++ b/internal/translate/emit_openai.go
@@ -564,7 +564,10 @@ func buildOpenAIToolCall(block gjson.Result) string {
 
 // writeOpenAIUserFromAnthropic emits zero or more OpenAI messages for an
 // Anthropic user message. Mixed content (tool_result + text + image) is split
-// into separate tool-role messages followed by a single user message.
+// into separate tool-role messages followed by a single user message. Images
+// nested inside tool_result blocks (e.g. a screenshot returned by a Read tool
+// call) cannot ride a role:tool message — OpenAI tool content is text-only —
+// so they are hoisted into that trailing user message instead of being dropped.
 func writeOpenAIUserFromAnthropic(jw *jsonWriter, msg gjson.Result) {
 	content := msg.Get("content")
 	switch content.Type {
@@ -592,6 +595,16 @@ func writeOpenAIUserFromAnthropic(jw *jsonWriter, msg gjson.Result) {
 		switch block.Get("type").String() {
 		case "tool_result":
 			toolResultRaws = append(toolResultRaws, buildOpenAIToolResultMessage(block))
+			// Hoist nested images into the trailing user message; role:tool
+			// content is text-only, so leaving them here would drop them.
+			block.Get("content").ForEach(func(_, inner gjson.Result) bool {
+				if inner.Get("type").String() == "image" {
+					if part := buildOpenAIImagePart(inner); part != "" {
+						userPartRaws = append(userPartRaws, part)
+					}
+				}
+				return true
+			})
 		case "text":
 			inner := newJSONWriter()
 			inner.Obj()

--- a/internal/translate/emit_openai.go
+++ b/internal/translate/emit_openai.go
@@ -565,9 +565,8 @@ func buildOpenAIToolCall(block gjson.Result) string {
 // writeOpenAIUserFromAnthropic emits zero or more OpenAI messages for an
 // Anthropic user message. Mixed content (tool_result + text + image) is split
 // into separate tool-role messages followed by a single user message. Images
-// nested inside tool_result blocks (e.g. a screenshot returned by a Read tool
-// call) cannot ride a role:tool message — OpenAI tool content is text-only —
-// so they are hoisted into that trailing user message instead of being dropped.
+// nested inside tool_result blocks are hoisted into that user message because
+// OpenAI role:tool content is text-only.
 func writeOpenAIUserFromAnthropic(jw *jsonWriter, msg gjson.Result) {
 	content := msg.Get("content")
 	switch content.Type {


### PR DESCRIPTION
Images nested inside an Anthropic tool_result block (e.g. a screenshot
returned by a Read tool call) were silently dropped on the OpenAI-compat
emit path: role:tool content is text-only, so buildOpenAIToolResultMessage
flattened them to an empty string and the upstream model never saw the
image — sessions then burned turns on OCR workarounds for content they
already had.

writeOpenAIUserFromAnthropic already splits mixed tool_result + text +
image content into tool messages followed by a user message; it now also
hoists nested tool_result images into that trailing user message as
image_url parts (the same shape top-level user images already use).

Detection was never broken: anthropicImageBytes counts tool_result-nested
images for HasImages/token math, so capability gates still routed
image-bearing turns to multimodal models — only the emit side lost them.