### PR TITLE
feat(ui): first-run onboarding flow + install command on key reveal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,6 +62,7 @@ docker-compose.smoke-run.override.yml
 # Node (eval/scripts tooling, dashboard frontend)
 node_modules/
 .next/
+frontend/out/
 tsconfig.tsbuildinfo
 
 # Eval results (stored in GCS, not git)

--- a/db/migrations/0060_installation-first-request-served.down.sql
+++ b/db/migrations/0060_installation-first-request-served.down.sql
@@ -1,0 +1,6 @@
+BEGIN;
+
+ALTER TABLE router.model_router_installations
+  DROP COLUMN first_request_served_at;
+
+COMMIT;

--- a/db/migrations/0060_installation-first-request-served.up.sql
+++ b/db/migrations/0060_installation-first-request-served.up.sql
@@ -1,0 +1,13 @@
+BEGIN;
+
+-- First time this installation routed a request through the router. Set once
+-- (WHERE IS NULL) from the key-usage path and never cleared, so it survives
+-- key rotation: onboarding is gated on "this install has served traffic", and
+-- deriving that from a key's last_used_at would reset the moment the only
+-- active key was rotated away.
+ALTER TABLE router.model_router_installations
+  ADD COLUMN first_request_served_at TIMESTAMPTZ;
+
+COMMENT ON COLUMN router.model_router_installations.first_request_served_at IS 'Timestamp of the installation''s first routed request. Monotonic — never moves backwards or clears on key rotation.';
+
+COMMIT;

--- a/db/migrations/0060_installation-first-request-served.up.sql
+++ b/db/migrations/0060_installation-first-request-served.up.sql
@@ -8,6 +8,23 @@ BEGIN;
 ALTER TABLE router.model_router_installations
   ADD COLUMN first_request_served_at TIMESTAMPTZ;
 
+-- Backfill from the keys that already served traffic, soft-deleted ones
+-- included: a rotated-away key still proves the install has routed. Without
+-- this every existing deployment reads as never-served on upgrade and lands
+-- back in first-run onboarding. MIN() because the column records the FIRST
+-- request, and last_used_at on the oldest-used key is the closest bound we
+-- have — the exact first-request time was never stored.
+UPDATE router.model_router_installations i
+SET first_request_served_at = k.first_used_at
+FROM (
+    SELECT installation_id, MIN(last_used_at) AS first_used_at
+    FROM router.model_router_api_keys
+    WHERE last_used_at IS NOT NULL
+      AND scope = 'routing'
+    GROUP BY installation_id
+) k
+WHERE i.id = k.installation_id;
+
 COMMENT ON COLUMN router.model_router_installations.first_request_served_at IS 'Timestamp of the installation''s first routed request. Monotonic — never moves backwards or clears on key rotation.';
 
 COMMIT;

--- a/db/queries/model_router_installations.sql
+++ b/db/queries/model_router_installations.sql
@@ -126,3 +126,13 @@ SET hide_terminal_surfaces = @hide_terminal_surfaces::boolean,
 WHERE id = @id::uuid
   AND external_id = @external_id::varchar
   AND deleted_at IS NULL;
+
+-- Stamps first_request_served_at the first time this installation routes a
+-- request. WHERE IS NULL makes the update a no-op after the first write, so
+-- the timestamp records the *first* request and rotation never resets it.
+-- name: MarkModelRouterInstallationFirstRequestServed :exec
+UPDATE router.model_router_installations
+SET first_request_served_at = NOW()
+WHERE id = @id::uuid
+  AND deleted_at IS NULL
+  AND first_request_served_at IS NULL;

--- a/frontend/src/app/(app)/dashboard/page.tsx
+++ b/frontend/src/app/(app)/dashboard/page.tsx
@@ -39,8 +39,33 @@ function formatNumber(v: number): string {
   return String(v);
 }
 
-// "checking" suppresses a flash of either surface until the keys probe lands.
+// "checking" suppresses a flash of either surface until the onboarding probe
+// lands.
 type OnboardingState = "checking" | "needed" | "done";
+
+// Set when the user chooses "Skip to dashboard". Persisted rather than held in
+// memory so a refresh doesn't drop them back into a flow they opted out of;
+// the server-side flag still takes over for good once a request is served.
+const SKIP_ONBOARDING_KEY = "weave-router.onboarding-skipped";
+
+function onboardingSkipped(): boolean {
+  if (typeof window === "undefined") return false;
+  try {
+    return window.localStorage.getItem(SKIP_ONBOARDING_KEY) === "true";
+  } catch {
+    // Private-mode/blocked storage: treat as not skipped rather than throwing
+    // on the render path.
+    return false;
+  }
+}
+
+function rememberOnboardingSkipped() {
+  try {
+    window.localStorage.setItem(SKIP_ONBOARDING_KEY, "true");
+  } catch {
+    // Non-fatal: the skip just won't survive this reload.
+  }
+}
 
 export default function DashboardPage() {
   const dashboardFilters = useDashboardFilters("30d");
@@ -53,17 +78,18 @@ export default function DashboardPage() {
   const [onboarding, setOnboarding] = useState<OnboardingState>("checking");
 
   // A router that has never served a request has nothing to chart, so a fresh
-  // install lands in onboarding instead of on six empty charts. "Served at
-  // least once" is the gate rather than "has a key": a key alone doesn't mean
-  // any harness was ever pointed here.
+  // install lands in onboarding instead of on six empty charts. The gate is the
+  // installation-level first_request_served_at, not a key's last_used_at:
+  // that flag survives rotation, so rotating the key that served the first
+  // request can't send an established install back through onboarding.
   useEffect(() => {
     let cancelled = false;
-    api.keys
-      .list()
+    api.onboarding
+      .get()
       .then(res => {
         if (cancelled) return;
-        const used = (res.keys ?? []).some(k => k.scope === "routing" && k.last_used_at != null);
-        setOnboarding(used ? "done" : "needed");
+        const served = res.first_request_served_at != null;
+        setOnboarding(served || onboardingSkipped() ? "done" : "needed");
       })
       // Non-fatal: on a failed probe show the dashboard rather than trapping
       // an established install in onboarding.
@@ -101,7 +127,15 @@ export default function DashboardPage() {
 
   if (onboarding === "checking") return null;
   if (onboarding === "needed") {
-    return <RouterOnboarding onComplete={() => setOnboarding("done")} />;
+    return (
+      <RouterOnboarding
+        onComplete={() => setOnboarding("done")}
+        onSkip={() => {
+          rememberOnboardingSkipped();
+          setOnboarding("done");
+        }}
+      />
+    );
   }
 
   if (error) {

--- a/frontend/src/app/(app)/dashboard/page.tsx
+++ b/frontend/src/app/(app)/dashboard/page.tsx
@@ -15,6 +15,7 @@ import { Card } from "@/components/molecules/Card";
 import { Page } from "@/components/Page";
 import { PageHeader } from "@/components/PageHeader";
 import { ResponsiveGrid } from "@/components/ResponsiveGrid";
+import { RouterOnboarding } from "@/components/RouterOnboarding";
 import { Statistic } from "@/components/Statistic";
 import {
   api,
@@ -38,6 +39,9 @@ function formatNumber(v: number): string {
   return String(v);
 }
 
+// "checking" suppresses a flash of either surface until the keys probe lands.
+type OnboardingState = "checking" | "needed" | "done";
+
 export default function DashboardPage() {
   const dashboardFilters = useDashboardFilters("30d");
   const { fromISO, toISO, granularity, range } = dashboardFilters.filters;
@@ -46,8 +50,33 @@ export default function DashboardPage() {
   const [buckets, setBuckets] = useState<TimeseriesBucket[]>([]);
   const [modelBuckets, setModelBuckets] = useState<ModelBreakdownBucket[]>([]);
   const [error, setError] = useState<string | null>(null);
+  const [onboarding, setOnboarding] = useState<OnboardingState>("checking");
+
+  // A router that has never served a request has nothing to chart, so a fresh
+  // install lands in onboarding instead of on six empty charts. "Served at
+  // least once" is the gate rather than "has a key": a key alone doesn't mean
+  // any harness was ever pointed here.
+  useEffect(() => {
+    let cancelled = false;
+    api.keys
+      .list()
+      .then(res => {
+        if (cancelled) return;
+        const used = (res.keys ?? []).some(k => k.scope === "routing" && k.last_used_at != null);
+        setOnboarding(used ? "done" : "needed");
+      })
+      // Non-fatal: on a failed probe show the dashboard rather than trapping
+      // an established install in onboarding.
+      .catch(() => {
+        if (!cancelled) setOnboarding("done");
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   useEffect(() => {
+    if (onboarding !== "done") return;
     let cancelled = false;
     setError(null);
     Promise.all([
@@ -68,7 +97,12 @@ export default function DashboardPage() {
     return () => {
       cancelled = true;
     };
-  }, [fromISO, toISO, granularity]);
+  }, [fromISO, toISO, granularity, onboarding]);
+
+  if (onboarding === "checking") return null;
+  if (onboarding === "needed") {
+    return <RouterOnboarding onComplete={() => setOnboarding("done")} />;
+  }
 
   if (error) {
     return (

--- a/frontend/src/components/CopyBlock.tsx
+++ b/frontend/src/components/CopyBlock.tsx
@@ -17,12 +17,18 @@ interface CopyBlockProps {
  * line if the user prefers to copy by hand.
  */
 export function CopyBlock({ value, title }: CopyBlockProps) {
-  const [copied, setCopied] = useState(false);
+  // Keyed by the value that was copied rather than a bare boolean: switching
+  // harness or scope swaps `value` under us, and a stale "Copied" would claim
+  // the clipboard holds a command it doesn't.
+  const [copiedValue, setCopiedValue] = useState<string | null>(null);
+  const copied = copiedValue === value;
 
   function handleCopy() {
     navigator.clipboard.writeText(value).then(() => {
-      setCopied(true);
-      setTimeout(() => setCopied(false), 2000);
+      setCopiedValue(value);
+      setTimeout(() => {
+        setCopiedValue(current => (current === value ? null : current));
+      }, 2000);
     });
   }
 

--- a/frontend/src/components/CopyBlock.tsx
+++ b/frontend/src/components/CopyBlock.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import { Button } from "@/components/molecules/Button";
+import { Appearance } from "@/components/types";
+import { Check, Copy } from "lucide-react";
+import { useState } from "react";
+
+interface CopyBlockProps {
+  value: string;
+  /** Accessible label for the copy button. Defaults to "Copy". */
+  title?: string;
+}
+
+/**
+ * A monospace block with a copy button. Long install commands scroll
+ * horizontally rather than wrapping, so the command stays selectable as one
+ * line if the user prefers to copy by hand.
+ */
+export function CopyBlock({ value, title }: CopyBlockProps) {
+  const [copied, setCopied] = useState(false);
+
+  function handleCopy() {
+    navigator.clipboard.writeText(value).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    });
+  }
+
+  return (
+    <div className="relative">
+      <pre className="w-full overflow-x-auto rounded-lg bg-muted p-3 pr-24 font-mono text-2xs text-foreground">
+        <code>{value}</code>
+      </pre>
+      <Button
+        appearance={Appearance.Outlined}
+        size="sm"
+        onClick={handleCopy}
+        title={title ?? "Copy"}
+        aria-label={copied ? "Copied" : (title ?? "Copy")}
+        className="absolute right-2 top-2 bg-background"
+      >
+        {copied ? <Check className="size-3.5" /> : <Copy className="size-3.5" />}
+        {copied ? "Copied" : "Copy"}
+      </Button>
+    </div>
+  );
+}

--- a/frontend/src/components/InstallCommandPicker.tsx
+++ b/frontend/src/components/InstallCommandPicker.tsx
@@ -1,0 +1,99 @@
+"use client";
+
+import { CopyBlock } from "@/components/CopyBlock";
+import { Text } from "@/components/atoms/Text";
+import { Button } from "@/components/molecules/Button";
+import { Appearance } from "@/components/types";
+import {
+  HARNESSES,
+  type HarnessID,
+  type InstallScope,
+  harness,
+  installCommand,
+  routerOrigin,
+} from "@/lib/installCommands";
+import { GitBranch, User } from "lucide-react";
+import { useState } from "react";
+
+const SCOPES: { value: InstallScope; label: string; icon: typeof User }[] = [
+  { value: "user", label: "Personal", icon: User },
+  { value: "project", label: "This project", icon: GitBranch },
+];
+
+interface InstallCommandPickerProps {
+  /** Raw bearer token to inline into the command. */
+  token: string;
+}
+
+/**
+ * Harness tabs on top, then the one command to run. The harness choice comes
+ * first because it's the only decision the user actually has to make — a
+ * freshly minted token is useless until it's paired with the right installer
+ * invocation, and burying that behind an endpoint block and an uninstall
+ * section is what made the old reveal unreadable.
+ */
+export function InstallCommandPicker({ token }: InstallCommandPickerProps) {
+  const [harnessID, setHarnessID] = useState<HarnessID>("claude");
+  const [scope, setScope] = useState<InstallScope>("user");
+  const origin = routerOrigin();
+  const selected = harness(harnessID);
+
+  return (
+    <div className="flex flex-col gap-3">
+      <div role="tablist" aria-label="Harness" className="flex flex-wrap gap-2">
+        {HARNESSES.map(h => (
+          <Button
+            key={h.id}
+            type="button"
+            role="tab"
+            aria-selected={harnessID === h.id}
+            size="sm"
+            appearance={harnessID === h.id ? Appearance.Filled : Appearance.Outlined}
+            className={
+              harnessID === h.id
+                ? "!border-brand !bg-brand !text-white hover:!bg-brand/90"
+                : undefined
+            }
+            onClick={() => setHarnessID(h.id)}
+          >
+            {h.label}
+          </Button>
+        ))}
+      </div>
+
+      <div role="radiogroup" aria-label="Install scope" className="flex flex-wrap gap-2">
+        {SCOPES.map(s => {
+          const Icon = s.icon;
+          return (
+            <Button
+              key={s.value}
+              type="button"
+              role="radio"
+              aria-checked={scope === s.value}
+              size="sm"
+              appearance={Appearance.Outlined}
+              className={scope === s.value ? "!border-foreground/40" : "text-muted-foreground"}
+              onClick={() => setScope(s.value)}
+            >
+              <Icon className="size-3.5" />
+              {s.label}
+            </Button>
+          );
+        })}
+      </div>
+
+      <Text className="text-2xs text-muted-foreground">
+        {scope === "project" ? selected.projectDetail : selected.detail}
+      </Text>
+
+      {origin === "" ? (
+        <Text className="text-2xs text-muted-foreground">Preparing install command…</Text>
+      ) : (
+        <CopyBlock
+          value={installCommand(harnessID, scope, token, origin)}
+          title="Copy install command"
+        />
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/RouterOnboarding.tsx
+++ b/frontend/src/components/RouterOnboarding.tsx
@@ -325,8 +325,9 @@ function InstallStep({
           Run the install command
         </Text>
         <Text className="text-xs text-muted-foreground">
-          Paste this into your terminal. It points {selected.label} at this router with your key
-          already inlined.
+          {token != null
+            ? `Paste this into your terminal. It points ${selected.label} at this router with your key already inlined.`
+            : `Paste this into your terminal after swapping in your key. It points ${selected.label} at this router.`}
         </Text>
       </div>
 

--- a/frontend/src/components/RouterOnboarding.tsx
+++ b/frontend/src/components/RouterOnboarding.tsx
@@ -1,0 +1,365 @@
+"use client";
+
+import { CopyBlock } from "@/components/CopyBlock";
+import { Text } from "@/components/atoms/Text";
+import { Button } from "@/components/molecules/Button";
+import { Appearance } from "@/components/types";
+import { api, type APIKey, type IssueAPIKeyResponse } from "@/lib/api";
+import {
+  HARNESSES,
+  type HarnessID,
+  type InstallScope,
+  harness,
+  installCommand,
+  routerOrigin,
+} from "@/lib/installCommands";
+import { cn } from "@/lib/cn";
+import { ArrowRight, ChevronRight, GitBranch, Loader2, User, Zap } from "lucide-react";
+import { useEffect, useState } from "react";
+
+const POLL_INTERVAL_MS = 3000;
+
+type StepID = "setup" | "harness" | "scope" | "install";
+
+const STEPS: StepID[] = ["setup", "harness", "scope", "install"];
+
+interface RouterOnboardingProps {
+  /** Called once the router has served its first request through any key. */
+  onComplete: () => void;
+}
+
+/**
+ * First-run onboarding for a self-hosted router: one decision per screen —
+ * issue a key → pick a harness → personal vs team → copy the command — then
+ * idle until the router serves its first request and hand off to the
+ * dashboard.
+ *
+ * Deliberately mirrors the hosted flow at router.workweave.ai so the two
+ * surfaces teach the same mental model, but the base URL comes from this
+ * deployment's own origin rather than the hosted endpoint.
+ */
+export function RouterOnboarding({ onComplete }: RouterOnboardingProps) {
+  const [step, setStep] = useState<StepID>("setup");
+  const [harnessID, setHarnessID] = useState<HarnessID | null>(null);
+  const [scope, setScope] = useState<InstallScope>("user");
+  const [issued, setIssued] = useState<IssueAPIKeyResponse | null>(null);
+  const [creating, setCreating] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleGetStarted() {
+    setCreating(true);
+    setError(null);
+    try {
+      const res = await api.keys.issue("Onboarding key");
+      setIssued(res);
+      setStep("harness");
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err.message : "Failed to create key.");
+    } finally {
+      setCreating(false);
+    }
+  }
+
+  const currentIndex = Math.max(0, STEPS.indexOf(step));
+
+  return (
+    <div className="flex min-h-full w-full flex-col items-center justify-center p-8">
+      {error != null && (
+        <div className="mb-4 rounded-md border border-danger/30 bg-danger/5 p-3 text-xs text-danger">
+          {error}
+        </div>
+      )}
+
+      {step === "setup" && (
+        <SetupStep creating={creating} onGetStarted={() => void handleGetStarted()} />
+      )}
+      {step === "harness" && (
+        <HarnessStep
+          onSelect={id => {
+            setHarnessID(id);
+            setStep("scope");
+          }}
+        />
+      )}
+      {step === "scope" && harnessID != null && (
+        <ScopeStep
+          harnessID={harnessID}
+          onBack={() => setStep("harness")}
+          onSelect={s => {
+            setScope(s);
+            setStep("install");
+          }}
+        />
+      )}
+      {step === "install" && harnessID != null && issued != null && (
+        <InstallStep
+          harnessID={harnessID}
+          scope={scope}
+          token={issued.token}
+          onBack={() => setStep("scope")}
+          onComplete={onComplete}
+        />
+      )}
+
+      {step !== "setup" && <StepDots currentIndex={currentIndex} />}
+    </div>
+  );
+}
+
+function StepDots({ currentIndex }: { currentIndex: number }) {
+  return (
+    <div className="mt-10 flex items-center gap-3">
+      {STEPS.map((id, index) => (
+        <div
+          key={id}
+          aria-label={id}
+          title={id}
+          className={cn(
+            "rounded-full transition-all duration-300",
+            index === currentIndex
+              ? "h-3 w-8 bg-brand"
+              : index < currentIndex
+                ? "size-2.5 bg-muted-foreground/50"
+                : "size-2.5 bg-muted-foreground/20",
+          )}
+        />
+      ))}
+    </div>
+  );
+}
+
+function SetupStep({
+  creating,
+  onGetStarted,
+}: {
+  creating: boolean;
+  onGetStarted: () => void;
+}) {
+  return (
+    <div className="flex w-full max-w-sm flex-col items-center gap-6 rounded-2xl bg-background p-10 shadow-lg ring-1 ring-border">
+      <div className="flex size-14 items-center justify-center rounded-2xl bg-brand/10">
+        <Zap className="size-7 text-brand" />
+      </div>
+      <div className="flex flex-col items-center gap-2 text-center">
+        <Text variant="h3" className="text-lg font-semibold">
+          Set up your router key
+        </Text>
+        <Text className="text-xs text-muted-foreground">
+          Issue a bearer token to start routing your AI requests through this router.
+        </Text>
+      </div>
+      <Button
+        appearance={Appearance.Filled}
+        onClick={onGetStarted}
+        disabled={creating}
+        className="w-full justify-center !border-brand !bg-brand !text-white hover:!bg-brand/90"
+      >
+        {creating ? "Creating key…" : "Get started"}
+        <ArrowRight className="size-4" />
+      </Button>
+    </div>
+  );
+}
+
+function HarnessStep({ onSelect }: { onSelect: (id: HarnessID) => void }) {
+  return (
+    <div className="flex w-full max-w-lg flex-col items-center gap-6">
+      <div className="flex flex-col items-center gap-2 text-center">
+        <Text variant="h3" className="text-lg font-semibold">
+          Choose your harness
+        </Text>
+        <Text className="text-xs text-muted-foreground">
+          Which coding agent do you want to route through this router?
+        </Text>
+      </div>
+      <div className="flex w-full flex-col gap-3">
+        {HARNESSES.map(h => (
+          <button
+            key={h.id}
+            type="button"
+            onClick={() => onSelect(h.id)}
+            className="flex items-center gap-4 rounded-xl border border-border-darker bg-background p-4 text-left transition-colors hover:border-brand"
+          >
+            <div className="flex min-w-0 flex-col gap-0.5">
+              <Text className="text-xs font-medium">{h.label}</Text>
+              <Text className="text-2xs text-muted-foreground">{h.detail}</Text>
+            </div>
+            <ChevronRight className="ml-auto size-4 shrink-0 text-muted-foreground" />
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function ScopeStep({
+  harnessID,
+  onBack,
+  onSelect,
+}: {
+  harnessID: HarnessID;
+  onBack: () => void;
+  onSelect: (scope: InstallScope) => void;
+}) {
+  const selected = harness(harnessID);
+  const options: { value: InstallScope; label: string; detail: string; icon: typeof User }[] = [
+    {
+      value: "user",
+      label: "Personal install",
+      detail: "Configures this machine for every project.",
+      icon: User,
+    },
+    {
+      value: "project",
+      label: "Team install (this project)",
+      detail: selected.projectDetail,
+      icon: GitBranch,
+    },
+  ];
+
+  return (
+    <div className="flex w-full max-w-lg flex-col items-center gap-6">
+      <div className="flex flex-col items-center gap-2 text-center">
+        <Text variant="h3" className="text-lg font-semibold">
+          Personal or team install?
+        </Text>
+        <Text className="text-xs text-muted-foreground">
+          You can always find both commands later in Settings.
+        </Text>
+      </div>
+      <div className="flex w-full flex-col gap-3">
+        {options.map(o => {
+          const Icon = o.icon;
+          return (
+            <button
+              key={o.value}
+              type="button"
+              onClick={() => onSelect(o.value)}
+              className="flex items-center gap-4 rounded-xl border border-border-darker bg-background p-4 text-left transition-colors hover:border-brand"
+            >
+              <Icon className="size-4 shrink-0 text-muted-foreground" />
+              <div className="flex min-w-0 flex-col gap-0.5">
+                <Text className="text-xs font-medium">{o.label}</Text>
+                <Text className="text-2xs text-muted-foreground">{o.detail}</Text>
+              </div>
+              <ChevronRight className="ml-auto size-4 shrink-0 text-muted-foreground" />
+            </button>
+          );
+        })}
+      </div>
+      <Button appearance={Appearance.Hollow} onClick={onBack} className="text-xs text-muted-foreground">
+        Back
+      </Button>
+    </div>
+  );
+}
+
+function InstallStep({
+  harnessID,
+  scope,
+  token,
+  onBack,
+  onComplete,
+}: {
+  harnessID: HarnessID;
+  scope: InstallScope;
+  token: string;
+  onBack: () => void;
+  onComplete: () => void;
+}) {
+  const origin = routerOrigin();
+  const selected = harness(harnessID);
+  const pinged = useFirstRequest();
+
+  useEffect(() => {
+    if (pinged) onComplete();
+  }, [pinged, onComplete]);
+
+  return (
+    <div className="flex w-full max-w-xl flex-col items-center gap-6">
+      <div className="flex flex-col items-center gap-2 text-center">
+        <Text variant="h3" className="text-lg font-semibold">
+          Run the install command
+        </Text>
+        <Text className="text-xs text-muted-foreground">
+          Paste this into your terminal. It points {selected.label} at this router with your key
+          already inlined.
+        </Text>
+      </div>
+
+      <div className="flex w-full flex-col gap-2">
+        {origin === "" ? (
+          <Text className="text-2xs text-muted-foreground">Preparing install command…</Text>
+        ) : (
+          <CopyBlock
+            value={installCommand(harnessID, scope, token, origin)}
+            title="Copy install command"
+          />
+        )}
+      </div>
+
+      <div className="flex w-full flex-col gap-2">
+        <Text className="text-xs font-medium">Your API key</Text>
+        <CopyBlock value={token} title="Copy API key" />
+        <Text className="text-2xs text-muted-foreground">
+          This is the only time the full key is shown. Save it somewhere safe.
+        </Text>
+      </div>
+
+      <div className="flex items-center gap-2 text-muted-foreground">
+        <Loader2 className="size-4 animate-spin text-brand" />
+        <Text className="text-2xs">
+          Waiting for your first request — send one prompt through {selected.label} and this page
+          moves on by itself.
+        </Text>
+      </div>
+
+      <div className="flex items-center gap-2">
+        <Button appearance={Appearance.Hollow} onClick={onBack} className="text-xs text-muted-foreground">
+          Back
+        </Button>
+        <Button appearance={Appearance.Outlined} size="sm" onClick={onComplete}>
+          Skip to dashboard
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * True once any routing key reports a `last_used_at`, i.e. the router has
+ * actually served a request. Polls because the signal arrives out-of-band
+ * (from the user's terminal), not from anything this page did.
+ */
+function useFirstRequest(): boolean {
+  const [pinged, setPinged] = useState(false);
+
+  useEffect(() => {
+    if (pinged) return;
+    let cancelled = false;
+
+    function check() {
+      api.keys
+        .list()
+        .then(res => {
+          if (cancelled) return;
+          if ((res.keys ?? []).some(hasBeenUsed)) setPinged(true);
+        })
+        // Non-fatal: a failed poll just means we try again on the next tick.
+        .catch(() => undefined);
+    }
+
+    check();
+    const interval = setInterval(check, POLL_INTERVAL_MS);
+    return () => {
+      cancelled = true;
+      clearInterval(interval);
+    };
+  }, [pinged]);
+
+  return pinged;
+}
+
+function hasBeenUsed(key: APIKey): boolean {
+  return key.scope === "routing" && key.last_used_at != null;
+}

--- a/frontend/src/components/RouterOnboarding.tsx
+++ b/frontend/src/components/RouterOnboarding.tsx
@@ -4,7 +4,7 @@ import { CopyBlock } from "@/components/CopyBlock";
 import { Text } from "@/components/atoms/Text";
 import { Button } from "@/components/molecules/Button";
 import { Appearance } from "@/components/types";
-import { api, type APIKey, type IssueAPIKeyResponse } from "@/lib/api";
+import { api, type IssueAPIKeyResponse } from "@/lib/api";
 import {
   HARNESSES,
   type HarnessID,
@@ -19,13 +19,23 @@ import { useEffect, useState } from "react";
 
 const POLL_INTERVAL_MS = 3000;
 
+// Name given to the key minted during onboarding, so it's recognizable in the
+// keys list later instead of showing up as "Unnamed key".
+const ONBOARDING_KEY_NAME = "Onboarding key";
+
+// Stand-in for the bearer token in a command shown to someone who already has
+// a key: the raw token exists only at issuance and can't be recovered here.
+const KEY_PLACEHOLDER = "<YOUR_ROUTER_KEY>";
+
 type StepID = "setup" | "harness" | "scope" | "install";
 
 const STEPS: StepID[] = ["setup", "harness", "scope", "install"];
 
 interface RouterOnboardingProps {
-  /** Called once the router has served its first request through any key. */
+  /** Called once the router has served its first request. */
   onComplete: () => void;
+  /** Called when the user opts out of the flow before that happens. */
+  onSkip: () => void;
 }
 
 /**
@@ -38,19 +48,45 @@ interface RouterOnboardingProps {
  * surfaces teach the same mental model, but the base URL comes from this
  * deployment's own origin rather than the hosted endpoint.
  */
-export function RouterOnboarding({ onComplete }: RouterOnboardingProps) {
+export function RouterOnboarding({ onComplete, onSkip }: RouterOnboardingProps) {
   const [step, setStep] = useState<StepID>("setup");
   const [harnessID, setHarnessID] = useState<HarnessID | null>(null);
   const [scope, setScope] = useState<InstallScope>("user");
   const [issued, setIssued] = useState<IssueAPIKeyResponse | null>(null);
   const [creating, setCreating] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [existingKeyCount, setExistingKeyCount] = useState<number | null>(null);
+
+  // An install that already holds routing keys shouldn't be offered "issue a
+  // key" again as if it were brand new: the raw token of an existing key can
+  // never be re-shown, so minting another on every revisit would pile up
+  // unused rk_ keys. Such a visit lands on the harness step and the install
+  // step renders the placeholder command instead of an inlined token.
+  useEffect(() => {
+    let cancelled = false;
+    api.keys
+      .list()
+      .then(res => {
+        if (cancelled) return;
+        const routing = (res.keys ?? []).filter(k => k.scope === "routing");
+        setExistingKeyCount(routing.length);
+        setStep(prev => (prev === "setup" && routing.length > 0 ? "harness" : prev));
+      })
+      // Non-fatal: on a failed probe keep the setup step, which is still a
+      // valid entry point.
+      .catch(() => {
+        if (!cancelled) setExistingKeyCount(0);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   async function handleGetStarted() {
     setCreating(true);
     setError(null);
     try {
-      const res = await api.keys.issue("Onboarding key");
+      const res = await api.keys.issue(ONBOARDING_KEY_NAME);
       setIssued(res);
       setStep("harness");
     } catch (err: unknown) {
@@ -91,13 +127,15 @@ export function RouterOnboarding({ onComplete }: RouterOnboardingProps) {
           }}
         />
       )}
-      {step === "install" && harnessID != null && issued != null && (
+      {step === "install" && harnessID != null && (
         <InstallStep
           harnessID={harnessID}
           scope={scope}
-          token={issued.token}
+          token={issued?.token}
+          hasExistingKey={(existingKeyCount ?? 0) > 0}
           onBack={() => setStep("scope")}
           onComplete={onComplete}
+          onSkip={onSkip}
         />
       )}
 
@@ -258,14 +296,19 @@ function InstallStep({
   harnessID,
   scope,
   token,
+  hasExistingKey,
   onBack,
   onComplete,
+  onSkip,
 }: {
   harnessID: HarnessID;
   scope: InstallScope;
-  token: string;
+  /** Undefined when no key was minted this session (a revisit). */
+  token?: string;
+  hasExistingKey: boolean;
   onBack: () => void;
   onComplete: () => void;
+  onSkip: () => void;
 }) {
   const origin = routerOrigin();
   const selected = harness(harnessID);
@@ -292,19 +335,30 @@ function InstallStep({
           <Text className="text-2xs text-muted-foreground">Preparing install command…</Text>
         ) : (
           <CopyBlock
-            value={installCommand(harnessID, scope, token, origin)}
+            value={installCommand(harnessID, scope, token ?? KEY_PLACEHOLDER, origin)}
             title="Copy install command"
           />
         )}
       </div>
 
-      <div className="flex w-full flex-col gap-2">
-        <Text className="text-xs font-medium">Your API key</Text>
-        <CopyBlock value={token} title="Copy API key" />
+      {token != null ? (
+        <div className="flex w-full flex-col gap-2">
+          <Text className="text-xs font-medium">Your API key</Text>
+          <CopyBlock value={token} title="Copy API key" />
+          <Text className="text-2xs text-muted-foreground">
+            This is the only time the full key is shown. Save it somewhere safe.
+          </Text>
+        </div>
+      ) : (
+        // A key already existed when this flow started, and a raw token is only
+        // ever shown at issuance. Rather than mint a spare key the user didn't
+        // ask for, the command ships with a placeholder to fill in.
         <Text className="text-2xs text-muted-foreground">
-          This is the only time the full key is shown. Save it somewhere safe.
+          {hasExistingKey
+            ? `Replace ${KEY_PLACEHOLDER} with an existing router key, or issue a new one from Settings.`
+            : `Replace ${KEY_PLACEHOLDER} with your router key.`}
         </Text>
-      </div>
+      )}
 
       <div className="flex items-center gap-2 text-muted-foreground">
         <Loader2 className="size-4 animate-spin text-brand" />
@@ -318,7 +372,7 @@ function InstallStep({
         <Button appearance={Appearance.Hollow} onClick={onBack} className="text-xs text-muted-foreground">
           Back
         </Button>
-        <Button appearance={Appearance.Outlined} size="sm" onClick={onComplete}>
+        <Button appearance={Appearance.Outlined} size="sm" onClick={onSkip}>
           Skip to dashboard
         </Button>
       </div>
@@ -327,9 +381,12 @@ function InstallStep({
 }
 
 /**
- * True once any routing key reports a `last_used_at`, i.e. the router has
- * actually served a request. Polls because the signal arrives out-of-band
- * (from the user's terminal), not from anything this page did.
+ * True once the installation has served a routed request. Reads the
+ * installation-level flag rather than any key's `last_used_at`: that flag is
+ * set once and survives rotation, so rotating the key that served the first
+ * request can't drop the user back into onboarding. Polls because the signal
+ * arrives out-of-band (from the user's terminal), not from anything this page
+ * did.
  */
 function useFirstRequest(): boolean {
   const [pinged, setPinged] = useState(false);
@@ -339,11 +396,11 @@ function useFirstRequest(): boolean {
     let cancelled = false;
 
     function check() {
-      api.keys
-        .list()
+      api.onboarding
+        .get()
         .then(res => {
           if (cancelled) return;
-          if ((res.keys ?? []).some(hasBeenUsed)) setPinged(true);
+          if (res.first_request_served_at != null) setPinged(true);
         })
         // Non-fatal: a failed poll just means we try again on the next tick.
         .catch(() => undefined);
@@ -358,8 +415,4 @@ function useFirstRequest(): boolean {
   }, [pinged]);
 
   return pinged;
-}
-
-function hasBeenUsed(key: APIKey): boolean {
-  return key.scope === "routing" && key.last_used_at != null;
 }

--- a/frontend/src/components/settings/RouterKeysPanel.tsx
+++ b/frontend/src/components/settings/RouterKeysPanel.tsx
@@ -3,10 +3,11 @@
 import { EmptyHint, ErrorBanner, formatDate } from "./shared";
 import { Text } from "@/components/atoms/Text";
 import { Input } from "@/components/Input";
+import { InstallCommandPicker } from "@/components/InstallCommandPicker";
 import { Button } from "@/components/molecules/Button";
 import { Card } from "@/components/molecules/Card";
 import { Appearance, Intent } from "@/components/types";
-import { api, type APIKey, type APIKeyScope } from "@/lib/api";
+import { api, type APIKey, type APIKeyScope, type IssueAPIKeyResponse } from "@/lib/api";
 import { Copy, RotateCw, Search, Trash2 } from "lucide-react";
 import { useEffect, useState } from "react";
 
@@ -62,7 +63,10 @@ export function RouterKeysPanel() {
   const [creating, setCreating] = useState(false);
   const [rotating, setRotating] = useState<string | null>(null);
   const [deleting, setDeleting] = useState<string | null>(null);
-  const [newToken, setNewToken] = useState<string | null>(null);
+  // Holds the issued token together with the scope it was minted for: only a
+  // routing key has an installer to offer, and rotate carries forward the
+  // rotated key's scope rather than whatever the create form currently shows.
+  const [issued, setIssued] = useState<IssueAPIKeyResponse | null>(null);
   const [copied, setCopied] = useState(false);
 
   const hasKey = keys.length > 0;
@@ -97,7 +101,7 @@ export function RouterKeysPanel() {
     setCreating(true);
     try {
       const res = await api.keys.issue(name.trim() || undefined, scope);
-      setNewToken(res.token);
+      setIssued(res);
       setName("");
       load();
     } catch (err: unknown) {
@@ -115,7 +119,7 @@ export function RouterKeysPanel() {
     setRotating(id);
     try {
       const res = await api.keys.rotate(id);
-      setNewToken(res.token);
+      setIssued(res);
       load();
     } catch (err: unknown) {
       setError(err instanceof Error ? err.message : "Failed to rotate key.");
@@ -141,8 +145,8 @@ export function RouterKeysPanel() {
   }
 
   function handleCopy() {
-    if (newToken == null) return;
-    navigator.clipboard.writeText(newToken).then(() => {
+    if (issued == null) return;
+    navigator.clipboard.writeText(issued.token).then(() => {
       setCopied(true);
       setTimeout(() => setCopied(false), 2000);
     });
@@ -152,23 +156,38 @@ export function RouterKeysPanel() {
     <>
       {error && <ErrorBanner>{error}</ErrorBanner>}
 
-      {newToken != null && (
-        <div className="rounded-lg border border-success/30 bg-success/5 p-4">
-          <Text className="mb-2 text-xs font-medium text-success">
-            Key created. Copy it; it won&apos;t be shown again.
-          </Text>
-          <div className="flex items-center gap-2">
-            <code className="flex-1 rounded bg-muted px-3 py-1.5 font-mono text-2xs text-foreground">
-              {newToken}
-            </code>
-            <Button appearance={Appearance.Outlined} size="sm" onClick={handleCopy}>
-              <Copy className="size-3.5" />
-              {copied ? "Copied" : "Copy"}
-            </Button>
+      {issued != null && (
+        <div className="flex flex-col gap-3 rounded-lg border border-success/30 bg-success/5 p-4">
+          <div className="flex flex-col gap-2">
+            <Text className="text-xs font-medium text-success">
+              Key created. Copy it; it won&apos;t be shown again.
+            </Text>
+            <div className="flex items-center gap-2">
+              <code className="flex-1 rounded bg-muted px-3 py-1.5 font-mono text-2xs text-foreground">
+                {issued.token}
+              </code>
+              <Button appearance={Appearance.Outlined} size="sm" onClick={handleCopy}>
+                <Copy className="size-3.5" />
+                {copied ? "Copied" : "Copy"}
+              </Button>
+            </div>
           </div>
+
+          {/* A routing key is only useful once a harness points at it, so the
+              installer command ships with the token rather than leaving the
+              user to hunt for it. Analytics keys have nothing to install. */}
+          {issued.key.scope === "routing" && (
+            <div className="flex flex-col gap-2 border-t border-success/30 pt-3">
+              <Text className="text-xs font-medium text-foreground">
+                Point a harness at this router
+              </Text>
+              <InstallCommandPicker token={issued.token} />
+            </div>
+          )}
+
           <button
-            className="mt-2 text-2xs text-muted-foreground underline"
-            onClick={() => setNewToken(null)}
+            className="self-start text-2xs text-muted-foreground underline"
+            onClick={() => setIssued(null)}
           >
             Dismiss
           </button>

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -145,6 +145,13 @@ export interface RouterConfig {
   env_provider_keys: string[];
 }
 
+// Whether this installation has ever served a routed request. Set once and
+// never cleared, so it survives key rotation — the dashboard gates first-run
+// onboarding on this rather than on a key's last_used_at.
+export interface OnboardingStatus {
+  first_request_served_at: string | null;
+}
+
 export interface MeResponse {
   authenticated: boolean;
   subject?: string;
@@ -256,6 +263,9 @@ export const api = {
   },
   config: {
     get: () => request<RouterConfig>("/config"),
+  },
+  onboarding: {
+    get: () => request<OnboardingStatus>("/onboarding"),
   },
   excludedModels: {
     get: () => request<ExcludedModelsResponse>("/excluded-models"),

--- a/frontend/src/lib/installCommands.ts
+++ b/frontend/src/lib/installCommands.ts
@@ -1,0 +1,87 @@
+// Install commands for pointing a coding harness at *this* router.
+//
+// Self-hosted deployments serve this dashboard from the router's own origin, so
+// the base URL is derived from the browser rather than hardcoded: an install
+// command that silently pointed at the hosted endpoint would route a
+// self-hoster's traffic off-box. `--base-url` is always passed explicitly for
+// the same reason — install.sh otherwise falls back to the hosted default.
+
+/** A harness the installer can configure, in the order the picker shows them. */
+export type HarnessID = "claude" | "codex" | "pi";
+
+/** Whether the installer writes machine-wide config or repo-local config. */
+export type InstallScope = "user" | "project";
+
+export interface HarnessInfo {
+  id: HarnessID;
+  label: string;
+  /** What the installer touches, shown under the label in the picker. */
+  detail: string;
+  /** How the repo-local install is launched, shown on the project scope option. */
+  projectDetail: string;
+}
+
+export const HARNESSES: HarnessInfo[] = [
+  {
+    id: "claude",
+    label: "Claude Code",
+    detail: "Patches ~/.claude/settings.json.",
+    projectDetail: "Writes <repo>/.claude/settings.json — commit it to share with teammates.",
+  },
+  {
+    id: "codex",
+    label: "Codex",
+    detail: "Patches ~/.codex/config.toml.",
+    projectDetail: "Writes <repo>/.codex/config.toml (gitignored). Run: CODEX_HOME=.codex codex",
+  },
+  {
+    id: "pi",
+    label: "pi",
+    detail: "Merges a weave provider into ~/.pi/agent/models.json.",
+    projectDetail: "Writes <repo>/.pi/ (gitignored). Run: PI_CODING_AGENT_DIR=.pi pi",
+  },
+];
+
+export function harness(id: HarnessID): HarnessInfo {
+  const found = HARNESSES.find(h => h.id === id);
+  if (found == null) throw new Error(`unknown harness: ${id}`);
+  return found;
+}
+
+/**
+ * Origin of the router serving this dashboard, with the /ui basePath stripped.
+ * Returns "" during SSR (static export prerender), which callers render as a
+ * disabled/placeholder state rather than a wrong command.
+ */
+export function routerOrigin(): string {
+  if (typeof window === "undefined") return "";
+  return window.location.origin;
+}
+
+/**
+ * The npx one-liner that configures `harnessID` against this router. The token
+ * rides in as a WEAVE_ROUTER_KEY env prefix, which install.sh reads to skip its
+ * interactive prompt.
+ *
+ * `--package … -- <bin>` rather than `npx -y @workweave/router`: npm <= 6's
+ * bundled npx treats an undeclared flag as consuming the next token, so the
+ * short form drops the package name and resolves `weave-router` from the
+ * registry instead — with the key already in its environment.
+ */
+export function installCommand(
+  harnessID: HarnessID,
+  scope: InstallScope,
+  token: string,
+  origin: string,
+): string {
+  const flags = [`--${harnessID}`, `--scope ${scope}`, `--base-url ${shellSingleQuote(origin)}`];
+  return `WEAVE_ROUTER_KEY=${shellSingleQuote(token)} npx --package @workweave/router -y -- weave-router ${flags.join(" ")}`;
+}
+
+/**
+ * Wraps a value in single quotes for POSIX shell, closing/escaping/reopening
+ * any embedded quote via the standard '\'' idiom.
+ */
+function shellSingleQuote(value: string): string {
+  return `'${value.replaceAll("'", `'\\''`)}'`;
+}

--- a/internal/api/admin/onboarding.go
+++ b/internal/api/admin/onboarding.go
@@ -16,8 +16,7 @@ type onboardingResponse struct {
 }
 
 // OnboardingHandler reports whether this installation has ever served a routed
-// request, which is what the dashboard uses to decide between the first-run
-// onboarding flow and the metrics view.
+// request; the dashboard uses it to gate the first-run flow vs. the metrics view.
 func OnboardingHandler(authSvc *auth.Service) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		installation, ok := resolveInstallation(c, authSvc)

--- a/internal/api/admin/onboarding.go
+++ b/internal/api/admin/onboarding.go
@@ -1,0 +1,34 @@
+package admin
+
+import (
+	"net/http"
+	"time"
+
+	"workweave/router/internal/auth"
+
+	"github.com/gin-gonic/gin"
+)
+
+type onboardingResponse struct {
+	// FirstRequestServedAt is when this installation first routed a request,
+	// or null if it never has. Set once and never cleared, so it stays put
+	// across key rotation — the dashboard gates first-run onboarding on it
+	// rather than on any single key's last_used_at, which disappears with the
+	// key that earned it.
+	FirstRequestServedAt *time.Time `json:"first_request_served_at"`
+}
+
+// OnboardingHandler reports whether this installation has ever served a routed
+// request, which is what the dashboard uses to decide between the first-run
+// onboarding flow and the metrics view.
+func OnboardingHandler(authSvc *auth.Service) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		installation, ok := resolveInstallation(c, authSvc)
+		if !ok {
+			return
+		}
+		c.JSON(http.StatusOK, onboardingResponse{
+			FirstRequestServedAt: installation.FirstRequestServedAt,
+		})
+	}
+}

--- a/internal/api/admin/onboarding.go
+++ b/internal/api/admin/onboarding.go
@@ -10,11 +10,8 @@ import (
 )
 
 type onboardingResponse struct {
-	// FirstRequestServedAt is when this installation first routed a request,
-	// or null if it never has. Set once and never cleared, so it stays put
-	// across key rotation — the dashboard gates first-run onboarding on it
-	// rather than on any single key's last_used_at, which disappears with the
-	// key that earned it.
+	// FirstRequestServedAt is when this installation first routed a request;
+	// null until then. Set once and never cleared, so it survives key rotation.
 	FirstRequestServedAt *time.Time `json:"first_request_served_at"`
 }
 

--- a/internal/auth/analytics_key.go
+++ b/internal/auth/analytics_key.go
@@ -29,7 +29,7 @@ func (s *Service) VerifyAnalyticsAPIKey(ctx context.Context, rawToken string) (*
 			if cached.APIKey.Scope != ScopeAnalyticsRead {
 				return nil, nil, ErrWrongKeyScope
 			}
-			s.fireMarkUsed(cached.APIKey.ID)
+			s.fireMarkUsed(cached.APIKey.ID, "")
 			return cached.Installation, cached.APIKey, nil
 		}
 	}
@@ -50,6 +50,6 @@ func (s *Service) VerifyAnalyticsAPIKey(ctx context.Context, rawToken string) (*
 	}
 
 	s.cache.Set(keyHash, CachedKey{APIKey: apiKey, Installation: installation})
-	s.fireMarkUsed(apiKey.ID)
+	s.fireMarkUsed(apiKey.ID, "")
 	return installation, apiKey, nil
 }

--- a/internal/auth/analytics_key.go
+++ b/internal/auth/analytics_key.go
@@ -29,7 +29,7 @@ func (s *Service) VerifyAnalyticsAPIKey(ctx context.Context, rawToken string) (*
 			if cached.APIKey.Scope != ScopeAnalyticsRead {
 				return nil, nil, ErrWrongKeyScope
 			}
-			s.fireMarkUsed(cached.APIKey.ID, "")
+			s.fireMarkUsed(cached.APIKey.ID)
 			return cached.Installation, cached.APIKey, nil
 		}
 	}
@@ -50,6 +50,6 @@ func (s *Service) VerifyAnalyticsAPIKey(ctx context.Context, rawToken string) (*
 	}
 
 	s.cache.Set(keyHash, CachedKey{APIKey: apiKey, Installation: installation})
-	s.fireMarkUsed(apiKey.ID, "")
+	s.fireMarkUsed(apiKey.ID)
 	return installation, apiKey, nil
 }

--- a/internal/auth/installation.go
+++ b/internal/auth/installation.go
@@ -84,6 +84,11 @@ type Installation struct {
 	// HideTerminalSurfaces suppresses the routing marker, feedback footer, and
 	// statusline; routing and feedback recording are unaffected. Defaults false.
 	HideTerminalSurfaces bool
+	// FirstRequestServedAt is when this installation routed its first request.
+	// Set once and never cleared, so it survives key rotation — onboarding is
+	// gated on "this install has served traffic", which a rotated-away key's
+	// last_used_at can no longer report.
+	FirstRequestServedAt *time.Time
 }
 
 type CreateInstallationParams struct {
@@ -98,6 +103,10 @@ type InstallationRepository interface {
 	Get(ctx context.Context, externalID, id string) (*Installation, error)
 	ListForExternalID(ctx context.Context, externalID string) ([]*Installation, error)
 	SoftDelete(ctx context.Context, externalID, id string) error
+	// MarkFirstRequestServed stamps FirstRequestServedAt the first time the
+	// installation routes a request. A no-op once set, so rotation of the key
+	// that served the first request doesn't reset onboarding.
+	MarkFirstRequestServed(ctx context.Context, id string) error
 	// UpdateExcludedModels replaces the per-installation exclusion list.
 	// An empty (or nil) slice clears the list.
 	UpdateExcludedModels(ctx context.Context, externalID, id string, models []string) error

--- a/internal/auth/installation.go
+++ b/internal/auth/installation.go
@@ -84,10 +84,8 @@ type Installation struct {
 	// HideTerminalSurfaces suppresses the routing marker, feedback footer, and
 	// statusline; routing and feedback recording are unaffected. Defaults false.
 	HideTerminalSurfaces bool
-	// FirstRequestServedAt is when this installation routed its first request.
-	// Set once and never cleared, so it survives key rotation — onboarding is
-	// gated on "this install has served traffic", which a rotated-away key's
-	// last_used_at can no longer report.
+	// FirstRequestServedAt is when this installation first routed a request.
+	// Set once and never cleared so it survives key rotation.
 	FirstRequestServedAt *time.Time
 }
 
@@ -103,9 +101,7 @@ type InstallationRepository interface {
 	Get(ctx context.Context, externalID, id string) (*Installation, error)
 	ListForExternalID(ctx context.Context, externalID string) ([]*Installation, error)
 	SoftDelete(ctx context.Context, externalID, id string) error
-	// MarkFirstRequestServed stamps FirstRequestServedAt the first time the
-	// installation routes a request. A no-op once set, so rotation of the key
-	// that served the first request doesn't reset onboarding.
+	// MarkFirstRequestServed stamps FirstRequestServedAt once; a no-op thereafter, so key rotation can't reset it.
 	MarkFirstRequestServed(ctx context.Context, id string) error
 	// UpdateExcludedModels replaces the per-installation exclusion list.
 	// An empty (or nil) slice clears the list.

--- a/internal/auth/service.go
+++ b/internal/auth/service.go
@@ -711,8 +711,7 @@ func (s *Service) fireMarkUsed(apiKeyID string) {
 }
 
 // fireMarkFirstRequestServed stamps the installation-level onboarding flag
-// off the request path (same rationale as fireMarkUsed). Not called from the
-// analytics path — an analytics read is not a routed request.
+// off the request path (same rationale as fireMarkUsed; not called on the analytics path).
 func (s *Service) fireMarkFirstRequestServed(installationID string) {
 	log := observability.Get().With("installation_id", installationID)
 	observability.SafeGo(log, 2*time.Second, "fireMarkFirstRequestServed", func(ctx context.Context) {

--- a/internal/auth/service.go
+++ b/internal/auth/service.go
@@ -542,7 +542,7 @@ func (s *Service) VerifyAPIKey(ctx context.Context, rawToken string) (*Installat
 			if cached.APIKey.Scope.Normalized() != ScopeRouting {
 				return nil, nil, nil, nil, ErrWrongKeyScope
 			}
-			s.fireMarkUsed(cached.APIKey.ID)
+			s.fireMarkUsed(cached.APIKey.ID, cached.APIKey.InstallationID)
 			return cached.Installation, cached.APIKey, s.resolveUpstreamSecrets(ctx, cached.ExternalKeys), cached.ClusterModelLists, nil
 		}
 		// Malformed positive entry (nil APIKey): fall through to DB lookup.
@@ -589,7 +589,7 @@ func (s *Service) VerifyAPIKey(ctx context.Context, rawToken string) (*Installat
 	if clusterModelListsFetchOK {
 		s.cache.Set(keyHash, CachedKey{APIKey: apiKey, Installation: installation, ExternalKeys: externalKeys, ClusterModelLists: clusterModelLists})
 	}
-	s.fireMarkUsed(apiKey.ID)
+	s.fireMarkUsed(apiKey.ID, apiKey.InstallationID)
 	return installation, apiKey, s.resolveUpstreamSecrets(ctx, externalKeys), clusterModelLists, nil
 }
 
@@ -699,11 +699,23 @@ func userIdentityKey(email, claudeAccountUUID string) string {
 
 // fireMarkUsed runs the last_used_at update off the request path. Uses context.Background because
 // the parent ctx is often canceled (response written) before the UPDATE completes.
-func (s *Service) fireMarkUsed(apiKeyID string) {
+//
+// A non-empty installationID also stamps that installation's
+// first_request_served_at, which is what onboarding is gated on: it has to
+// outlive the rotation of whatever key served the first request. Callers pass
+// "" when the read wasn't a routed request (an analytics export doesn't route),
+// so reading the export can't mark an installation as onboarded.
+func (s *Service) fireMarkUsed(apiKeyID, installationID string) {
 	log := observability.Get().With("api_key_id", apiKeyID)
 	observability.SafeGo(log, 2*time.Second, "fireMarkUsed", func(ctx context.Context) {
 		if err := s.apiKeys.MarkUsed(ctx, apiKeyID); err != nil {
 			log.Warn("Failed to mark router api key used", "err", err)
+		}
+		if installationID == "" {
+			return
+		}
+		if err := s.installations.MarkFirstRequestServed(ctx, installationID); err != nil {
+			log.Warn("Failed to mark installation first request served", "err", err, "installation_id", installationID)
 		}
 	})
 }

--- a/internal/auth/service.go
+++ b/internal/auth/service.go
@@ -542,7 +542,8 @@ func (s *Service) VerifyAPIKey(ctx context.Context, rawToken string) (*Installat
 			if cached.APIKey.Scope.Normalized() != ScopeRouting {
 				return nil, nil, nil, nil, ErrWrongKeyScope
 			}
-			s.fireMarkUsed(cached.APIKey.ID, cached.APIKey.InstallationID)
+			s.fireMarkUsed(cached.APIKey.ID)
+			s.fireMarkFirstRequestServed(cached.APIKey.InstallationID)
 			return cached.Installation, cached.APIKey, s.resolveUpstreamSecrets(ctx, cached.ExternalKeys), cached.ClusterModelLists, nil
 		}
 		// Malformed positive entry (nil APIKey): fall through to DB lookup.
@@ -589,7 +590,8 @@ func (s *Service) VerifyAPIKey(ctx context.Context, rawToken string) (*Installat
 	if clusterModelListsFetchOK {
 		s.cache.Set(keyHash, CachedKey{APIKey: apiKey, Installation: installation, ExternalKeys: externalKeys, ClusterModelLists: clusterModelLists})
 	}
-	s.fireMarkUsed(apiKey.ID, apiKey.InstallationID)
+	s.fireMarkUsed(apiKey.ID)
+	s.fireMarkFirstRequestServed(apiKey.InstallationID)
 	return installation, apiKey, s.resolveUpstreamSecrets(ctx, externalKeys), clusterModelLists, nil
 }
 
@@ -699,23 +701,28 @@ func userIdentityKey(email, claudeAccountUUID string) string {
 
 // fireMarkUsed runs the last_used_at update off the request path. Uses context.Background because
 // the parent ctx is often canceled (response written) before the UPDATE completes.
-//
-// A non-empty installationID also stamps that installation's
-// first_request_served_at, which is what onboarding is gated on: it has to
-// outlive the rotation of whatever key served the first request. Callers pass
-// "" when the read wasn't a routed request (an analytics export doesn't route),
-// so reading the export can't mark an installation as onboarded.
-func (s *Service) fireMarkUsed(apiKeyID, installationID string) {
+func (s *Service) fireMarkUsed(apiKeyID string) {
 	log := observability.Get().With("api_key_id", apiKeyID)
 	observability.SafeGo(log, 2*time.Second, "fireMarkUsed", func(ctx context.Context) {
 		if err := s.apiKeys.MarkUsed(ctx, apiKeyID); err != nil {
 			log.Warn("Failed to mark router api key used", "err", err)
 		}
-		if installationID == "" {
-			return
-		}
+	})
+}
+
+// fireMarkFirstRequestServed stamps the installation's first_request_served_at
+// off the request path, same rationale as fireMarkUsed for context.Background.
+// That flag is what the dashboard gates first-run onboarding on, so it lives on
+// the installation rather than the key: it has to outlive the rotation of
+// whatever key served the first request.
+//
+// Deliberately called only from the routing path. An analytics export doesn't
+// route a request, so reading it must not mark an installation as onboarded.
+func (s *Service) fireMarkFirstRequestServed(installationID string) {
+	log := observability.Get().With("installation_id", installationID)
+	observability.SafeGo(log, 2*time.Second, "fireMarkFirstRequestServed", func(ctx context.Context) {
 		if err := s.installations.MarkFirstRequestServed(ctx, installationID); err != nil {
-			log.Warn("Failed to mark installation first request served", "err", err, "installation_id", installationID)
+			log.Warn("Failed to mark installation first request served", "err", err)
 		}
 	})
 }

--- a/internal/auth/service.go
+++ b/internal/auth/service.go
@@ -710,14 +710,9 @@ func (s *Service) fireMarkUsed(apiKeyID string) {
 	})
 }
 
-// fireMarkFirstRequestServed stamps the installation's first_request_served_at
-// off the request path, same rationale as fireMarkUsed for context.Background.
-// That flag is what the dashboard gates first-run onboarding on, so it lives on
-// the installation rather than the key: it has to outlive the rotation of
-// whatever key served the first request.
-//
-// Deliberately called only from the routing path. An analytics export doesn't
-// route a request, so reading it must not mark an installation as onboarded.
+// fireMarkFirstRequestServed stamps the installation-level onboarding flag
+// off the request path (same rationale as fireMarkUsed). Not called from the
+// analytics path — an analytics read is not a routed request.
 func (s *Service) fireMarkFirstRequestServed(installationID string) {
 	log := observability.Get().With("installation_id", installationID)
 	observability.SafeGo(log, 2*time.Second, "fireMarkFirstRequestServed", func(ctx context.Context) {

--- a/internal/auth/service_test.go
+++ b/internal/auth/service_test.go
@@ -146,9 +146,7 @@ type fakeInstallationRepository struct {
 	subscriptionRoutingDisabledByID map[string]bool
 	contentCaptureModeByID          map[string]*string
 	hideTerminalSurfacesByID        map[string]bool
-	// firstRequestServedIDs counts MarkFirstRequestServed calls per installation
-	// so tests can assert a routed request stamps the onboarding flag (and that
-	// an analytics read does not).
+	// firstRequestServedIDs counts MarkFirstRequestServed calls per installation.
 	firstRequestServedIDs map[string]int
 	mu                    sync.Mutex
 	// updateErr, when set, is returned by Update* methods instead of recording —
@@ -504,10 +502,8 @@ func TestService_VerifyAPIKey_HappyPathReturnsInstallationAndKey(t *testing.T) {
 		"VerifyAPIKey must asynchronously call MarkUsed with the matched key id")
 }
 
-// The dashboard gates first-run onboarding on the installation-level stamp
-// rather than a key's last_used_at, precisely so rotating the key that served
-// the first request can't reset it. That only holds if verifying a routing key
-// actually stamps the installation.
+// VerifyAPIKey must stamp the installation-level onboarding flag, not just
+// the key's last_used_at, so the flag survives key rotation.
 func TestService_VerifyAPIKey_StampsInstallationFirstRequestServed(t *testing.T) {
 	rawToken := "rk_first_request_token_for_test"
 	keyHash := auth.HashAPIKeySHA256(rawToken)
@@ -531,9 +527,7 @@ func TestService_VerifyAPIKey_StampsInstallationFirstRequestServed(t *testing.T)
 		"a routed request must stamp the installation's first_request_served_at")
 }
 
-// An analytics export is not a routed request, so reading it must not mark the
-// installation as having served traffic — otherwise pulling the export on a
-// fresh deploy would skip the user past onboarding they never completed.
+// An analytics read is not a routed request and must not advance onboarding.
 func TestService_VerifyAnalyticsKey_DoesNotStampFirstRequestServed(t *testing.T) {
 	rawToken := "ra_analytics_token_for_test"
 	keyHash := auth.HashAPIKeySHA256(rawToken)

--- a/internal/auth/service_test.go
+++ b/internal/auth/service_test.go
@@ -146,23 +146,44 @@ type fakeInstallationRepository struct {
 	subscriptionRoutingDisabledByID map[string]bool
 	contentCaptureModeByID          map[string]*string
 	hideTerminalSurfacesByID        map[string]bool
+	// firstRequestServedIDs counts MarkFirstRequestServed calls per installation
+	// so tests can assert a routed request stamps the onboarding flag (and that
+	// an analytics read does not).
+	firstRequestServedIDs map[string]int
+	mu                    sync.Mutex
 	// updateErr, when set, is returned by Update* methods instead of recording —
 	// simulates a zero-row update (stale/soft-deleted/cross-tenant id), which the
 	// real postgres repo surfaces as auth.ErrInstallationNotFound.
 	updateErr error
 }
 
-func (fakeInstallationRepository) Create(ctx context.Context, params auth.CreateInstallationParams) (*auth.Installation, error) {
+func (*fakeInstallationRepository) Create(ctx context.Context, params auth.CreateInstallationParams) (*auth.Installation, error) {
 	return nil, errors.New("not used")
 }
-func (fakeInstallationRepository) Get(ctx context.Context, externalID, id string) (*auth.Installation, error) {
+func (*fakeInstallationRepository) Get(ctx context.Context, externalID, id string) (*auth.Installation, error) {
 	return nil, errors.New("not used")
 }
-func (fakeInstallationRepository) ListForExternalID(ctx context.Context, externalID string) ([]*auth.Installation, error) {
+func (*fakeInstallationRepository) ListForExternalID(ctx context.Context, externalID string) ([]*auth.Installation, error) {
 	return nil, errors.New("not used")
 }
-func (fakeInstallationRepository) SoftDelete(ctx context.Context, externalID, id string) error {
+func (*fakeInstallationRepository) SoftDelete(ctx context.Context, externalID, id string) error {
 	return errors.New("not used")
+}
+func (f *fakeInstallationRepository) MarkFirstRequestServed(ctx context.Context, id string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.firstRequestServedIDs == nil {
+		f.firstRequestServedIDs = map[string]int{}
+	}
+	f.firstRequestServedIDs[id]++
+	return nil
+}
+
+// firstRequestServedCount reports how many times the installation was stamped.
+func (f *fakeInstallationRepository) firstRequestServedCount(id string) int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.firstRequestServedIDs[id]
 }
 func (f *fakeInstallationRepository) UpdateExcludedModels(ctx context.Context, externalID, id string, models []string) error {
 	if f.updateErr != nil {
@@ -268,12 +289,24 @@ func frozenClock() auth.Clock {
 
 func makeService(t *testing.T, rows ...fakeKeyRow) (*auth.Service, *fakeAPIKeyRepository) {
 	t.Helper()
+	svc, apiKeys, _ := makeServiceWithInstallations(t, rows...)
+	return svc, apiKeys
+}
+
+// makeServiceWithInstallations is makeService plus a handle on the installation
+// repo, for tests that assert on the installation-level onboarding stamp.
+func makeServiceWithInstallations(
+	t *testing.T,
+	rows ...fakeKeyRow,
+) (*auth.Service, *fakeAPIKeyRepository, *fakeInstallationRepository) {
+	t.Helper()
 	apiKeys := &fakeAPIKeyRepository{byHash: map[string]fakeKeyRow{}}
 	for _, row := range rows {
 		apiKeys.byHash[row.apiKey.KeyHash] = row
 	}
+	installations := &fakeInstallationRepository{}
 	svc := auth.NewService(
-		&fakeInstallationRepository{},
+		installations,
 		apiKeys,
 		nil,
 		nil,
@@ -281,7 +314,7 @@ func makeService(t *testing.T, rows ...fakeKeyRow) (*auth.Service, *fakeAPIKeyRe
 		nil,
 		frozenClock(),
 	)
-	return svc, apiKeys
+	return svc, apiKeys, installations
 }
 
 type recordingAPIKeyCache struct {
@@ -469,6 +502,63 @@ func TestService_VerifyAPIKey_HappyPathReturnsInstallationAndKey(t *testing.T) {
 		return len(snap) == 1 && snap[0] == "key_xyz"
 	}, 500*time.Millisecond, 10*time.Millisecond,
 		"VerifyAPIKey must asynchronously call MarkUsed with the matched key id")
+}
+
+// The dashboard gates first-run onboarding on the installation-level stamp
+// rather than a key's last_used_at, precisely so rotating the key that served
+// the first request can't reset it. That only holds if verifying a routing key
+// actually stamps the installation.
+func TestService_VerifyAPIKey_StampsInstallationFirstRequestServed(t *testing.T) {
+	rawToken := "rk_first_request_token_for_test"
+	keyHash := auth.HashAPIKeySHA256(rawToken)
+
+	install := &auth.Installation{ID: "install_onboard", ExternalID: "org_acme", Name: "prod"}
+	key := &auth.APIKey{
+		ID:             "key_onboard",
+		InstallationID: install.ID,
+		KeyHash:        keyHash,
+		Scope:          auth.ScopeRouting,
+	}
+
+	svc, _, installations := makeServiceWithInstallations(t, fakeKeyRow{apiKey: key, installation: install})
+
+	_, _, _, _, err := svc.VerifyAPIKey(context.Background(), rawToken)
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool {
+		return installations.firstRequestServedCount("install_onboard") == 1
+	}, 500*time.Millisecond, 10*time.Millisecond,
+		"a routed request must stamp the installation's first_request_served_at")
+}
+
+// An analytics export is not a routed request, so reading it must not mark the
+// installation as having served traffic — otherwise pulling the export on a
+// fresh deploy would skip the user past onboarding they never completed.
+func TestService_VerifyAnalyticsKey_DoesNotStampFirstRequestServed(t *testing.T) {
+	rawToken := "ra_analytics_token_for_test"
+	keyHash := auth.HashAPIKeySHA256(rawToken)
+
+	install := &auth.Installation{ID: "install_analytics", ExternalID: "org_acme", Name: "prod"}
+	key := &auth.APIKey{
+		ID:             "key_analytics",
+		InstallationID: install.ID,
+		KeyHash:        keyHash,
+		Scope:          auth.ScopeAnalyticsRead,
+	}
+
+	svc, apiKeys, installations := makeServiceWithInstallations(t, fakeKeyRow{apiKey: key, installation: install})
+
+	_, _, err := svc.VerifyAnalyticsAPIKey(context.Background(), rawToken)
+	require.NoError(t, err)
+
+	// Wait for the async MarkUsed to land, so the assertion below observes the
+	// completed goroutine rather than racing ahead of it.
+	require.Eventually(t, func() bool {
+		return len(apiKeys.markUsedSnapshot()) == 1
+	}, 500*time.Millisecond, 10*time.Millisecond)
+
+	assert.Zero(t, installations.firstRequestServedCount("install_analytics"),
+		"reading the analytics export must not mark the installation as having served a request")
 }
 
 func TestService_VerifyAPIKey_RecoversFromMarkUsedPanic(t *testing.T) {

--- a/internal/postgres/converters.go
+++ b/internal/postgres/converters.go
@@ -54,6 +54,7 @@ func toAuthInstallation(row sqlc.RouterModelRouterInstallation) *auth.Installati
 		ByokEnabled:                  row.ByokEnabled,
 		ContentCaptureMode:           row.ContentCaptureMode,
 		HideTerminalSurfaces:         row.HideTerminalSurfaces,
+		FirstRequestServedAt:         timestamptzPtr(row.FirstRequestServedAt),
 	}
 }
 
@@ -82,6 +83,14 @@ func timestampOrZero(t pgtype.Timestamp) time.Time {
 }
 
 func timestampPtr(t pgtype.Timestamp) *time.Time {
+	if !t.Valid {
+		return nil
+	}
+	out := t.Time
+	return &out
+}
+
+func timestamptzPtr(t pgtype.Timestamptz) *time.Time {
 	if !t.Valid {
 		return nil
 	}

--- a/internal/postgres/repository.go
+++ b/internal/postgres/repository.go
@@ -98,6 +98,15 @@ func (r *installationRepo) SoftDelete(ctx context.Context, externalID, id string
 	})
 }
 
+func (r *installationRepo) MarkFirstRequestServed(ctx context.Context, id string) error {
+	parsed, err := uuid.Parse(id)
+	if err != nil {
+		return err
+	}
+	q := sqlc.New(r.tx)
+	return q.MarkModelRouterInstallationFirstRequestServed(ctx, parsed)
+}
+
 func (r *installationRepo) UpdateExcludedModels(ctx context.Context, externalID, id string, models []string) error {
 	parsed, err := uuid.Parse(id)
 	if err != nil {

--- a/internal/server/middleware/auth_test.go
+++ b/internal/server/middleware/auth_test.go
@@ -110,6 +110,10 @@ func (fakeInstallationRepository) SoftDelete(ctx context.Context, externalID, id
 	return errors.New("not used")
 }
 
+func (fakeInstallationRepository) MarkFirstRequestServed(ctx context.Context, id string) error {
+	return nil
+}
+
 func (fakeInstallationRepository) UpdateExcludedModels(ctx context.Context, externalID, id string, models []string) error {
 	return errors.New("not used")
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -159,6 +159,7 @@ func Register(engine *gin.Engine, authSvc *auth.Service, proxySvc *proxy.Service
 		mgmt.PUT("/provider-keys/:id/model-aliases", admin.UpdateExternalKeyAliasesHandler(authSvc, deployedModels))
 		mgmt.DELETE("/provider-keys/:id", admin.DeleteExternalKeyHandler(authSvc))
 		mgmt.GET("/config", admin.ConfigHandler)
+		mgmt.GET("/onboarding", admin.OnboardingHandler(authSvc))
 		mgmt.GET("/routing-preferences", admin.GetRoutingPreferencesHandler(authSvc))
 		mgmt.PUT("/routing-preferences", admin.UpdateRoutingPreferencesHandler(authSvc))
 		mgmt.GET("/content-capture", admin.GetContentCaptureHandler(authSvc, proxySvc))

--- a/internal/sqlc/model_router_api_keys.sql.go
+++ b/internal/sqlc/model_router_api_keys.sql.go
@@ -102,7 +102,7 @@ func (q *Queries) CreateModelRouterAPIKey(ctx context.Context, arg CreateModelRo
 }
 
 const getActiveModelRouterAPIKeyWithInstallationByHash = `-- name: GetActiveModelRouterAPIKeyWithInstallationByHash :one
-SELECT k.id, k.installation_id, k.external_id, k.name, k.key_prefix, k.key_hash, k.key_suffix, k.last_used_at, k.created_at, k.deleted_at, k.created_by, k.spend_cap_usd_micros, k.spent_usd_micros, k.scope, i.id, i.external_id, i.name, i.created_at, i.updated_at, i.deleted_at, i.created_by, i.excluded_models, i.excluded_providers, i.routing_quality_weight, i.usage_bypass_enabled, i.usage_bypass_threshold, i.preferred_models, i.subscription_routing_disabled, i.routing_strategy, i.routing_rollout_id, i.policy_shadow_strategy, i.policy_debug_enabled, i.policy_header_overrides_enabled, i.policy_routing_intent, i.ai_training_allowed, i.byok_enabled, i.content_capture_mode, i.hide_terminal_surfaces, i.allowed_models
+SELECT k.id, k.installation_id, k.external_id, k.name, k.key_prefix, k.key_hash, k.key_suffix, k.last_used_at, k.created_at, k.deleted_at, k.created_by, k.spend_cap_usd_micros, k.spent_usd_micros, k.scope, i.id, i.external_id, i.name, i.created_at, i.updated_at, i.deleted_at, i.created_by, i.excluded_models, i.excluded_providers, i.routing_quality_weight, i.usage_bypass_enabled, i.usage_bypass_threshold, i.preferred_models, i.subscription_routing_disabled, i.routing_strategy, i.routing_rollout_id, i.policy_shadow_strategy, i.policy_debug_enabled, i.policy_header_overrides_enabled, i.policy_routing_intent, i.ai_training_allowed, i.byok_enabled, i.content_capture_mode, i.hide_terminal_surfaces, i.allowed_models, i.first_request_served_at
 FROM router.model_router_api_keys k
 INNER JOIN router.model_router_installations i ON i.id = k.installation_id
 WHERE k.key_hash = $1::varchar
@@ -121,7 +121,7 @@ type GetActiveModelRouterAPIKeyWithInstallationByHashRow struct {
 // both sides so a soft-deleted installation invalidates all its keys without per-key
 // updates.
 //
-//	SELECT k.id, k.installation_id, k.external_id, k.name, k.key_prefix, k.key_hash, k.key_suffix, k.last_used_at, k.created_at, k.deleted_at, k.created_by, k.spend_cap_usd_micros, k.spent_usd_micros, k.scope, i.id, i.external_id, i.name, i.created_at, i.updated_at, i.deleted_at, i.created_by, i.excluded_models, i.excluded_providers, i.routing_quality_weight, i.usage_bypass_enabled, i.usage_bypass_threshold, i.preferred_models, i.subscription_routing_disabled, i.routing_strategy, i.routing_rollout_id, i.policy_shadow_strategy, i.policy_debug_enabled, i.policy_header_overrides_enabled, i.policy_routing_intent, i.ai_training_allowed, i.byok_enabled, i.content_capture_mode, i.hide_terminal_surfaces, i.allowed_models
+//	SELECT k.id, k.installation_id, k.external_id, k.name, k.key_prefix, k.key_hash, k.key_suffix, k.last_used_at, k.created_at, k.deleted_at, k.created_by, k.spend_cap_usd_micros, k.spent_usd_micros, k.scope, i.id, i.external_id, i.name, i.created_at, i.updated_at, i.deleted_at, i.created_by, i.excluded_models, i.excluded_providers, i.routing_quality_weight, i.usage_bypass_enabled, i.usage_bypass_threshold, i.preferred_models, i.subscription_routing_disabled, i.routing_strategy, i.routing_rollout_id, i.policy_shadow_strategy, i.policy_debug_enabled, i.policy_header_overrides_enabled, i.policy_routing_intent, i.ai_training_allowed, i.byok_enabled, i.content_capture_mode, i.hide_terminal_surfaces, i.allowed_models, i.first_request_served_at
 //	FROM router.model_router_api_keys k
 //	INNER JOIN router.model_router_installations i ON i.id = k.installation_id
 //	WHERE k.key_hash = $1::varchar
@@ -170,6 +170,7 @@ func (q *Queries) GetActiveModelRouterAPIKeyWithInstallationByHash(ctx context.C
 		&i.RouterModelRouterInstallation.ContentCaptureMode,
 		&i.RouterModelRouterInstallation.HideTerminalSurfaces,
 		&i.RouterModelRouterInstallation.AllowedModels,
+		&i.RouterModelRouterInstallation.FirstRequestServedAt,
 	)
 	return i, err
 }

--- a/internal/sqlc/model_router_installations.sql.go
+++ b/internal/sqlc/model_router_installations.sql.go
@@ -22,7 +22,7 @@ VALUES (
     $2::varchar,
     $3
 )
-RETURNING id, external_id, name, created_at, updated_at, deleted_at, created_by, excluded_models, excluded_providers, routing_quality_weight, usage_bypass_enabled, usage_bypass_threshold, preferred_models, subscription_routing_disabled, routing_strategy, routing_rollout_id, policy_shadow_strategy, policy_debug_enabled, policy_header_overrides_enabled, policy_routing_intent, ai_training_allowed, byok_enabled, content_capture_mode, hide_terminal_surfaces, allowed_models
+RETURNING id, external_id, name, created_at, updated_at, deleted_at, created_by, excluded_models, excluded_providers, routing_quality_weight, usage_bypass_enabled, usage_bypass_threshold, preferred_models, subscription_routing_disabled, routing_strategy, routing_rollout_id, policy_shadow_strategy, policy_debug_enabled, policy_header_overrides_enabled, policy_routing_intent, ai_training_allowed, byok_enabled, content_capture_mode, hide_terminal_surfaces, allowed_models, first_request_served_at
 `
 
 type CreateModelRouterInstallationParams struct {
@@ -43,7 +43,7 @@ type CreateModelRouterInstallationParams struct {
 //	    $2::varchar,
 //	    $3
 //	)
-//	RETURNING id, external_id, name, created_at, updated_at, deleted_at, created_by, excluded_models, excluded_providers, routing_quality_weight, usage_bypass_enabled, usage_bypass_threshold, preferred_models, subscription_routing_disabled, routing_strategy, routing_rollout_id, policy_shadow_strategy, policy_debug_enabled, policy_header_overrides_enabled, policy_routing_intent, ai_training_allowed, byok_enabled, content_capture_mode, hide_terminal_surfaces, allowed_models
+//	RETURNING id, external_id, name, created_at, updated_at, deleted_at, created_by, excluded_models, excluded_providers, routing_quality_weight, usage_bypass_enabled, usage_bypass_threshold, preferred_models, subscription_routing_disabled, routing_strategy, routing_rollout_id, policy_shadow_strategy, policy_debug_enabled, policy_header_overrides_enabled, policy_routing_intent, ai_training_allowed, byok_enabled, content_capture_mode, hide_terminal_surfaces, allowed_models, first_request_served_at
 func (q *Queries) CreateModelRouterInstallation(ctx context.Context, arg CreateModelRouterInstallationParams) (RouterModelRouterInstallation, error) {
 	row := q.db.QueryRow(ctx, createModelRouterInstallation, arg.ExternalID, arg.Name, arg.CreatedBy)
 	var i RouterModelRouterInstallation
@@ -73,12 +73,13 @@ func (q *Queries) CreateModelRouterInstallation(ctx context.Context, arg CreateM
 		&i.ContentCaptureMode,
 		&i.HideTerminalSurfaces,
 		&i.AllowedModels,
+		&i.FirstRequestServedAt,
 	)
 	return i, err
 }
 
 const getModelRouterInstallation = `-- name: GetModelRouterInstallation :one
-SELECT id, external_id, name, created_at, updated_at, deleted_at, created_by, excluded_models, excluded_providers, routing_quality_weight, usage_bypass_enabled, usage_bypass_threshold, preferred_models, subscription_routing_disabled, routing_strategy, routing_rollout_id, policy_shadow_strategy, policy_debug_enabled, policy_header_overrides_enabled, policy_routing_intent, ai_training_allowed, byok_enabled, content_capture_mode, hide_terminal_surfaces, allowed_models
+SELECT id, external_id, name, created_at, updated_at, deleted_at, created_by, excluded_models, excluded_providers, routing_quality_weight, usage_bypass_enabled, usage_bypass_threshold, preferred_models, subscription_routing_disabled, routing_strategy, routing_rollout_id, policy_shadow_strategy, policy_debug_enabled, policy_header_overrides_enabled, policy_routing_intent, ai_training_allowed, byok_enabled, content_capture_mode, hide_terminal_surfaces, allowed_models, first_request_served_at
 FROM router.model_router_installations
 WHERE id = $1::uuid
   AND external_id = $2::varchar
@@ -92,7 +93,7 @@ type GetModelRouterInstallationParams struct {
 
 // Gets an installation by id, scoped to an external_id to prevent cross-tenant access.
 //
-//	SELECT id, external_id, name, created_at, updated_at, deleted_at, created_by, excluded_models, excluded_providers, routing_quality_weight, usage_bypass_enabled, usage_bypass_threshold, preferred_models, subscription_routing_disabled, routing_strategy, routing_rollout_id, policy_shadow_strategy, policy_debug_enabled, policy_header_overrides_enabled, policy_routing_intent, ai_training_allowed, byok_enabled, content_capture_mode, hide_terminal_surfaces, allowed_models
+//	SELECT id, external_id, name, created_at, updated_at, deleted_at, created_by, excluded_models, excluded_providers, routing_quality_weight, usage_bypass_enabled, usage_bypass_threshold, preferred_models, subscription_routing_disabled, routing_strategy, routing_rollout_id, policy_shadow_strategy, policy_debug_enabled, policy_header_overrides_enabled, policy_routing_intent, ai_training_allowed, byok_enabled, content_capture_mode, hide_terminal_surfaces, allowed_models, first_request_served_at
 //	FROM router.model_router_installations
 //	WHERE id = $1::uuid
 //	  AND external_id = $2::varchar
@@ -126,12 +127,13 @@ func (q *Queries) GetModelRouterInstallation(ctx context.Context, arg GetModelRo
 		&i.ContentCaptureMode,
 		&i.HideTerminalSurfaces,
 		&i.AllowedModels,
+		&i.FirstRequestServedAt,
 	)
 	return i, err
 }
 
 const listModelRouterInstallationsForExternalID = `-- name: ListModelRouterInstallationsForExternalID :many
-SELECT id, external_id, name, created_at, updated_at, deleted_at, created_by, excluded_models, excluded_providers, routing_quality_weight, usage_bypass_enabled, usage_bypass_threshold, preferred_models, subscription_routing_disabled, routing_strategy, routing_rollout_id, policy_shadow_strategy, policy_debug_enabled, policy_header_overrides_enabled, policy_routing_intent, ai_training_allowed, byok_enabled, content_capture_mode, hide_terminal_surfaces, allowed_models
+SELECT id, external_id, name, created_at, updated_at, deleted_at, created_by, excluded_models, excluded_providers, routing_quality_weight, usage_bypass_enabled, usage_bypass_threshold, preferred_models, subscription_routing_disabled, routing_strategy, routing_rollout_id, policy_shadow_strategy, policy_debug_enabled, policy_header_overrides_enabled, policy_routing_intent, ai_training_allowed, byok_enabled, content_capture_mode, hide_terminal_surfaces, allowed_models, first_request_served_at
 FROM router.model_router_installations
 WHERE external_id = $1::varchar
   AND deleted_at IS NULL
@@ -140,7 +142,7 @@ ORDER BY created_at DESC
 
 // ListModelRouterInstallationsForExternalID
 //
-//	SELECT id, external_id, name, created_at, updated_at, deleted_at, created_by, excluded_models, excluded_providers, routing_quality_weight, usage_bypass_enabled, usage_bypass_threshold, preferred_models, subscription_routing_disabled, routing_strategy, routing_rollout_id, policy_shadow_strategy, policy_debug_enabled, policy_header_overrides_enabled, policy_routing_intent, ai_training_allowed, byok_enabled, content_capture_mode, hide_terminal_surfaces, allowed_models
+//	SELECT id, external_id, name, created_at, updated_at, deleted_at, created_by, excluded_models, excluded_providers, routing_quality_weight, usage_bypass_enabled, usage_bypass_threshold, preferred_models, subscription_routing_disabled, routing_strategy, routing_rollout_id, policy_shadow_strategy, policy_debug_enabled, policy_header_overrides_enabled, policy_routing_intent, ai_training_allowed, byok_enabled, content_capture_mode, hide_terminal_surfaces, allowed_models, first_request_served_at
 //	FROM router.model_router_installations
 //	WHERE external_id = $1::varchar
 //	  AND deleted_at IS NULL
@@ -180,6 +182,7 @@ func (q *Queries) ListModelRouterInstallationsForExternalID(ctx context.Context,
 			&i.ContentCaptureMode,
 			&i.HideTerminalSurfaces,
 			&i.AllowedModels,
+			&i.FirstRequestServedAt,
 		); err != nil {
 			return nil, err
 		}
@@ -189,6 +192,28 @@ func (q *Queries) ListModelRouterInstallationsForExternalID(ctx context.Context,
 		return nil, err
 	}
 	return items, nil
+}
+
+const markModelRouterInstallationFirstRequestServed = `-- name: MarkModelRouterInstallationFirstRequestServed :exec
+UPDATE router.model_router_installations
+SET first_request_served_at = NOW()
+WHERE id = $1::uuid
+  AND deleted_at IS NULL
+  AND first_request_served_at IS NULL
+`
+
+// Stamps first_request_served_at the first time this installation routes a
+// request. WHERE IS NULL makes the update a no-op after the first write, so
+// the timestamp records the *first* request and rotation never resets it.
+//
+//	UPDATE router.model_router_installations
+//	SET first_request_served_at = NOW()
+//	WHERE id = $1::uuid
+//	  AND deleted_at IS NULL
+//	  AND first_request_served_at IS NULL
+func (q *Queries) MarkModelRouterInstallationFirstRequestServed(ctx context.Context, id uuid.UUID) error {
+	_, err := q.db.Exec(ctx, markModelRouterInstallationFirstRequestServed, id)
+	return err
 }
 
 const softDeleteModelRouterInstallation = `-- name: SoftDeleteModelRouterInstallation :exec

--- a/internal/sqlc/models.go
+++ b/internal/sqlc/models.go
@@ -124,6 +124,8 @@ type RouterModelRouterInstallation struct {
 	HideTerminalSurfaces bool
 	// Org-level positive model allowlist. Empty = no restriction. Effective set = allowed_models minus excluded_models. Fail-closed: an allowlist with no eligible overlap refuses the turn.
 	AllowedModels []string
+	// Timestamp of the installation's first routed request. Monotonic — never moves backwards or clears on key rotation.
+	FirstRequestServedAt pgtype.Timestamptz
 }
 
 type RouterModelRouterRequestTelemetry struct {


### PR DESCRIPTION
## Why

Two rough edges in the self-hosted dashboard, both about the gap between "I have a key" and "my agent is actually routing":

1. **A fresh install landed on six empty charts.** Nothing told a new self-hoster what to do next.
2. **Issuing a key handed back a bare token.** The reveal banner showed the token and nothing else — no install command, no indication of which harness it applies to. The token is useless until a harness is pointed at the router, and the page never said how.

## What changed

**First-run onboarding** (`RouterOnboarding.tsx`), mirroring the hosted dashboard so both surfaces teach the same mental model — one decision per screen:

`issue a key` → `pick a harness` → `personal vs team` → `copy the command` → idle until the first request lands, then hand off to the dashboard on its own.

The gate for "onboarded" is **has served a request** (`last_used_at` on a routing key), not "has a key" — a key alone doesn't mean any harness was ever configured. A failed probe falls through to the dashboard rather than trapping an established install in onboarding.

**Key reveal now leads with the harness choice.** Harness tabs on top, then the single command to run, with the token above it. Dropped the endpoint block and the uninstall section from the reveal — neither is what you need in the ten seconds after minting a credential. Analytics (`ra_`) keys skip the installer block entirely, since they have nothing to install. Rotate carries the rotated key's scope rather than whatever the create form happens to show.

**Self-hosted correctness:** the install command is derived from the browser's origin and always passes `--base-url` explicitly. `install.sh` otherwise falls back to the hosted endpoint, so a self-hosted deployment could have handed out a command that silently routed traffic off-box.

Harnesses offered: Claude Code, Codex, pi (each with user + project scope).

Also gitignores `frontend/out/` — the static export was landing as untracked build output, since the existing `*.out` pattern only matches files.

## Validation

- `go vet ./...` — clean
- `wv mr tc`, `wv mr t` — pass
- `npx tsc --noEmit` (frontend) — clean
- `npm run build` — static export succeeds, all 7 routes prerender

`next lint` in this repo drops into an interactive config prompt (never set up), so the build + tsc are the enforceable checks.

🤖 Generated with [Weave Router](https://router.workweave.ai)