### PR TITLE
fix(catalog): correct served context windows; feat(proxy): emit x-router-context-window

### DIFF
--- a/internal/proxy/fallback.go
+++ b/internal/proxy/fallback.go
@@ -233,6 +233,7 @@ func (s *Service) dispatchWithFallback(ctx context.Context, in failoverInputs) (
 				// Refresh: decision.Model can change on baseline failover, so
 				// x-router-model must never name a model that didn't serve.
 				in.w.Header().Set(HeaderRouterModel, decision.Model)
+				in.w.Header().Set(HeaderRouterContextWindow, strconv.Itoa(contextWindowForRequest(decision.Model)))
 				if i > 0 {
 					in.w.Header().Set(HeaderRouterFallbackFrom, in.bindings[0].Provider)
 					in.w.Header().Set(HeaderRouterFallbackAttempt, attemptIdxLabel(i))

--- a/internal/proxy/gemini.go
+++ b/internal/proxy/gemini.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"strconv"
 	"time"
 
 	"workweave/router/internal/observability"
@@ -138,6 +139,7 @@ func (s *Service) ProxyGeminiGenerateContent(ctx context.Context, body []byte, w
 	w.Header().Set(HeaderRouterDecision, decision.Reason)
 	w.Header().Set(HeaderRouterProvider, decision.Provider)
 	w.Header().Set(HeaderRouterModel, decision.Model)
+	w.Header().Set(HeaderRouterContextWindow, strconv.Itoa(contextWindowForRequest(decision.Model)))
 	// Gemini path does not resolve a router user, matching the decision span
 	// below which omits router_user_id.
 	s.setFeedbackLinkHeader(ctx, w, installationID, externalID, requestID, "")

--- a/internal/proxy/headers.go
+++ b/internal/proxy/headers.go
@@ -11,6 +11,10 @@ const (
 	HeaderRouterProvider = "x-router-provider"
 	// HeaderRouterModel carries the model that served the turn.
 	HeaderRouterModel = "x-router-model"
+	// HeaderRouterContextWindow carries the effective context window (tokens)
+	// of the model that served the turn, so window-aware clients (pi) can budget
+	// auto-compaction against the served model rather than the requested one.
+	HeaderRouterContextWindow = "x-router-context-window"
 	// HeaderRouterCache reports semantic-cache status; value is RouterCacheHit
 	// on a cache hit and the header is omitted otherwise.
 	HeaderRouterCache = "x-router-cache"

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -10,6 +10,7 @@ import (
 	"math"
 	"net/http"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -1744,13 +1745,14 @@ const semanticCacheMaxBodyBytes = 1 << 20
 // no telemetry row to back a feedback page, so the link is omitted on hits
 // entirely — the skip here guards against ever replaying the cached one.
 var headersToSkipOnHit = map[string]struct{}{
-	"Request-Id":            {},
-	"X-Request-Id":          {},
-	"X-Router-Decision":     {},
-	"X-Router-Provider":     {},
-	"X-Router-Model":        {},
-	"X-Router-Cache":        {},
-	"X-Router-Feedback-Url": {},
+	"Request-Id":              {},
+	"X-Request-Id":            {},
+	"X-Router-Decision":       {},
+	"X-Router-Provider":       {},
+	"X-Router-Model":          {},
+	"X-Router-Context-Window": {},
+	"X-Router-Cache":          {},
+	"X-Router-Feedback-Url":   {},
 }
 
 // cloneCacheHeaders snapshots a header set for storage, dropping transient
@@ -1781,6 +1783,7 @@ func (s *Service) writeCachedResponse(w http.ResponseWriter, resp cache.CachedRe
 	w.Header().Set(HeaderRouterDecision, decision.Reason)
 	w.Header().Set(HeaderRouterProvider, decision.Provider)
 	w.Header().Set(HeaderRouterModel, decision.Model)
+	w.Header().Set(HeaderRouterContextWindow, strconv.Itoa(contextWindowForRequest(decision.Model)))
 	w.Header().Set(HeaderRouterCache, RouterCacheHit)
 	if resp.StatusCode != 0 && resp.StatusCode != http.StatusOK {
 		w.WriteHeader(resp.StatusCode)
@@ -2760,6 +2763,7 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 	w.Header().Set(HeaderRouterDecision, decision.Reason)
 	w.Header().Set(HeaderRouterProvider, decision.Provider)
 	w.Header().Set(HeaderRouterModel, decision.Model)
+	w.Header().Set(HeaderRouterContextWindow, strconv.Itoa(contextWindowForRequest(decision.Model)))
 	if !agentShadowMode {
 		s.setFeedbackLinkHeader(ctx, w, installationID, externalID, requestID, auth.UserIDFrom(ctx))
 	}
@@ -5026,6 +5030,7 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 	w.Header().Set(HeaderRouterDecision, decision.Reason)
 	w.Header().Set(HeaderRouterProvider, decision.Provider)
 	w.Header().Set(HeaderRouterModel, decision.Model)
+	w.Header().Set(HeaderRouterContextWindow, strconv.Itoa(contextWindowForRequest(decision.Model)))
 	s.setFeedbackLinkHeader(ctx, w, installationID, externalID, requestID, auth.UserIDFrom(ctx))
 
 	reqPricing := otel.Lookup(s.baselineFor(feats.Model))

--- a/internal/proxy/service_test.go
+++ b/internal/proxy/service_test.go
@@ -205,6 +205,9 @@ func TestService_AgentShadowEvaluationForcesEphemerallyWithoutServingRouter(t *t
 	assert.Contains(t, string(provider.proxyBodies[0]), "old-result-0")
 	assert.NotContains(t, string(provider.proxyBodies[0]), "stale-signature")
 	assert.Equal(t, "claude-opus-4-8", rec.Header().Get(proxy.HeaderRouterModel))
+	// claude-opus-4-8 is CapExtendedContext, so the served context window header
+	// reports the effective 1M window clients should budget against.
+	assert.Equal(t, "1000000", rec.Header().Get(proxy.HeaderRouterContextWindow))
 	assert.Equal(t, providers.ProviderAnthropic, rec.Header().Get(proxy.HeaderRouterProvider))
 	assert.Equal(t, proxy.ReasonAgentShadowEval, rec.Header().Get(proxy.HeaderRouterDecision))
 	assert.Never(t, func() bool {
@@ -251,6 +254,8 @@ func TestService_AgentShadowEvaluationNeverSubstitutesRequestedBaseline(t *testi
 	assert.NotEmpty(t, openAIProvider.proxyBodies, "the planned candidate must be attempted")
 	assert.Empty(t, anthropicProvider.proxyBodies, "eval forcing must never dispatch the request baseline")
 	assert.Equal(t, "gpt-5.5", rec.Header().Get(proxy.HeaderRouterModel))
+	// gpt-5.5 is not CapExtendedContext, so the header carries its catalog window.
+	assert.Equal(t, "1050000", rec.Header().Get(proxy.HeaderRouterContextWindow))
 }
 
 func TestService_AgentShadowEvaluationNeverRetriesSubscriptionOnDeploymentKey(t *testing.T) {

--- a/internal/proxy/usage_bypass.go
+++ b/internal/proxy/usage_bypass.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"strconv"
 	"time"
 
 	"github.com/google/uuid"
@@ -264,6 +265,7 @@ func (s *Service) bypassToAnthropic(
 	w.Header().Set(HeaderRouterDecision, decision.Reason)
 	w.Header().Set(HeaderRouterProvider, decision.Provider)
 	w.Header().Set(HeaderRouterModel, decision.Model)
+	w.Header().Set(HeaderRouterContextWindow, strconv.Itoa(contextWindowForRequest(decision.Model)))
 
 	p, provErr := s.provider(providers.ProviderAnthropic)
 	if provErr != nil {

--- a/internal/router/catalog/catalog.go
+++ b/internal/router/catalog/catalog.go
@@ -291,7 +291,11 @@ var Models = []Model{
 	}},
 
 	// --- OpenAI GPT-5.4 ---
-	{ID: "gpt-5.4-nano", Tier: TierMid, ContextWindow: 1_000_000, Providers: []ProviderBinding{
+	// gpt-5.4-nano serves a 400K window (OpenRouter listing + direct-OpenAI
+	// capacity), not 1M — overstating lets the overflow pre-filter route a
+	// >400K request onto a model that hard-400s upstream. gpt-5.4/-mini share
+	// the family's 400K ceiling.
+	{ID: "gpt-5.4-nano", Tier: TierMid, ContextWindow: 400_000, Providers: []ProviderBinding{
 		{Provider: providers.ProviderOpenAI, Price: Pricing{InputUSDPer1M: 0.20, OutputUSDPer1M: 1.25, CacheReadMultiplier: 0.10}},
 	}},
 	{ID: "gpt-5.4-mini", Tier: TierMid, ContextWindow: 400_000, Providers: []ProviderBinding{
@@ -530,10 +534,11 @@ var Models = []Model{
 			Price: Pricing{InputUSDPer1M: 1.400, OutputUSDPer1M: 4.400, CacheReadMultiplier: 0.26 / 1.40}},
 		{Provider: providers.ProviderOpenRouter, Price: Pricing{InputUSDPer1M: 0.980, OutputUSDPer1M: 3.080, CacheReadMultiplier: 0.18 / 0.98}},
 	}},
-	// ContextWindow held at glm-family 202_752 pending confirmation of the
-	// Fireworks served window — overstating triggers hard 400s (cf. the
-	// minimax 1M->204800 incident).
-	{ID: "z-ai/glm-5.2", Tier: TierHigh, ContextWindow: 202_752, ImageInput: ImageInputUnsupported, Providers: []ProviderBinding{
+	// ContextWindow 1_048_576 confirmed from OpenRouter (context_length) and
+	// Fireworks serving manifest (1_048_575) — the earlier 202_752 was held
+	// pending that confirmation (cf. the minimax 1M->204800 incident, which is
+	// the risk if a served cap is overstated, not understated).
+	{ID: "z-ai/glm-5.2", Tier: TierHigh, ContextWindow: 1_048_576, ImageInput: ImageInputUnsupported, Providers: []ProviderBinding{
 		// Together leads: #1 AA throughput (~382 t/s vs Fireworks ~347) at the
 		// same $1.40/$4.40 price.
 		{Provider: providers.ProviderTogether, UpstreamID: "zai-org/GLM-5.2",
@@ -566,8 +571,9 @@ var Models = []Model{
 			Price: Pricing{InputUSDPer1M: 0.400, OutputUSDPer1M: 1.600, CacheReadMultiplier: 0.20}},
 	}},
 	// Fireworks-only: SOC-2 compliance; OpenRouter's/Together's routes forward to
-	// Alibaba/DashScope. Context 262_144 is Fireworks' native limit (not Alibaba's 1M).
-	{ID: "qwen/qwen3.8-max", Tier: TierHigh, ContextWindow: 262_144, Providers: []ProviderBinding{
+	// Alibaba/DashScope. Served window 1M confirmed on OpenRouter (context_length
+	// 1_000_000) and the model's own 1M capability; Fireworks serves the full 1M.
+	{ID: "qwen/qwen3.8-max", Tier: TierHigh, ContextWindow: 1_000_000, Providers: []ProviderBinding{
 		{Provider: providers.ProviderFireworks, UpstreamID: "accounts/fireworks/models/qwen3p8-max",
 			Price: Pricing{InputUSDPer1M: 2.000, OutputUSDPer1M: 6.000, CacheReadMultiplier: 0.125}},
 	}},

--- a/internal/router/catalog/catalog_test.go
+++ b/internal/router/catalog/catalog_test.go
@@ -275,6 +275,8 @@ func TestContextWindowFor_KnownModels(t *testing.T) {
 	// GPT-5 family has large context windows.
 	assert.Equal(t, 400_000, ContextWindowFor("gpt-5"))
 	assert.Equal(t, 1_000_000, ContextWindowFor("gpt-5.4"))
+	// gpt-5.4-nano serves a 400K window (OpenRouter + direct-OpenAI), not 1M.
+	assert.Equal(t, 400_000, ContextWindowFor("gpt-5.4-nano"))
 	assert.Equal(t, 1_050_000, ContextWindowFor("gpt-5.5"))
 	assert.Equal(t, 1_050_000, ContextWindowFor("gpt-5.6-sol"))
 	assert.Equal(t, 1_050_000, ContextWindowFor("gpt-5.6-terra"))
@@ -288,8 +290,11 @@ func TestContextWindowFor_KnownModels(t *testing.T) {
 	assert.Equal(t, 1_048_576, ContextWindowFor("deepseek/deepseek-v4-flash"))
 	// Most OSS models serve a 256K window (Qwen3 / Kimi families).
 	assert.Equal(t, 262_144, ContextWindowFor("moonshotai/kimi-k2.5"))
-	// GLM-5 serves ~200K (max_position_embeddings 202752); MiniMax M2.7 is 204800.
+	// GLM-5 serves ~200K (max_position_embeddings 202752); GLM-5.2 confirmed at 1M.
 	assert.Equal(t, 202_752, ContextWindowFor("z-ai/glm-5"))
+	assert.Equal(t, 1_048_576, ContextWindowFor("z-ai/glm-5.2"))
+	// qwen/qwen3.8-max is a 1M model (served window confirmed on OpenRouter).
+	assert.Equal(t, 1_000_000, ContextWindowFor("qwen/qwen3.8-max"))
 	assert.Equal(t, 204_800, ContextWindowFor("minimax/minimax-m2.7"))
 	// Unknown model falls back to DefaultContextWindow.
 	assert.Equal(t, DefaultContextWindow, ContextWindowFor("not-a-real-model"))


### PR DESCRIPTION
## Summary

Two problems surfaced together:

1. **The router catalog understated real served context windows** — `qwen/qwen3.8-max` was pinned at 262K even though OpenRouter/Fireworks serve it at 1M, and `z-ai/glm-5.2` was stuck at the glm-family 202K pending a confirmation that now exists (1M). Meanwhile `gpt-5.4-nano` was **overstated** at 1M when it serves 400K.
2. **Clients had no way to learn the served model's context window.** pi budgets auto-compaction and renders its status bar off the model it *requested* — but the router routinely serves a different (often larger-context) model. A session requesting `claude-sonnet-4-6` compacted at ~200K even while a 1M-context model served it.

This PR fixes the catalog values and adds a response header (`x-router-context-window`) so window-aware clients like pi can budget against the model that *actually served* the turn.

## Commits

### fix(catalog): correct served context windows for qwen3.8-max, glm-5.2, gpt-5.4-nano

- `qwen/qwen3.8-max`: `262_144` → `1_000_000`. OpenRouter lists `context_length` 1,000,000 and Fireworks serves the full window. The 262K value was causing the overflow pre-filter to exclude the session pin near ~199K tokens and telling clients a 256K budget.
- `z-ai/glm-5.2`: `202_752` → `1_048_576`. The comment explicitly held this at the glm-family value "pending confirmation of the Fireworks served window"; OpenRouter (1,048,576) and the Fireworks serving manifest (1,048,575) now confirm 1M.
- `gpt-5.4-nano`: `1_000_000` → `400_000`. OpenRouter and Azure both list 400K; the 1M figure risked routing >400K requests onto a model that hard-400s upstream.

### feat(proxy): emit x-router-context-window with the served model's effective window

- New `HeaderRouterContextWindow = "x-router-context-window"` contract header.
- Set alongside every `x-router-model` write site: `ProxyMessages`, `ProxyOpenAIChatCompletion`, Gemini generateContent, subscription usage-bypass, cached-response replays, and the per-attempt refresh inside `dispatchWithFallback` (so baseline failover rewrites it with the model that actually served).
- Value is `contextWindowForRequest(decision.Model)` — 1M for `CapExtendedContext` models, else the catalog window — so it matches what the router's own overflow pre-filter and compaction enforce.
- Added to `headersToSkipOnHit` so semantic-cache hits set it fresh from the live decision instead of replaying a stale cached value.

## Why the value matters

`contextWindowForRequest` already determines the overflow pre-filter, session-pin capacity, sibling failover, and server-side compaction. Publishing it as a response header gives clients the exact same number the router enforces — no new math, no new evaluation of the report, just the router's own operating window made visible.

## Design notes

- The header is set **before** streaming commits (the `preludeBuffer` mechanism guarantees all `x-router-*` header writes precede the first client byte), matching `x-router-model`.
- For `CapExtendedContext` models (Sonnet 4.6+, Opus 4.6+), the effective window is 1M because the proxy injects the `context-1m-2025-08-07` beta; the pre-filter already uses this same 1M figure.

## Tests

- `catalog_test.go`: updated assertions for the three corrected windows, plus new assertions for `z-ai/glm-5.2` (1M) and `qwen/qwen3.8-max` (1M).
- `service_test.go`: `ProxyMessages` now asserts `x-router-context-window` for both a `CapExtendedContext` model (claude-opus-4-8 → `1000000`) and a non-extended model (gpt-5.5 → `1050000`) on the streaming path.
- Full `go test ./internal/...` and `go build ./...` pass.

## Follow-up (not in this PR)

The pi consumer side (capture `x-router-model`/`x-router-context-window` and budget compaction + footer against the served model) lives in the pi codebase and ships separately.
