### PR TITLE
fix(proxy): accept dash-form spellings of qwen3.8-max in /force-model

### DIFF
--- a/internal/proxy/force_model.go
+++ b/internal/proxy/force_model.go
@@ -126,6 +126,10 @@ var forceModelAliases = map[string]string{
 	"qwen-max":     "qwen/qwen3.8-max",
 	"qwen3.8-max":  "qwen/qwen3.8-max",
 	"qwen3.8":      "qwen/qwen3.8-max",
+	// Dash-form spellings people type from memory; the catalog ID uses dots.
+	"qwen/qwen-3.8-max": "qwen/qwen3.8-max",
+	"qwen-3.8-max":      "qwen/qwen3.8-max",
+	"qwen-3.8":          "qwen/qwen3.8-max",
 	// Generic kimi alias stays on 2.7; k3 is ~3x the price, so it needs an
 	// explicit pin rather than silently repricing everyone on the family alias.
 	"kimi":      "moonshotai/kimi-k2.7",

--- a/internal/proxy/force_model_internal_test.go
+++ b/internal/proxy/force_model_internal_test.go
@@ -124,6 +124,34 @@ func TestResolveForceModel(t *testing.T) {
 			wantProvider: providers.ProviderFireworks,
 			wantKnown:    true,
 		},
+		{
+			name:         "canonical qwen3.8-max with vendor prefix",
+			input:        "qwen/qwen3.8-max",
+			wantID:       "qwen/qwen3.8-max",
+			wantProvider: providers.ProviderFireworks,
+			wantKnown:    true,
+		},
+		{
+			name:         "dash spelling qwen/qwen-3.8-max",
+			input:        "qwen/qwen-3.8-max",
+			wantID:       "qwen/qwen3.8-max",
+			wantProvider: providers.ProviderFireworks,
+			wantKnown:    true,
+		},
+		{
+			name:         "dash spelling qwen-3.8-max",
+			input:        "qwen-3.8-max",
+			wantID:       "qwen/qwen3.8-max",
+			wantProvider: providers.ProviderFireworks,
+			wantKnown:    true,
+		},
+		{
+			name:         "dash spelling qwen-3.8",
+			input:        "qwen-3.8",
+			wantID:       "qwen/qwen3.8-max",
+			wantProvider: providers.ProviderFireworks,
+			wantKnown:    true,
+		},
 		// Heuristic fallback: not in the catalog, so known is false. The
 		// provider is a best-effort guess for logging only; the handler rejects
 		// these rather than pinning a model with no known tier.


### PR DESCRIPTION
## Summary

The catalog ID for Qwen 3.8 Max is `qwen/qwen3.8-max` (dots — [catalog.go](internal/router/catalog/catalog.go#L576)), but users type the version with dashes from memory:

- `/force-model qwen/qwen-3.8-max`
- `/force-model qwen-3.8-max`
- `/force-model qwen-3.8`

None of those resolved before — they fell through `forceModelAliases`, missed the catalog, and were rejected as unknown models.

## Change

Add three dash-form aliases to `forceModelAliases` in [force_model.go](internal/proxy/force_model.go), all mapping to the canonical `qwen/qwen3.8-max`:

```go
// Dash-form spellings people type from memory; the catalog ID uses dots.
"qwen/qwen-3.8-max": "qwen/qwen3.8-max",
"qwen-3.8-max":      "qwen/qwen3.8-max",
"qwen-3.8":          "qwen/qwen3.8-max",
```

The canonical dotted forms (`qwen/qwen3.8-max`, `qwen3.8-max`, `qwen3.8`, `qwen-max`) already resolved via the catalog/aliases and are unchanged.

## Tests

Extended [force_model_internal_test.go](internal/proxy/force_model_internal_test.go) with four cases covering the canonical vendor-prefixed form and all three dash spellings — each expects `qwen/qwen3.8-max` / Fireworks / `known=true`. Full `./internal/proxy` package passes; `go build ./...` passes.
