### PR TITLE
feat(router): emit sidecar serving stats on the decision span

### DIFF
--- a/internal/policyclient/client.go
+++ b/internal/policyclient/client.go
@@ -372,13 +372,22 @@ type routeResponse struct {
 	Error                string                 `json:"error"`
 }
 
-// routeTimings is the sidecar's optional per-request latency breakdown.
-// Fields are nil (not zero) when the sidecar didn't measure that stage;
-// route_ms spans the whole decision and is a superset of the other stages.
+// routeTimings is the sidecar's optional per-request latency breakdown plus
+// serving stats. Fields are nil (not zero) when the sidecar didn't measure
+// that stage or report that stat; route_ms spans the whole decision and is a
+// superset of the other latency stages. The serving-stats fields are
+// independent of the latency stages: embed cache deltas are per-request
+// (present only when the embed stage ran) and the roster gauges are instance
+// snapshots, always present on stats-capable sidecars.
 type routeTimings struct {
-	RouteMs  *float64 `json:"route_ms"`
-	SelectMs *float64 `json:"select_ms"`
-	EmbedMs  *float64 `json:"embed_ms"`
+	RouteMs             *float64 `json:"route_ms"`
+	SelectMs            *float64 `json:"select_ms"`
+	EmbedMs             *float64 `json:"embed_ms"`
+	EmbedCacheHits      *int64   `json:"embed_cache_hits"`
+	EmbedCacheMisses    *int64   `json:"embed_cache_misses"`
+	EmbedCacheEvictions *int64   `json:"embed_cache_evictions"`
+	RoutesInflight      *int64   `json:"routes_inflight"`
+	OverrunsLive        *int64   `json:"overruns_live"`
 }
 
 // decomposeTimings converts sidecar wire timings into non-overlapping stages; nil when nothing was measured.
@@ -407,6 +416,26 @@ func floatOrZero(value *float64) float64 {
 		return 0
 	}
 	return *value
+}
+
+// extractServingStats reads the sidecar's serving stats from the same wire
+// payload as decomposeTimings, but separately: stats are exempt from the
+// route_ms consistency check that can drop the latency breakdown wholesale.
+func extractServingStats(wire *routeTimings) *router.SidecarServingStats {
+	if wire == nil {
+		return nil
+	}
+	if wire.EmbedCacheHits == nil && wire.EmbedCacheMisses == nil && wire.EmbedCacheEvictions == nil &&
+		wire.RoutesInflight == nil && wire.OverrunsLive == nil {
+		return nil
+	}
+	return &router.SidecarServingStats{
+		EmbedCacheHits:      wire.EmbedCacheHits,
+		EmbedCacheMisses:    wire.EmbedCacheMisses,
+		EmbedCacheEvictions: wire.EmbedCacheEvictions,
+		RoutesInflight:      wire.RoutesInflight,
+		OverrunsLive:        wire.OverrunsLive,
+	}
 }
 
 type previewResponse struct {
@@ -486,6 +515,7 @@ func (c *Client) Decide(ctx context.Context, query policy.Query) (policy.Result,
 		Debug:                parsed.Debug,
 		RankedFallback:       parsed.RankedFallback,
 		Timings:              decomposeTimings(parsed.Timings),
+		ServingStats:         extractServingStats(parsed.Timings),
 	}, nil
 }
 

--- a/internal/policyclient/client.go
+++ b/internal/policyclient/client.go
@@ -373,12 +373,8 @@ type routeResponse struct {
 }
 
 // routeTimings is the sidecar's optional per-request latency breakdown plus
-// serving stats. Fields are nil (not zero) when the sidecar didn't measure
-// that stage or report that stat; route_ms spans the whole decision and is a
-// superset of the other latency stages. The serving-stats fields are
-// independent of the latency stages: embed cache deltas are per-request
-// (present only when the embed stage ran) and the roster gauges are instance
-// snapshots, always present on stats-capable sidecars.
+// serving stats. Fields are nil (not zero) when not measured/reported;
+// route_ms spans the whole decision and is a superset of the other stages.
 type routeTimings struct {
 	RouteMs             *float64 `json:"route_ms"`
 	SelectMs            *float64 `json:"select_ms"`

--- a/internal/policyclient/client_test.go
+++ b/internal/policyclient/client_test.go
@@ -234,6 +234,76 @@ func TestClientDecideDropsTimingsWhenStagesExceedRouteMs(t *testing.T) {
 	assert.Nil(t, result.Timings, "an inconsistent breakdown must be dropped, not published with overlapping stages")
 }
 
+func TestClientDecidePopulatesServingStatsFromTimings(t *testing.T) {
+	result := decideWithTimings(t, &routeTimings{
+		RouteMs:             floatPtr(20),
+		SelectMs:            floatPtr(3.5),
+		EmbedMs:             floatPtr(12.5),
+		EmbedCacheHits:      int64Ptr(42),
+		EmbedCacheMisses:    int64Ptr(0),
+		EmbedCacheEvictions: int64Ptr(3),
+		RoutesInflight:      int64Ptr(7),
+		OverrunsLive:        int64Ptr(1),
+	})
+
+	require.NotNil(t, result.ServingStats)
+	require.NotNil(t, result.ServingStats.EmbedCacheHits)
+	require.NotNil(t, result.ServingStats.EmbedCacheMisses, "a measured zero must be preserved as present-0, not collapsed to nil")
+	require.NotNil(t, result.ServingStats.EmbedCacheEvictions)
+	require.NotNil(t, result.ServingStats.RoutesInflight)
+	require.NotNil(t, result.ServingStats.OverrunsLive)
+	assert.Equal(t, int64(42), *result.ServingStats.EmbedCacheHits)
+	assert.Equal(t, int64(0), *result.ServingStats.EmbedCacheMisses)
+	assert.Equal(t, int64(3), *result.ServingStats.EmbedCacheEvictions)
+	assert.Equal(t, int64(7), *result.ServingStats.RoutesInflight)
+	assert.Equal(t, int64(1), *result.ServingStats.OverrunsLive)
+}
+
+func TestClientDecideLeavesServingStatsNilWhenStatsAbsent(t *testing.T) {
+	result := decideWithTimings(t, &routeTimings{RouteMs: floatPtr(20), SelectMs: floatPtr(3.5), EmbedMs: floatPtr(12.5)})
+
+	assert.Nil(t, result.ServingStats, "a sidecar that only reports latency must not synthesize serving stats")
+}
+
+func TestClientDecideServingStatsSurviveUntrustedLatencyBreakdown(t *testing.T) {
+	result := decideWithTimings(t, &routeTimings{
+		RouteMs:             floatPtr(5),
+		SelectMs:            floatPtr(4),
+		EmbedMs:             floatPtr(3),
+		EmbedCacheHits:      int64Ptr(10),
+		EmbedCacheMisses:    int64Ptr(2),
+		EmbedCacheEvictions: int64Ptr(0),
+		RoutesInflight:      int64Ptr(5),
+		OverrunsLive:        int64Ptr(0),
+	})
+
+	assert.Nil(t, result.Timings, "an inconsistent breakdown must still be dropped")
+	require.NotNil(t, result.ServingStats, "stats live in a sibling struct precisely so the latency-consistency check can't drop them along with a distrusted breakdown")
+	require.NotNil(t, result.ServingStats.EmbedCacheHits)
+	require.NotNil(t, result.ServingStats.EmbedCacheMisses)
+	require.NotNil(t, result.ServingStats.EmbedCacheEvictions, "a measured zero must be preserved as present-0, not collapsed to nil")
+	require.NotNil(t, result.ServingStats.RoutesInflight)
+	require.NotNil(t, result.ServingStats.OverrunsLive, "a measured zero must be preserved as present-0, not collapsed to nil")
+	assert.Equal(t, int64(10), *result.ServingStats.EmbedCacheHits)
+	assert.Equal(t, int64(2), *result.ServingStats.EmbedCacheMisses)
+	assert.Equal(t, int64(0), *result.ServingStats.EmbedCacheEvictions)
+	assert.Equal(t, int64(5), *result.ServingStats.RoutesInflight)
+	assert.Equal(t, int64(0), *result.ServingStats.OverrunsLive)
+}
+
+func TestClientDecidePopulatesServingStatsWhenOnlyStatsReported(t *testing.T) {
+	result := decideWithTimings(t, &routeTimings{
+		EmbedCacheHits:      int64Ptr(1),
+		EmbedCacheMisses:    int64Ptr(1),
+		EmbedCacheEvictions: int64Ptr(1),
+		RoutesInflight:      int64Ptr(1),
+		OverrunsLive:        int64Ptr(1),
+	})
+
+	assert.Nil(t, result.Timings, "no latency fields were reported, so there is nothing for decomposeTimings to build")
+	assert.NotNil(t, result.ServingStats, "stats do not depend on any latency field being present")
+}
+
 func TestClientOmitsV2CandidateFieldsFromV1(t *testing.T) {
 	body, err := marshalRouteRequest(policy.Query{
 		SchemaVersion: policy.SchemaVersionV1,
@@ -712,3 +782,5 @@ func TestRouteMessagesPreservesLatestUserWhenPayloadIsCapped(t *testing.T) {
 func floatPtr(value float64) *float64 { return &value }
 
 func intPointer(value int) *int { return &value }
+
+func int64Ptr(value int64) *int64 { return &value }

--- a/internal/proxy/decision_span_sidecar_stats_test.go
+++ b/internal/proxy/decision_span_sidecar_stats_test.go
@@ -67,10 +67,8 @@ func TestDecisionSpan_SidecarStats_PresentZeroIsEmittedAsZero(t *testing.T) {
 	assert.Zero(t, misses)
 }
 
-// TestDecisionSpan_SidecarStats_Absent covers every shape of "not reported":
-// nil Metadata, nil SidecarStats, and a partially-populated SidecarStats where
-// only the set field ("routing.sidecar_inflight") must be present and every
-// other of the five attrs must be absent.
+// TestDecisionSpan_SidecarStats_Absent covers nil Metadata, nil SidecarStats,
+// and a partial SidecarStats (only the set field must appear).
 func TestDecisionSpan_SidecarStats_Absent(t *testing.T) {
 	allFiveKeys := []string{
 		"routing.embed_cache_hits",

--- a/internal/proxy/decision_span_sidecar_stats_test.go
+++ b/internal/proxy/decision_span_sidecar_stats_test.go
@@ -1,0 +1,170 @@
+package proxy
+
+import (
+	"testing"
+	"time"
+
+	"workweave/router/internal/providers"
+	"workweave/router/internal/router"
+	"workweave/router/internal/router/sessionpin"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func sidecarStatsInt64Ptr(v int64) *int64 { return &v }
+
+// TestDecisionSpan_SidecarStats_AllFivePresent pins that all five serving-stats
+// attrs carry their exact values, with no rounding/truncation across the boundary.
+func TestDecisionSpan_SidecarStats_AllFivePresent(t *testing.T) {
+	collector := newBypassSpanCollector(t)
+	svc := newEmbedTestService(t, collector, &embedTestRouter{metadata: &router.RoutingMetadata{SidecarStats: &router.SidecarServingStats{
+		EmbedCacheHits:      sidecarStatsInt64Ptr(1009),
+		EmbedCacheMisses:    sidecarStatsInt64Ptr(37),
+		EmbedCacheEvictions: sidecarStatsInt64Ptr(5),
+		RoutesInflight:      sidecarStatsInt64Ptr(3),
+		OverrunsLive:        sidecarStatsInt64Ptr(2),
+	}}}, nil)
+
+	sp := decisionSpanEmbed(t, svc, collector)
+
+	hits, hitsPresent := spanEmbedInt(sp, "routing.embed_cache_hits")
+	require.True(t, hitsPresent, "EmbedCacheHits must carry routing.embed_cache_hits")
+	assert.Equal(t, int64(1009), hits)
+
+	misses, missesPresent := spanEmbedInt(sp, "routing.embed_cache_misses")
+	require.True(t, missesPresent, "EmbedCacheMisses must carry routing.embed_cache_misses")
+	assert.Equal(t, int64(37), misses)
+
+	evictions, evictionsPresent := spanEmbedInt(sp, "routing.embed_cache_evictions")
+	require.True(t, evictionsPresent, "EmbedCacheEvictions must carry routing.embed_cache_evictions")
+	assert.Equal(t, int64(5), evictions)
+
+	inflight, inflightPresent := spanEmbedInt(sp, "routing.sidecar_inflight")
+	require.True(t, inflightPresent, "RoutesInflight must carry routing.sidecar_inflight")
+	assert.Equal(t, int64(3), inflight)
+
+	overruns, overrunsPresent := spanEmbedInt(sp, "routing.sidecar_overruns_live")
+	require.True(t, overrunsPresent, "OverrunsLive must carry routing.sidecar_overruns_live")
+	assert.Equal(t, int64(2), overruns)
+
+	_, routePresent := spanEmbedInt(sp, "latency.route_ms")
+	assert.True(t, routePresent, "the established route_ms attribute must stay present")
+}
+
+// TestDecisionSpan_SidecarStats_PresentZeroIsEmittedAsZero pins that a measured
+// zero (warm embed cache, no misses) is emitted as a PRESENT 0 — distinct from absence.
+func TestDecisionSpan_SidecarStats_PresentZeroIsEmittedAsZero(t *testing.T) {
+	collector := newBypassSpanCollector(t)
+	svc := newEmbedTestService(t, collector, &embedTestRouter{metadata: &router.RoutingMetadata{SidecarStats: &router.SidecarServingStats{
+		EmbedCacheMisses: sidecarStatsInt64Ptr(0),
+	}}}, nil)
+
+	sp := decisionSpanEmbed(t, svc, collector)
+
+	misses, present := spanEmbedInt(sp, "routing.embed_cache_misses")
+	require.True(t, present, "a measured zero miss count must still be emitted as a present 0, not dropped")
+	assert.Zero(t, misses)
+}
+
+// TestDecisionSpan_SidecarStats_Absent covers every shape of "not reported":
+// nil Metadata, nil SidecarStats, and a partially-populated SidecarStats where
+// only the set field ("routing.sidecar_inflight") must be present and every
+// other of the five attrs must be absent.
+func TestDecisionSpan_SidecarStats_Absent(t *testing.T) {
+	allFiveKeys := []string{
+		"routing.embed_cache_hits",
+		"routing.embed_cache_misses",
+		"routing.embed_cache_evictions",
+		"routing.sidecar_inflight",
+		"routing.sidecar_overruns_live",
+	}
+	for _, tc := range []struct {
+		name         string
+		metadata     *router.RoutingMetadata
+		presentKey   string
+		presentValue int64
+	}{
+		{name: "nil metadata", metadata: nil},
+		{name: "metadata without sidecar stats", metadata: &router.RoutingMetadata{}},
+		{
+			name: "sidecar stats with only inflight set",
+			metadata: &router.RoutingMetadata{SidecarStats: &router.SidecarServingStats{
+				RoutesInflight: sidecarStatsInt64Ptr(4),
+			}},
+			presentKey:   "routing.sidecar_inflight",
+			presentValue: 4,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			collector := newBypassSpanCollector(t)
+			svc := newEmbedTestService(t, collector, &embedTestRouter{metadata: tc.metadata}, nil)
+
+			sp := decisionSpanEmbed(t, svc, collector)
+
+			for _, key := range allFiveKeys {
+				if key == tc.presentKey {
+					got, present := spanEmbedInt(sp, key)
+					require.True(t, present, "%s was explicitly set and must be present", key)
+					assert.Equal(t, tc.presentValue, got)
+					continue
+				}
+				_, present := spanEmbedInt(sp, key)
+				assert.False(t, present, "%s was never set and must not be emitted", key)
+			}
+
+			_, routePresent := spanEmbedInt(sp, "latency.route_ms")
+			assert.True(t, routePresent, "the span must still carry latency.route_ms regardless of sidecar stats")
+		})
+	}
+}
+
+// TestDecisionSpan_SidecarStats_EmittedWhenTimingsNil guards the independence
+// of the two Metadata guards: a nil SidecarTimings must not suppress SidecarStats.
+func TestDecisionSpan_SidecarStats_EmittedWhenTimingsNil(t *testing.T) {
+	collector := newBypassSpanCollector(t)
+	svc := newEmbedTestService(t, collector, &embedTestRouter{metadata: &router.RoutingMetadata{
+		SidecarTimings: nil,
+		SidecarStats: &router.SidecarServingStats{
+			EmbedCacheHits: sidecarStatsInt64Ptr(11),
+		},
+	}}, nil)
+
+	sp := decisionSpanEmbed(t, svc, collector)
+
+	hits, hitsPresent := spanEmbedInt(sp, "routing.embed_cache_hits")
+	require.True(t, hitsPresent, "SidecarStats must be emitted even when SidecarTimings is nil — the two guards are independent")
+	assert.Equal(t, int64(11), hits)
+
+	_, embedMsPresent := spanEmbedInt(sp, "latency.embed_ms")
+	assert.False(t, embedMsPresent, "nil SidecarTimings must not fabricate latency.embed_ms")
+}
+
+// TestDecisionSpan_SidecarStats_SurvivesPlannerStay mirrors
+// TestDecisionSpan_EmbedMs_SurvivesPlannerStay: a STAY turn replaces the served
+// decision with a pin (nil Metadata), so stats must come from Fresh, not Served.
+func TestDecisionSpan_SidecarStats_SurvivesPlannerStay(t *testing.T) {
+	collector := newBypassSpanCollector(t)
+	store := newStubPinStore()
+	store.getFound = true
+	store.getPin = sessionpin.Pin{
+		Provider:    providers.ProviderAnthropic,
+		Model:       "claude-haiku-4-5",
+		Reason:      "cluster",
+		PinnedUntil: time.Now().Add(time.Hour),
+	}
+	svc := newEmbedTestService(t, collector, &embedTestRouter{metadata: &router.RoutingMetadata{SidecarStats: &router.SidecarServingStats{
+		EmbedCacheHits:   sidecarStatsInt64Ptr(21),
+		EmbedCacheMisses: sidecarStatsInt64Ptr(0),
+	}}}, store)
+
+	sp := decisionSpanEmbed(t, svc, collector)
+
+	require.Equal(t, "stay", spanStr(t, sp, "planner.outcome"), "pin must be served via a planner STAY for this test to pin anything")
+	hits, hitsPresent := spanEmbedInt(sp, "routing.embed_cache_hits")
+	require.True(t, hitsPresent, "a STAY turn still ran the sidecar this turn — dropping stats undercounts serving load on sticky sessions")
+	assert.Equal(t, int64(21), hits)
+	misses, missesPresent := spanEmbedInt(sp, "routing.embed_cache_misses")
+	require.True(t, missesPresent, "a present zero must survive STAY the same as a present non-zero")
+	assert.Zero(t, misses)
+}

--- a/internal/proxy/gemini.go
+++ b/internal/proxy/gemini.go
@@ -144,7 +144,7 @@ func (s *Service) ProxyGeminiGenerateContent(ctx context.Context, body []byte, w
 
 	reqPricing := otel.Lookup(s.baselineFor(feats.Model))
 	actPricing := otel.Lookup(decision.Model)
-	geminiDecisionBuilder := otel.NewAttrBuilder(40).
+	geminiDecisionBuilder := otel.NewAttrBuilder(45).
 		String("request_id", requestID).
 		String("external_id", externalID).
 		String("client.device_id", clientID.DeviceID).
@@ -169,7 +169,7 @@ func (s *Service) ProxyGeminiGenerateContent(ctx context.Context, body []byte, w
 		Float64("catalog.actual_input_per_1m", actPricing.InputUSDPer1M).
 		Float64("catalog.actual_output_per_1m", actPricing.OutputUSDPer1M).
 		Int64("latency.route_ms", routeMs)
-	applySidecarLatencyAttrs(geminiDecisionBuilder, routeRes)
+	applySidecarAttrs(geminiDecisionBuilder, routeRes)
 	applyPlannerAttrs(geminiDecisionBuilder, routeRes)
 	applyRoutingStateAttrs(geminiDecisionBuilder, routeRes, decision.Model, sessionKey)
 	otel.Record(ctx, otel.Span{

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -2770,7 +2770,7 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 
 	reqPricing := otel.Lookup(s.baselineFor(feats.Model))
 	actPricing := otel.Lookup(decision.Model)
-	decisionBuilder := otel.NewAttrBuilder(40).
+	decisionBuilder := otel.NewAttrBuilder(45).
 		String("request_id", requestID).
 		String("external_id", externalID).
 		String("router_user_id", auth.UserIDFrom(ctx)).
@@ -2797,7 +2797,7 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 		Float64("catalog.actual_input_per_1m", actPricing.InputUSDPer1M).
 		Float64("catalog.actual_output_per_1m", actPricing.OutputUSDPer1M).
 		Int64("latency.route_ms", routeMs)
-	applySidecarLatencyAttrs(decisionBuilder, routeRes)
+	applySidecarAttrs(decisionBuilder, routeRes)
 	applyPlannerAttrs(decisionBuilder, routeRes)
 	applyRoutingStateAttrs(decisionBuilder, routeRes, decision.Model, sessionKey)
 	otel.Record(ctx, otel.Span{
@@ -3701,21 +3701,41 @@ func plannerOutcome(outcome planner.Outcome) string {
 	return "stay"
 }
 
-// applySidecarLatencyAttrs reads Fresh.Metadata, not the served decision:
+// applySidecarAttrs reads Fresh.Metadata, not the served decision:
 // STAY replaces the decision with a pin (nil Metadata) even when the sidecar ran this turn.
-func applySidecarLatencyAttrs(b *otel.AttrBuilder, res turnLoopResult) *otel.AttrBuilder {
-	if res.Fresh.Metadata == nil || res.Fresh.Metadata.SidecarTimings == nil {
+// Timings and serving stats are independent, separately-nilable payloads on the same
+// Metadata, so each gets its own guard below.
+func applySidecarAttrs(b *otel.AttrBuilder, res turnLoopResult) *otel.AttrBuilder {
+	if res.Fresh.Metadata == nil {
 		return b
 	}
-	st := res.Fresh.Metadata.SidecarTimings
-	if st.EmbedMs != nil {
-		b.Int64("latency.embed_ms", int64(math.Round(*st.EmbedMs)))
+	if st := res.Fresh.Metadata.SidecarTimings; st != nil {
+		if st.EmbedMs != nil {
+			b.Int64("latency.embed_ms", int64(math.Round(*st.EmbedMs)))
+		}
+		if st.SelectMs != nil {
+			b.Int64("latency.sidecar_select_ms", int64(math.Round(*st.SelectMs)))
+		}
+		if st.OtherMs != nil {
+			b.Int64("latency.sidecar_other_ms", int64(math.Round(*st.OtherMs)))
+		}
 	}
-	if st.SelectMs != nil {
-		b.Int64("latency.sidecar_select_ms", int64(math.Round(*st.SelectMs)))
-	}
-	if st.OtherMs != nil {
-		b.Int64("latency.sidecar_other_ms", int64(math.Round(*st.OtherMs)))
+	if ss := res.Fresh.Metadata.SidecarStats; ss != nil {
+		if ss.EmbedCacheHits != nil {
+			b.Int64("routing.embed_cache_hits", *ss.EmbedCacheHits)
+		}
+		if ss.EmbedCacheMisses != nil {
+			b.Int64("routing.embed_cache_misses", *ss.EmbedCacheMisses)
+		}
+		if ss.EmbedCacheEvictions != nil {
+			b.Int64("routing.embed_cache_evictions", *ss.EmbedCacheEvictions)
+		}
+		if ss.RoutesInflight != nil {
+			b.Int64("routing.sidecar_inflight", *ss.RoutesInflight)
+		}
+		if ss.OverrunsLive != nil {
+			b.Int64("routing.sidecar_overruns_live", *ss.OverrunsLive)
+		}
 	}
 	return b
 }
@@ -5030,7 +5050,7 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 
 	reqPricing := otel.Lookup(s.baselineFor(feats.Model))
 	actPricing := otel.Lookup(decision.Model)
-	openaiDecisionBuilder := otel.NewAttrBuilder(40).
+	openaiDecisionBuilder := otel.NewAttrBuilder(45).
 		String("request_id", requestID).
 		String("external_id", externalID).
 		String("router_user_id", auth.UserIDFrom(ctx)).
@@ -5057,7 +5077,7 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 		Float64("catalog.actual_input_per_1m", actPricing.InputUSDPer1M).
 		Float64("catalog.actual_output_per_1m", actPricing.OutputUSDPer1M).
 		Int64("latency.route_ms", routeMs)
-	applySidecarLatencyAttrs(openaiDecisionBuilder, routeRes)
+	applySidecarAttrs(openaiDecisionBuilder, routeRes)
 	applyPlannerAttrs(openaiDecisionBuilder, routeRes)
 	applyRoutingStateAttrs(openaiDecisionBuilder, routeRes, decision.Model, sessionKey)
 	otel.Record(ctx, otel.Span{

--- a/internal/router/policy/contract.go
+++ b/internal/router/policy/contract.go
@@ -110,7 +110,10 @@ type Result struct {
 	PolicyArtifactSHA256 string
 	// Timings is the sidecar's per-stage decision cost decomposed into
 	// non-overlapping stages; nil when the sidecar reported no timings.
-	Timings       *router.SidecarTimings
+	Timings *router.SidecarTimings
+	// ServingStats is the sidecar's serving stats passed through verbatim;
+	// nil when the sidecar reported none.
+	ServingStats  *router.SidecarServingStats
 	RosterVersion string
 	DebugRef      string
 	Debug         map[string]interface{}

--- a/internal/router/policy/sidecar_router.go
+++ b/internal/router/policy/sidecar_router.go
@@ -430,6 +430,7 @@ func (r *SidecarRouter) Route(ctx context.Context, req router.Request) (router.D
 			PolicyArtifactSHA256:          res.PolicyArtifactSHA256,
 			RosterVersion:                 res.RosterVersion,
 			SidecarTimings:                res.Timings,
+			SidecarStats:                  res.ServingStats,
 			SelectedArmID:                 binding.ArmID,
 			SidecarSchemaVersion:          res.SchemaVersion,
 			DebugRef:                      debugRef,

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -270,7 +270,10 @@ type RoutingMetadata struct {
 	RosterVersion        string
 	// SidecarTimings is set only on fresh sidecar decisions; never persist
 	// into pins or a replayed pin re-emits a stale measurement.
-	SidecarTimings       *SidecarTimings
+	SidecarTimings *SidecarTimings
+	// SidecarStats is set only on fresh sidecar decisions; never persist
+	// into pins or a replayed pin re-emits a stale measurement.
+	SidecarStats         *SidecarServingStats
 	SelectedArmID        string
 	SelectedUpstreamID   string
 	BindingIndex         int
@@ -316,6 +319,18 @@ type SidecarTimings struct {
 	EmbedMs  *float64 // embedding round trip
 	SelectMs *float64 // arm selection
 	OtherMs  *float64 // remainder of the sidecar's route handler
+}
+
+// SidecarServingStats holds per-decision serving stats sampled by the
+// sidecar: per-request embed-cache deltas (present only when the embed
+// stage ran) and instance gauges. A nil field was not reported by the
+// sidecar; present 0 is a measured zero and must be preserved as such.
+type SidecarServingStats struct {
+	EmbedCacheHits      *int64
+	EmbedCacheMisses    *int64
+	EmbedCacheEvictions *int64
+	RoutesInflight      *int64
+	OverrunsLive        *int64
 }
 
 type Router interface {


### PR DESCRIPTION
## Summary

The HMM policy sidecar reports per-decision serving stats in its `/route` response `timings` dict — embed-cache hit/miss/eviction deltas plus `routes_inflight` / `overruns_live` gauge snapshots — but `policyclient` only deserialized the three latency stages, so the stats were silently dropped and never reached telemetry.

- **`internal/policyclient`**: extend the `routeTimings` wire struct with the five stats keys and add `extractServingStats`, kept separate from `decomposeTimings` on purpose — stats are exempt from the `route_ms` consistency check that can drop the latency breakdown wholesale (`other < 0`, or no latency fields at all).
- **`internal/router` / `internal/router/policy`**: new `SidecarServingStats` sibling struct carried on `policy.Result.ServingStats` and `RoutingMetadata.SidecarStats`. Same conventions as `SidecarTimings`: pointer fields, nil = not reported, present 0 = measured zero; set only on fresh sidecar decisions so pins never replay stale gauges.
- **`internal/proxy`**: `applySidecarLatencyAttrs` → `applySidecarAttrs` with independent guards for timings vs stats, emitting five new `router.decision` span attributes exactly (no rounding): `routing.embed_cache_hits`, `routing.embed_cache_misses`, `routing.embed_cache_evictions`, `routing.sidecar_inflight`, `routing.sidecar_overruns_live`. All three endpoints (Anthropic/OpenAI/Gemini) pick this up through the shared apply function; the three decision `AttrBuilder` size hints go 40 → 45.

Additive JSON only — an older sidecar that omits the keys yields nil fields and no attributes (absence is distinct from a measured 0).

## Test plan

- 4 new `policyclient` tests: all-present (zero preserved as present-0), latency-only → nil stats, **stats survive an untrusted latency breakdown**, stats-only dict → `Timings` nil but stats populated.
- 5 new `internal/proxy` decision-span tests (existing embed-span harness): all five attrs with exact values, present-zero emitted as 0, absent shapes (nil metadata / nil stats / partial fields), stats independent of nil `SidecarTimings`, stats survive a planner STAY.
- `gofmt -l` clean, `go vet ./...` clean, full `go test ./...`: 49/49 packages ok.

🤖 Generated with [Weave Router](https://router.workweave.ai)
