### PR TITLE
feat(hmm): map bare xAI grok IDs to roster slugs

### DIFF
--- a/internal/router/hmm/hmm_test.go
+++ b/internal/router/hmm/hmm_test.go
@@ -206,9 +206,25 @@ func TestCatalogRoutingTargetsResolveCurrentHMMRosterArmsToProviders(t *testing.
 		"openai/gpt-5.6-terra",
 		"z-ai/glm-5.2",
 		"google/gemini-3.1-pro-preview",
+		"x-ai/grok-4.6",
 	} {
 		assert.Contains(t, gotRosterIDs, rosterID)
 	}
+}
+
+func TestRosterIDForMapsBareGrokIDsToXAIRosterSlugs(t *testing.T) {
+	grok46, ok := catalog.ByID("grok-4.6")
+	require.True(t, ok)
+	assert.Equal(t, "x-ai/grok-4.6", rosterIDFor(grok46))
+
+	grok45, ok := catalog.ByID("grok-4.5")
+	require.True(t, ok)
+	assert.Equal(t, "x-ai/grok-4.5", rosterIDFor(grok45))
+
+	// The reverse mapping must land on the bare catalog ID the dispatch path
+	// consumes, not echo the prefixed roster slug back.
+	assert.Equal(t, "grok-4.6", CatalogIDForRoster("x-ai/grok-4.6"))
+	assert.Equal(t, "grok-4.5", CatalogIDForRoster("x-ai/grok-4.5"))
 }
 
 func TestRouterOffersAndSelectsTerraWithoutLegacyDeployedSet(t *testing.T) {

--- a/internal/router/hmm/mapping.go
+++ b/internal/router/hmm/mapping.go
@@ -14,6 +14,12 @@ var rosterAliases = map[string]string{
 	"claude-opus-4-8":      "anthropic/claude-opus-4.8",
 	"claude-fable-5":       "anthropic/claude-fable-5",
 	"moonshotai/kimi-k2.7": "moonshotai/kimi-k2.7-code",
+	// Bare first-party xAI IDs have no provider prefix to inherit, and the
+	// switch below deliberately stays empty for them (a bare ID whose primary
+	// provider is a hosting platform would be ambiguous). An explicit alias is
+	// what makes an xAI-native model roster-addressable.
+	"grok-4.5": "x-ai/grok-4.5",
+	"grok-4.6": "x-ai/grok-4.6",
 }
 
 func rosterIDFor(m catalog.Model) string {

--- a/internal/router/hmm/roster_test.go
+++ b/internal/router/hmm/roster_test.go
@@ -17,6 +17,7 @@ func TestDeployedModelsForRosterIDs_MapsRosterSlugsToCatalogEntries(t *testing.T
 		"openai/gpt-5.6-sol",
 		"anthropic/claude-opus-4.8",
 		"deepseek/deepseek-v4-flash",
+		"x-ai/grok-4.6",
 	})
 
 	byModel := make(map[string]string, len(got))
@@ -26,6 +27,9 @@ func TestDeployedModelsForRosterIDs_MapsRosterSlugsToCatalogEntries(t *testing.T
 
 	assert.Equal(t, providers.ProviderOpenAI, byModel["gpt-5.6-sol"])
 	assert.Equal(t, providers.ProviderAnthropic, byModel["claude-opus-4-8"])
+	// Bare first-party xAI IDs map through an explicit roster alias; the
+	// provider is the native xAI binding.
+	assert.Equal(t, providers.ProviderXAI, byModel["grok-4.6"])
 	// OSS slugs already carry their provider prefix, so the roster_id equals
 	// the catalog ID; provider is whatever the catalog lists first.
 	require.Contains(t, byModel, "deepseek/deepseek-v4-flash")


### PR DESCRIPTION
grok-4.5/grok-4.6 are native-xAI catalog entries with bare IDs, so `rosterIDFor` returned `""` for them and `DeployedModelsForRosterIDs` silently dropped any `x-ai/*` roster arm. This adds explicit roster aliases (`grok-4.6` → `x-ai/grok-4.6`, `grok-4.5` → `x-ai/grok-4.5`) so an xAI-native model becomes roster-addressable.

Deliberately an alias rather than a `case providers.ProviderXAI` in the switch: bare IDs whose primary provider is a hosting platform (Fireworks/Bedrock/etc.) stay unmapped by design (`TestRosterIDForSkipsAmbiguousBareProviderIDs`), and only first-party xAI models get a roster slug.

Prereq for rostering `x-ai/grok-4.6` in the HMM five-cluster roster (high + maximum). No behavior change until a roster references the new slug.

Tests:
- `TestRosterIDForMapsBareGrokIDsToXAIRosterSlugs` — forward + reverse mapping round-trip
- Extended `TestCatalogRoutingTargetsResolveCurrentHMMRosterArmsToProviders` — `x-ai/grok-4.6` now resolves as a candidate when XAI is registered
- Extended `TestDeployedModelsForRosterIDs_MapsRosterSlugsToCatalogEntries` — slug → bare catalog ID + xai provider

```
go build ./... && go test ./internal/...   # green
```

🤖 Generated with [Weave Router](https://router.workweave.ai)