### PR TITLE
fix(translate): add qwen/qwen3.8-max output-token cap (32768)

### DIFF
--- a/internal/translate/default_max_tokens_test.go
+++ b/internal/translate/default_max_tokens_test.go
@@ -178,3 +178,22 @@ func TestOpenAISameFormat_ExplicitMaxTokensClampsToKimiK3Ceiling(t *testing.T) {
 	out := parseAndEmit(t, body, "openai", opts)
 	assert.Equal(t, float64(32000), out["max_tokens"])
 }
+
+// Regression: qwen/qwen3.8-max was absent from modelMaxOutputTokens, so a
+// Claude Code turn requesting max_tokens=64000 was clamped to the 8192
+// fallback. Qwen3-Max serves 32k output on Fireworks (qwen3p8-max); every
+// agentic turn ended in finish_reason=length and an auto-resume loop until
+// the client surfaced "response exceeded the 64000 output token maximum".
+func TestOpenAISameFormat_ExplicitMaxTokensClampsToQwen38MaxCeiling(t *testing.T) {
+	body := []byte(`{"model":"gpt-4o","messages":[{"role":"user","content":"hi"}],"max_tokens":64000}`)
+	opts := translate.EmitOptions{
+		TargetModel:  "qwen/qwen3.8-max",
+		Capabilities: router.Lookup("qwen/qwen3.8-max"),
+	}
+	out := parseAndEmit(t, body, "openai", opts)
+	assert.Equal(t, float64(32768), out["max_tokens"])
+
+	body = []byte(`{"model":"gpt-4o","messages":[{"role":"user","content":"hi"}],"max_tokens":16384}`)
+	out = parseAndEmit(t, body, "openai", opts)
+	assert.Equal(t, float64(16384), out["max_tokens"])
+}

--- a/internal/translate/envelope.go
+++ b/internal/translate/envelope.go
@@ -1201,6 +1201,10 @@ var modelMaxOutputTokens = map[string]int{
 	// Keyed by full catalog ID, since decision.Model keeps the vendor prefix.
 	// Other OSS rows are still absent and so inherit the 8192 fallback.
 	"moonshotai/kimi-k3": 131072,
+	// Qwen3-Max family serves 32k output on Fireworks (qwen3p8-max). Without
+	// this entry a Claude Code max_tokens=64000 turn was clamped to the 8192
+	// fallback and truncated every agentic turn (finish_reason=length loop).
+	"qwen/qwen3.8-max": 32768,
 }
 
 const defaultMaxOutputTokenCap = 8192


### PR DESCRIPTION
## Incident

Prod Claude Code session `5842e58e-0d13-4901-addd-8afb5b31965d` (2026-08-20 ~22:10Z) got a 👎 with:

> API Error: Claude's response exceeded the 64000 output token maximum. To configure this behavior, set the CLAUDE_CODE_MAX_OUTPUT_TOKENS environment variable.

Router telemetry shows the client requested `claude-opus-5` with max_tokens=64000; the HMM policy routed to `qwen/qwen3.8-max` on Fireworks (`hmm_policy(... fallback to 'high'; AA Agentic Index roster arm 'qwen/qwen3.8-max' (harness='claude_code', rank=1, eligible=4/4))`). Both observed turns came back truncated:

- `resp_output_tokens` ≈ 2913 / 2957, `upstream_finish_reason: length`, `resp_stop_reason: max_tokens`
- next request carried Claude Code's auto-continue prompt ("Output token limit hit. Resume directly…") — a truncate→resume loop until the client errored.

## Root cause

`qwen/qwen3.8-max` was onboarded in #907 and promoted to `high` as claude_code's rank-1 arm, but has no `modelMaxOutputTokens` entry, so the emit layer clamps the client's 64000 → `defaultMaxOutputTokenCap` = **8192**. Qwen3-Max thinking consumes most of that budget, leaving ~2.9k visible tokens per turn.

## Fix

Add `"qwen/qwen3.8-max": 32768` (Qwen3-Max family output ceiling on Fireworks' `qwen3p8-max`; adjust if the model card states otherwise). Same bug class as the kimi-k3 entry — regression test mirrors `TestOpenAISameFormat_ExplicitMaxTokensClampsToKimiK3Ceiling` and covers both the over-cap clamp (64000 → 32768) and under-cap passthrough (16384 unchanged). Verified red without the map entry, green with it; full `go test ./internal/translate/` passes.

## Follow-up (not in this PR)

Other rostered OSS arms still inherit the 8192 fallback: `deepseek/deepseek-v4-pro` (medium), `deepseek/deepseek-v4-flash` + `minimax/minimax-m3` (low). Their real ceilings need verification before adding entries — same silent-truncation risk applies.