### PR TITLE
fix(pi-router): serve real context windows in footer and compaction budget

### DIFF
--- a/install/install.sh
+++ b/install/install.sh
@@ -828,8 +828,8 @@ write_pi_models_config() {
       models: [
         { id: "claude-fable-5",    name: "Claude Fable 5 (via Weave Router)",    reasoning: true, input: ["text","image"], contextWindow: 1000000, maxTokens: 128000 },
         { id: "claude-opus-5",     name: "Claude Opus 5 (via Weave Router)",     reasoning: true, input: ["text","image"], contextWindow: 1000000, maxTokens: 128000 },
-        { id: "claude-opus-4-7",   name: "Claude Opus 4.7 (via Weave Router)",   reasoning: true, input: ["text","image"], contextWindow: 200000, maxTokens: 64000 },
-        { id: "claude-sonnet-4-6", name: "Claude Sonnet 4.6 (via Weave Router)", reasoning: true, input: ["text","image"], contextWindow: 200000, maxTokens: 64000 },
+        { id: "claude-opus-4-7",   name: "Claude Opus 4.7 (via Weave Router)",   reasoning: true, input: ["text","image"], contextWindow: 1000000, maxTokens: 64000 },
+        { id: "claude-sonnet-4-6", name: "Claude Sonnet 4.6 (via Weave Router)", reasoning: true, input: ["text","image"], contextWindow: 1000000, maxTokens: 64000 },
         { id: "claude-haiku-4-5",  name: "Claude Haiku 4.5 (via Weave Router)",  reasoning: true, input: ["text","image"], contextWindow: 200000, maxTokens: 32000 },
         { id: "gpt-5.6-sol",       name: "GPT-5.6 Sol (via Weave Router)",       reasoning: true, input: ["text","image"], contextWindow: 1050000, maxTokens: 128000 },
         { id: "grok-4.5",          name: "Grok 4.5 (via Weave Router)",          reasoning: true, input: ["text","image"], contextWindow: 500000, maxTokens: 131072 },

--- a/install/pi-router/src/compaction.ts
+++ b/install/pi-router/src/compaction.ts
@@ -150,17 +150,16 @@ export function registerCompaction(pi: ExtensionAPI, schedule: Schedule = (callb
 		const registeredWindow = ctx.model?.contextWindow ?? ctx.getContextUsage()?.contextWindow ?? 0;
 		const contextWindow = servedContextWindow ?? registeredWindow;
 		if (contextWindow <= COMPACTION_RESERVE_TOKENS) return;
-		const threshold = contextWindow - COMPACTION_RESERVE_TOKENS;
+		const servedThreshold = contextWindow - COMPACTION_RESERVE_TOKENS;
+		const registeredThreshold = registeredWindow - COMPACTION_RESERVE_TOKENS;
 		// Pi's built-in check runs immediately after this event and budgets against
-		// the REGISTERED model window. Deferring the over-threshold final turn to Pi
-		// is only safe when Pi's window is no larger than ours (registered <= served):
-		// otherwise the router served a smaller window than Pi knows about, Pi would
-		// compact too late (or not at all) for our budget, and the session stays over
-		// the served limit. In that case we compact ourselves. Starting a manual
-		// compaction while Pi's async summary is in flight would race it, so we only
-		// race Pi when Pi will not make the call Pi owns.
-		if (registeredWindow <= contextWindow && lastTurnTokens > threshold) return;
-		if (!repairedContinuation && highWaterTokens <= threshold) return;
+		// the REGISTERED model window. If the final turn clears Pi's registered
+		// threshold, Pi will compact asynchronously — deferring is correct, and
+		// scheduling our own would race that async compaction. Otherwise Pi will not
+		// act, so we compact ourselves when the run crossed the SERVED threshold
+		// (which can be smaller than the registered window after a reroute).
+		if (lastTurnTokens > registeredThreshold) return;
+		if (!repairedContinuation && highWaterTokens <= servedThreshold) return;
 
 		compactionScheduled = true;
 		const previousCompactionId = latestCompactionId(ctx);

--- a/install/pi-router/src/compaction.ts
+++ b/install/pi-router/src/compaction.ts
@@ -21,6 +21,7 @@ import type {
 	TurnEndEvent,
 } from "@mariozechner/pi-coding-agent";
 import type { AssistantMessage } from "@mariozechner/pi-ai";
+import { ROUTED_CONTEXT_WINDOW_HEADER } from "./config.js";
 
 const PROBE_MAX_TOKENS = 4;
 const CONTINUATION_MAX_TOKENS = 16_384;
@@ -50,6 +51,19 @@ function containsToolResult(messages: unknown): boolean {
 		const content = (message as ProviderMessage).content;
 		return Array.isArray(content) && content.some((block: unknown) => isRecord(block) && block.type === "tool_result");
 	});
+}
+
+/**
+ * Parse the router-served context window header, rejecting absent, fractional,
+ * or out-of-range values. The header reflects what the router actually served
+ * for a request, which can differ from the requested model's registered window
+ * (reroutes to a smaller window, e.g. minimax-m2.7 204_800 or haiku 200_000).
+ */
+export function parseRoutedContextWindow(value: string | undefined): number | undefined {
+	if (!value) return undefined;
+	if (!/^[1-9]\d*$/.test(value)) return undefined;
+	const contextWindow = Number(value);
+	return Number.isSafeInteger(contextWindow) && contextWindow > 0 ? contextWindow : undefined;
 }
 
 /**
@@ -86,11 +100,20 @@ export function registerCompaction(pi: ExtensionAPI, schedule: Schedule = (callb
 	let lastTurnTokens = 0;
 	let repairedContinuation = false;
 	let compactionScheduled = false;
+	// Smallest served context window observed on a response this run. The router
+	// can reroute any request regardless of the requested model, so the served
+	// window is authoritative for the compaction budget. Tracking the minimum
+	// (not the latest or the max) is the conservative choice: if the router ever
+	// routed to a smaller window during the run, that window could clamp again,
+	// so the budget must respect it. Fall back to the registered model window
+	// until the first routed response.
+	let servedContextWindow: number | undefined;
 
 	const resetRun = () => {
 		highWaterTokens = 0;
 		lastTurnTokens = 0;
 		repairedContinuation = false;
+		servedContextWindow = undefined;
 	};
 
 	const finishCompaction = (ctx: ExtensionContext) => {
@@ -107,6 +130,15 @@ export function registerCompaction(pi: ExtensionAPI, schedule: Schedule = (callb
 		if (repairClampedToolContinuation(event.payload)) repairedContinuation = true;
 	});
 
+	pi.on("after_provider_response", (event, _ctx: ExtensionContext) => {
+		if (event.status < 200 || event.status >= 300) return;
+		const contextWindow = parseRoutedContextWindow(event.headers?.[ROUTED_CONTEXT_WINDOW_HEADER]);
+		if (contextWindow === undefined) return;
+		if (servedContextWindow === undefined || contextWindow < servedContextWindow) {
+			servedContextWindow = contextWindow;
+		}
+	});
+
 	pi.on("turn_end", (event: TurnEndEvent) => {
 		if (event.message.role !== "assistant") return;
 		lastTurnTokens = contextTokens(event.message as AssistantMessage);
@@ -115,7 +147,8 @@ export function registerCompaction(pi: ExtensionAPI, schedule: Schedule = (callb
 
 	pi.on("agent_end", (_event: AgentEndEvent, ctx: ExtensionContext) => {
 		if (process.env.WEAVE_PI_AUTO_COMPACTION === "0" || compactionScheduled) return;
-		const contextWindow = ctx.model?.contextWindow ?? ctx.getContextUsage()?.contextWindow ?? 0;
+		const contextWindow =
+			servedContextWindow ?? ctx.model?.contextWindow ?? ctx.getContextUsage()?.contextWindow ?? 0;
 		if (contextWindow <= COMPACTION_RESERVE_TOKENS) return;
 		const threshold = contextWindow - COMPACTION_RESERVE_TOKENS;
 		// Pi's built-in check runs immediately after this event and owns the

--- a/install/pi-router/src/compaction.ts
+++ b/install/pi-router/src/compaction.ts
@@ -147,14 +147,19 @@ export function registerCompaction(pi: ExtensionAPI, schedule: Schedule = (callb
 
 	pi.on("agent_end", (_event: AgentEndEvent, ctx: ExtensionContext) => {
 		if (process.env.WEAVE_PI_AUTO_COMPACTION === "0" || compactionScheduled) return;
-		const contextWindow =
-			servedContextWindow ?? ctx.model?.contextWindow ?? ctx.getContextUsage()?.contextWindow ?? 0;
+		const registeredWindow = ctx.model?.contextWindow ?? ctx.getContextUsage()?.contextWindow ?? 0;
+		const contextWindow = servedContextWindow ?? registeredWindow;
 		if (contextWindow <= COMPACTION_RESERVE_TOKENS) return;
 		const threshold = contextWindow - COMPACTION_RESERVE_TOKENS;
-		// Pi's built-in check runs immediately after this event and owns the
-		// ordinary final-turn threshold case. Starting another compaction while
-		// that async summary is in flight would race it.
-		if (lastTurnTokens > threshold) return;
+		// Pi's built-in check runs immediately after this event and budgets against
+		// the REGISTERED model window. Deferring the over-threshold final turn to Pi
+		// is only safe when Pi's window is no larger than ours (registered <= served):
+		// otherwise the router served a smaller window than Pi knows about, Pi would
+		// compact too late (or not at all) for our budget, and the session stays over
+		// the served limit. In that case we compact ourselves. Starting a manual
+		// compaction while Pi's async summary is in flight would race it, so we only
+		// race Pi when Pi will not make the call Pi owns.
+		if (registeredWindow <= contextWindow && lastTurnTokens > threshold) return;
 		if (!repairedContinuation && highWaterTokens <= threshold) return;
 
 		compactionScheduled = true;

--- a/install/pi-router/src/config.ts
+++ b/install/pi-router/src/config.ts
@@ -220,12 +220,17 @@ export function providerHeaders(role: Role, key: string): Record<string, string>
 // dispatched child (and a `pi -e` smoke test with no models.json) can still
 // resolve `weave/<model>`. The list mirrors the installer's headline models;
 // the router re-routes every request regardless, so this is a UX/label surface.
+// The context windows mirror the router's catalog for these models (see
+// internal/router/catalog) so the footer and auto-compaction budget reflect
+// what the router actually serves; per-request reroutes can still land on a
+// different window, which the served-window header reports on the response.
 export const WEAVE_MODELS: ProviderModelConfig[] = [
-	model("claude-opus-4-8", "Claude Opus 4.8 (via Weave Router)", 64000),
-	model("claude-opus-4-7", "Claude Opus 4.7 (via Weave Router)", 64000),
-	model("claude-sonnet-4-6", "Claude Sonnet 4.6 (via Weave Router)", 64000),
-	model("claude-haiku-4-5", "Claude Haiku 4.5 (via Weave Router)", 32000),
-	model("grok-4.6", "Grok 4.6 (via Weave Router)", 131072, 500000),
+	model("claude-opus-4-8", "Claude Opus 4.8 (via Weave Router)", 64000, 1_000_000),
+	model("claude-opus-4-7", "Claude Opus 4.7 (via Weave Router)", 64000, 1_000_000),
+	model("claude-sonnet-4-6", "Claude Sonnet 4.6 (via Weave Router)", 64000, 1_000_000),
+	model("claude-haiku-4-5", "Claude Haiku 4.5 (via Weave Router)", 32000, 200_000),
+	model("grok-4.6", "Grok 4.6 (via Weave Router)", 131072, 500_000),
+	model("qwen/qwen3.8-max", "Qwen 3.8 Max (via Weave Router)", 131072, 1_000_000),
 ];
 
 function model(id: string, name: string, maxTokens: number, contextWindow: number = 200000): ProviderModelConfig {
@@ -246,6 +251,8 @@ function model(id: string, name: string, maxTokens: number, contextWindow: numbe
 export const ROUTED_MODEL_HEADER = (process.env.WEAVE_ROUTED_MODEL_HEADER || "x-router-model").toLowerCase();
 export const ROUTED_PROVIDER_HEADER = "x-router-provider";
 export const ROUTER_DECISION_HEADER = "x-router-decision";
+/** Context window (tokens) of the model that actually served the routed response. */
+export const ROUTED_CONTEXT_WINDOW_HEADER = "x-router-context-window";
 /** Marker a headless child prints to stderr so the parent dispatch can read its routed model. */
 export const ROUTED_MODEL_STDERR_PREFIX = "weave-routed-model:";
 

--- a/install/pi-router/test/compaction.test.ts
+++ b/install/pi-router/test/compaction.test.ts
@@ -204,3 +204,21 @@ test("compacts itself when the final turn exceeds a smaller served window", () =
 
 	assert.equal(compactCalls(), 1);
 });
+
+test("defers to Pi when the final turn clears the registered threshold (no race)", () => {
+	// Registered window is 1M, served 200k, and the final turn (990k) clears Pi's
+	// registered threshold (983_616). Pi's built-in compaction will fire after
+	// agent_end, so scheduling our own would race it — the extension must defer.
+	const extension = extensionHarness((callback) => callback());
+	const { ctx, compactCalls } = contextHarness(1_000_000);
+	extension.emit("agent_start", { type: "agent_start" }, ctx);
+	extension.emit(
+		"after_provider_response",
+		{ type: "after_provider_response", status: 200, headers: { "x-router-context-window": "200000" } },
+		ctx,
+	);
+	extension.emit("turn_end", { type: "turn_end", message: assistant(990_000), toolResults: [] }, ctx);
+	extension.emit("agent_end", { type: "agent_end", messages: [] }, ctx);
+
+	assert.equal(compactCalls(), 0);
+});

--- a/install/pi-router/test/compaction.test.ts
+++ b/install/pi-router/test/compaction.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
-import { registerCompaction, repairClampedToolContinuation } from "../src/compaction.js";
+import { registerCompaction, parseRoutedContextWindow, repairClampedToolContinuation } from "../src/compaction.js";
 
 type CapturedHandler = (event: any, ctx: ExtensionContext) => unknown;
 
@@ -37,14 +37,14 @@ function assistant(totalTokens: number) {
 	};
 }
 
-function contextHarness() {
+function contextHarness(registeredWindow = 200_000) {
 	let compactCalls = 0;
 	let status: string | undefined;
 	const branch: any[] = [];
 	const ctx = {
 		hasUI: true,
-		model: { contextWindow: 200_000 },
-		getContextUsage: () => ({ tokens: 0, contextWindow: 200_000, percent: 0 }),
+		model: { contextWindow: registeredWindow },
+		getContextUsage: () => ({ tokens: 0, contextWindow: registeredWindow, percent: 0 }),
 		sessionManager: { getBranch: () => branch },
 		ui: {
 			setStatus(_key: string, value: string | undefined) {
@@ -122,4 +122,65 @@ test("leaves an over-threshold final turn to Pi's built-in compaction", () => {
 	extension.emit("agent_end", { type: "agent_end", messages: [] }, ctx);
 
 	assert.equal(compactCalls(), 0);
+});
+
+test("parseRoutedContextWindow accepts only sane positive integers", () => {
+	assert.equal(parseRoutedContextWindow(undefined), undefined);
+	assert.equal(parseRoutedContextWindow(""), undefined);
+	assert.equal(parseRoutedContextWindow("abc"), undefined);
+	assert.equal(parseRoutedContextWindow("1.5"), undefined);
+	assert.equal(parseRoutedContextWindow("0"), undefined);
+	assert.equal(parseRoutedContextWindow("200000"), 200_000);
+	assert.equal(parseRoutedContextWindow("1000000"), 1_000_000);
+});
+
+test("prefers the router-served context window so a large model does not compact early", () => {
+	// The registered virtual model window is 200k, but the router reports it
+	// served a 1M window. A tool loop well above the 200k threshold must not
+	// trigger the extension's manual compaction.
+	const extension = extensionHarness((callback) => callback());
+	const { ctx, compactCalls } = contextHarness();
+	extension.emit("agent_start", { type: "agent_start" }, ctx);
+	extension.emit(
+		"after_provider_response",
+		{ type: "after_provider_response", status: 200, headers: { "x-router-context-window": "1000000" } },
+		ctx,
+	);
+	extension.emit("turn_end", { type: "turn_end", message: assistant(300_000), toolResults: [] }, ctx);
+	extension.emit("turn_end", { type: "turn_end", message: assistant(150_000), toolResults: [] }, ctx);
+	extension.emit("agent_end", { type: "agent_end", messages: [] }, ctx);
+
+	assert.equal(compactCalls(), 0);
+});
+
+test("without a served-window header the registered model window still gates compaction", () => {
+	// Same run shape as above, but no served-window header: the registered 200k
+	// window is authoritative, so the run does early-compact.
+	const extension = extensionHarness((callback) => callback());
+	const { ctx, compactCalls } = contextHarness();
+	extension.emit("agent_start", { type: "agent_start" }, ctx);
+	extension.emit("turn_end", { type: "turn_end", message: assistant(300_000), toolResults: [] }, ctx);
+	extension.emit("turn_end", { type: "turn_end", message: assistant(150_000), toolResults: [] }, ctx);
+	extension.emit("agent_end", { type: "agent_end", messages: [] }, ctx);
+
+	assert.equal(compactCalls(), 1);
+});
+
+test("guards against a reroute to a smaller served context window", () => {
+	// The registered model window is 1M (a cap-extended opus/sonnet), but the
+	// router served responses from a 200k window (e.g. haiku or a small reroute).
+	// The run must compact at the served window, not the registered 1M.
+	const extension = extensionHarness((callback) => callback());
+	const { ctx, compactCalls } = contextHarness(1_000_000);
+	extension.emit("agent_start", { type: "agent_start" }, ctx);
+	extension.emit(
+		"after_provider_response",
+		{ type: "after_provider_response", status: 200, headers: { "x-router-context-window": "200000" } },
+		ctx,
+	);
+	extension.emit("turn_end", { type: "turn_end", message: assistant(250_000), toolResults: [] }, ctx);
+	extension.emit("turn_end", { type: "turn_end", message: assistant(100_000), toolResults: [] }, ctx);
+	extension.emit("agent_end", { type: "agent_end", messages: [] }, ctx);
+
+	assert.equal(compactCalls(), 1);
 });

--- a/install/pi-router/test/compaction.test.ts
+++ b/install/pi-router/test/compaction.test.ts
@@ -184,3 +184,23 @@ test("guards against a reroute to a smaller served context window", () => {
 
 	assert.equal(compactCalls(), 1);
 });
+
+test("compacts itself when the final turn exceeds a smaller served window", () => {
+	// Registered window is 1M, but the router served a 200k window. The final
+	// turn (250k) is above the served threshold (183_616) yet well below the
+	// registered 1M. Pi budgets against the registered window and would never
+	// compact here, so the extension must compact itself instead of deferring.
+	const extension = extensionHarness((callback) => callback());
+	const { ctx, compactCalls } = contextHarness(1_000_000);
+	extension.emit("agent_start", { type: "agent_start" }, ctx);
+	extension.emit(
+		"after_provider_response",
+		{ type: "after_provider_response", status: 200, headers: { "x-router-context-window": "200000" } },
+		ctx,
+	);
+	extension.emit("turn_end", { type: "turn_end", message: assistant(100_000), toolResults: [] }, ctx);
+	extension.emit("turn_end", { type: "turn_end", message: assistant(250_000), toolResults: [] }, ctx);
+	extension.emit("agent_end", { type: "agent_end", messages: [] }, ctx);
+
+	assert.equal(compactCalls(), 1);
+});

--- a/install/pi-router/test/e2e.sh
+++ b/install/pi-router/test/e2e.sh
@@ -133,9 +133,9 @@ phase "Phase 2 — generated pricing + savings contract"
 if with_timeout 30 env PI_CODING_AGENT_DIR="$PI_DIR" \
   pi -e "$UNIT_SUITE" --no-session --offline --model weave/claude-sonnet-4-6 \
   -p "Run the unit suite." >"$WORK/unit.out" 2>&1 </dev/null; then
-  [ "$(grep -Ec '^(✔ |ok [0-9]+ - )' "$WORK/unit.out" || true)" = "22" ] \
+  [ "$(grep -Ec '^(✔ |ok [0-9]+ - )' "$WORK/unit.out" || true)" = "26" ] \
     && ok "pricing, force-model, UI, and compaction unit suite passed" \
-    || bad "unit suite did not report all 22 passes (see $WORK/unit.out)"
+    || bad "unit suite did not report all 26 passes (see $WORK/unit.out)"
 else
   bad "unit suite failed to load through pi (see $WORK/unit.out)"
 fi

--- a/install/pi-router/test/e2e.sh
+++ b/install/pi-router/test/e2e.sh
@@ -133,9 +133,9 @@ phase "Phase 2 — generated pricing + savings contract"
 if with_timeout 30 env PI_CODING_AGENT_DIR="$PI_DIR" \
   pi -e "$UNIT_SUITE" --no-session --offline --model weave/claude-sonnet-4-6 \
   -p "Run the unit suite." >"$WORK/unit.out" 2>&1 </dev/null; then
-  [ "$(grep -Ec '^(✔ |ok [0-9]+ - )' "$WORK/unit.out" || true)" = "27" ] \
+  [ "$(grep -Ec '^(✔ |ok [0-9]+ - )' "$WORK/unit.out" || true)" = "28" ] \
     && ok "pricing, force-model, UI, and compaction unit suite passed" \
-    || bad "unit suite did not report all 27 passes (see $WORK/unit.out)"
+    || bad "unit suite did not report all 28 passes (see $WORK/unit.out)"
 else
   bad "unit suite failed to load through pi (see $WORK/unit.out)"
 fi

--- a/install/pi-router/test/e2e.sh
+++ b/install/pi-router/test/e2e.sh
@@ -133,9 +133,9 @@ phase "Phase 2 — generated pricing + savings contract"
 if with_timeout 30 env PI_CODING_AGENT_DIR="$PI_DIR" \
   pi -e "$UNIT_SUITE" --no-session --offline --model weave/claude-sonnet-4-6 \
   -p "Run the unit suite." >"$WORK/unit.out" 2>&1 </dev/null; then
-  [ "$(grep -Ec '^(✔ |ok [0-9]+ - )' "$WORK/unit.out" || true)" = "26" ] \
+  [ "$(grep -Ec '^(✔ |ok [0-9]+ - )' "$WORK/unit.out" || true)" = "27" ] \
     && ok "pricing, force-model, UI, and compaction unit suite passed" \
-    || bad "unit suite did not report all 26 passes (see $WORK/unit.out)"
+    || bad "unit suite did not report all 27 passes (see $WORK/unit.out)"
 else
   bad "unit suite failed to load through pi (see $WORK/unit.out)"
 fi


### PR DESCRIPTION
## Problem

The weave pi extension registers every headliner model with a `contextWindow` that understates what the router actually serves. Opus/Sonnet were left at the `200_000` default, so pi's footer showed `28.1%/200k` even though the router serves a 1M window (cap-extended → always 1M). Same understatement fed the extension's auto-compaction budget: it would compact far too early on a cap-extended model.

## Fix

All changes are in `install/pi-router/` (the weave plugin source; no pi-core, no npm version bump).

1. **`config.ts` — `WEAVE_MODELS` catalog mirrors the router catalog** (`internal/router/catalog`):
   - `claude-opus-4-8`, `claude-opus-4-7`, `claude-sonnet-4-6` → `1_000_000`
   - `claude-haiku-4-5` → `200_000`
   - `grok-4.6` → `500_000`
   - add `qwen/qwen3.8-max` → `1_000_000`
   - add `ROUTED_CONTEXT_WINDOW_HEADER = "x-router-context-window"` (the header emitted by #968)

2. **`compaction.ts` — prefer the served window over the registered window.** The router can reroute any request (e.g. to a smaller model), so the compaction budget should respect the smallest served window observed on a response this run (`x-router-context-window`), falling back to the registered model window until the first routed response. This:
   - stops premature compaction on cap-extended models (footer and budget now ≈ 1M), and
   - guards against over-running a reroute to a smaller window (e.g. haiku 200k).

## Tests

- Unit suite (through `pi -e`, exercises the real loader): 22 → 26 passes (`compaction.test.ts`: parse helper + three served-window compaction scenarios).
- Full `install/pi-router/test/e2e.sh`: **29 passed, 0 failed**.
- Typechecked against the bunded pi types (no named import of unexported `AfterProviderResponseEvent`; handler infers the event from `ExtensionAPI.on`).