### PR TITLE
fix(translate,catalog): correct qwen3.8-max served window + output cap

### DIFF
--- a/internal/router/catalog/catalog.go
+++ b/internal/router/catalog/catalog.go
@@ -574,7 +574,6 @@ var Models = []Model{
 	// Fireworks-only: SOC-2 compliance; OpenRouter's/Together's routes forward to
 	// Alibaba/DashScope. Fireworks caps at 131069, not the 1M in model docs:
 	// prod 400s "The prompt is too long ... model maximum context length: 131069".
-	// Use 131072 so the overflow pre-filter blocks over-budget requests instead.
 	{ID: "qwen/qwen3.8-max", Tier: TierHigh, ContextWindow: 131_072, Providers: []ProviderBinding{
 		{Provider: providers.ProviderFireworks, UpstreamID: "accounts/fireworks/models/qwen3p8-max",
 			Price: Pricing{InputUSDPer1M: 2.000, OutputUSDPer1M: 6.000, CacheReadMultiplier: 0.125}},

--- a/internal/router/catalog/catalog.go
+++ b/internal/router/catalog/catalog.go
@@ -572,12 +572,9 @@ var Models = []Model{
 			Price: Pricing{InputUSDPer1M: 0.400, OutputUSDPer1M: 1.600, CacheReadMultiplier: 0.20}},
 	}},
 	// Fireworks-only: SOC-2 compliance; OpenRouter's/Together's routes forward to
-	// Alibaba/DashScope. The 1M figure in the prompt cache / model docs is NOT
-	// what the Fireworks endpoint exposes: prod observations consistently 400
-	// "The prompt is too long: <N>, model maximum context length: 131069" on
-	// requests over ~131K (and a 262141 window on the larger shard). Until
-	// Fireworks raises the served window, treat 131072 as the routing budget so
-	// the overflow pre-filter excludes the arm instead of hard-400ing the turn.
+	// Alibaba/DashScope. Fireworks caps at 131069, not the 1M in model docs:
+	// prod 400s "The prompt is too long ... model maximum context length: 131069".
+	// Use 131072 so the overflow pre-filter blocks over-budget requests instead.
 	{ID: "qwen/qwen3.8-max", Tier: TierHigh, ContextWindow: 131_072, Providers: []ProviderBinding{
 		{Provider: providers.ProviderFireworks, UpstreamID: "accounts/fireworks/models/qwen3p8-max",
 			Price: Pricing{InputUSDPer1M: 2.000, OutputUSDPer1M: 6.000, CacheReadMultiplier: 0.125}},

--- a/internal/router/catalog/catalog.go
+++ b/internal/router/catalog/catalog.go
@@ -572,9 +572,13 @@ var Models = []Model{
 			Price: Pricing{InputUSDPer1M: 0.400, OutputUSDPer1M: 1.600, CacheReadMultiplier: 0.20}},
 	}},
 	// Fireworks-only: SOC-2 compliance; OpenRouter's/Together's routes forward to
-	// Alibaba/DashScope. Served window 1M confirmed on OpenRouter (context_length
-	// 1_000_000) and the model's own 1M capability; Fireworks serves the full 1M.
-	{ID: "qwen/qwen3.8-max", Tier: TierHigh, ContextWindow: 1_000_000, Providers: []ProviderBinding{
+	// Alibaba/DashScope. The 1M figure in the prompt cache / model docs is NOT
+	// what the Fireworks endpoint exposes: prod observations consistently 400
+	// "The prompt is too long: <N>, model maximum context length: 131069" on
+	// requests over ~131K (and a 262141 window on the larger shard). Until
+	// Fireworks raises the served window, treat 131072 as the routing budget so
+	// the overflow pre-filter excludes the arm instead of hard-400ing the turn.
+	{ID: "qwen/qwen3.8-max", Tier: TierHigh, ContextWindow: 131_072, Providers: []ProviderBinding{
 		{Provider: providers.ProviderFireworks, UpstreamID: "accounts/fireworks/models/qwen3p8-max",
 			Price: Pricing{InputUSDPer1M: 2.000, OutputUSDPer1M: 6.000, CacheReadMultiplier: 0.125}},
 	}},

--- a/internal/router/catalog/catalog_test.go
+++ b/internal/router/catalog/catalog_test.go
@@ -293,8 +293,10 @@ func TestContextWindowFor_KnownModels(t *testing.T) {
 	// GLM-5 serves ~200K (max_position_embeddings 202752); GLM-5.2 confirmed at 1M.
 	assert.Equal(t, 202_752, ContextWindowFor("z-ai/glm-5"))
 	assert.Equal(t, 1_048_576, ContextWindowFor("z-ai/glm-5.2"))
-	// qwen/qwen3.8-max is a 1M model (served window confirmed on OpenRouter).
-	assert.Equal(t, 1_000_000, ContextWindowFor("qwen/qwen3.8-max"))
+	// qwen/qwen3.8-max is Fireworks-only; the served window there is ~131K,
+	// not the 1M the model card / OpenRouter list. Prod observed constant 400s
+	// "The prompt is too long ... model maximum context length: 131069".
+	assert.Equal(t, 131_072, ContextWindowFor("qwen/qwen3.8-max"))
 	assert.Equal(t, 204_800, ContextWindowFor("minimax/minimax-m2.7"))
 	// Unknown model falls back to DefaultContextWindow.
 	assert.Equal(t, DefaultContextWindow, ContextWindowFor("not-a-real-model"))

--- a/internal/router/catalog/catalog_test.go
+++ b/internal/router/catalog/catalog_test.go
@@ -293,9 +293,7 @@ func TestContextWindowFor_KnownModels(t *testing.T) {
 	// GLM-5 serves ~200K (max_position_embeddings 202752); GLM-5.2 confirmed at 1M.
 	assert.Equal(t, 202_752, ContextWindowFor("z-ai/glm-5"))
 	assert.Equal(t, 1_048_576, ContextWindowFor("z-ai/glm-5.2"))
-	// qwen/qwen3.8-max is Fireworks-only; the served window there is ~131K,
-	// not the 1M the model card / OpenRouter list. Prod observed constant 400s
-	// "The prompt is too long ... model maximum context length: 131069".
+	// Fireworks-only; served window is ~131K, not the 1M in model docs.
 	assert.Equal(t, 131_072, ContextWindowFor("qwen/qwen3.8-max"))
 	assert.Equal(t, 204_800, ContextWindowFor("minimax/minimax-m2.7"))
 	// Unknown model falls back to DefaultContextWindow.

--- a/internal/translate/default_max_tokens_test.go
+++ b/internal/translate/default_max_tokens_test.go
@@ -179,10 +179,8 @@ func TestOpenAISameFormat_ExplicitMaxTokensClampsToKimiK3Ceiling(t *testing.T) {
 	assert.Equal(t, float64(32000), out["max_tokens"])
 }
 
-// Regression: qwen/qwen3.8-max was absent from modelMaxOutputTokens, so an
-// explicit Claude Code max_tokens of 64000/32000 was clamped to the 8192
-// generic fallback. Fireworks serves a 64000 output ceiling, so a 32000
-// request must be passed through, not truncated to an 8th.
+// Regression: qwen/qwen3.8-max was absent from modelMaxOutputTokens, so
+// explicit max_tokens was clamped to the 8192 fallback instead of 64000.
 func TestOpenAISameFormat_ExplicitMaxTokensNotClampedTo8192ForQwen38Max(t *testing.T) {
 	body := []byte(`{"model":"gpt-4o","messages":[{"role":"user","content":"hi"}],"max_tokens":32000}`)
 	opts := translate.EmitOptions{
@@ -191,6 +189,20 @@ func TestOpenAISameFormat_ExplicitMaxTokensNotClampedTo8192ForQwen38Max(t *testi
 	}
 	out := parseAndEmit(t, body, "openai", opts)
 	assert.Equal(t, float64(32000), out["max_tokens"])
+}
+
+// Regression: the Bedrock-primary Qwen arms must stay clamped at Bedrock's
+// 16K output ceiling; a pass-through of Claude Code's 64000 would hard-400.
+func TestOpenAISameFormat_BedrockQwenClampedAt16384Ceiling(t *testing.T) {
+	for _, model := range []string{"qwen/qwen3-coder-next", "qwen/qwen3-235b-a22b-2507", "qwen/qwen3-next-80b-a3b-instruct"} {
+		body := []byte(`{"model":"gpt-4o","messages":[{"role":"user","content":"hi"}],"max_tokens":64000}`)
+		opts := translate.EmitOptions{
+			TargetModel:  model,
+			Capabilities: router.Lookup(model),
+		}
+		out := parseAndEmit(t, body, "openai", opts)
+		assert.Equal(t, float64(16384), out["max_tokens"], model)
+	}
 }
 
 // The flag ceiling (64000) is preserved — the clamp must not ask Qwen for

--- a/internal/translate/default_max_tokens_test.go
+++ b/internal/translate/default_max_tokens_test.go
@@ -178,3 +178,45 @@ func TestOpenAISameFormat_ExplicitMaxTokensClampsToKimiK3Ceiling(t *testing.T) {
 	out := parseAndEmit(t, body, "openai", opts)
 	assert.Equal(t, float64(32000), out["max_tokens"])
 }
+
+// Regression: qwen/qwen3.8-max was absent from modelMaxOutputTokens, so an
+// explicit Claude Code max_tokens of 64000/32000 was clamped to the 8192
+// generic fallback. Fireworks serves a 64000 output ceiling, so a 32000
+// request must be passed through, not truncated to an 8th.
+func TestOpenAISameFormat_ExplicitMaxTokensNotClampedTo8192ForQwen38Max(t *testing.T) {
+	body := []byte(`{"model":"gpt-4o","messages":[{"role":"user","content":"hi"}],"max_tokens":32000}`)
+	opts := translate.EmitOptions{
+		TargetModel:  "qwen/qwen3.8-max",
+		Capabilities: router.Lookup("qwen/qwen3.8-max"),
+	}
+	out := parseAndEmit(t, body, "openai", opts)
+	assert.Equal(t, float64(32000), out["max_tokens"])
+}
+
+// The flag ceiling (64000) is preserved — the clamp must not ask Qwen for
+// more than its served output limit.
+func TestOpenAISameFormat_Qwen38MaxClampsAt64000Ceiling(t *testing.T) {
+	body := []byte(`{"model":"gpt-4o","messages":[{"role":"user","content":"hi"}],"max_tokens":65536}`)
+	opts := translate.EmitOptions{
+		TargetModel:  "qwen/qwen3.8-max",
+		Capabilities: router.Lookup("qwen/qwen3.8-max"),
+	}
+	out := parseAndEmit(t, body, "openai", opts)
+	assert.Equal(t, float64(64000), out["max_tokens"])
+}
+
+// Same shape on the Anthropic->OpenAI cross-format path (the actual Claude
+// Code route): the explicit 64000 must not be clamped to 8192.
+func TestCrossFormat_AnthropicToOpenAI_Qwen38MaxExplicitMaxTokensPassedThrough(t *testing.T) {
+	body := []byte(`{"model":"claude-sonnet-4-20250514","messages":[{"role":"user","content":"hi"}],"max_tokens":64000}`)
+	env, err := translate.ParseAnthropic(body)
+	require.NoError(t, err)
+	prep, err := env.PrepareOpenAI(http.Header{}, translate.EmitOptions{
+		TargetModel:  "qwen/qwen3.8-max",
+		Capabilities: router.Lookup("qwen/qwen3.8-max"),
+	})
+	require.NoError(t, err)
+	var out map[string]any
+	require.NoError(t, json.Unmarshal(prep.Body, &out))
+	assert.Equal(t, float64(64000), out["max_tokens"])
+}

--- a/internal/translate/envelope.go
+++ b/internal/translate/envelope.go
@@ -1199,8 +1199,24 @@ var modelMaxOutputTokens = map[string]int{
 	"gemini-2.5-flash-lite": 65536,
 	"gemini-2.0-flash":      8192, "gemini-2.0-flash-lite": 8192,
 	// Keyed by full catalog ID, since decision.Model keeps the vendor prefix.
-	// Other OSS rows are still absent and so inherit the 8192 fallback.
-	"moonshotai/kimi-k3": 131072,
+	// OSS models genuinely accept far more than the 8192 generic fallback;
+	// leaving them unlisted clamped Claude Code's 64K output request to 8192,
+	// truncating every long turn (finish_reason="length"). When a provider's
+	// served output ceiling is higher than 131072, the overshoot only matters
+	// for pathological single turns; the 8192 floor was the actual defect.
+	"moonshotai/kimi-k3":               131072,
+	"qwen/qwen3.8-max":                 64000, // Fireworks reports a 64000 output token ceiling
+	"qwen/qwen3-coder-next":            65536,
+	"qwen/qwen3-235b-a22b-2507":        65536,
+	"qwen/qwen3-next-80b-a3b-instruct": 65536,
+	"deepseek/deepseek-v4-flash":       131072, // DeepSeek V4 documents 384K max output
+	"deepseek/deepseek-v4-pro":         131072,
+	"deepseek/deepseek-v4-pro-0813":    131072,
+	"minimax/minimax-m3":               131072, // 512K context, output up to the window
+	"minimax/minimax-m2.7":             65536,
+	"z-ai/glm-5":                       65536,
+	"z-ai/glm-5.1":                     65536,
+	"google/gemini-3.7-flash":          65536,
 }
 
 const defaultMaxOutputTokenCap = 8192

--- a/internal/translate/envelope.go
+++ b/internal/translate/envelope.go
@@ -1199,16 +1199,13 @@ var modelMaxOutputTokens = map[string]int{
 	"gemini-2.5-flash-lite": 65536,
 	"gemini-2.0-flash":      8192, "gemini-2.0-flash-lite": 8192,
 	// Keyed by full catalog ID, since decision.Model keeps the vendor prefix.
-	// OSS models genuinely accept far more than the 8192 generic fallback;
-	// leaving them unlisted clamped Claude Code's 64K output request to 8192,
-	// truncating every long turn (finish_reason="length"). When a provider's
-	// served output ceiling is higher than 131072, the overshoot only matters
-	// for pathological single turns; the 8192 floor was the actual defect.
+	// OSS models accept far more than the 8192 fallback; leaving them unlisted
+	// clamped Claude Code's 64K output request, truncating every long turn.
 	"moonshotai/kimi-k3":               131072,
 	"qwen/qwen3.8-max":                 64000, // Fireworks reports a 64000 output token ceiling
-	"qwen/qwen3-coder-next":            65536,
-	"qwen/qwen3-235b-a22b-2507":        65536,
-	"qwen/qwen3-next-80b-a3b-instruct": 65536,
+	"qwen/qwen3-coder-next":            16384, // Bedrock (primary) caps Qwen models at 16K output
+	"qwen/qwen3-235b-a22b-2507":        16384,
+	"qwen/qwen3-next-80b-a3b-instruct": 16384,
 	"deepseek/deepseek-v4-flash":       131072, // DeepSeek V4 documents 384K max output
 	"deepseek/deepseek-v4-pro":         131072,
 	"deepseek/deepseek-v4-pro-0813":    131072,


### PR DESCRIPTION
## Problem

Claude Code turns routed to `qwen/qwen3.8-max` surfaced two hard failures, both from router-side metadata that disagreed with what the Fireworks endpoint actually serves (traced to prod telemetry in a distributed-account session).

### 1. Every long turn truncated at 8192 output tokens → "exceeded the 64000 output token maximum"

`qwen/qwen3.8-max` was missing from `modelMaxOutputTokens` (`internal/translate/envelope.go`), so Claude Code's **explicit** `max_tokens: 64000` was clamped to the `8192` generic fallback. Prod telemetry: every `finish_reason="length"` turn on this arm ended at **exactly 8192 output tokens** — Qwen generates 8192, returns `length`, the router relays `stop_reason="max_tokens"`, and Claude Code reports "exceeded the 64000 output token maximum". Fireworks serves a **64000 output ceiling** for this model.

### 2. "prompt is too long" 400 → hard failure on over-budget requests

The catalog claimed **1M context** for `qwen/qwen3.8-max` (based on the OpenRouter listing), but the model is **Fireworks-only** and prod consistently 400s:

```
The prompt is too long: 519123, model maximum context length: 131069
```

The overflow pre-filter (`excludeContextOverflowModels`) compares `estimate + output reserve` against `catalog.ContextWindow`. With a bogus 1M window, a ~519K-token request passed the filter, was routed to the arm, and hard-400'd with no failover (single binding).

## Fix

- **`internal/translate/envelope.go`** — add `qwen/qwen3.8-max` at its 64000 ceiling (so explicit large `max_tokens` passes through, clamped to that ceiling), plus the other served OSS arms at their real output caps (deepseek-v4-flash/pro, minimax-m3/m2.7, glm-5/5.1, qwen3-coder-next, gemini-3.7-flash).
- **`internal/router/catalog/catalog.go`** — set `qwen/qwen3.8-max` `ContextWindow` to `131_072` (observed served window), so the overflow pre-filter and compaction exclude the arm for over-budget requests instead of hard-400ing.

## Validation

- `go build ./...` ✅
- `go test ./...` (full suite, incl. new regression tests) ✅
- `go vet` ✅
- Smoke suite (replay-only, real stack): **passed** ✅

## Tests

Added regression tests covering both failure modes:
- `TestOpenAISameFormat_ExplicitMaxTokensNotClampedTo8192ForQwen38Max` — 32000 not truncated to 8192
- `TestOpenAISameFormat_Qwen38MaxClampsAt64000Ceiling` — clamp respects 64000 ceiling
- `TestCrossFormat_AnthropicToOpenAI_Qwen38MaxExplicitMaxTokensPassedThrough` — the actual Claude Code route
- Updated `TestContextWindowFor_KnownModels` — qwen3.8-max at 131072