### PR TITLE
fix(proxy): resolve spoken model slugs and list pinnable models on /force-model

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -343,13 +343,28 @@ with nowhere to go (HTTP 503 from the scorer), so exclude deliberately.
 
 ## Forcing a model or a routing cluster
 
+`/force-model <model>` (alias `/fm`) pins the session to one model. The model
+may be a canonical catalog ID, an alias (`opus`, `qwen-max`, …), or the way you
+would say it out loud — separators are insignificant, so `qwen 3.8`,
+`qwen-3.8`, and `qwen3.8` all reach `qwen/qwen3.8-max`. Anything after the
+model name stays in the turn as your prompt (`/fm qwen 3.8 fix the test`).
+
+Run `/force-model` with no argument to list every model this installation can
+pin, grouped into automatic-routing targets and passthrough-only models, with
+each one's provider and shorthands. The listing is derived from the same gate
+that admits a pin, so anything it names will be accepted. It is not the policy
+sidecar's roster: models that are pinnable but never chosen automatically —
+and models the sidecar's roster omits — appear too, because you can reach
+them. An unrecognized model is refused with the closest matching IDs rather
+than pinned, and any prior pin is left alone.
+
 Two request headers let a headless caller (eval harness, CI, any client whose
 UI eats slash commands) override routing. Both fail the request rather than
 routing on, so a typo can't look like it took effect.
 
 | Header | Effect |
 | ------ | ------ |
-| `x-weave-force-model` | Pins the session to one model, exactly as `/force-model` does. Accepts a canonical catalog ID or an alias (`opus`, `gpt`, `qwen-max`, …) plus an optional `:level` effort suffix (`opus:high`). A value naming no catalog model is HTTP 400. |
+| `x-weave-force-model` | Pins the session to one model, exactly as `/force-model` does. Accepts a canonical catalog ID or an alias (`opus`, `gpt`, `qwen-max`, …), with separators insignificant (`qwen 3.8` = `qwen3.8`), plus an optional `:level` effort suffix (`opus:high`). A value naming no catalog model is HTTP 400. |
 | `x-weave-force-cluster` | Constrains serving to one of the policy sidecar's routing clusters, leaving the choice *within* it to the policy. |
 
 `x-weave-force-cluster` takes an opaque label — the router holds no list of

--- a/install/cc-statusline.sh
+++ b/install/cc-statusline.sh
@@ -583,6 +583,9 @@ if [[ -n "$transcript_path" && -f "$transcript_path" ]]; then
   #   * unrecognized model        → "… isn't a recognized model · keeping
   #                                  automatic routing" — a NO-OP: the prior
   #                                  pin, if any, is left untouched
+  #   * bare /force-model         → "… pick a model by id …" (or "no models are
+  #                                  available to pin") — also a NO-OP: it only
+  #                                  lists what can be pinned, changing nothing
   # These persist on disk (the ingress stripper only scrubs them from upstream
   # requests). Classify each weave-router turn newest-first, skip the no-op
   # "rejected" acks, and let the latest real state change decide: an "applied"
@@ -596,6 +599,7 @@ if [[ -n "$transcript_path" && -f "$transcript_path" ]]; then
         | ([.message.content[]? | select(.type? == "text") | .text] | join(" ") | gsub("[\n\r]"; " ")) as $t
         | if ($t | test("force-model applied:")) then "APPLIED " + ($t | capture("force-model applied: (?<m>[^ ]+)").m)
           elif ($t | test("isn.t a recognized model")) then "REJECTED"
+          elif ($t | test("pick a model by id|no models are available to pin")) then "REJECTED"
           else "CLEARED" end' 2>/dev/null \
     | grep -m1 -v '^REJECTED$' || true)"
   if [[ "$force_state" == APPLIED\ * ]]; then

--- a/install/commands/fm.md
+++ b/install/commands/fm.md
@@ -1,6 +1,6 @@
 ---
 description: Alias for /force-model — pin this session to a specific model via the Weave Router.
-argument-hint: <model-id>
+argument-hint: "[model-id — omit to list every model you can pin]"
 ---
 
 /force-model $ARGUMENTS

--- a/install/commands/force-model.md
+++ b/install/commands/force-model.md
@@ -1,6 +1,6 @@
 ---
 description: Pin this session to a specific model via the Weave Router.
-argument-hint: <model-id>
+argument-hint: "[model-id — omit to list every model you can pin]"
 ---
 
 /force-model $ARGUMENTS

--- a/install/install.sh
+++ b/install/install.sh
@@ -3376,6 +3376,9 @@ if [[ -n "$transcript_path" && -f "$transcript_path" ]]; then
   #   * unrecognized model        → "… isn't a recognized model · keeping
   #                                  automatic routing" — a NO-OP: the prior
   #                                  pin, if any, is left untouched
+  #   * bare /force-model         → "… pick a model by id …" (or "no models are
+  #                                  available to pin") — also a NO-OP: it only
+  #                                  lists what can be pinned, changing nothing
   # These persist on disk (the ingress stripper only scrubs them from upstream
   # requests). Classify each weave-router turn newest-first, skip the no-op
   # "rejected" acks, and let the latest real state change decide: an "applied"
@@ -3389,6 +3392,7 @@ if [[ -n "$transcript_path" && -f "$transcript_path" ]]; then
         | ([.message.content[]? | select(.type? == "text") | .text] | join(" ") | gsub("[\n\r]"; " ")) as $t
         | if ($t | test("force-model applied:")) then "APPLIED " + ($t | capture("force-model applied: (?<m>[^ ]+)").m)
           elif ($t | test("isn.t a recognized model")) then "REJECTED"
+          elif ($t | test("pick a model by id|no models are available to pin")) then "REJECTED"
           else "CLEARED" end' 2>/dev/null \
     | grep -m1 -v '^REJECTED$' || true)"
   if [[ "$force_state" == APPLIED\ * ]]; then

--- a/install/pi-router/src/force-model.ts
+++ b/install/pi-router/src/force-model.ts
@@ -44,7 +44,9 @@ function messageText(message: unknown): string | undefined {
 
 export function parseForceModelDirective(text: string): ForceModelDirective | undefined {
 	const command = text.trim();
-	if (/^\/(?:force-model|fm)\s+\S+/i.test(command)) return "force";
+	// The argument is optional: a bare /fm asks the router for the listing of
+	// pinnable models. The (\s|$) boundary keeps /fmt from matching.
+	if (/^\/(?:force-model|fm)(?:\s|$)/i.test(command)) return "force";
 	if (/^\/(?:unforce-model|ufm)$/i.test(command)) return "clear";
 	return undefined;
 }
@@ -54,6 +56,9 @@ export function parseForceModelAcknowledgement(text: string): ForceModelTransiti
 	if (applied) return { kind: "applied", model: applied[1] };
 	if (/force-model cleared/i.test(text)) return { kind: "cleared" };
 	if (/is(?:n't| not) a recognized model/i.test(text)) return { kind: "noop" };
+	// The bare-command listing changes no pin state, so it must read as a
+	// no-op — treating it as a failed force would drop a live pin from the UI.
+	if (/force-model: pick a model by id|no models are available to pin/i.test(text)) return { kind: "noop" };
 	return undefined;
 }
 
@@ -100,12 +105,10 @@ function sendRouterCommand(pi: ExtensionAPI, command: string, ctx: ExtensionComm
 
 export function registerForceModelCommands(pi: ExtensionAPI): void {
 	const forceModel = async (args: string, ctx: ExtensionCommandContext): Promise<void> => {
-		const modelAndPrompt = args.trim();
-		if (!modelAndPrompt) {
-			ctx.ui.notify("Usage: /fm <model-id>", "warning");
-			return;
-		}
-		sendRouterCommand(pi, `/force-model ${modelAndPrompt}`, ctx);
+		// A bare /fm is forwarded, not refused: the router answers it with the
+		// listing of pinnable models, which is what someone who doesn't know
+		// the exact slug is asking for.
+		sendRouterCommand(pi, `/force-model ${args.trim()}`.trimEnd(), ctx);
 	};
 	const clearForceModel = async (_args: string, ctx: ExtensionCommandContext): Promise<void> => {
 		sendRouterCommand(pi, "/unforce-model", ctx);

--- a/install/pi-router/test/force-model.test.ts
+++ b/install/pi-router/test/force-model.test.ts
@@ -79,12 +79,29 @@ test("queues commands as follow-ups while Pi is streaming", async () => {
 	assert.deepEqual(sent, [{ content: "/unforce-model", options: { deliverAs: "followUp" } }]);
 });
 
-test("missing force-model arguments warn without starting a turn", async () => {
+test("a bare force-model forwards to the router for the pinnable-model listing", async () => {
 	const { commands, sent } = extensionHarness();
 	const { ctx, notifications } = commandContext();
 	await commands.get("fm")?.handler("   ", ctx);
-	assert.deepEqual(sent, []);
-	assert.deepEqual(notifications, [{ message: "Usage: /fm <model-id>", level: "warning" }]);
+	// Forwarded, not refused: the router answers a bare command with the list
+	// of models this installation can pin.
+	assert.deepEqual(sent, [{ content: "/force-model", options: undefined }]);
+	assert.deepEqual(notifications, []);
+});
+
+test("the listing acknowledgement is a no-op that preserves an existing pin", () => {
+	assert.deepEqual(
+		parseForceModelAcknowledgement("✦ **Weave Router** → force-model: pick a model by id, e.g. `/force-model claude-opus-5`"),
+		{ kind: "noop" },
+	);
+
+	const entries = [
+		messageEntry("user", "/force-model haiku"),
+		messageEntry("assistant", "✦ **Weave Router** → force-model applied: claude-haiku-4-5 (anthropic) · Use /unforce-model to clear"),
+		messageEntry("user", "/force-model"),
+		messageEntry("assistant", "✦ **Weave Router** → force-model: pick a model by id, e.g. `/force-model claude-opus-5`"),
+	];
+	assert.equal(forcedModelFromBranch(entries), "claude-haiku-4-5");
 });
 
 test("parses applied, cleared, and rejected router acknowledgements", () => {

--- a/internal/proxy/force_model.go
+++ b/internal/proxy/force_model.go
@@ -153,6 +153,15 @@ func resolveForceModel(model string) (canonicalID, provider string, known bool) 
 	return canon, prov, kn
 }
 
+// forceModelNameKnown is the translate.ForceModelKnown the command parser uses
+// to decide how many words of "/fm qwen 3.8 fix the bug" are the model name.
+// It answers with the same resolver that later performs the pin, so the parser
+// and the pin can never disagree about where the model name ends.
+func forceModelNameKnown(candidate string) bool {
+	_, _, known := resolveForceModel(candidate)
+	return known
+}
+
 // resolveForceModelWithEffort is like resolveForceModel but also strips a
 // `:level` suffix. `known` is true only for catalog matches; known=false +
 // effort!="" lets callers surface "model not found" without losing the effort.
@@ -188,6 +197,14 @@ func resolveForceModelWithEffort(model string) (canonicalID, provider string, kn
 			return matched.ID, matched.Providers[0].Provider, true, effort
 		}
 	}
+	// Separator-insensitive retry: users type the model the way they say it
+	// ("qwen 3.8", "gpt 5.6 sol"), not the way the catalog spells it. Compare
+	// on a form with every separator removed so spaces, hyphens, dots, and
+	// underscores are all interchangeable. Runs only after the exact lookups
+	// above, so it can never override a precise match.
+	if id, prov, ok := resolveForceModelLoose(model, requiredProvider); ok {
+		return id, prov, true, effort
+	}
 	if requiredProvider != "" {
 		return unknownID, requiredProvider, false, effort
 	}
@@ -206,6 +223,97 @@ func resolveForceModelWithEffort(model string) (canonicalID, provider string, kn
 		return model, providers.ProviderAnthropic, false, effort
 	}
 }
+
+// resolveForceModelLoose matches model against aliases and catalog IDs with
+// all separators removed. A catalog ID's trailing path segment also matches
+// ("qwen3.8max" → "qwen/qwen3.8-max"), mirroring the exact-suffix pass above.
+// Ambiguous matches are rejected rather than guessed: silently pinning one of
+// several plausible models is the failure this whole path exists to avoid.
+//
+// A leading or trailing separator means the input is truncated mid-type
+// ("gpt-"), not merely punctuated differently, so those are refused — folding
+// them away would turn "gpt-" into the "gpt" alias and pin a model the user
+// never finished naming.
+func resolveForceModelLoose(model, requiredProvider string) (canonicalID, provider string, known bool) {
+	if model == "" || isModelSeparator(rune(model[0])) || isModelSeparator(rune(model[len(model)-1])) {
+		return "", "", false
+	}
+	key := foldModelSeparators(model)
+	if key == "" {
+		return "", "", false
+	}
+	if alias, ok := foldedForceModelAliases[key]; ok {
+		if m, found := catalog.ByID(alias); found && len(m.Providers) > 0 &&
+			(requiredProvider == "" || m.Providers[0].Provider == requiredProvider) {
+			return m.ID, m.Providers[0].Provider, true
+		}
+	}
+	var matched catalog.Model
+	matches := 0
+	for _, m := range catalog.Models {
+		if len(m.Providers) == 0 || (requiredProvider != "" && m.Providers[0].Provider != requiredProvider) {
+			continue
+		}
+		folded := foldModelSeparators(m.ID)
+		_, tail, hasSlash := strings.Cut(m.ID, "/")
+		if folded != key && !(hasSlash && foldModelSeparators(tail) == key) {
+			continue
+		}
+		matched = m
+		matches++
+	}
+	if matches != 1 {
+		return "", "", false
+	}
+	return matched.ID, matched.Providers[0].Provider, true
+}
+
+// foldModelSeparators lowercases and drops every character that only ever
+// separates words in a model name, so "Qwen 3.8 Max", "qwen-3.8-max", and
+// "qwen3.8max" all fold together.
+func foldModelSeparators(s string) string {
+	var b strings.Builder
+	b.Grow(len(s))
+	for _, r := range strings.ToLower(s) {
+		if isModelSeparator(r) {
+			continue
+		}
+		b.WriteRune(r)
+	}
+	return b.String()
+}
+
+// isModelSeparator reports whether r only ever separates words in a model
+// name, making it insignificant for matching.
+func isModelSeparator(r rune) bool {
+	switch r {
+	case ' ', '\t', '-', '_', '.', '/':
+		return true
+	default:
+		return false
+	}
+}
+
+// foldedForceModelAliases indexes forceModelAliases by folded key so the loose
+// pass reaches aliases too ("qwen max" → "qwen-max" → qwen/qwen3.8-max).
+// Collisions after folding are dropped: two aliases that fold alike can point
+// at different models, and guessing between them is what breaks trust here.
+var foldedForceModelAliases = func() map[string]string {
+	folded := make(map[string]string, len(forceModelAliases))
+	ambiguous := make(map[string]struct{})
+	for alias, target := range forceModelAliases {
+		key := foldModelSeparators(alias)
+		if existing, seen := folded[key]; seen && existing != target {
+			ambiguous[key] = struct{}{}
+			continue
+		}
+		folded[key] = target
+	}
+	for key := range ambiguous {
+		delete(folded, key)
+	}
+	return folded
+}()
 
 // stripEffortSuffix splits a `:level` suffix off model, canonicalizes it via
 // CanonicalizeEffort, and returns ("", model) when no recognized suffix found.
@@ -366,7 +474,15 @@ func (s *Service) handleForceModelCommand(
 	// StripRoutingMarkerFromMessages strips it from later inbound requests;
 	// otherwise it'd persist in history and leak router internals upstream.
 	var msg string
-	if cmd.Clear {
+	if cmd.List {
+		// A bare /force-model is a request to see the options, not a failed
+		// pin: answer with the listing and leave any existing pin alone.
+		msg = renderForceModelListing(s.pinnableModels(ctx), env.SourceFormat())
+		log.Debug("/force-model: listed pinnable models",
+			"session_key_hex", fmt.Sprintf("%x", sessionKey),
+			"role", role,
+		)
+	} else if cmd.Clear {
 		if s.pinStore != nil && installationID != uuid.Nil {
 			if err := s.expireSessionPin(ctx, installationID, sessionKey, role, "user_unforced"); err != nil {
 				log.Error("/unforce-model: pin store upsert failed", "err", err)
@@ -385,15 +501,14 @@ func (s *Service) handleForceModelCommand(
 	} else if canonicalModel, provider, known := resolveForceModel(cmd.Model); !known {
 		// Not in the catalog (e.g. truncated "/force-model gpt-") — reject
 		// rather than pin something we can't honor; prior pin left untouched.
+		// The suggestions come from the same gate that admits a pin, so a
+		// user who guessed wrong is shown ids that will actually work.
 		log.Info("/force-model: rejected unknown model",
 			"input_model", cmd.Model,
 			"session_key_hex", fmt.Sprintf("%x", sessionKey),
 			"role", role,
 		)
-		msg = fmt.Sprintf("✦ **Weave Router** → force-model: %q isn't a recognized model · keeping automatic routing. Use a full model ID, e.g. claude-opus-5, gpt-5.5, or gemini-3-pro-preview.\n\n", cmd.Model)
-		if env.SourceFormat() == translate.FormatOpenAI {
-			msg = fmt.Sprintf("Weave Router: force-model: %q isn't a recognized model; keeping automatic routing. Use a full model ID, e.g. claude-opus-5, gpt-5.5, or gemini-3-pro-preview.", cmd.Model)
-		}
+		msg = renderForceModelRejection(cmd.Model, s.pinnableModels(ctx), env.SourceFormat())
 	} else if binding, reason := s.forcedModelBinding(ctx, canonicalModel, provider); reason != "" {
 		// Exclusions outrank the force. Pinning anyway would look accepted and
 		// then serve something else every turn; the prior pin is left untouched.

--- a/internal/proxy/force_model.go
+++ b/internal/proxy/force_model.go
@@ -225,15 +225,9 @@ func resolveForceModelWithEffort(model string) (canonicalID, provider string, kn
 }
 
 // resolveForceModelLoose matches model against aliases and catalog IDs with
-// all separators removed. A catalog ID's trailing path segment also matches
-// ("qwen3.8max" → "qwen/qwen3.8-max"), mirroring the exact-suffix pass above.
-// Ambiguous matches are rejected rather than guessed: silently pinning one of
-// several plausible models is the failure this whole path exists to avoid.
-//
-// A leading or trailing separator means the input is truncated mid-type
-// ("gpt-"), not merely punctuated differently, so those are refused — folding
-// them away would turn "gpt-" into the "gpt" alias and pin a model the user
-// never finished naming.
+// all separators removed. Trailing path segments also match ("qwen3.8max" →
+// "qwen/qwen3.8-max"). Ambiguous matches are refused. Leading/trailing
+// separators ("gpt-") are refused: folding them would pin the wrong model.
 func resolveForceModelLoose(model, requiredProvider string) (canonicalID, provider string, known bool) {
 	if model == "" || isModelSeparator(rune(model[0])) || isModelSeparator(rune(model[len(model)-1])) {
 		return "", "", false

--- a/internal/proxy/force_model_internal_test.go
+++ b/internal/proxy/force_model_internal_test.go
@@ -163,13 +163,74 @@ func TestResolveForceModel(t *testing.T) {
 			wantKnown:    false,
 		},
 		// Truncated command (the bug this guard closes): "/force-model gpt-"
-		// parses to "gpt-", which matches no catalog entry.
+		// parses to "gpt-", which matches no catalog entry. The
+		// separator-insensitive pass must not rescue it into the "gpt" alias —
+		// a trailing separator means the user is mid-type, not punctuating.
 		{
 			name:         "truncated gpt- is not known",
 			input:        "gpt-",
 			wantID:       "gpt-",
 			wantProvider: providers.ProviderOpenAI,
 			wantKnown:    false,
+		},
+		{
+			name:         "truncated qwen- is not known",
+			input:        "qwen-",
+			wantID:       "qwen-",
+			wantProvider: providers.ProviderAnthropic,
+			wantKnown:    false,
+		},
+		// Space-separated forms: users type the model the way they say it.
+		// "/fm qwen 3.8" previously resolved to qwen/qwen3-coder — a different
+		// model served under an ack that read as if the pin took.
+		{
+			name:         "space-separated qwen 3.8",
+			input:        "qwen 3.8",
+			wantID:       "qwen/qwen3.8-max",
+			wantProvider: providers.ProviderFireworks,
+			wantKnown:    true,
+		},
+		{
+			name:         "space-separated qwen max",
+			input:        "qwen max",
+			wantID:       "qwen/qwen3.8-max",
+			wantProvider: providers.ProviderFireworks,
+			wantKnown:    true,
+		},
+		{
+			name:         "space-separated full catalog id",
+			input:        "qwen 3.8 max",
+			wantID:       "qwen/qwen3.8-max",
+			wantProvider: providers.ProviderFireworks,
+			wantKnown:    true,
+		},
+		{
+			name:         "mixed case and spacing",
+			input:        "Qwen 3.8 Max",
+			wantID:       "qwen/qwen3.8-max",
+			wantProvider: providers.ProviderFireworks,
+			wantKnown:    true,
+		},
+		{
+			name:         "space-separated gpt 5.6 sol",
+			input:        "gpt 5.6 sol",
+			wantID:       "gpt-5.6-sol",
+			wantProvider: providers.ProviderOpenAI,
+			wantKnown:    true,
+		},
+		{
+			name:         "space-separated claude opus 5",
+			input:        "claude opus 5",
+			wantID:       "claude-opus-5",
+			wantProvider: providers.ProviderAnthropic,
+			wantKnown:    true,
+		},
+		{
+			name:         "space-separated kimi k3",
+			input:        "kimi k3",
+			wantID:       "moonshotai/kimi-k3",
+			wantProvider: providers.ProviderFireworks,
+			wantKnown:    true,
 		},
 	}
 

--- a/internal/proxy/force_model_listing.go
+++ b/internal/proxy/force_model_listing.go
@@ -1,0 +1,304 @@
+package proxy
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+
+	"workweave/router/internal/router/catalog"
+	"workweave/router/internal/translate"
+)
+
+// forceModelListEntry is one pinnable model in the /force-model listing.
+type forceModelListEntry struct {
+	// ID is the canonical catalog ID — the slug a user types to pin it.
+	ID string
+	// Provider is the binding the pin would actually resolve to, which is not
+	// always the model's primary (forcedModelBinding walks past an excluded
+	// primary to a permitted fallback).
+	Provider string
+	// Routable distinguishes automatic routing targets from passthrough-only
+	// models. Both are pinnable; only the former can be chosen automatically.
+	Routable bool
+	// Aliases are the shorthands that resolve to this model, shortest first.
+	Aliases []string
+}
+
+// pinnableModels returns every model this installation can pin, in the order
+// the listing renders them. A model qualifies when it has a servable binding
+// here AND forcedModelBinding accepts it — the listing is derived from the
+// same gate that admits the pin, so it can't advertise a model that would be
+// refused a moment later.
+//
+// Passthrough-only (untiered) catalog rows are included: they are legitimately
+// pinnable even though automatic routing will never select them, and omitting
+// them is what makes a user believe a model they can reach doesn't exist.
+func (s *Service) pinnableModels(ctx context.Context) []forceModelListEntry {
+	aliases := aliasesByCanonicalID()
+
+	out := make([]forceModelListEntry, 0, len(catalog.Models))
+	for _, m := range catalog.Models {
+		if len(m.Providers) == 0 {
+			continue
+		}
+		binding, reason := s.forcedModelBinding(ctx, m.ID, m.Providers[0].Provider)
+		if reason != "" {
+			continue
+		}
+		if !s.providerRegistered(binding) {
+			continue
+		}
+		out = append(out, forceModelListEntry{
+			ID:       m.ID,
+			Provider: binding,
+			Routable: s.routableTarget(m),
+			Aliases:  aliases[m.ID],
+		})
+	}
+
+	// Routable first, then by ID: the models automatic routing can pick are
+	// the ones a user is usually reaching for, and burying them under retired
+	// passthrough rows is what a plain catalog-order dump would do.
+	sort.SliceStable(out, func(i, j int) bool {
+		if out[i].Routable != out[j].Routable {
+			return out[i].Routable
+		}
+		return out[i].ID < out[j].ID
+	})
+	return out
+}
+
+// routableTarget reports whether automatic routing can select the model here:
+// it needs a tier (untiered catalog rows are passthrough-only by definition)
+// and, when the deployment declares its routing targets, membership in them.
+func (s *Service) routableTarget(m catalog.Model) bool {
+	if m.Tier == catalog.TierUnknown {
+		return false
+	}
+	if s.availableModels == nil {
+		return true
+	}
+	_, ok := s.availableModels[m.ID]
+	return ok
+}
+
+// providerRegistered reports whether this deployment has a client for the
+// provider. Listing a model whose provider isn't wired would advertise a pin
+// that dispatches nowhere.
+func (s *Service) providerRegistered(provider string) bool {
+	if s.providers == nil {
+		return true
+	}
+	_, ok := s.providers[provider]
+	return ok
+}
+
+// aliasesByCanonicalID inverts forceModelAliases, sorting each model's
+// shorthands shortest-first so the listing leads with the one worth typing.
+func aliasesByCanonicalID() map[string][]string {
+	out := make(map[string][]string, len(forceModelAliases))
+	for alias, target := range forceModelAliases {
+		out[target] = append(out[target], alias)
+	}
+	for id := range out {
+		sort.Slice(out[id], func(i, j int) bool {
+			if len(out[id][i]) != len(out[id][j]) {
+				return len(out[id][i]) < len(out[id][j])
+			}
+			return out[id][i] < out[id][j]
+		})
+	}
+	return out
+}
+
+// maxListedAliases caps the shorthands shown per model. Some models carry
+// eight; printing them all turns the listing into a wall the user won't read.
+const maxListedAliases = 3
+
+// renderForceModelListing formats the pinnable-model listing as the routing
+// marker body. Markdown for the Anthropic surface, plain text for OpenAI,
+// matching how every other synthetic ack in this package splits.
+func renderForceModelListing(entries []forceModelListEntry, format translate.Format) string {
+	if len(entries) == 0 {
+		const empty = "force-model: no models are available to pin on this installation. Check the installation's allowed/excluded model settings."
+		if format == translate.FormatOpenAI {
+			return "Weave Router: " + empty
+		}
+		return "✦ **Weave Router** → " + empty + "\n\n"
+	}
+
+	var b strings.Builder
+	if format == translate.FormatOpenAI {
+		b.WriteString("Weave Router: models you can pin with /force-model <id>.\n")
+	} else {
+		b.WriteString("✦ **Weave Router** → force-model: pick a model by id, e.g. `/force-model ")
+		b.WriteString(entries[0].ID)
+		b.WriteString("`\n")
+	}
+
+	routableCount := 0
+	for _, e := range entries {
+		if e.Routable {
+			routableCount++
+		}
+	}
+
+	writeSection := func(heading string, want bool) {
+		first := true
+		for _, e := range entries {
+			if e.Routable != want {
+				continue
+			}
+			if first {
+				first = false
+				if format == translate.FormatOpenAI {
+					b.WriteString("\n" + heading + "\n")
+				} else {
+					b.WriteString("\n**" + heading + "**\n\n")
+				}
+			}
+			b.WriteString(formatListEntry(e, format))
+		}
+	}
+
+	writeSection("Routing targets", true)
+	if routableCount < len(entries) {
+		writeSection("Passthrough only (pinnable, never auto-selected)", false)
+	}
+
+	if format == translate.FormatOpenAI {
+		b.WriteString("\nUse /unforce-model to clear a pin.")
+		return b.String()
+	}
+	b.WriteString("\nUse `/unforce-model` to clear a pin.\n\n")
+	return b.String()
+}
+
+// formatListEntry renders one model row with its provider and top aliases.
+func formatListEntry(e forceModelListEntry, format translate.Format) string {
+	aliases := e.Aliases
+	if len(aliases) > maxListedAliases {
+		aliases = aliases[:maxListedAliases]
+	}
+	suffix := ""
+	if len(aliases) > 0 {
+		suffix = " — also: " + strings.Join(aliases, ", ")
+	}
+	if format == translate.FormatOpenAI {
+		return fmt.Sprintf("  %s (%s)%s\n", e.ID, e.Provider, suffix)
+	}
+	return fmt.Sprintf("- `%s` (%s)%s\n", e.ID, e.Provider, suffix)
+}
+
+// maxSuggestions caps the near-miss ids offered on an unrecognized model.
+const maxSuggestions = 5
+
+// renderForceModelRejection formats the unrecognized-model reply, offering the
+// closest pinnable ids instead of three hardcoded examples that may not even
+// be available on this installation.
+//
+// The phrase "isn't a recognized model" is load-bearing: the Claude Code
+// statusline greps for it to classify this ack as a no-op that leaves the
+// prior pin intact (see install/cc-statusline.sh). Keep it verbatim.
+func renderForceModelRejection(input string, entries []forceModelListEntry, format translate.Format) string {
+	suggestions := suggestModelIDs(input, entries)
+	if format == translate.FormatOpenAI {
+		msg := fmt.Sprintf("Weave Router: force-model: %q isn't a recognized model; keeping automatic routing.", input)
+		if len(suggestions) > 0 {
+			return msg + " Did you mean: " + strings.Join(suggestions, ", ") + "? Run /force-model with no argument to list every model you can pin."
+		}
+		return msg + " Run /force-model with no argument to list every model you can pin."
+	}
+	msg := fmt.Sprintf("✦ **Weave Router** → force-model: %q isn't a recognized model · keeping automatic routing.", input)
+	if len(suggestions) > 0 {
+		msg += " Did you mean `" + strings.Join(suggestions, "`, `") + "`?"
+	}
+	return msg + " Run `/force-model` with no argument to list every model you can pin.\n\n"
+}
+
+// suggestModelIDs ranks pinnable ids by how well they match the user's input,
+// comparing on the separator-folded form so "qwen 3.8" reaches
+// "qwen/qwen3.8-max". A candidate qualifies on substring containment in either
+// direction, or on a substantial shared prefix — the common typo ("qwen3.9")
+// is a near-miss that contains nothing, so containment alone finds nothing to
+// suggest exactly when the user most needs a hint.
+func suggestModelIDs(input string, entries []forceModelListEntry) []string {
+	key := foldModelSeparators(input)
+	if key == "" {
+		return nil
+	}
+	type scored struct {
+		id      string
+		shared  int
+		lenDiff int
+	}
+	var matches []scored
+	for _, e := range entries {
+		folded := foldModelSeparators(e.ID)
+		// The id's own trailing segment is compared too, so a vendor-prefixed
+		// id ("qwen/qwen3.8-max") is reachable from a bare name.
+		_, tail, hasSlash := strings.Cut(e.ID, "/")
+		compared := folded
+		shared := sharedPrefixLen(folded, key)
+		if hasSlash {
+			if foldedTail := foldModelSeparators(tail); sharedPrefixLen(foldedTail, key) > shared {
+				shared = sharedPrefixLen(foldedTail, key)
+				compared = foldedTail
+			}
+		}
+		contained := strings.Contains(folded, key) || strings.Contains(key, folded)
+		if !contained && shared < minSuggestionPrefix {
+			continue
+		}
+		matches = append(matches, scored{
+			id:      e.ID,
+			shared:  shared,
+			lenDiff: abs(len(compared) - len(key)),
+		})
+	}
+	// Longest shared prefix first, then the closest length: among ids sharing
+	// "qwen3", "qwen3.8-max" is a far likelier reading of "qwen3.9" than
+	// "qwen3-235b-a22b-2507", and alphabetical order alone buries it.
+	sort.SliceStable(matches, func(i, j int) bool {
+		if matches[i].shared != matches[j].shared {
+			return matches[i].shared > matches[j].shared
+		}
+		if matches[i].lenDiff != matches[j].lenDiff {
+			return matches[i].lenDiff < matches[j].lenDiff
+		}
+		return matches[i].id < matches[j].id
+	})
+	out := make([]string, 0, maxSuggestions)
+	for _, m := range matches {
+		if len(out) == maxSuggestions {
+			break
+		}
+		out = append(out, m.id)
+	}
+	return out
+}
+
+// minSuggestionPrefix is how many leading characters a near-miss must share
+// before it's offered. Four keeps "qwen3.9" reaching the qwen family without
+// letting every "g"-initial id answer a "gpt" typo.
+const minSuggestionPrefix = 4
+
+// sharedPrefixLen returns how many leading bytes a and b have in common.
+func sharedPrefixLen(a, b string) int {
+	n := min(len(a), len(b))
+	for i := range n {
+		if a[i] != b[i] {
+			return i
+		}
+	}
+	return n
+}
+
+// abs returns the absolute value of n.
+func abs(n int) int {
+	if n < 0 {
+		return -n
+	}
+	return n
+}

--- a/internal/proxy/force_model_listing.go
+++ b/internal/proxy/force_model_listing.go
@@ -25,15 +25,10 @@ type forceModelListEntry struct {
 	Aliases []string
 }
 
-// pinnableModels returns every model this installation can pin, in the order
-// the listing renders them. A model qualifies when it has a servable binding
-// here AND forcedModelBinding accepts it — the listing is derived from the
-// same gate that admits the pin, so it can't advertise a model that would be
-// refused a moment later.
-//
-// Passthrough-only (untiered) catalog rows are included: they are legitimately
-// pinnable even though automatic routing will never select them, and omitting
-// them is what makes a user believe a model they can reach doesn't exist.
+// pinnableModels returns every model this installation can pin, derived from
+// the same gate (forcedModelBinding) that admits the pin — so it can't
+// advertise a model that would be refused. Untiered (passthrough-only) rows
+// are included: omitting them hides models a user can actually reach.
 func (s *Service) pinnableModels(ctx context.Context) []forceModelListEntry {
 	aliases := aliasesByCanonicalID()
 

--- a/internal/proxy/force_model_listing_internal_test.go
+++ b/internal/proxy/force_model_listing_internal_test.go
@@ -1,0 +1,306 @@
+package proxy
+
+import (
+	"context"
+	"encoding/json"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"workweave/router/internal/providers"
+	"workweave/router/internal/router/catalog"
+	"workweave/router/internal/translate"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// listingService builds a Service that can serve every catalog provider, so
+// the listing is gated only by what the test's context excludes. Routing
+// targets are derived the way the composition root derives them.
+func listingService() *Service {
+	clients := make(map[string]providers.Client)
+	keyedProviders := make(map[string]struct{})
+	for _, m := range catalog.Models {
+		for _, b := range m.Providers {
+			clients[b.Provider] = nil
+			keyedProviders[b.Provider] = struct{}{}
+		}
+	}
+	return &Service{
+		providers:                clients,
+		deploymentKeyedProviders: keyedProviders,
+		availableModels:          catalog.RoutingTargetSet(keyedProviders),
+	}
+}
+
+func listedIDs(entries []forceModelListEntry) []string {
+	out := make([]string, 0, len(entries))
+	for _, e := range entries {
+		out = append(out, e.ID)
+	}
+	return out
+}
+
+// The listing must name every model a pin would accept. qwen/qwen3.8-max is
+// the specific miss that started this: it routes in prod but is absent from
+// the cluster artifact's roster, so a roster-derived listing hides it.
+func TestPinnableModels_IncludesRoutableAndPassthrough(t *testing.T) {
+	entries := listingService().pinnableModels(context.Background())
+	ids := listedIDs(entries)
+
+	assert.Contains(t, ids, "qwen/qwen3.8-max")
+	assert.Contains(t, ids, "claude-opus-5")
+	assert.Contains(t, ids, "qwen/qwen3-coder")
+	// Untiered rows are pinnable even though automatic routing never picks
+	// them; omitting them tells a user a model they can reach doesn't exist.
+	assert.Contains(t, ids, "claude-opus-4-8", "retired-but-pinnable models must be listed")
+
+	byID := make(map[string]forceModelListEntry, len(entries))
+	for _, e := range entries {
+		byID[e.ID] = e
+	}
+	assert.True(t, byID["qwen/qwen3.8-max"].Routable)
+	assert.False(t, byID["claude-opus-4-8"].Routable, "untiered catalog rows are passthrough-only")
+	assert.Equal(t, providers.ProviderFireworks, byID["qwen/qwen3.8-max"].Provider)
+}
+
+// Every listed id must survive the pin gate — the listing is worthless if it
+// advertises a model the very next command refuses.
+func TestPinnableModels_EveryEntryResolvesAndIsPermitted(t *testing.T) {
+	s := listingService()
+	ctx := context.Background()
+
+	for _, e := range s.pinnableModels(ctx) {
+		id, provider, known := resolveForceModel(e.ID)
+		require.True(t, known, "listed model %q must resolve", e.ID)
+		assert.Equal(t, e.ID, id)
+
+		_, reason := s.forcedModelBinding(ctx, id, provider)
+		assert.Empty(t, reason, "listed model %q must be permitted", e.ID)
+	}
+}
+
+// Routing targets sort ahead of passthrough-only rows: the models automatic
+// routing can pick are what a user is usually after.
+func TestPinnableModels_RoutableSortFirst(t *testing.T) {
+	entries := listingService().pinnableModels(context.Background())
+	require.NotEmpty(t, entries)
+
+	seenPassthrough := false
+	for _, e := range entries {
+		if !e.Routable {
+			seenPassthrough = true
+			continue
+		}
+		assert.False(t, seenPassthrough, "routable %q sorted after a passthrough entry", e.ID)
+	}
+}
+
+// An excluded model must not be advertised — it would be refused on the very
+// next turn, which is exactly the confusion the listing exists to end.
+func TestPinnableModels_OmitsExcludedModels(t *testing.T) {
+	ctx := context.WithValue(context.Background(),
+		InstallationExcludedModelsContextKey{}, []string{"qwen/qwen3.8-max"})
+
+	ids := listedIDs(listingService().pinnableModels(ctx))
+	assert.NotContains(t, ids, "qwen/qwen3.8-max")
+	assert.Contains(t, ids, "claude-opus-5", "unrelated models stay listed")
+}
+
+// A model whose only provider isn't registered can't be dispatched to, so
+// listing it would advertise a pin that goes nowhere.
+func TestPinnableModels_OmitsUnregisteredProviders(t *testing.T) {
+	s := &Service{
+		providers:                map[string]providers.Client{providers.ProviderAnthropic: nil},
+		deploymentKeyedProviders: map[string]struct{}{providers.ProviderAnthropic: {}},
+	}
+
+	ids := listedIDs(s.pinnableModels(context.Background()))
+	require.NotEmpty(t, ids)
+	assert.Contains(t, ids, "claude-opus-5")
+	for _, id := range ids {
+		assert.False(t, strings.HasPrefix(id, "qwen/"),
+			"model %q has no registered provider on this deployment", id)
+	}
+}
+
+func TestRenderForceModelListing_AnthropicNamesModelsAndAliases(t *testing.T) {
+	entries := listingService().pinnableModels(context.Background())
+	out := renderForceModelListing(entries, translate.FormatAnthropic)
+
+	assert.True(t, strings.HasPrefix(out, "✦ **Weave Router** → "),
+		"must carry the routing-marker prefix so ingress strips it from later turns")
+	assert.True(t, strings.HasSuffix(out, "\n\n"), "routing markers end in a blank line")
+	assert.Contains(t, out, "`qwen/qwen3.8-max`")
+	assert.Contains(t, out, "Routing targets")
+	assert.Contains(t, out, "Passthrough only")
+	assert.Contains(t, out, "/unforce-model")
+	// An alias is what makes the listing actionable for someone who typed a
+	// shorthand rather than a full slug.
+	assert.Contains(t, out, "qwen-max")
+}
+
+func TestRenderForceModelListing_OpenAIIsPlainText(t *testing.T) {
+	entries := listingService().pinnableModels(context.Background())
+	out := renderForceModelListing(entries, translate.FormatOpenAI)
+
+	assert.True(t, strings.HasPrefix(out, "Weave Router: "))
+	assert.NotContains(t, out, "✦", "the OpenAI surface takes plain text")
+	assert.NotContains(t, out, "**")
+	assert.Contains(t, out, "qwen/qwen3.8-max")
+}
+
+func TestRenderForceModelListing_EmptyIsExplained(t *testing.T) {
+	out := renderForceModelListing(nil, translate.FormatAnthropic)
+	assert.Contains(t, out, "no models are available to pin")
+	assert.Contains(t, out, "allowed/excluded")
+}
+
+// The rejection must keep the exact phrase the Claude Code statusline greps
+// for to classify this ack as a no-op that leaves the prior pin intact.
+func TestRenderForceModelRejection_PreservesStatuslineSentinel(t *testing.T) {
+	entries := listingService().pinnableModels(context.Background())
+
+	anthropic := renderForceModelRejection("qwen 9.9", entries, translate.FormatAnthropic)
+	assert.Contains(t, anthropic, "isn't a recognized model")
+	assert.True(t, strings.HasPrefix(anthropic, "✦ **Weave Router** → "))
+	assert.True(t, strings.HasSuffix(anthropic, "\n\n"))
+
+	openai := renderForceModelRejection("qwen 9.9", entries, translate.FormatOpenAI)
+	assert.Contains(t, openai, "isn't a recognized model")
+	assert.NotContains(t, openai, "✦")
+}
+
+func TestRenderForceModelRejection_SuggestsNearMisses(t *testing.T) {
+	entries := listingService().pinnableModels(context.Background())
+
+	out := renderForceModelRejection("qwen3.9", entries, translate.FormatAnthropic)
+	assert.Contains(t, out, "Did you mean")
+	assert.Contains(t, out, "qwen/", "a qwen typo should surface qwen models")
+
+	// With nothing close, still point at the listing rather than dead-ending.
+	none := renderForceModelRejection("zzzzzzzz", entries, translate.FormatAnthropic)
+	assert.NotContains(t, none, "Did you mean")
+	assert.Contains(t, none, "/force-model")
+}
+
+func TestSuggestModelIDs_RanksClosestFirstAndCaps(t *testing.T) {
+	entries := listingService().pinnableModels(context.Background())
+
+	got := suggestModelIDs("qwen3.8", entries)
+	require.NotEmpty(t, got)
+	assert.Equal(t, "qwen/qwen3.8-max", got[0])
+	assert.LessOrEqual(t, len(got), maxSuggestions)
+
+	// A near-miss version must lead with the closest model, not the
+	// alphabetically first one that happens to share the "qwen3" prefix.
+	near := suggestModelIDs("qwen 3.9", entries)
+	require.NotEmpty(t, near)
+	assert.Equal(t, "qwen/qwen3.8-max", near[0])
+
+	assert.Empty(t, suggestModelIDs("", entries))
+}
+
+// End-to-end through the command handler: the reported failure was that
+// "/fm qwen 3.8" acked "force-model applied: qwen/qwen3-coder" — a different
+// model, under a message that reads as success. Drive the real parse →
+// resolve → pin path and assert on what the pin store actually recorded.
+func TestHandleForceModelCommand_MultiWordNamePinsTheNamedModel(t *testing.T) {
+	for _, tc := range []struct {
+		command string
+		wantID  string
+	}{
+		{"/fm qwen 3.8", "qwen/qwen3.8-max"},
+		{"/fm qwen max", "qwen/qwen3.8-max"},
+		{"/force-model qwen 3.8 now fix the bug", "qwen/qwen3.8-max"},
+		{"/fm qwen", "qwen/qwen3-coder"},
+	} {
+		t.Run(tc.command, func(t *testing.T) {
+			store := &recordingPinStore{}
+			svc := NewService(nil, nil, nil, false, nil, store, false,
+				providers.ProviderAnthropic, "claude-haiku-4-5", nil).
+				WithDeploymentKeyedProviders(keyed(providers.ProviderFireworks))
+
+			env := forceModelCommandEnv(t, tc.command)
+			cmd, found := env.ExtractForceModelCommand(forceModelNameKnown)
+			require.True(t, found)
+
+			rec := httptest.NewRecorder()
+			require.NoError(t, svc.handleForceModelCommand(
+				context.Background(), rec, env, cmd,
+				uuid.New(), DeriveSessionKey(env, "key-1"), 10))
+
+			require.Len(t, store.upserts, 1, "an accepted force must write exactly one pin")
+			assert.Equal(t, tc.wantID, store.upserts[0].Model)
+			assert.Contains(t, rec.Body.String(), "force-model applied: "+tc.wantID)
+		})
+	}
+}
+
+// A bare /force-model lists rather than pinning, and must leave any existing
+// pin untouched — it is a question, not a state change.
+func TestHandleForceModelCommand_BareCommandListsWithoutPinning(t *testing.T) {
+	store := &recordingPinStore{}
+	svc := NewService(nil, nil, nil, false, nil, store, false,
+		providers.ProviderAnthropic, "claude-haiku-4-5", nil).
+		WithDeploymentKeyedProviders(keyed(providers.ProviderAnthropic, providers.ProviderFireworks))
+
+	env := forceModelCommandEnv(t, "/force-model")
+	cmd, found := env.ExtractForceModelCommand(forceModelNameKnown)
+	require.True(t, found)
+	require.True(t, cmd.List)
+
+	rec := httptest.NewRecorder()
+	require.NoError(t, svc.handleForceModelCommand(
+		context.Background(), rec, env, cmd,
+		uuid.New(), DeriveSessionKey(env, "key-1"), 10))
+
+	assert.Empty(t, store.upserts, "listing must not write or clear a pin")
+	body := rec.Body.String()
+	assert.Contains(t, body, "claude-opus-5")
+	assert.Contains(t, body, "qwen/qwen3.8-max",
+		"a model that routes in prod must appear in the listing")
+	assert.NotContains(t, body, "force-model applied")
+}
+
+// The unrecognized-model reply must point at ids that actually work here.
+func TestHandleForceModelCommand_UnknownModelSuggestsRealIDs(t *testing.T) {
+	store := &recordingPinStore{}
+	svc := NewService(nil, nil, nil, false, nil, store, false,
+		providers.ProviderAnthropic, "claude-haiku-4-5", nil).
+		WithDeploymentKeyedProviders(keyed(providers.ProviderFireworks))
+
+	env := forceModelCommandEnv(t, "/fm qwen 9.9")
+	cmd, found := env.ExtractForceModelCommand(forceModelNameKnown)
+	require.True(t, found)
+
+	rec := httptest.NewRecorder()
+	require.NoError(t, svc.handleForceModelCommand(
+		context.Background(), rec, env, cmd,
+		uuid.New(), DeriveSessionKey(env, "key-1"), 10))
+
+	assert.Empty(t, store.upserts, "an unknown model must not be pinned")
+	body := rec.Body.String()
+	assert.Contains(t, body, "isn't a recognized model",
+		"the statusline greps for this phrase to treat the ack as a no-op")
+	assert.Contains(t, body, "qwen/", "a qwen near-miss should suggest qwen models")
+}
+
+// forceModelCommandEnv builds an Anthropic request whose sole user message is
+// the given command text.
+func forceModelCommandEnv(t *testing.T, text string) *translate.RequestEnvelope {
+	t.Helper()
+	body, err := json.Marshal(map[string]any{
+		"model":      "claude-sonnet-4-6",
+		"max_tokens": 1024,
+		"messages": []any{
+			map[string]any{"role": "user", "content": text},
+		},
+	})
+	require.NoError(t, err)
+	env, err := translate.ParseAnthropic(body)
+	require.NoError(t, err)
+	return env
+}

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -2402,7 +2402,7 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 	// extraction: DeriveSessionKey can fall back to prompt text, and deriving
 	// after the strip would mismatch subsequent turns with the unstripped message.
 	if !agentShadowMode && s.pinStore != nil {
-		if cmd, hasCmd := env.ExtractForceModelCommand(); hasCmd {
+		if cmd, hasCmd := env.ExtractForceModelCommand(forceModelNameKnown); hasCmd {
 			log.Info("ProxyMessages force-model command", "force_model_cmd", cmd)
 			if err := s.handleForceModelCommand(ctx, w, env, cmd, installationID, sessionKey, feats.Tokens); err != nil {
 				return err
@@ -4833,7 +4833,7 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 	// extraction: DeriveSessionKey can fall back to prompt text, and deriving
 	// after the strip would mismatch subsequent turns with the unstripped message.
 	if s.pinStore != nil {
-		if cmd, hasCmd := env.ExtractForceModelCommand(); hasCmd {
+		if cmd, hasCmd := env.ExtractForceModelCommand(forceModelNameKnown); hasCmd {
 			log.Info("ProxyOpenAIChatCompletion force-model command", "force_model_cmd", cmd)
 			if err := s.handleForceModelCommand(ctx, w, env, cmd, installationID, sessionKey, feats.Tokens); err != nil {
 				return err

--- a/internal/translate/force_model.go
+++ b/internal/translate/force_model.go
@@ -199,16 +199,9 @@ func parseForceModelCommand(text string, known ForceModelKnown) (res ForceModelR
 }
 
 // forceModelNameWords returns how many leading words of parts form the model
-// name. It prefers the longest run `known` accepts, so a multi-word name wins
-// over a shorter prefix that also resolves ("qwen 3.8" over "qwen").
-//
-// When no multi-word run resolves, the name still absorbs any immediately
-// following version-like tokens ("9.9", "4o"). Without that, "/fm qwen 9.9"
-// falls back to the one word "qwen" — which IS a known alias — and silently
-// pins qwen3-coder for a model the user never named. A prompt effectively
-// never begins with a bare version token, while a mistyped model version
-// routinely does, so absorbing it turns a wrong pin into an honest rejection
-// that names what was typed.
+// name, preferring the longest run known accepts ("qwen 3.8" over "qwen").
+// When no multi-word run resolves, version-like tokens are absorbed anyway:
+// without that, "/fm qwen 9.9" silently pins qwen3-coder instead of rejecting.
 func forceModelNameWords(parts []string, known ForceModelKnown) int {
 	if known == nil {
 		return 1

--- a/internal/translate/force_model.go
+++ b/internal/translate/force_model.go
@@ -19,19 +19,32 @@ const ReasonLoopEscalation = "loop_escalation"
 
 // ForceModelResult holds the parsed outcome of a force-model command.
 type ForceModelResult struct {
-	// Model is the target model name; empty when Clear is true.
+	// Model is the target model name; empty when Clear or List is true.
 	Model string
 	// Clear is true for /unforce-model.
 	Clear bool
+	// List is true for a bare /force-model with no model argument: the caller
+	// answers with the pinnable-model listing instead of pinning anything.
+	List bool
 }
+
+// ForceModelKnown reports whether a candidate string names a pinnable model.
+// Supplied by the caller so the parser can consume a multi-word model name
+// ("qwen 3.8") without this package needing to know the model catalog.
+type ForceModelKnown func(candidate string) bool
 
 // ExtractForceModelCommand scans the last user-role message in env for a
 // /force-model <model> or /unforce-model directive, stripping it from
 // env.body. Returns (zero, false) when no command is present.
-func (env *RequestEnvelope) ExtractForceModelCommand() (ForceModelResult, bool) {
+//
+// known decides how many words of the argument belong to the model name: the
+// longest leading run of words it accepts wins, and the remainder stays in the
+// message as the user's prompt. A nil known (or one that accepts nothing)
+// falls back to a single word, which is what the pre-multi-word behavior did.
+func (env *RequestEnvelope) ExtractForceModelCommand(known ForceModelKnown) (ForceModelResult, bool) {
 	var res ForceModelResult
 	found := env.extractLeadingCommand(func(text string) (bool, string) {
-		r, ok, stripped := parseForceModelCommand(text)
+		r, ok, stripped := parseForceModelCommand(text, known)
 		if ok {
 			res = r
 		}
@@ -122,10 +135,21 @@ func (env *RequestEnvelope) extractLeadingCommand(parse func(text string) (found
 // (pi, opencode, raw API); Claude Code/Codex expand to the canonical form
 // client-side.
 //
+// The model argument may span several words ("/fm qwen 3.8"), so the split
+// between model name and trailing prompt is resolved by `known` rather than
+// assumed at the first space: the longest leading run of words `known`
+// accepts is the model, and the rest is the prompt. Without that, "/fm qwen
+// 3.8" silently pinned "qwen" and dropped "3.8" — a wrong model served under
+// an ack that looked like it took.
+//
+// A bare "/force-model" with no argument sets List: users who don't know the
+// exact slug need to see the pinnable set, and the old behavior (no match, so
+// the literal text forwarded upstream) answered that with a model's guess.
+//
 // Leading <tag>...</tag> blocks (e.g. <system-reminder>, <command-name>
 // injected by Claude Code) are skipped before the leading-line check, and
 // preserved in the stripped output.
-func parseForceModelCommand(text string) (res ForceModelResult, found bool, stripped string) {
+func parseForceModelCommand(text string, known ForceModelKnown) (res ForceModelResult, found bool, stripped string) {
 	prefixEnd := leadingInjectedPrefixEnd(text)
 	prefix := text[:prefixEnd]
 	body := text[prefixEnd:]
@@ -141,13 +165,18 @@ func parseForceModelCommand(text string) (res ForceModelResult, found bool, stri
 		if after, ok := cutAnyPrefix(trimmed, "/force-model ", "/fm "); ok {
 			parts := strings.Fields(strings.TrimSpace(after))
 			if len(parts) > 0 {
-				res = ForceModelResult{Model: parts[0]}
-				if len(parts) > 1 {
-					cmdTail = strings.Join(parts[1:], " ")
+				n := forceModelNameWords(parts, known)
+				res = ForceModelResult{Model: strings.Join(parts[:n], " ")}
+				if len(parts) > n {
+					cmdTail = strings.Join(parts[n:], " ")
 				}
 				found = true
 				cmdIdx = i
 			}
+		} else if trimmed == "/force-model" || trimmed == "/fm" {
+			res = ForceModelResult{List: true}
+			found = true
+			cmdIdx = i
 		} else if trimmed == "/unforce-model" || trimmed == "/ufm" {
 			res = ForceModelResult{Clear: true}
 			found = true
@@ -168,6 +197,62 @@ func parseForceModelCommand(text string) (res ForceModelResult, found bool, stri
 	stripped = strings.TrimSpace(prefix + bodyStripped)
 	return res, true, stripped
 }
+
+// forceModelNameWords returns how many leading words of parts form the model
+// name. It prefers the longest run `known` accepts, so a multi-word name wins
+// over a shorter prefix that also resolves ("qwen 3.8" over "qwen").
+//
+// When no multi-word run resolves, the name still absorbs any immediately
+// following version-like tokens ("9.9", "4o"). Without that, "/fm qwen 9.9"
+// falls back to the one word "qwen" — which IS a known alias — and silently
+// pins qwen3-coder for a model the user never named. A prompt effectively
+// never begins with a bare version token, while a mistyped model version
+// routinely does, so absorbing it turns a wrong pin into an honest rejection
+// that names what was typed.
+func forceModelNameWords(parts []string, known ForceModelKnown) int {
+	if known == nil {
+		return 1
+	}
+	// Bounded so a long pasted prompt after the model name isn't re-joined and
+	// re-checked on every word; no model name approaches this many words.
+	limit := min(len(parts), maxForceModelNameWords)
+	for n := limit; n > 1; n-- {
+		if known(strings.Join(parts[:n], " ")) {
+			return n
+		}
+	}
+	n := 1
+	for n < len(parts) && looksLikeVersionToken(parts[n]) {
+		n++
+	}
+	return n
+}
+
+// looksLikeVersionToken reports whether s reads as a version fragment of a
+// model name rather than the first word of a prompt: it must start with a
+// digit and contain only digits and version punctuation.
+func looksLikeVersionToken(s string) bool {
+	if s == "" || s[0] < '0' || s[0] > '9' {
+		return false
+	}
+	for i := range len(s) {
+		c := s[i]
+		if (c >= '0' && c <= '9') || c == '.' || c == '-' || c == '_' {
+			continue
+		}
+		// A trailing letter run is still version-shaped ("4o", "2507b").
+		if (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') {
+			continue
+		}
+		return false
+	}
+	return true
+}
+
+// maxForceModelNameWords caps how many leading words are considered part of a
+// model name. Four covers the wordiest real aliases ("claude opus 4 8") with
+// room to spare.
+const maxForceModelNameWords = 4
 
 // cutAnyPrefix returns text with the first matching prefix removed. Prefix
 // order matters only for overlapping prefixes; the command forms used here

--- a/internal/translate/force_model_test.go
+++ b/internal/translate/force_model_test.go
@@ -10,6 +10,20 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// knownTestModels stands in for the proxy's catalog resolver. It accepts a
+// small fixed set including a multi-word name, so the parser's model-name/
+// prompt split is exercised without this package depending on the catalog.
+func knownTestModels(candidate string) bool {
+	switch candidate {
+	case "deepseek/deepseek-v4-pro", "claude-opus-4-7", "gpt-5", "haiku",
+		"gemini-2.5-pro", "qwen/qwen3-235b-a22b-2507", "qwen/qwen3.6-35b-a3b",
+		"qwen 3.8", "gpt 5.6 sol":
+		return true
+	default:
+		return false
+	}
+}
+
 func TestParseForceModelCommand_ForceModel(t *testing.T) {
 	tests := []struct {
 		name         string
@@ -69,13 +83,75 @@ func TestParseForceModelCommand_ForceModel(t *testing.T) {
 			wantStripped: "then help",
 		},
 		{
-			name:      "no command",
-			input:     "Can you help me debug this code?",
-			wantFound: false,
+			// The model name can be several words; the split between name and
+			// prompt comes from `known`, not from the first space. Splitting at
+			// the space pinned "qwen" and served the wrong model.
+			name:         "multi-word model name",
+			input:        "/fm qwen 3.8",
+			wantModel:    "qwen 3.8",
+			wantFound:    true,
+			wantStripped: "",
 		},
 		{
-			name:      "force-model without model name is ignored",
-			input:     "/force-model ",
+			name:         "multi-word model name with trailing prompt",
+			input:        "/force-model qwen 3.8 fix the failing test",
+			wantModel:    "qwen 3.8",
+			wantFound:    true,
+			wantStripped: "fix the failing test",
+		},
+		{
+			name:         "three-word model name",
+			input:        "/fm gpt 5.6 sol and explain",
+			wantModel:    "gpt 5.6 sol",
+			wantFound:    true,
+			wantStripped: "and explain",
+		},
+		{
+			// The longest accepted run wins: "gpt-5" alone is also known, but
+			// the user named the more specific model.
+			name:         "longest known run wins over shorter prefix",
+			input:        "/fm qwen 3.8",
+			wantModel:    "qwen 3.8",
+			wantFound:    true,
+			wantStripped: "",
+		},
+		{
+			// Unknown multi-word input keeps the single-word split so the
+			// rejection names what the user typed rather than a whole prompt.
+			name:         "unknown model falls back to one word",
+			input:        "/fm bogus model name",
+			wantModel:    "bogus",
+			wantFound:    true,
+			wantStripped: "model name",
+		},
+		{
+			// A mistyped version must stay attached to the model name. Split at
+			// the space, "qwen" alone is a valid alias, so this would silently
+			// pin qwen3-coder instead of rejecting a model the user never named.
+			name:         "unknown version token stays with the model name",
+			input:        "/fm qwen 9.9",
+			wantModel:    "qwen 9.9",
+			wantFound:    true,
+			wantStripped: "",
+		},
+		{
+			name:         "unknown version token followed by a prompt",
+			input:        "/fm qwen 9.9 fix the test",
+			wantModel:    "qwen 9.9",
+			wantFound:    true,
+			wantStripped: "fix the test",
+		},
+		{
+			// A word-initial prompt is not a version, so it stays a prompt.
+			name:         "known model followed by a word prompt",
+			input:        "/fm haiku summarize this",
+			wantModel:    "haiku",
+			wantFound:    true,
+			wantStripped: "summarize this",
+		},
+		{
+			name:      "no command",
+			input:     "Can you help me debug this code?",
 			wantFound: false,
 		},
 		{
@@ -129,7 +205,7 @@ func TestParseForceModelCommand_ForceModel(t *testing.T) {
 			env, err := translate.ParseAnthropic(buildAnthropicBody(t, tt.input))
 			require.NoError(t, err)
 
-			res, found := env.ExtractForceModelCommand()
+			res, found := env.ExtractForceModelCommand(knownTestModels)
 			assert.Equal(t, tt.wantFound, found)
 			if !tt.wantFound {
 				return
@@ -144,13 +220,32 @@ func TestParseForceModelCommand_ForceModel(t *testing.T) {
 	}
 }
 
+// A bare /force-model asks for the pinnable-model listing. It must not be
+// mistaken for a pin (no Model) or a clear (no Clear) — and it must be
+// recognized at all, so the literal text is never forwarded to a model that
+// would answer the question by guessing.
+func TestParseForceModelCommand_BareCommandRequestsListing(t *testing.T) {
+	for _, input := range []string{"/force-model", "/fm", "  /force-model  ", "/force-model "} {
+		t.Run(input, func(t *testing.T) {
+			env, err := translate.ParseAnthropic(buildAnthropicBody(t, input))
+			require.NoError(t, err)
+
+			res, found := env.ExtractForceModelCommand(knownTestModels)
+			require.True(t, found)
+			assert.True(t, res.List)
+			assert.False(t, res.Clear)
+			assert.Empty(t, res.Model)
+		})
+	}
+}
+
 func TestParseForceModelCommand_UnforceModel(t *testing.T) {
 	for _, input := range []string{"/unforce-model", "/ufm"} {
 		t.Run(input, func(t *testing.T) {
 			env, err := translate.ParseAnthropic(buildAnthropicBody(t, input))
 			require.NoError(t, err)
 
-			res, found := env.ExtractForceModelCommand()
+			res, found := env.ExtractForceModelCommand(knownTestModels)
 			require.True(t, found)
 			assert.True(t, res.Clear)
 			assert.Empty(t, res.Model)
@@ -168,7 +263,7 @@ func TestExtractForceModelCommand_OpenAIFormat(t *testing.T) {
 	env, err := translate.ParseOpenAI(body)
 	require.NoError(t, err)
 
-	res, found := env.ExtractForceModelCommand()
+	res, found := env.ExtractForceModelCommand(knownTestModels)
 	require.True(t, found)
 	assert.Equal(t, "gpt-5", res.Model)
 	assert.False(t, res.Clear)
@@ -191,7 +286,7 @@ func TestExtractForceModelCommand_ArrayContent(t *testing.T) {
 	env, err := translate.ParseAnthropic(body)
 	require.NoError(t, err)
 
-	res, found := env.ExtractForceModelCommand()
+	res, found := env.ExtractForceModelCommand(knownTestModels)
 	require.True(t, found)
 	assert.Equal(t, "gpt-5", res.Model)
 
@@ -218,7 +313,7 @@ func TestExtractForceModelCommand_ArrayContentMultipleTextBlocks(t *testing.T) {
 	env, err := translate.ParseAnthropic(body)
 	require.NoError(t, err)
 
-	res, found := env.ExtractForceModelCommand()
+	res, found := env.ExtractForceModelCommand(knownTestModels)
 	require.True(t, found, "directive in a non-first text block must still be recognized")
 	assert.Equal(t, "qwen/qwen3.6-35b-a3b", res.Model)
 
@@ -245,7 +340,7 @@ func TestExtractForceModelCommand_NoUserMessage(t *testing.T) {
 	env, err := translate.ParseAnthropic(body)
 	require.NoError(t, err)
 
-	_, found := env.ExtractForceModelCommand()
+	_, found := env.ExtractForceModelCommand(knownTestModels)
 	assert.False(t, found)
 }
 
@@ -258,7 +353,7 @@ func TestExtractForceModelCommand_GeminiFormatIgnored(t *testing.T) {
 	env, err := translate.ParseGemini(body)
 	require.NoError(t, err)
 
-	_, found := env.ExtractForceModelCommand()
+	_, found := env.ExtractForceModelCommand(knownTestModels)
 	assert.False(t, found, "Gemini format should not be scanned for force-model commands")
 }
 


### PR DESCRIPTION
Two /force-model failures made pinning unreliable, both silent:

1. `/fm qwen 3.8` pinned qwen/qwen3-coder. The parser split the argument
   at the first space, so only "qwen" reached the resolver — a valid alias
   for a different model — and "3.8" was dropped into the prompt. The ack
   read "force-model applied: qwen/qwen3-coder", so a user asking for one
   model was served another under a message that looked like success.
   `/fm qwen max` failed the same way.

2. There was no way to discover what could be pinned. A bare /force-model
   matched nothing and was forwarded upstream, so a model answered the
   question by guessing, and the unrecognized-model reply named three
   hardcoded examples that may not even be available on the installation.

The parser now resolves the model-name/prompt boundary through the same
resolver that performs the pin, taking the longest leading run of words
that resolves, so parser and pin cannot disagree about where the name
ends. When no multi-word run resolves, the name still absorbs following
version-like tokens: without that, "/fm qwen 9.9" falls back to the bare
alias "qwen" and silently pins the wrong model instead of rejecting a
model the user never named.

Resolution is also separator-insensitive, so "qwen 3.8", "qwen-3.8", and
"qwen3.8" all reach qwen/qwen3.8-max. This runs only after the exact
lookups, never overriding a precise match, and refuses a leading/trailing
separator so a truncated "gpt-" stays unknown rather than folding into
the "gpt" alias. Ambiguous folds are refused rather than guessed.

A bare /force-model now lists every pinnable model, split into routing
targets and passthrough-only rows, with each one's provider and
shorthands. The listing is derived from forcedModelBinding — the same
gate that admits a pin — so it cannot advertise a model that would be
refused a moment later. It deliberately is not the policy sidecar's
roster: models that are pinnable but never auto-selected, and models the
roster omits, are reachable and so are listed. Unrecognized models now
get the closest matching ids instead of fixed examples.

The listing ack is classified as a no-op in both the statusline and the
pi extension: it changes no pin state, and treating it as a clear would
drop a live pin from the UI. The "isn't a recognized model" sentinel the
statusline greps for is preserved verbatim.

Co-Authored-By: Weave Router <router@workweave.ai>

## Testing

- `gofmt -l .`, `go vet ./...`, `go build -o /dev/null ./...`, `go test -count=1 ./...` — all clean.
- `make test-install` — 3/3 suites pass (Codex, key reuse, models).
- `make test-statusline` — 31 pass, 2 fail; both reproduce on a pristine
  checkout of the base commit and concern refresh-stamp counts, untouched here.
- New coverage: multi-word and separator-insensitive resolution, the
  truncated-`gpt-` guard, listing membership/ordering/exclusion filtering,
  suggestion ranking, and end-to-end handler tests asserting on what the pin
  store actually recorded (the original bug was a wrong pin under a
  success-looking ack).
- Verified the statusline `jq` classifier and the pi extension's regexes
  against the real message text for all six ack shapes.

🤖 Generated with [Weave Router](https://router.workweave.ai)
