### PR TITLE
fix(translate): intersect Gemini allOf branches, widen on conflict; fail over unservable builds to baseline

### DIFF
--- a/internal/proxy/dispatch_error.go
+++ b/internal/proxy/dispatch_error.go
@@ -173,9 +173,7 @@ func ClassifyDispatchError(err error) (DispatchErrorClass, bool) {
 			LogMessage: "Compatible translation provider unavailable",
 		}, true
 	case translate.IsIntrinsicallyIncompatible(err):
-		// Only reached when the baseline rescue in ProxyMessages either didn't
-		// apply or also failed — a routed model that provably can't serve this
-		// request shape, with nowhere left to retry.
+		// Only reached when every rescue was unavailable or also failed.
 		return DispatchErrorClass{
 			Kind:       DispatchErrorRoutedModelIncompatible,
 			Status:     http.StatusBadGateway,

--- a/internal/proxy/dispatch_error.go
+++ b/internal/proxy/dispatch_error.go
@@ -50,6 +50,7 @@ const (
 	DispatchErrorForcedModelUnknown
 	DispatchErrorForcedClusterUnsupportedStrategy
 	DispatchErrorForcedClusterUnservable
+	DispatchErrorRoutedModelIncompatible
 )
 
 // DispatchErrorClass is the format-agnostic classification of a dispatch
@@ -170,6 +171,17 @@ func ClassifyDispatchError(err error) (DispatchErrorClass, bool) {
 			RetryAfter: true,
 			LogLevel:   "warn",
 			LogMessage: "Compatible translation provider unavailable",
+		}, true
+	case translate.IsIntrinsicallyIncompatible(err):
+		// Only reached when the baseline rescue in ProxyMessages either didn't
+		// apply or also failed — a routed model that provably can't serve this
+		// request shape, with nowhere left to retry.
+		return DispatchErrorClass{
+			Kind:       DispatchErrorRoutedModelIncompatible,
+			Status:     http.StatusBadGateway,
+			Message:    "The routed model cannot serve this request's shape (tool schema, reasoning intent, or tool history). Please retry.",
+			LogLevel:   "warn",
+			LogMessage: "Routed model cannot serve this request shape; no failover was available",
 		}, true
 	// Must precede the ErrNoEligibleProvider case: ErrAllowlistEmptiesPool
 	// wraps it, so the generic case would otherwise match first and report a

--- a/internal/proxy/dispatch_error_test.go
+++ b/internal/proxy/dispatch_error_test.go
@@ -228,3 +228,28 @@ func TestClassifyDispatchError_ForcedClusterUnservableIs400(t *testing.T) {
 	assert.Contains(t, cls.Message, "explore")
 	assert.NotContains(t, cls.Message, "route:", "the internal wrap prefix must not leak to the client")
 }
+
+// When the baseline rescue doesn't apply (or also fails), a build-time
+// intrinsic-incompatibility error must classify as a clear 502 instead of
+// falling through to a generic upstream-failure response.
+func TestClassifyDispatchError_RoutedModelIncompatibleIs502(t *testing.T) {
+	err := fmt.Errorf("translate anthropic request to gemini: %w", translate.ErrGeminiUnsignedToolHistory)
+
+	cls, ok := proxy.ClassifyDispatchError(err)
+
+	require.True(t, ok)
+	assert.Equal(t, proxy.DispatchErrorRoutedModelIncompatible, cls.Kind)
+	assert.Equal(t, http.StatusBadGateway, cls.Status)
+	assert.False(t, cls.Kind.IsClientError(), "the routed model was incompatible, not the client's request")
+	assert.Equal(t, "warn", cls.LogLevel)
+}
+
+func TestClassifyDispatchError_ReasoningIncompatibleClassifiesAsRoutedModelIncompatible(t *testing.T) {
+	err := fmt.Errorf("emit body: %w", translate.ErrReasoningIncompatible)
+
+	cls, ok := proxy.ClassifyDispatchError(err)
+
+	require.True(t, ok)
+	assert.Equal(t, proxy.DispatchErrorRoutedModelIncompatible, cls.Kind)
+	assert.Equal(t, http.StatusBadGateway, cls.Status)
+}

--- a/internal/proxy/dispatch_error_test.go
+++ b/internal/proxy/dispatch_error_test.go
@@ -229,9 +229,7 @@ func TestClassifyDispatchError_ForcedClusterUnservableIs400(t *testing.T) {
 	assert.NotContains(t, cls.Message, "route:", "the internal wrap prefix must not leak to the client")
 }
 
-// When the baseline rescue doesn't apply (or also fails), a build-time
-// intrinsic-incompatibility error must classify as a clear 502 instead of
-// falling through to a generic upstream-failure response.
+// Build-time intrinsic-incompatibility must classify as a clear 502.
 func TestClassifyDispatchError_RoutedModelIncompatibleIs502(t *testing.T) {
 	err := fmt.Errorf("translate anthropic request to gemini: %w", translate.ErrGeminiUnsignedToolHistory)
 

--- a/internal/proxy/gemini_schema_failover_integration_test.go
+++ b/internal/proxy/gemini_schema_failover_integration_test.go
@@ -19,9 +19,7 @@ import (
 	"github.com/tidwall/gjson"
 )
 
-// TestProxyMessages_GeminiBuildIncompatibilityFailsOverToBaselineAnthropic:
-// PrepareGemini fails before Google is dialed; the turn must be rescued on
-// Anthropic, not surface a 502.
+// PrepareGemini fails before Google is dialed; the turn must be rescued on Anthropic.
 func TestProxyMessages_GeminiBuildIncompatibilityFailsOverToBaselineAnthropic(t *testing.T) {
 	var (
 		mu                     sync.Mutex

--- a/internal/proxy/gemini_schema_failover_integration_test.go
+++ b/internal/proxy/gemini_schema_failover_integration_test.go
@@ -1,0 +1,103 @@
+package proxy_test
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	"workweave/router/internal/providers"
+	"workweave/router/internal/providers/anthropic"
+	"workweave/router/internal/providers/google"
+	"workweave/router/internal/proxy"
+	"workweave/router/internal/router"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+)
+
+// TestProxyMessages_GeminiBuildIncompatibilityFailsOverToBaselineAnthropic:
+// when the router routes to a Gemini 3.x model but the inbound history is
+// unsigned tool-call history, PrepareGemini fails at request-BUILD time
+// (before any binding is ever dispatched) — the routed model provably can't
+// serve this request shape. The turn must still be rescued on the requested
+// model via Anthropic instead of surfacing a bare 502.
+func TestProxyMessages_GeminiBuildIncompatibilityFailsOverToBaselineAnthropic(t *testing.T) {
+	var (
+		mu                     sync.Mutex
+		googleCount            int
+		anthropicCount         int
+		anthropicReceivedModel string
+	)
+
+	googleUpstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		googleCount++
+		mu.Unlock()
+		t.Error("Google upstream must not be hit: PrepareGemini fails before any binding is dispatched")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer googleUpstream.Close()
+
+	anthropicUpstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		mu.Lock()
+		anthropicCount++
+		anthropicReceivedModel = gjson.GetBytes(body, "model").String()
+		mu.Unlock()
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(anthropicMessageSSE))
+		if f, ok := w.(http.Flusher); ok {
+			f.Flush()
+		}
+	}))
+	defer anthropicUpstream.Close()
+
+	store := newFakePinStore()
+	tel := newCaptureTelemetry()
+	svc := proxy.NewService(
+		// Router routes the turn to a Gemini 3.x model; the unsigned tool
+		// history below makes PrepareGemini fail before Google is ever dialed.
+		&fakeRouter{decision: router.Decision{Provider: providers.ProviderGoogle, Model: "gemini-3-pro-preview"}},
+		map[string]providers.Client{
+			providers.ProviderGoogle:    google.NewNativeClient("test-google-key", googleUpstream.URL),
+			providers.ProviderAnthropic: anthropic.NewClient("test-anthropic-key", anthropicUpstream.URL),
+		},
+		nil, false, nil, store, false, providers.ProviderAnthropic, "claude-haiku-4-5", tel,
+	).WithDeploymentKeyedProviders(map[string]struct{}{
+		providers.ProviderGoogle:    {},
+		providers.ProviderAnthropic: {},
+	})
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(""))
+	// The tool_use id carries no "__thought__" signature, so
+	// HasUnsignedToolCallHistory is true and PrepareGemini deterministically
+	// fails with ErrGeminiUnsignedToolHistory against a Gemini 3.x target.
+	body := []byte(`{"model":"claude-opus-4-8","stream":true,"messages":[` +
+		`{"role":"user","content":"please continue"},` +
+		`{"role":"assistant","content":[{"type":"tool_use","id":"toolu_1","name":"Bash","input":{}}]},` +
+		`{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_1","content":"ok"}]}` +
+		`]}`)
+
+	err := svc.ProxyMessages(authedCtx("11111111-1111-1111-1111-111111111111"), body, rec, req)
+	require.NoError(t, err, "ProxyMessages should succeed via baseline failover to Anthropic despite the build-time Gemini incompatibility")
+
+	mu.Lock()
+	defer mu.Unlock()
+	assert.Equal(t, 0, googleCount, "Google must never be dispatched: PrepareGemini fails before any binding is attempted")
+	assert.Equal(t, 1, anthropicCount, "Anthropic baseline failover dispatched once")
+	assert.Equal(t, "claude-opus-4-8", anthropicReceivedModel, "baseline failover must request the caller's model on Anthropic")
+
+	assert.Equal(t, http.StatusOK, rec.Code, "the client must see a successful response, not a 502")
+	respBody := rec.Body.String()
+	assert.Contains(t, respBody, "event: message_start", "client sees the Anthropic stream start")
+	assert.Contains(t, respBody, "event: message_stop", "client sees the Anthropic stream end")
+	assert.Contains(t, respBody, "hi", "client sees the canned completion text")
+	assert.Equal(t, providers.ProviderAnthropic, rec.Header().Get(proxy.HeaderRouterProvider), "served provider header reflects the baseline failover")
+	assert.Equal(t, "claude-opus-4-8", rec.Header().Get(proxy.HeaderRouterModel), "x-router-model reflects the baseline model that served")
+}

--- a/internal/proxy/gemini_schema_failover_integration_test.go
+++ b/internal/proxy/gemini_schema_failover_integration_test.go
@@ -20,11 +20,8 @@ import (
 )
 
 // TestProxyMessages_GeminiBuildIncompatibilityFailsOverToBaselineAnthropic:
-// when the router routes to a Gemini 3.x model but the inbound history is
-// unsigned tool-call history, PrepareGemini fails at request-BUILD time
-// (before any binding is ever dispatched) — the routed model provably can't
-// serve this request shape. The turn must still be rescued on the requested
-// model via Anthropic instead of surfacing a bare 502.
+// PrepareGemini fails before Google is dialed; the turn must be rescued on
+// Anthropic, not surface a 502.
 func TestProxyMessages_GeminiBuildIncompatibilityFailsOverToBaselineAnthropic(t *testing.T) {
 	var (
 		mu                     sync.Mutex

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -3155,9 +3155,7 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 	primaryProvider := decision.Provider
 	var winnerIdx int
 	if attemptBuildErr != nil {
-		// Nothing was dispatched — the build failure enters the rescue chain as
-		// if every binding failed pre-commit. preludeBuf is uncommitted by
-		// construction: Seal() only happens inside a dispatched attempt.
+		// Nothing was dispatched — enters the rescue chain as if every binding pre-committed failed.
 		winnerIdx, proxyErr = -1, attemptBuildErr
 	} else {
 		winnerIdx, proxyErr = s.dispatchWithFallback(ctx, failoverInputs{

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -3087,10 +3087,8 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 		}
 	}
 	attempt, attemptBuildErr := buildAttempt(decision, opts, marker)
-	// An intrinsically-incompatible build error (unrepresentable tool schema,
-	// reasoning intent, or unsigned Gemini tool history) means the routed model
-	// provably can't serve this request shape; let it fall through so the
-	// baseline rescue below can serve it on Anthropic instead of 502ing.
+	// An intrinsically-incompatible build error means the routed model provably
+	// can't serve this shape — let it fall through to the baseline rescue below.
 	if attemptBuildErr != nil && !translate.IsIntrinsicallyIncompatible(attemptBuildErr) {
 		return attemptBuildErr
 	}

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -3087,7 +3087,11 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 		}
 	}
 	attempt, attemptBuildErr := buildAttempt(decision, opts, marker)
-	if attemptBuildErr != nil {
+	// An intrinsically-incompatible build error (unrepresentable tool schema,
+	// reasoning intent, or unsigned Gemini tool history) means the routed model
+	// provably can't serve this request shape; let it fall through so the
+	// baseline rescue below can serve it on Anthropic instead of 502ing.
+	if attemptBuildErr != nil && !translate.IsIntrinsicallyIncompatible(attemptBuildErr) {
 		return attemptBuildErr
 	}
 
@@ -3152,16 +3156,23 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 
 	primaryProvider := decision.Provider
 	var winnerIdx int
-	winnerIdx, proxyErr = s.dispatchWithFallback(ctx, failoverInputs{
-		// contentSink is the raw w when capture is off.
-		w:                      contentSink,
-		buf:                    preludeBuf,
-		initialDecision:        decision,
-		bindings:               bindings,
-		attempt:                attempt,
-		flushErr:               flushUpstreamErrorAsAnthropic,
-		deferFlushOnExhaustion: baselineViable || subscriptionRetryEligible || siblingViable,
-	})
+	if attemptBuildErr != nil {
+		// Nothing was dispatched — the build failure enters the rescue chain as
+		// if every binding failed pre-commit. preludeBuf is uncommitted by
+		// construction: Seal() only happens inside a dispatched attempt.
+		winnerIdx, proxyErr = -1, attemptBuildErr
+	} else {
+		winnerIdx, proxyErr = s.dispatchWithFallback(ctx, failoverInputs{
+			// contentSink is the raw w when capture is off.
+			w:                      contentSink,
+			buf:                    preludeBuf,
+			initialDecision:        decision,
+			bindings:               bindings,
+			attempt:                attempt,
+			flushErr:               flushUpstreamErrorAsAnthropic,
+			deferFlushOnExhaustion: baselineViable || subscriptionRetryEligible || siblingViable,
+		})
+	}
 
 	// The deferred upstream error must reach the client exactly once: each
 	// rescue hands ownership to the next, and whichever declines to run flushes.
@@ -3193,7 +3204,8 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 	}
 	if proxyErr != nil && !preludeBuf.Committed() &&
 		((baselineEligible && (providers.IsRetryable(proxyErr) || providers.IsUpstreamModelNotFound(proxyErr))) ||
-			(baselineViable && capabilityRejected)) {
+			(baselineViable && capabilityRejected) ||
+			(baselineViable && translate.IsIntrinsicallyIncompatible(proxyErr))) {
 		baselineDecision := decision
 		baselineDecision.Model = baselineModel
 		baselineDecision.Provider = providers.ProviderAnthropic
@@ -3218,7 +3230,7 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 				flushDeferredErr()
 			}
 		} else {
-			log.Warn("Baseline failover: routed model exhausted, retrying requested model on Anthropic",
+			log.Warn("Baseline failover: retrying requested model on Anthropic",
 				"failed_model", decision.Model,
 				"failed_provider", primaryProvider,
 				"baseline_model", baselineModel,

--- a/internal/translate/emit_gemini.go
+++ b/internal/translate/emit_gemini.go
@@ -1544,10 +1544,8 @@ func mergeSchemaMaps(base, extra map[string]any, overwrite bool) map[string]any 
 }
 
 // geminiAnnotationKeys carry no validation semantics, so two allOf branches
-// disagreeing on one is not a conflict. The left (outer/earlier) value wins.
-// pattern is deliberately absent: it is a constraint, and two branches'
-// regexes cannot be intersected — keeping only the left would widen the
-// accepted set — so differing patterns stay a conflict like pre-fix.
+// disagreeing on one is not a conflict — the left (earlier) value wins.
+// pattern is absent: regexes cannot be intersected, so differing patterns conflict.
 var geminiAnnotationKeys = map[string]struct{}{
 	"description": {},
 	"title":       {},
@@ -1651,13 +1649,25 @@ func intersectGeminiSchemas(left, right map[string]any) (map[string]any, bool) {
 	return out, true
 }
 
-// clampNullableTyped makes a typed schema's implicit non-nullability explicit:
-// Gemini treats an absent nullable as non-nullable, so it only means something
-// when intersection ANDs two ops. A schema with no type constrains nothing and
-// is returned unchanged.
+// clampNullableTyped makes implicit non-nullability explicit on typed schemas:
+// Gemini treats an absent nullable as false, so AND-ing two ops needs the
+// value present on both sides. A raw operand's type:[T,"null"] array is
+// lowered here too — nested siblings reach intersection before their own
+// sanitize pass normalizes them.
 func clampNullableTyped(schema map[string]any) map[string]any {
-	if _, hasType := schema["type"]; !hasType {
+	typeValue, hasType := schema["type"]
+	if !hasType {
 		return schema
+	}
+	if types, isArray := typeValue.([]any); isArray {
+		primary, ok := lowerNullableTypeArray(types)
+		if !ok {
+			return schema
+		}
+		out := mergeSchemaMaps(schema, nil, false)
+		out["type"] = primary
+		out["nullable"] = true
+		return out
 	}
 	if _, hasNullable := schema["nullable"]; hasNullable {
 		return schema
@@ -1665,6 +1675,37 @@ func clampNullableTyped(schema map[string]any) map[string]any {
 	out := mergeSchemaMaps(schema, nil, false)
 	out["nullable"] = false
 	return out
+}
+
+// lowerNullableTypeArray reports the non-null member of an exact [T, "null"]
+// type pair; any other array shape is left for the sanitize pass to reject.
+func lowerNullableTypeArray(types []any) (string, bool) {
+	if len(types) != 2 {
+		return "", false
+	}
+	primary := ""
+	hasNull := false
+	for _, candidate := range types {
+		name, ok := candidate.(string)
+		if !ok {
+			return "", false
+		}
+		if name == "null" {
+			if hasNull {
+				return "", false
+			}
+			hasNull = true
+			continue
+		}
+		if primary != "" {
+			return "", false
+		}
+		primary = name
+	}
+	if primary == "" || !hasNull {
+		return "", false
+	}
+	return primary, true
 }
 
 // stripEmptyNullable removes a nullable:false that is indistinguishable from an

--- a/internal/translate/emit_gemini.go
+++ b/internal/translate/emit_gemini.go
@@ -1327,7 +1327,13 @@ func sanitizeGeminiSchemaNode(v any, path string) (any, error) {
 		}
 		base := mergeSchemaMaps(node, nil, false)
 		delete(base, "allOf")
-		node, ok = mergeSchemaMapsExact(base, merged)
+		// The merged branches arrived here already nullability-normalized
+		// (type:["x","null"] lowered to type + nullable:true); the sibling map
+		// is still raw, so normalize it before intersecting on equal footing.
+		if err := normalizeGeminiNullableType(base, path); err != nil {
+			return nil, err
+		}
+		node, ok = intersectGeminiSchemas(base, merged)
 		if !ok {
 			// No longer fatal: generation hints only need a superset-safe schema,
 			// so keep the sibling (base) side on conflict.
@@ -1437,7 +1443,7 @@ func sanitizeGeminiSchemaNode(v any, path string) (any, error) {
 		return nil, err
 	}
 	resolveGeminiEnum(out)
-	return out, nil
+	return stripEmptyNullable(out), nil
 }
 
 // resolveGeminiExclusiveBound writes the inclusive bound key ("minimum" or
@@ -1506,7 +1512,7 @@ func mergeGeminiAllOf(v any, path string) (merged map[string]any, widened bool, 
 			observability.Get().Info("Gemini allOf branch is unrepresentable — widening by dropping it", "path", branchPath, "err", branchErr)
 			continue
 		}
-		candidate, mergedOK := mergeSchemaMapsExact(merged, object)
+		candidate, mergedOK := intersectGeminiSchemas(merged, object)
 		if !mergedOK {
 			widened = true
 			if firstErr == nil {
@@ -1521,7 +1527,7 @@ func mergeGeminiAllOf(v any, path string) (merged map[string]any, widened bool, 
 	if !matched {
 		return nil, false, firstErr
 	}
-	return merged, widened, nil
+	return stripEmptyNullable(merged), widened, nil
 }
 
 func mergeSchemaMaps(base, extra map[string]any, overwrite bool) map[string]any {
@@ -1537,8 +1543,11 @@ func mergeSchemaMaps(base, extra map[string]any, overwrite bool) map[string]any 
 	return out
 }
 
-// geminiAnnotationKeys are schema keywords that document rather than
-// constrain; allOf branches may disagree on them without real conflict.
+// geminiAnnotationKeys carry no validation semantics, so two allOf branches
+// disagreeing on one is not a conflict. The left (outer/earlier) value wins.
+// pattern is deliberately absent: it is a constraint, and two branches'
+// regexes cannot be intersected — keeping only the left would widen the
+// accepted set — so differing patterns stay a conflict like pre-fix.
 var geminiAnnotationKeys = map[string]struct{}{
 	"description": {},
 	"title":       {},
@@ -1546,7 +1555,24 @@ var geminiAnnotationKeys = map[string]struct{}{
 	"example":     {},
 }
 
-func mergeSchemaMapsExact(left, right map[string]any) (map[string]any, bool) {
+// geminiStricterBoundKeys map a bound keyword to whether the intersection of
+// two values is the larger one (lower bounds) or the smaller one (upper).
+var geminiStricterBoundKeys = map[string]bool{
+	"minimum":       true,
+	"minLength":     true,
+	"minItems":      true,
+	"minProperties": true,
+	"maximum":       false,
+	"maxLength":     false,
+	"maxItems":      false,
+	"maxProperties": false,
+}
+
+// intersectGeminiSchemas merges two allOf branches: bounds narrow, annotations
+// defer to the left branch, and only disagreeing types or disjoint enums conflict.
+func intersectGeminiSchemas(left, right map[string]any) (map[string]any, bool) {
+	left = clampNullableTyped(left)
+	right = clampNullableTyped(right)
 	out := mergeSchemaMaps(left, nil, false)
 	for key, value := range right {
 		current, exists := out[key]
@@ -1560,7 +1586,7 @@ func mergeSchemaMapsExact(left, right map[string]any) (map[string]any, bool) {
 			if !leftOK || !rightOK {
 				return nil, false
 			}
-			mergedProperties, ok := mergeSchemaMapsExact(leftProperties, rightProperties)
+			mergedProperties, ok := mergeGeminiPropertyMaps(leftProperties, rightProperties)
 			if !ok {
 				return nil, false
 			}
@@ -1574,8 +1600,48 @@ func mergeSchemaMapsExact(left, right map[string]any) (map[string]any, bool) {
 			}
 			continue
 		}
+		if key == "items" {
+			leftItems, leftOK := current.(map[string]any)
+			rightItems, rightOK := value.(map[string]any)
+			if !leftOK || !rightOK {
+				return nil, false
+			}
+			mergedItems, ok := intersectGeminiSchemas(leftItems, rightItems)
+			if !ok {
+				return nil, false
+			}
+			out[key] = mergedItems
+			continue
+		}
 		if _, isAnnotation := geminiAnnotationKeys[key]; isAnnotation {
-			out[key] = deepCopyJSON(value)
+			continue
+		}
+		// nullable ANDs across clamps: a typed operand with no nullable key was
+		// explicitly set to false above, so the intersection requires both to
+		// admit null.
+		if key == "nullable" {
+			leftNullable, leftOK := current.(bool)
+			rightNullable, rightOK := value.(bool)
+			if !leftOK || !rightOK {
+				return nil, false
+			}
+			out[key] = leftNullable && rightNullable
+			continue
+		}
+		if key == "enum" {
+			shared, ok := intersectEnums(current, value)
+			if !ok {
+				return nil, false
+			}
+			out[key] = shared
+			continue
+		}
+		if larger, isBound := geminiStricterBoundKeys[key]; isBound {
+			stricter, ok := stricterBound(current, value, larger)
+			if !ok {
+				return nil, false
+			}
+			out[key] = stricter
 			continue
 		}
 		if !semanticJSONEqual(current, value) {
@@ -1585,7 +1651,100 @@ func mergeSchemaMapsExact(left, right map[string]any) (map[string]any, bool) {
 	return out, true
 }
 
-// mergeSchemaMapsLenient merges like mergeSchemaMapsExact but never fails:
+// clampNullableTyped makes a typed schema's implicit non-nullability explicit:
+// Gemini treats an absent nullable as non-nullable, so it only means something
+// when intersection ANDs two ops. A schema with no type constrains nothing and
+// is returned unchanged.
+func clampNullableTyped(schema map[string]any) map[string]any {
+	if _, hasType := schema["type"]; !hasType {
+		return schema
+	}
+	if _, hasNullable := schema["nullable"]; hasNullable {
+		return schema
+	}
+	out := mergeSchemaMaps(schema, nil, false)
+	out["nullable"] = false
+	return out
+}
+
+// stripEmptyNullable removes a nullable:false that is indistinguishable from an
+// absent key, keeping emitted schemas clean. A typed schema may carry a
+// redundant nullable:false after intersection.
+func stripEmptyNullable(schema map[string]any) map[string]any {
+	if _, hasType := schema["type"]; !hasType {
+		return schema
+	}
+	if nullable, ok := schema["nullable"].(bool); ok && !nullable {
+		delete(schema, "nullable")
+	}
+	return schema
+}
+
+// mergeGeminiPropertyMaps merges two `properties` maps. A name declared by
+// both branches has its two subschemas intersected, not compared for equality.
+func mergeGeminiPropertyMaps(left, right map[string]any) (map[string]any, bool) {
+	out := mergeSchemaMaps(left, nil, false)
+	for name, value := range right {
+		current, exists := out[name]
+		if !exists {
+			out[name] = deepCopyJSON(value)
+			continue
+		}
+		leftSchema, leftOK := current.(map[string]any)
+		rightSchema, rightOK := value.(map[string]any)
+		if !leftOK || !rightOK {
+			if !semanticJSONEqual(current, value) {
+				return nil, false
+			}
+			continue
+		}
+		merged, ok := intersectGeminiSchemas(leftSchema, rightSchema)
+		if !ok {
+			return nil, false
+		}
+		out[name] = merged
+	}
+	return out, true
+}
+
+// intersectEnums keeps the members present in both branches, preserving the
+// left order. A disjoint pair is unsatisfiable, so it reports a conflict.
+func intersectEnums(left, right any) (any, bool) {
+	leftValues, leftOK := left.([]any)
+	rightValues, rightOK := right.([]any)
+	if !leftOK || !rightOK {
+		return nil, false
+	}
+	shared := make([]any, 0, len(leftValues))
+	for _, candidate := range leftValues {
+		if valueInEnum(candidate, rightValues) {
+			shared = append(shared, deepCopyJSON(candidate))
+		}
+	}
+	if len(shared) == 0 {
+		return nil, false
+	}
+	return shared, true
+}
+
+// stricterBound returns whichever of the two numeric bounds is the tighter
+// one, which is exactly the intersection for a bound keyword.
+func stricterBound(left, right any, larger bool) (any, bool) {
+	leftValue, leftOK := left.(float64)
+	rightValue, rightOK := right.(float64)
+	if !leftOK || !rightOK {
+		if !semanticJSONEqual(left, right) {
+			return nil, false
+		}
+		return deepCopyJSON(left), true
+	}
+	if larger == (rightValue > leftValue) {
+		return rightValue, true
+	}
+	return leftValue, true
+}
+
+// mergeSchemaMapsLenient merges like intersectGeminiSchemas but never fails:
 // once a branch has been widened away the goal shifts from "prove no conflict"
 // to "produce some representable schema" — properties recurse, required unions,
 // any other conflict keeps left.

--- a/internal/translate/emit_gemini.go
+++ b/internal/translate/emit_gemini.go
@@ -1331,10 +1331,8 @@ func sanitizeGeminiSchemaNode(v any, path string) (any, error) {
 		delete(base, "allOf")
 		node, ok = mergeSchemaMapsExact(base, merged)
 		if !ok {
-			// A merge conflict here is no longer fatal: the caller only needs a
-			// superset-safe schema for generation hints, so fall back to keeping
-			// the sibling (base) side of any remaining conflict rather than
-			// rejecting the whole tool.
+			// No longer fatal: generation hints only need a superset-safe schema,
+			// so keep the sibling (base) side on conflict.
 			node = mergeSchemaMapsLenient(base, merged)
 			widened = true
 			observability.Get().Info("Gemini allOf conflicts with sibling constraints — keeping sibling values", "path", path)
@@ -1623,11 +1621,8 @@ func mergeSchemaMapsLenient(left, right map[string]any) map[string]any {
 	return out
 }
 
-// pruneGeminiRequired drops required entries that reference no declared
-// property. Widening an allOf can remove the branch that declared a property
-// another branch (or a sibling constraint) still lists as required; keeping
-// that entry would make validateGeminiRequired reject the widened schema
-// outright, defeating the point of widening.
+// pruneGeminiRequired drops required entries whose property was removed by
+// widening; Gemini 400s on required-without-property, defeating the widen.
 func pruneGeminiRequired(node map[string]any) {
 	required, ok := node["required"].([]any)
 	if !ok {

--- a/internal/translate/emit_gemini.go
+++ b/internal/translate/emit_gemini.go
@@ -10,6 +10,7 @@ import (
 	"sort"
 	"strings"
 
+	"workweave/router/internal/observability"
 	"workweave/router/internal/providers"
 	"workweave/router/internal/router"
 
@@ -489,10 +490,14 @@ func writeGeminiToolsFromOpenAI(jw *jsonWriter, body []byte) error {
 			}
 			clean, err := sanitizeSchemaForGemini(schema)
 			if err != nil {
-				emitErr = fmt.Errorf("function %q parameters: %w", name, err)
-				return false
+				// The client validates/executes tool calls itself and toolcheck
+				// validates model output against the ORIGINAL schema, so a
+				// declaration with no parameters is safe — a hard failure here
+				// would 502 the whole request over one unrepresentable tool.
+				observability.Get().Warn("Gemini tool schema is unrepresentable — emitting declaration without parameters", "tool_name", name, "err", err)
+			} else {
+				declaration["parameters"] = clean
 			}
-			declaration["parameters"] = clean
 		}
 		declarations = append(declarations, declaration)
 		return true
@@ -982,10 +987,12 @@ func writeGeminiToolsFromAnthropic(jw *jsonWriter, body []byte) error {
 			}
 			clean, err := sanitizeSchemaForGemini(schema)
 			if err != nil {
-				emitErr = fmt.Errorf("function %q input_schema: %w", name, err)
-				return false
+				// See writeGeminiToolsFromOpenAI: a widened/missing schema is
+				// always safe here, so degrade instead of failing the request.
+				observability.Get().Warn("Gemini tool schema is unrepresentable — emitting declaration without parameters", "tool_name", name, "err", err)
+			} else {
+				declaration["parameters"] = clean
 			}
-			declaration["parameters"] = clean
 		}
 		declarations = append(declarations, declaration)
 		return true
@@ -1316,7 +1323,7 @@ func sanitizeGeminiSchemaNode(v any, path string) (any, error) {
 	}
 
 	if allOf, exists := node["allOf"]; exists {
-		merged, err := mergeGeminiAllOf(allOf, path+".allOf")
+		merged, widened, err := mergeGeminiAllOf(allOf, path+".allOf")
 		if err != nil {
 			return nil, err
 		}
@@ -1324,7 +1331,16 @@ func sanitizeGeminiSchemaNode(v any, path string) (any, error) {
 		delete(base, "allOf")
 		node, ok = mergeSchemaMapsExact(base, merged)
 		if !ok {
-			return nil, fmt.Errorf("%w at %s.allOf: branches conflict with sibling constraints", ErrGeminiSchemaIncompatible, path)
+			// A merge conflict here is no longer fatal: the caller only needs a
+			// superset-safe schema for generation hints, so fall back to keeping
+			// the sibling (base) side of any remaining conflict rather than
+			// rejecting the whole tool.
+			node = mergeSchemaMapsLenient(base, merged)
+			widened = true
+			observability.Get().Info("Gemini allOf conflicts with sibling constraints — keeping sibling values", "path", path)
+		}
+		if widened {
+			pruneGeminiRequired(node)
 		}
 	}
 	if _, exists := node["oneOf"]; exists {
@@ -1459,28 +1475,61 @@ func resolveGeminiExclusiveBound(node, out map[string]any, key, exclusiveKey, pa
 	return nil
 }
 
-func mergeGeminiAllOf(v any, path string) (map[string]any, error) {
+// mergeGeminiAllOf merges allOf branches into a single Gemini-representable
+// schema, widening by dropping any branch it cannot merge rather than
+// rejecting the whole tool. Tool input schemas are generation hints only —
+// the client validates/executes tool calls itself and toolcheck validates
+// model output against the ORIGINAL schema — so a superset schema is always
+// safe; the alternative (failing the request) is strictly worse for every
+// caller. widened reports whether any branch was dropped, so the caller can
+// re-validate constraints (like required) that assumed every branch merged.
+func mergeGeminiAllOf(v any, path string) (merged map[string]any, widened bool, err error) {
 	branches, ok := v.([]any)
 	if !ok || len(branches) == 0 {
-		return nil, fmt.Errorf("%w at %s: expected non-empty array", ErrGeminiSchemaIncompatible, path)
+		return nil, false, fmt.Errorf("%w at %s: expected non-empty array", ErrGeminiSchemaIncompatible, path)
 	}
-	merged := map[string]any{}
+	merged = map[string]any{}
+	var (
+		matched  bool
+		firstErr error
+	)
 	for i, branch := range branches {
-		clean, err := sanitizeGeminiSchemaNode(branch, fmt.Sprintf("%s[%d]", path, i))
-		if err != nil {
-			return nil, err
+		branchPath := fmt.Sprintf("%s[%d]", path, i)
+		clean, cleanErr := sanitizeGeminiSchemaNode(branch, branchPath)
+		if cleanErr != nil {
+			widened = true
+			if firstErr == nil {
+				firstErr = cleanErr
+			}
+			observability.Get().Info("Gemini allOf branch is unrepresentable — widening by dropping it", "path", branchPath, "err", cleanErr)
+			continue
 		}
-		object, ok := clean.(map[string]any)
-		if !ok {
-			return nil, fmt.Errorf("%w at %s[%d]: branch is not an object schema", ErrGeminiSchemaIncompatible, path, i)
+		object, isObject := clean.(map[string]any)
+		if !isObject {
+			widened = true
+			branchErr := fmt.Errorf("%w at %s: branch is not an object schema", ErrGeminiSchemaIncompatible, branchPath)
+			if firstErr == nil {
+				firstErr = branchErr
+			}
+			observability.Get().Info("Gemini allOf branch is unrepresentable — widening by dropping it", "path", branchPath, "err", branchErr)
+			continue
 		}
-		var mergedOK bool
-		merged, mergedOK = mergeSchemaMapsExact(merged, object)
+		candidate, mergedOK := mergeSchemaMapsExact(merged, object)
 		if !mergedOK {
-			return nil, fmt.Errorf("%w at %s[%d]: branches conflict", ErrGeminiSchemaIncompatible, path, i)
+			widened = true
+			if firstErr == nil {
+				firstErr = fmt.Errorf("%w at %s: branch conflicts with prior branches", ErrGeminiSchemaIncompatible, branchPath)
+			}
+			observability.Get().Info("Gemini allOf branch is unrepresentable — widening by dropping it", "path", branchPath, "conflict", "branch conflicts with prior branches")
+			continue
 		}
+		merged = candidate
+		matched = true
 	}
-	return merged, nil
+	if !matched {
+		return nil, false, firstErr
+	}
+	return merged, widened, nil
 }
 
 func mergeSchemaMaps(base, extra map[string]any, overwrite bool) map[string]any {
@@ -1494,6 +1543,17 @@ func mergeSchemaMaps(base, extra map[string]any, overwrite bool) map[string]any 
 		}
 	}
 	return out
+}
+
+// geminiAnnotationKeys are schema keywords that document a value rather than
+// constrain what the model may generate. allOf branches disagreeing on one of
+// these isn't a real conflict, so mergeSchemaMapsExact lets the later branch
+// win instead of rejecting the merge.
+var geminiAnnotationKeys = map[string]struct{}{
+	"description": {},
+	"title":       {},
+	"default":     {},
+	"example":     {},
 }
 
 func mergeSchemaMapsExact(left, right map[string]any) (map[string]any, bool) {
@@ -1524,11 +1584,83 @@ func mergeSchemaMapsExact(left, right map[string]any) (map[string]any, bool) {
 			}
 			continue
 		}
+		if _, isAnnotation := geminiAnnotationKeys[key]; isAnnotation {
+			out[key] = deepCopyJSON(value)
+			continue
+		}
 		if !semanticJSONEqual(current, value) {
 			return nil, false
 		}
 	}
 	return out, true
+}
+
+// mergeSchemaMapsLenient merges left and right like mergeSchemaMapsExact but
+// never fails: it's the fallback once an allOf branch has already been
+// widened away, so the goal shifts from "prove no conflict" to "produce some
+// representable schema." properties recurse leniently; required unions via
+// uniqueStrings, keeping left's value if the input is too malformed to union;
+// any other conflicting key keeps left. Annotation-key conflicts never reach
+// here — mergeSchemaMapsExact already resolves those right-wins before this
+// fallback is needed, so this path's left-wins default doesn't apply to them.
+func mergeSchemaMapsLenient(left, right map[string]any) map[string]any {
+	out := mergeSchemaMaps(left, nil, false)
+	for key, value := range right {
+		current, exists := out[key]
+		if !exists {
+			out[key] = deepCopyJSON(value)
+			continue
+		}
+		if key == "properties" {
+			leftProperties, leftOK := current.(map[string]any)
+			rightProperties, rightOK := value.(map[string]any)
+			if !leftOK || !rightOK {
+				continue
+			}
+			out[key] = mergeSchemaMapsLenient(leftProperties, rightProperties)
+			continue
+		}
+		if key == "required" {
+			if merged := uniqueStrings(current, value); merged != nil {
+				out[key] = merged
+			}
+			continue
+		}
+		// Any other conflict keeps left (out[key] is already current).
+	}
+	return out
+}
+
+// pruneGeminiRequired drops required entries that reference no declared
+// property. Widening an allOf can remove the branch that declared a property
+// another branch (or a sibling constraint) still lists as required; keeping
+// that entry would make validateGeminiRequired reject the widened schema
+// outright, defeating the point of widening.
+func pruneGeminiRequired(node map[string]any) {
+	required, ok := node["required"].([]any)
+	if !ok {
+		return
+	}
+	properties, _ := node["properties"].(map[string]any)
+	if properties == nil {
+		delete(node, "required")
+		return
+	}
+	kept := make([]any, 0, len(required))
+	for _, entry := range required {
+		name, ok := entry.(string)
+		if !ok {
+			continue
+		}
+		if _, exists := properties[name]; exists {
+			kept = append(kept, name)
+		}
+	}
+	if len(kept) == 0 {
+		delete(node, "required")
+		return
+	}
+	node["required"] = kept
 }
 
 func uniqueStrings(left, right any) any {

--- a/internal/translate/emit_gemini.go
+++ b/internal/translate/emit_gemini.go
@@ -1539,10 +1539,8 @@ func mergeSchemaMaps(base, extra map[string]any, overwrite bool) map[string]any 
 	return out
 }
 
-// geminiAnnotationKeys are schema keywords that document a value rather than
-// constrain what the model may generate. allOf branches disagreeing on one of
-// these isn't a real conflict, so mergeSchemaMapsExact lets the later branch
-// win instead of rejecting the merge.
+// geminiAnnotationKeys are schema keywords that document rather than
+// constrain; allOf branches may disagree on them without real conflict.
 var geminiAnnotationKeys = map[string]struct{}{
 	"description": {},
 	"title":       {},

--- a/internal/translate/emit_gemini.go
+++ b/internal/translate/emit_gemini.go
@@ -490,10 +490,8 @@ func writeGeminiToolsFromOpenAI(jw *jsonWriter, body []byte) error {
 			}
 			clean, err := sanitizeSchemaForGemini(schema)
 			if err != nil {
-				// The client validates/executes tool calls itself and toolcheck
-				// validates model output against the ORIGINAL schema, so a
-				// declaration with no parameters is safe — a hard failure here
-				// would 502 the whole request over one unrepresentable tool.
+				// Tool schemas are generation hints; a parameterless declaration is
+				// safe — the client validates against the ORIGINAL schema.
 				observability.Get().Warn("Gemini tool schema is unrepresentable — emitting declaration without parameters", "tool_name", name, "err", err)
 			} else {
 				declaration["parameters"] = clean

--- a/internal/translate/emit_gemini.go
+++ b/internal/translate/emit_gemini.go
@@ -1476,13 +1476,9 @@ func resolveGeminiExclusiveBound(node, out map[string]any, key, exclusiveKey, pa
 }
 
 // mergeGeminiAllOf merges allOf branches into a single Gemini-representable
-// schema, widening by dropping any branch it cannot merge rather than
-// rejecting the whole tool. Tool input schemas are generation hints only —
-// the client validates/executes tool calls itself and toolcheck validates
-// model output against the ORIGINAL schema — so a superset schema is always
-// safe; the alternative (failing the request) is strictly worse for every
-// caller. widened reports whether any branch was dropped, so the caller can
-// re-validate constraints (like required) that assumed every branch merged.
+// schema, widening (dropping unrepresentable branches) instead of rejecting.
+// widened reports whether any branch was dropped, so the caller can
+// re-validate constraints (e.g. required) that assumed every branch merged.
 func mergeGeminiAllOf(v any, path string) (merged map[string]any, widened bool, err error) {
 	branches, ok := v.([]any)
 	if !ok || len(branches) == 0 {
@@ -1595,14 +1591,10 @@ func mergeSchemaMapsExact(left, right map[string]any) (map[string]any, bool) {
 	return out, true
 }
 
-// mergeSchemaMapsLenient merges left and right like mergeSchemaMapsExact but
-// never fails: it's the fallback once an allOf branch has already been
-// widened away, so the goal shifts from "prove no conflict" to "produce some
-// representable schema." properties recurse leniently; required unions via
-// uniqueStrings, keeping left's value if the input is too malformed to union;
-// any other conflicting key keeps left. Annotation-key conflicts never reach
-// here — mergeSchemaMapsExact already resolves those right-wins before this
-// fallback is needed, so this path's left-wins default doesn't apply to them.
+// mergeSchemaMapsLenient merges like mergeSchemaMapsExact but never fails:
+// once a branch has been widened away the goal shifts from "prove no conflict"
+// to "produce some representable schema" — properties recurse, required unions,
+// any other conflict keeps left.
 func mergeSchemaMapsLenient(left, right map[string]any) map[string]any {
 	out := mergeSchemaMaps(left, nil, false)
 	for key, value := range right {

--- a/internal/translate/fidelity_test.go
+++ b/internal/translate/fidelity_test.go
@@ -68,9 +68,8 @@ func TestPrepareGemini_SchemaFidelity(t *testing.T) {
 			},
 		},
 		{
-			// A dropped branch can leave sibling `required` referencing a
-			// property no surviving branch declares; Gemini rejects that
-			// outright, so the prune must run whenever a branch was widened.
+			// A widened branch can orphan sibling `required` entries;
+			// Gemini rejects required-without-property, so prune after widening.
 			name:   "required is pruned when the branch that declared it is dropped",
 			schema: `{"type":"object","required":["b"],"allOf":[{"type":"object","properties":{"a":{"type":"string"}},"pattern":"^1"},{"type":"object","properties":{"b":{"type":"string"}},"pattern":"^2"}]}`,
 			check: func(t *testing.T, schema map[string]any) {
@@ -88,10 +87,8 @@ func TestPrepareGemini_SchemaFidelity(t *testing.T) {
 			},
 		},
 		{
-			// oneOf has no widening path (selecting a branch would silently
-			// narrow the tool's input language), so the schema is still
-			// unrepresentable — but the per-tool backstop keeps the request
-			// alive by emitting the declaration without parameters.
+			// oneOf has no safe widening path — per-tool backstop degrades
+			// to no parameters rather than silently narrowing the input language.
 			name:         "oneOf degrades the tool rather than selecting a branch",
 			schema:       `{"oneOf":[{"type":"string"},{"type":"number"}]}`,
 			wantDegraded: true,

--- a/internal/translate/fidelity_test.go
+++ b/internal/translate/fidelity_test.go
@@ -199,6 +199,20 @@ func TestPrepareGemini_SchemaFidelity(t *testing.T) {
 			},
 		},
 		{
+			// A NESTED sibling property may still carry a raw type:[T,"null"]
+			// array when it reaches intersection (only the top level is
+			// normalized before the sibling merge); it must intersect with the
+			// branch's constraints, not fail into the lenient path and drop them.
+			name:   "raw nullable type array on a nested sibling property still intersects",
+			schema: `{"type":"object","properties":{"id":{"type":["string","null"]}},"allOf":[{"type":"object","properties":{"id":{"type":"string","minLength":4}}}]}`,
+			check: func(t *testing.T, schema map[string]any) {
+				id := schema["properties"].(map[string]any)["id"].(map[string]any)
+				assert.Equal(t, "string", id["type"])
+				assert.Equal(t, float64(4), id["minLength"])
+				assert.NotContains(t, id, "nullable")
+			},
+		},
+		{
 			// A nullable sibling combined with an identical nullable branch
 			// stays nullable rather than misreading the raw sibling type array as
 			// non-null and rejecting the pair as conflicting.

--- a/internal/translate/fidelity_test.go
+++ b/internal/translate/fidelity_test.go
@@ -51,11 +51,8 @@ func TestPrepareGemini_SchemaFidelity(t *testing.T) {
 			},
 		},
 		{
-			// Tool input schemas are generation hints only — the client
-			// validates/executes tool calls itself and toolcheck validates
-			// model output against the ORIGINAL schema — so widening by
-			// dropping the conflicting branch is always safe; failing the
-			// whole request over one unrepresentable allOf is strictly worse.
+			// Tool schemas are generation hints; the client validates against the
+			// ORIGINAL schema, so a widened superset is always safe.
 			name:   "allOf conflict widens by dropping the conflicting branch",
 			schema: `{"allOf":[{"type":"string"},{"type":"number"}]}`,
 			check: func(t *testing.T, schema map[string]any) {

--- a/internal/translate/fidelity_test.go
+++ b/internal/translate/fidelity_test.go
@@ -60,11 +60,11 @@ func TestPrepareGemini_SchemaFidelity(t *testing.T) {
 			},
 		},
 		{
-			name:   "allOf annotation conflict merges with later branch winning",
+			name:   "allOf annotation conflict merges with earlier branch winning",
 			schema: `{"allOf":[{"type":"string","description":"from the base type"},{"type":"string","description":"per-tool override"}]}`,
 			check: func(t *testing.T, schema map[string]any) {
 				assert.Equal(t, "string", schema["type"])
-				assert.Equal(t, "per-tool override", schema["description"])
+				assert.Equal(t, "from the base type", schema["description"])
 			},
 		},
 		{
@@ -77,6 +77,136 @@ func TestPrepareGemini_SchemaFidelity(t *testing.T) {
 				assert.Contains(t, props, "a")
 				assert.NotContains(t, props, "b")
 				assert.NotContains(t, schema, "required")
+			},
+		},
+		{
+			// Annotation-only branch (prod-observed shape); outer branch value wins.
+			name:   "allOf branches disagreeing on annotations merge",
+			schema: `{"type":"object","properties":{"to":{"allOf":[{"type":"string","description":"A","title":"T1"},{"type":"string","description":"B","title":"T2"}]}}}`,
+			check: func(t *testing.T, schema map[string]any) {
+				to := schema["properties"].(map[string]any)["to"].(map[string]any)
+				assert.Equal(t, "string", to["type"])
+				assert.Equal(t, "A", to["description"])
+				assert.Equal(t, "T1", to["title"])
+			},
+		},
+		{
+			name:   "allOf bounds narrow to the stricter of each pair",
+			schema: `{"allOf":[{"type":"string","minLength":1,"maxLength":10},{"type":"string","minLength":5,"maxLength":8}]}`,
+			check: func(t *testing.T, schema map[string]any) {
+				assert.Equal(t, float64(5), schema["minLength"])
+				assert.Equal(t, float64(8), schema["maxLength"])
+			},
+		},
+		{
+			name:   "allOf numeric bounds narrow regardless of branch order",
+			schema: `{"allOf":[{"type":"integer","minimum":10,"maximum":20},{"type":"integer","minimum":2,"maximum":50}]}`,
+			check: func(t *testing.T, schema map[string]any) {
+				assert.Equal(t, float64(10), schema["minimum"])
+				assert.Equal(t, float64(20), schema["maximum"])
+			},
+		},
+		{
+			name:   "allOf enums intersect to the shared members",
+			schema: `{"allOf":[{"type":"string","enum":["a","b","c"]},{"type":"string","enum":["b","c","d"]}]}`,
+			check: func(t *testing.T, schema map[string]any) {
+				assert.Equal(t, []any{"b", "c"}, schema["enum"])
+			},
+		},
+		{
+			// Disjoint enums admit no value at all — an unsatisfiable
+			// intersection — so the conflicting branch is dropped (widened)
+			// rather than failing the request.
+			name:   "allOf disjoint enums widen by dropping the later branch",
+			schema: `{"allOf":[{"type":"string","enum":["a"]},{"type":"string","enum":["b"]}]}`,
+			check: func(t *testing.T, schema map[string]any) {
+				assert.Equal(t, []any{"a"}, schema["enum"])
+			},
+		},
+		{
+			// pattern is a constraint, not an annotation: identical branch
+			// patterns merge; differing regexes cannot be intersected, so the
+			// later branch is dropped (widened) instead.
+			name:   "allOf identical patterns merge",
+			schema: `{"allOf":[{"type":"string","pattern":"^[A-Z]{3}$"},{"type":"string","pattern":"^[A-Z]{3}$"}]}`,
+			check: func(t *testing.T, schema map[string]any) {
+				assert.Equal(t, "^[A-Z]{3}$", schema["pattern"])
+			},
+		},
+		{
+			name:   "allOf differing patterns widen by dropping the later branch",
+			schema: `{"allOf":[{"type":"string","pattern":"^[A-Z]+$"},{"type":"string","pattern":"^[A-Z]{3}$"}]}`,
+			check: func(t *testing.T, schema map[string]any) {
+				assert.Equal(t, "^[A-Z]+$", schema["pattern"])
+			},
+		},
+		{
+			name:   "allOf intersects a property declared by both branches",
+			schema: `{"allOf":[{"type":"object","properties":{"id":{"type":"string","minLength":1}}},{"type":"object","properties":{"id":{"type":"string","minLength":4}}}]}`,
+			check: func(t *testing.T, schema map[string]any) {
+				id := schema["properties"].(map[string]any)["id"].(map[string]any)
+				assert.Equal(t, "string", id["type"])
+				assert.Equal(t, float64(4), id["minLength"])
+			},
+		},
+		{
+			// A type conflict nested under a shared property makes the later
+			// branch unmergeable, so it is dropped (widened).
+			name:   "allOf conflict nested under a shared property widens",
+			schema: `{"allOf":[{"type":"object","properties":{"id":{"type":"string"}}},{"type":"object","properties":{"id":{"type":"number"}}}]}`,
+			check: func(t *testing.T, schema map[string]any) {
+				id := schema["properties"].(map[string]any)["id"].(map[string]any)
+				assert.Equal(t, "string", id["type"])
+			},
+		},
+		{
+			name:   "allOf array item schemas intersect",
+			schema: `{"allOf":[{"type":"array","items":{"type":"string","minLength":2}},{"type":"array","items":{"type":"string","minLength":6}}]}`,
+			check: func(t *testing.T, schema map[string]any) {
+				items := schema["items"].(map[string]any)
+				assert.Equal(t, "string", items["type"])
+				assert.Equal(t, float64(6), items["minLength"])
+			},
+		},
+		{
+			// nullable intersects: a nullable branch AND a non-nullable one is
+			// non-nullable, which Gemini spells as the absence of the key.
+			name:   "allOf nullable requires both branches to admit null",
+			schema: `{"allOf":[{"type":["string","null"]},{"type":"string"}]}`,
+			check: func(t *testing.T, schema map[string]any) {
+				assert.Equal(t, "string", schema["type"])
+				assert.NotContains(t, schema, "nullable")
+			},
+		},
+		{
+			name:   "allOf keeps nullable when both branches admit null",
+			schema: `{"allOf":[{"type":["string","null"]},{"type":["string","null"]}]}`,
+			check: func(t *testing.T, schema map[string]any) {
+				assert.Equal(t, "string", schema["type"])
+				assert.Equal(t, true, schema["nullable"])
+			},
+		},
+		{
+			// A typed sibling that omits nullable is non-nullable, so a nullable
+			// allOf branch must not widen it back (regression: intersect used to
+			// absorb nullable:true from the branch over the sibling's implicit
+			// non-nullability).
+			name:   "nullable allOf branch does not widen a non-null sibling",
+			schema: `{"type":"string","allOf":[{"type":["string","null"]}]}`,
+			check: func(t *testing.T, schema map[string]any) {
+				assert.Equal(t, "string", schema["type"])
+				assert.NotContains(t, schema, "nullable")
+			},
+		},
+		{
+			// A nullable sibling combined with an identical nullable branch
+			// stays nullable rather than misreading the raw sibling type array as
+			// non-null and rejecting the pair as conflicting.
+			name:   "nullable sibling plus same nullable branch merges",
+			schema: `{"type":["string","null"],"allOf":[{"type":["string","null"]}]}`,
+			check: func(t *testing.T, schema map[string]any) {
+				assert.Equal(t, "string", schema["type"])
+				assert.Equal(t, true, schema["nullable"])
 			},
 		},
 		{

--- a/internal/translate/fidelity_test.go
+++ b/internal/translate/fidelity_test.go
@@ -15,10 +15,13 @@ import (
 
 func TestPrepareGemini_SchemaFidelity(t *testing.T) {
 	tests := []struct {
-		name    string
-		schema  string
-		wantErr error
-		check   func(*testing.T, map[string]any)
+		name   string
+		schema string
+		// wantDegraded expects the request to succeed with the tool's
+		// declaration emitted WITHOUT parameters (the per-tool backstop for
+		// schemas that stay unrepresentable after widening).
+		wantDegraded bool
+		check        func(*testing.T, map[string]any)
 	}{
 		{
 			// Gemini types every enum member as TYPE_STRING; a numeric const lowers
@@ -48,9 +51,37 @@ func TestPrepareGemini_SchemaFidelity(t *testing.T) {
 			},
 		},
 		{
-			name:    "allOf conflict rejects",
-			schema:  `{"allOf":[{"type":"string"},{"type":"number"}]}`,
-			wantErr: translate.ErrGeminiSchemaIncompatible,
+			// Tool input schemas are generation hints only — the client
+			// validates/executes tool calls itself and toolcheck validates
+			// model output against the ORIGINAL schema — so widening by
+			// dropping the conflicting branch is always safe; failing the
+			// whole request over one unrepresentable allOf is strictly worse.
+			name:   "allOf conflict widens by dropping the conflicting branch",
+			schema: `{"allOf":[{"type":"string"},{"type":"number"}]}`,
+			check: func(t *testing.T, schema map[string]any) {
+				assert.Equal(t, "string", schema["type"])
+			},
+		},
+		{
+			name:   "allOf annotation conflict merges with later branch winning",
+			schema: `{"allOf":[{"type":"string","description":"from the base type"},{"type":"string","description":"per-tool override"}]}`,
+			check: func(t *testing.T, schema map[string]any) {
+				assert.Equal(t, "string", schema["type"])
+				assert.Equal(t, "per-tool override", schema["description"])
+			},
+		},
+		{
+			// A dropped branch can leave sibling `required` referencing a
+			// property no surviving branch declares; Gemini rejects that
+			// outright, so the prune must run whenever a branch was widened.
+			name:   "required is pruned when the branch that declared it is dropped",
+			schema: `{"type":"object","required":["b"],"allOf":[{"type":"object","properties":{"a":{"type":"string"}},"pattern":"^1"},{"type":"object","properties":{"b":{"type":"string"}},"pattern":"^2"}]}`,
+			check: func(t *testing.T, schema map[string]any) {
+				props := schema["properties"].(map[string]any)
+				assert.Contains(t, props, "a")
+				assert.NotContains(t, props, "b")
+				assert.NotContains(t, schema, "required")
+			},
 		},
 		{
 			name:   "anyOf preserves every branch",
@@ -60,14 +91,18 @@ func TestPrepareGemini_SchemaFidelity(t *testing.T) {
 			},
 		},
 		{
-			name:    "oneOf rejects rather than selecting a branch",
-			schema:  `{"oneOf":[{"type":"string"},{"type":"number"}]}`,
-			wantErr: translate.ErrGeminiSchemaIncompatible,
+			// oneOf has no widening path (selecting a branch would silently
+			// narrow the tool's input language), so the schema is still
+			// unrepresentable — but the per-tool backstop keeps the request
+			// alive by emitting the declaration without parameters.
+			name:         "oneOf degrades the tool rather than selecting a branch",
+			schema:       `{"oneOf":[{"type":"string"},{"type":"number"}]}`,
+			wantDegraded: true,
 		},
 		{
-			name:    "unresolved reference rejects",
-			schema:  `{"$ref":"#/$defs/Missing","$defs":{"Present":{"type":"string"}}}`,
-			wantErr: translate.ErrGeminiSchemaIncompatible,
+			name:         "unresolved reference degrades the tool",
+			schema:       `{"$ref":"#/$defs/Missing","$defs":{"Present":{"type":"string"}}}`,
+			wantDegraded: true,
 		},
 		{
 			// additionalProperties has no Gemini equivalent (Gemini always
@@ -91,15 +126,15 @@ func TestPrepareGemini_SchemaFidelity(t *testing.T) {
 			env, err := translate.ParseAnthropic(body)
 			require.NoError(t, err)
 			prep, err := env.PrepareGemini(http.Header{}, translate.EmitOptions{TargetModel: "gemini-3.1-pro-preview"})
-			if tt.wantErr != nil {
-				require.ErrorIs(t, err, tt.wantErr)
-				return
-			}
 			require.NoError(t, err)
 			var out map[string]any
 			require.NoError(t, json.Unmarshal(prep.Body, &out))
-			schema := out["tools"].([]any)[0].(map[string]any)["functionDeclarations"].([]any)[0].(map[string]any)["parameters"].(map[string]any)
-			tt.check(t, schema)
+			declaration := out["tools"].([]any)[0].(map[string]any)["functionDeclarations"].([]any)[0].(map[string]any)
+			if tt.wantDegraded {
+				assert.NotContains(t, declaration, "parameters")
+				return
+			}
+			tt.check(t, declaration["parameters"].(map[string]any))
 		})
 	}
 }

--- a/internal/translate/gemini_test.go
+++ b/internal/translate/gemini_test.go
@@ -711,9 +711,8 @@ func TestPrepareGemini_WidensExclusiveBoundsToInclusive(t *testing.T) {
 
 func TestPrepareGemini_DanglingRequiredDegradesToNoParameters(t *testing.T) {
 	// Gemini 400s when "required" names a property not in "properties" —
-	// valid JSON Schema, so MCP tool schemas can carry it. The strict
-	// validator still flags it, but the per-tool backstop emits the
-	// declaration without parameters instead of failing the whole request.
+	// valid JSON Schema, so MCP tool schemas can carry it; the backstop
+	// degrades that tool instead of failing the whole request.
 	body := []byte(`{
 		"messages": [{"role":"user","content":"hi"}],
 		"tools": [{
@@ -793,9 +792,8 @@ func TestPrepareGemini_PreservesPropertyNamedRequired(t *testing.T) {
 
 func TestPrepareGemini_VendorExtensionKeysDegradeToNoParameters(t *testing.T) {
 	// MCP schemas derived from Google APIs embed vendor extensions
-	// (`x-google-*`) at every level; Gemini 400s on unknown fields and the
-	// sanitizer's allowlist rejects them. The per-tool backstop turns that
-	// into a parameterless declaration instead of failing the request.
+	// (`x-google-*`) at every level; Gemini 400s on unknown fields,
+	// so the per-tool backstop degrades rather than 502ing.
 	body := []byte(`{
 		"messages": [{"role":"user","content":"hi"}],
 		"tools": [{
@@ -916,9 +914,8 @@ func TestPrepareGemini_DropsUnsupportedFormatValues(t *testing.T) {
 
 func TestPrepareGemini_ItemsFalseDegradesToNoParameters(t *testing.T) {
 	// MCP schemas use boolean `items`; Gemini's proto Schema.items rejects
-	// booleans. `items: true` collapses to the permissive empty schema, but
-	// `items: false` (an unsatisfiable array) stays unrepresentable — the
-	// per-tool backstop degrades that tool instead of failing the request.
+	// booleans. `items: true` collapses to the permissive empty schema;
+	// `items: false` (unsatisfiable) stays unrepresentable — backstop degrades.
 	body := []byte(`{
 		"messages": [{"role":"user","content":"hi"}],
 		"tools": [{
@@ -1320,10 +1317,9 @@ func TestPrepareGemini_SendMessageToAllOfRegression(t *testing.T) {
 }
 
 func TestPrepareGemini_UnrepresentableToolSchemaDegradesToNoParameters(t *testing.T) {
-	// oneOf has no widening path (selecting a branch would silently narrow the
-	// tool's input language), so it stays a hard sanitize failure. The
-	// per-tool backstop must still keep the rest of the request alive by
-	// emitting the declaration without parameters instead of 502ing.
+	// oneOf has no widening path (selecting a branch would silently narrow
+	// the tool's input language) — the per-tool backstop emits without
+	// parameters, keeping other healthy tools alive.
 	body := []byte(`{
 		"messages": [{"role":"user","content":"hi"}],
 		"tools": [

--- a/internal/translate/gemini_test.go
+++ b/internal/translate/gemini_test.go
@@ -1310,7 +1310,7 @@ func TestPrepareGemini_SendMessageToAllOfRegression(t *testing.T) {
 
 	to := props["to"].(map[string]any)
 	assert.Equal(t, "string", to["type"])
-	assert.Equal(t, "Recipient: teammate name", to["description"], "later branch's annotation wins")
+	assert.Equal(t, "Teammate recipient", to["description"], "earlier branch's annotation wins")
 	assert.ElementsMatch(t, []any{"message", "to"}, params["required"])
 }
 

--- a/internal/translate/gemini_test.go
+++ b/internal/translate/gemini_test.go
@@ -1277,10 +1277,8 @@ func TestPrepareGemini_ConvertsBoolPropertySchemas(t *testing.T) {
 }
 
 func TestPrepareGemini_SendMessageToAllOfRegression(t *testing.T) {
-	// Prod regression: a Claude Code SendMessage-shaped tool whose "to"
-	// property is an allOf of two same-typed branches with differing
-	// descriptions. This used to fail the whole request with
-	// ErrGeminiSchemaIncompatible ("branches conflict"); it must now widen.
+	// Regression: allOf branches with differing descriptions must widen
+	// (annotation merge), not fail the whole request.
 	body := []byte(`{
 		"messages": [{"role":"user","content":"hi"}],
 		"tools": [{
@@ -1317,9 +1315,7 @@ func TestPrepareGemini_SendMessageToAllOfRegression(t *testing.T) {
 }
 
 func TestPrepareGemini_UnrepresentableToolSchemaDegradesToNoParameters(t *testing.T) {
-	// oneOf has no widening path (selecting a branch would silently narrow
-	// the tool's input language) — the per-tool backstop emits without
-	// parameters, keeping other healthy tools alive.
+	// oneOf has no widening path — per-tool backstop keeps healthy tools alive.
 	body := []byte(`{
 		"messages": [{"role":"user","content":"hi"}],
 		"tools": [

--- a/internal/translate/gemini_test.go
+++ b/internal/translate/gemini_test.go
@@ -3,6 +3,8 @@ package translate_test
 import (
 	"encoding/base64"
 	"encoding/json"
+	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -707,9 +709,11 @@ func TestPrepareGemini_WidensExclusiveBoundsToInclusive(t *testing.T) {
 	assert.Equal(t, float64(5), strict["minimum"], "widened exclusiveMinimum (5) is tighter than explicit minimum (0)")
 }
 
-func TestPrepareGemini_PrunesDanglingRequired(t *testing.T) {
-	// Regression: Gemini 400s when "required" names a property not in
-	// "properties" — valid JSON Schema, so MCP tool schemas can carry it; prune it.
+func TestPrepareGemini_DanglingRequiredDegradesToNoParameters(t *testing.T) {
+	// Gemini 400s when "required" names a property not in "properties" —
+	// valid JSON Schema, so MCP tool schemas can carry it. The strict
+	// validator still flags it, but the per-tool backstop emits the
+	// declaration without parameters instead of failing the whole request.
 	body := []byte(`{
 		"messages": [{"role":"user","content":"hi"}],
 		"tools": [{
@@ -721,19 +725,30 @@ func TestPrepareGemini_PrunesDanglingRequired(t *testing.T) {
 				"required":["x","ghost"]
 			}
 		},{
-			"name":"AllDangling",
+			"name":"Healthy",
 			"description":"d",
 			"input_schema":{
 				"type":"object",
 				"properties":{"a":{"type":"string"}},
-				"required":["missing"]
+				"required":["a"]
 			}
 		}]
 	}`)
 	env, err := translate.ParseAnthropic(body)
 	require.NoError(t, err)
-	_, err = env.PrepareGemini(http.Header{}, translate.EmitOptions{})
-	require.ErrorIs(t, err, translate.ErrGeminiSchemaIncompatible)
+	prep, err := env.PrepareGemini(http.Header{}, translate.EmitOptions{})
+	require.NoError(t, err)
+
+	out := mustUnmarshal(t, prep.Body)
+	decls := out["tools"].([]any)[0].(map[string]any)["functionDeclarations"].([]any)
+	require.Len(t, decls, 2)
+	byName := make(map[string]map[string]any, len(decls))
+	for _, d := range decls {
+		decl := d.(map[string]any)
+		byName[decl["name"].(string)] = decl
+	}
+	assert.NotContains(t, byName["DoThing"], "parameters", "dangling required degrades that tool only")
+	assert.Contains(t, byName["Healthy"], "parameters")
 }
 
 func TestPrepareGemini_PreservesPropertyNamedRequired(t *testing.T) {
@@ -776,10 +791,11 @@ func TestPrepareGemini_PreservesPropertyNamedRequired(t *testing.T) {
 	assert.Equal(t, []any{"inner"}, prop["required"])
 }
 
-func TestPrepareGemini_StripsVendorExtensionAndDollarPrefixedKeys(t *testing.T) {
-	// Regression: MCP schemas derived from Google APIs embed vendor extensions
-	// (`x-google-*`) at every level; Gemini 400s on unknown fields. Strip any
-	// "x-" or "$" prefixed key instead of maintaining an allowlist.
+func TestPrepareGemini_VendorExtensionKeysDegradeToNoParameters(t *testing.T) {
+	// MCP schemas derived from Google APIs embed vendor extensions
+	// (`x-google-*`) at every level; Gemini 400s on unknown fields and the
+	// sanitizer's allowlist rejects them. The per-tool backstop turns that
+	// into a parameterless declaration instead of failing the request.
 	body := []byte(`{
 		"messages": [{"role":"user","content":"hi"}],
 		"tools": [{
@@ -808,8 +824,13 @@ func TestPrepareGemini_StripsVendorExtensionAndDollarPrefixedKeys(t *testing.T) 
 	}`)
 	env, err := translate.ParseAnthropic(body)
 	require.NoError(t, err)
-	_, err = env.PrepareGemini(http.Header{}, translate.EmitOptions{})
-	require.ErrorIs(t, err, translate.ErrGeminiSchemaIncompatible)
+	prep, err := env.PrepareGemini(http.Header{}, translate.EmitOptions{})
+	require.NoError(t, err)
+
+	out := mustUnmarshal(t, prep.Body)
+	decl := out["tools"].([]any)[0].(map[string]any)["functionDeclarations"].([]any)[0].(map[string]any)
+	assert.Equal(t, "sheets_get", decl["name"])
+	assert.NotContains(t, decl, "parameters")
 }
 
 func TestSanitizeSchemaForGemini_PreservesSupportedFields(t *testing.T) {
@@ -893,9 +914,11 @@ func TestPrepareGemini_DropsUnsupportedFormatValues(t *testing.T) {
 	assert.Equal(t, "double", score["format"])
 }
 
-func TestPrepareGemini_CollapsesItemsBool(t *testing.T) {
-	// Regression: MCP schemas (e.g. SigNoz) use `"items": true` (JSON Schema:
-	// any items allowed); Gemini's proto Schema.items rejects boolean values.
+func TestPrepareGemini_ItemsFalseDegradesToNoParameters(t *testing.T) {
+	// MCP schemas use boolean `items`; Gemini's proto Schema.items rejects
+	// booleans. `items: true` collapses to the permissive empty schema, but
+	// `items: false` (an unsatisfiable array) stays unrepresentable — the
+	// per-tool backstop degrades that tool instead of failing the request.
 	body := []byte(`{
 		"messages": [{"role":"user","content":"hi"}],
 		"tools": [{
@@ -907,13 +930,20 @@ func TestPrepareGemini_CollapsesItemsBool(t *testing.T) {
 						"type":"array",
 						"items":true
 					},
-					"disabled":{
-						"type":"array",
-						"items":false
-					},
 					"links":{
 						"type":"array",
 						"items":{"type":"string"}
+					}
+				}
+			}
+		},{
+			"name":"toggle_widgets",
+			"input_schema":{
+				"type":"object",
+				"properties":{
+					"disabled":{
+						"type":"array",
+						"items":false
 					}
 				}
 			}
@@ -921,8 +951,25 @@ func TestPrepareGemini_CollapsesItemsBool(t *testing.T) {
 	}`)
 	env, err := translate.ParseAnthropic(body)
 	require.NoError(t, err)
-	_, err = env.PrepareGemini(http.Header{}, translate.EmitOptions{})
-	require.ErrorIs(t, err, translate.ErrGeminiSchemaIncompatible)
+	prep, err := env.PrepareGemini(http.Header{}, translate.EmitOptions{})
+	require.NoError(t, err)
+
+	out := mustUnmarshal(t, prep.Body)
+	decls := out["tools"].([]any)[0].(map[string]any)["functionDeclarations"].([]any)
+	require.Len(t, decls, 2)
+	byName := make(map[string]map[string]any, len(decls))
+	for _, d := range decls {
+		decl := d.(map[string]any)
+		byName[decl["name"].(string)] = decl
+	}
+
+	// items:true collapses to the permissive empty schema.
+	params := byName["create_dashboard"]["parameters"].(map[string]any)
+	args := params["properties"].(map[string]any)["args"].(map[string]any)
+	assert.Equal(t, map[string]any{}, args["items"])
+
+	// items:false degrades only the tool that carries it.
+	assert.NotContains(t, byName["toggle_widgets"], "parameters")
 }
 
 func TestPrepareGemini_CollapsesArrayTypeField(t *testing.T) {
@@ -1230,4 +1277,135 @@ func TestPrepareGemini_ConvertsBoolPropertySchemas(t *testing.T) {
 	rp, ok := props["realProp"].(map[string]any)
 	require.True(t, ok)
 	assert.Equal(t, "string", rp["type"])
+}
+
+func TestPrepareGemini_SendMessageToAllOfRegression(t *testing.T) {
+	// Prod regression: a Claude Code SendMessage-shaped tool whose "to"
+	// property is an allOf of two same-typed branches with differing
+	// descriptions. This used to fail the whole request with
+	// ErrGeminiSchemaIncompatible ("branches conflict"); it must now widen.
+	body := []byte(`{
+		"messages": [{"role":"user","content":"hi"}],
+		"tools": [{
+			"name":"SendMessage",
+			"input_schema":{
+				"type":"object",
+				"properties":{
+					"to":{
+						"allOf":[
+							{"type":"string","description":"Teammate recipient"},
+							{"type":"string","description":"Recipient: teammate name"}
+						]
+					},
+					"message":{"type":"string"}
+				},
+				"required":["to","message"]
+			}
+		}]
+	}`)
+	env, err := translate.ParseAnthropic(body)
+	require.NoError(t, err)
+	prep, err := env.PrepareGemini(http.Header{}, translate.EmitOptions{TargetModel: "gemini-3.1-pro-preview"})
+	require.NoError(t, err)
+
+	out := mustUnmarshal(t, prep.Body)
+	decls := out["tools"].([]any)[0].(map[string]any)["functionDeclarations"].([]any)
+	params := decls[0].(map[string]any)["parameters"].(map[string]any)
+	props := params["properties"].(map[string]any)
+
+	to := props["to"].(map[string]any)
+	assert.Equal(t, "string", to["type"])
+	assert.Equal(t, "Recipient: teammate name", to["description"], "later branch's annotation wins")
+	assert.ElementsMatch(t, []any{"message", "to"}, params["required"])
+}
+
+func TestPrepareGemini_UnrepresentableToolSchemaDegradesToNoParameters(t *testing.T) {
+	// oneOf has no widening path (selecting a branch would silently narrow the
+	// tool's input language), so it stays a hard sanitize failure. The
+	// per-tool backstop must still keep the rest of the request alive by
+	// emitting the declaration without parameters instead of 502ing.
+	body := []byte(`{
+		"messages": [{"role":"user","content":"hi"}],
+		"tools": [
+			{"name":"healthy","input_schema":{"type":"object","properties":{"x":{"type":"string"}}}},
+			{"name":"degraded","input_schema":{"oneOf":[{"type":"string"},{"type":"number"}]}}
+		]
+	}`)
+	env, err := translate.ParseAnthropic(body)
+	require.NoError(t, err)
+	prep, err := env.PrepareGemini(http.Header{}, translate.EmitOptions{TargetModel: "gemini-3.1-pro-preview"})
+	require.NoError(t, err)
+
+	out := mustUnmarshal(t, prep.Body)
+	decls := out["tools"].([]any)[0].(map[string]any)["functionDeclarations"].([]any)
+	require.Len(t, decls, 2)
+
+	byName := make(map[string]map[string]any, len(decls))
+	for _, d := range decls {
+		decl := d.(map[string]any)
+		byName[decl["name"].(string)] = decl
+	}
+
+	healthy, ok := byName["healthy"]
+	require.True(t, ok)
+	assert.Contains(t, healthy, "parameters")
+
+	degraded, ok := byName["degraded"]
+	require.True(t, ok)
+	assert.NotContains(t, degraded, "parameters", "unrepresentable schema must degrade to no parameters, not fail the request")
+}
+
+func TestPrepareGemini_DegradedDuplicateDeclarationsStillConflict(t *testing.T) {
+	// Two tools with the same name are a client bug regardless of whether one
+	// happened to degrade to no parameters; dedupe must keep rejecting them.
+	body := []byte(`{
+		"messages": [{"role":"user","content":"hi"}],
+		"tools": [
+			{"name":"dup","input_schema":{"type":"object"}},
+			{"name":"dup","input_schema":{"oneOf":[{"type":"string"},{"type":"number"}]}}
+		]
+	}`)
+	env, err := translate.ParseAnthropic(body)
+	require.NoError(t, err)
+	_, err = env.PrepareGemini(http.Header{}, translate.EmitOptions{TargetModel: "gemini-3.1-pro-preview"})
+	require.ErrorIs(t, err, translate.ErrGeminiToolDeclarationConflict)
+}
+
+func TestIsIntrinsicallyIncompatible(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "wrapped gemini schema incompatible",
+			err:  fmt.Errorf("prepare gemini: %w", translate.ErrGeminiSchemaIncompatible),
+			want: true,
+		},
+		{
+			name: "wrapped reasoning incompatible",
+			err:  fmt.Errorf("prepare gemini: %w", translate.ErrReasoningIncompatible),
+			want: true,
+		},
+		{
+			name: "wrapped gemini unsigned tool history",
+			err:  fmt.Errorf("prepare gemini: %w", translate.ErrGeminiUnsignedToolHistory),
+			want: true,
+		},
+		{
+			name: "unrelated error",
+			err:  errors.New("other"),
+			want: false,
+		},
+		{
+			name: "tool declaration conflict is a client bug, not intrinsic incompatibility",
+			err:  translate.ErrGeminiToolDeclarationConflict,
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, translate.IsIntrinsicallyIncompatible(tt.err))
+		})
+	}
 }

--- a/internal/translate/gemini_test.go
+++ b/internal/translate/gemini_test.go
@@ -1276,13 +1276,14 @@ func TestPrepareGemini_ConvertsBoolPropertySchemas(t *testing.T) {
 	assert.Equal(t, "string", rp["type"])
 }
 
-func TestPrepareGemini_SendMessageToAllOfRegression(t *testing.T) {
-	// Regression: allOf branches with differing descriptions must widen
-	// (annotation merge), not fail the whole request.
+func TestPrepareGemini_ToolAllOfAnnotationRegression(t *testing.T) {
+	// Regression (prod shape: SendMessage.to): allOf branches with differing
+	// descriptions must widen (annotation merge), not fail the whole request.
+	// Uses a non-CC-internal tool name so the claudecode filter keeps it.
 	body := []byte(`{
 		"messages": [{"role":"user","content":"hi"}],
 		"tools": [{
-			"name":"SendMessage",
+			"name":"NotifyTeammate",
 			"input_schema":{
 				"type":"object",
 				"properties":{

--- a/internal/translate/incompatible.go
+++ b/internal/translate/incompatible.go
@@ -1,0 +1,14 @@
+package translate
+
+import "errors"
+
+// IsIntrinsicallyIncompatible reports whether err marks a request the routed
+// model provably cannot serve (unrepresentable tool schema, reasoning intent,
+// or missing Gemini thought signatures on tool history) — as opposed to a
+// transient upstream fault. The proxy uses it to fail over to the baseline
+// Anthropic model instead of surfacing a generic 502.
+func IsIntrinsicallyIncompatible(err error) bool {
+	return errors.Is(err, ErrGeminiSchemaIncompatible) ||
+		errors.Is(err, ErrReasoningIncompatible) ||
+		errors.Is(err, ErrGeminiUnsignedToolHistory)
+}

--- a/internal/translate/incompatible.go
+++ b/internal/translate/incompatible.go
@@ -5,8 +5,7 @@ import "errors"
 // IsIntrinsicallyIncompatible reports whether err marks a request the routed
 // model provably cannot serve (unrepresentable tool schema, reasoning intent,
 // or missing Gemini thought signatures on tool history) — as opposed to a
-// transient upstream fault. The proxy uses it to fail over to the baseline
-// Anthropic model instead of surfacing a generic 502.
+// transient upstream fault.
 func IsIntrinsicallyIncompatible(err error) bool {
 	return errors.Is(err, ErrGeminiSchemaIncompatible) ||
 		errors.Is(err, ErrReasoningIncompatible) ||


### PR DESCRIPTION
## Summary

Combines #980 and #981 (now closed) — same prod incident: Gemini emitter's allOf handling was validate-and-reject with exact-merge semantics, so tool schemas whose branches merely annotate differently (e.g. `SendMessage.to` with two descriptions) failed the **entire request** with a generic 502, before baseline failover could run. 21k+ failures observed.

Tool input schemas are generation hints: the client executes/validates tool calls itself, and toolcheck validates model output against the ORIGINAL schema — the same posture as #808/#809/#810/#952.

## Fix (four layers, most fidelity-preserving first)

1. **True intersection merge** (from #981, `internal/translate/emit_gemini.go`) — `mergeSchemaMapsExact` → `intersectGeminiSchemas`, implementing real `allOf` intersection semantics:
   - Annotations (`description`, `title`, `default`, `example`) — disagreement is not a conflict; the earlier/outer branch wins.
   - Bounds (`min*`/`max*`) narrow to the stricter value.
   - Enums intersect (`[a,b,c]` ⋂ `[b,c,d]` → `[b,c]`); disjoint pairs still conflict.
   - `properties` / `items` recurse and intersect subschemas instead of demanding equality.
   - `nullable` ANDs (an omitted `nullable` alongside a declared `type` asserts non-nullable); a redundant `nullable:false` is stripped from emitted schemas.
   - The result is always equal-or-*stricter* than the original — never wider — so it cannot let a model emit input the original schema forbade.
2. **Tolerant widening** (from #980) — a branch that still can't be intersected (type conflict, disjoint enums, differing `pattern`s) is dropped (widening, logged per branch) instead of rejecting; conflicts between the merged allOf and sibling constraints fall back to a lenient merge that keeps the sibling values. `required` entries orphaned by a dropped branch are pruned (Gemini 400s on required-without-property), only on the widened path.
3. **Per-tool backstop** — a tool schema that stays unrepresentable (e.g. `oneOf`, `items:false`, vendor `x-*` keys) degrades that one tool to a parameterless declaration (logged with the tool name) instead of failing the request. Cross-format paths only; same-format Gemini ingress stays strict.
4. **Route-level rescue** (`internal/proxy/service.go`) — build-time errors matching `translate.IsIntrinsicallyIncompatible` skip the primary dispatch and enter the existing baseline-Anthropic rescue (gated on `baselineViable`). When no rescue is viable, `DispatchErrorRoutedModelIncompatible` returns a clear 502.

## Tests

- Regression for the prod shape plus fidelity rows for intersection (annotation left-wins, bounds narrowing, enum intersection, property/items recursion, nullable AND — ported from #981) and for widening/pruning/degradation (from #980).
- Proxy integration test: a Gemini build-time incompatibility serves on baseline Anthropic.
- `make precommit` green (gofmt, vet, build, full module suite, statusline, install).

## Follow-ups (not in this PR)

- Dangling `required` and vendor `x-*` keys still degrade the whole tool via the backstop; pruning/stripping them in place would preserve more fidelity for MCP-derived schemas.

Link to Devin session: https://app.devin.ai/sessions/666f17f7eef14c19b74ed438d8b214f9
Requested by: @steventohme