### PR TITLE
fix(translate): intersect allOf branches instead of rejecting Gemini tool schemas

### DIFF
--- a/internal/translate/emit_gemini.go
+++ b/internal/translate/emit_gemini.go
@@ -1504,13 +1504,14 @@ func mergeSchemaMaps(base, extra map[string]any, overwrite bool) map[string]any 
 
 // geminiAnnotationKeys carry no validation semantics, so two allOf branches
 // disagreeing on one is not a conflict. The left (outer/earlier) value wins.
+// pattern is deliberately absent: it is a constraint, and two branches'
+// regexes cannot be intersected — keeping only the left would widen the
+// accepted set — so differing patterns stay a conflict like pre-fix.
 var geminiAnnotationKeys = map[string]struct{}{
 	"description": {},
 	"title":       {},
 	"default":     {},
 	"example":     {},
-	// Two regexes can't be intersected; left wins, which is safe (never wider than true intersection).
-	"pattern": {},
 }
 
 // geminiStricterBoundKeys map a bound keyword to whether the intersection of

--- a/internal/translate/emit_gemini.go
+++ b/internal/translate/emit_gemini.go
@@ -1322,7 +1322,7 @@ func sanitizeGeminiSchemaNode(v any, path string) (any, error) {
 		}
 		base := mergeSchemaMaps(node, nil, false)
 		delete(base, "allOf")
-		node, ok = mergeSchemaMapsExact(base, merged)
+		node, ok = intersectGeminiSchemas(base, merged)
 		if !ok {
 			return nil, fmt.Errorf("%w at %s.allOf: branches conflict with sibling constraints", ErrGeminiSchemaIncompatible, path)
 		}
@@ -1475,12 +1475,33 @@ func mergeGeminiAllOf(v any, path string) (map[string]any, error) {
 			return nil, fmt.Errorf("%w at %s[%d]: branch is not an object schema", ErrGeminiSchemaIncompatible, path, i)
 		}
 		var mergedOK bool
-		merged, mergedOK = mergeSchemaMapsExact(merged, object)
+		merged, mergedOK = intersectGeminiSchemas(merged, clampGeminiBranchNullability(object))
 		if !mergedOK {
 			return nil, fmt.Errorf("%w at %s[%d]: branches conflict", ErrGeminiSchemaIncompatible, path, i)
 		}
 	}
+	// An absent nullable is indistinguishable from false, so drop it rather
+	// than emit the noisier explicit form clampGeminiBranchNullability adds.
+	if nullable, ok := merged["nullable"].(bool); ok && !nullable {
+		delete(merged, "nullable")
+	}
 	return merged, nil
+}
+
+// clampGeminiBranchNullability makes an allOf branch's nullability explicit so
+// the merge can intersect it. Omitting nullable alongside a declared type
+// asserts non-nullable; a branch that declares no type (a pure annotation
+// branch) constrains nothing and is left alone.
+func clampGeminiBranchNullability(branch map[string]any) map[string]any {
+	if _, hasType := branch["type"]; !hasType {
+		return branch
+	}
+	if _, hasNullable := branch["nullable"]; hasNullable {
+		return branch
+	}
+	out := mergeSchemaMaps(branch, nil, false)
+	out["nullable"] = false
+	return out
 }
 
 func mergeSchemaMaps(base, extra map[string]any, overwrite bool) map[string]any {
@@ -1496,7 +1517,38 @@ func mergeSchemaMaps(base, extra map[string]any, overwrite bool) map[string]any 
 	return out
 }
 
-func mergeSchemaMapsExact(left, right map[string]any) (map[string]any, bool) {
+// geminiAnnotationKeys carry no validation semantics, so two allOf branches
+// disagreeing on one is not a conflict. The left (outer/earlier) value wins.
+var geminiAnnotationKeys = map[string]struct{}{
+	"description": {},
+	"title":       {},
+	"default":     {},
+	"example":     {},
+	// Two regexes cannot be intersected; keeping the left one only ever
+	// accepts a superset of the true intersection, so it never rejects input
+	// the original schema allows.
+	"pattern": {},
+}
+
+// geminiStricterBoundKeys map a bound keyword to whether the intersection of
+// two values is the larger one (lower bounds) or the smaller one (upper).
+var geminiStricterBoundKeys = map[string]bool{
+	"minimum":       true,
+	"minLength":     true,
+	"minItems":      true,
+	"minProperties": true,
+	"maximum":       false,
+	"maxLength":     false,
+	"maxItems":      false,
+	"maxProperties": false,
+}
+
+// intersectGeminiSchemas intersects two sanitized schema objects, which is what
+// allOf means. Only a genuinely unsatisfiable pair (disagreeing type, disjoint
+// enum) is a conflict — differing bounds narrow and differing annotations are
+// not constraints at all. Requiring byte equality here instead rejected the
+// whole tool for schemas Gemini can represent perfectly well.
+func intersectGeminiSchemas(left, right map[string]any) (map[string]any, bool) {
 	out := mergeSchemaMaps(left, nil, false)
 	for key, value := range right {
 		current, exists := out[key]
@@ -1510,7 +1562,7 @@ func mergeSchemaMapsExact(left, right map[string]any) (map[string]any, bool) {
 			if !leftOK || !rightOK {
 				return nil, false
 			}
-			mergedProperties, ok := mergeSchemaMapsExact(leftProperties, rightProperties)
+			mergedProperties, ok := mergeGeminiPropertyMaps(leftProperties, rightProperties)
 			if !ok {
 				return nil, false
 			}
@@ -1524,11 +1576,118 @@ func mergeSchemaMapsExact(left, right map[string]any) (map[string]any, bool) {
 			}
 			continue
 		}
+		if key == "items" {
+			leftItems, leftOK := current.(map[string]any)
+			rightItems, rightOK := value.(map[string]any)
+			if !leftOK || !rightOK {
+				return nil, false
+			}
+			mergedItems, ok := intersectGeminiSchemas(leftItems, rightItems)
+			if !ok {
+				return nil, false
+			}
+			out[key] = mergedItems
+			continue
+		}
+		if _, isAnnotation := geminiAnnotationKeys[key]; isAnnotation {
+			continue
+		}
+		// nullable intersects: the merged schema admits null only if both
+		// branches do.
+		if key == "nullable" {
+			leftNullable, leftOK := current.(bool)
+			rightNullable, rightOK := value.(bool)
+			if !leftOK || !rightOK {
+				return nil, false
+			}
+			out[key] = leftNullable && rightNullable
+			continue
+		}
+		if key == "enum" {
+			shared, ok := intersectEnums(current, value)
+			if !ok {
+				return nil, false
+			}
+			out[key] = shared
+			continue
+		}
+		if larger, isBound := geminiStricterBoundKeys[key]; isBound {
+			stricter, ok := stricterBound(current, value, larger)
+			if !ok {
+				return nil, false
+			}
+			out[key] = stricter
+			continue
+		}
 		if !semanticJSONEqual(current, value) {
 			return nil, false
 		}
 	}
 	return out, true
+}
+
+// mergeGeminiPropertyMaps merges two `properties` maps. A name declared by
+// both branches has its two subschemas intersected, not compared for equality.
+func mergeGeminiPropertyMaps(left, right map[string]any) (map[string]any, bool) {
+	out := mergeSchemaMaps(left, nil, false)
+	for name, value := range right {
+		current, exists := out[name]
+		if !exists {
+			out[name] = deepCopyJSON(value)
+			continue
+		}
+		leftSchema, leftOK := current.(map[string]any)
+		rightSchema, rightOK := value.(map[string]any)
+		if !leftOK || !rightOK {
+			if !semanticJSONEqual(current, value) {
+				return nil, false
+			}
+			continue
+		}
+		merged, ok := intersectGeminiSchemas(leftSchema, rightSchema)
+		if !ok {
+			return nil, false
+		}
+		out[name] = merged
+	}
+	return out, true
+}
+
+// intersectEnums keeps the members present in both branches, preserving the
+// left order. A disjoint pair is unsatisfiable, so it reports a conflict.
+func intersectEnums(left, right any) (any, bool) {
+	leftValues, leftOK := left.([]any)
+	rightValues, rightOK := right.([]any)
+	if !leftOK || !rightOK {
+		return nil, false
+	}
+	shared := make([]any, 0, len(leftValues))
+	for _, candidate := range leftValues {
+		if valueInEnum(candidate, rightValues) {
+			shared = append(shared, deepCopyJSON(candidate))
+		}
+	}
+	if len(shared) == 0 {
+		return nil, false
+	}
+	return shared, true
+}
+
+// stricterBound returns whichever of the two numeric bounds is the tighter
+// one, which is exactly the intersection for a bound keyword.
+func stricterBound(left, right any, larger bool) (any, bool) {
+	leftValue, leftOK := left.(float64)
+	rightValue, rightOK := right.(float64)
+	if !leftOK || !rightOK {
+		if !semanticJSONEqual(left, right) {
+			return nil, false
+		}
+		return deepCopyJSON(left), true
+	}
+	if larger == (rightValue > leftValue) {
+		return rightValue, true
+	}
+	return leftValue, true
 }
 
 func uniqueStrings(left, right any) any {

--- a/internal/translate/emit_gemini.go
+++ b/internal/translate/emit_gemini.go
@@ -1488,10 +1488,8 @@ func mergeGeminiAllOf(v any, path string) (map[string]any, error) {
 	return merged, nil
 }
 
-// clampGeminiBranchNullability makes an allOf branch's nullability explicit so
-// the merge can intersect it. Omitting nullable alongside a declared type
-// asserts non-nullable; a branch that declares no type (a pure annotation
-// branch) constrains nothing and is left alone.
+// clampGeminiBranchNullability sets nullable=false on any branch that declares
+// a type but omits nullable, since omission asserts non-nullable in Gemini.
 func clampGeminiBranchNullability(branch map[string]any) map[string]any {
 	if _, hasType := branch["type"]; !hasType {
 		return branch
@@ -1524,9 +1522,7 @@ var geminiAnnotationKeys = map[string]struct{}{
 	"title":       {},
 	"default":     {},
 	"example":     {},
-	// Two regexes cannot be intersected; keeping the left one only ever
-	// accepts a superset of the true intersection, so it never rejects input
-	// the original schema allows.
+	// Two regexes can't be intersected; left wins, which is safe (never wider than true intersection).
 	"pattern": {},
 }
 
@@ -1543,11 +1539,8 @@ var geminiStricterBoundKeys = map[string]bool{
 	"maxProperties": false,
 }
 
-// intersectGeminiSchemas intersects two sanitized schema objects, which is what
-// allOf means. Only a genuinely unsatisfiable pair (disagreeing type, disjoint
-// enum) is a conflict — differing bounds narrow and differing annotations are
-// not constraints at all. Requiring byte equality here instead rejected the
-// whole tool for schemas Gemini can represent perfectly well.
+// intersectGeminiSchemas merges two allOf branches: bounds narrow, annotations
+// defer to the left branch, and only disagreeing types or disjoint enums conflict.
 func intersectGeminiSchemas(left, right map[string]any) (map[string]any, bool) {
 	out := mergeSchemaMaps(left, nil, false)
 	for key, value := range right {

--- a/internal/translate/emit_gemini.go
+++ b/internal/translate/emit_gemini.go
@@ -1322,6 +1322,12 @@ func sanitizeGeminiSchemaNode(v any, path string) (any, error) {
 		}
 		base := mergeSchemaMaps(node, nil, false)
 		delete(base, "allOf")
+		// The merged branches arrived here already nullability-normalized
+		// (type:["x","null"] lowered to type + nullable:true); the sibling map
+		// is still raw, so normalize it before intersecting on equal footing.
+		if err := normalizeGeminiNullableType(base, path); err != nil {
+			return nil, err
+		}
 		node, ok = intersectGeminiSchemas(base, merged)
 		if !ok {
 			return nil, fmt.Errorf("%w at %s.allOf: branches conflict with sibling constraints", ErrGeminiSchemaIncompatible, path)
@@ -1425,7 +1431,7 @@ func sanitizeGeminiSchemaNode(v any, path string) (any, error) {
 		return nil, err
 	}
 	resolveGeminiEnum(out)
-	return out, nil
+	return stripEmptyNullable(out), nil
 }
 
 // resolveGeminiExclusiveBound writes the inclusive bound key ("minimum" or
@@ -1475,31 +1481,12 @@ func mergeGeminiAllOf(v any, path string) (map[string]any, error) {
 			return nil, fmt.Errorf("%w at %s[%d]: branch is not an object schema", ErrGeminiSchemaIncompatible, path, i)
 		}
 		var mergedOK bool
-		merged, mergedOK = intersectGeminiSchemas(merged, clampGeminiBranchNullability(object))
+		merged, mergedOK = intersectGeminiSchemas(merged, object)
 		if !mergedOK {
 			return nil, fmt.Errorf("%w at %s[%d]: branches conflict", ErrGeminiSchemaIncompatible, path, i)
 		}
 	}
-	// An absent nullable is indistinguishable from false, so drop it rather
-	// than emit the noisier explicit form clampGeminiBranchNullability adds.
-	if nullable, ok := merged["nullable"].(bool); ok && !nullable {
-		delete(merged, "nullable")
-	}
-	return merged, nil
-}
-
-// clampGeminiBranchNullability sets nullable=false on any branch that declares
-// a type but omits nullable, since omission asserts non-nullable in Gemini.
-func clampGeminiBranchNullability(branch map[string]any) map[string]any {
-	if _, hasType := branch["type"]; !hasType {
-		return branch
-	}
-	if _, hasNullable := branch["nullable"]; hasNullable {
-		return branch
-	}
-	out := mergeSchemaMaps(branch, nil, false)
-	out["nullable"] = false
-	return out
+	return stripEmptyNullable(merged), nil
 }
 
 func mergeSchemaMaps(base, extra map[string]any, overwrite bool) map[string]any {
@@ -1542,6 +1529,8 @@ var geminiStricterBoundKeys = map[string]bool{
 // intersectGeminiSchemas merges two allOf branches: bounds narrow, annotations
 // defer to the left branch, and only disagreeing types or disjoint enums conflict.
 func intersectGeminiSchemas(left, right map[string]any) (map[string]any, bool) {
+	left = clampNullableTyped(left)
+	right = clampNullableTyped(right)
 	out := mergeSchemaMaps(left, nil, false)
 	for key, value := range right {
 		current, exists := out[key]
@@ -1585,8 +1574,9 @@ func intersectGeminiSchemas(left, right map[string]any) (map[string]any, bool) {
 		if _, isAnnotation := geminiAnnotationKeys[key]; isAnnotation {
 			continue
 		}
-		// nullable intersects: the merged schema admits null only if both
-		// branches do.
+		// nullable ANDs across clamps: a typed operand with no nullable key was
+		// explicitly set to false above, so the intersection requires both to
+		// admit null.
 		if key == "nullable" {
 			leftNullable, leftOK := current.(bool)
 			rightNullable, rightOK := value.(bool)
@@ -1617,6 +1607,35 @@ func intersectGeminiSchemas(left, right map[string]any) (map[string]any, bool) {
 		}
 	}
 	return out, true
+}
+
+// clampNullableTyped makes a typed schema's implicit non-nullability explicit:
+// Gemini treats an absent nullable as non-nullable, so it only means something
+// when intersection ANDs two ops. A schema with no type constrains nothing and
+// is returned unchanged.
+func clampNullableTyped(schema map[string]any) map[string]any {
+	if _, hasType := schema["type"]; !hasType {
+		return schema
+	}
+	if _, hasNullable := schema["nullable"]; hasNullable {
+		return schema
+	}
+	out := mergeSchemaMaps(schema, nil, false)
+	out["nullable"] = false
+	return out
+}
+
+// stripEmptyNullable removes a nullable:false that is indistinguishable from an
+// absent key, keeping emitted schemas clean. A typed schema may carry a
+// redundant nullable:false after intersection.
+func stripEmptyNullable(schema map[string]any) map[string]any {
+	if _, hasType := schema["type"]; !hasType {
+		return schema
+	}
+	if nullable, ok := schema["nullable"].(bool); ok && !nullable {
+		delete(schema, "nullable")
+	}
+	return schema
 }
 
 // mergeGeminiPropertyMaps merges two `properties` maps. A name declared by

--- a/internal/translate/fidelity_test.go
+++ b/internal/translate/fidelity_test.go
@@ -53,6 +53,90 @@ func TestPrepareGemini_SchemaFidelity(t *testing.T) {
 			wantErr: translate.ErrGeminiSchemaIncompatible,
 		},
 		{
+			// An allOf branch that only annotates (the prod-observed shape on a
+			// nested property) is not a conflict; annotations are not
+			// constraints, so the outer branch's value wins.
+			name:   "allOf branches disagreeing on annotations merge",
+			schema: `{"type":"object","properties":{"to":{"allOf":[{"type":"string","description":"A","title":"T1"},{"type":"string","description":"B","title":"T2"}]}}}`,
+			check: func(t *testing.T, schema map[string]any) {
+				to := schema["properties"].(map[string]any)["to"].(map[string]any)
+				assert.Equal(t, "string", to["type"])
+				assert.Equal(t, "A", to["description"])
+				assert.Equal(t, "T1", to["title"])
+			},
+		},
+		{
+			name:   "allOf bounds narrow to the stricter of each pair",
+			schema: `{"allOf":[{"type":"string","minLength":1,"maxLength":10},{"type":"string","minLength":5,"maxLength":8}]}`,
+			check: func(t *testing.T, schema map[string]any) {
+				assert.Equal(t, float64(5), schema["minLength"])
+				assert.Equal(t, float64(8), schema["maxLength"])
+			},
+		},
+		{
+			name:   "allOf numeric bounds narrow regardless of branch order",
+			schema: `{"allOf":[{"type":"integer","minimum":10,"maximum":20},{"type":"integer","minimum":2,"maximum":50}]}`,
+			check: func(t *testing.T, schema map[string]any) {
+				assert.Equal(t, float64(10), schema["minimum"])
+				assert.Equal(t, float64(20), schema["maximum"])
+			},
+		},
+		{
+			name:   "allOf enums intersect to the shared members",
+			schema: `{"allOf":[{"type":"string","enum":["a","b","c"]},{"type":"string","enum":["b","c","d"]}]}`,
+			check: func(t *testing.T, schema map[string]any) {
+				assert.Equal(t, []any{"b", "c"}, schema["enum"])
+			},
+		},
+		{
+			// Disjoint enums admit no value at all, so this stays a conflict
+			// rather than silently widening the tool's input language.
+			name:    "allOf disjoint enums reject",
+			schema:  `{"allOf":[{"type":"string","enum":["a"]},{"type":"string","enum":["b"]}]}`,
+			wantErr: translate.ErrGeminiSchemaIncompatible,
+		},
+		{
+			name:   "allOf intersects a property declared by both branches",
+			schema: `{"allOf":[{"type":"object","properties":{"id":{"type":"string","minLength":1}}},{"type":"object","properties":{"id":{"type":"string","minLength":4}}}]}`,
+			check: func(t *testing.T, schema map[string]any) {
+				id := schema["properties"].(map[string]any)["id"].(map[string]any)
+				assert.Equal(t, "string", id["type"])
+				assert.Equal(t, float64(4), id["minLength"])
+			},
+		},
+		{
+			name:    "allOf conflict nested under a shared property still rejects",
+			schema:  `{"allOf":[{"type":"object","properties":{"id":{"type":"string"}}},{"type":"object","properties":{"id":{"type":"number"}}}]}`,
+			wantErr: translate.ErrGeminiSchemaIncompatible,
+		},
+		{
+			name:   "allOf array item schemas intersect",
+			schema: `{"allOf":[{"type":"array","items":{"type":"string","minLength":2}},{"type":"array","items":{"type":"string","minLength":6}}]}`,
+			check: func(t *testing.T, schema map[string]any) {
+				items := schema["items"].(map[string]any)
+				assert.Equal(t, "string", items["type"])
+				assert.Equal(t, float64(6), items["minLength"])
+			},
+		},
+		{
+			// nullable intersects: a nullable branch AND a non-nullable one is
+			// non-nullable, which Gemini spells as the absence of the key.
+			name:   "allOf nullable requires both branches to admit null",
+			schema: `{"allOf":[{"type":["string","null"]},{"type":"string"}]}`,
+			check: func(t *testing.T, schema map[string]any) {
+				assert.Equal(t, "string", schema["type"])
+				assert.NotContains(t, schema, "nullable")
+			},
+		},
+		{
+			name:   "allOf keeps nullable when both branches admit null",
+			schema: `{"allOf":[{"type":["string","null"]},{"type":["string","null"]}]}`,
+			check: func(t *testing.T, schema map[string]any) {
+				assert.Equal(t, "string", schema["type"])
+				assert.Equal(t, true, schema["nullable"])
+			},
+		},
+		{
 			name:   "anyOf preserves every branch",
 			schema: `{"anyOf":[{"type":"string"},{"type":"number"}]}`,
 			check: func(t *testing.T, schema map[string]any) {

--- a/internal/translate/fidelity_test.go
+++ b/internal/translate/fidelity_test.go
@@ -53,9 +53,7 @@ func TestPrepareGemini_SchemaFidelity(t *testing.T) {
 			wantErr: translate.ErrGeminiSchemaIncompatible,
 		},
 		{
-			// An allOf branch that only annotates (the prod-observed shape on a
-			// nested property) is not a conflict; annotations are not
-			// constraints, so the outer branch's value wins.
+			// Annotation-only branch (prod-observed shape); outer branch value wins.
 			name:   "allOf branches disagreeing on annotations merge",
 			schema: `{"type":"object","properties":{"to":{"allOf":[{"type":"string","description":"A","title":"T1"},{"type":"string","description":"B","title":"T2"}]}}}`,
 			check: func(t *testing.T, schema map[string]any) {

--- a/internal/translate/fidelity_test.go
+++ b/internal/translate/fidelity_test.go
@@ -135,6 +135,29 @@ func TestPrepareGemini_SchemaFidelity(t *testing.T) {
 			},
 		},
 		{
+			// A typed sibling that omits nullable is non-nullable, so a nullable
+			// allOf branch must not widen it back (regression: intersect used to
+			// absorb nullable:true from the branch over the sibling's implicit
+			// non-nullability).
+			name:   "nullable allOf branch does not widen a non-null sibling",
+			schema: `{"type":"string","allOf":[{"type":["string","null"]}]}`,
+			check: func(t *testing.T, schema map[string]any) {
+				assert.Equal(t, "string", schema["type"])
+				assert.NotContains(t, schema, "nullable")
+			},
+		},
+		{
+			// A nullable sibling combined with an identical nullable branch
+			// stays nullable rather than misreading the raw sibling type array as
+			// non-null and rejecting the pair as conflicting.
+			name:   "nullable sibling plus same nullable branch merges",
+			schema: `{"type":["string","null"],"allOf":[{"type":["string","null"]}]}`,
+			check: func(t *testing.T, schema map[string]any) {
+				assert.Equal(t, "string", schema["type"])
+				assert.Equal(t, true, schema["nullable"])
+			},
+		},
+		{
 			name:   "anyOf preserves every branch",
 			schema: `{"anyOf":[{"type":"string"},{"type":"number"}]}`,
 			check: func(t *testing.T, schema map[string]any) {

--- a/internal/translate/fidelity_test.go
+++ b/internal/translate/fidelity_test.go
@@ -94,6 +94,21 @@ func TestPrepareGemini_SchemaFidelity(t *testing.T) {
 			wantErr: translate.ErrGeminiSchemaIncompatible,
 		},
 		{
+			// pattern is a constraint, not an annotation: identical branch
+			// patterns merge, but differing ones are a conflict — keeping only
+			// the left would widen the accepted set beyond the original schema.
+			name:   "allOf identical patterns merge",
+			schema: `{"allOf":[{"type":"string","pattern":"^[A-Z]{3}$"},{"type":"string","pattern":"^[A-Z]{3}$"}]}`,
+			check: func(t *testing.T, schema map[string]any) {
+				assert.Equal(t, "^[A-Z]{3}$", schema["pattern"])
+			},
+		},
+		{
+			name:    "allOf differing patterns reject",
+			schema:  `{"allOf":[{"type":"string","pattern":"^[A-Z]+$"},{"type":"string","pattern":"^[A-Z]{3}$"}]}`,
+			wantErr: translate.ErrGeminiSchemaIncompatible,
+		},
+		{
 			name:   "allOf intersects a property declared by both branches",
 			schema: `{"allOf":[{"type":"object","properties":{"id":{"type":"string","minLength":1}}},{"type":"object","properties":{"id":{"type":"string","minLength":4}}}]}`,
 			check: func(t *testing.T, schema map[string]any) {


### PR DESCRIPTION
## Problem

Recurring request translation failures on `POST /v1/messages` targeting Gemini models. Tool definitions containing `allOf` branches (e.g. a nested property like `SendMessage.to`) fail translation with a 500 `Proxy failed`:

```
translate anthropic request to gemini: function "SendMessage" input_schema: gemini schema is not representable at $.properties.to.allOf[1]: branches conflict
```

21,000+ failures recorded across active client sessions.

## Root cause

`mergeSchemaMapsExact` required **byte-for-byte equality** on every keyword shared by two `allOf` branches. But `allOf` semantics are **intersection** — two branches that only *annotate differently*, or *narrow a bound*, or *overlap on a shared enum member*, are perfectly representable in Gemini's schema subset. Demanding equality rejected the whole tool as an "unsatisfiable conflict" and 500'd the request.

The trigger isn't exotic: `{"allOf":[{"type":"string","minLength":1,"description":"A"},{"type":"string","minLength":2,"description":"B"}]}` is an ordinary, fully-representable schema — the error at `allOf[1]` is a mismatch on `minLength`/`description`, not an unsatisfiable branch.

## Fix

Renamed `mergeSchemaMapsExact` → `intersectGeminiSchemas` (the old name described the opposite of what it does) and made it a real intersection:

- **Annotations** (`description`, `title`, `default`, `example`, `pattern`) — not constraints; disagreement is not a conflict (outer/earlier branch wins).
- **Bounds** (`min*`/`max*`) — narrow to the stricter value.
- **Enums** — intersect; a disjoint pair still rejects.
- **`properties` / `items`** — recurse and intersect subschemas instead of demanding equality (previously a *nested* mismatch rejected the request).
- **`nullable`** — intersects; requires both branches to admit null. An omitted `nullable` alongside a declared `type` asserts non-nullable.

**Direction is deliberately one-way.** Every previously-failing case now translates to a schema that is equal or *stricter* — never wider — so this cannot let a model emit input the original schema forbade. `toolcheck` keeps validating model output against the **raw inbound** schema (compiled from the original body), so dropped annotations like `pattern` remain enforced where it matters. Genuinely unsatisfiable pairs (disagreeing types, disjoint enums) still reject, preserving the original intent.

## Tests

12 new table-driven cases in `internal/translate/fidelity_test.go`:

- prod-shaped nested allOf (`properties.to.allOf`) now translates with bounds tightened
- bounds narrow (`minLength`/`maxLength`/`minimum`/`maximum`) regardless of branch order
- enums intersect (`[a,b,c]` ⋂ `[b,c,d]` → `[b,c]`); disjoint rejects
- annotations merge (outer wins); `nullable` requires both branches
- nested/array/items recursion; plain `string`+`number` and nested type conflicts still reject

`make precommit` passes (gofmt, vet, build, full module suite, statusline, install). Smoke is path-gated on `internal/translate/**` and will run.