### PR TITLE
fix(pubsub): degrade instead of panicking when per-replica subscription creation times out at boot

### DIFF
--- a/cmd/router/main.go
+++ b/cmd/router/main.go
@@ -416,26 +416,19 @@ func main() {
 		WithWIFTokenSource(buildWIFTokenSource(logger))
 
 	// Fans out Pub/Sub invalidations to this replica's cache; the 5-min TTL
-	// is the safety net if the listener falls behind.
-	subCtx, subCancel := context.WithTimeout(context.Background(), 30*time.Second)
-	subscriptionName, deleteSubscription, err := routerpubsub.CreateReplicaSubscription(
-		subCtx, pubsubClient, pubsubProjectID, pubsubTopicID, pubsubSubscriptionPrefix,
+	// is the safety net if the listener falls behind — including while the
+	// subscription is still being created after a transient boot failure
+	// (slow Pub/Sub admin API on a cold start degrades to TTL-only
+	// invalidation with background retry; only misconfiguration aborts boot).
+	invalidation, err := routerpubsub.StartReplicaInvalidation(
+		pubsubClient, pubsubProjectID, pubsubTopicID, pubsubSubscriptionPrefix,
+		cache, userClusterCache,
 	)
-	subCancel()
 	if err != nil {
 		logger.Error("Failed to create per-replica invalidation subscription", "err", err)
 		panic(err)
 	}
-	defer deleteSubscription()
-	logger.Info("Created per-replica invalidation subscription", "subscription", subscriptionName)
-
-	listener := routerpubsub.NewInvalidationListener(pubsubClient.Subscriber(subscriptionName), cache, userClusterCache)
-	listenerCtx, listenerCancel := context.WithCancel(context.Background())
-	defer func() {
-		listenerCancel()
-		listener.Wait()
-	}()
-	safeGo(logger, "invalidation-listener", func() { listener.Run(listenerCtx) })
+	defer invalidation.Stop()
 
 	// Managed mode doesn't mount the dashboard, so this only matters selfhosted.
 	if deploymentMode == server.DeploymentModeSelfHosted {

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	cloud.google.com/go/pubsub/v2 v2.4.0
 	github.com/dmitryikh/leaves v0.0.0-20230708180554-25d19a787328
 	github.com/gin-gonic/gin v1.10.1
+	github.com/golang-jwt/jwt/v5 v5.3.0
 	github.com/google/uuid v1.6.0
 	github.com/hashicorp/golang-lru/v2 v2.0.7
 	github.com/jackc/pgx/v5 v5.9.2
@@ -34,6 +35,7 @@ require (
 	golang.org/x/sync v0.20.0
 	golang.org/x/text v0.37.0
 	golang.org/x/time v0.15.0
+	google.golang.org/grpc v1.80.0
 	google.golang.org/protobuf v1.36.11
 	gopkg.in/yaml.v3 v3.0.1
 )
@@ -62,7 +64,6 @@ require (
 	github.com/go-playground/validator/v10 v10.26.0 // indirect
 	github.com/goccy/go-json v0.10.5 // indirect
 	github.com/gofrs/flock v0.13.0 // indirect
-	github.com/golang-jwt/jwt/v5 v5.3.0 // indirect
 	github.com/gomlx/exceptions v0.0.3 // indirect
 	github.com/gomlx/go-huggingface v0.3.5-0.20260327162928-af20e4f3e7b5 // indirect
 	github.com/gomlx/go-xla v0.2.2 // indirect
@@ -109,6 +110,5 @@ require (
 	google.golang.org/genproto v0.0.0-20260217215200-42d3e9bedb6d // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260401024825-9d38bb4040a9 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260401024825-9d38bb4040a9 // indirect
-	google.golang.org/grpc v1.80.0 // indirect
 	k8s.io/klog/v2 v2.140.0 // indirect
 )

--- a/internal/pubsub/invalidation.go
+++ b/internal/pubsub/invalidation.go
@@ -2,6 +2,7 @@ package pubsub
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -26,6 +27,10 @@ const replicaSubscriptionTTL = 24 * time.Hour
 // subscriptionDeleteTimeout bounds the cleanup call during shutdown so a slow
 // Pub/Sub admin API can't hold up termination indefinitely.
 const subscriptionDeleteTimeout = 10 * time.Second
+
+// errMissingPrefix means the subscription env var is misconfigured — a
+// permanent error that retrying cannot fix, so boot should fail fast.
+var errMissingPrefix = errors.New("subscription prefix is required")
 
 // publisher is the narrow seam NotifyInstallationChanged needs from a GCP
 // Pub/Sub Publisher: publish installationID and synchronously wait for the
@@ -147,7 +152,7 @@ func CreateReplicaSubscription(
 	prefix string,
 ) (subscriptionName string, cleanup func(), err error) {
 	if prefix == "" {
-		return "", nil, fmt.Errorf("subscription prefix is required")
+		return "", nil, errMissingPrefix
 	}
 	subID := fmt.Sprintf("%s-%s", strings.TrimRight(prefix, "-"), uuid.NewString())
 	subscriptionName = fmt.Sprintf("projects/%s/subscriptions/%s", projectID, subID)

--- a/internal/pubsub/replica_invalidation.go
+++ b/internal/pubsub/replica_invalidation.go
@@ -1,0 +1,218 @@
+package pubsub
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"time"
+
+	"workweave/router/internal/auth"
+	"workweave/router/internal/observability"
+
+	gcppubsub "cloud.google.com/go/pubsub/v2"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// Boot gets a bounded budget for creating the per-replica subscription; a
+// replica that can't finish inside it serves with TTL-only cache invalidation
+// while retryLoop keeps trying, so a slow Pub/Sub admin API during a cold
+// start degrades cache freshness instead of crashing the instance.
+const (
+	createAttemptTimeout = 15 * time.Second
+	bootCreateAttempts   = 2
+	bootAttemptBackoff   = 2 * time.Second
+	retryBackoffFloor    = 10 * time.Second
+	retryBackoffCap      = 5 * time.Minute
+)
+
+// permanentSubscriptionError reports whether a CreateSubscription failure is
+// misconfiguration that retrying cannot fix. Unknown codes count as
+// transient: for this component the safe default is to keep the replica
+// alive and retry, because the cache TTL already bounds staleness.
+func permanentSubscriptionError(err error) bool {
+	if errors.Is(err, errMissingPrefix) {
+		return true
+	}
+	s, ok := status.FromError(err)
+	if !ok {
+		return false
+	}
+	switch s.Code() {
+	case codes.NotFound, codes.PermissionDenied, codes.Unauthenticated,
+		codes.InvalidArgument, codes.FailedPrecondition, codes.Unimplemented:
+		return true
+	default:
+		return false
+	}
+}
+
+// ReplicaInvalidation owns this replica's invalidation pipeline: per-replica
+// subscription creation (with background retry after a transient boot
+// failure), the listener that fans messages out to caches, and teardown.
+type ReplicaInvalidation struct {
+	create    func(ctx context.Context) (subscriptionName string, cleanup func(), err error)
+	subscribe func(subscriptionName string) subscriberReceiver
+	caches    []auth.InstallationInvalidator
+	sleep     func(ctx context.Context, d time.Duration) error
+
+	ctx    context.Context
+	cancel context.CancelFunc
+	bgDone chan struct{}
+
+	mu       sync.Mutex
+	cleanup  func()
+	listener *InvalidationListener
+}
+
+// StartReplicaInvalidation provisions the per-replica subscription and starts
+// the listener that fans invalidation messages out to caches.
+// Misconfiguration (missing topic, denied IAM, empty prefix) is returned so
+// boot can fail fast; a transient failure (slow or unreachable Pub/Sub admin
+// API during a cold start) degrades instead of failing — the replica serves
+// with TTL-bounded staleness while a background loop retries and attaches the
+// listener once creation succeeds.
+func StartReplicaInvalidation(
+	client *gcppubsub.Client,
+	projectID string,
+	topicID string,
+	prefix string,
+	caches ...auth.InstallationInvalidator,
+) (*ReplicaInvalidation, error) {
+	r := &ReplicaInvalidation{
+		create: func(ctx context.Context) (string, func(), error) {
+			return CreateReplicaSubscription(ctx, client, projectID, topicID, prefix)
+		},
+		subscribe: func(subscriptionName string) subscriberReceiver { return client.Subscriber(subscriptionName) },
+		caches:    caches,
+		sleep:     sleepCtx,
+		bgDone:    make(chan struct{}),
+	}
+	r.ctx, r.cancel = context.WithCancel(context.Background())
+	return r, r.start()
+}
+
+func (r *ReplicaInvalidation) start() error {
+	log := observability.Get()
+	backoff := bootAttemptBackoff
+	var lastErr error
+	for attempt := 1; attempt <= bootCreateAttempts; attempt++ {
+		if attempt > 1 {
+			if err := r.sleep(r.ctx, backoff); err != nil {
+				break
+			}
+			backoff *= 2
+		}
+		subscriptionName, cleanup, err := r.createOnce()
+		if err == nil {
+			close(r.bgDone)
+			r.attach(subscriptionName, cleanup)
+			return nil
+		}
+		if permanentSubscriptionError(err) {
+			close(r.bgDone)
+			return err
+		}
+		lastErr = err
+		log.Warn("Transient failure creating per-replica invalidation subscription", "attempt", attempt, "err", err)
+	}
+	log.Error("Could not create per-replica invalidation subscription at boot; serving with TTL-only cache invalidation while retrying in background", "err", lastErr)
+	goRecovered("invalidation-subscription-retry", r.retryLoop)
+	return nil
+}
+
+// retryLoop keeps attempting subscription creation after a transient boot
+// failure, backing off exponentially up to retryBackoffCap, until creation
+// succeeds, the error turns permanent, or Stop cancels the context.
+func (r *ReplicaInvalidation) retryLoop() {
+	defer close(r.bgDone)
+	log := observability.Get()
+	backoff := retryBackoffFloor
+	for {
+		if err := r.sleep(r.ctx, backoff); err != nil {
+			return
+		}
+		subscriptionName, cleanup, err := r.createOnce()
+		if err == nil {
+			r.attach(subscriptionName, cleanup)
+			return
+		}
+		if permanentSubscriptionError(err) {
+			log.Error("Per-replica invalidation subscription creation failed permanently; serving with TTL-only cache invalidation", "err", err)
+			return
+		}
+		log.Warn("Retrying per-replica invalidation subscription creation", "backoff_sec", int(backoff.Seconds()), "err", err)
+		backoff = min(backoff*2, retryBackoffCap)
+	}
+}
+
+func (r *ReplicaInvalidation) createOnce() (subscriptionName string, cleanup func(), err error) {
+	ctx, cancel := context.WithTimeout(r.ctx, createAttemptTimeout)
+	defer cancel()
+	return r.create(ctx)
+}
+
+// attach wires the listener for a freshly created subscription, or deletes it
+// right away if Stop won the race while creation was in flight.
+func (r *ReplicaInvalidation) attach(subscriptionName string, cleanup func()) {
+	r.mu.Lock()
+	if r.ctx.Err() != nil {
+		r.mu.Unlock()
+		cleanup()
+		return
+	}
+	r.cleanup = cleanup
+	listener := &InvalidationListener{
+		subscriber: r.subscribe(subscriptionName),
+		caches:     r.caches,
+		done:       make(chan struct{}),
+	}
+	r.listener = listener
+	r.mu.Unlock()
+	observability.Get().Info("Created per-replica invalidation subscription", "subscription", subscriptionName)
+	goRecovered("invalidation-listener", func() { listener.Run(r.ctx) })
+}
+
+// Stop halts any background retry, stops the listener, and deletes the
+// subscription (best effort — the expiration policy reclaims it otherwise).
+// Safe to call even when boot-time creation failed.
+func (r *ReplicaInvalidation) Stop() {
+	r.cancel()
+	<-r.bgDone
+	r.mu.Lock()
+	listener := r.listener
+	cleanup := r.cleanup
+	r.mu.Unlock()
+	if listener != nil {
+		listener.Wait()
+	}
+	if cleanup != nil {
+		cleanup()
+	}
+}
+
+// goRecovered mirrors cmd/router's safeGo for this package's long-running
+// goroutines: a panic logs and kills the goroutine, not the process.
+func goRecovered(name string, fn func()) {
+	go func() {
+		defer func() {
+			if rec := recover(); rec != nil {
+				observability.Get().Error("Background goroutine panicked", "goroutine", name, "panic", rec)
+			}
+		}()
+		fn()
+	}()
+}
+
+// sleepCtx blocks for d or until ctx is done, returning ctx.Err() in the
+// latter case so callers can distinguish shutdown from a completed wait.
+func sleepCtx(ctx context.Context, d time.Duration) error {
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}

--- a/internal/pubsub/replica_invalidation_internal_test.go
+++ b/internal/pubsub/replica_invalidation_internal_test.go
@@ -1,0 +1,164 @@
+package pubsub
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"workweave/router/internal/auth"
+
+	gcppubsub "cloud.google.com/go/pubsub/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// newTestReplicaInvalidation builds a ReplicaInvalidation with injected seams
+// and instant sleeps so tests never wait on real backoff.
+func newTestReplicaInvalidation(
+	create func(ctx context.Context) (string, func(), error),
+	sub subscriberReceiver,
+	caches ...auth.InstallationInvalidator,
+) *ReplicaInvalidation {
+	r := &ReplicaInvalidation{
+		create:    create,
+		subscribe: func(string) subscriberReceiver { return sub },
+		caches:    caches,
+		sleep:     func(ctx context.Context, _ time.Duration) error { return ctx.Err() },
+		bgDone:    make(chan struct{}),
+	}
+	r.ctx, r.cancel = context.WithCancel(context.Background())
+	return r
+}
+
+func TestStartReplicaInvalidation_BootSuccessWiresListener(t *testing.T) {
+	sub := &fakeSubscriber{messages: []*gcppubsub.Message{{Data: []byte("install-1")}}}
+	cache := &fakeAPIKeyCache{}
+	var cleaned atomic.Bool
+	r := newTestReplicaInvalidation(func(_ context.Context) (string, func(), error) {
+		return "projects/p/subscriptions/s-1", func() { cleaned.Store(true) }, nil
+	}, sub, cache)
+
+	require.NoError(t, r.start())
+
+	require.Eventually(t, func() bool {
+		return len(cache.Invalidated()) == 1
+	}, time.Second, 5*time.Millisecond, "listener must forward messages after a successful boot")
+	assert.Equal(t, []string{"install-1"}, cache.Invalidated())
+
+	r.Stop()
+	assert.True(t, cleaned.Load(), "Stop must delete the subscription")
+}
+
+func TestStartReplicaInvalidation_PermanentBootErrorFailsFast(t *testing.T) {
+	permErr := fmt.Errorf("create per-replica subscription: %w", status.Error(codes.NotFound, "topic missing"))
+	var calls atomic.Int32
+	r := newTestReplicaInvalidation(func(_ context.Context) (string, func(), error) {
+		calls.Add(1)
+		return "", nil, permErr
+	}, &fakeSubscriber{})
+
+	err := r.start()
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, permErr)
+	assert.Equal(t, int32(1), calls.Load(), "a permanent error must not be retried")
+	assert.NotPanics(t, r.Stop, "Stop must be safe after a failed boot")
+}
+
+func TestStartReplicaInvalidation_TransientBootFailureRetriesInBackground(t *testing.T) {
+	sub := &fakeSubscriber{messages: []*gcppubsub.Message{{Data: []byte("install-9")}}}
+	cache := &fakeAPIKeyCache{}
+	var calls atomic.Int32
+	r := newTestReplicaInvalidation(func(_ context.Context) (string, func(), error) {
+		if calls.Add(1) <= bootCreateAttempts+1 {
+			return "", nil, status.Error(codes.DeadlineExceeded, "slow admin api")
+		}
+		return "projects/p/subscriptions/s-2", func() {}, nil
+	}, sub, cache)
+
+	require.NoError(t, r.start(), "a transient failure must not fail boot")
+
+	require.Eventually(t, func() bool {
+		return len(cache.Invalidated()) == 1
+	}, time.Second, 5*time.Millisecond, "listener must attach once the background retry succeeds")
+	r.Stop()
+}
+
+func TestStartReplicaInvalidation_StopHaltsBackgroundRetry(t *testing.T) {
+	r := newTestReplicaInvalidation(func(_ context.Context) (string, func(), error) {
+		return "", nil, status.Error(codes.Unavailable, "unreachable")
+	}, &fakeSubscriber{})
+	// Keep boot-attempt backoffs instant, then block the retry loop in its
+	// backoff wait so the test asserts Stop interrupts a sleeping loop
+	// rather than racing a hot one.
+	var sleeps atomic.Int32
+	r.sleep = func(ctx context.Context, _ time.Duration) error {
+		if sleeps.Add(1) < bootCreateAttempts {
+			return ctx.Err()
+		}
+		<-ctx.Done()
+		return ctx.Err()
+	}
+
+	require.NoError(t, r.start())
+
+	done := make(chan struct{})
+	go func() {
+		r.Stop()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Stop must halt the background retry loop")
+	}
+}
+
+func TestStartReplicaInvalidation_StopDuringCreateDeletesFreshSubscription(t *testing.T) {
+	var cleaned atomic.Bool
+	var calls atomic.Int32
+	creating := make(chan struct{})
+	r := newTestReplicaInvalidation(func(ctx context.Context) (string, func(), error) {
+		if calls.Add(1) <= bootCreateAttempts {
+			return "", nil, status.Error(codes.DeadlineExceeded, "boot attempt fails")
+		}
+		// Simulate the create succeeding server-side just as shutdown begins.
+		close(creating)
+		<-ctx.Done()
+		return "projects/p/subscriptions/s-3", func() { cleaned.Store(true) }, nil
+	}, &fakeSubscriber{})
+
+	require.NoError(t, r.start())
+	select {
+	case <-creating:
+	case <-time.After(2 * time.Second):
+		t.Fatal("the background retry loop never reached the in-flight create")
+	}
+
+	done := make(chan struct{})
+	go func() {
+		r.Stop()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Stop must return even when a create is in flight")
+	}
+	assert.True(t, cleaned.Load(), "a subscription created during shutdown must be deleted immediately")
+}
+
+func TestPermanentSubscriptionError(t *testing.T) {
+	assert.True(t, permanentSubscriptionError(status.Error(codes.NotFound, "topic missing")))
+	assert.True(t, permanentSubscriptionError(fmt.Errorf("create per-replica subscription: %w", status.Error(codes.PermissionDenied, "iam"))))
+	assert.True(t, permanentSubscriptionError(errMissingPrefix))
+	assert.False(t, permanentSubscriptionError(status.Error(codes.DeadlineExceeded, "slow admin api")))
+	assert.False(t, permanentSubscriptionError(status.Error(codes.Unavailable, "backend down")))
+	assert.False(t, permanentSubscriptionError(context.DeadlineExceeded))
+	assert.False(t, permanentSubscriptionError(errors.New("plain error")))
+}


### PR DESCRIPTION
## Problem

A production replica crashed at boot (`panic: create per-replica subscription: context deadline exceeded`, exit 2) when the Pub/Sub `CreateSubscription` call for the per-replica invalidation subscription exceeded its single 30s deadline during a cold start with degraded egress — the same boot also logged Postgres-ping and billing health-check timeouts before the panic. Cloud Run had to replace the instance, delaying replica availability during scaling.

The invalidation listener is an optimization: the 5-minute cache TTL already bounds staleness when it's absent (that's its documented safety net). A transient admin-API failure should therefore never take the instance down.

## Fix

`pubsub.StartReplicaInvalidation` now owns the whole pipeline lifecycle (creation, listener, teardown), replacing the create-then-panic wiring in `main.go`:

- **Boot**: up to 2 creation attempts (15s each, short backoff). On transient failure the replica **serves with TTL-only invalidation** and a background loop keeps retrying with capped exponential backoff (10s → 5min), attaching the listener as soon as creation succeeds.
- **Fail-fast preserved for misconfiguration**: `NotFound`, `PermissionDenied`, `Unauthenticated`, `InvalidArgument`, `FailedPrecondition`, `Unimplemented`, and an empty subscription prefix still abort boot, so a bad deploy fails its rollout instead of silently degrading. Unknown codes count as transient — the safe default is to keep serving.
- **Teardown**: `Stop` halts the retry loop, drains the listener, and deletes the subscription — including the race where a create completes server-side just as shutdown begins (the fresh subscription is deleted immediately). Orphans from hard kills are still reclaimed by the existing 24h expiration policy.

`go mod tidy` moved `google.golang.org/grpc` to a direct dependency (error-code classification) and reclassified `golang-jwt/jwt/v5`, which was already imported directly.

## Testing

- New unit tests cover: boot success, permanent-error fail-fast (no retry), transient boot failure → background retry → listener attach, `Stop` interrupting the retry loop, the shutdown-vs-create race deleting the fresh subscription, and error classification (including wrapped gRPC status errors). Pass with `-race`.
- Full suite: `go test ./...` green; `wv mr tc` green; `go vet` clean on changed packages.

🤖 Generated with [Weave Router](https://router.workweave.ai)
