### PR TITLE
fix(proxy): route grok/xai pins to 4.6 and floor grok effort at low

### DIFF
--- a/internal/proxy/force_effort_test.go
+++ b/internal/proxy/force_effort_test.go
@@ -17,8 +17,8 @@ func TestForcedReasoningEffort(t *testing.T) {
 		{"gpt-5.4-mini", true, "high"},
 		{"gemini-3.1-pro-preview", false, "low"},
 		{"gemini-3.1-pro-preview", true, "low"}, // effort-immune: escalation ignored
-		{"grok-4.6", false, "low"},              // bare pin must not fall to xAI's non-disableable high default
-		{"grok-4.6", true, "low"},               // pinned low; escalation not spent on grok
+		{"grok-4.6", false, "low"},              // unconditional: bare pin must not fall to xAI's non-disableable high default
+		{"grok-4.6", true, "low"},               // floor ignores escalation
 		{"grok-4.5", false, "low"},
 		{"claude-opus-4-8", false, ""}, // adaptive path untouched
 		{"claude-opus-4-8", true, ""},

--- a/internal/proxy/force_effort_test.go
+++ b/internal/proxy/force_effort_test.go
@@ -17,7 +17,10 @@ func TestForcedReasoningEffort(t *testing.T) {
 		{"gpt-5.4-mini", true, "high"},
 		{"gemini-3.1-pro-preview", false, "low"},
 		{"gemini-3.1-pro-preview", true, "low"}, // effort-immune: escalation ignored
-		{"claude-opus-4-8", false, ""},          // adaptive path untouched
+		{"grok-4.6", false, "low"},              // bare pin must not fall to xAI's non-disableable high default
+		{"grok-4.6", true, "low"},               // pinned low; escalation not spent on grok
+		{"grok-4.5", false, "low"},
+		{"claude-opus-4-8", false, ""}, // adaptive path untouched
 		{"claude-opus-4-8", true, ""},
 		{"deepseek/deepseek-v4-pro", true, ""},
 		{"gemini-2.5-flash", true, ""}, // only gemini-3.x is pinned

--- a/internal/proxy/force_model.go
+++ b/internal/proxy/force_model.go
@@ -183,9 +183,6 @@ func resolveForceModelWithEffort(model string) (canonicalID, provider string, kn
 		model = canonical
 	}
 	if m, ok := catalog.ByID(model); ok && len(m.Providers) > 0 && (requiredProvider == "" || m.Providers[0].Provider == requiredProvider) {
-		if effort == "" {
-			effort = defaultForceEffort[m.ID]
-		}
 		return m.ID, m.Providers[0].Provider, true, effort
 	}
 	if requiredProvider != "" {
@@ -205,14 +202,6 @@ func resolveForceModelWithEffort(model string) (canonicalID, provider string, kn
 	default:
 		return model, providers.ProviderAnthropic, false, effort
 	}
-}
-
-// defaultForceEffort floors reasoning_effort for models whose provider default is unusable
-// when the field is omitted. xAI's grok-4.x server-side default is "high" and not
-// disableable, causing a ~15 s p50 TTFT stall. An explicit :level suffix always wins.
-var defaultForceEffort = map[string]string{
-	"grok-4.5": "low",
-	"grok-4.6": "low",
 }
 
 // bareCatalogNames maps a slash-form model's bare tail to its canonical

--- a/internal/proxy/force_model.go
+++ b/internal/proxy/force_model.go
@@ -94,11 +94,8 @@ var forceModelAliases = map[string]string{
 	"gpt-5-5-pro":   "gpt-5.5-pro",
 	"gpt-5-5-mini":  "gpt-5.5-mini",
 	"gpt-5-5-nano":  "gpt-5.5-nano",
-	// grok-4.5 is retired from routing: it has no AA Agentic Index score, was
-	// never rostered, and pins to it underperformed with slow TTFT (default-high
-	// reasoning_effort on xAI native). The family aliases follow the current
-	// flagship, 4.6; the model itself stays servable as priced passthrough via
-	// its own-name alias so existing explicit pins keep resolving.
+	// grok-4.5 is retired from routing (no AA Agentic Index score, never rostered).
+	// Family aliases follow flagship 4.6; own-name alias keeps grok-4.5 as passthrough.
 	"grok":                  "grok-4.6",
 	"grok-4.5":              "grok-4.5",
 	"grok4.5":               "grok-4.5",
@@ -210,12 +207,9 @@ func resolveForceModelWithEffort(model string) (canonicalID, provider string, kn
 	}
 }
 
-// defaultForceEffort pins a reasoning_effort floor for models whose provider
-// default is unusable when the field is omitted. A bare pin sends no effort at
-// all, and xAI's server-side default for grok-4.x is "high" and not
-// disableable — measured 2026-08-21 as a ~15.4s p50 TTFT stall on a fixed
-// reasoning pass, with a tight p50/p90 band (15,444/15,985 ms) that marks a
-// fixed stall, not variable prefill. An explicit :level suffix always wins.
+// defaultForceEffort floors reasoning_effort for models whose provider default is unusable
+// when the field is omitted. xAI's grok-4.x server-side default is "high" and not
+// disableable, causing a ~15 s p50 TTFT stall. An explicit :level suffix always wins.
 var defaultForceEffort = map[string]string{
 	"grok-4.5": "low",
 	"grok-4.6": "low",

--- a/internal/proxy/force_model.go
+++ b/internal/proxy/force_model.go
@@ -94,11 +94,15 @@ var forceModelAliases = map[string]string{
 	"gpt-5-5-pro":   "gpt-5.5-pro",
 	"gpt-5-5-mini":  "gpt-5.5-mini",
 	"gpt-5-5-nano":  "gpt-5.5-nano",
-	"grok":          "grok-4.5",
-	"grok-4.5":      "grok-4.5",
-	"grok4.5":       "grok-4.5",
-	"xai":           "grok-4.5",
-	// "grok" stays at 4.5 for backward compat; "grok-max" surfaces 4.6.
+	// grok-4.5 is retired from routing: it has no AA Agentic Index score, was
+	// never rostered, and pins to it underperformed with slow TTFT (default-high
+	// reasoning_effort on xAI native). The family aliases follow the current
+	// flagship, 4.6; the model itself stays servable as priced passthrough via
+	// its own-name alias so existing explicit pins keep resolving.
+	"grok":                  "grok-4.6",
+	"grok-4.5":              "grok-4.5",
+	"grok4.5":               "grok-4.5",
+	"xai":                   "grok-4.6",
 	"grok-4.6":              "grok-4.6",
 	"grok4.6":               "grok-4.6",
 	"grok-max":              "grok-4.6",
@@ -182,6 +186,9 @@ func resolveForceModelWithEffort(model string) (canonicalID, provider string, kn
 		model = canonical
 	}
 	if m, ok := catalog.ByID(model); ok && len(m.Providers) > 0 && (requiredProvider == "" || m.Providers[0].Provider == requiredProvider) {
+		if effort == "" {
+			effort = defaultForceEffort[m.ID]
+		}
 		return m.ID, m.Providers[0].Provider, true, effort
 	}
 	if requiredProvider != "" {
@@ -201,6 +208,17 @@ func resolveForceModelWithEffort(model string) (canonicalID, provider string, kn
 	default:
 		return model, providers.ProviderAnthropic, false, effort
 	}
+}
+
+// defaultForceEffort pins a reasoning_effort floor for models whose provider
+// default is unusable when the field is omitted. A bare pin sends no effort at
+// all, and xAI's server-side default for grok-4.x is "high" and not
+// disableable — measured 2026-08-21 as a ~15.4s p50 TTFT stall on a fixed
+// reasoning pass, with a tight p50/p90 band (15,444/15,985 ms) that marks a
+// fixed stall, not variable prefill. An explicit :level suffix always wins.
+var defaultForceEffort = map[string]string{
+	"grok-4.5": "low",
+	"grok-4.6": "low",
 }
 
 // bareCatalogNames maps a slash-form model's bare tail to its canonical

--- a/internal/proxy/force_model_internal_test.go
+++ b/internal/proxy/force_model_internal_test.go
@@ -308,9 +308,7 @@ func TestBareCatalogNames_AliasesTakePrecedence(t *testing.T) {
 	}
 }
 
-// The grok family alias follows the current flagship (4.6), never the retired
-// 4.5; xai is a vendor shorthand for the same flagship. Own-name pins still
-// resolve exactly, so an explicit grok-4.5 keeps working as passthrough.
+// grok-4.5 is retired; family aliases (grok, xai) now follow flagship 4.6, own-name pins still resolve exactly.
 func TestResolveForceModel_GrokFamilyAlias(t *testing.T) {
 	for _, input := range []string{"grok", "xai"} {
 		t.Run(input, func(t *testing.T) {
@@ -322,27 +320,10 @@ func TestResolveForceModel_GrokFamilyAlias(t *testing.T) {
 	}
 }
 
-// xAI's grok-4.x effort default is "high" and not disableable; bare grok pins must
-// carry the "low" floor, and an explicit :level suffix must always win.
-func TestResolveForceModel_GrokEffortFloor(t *testing.T) {
-	tests := []struct {
-		name       string
-		input      string
-		wantID     string
-		wantEffort string
-	}{
-		{name: "family alias bare", input: "grok", wantID: "grok-4.6", wantEffort: "low"},
-		{name: "own-name 4.6 bare", input: "grok-4.6", wantID: "grok-4.6", wantEffort: "low"},
-		{name: "own-name 4.5 bare", input: "grok-4.5", wantID: "grok-4.5", wantEffort: "low"},
-		{name: "explicit suffix wins", input: "grok-4.6:high", wantID: "grok-4.6", wantEffort: "high"},
-		{name: "non-grok carries no floor", input: "gpt", wantID: "gpt-5.6-sol", wantEffort: ""},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			gotID, _, gotKnown, gotEffort := resolveForceModelWithEffort(tt.input)
-			assert.Equal(t, tt.wantID, gotID, "canonical id")
-			assert.True(t, gotKnown, "known")
-			assert.Equal(t, tt.wantEffort, gotEffort, "effort")
-		})
-	}
+// An explicit :level suffix must survive resolution to its catalog model.
+func TestResolveForceModel_EffortSuffixPreserved(t *testing.T) {
+	gotID, _, gotKnown, gotEffort := resolveForceModelWithEffort("grok-4.6:high")
+	assert.Equal(t, "grok-4.6", gotID, "canonical id")
+	assert.True(t, gotKnown, "known")
+	assert.Equal(t, "high", gotEffort, "effort")
 }

--- a/internal/proxy/force_model_internal_test.go
+++ b/internal/proxy/force_model_internal_test.go
@@ -307,3 +307,44 @@ func TestBareCatalogNames_AliasesTakePrecedence(t *testing.T) {
 		assert.False(t, shadowed, "alias %q must not also be a bare-name entry", alias)
 	}
 }
+
+// The grok family alias follows the current flagship (4.6), never the retired
+// 4.5; xai is a vendor shorthand for the same flagship. Own-name pins still
+// resolve exactly, so an explicit grok-4.5 keeps working as passthrough.
+func TestResolveForceModel_GrokFamilyAlias(t *testing.T) {
+	for _, input := range []string{"grok", "xai"} {
+		t.Run(input, func(t *testing.T) {
+			gotID, gotProvider, gotKnown := resolveForceModel(input)
+			assert.Equal(t, "grok-4.6", gotID, "canonical id")
+			assert.Equal(t, providers.ProviderXAI, gotProvider, "provider")
+			assert.True(t, gotKnown, "known")
+		})
+	}
+}
+
+// xAI's server-side reasoning_effort default for grok-4.x is "high" and not
+// disableable; a bare pin sends no effort, which measured as a ~15.4s p50
+// TTFT stall (2026-08-21). A bare grok pin must therefore carry the "low"
+// floor, and an explicit :level suffix must always win over it.
+func TestResolveForceModel_GrokEffortFloor(t *testing.T) {
+	tests := []struct {
+		name       string
+		input      string
+		wantID     string
+		wantEffort string
+	}{
+		{name: "family alias bare", input: "grok", wantID: "grok-4.6", wantEffort: "low"},
+		{name: "own-name 4.6 bare", input: "grok-4.6", wantID: "grok-4.6", wantEffort: "low"},
+		{name: "own-name 4.5 bare", input: "grok-4.5", wantID: "grok-4.5", wantEffort: "low"},
+		{name: "explicit suffix wins", input: "grok-4.6:high", wantID: "grok-4.6", wantEffort: "high"},
+		{name: "non-grok carries no floor", input: "gpt", wantID: "gpt-5.6-sol", wantEffort: ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotID, _, gotKnown, gotEffort := resolveForceModelWithEffort(tt.input)
+			assert.Equal(t, tt.wantID, gotID, "canonical id")
+			assert.True(t, gotKnown, "known")
+			assert.Equal(t, tt.wantEffort, gotEffort, "effort")
+		})
+	}
+}

--- a/internal/proxy/force_model_internal_test.go
+++ b/internal/proxy/force_model_internal_test.go
@@ -322,10 +322,8 @@ func TestResolveForceModel_GrokFamilyAlias(t *testing.T) {
 	}
 }
 
-// xAI's server-side reasoning_effort default for grok-4.x is "high" and not
-// disableable; a bare pin sends no effort, which measured as a ~15.4s p50
-// TTFT stall (2026-08-21). A bare grok pin must therefore carry the "low"
-// floor, and an explicit :level suffix must always win over it.
+// xAI's grok-4.x effort default is "high" and not disableable; bare grok pins must
+// carry the "low" floor, and an explicit :level suffix must always win.
 func TestResolveForceModel_GrokEffortFloor(t *testing.T) {
 	tests := []struct {
 		name       string

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -1439,6 +1439,12 @@ func (s *Service) WithContentCapture(mode ContentCaptureMode, maxBytes int, reda
 //     "high" default, a ~15 s fixed TTFT stall on every pinned turn.
 //   - everything else: "" — left to its own path.
 func forcedReasoningEffort(model string, escalate bool) string {
+	// The grok floor is unconditional (not gated on effortEscalation): a bare
+	// pin that omits effort falls to xAI's non-disableable "high" default, a
+	// ~15 s fixed TTFT stall — a defect to correct, not an escalation to tune.
+	if strings.HasPrefix(model, "grok-") {
+		return "low"
+	}
 	switch {
 	case strings.HasPrefix(model, "gpt-5"):
 		if escalate {
@@ -1446,8 +1452,6 @@ func forcedReasoningEffort(model string, escalate bool) string {
 		}
 		return "low"
 	case strings.HasPrefix(model, "gemini-3"):
-		return "low"
-	case strings.HasPrefix(model, "grok-"):
 		return "low"
 	default:
 		return ""
@@ -2831,8 +2835,8 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 	if knobs := routingKnobsForRequest(ctx); knobs != nil && knobs.ForceEffort != "" {
 		opts.ForceEffort = knobs.ForceEffort
 		opts.ForceReasoningEffort = translate.ResolveForceEffort(opts.Capabilities, opts.ForceEffort)
-	} else if s.effortEscalation {
-		opts.ForceReasoningEffort = forcedReasoningEffort(decision.Model, routeRes.EscalateEffort)
+	} else if effort := forcedReasoningEffort(decision.Model, routeRes.EscalateEffort); effort != "" && (s.effortEscalation || strings.HasPrefix(decision.Model, "grok-")) {
+		opts.ForceReasoningEffort = effort
 	}
 
 	// A caller whose Claude subscription has bound its plan window can't serve
@@ -3212,8 +3216,8 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 		if knobs := routingKnobsForRequest(ctx); knobs != nil && knobs.ForceEffort != "" {
 			baselineOpts.ForceEffort = knobs.ForceEffort
 			baselineOpts.ForceReasoningEffort = translate.ResolveForceEffort(baselineOpts.Capabilities, knobs.ForceEffort)
-		} else if s.effortEscalation {
-			baselineOpts.ForceReasoningEffort = forcedReasoningEffort(baselineModel, routeRes.EscalateEffort)
+		} else if effort := forcedReasoningEffort(baselineModel, routeRes.EscalateEffort); effort != "" && (s.effortEscalation || strings.HasPrefix(baselineModel, "grok-")) {
+			baselineOpts.ForceReasoningEffort = effort
 		}
 		baselinePrep, baselineEmitErr := env.PrepareAnthropic(r.Header, baselineOpts)
 		if baselineEmitErr != nil {
@@ -3348,8 +3352,8 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 		if knobs := routingKnobsForRequest(ctx); knobs != nil && knobs.ForceEffort != "" {
 			siblingOpts.ForceEffort = knobs.ForceEffort
 			siblingOpts.ForceReasoningEffort = translate.ResolveForceEffort(siblingOpts.Capabilities, knobs.ForceEffort)
-		} else if s.effortEscalation {
-			siblingOpts.ForceReasoningEffort = forcedReasoningEffort(siblingDecision.Model, routeRes.EscalateEffort)
+		} else if effort := forcedReasoningEffort(siblingDecision.Model, routeRes.EscalateEffort); effort != "" && (s.effortEscalation || strings.HasPrefix(siblingDecision.Model, "grok-")) {
+			siblingOpts.ForceReasoningEffort = effort
 		}
 		siblingCtx := resolveAndInjectCredentials(ctx, siblingDecision.Provider, siblingDecision.Model, r.Header)
 		siblingBindings := s.resolveBindingsForDispatch(siblingCtx, siblingDecision)
@@ -5109,8 +5113,8 @@ func (s *Service) ProxyOpenAIChatCompletion(ctx context.Context, body []byte, w 
 	if knobs := routingKnobsForRequest(ctx); knobs != nil && knobs.ForceEffort != "" {
 		opts.ForceEffort = knobs.ForceEffort
 		opts.ForceReasoningEffort = translate.ResolveForceEffort(opts.Capabilities, opts.ForceEffort)
-	} else if s.effortEscalation {
-		opts.ForceReasoningEffort = forcedReasoningEffort(decision.Model, routeRes.EscalateEffort)
+	} else if effort := forcedReasoningEffort(decision.Model, routeRes.EscalateEffort); effort != "" && (s.effortEscalation || strings.HasPrefix(decision.Model, "grok-")) {
+		opts.ForceReasoningEffort = effort
 	}
 
 	ctx = resolveAndInjectCredentials(ctx, decision.Provider, decision.Model, r.Header)

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -1435,6 +1435,8 @@ func (s *Service) WithContentCapture(mode ContentCaptureMode, maxBytes int, reda
 //     On SWE-Bench Pro this beats both fixed policies (24% < 32% < ~40% resolved)
 //     since high is spent only where it flips the outcome.
 //   - gemini-3.x: pinned "low" — effort-immune on hard tasks (0/15 in the sweep).
+//   - grok-4.x: pinned "low" — omitting effort falls to xAI's non-disableable
+//     "high" default, a ~15 s fixed TTFT stall on every pinned turn.
 //   - everything else: "" — left to its own path.
 func forcedReasoningEffort(model string, escalate bool) string {
 	switch {
@@ -1444,6 +1446,8 @@ func forcedReasoningEffort(model string, escalate bool) string {
 		}
 		return "low"
 	case strings.HasPrefix(model, "gemini-3"):
+		return "low"
+	case strings.HasPrefix(model, "grok-"):
 		return "low"
 	default:
 		return ""

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -1439,9 +1439,8 @@ func (s *Service) WithContentCapture(mode ContentCaptureMode, maxBytes int, reda
 //     "high" default, a ~15 s fixed TTFT stall on every pinned turn.
 //   - everything else: "" — left to its own path.
 func forcedReasoningEffort(model string, escalate bool) string {
-	// The grok floor is unconditional (not gated on effortEscalation): a bare
-	// pin that omits effort falls to xAI's non-disableable "high" default, a
-	// ~15 s fixed TTFT stall — a defect to correct, not an escalation to tune.
+	// Unconditional: omitting effort falls to xAI's non-disableable "high" default
+	// (~15 s TTFT stall) — a defect to correct, not an escalation to tune.
 	if strings.HasPrefix(model, "grok-") {
 		return "low"
 	}


### PR DESCRIPTION
Force-model fixes for the grok family, prompted by a bad `/fm grok` pin that silently resolved to the retired 4.5 and then ran unusably slow.

## The problem

`/fm grok` pinned **grok-4.5**. Two things made that a bad outcome:

1. **Stale family alias.** `grok` / `xai` resolved to grok-4.5, which is retired from routing (no AA Agentic Index score, never rostered) and underperformed as a pin. Family aliases should follow the current flagship, the way `gpt`/`gemini` do.
2. **A bare grok pin sends no `reasoning_effort` at all**, and xAI's server-side default for grok-4.x is **high and not disableable**. Measured 2026-08-21 (prod, claude-code, input >20k): grok-4.6 p50 TTFT **15,444 ms** vs 2,949 ms for the next-worst arm — a tight p50/p90 band (15,444/15,985) marking a fixed reasoning stall, not variable prefill, and only ~107 avg output tokens.

## The fix

- **`grok` / `xai` → grok-4.6.** grok-4.5 stays servable as priced passthrough via its own-name alias, so any existing explicit `grok-4.5` pin keeps resolving.
- **Pin grok-4.x to `low` in `forcedReasoningEffort`, unconditionally.** This is the dispatch-time resolver hit on every forced and sticky-pin turn (forced, baseline, sibling seams), so a bare pin — header **or** chat command — no longer falls to xAI's high default. An explicit `:level` suffix still wins (it lands on `ForceEffort`, which outranks `ForceReasoningEffort`).

Two deliberate placement choices, both correcting earlier drafts:

- **Dispatch-time, not resolve-time.** Force-model resolution (the header's `resolveForceModelWithEffort` and the chat command's `resolveForceModel`) runs only on the turn that sets the pin; sticky-pin turns never re-derive effort. A resolve-time floor would miss the exact pinned turns this is for. `forcedReasoningEffort` runs at every dispatch seam.
- **Unconditional, not behind `ROUTER_EFFORT_ESCALATION`.** That flag gates the gpt-5/gemini-3 escalate-on-failure *policy* and defaults off. The grok floor is a correction for a defect (a bare pin falling to a non-disableable high default), not an escalation to bake off, so it applies regardless of the flag. The escalation policy stays gated.

## Behavior

```
/fm grok          -> grok-4.6, effort=low   (was: grok-4.5, no effort -> xAI high)
/fm xai           -> grok-4.6, effort=low   (was: grok-4.5)
/fm grok-4.5      -> grok-4.5, effort=low   (passthrough, still resolvable)
/fm grok-4.6:high -> grok-4.6, effort=high  (explicit suffix wins)
sticky grok pin   -> effort=low every turn  (was: no effort -> xAI high), flag on or off
```

## Testing

- `gofmt -l .` clean, `go vet ./...`, `go build ./...`, `go test ./...` — all pass.
- Coverage: `TestResolveForceModel_GrokFamilyAlias` (grok/xai → 4.6), `TestResolveForceModel_EffortSuffixPreserved` (`:high` survives), and new `forcedReasoningEffort` cases asserting grok-4.5/4.6 pin low with the floor ignoring escalation.

🤖 Generated with [Weave Router](https://router.workweave.ai)