### PR TITLE
fix(translate): strip SendMessage tool from cross-vendor emit

### DIFF
--- a/internal/translate/claudecode_tool_filter.go
+++ b/internal/translate/claudecode_tool_filter.go
@@ -28,14 +28,15 @@ import (
 // not a CC-internal control-plane tool.
 var claudeCodeOnlyToolNames = map[string]struct{}{
 	// Subagent dispatch. Task = pre-2.1 name; Agent = current CC name.
-	"Task":       {},
-	"Agent":      {},
-	"TaskCreate": {},
-	"TaskUpdate": {},
-	"TaskGet":    {},
-	"TaskList":   {},
-	"TaskOutput": {},
-	"TaskStop":   {},
+	"Task":        {},
+	"Agent":       {},
+	"TaskCreate":  {},
+	"TaskUpdate":  {},
+	"TaskGet":     {},
+	"TaskList":    {},
+	"TaskOutput":  {},
+	"TaskStop":    {},
+	"SendMessage": {}, // teammate/subagent messaging: CC-internal like Task*
 	// Plan mode / skills / workflows.
 	"EnterPlanMode":   {},
 	"ExitPlanMode":    {},

--- a/internal/translate/claudecode_tool_filter_internal_test.go
+++ b/internal/translate/claudecode_tool_filter_internal_test.go
@@ -36,6 +36,7 @@ func TestShouldStripCCTool(t *testing.T) {
 		{"AskUserQuestion", true, true},  // CC-only non-orchestration: stripped even when flag on
 		{"ToolSearch", true, true},       // CC-only non-orchestration: stripped even when flag on
 		{"TodoWrite", false, true},       // CC-only non-orchestration: stripped
+		{"SendMessage", true, true},      // CC-only subagent messaging: stripped even when flag on
 	}
 	for _, tc := range cases {
 		if got := shouldStripCCTool(tc.name, tc.keepOrchestration); got != tc.want {

--- a/internal/translate/claudecode_tool_filter_test.go
+++ b/internal/translate/claudecode_tool_filter_test.go
@@ -90,6 +90,7 @@ const claudeCodeMixedToolBody = `{
 		{"name":"KillShell","description":"bg kill","input_schema":{"type":"object"}},
 		{"name":"Task","description":"sub-agent dispatch","input_schema":{"type":"object"}},
 		{"name":"Agent","description":"sub-agent dispatch","input_schema":{"type":"object"}},
+		{"name":"SendMessage","description":"","input_schema":{"type":"object"}},
 		{"name":"TaskCreate","description":"","input_schema":{"type":"object"}},
 		{"name":"TaskUpdate","description":"","input_schema":{"type":"object"}},
 		{"name":"TaskList","description":"","input_schema":{"type":"object"}},
@@ -124,6 +125,7 @@ func TestStripCCTools_AnthropicSourceOpenAITarget_DropsCCOnlyKeepsReal(t *testin
 		"coding + scheduling tools survive; CC-only control-plane schemas stripped on Anthropic→OpenAI")
 	assert.NotContains(t, names, "Task")
 	assert.NotContains(t, names, "Agent")
+	assert.NotContains(t, names, "SendMessage")
 	assert.NotContains(t, names, "ToolSearch")
 }
 
@@ -190,6 +192,7 @@ func TestKeepOrchestrationTools_OpenAITarget_KeepsOrchestrationDropsRest(t *test
 		"Task", "Agent", "TaskCreate", "TaskUpdate", "TaskList",
 		"EnterPlanMode", "ExitPlanMode", "UpdatePlan", "Skill", "Workflow",
 	}, names, "orchestration + scheduling tools survive when the flag is on")
+	assert.NotContains(t, names, "SendMessage", "non-orchestration CC-only tools stay stripped")
 	assert.NotContains(t, names, "AskUserQuestion", "non-orchestration CC-only tools stay stripped")
 	assert.NotContains(t, names, "ToolSearch")
 	assert.NotContains(t, names, "TodoWrite")
@@ -241,6 +244,7 @@ func TestKeepOrchestrationTools_GeminiTarget_KeepsOrchestrationDropsRest(t *test
 		"Task", "Agent", "TaskCreate", "TaskUpdate", "TaskList",
 		"EnterPlanMode", "ExitPlanMode", "UpdatePlan", "Skill", "Workflow",
 	}, names, "Anthropic→Gemini keeps orchestration + scheduling tools when the flag is on")
+	assert.NotContains(t, names, "SendMessage")
 	assert.NotContains(t, names, "AskUserQuestion")
 	assert.NotContains(t, names, "ToolSearch")
 }


### PR DESCRIPTION
## Problem

Claude Code emits the `SendMessage` subagent/teammate messaging tool whenever a session has a teammate or subagent. Its `input_schema` carries `if`/`then` conditionals and per-property `pattern` constraints — including two conflicting `description` patterns (`^[^\n\r]*$` vs `^[\s\S]{0,300}$`).

When such a session routes cross-format to a Fireworks-served model, Fireworks' OpenAI-compat validator rejects the translated tool schema:

```
400 Conflict in schema definitions for key 'description'. Previous: (pattern: ^[^\n\r]*$), New: (pattern: ^[\s\S]{0,300}$)
```

Gemini's translator rejects the same schema independently:

```
function "SendMessage" input_schema: gemini schema is not representable at $.properties.to.allOf[1]: branches conflict
```

Because 4xx is not retryable and only 404/402 trigger cross-binding failover, this hard-fails the turn to the client.

## Root cause

The Claude-Code-only tool filter (`internal/translate/claudecode_tool_filter.go`) strips client-dispatched CC control-plane tools from cross-vendor emit — `Task`, `Agent`, `TaskCreate/Update/Get/List/Output/Stop`, `Workflow`, `Skill`, plan-mode toggles, etc. — but **`SendMessage` was missing from `claudeCodeOnlyToolNames`**. Its schema therefore rode through to Fireworks/Gemini.

Confirmed in prod: every affected session has `cross_format=true, has_tools=true` (kimi-k3, qwen3.8-max on Fireworks). The current session had `cc_only_tools_stripped=6` — six CC-only tools stripped, but not `SendMessage`.

## Fix

Add `SendMessage` to `claudeCodeOnlyToolNames` (not the orchestration subset) so cross-vendor emit drops its schema like the rest of the subagent family. This both unbreaks upstream validation and stops non-Anthropic models from hallucinating calls to a tool they can't dispatch.

## Tests

- `TestShouldStripCCTool`: pinned `SendMessage` stripped even when `KeepCrossVendorOrchestrationTools` is on (mirrors `AskUserQuestion`).
- `TestStripCCTools_AnthropicSourceOpenAITarget_*` / Gemini + flag-on variants: `SendMessage` added to the fixture, asserted absent from emitted OpenAI and Gemini tool lists (flag on and off).
- Full `go test ./internal/...` + `go build ./...` green.

🤖 Generated with [Weave Router](https://router.workweave.ai)