### PR TITLE
fix(translate,proxy): intersect allOf branches; never hard-fail a turn on an untranslatable tool schema

### DIFF
--- a/internal/proxy/dispatch_error.go
+++ b/internal/proxy/dispatch_error.go
@@ -50,7 +50,17 @@ const (
 	DispatchErrorForcedModelUnknown
 	DispatchErrorForcedClusterUnsupportedStrategy
 	DispatchErrorForcedClusterUnservable
+	DispatchErrorToolSchemaUntranslatable
 )
+
+// isUntranslatableToolSchemaErr reports whether err is a tool schema the routed
+// provider's function-calling grammar cannot express. Pre-dispatch and
+// route-specific: the same tools translate for another provider, so the caller
+// can rescue the turn instead of failing it.
+func isUntranslatableToolSchemaErr(err error) bool {
+	return errors.Is(err, translate.ErrGeminiSchemaIncompatible) ||
+		errors.Is(err, translate.ErrGeminiToolDeclarationConflict)
+}
 
 // DispatchErrorClass is the format-agnostic classification of a dispatch
 // error: the HTTP status to return, the client-facing message, whether to
@@ -161,6 +171,18 @@ func ClassifyDispatchError(err error) (DispatchErrorClass, bool) {
 			Message:    "This request requires a native compatibility path that the router does not support.",
 			LogLevel:   "warn",
 			LogMessage: "Translation requirements are intrinsically incompatible",
+		}, true
+	case isUntranslatableToolSchemaErr(err):
+		// 400, not 502: nothing was dispatched and retrying is futile. The
+		// unclassified 502 this used to fall through to told Claude Code the
+		// upstream had failed, so it retried the same doomed request eleven
+		// times per turn.
+		return DispatchErrorClass{
+			Kind:       DispatchErrorToolSchemaUntranslatable,
+			Status:     http.StatusBadRequest,
+			Message:    "A tool's input schema cannot be expressed in the routed provider's function-calling schema: " + err.Error() + ". Simplify that tool's schema, or exclude this provider for the installation.",
+			LogLevel:   "error",
+			LogMessage: "Rejected request: a tool schema is not representable for the routed provider",
 		}, true
 	case errors.Is(err, ErrTranslationCompatibleProviderUnavailable):
 		return DispatchErrorClass{
@@ -299,7 +321,7 @@ func unwrapToSentinelMessage(err error) string {
 // rather than "api_error".
 func (k DispatchErrorKind) IsClientError() bool {
 	switch k {
-	case DispatchErrorRequestNotJSONObject, DispatchErrorNoEligibleProvider, DispatchErrorAllowlistEmptiesPool, DispatchErrorContextWindowExceeded, DispatchErrorInvalidRoutingKnobs, DispatchErrorTranslationIntrinsicallyIncompatible, DispatchErrorAnthropicCacheControlInvalid, DispatchErrorForcedModelExcluded, DispatchErrorForcedModelUnknown, DispatchErrorForcedClusterUnsupportedStrategy, DispatchErrorForcedClusterUnservable:
+	case DispatchErrorRequestNotJSONObject, DispatchErrorNoEligibleProvider, DispatchErrorAllowlistEmptiesPool, DispatchErrorContextWindowExceeded, DispatchErrorInvalidRoutingKnobs, DispatchErrorTranslationIntrinsicallyIncompatible, DispatchErrorAnthropicCacheControlInvalid, DispatchErrorForcedModelExcluded, DispatchErrorForcedModelUnknown, DispatchErrorForcedClusterUnsupportedStrategy, DispatchErrorForcedClusterUnservable, DispatchErrorToolSchemaUntranslatable:
 		return true
 	default:
 		return false

--- a/internal/proxy/dispatch_error_test.go
+++ b/internal/proxy/dispatch_error_test.go
@@ -52,9 +52,9 @@ func TestClassifyDispatchError_UntranslatableToolSchema(t *testing.T) {
 		{
 			// The exact wrapping service.go's Gemini branch produces.
 			name:     "schema incompatible",
-			wantTool: "SendMessage",
+			wantTool: "weave_send_message",
 			err: fmt.Errorf("translate anthropic request to gemini: %w",
-				fmt.Errorf("function %q input_schema: %w", "SendMessage",
+				fmt.Errorf("function %q input_schema: %w", "weave_send_message",
 					fmt.Errorf("%w at $.properties.to.allOf[1]: %q is unsatisfiable across branches",
 						translate.ErrGeminiSchemaIncompatible, "pattern"))),
 		},

--- a/internal/proxy/dispatch_error_test.go
+++ b/internal/proxy/dispatch_error_test.go
@@ -39,6 +39,49 @@ func TestClassifyDispatchError_ProviderNotConfigured(t *testing.T) {
 	assert.False(t, cls.Kind.IsClientError(), "provider-not-configured is an upstream/routing problem, not a client-input one")
 }
 
+// TestClassifyDispatchError_UntranslatableToolSchema locks in the status that
+// stops the retry storm: the unclassified fall-through used to return 502
+// "Upstream call failed." for a request no upstream ever saw, and Claude Code
+// retried each doomed turn eleven times.
+func TestClassifyDispatchError_UntranslatableToolSchema(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		wantTool string
+	}{
+		{
+			// The exact wrapping service.go's Gemini branch produces.
+			name:     "schema incompatible",
+			wantTool: "SendMessage",
+			err: fmt.Errorf("translate anthropic request to gemini: %w",
+				fmt.Errorf("function %q input_schema: %w", "SendMessage",
+					fmt.Errorf("%w at $.properties.to.allOf[1]: %q is unsatisfiable across branches",
+						translate.ErrGeminiSchemaIncompatible, "pattern"))),
+		},
+		{
+			name:     "duplicate declaration conflict",
+			wantTool: "read",
+			err: fmt.Errorf("translate anthropic request to gemini: %w",
+				fmt.Errorf("%w: duplicate declaration %q differs",
+					translate.ErrGeminiToolDeclarationConflict, "read")),
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			cls, ok := proxy.ClassifyDispatchError(test.err)
+
+			require.True(t, ok, "an untranslatable tool schema must be classified")
+			assert.Equal(t, proxy.DispatchErrorToolSchemaUntranslatable, cls.Kind)
+			assert.Equal(t, http.StatusBadRequest, cls.Status)
+			assert.False(t, cls.RetryAfter, "retrying an unrepresentable schema is futile")
+			assert.True(t, cls.Kind.IsClientError(),
+				"the tool schema is the client's to fix, so the envelope is invalid_request_error")
+			assert.Contains(t, cls.Message, test.wantTool,
+				"the message must name the offending tool")
+		})
+	}
+}
+
 func TestClassifyDispatchError_UpstreamStatusErrorPreservesStatus(t *testing.T) {
 	err := &providers.UpstreamStatusError{Status: http.StatusTooManyRequests}
 

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -3086,11 +3086,6 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 			return nil, fmt.Errorf("%w: %s (no translation path defined for inbound Anthropic Messages)", ErrProviderNotConfigured, target.Provider)
 		}
 	}
-	attempt, attemptBuildErr := buildAttempt(decision, opts, marker)
-	if attemptBuildErr != nil {
-		return attemptBuildErr
-	}
-
 	// In-turn baseline failover eligibility: when the router cost-routes to an
 	// OSS/Gemini model and every binding fails, fall back to the requested
 	// model on Anthropic instead of hard-failing. Eligible only when: not
@@ -3114,6 +3109,121 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 		baselineModel != decision.Model &&
 		baselineKnown && baselineCatalog.PrimaryProvider() == providers.ProviderAnthropic
 	baselineEligible := !routeRes.AuthoritativePerTurn && baselineViable
+
+	// Built after baseline eligibility so an untranslatable tool schema can be
+	// rescued below rather than hard-failing the turn.
+	attempt, attemptBuildErr := buildAttempt(decision, opts, marker)
+	toolSchemaRescueUsed := false
+	if attemptBuildErr != nil && baselineEligible && isUntranslatableToolSchemaErr(attemptBuildErr) {
+		// A tool schema the routed provider's function-calling grammar cannot
+		// express is a property of the ROUTE, not of the request: the same tools
+		// translate fine for Anthropic. Nothing has reached the wire yet, so
+		// serve the baseline instead of an error the client will retry ten
+		// times. Without this, one unrepresentable tool fails every turn of
+		// every session that declares it — 9,337 requests for a single
+		// installation on 2026-08-20, none of them visible in telemetry.
+		rescueDecision := decision
+		rescueDecision.Model = baselineModel
+		rescueDecision.Provider = providers.ProviderAnthropic
+		rescueOpts := opts
+		rescueOpts.TargetModel = baselineModel
+		rescueOpts.TargetProvider = providers.ProviderAnthropic
+		rescueOpts.Capabilities = router.Lookup(baselineModel)
+		// Recompute against the model that actually serves: see the same
+		// reasoning in the post-dispatch baseline failover below.
+		rescueOpts.ModelSwitched = routeRes.PriorServedModel != baselineModel || routeRes.SessionEverSwitched
+		if knobs := routingKnobsForRequest(ctx); knobs != nil && knobs.ForceEffort != "" {
+			rescueOpts.ForceEffort = knobs.ForceEffort
+			rescueOpts.ForceReasoningEffort = translate.ResolveForceEffort(rescueOpts.Capabilities, knobs.ForceEffort)
+		} else if s.effortEscalation {
+			rescueOpts.ForceReasoningEffort = forcedReasoningEffort(baselineModel, routeRes.EscalateEffort)
+		}
+		rescueCtx := ctx
+		if s.claudeSubscriptionExhausted(ctx, r.Header) {
+			rescueCtx = withSuppressedClaudeSubscription(rescueCtx)
+		}
+		rescueCtx = resolveAndInjectCredentials(rescueCtx, providers.ProviderAnthropic, baselineModel, r.Header)
+		rescueBindings := s.resolveBindingsForDispatch(rescueCtx, rescueDecision)
+		rescueMarker := suppressMarkerIfRequested(ctx, r.Header, baselineRoutingMarkerFor(routeRes, baselineModel))
+		rescueAttempt, rescueBuildErr := buildAttempt(rescueDecision, rescueOpts, rescueMarker)
+		switch {
+		case rescueBuildErr != nil:
+			log.Error("Tool-schema rescue: preparing the baseline request also failed; surfacing the original error",
+				"err", rescueBuildErr,
+				"baseline_model", baselineModel)
+		case len(rescueBindings) == 0:
+			log.Error("Tool-schema rescue: baseline has no usable binding; surfacing the original error",
+				"err", attemptBuildErr,
+				"baseline_model", baselineModel)
+		default:
+			log.Warn("Tool-schema rescue: routed provider cannot express a tool schema, serving the baseline on Anthropic",
+				"err", attemptBuildErr,
+				"failed_model", decision.Model,
+				"failed_provider", decision.Provider,
+				"baseline_model", baselineModel)
+			// Pre-dispatch, so swapping the routed decision wholesale is safe:
+			// every downstream reader (markers, telemetry, billing) then
+			// describes the model that actually serves. The policy-outcome
+			// capture wired above still names the original decision, matching
+			// the post-dispatch sibling/baseline rescues.
+			ctx = rescueCtx
+			decision = rescueDecision
+			opts = rescueOpts
+			marker = rescueMarker
+			bindings = rescueBindings
+			attempt = rescueAttempt
+			attemptBuildErr = nil
+			toolSchemaRescueUsed = true
+		}
+	}
+	if attemptBuildErr != nil {
+		// Pre-dispatch failures used to return here with no telemetry row at
+		// all, so a provider failing most of its requests still read as 100%
+		// healthy on the dashboard. Record the turn with the status the client
+		// is about to receive before surfacing it.
+		failStatus := http.StatusBadGateway
+		if cls, classified := ClassifyDispatchError(attemptBuildErr); classified {
+			failStatus = cls.Status
+		}
+		if !agentShadowMode && installationID != uuid.Nil {
+			obs := buildObservationContext(ctx, decision, routeRes.Fresh, s.effectiveCaptureMode(ctx))
+			s.fireTelemetry(InsertTelemetryParams{
+				InstallationID:       installationID.String(),
+				APIKeyID:             apiKeyIDFromContext(ctx),
+				RequestID:            requestID,
+				SpanType:             "router.upstream",
+				TraceID:              requestID,
+				Timestamp:            requestStart,
+				RequestedModel:       feats.Model,
+				DecisionModel:        decision.Model,
+				DecisionProvider:     decision.Provider,
+				DecisionReason:       decision.Reason,
+				EstimatedInputTokens: int32(feats.Tokens),
+				StickyHit:            stickyHit,
+				EmbedInput:           embedInput,
+				RouteLatencyMs:       routeMs,
+				TotalLatencyMs:       time.Since(requestStart).Milliseconds(),
+				// No upstream call happened, so tokens and cost stay zero.
+				UpstreamStatusCode:   int32(failStatus),
+				ClusterIDs:           obs.ClusterIDs,
+				CandidateModels:      obs.CandidateModels,
+				ChosenScore:          obs.ChosenScore,
+				CandidateScores:      obs.CandidateScores,
+				Propensity:           obs.Propensity,
+				ClusterRouterVersion: obs.ClusterRouterVersion,
+				Strategy:             obs.Strategy,
+				RouteID:              obs.RouteID,
+				PolicyRouteKey:       obs.PolicyRouteKey,
+				PolicyArtifactID:     obs.PolicyArtifactID,
+				PolicyArtifactSHA256: obs.PolicyArtifactSHA256,
+				RosterVersion:        obs.RosterVersion,
+				SidecarSchemaVersion: obs.SidecarSchemaVersion,
+				SessionKey:           routeRes.SessionKey[:],
+				Role:                 stickyStateRole(routeRes),
+			})
+		}
+		return attemptBuildErr
+	}
 
 	// Subscription-credit failover eligibility. A Claude turn served on the
 	// caller's subscription (sk-ant-oat) is pinned to a single Anthropic
@@ -3504,7 +3614,10 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 		// Same-provider subscription->Weave retries keep finalProvider ==
 		// primaryProvider, so OR in subscriptionFailoverUsed to match the OTel
 		// span + completion log.
-		failoverUsed := finalProvider != primaryProvider || subscriptionFailoverUsed || siblingFailoverUsed
+		// toolSchemaRescueUsed is ORed in because that rescue swaps the decision
+		// before primaryProvider is read, so finalProvider == primaryProvider
+		// even though the turn did leave its routed provider.
+		failoverUsed := finalProvider != primaryProvider || subscriptionFailoverUsed || siblingFailoverUsed || toolSchemaRescueUsed
 		degShadow := proxyErr == nil && isDegenerateResponse(out, respSummary.ToolUseBlocks, respSummary.StopReason, respSummary.StopReasonDemoted)
 		if degShadow && !agentShadowMode {
 			log.Info("router.degenerate_shadow",
@@ -3651,7 +3764,7 @@ func (s *Service) ProxyMessages(ctx context.Context, body []byte, w http.Respons
 		)
 	}
 
-	log.Info("ProxyMessages complete", append([]any{"requested_model", feats.Model, "baseline_model", s.baselineFor(feats.Model), "decision_model", decision.Model, "decision_provider", decision.Provider, "primary_provider", primaryProvider, "fallback_attempts", winnerIdx, "failover_used", finalProvider != primaryProvider || subscriptionFailoverUsed || siblingFailoverUsed, "subscription_failover", subscriptionFailoverUsed, "decision_reason", decision.Reason, "requested_tier", routeRes.RequestedTier.String(), "decision_tier", catalog.TierFor(decision.Model).String(), "embedded_tokens", len(promptText) / 4, "total_input_tokens", feats.Tokens, "has_tools", feats.HasTools, "message_count", feats.MessageCount, "last_kind", feats.LastKind, "last_preview", feats.LastPreview, "embed_input", embedInput, "cross_format", crossFormat, "sticky_hit", stickyHit, "route_ms", routeMs, "proxy_ms", proxyMs, "proxy_err", proxyErr, "upstream_status", upstreamStatus(proxyErr), "upstream_finish_reason", respSummary.UpstreamFinishReason, "resp_stop_reason", respSummary.StopReason, "stop_reason_promoted", respSummary.StopReasonPromoted, "tool_use_blocks", respSummary.ToolUseBlocks, "invalid_tool_args_blocks", respSummary.InvalidToolArgsBlocks, "text_only_turn_nudged", respSummary.TextOnlyTurnNudged, "stop_reason_demoted", respSummary.StopReasonDemoted, "suppressed_tool_calls", respSummary.SuppressedToolCalls, "tool_call_invalid_blocks", len(respSummary.ToolCallIssues), "cc_only_tools_stripped", reqStats.CCOnlyToolsStripped, "gemini_reminder_injected", reqStats.GeminiReminderInjected, "gemini_validated_tool_mode", reqStats.GeminiValidatedToolMode, "resp_output_tokens", respSummary.OutputTokens, "prelude_committed", preludeBuf.Committed(), "routing_marker", marker, "prior_served_model", routeRes.PriorServedModel, "hard_pinned", routeRes.HardPinned}, plannerLogFields(routeRes)...)...)
+	log.Info("ProxyMessages complete", append([]any{"requested_model", feats.Model, "baseline_model", s.baselineFor(feats.Model), "decision_model", decision.Model, "decision_provider", decision.Provider, "primary_provider", primaryProvider, "fallback_attempts", winnerIdx, "failover_used", finalProvider != primaryProvider || subscriptionFailoverUsed || siblingFailoverUsed || toolSchemaRescueUsed, "subscription_failover", subscriptionFailoverUsed, "tool_schema_rescue", toolSchemaRescueUsed, "decision_reason", decision.Reason, "requested_tier", routeRes.RequestedTier.String(), "decision_tier", catalog.TierFor(decision.Model).String(), "embedded_tokens", len(promptText) / 4, "total_input_tokens", feats.Tokens, "has_tools", feats.HasTools, "message_count", feats.MessageCount, "last_kind", feats.LastKind, "last_preview", feats.LastPreview, "embed_input", embedInput, "cross_format", crossFormat, "sticky_hit", stickyHit, "route_ms", routeMs, "proxy_ms", proxyMs, "proxy_err", proxyErr, "upstream_status", upstreamStatus(proxyErr), "upstream_finish_reason", respSummary.UpstreamFinishReason, "resp_stop_reason", respSummary.StopReason, "stop_reason_promoted", respSummary.StopReasonPromoted, "tool_use_blocks", respSummary.ToolUseBlocks, "invalid_tool_args_blocks", respSummary.InvalidToolArgsBlocks, "text_only_turn_nudged", respSummary.TextOnlyTurnNudged, "stop_reason_demoted", respSummary.StopReasonDemoted, "suppressed_tool_calls", respSummary.SuppressedToolCalls, "tool_call_invalid_blocks", len(respSummary.ToolCallIssues), "cc_only_tools_stripped", reqStats.CCOnlyToolsStripped, "gemini_reminder_injected", reqStats.GeminiReminderInjected, "gemini_validated_tool_mode", reqStats.GeminiValidatedToolMode, "resp_output_tokens", respSummary.OutputTokens, "prelude_committed", preludeBuf.Committed(), "routing_marker", marker, "prior_served_model", routeRes.PriorServedModel, "hard_pinned", routeRes.HardPinned}, plannerLogFields(routeRes)...)...)
 	policyRespBody, policyRespTrunc := capturedResponse(policyOutcomeCap)
 	var policyResp *policyOutcomeResponse
 	if policyOutcomeCap != nil {

--- a/internal/proxy/tool_schema_rescue_integration_test.go
+++ b/internal/proxy/tool_schema_rescue_integration_test.go
@@ -1,0 +1,130 @@
+package proxy_test
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	"workweave/router/internal/providers"
+	"workweave/router/internal/providers/anthropic"
+	"workweave/router/internal/proxy"
+	"workweave/router/internal/router"
+	"workweave/router/internal/translate"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+)
+
+// untranslatableToolBody asks for an Anthropic model while declaring a tool
+// whose input schema has no Gemini representation (oneOf). The router
+// cost-routes it to Gemini, so PrepareGemini fails before anything is
+// dispatched.
+const untranslatableToolBody = `{"model":"claude-opus-4-8","stream":true,` +
+	`"messages":[{"role":"user","content":"hi"}],` +
+	`"tools":[{"name":"SendMessage","input_schema":{"type":"object","properties":` +
+	`{"to":{"oneOf":[{"type":"string"},{"type":"number"}]}}}}]}`
+
+// TestProxyMessages_UntranslatableToolSchemaRescuesToBaseline: a tool schema
+// the routed provider cannot express is a property of the route, not of the
+// request — the same tool translates fine for Anthropic. Before this rescue the
+// turn returned an unclassified 502 that Claude Code retried eleven times, and
+// wrote no telemetry row at all.
+func TestProxyMessages_UntranslatableToolSchemaRescuesToBaseline(t *testing.T) {
+	var (
+		mu                     sync.Mutex
+		anthropicCount         int
+		anthropicReceivedModel string
+	)
+
+	anthropicUpstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		mu.Lock()
+		anthropicCount++
+		anthropicReceivedModel = gjson.GetBytes(body, "model").String()
+		mu.Unlock()
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(anthropicMessageSSE))
+		if f, ok := w.(http.Flusher); ok {
+			f.Flush()
+		}
+	}))
+	defer anthropicUpstream.Close()
+
+	// A Google client is registered so the routed provider is configured: the
+	// turn must fail in translation, not for a missing provider key.
+	googleProv := &fakeProvider{}
+	store := newFakePinStore()
+	tel := newCaptureTelemetry()
+	svc := proxy.NewService(
+		&fakeRouter{decision: router.Decision{Provider: providers.ProviderGoogle, Model: "gemini-2.5-pro", Reason: "cluster"}},
+		map[string]providers.Client{
+			providers.ProviderGoogle:    googleProv,
+			providers.ProviderAnthropic: anthropic.NewClient("test-anthropic-key", anthropicUpstream.URL),
+		},
+		nil, false, nil, store, false, providers.ProviderAnthropic, "claude-haiku-4-5", tel,
+	).WithDeploymentKeyedProviders(map[string]struct{}{
+		providers.ProviderGoogle:    {},
+		providers.ProviderAnthropic: {},
+	})
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(""))
+
+	err := svc.ProxyMessages(
+		authedCtx("22222222-2222-2222-2222-222222222222"),
+		[]byte(untranslatableToolBody), rec, req,
+	)
+	require.NoError(t, err, "an untranslatable tool schema must be rescued on the baseline, not surfaced")
+
+	mu.Lock()
+	defer mu.Unlock()
+	assert.Empty(t, googleProv.proxyBodies, "the Gemini upstream must never be called: translation failed pre-dispatch")
+	assert.Equal(t, 1, anthropicCount, "the baseline Anthropic upstream serves the turn")
+	assert.Equal(t, "claude-opus-4-8", anthropicReceivedModel, "the rescue requests the caller's model on Anthropic")
+
+	respBody := rec.Body.String()
+	assert.Contains(t, respBody, "event: message_start", "the client sees a real stream, not an error envelope")
+	assert.Contains(t, respBody, "event: message_stop")
+	assert.Equal(t, providers.ProviderAnthropic, rec.Header().Get(proxy.HeaderRouterProvider),
+		"the served-provider header reflects the rescue")
+	assert.Equal(t, "claude-opus-4-8", rec.Header().Get(proxy.HeaderRouterModel))
+}
+
+// TestProxyMessages_UntranslatableToolSchemaWithNoBaselineIsClassified: when
+// the requested model IS the Gemini model there is no baseline to rescue to, so
+// the turn still fails — but as a classified 400 the client will not retry,
+// rather than the bare 502 "Upstream call failed." it used to fall through to.
+func TestProxyMessages_UntranslatableToolSchemaWithNoBaselineIsClassified(t *testing.T) {
+	googleProv := &fakeProvider{}
+	store := newFakePinStore()
+	svc := proxy.NewService(
+		&fakeRouter{decision: router.Decision{Provider: providers.ProviderGoogle, Model: "gemini-2.5-pro", Reason: "cluster"}},
+		map[string]providers.Client{providers.ProviderGoogle: googleProv},
+		nil, false, nil, store, false, providers.ProviderGoogle, "gemini-2.5-flash", nil,
+	).WithDeploymentKeyedProviders(map[string]struct{}{providers.ProviderGoogle: {}})
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(""))
+	body := []byte(`{"model":"gemini-2.5-pro","stream":true,` +
+		`"messages":[{"role":"user","content":"hi"}],` +
+		`"tools":[{"name":"SendMessage","input_schema":{"type":"object","properties":` +
+		`{"to":{"oneOf":[{"type":"string"},{"type":"number"}]}}}}]}`)
+
+	err := svc.ProxyMessages(
+		authedCtx("33333333-3333-3333-3333-333333333333"),
+		body, rec, req,
+	)
+	require.Error(t, err, "with no baseline to rescue to the turn must still fail")
+	assert.ErrorIs(t, err, translate.ErrGeminiSchemaIncompatible)
+	assert.Empty(t, googleProv.proxyBodies, "nothing may be dispatched")
+
+	cls, classified := proxy.ClassifyDispatchError(err)
+	require.True(t, classified, "the handler must be able to classify this instead of defaulting to 502")
+	assert.Equal(t, http.StatusBadRequest, cls.Status)
+	assert.False(t, cls.RetryAfter, "retrying an unrepresentable schema is futile")
+}

--- a/internal/proxy/tool_schema_rescue_integration_test.go
+++ b/internal/proxy/tool_schema_rescue_integration_test.go
@@ -23,9 +23,14 @@ import (
 // whose input schema has no Gemini representation (oneOf). The router
 // cost-routes it to Gemini, so PrepareGemini fails before anything is
 // dispatched.
+//
+// The tool is deliberately NOT one of claudeCodeOnlyToolNames: those are
+// stripped from cross-vendor emit before the translator runs (#986 added the
+// real-world offender, SendMessage, to that list), which would make these tests
+// exercise the tool filter instead of the schema translator they are about.
 const untranslatableToolBody = `{"model":"claude-opus-4-8","stream":true,` +
 	`"messages":[{"role":"user","content":"hi"}],` +
-	`"tools":[{"name":"SendMessage","input_schema":{"type":"object","properties":` +
+	`"tools":[{"name":"weave_send_message","input_schema":{"type":"object","properties":` +
 	`{"to":{"oneOf":[{"type":"string"},{"type":"number"}]}}}}]}`
 
 // TestProxyMessages_UntranslatableToolSchemaRescuesToBaseline: a tool schema
@@ -112,7 +117,7 @@ func TestProxyMessages_UntranslatableToolSchemaWithNoBaselineIsClassified(t *tes
 	req := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(""))
 	body := []byte(`{"model":"gemini-2.5-pro","stream":true,` +
 		`"messages":[{"role":"user","content":"hi"}],` +
-		`"tools":[{"name":"SendMessage","input_schema":{"type":"object","properties":` +
+		`"tools":[{"name":"weave_send_message","input_schema":{"type":"object","properties":` +
 		`{"to":{"oneOf":[{"type":"string"},{"type":"number"}]}}}}]}`)
 
 	err := svc.ProxyMessages(

--- a/internal/translate/emit_gemini.go
+++ b/internal/translate/emit_gemini.go
@@ -1322,9 +1322,13 @@ func sanitizeGeminiSchemaNode(v any, path string) (any, error) {
 		}
 		base := mergeSchemaMaps(node, nil, false)
 		delete(base, "allOf")
-		node, ok = mergeSchemaMapsExact(base, merged)
+		var conflictKey string
+		node, conflictKey, ok = mergeSchemaMapsExact(base, merged)
 		if !ok {
-			return nil, fmt.Errorf("%w at %s.allOf: branches conflict with sibling constraints", ErrGeminiSchemaIncompatible, path)
+			return nil, fmt.Errorf(
+				"%w at %s.allOf: %q is unsatisfiable against the sibling constraints",
+				ErrGeminiSchemaIncompatible, path, conflictKey,
+			)
 		}
 	}
 	if _, exists := node["oneOf"]; exists {
@@ -1474,10 +1478,14 @@ func mergeGeminiAllOf(v any, path string) (map[string]any, error) {
 		if !ok {
 			return nil, fmt.Errorf("%w at %s[%d]: branch is not an object schema", ErrGeminiSchemaIncompatible, path, i)
 		}
+		var conflictKey string
 		var mergedOK bool
-		merged, mergedOK = mergeSchemaMapsExact(merged, object)
+		merged, conflictKey, mergedOK = mergeSchemaMapsExact(merged, object)
 		if !mergedOK {
-			return nil, fmt.Errorf("%w at %s[%d]: branches conflict", ErrGeminiSchemaIncompatible, path, i)
+			return nil, fmt.Errorf(
+				"%w at %s[%d]: %q is unsatisfiable across branches",
+				ErrGeminiSchemaIncompatible, path, i, conflictKey,
+			)
 		}
 	}
 	return merged, nil
@@ -1496,7 +1504,20 @@ func mergeSchemaMaps(base, extra map[string]any, overwrite bool) map[string]any 
 	return out
 }
 
-func mergeSchemaMapsExact(left, right map[string]any) (map[string]any, bool) {
+// mergeSchemaMapsExact merges two schemas that must BOTH hold — the allOf
+// branches of one node, or an allOf result against its sibling constraints —
+// by intersecting each shared keyword. It reports false only when the
+// intersection is genuinely empty (no value could satisfy both), never merely
+// because two branches spell a constraint differently.
+//
+// The equality-or-reject version of this function 502'd every request carrying
+// a tool whose schema intersects two string refinements: two `pattern`s, or a
+// `$defs` description bound narrowed twice. allOf means intersection, so
+// "different" is the normal case, not a conflict.
+// conflictKey names the keyword (or dotted path to it) whose intersection was
+// empty, so the error a rejected tool produces says which constraint could not
+// be satisfied instead of only "branches conflict".
+func mergeSchemaMapsExact(left, right map[string]any) (merged map[string]any, conflictKey string, ok bool) {
 	out := mergeSchemaMaps(left, nil, false)
 	for key, value := range right {
 		current, exists := out[key]
@@ -1504,31 +1525,304 @@ func mergeSchemaMapsExact(left, right map[string]any) (map[string]any, bool) {
 			out[key] = deepCopyJSON(value)
 			continue
 		}
-		if key == "properties" {
-			leftProperties, leftOK := current.(map[string]any)
-			rightProperties, rightOK := value.(map[string]any)
-			if !leftOK || !rightOK {
-				return nil, false
+		intersected, childKey, intersectedOK := intersectSchemaKeyword(key, current, value)
+		if !intersectedOK {
+			if childKey != "" {
+				return nil, key + "." + childKey, false
 			}
-			mergedProperties, ok := mergeSchemaMapsExact(leftProperties, rightProperties)
-			if !ok {
-				return nil, false
-			}
-			out[key] = mergedProperties
-			continue
+			return nil, key, false
 		}
-		if key == "required" {
-			out[key] = uniqueStrings(current, value)
-			if out[key] == nil {
-				return nil, false
-			}
-			continue
-		}
-		if !semanticJSONEqual(current, value) {
-			return nil, false
+		out[key] = intersected
+	}
+	// nullable is a permission, not a restriction: alone among these keywords,
+	// its ABSENCE narrows the schema. The per-key loop copies a key present on
+	// only one side, which for nullable would hand back a schema admitting null
+	// when the other side forbids it — so reconcile it from both inputs, and
+	// only when one of them actually says something about null (otherwise a
+	// merge of two unrelated bounds would sprout a nullable flag).
+	if schemaMentionsNull(left) || schemaMentionsNull(right) {
+		if schemaAllowsNull(left) && schemaAllowsNull(right) {
+			out["nullable"] = true
+		} else {
+			delete(out, "nullable")
 		}
 	}
+	return out, "", true
+}
+
+// schemaMentionsNull reports whether a schema says anything about null, in
+// either spelling: the sanitized `nullable` flag, or the raw ["<type>","null"]
+// union an un-sanitized sibling schema can still carry at the allOf seam.
+func schemaMentionsNull(schema map[string]any) bool {
+	if _, hasFlag := schema["nullable"]; hasFlag {
+		return true
+	}
+	typeValue, hasType := schema["type"]
+	if !hasType {
+		return false
+	}
+	_, nullable, ok := splitNullableType(typeValue)
+	return ok && nullable
+}
+
+// schemaAllowsNull reports whether a schema admits null. A schema with no type
+// constraint and no nullable flag constrains nothing, so it admits null.
+func schemaAllowsNull(schema map[string]any) bool {
+	if flag, ok := schema["nullable"].(bool); ok {
+		return flag
+	}
+	typeValue, hasType := schema["type"]
+	if !hasType {
+		return true
+	}
+	_, nullable, ok := splitNullableType(typeValue)
+	return ok && nullable
+}
+
+// schemaLowerBoundKeys/schemaUpperBoundKeys hold the keywords whose
+// intersection is the stricter of the two bounds.
+var (
+	schemaLowerBoundKeys = map[string]struct{}{
+		"minimum":       {},
+		"minLength":     {},
+		"minItems":      {},
+		"minProperties": {},
+	}
+	schemaUpperBoundKeys = map[string]struct{}{
+		"maximum":       {},
+		"maxLength":     {},
+		"maxItems":      {},
+		"maxProperties": {},
+	}
+)
+
+// schemaAnnotationKeys carry documentation, not constraints. Two branches
+// describing the same field differently is not an unsatisfiable schema, and
+// Gemini accepts exactly one value, so the left (parent, or earlier-branch)
+// spelling wins.
+var schemaAnnotationKeys = map[string]struct{}{
+	"description":      {},
+	"title":            {},
+	"default":          {},
+	"example":          {},
+	"propertyOrdering": {},
+}
+
+// schemaSingleValuedConstraintKeys are real constraints that a Gemini schema
+// can only carry once. The true intersection of two different values is
+// narrower than either, so keeping the left one WIDENS the tool's accepted
+// input language. That is the same trade already made for
+// exclusiveMinimum -> minimum (resolveGeminiExclusiveBound) and for dropping
+// unsupported `format` values: a slightly wide tool schema routes and the
+// tool's own handler still validates its arguments, whereas a rejected one
+// fails the whole turn.
+var schemaSingleValuedConstraintKeys = map[string]struct{}{
+	"pattern": {},
+	"format":  {},
+}
+
+// intersectSchemaKeyword intersects one keyword's two values under allOf
+// semantics. Unknown keywords keep the old equality rule: silently picking a
+// side for a constraint this function does not understand could widen a tool's
+// input language without anyone noticing.
+func intersectSchemaKeyword(key string, left, right any) (value any, conflictKey string, ok bool) {
+	switch key {
+	case "properties":
+		leftProperties, leftOK := left.(map[string]any)
+		rightProperties, rightOK := right.(map[string]any)
+		if !leftOK || !rightOK {
+			return nil, "", false
+		}
+		merged, childKey, mergedOK := intersectSchemaProperties(leftProperties, rightProperties)
+		if !mergedOK {
+			return nil, childKey, false
+		}
+		return merged, "", true
+	case "items":
+		leftItems, leftOK := left.(map[string]any)
+		rightItems, rightOK := right.(map[string]any)
+		if !leftOK || !rightOK {
+			// items may legitimately be a non-object (a bool schema); fall back
+			// to equality rather than pretending to intersect it.
+			if semanticJSONEqual(left, right) {
+				return deepCopyJSON(left), "", true
+			}
+			return nil, "", false
+		}
+		merged, childKey, mergedOK := mergeSchemaMapsExact(leftItems, rightItems)
+		if !mergedOK {
+			return nil, childKey, false
+		}
+		return merged, "", true
+	case "required":
+		merged := uniqueStrings(left, right)
+		if merged == nil {
+			return nil, "", false
+		}
+		return merged, "", true
+	case "type":
+		merged, mergedOK := intersectSchemaType(left, right)
+		return merged, "", mergedOK
+	case "enum":
+		merged, mergedOK := intersectSchemaEnum(left, right)
+		return merged, "", mergedOK
+	case "nullable":
+		// A value has to satisfy both branches, so null is permitted only if
+		// both permit it.
+		leftNullable, leftOK := left.(bool)
+		rightNullable, rightOK := right.(bool)
+		if !leftOK || !rightOK {
+			return nil, "", false
+		}
+		return leftNullable && rightNullable, "", true
+	}
+	if _, isAnnotation := schemaAnnotationKeys[key]; isAnnotation {
+		return deepCopyJSON(left), "", true
+	}
+	if _, isSingleValued := schemaSingleValuedConstraintKeys[key]; isSingleValued {
+		return deepCopyJSON(left), "", true
+	}
+	if _, isLowerBound := schemaLowerBoundKeys[key]; isLowerBound {
+		merged, mergedOK := intersectNumericBound(left, right, true)
+		return merged, "", mergedOK
+	}
+	if _, isUpperBound := schemaUpperBoundKeys[key]; isUpperBound {
+		merged, mergedOK := intersectNumericBound(left, right, false)
+		return merged, "", mergedOK
+	}
+	if !semanticJSONEqual(left, right) {
+		return nil, "", false
+	}
+	return deepCopyJSON(left), "", true
+}
+
+// intersectSchemaProperties merges two `properties` maps. Its keys are property
+// NAMES, not schema keywords, so a shared name recurses as a whole schema
+// instead of going through intersectSchemaKeyword — which would have compared
+// two sub-schemas for equality and rejected any property both branches
+// constrain differently.
+func intersectSchemaProperties(left, right map[string]any) (merged map[string]any, conflictKey string, ok bool) {
+	out := make(map[string]any, len(left)+len(right))
+	for name, schema := range left {
+		out[name] = deepCopyJSON(schema)
+	}
+	for name, schema := range right {
+		current, exists := out[name]
+		if !exists {
+			out[name] = deepCopyJSON(schema)
+			continue
+		}
+		leftNode, leftOK := current.(map[string]any)
+		rightNode, rightOK := schema.(map[string]any)
+		if !leftOK || !rightOK {
+			if semanticJSONEqual(current, schema) {
+				continue
+			}
+			return nil, name, false
+		}
+		intersected, childKey, intersectedOK := mergeSchemaMapsExact(leftNode, rightNode)
+		if !intersectedOK {
+			if childKey != "" {
+				return nil, name + "." + childKey, false
+			}
+			return nil, name, false
+		}
+		out[name] = intersected
+	}
+	return out, "", true
+}
+
+// intersectSchemaType intersects two `type` values. Branches are sanitized
+// before they reach here so their type is a bare string, but the sibling
+// schema merged in at the allOf seam is still raw and may carry the
+// ["string","null"] union form, so both sides are normalized first.
+func intersectSchemaType(left, right any) (value any, ok bool) {
+	// Nullability rides on the `nullable` key, reconciled once per merge by
+	// mergeSchemaMapsExact, so it is deliberately ignored here: letting both
+	// spellings decide would let them disagree.
+	leftName, _, leftOK := splitNullableType(left)
+	rightName, _, rightOK := splitNullableType(right)
+	if !leftOK || !rightOK {
+		return nil, false
+	}
+	name := leftName
+	switch {
+	case leftName == rightName:
+	case leftName == "integer" && rightName == "number",
+		leftName == "number" && rightName == "integer":
+		// Every integer is a number, so the intersection is the integers.
+		name = "integer"
+	default:
+		// No value is two different JSON types at once.
+		return nil, false
+	}
+	return name, true
+}
+
+// splitNullableType reads a `type` value as (name, nullable). It accepts the
+// bare string form and the two-element ["<type>","null"] union; anything else
+// (a three-way union, a non-string entry) is not representable and reports
+// ok=false so the caller rejects rather than guesses.
+func splitNullableType(v any) (name string, nullable bool, ok bool) {
+	if single, isString := v.(string); isString {
+		return single, false, true
+	}
+	names, isArray := v.([]any)
+	if !isArray || len(names) != 2 {
+		return "", false, false
+	}
+	for _, candidate := range names {
+		entry, isString := candidate.(string)
+		if !isString {
+			return "", false, false
+		}
+		if entry == "null" {
+			nullable = true
+			continue
+		}
+		if name != "" {
+			return "", false, false
+		}
+		name = entry
+	}
+	if name == "" || !nullable {
+		return "", false, false
+	}
+	return name, true, true
+}
+
+// intersectSchemaEnum keeps only the values both branches allow. Disjoint
+// enums are a genuinely unsatisfiable schema, so that case still rejects.
+func intersectSchemaEnum(left, right any) (value any, ok bool) {
+	leftValues, leftOK := left.([]any)
+	if _, rightOK := right.([]any); !leftOK || !rightOK {
+		return nil, false
+	}
+	out := make([]any, 0, len(leftValues))
+	for _, candidate := range leftValues {
+		if valueInEnum(candidate, right) && !valueInEnum(candidate, out) {
+			out = append(out, deepCopyJSON(candidate))
+		}
+	}
+	if len(out) == 0 {
+		return nil, false
+	}
 	return out, true
+}
+
+// intersectNumericBound keeps the stricter bound: the larger of two lower
+// bounds, the smaller of two upper bounds. Non-numeric bounds fall back to the
+// equality rule rather than being silently reordered.
+func intersectNumericBound(left, right any, keepLarger bool) (value any, ok bool) {
+	leftValue, leftOK := left.(float64)
+	rightValue, rightOK := right.(float64)
+	if !leftOK || !rightOK {
+		return deepCopyJSON(left), semanticJSONEqual(left, right)
+	}
+	if keepLarger == (leftValue > rightValue) {
+		return leftValue, true
+	}
+	return rightValue, true
 }
 
 func uniqueStrings(left, right any) any {

--- a/internal/translate/fidelity_test.go
+++ b/internal/translate/fidelity_test.go
@@ -83,6 +83,72 @@ func TestPrepareGemini_SchemaFidelity(t *testing.T) {
 				assert.Equal(t, "object", schema["type"])
 			},
 		},
+		{
+			// The prod incident: Claude Code's SendMessage "to" property is an
+			// allOf of two string refinements. Requiring the branches to be
+			// byte-equal 502'd ~9k requests a day for one installation, so a
+			// satisfiable intersection must now merge instead of rejecting.
+			name:   "allOf of two patterns keeps one instead of rejecting",
+			schema: `{"type":"object","properties":{"to":{"type":"string","allOf":[{"type":"string","pattern":"^[^\n\r]*$"},{"type":"string","pattern":"^[\\s\\S]{0,300}$"}]}}}`,
+			check: func(t *testing.T, schema map[string]any) {
+				to := schema["properties"].(map[string]any)["to"].(map[string]any)
+				assert.Equal(t, "string", to["type"])
+				assert.Contains(t, to, "pattern", "one of the two patterns must survive")
+			},
+		},
+		{
+			name:   "allOf branches with different descriptions merge",
+			schema: `{"allOf":[{"type":"string","description":"one"},{"type":"string","description":"two"}]}`,
+			check: func(t *testing.T, schema map[string]any) {
+				assert.Equal(t, "string", schema["type"])
+				assert.Contains(t, []any{"one", "two"}, schema["description"])
+			},
+		},
+		{
+			name:   "allOf keeps the stricter of two bounds",
+			schema: `{"allOf":[{"type":"string","minLength":2,"maxLength":90},{"type":"string","minLength":5,"maxLength":40}]}`,
+			check: func(t *testing.T, schema map[string]any) {
+				assert.Equal(t, float64(5), schema["minLength"], "the larger lower bound wins")
+				assert.Equal(t, float64(40), schema["maxLength"], "the smaller upper bound wins")
+			},
+		},
+		{
+			name:   "allOf intersects overlapping enums",
+			schema: `{"allOf":[{"type":"string","enum":["a","b","c"]},{"type":"string","enum":["b","c","d"]}]}`,
+			check: func(t *testing.T, schema map[string]any) {
+				assert.ElementsMatch(t, []any{"b", "c"}, schema["enum"])
+			},
+		},
+		{
+			name:    "allOf of disjoint enums is genuinely unsatisfiable",
+			schema:  `{"allOf":[{"type":"string","enum":["a"]},{"type":"string","enum":["b"]}]}`,
+			wantErr: translate.ErrGeminiSchemaIncompatible,
+		},
+		{
+			name:   "allOf of integer and number narrows to integer",
+			schema: `{"allOf":[{"type":"integer"},{"type":"number"}]}`,
+			check: func(t *testing.T, schema map[string]any) {
+				assert.Equal(t, "integer", schema["type"])
+			},
+		},
+		{
+			// nullable is a constraint, not an annotation: a value must satisfy
+			// both branches, so one branch forbidding null forbids it outright.
+			name:   "allOf nullability is ANDed, not ORed",
+			schema: `{"allOf":[{"type":["string","null"]},{"type":"string"}]}`,
+			check: func(t *testing.T, schema map[string]any) {
+				assert.Equal(t, "string", schema["type"])
+				assert.NotEqual(t, true, schema["nullable"])
+			},
+		},
+		{
+			name:   "allOf merges nested object properties recursively",
+			schema: `{"allOf":[{"type":"object","properties":{"inner":{"type":"string","minLength":1}}},{"type":"object","properties":{"inner":{"type":"string","minLength":4}}}]}`,
+			check: func(t *testing.T, schema map[string]any) {
+				inner := schema["properties"].(map[string]any)["inner"].(map[string]any)
+				assert.Equal(t, float64(4), inner["minLength"])
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## The bug

Every request carrying Claude Code's `SendMessage` tool that the policy routed to Gemini failed **before dispatch**:

```
translate anthropic request to gemini: function "SendMessage" input_schema:
gemini schema is not representable at $.properties.to.allOf[1]: branches conflict
```

Prod, org Weave (`org_QWsHDcRQWQEs6RpkdEZrlFK8`, key `weave-checks`):

| Day | Failures |
|---|---|
| 2026-08-19 | ≥5,000 (query cap) |
| 2026-08-20 | **9,337** |
| 2026-08-21 (to 18:20Z) | 3,915 |

761 of the 849 affected sessions failed **exactly 11 times** — the client's full retry ladder against a request no upstream ever saw. So ~875 real user turns died, each burning 11 round trips.

## Three independent defects

### 1. `allOf` was treated as "must be identical", not "must both hold"

`mergeSchemaMapsExact` merged `properties` and `required`, then required every other shared keyword to be byte-equal. `allOf` means *intersection*, so branches differing on `pattern`, `description`, or a bound are the normal case, not a conflict.

`intersectSchemaKeyword` now intersects per keyword:

| Keyword | Intersection |
|---|---|
| `minimum`/`minLength`/`minItems`/`minProperties` | larger (stricter) |
| `maximum`/`maxLength`/`maxItems`/`maxProperties` | smaller (stricter) |
| `enum` | set intersection; empty → reject |
| `type` | equal → keep; `integer`∧`number` → `integer`; else reject |
| `items` | recurse as a schema |
| `nullable` | AND, reconciled from both inputs |
| `description`/`title`/`default`/`example`/`propertyOrdering` | annotations — take one side |
| `pattern`/`format` | Gemini carries one; keep the left |
| anything else | unchanged equality rule |

Only a genuinely empty intersection still rejects (disjoint enums, two different types) — the existing `{"type":"string"}` ∧ `{"type":"number"}` rejection test is untouched.

`pattern`/`format` is the one lossy case: keeping one **widens** the accepted input language. That is the same deliberate trade already made for `exclusiveMinimum → minimum` and for dropping unsupported `format` values, and it is commented as such. The tool's own handler still validates its arguments.

### 2. `properties` was merged as though its keys were schema keywords

`properties` is a map of property *names* → schemas, but it was fed straight back into `mergeSchemaMapsExact`, so two branches constraining the same property differently were compared for **equality** and rejected. Nested merging only ever worked for disjoint property sets. `intersectSchemaProperties` now recurses per property name.

### 3. A translation failure hard-failed the turn, invisibly

`buildAttempt`'s error returned straight out of `ProxyMessages` — before the baseline/sibling failover eligibility block, and before `fireTelemetry`. Two consequences:

- The turn died even though **the same tools translate fine for Anthropic**. A schema the routed provider cannot express is a property of the *route*, not of the request.
- No telemetry row at all. The affected key showed **5,290 `decision_provider='google'` rows with 0 errors** while ~70% of its google-routed requests were failing. The dashboard read 100% healthy.

Now: the turn is rescued on the baseline pre-dispatch (nothing has reached the wire, so the prelude is still discardable), the failure is recorded in telemetry with the status the client will actually receive, and with no baseline to rescue to it surfaces as a classified **400** instead of the unclassified **502 "Upstream call failed."** — which is what invited the eleven retries for a request that never left the router.

## Tests

- 9 new `TestPrepareGemini_SchemaFidelity` cases, including the incident's shape (two `pattern`s under `allOf`), disjoint enums still rejecting, `integer`∧`number`, ANDed nullability, and recursive nested-property merging.
- `TestProxyMessages_UntranslatableToolSchemaRescuesToBaseline` — asserts the Gemini upstream is **never** called and the turn serves on Anthropic with the caller's model.
- `TestProxyMessages_UntranslatableToolSchemaWithNoBaselineIsClassified` — no baseline still fails, but as a classified 400 with no `Retry-After`.
- `TestClassifyDispatchError_UntranslatableToolSchema` — pins 400 / client-error / no-retry / names the tool.

## Validation

`wv mr tc`, `wv mr t` (full suite), `go vet ./...` — all clean.

## Follow-up (not in this PR)

Make untranslatable-tools a *routing* signal so the policy excludes Gemini for a request carrying such a tool, instead of picking it and then rescuing. Avoids a wasted decision and the pin churn.

🤖 Generated with [Weave Router](https://router.workweave.ai)